### PR TITLE
Use kernel threads for BGP packet writes & keepalive generation

### DIFF
--- a/bgpd/Makefile.am
+++ b/bgpd/Makefile.am
@@ -81,7 +81,7 @@ libbgp_a_SOURCES = \
 	bgp_damp.c bgp_table.c bgp_advertise.c bgp_vty.c bgp_mpath.c \
 	bgp_nht.c bgp_updgrp.c bgp_updgrp_packet.c bgp_updgrp_adv.c bgp_bfd.c \
 	bgp_encap.c bgp_encap_tlv.c $(BGP_VNC_RFAPI_SRC) bgp_attr_evpn.c \
-	bgp_evpn.c bgp_evpn_vty.c bgp_vpn.c
+	bgp_evpn.c bgp_evpn_vty.c bgp_vpn.c bgp_keepalives.c
 
 noinst_HEADERS = \
 	bgp_memory.h \
@@ -92,7 +92,8 @@ noinst_HEADERS = \
 	bgp_mplsvpn.h bgp_nexthop.h bgp_damp.h bgp_table.h \
 	bgp_advertise.h bgp_vty.h bgp_mpath.h bgp_nht.h \
 	bgp_updgrp.h bgp_bfd.h bgp_encap.h bgp_encap_tlv.h bgp_encap_types.h \
-	$(BGP_VNC_RFAPI_HD) bgp_attr_evpn.h bgp_evpn.h bgp_evpn_vty.h bgp_vpn.h
+	$(BGP_VNC_RFAPI_HD) bgp_attr_evpn.h bgp_evpn.h bgp_evpn_vty.h bgp_vpn.h \
+	bgp_keepalives.h
 
 bgpd_SOURCES = bgp_main.c
 bgpd_LDADD = libbgp.a  $(BGP_VNC_RFP_LIB) ../lib/libfrr.la @LIBCAP@ @LIBM@

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1219,6 +1219,9 @@ bgp_connect_check (struct thread *thread)
 
   peer = THREAD_ARG (thread);
 
+  /* This value needs to be unset in order for bgp_read() to be scheduled */
+  BGP_READ_OFF (peer->t_read);
+
   /* Check file descriptor. */
   slen = sizeof (status);
   ret = getsockopt(peer->fd, SOL_SOCKET, SO_ERROR, (void *) &status, &slen);
@@ -1407,7 +1410,7 @@ bgp_start (struct peer *peer)
 	}
       // when the socket becomes ready (or fails to connect), bgp_connect_check
       // will be called.
-      thread_add_read (bm->master, bgp_connect_check, peer, peer->fd);
+      BGP_READ_ON(peer->t_read, bgp_connect_check, peer->fd);
       break;
     }
   return 0;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -140,17 +140,20 @@ peer_xfer_conn(struct peer *from_peer)
   from_peer->fd = fd;
   stream_reset(peer->ibuf);
 
+  // At this point in time, it is possible that there are packets pending on
+  // from_peer->obuf. These need to be transferred to the new peer struct.
   pthread_mutex_lock (&peer->obuf_mtx);
-  {
-    stream_fifo_clean(peer->obuf);
-  }
-  pthread_mutex_unlock (&peer->obuf_mtx);
-
   pthread_mutex_lock (&from_peer->obuf_mtx);
   {
-    stream_fifo_clean(from_peer->obuf);
+    // wipe new peer's packet queue
+    stream_fifo_clean (peer->obuf);
+
+    // copy each packet from old peer's queue to new peer's queue
+    while (from_peer->obuf->head)
+      stream_fifo_push (peer->obuf, stream_fifo_pop(from_peer->obuf));
   }
   pthread_mutex_unlock (&from_peer->obuf_mtx);
+  pthread_mutex_unlock (&peer->obuf_mtx);
 
   peer->as = from_peer->as;
   peer->v_holdtime = from_peer->v_holdtime;
@@ -1455,8 +1458,12 @@ bgp_fsm_holdtime_expire (struct peer *peer)
   return bgp_stop_with_notify (peer, BGP_NOTIFY_HOLD_ERR, 0);
 }
 
-/* Status goes to Established.  Send keepalive packet then make first
-   update information. */
+/**
+ * Transition to Established state.
+ *
+ * Convert peer from stub to full fledged peer, set some timers, and generate
+ * initial updates.
+ */
 static int
 bgp_establish (struct peer *peer)
 {

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1220,6 +1220,52 @@ bgp_stop_with_notify (struct peer *peer, u_char code, u_char sub_code)
   return(bgp_stop(peer));
 }
 
+/**
+ * Determines whether a TCP session has successfully established for a peer and
+ * events as appropriate.
+ *
+ * This function is called when setting up a new session. After connect() is
+ * called on the peer's socket (in bgp_start()), the fd is passed to select()
+ * to wait for connection success or failure. When select() returns, this
+ * function is called to evaluate the result.
+ */
+static int
+bgp_connect_check (struct thread *thread)
+{
+  int status;
+  socklen_t slen;
+  int ret;
+  struct peer *peer;
+
+  peer = THREAD_ARG (thread);
+
+  /* Check file descriptor. */
+  slen = sizeof (status);
+  ret = getsockopt(peer->fd, SOL_SOCKET, SO_ERROR, (void *) &status, &slen);
+
+  /* If getsockopt is fail, this is fatal error. */
+  if (ret < 0)
+    {
+      zlog_info ("can't get sockopt for nonblocking connect");
+      BGP_EVENT_ADD (peer, TCP_fatal_error);
+      return -1;
+    }
+
+  /* When status is 0 then TCP connection is established. */
+  if (status == 0)
+    {
+      BGP_EVENT_ADD (peer, TCP_connection_open);
+      return 1;
+    }
+  else
+    {
+      if (bgp_debug_neighbor_events(peer))
+        zlog_debug ("%s [Event] Connect failed (%s)",
+                    peer->host, safe_strerror (errno));
+      BGP_EVENT_ADD (peer, TCP_connection_open_failed);
+      return 0;
+    }
+}
 
 /* TCP connection open.  Next we send open message to remote peer. And
    add read thread for reading open message. */
@@ -1379,8 +1425,9 @@ bgp_start (struct peer *peer)
 		    peer->fd);
 	  return -1;
 	}
-      BGP_READ_ON (peer->t_read, bgp_read, peer->fd);
-      peer_writes_on (peer);
+      // when the socket becomes ready (or fails to connect), bgp_connect_check
+      // will be called.
+      thread_add_read (bm->master, bgp_connect_check, peer, peer->fd);
       break;
     }
   return 0;

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -35,18 +35,6 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
       THREAD_READ_OFF(T);			\
   } while (0)
 
-#define BGP_WRITE_ON(T,F,V)			\
-  do {						\
-    if (!(T) && (peer->status != Deleted))	\
-      THREAD_WRITE_ON(bm->master,(T),(F),peer,(V)); \
-  } while (0)
-
-#define BGP_PEER_WRITE_ON(T,F,V, peer)			\
-  do {							\
-    if (!(T) && ((peer)->status != Deleted))		\
-      THREAD_WRITE_ON(bm->master,(T),(F),(peer),(V));	\
-  } while (0)
-
 #define BGP_WRITE_OFF(T)			\
   do {						\
     if (T)					\

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -1,25 +1,26 @@
-/* BGP Keepalives.
+/*
+ * BGP Keepalives.
  *
- * Implemented server-style in a pthread.
- * --------------------------------------
+ * Implements a producer thread to generate BGP keepalives for peers.
+ * ----------------------------------------
  * Copyright (C) 2017 Cumulus Networks, Inc.
+ * Quentin Young
  *
- * This file is part of Free Range Routing.
+ * This file is part of FRRouting.
  *
- * Free Range Routing is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any later
+ * FRRouting is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any later
  * version.
  *
- * Free Range Routing is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
+ * FRRouting is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
  *
- * You should have received a copy of the GN5U General Public License along
- * with Free Range Routing; see the file COPYING.  If not, write to the Free
- * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA.
+ * You should have received a copy of the GNU General Public License along with
+ * FRRouting; see the file COPYING.  If not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 #include <zebra.h>
 #include <signal.h>
@@ -29,6 +30,7 @@
 #include "log.h"
 #include "vty.h"
 #include "monotime.h"
+#include "hash.h"
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_keepalives.h"
@@ -49,9 +51,9 @@ struct pkat
 };
 
 /* List of peers we are sending keepalives for, and associated mutex. */
-static pthread_mutex_t *peerlist_mtx;
-static pthread_cond_t *peerlist_cond;
-static struct list *peerlist;
+static pthread_mutex_t *peerhash_mtx;
+static pthread_cond_t *peerhash_cond;
+static struct hash *peerhash;
 
 /* Thread control flag. */
 bool bgp_keepalives_thread_run = false;
@@ -71,6 +73,7 @@ pkat_del (void *pkat)
   XFREE (MTYPE_TMP, pkat);
 }
 
+
 /*
  * Walks the list of peers, sending keepalives to those that are due for them.
  *
@@ -89,75 +92,79 @@ pkat_del (void *pkat)
  *
  * @return maximum time to wait until next update (0 if infinity)
  */
-static struct timeval
-update ()
+static void
+peer_process (struct hash_backet *hb, void *arg)
 {
-  struct listnode *ln;
-  struct pkat *pkat;
+  struct pkat *pkat = hb->data;
 
-  int update_set = 0;                   // whether next_update has been set
-  struct timeval next_update;           // max sleep until next tick
+  struct timeval *next_update = arg;
+
   static struct timeval elapsed;        // elapsed time since keepalive
   static struct timeval ka = { 0 };     // peer->v_keepalive as a timeval
   static struct timeval diff;           // ka - elapsed
 
-  // see function comment
   static struct timeval tolerance = { 0, 100000 };
 
-  for (ALL_LIST_ELEMENTS_RO (peerlist, ln, pkat))
+  // calculate elapsed time since last keepalive
+  monotime_since (&pkat->last, &elapsed);
+
+  // calculate difference between elapsed time and configured time
+  ka.tv_sec = pkat->peer->v_keepalive;
+  timersub (&ka, &elapsed, &diff);
+
+  int send_keepalive = elapsed.tv_sec >= ka.tv_sec ||
+    timercmp (&diff, &tolerance, <);
+
+  if (send_keepalive)
     {
-      // calculate elapsed time since last keepalive
-      monotime_since (&pkat->last, &elapsed);
+      if (bgp_debug_neighbor_events (pkat->peer))
+        zlog_debug ("%s [FSM] Timer (keepalive timer expire)",
+                    pkat->peer->host);
 
-      // calculate difference between elapsed time and configured time
-      ka.tv_sec = pkat->peer->v_keepalive;
-      timersub (&ka, &elapsed, &diff);
-
-      int send_keepalive = elapsed.tv_sec >= ka.tv_sec ||
-        timercmp (&diff, &tolerance, <);
-
-      if (send_keepalive)
-        {
-          if (bgp_debug_neighbor_events (pkat->peer))
-            zlog_debug ("%s [FSM] Timer (keepalive timer expire)",
-                        pkat->peer->host);
-
-          bgp_keepalive_send (pkat->peer);
-          monotime (&pkat->last);
-          memset (&elapsed, 0x00, sizeof (struct timeval));
-          diff = ka;            // time until next keepalive == peer keepalive time
-        }
-
-      // if calculated next update for this peer < current delay, use it
-      if (!update_set || timercmp (&diff, &next_update, <))
-        {
-          next_update = diff;
-          update_set = 1;
-        }
+      bgp_keepalive_send (pkat->peer);
+      monotime (&pkat->last);
+      memset (&elapsed, 0x00, sizeof (struct timeval));
+      diff = ka;            // time until next keepalive == peer keepalive time
     }
 
-  return next_update;
+  // if calculated next update for this peer < current delay, use it
+  if (next_update->tv_sec <= 0 || timercmp (&diff, next_update, <))
+    *next_update = diff;
+}
+
+static int
+peer_hash_cmp (const void *f, const void *s)
+{
+   const struct pkat *p1 = f;
+   const struct pkat *p2 = s;
+   return p1->peer == p2->peer;
+}
+
+static unsigned int
+peer_hash_key (void *arg)
+{
+  struct pkat *pkat = arg;
+  return (uintptr_t) pkat->peer;
 }
 
 void
 peer_keepalives_init ()
 {
-  peerlist_mtx = XCALLOC (MTYPE_PTHREAD, sizeof(pthread_mutex_t));
-  peerlist_cond = XCALLOC (MTYPE_PTHREAD, sizeof(pthread_cond_t));
+  peerhash_mtx = XCALLOC (MTYPE_PTHREAD, sizeof(pthread_mutex_t));
+  peerhash_cond = XCALLOC (MTYPE_PTHREAD, sizeof(pthread_cond_t));
 
   // initialize mutex
-  pthread_mutex_init (peerlist_mtx, NULL);
+  pthread_mutex_init (peerhash_mtx, NULL);
 
   // use monotonic clock with condition variable
   pthread_condattr_t attrs;
   pthread_condattr_init (&attrs);
   pthread_condattr_setclock (&attrs, CLOCK_MONOTONIC);
-  pthread_cond_init (peerlist_cond, &attrs);
+  pthread_cond_init (peerhash_cond, &attrs);
   pthread_condattr_destroy (&attrs);
 
-  // initialize peerlist
-  peerlist = list_new ();
-  peerlist->del = pkat_del;
+  // initialize peer hashtable
+  peerhash = hash_create_size (2048, peer_hash_key, peer_hash_cmp);
 }
 
 static void
@@ -165,17 +172,20 @@ peer_keepalives_finish (void *arg)
 {
   bgp_keepalives_thread_run = false;
 
-  if (peerlist)
-    list_delete (peerlist);
+  if (peerhash)
+    {
+      hash_clean (peerhash, pkat_del);
+      hash_free (peerhash);
+    }
 
-  peerlist = NULL;
+  peerhash = NULL;
 
-  pthread_mutex_unlock (peerlist_mtx);
-  pthread_mutex_destroy (peerlist_mtx);
-  pthread_cond_destroy (peerlist_cond);
+  pthread_mutex_unlock (peerhash_mtx);
+  pthread_mutex_destroy (peerhash_mtx);
+  pthread_cond_destroy (peerhash_cond);
 
-  XFREE (MTYPE_PTHREAD, peerlist_mtx);
-  XFREE (MTYPE_PTHREAD, peerlist_cond);
+  XFREE (MTYPE_PTHREAD, peerhash_mtx);
+  XFREE (MTYPE_PTHREAD, peerhash_cond);
 }
 
 /**
@@ -187,10 +197,11 @@ void *
 peer_keepalives_start (void *arg)
 {
   struct timeval currtime = { 0, 0 };
+  struct timeval aftertime = {0, 0};
   struct timeval next_update = { 0, 0 };
   struct timespec next_update_ts = { 0, 0 };
 
-  pthread_mutex_lock (peerlist_mtx);
+  pthread_mutex_lock (peerhash_mtx);
 
   // register cleanup handler
   pthread_cleanup_push (&peer_keepalives_finish, NULL);
@@ -199,14 +210,22 @@ peer_keepalives_start (void *arg)
 
   while (bgp_keepalives_thread_run)
     {
-      if (peerlist->count > 0)
-        pthread_cond_timedwait (peerlist_cond, peerlist_mtx, &next_update_ts);
+      if (peerhash->count > 0)
+        pthread_cond_timedwait (peerhash_cond, peerhash_mtx, &next_update_ts);
       else
-        while (peerlist->count == 0 && bgp_keepalives_thread_run)
-          pthread_cond_wait (peerlist_cond, peerlist_mtx);
+        while (peerhash->count == 0 && bgp_keepalives_thread_run)
+          pthread_cond_wait (peerhash_cond, peerhash_mtx);
 
       monotime (&currtime);
-      next_update = update ();
+
+      next_update.tv_sec = -1;
+
+      hash_iterate (peerhash, peer_process, &next_update);
+      if (next_update.tv_sec == -1)
+        memset (&next_update, 0x00, sizeof(next_update));
+
+      monotime_since (&currtime, &aftertime);
+
       timeradd (&currtime, &next_update, &next_update);
       TIMEVAL_TO_TIMESPEC (&next_update, &next_update_ts);
     }
@@ -222,55 +241,51 @@ peer_keepalives_start (void *arg)
 void
 peer_keepalives_on (struct peer *peer)
 {
-  pthread_mutex_lock (peerlist_mtx);
+  /* placeholder bucket data to use for fast key lookups */
+  static struct pkat holder = { 0 };
+
+  pthread_mutex_lock (peerhash_mtx);
   {
-    struct listnode *ln, *nn;
-    struct pkat *pkat;
-
-    for (ALL_LIST_ELEMENTS (peerlist, ln, nn, pkat))
-      if (pkat->peer == peer)
-        {
-          pthread_mutex_unlock (peerlist_mtx);
-          return;
-        }
-
-    pkat = pkat_new (peer);
-    listnode_add (peerlist, pkat);
-    peer_lock (peer);
+    holder.peer = peer;
+    if (!hash_lookup (peerhash, &holder))
+      {
+        struct pkat *pkat = pkat_new (peer);
+        hash_get (peerhash, pkat, hash_alloc_intern);
+        peer_lock (peer);
+      }
     SET_FLAG (peer->thread_flags, PEER_THREAD_KEEPALIVES_ON);
   }
-  pthread_mutex_unlock (peerlist_mtx);
+  pthread_mutex_unlock (peerhash_mtx);
   peer_keepalives_wake ();
 }
 
 void
 peer_keepalives_off (struct peer *peer)
 {
-  pthread_mutex_lock (peerlist_mtx);
+  /* placeholder bucket data to use for fast key lookups */
+  static struct pkat holder = { 0 };
+
+  pthread_mutex_lock (peerhash_mtx);
   {
-    struct listnode *ln, *nn;
-    struct pkat *pkat;
-
-    for (ALL_LIST_ELEMENTS (peerlist, ln, nn, pkat))
-      if (pkat->peer == peer)
-        {
-          XFREE (MTYPE_TMP, pkat);
-          list_delete_node (peerlist, ln);
-          peer_unlock (peer);
-        }
-
+    holder.peer = peer;
+    struct pkat *res = hash_release (peerhash, &holder);
+    if (res)
+      {
+        pkat_del (res);
+        peer_unlock (peer);
+      }
     UNSET_FLAG (peer->thread_flags, PEER_THREAD_KEEPALIVES_ON);
   }
-  pthread_mutex_unlock (peerlist_mtx);
+  pthread_mutex_unlock (peerhash_mtx);
 }
 
 void
 peer_keepalives_wake ()
 {
-  pthread_mutex_lock (peerlist_mtx);
+  pthread_mutex_lock (peerhash_mtx);
   {
-    pthread_cond_signal (peerlist_cond);
+    pthread_cond_signal (peerhash_cond);
   }
-  pthread_mutex_unlock (peerlist_mtx);
+  pthread_mutex_unlock (peerhash_mtx);
 }
 

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -222,6 +222,7 @@ peer_keepalives_on (struct peer *peer)
     pkat = pkat_new (peer);
     listnode_add (peerlist, pkat);
     peer_lock (peer);
+    SET_FLAG (peer->thread_flags, PEER_THREAD_KEEPALIVES_ON);
   }
   pthread_mutex_unlock (&peerlist_mtx);
   peer_keepalives_wake ();
@@ -242,6 +243,8 @@ peer_keepalives_off (struct peer *peer)
           list_delete_node (peerlist, ln);
           peer_unlock (peer);
         }
+
+    UNSET_FLAG (peer->thread_flags, PEER_THREAD_KEEPALIVES_ON);
   }
   pthread_mutex_unlock (&peerlist_mtx);
 }

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -1,0 +1,258 @@
+/* BGP Keepalives.
+ *
+ * Implemented server-style in a pthread.
+ * --------------------------------------
+ * Copyright (C) 2017 Cumulus Networks, Inc.
+ *
+ * This file is part of Free Range Routing.
+ *
+ * Free Range Routing is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any later
+ * version.
+ *
+ * Free Range Routing is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GN5U General Public License along
+ * with Free Range Routing; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+#include <zebra.h>
+#include <signal.h>
+#include <sys/time.h>
+
+#include "thread.h"
+#include "log.h"
+#include "vty.h"
+#include "monotime.h"
+
+#include "bgpd/bgpd.h"
+#include "bgpd/bgp_keepalives.h"
+#include "bgpd/bgp_debug.h"
+#include "bgpd/bgp_attr.h"
+#include "bgpd/bgp_packet.h"
+
+/**
+ * Peer KeepAlive Timer.
+ * Associates a peer with the time of its last keepalive.
+ */
+struct pkat
+{
+  // the peer to send keepalives to
+  struct peer *peer;
+  // absolute time of last keepalive sent
+  struct timeval last;
+};
+
+/* List of peers we are sending keepalives for, and associated mutex. */
+static pthread_mutex_t peerlist_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t peerlist_cond;
+static struct list *peerlist;
+
+/* Thread control flag. */
+bool bgp_keepalives_thread_run;
+
+static struct pkat *
+pkat_new (struct peer *peer)
+{
+  struct pkat *pkat = XMALLOC (MTYPE_TMP, sizeof (struct pkat));
+  pkat->peer = peer;
+  monotime (&pkat->last);
+  return pkat;
+}
+
+static void
+pkat_del (void *pkat)
+{
+  XFREE (MTYPE_TMP, pkat);
+}
+/**
+ * Cleanup thread resources at termination.
+ *
+ * @param arg not used
+ */
+static void
+cleanup_handler (void *arg)
+{
+  if (peerlist)
+    list_delete (peerlist);
+
+  peerlist = NULL;
+
+  pthread_mutex_unlock (&peerlist_mtx);
+  pthread_cond_destroy (&peerlist_cond);
+  memset (&peerlist_cond, 0, sizeof(peerlist_cond));
+}
+
+/*
+ * Walks the list of peers, sending keepalives to those that are due for them.
+ *
+ * For any given peer, if the elapsed time since its last keepalive exceeds its
+ * configured keepalive timer, a keepalive is sent to the peer and its
+ * last-sent time is reset. Additionally, If the elapsed time does not exceed
+ * the configured keepalive timer, but the time until the next keepalive is due
+ * is within a hardcoded tolerance, a keepalive is sent as if the configured
+ * timer was exceeded. Doing this helps alleviate nanosecond sleeps between
+ * ticks by grouping together peers who are due for keepalives at roughly the
+ * same time. This tolerance value is arbitrarily chosen to be 100ms.
+ *
+ * In addition, this function calculates the maximum amount of time that the
+ * keepalive thread can sleep before another tick needs to take place. This is
+ * equivalent to shortest time until a keepalive is due for any one peer.
+ *
+ * @return maximum time to wait until next update (0 if infinity)
+ */
+static struct timeval
+update ()
+{
+  struct listnode *ln;
+  struct pkat *pkat;
+
+  int update_set = 0;                   // whether next_update has been set
+  struct timeval next_update;           // max sleep until next tick
+  static struct timeval elapsed;        // elapsed time since keepalive
+  static struct timeval ka = { 0 };     // peer->v_keepalive as a timeval
+  static struct timeval diff;           // ka - elapsed
+
+  // see function comment
+  static struct timeval tolerance = { 0, 100000 };
+
+  for (ALL_LIST_ELEMENTS_RO (peerlist, ln, pkat))
+    {
+      // calculate elapsed time since last keepalive
+      monotime_since (&pkat->last, &elapsed);
+
+      // calculate difference between elapsed time and configured time
+      ka.tv_sec = pkat->peer->v_keepalive;
+      timersub (&ka, &elapsed, &diff);
+
+      int send_keepalive = elapsed.tv_sec >= ka.tv_sec ||
+        timercmp (&diff, &tolerance, <);
+
+      if (send_keepalive)
+        {
+          if (bgp_debug_neighbor_events (pkat->peer))
+            zlog_debug ("%s [FSM] Timer (keepalive timer expire)",
+                        pkat->peer->host);
+
+          bgp_keepalive_send (pkat->peer);
+          monotime (&pkat->last);
+          memset (&elapsed, 0x00, sizeof (struct timeval));
+          diff = ka;            // time until next keepalive == peer keepalive time
+        }
+
+      // if calculated next update for this peer < current delay, use it
+      if (!update_set || timercmp (&diff, &next_update, <))
+        {
+          next_update = diff;
+          update_set = 1;
+        }
+    }
+
+  return next_update;
+}
+
+void *
+peer_keepalives_start (void *arg)
+{
+  struct timeval currtime = { 0, 0 };
+  struct timeval next_update = { 0, 0 };
+  struct timespec next_update_ts = { 0, 0 };
+
+  // initialize synchronization primitives
+  pthread_mutex_lock (&peerlist_mtx);
+
+  // use monotonic clock with condition variable
+  pthread_condattr_t attrs;
+  pthread_condattr_init (&attrs);
+  pthread_condattr_setclock (&attrs, CLOCK_MONOTONIC);
+  pthread_cond_init (&peerlist_cond, &attrs);
+
+  // initialize peerlist
+  peerlist = list_new ();
+  peerlist->del = pkat_del;
+
+  // register cleanup handlers
+  pthread_cleanup_push (&cleanup_handler, NULL);
+
+  bgp_keepalives_thread_run = true;
+
+  while (bgp_keepalives_thread_run)
+    {
+      if (peerlist->count > 0)
+        pthread_cond_timedwait (&peerlist_cond, &peerlist_mtx,
+                                &next_update_ts);
+      else
+        while (peerlist->count == 0 && bgp_keepalives_thread_run)
+          pthread_cond_wait (&peerlist_cond, &peerlist_mtx);
+
+      monotime (&currtime);
+      next_update = update ();
+      timeradd (&currtime, &next_update, &next_update);
+      TIMEVAL_TO_TIMESPEC (&next_update, &next_update_ts);
+    }
+
+  // clean up
+  pthread_cleanup_pop (1);
+
+  return NULL;
+}
+
+/* --- thread external functions ------------------------------------------- */
+
+void
+peer_keepalives_on (struct peer *peer)
+{
+  pthread_mutex_lock (&peerlist_mtx);
+  {
+    struct listnode *ln, *nn;
+    struct pkat *pkat;
+
+    for (ALL_LIST_ELEMENTS (peerlist, ln, nn, pkat))
+      if (pkat->peer == peer)
+        {
+          pthread_mutex_unlock (&peerlist_mtx);
+          return;
+        }
+
+    pkat = pkat_new (peer);
+    listnode_add (peerlist, pkat);
+    peer_lock (peer);
+  }
+  pthread_mutex_unlock (&peerlist_mtx);
+  peer_keepalives_wake ();
+}
+
+void
+peer_keepalives_off (struct peer *peer)
+{
+  pthread_mutex_lock (&peerlist_mtx);
+  {
+    struct listnode *ln, *nn;
+    struct pkat *pkat;
+
+    for (ALL_LIST_ELEMENTS (peerlist, ln, nn, pkat))
+      if (pkat->peer == peer)
+        {
+          XFREE (MTYPE_TMP, pkat);
+          list_delete_node (peerlist, ln);
+          peer_unlock (peer);
+        }
+  }
+  pthread_mutex_unlock (&peerlist_mtx);
+}
+
+void
+peer_keepalives_wake ()
+{
+  pthread_mutex_lock (&peerlist_mtx);
+  {
+    pthread_cond_signal (&peerlist_cond);
+  }
+  pthread_mutex_unlock (&peerlist_mtx);
+}
+

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -49,12 +49,12 @@ struct pkat
 };
 
 /* List of peers we are sending keepalives for, and associated mutex. */
-static pthread_mutex_t peerlist_mtx = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t peerlist_cond;
+static pthread_mutex_t *peerlist_mtx;
+static pthread_cond_t *peerlist_cond;
 static struct list *peerlist;
 
 /* Thread control flag. */
-bool bgp_keepalives_thread_run;
+bool bgp_keepalives_thread_run = false;
 
 static struct pkat *
 pkat_new (struct peer *peer)
@@ -69,23 +69,6 @@ static void
 pkat_del (void *pkat)
 {
   XFREE (MTYPE_TMP, pkat);
-}
-/**
- * Cleanup thread resources at termination.
- *
- * @param arg not used
- */
-static void
-cleanup_handler (void *arg)
-{
-  if (peerlist)
-    list_delete (peerlist);
-
-  peerlist = NULL;
-
-  pthread_mutex_unlock (&peerlist_mtx);
-  pthread_cond_destroy (&peerlist_cond);
-  memset (&peerlist_cond, 0, sizeof(peerlist_cond));
 }
 
 /*
@@ -156,6 +139,50 @@ update ()
   return next_update;
 }
 
+void
+peer_keepalives_init ()
+{
+  peerlist_mtx = XCALLOC (MTYPE_PTHREAD, sizeof(pthread_mutex_t));
+  peerlist_cond = XCALLOC (MTYPE_PTHREAD, sizeof(pthread_cond_t));
+
+  // initialize mutex
+  pthread_mutex_init (peerlist_mtx, NULL);
+
+  // use monotonic clock with condition variable
+  pthread_condattr_t attrs;
+  pthread_condattr_init (&attrs);
+  pthread_condattr_setclock (&attrs, CLOCK_MONOTONIC);
+  pthread_cond_init (peerlist_cond, &attrs);
+  pthread_condattr_destroy (&attrs);
+
+  // initialize peerlist
+  peerlist = list_new ();
+  peerlist->del = pkat_del;
+}
+
+static void
+peer_keepalives_finish (void *arg)
+{
+  bgp_keepalives_thread_run = false;
+
+  if (peerlist)
+    list_delete (peerlist);
+
+  peerlist = NULL;
+
+  pthread_mutex_unlock (peerlist_mtx);
+  pthread_mutex_destroy (peerlist_mtx);
+  pthread_cond_destroy (peerlist_cond);
+
+  XFREE (MTYPE_PTHREAD, peerlist_mtx);
+  XFREE (MTYPE_PTHREAD, peerlist_cond);
+}
+
+/**
+ * Entry function for peer keepalive generation pthread.
+ *
+ * peer_keepalives_init() must be called prior to this.
+ */
 void *
 peer_keepalives_start (void *arg)
 {
@@ -163,32 +190,20 @@ peer_keepalives_start (void *arg)
   struct timeval next_update = { 0, 0 };
   struct timespec next_update_ts = { 0, 0 };
 
-  // initialize synchronization primitives
-  pthread_mutex_lock (&peerlist_mtx);
+  pthread_mutex_lock (peerlist_mtx);
 
-  // use monotonic clock with condition variable
-  pthread_condattr_t attrs;
-  pthread_condattr_init (&attrs);
-  pthread_condattr_setclock (&attrs, CLOCK_MONOTONIC);
-  pthread_cond_init (&peerlist_cond, &attrs);
-
-  // initialize peerlist
-  peerlist = list_new ();
-  peerlist->del = pkat_del;
-
-  // register cleanup handlers
-  pthread_cleanup_push (&cleanup_handler, NULL);
+  // register cleanup handler
+  pthread_cleanup_push (&peer_keepalives_finish, NULL);
 
   bgp_keepalives_thread_run = true;
 
   while (bgp_keepalives_thread_run)
     {
       if (peerlist->count > 0)
-        pthread_cond_timedwait (&peerlist_cond, &peerlist_mtx,
-                                &next_update_ts);
+        pthread_cond_timedwait (peerlist_cond, peerlist_mtx, &next_update_ts);
       else
         while (peerlist->count == 0 && bgp_keepalives_thread_run)
-          pthread_cond_wait (&peerlist_cond, &peerlist_mtx);
+          pthread_cond_wait (peerlist_cond, peerlist_mtx);
 
       monotime (&currtime);
       next_update = update ();
@@ -207,7 +222,7 @@ peer_keepalives_start (void *arg)
 void
 peer_keepalives_on (struct peer *peer)
 {
-  pthread_mutex_lock (&peerlist_mtx);
+  pthread_mutex_lock (peerlist_mtx);
   {
     struct listnode *ln, *nn;
     struct pkat *pkat;
@@ -215,7 +230,7 @@ peer_keepalives_on (struct peer *peer)
     for (ALL_LIST_ELEMENTS (peerlist, ln, nn, pkat))
       if (pkat->peer == peer)
         {
-          pthread_mutex_unlock (&peerlist_mtx);
+          pthread_mutex_unlock (peerlist_mtx);
           return;
         }
 
@@ -224,14 +239,14 @@ peer_keepalives_on (struct peer *peer)
     peer_lock (peer);
     SET_FLAG (peer->thread_flags, PEER_THREAD_KEEPALIVES_ON);
   }
-  pthread_mutex_unlock (&peerlist_mtx);
+  pthread_mutex_unlock (peerlist_mtx);
   peer_keepalives_wake ();
 }
 
 void
 peer_keepalives_off (struct peer *peer)
 {
-  pthread_mutex_lock (&peerlist_mtx);
+  pthread_mutex_lock (peerlist_mtx);
   {
     struct listnode *ln, *nn;
     struct pkat *pkat;
@@ -246,16 +261,16 @@ peer_keepalives_off (struct peer *peer)
 
     UNSET_FLAG (peer->thread_flags, PEER_THREAD_KEEPALIVES_ON);
   }
-  pthread_mutex_unlock (&peerlist_mtx);
+  pthread_mutex_unlock (peerlist_mtx);
 }
 
 void
 peer_keepalives_wake ()
 {
-  pthread_mutex_lock (&peerlist_mtx);
+  pthread_mutex_lock (peerlist_mtx);
   {
-    pthread_cond_signal (&peerlist_cond);
+    pthread_cond_signal (peerlist_cond);
   }
-  pthread_mutex_unlock (&peerlist_mtx);
+  pthread_mutex_unlock (peerlist_mtx);
 }
 

--- a/bgpd/bgp_keepalives.h
+++ b/bgpd/bgp_keepalives.h
@@ -1,0 +1,83 @@
+/* BGP Keepalives.
+ *
+ * Implemented server-style in a pthread.
+ * --------------------------------------
+ * Copyright (C) 2017 Cumulus Networks, Inc.
+ *
+ * This file is part of Free Range Routing.
+ *
+ * Free Range Routing is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any later
+ * version.
+ *
+ * Free Range Routing is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GN5U General Public License along
+ * with Free Range Routing; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+#ifndef _BGP_KEEPALIVES_H_
+#define _BGP_KEEPALIVES_H_
+
+#include "bgpd.h"
+
+/* Thread control flag.
+ *
+ * Setting this flag to 'false' while the thread is running will result in
+ * thread termination.
+ */
+extern bool bgp_keepalives_thread_run;
+
+/* Turns on keepalives for a peer.
+ *
+ * This function adds the peer to an internal list of peers to generate
+ * keepalives for.
+ *
+ * At set intervals, a BGP KEEPALIVE packet is generated and placed on
+ * peer->obuf. This operation is thread-safe with respect to peer->obuf.
+ *
+ * peer->v_keepalive determines the interval. Changing this value before
+ * unregistering this peer with peer_keepalives_off() results in undefined
+ * behavior.
+ *
+ * If the peer is already registered for keepalives via this function, nothing
+ * happens.
+ */
+extern void peer_keepalives_on (struct peer *);
+
+/* Turns off keepalives for a peer.
+ *
+ * Removes the peer from the internal list of peers to generate keepalives for.
+ *
+ * If the peer is already unregistered for keepalives, nothing happens.
+ */
+extern void peer_keepalives_off (struct peer *);
+
+/* Entry function for keepalives pthread.
+ *
+ * This function loops over an internal list of peers, generating keepalives at
+ * regular intervals as determined by each peer's keepalive timer.
+ *
+ * See peer_keepalives_on() for additional details.
+ *
+ * @param arg pthread arg, not used
+ */
+extern void *peer_keepalives_start (void *arg);
+
+/* Poking function for keepalives pthread.
+ *
+ * Under normal circumstances the pthread will automatically wake itself
+ * whenever it is necessary to do work. This function may be used to force the
+ * thread to wake up and see if there is any work to do, or if it is time to
+ * die.
+ *
+ * It is not necessary to call this after peer_keepalives_on().
+ */
+extern void peer_keepalives_wake (void);
+
+#endif /* _BGP_KEEPALIVES_H */

--- a/bgpd/bgp_keepalives.h
+++ b/bgpd/bgp_keepalives.h
@@ -58,6 +58,13 @@ extern void peer_keepalives_on (struct peer *);
  */
 extern void peer_keepalives_off (struct peer *);
 
+/* Pre-run initialization function for keepalives pthread.
+ *
+ * Initializes synchronization primitives. This should be called before
+ * anything else to avoid race conditions.
+ */
+extern void peer_keepalives_init (void);
+
 /* Entry function for keepalives pthread.
  *
  * This function loops over an internal list of peers, generating keepalives at

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -20,6 +20,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 
 #include <zebra.h>
 
+#include <pthread.h>
 #include "vector.h"
 #include "command.h"
 #include "getopt.h"
@@ -55,6 +56,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_filter.h"
 #include "bgpd/bgp_zebra.h"
 #include "bgpd/bgp_packet.h"
+#include "bgpd/bgp_keepalives.h"
 
 #ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/rfapi_backend.h"
@@ -430,8 +432,9 @@ main (int argc, char **argv)
             (bm->address ? bm->address : "<all>"),
             bm->port);
 
-  pthread_t packet_writes;
+  pthread_t packet_writes, keepalives;
   pthread_create (&packet_writes, NULL, &peer_writes_start, NULL);
+  pthread_create (&keepalives, NULL, &keepalives_start, NULL);
 
   frr_config_fork ();
   frr_run (bm->master);

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -437,7 +437,7 @@ main (int argc, char **argv)
 
   frr_config_fork ();
   /* must be called after fork() */
-  bgp_pthreads_init ();
+  bgp_pthreads_run ();
   frr_run (bm->master);
 
   /* Not reached. */

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -209,6 +209,9 @@ bgp_exit (int status)
   /* reverse bgp_attr_init */
   bgp_attr_finish ();
 
+  /* stop pthreads */
+  bgp_pthreads_finish ();
+
   /* reverse access_list_init */
   access_list_add_hook (NULL);
   access_list_delete_hook (NULL);
@@ -432,11 +435,9 @@ main (int argc, char **argv)
             (bm->address ? bm->address : "<all>"),
             bm->port);
 
-  pthread_t packet_writes, keepalives;
-  pthread_create (&packet_writes, NULL, &peer_writes_start, NULL);
-  pthread_create (&keepalives, NULL, &keepalives_start, NULL);
-
   frr_config_fork ();
+  /* must be called after fork() */
+  bgp_pthreads_init ();
   frr_run (bm->master);
 
   /* Not reached. */

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -54,6 +54,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_filter.h"
 #include "bgpd/bgp_zebra.h"
+#include "bgpd/bgp_packet.h"
 
 #ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/rfapi_backend.h"
@@ -428,6 +429,9 @@ main (int argc, char **argv)
   snprintf (bgpd_di.startinfo, sizeof (bgpd_di.startinfo), ", bgp@%s:%d",
             (bm->address ? bm->address : "<all>"),
             bm->port);
+
+  pthread_t packet_writes;
+  pthread_create (&packet_writes, NULL, &peer_writes_start, NULL);
 
   frr_config_fork ();
   frr_run (bm->master);

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2280,6 +2280,9 @@ peer_writes_start (void *arg)
             bgp_write (peer);
           }
           pthread_mutex_unlock (&peer->obuf_mtx);
+
+          if (!bgp_packet_writes_thread_run)
+            break;
         }
 
       // schedule update packet generation on main thread

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2325,6 +2325,8 @@ peer_writes_on (struct peer *peer)
 
     peer_lock (peer);
     listnode_add (plist, peer);
+
+    SET_FLAG (peer->thread_flags, PEER_THREAD_WRITES_ON);
   }
   pthread_mutex_unlock (&plist_mtx);
   peer_writes_wake();
@@ -2347,6 +2349,8 @@ peer_writes_off (struct peer *peer)
           peer_unlock (peer);
           break;
         }
+
+    UNSET_FLAG (peer->thread_flags, PEER_THREAD_WRITES_ON);
   }
   pthread_mutex_unlock (&plist_mtx);
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2161,10 +2161,9 @@ bgp_write (struct peer *peer)
 
         if (num < 0)
           {
-            if (ERRNO_IO_RETRY(errno))
-              continue;
+            if (!ERRNO_IO_RETRY(errno))
+              BGP_EVENT_ADD (peer, TCP_fatal_error);
 
-            BGP_EVENT_ADD (peer, TCP_fatal_error);
             goto done;
           }
         else if (num != writenum) // incomplete write

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -135,47 +135,6 @@ bgp_packet_delete_unsafe (struct peer *peer)
   stream_free (stream_fifo_pop (peer->obuf));
 }
 
-
-/* Check file descriptor whether connect is established. */
-static int
-bgp_connect_check (struct peer *peer, int change_state)
-{
-  int status;
-  socklen_t slen;
-  int ret;
-
-  /* Anyway I have to reset read and write thread. */
-  BGP_READ_OFF (peer->t_read);
-
-  /* Check file descriptor. */
-  slen = sizeof (status);
-  ret = getsockopt(peer->fd, SOL_SOCKET, SO_ERROR, (void *) &status, &slen);
-
-  /* If getsockopt is fail, this is fatal error. */
-  if (ret < 0)
-    {
-      zlog_info ("can't get sockopt for nonblocking connect");
-      BGP_EVENT_ADD (peer, TCP_fatal_error);
-      return -1;
-    }      
-
-  /* When status is 0 then TCP connection is established. */
-  if (status == 0)
-    {
-      BGP_EVENT_ADD (peer, TCP_connection_open);
-      return 1;
-    }
-  else
-    {
-      if (bgp_debug_neighbor_events(peer))
-	  zlog_debug ("%s [Event] Connect failed (%s)",
-		      peer->host, safe_strerror (errno));
-      if (change_state)
-	BGP_EVENT_ADD (peer, TCP_connection_open_failed);
-      return 0;
-    }
-}
-
 static struct stream *
 bgp_update_packet_eor (struct peer *peer, afi_t afi, safi_t safi)
 {
@@ -2018,21 +1977,13 @@ bgp_read (struct thread *thread)
   /* Note notify_out so we can check later to see if we sent another one */
   notify_out = peer->notify_out;
 
-  /* For non-blocking IO check. */
-  if (peer->status == Connect)
+  if (peer->fd < 0)
     {
-      bgp_connect_check (peer, 1);
-      goto done;
+      zlog_err ("bgp_read(): peer's fd is negative value %d", peer->fd);
+      return -1;
     }
-  else
-    {
-      if (peer->fd < 0)
-	{
-	  zlog_err ("bgp_read peer's fd is negative value %d", peer->fd);
-	  return -1;
-	}
-      BGP_READ_ON (peer->t_read, bgp_read, peer->fd);
-    }
+
+  BGP_READ_ON (peer->t_read, bgp_read, peer->fd);
 
   /* Read packet header to determine type of the packet */
   if (peer->packet_size == 0)
@@ -2198,13 +2149,6 @@ bgp_write (struct peer *peer)
   int update_last_write = 0;
   unsigned int count = 0;
   unsigned int oc = 0;
-
-  /* For non-blocking IO check. */
-  if (peer->status == Connect)
-    {
-      bgp_connect_check (peer, 1);
-      return 0;
-    }
 
   /* Write packets. The number of packets written is the value of
    * bgp->wpkt_quanta or the size of the output buffer, whichever is smaller.*/

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -19,6 +19,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 02111-1307, USA.  */
 
 #include <zebra.h>
+#include <sys/time.h>
 
 #include "thread.h"
 #include "stream.h"
@@ -56,6 +57,13 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_vty.h"
 #include "bgpd/bgp_updgrp.h"
 
+/* Linked list of active peers */
+static pthread_mutex_t plist_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t write_cond = PTHREAD_COND_INITIALIZER;
+static struct list *plist;
+
+bool bgp_packet_writes_thread_run;
+
 /* Set up BGP packet marker and packet type. */
 int
 bgp_packet_set_marker (struct stream *s, u_char type)
@@ -90,23 +98,43 @@ bgp_packet_set_size (struct stream *s)
   return cp;
 }
 
-/* Add new packet to the peer. */
-void
-bgp_packet_add (struct peer *peer, struct stream *s)
+/**
+ * Push a packet onto the beginning of the peer's output queue.
+ * Must be externally synchronized around 'peer'.
+ */
+static void
+bgp_packet_add_unsafe (struct peer *peer, struct stream *s)
 {
   /* Add packet to the end of list. */
   stream_fifo_push (peer->obuf, s);
+  peer_writes_wake();
 }
 
-/* Free first packet. */
+/*
+ * Push a packet onto the beginning of the peer's output queue.
+ * This function acquires the peer's write mutex before proceeding.
+ */
 static void
-bgp_packet_delete (struct peer *peer)
+bgp_packet_add (struct peer *peer, struct stream *s)
+{
+  pthread_mutex_lock (&peer->obuf_mtx);
+  bgp_packet_add_unsafe (peer, s);
+  pthread_mutex_unlock (&peer->obuf_mtx);
+}
+
+/**
+ * Pop a packet off the end of the peer's output queue.
+ * Must be externally synchronized around 'peer'.
+ */
+static void
+bgp_packet_delete_unsafe (struct peer *peer)
 {
   stream_free (stream_fifo_pop (peer->obuf));
 }
 
+
 /* Check file descriptor whether connect is established. */
-int
+static int
 bgp_connect_check (struct peer *peer, int change_state)
 {
   int status;
@@ -115,7 +143,6 @@ bgp_connect_check (struct peer *peer, int change_state)
 
   /* Anyway I have to reset read and write thread. */
   BGP_READ_OFF (peer->t_read);
-  BGP_WRITE_OFF (peer->t_write);
 
   /* Check file descriptor. */
   slen = sizeof (status);
@@ -187,7 +214,7 @@ bgp_update_packet_eor (struct peer *peer, afi_t afi, safi_t safi)
     }
 
   bgp_packet_set_size (s);
-  bgp_packet_add (peer, s);
+  bgp_packet_add_unsafe (peer, s);
   return s;
 }
 
@@ -260,11 +287,10 @@ bgp_write_packet (struct peer *peer)
 	  }
 
 
-        /*
-	 * Found a packet template to send, overwrite packet with appropriate
-         * attributes from peer and advance peer
-	 */
+        /* Found a packet template to send, overwrite packet with appropriate
+         * attributes from peer and advance peer */
         s = bpacket_reformat_for_peer (next_pkt, paf);
+        bgp_packet_add_unsafe (peer, s);
         bpacket_queue_advance_peer (paf);
         return s;
       }
@@ -272,252 +298,9 @@ bgp_write_packet (struct peer *peer)
   return NULL;
 }
 
-/* The next action for the peer from a write perspective */
-static void
-bgp_write_proceed_actions (struct peer *peer)
-{
-  afi_t afi;
-  safi_t safi;
-  struct peer_af *paf;
-  struct bpacket *next_pkt;
-  int fullq_found = 0;
-  struct update_subgroup *subgrp;
-
-  if (stream_fifo_head (peer->obuf))
-    {
-      BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
-      return;
-    }
-
-   for (afi = AFI_IP; afi < AFI_MAX; afi++)
-     for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++)
-      {
-        paf = peer_af_find (peer, afi, safi);
-        if (!paf)
-          continue;
-        subgrp = paf->subgroup;
-        if (!subgrp)
-          continue;
-
-        next_pkt = paf->next_pkt_to_send;
-        if (next_pkt && next_pkt->buffer)
-          {
-            BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
-            return;
-          }
-
-        /* No packets readily available for AFI/SAFI, are there subgroup packets
-         * that need to be generated? */
-        if (bpacket_queue_is_full(SUBGRP_INST(subgrp),
-                                  SUBGRP_PKTQ(subgrp)))
-          fullq_found = 1;
-        else if (subgroup_packets_to_build (subgrp))
-          {
-            BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
-            return;
-          }
-
-        /* No packets to send, see if EOR is pending */
-        if (CHECK_FLAG (peer->cap, PEER_CAP_RESTART_RCV))
-          {
-            if (!subgrp->t_coalesce &&
-                peer->afc_nego[afi][safi] &&
-                peer->synctime &&
-                !CHECK_FLAG(peer->af_sflags[afi][safi],
-                            PEER_STATUS_EOR_SEND) &&
-                safi != SAFI_MPLS_VPN)
-              {
-                BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
-                return;
-              }
-
-          }
-      }
-  if (fullq_found)
-    {
-      BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
-      return;
-    }
-}
-
-/* Write packet to the peer. */
-int
-bgp_write (struct thread *thread)
-{
-  struct peer *peer;
-  u_char type;
-  struct stream *s;
-  int num;
-  int update_last_write = 0;
-  unsigned int count = 0;
-  unsigned int oc = 0;
-
-  /* Yes first of all get peer pointer. */
-  peer = THREAD_ARG (thread);
-  peer->t_write = NULL;
-
-  /* For non-blocking IO check. */
-  if (peer->status == Connect)
-    {
-      bgp_connect_check (peer, 1);
-      return 0;
-    }
-
-  s = bgp_write_packet (peer);
-  if (!s)
-    {
-      bgp_write_proceed_actions (peer);
-      return 0;
-    }
-
-  sockopt_cork (peer->fd, 1);
-
-  oc = peer->update_out;
-
-  /* Nonblocking write until TCP output buffer is full.  */
-  do
-    {
-      int writenum;
-
-      /* Number of bytes to be sent.  */
-      writenum = stream_get_endp (s) - stream_get_getp (s);
-
-      /* Call write() system call.  */
-      num = write (peer->fd, STREAM_PNT (s), writenum);
-      if (num < 0)
-	{
-	  /* write failed either retry needed or error */
-	  if (ERRNO_IO_RETRY(errno))
-		break;
-
-          BGP_EVENT_ADD (peer, TCP_fatal_error);
-	  return 0;
-	}
-
-      if (num != writenum)
-	{
-	  /* Partial write */
-	  stream_forward_getp (s, num);
-	  break;
-	}
-
-      /* Retrieve BGP packet type. */
-      stream_set_getp (s, BGP_MARKER_SIZE + 2);
-      type = stream_getc (s);
-
-      switch (type)
-	{
-	case BGP_MSG_OPEN:
-	  peer->open_out++;
-	  break;
-	case BGP_MSG_UPDATE:
-	  peer->update_out++;
-	  break;
-	case BGP_MSG_NOTIFY:
-	  peer->notify_out++;
-	  /* Double start timer. */
-	  peer->v_start *= 2;
-
-	  /* Overflow check. */
-	  if (peer->v_start >= (60 * 2))
-	    peer->v_start = (60 * 2);
-
-	  /* Flush any existing events */
-	  BGP_EVENT_ADD (peer, BGP_Stop);
-	  goto done;
-
-	case BGP_MSG_KEEPALIVE:
-	  peer->keepalive_out++;
-	  break;
-	case BGP_MSG_ROUTE_REFRESH_NEW:
-	case BGP_MSG_ROUTE_REFRESH_OLD:
-	  peer->refresh_out++;
-	  break;
-	case BGP_MSG_CAPABILITY:
-	  peer->dynamic_cap_out++;
-	  break;
-	}
-
-      /* OK we send packet so delete it. */
-      bgp_packet_delete (peer);
-      update_last_write = 1;
-    }
-  while (++count < peer->bgp->wpkt_quanta &&
-	 (s = bgp_write_packet (peer)) != NULL);
-
-  bgp_write_proceed_actions (peer);
-
- done:
-  /* Update last_update if UPDATEs were written. */
-  if (peer->update_out > oc)
-    peer->last_update = bgp_clock ();
-
-  /* If we TXed any flavor of packet update last_write */
-  if (update_last_write)
-    peer->last_write = bgp_clock ();
-
-  sockopt_cork (peer->fd, 0);
-  return 0;
-}
-
-/* This is only for sending NOTIFICATION message to neighbor. */
-static int
-bgp_write_notify (struct peer *peer)
-{
-  int ret, val;
-  u_char type;
-  struct stream *s;
-
-  /* There should be at least one packet. */
-  s = stream_fifo_head (peer->obuf);
-  if (!s)
-    return 0;
-  assert (stream_get_endp (s) >= BGP_HEADER_SIZE);
-
-  /* Stop collecting data within the socket */
-  sockopt_cork (peer->fd, 0);
-
-  /* socket is in nonblocking mode, if we can't deliver the NOTIFY, well,
-   * we only care about getting a clean shutdown at this point. */
-  ret = write (peer->fd, STREAM_DATA (s), stream_get_endp (s));
-
-  /* only connection reset/close gets counted as TCP_fatal_error, failure
-   * to write the entire NOTIFY doesn't get different FSM treatment */
-  if (ret <= 0)
-    {
-      BGP_EVENT_ADD (peer, TCP_fatal_error);
-      return 0;
-    }
-
-  /* Disable Nagle, make NOTIFY packet go out right away */
-  val = 1;
-  (void) setsockopt (peer->fd, IPPROTO_TCP, TCP_NODELAY,
-                            (char *) &val, sizeof (val));
-
-  /* Retrieve BGP packet type. */
-  stream_set_getp (s, BGP_MARKER_SIZE + 2);
-  type = stream_getc (s);
-
-  assert (type == BGP_MSG_NOTIFY);
-
-  /* Type should be notify. */
-  peer->notify_out++;
-
-  /* Double start timer. */
-  peer->v_start *= 2;
-
-  /* Overflow check. */
-  if (peer->v_start >= (60 * 2))
-    peer->v_start = (60 * 2);
-
-  /* Handle Graceful Restart case where the state changes to
-     Connect instead of Idle */
-  BGP_EVENT_ADD (peer, BGP_Stop);
-
-  return 0;
-}
-
-/* Make keepalive packet and send it to the peer. */
+/*
+ * Creates a BGP Keepalive packet and appends it to the peer's output queue.
+ */
 void
 bgp_keepalive_send (struct peer *peer)
 {
@@ -539,11 +322,12 @@ bgp_keepalive_send (struct peer *peer)
 
   /* Add packet to the peer. */
   bgp_packet_add (peer, s);
-
-  BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
 }
 
-/* Make open packet and send it to the peer. */
+/*
+ * Creates a BGP Open packet and appends it to the peer's output queue.
+ * Sets capabilities as necessary.
+ */
 void
 bgp_open_send (struct peer *peer)
 {
@@ -590,11 +374,20 @@ bgp_open_send (struct peer *peer)
 
   /* Add packet to the peer. */
   bgp_packet_add (peer, s);
-
-  BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
 }
 
-/* Send BGP notify packet with data potion. */
+/*
+ * Creates a BGP Notify and appends it to the peer's output queue.
+ *
+ * This function awakens the write thread to ensure the packet
+ * gets out ASAP.
+ *
+ * @param peer
+ * @param code      BGP error code
+ * @param sub_code  BGP error subcode
+ * @param data      Data portion
+ * @param datalen   length of data portion
+ */
 void
 bgp_notify_send_with_data (struct peer *peer, u_char code, u_char sub_code,
 			   u_char *data, size_t datalen)
@@ -605,7 +398,7 @@ bgp_notify_send_with_data (struct peer *peer, u_char code, u_char sub_code,
   /* Allocate new stream. */
   s = stream_new (BGP_MAX_PACKET_SIZE);
 
-  /* Make nitify packet. */
+  /* Make notify packet. */
   bgp_packet_set_marker (s, BGP_MSG_NOTIFY);
 
   /* Set notify packet values. */
@@ -620,8 +413,9 @@ bgp_notify_send_with_data (struct peer *peer, u_char code, u_char sub_code,
   length = bgp_packet_set_size (s);
   
   /* Add packet to the peer. */
+  pthread_mutex_lock (&peer->obuf_mtx);
   stream_fifo_clean (peer->obuf);
-  bgp_packet_add (peer, s);
+  pthread_mutex_unlock (&peer->obuf_mtx);
 
   /* For debug */
   {
@@ -678,20 +472,38 @@ bgp_notify_send_with_data (struct peer *peer, u_char code, u_char sub_code,
   else
     peer->last_reset = PEER_DOWN_NOTIFY_SEND;
 
-  /* Call immediately. */
-  BGP_WRITE_OFF (peer->t_write);
-
-  bgp_write_notify (peer);
+  /* Add packet to peer's output queue */
+  bgp_packet_add (peer, s);
+  /* Wake up the write thread to get the notify out ASAP */
+  peer_writes_wake ();
 }
 
-/* Send BGP notify packet. */
+/*
+ * Creates a BGP Notify and appends it to the peer's output queue.
+ *
+ * This function awakens the write thread to ensure the packet
+ * gets out ASAP.
+ *
+ * @param peer
+ * @param code      BGP error code
+ * @param sub_code  BGP error subcode
+ */
 void
 bgp_notify_send (struct peer *peer, u_char code, u_char sub_code)
 {
   bgp_notify_send_with_data (peer, code, sub_code, NULL, 0);
 }
 
-/* Send route refresh message to the peer. */
+/*
+ * Creates BGP Route Refresh packet and appends it to the peer's output queue.
+ *
+ * @param peer
+ * @param afi               Address Family Identifier
+ * @param safi              Subsequent Address Family Identifier
+ * @param orf_type          Outbound Route Filtering type
+ * @param when_to_refresh   Whether to refresh immediately or defer
+ * @param remove            Whether to remove ORF for specified AFI/SAFI
+ */
 void
 bgp_route_refresh_send (struct peer *peer, afi_t afi, safi_t safi,
 			u_char orf_type, u_char when_to_refresh, int remove)
@@ -776,11 +588,17 @@ bgp_route_refresh_send (struct peer *peer, afi_t afi, safi_t safi,
 
   /* Add packet to the peer. */
   bgp_packet_add (peer, s);
-
-  BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
 }
 
-/* Send capability message to the peer. */
+/*
+ * Create a BGP Capability packet and append it to the peer's output queue.
+ *
+ * @param peer
+ * @param afi              Address Family Identifier
+ * @param safi             Subsequent Address Family Identifier
+ * @param capability_code  BGP Capability Code
+ * @param action           Set or Remove capability
+ */
 void
 bgp_capability_send (struct peer *peer, afi_t afi, safi_t safi,
 		     int capability_code, int action)
@@ -818,8 +636,6 @@ bgp_capability_send (struct peer *peer, afi_t afi, safi_t safi,
 
   /* Add packet to the peer. */
   bgp_packet_add (peer, s);
-
-  BGP_WRITE_ON (peer->t_write, bgp_write, peer->fd);
 }
 
 /* RFC1771 6.8 Connection collision detection. */
@@ -2338,4 +2154,237 @@ bgp_read (struct thread *thread)
     }
 
   return 0;
+}
+
+/* ------------- write thread ------------------ */
+
+/**
+ * Flush peer output buffer.
+ *
+ * This function pops packets off of peer->obuf and writes them to peer->fd.
+ * The amount of packets written is equal to the minimum of peer->wpkt_quanta
+ * and the number of packets on the output buffer.
+ *
+ * If write() returns an error, the appropriate FSM event is generated.
+ *
+ * The return value is equal to the number of packets written
+ * (which may be zero).
+ */
+static int
+bgp_write (struct peer *peer)
+{
+  u_char type;
+  struct stream *s;
+  int num;
+  int update_last_write = 0;
+  unsigned int count = 0;
+  unsigned int oc = 0;
+
+  /* For non-blocking IO check. */
+  if (peer->status == Connect)
+    {
+      bgp_connect_check (peer, 1);
+      return 0;
+    }
+
+  /* Write packets. The number of packets written is the value of
+   * bgp->wpkt_quanta or the size of the output buffer, whichever is smaller.*/
+  while (count < peer->bgp->wpkt_quanta && (s = bgp_write_packet (peer)) != NULL)
+    {
+      int writenum;
+      do { // write a full packet, or return on error
+        writenum = stream_get_endp (s) - stream_get_getp (s);
+        num = write (peer->fd, STREAM_PNT (s), writenum);
+
+        if (num < 0)
+          {
+            if (ERRNO_IO_RETRY(errno))
+              continue;
+
+            BGP_EVENT_ADD (peer, TCP_fatal_error);
+            goto done;
+          }
+        else if (num != writenum) // incomplete write
+          stream_forward_getp (s, num);
+
+      } while (num != writenum);
+
+      /* Retrieve BGP packet type. */
+      stream_set_getp (s, BGP_MARKER_SIZE + 2);
+      type = stream_getc (s);
+
+      switch (type)
+        {
+        case BGP_MSG_OPEN:
+          peer->open_out++;
+          break;
+        case BGP_MSG_UPDATE:
+          peer->update_out++;
+          break;
+        case BGP_MSG_NOTIFY:
+          peer->notify_out++;
+          /* Double start timer. */
+          peer->v_start *= 2;
+
+          /* Overflow check. */
+          if (peer->v_start >= (60 * 2))
+            peer->v_start = (60 * 2);
+
+          /* Handle Graceful Restart case where the state changes to
+             Connect instead of Idle */
+          /* Flush any existing events */
+          BGP_EVENT_ADD (peer, BGP_Stop);
+          goto done;
+
+        case BGP_MSG_KEEPALIVE:
+          peer->keepalive_out++;
+          break;
+        case BGP_MSG_ROUTE_REFRESH_NEW:
+        case BGP_MSG_ROUTE_REFRESH_OLD:
+          peer->refresh_out++;
+          break;
+        case BGP_MSG_CAPABILITY:
+          peer->dynamic_cap_out++;
+          break;
+        }
+
+      count++;
+      /* OK we send packet so delete it. */
+      bgp_packet_delete_unsafe (peer);
+      update_last_write = 1;
+    }
+
+  done:
+    {
+      /* Update last_update if UPDATEs were written. */
+      if (peer->update_out > oc)
+        peer->last_update = bgp_clock ();
+
+      /* If we TXed any flavor of packet update last_write */
+      if (update_last_write)
+        peer->last_write = bgp_clock ();
+    }
+
+  return count;
+}
+
+static void
+cleanup_handler (void *arg)
+{
+  if (plist)
+    list_delete (plist);
+
+  plist = NULL;
+
+  pthread_mutex_unlock (&plist_mtx);
+}
+
+/**
+ * Entry function for peer packet flushing pthread.
+ *
+ * The plist must be initialized before calling this.
+ */
+void *
+peer_writes_start (void *arg)
+{
+  struct timeval currtime = { 0, 0 };
+  struct timeval sleeptime = { 0 , 500 };
+  struct timespec next_update = { 0, 0 };
+
+  // initialize
+  pthread_mutex_lock (&plist_mtx);
+  plist = list_new ();
+
+  struct listnode *ln;
+  struct peer *peer;
+
+  pthread_cleanup_push (&cleanup_handler, NULL);
+
+  bgp_packet_writes_thread_run = true;
+
+  while (bgp_packet_writes_thread_run)
+    { // wait around until next update time
+      if (plist->count > 0)
+        pthread_cond_timedwait (&write_cond, &plist_mtx, &next_update);
+      else // wait around until we have some peers
+        while (plist->count == 0 && bgp_packet_writes_thread_run)
+          pthread_cond_wait (&write_cond, &plist_mtx);
+
+      for (ALL_LIST_ELEMENTS_RO(plist,ln,peer))
+        {
+          pthread_mutex_lock (&peer->obuf_mtx);
+          {
+            bgp_write (peer);
+          }
+          pthread_mutex_unlock (&peer->obuf_mtx);
+        }
+
+      gettimeofday (&currtime, NULL);
+      timeradd (&currtime, &sleeptime, &currtime);
+      TIMEVAL_TO_TIMESPEC (&currtime, &next_update);
+    }
+
+  // clean up
+  pthread_cleanup_pop (1);
+
+  return NULL;
+}
+
+/**
+ * Turns on packet writing for a peer.
+ */
+void
+peer_writes_on (struct peer *peer)
+{
+  if (peer->status == Deleted)
+    return;
+
+  pthread_mutex_lock (&plist_mtx);
+  {
+    struct listnode *ln, *nn;
+    struct peer *p;
+
+    // make sure this peer isn't already in the list
+    for (ALL_LIST_ELEMENTS(plist,ln,nn,p))
+      if (p == peer)
+        {
+          pthread_mutex_unlock (&plist_mtx);
+          return;
+        }
+
+    peer_lock (peer);
+    listnode_add (plist, peer);
+  }
+  pthread_mutex_unlock (&plist_mtx);
+  peer_writes_wake();
+}
+
+/**
+ * Turns off packet writing for a peer.
+ */
+void
+peer_writes_off (struct peer *peer)
+{
+  struct listnode *ln, *nn;
+  struct peer *p;
+  pthread_mutex_lock (&plist_mtx);
+  {
+    for (ALL_LIST_ELEMENTS(plist,ln,nn,p))
+      if (p == peer)
+        {
+          list_delete_node (plist, ln);
+          peer_unlock (peer);
+          break;
+        }
+  }
+  pthread_mutex_unlock (&plist_mtx);
+}
+
+/**
+ * Wakes up the write thread to do work.
+ */
+void
+peer_writes_wake ()
+{
+  pthread_cond_signal (&write_cond);
 }

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -65,6 +65,7 @@ extern int bgp_packet_set_size (struct stream *s);
 /* Control variable for write thread. */
 extern bool bgp_packet_writes_thread_run;
 
+extern void peer_writes_init (void);
 extern void *peer_writes_start (void *arg);
 extern void peer_writes_on (struct peer *peer);
 extern void peer_writes_off (struct peer *peer);

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -39,8 +39,6 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 
 /* Packet send and receive function prototypes. */
 extern int bgp_read (struct thread *);
-extern int bgp_write (struct thread *);
-extern int bgp_connect_check (struct peer *, int change_state);
 
 extern void bgp_keepalive_send (struct peer *);
 extern void bgp_open_send (struct peer *);
@@ -63,6 +61,13 @@ extern void bgp_check_update_delay (struct bgp *);
 
 extern int bgp_packet_set_marker (struct stream *s, u_char type);
 extern int bgp_packet_set_size (struct stream *s);
-extern void bgp_packet_add (struct peer *peer, struct stream *s);
+
+/* Control variable for write thread. */
+extern bool bgp_packet_writes_thread_run;
+
+extern void *peer_writes_start (void *arg);
+extern void peer_writes_on (struct peer *peer);
+extern void peer_writes_off (struct peer *peer);
+extern void peer_writes_wake (void);
 
 #endif /* _QUAGGA_BGP_PACKET_H */

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1914,26 +1914,6 @@ peer_af_announce_route (struct peer_af *paf, int combine)
 		       subgrp->peer_count - 1);
 }
 
-void
-subgroup_trigger_write (struct update_subgroup *subgrp)
-{
-  struct peer_af *paf;
-
-#if 0
-  if (bgp_debug_update(NULL, NULL, subgrp->update_group, 0))
-    zlog_debug("u%llu:s%llu scheduling write thread for peers",
-               subgrp->update_group->id, subgrp->id);
-#endif
-  SUBGRP_FOREACH_PEER (subgrp, paf)
-    {
-      if (paf->peer->status == Established)
-        {
-	  BGP_PEER_WRITE_ON (paf->peer->t_write, bgp_write, paf->peer->fd,
-                            paf->peer);
-        }
-    }
-}
-
 int
 update_group_clear_update_dbg (struct update_group *updgrp, void *arg)
 {

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -475,8 +475,6 @@ bgp_adj_out_unset_subgroup (struct bgp_node *rn,
 void
 subgroup_announce_table (struct update_subgroup *subgrp,
 			 struct bgp_table *table);
-extern void
-subgroup_trigger_write (struct update_subgroup *subgrp);
 
 extern int
 update_group_clear_update_dbg (struct update_group *updgrp, void *arg);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -500,7 +500,6 @@ bgp_adj_out_unset_subgroup (struct bgp_node *rn,
 {
   struct bgp_adj_out *adj;
   struct bgp_advertise *adv;
-  char trigger_write;
 
   if (DISABLE_BGP_ANNOUNCE)
     return;
@@ -520,18 +519,8 @@ bgp_adj_out_unset_subgroup (struct bgp_node *rn,
           adv->rn = rn;
           adv->adj = adj;
 
-          /* Note if we need to trigger a packet write */
-          if (BGP_ADV_FIFO_EMPTY (&subgrp->sync->withdraw))
-            trigger_write = 1;
-          else
-            trigger_write = 0;
-
           /* Add to synchronization entry for withdraw announcement.  */
           BGP_ADV_FIFO_ADD (&subgrp->sync->withdraw, &adv->fifo);
-
-          /* Schedule packet write, if FIFO is getting its first entry. */
-          if (trigger_write)
-            subgroup_trigger_write(subgrp);
         }
       else
         {

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -572,7 +572,6 @@ bpacket_reformat_for_peer (struct bpacket *pkt, struct peer_af *paf)
 	}
     }
 
-  bgp_packet_add (peer, s);
   return s;
 }
 
@@ -1054,7 +1053,6 @@ subgroup_default_update_packet (struct update_subgroup *subgrp,
   bgp_packet_set_size (s);
 
   (void) bpacket_queue_add (SUBGRP_PKTQ (subgrp), s, &vecarr);
-  subgroup_trigger_write(subgrp);
 }
 
 void
@@ -1142,7 +1140,6 @@ subgroup_default_withdraw_packet (struct update_subgroup *subgrp)
   bgp_packet_set_size (s);
 
   (void) bpacket_queue_add (SUBGRP_PKTQ (subgrp), s, NULL);
-  subgroup_trigger_write(subgrp);
 }
 
 static void

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8538,7 +8538,8 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         json_object_string_add(json_neigh, "readThread", "on");
       else
         json_object_string_add(json_neigh, "readThread", "off");
-      if (p->t_write)
+
+      if (CHECK_FLAG (p->thread_flags, PEER_THREAD_WRITES_ON))
         json_object_string_add(json_neigh, "writeThread", "on");
       else
         json_object_string_add(json_neigh, "writeThread", "off");
@@ -8563,7 +8564,8 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
 
       vty_out (vty, "Read thread: %s  Write thread: %s%s",
                p->t_read ? "on" : "off",
-               p->t_write ? "on" : "off",
+               CHECK_FLAG (p->thread_flags, PEER_THREAD_WRITES_ON) ?
+               "on" : "off",
                VTY_NEWLINE);
     }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7675,10 +7675,18 @@ bgp_if_finish (struct bgp *bgp)
 
 extern void bgp_snmp_init (void);
 
-void
+static void
 bgp_pthreads_init ()
 {
-  /* init write & keepalive threads */
+  /* pre-run initialization */
+  peer_keepalives_init ();
+  peer_writes_init ();
+}
+
+void
+bgp_pthreads_run ()
+{
+  /* run threads */
   pthread_create (bm->t_bgp_keepalives, NULL, &peer_keepalives_start, NULL);
   pthread_create (bm->t_bgp_packet_writes, NULL, &peer_writes_start, NULL);
 }
@@ -7707,6 +7715,9 @@ bgp_init (void)
 {
 
   /* allocates some vital data structures used by peer commands in vty_init */
+
+  /* pre-init pthreads */
+  bgp_pthreads_init ();
 
   /* Init zebra. */
   bgp_zebra_init(bm->master);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1062,7 +1062,7 @@ peer_free (struct peer *peer)
    */
   bgp_timer_set (peer);
   BGP_READ_OFF (peer->t_read);
-  BGP_WRITE_OFF (peer->t_write);
+  peer_writes_off (peer);
   BGP_EVENT_FLUSH (peer);
   
   /* Free connected nexthop, if present */
@@ -1221,6 +1221,7 @@ peer_new (struct bgp *bgp)
   /* Create buffers.  */
   peer->ibuf = stream_new (BGP_MAX_PACKET_SIZE);
   peer->obuf = stream_fifo_new ();
+  pthread_mutex_init (&peer->obuf_mtx, NULL);
 
   /* We use a larger buffer for peer->work in the event that:
    * - We RX a BGP_UPDATE where the attributes alone are just

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -97,6 +97,10 @@ struct bgp_master
   /* BGP thread master.  */
   struct thread_master *master;
 
+  /* BGP pthreads. */
+  pthread_t *t_bgp_keepalives;
+  pthread_t *t_bgp_packet_writes;
+
   /* work queues */
   struct work_queue *process_main_queue;
   
@@ -1226,6 +1230,8 @@ extern void bgp_config_write_family_header (struct vty *, afi_t, safi_t, int *);
 extern void bgp_master_init (struct thread_master *master);
 
 extern void bgp_init (void);
+extern void bgp_pthreads_init (void);
+extern void bgp_pthreads_finish (void);
 extern void bgp_route_map_init (void);
 extern void bgp_session_reset (struct peer *);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1233,7 +1233,7 @@ extern void bgp_config_write_family_header (struct vty *, afi_t, safi_t, int *);
 extern void bgp_master_init (struct thread_master *master);
 
 extern void bgp_init (void);
-extern void bgp_pthreads_init (void);
+extern void bgp_pthreads_run (void);
 extern void bgp_pthreads_finish (void);
 extern void bgp_route_map_init (void);
 extern void bgp_session_reset (struct peer *);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -771,15 +771,18 @@ struct peer
 
   /* Threads. */
   struct thread *t_read;
-  struct thread *t_write;
   struct thread *t_start;
   struct thread *t_connect;
   struct thread *t_holdtime;
-  struct thread *t_keepalive;
   struct thread *t_routeadv;
   struct thread *t_pmax_restart;
   struct thread *t_gr_restart;
   struct thread *t_gr_stale;
+
+  /* Thread flags. */
+  u_int16_t thread_flags;
+#define PEER_THREAD_WRITES_ON         (1 << 0)
+#define PEER_THREAD_KEEPALIVES_ON     (1 << 1)
   
   /* workqueues */
   struct work_queue *clear_node_queue;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -22,6 +22,8 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #define _QUAGGA_BGPD_H
 
 #include "qobj.h"
+#include <pthread.h>
+
 #include "lib/json.h"
 #include "vrf.h"
 #include "vty.h"
@@ -561,6 +563,7 @@ struct peer
 
   /* Packet receive and send buffer. */
   struct stream *ibuf;
+  pthread_mutex_t obuf_mtx;
   struct stream_fifo *obuf;
   struct stream *work;
 

--- a/configure.ac
+++ b/configure.ac
@@ -362,6 +362,11 @@ if test "${enable_poll}" = "yes" ; then
 fi
 
 dnl ----------
+dnl pthreads
+dnl ----------
+AC_SEARCH_LIBS([pthread_create], [pthread])
+
+dnl ----------
 dnl MPLS check
 dnl ----------
 AC_MSG_CHECKING(whether this OS has MPLS stack)

--- a/lib/pqueue.c
+++ b/lib/pqueue.c
@@ -188,3 +188,11 @@ pqueue_remove_at (int index, struct pqueue *queue)
       trickle_down (index, queue);
     }
 }
+
+void
+pqueue_remove (void *data, struct pqueue *queue)
+{
+  for (int i = 0; i < queue->size; i++)
+    if (queue->array[i] == data)
+      pqueue_remove_at (i, queue);
+}

--- a/lib/pqueue.h
+++ b/lib/pqueue.h
@@ -39,6 +39,7 @@ extern void pqueue_delete (struct pqueue *queue);
 extern void pqueue_enqueue (void *data, struct pqueue *queue);
 extern void *pqueue_dequeue (struct pqueue *queue);
 extern void pqueue_remove_at (int index, struct pqueue *queue);
+extern void pqueue_remove (void *data, struct pqueue *queue);
 
 extern void trickle_down (int index, struct pqueue *queue);
 extern void trickle_up (int index, struct pqueue *queue);

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -35,6 +35,7 @@
 DEFINE_MTYPE_STATIC(LIB, THREAD,        "Thread")
 DEFINE_MTYPE_STATIC(LIB, THREAD_MASTER, "Thread master")
 DEFINE_MTYPE_STATIC(LIB, THREAD_STATS,  "Thread stats")
+DEFINE_MTYPE       (LIB, PTHREAD,       "POSIX Thread")
 
 #if defined(__APPLE__)
 #include <mach/mach.h>

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -26,6 +26,9 @@
 #include "monotime.h"
 #include <pthread.h>
 
+#include "memory.h"
+DECLARE_MTYPE(PTHREAD)
+
 struct rusage_t
 {
   struct rusage cpu;

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -24,6 +24,7 @@
 
 #include <zebra.h>
 #include "monotime.h"
+#include <pthread.h>
 
 struct rusage_t
 {
@@ -84,6 +85,7 @@ struct thread_master
   int fd_limit;
   struct fd_handler handler;
   unsigned long alloc;
+  pthread_mutex_t mtx;
 };
 
 typedef unsigned char thread_type;
@@ -110,6 +112,7 @@ struct thread
   const char *funcname;
   const char *schedfrom;
   int schedfrom_line;
+  pthread_mutex_t mtx;
 };
 
 struct cpu_thread_history 

--- a/tests/bgpd/test_aspath.c
+++ b/tests/bgpd/test_aspath.c
@@ -30,6 +30,7 @@
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_aspath.h"
 #include "bgpd/bgp_attr.h"
+#include "bgpd/bgp_packet.h"
 
 #define VT100_RESET "\x1b[0m"
 #define VT100_RED "\x1b[31m"
@@ -1336,6 +1337,7 @@ main (void)
   master = bm->master;
   bgp_option_set (BGP_OPT_NO_LISTEN);
   bgp_attr_init ();
+  peer_writes_init ();
   
   while (test_segments[i].name)
     {

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -653,6 +653,7 @@ main (void)
   bgp_master_init (master);
   vrf_init ();
   bgp_option_set (BGP_OPT_NO_LISTEN);
+  peer_writes_init ();
   
   if (fileno (stdout) >= 0) 
     tty = isatty (fileno (stdout));


### PR DESCRIPTION
This change set moves BGP's packet writing and keepalive generation functionality into dedicated kernel threads.

The motivation for this change set is that with a single kernel thread for all tasks, any task except the write task will block packet writes while it runs. A task whose runtime exceeds the BGP hold timer will then cause a session flap. An example which is easy to reproduce is dumping BGP's internal state to JSON with e.g. `show ip bgp json`; with a large number of RIB entries this task's running time can easily exceed the value of typical hold timers. These changes resolve this problem by decoupling packet writes from the main thread's event loop and continuing to generate and write keepalives as dedicated tasks, which is sufficient to keep the session alive during long-running computations.

Overview of changes:
* Create a dedicated pthread whose sole task is to run through all active peers and flush their output queues to the network
* Create a dedicated pthread whose sole task is to generate keepalives for peers and place them onto their output queues
* Make `thread.c` safe to use with kernel threads without needing explicit synchronization
* Update tests and makefiles as appropriate

The `thread.c` changes are necessary to avoid race conditions and lays the framework for possible similar changes in other daemons in the future.