### PR TITLE
lib: fix usage of getgrouplist() in *BSD

### DIFF
--- a/lib/privs.c
+++ b/lib/privs.c
@@ -731,7 +731,7 @@ zprivs_init(struct zebra_privs_t *zprivs)
   if (zprivs->user)
     {
       ngroups = sizeof(groups);
-      if ( (ngroups = getgrouplist (zprivs->user, zprivs_state.zgid, groups, &ngroups )) < 0 )
+      if (getgrouplist (zprivs->user, zprivs_state.zgid, groups, &ngroups) < 0)
         {
           /* cant use log.h here as it depends on vty */
           fprintf (stderr, "privs_init: could not getgrouplist for user %s\n",


### PR DESCRIPTION
On BSD systems, the getgrouplist() function returns 0 if successful and
-1 on error.

Linux in the other hand returns ngroups (the number of groups of which
user is a member) on success and -1 on error.

Given this difference, the most portable way to use getgrouplist()
is use its return value only for checking if it succeeded or not.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>