### PR TITLE
Restore functionality broken/overridden by 857b5446497505f582417e4a5ada029712743cbc

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -363,6 +363,7 @@ main (int argc, char **argv)
 
   int bgp_port = BGP_PORT_DEFAULT;
   char *bgp_address = NULL;
+  int no_fib_flag = 0;
 
   frr_preinit(&bgpd_di, argc, argv);
   frr_opt_add("p:l:rne:", longopts,
@@ -389,7 +390,7 @@ main (int argc, char **argv)
 	  if (tmp_port <= 0 || tmp_port > 0xffff)
 	    bgp_port = BGP_PORT_DEFAULT;
 	  else
-	    bm->port = tmp_port;
+	    bgp_port = tmp_port;
 	  break;
         case 'e':
           multipath_num = atoi (optarg);
@@ -406,7 +407,7 @@ main (int argc, char **argv)
 	  bgp_address = optarg;
 	  /* listenon implies -n */
 	case 'n':
-	  bgp_option_set (BGP_OPT_NO_FIB);
+          no_fib_flag = 1;
 	  break;
 	default:
 	  frr_help_exit (1);
@@ -418,6 +419,8 @@ main (int argc, char **argv)
   bgp_master_init (frr_init ());
   bm->port = bgp_port;
   bm->address = bgp_address;
+  if (no_fib_flag)
+    bgp_option_set (BGP_OPT_NO_FIB);
 
   /* Initializations. */
   bgp_vrf_init ();

--- a/lib/privs.c
+++ b/lib/privs.c
@@ -769,6 +769,7 @@ zprivs_init(struct zebra_privs_t *zprivs)
         }
     }
 
+  zprivs_state.zsuid = geteuid(); /* initial uid */
   /* add groups only if we changed uid - otherwise skip */
   if ((ngroups) && (zprivs_state.zsuid != zprivs_state.zuid))
     {


### PR DESCRIPTION
    bgp: fix a couple of instances of bm being used before init'ed
    lib/frr: fix reference to zsuid before it is set
    bgpd: restore  -S, --skip_runas options
