### PR TITLE
lib: fix proto_redistnum() oversight from #257

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -1059,7 +1059,7 @@ proto_redistnum(int afi, const char *s)
 	return ZEBRA_ROUTE_VNC;
       else if (strmatch (s, "vnc-direct"))
 	return ZEBRA_ROUTE_VNC_DIRECT;
-      else if (strncmp (s, "n", 1) == 0)
+      else if (strmatch (s, "nhrp"))
 	return ZEBRA_ROUTE_NHRP;
     }
   if (afi == AFI_IP6)
@@ -1084,7 +1084,7 @@ proto_redistnum(int afi, const char *s)
 	return ZEBRA_ROUTE_VNC;
       else if (strmatch (s, "vnc-direct"))
 	return ZEBRA_ROUTE_VNC_DIRECT;
-      else if (strncmp (s, "n", 1) == 0)
+      else if (strmatch (s, "nhrp"))
 	return ZEBRA_ROUTE_NHRP;
     }
   return -1;


### PR DESCRIPTION
proto_redistnum() now accepts full protocol strings and not partial
names per #10

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>