### PR TITLE
ospfd, ospf6d: fix distance commands

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -470,21 +470,9 @@ DEFUN (no_ospf6_distance,
 
 DEFUN (ospf6_distance_ospf6,
        ospf6_distance_ospf6_cmd,
-       "distance ospf6 <intra-area (1-255)|inter-area (1-255)|external (1-255)> <intra-area (1-255)|inter-area (1-255)|external (1-255)> <intra-area (1-255)|inter-area (1-255)|external (1-255)>",
+       "distance ospf6 {intra-area (1-255)|inter-area (1-255)|external (1-255)}",
        "Administrative distance\n"
-       "OSPF6 distance\n"
-       "Intra-area routes\n"
-       "Distance for intra-area routes\n"
-       "Inter-area routes\n"
-       "Distance for inter-area routes\n"
-       "External routes\n"
-       "Distance for external routes\n"
-       "Intra-area routes\n"
-       "Distance for intra-area routes\n"
-       "Inter-area routes\n"
-       "Distance for inter-area routes\n"
-       "External routes\n"
-       "Distance for external routes\n"
+       "OSPF6 administrative distance\n"
        "Intra-area routes\n"
        "Distance for intra-area routes\n"
        "Inter-area routes\n"
@@ -493,53 +481,23 @@ DEFUN (ospf6_distance_ospf6,
        "Distance for external routes\n")
 {
   VTY_DECLVAR_CONTEXT(ospf6, o);
-
-  char *intra, *inter, *external;
-  intra = inter = external = NULL;
-
   int idx = 0;
-  if (argv_find (argv, argc, "intra-area", &idx))
-    intra = argv[++idx]->arg;
-  if (argv_find (argv, argc, "intra-area", &idx))
-  {
-    vty_out (vty, "%% Cannot specify intra-area distance twice%s", VTY_NEWLINE);
-    return CMD_WARNING;
-  }
 
+  if (argv_find (argv, argc, "intra-area", &idx))
+    o->distance_intra = atoi(argv[idx + 1]->arg);
   idx = 0;
   if (argv_find (argv, argc, "inter-area", &idx))
-    inter = argv[++idx]->arg;
-  if (argv_find (argv, argc, "inter-area", &idx))
-  {
-    vty_out (vty, "%% Cannot specify inter-area distance twice%s", VTY_NEWLINE);
-    return CMD_WARNING;
-  }
-
+    o->distance_inter = atoi(argv[idx + 1]->arg);
   idx = 0;
   if (argv_find (argv, argc, "external", &idx))
-    external = argv[++idx]->arg;
-  if (argv_find (argv, argc, "external", &idx))
-  {
-    vty_out (vty, "%% Cannot specify external distance twice%s", VTY_NEWLINE);
-    return CMD_WARNING;
-  }
-
-
-  if (intra)
-    o->distance_intra = atoi (intra);
-
-  if (inter)
-    o->distance_inter = atoi (inter);
-
-  if (external)
-    o->distance_external = atoi (external);
+    o->distance_external = atoi(argv[idx + 1]->arg);
 
   return CMD_SUCCESS;
 }
 
 DEFUN (no_ospf6_distance_ospf6,
        no_ospf6_distance_ospf6_cmd,
-       "no distance ospf6 [<intra-area (1-255)|inter-area (1-255)|external (1-255)> <intra-area (1-255)|inter-area (1-255)|external (1-255)> <intra-area (1-255)|inter-area (1-255)|external (1-255)>]",
+       "no distance ospf6 [{intra-area [(1-255)]|inter-area [(1-255)]|external [(1-255)]}]",
        NO_STR
        "Administrative distance\n"
        "OSPF6 distance\n"
@@ -548,70 +506,16 @@ DEFUN (no_ospf6_distance_ospf6,
        "Inter-area routes\n"
        "Distance for inter-area routes\n"
        "External routes\n"
-       "Distance for external routes\n"
-       "Intra-area routes\n"
-       "Distance for intra-area routes\n"
-       "Inter-area routes\n"
-       "Distance for inter-area routes\n"
-       "External routes\n"
-       "Distance for external routes\n"
-       "Intra-area routes\n"
-       "Distance for intra-area routes\n"
-       "Inter-area routes\n"
-       "Distance for inter-area routes\n"
-       "External routes\n"
        "Distance for external routes\n")
 {
   VTY_DECLVAR_CONTEXT(ospf6, o);
-
-  char *intra, *inter, *external;
-  intra = inter = external = NULL;
-
-  if (argc == 3)
-  {
-    /* If no arguments are given, clear all distance information */
-    o->distance_intra = 0;
-    o->distance_inter = 0;
-    o->distance_external = 0;
-    return CMD_SUCCESS;
-  }
-
   int idx = 0;
-  if (argv_find (argv, argc, "intra-area", &idx))
-    intra = argv[++idx]->arg;
-  if (argv_find (argv, argc, "intra-area", &idx))
-  {
-    vty_out (vty, "%% Cannot specify intra-area distance twice%s", VTY_NEWLINE);
-    return CMD_WARNING;
-  }
 
-  idx = 0;
-  if (argv_find (argv, argc, "inter-area", &idx))
-    inter = argv[++idx]->arg;
-  if (argv_find (argv, argc, "inter-area", &idx))
-  {
-    vty_out (vty, "%% Cannot specify inter-area distance twice%s", VTY_NEWLINE);
-    return CMD_WARNING;
-  }
-
-  idx = 0;
-  if (argv_find (argv, argc, "external", &idx))
-    external = argv[++idx]->arg;
-  if (argv_find (argv, argc, "external", &idx))
-  {
-    vty_out (vty, "%% Cannot specify external distance twice%s", VTY_NEWLINE);
-    return CMD_WARNING;
-  }
-  if (argc < 3) /* should not happen */
-    return CMD_WARNING;
-
-  if (intra)
-    o->distance_intra = 0;
-
-  if (inter)
-    o->distance_inter = 0;
-
-  if (external)
+  if (argv_find (argv, argc, "intra-area", &idx) || argc == 3)
+    idx = o->distance_intra = 0;
+  if (argv_find (argv, argc, "inter-area", &idx) || argc == 3)
+    idx = o->distance_inter = 0;
+  if (argv_find (argv, argc, "external", &idx) || argc == 3)
     o->distance_external = 0;
 
   return CMD_SUCCESS;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7458,7 +7458,7 @@ DEFUN (no_ospf_default_metric,
 DEFUN (ospf_distance,
        ospf_distance_cmd,
        "distance (1-255)",
-       "Define an administrative distance\n"
+       "Administrative distance\n"
        "OSPF Administrative distance\n")
 {
   VTY_DECLVAR_CONTEXT(ospf, ospf);
@@ -7473,7 +7473,7 @@ DEFUN (no_ospf_distance,
        no_ospf_distance_cmd,
        "no distance (1-255)",
        NO_STR
-       "Define an administrative distance\n"
+       "Administrative distance\n"
        "OSPF Administrative distance\n")
 {
   VTY_DECLVAR_CONTEXT(ospf, ospf);
@@ -7485,10 +7485,10 @@ DEFUN (no_ospf_distance,
 
 DEFUN (no_ospf_distance_ospf,
        no_ospf_distance_ospf_cmd,
-       "no distance ospf [<intra-area (1-255)|inter-area (1-255)|external (1-255)>]",
+       "no distance ospf [{intra-area [(1-255)]|inter-area [(1-255)]|external [(1-255)]}]",
        NO_STR
-       "Define an administrative distance\n"
-       "OSPF Administrative distance\n"
+       "Administrative distance\n"
+       "OSPF administrative distance\n"
        "Intra-area routes\n"
        "Distance for intra-area routes\n"
        "Inter-area routes\n"
@@ -7497,42 +7497,26 @@ DEFUN (no_ospf_distance_ospf,
        "Distance for external routes\n")
 {
   VTY_DECLVAR_CONTEXT(ospf, ospf);
-  int idx_area_distance = 3;
+  int idx = 0;
 
   if (!ospf)
     return CMD_SUCCESS;
 
-  if (argc < 3)
-    return CMD_WARNING;
-
-  if (!ospf)
-    return CMD_SUCCESS;
-
-  if (argv[idx_area_distance]->arg != NULL)
-    ospf->distance_intra = 0;
-
-  if (argv[1] != NULL)
-    ospf->distance_inter = 0;
-
-  if (argv[2] != NULL)
+  if (argv_find (argv, argc, "intra-area", &idx) || argc == 3)
+    idx = ospf->distance_intra = 0;
+  if (argv_find (argv, argc, "inter-area", &idx) || argc == 3)
+    idx = ospf->distance_inter = 0;
+  if (argv_find (argv, argc, "external", &idx) || argc == 3)
     ospf->distance_external = 0;
-
-  if (argv[idx_area_distance]->arg || argv[1] || argv[2])
-    return CMD_SUCCESS;
-
-  /* If no arguments are given, clear all distance information */
-  ospf->distance_intra = 0;
-  ospf->distance_inter = 0;
-  ospf->distance_external = 0;
 
   return CMD_SUCCESS;
 }
 
 DEFUN (ospf_distance_ospf,
        ospf_distance_ospf_cmd,
-       "distance ospf [<intra-area (1-255)|inter-area (1-255)|external (1-255)>]",
-       "Define an administrative distance\n"
-       "OSPF Administrative distance\n"
+       "distance ospf {intra-area (1-255)|inter-area (1-255)|external (1-255)}",
+       "Administrative distance\n"
+       "OSPF administrative distance\n"
        "Intra-area routes\n"
        "Distance for intra-area routes\n"
        "Inter-area routes\n"
@@ -7541,26 +7525,16 @@ DEFUN (ospf_distance_ospf,
        "Distance for external routes\n")
 {
   VTY_DECLVAR_CONTEXT(ospf, ospf);
-  int idx_area_distance = 2;
+  int idx = 0;
 
-  if (argc < 3) /* should not happen */
-    return CMD_WARNING;
-
-  if (!argv[idx_area_distance]->arg && !argv[1] && !argv[2])
-    {
-      vty_out(vty, "%% Command incomplete. (Arguments required)%s",
-              VTY_NEWLINE);
-      return CMD_WARNING;
-    }
-
-  if (strcmp (argv[idx_area_distance]->text, "intra") == 0)
-    ospf->distance_intra = atoi(argv[idx_area_distance+1]->arg);
-
-  if (strcmp (argv[idx_area_distance]->text, "inter") == 0)
-    ospf->distance_inter = atoi(argv[idx_area_distance+1]->arg);
-
-  if (strcmp (argv[idx_area_distance]->text, "external") == 0)
-    ospf->distance_external = atoi(argv[idx_area_distance+1]->arg);
+  if (argv_find (argv, argc, "intra-area", &idx))
+    ospf->distance_intra = atoi(argv[idx + 1]->arg);
+  idx = 0;
+  if (argv_find (argv, argc, "inter-area", &idx))
+    ospf->distance_inter = atoi(argv[idx + 1]->arg);
+  idx = 0;
+  if (argv_find (argv, argc, "external", &idx))
+    ospf->distance_external = atoi(argv[idx + 1]->arg);
 
   return CMD_SUCCESS;
 }


### PR DESCRIPTION
OSPF distance commands were broken in a variety of ways. Fix 'em.

* `distance ospf` and `distance ospf6` were accepted commands
* Inconsistent doc strings
* Make use of {keyword|tokens}
* Add ability to reset specific distance without specifying a value
  Ex: ~# no distance ospf6 intra

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>