### PR TITLE
zebra: "debug zebra nht" is not in the config

### DIFF
--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -399,6 +399,11 @@ config_write_debug (struct vty *vty)
       vty_out (vty, "debug zebra fpm%s", VTY_NEWLINE);
       write++;
     }
+  if (IS_ZEBRA_DEBUG_NHT)
+    {
+      vty_out (vty, "debug zebra nht%s", VTY_NEWLINE);
+      write++;
+    }
   if (IS_ZEBRA_DEBUG_MPLS)
     {
       vty_out (vty, "debug zebra mpls%s", VTY_NEWLINE);


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>
Reviewed-by:   Donald Sharp <sharpd@cumulusnetworks.com>