### PR TITLE
pimd: Pim ECMP changes along with nexthop tracking using cached DB

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -30,6 +30,7 @@
 #include "hash.h"
 
 #include "pimd.h"
+#include "pim_zebra.h"
 #include "pim_iface.h"
 #include "pim_igmp.h"
 #include "pim_mroute.h"
@@ -42,6 +43,7 @@
 #include "pim_time.h"
 #include "pim_ssmpingd.h"
 #include "pim_rp.h"
+#include "pim_nht.h"
 
 struct interface *pim_regiface = NULL;
 struct list *pim_ifchannel_list = NULL;
@@ -583,21 +585,40 @@ void pim_if_addr_add(struct connected *ifc)
     }
   } /* igmp */
 
-  if (PIM_IF_TEST_PIM(pim_ifp->options)) {
+  if (PIM_IF_TEST_PIM(pim_ifp->options))
+    {
 
-    /* Interface has a valid primary address ? */
-    if (PIM_INADDR_ISNOT_ANY(pim_ifp->primary_address)) {
+      if (PIM_INADDR_ISNOT_ANY (pim_ifp->primary_address))
+        {
 
-      /* Interface has a valid socket ? */
-      if (pim_ifp->pim_sock_fd < 0) {
-	if (pim_sock_add(ifp)) {
-	  zlog_warn("Failure creating PIM socket for interface %s",
-		    ifp->name);
-	}
-      }
+          /* Interface has a valid socket ? */
+          if (pim_ifp->pim_sock_fd < 0)
+            {
+              if (pim_sock_add (ifp))
+                {
+                  zlog_warn ("Failure creating PIM socket for interface %s",
+                             ifp->name);
+                }
+            }
+          struct pim_nexthop_cache *pnc = NULL;
+          struct pim_rpf rpf;
+          struct zclient *zclient = NULL;
 
-    }
-  } /* pim */
+          zclient = pim_zebra_zclient_get ();
+          /* RP config might come prior to (local RP's interface) IF UP event.
+             In this case, pnc would not have pim enabled nexthops.
+             Once Interface is UP and pim info is available, reregister
+             with RNH address to receive update and add the interface as nexthop. */
+          memset (&rpf, 0, sizeof (struct pim_rpf));
+          rpf.rpf_addr.family = AF_INET;
+          rpf.rpf_addr.prefixlen = IPV4_MAX_BITLEN;
+          rpf.rpf_addr.u.prefix4 = ifc->address->u.prefix4;
+          pnc = pim_nexthop_cache_find (&rpf);
+          if (pnc)
+            pim_sendmsg_zebra_rnh (zclient, pnc,
+                                   ZEBRA_NEXTHOP_REGISTER);
+        }
+    } /* pim */
 
     /*
       PIM or IGMP is enabled on interface, and there is at least one

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -178,6 +178,15 @@ pim_mroute_msg_nocache (int fd, struct interface *ifp, const struct igmpmsg *msg
 
   up->channel_oil->cc.pktcnt++;
   PIM_UPSTREAM_FLAG_SET_FHR(up->flags);
+  // resolve mfcc_parent prior to mroute_add in channel_add_oif
+  if (up->channel_oil->oil.mfcc_parent >= MAXVIFS)
+    {
+      int vif_index = 0;
+      vif_index =
+        pim_if_find_vifindex_by_ifindex (up->rpf.source_nexthop.
+                                         interface->ifindex);
+      up->channel_oil->oil.mfcc_parent = vif_index;
+    }
   pim_register_join (up);
 
   return 0;
@@ -858,9 +867,8 @@ int pim_mroute_del (struct channel_oil *c_oil, const char *name)
                  pim_channel_oil_dump (c_oil, buf, sizeof(buf)));
     }
 
-  /*reset incoming vifi and kernel installed flags*/
+  //Reset kernel installed flag
   c_oil->installed = 0;
-  c_oil->oil.mfcc_parent = MAXVIFS;
 
   return 0;
 }

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -502,6 +502,12 @@ struct pim_neighbor *pim_neighbor_add(struct interface *ifp,
 
   listnode_add(pim_ifp->pim_neighbor_list, neigh);
 
+  if (PIM_DEBUG_PIM_TRACE_DETAIL)
+    {
+      char str[INET_ADDRSTRLEN];
+      pim_inet4_dump("<nht_nbr?>", source_addr, str, sizeof (str));
+      zlog_debug ("%s: neighbor %s added ", __PRETTY_FUNCTION__, str);
+    }
   /*
     RFC 4601: 4.3.2.  DR Election
 
@@ -531,6 +537,14 @@ struct pim_neighbor *pim_neighbor_add(struct interface *ifp,
     pim_hello_restart_triggered(neigh->interface);
 
   pim_upstream_find_new_rpf();
+
+  /* RNH can send nexthop update prior to PIM neibhor UP
+     in that case nexthop cache would not consider this neighbor
+     as RPF.
+     Upon PIM neighbor UP, iterate all RPs and update
+     nexthop cache with this neighbor.
+   */
+  pim_resolve_rp_nh ();
 
   pim_rp_setup ();
 

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -51,10 +51,19 @@ struct pim_nexthop_cache
 int pim_parse_nexthop_update (int command, struct zclient *zclient,
                               zebra_size_t length, vrf_id_t vrf_id);
 int pim_find_or_track_nexthop (struct prefix *addr, struct pim_upstream *up,
-                               struct rp_info *rp);
+                               struct rp_info *rp, struct pim_nexthop_cache *out_pnc);
 void pim_delete_tracked_nexthop (struct prefix *addr, struct pim_upstream *up,
                                  struct rp_info *rp);
 struct pim_nexthop_cache *pim_nexthop_cache_add (struct pim_rpf *rpf_addr);
 struct pim_nexthop_cache *pim_nexthop_cache_find (struct pim_rpf *rpf);
-
+uint32_t pim_compute_ecmp_hash (struct prefix *src, struct prefix *grp);
+int pim_ecmp_nexthop_search (struct pim_nexthop_cache * pnc,
+                         struct pim_nexthop *nexthop, struct prefix *src,
+                         struct prefix *grp, int neighbor_needed);
+int pim_ecmp_nexthop_lookup (struct pim_nexthop *nexthop, struct in_addr addr,
+                         struct prefix *src, struct prefix *grp,
+                         int neighbor_needed);
+void pim_sendmsg_zebra_rnh (struct zclient *zclient, struct pim_nexthop_cache *pnc,
+                          int command);
+void pim_resolve_upstream_nh (struct prefix *nht_p);
 #endif

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -289,10 +289,10 @@ pim_channel_del_oif (struct channel_oil *channel_oil,
       char source_str[INET_ADDRSTRLEN];
       pim_inet4_dump("<group?>", channel_oil->oil.mfcc_mcastgrp, group_str, sizeof(group_str));
       pim_inet4_dump("<source?>", channel_oil->oil.mfcc_origin, source_str, sizeof(source_str));
-      zlog_debug("%s %s: (S,G)=(%s,%s): proto_mask=%u OIF=%s vif_index=%d",
+      zlog_debug("%s %s: (S,G)=(%s,%s): proto_mask=%u IIF:%d OIF=%s vif_index=%d",
 		 __FILE__, __PRETTY_FUNCTION__,
 		 source_str, group_str,
-		 proto_mask, oif->name, pim_ifp->mroute_vif_index);
+	         proto_mask, channel_oil->oil.mfcc_parent ,oif->name, pim_ifp->mroute_vif_index);
     }
 
   return 0;

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -187,6 +187,15 @@ pim_register_send (const uint8_t *buf, int buf_size, struct in_addr src, struct 
     return;
   }
 
+  if (PIM_DEBUG_PIM_REG)
+    {
+      char rp_str[INET_ADDRSTRLEN];
+      strcpy (rp_str, inet_ntoa (rpg->rpf_addr.u.prefix4));
+      zlog_debug ("%s: Sending %s %sRegister Packet to %s on %s",
+              __PRETTY_FUNCTION__, up->sg_str,
+              null_register ? "NULL " : "", rp_str, ifp->name);
+    }
+
   memset(buffer, 0, 10000);
   b1 = buffer + PIM_MSG_HEADER_LEN;
   *b1 |= null_register << 6;

--- a/pimd/pim_rp.h
+++ b/pimd/pim_rp.h
@@ -61,6 +61,6 @@ struct pim_rpf *pim_rp_g (struct in_addr group);
 #define RP(G)       pim_rp_g ((G))
 
 void pim_rp_show_information (struct vty *vty, u_char uj);
-
+void pim_resolve_rp_nh (void);
 int pim_rp_list_cmp (void *v1, void *v2);
 #endif

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -227,8 +227,8 @@ pim_upstream_del(struct pim_upstream *up, const char *name)
     {
       char buf[PREFIX2STR_BUFFER];
       prefix2str (&nht_p, buf, sizeof (buf));
-      zlog_debug ("%s: Deregister upstream %s upstream addr %s with NHT ",
-                __PRETTY_FUNCTION__, up->sg_str, buf);
+      zlog_debug ("%s: Deregister upstream %s addr %s with Zebra",
+                  __PRETTY_FUNCTION__, up->sg_str, buf);
     }
   pim_delete_tracked_nexthop (&nht_p, up, NULL);
 
@@ -694,10 +694,12 @@ pim_upstream_new (struct prefix_sg *sg,
     return NULL;
   }
 
-  pim_ifp = up->rpf.source_nexthop.interface->info;
-  if (pim_ifp)
-    up->channel_oil = pim_channel_oil_add(&up->sg, pim_ifp->mroute_vif_index);
-
+  if (up->rpf.source_nexthop.interface)
+    {
+      pim_ifp = up->rpf.source_nexthop.interface->info;
+      if (pim_ifp)
+        up->channel_oil = pim_channel_oil_add(&up->sg, pim_ifp->mroute_vif_index);
+    }
   listnode_add_sort(pim_upstream_list, up);
 
   if (PIM_DEBUG_TRACE)
@@ -768,10 +770,14 @@ struct pim_upstream *pim_upstream_add(struct prefix_sg *sg,
   if (PIM_DEBUG_TRACE)
     {
       if (up)
-	zlog_debug("%s(%s): %s, found: %d: ref_count: %d",
+        {
+          char buf[PREFIX2STR_BUFFER];
+          prefix2str (&up->rpf.rpf_addr, buf, sizeof (buf));
+	  zlog_debug("%s(%s): %s, iif %s found: %d: ref_count: %d",
 		   __PRETTY_FUNCTION__, name,
-		   up->sg_str, found,
+		   up->sg_str, buf, found,
 		   up->ref_count);
+        }
       else
 	zlog_debug("%s(%s): (%s) failure to create",
 		   __PRETTY_FUNCTION__, name,

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -372,6 +372,12 @@ static void scan_upstream_rpf_cache()
   for (ALL_LIST_ELEMENTS(pim_upstream_list, up_node, up_nextnode, up)) {
     enum pim_rpf_result rpf_result;
     struct pim_rpf      old;
+    struct prefix nht_p;
+
+    nht_p.family = AF_INET;
+    nht_p.prefixlen = IPV4_MAX_BITLEN;
+    nht_p.u.prefix4.s_addr = up->upstream_addr.s_addr;
+    pim_resolve_upstream_nh (&nht_p);
 
     old.source_nexthop.interface = up->rpf.source_nexthop.interface;
     old.source_nexthop.nbr       = up->rpf.source_nexthop.nbr;
@@ -574,7 +580,8 @@ static int on_rpf_cache_refresh(struct thread *t)
   qpim_rpf_cache_refresh_last = pim_time_monotonic_sec();
   ++qpim_rpf_cache_refresh_events;
 
-  pim_rp_setup ();
+  //It is called as part of pim_neighbor_add
+  //pim_rp_setup ();
   return 0;
 }
 
@@ -836,6 +843,7 @@ void igmp_source_forward_start(struct igmp_source *source)
   struct igmp_group *group;
   struct prefix_sg sg;
   int result;
+  int input_iface_vif_index = 0;
 
   memset (&sg, 0, sizeof (struct prefix_sg));
   sg.src = source->source_addr;
@@ -861,11 +869,61 @@ void igmp_source_forward_start(struct igmp_source *source)
   if (!source->source_channel_oil) {
     struct in_addr vif_source;
     struct pim_interface *pim_oif;
+    struct prefix nht_p, src, grp;
+    int ret = 0;
+    struct pim_nexthop_cache out_pnc;
+    struct pim_nexthop nexthop;
 
     if (!pim_rp_set_upstream_addr (&vif_source, source->source_addr, sg.grp))
       return;
 
-    int input_iface_vif_index = fib_lookup_if_vif_index(vif_source);
+    /* Register addr with Zebra NHT */
+    nht_p.family = AF_INET;
+    nht_p.prefixlen = IPV4_MAX_BITLEN;
+    nht_p.u.prefix4 = vif_source;
+    memset (&out_pnc, 0, sizeof (struct pim_nexthop_cache));
+
+    if ((ret = pim_find_or_track_nexthop (&nht_p, NULL, NULL, &out_pnc)) == 1)
+      {
+        if (out_pnc.nexthop_num)
+          {
+            src.family = AF_INET;
+            src.prefixlen = IPV4_MAX_BITLEN;
+            src.u.prefix4 = vif_source;   //RP or Src address
+            grp.family = AF_INET;
+            grp.prefixlen = IPV4_MAX_BITLEN;
+            grp.u.prefix4 = sg.grp;
+            memset (&nexthop, 0, sizeof (nexthop));
+            //Compute PIM RPF using Cached nexthop
+            pim_ecmp_nexthop_search (&out_pnc, &nexthop,
+                                  &src, &grp, 0);
+            if (nexthop.interface)
+              input_iface_vif_index = pim_if_find_vifindex_by_ifindex (nexthop.interface->ifindex);
+          }
+        else
+          {
+            if (PIM_DEBUG_ZEBRA)
+              {
+                char buf1[INET_ADDRSTRLEN];
+                char buf2[INET_ADDRSTRLEN];
+                pim_inet4_dump("<source?>", nht_p.u.prefix4, buf1, sizeof(buf1));
+                pim_inet4_dump("<source?>", grp.u.prefix4, buf2, sizeof(buf2));
+                zlog_debug ("%s: NHT Nexthop not found for addr %s grp %s" ,
+                          __PRETTY_FUNCTION__, buf1, buf2);
+              }
+          }
+      }
+    else
+      input_iface_vif_index = fib_lookup_if_vif_index(vif_source);
+
+    if (PIM_DEBUG_ZEBRA)
+      {
+        char buf2[INET_ADDRSTRLEN];
+        pim_inet4_dump("<source?>", vif_source, buf2, sizeof(buf2));
+        zlog_debug ("%s: NHT %s vif_source %s vif_index:%d ", __PRETTY_FUNCTION__,
+            pim_str_sg_dump (&sg), buf2, input_iface_vif_index);
+      }
+
     if (input_iface_vif_index < 1) {
       if (PIM_DEBUG_IGMP_TRACE)
 	{
@@ -1013,49 +1071,105 @@ void pim_forward_start(struct pim_ifchannel *ch)
 {
   struct pim_upstream *up = ch->upstream;
   uint32_t mask = PIM_OIF_FLAG_PROTO_PIM;
+  int input_iface_vif_index =  0;
 
   if (PIM_DEBUG_PIM_TRACE) {
     char source_str[INET_ADDRSTRLEN];
-    char group_str[INET_ADDRSTRLEN]; 
+    char group_str[INET_ADDRSTRLEN];
     char upstream_str[INET_ADDRSTRLEN];
 
     pim_inet4_dump("<source?>", ch->sg.src, source_str, sizeof(source_str));
     pim_inet4_dump("<group?>", ch->sg.grp, group_str, sizeof(group_str));
     pim_inet4_dump("<upstream?>", up->upstream_addr, upstream_str, sizeof(upstream_str));
-    zlog_debug("%s: (S,G)=(%s,%s) oif=%s(%s)",
+    zlog_debug("%s: (S,G)=(%s,%s) oif=%s (%s)",
 	       __PRETTY_FUNCTION__,
 	       source_str, group_str, ch->interface->name, upstream_str);
   }
 
-  if (!up->channel_oil) {
-    int input_iface_vif_index = fib_lookup_if_vif_index(up->upstream_addr);
-    if (input_iface_vif_index < 1) {
-      if (PIM_DEBUG_PIM_TRACE)
-	{
-	  char source_str[INET_ADDRSTRLEN];
-	  pim_inet4_dump("<source?>", up->sg.src, source_str, sizeof(source_str));
-	  zlog_debug("%s %s: could not find input interface for source %s",
-		     __FILE__, __PRETTY_FUNCTION__,
-		     source_str);
-	}
-      return;
-    }
+  /* Resolve IIF for upstream as mroute_del sets mfcc_parent to MAXVIFS,
+     as part of mroute_del called by pim_forward_stop.
+  */
+  if (!up->channel_oil ||
+      (up->channel_oil && up->channel_oil->oil.mfcc_parent >= MAXVIFS))
+    {
+      struct prefix nht_p, src, grp;
+      int ret = 0;
+      struct pim_nexthop_cache out_pnc;
+      struct pim_nexthop nexthop;
 
-    up->channel_oil = pim_channel_oil_add(&up->sg,
-					  input_iface_vif_index);
-    if (!up->channel_oil) {
-      if (PIM_DEBUG_PIM_TRACE)
-	zlog_debug("%s %s: could not create OIL for channel (S,G)=%s",
-		   __FILE__, __PRETTY_FUNCTION__,
-		   up->sg_str);
-      return;
+      /* Register addr with Zebra NHT */
+      nht_p.family = AF_INET;
+      nht_p.prefixlen = IPV4_MAX_BITLEN;
+      nht_p.u.prefix4.s_addr = up->upstream_addr.s_addr;
+      grp.family = AF_INET;
+      grp.prefixlen = IPV4_MAX_BITLEN;
+      grp.u.prefix4 = up->sg.grp;
+      memset (&out_pnc, 0, sizeof (struct pim_nexthop_cache));
+
+      if ((ret =
+                  pim_find_or_track_nexthop (&nht_p, NULL, NULL, &out_pnc)) == 1)
+        {
+          if (out_pnc.nexthop_num)
+            {
+              src.family = AF_INET;
+              src.prefixlen = IPV4_MAX_BITLEN;
+              src.u.prefix4 = up->upstream_addr; //RP or Src address
+              grp.family = AF_INET;
+              grp.prefixlen = IPV4_MAX_BITLEN;
+              grp.u.prefix4 = up->sg.grp;
+              memset (&nexthop, 0, sizeof (nexthop));
+              //Compute PIM RPF using Cached nexthop
+              pim_ecmp_nexthop_search (&out_pnc, &nexthop, &src, &grp, 0);
+              input_iface_vif_index =
+                  pim_if_find_vifindex_by_ifindex (nexthop.interface->ifindex);
+            }
+          else
+            {
+              if (PIM_DEBUG_ZEBRA)
+                {
+                  char buf1[INET_ADDRSTRLEN];
+                  char buf2[INET_ADDRSTRLEN];
+                  pim_inet4_dump("<source?>", nht_p.u.prefix4, buf1, sizeof(buf1));
+                  pim_inet4_dump("<source?>", grp.u.prefix4, buf2, sizeof(buf2));
+                  zlog_debug ("%s: NHT pnc is NULL for addr %s grp %s" ,
+                          __PRETTY_FUNCTION__, buf1, buf2);
+                }
+            }
+        }
+      else
+          input_iface_vif_index = fib_lookup_if_vif_index (up->upstream_addr);
+
+      if (input_iface_vif_index < 1)
+        {
+          if (PIM_DEBUG_PIM_TRACE)
+            {
+              char source_str[INET_ADDRSTRLEN];
+              pim_inet4_dump("<source?>", up->sg.src, source_str, sizeof(source_str));
+              zlog_debug("%s %s: could not find input interface for source %s",
+                      __FILE__, __PRETTY_FUNCTION__,
+                      source_str);
+            }
+          return;
+        }
+      if (PIM_DEBUG_TRACE)
+        {
+          zlog_debug ("%s: NHT entry %s update channel_oil vif_index %d ",
+                      __PRETTY_FUNCTION__, up->sg_str, input_iface_vif_index);
+        }
+      up->channel_oil = pim_channel_oil_add (&up->sg, input_iface_vif_index);
+      if (!up->channel_oil)
+        {
+          if (PIM_DEBUG_PIM_TRACE)
+            zlog_debug ("%s %s: could not create OIL for channel (S,G)=%s",
+                        __FILE__, __PRETTY_FUNCTION__, up->sg_str);
+          return;
+        }
     }
-  }
 
   if (up->flags & PIM_UPSTREAM_FLAG_MASK_SRC_IGMP)
     mask = PIM_OIF_FLAG_PROTO_IGMP;
 
-  pim_channel_add_oif(up->channel_oil, ch->interface, mask);
+  pim_channel_add_oif (up->channel_oil, ch->interface, mask);
 }
 
 void pim_forward_stop(struct pim_ifchannel *ch)

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -75,7 +75,9 @@ unsigned int              qpim_keep_alive_time = PIM_KEEPALIVE_PERIOD;
 signed int                qpim_rp_keep_alive_time = 0;
 int64_t                   qpim_nexthop_lookups = 0;
 int                       qpim_packet_process = PIM_DEFAULT_PACKET_PROCESS;
-struct pim_instance          *pimg = NULL;
+uint8_t                   qpim_ecmp_enable = 0;
+uint8_t                   qpim_ecmp_rebalance_enable = 0;
+struct pim_instance       *pimg = NULL;
 
 int32_t qpim_register_suppress_time = PIM_REGISTER_SUPPRESSION_TIME_DEFAULT;
 int32_t qpim_register_probe_time = PIM_REGISTER_PROBE_TIME_DEFAULT;

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -155,6 +155,9 @@ struct list              *qpim_static_route_list; /* list of routes added static
 extern unsigned int       qpim_keep_alive_time;
 extern signed int         qpim_rp_keep_alive_time;
 extern int                qpim_packet_process;
+extern uint8_t            qpim_ecmp_enable;
+extern uint8_t            qpim_ecmp_rebalance_enable;
+
 #define PIM_DEFAULT_PACKET_PROCESS 3
 
 #define PIM_JP_HOLDTIME (qpim_t_periodic * 7 / 2)


### PR DESCRIPTION
In this patch, PIM nexthop tracking uses locally populated nexthop cached list
to determine ECMP based nexthop (w/ ECMP knob enabled), otherwise picks
the first nexthop as RPF.
Introduced '[no] ip pim ecmp' command to enable/disable PIM ECMP knob.
By default, PIM ECMP is disabled.
Introduced '[no] ip pim ecmp rebalance' command to provide existing mcache
entry to switch new path based on hash chosen path.
Introduced, show command to display pim registered addresses with Zebra and respective nexthops.
Introduce, show command to find nexthop and out interface for (S,G) or (RP,G).
Re-Register an address with nexthop when Interface UP event received,
to ensure the PIM nexthop cache is updated (being PIM enabled).
During PIM neighbor UP, traverse all RPs and Upstreams nexthop and determine, if
any of nexthop's IPv4 address changes/resolves due to neighbor UP event.

Testing Done: Run various LHR, RP and FHR related cases to resolve RPF using
nexthop cache with ECMP knob disabled, performed interface/PIM neighbor flap events.


Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>