### PR TITLE
lib: add #pragma to ignore flex sign cmp error

### DIFF
--- a/lib/command_lex.l
+++ b/lib/command_lex.l
@@ -23,6 +23,9 @@
  */
 
 %{
+/* ignore harmless bug in old versions of flex */
+#pragma GCC diagnostic ignored "-Wsign-compare"
+
 #include "command_parse.h"
 
 #define YY_USER_ACTION yylloc->last_column += yyleng;


### PR DESCRIPTION
Workaround for #84 when using old versions of flex

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>