### PR TITLE
snapcraft: Improve README.usage.md based on feedback received

### DIFF
--- a/snapcraft/README.usage.md
+++ b/snapcraft/README.usage.md
@@ -3,7 +3,7 @@ Using the FRRouting Snap
 
 After installing the Snap, the priviledged plug need to be connected:
 
-    snap connect frr:network-control ubuntu-core:network-control
+    snap connect frr:network-control core:network-control
 
 Enabling/Disabling FRRouting Daemons
 -------------------------------------------
@@ -53,25 +53,74 @@ depend on them). These are mainly intended to debug the Snap
 - `frr.ldpd-debug`:
     Starts ldpd daemon in foreground
 
+MPLS (LDP)
+----------
+The MPLS forwarding requires a Linux Kernel version 4.5 or newer and
+specific MPLS kernel modules loaded. It will be auto-detected by
+FRR. You can check the detected setup with the `show mpls status`
+command from within `frr.vtysh`
+
+The following kernel modules `mpls-router` and `mpls-iptunnel`
+need to be loaded. On Ubuntu 16.04, this can be done by editing 
+'/etc/modules-load.d/modules.conf' and add the following lines:
+
+	# Load MPLS Kernel Modules
+	mpls-router
+	mpls-iptunnel
+
+For other distributions, please check the documentation on loading
+modules. You need to either reboot or use `modprobe` to manually load
+the modules as well before MPLS will be available.
+
+In addition to this, the MPLS Label-Processing needs to be enabled
+with `sysctl` on the required interfaces. Assuming the interfaces
+are named `eth0`, `eth1` and `eth2`, then the additional lines in
+`/etc/sysctl.conf` will enable it on a Ubuntu 16.04 system:
+
+	# Enable MPLS Label processing on all interfaces
+	net.mpls.conf.eth0.input=1
+	net.mpls.conf.eth1.input=1
+	net.mpls.conf.eth2.input=1
+	net.mpls.platform_labels=100000
+
+These settings require either a reboot or a manual configuration with
+`sysctl` as well.
+
 FAQ
 ---
 - frr.vtysh displays `--MORE--` on long output. How to suppress this?
     - Define `VTYSH_PAGER` to `cat` (default is `more`). (Ie add 
       `export VTYSH_PAGER=cat` to the end of your `.profile`)
 
+- ospfd / ospf6d are not running after installation
+	- Installing a new snap starts the daemons, but at this time they
+	  may not have the required priviledged access. Make sure you 
+	  issue the `snap connect` command as given above (can be verified
+	  with `snap interfaces`) and **THEN** restart the daemons (or
+	  reboot the system). 
+	  This is a limitation of any snap package at this time which
+	  requires priviledged interfaces (ie to manipulate routing tables)
+	
 Sourcecode available
 ====================
 
 The source for this SNAP is available as part of the FRRouting
-Source Code Distribution. 
+Source Code Distribution under `GPLv2 or later`
 
-    https://github.com/frrouting/frr.git
+<https://github.com/frrouting/frr.git>
 
-Instructions for rebuilding the snap are in `README.snap_build.md`
+Instructions for rebuilding the snap are in `snapcraft/README.snap_build.md`
+
+*Please checkout the desired branch before following the instructions
+as they may have changed between versions of FRR*
+
+Official Webpage for FRR
+========================
+
+Official webpage for FRR is at <https://www.frrouting.org/>
 
 Feedback welcome
 ================
 
 Please send Feedback about this snap to Martin Winter at 
 `mwinter@opensourcerouting.org`
-


### PR DESCRIPTION
This is just a documentation improvement based on feedback. No code changes, but would
like it in 2.0 to be included if/when we build any maintenance release in the future.

- Fix snap connect (it's now called core, not ubuntu-core)
- Add section on MPLS configuration
- Add FAQ topic on ospfd/ospf6d crashing before privs are assigned to snap
- Add pointer to official webpage

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>