### PR TITLE
bgpd: Fix 'set as-path prepend last-as 10'

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1362,7 +1362,7 @@ route_set_aspath_prepend_compile (const char *arg)
 {
   unsigned int num;
 
-  if (sscanf(arg, "last-as %u", &num) == 1 && num > 0 && num < 10)
+  if (sscanf(arg, "last-as %u", &num) == 1 && num > 0 && num <= 10)
     return (void*)(uintptr_t)num;
 
   return route_aspath_compile(arg);


### PR DESCRIPTION
The route-map compilation function was comparing < 10
instead of <= 10.  While the cli was accepting 1-10.

Fix:
!
route-map FOO permit 44
 set as-path prepend last-as 10
!

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>