### PR TITLE
bgpd: Fix 'set as-path prepend last-as 10'

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8562,8 +8562,6 @@ static int
 bgp_show_regexp (struct vty *vty, const char *regstr, afi_t afi,
 		 safi_t safi, enum bgp_show_type type)
 {
-  return CMD_SUCCESS;
-
   regex_t *regex;
   int rc;
   

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1437,7 +1437,7 @@ route_set_aspath_prepend_compile (const char *arg)
 {
   unsigned int num;
 
-  if (sscanf(arg, "last-as %u", &num) == 1 && num > 0 && num < 10)
+  if (sscanf(arg, "last-as %u", &num) == 1 && num > 0 && num <= 10)
     return (void*)(uintptr_t)num;
 
   return route_aspath_compile(arg);
@@ -3677,12 +3677,12 @@ DEFUN (set_aspath_prepend_asn,
 
 DEFUN (set_aspath_prepend_lastas,
        set_aspath_prepend_lastas_cmd,
-       "set as-path prepend last-as (1-9)",
+       "set as-path prepend last-as (1-10)",
        SET_STR
        "Transform BGP AS_PATH attribute\n"
        "Prepend to the as-path\n"
        "Use the peer's AS-number\n"
-       "Number of times to insert")
+       "Number of times to insert\n")
 {
   return set_aspath_prepend_asn (self, vty, argc, argv);
 }


### PR DESCRIPTION
1) Fix missing newline in help string
2) Make the ability to have 10 be consistent with the stable/2.0 branch.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>