### PR TITLE
vtysh: remove deprecated HAVE_EVPN flag

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1221,9 +1221,7 @@ DEFUNSH (VTYSH_BGPD,
          "Layer2 VPN Address family\n"
          "Ethernet Virtual Private Network Subsequent Address Family\n")
 {
-#if defined(HAVE_EVPN)
   vty->node = BGP_EVPN_NODE;
-#endif /* HAVE_EVPN */
   return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
This flag prevents from entering into evpn address-family node, when
calling command from vtysh.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>