### PR TITLE
Snap fixes 3.0

### DIFF
--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -52,6 +52,7 @@ struct frr_daemon_info {
 	const char *config_file;
 	const char *pid_file;
 	const char *vty_path;
+	const char *module_path;
 
 	const char *proghelp;
 	void (*printhelp)(FILE *target);
@@ -107,5 +108,6 @@ extern void frr_run(struct thread_master *master);
 extern char config_default[256];
 extern const char frr_sysconfdir[];
 extern const char frr_vtydir[];
+extern const char frr_moduledir[];
 
 #endif /* _ZEBRA_FRR_H */

--- a/lib/module.c
+++ b/lib/module.c
@@ -69,7 +69,7 @@ void frrmod_init(struct frrmod_runtime *modinfo)
 }
 
 struct frrmod_runtime *frrmod_load(const char *spec,
-		char *err, size_t err_len)
+		const char *dir, char *err, size_t err_len)
 {
 	void *handle = NULL;
 	char name[PATH_MAX], fullpath[PATH_MAX], *args;
@@ -84,12 +84,12 @@ struct frrmod_runtime *frrmod_load(const char *spec,
 	if (!strchr(name, '/')) {
 		if (!handle && execname) {
 			snprintf(fullpath, sizeof(fullpath), "%s/%s_%s.so",
-					MODULE_PATH, execname, name);
+					dir, execname, name);
 			handle = dlopen(fullpath, RTLD_NOW | RTLD_GLOBAL);
 		}
 		if (!handle) {
 			snprintf(fullpath, sizeof(fullpath), "%s/%s.so",
-					MODULE_PATH, name);
+					dir, name);
 			handle = dlopen(fullpath, RTLD_NOW | RTLD_GLOBAL);
 		}
 	}

--- a/lib/module.h
+++ b/lib/module.h
@@ -95,7 +95,7 @@ extern struct frrmod_runtime *frrmod_list;
 
 extern void frrmod_init(struct frrmod_runtime *modinfo);
 extern struct frrmod_runtime *frrmod_load(const char *spec,
-		char *err, size_t err_len);
+		const char *dir, char *err, size_t err_len);
 #if 0
 /* not implemented yet */
 extern void frrmod_unload(struct frrmod_runtime *module);

--- a/snapcraft/README.snap_build.md
+++ b/snapcraft/README.snap_build.md
@@ -47,8 +47,10 @@ Installing the snap
 
     Connect the priviledged `network-control` plug to the snap:
 
-        snap connect frr:network-control ubuntu-core:network-control
+        snap connect frr:network-control core:network-control
 
+See README.usage.md for more details on setting up and using the snap
+        
 DONE.
 
 The Snap will be auto-started and running. 

--- a/snapcraft/README.usage.md
+++ b/snapcraft/README.usage.md
@@ -30,6 +30,8 @@ Commands defined by this snap
 	options
 - `frr.readme`:
 	Returns this document `cat README_usage.md`
+- `frr.set`:
+	Allows to enable `FPM` module. See FPM section below
 
 and for debugging defined at this time (May get removed later - do not 
 depend on them). These are mainly intended to debug the Snap
@@ -85,6 +87,20 @@ are named `eth0`, `eth1` and `eth2`, then the additional lines in
 
 These settings require either a reboot or a manual configuration with
 `sysctl` as well.
+
+FPM Module
+----------
+The `frr.set` allows to turn FPM module on or off.
+
+    frr.set fpm {disable|protobuf|netlink}
+    
+    Disables FPM or enables FPM with selected mode
+
+By default, the FPM module is disabled, but installed with netlink and
+protobuf support. To enable the FPM module, use the `frr.set fpm protobuf`
+or `frr.set fpm netlink` command. The command will only enable the mode
+for the next restart of zebra. Please reboot or restart zebra after
+changing the mode to become effective.
 
 FAQ
 ---

--- a/snapcraft/scripts/Makefile
+++ b/snapcraft/scripts/Makefile
@@ -12,3 +12,4 @@ install:
 	install -D -m 0755 pimd-service $(DESTDIR)/bin/
 	install -D -m 0755 ldpd-service $(DESTDIR)/bin/
 	install -D -m 0755 nhrpd-service $(DESTDIR)/bin/
+	install -D -m 0755 set-options $(DESTDIR)/bin/

--- a/snapcraft/scripts/Makefile
+++ b/snapcraft/scripts/Makefile
@@ -11,4 +11,4 @@ install:
 	install -D -m 0755 isisd-service $(DESTDIR)/bin/
 	install -D -m 0755 pimd-service $(DESTDIR)/bin/
 	install -D -m 0755 ldpd-service $(DESTDIR)/bin/
-
+	install -D -m 0755 nhrpd-service $(DESTDIR)/bin/

--- a/snapcraft/scripts/nhrpd-service
+++ b/snapcraft/scripts/nhrpd-service
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e -x
+
+if ! [ -e $SNAP_DATA/nhrpd.conf ]; then
+    cp $SNAP/etc/frr/nhrpd.conf.default $SNAP_DATA/nhrpd.conf
+fi
+exec $SNAP/sbin/nhrpd \
+    -f $SNAP_DATA/nhrpd.conf \
+    --pid_file $SNAP_DATA/nhrpd.pid \
+    --socket $SNAP_DATA/zsock \
+    --vty_socket $SNAP_DATA

--- a/snapcraft/scripts/set-options
+++ b/snapcraft/scripts/set-options
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -e
+
+case $1 in
+    fpm) 
+        case $2 in
+            disable)
+                rm -f $SNAP_DATA/fpm.conf
+                echo "FPM module disabled. Please restart FRR"
+                ;;
+            protobuf)
+                echo "-M fpm:protobuf" > $SNAP_DATA/fpm.conf
+                echo "FPM enabled and set to protobuf mode. Please restart FRR"
+                ;;
+            netlink)
+                echo "-M fpm:netlink" > $SNAP_DATA/fpm.conf
+                echo "FPM enabled and set to netlink mode. Please restart FRR"
+                ;;
+            *)
+                echo "Usage:"
+                echo "    ${SNAP_NAME}.set fpm {disable|protobuf|netlink}"
+                echo ""
+                echo "    Disables FPM module or enables it with specified mode"
+                echo "    Mode will be saved for next restart of zebra, but zebra"
+                echo "    is not automatically restarted"               
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "Usage:"
+        echo "    ${SNAP_NAME}.set fpm {disable|protobuf|netlink}"
+        echo ""
+        echo "    Disables FPM or enables FPM with selected mode"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/snapcraft/scripts/zebra-service
+++ b/snapcraft/scripts/zebra-service
@@ -8,9 +8,13 @@ fi
 if ! [ -e $SNAP_DATA/vtysh.conf ]; then
     cp $SNAP/etc/frr/vtysh.conf.default $SNAP_DATA/vtysh.conf
 fi
+EXTRA_OPTIONS=""
+if [ -e $SNAP_DATA/fpm.conf ]; then
+	EXTRA_OPTIONS="`cat $SNAP_DATA/fpm.conf`"
+fi
 exec $SNAP/sbin/zebra \
     -f $SNAP_DATA/zebra.conf \
     --pid_file $SNAP_DATA/zebra.pid \
     --socket $SNAP_DATA/zsock \
-    --vty_socket $SNAP_DATA
-
+    --vty_socket $SNAP_DATA \
+    --moduledir $SNAP/lib/frr/modules $EXTRA_OPTIONS

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -148,7 +148,6 @@ parts:
            - gawk
            - libreadline-dev
            - texinfo
-           - dejagnu
            - libncurses5-dev
            - texlive-latex-base
            - texlive-generic-recommended
@@ -161,6 +160,10 @@ parts:
            - chrpath
            - pkg-config
            - libjson-c-dev
+           - libc-ares-dev
+           - bison
+           - flex
+           - python3-dev
         stage-packages:
            - coreutils
            - iproute2

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -83,6 +83,13 @@ apps:
             - network
             - network-bind
             - network-control
+    nhrpd:
+        command: bin/nhrpd-service
+        daemon: simple
+        plugs:
+            - network
+            - network-bind
+            - network-control
     zebra-debug:
         command: sbin/zebra -f $SNAP_DATA/zebra.conf --pid_file $SNAP_DATA/zebra.pid --socket $SNAP_DATA/zsock --vty_socket $SNAP_DATA
         plugs:
@@ -132,12 +139,18 @@ apps:
             - network-bind
             - network-control
     ldpd-debug:
-        command: sbin/ldpd -f $SNAP_DATA/pimd.conf --pid_file $SNAP_DATA/pimd.pid --socket $SNAP_DATA/zsock --ctl_socket $SNAP_DATA --vty_socket $SNAP_DATA
+        command: sbin/ldpd -f $SNAP_DATA/ldpd.conf --pid_file $SNAP_DATA/ldpd.pid --socket $SNAP_DATA/zsock --ctl_socket $SNAP_DATA --vty_socket $SNAP_DATA
         plugs:
             - network
             - network-bind
             - network-control
-
+    nhrpd-debug:
+        command: sbin/nhrpd -f $SNAP_DATA/nhrpd.conf --pid_file $SNAP_DATA/nhrpd.pid --socket $SNAP_DATA/zsock --vty_socket $SNAP_DATA
+        plugs:
+            - network
+            - network-bind
+            - network-control
+            
 parts:
     frr: 
         build-packages: 
@@ -215,6 +228,7 @@ parts:
             ripd.conf.default: etc/frr/ripd.conf.default
             ripngd.conf.default: etc/frr/ripngd.conf.default
             ldpd.conf.default: etc/frr/ldpd.conf.default
+            nhrpd.conf.default: etc/frr/nhrpd.conf.default
             vtysh.conf.default: etc/frr/vtysh.conf.default
     frr-scripts:
         plugin: make

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -90,6 +90,8 @@ apps:
             - network
             - network-bind
             - network-control
+    set:
+        command: bin/set-options
     zebra-debug:
         command: sbin/zebra -f $SNAP_DATA/zebra.conf --pid_file $SNAP_DATA/zebra.pid --socket $SNAP_DATA/zsock --vty_socket $SNAP_DATA
         plugs:
@@ -177,6 +179,7 @@ parts:
            - bison
            - flex
            - python3-dev
+           - protobuf-c-compiler
         stage-packages:
            - coreutils
            - iproute2
@@ -208,6 +211,8 @@ parts:
             - --enable-group=root
             - --enable-pimd
             - --enable-ldpd
+            - --enable-fpm
+            - --enable-protobuf
             - --enable-configfile-mask=0640
             - --enable-logfile-mask=0640 
             - --localstatedir=/var/run


### PR DESCRIPTION
Fixes to update snap package for 3.0 code.
- new build requirements
- Add nhrpd daemon
- Add support for fpm as a module (incl simple cmd to enable/disable it)

For reviewers: Main section to review is a new `--moduledir` option I've added to
the daemons to support dynamic directories for module location. (Library directory isn't
known for Snap's until runtime) See commit 80b4df3