### PR TITLE
ospf6d: fix "no router ospf6"

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -315,6 +315,14 @@ DEFUN (no_router_ospf6,
        ROUTER_STR
        OSPF6_STR)
 {
+  if (ospf6 == NULL)
+    vty_out (vty, "OSPFv3 is not configured%s", VNL);
+  else
+    {
+      ospf6_delete (ospf6);
+      ospf6 = NULL;
+    }
+
   /* return to config node . */
   VTY_PUSH_CONTEXT_NULL(CONFIG_NODE);
 


### PR DESCRIPTION
The "no router ospf6" command wasn't working.

Regression introduced by commit 16cedbb.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>