### PR TITLE
vtysh: "Command incomplete: log syslog"

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2165,7 +2165,7 @@ DEFUNSH (VTYSH_ALL,
 DEFUNSH (VTYSH_ALL,
 	 vtysh_log_syslog,
 	 vtysh_log_syslog_cmd,
-	 "log syslog <emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>",
+	 "log syslog [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>]",
 	 "Logging control\n"
 	 "Set syslog logging level\n"
          LOG_LEVEL_DESC)


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

Before
======
root@spine-1[~]# cat /etc/frr/frr.conf
no log monitor
!
service integrated-vtysh-config
!
log syslog
!
log syslog informational
!
line vty
!
root@spine-1[~]#
root@spine-1[~]# vtysh -m -f /etc/frr/frr.conf
no log monitor
!
service integrated-vtysh-config
!
line 5: % Command incomplete: log syslog

root@spine-1[~]#

After
=====
root@spine-1[~]# vtysh -m -f /etc/frr/frr.conf
no log monitor
!
service integrated-vtysh-config
!
log syslog
!
log syslog informational
!
line vty
!
end
root@spine-1[~]#