### PR TITLE
lib: distribute-list "Ran out of docstring while parsing"

### DIFF
--- a/lib/distribute.c
+++ b/lib/distribute.c
@@ -254,6 +254,7 @@ DEFUN (distribute_list,
        distribute_list_cmd,
        "distribute-list [prefix] WORD <in|out> [WORD]",
        "Filter networks in routing updates\n"
+       "Specify a prefix\n"
        "Access-list name\n"
        "Filter incoming routing updates\n"
        "Filter outgoing routing updates\n"
@@ -316,7 +317,9 @@ DEFUN (no_distribute_list,
        no_distribute_list_cmd,
        "no [ipv6] distribute-list [prefix] WORD <in|out> [WORD]",
        NO_STR
+       "IPv6\n"
        "Filter networks in routing updates\n"
+       "Specify a prefix\n"
        "Access-list name\n"
        "Filter incoming routing updates\n"
        "Filter outgoing routing updates\n"


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

Before
======
root@spine-1[frr]# vtysh
2017/04/24 17:17:08 unknown: Ran out of docstring while parsing 'no
[ipv6] distribute-list [prefix] WORD <in|out> [WORD]'
2017/04/24 17:17:08 unknown: Ran out of docstring while parsing
'distribute-list [prefix] WORD <in|out> [WORD]'
2017/04/24 17:17:08 unknown: Ran out of docstring while parsing
'distribute-list [prefix] WORD <in|out> [WORD]'
2017/04/24 17:17:08 unknown: Ran out of docstring while parsing 'no
[ipv6] distribute-list [prefix] WORD <in|out> [WORD]'

Hello, this is FreeRangeRouting (version 2.1-dev).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

spine-1# exit
root@spine-1[frr]#

After
=====
root@spine-1[frr]# vtysh

Hello, this is FreeRangeRouting (version 2.1-dev).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

spine-1#