### PR TITLE
Pim Development

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4087,23 +4087,37 @@ static int
 pim_cmd_igmp_start (struct vty *vty, struct interface *ifp)
 {
   struct pim_interface *pim_ifp;
+  uint8_t need_startup = 0;
 
   pim_ifp = ifp->info;
 
-  if (!pim_ifp) {
-    pim_ifp = pim_if_new(ifp, 1 /* igmp=true */, 0 /* pim=false */);
-    if (!pim_ifp) {
-      vty_out(vty, "Could not enable IGMP on interface %s%s",
+  if (!pim_ifp)
+    {
+      pim_ifp = pim_if_new(ifp, 1 /* igmp=true */, 0 /* pim=false */);
+      if (!pim_ifp)
+        {
+          vty_out(vty, "Could not enable IGMP on interface %s%s",
 	      ifp->name, VTY_NEWLINE);
-      return CMD_WARNING;
+          return CMD_WARNING;
+        }
+      need_startup = 1;
     }
-  }
-  else {
-    PIM_IF_DO_IGMP(pim_ifp->options);
-  }
+  else
+    {
+      if (!PIM_IF_TEST_IGMP(pim_ifp->options))
+        {
+          PIM_IF_DO_IGMP(pim_ifp->options);
+          need_startup = 1;
+        }
+    }
 
-  pim_if_addr_add_all(ifp);
-  pim_if_membership_refresh(ifp);
+  /* 'ip igmp' executed multiple times, with need_startup
+    avoid multiple if add all and membership refresh */
+  if (need_startup)
+    {
+      pim_if_addr_add_all(ifp);
+      pim_if_membership_refresh(ifp);
+    }
 
   return CMD_SUCCESS;
 }
@@ -4469,21 +4483,36 @@ DEFUN (interface_ip_igmp_version,
        "IGMP version number\n")
 {
   VTY_DECLVAR_CONTEXT(interface,ifp);
-  struct pim_interface *pim_ifp;
-  int igmp_version;
+  struct pim_interface *pim_ifp = NULL;
+  int igmp_version, old_version = 0;
   int ret;
 
   pim_ifp = ifp->info;
 
-  if (!pim_ifp) {
-    ret = pim_cmd_igmp_start(vty, ifp);
-    if (ret != CMD_SUCCESS)
-      return ret;
-    pim_ifp = ifp->info;
-  }
+  if (!pim_ifp)
+    {
+      ret = pim_cmd_igmp_start(vty, ifp);
+      if (ret != CMD_SUCCESS)
+        return ret;
+      pim_ifp = ifp->info;
+    }
 
   igmp_version = atoi(argv[3]->arg);
+  old_version = pim_ifp->igmp_version;
   pim_ifp->igmp_version = igmp_version;
+
+  //Check if IGMP is Enabled otherwise, enable on interface
+  if (!PIM_IF_TEST_IGMP (pim_ifp->options))
+    {
+      PIM_IF_DO_IGMP(pim_ifp->options);
+      pim_if_addr_add_all(ifp);
+      pim_if_membership_refresh(ifp);
+      old_version = igmp_version;   //avoid refreshing membership again.
+    }
+  /* Current and new version is different refresh existing
+     membership. Going from 3 -> 2 or 2 -> 3. */
+  if (old_version != igmp_version)
+    pim_if_membership_refresh(ifp);
 
   return CMD_SUCCESS;
 }

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -151,7 +151,7 @@ void pim_ifchannel_update_my_assert_metric(struct pim_ifchannel *ch);
 void pim_ifchannel_update_assert_tracking_desired(struct pim_ifchannel *ch);
 
 void pim_ifchannel_scan_forward_start (struct interface *new_ifp);
-void pim_ifchannel_set_star_g_join_state (struct pim_ifchannel *ch, int eom);
+void pim_ifchannel_set_star_g_join_state (struct pim_ifchannel *ch, int eom, uint8_t source_flags, uint8_t join);
 
 int pim_ifchannel_compare (struct pim_ifchannel *ch1, struct pim_ifchannel *ch2);
 

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -387,7 +387,13 @@ int pim_joinprune_send(struct pim_rpf *rpf,
 
   on_trace (__PRETTY_FUNCTION__, rpf->source_nexthop.interface, rpf->rpf_addr.u.prefix4);
 
-  pim_ifp = rpf->source_nexthop.interface->info;
+  if (rpf->source_nexthop.interface)
+    pim_ifp = rpf->source_nexthop.interface->info;
+  else
+    {
+      zlog_warn ("%s: RPF interface is not present", __PRETTY_FUNCTION__);
+      return -1;
+    }
 
   if (!pim_ifp) {
     zlog_warn("%s: multicast not enabled on interface %s",

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -276,7 +276,7 @@ int pim_joinprune_recv(struct interface *ifp,
         {
           ch = pim_ifchannel_find (ifp, &sg);
 	  if (ch)
-	    pim_ifchannel_set_star_g_join_state (ch, 0);
+	    pim_ifchannel_set_star_g_join_state (ch, 0, msg_source_flags, 1);
         }
     }
 
@@ -297,7 +297,7 @@ int pim_joinprune_recv(struct interface *ifp,
 		 msg_source_flags);
     }
     if (ch)
-      pim_ifchannel_set_star_g_join_state (ch, 1);
+      pim_ifchannel_set_star_g_join_state (ch, 1, msg_source_flags, 0);
     ch = NULL;
   } /* scan groups */
 

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -343,8 +343,9 @@ pim_jp_agg_single_upstream_send (struct pim_rpf *rpf,
   static bool first = true;
 
   /* skip JP upstream messages if source is directly connected */
-  if (pim_if_connected_to_source (rpf->source_nexthop.interface, up->sg.src))
-      return;
+  if (!rpf->source_nexthop.interface ||
+      pim_if_connected_to_source (rpf->source_nexthop.interface, up->sg.src))
+    return;
 
   if (first)
     {

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -455,6 +455,9 @@ struct pim_neighbor *pim_neighbor_find(struct interface *ifp,
   struct listnode      *node;
   struct pim_neighbor  *neigh;
 
+  if (!ifp)
+    return NULL;
+
   pim_ifp = ifp->info;
   if (!pim_ifp)
     return NULL;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -276,7 +276,6 @@ pim_update_rp_nh (struct pim_nexthop_cache *pnc)
 {
   struct listnode *node = NULL;
   struct rp_info *rp_info = NULL;
-  int ret = 0;
 
   /*Traverse RP list and update each RP Nexthop info */
   for (ALL_LIST_ELEMENTS_RO (pnc->rp_list, node, rp_info))
@@ -299,11 +298,7 @@ pim_update_rp_nh (struct pim_nexthop_cache *pnc)
         }
     }
 
-  if (ret)
-    return 0;
-
-  return 1;
-
+  return 0;
 }
 
 /* This API is used to traverse nexthop cache of RPF addr

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -665,7 +665,10 @@ pim_ecmp_nexthop_search (struct pim_nexthop_cache *pnc,
 
     }
 
-  return 0;
+  if (found)
+    return 0;
+  else
+    return -1;
 }
 
 /* This API is used to parse Registered address nexthop update coming from Zebra */

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -190,7 +190,7 @@ pim_register_send (const uint8_t *buf, int buf_size, struct in_addr src, struct 
   if (PIM_DEBUG_PIM_REG)
     {
       char rp_str[INET_ADDRSTRLEN];
-      strcpy (rp_str, inet_ntoa (rpg->rpf_addr.u.prefix4));
+      strncpy (rp_str, inet_ntoa (rpg->rpf_addr.u.prefix4), INET_ADDRSTRLEN-1);
       zlog_debug ("%s: Sending %s %sRegister Packet to %s on %s",
               __PRETTY_FUNCTION__, up->sg_str,
               null_register ? "NULL " : "", rp_str, ifp->name);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -281,7 +281,7 @@ pim_rp_check_interfaces (struct rp_info *rp_info)
 int
 pim_rp_new (const char *rp, const char *group_range, const char *plist)
 {
-  int result, ret = 0;
+  int result;
   struct rp_info *rp_info;
   struct rp_info *rp_all;
   struct prefix group_all;
@@ -400,12 +400,12 @@ pim_rp_new (const char *rp, const char *group_range, const char *plist)
                           __PRETTY_FUNCTION__, buf, buf1);
             }
           memset (&pnc, 0, sizeof (struct pim_nexthop_cache));
-          if ((ret =
-               pim_find_or_track_nexthop (&nht_p, NULL, rp_all, &pnc)) == 1)
+          if ((pim_find_or_track_nexthop (&nht_p, NULL, rp_all, &pnc)) == 1)
             {
               //Compute PIM RPF using Cached nexthop
-              pim_ecmp_nexthop_search (&pnc, &rp_all->rp.source_nexthop,
-                                       &nht_p, &rp_all->group, 1);
+              if ((pim_ecmp_nexthop_search (&pnc, &rp_all->rp.source_nexthop,
+                                       &nht_p, &rp_all->group, 1)) != 0)
+                return PIM_RP_NO_PATH;
             }
           else
             {
@@ -471,11 +471,12 @@ pim_rp_new (const char *rp, const char *group_range, const char *plist)
     }
 
   memset (&pnc, 0, sizeof (struct pim_nexthop_cache));
-  if ((ret = pim_find_or_track_nexthop (&nht_p, NULL, rp_info, &pnc)) == 1)
+  if ((pim_find_or_track_nexthop (&nht_p, NULL, rp_info, &pnc)) == 1)
     {
       //Compute PIM RPF using Cached nexthop
-      pim_ecmp_nexthop_search (&pnc, &rp_info->rp.source_nexthop,
-                               &nht_p, &rp_info->group, 1);
+      if (pim_ecmp_nexthop_search (&pnc, &rp_info->rp.source_nexthop,
+                               &nht_p, &rp_info->group, 1) != 0)
+        return PIM_RP_NO_PATH;
     }
   else
     {
@@ -575,8 +576,9 @@ pim_rp_setup (void)
       if ((pim_find_or_track_nexthop (&nht_p, NULL, rp_info, &pnc)) == 1)
         {
           //Compute PIM RPF using Cached nexthop
-          pim_ecmp_nexthop_search (&pnc, &rp_info->rp.source_nexthop,
-                                   &nht_p, &rp_info->group, 1);
+          if ((pim_ecmp_nexthop_search (&pnc, &rp_info->rp.source_nexthop,
+                                   &nht_p, &rp_info->group, 1)) != 0)
+            ret++;
         }
       else
         {
@@ -727,7 +729,6 @@ pim_rp_g (struct in_addr group)
 
   if (rp_info)
     {
-      int ret = 0;
       struct prefix nht_p;
       struct pim_nexthop_cache pnc;
       /* Register addr with Zebra NHT */
@@ -744,7 +745,7 @@ pim_rp_g (struct in_addr group)
                       __PRETTY_FUNCTION__, buf, buf1);
         }
       memset (&pnc, 0, sizeof (struct pim_nexthop_cache));
-      if ((ret = pim_find_or_track_nexthop (&nht_p, NULL, rp_info, &pnc)) == 1)
+      if ((pim_find_or_track_nexthop (&nht_p, NULL, rp_info, &pnc)) == 1)
         {
           //Compute PIM RPF using Cached nexthop
           pim_ecmp_nexthop_search (&pnc, &rp_info->rp.source_nexthop,

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -225,11 +225,14 @@ enum pim_rpf_result pim_rpf_update(struct pim_upstream *up, struct pim_rpf *old,
       if (pnc.nexthop_num)
         {
           //Compute PIM RPF using Cached nexthop
-          pim_ecmp_nexthop_search (&pnc, &up->rpf.source_nexthop,
-                                   &src, &grp,
-                                   !PIM_UPSTREAM_FLAG_TEST_FHR (up->flags) &&
-                                   !PIM_UPSTREAM_FLAG_TEST_SRC_IGMP (up->
-                                                                     flags));
+          if (pim_ecmp_nexthop_search (&pnc, &up->rpf.source_nexthop,
+                                       &src, &grp,
+                                       !PIM_UPSTREAM_FLAG_TEST_FHR (up->flags) &&
+                                       !PIM_UPSTREAM_FLAG_TEST_SRC_IGMP (up->flags)))
+
+            {
+              return PIM_RPF_FAILURE;
+            }
         }
     }
   else

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -481,7 +481,15 @@ static void forward_off(struct pim_upstream *up)
 static int
 pim_upstream_could_register (struct pim_upstream *up)
 {
-  struct pim_interface *pim_ifp = up->rpf.source_nexthop.interface->info;
+  struct pim_interface *pim_ifp = NULL;
+
+  if (up->rpf.source_nexthop.interface)
+    pim_ifp = up->rpf.source_nexthop.interface->info;
+  else
+    {
+      if (PIM_DEBUG_TRACE)
+        zlog_debug ("%s: up %s RPF is not present", __PRETTY_FUNCTION__, up->sg_str);
+    }
 
   if (pim_ifp && PIM_I_am_DR (pim_ifp) &&
       pim_if_connected_to_source (up->rpf.source_nexthop.interface, up->sg.src))
@@ -1439,13 +1447,19 @@ pim_upstream_start_register_stop_timer (struct pim_upstream *up, int null_regist
 int
 pim_upstream_inherited_olist_decide (struct pim_upstream *up)
 {
-  struct pim_interface *pim_ifp;
+  struct pim_interface *pim_ifp = NULL;
   struct listnode *chnextnode;
   struct pim_ifchannel *ch;
   struct listnode *chnode;
   int output_intf = 0;
 
-  pim_ifp = up->rpf.source_nexthop.interface->info;
+  if (up->rpf.source_nexthop.interface)
+    pim_ifp = up->rpf.source_nexthop.interface->info;
+  else
+    {
+      if (PIM_DEBUG_TRACE)
+        zlog_debug ("%s: up %s RPF is not present", __PRETTY_FUNCTION__, up->sg_str);
+    }
   if (pim_ifp && !up->channel_oil)
     up->channel_oil = pim_channel_oil_add (&up->sg, pim_ifp->mroute_vif_index);
 


### PR DESCRIPTION
Following set of changes are in this pull request. 

1.  pimd: fix pimd crashes around pim rpf

    During neighbor down event, all upstream entries rpf lookup may result
    into nhop address with 0.0.0.0 and rpf interface info being NULL.
    Put preventin check where rpf interface info is accessed.
    Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>

2.  pimd: Fix WG/SGRpt & WG J/P processing

    During processing of Join/Prune,
    for a S,G entry, current state is SGRpt, when only *,G is
    received, need to clear SGRpt and add/inherit the *,G OIF to S,G so
    it can forward traffic to downstream where *,G is received.
    Upon receiving SGRpt prune remove the inherited *,G OIF.

    Testing Done:
    Trigger SPT switchover, *,G path received SGRpt later data
    traffic stopped S,G ages out from LHR, sends only
    *,G join to upstream, verified S,G entry inherit the OIF.
    Upon receiving SGRpt deletes inherited oif and retains in SGRpt state.

    Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>

3.  pimd: Enable igmp on igmp version change cli

    Execute ip igmp version 3 under swp interface,
    verified show running displayed 'ip igmp' configuration.
    Continuous sending group membership, performed 'no ip igmp'
    and verified, group membership flushed. Performed
    'ip igmp version 3', verified 'show ip igmp groups'
    displaying igmp membership re-populated.
    - Fix coverity found issues 

    Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>