### PR TITLE
lib: When we receive SIGUSR2 log memory stats and exit cleanly

### DIFF
--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -223,6 +223,10 @@ exit_handler(int signo
 	      , siginfo, program_counter(context)
 #endif
 	     );
+
+  if (signo == SIGUSR2)
+    log_memstats_stderr ("SIGUSR2");
+
   _exit(128+signo);
 }
 


### PR DESCRIPTION
Currently our topotests are sending `kill -7 <daemon>` to
kill the daemon at the end of the tests.  -7 causes a core
file to be generated.  Changing the tests to use SIGUSR2 instead
will allow the memory stats to be generated and also to safely
shutdown.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>