### PR TITLE
*: remove THREAD_ON macros, add nullity check

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -117,7 +117,7 @@ bgp_reuse_timer (struct thread *t)
     
   damp->t_reuse = NULL;
   damp->t_reuse =
-    thread_add_timer (bm->master, bgp_reuse_timer, NULL, DELTA_REUSE);
+    thread_add_timer(bm->master, bgp_reuse_timer, NULL, DELTA_REUSE, NULL);
 
   t_now = bgp_clock ();
 
@@ -447,9 +447,8 @@ bgp_damp_enable (struct bgp *bgp, afi_t afi, safi_t safi, time_t half,
   bgp_damp_parameter_set (half, reuse, suppress, max);
 
   /* Register reuse timer.  */
-  if (! damp->t_reuse)
-    damp->t_reuse = 
-      thread_add_timer (bm->master, bgp_reuse_timer, NULL, DELTA_REUSE);
+  thread_add_timer(bm->master, bgp_reuse_timer, NULL, DELTA_REUSE,
+                   &damp->t_reuse);
 
   return 0;
 }

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -116,8 +116,8 @@ bgp_reuse_timer (struct thread *t)
   time_t t_now, t_diff;
     
   damp->t_reuse = NULL;
-  damp->t_reuse =
-    thread_add_timer(bm->master, bgp_reuse_timer, NULL, DELTA_REUSE, NULL);
+  thread_add_timer(bm->master, bgp_reuse_timer, NULL, DELTA_REUSE,
+                   &damp->t_reuse);
 
   t_now = bgp_clock ();
 

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -171,16 +171,16 @@ bgp_dump_interval_add (struct bgp_dump *bgp_dump, int interval)
 	  secs_into_day = tm->tm_sec + 60*tm->tm_min + 60*60*tm->tm_hour;
 	  interval = interval - secs_into_day % interval; /* always > 0 */
 	}
-      bgp_dump->t_interval = thread_add_timer(bm->master,
-                                              bgp_dump_interval_func,
-                                              bgp_dump, interval, NULL);
+      bgp_dump->t_interval = NULL;
+      thread_add_timer(bm->master, bgp_dump_interval_func, bgp_dump, interval,
+                       &bgp_dump->t_interval);
     }
   else
     {
       /* One-off dump: execute immediately, don't affect any scheduled dumps */
-      bgp_dump->t_interval = thread_add_event(bm->master,
-                                              bgp_dump_interval_func,
-                                              bgp_dump, 0, NULL);
+      bgp_dump->t_interval = NULL;
+      thread_add_event(bm->master, bgp_dump_interval_func, bgp_dump, 0,
+                       &bgp_dump->t_interval);
     }
 
   return 0;

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -171,14 +171,16 @@ bgp_dump_interval_add (struct bgp_dump *bgp_dump, int interval)
 	  secs_into_day = tm->tm_sec + 60*tm->tm_min + 60*60*tm->tm_hour;
 	  interval = interval - secs_into_day % interval; /* always > 0 */
 	}
-      bgp_dump->t_interval = thread_add_timer (bm->master, bgp_dump_interval_func,
-					       bgp_dump, interval);
+      bgp_dump->t_interval = thread_add_timer(bm->master,
+                                              bgp_dump_interval_func,
+                                              bgp_dump, interval, NULL);
     }
   else
     {
       /* One-off dump: execute immediately, don't affect any scheduled dumps */
-      bgp_dump->t_interval = thread_add_event (bm->master, bgp_dump_interval_func,
-					       bgp_dump, 0);
+      bgp_dump->t_interval = thread_add_event(bm->master,
+                                              bgp_dump_interval_func,
+                                              bgp_dump, 0, NULL);
     }
 
   return 0;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -808,9 +808,8 @@ bgp_maxmed_onstartup_begin (struct bgp *bgp)
   zlog_info ("Begin maxmed onstartup mode - timer %d seconds",
              bgp->v_maxmed_onstartup);
 
-  THREAD_TIMER_ON (bm->master, bgp->t_maxmed_onstartup,
-                   bgp_maxmed_onstartup_timer,
-                   bgp, bgp->v_maxmed_onstartup);
+  thread_add_timer(bm->master, bgp_maxmed_onstartup_timer, bgp,
+                   bgp->v_maxmed_onstartup, &bgp->t_maxmed_onstartup);
 
   if (!bgp->v_maxmed_admin)
     {
@@ -877,12 +876,12 @@ bgp_update_delay_begin (struct bgp *bgp)
     peer->update_delay_over = 0;
 
   /* Start the update-delay timer */
-  THREAD_TIMER_ON (bm->master, bgp->t_update_delay, bgp_update_delay_timer,
-                   bgp, bgp->v_update_delay);
+  thread_add_timer(bm->master, bgp_update_delay_timer, bgp,
+                   bgp->v_update_delay, &bgp->t_update_delay);
 
   if (bgp->v_establish_wait != bgp->v_update_delay)
-    THREAD_TIMER_ON (bm->master, bgp->t_establish_wait, bgp_establish_wait_timer,
-                     bgp, bgp->v_establish_wait);
+    thread_add_timer(bm->master, bgp_establish_wait_timer, bgp,
+                     bgp->v_establish_wait, &bgp->t_establish_wait);
 
   quagga_timestamp(3, bgp->update_delay_begin_time,
                    sizeof(bgp->update_delay_begin_time));

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -23,58 +23,58 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #define _QUAGGA_BGP_FSM_H
 
 /* Macro for BGP read, write and timer thread.  */
-#define BGP_READ_ON(T,F,V)			\
-  do {						\
-    if (!(T) && (peer->status != Deleted))	\
-      THREAD_READ_ON(bm->master,T,F,peer,V);	\
+#define BGP_READ_ON(T,F,V) \
+  do { \
+    if ((peer->status != Deleted)) \
+      thread_add_read (bm->master,(F),peer,(V),&(T)); \
   } while (0)
 
-#define BGP_READ_OFF(T)				\
-  do {						\
-    if (T)					\
-      THREAD_READ_OFF(T);			\
+#define BGP_READ_OFF(T) \
+  do { \
+    if (T) \
+      THREAD_READ_OFF(T); \
   } while (0)
 
-#define BGP_WRITE_ON(T,F,V)			\
-  do {						\
-    if (!(T) && (peer->status != Deleted))	\
-      THREAD_WRITE_ON(bm->master,(T),(F),peer,(V)); \
+#define BGP_WRITE_ON(T,F,V) \
+  do { \
+    if ((peer)->status != Deleted) \
+      thread_add_write (bm->master,(F),(peer),(V),&(T)); \
   } while (0)
 
-#define BGP_PEER_WRITE_ON(T,F,V, peer)			\
-  do {							\
-    if (!(T) && ((peer)->status != Deleted))		\
-      THREAD_WRITE_ON(bm->master,(T),(F),(peer),(V));	\
+#define BGP_PEER_WRITE_ON(T,F,V, peer) \
+  do { \
+    if ((peer)->status != Deleted) \
+      thread_add_write (bm->master,(F),(peer),(V),&(T)); \
   } while (0)
 
-#define BGP_WRITE_OFF(T)			\
-  do {						\
-    if (T)					\
-      THREAD_WRITE_OFF(T);			\
+#define BGP_WRITE_OFF(T) \
+  do { \
+    if (T) \
+      THREAD_WRITE_OFF(T); \
   } while (0)
 
-#define BGP_TIMER_ON(T,F,V)			\
-  do {						\
-    if (!(T) && (peer->status != Deleted))	\
-      THREAD_TIMER_ON(bm->master,(T),(F),peer,(V)); \
+#define BGP_TIMER_ON(T,F,V) \
+  do { \
+    if ((peer->status != Deleted)) \
+      thread_add_timer (bm->master,(F),peer,(V),&(T)); \
   } while (0)
 
-#define BGP_TIMER_OFF(T)			\
-  do {						\
-    if (T)					\
-      THREAD_TIMER_OFF(T);			\
+#define BGP_TIMER_OFF(T) \
+  do { \
+    if (T) \
+      THREAD_TIMER_OFF(T); \
   } while (0)
 
-#define BGP_EVENT_ADD(P,E)			\
-  do {						\
-    if ((P)->status != Deleted)			\
-      thread_add_event (bm->master, bgp_event, (P), (E)); \
+#define BGP_EVENT_ADD(P,E) \
+  do { \
+    if ((P)->status != Deleted) \
+      thread_add_event (bm->master, bgp_event, (P), (E), NULL); \
   } while (0)
 
-#define BGP_EVENT_FLUSH(P)			\
-  do { 						\
-    assert (peer); 				\
-    thread_cancel_event (bm->master, (P)); 		\
+#define BGP_EVENT_FLUSH(P) \
+  do { \
+    assert (peer); \
+    thread_cancel_event (bm->master, (P)); \
   } while (0)
 
 #define BGP_MSEC_JITTER 10

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -297,7 +297,8 @@ bgp_accept (struct thread *thread)
       zlog_err ("accept_sock is nevative value %d", accept_sock);
       return -1;
     }
-  listener->thread = thread_add_read (bm->master, bgp_accept, listener, accept_sock);
+  listener->thread = thread_add_read(bm->master, bgp_accept, listener,
+                                     accept_sock, NULL);
 
   /* Accept client connection. */
   bgp_sock = sockunion_accept (accept_sock, &su);
@@ -704,7 +705,8 @@ bgp_listener (int sock, struct sockaddr *sa, socklen_t salen)
   listener = XMALLOC (MTYPE_BGP_LISTENER, sizeof(*listener));
   listener->fd = sock;
   memcpy(&listener->su, sa, salen);
-  listener->thread = thread_add_read (bm->master, bgp_accept, listener, sock);
+  listener->thread = thread_add_read(bm->master, bgp_accept, listener, sock,
+                                     NULL);
   listnode_add (bm->listen_sockets, listener);
 
   return 0;

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -297,8 +297,9 @@ bgp_accept (struct thread *thread)
       zlog_err ("accept_sock is nevative value %d", accept_sock);
       return -1;
     }
-  listener->thread = thread_add_read(bm->master, bgp_accept, listener,
-                                     accept_sock, NULL);
+  listener->thread = NULL;
+  thread_add_read(bm->master, bgp_accept, listener, accept_sock,
+                  &listener->thread);
 
   /* Accept client connection. */
   bgp_sock = sockunion_accept (accept_sock, &su);
@@ -705,8 +706,8 @@ bgp_listener (int sock, struct sockaddr *sa, socklen_t salen)
   listener = XMALLOC (MTYPE_BGP_LISTENER, sizeof(*listener));
   listener->fd = sock;
   memcpy(&listener->su, sa, salen);
-  listener->thread = thread_add_read(bm->master, bgp_accept, listener, sock,
-                                     NULL);
+  listener->thread = NULL;
+  thread_add_read(bm->master, bgp_accept, listener, sock, &listener->thread);
   listnode_add (bm->listen_sockets, listener);
 
   return 0;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2017,9 +2017,10 @@ bgp_process_main (struct work_queue *wq, void *data)
       if (!bgp->t_rmap_def_originate_eval)
         {
           bgp_lock (bgp);
-          THREAD_TIMER_ON(bm->master, bgp->t_rmap_def_originate_eval,
-                          update_group_refresh_default_originate_route_map,
-                          bgp, RMAP_DEFAULT_ORIGINATE_EVAL_TIMER);
+          thread_add_timer(bm->master,
+                           update_group_refresh_default_originate_route_map,
+                           bgp, RMAP_DEFAULT_ORIGINATE_EVAL_TIMER,
+                           &bgp->t_rmap_def_originate_eval);
         }
     }
 
@@ -3130,11 +3131,9 @@ bgp_announce_route (struct peer *peer, afi_t afi, safi_t safi)
    * multiple peers and the announcement doesn't happen in the
    * vty context.
    */
-  THREAD_TIMER_MSEC_ON (bm->master, paf->t_announce_route,
-			bgp_announce_route_timer_expired, paf,
-                        (subgrp->peer_count == 1) ?
-			BGP_ANNOUNCE_ROUTE_SHORT_DELAY_MS :
-			BGP_ANNOUNCE_ROUTE_DELAY_MS);
+  thread_add_timer_msec(bm->master, bgp_announce_route_timer_expired, paf,
+                        (subgrp->peer_count == 1) ? BGP_ANNOUNCE_ROUTE_SHORT_DELAY_MS : BGP_ANNOUNCE_ROUTE_DELAY_MS,
+                        &paf->t_announce_route);
 }
 
 /*

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3089,9 +3089,6 @@ bgp_announce_route_timer_expired (struct thread *t)
   paf = THREAD_ARG (t);
   peer = paf->peer;
 
-  assert (paf->t_announce_route);
-  paf->t_announce_route = NULL;
-
   if (peer->status != Established)
     return 0;
 

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3176,9 +3176,9 @@ bgp_route_map_mark_update (const char *rmap_name)
       /* rmap_update_timer of 0 means don't do route updates */
       if (bm->rmap_update_timer)
         {
-          bm->t_rmap_update =
-            thread_add_timer(bm->master, bgp_route_map_update_timer, NULL,
-                             bm->rmap_update_timer, NULL);
+          bm->t_rmap_update = NULL;
+          thread_add_timer(bm->master, bgp_route_map_update_timer, NULL, bm->rmap_update_timer,
+                           &bm->t_rmap_update);
 
           /* Signal the groups that a route-map update event has started */
           for (ALL_LIST_ELEMENTS (bm->bgp, node, nnode, bgp))

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3178,7 +3178,7 @@ bgp_route_map_mark_update (const char *rmap_name)
         {
           bm->t_rmap_update =
             thread_add_timer(bm->master, bgp_route_map_update_timer, NULL,
-                             bm->rmap_update_timer);
+                             bm->rmap_update_timer, NULL);
 
           /* Signal the groups that a route-map update event has started */
           for (ALL_LIST_ELEMENTS (bm->bgp, node, nnode, bgp))

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1170,9 +1170,8 @@ update_subgroup_trigger_merge_check (struct update_subgroup *subgrp,
     return 0;
 
   subgrp->t_merge_check =
-    thread_add_background (bm->master,
-			   update_subgroup_merge_check_thread_cb,
-			   subgrp, 0);
+    thread_add_background(bm->master, update_subgroup_merge_check_thread_cb,
+                          subgrp, 0, NULL);
 
   SUBGRP_INCR_STAT (subgrp, merge_checks_triggered);
 

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1169,9 +1169,9 @@ update_subgroup_trigger_merge_check (struct update_subgroup *subgrp,
   if (!force && !update_subgroup_ready_for_merge (subgrp))
     return 0;
 
-  subgrp->t_merge_check =
-    thread_add_background(bm->master, update_subgroup_merge_check_thread_cb,
-                          subgrp, 0, NULL);
+  subgrp->t_merge_check = NULL;
+  thread_add_background(bm->master, update_subgroup_merge_check_thread_cb, subgrp, 0,
+                        &subgrp->t_merge_check);
 
   SUBGRP_INCR_STAT (subgrp, merge_checks_triggered);
 

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -828,8 +828,8 @@ subgroup_announce_all (struct update_subgroup *subgrp)
    */
   if (!subgrp->t_coalesce)
     {
-      THREAD_TIMER_MSEC_ON (bm->master, subgrp->t_coalesce, subgroup_coalesce_timer,
-		            subgrp, subgrp->v_coalesce);
+      thread_add_timer_msec(bm->master, subgroup_coalesce_timer, subgrp,
+                            subgrp->v_coalesce, &subgrp->t_coalesce);
     }
 }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2967,8 +2967,8 @@ bgp_create (as_t *as, const char *name, enum bgp_instance_type inst_type)
   else
     {
       /* TODO - The startup timer needs to be run for the whole of BGP */
-      THREAD_TIMER_ON (bm->master, bgp->t_startup, bgp_startup_timer_expire,
-                       bgp, bgp->restart_time);
+      thread_add_timer(bm->master, bgp_startup_timer_expire, bgp,
+                       bgp->restart_time, &bgp->t_startup);
     }
 
   bgp->wpkt_quanta = BGP_WRITE_PACKET_MAX;

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -3033,9 +3033,9 @@ rfapiBiStartWithdrawTimer (
   if (lifetime > UINT32_MAX / 1001)
     {
       /* sub-optimal case, but will probably never happen */
-      bi->extra->vnc.import.timer = thread_add_timer (bm->master,
-                                                      timer_service_func,
-                                                      wcb, lifetime);
+      bi->extra->vnc.import.timer = thread_add_timer(bm->master,
+                                                     timer_service_func, wcb,
+                                                     lifetime, NULL);
     }
   else
     {
@@ -3051,10 +3051,10 @@ rfapiBiStartWithdrawTimer (
 
       lifetime_msec = (lifetime * 1000) + jitter;
 
-      bi->extra->vnc.import.timer = thread_add_background (bm->master,
-                                                           timer_service_func,
-                                                           wcb,
-                                                           lifetime_msec);
+      bi->extra->vnc.import.timer = thread_add_background(bm->master,
+                                                          timer_service_func,
+                                                          wcb, lifetime_msec,
+                                                          NULL);
     }
 
   /* re-sort route list (BGP_INFO_REMOVED routes are last) */

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -3033,9 +3033,9 @@ rfapiBiStartWithdrawTimer (
   if (lifetime > UINT32_MAX / 1001)
     {
       /* sub-optimal case, but will probably never happen */
-      bi->extra->vnc.import.timer = thread_add_timer(bm->master,
-                                                     timer_service_func, wcb,
-                                                     lifetime, NULL);
+      bi->extra->vnc.import.timer = NULL;
+      thread_add_timer(bm->master, timer_service_func, wcb, lifetime,
+                       &bi->extra->vnc.import.timer);
     }
   else
     {
@@ -3051,10 +3051,9 @@ rfapiBiStartWithdrawTimer (
 
       lifetime_msec = (lifetime * 1000) + jitter;
 
-      bi->extra->vnc.import.timer = thread_add_background(bm->master,
-                                                          timer_service_func,
-                                                          wcb, lifetime_msec,
-                                                          NULL);
+      bi->extra->vnc.import.timer = NULL;
+      thread_add_background(bm->master, timer_service_func, wcb, lifetime_msec,
+                            &bi->extra->vnc.import.timer);
     }
 
   /* re-sort route list (BGP_INFO_REMOVED routes are last) */

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -852,8 +852,8 @@ rfapiMonitorTimerRestart (struct rfapi_monitor_vpn *m)
                 rfapi_ntop (m->p.family, m->p.u.val, buf, BUFSIZ),
                 m->rfd->response_lifetime);
   }
-  m->timer = thread_add_timer (bm->master, rfapiMonitorTimerExpire, m,
-                               m->rfd->response_lifetime);
+  m->timer = thread_add_timer(bm->master, rfapiMonitorTimerExpire, m,
+                              m->rfd->response_lifetime, NULL);
 }
 
 /* 
@@ -1183,8 +1183,8 @@ rfapiMonitorEthTimerRestart (struct rfapi_monitor_eth *m)
                 rfapiEthAddr2Str (&m->macaddr, buf, BUFSIZ),
                 m->rfd->response_lifetime);
   }
-  m->timer = thread_add_timer (bm->master, rfapiMonitorEthTimerExpire, m,
-                               m->rfd->response_lifetime);
+  m->timer = thread_add_timer(bm->master, rfapiMonitorEthTimerExpire, m,
+                              m->rfd->response_lifetime, NULL);
 }
 
 static int

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -852,8 +852,9 @@ rfapiMonitorTimerRestart (struct rfapi_monitor_vpn *m)
                 rfapi_ntop (m->p.family, m->p.u.val, buf, BUFSIZ),
                 m->rfd->response_lifetime);
   }
-  m->timer = thread_add_timer(bm->master, rfapiMonitorTimerExpire, m,
-                              m->rfd->response_lifetime, NULL);
+  m->timer = NULL;
+  thread_add_timer(bm->master, rfapiMonitorTimerExpire, m, m->rfd->response_lifetime,
+                   &m->timer);
 }
 
 /* 
@@ -1183,8 +1184,9 @@ rfapiMonitorEthTimerRestart (struct rfapi_monitor_eth *m)
                 rfapiEthAddr2Str (&m->macaddr, buf, BUFSIZ),
                 m->rfd->response_lifetime);
   }
-  m->timer = thread_add_timer(bm->master, rfapiMonitorEthTimerExpire, m,
-                              m->rfd->response_lifetime, NULL);
+  m->timer = NULL;
+  thread_add_timer(bm->master, rfapiMonitorEthTimerExpire, m, m->rfd->response_lifetime,
+                   &m->timer);
 }
 
 static int

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -400,8 +400,9 @@ rfapiRibStartTimer (
   prefix2str (&rn->p, buf_prefix, BUFSIZ);
   vnc_zlog_debug_verbose ("%s: rfd %p pfx %s life %u", __func__, rfd, buf_prefix,
               ri->lifetime);
-  ri->timer = thread_add_timer(bm->master, rfapiRibExpireTimer, tcb,
-                               ri->lifetime, NULL);
+  ri->timer = NULL;
+  thread_add_timer(bm->master, rfapiRibExpireTimer, tcb, ri->lifetime,
+                   &ri->timer);
   assert (ri->timer);
 }
 

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -400,8 +400,8 @@ rfapiRibStartTimer (
   prefix2str (&rn->p, buf_prefix, BUFSIZ);
   vnc_zlog_debug_verbose ("%s: rfd %p pfx %s life %u", __func__, rfd, buf_prefix,
               ri->lifetime);
-  ri->timer = thread_add_timer (bm->master, rfapiRibExpireTimer,
-                                tcb, ri->lifetime);
+  ri->timer = thread_add_timer(bm->master, rfapiRibExpireTimer, tcb,
+                               ri->lifetime, NULL);
   assert (ri->timer);
 }
 

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1856,8 +1856,9 @@ vnc_direct_bgp_rh_del_route (
 
   if (!eti->timer && eti->lifetime <= INT32_MAX)
     {
-      eti->timer = thread_add_timer(bm->master, vncExportWithdrawTimer, eti,
-                                    eti->lifetime, NULL);
+      eti->timer = NULL;
+      thread_add_timer(bm->master, vncExportWithdrawTimer, eti, eti->lifetime,
+                       &eti->timer);
       vnc_zlog_debug_verbose ("%s: set expiration timer for %u seconds",
                   __func__, eti->lifetime);
     }

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1856,9 +1856,8 @@ vnc_direct_bgp_rh_del_route (
 
   if (!eti->timer && eti->lifetime <= INT32_MAX)
     {
-      eti->timer = thread_add_timer (bm->master,
-                                     vncExportWithdrawTimer,
-                                     eti, eti->lifetime);
+      eti->timer = thread_add_timer(bm->master, vncExportWithdrawTimer, eti,
+                                    eti->lifetime, NULL);
       vnc_zlog_debug_verbose ("%s: set expiration timer for %u seconds",
                   __func__, eti->lifetime);
     }

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -181,7 +181,9 @@ eigrp_distribute_update (struct distribute *dist)
           thread_cancel(e->t_distribute);
         }
       /* schedule Graceful restart for whole process in 10sec */
-      e->t_distribute = thread_add_timer(master, eigrp_distribute_timer_process, e,(10));
+      e->t_distribute = NULL;
+      thread_add_timer(master, eigrp_distribute_timer_process, e, (10),
+                       &e->t_distribute);
 
       return;
     }
@@ -305,7 +307,9 @@ eigrp_distribute_update (struct distribute *dist)
       thread_cancel(ei->t_distribute);
     }
   /* schedule Graceful restart for interface in 10sec */
-  e->t_distribute = thread_add_timer(master, eigrp_distribute_timer_interface, ei, 10);
+  e->t_distribute = NULL;
+  thread_add_timer(master, eigrp_distribute_timer_interface, ei, 10,
+                   &e->t_distribute);
 }
 
 /*

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -276,7 +276,7 @@ eigrp_if_up (struct eigrp_interface *ei)
   /* Set multicast memberships appropriately for new state. */
   eigrp_if_set_multicast (ei);
 
-  thread_add_event (master, eigrp_hello_timer, ei, (1));
+  thread_add_event(master, eigrp_hello_timer, ei, (1), NULL);
 
   /*Prepare metrics*/
   metric.bandwith = eigrp_bandwidth_to_scaled (EIGRP_IF_PARAM (ei,bandwidth));

--- a/eigrpd/eigrp_neighbor.c
+++ b/eigrpd/eigrp_neighbor.c
@@ -298,16 +298,16 @@ eigrp_nbr_state_update (struct eigrp_neighbor *nbr)
       {
         /*Reset Hold Down Timer for neighbor*/
         THREAD_OFF(nbr->t_holddown);
-        THREAD_TIMER_ON(master, nbr->t_holddown, holddown_timer_expired, nbr,
-                        nbr->v_holddown);
+        thread_add_timer(master, holddown_timer_expired, nbr,
+                         nbr->v_holddown, &nbr->t_holddown);
         break;
       }
     case EIGRP_NEIGHBOR_UP:
       {
         /*Reset Hold Down Timer for neighbor*/
         THREAD_OFF(nbr->t_holddown);
-        THREAD_TIMER_ON(master, nbr->t_holddown, holddown_timer_expired, nbr,
-                        nbr->v_holddown);
+        thread_add_timer(master, holddown_timer_expired, nbr,
+                         nbr->v_holddown, &nbr->t_holddown);
         break;
       }
     }

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -181,7 +181,8 @@ eigrp_new (const char *AS)
       exit(1);
     }
 
-  eigrp->t_read = thread_add_read(master, eigrp_read, eigrp, eigrp->fd);
+  eigrp->t_read = NULL;
+  thread_add_read(master, eigrp_read, eigrp, eigrp->fd, &eigrp->t_read);
   eigrp->oi_write_q = list_new();
 
   eigrp->topology_table = eigrp_topology_new();

--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -259,12 +259,13 @@ isis_dr_resign (struct isis_circuit *circuit, int level)
 
       THREAD_TIMER_OFF (circuit->t_send_csnp[0]);
 
-      THREAD_TIMER_ON (master, circuit->u.bc.t_run_dr[0], isis_run_dr_l1,
-		       circuit, 2 * circuit->hello_interval[0]);
+      thread_add_timer(master, isis_run_dr_l1, circuit,
+                       2 * circuit->hello_interval[0],
+                       &circuit->u.bc.t_run_dr[0]);
 
-      THREAD_TIMER_ON (master, circuit->t_send_psnp[0], send_l1_psnp, circuit,
-		       isis_jitter (circuit->psnp_interval[level - 1],
-				    PSNP_JITTER));
+      thread_add_timer(master, send_l1_psnp, circuit,
+                       isis_jitter(circuit->psnp_interval[level - 1], PSNP_JITTER),
+                       &circuit->t_send_psnp[0]);
     }
   else
     {
@@ -272,15 +273,16 @@ isis_dr_resign (struct isis_circuit *circuit, int level)
 
       THREAD_TIMER_OFF (circuit->t_send_csnp[1]);
 
-      THREAD_TIMER_ON (master, circuit->u.bc.t_run_dr[1], isis_run_dr_l2,
-		       circuit, 2 * circuit->hello_interval[1]);
+      thread_add_timer(master, isis_run_dr_l2, circuit,
+                       2 * circuit->hello_interval[1],
+                       &circuit->u.bc.t_run_dr[1]);
 
-      THREAD_TIMER_ON (master, circuit->t_send_psnp[1], send_l2_psnp, circuit,
-		       isis_jitter (circuit->psnp_interval[level - 1],
-				    PSNP_JITTER));
+      thread_add_timer(master, send_l2_psnp, circuit,
+                       isis_jitter(circuit->psnp_interval[level - 1], PSNP_JITTER),
+                       &circuit->t_send_psnp[1]);
     }
 
-  thread_add_event (master, isis_event_dis_status_change, circuit, 0);
+  thread_add_event(master, isis_event_dis_status_change, circuit, 0, NULL);
 
   return ISIS_OK;
 }
@@ -296,11 +298,13 @@ isis_dr_commence (struct isis_circuit *circuit, int level)
   /* Lets keep a pause in DR election */
   circuit->u.bc.run_dr_elect[level - 1] = 0;
   if (level == 1)
-    THREAD_TIMER_ON (master, circuit->u.bc.t_run_dr[0], isis_run_dr_l1,
-		     circuit, 2 * circuit->hello_interval[0]);
+    thread_add_timer(master, isis_run_dr_l1, circuit,
+                     2 * circuit->hello_interval[0],
+                     &circuit->u.bc.t_run_dr[0]);
   else
-    THREAD_TIMER_ON (master, circuit->u.bc.t_run_dr[1], isis_run_dr_l2,
-		     circuit, 2 * circuit->hello_interval[1]);
+    thread_add_timer(master, isis_run_dr_l2, circuit,
+                     2 * circuit->hello_interval[1],
+                     &circuit->u.bc.t_run_dr[1]);
   circuit->u.bc.is_dr[level - 1] = 1;
 
   if (level == 1)
@@ -321,12 +325,13 @@ isis_dr_commence (struct isis_circuit *circuit, int level)
       lsp_generate_pseudo (circuit, 1);
 
       THREAD_TIMER_OFF (circuit->u.bc.t_run_dr[0]);
-      THREAD_TIMER_ON (master, circuit->u.bc.t_run_dr[0], isis_run_dr_l1,
-		       circuit, 2 * circuit->hello_interval[0]);
+      thread_add_timer(master, isis_run_dr_l1, circuit,
+                       2 * circuit->hello_interval[0],
+                       &circuit->u.bc.t_run_dr[0]);
 
-      THREAD_TIMER_ON (master, circuit->t_send_csnp[0], send_l1_csnp, circuit,
-		       isis_jitter (circuit->csnp_interval[level - 1],
-				    CSNP_JITTER));
+      thread_add_timer(master, send_l1_csnp, circuit,
+                       isis_jitter(circuit->csnp_interval[level - 1], CSNP_JITTER),
+                       &circuit->t_send_csnp[0]);
 
     }
   else
@@ -347,15 +352,16 @@ isis_dr_commence (struct isis_circuit *circuit, int level)
       lsp_generate_pseudo (circuit, 2);
 
       THREAD_TIMER_OFF (circuit->u.bc.t_run_dr[1]);
-      THREAD_TIMER_ON (master, circuit->u.bc.t_run_dr[1], isis_run_dr_l2,
-		       circuit, 2 * circuit->hello_interval[1]);
+      thread_add_timer(master, isis_run_dr_l2, circuit,
+                       2 * circuit->hello_interval[1],
+                       &circuit->u.bc.t_run_dr[1]);
 
-      THREAD_TIMER_ON (master, circuit->t_send_csnp[1], send_l2_csnp, circuit,
-		       isis_jitter (circuit->csnp_interval[level - 1],
-				    CSNP_JITTER));
+      thread_add_timer(master, send_l2_csnp, circuit,
+                       isis_jitter(circuit->csnp_interval[level - 1], CSNP_JITTER),
+                       &circuit->t_send_csnp[1]);
     }
 
-  thread_add_event (master, isis_event_dis_status_change, circuit, 0);
+  thread_add_event(master, isis_event_dis_status_change, circuit, 0, NULL);
 
   return ISIS_OK;
 }

--- a/isisd/isis_dynhn.c
+++ b/isisd/isis_dynhn.c
@@ -51,7 +51,7 @@ dyn_cache_init (void)
 {
   if (dyn_cache == NULL)
     dyn_cache = list_new ();
-  THREAD_TIMER_ON (master, isis->t_dync_clean, dyn_cache_cleanup, NULL, 120);
+  thread_add_timer(master, dyn_cache_cleanup, NULL, 120, &isis->t_dync_clean);
   return;
 }
 
@@ -73,7 +73,7 @@ dyn_cache_cleanup (struct thread *thread)
       XFREE (MTYPE_ISIS_DYNHN, dyn);
     }
 
-  THREAD_TIMER_ON (master, isis->t_dync_clean, dyn_cache_cleanup, NULL, 120);
+  thread_add_timer(master, dyn_cache_cleanup, NULL, 120, &isis->t_dync_clean);
   return ISIS_OK;
 }
 

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -82,18 +82,19 @@ circuit_commence_level (struct isis_circuit *circuit, int level)
   if (level == 1)
     {
       if (! circuit->is_passive)
-        THREAD_TIMER_ON (master, circuit->t_send_psnp[0], send_l1_psnp, circuit,
-		         isis_jitter (circuit->psnp_interval[0], PSNP_JITTER));
+        thread_add_timer(master, send_l1_psnp, circuit,
+                         isis_jitter(circuit->psnp_interval[0], PSNP_JITTER),
+                         &circuit->t_send_psnp[0]);
 
       if (circuit->circ_type == CIRCUIT_T_BROADCAST)
 	{
-	  THREAD_TIMER_ON (master, circuit->u.bc.t_run_dr[0], isis_run_dr_l1,
-			   circuit, 2 * circuit->hello_interval[0]);
+	  thread_add_timer(master, isis_run_dr_l1, circuit,
+                           2 * circuit->hello_interval[0],
+                           &circuit->u.bc.t_run_dr[0]);
 
-	  THREAD_TIMER_ON (master, circuit->u.bc.t_send_lan_hello[0],
-			   send_lan_l1_hello, circuit,
-			   isis_jitter (circuit->hello_interval[0],
-					IIH_JITTER));
+	  thread_add_timer(master, send_lan_l1_hello, circuit,
+                           isis_jitter(circuit->hello_interval[0], IIH_JITTER),
+                           &circuit->u.bc.t_send_lan_hello[0]);
 
 	  circuit->u.bc.lan_neighs[0] = list_new ();
 	}
@@ -101,18 +102,19 @@ circuit_commence_level (struct isis_circuit *circuit, int level)
   else
     {
       if (! circuit->is_passive)
-        THREAD_TIMER_ON (master, circuit->t_send_psnp[1], send_l2_psnp, circuit,
-		         isis_jitter (circuit->psnp_interval[1], PSNP_JITTER));
+        thread_add_timer(master, send_l2_psnp, circuit,
+                         isis_jitter(circuit->psnp_interval[1], PSNP_JITTER),
+                         &circuit->t_send_psnp[1]);
 
       if (circuit->circ_type == CIRCUIT_T_BROADCAST)
 	{
-	  THREAD_TIMER_ON (master, circuit->u.bc.t_run_dr[1], isis_run_dr_l2,
-			   circuit, 2 * circuit->hello_interval[1]);
+	  thread_add_timer(master, isis_run_dr_l2, circuit,
+                           2 * circuit->hello_interval[1],
+                           &circuit->u.bc.t_run_dr[1]);
 
-	  THREAD_TIMER_ON (master, circuit->u.bc.t_send_lan_hello[1],
-			   send_lan_l2_hello, circuit,
-			   isis_jitter (circuit->hello_interval[1],
-					IIH_JITTER));
+	  thread_add_timer(master, send_lan_l2_hello, circuit,
+                           isis_jitter(circuit->hello_interval[1], IIH_JITTER),
+                           &circuit->u.bc.t_send_lan_hello[1]);
 
 	  circuit->u.bc.lan_neighs[1] = list_new ();
 	}

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1279,9 +1279,9 @@ isis_spf_schedule (struct isis_area *area, int level)
       if (area->spf_timer[level - 1])
         return ISIS_OK;
 
-      THREAD_TIMER_MSEC_ON(master, area->spf_timer[level-1],
-                           isis_run_spf_cb, isis_run_spf_arg(area, level),
-                           delay);
+      thread_add_timer_msec (master, isis_run_spf_cb,
+                             isis_run_spf_arg(area, level),
+                             delay, &area->spf_timer[level-1]);
       return ISIS_OK;
     }
 
@@ -1301,9 +1301,9 @@ isis_spf_schedule (struct isis_area *area, int level)
       return retval;
     }
 
-  THREAD_TIMER_ON (master, area->spf_timer[level-1],
-                   isis_run_spf_cb, isis_run_spf_arg(area, level),
-                   area->min_spf_interval[level-1] - diff);
+  thread_add_timer (master, isis_run_spf_cb, isis_run_spf_arg(area, level),
+                    area->min_spf_interval[level-1] - diff,
+                    &area->spf_timer[level-1]);
 
   if (isis->debugs & DEBUG_SPF_EVENTS)
     zlog_debug ("ISIS-Spf (%s) L%d SPF scheduled %d sec from now",

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -137,7 +137,7 @@ isis_area_create (const char *area_tag)
 
   area->circuit_list = list_new ();
   area->area_addrs = list_new ();
-  THREAD_TIMER_ON (master, area->t_tick, lsp_tick, area, 1);
+  thread_add_timer(master, lsp_tick, area, 1, &area->t_tick);
   flags_initialize (&area->flags);
 
   /*

--- a/ldpd/accept.c
+++ b/ldpd/accept.c
@@ -58,7 +58,7 @@ accept_add(int fd, int (*cb)(struct thread *), void *arg)
 	av->arg = arg;
 	LIST_INSERT_HEAD(&accept_queue.queue, av, entry);
 
-	av->ev = thread_add_read(master, accept_cb, av, av->fd);
+	av->ev = thread_add_read(master, accept_cb, av, av->fd, NULL);
 
 	log_debug("%s: accepting on fd %d", __func__, fd);
 
@@ -85,7 +85,8 @@ accept_pause(void)
 {
 	log_debug(__func__);
 	accept_unarm();
-	accept_queue.evt = thread_add_timer(master, accept_timeout, NULL, 1);
+	accept_queue.evt = thread_add_timer(master, accept_timeout, NULL, 1,
+					    NULL);
 }
 
 void
@@ -103,7 +104,7 @@ accept_arm(void)
 {
 	struct accept_ev	*av;
 	LIST_FOREACH(av, &accept_queue.queue, entry)
-		av->ev = thread_add_read(master, accept_cb, av, av->fd);
+		av->ev = thread_add_read(master, accept_cb, av, av->fd, NULL);
 }
 
 static void
@@ -118,7 +119,7 @@ static int
 accept_cb(struct thread *thread)
 {
 	struct accept_ev	*av = THREAD_ARG(thread);
-	av->ev = thread_add_read(master, accept_cb, av, av->fd);
+	av->ev = thread_add_read(master, accept_cb, av, av->fd, NULL);
 	av->accept_cb(thread);
 
 	return (0);

--- a/ldpd/accept.c
+++ b/ldpd/accept.c
@@ -58,7 +58,8 @@ accept_add(int fd, int (*cb)(struct thread *), void *arg)
 	av->arg = arg;
 	LIST_INSERT_HEAD(&accept_queue.queue, av, entry);
 
-	av->ev = thread_add_read(master, accept_cb, av, av->fd, NULL);
+	av->ev = NULL;
+	thread_add_read(master, accept_cb, av, av->fd, &av->ev);
 
 	log_debug("%s: accepting on fd %d", __func__, fd);
 
@@ -85,8 +86,8 @@ accept_pause(void)
 {
 	log_debug(__func__);
 	accept_unarm();
-	accept_queue.evt = thread_add_timer(master, accept_timeout, NULL, 1,
-					    NULL);
+	accept_queue.evt = NULL;
+	thread_add_timer(master, accept_timeout, NULL, 1, &accept_queue.evt);
 }
 
 void
@@ -103,8 +104,10 @@ static void
 accept_arm(void)
 {
 	struct accept_ev	*av;
-	LIST_FOREACH(av, &accept_queue.queue, entry)
-		av->ev = thread_add_read(master, accept_cb, av, av->fd, NULL);
+	LIST_FOREACH(av, &accept_queue.queue, entry) {
+		av->ev = NULL;
+		thread_add_read(master, accept_cb, av, av->fd, &av->ev);
+	}
 }
 
 static void
@@ -119,7 +122,8 @@ static int
 accept_cb(struct thread *thread)
 {
 	struct accept_ev	*av = THREAD_ARG(thread);
-	av->ev = thread_add_read(master, accept_cb, av, av->fd, NULL);
+	av->ev = NULL;
+	thread_add_read(master, accept_cb, av, av->fd, &av->ev);
 	av->accept_cb(thread);
 
 	return (0);

--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -206,8 +206,9 @@ void
 adj_start_itimer(struct adj *adj)
 {
 	THREAD_TIMER_OFF(adj->inactivity_timer);
-	adj->inactivity_timer = thread_add_timer(master, adj_itimer, adj,
-						 adj->holdtime, NULL);
+	adj->inactivity_timer = NULL;
+	thread_add_timer(master, adj_itimer, adj, adj->holdtime,
+			 &adj->inactivity_timer);
 }
 
 void
@@ -366,9 +367,9 @@ static void
 tnbr_start_hello_timer(struct tnbr *tnbr)
 {
 	THREAD_TIMER_OFF(tnbr->hello_timer);
-	tnbr->hello_timer = thread_add_timer(master, tnbr_hello_timer, tnbr,
-					     tnbr_get_hello_interval(tnbr),
-					     NULL);
+	tnbr->hello_timer = NULL;
+	thread_add_timer(master, tnbr_hello_timer, tnbr, tnbr_get_hello_interval(tnbr),
+			 &tnbr->hello_timer);
 }
 
 static void

--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -207,7 +207,7 @@ adj_start_itimer(struct adj *adj)
 {
 	THREAD_TIMER_OFF(adj->inactivity_timer);
 	adj->inactivity_timer = thread_add_timer(master, adj_itimer, adj,
-	    adj->holdtime);
+						 adj->holdtime, NULL);
 }
 
 void
@@ -367,7 +367,8 @@ tnbr_start_hello_timer(struct tnbr *tnbr)
 {
 	THREAD_TIMER_OFF(tnbr->hello_timer);
 	tnbr->hello_timer = thread_add_timer(master, tnbr_hello_timer, tnbr,
-	    tnbr_get_hello_interval(tnbr));
+					     tnbr_get_hello_interval(tnbr),
+					     NULL);
 }
 
 static void

--- a/ldpd/control.c
+++ b/ldpd/control.c
@@ -133,8 +133,8 @@ control_accept(struct thread *thread)
 
 	imsg_init(&c->iev.ibuf, connfd);
 	c->iev.handler_read = control_dispatch_imsg;
-	c->iev.ev_read = thread_add_read(master, c->iev.handler_read,
-	    &c->iev, c->iev.ibuf.fd);
+	c->iev.ev_read = thread_add_read(master, c->iev.handler_read, &c->iev,
+					 c->iev.ibuf.fd, NULL);
 	c->iev.handler_write = ldp_write_handler;
 	c->iev.ev_write = NULL;
 

--- a/ldpd/control.c
+++ b/ldpd/control.c
@@ -133,8 +133,9 @@ control_accept(struct thread *thread)
 
 	imsg_init(&c->iev.ibuf, connfd);
 	c->iev.handler_read = control_dispatch_imsg;
-	c->iev.ev_read = thread_add_read(master, c->iev.handler_read, &c->iev,
-					 c->iev.ibuf.fd, NULL);
+	c->iev.ev_read = NULL;
+	thread_add_read(master, c->iev.handler_read, &c->iev, c->iev.ibuf.fd,
+			&c->iev.ev_read);
 	c->iev.handler_write = ldp_write_handler;
 	c->iev.ev_write = NULL;
 

--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -440,8 +440,9 @@ static void
 if_start_hello_timer(struct iface_af *ia)
 {
 	THREAD_TIMER_OFF(ia->hello_timer);
-	ia->hello_timer = thread_add_timer(master, if_hello_timer, ia,
-					   if_get_hello_interval(ia), NULL);
+	ia->hello_timer = NULL;
+	thread_add_timer(master, if_hello_timer, ia, if_get_hello_interval(ia),
+			 &ia->hello_timer);
 }
 
 static void

--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -441,7 +441,7 @@ if_start_hello_timer(struct iface_af *ia)
 {
 	THREAD_TIMER_OFF(ia->hello_timer);
 	ia->hello_timer = thread_add_timer(master, if_hello_timer, ia,
-	    if_get_hello_interval(ia));
+					   if_get_hello_interval(ia), NULL);
 }
 
 static void

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -140,8 +140,9 @@ lde(void)
 		fatal(NULL);
 	imsg_init(&iev_main->ibuf, LDPD_FD_ASYNC);
 	iev_main->handler_read = lde_dispatch_parent;
-	iev_main->ev_read = thread_add_read(master, iev_main->handler_read,
-				            iev_main, iev_main->ibuf.fd, NULL);
+	iev_main->ev_read = NULL;
+	thread_add_read(master, iev_main->handler_read, iev_main, iev_main->ibuf.fd,
+		        &iev_main->ev_read);
 	iev_main->handler_write = ldp_write_handler;
 
 	if ((iev_main_sync = calloc(1, sizeof(struct imsgev))) == NULL)
@@ -526,11 +527,9 @@ lde_dispatch_parent(struct thread *thread)
 				fatal(NULL);
 			imsg_init(&iev_ldpe->ibuf, fd);
 			iev_ldpe->handler_read = lde_dispatch_imsg;
-			iev_ldpe->ev_read = thread_add_read(master,
-							    iev_ldpe->handler_read,
-							    iev_ldpe,
-							    iev_ldpe->ibuf.fd,
-							    NULL);
+			iev_ldpe->ev_read = NULL;
+			thread_add_read(master, iev_ldpe->handler_read, iev_ldpe, iev_ldpe->ibuf.fd,
+					&iev_ldpe->ev_read);
 			iev_ldpe->handler_write = ldp_write_handler;
 			iev_ldpe->ev_write = NULL;
 			break;

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -141,7 +141,7 @@ lde(void)
 	imsg_init(&iev_main->ibuf, LDPD_FD_ASYNC);
 	iev_main->handler_read = lde_dispatch_parent;
 	iev_main->ev_read = thread_add_read(master, iev_main->handler_read,
-	    iev_main, iev_main->ibuf.fd);
+				            iev_main, iev_main->ibuf.fd, NULL);
 	iev_main->handler_write = ldp_write_handler;
 
 	if ((iev_main_sync = calloc(1, sizeof(struct imsgev))) == NULL)
@@ -527,7 +527,10 @@ lde_dispatch_parent(struct thread *thread)
 			imsg_init(&iev_ldpe->ibuf, fd);
 			iev_ldpe->handler_read = lde_dispatch_imsg;
 			iev_ldpe->ev_read = thread_add_read(master,
-			    iev_ldpe->handler_read, iev_ldpe, iev_ldpe->ibuf.fd);
+							    iev_ldpe->handler_read,
+							    iev_ldpe,
+							    iev_ldpe->ibuf.fd,
+							    NULL);
 			iev_ldpe->handler_write = ldp_write_handler;
 			iev_ldpe->ev_write = NULL;
 			break;

--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -933,7 +933,7 @@ lde_gc_start_timer(void)
 {
 	THREAD_TIMER_OFF(gc_timer);
 	gc_timer = thread_add_timer(master, lde_gc_timer, NULL,
-	    LDE_GC_INTERVAL);
+				    LDE_GC_INTERVAL, NULL);
 }
 
 void

--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -932,8 +932,9 @@ void
 lde_gc_start_timer(void)
 {
 	THREAD_TIMER_OFF(gc_timer);
-	gc_timer = thread_add_timer(master, lde_gc_timer, NULL,
-				    LDE_GC_INTERVAL, NULL);
+	gc_timer = NULL;
+	thread_add_timer(master, lde_gc_timer, NULL, LDE_GC_INTERVAL,
+			 &gc_timer);
 }
 
 void

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -359,25 +359,29 @@ main(int argc, char *argv[])
 	imsg_init(&iev_ldpe->ibuf, pipe_parent2ldpe[0]);
 	iev_ldpe->handler_read = main_dispatch_ldpe;
 	iev_ldpe->ev_read = thread_add_read(master, iev_ldpe->handler_read,
-	    iev_ldpe, iev_ldpe->ibuf.fd);
+					    iev_ldpe, iev_ldpe->ibuf.fd, NULL);
 	iev_ldpe->handler_write = ldp_write_handler;
 
 	imsg_init(&iev_ldpe_sync->ibuf, pipe_parent2ldpe_sync[0]);
 	iev_ldpe_sync->handler_read = main_dispatch_ldpe;
 	iev_ldpe_sync->ev_read = thread_add_read(master,
-	    iev_ldpe_sync->handler_read, iev_ldpe_sync, iev_ldpe_sync->ibuf.fd);
+						 iev_ldpe_sync->handler_read,
+						 iev_ldpe_sync,
+						 iev_ldpe_sync->ibuf.fd, NULL);
 	iev_ldpe_sync->handler_write = ldp_write_handler;
 
 	imsg_init(&iev_lde->ibuf, pipe_parent2lde[0]);
 	iev_lde->handler_read = main_dispatch_lde;
 	iev_lde->ev_read = thread_add_read(master, iev_lde->handler_read,
-	    iev_lde, iev_lde->ibuf.fd);
+					   iev_lde, iev_lde->ibuf.fd, NULL);
 	iev_lde->handler_write = ldp_write_handler;
 
 	imsg_init(&iev_lde_sync->ibuf, pipe_parent2lde_sync[0]);
 	iev_lde_sync->handler_read = main_dispatch_lde;
 	iev_lde_sync->ev_read = thread_add_read(master,
-	    iev_lde_sync->handler_read, iev_lde_sync, iev_lde_sync->ibuf.fd);
+						iev_lde_sync->handler_read,
+						iev_lde_sync,
+						iev_lde_sync->ibuf.fd, NULL);
 	iev_lde_sync->handler_write = ldp_write_handler;
 
 	if (main_imsg_send_ipc_sockets(&iev_ldpe->ibuf, &iev_lde->ibuf))
@@ -690,12 +694,12 @@ void
 imsg_event_add(struct imsgev *iev)
 {
 	if (iev->handler_read)
-		THREAD_READ_ON(master, iev->ev_read, iev->handler_read, iev,
-		    iev->ibuf.fd);
+		thread_add_read(master, iev->handler_read, iev, iev->ibuf.fd,
+				&iev->ev_read);
 
 	if (iev->handler_write && iev->ibuf.w.queued)
-		THREAD_WRITE_ON(master, iev->ev_write, iev->handler_write, iev,
-		    iev->ibuf.fd);
+		thread_add_write(master, iev->handler_write, iev,
+				 iev->ibuf.fd, &iev->ev_write);
 }
 
 int
@@ -721,8 +725,8 @@ void
 evbuf_event_add(struct evbuf *eb)
 {
 	if (eb->wbuf.queued)
-		THREAD_WRITE_ON(master, eb->ev, eb->handler, eb->arg,
-		    eb->wbuf.fd);
+		thread_add_write(master, eb->handler, eb->arg, eb->wbuf.fd,
+				 &eb->ev);
 }
 
 void

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -358,30 +358,30 @@ main(int argc, char *argv[])
 		fatal(NULL);
 	imsg_init(&iev_ldpe->ibuf, pipe_parent2ldpe[0]);
 	iev_ldpe->handler_read = main_dispatch_ldpe;
-	iev_ldpe->ev_read = thread_add_read(master, iev_ldpe->handler_read,
-					    iev_ldpe, iev_ldpe->ibuf.fd, NULL);
+	iev_ldpe->ev_read = NULL;
+	thread_add_read(master, iev_ldpe->handler_read, iev_ldpe, iev_ldpe->ibuf.fd,
+			&iev_ldpe->ev_read);
 	iev_ldpe->handler_write = ldp_write_handler;
 
 	imsg_init(&iev_ldpe_sync->ibuf, pipe_parent2ldpe_sync[0]);
 	iev_ldpe_sync->handler_read = main_dispatch_ldpe;
-	iev_ldpe_sync->ev_read = thread_add_read(master,
-						 iev_ldpe_sync->handler_read,
-						 iev_ldpe_sync,
-						 iev_ldpe_sync->ibuf.fd, NULL);
+	iev_ldpe_sync->ev_read = NULL;
+	thread_add_read(master, iev_ldpe_sync->handler_read, iev_ldpe_sync, iev_ldpe_sync->ibuf.fd,
+			&iev_ldpe_sync->ev_read);
 	iev_ldpe_sync->handler_write = ldp_write_handler;
 
 	imsg_init(&iev_lde->ibuf, pipe_parent2lde[0]);
 	iev_lde->handler_read = main_dispatch_lde;
-	iev_lde->ev_read = thread_add_read(master, iev_lde->handler_read,
-					   iev_lde, iev_lde->ibuf.fd, NULL);
+	iev_lde->ev_read = NULL;
+	thread_add_read(master, iev_lde->handler_read, iev_lde, iev_lde->ibuf.fd,
+			&iev_lde->ev_read);
 	iev_lde->handler_write = ldp_write_handler;
 
 	imsg_init(&iev_lde_sync->ibuf, pipe_parent2lde_sync[0]);
 	iev_lde_sync->handler_read = main_dispatch_lde;
-	iev_lde_sync->ev_read = thread_add_read(master,
-						iev_lde_sync->handler_read,
-						iev_lde_sync,
-						iev_lde_sync->ibuf.fd, NULL);
+	iev_lde_sync->ev_read = NULL;
+	thread_add_read(master, iev_lde_sync->handler_read, iev_lde_sync, iev_lde_sync->ibuf.fd,
+			&iev_lde_sync->ev_read);
 	iev_lde_sync->handler_write = ldp_write_handler;
 
 	if (main_imsg_send_ipc_sockets(&iev_ldpe->ibuf, &iev_lde->ibuf))

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -120,7 +120,7 @@ ldpe(void)
 	imsg_init(&iev_main->ibuf, LDPD_FD_ASYNC);
 	iev_main->handler_read = ldpe_dispatch_main;
 	iev_main->ev_read = thread_add_read(master, iev_main->handler_read,
-	    iev_main, iev_main->ibuf.fd);
+				            iev_main, iev_main->ibuf.fd, NULL);
 	iev_main->handler_write = ldp_write_handler;
 
 	if ((iev_main_sync = calloc(1, sizeof(struct imsgev))) == NULL)
@@ -165,8 +165,8 @@ ldpe_init(struct ldpd_init *init)
 #ifdef __OpenBSD__
 	global.pfkeysock = pfkey_init();
 	if (sysdep.no_pfkey == 0)
-		pfkey_ev = thread_add_read(master, ldpe_dispatch_pfkey,
-		    NULL, global.pfkeysock);
+		pfkey_ev = thread_add_read(master, ldpe_dispatch_pfkey, NULL,
+				           global.pfkeysock, NULL);
 #endif
 
 	/* mark sockets as closed */
@@ -354,7 +354,10 @@ ldpe_dispatch_main(struct thread *thread)
 			imsg_init(&iev_lde->ibuf, fd);
 			iev_lde->handler_read = ldpe_dispatch_lde;
 			iev_lde->ev_read = thread_add_read(master,
-			    iev_lde->handler_read, iev_lde, iev_lde->ibuf.fd);
+							   iev_lde->handler_read,
+							   iev_lde,
+							   iev_lde->ibuf.fd,
+							   NULL);
 			iev_lde->handler_write = ldp_write_handler;
 			iev_lde->ev_write = NULL;
 			break;
@@ -694,8 +697,8 @@ ldpe_dispatch_pfkey(struct thread *thread)
 {
 	int	 fd = THREAD_FD(thread);
 
-	pfkey_ev = thread_add_read(master, ldpe_dispatch_pfkey,
-	    NULL, global.pfkeysock);
+	pfkey_ev = thread_add_read(master, ldpe_dispatch_pfkey, NULL,
+				   global.pfkeysock, NULL);
 
 	if (pfkey_read(fd, NULL) == -1)
 		fatal("pfkey_read failed, exiting...");
@@ -715,12 +718,15 @@ ldpe_setup_sockets(int af, int disc_socket, int edisc_socket,
 	/* discovery socket */
 	af_global->ldp_disc_socket = disc_socket;
 	af_global->disc_ev = thread_add_read(master, disc_recv_packet,
-	    &af_global->disc_ev, af_global->ldp_disc_socket);
+					     &af_global->disc_ev,
+					     af_global->ldp_disc_socket, NULL);
 
 	/* extended discovery socket */
 	af_global->ldp_edisc_socket = edisc_socket;
 	af_global->edisc_ev = thread_add_read(master, disc_recv_packet,
-	    &af_global->edisc_ev, af_global->ldp_edisc_socket);
+					      &af_global->edisc_ev,
+					      af_global->ldp_edisc_socket,
+					      NULL);
 
 	/* session socket */
 	af_global->ldp_session_socket = session_socket;

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -408,8 +408,8 @@ nbr_start_ktimer(struct nbr *nbr)
 	/* send three keepalives per period */
 	secs = nbr->keepalive / KEEPALIVE_PER_PERIOD;
 	THREAD_TIMER_OFF(nbr->keepalive_timer);
-	nbr->keepalive_timer = thread_add_timer(master, nbr_ktimer, nbr, secs,
-						NULL);
+	nbr->keepalive_timer = NULL;
+	thread_add_timer(master, nbr_ktimer, nbr, secs, &nbr->keepalive_timer);
 }
 
 void
@@ -438,8 +438,9 @@ static void
 nbr_start_ktimeout(struct nbr *nbr)
 {
 	THREAD_TIMER_OFF(nbr->keepalive_timeout);
-	nbr->keepalive_timeout = thread_add_timer(master, nbr_ktimeout, nbr,
-						  nbr->keepalive, NULL);
+	nbr->keepalive_timeout = NULL;
+	thread_add_timer(master, nbr_ktimeout, nbr, nbr->keepalive,
+			 &nbr->keepalive_timeout);
 }
 
 void
@@ -469,8 +470,8 @@ nbr_start_itimeout(struct nbr *nbr)
 
 	secs = INIT_FSM_TIMEOUT;
 	THREAD_TIMER_OFF(nbr->init_timeout);
-	nbr->init_timeout = thread_add_timer(master, nbr_itimeout, nbr, secs,
-					     NULL);
+	nbr->init_timeout = NULL;
+	thread_add_timer(master, nbr_itimeout, nbr, secs, &nbr->init_timeout);
 }
 
 void
@@ -518,8 +519,9 @@ nbr_start_idtimer(struct nbr *nbr)
 	}
 
 	THREAD_TIMER_OFF(nbr->initdelay_timer);
-	nbr->initdelay_timer = thread_add_timer(master, nbr_idtimer, nbr,
-						secs, NULL);
+	nbr->initdelay_timer = NULL;
+	thread_add_timer(master, nbr_idtimer, nbr, secs,
+			 &nbr->initdelay_timer);
 }
 
 void

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -408,7 +408,8 @@ nbr_start_ktimer(struct nbr *nbr)
 	/* send three keepalives per period */
 	secs = nbr->keepalive / KEEPALIVE_PER_PERIOD;
 	THREAD_TIMER_OFF(nbr->keepalive_timer);
-	nbr->keepalive_timer = thread_add_timer(master, nbr_ktimer, nbr, secs);
+	nbr->keepalive_timer = thread_add_timer(master, nbr_ktimer, nbr, secs,
+						NULL);
 }
 
 void
@@ -438,7 +439,7 @@ nbr_start_ktimeout(struct nbr *nbr)
 {
 	THREAD_TIMER_OFF(nbr->keepalive_timeout);
 	nbr->keepalive_timeout = thread_add_timer(master, nbr_ktimeout, nbr,
-	    nbr->keepalive);
+						  nbr->keepalive, NULL);
 }
 
 void
@@ -468,7 +469,8 @@ nbr_start_itimeout(struct nbr *nbr)
 
 	secs = INIT_FSM_TIMEOUT;
 	THREAD_TIMER_OFF(nbr->init_timeout);
-	nbr->init_timeout = thread_add_timer(master, nbr_itimeout, nbr, secs);
+	nbr->init_timeout = thread_add_timer(master, nbr_itimeout, nbr, secs,
+					     NULL);
 }
 
 void
@@ -516,7 +518,8 @@ nbr_start_idtimer(struct nbr *nbr)
 	}
 
 	THREAD_TIMER_OFF(nbr->initdelay_timer);
-	nbr->initdelay_timer = thread_add_timer(master, nbr_idtimer, nbr, secs);
+	nbr->initdelay_timer = thread_add_timer(master, nbr_idtimer, nbr,
+						secs, NULL);
 }
 
 void
@@ -633,8 +636,8 @@ nbr_establish_connection(struct nbr *nbr)
 	if (connect(nbr->fd, (struct sockaddr *)&remote_sa,
 	    sockaddr_len((struct sockaddr *)&remote_sa)) == -1) {
 		if (errno == EINPROGRESS) {
-			THREAD_WRITE_ON(master, nbr->ev_connect, nbr_connect_cb,
-			    nbr, nbr->fd);
+			thread_add_write(master, nbr_connect_cb, nbr, nbr->fd,
+					 &nbr->ev_connect);
 			return (0);
 		}
 		log_warn("%s: error while connecting to %s", __func__,

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -143,8 +143,8 @@ disc_recv_packet(struct thread *thread)
 	struct in_addr		 lsr_id;
 
 	/* reschedule read */
-	*threadp = thread_add_read(master, disc_recv_packet, threadp, fd,
-				   NULL);
+	*threadp = NULL;
+	thread_add_read(master, disc_recv_packet, threadp, fd, &*threadp);
 
 	/* setup buffer */
 	memset(&m, 0, sizeof(m));
@@ -428,7 +428,8 @@ session_read(struct thread *thread)
 	uint16_t	 pdu_len, msg_len, msg_size, max_pdu_len;
 	int		 ret;
 
-	tcp->rev = thread_add_read(master, session_read, nbr, fd, NULL);
+	tcp->rev = NULL;
+	thread_add_read(master, session_read, nbr, fd, &tcp->rev);
 
 	if ((n = read(fd, tcp->rbuf->buf + tcp->rbuf->wpos,
 	    sizeof(tcp->rbuf->buf) - tcp->rbuf->wpos)) == -1) {
@@ -732,8 +733,8 @@ tcp_new(int fd, struct nbr *nbr)
 		if ((tcp->rbuf = calloc(1, sizeof(struct ibuf_read))) == NULL)
 			fatal(__func__);
 
-		tcp->rev = thread_add_read(master, session_read, nbr, tcp->fd,
-					   NULL);
+		tcp->rev = NULL;
+		thread_add_read(master, session_read, nbr, tcp->fd, &tcp->rev);
 		tcp->nbr = nbr;
 	}
 
@@ -779,9 +780,9 @@ pending_conn_new(int fd, int af, union ldpd_addr *addr)
 	pconn->af = af;
 	pconn->addr = *addr;
 	TAILQ_INSERT_TAIL(&global.pending_conns, pconn, entry);
-	pconn->ev_timeout = thread_add_timer(master, pending_conn_timeout,
-					     pconn, PENDING_CONN_TIMEOUT,
-					     NULL);
+	pconn->ev_timeout = NULL;
+	thread_add_timer(master, pending_conn_timeout, pconn, PENDING_CONN_TIMEOUT,
+			 &pconn->ev_timeout);
 
 	return (pconn);
 }

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -143,7 +143,8 @@ disc_recv_packet(struct thread *thread)
 	struct in_addr		 lsr_id;
 
 	/* reschedule read */
-	*threadp = thread_add_read(master, disc_recv_packet, threadp, fd);
+	*threadp = thread_add_read(master, disc_recv_packet, threadp, fd,
+				   NULL);
 
 	/* setup buffer */
 	memset(&m, 0, sizeof(m));
@@ -427,7 +428,7 @@ session_read(struct thread *thread)
 	uint16_t	 pdu_len, msg_len, msg_size, max_pdu_len;
 	int		 ret;
 
-	tcp->rev = thread_add_read(master, session_read, nbr, fd);
+	tcp->rev = thread_add_read(master, session_read, nbr, fd, NULL);
 
 	if ((n = read(fd, tcp->rbuf->buf + tcp->rbuf->wpos,
 	    sizeof(tcp->rbuf->buf) - tcp->rbuf->wpos)) == -1) {
@@ -731,7 +732,8 @@ tcp_new(int fd, struct nbr *nbr)
 		if ((tcp->rbuf = calloc(1, sizeof(struct ibuf_read))) == NULL)
 			fatal(__func__);
 
-		tcp->rev = thread_add_read(master, session_read, nbr, tcp->fd);
+		tcp->rev = thread_add_read(master, session_read, nbr, tcp->fd,
+					   NULL);
 		tcp->nbr = nbr;
 	}
 
@@ -778,7 +780,8 @@ pending_conn_new(int fd, int af, union ldpd_addr *addr)
 	pconn->addr = *addr;
 	TAILQ_INSERT_TAIL(&global.pending_conns, pconn, entry);
 	pconn->ev_timeout = thread_add_timer(master, pending_conn_timeout,
-	    pconn, PENDING_CONN_TIMEOUT);
+					     pconn, PENDING_CONN_TIMEOUT,
+					     NULL);
 
 	return (pconn);
 }

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -85,9 +85,11 @@ agentx_events_update(void)
   FD_ZERO (&fds);
   snmp_select_info (&maxfd, &fds, &timeout, &block);
 
-  if (!block)
-    timeout_thr = thread_add_timer_tv(agentx_tm, agentx_timeout, NULL,
-                                      &timeout, NULL);
+  if (!block) {
+    timeout_thr = NULL;
+    thread_add_timer_tv(agentx_tm, agentx_timeout, NULL, &timeout,
+                        &timeout_thr);
+  }
 
   ln = listhead (events);
   thr = ln ? listgetdata (ln) : NULL;
@@ -115,7 +117,8 @@ agentx_events_update(void)
       else if (FD_ISSET (fd, &fds))
         {
           struct listnode *newln;
-          thr = thread_add_read(agentx_tm, agentx_read, NULL, fd, NULL);
+          thr = NULL;
+          thread_add_read(agentx_tm, agentx_read, NULL, fd, &thr);
           newln = listnode_add_before (events, ln, thr);
           thr->arg = newln;
         }

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -86,7 +86,8 @@ agentx_events_update(void)
   snmp_select_info (&maxfd, &fds, &timeout, &block);
 
   if (!block)
-    timeout_thr = thread_add_timer_tv (agentx_tm, agentx_timeout, NULL, &timeout);
+    timeout_thr = thread_add_timer_tv(agentx_tm, agentx_timeout, NULL,
+                                      &timeout, NULL);
 
   ln = listhead (events);
   thr = ln ? listgetdata (ln) : NULL;
@@ -114,7 +115,7 @@ agentx_events_update(void)
       else if (FD_ISSET (fd, &fds))
         {
           struct listnode *newln;
-          thr = thread_add_read (agentx_tm, agentx_read, NULL, fd);
+          thr = thread_add_read(agentx_tm, agentx_read, NULL, fd, NULL);
           newln = listnode_add_before (events, ln, thr);
           thr->arg = newln;
         }

--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -132,8 +132,8 @@ quagga_signal_timer (struct thread *t)
   int i;
 
   sigm = THREAD_ARG (t);
-  sigm->t = thread_add_timer (sigm->t->master, quagga_signal_timer, &sigmaster,
-                              QUAGGA_SIGNAL_TIMER_INTERVAL);
+  sigm->t = thread_add_timer(sigm->t->master, quagga_signal_timer, &sigmaster,
+                             QUAGGA_SIGNAL_TIMER_INTERVAL, NULL);
   return quagga_sigevent_process ();
 }
 #endif /* SIGEVENT_SCHEDULE_THREAD */
@@ -379,7 +379,7 @@ signal_init (struct thread_master *m, int sigc,
 
 #ifdef SIGEVENT_SCHEDULE_THREAD  
   sigmaster.t = 
-    thread_add_timer (m, quagga_signal_timer, &sigmaster, 
-                      QUAGGA_SIGNAL_TIMER_INTERVAL);
+    thread_add_timer(m, quagga_signal_timer, &sigmaster,
+                     QUAGGA_SIGNAL_TIMER_INTERVAL, NULL);
 #endif /* SIGEVENT_SCHEDULE_THREAD */
 }

--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -132,8 +132,9 @@ quagga_signal_timer (struct thread *t)
   int i;
 
   sigm = THREAD_ARG (t);
-  sigm->t = thread_add_timer(sigm->t->master, quagga_signal_timer, &sigmaster,
-                             QUAGGA_SIGNAL_TIMER_INTERVAL, NULL);
+  sigm->t = NULL;
+  thread_add_timer(sigm->t->master, quagga_signal_timer, &sigmaster, QUAGGA_SIGNAL_TIMER_INTERVAL,
+                   &sigm->t);
   return quagga_sigevent_process ();
 }
 #endif /* SIGEVENT_SCHEDULE_THREAD */
@@ -378,8 +379,8 @@ signal_init (struct thread_master *m, int sigc,
   sigmaster.signals = signals;
 
 #ifdef SIGEVENT_SCHEDULE_THREAD  
-  sigmaster.t = 
-    thread_add_timer(m, quagga_signal_timer, &sigmaster,
-                     QUAGGA_SIGNAL_TIMER_INTERVAL, NULL);
+  sigmaster.t = NULL;
+  thread_add_timer(m, quagga_signal_timer, &sigmaster, QUAGGA_SIGNAL_TIMER_INTERVAL,
+                   &sigmaster.t);
 #endif /* SIGEVENT_SCHEDULE_THREAD */
 }

--- a/lib/smux.c
+++ b/lib/smux.c
@@ -1197,16 +1197,18 @@ smux_event (enum smux_event event, int sock)
   switch (event)
     {
     case SMUX_SCHEDULE:
-      smux_connect_thread = thread_add_event(smux_master, smux_connect, NULL,
-                                             0, NULL);
+      smux_connect_thread = NULL;
+      thread_add_event(smux_master, smux_connect, NULL, 0,
+                       &smux_connect_thread);
       break;
     case SMUX_CONNECT:
-      smux_connect_thread = thread_add_timer(smux_master, smux_connect, NULL,
-                                             10, NULL);
+      smux_connect_thread = NULL;
+      thread_add_timer(smux_master, smux_connect, NULL, 10,
+                       &smux_connect_thread);
       break;
     case SMUX_READ:
-      smux_read_thread = thread_add_read(smux_master, smux_read, NULL, sock,
-                                         NULL);
+      smux_read_thread = NULL;
+      thread_add_read(smux_master, smux_read, NULL, sock, &smux_read_thread);
       break;
     default:
       break;

--- a/lib/smux.c
+++ b/lib/smux.c
@@ -1197,13 +1197,16 @@ smux_event (enum smux_event event, int sock)
   switch (event)
     {
     case SMUX_SCHEDULE:
-      smux_connect_thread = thread_add_event (smux_master, smux_connect, NULL, 0);
+      smux_connect_thread = thread_add_event(smux_master, smux_connect, NULL,
+                                             0, NULL);
       break;
     case SMUX_CONNECT:
-      smux_connect_thread = thread_add_timer (smux_master, smux_connect, NULL, 10);
+      smux_connect_thread = thread_add_timer(smux_master, smux_connect, NULL,
+                                             10, NULL);
       break;
     case SMUX_READ:
-      smux_read_thread = thread_add_read (smux_master, smux_read, NULL, sock);
+      smux_read_thread = thread_add_read(smux_master, smux_read, NULL, sock,
+                                         NULL);
       break;
     default:
       break;

--- a/lib/spf_backoff.c
+++ b/lib/spf_backoff.c
@@ -169,21 +169,19 @@ long spf_backoff_schedule(struct spf_backoff *backoff)
     {
     case SPF_BACKOFF_QUIET:
       backoff->state = SPF_BACKOFF_SHORT_WAIT;
-      THREAD_TIMER_MSEC_ON(backoff->m, backoff->t_timetolearn,
-                           spf_backoff_timetolearn_elapsed, backoff,
-                           backoff->timetolearn);
-      THREAD_TIMER_MSEC_ON(backoff->m, backoff->t_holddown,
-                           spf_backoff_holddown_elapsed, backoff,
-                           backoff->holddown);
+      thread_add_timer_msec(backoff->m, spf_backoff_timetolearn_elapsed,
+                            backoff, backoff->timetolearn,
+                            &backoff->t_timetolearn);
+      thread_add_timer_msec(backoff->m, spf_backoff_holddown_elapsed, backoff,
+                            backoff->holddown, &backoff->t_holddown);
       backoff->first_event_time = now;
       rv = backoff->init_delay;
       break;
     case SPF_BACKOFF_SHORT_WAIT:
     case SPF_BACKOFF_LONG_WAIT:
       THREAD_TIMER_OFF(backoff->t_holddown);
-      THREAD_TIMER_MSEC_ON(backoff->m, backoff->t_holddown,
-                           spf_backoff_holddown_elapsed, backoff,
-                           backoff->holddown);
+      thread_add_timer_msec(backoff->m, spf_backoff_holddown_elapsed, backoff,
+                            backoff->holddown, &backoff->t_holddown);
       if (backoff->state == SPF_BACKOFF_SHORT_WAIT)
         rv = backoff->short_delay;
       else

--- a/lib/systemd.c
+++ b/lib/systemd.c
@@ -104,7 +104,7 @@ systemd_send_watchdog (struct thread *t)
 {
   systemd_send_information ("WATCHDOG=1");
 
-  thread_add_timer (systemd_master, systemd_send_watchdog, NULL, wsecs);
+  thread_add_timer(systemd_master, systemd_send_watchdog, NULL, wsecs, NULL);
 
   return 1;
 }
@@ -119,5 +119,5 @@ systemd_send_started (struct thread_master *m, int the_process)
 
   systemd_send_information ("READY=1");
   if (wsecs != 0)
-    thread_add_timer (m, systemd_send_watchdog, m, wsecs);
+    thread_add_timer(m, systemd_send_watchdog, m, wsecs, NULL);
 }

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -153,30 +153,6 @@ struct cpu_thread_history
 #define THREAD_FD(X)  ((X)->u.fd)
 #define THREAD_VAL(X) ((X)->u.val)
 
-#define THREAD_READ_ON(master,thread,func,arg,sock) \
-  do { \
-    if (! thread) \
-      thread = thread_add_read (master, func, arg, sock); \
-  } while (0)
-
-#define THREAD_WRITE_ON(master,thread,func,arg,sock) \
-  do { \
-    if (! thread) \
-      thread = thread_add_write (master, func, arg, sock); \
-  } while (0)
-
-#define THREAD_TIMER_ON(master,thread,func,arg,time) \
-  do { \
-    if (! thread) \
-      thread = thread_add_timer (master, func, arg, time); \
-  } while (0)
-
-#define THREAD_TIMER_MSEC_ON(master,thread,func,arg,time) \
-  do { \
-    if (! thread) \
-      thread = thread_add_timer_msec (master, func, arg, time); \
-  } while (0)
-
 #define THREAD_OFF(thread) \
   do { \
     if (thread) \
@@ -192,16 +168,16 @@ struct cpu_thread_history
 
 #define debugargdef  const char *funcname, const char *schedfrom, int fromln
 
-#define thread_add_read(m,f,a,v) funcname_thread_add_read_write(THREAD_READ,m,f,a,v,#f,__FILE__,__LINE__)
-#define thread_add_write(m,f,a,v) funcname_thread_add_read_write(THREAD_WRITE,m,f,a,v,#f,__FILE__,__LINE__)
-#define thread_add_timer(m,f,a,v) funcname_thread_add_timer(m,f,a,v,#f,__FILE__,__LINE__)
-#define thread_add_timer_msec(m,f,a,v) funcname_thread_add_timer_msec(m,f,a,v,#f,__FILE__,__LINE__)
-#define thread_add_timer_tv(m,f,a,v) funcname_thread_add_timer_tv(m,f,a,v,#f,__FILE__,__LINE__)
-#define thread_add_event(m,f,a,v) funcname_thread_add_event(m,f,a,v,#f,__FILE__,__LINE__)
+#define thread_add_read(m,f,a,v,t) funcname_thread_add_read_write(THREAD_READ,m,f,a,v,t,#f,__FILE__,__LINE__)
+#define thread_add_write(m,f,a,v,t) funcname_thread_add_read_write(THREAD_WRITE,m,f,a,v,t,#f,__FILE__,__LINE__)
+#define thread_add_timer(m,f,a,v,t) funcname_thread_add_timer(m,f,a,v,t,#f,__FILE__,__LINE__)
+#define thread_add_timer_msec(m,f,a,v,t) funcname_thread_add_timer_msec(m,f,a,v,t,#f,__FILE__,__LINE__)
+#define thread_add_timer_tv(m,f,a,v,t) funcname_thread_add_timer_tv(m,f,a,v,t,#f,__FILE__,__LINE__)
+#define thread_add_event(m,f,a,v,t) funcname_thread_add_event(m,f,a,v,t,#f,__FILE__,__LINE__)
 #define thread_execute(m,f,a,v) funcname_thread_execute(m,f,a,v,#f,__FILE__,__LINE__)
 
 /* The 4th arg to thread_add_background is the # of milliseconds to delay. */
-#define thread_add_background(m,f,a,v) funcname_thread_add_background(m,f,a,v,#f,__FILE__,__LINE__)
+#define thread_add_background(m,f,a,v,t) funcname_thread_add_background(m,f,a,v,t,#f,__FILE__,__LINE__)
 
 /* Prototypes. */
 extern struct thread_master *thread_master_create (void);
@@ -209,29 +185,26 @@ extern void thread_master_free (struct thread_master *);
 extern void thread_master_free_unused(struct thread_master *);
 
 extern struct thread *funcname_thread_add_read_write (int dir, struct thread_master *,
-				                int (*)(struct thread *),
-				                void *, int, debugargdef);
+    int (*)(struct thread *), void *, int, struct thread **, debugargdef);
+
 extern struct thread *funcname_thread_add_timer (struct thread_master *,
-				                 int (*)(struct thread *),
-				                 void *, long, debugargdef);
+    int (*)(struct thread *), void *, long, struct thread **, debugargdef);
+
 extern struct thread *funcname_thread_add_timer_msec (struct thread_master *,
-				                      int (*)(struct thread *),
-				                      void *, long, debugargdef);
+    int (*)(struct thread *), void *, long, struct thread **, debugargdef);
+
 extern struct thread *funcname_thread_add_timer_tv (struct thread_master *,
-				                    int (*)(struct thread *),
-				                    void *, struct timeval *,
-						    debugargdef);
+    int (*)(struct thread *), void *, struct timeval *, struct thread **, debugargdef);
+
 extern struct thread *funcname_thread_add_event (struct thread_master *,
-				                 int (*)(struct thread *),
-				                 void *, int, debugargdef);
+    int (*)(struct thread *), void *, int, struct thread **, debugargdef);
+
 extern struct thread *funcname_thread_add_background (struct thread_master *,
-                                               int (*func)(struct thread *),
-				               void *arg,
-				               long milliseconds_to_delay,
-					       debugargdef);
+    int (*func)(struct thread *), void *arg, long milliseconds_to_delay,
+    struct thread **, debugargdef);
+
 extern struct thread *funcname_thread_execute (struct thread_master *,
-                                               int (*)(struct thread *),
-                                               void *, int, debugargdef);
+    int (*)(struct thread *), void *, int, debugargdef);
 #undef debugargdef
 
 extern void thread_cancel (struct thread *);

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -96,26 +96,27 @@ typedef unsigned char thread_type;
 /* Thread itself. */
 struct thread
 {
-  thread_type type;		/* thread type */
-  thread_type add_type;		/* thread type */
-  struct thread *next;		/* next pointer of the thread */   
-  struct thread *prev;		/* previous pointer of the thread */
-  struct thread_master *master;	/* pointer to the struct thread_master. */
-  int (*func) (struct thread *); /* event function */
-  void *arg;			/* event argument */
+  thread_type type;                 /* thread type */
+  thread_type add_type;             /* thread type */
+  struct thread *next;              /* next pointer of the thread */
+  struct thread *prev;              /* previous pointer of the thread */
+  struct thread **ref;              /* external reference (if given) */
+  struct thread_master *master;     /* pointer to the struct thread_master */
+  int (*func) (struct thread *);    /* event function */
+  void *arg;                        /* event argument */
   union {
-    int val;			/* second argument of the event. */
-    int fd;			/* file descriptor in case of read/write. */
-    struct timeval sands;	/* rest of time sands value. */
+    int val;                        /* second argument of the event. */
+    int fd;                         /* file descriptor in case of r/w */
+    struct timeval sands;           /* rest of time sands value. */
   } u;
-  int index;			/* used for timers to store position in queue */
+  int index;                        /* queue position for timers */
   struct timeval real;
-  struct cpu_thread_history *hist; /* cache pointer to cpu_history */
-  unsigned long yield; /* yield time in us */
-  const char *funcname;
-  const char *schedfrom;
-  int schedfrom_line;
-  pthread_mutex_t mtx;
+  struct cpu_thread_history *hist;  /* cache pointer to cpu_history */
+  unsigned long yield;              /* yield time in microseconds */
+  const char *funcname;             /* name of thread function */
+  const char *schedfrom;            /* source file thread was scheduled from */
+  int schedfrom_line;               /* line number of source file */
+  pthread_mutex_t mtx;              /* mutex for thread.c functions */
 };
 
 struct cpu_thread_history 
@@ -184,26 +185,25 @@ extern struct thread_master *thread_master_create (void);
 extern void thread_master_free (struct thread_master *);
 extern void thread_master_free_unused(struct thread_master *);
 
-extern struct thread *funcname_thread_add_read_write (int dir, struct thread_master *,
+extern void funcname_thread_add_read_write (int dir, struct thread_master *,
     int (*)(struct thread *), void *, int, struct thread **, debugargdef);
 
-extern struct thread *funcname_thread_add_timer (struct thread_master *,
+extern void funcname_thread_add_timer (struct thread_master *,
     int (*)(struct thread *), void *, long, struct thread **, debugargdef);
 
-extern struct thread *funcname_thread_add_timer_msec (struct thread_master *,
+extern void funcname_thread_add_timer_msec (struct thread_master *,
     int (*)(struct thread *), void *, long, struct thread **, debugargdef);
 
-extern struct thread *funcname_thread_add_timer_tv (struct thread_master *,
+extern void funcname_thread_add_timer_tv (struct thread_master *,
     int (*)(struct thread *), void *, struct timeval *, struct thread **, debugargdef);
 
-extern struct thread *funcname_thread_add_event (struct thread_master *,
+extern void funcname_thread_add_event (struct thread_master *,
     int (*)(struct thread *), void *, int, struct thread **, debugargdef);
 
-extern struct thread *funcname_thread_add_background (struct thread_master *,
-    int (*func)(struct thread *), void *arg, long milliseconds_to_delay,
-    struct thread **, debugargdef);
+extern void funcname_thread_add_background (struct thread_master *,
+    int (*)(struct thread *), void *, long, struct thread **, debugargdef);
 
-extern struct thread *funcname_thread_execute (struct thread_master *,
+extern void funcname_thread_execute (struct thread_master *,
     int (*)(struct thread *), void *, int, debugargdef);
 #undef debugargdef
 

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2618,35 +2618,37 @@ vty_event (enum event event, int sock, struct vty *vty)
   switch (event)
     {
     case VTY_SERV:
-      vty_serv_thread = thread_add_read(vty_master, vty_accept, vty, sock,
-                                        NULL);
+      vty_serv_thread = NULL;
+      thread_add_read(vty_master, vty_accept, vty, sock, &vty_serv_thread);
       vector_set_index (Vvty_serv_thread, sock, vty_serv_thread);
       break;
 #ifdef VTYSH
     case VTYSH_SERV:
-      vty_serv_thread = thread_add_read(vty_master, vtysh_accept, vty, sock,
-                                        NULL);
+      vty_serv_thread = NULL;
+      thread_add_read(vty_master, vtysh_accept, vty, sock, &vty_serv_thread);
       vector_set_index (Vvty_serv_thread, sock, vty_serv_thread);
       break;
     case VTYSH_READ:
-      vty->t_read = thread_add_read(vty_master, vtysh_read, vty, sock, NULL);
+      vty->t_read = NULL;
+      thread_add_read(vty_master, vtysh_read, vty, sock, &vty->t_read);
       break;
     case VTYSH_WRITE:
-      vty->t_write = thread_add_write(vty_master, vtysh_write, vty, sock,
-                                      NULL);
+      vty->t_write = NULL;
+      thread_add_write(vty_master, vtysh_write, vty, sock, &vty->t_write);
       break;
 #endif /* VTYSH */
     case VTY_READ:
-      vty->t_read = thread_add_read(vty_master, vty_read, vty, sock, NULL);
+      vty->t_read = NULL;
+      thread_add_read(vty_master, vty_read, vty, sock, &vty->t_read);
 
       /* Time out treatment. */
       if (vty->v_timeout)
         {
           if (vty->t_timeout)
             thread_cancel (vty->t_timeout);
-          vty->t_timeout =
-            thread_add_timer(vty_master, vty_timeout, vty, vty->v_timeout,
-                             NULL);
+          vty->t_timeout = NULL;
+          thread_add_timer(vty_master, vty_timeout, vty, vty->v_timeout,
+                           &vty->t_timeout);
         }
       break;
     case VTY_WRITE:
@@ -2660,9 +2662,9 @@ vty_event (enum event event, int sock, struct vty *vty)
         }
       if (vty->v_timeout)
         {
-          vty->t_timeout =
-            thread_add_timer(vty_master, vty_timeout, vty, vty->v_timeout,
-                             NULL);
+          vty->t_timeout = NULL;
+          thread_add_timer(vty_master, vty_timeout, vty, vty->v_timeout,
+                           &vty->t_timeout);
         }
       break;
     }

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2618,23 +2618,26 @@ vty_event (enum event event, int sock, struct vty *vty)
   switch (event)
     {
     case VTY_SERV:
-      vty_serv_thread = thread_add_read (vty_master, vty_accept, vty, sock);
+      vty_serv_thread = thread_add_read(vty_master, vty_accept, vty, sock,
+                                        NULL);
       vector_set_index (Vvty_serv_thread, sock, vty_serv_thread);
       break;
 #ifdef VTYSH
     case VTYSH_SERV:
-      vty_serv_thread = thread_add_read (vty_master, vtysh_accept, vty, sock);
+      vty_serv_thread = thread_add_read(vty_master, vtysh_accept, vty, sock,
+                                        NULL);
       vector_set_index (Vvty_serv_thread, sock, vty_serv_thread);
       break;
     case VTYSH_READ:
-      vty->t_read = thread_add_read (vty_master, vtysh_read, vty, sock);
+      vty->t_read = thread_add_read(vty_master, vtysh_read, vty, sock, NULL);
       break;
     case VTYSH_WRITE:
-      vty->t_write = thread_add_write (vty_master, vtysh_write, vty, sock);
+      vty->t_write = thread_add_write(vty_master, vtysh_write, vty, sock,
+                                      NULL);
       break;
 #endif /* VTYSH */
     case VTY_READ:
-      vty->t_read = thread_add_read (vty_master, vty_read, vty, sock);
+      vty->t_read = thread_add_read(vty_master, vty_read, vty, sock, NULL);
 
       /* Time out treatment. */
       if (vty->v_timeout)
@@ -2642,12 +2645,12 @@ vty_event (enum event event, int sock, struct vty *vty)
           if (vty->t_timeout)
             thread_cancel (vty->t_timeout);
           vty->t_timeout =
-            thread_add_timer (vty_master, vty_timeout, vty, vty->v_timeout);
+            thread_add_timer(vty_master, vty_timeout, vty, vty->v_timeout,
+                             NULL);
         }
       break;
     case VTY_WRITE:
-      if (! vty->t_write)
-        vty->t_write = thread_add_write (vty_master, vty_flush, vty, sock);
+      thread_add_write(vty_master, vty_flush, vty, sock, &vty->t_write);
       break;
     case VTY_TIMEOUT_RESET:
       if (vty->t_timeout)
@@ -2658,7 +2661,8 @@ vty_event (enum event event, int sock, struct vty *vty)
       if (vty->v_timeout)
         {
           vty->t_timeout =
-            thread_add_timer (vty_master, vty_timeout, vty, vty->v_timeout);
+            thread_add_timer(vty_master, vty_timeout, vty, vty->v_timeout,
+                             NULL);
         }
       break;
     }

--- a/lib/wheel.c
+++ b/lib/wheel.c
@@ -60,9 +60,8 @@ wheel_timer_thread (struct thread *t)
     slots_to_skip++;
 
   wheel->slots_to_skip = slots_to_skip;
-  THREAD_TIMER_MSEC_ON (wheel->master, wheel->timer,
-			wheel_timer_thread, wheel,
-			wheel->nexttime * slots_to_skip);
+  thread_add_timer_msec(wheel->master, wheel_timer_thread, wheel,
+                        wheel->nexttime * slots_to_skip, &wheel->timer);
 
   return 0;
 }
@@ -91,9 +90,8 @@ wheel_init (struct thread_master *master, int period, size_t slots,
   for (i = 0; i < slots; i++)
     wheel->wheel_slot_lists[i] = list_new ();
 
-  THREAD_TIMER_MSEC_ON (wheel->master, wheel->timer,
-			wheel_timer_thread, wheel,
-			wheel->nexttime);
+  thread_add_timer_msec(wheel->master, wheel_timer_thread, wheel,
+                        wheel->nexttime, &wheel->timer);
 
   return wheel;
 }
@@ -124,9 +122,8 @@ int
 wheel_start (struct timer_wheel *wheel)
 {
   if (!wheel->timer)
-    THREAD_TIMER_MSEC_ON (wheel->master, wheel->timer,
-			  wheel_timer_thread, wheel,
-			  wheel->nexttime);
+    thread_add_timer_msec(wheel->master, wheel_timer_thread, wheel,
+                          wheel->nexttime, &wheel->timer);
 
   return 0;
 }

--- a/lib/workqueue.c
+++ b/lib/workqueue.c
@@ -126,8 +126,9 @@ work_queue_schedule (struct work_queue *wq, unsigned int delay)
        && (wq->thread == NULL)
        && (listcount (wq->items) > 0) )
     {
-      wq->thread = thread_add_background(wq->master, work_queue_run, wq,
-                                         delay, NULL);
+      wq->thread = NULL;
+      thread_add_background(wq->master, work_queue_run, wq, delay,
+                            &wq->thread);
       /* set thread yield time, if needed */
       if (wq->thread && wq->spec.yield != THREAD_YIELD_TIME_SLOT)
         thread_set_yield_time (wq->thread, wq->spec.yield);

--- a/lib/workqueue.c
+++ b/lib/workqueue.c
@@ -126,8 +126,8 @@ work_queue_schedule (struct work_queue *wq, unsigned int delay)
        && (wq->thread == NULL)
        && (listcount (wq->items) > 0) )
     {
-      wq->thread = thread_add_background (wq->master, work_queue_run, 
-                                          wq, delay);
+      wq->thread = thread_add_background(wq->master, work_queue_run, wq,
+                                         delay, NULL);
       /* set thread yield time, if needed */
       if (wq->thread && wq->spec.yield != THREAD_YIELD_TIME_SLOT)
         thread_set_yield_time (wq->thread, wq->spec.yield);

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -311,7 +311,7 @@ zclient_flush_data(struct thread *thread)
       break;
     case BUFFER_PENDING:
       zclient->t_write = thread_add_write(zclient->master, zclient_flush_data,
-					  zclient, zclient->sock);
+                                          zclient, zclient->sock, NULL);
       break;
     case BUFFER_EMPTY:
       break;
@@ -336,8 +336,8 @@ zclient_send_message(struct zclient *zclient)
       THREAD_OFF(zclient->t_write);
       break;
     case BUFFER_PENDING:
-      THREAD_WRITE_ON(zclient->master, zclient->t_write,
-		      zclient_flush_data, zclient, zclient->sock);
+      thread_add_write(zclient->master, zclient_flush_data, zclient,
+                       zclient->sock, &zclient->t_write);
       break;
     }
   return 0;
@@ -2012,22 +2012,20 @@ zclient_event (enum event event, struct zclient *zclient)
   switch (event)
     {
     case ZCLIENT_SCHEDULE:
-      if (! zclient->t_connect)
-	zclient->t_connect =
-	  thread_add_event (zclient->master, zclient_connect, zclient, 0);
+      thread_add_event(zclient->master, zclient_connect, zclient, 0,
+                       &zclient->t_connect);
       break;
     case ZCLIENT_CONNECT:
       if (zclient_debug)
 	zlog_debug ("zclient connect failures: %d schedule interval is now %d",
 		    zclient->fail, zclient->fail < 3 ? 10 : 60);
-      if (! zclient->t_connect)
-	zclient->t_connect = 
-	  thread_add_timer (zclient->master, zclient_connect, zclient,
-			    zclient->fail < 3 ? 10 : 60);
+      thread_add_timer(zclient->master, zclient_connect, zclient,
+                       zclient->fail < 3 ? 10 : 60, &zclient->t_connect);
       break;
     case ZCLIENT_READ:
       zclient->t_read = 
-	thread_add_read (zclient->master, zclient_read, zclient, zclient->sock);
+	thread_add_read(zclient->master, zclient_read, zclient, zclient->sock,
+                        NULL);
       break;
     }
 }

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -310,8 +310,9 @@ zclient_flush_data(struct thread *thread)
       return zclient_failed(zclient);
       break;
     case BUFFER_PENDING:
-      zclient->t_write = thread_add_write(zclient->master, zclient_flush_data,
-                                          zclient, zclient->sock, NULL);
+      zclient->t_write = NULL;
+      thread_add_write(zclient->master, zclient_flush_data, zclient, zclient->sock,
+                       &zclient->t_write);
       break;
     case BUFFER_EMPTY:
       break;
@@ -2023,9 +2024,9 @@ zclient_event (enum event event, struct zclient *zclient)
                        zclient->fail < 3 ? 10 : 60, &zclient->t_connect);
       break;
     case ZCLIENT_READ:
-      zclient->t_read = 
-	thread_add_read(zclient->master, zclient_read, zclient, zclient->sock,
-                        NULL);
+      zclient->t_read = NULL;
+      thread_add_read(zclient->master, zclient_read, zclient, zclient->sock,
+                      &zclient->t_read);
       break;
     }
 }

--- a/nhrpd/netlink_arp.c
+++ b/nhrpd/netlink_arp.c
@@ -124,7 +124,7 @@ static int netlink_route_recv(struct thread *t)
 		}
 	}
 
-	thread_add_read(master, netlink_route_recv, 0, fd);
+	thread_add_read(master, netlink_route_recv, 0, fd, NULL);
 
 	return 0;
 }
@@ -214,7 +214,8 @@ static int netlink_log_recv(struct thread *t)
 		}
 	}
 
-	THREAD_READ_ON(master, netlink_log_thread, netlink_log_recv, 0, netlink_log_fd);
+	thread_add_read(master, netlink_log_recv, 0, netlink_log_fd,
+			&netlink_log_thread);
 
 	return 0;
 }
@@ -230,7 +231,8 @@ void netlink_set_nflog_group(int nlgroup)
 	if (nlgroup) {
 		netlink_log_fd = znl_open(NETLINK_NETFILTER,  0);
 		netlink_log_register(netlink_log_fd, nlgroup);
-		THREAD_READ_ON(master, netlink_log_thread, netlink_log_recv, 0, netlink_log_fd);
+		thread_add_read(master, netlink_log_recv, 0, netlink_log_fd,
+				&netlink_log_thread);
 	}
 }
 
@@ -238,7 +240,8 @@ int netlink_init(void)
 {
 	netlink_req_fd = znl_open(NETLINK_ROUTE, 0);
 	netlink_listen_fd = znl_open(NETLINK_ROUTE, RTMGRP_NEIGH);
-	thread_add_read(master, netlink_route_recv, 0, netlink_listen_fd);
+	thread_add_read(master, netlink_route_recv, 0, netlink_listen_fd,
+			NULL);
 
 	return 0;
 }

--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -269,7 +269,7 @@ static int nhrp_packet_recvraw(struct thread *t)
 	uint8_t addr[64];
 	size_t len, addrlen;
 
-	thread_add_read(master, nhrp_packet_recvraw, 0, fd);
+	thread_add_read(master, nhrp_packet_recvraw, 0, fd, NULL);
 
 	zb = zbuf_alloc(1500);
 	if (!zb) return 0;
@@ -307,6 +307,6 @@ err:
 
 int nhrp_packet_init(void)
 {
-	thread_add_read(master, nhrp_packet_recvraw, 0, os_socket());
+	thread_add_read(master, nhrp_packet_recvraw, 0, os_socket(), NULL);
 	return 0;
 }

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -251,7 +251,7 @@ ospf6_bfd_interface_dest_update (int command, struct zclient *zclient,
       if ((status == BFD_STATUS_DOWN) && (old_status == BFD_STATUS_UP))
         {
           THREAD_OFF (on->inactivity_timer);
-          thread_add_event (master, inactivity_timer, on, 0);
+          thread_add_event(master, inactivity_timer, on, 0, NULL);
         }
     }
 

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -112,8 +112,9 @@ ospf6_lsa_originate (struct ospf6_lsa *lsa)
   lsdb_self = ospf6_get_scoped_lsdb_self (lsa);
   ospf6_lsdb_add (ospf6_lsa_copy (lsa), lsdb_self);
 
-  lsa->refresh = thread_add_timer(master, ospf6_lsa_refresh, lsa,
-                                  OSPF_LS_REFRESH_TIME, NULL);
+  lsa->refresh = NULL;
+  thread_add_timer(master, ospf6_lsa_refresh, lsa, OSPF_LS_REFRESH_TIME,
+                   &lsa->refresh);
 
   if (IS_OSPF6_DEBUG_LSA_TYPE (lsa->header->type) ||
       IS_OSPF6_DEBUG_ORIGINATE_TYPE (lsa->header->type))
@@ -225,10 +226,11 @@ ospf6_install_lsa (struct ospf6_lsa *lsa)
     }
 
   monotime(&now);
-  if (! OSPF6_LSA_IS_MAXAGE (lsa))
-    lsa->expire = thread_add_timer(master, ospf6_lsa_expire, lsa,
-                                   OSPF_LSA_MAXAGE + lsa->birth.tv_sec - now.tv_sec,
-                                   NULL);
+  if (! OSPF6_LSA_IS_MAXAGE (lsa)) {
+    lsa->expire = NULL;
+    thread_add_timer(master, ospf6_lsa_expire, lsa, OSPF_LSA_MAXAGE + lsa->birth.tv_sec - now.tv_sec,
+                     &lsa->expire);
+  }
   else
     lsa->expire = NULL;
 
@@ -362,10 +364,8 @@ ospf6_flood_interface (struct ospf6_neighbor *from,
         zlog_debug ("Add retrans-list of this neighbor");
       ospf6_increment_retrans_count (lsa);
       ospf6_lsdb_add (ospf6_lsa_copy (lsa), on->retrans_list);
-      if (on->thread_send_lsupdate == NULL)
-        on->thread_send_lsupdate =
-          thread_add_timer(master, ospf6_lsupdate_send_neighbor, on,
-                           on->ospf6_if->rxmt_interval, NULL);
+      thread_add_timer(master, ospf6_lsupdate_send_neighbor, on, on->ospf6_if->rxmt_interval,
+                       &on->thread_send_lsupdate);
       retrans_added++;
     }
 
@@ -407,9 +407,8 @@ ospf6_flood_interface (struct ospf6_neighbor *from,
       (oi->type == OSPF_IFTYPE_POINTOPOINT))
     {
       ospf6_lsdb_add (ospf6_lsa_copy (lsa), oi->lsupdate_list);
-      if (oi->thread_send_lsupdate == NULL)
-        oi->thread_send_lsupdate =
-          thread_add_event(master, ospf6_lsupdate_send_interface, oi, 0, NULL);
+      thread_add_event(master, ospf6_lsupdate_send_interface, oi, 0,
+                       &oi->thread_send_lsupdate);
     }
   else
     {
@@ -417,9 +416,9 @@ ospf6_flood_interface (struct ospf6_neighbor *from,
       for (ALL_LIST_ELEMENTS (oi->neighbor_list, node, nnode, on))
         {
           THREAD_OFF (on->thread_send_lsupdate);
-          on->thread_send_lsupdate =
-            thread_add_event(master, ospf6_lsupdate_send_neighbor, on, 0,
-                             NULL);
+          on->thread_send_lsupdate = NULL;
+          thread_add_event(master, ospf6_lsupdate_send_neighbor, on, 0,
+                           &on->thread_send_lsupdate);
         }
     }
 }
@@ -579,10 +578,8 @@ ospf6_acknowledge_lsa_bdrouter (struct ospf6_lsa *lsa, int ismore_recent,
             zlog_debug ("Delayed acknowledgement (BDR & MoreRecent & from DR)");
           /* Delayed acknowledgement */
           ospf6_lsdb_add (ospf6_lsa_copy (lsa), oi->lsack_list);
-          if (oi->thread_send_lsack == NULL)
-            oi->thread_send_lsack =
-              thread_add_timer(master, ospf6_lsack_send_interface, oi, 3,
-                               NULL);
+          thread_add_timer(master, ospf6_lsack_send_interface, oi, 3,
+                           &oi->thread_send_lsack);
         }
       else
         {
@@ -604,10 +601,8 @@ ospf6_acknowledge_lsa_bdrouter (struct ospf6_lsa *lsa, int ismore_recent,
             zlog_debug ("Delayed acknowledgement (BDR & Duplicate & ImpliedAck & from DR)");
           /* Delayed acknowledgement */
           ospf6_lsdb_add (ospf6_lsa_copy (lsa), oi->lsack_list);
-          if (oi->thread_send_lsack == NULL)
-            oi->thread_send_lsack =
-              thread_add_timer(master, ospf6_lsack_send_interface, oi, 3,
-                               NULL);
+          thread_add_timer(master, ospf6_lsack_send_interface, oi, 3,
+                           &oi->thread_send_lsack);
         }
       else
         {
@@ -625,9 +620,8 @@ ospf6_acknowledge_lsa_bdrouter (struct ospf6_lsa *lsa, int ismore_recent,
       if (is_debug)
         zlog_debug ("Direct acknowledgement (BDR & Duplicate)");
       ospf6_lsdb_add (ospf6_lsa_copy (lsa), from->lsack_list);
-      if (from->thread_send_lsack == NULL)
-        from->thread_send_lsack =
-          thread_add_event(master, ospf6_lsack_send_neighbor, from, 0, NULL);
+      thread_add_event(master, ospf6_lsack_send_neighbor, from, 0,
+                       &from->thread_send_lsack);
       return;
     }
 
@@ -669,9 +663,8 @@ ospf6_acknowledge_lsa_allother (struct ospf6_lsa *lsa, int ismore_recent,
         zlog_debug ("Delayed acknowledgement (AllOther & MoreRecent)");
       /* Delayed acknowledgement */
       ospf6_lsdb_add (ospf6_lsa_copy (lsa), oi->lsack_list);
-      if (oi->thread_send_lsack == NULL)
-        oi->thread_send_lsack =
-          thread_add_timer(master, ospf6_lsack_send_interface, oi, 3, NULL);
+      thread_add_timer(master, ospf6_lsack_send_interface, oi, 3,
+                       &oi->thread_send_lsack);
       return;
     }
 
@@ -693,9 +686,8 @@ ospf6_acknowledge_lsa_allother (struct ospf6_lsa *lsa, int ismore_recent,
       if (is_debug)
         zlog_debug ("Direct acknowledgement (AllOther & Duplicate)");
       ospf6_lsdb_add (ospf6_lsa_copy (lsa), from->lsack_list);
-      if (from->thread_send_lsack == NULL)
-        from->thread_send_lsack =
-          thread_add_event(master, ospf6_lsack_send_neighbor, from, 0, NULL);
+      thread_add_event(master, ospf6_lsack_send_neighbor, from, 0,
+                       &from->thread_send_lsack);
       return;
     }
 
@@ -832,9 +824,8 @@ ospf6_receive_lsa (struct ospf6_neighbor *from,
 
       /* a) Acknowledge back to neighbor (Direct acknowledgement, 13.5) */
       ospf6_lsdb_add (ospf6_lsa_copy (new), from->lsack_list);
-      if (from->thread_send_lsack == NULL)
-        from->thread_send_lsack =
-          thread_add_event(master, ospf6_lsack_send_neighbor, from, 0, NULL);
+      thread_add_event(master, ospf6_lsack_send_neighbor, from, 0,
+                       &from->thread_send_lsack);
 
       /* b) Discard */
       ospf6_lsa_delete (new);
@@ -916,8 +907,8 @@ ospf6_receive_lsa (struct ospf6_neighbor *from,
               zlog_debug ("Newer instance of the self-originated LSA");
               zlog_debug ("Schedule reorigination");
             }
-          new->refresh = thread_add_event(master, ospf6_lsa_refresh, new, 0,
-                                          NULL);
+          new->refresh = NULL;
+          thread_add_event(master, ospf6_lsa_refresh, new, 0, &new->refresh);
         }
 
       return;
@@ -1003,10 +994,8 @@ ospf6_receive_lsa (struct ospf6_neighbor *from,
           /* XXX, MinLSArrival check !? RFC 2328 13 (8) */
 
           ospf6_lsdb_add (ospf6_lsa_copy (old), from->lsupdate_list);
-          if (from->thread_send_lsupdate == NULL)
-            from->thread_send_lsupdate =
-              thread_add_event(master, ospf6_lsupdate_send_neighbor, from, 0,
-                               NULL);
+          thread_add_event(master, ospf6_lsupdate_send_neighbor, from, 0,
+                           &from->thread_send_lsupdate);
 	  ospf6_lsa_delete (new);
 	  return;
         }

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -392,9 +392,9 @@ ospf6_interface_state_update (struct interface *ifp)
   if (if_is_operative (ifp)
       && (ospf6_interface_get_linklocal_address(oi->interface)
           || if_is_loopback(oi->interface)))
-    thread_add_event (master, interface_up, oi, 0);
+    thread_add_event(master, interface_up, oi, 0, NULL);
   else
-    thread_add_event (master, interface_down, oi, 0);
+    thread_add_event(master, interface_down, oi, 0, NULL);
 
   return;
 }
@@ -671,7 +671,7 @@ dr_election (struct ospf6_interface *oi)
           if (on->state < OSPF6_NEIGHBOR_TWOWAY)
             continue;
           /* Schedule AdjOK. */
-          thread_add_event (master, adj_ok, on, 0);
+          thread_add_event(master, adj_ok, on, 0, NULL);
         }
     }
 
@@ -740,8 +740,8 @@ interface_up (struct thread *thread)
         {
           zlog_info("Scheduling %s for sso retry, trial count: %d",
                     oi->interface->name, oi->sso_try_cnt);
-          thread_add_timer (master, interface_up, oi,
-                            OSPF6_INTERFACE_SSO_RETRY_INT);
+          thread_add_timer(master, interface_up, oi,
+                           OSPF6_INTERFACE_SSO_RETRY_INT, NULL);
         }
       return 0;
     }
@@ -753,7 +753,8 @@ interface_up (struct thread *thread)
   /* Schedule Hello */
   if (! CHECK_FLAG (oi->flag, OSPF6_INTERFACE_PASSIVE) &&
       !if_is_loopback (oi->interface))
-    oi->thread_send_hello = thread_add_event (master, ospf6_hello_send, oi, 0);
+    oi->thread_send_hello = thread_add_event(master, ospf6_hello_send, oi, 0,
+                                             NULL);
 
   /* decide next interface state */
   if ((if_is_pointopoint (oi->interface)) ||
@@ -765,7 +766,7 @@ interface_up (struct thread *thread)
   else
     {
       ospf6_interface_state_change (OSPF6_INTERFACE_WAITING, oi);
-      thread_add_timer (master, wait_timer, oi, oi->dead_interval);
+      thread_add_timer(master, wait_timer, oi, oi->dead_interval, NULL);
     }
 
   return 0;
@@ -1140,7 +1141,7 @@ DEFUN (ipv6_ospf6_ifmtu,
   for (ALL_LIST_ELEMENTS (oi->neighbor_list, node, nnode, on))
     {
       THREAD_OFF (on->inactivity_timer);
-      thread_add_event (master, inactivity_timer, on, 0);
+      thread_add_event(master, inactivity_timer, on, 0, NULL);
     }
 
   return CMD_SUCCESS;
@@ -1187,7 +1188,7 @@ DEFUN (no_ipv6_ospf6_ifmtu,
   for (ALL_LIST_ELEMENTS (oi->neighbor_list, node, nnode, on))
     {
       THREAD_OFF (on->inactivity_timer);
-      thread_add_event (master, inactivity_timer, on, 0);
+      thread_add_event(master, inactivity_timer, on, 0, NULL);
     }
 
   return CMD_SUCCESS;
@@ -1490,7 +1491,7 @@ DEFUN (ipv6_ospf6_passive,
   for (ALL_LIST_ELEMENTS (oi->neighbor_list, node, nnode, on))
     {
       THREAD_OFF (on->inactivity_timer);
-      thread_add_event (master, inactivity_timer, on, 0);
+      thread_add_event(master, inactivity_timer, on, 0, NULL);
     }
 
   return CMD_SUCCESS;
@@ -1517,7 +1518,7 @@ DEFUN (no_ipv6_ospf6_passive,
   UNSET_FLAG (oi->flag, OSPF6_INTERFACE_PASSIVE);
   THREAD_OFF (oi->thread_send_hello);
   oi->thread_send_hello =
-    thread_add_event (master, ospf6_hello_send, oi, 0);
+    thread_add_event(master, ospf6_hello_send, oi, 0, NULL);
 
   return CMD_SUCCESS;
 }
@@ -1685,8 +1686,8 @@ DEFUN (ipv6_ospf6_network,
       }
 
   /* Reset the interface */
-  thread_add_event (master, interface_down, oi, 0);
-  thread_add_event (master, interface_up, oi, 0);
+  thread_add_event(master, interface_down, oi, 0, NULL);
+  thread_add_event(master, interface_up, oi, 0, NULL);
 
   return CMD_SUCCESS;
 }
@@ -1720,8 +1721,8 @@ DEFUN (no_ipv6_ospf6_network,
   oi->type = type;
 
   /* Reset the interface */
-  thread_add_event (master, interface_down, oi, 0);
-  thread_add_event (master, interface_up, oi, 0);
+  thread_add_event(master, interface_down, oi, 0, NULL);
+  thread_add_event(master, interface_up, oi, 0, NULL);
 
   return CMD_SUCCESS;
 }
@@ -1864,8 +1865,8 @@ ospf6_interface_clear (struct vty *vty, struct interface *ifp)
     zlog_debug ("Interface %s: clear by reset", ifp->name);
 
   /* Reset the interface */
-  thread_add_event (master, interface_down, oi, 0);
-  thread_add_event (master, interface_up, oi, 0);
+  thread_add_event(master, interface_down, oi, 0, NULL);
+  thread_add_event(master, interface_up, oi, 0, NULL);
 }
 
 /* Clear interface */

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -752,9 +752,10 @@ interface_up (struct thread *thread)
 
   /* Schedule Hello */
   if (! CHECK_FLAG (oi->flag, OSPF6_INTERFACE_PASSIVE) &&
-      !if_is_loopback (oi->interface))
-    oi->thread_send_hello = thread_add_event(master, ospf6_hello_send, oi, 0,
-                                             NULL);
+      !if_is_loopback (oi->interface)) {
+    oi->thread_send_hello = NULL;
+    thread_add_event(master, ospf6_hello_send, oi, 0, &oi->thread_send_hello);
+  }
 
   /* decide next interface state */
   if ((if_is_pointopoint (oi->interface)) ||
@@ -1517,8 +1518,8 @@ DEFUN (no_ipv6_ospf6_passive,
 
   UNSET_FLAG (oi->flag, OSPF6_INTERFACE_PASSIVE);
   THREAD_OFF (oi->thread_send_hello);
-  oi->thread_send_hello =
-    thread_add_event(master, ospf6_hello_send, oi, 0, NULL);
+  oi->thread_send_hello = NULL;
+  thread_add_event(master, ospf6_hello_send, oi, 0, &oi->thread_send_hello);
 
   return CMD_SUCCESS;
 }

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -156,40 +156,30 @@ struct ospf6_intra_prefix_lsa
 
 #define OSPF6_ROUTER_LSA_SCHEDULE(oa) \
   do { \
-    if (! (oa)->thread_router_lsa \
-        && CHECK_FLAG((oa)->flag, OSPF6_AREA_ENABLE)) \
-      (oa)->thread_router_lsa = \
-        thread_add_event (master, ospf6_router_lsa_originate, oa, 0); \
+    if (CHECK_FLAG((oa)->flag, OSPF6_AREA_ENABLE)) \
+      thread_add_event (master, ospf6_router_lsa_originate, oa, 0, &(oa)->thread_router_lsa); \
   } while (0)
 #define OSPF6_NETWORK_LSA_SCHEDULE(oi) \
   do { \
-    if (! (oi)->thread_network_lsa \
-        && ! CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE)) \
-      (oi)->thread_network_lsa = \
-        thread_add_event (master, ospf6_network_lsa_originate, oi, 0); \
+    if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE)) \
+      thread_add_event (master, ospf6_network_lsa_originate, oi, 0, &(oi)->thread_network_lsa); \
   } while (0)
 #define OSPF6_LINK_LSA_SCHEDULE(oi) \
   do { \
-    if (! (oi)->thread_link_lsa \
-        && ! CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE)) \
-      (oi)->thread_link_lsa = \
-        thread_add_event (master, ospf6_link_lsa_originate, oi, 0); \
+    if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE)) \
+      thread_add_event (master, ospf6_link_lsa_originate, oi, 0, &(oi)->thread_link_lsa); \
   } while (0)
 #define OSPF6_INTRA_PREFIX_LSA_SCHEDULE_STUB(oa) \
   do { \
-    if (! (oa)->thread_intra_prefix_lsa \
-        && CHECK_FLAG((oa)->flag, OSPF6_AREA_ENABLE)) \
-      (oa)->thread_intra_prefix_lsa = \
-        thread_add_event (master, ospf6_intra_prefix_lsa_originate_stub, \
-                          oa, 0); \
+    if (CHECK_FLAG((oa)->flag, OSPF6_AREA_ENABLE)) \
+      thread_add_event (master, ospf6_intra_prefix_lsa_originate_stub, \
+                        oa, 0, &(oa)->thread_intra_prefix_lsa); \
   } while (0)
 #define OSPF6_INTRA_PREFIX_LSA_SCHEDULE_TRANSIT(oi) \
   do { \
-    if (! (oi)->thread_intra_prefix_lsa \
-        && ! CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE)) \
-      (oi)->thread_intra_prefix_lsa = \
-        thread_add_event (master, ospf6_intra_prefix_lsa_originate_transit, \
-                          oi, 0); \
+    if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE)) \
+      thread_add_event (master, ospf6_intra_prefix_lsa_originate_transit, \
+                        oi, 0, &(oi)->thread_intra_prefix_lsa); \
   } while (0)
 
 #define OSPF6_NETWORK_LSA_EXECUTE(oi) \

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -722,8 +722,9 @@ ospf6_lsa_refresh (struct thread *thread)
 
   new = ospf6_lsa_create (self->header);
   new->lsdb = old->lsdb;
-  new->refresh = thread_add_timer(master, ospf6_lsa_refresh, new,
-                                  OSPF_LS_REFRESH_TIME, NULL);
+  new->refresh = NULL;
+  thread_add_timer(master, ospf6_lsa_refresh, new, OSPF_LS_REFRESH_TIME,
+                   &new->refresh);
 
   /* store it in the LSDB for self-originated LSAs */
   ospf6_lsdb_add (ospf6_lsa_copy (new), lsdb_self);

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -722,8 +722,8 @@ ospf6_lsa_refresh (struct thread *thread)
 
   new = ospf6_lsa_create (self->header);
   new->lsdb = old->lsdb;
-  new->refresh = thread_add_timer (master, ospf6_lsa_refresh, new,
-                                   OSPF_LS_REFRESH_TIME);
+  new->refresh = thread_add_timer(master, ospf6_lsa_refresh, new,
+                                  OSPF_LS_REFRESH_TIME, NULL);
 
   /* store it in the LSDB for self-originated LSAs */
   ospf6_lsdb_add (ospf6_lsa_copy (new), lsdb_self);

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -696,7 +696,6 @@ ospf6_lsa_refresh (struct thread *thread)
   struct ospf6_lsa *old, *self, *new;
   struct ospf6_lsdb *lsdb_self;
 
-  assert (thread);
   old = (struct ospf6_lsa *) THREAD_ARG (thread);
   assert (old && old->header);
 

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -352,9 +352,9 @@ ospf6_hello_recv (struct in6_addr *src, struct in6_addr *dst,
 
   /* Schedule interface events */
   if (backupseen)
-    thread_add_event (master, backup_seen, oi, 0);
+    thread_add_event (master, backup_seen, oi, 0, NULL);
   if (neighborchange)
-    thread_add_event (master, neighbor_change, oi, 0);
+    thread_add_event (master, neighbor_change, oi, 0, NULL);
 
   if (neighbor_ifindex_change && on->state == OSPF6_NEIGHBOR_FULL)
     OSPF6_ROUTER_LSA_SCHEDULE (oi->area);
@@ -428,7 +428,7 @@ ospf6_dbdesc_recv_master (struct ospf6_header *oh,
         {
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Master/Slave bit mismatch");
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
 
@@ -436,7 +436,7 @@ ospf6_dbdesc_recv_master (struct ospf6_header *oh,
         {
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Initialize bit mismatch");
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
 
@@ -444,7 +444,7 @@ ospf6_dbdesc_recv_master (struct ospf6_header *oh,
         {
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Option field mismatch");
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
 
@@ -453,7 +453,7 @@ ospf6_dbdesc_recv_master (struct ospf6_header *oh,
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Sequence number mismatch (%#lx expected)",
                        (u_long) on->dbdesc_seqnum);
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
       break;
@@ -471,7 +471,7 @@ ospf6_dbdesc_recv_master (struct ospf6_header *oh,
       if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
         zlog_debug ("Not duplicate dbdesc in state %s",
 		    ospf6_neighbor_state_str[on->state]);
-      thread_add_event (master, seqnumber_mismatch, on, 0);
+      thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
       return;
 
     default:
@@ -517,7 +517,7 @@ ospf6_dbdesc_recv_master (struct ospf6_header *oh,
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("SeqNumMismatch (E-bit mismatch), discard");
           ospf6_lsa_delete (his);
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
 
@@ -549,19 +549,18 @@ ospf6_dbdesc_recv_master (struct ospf6_header *oh,
   on->dbdesc_seqnum ++;
 
   /* schedule send lsreq */
-  if (on->request_list->count && (on->thread_send_lsreq == NULL))
-    on->thread_send_lsreq =
-      thread_add_event (master, ospf6_lsreq_send, on, 0);
+  if (on->request_list->count)
+    thread_add_event (master, ospf6_lsreq_send, on, 0, &on->thread_send_lsreq);
 
   THREAD_OFF (on->thread_send_dbdesc);
 
   /* More bit check */
   if (! CHECK_FLAG (dbdesc->bits, OSPF6_DBDESC_MBIT) &&
       ! CHECK_FLAG (on->dbdesc_bits, OSPF6_DBDESC_MBIT))
-    thread_add_event (master, exchange_done, on, 0);
+    thread_add_event (master, exchange_done, on, 0, NULL);
   else
     on->thread_send_dbdesc =
-      thread_add_event (master, ospf6_dbdesc_send_newone, on, 0);
+      thread_add_event (master, ospf6_dbdesc_send_newone, on, 0, NULL);
 
   /* save last received dbdesc */
   memcpy (&on->dbdesc_last, dbdesc, sizeof (struct ospf6_dbdesc));
@@ -638,7 +637,7 @@ ospf6_dbdesc_recv_slave (struct ospf6_header *oh,
             zlog_debug ("Duplicated dbdesc causes retransmit");
           THREAD_OFF (on->thread_send_dbdesc);
           on->thread_send_dbdesc =
-            thread_add_event (master, ospf6_dbdesc_send, on, 0);
+            thread_add_event (master, ospf6_dbdesc_send, on, 0, NULL);
           return;
         }
 
@@ -646,7 +645,7 @@ ospf6_dbdesc_recv_slave (struct ospf6_header *oh,
         {
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Master/Slave bit mismatch");
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
 
@@ -654,7 +653,7 @@ ospf6_dbdesc_recv_slave (struct ospf6_header *oh,
         {
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Initialize bit mismatch");
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
 
@@ -662,7 +661,7 @@ ospf6_dbdesc_recv_slave (struct ospf6_header *oh,
         {
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Option field mismatch");
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
 
@@ -671,7 +670,7 @@ ospf6_dbdesc_recv_slave (struct ospf6_header *oh,
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Sequence number mismatch (%#lx expected)",
 			(u_long) on->dbdesc_seqnum + 1);
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
       break;
@@ -684,15 +683,14 @@ ospf6_dbdesc_recv_slave (struct ospf6_header *oh,
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Duplicated dbdesc causes retransmit");
           THREAD_OFF (on->thread_send_dbdesc);
-          on->thread_send_dbdesc =
-            thread_add_event (master, ospf6_dbdesc_send, on, 0);
+          thread_add_event (master, ospf6_dbdesc_send, on, 0, &on->thread_send_dbdesc);
           return;
         }
 
       if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
         zlog_debug ("Not duplicate dbdesc in state %s",
 		    ospf6_neighbor_state_str[on->state]);
-      thread_add_event (master, seqnumber_mismatch, on, 0);
+      thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
       return;
 
     default:
@@ -735,7 +733,7 @@ ospf6_dbdesc_recv_slave (struct ospf6_header *oh,
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("E-bit mismatch with LSA Headers");
           ospf6_lsa_delete (his);
-          thread_add_event (master, seqnumber_mismatch, on, 0);
+          thread_add_event (master, seqnumber_mismatch, on, 0, NULL);
           return;
         }
 
@@ -756,14 +754,11 @@ ospf6_dbdesc_recv_slave (struct ospf6_header *oh,
   on->dbdesc_seqnum = ntohl (dbdesc->seqnum);
 
   /* schedule send lsreq */
-  if ((on->thread_send_lsreq == NULL) &&
-      (on->request_list->count))
-    on->thread_send_lsreq =
-      thread_add_event (master, ospf6_lsreq_send, on, 0);
+  if (on->request_list->count)
+    thread_add_event (master, ospf6_lsreq_send, on, 0, &on->thread_send_lsreq);
 
   THREAD_OFF (on->thread_send_dbdesc);
-  on->thread_send_dbdesc =
-    thread_add_event (master, ospf6_dbdesc_send_newone, on, 0);
+  thread_add_event (master, ospf6_dbdesc_send_newone, on, 0, &on->thread_send_dbdesc);
 
   /* save last received dbdesc */
   memcpy (&on->dbdesc_last, dbdesc, sizeof (struct ospf6_dbdesc));
@@ -880,7 +875,7 @@ ospf6_lsreq_recv (struct in6_addr *src, struct in6_addr *dst,
               zlog_debug ("Can't find requested [%s Id:%s Adv:%s]",
 			  ospf6_lstype_name (e->type), id, adv_router);
             }
-          thread_add_event (master, bad_lsreq, on, 0);
+          thread_add_event (master, bad_lsreq, on, 0, NULL);
           return;
         }
 
@@ -891,8 +886,7 @@ ospf6_lsreq_recv (struct in6_addr *src, struct in6_addr *dst,
 
   /* schedule send lsupdate */
   THREAD_OFF (on->thread_send_lsupdate);
-  on->thread_send_lsupdate =
-    thread_add_event (master, ospf6_lsupdate_send_neighbor, on, 0);
+  thread_add_event (master, ospf6_lsupdate_send_neighbor, on, 0, &on->thread_send_lsupdate);
 }
 
 /* Verify, that the specified memory area contains exactly N valid IPv6
@@ -1532,7 +1526,7 @@ ospf6_receive (struct thread *thread)
 
   /* add next read thread */
   sockfd = THREAD_FD (thread);
-  thread_add_read (master, ospf6_receive, NULL, sockfd);
+  thread_add_read (master, ospf6_receive, NULL, sockfd, NULL);
 
   /* initialize */
   memset (&src, 0, sizeof (src));
@@ -1739,8 +1733,7 @@ ospf6_hello_send (struct thread *thread)
     }
 
   /* set next thread */
-  oi->thread_send_hello = thread_add_timer (master, ospf6_hello_send,
-                                            oi, oi->hello_interval);
+  thread_add_timer (master, ospf6_hello_send, oi, oi->hello_interval, &oi->thread_send_hello);
 
   memset (sendbuf, 0, iobuflen);
   oh = (struct ospf6_header *) sendbuf;
@@ -1804,9 +1797,9 @@ ospf6_dbdesc_send (struct thread *thread)
 
   /* set next thread if master */
   if (CHECK_FLAG (on->dbdesc_bits, OSPF6_DBDESC_MSBIT))
-    on->thread_send_dbdesc =
-      thread_add_timer (master, ospf6_dbdesc_send, on,
-                        on->ospf6_if->rxmt_interval);
+    thread_add_timer (master, ospf6_dbdesc_send, on,
+                      on->ospf6_if->rxmt_interval,
+                      &on->thread_send_dbdesc);
 
   memset (sendbuf, 0, iobuflen);
   oh = (struct ospf6_header *) sendbuf;
@@ -1896,7 +1889,7 @@ ospf6_dbdesc_send_newone (struct thread *thread)
   if (! CHECK_FLAG (on->dbdesc_bits, OSPF6_DBDESC_MSBIT) && /* Slave */
       ! CHECK_FLAG (on->dbdesc_last.bits, OSPF6_DBDESC_MBIT) &&
       ! CHECK_FLAG (on->dbdesc_bits, OSPF6_DBDESC_MBIT))
-    thread_add_event (master, exchange_done, on, 0);
+    thread_add_event (master, exchange_done, on, 0, NULL);
 
   thread_execute (master, ospf6_dbdesc_send, on, 0);
   return 0;
@@ -1927,7 +1920,7 @@ ospf6_lsreq_send (struct thread *thread)
   /* schedule loading_done if request list is empty */
   if (on->request_list->count == 0)
     {
-      thread_add_event (master, loading_done, on, 0);
+      thread_add_event (master, loading_done, on, 0, NULL);
       return 0;
     }
 
@@ -1979,8 +1972,8 @@ ospf6_lsreq_send (struct thread *thread)
   if (on->request_list->count != 0)
     {
       on->thread_send_lsreq =
-	thread_add_timer (master, ospf6_lsreq_send, on,
-			  on->ospf6_if->rxmt_interval);
+         thread_add_timer (master, ospf6_lsreq_send, on,
+                           on->ospf6_if->rxmt_interval, NULL);
     }
 
   return 0;
@@ -2099,11 +2092,11 @@ ospf6_lsupdate_send_neighbor (struct thread *thread)
 
   if (on->lsupdate_list->count != 0)
     on->thread_send_lsupdate =
-      thread_add_event (master, ospf6_lsupdate_send_neighbor, on, 0);
+      thread_add_event (master, ospf6_lsupdate_send_neighbor, on, 0, NULL);
   else if (on->retrans_list->count != 0)
     on->thread_send_lsupdate =
       thread_add_timer (master, ospf6_lsupdate_send_neighbor, on,
-			on->ospf6_if->rxmt_interval);
+			on->ospf6_if->rxmt_interval, NULL);
   return 0;
 }
 
@@ -2179,7 +2172,7 @@ ospf6_lsupdate_send_interface (struct thread *thread)
   if (oi->lsupdate_list->count > 0)
     {
       oi->thread_send_lsupdate =
-        thread_add_event (master, ospf6_lsupdate_send_interface, oi, 0);
+        thread_add_event (master, ospf6_lsupdate_send_interface, oi, 0, NULL);
     }
 
   return 0;
@@ -2223,8 +2216,7 @@ ospf6_lsack_send_neighbor (struct thread *thread)
 	  /* if we run out of packet size/space here,
 	     better to try again soon. */
 	  THREAD_OFF (on->thread_send_lsack);
-	  on->thread_send_lsack =
-	    thread_add_event (master, ospf6_lsack_send_neighbor, on, 0);
+      thread_add_event (master, ospf6_lsack_send_neighbor, on, 0, &on->thread_send_lsack);
 
 	  ospf6_lsdb_lsa_unlock (lsa);
 	  break;
@@ -2248,11 +2240,8 @@ ospf6_lsack_send_neighbor (struct thread *thread)
 		  on->ospf6_if, oh);
     }
 
-  if (on->thread_send_lsack == NULL && on->lsack_list->count > 0)
-    {
-      on->thread_send_lsack =
-        thread_add_event (master, ospf6_lsack_send_neighbor, on, 0);
-    }
+  if (on->lsack_list->count > 0)
+    thread_add_event (master, ospf6_lsack_send_neighbor, on, 0, &on->thread_send_lsack);
 
   return 0;
 }
@@ -2295,8 +2284,8 @@ ospf6_lsack_send_interface (struct thread *thread)
 	  /* if we run out of packet size/space here,
 	     better to try again soon. */
 	  THREAD_OFF (oi->thread_send_lsack);
-	  oi->thread_send_lsack =
-	    thread_add_event (master, ospf6_lsack_send_interface, oi, 0);
+      thread_add_event (master, ospf6_lsack_send_interface, oi, 0,
+                        &oi->thread_send_lsack);
 
 	  ospf6_lsdb_lsa_unlock (lsa);
 	  break;
@@ -2324,11 +2313,8 @@ ospf6_lsack_send_interface (struct thread *thread)
 	ospf6_send (oi->linklocal_addr, &alldrouters6, oi, oh);
     }
 
-  if (oi->thread_send_lsack == NULL && oi->lsack_list->count > 0)
-    {
-      oi->thread_send_lsack =
-        thread_add_event (master, ospf6_lsack_send_interface, oi, 0);
-    }
+  if (oi->lsack_list->count > 0)
+    thread_add_event (master, ospf6_lsack_send_interface, oi, 0, &oi->thread_send_lsack);
 
   return 0;
 }

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -558,9 +558,11 @@ ospf6_dbdesc_recv_master (struct ospf6_header *oh,
   if (! CHECK_FLAG (dbdesc->bits, OSPF6_DBDESC_MBIT) &&
       ! CHECK_FLAG (on->dbdesc_bits, OSPF6_DBDESC_MBIT))
     thread_add_event (master, exchange_done, on, 0, NULL);
-  else
-    on->thread_send_dbdesc =
-      thread_add_event (master, ospf6_dbdesc_send_newone, on, 0, NULL);
+  else {
+    on->thread_send_dbdesc = NULL;
+    thread_add_event(master, ospf6_dbdesc_send_newone, on, 0,
+                     &on->thread_send_dbdesc);
+  }
 
   /* save last received dbdesc */
   memcpy (&on->dbdesc_last, dbdesc, sizeof (struct ospf6_dbdesc));
@@ -636,8 +638,9 @@ ospf6_dbdesc_recv_slave (struct ospf6_header *oh,
           if (IS_OSPF6_DEBUG_MESSAGE (oh->type, RECV))
             zlog_debug ("Duplicated dbdesc causes retransmit");
           THREAD_OFF (on->thread_send_dbdesc);
-          on->thread_send_dbdesc =
-            thread_add_event (master, ospf6_dbdesc_send, on, 0, NULL);
+          on->thread_send_dbdesc = NULL;
+          thread_add_event(master, ospf6_dbdesc_send, on, 0,
+                           &on->thread_send_dbdesc);
           return;
         }
 
@@ -1971,9 +1974,9 @@ ospf6_lsreq_send (struct thread *thread)
   /* set next thread */
   if (on->request_list->count != 0)
     {
-      on->thread_send_lsreq =
-         thread_add_timer (master, ospf6_lsreq_send, on,
-                           on->ospf6_if->rxmt_interval, NULL);
+      on->thread_send_lsreq = NULL;
+      thread_add_timer(master, ospf6_lsreq_send, on, on->ospf6_if->rxmt_interval,
+                       &on->thread_send_lsreq);
     }
 
   return 0;
@@ -2090,13 +2093,16 @@ ospf6_lsupdate_send_neighbor (struct thread *thread)
 		    on->ospf6_if, oh);
     }
 
-  if (on->lsupdate_list->count != 0)
-    on->thread_send_lsupdate =
-      thread_add_event (master, ospf6_lsupdate_send_neighbor, on, 0, NULL);
-  else if (on->retrans_list->count != 0)
-    on->thread_send_lsupdate =
-      thread_add_timer (master, ospf6_lsupdate_send_neighbor, on,
-			on->ospf6_if->rxmt_interval, NULL);
+  if (on->lsupdate_list->count != 0) {
+    on->thread_send_lsupdate = NULL;
+    thread_add_event(master, ospf6_lsupdate_send_neighbor, on, 0,
+                     &on->thread_send_lsupdate);
+  }
+  else if (on->retrans_list->count != 0) {
+    on->thread_send_lsupdate = NULL;
+    thread_add_timer(master, ospf6_lsupdate_send_neighbor, on, on->ospf6_if->rxmt_interval,
+                     &on->thread_send_lsupdate);
+  }
   return 0;
 }
 
@@ -2171,8 +2177,9 @@ ospf6_lsupdate_send_interface (struct thread *thread)
 
   if (oi->lsupdate_list->count > 0)
     {
-      oi->thread_send_lsupdate =
-        thread_add_event (master, ospf6_lsupdate_send_interface, oi, 0, NULL);
+      oi->thread_send_lsupdate = NULL;
+      thread_add_event(master, ospf6_lsupdate_send_interface, oi, 0,
+                       &oi->thread_send_lsupdate);
     }
 
   return 0;

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -238,8 +238,8 @@ hello_received (struct thread *thread)
 
   /* reset Inactivity Timer */
   THREAD_OFF (on->inactivity_timer);
-  on->inactivity_timer = thread_add_timer (master, inactivity_timer, on,
-                                           on->ospf6_if->dead_interval);
+  on->inactivity_timer = thread_add_timer(master, inactivity_timer, on,
+                                          on->ospf6_if->dead_interval, NULL);
 
   if (on->state <= OSPF6_NEIGHBOR_DOWN)
     ospf6_neighbor_state_change (OSPF6_NEIGHBOR_INIT, on,
@@ -262,7 +262,7 @@ twoway_received (struct thread *thread)
   if (IS_OSPF6_DEBUG_NEIGHBOR (EVENT))
     zlog_debug ("Neighbor Event %s: *2Way-Received*", on->name);
 
-  thread_add_event (master, neighbor_change, on->ospf6_if, 0);
+  thread_add_event(master, neighbor_change, on->ospf6_if, 0, NULL);
 
   if (! need_adjacency (on))
     {
@@ -279,7 +279,7 @@ twoway_received (struct thread *thread)
 
   THREAD_OFF (on->thread_send_dbdesc);
   on->thread_send_dbdesc =
-    thread_add_event (master, ospf6_dbdesc_send, on, 0);
+    thread_add_event(master, ospf6_dbdesc_send, on, 0, NULL);
 
   return 0;
 }
@@ -385,9 +385,8 @@ exchange_done (struct thread *thread)
       ospf6_neighbor_state_change (OSPF6_NEIGHBOR_LOADING, on,
 				   OSPF6_NEIGHBOR_EVENT_EXCHANGE_DONE);
 
-      if (on->thread_send_lsreq == NULL)
-	on->thread_send_lsreq =
-	  thread_add_event (master, ospf6_lsreq_send, on, 0);
+      thread_add_event(master, ospf6_lsreq_send, on, 0,
+                       &on->thread_send_lsreq);
     }
 
   return 0;
@@ -406,13 +405,13 @@ ospf6_check_nbr_loading (struct ospf6_neighbor *on)
       (on->state == OSPF6_NEIGHBOR_EXCHANGE))
     {
       if (on->request_list->count == 0)
-	thread_add_event (master, loading_done, on, 0);
+	thread_add_event(master, loading_done, on, 0, NULL);
       else if (on->last_ls_req == NULL)
 	{
 	  if (on->thread_send_lsreq != NULL)
 	    THREAD_OFF (on->thread_send_lsreq);
 	  on->thread_send_lsreq =
-	    thread_add_event (master, ospf6_lsreq_send, on, 0);
+	    thread_add_event(master, ospf6_lsreq_send, on, 0, NULL);
 	}
     }
 }
@@ -461,7 +460,7 @@ adj_ok (struct thread *thread)
 
       THREAD_OFF (on->thread_send_dbdesc);
       on->thread_send_dbdesc =
-        thread_add_event (master, ospf6_dbdesc_send, on, 0);
+        thread_add_event(master, ospf6_dbdesc_send, on, 0, NULL);
 
     }
   else if (on->state >= OSPF6_NEIGHBOR_EXSTART &&
@@ -516,7 +515,7 @@ seqnumber_mismatch (struct thread *thread)
   on->dbdesc_seqnum++;		/* Incr seqnum as per RFC2328, sec 10.3 */
 
   on->thread_send_dbdesc =
-    thread_add_event (master, ospf6_dbdesc_send, on, 0);
+    thread_add_event(master, ospf6_dbdesc_send, on, 0, NULL);
 
   return 0;
 }
@@ -555,7 +554,7 @@ bad_lsreq (struct thread *thread)
   on->dbdesc_seqnum++;		/* Incr seqnum as per RFC2328, sec 10.3 */
 
   on->thread_send_dbdesc =
-    thread_add_event (master, ospf6_dbdesc_send, on, 0);
+    thread_add_event(master, ospf6_dbdesc_send, on, 0, NULL);
 
   return 0;
 }
@@ -577,7 +576,7 @@ oneway_received (struct thread *thread)
 
   ospf6_neighbor_state_change (OSPF6_NEIGHBOR_INIT, on,
 			       OSPF6_NEIGHBOR_EVENT_ONEWAY_RCVD);
-  thread_add_event (master, neighbor_change, on->ospf6_if, 0);
+  thread_add_event(master, neighbor_change, on->ospf6_if, 0, NULL);
 
   ospf6_lsdb_remove_all (on->summary_list);
   ospf6_lsdb_remove_all (on->request_list);
@@ -613,7 +612,7 @@ inactivity_timer (struct thread *thread)
 
   ospf6_neighbor_state_change (OSPF6_NEIGHBOR_DOWN, on,
 			       OSPF6_NEIGHBOR_EVENT_INACTIVITY_TIMER);
-  thread_add_event (master, neighbor_change, on->ospf6_if, 0);
+  thread_add_event(master, neighbor_change, on->ospf6_if, 0, NULL);
 
   listnode_delete (on->ospf6_if->neighbor_list, on);
   ospf6_neighbor_delete (on);

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -238,8 +238,9 @@ hello_received (struct thread *thread)
 
   /* reset Inactivity Timer */
   THREAD_OFF (on->inactivity_timer);
-  on->inactivity_timer = thread_add_timer(master, inactivity_timer, on,
-                                          on->ospf6_if->dead_interval, NULL);
+  on->inactivity_timer = NULL;
+  thread_add_timer(master, inactivity_timer, on, on->ospf6_if->dead_interval,
+                   &on->inactivity_timer);
 
   if (on->state <= OSPF6_NEIGHBOR_DOWN)
     ospf6_neighbor_state_change (OSPF6_NEIGHBOR_INIT, on,
@@ -278,8 +279,8 @@ twoway_received (struct thread *thread)
   SET_FLAG (on->dbdesc_bits, OSPF6_DBDESC_IBIT);
 
   THREAD_OFF (on->thread_send_dbdesc);
-  on->thread_send_dbdesc =
-    thread_add_event(master, ospf6_dbdesc_send, on, 0, NULL);
+  on->thread_send_dbdesc = NULL;
+  thread_add_event(master, ospf6_dbdesc_send, on, 0, &on->thread_send_dbdesc);
 
   return 0;
 }
@@ -410,8 +411,9 @@ ospf6_check_nbr_loading (struct ospf6_neighbor *on)
 	{
 	  if (on->thread_send_lsreq != NULL)
 	    THREAD_OFF (on->thread_send_lsreq);
-	  on->thread_send_lsreq =
-	    thread_add_event(master, ospf6_lsreq_send, on, 0, NULL);
+	  on->thread_send_lsreq = NULL;
+	  thread_add_event(master, ospf6_lsreq_send, on, 0,
+                           &on->thread_send_lsreq);
 	}
     }
 }
@@ -459,8 +461,9 @@ adj_ok (struct thread *thread)
       SET_FLAG (on->dbdesc_bits, OSPF6_DBDESC_IBIT);
 
       THREAD_OFF (on->thread_send_dbdesc);
-      on->thread_send_dbdesc =
-        thread_add_event(master, ospf6_dbdesc_send, on, 0, NULL);
+      on->thread_send_dbdesc = NULL;
+      thread_add_event(master, ospf6_dbdesc_send, on, 0,
+                       &on->thread_send_dbdesc);
 
     }
   else if (on->state >= OSPF6_NEIGHBOR_EXSTART &&
@@ -514,8 +517,8 @@ seqnumber_mismatch (struct thread *thread)
   THREAD_OFF (on->thread_send_dbdesc);
   on->dbdesc_seqnum++;		/* Incr seqnum as per RFC2328, sec 10.3 */
 
-  on->thread_send_dbdesc =
-    thread_add_event(master, ospf6_dbdesc_send, on, 0, NULL);
+  on->thread_send_dbdesc = NULL;
+  thread_add_event(master, ospf6_dbdesc_send, on, 0, &on->thread_send_dbdesc);
 
   return 0;
 }
@@ -553,8 +556,8 @@ bad_lsreq (struct thread *thread)
   THREAD_OFF (on->thread_send_dbdesc);
   on->dbdesc_seqnum++;		/* Incr seqnum as per RFC2328, sec 10.3 */
 
-  on->thread_send_dbdesc =
-    thread_add_event(master, ospf6_dbdesc_send, on, 0, NULL);
+  on->thread_send_dbdesc = NULL;
+  thread_add_event(master, ospf6_dbdesc_send, on, 0, &on->thread_send_dbdesc);
 
   return 0;
 }

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -727,9 +727,9 @@ ospf6_spf_schedule (struct ospf6 *ospf6, unsigned int reason)
 
   zlog_info ("SPF: Scheduled in %ld msec", delay);
 
-  ospf6->t_spf_calc =
-    thread_add_timer_msec(master, ospf6_spf_calculation_thread, ospf6, delay,
-                          NULL);
+  ospf6->t_spf_calc = NULL;
+  thread_add_timer_msec(master, ospf6_spf_calculation_thread, ospf6, delay,
+                        &ospf6->t_spf_calc);
 }
 
 void

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -728,7 +728,8 @@ ospf6_spf_schedule (struct ospf6 *ospf6, unsigned int reason)
   zlog_info ("SPF: Scheduled in %ld msec", delay);
 
   ospf6->t_spf_calc =
-    thread_add_timer_msec (master, ospf6_spf_calculation_thread, ospf6, delay);
+    thread_add_timer_msec(master, ospf6_spf_calculation_thread, ospf6, delay,
+                          NULL);
 }
 
 void

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -286,10 +286,9 @@ ospf6_maxage_remover (struct thread *thread)
 void
 ospf6_maxage_remove (struct ospf6 *o)
 {
-  if (o && ! o->maxage_remover)
-    o->maxage_remover = thread_add_timer(master, ospf6_maxage_remover, o,
-                                         OSPF_LSA_MAXAGE_REMOVE_DELAY_DEFAULT,
-                                         NULL);
+  if (o)
+    thread_add_timer(master, ospf6_maxage_remover, o, OSPF_LSA_MAXAGE_REMOVE_DELAY_DEFAULT,
+                     &o->maxage_remover);
 }
 
 /* start ospf6 */

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -287,8 +287,9 @@ void
 ospf6_maxage_remove (struct ospf6 *o)
 {
   if (o && ! o->maxage_remover)
-    o->maxage_remover = thread_add_timer (master, ospf6_maxage_remover, o,
-					  OSPF_LSA_MAXAGE_REMOVE_DELAY_DEFAULT);
+    o->maxage_remover = thread_add_timer(master, ospf6_maxage_remover, o,
+                                         OSPF_LSA_MAXAGE_REMOVE_DELAY_DEFAULT,
+                                         NULL);
 }
 
 /* start ospf6 */

--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -1252,7 +1252,7 @@ ospf6_init (void)
 
   /* Make ospf protocol socket. */
   ospf6_serv_sock ();
-  thread_add_read (master, ospf6_receive, NULL, ospf6_sock);
+  thread_add_read(master, ospf6_receive, NULL, ospf6_sock, NULL);
 }
 
 void

--- a/ospfclient/ospfclient.c
+++ b/ospfclient/ospfclient.c
@@ -168,7 +168,7 @@ lsa_read (struct thread *thread)
   }
 
   /* Reschedule read thread */
-  thread_add_read (master, lsa_read, oclient, fd);
+  thread_add_read(master, lsa_read, oclient, fd, NULL);
 
   return 0;
 }
@@ -224,13 +224,13 @@ ready_callback (u_char lsa_type, u_char opaque_type, struct in_addr addr)
 	  lsa_type, opaque_type, inet_ntoa (addr));
 
   /* Schedule opaque LSA originate in 5 secs */
-  thread_add_timer (master, lsa_inject, oclient, 5);
+  thread_add_timer(master, lsa_inject, oclient, 5, NULL);
 
   /* Schedule opaque LSA update with new value */
-  thread_add_timer (master, lsa_inject, oclient, 10);
+  thread_add_timer(master, lsa_inject, oclient, 10, NULL);
 
   /* Schedule delete */
-  thread_add_timer (master, lsa_delete, oclient, 30);
+  thread_add_timer(master, lsa_delete, oclient, 30, NULL);
 }
 
 static void
@@ -340,7 +340,7 @@ main (int argc, char *argv[])
   ospf_apiclient_sync_lsdb (oclient);
 
   /* Schedule thread that handles asynchronous messages */
-  thread_add_read (master, lsa_read, oclient, oclient->fd_async);
+  thread_add_read(master, lsa_read, oclient, oclient->fd_async, NULL);
 
   /* Now connection is established, run loop */
   while (1)

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -1881,7 +1881,6 @@ ospf_schedule_abr_task (struct ospf *ospf)
   if (IS_DEBUG_OSPF_EVENT)
     zlog_debug ("Scheduling ABR task");
 
-  if (ospf->t_abr_task == NULL)
-    ospf->t_abr_task = thread_add_timer (master, ospf_abr_task_timer,
-					 ospf, OSPF_ABR_TASK_DELAY);
+  thread_add_timer(master, ospf_abr_task_timer, ospf, OSPF_ABR_TASK_DELAY,
+                   &ospf->t_abr_task);
 }

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -304,30 +304,24 @@ ospf_apiserver_event (enum event event, int fd,
       (void) thread_add_read(master, ospf_apiserver_accept, apiserv, fd, NULL);
       break;
     case OSPF_APISERVER_SYNC_READ:
-      apiserv->t_sync_read =
-	thread_add_read(master, ospf_apiserver_read, apiserv, fd, NULL);
+      apiserv->t_sync_read = NULL;
+      thread_add_read(master, ospf_apiserver_read, apiserv, fd,
+                      &apiserv->t_sync_read);
       break;
 #ifdef USE_ASYNC_READ
     case OSPF_APISERVER_ASYNC_READ:
-      apiserv->t_async_read =
-	thread_add_read(master, ospf_apiserver_read, apiserv, fd, NULL);
+      apiserv->t_async_read = NULL;
+      thread_add_read(master, ospf_apiserver_read, apiserv, fd,
+                      &apiserv->t_async_read);
       break;
 #endif /* USE_ASYNC_READ */
     case OSPF_APISERVER_SYNC_WRITE:
-      if (!apiserv->t_sync_write)
-	{
-	  apiserv->t_sync_write =
-	    thread_add_write(master, ospf_apiserver_sync_write, apiserv, fd,
-                             NULL);
-	}
+      thread_add_write(master, ospf_apiserver_sync_write, apiserv, fd,
+                       &apiserv->t_sync_write);
       break;
     case OSPF_APISERVER_ASYNC_WRITE:
-      if (!apiserv->t_async_write)
-	{
-	  apiserv->t_async_write =
-	    thread_add_write(master, ospf_apiserver_async_write, apiserv, fd,
-                             NULL);
-	}
+      thread_add_write(master, ospf_apiserver_async_write, apiserv, fd,
+                       &apiserv->t_async_write);
       break;
     }
 }

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -301,30 +301,32 @@ ospf_apiserver_event (enum event event, int fd,
   switch (event)
     {
     case OSPF_APISERVER_ACCEPT:
-      (void)thread_add_read (master, ospf_apiserver_accept, apiserv, fd);
+      (void) thread_add_read(master, ospf_apiserver_accept, apiserv, fd, NULL);
       break;
     case OSPF_APISERVER_SYNC_READ:
       apiserv->t_sync_read =
-	thread_add_read (master, ospf_apiserver_read, apiserv, fd);
+	thread_add_read(master, ospf_apiserver_read, apiserv, fd, NULL);
       break;
 #ifdef USE_ASYNC_READ
     case OSPF_APISERVER_ASYNC_READ:
       apiserv->t_async_read =
-	thread_add_read (master, ospf_apiserver_read, apiserv, fd);
+	thread_add_read(master, ospf_apiserver_read, apiserv, fd, NULL);
       break;
 #endif /* USE_ASYNC_READ */
     case OSPF_APISERVER_SYNC_WRITE:
       if (!apiserv->t_sync_write)
 	{
 	  apiserv->t_sync_write =
-	    thread_add_write (master, ospf_apiserver_sync_write, apiserv, fd);
+	    thread_add_write(master, ospf_apiserver_sync_write, apiserv, fd,
+                             NULL);
 	}
       break;
     case OSPF_APISERVER_ASYNC_WRITE:
       if (!apiserv->t_async_write)
 	{
 	  apiserv->t_async_write =
-	    thread_add_write (master, ospf_apiserver_async_write, apiserv, fd);
+	    thread_add_write(master, ospf_apiserver_async_write, apiserv, fd,
+                             NULL);
 	}
       break;
     }

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -705,9 +705,8 @@ ospf_ase_calculate_timer_add (struct ospf *ospf)
   if (ospf == NULL)
     return;
 
-  if (! ospf->t_ase_calc)
-    ospf->t_ase_calc = thread_add_timer (master, ospf_ase_calculate_timer,
-					 ospf, OSPF_ASE_CALC_INTERVAL);
+  thread_add_timer(master, ospf_ase_calculate_timer, ospf,
+                   OSPF_ASE_CALC_INTERVAL, &ospf->t_ase_calc);
 }
 
 void

--- a/ospfd/ospf_ism.h
+++ b/ospfd/ospf_ism.h
@@ -48,30 +48,23 @@
 #define ISM_InterfaceDown                 7
 #define OSPF_ISM_EVENT_MAX                8
 
-#define OSPF_ISM_WRITE_ON(O)                                                  \
-      do                                                                      \
-        {                                                                     \
-          if (oi->on_write_q == 0)                                            \
-	    {                                                                 \
-              listnode_add ((O)->oi_write_q, oi);                             \
-	      oi->on_write_q = 1;                                             \
-	    }                                                                 \
-	  if ((O)->t_write == NULL)                                           \
-	    (O)->t_write =                                                    \
-	      thread_add_write (master, ospf_write, (O), (O)->fd);            \
-        } while (0)
+#define OSPF_ISM_WRITE_ON(O) \
+  do \
+    { \
+      if (oi->on_write_q == 0) \
+        { \
+          listnode_add ((O)->oi_write_q, oi); \
+          oi->on_write_q = 1; \
+        } \
+      thread_add_write (master, ospf_write, (O), (O)->fd, &(O)->t_write); \
+    } while (0)
      
 /* Macro for OSPF ISM timer turn on. */
 #define OSPF_ISM_TIMER_ON(T,F,V) \
-  do { \
-    if (!(T)) \
-      (T) = thread_add_timer (master, (F), oi, (V)); \
-  } while (0)
+    thread_add_timer (master, (F), oi, (V), &(T))
+
 #define OSPF_ISM_TIMER_MSEC_ON(T,F,V) \
-  do { \
-    if (!(T)) \
-      (T) = thread_add_timer_msec (master, (F), oi, (V)); \
-  } while (0)
+    thread_add_timer_msec (master, (F), oi, (V), &(T))
 
 /* convenience macro to set hello timer correctly, according to
  * whether fast-hello is set or not
@@ -98,7 +91,7 @@
 
 /* Macro for OSPF schedule event. */
 #define OSPF_ISM_EVENT_SCHEDULE(I,E) \
-      thread_add_event (master, ospf_ism_event, (I), (E))
+      thread_add_event (master, ospf_ism_event, (I), (E), NULL)
 
 /* Macro for OSPF execute event. */
 #define OSPF_ISM_EVENT_EXECUTE(I,E) \

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3741,9 +3741,9 @@ ospf_lsa_refresh_walker (struct thread *t)
 	}
     }
 
-  ospf->t_lsa_refresher = thread_add_timer(master, ospf_lsa_refresh_walker,
-                                           ospf, ospf->lsa_refresh_interval,
-                                           NULL);
+  ospf->t_lsa_refresher = NULL;
+  thread_add_timer(master, ospf_lsa_refresh_walker, ospf, ospf->lsa_refresh_interval,
+                   &ospf->t_lsa_refresher);
   ospf->lsa_refresher_started = monotime(NULL);
 
   for (ALL_LIST_ELEMENTS (lsa_to_refresh, node, nnode, lsa))

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3553,7 +3553,7 @@ ospf_schedule_lsa_flood_area (struct ospf_area *area, struct ospf_lsa *lsa)
   data->area = area;
   data->lsa  = ospf_lsa_lock (lsa); /* Message / Flood area */
 
-  thread_add_event (master, ospf_lsa_action, data, 0);
+  thread_add_event(master, ospf_lsa_action, data, 0, NULL);
 }
 
 void
@@ -3566,7 +3566,7 @@ ospf_schedule_lsa_flush_area (struct ospf_area *area, struct ospf_lsa *lsa)
   data->area = area;
   data->lsa  = ospf_lsa_lock (lsa); /* Message / Flush area */
 
-  thread_add_event (master, ospf_lsa_action, data, 0);
+  thread_add_event(master, ospf_lsa_action, data, 0, NULL);
 }
 
 
@@ -3741,8 +3741,9 @@ ospf_lsa_refresh_walker (struct thread *t)
 	}
     }
 
-  ospf->t_lsa_refresher = thread_add_timer (master, ospf_lsa_refresh_walker,
-					   ospf, ospf->lsa_refresh_interval);
+  ospf->t_lsa_refresher = thread_add_timer(master, ospf_lsa_refresh_walker,
+                                           ospf, ospf->lsa_refresh_interval,
+                                           NULL);
   ospf->lsa_refresher_started = monotime(NULL);
 
   for (ALL_LIST_ELEMENTS (lsa_to_refresh, node, nnode, lsa))

--- a/ospfd/ospf_nsm.h
+++ b/ospfd/ospf_nsm.h
@@ -57,11 +57,7 @@
 #define OSPF_NSM_EVENT_MAX     14
 
 /* Macro for OSPF NSM timer turn on. */
-#define OSPF_NSM_TIMER_ON(T,F,V)                                              \
-      do {                                                                    \
-        if (!(T))                                                             \
-          (T) = thread_add_timer (master, (F), nbr, (V));                     \
-      } while (0)
+#define OSPF_NSM_TIMER_ON(T,F,V) thread_add_timer (master, (F), nbr, (V), &(T))
 
 /* Macro for OSPF NSM timer turn off. */
 #define OSPF_NSM_TIMER_OFF(X)                                                 \
@@ -75,7 +71,7 @@
 
 /* Macro for OSPF NSM schedule event. */
 #define OSPF_NSM_EVENT_SCHEDULE(N,E)                                          \
-      thread_add_event (master, ospf_nsm_event, (N), (E))
+      thread_add_event (master, ospf_nsm_event, (N), (E), NULL)
 
 /* Macro for OSPF NSM execute event. */
 #define OSPF_NSM_EVENT_EXECUTE(N,E)                                           \

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1342,9 +1342,9 @@ ospf_opaque_lsa_originate_schedule (struct ospf_interface *oi, int *delay0)
     {
       if (IS_DEBUG_OSPF_EVENT)
         zlog_debug ("Schedule Type-9 Opaque-LSA origination in %d ms later.", delay);
-      oi->t_opaque_lsa_self =
-	thread_add_timer_msec(master, ospf_opaque_type9_lsa_originate, oi,
-                              delay, NULL);
+      oi->t_opaque_lsa_self = NULL;
+      thread_add_timer_msec(master, ospf_opaque_type9_lsa_originate, oi, delay,
+                            &oi->t_opaque_lsa_self);
       delay += top->min_ls_interval;
     }
 
@@ -1359,9 +1359,9 @@ ospf_opaque_lsa_originate_schedule (struct ospf_interface *oi, int *delay0)
        */
       if (IS_DEBUG_OSPF_EVENT)
         zlog_debug ("Schedule Type-10 Opaque-LSA origination in %d ms later.", delay);
-      area->t_opaque_lsa_self =
-        thread_add_timer_msec(master, ospf_opaque_type10_lsa_originate, area,
-                              delay, NULL);
+      area->t_opaque_lsa_self = NULL;
+      thread_add_timer_msec(master, ospf_opaque_type10_lsa_originate, area, delay,
+                            &area->t_opaque_lsa_self);
       delay += top->min_ls_interval;
     }
 
@@ -1376,9 +1376,9 @@ ospf_opaque_lsa_originate_schedule (struct ospf_interface *oi, int *delay0)
        */
       if (IS_DEBUG_OSPF_EVENT)
         zlog_debug ("Schedule Type-11 Opaque-LSA origination in %d ms later.", delay);
-      top->t_opaque_lsa_self =
-        thread_add_timer_msec(master, ospf_opaque_type11_lsa_originate, top,
-                              delay, NULL);
+      top->t_opaque_lsa_self = NULL;
+      thread_add_timer_msec(master, ospf_opaque_type11_lsa_originate, top, delay,
+                            &top->t_opaque_lsa_self);
       delay += top->min_ls_interval;
     }
 

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1343,7 +1343,8 @@ ospf_opaque_lsa_originate_schedule (struct ospf_interface *oi, int *delay0)
       if (IS_DEBUG_OSPF_EVENT)
         zlog_debug ("Schedule Type-9 Opaque-LSA origination in %d ms later.", delay);
       oi->t_opaque_lsa_self =
-	thread_add_timer_msec (master, ospf_opaque_type9_lsa_originate, oi, delay);
+	thread_add_timer_msec(master, ospf_opaque_type9_lsa_originate, oi,
+                              delay, NULL);
       delay += top->min_ls_interval;
     }
 
@@ -1359,8 +1360,8 @@ ospf_opaque_lsa_originate_schedule (struct ospf_interface *oi, int *delay0)
       if (IS_DEBUG_OSPF_EVENT)
         zlog_debug ("Schedule Type-10 Opaque-LSA origination in %d ms later.", delay);
       area->t_opaque_lsa_self =
-        thread_add_timer_msec (master, ospf_opaque_type10_lsa_originate,
-			       area, delay);
+        thread_add_timer_msec(master, ospf_opaque_type10_lsa_originate, area,
+                              delay, NULL);
       delay += top->min_ls_interval;
     }
 
@@ -1376,8 +1377,8 @@ ospf_opaque_lsa_originate_schedule (struct ospf_interface *oi, int *delay0)
       if (IS_DEBUG_OSPF_EVENT)
         zlog_debug ("Schedule Type-11 Opaque-LSA origination in %d ms later.", delay);
       top->t_opaque_lsa_self =
-        thread_add_timer_msec (master, ospf_opaque_type11_lsa_originate,
-			       top, delay);
+        thread_add_timer_msec(master, ospf_opaque_type11_lsa_originate, top,
+                              delay, NULL);
       delay += top->min_ls_interval;
     }
 
@@ -1654,9 +1655,7 @@ ospf_opaque_lsa_refresh (struct ospf_lsa *lsa)
  * triggered by external interventions (vty session, signaling, etc).
  *------------------------------------------------------------------------*/
 
-#define OSPF_OPAQUE_TIMER_ON(T,F,L,V) \
-      if (!(T)) \
-        (T) = thread_add_timer_msec (master, (F), (L), (V))
+#define OSPF_OPAQUE_TIMER_ON(T,F,L,V) thread_add_timer_msec (master, (F), (L), (V), &(T))
 
 static struct ospf_lsa *pseudo_lsa (struct ospf_interface *oi, struct ospf_area *area, u_char lsa_type, u_char opaque_type);
 static int ospf_opaque_type9_lsa_reoriginate_timer (struct thread *t);

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1465,5 +1465,5 @@ ospf_spf_calculate_schedule (struct ospf *ospf, ospf_spf_reason_t reason)
   zlog_info ("SPF: Scheduled in %ld msec", delay);
 
   ospf->t_spf_calc =
-    thread_add_timer_msec (master, ospf_spf_calculate_timer, ospf, delay);
+    thread_add_timer_msec(master, ospf_spf_calculate_timer, ospf, delay, NULL);
 }

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1464,6 +1464,7 @@ ospf_spf_calculate_schedule (struct ospf *ospf, ospf_spf_reason_t reason)
 
   zlog_info ("SPF: Scheduled in %ld msec", delay);
 
-  ospf->t_spf_calc =
-    thread_add_timer_msec(master, ospf_spf_calculate_timer, ospf, delay, NULL);
+  ospf->t_spf_calc = NULL;
+  thread_add_timer_msec(master, ospf_spf_calculate_timer, ospf, delay,
+                        &ospf->t_spf_calc);
 }

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1278,9 +1278,9 @@ ospf_distribute_list_update (struct ospf *ospf, uintptr_t type,
     return;
 
   /* Set timer. */
-  ospf->t_distribute_update =
-    thread_add_timer_msec(master, ospf_distribute_list_update_timer,
-                          (void *)type, ospf->min_ls_interval, NULL);
+  ospf->t_distribute_update = NULL;
+  thread_add_timer_msec(master, ospf_distribute_list_update_timer, (void *)type, ospf->min_ls_interval,
+                        &ospf->t_distribute_update);
 }
 
 /* If access-list is updated, apply some check. */

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -883,7 +883,7 @@ ospf_redistribute_default_set (struct ospf *ospf, int originate,
   if (ospf->router_id.s_addr == 0)
     ospf->external_origin |= (1 << DEFAULT_ROUTE);
   else
-    thread_add_timer (master, ospf_default_originate_timer, ospf, 1);
+    thread_add_timer(master, ospf_default_originate_timer, ospf, 1, NULL);
 
   ospf_asbr_status_update (ospf, ++ospf->redistribute);
 
@@ -1279,8 +1279,8 @@ ospf_distribute_list_update (struct ospf *ospf, uintptr_t type,
 
   /* Set timer. */
   ospf->t_distribute_update =
-    thread_add_timer_msec (master, ospf_distribute_list_update_timer,
-                           (void *) type, ospf->min_ls_interval);
+    thread_add_timer_msec(master, ospf_distribute_list_update_timer,
+                          (void *)type, ospf->min_ls_interval, NULL);
 }
 
 /* If access-list is updated, apply some check. */

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -264,18 +264,18 @@ ospf_new (u_short instance)
   /* MaxAge init. */
   new->maxage_delay = OSPF_LSA_MAXAGE_REMOVE_DELAY_DEFAULT;
   new->maxage_lsa = route_table_init();
-  new->t_maxage_walker =
-    thread_add_timer(master, ospf_lsa_maxage_walker, new,
-                     OSPF_LSA_MAXAGE_CHECK_INTERVAL, NULL);
+  new->t_maxage_walker = NULL;
+  thread_add_timer(master, ospf_lsa_maxage_walker, new, OSPF_LSA_MAXAGE_CHECK_INTERVAL,
+                   &new->t_maxage_walker);
 
   /* Distance table init. */
   new->distance_table = route_table_init ();
 
   new->lsa_refresh_queue.index = 0;
   new->lsa_refresh_interval = OSPF_LSA_REFRESH_INTERVAL_DEFAULT;
-  new->t_lsa_refresher = thread_add_timer(master, ospf_lsa_refresh_walker,
-                                          new, new->lsa_refresh_interval,
-                                          NULL);
+  new->t_lsa_refresher = NULL;
+  thread_add_timer(master, ospf_lsa_refresh_walker, new, new->lsa_refresh_interval,
+                   &new->t_lsa_refresher);
   new->lsa_refresher_started = monotime(NULL);
 
   if ((new->fd = ospf_sock_init()) < 0)
@@ -290,7 +290,8 @@ ospf_new (u_short instance)
 	       OSPF_MAX_PACKET_SIZE+1);
       exit(1);
     }
-  new->t_read = thread_add_read(master, ospf_read, new, new->fd, NULL);
+  new->t_read = NULL;
+  thread_add_read(master, ospf_read, new, new->fd, &new->t_read);
   new->oi_write_q = list_new ();
   new->write_oi_count = OSPF_WRITE_INTERFACE_COUNT_DEFAULT;
   
@@ -1594,9 +1595,8 @@ ospf_timers_refresh_set (struct ospf *ospf, int interval)
   if (time_left > interval)
     {
       OSPF_TIMER_OFF (ospf->t_lsa_refresher);
-      ospf->t_lsa_refresher =
-	thread_add_timer(master, ospf_lsa_refresh_walker, ospf, interval,
-                         NULL);
+      thread_add_timer(master, ospf_lsa_refresh_walker, ospf, interval,
+                       &ospf->t_lsa_refresher);
     }
   ospf->lsa_refresh_interval = interval;
 
@@ -1614,9 +1614,9 @@ ospf_timers_refresh_unset (struct ospf *ospf)
   if (time_left > OSPF_LSA_REFRESH_INTERVAL_DEFAULT)
     {
       OSPF_TIMER_OFF (ospf->t_lsa_refresher);
-      ospf->t_lsa_refresher =
-	thread_add_timer(master, ospf_lsa_refresh_walker, ospf,
-                         OSPF_LSA_REFRESH_INTERVAL_DEFAULT, NULL);
+      ospf->t_lsa_refresher = NULL;
+      thread_add_timer(master, ospf_lsa_refresh_walker, ospf, OSPF_LSA_REFRESH_INTERVAL_DEFAULT,
+                       &ospf->t_lsa_refresher);
     }
 
   ospf->lsa_refresh_interval = OSPF_LSA_REFRESH_INTERVAL_DEFAULT;

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -135,11 +135,12 @@ ospf_router_id_update (struct ospf *ospf)
 	  /* Originate each redistributed external route. */
 	  for (type = 0; type < ZEBRA_ROUTE_MAX; type++)
 	    if (ospf->external_origin & (1 << type))
-	      thread_add_event (master, ospf_external_lsa_originate_timer,
-				ospf, type);
+	      thread_add_event(master, ospf_external_lsa_originate_timer,
+                               ospf, type, NULL);
 	  /* Originate Deafult. */
 	  if (ospf->external_origin & (1 << ZEBRA_ROUTE_MAX))
-	    thread_add_event (master, ospf_default_originate_timer, ospf, 0);
+	    thread_add_event(master, ospf_default_originate_timer, ospf, 0,
+                             NULL);
 
 	  ospf->external_origin = 0;
 	}
@@ -184,9 +185,9 @@ ospf_router_id_update (struct ospf *ospf)
 
       /* Originate each redistributed external route. */
       for (type = 0; type < ZEBRA_ROUTE_MAX; type++)
-        thread_add_event (master, ospf_external_lsa_originate_timer,
-                          ospf, type);
-      thread_add_event (master, ospf_default_originate_timer, ospf, 0);
+        thread_add_event(master, ospf_external_lsa_originate_timer, ospf,
+                         type, NULL);
+      thread_add_event(master, ospf_default_originate_timer, ospf, 0, NULL);
 
       /* update router-lsa's for each area */
       ospf_router_lsa_update (ospf);
@@ -264,16 +265,17 @@ ospf_new (u_short instance)
   new->maxage_delay = OSPF_LSA_MAXAGE_REMOVE_DELAY_DEFAULT;
   new->maxage_lsa = route_table_init();
   new->t_maxage_walker =
-    thread_add_timer (master, ospf_lsa_maxage_walker,
-                      new, OSPF_LSA_MAXAGE_CHECK_INTERVAL);
+    thread_add_timer(master, ospf_lsa_maxage_walker, new,
+                     OSPF_LSA_MAXAGE_CHECK_INTERVAL, NULL);
 
   /* Distance table init. */
   new->distance_table = route_table_init ();
 
   new->lsa_refresh_queue.index = 0;
   new->lsa_refresh_interval = OSPF_LSA_REFRESH_INTERVAL_DEFAULT;
-  new->t_lsa_refresher = thread_add_timer (master, ospf_lsa_refresh_walker,
-					   new, new->lsa_refresh_interval);
+  new->t_lsa_refresher = thread_add_timer(master, ospf_lsa_refresh_walker,
+                                          new, new->lsa_refresh_interval,
+                                          NULL);
   new->lsa_refresher_started = monotime(NULL);
 
   if ((new->fd = ospf_sock_init()) < 0)
@@ -288,7 +290,7 @@ ospf_new (u_short instance)
 	       OSPF_MAX_PACKET_SIZE+1);
       exit(1);
     }
-  new->t_read = thread_add_read (master, ospf_read, new, new->fd);
+  new->t_read = thread_add_read(master, ospf_read, new, new->fd, NULL);
   new->oi_write_q = list_new ();
   new->write_oi_count = OSPF_WRITE_INTERFACE_COUNT_DEFAULT;
   
@@ -1593,7 +1595,8 @@ ospf_timers_refresh_set (struct ospf *ospf, int interval)
     {
       OSPF_TIMER_OFF (ospf->t_lsa_refresher);
       ospf->t_lsa_refresher =
-	thread_add_timer (master, ospf_lsa_refresh_walker, ospf, interval);
+	thread_add_timer(master, ospf_lsa_refresh_walker, ospf, interval,
+                         NULL);
     }
   ospf->lsa_refresh_interval = interval;
 
@@ -1612,8 +1615,8 @@ ospf_timers_refresh_unset (struct ospf *ospf)
     {
       OSPF_TIMER_OFF (ospf->t_lsa_refresher);
       ospf->t_lsa_refresher =
-	thread_add_timer (master, ospf_lsa_refresh_walker, ospf,
-			  OSPF_LSA_REFRESH_INTERVAL_DEFAULT);
+	thread_add_timer(master, ospf_lsa_refresh_walker, ospf,
+                         OSPF_LSA_REFRESH_INTERVAL_DEFAULT, NULL);
     }
 
   ospf->lsa_refresh_interval = OSPF_LSA_REFRESH_INTERVAL_DEFAULT;

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -480,26 +480,10 @@ struct ospf_nbr_nbma
 #define LSA_OPTIONS_NSSA_GET(area) \
         (((area)->external_routing == OSPF_AREA_NSSA)  ? OSPF_OPTION_NP : 0)
 
-#define OSPF_TIMER_ON(T,F,V)                                                  \
-    do {                                                                      \
-      if (!(T))                                                               \
-	(T) = thread_add_timer (master, (F), ospf, (V));                      \
-    } while (0)
-
-#define OSPF_AREA_TIMER_ON(T,F,V)                                             \
-    do {                                                                      \
-      if (!(T))                                                               \
-        (T) = thread_add_timer (master, (F), area, (V));                      \
-    } while (0)
-
-#define OSPF_POLL_TIMER_ON(T,F,V)                                             \
-    do {                                                                      \
-      if (!(T))                                                               \
-        (T) = thread_add_timer (master, (F), nbr_nbma, (V));                  \
-    } while (0)
-
-#define OSPF_POLL_TIMER_OFF(X)		OSPF_TIMER_OFF((X))
-
+#define OSPF_TIMER_ON(T,F,V) thread_add_timer (master,(F),ospf,(V),&(T))
+#define OSPF_AREA_TIMER_ON(T,F,V) thread_add_timer (master, (F), area, (V), &(T))
+#define OSPF_POLL_TIMER_ON(T,F,V) thread_add_timer (master, (F), nbr_nbma, (V), &(T))
+#define OSPF_POLL_TIMER_OFF(X) OSPF_TIMER_OFF((X))
 #define OSPF_TIMER_OFF(X)                                                     \
     do {                                                                      \
       if (X)                                                                  \

--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -576,9 +576,8 @@ static void pim_assert_timer_set(struct pim_ifchannel *ch,
 	       ch->sg_str, interval, ch->interface->name);
   }
 
-  THREAD_TIMER_ON(master, ch->t_ifassert_timer,
-		  on_assert_timer,
-		  ch, interval);
+  thread_add_timer(master, on_assert_timer, ch, interval,
+                   &ch->t_ifassert_timer);
 }
 
 static void pim_assert_timer_reset(struct pim_ifchannel *ch)

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -855,9 +855,8 @@ void pim_ifchannel_join_add(struct interface *ifp,
   }
 
   if (holdtime != 0xFFFF) {
-    THREAD_TIMER_ON(master, ch->t_ifjoin_expiry_timer,
-		    on_ifjoin_expiry_timer,
-		    ch, holdtime);
+    thread_add_timer(master, on_ifjoin_expiry_timer, ch, holdtime,
+                     &ch->t_ifjoin_expiry_timer);
   }
 }
 
@@ -907,12 +906,11 @@ void pim_ifchannel_prune(struct interface *ifp,
 
 	THREAD_OFF(ch->t_ifjoin_prune_pending_timer);
 	THREAD_OFF(ch->t_ifjoin_expiry_timer);
-	THREAD_TIMER_MSEC_ON(master, ch->t_ifjoin_prune_pending_timer,
-			     on_ifjoin_prune_pending_timer,
-			     ch, jp_override_interval_msec);
-	THREAD_TIMER_ON(master, ch->t_ifjoin_expiry_timer,
-			on_ifjoin_expiry_timer,
-			ch, holdtime);
+	thread_add_timer_msec(master, on_ifjoin_prune_pending_timer, ch,
+                              jp_override_interval_msec,
+                              &ch->t_ifjoin_prune_pending_timer);
+	thread_add_timer(master, on_ifjoin_expiry_timer, ch, holdtime,
+                         &ch->t_ifjoin_expiry_timer);
         pim_upstream_update_join_desired(ch->upstream);
       }
     break;
@@ -932,17 +930,16 @@ void pim_ifchannel_prune(struct interface *ifp,
 	 be taken not to use "ch" afterwards since it would be
 	 deleted. */
     THREAD_OFF(ch->t_ifjoin_prune_pending_timer);
-    THREAD_TIMER_MSEC_ON(master, ch->t_ifjoin_prune_pending_timer,
-			 on_ifjoin_prune_pending_timer,
-			 ch, jp_override_interval_msec);
+    thread_add_timer_msec(master, on_ifjoin_prune_pending_timer, ch,
+                          jp_override_interval_msec,
+                          &ch->t_ifjoin_prune_pending_timer);
     break;
   case PIM_IFJOIN_PRUNE:
     if (source_flags & PIM_ENCODE_RPT_BIT)
       {
 	THREAD_OFF(ch->t_ifjoin_prune_pending_timer);
-	THREAD_TIMER_ON(master, ch->t_ifjoin_expiry_timer,
-			on_ifjoin_expiry_timer,
-			ch, holdtime);
+	thread_add_timer(master, on_ifjoin_expiry_timer, ch, holdtime,
+                         &ch->t_ifjoin_expiry_timer);
       }
     break;
   case PIM_IFJOIN_PRUNE_TMP:
@@ -950,9 +947,8 @@ void pim_ifchannel_prune(struct interface *ifp,
       {
 	ch->ifjoin_state = PIM_IFJOIN_PRUNE;
 	THREAD_OFF(ch->t_ifjoin_expiry_timer);
-	THREAD_TIMER_ON(master, ch->t_ifjoin_expiry_timer,
-			on_ifjoin_expiry_timer,
-			ch, holdtime);
+	thread_add_timer(master, on_ifjoin_expiry_timer, ch, holdtime,
+                         &ch->t_ifjoin_expiry_timer);
       }
     break;
   case PIM_IFJOIN_PRUNE_PENDING_TMP:
@@ -960,9 +956,8 @@ void pim_ifchannel_prune(struct interface *ifp,
       {
 	ch->ifjoin_state = PIM_IFJOIN_PRUNE_PENDING;
 	THREAD_OFF(ch->t_ifjoin_expiry_timer);
-	THREAD_TIMER_ON(master, ch->t_ifjoin_expiry_timer,
-			on_ifjoin_expiry_timer,
-			ch, holdtime);
+	thread_add_timer(master, on_ifjoin_expiry_timer, ch, holdtime,
+                         &ch->t_ifjoin_expiry_timer);
       }
     break;
   }

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -247,9 +247,9 @@ void pim_igmp_other_querier_timer_on(struct igmp_sock *igmp)
 	       other_querier_present_interval_msec % 1000);
   }
   
-  THREAD_TIMER_MSEC_ON(master, igmp->t_other_querier_timer,
-		       pim_igmp_other_querier_expire,
-		       igmp, other_querier_present_interval_msec);
+  thread_add_timer_msec(master, pim_igmp_other_querier_expire, igmp,
+                        other_querier_present_interval_msec,
+                        &igmp->t_other_querier_timer);
 }
 
 void pim_igmp_other_querier_timer_off(struct igmp_sock *igmp)
@@ -551,9 +551,8 @@ void pim_igmp_general_query_on(struct igmp_sock *igmp)
 	       igmp->fd);
   }
   igmp->t_igmp_query_timer = NULL;
-  THREAD_TIMER_ON(master, igmp->t_igmp_query_timer,
-		  pim_igmp_general_query,
-		  igmp, query_interval);
+  thread_add_timer(master, pim_igmp_general_query, igmp, query_interval,
+                   &igmp->t_igmp_query_timer);
 }
 
 void pim_igmp_general_query_off(struct igmp_sock *igmp)
@@ -896,7 +895,7 @@ igmp_read_on (struct igmp_sock *igmp)
 	       igmp->fd);
   }
   igmp->t_igmp_read = NULL;
-  THREAD_READ_ON(master, igmp->t_igmp_read, pim_igmp_read, igmp, igmp->fd);
+  thread_add_read(master, pim_igmp_read, igmp, igmp->fd, &igmp->t_igmp_read);
 
 }
 
@@ -1029,9 +1028,8 @@ void igmp_group_timer_on(struct igmp_group *group,
   */
   zassert(group->group_filtermode_isexcl);
 
-  THREAD_TIMER_MSEC_ON(master, group->t_group_timer,
-		       igmp_group_timer,
-		       group, interval_msec);
+  thread_add_timer_msec(master, igmp_group_timer, group, interval_msec,
+                        &group->t_group_timer);
 }
 
 struct igmp_group *

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -215,9 +215,8 @@ static void igmp_source_timer_on(struct igmp_group *group,
 	       group->group_igmp_sock->interface->name);
   }
 
-  THREAD_TIMER_MSEC_ON(master, source->t_source_timer,
-		       igmp_source_timer,
-		       source, interval_msec);
+  thread_add_timer_msec(master, igmp_source_timer, source, interval_msec,
+                        &source->t_source_timer);
   zassert(source->t_source_timer);
 
   /*
@@ -1328,9 +1327,8 @@ static void group_retransmit_timer_on(struct igmp_group *group)
 	       igmp->interface->name);
   }
 
-  THREAD_TIMER_MSEC_ON(master, group->t_group_query_retransmit_timer,
-		       igmp_group_retransmit,
-		       group, lmqi_msec);
+  thread_add_timer_msec(master, igmp_group_retransmit, group, lmqi_msec,
+                        &group->t_group_query_retransmit_timer);
 }
 
 static long igmp_group_timer_remain_msec(struct igmp_group *group)

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -636,8 +636,8 @@ static void mroute_read_on()
 {
   zassert(!qpim_mroute_socket_reader);
 
-  THREAD_READ_ON(master, qpim_mroute_socket_reader,
-		 mroute_read, 0, qpim_mroute_socket_fd);
+  thread_add_read(master, mroute_read, 0, qpim_mroute_socket_fd,
+                  &qpim_mroute_socket_reader);
 }
 
 static void mroute_read_off()

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -82,8 +82,8 @@ pim_msdp_sa_adv_timer_setup(bool start)
 {
   THREAD_OFF(msdp->sa_adv_timer);
   if (start) {
-    THREAD_TIMER_ON(msdp->master, msdp->sa_adv_timer,
-        pim_msdp_sa_adv_timer_cb, NULL, PIM_MSDP_SA_ADVERTISMENT_TIME);
+    thread_add_timer(msdp->master, pim_msdp_sa_adv_timer_cb, NULL,
+                     PIM_MSDP_SA_ADVERTISMENT_TIME, &msdp->sa_adv_timer);
   }
 }
 
@@ -108,8 +108,8 @@ pim_msdp_sa_state_timer_setup(struct pim_msdp_sa *sa, bool start)
 {
   THREAD_OFF(sa->sa_state_timer);
   if (start) {
-    THREAD_TIMER_ON(msdp->master, sa->sa_state_timer,
-        pim_msdp_sa_state_timer_cb, sa, PIM_MSDP_SA_HOLD_TIME);
+    thread_add_timer(msdp->master, pim_msdp_sa_state_timer_cb, sa,
+                     PIM_MSDP_SA_HOLD_TIME, &sa->sa_state_timer);
   }
 }
 
@@ -920,8 +920,8 @@ pim_msdp_peer_hold_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
   THREAD_OFF(mp->hold_timer);
   if (start) {
-    THREAD_TIMER_ON(msdp->master, mp->hold_timer,
-        pim_msdp_peer_hold_timer_cb, mp, PIM_MSDP_PEER_HOLD_TIME);
+    thread_add_timer(msdp->master, pim_msdp_peer_hold_timer_cb, mp,
+                     PIM_MSDP_PEER_HOLD_TIME, &mp->hold_timer);
   }
 }
 
@@ -948,8 +948,8 @@ pim_msdp_peer_ka_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
   THREAD_OFF(mp->ka_timer);
   if (start) {
-    THREAD_TIMER_ON(msdp->master, mp->ka_timer,
-        pim_msdp_peer_ka_timer_cb, mp, PIM_MSDP_PEER_KA_TIME);
+    thread_add_timer(msdp->master, pim_msdp_peer_ka_timer_cb, mp,
+                     PIM_MSDP_PEER_KA_TIME, &mp->ka_timer);
   }
 }
 
@@ -1013,8 +1013,8 @@ pim_msdp_peer_cr_timer_setup(struct pim_msdp_peer *mp, bool start)
 {
   THREAD_OFF(mp->cr_timer);
   if (start) {
-    THREAD_TIMER_ON(msdp->master, mp->cr_timer,
-        pim_msdp_peer_cr_timer_cb, mp, PIM_MSDP_PEER_CONNECT_RETRY_TIME);
+    thread_add_timer(msdp->master, pim_msdp_peer_cr_timer_cb, mp,
+                     PIM_MSDP_PEER_CONNECT_RETRY_TIME, &mp->cr_timer);
   }
 }
 

--- a/pimd/pim_msdp.h
+++ b/pimd/pim_msdp.h
@@ -197,8 +197,11 @@ struct pim_msdp {
   struct pim_msdp_mg *mg;
 };
 
-#define PIM_MSDP_PEER_READ_ON(mp) THREAD_READ_ON(msdp->master, mp->t_read, pim_msdp_read, mp, mp->fd);
-#define PIM_MSDP_PEER_WRITE_ON(mp) THREAD_WRITE_ON(msdp->master, mp->t_write, pim_msdp_write, mp, mp->fd);
+#define PIM_MSDP_PEER_READ_ON(mp) \
+  thread_add_read (msdp->master, pim_msdp_read, mp, mp->fd, &mp->t_read)
+
+#define PIM_MSDP_PEER_WRITE_ON(mp) \
+  thread_add_write (msdp->master, pim_msdp_write, mp, mp->fd, &mp->t_write)
 
 #define PIM_MSDP_PEER_READ_OFF(mp) THREAD_READ_OFF(mp->t_read)
 #define PIM_MSDP_PEER_WRITE_OFF(mp) THREAD_WRITE_OFF(mp->t_write)

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -70,8 +70,9 @@ pim_msdp_sock_accept(struct thread *thread)
     zlog_err ("accept_sock is negative value %d", accept_sock);
     return -1;
   }
-  listener->thread = thread_add_read(master, pim_msdp_sock_accept, listener,
-                                     accept_sock, NULL);
+  listener->thread = NULL;
+  thread_add_read(master, pim_msdp_sock_accept, listener, accept_sock,
+                  &listener->thread);
 
   /* accept client connection. */
   msdp_sock = sockunion_accept(accept_sock, &su);
@@ -173,8 +174,9 @@ pim_msdp_sock_listen(void)
   /* add accept thread */
   listener->fd = sock;
   memcpy(&listener->su, &sin, socklen);
-  listener->thread = thread_add_read(msdp->master, pim_msdp_sock_accept,
-                                     listener, sock, NULL);
+  listener->thread = NULL;
+  thread_add_read(msdp->master, pim_msdp_sock_accept, listener, sock,
+                  &listener->thread);
 
   msdp->flags |= PIM_MSDPF_LISTENER;
   return 0;

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -70,8 +70,8 @@ pim_msdp_sock_accept(struct thread *thread)
     zlog_err ("accept_sock is negative value %d", accept_sock);
     return -1;
   }
-  listener->thread = thread_add_read(master, pim_msdp_sock_accept,
-                                     listener, accept_sock);
+  listener->thread = thread_add_read(master, pim_msdp_sock_accept, listener,
+                                     accept_sock, NULL);
 
   /* accept client connection. */
   msdp_sock = sockunion_accept(accept_sock, &su);
@@ -173,7 +173,8 @@ pim_msdp_sock_listen(void)
   /* add accept thread */
   listener->fd = sock;
   memcpy(&listener->su, &sin, socklen);
-  listener->thread = thread_add_read(msdp->master, pim_msdp_sock_accept, listener, sock);
+  listener->thread = thread_add_read(msdp->master, pim_msdp_sock_accept,
+                                     listener, sock, NULL);
 
   msdp->flags |= PIM_MSDPF_LISTENER;
   return 0;

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -262,9 +262,8 @@ void pim_neighbor_timer_reset(struct pim_neighbor *neigh, uint16_t holdtime)
 	       neigh->holdtime, src_str, neigh->interface->name);
   }
 
-  THREAD_TIMER_ON(master, neigh->t_expire_timer,
-		  on_neighbor_timer,
-		  neigh, neigh->holdtime);
+  thread_add_timer(master, on_neighbor_timer, neigh, neigh->holdtime,
+                   &neigh->t_expire_timer);
 }
 
 static int
@@ -286,9 +285,8 @@ on_neighbor_jp_timer (struct thread *t)
   rpf.rpf_addr.u.prefix4 = neigh->source_addr;
   pim_joinprune_send(&rpf, neigh->upstream_jp_agg);
 
-  THREAD_TIMER_ON(master, neigh->jp_timer,
-                  on_neighbor_jp_timer,
-                  neigh, qpim_t_periodic);
+  thread_add_timer(master, on_neighbor_jp_timer, neigh, qpim_t_periodic,
+                   &neigh->jp_timer);
 
   return 0;
 }
@@ -297,9 +295,8 @@ static void
 pim_neighbor_start_jp_timer (struct pim_neighbor *neigh)
 {
   THREAD_TIMER_OFF(neigh->jp_timer);
-  THREAD_TIMER_ON(master, neigh->jp_timer,
-                  on_neighbor_jp_timer,
-                  neigh, qpim_t_periodic);
+  thread_add_timer(master, on_neighbor_jp_timer, neigh, qpim_t_periodic,
+                   &neigh->jp_timer);
 }
 
 static struct pim_neighbor *pim_neighbor_new(struct interface *ifp,

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -383,8 +383,8 @@ static void pim_sock_read_on(struct interface *ifp)
 	       pim_ifp->pim_sock_fd);
   }
   pim_ifp->t_pim_sock_read = NULL;
-  THREAD_READ_ON(master, pim_ifp->t_pim_sock_read, pim_sock_read, ifp,
-		 pim_ifp->pim_sock_fd);
+  thread_add_read(master, pim_sock_read, ifp, pim_ifp->pim_sock_fd,
+                  &pim_ifp->t_pim_sock_read);
 }
 
 static int pim_sock_open(struct interface *ifp)
@@ -703,9 +703,8 @@ static void hello_resched(struct interface *ifp)
 	       pim_ifp->pim_hello_period, ifp->name);
   }
   THREAD_OFF(pim_ifp->t_pim_hello_timer);
-  THREAD_TIMER_ON(master, pim_ifp->t_pim_hello_timer,
-		  on_pim_hello_send,
-		  ifp, pim_ifp->pim_hello_period);
+  thread_add_timer(master, on_pim_hello_send, ifp, pim_ifp->pim_hello_period,
+                   &pim_ifp->t_pim_hello_timer);
 }
 
 /*
@@ -814,9 +813,8 @@ void pim_hello_restart_triggered(struct interface *ifp)
 	       random_msec, ifp->name);
   }
 
-  THREAD_TIMER_MSEC_ON(master, pim_ifp->t_pim_hello_timer,
-		       on_pim_hello_send,
-		       ifp, random_msec);
+  thread_add_timer_msec(master, on_pim_hello_send, ifp, random_msec,
+                        &pim_ifp->t_pim_hello_timer);
 }
 
 int pim_sock_add(struct interface *ifp)

--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -331,8 +331,8 @@ static int ssmpingd_sock_read(struct thread *t)
 static void ssmpingd_read_on(struct ssmpingd_sock *ss)
 {
   zassert(!ss->t_sock_read);
-  THREAD_READ_ON(master, ss->t_sock_read,
-		 ssmpingd_sock_read, ss, ss->sock_fd);
+  thread_add_read(master, ssmpingd_sock_read, ss, ss->sock_fd,
+                  &ss->t_sock_read);
 }
 
 static struct ssmpingd_sock *ssmpingd_new(struct in_addr source_addr)

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -340,9 +340,8 @@ join_timer_start(struct pim_upstream *up)
   else
     {
       THREAD_OFF (up->t_join_timer);
-      THREAD_TIMER_ON(master, up->t_join_timer,
-                      on_join_timer,
-                      up, qpim_t_periodic);
+      thread_add_timer(master, on_join_timer, up, qpim_t_periodic,
+                       &up->t_join_timer);
     }
   pim_jp_agg_upstream_verification (up, true);
 }
@@ -371,9 +370,8 @@ static void pim_upstream_join_timer_restart_msec(struct pim_upstream *up,
   }
 
   THREAD_OFF(up->t_join_timer);
-  THREAD_TIMER_MSEC_ON(master, up->t_join_timer,
-		       on_join_timer,
-		       up, interval_msec);
+  thread_add_timer_msec(master, on_join_timer, up, interval_msec,
+                        &up->t_join_timer);
 }
 
 void pim_upstream_join_suppress(struct pim_upstream *up,
@@ -1119,10 +1117,8 @@ pim_upstream_keep_alive_timer_start (struct pim_upstream *up,
       zlog_debug ("kat start on %s with no stream reference", up->sg_str);
   }
   THREAD_OFF (up->t_ka_timer);
-  THREAD_TIMER_ON (master,
-		   up->t_ka_timer,
-		   pim_upstream_keep_alive_timer,
-		   up, time);
+  thread_add_timer(master, pim_upstream_keep_alive_timer, up, time,
+                   &up->t_ka_timer);
 
   /* any time keepalive is started against a SG we will have to
    * re-evaluate our active source database */
@@ -1146,8 +1142,8 @@ void
 pim_upstream_msdp_reg_timer_start(struct pim_upstream *up)
 {
   THREAD_OFF(up->t_msdp_reg_timer);
-  THREAD_TIMER_ON(master, up->t_msdp_reg_timer,
-      pim_upstream_msdp_reg_timer, up, PIM_MSDP_REG_RXED_PERIOD);
+  thread_add_timer(master, pim_upstream_msdp_reg_timer, up,
+                   PIM_MSDP_REG_RXED_PERIOD, &up->t_msdp_reg_timer);
 
   pim_msdp_sa_local_update(up);
 }
@@ -1408,9 +1404,8 @@ pim_upstream_start_register_stop_timer (struct pim_upstream *up, int null_regist
       zlog_debug ("%s: (S,G)=%s Starting upstream register stop timer %d",
 		  __PRETTY_FUNCTION__, up->sg_str, time);
     }
-  THREAD_TIMER_ON (master, up->t_rs_timer,
-		   pim_upstream_register_stop_timer,
-		   up, time);
+  thread_add_timer(master, pim_upstream_register_stop_timer, up, time,
+                   &up->t_rs_timer);
 }
 
 int

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -617,9 +617,9 @@ void sched_rpf_cache_refresh(void)
                qpim_rpf_cache_refresh_delay_msec);
   }
 
-  THREAD_TIMER_MSEC_ON(master, qpim_rpf_cache_refresher,
-                       on_rpf_cache_refresh,
-                       0, qpim_rpf_cache_refresh_delay_msec);
+  thread_add_timer_msec(master, on_rpf_cache_refresh, 0,
+                        qpim_rpf_cache_refresh_delay_msec,
+                        &qpim_rpf_cache_refresher);
 }
 
 static void

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -88,9 +88,8 @@ static void zclient_lookup_sched(struct zclient *zlookup, int delay)
 static void zclient_lookup_sched_now(struct zclient *zlookup)
 {
   zassert(!zlookup->t_connect);
-
-  zlookup->t_connect = thread_add_event(master, zclient_lookup_connect,
-                                        zlookup, 0, NULL);
+  thread_add_event(master, zclient_lookup_connect, zlookup, 0,
+                   &zlookup->t_connect);
 
   zlog_notice("%s: zclient lookup immediate connection scheduled",
 	      __PRETTY_FUNCTION__);

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -77,9 +77,8 @@ static void zclient_lookup_sched(struct zclient *zlookup, int delay)
 {
   zassert(!zlookup->t_connect);
 
-  THREAD_TIMER_ON(master, zlookup->t_connect,
-		  zclient_lookup_connect,
-		  zlookup, delay);
+  thread_add_timer(master, zclient_lookup_connect, zlookup, delay,
+                   &zlookup->t_connect);
 
   zlog_notice("%s: zclient lookup connection scheduled for %d seconds",
 	      __PRETTY_FUNCTION__, delay);
@@ -91,7 +90,7 @@ static void zclient_lookup_sched_now(struct zclient *zlookup)
   zassert(!zlookup->t_connect);
 
   zlookup->t_connect = thread_add_event(master, zclient_lookup_connect,
-					zlookup, 0);
+                                        zlookup, 0, NULL);
 
   zlog_notice("%s: zclient lookup immediate connection scheduled",
 	      __PRETTY_FUNCTION__);

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -1011,9 +1011,8 @@ rip_enable_apply (struct interface *ifp)
 	    zlog_debug ("turn on %s", ifp->name);
 
 	  /* Add interface wake up thread. */
-	  if (! ri->t_wakeup)
-	    ri->t_wakeup = thread_add_timer (master, rip_interface_wakeup,
-					     ifp, 1);
+	  thread_add_timer(master, rip_interface_wakeup, ifp, 1,
+                           &ri->t_wakeup);
           rip_connect_set (ifp, 1);
 	}
     }

--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -107,8 +107,8 @@ rip_peer_get (struct in_addr *addr)
     }
 
   /* Update timeout thread. */
-  peer->t_timeout = thread_add_timer (master, rip_peer_timeout, peer,
-				      RIP_PEER_TIMER_DEFAULT);
+  peer->t_timeout = thread_add_timer(master, rip_peer_timeout, peer,
+                                     RIP_PEER_TIMER_DEFAULT, NULL);
 
   /* Last update time set. */
   time (&peer->uptime);

--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -107,8 +107,9 @@ rip_peer_get (struct in_addr *addr)
     }
 
   /* Update timeout thread. */
-  peer->t_timeout = thread_add_timer(master, rip_peer_timeout, peer,
-                                     RIP_PEER_TIMER_DEFAULT, NULL);
+  peer->t_timeout = NULL;
+  thread_add_timer(master, rip_peer_timeout, peer, RIP_PEER_TIMER_DEFAULT,
+                   &peer->t_timeout);
 
   /* Last update time set. */
   time (&peer->uptime);

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2626,7 +2626,7 @@ rip_triggered_update (struct thread *t)
   interval = (random () % 5) + 1;
 
   rip->t_triggered_interval = 
-    thread_add_timer (master, rip_triggered_interval, NULL, interval);
+    thread_add_timer(master, rip_triggered_interval, NULL, interval, NULL);
 
   return 0;
 }
@@ -2781,21 +2781,20 @@ rip_event (enum rip_event event, int sock)
   switch (event)
     {
     case RIP_READ:
-      rip->t_read = thread_add_read (master, rip_read, NULL, sock);
+      rip->t_read = thread_add_read(master, rip_read, NULL, sock, NULL);
       break;
     case RIP_UPDATE_EVENT:
       RIP_TIMER_OFF (rip->t_update);
       jitter = rip_update_jitter (rip->update_time);
       rip->t_update = 
-	thread_add_timer (master, rip_update, NULL, 
-			  sock ? 2 : rip->update_time + jitter);
+	thread_add_timer(master, rip_update, NULL,
+                         sock ? 2 : rip->update_time + jitter, NULL);
       break;
     case RIP_TRIGGERED_UPDATE:
       if (rip->t_triggered_interval)
 	rip->trigger = 1;
-      else if (! rip->t_triggered_update)
-	rip->t_triggered_update = 
-	  thread_add_event (master, rip_triggered_update, NULL, 0);
+      else thread_add_event(master, rip_triggered_update, NULL, 0,
+                            &rip->t_triggered_update);
       break;
     default:
       break;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2625,8 +2625,9 @@ rip_triggered_update (struct thread *t)
    update is triggered when the timer expires. */
   interval = (random () % 5) + 1;
 
-  rip->t_triggered_interval = 
-    thread_add_timer(master, rip_triggered_interval, NULL, interval, NULL);
+  rip->t_triggered_interval = NULL;
+  thread_add_timer(master, rip_triggered_interval, NULL, interval,
+                   &rip->t_triggered_interval);
 
   return 0;
 }
@@ -2781,18 +2782,18 @@ rip_event (enum rip_event event, int sock)
   switch (event)
     {
     case RIP_READ:
-      rip->t_read = thread_add_read(master, rip_read, NULL, sock, NULL);
+      rip->t_read = NULL;
+      thread_add_read(master, rip_read, NULL, sock, &rip->t_read);
       break;
     case RIP_UPDATE_EVENT:
       RIP_TIMER_OFF (rip->t_update);
       jitter = rip_update_jitter (rip->update_time);
-      rip->t_update = 
-	thread_add_timer(master, rip_update, NULL,
-                         sock ? 2 : rip->update_time + jitter, NULL);
+      thread_add_timer(master, rip_update, NULL, sock ? 2 : rip->update_time + jitter,
+                       &rip->t_update);
       break;
     case RIP_TRIGGERED_UPDATE:
       if (rip->t_triggered_interval)
-	rip->trigger = 1;
+        rip->trigger = 1;
       else thread_add_event(master, rip_triggered_update, NULL, 0,
                             &rip->t_triggered_update);
       break;

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -371,11 +371,7 @@ enum rip_event
 };
 
 /* Macro for timer turn on. */
-#define RIP_TIMER_ON(T,F,V) \
-  do { \
-    if (!(T)) \
-      (T) = thread_add_timer (master, (F), rinfo, (V)); \
-  } while (0)
+#define RIP_TIMER_ON(T,F,V) thread_add_timer (master, (F), rinfo, (V), &(T))
 
 /* Macro for timer turn off. */
 #define RIP_TIMER_OFF(X) THREAD_TIMER_OFF(X)

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -761,9 +761,8 @@ ripng_enable_apply (struct interface *ifp)
 	    zlog_debug ("RIPng turn on %s", ifp->name);
 
 	  /* Add interface wake up thread. */
-	  if (! ri->t_wakeup)
-	    ri->t_wakeup = thread_add_timer (master, ripng_interface_wakeup,
-					     ifp, 1);
+	  thread_add_timer(master, ripng_interface_wakeup, ifp, 1,
+                           &ri->t_wakeup);
 
 	  ripng_connect_set (ifp, 1);
 	}

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -115,8 +115,8 @@ ripng_peer_get (struct in6_addr *addr)
     }
 
   /* Update timeout thread. */
-  peer->t_timeout = thread_add_timer (master, ripng_peer_timeout, peer,
-				      RIPNG_PEER_TIMER_DEFAULT);
+  peer->t_timeout = thread_add_timer(master, ripng_peer_timeout, peer,
+                                     RIPNG_PEER_TIMER_DEFAULT, NULL);
 
   /* Last update time set. */
   time (&peer->uptime);

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -115,8 +115,9 @@ ripng_peer_get (struct in6_addr *addr)
     }
 
   /* Update timeout thread. */
-  peer->t_timeout = thread_add_timer(master, ripng_peer_timeout, peer,
-                                     RIPNG_PEER_TIMER_DEFAULT, NULL);
+  peer->t_timeout = NULL;
+  thread_add_timer(master, ripng_peer_timeout, peer, RIPNG_PEER_TIMER_DEFAULT,
+                   &peer->t_timeout);
 
   /* Last update time set. */
   time (&peer->uptime);

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -1539,8 +1539,9 @@ ripng_triggered_update (struct thread *t)
      update is triggered when the timer expires. */
   interval = (random () % 5) + 1;
 
-  ripng->t_triggered_interval = 
-    thread_add_timer(master, ripng_triggered_interval, NULL, interval, NULL);
+  ripng->t_triggered_interval = NULL;
+  thread_add_timer(master, ripng_triggered_interval, NULL, interval,
+                   &ripng->t_triggered_interval);
 
   return 0;
 }
@@ -1909,9 +1910,9 @@ ripng_event (enum ripng_event event, int sock)
       /* Update timer jitter. */
       jitter = ripng_update_jitter (ripng->update_time);
 
-      ripng->t_update = 
-	thread_add_timer(master, ripng_update, NULL,
-                         sock ? 2 : ripng->update_time + jitter, NULL);
+      ripng->t_update = NULL;
+      thread_add_timer(master, ripng_update, NULL, sock ? 2 : ripng->update_time + jitter,
+                       &ripng->t_update);
       break;
     case RIPNG_TRIGGERED_UPDATE:
       if (ripng->t_triggered_interval)

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -1540,7 +1540,7 @@ ripng_triggered_update (struct thread *t)
   interval = (random () % 5) + 1;
 
   ripng->t_triggered_interval = 
-    thread_add_timer (master, ripng_triggered_interval, NULL, interval);
+    thread_add_timer(master, ripng_triggered_interval, NULL, interval, NULL);
 
   return 0;
 }
@@ -1898,8 +1898,7 @@ ripng_event (enum ripng_event event, int sock)
   switch (event)
     {
     case RIPNG_READ:
-      if (!ripng->t_read)
-	ripng->t_read = thread_add_read (master, ripng_read, NULL, sock);
+      thread_add_read(master, ripng_read, NULL, sock, &ripng->t_read);
       break;
     case RIPNG_UPDATE_EVENT:
       if (ripng->t_update)
@@ -1911,15 +1910,14 @@ ripng_event (enum ripng_event event, int sock)
       jitter = ripng_update_jitter (ripng->update_time);
 
       ripng->t_update = 
-	thread_add_timer (master, ripng_update, NULL, 
-			  sock ? 2 : ripng->update_time + jitter);
+	thread_add_timer(master, ripng_update, NULL,
+                         sock ? 2 : ripng->update_time + jitter, NULL);
       break;
     case RIPNG_TRIGGERED_UPDATE:
       if (ripng->t_triggered_interval)
 	ripng->trigger = 1;
-      else if (! ripng->t_triggered_update)
-	ripng->t_triggered_update = 
-	  thread_add_event (master, ripng_triggered_update, NULL, 0);
+      else thread_add_event(master, ripng_triggered_update, NULL, 0,
+                            &ripng->t_triggered_update);
       break;
     default:
       break;

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -324,11 +324,7 @@ enum ripng_event
 };
 
 /* RIPng timer on/off macro. */
-#define RIPNG_TIMER_ON(T,F,V) \
-do { \
-   if (!(T)) \
-      (T) = thread_add_timer (master, (F), rinfo, (V)); \
-} while (0)
+#define RIPNG_TIMER_ON(T,F,V) thread_add_timer (master, (F), rinfo, (V), &(T))
 
 #define RIPNG_TIMER_OFF(T) \
 do { \

--- a/tests/helpers/c/main.c
+++ b/tests/helpers/c/main.c
@@ -59,14 +59,14 @@ test_timer (struct thread *thread)
   int *count = THREAD_ARG(thread);
   
   printf ("run %d of timer\n", (*count)++);
-  thread_add_timer (master, test_timer, count, 5);
+  thread_add_timer(master, test_timer, count, 5, NULL);
   return 0;
 }
 
 static void
 test_timer_init()
 {
-  thread_add_timer (master, test_timer, &timer_count, 10);
+  thread_add_timer(master, test_timer, &timer_count, 10, NULL);
 }
 
 static void

--- a/tests/lib/test_heavy_thread.c
+++ b/tests/lib/test_heavy_thread.c
@@ -91,7 +91,7 @@ clear_something (struct thread *thread)
       ws->i++;
       if (thread_should_yield(thread))
         {
-	  thread_add_background(master, clear_something, ws, 0);
+	  thread_add_background(master, clear_something, ws, 0, NULL);
 	  return 0;
         }
     }
@@ -135,7 +135,7 @@ DEFUN (clear_foo,
   ws->vty = vty;
   ws->i = ITERS_FIRST;
 
-  thread_add_background(master, clear_something, ws, 0);
+  thread_add_background(master, clear_something, ws, 0, NULL);
 
   return CMD_SUCCESS;
 }

--- a/tests/lib/test_timer_correctness.c
+++ b/tests/lib/test_timer_correctness.c
@@ -139,7 +139,8 @@ int main(int argc, char **argv)
       /* Schedule timers to expire in 0..5 seconds */
       interval_msec = prng_rand(prng) % 5000;
       arg = XMALLOC(MTYPE_TMP, TIMESTR_LEN + 1);
-      timers[i] = thread_add_timer_msec(master, timer_func, arg, interval_msec);
+      timers[i] = thread_add_timer_msec(master, timer_func, arg,
+                                        interval_msec, NULL);
       ret = snprintf(arg, TIMESTR_LEN + 1, "%lld.%06lld",
                      (long long)timers[i]->u.sands.tv_sec,
                      (long long)timers[i]->u.sands.tv_usec);

--- a/tests/lib/test_timer_correctness.c
+++ b/tests/lib/test_timer_correctness.c
@@ -139,8 +139,9 @@ int main(int argc, char **argv)
       /* Schedule timers to expire in 0..5 seconds */
       interval_msec = prng_rand(prng) % 5000;
       arg = XMALLOC(MTYPE_TMP, TIMESTR_LEN + 1);
-      timers[i] = thread_add_timer_msec(master, timer_func, arg,
-                                        interval_msec, NULL);
+      timers[i] = NULL;
+      thread_add_timer_msec(master, timer_func, arg, interval_msec,
+                            &timers[i]);
       ret = snprintf(arg, TIMESTR_LEN + 1, "%lld.%06lld",
                      (long long)timers[i]->u.sands.tv_sec,
                      (long long)timers[i]->u.sands.tv_usec);

--- a/tests/lib/test_timer_performance.c
+++ b/tests/lib/test_timer_performance.c
@@ -56,8 +56,10 @@ int main(int argc, char **argv)
 
   /* create thread structures so they won't be allocated during the
    * time measurement */
-  for (i = 0; i < SCHEDULE_TIMERS; i++)
-    timers[i] = thread_add_timer_msec(master, dummy_func, NULL, 0, NULL);
+  for (i = 0; i < SCHEDULE_TIMERS; i++) {
+    timers[i] = NULL;
+    thread_add_timer_msec(master, dummy_func, NULL, 0, &timers[i]);
+  }
   for (i = 0; i < SCHEDULE_TIMERS; i++)
     thread_cancel(timers[i]);
 
@@ -68,8 +70,9 @@ int main(int argc, char **argv)
       long interval_msec;
 
       interval_msec = prng_rand(prng) % (100 * SCHEDULE_TIMERS);
-      timers[i] = thread_add_timer_msec(master, dummy_func, NULL,
-                                        interval_msec, NULL);
+      timers[i] = NULL;
+      thread_add_timer_msec(master, dummy_func, NULL, interval_msec,
+                            &timers[i]);
     }
 
   monotime(&tv_lap);

--- a/tests/lib/test_timer_performance.c
+++ b/tests/lib/test_timer_performance.c
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
   /* create thread structures so they won't be allocated during the
    * time measurement */
   for (i = 0; i < SCHEDULE_TIMERS; i++)
-    timers[i] = thread_add_timer_msec(master, dummy_func, NULL, 0);
+    timers[i] = thread_add_timer_msec(master, dummy_func, NULL, 0, NULL);
   for (i = 0; i < SCHEDULE_TIMERS; i++)
     thread_cancel(timers[i]);
 
@@ -68,8 +68,8 @@ int main(int argc, char **argv)
       long interval_msec;
 
       interval_msec = prng_rand(prng) % (100 * SCHEDULE_TIMERS);
-      timers[i] = thread_add_timer_msec(master, dummy_func,
-                                        NULL, interval_msec);
+      timers[i] = thread_add_timer_msec(master, dummy_func, NULL,
+                                        interval_msec, NULL);
     }
 
   monotime(&tv_lap);

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -373,8 +373,9 @@ static int restart_kill(struct thread *t_kill)
 		  (long)delay.tv_sec, (restart->kills ? SIGKILL : SIGTERM));
 	kill(-restart->pid, (restart->kills ? SIGKILL : SIGTERM));
 	restart->kills++;
-	restart->t_kill = thread_add_timer(master, restart_kill, restart,
-					   gs.restart_timeout, NULL);
+	restart->t_kill = NULL;
+	thread_add_timer(master, restart_kill, restart, gs.restart_timeout,
+			 &restart->t_kill);
 	return 0;
 }
 
@@ -487,9 +488,9 @@ run_job(struct restart_info *restart, const char *cmdtype, const char *command,
 		char cmd[strlen(command) + strlen(restart->name) + 1];
 		snprintf(cmd, sizeof(cmd), command, restart->name);
 		if ((restart->pid = run_background(cmd)) > 0) {
-			restart->t_kill =
-			    thread_add_timer(master, restart_kill, restart,
-					     gs.restart_timeout, NULL);
+			restart->t_kill = NULL;
+			thread_add_timer(master, restart_kill, restart, gs.restart_timeout,
+					 &restart->t_kill);
 			restart->what = cmdtype;
 			gs.numpids++;
 		} else
@@ -510,19 +511,31 @@ run_job(struct restart_info *restart, const char *cmdtype, const char *command,
 }
 
 #define SET_READ_HANDLER(DMN) \
-  (DMN)->t_read = thread_add_read(master,handle_read,(DMN),(DMN)->fd, NULL)
+  do { \
+    (DMN)->t_read = NULL; \
+    thread_add_read (master, handle_read, (DMN), (DMN)->fd, &(DMN)->t_read); \
+  } while (0);
 
-#define SET_WAKEUP_DOWN(DMN)	\
-  (DMN)->t_wakeup = thread_add_timer_msec(master,wakeup_down,(DMN),	\
-					  FUZZY(gs.period), NULL)
+#define SET_WAKEUP_DOWN(DMN) \
+  do { \
+    (DMN)->t_wakeup = NULL; \
+    thread_add_timer_msec (master, wakeup_down, (DMN), FUZZY(gs.period), \
+                           &(DMN)->t_wakeup); \
+  } while (0);
 
-#define SET_WAKEUP_UNRESPONSIVE(DMN)	\
-  (DMN)->t_wakeup = thread_add_timer_msec(master,wakeup_unresponsive,(DMN), \
-					  FUZZY(gs.period), NULL)
+#define SET_WAKEUP_UNRESPONSIVE(DMN) \
+  do { \
+    (DMN)->t_wakeup = NULL; \
+    thread_add_timer_msec (master, wakeup_unresponsive, (DMN), \
+                           FUZZY(gs.period), &(DMN)->t_wakeup); \
+  } while (0);
 
 #define SET_WAKEUP_ECHO(DMN) \
-  (DMN)->t_wakeup = thread_add_timer_msec(master,wakeup_send_echo,(DMN), \
-					  FUZZY(gs.period), NULL)
+  do { \
+    (DMN)->t_wakeup = NULL; \
+    thread_add_timer_msec (master, wakeup_send_echo, (DMN), \
+                           FUZZY(gs.period), &(DMN)->t_wakeup); \
+  } while (0);
 
 static int wakeup_down(struct thread *t_wakeup)
 {
@@ -775,12 +788,11 @@ static int try_connect(struct daemon *dmn)
 			zlog_debug("%s: connection in progress", dmn->name);
 		dmn->state = DAEMON_CONNECTING;
 		dmn->fd = sock;
-		dmn->t_write =
-		    thread_add_write(master, check_connect, dmn, dmn->fd,
-				     NULL);
-		dmn->t_wakeup =
-		    thread_add_timer(master, wakeup_connect_hanging, dmn,
-				     gs.timeout, NULL);
+		dmn->t_write = NULL;
+		thread_add_write(master, check_connect, dmn, dmn->fd,
+				 &dmn->t_write);dmn->t_wakeup = NULL;
+		thread_add_timer(master, wakeup_connect_hanging, dmn, gs.timeout,
+				 &dmn->t_wakeup);
 		SET_READ_HANDLER(dmn);
 		return 0;
 	}
@@ -805,8 +817,9 @@ static void set_phase(restart_phase_t new_phase)
 	gs.phase = new_phase;
 	if (gs.t_phase_hanging)
 		thread_cancel(gs.t_phase_hanging);
-	gs.t_phase_hanging = thread_add_timer(master, phase_hanging, NULL,
-					      PHASE_TIMEOUT, NULL);
+	gs.t_phase_hanging = NULL;
+	thread_add_timer(master, phase_hanging, NULL, PHASE_TIMEOUT,
+			 &gs.t_phase_hanging);
 }
 
 static void phase_check(void)
@@ -963,9 +976,9 @@ static int wakeup_send_echo(struct thread *t_wakeup)
 		daemon_down(dmn, why);
 	} else {
 		gettimeofday(&dmn->echo_sent, NULL);
-		dmn->t_wakeup =
-		    thread_add_timer(master, wakeup_no_answer, dmn,
-				     gs.timeout, NULL);
+		dmn->t_wakeup = NULL;
+		thread_add_timer(master, wakeup_no_answer, dmn, gs.timeout,
+				 &dmn->t_wakeup);
 	}
 	return 0;
 }
@@ -1312,10 +1325,9 @@ int main(int argc, char **argv)
 			gs.numdaemons++;
 			gs.numdown++;
 			dmn->fd = -1;
-			dmn->t_wakeup =
-			    thread_add_timer_msec(master, wakeup_init, dmn,
-						  100 + (random() % 900),
-						  NULL);
+			dmn->t_wakeup = NULL;
+			thread_add_timer_msec(master, wakeup_init, dmn, 100 + (random() % 900),
+					      &dmn->t_wakeup);
 			dmn->restart.interval = gs.min_restart_interval;
 			if (tail)
 				tail->next = dmn;

--- a/zebra/irdp_interface.c
+++ b/zebra/irdp_interface.c
@@ -259,10 +259,8 @@ irdp_if_start(struct interface *ifp, int multicast, int set_defaults)
 	       ifp->name,
 	       timer);
 
-  irdp->t_advertise = thread_add_timer(zebrad.master,
-				       irdp_send_thread,
-				       ifp,
-				       timer);
+  irdp->t_advertise = thread_add_timer(zebrad.master, irdp_send_thread, ifp,
+                                       timer, NULL);
 }
 
 static void

--- a/zebra/irdp_interface.c
+++ b/zebra/irdp_interface.c
@@ -259,8 +259,9 @@ irdp_if_start(struct interface *ifp, int multicast, int set_defaults)
 	       ifp->name,
 	       timer);
 
-  irdp->t_advertise = thread_add_timer(zebrad.master, irdp_send_thread, ifp,
-                                       timer, NULL);
+  irdp->t_advertise = NULL;
+  thread_add_timer(zebrad.master, irdp_send_thread, ifp, timer,
+                   &irdp->t_advertise);
 }
 
 static void

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -114,7 +114,8 @@ irdp_sock_init (void)
     return ret;
   };
 
-  t_irdp_raw = thread_add_read(zebrad.master, irdp_read_raw, NULL, sock, NULL);
+  t_irdp_raw = NULL;
+  thread_add_read(zebrad.master, irdp_read_raw, NULL, sock, &t_irdp_raw);
 
   return sock;
 }
@@ -244,8 +245,9 @@ int irdp_send_thread(struct thread *t_advert)
   if(irdp->flags & IF_DEBUG_MISC)
     zlog_debug("IRDP: New timer for %s set to %u\n", ifp->name, timer);
 
-  irdp->t_advertise = thread_add_timer(zebrad.master, irdp_send_thread, ifp,
-                                       timer, NULL);
+  irdp->t_advertise = NULL;
+  thread_add_timer(zebrad.master, irdp_send_thread, ifp, timer,
+                   &irdp->t_advertise);
   return 0;
 }
 
@@ -297,8 +299,9 @@ void process_solicit (struct interface *ifp)
 
   timer =  (random () % MAX_RESPONSE_DELAY) + 1;
 
-  irdp->t_advertise = thread_add_timer(zebrad.master, irdp_send_thread, ifp,
-                                       timer, NULL);
+  irdp->t_advertise = NULL;
+  thread_add_timer(zebrad.master, irdp_send_thread, ifp, timer,
+                   &irdp->t_advertise);
 }
 
 void irdp_finish()

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -114,7 +114,7 @@ irdp_sock_init (void)
     return ret;
   };
 
-  t_irdp_raw = thread_add_read (zebrad.master, irdp_read_raw, NULL, sock); 
+  t_irdp_raw = thread_add_read(zebrad.master, irdp_read_raw, NULL, sock, NULL);
 
   return sock;
 }
@@ -244,7 +244,8 @@ int irdp_send_thread(struct thread *t_advert)
   if(irdp->flags & IF_DEBUG_MISC)
     zlog_debug("IRDP: New timer for %s set to %u\n", ifp->name, timer);
 
-  irdp->t_advertise = thread_add_timer(zebrad.master, irdp_send_thread, ifp, timer);
+  irdp->t_advertise = thread_add_timer(zebrad.master, irdp_send_thread, ifp,
+                                       timer, NULL);
   return 0;
 }
 
@@ -296,10 +297,8 @@ void process_solicit (struct interface *ifp)
 
   timer =  (random () % MAX_RESPONSE_DELAY) + 1;
 
-  irdp->t_advertise = thread_add_timer(zebrad.master, 
-				       irdp_send_thread, 
-				       ifp, 
-				       timer);
+  irdp->t_advertise = thread_add_timer(zebrad.master, irdp_send_thread, ifp,
+                                       timer, NULL);
 }
 
 void irdp_finish()

--- a/zebra/irdp_packet.c
+++ b/zebra/irdp_packet.c
@@ -232,8 +232,8 @@ int irdp_read_raw(struct thread *r)
   int ret, ifindex = 0;
   
   int irdp_sock = THREAD_FD (r);
-  t_irdp_raw = thread_add_read(zebrad.master, irdp_read_raw, NULL, irdp_sock,
-                               NULL);
+  t_irdp_raw = NULL;
+  thread_add_read(zebrad.master, irdp_read_raw, NULL, irdp_sock, &t_irdp_raw);
   
   ret = irdp_recvmsg (irdp_sock, (u_char *) buf, IRDP_RX_BUF,  &ifindex);
  

--- a/zebra/irdp_packet.c
+++ b/zebra/irdp_packet.c
@@ -232,7 +232,8 @@ int irdp_read_raw(struct thread *r)
   int ret, ifindex = 0;
   
   int irdp_sock = THREAD_FD (r);
-  t_irdp_raw = thread_add_read (zebrad.master, irdp_read_raw, NULL, irdp_sock);
+  t_irdp_raw = thread_add_read(zebrad.master, irdp_read_raw, NULL, irdp_sock,
+                               NULL);
   
   ret = irdp_recvmsg (irdp_sock, (u_char *) buf, IRDP_RX_BUF,  &ifindex);
  

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -283,8 +283,8 @@ kernel_read (struct thread *thread)
 {
   struct zebra_ns *zns = (struct zebra_ns *)THREAD_ARG (thread);
   netlink_parse_info (netlink_information_fetch, &zns->netlink, zns, 5, 0);
-  zns->t_netlink = thread_add_read (zebrad.master, kernel_read, zns,
-                                     zns->netlink.sock);
+  zns->t_netlink = thread_add_read(zebrad.master, kernel_read, zns,
+                                   zns->netlink.sock, NULL);
 
   return 0;
 }
@@ -813,8 +813,8 @@ kernel_init (struct zebra_ns *zns)
         netlink_recvbuf (&zns->netlink, nl_rcvbufsize);
 
       netlink_install_filter (zns->netlink.sock, zns->netlink_cmd.snl.nl_pid);
-      zns->t_netlink = thread_add_read (zebrad.master, kernel_read, zns,
-                                         zns->netlink.sock);
+      zns->t_netlink = thread_add_read(zebrad.master, kernel_read, zns,
+                                       zns->netlink.sock, NULL);
     }
 }
 

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -283,8 +283,9 @@ kernel_read (struct thread *thread)
 {
   struct zebra_ns *zns = (struct zebra_ns *)THREAD_ARG (thread);
   netlink_parse_info (netlink_information_fetch, &zns->netlink, zns, 5, 0);
-  zns->t_netlink = thread_add_read(zebrad.master, kernel_read, zns,
-                                   zns->netlink.sock, NULL);
+  zns->t_netlink = NULL;
+  thread_add_read(zebrad.master, kernel_read, zns, zns->netlink.sock,
+                  &zns->t_netlink);
 
   return 0;
 }
@@ -813,8 +814,9 @@ kernel_init (struct zebra_ns *zns)
         netlink_recvbuf (&zns->netlink, nl_rcvbufsize);
 
       netlink_install_filter (zns->netlink.sock, zns->netlink_cmd.snl.nl_pid);
-      zns->t_netlink = thread_add_read(zebrad.master, kernel_read, zns,
-                                       zns->netlink.sock, NULL);
+      zns->t_netlink = NULL;
+      thread_add_read(zebrad.master, kernel_read, zns, zns->netlink.sock,
+                      &zns->t_netlink);
     }
 }
 

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1282,7 +1282,7 @@ kernel_read (struct thread *thread)
       return 0;
     }
 
-  thread_add_read (zebrad.master, kernel_read, NULL, sock);
+  thread_add_read(zebrad.master, kernel_read, NULL, sock, NULL);
 
   if (IS_ZEBRA_DEBUG_KERNEL)
     rtmsg_debug (&buf.r.rtm);
@@ -1355,7 +1355,7 @@ routing_socket (struct zebra_ns *zns)
     zlog_err ("routing_socket: Can't lower privileges");
 
   /* kernel_read needs rewrite. */
-  thread_add_read (zebrad.master, kernel_read, NULL, routing_sock);
+  thread_add_read(zebrad.master, kernel_read, NULL, routing_sock, NULL);
 }
 
 /* Exported interface function.  This function simply calls

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -141,9 +141,8 @@ static int zclient_connect(struct thread *t)
 
 	if (zclient_socket_connect(zclient) < 0) {
 		zlog_err("Error connecting synchronous zclient!");
-		THREAD_TIMER_ON(zebrad.master, zclient->t_connect,
-						zclient_connect,
-						zclient, CONNECTION_DELAY);
+		thread_add_timer(zebrad.master, zclient_connect, zclient,
+				 CONNECTION_DELAY, &zclient->t_connect);
 		return -1;
 	}
 

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -1574,11 +1574,8 @@ rtadv_event (struct zebra_ns *zns, enum rtadv_event event, int val)
   switch (event)
     {
     case RTADV_START:
-      if (! rtadv->ra_read)
-       rtadv->ra_read = thread_add_read (zebrad.master, rtadv_read, zns, val);
-      if (! rtadv->ra_timer)
-       rtadv->ra_timer = thread_add_event (zebrad.master, rtadv_timer,
-                                           zns, 0);
+      thread_add_read(zebrad.master, rtadv_read, zns, val, &rtadv->ra_read);
+      thread_add_event(zebrad.master, rtadv_timer, zns, 0, &rtadv->ra_timer);
       break;
     case RTADV_STOP:
       if (rtadv->ra_timer)
@@ -1593,18 +1590,14 @@ rtadv_event (struct zebra_ns *zns, enum rtadv_event event, int val)
 	}
       break;
     case RTADV_TIMER:
-      if (! rtadv->ra_timer)
-	rtadv->ra_timer = thread_add_timer (zebrad.master, rtadv_timer, zns,
-	                                    val);
+      thread_add_timer(zebrad.master, rtadv_timer, zns, val, &rtadv->ra_timer);
       break;
     case RTADV_TIMER_MSEC:
-      if (! rtadv->ra_timer)
-	rtadv->ra_timer = thread_add_timer_msec (zebrad.master, rtadv_timer, 
-					    zns, val);
+      thread_add_timer_msec(zebrad.master, rtadv_timer, zns, val,
+                            &rtadv->ra_timer);
       break;
     case RTADV_READ:
-      if (! rtadv->ra_read)
-	rtadv->ra_read = thread_add_read (zebrad.master, rtadv_read, zns, val);
+      thread_add_read(zebrad.master, rtadv_read, zns, val, &rtadv->ra_read);
       break;
     default:
       break;

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -535,7 +535,6 @@ zfpm_conn_up_thread_cb (struct thread *thread)
   zfpm_rnodes_iter_t *iter;
   rib_dest_t *dest;
 
-  assert (zfpm_g->t_conn_up);
   zfpm_g->t_conn_up = NULL;
 
   iter = &zfpm_g->t_conn_up_state.iter;
@@ -655,7 +654,6 @@ zfpm_conn_down_thread_cb (struct thread *thread)
 
   assert (zfpm_g->state == ZFPM_STATE_IDLE);
 
-  assert (zfpm_g->t_conn_down);
   zfpm_g->t_conn_down = NULL;
 
   iter = &zfpm_g->t_conn_down_state.iter;
@@ -758,7 +756,6 @@ zfpm_read_cb (struct thread *thread)
   fpm_msg_hdr_t *hdr;
 
   zfpm_g->stats.read_cb_calls++;
-  assert (zfpm_g->t_read);
   zfpm_g->t_read = NULL;
 
   /*
@@ -1047,7 +1044,6 @@ zfpm_write_cb (struct thread *thread)
   int num_writes;
 
   zfpm_g->stats.write_cb_calls++;
-  assert (zfpm_g->t_write);
   zfpm_g->t_write = NULL;
 
   /*
@@ -1139,7 +1135,6 @@ zfpm_connect_cb (struct thread *t)
   int sock, ret;
   struct sockaddr_in serv;
 
-  assert (zfpm_g->t_connect);
   zfpm_g->t_connect = NULL;
   assert (zfpm_g->state == ZFPM_STATE_ACTIVE);
 
@@ -1390,7 +1385,6 @@ zfpm_trigger_update (struct route_node *rn, const char *reason)
 static int
 zfpm_stats_timer_cb (struct thread *t)
 {
-  assert (zfpm_g->t_stats);
   zfpm_g->t_stats = NULL;
 
   /*

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -565,9 +565,9 @@ zfpm_conn_up_thread_cb (struct thread *thread)
 
       zfpm_g->stats.t_conn_up_yields++;
       zfpm_rnodes_iter_pause (iter);
-      zfpm_g->t_conn_up = thread_add_background(zfpm_g->master,
-                                                zfpm_conn_up_thread_cb, 0, 0,
-                                                NULL);
+      zfpm_g->t_conn_up = NULL;
+      thread_add_background(zfpm_g->master, zfpm_conn_up_thread_cb, 0, 0,
+                            &zfpm_g->t_conn_up);
       return 0;
     }
 
@@ -599,9 +599,9 @@ zfpm_connection_up (const char *detail)
   zfpm_rnodes_iter_init (&zfpm_g->t_conn_up_state.iter);
 
   zfpm_debug ("Starting conn_up thread");
-  zfpm_g->t_conn_up = thread_add_background(zfpm_g->master,
-                                            zfpm_conn_up_thread_cb, 0, 0,
-                                            NULL);
+  zfpm_g->t_conn_up = NULL;
+  thread_add_background(zfpm_g->master, zfpm_conn_up_thread_cb, 0, 0,
+                        &zfpm_g->t_conn_up);
   zfpm_g->stats.t_conn_up_starts++;
 }
 
@@ -690,9 +690,9 @@ zfpm_conn_down_thread_cb (struct thread *thread)
 
       zfpm_g->stats.t_conn_down_yields++;
       zfpm_rnodes_iter_pause (iter);
-      zfpm_g->t_conn_down = thread_add_background(zfpm_g->master,
-                                                  zfpm_conn_down_thread_cb, 0,
-                                                  0, NULL);
+      zfpm_g->t_conn_down = NULL;
+      thread_add_background(zfpm_g->master, zfpm_conn_down_thread_cb, 0, 0,
+                            &zfpm_g->t_conn_down);
       return 0;
     }
 
@@ -738,9 +738,9 @@ zfpm_connection_down (const char *detail)
   assert (!zfpm_g->t_conn_down);
   zfpm_debug ("Starting conn_down thread");
   zfpm_rnodes_iter_init (&zfpm_g->t_conn_down_state.iter);
-  zfpm_g->t_conn_down = thread_add_background(zfpm_g->master,
-                                              zfpm_conn_down_thread_cb, 0, 0,
-                                              NULL);
+  zfpm_g->t_conn_down = NULL;
+  thread_add_background(zfpm_g->master, zfpm_conn_down_thread_cb, 0, 0,
+                        &zfpm_g->t_conn_down);
   zfpm_g->stats.t_conn_down_starts++;
 
   zfpm_set_state (ZFPM_STATE_IDLE, detail);

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -487,8 +487,8 @@ zfpm_read_on (void)
   assert (!zfpm_g->t_read);
   assert (zfpm_g->sock >= 0);
 
-  THREAD_READ_ON (zfpm_g->master, zfpm_g->t_read, zfpm_read_cb, 0,
-		  zfpm_g->sock);
+  thread_add_read(zfpm_g->master, zfpm_read_cb, 0, zfpm_g->sock,
+                  &zfpm_g->t_read);
 }
 
 /*
@@ -500,8 +500,8 @@ zfpm_write_on (void)
   assert (!zfpm_g->t_write);
   assert (zfpm_g->sock >= 0);
 
-  THREAD_WRITE_ON (zfpm_g->master, zfpm_g->t_write, zfpm_write_cb, 0,
-		   zfpm_g->sock);
+  thread_add_write(zfpm_g->master, zfpm_write_cb, 0, zfpm_g->sock,
+                   &zfpm_g->t_write);
 }
 
 /*
@@ -565,9 +565,9 @@ zfpm_conn_up_thread_cb (struct thread *thread)
 
       zfpm_g->stats.t_conn_up_yields++;
       zfpm_rnodes_iter_pause (iter);
-      zfpm_g->t_conn_up = thread_add_background (zfpm_g->master,
-						 zfpm_conn_up_thread_cb,
-						 0, 0);
+      zfpm_g->t_conn_up = thread_add_background(zfpm_g->master,
+                                                zfpm_conn_up_thread_cb, 0, 0,
+                                                NULL);
       return 0;
     }
 
@@ -599,8 +599,9 @@ zfpm_connection_up (const char *detail)
   zfpm_rnodes_iter_init (&zfpm_g->t_conn_up_state.iter);
 
   zfpm_debug ("Starting conn_up thread");
-  zfpm_g->t_conn_up = thread_add_background (zfpm_g->master,
-					     zfpm_conn_up_thread_cb, 0, 0);
+  zfpm_g->t_conn_up = thread_add_background(zfpm_g->master,
+                                            zfpm_conn_up_thread_cb, 0, 0,
+                                            NULL);
   zfpm_g->stats.t_conn_up_starts++;
 }
 
@@ -689,9 +690,9 @@ zfpm_conn_down_thread_cb (struct thread *thread)
 
       zfpm_g->stats.t_conn_down_yields++;
       zfpm_rnodes_iter_pause (iter);
-      zfpm_g->t_conn_down = thread_add_background (zfpm_g->master,
-						   zfpm_conn_down_thread_cb,
-						   0, 0);
+      zfpm_g->t_conn_down = thread_add_background(zfpm_g->master,
+                                                  zfpm_conn_down_thread_cb, 0,
+                                                  0, NULL);
       return 0;
     }
 
@@ -737,8 +738,9 @@ zfpm_connection_down (const char *detail)
   assert (!zfpm_g->t_conn_down);
   zfpm_debug ("Starting conn_down thread");
   zfpm_rnodes_iter_init (&zfpm_g->t_conn_down_state.iter);
-  zfpm_g->t_conn_down = thread_add_background (zfpm_g->master,
-					       zfpm_conn_down_thread_cb, 0, 0);
+  zfpm_g->t_conn_down = thread_add_background(zfpm_g->master,
+                                              zfpm_conn_down_thread_cb, 0, 0,
+                                              NULL);
   zfpm_g->stats.t_conn_down_starts++;
 
   zfpm_set_state (ZFPM_STATE_IDLE, detail);
@@ -1294,8 +1296,8 @@ zfpm_start_connect_timer (const char *reason)
   delay_secs = zfpm_calc_connect_delay();
   zfpm_debug ("scheduling connect in %ld seconds", delay_secs);
 
-  THREAD_TIMER_ON (zfpm_g->master, zfpm_g->t_connect, zfpm_connect_cb, 0,
-		   delay_secs);
+  thread_add_timer(zfpm_g->master, zfpm_connect_cb, 0, delay_secs,
+                   &zfpm_g->t_connect);
   zfpm_set_state (ZFPM_STATE_ACTIVE, reason);
 }
 
@@ -1434,8 +1436,8 @@ zfpm_start_stats_timer (void)
 {
   assert (!zfpm_g->t_stats);
 
-  THREAD_TIMER_ON (zfpm_g->master, zfpm_g->t_stats, zfpm_stats_timer_cb, 0,
-		   ZFPM_STATS_IVL_SECS);
+  thread_add_timer(zfpm_g->master, zfpm_stats_timer_cb, 0,
+                   ZFPM_STATS_IVL_SECS, &zfpm_g->t_stats);
 }
 
 /*

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -182,13 +182,14 @@ zebra_ptm_flush_messages (struct thread *thread)
       close(ptm_cb.ptm_sock);
       ptm_cb.ptm_sock = -1;
       zebra_ptm_reset_status(0);
-      ptm_cb.t_timer = thread_add_timer(zebrad.master, zebra_ptm_connect,
-                                        NULL, ptm_cb.reconnect_time, NULL);
+      ptm_cb.t_timer = NULL;
+      thread_add_timer(zebrad.master, zebra_ptm_connect, NULL, ptm_cb.reconnect_time,
+                       &ptm_cb.t_timer);
       return (-1);
     case BUFFER_PENDING:
-      ptm_cb.t_write = thread_add_write(zebrad.master,
-                                        zebra_ptm_flush_messages, NULL,
-                                        ptm_cb.ptm_sock, NULL);
+      ptm_cb.t_write = NULL;
+      thread_add_write(zebrad.master, zebra_ptm_flush_messages, NULL, ptm_cb.ptm_sock,
+                       &ptm_cb.t_write);
       break;
     case BUFFER_EMPTY:
       break;
@@ -208,8 +209,9 @@ zebra_ptm_send_message(char *data, int size)
       close(ptm_cb.ptm_sock);
       ptm_cb.ptm_sock = -1;
       zebra_ptm_reset_status(0);
-      ptm_cb.t_timer = thread_add_timer(zebrad.master, zebra_ptm_connect,
-                                        NULL, ptm_cb.reconnect_time, NULL);
+      ptm_cb.t_timer = NULL;
+      thread_add_timer(zebrad.master, zebra_ptm_connect, NULL, ptm_cb.reconnect_time,
+                       &ptm_cb.t_timer);
       return -1;
     case BUFFER_EMPTY:
       THREAD_OFF(ptm_cb.t_write);
@@ -235,8 +237,9 @@ zebra_ptm_connect (struct thread *t)
 
   if (ptm_cb.ptm_sock != -1) {
     if (init) {
-      ptm_cb.t_read = thread_add_read(zebrad.master, zebra_ptm_sock_read,
-                                      NULL, ptm_cb.ptm_sock, NULL);
+      ptm_cb.t_read = NULL;
+      thread_add_read(zebrad.master, zebra_ptm_sock_read, NULL, ptm_cb.ptm_sock,
+                      &ptm_cb.t_read);
       zebra_bfd_peer_replay_req();
     }
     zebra_ptm_send_status_req();
@@ -246,8 +249,9 @@ zebra_ptm_connect (struct thread *t)
     if (ptm_cb.reconnect_time > ZEBRA_PTM_RECONNECT_TIME_MAX)
       ptm_cb.reconnect_time = ZEBRA_PTM_RECONNECT_TIME_MAX;
 
-    ptm_cb.t_timer = thread_add_timer(zebrad.master, zebra_ptm_connect, NULL,
-                                      ptm_cb.reconnect_time, NULL);
+    ptm_cb.t_timer = NULL;
+    thread_add_timer(zebrad.master, zebra_ptm_connect, NULL, ptm_cb.reconnect_time,
+                     &ptm_cb.t_timer);
   } else if (ptm_cb.reconnect_time >= ZEBRA_PTM_RECONNECT_TIME_MAX){
     ptm_cb.reconnect_time = ZEBRA_PTM_RECONNECT_TIME_INITIAL;
   }
@@ -654,14 +658,16 @@ zebra_ptm_sock_read (struct thread *thread)
       close (ptm_cb.ptm_sock);
       ptm_cb.ptm_sock = -1;
       zebra_ptm_reset_status(0);
-      ptm_cb.t_timer = thread_add_timer(zebrad.master, zebra_ptm_connect,
-                                        NULL, ptm_cb.reconnect_time, NULL);
+      ptm_cb.t_timer = NULL;
+      thread_add_timer(zebrad.master, zebra_ptm_connect, NULL, ptm_cb.reconnect_time,
+                       &ptm_cb.t_timer);
       return (-1);
     }
   }
 
-  ptm_cb.t_read = thread_add_read(zebrad.master, zebra_ptm_sock_read, NULL,
-                                  ptm_cb.ptm_sock, NULL);
+  ptm_cb.t_read = NULL;
+  thread_add_read(zebrad.master, zebra_ptm_sock_read, NULL, ptm_cb.ptm_sock,
+                  &ptm_cb.t_read);
 
   return 0;
 }
@@ -698,8 +704,9 @@ zebra_ptm_bfd_dst_register (struct zserv *client, int sock, u_short length,
 
   if (ptm_cb.ptm_sock == -1)
     {
-      ptm_cb.t_timer = thread_add_timer(zebrad.master, zebra_ptm_connect,
-                                        NULL, ptm_cb.reconnect_time, NULL);
+      ptm_cb.t_timer = NULL;
+      thread_add_timer(zebrad.master, zebra_ptm_connect, NULL, ptm_cb.reconnect_time,
+                       &ptm_cb.t_timer);
       return -1;
     }
 
@@ -855,8 +862,9 @@ zebra_ptm_bfd_dst_deregister (struct zserv *client, int sock, u_short length,
 
   if (ptm_cb.ptm_sock == -1)
     {
-      ptm_cb.t_timer = thread_add_timer(zebrad.master, zebra_ptm_connect,
-                                        NULL, ptm_cb.reconnect_time, NULL);
+      ptm_cb.t_timer = NULL;
+      thread_add_timer(zebrad.master, zebra_ptm_connect, NULL, ptm_cb.reconnect_time,
+                       &ptm_cb.t_timer);
       return -1;
     }
 
@@ -977,8 +985,9 @@ zebra_ptm_bfd_client_register (struct zserv *client, int sock, u_short length)
 
   if (ptm_cb.ptm_sock == -1)
     {
-      ptm_cb.t_timer = thread_add_timer(zebrad.master, zebra_ptm_connect,
-                                        NULL, ptm_cb.reconnect_time, NULL);
+      ptm_cb.t_timer = NULL;
+      thread_add_timer(zebrad.master, zebra_ptm_connect, NULL, ptm_cb.reconnect_time,
+                       &ptm_cb.t_timer);
       return -1;
     }
 
@@ -1027,8 +1036,9 @@ zebra_ptm_bfd_client_deregister (int proto)
 
   if (ptm_cb.ptm_sock == -1)
     {
-      ptm_cb.t_timer = thread_add_timer(zebrad.master, zebra_ptm_connect,
-                                        NULL, ptm_cb.reconnect_time, NULL);
+      ptm_cb.t_timer = NULL;
+      thread_add_timer(zebrad.master, zebra_ptm_connect, NULL, ptm_cb.reconnect_time,
+                       &ptm_cb.t_timer);
       return;
     }
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1403,10 +1403,11 @@ static void
 zebra_route_map_mark_update (const char *rmap_name)
 {
   /* rmap_update_timer of 0 means don't do route updates */
-  if (zebra_rmap_update_timer && !zebra_t_rmap_update)
-    zebra_t_rmap_update =
-      thread_add_timer(zebrad.master, zebra_route_map_update_timer, NULL,
-                       zebra_rmap_update_timer, NULL);
+  if (zebra_rmap_update_timer && !zebra_t_rmap_update) {
+    zebra_t_rmap_update = NULL;
+    thread_add_timer(zebrad.master, zebra_route_map_update_timer, NULL, zebra_rmap_update_timer,
+                     &zebra_t_rmap_update);
+  }
 }
 
 static void

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1406,7 +1406,7 @@ zebra_route_map_mark_update (const char *rmap_name)
   if (zebra_rmap_update_timer && !zebra_t_rmap_update)
     zebra_t_rmap_update =
       thread_add_timer(zebrad.master, zebra_route_map_update_timer, NULL,
-		       zebra_rmap_update_timer);
+                       zebra_rmap_update_timer, NULL);
 }
 
 static void

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -96,7 +96,7 @@ zserv_flush_data(struct thread *thread)
       break;
     case BUFFER_PENDING:
       client->t_write = thread_add_write(zebrad.master, zserv_flush_data,
-      					 client, client->sock);
+                                         client, client->sock, NULL);
       break;
     case BUFFER_EMPTY:
       break;
@@ -129,14 +129,14 @@ zebra_server_send_message(struct zserv *client)
 	 possibility that an I/O error may have caused the client to be
 	 deleted. */
       client->t_suicide = thread_add_event(zebrad.master, zserv_delayed_close,
-					   client, 0);
+                                           client, 0, NULL);
       return -1;
     case BUFFER_EMPTY:
       THREAD_OFF(client->t_write);
       break;
     case BUFFER_PENDING:
-      THREAD_WRITE_ON(zebrad.master, client->t_write,
-		      zserv_flush_data, client, client->sock);
+      thread_add_write(zebrad.master, zserv_flush_data, client, client->sock,
+                       &client->t_write);
       break;
     }
 
@@ -2588,11 +2588,11 @@ zebra_event (enum event event, int sock, struct zserv *client)
   switch (event)
     {
     case ZEBRA_SERV:
-      thread_add_read (zebrad.master, zebra_accept, client, sock);
+      thread_add_read(zebrad.master, zebra_accept, client, sock, NULL);
       break;
     case ZEBRA_READ:
       client->t_read = 
-	thread_add_read (zebrad.master, zebra_client_read, client, sock);
+	thread_add_read(zebrad.master, zebra_client_read, client, sock, NULL);
       break;
     case ZEBRA_WRITE:
       /**/

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -95,8 +95,9 @@ zserv_flush_data(struct thread *thread)
       client = NULL;
       break;
     case BUFFER_PENDING:
-      client->t_write = thread_add_write(zebrad.master, zserv_flush_data,
-                                         client, client->sock, NULL);
+      client->t_write = NULL;
+      thread_add_write(zebrad.master, zserv_flush_data, client, client->sock,
+                       &client->t_write);
       break;
     case BUFFER_EMPTY:
       break;
@@ -128,8 +129,9 @@ zebra_server_send_message(struct zserv *client)
          one do not check the return code.  They do not allow for the
 	 possibility that an I/O error may have caused the client to be
 	 deleted. */
-      client->t_suicide = thread_add_event(zebrad.master, zserv_delayed_close,
-                                           client, 0, NULL);
+      client->t_suicide = NULL;
+      thread_add_event(zebrad.master, zserv_delayed_close, client, 0,
+                       &client->t_suicide);
       return -1;
     case BUFFER_EMPTY:
       THREAD_OFF(client->t_write);
@@ -2591,8 +2593,9 @@ zebra_event (enum event event, int sock, struct zserv *client)
       thread_add_read(zebrad.master, zebra_accept, client, sock, NULL);
       break;
     case ZEBRA_READ:
-      client->t_read = 
-	thread_add_read(zebrad.master, zebra_client_read, client, sock, NULL);
+      client->t_read = NULL;
+      thread_add_read(zebrad.master, zebra_client_read, client, sock,
+                      &client->t_read);
       break;
     case ZEBRA_WRITE:
       /**/


### PR DESCRIPTION
The way thread.c is written, a caller who wishes to be able to cancel a
thread or avoid scheduling it twice must keep a reference to the thread.
Typically this is done with a long lived pointer whose value is checked
for null in order to know if the thread is currently scheduled.  The
check-and-schedule idiom is so common that several wrapper macros in
thread.h existed solely to provide it.

This patch removes those macros and adds a new parameter to all
`thread_add_*` functions which is a pointer to the `struct thread *` to
store the result of a scheduling call. If the pointer passed is non-null,
the thread will only be scheduled if the value is null. This helps with
consistency and removes a layer of abstraction...

A Coccinelle spatch has been used to transform code of the form:

```
  if (t == NULL)
    t = thread_add_* (...)
```

to the form

```
  thread_add_* (..., &t)
```

The THREAD_ON macros have also been transformed to the underlying
thread.c calls.

The human-made changes are in `lib/thread.[ch]` and a few miscellaneous header files in bgpd, isisd and rip[ng]d (same edits for daemon specific wrapper macros), everything else was done with spatch.