### PR TITLE
Update to draft-ietf-idr-bgp-prefix-sid-05

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -57,6 +57,14 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #define BGP_ATTR_NHLEN_VPNV6_GLOBAL       8+IPV6_MAX_BYTELEN
 #define BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL ((8+IPV6_MAX_BYTELEN) * 2)
 
+/* Prefix SID types */
+#define BGP_PREFIX_SID_LABEL_INDEX     1
+#define BGP_PREFIX_SID_IPV6            2
+#define BGP_PREFIX_SID_ORIGINATOR_SRGB 3
+
+#define BGP_PREFIX_SID_LABEL_INDEX_LENGTH      7
+#define BGP_PREFIX_SID_IPV6_LENGTH            19
+#define BGP_PREFIX_SID_ORIGINATOR_SRGB_LENGTH  6
 
 struct bgp_attr_encap_subtlv {
     struct bgp_attr_encap_subtlv	*next;		/* for chaining */

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -450,9 +450,12 @@ bgp_dump_attr (struct peer *peer, struct attr *attr, char *buf, size_t size)
     snprintf (buf + strlen (buf), size - strlen (buf), ", path %s",
 	      aspath_print (attr->aspath));
 
-  if (CHECK_FLAG (attr->flag, ATTR_FLAG_BIT (BGP_ATTR_LABEL_INDEX)))
-    snprintf (buf + strlen (buf), size - strlen (buf), ", label-index %u",
+  if (CHECK_FLAG (attr->flag, ATTR_FLAG_BIT (BGP_ATTR_PREFIX_SID)))
+    {
+      if (attr->extra->label_index != BGP_INVALID_LABEL_INDEX)
+        snprintf (buf + strlen (buf), size - strlen (buf), ", label-index %u",
               attr->extra->label_index);
+    }
 
   if (strlen (buf) > 1)
     return 1;

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -150,11 +150,15 @@ bgp_reg_dereg_for_label (struct bgp_node *rn, struct bgp_info *ri,
   if (reg)
     {
       assert (ri);
-      if (ri->attr->flag & ATTR_FLAG_BIT (BGP_ATTR_LABEL_INDEX))
+      if (ri->attr->flag & ATTR_FLAG_BIT (BGP_ATTR_PREFIX_SID))
         {
           assert (ri->attr->extra);
-          flags |= ZEBRA_FEC_REGISTER_LABEL_INDEX;
-          stream_putl (s, ri->attr->extra->label_index);
+
+          if (ri->attr->extra->label_index != BGP_INVALID_LABEL_INDEX)
+            {
+              flags |= ZEBRA_FEC_REGISTER_LABEL_INDEX;
+              stream_putl (s, ri->attr->extra->label_index);
+            }
         }
       SET_FLAG (rn->flags, BGP_NODE_REGISTERED_FOR_LABEL);
     }

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -973,7 +973,7 @@ struct bgp_nlri
 #define BGP_ATTR_AS_PATHLIMIT                   21
 #define BGP_ATTR_ENCAP                          23
 #define BGP_ATTR_LARGE_COMMUNITIES              32
-#define BGP_ATTR_LABEL_INDEX                    40
+#define BGP_ATTR_PREFIX_SID                     40
 #if ENABLE_BGP_VNC
 #define BGP_ATTR_VNC                           255
 #endif


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

The initial implementation was against draft-keyupate-idr-bgp-prefix-sid-02
This updates our label-index implementation up to draft-ietf-idr-bgp-prefix-sid-05
- changed BGP_ATTR_LABEL_INDEX to BGP_ATTR_PREFIX_SID
- since there are multiple TLVs in BGP_ATTR_PREFIX_SID you can no longer
  rely on that flag to know if there is a label-index for the path. I
changed bgp_attr_extra_new() to init the label_index to
BGP_INVALID_LABEL_INDEX
- put some placeholder code in for the other two TLVs (IPv6 and
  Originator SRGB)