### PR TITLE
More snapcraft cleanups

### DIFF
--- a/snapcraft/Makefile.am
+++ b/snapcraft/Makefile.am
@@ -1,25 +1,7 @@
 EXTRA_DIST = snapcraft.yaml \
 	README.snap_build.md \
 	README.usage.md \
-	scripts/Makefile \
-	scripts/bgpd-service \
-	scripts/isisd-service \
-	scripts/ldpd-service \
-	scripts/ospf6d-service \
-	scripts/ospfd-service \
-	scripts/pimd-service \
-	scripts/ripd-service \
-	scripts/ripngd-service \
-	scripts/zebra-service \
-	defaults/bgpd.conf.default \
-	defaults/isisd.conf.default \
-	defaults/ldpd.conf.default \
-	defaults/ospf6d.conf.default \
-	defaults/ospfd.conf.default \
-	defaults/pimd.conf.default \
-	defaults/ripd.conf.default \
-	defaults/ripngd.conf.default \
-	defaults/vtysh.conf.default \
-	defaults/zebra.conf.default \
+	scripts \
+	defaults \
 	helpers \
 	snap

--- a/snapcraft/Makefile.am
+++ b/snapcraft/Makefile.am
@@ -1,6 +1,7 @@
 EXTRA_DIST = snapcraft.yaml \
 	README.snap_build.md \
 	README.usage.md \
+	extra_version_info.txt \
 	scripts \
 	defaults \
 	helpers \

--- a/snapcraft/README.snap_build.md
+++ b/snapcraft/README.snap_build.md
@@ -12,7 +12,12 @@ which uses earlier versions of snaps)
         git clone https://github.com/frrouting/frr.git
         cd frr
 
-3. Run Bootstrap and make distribution tar.gz
+3. (Optional) Add extra version information to 
+   `snapcraft/extra_version_info.txt`. Information in this file will
+   be displayed with the frr.version command (simple `cat` after
+   the display of the `zebra --version` output)
+
+4. Run Bootstrap and make distribution tar.gz
 
         ./bootstrap.sh
         ./configure --with-pkg-extra-version=-MySnapVersion
@@ -25,7 +30,7 @@ which uses earlier versions of snaps)
     This will build `frr-something.tar.gz` - the distribution tar and 
     the snapcraft/snapcraft.yaml with the matching version number
 
-4. Create snap
+5. Create snap
 
         cd snapcraft
         snapcraft

--- a/snapcraft/scripts/Makefile
+++ b/snapcraft/scripts/Makefile
@@ -13,3 +13,5 @@ install:
 	install -D -m 0755 ldpd-service $(DESTDIR)/bin/
 	install -D -m 0755 nhrpd-service $(DESTDIR)/bin/
 	install -D -m 0755 set-options $(DESTDIR)/bin/
+	install -D -m 0755 show_version $(DESTDIR)/bin/
+

--- a/snapcraft/scripts/show_version
+++ b/snapcraft/scripts/show_version
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+$SNAP/sbin/zebra --version
+$SNAP/bin/cat $SNAP/doc/extra_version_info.txt
+
+exit 0

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -192,12 +192,6 @@ parts:
         plugin: autotools
         source: ../frr-@PACKAGE_VERSION@.tar.gz
         configflags:
-            - --with-cflags=-g
-            - --with-cflags=-O0
-            - --with-cflags=-std=gnu99
-            - --with-cflags=-fpie
-            - --with-cflags=-fno-omit-frame-pointer
-            - --with-cflags=-Wall
             - --enable-vtysh
             - --enable-isisd
             - --enable-watchfrr
@@ -206,7 +200,6 @@ parts:
             - --enable-multipath=64
             - --enable-rtadv
             - --enable-irdp
-            - --enable-gcc-rdynamic
             - --enable-user=root
             - --enable-group=root
             - --enable-pimd

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -17,7 +17,7 @@ apps:
             - network-bind
             - network-control
     version:
-        command: sbin/zebra --version
+        command: bin/show_version
     readme:
         command: bin/cat $SNAP/doc/README.usage.md
     zebra:
@@ -254,4 +254,5 @@ parts:
         organize:
             README.usage.md: doc/README.usage.md
             README.snap_build.md: doc/README.snap_build.md
+            extra_version_info.txt: doc/extra_version_info.txt
 


### PR DESCRIPTION
A few additional fixes for the snap package:
- Fix 'make dist' which was missing some files
- Add feature to add optional additional snap version information
- Cleanup configure flags to remove outdated flags