### PR TITLE
bgpd: fix "clear bgp" commands

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5895,7 +5895,6 @@ DEFUN (clear_ip_bgp_all,
        "Push out prefix-list ORF and do inbound soft reconfig\n"
        BGP_SOFT_OUT_STR)
 {
-  VTY_DECLVAR_CONTEXT(bgp, bgp);
   char *vrf = NULL;
 
   afi_t afi = AFI_IP6;
@@ -5935,25 +5934,11 @@ DEFUN (clear_ip_bgp_all,
       clr_sort = clear_group;
       idx++;
       clr_arg = argv[idx]->arg;
-
-      if (! peer_group_lookup (bgp, clr_arg))
-        {
-          vty_out (vty, "%% No such peer-group%s", VTY_NEWLINE);
-          return CMD_WARNING;
-        }
     }
   else if (argv_find (argv, argc, "WORD", &idx))
     {
-      if (peer_lookup_by_conf_if (bgp, argv[idx]->arg))
-        {
-          clr_sort = clear_peer;
-          clr_arg = argv[idx]->arg;
-        }
-      else
-        {
-          vty_out (vty, "%% No such neighbor%s", VTY_NEWLINE);
-	  return CMD_WARNING;
-        }
+      clr_sort = clear_peer;
+      clr_arg = argv[idx]->arg;
     }
   else if (argv_find (argv, argc, "(1-4294967295)", &idx))
     {


### PR DESCRIPTION
The use of VTY_DECLVAR_CONTEXT(bgp, bgp) here is wrong as we are not
inside the "router bgp" configuration node. This was making the clear
commands always fail with a "Current configuration object was deleted
by another process" error, which doesn't make any sense.

Also, the bgp_clear() function will already check for us if the given
peer-group or neighbor exists or not, there's no need to duplicate this
logic here.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>