### PR TITLE
lib: fix segfault on exit caused by interface removal

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -190,6 +190,7 @@ if_unlink_per_ns (struct interface *ifp)
 {
   ifp->node->info = NULL;
   route_unlock_node(ifp->node);
+  ifp->node = NULL;
 }
 
 /* Look up an interface by identifier within a NS */


### PR DESCRIPTION
Add missing bits to properly unlink interface in the if_unlink_per_ns()
function.

In the long term we should convert if_table to use a more convenient
data structure like a red-black tree instead of a routing table.

Fixes issue #398.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>