### PR TITLE
zebra: fix infinite loop when deleting non-default vrf

### DIFF
--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -265,6 +265,7 @@ zebra_vrf_delete (struct vrf *vrf)
 	    {
 	      route_unlock_node (rnode);
 	      list_delete_node (zebrad.mq->subq[i], lnode);
+	      zebrad.mq->size--;
 	    }
 	}
     }


### PR DESCRIPTION
How to reproduce the bug:
% ip link add vrf-red type vrf table 10
% ip link set dev vrf-red up
% ip rule add oif vrf-red table 10
% ip rule add iif vrf-red table 10
% ip link add name lo1 type dummy
% ip link set dev lo1 up
% ip link set dev lo1 master vrf-red
% ip link del dev vrf-red
(zebra gets stuck in an infinite loop inside work_queue_run())

Regression introduced by commit 5a8dfcd8.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>