### PR TITLE
Fix interface renames

### DIFF
--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -209,7 +209,7 @@ if_addr_add(struct kaddr *ka)
 		}
 	}
 
-	iface = if_lookup(leconf, ka->ifindex);
+	iface = if_lookup_name(leconf, ka->ifname);
 	if (iface) {
 		if (ka->af == AF_INET6 && IN6_IS_ADDR_LINKLOCAL(&ka->addr.v6))
 			iface->linklocal = ka->addr.v6;
@@ -229,7 +229,7 @@ if_addr_del(struct kaddr *ka)
 	struct if_addr		*if_addr;
 	struct nbr		*nbr;
 
-	iface = if_lookup(leconf, ka->ifindex);
+	iface = if_lookup_name(leconf, ka->ifname);
 	if (iface) {
 		if (ka->af == AF_INET6 &&
 		    IN6_ARE_ADDR_EQUAL(&iface->linklocal, &ka->addr.v6))

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -73,6 +73,7 @@ static void
 ifc2kaddr(struct interface *ifp, struct connected *ifc, struct kaddr *ka)
 {
 	memset(ka, 0, sizeof(*ka));
+	strlcpy(ka->ifname, ifp->name, sizeof(ka->ifname));
 	ka->ifindex = ifp->ifindex;
 	ka->af = ifc->address->family;
 	ka->prefixlen = ifc->address->prefixlen;
@@ -232,6 +233,7 @@ ldp_interface_delete(int command, struct zclient *zclient, zebra_size_t length,
     vrf_id_t vrf_id)
 {
 	struct interface	*ifp;
+	struct kif		 kif;
 
 	/* zebra_interface_state_read() updates interface structure in iflist */
 	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
@@ -243,7 +245,10 @@ ldp_interface_delete(int command, struct zclient *zclient, zebra_size_t length,
 
 	/* To support pseudo interface do not free interface structure.  */
 	/* if_delete(ifp); */
-	ifp->ifindex = IFINDEX_INTERNAL;
+	ifp->ifindex = IFINDEX_DELETED;
+
+	ifp2kif(ifp, &kif);
+	main_imsg_compose_both(IMSG_IFSTATUS, &kif, sizeof(kif));
 
 	return (0);
 }
@@ -309,8 +314,8 @@ ldp_interface_address_add(int command, struct zclient *zclient,
 	if (bad_addr(ka.af, &ka.addr))
 		return (0);
 
-	debug_zebra_in("address add %s/%u", log_addr(ka.af, &ka.addr),
-	    ka.prefixlen);
+	debug_zebra_in("address add %s/%u interface %s",
+	    log_addr(ka.af, &ka.addr), ka.prefixlen, ifp->name);
 
 	/* notify ldpe about new address */
 	main_imsg_compose_ldpe(IMSG_NEWADDR, 0, &ka, sizeof(ka));
@@ -338,8 +343,8 @@ ldp_interface_address_delete(int command, struct zclient *zclient,
 	if (bad_addr(ka.af, &ka.addr))
 		return (0);
 
-	debug_zebra_in("address delete %s/%u", log_addr(ka.af, &ka.addr),
-	    ka.prefixlen);
+	debug_zebra_in("address delete %s/%u interface %s",
+	    log_addr(ka.af, &ka.addr), ka.prefixlen, ifp->name);
 
 	/* notify ldpe about removed address */
 	main_imsg_compose_ldpe(IMSG_DELADDR, 0, &ka, sizeof(ka));

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -541,6 +541,7 @@ struct kpw {
 };
 
 struct kaddr {
+	char			 ifname[IF_NAMESIZE];
 	unsigned short		 ifindex;
 	int			 af;
 	union ldpd_addr		 addr;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -746,7 +746,7 @@ netlink_link_change (struct sockaddr_nl *snl, struct nlmsghdr *h,
     }
 
   /* See if interface is present. */
-  ifp = if_lookup_by_index_per_ns (zns, ifi->ifi_index);
+  ifp = if_lookup_by_name_per_ns (zns, name);
 
   if (h->nlmsg_type == RTM_NEWLINK)
     {

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -211,6 +211,23 @@ if_lookup_by_index_per_ns (struct zebra_ns *ns, u_int32_t ifindex)
   return ifp;
 }
 
+/* Look up an interface by name within a NS */
+struct interface *
+if_lookup_by_name_per_ns (struct zebra_ns *ns, const char *ifname)
+{
+  struct route_node *rn;
+  struct interface *ifp;
+
+  for (rn = route_top (ns->if_table); rn; rn = route_next (rn))
+    {
+      ifp = (struct interface *)rn->info;
+      if (ifp && strcmp (ifp->name, ifname) == 0)
+	return (ifp);
+    }
+
+  return NULL;
+}
+
 const char *
 ifindex2ifname_per_ns (struct zebra_ns *zns, unsigned int ifindex)
 {

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -236,6 +236,7 @@ struct zebra_if
 
 
 extern struct interface *if_lookup_by_index_per_ns (struct zebra_ns *, u_int32_t);
+extern struct interface *if_lookup_by_name_per_ns (struct zebra_ns *, const char *);
 extern struct interface *if_link_per_ns (struct zebra_ns *, struct interface *);
 extern const char *ifindex2ifname_per_ns (struct zebra_ns *, unsigned int);
 


### PR DESCRIPTION
More details in the commit messages.

I did some testing with ospfd and ospf6d and both are handling interface renames ok. ldpd needed some additional work but now is handling renames ok too.

Fixes #397.