### PR TITLE
ldpd: respect link-detect configuration

### DIFF
--- a/ldpd/l2vpn.c
+++ b/ldpd/l2vpn.c
@@ -142,7 +142,7 @@ void
 l2vpn_if_update_info(struct l2vpn_if *lif, struct kif *kif)
 {
 	lif->ifindex = kif->ifindex;
-	lif->flags = kif->flags;
+	lif->operative = kif->operative;
 	memcpy(lif->mac, kif->mac, sizeof(lif->mac));
 }
 
@@ -154,7 +154,7 @@ l2vpn_if_update(struct l2vpn_if *lif)
 	struct map	 fec;
 	struct nbr	*nbr;
 
-	if ((lif->flags & IFF_UP) && (lif->flags & IFF_RUNNING))
+	if (lif->operative)
 		return;
 
 	RB_FOREACH(pw, l2vpn_pw_head, &l2vpn->pw_tree) {

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -298,7 +298,7 @@ struct iface {
 	struct if_addr_head	 addr_list;
 	struct in6_addr		 linklocal;
 	enum iface_type		 type;
-	uint16_t		 flags;
+	int			 operative;
 	struct iface_af		 ipv4;
 	struct iface_af		 ipv6;
 	QOBJ_FIELDS
@@ -380,7 +380,7 @@ struct l2vpn_if {
 	struct l2vpn		*l2vpn;
 	char			 ifname[IF_NAMESIZE];
 	unsigned int		 ifindex;
-	uint16_t		 flags;
+	int			 operative;
 	uint8_t			 mac[ETHER_ADDR_LEN];
 	QOBJ_FIELDS
 };
@@ -552,6 +552,7 @@ struct kif {
 	char			 ifname[IF_NAMESIZE];
 	unsigned short		 ifindex;
 	int			 flags;
+	int			 operative;
 	uint8_t			 mac[ETHER_ADDR_LEN];
 	int			 mtu;
 };
@@ -569,7 +570,6 @@ struct ctl_iface {
 	char			 name[IF_NAMESIZE];
 	unsigned int		 ifindex;
 	int			 state;
-	uint16_t		 flags;
 	enum iface_type		 type;
 	uint16_t		 hello_holdtime;
 	uint16_t		 hello_interval;


### PR DESCRIPTION
We shouldn't check the operational status of an interface in ldpd if
it's configured with "no link-detect" in zebra. That's what all the
other routing daemons do.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>