### PR TITLE
Fix the error when execute nhrpd

### DIFF
--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -44,11 +44,9 @@ static zebra_capabilities_t _caps_p [] = {
 };
 
 static struct zebra_privs_t nhrpd_privs = {
-#ifdef QUAGGA_USER
-	.user = QUAGGA_USER,
-#endif
-#ifdef QUAGGA_GROUP
-	.group = QUAGGA_GROUP,
+#if defined(FRR_USER) && defined(FRR_GROUP)
+	.user = FRR_USER,
+	.group = FRR_GROUP,
 #endif
 #ifdef VTY_GROUP
 	.vty_group = VTY_GROUP,


### PR DESCRIPTION
Error message **privs_init: user((null)) is not part of vty group specified(frrvty)**

- The **nhrpd** still use the **QUAGGA** for its **nhrpd_privs**.
- Modify the define from **QUAGGA** to **FRR**

Signed-off-by: Hung-Weic Chiu <sppsorrg@gmail.com>