### PR TITLE
ospfd: fix small problem in the redistribute command

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7160,7 +7160,7 @@ DEFUN (no_ospf_redistribute_source,
 
 DEFUN (ospf_redistribute_instance_source,
        ospf_redistribute_instance_source_cmd,
-       "redistribute <ospf|table> (1-65535) {<metric (0-16777214)|metric-type (1-2)|route-map WORD>}",
+       "redistribute <ospf|table> (1-65535) {metric (0-16777214)|metric-type (1-2)|route-map WORD}",
        REDIST_STR
        "Open Shortest Path First\n"
        "Non-main Kernel Routing Table\n"
@@ -7231,7 +7231,7 @@ DEFUN (ospf_redistribute_instance_source,
 
 DEFUN (no_ospf_redistribute_instance_source,
        no_ospf_redistribute_instance_source_cmd,
-       "no redistribute <ospf|table> (1-65535) {<metric (0-16777214)|metric-type (1-2)|route-map WORD>}",
+       "no redistribute <ospf|table> (1-65535) {metric (0-16777214)|metric-type (1-2)|route-map WORD}",
        NO_STR
        REDIST_STR
        "Open Shortest Path First\n"


### PR DESCRIPTION
The use of {<>} is unnecessary and not correct.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>