### PR TITLE
Label Manager filter messages

### DIFF
--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -130,7 +130,6 @@ struct zclient *zclient_sync = NULL;
 static void
 zclient_sync_init(u_short instance)
 {
-	int flags;
 	/* Initialize special zclient for synchronous message exchanges. */
 	log_debug("Initializing synchronous zclient for label manager");
 	zclient_sync = zclient_new(master);
@@ -142,9 +141,7 @@ zclient_sync_init(u_short instance)
 		lde_sleep();
 	}
 	/* make socket non-blocking */
-	flags = fcntl(zclient_sync->sock, F_GETFL);
-	flags |= O_NONBLOCK;
-	fcntl(zclient_sync->sock, F_SETFL, flags);
+	sock_set_nonblock(zclient_sync->sock);
 
 	/* Connect to label manager */
 	while (lm_label_manager_connect (zclient_sync) != 0) {

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -130,6 +130,7 @@ struct zclient *zclient_sync = NULL;
 static void
 zclient_sync_init(u_short instance)
 {
+	int flags;
 	/* Initialize special zclient for synchronous message exchanges. */
 	log_debug("Initializing synchronous zclient for label manager");
 	zclient_sync = zclient_new(master);
@@ -140,6 +141,10 @@ zclient_sync_init(u_short instance)
 		fprintf(stderr, "Error connecting synchronous zclient!\n");
 		lde_sleep();
 	}
+	/* make socket non-blocking */
+	flags = fcntl(zclient_sync->sock, F_GETFL);
+	flags |= O_NONBLOCK;
+	fcntl(zclient_sync->sock, F_SETFL, flags);
 
 	/* Connect to label manager */
 	while (lm_label_manager_connect (zclient_sync) != 0) {

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -1596,8 +1596,6 @@ lde_get_label_chunk(void)
 	if (ret < 0)
 	{
 		log_warnx("Error getting label chunk!");
-		close(zclient_sync->sock);
-		zclient_sync->sock = -1;
 		return -1;
 	}
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1465,6 +1465,47 @@ zebra_interface_vrf_update_read (struct stream *s, vrf_id_t vrf_id,
   *new_vrf_id = new_id;
   return ifp;
 }
+
+/* filter unwanted messages until the expected one arrives */
+static int
+zclient_read_sync_response (struct zclient *zclient, u_int16_t expected_cmd)
+{
+  struct stream *s;
+  u_int16_t size;
+  u_char marker;
+  u_char version;
+  vrf_id_t vrf_id;
+  u_int16_t cmd;
+  fd_set readfds;
+  int ret;
+
+  ret = 0;
+  cmd = expected_cmd + 1;
+  while (ret == 0 && cmd != expected_cmd)
+    {
+      s = zclient->ibuf;
+      stream_reset (s);
+
+      /* wait until response arrives */
+      FD_ZERO (&readfds);
+      FD_SET (zclient->sock, &readfds);
+      select (zclient->sock+1, &readfds, NULL, NULL, NULL);
+      if (!FD_ISSET(zclient->sock, &readfds))
+        continue;
+      /* read response */
+      ret = zclient_read_header (s, zclient->sock, &size, &marker, &version,
+                                 &vrf_id, &cmd);
+      if (zclient_debug)
+        zlog_debug ("%s: Response (%d bytes) received", __func__, size);
+    }
+  if (ret != 0)
+    {
+      zlog_err ("%s: Invalid Sync Message Reply", __func__);
+      return -1;
+    }
+
+  return 0;
+}
 /**
  * Connect to label manager in a syncronous way
  *
@@ -1480,11 +1521,6 @@ lm_label_manager_connect (struct zclient *zclient)
   int ret;
   struct stream *s;
   u_char result;
-  u_int16_t size;
-  u_char marker;
-  u_char version;
-  vrf_id_t vrf_id;
-  u_int16_t cmd;
 
   if (zclient_debug)
     zlog_debug ("Connecting to Label Manager");
@@ -1524,20 +1560,15 @@ lm_label_manager_connect (struct zclient *zclient)
     zlog_debug ("%s: Label manager connect request (%d bytes) sent", __func__, ret);
 
   /* read response */
-  s = zclient->ibuf;
-  stream_reset (s);
+  if (zclient_read_sync_response (zclient, ZEBRA_LABEL_MANAGER_CONNECT) != 0)
+    return -1;
 
-  ret = zclient_read_header (s, zclient->sock, &size, &marker, &version,
-                             &vrf_id, &cmd);
-  if (ret != 0 || cmd != ZEBRA_LABEL_MANAGER_CONNECT) {
-      zlog_err ("%s: Invalid Label Manager Connect Message Reply Header", __func__);
-      return -1;
-  }
   /* result */
+  s = zclient->ibuf;
   result = stream_getc(s);
   if (zclient_debug)
-    zlog_debug ("%s: Label Manager connect response (%d bytes) received, result %u",
-                __func__, size, result);
+    zlog_debug ("%s: Label Manager connect response received, result %u",
+                __func__, result);
 
   return (int)result;
 }
@@ -1561,11 +1592,6 @@ lm_get_label_chunk (struct zclient *zclient, u_char keep, uint32_t chunk_size,
 {
   int ret;
   struct stream *s;
-  u_int16_t size;
-  u_char marker;
-  u_char version;
-  vrf_id_t vrf_id;
-  u_int16_t cmd;
   u_char response_keep;
 
   if (zclient_debug)
@@ -1604,18 +1630,10 @@ lm_get_label_chunk (struct zclient *zclient, u_char keep, uint32_t chunk_size,
     zlog_debug ("%s: Label chunk request (%d bytes) sent", __func__, ret);
 
   /* read response */
+  if (zclient_read_sync_response (zclient, ZEBRA_GET_LABEL_CHUNK) != 0)
+    return -1;
+
   s = zclient->ibuf;
-  stream_reset (s);
-
-  ret = zclient_read_header (s, zclient->sock, &size, &marker, &version,
-                             &vrf_id, &cmd);
-  if (ret != 0 || cmd != ZEBRA_GET_LABEL_CHUNK) {
-      zlog_err ("%s: Invalid Get Label Chunk Message Reply Header", __func__);
-      return -1;
-  }
-  if (zclient_debug)
-    zlog_debug ("%s: Label chunk response (%d bytes) received", __func__, size);
-
   /* keep */
   response_keep = stream_getc(s);
   /* start and end labels */
@@ -1623,18 +1641,20 @@ lm_get_label_chunk (struct zclient *zclient, u_char keep, uint32_t chunk_size,
   *end = stream_getl(s);
 
   /* not owning this response */
-  if (keep != response_keep) {
-          zlog_err ("%s: Invalid Label chunk: %u - %u, keeps mismatch %u != %u",
-                    __func__, *start, *end, keep, response_keep);
-  }
+  if (keep != response_keep)
+    {
+      zlog_err ("%s: Invalid Label chunk: %u - %u, keeps mismatch %u != %u",
+                __func__, *start, *end, keep, response_keep);
+    }
   /* sanity */
   if (*start > *end
       || *start < MPLS_MIN_UNRESERVED_LABEL
-      || *end > MPLS_MAX_UNRESERVED_LABEL) {
-          zlog_err ("%s: Invalid Label chunk: %u - %u", __func__,
-                    *start, *end);
-          return -1;
-  }
+      || *end > MPLS_MAX_UNRESERVED_LABEL)
+    {
+      zlog_err ("%s: Invalid Label chunk: %u - %u", __func__,
+                *start, *end);
+      return -1;
+    }
 
   if (zclient_debug)
     zlog_debug ("Label Chunk assign: %u - %u (%u) ",

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1911,10 +1911,7 @@ zread_label_manager_request (int cmd, struct zserv *client, vrf_id_t vrf_id)
 
   /* external label manager */
   if (lm_is_external)
-    {
-      if (zread_relay_label_manager_request (cmd, client) != 0)
-        zsend_label_manager_connect_response (client, vrf_id, 1);
-    }
+    zread_relay_label_manager_request (cmd, client);
   /* this is a label manager */
   else
     {


### PR DESCRIPTION
Until LDE client sends ZEBRA_LABEL_MANAGER_CONNECT message, zserv
doesn't know which kind of client it is, so it might enqueue unwanted
messages like interface add, interface up, etc. Changes in this commit
discard those messages in the client side in case they arrive before the
expected response.