### PR TITLE
*: fix a bunch of segfaults detected by a CLI fuzzer

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -300,9 +300,11 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd,
       "Display information for a route distinguisher\n"
       "VPN Route Distinguisher\n" JSON_STR)
 {
-	int idx_ext_community = 6;
+	int idx_ext_community = 0;
 	int ret;
 	struct prefix_rd prd;
+
+	argv_find (argv, argc, "ASN:nn_or_IP-address:nn", &idx_ext_community);
 
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
 	if (!ret) {
@@ -339,9 +341,11 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_tags,
       "Display information for a route distinguisher\n"
       "VPN Route Distinguisher\n" "Display BGP tags for prefixes\n")
 {
-	int idx_ext_community = 6;
+	int idx_ext_community = 0;
 	int ret;
 	struct prefix_rd prd;
+
+	argv_find (argv, argc, "ASN:nn_or_IP-address:nn", &idx_ext_community);
 
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
 	if (!ret) {
@@ -365,11 +369,13 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_neighbor_routes,
       "Neighbor to display information about\n"
       "Display routes learned from neighbor\n" JSON_STR)
 {
-	int idx_ipv4 = 6;
+	int idx_ipv4 = 0;
 	union sockunion su;
 	struct peer *peer;
 	int ret;
 	u_char uj = use_json(argc, argv);
+
+	argv_find (argv, argc, "A.B.C.D", &idx_ipv4);
 
 	ret = str2sockunion(argv[idx_ipv4]->arg, &su);
 	if (ret < 0) {
@@ -423,13 +429,16 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
       "Neighbor to display information about\n"
       "Display routes learned from neighbor\n" JSON_STR)
 {
-	int idx_ext_community = 6;
-	int idx_ipv4 = 8;
+	int idx_ext_community = 0;
+	int idx_ipv4 = 0;
 	int ret;
 	union sockunion su;
 	struct peer *peer;
 	struct prefix_rd prd;
 	u_char uj = use_json(argc, argv);
+
+	argv_find (argv, argc, "ASN:nn_or_IP-address:nn", &idx_ext_community);
+	argv_find (argv, argc, "A.B.C.D", &idx_ipv4);
 
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
 	if (!ret) {
@@ -499,11 +508,13 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_neighbor_advertised_routes,
       "Neighbor to display information about\n"
       "Display the routes advertised to a BGP neighbor\n" JSON_STR)
 {
-	int idx_ipv4 = 7;
+	int idx_ipv4 = 0;
 	int ret;
 	struct peer *peer;
 	union sockunion su;
 	u_char uj = use_json(argc, argv);
+
+	argv_find (argv, argc, "A.B.C.D", &idx_ipv4);
 
 	ret = str2sockunion(argv[idx_ipv4]->arg, &su);
 	if (ret < 0) {
@@ -555,13 +566,16 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes,
       "Neighbor to display information about\n"
       "Display the routes advertised to a BGP neighbor\n" JSON_STR)
 {
-	int idx_ext_community = 6;
-	int idx_ipv4 = 8;
+	int idx_ext_community = 0;
+	int idx_ipv4 = 0;
 	int ret;
 	struct peer *peer;
 	struct prefix_rd prd;
 	union sockunion su;
 	u_char uj = use_json(argc, argv);
+
+	argv_find (argv, argc, "ASN:nn_or_IP-address:nn", &idx_ext_community);
+	argv_find (argv, argc, "A.B.C.D", &idx_ipv4);
 
 	ret = str2sockunion(argv[idx_ipv4]->arg, &su);
 	if (ret < 0) {
@@ -644,9 +658,11 @@ DEFUN(show_ip_bgp_evpn_rd_overlay,
       "VPN Route Distinguisher\n"
       "Display BGP Overlay Information for prefixes\n")
 {
-	int idx_ext_community = 6;
+	int idx_ext_community = 0;
 	int ret;
 	struct prefix_rd prd;
+
+	argv_find (argv, argc, "ASN:nn_or_IP-address:nn", &idx_ext_community);
 
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
 	if (!ret) {

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -531,7 +531,7 @@ DEFUN (vpnv6_network,
   int idx_ext_community = 3;
   int idx_word = 5;
   int idx_word_2 = 7;
-  if (argv[idx_word_2])
+  if (argc == 8)
     return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg, 0, NULL, NULL, NULL, NULL);
   else
     return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL, 0, NULL, NULL, NULL, NULL);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4333,7 +4333,7 @@ DEFUN (no_set_ipv6_nexthop_global,
 #ifdef KEEP_OLD_VPN_COMMANDS
 DEFUN (set_vpn_nexthop,
        set_vpn_nexthop_cmd,
-       "set <vpnv4|vpnv6> next-hop [A.B.C.D|X:X::X:X]",
+       "set <vpnv4|vpnv6> next-hop <A.B.C.D|X:X::X:X>",
        SET_STR
        "VPNv4 information\n"
        "VPNv6 information\n"
@@ -4359,7 +4359,7 @@ DEFUN (set_vpn_nexthop,
 
 DEFUN (no_set_vpn_nexthop,
        no_set_vpn_nexthop_cmd,
-       "no set vpn next-hop [A.B.C.D|X:X::X:X]",
+       "no set vpn next-hop <A.B.C.D|X:X::X:X>",
        NO_STR
        SET_STR
        "VPN information\n"
@@ -4444,7 +4444,7 @@ DEFUN (no_set_ipx_vpn_nexthop,
                                    "ip vpn next-hop", arg);
       else
         return generic_set_delete (vty, VTY_GET_CONTEXT(route_map_index),
-                                   "ipv6 vpn next-hop", argv[idx_ip]->arg);
+                                   "ipv6 vpn next-hop", arg);
     }
   return CMD_SUCCESS;
 }

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2046,12 +2046,12 @@ DEFUN (vnc_nve_export_no_prefixlist,
   if (argv[3]->arg[0] == 'b')
     {
       if (((argc > 6)
+           && hc->plist_export_bgp_name[afi]
            && !strcmp (argv[6]->arg, hc->plist_export_bgp_name[afi]))
           || (argc <= 6))
         {
 
-          if (hc->plist_export_bgp_name[afi])
-            free (hc->plist_export_bgp_name[afi]);
+          free (hc->plist_export_bgp_name[afi]);
           hc->plist_export_bgp_name[afi] = NULL;
           hc->plist_export_bgp[afi] = NULL;
           vnc_direct_bgp_reexport (bgp, afi);
@@ -2060,12 +2060,12 @@ DEFUN (vnc_nve_export_no_prefixlist,
   else
     {
       if (((argc > 6)
+           && hc->plist_export_zebra_name[afi]
            && !strcmp (argv[6]->arg, hc->plist_export_zebra_name[afi]))
           || (argc <= 6))
         {
 
-          if (hc->plist_export_zebra_name[afi])
-            free (hc->plist_export_zebra_name[afi]);
+          free (hc->plist_export_zebra_name[afi]);
           hc->plist_export_zebra_name[afi] = NULL;
           hc->plist_export_zebra[afi] = NULL;
           /* TBD vnc_zebra_rh_reexport(bgp, afi); */
@@ -2146,12 +2146,12 @@ DEFUN (vnc_nve_export_no_routemap,
   if (argv[3]->arg[0] == 'b')
     {
       if (((argc > 5)
+           && hc->routemap_export_bgp_name
            && !strcmp (argv[5]->arg, hc->routemap_export_bgp_name))
           || (argc <= 5))
         {
 
-          if (hc->routemap_export_bgp_name)
-            free (hc->routemap_export_bgp_name);
+          free (hc->routemap_export_bgp_name);
           hc->routemap_export_bgp_name = NULL;
           hc->routemap_export_bgp = NULL;
           vnc_direct_bgp_reexport (bgp, AFI_IP);
@@ -2161,12 +2161,12 @@ DEFUN (vnc_nve_export_no_routemap,
   else
     {
       if (((argc > 5)
+           && hc->routemap_export_zebra_name
            && !strcmp (argv[5]->arg, hc->routemap_export_zebra_name))
           || (argc <= 5))
         {
 
-          if (hc->routemap_export_zebra_name)
-            free (hc->routemap_export_zebra_name);
+          free (hc->routemap_export_zebra_name);
           hc->routemap_export_zebra_name = NULL;
           hc->routemap_export_zebra = NULL;
           /* TBD vnc_zebra_rh_reexport(bgp, AFI_IP); */

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -2190,9 +2190,9 @@ register_add (
   int        argc,
   struct cmd_token **argv)
 {
-       const char *arg_prefix = carg_prefix->arg;
-       const char *arg_vn = carg_vn->arg;
-       const char *arg_un = carg_un->arg;
+       const char *arg_prefix = carg_prefix ? carg_prefix->arg : NULL;
+       const char *arg_vn = carg_vn ? carg_vn->arg : NULL;
+       const char *arg_un = carg_un ? carg_un->arg : NULL;
        const char *arg_cost = carg_cost ? carg_cost->arg : NULL;
        const char *arg_lifetime = carg_lifetime ? carg_lifetime->arg : NULL;
        const char *arg_macaddr = carg_macaddr ? carg_macaddr->arg : NULL;
@@ -3906,7 +3906,7 @@ DEFUN (clear_vnc_nve_un,
   struct rfapi_local_reg_delete_arg cda;
   int rc;
 
-  if ((rc = parse_deleter_tokens (vty, NULL, NULL, NULL, argv[6], NULL, NULL, NULL, NULL, &cda)))
+  if ((rc = parse_deleter_tokens (vty, NULL, NULL, NULL, argv[4], NULL, NULL, NULL, NULL, &cda)))
     return rc;
 
   cda.vty = vty;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1539,7 +1539,7 @@ ospf_area_nssa_cmd_handler (struct vty *vty, int argc, struct cmd_token **argv,
       return CMD_WARNING;
     }
 
-  if (argc > 1)
+  if (argc > 3)
     {
       if (strncmp (argv[3]->text, "translate-c", 11) == 0)
         ospf_area_nssa_translator_role_set (ospf, area_id,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4003,7 +4003,7 @@ DEFUN (ip_ssmpingd,
   int idx_ipv4 = 2;
   int result;
   struct in_addr source_addr;
-  const char *source_str = (argc == idx_ipv4) ? argv[idx_ipv4]->arg : "0.0.0.0";
+  const char *source_str = (argc == 3) ? argv[idx_ipv4]->arg : "0.0.0.0";
 
   result = inet_pton(AF_INET, source_str, &source_addr);
   if (result <= 0) {
@@ -4033,7 +4033,7 @@ DEFUN (no_ip_ssmpingd,
   int idx_ipv4 = 3;
   int result;
   struct in_addr source_addr;
-  const char *source_str = (argc == idx_ipv4) ? argv[idx_ipv4]->arg : "0.0.0.0";
+  const char *source_str = (argc == 4) ? argv[idx_ipv4]->arg : "0.0.0.0";
 
   result = inet_pton(AF_INET, source_str, &source_addr);
   if (result <= 0) {
@@ -5956,7 +5956,7 @@ DEFUN (no_ip_msdp_mesh_group_source,
        "mesh group source\n"
        "mesh group local address\n")
 {
-  if (argc == 6)
+  if (argc == 7)
     return ip_no_msdp_mesh_group_cmd_worker(vty, argv[6]->arg);
   else
     return ip_no_msdp_mesh_group_source_cmd_worker(vty, argv[4]->arg);
@@ -6459,9 +6459,9 @@ DEFUN (show_ip_msdp_sa_sg,
   if (uj)
     argc--;
 
-  if (argc == 5)
+  if (argc == 6)
     ip_msdp_show_sa_sg(vty, argv[4]->arg, argv[5]->arg, uj);
-  else if (argc == 4)
+  else if (argc == 5)
     ip_msdp_show_sa_addr(vty, argv[4]->arg, uj);
   else
     ip_msdp_show_sa(vty, uj);

--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -173,11 +173,12 @@ DEFUN (debug_zebra_kernel_msgdump,
        "Dump raw netlink messages received\n"
        "Dump raw netlink messages sent\n")
 {
-  int idx_recv_send = 4;
-  if (argv[idx_recv_send]->arg && strncmp(argv[idx_recv_send]->arg, "recv", strlen(argv[idx_recv_send]->arg)) == 0)
+  int idx = 0;
+  if (argc == 4 || argv_find (argv, argc, "recv", &idx))
     SET_FLAG(zebra_debug_kernel, ZEBRA_DEBUG_KERNEL_MSGDUMP_RECV);
-  if (!argv[idx_recv_send]->arg || strncmp(argv[idx_recv_send]->arg, "send", strlen(argv[idx_recv_send]->arg)) == 0)
+  if (argc == 4 || argv_find (argv, argc, "send", &idx))
     SET_FLAG(zebra_debug_kernel, ZEBRA_DEBUG_KERNEL_MSGDUMP_SEND);
+
   return CMD_SUCCESS;
 }
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1706,6 +1706,8 @@ link_param_cmd_set_float (struct interface *ifp, float *field,
 static void
 link_param_cmd_unset (struct interface *ifp, uint32_t type)
 {
+  if (ifp->link_params == NULL)
+    return;
 
   /* Unset field */
   UNSET_PARAM(ifp->link_params, type);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3338,7 +3338,7 @@ DEFUN (show_ipv6_mroute,
   int first = 1;
   vrf_id_t vrf_id = VRF_DEFAULT;
 
-  if (strmatch(argv[3]->text, "vrf"))
+  if (argc == 5)
     VRF_GET_ID (vrf_id, argv[4]->arg);
 
   table = zebra_vrf_table (AFI_IP6, SAFI_MULTICAST, vrf_id);


### PR DESCRIPTION
This patch fixes the following segfaults:
```
zebra aborted: vtysh -c "show ipv6 mroute"
zebra aborted: vtysh -c "configure terminal" -c "debug zebra kernel msgdump"
zebra aborted: vtysh -c "configure terminal" -c "interface eth99" -c "link-params" -c "no packet-loss"
zebra aborted: vtysh -c "configure terminal" -c "interface eth99" -c "link-params" -c "no metric"
zebra aborted: vtysh -c "configure terminal" -c "interface eth99" -c "link-params" -c "no ava-bw"
zebra aborted: vtysh -c "configure terminal" -c "interface eth99" -c "link-params" -c "no res-bw"
zebra aborted: vtysh -c "configure terminal" -c "interface eth99" -c "link-params" -c "no use-bw"
ospfd aborted: vtysh -c "configure terminal" -c "router ospf" -c "area 1.1.1.1 nssa"
ospfd aborted: vtysh -c "configure terminal" -c "router ospf" -c "area 4294967295 nssa"
pimd aborted: vtysh -c "show ip msdp sa 1.1.1.1"
pimd aborted: vtysh -c "configure terminal" -c "ip ssmpingd"
pimd aborted: vtysh -c "configure terminal" -c "no ip ssmpingd"
pimd aborted: vtysh -c "configure terminal" -c "no ip msdp mesh-group WORD source"
pimd aborted: vtysh -c "configure terminal" -c "interface eth99" -c "ip pim hello 180"
bgpd aborted: vtysh -c "show bgp l2vpn evpn rd 1:1"
bgpd aborted: vtysh -c "clear vnc nve un *"
bgpd aborted: vtysh -c "clear vnc nve un 1.1.1.1"
bgpd aborted: vtysh -c "clear vnc nve un 2001:db8::1"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 1.1.1.1 un 1.1.1.1 lifetime 4294967295"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 1.1.1.1 un 1.1.1.1 cost 255 lifetime 4294967295"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 1.1.1.1 un 1.1.1.1 cost 255"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 1.1.1.1 un 1.1.1.1"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 1.1.1.1 un 2001:db8::1 lifetime 4294967295"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 1.1.1.1 un 2001:db8::1 cost 255 lifetime 4294967295"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 1.1.1.1 un 2001:db8::1 cost 255"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 1.1.1.1 un 2001:db8::1"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 2001:db8::1 un 1.1.1.1 lifetime 4294967295"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 2001:db8::1 un 1.1.1.1 cost 255 lifetime 4294967295"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 2001:db8::1 un 1.1.1.1 cost 255"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 2001:db8::1 un 1.1.1.1"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 2001:db8::1 un 2001:db8::1 lifetime 4294967295"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 2001:db8::1 un 2001:db8::1 cost 255 lifetime 4294967295"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 2001:db8::1 un 2001:db8::1 cost 255"
bgpd aborted: vtysh -c "add vnc mac 11:11:11:11:11:11 virtual-network-identifier 4294967295 vn 2001:db8::1 un 2001:db8::1"
bgpd aborted: vtysh -c "configure terminal" -c "router bgp 1" -c "no vnc export bgp ipv4 prefix-list NAME"
bgpd aborted: vtysh -c "configure terminal" -c "router bgp 1" -c "no vnc export bgp ipv6 prefix-list NAME"
bgpd aborted: vtysh -c "configure terminal" -c "router bgp 1" -c "no vnc export bgp route-map NAME"
bgpd aborted: vtysh -c "configure terminal" -c "router bgp 1" -c "no vnc export zebra ipv4 prefix-list NAME"
bgpd aborted: vtysh -c "configure terminal" -c "router bgp 1" -c "no vnc export zebra ipv6 prefix-list NAME"
bgpd aborted: vtysh -c "configure terminal" -c "router bgp 1" -c "no vnc export zebra route-map NAME"
bgpd aborted: vtysh -c "configure terminal" -c "route-map RMAP permit 1" -c "no set ipv6 vpn next-hop"
bgpd aborted: vtysh -c "configure terminal" -c "route-map RMAP permit 1" -c "set vpnv4 next-hop"
bgpd aborted: vtysh -c "configure terminal" -c "route-map RMAP permit 1" -c "set vpnv6 next-hop"
bgpd aborted: vtysh -c "configure terminal" -c "router bgp" -c "address-family ipv6 vpn" -c "network 2001:db8::1/128 rd 1:1 tag WORD"
bgpd aborted: vtysh -c "configure terminal" -c "router bgp" -c "address-family vpnv6 unicast" -c "network 2001:db8::1/128 rd 1:1 tag WORD"
bgpd aborted: vtysh -c "configure terminal" -c "router bgp" -c "no neighbor WORD shutdown message MSG..."
bgpd aborted: vtysh -c "configure terminal" -c "router bgp" -c "neighbor WORD shutdown message MSG..."
```

More to come later.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>