### PR TITLE
bgpd: resolve crash displaying bgp vrf routing info

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -262,7 +262,6 @@ bgp_vty_find_and_parse_afi_safi_bgp (struct vty *vty, struct cmd_token **argv, i
   if (argv_find (argv, argc, "view", idx) || argv_find (argv, argc, "vrf", idx))
     {
       vrf_name = argv[*idx + 1]->arg;
-      *idx += 2;
 
       if (strmatch (vrf_name, "all"))
         *bgp = NULL;


### PR DESCRIPTION
Problem uncovered with crash when entering the command "show ip bgp
vrf vrf1001 0.0.0.0".   The crash was caused by a mistake incrementing
the index value in the vrf/view case.  Manual testing completed and
failing test case now passes successfully.

Ticket: CM-16223
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Reviewed By: Donald Sharp <sharpd@cumulusnetworks.com>