### PR TITLE
IS-IS additions

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -415,6 +415,12 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
       vty_out (vty, "    Circuit type: %s", circuit_t2string (adj->circuit_t));
       vty_out (vty, ", Speaks: %s", nlpid2string (&adj->nlpids));
       vty_out (vty, "%s", VTY_NEWLINE);
+      if (adj->mt_count != 1 || adj->mt_set[0] != ISIS_MT_IPV4_UNICAST)
+        {
+          vty_out (vty, "    Topologies:%s", VTY_NEWLINE);
+          for (unsigned int i = 0; i < adj->mt_count; i++)
+            vty_out (vty, "      %s%s", isis_mtid2str(adj->mt_set[i]), VTY_NEWLINE);
+        }
       vty_out (vty, "    SNPA: %s", snpa_print (adj->snpa));
       if (adj->circuit && (adj->circuit->circ_type == CIRCUIT_T_BROADCAST))
       {

--- a/isisd/isis_mt.c
+++ b/isisd/isis_mt.c
@@ -415,7 +415,7 @@ tlvs_to_adj_mt_set(struct tlvs *tlvs, bool v4_usable, bool v6_usable,
       if (!tlvs->mt_router_info)
         {
           /* Other end does not have MT enabled */
-          if (mt_settings[i]->mtid == ISIS_MT_IPV4_UNICAST)
+          if (mt_settings[i]->mtid == ISIS_MT_IPV4_UNICAST && v4_usable)
             adj_mt_set(adj, intersect_count++, ISIS_MT_IPV4_UNICAST);
         }
       else
@@ -425,7 +425,27 @@ tlvs_to_adj_mt_set(struct tlvs *tlvs, bool v4_usable, bool v6_usable,
           for (ALL_LIST_ELEMENTS_RO(tlvs->mt_router_info, node, info))
             {
               if (mt_settings[i]->mtid == info->mtid)
-                adj_mt_set(adj, intersect_count++, info->mtid);
+                {
+                  bool usable;
+                  switch (info->mtid)
+                    {
+                      case ISIS_MT_IPV4_UNICAST:
+                      case ISIS_MT_IPV4_MGMT:
+                      case ISIS_MT_IPV4_MULTICAST:
+                        usable = v4_usable;
+                        break;
+                      case ISIS_MT_IPV6_UNICAST:
+                      case ISIS_MT_IPV6_MGMT:
+                      case ISIS_MT_IPV6_MULTICAST:
+                        usable = v6_usable;
+                        break;
+                      default:
+                        usable = true;
+                        break;
+                    }
+                  if (usable)
+                    adj_mt_set(adj, intersect_count++, info->mtid);
+                }
             }
         }
     }

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -940,7 +940,9 @@ isis_spf_preload_tent (struct isis_spftree *spftree,
 	      switch (adj->sys_type)
 		{
 		case ISIS_SYSTYPE_ES:
-		  isis_spf_add_local (spftree, VTYPE_ES, adj->sysid, adj,
+		  memcpy(lsp_id, adj->sysid, ISIS_SYS_ID_LEN);
+		  LSP_PSEUDO_ID (lsp_id) = 0;
+		  isis_spf_add_local (spftree, VTYPE_ES, lsp_id, adj,
 				      circuit->te_metric[spftree->level - 1],
 				      parent);
 		  break;
@@ -1017,7 +1019,9 @@ isis_spf_preload_tent (struct isis_spftree *spftree,
 	  switch (adj->sys_type)
 	    {
 	    case ISIS_SYSTYPE_ES:
-	      isis_spf_add_local (spftree, VTYPE_ES, adj->sysid, adj,
+	      memcpy (lsp_id, adj->sysid, ISIS_SYS_ID_LEN);
+	      LSP_PSEUDO_ID (lsp_id) = 0;
+	      isis_spf_add_local (spftree, VTYPE_ES, lsp_id, adj,
 				  circuit->te_metric[spftree->level - 1],
 				  parent);
 	      break;

--- a/isisd/isis_vty.c
+++ b/isisd/isis_vty.c
@@ -1284,6 +1284,13 @@ DEFUN (circuit_topology,
     return CMD_ERR_NO_MATCH;
   const char *arg = argv[2]->arg;
   uint16_t mtid = isis_str2mtid(arg);
+
+  if (circuit->area && circuit->area->oldmetric)
+    {
+      vty_out (vty, "Multi topology IS-IS can only be used with wide metrics%s", VTY_NEWLINE);
+      return CMD_ERR_AMBIGUOUS;
+    }
+
   if (mtid == (uint16_t)-1)
     {
       vty_out (vty, "Don't know topology '%s'%s", arg, VTY_NEWLINE);
@@ -1306,6 +1313,13 @@ DEFUN (no_circuit_topology,
     return CMD_ERR_NO_MATCH;
   const char *arg = argv[3]->arg;
   uint16_t mtid = isis_str2mtid(arg);
+
+  if (circuit->area && circuit->area->oldmetric)
+    {
+      vty_out (vty, "Multi topology IS-IS can only be used with wide metrics%s", VTY_NEWLINE);
+      return CMD_ERR_AMBIGUOUS;
+    }
+
   if (mtid == (uint16_t)-1)
     {
       vty_out (vty, "Don't know topology '%s'%s", arg, VTY_NEWLINE);
@@ -1371,6 +1385,12 @@ DEFUN (metric_style,
       return CMD_SUCCESS;
     }
 
+  if (area_is_mt(area))
+    {
+      vty_out (vty, "Narrow metrics cannot be used while multi topology IS-IS is active%s", VTY_NEWLINE);
+      return CMD_ERR_AMBIGUOUS;
+    }
+
   ret = validate_metric_style_narrow (vty, area);
   if (ret != CMD_SUCCESS)
     return ret;
@@ -1392,6 +1412,12 @@ DEFUN (no_metric_style,
 {
   VTY_DECLVAR_CONTEXT (isis_area, area);
   int ret;
+
+  if (area_is_mt(area))
+    {
+      vty_out (vty, "Narrow metrics cannot be used while multi topology IS-IS is active%s", VTY_NEWLINE);
+      return CMD_ERR_AMBIGUOUS;
+    }
 
   ret = validate_metric_style_narrow (vty, area);
   if (ret != CMD_SUCCESS)

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -300,8 +300,9 @@ isis_zebra_route_add_ipv4 (struct prefix *prefix,
 	  /* FIXME: can it be ? */
 	  if (nexthop->ip.s_addr != INADDR_ANY)
 	    {
-	      stream_putc (stream, NEXTHOP_TYPE_IPV4);
+	      stream_putc (stream, NEXTHOP_TYPE_IPV4_IFINDEX);
 	      stream_put_in_addr (stream, &nexthop->ip);
+	      stream_putl (stream, nexthop->ifindex);
 	    }
 	  else
 	    {

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -1669,6 +1669,13 @@ DEFUN (isis_topology,
 
   const char *arg = argv[1]->arg;
   uint16_t mtid = isis_str2mtid(arg);
+
+  if (area->oldmetric)
+    {
+      vty_out (vty, "Multi topology IS-IS can only be used with wide metrics%s", VTY_NEWLINE);
+      return CMD_ERR_AMBIGUOUS;
+    }
+
   if (mtid == (uint16_t)-1)
     {
       vty_out (vty, "Don't know topology '%s'%s", arg, VTY_NEWLINE);
@@ -1697,6 +1704,13 @@ DEFUN (no_isis_topology,
 
   const char *arg = argv[2]->arg;
   uint16_t mtid = isis_str2mtid(arg);
+
+  if (area->oldmetric)
+    {
+      vty_out (vty, "Multi topology IS-IS can only be used with wide metrics%s", VTY_NEWLINE);
+      return CMD_ERR_AMBIGUOUS;
+    }
+
   if (mtid == (uint16_t)-1)
     {
       vty_out (vty, "Don't know topology '%s'%s", arg, VTY_NEWLINE);


### PR DESCRIPTION
- fix for an issue in the previous patchset which was discovered by coverity
- only allow to use MT with wide metrics enabled
- more information in show commands
- support for unnumbered
- verify if links support IPv4/IPv6 and only advertise adjacencies for the respective topologies if they do 