### PR TITLE
*: ignore libtool library anotation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ GTAGS
 GSYMS
 GRTAGS
 GPATH
-
+*.la
+*.lo


### PR DESCRIPTION
At least on my system, the fpm module .la and .lo files are not ignored by git as they should be.
There are no .la and .lo files which I am aware of that need tracking in version control, so exempt them completely.