### PR TITLE
tests: allow to use exit_cleanly as test method

### DIFF
--- a/tests/helpers/python/frrtest.py
+++ b/tests/helpers/python/frrtest.py
@@ -87,7 +87,8 @@ class _TestMultiOut(object):
     def _add_test(cls, method, *args, **kwargs):
         if 'tests' not in dir(cls):
             setattr(cls,'tests',[])
-            cls._add_test(cls._exit_cleanly)
+            if method is not cls._exit_cleanly:
+                cls._add_test(cls._exit_cleanly)
 
         def matchfunction(self):
             method(self, *args, **kwargs)


### PR DESCRIPTION
Without this patch, exit_cleanly will be registered twice if it is used as test method directly. Fix that so that it can be used in upcoming work.