### PR TITLE
bgp rfapi: rfapi shouldn't be called (yet) for BGP VRF instances.

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2951,9 +2951,12 @@ bgp_create (as_t *as, const char *name, enum bgp_instance_type inst_type)
   bgp->as = *as;
 
 #if ENABLE_BGP_VNC
-  bgp->rfapi = bgp_rfapi_new(bgp);
-  assert(bgp->rfapi);
-  assert(bgp->rfapi_cfg);
+  if (inst_type != BGP_INSTANCE_TYPE_VRF)
+    {
+      bgp->rfapi = bgp_rfapi_new(bgp);
+      assert(bgp->rfapi);
+      assert(bgp->rfapi_cfg);
+    }
 #endif /* ENABLE_BGP_VNC */
 
   if (name)

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -4281,6 +4281,8 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
   int write = 0;
   afi_t afi;
   int type;
+  if (bgp->rfapi == NULL || hc == NULL)
+    return write;
 
   vty_out (vty, "!%s", VTY_NEWLINE);
   for (ALL_LIST_ELEMENTS (hc->nve_groups_sequential, node, nnode, rfg))


### PR DESCRIPTION
Documented in issue #483. Also needs to be applied to master.  Could be applied to 2.0, but don't think it's necessary.  