### PR TITLE
Fix static analysis and coverity scan

### DIFF
--- a/bgpd/bgp_btoa.c
+++ b/bgpd/bgp_btoa.c
@@ -238,7 +238,7 @@ main (int argc, char **argv)
 
       printf ("len: %zd\n", len);
 
-      ret = fread (s->data + 12, len, 1, fp);
+      fread (s->data + 12, len, 1, fp);
       if (feof (fp))
 	{
 	  printf ("ENDOF FILE 2\n");

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6116,7 +6116,7 @@ peer_ttl_security_hops_set (struct peer *peer, int gtsm_hops)
 	       * min & max ttls on the socket. The return value is
 	       * irrelevant.
 	       */
-	      ret = peer_ebgp_multihop_set (peer, MAXTTL);
+	      peer_ebgp_multihop_set (peer, MAXTTL);
 	    }
 	}
     }

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -1306,7 +1306,6 @@ callback:
       if (!printedprefix)
         {
           vnc_zlog_debug_verbose ("%s: For prefix %s (d)", __func__, buf_prefix);
-          printedprefix = 1;
         }
       vnc_zlog_debug_verbose ("%s: delete_list has %d elements",
                   __func__, delete_list->count);

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -1458,7 +1458,6 @@ process_lsp (int level, struct isis_circuit *circuit, const u_char *ssnpa)
 	      ((level == IS_LEVEL_2) &&
 	       (circuit->u.p2p.neighbor->adj_usage == ISIS_ADJ_LEVEL1)))
 	    return ISIS_WARNING;	/* Silently discard */
-	  adj = circuit->u.p2p.neighbor;
 	}
     }
 

--- a/lib/command.c
+++ b/lib/command.c
@@ -1615,8 +1615,11 @@ permute (struct graph_node *start, struct vty *vty)
       bool skip = false;
       if (stok->type == FORK_TKN && tok->type != FORK_TKN)
         for (ALL_LIST_ELEMENTS_RO (position, ln, gnn))
-           if (gnn == gn && (skip = true))
+           if (gnn == gn)
+           {
+             skip = true;
              break;
+           }
       if (!skip)
         permute (gn, vty);
     }

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -260,7 +260,6 @@ ospf_flood (struct ospf *ospf, struct ospf_neighbor *nbr,
                (void *)current,
                dump_lsa_key (new));
 
-  lsa_ack_flag = 0;
   oi = nbr->oi;
 
   /* If there is already a database copy, and if the

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1480,12 +1480,12 @@ ospf_mpls_te_lsa_originate_as (void *arg)
       if (IS_FLOOD_AS (lp->type))
         {
           top = (struct ospf *) arg;
-          rc = ospf_mpls_te_lsa_originate2 (top, lp);
+          ospf_mpls_te_lsa_originate2 (top, lp);
         }
       else
         {
           area = (struct ospf_area *) arg;
-          rc = ospf_mpls_te_lsa_originate1 (area, lp);
+          ospf_mpls_te_lsa_originate1 (area, lp);
         }
     }
 

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2398,7 +2398,6 @@ rip_output_process (struct connected *ifc, struct sockaddr_in *to,
       if (ret >= 0 && IS_RIP_DEBUG_SEND)
 	rip_packet_dump ((struct rip_packet *)STREAM_DATA (s),
 			 stream_get_endp (s), "SEND");
-      num = 0;
       stream_reset (s);
     }
 

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -970,11 +970,11 @@ ripng_redistribute_add (int type, int sub_type, struct prefix_ipv6 *p,
 	}
       }
 
-      rinfo = ripng_ecmp_replace (&newinfo);
+      ripng_ecmp_replace (&newinfo);
       route_unlock_node (rp);
     }
   else
-    rinfo = ripng_ecmp_add (&newinfo);
+    ripng_ecmp_add (&newinfo);
 
   if (IS_RIPNG_DEBUG_EVENT) {
     if (!nexthop)
@@ -2021,11 +2021,11 @@ DEFUN (show_ipv6_ripng,
 	  p = (struct prefix_ipv6 *) &rp->p;
 
 #ifdef DEBUG
-	  len = vty_out (vty, "R(a) %d/%d %s/%d ",
+	  vty_out (vty, "R(a) %d/%d %s/%d ",
 			 aggregate->count, aggregate->suppress,
 			 inet6_ntoa (p->prefix), p->prefixlen);
 #else
-	  len = vty_out (vty, "R(a) %s/%d ", 
+	  vty_out (vty, "R(a) %s/%d ",
 			 inet6_ntoa (p->prefix), p->prefixlen);
 #endif /* DEBUG */
 	  vty_out (vty, "%s", VTY_NEWLINE);
@@ -2043,13 +2043,13 @@ DEFUN (show_ipv6_ripng,
 	  p = (struct prefix_ipv6 *) &rp->p;
 
 #ifdef DEBUG
-	  len = vty_out (vty, "%c(%s) 0/%d %s/%d ",
+	  vty_out (vty, "%c(%s) 0/%d %s/%d ",
 			 zebra_route_char(rinfo->type),
 			 ripng_route_subtype_print(rinfo),
 			 rinfo->suppress,
 			 inet6_ntoa (p->prefix), p->prefixlen);
 #else
-	  len = vty_out (vty, "%c(%s) %s/%d ",
+	  vty_out (vty, "%c(%s) %s/%d ",
 			 zebra_route_char(rinfo->type),
 			 ripng_route_subtype_print(rinfo),
 			 inet6_ntoa (p->prefix), p->prefixlen);

--- a/tools/permutations.c
+++ b/tools/permutations.c
@@ -87,8 +87,11 @@ permute (struct graph_node *start)
       bool skip = false;
       if (stok->type == FORK_TKN && tok->type != FORK_TKN)
         for (ALL_LIST_ELEMENTS_RO (position, ln, gnn))
-           if (gnn == gn && (skip = true))
+           if (gnn == gn)
+           { 
+             skip = true;
              break;
+           }
       if (!skip)
         permute (gn);
     }

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -205,7 +205,6 @@ struct label_manager_chunk *assign_label_chunk(u_char proto, u_short instance,
 	struct label_manager_chunk *lmc;
 	struct listnode *node;
 
-	node = lbl_mgr.lc_list->head;
 	/* first check if there's one available */
 	for (ALL_LIST_ELEMENTS_RO(lbl_mgr.lc_list, node, lmc)) {
 		if (lmc->proto == NO_PROTO && lmc->end - lmc->start + 1 == size) {


### PR DESCRIPTION
- Fix the Warning **PW.ASSIGN_WHERE_COMPARE_MEANT** of Coverity Scan 
- Fix the Warning **"Dead assignment** of static analysis
  - Refer to [here](https://ci1.netdef.org/browse/FRR-FRR4-44/artifact/shared/static_analysis/index.html)