### PR TITLE
lib: allow pthreads to poke select/poll

### DIFF
--- a/lib/thread.h
+++ b/lib/thread.h
@@ -82,6 +82,8 @@ struct thread_master
   struct thread_list ready;
   struct thread_list unuse;
   struct pqueue *background;
+  int io_pipe[2];
+  pthread_t threadid;
   int fd_limit;
   struct fd_handler handler;
   unsigned long alloc;


### PR DESCRIPTION
When scheduling a task onto a thread master owned by another pthread, we
need to lock the thread master's mutex. However, if the thread master is
in poll() or select(), we could be stuck waiting for a very long time.

This change adds a pipe to the thread master. The reading end is passed into
select() or poll(). When another pthread wants to lock the mutex but
can't, it will write a byte into the pipe and tries again. The thread
master which owns the pipe will flush out the pipe so it can go back to
sleep while waiting on I/O.

Have tested this strategy with 1000+ BGP peers and did not see
performance degradation, so I would say this scales well.

Also has a one-off fix for a null deref.