### PR TITLE
vtysh: add \n to 'router rip[ng]' docstrings (3.0)

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1315,22 +1315,22 @@ DEFUNSH (VTYSH_RIPD,
 }
 
 DEFUNSH (VTYSH_RIPD,
-	 router_rip,
-	 router_rip_cmd,
-	 "router rip",
-	 ROUTER_STR
-	 "RIP")
+         router_rip,
+         router_rip_cmd,
+         "router rip",
+         ROUTER_STR
+         "RIP\n")
 {
   vty->node = RIP_NODE;
   return CMD_SUCCESS;
 }
 
 DEFUNSH (VTYSH_RIPNGD,
-	 router_ripng,
-	 router_ripng_cmd,
-	 "router ripng",
-	 ROUTER_STR
-	 "RIPng")
+         router_ripng,
+         router_ripng_cmd,
+         "router ripng",
+         ROUTER_STR
+         "RIPng\n")
 {
   vty->node = RIPNG_NODE;
   return CMD_SUCCESS;


### PR DESCRIPTION
fix #482 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>