### PR TITLE
CLI autocomplete for variables

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10921,9 +10921,51 @@ static struct cmd_node bgp_evpn_node =
 
 static void community_list_vty (void);
 
+static void
+bgp_ac_neighbor (vector comps, struct cmd_token *token)
+{
+  struct bgp *bgp;
+  struct peer *peer;
+  struct listnode *lnbgp, *lnpeer;
+
+  bool ipv4 = !strcmp(token->text, "A.B.C.D");
+  bool ipv6 = !strcmp(token->text, "X:X::X:X");
+  bool name = !(ipv4 || ipv6);
+
+  for (ALL_LIST_ELEMENTS_RO (bm->bgp, lnbgp, bgp))
+    for (ALL_LIST_ELEMENTS_RO (bgp->peer, lnpeer, peer))
+      if (peer->group)
+        {
+          if (!name)
+            continue;
+          vector_set(comps, XSTRDUP(MTYPE_COMPLETION, peer->host));
+        }
+      else
+        {
+          bool is_v6 = !!strchr(peer->host, ':');
+          if (is_v6 != ipv6 || name)
+            continue;
+          vector_set(comps, XSTRDUP(MTYPE_COMPLETION, peer->host));
+        }
+}
+
+static const struct cmd_variable_handler bgp_var_neighbor[] = {
+    {
+        .varname = "neighbor",
+        .completions = bgp_ac_neighbor
+    }, {
+        .varname = "neighbors",
+        .completions = bgp_ac_neighbor
+    }, {
+        .completions = NULL
+    }
+};
+
 void
 bgp_vty_init (void)
 {
+  cmd_variable_handler_register(bgp_var_neighbor);
+
   /* Install bgp top node. */
   install_node (&bgp_node, bgp_config_write);
   install_node (&bgp_ipv4_unicast_node, NULL);

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -7,10 +7,12 @@ Definition Grammar
 This is a reference for the syntax used when defining new CLI commands.  An
 example definition is:
 
+```
 DEFUN (command_name,
        command_name_cmd,
 -->    "example <command|line [interface]> DEFINITION...",
        <..doc strings..>)
+```
 
 The arrowed part is the definition string.
 
@@ -27,34 +29,36 @@ Characters allowed in each token type:
 
 Tokens
 ------
-* WORD          -- A token that begins with +, -, or a lowercase letter. It is
-                   an unchanging part of the command and will only match itself.
-                   Example: "show ip bgp", every token is a WORD.
-* IPV4          -- 'A.B.C.D', matches an IPv4 address.
-* IPV6          -- 'X:X::X:X', matches an IPv6 address.
-* IPV4_PREFIX   -- 'A.B.C.D/M', matches an IPv4 prefix in CIDR notation.
-* IPV6_PREFIX   -- 'X:X::X:X/M', matches an IPv6 prefix in CIDR notation.
-* VARIABLE      -- Begins with a capital letter. Matches any input.
-* RANGE         -- Numeric range delimited by parentheses, e.g. (-100 - 100) or
-                   (10-20). Will only match numbers in the range.
+* `WORD`        -- A token that begins with +, -, or a lowercase letter. It is
+                  an unchanging part of the command and will only match itself.
+                  Example: "show ip bgp", every token is a WORD.
+* `IPV4`        -- 'A.B.C.D', matches an IPv4 address.
+* `IPV6`        -- 'X:X::X:X', matches an IPv6 address.
+* `IPV4_PREFIX` -- 'A.B.C.D/M', matches an IPv4 prefix in CIDR notation.
+* `IPV6_PREFIX` -- 'X:X::X:X/M', matches an IPv6 prefix in CIDR notation.
+* `VARIABLE`    -- Begins with a capital letter. Matches any input.
+* `RANGE`       -- Numeric range delimited by parentheses, e.g. (-100 - 100) or
+                 (10-20). Will only match numbers in the range.
 
 Rules
 -----
-* <angle|brackets>  -- Contain sequences of tokens separated by pipes and
+* `<angle|brackets>`  -- Contain sequences of tokens separated by pipes and
                        provide mutual exclusion.  Sequences may contain
-                       <mutual|exclusion> but not as the first token.
-                       Disallowed: "example <<a|b> c|d>"
-                       Allowed:   "example <a c|b c|d>
-* [square brackets] -- Contains sequences of tokens that are optional (can be
-                       omitted).
-* {curly|braces}    -- similar to angle brackets, but instead of mutual
+                       `<mutual|exclusion>` but not as the first token.
+                       Disallowed: `"example <<a|b> c|d>"`
+                       Allowed:   `"example <a c|b c|d>"`
+* `[square brackets]` -- Contains sequences of tokens that are optional (can be
+                       omitted).  `[<a|b>]` can be shortened to `[a|b]`.
+* `{curly|braces}`    -- similar to angle brackets, but instead of mutual
                        exclusion, curly braces indicate that one or more of the
                        pipe-separated sequences may be provided in any order.
-* VARIADICS...      -- Any token which accepts input (so anything except WORD)
+* `VARIADICS...`      -- Any token which accepts input (so anything except WORD)
                        and that occurs as the last token of a line may be
                        followed by an ellipsis, which indicates that input
                        matching the token may be repeated an unlimited number
                        of times.
+* `$name`             -- Specify a variable name for the preceding token. See
+                       "Variable Names" below.
 
 Some general notes:
 
@@ -69,6 +73,40 @@ Some general notes:
   configuration items should be defined in separate commands. Clarity is
   preferred over LOC (within reason).
 
+Variable Names
+--------------
+The parser tries to fill the "varname" field on each token.  This can happen
+either manually or automatically.  Manual specifications work by appending
+`"$name"` after the input specifier:
+
+```
+foo bar$cmd WORD$name A.B.C.D$ip
+```
+
+Note that you can also assign variable names to fixed input tokens, this can
+be useful if multiple commands share code.  You can also use "$name" after a
+multiple-choice option:
+
+```
+foo bar <A.B.C.D|X:X::X:X>$addr [optionA|optionB]$mode
+```
+
+The variable name is in this case assigned to the last token in each of the
+branches.
+
+Automatic assignment of variable names works by applying the following rules:
+
+- manual names always have priority
+- a "[no]" at the beginning receives "no" as varname on the "no" token
+- WORD tokens whose text is not "WORD" or "NAME" receive a cleaned lowercase
+  version of the token text as varname, e.g. "ROUTE-MAP" becomes "route_map".
+- other variable tokens (i.e. everything except "fixed") receive the text of
+  the preceding fixed token as varname, if one can be found.  E.g.:
+  "ip route A.B.C.D/M INTERFACE" assigns "route" to the "A.B.C.D/M" token.
+
+These rules should make it possible to avoid manual varname assignment in 90%
+of the cases.
+
 Doc Strings
 -----------
 Each token in a command definition should be documented with a brief doc
@@ -77,11 +115,13 @@ command tree. These strings are provided as the last parameter to DEFUN macros,
 concatenated together and separated by an escaped newline ('\n'). These are
 best explained by example.
 
+```
 DEFUN (config_terminal,
        config_terminal_cmd,
        "configure terminal",
        "Configuration from vty interface\n"
        "Configuration terminal\n")
+```
 
 The last parameter is split into two lines for readability. Two newline
 delimited doc strings are present, one for each token in the command. The
@@ -110,11 +150,13 @@ constructs.
 
 In the examples below, each arrowed token needs a doc string.
 
+```
   "show ip bgp"
    ^    ^  ^
 
   "command <foo|bar> [example]"
    ^        ^   ^     ^
+```
 
 Data Structures
 ---------------
@@ -216,22 +258,32 @@ it is generally _incorrect_ to assume consistent indices in this array. As a
 simple example:
 
 Command definition:
+```
   command [foo] <bar|baz>
+```
 
 User enters:
+```
   command foo bar
+```
 
 Array:
+```
   [0] -> command
   [1] -> foo
   [2] -> bar
+```
 
 User enters:
+```
   command baz
+```
 
 Array:
+```
   [0] -> command
   [1] -> baz
+```
 
 
 
@@ -242,24 +294,32 @@ tokens when the CLI matcher does not need them to make an unambiguous match.
 This is best explained by example.
 
 Command definitions:
+```
   command dog cow
   command dog crow
+```
 
 User input:
+```
   c d c         -> ambiguous command
   c d co        -> match "command dog cow"
+```
 
 In the new implementation, this functionality has improved. Where previously
 the parser would stop at the first ambiguous token, it will now look ahead and
 attempt to disambiguate based on tokens later on in the input string.
 
 Command definitions:
+```
   show ip bgp A.B.C.D
   show ipv6 bgp X:X::X:X
+```
 
 User enters:
+```
   s i b 4.3.2.1         -> match "show ip bgp A.B.C.D"
   s i b ::e0            -> match "show ipv6 bgp X:X::X:X"
+```
 
 Previously both of these commands would be ambiguous since 'i' does not
 explicitly select either 'ip' or 'ipv6'. However, since the user later provides
@@ -268,17 +328,23 @@ parser is able to look ahead and select the appropriate command. This has some
 implications for parsing the argv*[] that is passed to the command handler.
 
 Now consider a command definition such as:
+```
   command <foo|VAR>
+```
 
 'foo' only matches the string 'foo', but 'VAR' matches any input, including
 'foo'. Who wins? In situations like this the matcher will always choose the
 'better' match, so 'foo' will win.
 
 Consider also:
+```
   show <ip|ipv6> foo
+```
 
 User input:
+```
   show ip foo
+```
 
 'ip' partially matches 'ipv6' but exactly matches 'ip', so 'ip' will win.
 
@@ -286,6 +352,7 @@ User input:
 struct cmd_token
 ----------------
 
+```
 /* Command token struct. */
 struct cmd_token
 {
@@ -297,7 +364,9 @@ struct cmd_token
   char *desc;                   // token description
   long long min, max;           // for ranges
   char *arg;                    // user input that matches this token
+  char *varname;                // variable name
 };
+```
 
 This struct is used in the CLI graph to match input against. It is also used to
 pass user input to command handler functions, as it is frequently useful for
@@ -316,7 +385,9 @@ has the full text of the corresponding token in the definition string and using
 it makes for much more readable code. An example is helpful.
 
 Command definition:
+```
   command <(1-10)|foo|BAR>
+```
 
 In this example, the user may enter any one of:
   * an integer between 1 and 10
@@ -325,9 +396,11 @@ In this example, the user may enter any one of:
 
 If the user enters "command f", then:
 
+```
 argv[1]->type == WORD_TKN
 argv[1]->arg  == "f"
 argv[1]->text == "foo"
+```
 
 Range tokens have some special treatment; a token with ->type == RANGE_TKN will
 have the ->min and ->max fields set to the bounding values of the range.
@@ -342,6 +415,7 @@ all matching input permutations. It also dumps a text representation of the
 graph, which is more useful for debugging than anything else. It looks like
 this:
 
+```
 $ ./permutations "show [ip] bgp [<view|vrf> WORD]"
 
 show ip bgp view WORD
@@ -350,6 +424,7 @@ show ip bgp
 show bgp view WORD
 show bgp vrf WORD
 show bgp
+```
 
 This functionality is also built into VTY/VTYSH; the 'list permutations'
 command will list all possible matching input permutations in the current CLI

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -98,7 +98,7 @@ Automatic assignment of variable names works by applying the following rules:
 
 - manual names always have priority
 - a "[no]" at the beginning receives "no" as varname on the "no" token
-- WORD tokens whose text is not "WORD" or "NAME" receive a cleaned lowercase
+- VARIABLE tokens whose text is not "WORD" or "NAME" receive a cleaned lowercase
   version of the token text as varname, e.g. "ROUTE-MAP" becomes "route_map".
 - other variable tokens (i.e. everything except "fixed") receive the text of
   the preceding fixed token as varname, if one can be found.  E.g.:

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -17,6 +17,7 @@ libfrr_la_SOURCES = \
 	network.c pid_output.c getopt.c getopt1.c \
 	checksum.c vector.c linklist.c vty.c \
 	graph.c command_parse.y command_lex.l command_match.c \
+	command_graph.c \
 	command.c \
 	sockunion.c prefix.c thread.c if.c buffer.c table.c hash.c \
 	filter.c routemap.c distribute.c stream.c log.c plist.c \
@@ -60,6 +61,7 @@ pkginclude_HEADERS = \
 	buffer.h checksum.h filter.h getopt.h hash.h \
 	if.h linklist.h log.h \
 	graph.h command_match.h \
+	command_graph.h \
 	command.h \
 	memory.h network.h prefix.h routemap.h distribute.h sockunion.h \
 	stream.h table.h thread.h vector.h version.h vty.h zebra.h \

--- a/lib/command.c
+++ b/lib/command.c
@@ -2788,6 +2788,7 @@ new_cmd_token (enum cmd_token_type type, u_char attr,
   token->refcnt = 1;
   token->arg  = NULL;
   token->allowrepeat = false;
+  token->varname = NULL;
 
   return token;
 }
@@ -2816,8 +2817,16 @@ copy_cmd_token (struct cmd_token *token)
   copy->text  = token->text ? XSTRDUP (MTYPE_CMD_TEXT, token->text) : NULL;
   copy->desc  = token->desc ? XSTRDUP (MTYPE_CMD_DESC, token->desc) : NULL;
   copy->arg   = token->arg  ? XSTRDUP (MTYPE_CMD_ARG, token->arg) : NULL;
+  copy->varname = token->varname ? XSTRDUP (MTYPE_CMD_ARG, token->varname) : NULL;
 
   return copy;
+}
+
+void
+cmd_set_varname (struct cmd_token *token, const char *varname)
+{
+  XFREE (MTYPE_CMD_VAR, token->varname);
+  token->varname = varname ? XSTRDUP (MTYPE_CMD_VAR, varname) : NULL;
 }
 
 void

--- a/lib/command.c
+++ b/lib/command.c
@@ -341,6 +341,7 @@ install_element (enum node_type ntype, struct cmd_element *cmd)
   graph_new_node (graph, token, (void (*)(void *)) &cmd_token_del);
 
   cmd_graph_parse (graph, cmd);
+  cmd_graph_names (graph);
   cmd_graph_merge (cnode->cmdgraph, graph, +1);
   graph_delete_graph (graph);
 
@@ -387,6 +388,7 @@ uninstall_element (enum node_type ntype, struct cmd_element *cmd)
   graph_new_node (graph, token, (void (*)(void *)) &cmd_token_del);
 
   cmd_graph_parse (graph, cmd);
+  cmd_graph_names (graph);
   cmd_graph_merge (cnode->cmdgraph, graph, -1);
   graph_delete_graph (graph);
 

--- a/lib/command.c
+++ b/lib/command.c
@@ -40,15 +40,12 @@
 #include "workqueue.h"
 #include "vrf.h"
 #include "command_match.h"
+#include "command_graph.h"
 #include "qobj.h"
 #include "defaults.h"
 
 DEFINE_MTYPE(       LIB, HOST,       "Host config")
 DEFINE_MTYPE(       LIB, STRVEC,     "String vector")
-DEFINE_MTYPE_STATIC(LIB, CMD_TOKENS, "Command Tokens")
-DEFINE_MTYPE_STATIC(LIB, CMD_DESC,   "Command Token Text")
-DEFINE_MTYPE_STATIC(LIB, CMD_TEXT,   "Command Token Help")
-DEFINE_MTYPE(       LIB, CMD_ARG,    "Command Argument")
 
 /* Command vector which includes some level of command lists. Normally
    each daemon maintains each own cmdvec. */
@@ -234,8 +231,8 @@ install_node (struct cmd_node *node,
   node->cmdgraph = graph_new ();
   node->cmd_vector = vector_init (VECTOR_MIN_SIZE);
   // add start node
-  struct cmd_token *token = new_cmd_token (START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
-  graph_new_node (node->cmdgraph, token, (void (*)(void *)) &del_cmd_token);
+  struct cmd_token *token = cmd_token_new (START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
+  graph_new_node (node->cmdgraph, token, (void (*)(void *)) &cmd_token_del);
   node->cmd_hash = hash_create (cmd_hash_key, cmd_hash_cmp);
 }
 
@@ -306,272 +303,6 @@ cmd_prompt (enum node_type node)
   return cnode->prompt;
 }
 
-static bool
-cmd_nodes_link (struct graph_node *from, struct graph_node *to)
-{
-  for (size_t i = 0; i < vector_active (from->to); i++)
-    if (vector_slot (from->to, i) == to)
-      return true;
-  return false;
-}
-
-static bool cmd_nodes_equal (struct graph_node *ga, struct graph_node *gb);
-
-/* returns a single node to be excluded as "next" from iteration
- * - for JOIN_TKN, never continue back to the FORK_TKN
- * - in all other cases, don't try the node itself (in case of "...")
- */
-static inline struct graph_node *
-cmd_loopstop(struct graph_node *gn)
-{
-  struct cmd_token *tok = gn->data;
-  if (tok->type == JOIN_TKN)
-    return tok->forkjoin;
-  else
-    return gn;
-}
-
-static bool
-cmd_subgraph_equal (struct graph_node *ga, struct graph_node *gb,
-                    struct graph_node *a_join)
-{
-  size_t i, j;
-  struct graph_node *a_fork, *b_fork;
-  a_fork = cmd_loopstop (ga);
-  b_fork = cmd_loopstop (gb);
-
-  if (vector_active (ga->to) != vector_active (gb->to))
-    return false;
-  for (i = 0; i < vector_active (ga->to); i++)
-    {
-      struct graph_node *cga = vector_slot (ga->to, i);
-
-      for (j = 0; j < vector_active (gb->to); j++)
-        {
-          struct graph_node *cgb = vector_slot (gb->to, i);
-
-          if (cga == a_fork && cgb != b_fork)
-            continue;
-          if (cga == a_fork && cgb == b_fork)
-            break;
-
-          if (cmd_nodes_equal (cga, cgb))
-            {
-              if (cga == a_join)
-                break;
-              if (cmd_subgraph_equal (cga, cgb, a_join))
-                break;
-            }
-        }
-      if (j == vector_active (gb->to))
-        return false;
-    }
-  return true;
-}
-
-/* deep compare -- for FORK_TKN, the entire subgraph is compared.
- * this is what's needed since we're not currently trying to partially
- * merge subgraphs */
-static bool
-cmd_nodes_equal (struct graph_node *ga, struct graph_node *gb)
-{
-  struct cmd_token *a = ga->data, *b = gb->data;
-
-  if (a->type != b->type || a->allowrepeat != b->allowrepeat)
-    return false;
-  if (a->type < SPECIAL_TKN && strcmp (a->text, b->text))
-    return false;
-  /* one a ..., the other not. */
-  if (cmd_nodes_link (ga, ga) != cmd_nodes_link (gb, gb))
-    return false;
-
-  switch (a->type)
-    {
-    case RANGE_TKN:
-      return a->min == b->min && a->max == b->max;
-
-    case FORK_TKN:
-      /* one is keywords, the other just option or selector ... */
-      if (cmd_nodes_link (a->forkjoin, ga) != cmd_nodes_link (b->forkjoin, gb))
-        return false;
-      if (cmd_nodes_link (ga, a->forkjoin) != cmd_nodes_link (gb, b->forkjoin))
-        return false;
-      return cmd_subgraph_equal (ga, gb, a->forkjoin);
-
-    default:
-      return true;
-    }
-}
-
-static void
-cmd_fork_bump_attr (struct graph_node *gn, struct graph_node *join,
-                    u_char attr)
-{
-  size_t i;
-  struct cmd_token *tok = gn->data;
-  struct graph_node *stop = cmd_loopstop (gn);
-
-  tok->attr = attr;
-  for (i = 0; i < vector_active (gn->to); i++)
-    {
-      struct graph_node *next = vector_slot (gn->to, i);
-      if (next == stop || next == join)
-        continue;
-      cmd_fork_bump_attr (next, join, attr);
-    }
-}
-
-/* move an entire subtree from the temporary graph resulting from
- * parse() into the permanent graph for the command node.
- *
- * this touches rather deeply into the graph code unfortunately.
- */
-static void
-cmd_reparent_tree (struct graph *fromgraph, struct graph *tograph,
-                   struct graph_node *node)
-{
-  struct graph_node *stop = cmd_loopstop (node);
-  size_t i;
-
-  for (i = 0; i < vector_active (fromgraph->nodes); i++)
-    if (vector_slot (fromgraph->nodes, i) == node)
-      {
-        /* agressive iteration punching through subgraphs - may hit some
-         * nodes twice.  reparent only if found on old graph */
-        vector_unset (fromgraph->nodes, i);
-        vector_set (tograph->nodes, node);
-        break;
-      }
-
-  for (i = 0; i < vector_active (node->to); i++)
-    {
-      struct graph_node *next = vector_slot (node->to, i);
-      if (next != stop)
-        cmd_reparent_tree (fromgraph, tograph, next);
-    }
-}
-
-static void
-cmd_free_recur (struct graph *graph, struct graph_node *node,
-                struct graph_node *stop)
-{
-  struct graph_node *next, *nstop;
-
-  for (size_t i = vector_active (node->to); i; i--)
-    {
-      next = vector_slot (node->to, i - 1);
-      if (next == stop)
-        continue;
-      nstop = cmd_loopstop (next);
-      if (nstop != next)
-        cmd_free_recur (graph, next, nstop);
-      cmd_free_recur (graph, nstop, stop);
-    }
-  graph_delete_node (graph, node);
-}
-
-static void
-cmd_free_node (struct graph *graph, struct graph_node *node)
-{
-  struct cmd_token *tok = node->data;
-  if (tok->type == JOIN_TKN)
-    cmd_free_recur (graph, tok->forkjoin, node);
-  graph_delete_node (graph, node);
-}
-
-/* recursive graph merge.  call with
- *   old ~= new
- * (which holds true for old == START_TKN, new == START_TKN)
- */
-static void
-cmd_merge_nodes (struct graph *oldgraph, struct graph *newgraph,
-                 struct graph_node *old, struct graph_node *new,
-                 int direction)
-{
-  struct cmd_token *tok;
-  struct graph_node *old_skip, *new_skip;
-  old_skip = cmd_loopstop (old);
-  new_skip = cmd_loopstop (new);
-
-  assert (direction == 1 || direction == -1);
-
-  tok = old->data;
-  tok->refcnt += direction;
-
-  size_t j, i;
-  for (j = 0; j < vector_active (new->to); j++)
-    {
-      struct graph_node *cnew = vector_slot (new->to, j);
-      if (cnew == new_skip)
-        continue;
-
-      for (i = 0; i < vector_active (old->to); i++)
-        {
-          struct graph_node *cold = vector_slot (old->to, i);
-          if (cold == old_skip)
-            continue;
-
-          if (cmd_nodes_equal (cold, cnew))
-            {
-              struct cmd_token *told = cold->data, *tnew = cnew->data;
-
-              if (told->type == END_TKN)
-                {
-                  if (direction < 0)
-                    {
-                      graph_delete_node (oldgraph, vector_slot (cold->to, 0));
-                      graph_delete_node (oldgraph, cold);
-                    }
-                  else
-                    /* force no-match handling to install END_TKN */
-                    i = vector_active (old->to);
-                  break;
-                }
-
-              /* the entire fork compared as equal, we continue after it. */
-              if (told->type == FORK_TKN)
-                {
-                  if (tnew->attr < told->attr && direction > 0)
-                    cmd_fork_bump_attr (cold, told->forkjoin, tnew->attr);
-                  /* XXX: no reverse bump on uninstall */
-                  told = (cold = told->forkjoin)->data;
-                  tnew = (cnew = tnew->forkjoin)->data;
-                }
-              if (tnew->attr < told->attr)
-                told->attr = tnew->attr;
-
-              cmd_merge_nodes (oldgraph, newgraph, cold, cnew, direction);
-              break;
-            }
-        }
-      /* nothing found => add new to old */
-      if (i == vector_active (old->to) && direction > 0)
-        {
-          assert (vector_count (cnew->from) ==
-                          cmd_nodes_link (cnew, cnew) ? 2 : 1);
-          graph_remove_edge (new, cnew);
-
-          cmd_reparent_tree (newgraph, oldgraph, cnew);
-
-          graph_add_edge (old, cnew);
-        }
-    }
-
-  if (!tok->refcnt)
-    cmd_free_node (oldgraph, old);
-}
-
-void
-cmd_merge_graphs (struct graph *old, struct graph *new, int direction)
-{
-  assert (vector_active (old->nodes) >= 1);
-  assert (vector_active (new->nodes) >= 1);
-
-  cmd_merge_nodes (old, new,
-                   vector_slot (old->nodes, 0), vector_slot (new->nodes, 0),
-                   direction);
-}
-
 /* Install a command into a node. */
 void
 install_element (enum node_type ntype, struct cmd_element *cmd)
@@ -606,11 +337,11 @@ install_element (enum node_type ntype, struct cmd_element *cmd)
   assert (hash_get (cnode->cmd_hash, cmd, hash_alloc_intern));
 
   struct graph *graph = graph_new();
-  struct cmd_token *token = new_cmd_token (START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
-  graph_new_node (graph, token, (void (*)(void *)) &del_cmd_token);
+  struct cmd_token *token = cmd_token_new (START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
+  graph_new_node (graph, token, (void (*)(void *)) &cmd_token_del);
 
-  command_parse_format (graph, cmd);
-  cmd_merge_graphs (cnode->cmdgraph, graph, +1);
+  cmd_graph_parse (graph, cmd);
+  cmd_graph_merge (cnode->cmdgraph, graph, +1);
   graph_delete_graph (graph);
 
   vector_set (cnode->cmd_vector, cmd);
@@ -652,11 +383,11 @@ uninstall_element (enum node_type ntype, struct cmd_element *cmd)
   vector_unset_value (cnode->cmd_vector, cmd);
 
   struct graph *graph = graph_new();
-  struct cmd_token *token = new_cmd_token (START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
-  graph_new_node (graph, token, (void (*)(void *)) &del_cmd_token);
+  struct cmd_token *token = cmd_token_new (START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
+  graph_new_node (graph, token, (void (*)(void *)) &cmd_token_del);
 
-  command_parse_format (graph, cmd);
-  cmd_merge_graphs (cnode->cmdgraph, graph, -1);
+  cmd_graph_parse (graph, cmd);
+  cmd_graph_merge (cnode->cmdgraph, graph, -1);
   graph_delete_graph (graph);
 
   if (ntype == VIEW_NODE)
@@ -2774,59 +2505,6 @@ cmd_init (int terminal)
 #ifdef DEV_BUILD
   grammar_sandbox_init();
 #endif
-}
-
-struct cmd_token *
-new_cmd_token (enum cmd_token_type type, u_char attr,
-               const char *text, const char *desc)
-{
-  struct cmd_token *token = XCALLOC (MTYPE_CMD_TOKENS, sizeof (struct cmd_token));
-  token->type = type;
-  token->attr = attr;
-  token->text = text ? XSTRDUP (MTYPE_CMD_TEXT, text) : NULL;
-  token->desc = desc ? XSTRDUP (MTYPE_CMD_DESC, desc) : NULL;
-  token->refcnt = 1;
-  token->arg  = NULL;
-  token->allowrepeat = false;
-  token->varname = NULL;
-
-  return token;
-}
-
-void
-del_cmd_token (struct cmd_token *token)
-{
-  if (!token) return;
-
-  if (token->text)
-    XFREE (MTYPE_CMD_TEXT, token->text);
-  if (token->desc)
-    XFREE (MTYPE_CMD_DESC, token->desc);
-  if (token->arg)
-    XFREE (MTYPE_CMD_ARG, token->arg);
-
-  XFREE (MTYPE_CMD_TOKENS, token);
-}
-
-struct cmd_token *
-copy_cmd_token (struct cmd_token *token)
-{
-  struct cmd_token *copy = new_cmd_token (token->type, token->attr, NULL, NULL);
-  copy->max   = token->max;
-  copy->min   = token->min;
-  copy->text  = token->text ? XSTRDUP (MTYPE_CMD_TEXT, token->text) : NULL;
-  copy->desc  = token->desc ? XSTRDUP (MTYPE_CMD_DESC, token->desc) : NULL;
-  copy->arg   = token->arg  ? XSTRDUP (MTYPE_CMD_ARG, token->arg) : NULL;
-  copy->varname = token->varname ? XSTRDUP (MTYPE_CMD_ARG, token->varname) : NULL;
-
-  return copy;
-}
-
-void
-cmd_set_varname (struct cmd_token *token, const char *varname)
-{
-  XFREE (MTYPE_CMD_VAR, token->varname);
-  token->varname = varname ? XSTRDUP (MTYPE_CMD_VAR, varname) : NULL;
 }
 
 void

--- a/lib/command.c
+++ b/lib/command.c
@@ -727,6 +727,38 @@ cmd_variable_handler_register (const struct cmd_variable_handler *cvh)
     listnode_add(varhandlers, (void *)cvh);
 }
 
+DEFUN_HIDDEN (autocomplete,
+              autocomplete_cmd,
+              "autocomplete TYPE TEXT VARNAME",
+              "Autocompletion handler (internal, for vtysh)\n"
+              "cmd_token->type\n"
+              "cmd_token->text\n"
+              "cmd_token->varname\n")
+{
+  struct cmd_token tok;
+  vector comps = vector_init(32);
+  size_t i;
+
+  memset(&tok, 0, sizeof(tok));
+  tok.type = atoi(argv[1]->arg);
+  tok.text = argv[2]->arg;
+  tok.varname = argv[3]->arg;
+  if (!strcmp(tok.varname, "-"))
+    tok.varname = NULL;
+
+  cmd_variable_complete(&tok, NULL, comps);
+
+  for (i = 0; i < vector_active(comps); i++)
+    {
+      char *text = vector_slot(comps, i);
+      vty_out(vty, "%s\n", text);
+      XFREE(MTYPE_COMPLETION, text);
+    }
+
+  vector_free(comps);
+  return CMD_SUCCESS;
+}
+
 /**
  * Generate possible tab-completions for the given input. This function only
  * returns results that would result in a valid command if used as Readline
@@ -2450,6 +2482,8 @@ install_default (enum node_type node)
 
   install_element (node, &config_write_cmd);
   install_element (node, &show_running_config_cmd);
+
+  install_element (node, &autocomplete_cmd);
 }
 
 /* Initialize command interface. Install basic nodes and commands.
@@ -2499,6 +2533,7 @@ cmd_init (int terminal)
       install_element (VIEW_NODE, &show_logging_cmd);
       install_element (VIEW_NODE, &show_commandtree_cmd);
       install_element (VIEW_NODE, &echo_cmd);
+      install_element (VIEW_NODE, &autocomplete_cmd);
     }
 
   if (terminal)

--- a/lib/command.c
+++ b/lib/command.c
@@ -46,6 +46,7 @@
 
 DEFINE_MTYPE(       LIB, HOST,       "Host config")
 DEFINE_MTYPE(       LIB, STRVEC,     "String vector")
+DEFINE_MTYPE(       LIB, COMPLETION, "Completion item")
 
 /* Command vector which includes some level of command lists. Normally
    each daemon maintains each own cmdvec. */
@@ -678,6 +679,54 @@ cmd_describe_command (vector vline, struct vty *vty, int *status)
   return cmd_complete_command_real (vline, vty, status);
 }
 
+static struct list *varhandlers = NULL;
+
+void
+cmd_variable_complete (struct cmd_token *token, const char *arg, vector comps)
+{
+  struct listnode *ln;
+  const struct cmd_variable_handler *cvh;
+  size_t i, argsz;
+  vector tmpcomps;
+
+  tmpcomps = arg ? vector_init (VECTOR_MIN_SIZE) : comps;
+
+  for (ALL_LIST_ELEMENTS_RO(varhandlers, ln, cvh))
+    {
+      if (cvh->tokenname && strcmp(cvh->tokenname, token->text))
+        continue;
+      if (cvh->varname && (!token->varname || strcmp(cvh->varname, token->varname)))
+        continue;
+      cvh->completions(tmpcomps, token);
+      break;
+    }
+
+  if (!arg)
+    return;
+
+  argsz = strlen(arg);
+  for (i = vector_active(tmpcomps); i; i--)
+    {
+      char *item = vector_slot(tmpcomps, i - 1);
+      if (strlen(item) >= argsz
+          && !strncmp(item, arg, argsz))
+        vector_set(comps, item);
+      else
+        XFREE(MTYPE_COMPLETION, item);
+    }
+  vector_free(tmpcomps);
+}
+
+void
+cmd_variable_handler_register (const struct cmd_variable_handler *cvh)
+{
+  if (!varhandlers)
+    return;
+
+  for (; cvh->completions; cvh++)
+    listnode_add(varhandlers, (void *)cvh);
+}
+
 /**
  * Generate possible tab-completions for the given input. This function only
  * returns results that would result in a valid command if used as Readline
@@ -719,7 +768,12 @@ cmd_complete_command (vector vline, struct vty *vty, int *status)
     {
       struct cmd_token *token = vector_slot (initial_comps, i);
       if (token->type == WORD_TKN)
-        vector_set (comps, token);
+        vector_set (comps, XSTRDUP (MTYPE_COMPLETION, token->text));
+      else if (IS_VARYING_TOKEN(token->type))
+        {
+          const char *ref = vector_lookup(vline, vector_active (vline) - 1);
+          cmd_variable_complete (token, ref, comps);
+        }
     }
     vector_free (initial_comps);
 
@@ -741,9 +795,7 @@ cmd_complete_command (vector vline, struct vty *vty, int *status)
     unsigned int i;
     for (i = 0; i < vector_active (comps); i++)
       {
-        struct cmd_token *token = vector_slot (comps, i);
-        ret[i] = XSTRDUP (MTYPE_TMP, token->text);
-        vector_unset (comps, i);
+        ret[i] = vector_slot (comps, i);
       }
     // set the last element to NULL, because this array is used in
     // a Readline completion_generator function which expects NULL
@@ -2409,6 +2461,8 @@ void
 cmd_init (int terminal)
 {
   qobj_init ();
+
+  varhandlers = list_new ();
 
   /* Allocate initial top vector of commands. */
   cmdvec = vector_init (VECTOR_MIN_SIZE);

--- a/lib/command.h
+++ b/lib/command.h
@@ -32,6 +32,7 @@
 #include "command_graph.h"
 
 DECLARE_MTYPE(HOST)
+DECLARE_MTYPE(COMPLETION)
 
 /* for test-commands.c */
 DECLARE_MTYPE(STRVEC)
@@ -390,5 +391,13 @@ extern int cmd_banner_motd_file (const char *);
 
 /* struct host global, ick */
 extern struct host host;
+
+struct cmd_variable_handler {
+        const char *tokenname, *varname;
+        void (*completions)(vector out, struct cmd_token *token);
+};
+
+extern void cmd_variable_complete (struct cmd_token *token, const char *arg, vector comps);
+extern void cmd_variable_handler_register (const struct cmd_variable_handler *cvh);
 
 #endif /* _ZEBRA_COMMAND_H */

--- a/lib/command.h
+++ b/lib/command.h
@@ -210,6 +210,7 @@ struct cmd_token
   char *desc;                   // token description
   long long min, max;           // for ranges
   char *arg;                    // user input that matches this token
+  char *varname;
 
   struct graph_node *forkjoin;  // paired FORK/JOIN for JOIN/FORK
 };
@@ -446,6 +447,7 @@ extern struct cmd_token *new_cmd_token (enum cmd_token_type, u_char attr,
                                         const char *text, const char *desc);
 extern void del_cmd_token (struct cmd_token *);
 extern struct cmd_token *copy_cmd_token (struct cmd_token *);
+extern void cmd_set_varname(struct cmd_token *token, const char *varname);
 
 extern vector completions_to_vec (struct list *completions);
 extern void cmd_merge_graphs (struct graph *old, struct graph *new, int direction);

--- a/lib/command.h
+++ b/lib/command.h
@@ -29,9 +29,9 @@
 #include "graph.h"
 #include "memory.h"
 #include "hash.h"
+#include "command_graph.h"
 
 DECLARE_MTYPE(HOST)
-DECLARE_MTYPE(CMD_ARG)
 
 /* for test-commands.c */
 DECLARE_MTYPE(STRVEC)
@@ -163,70 +163,6 @@ struct cmd_node
 
   /* Hashed index of command node list, for de-dupping primarily */
   struct hash *cmd_hash;
-};
-
-/**
- * Types for tokens.
- *
- * The type determines what kind of data the token can match (in the
- * matching use case) or hold (in the argv use case).
- */
-enum cmd_token_type
-{
-  WORD_TKN,         // words
-  VARIABLE_TKN,     // almost anything
-  RANGE_TKN,        // integer range
-  IPV4_TKN,         // IPV4 addresses
-  IPV4_PREFIX_TKN,  // IPV4 network prefixes
-  IPV6_TKN,         // IPV6 prefixes
-  IPV6_PREFIX_TKN,  // IPV6 network prefixes
-
-  /* plumbing types */
-  FORK_TKN,         // marks subgraph beginning
-  JOIN_TKN,         // marks subgraph end
-  START_TKN,        // first token in line
-  END_TKN,          // last token in line
-
-  SPECIAL_TKN = FORK_TKN,
-};
-
-/* Command attributes */
-enum
-{
-  CMD_ATTR_NORMAL,
-  CMD_ATTR_DEPRECATED,
-  CMD_ATTR_HIDDEN,
-};
-
-/* Comamand token struct. */
-struct cmd_token
-{
-  enum cmd_token_type type;     // token type
-  u_char attr;                  // token attributes
-  bool allowrepeat;             // matcher allowed to match token repetively?
-  uint32_t refcnt;
-
-  char *text;                   // token text
-  char *desc;                   // token description
-  long long min, max;           // for ranges
-  char *arg;                    // user input that matches this token
-  char *varname;
-
-  struct graph_node *forkjoin;  // paired FORK/JOIN for JOIN/FORK
-};
-
-/* Structure of command element. */
-struct cmd_element
-{
-  const char *string;           /* Command specification by string. */
-  const char *doc;              /* Documentation of this command. */
-  int daemon;                   /* Daemon to which this command belong. */
-  u_char attr;                  /* Command attributes */
-
-  /* handler function for command */
-  int (*func) (const struct cmd_element *, struct vty *, int, struct cmd_token *[]);
-
-  const char *name;             /* symbol name for debugging */
 };
 
 /* Return value of the commands. */
@@ -442,16 +378,7 @@ extern int cmd_hostname_set (const char *hostname);
 /* NOT safe for general use; call this only if DEV_BUILD! */
 extern void grammar_sandbox_init (void);
 
-/* memory management for cmd_token */
-extern struct cmd_token *new_cmd_token (enum cmd_token_type, u_char attr,
-                                        const char *text, const char *desc);
-extern void del_cmd_token (struct cmd_token *);
-extern struct cmd_token *copy_cmd_token (struct cmd_token *);
-extern void cmd_set_varname(struct cmd_token *token, const char *varname);
-
 extern vector completions_to_vec (struct list *completions);
-extern void cmd_merge_graphs (struct graph *old, struct graph *new, int direction);
-extern void command_parse_format (struct graph *graph, struct cmd_element *cmd);
 
 /* Export typical functions. */
 extern const char *host_config_get (void);
@@ -463,8 +390,5 @@ extern int cmd_banner_motd_file (const char *);
 
 /* struct host global, ick */
 extern struct host host;
-
-/* text for <cr> command */
-#define CMD_CR_TEXT "<cr>"
 
 #endif /* _ZEBRA_COMMAND_H */

--- a/lib/command_graph.c
+++ b/lib/command_graph.c
@@ -1,0 +1,351 @@
+/*
+ * CLI graph handling
+ *
+ * --
+ * Copyright (C) 2016 Cumulus Networks, Inc.
+ * Copyright (C) 1997, 98, 99 Kunihiro Ishiguro
+ * Copyright (C) 2013 by Open Source Routing.
+ * Copyright (C) 2013 by Internet Systems Consortium, Inc. ("ISC")
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <zebra.h>
+
+#include "command_graph.h"
+
+DECLARE_MTYPE(CMD_TOKEN_DATA)
+
+DEFINE_MTYPE_STATIC(LIB, CMD_TOKENS, "Command Tokens")
+DEFINE_MTYPE_STATIC(LIB, CMD_DESC,   "Command Token Text")
+DEFINE_MTYPE_STATIC(LIB, CMD_TEXT,   "Command Token Help")
+DEFINE_MTYPE(       LIB, CMD_ARG,    "Command Argument")
+DEFINE_MTYPE_STATIC(LIB, CMD_VAR,    "Command Argument Name")
+
+struct cmd_token *
+cmd_token_new (enum cmd_token_type type, u_char attr,
+               const char *text, const char *desc)
+{
+  struct cmd_token *token = XCALLOC (MTYPE_CMD_TOKENS, sizeof (struct cmd_token));
+  token->type = type;
+  token->attr = attr;
+  token->text = text ? XSTRDUP (MTYPE_CMD_TEXT, text) : NULL;
+  token->desc = desc ? XSTRDUP (MTYPE_CMD_DESC, desc) : NULL;
+  token->refcnt = 1;
+  token->arg  = NULL;
+  token->allowrepeat = false;
+  token->varname = NULL;
+
+  return token;
+}
+
+void
+cmd_token_del (struct cmd_token *token)
+{
+  if (!token) return;
+
+  XFREE (MTYPE_CMD_TEXT, token->text);
+  XFREE (MTYPE_CMD_DESC, token->desc);
+  XFREE (MTYPE_CMD_ARG, token->arg);
+  XFREE (MTYPE_CMD_VAR, token->varname);
+
+  XFREE (MTYPE_CMD_TOKENS, token);
+}
+
+struct cmd_token *
+cmd_token_dup (struct cmd_token *token)
+{
+  struct cmd_token *copy = cmd_token_new (token->type, token->attr, NULL, NULL);
+  copy->max   = token->max;
+  copy->min   = token->min;
+  copy->text  = token->text ? XSTRDUP (MTYPE_CMD_TEXT, token->text) : NULL;
+  copy->desc  = token->desc ? XSTRDUP (MTYPE_CMD_DESC, token->desc) : NULL;
+  copy->arg   = token->arg  ? XSTRDUP (MTYPE_CMD_ARG, token->arg) : NULL;
+  copy->varname = token->varname ? XSTRDUP (MTYPE_CMD_VAR, token->varname) : NULL;
+
+  return copy;
+}
+
+void cmd_token_varname_set(struct cmd_token *token, const char *varname)
+{
+  XFREE (MTYPE_CMD_VAR, token->varname);
+  token->varname = varname ? XSTRDUP (MTYPE_CMD_VAR, varname) : NULL;
+}
+
+static bool
+cmd_nodes_link (struct graph_node *from, struct graph_node *to)
+{
+  for (size_t i = 0; i < vector_active (from->to); i++)
+    if (vector_slot (from->to, i) == to)
+      return true;
+  return false;
+}
+
+static bool cmd_nodes_equal (struct graph_node *ga, struct graph_node *gb);
+
+/* returns a single node to be excluded as "next" from iteration
+ * - for JOIN_TKN, never continue back to the FORK_TKN
+ * - in all other cases, don't try the node itself (in case of "...")
+ */
+static inline struct graph_node *
+cmd_loopstop(struct graph_node *gn)
+{
+  struct cmd_token *tok = gn->data;
+  if (tok->type == JOIN_TKN)
+    return tok->forkjoin;
+  else
+    return gn;
+}
+
+static bool
+cmd_subgraph_equal (struct graph_node *ga, struct graph_node *gb,
+                    struct graph_node *a_join)
+{
+  size_t i, j;
+  struct graph_node *a_fork, *b_fork;
+  a_fork = cmd_loopstop (ga);
+  b_fork = cmd_loopstop (gb);
+
+  if (vector_active (ga->to) != vector_active (gb->to))
+    return false;
+  for (i = 0; i < vector_active (ga->to); i++)
+    {
+      struct graph_node *cga = vector_slot (ga->to, i);
+
+      for (j = 0; j < vector_active (gb->to); j++)
+        {
+          struct graph_node *cgb = vector_slot (gb->to, i);
+
+          if (cga == a_fork && cgb != b_fork)
+            continue;
+          if (cga == a_fork && cgb == b_fork)
+            break;
+
+          if (cmd_nodes_equal (cga, cgb))
+            {
+              if (cga == a_join)
+                break;
+              if (cmd_subgraph_equal (cga, cgb, a_join))
+                break;
+            }
+        }
+      if (j == vector_active (gb->to))
+        return false;
+    }
+  return true;
+}
+
+/* deep compare -- for FORK_TKN, the entire subgraph is compared.
+ * this is what's needed since we're not currently trying to partially
+ * merge subgraphs */
+static bool
+cmd_nodes_equal (struct graph_node *ga, struct graph_node *gb)
+{
+  struct cmd_token *a = ga->data, *b = gb->data;
+
+  if (a->type != b->type || a->allowrepeat != b->allowrepeat)
+    return false;
+  if (a->type < SPECIAL_TKN && strcmp (a->text, b->text))
+    return false;
+  /* one a ..., the other not. */
+  if (cmd_nodes_link (ga, ga) != cmd_nodes_link (gb, gb))
+    return false;
+
+  switch (a->type)
+    {
+    case RANGE_TKN:
+      return a->min == b->min && a->max == b->max;
+
+    case FORK_TKN:
+      /* one is keywords, the other just option or selector ... */
+      if (cmd_nodes_link (a->forkjoin, ga) != cmd_nodes_link (b->forkjoin, gb))
+        return false;
+      if (cmd_nodes_link (ga, a->forkjoin) != cmd_nodes_link (gb, b->forkjoin))
+        return false;
+      return cmd_subgraph_equal (ga, gb, a->forkjoin);
+
+    default:
+      return true;
+    }
+}
+
+static void
+cmd_fork_bump_attr (struct graph_node *gn, struct graph_node *join,
+                    u_char attr)
+{
+  size_t i;
+  struct cmd_token *tok = gn->data;
+  struct graph_node *stop = cmd_loopstop (gn);
+
+  tok->attr = attr;
+  for (i = 0; i < vector_active (gn->to); i++)
+    {
+      struct graph_node *next = vector_slot (gn->to, i);
+      if (next == stop || next == join)
+        continue;
+      cmd_fork_bump_attr (next, join, attr);
+    }
+}
+
+/* move an entire subtree from the temporary graph resulting from
+ * parse() into the permanent graph for the command node.
+ *
+ * this touches rather deeply into the graph code unfortunately.
+ */
+static void
+cmd_reparent_tree (struct graph *fromgraph, struct graph *tograph,
+                   struct graph_node *node)
+{
+  struct graph_node *stop = cmd_loopstop (node);
+  size_t i;
+
+  for (i = 0; i < vector_active (fromgraph->nodes); i++)
+    if (vector_slot (fromgraph->nodes, i) == node)
+      {
+        /* agressive iteration punching through subgraphs - may hit some
+         * nodes twice.  reparent only if found on old graph */
+        vector_unset (fromgraph->nodes, i);
+        vector_set (tograph->nodes, node);
+        break;
+      }
+
+  for (i = 0; i < vector_active (node->to); i++)
+    {
+      struct graph_node *next = vector_slot (node->to, i);
+      if (next != stop)
+        cmd_reparent_tree (fromgraph, tograph, next);
+    }
+}
+
+static void
+cmd_free_recur (struct graph *graph, struct graph_node *node,
+                struct graph_node *stop)
+{
+  struct graph_node *next, *nstop;
+
+  for (size_t i = vector_active (node->to); i; i--)
+    {
+      next = vector_slot (node->to, i - 1);
+      if (next == stop)
+        continue;
+      nstop = cmd_loopstop (next);
+      if (nstop != next)
+        cmd_free_recur (graph, next, nstop);
+      cmd_free_recur (graph, nstop, stop);
+    }
+  graph_delete_node (graph, node);
+}
+
+static void
+cmd_free_node (struct graph *graph, struct graph_node *node)
+{
+  struct cmd_token *tok = node->data;
+  if (tok->type == JOIN_TKN)
+    cmd_free_recur (graph, tok->forkjoin, node);
+  graph_delete_node (graph, node);
+}
+
+/* recursive graph merge.  call with
+ *   old ~= new
+ * (which holds true for old == START_TKN, new == START_TKN)
+ */
+static void
+cmd_merge_nodes (struct graph *oldgraph, struct graph *newgraph,
+                 struct graph_node *old, struct graph_node *new,
+                 int direction)
+{
+  struct cmd_token *tok;
+  struct graph_node *old_skip, *new_skip;
+  old_skip = cmd_loopstop (old);
+  new_skip = cmd_loopstop (new);
+
+  assert (direction == 1 || direction == -1);
+
+  tok = old->data;
+  tok->refcnt += direction;
+
+  size_t j, i;
+  for (j = 0; j < vector_active (new->to); j++)
+    {
+      struct graph_node *cnew = vector_slot (new->to, j);
+      if (cnew == new_skip)
+        continue;
+
+      for (i = 0; i < vector_active (old->to); i++)
+        {
+          struct graph_node *cold = vector_slot (old->to, i);
+          if (cold == old_skip)
+            continue;
+
+          if (cmd_nodes_equal (cold, cnew))
+            {
+              struct cmd_token *told = cold->data, *tnew = cnew->data;
+
+              if (told->type == END_TKN)
+                {
+                  if (direction < 0)
+                    {
+                      graph_delete_node (oldgraph, vector_slot (cold->to, 0));
+                      graph_delete_node (oldgraph, cold);
+                    }
+                  else
+                    /* force no-match handling to install END_TKN */
+                    i = vector_active (old->to);
+                  break;
+                }
+
+              /* the entire fork compared as equal, we continue after it. */
+              if (told->type == FORK_TKN)
+                {
+                  if (tnew->attr < told->attr && direction > 0)
+                    cmd_fork_bump_attr (cold, told->forkjoin, tnew->attr);
+                  /* XXX: no reverse bump on uninstall */
+                  told = (cold = told->forkjoin)->data;
+                  tnew = (cnew = tnew->forkjoin)->data;
+                }
+              if (tnew->attr < told->attr)
+                told->attr = tnew->attr;
+
+              cmd_merge_nodes (oldgraph, newgraph, cold, cnew, direction);
+              break;
+            }
+        }
+      /* nothing found => add new to old */
+      if (i == vector_active (old->to) && direction > 0)
+        {
+          assert (vector_count (cnew->from) ==
+                          cmd_nodes_link (cnew, cnew) ? 2 : 1);
+          graph_remove_edge (new, cnew);
+
+          cmd_reparent_tree (newgraph, oldgraph, cnew);
+
+          graph_add_edge (old, cnew);
+        }
+    }
+
+  if (!tok->refcnt)
+    cmd_free_node (oldgraph, old);
+}
+
+void
+cmd_graph_merge (struct graph *old, struct graph *new, int direction)
+{
+  assert (vector_active (old->nodes) >= 1);
+  assert (vector_active (new->nodes) >= 1);
+
+  cmd_merge_nodes (old, new,
+                   vector_slot (old->nodes, 0), vector_slot (new->nodes, 0),
+                   direction);
+}

--- a/lib/command_graph.h
+++ b/lib/command_graph.h
@@ -1,0 +1,116 @@
+/*
+ * CLI graph handling
+ *
+ * --
+ * Copyright (C) 2016 Cumulus Networks, Inc.
+ * Copyright (C) 1997, 98, 99 Kunihiro Ishiguro
+ * Copyright (C) 2013 by Open Source Routing.
+ * Copyright (C) 2013 by Internet Systems Consortium, Inc. ("ISC")
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef _FRR_COMMAND_GRAPH_H
+#define _FRR_COMMAND_GRAPH_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "memory.h"
+#include "vector.h"
+#include "graph.h"
+
+DECLARE_MTYPE(CMD_ARG)
+
+struct vty;
+
+/**
+ * Types for tokens.
+ *
+ * The type determines what kind of data the token can match (in the
+ * matching use case) or hold (in the argv use case).
+ */
+enum cmd_token_type
+{
+  WORD_TKN,         // words
+  VARIABLE_TKN,     // almost anything
+  RANGE_TKN,        // integer range
+  IPV4_TKN,         // IPV4 addresses
+  IPV4_PREFIX_TKN,  // IPV4 network prefixes
+  IPV6_TKN,         // IPV6 prefixes
+  IPV6_PREFIX_TKN,  // IPV6 network prefixes
+
+  /* plumbing types */
+  FORK_TKN,         // marks subgraph beginning
+  JOIN_TKN,         // marks subgraph end
+  START_TKN,        // first token in line
+  END_TKN,          // last token in line
+
+  SPECIAL_TKN = FORK_TKN,
+};
+
+/* Command attributes */
+enum
+{
+  CMD_ATTR_NORMAL,
+  CMD_ATTR_DEPRECATED,
+  CMD_ATTR_HIDDEN,
+};
+
+/* Comamand token struct. */
+struct cmd_token
+{
+  enum cmd_token_type type;     // token type
+  uint8_t attr;                 // token attributes
+  bool allowrepeat;             // matcher allowed to match token repetively?
+  uint32_t refcnt;
+
+  char *text;                   // token text
+  char *desc;                   // token description
+  long long min, max;           // for ranges
+  char *arg;                    // user input that matches this token
+  char *varname;
+
+  struct graph_node *forkjoin;  // paired FORK/JOIN for JOIN/FORK
+};
+
+/* Structure of command element. */
+struct cmd_element
+{
+  const char *string;           /* Command specification by string. */
+  const char *doc;              /* Documentation of this command. */
+  int daemon;                   /* Daemon to which this command belong. */
+  uint8_t attr;                 /* Command attributes */
+
+  /* handler function for command */
+  int (*func) (const struct cmd_element *, struct vty *, int, struct cmd_token *[]);
+
+  const char *name;             /* symbol name for debugging */
+};
+
+/* text for <cr> command */
+#define CMD_CR_TEXT "<cr>"
+
+/* memory management for cmd_token */
+extern struct cmd_token *cmd_token_new (enum cmd_token_type, uint8_t attr,
+                                        const char *text, const char *desc);
+extern struct cmd_token *cmd_token_dup (struct cmd_token *);
+extern void cmd_token_del (struct cmd_token *);
+extern void cmd_token_varname_set(struct cmd_token *token, const char *varname);
+
+extern void cmd_graph_parse (struct graph *graph, struct cmd_element *cmd);
+extern void cmd_graph_merge (struct graph *old, struct graph *new, int direction);
+
+#endif /* _FRR_COMMAND_GRAPH_H */

--- a/lib/command_graph.h
+++ b/lib/command_graph.h
@@ -61,6 +61,8 @@ enum cmd_token_type
   SPECIAL_TKN = FORK_TKN,
 };
 
+#define IS_VARYING_TOKEN(x) ((x) >= VARIABLE_TKN && (x) < FORK_TKN)
+
 /* Command attributes */
 enum
 {

--- a/lib/command_graph.h
+++ b/lib/command_graph.h
@@ -111,6 +111,7 @@ extern void cmd_token_del (struct cmd_token *);
 extern void cmd_token_varname_set(struct cmd_token *token, const char *varname);
 
 extern void cmd_graph_parse (struct graph *graph, struct cmd_element *cmd);
+extern void cmd_graph_names (struct graph *graph);
 extern void cmd_graph_merge (struct graph *old, struct graph *new, int direction);
 
 #endif /* _FRR_COMMAND_GRAPH_H */

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -117,7 +117,7 @@ command_match (struct graph *cmdgraph,
       struct listnode *tail = listtail (*argv);
 
       // delete dummy start node
-      del_cmd_token ((struct cmd_token *) head->data);
+      cmd_token_del ((struct cmd_token *) head->data);
       list_delete_node (*argv, head);
 
       // get cmd_element out of list tail
@@ -281,7 +281,7 @@ command_match_r (struct graph_node *start, vector vline, unsigned int n,
               // manually deleted
               struct cmd_element *el = leaf->data;
               listnode_add (currbest, el);
-              currbest->del = (void (*)(void *)) &del_cmd_token;
+              currbest->del = (void (*)(void *)) &cmd_token_del;
               // do not break immediately; continue walking through the follow set
               // to ensure that there is exactly one END_TKN
             }
@@ -320,7 +320,7 @@ command_match_r (struct graph_node *start, vector vline, unsigned int n,
         {
           // copy token, set arg and prepend to currbest
           struct cmd_token *token = start->data;
-          struct cmd_token *copy = copy_cmd_token (token);
+          struct cmd_token *copy = cmd_token_dup (token);
           copy->arg = XSTRDUP (MTYPE_CMD_ARG, input_token);
           listnode_add_before (currbest, currbest->head, copy);
           matcher_rv = MATCHER_OK;

--- a/lib/command_parse.y
+++ b/lib/command_parse.y
@@ -104,11 +104,14 @@
 %type <node> start
 %type <node> literal_token
 %type <node> placeholder_token
+%type <node> placeholder_token_real
 %type <node> simple_token
 %type <subgraph> selector
 %type <subgraph> selector_token
 %type <subgraph> selector_token_seq
 %type <subgraph> selector_seq_seq
+
+%type <string> varname_token
 
 %code {
 
@@ -184,6 +187,16 @@ start:
 }
 ;
 
+varname_token: '$' WORD
+{
+  $$ = XSTRDUP (MTYPE_LEX, $2);
+}
+| /* empty */
+{
+  $$ = NULL;
+}
+;
+
 cmd_token_seq:
   /* empty */
 | cmd_token_seq cmd_token
@@ -207,14 +220,16 @@ simple_token:
 | placeholder_token
 ;
 
-literal_token: WORD
+literal_token: WORD varname_token
 {
   $$ = new_token_node (ctx, WORD_TKN, $1, doc_next(ctx));
+  cmd_set_varname ($$->data, $2);
+  XFREE (MTYPE_LEX, $2);
   XFREE (MTYPE_LEX, $1);
 }
 ;
 
-placeholder_token:
+placeholder_token_real:
   IPV4
 {
   $$ = new_token_node (ctx, IPV4_TKN, $1, doc_next(ctx));
@@ -257,10 +272,22 @@ placeholder_token:
   XFREE (MTYPE_LEX, $1);
 }
 
+placeholder_token:
+  placeholder_token_real varname_token
+{
+  struct cmd_token *token = $$->data;
+  $$ = $1;
+  cmd_set_varname (token, $2);
+  XFREE (MTYPE_LEX, $2);
+};
+
+
 /* <selector|set> productions */
-selector: '<' selector_seq_seq '>'
+selector: '<' selector_seq_seq '>' varname_token
 {
   $$ = $2;
+  cmd_set_varname ($2.end->data, $4);
+  XFREE (MTYPE_LEX, $4);
 };
 
 selector_seq_seq:
@@ -283,7 +310,7 @@ selector_seq_seq:
 ;
 
 /* {keyword} productions */
-selector: '{' selector_seq_seq '}'
+selector: '{' selector_seq_seq '}' varname_token
 {
   $$ = $2;
   graph_add_edge ($$.end, $$.start);
@@ -293,6 +320,9 @@ selector: '{' selector_seq_seq '}'
    *    loop-avoidal fails to handle
    * just use [{a|b}] if neccessary, that will work perfectly fine, and reason
    * #1 is good enough to keep it this way. */
+
+  cmd_set_varname ($2.end->data, $4);
+  XFREE (MTYPE_LEX, $4);
 };
 
 
@@ -315,10 +345,12 @@ selector_token_seq:
 ;
 
 /* [option] productions */
-selector: '[' selector_seq_seq ']'
+selector: '[' selector_seq_seq ']' varname_token
 {
   $$ = $2;
   graph_add_edge ($$.start, $$.end);
+  cmd_set_varname ($2.end->data, $4);
+  XFREE (MTYPE_LEX, $4);
 }
 ;
 

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -70,11 +70,11 @@ DEFUN (grammar_test,
 
   // parse the command and install it into the command graph
   struct graph *graph = graph_new();
-  struct cmd_token *token = new_cmd_token (START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
-  graph_new_node (graph, token, (void (*)(void *)) &del_cmd_token);
+  struct cmd_token *token = cmd_token_new (START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
+  graph_new_node (graph, token, (void (*)(void *)) &cmd_token_del);
 
-  command_parse_format (graph, cmd);
-  cmd_merge_graphs (nodegraph, graph, +1);
+  cmd_graph_parse (graph, cmd);
+  cmd_graph_merge (nodegraph, graph, +1);
 
   return CMD_SUCCESS;
 }
@@ -123,7 +123,7 @@ DEFUN (grammar_test_complete,
       }
 
       for (i = 0; i < vector_active (comps); i++)
-        del_cmd_token ((struct cmd_token *) vector_slot (comps, i));
+        cmd_token_del ((struct cmd_token *) vector_slot (comps, i));
       vector_free (comps);
     }
   else
@@ -229,7 +229,7 @@ DEFUN (grammar_test_doc,
   cmd->func = NULL;
 
   // parse element
-  command_parse_format (nodegraph, cmd);
+  cmd_graph_parse (nodegraph, cmd);
 
   return CMD_SUCCESS;
 }
@@ -656,8 +656,8 @@ init_cmdgraph (struct vty *vty, struct graph **graph)
   // initialize graph, add start noe
   *graph = graph_new ();
   nodegraph_free = *graph;
-  struct cmd_token *token = new_cmd_token (START_TKN, 0, NULL, NULL);
-  graph_new_node (*graph, token, (void (*)(void *)) &del_cmd_token);
+  struct cmd_token *token = cmd_token_new (START_TKN, 0, NULL, NULL);
+  graph_new_node (*graph, token, (void (*)(void *)) &cmd_token_del);
   if (vty)
     vty_out (vty, "initialized graph%s", VTY_NEWLINE);
 }

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -526,6 +526,8 @@ pretty_print_graph (struct vty *vty, struct graph_node *start, int level,
   vty_out(vty, "%s", LOOKUP_DEF(tokennames, tok->type, tokennum));
   if (tok->text)
     vty_out(vty, ":\"%s\"", tok->text);
+  if (tok->varname)
+    vty_out(vty, " => %s", tok->varname);
   if (desc)
     vty_out(vty, " ?'%s'", tok->desc);
   vty_out(vty, " ");

--- a/lib/if.c
+++ b/lib/if.c
@@ -1126,6 +1126,36 @@ ifaddr_ipv4_lookup (struct in_addr *addr, ifindex_t ifindex)
 }
 #endif /* ifaddr_ipv4_table */
 
+static void if_autocomplete(vector comps, struct cmd_token *token)
+{
+  struct interface *ifp;
+  struct listnode *ln;
+  struct vrf *vrf = NULL;
+
+  RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
+    {
+      for (ALL_LIST_ELEMENTS_RO(vrf->iflist, ln, ifp))
+        vector_set (comps, XSTRDUP (MTYPE_COMPLETION, ifp->name));
+    }
+
+}
+
+static const struct cmd_variable_handler if_var_handlers[] = {
+    {
+        /* "interface NAME" */
+        .varname = "interface",
+        .completions = if_autocomplete
+    }, {
+        .tokenname = "IFNAME",
+        .completions = if_autocomplete
+    }, {
+        .tokenname = "INTERFACE",
+        .completions = if_autocomplete
+    }, {
+        .completions = NULL
+    }
+};
+
 /* Initialize interface list. */
 void
 if_init (struct list **intf_list)
@@ -1136,6 +1166,8 @@ if_init (struct list **intf_list)
 #endif /* ifaddr_ipv4_table */
 
   (*intf_list)->cmp = (int (*)(void *, void *))if_cmp_func;
+
+  cmd_variable_handler_register(if_var_handlers);
 }
 
 void

--- a/lib/log.h
+++ b/lib/log.h
@@ -24,6 +24,7 @@
 #define _ZEBRA_LOG_H
 
 #include <syslog.h>
+#include <stdint.h>
 #include <stdio.h>
 
 /* Here is some guidance on logging levels to use:
@@ -64,7 +65,7 @@ struct message
 
 /* Open zlog function */
 extern void openzlog (const char *progname, const char *protoname,
-                      u_short instance, int syslog_options, int syslog_facility);
+                      uint16_t instance, int syslog_options, int syslog_facility);
 
 /* Close zlog function. */
 extern void closezlog (void);

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -2001,7 +2001,7 @@ DEFUN (match_interface,
 
 DEFUN (no_match_interface,
        no_match_interface_cmd,
-       "no match interface [INTERFACE]",
+       "no match interface [WORD]",
        NO_STR
        MATCH_STR
        "Match first hop interface of route\n"
@@ -2958,6 +2958,30 @@ route_map_finish (void)
   route_map_master_hash = NULL;
 }
 
+static void rmap_autocomplete(vector comps, struct cmd_token *token)
+{
+  struct route_map *map;
+
+  for (map = route_map_master.head; map; map = map->next)
+    vector_set (comps, XSTRDUP (MTYPE_COMPLETION, map->name));
+}
+
+static const struct cmd_variable_handler rmap_var_handlers[] = {
+    {
+        /* "route-map WORD" */
+        .varname = "route_map",
+        .completions = rmap_autocomplete
+    }, {
+        .tokenname = "ROUTEMAP_NAME",
+        .completions = rmap_autocomplete
+    }, {
+        .tokenname = "RMAP_NAME",
+        .completions = rmap_autocomplete
+    }, {
+        .completions = NULL
+    }
+};
+
 /* Initialization of route map vector. */
 void
 route_map_init (void)
@@ -2972,6 +2996,8 @@ route_map_init (void)
   for (i = 1; i < ROUTE_MAP_DEP_MAX; i++)
     route_map_dep_hash[i] = hash_create(route_map_dep_hash_make_key,
 					route_map_dep_hash_cmp);
+
+  cmd_variable_handler_register(rmap_var_handlers);
 
   /* Install route map top node. */
   install_node (&rmap_node, route_map_config_write);

--- a/tests/lib/cli/test_cli.refout.in
+++ b/tests/lib/cli/test_cli.refout.in
@@ -61,7 +61,7 @@ cmd2 with 3 args.
 [01]: ipv6
 [02]: de4d:b33f::cafe
 test# arg ipv6 de4d:b3
-% There is no matched command.
+  X:X::X:X  02
 test# arg ipv6 de4d:b33f::caf
   X:X::X:X  02
 test# arg ipv6 de4d:b33f::cafe
@@ -264,7 +264,8 @@ cmd10 with 3 args.
 test# 
 test# alt a 
 test# alt a a
-  WORD  02
+  WORD      02
+  X:X::X:X  02
 test# alt a ab
 cmd11 with 3 args.
 [00]: alt
@@ -281,7 +282,8 @@ cmd12 with 3 args.
 [02]: 1.2.3.4
 test# alt a 1
 test# alt a 1:2
-  WORD  02
+  WORD      02
+  X:X::X:X  02
 test# alt a 1:2
 test# alt a 1:2::
   WORD      02

--- a/tools/permutations.c
+++ b/tools/permutations.c
@@ -43,9 +43,9 @@ int main (int argc, char *argv[])
   cmd->string = strdup(argv[1]);
 
   struct graph *graph = graph_new();
-  struct cmd_token *token = new_cmd_token (START_TKN, cmd->attr, NULL, NULL);
+  struct cmd_token *token = cmd_token_new (START_TKN, cmd->attr, NULL, NULL);
   graph_new_node (graph, token, NULL);
-  command_parse_format (graph, cmd);
+  cmd_graph_parse (graph, cmd);
 
   permute (vector_slot (graph->nodes, 0));
 }

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -107,12 +107,9 @@ begins_with(const char *str, const char *prefix)
   return strncmp(str, prefix, lenprefix) == 0;
 }
 
-/* NB: multiplexed function:
- *  if fp == NULL, this calls vtysh_config_parse_line
- *  if fp != NULL, this prints lines to fp
- */
 static int
-vtysh_client_run (struct vtysh_client *vclient, const char *line, FILE *fp)
+vtysh_client_run (struct vtysh_client *vclient, const char *line, FILE *fp,
+                  void (*callback)(void *, const char *), void *cbarg)
 {
   int ret;
   char stackbuf[4096];
@@ -178,8 +175,8 @@ vtysh_client_run (struct vtysh_client *vclient, const char *line, FILE *fp)
               fputs (buf, fp);
               fputc ('\n', fp);
             }
-          else
-            vtysh_config_parse_line (buf);
+          if (callback)
+            callback(cbarg, buf);
 
           if (eol == end)
             /* \n\0\0\0 */
@@ -223,14 +220,15 @@ out:
 
 static int
 vtysh_client_run_all (struct vtysh_client *head_client, const char *line,
-                      int continue_on_err, FILE *fp)
+                      int continue_on_err, FILE *fp,
+                      void (*callback)(void *, const char *), void *cbarg)
 {
   struct vtysh_client *client;
   int rc, rc_all = CMD_SUCCESS;
 
   for (client = head_client; client; client = client->next)
     {
-      rc = vtysh_client_run(client, line, fp);
+      rc = vtysh_client_run(client, line, fp, callback, cbarg);
       if (rc != CMD_SUCCESS)
         {
           if (!continue_on_err)
@@ -245,13 +243,13 @@ static int
 vtysh_client_execute (struct vtysh_client *head_client, const char *line,
                       FILE *fp)
 {
-  return vtysh_client_run_all (head_client, line, 0, fp);
+  return vtysh_client_run_all (head_client, line, 0, fp, NULL, NULL);
 }
 
 static void
 vtysh_client_config (struct vtysh_client *head_client, char *line)
 {
-  vtysh_client_run_all (head_client, line, 1, NULL);
+  vtysh_client_run_all (head_client, line, 1, NULL, vtysh_config_parse_line, NULL);
 }
 
 void
@@ -796,6 +794,27 @@ vtysh_rl_describe (void)
 		   width,
 		   token->text,
 		   token->desc);
+
+        if (IS_VARYING_TOKEN(token->type))
+          {
+            const char *ref = vector_slot(vline, vector_active(vline) - 1);
+
+            vector varcomps = vector_init (VECTOR_MIN_SIZE);
+            cmd_variable_complete (token, ref, varcomps);
+
+            if (vector_active (varcomps) > 0)
+              {
+                fprintf(stdout, "     ");
+                for (size_t j = 0; j < vector_active (varcomps); j++)
+                  {
+                    char *item = vector_slot (varcomps, j);
+                    fprintf (stdout, " %s", item);
+                    XFREE (MTYPE_COMPLETION, item);
+                  }
+                vty_out (vty, "%s", VTY_NEWLINE);
+              }
+            vector_free (varcomps);
+          }
       }
 
   cmd_free_strvec (vline);
@@ -838,6 +857,7 @@ command_generator (const char *text, int state)
     }
 
   if (matched && matched[index])
+    /* this is free()'d by readline, but we leak 1 count of MTYPE_COMPLETION */
     return matched[index++];
 
   XFREE (MTYPE_TMP, matched);
@@ -3193,6 +3213,36 @@ vtysh_prompt (void)
   return buf;
 }
 
+static void vtysh_ac_line(void *arg, const char *line)
+{
+  vector comps = arg;
+  size_t i;
+  for (i = 0; i < vector_active(comps); i++)
+    if (!strcmp(line, (char *)vector_slot(comps, i)))
+      return;
+  vector_set(comps, XSTRDUP(MTYPE_COMPLETION, line));
+}
+
+static void vtysh_autocomplete(vector comps, struct cmd_token *token)
+{
+  char accmd[256];
+  size_t i;
+
+  snprintf(accmd, sizeof(accmd), "autocomplete %d %s %s", token->type,
+           token->text, token->varname ? token->varname : "-");
+
+  for (i = 0; i < array_size(vtysh_client); i++)
+    vtysh_client_run_all (&vtysh_client[i], accmd, 1, NULL,
+                          vtysh_ac_line, comps);
+}
+
+static const struct cmd_variable_handler vtysh_var_handler = {
+        /* match all */
+        .tokenname = NULL,
+        .varname = NULL,
+        .completions = vtysh_autocomplete
+};
+
 void
 vtysh_init_vty (void)
 {
@@ -3203,6 +3253,7 @@ vtysh_init_vty (void)
 
   /* Initialize commands. */
   cmd_init (0);
+  cmd_variable_handler_register(&vtysh_var_handler);
 
   /* Install nodes. */
   install_node (&bgp_node, NULL);

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -85,7 +85,7 @@ int vtysh_mark_file(const char *filename);
 int vtysh_read_config (const char *);
 int vtysh_write_config_integrated (void);
 
-void vtysh_config_parse_line (const char *);
+void vtysh_config_parse_line (void *, const char *);
 
 void vtysh_config_dump (FILE *);
 

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -145,7 +145,7 @@ config_add_line_uniq (struct list *config, const char *line)
 }
 
 void
-vtysh_config_parse_line (const char *line)
+vtysh_config_parse_line (void *arg, const char *line)
 {
   char c;
   static struct config *config = NULL;
@@ -418,12 +418,12 @@ vtysh_config_write ()
   if (host.name)
     {
       sprintf (line, "hostname %s", host.name);
-      vtysh_config_parse_line(line);
+      vtysh_config_parse_line(NULL, line);
     }
   if (vtysh_write_integrated == WRITE_INTEGRATED_NO)
-    vtysh_config_parse_line ("no service integrated-vtysh-config");
+    vtysh_config_parse_line (NULL, "no service integrated-vtysh-config");
   if (vtysh_write_integrated == WRITE_INTEGRATED_YES)
-    vtysh_config_parse_line ("service integrated-vtysh-config");
+    vtysh_config_parse_line (NULL, "service integrated-vtysh-config");
 
   user_config_write ();
 }


### PR DESCRIPTION
can now Tab/? the following things:
- interface names
- prefix list names
- route-map names
- bgp neighbor addresses/peer group names

note: the "varname" stuff is actually in preparation for another stack of CLI improvements, but it works very nicely for the autocomplete bits too.