### PR TITLE
zebra: Fix kernel netlink hex dump of information

### DIFF
--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -384,6 +384,16 @@ config_write_debug (struct vty *vty)
       vty_out (vty, "debug zebra kernel%s", VTY_NEWLINE);
       write++;
     }
+  if (IS_ZEBRA_DEBUG_KERNEL_MSGDUMP_RECV)
+    {
+      vty_out (vty, "debug zebra kernel msgdump recv%s", VTY_NEWLINE);
+      write++;
+    }
+  if (IS_ZEBRA_DEBUG_KERNEL_MSGDUMP_SEND)
+    {
+      vty_out (vty, "debug zebra kernel msgdump send%s", VTY_NEWLINE);
+      write++;
+    }
   /* Check here using flags as the 'macro' does an OR */
   if (CHECK_FLAG (zebra_debug_rib, ZEBRA_DEBUG_RIB))
     {

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -522,7 +522,7 @@ netlink_parse_info (int (*filter) (struct sockaddr_nl *, struct nlmsghdr *,
       if (IS_ZEBRA_DEBUG_KERNEL_MSGDUMP_RECV)
         {
           zlog_debug("%s: << netlink message dump [recv]", __func__);
-          zlog_hexdump(&msg, sizeof(msg));
+          zlog_hexdump(buf, status);
         }
 
       read_in++;
@@ -705,7 +705,7 @@ netlink_talk (int (*filter) (struct sockaddr_nl *, struct nlmsghdr *,
   if (IS_ZEBRA_DEBUG_KERNEL_MSGDUMP_SEND)
     {
       zlog_debug("%s: >> netlink message dump [sent]", __func__);
-      zlog_hexdump(&msg, sizeof(msg));
+      zlog_hexdump(n, n->nlmsg_len);
     }
 
   if (status < 0)


### PR DESCRIPTION
1) Fix the kernel send and recv hex dump of what we
are sending to the kernel

2) When configuring the debugs under 'conf t' display
it too.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>