### PR TITLE
snap: add vtysh as a "proper" command alias for frr.vtysh

### DIFF
--- a/snapcraft/README.snap_build.md
+++ b/snapcraft/README.snap_build.md
@@ -94,7 +94,16 @@ All the commands are prefixed with frr.
     frr.zebra-debug
 
 vtysh can be accessed as frr.vtysh (Make sure you have /snap/bin in your
-path). If access as `vtysh` instead of `frr.vtysh` is needed, a symlink 
-can be created:
+path). If access as `vtysh` instead of `frr.vtysh` is needed, you can enable it
+via a snap alias as follows:
 
-    sudo ln -s /snap/bin/frr.vtysh /usr/local/bin/vtysh
+   sudo snap alias frr vtysh
+
+This will add the vtysh command to your /snap/bin for direct access. The output of
+
+   sudo snap aliases
+
+should list vtysh command alias as enabled:
+
+App          Alias    Notes
+frr.vtysh    vtysh    enabled

--- a/snapcraft/README.usage.md
+++ b/snapcraft/README.usage.md
@@ -109,13 +109,17 @@ FAQ
       `export VTYSH_PAGER=cat` to the end of your `.profile`)
 
 - ospfd / ospf6d are not running after installation
-	- Installing a new snap starts the daemons, but at this time they
-	  may not have the required priviledged access. Make sure you 
-	  issue the `snap connect` command as given above (can be verified
-	  with `snap interfaces`) and **THEN** restart the daemons (or
-	  reboot the system). 
-	  This is a limitation of any snap package at this time which
-	  requires priviledged interfaces (ie to manipulate routing tables)
+    - Installing a new snap starts the daemons, but at this time they
+      may not have the required priviledged access. Make sure you 
+      issue the `snap connect` command as given above (can be verified
+      with `snap interfaces`) and **THEN** restart the daemons (or
+      reboot the system). 
+      This is a limitation of any snap package at this time which
+      requires priviledged interfaces (ie to manipulate routing tables)
+
+- Can I run vtysh directly without the "frr." prefix?
+    - Yes, enable the vtysh alias in the frr snap package by:
+      sudo snap alias frr vtysh
 	
 Sourcecode available
 ====================

--- a/snapcraft/README.usage.md
+++ b/snapcraft/README.usage.md
@@ -110,12 +110,12 @@ FAQ
 
 - ospfd / ospf6d are not running after installation
     - Installing a new snap starts the daemons, but at this time they
-      may not have the required priviledged access. Make sure you 
+      may not have the required privileged access. Make sure you 
       issue the `snap connect` command as given above (can be verified
       with `snap interfaces`) and **THEN** restart the daemons (or
       reboot the system). 
       This is a limitation of any snap package at this time which
-      requires priviledged interfaces (ie to manipulate routing tables)
+      requires privileged interfaces (ie to manipulate routing tables)
 
 - Can I run vtysh directly without the "frr." prefix?
     - Yes, enable the vtysh alias in the frr snap package by:

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -16,6 +16,7 @@ apps:
             - network
             - network-bind
             - network-control
+        aliases: [vtysh]
     version:
         command: bin/show_version
     readme:


### PR DESCRIPTION
   This allows direct access to vtysh without the "frr." prefix.
   The alias can be enabled by sudo snap frr vtysh

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>