### PR TITLE
frr: clarify style guide

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -268,7 +268,8 @@ Portions:
 ### Code styling / format
 
 Coding style standards in FRR vary depending on location.  Pre-existing
-code uses GNU coding standards.  New code may use Linux kernel coding style.
+code uses GNU coding standards.  New code may use Linux kernel coding style but
+with 8 spaces replacing hard tabs.
 
 GNU coding style apply to the following parts:
 
@@ -320,7 +321,8 @@ due to whitespace issues, to minimise merging conflicts.
 
 These styles are documented externally:
 
-* [https://www.kernel.org/doc/Documentation/CodingStyle](https://www.kernel.org/doc/Documentation/CodingStyle).
+* [https://www.kernel.org/doc/Documentation/process/coding-style.rst]
+  (https://www.kernel.org/doc/Documentation/process/coding-style.rst).
 * [http://man.openbsd.org/style](http://man.openbsd.org/style)
 
 They are relatively similar but differ in details.
@@ -331,7 +333,12 @@ It is acceptable to convert indentation in pimd/ to Linux kernel style, but
 please convert an entire file at a time.  (Rationale: apart from 2-space
 indentation, the styles are sufficiently close to not upset when mixed.)
 
-Unlike GNU style, these styles use tabs, not spaces.
+When using Linux kernel style for new code, use 8 spaces instead of tabs. You
+may use GNU Indent to properly format your code, with the following invocation:
+
+```
+indent -kr -i8 -nut <sourcefiles>
+```
 
 
 ### Compile-Time conditional code


### PR DESCRIPTION
Add a note that when using Linux style FRRouting prefers 8 spaces
instead of hard tabs, and add the appropriate GNU Indent invocation to
use.

Also fixes broken link to kernel style guide.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>