### PR TITLE
zebra: Distributed Dataplane module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -285,10 +285,14 @@ AC_ARG_ENABLE(systemd,
   AS_HELP_STRING([--enable-systemd], [enable Systemd support]))
 AC_ARG_ENABLE(poll,
   AS_HELP_STRING([--enable-poll], [enable usage of Poll instead of select]))
+AC_ARG_ENABLE(zmq-poll,
+  AS_HELP_STRING([--enable-zmq-poll], [enable usage of ZMQ Poll instead of select]))
 AC_ARG_ENABLE(werror,
   AS_HELP_STRING([--enable-werror], [enable -Werror (recommended for developers only)]))
 AC_ARG_ENABLE(cumulus,
   AS_HELP_STRING([--enable-cumulus], [enable Cumulus Switch Special Extensions]))
+AC_ARG_ENABLE(distributed-dataplane,
+  AS_HELP_STRING([--enable-distributed-dataplane], [enable Distributed Dataplane Extension]))
 AC_ARG_ENABLE(rr-semantics,
   AS_HELP_STRING([--disable-rr-semantics], [disable the v6 Route Replace semantics]))
 AC_ARG_ENABLE([protobuf],
@@ -337,6 +341,11 @@ if test "${enable_poll}" = "yes" ; then
   AC_DEFINE(HAVE_POLL_CALL,,Compile systemd support in)
 fi
 
+if test "${enable_zmq_poll}" = "yes" ; then
+  AC_DEFINE(HAVE_ZMQ_POLL,,Compile ZMQ support in)
+fi
+AM_CONDITIONAL([HAVE_ZMQ_POLL], [test "x$enable_zmq_poll" = "xyes"])
+
 dnl ----------
 dnl MPLS check
 dnl ----------
@@ -365,6 +374,11 @@ else
 fi
 AC_SUBST(DFLT_NAME)
 AC_DEFINE_UNQUOTED(DFLT_NAME,["$DFLT_NAME"], Name of the configuration default set)
+
+if test "${enable_distributed_dataplane}" = "yes" ; then
+  AC_DEFINE(HAVE_DISTRIBUTED_DATAPLANE,,Compile Special Distributed Dataplane Code in)
+fi
+AM_CONDITIONAL([HAVE_DISTRIBUTED_DATAPLANE], [test "x$enable_distributed_dataplane" = "xyes"])
 
 if test "${enable_shell_access}" = "yes"; then
    AC_DEFINE(HAVE_SHELL_ACCESS,,Allow user to use ssh/telnet/bash)

--- a/ldpd/l2vpn.c
+++ b/ldpd/l2vpn.c
@@ -600,3 +600,40 @@ ldpe_l2vpn_pw_exit(struct l2vpn_pw *pw)
 		tnbr_check(leconf, tnbr);
 	}
 }
+
+/**
+ * Update PW status
+ *
+ * @return 0 on success, 1 on failure
+ */
+int
+l2vpn_pw_status_update (struct kpw *kpw)
+{
+	struct l2vpn *l2vpn;
+	struct l2vpn_pw *pw;
+
+	/* Find L2VPN */
+	l2vpn = l2vpn_find(ldeconf, kpw->vpn_name);
+	if (!l2vpn) {
+		log_warn("%s: No L2VPN found for %s", __func__, kpw->vpn_name);
+		return 1;
+	}
+
+	/* Find PW */
+	pw = l2vpn_pw_find(l2vpn, kpw->ifname);
+	if (!pw) {
+		log_warn("%s: No PW found for VPN %s and interface %s",
+				 __func__, kpw->vpn_name, kpw->ifname);
+		return 1;
+	}
+
+	kpw->af = pw->af;
+	memcpy(&kpw->nexthop, &pw->addr, sizeof (union ldpd_addr));
+	/* Update status */
+	if (kpw->flags & F_PW_STATUS_UP)
+		pw->flags |= F_PW_STATUS_UP;
+	else
+		pw->flags &= ~F_PW_STATUS_UP;
+
+	return 0;
+}

--- a/ldpd/lde.h
+++ b/ldpd/lde.h
@@ -25,6 +25,8 @@
 #include "openbsd-tree.h"
 #include "if.h"
 
+#define RETRY_SYNC_PW_INTERVAL 5 /* in seconds */
+
 enum fec_type {
 	FEC_TYPE_IPV4,
 	FEC_TYPE_IPV6,
@@ -188,6 +190,7 @@ void		 fec_snap(struct lde_nbr *);
 void		 fec_tree_clear(void);
 struct fec_nh	*fec_nh_find(struct fec_node *, int, union ldpd_addr *,
 		    ifindex_t, uint8_t);
+void 		 update_local_label (struct fec_node *fn, int connected);
 void		 lde_kernel_insert(struct fec *, int, union ldpd_addr *,
 		    ifindex_t, uint8_t, int, void *);
 void		 lde_kernel_remove(struct fec *, int, union ldpd_addr *,
@@ -235,5 +238,6 @@ void		 l2vpn_recv_pw_status_wcard(struct lde_nbr *,
 		    struct notify_msg *);
 void		 l2vpn_pw_ctl(pid_t);
 void		 l2vpn_binding_ctl(pid_t);
+int 		 l2vpn_pw_status_update (struct kpw *kpw);
 
 #endif	/* _LDE_H_ */

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -147,7 +147,8 @@ enum imsg_type {
 	IMSG_LOG,
 	IMSG_ACL_CHECK,
 	IMSG_GET_LABEL_CHUNK,
-	IMSG_RELEASE_LABEL_CHUNK
+	IMSG_RELEASE_LABEL_CHUNK,
+	IMSG_PW_UPDATE
 };
 
 union ldpd_addr {
@@ -531,13 +532,18 @@ struct kroute {
 };
 
 struct kpw {
+	char                     ifname[IF_NAMESIZE];
 	unsigned short		 ifindex;
 	int			 pw_type;
+	struct in_addr           lsr_id;
 	int			 af;
 	union ldpd_addr		 nexthop;
 	uint32_t		 local_label;
 	uint32_t		 remote_label;
 	uint8_t			 flags;
+	uint32_t                 pwid;
+	char			 vpn_name[L2VPN_NAME_LEN];
+	unsigned short           ac_port_ifindex;
 };
 
 struct kaddr {

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -10,8 +10,12 @@ command_lex.h: command_lex.c
 	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) command_lex.c; else :; fi
 command_parse.lo: command_lex.h
 
+if HAVE_ZMQ_POLL
+libzmq = -lzmq -lsodium -lstdc++
+endif
+
 lib_LTLIBRARIES = libfrr.la
-libfrr_la_LDFLAGS = -version-info 0:0:0 
+libfrr_la_LDFLAGS = -version-info 0:0:0  $(libzmq)
 
 libfrr_la_SOURCES = \
 	network.c pid_output.c getopt.c getopt1.c \

--- a/lib/log.c
+++ b/lib/log.c
@@ -967,6 +967,8 @@ static const struct zebra_desc_table command_types[] = {
   DESC_ENTRY    (ZEBRA_LABEL_MANAGER_CONNECT),
   DESC_ENTRY    (ZEBRA_GET_LABEL_CHUNK),
   DESC_ENTRY    (ZEBRA_RELEASE_LABEL_CHUNK),
+  DESC_ENTRY    (ZEBRA_KPW_ADD),
+  DESC_ENTRY    (ZEBRA_KPW_DELETE),
 };
 #undef DESC_ENTRY
 
@@ -1161,3 +1163,4 @@ zlog_sanitize (char *buf, size_t bufsz, const void *in, size_t inlen)
     }
   return buf;
 }
+

--- a/lib/log.h
+++ b/lib/log.h
@@ -79,6 +79,7 @@ extern const char *zlog_protoname (void);
 #endif /* __GNUC__ */
 
 /* Handy zlog functions. */
+void zlog (int priority, const char *format, ...);
 extern void zlog_err (const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
 extern void zlog_warn (const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
 extern void zlog_info (const char *format, ...) PRINTF_ATTRIBUTE(1, 2);

--- a/lib/module.h
+++ b/lib/module.h
@@ -25,6 +25,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h> /* for size_t */
 
 #if !defined(__GNUC__)
 # error module code needs GCC visibility extensions

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -71,6 +71,7 @@ struct nexthop
 #define NEXTHOP_FLAG_ONLINK     (1 << 3) /* Nexthop should be installed onlink. */
 #define NEXTHOP_FLAG_MATCHED    (1 << 4) /* Already matched vs a nexthop */
 #define NEXTHOP_FLAG_FILTERED   (1 << 5) /* rmap filtered, used by static only */
+#define NEXTHOP_FLAG_HW_NA      (1 << 6) /* Accepted by HW but not active */
 
   /* Nexthop address */
   union g_addr gate;

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -41,6 +41,10 @@ DEFINE_MTYPE_STATIC(LIB, THREAD_STATS,  "Thread stats")
 #include <mach/mach_time.h>
 #endif
 
+#if defined(HAVE_ZMQ_POLL)
+#include <zmq.h>
+#endif
+
 /* Relative time, since startup */
 static struct hash *cpu_record = NULL;
 
@@ -365,6 +369,17 @@ thread_master_create (void)
   rv->handler.pfds = XCALLOC (MTYPE_THREAD_MASTER,
                               sizeof (struct pollfd) * rv->handler.pfdsize);
 #endif
+#if defined(HAVE_ZMQ_POLL)
+  int i;
+  for (i = 0; i < FD_SETSIZE; i++)
+    {
+      rv->zmq_pollitems[i].socket = NULL;
+      rv->zmq_pollitems[i].fd = -1;
+      rv->zmq_pollitems[i].events = 0;
+    }
+  rv->zmq_poll_nitems = 0;
+#endif
+
   return rv;
 }
 
@@ -646,6 +661,86 @@ generic_thread_add(struct thread_master *m, int (*func) (struct thread *),
 #define fd_copy_fd_set(X) (X)
 #endif
 
+#if defined(HAVE_ZMQ_POLL)
+
+/**
+ * Check if a zmq poll item was set for a given mask
+ *
+ * It checks events field, not revents!
+ *
+ * @param pollitem Item to check
+ * @param mask Mask to check (like ZMQ_POLLIN, ZMQ_POLLOUT, ...)
+ * @return 1 if is set, 0 otherwise
+ */
+static int
+check_pollitem (zmq_pollitem_t *pollitem, short mask)
+{
+  if ((pollitem->socket != NULL || pollitem->fd >= 0)
+      && CHECK_FLAG(pollitem->events, mask))
+    return 1;
+
+  return 0;
+}
+
+/* Add new read thread. */
+struct thread *
+funcname_thread_add_zmq (struct thread_master *m,
+                         int (*func) (struct thread *), void *arg, int fd,
+                         debugargdef, void *zmq_socket, int dir)
+{
+
+  struct thread *thread;
+  short mask;
+
+  if (dir == THREAD_READ)
+    mask = ZMQ_POLLIN;
+  else if (dir == THREAD_WRITE)
+    mask = ZMQ_POLLOUT;
+  else
+    {
+      zlog_warn ("Invalid option for thread add! dir %d fd %d", dir, fd);
+      return NULL;
+    }
+
+  assert (m != NULL);
+
+  if (check_pollitem (&(m->zmq_pollitems[fd]), mask))
+    {
+      zlog_warn ("There is already fd [%d]", fd);
+      return NULL;
+    }
+
+  thread = thread_get (m, dir, func, arg, debugargpass);
+
+  if (zmq_socket != NULL)
+    m->zmq_pollitems[fd].socket = zmq_socket;
+  else
+    m->zmq_pollitems[fd].fd = fd;
+  SET_FLAG (m->zmq_pollitems[fd].events, mask);
+  /* update max pollitems number */
+  if (m->zmq_poll_nitems <= fd)
+    m->zmq_poll_nitems = fd + 1;
+
+  thread->u.fd = fd;
+  if (dir == THREAD_READ)
+    thread_add_fd (m->read, thread);
+  else
+    thread_add_fd (m->write, thread);
+
+  return thread;
+}
+
+struct thread *
+funcname_thread_add_read_write (int dir, struct thread_master *m,
+                                int (*func) (struct thread *), void *arg, int fd,
+                                debugargdef)
+{
+
+  return funcname_thread_add_zmq(m, func, arg, fd, debugargpass, NULL, dir);
+}
+
+#else /* HAVE_ZMQ_POLL */
+
 static int
 fd_select (struct thread_master *m, int size, thread_fd_set *read, thread_fd_set *write, thread_fd_set *except, struct timeval *timer_wait)
 {
@@ -701,6 +796,7 @@ funcname_thread_add_read_write (int dir, struct thread_master *m,
 				int (*func) (struct thread *), void *arg, int fd,
 				debugargdef)
 {
+
   struct thread *thread = NULL;
 
 #if !defined(HAVE_POLL_CALL)
@@ -736,6 +832,8 @@ funcname_thread_add_read_write (int dir, struct thread_master *m,
 
   return thread;
 }
+
+#endif /* HAVE_ZMQ_POLL */
 
 static struct thread *
 funcname_thread_add_timer_timeval (struct thread_master *m,
@@ -854,6 +952,56 @@ funcname_thread_add_event (struct thread_master *m,
   return thread;
 }
 
+#if defined(HAVE_ZMQ_POLL)
+
+/**
+ * Find last active socket and set zmq_poll_nitems
+ *
+ * @param m Thread master
+ */
+static void
+reduce_zmq_poll_nitems(struct thread_master *m)
+{
+  int i;
+
+  for( i = m->zmq_poll_nitems; i >= 0; i-- )
+    {
+      if( m->zmq_pollitems[i].socket != NULL || m->zmq_pollitems[i].fd >= 0 )
+        {
+          m->zmq_poll_nitems = i + 1;
+          return;
+        }
+    }
+
+  m->zmq_poll_nitems = 0;
+
+}
+static void
+cancel_pollitem (struct thread *thread, short mask)
+{
+  int fd;
+  zmq_pollitem_t *pollitem;
+
+  fd = THREAD_FD (thread); // thread->u.fd
+  pollitem = &(thread->master->zmq_pollitems[fd]);
+
+  assert (check_pollitem (pollitem, mask));
+
+  UNSET_FLAG (pollitem->events, mask);
+  UNSET_FLAG (pollitem->revents, mask);
+  /* disable poll item only if it doesn't have other events */
+  if (pollitem->events == 0)
+    {
+      pollitem->socket = NULL;
+      pollitem->fd = -1;
+      pollitem->events = 0;
+      reduce_zmq_poll_nitems(thread->master);
+    }
+
+}
+
+#else /* HAVE_ZMQ_POLL */
+
 static void
 thread_cancel_read_or_write (struct thread *thread, short int state)
 {
@@ -880,6 +1028,8 @@ thread_cancel_read_or_write (struct thread *thread, short int state)
   fd_clear_read_write (thread);
 }
 
+#endif /* HAVE_ZMQ_POLL */
+
 /* Cancel thread from scheduler. */
 void
 thread_cancel (struct thread *thread)
@@ -891,7 +1041,9 @@ thread_cancel (struct thread *thread)
   switch (thread->type)
     {
     case THREAD_READ:
-#if defined (HAVE_POLL_CALL)
+#if defined(HAVE_ZMQ_POLL)
+      cancel_pollitem (thread, ZMQ_POLLIN);
+#elif defined (HAVE_POLL_CALL)
       thread_cancel_read_or_write (thread, POLLIN | POLLHUP);
 #else
       thread_cancel_read_or_write (thread, 0);
@@ -899,7 +1051,9 @@ thread_cancel (struct thread *thread)
       thread_array = thread->master->read;
       break;
     case THREAD_WRITE:
-#if defined (HAVE_POLL_CALL)
+#if defined(HAVE_ZMQ_POLL)
+      cancel_pollitem (thread, ZMQ_POLLOUT);
+#elif defined (HAVE_POLL_CALL)
       thread_cancel_read_or_write (thread, POLLOUT | POLLHUP);
 #else
       thread_cancel_read_or_write (thread, 0);
@@ -1008,6 +1162,40 @@ thread_run (struct thread_master *m, struct thread *thread,
   return fetch;
 }
 
+
+#if defined(HAVE_ZMQ_POLL)
+static int
+thread_process_fd (struct thread_master *m, struct thread **thread_array, short mask, int num)
+{
+  struct thread *thread;
+  int ready = 0;
+  int fd;
+  zmq_pollitem_t *pollitem;
+  int index;
+
+  for (index = 0; index < m->zmq_poll_nitems && ready < num; ++index)
+    {
+      thread = thread_array[index];
+      if (thread)
+        {
+          fd = THREAD_FD (thread);
+          pollitem = &(thread->master->zmq_pollitems[fd]);
+
+          if( (pollitem->socket != NULL || pollitem->fd >= 0) &&
+              CHECK_FLAG (pollitem->revents, mask) )
+            {
+              cancel_pollitem (thread, mask);
+
+              thread_delete_fd (thread_array, thread);
+              thread_list_add (&m->ready, thread);
+              thread->type = THREAD_READY;
+              ready++;
+            }
+        }
+    }
+  return ready;
+}
+#else /* #if defined(HAVE_ZMQ_POLL) */
 static int
 thread_process_fds_helper (struct thread_master *m, struct thread *thread, thread_fd_set *fdset, short int state, int pos)
 {
@@ -1071,7 +1259,7 @@ check_pollfds(struct thread_master *m, fd_set *readfd, int num)
           m->handler.pfds[i].revents = 0;
     }
 }
-#endif
+#endif /* #if defined (HAVE_POLL_CALL) */
 
 static void
 thread_process_fds (struct thread_master *m, thread_fd_set *rset, thread_fd_set *wset, int num)
@@ -1088,6 +1276,7 @@ thread_process_fds (struct thread_master *m, thread_fd_set *rset, thread_fd_set 
     }
 #endif
 }
+#endif /* #if HAVE_ZMQ_POLL */
 
 /* Add all timers that have popped to the ready list. */
 static unsigned int
@@ -1134,9 +1323,11 @@ struct thread *
 thread_fetch (struct thread_master *m, struct thread *fetch)
 {
   struct thread *thread;
+#if !defined(HAVE_ZMQ_POLL)
   thread_fd_set readfd;
   thread_fd_set writefd;
   thread_fd_set exceptfd;
+#endif
   struct timeval now;
   struct timeval timer_val = { .tv_sec = 0, .tv_usec = 0 };
   struct timeval timer_val_bg;
@@ -1165,7 +1356,7 @@ thread_fetch (struct thread_master *m, struct thread *fetch)
       thread_process (&m->event);
       
       /* Structure copy.  */
-#if !defined(HAVE_POLL_CALL)
+#if !defined(HAVE_ZMQ_POLL) &&  !defined(HAVE_POLL_CALL)
       readfd = fd_copy_fd_set(m->handler.readfd);
       writefd = fd_copy_fd_set(m->handler.writefd);
       exceptfd = fd_copy_fd_set(m->handler.exceptfd);
@@ -1188,8 +1379,15 @@ thread_fetch (struct thread_master *m, struct thread *fetch)
           timer_wait = &timer_val;
         }
 
+#if defined(HAVE_ZMQ_POLL)
+          long zmq_poll_timeout = timer_wait != NULL ?
+          (long)(timer_wait->tv_sec * 1000 + timer_wait->tv_usec / 1000) :
+      -1;
+      num = zmq_poll(m->zmq_pollitems, m->zmq_poll_nitems, zmq_poll_timeout);
+#else
       num = fd_select (m, FD_SETSIZE, &readfd, &writefd, &exceptfd, timer_wait);
-      
+#endif
+
       /* Signals should get quick treatment */
       if (num < 0)
         {
@@ -1207,7 +1405,16 @@ thread_fetch (struct thread_master *m, struct thread *fetch)
       
       /* Got IO, process it */
       if (num > 0)
-        thread_process_fds (m, &readfd, &writefd, num);
+        {
+#if defined(HAVE_ZMQ_POLL)
+          /* Normal priority read thead. */
+          thread_process_fd (m, m->read, ZMQ_POLLIN, num);
+          /* Write thead. */
+          thread_process_fd (m, m->write, ZMQ_POLLOUT, num);
+#else
+          thread_process_fds (m, &readfd, &writefd, num);
+#endif
+        }
 
 #if 0
       /* If any threads were made ready above (I/O or foreground timer),

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1879,6 +1879,10 @@ zclient_read (struct thread *thread)
       if (zclient->interface_link_params)
         (*zclient->interface_link_params) (command, zclient, length);
       break;
+    case ZEBRA_PW_STATUS_UPDATE:
+      if (zclient->pw_status_update)
+        (*zclient->pw_status_update) (command, zclient, length, vrf_id);
+      break;
     default:
       break;
     }

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -94,6 +94,9 @@ typedef enum {
   ZEBRA_LABEL_MANAGER_CONNECT,
   ZEBRA_GET_LABEL_CHUNK,
   ZEBRA_RELEASE_LABEL_CHUNK,
+  ZEBRA_KPW_ADD,
+  ZEBRA_KPW_DELETE,
+  ZEBRA_PW_STATUS_UPDATE,
 } zebra_message_types_t;
 
 struct redist_proto
@@ -164,6 +167,7 @@ struct zclient
   int (*redistribute_route_ipv4_del) (int, struct zclient *, uint16_t, vrf_id_t);
   int (*redistribute_route_ipv6_add) (int, struct zclient *, uint16_t, vrf_id_t);
   int (*redistribute_route_ipv6_del) (int, struct zclient *, uint16_t, vrf_id_t);
+  int (*pw_status_update) (int, struct zclient *, uint16_t, vrf_id_t);
 };
 
 /* Zebra API message flag. */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -222,6 +222,9 @@ typedef unsigned char   u_int8_t;
 
 #include "zassert.h"
 
+#include "hook.h"
+DECLARE_HOOK(zebra_finish, (), ())
+
 #ifndef HAVE_STRLCAT
 size_t strlcat (char *__restrict dest, const char *__restrict src, size_t size);
 #endif

--- a/zebra/.gitignore
+++ b/zebra/.gitignore
@@ -1,6 +1,8 @@
 Makefile
 Makefile.in
 *.o
+*.lo
+*.la
 zebra
 zebra.conf
 client

--- a/zebra/Makefile.am
+++ b/zebra/Makefile.am
@@ -6,6 +6,12 @@ AM_CPPFLAGS = -I.. -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_builddir)/lib
 DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\"
 INSTALL_SDATA=@INSTALL@ -m 600
 
+if HAVE_ZMQ_POLL
+libzmq = -lzmq
+endif
+
+AM_LDFLAGS = $(PILDFLAGS) $(libzmq)
+
 LIBCAP = @LIBCAP@
 
 ipforward = @IPFORWARD@
@@ -33,8 +39,11 @@ zebra_SOURCES = \
 	zebra_ptm.c zebra_rnh.c zebra_ptm_redistribute.c \
 	zebra_ns.c zebra_vrf.c zebra_static.c zebra_mpls.c zebra_mpls_vty.c \
 	zebra_mroute.c \
-	label_manager.c \
+	label_manager.c zebra_pw.c \
 	# end
+if !HAVE_DISTRIBUTED_DATAPLANE
+zebra_SOURCES += zebra_dataplane.c
+endif
 
 testzebra_SOURCES = test_main.c zebra_rib.c interface.c connected.c debug.c \
 	zebra_vty.c zebra_ptm.c zebra_routemap.c zebra_ns.c zebra_vrf.c \
@@ -49,7 +58,8 @@ noinst_HEADERS = \
 	rt_netlink.h zebra_fpm_private.h zebra_rnh.h \
 	zebra_ptm_redistribute.h zebra_ptm.h zebra_routemap.h \
 	zebra_ns.h zebra_vrf.h ioctl_solaris.h zebra_static.h zebra_mpls.h \
-	kernel_netlink.h if_netlink.h zebra_mroute.h label_manager.h
+	kernel_netlink.h if_netlink.h zebra_mroute.h label_manager.h zebra_pw.h \
+	# end
 
 zebra_LDADD = $(otherobj) ../lib/libfrr.la $(LIBCAP)
 

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -38,6 +38,9 @@
 #define IF_ZEBRA_SHUTDOWN_OFF    0
 #define IF_ZEBRA_SHUTDOWN_ON     1
 
+DECLARE_HOOK (address_change, (int cmd, int family, struct interface *ifp,
+                              struct connected *ifc), (cmd, family, ifp, ifc))
+
 #if defined (HAVE_RTADV)
 /* Router advertisement parameter.  From RFC4861, RFC6275 and RFC4191. */
 struct rtadvconf
@@ -234,6 +237,8 @@ struct zebra_if
   u_char ptm_enable;
 };
 
+int address_change (int cmd, int family, struct interface *ifp,
+                    struct connected *ifc);
 
 extern struct interface *if_lookup_by_index_per_ns (struct zebra_ns *, u_int32_t);
 extern struct interface *if_lookup_by_name_per_ns (struct zebra_ns *, const char *);

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -36,6 +36,7 @@
 #include "sigevent.h"
 #include "vrf.h"
 #include "libfrr.h"
+#include "hook.h"
 
 #include "zebra/rib.h"
 #include "zebra/zserv.h"
@@ -48,6 +49,9 @@
 #include "zebra/redistribute.h"
 #include "zebra/zebra_mpls.h"
 #include "zebra/label_manager.h"
+#include "zebra/zebra_dataplane.h"
+
+DEFINE_HOOK(zebra_finish, (), ())
 
 #define ZEBRA_PTM_SUPPORT
 
@@ -77,6 +81,12 @@ int keep_kernel_mode = 0;
 u_int32_t nl_rcvbufsize = 4194304;
 #endif /* HAVE_NETLINK */
 
+#ifdef HAVE_DISTRIBUTED_DATAPLANE
+#define OPTION_DP_OPTS 2001
+/* Distributed Dataplane Module options */
+char *dp_opts = NULL;
+#endif /* HAVE_DISTRIBUTED_DATAPLANE */
+
 /* Command line options. */
 struct option longopts[] =
 {
@@ -90,6 +100,9 @@ struct option longopts[] =
 #ifdef HAVE_NETLINK
   { "nl-bufsize",   required_argument, NULL, 's'},
 #endif /* HAVE_NETLINK */
+#if defined(HAVE_DISTRIBUTED_DATAPLANE)
+  { "dp-opts",      required_argument, NULL, OPTION_DP_OPTS},
+#endif /* HAVE_DISTRIBUTED_DATAPLANE */
   { 0 }
 };
 
@@ -155,6 +168,8 @@ sigint (void)
 
   zns = zebra_ns_lookup (NS_DEFAULT);
   zebra_ns_disable (0, (void **)&zns);
+
+  hook_call (zebra_finish);
 
   access_list_reset ();
   prefix_list_reset ();
@@ -239,6 +254,9 @@ main (int argc, char **argv)
 #ifdef HAVE_NETLINK
 	"  -s, --nl-bufsize   Set netlink receive buffer size\n"
 #endif /* HAVE_NETLINK */
+#ifdef HAVE_DISTRIBUTED_DATAPLANE
+	"      --dp-opts      Options for Distributed Dataplane module\n"
+#endif /* HAVE_DISTRIBUTED_DATAPLANE */
 	);
 
   while (1)
@@ -283,6 +301,11 @@ main (int argc, char **argv)
 	  nl_rcvbufsize = atoi (optarg);
 	  break;
 #endif /* HAVE_NETLINK */
+#ifdef HAVE_DISTRIBUTED_DATAPLANE
+	case OPTION_DP_OPTS:
+	  dp_opts = optarg;
+	  break;
+#endif /* HAVE_DISTRIBUTED_DATAPLANE */
 	default:
 	  frr_help_exit (1);
 	  break;
@@ -314,6 +337,7 @@ main (int argc, char **argv)
 
   zebra_mpls_init ();
   zebra_mpls_vty_init ();
+  zebra_pw_init ();
 
   /* For debug purpose. */
   /* SET_FLAG (zebra_debug_event, ZEBRA_DEBUG_EVENT); */
@@ -329,6 +353,10 @@ main (int argc, char **argv)
   *  to that after daemon() completes (if ever called).
   */
   frr_config_fork();
+
+#if !defined(HAVE_DISTRIBUTED_DATAPLANE)
+  init_default_dataplane ();
+#endif
 
   /* Clean up rib -- before fork (?) */
   /* rib_weed_tables (); */

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -97,6 +97,9 @@ struct rib
   u_char nexthop_active_num;
 };
 
+#define RIB_SYSTEM_ROUTE(R)                                             \
+  ((R)->type == ZEBRA_ROUTE_KERNEL || (R)->type == ZEBRA_ROUTE_CONNECT)
+
 /* meta-queue structure:
  * sub-queue 0: connected, kernel
  * sub-queue 1: static
@@ -340,6 +343,14 @@ extern void rib_delnode (struct route_node *rn, struct rib *rib);
 extern int rib_install_kernel (struct route_node *rn, struct rib *rib, struct rib *old);
 extern int rib_uninstall_kernel (struct route_node *rn, struct rib *rib);
 
+int nexthop_active_update (struct route_node *rn, struct rib *rib, int set);
+
+int route_change (struct route_node *rn, struct rib *new, struct rib *old);
+int rib_process_after (struct route_node *rn,
+                       struct rib *old_selected, struct rib *new_selected,
+                       struct rib *old_fib, struct rib *new_fib,
+                       struct prefix *p, struct prefix *src_p,
+                       bool selected_changed, vrf_id_t vrf_id);
 /* NOTE:
  * All rib_add function will not just add prefix into RIB, but
  * also implicitly withdraw equal prefix of same type. */
@@ -492,5 +503,14 @@ rib_tables_iter_cleanup (rib_tables_iter_t *iter)
 }
 
 DECLARE_HOOK(rib_update, (struct route_node *rn, const char *reason), (rn, reason))
+DECLARE_HOOK(route_change, (struct route_node *rn, struct rib *new, struct rib *old),
+            (rn, new, old))
+DECLARE_HOOK(rib_process_after,
+             (struct route_node *rn, struct rib *old_selected,
+              struct rib *new_selected, struct rib *old_fib,
+              struct rib *new_fib, struct prefix *p, struct prefix *src_p,
+              bool selected_changed, vrf_id_t vrf_id),
+             (rn, old_selected, new_selected, old_fib, new_fib, p, src_p,
+              selected_changed, vrf_id))
 
 #endif /*_ZEBRA_RIB_H */

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -96,6 +96,8 @@
 #endif
 /* End of temporary definitions */
 
+DEFINE_HOOK (mpls_route_change, (int cmd, zebra_lsp_t *lsp), (cmd, lsp))
+
 struct gw_family_t
 {
   u_int16_t     filler;
@@ -1453,6 +1455,15 @@ kernel_neigh_update (int add, int ifindex, uint32_t addr, char *lla, int llalen)
  */
 int
 netlink_mpls_multipath (int cmd, zebra_lsp_t *lsp)
+{
+  return hook_call (mpls_route_change, cmd, lsp);
+}
+/**
+ * This function is called on mpls_route_change hook_call in case no
+ * distributed dataplane module is enabled (and can be called by the module too)
+ */
+int
+mpls_route_change (int cmd, zebra_lsp_t *lsp)
 {
   mpls_lse_t lse;
   zebra_nhlfe_t *nhlfe;

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -24,14 +24,19 @@
 
 #ifdef HAVE_NETLINK
 
+#include "hook.h"
 #include "zebra/zebra_mpls.h"
 
 #define NL_DEFAULT_ROUTE_METRIC 20
+
+DECLARE_HOOK (mpls_route_change, (int cmd, zebra_lsp_t *lsp), (cmd, lsp))
 
 extern void
 clear_nhlfe_installed (zebra_lsp_t *lsp);
 extern int
 netlink_mpls_multipath (int cmd, zebra_lsp_t *lsp);
+
+extern int mpls_route_change (int cmd, zebra_lsp_t *lsp);
 
 extern int netlink_route_change (struct sockaddr_nl *snl, struct nlmsghdr *h,
                                  ns_id_t ns_id, int startup);

--- a/zebra/zebra_dataplane.c
+++ b/zebra/zebra_dataplane.c
@@ -1,0 +1,26 @@
+#include "zebra.h"
+#include "if.h"
+#include "ioctl.h"
+#include "version.h"
+#include "zserv.h"
+#include "rt_netlink.h"
+#include "interface.h"
+#include "hook.h"
+#include "module.h"
+
+#include "zebra_dataplane.h"
+
+int
+init_default_dataplane (void)
+{
+  hook_register (address_change, address_change);
+
+  hook_register (route_change, route_change);
+  hook_register (rib_process_after, rib_process_after);
+
+  hook_register (mpls_route_change, mpls_route_change);
+  /* not needed */
+  /* hook_register (pw_change, pw_change); */
+
+  return 0;
+}

--- a/zebra/zebra_dataplane.h
+++ b/zebra/zebra_dataplane.h
@@ -1,0 +1,6 @@
+#ifndef ZEBRA_DATAPLANE_H_
+#define ZEBRA_DATAPLANE_H_
+
+int init_default_dataplane (void);
+
+#endif /* ZEBRA_DATAPLANE_H_ */

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -90,10 +90,6 @@ static int
 nhlfe_nhop_match (zebra_nhlfe_t *nhlfe, enum nexthop_types_t gtype,
                   union g_addr *gate, char *ifname, ifindex_t ifindex);
 static zebra_nhlfe_t *
-nhlfe_find (zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
-            enum nexthop_types_t gtype, union g_addr *gate,
-            char *ifname, ifindex_t ifindex);
-static zebra_nhlfe_t *
 nhlfe_add (zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
            enum nexthop_types_t gtype, union g_addr *gate,
            char *ifname, ifindex_t ifindex, mpls_label_t out_label);
@@ -641,7 +637,7 @@ nhlfe_nhop_match (zebra_nhlfe_t *nhlfe, enum nexthop_types_t gtype,
 /*
  * Locate NHLFE that matches with passed info.
  */
-static zebra_nhlfe_t *
+zebra_nhlfe_t *
 nhlfe_find (zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
             enum nexthop_types_t gtype, union g_addr *gate,
             char *ifname, ifindex_t ifindex)
@@ -961,7 +957,7 @@ lsp_json (zebra_lsp_t *lsp)
 
 
 /* Return a sorted linked list of the hash contents */
-static struct list *
+struct list *
 hash_get_sorted_list (struct hash *hash, void *cmp)
 {
   unsigned int i;
@@ -980,7 +976,7 @@ hash_get_sorted_list (struct hash *hash, void *cmp)
 /*
  * Compare two LSPs based on their label values.
  */
-static int
+int
 lsp_cmp (zebra_lsp_t *lsp1, zebra_lsp_t *lsp2)
 {
   if (lsp1->ile.in_label < lsp2->ile.in_label)
@@ -1936,11 +1932,13 @@ zebra_mpls_init_tables (struct zebra_vrf *zvrf)
 void
 zebra_mpls_init (void)
 {
+#if !defined(HAVE_DISTRIBUTED_DATAPLANE)
   if (mpls_kernel_init () < 0)
     {
       zlog_warn ("Disabling MPLS support (no kernel support)");
       return;
     }
+#endif
 
   mpls_enabled = 1;
   mpls_processq_init (&zebrad);

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -151,6 +151,23 @@ struct zebra_lsp_t_
 /* Function declarations. */
 
 /*
+ * Locate NHLFE that matches with passed info.
+ */
+zebra_nhlfe_t *
+nhlfe_find (zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
+            enum nexthop_types_t gtype, union g_addr *gate,
+            char *ifname, ifindex_t ifindex);
+
+/* Return a sorted linked list of the hash contents */
+struct list *
+hash_get_sorted_list (struct hash *hash, void *cmp);
+/*
+ * Compare two LSPs based on their label values.
+ */
+int
+lsp_cmp (zebra_lsp_t *lsp1, zebra_lsp_t *lsp2);
+
+/*
  * String to label conversion, labels separated by '/'.
  */
 int

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -1,0 +1,164 @@
+/* Zebra PW code
+ * Copyright (C) 2016 Volta Networks, Inc.
+ *
+ * This file is part of GNU Zebra.
+ *
+ * GNU Zebra is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * GNU Zebra is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Zebra; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+
+#include <zebra.h>
+
+#include "log.h"
+#include "memory.h"
+#include "workqueue.h"
+#include "zserv.h"
+
+#include "zebra_pw.h"
+
+DEFINE_MTYPE_STATIC(LIB, PW, "Pseudowire")
+
+DEFINE_HOOK(pw_change, (struct zebra_pw_t *pw), (pw))
+
+extern struct zebra_t zebrad;
+
+struct zebra_pw_t *
+pw_add (void)
+{
+  return XCALLOC (MTYPE_PW, sizeof (struct zebra_pw_t));
+}
+
+void
+pw_del (struct zebra_pw_t *pw)
+{
+  XFREE (MTYPE_PW, pw);
+}
+
+/**
+ * Add PW to work queue
+ *
+ * @param pw Pseudowire to enqueue
+ */
+void
+pw_queue_add (struct zebra_pw_t *pw)
+{
+  assert (pw);
+
+  /* If already scheduled, exit. */
+  if (CHECK_FLAG (pw->queue_flags, PW_FLAG_SCHEDULED))
+    return;
+
+  work_queue_add (zebrad.pwq, pw);
+  SET_FLAG (pw->queue_flags, PW_FLAG_SCHEDULED);
+
+}
+/**
+ * Call on completion of a PseudWire processing.
+ *
+ * @param wq Workqueue
+ * @param data The pseudowire to be removed
+ */
+static void
+pw_queue_del (struct work_queue *wq, void *data)
+{
+  struct zebra_pw_t *pw;
+
+  pw = (struct zebra_pw_t *)data;
+  XFREE (MTYPE_PW, pw);
+
+}
+/**
+ * Remove PWs from workqueue.
+ *
+ * It actually sets the ran counter over the max, so it will be
+ * deleted on next iteration
+ *
+ * @param pw Pseudowire to be removed from queue
+ */
+void
+unqueue_pw (struct zebra_pw_t *pw)
+{
+  struct work_queue *wq;
+  struct work_queue_item *item;
+  struct listnode *node, *nnode;
+  struct zebra_pw_t *item_pw;
+
+  wq = zebrad.pwq;
+
+  for (ALL_LIST_ELEMENTS (wq->items, node, nnode, item))
+    {
+      item_pw = (struct zebra_pw_t *)item->data;
+      if (item_pw->cmd != pw->cmd)
+        continue;
+      if (strncmp (item_pw->ifname, pw->ifname, IF_NAMESIZE) != 0)
+        continue;
+      if (item_pw->pwid != pw->pwid)
+        continue;
+      if (strncmp(item_pw->vpn_name, pw->vpn_name, L2VPN_NAME_LEN) != 0)
+        continue;
+      item->ran = PW_MAX_RETRIES + 1;
+    }
+
+}
+
+/**
+ * Process a PsuedoWire that is in the queue
+ * Send it to External Manager
+ *
+ * @param wq PW work queue
+ * @param data The PW itself
+ */
+static wq_item_status
+pw_process (struct work_queue *wq, void *data)
+{
+  struct zebra_pw_t *pw;
+  int ret;
+
+  pw = (struct zebra_pw_t *) data;
+  ret = hook_call (pw_change, pw);
+
+  if (ret != 0)
+    return WQ_RETRY_LATER;
+
+  return WQ_SUCCESS;
+
+}
+static void
+pw_queue_init (struct zebra_t *zebra)
+{
+  assert (zebra);
+
+  if (! (zebra->pwq = work_queue_new (zebra->master,
+                                      "Pseudowire processing")))
+    {
+      zlog_err ("%s: could not initialize work queue!", __func__);
+      return;
+    }
+
+  /* fill in the work queue spec */
+  zebra->pwq->spec.workfunc = &pw_process;
+  zebra->pwq->spec.del_item_data = &pw_queue_del;
+  zebra->pwq->spec.errorfunc = NULL;
+  zebra->pwq->spec.max_retries = PW_MAX_RETRIES;
+  zebra->pwq->spec.hold = PW_PROCESS_HOLD_TIME;
+
+  return;
+}
+
+void
+zebra_pw_init (void)
+{
+  pw_queue_init (&zebrad);
+}

--- a/zebra/zebra_pw.h
+++ b/zebra/zebra_pw.h
@@ -1,0 +1,51 @@
+#ifndef ZEBRA_PW_H_
+#define ZEBRA_PW_H_
+
+#include <net/if.h>
+#include <netinet/in.h>
+
+#define PW_PROCESS_HOLD_TIME 10
+#define PW_MAX_RETRIES 3
+
+#define PW_SET 1
+#define PW_UNSET 2
+
+#define PW_STATUS_DOWN 0
+#define PW_STATUS_UP 1
+
+#define L2VPN_NAME_LEN 32 /* must be synced with the one in ldpd/ldpd.h */
+
+struct zebra_pw_t
+{
+	int cmd; /* set or unset */
+	char ifname[IF_NAMESIZE];
+	unsigned short ifindex;
+	int	pw_type;
+	struct in_addr lsr_id;
+	int	af;
+	union {
+		struct in_addr v4;
+		struct in6_addr v6;
+	} nexthop;
+	uint32_t local_label;
+	uint32_t remote_label;
+	uint8_t	flags;
+	uint32_t pwid;
+	char vpn_name[L2VPN_NAME_LEN];
+	unsigned short ac_port_ifindex;
+	/* Work queue flags */
+	u_int32_t queue_flags;
+#define PW_FLAG_SCHEDULED        (1 << 0)
+#define PW_FLAG_INSTALLED        (1 << 1)
+#define PW_FLAG_CHANGED          (1 << 2)
+};
+
+DECLARE_HOOK(pw_change, (struct zebra_pw_t *pw), (pw))
+
+struct zebra_pw_t *pw_add (void);
+void pw_del (struct zebra_pw_t *pw);
+void pw_queue_add (struct zebra_pw_t *pw);
+void unqueue_pw (struct zebra_pw_t *pw);
+void zebra_pw_init (void);
+
+#endif /* ZEBRA_PW_H_ */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -31,6 +31,8 @@
 #include "zclient.h"
 
 #include "zebra/zebra_ns.h"
+#include "zebra_pw.h"
+
 /* Default port information. */
 #define ZEBRA_VTY_PORT                2601
 
@@ -134,6 +136,9 @@ struct zebra_t
 
   /* LSP work queue */
   struct work_queue *lsp_process_q;
+
+  /* PseudoWire work queue */
+  struct work_queue *pwq;
 };
 extern struct zebra_t zebrad;
 extern unsigned int multipath_num;
@@ -170,6 +175,8 @@ extern int zsend_interface_vrf_update (struct zserv *, struct interface *,
                                        vrf_id_t);
 
 extern int zsend_interface_link_params (struct zserv *, struct interface *);
+extern int zsend_pw_update (int cmd, struct zserv *client, struct zebra_pw_t *pw,
+                 u_short status, vrf_id_t vrf_id);
 
 extern pid_t pid;
 


### PR DESCRIPTION
Using the recently added feature to allow loading modules dynamically
with dlopen, a few hooks are added to be able to have a remote
dataplane. In particular, control is outsourced for:

- Add and delete IP addresses.
- Add and delete IP routes.
- Add and delete MPLS routes.
- Add and delete Pseudowires.

If an external module is enabled, installation of routes is held in Zebra and the module is responsible for it.

A new command line parameter, --dp-opts, is added to be able to tweak
module execution. It's up to the module to parse and use content passed
into it.

Besides, support for ZMQ communication is added to FRR thread library.

Signed-off-by: ßingen <bingen@voltanet.io>