### PR TITLE
lib: fix access to stack value

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -613,6 +613,7 @@ thread_get (struct thread_master *m, u_char type,
   thread->arg = arg;
   thread->index = -1;
   thread->yield = THREAD_YIELD_TIME_SLOT; /* default */
+  thread->ref = NULL;
 
   /*
    * So if the passed in funcname is not what we have
@@ -829,12 +830,12 @@ funcname_thread_add_read_write (int dir, struct thread_master *m,
             thread_add_fd (m->write, thread);
         }
         pthread_mutex_unlock (&thread->mtx);
-      }
 
-    if (t_ptr)
-      {
-        *t_ptr = thread;
-        thread->ref = t_ptr;
+        if (t_ptr)
+          {
+            *t_ptr = thread;
+            thread->ref = t_ptr;
+          }
       }
   }
   pthread_mutex_unlock (&m->mtx);
@@ -869,14 +870,13 @@ funcname_thread_add_timer_timeval (struct thread_master *m,
       monotime(&thread->u.sands);
       timeradd(&thread->u.sands, time_relative, &thread->u.sands);
       pqueue_enqueue(thread, queue);
+      if (t_ptr)
+        {
+          *t_ptr = thread;
+          thread->ref = t_ptr;
+        }
     }
     pthread_mutex_unlock (&thread->mtx);
-
-    if (t_ptr)
-      {
-        *t_ptr = thread;
-        thread->ref = t_ptr;
-      }
   }
   pthread_mutex_unlock (&m->mtx);
 }

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2613,20 +2613,18 @@ static struct thread_master *vty_master;
 static void
 vty_event (enum event event, int sock, struct vty *vty)
 {
-  struct thread *vty_serv_thread;
-
   switch (event)
     {
     case VTY_SERV:
-      vty_serv_thread = NULL;
-      thread_add_read(vty_master, vty_accept, vty, sock, &vty_serv_thread);
-      vector_set_index (Vvty_serv_thread, sock, vty_serv_thread);
+      vector_set_index (Vvty_serv_thread, sock, NULL);
+      thread_add_read(vty_master, vty_accept, vty, sock,
+                      (struct thread **) &Vvty_serv_thread->index[sock]);
       break;
 #ifdef VTYSH
     case VTYSH_SERV:
-      vty_serv_thread = NULL;
-      thread_add_read(vty_master, vtysh_accept, vty, sock, &vty_serv_thread);
-      vector_set_index (Vvty_serv_thread, sock, vty_serv_thread);
+      vector_set_index (Vvty_serv_thread, sock, NULL);
+      thread_add_read(vty_master, vtysh_accept, vty, sock,
+                      (struct thread **) &Vvty_serv_thread->index[sock]);
       break;
     case VTYSH_READ:
       vty->t_read = NULL;


### PR DESCRIPTION
Passing stack value to thread_add_* causes thread->ref to become an
invalid pointer when the value goes out of scope

fixes #529 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>