### PR TITLE
lib: parser: remove forgotten line

### DIFF
--- a/lib/command_graph.c
+++ b/lib/command_graph.c
@@ -26,8 +26,6 @@
 
 #include "command_graph.h"
 
-DECLARE_MTYPE(CMD_TOKEN_DATA)
-
 DEFINE_MTYPE_STATIC(LIB, CMD_TOKENS, "Command Tokens")
 DEFINE_MTYPE_STATIC(LIB, CMD_DESC,   "Command Token Text")
 DEFINE_MTYPE_STATIC(LIB, CMD_TEXT,   "Command Token Help")


### PR DESCRIPTION
MTYPE_CMD_TOKEN_DATA isn't used anymore, I forgot to ditch the line.

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>