### PR TITLE
bgpd: added bgp_nexthop_afi()

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2817,17 +2817,6 @@ bgp_packet_mpattr_start (struct stream *s, struct peer *peer,
   safi_t pkt_safi;
   afi_t nh_afi;
 
-  if (peer_cap_enhe(peer, afi, safi)) {
-    nh_afi = AFI_IP6;
-  } else {
-    if (afi == AFI_L2VPN)
-      nh_afi = AFI_L2VPN;
-    else if (safi == SAFI_LABELED_UNICAST)
-      nh_afi = afi;
-    else
-      nh_afi = BGP_NEXTHOP_AFI_FROM_NHLEN(attr->extra->mp_nexthop_len);
-  }
-
   /* Set extended bit always to encode the attribute length as 2 bytes */
   stream_putc (s, BGP_ATTR_FLAG_OPTIONAL|BGP_ATTR_FLAG_EXTLEN);
   stream_putc (s, BGP_ATTR_MP_REACH_NLRI);
@@ -2840,6 +2829,18 @@ bgp_packet_mpattr_start (struct stream *s, struct peer *peer,
 
   stream_putw (s, pkt_afi);    /* AFI */
   stream_putc (s, pkt_safi);   /* SAFI */
+
+  /* Nexthop AFI */
+  if (peer_cap_enhe(peer, afi, safi)) {
+    nh_afi = AFI_IP6;
+  } else {
+    if (afi == AFI_L2VPN)
+      nh_afi = AFI_L2VPN;
+    else if (safi == SAFI_LABELED_UNICAST)
+      nh_afi = afi;
+    else
+      nh_afi = BGP_NEXTHOP_AFI_FROM_NHLEN(attr->extra->mp_nexthop_len);
+  }
 
   /* Nexthop */
   switch (nh_afi)
@@ -3107,7 +3108,6 @@ bgp_packet_mpattr_end (struct stream *s, size_t sizep)
      the attr length */
   stream_putw_at (s, sizep, (stream_get_endp (s) - sizep) - 2);
 }
-
 
 /* Make attribute packet. */
 bgp_size_t

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -249,6 +249,8 @@ extern struct attr *bgp_attr_default_set (struct attr *attr, u_char);
 extern struct attr *bgp_attr_aggregate_intern (struct bgp *, u_char,
                                         struct aspath *, 
                                         struct community *, int as_set, u_char);
+extern afi_t bgp_nexthop_afi (struct peer *peer, afi_t afi, safi_t safi,
+                              struct attr *attr);
 extern bgp_size_t bgp_packet_attribute (struct bgp *bgp, struct peer *,
 					struct stream *, struct attr *,
 					struct bpacket_attr_vec_arr *vecarr,

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -299,8 +299,8 @@ bgp_attr_flush_encap(struct attr *attr);
  * one for each NLRI that needs to be encoded into the UPDATE message, and
  * finally the _end() function.
  */
-extern size_t bgp_packet_mpattr_start(struct stream *s, afi_t afi, safi_t safi,
-                                      afi_t nh_afi,
+extern size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer,
+                                      afi_t afi, safi_t safi,
                                       struct bpacket_attr_vec_arr *vecarr,
 				      struct attr *attr);
 extern void bgp_packet_mpattr_prefix(struct stream *s, afi_t afi, safi_t safi,

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -656,7 +656,6 @@ subgroup_update_packet (struct update_subgroup *subgrp)
   u_int32_t addpath_tx_id = 0;
   struct prefix_rd *prd = NULL;
   char label_buf[20];
-  afi_t nh_afi;
 
   if (!subgrp)
     return NULL;
@@ -768,11 +767,9 @@ subgroup_update_packet (struct update_subgroup *subgrp)
           if (bgp_labeled_safi(safi))
             sprintf (label_buf, "label %u", label_pton(tag));
 
-	  if (stream_empty (snlri)) {
-            nh_afi = bgp_nexthop_afi(peer, afi, safi, adv->baa->attr);
-            mpattrlen_pos = bgp_packet_mpattr_start (snlri, afi, safi, nh_afi,
+	  if (stream_empty (snlri))
+            mpattrlen_pos = bgp_packet_mpattr_start (snlri, peer, afi, safi,
                                                      &vecarr, adv->baa->attr);
-          }
 
           bgp_packet_mpattr_prefix (snlri, afi, safi, &rn->p, prd,
                                     tag, addpath_encode, addpath_tx_id, adv->baa->attr);

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -656,6 +656,7 @@ subgroup_update_packet (struct update_subgroup *subgrp)
   u_int32_t addpath_tx_id = 0;
   struct prefix_rd *prd = NULL;
   char label_buf[20];
+  afi_t nh_afi;
 
   if (!subgrp)
     return NULL;
@@ -767,11 +768,11 @@ subgroup_update_packet (struct update_subgroup *subgrp)
           if (bgp_labeled_safi(safi))
             sprintf (label_buf, "label %u", label_pton(tag));
 
-	  if (stream_empty (snlri))
-	    mpattrlen_pos = bgp_packet_mpattr_start (snlri, afi, safi,
-                                                     (peer_cap_enhe(peer, afi, safi) ? AFI_IP6 :
-                                                      AFI_MAX), /* get from NH */
+	  if (stream_empty (snlri)) {
+            nh_afi = bgp_nexthop_afi(peer, afi, safi, adv->baa->attr);
+            mpattrlen_pos = bgp_packet_mpattr_start (snlri, afi, safi, nh_afi,
                                                      &vecarr, adv->baa->attr);
+          }
 
           bgp_packet_mpattr_prefix (snlri, afi, safi, &rn->p, prd,
                                     tag, addpath_encode, addpath_tx_id, adv->baa->attr);


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

Added bgp_nexthop_afi() to have one place that determines what the
Nexthop AFI is for bgp_packet_mpattr_start()