### PR TITLE
lib: return thread * from thread_add*

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -777,7 +777,7 @@ fd_clear_read_write (struct thread *thread)
 }
 
 /* Add new read thread. */
-void
+struct thread *
 funcname_thread_add_read_write (int dir, struct thread_master *m,
         int (*func) (struct thread *), void *arg, int fd, struct thread **t_ptr,
         debugargdef)
@@ -789,7 +789,7 @@ funcname_thread_add_read_write (int dir, struct thread_master *m,
     if (t_ptr && *t_ptr) // thread is already scheduled; don't reschedule
       {
         pthread_mutex_unlock (&m->mtx);
-        return;
+        return NULL;
       }
 
 #if defined (HAVE_POLL_CALL)
@@ -839,9 +839,11 @@ funcname_thread_add_read_write (int dir, struct thread_master *m,
       }
   }
   pthread_mutex_unlock (&m->mtx);
+
+  return thread;
 }
 
-static void
+static struct thread *
 funcname_thread_add_timer_timeval (struct thread_master *m,
          int (*func) (struct thread *), int type, void *arg,
          struct timeval *time_relative, struct thread **t_ptr, debugargdef)
@@ -859,7 +861,7 @@ funcname_thread_add_timer_timeval (struct thread_master *m,
     if (t_ptr && *t_ptr) // thread is already scheduled; don't reschedule
       {
         pthread_mutex_unlock (&m->mtx);
-        return;
+        return NULL;
       }
 
     queue = ((type == THREAD_TIMER) ? m->timer : m->background);
@@ -879,11 +881,13 @@ funcname_thread_add_timer_timeval (struct thread_master *m,
     pthread_mutex_unlock (&thread->mtx);
   }
   pthread_mutex_unlock (&m->mtx);
+
+  return thread;
 }
 
 
 /* Add timer event thread. */
-void
+struct thread *
 funcname_thread_add_timer (struct thread_master *m,
         int (*func) (struct thread *), void *arg, long timer,
         struct thread **t_ptr, debugargdef)
@@ -900,7 +904,7 @@ funcname_thread_add_timer (struct thread_master *m,
 }
 
 /* Add timer event thread with "millisecond" resolution */
-void
+struct thread *
 funcname_thread_add_timer_msec (struct thread_master *m,
         int (*func) (struct thread *), void *arg, long timer,
         struct thread **t_ptr, debugargdef)
@@ -912,22 +916,22 @@ funcname_thread_add_timer_msec (struct thread_master *m,
   trel.tv_sec = timer / 1000;
   trel.tv_usec = 1000*(timer % 1000);
 
-  funcname_thread_add_timer_timeval (m, func, THREAD_TIMER, arg, &trel,
-                                     t_ptr, debugargpass);
+  return funcname_thread_add_timer_timeval (m, func, THREAD_TIMER, arg, &trel,
+                                            t_ptr, debugargpass);
 }
 
 /* Add timer event thread with "millisecond" resolution */
-void
+struct thread *
 funcname_thread_add_timer_tv (struct thread_master *m,
         int (*func) (struct thread *), void *arg, struct timeval *tv,
         struct thread **t_ptr, debugargdef)
 {
-  funcname_thread_add_timer_timeval (m, func, THREAD_TIMER, arg, tv, t_ptr,
-                                     debugargpass);
+  return funcname_thread_add_timer_timeval (m, func, THREAD_TIMER, arg, tv,
+                                            t_ptr, debugargpass);
 }
 
 /* Add a background thread, with an optional millisec delay */
-void
+struct thread *
 funcname_thread_add_background (struct thread_master *m,
         int (*func) (struct thread *), void *arg, long delay,
         struct thread **t_ptr, debugargdef)
@@ -947,12 +951,12 @@ funcname_thread_add_background (struct thread_master *m,
       trel.tv_usec = 0;
     }
 
-  funcname_thread_add_timer_timeval (m, func, THREAD_BACKGROUND, arg, &trel,
-                                     t_ptr, debugargpass);
+  return funcname_thread_add_timer_timeval (m, func, THREAD_BACKGROUND, arg, &trel,
+                                            t_ptr, debugargpass);
 }
 
 /* Add simple event thread. */
-void
+struct thread *
 funcname_thread_add_event (struct thread_master *m,
         int (*func) (struct thread *), void *arg, int val,
         struct thread **t_ptr, debugargdef)
@@ -966,7 +970,7 @@ funcname_thread_add_event (struct thread_master *m,
     if (t_ptr && *t_ptr) // thread is already scheduled; don't reschedule
       {
         pthread_mutex_unlock (&m->mtx);
-        return;
+        return NULL;
       }
 
     thread = thread_get (m, THREAD_EVENT, func, arg, debugargpass);
@@ -984,6 +988,8 @@ funcname_thread_add_event (struct thread_master *m,
       }
   }
   pthread_mutex_unlock (&m->mtx);
+
+  return thread;
 }
 
 static void

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -185,22 +185,22 @@ extern struct thread_master *thread_master_create (void);
 extern void thread_master_free (struct thread_master *);
 extern void thread_master_free_unused(struct thread_master *);
 
-extern void funcname_thread_add_read_write (int dir, struct thread_master *,
+extern struct thread * funcname_thread_add_read_write (int dir, struct thread_master *,
     int (*)(struct thread *), void *, int, struct thread **, debugargdef);
 
-extern void funcname_thread_add_timer (struct thread_master *,
+extern struct thread * funcname_thread_add_timer (struct thread_master *,
     int (*)(struct thread *), void *, long, struct thread **, debugargdef);
 
-extern void funcname_thread_add_timer_msec (struct thread_master *,
+extern struct thread * funcname_thread_add_timer_msec (struct thread_master *,
     int (*)(struct thread *), void *, long, struct thread **, debugargdef);
 
-extern void funcname_thread_add_timer_tv (struct thread_master *,
+extern struct thread * funcname_thread_add_timer_tv (struct thread_master *,
     int (*)(struct thread *), void *, struct timeval *, struct thread **, debugargdef);
 
-extern void funcname_thread_add_event (struct thread_master *,
+extern struct thread * funcname_thread_add_event (struct thread_master *,
     int (*)(struct thread *), void *, int, struct thread **, debugargdef);
 
-extern void funcname_thread_add_background (struct thread_master *,
+extern struct thread * funcname_thread_add_background (struct thread_master *,
     int (*)(struct thread *), void *, long, struct thread **, debugargdef);
 
 extern void funcname_thread_execute (struct thread_master *,

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2633,18 +2633,18 @@ static struct thread_master *vty_master;
 static void
 vty_event (enum event event, int sock, struct vty *vty)
 {
+  struct thread *vty_serv_thread = NULL;
+
   switch (event)
     {
     case VTY_SERV:
-      vector_set_index (Vvty_serv_thread, sock, NULL);
-      thread_add_read(vty_master, vty_accept, vty, sock,
-                      (struct thread **) &Vvty_serv_thread->index[sock]);
+      vty_serv_thread = thread_add_read(vty_master, vty_accept, vty, sock, NULL);
+      vector_set_index (Vvty_serv_thread, sock, vty_serv_thread);
       break;
 #ifdef VTYSH
     case VTYSH_SERV:
-      vector_set_index (Vvty_serv_thread, sock, NULL);
-      thread_add_read(vty_master, vtysh_accept, vty, sock,
-                      (struct thread **) &Vvty_serv_thread->index[sock]);
+      vty_serv_thread = thread_add_read(vty_master, vtysh_accept, vty, sock, NULL);
+      vector_set_index (Vvty_serv_thread, sock, vty_serv_thread);
       break;
     case VTYSH_READ:
       vty->t_read = NULL;


### PR DESCRIPTION
in case callers want to manually manage their pointer lifecycles

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>