### PR TITLE
Arm

### DIFF
--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -313,7 +313,7 @@ show_ip_eigrp_prefix_entry (struct vty *vty, struct eigrp_prefix_entry *tn)
   vty_out (vty, "%-3c",(tn->state > 0) ? 'A' : 'P');
   vty_out (vty, "%s/%u, ",inet_ntoa (tn->destination_ipv4->prefix),tn->destination_ipv4->prefixlen);
   vty_out (vty, "%u successors, ",eigrp_topology_get_successor(tn)->count);
-  vty_out (vty, "FD is %u, serno: %lu %s",tn->fdistance, tn->serno, VTY_NEWLINE);
+  vty_out (vty, "FD is %u, serno: %" PRIu64 " %s",tn->fdistance, tn->serno, VTY_NEWLINE);
 }
 
 void

--- a/lib/command.c
+++ b/lib/command.c
@@ -324,6 +324,7 @@ install_element (enum node_type ntype, struct cmd_element *cmd)
     {
       fprintf (stderr, "Command node %d doesn't exist, please check it\n",
                ntype);
+      fprintf (stderr, "Have you called install_node before this install_element?\n");
       exit (EXIT_FAILURE);
     }
 
@@ -371,6 +372,7 @@ uninstall_element (enum node_type ntype, struct cmd_element *cmd)
     {
       fprintf (stderr, "Command node %d doesn't exist, please check it\n",
                ntype);
+      fprintf (stderr, "Have you called install_node before this install_element?\n");
       exit (EXIT_FAILURE);
     }
 


### PR DESCRIPTION
Fix up a compile issue with -werror on arm platforms and gcc

Add a bread (hopefully) better breadcrumb for when install_element fails because of install_node not being called.