### PR TITLE
bgpd: resolve issue with sending vpn labels

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -763,7 +763,13 @@ subgroup_update_packet (struct update_subgroup *subgrp)
 
 	  if (rn->prn)
 	    prd = (struct prefix_rd *) &rn->prn->p;
-          tag = bgp_adv_label(rn, binfo, peer, afi, safi);
+
+          if (safi == SAFI_LABELED_UNICAST)
+            tag = bgp_adv_label(rn, binfo, peer, afi, safi);
+          else
+            if (binfo && binfo->extra)
+              tag = binfo->extra->tag;
+
           if (bgp_labeled_safi(safi))
             sprintf (label_buf, "label %u", label_pton(tag));
 


### PR DESCRIPTION
Found issue where sending labels using "address-family ipv4 vpn" was
broken by the labeled-unicast changes.

Before with label value 0:
Route Distinguisher: 4.4.4.4:4
*>i4.4.4.4/32       ::         0    100      0 i
    UN=:: label=0 type=bgp, subtype=0

After with correct label value:
Route Distinguisher: 4.4.4.4:4
*>i4.4.4.4/32       ::         0    100      0 i
    UN=:: label=4000 type=bgp, subtype=0

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>