### PR TITLE
pimd: Fix core from json static mroute show

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3274,7 +3274,7 @@ static void show_mroute(struct vty *vty, u_char uj)
         json_object_string_add(json_ifp_out, "group", grp_str);
         json_object_boolean_true_add(json_ifp_out, "protocolStatic");
         json_object_string_add(json_ifp_out, "inboundInterface", in_ifname);
-        json_object_int_add(json_ifp_out, "iVifI", c_oil->oil.mfcc_parent);
+        json_object_int_add(json_ifp_out, "iVifI", s_route->c_oil.oil.mfcc_parent);
         json_object_string_add(json_ifp_out, "outboundInterface", out_ifname);
         json_object_int_add(json_ifp_out, "oVifI", oif_vif_index);
         json_object_int_add(json_ifp_out, "ttl", ttl);


### PR DESCRIPTION
When we have no normal mroutes and only static mroutes
there exists a code path where we attempted to dereference
c_oil when we were showing static mroutes.  Looks like
a cut-n-paste error, we should be using s_route->c_oil there

Ticket: CM-15013
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>