### PR TITLE
Pim dev 3 0 defect fixes

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5075,11 +5075,16 @@ DEFUN (interface_ip_pim_hello,
 
   pim_ifp = ifp->info;
 
-  if (!pim_ifp) {
-    vty_out(vty, "Pim not enabled on this interface%s", VTY_NEWLINE);
-    return CMD_WARNING;
-  }
+  if (!pim_ifp)
+    {
+      if (!pim_cmd_interface_add(ifp))
+        {
+          vty_out(vty, "Could not enable PIM SM on interface%s", VTY_NEWLINE);
+          return CMD_WARNING;
+        }
+    }
 
+  pim_ifp = ifp->info;
   pim_ifp->pim_hello_period = strtol(argv[idx_time]->arg, NULL, 10);
 
   if (argc == idx_hold + 1)

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -583,7 +583,7 @@ pim_ifchannel_add(struct interface *ifp,
   return ch;
 }
 
-static void ifjoin_to_noinfo(struct pim_ifchannel *ch, uint8_t ch_del)
+static void ifjoin_to_noinfo(struct pim_ifchannel *ch, bool ch_del)
 {
   pim_forward_stop(ch);
   pim_ifchannel_ifjoin_switch(__PRETTY_FUNCTION__, ch, PIM_IFJOIN_NOINFO);
@@ -599,7 +599,7 @@ static int on_ifjoin_expiry_timer(struct thread *t)
 
   ch->t_ifjoin_expiry_timer = NULL;
 
-  ifjoin_to_noinfo(ch, 1);
+  ifjoin_to_noinfo(ch, true);
   /* ch may have been deleted */
 
   return 0;
@@ -643,10 +643,10 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
               ch_del is set to 0 for not deleteing from here.
               Holdtime expiry (ch_del set to 1) delete the entry.
             */
-            ifjoin_to_noinfo(ch, 0);
+            ifjoin_to_noinfo(ch, false);
         }
       else
-        ifjoin_to_noinfo(ch, 1);
+        ifjoin_to_noinfo(ch, true);
         /* from here ch may have been deleted */
     }
   else

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -148,7 +148,6 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
       /* SGRpt entry could have empty oil */
       if (ch->upstream->channel_oil)
         pim_channel_del_oif (ch->upstream->channel_oil, ch->interface, mask);
-      pim_channel_del_oif (ch->upstream->channel_oil, ch->interface, mask);
       /*
        * Do we have any S,G's that are inheriting?
        * Nuke from on high too.
@@ -179,6 +178,10 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
     pim_upstream_update_join_desired(ch->upstream);
   }
 
+  /* upstream is common across ifchannels, check if upstream's
+     ifchannel list is empty before deleting upstream_del
+     ref count will take care of it.
+  */
   pim_upstream_del(ch->upstream, __PRETTY_FUNCTION__);
   ch->upstream = NULL;
 
@@ -199,6 +202,9 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
   listnode_delete(pim_ifp->pim_ifchannel_list, ch);
   hash_release(pim_ifp->pim_ifchannel_hash, ch);
   listnode_delete(pim_ifchannel_list, ch);
+
+  if (PIM_DEBUG_PIM_TRACE)
+    zlog_debug ("%s: ifchannel entry %s is deleted ", __PRETTY_FUNCTION__, ch->sg_str);
 
   pim_ifchannel_free(ch);
 }
@@ -571,14 +577,18 @@ pim_ifchannel_add(struct interface *ifp,
 
   listnode_add_sort(up->ifchannels, ch);
 
+  if (PIM_DEBUG_PIM_TRACE)
+    zlog_debug ("%s: ifchannel %s is created ", __PRETTY_FUNCTION__, ch->sg_str);
+
   return ch;
 }
 
-static void ifjoin_to_noinfo(struct pim_ifchannel *ch)
+static void ifjoin_to_noinfo(struct pim_ifchannel *ch, uint8_t ch_del)
 {
   pim_forward_stop(ch);
   pim_ifchannel_ifjoin_switch(__PRETTY_FUNCTION__, ch, PIM_IFJOIN_NOINFO);
-  delete_on_noinfo(ch);
+  if (ch_del)
+    delete_on_noinfo(ch);
 }
 
 static int on_ifjoin_expiry_timer(struct thread *t)
@@ -589,7 +599,7 @@ static int on_ifjoin_expiry_timer(struct thread *t)
 
   ch->t_ifjoin_expiry_timer = NULL;
 
-  ifjoin_to_noinfo(ch);
+  ifjoin_to_noinfo(ch, 1);
   /* ch may have been deleted */
 
   return 0;
@@ -613,10 +623,6 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
       pim_ifp = ifp->info;
       send_prune_echo = (listcount(pim_ifp->pim_neighbor_list) > 1);
 
-      //ch->ifjoin_state transition to NOINFO
-      ifjoin_to_noinfo(ch);
-      /* from here ch may have been deleted */
-
       if (send_prune_echo)
         {
           struct pim_rpf rpf;
@@ -625,6 +631,23 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
           rpf.rpf_addr.u.prefix4 = pim_ifp->primary_address;
           pim_jp_agg_single_upstream_send(&rpf, ch->upstream, 0);
         }
+      /* If SGRpt flag is set on ifchannel, Trigger SGRpt
+         message on RP path upon prune timer expiry.
+      */
+      if (PIM_IF_FLAG_TEST_S_G_RPT (ch->flags))
+        {
+          if (ch->upstream)
+            pim_upstream_update_join_desired(ch->upstream);
+            /*
+              ch->ifjoin_state transition to NOINFO state
+              ch_del is set to 0 for not deleteing from here.
+              Holdtime expiry (ch_del set to 1) delete the entry.
+            */
+            ifjoin_to_noinfo(ch, 0);
+        }
+      else
+        ifjoin_to_noinfo(ch, 1);
+        /* from here ch may have been deleted */
     }
   else
     {
@@ -801,7 +824,7 @@ void pim_ifchannel_join_add(struct interface *ifp,
         (ch->upstream->parent->flags & PIM_UPSTREAM_FLAG_MASK_SRC_IGMP) &&
         !(ch->upstream->flags & PIM_UPSTREAM_FLAG_MASK_SRC_LHR))
       {
-        pim_upstream_ref (ch->upstream, PIM_UPSTREAM_FLAG_MASK_SRC_LHR);
+        pim_upstream_ref (ch->upstream, PIM_UPSTREAM_FLAG_MASK_SRC_LHR, __PRETTY_FUNCTION__);
         pim_upstream_keep_alive_timer_start (ch->upstream, qpim_keep_alive_time);
       }
     break;
@@ -895,8 +918,10 @@ void pim_ifchannel_prune(struct interface *ifp,
   case PIM_IFJOIN_NOINFO:
     if (source_flags & PIM_ENCODE_RPT_BIT)
       {
-	PIM_IF_FLAG_SET_S_G_RPT(ch->flags);
-	ch->ifjoin_state = PIM_IFJOIN_PRUNE_PENDING;
+	if (!(source_flags & PIM_ENCODE_WC_BIT))
+          PIM_IF_FLAG_SET_S_G_RPT(ch->flags);
+
+        ch->ifjoin_state = PIM_IFJOIN_PRUNE_PENDING;
         if (listcount(pim_ifp->pim_neighbor_list) > 1)
           jp_override_interval_msec = pim_if_jp_override_interval_msec(ifp);
         else
@@ -1306,7 +1331,7 @@ pim_ifchannel_set_star_g_join_state (struct pim_ifchannel *ch, int eom, uint8_t 
           if (up)
             {
               if (PIM_DEBUG_TRACE)
-                zlog_debug ("%s: del inherit oif from up %s", __PRETTY_FUNCTION__, up->sg_str);
+                zlog_debug ("%s: SGRpt Set, del inherit oif from up %s", __PRETTY_FUNCTION__, up->sg_str);
               pim_channel_del_oif (up->channel_oil, ch->interface, PIM_OIF_FLAG_PROTO_STAR);
             }
         }

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -39,6 +39,7 @@
 #include "pim_zebra.h"
 
 static void group_timer_off(struct igmp_group *group);
+static int pim_igmp_general_query(struct thread *t);
 
 /* This socket is used for TXing IGMP packets only, IGMP RX happens
  * in pim_mroute_msg()
@@ -172,8 +173,11 @@ static int pim_igmp_other_querier_expire(struct thread *t)
   /*
     We are the current querier, then
     re-start sending general queries.
+    RFC 2236 - sec 7 Other Querier
+    present timer expired (Send General
+    Query, Set Gen. Query. timer)
   */
-  pim_igmp_general_query_on(igmp);
+  pim_igmp_general_query(t);
 
   return 0;
 }
@@ -496,8 +500,6 @@ int pim_igmp_packet(struct igmp_sock *igmp, char *buf, size_t len)
 
   return -1;
 }
-
-static int pim_igmp_general_query(struct thread *t);
 
 void pim_igmp_general_query_on(struct igmp_sock *igmp)
 {

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -567,7 +567,7 @@ pim_ecmp_nexthop_search (struct pim_nexthop_cache *pnc,
       //PIM ECMP flag is enable then choose ECMP path.
       hash_val = pim_compute_ecmp_hash (src, grp);
       mod_val = hash_val % pnc->nexthop_num;
-      if (PIM_DEBUG_TRACE)
+      if (PIM_DEBUG_PIM_TRACE_DETAIL)
         zlog_debug ("%s: hash_val %u mod_val %u ",
                     __PRETTY_FUNCTION__, hash_val, mod_val);
     }
@@ -914,7 +914,7 @@ pim_ecmp_nexthop_lookup (struct pim_nexthop *nexthop, struct in_addr addr,
     {
       hash_val = pim_compute_ecmp_hash (src, grp);
       mod_val = hash_val % num_ifindex;
-      if (PIM_DEBUG_TRACE)
+      if (PIM_DEBUG_PIM_TRACE_DETAIL)
         zlog_debug ("%s: hash_val %u mod_val %u",
                     __PRETTY_FUNCTION__, hash_val, mod_val);
     }
@@ -1037,7 +1037,7 @@ int pim_ecmp_fib_lookup_if_vif_index(struct in_addr addr,
     {
       hash_val = pim_compute_ecmp_hash (src, grp);
       mod_val = hash_val % num_ifindex;
-      if (PIM_DEBUG_TRACE)
+      if (PIM_DEBUG_PIM_TRACE_DETAIL)
         zlog_debug ("%s: hash_val %u mod_val %u",
                     __PRETTY_FUNCTION__, hash_val, mod_val);
     }

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -346,7 +346,7 @@ pim_register_recv (struct interface *ifp,
 	  zlog_debug("%s: Sending register-Stop to %s and dropping mr. packet",
 	    __func__, "Sender");
 	/* Drop Packet Silently */
-	return 1;
+	return 0;
       }
     }
 
@@ -408,5 +408,5 @@ pim_register_recv (struct interface *ifp,
     pim_register_stop_send (ifp, &sg, dest_addr, src_addr);
   }
 
-  return 1;
+  return 0;
 }

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -145,7 +145,7 @@ struct pim_upstream *pim_upstream_find_or_add (struct prefix_sg *sg,
 struct pim_upstream *pim_upstream_add (struct prefix_sg *sg,
 				       struct interface *ifp, int flags,
 				       const char *name);
-void pim_upstream_ref (struct pim_upstream *up, int flags);
+void pim_upstream_ref (struct pim_upstream *up, int flags, const char *name);
 struct pim_upstream *pim_upstream_del(struct pim_upstream *up, const char *name);
 
 int pim_upstream_evaluate_join_desired(struct pim_upstream *up);


### PR DESCRIPTION
1.    Send IGMP General Query and Get Gen. Query timer, once Other Querier timer expired.

2.   - Upon Receving SGRpt Prune message, transitioning from Prune Pending state
    to NOINFO state, ifchannel entry was getting deleted in prune pending timer
    expiry. This can result in SGRpt ifhchannel deleted and recreated upon receving
    triggered or periodic SGRpt received from downstream.
    The automation test failed as it expected (check) SGRpt entry at RP after it triggers
    SPT switchover.
    - While transitioning from Prune-Pending state to NOINFO(Pruned) state, Trigger
    SGRpt message towards RP.
    - Add/del some of the debug traces

