### PR TITLE
lib: enforce thread_cancel() MT-unsafe invariant

### DIFF
--- a/lib/thread.h
+++ b/lib/thread.h
@@ -88,6 +88,7 @@ struct thread_master
   bool spin;
   bool handle_signals;
   pthread_mutex_t mtx;
+  pthread_t owner;
 };
 
 typedef unsigned char thread_type;


### PR DESCRIPTION
Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>