### PR TITLE
vtysh: fix ldpd vtysh

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -324,7 +324,11 @@ vtysh_execute_func (const char *line, int pager)
 	{
 	  vtysh_execute("exit-vnc");
 	}
-      else if ((saved_node == KEYCHAIN_KEY_NODE) && (tried == 1))
+      else if ((saved_node == KEYCHAIN_KEY_NODE
+               || saved_node == LDP_PSEUDOWIRE_NODE
+               || saved_node == LDP_IPV4_IFACE_NODE
+               || saved_node == LDP_IPV6_IFACE_NODE)
+               && (tried == 1))
 	{
 	  vtysh_execute("exit");
 	}


### PR DESCRIPTION
ldpd needs a special case to execute the correct exit command for walkup
when using vtysh

See also: #559 