### PR TITLE
ospf6d: fix decimal area ID cli

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -406,26 +406,11 @@ ospf6_area_show (struct vty *vty, struct ospf6_area *oa)
 }
 
 
-#define OSPF6_CMD_AREA_LOOKUP(str, oa)                     \
-{                                                          \
-  u_int32_t area_id = 0;                                   \
-  if (inet_pton (AF_INET, str, &area_id) != 1)             \
-    {                                                      \
-      vty_out (vty, "Malformed Area-ID: %s%s", str, VNL);  \
-      return CMD_SUCCESS;                                  \
-    }                                                      \
-  oa = ospf6_area_lookup (area_id, ospf6);                 \
-  if (oa == NULL)                                          \
-    {                                                      \
-      vty_out (vty, "No such Area: %s%s", str, VNL);       \
-      return CMD_SUCCESS;                                  \
-    }                                                      \
-}
-
 #define OSPF6_CMD_AREA_GET(str, oa)                        \
 {                                                          \
-  u_int32_t area_id = 0;                                   \
-  if (inet_pton (AF_INET, str, &area_id) != 1)             \
+  char *ep;                                                \
+  u_int32_t area_id = htonl (strtol(str, &ep, 10));        \
+  if (*ep && inet_pton (AF_INET, str, &area_id) != 1)      \
     {                                                      \
       vty_out (vty, "Malformed Area-ID: %s%s", str, VNL);  \
       return CMD_SUCCESS;                                  \


### PR DESCRIPTION
Not all numbers are dotted quads

platforms disagree on inet_pton behavior:

some bsd
```
INTERNET ADDRESSES
     Values specified using the `.' notation take one of the following forms:

           a.b.c.d
           a.b.c
           a.b
           a

     When four parts are specified, each is interpreted as a byte of data and assigned, from left to right, to the four bytes of an Internet address.  Note that when an Internet address is
     viewed as a 32-bit integer quantity on the VAX the bytes referred to above appear as ``d.c.b.a''.  That is, VAX bytes are ordered from right to left.

     When a three part address is specified, the last part is interpreted as a 16-bit quantity and placed in the right-most two bytes of the network address.  This makes the three part
     address format convenient for specifying Class B network addresses as ``128.net.host''.

     When a two part address is supplied, the last part is interpreted as a 24-bit quantity and placed in the right most three bytes of the network address.  This makes the two part address
     format convenient for specifying Class A network addresses as ``net.host''.

     When only one part is given, the value is stored directly in the network address without any byte rearrangement.
```

debian jessie
```
       AF_INET
              src points to a character string containing an IPv4 network address in dotted-decimal format, "ddd.ddd.ddd.ddd", where ddd is a decimal number of up to three digits in the  range  0  to  255.
              The address is converted to a struct in_addr and copied to dst, which must be sizeof(struct in_addr) (4) bytes (32 bits) long.
```

some bsd
```
STANDARDS
     The inet_ntop() and inet_pton() functions conform to IEEE Std 1003.1-2001
     (``POSIX.1'').  Note that inet_pton() does not accept 1-, 2-, or 3-part
     dotted addresses; all four parts must be specified.  Additionally all
     four parts of a dotted address must be decimal.  This is a narrower input
     set than that accepted by inet_aton()
```

this should work for all of them

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>