### PR TITLE
ospf6d: remember format for ospf6 area id

### DIFF
--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -31,6 +31,8 @@ struct ospf6_area
   /* Area-ID */
   u_int32_t area_id;
 
+#define OSPF6_AREA_FMT_DOTTEDQUAD 1
+#define OSPF6_AREA_FMT_DECIMAL    2
   /* Area-ID string */
   char name[16];
 
@@ -115,7 +117,7 @@ struct ospf6_area
 /* prototypes */
 extern int ospf6_area_cmp (void *va, void *vb);
 
-extern struct ospf6_area *ospf6_area_create (u_int32_t, struct ospf6 *);
+extern struct ospf6_area *ospf6_area_create (u_int32_t, struct ospf6 *, int);
 extern void ospf6_area_delete (struct ospf6_area *);
 extern struct ospf6_area *ospf6_area_lookup (u_int32_t, struct ospf6 *);
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -603,7 +603,7 @@ DEFUN (ospf6_interface_area,
   /* find/create ospf6 area */
   oa = ospf6_area_lookup (area_id, o);
   if (oa == NULL)
-    oa = ospf6_area_create (area_id, o);
+    oa = ospf6_area_create (area_id, o, OSPF6_AREA_FMT_DOTTEDQUAD);
 
   /* attach interface to area */
   listnode_add (oa->if_list, oi); /* sort ?? */


### PR DESCRIPTION
If the user enters a decimal, display a decimal.
If the user enters a dotted quad, display a dotted quad.

```
ubuntu-xenial# conf t
ubuntu-xenial(config)# router ospf6
ubuntu-xenial(config-ospf6)# area 22 stub
ubuntu-xenial(config-ospf6)# area 1.2.3.4 stub
ubuntu-xenial(config-ospf6)# area 0.0.0.22 stub
ubuntu-xenial(config-ospf6)# area 22.0.0.0 stub
ubuntu-xenial(config-ospf6)# do sh run
Building configuration...

Current configuration:
!
frr version 3.1-dev-my-manual-build
frr defaults traditional
router zebra
 no redistribute ospf6
!
service integrated-vtysh-config
!
router ospf6
 area 22 stub
 area 1.2.3.4 stub
 area 22.0.0.0 stub
!
line vty
!
end
```

As shown above, note that if a user enters an area command that specifies an area number in a different format but has the same integer value we won't change the display format. I think this is preferable but open to changing it.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>