### PR TITLE
bgpd: Address some issues seen while encoding VPN static routes (Issue #572)  -- V2

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2918,7 +2918,8 @@ bgp_packet_mpattr_tea(
 	case BGP_ATTR_ENCAP:
 	    attrname = "Tunnel Encap";
 	    subtlvs = attr->extra->encap_subtlvs;
-
+            if (subtlvs == NULL) /* nothing to do */
+              return;
 	    /*
 	     * The tunnel encap attr has an "outer" tlv.
 	     * T = tunneltype,
@@ -2933,6 +2934,8 @@ bgp_packet_mpattr_tea(
 	case BGP_ATTR_VNC:
 	    attrname = "VNC";
 	    subtlvs = attr->extra->vnc_subtlvs;
+            if (subtlvs == NULL) /* nothing to do */
+              return;
 	    attrlenfield = 0;     /* no outer T + L */
             attrhdrlen   = 2 + 2; /* subTLV T + L */
 	    break;

--- a/bgpd/bgp_encap.c
+++ b/bgpd/bgp_encap.c
@@ -208,25 +208,22 @@ bgp_nlri_parse_encap(
 /* For testing purpose, static route of ENCAP. */
 DEFUN (encap_network,
        encap_network_cmd,
-       "network A.B.C.D/M rd ASN:nn_or_IP-address:nn tag WORD",
+       "network A.B.C.D/M rd ASN:nn_or_IP-address:nn",
        "Specify a network to announce via BGP\n"
        "IPv4 prefix\n"
        "Specify Route Distinguisher\n"
-       "ENCAP Route Distinguisher\n"
-       "BGP tag\n"
-       "tag value\n")
+       "ENCAP Route Distinguisher\n")
 {
   int idx_ipv4 = 1;
   int idx_rd = 3;
-  int idx_word = 5;
-  return bgp_static_set_safi (AFI_IP, SAFI_ENCAP, vty, argv[idx_ipv4]->arg, argv[idx_rd]->arg, argv[idx_word]->arg,
+  return bgp_static_set_safi (AFI_IP, SAFI_ENCAP, vty, argv[idx_ipv4]->arg, argv[idx_rd]->arg, NULL,
                               NULL, 0, NULL, NULL, NULL, NULL);
 }
 
 /* For testing purpose, static route of ENCAP. */
 DEFUN (no_encap_network,
        no_encap_network_cmd,
-       "no network A.B.C.D/M rd ASN:nn_or_IP-address:nn tag WORD",
+       "no network A.B.C.D/M rd ASN:nn_or_IP-address:nn",
        NO_STR
        "Specify a network to announce via BGP\n"
        "IPv4 prefix\n"
@@ -237,8 +234,7 @@ DEFUN (no_encap_network,
 {
   int idx_ipv4 = 2;
   int idx_rd = 4;
-  int idx_word = 6;
-  return bgp_static_unset_safi (AFI_IP, SAFI_ENCAP, vty, argv[idx_ipv4]->arg, argv[idx_rd]->arg, argv[idx_word]->arg,
+  return bgp_static_unset_safi (AFI_IP, SAFI_ENCAP, vty, argv[idx_ipv4]->arg, argv[idx_rd]->arg, NULL,
                                 0, NULL, NULL, NULL);
 }
 

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -460,99 +460,104 @@ prefix_rd2str (struct prefix_rd *prd, char *buf, size_t size)
 /* For testing purpose, static route of MPLS-VPN. */
 DEFUN (vpnv4_network,
        vpnv4_network_cmd,
-       "network A.B.C.D/M rd ASN:nn_or_IP-address:nn tag WORD",
+       "network A.B.C.D/M rd ASN:nn_or_IP-address:nn <tag|label> (0-1048575)",
        "Specify a network to announce via BGP\n"
        "IPv4 prefix\n"
        "Specify Route Distinguisher\n"
        "VPN Route Distinguisher\n"
-       "BGP tag\n"
-       "tag value\n")
+       "VPN NLRI label (tag)\n"
+       "VPN NLRI label (tag)\n"
+       "Label value\n")
 {
   int idx_ipv4_prefixlen = 1;
   int idx_ext_community = 3;
-  int idx_word = 5;
+  int idx_label = 5;
   return bgp_static_set_safi (AFI_IP, SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg,
-                              argv[idx_word]->arg, NULL, 0, NULL, NULL, NULL, NULL);
+                              argv[idx_label]->arg, NULL, 0, NULL, NULL, NULL, NULL);
 }
 
 DEFUN (vpnv4_network_route_map,
        vpnv4_network_route_map_cmd,
-       "network A.B.C.D/M rd ASN:nn_or_IP-address:nn tag WORD route-map WORD",
+       "network A.B.C.D/M rd ASN:nn_or_IP-address:nn <tag|label> (0-1048575) route-map WORD",
        "Specify a network to announce via BGP\n"
        "IPv4 prefix\n"
        "Specify Route Distinguisher\n"
        "VPN Route Distinguisher\n"
-       "BGP tag\n"
-       "tag value\n"
+       "VPN NLRI label (tag)\n"
+       "VPN NLRI label (tag)\n"
+       "Label value\n"
        "route map\n"
        "route map name\n")
 {
   int idx_ipv4_prefixlen = 1;
   int idx_ext_community = 3;
-  int idx_word = 5;
+  int idx_label = 5;
   int idx_word_2 = 7;
-  return bgp_static_set_safi (AFI_IP, SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg,
+  return bgp_static_set_safi (AFI_IP, SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, argv[idx_label]->arg,
                               argv[idx_word_2]->arg, 0, NULL, NULL, NULL, NULL);
 }
 
 /* For testing purpose, static route of MPLS-VPN. */
 DEFUN (no_vpnv4_network,
        no_vpnv4_network_cmd,
-       "no network A.B.C.D/M rd ASN:nn_or_IP-address:nn tag WORD",
+       "no network A.B.C.D/M rd ASN:nn_or_IP-address:nn <tag|label> (0-1048575)",
        NO_STR
        "Specify a network to announce via BGP\n"
        "IPv4 prefix\n"
        "Specify Route Distinguisher\n"
        "VPN Route Distinguisher\n"
-       "BGP tag\n"
-       "tag value\n")
+       "VPN NLRI label (tag)\n"
+       "VPN NLRI label (tag)\n"
+       "Label value\n")
 {
   int idx_ipv4_prefixlen = 2;
   int idx_ext_community = 4;
-  int idx_word = 6;
+  int idx_label = 6;
   return bgp_static_unset_safi (AFI_IP, SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg,
-                                argv[idx_ext_community]->arg, argv[idx_word]->arg,
+                                argv[idx_ext_community]->arg, argv[idx_label]->arg,
                                 0, NULL, NULL, NULL);
 }
 
 DEFUN (vpnv6_network,
        vpnv6_network_cmd,
-       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD [route-map WORD]",
+       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn <tag|label> (0-1048575) [route-map WORD]",
        "Specify a network to announce via BGP\n"
        "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
        "Specify Route Distinguisher\n"
        "VPN Route Distinguisher\n"
-       "BGP tag\n"
-       "tag value\n"
+       "VPN NLRI label (tag)\n"
+       "VPN NLRI label (tag)\n"
+       "Label value\n"
        "route map\n"
        "route map name\n")
 {
   int idx_ipv6_prefix = 1;
   int idx_ext_community = 3;
-  int idx_word = 5;
+  int idx_label = 5;
   int idx_word_2 = 7;
   if (argc == 8)
-    return bgp_static_set_safi (AFI_IP6, SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg, 0, NULL, NULL, NULL, NULL);
+    return bgp_static_set_safi (AFI_IP6, SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_label]->arg, argv[idx_word_2]->arg, 0, NULL, NULL, NULL, NULL);
   else
-    return bgp_static_set_safi (AFI_IP6, SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL, 0, NULL, NULL, NULL, NULL);
+    return bgp_static_set_safi (AFI_IP6, SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_label]->arg, NULL, 0, NULL, NULL, NULL, NULL);
 }
 
 /* For testing purpose, static route of MPLS-VPN. */
 DEFUN (no_vpnv6_network,
        no_vpnv6_network_cmd,
-       "no network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD",
+       "no network X:X::X:X/M rd ASN:nn_or_IP-address:nn <tag|label> (0-1048575)",
        NO_STR
        "Specify a network to announce via BGP\n"
        "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
        "Specify Route Distinguisher\n"
        "VPN Route Distinguisher\n"
-       "BGP tag\n"
-       "tag value\n")
+       "VPN NLRI label (tag)\n"
+       "VPN NLRI label (tag)\n"
+       "Label value\n")
 {
   int idx_ipv6_prefix = 2;
   int idx_ext_community = 4;
-  int idx_word = 6;
-  return bgp_static_unset_safi (AFI_IP6, SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, 0, NULL, NULL, NULL);
+  int idx_label = 6;
+  return bgp_static_unset_safi (AFI_IP6, SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_label]->arg, 0, NULL, NULL, NULL);
 }
 
 int

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10438,6 +10438,13 @@ bgp_config_write_network_vpn (struct vty *vty, struct bgp *bgp,
 		     inet_ntop (p->family, &p->u.prefix, buf, SU_ADDRSTRLEN), 
 		     p->prefixlen,
 		     rdbuf, label);
+            if (bgp_static->rmap.name)
+              vty_out (vty, " route-map %s", bgp_static->rmap.name);
+            else
+              {
+                if (bgp_static->backdoor)
+                  vty_out (vty, " backdoor");
+              }
 	    vty_out (vty, "%s", VTY_NEWLINE);
 	  }
   return 0;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4008,7 +4008,7 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
 
   if ((safi == SAFI_EVPN) || (safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP))
     {
-      if (bgp_static->igpnexthop.s_addr)
+      if (afi == AFI_IP)
         {
           bgp_attr_extra_get (&attr)->mp_nexthop_global_in = bgp_static->igpnexthop;
           bgp_attr_extra_get (&attr)->mp_nexthop_len = IPV4_MAX_BYTELEN;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4454,7 +4454,7 @@ bgp_purge_static_redist_routes (struct bgp *bgp)
  */
 int
 bgp_static_set_safi (afi_t afi, safi_t safi, struct vty *vty, const char *ip_str,
-                     const char *rd_str, const char *tag_str,
+                     const char *rd_str, const char *label_str,
                      const char *rmap_str, int evpn_type, const char *esi, const char *gwip,
                      const char *ethtag, const char *routermac)
 {
@@ -4491,18 +4491,15 @@ bgp_static_set_safi (afi_t afi, safi_t safi, struct vty *vty, const char *ip_str
       return CMD_WARNING;
     }
 
-  if (tag_str)
+  if (label_str)
     {
-      ret = str2tag (tag_str, tag);
-      if (! ret)
-        {
-          vty_out (vty, "%% Malformed tag%s", VTY_NEWLINE);
-          return CMD_WARNING;
-        }
+      unsigned long label_val;
+      VTY_GET_INTEGER_RANGE("Label/tag", label_val, label_str, 0, 16777215);
+      encode_label (label_val, tag);
     }
   else
     {
-      encode_label (0, tag);
+      memset (tag, 0, sizeof(tag)); /* empty, not even BoS */
     }
   if (safi == SAFI_EVPN)
     {
@@ -4594,7 +4591,7 @@ bgp_static_set_safi (afi_t afi, safi_t safi, struct vty *vty, const char *ip_str
 /* Configure static BGP network. */
 int
 bgp_static_unset_safi(afi_t afi, safi_t safi, struct vty *vty, const char *ip_str,
-                      const char *rd_str, const char *tag_str,
+                      const char *rd_str, const char *label_str,
                       int evpn_type, const char *esi, const char *gwip, const char *ethtag)
 {
   VTY_DECLVAR_CONTEXT(bgp, bgp);
@@ -4628,11 +4625,15 @@ bgp_static_unset_safi(afi_t afi, safi_t safi, struct vty *vty, const char *ip_st
       return CMD_WARNING;
     }
 
-  ret = str2tag (tag_str, tag);
-  if (! ret)
+  if (label_str)
     {
-      vty_out (vty, "%% Malformed tag%s", VTY_NEWLINE);
-      return CMD_WARNING;
+      unsigned long label_val;
+      VTY_GET_INTEGER_RANGE("Label/tag", label_val, label_str, 0, MPLS_LABEL_MAX);
+      encode_label (label_val, tag);
+    }
+  else
+    {
+      memset (tag, 0, sizeof(tag)); /* empty, not even BoS */
     }
 
   prn = bgp_node_get (bgp->route[afi][safi],
@@ -10433,7 +10434,7 @@ bgp_config_write_network_vpn (struct vty *vty, struct bgp *bgp,
 	    prefix_rd2str (prd, rdbuf, RD_ADDRSTRLEN);
 	    label = decode_label (bgp_static->tag);
 
-	    vty_out (vty, "  network %s/%d rd %s tag %d",
+	    vty_out (vty, "  network %s/%d rd %s label %d",
 		     inet_ntop (p->family, &p->u.prefix, buf, SU_ADDRSTRLEN), 
 		     p->prefixlen,
 		     rdbuf, label);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4559,8 +4559,8 @@ bgp_static_set_safi (afi_t afi, safi_t safi, struct vty *vty, const char *ip_str
       if (rmap_str)
 	{
 	  if (bgp_static->rmap.name)
-	    free (bgp_static->rmap.name);
-	  bgp_static->rmap.name = strdup (rmap_str);
+	    XFREE(MTYPE_ROUTE_MAP_NAME, bgp_static->rmap.name);
+	  bgp_static->rmap.name = XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap_str);
 	  bgp_static->rmap.map = route_map_lookup_by_name (rmap_str);
 	}
 


### PR DESCRIPTION
All looks good for IPv4 and v6 VPN. when running without zebra need to set NH via route-map.

bgpd: fix ipv4|6 vpn|encap with route-map show config
bgp: don't put empty encap or vnc attributes on the wire
bgpd: replace direct calls to system memory functions
bgpd: cleanup vpn label config, set BoS, use 'label' in place of 'tag'