### PR TITLE
ospfd: remember format for ospf area id

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -196,9 +196,8 @@ ospf_area_range_set (struct ospf *ospf, struct in_addr area_id,
 {
   struct ospf_area *area;
   struct ospf_area_range *range;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, ret);
+  area = ospf_area_get (ospf, area_id);
   if (area == NULL)
     return 0;
 
@@ -232,9 +231,8 @@ ospf_area_range_cost_set (struct ospf *ospf, struct in_addr area_id,
 {
   struct ospf_area *area;
   struct ospf_area_range *range;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, ret);
+  area = ospf_area_get (ospf, area_id);
   if (area == NULL)
     return 0;
 
@@ -281,9 +279,8 @@ ospf_area_range_substitute_set (struct ospf *ospf, struct in_addr area_id,
 {
   struct ospf_area *area;
   struct ospf_area_range *range;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, ret);
+  area = ospf_area_get (ospf, area_id);
   range = ospf_area_range_lookup (area, p);
 
   if (range != NULL)

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -794,7 +794,7 @@ ospf_vl_data_new (struct ospf_area *area, struct in_addr vl_peer)
 
   vl_data->vl_peer.s_addr = vl_peer.s_addr;
   vl_data->vl_area_id = area->area_id;
-  vl_data->format = area->format;
+  vl_data->vl_area_id_fmt = area->area_id_fmt;
 
   return vl_data;
 }
@@ -868,7 +868,7 @@ ospf_vl_new (struct ospf *ospf, struct ospf_vl_data *vl_data)
     zlog_debug ("ospf_vl_new(): set if->name to %s", vi->name);
 
   area_id.s_addr = 0;
-  area = ospf_area_get (ospf, area_id, OSPF_AREA_ID_FORMAT_ADDRESS);
+  area = ospf_area_get (ospf, area_id);
   voi->area = area;
 
   if (IS_DEBUG_OSPF_EVENT)

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -103,12 +103,12 @@ struct ospf_interface;
 
 struct ospf_vl_data
 {
-  struct in_addr    vl_peer;	   /* Router-ID of the peer for VLs. */
-  struct in_addr    vl_area_id;	   /* Transit area for this VL. */
-  int format;                      /* area ID format */
-  struct ospf_interface *vl_oi;	   /* Interface data structure for the VL. */
-  struct vertex_nexthop nexthop;   /* Nexthop router and oi to use */
-  struct in_addr    peer_addr;	   /* Address used to reach the peer. */
+  struct in_addr    vl_peer;      /* Router-ID of the peer */
+  struct in_addr    vl_area_id;   /* Transit area */
+  int vl_area_id_fmt;             /* Area ID format */
+  struct ospf_interface *vl_oi;   /* Interface data structure */
+  struct vertex_nexthop nexthop;  /* Nexthop router and oi to use */
+  struct in_addr    peer_addr;    /* Address used to reach the peer */
   u_char flags;
 };
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -66,36 +66,29 @@ static const char *ospf_network_type_str[] =
 
 /* Utility functions. */
 int
-ospf_str2area_id (const char *str, struct in_addr *area_id, int *format)
+str2area_id (const char *str, struct in_addr *area_id, int *area_id_fmt)
 {
-  char *endptr = NULL;
-  unsigned long ret;
+  char *ep;
 
-  /* match "A.B.C.D". */
-  if (strchr (str, '.') != NULL)
-    {
-      ret = inet_aton (str, area_id);
-      if (!ret)
-        return -1;
-      *format = OSPF_AREA_ID_FORMAT_ADDRESS;
-    }
-  /* match "<0-4294967295>". */
-  else
-    {
-      if (*str == '-')
-        return -1;
-      errno = 0;
-      ret = strtoul (str, &endptr, 10);
-      if (*endptr != '\0' || errno || ret > UINT32_MAX)
-        return -1;
+  area_id->s_addr = htonl (strtoul (str, &ep, 10));
+  if (*ep && !inet_aton (str, area_id))
+    return -1;
 
-      area_id->s_addr = htonl (ret);
-      *format = OSPF_AREA_ID_FORMAT_DECIMAL;
-    }
+  *area_id_fmt = *ep ? OSPF_AREA_ID_FMT_DOTTEDQUAD : OSPF_AREA_ID_FMT_DECIMAL;
 
   return 0;
 }
 
+void
+area_id2str (char *buf, int length, struct in_addr *area_id, int area_id_fmt)
+{
+  memset (buf, 0, length);
+
+  if (area_id_fmt == OSPF_AREA_ID_FMT_DOTTEDQUAD)
+    strncpy (buf, inet_ntoa (*area_id), length);
+  else
+    sprintf (buf, "%lu", (unsigned long) ntohl (area_id->s_addr));
+}
 
 static int
 str2metric (const char *str, int *metric)
@@ -533,7 +526,7 @@ DEFUN (ospf_network_area,
   VTY_GET_IPV4_PREFIX ("network prefix", p, argv[idx_ipv4_prefixlen]->arg);
   VTY_GET_OSPF_AREA_ID (area_id, format, argv[idx_ipv4_number]->arg);
 
-  ret = ospf_network_set (ospf, &p, area_id);
+  ret = ospf_network_set (ospf, &p, area_id, format);
   if (ret == 0)
     {
       vty_out (vty, "There is already same network statement.%s", VTY_NEWLINE);
@@ -640,6 +633,7 @@ DEFUN (ospf_area_range_cost,
   VTY_GET_IPV4_PREFIX ("area range", p, argv[idx_ipv4_prefixlen]->arg);
 
   ospf_area_range_set (ospf, area_id, &p, OSPF_AREA_RANGE_ADVERTISE);
+  ospf_area_display_format_set (ospf, ospf_area_get (ospf, area_id), format);
 
   VTY_GET_INTEGER ("range cost", cost, argv[idx_cost]->arg);
   ospf_area_range_cost_set (ospf, area_id, &p, cost);
@@ -668,6 +662,7 @@ DEFUN (ospf_area_range_not_advertise,
   VTY_GET_IPV4_PREFIX ("area range", p, argv[idx_ipv4_prefixlen]->arg);
 
   ospf_area_range_set (ospf, area_id, &p, 0);
+  ospf_area_display_format_set (ospf, ospf_area_get (ospf, area_id), format);
 
   return CMD_SUCCESS;
 }
@@ -727,6 +722,7 @@ DEFUN (ospf_area_range_substitute,
   VTY_GET_IPV4_PREFIX ("substituted network prefix", s, argv[idx_ipv4_prefixlen_2]->arg);
 
   ospf_area_range_substitute_set (ospf, area_id, &p, &s);
+  ospf_area_display_format_set (ospf, ospf_area_get (ospf, area_id), format);
 
   return CMD_SUCCESS;
 }
@@ -781,7 +777,7 @@ DEFUN (no_ospf_area_range_substitute,
 struct ospf_vl_config_data {
   struct vty *vty;		/* vty stuff */
   struct in_addr area_id;	/* area ID from command line */
-  int format;			/* command line area ID format */
+  int area_id_fmt;		/* command line area ID format */
   struct in_addr vl_peer;	/* command line vl_peer */
   int auth_type;		/* Authehntication type, if given */
   char *auth_key;		/* simple password if present */
@@ -820,11 +816,12 @@ ospf_find_vl_data (struct ospf *ospf, struct ospf_vl_config_data *vl_config)
                VTY_NEWLINE);
       return NULL;
     }
-  area = ospf_area_get (ospf, area_id, vl_config->format);
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, vl_config->area_id_fmt);
 
   if (area->external_routing != OSPF_AREA_DEFAULT)
     {
-      if (vl_config->format == OSPF_AREA_ID_FORMAT_ADDRESS)
+      if (vl_config->area_id_fmt == OSPF_AREA_ID_FMT_DOTTEDQUAD)
 	vty_out (vty, "Area %s is %s%s",
 		 inet_ntoa (area_id),
 		 area->external_routing == OSPF_AREA_NSSA?"nssa":"stub",
@@ -1036,7 +1033,8 @@ DEFUN (ospf_area_vlink,
   ospf_vl_config_data_init(&vl_config, vty);
 
   /* Read off first 2 parameters and check them */
-  ret = ospf_str2area_id (argv[idx_ipv4_number]->arg, &vl_config.area_id, &vl_config.format);
+  ret = str2area_id (argv[idx_ipv4_number]->arg, &vl_config.area_id,
+                          &vl_config.area_id_fmt);
   if (ret < 0)
     {
       vty_out (vty, "OSPF area ID is invalid%s", VTY_NEWLINE);
@@ -1154,7 +1152,7 @@ DEFUN (ospf_area_vlink_intervals,
   char *area_id   = argv[1]->arg;
   char *router_id = argv[3]->arg;
 
-  ret = ospf_str2area_id (area_id, &vl_config.area_id, &vl_config.format);
+  ret = str2area_id (area_id, &vl_config.area_id, &vl_config.area_id_fmt);
   if (ret < 0)
     {
       vty_out (vty, "OSPF area ID is invalid%s", VTY_NEWLINE);
@@ -1209,7 +1207,7 @@ DEFUN (no_ospf_area_vlink,
 
   ospf_vl_config_data_init(&vl_config, vty);
 
-  ret = ospf_str2area_id (argv[idx_ipv4_number]->arg, &vl_config.area_id, &format);
+  ret = str2area_id (argv[idx_ipv4_number]->arg, &vl_config.area_id, &format);
   if (ret < 0)
     {
       vty_out (vty, "OSPF area ID is invalid%s", VTY_NEWLINE);
@@ -1318,7 +1316,7 @@ DEFUN (no_ospf_area_vlink_intervals,
   char *area_id   = argv[2]->arg;
   char *router_id = argv[4]->arg;
 
-  ret = ospf_str2area_id (area_id, &vl_config.area_id, &vl_config.format);
+  ret = str2area_id (area_id, &vl_config.area_id, &vl_config.area_id_fmt);
   if (ret < 0)
     {
       vty_out (vty, "OSPF area ID is invalid%s", VTY_NEWLINE);
@@ -1370,7 +1368,8 @@ DEFUN (ospf_area_shortcut,
 
   VTY_GET_OSPF_AREA_ID_NO_BB ("shortcut", area_id, format, argv[idx_ipv4_number]->arg);
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, format);
 
   if (strncmp (argv[idx_enable_disable]->arg, "de", 2) == 0)
     mode = OSPF_SHORTCUT_DEFAULT;
@@ -1436,6 +1435,7 @@ DEFUN (ospf_area_stub,
   VTY_GET_OSPF_AREA_ID_NO_BB ("stub", area_id, format, argv[idx_ipv4_number]->arg);
 
   ret = ospf_area_stub_set (ospf, area_id);
+  ospf_area_display_format_set (ospf, ospf_area_get (ospf, area_id), format);
   if (ret == 0)
     {
       vty_out (vty, "First deconfigure all virtual link through this area%s",
@@ -1465,6 +1465,7 @@ DEFUN (ospf_area_stub_no_summary,
   VTY_GET_OSPF_AREA_ID_NO_BB ("stub", area_id, format, argv[idx_ipv4_number]->arg);
 
   ret = ospf_area_stub_set (ospf, area_id);
+  ospf_area_display_format_set (ospf, ospf_area_get (ospf, area_id), format);
   if (ret == 0)
     {
       vty_out (vty, "%% Area cannot be stub as it contains a virtual link%s",
@@ -1531,6 +1532,7 @@ ospf_area_nssa_cmd_handler (struct vty *vty, int argc, struct cmd_token **argv,
   VTY_GET_OSPF_AREA_ID_NO_BB ("NSSA", area_id, format, argv[1]->arg);
 
   ret = ospf_area_nssa_set (ospf, area_id);
+  ospf_area_display_format_set (ospf, ospf_area_get (ospf, area_id), format);
   if (ret == 0)
     {
       vty_out (vty, "%% Area cannot be nssa as it contains a virtual link%s",
@@ -1668,7 +1670,8 @@ DEFUN (ospf_area_default_cost,
   VTY_GET_OSPF_AREA_ID_NO_BB ("default-cost", area_id, format, argv[idx_ipv4_number]->arg);
   VTY_GET_INTEGER_RANGE ("stub default cost", cost, argv[idx_number]->arg, 0, 16777215);
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, format);
 
   if (area->external_routing == OSPF_AREA_DEFAULT)
     {
@@ -1755,7 +1758,8 @@ DEFUN (ospf_area_export_list,
 
   VTY_GET_OSPF_AREA_ID (area_id, format, argv[idx_ipv4_number]->arg);
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, format);
   ospf_area_export_list_set (ospf, area, argv[3]->arg);
 
   return CMD_SUCCESS;
@@ -1806,7 +1810,8 @@ DEFUN (ospf_area_import_list,
 
   VTY_GET_OSPF_AREA_ID (area_id, format, argv[idx_ipv4_number]->arg);
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, format);
   ospf_area_import_list_set (ospf, area, argv[3]->arg);
 
   return CMD_SUCCESS;
@@ -1862,7 +1867,8 @@ DEFUN (ospf_area_filter_list,
 
   VTY_GET_OSPF_AREA_ID (area_id, format, argv[idx_ipv4_number]->arg);
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, format);
   plist = prefix_list_lookup (AFI_IP, argv[idx_word]->arg);
   if (strncmp (argv[idx_in_out]->arg, "in", 2) == 0)
     {
@@ -1962,7 +1968,8 @@ DEFUN (ospf_area_authentication_message_digest,
 
   VTY_GET_OSPF_AREA_ID (area_id, format, argv[idx_ipv4_number]->arg);
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, format);
   area->auth_type = OSPF_AUTH_CRYPTOGRAPHIC;
 
   return CMD_SUCCESS;
@@ -1984,7 +1991,8 @@ DEFUN (ospf_area_authentication,
 
   VTY_GET_OSPF_AREA_ID (area_id, format, argv[idx_ipv4_number]->arg);
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, format);
   area->auth_type = OSPF_AUTH_SIMPLE;
 
   return CMD_SUCCESS;
@@ -7003,7 +7011,7 @@ DEFUN (ip_ospf_area,
       return CMD_SUCCESS;
     }
 
-  ret = ospf_str2area_id (areaid, &area_id, &format);
+  ret = str2area_id (areaid, &area_id, &format);
   if (ret < 0)
     {
       vty_out (vty, "Please specify area by A.B.C.D|<0-4294967295>%s",
@@ -8165,19 +8173,6 @@ const char *ospf_shortcut_mode_str[] =
   "disable"
 };
 
-
-static void
-area_id2str (char *buf, int length, struct ospf_area *area)
-{
-  memset (buf, 0, length);
-
-  if (area->format == OSPF_AREA_ID_FORMAT_ADDRESS)
-    strncpy (buf, inet_ntoa (area->area_id), length);
-  else
-    sprintf (buf, "%lu", (unsigned long) ntohl (area->area_id.s_addr));
-}
-
-
 const char *ospf_int_type_str[] = 
 {
   "unknown",		/* should never be used. */
@@ -8424,7 +8419,7 @@ config_write_network_area (struct vty *vty, struct ospf *ospf)
 	memset (buf, 0, INET_ADDRSTRLEN);
 
 	/* Create Area ID string by specified Area ID format. */
-	if (n->format == OSPF_AREA_ID_FORMAT_ADDRESS)
+	if (n->area_id_fmt == OSPF_AREA_ID_FMT_DOTTEDQUAD)
 	  strncpy ((char *) buf, inet_ntoa (n->area_id), INET_ADDRSTRLEN);
 	else
 	  sprintf ((char *) buf, "%lu", 
@@ -8451,7 +8446,8 @@ config_write_ospf_area (struct vty *vty, struct ospf *ospf)
     {
       struct route_node *rn1;
 
-      area_id2str ((char *) buf, INET_ADDRSTRLEN, area);
+      area_id2str ((char *) buf, INET_ADDRSTRLEN, &area->area_id,
+                   area->area_id_fmt);
 
       if (area->auth_type != OSPF_AUTH_NULL)
 	{
@@ -8570,7 +8566,7 @@ config_write_virtual_link (struct vty *vty, struct ospf *ospf)
 {
   struct listnode *node;
   struct ospf_vl_data *vl_data;
-  u_char buf[INET_ADDRSTRLEN];
+  char buf[INET_ADDRSTRLEN];
 
   /* Virtual-Link print */
   for (ALL_LIST_ELEMENTS_RO (ospf->vlinks, node, vl_data))
@@ -8582,12 +8578,8 @@ config_write_virtual_link (struct vty *vty, struct ospf *ospf)
       if (vl_data != NULL)
 	{
 	  memset (buf, 0, INET_ADDRSTRLEN);
-	  
-	  if (vl_data->format == OSPF_AREA_ID_FORMAT_ADDRESS)
-	    strncpy ((char *) buf, inet_ntoa (vl_data->vl_area_id), INET_ADDRSTRLEN);
-	  else
-	    sprintf ((char *) buf, "%lu", 
-		     (unsigned long int) ntohl (vl_data->vl_area_id.s_addr));
+
+          area_id2str (buf, sizeof(buf), &vl_data->vl_area_id, vl_data->vl_area_id_fmt);
 	  oi = vl_data->vl_oi;
 
 	  /* timers */

--- a/ospfd/ospf_vty.h
+++ b/ospfd/ospf_vty.h
@@ -25,7 +25,7 @@
 #define VTY_GET_OSPF_AREA_ID(V,F,STR)                                         \
 {                                                                             \
   int retv;                                                                   \
-  retv = ospf_str2area_id ((STR), &(V), &(F));                                \
+  retv = str2area_id ((STR), &(V), &(F));                                     \
   if (retv < 0)                                                               \
     {                                                                         \
       vty_out (vty, "%% Invalid OSPF area ID%s", VTY_NEWLINE);                \
@@ -36,7 +36,7 @@
 #define VTY_GET_OSPF_AREA_ID_NO_BB(NAME,V,F,STR)                              \
 {                                                                             \
   int retv;                                                                   \
-  retv = ospf_str2area_id ((STR), &(V), &(F));                                \
+  retv = str2area_id ((STR), &(V), &(F));                                     \
   if (retv < 0)                                                               \
     {                                                                         \
       vty_out (vty, "%% Invalid OSPF area ID%s", VTY_NEWLINE);                \
@@ -53,6 +53,7 @@
 extern void ospf_vty_init (void);
 extern void ospf_vty_show_init (void);
 extern void ospf_vty_clear_init (void);
-extern int ospf_str2area_id (const char *, struct in_addr *, int *);
+extern int str2area_id (const char *, struct in_addr *, int *);
+extern void area_id2str (char *, int, struct in_addr *, int);
 
 #endif /* _QUAGGA_OSPF_VTY_H */

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -720,6 +720,7 @@ ospf_area_new (struct ospf *ospf, struct in_addr area_id)
   new->ospf = ospf;
 
   new->area_id = area_id;
+  new->area_id_fmt = OSPF_AREA_ID_FMT_DOTTEDQUAD;
 
   new->external_routing = OSPF_AREA_DEFAULT;
   new->default_cost = 1;
@@ -812,7 +813,7 @@ ospf_area_check_free (struct ospf *ospf, struct in_addr area_id)
 }
 
 struct ospf_area *
-ospf_area_get (struct ospf *ospf, struct in_addr area_id, int format)
+ospf_area_get (struct ospf *ospf, struct in_addr area_id)
 {
   struct ospf_area *area;
   
@@ -820,7 +821,6 @@ ospf_area_get (struct ospf *ospf, struct in_addr area_id, int format)
   if (!area)
     {
       area = ospf_area_new (ospf, area_id);
-      area->format = format;
       listnode_add_sort (ospf->areas, area);
       ospf_check_abr_status (ospf);  
       if (ospf->stub_router_admin_set == OSPF_STUB_ROUTER_ADMINISTRATIVE_SET)
@@ -923,13 +923,13 @@ static void update_redistributed(struct ospf *ospf, int add_to_ospf)
 
 /* Config network statement related functions. */
 static struct ospf_network *
-ospf_network_new (struct in_addr area_id, int format)
+ospf_network_new (struct in_addr area_id)
 {
   struct ospf_network *new;
   new = XCALLOC (MTYPE_OSPF_NETWORK, sizeof (struct ospf_network));
 
   new->area_id = area_id;
-  new->format = format;
+  new->area_id_fmt = OSPF_AREA_ID_FMT_DOTTEDQUAD;
   
   return new;
 }
@@ -944,12 +944,11 @@ ospf_network_free (struct ospf *ospf, struct ospf_network *network)
 
 int
 ospf_network_set (struct ospf *ospf, struct prefix_ipv4 *p,
-		  struct in_addr area_id)
+		  struct in_addr area_id, int df)
 {
   struct ospf_network *network;
   struct ospf_area *area;
   struct route_node *rn;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
   rn = route_node_get (ospf->networks, (struct prefix *)p);
   if (rn->info)
@@ -959,8 +958,10 @@ ospf_network_set (struct ospf *ospf, struct prefix_ipv4 *p,
       return 0;
     }
 
-  rn->info = network = ospf_network_new (area_id, ret);
-  area = ospf_area_get (ospf, area_id, ret);
+  rn->info = network = ospf_network_new (area_id);
+  network->area_id_fmt = df;
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, df);
 
   /* Run network config now. */
   ospf_network_run ((struct prefix *)p, area);
@@ -1040,7 +1041,6 @@ ospf_interface_set (struct interface *ifp, struct in_addr area_id)
   struct ospf *ospf;
   struct ospf_if_params *params;
   struct ospf_interface *oi;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
   if ((ospf = ospf_lookup ()) == NULL)
     return 1; /* Ospf not ready yet */
@@ -1050,7 +1050,7 @@ ospf_interface_set (struct interface *ifp, struct in_addr area_id)
   SET_IF_PARAM (params, if_area);
   params->if_area = area_id;
 
-  area = ospf_area_get (ospf, area_id, ret);
+  area = ospf_area_get (ospf, area_id);
 
   for (ALL_LIST_ELEMENTS_RO (ifp->connected, cnode, co))
     {
@@ -1238,7 +1238,7 @@ ospf_if_update (struct ospf *ospf, struct interface *ifp)
     if (rn->info != NULL)
       {
         network = (struct ospf_network *) rn->info;
-        area = ospf_area_get (ospf, network->area_id, network->format);
+        area = ospf_area_get (ospf, network->area_id);
         ospf_network_run_interface (&rn->p, area, ifp);
       }
 
@@ -1372,12 +1372,19 @@ ospf_area_vlink_count (struct ospf *ospf, struct ospf_area *area)
 }
 
 int
+ospf_area_display_format_set (struct ospf *ospf, struct ospf_area *area, int df)
+{
+  area->area_id_fmt = df;
+
+  return 1;
+}
+
+int
 ospf_area_stub_set (struct ospf *ospf, struct in_addr area_id)
 {
   struct ospf_area *area;
-  int format = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
   if (ospf_area_vlink_count (ospf, area))
     return 0;
 
@@ -1408,9 +1415,8 @@ int
 ospf_area_no_summary_set (struct ospf *ospf, struct in_addr area_id)
 {
   struct ospf_area *area;
-  int format = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
   area->no_summary = 1;
 
   return 1;
@@ -1435,9 +1441,8 @@ int
 ospf_area_nssa_set (struct ospf *ospf, struct in_addr area_id)
 {
   struct ospf_area *area;
-  int format = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
   if (ospf_area_vlink_count (ospf, area))
     return 0;
 

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -321,9 +321,9 @@ struct ospf_area
   struct in_addr area_id;
 
   /* Area ID format. */
-  char format;
-#define OSPF_AREA_ID_FORMAT_ADDRESS         1
-#define OSPF_AREA_ID_FORMAT_DECIMAL         2
+  int area_id_fmt;
+#define OSPF_AREA_ID_FMT_DOTTEDQUAD     1
+#define OSPF_AREA_ID_FMT_DECIMAL        2
 
   /* Address range. */
   struct list *address_range;
@@ -430,7 +430,7 @@ struct ospf_network
 {
   /* Area ID. */
   struct in_addr area_id;
-  int format;
+  int area_id_fmt;
 };
 
 /* OSPF NBMA neighbor structure. */
@@ -508,9 +508,11 @@ extern struct ospf *ospf_get_instance (u_short);
 extern void ospf_finish (struct ospf *);
 extern void ospf_router_id_update (struct ospf *ospf);
 extern int ospf_network_set (struct ospf *, struct prefix_ipv4 *,
-			     struct in_addr);
+			     struct in_addr, int);
 extern int ospf_network_unset (struct ospf *, struct prefix_ipv4 *,
 			       struct in_addr);
+extern int ospf_area_display_format_set (struct ospf *, struct ospf_area *area,
+                                         int df);
 extern int ospf_area_stub_set (struct ospf *, struct in_addr);
 extern int ospf_area_stub_unset (struct ospf *, struct in_addr);
 extern int ospf_area_no_summary_set (struct ospf *, struct in_addr);
@@ -549,7 +551,7 @@ extern struct ospf_nbr_nbma *ospf_nbr_nbma_lookup_next (struct ospf *,
 							int);
 extern int ospf_oi_count (struct interface *);
 
-extern struct ospf_area *ospf_area_get (struct ospf *, struct in_addr, int);
+extern struct ospf_area *ospf_area_get (struct ospf *, struct in_addr);
 extern void ospf_area_check_free (struct ospf *, struct in_addr);
 extern struct ospf_area *ospf_area_lookup_by_area_id (struct ospf *,
 						      struct in_addr);


### PR DESCRIPTION
If the user enters a decimal, display a decimal.
If the user enters a dotted quad, display a dotted quad.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>