### PR TITLE
ospfd: remember format for ospf area id

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -197,9 +197,8 @@ ospf_area_range_set (struct ospf *ospf, struct in_addr area_id,
 {
   struct ospf_area *area;
   struct ospf_area_range *range;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, ret);
+  area = ospf_area_get (ospf, area_id);
   if (area == NULL)
     return 0;
 
@@ -233,9 +232,8 @@ ospf_area_range_cost_set (struct ospf *ospf, struct in_addr area_id,
 {
   struct ospf_area *area;
   struct ospf_area_range *range;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, ret);
+  area = ospf_area_get (ospf, area_id);
   if (area == NULL)
     return 0;
 
@@ -282,9 +280,8 @@ ospf_area_range_substitute_set (struct ospf *ospf, struct in_addr area_id,
 {
   struct ospf_area *area;
   struct ospf_area_range *range;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, ret);
+  area = ospf_area_get (ospf, area_id);
   range = ospf_area_range_lookup (area, p);
 
   if (range != NULL)

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -795,7 +795,7 @@ ospf_vl_data_new (struct ospf_area *area, struct in_addr vl_peer)
 
   vl_data->vl_peer.s_addr = vl_peer.s_addr;
   vl_data->vl_area_id = area->area_id;
-  vl_data->format = area->format;
+  vl_data->vl_area_id_fmt = area->area_id_fmt;
 
   return vl_data;
 }
@@ -869,7 +869,7 @@ ospf_vl_new (struct ospf *ospf, struct ospf_vl_data *vl_data)
     zlog_debug ("ospf_vl_new(): set if->name to %s", vi->name);
 
   area_id.s_addr = 0;
-  area = ospf_area_get (ospf, area_id, OSPF_AREA_ID_FORMAT_ADDRESS);
+  area = ospf_area_get (ospf, area_id);
   voi->area = area;
 
   if (IS_DEBUG_OSPF_EVENT)

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -104,12 +104,12 @@ struct ospf_interface;
 
 struct ospf_vl_data
 {
-  struct in_addr    vl_peer;	   /* Router-ID of the peer for VLs. */
-  struct in_addr    vl_area_id;	   /* Transit area for this VL. */
-  int format;                      /* area ID format */
-  struct ospf_interface *vl_oi;	   /* Interface data structure for the VL. */
-  struct vertex_nexthop nexthop;   /* Nexthop router and oi to use */
-  struct in_addr    peer_addr;	   /* Address used to reach the peer. */
+  struct in_addr    vl_peer;      /* Router-ID of the peer */
+  struct in_addr    vl_area_id;   /* Transit area */
+  int vl_area_id_fmt;             /* Area ID format */
+  struct ospf_interface *vl_oi;   /* Interface data structure */
+  struct vertex_nexthop nexthop;  /* Nexthop router and oi to use */
+  struct in_addr    peer_addr;    /* Address used to reach the peer */
   u_char flags;
 };
 

--- a/ospfd/ospf_vty.h
+++ b/ospfd/ospf_vty.h
@@ -26,7 +26,7 @@
 #define VTY_GET_OSPF_AREA_ID(V,F,STR)                                         \
 {                                                                             \
   int retv;                                                                   \
-  retv = ospf_str2area_id ((STR), &(V), &(F));                                \
+  retv = str2area_id ((STR), &(V), &(F));                                     \
   if (retv < 0)                                                               \
     {                                                                         \
       vty_out (vty, "%% Invalid OSPF area ID%s", VTY_NEWLINE);                \
@@ -37,7 +37,7 @@
 #define VTY_GET_OSPF_AREA_ID_NO_BB(NAME,V,F,STR)                              \
 {                                                                             \
   int retv;                                                                   \
-  retv = ospf_str2area_id ((STR), &(V), &(F));                                \
+  retv = str2area_id ((STR), &(V), &(F));                                     \
   if (retv < 0)                                                               \
     {                                                                         \
       vty_out (vty, "%% Invalid OSPF area ID%s", VTY_NEWLINE);                \
@@ -54,6 +54,7 @@
 extern void ospf_vty_init (void);
 extern void ospf_vty_show_init (void);
 extern void ospf_vty_clear_init (void);
-extern int ospf_str2area_id (const char *, struct in_addr *, int *);
+extern int str2area_id (const char *, struct in_addr *, int *);
+extern void area_id2str (char *, int, struct in_addr *, int);
 
 #endif /* _QUAGGA_OSPF_VTY_H */

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -717,6 +717,7 @@ ospf_area_new (struct ospf *ospf, struct in_addr area_id)
   new->ospf = ospf;
 
   new->area_id = area_id;
+  new->area_id_fmt = OSPF_AREA_ID_FMT_DOTTEDQUAD;
 
   new->external_routing = OSPF_AREA_DEFAULT;
   new->default_cost = 1;
@@ -809,7 +810,7 @@ ospf_area_check_free (struct ospf *ospf, struct in_addr area_id)
 }
 
 struct ospf_area *
-ospf_area_get (struct ospf *ospf, struct in_addr area_id, int format)
+ospf_area_get (struct ospf *ospf, struct in_addr area_id)
 {
   struct ospf_area *area;
   
@@ -817,7 +818,6 @@ ospf_area_get (struct ospf *ospf, struct in_addr area_id, int format)
   if (!area)
     {
       area = ospf_area_new (ospf, area_id);
-      area->format = format;
       listnode_add_sort (ospf->areas, area);
       ospf_check_abr_status (ospf);  
       if (ospf->stub_router_admin_set == OSPF_STUB_ROUTER_ADMINISTRATIVE_SET)
@@ -920,13 +920,13 @@ static void update_redistributed(struct ospf *ospf, int add_to_ospf)
 
 /* Config network statement related functions. */
 static struct ospf_network *
-ospf_network_new (struct in_addr area_id, int format)
+ospf_network_new (struct in_addr area_id)
 {
   struct ospf_network *new;
   new = XCALLOC (MTYPE_OSPF_NETWORK, sizeof (struct ospf_network));
 
   new->area_id = area_id;
-  new->format = format;
+  new->area_id_fmt = OSPF_AREA_ID_FMT_DOTTEDQUAD;
   
   return new;
 }
@@ -941,12 +941,11 @@ ospf_network_free (struct ospf *ospf, struct ospf_network *network)
 
 int
 ospf_network_set (struct ospf *ospf, struct prefix_ipv4 *p,
-		  struct in_addr area_id)
+		  struct in_addr area_id, int df)
 {
   struct ospf_network *network;
   struct ospf_area *area;
   struct route_node *rn;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
   rn = route_node_get (ospf->networks, (struct prefix *)p);
   if (rn->info)
@@ -956,8 +955,10 @@ ospf_network_set (struct ospf *ospf, struct prefix_ipv4 *p,
       return 0;
     }
 
-  rn->info = network = ospf_network_new (area_id, ret);
-  area = ospf_area_get (ospf, area_id, ret);
+  rn->info = network = ospf_network_new (area_id);
+  network->area_id_fmt = df;
+  area = ospf_area_get (ospf, area_id);
+  ospf_area_display_format_set (ospf, area, df);
 
   /* Run network config now. */
   ospf_network_run ((struct prefix *)p, area);
@@ -1037,7 +1038,6 @@ ospf_interface_set (struct interface *ifp, struct in_addr area_id)
   struct ospf *ospf;
   struct ospf_if_params *params;
   struct ospf_interface *oi;
-  int ret = OSPF_AREA_ID_FORMAT_ADDRESS;
 
   if ((ospf = ospf_lookup ()) == NULL)
     return 1; /* Ospf not ready yet */
@@ -1047,7 +1047,7 @@ ospf_interface_set (struct interface *ifp, struct in_addr area_id)
   SET_IF_PARAM (params, if_area);
   params->if_area = area_id;
 
-  area = ospf_area_get (ospf, area_id, ret);
+  area = ospf_area_get (ospf, area_id);
 
   for (ALL_LIST_ELEMENTS_RO (ifp->connected, cnode, co))
     {
@@ -1235,7 +1235,7 @@ ospf_if_update (struct ospf *ospf, struct interface *ifp)
     if (rn->info != NULL)
       {
         network = (struct ospf_network *) rn->info;
-        area = ospf_area_get (ospf, network->area_id, network->format);
+        area = ospf_area_get (ospf, network->area_id);
         ospf_network_run_interface (&rn->p, area, ifp);
       }
 
@@ -1369,12 +1369,19 @@ ospf_area_vlink_count (struct ospf *ospf, struct ospf_area *area)
 }
 
 int
+ospf_area_display_format_set (struct ospf *ospf, struct ospf_area *area, int df)
+{
+  area->area_id_fmt = df;
+
+  return 1;
+}
+
+int
 ospf_area_stub_set (struct ospf *ospf, struct in_addr area_id)
 {
   struct ospf_area *area;
-  int format = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
   if (ospf_area_vlink_count (ospf, area))
     return 0;
 
@@ -1405,9 +1412,8 @@ int
 ospf_area_no_summary_set (struct ospf *ospf, struct in_addr area_id)
 {
   struct ospf_area *area;
-  int format = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
   area->no_summary = 1;
 
   return 1;
@@ -1432,9 +1438,8 @@ int
 ospf_area_nssa_set (struct ospf *ospf, struct in_addr area_id)
 {
   struct ospf_area *area;
-  int format = OSPF_AREA_ID_FORMAT_ADDRESS;
 
-  area = ospf_area_get (ospf, area_id, format);
+  area = ospf_area_get (ospf, area_id);
   if (ospf_area_vlink_count (ospf, area))
     return 0;
 

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -322,9 +322,9 @@ struct ospf_area
   struct in_addr area_id;
 
   /* Area ID format. */
-  char format;
-#define OSPF_AREA_ID_FORMAT_ADDRESS         1
-#define OSPF_AREA_ID_FORMAT_DECIMAL         2
+  int area_id_fmt;
+#define OSPF_AREA_ID_FMT_DOTTEDQUAD     1
+#define OSPF_AREA_ID_FMT_DECIMAL        2
 
   /* Address range. */
   struct list *address_range;
@@ -431,7 +431,7 @@ struct ospf_network
 {
   /* Area ID. */
   struct in_addr area_id;
-  int format;
+  int area_id_fmt;
 };
 
 /* OSPF NBMA neighbor structure. */
@@ -525,9 +525,11 @@ extern struct ospf *ospf_get_instance (u_short);
 extern void ospf_finish (struct ospf *);
 extern void ospf_router_id_update (struct ospf *ospf);
 extern int ospf_network_set (struct ospf *, struct prefix_ipv4 *,
-			     struct in_addr);
+			     struct in_addr, int);
 extern int ospf_network_unset (struct ospf *, struct prefix_ipv4 *,
 			       struct in_addr);
+extern int ospf_area_display_format_set (struct ospf *, struct ospf_area *area,
+                                         int df);
 extern int ospf_area_stub_set (struct ospf *, struct in_addr);
 extern int ospf_area_stub_unset (struct ospf *, struct in_addr);
 extern int ospf_area_no_summary_set (struct ospf *, struct in_addr);
@@ -566,7 +568,7 @@ extern struct ospf_nbr_nbma *ospf_nbr_nbma_lookup_next (struct ospf *,
 							int);
 extern int ospf_oi_count (struct interface *);
 
-extern struct ospf_area *ospf_area_get (struct ospf *, struct in_addr, int);
+extern struct ospf_area *ospf_area_get (struct ospf *, struct in_addr);
 extern void ospf_area_check_free (struct ospf *, struct in_addr);
 extern struct ospf_area *ospf_area_lookup_by_area_id (struct ospf *,
 						      struct in_addr);


### PR DESCRIPTION
If the user enters a decimal, display a decimal.
If the user enters a dotted quad, display a dotted quad.

We were already doing the work to parse this data and display it appropriately, but never storing the actual format...

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>