### PR TITLE
bgpd: Fix crash when going down

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -194,7 +194,6 @@ bgp_exit (int status)
   /* reverse bgp_master_init */
   for (ALL_LIST_ELEMENTS (bm->bgp, node, nnode, bgp))
     bgp_delete (bgp);
-  list_free (bm->bgp);
 
   /* reverse bgp_dump_init */
   bgp_dump_finish ();
@@ -246,6 +245,7 @@ bgp_exit (int status)
 
   closezlog ();
 
+  list_delete (bm->bgp);
   memset (bm, 0, sizeof (*bm));
 
   if (bgp_debug_count())


### PR DESCRIPTION
When bgp is sent a SIGINT signal with vrf's configured
bgp proceeds to crash on the way down.  This is because
the bm->bgp list was deleted( but the pointer was kept around)
and then later in the going down process vrf_terminate is called
which attempts to find any associated processes.  Since memory
has been freed and subsuquently used for something else
we get a corrupt bgp pointer and bgp crashes.

Here is the trace:

(gdb) bt
    at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
    at sigevent.c:255
    at thread.c:1315
(gdb)

Multiple protocols besides bgp and zebra running are needed to make
this happen as well.  So a weird timing related issue?

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>