### PR TITLE
ospf6d: fix use-after-free

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1455,13 +1455,14 @@ ospf6_intra_route_calculation (struct ospf6_area *oa)
         {
           if (hook_add)
             (*hook_add) (route);
+          route->flag = 0;
         }
       else
 	{
 	  /* Redo the summaries as things might have changed */
 	  ospf6_abr_originate_summary (route);
+	  route->flag = 0;
 	}
-      route->flag = 0;
     }
 
   if (IS_OSPF6_DEBUG_EXAMIN (INTRA_PREFIX))


### PR DESCRIPTION
ospf6_route_remove may free the ospf6_route passed to it if the refcount
reaches zero, in which case zeroing the ->flag field constitutes a uaf

fixes #587 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>