### PR TITLE
zebra: Distributed Dataplane module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -320,6 +320,8 @@ AC_ARG_ENABLE(cumulus,
   AS_HELP_STRING([--enable-cumulus], [enable Cumulus Switch Special Extensions]))
 AC_ARG_ENABLE(datacenter,
   AS_HELP_STRING([--enable-datacenter], [enable Compilation for Data Center Extensions]))
+AC_ARG_ENABLE(distributed-dataplane,
+  AS_HELP_STRING([--enable-distributed-dataplane], [enable Distributed Dataplane Extension]))
 AC_ARG_ENABLE(rr-semantics,
   AS_HELP_STRING([--disable-rr-semantics], [disable the v6 Route Replace semantics]))
 AC_ARG_ENABLE([protobuf],
@@ -401,6 +403,11 @@ fi
 
 AC_SUBST(DFLT_NAME)
 AC_DEFINE_UNQUOTED(DFLT_NAME,["$DFLT_NAME"], Name of the configuration default set)
+
+if test "${enable_distributed_dataplane}" = "yes" ; then
+  AC_DEFINE(HAVE_DISTRIBUTED_DATAPLANE,,Compile Special Distributed Dataplane Code in)
+fi
+AM_CONDITIONAL([HAVE_DISTRIBUTED_DATAPLANE], [test "x$enable_distributed_dataplane" = "xyes"])
 
 if test "${enable_shell_access}" = "yes"; then
    AC_DEFINE(HAVE_SHELL_ACCESS,,Allow user to use ssh/telnet/bash)

--- a/lib/log.h
+++ b/lib/log.h
@@ -77,6 +77,7 @@ extern void closezlog (void);
 #endif /* __GNUC__ */
 
 /* Handy zlog functions. */
+void zlog (int priority, const char *format, ...);
 extern void zlog_err (const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
 extern void zlog_warn (const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
 extern void zlog_info (const char *format, ...) PRINTF_ATTRIBUTE(1, 2);

--- a/lib/module.h
+++ b/lib/module.h
@@ -25,6 +25,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h> /* for size_t */
 
 #if !defined(__GNUC__)
 # error module code needs GCC visibility extensions

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -70,6 +70,7 @@ struct nexthop
 #define NEXTHOP_FLAG_ONLINK     (1 << 3) /* Nexthop should be installed onlink. */
 #define NEXTHOP_FLAG_MATCHED    (1 << 4) /* Already matched vs a nexthop */
 #define NEXTHOP_FLAG_FILTERED   (1 << 5) /* rmap filtered, used by static only */
+#define NEXTHOP_FLAG_HW_NA      (1 << 6) /* Accepted by HW but not active */
 
   /* Nexthop address */
   union g_addr gate;

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -222,6 +222,9 @@ typedef unsigned char   u_int8_t;
 
 #include "zassert.h"
 
+#include "hook.h"
+DECLARE_HOOK(zebra_finish, (), ())
+
 #ifndef HAVE_STRLCAT
 size_t strlcat (char *__restrict dest, const char *__restrict src, size_t size);
 #endif

--- a/zebra/Makefile.am
+++ b/zebra/Makefile.am
@@ -35,6 +35,9 @@ zebra_SOURCES = \
 	zebra_mroute.c \
 	label_manager.c \
 	# end
+if !HAVE_DISTRIBUTED_DATAPLANE
+zebra_SOURCES += zebra_dataplane.c
+endif
 
 testzebra_SOURCES = test_main.c zebra_rib.c interface.c connected.c debug.c \
 	zebra_vty.c zebra_ptm.c zebra_routemap.c zebra_ns.c zebra_vrf.c \

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -50,6 +50,9 @@
 
 #define ZEBRA_PTM_SUPPORT
 
+DEFINE_HOOK (address_change, (int cmd, int family, struct interface *ifp,
+                              struct connected *ifc), (cmd, family, ifp, ifc))
+
 #if defined (HAVE_RTADV)
 /* Order is intentional.  Matches RFC4191.  This array is also used for
    command matching, so only modify with care. */
@@ -400,6 +403,32 @@ if_flags_update (struct interface *ifp, uint64_t newflags)
     }
 }
 
+/**
+ * This function is called on address_change hook_call in case no
+ * distributed dataplane module is enabled (and can be called by the module too)
+ */
+int
+address_change (int cmd, int family, struct interface *ifp,
+                struct connected *ifc)
+{
+  if (family == AF_INET)
+    {
+      if (cmd == RTM_NEWADDR)
+        return if_set_prefix (ifp, ifc);
+      else if (cmd == RTM_DELADDR)
+        return if_unset_prefix (ifp, ifc);
+    }
+  else if (family == AF_INET6)
+    {
+      if (cmd == RTM_NEWADDR)
+        return if_prefix_add_ipv6 (ifp, ifc);
+      else if (cmd == RTM_DELADDR)
+        return if_prefix_delete_ipv6 (ifp, ifc);
+    }
+
+  return 1;
+}
+
 /* Wake up configured address if it is not in current kernel
    address. */
 static void
@@ -443,7 +472,8 @@ if_addr_wakeup (struct interface *ifp)
 		  if_refresh (ifp);
 		}
 
-	      ret = if_set_prefix (ifp, ifc);
+          /* ret = if_set_prefix (ifp, ifc); */
+          ret = hook_call (address_change, RTM_NEWADDR, AF_INET, ifp, ifc);
 	      if (ret < 0)
 		{
 		  zlog_warn ("Can't set interface's address: %s", 
@@ -465,7 +495,8 @@ if_addr_wakeup (struct interface *ifp)
 		  if_refresh (ifp);
 		}
 
-	      ret = if_prefix_add_ipv6 (ifp, ifc);
+          /* ret = if_prefix_add_ipv6 (ifp, ifc); */
+          ret = hook_call (address_change, RTM_NEWADDR, AF_INET6, ifp, ifc);
 	      if (ret < 0)
 		{
 		  zlog_warn ("Can't set interface's address: %s", 
@@ -2437,7 +2468,9 @@ ip_address_install (struct vty *vty, struct interface *ifp,
 	  if_refresh (ifp);
 	}
 
-      ret = if_set_prefix (ifp, ifc);
+      /* ret = if_set_prefix (ifp, ifc); */
+      ret = hook_call (address_change, RTM_NEWADDR, AF_INET, ifp, ifc);
+
       if (ret < 0)
 	{
 	  vty_out (vty, "%% Can't set interface IP address: %s.%s", 
@@ -2495,7 +2528,8 @@ ip_address_uninstall (struct vty *vty, struct interface *ifp,
     }
 
   /* This is real route. */
-  ret = if_unset_prefix (ifp, ifc);
+  /* ret = if_unset_prefix (ifp, ifc); */
+  ret = hook_call (address_change, RTM_DELADDR, AF_INET, ifp, ifc);
   if (ret < 0)
     {
       vty_out (vty, "%% Can't unset interface IP address: %s.%s", 
@@ -2632,7 +2666,8 @@ ipv6_address_install (struct vty *vty, struct interface *ifp,
 	  if_refresh (ifp);
 	}
 
-      ret = if_prefix_add_ipv6 (ifp, ifc);
+      /* ret = if_prefix_add_ipv6 (ifp, ifc); */
+      ret = hook_call (address_change, RTM_NEWADDR, AF_INET6, ifp, ifc);
 
       if (ret < 0)
 	{
@@ -2704,7 +2739,8 @@ ipv6_address_uninstall (struct vty *vty, struct interface *ifp,
     }
 
   /* This is real route. */
-  ret = if_prefix_delete_ipv6 (ifp, ifc);
+  /* ret = if_prefix_delete_ipv6 (ifp, ifc); */
+  ret = hook_call (address_change, RTM_DELADDR, AF_INET6, ifp, ifc);
   if (ret < 0)
     {
       vty_out (vty, "%% Can't unset interface IP address: %s.%s", 

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -37,6 +37,9 @@
 #define IF_ZEBRA_SHUTDOWN_OFF    0
 #define IF_ZEBRA_SHUTDOWN_ON     1
 
+DECLARE_HOOK (address_change, (int cmd, int family, struct interface *ifp,
+                              struct connected *ifc), (cmd, family, ifp, ifc))
+
 #if defined (HAVE_RTADV)
 /* Router advertisement parameter.  From RFC4861, RFC6275 and RFC4191. */
 struct rtadvconf
@@ -233,6 +236,8 @@ struct zebra_if
   u_char ptm_enable;
 };
 
+int address_change (int cmd, int family, struct interface *ifp,
+                    struct connected *ifc);
 
 extern struct interface *if_lookup_by_index_per_ns (struct zebra_ns *, u_int32_t);
 extern struct interface *if_lookup_by_name_per_ns (struct zebra_ns *, const char *);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -96,6 +96,9 @@ struct rib
   u_char nexthop_active_num;
 };
 
+#define RIB_SYSTEM_ROUTE(R)                                             \
+  ((R)->type == ZEBRA_ROUTE_KERNEL || (R)->type == ZEBRA_ROUTE_CONNECT)
+
 /* meta-queue structure:
  * sub-queue 0: connected, kernel
  * sub-queue 1: static
@@ -339,6 +342,14 @@ extern void rib_delnode (struct route_node *rn, struct rib *rib);
 extern int rib_install_kernel (struct route_node *rn, struct rib *rib, struct rib *old);
 extern int rib_uninstall_kernel (struct route_node *rn, struct rib *rib);
 
+int nexthop_active_update (struct route_node *rn, struct rib *rib, int set);
+
+int route_change (struct route_node *rn, struct rib *new, struct rib *old);
+int rib_process_after (struct route_node *rn,
+                       struct rib *old_selected, struct rib *new_selected,
+                       struct rib *old_fib, struct rib *new_fib,
+                       struct prefix *p, struct prefix *src_p,
+                       bool selected_changed, vrf_id_t vrf_id);
 /* NOTE:
  * All rib_add function will not just add prefix into RIB, but
  * also implicitly withdraw equal prefix of same type. */
@@ -491,5 +502,14 @@ rib_tables_iter_cleanup (rib_tables_iter_t *iter)
 }
 
 DECLARE_HOOK(rib_update, (struct route_node *rn, const char *reason), (rn, reason))
+DECLARE_HOOK(route_change, (struct route_node *rn, struct rib *new, struct rib *old),
+            (rn, new, old))
+DECLARE_HOOK(rib_process_after,
+             (struct route_node *rn, struct rib *old_selected,
+              struct rib *new_selected, struct rib *old_fib,
+              struct rib *new_fib, struct prefix *p, struct prefix *src_p,
+              bool selected_changed, vrf_id_t vrf_id),
+             (rn, old_selected, new_selected, old_fib, new_fib, p, src_p,
+              selected_changed, vrf_id))
 
 #endif /*_ZEBRA_RIB_H */

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -95,6 +95,8 @@
 #endif
 /* End of temporary definitions */
 
+DEFINE_HOOK (mpls_route_change, (int cmd, zebra_lsp_t *lsp), (cmd, lsp))
+
 struct gw_family_t
 {
   u_int16_t     filler;
@@ -1493,6 +1495,15 @@ kernel_neigh_update (int add, int ifindex, uint32_t addr, char *lla, int llalen)
  */
 int
 netlink_mpls_multipath (int cmd, zebra_lsp_t *lsp)
+{
+  return hook_call (mpls_route_change, cmd, lsp);
+}
+/**
+ * This function is called on mpls_route_change hook_call in case no
+ * distributed dataplane module is enabled (and can be called by the module too)
+ */
+int
+mpls_route_change (int cmd, zebra_lsp_t *lsp)
 {
   mpls_lse_t lse;
   zebra_nhlfe_t *nhlfe;

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -23,6 +23,7 @@
 
 #ifdef HAVE_NETLINK
 
+#include "hook.h"
 #include "zebra/zebra_mpls.h"
 
 #define NL_DEFAULT_ROUTE_METRIC 20
@@ -34,11 +35,14 @@
 #define RTPROT_RIP         189
 #define RTPROT_RIPNG       190
 
+DECLARE_HOOK (mpls_route_change, (int cmd, zebra_lsp_t *lsp), (cmd, lsp))
 
 extern void
 clear_nhlfe_installed (zebra_lsp_t *lsp);
 extern int
 netlink_mpls_multipath (int cmd, zebra_lsp_t *lsp);
+
+extern int mpls_route_change (int cmd, zebra_lsp_t *lsp);
 
 extern int netlink_route_change (struct sockaddr_nl *snl, struct nlmsghdr *h,
                                  ns_id_t ns_id, int startup);

--- a/zebra/zebra_dataplane.c
+++ b/zebra/zebra_dataplane.c
@@ -1,0 +1,26 @@
+#include "zebra.h"
+#include "if.h"
+#include "ioctl.h"
+#include "version.h"
+#include "zserv.h"
+#include "rt_netlink.h"
+#include "interface.h"
+#include "hook.h"
+#include "module.h"
+
+#include "zebra_dataplane.h"
+
+int
+init_default_dataplane (void)
+{
+  hook_register (address_change, address_change);
+
+  hook_register (route_change, route_change);
+  hook_register (rib_process_after, rib_process_after);
+
+  hook_register (mpls_route_change, mpls_route_change);
+  /* not needed */
+  /* hook_register (pw_change, pw_change); */
+
+  return 0;
+}

--- a/zebra/zebra_dataplane.h
+++ b/zebra/zebra_dataplane.h
@@ -1,0 +1,6 @@
+#ifndef ZEBRA_DATAPLANE_H_
+#define ZEBRA_DATAPLANE_H_
+
+int init_default_dataplane (void);
+
+#endif /* ZEBRA_DATAPLANE_H_ */

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -118,10 +118,6 @@ static int
 nhlfe_nhop_match (zebra_nhlfe_t *nhlfe, enum nexthop_types_t gtype,
                   union g_addr *gate, ifindex_t ifindex);
 static zebra_nhlfe_t *
-nhlfe_find (zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
-            enum nexthop_types_t gtype, union g_addr *gate,
-            ifindex_t ifindex);
-static zebra_nhlfe_t *
 nhlfe_add (zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
            enum nexthop_types_t gtype, union g_addr *gate,
            ifindex_t ifindex, mpls_label_t out_label);
@@ -1135,7 +1131,7 @@ nhlfe_nhop_match (zebra_nhlfe_t *nhlfe, enum nexthop_types_t gtype,
 /*
  * Locate NHLFE that matches with passed info.
  */
-static zebra_nhlfe_t *
+zebra_nhlfe_t *
 nhlfe_find (zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
             enum nexthop_types_t gtype, union g_addr *gate,
             ifindex_t ifindex)
@@ -1464,7 +1460,7 @@ lsp_json (zebra_lsp_t *lsp)
 
 
 /* Return a sorted linked list of the hash contents */
-static struct list *
+struct list *
 hash_get_sorted_list (struct hash *hash, void *cmp)
 {
   unsigned int i;
@@ -1483,7 +1479,7 @@ hash_get_sorted_list (struct hash *hash, void *cmp)
 /*
  * Compare two LSPs based on their label values.
  */
-static int
+int
 lsp_cmp (zebra_lsp_t *lsp1, zebra_lsp_t *lsp2)
 {
   if (lsp1->ile.in_label < lsp2->ile.in_label)
@@ -2987,11 +2983,13 @@ zebra_mpls_init (void)
 {
   mpls_enabled = 0;
 
+#if !defined(HAVE_DISTRIBUTED_DATAPLANE)
   if (mpls_kernel_init () < 0)
     {
       zlog_warn ("Disabling MPLS support (no kernel support)");
       return;
     }
+#endif
 
   if (! mpls_processq_init (&zebrad))
     mpls_enabled = 1;

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -172,6 +172,23 @@ struct zebra_fec_t_
 /* Function declarations. */
 
 /*
+ * Locate NHLFE that matches with passed info.
+ */
+zebra_nhlfe_t *
+nhlfe_find (zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
+            enum nexthop_types_t gtype, union g_addr *gate,
+            ifindex_t ifindex);
+
+/* Return a sorted linked list of the hash contents */
+struct list *
+hash_get_sorted_list (struct hash *hash, void *cmp);
+/*
+ * Compare two LSPs based on their label values.
+ */
+int
+lsp_cmp (zebra_lsp_t *lsp1, zebra_lsp_t *lsp2);
+
+/*
  * String to label conversion, labels separated by '/'.
  */
 int

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -52,6 +52,15 @@
 #include "zebra/connected.h"
 
 DEFINE_HOOK(rib_update, (struct route_node *rn, const char *reason), (rn, reason))
+DEFINE_HOOK(route_change, (struct route_node *rn, struct rib *new, struct rib *old),
+            (rn, new, old))
+DEFINE_HOOK(rib_process_after,
+            (struct route_node *rn, struct rib *old_selected,
+             struct rib *new_selected, struct rib *old_fib,
+             struct rib *new_fib, struct prefix *p, struct prefix *src_p,
+             bool selected_changed, vrf_id_t vrf_id),
+            (rn, old_selected, new_selected, old_fib, new_fib, p, src_p,
+             selected_changed, vrf_id))
 
 /* Should we allow non Quagga processes to delete our routes */
 extern int allow_delete;
@@ -905,9 +914,6 @@ rib_lookup_ipv4_route (struct prefix_ipv4 *p, union sockunion * qgate,
   return ZEBRA_RIB_NOTFOUND;
 }
 
-#define RIB_SYSTEM_ROUTE(R) \
-        ((R)->type == ZEBRA_ROUTE_KERNEL || (R)->type == ZEBRA_ROUTE_CONNECT)
-
 /* This function verifies reachability of one given nexthop, which can be
  * numbered or unnumbered, IPv4 or IPv6. The result is unconditionally stored
  * in nexthop->flags field. If the 4th parameter, 'set', is non-zero,
@@ -1037,7 +1043,7 @@ nexthop_active_check (struct route_node *rn, struct rib *rib,
  * Return value is the new number of active nexthops.
  */
 
-static int
+int
 nexthop_active_update (struct route_node *rn, struct rib *rib, int set)
 {
   struct nexthop *nexthop;
@@ -1181,6 +1187,58 @@ rib_uninstall_kernel (struct route_node *rn, struct rib *rib)
   return ret;
 }
 
+/**
+ * This function is called on route_change hook_call in case no
+ * distributed dataplane module is enabled (and can be called by the module too)
+ */
+int
+route_change (struct route_node *rn, struct rib *new, struct rib *old)
+{
+  int ret = 1;
+
+  if (!new && !old)
+    {
+      char buf[SRCDEST2STR_BUFFER];
+      srcdest_rnode2str(rn, buf, sizeof(buf));
+      zlog_warn ("%s: No Rib provided for Route", buf);
+      return 1;
+    }
+  rib_table_info_t *info = srcdest_rnode_table_info(rn);
+  /* Add or Update */
+  if (new)
+    {
+      /* If labeled-unicast route, install transit LSP. */
+      if (zebra_rib_labeled_unicast (new))
+        zebra_mpls_lsp_install (info->zvrf, rn, new);
+
+      /* Non-system route should be installed. */
+      if (!RIB_SYSTEM_ROUTE (new))
+        {
+          if ((ret = rib_install_kernel (rn, new, old)))
+            {
+              char buf[SRCDEST2STR_BUFFER];
+              srcdest_rnode2str(rn, buf, sizeof(buf));
+              zlog_warn ("%u:%s: Route install failed",
+                         new->vrf_id, buf);
+            }
+        }
+      else
+        ret = 0;
+    }
+  else
+    {
+      /* If labeled-unicast route, uninstall transit LSP. */
+      if (zebra_rib_labeled_unicast (old))
+        zebra_mpls_lsp_uninstall (info->zvrf, rn, old);
+
+      /* Del */
+      if (!RIB_SYSTEM_ROUTE (old))
+        ret = rib_uninstall_kernel (rn, old);
+    }
+
+  return ret;
+}
+
 /* Uninstall the route from kernel. */
 static void
 rib_uninstall (struct route_node *rn, struct rib *rib)
@@ -1192,14 +1250,8 @@ rib_uninstall (struct route_node *rn, struct rib *rib)
       if (info->safi == SAFI_UNICAST)
         hook_call(rib_update, rn, "rib_uninstall");
 
-      if (! RIB_SYSTEM_ROUTE (rib))
-	rib_uninstall_kernel (rn, rib);
-
-      /* If labeled-unicast route, uninstall transit LSP. */
-      if (zebra_rib_labeled_unicast (rib))
-        zebra_mpls_lsp_uninstall (info->zvrf, rn, rib);
-
-       UNSET_FLAG (rib->status, RIB_ENTRY_SELECTED_FIB);
+      hook_call (route_change, rn, NULL, rib);
+      UNSET_FLAG (rib->status, RIB_ENTRY_SELECTED_FIB);
     }
 
   if (CHECK_FLAG (rib->flags, ZEBRA_FLAG_SELECTED))
@@ -1294,20 +1346,7 @@ rib_process_add_fib(struct zebra_vrf *zvrf, struct route_node *rn,
                    zvrf_id (zvrf), buf, rn, new, new->type);
     }
 
-  /* If labeled-unicast route, install transit LSP. */
-  if (zebra_rib_labeled_unicast (new))
-    zebra_mpls_lsp_install (zvrf, rn, new);
-
-  if (!RIB_SYSTEM_ROUTE (new))
-    {
-      if (rib_install_kernel (rn, new, NULL))
-        {
-          char buf[SRCDEST2STR_BUFFER];
-          srcdest_rnode2str(rn, buf, sizeof(buf));
-          zlog_warn ("%u:%s: Route install failed",
-                     zvrf_id (zvrf), buf);
-        }
-    }
+  hook_call (route_change, rn, new, NULL);
 
   UNSET_FLAG(new->status, RIB_ENTRY_CHANGED);
 }
@@ -1327,12 +1366,7 @@ rib_process_del_fib(struct zebra_vrf *zvrf, struct route_node *rn,
                   zvrf_id (zvrf), buf, rn, old, old->type);
     }
 
-  /* If labeled-unicast route, uninstall transit LSP. */
-  if (zebra_rib_labeled_unicast (old))
-    zebra_mpls_lsp_uninstall (zvrf, rn, old);
-
-  if (!RIB_SYSTEM_ROUTE (old))
-    rib_uninstall_kernel (rn, old);
+  hook_call (route_change, rn, NULL, old);
 
   UNSET_FLAG (old->status, RIB_ENTRY_SELECTED_FIB);
 
@@ -1381,27 +1415,10 @@ rib_process_update_fib (struct zebra_vrf *zvrf, struct route_node *rn,
                 zlog_debug ("%u:%s: Updating route rn %p, rib %p (type %d)",
                             zvrf_id (zvrf), buf, rn, new, new->type);
             }
+          if (hook_call (route_change, rn, new, old) != 0)
+            installed = 0;
 
-          /* If labeled-unicast route, uninstall transit LSP. */
-          if (zebra_rib_labeled_unicast (old))
-            zebra_mpls_lsp_uninstall (zvrf, rn, old);
-
-          /* Non-system route should be installed. */
-          if (!RIB_SYSTEM_ROUTE (new))
-            {
-              /* If labeled-unicast route, install transit LSP. */
-              if (zebra_rib_labeled_unicast (new))
-                zebra_mpls_lsp_install (zvrf, rn, new);
-
-              if (rib_install_kernel (rn, new, old))
-                {
-                  char buf[SRCDEST2STR_BUFFER];
-                  srcdest_rnode2str(rn, buf, sizeof(buf));
-                  installed = 0;
-                  zlog_warn ("%u:%s: Route install failed", zvrf_id (zvrf), buf);
-                }
-            }
-
+#if !defined(HAVE_DISTRIBUTED_DATAPLANE)
           /* If install succeeded or system route, cleanup flags for prior route. */
           if (installed && new != old)
             {
@@ -1416,6 +1433,7 @@ rib_process_update_fib (struct zebra_vrf *zvrf, struct route_node *rn,
                     UNSET_FLAG (nexthop->flags, NEXTHOP_FLAG_FIB);
                 }
             }
+#endif
 
           /* Update for redistribution. */
           if (installed)
@@ -1443,12 +1461,7 @@ rib_process_update_fib (struct zebra_vrf *zvrf, struct route_node *rn,
                             nh_active ? "install failed" : "nexthop inactive");
             }
 
-          /* If labeled-unicast route, uninstall transit LSP. */
-          if (zebra_rib_labeled_unicast (old))
-            zebra_mpls_lsp_uninstall (zvrf, rn, old);
-
-          if (!RIB_SYSTEM_ROUTE (old))
-            rib_uninstall_kernel (rn, old);
+          hook_call (route_change, rn, NULL, old);
           UNSET_FLAG (new->status, RIB_ENTRY_SELECTED_FIB);
         }
     }
@@ -1471,7 +1484,7 @@ rib_process_update_fib (struct zebra_vrf *zvrf, struct route_node *rn,
                 break;
               }
           if (!in_fib)
-            rib_install_kernel (rn, new, NULL);
+            hook_call (route_change, rn, new, NULL);
         }
     }
 
@@ -1692,6 +1705,25 @@ rib_process (struct route_node *rn)
   else if (old_fib)
     rib_process_del_fib (zvrf, rn, old_fib);
 
+  hook_call (rib_process_after, rn, old_selected, new_selected,
+             old_fib, new_fib, p, src_p, selected_changed, vrf_id);
+
+}
+
+/**
+ * This function is called on rib_process_after hook_call in case no
+ * distributed dataplane module is enabled (and can be called by the module too)
+ */
+int
+rib_process_after (struct route_node *rn,
+                   struct rib *old_selected, struct rib *new_selected,
+                   struct rib *old_fib, struct rib *new_fib,
+                   struct prefix *p, struct prefix *src_p,
+                   bool selected_changed, vrf_id_t vrf_id)
+{
+  struct rib *rib;
+  struct rib *next;
+
   /* Redistribute SELECTED entry */
   if (old_selected != new_selected || selected_changed)
     {
@@ -1751,6 +1783,8 @@ rib_process (struct route_node *rn)
    * Check if the dest can be deleted now.
    */
   rib_gc_dest (rn);
+
+  return 0;
 }
 
 /* Take a list of route_node structs and return 1, if there was a record
@@ -2920,8 +2954,7 @@ rib_close_table (struct route_table *table)
           if (info->safi == SAFI_UNICAST)
             hook_call(rib_update, rn, NULL);
 
-	  if (! RIB_SYSTEM_ROUTE (rib))
-	    rib_uninstall_kernel (rn, rib);
+          hook_call (route_change, rn, NULL, rib);
         }
 }
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1272,6 +1272,10 @@ zread_ipv4_add (struct zserv *client, u_short length, struct zebra_vrf *zvrf)
   else
     rib->mtu = 0;
 
+  if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+    zlog_debug("%s: received route for  %s/%d",
+               __func__, inet_ntoa(p.u.prefix4), p.prefixlen);
+
   /* Table */
   rib->table = zvrf->table_id;
 


### PR DESCRIPTION
Using the recently added feature to allow loading modules dynamically
with dlopen, a few hooks are added to be able to have a remote
dataplane. In particular, control is outsourced for:

- Add and delete IP addresses.
- Add and delete IP routes.
- Add and delete MPLS routes.

Once Zebra PW management is merge, it will be added too:

- Add and delete Pseudowires.

If an external module is enabled, installation of routes is held in
Zebra and the module is responsible for it.

A new command line parameter, --dp-opts, is added to be able to tweak
module execution. It's up to the module to parse and use content passed
into it.

Signed-off-by: ßingen <bingen@voltanet.io>