### PR TITLE
pimd: Allow secondary address comparisons to work

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -98,6 +98,7 @@ pim_rp_init (void)
   str2prefix ("224.0.0.0/4", &rp_info->group);
   rp_info->group.family = AF_INET;
   rp_info->rp.rpf_addr.family = AF_INET;
+  rp_info->rp.rpf_addr.prefixlen = IPV4_MAX_PREFIXLEN;
   rp_info->rp.rpf_addr.u.prefix4.s_addr = INADDR_NONE;
   tail = rp_info;
 
@@ -306,6 +307,7 @@ pim_rp_new (const char *rp, const char *group_range, const char *plist)
     }
 
   rp_info->rp.rpf_addr.family = AF_INET;
+  rp_info->rp.rpf_addr.prefixlen = IPV4_MAX_PREFIXLEN;
   result = inet_pton (rp_info->rp.rpf_addr.family, rp, &rp_info->rp.rpf_addr.u.prefix4);
 
   if (result <= 0)


### PR DESCRIPTION
The secondary address comparison done to determine if we are
an RP for a specified address was comparing A.B.C.D/32 to A.B.C.D/0
because when we created the rp_info we were not setting the prefixlen

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>