### PR TITLE
ldpd: Fix bug with LDP dual-stack

### DIFF
--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -82,8 +82,8 @@ adj_new(struct in_addr lsr_id, struct hello_source *source,
 {
 	struct adj	*adj;
 
-	log_debug("%s: lsr-id %s, %s", __func__, inet_ntoa(lsr_id),
-	    log_hello_src(source));
+	log_debug("%s: lsr-id %s, %s, transport addres: %s", __func__, inet_ntoa(lsr_id),
+	    log_hello_src(source), log_addr(source->link.ia->af, addr));
 
 	if ((adj = calloc(1, sizeof(*adj))) == NULL)
 		fatal(__func__);

--- a/ldpd/neighbor.c
+++ b/ldpd/neighbor.c
@@ -103,7 +103,16 @@ struct nbr_pid_head nbrs_by_pid = RB_INITIALIZER(&nbrs_by_pid);
 static __inline int
 nbr_id_compare(struct nbr *a, struct nbr *b)
 {
-	return (ntohl(a->id.s_addr) - ntohl(b->id.s_addr));
+	int ret;
+	ret = (ntohl(a->id.s_addr) - ntohl(b->id.s_addr));
+	if (ret != 0)
+		return ret;
+	if (a->af < b->af)
+		return (-1);
+	if (a->af > b->af)
+		return (1);
+
+	return (ldp_addrcmp(a->af, &a->raddr, &b->raddr));
 }
 
 static __inline int


### PR DESCRIPTION
Sometimes connection between neighbors doesn't get established because
it creates first the IPv4 neighbor and then it's unable to find the IPv6
one.

The scenario to reproduce it is the following:
Config of first node:
```
interface 1-xge3.100
 ip address 10.0.0.1/24
 ip router isis 1.1.1.0
 ipv6 address abcd:1:10::1/120
 ipv6 router isis 1.1.1.0
 isis circuit-type level-2-only
!
interface lo
 ip address 1.1.1.0/32
 ip router isis 1.1.1.0
 ipv6 address abcd::1/128
 ipv6 router isis 1.1.1.0
 isis circuit-type level-2-only
 isis passive
!
mpls ldp
 router-id 1.1.1.0
 !
 address-family ipv4
  discovery transport-address 1.1.1.0
  !
  interface 1-xge3.100
  !
 !
 address-family ipv6
  discovery transport-address abcd::1
  !
  interface 1-xge3.100
```
Config of second node:
```
interface 2-xge3.100
 ip address 10.0.0.2/24
 ip router isis 2.2.2.0
 ipv6 address abcd:1:10::2/120
 ipv6 router isis 2.2.2.0
 isis circuit-type level-2-only
!
interface lo
 ip address 2.2.2.0/32
 ip router isis 2.2.2.0
 ipv6 address abcd::2/128
 ipv6 router isis 2.2.2.0
 isis circuit-type level-2-only
 isis passive
!
mpls ldp
 router-id 2.2.2.0
 !
 address-family ipv4
  discovery transport-address 2.2.2.0
  !
  interface 2-xge3.100
  !
 !
 address-family ipv6
  discovery transport-address abcd::2
  !
  interface 2-xge3.100
```

After the first node is running and configured the trick is to manually configure second node, enabling first IPv4 and after a few seconds adding IPv6 conf.

Log from first node:
```
2017/05/22 15:20:12 LDP: adj_new: lsr-id 2.2.2.0, iface 1-xge3.100
2017/05/22 15:20:12 LDP: nbr_new: lsr-id 2.2.2.0 transport-address 2.2.2.0
2017/05/22 15:20:13 LDP: adj_new: lsr-id 2.2.2.0, iface 1-xge3.100
2017/05/22 15:20:21 LDP: pending_conn_timeout: no adjacency with remote end: abcd::2
2017/05/22 15:20:41 LDP: pending_conn_timeout: no adjacency with remote end: abcd::2
2017/05/22 15:21:16 LDP: pending_conn_timeout: no adjacency with remote end: abcd::2
(...)
```
Log from second node:
```
2017/05/22 15:20:16 LDP: adj_new: lsr-id 1.1.1.0, iface 2-xge3.100
2017/05/22 15:20:16 LDP: adj_new: lsr-id 1.1.1.0, iface 2-xge3.100
2017/05/22 15:20:16 LDP: nbr_new: lsr-id 1.1.1.0 transport-address abcd::1
2017/05/22 15:20:16 LDP: nbr_fsm: event CONNECTION UP resulted in action SETUP NEIGHBOR CONNECTION and changing state for lsr-id 1.1.1.0 from PRESENT to INITIALIZED
2017/05/22 15:20:16 LDP: msg[out]: initialization: lsr-id 1.1.1.0
2017/05/22 15:20:16 LDP: nbr_fsm: event INIT SENT resulted in action NOTHING and changing state for lsr-id 1.1.1.0 from INITIALIZED to OPENSENT
2017/05/22 15:20:21 LDP: msg[in]: notification: lsr-id 1.1.1.0: Session Rejected, No Hello (fatal)
2017/05/22 15:20:21 LDP: nbr_fsm: event SESSION CLOSE resulted in action CLOSE SESSION and changing state for lsr-id 1.1.1.0 from OPENSENT to PRESENT
2017/05/22 15:20:21 LDP: session_close: closing session with lsr-id 1.1.1.0
2017/05/22 15:20:36 LDP: nbr_idtimer: lsr-id 1.1.1.0
2017/05/22 15:20:36 LDP: nbr_fsm: event CONNECTION UP resulted in action SETUP NEIGHBOR CONNECTION and changing state for lsr-id 1.1.1.0 from PRESENT to INITIALIZED
2017/05/22 15:20:36 LDP: msg[out]: initialization: lsr-id 1.1.1.0
2017/05/22 15:20:36 LDP: nbr_fsm: event INIT SENT resulted in action NOTHING and changing state for lsr-id 1.1.1.0 from INITIALIZED to OPENSENT
2017/05/22 15:20:41 LDP: msg[in]: notification: lsr-id 1.1.1.0: Session Rejected, No Hello (fatal)
2017/05/22 15:20:41 LDP: nbr_fsm: event SESSION CLOSE resulted in action CLOSE SESSION and changing state for lsr-id 1.1.1.0 from OPENSENT to PRESENT
2017/05/22 15:20:41 LDP: session_close: closing session with lsr-id 1.1.1.0
(...)
```
Signed-off-by: ßingen <bingen@voltanet.io>