### PR TITLE
bgpd: fix issue with ipv6 ecmp with vrfs

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1509,7 +1509,8 @@ bgp_zebra_announce (struct prefix *p, struct bgp_info *info, struct bgp *bgp,
           if (!ifindex)
 	    {
 	      if (mpinfo->peer->conf_if || mpinfo->peer->ifname)
-		ifindex = ifname2ifindex (mpinfo->peer->conf_if ? mpinfo->peer->conf_if : mpinfo->peer->ifname);
+                ifindex = ifname2ifindex_vrf (mpinfo->peer->conf_if ? mpinfo->peer->conf_if :
+                                              mpinfo->peer->ifname, bgp->vrf_id);
 	      else if (mpinfo->peer->nexthop.ifp)
 		ifindex = mpinfo->peer->nexthop.ifp->ifindex;
 	    }


### PR DESCRIPTION
Problem reported by customer that ipv6 wasn't installing ecmp paths
when using vrfs.  Found a vrf-unware call in bgp_zebra_announce that
was the culprit.  Testing of the fix looks good.

Ticket: CM-15545
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>