### PR TITLE
vtysh: fix a compile error when user/group are disabled

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2488,6 +2488,7 @@ vtysh_write_config_integrated(void)
       err++;
     }
 
+#ifdef FRR_USER
   pwentry = getpwnam (FRR_USER);
   if (pwentry)
     uid = pwentry->pw_uid;
@@ -2496,7 +2497,8 @@ vtysh_write_config_integrated(void)
       printf ("%% Warning: could not look up user \"%s\"\n", FRR_USER);
       err++;
     }
-
+#endif
+#ifdef FRR_GROUP
   grentry = getgrnam (FRR_GROUP);
   if (grentry)
     gid = grentry->gr_gid;
@@ -2505,6 +2507,7 @@ vtysh_write_config_integrated(void)
       printf ("%% Warning: could not look up group \"%s\"\n", FRR_GROUP);
       err++;
     }
+#endif
 
   if (!fstat (fd, &st))
     {


### PR DESCRIPTION
If FRR is configured explicilty with --disable-user and
--disable-group, FRR_USER and FRR_GROUP will not be defined
and can be safely skipped in vtysh.

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>