### PR TITLE
lib, ripngd: Remove ripng specialized data in table.h

### DIFF
--- a/lib/table.h
+++ b/lib/table.h
@@ -89,8 +89,6 @@ struct route_table
   /* Each node of route. */			\
   void *info;					\
 						\
-  /* Aggregation. */				\
-  void *aggregate;
 
 
 /* Each routing entry. */

--- a/ripngd/Makefile.am
+++ b/ripngd/Makefile.am
@@ -16,7 +16,8 @@ libripng_a_SOURCES = \
 
 noinst_HEADERS = \
 	ripng_memory.h \
-	ripng_debug.h ripng_route.h ripngd.h ripng_nexthop.h
+	ripng_debug.h ripng_route.h ripngd.h ripng_nexthop.h \
+	ripng_table.h
 
 ripngd_SOURCES = \
 	ripng_main.c $(libripng_a_SOURCES)

--- a/ripngd/ripng_route.h
+++ b/ripngd/ripng_route.h
@@ -22,6 +22,8 @@
 #ifndef _ZEBRA_RIPNG_ROUTE_H
 #define _ZEBRA_RIPNG_ROUTE_H
 
+#include "ripngd/ripng_table.h"
+
 struct ripng_aggregate
 {
   /* Aggregate route count. */
@@ -43,11 +45,11 @@ struct ripng_aggregate
   u_int16_t tag_out;
 };
 
-extern void ripng_aggregate_increment (struct route_node *rp,
+extern void ripng_aggregate_increment (struct ripng_node *rp,
                                        struct ripng_info *rinfo);
-extern void ripng_aggregate_decrement (struct route_node *rp,
+extern void ripng_aggregate_decrement (struct ripng_node *rp,
                                        struct ripng_info *rinfo);
-extern void ripng_aggregate_decrement_list (struct route_node *rp,
+extern void ripng_aggregate_decrement_list (struct ripng_node *rp,
                                        struct list *list);
 extern int ripng_aggregate_add (struct prefix *p);
 extern int ripng_aggregate_delete (struct prefix *p);

--- a/ripngd/ripng_table.h
+++ b/ripngd/ripng_table.h
@@ -1,0 +1,90 @@
+/*
+ * RIPNG Table Routines
+ * Copyright (C) 2017 Cumulus Networks, Inc.
+ *                    Donald Sharp
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __RIPNGD_TABLE_H__
+#define __RIPNGD_TABLE_H__
+
+#include "table.h"
+
+extern route_table_delegate_t ripng_delegate;
+
+struct ripng_node
+{
+  ROUTE_NODE_FIELDS
+
+  /* Aggregation. */
+  void *aggregate;
+};
+
+static inline void
+ripng_unlock_node (struct ripng_node *node)
+{
+  route_unlock_node ((struct route_node *)node);
+}
+
+static inline struct ripng_node *
+ripng_table_top (struct route_table *table)
+{
+  return (struct ripng_node *)route_top (table);
+}
+
+static inline struct ripng_node *
+ripng_route_next (struct ripng_node *node)
+{
+  return (struct ripng_node *)route_next ((struct route_node *)node);
+}
+
+static inline void
+ripng_route_unlock_node (struct ripng_node *node)
+{
+  route_unlock_node ((struct route_node *)node);
+}
+
+static inline struct ripng_node *
+ripng_route_lock_node (struct ripng_node *node)
+{
+  return (struct ripng_node *)route_lock_node ((struct route_node *)node);
+}
+
+static inline struct ripng_node *
+ripng_route_node_match (struct route_table *table, struct prefix *p)
+{
+  return (struct ripng_node *)route_node_match (table, p);
+}
+
+static inline struct ripng_node *
+ripng_route_node_get (struct route_table *table, struct prefix *p)
+{
+  return (struct ripng_node *)route_node_get (table, p);
+}
+
+static inline struct ripng_node *
+ripng_route_node_lookup (struct route_table *table, struct prefix *p)
+{
+  return (struct ripng_node *)route_node_lookup (table, p);
+}
+static inline struct ripng_node *
+ripng_route_next_until (struct ripng_node *node, struct ripng_node *until)
+{
+  return (struct ripng_node *)route_next_until ((struct route_node *)node,
+						(struct route_node *)until);
+}
+
+#endif

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -31,6 +31,7 @@
 #include "log.h"
 
 #include "ripngd/ripngd.h"
+#include "ripngd/ripng_table.h"
 #include "ripngd/ripng_debug.h"
 
 /* All information about zebra. */
@@ -38,7 +39,7 @@ struct zclient *zclient = NULL;
 
 /* Send ECMP routes to zebra. */
 static void
-ripng_zebra_ipv6_send (struct route_node *rp, u_char cmd)
+ripng_zebra_ipv6_send (struct ripng_node *rp, u_char cmd)
 {
   static struct in6_addr **nexthops = NULL;
   static ifindex_t *ifindexes = NULL;
@@ -118,14 +119,14 @@ ripng_zebra_ipv6_send (struct route_node *rp, u_char cmd)
 
 /* Add/update ECMP routes to zebra. */
 void
-ripng_zebra_ipv6_add (struct route_node *rp)
+ripng_zebra_ipv6_add (struct ripng_node *rp)
 {
   ripng_zebra_ipv6_send (rp, ZEBRA_IPV6_ROUTE_ADD);
 }
 
 /* Delete ECMP routes from zebra. */
 void
-ripng_zebra_ipv6_delete (struct route_node *rp)
+ripng_zebra_ipv6_delete (struct ripng_node *rp)
 {
   ripng_zebra_ipv6_send (rp, ZEBRA_IPV6_ROUTE_DELETE);
 }

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -37,6 +37,7 @@
 #include "privs.h"
 
 #include "ripngd/ripngd.h"
+#include "ripngd/ripng_table.h"
 #include "ripngd/ripng_route.h"
 #include "ripngd/ripng_debug.h"
 #include "ripngd/ripng_nexthop.h"
@@ -408,7 +409,7 @@ static int
 ripng_garbage_collect (struct thread *t)
 {
   struct ripng_info *rinfo;
-  struct route_node *rp;
+  struct ripng_node *rp;
 
   rinfo = THREAD_ARG (t);
   rinfo->t_garbage_collect = NULL;
@@ -425,7 +426,7 @@ ripng_garbage_collect (struct thread *t)
     {
       list_free (rp->info);
       rp->info = NULL;
-      route_unlock_node (rp);
+      ripng_route_unlock_node (rp);
     }
 
   /* Free RIPng routing information. */
@@ -443,7 +444,7 @@ static void ripng_timeout_update (struct ripng_info *rinfo);
 struct ripng_info *
 ripng_ecmp_add (struct ripng_info *rinfo_new)
 {
-  struct route_node *rp = rinfo_new->rp;
+  struct ripng_node *rp = rinfo_new->rp;
   struct ripng_info *rinfo = NULL;
   struct list *list = NULL;
 
@@ -484,7 +485,7 @@ ripng_ecmp_add (struct ripng_info *rinfo_new)
 struct ripng_info *
 ripng_ecmp_replace (struct ripng_info *rinfo_new)
 {
-  struct route_node *rp = rinfo_new->rp;
+  struct ripng_node *rp = rinfo_new->rp;
   struct list *list = (struct list *)rp->info;
   struct ripng_info *rinfo = NULL, *tmp_rinfo = NULL;
   struct listnode *node = NULL, *nextnode = NULL;
@@ -544,7 +545,7 @@ ripng_ecmp_replace (struct ripng_info *rinfo_new)
 struct ripng_info *
 ripng_ecmp_delete (struct ripng_info *rinfo)
 {
-  struct route_node *rp = rinfo->rp;
+  struct ripng_node *rp = rinfo->rp;
   struct list *list = (struct list *)rp->info;
 
   RIPNG_TIMER_OFF (rinfo->t_timeout);
@@ -689,7 +690,7 @@ ripng_route_process (struct rte *rte, struct sockaddr_in6 *from,
 {
   int ret;
   struct prefix_ipv6 p;
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo = NULL, newinfo;
   struct ripng_interface *ri;
   struct in6_addr *nexthop;
@@ -791,7 +792,7 @@ ripng_route_process (struct rte *rte, struct sockaddr_in6 *from,
     nexthop = &from->sin6_addr;
 
   /* Lookup RIPng routing table. */
-  rp = route_node_get (ripng->table, (struct prefix *) &p);
+  rp = ripng_route_node_get (ripng->table, (struct prefix *) &p);
 
   newinfo.rp = rp;
   newinfo.nexthop = *nexthop;
@@ -817,7 +818,7 @@ ripng_route_process (struct rte *rte, struct sockaddr_in6 *from,
             if (rte->metric > rinfo->metric)
               {
                 /* New route has a greater metric. Discard it. */
-                route_unlock_node (rp);
+                ripng_route_unlock_node (rp);
                 return;
               }
 
@@ -839,7 +840,7 @@ ripng_route_process (struct rte *rte, struct sockaddr_in6 *from,
       if (rinfo->type != ZEBRA_ROUTE_RIPNG
 	  && rinfo->metric != RIPNG_METRIC_INFINITY)
         {
-          route_unlock_node (rp);
+          ripng_route_unlock_node (rp);
           return;
         }
 
@@ -849,7 +850,7 @@ ripng_route_process (struct rte *rte, struct sockaddr_in6 *from,
 	      (rinfo->sub_type == RIPNG_ROUTE_DEFAULT))
 	  && rinfo->metric != RIPNG_METRIC_INFINITY)
         {
-          route_unlock_node (rp);
+          ripng_route_unlock_node (rp);
           return;
         }
     }
@@ -912,7 +913,7 @@ ripng_route_process (struct rte *rte, struct sockaddr_in6 *from,
         ripng_timeout_update (rinfo);
 
       /* Unlock tempolary lock of the route. */
-      route_unlock_node (rp);
+      ripng_route_unlock_node (rp);
     }
 }
 
@@ -922,7 +923,7 @@ ripng_redistribute_add (int type, int sub_type, struct prefix_ipv6 *p,
 			ifindex_t ifindex, struct in6_addr *nexthop,
 			route_tag_t tag)
 {
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo = NULL, newinfo;
   struct list *list = NULL;
 
@@ -932,7 +933,7 @@ ripng_redistribute_add (int type, int sub_type, struct prefix_ipv6 *p,
   if (IN6_IS_ADDR_LOOPBACK (&p->prefix))
     return;
 
-  rp = route_node_get (ripng->table, (struct prefix *) p);
+  rp = ripng_route_node_get (ripng->table, (struct prefix *) p);
 
   memset (&newinfo, 0, sizeof (struct ripng_info));
   newinfo.type = type;
@@ -952,7 +953,7 @@ ripng_redistribute_add (int type, int sub_type, struct prefix_ipv6 *p,
       if (rinfo->type == ZEBRA_ROUTE_CONNECT
           && rinfo->sub_type == RIPNG_ROUTE_INTERFACE
 	  && rinfo->metric != RIPNG_METRIC_INFINITY) {
-        route_unlock_node (rp);
+        ripng_route_unlock_node (rp);
 	   return;
       }
 
@@ -964,13 +965,13 @@ ripng_redistribute_add (int type, int sub_type, struct prefix_ipv6 *p,
               (rinfo->sub_type == RIPNG_ROUTE_DEFAULT)) ) {
         if (type != ZEBRA_ROUTE_RIPNG || ((sub_type != RIPNG_ROUTE_STATIC) &&
                                           (sub_type != RIPNG_ROUTE_DEFAULT))) {
-	  route_unlock_node (rp);
+	  ripng_route_unlock_node (rp);
 	  return;
 	}
       }
 
       ripng_ecmp_replace (&newinfo);
-      route_unlock_node (rp);
+      ripng_route_unlock_node (rp);
     }
   else
     ripng_ecmp_add (&newinfo);
@@ -994,7 +995,7 @@ void
 ripng_redistribute_delete (int type, int sub_type, struct prefix_ipv6 *p, 
 			   ifindex_t ifindex)
 {
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo;
 
   if (IN6_IS_ADDR_LINKLOCAL (&p->prefix))
@@ -1002,7 +1003,7 @@ ripng_redistribute_delete (int type, int sub_type, struct prefix_ipv6 *p,
   if (IN6_IS_ADDR_LOOPBACK (&p->prefix))
     return;
 
-  rp = route_node_lookup (ripng->table, (struct prefix *) p);
+  rp = ripng_route_node_lookup (ripng->table, (struct prefix *) p);
 
   if (rp)
     {
@@ -1036,7 +1037,7 @@ ripng_redistribute_delete (int type, int sub_type, struct prefix_ipv6 *p,
               ripng_event (RIPNG_TRIGGERED_UPDATE, 0);
             }
         }
-      route_unlock_node (rp);
+      ripng_route_unlock_node (rp);
     }
 }
 
@@ -1044,14 +1045,14 @@ ripng_redistribute_delete (int type, int sub_type, struct prefix_ipv6 *p,
 void
 ripng_redistribute_withdraw (int type)
 {
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo = NULL;
   struct list *list = NULL;
 
   if (!ripng)
     return;
   
-  for (rp = route_top (ripng->table); rp; rp = route_next (rp))
+  for (rp = ripng_table_top (ripng->table); rp; rp = ripng_route_next (rp))
     if ((list = rp->info) != NULL)
       {
 	rinfo = listgetdata (listhead (list));
@@ -1223,7 +1224,7 @@ ripng_request_process (struct ripng_packet *packet,int size,
   caddr_t lim;
   struct rte *rte;
   struct prefix_ipv6 p;
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo;
   struct ripng_interface *ri;
 
@@ -1285,13 +1286,13 @@ ripng_request_process (struct ripng_packet *packet,int size,
 	  p.prefixlen = rte->prefixlen;
 	  apply_mask_ipv6 (&p);
 	  
-	  rp = route_node_lookup (ripng->table, (struct prefix *) &p);
+	  rp = ripng_route_node_lookup (ripng->table, (struct prefix *) &p);
 
 	  if (rp)
 	    {
 	      rinfo = listgetdata (listhead ((struct list *)rp->info));
 	      rte->metric = rinfo->metric;
-	      route_unlock_node (rp);
+	      ripng_route_unlock_node (rp);
 	    }
 	  else
 	    rte->metric = RIPNG_METRIC_INFINITY;
@@ -1396,12 +1397,12 @@ ripng_read (struct thread *thread)
 static void
 ripng_clear_changed_flag (void)
 {
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo = NULL;
   struct list *list = NULL;
   struct listnode *listnode = NULL;
 
-  for (rp = route_top (ripng->table); rp; rp = route_next (rp))
+  for (rp = ripng_table_top (ripng->table); rp; rp = ripng_route_next (rp))
     if ((list = rp->info) != NULL)
       for (ALL_LIST_ELEMENTS_RO (list, listnode, rinfo))
         {
@@ -1580,7 +1581,7 @@ ripng_output_process (struct interface *ifp, struct sockaddr_in6 *to,
 		      int route_type)
 {
   int ret;
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo;
   struct ripng_interface *ri;
   struct ripng_aggregate *aggregate;
@@ -1602,7 +1603,7 @@ ripng_output_process (struct interface *ifp, struct sockaddr_in6 *to,
  
   ripng_rte_list = ripng_rte_new();
  
-  for (rp = route_top (ripng->table); rp; rp = route_next (rp))
+  for (rp = ripng_table_top (ripng->table); rp; rp = ripng_route_next (rp))
     {
       if ((list = rp->info) != NULL &&
           (rinfo = listgetdata (listhead (list))) != NULL &&
@@ -1817,6 +1818,30 @@ ripng_output_process (struct interface *ifp, struct sockaddr_in6 *to,
   ripng_rte_free(ripng_rte_list);
 }
 
+static struct route_node *
+ripng_route_node_create (route_table_delegate_t *delegate,
+			 struct route_table *table)
+{
+  struct ripng_node *node;
+
+  node = XCALLOC (MTYPE_ROUTE_NODE, sizeof (*node));
+
+  return (struct route_node *)node;
+}
+
+static void
+ripng_route_node_destroy (route_table_delegate_t *delegate,
+			  struct route_table *table,
+			  struct route_node *node)
+{
+  XFREE(MTYPE_ROUTE_NODE, node);
+}
+
+route_table_delegate_t ripng_delegate = {
+  .create_node = ripng_route_node_create,
+  .destroy_node = ripng_route_node_destroy
+};
+
 /* Create new RIPng instance and set it to global variable. */
 static int
 ripng_create (void)
@@ -1839,9 +1864,9 @@ ripng_create (void)
   ripng->obuf = stream_new (RIPNG_MAX_PACKET_SIZE);
 
   /* Initialize RIPng routig table. */
-  ripng->table = route_table_init ();
-  ripng->route = route_table_init ();
-  ripng->aggregate = route_table_init ();
+  ripng->table = route_table_init_with_delegate (&ripng_delegate);
+  ripng->route = route_table_init_with_delegate (&ripng_delegate);
+  ripng->aggregate = route_table_init_with_delegate (&ripng_delegate);
  
   /* Make socket. */
   ripng->sock = ripng_make_socket ();
@@ -1992,7 +2017,7 @@ DEFUN (show_ipv6_ripng,
        IPV6_STR
        "Show RIPng routes\n")
 {
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo;
   struct ripng_aggregate *aggregate;
   struct prefix_ipv6 *p;
@@ -2012,7 +2037,7 @@ DEFUN (show_ipv6_ripng,
 	   VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE,
 	   VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
   
-  for (rp = route_top (ripng->table); rp; rp = route_next (rp))
+  for (rp = ripng_table_top (ripng->table); rp; rp = ripng_route_next (rp))
     {
       if ((aggregate = rp->aggregate) != NULL)
 	{
@@ -2172,13 +2197,13 @@ DEFUN (clear_ipv6_rip,
        IPV6_STR
        "Clear IPv6 RIP database")
 {
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo;
   struct list *list;
   struct listnode *listnode;
 
   /* Clear received RIPng routes */
-  for (rp = route_top (ripng->table); rp; rp = route_next (rp))
+  for (rp = ripng_table_top (ripng->table); rp; rp = ripng_route_next (rp))
     {
       list = rp->info;
       if (list == NULL)
@@ -2206,7 +2231,7 @@ DEFUN (clear_ipv6_rip,
 	{
 	  list_free (list);
 	  rp->info = NULL;
-	  route_unlock_node (rp);
+	  ripng_route_unlock_node (rp);
 	}
     }
 
@@ -2259,7 +2284,7 @@ DEFUN (ripng_route,
   int idx_ipv6addr = 1;
   int ret;
   struct prefix_ipv6 p;
-  struct route_node *rp;
+  struct ripng_node *rp;
 
   ret = str2prefix_ipv6 (argv[idx_ipv6addr]->arg, (struct prefix_ipv6 *)&p);
   if (ret <= 0)
@@ -2269,11 +2294,11 @@ DEFUN (ripng_route,
     }
   apply_mask_ipv6 (&p);
 
-  rp = route_node_get (ripng->route, (struct prefix *) &p);
+  rp = ripng_route_node_get (ripng->route, (struct prefix *) &p);
   if (rp->info)
     {
       vty_out (vty, "There is already same static route.%s", VTY_NEWLINE);
-      route_unlock_node (rp);
+      ripng_route_unlock_node (rp);
       return CMD_WARNING;
     }
   rp->info = (void *)1;
@@ -2293,7 +2318,7 @@ DEFUN (no_ripng_route,
   int idx_ipv6addr = 2;
   int ret;
   struct prefix_ipv6 p;
-  struct route_node *rp;
+  struct ripng_node *rp;
 
   ret = str2prefix_ipv6 (argv[idx_ipv6addr]->arg, (struct prefix_ipv6 *)&p);
   if (ret <= 0)
@@ -2303,7 +2328,7 @@ DEFUN (no_ripng_route,
     }
   apply_mask_ipv6 (&p);
 
-  rp = route_node_lookup (ripng->route, (struct prefix *) &p);
+  rp = ripng_route_node_lookup (ripng->route, (struct prefix *) &p);
   if (! rp)
     {
       vty_out (vty, "Can't find static route.%s", VTY_NEWLINE);
@@ -2311,10 +2336,10 @@ DEFUN (no_ripng_route,
     }
 
   ripng_redistribute_delete (ZEBRA_ROUTE_RIPNG, RIPNG_ROUTE_STATIC, &p, 0);
-  route_unlock_node (rp);
+  ripng_route_unlock_node (rp);
 
   rp->info = NULL;
-  route_unlock_node (rp);
+  ripng_route_unlock_node (rp);
 
   return CMD_SUCCESS;
 }
@@ -2328,7 +2353,7 @@ DEFUN (ripng_aggregate_address,
   int idx_ipv6_prefixlen = 1;
   int ret;
   struct prefix p;
-  struct route_node *node;
+  struct ripng_node *node;
 
   ret = str2prefix_ipv6 (argv[idx_ipv6_prefixlen]->arg, (struct prefix_ipv6 *)&p);
   if (ret <= 0)
@@ -2338,11 +2363,11 @@ DEFUN (ripng_aggregate_address,
     }
 
   /* Check aggregate alredy exist or not. */
-  node = route_node_get (ripng->aggregate, &p);
+  node = ripng_route_node_get (ripng->aggregate, &p);
   if (node->info)
     {
       vty_out (vty, "There is already same aggregate route.%s", VTY_NEWLINE);
-      route_unlock_node (node);
+      ripng_route_unlock_node (node);
       return CMD_WARNING;
     }
   node->info = (void *)1;
@@ -2362,7 +2387,7 @@ DEFUN (no_ripng_aggregate_address,
   int idx_ipv6_prefixlen = 2;
   int ret;
   struct prefix p;
-  struct route_node *rn;
+  struct ripng_node *rn;
 
   ret = str2prefix_ipv6 (argv[idx_ipv6_prefixlen]->arg, (struct prefix_ipv6 *) &p);
   if (ret <= 0)
@@ -2371,15 +2396,15 @@ DEFUN (no_ripng_aggregate_address,
       return CMD_WARNING;
     }
 
-  rn = route_node_lookup (ripng->aggregate, &p);
+  rn = ripng_route_node_lookup (ripng->aggregate, &p);
   if (! rn)
     {
       vty_out (vty, "Can't find aggregate route.%s", VTY_NEWLINE);
       return CMD_WARNING;
     }
-  route_unlock_node (rn);
+  ripng_route_unlock_node (rn);
   rn->info = NULL;
-  route_unlock_node (rn);
+  ripng_route_unlock_node (rn);
 
   ripng_aggregate_delete (&p);
 
@@ -2641,7 +2666,7 @@ DEFUN (no_ripng_default_information_originate,
 static void
 ripng_ecmp_disable (void)
 {
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo, *tmp_rinfo;
   struct list *list;
   struct listnode *node, *nextnode;
@@ -2649,7 +2674,7 @@ ripng_ecmp_disable (void)
   if (!ripng)
     return;
 
-  for (rp = route_top (ripng->table); rp; rp = route_next (rp))
+  for (rp = ripng_table_top (ripng->table); rp; rp = ripng_route_next (rp))
     if ((list = rp->info) != NULL && listcount (list) > 1)
       {
         rinfo = listgetdata (listhead (list));
@@ -2718,7 +2743,7 @@ ripng_config_write (struct vty *vty)
   int ripng_network_write (struct vty *, int);
   void ripng_redistribute_write (struct vty *, int);
   int write = 0;
-  struct route_node *rp;
+  struct ripng_node *rp;
 
   if (ripng)
     {
@@ -2742,7 +2767,7 @@ ripng_config_write (struct vty *vty)
       config_write_ripng_offset_list (vty);
       
       /* RIPng aggregate routes. */
-      for (rp = route_top (ripng->aggregate); rp; rp = route_next (rp))
+      for (rp = ripng_table_top (ripng->aggregate); rp; rp = ripng_route_next (rp))
 	if (rp->info != NULL)
 	  vty_out (vty, " aggregate-address %s/%d%s", 
 		   inet6_ntoa (rp->p.u.prefix6),
@@ -2755,7 +2780,7 @@ ripng_config_write (struct vty *vty)
         vty_out (vty, " allow-ecmp%s", VTY_NEWLINE);
 
       /* RIPng static routes. */
-      for (rp = route_top (ripng->route); rp; rp = route_next (rp))
+      for (rp = ripng_table_top (ripng->route); rp; rp = ripng_route_next (rp))
 	if (rp->info != NULL)
 	  vty_out (vty, " route %s/%d%s", inet6_ntoa (rp->p.u.prefix6),
 		   rp->p.prefixlen,
@@ -2895,7 +2920,7 @@ void
 ripng_clean()
 {
   int i;
-  struct route_node *rp;
+  struct ripng_node *rp;
   struct ripng_info *rinfo;
   struct ripng_aggregate *aggregate;
   struct list *list = NULL;
@@ -2903,7 +2928,7 @@ ripng_clean()
 
   if (ripng) {
     /* Clear RIPng routes */
-    for (rp = route_top (ripng->table); rp; rp = route_next (rp))
+    for (rp = ripng_table_top (ripng->table); rp; rp = ripng_route_next (rp))
       {
         if ((list = rp->info) != NULL)
           {
@@ -2919,14 +2944,14 @@ ripng_clean()
               }
             list_delete (list);
             rp->info = NULL;
-            route_unlock_node (rp);
+            ripng_route_unlock_node (rp);
           }
 
         if ((aggregate = rp->aggregate) != NULL)
           {
             ripng_aggregate_free (aggregate);
             rp->aggregate = NULL;
-            route_unlock_node (rp);
+            ripng_route_unlock_node (rp);
           }
     }
 
@@ -2948,17 +2973,17 @@ ripng_clean()
     }
 
     /* Static RIPng route configuration. */
-    for (rp = route_top (ripng->route); rp; rp = route_next (rp))
+    for (rp = ripng_table_top (ripng->route); rp; rp = ripng_route_next (rp))
       if (rp->info) {
         rp->info = NULL;
-        route_unlock_node (rp);
+        ripng_route_unlock_node (rp);
     }
 
     /* RIPng aggregated prefixes */
-    for (rp = route_top (ripng->aggregate); rp; rp = route_next (rp))
+    for (rp = ripng_table_top (ripng->aggregate); rp; rp = ripng_route_next (rp))
       if (rp->info) {
           rp->info = NULL;
-          route_unlock_node (rp);
+          ripng_route_unlock_node (rp);
     }
 
     for (i = 0; i < ZEBRA_ROUTE_MAX; i++)

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -203,7 +203,7 @@ struct ripng_info
   u_char metric_out;
   u_int16_t tag_out;
 
-  struct route_node *rp;
+  struct ripng_node *rp;
 };
 
 #ifdef notyet
@@ -385,8 +385,8 @@ extern void ripng_redistribute_withdraw (int type);
 extern void ripng_distribute_update_interface (struct interface *);
 extern void ripng_if_rmap_update_interface (struct interface *);
 
-extern void ripng_zebra_ipv6_add (struct route_node *);
-extern void ripng_zebra_ipv6_delete (struct route_node *);
+extern void ripng_zebra_ipv6_add (struct ripng_node *);
+extern void ripng_zebra_ipv6_delete (struct ripng_node *);
 
 extern void ripng_redistribute_clean (void);
 extern int ripng_redistribute_check (int);


### PR DESCRIPTION
void *aggreggate was a special pointer for ripng.  Fix up
ripng to create it's own table structure and use the
delegates to create/destroy.  Also create special handler
functions to convert to/from 'struct route_node' to 'struct ripng_node'

This commit reduces the size of 'struct route_node' by the
sizeof (a pointer) on your platform.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>