### PR TITLE
[2.0] fix --enable-pcreposix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1271,8 +1271,9 @@ dnl ---------------------------
 dnl check system has PCRE regexp
 dnl ---------------------------
 if test "x$enable_pcreposix" = "xyes"; then
-  AC_CHECK_LIB(pcreposix, pcreposix_regexec, ,[enable_pcreposix=no
-  AC_MSG_WARN([*** falling back to other regex library ***]) ])
+  AC_CHECK_LIB(pcreposix, regexec, [], [
+    AC_MSG_ERROR([--enable-pcreposix given but unable to find libpcreposix])
+  ])
 fi
 AC_SUBST(HAVE_LIBPCREPOSIX)
 


### PR DESCRIPTION
pcreposix_regexec doesn't exist (anymore?), it's just regexec.  Also, if
the user specifies --enable-pcreposix, not finding it is a fatal error.

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>