### PR TITLE
lib: use heap for pollfds

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -393,6 +393,8 @@ thread_master_create (void)
   rv->handler.pfdcount = 0;
   rv->handler.pfds = XCALLOC (MTYPE_THREAD_MASTER,
                               sizeof (struct pollfd) * rv->handler.pfdsize);
+  rv->handler.copy = XCALLOC (MTYPE_THREAD_MASTER,
+                              sizeof (struct pollfd) * rv->handler.pfdsize);
 
   return rv;
 }
@@ -544,6 +546,7 @@ thread_master_free (struct thread_master *m)
   close (m->io_pipe[1]);
 
   XFREE (MTYPE_THREAD_MASTER, m->handler.pfds);
+  XFREE (MTYPE_THREAD_MASTER, m->handler.copy);
   XFREE (MTYPE_THREAD_MASTER, m);
 
   pthread_mutex_lock (&cpu_record_mtx);
@@ -1231,17 +1234,15 @@ thread_fetch (struct thread_master *m, struct thread *fetch)
           timer_wait = &timer_val;
         }
 
-      /* copy pollfds so we can unlock during blocking calls to poll() */
-      struct pollfd pfds[m->handler.pfdsize];
       unsigned int count = m->handler.pfdcount + m->handler.pfdcountsnmp;
-      memcpy (pfds, m->handler.pfds, count * sizeof (struct pollfd));
+      memcpy (m->handler.copy, m->handler.pfds, count * sizeof (struct pollfd));
 
       pthread_mutex_unlock (&m->mtx);
       {
-        num = fd_poll (m, pfds, m->handler.pfdsize, count, timer_wait);
+        num = fd_poll (m, m->handler.copy, m->handler.pfdsize, count, timer_wait);
       }
       pthread_mutex_lock (&m->mtx);
-      
+
       /* Signals should get quick treatment */
       if (num < 0)
         {
@@ -1263,7 +1264,7 @@ thread_fetch (struct thread_master *m, struct thread *fetch)
       
       /* Got IO, process it */
       if (num > 0)
-        thread_process_io (m, pfds, num, count);
+        thread_process_io (m, m->handler.copy, num, count);
 
 #if 0
       /* If any threads were made ready above (I/O or foreground timer),

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -53,7 +53,10 @@ struct fd_handler
   nfds_t pfdcountsnmp;
   /* number of pfd that fit in the allocated space of pfds */
   nfds_t pfdsize;
+  /* file descriptors to monitor for i/o */
   struct pollfd *pfds;
+  /* chunk used for temp copy of pollfds */
+  struct pollfd *copy;
 };
 
 /* Master of the theads. */


### PR DESCRIPTION
a bunch of pollfds can cause a stack overflow when using a stack
allocated buffer...silly me...

fixes #640 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>