### PR TITLE
frr: ignore 'compile_commands.json'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ GRTAGS
 GPATH
 *.la
 *.lo
+compile_commands.json


### PR DESCRIPTION
This file is generated by most tooling for Clang and generally wants to
be in the root directory. Best to ignore it.

https://clang.llvm.org/docs/JSONCompilationDatabase.html

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>