### PR TITLE
lib: free varhandlers on exit

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -2611,5 +2611,6 @@ cmd_terminate ()
   if (host.config)
     XFREE (MTYPE_HOST, host.config);
 
+  list_delete (varhandlers);
   qobj_finish ();
 }


### PR DESCRIPTION
fix #564 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>