### PR TITLE
ospfd: fix 'show ip ospf interface json'

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3552,7 +3552,6 @@ show_ip_ospf_interface_common (struct vty *vty, struct ospf *ospf, int argc,
   if (use_json)
     {
       json = json_object_new_object();
-      json_interface_sub = json_object_new_object();
     }
 
   if (ospf->instance)
@@ -3571,7 +3570,11 @@ show_ip_ospf_interface_common (struct vty *vty, struct ospf *ospf, int argc,
         {
           if (ospf_oi_count(ifp))
             {
+              if (use_json)
+                json_interface_sub = json_object_new_object();
+
               show_ip_ospf_interface_sub (vty, ospf, ifp, json_interface_sub, use_json);
+
 	      if (use_json)
 		json_object_object_add (json, ifp->name, json_interface_sub);
             }
@@ -3589,7 +3592,11 @@ show_ip_ospf_interface_common (struct vty *vty, struct ospf *ospf, int argc,
         }
       else
         {
+          if (use_json)
+            json_interface_sub = json_object_new_object();
+
           show_ip_ospf_interface_sub (vty, ospf, ifp, json_interface_sub, use_json);
+
           if (use_json)
             json_object_object_add(json, ifp->name, json_interface_sub);
         }


### PR DESCRIPTION
json obj not recreated for each interface

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>