### PR TITLE
ospfd: Fix ospf timers commands

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9099,7 +9099,7 @@ DEFUN (clear_ip_ospf_interface,
     }
   else /* Interface name is specified. */
     {
-      if ((ifp = if_lookup_by_name (argv[idx_ifname]->text, VRF_DEFAULT)) == NULL)
+      if ((ifp = if_lookup_by_name (argv[idx_ifname]->arg, VRF_DEFAULT)) == NULL)
         vty_out (vty, "No such interface name%s", VTY_NEWLINE);
       else
         ospf_interface_clear(ifp);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2222,7 +2222,7 @@ DEFUN (ospf_timers_min_ls_interval,
   int idx_number = 4;
   unsigned int interval;
 
-  if (argc != 1)
+  if (argc < 5)
     {
       vty_out (vty, "Insufficient arguments%s", VTY_NEWLINE);
       return CMD_WARNING;
@@ -2264,7 +2264,7 @@ DEFUN (ospf_timers_min_ls_arrival,
   int idx_number = 3;
   unsigned int arrival;
 
-  if (argc != 1)
+  if (argc < 4)
     {
       vty_out (vty, "Insufficient arguments%s", VTY_NEWLINE);
       return CMD_WARNING;
@@ -2309,7 +2309,7 @@ DEFUN (ospf_timers_throttle_spf,
   int idx_number_3 = 5;
   unsigned int delay, hold, max;
   
-  if (argc != 3)
+  if (argc < 6)
     {
       vty_out (vty, "Insufficient arguments%s", VTY_NEWLINE);
       return CMD_WARNING;
@@ -2352,7 +2352,7 @@ DEFUN (ospf_timers_lsa,
   int idx_number = 3;
   unsigned int minarrival;
 
-  if (argc != 1)
+  if (argc < 4)
     {
       vty_out (vty, "Insufficient number of arguments%s", VTY_NEWLINE);
       return CMD_WARNING;


### PR DESCRIPTION
1. ospf timers related commands under router ospf were not accepted
due to incorrect argument count check.

timers throttle lsa all (0-5000)
timers throttle spf (0-600000) (0-600000) (0-600000)
timers lsa arrival (0-1000)
timers lsa min-arrival (0-600000)

2.    ospfd: fix clear ip ospf interface cmd

    clear ip ospf interface <IFNAME> parsing issue,
    instead of arguement of interface "IFNAME" parsed.
 

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>