### PR TITLE
redhat/frr.spec.in: Fix postun script for Fedora.

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -428,6 +428,7 @@ if [ "$1" -ge 1 ]; then
         ##
         /etc/rc.d/init.d/frr restart >/dev/null 2>&1
     %endif
+    :
 fi
 
 %preun


### PR DESCRIPTION
Fedora uninstall showed some non-fatal postun script error because of an empty if which only applied to other distro's

Issue found based on new tests for RPM packages. This fix is needed independent of the requested change to merge of the package scripts. Would like to get it merged to have a passing test setup while working on the merging of the package scripts.

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>