### PR TITLE
bgpd: fix ipv6 network statement label-index node

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10988,10 +10988,10 @@ bgp_route_init (void)
   install_element (BGP_IPV6_NODE, &ipv6_bgp_network_route_map_cmd);
   install_element (BGP_IPV6_NODE, &no_bgp_table_map_cmd);
   install_element (BGP_IPV6_NODE, &no_ipv6_bgp_network_cmd);
-  install_element (BGP_IPV6_NODE, &ipv6_bgp_network_label_index_cmd);
-  install_element (BGP_IPV6_NODE, &no_ipv6_bgp_network_label_index_cmd);
-  install_element (BGP_IPV6_NODE, &ipv6_bgp_network_label_index_route_map_cmd);
-  install_element (BGP_IPV6_NODE, &no_ipv6_bgp_network_label_index_route_map_cmd);
+  install_element (BGP_IPV6L_NODE, &ipv6_bgp_network_label_index_cmd);
+  install_element (BGP_IPV6L_NODE, &no_ipv6_bgp_network_label_index_cmd);
+  install_element (BGP_IPV6L_NODE, &ipv6_bgp_network_label_index_route_map_cmd);
+  install_element (BGP_IPV6L_NODE, &no_ipv6_bgp_network_label_index_route_map_cmd);
 
   install_element (BGP_IPV6_NODE, &ipv6_aggregate_address_cmd);
   install_element (BGP_IPV6_NODE, &no_ipv6_aggregate_address_cmd);


### PR DESCRIPTION
Problem reported with the inability to define "network x:x:x::/64 label-index" to
the config.  Found that the install_element was pointing to the wrong node.

Ticket: CM-16615
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>