### PR TITLE
Redhat: Add remaining NHRP modifications to match 2.0 and master branch

### DIFF
--- a/redhat/README.rpm_build.md
+++ b/redhat/README.rpm_build.md
@@ -59,6 +59,7 @@ Building your own FRRouting RPM
         %{!?with_irdp:          %global  with_irdp          1 }
         %{!?with_rtadv:         %global  with_rtadv         1 }
         %{!?with_ldpd:          %global  with_ldpd          1 }
+        %{!?with_nhrpd:         %global  with_nhrpd         1 }
         %{!?with_shared:        %global  with_shared        1 }
         %{!?with_multipath:     %global  with_multipath     256 }
         %{!?frr_user:           %global  frr_user           frr }

--- a/redhat/daemons
+++ b/redhat/daemons
@@ -45,6 +45,7 @@ ripd=no
 ripngd=no
 isisd=no
 ldpd=no
+nhrpd=no
 #
 # Command line options for the daemons
 #
@@ -56,4 +57,5 @@ ripd_options=("-A 127.0.0.1")
 ripngd_options=("-A ::1")
 isisd_options=("-A 127.0.0.1")
 ldpd_options=("-A 127.0.0.1")
+nhrpd_options=("-A 127.0.0.1")
 

--- a/redhat/frr.init
+++ b/redhat/frr.init
@@ -33,7 +33,7 @@ V_PATH=/var/run/frr
 # Local Daemon selection may be done by using /etc/frr/daemons.
 # See /usr/share/doc/frr/README.Debian.gz for further information.
 # Keep zebra first and do not list watchfrr!
-DAEMONS="zebra bgpd ripd ripngd ospfd ospf6d isisd pimd ldpd"
+DAEMONS="zebra bgpd ripd ripngd ospfd ospf6d isisd pimd ldpd nhrpd"
 MAX_INSTANCES=5
 RELOAD_SCRIPT=/usr/lib/frr/frr-reload.py
 

--- a/redhat/frr.logrotate
+++ b/redhat/frr.logrotate
@@ -61,3 +61,11 @@
 	/bin/kill -USR1 `cat /var/run/frr/ldpd.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }
+
+/var/log/frr/nhrpd.log {
+    notifempty
+    missingok
+    postrotate
+        /bin/kill -USR1 `cat /var/run/frr/nhrpd.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -16,7 +16,7 @@
 %{!?with_ospfapi:       %global  with_ospfapi       1 }
 %{!?with_irdp:          %global  with_irdp          1 }
 %{!?with_rtadv:         %global  with_rtadv         1 }
-%{!?with_ldpd:          %global  with_ldpd          0 }
+%{!?with_ldpd:          %global  with_ldpd          1 }
 %{!?with_nhrpd:         %global  with_nhrpd         1 }
 %{!?with_shared:        %global  with_shared        1 }
 %{!?with_multipath:     %global  with_multipath     256 }
@@ -96,9 +96,9 @@
 %endif
 
 %if %{with_nhrpd}
-%define     daemon_nhrpd nhrpd
+%define         daemon_nhrpd	nhrpd
 %else
-%define     daemon_nhrpd ""
+%define		daemon_nhrpd	""
 %endif
 
 %if %{with_watchfrr}
@@ -107,7 +107,7 @@
 %define     daemon_watchfrr ""
 %endif
 
-%define     all_daemons %{daemon_list} %{daemon_ldpd} %{daemon_nhrpd} %{daemon_pimd} %{daemon_watchfrr}
+%define     all_daemons %{daemon_list} %{daemon_ldpd} %{daemon_pimd} %{daemon_nhrpd} %{daemon_watchfrr}
 
 # allow build dir to be kept
 %{!?keep_build:         %global  keep_build         0 }
@@ -153,7 +153,7 @@ protocol. It takes multi-server and multi-thread approach to resolve
 the current complexity of the Internet.
 
 FRRouting supports BGP4, OSPFv2, OSPFv3, ISIS, RIP, RIPng, PIM, LDP
-and NHRP.
+NHRP and EIGRP.
 
 FRRouting is a fork of Quagga.
 
@@ -239,15 +239,15 @@ developing OSPF-API and frr applications.
 %else
     --disable-ldpd \
 %endif
-%if %{with_nhrpd}
-    --enable-nhrpd \
-%else
-    --disable-nhrpd \
-%endif
 %if %{with_pimd}
     --enable-pimd \
 %else
     --disable-pimd \
+%endif
+%if %{with_nhrpd}
+	--enable-nhrpd \
+%else
+	--disable-nhrpd \
 %endif
 %if %{with_pam}
     --with-libpam \
@@ -443,6 +443,7 @@ if [ "$1" -ge 1 ]; then
         ##
         /etc/rc.d/init.d/frr restart >/dev/null 2>&1
     %endif
+    :
 fi
 
 %preun
@@ -511,7 +512,7 @@ rm -rf %{buildroot}
     %{_sbindir}/ldpd
 %endif
 %if %{with_nhrpd}
-%{_sbindir}/nhrpd
+    %{_sbindir}/nhrpd
 %endif
 %if %{with_shared}
 %{_libdir}/lib*.so
@@ -560,7 +561,7 @@ rm -rf %{buildroot}
 * Mon Jun  5 2017 Martin Winter <mwinter@opensourcerouting.org> - %{version}
 - added NHRP daemon
 
-* Thu Apr 17 2017 Martin Winter <mwinter@opensourcerouting.org>
+* Mon Apr 17 2017 Martin Winter <mwinter@opensourcerouting.org>
 - new subpackage frr-pythontools with python 2.7 restart script
 - remove PIMd from CentOS/RedHat 6 RPM packages (won't work - too old)
 - converted to single frr init script (not per daemon) based on debian init script


### PR DESCRIPTION
Remaining changes on top of Donald's merge to make stable/3.0 the same as 2.0 and master.
(Only difference is the daemons: 3.0 has nhrpd added and master has nhrpd and eigrpd over 2.0 branch.)

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>