### PR TITLE
*: remove THREAD_BACKGROUND

### DIFF
--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1169,8 +1169,8 @@ update_subgroup_trigger_merge_check (struct update_subgroup *subgrp,
     return 0;
 
   subgrp->t_merge_check = NULL;
-  thread_add_background(bm->master, update_subgroup_merge_check_thread_cb, subgrp, 0,
-                        &subgrp->t_merge_check);
+  thread_add_timer_msec (bm->master, update_subgroup_merge_check_thread_cb, subgrp,
+                         0, &subgrp->t_merge_check);
 
   SUBGRP_INCR_STAT (subgrp, merge_checks_triggered);
 

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -3051,7 +3051,7 @@ rfapiBiStartWithdrawTimer (
       lifetime_msec = (lifetime * 1000) + jitter;
 
       bi->extra->vnc.import.timer = NULL;
-      thread_add_background(bm->master, timer_service_func, wcb, lifetime_msec,
+      thread_add_timer_msec(bm->master, timer_service_func, wcb, lifetime_msec,
                             &bi->extra->vnc.import.timer);
     }
 

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -68,7 +68,6 @@ struct thread_master
   struct thread_list event;
   struct thread_list ready;
   struct thread_list unuse;
-  struct pqueue *background;
   int io_pipe[2];
   int fd_limit;
   struct fd_handler handler;
@@ -131,9 +130,8 @@ struct cpu_thread_history
 #define THREAD_TIMER          2
 #define THREAD_EVENT          3
 #define THREAD_READY          4
-#define THREAD_BACKGROUND     5
-#define THREAD_UNUSED         6
-#define THREAD_EXECUTE        7
+#define THREAD_UNUSED         5
+#define THREAD_EXECUTE        6
 
 /* Thread yield time.  */
 #define THREAD_YIELD_TIME_SLOT     10 * 1000L /* 10ms */
@@ -166,9 +164,6 @@ struct cpu_thread_history
 #define thread_add_event(m,f,a,v,t) funcname_thread_add_event(m,f,a,v,t,#f,__FILE__,__LINE__)
 #define thread_execute(m,f,a,v) funcname_thread_execute(m,f,a,v,#f,__FILE__,__LINE__)
 
-/* The 4th arg to thread_add_background is the # of milliseconds to delay. */
-#define thread_add_background(m,f,a,v,t) funcname_thread_add_background(m,f,a,v,t,#f,__FILE__,__LINE__)
-
 /* Prototypes. */
 extern struct thread_master *thread_master_create (void);
 extern void thread_master_free (struct thread_master *);
@@ -188,9 +183,6 @@ extern struct thread * funcname_thread_add_timer_tv (struct thread_master *,
 
 extern struct thread * funcname_thread_add_event (struct thread_master *,
     int (*)(struct thread *), void *, int, struct thread **, debugargdef);
-
-extern struct thread * funcname_thread_add_background (struct thread_master *,
-    int (*)(struct thread *), void *, long, struct thread **, debugargdef);
 
 extern void funcname_thread_execute (struct thread_master *,
     int (*)(struct thread *), void *, int, debugargdef);

--- a/lib/workqueue.c
+++ b/lib/workqueue.c
@@ -126,8 +126,8 @@ work_queue_schedule (struct work_queue *wq, unsigned int delay)
        && (listcount (wq->items) > 0) )
     {
       wq->thread = NULL;
-      thread_add_background(wq->master, work_queue_run, wq, delay,
-                            &wq->thread);
+      thread_add_timer_msec (wq->master, work_queue_run, wq, delay,
+                             &wq->thread);
       /* set thread yield time, if needed */
       if (wq->thread && wq->spec.yield != THREAD_YIELD_TIME_SLOT)
         thread_set_yield_time (wq->thread, wq->spec.yield);

--- a/tests/lib/test_heavy_thread.c
+++ b/tests/lib/test_heavy_thread.c
@@ -90,7 +90,7 @@ clear_something (struct thread *thread)
       ws->i++;
       if (thread_should_yield(thread))
         {
-	  thread_add_background(master, clear_something, ws, 0, NULL);
+	  thread_add_timer_msec (master, clear_something, ws, 0, NULL);
 	  return 0;
         }
     }
@@ -134,7 +134,7 @@ DEFUN (clear_foo,
   ws->vty = vty;
   ws->i = ITERS_FIRST;
 
-  thread_add_background(master, clear_something, ws, 0, NULL);
+  thread_add_timer_msec (master, clear_something, ws, 0, NULL);
 
   return CMD_SUCCESS;
 }

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -564,8 +564,8 @@ zfpm_conn_up_thread_cb (struct thread *thread)
       zfpm_g->stats.t_conn_up_yields++;
       zfpm_rnodes_iter_pause (iter);
       zfpm_g->t_conn_up = NULL;
-      thread_add_background(zfpm_g->master, zfpm_conn_up_thread_cb, 0, 0,
-                            &zfpm_g->t_conn_up);
+      thread_add_timer_msec (zfpm_g->master, zfpm_conn_up_thread_cb, NULL, 0,
+                             &zfpm_g->t_conn_up);
       return 0;
     }
 
@@ -598,7 +598,7 @@ zfpm_connection_up (const char *detail)
 
   zfpm_debug ("Starting conn_up thread");
   zfpm_g->t_conn_up = NULL;
-  thread_add_background(zfpm_g->master, zfpm_conn_up_thread_cb, 0, 0,
+  thread_add_timer_msec(zfpm_g->master, zfpm_conn_up_thread_cb, NULL, 0,
                         &zfpm_g->t_conn_up);
   zfpm_g->stats.t_conn_up_starts++;
 }
@@ -688,7 +688,7 @@ zfpm_conn_down_thread_cb (struct thread *thread)
       zfpm_g->stats.t_conn_down_yields++;
       zfpm_rnodes_iter_pause (iter);
       zfpm_g->t_conn_down = NULL;
-      thread_add_background(zfpm_g->master, zfpm_conn_down_thread_cb, 0, 0,
+      thread_add_timer_msec(zfpm_g->master, zfpm_conn_down_thread_cb, NULL, 0,
                             &zfpm_g->t_conn_down);
       return 0;
     }
@@ -736,7 +736,7 @@ zfpm_connection_down (const char *detail)
   zfpm_debug ("Starting conn_down thread");
   zfpm_rnodes_iter_init (&zfpm_g->t_conn_down_state.iter);
   zfpm_g->t_conn_down = NULL;
-  thread_add_background(zfpm_g->master, zfpm_conn_down_thread_cb, 0, 0,
+  thread_add_timer_msec(zfpm_g->master, zfpm_conn_down_thread_cb, NULL, 0,
                         &zfpm_g->t_conn_down);
   zfpm_g->stats.t_conn_down_starts++;
 


### PR DESCRIPTION
it's just an alias for a millisecond timer used in exactly nine places
and serves only to complicate

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>