### PR TITLE
tools, zebra: Fix netlink notification of who owns the routes

### DIFF
--- a/tools/etc/iproute2/rt_protos.d/frr.conf
+++ b/tools/etc/iproute2/rt_protos.d/frr.conf
@@ -5,4 +5,6 @@
 188  ospf
 189  rip
 190  ripng
-191  static
+191  nhrp
+192  eigrp
+193  ldp

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -121,7 +121,9 @@ static inline int is_selfroute(int proto)
 {
   if ((proto == RTPROT_BGP) || (proto == RTPROT_OSPF) ||
       (proto == RTPROT_STATIC) || (proto == RTPROT_ZEBRA) ||
-      (proto == RTPROT_ISIS) || (proto == RTPROT_RIPNG)) {
+      (proto == RTPROT_ISIS) || (proto == RTPROT_RIPNG) ||
+      (proto == RTPROT_NHRP) || (proto == RTPROT_EIGRP) ||
+      (proto == RTPROT_LDP)) {
     return 1;
   }
 
@@ -149,6 +151,15 @@ static inline int get_rt_proto(int proto)
     break;
   case ZEBRA_ROUTE_RIPNG:
     proto = RTPROT_RIPNG;
+    break;
+  case ZEBRA_ROUTE_NHRP:
+    proto = RTPROT_NHRP;
+    break;
+  case ZEBRA_ROUTE_EIGRP:
+    proto = RTPROT_EIGRP;
+    break;
+  case ZEBRA_ROUTE_LDP:
+    proto = RTPROT_LDP;
     break;
   default:
     proto = RTPROT_ZEBRA;

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -33,6 +33,9 @@
 #define RTPROT_OSPF        188
 #define RTPROT_RIP         189
 #define RTPROT_RIPNG       190
+#define RTPROT_NHRP        191
+#define RTPROT_EIGRP       192
+#define RTPROT_LDP         193
 
 void rt_netlink_init (void);
 


### PR DESCRIPTION
For NHRP, EIGRP and LDP( This is for consistency as opposed to correctness )
assign some new values to routes to be installed into the kernel
so we can know who owns them later.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>