### PR TITLE
zebra: define default segment routing global block values

### DIFF
--- a/lib/mpls.h
+++ b/lib/mpls.h
@@ -40,6 +40,10 @@
 #define MPLS_MIN_UNRESERVED_LABEL          16
 #define MPLS_MAX_UNRESERVED_LABEL          1048575
 
+/* Default min and max SRGB label range */
+#define MPLS_DEFAULT_MIN_SRGB_LABEL        16000
+#define MPLS_DEFAULT_MAX_SRGB_LABEL        23999
+
 #define IS_MPLS_RESERVED_LABEL(label) \
         (label >= MPLS_MIN_RESERVED_LABEL && label <= MPLS_MAX_RESERVED_LABEL)
 


### PR DESCRIPTION
Standards define the default SRGB range from 16000 to 23999.  This
commit defines these default values for frr.

Ticket: CM-16737
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Reviewed-by: CCR-6347