### PR TITLE
mt-safe thread_cancel()

### DIFF
--- a/lib/thread.h
+++ b/lib/thread.h
@@ -47,16 +47,19 @@ struct pqueue;
 
 struct fd_handler
 {
-  /* number of pfd stored in pfds */
-  nfds_t pfdcount;
-  /* number of pfd stored in pfds + number of snmp pfd */
-  nfds_t pfdcountsnmp;
-  /* number of pfd that fit in the allocated space of pfds */
+  /* number of pfd that fit in the allocated space of pfds. This is a constant
+   * and is the same for both pfds and copy. */
   nfds_t pfdsize;
+
   /* file descriptors to monitor for i/o */
   struct pollfd *pfds;
+  /* number of pollfds stored in pfds */
+  nfds_t pfdcount;
+
   /* chunk used for temp copy of pollfds */
   struct pollfd *copy;
+  /* number of pollfds stored in copy */
+  nfds_t copycount;
 };
 
 struct cancel_req {
@@ -75,6 +78,7 @@ struct thread_master
   struct thread_list ready;
   struct thread_list unuse;
   struct list *cancel_req;
+  bool canceled;
   pthread_cond_t cancel_cond;
   int io_pipe[2];
   int fd_limit;

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -59,6 +59,12 @@ struct fd_handler
   struct pollfd *copy;
 };
 
+struct cancel_req {
+  struct thread *thread;
+  void *eventobj;
+  struct thread **threadref;
+};
+
 /* Master of the theads. */
 struct thread_master
 {
@@ -68,6 +74,8 @@ struct thread_master
   struct thread_list event;
   struct thread_list ready;
   struct thread_list unuse;
+  struct list *cancel_req;
+  pthread_cond_t cancel_cond;
   int io_pipe[2];
   int fd_limit;
   struct fd_handler handler;
@@ -189,7 +197,8 @@ extern void funcname_thread_execute (struct thread_master *,
 #undef debugargdef
 
 extern void thread_cancel (struct thread *);
-extern unsigned int thread_cancel_event (struct thread_master *, void *);
+extern void thread_cancel_async (struct thread_master *, struct thread **, void *);
+extern void thread_cancel_event (struct thread_master *, void *);
 extern struct thread *thread_fetch (struct thread_master *, struct thread *);
 extern void thread_call (struct thread *);
 extern unsigned long thread_timer_remain_second (struct thread *);


### PR DESCRIPTION
This patch implements an MT-safe version of `thread_cancel()` in `thread_cancel_async()`. Behavior as follows:

* Cancellation requests are queued into a list
* Cancellation requests made from the same pthread as the `thread_master` owner are serviced immediately (`thread_cancel()`)
* Cancellation requests made from a separate pthread are queued and the call blocks on a condition variable until the owning pthread services the request, at which point the condition variable is signaled and execution continues (`thread_cancel_async()`)

edit:
this needs some in-depth review, I think it is race free, but needs eyes