### PR TITLE
ospfd: ospf bandwidth handling

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -59,7 +59,12 @@ ospf_if_get_output_cost (struct ospf_interface *oi)
   u_int32_t cost;
   u_int32_t bw, refbw;
 
-  bw = oi->ifp->bandwidth ? oi->ifp->bandwidth : OSPF_DEFAULT_BANDWIDTH;
+  if (oi->ifp->bandwidth)
+    bw = oi->ifp->bandwidth;
+  if (!oi->ifp->bandwidth && oi->ifp->speed)
+    bw = oi->ifp->speed;
+  else
+   bw = OSPF_DEFAULT_BANDWIDTH;
   refbw = oi->ospf->ref_bandwidth;
 
   /* A specifed ip ospf cost overrides a calculated one. */

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -59,12 +59,10 @@ ospf_if_get_output_cost (struct ospf_interface *oi)
   u_int32_t cost;
   u_int32_t bw, refbw;
 
-  if (oi->ifp->bandwidth)
-    bw = oi->ifp->bandwidth;
   if (!oi->ifp->bandwidth && oi->ifp->speed)
     bw = oi->ifp->speed;
   else
-   bw = OSPF_DEFAULT_BANDWIDTH;
+    bw = oi->ifp->bandwidth ? oi->ifp->bandwidth : OSPF_DEFAULT_BANDWIDTH;
   refbw = oi->ospf->ref_bandwidth;
 
   /* A specifed ip ospf cost overrides a calculated one. */

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -59,6 +59,9 @@ ospf_if_get_output_cost (struct ospf_interface *oi)
   u_int32_t cost;
   u_int32_t bw, refbw;
 
+  /* ifp speed and bw can be 0 in some platforms, use ospf default bw
+     if bw is configured under interface it would be used.
+   */
   if (!oi->ifp->bandwidth && oi->ifp->speed)
     bw = oi->ifp->speed;
   else

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3252,6 +3252,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
   int is_up;
   struct ospf_neighbor *nbr;
   struct route_node *rn;
+  uint32_t bandwidth = ifp->bandwidth ? ifp->bandwidth : ifp->speed;
 
   /* Is interface up? */
   if (use_json)
@@ -3264,7 +3265,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
 
       json_object_int_add(json_interface_sub, "ifIndex", ifp->ifindex);
       json_object_int_add(json_interface_sub, "mtuBytes", ifp->mtu);
-      json_object_int_add(json_interface_sub, "bandwidthMbit", ifp->bandwidth);
+      json_object_int_add(json_interface_sub, "bandwidthMbit", bandwidth);
       json_object_string_add(json_interface_sub, "ifFlags", if_flag_dump(ifp->flags));
     }
   else
@@ -3272,7 +3273,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
       vty_out (vty, "%s is %s%s", ifp->name,
                ((is_up = if_is_operative(ifp)) ? "up" : "down"), VTY_NEWLINE);
       vty_out (vty, "  ifindex %u, MTU %u bytes, BW %u Mbit %s%s",
-               ifp->ifindex, ifp->mtu, ifp->bandwidth, if_flag_dump(ifp->flags),
+               ifp->ifindex, ifp->mtu, bandwidth, if_flag_dump(ifp->flags),
                VTY_NEWLINE);
     }
 

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -188,16 +188,10 @@ ospf_interface_state_up (int command, struct zclient *zclient,
       zebra_interface_if_set_value (zclient->ibuf, ifp);
 
       if (IS_DEBUG_OSPF (zebra, ZEBRA_INTERFACE))
-        zlog_debug ("Zebra: Interface[%s] state update.", ifp->name);
+        zlog_debug ("Zebra: Interface[%s] state udpate speed change %u -> %u bw change %d -> %d.",
+                  ifp->name, if_tmp.speed, ifp->speed, if_tmp.bandwidth, ifp->bandwidth);
 
-      if (if_tmp.bandwidth != ifp->bandwidth)
-        {
-          if (IS_DEBUG_OSPF (zebra, ZEBRA_INTERFACE))
-            zlog_debug ("Zebra: Interface[%s] bandwidth change %d -> %d.",
-                       ifp->name, if_tmp.bandwidth, ifp->bandwidth);
-
-          ospf_if_recalculate_output_cost (ifp);
-        }
+      ospf_if_recalculate_output_cost (ifp);
 
       if (if_tmp.mtu != ifp->mtu)
         {

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -189,7 +189,7 @@ ospf_interface_state_up (int command, struct zclient *zclient,
 
       if (IS_DEBUG_OSPF (zebra, ZEBRA_INTERFACE))
         zlog_debug ("Zebra: Interface[%s] state udpate speed change %u -> %u bw change %d -> %d.",
-                  ifp->name, if_tmp.speed, ifp->speed, if_tmp.bandwidth, ifp->bandwidth);
+                    ifp->name, if_tmp.speed, ifp->speed, if_tmp.bandwidth, ifp->bandwidth);
 
       ospf_if_recalculate_output_cost (ifp);
 

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -188,7 +188,7 @@ ospf_interface_state_up (int command, struct zclient *zclient,
       zebra_interface_if_set_value (zclient->ibuf, ifp);
 
       if (IS_DEBUG_OSPF (zebra, ZEBRA_INTERFACE))
-        zlog_debug ("Zebra: Interface[%s] state udpate speed change %u -> %u bw change %d -> %d.",
+        zlog_debug ("Zebra: Interface[%s] state update speed %u -> %u, bw  %d -> %d",
                     ifp->name, if_tmp.speed, ifp->speed, if_tmp.bandwidth, ifp->bandwidth);
 
       ospf_if_recalculate_output_cost (ifp);


### PR DESCRIPTION
if bandwidth is not set from Zebra use speed as bandwidth
for ospf route. Speed and bandwidth are both scaled at Mbps. 

Testing Done:
Verfied over bond which has aggregated speed of all member interfaces,
cost is reflected in ospf route and ip route.
Manually changed interface bandwidth which replaces speed as bw, instead
uses cli entered value as bw, verifid output of ospf route and ip route.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>