### PR TITLE
zebra: "ZEBRA" truncated to "ZEBR" in "show ip prefix-list"

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -36,8 +36,8 @@ const char frr_sysconfdir[] = SYSCONFDIR;
 const char frr_vtydir[] = DAEMON_VTY_DIR;
 const char frr_moduledir[] = MODULE_PATH;
 
-char frr_protoname[] = "NONE";
-char frr_protonameinst[] = "NONE";
+char frr_protoname[] = "NONE ";
+char frr_protonameinst[] = "NONE ";
 
 char config_default[256];
 static char pidfile_default[256];

--- a/tests/lib/cli/test_cli.refout.in
+++ b/tests/lib/cli/test_cli.refout.in
@@ -20,13 +20,13 @@ cmd0 with 3 args.
 [01]: ipv4
 [02]: 1.2.3.4
 test# arg ipv4 1.2.3
-% [NONE] Unknown command: arg ipv4 1.2.3
+% [NONE ] Unknown command: arg ipv4 1.2.3
 test# arg ipv4 1.2.3.4.5
-% [NONE] Unknown command: arg ipv4 1.2.3.4.5
+% [NONE ] Unknown command: arg ipv4 1.2.3.4.5
 test# arg ipv4 1.a.3.4
-% [NONE] Unknown command: arg ipv4 1.a.3.4
+% [NONE ] Unknown command: arg ipv4 1.a.3.4
 test# arg ipv4 blah
-% [NONE] Unknown command: arg ipv4 blah
+% [NONE ] Unknown command: arg ipv4 blah
 test# 
 test# arg ipv4m 1.2.3.0/24
 cmd1 with 3 args.
@@ -41,19 +41,19 @@ cmd1 with 3 args.
 [01]: ipv4m
 [02]: 1.2.3.0/24
 test# arg ipv4m 1.2.3/9
-% [NONE] Unknown command: arg ipv4m 1.2.3/9
+% [NONE ] Unknown command: arg ipv4m 1.2.3/9
 test# arg ipv4m 1.2.3.4.5/6
-% [NONE] Unknown command: arg ipv4m 1.2.3.4.5/6
+% [NONE ] Unknown command: arg ipv4m 1.2.3.4.5/6
 test# arg ipv4m 1.a.3.4
-% [NONE] Unknown command: arg ipv4m 1.a.3.4
+% [NONE ] Unknown command: arg ipv4m 1.a.3.4
 test# arg ipv4m blah
-% [NONE] Unknown command: arg ipv4m blah
+% [NONE ] Unknown command: arg ipv4m blah
 test# arg ipv4m 1.2.3.0/999
-% [NONE] Unknown command: arg ipv4m 1.2.3.0/999
+% [NONE ] Unknown command: arg ipv4m 1.2.3.0/999
 test# arg ipv4m 1.2.3.0/a9
-% [NONE] Unknown command: arg ipv4m 1.2.3.0/a9
+% [NONE ] Unknown command: arg ipv4m 1.2.3.0/a9
 test# arg ipv4m 1.2.3.0/9a
-% [NONE] Unknown command: arg ipv4m 1.2.3.0/9a
+% [NONE ] Unknown command: arg ipv4m 1.2.3.0/9a
 test# 
 test# arg ipv6 de4d:b33f::cafe
 cmd2 with 3 args.
@@ -78,20 +78,20 @@ cmd2 with 3 args.
 [01]: ipv6
 [02]: de4d:b33f::cafe
 test# arg ipv6 de4d:b33f:z::cafe
-% [NONE] Unknown command: arg ipv6 de4d:b33f:z::cafe
+% [NONE ] Unknown command: arg ipv6 de4d:b33f:z::cafe
 test# arg ipv6 de4d:b33f:cafe:
-% [NONE] Unknown command: arg ipv6 de4d:b33f:cafe:
+% [NONE ] Unknown command: arg ipv6 de4d:b33f:cafe:
 test# arg ipv6 ::
 cmd2 with 3 args.
 [00]: arg
 [01]: ipv6
 [02]: ::
 test# arg ipv6 ::/
-% [NONE] Unknown command: arg ipv6 ::/
+% [NONE ] Unknown command: arg ipv6 ::/
 test# arg ipv6 1:2:3:4:5:6:7:8:9:0:1:2:3:4:5:6:7:8:9:0:1:2:3:4:5:6:7:8:9:0
-% [NONE] Unknown command: arg ipv6 1:2:3:4:5:6:7:8:9:0:1:2:3:4:5:6:7:8:9:0:1:2:3:4:5:6:7:8:9:0
+% [NONE ] Unknown command: arg ipv6 1:2:3:4:5:6:7:8:9:0:1:2:3:4:5:6:7:8:9:0:1:2:3:4:5:6:7:8:9:0
 test# arg ipv6 12::34::56
-% [NONE] Unknown command: arg ipv6 12::34::56
+% [NONE ] Unknown command: arg ipv6 12::34::56
 test# arg ipv6m dead:beef:cafe::/64
 cmd3 with 3 args.
 [00]: arg
@@ -108,7 +108,7 @@ cmd3 with 3 args.
 [02]: dead:beef:cafe::/64
 test# 
 test# arg range 4
-% [NONE] Unknown command: arg range 4
+% [NONE ] Unknown command: arg range 4
 test# arg range 5
 cmd4 with 3 args.
 [00]: arg
@@ -127,11 +127,11 @@ cmd4 with 3 args.
 [01]: range
 [02]: 15
 test# arg range 16
-% [NONE] Unknown command: arg range 16
+% [NONE ] Unknown command: arg range 16
 test# arg range -1
-% [NONE] Unknown command: arg range -1
+% [NONE ] Unknown command: arg range -1
 test# arg range 99999999999999999999999999999999999999999
-% [NONE] Unknown command: arg range 99999999999999999999999999999999999999999
+% [NONE ] Unknown command: arg range 99999999999999999999999999999999999999999
 test# 
 test# arg 
   ipv4   01
@@ -168,9 +168,9 @@ cmd5 with 3 args.
 test# pat a c
 % There is no matched command.
 test# pat a c
-% [NONE] Unknown command: pat a c
+% [NONE ] Unknown command: pat a c
 test# pat a a x
-% [NONE] Unknown command: pat a a x
+% [NONE ] Unknown command: pat a a x
 test# 
 test# pat c a
 % Command incomplete.
@@ -181,11 +181,11 @@ cmd7 with 4 args.
 [02]: a
 [03]: 1.2.3.4
 test# pat c b 2.3.4
-% [NONE] Unknown command: pat c b 2.3.4
+% [NONE ] Unknown command: pat c b 2.3.4
 test# pat c c 
   A.B.C.D  05
 test# pat c c x
-% [NONE] Unknown command: pat c c x
+% [NONE ] Unknown command: pat c c x
 test# 
 test# pat d
 % Command incomplete.
@@ -202,7 +202,7 @@ cmd8 with 4 args.
 test# pat d foo
 % Command incomplete.
 test# pat d noooo
-% [NONE] Unknown command: pat d noooo
+% [NONE ] Unknown command: pat d noooo
 test# pat d bar 1::2
 cmd8 with 4 args.
 [00]: pat
@@ -243,7 +243,7 @@ cmd9 with 3 args.
 [01]: e
 [02]: f
 test# pat e f g
-% [NONE] Unknown command: pat e f g
+% [NONE ] Unknown command: pat e f g
 test# pat e 1.2.3.4
 cmd9 with 3 args.
 [00]: pat
@@ -255,7 +255,7 @@ cmd10 with 2 args.
 [00]: pat
 [01]: f
 test# pat f foo
-% [NONE] Unknown command: pat f foo
+% [NONE ] Unknown command: pat f foo
 test# pat f key
 cmd10 with 3 args.
 [00]: pat


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

and "show ip access-list".  With the fix:

cel-redxp-10# show run
Building configuration...

Current configuration:
!
frr version 3.1-dev
frr defaults datacenter
no log monitor
!
service integrated-vtysh-config
!
log syslog informational
!
access-list FOOBAR permit 3.3.3.3/32
!
ip prefix-list FOO seq 10 permit 2.2.2.2/32
!
line vty
!
end
cel-redxp-10#

cel-redxp-10# show ip prefix-list
ZEBRA: ip prefix-list FOO: 1 entries
   seq 10 permit 2.2.2.2/32
BGP: ip prefix-list FOO: 1 entries
   seq 10 permit 2.2.2.2/32
cel-redxp-10#

cel-redxp-10# show ip access-list
ZEBRA:
Zebra IP access list FOOBAR
    permit 3.3.3.3/32
BGP:
Zebra IP access list FOOBAR
    permit 3.3.3.3/32
cel-redxp-10#