### PR TITLE
lib: allow 'do' commands in ENABLE_NODE

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -534,7 +534,6 @@ cmd_try_do_shortcut (enum node_type node, char* first_word) {
        node != AUTH_NODE &&
        node != VIEW_NODE &&
        node != AUTH_ENABLE_NODE &&
-       node != ENABLE_NODE &&
        0 == strcmp( "do", first_word ) )
     return 1;
   return 0;

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2588,7 +2588,7 @@ int
 vtysh_write_config_integrated(void)
 {
   u_int i;
-  char line[] = "write terminal\n";
+  char line[] = "do write terminal\n";
   FILE *fp;
   int fd;
   struct passwd *pwentry;
@@ -2713,7 +2713,7 @@ DEFUN (vtysh_write_memory,
         if (vtysh_client[i].flag == VTYSH_WATCHFRR)
           break;
       if (i < array_size(vtysh_client) && vtysh_client[i].fd != -1)
-        ret = vtysh_client_execute (&vtysh_client[i], "write integrated", stdout);
+        ret = vtysh_client_execute (&vtysh_client[i], "do write integrated", stdout);
 
       if (ret != CMD_SUCCESS)
         {


### PR DESCRIPTION
'do' is syntax sugar that allows the user to execute a command under
ENABLE_NODE when in another CLI node. If the user is already in
ENABLE_NODE, use of 'do' was previously disallowed. This patch allows it
because it makes it easier for us to hack around certain instances of
the node synchronization problem with vtysh.

Also included is a fix for one of these problems.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>