### PR TITLE
redhat/frr.spec.in: Avoid expand when possible

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -43,13 +43,17 @@
 %{expand: %%global rpmversion %(echo '@VERSION@' | tr [:blank:]- _ )}
 %define         frrversion   @VERSION@
 
-#### Check version of texi2html 
-# Old versions don't support "--number-footnotes" option.
-%{expand: %%global texi2htmlversion %(if [[ -f /usr/bin/texi2html ]]; then /usr/bin/texi2html --version | cut -d. -f1; else echo 0; fi)}
-
 #### Check for systemd or init.d (upstart)
 # Check for init.d (upstart) as used in CentOS 6 or systemd (ie CentOS 7)
-%{expand: %%global initsystem %(if [[ `/sbin/init --version 2> /dev/null` =~ upstart ]]; then echo upstart; elif [[ `file /sbin/init` =~ "symbolic link to \`../lib/systemd/systemd'" ]]; then echo systemd; elif [[ `systemctl` =~ -\.mount ]]; then echo systemd; fi)}
+%if 0%{?fedora} >= 15 || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1210
+    %global initsystem systemd
+%else
+%if (0%{?fedora} && 0%{?fedora} < 15) || (0%{?rhel} && 0%{?rhel} < 7)
+    %global initsystem upstart
+%else
+    %{expand: %%global initsystem %(if [[ `/sbin/init --version 2> /dev/null` =~ upstart ]]; then echo upstart; elif [[ `readlink -f /sbin/init` = /usr/lib/systemd/systemd ]]; then echo systemd; elif [[ `systemctl` =~ -\.mount ]]; then echo systemd; fi)}
+%endif
+%endif
 #
 # If init system is systemd, then always disable watchfrr
 #
@@ -62,10 +66,9 @@
 
 #### Check for RedHat 6.x or CentOS 6.x - they are too old to support PIM. 
 ####   Always disable it on these old systems unconditionally
-%{expand: %%global redhat6 %(if [[ `cat /etc/redhat-release 2> /dev/null` =~ release\ 6\. ]]; then echo 6; else echo 0; fi)}
 #
 # if CentOS 6 / RedHat 6, then disable PIMd
-%if "%{redhat6}" == "6"
+%if 0%{?rhel} < 7
     %global  with_pimd  0
 %endif
 
@@ -262,7 +265,6 @@ developing OSPF-API and frr applications.
 %else
     --disable-bgp-vnc \
 %endif
-    --enable-gcc-rdynamic \
     --enable-isisd=yes \
 %if "%{initsystem}" == "systemd"
     --enable-systemd=yes \
@@ -272,11 +274,11 @@ developing OSPF-API and frr applications.
 make %{?_smp_mflags} MAKEINFO="makeinfo --no-split"
 
 pushd doc
-%if %{texi2htmlversion} < 5
+if [ $(texi2html --version | cut -d. -f1) -lt 5 ]; then
 texi2html --number-sections frr.texi
-%else
+else
 texi2html --number-footnotes  --number-sections frr.texi
-%endif
+fi
 popd
 
 %install


### PR DESCRIPTION
expand + running shell commands doesn't work very well when building on mock

Bonuses:
```
[[ `file /sbin/init` =~ "symbolic link to \`../lib/systemd/systemd'" ]]
```
doesn't work correctly on Fedora 26 (for example) since the output is changed to `/sbin/init: symbolic link to ../lib/systemd/systemd`. Moreover file should not be used in scripts so changed to `readlink -f`

And `--enable-gcc-rdynamic` doesn't exists anymore