### PR TITLE
lib: more multithreading infra work

### DIFF
--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -131,7 +131,7 @@ lde(void)
 	ldpd_process = PROC_LDE_ENGINE;
 	log_procname = log_procnames[PROC_LDE_ENGINE];
 
-	master = thread_master_create();
+	master = thread_master_create(NULL);
 
 	/* setup signal handler */
 	signal_init(master, array_size(lde_signals), lde_signals);

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -109,7 +109,7 @@ ldpe(void)
 	ldpd_process = PROC_LDP_ENGINE;
 	log_procname = log_procnames[ldpd_process];
 
-  	master = thread_master_create();
+	master = thread_master_create(NULL);
 
 	/* setup signal handler */
 	signal_init(master, array_size(ldpe_signals), ldpe_signals);

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -86,7 +86,7 @@ struct frr_pthread *frr_pthread_new(const char *name, unsigned int id,
                             XCALLOC(MTYPE_FRR_PTHREAD,
                                     sizeof(struct frr_pthread));
                         fpt->id = id;
-                        fpt->master = thread_master_create();
+                        fpt->master = thread_master_create(name);
                         fpt->start_routine = start_routine;
                         fpt->stop_routine = stop_routine;
                         fpt->name = XSTRDUP(MTYPE_FRR_PTHREAD, name);

--- a/lib/grammar_sandbox_main.c
+++ b/lib/grammar_sandbox_main.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
 {
   struct thread thread;
 
-  master = thread_master_create ();
+  master = thread_master_create(NULL);
 
   openzlog ("grammar_sandbox", "NONE", 0,
                            LOG_CONS|LOG_NDELAY|LOG_PID, LOG_DAEMON);

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -366,7 +366,7 @@ struct thread_master *frr_init(void)
 
 	zprivs_init(di->privs);
 
-	master = thread_master_create();
+	master = thread_master_create(NULL);
 	signal_init(master, di->n_signals, di->signals);
 
 	if (di->flags & FRR_LIMITED_CLI)

--- a/lib/log.c
+++ b/lib/log.c
@@ -509,16 +509,18 @@ zlog_signal(int signo, const char *action
 			);
 
   s = buf;
-  if (!thread_current)
+  struct thread *tc;
+  tc = pthread_getspecific (thread_current);
+  if (!tc)
     s = str_append (LOC, "no thread information available\n");
   else
     {
       s = str_append (LOC, "in thread ");
-      s = str_append (LOC, thread_current->funcname);
+      s = str_append (LOC, tc->funcname);
       s = str_append (LOC, " scheduled from ");
-      s = str_append (LOC, thread_current->schedfrom);
+      s = str_append (LOC, tc->schedfrom);
       s = str_append (LOC, ":");
-      s = num_append (LOC, thread_current->schedfrom_line);
+      s = num_append (LOC, tc->schedfrom_line);
       s = str_append (LOC, "\n");
     }
 
@@ -700,10 +702,13 @@ ZLOG_FUNC(zlog_debug, LOG_DEBUG)
 
 void zlog_thread_info (int log_level)
 {
-  if (thread_current)
+  struct thread *tc;
+  tc = pthread_getspecific (thread_current);
+
+  if (tc)
     zlog(log_level, "Current thread function %s, scheduled from "
-	 "file %s, line %u", thread_current->funcname,
-	 thread_current->schedfrom, thread_current->schedfrom_line);
+	 "file %s, line %u", tc->funcname,
+	 tc->schedfrom, tc->schedfrom_line);
   else
     zlog(log_level, "Current thread not known/applicable");
 }

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -676,7 +676,7 @@ fd_poll (struct thread_master *m, struct pollfd *pfds, nfds_t pfdsize,
 
   num = poll (pfds, count + 1, timeout);
 
-  static unsigned char trash[64];
+  unsigned char trash[64];
   if (num > 0 && pfds[count].revents != 0 && num--)
     while (read (m->io_pipe[0], &trash, sizeof (trash)) > 0);
 

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -1115,7 +1115,6 @@ thread_cancel (struct thread *thread)
     listnode_add (thread->master->cancel_req, cr);
     do_thread_cancel (thread->master);
   }
-done:
   pthread_mutex_unlock (&thread->master->mtx);
 }
 

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -220,6 +220,6 @@ extern unsigned long thread_consumed_time(RUSAGE_T *after, RUSAGE_T *before,
 					  unsigned long *cpu_time_elapsed);
 
 /* only for use in logging functions! */
-extern struct thread *thread_current;
+extern pthread_key_t thread_current;
 
 #endif /* _ZEBRA_THREAD_H */

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -80,6 +80,7 @@ struct thread_master
   struct list *cancel_req;
   bool canceled;
   pthread_cond_t cancel_cond;
+  struct hash *cpu_record;
   int io_pipe[2];
   int fd_limit;
   struct fd_handler handler;

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -71,6 +71,8 @@ struct cancel_req {
 /* Master of the theads. */
 struct thread_master
 {
+  char *name;
+
   struct thread **read;
   struct thread **write;
   struct pqueue *timer;
@@ -178,7 +180,7 @@ struct cpu_thread_history
 #define thread_execute(m,f,a,v) funcname_thread_execute(m,f,a,v,#f,__FILE__,__LINE__)
 
 /* Prototypes. */
-extern struct thread_master *thread_master_create (void);
+extern struct thread_master *thread_master_create (const char *);
 extern void thread_master_free (struct thread_master *);
 extern void thread_master_free_unused(struct thread_master *);
 

--- a/ospfclient/ospfclient.c
+++ b/ospfclient/ospfclient.c
@@ -326,7 +326,7 @@ main (int argc, char *argv[])
 
   /* Initialization */
   zprivs_init (&ospfd_privs);
-  master = thread_master_create ();
+  master = thread_master_create(NULL);
 
   /* Open connection to OSPF daemon */
   oclient = ospf_apiclient_connect (args[1], ASYNCPORT);

--- a/tests/bgpd/test_aspath.c
+++ b/tests/bgpd/test_aspath.c
@@ -1331,7 +1331,7 @@ main (void)
 {
   int i = 0;
   qobj_init ();
-  bgp_master_init (thread_master_create ());
+  bgp_master_init (thread_master_create(NULL));
   master = bm->master;
   bgp_option_set (BGP_OPT_NO_LISTEN);
   bgp_attr_init ();

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -648,7 +648,7 @@ main (void)
   term_bgp_debug_as4 = -1UL;
   
   qobj_init ();
-  master = thread_master_create ();
+  master = thread_master_create(NULL);
   bgp_master_init (master);
   vrf_init (NULL, NULL, NULL, NULL);
   bgp_option_set (BGP_OPT_NO_LISTEN);

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -748,7 +748,7 @@ main (void)
   term_bgp_debug_as4 = -1UL;
   
   qobj_init ();
-  master = thread_master_create ();
+  master = thread_master_create(NULL);
   bgp_master_init (master);
   vrf_init (NULL, NULL, NULL, NULL);
   bgp_option_set (BGP_OPT_NO_LISTEN);

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -376,7 +376,7 @@ static int
 global_test_init (void)
 {
   qobj_init ();
-  master = thread_master_create ();
+  master = thread_master_create(NULL);
   zclient = zclient_new(master);
   bgp_master_init (master);
   vrf_init (NULL, NULL, NULL, NULL);

--- a/tests/helpers/c/main.c
+++ b/tests/helpers/c/main.c
@@ -116,7 +116,7 @@ main (int argc, char **argv)
   progname = ((p = strrchr (argv[0], '/')) ? ++p : argv[0]);
 
   /* master init. */
-  master = thread_master_create ();
+  master = thread_master_create(NULL);
 
   while (1) 
     {

--- a/tests/lib/cli/common_cli.c
+++ b/tests/lib/cli/common_cli.c
@@ -67,7 +67,7 @@ main (int argc, char **argv)
   umask (0027);
 
   /* master init. */
-  master = thread_master_create ();
+  master = thread_master_create(NULL);
 
   openzlog("common-cli", "NONE", 0, LOG_CONS | LOG_NDELAY | LOG_PID,
            LOG_DAEMON);

--- a/tests/lib/test_segv.c
+++ b/tests/lib/test_segv.c
@@ -45,7 +45,7 @@ threadfunc (struct thread *thread)
 int
 main (void)
 {
-  master = thread_master_create ();
+  master = thread_master_create(NULL);
   signal_init (master, array_size(sigs), sigs);
 
   openzlog("testsegv", "NONE", 0, LOG_CONS | LOG_NDELAY | LOG_PID, LOG_DAEMON);

--- a/tests/lib/test_sig.c
+++ b/tests/lib/test_sig.c
@@ -61,7 +61,7 @@ struct thread t;
 int
 main (void)
 {
-  master = thread_master_create ();
+  master = thread_master_create(NULL);
   signal_init (master, array_size(sigs), sigs);
 
   openzlog("testsig", "NONE", 0, LOG_CONS | LOG_NDELAY | LOG_PID, LOG_DAEMON);

--- a/tests/lib/test_timer_correctness.c
+++ b/tests/lib/test_timer_correctness.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
   struct thread t;
   struct timeval **alarms;
 
-  master = thread_master_create();
+  master = thread_master_create(NULL);
 
   log_buf_len = SCHEDULE_TIMERS * (TIMESTR_LEN + 1) + 1;
   log_buf_pos = 0;

--- a/tests/lib/test_timer_performance.c
+++ b/tests/lib/test_timer_performance.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
   struct timeval tv_start, tv_lap, tv_stop;
   unsigned long t_schedule, t_remove;
 
-  master = thread_master_create();
+  master = thread_master_create(NULL);
   prng = prng_new(0);
   timers = calloc(SCHEDULE_TIMERS, sizeof(*timers));
 

--- a/tests/test_lblmgr.c
+++ b/tests/test_lblmgr.c
@@ -140,7 +140,7 @@ int main (int argc, char *argv[])
 
 		printf ("Sequence to be tested: %s\n", sequence);
 
-		master = thread_master_create();
+		master = thread_master_create(NULL);
 		init_zclient (master, ZSERV_PATH);
 
 		zebra_send_label_manager_connect ();

--- a/zebra/client_main.c
+++ b/zebra/client_main.c
@@ -200,7 +200,7 @@ main (int argc, char **argv)
   if (argc == 1)
       usage_exit ();
 
-  master = thread_master_create();
+  master = thread_master_create(NULL);
   /* Establish connection to zebra. */
   zclient = zclient_new(master);
   zclient->enable = 1;


### PR DESCRIPTION
eliminate / fix the following

* data races
* lock inversion
* tracebacks
* heap use after free

add the following

* `show thread cpu [FILTER]` for multiple `thread_master`s
* `clear thread cpu [FILTER]` for multiple `thread_master`s

New output style for single threaded daemons:

```
ubuntu-xenial# show thread cpu
Thread statistics for bgpd:

Showing statistics for pthread main
----------------------------------------
                      CPU (user+system): Real (wall-clock):
Active   Runtime(ms)   Invoked Avg uSec Max uSecs Avg uSec Max uSecs  Type  Thread
    0          0.000         2        0         0       36        40  W    (bgp_write)
    0          0.000         1        0         0      129       129   T   (bgp_start_timer)
    2          0.000         6        0         0       30        69   TE  zclient_connect
    0          0.000         1        0         0       34        34    E  bgp_event
    0          0.000         9        0         0       94       135 R     vtysh_read
    1          0.000         1        0         0       30        30 R     vtysh_accept


Total thread statistics
------------------------------
                      CPU (user+system): Real (wall-clock):
Active   Runtime(ms)   Invoked Avg uSec Max uSecs Avg uSec Max uSecs  Type  Thread
    3          0.000        20        0         0       64       135 RWTEX TOTAL
```

Multithreaded daemons have one of the first table per pthread that shows which tracked functions they spend their time in.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>