### PR TITLE
Hashtable statistics

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -267,7 +267,7 @@ bgp_sync_init (struct peer *peer)
 	BGP_ADV_FIFO_INIT (&sync->withdraw);
 	BGP_ADV_FIFO_INIT (&sync->withdraw_low);
 	peer->sync[afi][safi] = sync;
-	peer->hash[afi][safi] = hash_create (baa_hash_key, baa_hash_cmp);
+	peer->hash[afi][safi] = hash_create (baa_hash_key, baa_hash_cmp, NULL);
       }
 }
 

--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -2134,7 +2134,7 @@ aspath_cmp (const void *arg1, const void *arg2)
 void
 aspath_init (void)
 {
-  ashash = hash_create_size (32768, aspath_key_make, aspath_cmp);
+  ashash = hash_create_size (32768, aspath_key_make, aspath_cmp, NULL);
 }
 
 void

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -215,7 +215,7 @@ cluster_unintern (struct cluster_list *cluster)
 static void
 cluster_init (void)
 {
-  cluster_hash = hash_create (cluster_hash_key_make, cluster_hash_cmp);
+  cluster_hash = hash_create (cluster_hash_key_make, cluster_hash_cmp, NULL);
 }
 
 static void
@@ -403,9 +403,9 @@ encap_hash_cmp (const void *p1, const void *p2)
 static void
 encap_init (void)
 {
-  encap_hash = hash_create (encap_hash_key_make, encap_hash_cmp);
+  encap_hash = hash_create (encap_hash_key_make, encap_hash_cmp, NULL);
 #if ENABLE_BGP_VNC
-  vnc_hash = hash_create (encap_hash_key_make, encap_hash_cmp);
+  vnc_hash = hash_create (encap_hash_key_make, encap_hash_cmp, NULL);
 #endif
 }
 
@@ -517,7 +517,7 @@ transit_hash_cmp (const void *p1, const void *p2)
 static void
 transit_init (void)
 {
-  transit_hash = hash_create (transit_hash_key_make, transit_hash_cmp);
+  transit_hash = hash_create (transit_hash_key_make, transit_hash_cmp, NULL);
 }
 
 static void
@@ -765,7 +765,7 @@ attrhash_cmp (const void *p1, const void *p2)
 static void
 attrhash_init (void)
 {
-  attrhash = hash_create (attrhash_key_make, attrhash_cmp);
+  attrhash = hash_create (attrhash_key_make, attrhash_cmp, "BGP Attributes");
 }
 
 /*

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -686,7 +686,7 @@ void
 community_init (void)
 {
   comhash = hash_create ((unsigned int (*) (void *))community_hash_make,
-			 (int (*) (const void *, const void *))community_cmp);
+			 (int (*) (const void *, const void *))community_cmp, NULL);
 }
 
 void

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -284,7 +284,7 @@ ecommunity_cmp (const void *arg1, const void *arg2)
 void
 ecommunity_init (void)
 {
-  ecomhash = hash_create (ecommunity_hash_make, ecommunity_cmp);
+  ecomhash = hash_create (ecommunity_hash_make, ecommunity_cmp, NULL);
 }
 
 void

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -286,7 +286,7 @@ lcommunity_hash (void)
 void
 lcommunity_init (void)
 {
-  lcomhash = hash_create (lcommunity_hash_make, lcommunity_cmp);
+  lcomhash = hash_create (lcommunity_hash_make, lcommunity_cmp, NULL);
 }
 
 void

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -140,7 +140,7 @@ void
 bgp_address_init (struct bgp *bgp)
 {
   bgp->address_hash = hash_create (bgp_address_hash_key_make,
-                                  bgp_address_hash_cmp);
+                                  bgp_address_hash_cmp, NULL);
 }
 
 void

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -87,7 +87,7 @@ sync_init (struct update_subgroup *subgrp)
   BGP_ADV_FIFO_INIT (&subgrp->sync->update);
   BGP_ADV_FIFO_INIT (&subgrp->sync->withdraw);
   BGP_ADV_FIFO_INIT (&subgrp->sync->withdraw_low);
-  subgrp->hash = hash_create (baa_hash_key, baa_hash_cmp);
+  subgrp->hash = hash_create (baa_hash_key, baa_hash_cmp, NULL);
 
   /* We use a larger buffer for subgrp->work in the event that:
    * - We RX a BGP_UPDATE where the attributes alone are just
@@ -1559,7 +1559,7 @@ update_bgp_group_init (struct bgp *bgp)
 
   AF_FOREACH (afid)
     bgp->update_groups[afid] = hash_create (updgrp_hash_key_make,
-					    updgrp_hash_cmp);
+					    updgrp_hash_cmp, NULL);
 }
 
 void

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2910,7 +2910,7 @@ bgp_create (as_t *as, const char *name, enum bgp_instance_type inst_type)
   bgp->peer_self->host = XSTRDUP(MTYPE_BGP_PEER_HOST, "Static announcement");
   bgp->peer = list_new ();
   bgp->peer->cmp = (int (*)(void *, void *)) peer_cmp;
-  bgp->peerhash = hash_create (peer_hash_key_make, peer_hash_cmp);
+  bgp->peerhash = hash_create (peer_hash_key_make, peer_hash_cmp, NULL);
 
   bgp->group = list_new ();
   bgp->group->cmp = (int (*)(void *, void *)) peer_group_cmp;

--- a/configure.ac
+++ b/configure.ac
@@ -1590,6 +1590,11 @@ AC_SUBST(SNMP_LIBS)
 AC_SUBST(SNMP_CFLAGS)
 
 dnl ---------------
+dnl math
+dnl ---------------
+AC_SEARCH_LIBS([sqrt], [m])
+
+dnl ---------------
 dnl dlopen & dlinfo
 dnl ---------------
 AC_SEARCH_LIBS(dlopen, [dl dld], [], [

--- a/lib/command.c
+++ b/lib/command.c
@@ -2522,6 +2522,7 @@ cmd_init (int terminal)
       workqueue_cmd_init ();
     }
 
+  hash_cmd_init ();
   install_element (CONFIG_NODE, &hostname_cmd);
   install_element (CONFIG_NODE, &no_hostname_cmd);
   install_element (CONFIG_NODE, &frr_version_defaults_cmd);

--- a/lib/command.c
+++ b/lib/command.c
@@ -2520,9 +2520,9 @@ cmd_init (int terminal)
 
       thread_cmd_init ();
       workqueue_cmd_init ();
+      hash_cmd_init ();
     }
 
-  hash_cmd_init ();
   install_element (CONFIG_NODE, &hostname_cmd);
   install_element (CONFIG_NODE, &no_hostname_cmd);
   install_element (CONFIG_NODE, &frr_version_defaults_cmd);

--- a/lib/command.c
+++ b/lib/command.c
@@ -233,7 +233,7 @@ install_node (struct cmd_node *node,
   // add start node
   struct cmd_token *token = cmd_token_new (START_TKN, CMD_ATTR_NORMAL, NULL, NULL);
   graph_new_node (node->cmdgraph, token, (void (*)(void *)) &cmd_token_del);
-  node->cmd_hash = hash_create (cmd_hash_key, cmd_hash_cmp);
+  node->cmd_hash = hash_create (cmd_hash_key, cmd_hash_cmp, NULL);
 }
 
 /**

--- a/lib/distribute.c
+++ b/lib/distribute.c
@@ -522,7 +522,8 @@ void
 distribute_list_init (int node)
 {
   disthash = hash_create (distribute_hash_make,
-                          (int (*) (const void *, const void *)) distribute_cmp);
+			  (int (*) (const void *, const void *))
+			  distribute_cmp, NULL);
 
   /* vtysh command-extraction doesn't grok install_element(node, ) */
   if (node == RIP_NODE) {

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -55,7 +55,7 @@ void frr_pthread_init()
         pthread_mutex_lock(&pthread_table_mtx);
         {
                 pthread_table =
-                    hash_create(pthread_table_hash_key, pthread_table_hash_cmp);
+                    hash_create(pthread_table_hash_key, pthread_table_hash_cmp, NULL);
         }
         pthread_mutex_unlock(&pthread_table_mtx);
 }

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -458,22 +458,21 @@ DEFUN(show_hash_stats,
   char underln[sizeof(header) + strlen(frr_protonameinst)];
   memset (underln, '-', sizeof(underln));
   underln[sizeof(underln) - 1] = '\0';
-  vty_out (vty, "%s%s%s", header, frr_protonameinst, VTY_NEWLINE);
-  vty_out (vty, "%s%s", underln, VTY_NEWLINE);
+  vty_outln (vty, "%s%s", header, frr_protonameinst);
+  vty_outln (vty, "%s", underln);
 
-  vty_out (vty, "# allocated: %d%s", _hashes->count, VTY_NEWLINE);
-  vty_out (vty, "# named:     %d%s%s", tt->nrows - 1, VTY_NEWLINE,
-           VTY_NEWLINE);
+  vty_outln (vty, "# allocated: %d", _hashes->count);
+  vty_outln (vty, "# named:     %d%s", tt->nrows - 1, VTYNL);
 
   if (tt->nrows > 1)
     {
       ttable_colseps (tt, 0, RIGHT, true, '|');
-      char *table = ttable_dump (tt, VTY_NEWLINE);
-      vty_out (vty, "%s%s", table, VTY_NEWLINE);
+      char *table = ttable_dump (tt, VTYNL);
+      vty_out (vty, "%s%s", table, VTYNL);
       XFREE (MTYPE_TMP, table);
     }
   else
-    vty_out (vty, "No named hash tables to display.%s", VTY_NEWLINE);
+    vty_outln (vty, "No named hash tables to display.");
 
   ttable_del (tt);
 

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -64,6 +64,9 @@ struct hash
 
   /* Backet alloc. */
   unsigned long count;
+
+  /* hash name */
+  const char *name;
 };
 
 extern struct hash *hash_create (unsigned int (*) (void *), 
@@ -86,5 +89,10 @@ extern void hash_clean (struct hash *, void (*) (void *));
 extern void hash_free (struct hash *);
 
 extern unsigned int string_hash_make (const char *);
+
+extern void hash_stats (struct hash *, double *, double *, int *, int *, int *, double *);
+extern void hash_cmd_init (void);
+extern void hash_register (struct hash *, const char *);
+extern void hash_unregister (struct hash *);
 
 #endif /* _ZEBRA_HASH_H */

--- a/lib/if_rmap.c
+++ b/lib/if_rmap.c
@@ -316,7 +316,7 @@ if_rmap_reset ()
 void
 if_rmap_init (int node)
 {
-  ifrmaphash = hash_create (if_rmap_hash_make, if_rmap_hash_cmp);
+  ifrmaphash = hash_create (if_rmap_hash_make, if_rmap_hash_cmp, NULL);
   if (node == RIPNG_NODE) {
   } else if (node == RIP_NODE) {
     install_element (RIP_NODE, &if_rmap_cmd);

--- a/lib/qobj.c
+++ b/lib/qobj.c
@@ -97,7 +97,7 @@ void qobj_init (void)
   if (!nodes)
     {
       pthread_rwlock_init (&nodes_lock, NULL);
-      nodes = hash_create (qobj_key, qobj_cmp);
+      nodes = hash_create (qobj_key, qobj_cmp, NULL);
     }
 }
 

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1767,7 +1767,7 @@ route_map_dep_hash_alloc(void *p)
   dep_entry = XCALLOC(MTYPE_ROUTE_MAP_DEP, sizeof(struct route_map_dep));
   dep_entry->dep_name = XSTRDUP(MTYPE_ROUTE_MAP_NAME, dep_name);
   dep_entry->dep_rmap_hash = hash_create(route_map_dep_hash_make_key,
-					 route_map_rmap_hash_cmp);
+					 route_map_rmap_hash_cmp, NULL);
   dep_entry->this_hash = NULL;
 
   return((void *)dep_entry);
@@ -2986,11 +2986,11 @@ route_map_init (void)
   /* Make vector for match and set. */
   route_match_vec = vector_init (1);
   route_set_vec = vector_init (1);
-  route_map_master_hash = hash_create(route_map_hash_key_make, route_map_hash_cmp);
+  route_map_master_hash = hash_create(route_map_hash_key_make, route_map_hash_cmp, NULL);
 
   for (i = 1; i < ROUTE_MAP_DEP_MAX; i++)
     route_map_dep_hash[i] = hash_create(route_map_dep_hash_make_key,
-					route_map_dep_hash_cmp);
+					route_map_dep_hash_cmp, NULL);
 
   cmd_variable_handler_register(rmap_var_handlers);
 

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -388,7 +388,7 @@ thread_master_create (const char *name)
 
   rv->cpu_record = hash_create ((unsigned int (*) (void *))cpu_record_hash_key,
                                 (int (*) (const void *, const void *))
-                                cpu_record_hash_cmp);
+                                cpu_record_hash_cmp, NULL);
 
 
   /* Initialize the timer queues */

--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -81,7 +81,7 @@ struct nhrp_cache *nhrp_cache_get(struct interface *ifp, union sockunion *remote
 	struct nhrp_cache key;
 
 	if (!nifp->cache_hash) {
-		nifp->cache_hash = hash_create(nhrp_cache_protocol_key, nhrp_cache_protocol_cmp);
+		nifp->cache_hash = hash_create(nhrp_cache_protocol_key, nhrp_cache_protocol_cmp, NULL);
 		if (!nifp->cache_hash)
 			return NULL;
 	}

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -182,7 +182,7 @@ struct nhrp_peer *nhrp_peer_get(struct interface *ifp, const union sockunion *re
 	struct nhrp_vc *vc;
 
 	if (!nifp->peer_hash) {
-		nifp->peer_hash = hash_create(nhrp_peer_key, nhrp_peer_cmp);
+		nifp->peer_hash = hash_create(nhrp_peer_key, nhrp_peer_cmp, NULL);
 		if (!nifp->peer_hash) return NULL;
 	}
 

--- a/nhrpd/nhrp_vc.c
+++ b/nhrpd/nhrp_vc.c
@@ -196,7 +196,7 @@ void nhrp_vc_init(void)
 {
 	size_t i;
 
-	nhrp_vc_hash = hash_create(nhrp_vc_key, nhrp_vc_cmp);
+	nhrp_vc_hash = hash_create(nhrp_vc_key, nhrp_vc_cmp, NULL);
 	for (i = 0; i < ZEBRA_NUM_OF(childlist_head); i++)
 		list_init(&childlist_head[i]);
 }

--- a/nhrpd/reqid.c
+++ b/nhrpd/reqid.c
@@ -17,7 +17,7 @@ static int nhrp_reqid_cmp(const void *data, const void *key)
 uint32_t nhrp_reqid_alloc(struct nhrp_reqid_pool *p, struct nhrp_reqid *r, void (*cb)(struct nhrp_reqid *, void *))
 {
 	if (!p->reqid_hash) {
-		p->reqid_hash = hash_create(nhrp_reqid_key, nhrp_reqid_cmp);
+		p->reqid_hash = hash_create(nhrp_reqid_key, nhrp_reqid_cmp, NULL);
 		p->next_request_id = 1;
 	}
 

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -180,7 +180,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, int igmp, int pim)
   pim_ifp->pim_ifchannel_list->cmp = (int (*)(void *, void *)) pim_ifchannel_compare;
 
   pim_ifp->pim_ifchannel_hash = hash_create (pim_ifchannel_hash_key,
-                                             pim_ifchannel_equal);
+                                             pim_ifchannel_equal, NULL);
 
   ifp->info = pim_ifp;
 

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -822,7 +822,7 @@ static struct igmp_sock *igmp_sock_new(int fd,
   igmp->igmp_group_list->del = (void (*)(void *)) igmp_group_free;
 
   igmp->igmp_group_hash = hash_create (igmp_group_hash_key,
-                                       igmp_group_hash_equal);
+                                       igmp_group_hash_equal, NULL);
 
   igmp->fd                          = fd;
   igmp->interface                   = ifp;

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1570,13 +1570,13 @@ pim_msdp_init(struct thread_master *master)
   msdp->master = master;
 
   msdp->peer_hash = hash_create(pim_msdp_peer_hash_key_make,
-                                 pim_msdp_peer_hash_eq);
+                                 pim_msdp_peer_hash_eq, NULL);
   msdp->peer_list = list_new();
   msdp->peer_list->del = (void (*)(void *))pim_msdp_peer_free;
   msdp->peer_list->cmp = (int (*)(void *, void *))pim_msdp_peer_comp;
 
   msdp->sa_hash = hash_create(pim_msdp_sa_hash_key_make,
-                                 pim_msdp_sa_hash_eq);
+                                 pim_msdp_sa_hash_eq, NULL);
   msdp->sa_list = list_new();
   msdp->sa_list->del = (void (*)(void *))pim_msdp_sa_free;
   msdp->sa_list->cmp = (int (*)(void *, void *))pim_msdp_sa_comp;

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -103,7 +103,7 @@ void
 pim_oil_init (void)
 {
   pim_channel_oil_hash = hash_create_size (8192, pim_oil_hash_key,
-					   pim_oil_equal);
+					   pim_oil_equal, NULL);
 
   pim_channel_oil_list = list_new();
   if (!pim_channel_oil_list) {

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1760,7 +1760,7 @@ pim_upstream_init (void)
 				      pim_upstream_hash_key,
 				      pim_upstream_sg_running);
   pim_upstream_hash = hash_create_size (8192, pim_upstream_hash_key,
-					pim_upstream_equal);
+					pim_upstream_equal, NULL);
 
   pim_upstream_list = list_new ();
   pim_upstream_list->del = (void (*)(void *)) pim_upstream_free;

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -250,7 +250,7 @@ pim_instance_init (vrf_id_t vrf_id, afi_t afi)
   pim->spt.switchover = PIM_SPT_IMMEDIATE;
   pim->spt.plist = NULL;
 
-  pim->rpf_hash = hash_create_size (256, pim_rpf_hash_key, pim_rpf_equal);
+  pim->rpf_hash = hash_create_size (256, pim_rpf_hash_key, pim_rpf_equal, NULL);
 
   if (PIM_DEBUG_ZEBRA)
     zlog_debug ("%s: NHT rpf hash init ", __PRETTY_FUNCTION__);

--- a/tests/lib/test_srcdest_table.c
+++ b/tests/lib/test_srcdest_table.c
@@ -140,7 +140,7 @@ test_state_new(void)
   rv->table = srcdest_table_init();
   assert(rv->table);
 
-  rv->log = hash_create(log_key, log_cmp);
+  rv->log = hash_create(log_key, log_cmp, NULL);
   return rv;
 }
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2114,15 +2114,13 @@ DEFUN (vtysh_show_hashtable,
   unsigned long i;
   int ret = CMD_SUCCESS;
 
-  vty_out (vty, "%sLoad factor (LF) - average number of elements across all "
-                "buckets%s", VTY_NEWLINE, VTY_NEWLINE);
-  vty_out (vty, "Full load factor (FLF) - average number of elements "
-                "across full buckets%s%s", VTY_NEWLINE, VTY_NEWLINE);
+  fprintf (stdout, "\n");
+  fprintf (stdout, "Load factor (LF) - average number of elements across all buckets\n");
+  fprintf (stdout, "Full load factor (FLF) - average number of elements across full buckets\n\n");
 
-  vty_out (vty, "Standard deviation (SD) is calculated for both the LF and FLF%s", VTY_NEWLINE);
-  vty_out (vty, "and indicates the typical deviation of bucket chain length%s", VTY_NEWLINE);
-  vty_out (vty, "from the value in the corresponding load factor.%s%s",
-           VTY_NEWLINE, VTY_NEWLINE);
+  fprintf (stdout, "Standard deviation (SD) is calculated for both the LF and FLF\n");
+  fprintf (stdout, "and indicates the typical deviation of bucket chain length\n");
+  fprintf (stdout, "from the value in the corresponding load factor.\n\n");
 
   for (i = 0; i < array_size(vtysh_client); i++)
     if ( vtysh_client[i].fd >= 0 ) {

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2103,6 +2103,35 @@ DEFUN (vtysh_show_work_queues_daemon,
   return ret;
 }
 
+DEFUN (vtysh_show_hashtable,
+       vtysh_show_hashtable_cmd,
+       "show hashtable [statistics]",
+       SHOW_STR
+       "Statistics about hash tables\n"
+       "Statistics about hash tables\n")
+{
+  char cmd[] = "do show hashtable statistics";
+  unsigned long i;
+  int ret = CMD_SUCCESS;
+
+  vty_out (vty, "%sLoad factor (LF) - average number of elements across all "
+                "buckets%s", VTY_NEWLINE, VTY_NEWLINE);
+  vty_out (vty, "Full load factor (FLF) - average number of elements "
+                "across full buckets%s%s", VTY_NEWLINE, VTY_NEWLINE);
+
+  vty_out (vty, "Standard deviation (SD) is calculated for both the LF and FLF%s", VTY_NEWLINE);
+  vty_out (vty, "and indicates the typical deviation of bucket chain length%s", VTY_NEWLINE);
+  vty_out (vty, "from the value in the corresponding load factor.%s%s",
+           VTY_NEWLINE, VTY_NEWLINE);
+
+  for (i = 0; i < array_size(vtysh_client); i++)
+    if ( vtysh_client[i].fd >= 0 ) {
+        ret = vtysh_client_execute (&vtysh_client[i], cmd, stdout);
+        fprintf (stdout, "\n");
+      }
+  return ret;
+}
+
 DEFUNSH (VTYSH_ZEBRA,
          vtysh_link_params,
          vtysh_link_params_cmd,
@@ -3574,6 +3603,8 @@ vtysh_init_vty (void)
 
   install_element (VIEW_NODE, &vtysh_show_work_queues_cmd);
   install_element (VIEW_NODE, &vtysh_show_work_queues_daemon_cmd);
+
+  install_element (VIEW_NODE, &vtysh_show_hashtable_cmd);
 
   install_element (VIEW_NODE, &vtysh_show_thread_cmd);
 

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2994,8 +2994,8 @@ zebra_mpls_init_tables (struct zebra_vrf *zvrf)
 {
   if (!zvrf)
     return;
-  zvrf->slsp_table = hash_create(label_hash, label_cmp);
-  zvrf->lsp_table = hash_create(label_hash, label_cmp);
+  zvrf->slsp_table = hash_create(label_hash, label_cmp, NULL);
+  zvrf->lsp_table = hash_create(label_hash, label_cmp, NULL);
   zvrf->fec_table[AFI_IP] = route_table_init();
   zvrf->fec_table[AFI_IP6] = route_table_init();
   zvrf->mpls_flags = 0;


### PR DESCRIPTION
This patchset adds statistics collection for FRR's hash table implementation. This is primarily a developer-oriented feature that will allow us to easily evaluate the performance of hash functions and resizing parameters.

```
  /* Summary statistics calculated are:
   *
   * - Load factor: This is the number of elements in the table divided by the
   *   number of buckets. Since this hash table implementation uses chaining,
   *   this value can be greater than 1. This number provides information on
   *   how 'full' the table is, but does not provide information on how evenly
   *   distributed the elements are. Notably, a load factor >= 1 does not imply
   *   that every bucket has an element; with a pathological hash function, all
   *   elements could be in a single bucket.
   *
   * - Full load factor: this is the number of elements in the table divided by
   *   the number of buckets that have some elements in them.
   *
   * - Std. Dev.: This is the standard deviation from the full load factor. If
   *   the FLF is the mean of number of elements per bucket, the standard
   *   deviation measures how much any particular bucket is likely to deviate
   *   from the mean. As a rule of thumb this number should be less than 2, and
   *   ideally <= 1 for optimal performance. A number larger than 3 generally
   *   indicates a poor hash function.
   */
```

These data along with some other basic information are displayed for each named table for each daemon. Example output with just 1 named table (in bgpd)

```
ubuntu-xenial# show hashtable statistics

Load factor (LF) - average number of elements across all buckets
Full load factor (FLF) - average number of elements across full buckets
Standard deviation (SD) refers to the FLF

Showing hash table statistics for OSPF
--------------------------------------
# allocated: 18
# named:     0

No named hash tables to display.

Showing hash table statistics for LDP
-------------------------------------
# allocated: 12
# named:     0

No named hash tables to display.

Showing hash table statistics for BGP
-------------------------------------
# allocated: 98
# named:     1

   Hash table     |  Buckets   Entries   Empty   LF     FLF    SD
 -----------------+-------------------------------------------------
   BGP Attributes |  256       0         100%    0.00   0.00   0.00


ubuntu-xenial#
```

Since hash creation calls have gained a parameter refactor all of those as well.

If anyone feels so inclined it might be neat to add an ASCII frequency-bin histogram for summarizing bucket length distribution.