### PR TITLE
vty_outln()

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -290,8 +290,8 @@ DEFUN (babel_network,
         ret = babel_enable_if_add (argv[1]->arg);
 
     if (ret < 0) {
-        vty_out (vty, "There is same network configuration %s%s", argv[1]->arg,
-                 VTY_NEWLINE);
+        vty_outln (vty, "There is same network configuration %s",
+                   argv[1]->arg);
         return CMD_WARNING;
     }
 
@@ -318,8 +318,7 @@ DEFUN (no_babel_network,
         ret = babel_enable_if_delete (argv[2]->arg);
 
     if (ret < 0) {
-        vty_out (vty, "can't find network %s%s", argv[2]->arg,
-                 VTY_NEWLINE);
+        vty_outln (vty, "can't find network %s",argv[2]->arg);
         return CMD_WARNING;
     }
 
@@ -862,30 +861,31 @@ show_babel_interface_sub (struct vty *vty, struct interface *ifp)
   int is_up;
   babel_interface_nfo *babel_ifp;
 
-  vty_out (vty, "%s is %s%s", ifp->name,
-    ((is_up = if_is_operative(ifp)) ? "up" : "down"), VTY_NEWLINE);
-  vty_out (vty, "  ifindex %u, MTU %u bytes %s%s",
-    ifp->ifindex, MIN(ifp->mtu, ifp->mtu6), if_flag_dump(ifp->flags), VTY_NEWLINE);
+  vty_outln (vty, "%s is %s", ifp->name,
+    ((is_up = if_is_operative(ifp)) ? "up" : "down"));
+  vty_outln (vty, "  ifindex %u, MTU %u bytes %s",
+    ifp->ifindex, MIN(ifp->mtu, ifp->mtu6), if_flag_dump(ifp->flags));
 
   if (!IS_ENABLE(ifp))
   {
-    vty_out (vty, "  Babel protocol is not enabled on this interface%s", VTY_NEWLINE);
+    vty_outln (vty, "  Babel protocol is not enabled on this interface");
     return;
   }
   if (!is_up)
   {
-    vty_out (vty, "  Babel protocol is enabled, but not running on this interface%s", VTY_NEWLINE);
+    vty_outln (vty,
+               "  Babel protocol is enabled, but not running on this interface");
     return;
   }
   babel_ifp = babel_get_if_nfo (ifp);
-  vty_out (vty, "  Babel protocol is running on this interface%s", VTY_NEWLINE);
-  vty_out (vty, "  Operating mode is \"%s\"%s",
-           CHECK_FLAG (babel_ifp->flags, BABEL_IF_WIRED) ? "wired" : "wireless", VTY_NEWLINE);
-  vty_out (vty, "  Split horizon mode is %s%s",
-           CHECK_FLAG (babel_ifp->flags, BABEL_IF_SPLIT_HORIZON) ? "On" : "Off", VTY_NEWLINE);
-  vty_out (vty, "  Hello interval is %u ms%s", babel_ifp->hello_interval, VTY_NEWLINE);
-  vty_out (vty, "  Update interval is %u ms%s", babel_ifp->update_interval, VTY_NEWLINE);
-  vty_out (vty, "  Rxcost multiplier is %u%s", babel_ifp->cost, VTY_NEWLINE);
+  vty_outln (vty, "  Babel protocol is running on this interface");
+  vty_outln (vty, "  Operating mode is \"%s\"",
+           CHECK_FLAG(babel_ifp->flags, BABEL_IF_WIRED) ? "wired" : "wireless");
+  vty_outln (vty, "  Split horizon mode is %s",
+           CHECK_FLAG(babel_ifp->flags, BABEL_IF_SPLIT_HORIZON) ? "On" : "Off");
+  vty_outln (vty, "  Hello interval is %u ms", babel_ifp->hello_interval);
+  vty_outln (vty, "  Update interval is %u ms", babel_ifp->update_interval);
+  vty_outln (vty, "  Rxcost multiplier is %u", babel_ifp->cost);
 }
 
 DEFUN (show_babel_interface,
@@ -907,7 +907,7 @@ DEFUN (show_babel_interface,
   }
   if ((ifp = if_lookup_by_name (argv[3]->arg, VRF_DEFAULT)) == NULL)
   {
-    vty_out (vty, "No such interface name%s", VTY_NEWLINE);
+    vty_outln (vty, "No such interface name");
     return CMD_WARNING;
   }
   show_babel_interface_sub (vty, ifp);
@@ -917,9 +917,9 @@ DEFUN (show_babel_interface,
 static void
 show_babel_neighbour_sub (struct vty *vty, struct neighbour *neigh)
 {
-    vty_out (vty,
+    vty_outln (vty,
              "Neighbour %s dev %s reach %04x rxcost %d txcost %d "
-             "rtt %s rttcost %d%s.%s",
+             "rtt %s rttcost %d%s.",
              format_address(neigh->address),
              neigh->ifp->name,
              neigh->reach,
@@ -927,8 +927,7 @@ show_babel_neighbour_sub (struct vty *vty, struct neighbour *neigh)
              neigh->txcost,
              format_thousands(neigh->rtt),
              neighbour_rttcost(neigh),
-             if_up(neigh->ifp) ? "" : " (down)",
-             VTY_NEWLINE);
+             if_up(neigh->ifp) ? "" : " (down)");
 }
 
 DEFUN (show_babel_neighbour,
@@ -950,7 +949,7 @@ DEFUN (show_babel_neighbour,
     }
     if ((ifp = if_lookup_by_name (argv[3]->arg, VRF_DEFAULT)) == NULL)
     {
-        vty_out (vty, "No such interface name%s", VTY_NEWLINE);
+        vty_outln (vty, "No such interface name");
         return CMD_WARNING;
     }
     FOR_ALL_NEIGHBOURS(neigh) {
@@ -1010,9 +1009,9 @@ show_babel_routes_sub(struct babel_route *route, struct vty *vty,
             channels[0] = '\0';
     }
 
-    vty_out(vty,
+    vty_outln (vty,
             "%s metric %d refmetric %d id %s seqno %d%s age %d "
-            "via %s neigh %s%s%s%s%s",
+            "via %s neigh %s%s%s%s",
             format_prefix(route->src->prefix, route->src->plen),
             route_metric(route), route->refmetric,
             format_eui64(route->src->id),
@@ -1023,9 +1022,7 @@ show_babel_routes_sub(struct babel_route *route, struct vty *vty,
             format_address(route->neigh->address),
             nexthop ? " nexthop " : "",
             nexthop ? format_address(nexthop) : "",
-            route->installed ? " (installed)" :
-            route_feasible(route) ? " (feasible)" : "",
-            VTY_NEWLINE);
+            route->installed ? " (installed)" : route_feasible(route) ? " (feasible)" : "");
 }
 
 static void
@@ -1035,10 +1032,9 @@ show_babel_xroutes_sub (struct xroute *xroute, struct vty *vty,
     if(prefix && !babel_prefix_eq(prefix, xroute->prefix, xroute->plen))
         return;
 
-    vty_out(vty, "%s metric %d (exported)%s",
+    vty_outln (vty, "%s metric %d (exported)",
             format_prefix(xroute->prefix, xroute->plen),
-            xroute->metric,
-            VTY_NEWLINE);
+            xroute->metric);
 }
 
 DEFUN (show_babel_route,
@@ -1093,7 +1089,7 @@ DEFUN (show_babel_route_prefix,
 
     ret = str2prefix(argv[3]->arg, &prefix);
     if(ret == 0) {
-      vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed address");
       return CMD_WARNING;
     }
         
@@ -1142,7 +1138,7 @@ DEFUN (show_babel_route_addr,
 
     ret = inet_aton (argv[3]->arg, &addr);
     if (ret <= 0) {
-        vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+        vty_outln (vty, "%% Malformed address");
         return CMD_WARNING;
     }
 
@@ -1151,7 +1147,7 @@ DEFUN (show_babel_route_addr,
 
     ret = str2prefix(buf, &prefix);
     if (ret == 0) {
-        vty_out (vty, "%% Parse error -- this shouldn't happen%s", VTY_NEWLINE);
+        vty_outln (vty, "%% Parse error -- this shouldn't happen");
         return CMD_WARNING;
     }
 
@@ -1200,7 +1196,7 @@ DEFUN (show_babel_route_addr6,
 
     ret = inet_pton (AF_INET6, argv[3]->arg, &addr);
     if (ret <= 0) {
-        vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+        vty_outln (vty, "%% Malformed address");
         return CMD_WARNING;
     }
 
@@ -1210,7 +1206,7 @@ DEFUN (show_babel_route_addr6,
 
     ret = str2prefix(buf, &prefix);
     if (ret == 0) {
-        vty_out (vty, "%% Parse error -- this shouldn't happen%s", VTY_NEWLINE);
+        vty_outln (vty, "%% Parse error -- this shouldn't happen");
         return CMD_WARNING;
     }
 
@@ -1248,9 +1244,9 @@ DEFUN (show_babel_parameters,
        "Babel information\n"
        "Configuration information\n")
 {
-    vty_out(vty, "    -- Babel running configuration --%s", VTY_NEWLINE);
+    vty_outln (vty, "    -- Babel running configuration --");
     show_babel_main_configuration(vty);
-    vty_out(vty, "    -- distribution lists --%s", VTY_NEWLINE);
+    vty_outln (vty, "    -- distribution lists --");
     config_show_distribute(vty);
 
     return CMD_SUCCESS;
@@ -1325,65 +1321,63 @@ interface_config_write (struct vty *vty)
     int write = 0;
 
     for (ALL_LIST_ELEMENTS_RO (vrf_iflist(VRF_DEFAULT), node, ifp)) {
-        vty_out (vty, "interface %s%s", ifp->name,
-                 VTY_NEWLINE);
+        vty_outln (vty, "interface %s",ifp->name);
         if (ifp->desc)
-            vty_out (vty, " description %s%s", ifp->desc,
-                     VTY_NEWLINE);
+            vty_outln (vty, " description %s",ifp->desc);
         babel_interface_nfo *babel_ifp = babel_get_if_nfo (ifp);
         /* wireless is the default*/
         if (CHECK_FLAG (babel_ifp->flags, BABEL_IF_WIRED))
         {
-            vty_out (vty, " babel wired%s", VTY_NEWLINE);
+            vty_outln (vty, " babel wired");
             write++;
         }
         if (babel_ifp->hello_interval != BABEL_DEFAULT_HELLO_INTERVAL)
         {
-            vty_out (vty, " babel hello-interval %u%s", babel_ifp->hello_interval, VTY_NEWLINE);
+            vty_outln (vty, " babel hello-interval %u",
+                       babel_ifp->hello_interval);
             write++;
         }
         if (babel_ifp->update_interval != BABEL_DEFAULT_UPDATE_INTERVAL)
         {
-            vty_out (vty, " babel update-interval %u%s", babel_ifp->update_interval, VTY_NEWLINE);
+            vty_outln (vty, " babel update-interval %u",
+                       babel_ifp->update_interval);
             write++;
         }
         /* Some parameters have different defaults for wired/wireless. */
         if (CHECK_FLAG (babel_ifp->flags, BABEL_IF_WIRED)) {
             if (!CHECK_FLAG (babel_ifp->flags, BABEL_IF_SPLIT_HORIZON)) {
-                vty_out (vty, " no babel split-horizon%s", VTY_NEWLINE);
+                vty_outln (vty, " no babel split-horizon");
                 write++;
             }
             if (babel_ifp->cost != BABEL_DEFAULT_RXCOST_WIRED) {
-                vty_out (vty, " babel rxcost %u%s", babel_ifp->cost, VTY_NEWLINE);
+                vty_outln (vty, " babel rxcost %u", babel_ifp->cost);
                 write++;
             }
             if (babel_ifp->channel == BABEL_IF_CHANNEL_INTERFERING) {
-                vty_out (vty, " babel channel interfering%s", VTY_NEWLINE);
+                vty_outln (vty, " babel channel interfering");
                 write++;
             } else if(babel_ifp->channel != BABEL_IF_CHANNEL_NONINTERFERING) {
-                vty_out (vty, " babel channel %d%s", babel_ifp->channel,
-                         VTY_NEWLINE);
+                vty_outln (vty, " babel channel %d",babel_ifp->channel);
                 write++;
             }
         } else {
             if (CHECK_FLAG (babel_ifp->flags, BABEL_IF_SPLIT_HORIZON)) {
-                vty_out (vty, " babel split-horizon%s", VTY_NEWLINE);
+                vty_outln (vty, " babel split-horizon");
                 write++;
             }
             if (babel_ifp->cost != BABEL_DEFAULT_RXCOST_WIRELESS) {
-                vty_out (vty, " babel rxcost %u%s", babel_ifp->cost, VTY_NEWLINE);
+                vty_outln (vty, " babel rxcost %u", babel_ifp->cost);
                 write++;
             }
             if (babel_ifp->channel == BABEL_IF_CHANNEL_NONINTERFERING) {
-                vty_out (vty, " babel channel noninterfering%s", VTY_NEWLINE);
+                vty_outln (vty, " babel channel noninterfering");
                 write++;
             } else if(babel_ifp->channel != BABEL_IF_CHANNEL_INTERFERING) {
-                vty_out (vty, " babel channel %d%s", babel_ifp->channel,
-                         VTY_NEWLINE);
+                vty_outln (vty, " babel channel %d",babel_ifp->channel);
                 write++;
             }
         }
-        vty_out (vty, "!%s", VTY_NEWLINE);
+        vty_outln (vty, "!");
         write++;
     }
     return write;
@@ -1399,7 +1393,7 @@ babel_enable_if_config_write (struct vty * vty)
     for (i = 0; i < vector_active (babel_enable_if); i++)
         if ((str = vector_slot (babel_enable_if, i)) != NULL)
         {
-            vty_out (vty, " network %s%s", str, VTY_NEWLINE);
+            vty_outln (vty, " network %s", str);
             lines++;
         }
     return lines;

--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -387,15 +387,15 @@ show_babel_main_configuration (struct vty *vty)
             "vty port                = %d%s"
             "id                      = %s%s"
             "kernel_metric           = %d",
-            state_file, VTY_NEWLINE,
+            state_file, VTYNL,
             babel_config_file ? babel_config_file : babel_config_default,
-            VTY_NEWLINE,
-            VTY_NEWLINE,
-            format_address(protocol_group), VTY_NEWLINE,
-            protocol_port, VTY_NEWLINE,
+            VTYNL,
+            VTYNL,
+            format_address(protocol_group), VTYNL,
+            protocol_port, VTYNL,
             babel_vty_addr ? babel_vty_addr : "None",
-            VTY_NEWLINE,
-            babel_vty_port, VTY_NEWLINE,
-            format_eui64(myid), VTY_NEWLINE,
+            VTYNL,
+            babel_vty_port, VTYNL,
+            format_eui64(myid), VTYNL,
             kernel_metric);
 }

--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -377,7 +377,7 @@ babel_save_state_file(void)
 void
 show_babel_main_configuration (struct vty *vty)
 {
-    vty_out(vty,
+    vty_outln (vty,
             "state file              = %s%s"
             "configuration file      = %s%s"
             "protocol informations:%s"
@@ -386,7 +386,7 @@ show_babel_main_configuration (struct vty *vty)
             "vty address             = %s%s"
             "vty port                = %d%s"
             "id                      = %s%s"
-            "kernel_metric           = %d%s",
+            "kernel_metric           = %d",
             state_file, VTY_NEWLINE,
             babel_config_file ? babel_config_file : babel_config_default,
             VTY_NEWLINE,
@@ -397,5 +397,5 @@ show_babel_main_configuration (struct vty *vty)
             VTY_NEWLINE,
             babel_vty_port, VTY_NEWLINE,
             format_eui64(myid), VTY_NEWLINE,
-            kernel_metric, VTY_NEWLINE);
+            kernel_metric);
 }

--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -222,7 +222,7 @@ DEFUN (babel_redistribute_type,
     type = babel_proto_redistnum(argv[1]->arg);
 
     if (type < 0) {
-        vty_out(vty, "Invalid type %s%s", argv[1]->arg, VTY_NEWLINE);
+        vty_outln (vty, "Invalid type %s", argv[1]->arg);
         return CMD_WARNING;
     }
 
@@ -243,7 +243,7 @@ DEFUN (no_babel_redistribute_type,
     type = babel_proto_redistnum(argv[2]->arg);
 
     if (type < 0) {
-        vty_out(vty, "Invalid type %s%s", argv[2]->arg, VTY_NEWLINE);
+        vty_outln (vty, "Invalid type %s", argv[2]->arg);
         return CMD_WARNING;
     }
 
@@ -277,7 +277,7 @@ DEFUN (debug_babel,
         }
     }
 
-    vty_out(vty, "Invalid type %s%s", argv[2]->arg, VTY_NEWLINE);
+    vty_outln (vty, "Invalid type %s", argv[2]->arg);
 
     return CMD_WARNING;
 }
@@ -307,7 +307,7 @@ DEFUN (no_debug_babel,
         }
     }
 
-    vty_out(vty, "Invalid type %s%s", argv[3]->arg, VTY_NEWLINE);
+    vty_outln (vty, "Invalid type %s", argv[3]->arg);
 
     return CMD_WARNING;
 }
@@ -324,7 +324,7 @@ debug_babel_config_write (struct vty * vty)
 
     if (debug == BABEL_DEBUG_ALL)
     {
-        vty_out (vty, "debug babel all%s", VTY_NEWLINE);
+        vty_outln (vty, "debug babel all");
         lines++;
     }
     else
@@ -335,12 +335,12 @@ debug_babel_config_write (struct vty * vty)
                 && CHECK_FLAG (debug, debug_type[i].type)
             )
             {
-                vty_out (vty, "debug babel %s%s", debug_type[i].str, VTY_NEWLINE);
+                vty_outln (vty, "debug babel %s", debug_type[i].str);
                 lines++;
             }
     if (lines)
     {
-        vty_out (vty, "!%s", VTY_NEWLINE);
+        vty_outln (vty, "!");
         lines++;
     }
     return lines;
@@ -384,13 +384,13 @@ zebra_config_write (struct vty *vty)
 {
     if (! zclient->enable)
     {
-        vty_out (vty, "no router zebra%s", VTY_NEWLINE);
+        vty_outln (vty, "no router zebra");
         return 1;
     }
     else if (! vrf_bitmap_check (zclient->redist[AFI_IP][ZEBRA_ROUTE_BABEL], VRF_DEFAULT))
     {
-        vty_out (vty, "router zebra%s", VTY_NEWLINE);
-        vty_out (vty, " no redistribute babel%s", VTY_NEWLINE);
+        vty_outln (vty, "router zebra");
+        vty_outln (vty, " no redistribute babel");
         return 1;
     }
     return 0;

--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -83,27 +83,26 @@ babel_config_write (struct vty *vty)
 
     if (!babel_routing_process)
         return lines;
-    vty_out (vty, "router babel%s", VTY_NEWLINE);
+    vty_outln (vty, "router babel");
     if (diversity_kind != DIVERSITY_NONE)
     {
-        vty_out (vty, " babel diversity%s", VTY_NEWLINE);
+        vty_outln (vty, " babel diversity");
         lines++;
     }
     if (diversity_factor != BABEL_DEFAULT_DIVERSITY_FACTOR)
     {
-        vty_out (vty, " babel diversity-factor %d%s", diversity_factor,
-                 VTY_NEWLINE);
+        vty_outln (vty, " babel diversity-factor %d",diversity_factor);
         lines++;
     }
     if (resend_delay != BABEL_DEFAULT_RESEND_DELAY)
     {
-        vty_out (vty, " babel resend-delay %u%s", resend_delay, VTY_NEWLINE);
+        vty_outln (vty, " babel resend-delay %u", resend_delay);
         lines++;
     }
     if (smoothing_half_life != BABEL_DEFAULT_SMOOTHING_HALF_LIFE)
     {
-        vty_out (vty, " babel smoothing-half-life %u%s",
-                 smoothing_half_life, VTY_NEWLINE);
+        vty_outln (vty, " babel smoothing-half-life %u",
+                 smoothing_half_life);
         lines++;
     }
     /* list enabled interfaces */
@@ -113,7 +112,7 @@ babel_config_write (struct vty *vty)
         if (i != zclient->redist_default &&
 	    vrf_bitmap_check (zclient->redist[AFI_IP][i], VRF_DEFAULT))
         {
-            vty_out (vty, " redistribute %s%s", zebra_route_string (i), VTY_NEWLINE);
+            vty_outln (vty, " redistribute %s", zebra_route_string(i));
             lines++;
         }
 

--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -2176,7 +2176,7 @@ aspath_show_all_iterator (struct hash_backet *backet, struct vty *vty)
   as = (struct aspath *) backet->data;
 
   vty_out (vty, "[%p:%u] (%ld) ", (void *)backet, backet->key, as->refcnt);
-  vty_out (vty, "%s%s", as->str, VTY_NEWLINE);
+  vty_outln (vty, "%s", as->str);
 }
 
 /* Print all aspath and hash information.  This function is used from

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -791,8 +791,8 @@ attr_show_all_iterator (struct hash_backet *backet, struct vty *vty)
 {
   struct attr *attr = backet->data;
 
-  vty_out (vty, "attr[%ld] nexthop %s%s", attr->refcnt, 
-	   inet_ntoa (attr->nexthop), VTY_NEWLINE);
+  vty_outln (vty, "attr[%ld] nexthop %s", attr->refcnt, 
+	   inet_ntoa(attr->nexthop));
 }
 
 void

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -526,18 +526,17 @@ bgp_bfd_peer_config_write(struct vty *vty, struct peer *peer, char *addr)
   bfd_info = (struct bfd_info *)peer->bfd_info;
 
   if (CHECK_FLAG (bfd_info->flags, BFD_FLAG_PARAM_CFG))
-    vty_out (vty, " neighbor %s bfd %d %d %d%s", addr,
+    vty_outln (vty, " neighbor %s bfd %d %d %d", addr,
       bfd_info->detect_mult, bfd_info->required_min_rx,
-      bfd_info->desired_min_tx, VTY_NEWLINE);
+      bfd_info->desired_min_tx);
 
   if (bfd_info->type != BFD_TYPE_NOT_CONFIGURED)
-    vty_out (vty, " neighbor %s bfd %s%s", addr,
-      (bfd_info->type == BFD_TYPE_MULTIHOP) ? "multihop" : "singlehop",
-      VTY_NEWLINE);
+    vty_outln (vty, " neighbor %s bfd %s", addr,
+      (bfd_info->type == BFD_TYPE_MULTIHOP) ? "multihop" : "singlehop");
 
   if (!CHECK_FLAG (bfd_info->flags, BFD_FLAG_PARAM_CFG) &&
         (bfd_info->type == BFD_TYPE_NOT_CONFIGURED))
-    vty_out (vty, " neighbor %s bfd%s", addr, VTY_NEWLINE);
+    vty_outln (vty, " neighbor %s bfd", addr);
 }
 
 /*

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -525,21 +525,19 @@ bgp_config_write_damp (struct vty *vty)
       && bgp_damp_cfg.reuse_limit == DEFAULT_REUSE
       && bgp_damp_cfg.suppress_value == DEFAULT_SUPPRESS
       && bgp_damp_cfg.max_suppress_time == bgp_damp_cfg.half_life*4)
-    vty_out (vty, " bgp dampening%s", VTY_NEWLINE);
+    vty_outln (vty, " bgp dampening");
   else if (bgp_damp_cfg.half_life != DEFAULT_HALF_LIFE*60
 	   && bgp_damp_cfg.reuse_limit == DEFAULT_REUSE
 	   && bgp_damp_cfg.suppress_value == DEFAULT_SUPPRESS
 	   && bgp_damp_cfg.max_suppress_time == bgp_damp_cfg.half_life*4)
-    vty_out (vty, " bgp dampening %lld%s",
-	     bgp_damp_cfg.half_life/60LL,
-	     VTY_NEWLINE);
+    vty_outln (vty, " bgp dampening %lld",
+	     bgp_damp_cfg.half_life / 60LL);
   else
-    vty_out (vty, " bgp dampening %lld %d %d %lld%s",
+    vty_outln (vty, " bgp dampening %lld %d %d %lld",
 	     bgp_damp_cfg.half_life/60LL,
 	     bgp_damp_cfg.reuse_limit,
 	     bgp_damp_cfg.suppress_value,
-	     bgp_damp_cfg.max_suppress_time/60LL,
-	     VTY_NEWLINE);
+	     bgp_damp_cfg.max_suppress_time / 60LL);
 }
 
 static const char *
@@ -654,7 +652,7 @@ bgp_damp_info_vty (struct vty *vty, struct bgp_info *binfo,
         vty_out (vty, ", reuse in %s",
 	       bgp_get_reuse_time (penalty, timebuf, BGP_UPTIME_LEN, 0, json_path));
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 }
 
@@ -693,27 +691,27 @@ bgp_show_dampening_parameters (struct vty *vty, afi_t afi, safi_t safi)
 
   if (bgp == NULL)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
   if (CHECK_FLAG (bgp->af_flags[afi][safi], BGP_CONFIG_DAMPENING))
     {
-      vty_out (vty, "Half-life time: %lld min%s",
-               (long long)damp->half_life / 60, VTY_NEWLINE);
-      vty_out (vty, "Reuse penalty: %d%s",
-               damp->reuse_limit, VTY_NEWLINE);
-      vty_out (vty, "Suppress penalty: %d%s",
-               damp->suppress_value, VTY_NEWLINE);
-      vty_out (vty, "Max suppress time: %lld min%s",
-               (long long)damp->max_suppress_time / 60, VTY_NEWLINE);
-      vty_out (vty, "Max supress penalty: %u%s",
-               damp->ceiling, VTY_NEWLINE);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "Half-life time: %lld min",
+               (long long)damp->half_life / 60);
+      vty_outln (vty, "Reuse penalty: %d",
+               damp->reuse_limit);
+      vty_outln (vty, "Suppress penalty: %d",
+               damp->suppress_value);
+      vty_outln (vty, "Max suppress time: %lld min",
+               (long long)damp->max_suppress_time / 60);
+      vty_outln (vty, "Max supress penalty: %u",
+               damp->ceiling);
+      vty_outln (vty, "");
     }
   else
-    vty_out (vty, "dampening not enabled for %s%s",
-                  afi == AFI_IP ? "IPv4" : "IPv6", VTY_NEWLINE);
+    vty_outln (vty, "dampening not enabled for %s",
+                  afi == AFI_IP ? "IPv4" : "IPv6");
 
   return CMD_SUCCESS;
 }

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -652,7 +652,7 @@ bgp_damp_info_vty (struct vty *vty, struct bgp_info *binfo,
         vty_out (vty, ", reuse in %s",
 	       bgp_get_reuse_time (penalty, timebuf, BGP_UPTIME_LEN, 0, json_path));
 
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 }
 
@@ -707,7 +707,7 @@ bgp_show_dampening_parameters (struct vty *vty, afi_t afi, safi_t safi)
                (long long)damp->max_suppress_time / 60);
       vty_outln (vty, "Max supress penalty: %u",
                damp->ceiling);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   else
     vty_outln (vty, "dampening not enabled for %s",

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -254,7 +254,7 @@ bgp_debug_list_print (struct vty *vty, const char *desc, struct list *list)
         }
     }
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 }
 
 /* Print the command to enable the debug for each peer/prefix this debug is
@@ -1747,7 +1747,7 @@ DEFUN (show_debugging_bgp,
 
   if (BGP_DEBUG (allow_martians, ALLOW_MARTIANS))
     vty_outln (vty, "  BGP allow martian next hop debugging is on");
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   return CMD_SUCCESS;
 }
 

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -254,7 +254,7 @@ bgp_debug_list_print (struct vty *vty, const char *desc, struct list *list)
         }
     }
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 }
 
 /* Print the command to enable the debug for each peer/prefix this debug is
@@ -274,16 +274,16 @@ bgp_debug_list_conf_print (struct vty *vty, const char *desc, struct list *list)
         {
           if (filter->host)
             {
-              vty_out (vty, "%s %s%s", desc, filter->host, VTY_NEWLINE);
+              vty_outln (vty, "%s %s", desc, filter->host);
               write++;
             }
 
 
           if (filter->p)
             {
-              vty_out (vty, "%s %s/%d%s", desc,
+              vty_outln (vty, "%s %s/%d", desc,
                        inet_ntop (filter->p->family, &filter->p->u.prefix, buf, INET6_ADDRSTRLEN),
-                       filter->p->prefixlen, VTY_NEWLINE);
+                       filter->p->prefixlen);
               write++;
             }
         }
@@ -291,7 +291,7 @@ bgp_debug_list_conf_print (struct vty *vty, const char *desc, struct list *list)
 
     if (!write)
       {
-        vty_out (vty, "%s%s", desc, VTY_NEWLINE);
+        vty_outln (vty, "%s", desc);
         write++;
       }
 
@@ -583,7 +583,7 @@ DEFUN (debug_bgp_as4,
   else
     {
       TERM_DEBUG_ON (as4, AS4);
-      vty_out (vty, "BGP as4 debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP as4 debugging is on");
     }
   return CMD_SUCCESS;
 }
@@ -601,7 +601,7 @@ DEFUN (no_debug_bgp_as4,
   else
     {
       TERM_DEBUG_OFF (as4, AS4);
-      vty_out (vty, "BGP as4 debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP as4 debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -619,7 +619,7 @@ DEFUN (debug_bgp_as4_segment,
   else
     {
       TERM_DEBUG_ON (as4, AS4_SEGMENT);
-      vty_out (vty, "BGP as4 segment debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP as4 segment debugging is on");
     }
   return CMD_SUCCESS;
 }
@@ -638,7 +638,7 @@ DEFUN (no_debug_bgp_as4_segment,
   else
     {
       TERM_DEBUG_OFF (as4, AS4_SEGMENT);
-      vty_out (vty, "BGP as4 segment debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP as4 segment debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -658,7 +658,7 @@ DEFUN (debug_bgp_neighbor_events,
   else
     {
       TERM_DEBUG_ON (neighbor_events, NEIGHBOR_EVENTS);
-      vty_out (vty, "BGP neighbor-events debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP neighbor-events debugging is on");
     }
   return CMD_SUCCESS;
 }
@@ -681,7 +681,8 @@ DEFUN (debug_bgp_neighbor_events_peer,
 
   if (bgp_debug_list_has_entry(bgp_debug_neighbor_events_peers, host, NULL))
     {
-      vty_out (vty, "BGP neighbor-events debugging is already enabled for %s%s", host, VTY_NEWLINE);
+      vty_outln (vty, "BGP neighbor-events debugging is already enabled for %s",
+                 host);
       return CMD_SUCCESS;
     }
 
@@ -692,7 +693,7 @@ DEFUN (debug_bgp_neighbor_events_peer,
   else
     {
       TERM_DEBUG_ON (neighbor_events, NEIGHBOR_EVENTS);
-      vty_out (vty, "BGP neighbor-events debugging is on for %s%s", host, VTY_NEWLINE);
+      vty_outln (vty, "BGP neighbor-events debugging is on for %s", host);
     }
   return CMD_SUCCESS;
 }
@@ -712,7 +713,7 @@ DEFUN (no_debug_bgp_neighbor_events,
   else
     {
       TERM_DEBUG_OFF (neighbor_events, NEIGHBOR_EVENTS);
-      vty_out (vty, "BGP neighbor-events debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP neighbor-events debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -746,9 +747,10 @@ DEFUN (no_debug_bgp_neighbor_events_peer,
     }
 
   if (found_peer)
-    vty_out (vty, "BGP neighbor-events debugging is off for %s%s", host, VTY_NEWLINE);
+    vty_outln (vty, "BGP neighbor-events debugging is off for %s", host);
   else
-    vty_out (vty, "BGP neighbor-events debugging was not enabled for %s%s", host, VTY_NEWLINE);
+    vty_outln (vty, "BGP neighbor-events debugging was not enabled for %s",
+               host);
 
   return CMD_SUCCESS;
 }
@@ -766,7 +768,7 @@ DEFUN (debug_bgp_nht,
   else
     {
       TERM_DEBUG_ON (nht, NHT);
-      vty_out (vty, "BGP nexthop tracking debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP nexthop tracking debugging is on");
     }
   return CMD_SUCCESS;
 }
@@ -784,7 +786,7 @@ DEFUN (no_debug_bgp_nht,
   else
     {
       TERM_DEBUG_OFF (nht, NHT);
-      vty_out (vty, "BGP nexthop tracking debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP nexthop tracking debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -804,7 +806,7 @@ DEFUN (debug_bgp_keepalive,
   else
     {
       TERM_DEBUG_ON (keepalive, KEEPALIVE);
-      vty_out (vty, "BGP keepalives debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP keepalives debugging is on");
     }
   return CMD_SUCCESS;
 }
@@ -827,7 +829,8 @@ DEFUN (debug_bgp_keepalive_peer,
 
   if (bgp_debug_list_has_entry(bgp_debug_keepalive_peers, host, NULL))
     {
-      vty_out (vty, "BGP keepalive debugging is already enabled for %s%s", host, VTY_NEWLINE);
+      vty_outln (vty, "BGP keepalive debugging is already enabled for %s",
+                 host);
       return CMD_SUCCESS;
     }
 
@@ -838,7 +841,7 @@ DEFUN (debug_bgp_keepalive_peer,
   else
     {
       TERM_DEBUG_ON (keepalive, KEEPALIVE);
-      vty_out (vty, "BGP keepalives debugging is on for %s%s", host, VTY_NEWLINE);
+      vty_outln (vty, "BGP keepalives debugging is on for %s", host);
     }
   return CMD_SUCCESS;
 }
@@ -858,7 +861,7 @@ DEFUN (no_debug_bgp_keepalive,
   else
     {
       TERM_DEBUG_OFF (keepalive, KEEPALIVE);
-      vty_out (vty, "BGP keepalives debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP keepalives debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -892,9 +895,9 @@ DEFUN (no_debug_bgp_keepalive_peer,
     }
 
   if (found_peer)
-    vty_out (vty, "BGP keepalives debugging is off for %s%s", host, VTY_NEWLINE);
+    vty_outln (vty, "BGP keepalives debugging is off for %s", host);
   else
-    vty_out (vty, "BGP keepalives debugging was not enabled for %s%s", host, VTY_NEWLINE);
+    vty_outln (vty, "BGP keepalives debugging was not enabled for %s", host);
 
   return CMD_SUCCESS;
 }
@@ -919,7 +922,7 @@ DEFPY (debug_bgp_bestpath_prefix,
 
   if (bgp_debug_list_has_entry(bgp_debug_bestpath_prefixes, NULL, bestpath))
     {
-      vty_out (vty, "BGP bestpath debugging is already enabled for %s%s", bestpath_str, VTY_NEWLINE);
+      vty_outln (vty, "BGP bestpath debugging is already enabled for %s", bestpath_str);
       return CMD_SUCCESS;
     }
 
@@ -932,7 +935,7 @@ DEFPY (debug_bgp_bestpath_prefix,
   else
     {
       TERM_DEBUG_ON (bestpath, BESTPATH);
-      vty_out (vty, "BGP bestpath debugging is on for %s%s", bestpath_str, VTY_NEWLINE);
+      vty_outln (vty, "BGP bestpath debugging is on for %s", bestpath_str);
     }
 
   return CMD_SUCCESS;
@@ -959,7 +962,7 @@ DEFUN (no_debug_bgp_bestpath_prefix,
   if (!ret)
     {
       prefix_free(argv_p);
-      vty_out (vty, "%% Malformed Prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed Prefix");
       return CMD_WARNING;
     }
 
@@ -976,15 +979,17 @@ DEFUN (no_debug_bgp_bestpath_prefix,
           else
             {
               TERM_DEBUG_OFF (bestpath, BESTPATH);
-              vty_out (vty, "BGP bestpath debugging (per prefix) is off%s", VTY_NEWLINE);
+              vty_outln (vty, "BGP bestpath debugging (per prefix) is off");
             }
         }
     }
 
   if (found_prefix)
-    vty_out (vty, "BGP bestpath debugging is off for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+    vty_outln (vty, "BGP bestpath debugging is off for %s",
+               argv[idx_ipv4_ipv6_prefixlen]->arg);
   else
-    vty_out (vty, "BGP bestpath debugging was not enabled for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+    vty_outln (vty, "BGP bestpath debugging was not enabled for %s",
+               argv[idx_ipv4_ipv6_prefixlen]->arg);
 
   return CMD_SUCCESS;
 }
@@ -1004,7 +1009,7 @@ DEFUN (no_debug_bgp_bestpath,
   else
     {
       TERM_DEBUG_OFF (bestpath, BESTPATH);
-      vty_out (vty, "BGP bestpath debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP bestpath debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -1030,7 +1035,7 @@ DEFUN (debug_bgp_update,
     {
       TERM_DEBUG_ON (update, UPDATE_IN);
       TERM_DEBUG_ON (update, UPDATE_OUT);
-      vty_out (vty, "BGP updates debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP updates debugging is on");
     }
   return CMD_SUCCESS;
 }
@@ -1063,12 +1068,12 @@ DEFUN (debug_bgp_update_direct,
       if (strncmp ("i", argv[idx_in_out]->arg, 1) == 0)
 	{
 	  TERM_DEBUG_ON (update, UPDATE_IN);
-	  vty_out (vty, "BGP updates debugging is on (inbound)%s", VTY_NEWLINE);
+	  vty_outln (vty, "BGP updates debugging is on (inbound)");
 	}
       else
 	{
 	  TERM_DEBUG_ON (update, UPDATE_OUT);
-	  vty_out (vty, "BGP updates debugging is on (outbound)%s", VTY_NEWLINE);
+	  vty_outln (vty, "BGP updates debugging is on (outbound)");
 	}
     }
   return CMD_SUCCESS;
@@ -1106,7 +1111,8 @@ DEFUN (debug_bgp_update_direct_peer,
     {
       if (bgp_debug_list_has_entry(bgp_debug_update_in_peers, host, NULL))
         {
-          vty_out (vty, "BGP inbound update debugging is already enabled for %s%s", host, VTY_NEWLINE);
+          vty_outln (vty, "BGP inbound update debugging is already enabled for %s",
+                     host);
           return CMD_SUCCESS;
         }
     }
@@ -1115,7 +1121,8 @@ DEFUN (debug_bgp_update_direct_peer,
     {
       if (bgp_debug_list_has_entry(bgp_debug_update_out_peers, host, NULL))
         {
-          vty_out (vty, "BGP outbound update debugging is already enabled for %s%s", host, VTY_NEWLINE);
+          vty_outln (vty, "BGP outbound update debugging is already enabled for %s",
+                     host);
           return CMD_SUCCESS;
         }
     }
@@ -1159,12 +1166,14 @@ DEFUN (debug_bgp_update_direct_peer,
       if (inbound)
 	{
 	  TERM_DEBUG_ON (update, UPDATE_IN);
-	  vty_out (vty, "BGP updates debugging is on (inbound) for %s%s", argv[idx_peer]->arg, VTY_NEWLINE);
+	  vty_outln (vty, "BGP updates debugging is on (inbound) for %s",
+                     argv[idx_peer]->arg);
 	}
       else
 	{
 	  TERM_DEBUG_ON (update, UPDATE_OUT);
-	  vty_out (vty, "BGP updates debugging is on (outbound) for %s%s", argv[idx_peer]->arg, VTY_NEWLINE);
+	  vty_outln (vty, "BGP updates debugging is on (outbound) for %s",
+                     argv[idx_peer]->arg);
 	}
     }
   return CMD_SUCCESS;
@@ -1192,7 +1201,7 @@ DEFUN (no_debug_bgp_update_direct,
       else
         {
           TERM_DEBUG_OFF (update, UPDATE_IN);
-          vty_out (vty, "BGP updates debugging is off (inbound)%s", VTY_NEWLINE);
+          vty_outln (vty, "BGP updates debugging is off (inbound)");
         }
     }
   else
@@ -1206,7 +1215,7 @@ DEFUN (no_debug_bgp_update_direct,
       else
         {
           TERM_DEBUG_OFF (update, UPDATE_OUT);
-          vty_out (vty, "BGP updates debugging is off (outbound)%s", VTY_NEWLINE);
+          vty_outln (vty, "BGP updates debugging is off (outbound)");
         }
     }
 
@@ -1249,7 +1258,7 @@ DEFUN (no_debug_bgp_update_direct_peer,
           else
             {
               TERM_DEBUG_OFF (update, UPDATE_IN);
-              vty_out (vty, "BGP updates debugging (inbound) is off%s", VTY_NEWLINE);
+              vty_outln (vty, "BGP updates debugging (inbound) is off");
             }
         }
     }
@@ -1266,7 +1275,7 @@ DEFUN (no_debug_bgp_update_direct_peer,
           else
             {
               TERM_DEBUG_OFF (update, UPDATE_OUT);
-              vty_out (vty, "BGP updates debugging (outbound) is off%s", VTY_NEWLINE);
+              vty_outln (vty, "BGP updates debugging (outbound) is off");
             }
         }
 
@@ -1293,14 +1302,17 @@ DEFUN (no_debug_bgp_update_direct_peer,
 
   if (found_peer)
     if (inbound)
-      vty_out (vty, "BGP updates debugging (inbound) is off for %s%s", host, VTY_NEWLINE);
+      vty_outln (vty, "BGP updates debugging (inbound) is off for %s", host);
     else
-      vty_out (vty, "BGP updates debugging (outbound) is off for %s%s", host, VTY_NEWLINE);
+      vty_outln (vty, "BGP updates debugging (outbound) is off for %s",
+                 host);
   else
     if (inbound)
-      vty_out (vty, "BGP updates debugging (inbound) was not enabled for %s%s", host, VTY_NEWLINE);
+      vty_outln (vty, "BGP updates debugging (inbound) was not enabled for %s",
+                 host);
     else
-      vty_out (vty, "BGP updates debugging (outbound) was not enabled for %s%s", host, VTY_NEWLINE);
+      vty_outln (vty, "BGP updates debugging (outbound) was not enabled for %s",
+                 host);
 
   return CMD_SUCCESS;
 }
@@ -1325,7 +1337,7 @@ DEFUN (debug_bgp_update_prefix,
   if (!ret)
     {
       prefix_free(argv_p);
-      vty_out (vty, "%% Malformed Prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed Prefix");
       return CMD_WARNING;
     }
 
@@ -1335,7 +1347,8 @@ DEFUN (debug_bgp_update_prefix,
 
   if (bgp_debug_list_has_entry(bgp_debug_update_prefixes, NULL, argv_p))
     {
-      vty_out (vty, "BGP updates debugging is already enabled for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+      vty_outln (vty, "BGP updates debugging is already enabled for %s",
+                 argv[idx_ipv4_ipv6_prefixlen]->arg);
       return CMD_SUCCESS;
     }
 
@@ -1348,7 +1361,8 @@ DEFUN (debug_bgp_update_prefix,
   else
     {
       TERM_DEBUG_ON (update, UPDATE_PREFIX);
-      vty_out (vty, "BGP updates debugging is on for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+      vty_outln (vty, "BGP updates debugging is on for %s",
+                 argv[idx_ipv4_ipv6_prefixlen]->arg);
     }
 
   return CMD_SUCCESS;
@@ -1376,7 +1390,7 @@ DEFUN (no_debug_bgp_update_prefix,
   if (!ret)
     {
       prefix_free(argv_p);
-      vty_out (vty, "%% Malformed Prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed Prefix");
       return CMD_WARNING;
     }
 
@@ -1393,15 +1407,17 @@ DEFUN (no_debug_bgp_update_prefix,
           else
             {
               TERM_DEBUG_OFF (update, UPDATE_PREFIX);
-              vty_out (vty, "BGP updates debugging (per prefix) is off%s", VTY_NEWLINE);
+              vty_outln (vty, "BGP updates debugging (per prefix) is off");
             }
         }
     }
 
   if (found_prefix)
-    vty_out (vty, "BGP updates debugging is off for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+    vty_outln (vty, "BGP updates debugging is off for %s",
+               argv[idx_ipv4_ipv6_prefixlen]->arg);
   else
-    vty_out (vty, "BGP updates debugging was not enabled for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+    vty_outln (vty, "BGP updates debugging was not enabled for %s",
+               argv[idx_ipv4_ipv6_prefixlen]->arg);
 
   return CMD_SUCCESS;
 }
@@ -1432,7 +1448,7 @@ DEFUN (no_debug_bgp_update,
       TERM_DEBUG_OFF (update, UPDATE_IN);
       TERM_DEBUG_OFF (update, UPDATE_OUT);
       TERM_DEBUG_OFF (update, UPDATE_PREFIX);
-      vty_out (vty, "BGP updates debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP updates debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -1450,7 +1466,7 @@ DEFUN (debug_bgp_zebra,
   else
     {
       TERM_DEBUG_ON (zebra, ZEBRA);
-      vty_out (vty, "BGP zebra debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP zebra debugging is on");
     }
   return CMD_SUCCESS;
 }
@@ -1475,7 +1491,7 @@ DEFUN (debug_bgp_zebra_prefix,
   if (!ret)
     {
       prefix_free(argv_p);
-      vty_out (vty, "%% Malformed Prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed Prefix");
       return CMD_WARNING;
     }
 
@@ -1484,7 +1500,8 @@ DEFUN (debug_bgp_zebra_prefix,
 
   if (bgp_debug_list_has_entry(bgp_debug_zebra_prefixes, NULL, argv_p))
     {
-      vty_out (vty, "BGP zebra debugging is already enabled for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+      vty_outln (vty, "BGP zebra debugging is already enabled for %s",
+                 argv[idx_ipv4_ipv6_prefixlen]->arg);
       return CMD_SUCCESS;
     }
 
@@ -1495,7 +1512,8 @@ DEFUN (debug_bgp_zebra_prefix,
   else
     {
       TERM_DEBUG_ON (zebra, ZEBRA);
-      vty_out (vty, "BGP zebra debugging is on for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+      vty_outln (vty, "BGP zebra debugging is on for %s",
+                 argv[idx_ipv4_ipv6_prefixlen]->arg);
     }
 
   return CMD_SUCCESS;
@@ -1516,7 +1534,7 @@ DEFUN (no_debug_bgp_zebra,
   else
     {
       TERM_DEBUG_OFF (zebra, ZEBRA);
-      vty_out (vty, "BGP zebra debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP zebra debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -1543,7 +1561,7 @@ DEFUN (no_debug_bgp_zebra_prefix,
   if (!ret)
     {
       prefix_free(argv_p);
-      vty_out (vty, "%% Malformed Prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed Prefix");
       return CMD_WARNING;
     }
 
@@ -1558,15 +1576,17 @@ DEFUN (no_debug_bgp_zebra_prefix,
           else
             {
               TERM_DEBUG_OFF (zebra, ZEBRA);
-              vty_out (vty, "BGP zebra debugging is off%s", VTY_NEWLINE);
+              vty_outln (vty, "BGP zebra debugging is off");
             }
         }
     }
 
   if (found_prefix)
-    vty_out (vty, "BGP zebra debugging is off for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+    vty_outln (vty, "BGP zebra debugging is off for %s",
+               argv[idx_ipv4_ipv6_prefixlen]->arg);
   else
-    vty_out (vty, "BGP zebra debugging was not enabled for %s%s", argv[idx_ipv4_ipv6_prefixlen]->arg, VTY_NEWLINE);
+    vty_outln (vty, "BGP zebra debugging was not enabled for %s",
+               argv[idx_ipv4_ipv6_prefixlen]->arg);
 
   return CMD_SUCCESS;
 }
@@ -1583,7 +1603,7 @@ DEFUN (debug_bgp_allow_martians,
   else
     {
       TERM_DEBUG_ON (allow_martians, ALLOW_MARTIANS);
-      vty_out (vty, "BGP allow_martian next hop debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP allow_martian next hop debugging is on");
     }
   return CMD_SUCCESS;
 }
@@ -1601,7 +1621,7 @@ DEFUN (no_debug_bgp_allow_martians,
   else
     {
       TERM_DEBUG_OFF (allow_martians, ALLOW_MARTIANS);
-      vty_out (vty, "BGP allow martian next hop debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP allow martian next hop debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -1620,7 +1640,7 @@ DEFUN (debug_bgp_update_groups,
   else
     {
       TERM_DEBUG_ON (update_groups, UPDATE_GROUPS);
-      vty_out (vty, "BGP update-groups debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP update-groups debugging is on");
     }
   return CMD_SUCCESS;
 }
@@ -1638,7 +1658,7 @@ DEFUN (no_debug_bgp_update_groups,
   else
     {
       TERM_DEBUG_OFF (update_groups, UPDATE_GROUPS);
-      vty_out (vty, "BGP update-groups debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "BGP update-groups debugging is off");
     }
   return CMD_SUCCESS;
 }
@@ -1671,7 +1691,7 @@ DEFUN (no_debug_bgp,
   TERM_DEBUG_OFF (neighbor_events, NEIGHBOR_EVENTS);
   TERM_DEBUG_OFF (zebra, ZEBRA);
   TERM_DEBUG_OFF (allow_martians, ALLOW_MARTIANS);
-  vty_out (vty, "All possible debugging has been turned off%s", VTY_NEWLINE);
+  vty_outln (vty, "All possible debugging has been turned off");
       
   return CMD_SUCCESS;
 }
@@ -1683,13 +1703,13 @@ DEFUN (show_debugging_bgp,
        DEBUG_STR
        BGP_STR)
 {
-  vty_out (vty, "BGP debugging status:%s", VTY_NEWLINE);
+  vty_outln (vty, "BGP debugging status:");
 
   if (BGP_DEBUG (as4, AS4))
-    vty_out (vty, "  BGP as4 debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  BGP as4 debugging is on");
 
   if (BGP_DEBUG (as4, AS4_SEGMENT))
-    vty_out (vty, "  BGP as4 aspath segment debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  BGP as4 aspath segment debugging is on");
 
   if (BGP_DEBUG (bestpath, BESTPATH))
     bgp_debug_list_print (vty, "  BGP bestpath debugging is on",
@@ -1704,10 +1724,10 @@ DEFUN (show_debugging_bgp,
                           bgp_debug_neighbor_events_peers);
 
   if (BGP_DEBUG (nht, NHT))
-    vty_out (vty, "  BGP next-hop tracking debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  BGP next-hop tracking debugging is on");
 
   if (BGP_DEBUG (update_groups, UPDATE_GROUPS))
-    vty_out (vty, "  BGP update-groups debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  BGP update-groups debugging is on");
 
   if (BGP_DEBUG (update, UPDATE_PREFIX))
     bgp_debug_list_print (vty, "  BGP updates debugging is on",
@@ -1726,8 +1746,8 @@ DEFUN (show_debugging_bgp,
                           bgp_debug_zebra_prefixes);
 
   if (BGP_DEBUG (allow_martians, ALLOW_MARTIANS))
-    vty_out (vty, "  BGP allow martian next hop debugging is on%s", VTY_NEWLINE);
-  vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "  BGP allow martian next hop debugging is on");
+  vty_outln (vty, "");
   return CMD_SUCCESS;
 }
 
@@ -1782,13 +1802,13 @@ bgp_config_write_debug (struct vty *vty)
 
   if (CONF_BGP_DEBUG (as4, AS4))
     {
-      vty_out (vty, "debug bgp as4%s", VTY_NEWLINE);
+      vty_outln (vty, "debug bgp as4");
       write++;
     }
 
   if (CONF_BGP_DEBUG (as4, AS4_SEGMENT))
     {
-      vty_out (vty, "debug bgp as4 segment%s", VTY_NEWLINE);
+      vty_outln (vty, "debug bgp as4 segment");
       write++;
     }
 
@@ -1812,13 +1832,13 @@ bgp_config_write_debug (struct vty *vty)
 
   if (CONF_BGP_DEBUG (nht, NHT))
     {
-      vty_out (vty, "debug bgp nht%s", VTY_NEWLINE);
+      vty_outln (vty, "debug bgp nht");
       write++;
     }
 
   if (CONF_BGP_DEBUG (update_groups, UPDATE_GROUPS))
     {
-      vty_out (vty, "debug bgp update-groups%s", VTY_NEWLINE);
+      vty_outln (vty, "debug bgp update-groups");
       write++;
     }
 
@@ -1844,7 +1864,7 @@ bgp_config_write_debug (struct vty *vty)
     {
       if (!bgp_debug_zebra_prefixes || list_isempty(bgp_debug_zebra_prefixes))
         {
-          vty_out (vty, "debug bgp zebra%s", VTY_NEWLINE);
+          vty_outln (vty, "debug bgp zebra");
           write++;
         }
       else
@@ -1856,7 +1876,7 @@ bgp_config_write_debug (struct vty *vty)
 
   if (CONF_BGP_DEBUG (allow_martians, ALLOW_MARTIANS))
     {
-      vty_out (vty, "debug bgp allow-martians%s", VTY_NEWLINE);
+      vty_outln (vty, "debug bgp allow-martians");
       write++;
     }
 

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -667,7 +667,7 @@ bgp_dump_set (struct vty *vty, struct bgp_dump *bgp_dump,
       interval = bgp_dump_parse_time (interval_str);
       if (interval == 0)
 	{
-	  vty_out (vty, "Malformed interval string%s", VTY_NEWLINE);
+	  vty_outln (vty, "Malformed interval string");
 	  return CMD_WARNING;
 	}
 
@@ -866,12 +866,11 @@ config_write_bgp_dump (struct vty *vty)
           type_str = "all-et";
 
       if (bgp_dump_all.interval_str)
-	vty_out (vty, "dump bgp %s %s %s%s", type_str,
-		 bgp_dump_all.filename, bgp_dump_all.interval_str,
-		 VTY_NEWLINE);
+	vty_outln (vty, "dump bgp %s %s %s", type_str,
+		 bgp_dump_all.filename,bgp_dump_all.interval_str);
       else
-	vty_out (vty, "dump bgp %s %s%s", type_str,
-		 bgp_dump_all.filename, VTY_NEWLINE);
+	vty_outln (vty, "dump bgp %s %s", type_str,
+		 bgp_dump_all.filename);
     }
   if (bgp_dump_updates.filename)
     {
@@ -880,22 +879,20 @@ config_write_bgp_dump (struct vty *vty)
         type_str = "updates-et";
 
       if (bgp_dump_updates.interval_str)
-	vty_out (vty, "dump bgp %s %s %s%s", type_str,
-		 bgp_dump_updates.filename, bgp_dump_updates.interval_str,
-		 VTY_NEWLINE);
+	vty_outln (vty, "dump bgp %s %s %s", type_str,
+		 bgp_dump_updates.filename,bgp_dump_updates.interval_str);
       else
-	vty_out (vty, "dump bgp %s %s%s", type_str,
-		 bgp_dump_updates.filename, VTY_NEWLINE);
+	vty_outln (vty, "dump bgp %s %s", type_str,
+		 bgp_dump_updates.filename);
     }
   if (bgp_dump_routes.filename)
     {
       if (bgp_dump_routes.interval_str)
-	vty_out (vty, "dump bgp routes-mrt %s %s%s", 
-		 bgp_dump_routes.filename, bgp_dump_routes.interval_str,
-		 VTY_NEWLINE);
+	vty_outln (vty, "dump bgp routes-mrt %s %s", 
+		 bgp_dump_routes.filename,bgp_dump_routes.interval_str);
       else
-        vty_out (vty, "dump bgp routes-mrt %s%s",
-                 bgp_dump_routes.filename, VTY_NEWLINE);
+        vty_outln (vty, "dump bgp routes-mrt %s",
+                 bgp_dump_routes.filename);
 
     }
   return 0;

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -147,7 +147,7 @@ bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 									"Status codes: s suppressed, d damped, h history, * valid, > best, i - internal");
 								vty_outln (vty,
 									"Origin codes: i - IGP, e - EGP, ? - incomplete%s",
-									VTY_NEWLINE);
+									VTYNL);
 								vty_outln(vty, V4_HEADER);
 							}
 						}
@@ -257,7 +257,7 @@ bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 			  total_count);
 	else
 		vty_outln (vty, "%sDisplayed %ld out of %ld total prefixes",
-			VTY_NEWLINE, output_count, total_count);
+			VTYNL, output_count, total_count);
 	return CMD_SUCCESS;
 }
 

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -49,12 +49,6 @@ bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 	struct bgp_info *ri;
 	int rd_header;
 	int header = 1;
-	char v4_header[] =
-	    "   Network          Next Hop            Metric LocPrf Weight Path%s";
-	char v4_header_tag[] =
-	    "   Network          Next Hop      In tag/Out tag%s";
-	char v4_header_overlay[] =
-	    "   Network          Next Hop      EthTag    Overlay Index   RouterMac%s";
 
 	unsigned long output_count = 0;
 	unsigned long total_count = 0;
@@ -67,8 +61,7 @@ bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 	bgp = bgp_get_default();
 	if (bgp == NULL) {
 		if (!use_json)
-			vty_out(vty, "No BGP process is configured%s",
-				VTY_NEWLINE);
+			vty_outln (vty,"No BGP process is configured");
 		return CMD_WARNING;
 	}
 
@@ -142,31 +135,20 @@ bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 						} else {
 							if (option ==
 							    SHOW_DISPLAY_TAGS)
-								vty_out(vty,
-									v4_header_tag,
-									VTY_NEWLINE);
+								vty_outln(vty, V4_HEADER_TAG);
 							else if (option ==
 								 SHOW_DISPLAY_OVERLAY)
-								vty_out(vty,
-									v4_header_overlay,
-									VTY_NEWLINE);
+								vty_outln(vty, V4_HEADER_OVERLAY);
 							else {
-								vty_out(vty,
-									"BGP table version is 0, local router ID is %s%s",
-									inet_ntoa
-									(bgp->
-									 router_id),
+								vty_outln (vty,
+									"BGP table version is 0, local router ID is %s",
+									inet_ntoa(bgp->router_id));
+								vty_outln (vty,
+									"Status codes: s suppressed, d damped, h history, * valid, > best, i - internal");
+								vty_outln (vty,
+									"Origin codes: i - IGP, e - EGP, ? - incomplete%s",
 									VTY_NEWLINE);
-								vty_out(vty,
-									"Status codes: s suppressed, d damped, h history, * valid, > best, i - internal%s",
-									VTY_NEWLINE);
-								vty_out(vty,
-									"Origin codes: i - IGP, e - EGP, ? - incomplete%s%s",
-									VTY_NEWLINE,
-									VTY_NEWLINE);
-								vty_out(vty,
-									v4_header,
-									VTY_NEWLINE);
+								vty_outln(vty, V4_HEADER);
 							}
 						}
 						header = 0;
@@ -242,8 +224,7 @@ bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 									 ip),
 									rd_ip.
 									val);
-							vty_out(vty, "%s",
-								VTY_NEWLINE);
+							vty_outln (vty, VTYNL);
 						}
 						rd_header = 0;
 					}
@@ -272,11 +253,11 @@ bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 		}
 	}
 	if (output_count == 0)
-		vty_out(vty, "No prefixes displayed, %ld exist%s", total_count,
-			VTY_NEWLINE);
+		vty_outln (vty, "No prefixes displayed, %ld exist",
+			  total_count);
 	else
-		vty_out(vty, "%sDisplayed %ld out of %ld total prefixes%s",
-			VTY_NEWLINE, output_count, total_count, VTY_NEWLINE);
+		vty_outln (vty, "%sDisplayed %ld out of %ld total prefixes",
+			VTY_NEWLINE, output_count, total_count);
 	return CMD_SUCCESS;
 }
 
@@ -308,7 +289,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd,
 
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
 	if (!ret) {
-		vty_out(vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed Route Distinguisher");
 		return CMD_WARNING;
 	}
 	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL, 0,
@@ -349,7 +330,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_tags,
 
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
 	if (!ret) {
-		vty_out(vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed Route Distinguisher");
 		return CMD_WARNING;
 	}
 	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL, 1,
@@ -384,13 +365,12 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_neighbor_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "Malformed address");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "Malformed address: %s%s",
-				argv[idx_ipv4]->arg, VTY_NEWLINE);
+			vty_outln (vty, "Malformed address: %s",
+				argv[idx_ipv4]->arg);
 		return CMD_WARNING;
 	}
 
@@ -401,13 +381,12 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_neighbor_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "No such neighbor or address family");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "%% No such neighbor or address family%s",
-				VTY_NEWLINE);
+			vty_outln (vty,
+				  "%% No such neighbor or address family");
 		return CMD_WARNING;
 	}
 
@@ -447,13 +426,11 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "Malformed Route Distinguisher");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "%% Malformed Route Distinguisher%s",
-				VTY_NEWLINE);
+			vty_outln (vty,"%% Malformed Route Distinguisher");
 		return CMD_WARNING;
 	}
 
@@ -464,13 +441,12 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "Malformed address");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "Malformed address: %s%s",
-				argv[idx_ext_community]->arg, VTY_NEWLINE);
+			vty_outln (vty, "Malformed address: %s",
+				argv[idx_ext_community]->arg);
 		return CMD_WARNING;
 	}
 
@@ -481,13 +457,12 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "No such neighbor or address family");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "%% No such neighbor or address family%s",
-				VTY_NEWLINE);
+			vty_outln (vty,
+				  "%% No such neighbor or address family");
 		return CMD_WARNING;
 	}
 
@@ -523,13 +498,12 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_neighbor_advertised_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "Malformed address");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "Malformed address: %s%s",
-				argv[idx_ipv4]->arg, VTY_NEWLINE);
+			vty_outln (vty, "Malformed address: %s",
+				argv[idx_ipv4]->arg);
 		return CMD_WARNING;
 	}
 	peer = peer_lookup(NULL, &su);
@@ -539,13 +513,12 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_neighbor_advertised_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "No such neighbor or address family");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "%% No such neighbor or address family%s",
-				VTY_NEWLINE);
+			vty_outln (vty,
+				  "%% No such neighbor or address family");
 		return CMD_WARNING;
 	}
 
@@ -584,13 +557,12 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "Malformed address");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "Malformed address: %s%s",
-				argv[idx_ext_community]->arg, VTY_NEWLINE);
+			vty_outln (vty, "Malformed address: %s",
+				argv[idx_ext_community]->arg);
 		return CMD_WARNING;
 	}
 	peer = peer_lookup(NULL, &su);
@@ -600,13 +572,12 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "No such neighbor or address family");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "%% No such neighbor or address family%s",
-				VTY_NEWLINE);
+			vty_outln (vty,
+				  "%% No such neighbor or address family");
 		return CMD_WARNING;
 	}
 
@@ -617,13 +588,11 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes,
 			json_no = json_object_new_object();
 			json_object_string_add(json_no, "warning",
 					       "Malformed Route Distinguisher");
-			vty_out(vty, "%s%s",
-				json_object_to_json_string(json_no),
-				VTY_NEWLINE);
+			vty_outln (vty, "%s",
+				json_object_to_json_string(json_no));
 			json_object_free(json_no);
 		} else
-			vty_out(vty, "%% Malformed Route Distinguisher%s",
-				VTY_NEWLINE);
+			vty_outln (vty,"%% Malformed Route Distinguisher");
 		return CMD_WARNING;
 	}
 
@@ -666,7 +635,7 @@ DEFUN(show_ip_bgp_evpn_rd_overlay,
 
 	ret = str2prefix_rd(argv[idx_ext_community]->arg, &prd);
 	if (!ret) {
-		vty_out(vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed Route Distinguisher");
 		return CMD_WARNING;
 	}
 	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL,

--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -457,7 +457,7 @@ DEFUN (ip_as_path,
   regex = bgp_regcomp (regstr);
   if (!regex)
     {
-      vty_out (vty, "can't compile regexp %s%s", regstr, VTY_NEWLINE);
+      vty_outln (vty, "can't compile regexp %s", regstr);
       XFREE (MTYPE_TMP, regstr);
       return CMD_WARNING;
     }
@@ -503,8 +503,7 @@ DEFUN (no_ip_as_path,
   aslist = as_list_lookup (aslistname);
   if (aslist == NULL)
     {
-      vty_out (vty, "ip as-path access-list %s doesn't exist%s", aslistname,
-	       VTY_NEWLINE);
+      vty_outln (vty, "ip as-path access-list %s doesn't exist",aslistname);
       return CMD_WARNING;
     }
 
@@ -515,7 +514,7 @@ DEFUN (no_ip_as_path,
     type = AS_FILTER_DENY;
   else
     {
-      vty_out (vty, "filter type must be [permit|deny]%s", VTY_NEWLINE);
+      vty_outln (vty, "filter type must be [permit|deny]");
       return CMD_WARNING;
     }
   
@@ -526,7 +525,7 @@ DEFUN (no_ip_as_path,
   regex = bgp_regcomp (regstr);
   if (!regex)
     {
-      vty_out (vty, "can't compile regexp %s%s", regstr, VTY_NEWLINE);
+      vty_outln (vty, "can't compile regexp %s", regstr);
       XFREE (MTYPE_TMP, regstr);
       return CMD_WARNING;
     }
@@ -539,7 +538,7 @@ DEFUN (no_ip_as_path,
 
   if (asfilter == NULL)
     {
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
       return CMD_WARNING;
     }
 
@@ -563,8 +562,8 @@ DEFUN (no_ip_as_path_all,
   aslist = as_list_lookup (argv[idx_word]->arg);
   if (aslist == NULL)
     {
-      vty_out (vty, "ip as-path access-list %s doesn't exist%s", argv[idx_word]->arg,
-	       VTY_NEWLINE);
+      vty_outln (vty, "ip as-path access-list %s doesn't exist",
+                 argv[idx_word]->arg);
       return CMD_WARNING;
     }
 
@@ -582,12 +581,12 @@ as_list_show (struct vty *vty, struct as_list *aslist)
 {
   struct as_filter *asfilter;
 
-  vty_out (vty, "AS path access list %s%s", aslist->name, VTY_NEWLINE);
+  vty_outln (vty, "AS path access list %s", aslist->name);
 
   for (asfilter = aslist->head; asfilter; asfilter = asfilter->next)
     {
-      vty_out (vty, "    %s %s%s", filter_type_str (asfilter->type),
-	       asfilter->reg_str, VTY_NEWLINE);
+      vty_outln (vty, "    %s %s", filter_type_str (asfilter->type),
+	       asfilter->reg_str);
     }
 }
 
@@ -599,23 +598,23 @@ as_list_show_all (struct vty *vty)
 
   for (aslist = as_list_master.num.head; aslist; aslist = aslist->next)
     {
-      vty_out (vty, "AS path access list %s%s", aslist->name, VTY_NEWLINE);
+      vty_outln (vty, "AS path access list %s", aslist->name);
 
       for (asfilter = aslist->head; asfilter; asfilter = asfilter->next)
 	{
-	  vty_out (vty, "    %s %s%s", filter_type_str (asfilter->type),
-		   asfilter->reg_str, VTY_NEWLINE);
+	  vty_outln (vty, "    %s %s", filter_type_str (asfilter->type),
+		   asfilter->reg_str);
 	}
     }
 
   for (aslist = as_list_master.str.head; aslist; aslist = aslist->next)
     {
-      vty_out (vty, "AS path access list %s%s", aslist->name, VTY_NEWLINE);
+      vty_outln (vty, "AS path access list %s", aslist->name);
 
       for (asfilter = aslist->head; asfilter; asfilter = asfilter->next)
 	{
-	  vty_out (vty, "    %s %s%s", filter_type_str (asfilter->type),
-		   asfilter->reg_str, VTY_NEWLINE);
+	  vty_outln (vty, "    %s %s", filter_type_str (asfilter->type),
+		   asfilter->reg_str);
 	}
     }
 }
@@ -659,20 +658,18 @@ config_write_as_list (struct vty *vty)
   for (aslist = as_list_master.num.head; aslist; aslist = aslist->next)
     for (asfilter = aslist->head; asfilter; asfilter = asfilter->next)
       {
-	vty_out (vty, "ip as-path access-list %s %s %s%s",
+	vty_outln (vty, "ip as-path access-list %s %s %s",
 		 aslist->name, filter_type_str (asfilter->type), 
-		 asfilter->reg_str,
-		 VTY_NEWLINE);
+		 asfilter->reg_str);
 	write++;
       }
 
   for (aslist = as_list_master.str.head; aslist; aslist = aslist->next)
     for (asfilter = aslist->head; asfilter; asfilter = asfilter->next)
       {
-	vty_out (vty, "ip as-path access-list %s %s %s%s",
+	vty_outln (vty, "ip as-path access-list %s %s %s",
 		 aslist->name, filter_type_str (asfilter->type), 
-		 asfilter->reg_str,
-		 VTY_NEWLINE);
+		 asfilter->reg_str);
 	write++;
       }
   return write;

--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -538,7 +538,7 @@ DEFUN (no_ip_as_path,
 
   if (asfilter == NULL)
     {
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       return CMD_WARNING;
     }
 

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -546,8 +546,6 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
   struct bgp_info *ri;
   int rd_header;
   int header = 1;
-  char v4_header[] = "   Network          Next Hop            Metric LocPrf Weight Path%s";
-  char v4_header_tag[] = "   Network          Next Hop      In tag/Out tag%s";
   unsigned long output_count = 0;
   unsigned long total_count  = 0;
   json_object *json = NULL;
@@ -561,7 +559,7 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
   if (bgp == NULL)
     {
       if (!use_json)
-        vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+        vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -587,7 +585,7 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
 
   if ((afi != AFI_IP) && (afi != AFI_IP6))
     {
-      vty_out (vty, "Afi %d not supported%s", afi, VTY_NEWLINE);
+      vty_outln (vty, "Afi %d not supported", afi);
       return CMD_WARNING;
     }
 
@@ -632,16 +630,16 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
                       else
                         {
 		          if (tags)
-		            vty_out (vty, v4_header_tag, VTY_NEWLINE);
+		            vty_outln (vty, V4_HEADER_TAG);
 		          else
 		            {
-		              vty_out (vty, "BGP table version is 0, local router ID is %s%s",
-		                       inet_ntoa (bgp->router_id), VTY_NEWLINE);
-		              vty_out (vty, "Status codes: s suppressed, d damped, h history, * valid, > best, i - internal%s",
+		              vty_outln (vty, "BGP table version is 0, local router ID is %s",
+		                       inet_ntoa(bgp->router_id));
+		              vty_outln (vty,
+                                         "Status codes: s suppressed, d damped, h history, * valid, > best, i - internal");
+		              vty_outln (vty, "Origin codes: i - IGP, e - EGP, ? - incomplete%s",
 		                       VTY_NEWLINE);
-		              vty_out (vty, "Origin codes: i - IGP, e - EGP, ? - incomplete%s%s",
-		                       VTY_NEWLINE, VTY_NEWLINE);
-		              vty_out (vty, v4_header, VTY_NEWLINE);
+		              vty_outln (vty, V4_HEADER);
 		            }
                         }
 		      header = 0;
@@ -701,7 +699,7 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
                                      rd_vnc_eth.macaddr.octet[4],
                                      rd_vnc_eth.macaddr.octet[5]);
 #endif
-		          vty_out (vty, "%s", VTY_NEWLINE);
+		          vty_outln (vty, "");
                         }
 		      rd_header = 0;
 		    }
@@ -738,16 +736,17 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
   if (use_json)
     {
       json_object_object_add(json, "routes", json_nroute);
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free(json);
     }
   else
     {
       if (output_count == 0)
-	vty_out (vty, "No prefixes displayed, %ld exist%s", total_count, VTY_NEWLINE);
+	vty_outln (vty, "No prefixes displayed, %ld exist", total_count);
       else
-	vty_out (vty, "%sDisplayed %ld routes and %ld total paths%s",
-		 VTY_NEWLINE, output_count, total_count, VTY_NEWLINE);
+	vty_outln (vty, "%sDisplayed %ld routes and %ld total paths",
+		 VTY_NEWLINE, output_count, total_count);
     }
 
   return CMD_SUCCESS;
@@ -778,7 +777,7 @@ DEFUN (show_bgp_ip_vpn_all_rd,
           ret = str2prefix_rd (argv[idx_rd]->arg, &prd);
           if (! ret)
             {
-              vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+              vty_outln (vty, "%% Malformed Route Distinguisher");
               return CMD_WARNING;
             }
           return bgp_show_mpls_vpn (vty, afi, &prd, bgp_show_type_normal, NULL, 0, use_json (argc, argv));
@@ -813,7 +812,7 @@ DEFUN (show_ip_bgp_vpn_rd,
       ret = str2prefix_rd (argv[idx_ext_community]->arg, &prd);
       if (! ret)
         {
-          vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed Route Distinguisher");
           return CMD_WARNING;
         }
       return bgp_show_mpls_vpn (vty, afi, &prd, bgp_show_type_normal, NULL, 0, 0);
@@ -878,7 +877,7 @@ DEFUN (show_ip_bgp_vpn_rd_tags,
       ret = str2prefix_rd (argv[idx_ext_community]->arg, &prd);
       if (! ret)
         {
-          vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed Route Distinguisher");
           return CMD_WARNING;
         }
       return bgp_show_mpls_vpn (vty, afi, &prd, bgp_show_type_normal, NULL, 1, 0);
@@ -917,11 +916,11 @@ DEFUN (show_ip_bgp_vpn_all_neighbor_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "Malformed address");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "Malformed address: %s%s", argv[idx_ipv4]->arg, VTY_NEWLINE);
+            vty_outln (vty, "Malformed address: %s", argv[idx_ipv4]->arg);
           return CMD_WARNING;
         }
 
@@ -933,11 +932,11 @@ DEFUN (show_ip_bgp_vpn_all_neighbor_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "No such neighbor or address family");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+            vty_outln (vty, "%% No such neighbor or address family");
           return CMD_WARNING;
         }
 
@@ -980,11 +979,11 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "Malformed Route Distinguisher");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+            vty_outln (vty, "%% Malformed Route Distinguisher");
           return CMD_WARNING;
         }
 
@@ -996,11 +995,12 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "Malformed address");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "Malformed address: %s%s", argv[idx_ext_community]->arg, VTY_NEWLINE);
+            vty_outln (vty, "Malformed address: %s",
+                       argv[idx_ext_community]->arg);
           return CMD_WARNING;
         }
 
@@ -1012,11 +1012,11 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "No such neighbor or address family");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+            vty_outln (vty, "%% No such neighbor or address family");
           return CMD_WARNING;
         }
 
@@ -1056,11 +1056,11 @@ DEFUN (show_ip_bgp_vpn_all_neighbor_advertised_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "Malformed address");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "Malformed address: %s%s", argv[idx_ipv4]->arg, VTY_NEWLINE);
+            vty_outln (vty, "Malformed address: %s", argv[idx_ipv4]->arg);
           return CMD_WARNING;
         }
       peer = peer_lookup (NULL, &su);
@@ -1071,11 +1071,11 @@ DEFUN (show_ip_bgp_vpn_all_neighbor_advertised_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "No such neighbor or address family");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+            vty_outln (vty, "%% No such neighbor or address family");
           return CMD_WARNING;
         }
       return show_adj_route_vpn (vty, peer, NULL, AFI_IP, SAFI_MPLS_VPN, uj);
@@ -1117,11 +1117,12 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_advertised_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "Malformed address");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "Malformed address: %s%s", argv[idx_ext_community]->arg, VTY_NEWLINE);
+            vty_outln (vty, "Malformed address: %s",
+                       argv[idx_ext_community]->arg);
           return CMD_WARNING;
         }
       peer = peer_lookup (NULL, &su);
@@ -1132,11 +1133,11 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_advertised_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "No such neighbor or address family");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+            vty_outln (vty, "%% No such neighbor or address family");
           return CMD_WARNING;
         }
 
@@ -1148,11 +1149,11 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_advertised_routes,
               json_object *json_no = NULL;
               json_no = json_object_new_object();
               json_object_string_add(json_no, "warning", "Malformed Route Distinguisher");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+              vty_outln (vty, "%s", json_object_to_json_string(json_no));
               json_object_free(json_no);
             }
           else
-            vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+            vty_outln (vty, "%% Malformed Route Distinguisher");
           return CMD_WARNING;
         }
 

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -638,7 +638,7 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
 		              vty_outln (vty,
                                          "Status codes: s suppressed, d damped, h history, * valid, > best, i - internal");
 		              vty_outln (vty, "Origin codes: i - IGP, e - EGP, ? - incomplete%s",
-		                       VTY_NEWLINE);
+		                       VTYNL);
 		              vty_outln (vty, V4_HEADER);
 		            }
                         }
@@ -746,7 +746,7 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
 	vty_outln (vty, "No prefixes displayed, %ld exist", total_count);
       else
 	vty_outln (vty, "%sDisplayed %ld routes and %ld total paths",
-		 VTY_NEWLINE, output_count, total_count);
+		 VTYNL, output_count, total_count);
     }
 
   return CMD_SUCCESS;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -699,7 +699,7 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
                                      rd_vnc_eth.macaddr.octet[4],
                                      rd_vnc_eth.macaddr.octet[5]);
 #endif
-		          vty_outln (vty, "");
+		          vty_out (vty, VTYNL);
                         }
 		      rd_header = 0;
 		    }

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -67,6 +67,13 @@ typedef enum {
   "Address Family\n"   \
   "Address Family\n"
 
+#define V4_HEADER \
+  "   Network          Next Hop            Metric LocPrf Weight Path"
+#define V4_HEADER_TAG \
+  "   Network          Next Hop      In tag/Out tag"
+#define V4_HEADER_OVERLAY \
+  "   Network          Next Hop      EthTag    Overlay Index   RouterMac"
+
 struct rd_as
 {
   u_int16_t type;

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -387,7 +387,7 @@ bgp_show_nexthops (struct vty *vty, struct bgp *bgp, int detail)
   time_t tbuf;
   afi_t afi;
 
-  vty_out (vty, "Current BGP nexthop cache:%s", VTY_NEWLINE);
+  vty_outln (vty, "Current BGP nexthop cache:");
   for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
     {
       if (!bgp->nexthop_cache_table[afi])
@@ -399,56 +399,52 @@ bgp_show_nexthops (struct vty *vty, struct bgp *bgp, int detail)
 	    {
 	      if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_VALID))
 		{
-		  vty_out (vty, " %s valid [IGP metric %d], #paths %d%s",
+		  vty_outln (vty, " %s valid [IGP metric %d], #paths %d",
 			   inet_ntop (rn->p.family, &rn->p.u.prefix, buf, sizeof (buf)),
-			   bnc->metric, bnc->path_count, VTY_NEWLINE);
+			   bnc->metric, bnc->path_count);
 		  if (detail)
 		    for (nexthop = bnc->nexthop; nexthop; nexthop = nexthop->next)
 		      switch (nexthop->type)
 			{
 			case NEXTHOP_TYPE_IPV6:
-			  vty_out (vty, "  gate %s%s",
-				   inet_ntop (AF_INET6, &nexthop->gate.ipv6,
-					      buf, sizeof (buf)), VTY_NEWLINE);
+			  vty_outln (vty, "  gate %s",
+				   inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf, sizeof(buf)));
 			  break;
 			case NEXTHOP_TYPE_IPV6_IFINDEX:
-			  vty_out(vty, "  gate %s, if %s%s",
+			  vty_outln (vty, "  gate %s, if %s",
 				  inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf,
 					    sizeof (buf)),
-				  ifindex2ifname(nexthop->ifindex, bgp->vrf_id),
-				  VTY_NEWLINE);
+				  ifindex2ifname(nexthop->ifindex, bgp->vrf_id));
 			  break;
 			case NEXTHOP_TYPE_IPV4:
-			  vty_out (vty, "  gate %s%s",
-				   inet_ntop (AF_INET, &nexthop->gate.ipv4, buf,
-					      sizeof (buf)), VTY_NEWLINE);
+			  vty_outln (vty, "  gate %s",
+				   inet_ntop(AF_INET, &nexthop->gate.ipv4, buf, sizeof(buf)));
 			  break;
 			case NEXTHOP_TYPE_IFINDEX:
-			  vty_out (vty, "  if %s%s",
-				   ifindex2ifname(nexthop->ifindex, bgp->vrf_id), VTY_NEWLINE);
+			  vty_outln (vty, "  if %s",
+				   ifindex2ifname(nexthop->ifindex, bgp->vrf_id));
 			  break;
 			case NEXTHOP_TYPE_IPV4_IFINDEX:
-			  vty_out (vty, "  gate %s, if %s%s",
+			  vty_outln (vty, "  gate %s, if %s",
 				   inet_ntop(AF_INET, &nexthop->gate.ipv4, buf,
 					     sizeof (buf)),
-				   ifindex2ifname(nexthop->ifindex, bgp->vrf_id), VTY_NEWLINE);
+				   ifindex2ifname(nexthop->ifindex, bgp->vrf_id));
 			  break;
 			default:
-			  vty_out (vty, "  invalid nexthop type %u%s",
-				   nexthop->type, VTY_NEWLINE);
+			  vty_outln (vty, "  invalid nexthop type %u",
+				   nexthop->type);
 			}
 		}
 	      else
 		{
-		  vty_out (vty, " %s invalid%s",
-			   inet_ntop (rn->p.family, &rn->p.u.prefix,
-				      buf, sizeof (buf)), VTY_NEWLINE);
+		  vty_outln (vty, " %s invalid",
+			   inet_ntop(rn->p.family, &rn->p.u.prefix, buf, sizeof(buf)));
 		  if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_CONNECTED))
-		    vty_out (vty, "  Must be Connected%s", VTY_NEWLINE);
+		    vty_outln (vty, "  Must be Connected");
 		}
 	      tbuf = time(NULL) - (bgp_clock() - bnc->last_update);
 	      vty_out (vty, "  Last update: %s", ctime(&tbuf));
-	      vty_out(vty, "%s", VTY_NEWLINE);
+	      vty_outln (vty, "");
 	    }
 	}
     }
@@ -465,7 +461,7 @@ show_ip_bgp_nexthop_table (struct vty *vty, const char *name, int detail)
     bgp = bgp_get_default ();
   if (!bgp)
     {
-      vty_out (vty, "%% No such BGP instance exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% No such BGP instance exist");
       return CMD_WARNING;
     }
 
@@ -482,10 +478,9 @@ bgp_show_all_instances_nexthops_vty (struct vty *vty)
 
   for (ALL_LIST_ELEMENTS (bm->bgp, node, nnode, bgp))
     {
-      vty_out (vty, "%sInstance %s:%s",
+      vty_outln (vty, "%sInstance %s:",
                VTY_NEWLINE,
-               (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) ? "Default" : bgp->name,
-               VTY_NEWLINE);
+               (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) ? "Default" : bgp->name);
       bgp_show_nexthops (vty, bgp, 0);
     }
 }

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -444,7 +444,7 @@ bgp_show_nexthops (struct vty *vty, struct bgp *bgp, int detail)
 		}
 	      tbuf = time(NULL) - (bgp_clock() - bnc->last_update);
 	      vty_out (vty, "  Last update: %s", ctime(&tbuf));
-	      vty_outln (vty, "");
+	      vty_out (vty, VTYNL);
 	    }
 	}
     }

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -479,7 +479,7 @@ bgp_show_all_instances_nexthops_vty (struct vty *vty)
   for (ALL_LIST_ELEMENTS (bm->bgp, node, nnode, bgp))
     {
       vty_outln (vty, "%sInstance %s:",
-               VTY_NEWLINE,
+               VTYNL,
                (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) ? "Default" : bgp->name);
       bgp_show_nexthops (vty, bgp, 0);
     }

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -167,7 +167,7 @@ bgp_capability_vty_out (struct vty *vty, struct peer *peer, u_char use_json, jso
                     vty_out (vty, "SAFI Unknown %d ", mpc.safi);
                   break;
                 }
-              vty_outln (vty, "");
+              vty_out (vty, VTYNL);
             }
         }
       else if (hdr->code >= 128)

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -167,7 +167,7 @@ bgp_capability_vty_out (struct vty *vty, struct peer *peer, u_char use_json, jso
                     vty_out (vty, "SAFI Unknown %d ", mpc.safi);
                   break;
                 }
-              vty_out (vty, "%s", VTY_NEWLINE);
+              vty_outln (vty, "");
             }
         }
       else if (hdr->code >= 128)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6169,7 +6169,7 @@ route_vty_out_route (struct prefix *p, struct vty *vty)
 
   len = 17 - len;
   if (len < 1)
-    vty_out (vty, "%s%*s", VTY_NEWLINE, 20, " ");
+    vty_out (vty, "%s%*s", VTYNL, 20, " ");
   else
     vty_out (vty, "%*s", len, " ");
 }
@@ -6393,7 +6393,7 @@ route_vty_out (struct vty *vty, struct prefix *p,
 		      len = 7 - len; /* len of IPv6 addr + max len of def ifname */
 
 		      if (len < 1)
-			vty_out (vty, "%s%*s", VTY_NEWLINE, 45, " ");
+			vty_out (vty, "%s%*s", VTYNL, 45, " ");
 		      else
 			vty_out (vty, "%*s", len, " ");
 		    }
@@ -6406,7 +6406,7 @@ route_vty_out (struct vty *vty, struct prefix *p,
 		      len = 16 - len;
 
 		      if (len < 1)
-			vty_out (vty, "%s%*s", VTY_NEWLINE, 36, " ");
+			vty_out (vty, "%s%*s", VTYNL, 36, " ");
 		      else
 			vty_out (vty, "%*s", len, " ");
 		    }
@@ -6420,7 +6420,7 @@ route_vty_out (struct vty *vty, struct prefix *p,
 		  len = 16 - len;
 
 		  if (len < 1)
-		    vty_out (vty, "%s%*s", VTY_NEWLINE, 36, " ");
+		    vty_out (vty, "%s%*s", VTYNL, 36, " ");
 		  else
 		    vty_out (vty, "%*s", len, " ");
 		}
@@ -6608,7 +6608,7 @@ route_vty_out_tmp (struct vty *vty, struct prefix *p, struct attr *attr, safi_t 
                              buf, BUFSIZ));
               len = 16 - len;
               if (len < 1)
-                vty_out (vty, "%s%*s", VTY_NEWLINE, 36, " ");
+                vty_out (vty, "%s%*s", VTYNL, 36, " ");
               else
                 vty_out (vty, "%*s", len, " ");
             }
@@ -6861,7 +6861,7 @@ damp_route_vty_out (struct vty *vty, struct prefix *p, struct bgp_info *binfo,
   if (len < 1)
     {
       if (!use_json)
-        vty_out (vty, "%s%*s", VTY_NEWLINE, 34, " ");
+        vty_out (vty, "%s%*s", VTYNL, 34, " ");
     }
   else
     {
@@ -6931,7 +6931,7 @@ flap_route_vty_out (struct vty *vty, struct prefix *p, struct bgp_info *binfo,
   if (len < 1)
     {
       if (!use_json)
-        vty_out (vty, "%s%*s", VTY_NEWLINE, 33, " ");
+        vty_out (vty, "%s%*s", VTYNL, 33, " ");
     }
   else
     {
@@ -7964,8 +7964,8 @@ bgp_show_table (struct vty *vty, struct bgp *bgp, struct bgp_table *table,
               {
                 vty_outln (vty, "BGP table version is %" PRIu64 ", local router ID is %s", table->version,
                            inet_ntoa(bgp->router_id));
-                vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
-                vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
+                vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTYNL);
+                vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTYNL);
                 if (type == bgp_show_type_dampend_paths
                     || type == bgp_show_type_damp_neighbor)
                   vty_outln (vty, BGP_SHOW_DAMP_HEADER);
@@ -8020,7 +8020,7 @@ bgp_show_table (struct vty *vty, struct bgp *bgp, struct bgp_table *table,
         }
       else
         vty_outln (vty, "%sDisplayed  %ld routes and %ld total paths",
-                 VTY_NEWLINE, output_count, total_count);
+                 VTYNL, output_count, total_count);
     }
 
   return CMD_SUCCESS;
@@ -8082,7 +8082,7 @@ bgp_show_all_instances_routes_vty (struct vty *vty, afi_t afi, safi_t safi,
       else
         {
           vty_outln (vty, "%sInstance %s:",
-                   VTY_NEWLINE,
+                   VTYNL,
                    (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) ? "Default" : bgp->name);
         }
       bgp_show (vty, bgp, afi, safi, bgp_show_type_normal, NULL, use_json);
@@ -9169,7 +9169,7 @@ bgp_table_stats (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi)
   thread_execute (bm->master, bgp_table_stats_walker, &ts, 0);
 
   vty_outln (vty, "BGP %s RIB statistics%s",
-           afi_safi_print (afi, safi), VTY_NEWLINE);
+           afi_safi_print (afi, safi), VTYNL);
   
   for (i = 0; i < BGP_STATS_MAX; i++)
     {
@@ -9405,7 +9405,7 @@ bgp_peer_counts (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi, u_c
 
       vty_outln (vty, "PfxCt: %ld", peer->pcount[afi][safi]);
       vty_outln (vty, "%sCounts from RIB table walk:%s",
-               VTY_NEWLINE, VTY_NEWLINE);
+               VTYNL, VTYNL);
 
       for (i = 0; i < PCOUNT_MAX; i++)
         vty_outln (vty, "%20s: %-10d", pcount_strs[i], pcounts.count[i]);
@@ -9633,11 +9633,11 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
         {
           vty_outln (vty, "BGP table version is %" PRIu64 ", local router ID is %s", table->version,
                      inet_ntoa(bgp->router_id));
-          vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
-          vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
+          vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTYNL);
+          vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTYNL);
 
           vty_outln (vty, "Originating default network 0.0.0.0%s",
-                   VTY_NEWLINE);
+                   VTYNL);
         }
       header1 = 0;
     }
@@ -9664,8 +9664,8 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
                         {
                           vty_outln (vty, "BGP table version is 0, local router ID is %s",
                                      inet_ntoa(bgp->router_id));
-                          vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
-                          vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
+                          vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTYNL);
+                          vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTYNL);
                         }
                       header1 = 0;
                     }
@@ -9708,8 +9708,8 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
                         {
                           vty_outln (vty, "BGP table version is %" PRIu64 ", local router ID is %s", table->version,
                                    inet_ntoa(bgp->router_id));
-                          vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
-                          vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
+                          vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTYNL);
+                          vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTYNL);
                         }
                       header1 = 0;
                     }
@@ -9745,7 +9745,7 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
         json_object_int_add(json, "totalPrefixCounter", output_count);
       else
         vty_outln (vty, "%sTotal number of prefixes %ld",
-                 VTY_NEWLINE, output_count);
+                 VTYNL, output_count);
     }
   if (use_json)
     {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4245,13 +4245,12 @@ bgp_static_set (struct vty *vty, const char *ip_str,
   ret = str2prefix (ip_str, &p);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed prefix");
       return CMD_WARNING;
     }
   if (afi == AFI_IP6 && IN6_IS_ADDR_LINKLOCAL (&p.u.prefix6))
     {
-      vty_out (vty, "%% Malformed prefix (link-local address)%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,"%% Malformed prefix (link-local address)");
       return CMD_WARNING;
     }
 
@@ -4268,7 +4267,7 @@ bgp_static_set (struct vty *vty, const char *ip_str,
       /* Label index cannot be changed. */
       if (bgp_static->label_index != label_index)
         {
-          vty_out (vty, "%% Label index cannot be changed%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Label index cannot be changed");
           return CMD_WARNING;
         }
 
@@ -4340,13 +4339,12 @@ bgp_static_unset (struct vty *vty, const char *ip_str,
   ret = str2prefix (ip_str, &p);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed prefix");
       return CMD_WARNING;
     }
   if (afi == AFI_IP6 && IN6_IS_ADDR_LINKLOCAL (&p.u.prefix6))
     {
-      vty_out (vty, "%% Malformed prefix (link-local address)%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,"%% Malformed prefix (link-local address)");
       return CMD_WARNING;
     }
 
@@ -4355,8 +4353,7 @@ bgp_static_unset (struct vty *vty, const char *ip_str,
   rn = bgp_node_lookup (bgp->route[afi][safi], &p);
   if (! rn)
     {
-      vty_out (vty, "%% Can't find specified static route configuration.%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,"%% Can't find specified static route configuration.");
       return CMD_WARNING;
     }
 
@@ -4555,21 +4552,21 @@ bgp_static_set_safi (afi_t afi, safi_t safi, struct vty *vty, const char *ip_str
   ret = str2prefix (ip_str, &p);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed prefix");
       return CMD_WARNING;
     }
   apply_mask (&p);
   if ( (afi == AFI_L2VPN) &&
        (bgp_build_evpn_prefix ( evpn_type, ethtag!=NULL?atol(ethtag):0, &p)))
     {
-      vty_out (vty, "%% L2VPN prefix could not be forged%s", VTY_NEWLINE);
+      vty_outln (vty, "%% L2VPN prefix could not be forged");
       return CMD_WARNING;
     }
 
   ret = str2prefix_rd (rd_str, &prd);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed rd");
       return CMD_WARNING;
     }
 
@@ -4587,12 +4584,12 @@ bgp_static_set_safi (afi_t afi, safi_t safi, struct vty *vty, const char *ip_str
     {
       if( esi && str2esi (esi, NULL) == 0)
         {
-          vty_out (vty, "%% Malformed ESI%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed ESI");
           return CMD_WARNING;
         }
       if( routermac && prefix_str2mac (routermac, NULL) == 0)
         {
-          vty_out (vty, "%% Malformed Router MAC%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed Router MAC");
           return CMD_WARNING;
         }
       if (gwip)
@@ -4601,13 +4598,13 @@ bgp_static_set_safi (afi_t afi, safi_t safi, struct vty *vty, const char *ip_str
           ret = str2prefix (gwip, &gw_ip);
           if (! ret)
             {
-              vty_out (vty, "%% Malformed GatewayIp%s", VTY_NEWLINE);
+              vty_outln (vty, "%% Malformed GatewayIp");
               return CMD_WARNING;
             }
           if((gw_ip.family == AF_INET &&  (p.u.prefix_evpn.flags & IP_PREFIX_V6))
              || (gw_ip.family == AF_INET6 &&  (p.u.prefix_evpn.flags & IP_PREFIX_V4)))
             {
-              vty_out (vty, "%% GatewayIp family differs with IP prefix%s", VTY_NEWLINE);
+              vty_outln (vty, "%% GatewayIp family differs with IP prefix");
               return CMD_WARNING;
             }
         }
@@ -4624,7 +4621,7 @@ bgp_static_set_safi (afi_t afi, safi_t safi, struct vty *vty, const char *ip_str
 
   if (rn->info)
     {
-      vty_out (vty, "%% Same network configuration exists%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Same network configuration exists");
       bgp_unlock_node (rn);
     }
   else
@@ -4690,20 +4687,20 @@ bgp_static_unset_safi(afi_t afi, safi_t safi, struct vty *vty, const char *ip_st
   ret = str2prefix (ip_str, &p);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed prefix");
       return CMD_WARNING;
     }
   apply_mask (&p);
   if ( (afi == AFI_L2VPN) &&
        (bgp_build_evpn_prefix ( evpn_type, ethtag!=NULL?atol(ethtag):0, &p)))
     {
-      vty_out (vty, "%% L2VPN prefix could not be forged%s", VTY_NEWLINE);
+      vty_outln (vty, "%% L2VPN prefix could not be forged");
       return CMD_WARNING;
     }
   ret = str2prefix_rd (rd_str, &prd);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed rd");
       return CMD_WARNING;
     }
 
@@ -4739,7 +4736,7 @@ bgp_static_unset_safi(afi_t afi, safi_t safi, struct vty *vty, const char *ip_st
       bgp_unlock_node (rn);
     }
   else
-    vty_out (vty, "%% Can't find the route%s", VTY_NEWLINE);
+    vty_outln (vty, "%% Can't find the route");
 
   return CMD_SUCCESS;
 }
@@ -4797,8 +4794,8 @@ bgp_config_write_table_map (struct vty *vty, struct bgp *bgp, afi_t afi,
   if (bgp->table_map[afi][safi].name)
     {
       bgp_config_write_family_header (vty, afi, safi, write);
-      vty_out (vty, "  table-map %s%s",
-	       bgp->table_map[afi][safi].name, VTY_NEWLINE);
+      vty_outln (vty, "  table-map %s",
+	       bgp->table_map[afi][safi].name);
     }
 
   return 0;
@@ -4881,7 +4878,7 @@ DEFUN (bgp_network_mask,
   ret = netmask_str2prefix_str (argv[idx_ipv4]->arg, argv[idx_ipv4_2]->arg, prefix_str);
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -4908,7 +4905,7 @@ DEFUN (bgp_network_mask_route_map,
   ret = netmask_str2prefix_str (argv[idx_ipv4]->arg, argv[idx_ipv4_2]->arg, prefix_str);
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -4933,7 +4930,7 @@ DEFUN (bgp_network_mask_backdoor,
   ret = netmask_str2prefix_str (argv[idx_ipv4]->arg, argv[idx_ipv4_2]->arg, prefix_str);
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -4955,7 +4952,7 @@ DEFUN (bgp_network_mask_natural,
   ret = netmask_str2prefix_str (argv[idx_ipv4]->arg, NULL, prefix_str);
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -4980,7 +4977,7 @@ DEFUN (bgp_network_mask_natural_route_map,
   ret = netmask_str2prefix_str (argv[idx_ipv4]->arg, NULL, prefix_str);
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -5003,7 +5000,7 @@ DEFUN (bgp_network_mask_natural_backdoor,
   ret = netmask_str2prefix_str (argv[idx_ipv4]->arg, NULL, prefix_str);
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -5078,7 +5075,7 @@ DEFUN (no_bgp_network_mask,
   ret = netmask_str2prefix_str (argv[idx_ipv4]->arg, argv[idx_ipv4_2]->arg, prefix_str);
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -5103,7 +5100,7 @@ DEFUN (no_bgp_network_mask_natural,
   ret = netmask_str2prefix_str (argv[idx_ipv4]->arg, NULL, prefix_str);
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -5737,7 +5734,7 @@ bgp_aggregate_unset (struct vty *vty, const char *prefix_str,
   ret = str2prefix (prefix_str, &p);
   if (!ret)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
   apply_mask (&p);
@@ -5746,8 +5743,7 @@ bgp_aggregate_unset (struct vty *vty, const char *prefix_str,
   rn = bgp_node_lookup (bgp->aggregate[afi][safi], &p);
   if (! rn)
     {
-      vty_out (vty, "%% There is no aggregate-address configuration.%s",
-               VTY_NEWLINE);
+      vty_outln (vty,"%% There is no aggregate-address configuration.");
       return CMD_WARNING;
     }
 
@@ -5783,7 +5779,7 @@ bgp_aggregate_set (struct vty *vty, const char *prefix_str,
   ret = str2prefix (prefix_str, &p);
   if (!ret)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
   apply_mask (&p);
@@ -5793,12 +5789,12 @@ bgp_aggregate_set (struct vty *vty, const char *prefix_str,
 
   if (rn->info)
     {
-      vty_out (vty, "There is already same aggregate network.%s", VTY_NEWLINE);
+      vty_outln (vty, "There is already same aggregate network.");
       /* try to remove the old entry */
       ret = bgp_aggregate_unset (vty, prefix_str, afi, safi);
       if (ret)
         {
-          vty_out (vty, "Error deleting aggregate.%s", VTY_NEWLINE);
+          vty_outln (vty, "Error deleting aggregate.");
 	  bgp_unlock_node (rn);
 	  return CMD_WARNING;
         }
@@ -5866,7 +5862,7 @@ DEFUN (aggregate_address_mask,
 
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -5912,7 +5908,7 @@ DEFUN (no_aggregate_address_mask,
 
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -6486,7 +6482,7 @@ route_vty_out (struct vty *vty, struct prefix *p,
       if (json_paths)
         json_object_string_add(json_path, "alert", "No attributes");
       else
-        vty_out (vty, "No attributes to print%s", VTY_NEWLINE);
+        vty_outln (vty, "No attributes to print");
     }
 
   if (json_paths)
@@ -6508,7 +6504,7 @@ route_vty_out (struct vty *vty, struct prefix *p,
     }
   else
     {
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
 #if ENABLE_BGP_VNC
       /* prints an additional line, indented, with VNC info, if present */
       if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP))
@@ -6645,7 +6641,7 @@ route_vty_out_tmp (struct vty *vty, struct prefix *p, struct attr *attr, safi_t 
       json_object_object_add(json_ar, inet_ntop (p->family, &p->u.prefix, buf_cut, BUFSIZ), json_net);
     }
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
 }  
 
 void
@@ -6749,7 +6745,7 @@ route_vty_out_tag (struct vty *vty, struct prefix *p,
     {
       vty_out (vty, "notag/%d", label);
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 }  
 
@@ -6836,7 +6832,7 @@ route_vty_out_overlay (struct vty *vty, struct prefix *p,
             }
         }
     }
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 }
 
 /* dampening route */
@@ -6900,7 +6896,7 @@ damp_route_vty_out (struct vty *vty, struct prefix *p, struct bgp_info *binfo,
         vty_out (vty, "%s", bgp_origin_str[attr->origin]);
     }
   if (!use_json)
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
 }
 
 /* flap route */
@@ -7000,7 +6996,7 @@ flap_route_vty_out (struct vty *vty, struct prefix *p, struct bgp_info *binfo,
         vty_out (vty, "%s", bgp_origin_str[attr->origin]);
     }
   if (!use_json)
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
 }
 
 static void
@@ -7174,7 +7170,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
         }
 
       if (!json_paths)
-        vty_out (vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "");
 	  
       /* Line2 display Next-hop, Neighbor, Router-id */
       /* Display the nexthop */
@@ -7323,7 +7319,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
 	}
 
       if (!json_paths)
-        vty_out (vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "");
 
       /* display the link-local nexthop */
       if (attr->extra && attr->extra->mp_nexthop_len == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
@@ -7346,12 +7342,10 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
             }
           else
             {
-	      vty_out (vty, "    (%s) %s%s",
+	      vty_outln (vty, "    (%s) %s",
                        inet_ntop (AF_INET6, &attr->extra->mp_nexthop_local,
 			          buf, INET6_ADDRSTRLEN),
-                       attr->extra->mp_nexthop_prefer_global ?
-                                   "(prefer-global)" : "(used)",
-		       VTY_NEWLINE);
+                       attr->extra->mp_nexthop_prefer_global ? "(prefer-global)" : "(used)");
             }
 	}
       /* If we do not have a link-local nexthop then we must flag the global as "used" */
@@ -7544,7 +7538,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
         json_object_object_add(json_path, "bestpath", json_bestpath);
 
       if (!json_paths)
-        vty_out (vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "");
 	  
       /* Line 4 display Community */
       if (attr->community)
@@ -7556,8 +7550,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
             }
           else
             {
-	      vty_out (vty, "      Community: %s%s", attr->community->str,
-		       VTY_NEWLINE);
+	      vty_outln (vty, "      Community: %s",attr->community->str);
             }
         }
 	  
@@ -7572,15 +7565,15 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
             }
           else
             {
-	       vty_out (vty, "      Extended Community: %s%s",
-	                attr->extra->ecommunity->str, VTY_NEWLINE);
+	       vty_outln (vty, "      Extended Community: %s",
+	                attr->extra->ecommunity->str);
             }
         }
 
       /* Line 6 display Large community */
       if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES))
-        vty_out (vty, "      Large Community: %s%s",
-                 attr->extra->lcommunity->str, VTY_NEWLINE);
+        vty_outln (vty, "      Large Community: %s",
+                 attr->extra->lcommunity->str);
 
       /* Line 7 display Originator, Cluster-id */
       if ((attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID)) ||
@@ -7632,7 +7625,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
 	    }
 
           if (!json_paths)
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_outln (vty, "");
 	}
 
       if (binfo->extra && binfo->extra->damp_info)
@@ -7645,7 +7638,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
           if (json_paths)
             json_object_int_add(json_path, "remoteLabel", label);
           else
-            vty_out(vty, "      Remote label: %d%s", label, VTY_NEWLINE);
+            vty_outln (vty, "      Remote label: %d", label);
         }
 
       /* Label Index */
@@ -7654,7 +7647,8 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
           if (json_paths)
             json_object_int_add(json_path, "labelIndex", attr->extra->label_index);
           else
-            vty_out(vty, "      Label Index: %d%s", attr->extra->label_index, VTY_NEWLINE);
+            vty_outln (vty, "      Label Index: %d",
+                      attr->extra->label_index);
         }
 
       /* Line 8 display Addpath IDs */
@@ -7667,9 +7661,8 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
             }
           else
             {
-              vty_out (vty, "      AddPath ID: RX %u, TX %u%s",
-                       binfo->addpath_rx_id, binfo->addpath_tx_id,
-                       VTY_NEWLINE);
+              vty_outln (vty, "      AddPath ID: RX %u, TX %u",
+                       binfo->addpath_rx_id,binfo->addpath_tx_id);
             }
         }
 
@@ -7707,7 +7700,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
             {
               if (!first)
                 {
-	          vty_out (vty, "%s", VTY_NEWLINE);
+	          vty_outln (vty, "");
                 }
             }
         }
@@ -7747,12 +7740,12 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
       json_object_array_add(json_paths, json_path);
     }
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
 }
 
-#define BGP_SHOW_HEADER_CSV "Flags, Network, Next Hop, Metric, LocPrf, Weight, Path%s"
-#define BGP_SHOW_DAMP_HEADER "   Network          From             Reuse    Path%s"
-#define BGP_SHOW_FLAP_HEADER "   Network          From            Flaps Duration Reuse    Path%s"
+#define BGP_SHOW_HEADER_CSV "Flags, Network, Next Hop, Metric, LocPrf, Weight, Path"
+#define BGP_SHOW_DAMP_HEADER "   Network          From             Reuse    Path"
+#define BGP_SHOW_FLAP_HEADER "   Network          From            Flaps Duration Reuse    Path"
 
 static int
 bgp_show_prefix_list (struct vty *vty, struct bgp *bgp,
@@ -7969,17 +7962,18 @@ bgp_show_table (struct vty *vty, struct bgp *bgp, struct bgp_table *table,
 
             if (!use_json && header)
               {
-                vty_out (vty, "BGP table version is %" PRIu64 ", local router ID is %s%s", table->version, inet_ntoa (bgp->router_id), VTY_NEWLINE);
-                vty_out (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
-                vty_out (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+                vty_outln (vty, "BGP table version is %" PRIu64 ", local router ID is %s", table->version,
+                           inet_ntoa(bgp->router_id));
+                vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
+                vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
                 if (type == bgp_show_type_dampend_paths
                     || type == bgp_show_type_damp_neighbor)
-                  vty_out (vty, BGP_SHOW_DAMP_HEADER, VTY_NEWLINE);
+                  vty_outln (vty, BGP_SHOW_DAMP_HEADER);
                 else if (type == bgp_show_type_flap_statistics
                          || type == bgp_show_type_flap_neighbor)
-                  vty_out (vty, BGP_SHOW_FLAP_HEADER, VTY_NEWLINE);
+                  vty_outln (vty, BGP_SHOW_FLAP_HEADER);
                 else
-                  vty_out (vty, BGP_SHOW_HEADER, VTY_NEWLINE);
+                  vty_outln (vty, BGP_SHOW_HEADER);
                 header = 0;
               }
 
@@ -8013,7 +8007,7 @@ bgp_show_table (struct vty *vty, struct bgp *bgp, struct bgp_table *table,
   if (use_json)
     {
       json_object_free (json_paths);
-      vty_out (vty, " } }%s", VTY_NEWLINE);
+      vty_outln (vty, " } }");
     }
   else
     {
@@ -8021,11 +8015,12 @@ bgp_show_table (struct vty *vty, struct bgp *bgp, struct bgp_table *table,
       if (output_count == 0)
         {
           if (type == bgp_show_type_normal)
-            vty_out (vty, "No BGP prefixes displayed, %ld exist%s", total_count, VTY_NEWLINE);
+            vty_outln (vty, "No BGP prefixes displayed, %ld exist",
+                       total_count);
         }
       else
-        vty_out (vty, "%sDisplayed  %ld routes and %ld total paths%s",
-                 VTY_NEWLINE, output_count, total_count, VTY_NEWLINE);
+        vty_outln (vty, "%sDisplayed  %ld routes and %ld total paths",
+                 VTY_NEWLINE, output_count, total_count);
     }
 
   return CMD_SUCCESS;
@@ -8045,7 +8040,7 @@ bgp_show (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
   if (bgp == NULL)
     {
       if (!use_json)
-        vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+        vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
   /* use MPLS and ENCAP specific shows until they are merged */
@@ -8070,14 +8065,14 @@ bgp_show_all_instances_routes_vty (struct vty *vty, afi_t afi, safi_t safi,
   int is_first = 1;
 
   if (use_json)
-    vty_out (vty, "{%s", VTY_NEWLINE);
+    vty_outln (vty, "{");
 
   for (ALL_LIST_ELEMENTS (bm->bgp, node, nnode, bgp))
     {
       if (use_json)
         {
           if (! is_first)
-            vty_out (vty, ",%s", VTY_NEWLINE);
+            vty_outln (vty, ",");
           else
             is_first = 0;
 
@@ -8086,18 +8081,16 @@ bgp_show_all_instances_routes_vty (struct vty *vty, afi_t afi, safi_t safi,
         }
       else
         {
-          vty_out (vty, "%sInstance %s:%s",
+          vty_outln (vty, "%sInstance %s:",
                    VTY_NEWLINE,
-                   (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)
-                   ? "Default" : bgp->name,
-                   VTY_NEWLINE);
+                   (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) ? "Default" : bgp->name);
         }
       bgp_show (vty, bgp, afi, safi, bgp_show_type_normal, NULL, use_json);
 
     }
 
   if (use_json)
-    vty_out (vty, "}%s", VTY_NEWLINE);
+    vty_outln (vty, "}");
 }
 
 /* Header of detailed BGP route information */
@@ -8135,22 +8128,22 @@ route_vty_out_detail_header (struct vty *vty, struct bgp *bgp,
         prefix2str (p, buf2, INET6_ADDRSTRLEN);
       else
         inet_ntop (p->family, &p->u.prefix, buf2, INET6_ADDRSTRLEN);
-      vty_out (vty, "BGP routing table entry for %s%s%s/%d%s",
+      vty_outln (vty, "BGP routing table entry for %s%s%s/%d",
 	       ((safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP || safi == SAFI_EVPN) ?
 	       prefix_rd2str (prd, buf1, RD_ADDRSTRLEN) : ""),
 	       ((safi == SAFI_MPLS_VPN) || (safi == SAFI_EVPN)) ? ":" : "",
 	       buf2,
-	       p->prefixlen, VTY_NEWLINE);
+	       p->prefixlen);
 
       if (bgp_labeled_safi(safi))
         {
           vty_out(vty, "Local label: ");
           if (!bgp_is_valid_label(rn->local_label))
-            vty_out(vty, "not allocated%s", VTY_NEWLINE);
+            vty_outln (vty, "not allocated");
           else
             {
               uint32_t label = label_pton(rn->local_label);
-              vty_out(vty, "%d%s", label, VTY_NEWLINE);
+              vty_outln (vty, "%d", label);
             }
         }
     }
@@ -8198,7 +8191,7 @@ route_vty_out_detail_header (struct vty *vty, struct bgp *bgp,
 
       if (suppress)
         vty_out (vty, ", Advertisements suppressed by an aggregate.");
-      vty_out (vty, ")%s", VTY_NEWLINE);
+      vty_outln (vty, ")");
     }
 
   /* If we are not using addpath then we can display Advertised to and that will
@@ -8230,7 +8223,7 @@ route_vty_out_detail_header (struct vty *vty, struct bgp *bgp,
         {
           if (first)
             vty_out (vty, "  Not advertised to any peer");
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
         }
     }
 }
@@ -8258,7 +8251,7 @@ bgp_show_route_in_table (struct vty *vty, struct bgp *bgp,
   ret = str2prefix (ip_str, &match);
   if (! ret)
     {
-      vty_out (vty, "address is malformed%s", VTY_NEWLINE);
+      vty_outln (vty, "address is malformed");
       return CMD_WARNING;
     }
 
@@ -8345,14 +8338,15 @@ bgp_show_route_in_table (struct vty *vty, struct bgp *bgp,
       if (display)
         json_object_object_add(json, "paths", json_paths);
 
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free(json);
     }
   else
     {
       if (!display)
         {
-          vty_out (vty, "%% Network not in table%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Network not in table");
           return CMD_WARNING;
         }
     }
@@ -8408,7 +8402,7 @@ bgp_show_lcommunity (struct vty *vty, struct bgp *bgp, int argc,
   XFREE (MTYPE_TMP, str);
   if (! lcom)
     {
-      vty_out (vty, "%% Large-community malformed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Large-community malformed");
       return CMD_WARNING;
     }
 
@@ -8424,8 +8418,7 @@ bgp_show_lcommunity_list (struct vty *vty, struct bgp *bgp, const char *lcom,
   list = community_list_lookup (bgp_clist, lcom, LARGE_COMMUNITY_LIST_MASTER);
   if (list == NULL)
     {
-      vty_out (vty, "%% %s is not a valid large-community-list name%s", lcom,
-               VTY_NEWLINE);
+      vty_outln (vty, "%% %s is not a valid large-community-list name",lcom);
       return CMD_WARNING;
     }
 
@@ -8471,7 +8464,7 @@ DEFUN (show_ip_bgp_large_community_list,
     struct bgp *bgp = bgp_lookup_by_name (vrf);
   if (bgp == NULL)
    {
-     vty_out (vty, "Can't find BGP instance %s%s", vrf, VTY_NEWLINE);
+     vty_outln (vty, "Can't find BGP instance %s", vrf);
      return CMD_WARNING;
    }
 
@@ -8516,7 +8509,7 @@ DEFUN (show_ip_bgp_large_community,
   struct bgp *bgp = bgp_lookup_by_name (vrf);
   if (bgp == NULL)
    {
-     vty_out (vty, "Can't find BGP instance %s%s", vrf, VTY_NEWLINE);
+     vty_outln (vty, "Can't find BGP instance %s", vrf);
      return CMD_WARNING;
    }
 
@@ -8685,7 +8678,8 @@ DEFUN (show_ip_bgp_route,
 
   if (!bgp)
     {
-      vty_out (vty, "Specified 'all' vrf's but this command currently only works per view/vrf%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Specified 'all' vrf's but this command currently only works per view/vrf");
       return CMD_WARNING;
     }
 
@@ -8697,12 +8691,14 @@ DEFUN (show_ip_bgp_route,
 
   if ((argv[idx]->type == IPV6_TKN || argv[idx]->type == IPV6_PREFIX_TKN) && afi != AFI_IP6)
   {
-    vty_out (vty, "%% Cannot specify IPv6 address or prefix with IPv4 AFI%s", VTY_NEWLINE);
+    vty_outln (vty,
+               "%% Cannot specify IPv6 address or prefix with IPv4 AFI");
     return CMD_WARNING;
   }
   if ((argv[idx]->type == IPV4_TKN || argv[idx]->type == IPV4_PREFIX_TKN) && afi != AFI_IP)
   {
-    vty_out (vty, "%% Cannot specify IPv4 address or prefix with IPv6 AFI%s", VTY_NEWLINE);
+    vty_outln (vty,
+               "%% Cannot specify IPv4 address or prefix with IPv6 AFI");
     return CMD_WARNING;
   }
 
@@ -8787,7 +8783,7 @@ bgp_show_regexp (struct vty *vty, const char *regstr, afi_t afi,
   regex = bgp_regcomp (regstr);
   if (! regex)
     {
-      vty_out (vty, "Can't compile regexp %s%s", regstr, VTY_NEWLINE);
+      vty_outln (vty, "Can't compile regexp %s", regstr);
       return CMD_WARNING;
     }
 
@@ -8806,8 +8802,8 @@ bgp_show_prefix_list (struct vty *vty, struct bgp *bgp,
   plist = prefix_list_lookup (afi, prefix_list_str);
   if (plist == NULL)
     {
-      vty_out (vty, "%% %s is not a valid prefix-list name%s",
-               prefix_list_str, VTY_NEWLINE);	    
+      vty_outln (vty, "%% %s is not a valid prefix-list name",
+               prefix_list_str);	    
       return CMD_WARNING;
     }
 
@@ -8824,7 +8820,8 @@ bgp_show_filter_list (struct vty *vty, struct bgp *bgp,
   as_list = as_list_lookup (filter);
   if (as_list == NULL)
     {
-      vty_out (vty, "%% %s is not a valid AS-path access-list name%s", filter, VTY_NEWLINE);	    
+      vty_outln (vty, "%% %s is not a valid AS-path access-list name",
+                 filter);	    
       return CMD_WARNING;
     }
 
@@ -8841,8 +8838,8 @@ bgp_show_route_map (struct vty *vty, struct bgp *bgp,
   rmap = route_map_lookup_by_name (rmap_str);
   if (! rmap)
     {
-      vty_out (vty, "%% %s is not a valid route-map name%s",
-	       rmap_str, VTY_NEWLINE);	    
+      vty_outln (vty, "%% %s is not a valid route-map name",
+	       rmap_str);	    
       return CMD_WARNING;
     }
 
@@ -8883,7 +8880,7 @@ bgp_show_community (struct vty *vty, struct bgp *bgp, int argc,
   XFREE (MTYPE_TMP, str);
   if (! com)
     {
-      vty_out (vty, "%% Community malformed: %s", VTY_NEWLINE);
+      vty_outln (vty, "%% Community malformed: ");
       return CMD_WARNING;
     }
 
@@ -8905,8 +8902,7 @@ bgp_show_community_list (struct vty *vty, struct bgp *bgp,
   list = community_list_lookup (bgp_clist, com, COMMUNITY_LIST_MASTER);
   if (list == NULL)
     {
-      vty_out (vty, "%% %s is not a valid community-list name%s", com,
-	       VTY_NEWLINE);
+      vty_outln (vty, "%% %s is not a valid community-list name",com);
       return CMD_WARNING;
     }
 
@@ -8928,7 +8924,7 @@ bgp_show_prefix_longer (struct vty *vty, struct bgp *bgp,
   ret = str2prefix (prefix, p);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed Prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed Prefix");
       return CMD_WARNING;
     }
 
@@ -8961,11 +8957,11 @@ peer_lookup_in_view (struct vty *vty, struct bgp *bgp,
                   json_object *json_no = NULL;
                   json_no = json_object_new_object();
                   json_object_string_add(json_no, "malformedAddressOrName", ip_str);
-                  vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+                  vty_outln (vty, "%s", json_object_to_json_string(json_no));
                   json_object_free(json_no);
                 }
               else
-                vty_out (vty, "%% Malformed address or name: %s%s", ip_str, VTY_NEWLINE);
+                vty_outln (vty, "%% Malformed address or name: %s", ip_str);
               return NULL;
             }
         }
@@ -8981,11 +8977,11 @@ peer_lookup_in_view (struct vty *vty, struct bgp *bgp,
           json_object *json_no = NULL;
           json_no = json_object_new_object();
           json_object_string_add(json_no, "warning","No such neighbor");
-          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          vty_outln (vty, "%s", json_object_to_json_string(json_no));
           json_object_free(json_no);
         }
       else
-        vty_out (vty, "No such neighbor%s", VTY_NEWLINE);
+        vty_outln (vty, "No such neighbor");
       return NULL;
     }
   
@@ -9163,8 +9159,8 @@ bgp_table_stats (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi)
   
   if (!bgp->rib[afi][safi])
     {
-      vty_out (vty, "%% No RIB exist's for the AFI(%d)/SAFI(%d)%s",
-	       afi, safi, VTY_NEWLINE);
+      vty_outln (vty, "%% No RIB exist's for the AFI(%d)/SAFI(%d)",
+	       afi, safi);
       return CMD_WARNING;
     }
   
@@ -9172,8 +9168,8 @@ bgp_table_stats (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi)
   ts.table = bgp->rib[afi][safi];
   thread_execute (bm->master, bgp_table_stats_walker, &ts, 0);
 
-  vty_out (vty, "BGP %s RIB statistics%s%s",
-           afi_safi_print (afi, safi), VTY_NEWLINE, VTY_NEWLINE);
+  vty_outln (vty, "BGP %s RIB statistics%s",
+           afi_safi_print (afi, safi), VTY_NEWLINE);
   
   for (i = 0; i < BGP_STATS_MAX; i++)
     {
@@ -9210,19 +9206,15 @@ bgp_table_stats (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi)
             break;
           case BGP_STATS_SPACE:
             vty_out (vty, "%-30s: ", table_stats_strs[i]);
-            vty_out (vty, "%12llu%s", ts.counts[i], VTY_NEWLINE);
+            vty_outln (vty, "%12llu", ts.counts[i]);
             if (ts.counts[BGP_STATS_MAXBITLEN] < 9)
               break;
             vty_out (vty, "%30s: ", "%% announced ");
-            vty_out (vty, "%12.2f%s", 
-                     100 * (float)ts.counts[BGP_STATS_SPACE] / 
-                       (float)((uint64_t)1UL << ts.counts[BGP_STATS_MAXBITLEN]),
-                       VTY_NEWLINE);
+            vty_outln (vty, "%12.2f", 
+                     100 * (float)ts.counts[BGP_STATS_SPACE] / (float)((uint64_t)1UL << ts.counts[BGP_STATS_MAXBITLEN]));
             vty_out (vty, "%30s: ", "/8 equivalent ");
-            vty_out (vty, "%12.2f%s", 
-                     (float)ts.counts[BGP_STATS_SPACE] / 
-                       (float)(1UL << (ts.counts[BGP_STATS_MAXBITLEN] - 8)),
-                     VTY_NEWLINE);
+            vty_outln (vty, "%12.2f", 
+                     (float)ts.counts[BGP_STATS_SPACE] / (float)(1UL << (ts.counts[BGP_STATS_MAXBITLEN] - 8)));
             if (ts.counts[BGP_STATS_MAXBITLEN] < 25)
               break;
             vty_out (vty, "%30s: ", "/24 equivalent ");
@@ -9235,7 +9227,7 @@ bgp_table_stats (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi)
             vty_out (vty, "%12llu", ts.counts[i]);
         }
         
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
   return CMD_SUCCESS;
 }
@@ -9359,11 +9351,11 @@ bgp_peer_counts (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi, u_c
       if (use_json)
         {
           json_object_string_add(json, "warning", "No such neighbor or address family");
-          vty_out (vty, "%s%s", json_object_to_json_string(json), VTY_NEWLINE);
+          vty_outln (vty, "%s", json_object_to_json_string(json));
           json_object_free(json);
         }
       else
-        vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+        vty_outln (vty, "%% No such neighbor or address family");
 
       return CMD_WARNING;
     }
@@ -9394,7 +9386,7 @@ bgp_peer_counts (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi, u_c
           json_object_string_add(json, "pfxctDriftFor", peer->host);
           json_object_string_add(json, "recommended", "Please report this bug, with the above command output");
         }
-      vty_out (vty, "%s%s", json_object_to_json_string(json), VTY_NEWLINE);
+      vty_outln (vty, "%s", json_object_to_json_string(json));
       json_object_free(json);
     }
   else
@@ -9402,29 +9394,28 @@ bgp_peer_counts (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi, u_c
 
       if (peer->hostname && bgp_flag_check(peer->bgp, BGP_FLAG_SHOW_HOSTNAME))
         {
-          vty_out (vty, "Prefix counts for %s/%s, %s%s",
-                   peer->hostname, peer->host, afi_safi_print (afi, safi),
-                   VTY_NEWLINE);
+          vty_outln (vty, "Prefix counts for %s/%s, %s",
+                   peer->hostname, peer->host,afi_safi_print(afi, safi));
         }
       else
         {
-          vty_out (vty, "Prefix counts for %s, %s%s",
-                   peer->host, afi_safi_print (afi, safi), VTY_NEWLINE);
+          vty_outln (vty, "Prefix counts for %s, %s",
+                   peer->host, afi_safi_print(afi, safi));
         }
 
-      vty_out (vty, "PfxCt: %ld%s", peer->pcount[afi][safi], VTY_NEWLINE);
-      vty_out (vty, "%sCounts from RIB table walk:%s%s",
-               VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+      vty_outln (vty, "PfxCt: %ld", peer->pcount[afi][safi]);
+      vty_outln (vty, "%sCounts from RIB table walk:%s",
+               VTY_NEWLINE, VTY_NEWLINE);
 
       for (i = 0; i < PCOUNT_MAX; i++)
-        vty_out (vty, "%20s: %-10d%s", pcount_strs[i], pcounts.count[i], VTY_NEWLINE);
+        vty_outln (vty, "%20s: %-10d", pcount_strs[i], pcounts.count[i]);
 
       if (pcounts.count[PCOUNT_PFCNT] != peer->pcount[afi][safi])
         {
-          vty_out (vty, "%s [pcount] PfxCt drift!%s",
-                   peer->host, VTY_NEWLINE);
-          vty_out (vty, "Please report this bug, with the above command output%s",
-                   VTY_NEWLINE);
+          vty_outln (vty, "%s [pcount] PfxCt drift!",
+                   peer->host);
+          vty_outln (vty,
+                     "Please report this bug, with the above command output");
         }
     }
                
@@ -9518,7 +9509,7 @@ DEFUN (show_ip_bgp_vpn_all_route_prefix,
   struct bgp *bgp = bgp_get_default();
   if (!bgp)
     {
-      vty_out (vty, "Can't find default instance%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't find default instance");
       return CMD_WARNING;
     }
 
@@ -9528,7 +9519,7 @@ DEFUN (show_ip_bgp_vpn_all_route_prefix,
     network = argv[idx]->arg;
   else
     {
-      vty_out (vty, "Unable to figure out Network%s", VTY_NEWLINE);
+      vty_outln (vty, "Unable to figure out Network");
       return CMD_WARNING;
     }
 
@@ -9558,7 +9549,7 @@ DEFUN (show_ip_bgp_l2vpn_evpn_all_route_prefix,
     network = argv[idx]->arg;
   else
     {
-      vty_out (vty, "Unable to figure out Network%s", VTY_NEWLINE);
+      vty_outln (vty, "Unable to figure out Network");
       return CMD_WARNING;
     }
   return bgp_show_route (vty, NULL, network, AFI_L2VPN, SAFI_EVPN, NULL, 0, BGP_PATH_ALL, use_json(argc, argv));
@@ -9615,11 +9606,11 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
       if (use_json)
         {
           json_object_string_add(json, "alert", "no BGP");
-          vty_out (vty, "%s%s", json_object_to_json_string(json), VTY_NEWLINE);
+          vty_outln (vty, "%s", json_object_to_json_string(json));
           json_object_free(json);
         }
       else
-        vty_out (vty, "%% No bgp%s", VTY_NEWLINE);
+        vty_outln (vty, "%% No bgp");
       return;
     }
 
@@ -9640,12 +9631,13 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
         }
       else
         {
-          vty_out (vty, "BGP table version is %" PRIu64 ", local router ID is %s%s", table->version, inet_ntoa (bgp->router_id), VTY_NEWLINE);
-          vty_out (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
-          vty_out (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+          vty_outln (vty, "BGP table version is %" PRIu64 ", local router ID is %s", table->version,
+                     inet_ntoa(bgp->router_id));
+          vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
+          vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
 
-          vty_out (vty, "Originating default network 0.0.0.0%s%s",
-                   VTY_NEWLINE, VTY_NEWLINE);
+          vty_outln (vty, "Originating default network 0.0.0.0%s",
+                   VTY_NEWLINE);
         }
       header1 = 0;
     }
@@ -9670,16 +9662,17 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
                         }
                       else
                         {
-                          vty_out (vty, "BGP table version is 0, local router ID is %s%s", inet_ntoa (bgp->router_id), VTY_NEWLINE);
-                          vty_out (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
-                          vty_out (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+                          vty_outln (vty, "BGP table version is 0, local router ID is %s",
+                                     inet_ntoa(bgp->router_id));
+                          vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
+                          vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
                         }
                       header1 = 0;
                     }
                   if (header2)
                     {
                       if (!use_json)
-                        vty_out (vty, BGP_SHOW_HEADER, VTY_NEWLINE);
+                        vty_outln (vty, BGP_SHOW_HEADER);
                       header2 = 0;
                     }
                   if (ain->attr)
@@ -9713,10 +9706,10 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
                         }
                       else
                         {
-                          vty_out (vty, "BGP table version is %" PRIu64 ", local router ID is %s%s", table->version,
-                                   inet_ntoa (bgp->router_id), VTY_NEWLINE);
-                          vty_out (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
-                          vty_out (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+                          vty_outln (vty, "BGP table version is %" PRIu64 ", local router ID is %s", table->version,
+                                   inet_ntoa(bgp->router_id));
+                          vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
+                          vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
                         }
                       header1 = 0;
                     }
@@ -9724,7 +9717,7 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
                   if (header2)
                     {
                       if (!use_json)
-                        vty_out (vty, BGP_SHOW_HEADER, VTY_NEWLINE);
+                        vty_outln (vty, BGP_SHOW_HEADER);
                       header2 = 0;
                     }
 
@@ -9751,12 +9744,12 @@ show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
       if (use_json)
         json_object_int_add(json, "totalPrefixCounter", output_count);
       else
-        vty_out (vty, "%sTotal number of prefixes %ld%s",
-                 VTY_NEWLINE, output_count, VTY_NEWLINE);
+        vty_outln (vty, "%sTotal number of prefixes %ld",
+                 VTY_NEWLINE, output_count);
     }
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string(json), VTY_NEWLINE);
+      vty_outln (vty, "%s", json_object_to_json_string(json));
       json_object_free(json);
     }
 
@@ -9776,11 +9769,11 @@ peer_adj_routes (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
       if (use_json)
         {
           json_object_string_add(json, "warning", "No such neighbor or address family");
-          vty_out (vty, "%s%s", json_object_to_json_string(json), VTY_NEWLINE);
+          vty_outln (vty, "%s", json_object_to_json_string(json));
           json_object_free(json);
         }
       else
-        vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+        vty_outln (vty, "%% No such neighbor or address family");
 
       return CMD_WARNING;
     }
@@ -9790,11 +9783,11 @@ peer_adj_routes (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
       if (use_json)
         {
           json_object_string_add(json, "warning", "Inbound soft reconfiguration not enabled");
-          vty_out (vty, "%s%s", json_object_to_json_string(json), VTY_NEWLINE);
+          vty_outln (vty, "%s", json_object_to_json_string(json));
           json_object_free(json);
         }
       else
-        vty_out (vty, "%% Inbound soft reconfiguration not enabled%s", VTY_NEWLINE);
+        vty_outln (vty, "%% Inbound soft reconfiguration not enabled");
 
       return CMD_WARNING;
     }
@@ -9908,9 +9901,9 @@ DEFUN (show_ip_bgp_neighbor_received_prefix_filter,
       if (! peer)
         {
           if (uj)
-            vty_out (vty, "{}%s", VTY_NEWLINE);
+            vty_outln (vty, "{}");
           else
-            vty_out (vty, "%% Malformed address or name: %s%s", peerstr, VTY_NEWLINE);
+            vty_outln (vty, "%% Malformed address or name: %s", peerstr);
           return CMD_WARNING;
         }
     }
@@ -9920,9 +9913,9 @@ DEFUN (show_ip_bgp_neighbor_received_prefix_filter,
       if (! peer)
         {
           if (uj)
-            vty_out (vty, "{}%s", VTY_NEWLINE);
+            vty_outln (vty, "{}");
           else
-            vty_out (vty, "No peer%s", VTY_NEWLINE);
+            vty_outln (vty, "No peer");
           return CMD_WARNING;
         }
     }
@@ -9932,15 +9925,15 @@ DEFUN (show_ip_bgp_neighbor_received_prefix_filter,
   if (count)
     {
       if (!uj)
-        vty_out (vty, "Address Family: %s%s", afi_safi_print(afi, safi), VTY_NEWLINE);
+        vty_outln (vty, "Address Family: %s", afi_safi_print(afi, safi));
       prefix_bgp_show_prefix_list (vty, afi, name, uj);
     }
   else
     {
       if (uj)
-        vty_out (vty, "{}%s", VTY_NEWLINE);
+        vty_outln (vty, "{}");
       else
-        vty_out (vty, "No functional output%s", VTY_NEWLINE);
+        vty_outln (vty, "No functional output");
     }
 
   return CMD_SUCCESS;
@@ -9957,11 +9950,11 @@ bgp_show_neighbor_route (struct vty *vty, struct peer *peer, afi_t afi,
           json_object *json_no = NULL;
           json_no = json_object_new_object();
           json_object_string_add(json_no, "warning", "No such neighbor or address family");
-          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          vty_outln (vty, "%s", json_object_to_json_string(json_no));
           json_object_free(json_no);
         }
       else
-        vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+        vty_outln (vty, "%% No such neighbor or address family");
       return CMD_WARNING;
     }
 
@@ -10010,7 +10003,7 @@ DEFUN (show_ip_bgp_neighbor_routes,
   peer = peer_lookup_in_view (vty, bgp, peerstr, uj);
   if (! peer)
     {
-      vty_out (vty, "No such neighbor%s", VTY_NEWLINE);
+      vty_outln (vty, "No such neighbor");
       return CMD_WARNING;
     }
 
@@ -10057,7 +10050,7 @@ DEFUN (show_bgp_afi_vpn_rd_route,
   ret = str2prefix_rd (argv[5]->arg, &prd);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed Route Distinguisher");
       return CMD_WARNING;
     }
   return bgp_show_route (vty, NULL, argv[6]->arg, afi, SAFI_MPLS_VPN, &prd, 0, BGP_PATH_ALL, use_json (argc, argv));
@@ -10093,7 +10086,7 @@ bgp_distance_set (struct vty *vty, const char *distance_str,
   ret = str2prefix (ip_str, &p);
   if (ret == 0)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
 
@@ -10145,14 +10138,14 @@ bgp_distance_unset (struct vty *vty, const char *distance_str,
   ret = str2prefix (ip_str, &p);
   if (ret == 0)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
 
   rn = bgp_node_lookup (bgp_distance_table[afi][safi], (struct prefix *)&p);
   if (! rn)
     {
-      vty_out (vty, "Can't find specified prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't find specified prefix");
       return CMD_WARNING;
     }
 
@@ -10161,7 +10154,7 @@ bgp_distance_unset (struct vty *vty, const char *distance_str,
 
   if (bdistance->distance != distance)
     {
-       vty_out (vty, "Distance does not match configured%s", VTY_NEWLINE);
+       vty_outln (vty, "Distance does not match configured");
        return CMD_WARNING;
     }
 
@@ -10431,8 +10424,7 @@ DEFUN (bgp_damp_set,
 
   if (suppress < reuse)
     {
-      vty_out (vty, "Suppress value cannot be less than reuse value %s",
-                    VTY_NEWLINE);
+      vty_outln (vty,"Suppress value cannot be less than reuse value ");
       return 0;
     }
 
@@ -10476,7 +10468,7 @@ bgp_clear_damp_route (struct vty *vty, const char *view_name,
       bgp = bgp_lookup_by_name (view_name);
       if (bgp == NULL)
 	{
-	  vty_out (vty, "%% Can't find BGP instance %s%s", view_name, VTY_NEWLINE);
+	  vty_outln (vty, "%% Can't find BGP instance %s", view_name);
 	  return CMD_WARNING;
 	}
     }
@@ -10485,7 +10477,7 @@ bgp_clear_damp_route (struct vty *vty, const char *view_name,
       bgp = bgp_get_default ();
       if (bgp == NULL)
 	{
-	  vty_out (vty, "%% No BGP process is configured%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% No BGP process is configured");
 	  return CMD_WARNING;
 	}
     }
@@ -10494,7 +10486,7 @@ bgp_clear_damp_route (struct vty *vty, const char *view_name,
   ret = str2prefix (ip_str, &match);
   if (! ret)
     {
-      vty_out (vty, "%% address is malformed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% address is malformed");
       return CMD_WARNING;
     }
 
@@ -10615,7 +10607,7 @@ DEFUN (clear_ip_bgp_dampening_address_mask,
   ret = netmask_str2prefix_str (argv[idx_ipv4]->arg, argv[idx_ipv4_2]->arg, prefix_str);
   if (! ret)
     {
-      vty_out (vty, "%% Inconsistent address and mask%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -10667,7 +10659,7 @@ bgp_config_write_network_vpn (struct vty *vty, struct bgp *bgp,
                 if (bgp_static->backdoor)
                   vty_out (vty, " backdoor");
               }
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_outln (vty, "");
 	  }
   return 0;
 }
@@ -10714,7 +10706,7 @@ bgp_config_write_network_evpn (struct vty *vty, struct bgp *bgp,
 	    vty_out (vty, " network %s rd %s ethtag %u tag %u esi %s gwip %s routermac %s",
 		     buf, rdbuf, p->u.prefix_evpn.eth_tag,
                      decode_label (bgp_static->tag), esi, buf2 , macrouter);
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_outln (vty, "");
             if (macrouter)
               XFREE (MTYPE_TMP, macrouter);
             if (esi)
@@ -10789,7 +10781,7 @@ bgp_config_write_network (struct vty *vty, struct bgp *bgp,
 	      vty_out (vty, " backdoor");
           }
 
-	vty_out (vty, "%s", VTY_NEWLINE);
+	vty_outln (vty, "");
       }
 
   /* Aggregate-address configuration. */
@@ -10823,7 +10815,7 @@ bgp_config_write_network (struct vty *vty, struct bgp *bgp,
 	if (bgp_aggregate->summary_only)
 	  vty_out (vty, " summary-only");
 
-	vty_out (vty, "%s", VTY_NEWLINE);
+	vty_outln (vty, "");
       }
 
   return 0;
@@ -10845,9 +10837,9 @@ bgp_config_write_distance (struct vty *vty, struct bgp *bgp, afi_t afi,
 	  || bgp->distance_local[afi][safi] != ZEBRA_IBGP_DISTANCE_DEFAULT))
     {
       bgp_config_write_family_header (vty, afi, safi, write);
-      vty_out (vty, "  distance bgp %d %d %d%s",
+      vty_outln (vty, "  distance bgp %d %d %d",
 	       bgp->distance_ebgp[afi][safi], bgp->distance_ibgp[afi][safi],
-	       bgp->distance_local[afi][safi], VTY_NEWLINE);
+	       bgp->distance_local[afi][safi]);
     }
 
   for (rn = bgp_table_top (bgp_distance_table[afi][safi]); rn;
@@ -10857,10 +10849,9 @@ bgp_config_write_distance (struct vty *vty, struct bgp *bgp, afi_t afi,
 	char buf[PREFIX_STRLEN];
 
 	bgp_config_write_family_header (vty, afi, safi, write);
-	vty_out (vty, "  distance %d %s %s%s", bdistance->distance,
+	vty_outln (vty, "  distance %d %s %s", bdistance->distance,
 		 prefix2str (&rn->p, buf, sizeof (buf)),
-		 bdistance->access_list ? bdistance->access_list : "",
-		 VTY_NEWLINE);
+		 bdistance->access_list ? bdistance->access_list : "");
       }
 
   return *write;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6504,7 +6504,7 @@ route_vty_out (struct vty *vty, struct prefix *p,
     }
   else
     {
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
 #if ENABLE_BGP_VNC
       /* prints an additional line, indented, with VNC info, if present */
       if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP))
@@ -6641,7 +6641,7 @@ route_vty_out_tmp (struct vty *vty, struct prefix *p, struct attr *attr, safi_t 
       json_object_object_add(json_ar, inet_ntop (p->family, &p->u.prefix, buf_cut, BUFSIZ), json_net);
     }
   else
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
 }  
 
 void
@@ -6745,7 +6745,7 @@ route_vty_out_tag (struct vty *vty, struct prefix *p,
     {
       vty_out (vty, "notag/%d", label);
 
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 }  
 
@@ -6832,7 +6832,7 @@ route_vty_out_overlay (struct vty *vty, struct prefix *p,
             }
         }
     }
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 }
 
 /* dampening route */
@@ -6896,7 +6896,7 @@ damp_route_vty_out (struct vty *vty, struct prefix *p, struct bgp_info *binfo,
         vty_out (vty, "%s", bgp_origin_str[attr->origin]);
     }
   if (!use_json)
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
 }
 
 /* flap route */
@@ -6996,7 +6996,7 @@ flap_route_vty_out (struct vty *vty, struct prefix *p, struct bgp_info *binfo,
         vty_out (vty, "%s", bgp_origin_str[attr->origin]);
     }
   if (!use_json)
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
 }
 
 static void
@@ -7170,7 +7170,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
         }
 
       if (!json_paths)
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
 	  
       /* Line2 display Next-hop, Neighbor, Router-id */
       /* Display the nexthop */
@@ -7319,7 +7319,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
 	}
 
       if (!json_paths)
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
 
       /* display the link-local nexthop */
       if (attr->extra && attr->extra->mp_nexthop_len == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
@@ -7538,7 +7538,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
         json_object_object_add(json_path, "bestpath", json_bestpath);
 
       if (!json_paths)
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
 	  
       /* Line 4 display Community */
       if (attr->community)
@@ -7625,7 +7625,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
 	    }
 
           if (!json_paths)
-	    vty_outln (vty, "");
+	    vty_out (vty, VTYNL);
 	}
 
       if (binfo->extra && binfo->extra->damp_info)
@@ -7700,7 +7700,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
             {
               if (!first)
                 {
-	          vty_outln (vty, "");
+	          vty_out (vty, VTYNL);
                 }
             }
         }
@@ -7740,7 +7740,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
       json_object_array_add(json_paths, json_path);
     }
   else
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
 }
 
 #define BGP_SHOW_HEADER_CSV "Flags, Network, Next Hop, Metric, LocPrf, Weight, Path"
@@ -8223,7 +8223,7 @@ route_vty_out_detail_header (struct vty *vty, struct bgp *bgp,
         {
           if (first)
             vty_out (vty, "  Not advertised to any peer");
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
         }
     }
 }
@@ -9227,7 +9227,7 @@ bgp_table_stats (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi)
             vty_out (vty, "%12llu", ts.counts[i]);
         }
         
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   return CMD_SUCCESS;
 }
@@ -10659,7 +10659,7 @@ bgp_config_write_network_vpn (struct vty *vty, struct bgp *bgp,
                 if (bgp_static->backdoor)
                   vty_out (vty, " backdoor");
               }
-	    vty_outln (vty, "");
+	    vty_out (vty, VTYNL);
 	  }
   return 0;
 }
@@ -10706,7 +10706,7 @@ bgp_config_write_network_evpn (struct vty *vty, struct bgp *bgp,
 	    vty_out (vty, " network %s rd %s ethtag %u tag %u esi %s gwip %s routermac %s",
 		     buf, rdbuf, p->u.prefix_evpn.eth_tag,
                      decode_label (bgp_static->tag), esi, buf2 , macrouter);
-	    vty_outln (vty, "");
+	    vty_out (vty, VTYNL);
             if (macrouter)
               XFREE (MTYPE_TMP, macrouter);
             if (esi)
@@ -10781,7 +10781,7 @@ bgp_config_write_network (struct vty *vty, struct bgp *bgp,
 	      vty_out (vty, " backdoor");
           }
 
-	vty_outln (vty, "");
+	vty_out (vty, VTYNL);
       }
 
   /* Aggregate-address configuration. */
@@ -10815,7 +10815,7 @@ bgp_config_write_network (struct vty *vty, struct bgp *bgp,
 	if (bgp_aggregate->summary_only)
 	  vty_out (vty, " summary-only");
 
-	vty_outln (vty, "");
+	vty_out (vty, VTYNL);
       }
 
   return 0;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -54,9 +54,9 @@ enum bgp_show_type
 
 #define BGP_SHOW_SCODE_HEADER "Status codes: s suppressed, d damped, "\
                               "h history, * valid, > best, = multipath,%s"\
-                "              i internal, r RIB-failure, S Stale, R Removed%s"
-#define BGP_SHOW_OCODE_HEADER "Origin codes: i - IGP, e - EGP, ? - incomplete%s%s"
-#define BGP_SHOW_HEADER "   Network          Next Hop            Metric LocPrf Weight Path%s"
+                "              i internal, r RIB-failure, S Stale, R Removed"
+#define BGP_SHOW_OCODE_HEADER "Origin codes: i - IGP, e - EGP, ? - incomplete%s"
+#define BGP_SHOW_HEADER "   Network          Next Hop            Metric LocPrf Weight Path"
 
 /* Ancillary information to struct bgp_info, 
  * used for uncommonly used data (aggregation, MPLS, etc.)

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2851,10 +2851,10 @@ bgp_route_match_add (struct vty *vty,
       switch (ret)
 	{
 	case RMAP_RULE_MISSING:
-	  vty_out (vty, "%% BGP Can't find rule.%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% BGP Can't find rule.");
 	  return CMD_WARNING;
 	case RMAP_COMPILE_ERROR:
-	  vty_out (vty, "%% BGP Argument is malformed.%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% BGP Argument is malformed.");
 	  return CMD_WARNING;
 	}
     }
@@ -2900,10 +2900,10 @@ bgp_route_match_delete (struct vty *vty,
       switch (ret)
 	{
 	case RMAP_RULE_MISSING:
-	  vty_out (vty, "%% BGP Can't find rule.%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% BGP Can't find rule.");
 	  break;
 	case RMAP_COMPILE_ERROR:
-	  vty_out (vty, "%% BGP Argument is malformed.%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% BGP Argument is malformed.");
 	  break;
 	}
       if (dep_name)
@@ -3886,7 +3886,7 @@ DEFUN (set_community,
   /* Can't compile user input into communities attribute.  */
   if (! com)
     {
-      vty_out (vty, "%% Malformed communities attribute%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed communities attribute");
       return CMD_WARNING;
     }
 
@@ -4210,7 +4210,7 @@ DEFUN (set_aggregator_as,
   ret = inet_aton (argv[idx_ipv4]->arg, &address);
   if (ret == 0)
     {
-      vty_out (vty, "Aggregator IP address is invalid%s", VTY_NEWLINE);
+      vty_outln (vty, "Aggregator IP address is invalid");
       return CMD_WARNING;
     }
 
@@ -4251,7 +4251,7 @@ DEFUN (no_set_aggregator_as,
   ret = inet_aton (argv[idx_ip]->arg, &address);
   if (ret == 0)
     {
-      vty_out (vty, "Aggregator IP address is invalid%s", VTY_NEWLINE);
+      vty_outln (vty, "Aggregator IP address is invalid");
       return CMD_WARNING;
     }
 
@@ -4362,7 +4362,7 @@ DEFUN (set_ipv6_nexthop_global,
   ret = inet_pton (AF_INET6, argv[idx_ipv6]->arg, &addr);
   if (!ret)
     {
-      vty_out (vty, "%% Malformed nexthop address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed nexthop address");
       return CMD_WARNING;
     }
   if (IN6_IS_ADDR_UNSPECIFIED(&addr) ||
@@ -4370,7 +4370,7 @@ DEFUN (set_ipv6_nexthop_global,
       IN6_IS_ADDR_MULTICAST(&addr)   ||
       IN6_IS_ADDR_LINKLOCAL(&addr))
     {
-      vty_out (vty, "%% Invalid global nexthop address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Invalid global nexthop address");
       return CMD_WARNING;
     }
 

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -564,73 +564,69 @@ update_group_show_walkcb (struct update_group *updgrp, void *arg)
 
   vty = ctx->vty;
 
-  vty_out (vty, "Update-group %" PRIu64 ":%s", updgrp->id, VTY_NEWLINE);
+  vty_outln (vty, "Update-group %" PRIu64 ":", updgrp->id);
   vty_out (vty, "  Created: %s", timestamp_string (updgrp->uptime));
   filter = &updgrp->conf->filter[updgrp->afi][updgrp->safi];
   if (filter->map[RMAP_OUT].name)
-    vty_out (vty, "  Outgoing route map: %s%s%s",
+    vty_outln (vty, "  Outgoing route map: %s%s",
 	     filter->map[RMAP_OUT].map ? "X" : "",
-	     filter->map[RMAP_OUT].name, VTY_NEWLINE);
-  vty_out (vty, "  MRAI value (seconds): %d%s",
-	   updgrp->conf->v_routeadv, VTY_NEWLINE);
+	     filter->map[RMAP_OUT].name);
+  vty_outln (vty, "  MRAI value (seconds): %d",
+	   updgrp->conf->v_routeadv);
   if (updgrp->conf->change_local_as)
-    vty_out (vty, "  Local AS %u%s%s%s",
+    vty_outln (vty, "  Local AS %u%s%s",
              updgrp->conf->change_local_as,
              CHECK_FLAG (updgrp->conf->flags,
                      PEER_FLAG_LOCAL_AS_NO_PREPEND) ?  " no-prepend" : "",
-             CHECK_FLAG (updgrp->conf->flags,
-                     PEER_FLAG_LOCAL_AS_REPLACE_AS) ?  " replace-as" : "",
-             VTY_NEWLINE);
+             CHECK_FLAG(updgrp->conf->flags, PEER_FLAG_LOCAL_AS_REPLACE_AS) ? " replace-as" : "");
 
   UPDGRP_FOREACH_SUBGRP (updgrp, subgrp)
   {
     if (ctx->subgrp_id && (ctx->subgrp_id != subgrp->id))
       continue;
-    vty_out (vty, "%s", VTY_NEWLINE);
-    vty_out (vty, "  Update-subgroup %" PRIu64 ":%s", subgrp->id, VTY_NEWLINE);
+    vty_outln (vty, "");
+    vty_outln (vty, "  Update-subgroup %" PRIu64 ":", subgrp->id);
     vty_out (vty, "    Created: %s", timestamp_string (subgrp->uptime));
 
     if (subgrp->split_from.update_group_id || subgrp->split_from.subgroup_id)
       {
-	vty_out (vty, "    Split from group id: %" PRIu64 "%s",
-		 subgrp->split_from.update_group_id, VTY_NEWLINE);
-	vty_out (vty, "    Split from subgroup id: %" PRIu64 "%s",
-		 subgrp->split_from.subgroup_id, VTY_NEWLINE);
+	vty_outln (vty, "    Split from group id: %" PRIu64 "",
+		 subgrp->split_from.update_group_id);
+	vty_outln (vty, "    Split from subgroup id: %" PRIu64 "",
+		 subgrp->split_from.subgroup_id);
       }
 
-    vty_out (vty, "    Join events: %u%s", subgrp->join_events, VTY_NEWLINE);
-    vty_out (vty, "    Prune events: %u%s",
-	     subgrp->prune_events, VTY_NEWLINE);
-    vty_out (vty, "    Merge events: %u%s",
-	     subgrp->merge_events, VTY_NEWLINE);
-    vty_out (vty, "    Split events: %u%s",
-	     subgrp->split_events, VTY_NEWLINE);
-    vty_out (vty, "    Update group switch events: %u%s",
-	     subgrp->updgrp_switch_events, VTY_NEWLINE);
-    vty_out (vty, "    Peer refreshes combined: %u%s",
-	     subgrp->peer_refreshes_combined, VTY_NEWLINE);
-    vty_out (vty, "    Merge checks triggered: %u%s",
-	     subgrp->merge_checks_triggered, VTY_NEWLINE);
-    vty_out (vty, "    Version: %" PRIu64 "%s", subgrp->version, VTY_NEWLINE);
-    vty_out (vty, "    Packet queue length: %d%s",
-	     bpacket_queue_length (SUBGRP_PKTQ (subgrp)), VTY_NEWLINE);
-    vty_out (vty, "    Total packets enqueued: %u%s",
-	     subgroup_total_packets_enqueued (subgrp), VTY_NEWLINE);
-    vty_out (vty, "    Packet queue high watermark: %d%s",
-	     bpacket_queue_hwm_length (SUBGRP_PKTQ (subgrp)), VTY_NEWLINE);
-    vty_out (vty, "    Adj-out list count: %u%s",
-	     subgrp->adj_count, VTY_NEWLINE);
-    vty_out (vty, "    Advertise list: %s%s",
-	     advertise_list_is_empty (subgrp) ? "empty" : "not empty",
-	     VTY_NEWLINE);
-    vty_out (vty, "    Flags: %s%s",
-	     CHECK_FLAG (subgrp->flags,
-			 SUBGRP_FLAG_NEEDS_REFRESH) ? "R" : "", VTY_NEWLINE);
+    vty_outln (vty, "    Join events: %u", subgrp->join_events);
+    vty_outln (vty, "    Prune events: %u",
+	     subgrp->prune_events);
+    vty_outln (vty, "    Merge events: %u",
+	     subgrp->merge_events);
+    vty_outln (vty, "    Split events: %u",
+	     subgrp->split_events);
+    vty_outln (vty, "    Update group switch events: %u",
+	     subgrp->updgrp_switch_events);
+    vty_outln (vty, "    Peer refreshes combined: %u",
+	     subgrp->peer_refreshes_combined);
+    vty_outln (vty, "    Merge checks triggered: %u",
+	     subgrp->merge_checks_triggered);
+    vty_outln (vty, "    Version: %" PRIu64 "", subgrp->version);
+    vty_outln (vty, "    Packet queue length: %d",
+	     bpacket_queue_length(SUBGRP_PKTQ(subgrp)));
+    vty_outln (vty, "    Total packets enqueued: %u",
+	     subgroup_total_packets_enqueued(subgrp));
+    vty_outln (vty, "    Packet queue high watermark: %d",
+	     bpacket_queue_hwm_length(SUBGRP_PKTQ(subgrp)));
+    vty_outln (vty, "    Adj-out list count: %u",
+	     subgrp->adj_count);
+    vty_outln (vty, "    Advertise list: %s",
+	     advertise_list_is_empty(subgrp) ? "empty" : "not empty");
+    vty_outln (vty, "    Flags: %s",
+	     CHECK_FLAG(subgrp->flags, SUBGRP_FLAG_NEEDS_REFRESH) ? "R" : "");
     if (subgrp->peer_count > 0)
       {
-	vty_out (vty, "    Peers:%s", VTY_NEWLINE);
+	vty_outln (vty, "    Peers:");
 	SUBGRP_FOREACH_PEER (subgrp, paf)
-	  vty_out (vty, "      - %s%s", paf->peer->host, VTY_NEWLINE);
+	  vty_outln (vty, "      - %s", paf->peer->host);
       }
   }
   return UPDWALK_CONTINUE;
@@ -652,8 +648,8 @@ updgrp_show_packet_queue_walkcb (struct update_group *updgrp, void *arg)
   {
     if (ctx->subgrp_id && (ctx->subgrp_id != subgrp->id))
       continue;
-    vty_out (vty, "update group %" PRIu64 ", subgroup %" PRIu64 "%s", updgrp->id,
-	     subgrp->id, VTY_NEWLINE);
+    vty_outln (vty, "update group %" PRIu64 ", subgroup %" PRIu64 "", updgrp->id,
+	     subgrp->id);
     bpacket_queue_show_vty (SUBGRP_PKTQ (subgrp), vty);
   }
   return UPDWALK_CONTINUE;
@@ -1601,28 +1597,28 @@ update_group_show (struct bgp *bgp, afi_t afi, safi_t safi, struct vty *vty,
 void
 update_group_show_stats (struct bgp *bgp, struct vty *vty)
 {
-  vty_out (vty, "Update groups created: %u%s",
-	   bgp->update_group_stats.updgrps_created, VTY_NEWLINE);
-  vty_out (vty, "Update groups deleted: %u%s",
-	   bgp->update_group_stats.updgrps_deleted, VTY_NEWLINE);
-  vty_out (vty, "Update subgroups created: %u%s",
-	   bgp->update_group_stats.subgrps_created, VTY_NEWLINE);
-  vty_out (vty, "Update subgroups deleted: %u%s",
-	   bgp->update_group_stats.subgrps_deleted, VTY_NEWLINE);
-  vty_out (vty, "Join events: %u%s",
-	   bgp->update_group_stats.join_events, VTY_NEWLINE);
-  vty_out (vty, "Prune events: %u%s",
-	   bgp->update_group_stats.prune_events, VTY_NEWLINE);
-  vty_out (vty, "Merge events: %u%s",
-	   bgp->update_group_stats.merge_events, VTY_NEWLINE);
-  vty_out (vty, "Split events: %u%s",
-	   bgp->update_group_stats.split_events, VTY_NEWLINE);
-  vty_out (vty, "Update group switch events: %u%s",
-	   bgp->update_group_stats.updgrp_switch_events, VTY_NEWLINE);
-  vty_out (vty, "Peer route refreshes combined: %u%s",
-	   bgp->update_group_stats.peer_refreshes_combined, VTY_NEWLINE);
-  vty_out (vty, "Merge checks triggered: %u%s",
-	   bgp->update_group_stats.merge_checks_triggered, VTY_NEWLINE);
+  vty_outln (vty, "Update groups created: %u",
+	   bgp->update_group_stats.updgrps_created);
+  vty_outln (vty, "Update groups deleted: %u",
+	   bgp->update_group_stats.updgrps_deleted);
+  vty_outln (vty, "Update subgroups created: %u",
+	   bgp->update_group_stats.subgrps_created);
+  vty_outln (vty, "Update subgroups deleted: %u",
+	   bgp->update_group_stats.subgrps_deleted);
+  vty_outln (vty, "Join events: %u",
+	   bgp->update_group_stats.join_events);
+  vty_outln (vty, "Prune events: %u",
+	   bgp->update_group_stats.prune_events);
+  vty_outln (vty, "Merge events: %u",
+	   bgp->update_group_stats.merge_events);
+  vty_outln (vty, "Split events: %u",
+	   bgp->update_group_stats.split_events);
+  vty_outln (vty, "Update group switch events: %u",
+	   bgp->update_group_stats.updgrp_switch_events);
+  vty_outln (vty, "Peer route refreshes combined: %u",
+	   bgp->update_group_stats.peer_refreshes_combined);
+  vty_outln (vty, "Merge checks triggered: %u",
+	   bgp->update_group_stats.merge_checks_triggered);
 }
 
 /*

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -584,7 +584,7 @@ update_group_show_walkcb (struct update_group *updgrp, void *arg)
   {
     if (ctx->subgrp_id && (ctx->subgrp_id != subgrp->id))
       continue;
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
     vty_outln (vty, "  Update-subgroup %" PRIu64 ":", subgrp->id);
     vty_out (vty, "    Created: %s", timestamp_string (subgrp->uptime));
 

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -229,8 +229,8 @@ subgrp_show_adjq_vty (struct update_subgroup *subgrp, struct vty *vty,
 	      vty_outln (vty,
 		       "BGP table version is %" PRIu64 ", local router ID is %s",
 		       table->version,inet_ntoa(bgp->router_id));
-	      vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
-	      vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
+	      vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTYNL);
+	      vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTYNL);
 	      header1 = 0;
 	    }
 	  if (header2)
@@ -251,7 +251,7 @@ subgrp_show_adjq_vty (struct update_subgroup *subgrp, struct vty *vty,
 	}
   if (output_count != 0)
     vty_outln (vty, "%sTotal number of prefixes %ld",
-	     VTY_NEWLINE, output_count);
+	     VTYNL, output_count);
 }
 
 static int

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -226,17 +226,16 @@ subgrp_show_adjq_vty (struct update_subgroup *subgrp, struct vty *vty,
 	{
 	  if (header1)
 	    {
-	      vty_out (vty,
-		       "BGP table version is %" PRIu64 ", local router ID is %s%s",
-		       table->version, inet_ntoa (bgp->router_id),
-		       VTY_NEWLINE);
-	      vty_out (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
-	      vty_out (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE, VTY_NEWLINE);
+	      vty_outln (vty,
+		       "BGP table version is %" PRIu64 ", local router ID is %s",
+		       table->version,inet_ntoa(bgp->router_id));
+	      vty_outln (vty, BGP_SHOW_SCODE_HEADER, VTY_NEWLINE);
+	      vty_outln (vty, BGP_SHOW_OCODE_HEADER, VTY_NEWLINE);
 	      header1 = 0;
 	    }
 	  if (header2)
 	    {
-	      vty_out (vty, BGP_SHOW_HEADER, VTY_NEWLINE);
+	      vty_outln (vty, BGP_SHOW_HEADER);
 	      header2 = 0;
 	    }
 	  if ((flags & UPDWALK_FLAGS_ADVQUEUE) && adj->adv && adj->adv->baa)
@@ -251,8 +250,8 @@ subgrp_show_adjq_vty (struct update_subgroup *subgrp, struct vty *vty,
 	    }
 	}
   if (output_count != 0)
-    vty_out (vty, "%sTotal number of prefixes %ld%s",
-	     VTY_NEWLINE, output_count, VTY_NEWLINE);
+    vty_outln (vty, "%sTotal number of prefixes %ld",
+	     VTY_NEWLINE, output_count);
 }
 
 static int
@@ -267,8 +266,8 @@ updgrp_show_adj_walkcb (struct update_group *updgrp, void *arg)
   {
     if (ctx->subgrp_id && (ctx->subgrp_id != subgrp->id))
       continue;
-    vty_out (vty, "update group %" PRIu64 ", subgroup %" PRIu64 "%s", updgrp->id,
-	     subgrp->id, VTY_NEWLINE);
+    vty_outln (vty, "update group %" PRIu64 ", subgroup %" PRIu64 "", updgrp->id,
+	     subgrp->id);
     subgrp_show_adjq_vty (subgrp, vty, ctx->flags);
   }
   return UPDWALK_CONTINUE;

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -392,12 +392,12 @@ bpacket_queue_show_vty (struct bpacket_queue *q, struct vty *vty)
   pkt = bpacket_queue_first (q);
   while (pkt)
     {
-      vty_out (vty, "  Packet %p ver %u buffer %p%s", pkt, pkt->ver,
-	       pkt->buffer, VTY_NEWLINE);
+      vty_outln (vty, "  Packet %p ver %u buffer %p", pkt, pkt->ver,
+	       pkt->buffer);
 
       LIST_FOREACH (paf, &(pkt->peers), pkt_train)
       {
-	vty_out (vty, "      - %s%s", paf->peer->host, VTY_NEWLINE);
+	vty_outln (vty, "      - %s", paf->peer->host);
       }
       pkt = bpacket_next (pkt);
     }

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -170,7 +170,7 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd,
                                      rd_vnc_eth.macaddr.octet[5]);
 #endif
 
-                          vty_outln (vty, "");
+                          vty_out (vty, VTYNL);
                         }
                       rd_header = 0;
                     }

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -41,7 +41,6 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd,
   struct attr *attr;
   int rd_header;
   int header = 1;
-  char v4_header[] = "   Network          Next Hop            Metric LocPrf Weight Path%s";
   json_object *json = NULL;
   json_object *json_scode = NULL;
   json_object *json_ocode = NULL;
@@ -52,7 +51,7 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd,
   if (bgp == NULL)
     {
       if (!use_json)
-        vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+        vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -105,13 +104,13 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd,
                         }
                       else
                         {
-                          vty_out (vty, "BGP table version is 0, local router ID is %s%s",
-                                   inet_ntoa (bgp->router_id), VTY_NEWLINE);
-                          vty_out (vty, "Status codes: s suppressed, d damped, h history, * valid, > best, i - internal%s",
+                          vty_outln (vty, "BGP table version is 0, local router ID is %s",
+                                   inet_ntoa(bgp->router_id));
+                          vty_outln (vty,
+                                     "Status codes: s suppressed, d damped, h history, * valid, > best, i - internal");
+                          vty_outln (vty, "Origin codes: i - IGP, e - EGP, ? - incomplete%s",
                                    VTY_NEWLINE);
-                          vty_out (vty, "Origin codes: i - IGP, e - EGP, ? - incomplete%s%s",
-                                   VTY_NEWLINE, VTY_NEWLINE);
-                          vty_out (vty, v4_header, VTY_NEWLINE);
+                          vty_outln (vty, V4_HEADER);
                         }
                       header = 0;
                     }
@@ -171,7 +170,7 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd,
                                      rd_vnc_eth.macaddr.octet[5]);
 #endif
 
-                          vty_out (vty, "%s", VTY_NEWLINE);
+                          vty_outln (vty, "");
                         }
                       rd_header = 0;
                     }
@@ -192,7 +191,8 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd,
   if (use_json)
     {
       json_object_object_add(json, "routes", json_routes);
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free(json);
     }
   return CMD_SUCCESS;

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -109,7 +109,7 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd,
                           vty_outln (vty,
                                      "Status codes: s suppressed, d damped, h history, * valid, > best, i - internal");
                           vty_outln (vty, "Origin codes: i - IGP, e - EGP, ? - incomplete%s",
-                                   VTY_NEWLINE);
+                                   VTYNL);
                           vty_outln (vty, V4_HEADER);
                         }
                       header = 0;

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1009,7 +1009,7 @@ DEFPY (no_bgp_router_id,
     {
       if (! IPV4_ADDR_SAME (&bgp->router_id_static, &router_id))
 	{
-	  vty_outln (vty, "%% BGP router-id doesn't match%s");
+	  vty_outln (vty, "%% BGP router-id doesn't match");
 	  return CMD_WARNING;
 	}
     }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -308,7 +308,7 @@ bgp_vty_find_and_parse_afi_safi_bgp (struct vty *vty, struct cmd_token **argv, i
           *bgp = bgp_lookup_by_name (vrf_name);
           if (!*bgp)
             {
-              vty_out (vty, "View/Vrf specified is unknown: %s%s", vrf_name, VTY_NEWLINE);
+              vty_out (vty, "View/Vrf specified is unknown: %s%s", vrf_name, VTYNL);
               *idx = 0;
               return 0;
             }
@@ -319,7 +319,7 @@ bgp_vty_find_and_parse_afi_safi_bgp (struct vty *vty, struct cmd_token **argv, i
       *bgp = bgp_get_default ();
       if (!*bgp)
         {
-          vty_out (vty, "Unable to find default BGP instance%s", VTY_NEWLINE);
+          vty_out (vty, "Unable to find default BGP instance%s", VTYNL);
           *idx = 0;
           return 0;
         }
@@ -373,7 +373,7 @@ peer_lookup_vty (struct vty *vty, const char *ip_str)
         {
 	  if ((peer = peer_lookup_by_hostname(bgp, ip_str)) == NULL)
 	    {
-	      vty_out (vty, "%% Malformed address or name: %s%s", ip_str, VTY_NEWLINE);
+	      vty_out (vty, "%% Malformed address or name: %s%s", ip_str, VTYNL);
 	      return NULL;
 	    }
         }
@@ -384,13 +384,13 @@ peer_lookup_vty (struct vty *vty, const char *ip_str)
       if (! peer)
         {
           vty_out (vty, "%% Specify remote-as or peer-group commands first%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           return NULL;
         }
       if (peer_dynamic_neighbor (peer))
         {
           vty_out (vty, "%% Operation not allowed on a dynamic neighbor%s",
-	           VTY_NEWLINE);
+	           VTYNL);
           return NULL;
         }
 
@@ -434,7 +434,7 @@ peer_and_group_lookup_vty (struct vty *vty, const char *peer_str)
       if (peer_dynamic_neighbor (peer))
         {
           vty_out (vty, "%% Operation not allowed on a dynamic neighbor%s",
-	           VTY_NEWLINE);
+	           VTYNL);
           return NULL;
         }
 
@@ -445,7 +445,7 @@ peer_and_group_lookup_vty (struct vty *vty, const char *peer_str)
     return group->conf;
 
   vty_out (vty, "%% Specify remote-as or peer-group commands first%s",
-	   VTY_NEWLINE);
+	   VTYNL);
 
   return NULL;
 }
@@ -520,7 +520,7 @@ bgp_vty_return (struct vty *vty, int ret)
     }
   if (str)
     {
-      vty_out (vty, "%% %s%s", str, VTY_NEWLINE);
+      vty_out (vty, "%% %s%s", str, VTYNL);
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -545,10 +545,10 @@ bgp_clear_vty_error (struct vty *vty, struct peer *peer, afi_t afi,
     case BGP_ERR_AF_UNCONFIGURED:
       vty_out (vty,
 	       "%%BGP: Enable %s address family for the neighbor %s%s",
-	       afi_safi_print(afi, safi), peer->host, VTY_NEWLINE);
+	       afi_safi_print(afi, safi), peer->host, VTYNL);
       break;
     case BGP_ERR_SOFT_RECONFIG_UNCONFIGURED:
-      vty_out (vty, "%%BGP: Inbound soft reconfig for %s not possible as it%s      has neither refresh capability, nor inbound soft reconfig%s", peer->host, VTY_NEWLINE, VTY_NEWLINE);
+      vty_out (vty, "%%BGP: Inbound soft reconfig for %s not possible as it%s      has neither refresh capability, nor inbound soft reconfig%s", peer->host, VTYNL, VTYNL);
       break;
     default:
       break;
@@ -607,7 +607,7 @@ bgp_clear (struct vty *vty, struct bgp *bgp,  afi_t afi, safi_t safi,
 	      peer = peer_lookup_by_hostname(bgp, arg);
 	      if (!peer)
 		{
-		  vty_out (vty, "Malformed address or name: %s%s", arg, VTY_NEWLINE);
+		  vty_out (vty, "Malformed address or name: %s%s", arg, VTYNL);
 		  return CMD_WARNING;
 		}
             }
@@ -617,7 +617,7 @@ bgp_clear (struct vty *vty, struct bgp *bgp,  afi_t afi, safi_t safi,
           peer = peer_lookup (bgp, &su);
           if (! peer)
             {
-              vty_out (vty, "%%BGP: Unknown neighbor - \"%s\"%s", arg, VTY_NEWLINE);
+              vty_out (vty, "%%BGP: Unknown neighbor - \"%s\"%s", arg, VTYNL);
               return CMD_WARNING;
             }
         }
@@ -641,7 +641,7 @@ bgp_clear (struct vty *vty, struct bgp *bgp,  afi_t afi, safi_t safi,
       group = peer_group_lookup (bgp, arg);
       if (! group)
 	{
-	  vty_out (vty, "%%BGP: No such peer-group %s%s", arg, VTY_NEWLINE);
+	  vty_out (vty, "%%BGP: No such peer-group %s%s", arg, VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -705,7 +705,7 @@ bgp_clear (struct vty *vty, struct bgp *bgp,  afi_t afi, safi_t safi,
 	}
       if (! find)
 	vty_out (vty, "%%BGP: No peer is configured with AS %s%s", arg,
-		 VTY_NEWLINE);
+		 VTYNL);
       return CMD_SUCCESS;
     }
 
@@ -725,7 +725,7 @@ bgp_clear_vty (struct vty *vty, const char *name, afi_t afi, safi_t safi,
       bgp = bgp_lookup_by_name (name);
       if (bgp == NULL)
         {
-          vty_out (vty, "Can't find BGP instance %s%s", name, VTY_NEWLINE);
+          vty_out (vty, "Can't find BGP instance %s%s", name, VTYNL);
           return CMD_WARNING;
         }
     }
@@ -734,7 +734,7 @@ bgp_clear_vty (struct vty *vty, const char *name, afi_t afi, safi_t safi,
       bgp = bgp_get_default ();
       if (bgp == NULL)
         {
-          vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+          vty_out (vty, "No BGP process is configured%s", VTYNL);
           return CMD_WARNING;
         }
     }
@@ -791,7 +791,7 @@ DEFUN (no_bgp_multiple_instance,
   ret = bgp_option_unset (BGP_OPT_MULTIPLE_INSTANCE);
   if (ret < 0)
     {
-      vty_out (vty, "%% There are more than two BGP instances%s", VTY_NEWLINE);
+      vty_out (vty, "%% There are more than two BGP instances%s", VTYNL);
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -872,13 +872,13 @@ DEFUN_NOSH (router_bgp,
 
       if (bgp == NULL)
         {
-          vty_out (vty, "%% No BGP process is configured%s", VTY_NEWLINE);
+          vty_out (vty, "%% No BGP process is configured%s", VTYNL);
           return CMD_WARNING;
         }
 
       if (listcount(bm->bgp) > 1)
         {
-          vty_out (vty, "%% Multiple BGP processes are configured%s", VTY_NEWLINE);
+          vty_out (vty, "%% Multiple BGP processes are configured%s", VTYNL);
           return CMD_WARNING;
         }
     }
@@ -904,15 +904,15 @@ DEFUN_NOSH (router_bgp,
         {
         case BGP_ERR_MULTIPLE_INSTANCE_NOT_SET:
           vty_out (vty, "Please specify 'bgp multiple-instance' first%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           return CMD_WARNING;
         case BGP_ERR_AS_MISMATCH:
-          vty_out (vty, "BGP is already running; AS is %u%s", as, VTY_NEWLINE);
+          vty_out (vty, "BGP is already running; AS is %u%s", as, VTYNL);
           return CMD_WARNING;
         case BGP_ERR_INSTANCE_MISMATCH:
-          vty_out (vty, "BGP instance name and AS number mismatch%s", VTY_NEWLINE);
+          vty_out (vty, "BGP instance name and AS number mismatch%s", VTYNL);
           vty_out (vty, "BGP instance is already running; AS is %u%s",
-                   as, VTY_NEWLINE);
+                   as, VTYNL);
           return CMD_WARNING;
         }
 
@@ -948,13 +948,13 @@ DEFUN (no_router_bgp,
 
       if (bgp == NULL)
         {
-          vty_out (vty, "%% No BGP process is configured%s", VTY_NEWLINE);
+          vty_out (vty, "%% No BGP process is configured%s", VTYNL);
           return CMD_WARNING;
         }
 
       if (listcount(bm->bgp) > 1)
         {
-          vty_out (vty, "%% Multiple BGP processes are configured%s", VTY_NEWLINE);
+          vty_out (vty, "%% Multiple BGP processes are configured%s", VTYNL);
           return CMD_WARNING;
         }
     }
@@ -969,7 +969,7 @@ DEFUN (no_router_bgp,
       bgp = bgp_lookup (as, name);
       if (! bgp)
         {
-          vty_out (vty, "%% Can't find BGP instance%s", VTY_NEWLINE);
+          vty_out (vty, "%% Can't find BGP instance%s", VTYNL);
           return CMD_WARNING;
         }
     }
@@ -1009,7 +1009,7 @@ DEFPY (no_bgp_router_id,
     {
       if (! IPV4_ADDR_SAME (&bgp->router_id_static, &router_id))
 	{
-	  vty_out (vty, "%% BGP router-id doesn't match%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% BGP router-id doesn't match%s");
 	  return CMD_WARNING;
 	}
     }
@@ -1038,7 +1038,7 @@ DEFUN (bgp_cluster_id,
   ret = inet_aton (argv[idx_ipv4]->arg, &cluster);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed bgp cluster identifier%s", VTY_NEWLINE);
+      vty_out (vty, "%% Malformed bgp cluster identifier%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -1118,7 +1118,7 @@ DEFUN (bgp_confederation_peers,
       if (bgp->as == as)
 	{
 	  vty_out (vty, "%% Local member-AS not allowed in confed peer list%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  continue;
 	}
 
@@ -1189,7 +1189,7 @@ bgp_maxpaths_config_vty (struct vty *vty, int peer_type, const char *mpaths,
 	       "%% Failed to %sset maximum-paths %s %u for afi %u, safi %u%s",
 	       (set == 1) ? "" : "un",
 	       (peer_type == BGP_PEER_EBGP) ? "ebgp" : "ibgp",
-	       maxpaths, afi, safi, VTY_NEWLINE);
+	       maxpaths, afi, safi, VTYNL);
       return CMD_WARNING;
     }
 
@@ -1324,7 +1324,7 @@ bgp_update_delay_config_vty (struct vty *vty, const char *delay,
   if (update_delay < establish_wait)
     {
       vty_out (vty, "%%Failed: update-delay less than the establish-wait!%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
@@ -1353,7 +1353,7 @@ bgp_config_write_update_delay (struct vty *vty, struct bgp *bgp)
       vty_out (vty, " update-delay %d", bgp->v_update_delay);
       if (bgp->v_update_delay != bgp->v_establish_wait)
         vty_out (vty, " %d", bgp->v_establish_wait);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 
   return 0;
@@ -1415,7 +1415,7 @@ bgp_config_write_wpkt_quanta (struct vty *vty, struct bgp *bgp)
 {
   if (bgp->wpkt_quanta != BGP_WRITE_PACKET_MAX)
       vty_out (vty, " write-quanta %d%s",
-               bgp->wpkt_quanta, VTY_NEWLINE);
+               bgp->wpkt_quanta, VTYNL);
 
   return 0;
 }
@@ -1449,7 +1449,7 @@ bgp_config_write_coalesce_time (struct vty *vty, struct bgp *bgp)
 {
   if (bgp->coalesce_time != BGP_DEFAULT_SUBGROUP_COALESCE_TIME)
       vty_out (vty, " coalesce-time %u%s",
-               bgp->coalesce_time, VTY_NEWLINE);
+               bgp->coalesce_time, VTYNL);
 
   return 0;
 }
@@ -1584,7 +1584,7 @@ bgp_config_write_maxpaths (struct vty *vty, struct bgp *bgp, afi_t afi,
     {
       bgp_config_write_family_header (vty, afi, safi, write);
       vty_out (vty, "  maximum-paths %d%s",
-	       bgp->maxpaths[afi][safi].maxpaths_ebgp, VTY_NEWLINE);
+	       bgp->maxpaths[afi][safi].maxpaths_ebgp, VTYNL);
     }
 
   if (bgp->maxpaths[afi][safi].maxpaths_ibgp != MULTIPATH_NUM)
@@ -1595,7 +1595,7 @@ bgp_config_write_maxpaths (struct vty *vty, struct bgp *bgp, afi_t afi,
       if (CHECK_FLAG (bgp->maxpaths[afi][safi].ibgp_flags,
 		      BGP_FLAG_IBGP_MULTIPATH_SAME_CLUSTERLEN))
 	vty_out (vty, " equal-cluster-length");
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 
   return 0;
@@ -1624,7 +1624,7 @@ DEFUN (bgp_timers,
   if (holdtime < 3 && holdtime != 0)
     {
       vty_out (vty, "%% hold time value must be either 0 or greater than 3%s",
-	       VTY_NEWLINE);
+	       VTYNL);
       return CMD_WARNING;
     }
 
@@ -1759,7 +1759,7 @@ DEFUN (no_bgp_deterministic_med,
       if (bestpath_per_as_used)
         {
           vty_out (vty, "bgp deterministic-med cannot be disabled while addpath-tx-bestpath-per-AS is in use%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           return CMD_WARNING;
         }
       else
@@ -2452,7 +2452,7 @@ DEFUN (bgp_listen_range,
   ret = str2prefix (prefix, &range);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed listen range%s", VTY_NEWLINE);
+      vty_out (vty, "%% Malformed listen range%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2461,7 +2461,7 @@ DEFUN (bgp_listen_range,
   if (afi == AFI_IP6 && IN6_IS_ADDR_LINKLOCAL (&range.u.prefix6))
     {
       vty_out (vty, "%% Malformed listen range (link-local address)%s",
-	       VTY_NEWLINE);
+	       VTYNL);
       return CMD_WARNING;
     }
 
@@ -2476,7 +2476,7 @@ DEFUN (bgp_listen_range,
       else
         {
           vty_out (vty, "%% Same listen range is attached to peer-group %s%s",
-                   existing_group->name, VTY_NEWLINE);
+                   existing_group->name, VTYNL);
           return CMD_WARNING;
         }
     }
@@ -2485,14 +2485,14 @@ DEFUN (bgp_listen_range,
   if (listen_range_exists (bgp, &range, 0))
     {
       vty_out (vty, "%% Listen range overlaps with existing listen range%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
   group = peer_group_lookup (bgp, peergroup);
   if (! group)
     {
-      vty_out (vty, "%% Configure the peer-group first%s", VTY_NEWLINE);
+      vty_out (vty, "%% Configure the peer-group first%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2528,7 +2528,7 @@ DEFUN (no_bgp_listen_range,
   ret = str2prefix (prefix, &range);
   if (! ret)
     {
-      vty_out (vty, "%% Malformed listen range%s", VTY_NEWLINE);
+      vty_out (vty, "%% Malformed listen range%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2537,7 +2537,7 @@ DEFUN (no_bgp_listen_range,
   if (afi == AFI_IP6 && IN6_IS_ADDR_LINKLOCAL (&range.u.prefix6))
     {
       vty_out (vty, "%% Malformed listen range (link-local address)%s",
-	       VTY_NEWLINE);
+	       VTYNL);
       return CMD_WARNING;
     }
 
@@ -2546,7 +2546,7 @@ DEFUN (no_bgp_listen_range,
   group = peer_group_lookup (bgp, peergroup);
   if (! group)
     {
-      vty_out (vty, "%% Peer-group does not exist%s", VTY_NEWLINE);
+      vty_out (vty, "%% Peer-group does not exist%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2565,7 +2565,7 @@ bgp_config_write_listen (struct vty *vty, struct bgp *bgp)
 
   if (bgp->dynamic_neighbors_limit != BGP_DYNAMIC_NEIGHBORS_LIMIT_DEFAULT)
       vty_out (vty, " bgp listen limit %d%s",
-               bgp->dynamic_neighbors_limit, VTY_NEWLINE);
+               bgp->dynamic_neighbors_limit, VTYNL);
 
   for (ALL_LIST_ELEMENTS (bgp->group, node, nnode, group))
     {
@@ -2575,7 +2575,7 @@ bgp_config_write_listen (struct vty *vty, struct bgp *bgp)
             {
               prefix2str(range, buf, sizeof(buf));
               vty_out(vty, " bgp listen range %s peer-group %s%s",
-                      buf, group->name, VTY_NEWLINE);
+                      buf, group->name, VTYNL);
             }
         }
     }
@@ -2650,7 +2650,7 @@ peer_remote_as_vty (struct vty *vty, const char *peer_str,
           if (ret < 0)
             {
               vty_out (vty, "%% Create the peer-group or interface first%s",
-                       VTY_NEWLINE);
+                       VTYNL);
               return CMD_WARNING;
             }
           return CMD_SUCCESS;
@@ -2661,7 +2661,7 @@ peer_remote_as_vty (struct vty *vty, const char *peer_str,
       if (peer_address_self_check (bgp, &su))
         {
           vty_out (vty, "%% Can not configure the local system as neighbor%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           return CMD_WARNING;
         }
       ret = peer_remote_as (bgp, &su, NULL, &as, as_type, afi, safi);
@@ -2671,10 +2671,10 @@ peer_remote_as_vty (struct vty *vty, const char *peer_str,
   switch (ret)
     {
     case BGP_ERR_PEER_GROUP_MEMBER:
-      vty_out (vty, "%% Peer-group AS %u. Cannot configure remote-as for member%s", as, VTY_NEWLINE);
+      vty_out (vty, "%% Peer-group AS %u. Cannot configure remote-as for member%s", as, VTYNL);
       return CMD_WARNING;
     case BGP_ERR_PEER_GROUP_PEER_TYPE_DIFFERENT:
-      vty_out (vty, "%% The AS# can not be changed from %u to %s, peer-group members must be all internal or all external%s", as, as_str, VTY_NEWLINE);
+      vty_out (vty, "%% The AS# can not be changed from %u to %s, peer-group members must be all internal or all external%s", as, as_str, VTYNL);
       return CMD_WARNING;
     }
   return bgp_vty_return (vty, ret);
@@ -2712,7 +2712,7 @@ peer_conf_interface_get (struct vty *vty, const char *conf_if, afi_t afi,
 
   if (group)
     {
-      vty_out (vty, "%% Name conflict with peer-group %s", VTY_NEWLINE);
+      vty_out (vty, "%% Name conflict with peer-group %s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2792,7 +2792,7 @@ peer_conf_interface_get (struct vty *vty, const char *conf_if, afi_t afi,
       group = peer_group_lookup (bgp, peer_group_name);
       if (! group)
         {
-          vty_out (vty, "%% Configure the peer-group first%s", VTY_NEWLINE);
+          vty_out (vty, "%% Configure the peer-group first%s", VTYNL);
           return CMD_WARNING;
         }
 
@@ -2894,7 +2894,7 @@ DEFUN (neighbor_peer_group,
   peer = peer_lookup_by_conf_if (bgp, argv[idx_word]->arg);
   if (peer)
     {
-      vty_out (vty, "%% Name conflict with interface: %s", VTY_NEWLINE);
+      vty_out (vty, "%% Name conflict with interface: %s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2943,7 +2943,7 @@ DEFUN (no_neighbor,
 	peer_group_delete (group);
       else
 	{
-	  vty_out (vty, "%% Create the peer-group first%s", VTY_NEWLINE);
+	  vty_out (vty, "%% Create the peer-group first%s", VTYNL);
 	  return CMD_WARNING;
 	}
     }
@@ -2955,7 +2955,7 @@ DEFUN (no_neighbor,
           if (peer_dynamic_neighbor (peer))
             {
               vty_out (vty, "%% Operation not allowed on a dynamic neighbor%s",
-                       VTY_NEWLINE);
+                       VTYNL);
               return CMD_WARNING;
             }
 
@@ -2999,7 +2999,7 @@ DEFUN (no_neighbor_interface_config,
     }
   else
     {
-      vty_out (vty, "%% Create the bgp interface first%s", VTY_NEWLINE);
+      vty_out (vty, "%% Create the bgp interface first%s", VTYNL);
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -3022,7 +3022,7 @@ DEFUN (no_neighbor_peer_group,
     peer_group_delete (group);
   else
     {
-      vty_out (vty, "%% Create the peer-group first%s", VTY_NEWLINE);
+      vty_out (vty, "%% Create the peer-group first%s", VTYNL);
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -3057,7 +3057,7 @@ DEFUN (no_neighbor_interface_peer_group_remote_as,
     peer_group_remote_as_delete (group);
   else
     {
-      vty_out (vty, "%% Create the peer-group or interface first%s", VTY_NEWLINE);
+      vty_out (vty, "%% Create the peer-group or interface first%s", VTYNL);
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -3329,7 +3329,7 @@ DEFUN (neighbor_set_peer_group,
       peer = peer_lookup_by_conf_if (bgp, argv[idx_peer]->arg);
       if (!peer)
         {
-          vty_out (vty, "%% Malformed address or name: %s%s", argv[idx_peer]->arg, VTY_NEWLINE);
+          vty_out (vty, "%% Malformed address or name: %s%s", argv[idx_peer]->arg, VTYNL);
           return CMD_WARNING;
         }
     }
@@ -3338,7 +3338,7 @@ DEFUN (neighbor_set_peer_group,
       if (peer_address_self_check (bgp, &su))
         {
           vty_out (vty, "%% Can not configure the local system as neighbor%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           return CMD_WARNING;
         }
 
@@ -3347,7 +3347,7 @@ DEFUN (neighbor_set_peer_group,
       if (peer && peer_dynamic_neighbor (peer))
         {
           vty_out (vty, "%% Operation not allowed on a dynamic neighbor%s",
-	           VTY_NEWLINE);
+	           VTYNL);
           return CMD_WARNING;
         }
     }
@@ -3355,7 +3355,7 @@ DEFUN (neighbor_set_peer_group,
   group = peer_group_lookup (bgp, argv[idx_word]->arg);
   if (! group)
     {
-      vty_out (vty, "%% Configure the peer-group first%s", VTY_NEWLINE);
+      vty_out (vty, "%% Configure the peer-group first%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -3363,7 +3363,7 @@ DEFUN (neighbor_set_peer_group,
 
   if (ret == BGP_ERR_PEER_GROUP_PEER_TYPE_DIFFERENT)
     {
-      vty_out (vty, "%% Peer with AS %u cannot be in this peer-group, members must be all internal or all external%s", as, VTY_NEWLINE);
+      vty_out (vty, "%% Peer with AS %u cannot be in this peer-group, members must be all internal or all external%s", as, VTYNL);
       return CMD_WARNING;
     }
 
@@ -3401,7 +3401,7 @@ DEFUN (no_neighbor_set_peer_group,
   group = peer_group_lookup (bgp, argv[idx_word]->arg);
   if (! group)
     {
-      vty_out (vty, "%% Configure the peer-group first%s", VTY_NEWLINE);
+      vty_out (vty, "%% Configure the peer-group first%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -3436,7 +3436,7 @@ peer_flag_modify_vty (struct vty *vty, const char *ip_str,
    */
   if (peer->conf_if && (flag == PEER_FLAG_DISABLE_CONNECTED_CHECK)) {
     vty_out (vty, "%s is directly connected peer, cannot accept disable-"
-                  "connected-check%s", ip_str, VTY_NEWLINE);
+                  "connected-check%s", ip_str, VTYNL);
     return CMD_WARNING;
   }
 
@@ -4642,7 +4642,7 @@ peer_update_source_vty (struct vty *vty, const char *peer_str,
           if (str2prefix (source_str, &p))
             {
               vty_out (vty, "%% Invalid update-source, remove prefix length %s",
-                       VTY_NEWLINE);
+                       VTYNL);
               return CMD_WARNING;
             }
           else
@@ -6054,7 +6054,7 @@ DEFUN (neighbor_ttl_security,
    */
   if (peer->conf_if && (gtsm_hops > 1)) {
     vty_out (vty, "%s is directly connected peer, hops cannot exceed 1%s",
-                  argv[idx_peer]->arg, VTY_NEWLINE);
+                  argv[idx_peer]->arg, VTYNL);
     return CMD_WARNING;
   }
 
@@ -6287,7 +6287,7 @@ bgp_clear_prefix (struct vty *vty, const char *view_name, const char *ip_str,
       bgp = bgp_lookup_by_name (view_name);
       if (bgp == NULL)
         {
-          vty_out (vty, "%% Can't find BGP instance %s%s", view_name, VTY_NEWLINE);
+          vty_out (vty, "%% Can't find BGP instance %s%s", view_name, VTYNL);
           return CMD_WARNING;
         }
     }
@@ -6296,7 +6296,7 @@ bgp_clear_prefix (struct vty *vty, const char *view_name, const char *ip_str,
       bgp = bgp_get_default ();
       if (bgp == NULL)
         {
-          vty_out (vty, "%% No BGP process is configured%s", VTY_NEWLINE);
+          vty_out (vty, "%% No BGP process is configured%s", VTYNL);
           return CMD_WARNING;
         }
     }
@@ -6305,7 +6305,7 @@ bgp_clear_prefix (struct vty *vty, const char *view_name, const char *ip_str,
   ret = str2prefix (ip_str, &match);
   if (! ret)
     {
-      vty_out (vty, "%% address is malformed%s", VTY_NEWLINE);
+      vty_out (vty, "%% address is malformed%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -6529,11 +6529,11 @@ DEFUN (show_bgp_views,
 
   if (!bgp_option_check (BGP_OPT_MULTIPLE_INSTANCE))
     {
-      vty_out (vty, "BGP Multiple Instance is not enabled%s", VTY_NEWLINE);
+      vty_out (vty, "BGP Multiple Instance is not enabled%s", VTYNL);
       return CMD_WARNING;
     }
 
-  vty_out (vty, "Defined BGP views:%s", VTY_NEWLINE);
+  vty_out (vty, "Defined BGP views:%s", VTYNL);
   for (ALL_LIST_ELEMENTS_RO(inst, node, bgp))
     {
       /* Skip VRFs. */
@@ -6541,7 +6541,7 @@ DEFUN (show_bgp_views,
         continue;
       vty_out (vty, "\t%s (AS%u)%s",
                bgp->name ? bgp->name : "(null)",
-               bgp->as, VTY_NEWLINE);
+               bgp->as, VTYNL);
     }
 
   return CMD_SUCCESS;
@@ -6567,7 +6567,7 @@ DEFUN (show_bgp_vrfs,
 
   if (!bgp_option_check (BGP_OPT_MULTIPLE_INSTANCE))
     {
-      vty_out (vty, "BGP Multiple Instance is not enabled%s", VTY_NEWLINE);
+      vty_out (vty, "BGP Multiple Instance is not enabled%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -6592,7 +6592,7 @@ DEFUN (show_bgp_vrfs,
 
       count++;
       if (!uj && count == 1)
-        vty_out (vty, "%s%s", header, VTY_NEWLINE);
+        vty_out (vty, "%s%s", header, VTYNL);
 
       peers_cfg = peers_estb = 0;
       if (uj)
@@ -6634,7 +6634,7 @@ DEFUN (show_bgp_vrfs,
         vty_out (vty, "%4s  %-5d  %-16s  %9u  %10u  %s%s",
                  type, vrf_id_ui, inet_ntoa (bgp->router_id),
                  peers_cfg, peers_estb, name,
-                 VTY_NEWLINE);
+                 VTYNL);
     }
 
   if (uj)
@@ -6643,14 +6643,14 @@ DEFUN (show_bgp_vrfs,
 
       json_object_int_add(json, "totalVrfs", count);
 
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
     {
       if (count)
         vty_out (vty, "%sTotal number of VRFs (including default): %d%s",
-                 VTY_NEWLINE, count, VTY_NEWLINE);
+                 VTYNL, count, VTYNL);
     }
 
   return CMD_SUCCESS;
@@ -6672,136 +6672,136 @@ DEFUN (show_bgp_memory,
   vty_out (vty, "%ld RIB nodes, using %s of memory%s", count,
            mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct bgp_node)),
-           VTY_NEWLINE);
+           VTYNL);
 
   count = mtype_stats_alloc (MTYPE_BGP_ROUTE);
   vty_out (vty, "%ld BGP routes, using %s of memory%s", count,
            mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct bgp_info)),
-           VTY_NEWLINE);
+           VTYNL);
   if ((count = mtype_stats_alloc (MTYPE_BGP_ROUTE_EXTRA)))
     vty_out (vty, "%ld BGP route ancillaries, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                            count * sizeof (struct bgp_info_extra)),
-             VTY_NEWLINE);
+             VTYNL);
 
   if ((count = mtype_stats_alloc (MTYPE_BGP_STATIC)))
     vty_out (vty, "%ld Static routes, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct bgp_static)),
-             VTY_NEWLINE);
+             VTYNL);
 
   if ((count = mtype_stats_alloc (MTYPE_BGP_PACKET)))
     vty_out (vty, "%ld Packets, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct bpacket)),
-             VTY_NEWLINE);
+             VTYNL);
 
   /* Adj-In/Out */
   if ((count = mtype_stats_alloc (MTYPE_BGP_ADJ_IN)))
     vty_out (vty, "%ld Adj-In entries, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                            count * sizeof (struct bgp_adj_in)),
-             VTY_NEWLINE);
+             VTYNL);
   if ((count = mtype_stats_alloc (MTYPE_BGP_ADJ_OUT)))
     vty_out (vty, "%ld Adj-Out entries, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                            count * sizeof (struct bgp_adj_out)),
-             VTY_NEWLINE);
+             VTYNL);
 
   if ((count = mtype_stats_alloc (MTYPE_BGP_NEXTHOP_CACHE)))
     vty_out (vty, "%ld Nexthop cache entries, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct bgp_nexthop_cache)),
-             VTY_NEWLINE);
+             VTYNL);
 
   if ((count = mtype_stats_alloc (MTYPE_BGP_DAMP_INFO)))
     vty_out (vty, "%ld Dampening entries, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct bgp_damp_info)),
-             VTY_NEWLINE);
+             VTYNL);
 
   /* Attributes */
   count = attr_count();
   vty_out (vty, "%ld BGP attributes, using %s of memory%s", count,
            mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof(struct attr)),
-           VTY_NEWLINE);
+           VTYNL);
   if ((count = mtype_stats_alloc (MTYPE_ATTR_EXTRA)))
     vty_out (vty, "%ld BGP extra attributes, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                            count * sizeof(struct attr_extra)),
-             VTY_NEWLINE);
+             VTYNL);
 
   if ((count = attr_unknown_count()))
-    vty_out (vty, "%ld unknown attributes%s", count, VTY_NEWLINE);
+    vty_out (vty, "%ld unknown attributes%s", count, VTYNL);
 
   /* AS_PATH attributes */
   count = aspath_count ();
   vty_out (vty, "%ld BGP AS-PATH entries, using %s of memory%s", count,
            mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct aspath)),
-           VTY_NEWLINE);
+           VTYNL);
 
   count = mtype_stats_alloc (MTYPE_AS_SEG);
   vty_out (vty, "%ld BGP AS-PATH segments, using %s of memory%s", count,
            mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct assegment)),
-           VTY_NEWLINE);
+           VTYNL);
 
   /* Other attributes */
   if ((count = community_count ()))
     vty_out (vty, "%ld BGP community entries, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct community)),
-             VTY_NEWLINE);
+             VTYNL);
   if ((count = mtype_stats_alloc (MTYPE_ECOMMUNITY)))
     vty_out (vty, "%ld BGP community entries, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct ecommunity)),
-             VTY_NEWLINE);
+             VTYNL);
   if ((count = mtype_stats_alloc (MTYPE_LCOMMUNITY)))
     vty_out (vty, "%ld BGP large-community entries, using %s of memory%s",
              count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct lcommunity)),
-             VTY_NEWLINE);
+             VTYNL);
 
   if ((count = mtype_stats_alloc (MTYPE_CLUSTER)))
     vty_out (vty, "%ld Cluster lists, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct cluster_list)),
-             VTY_NEWLINE);
+             VTYNL);
 
   /* Peer related usage */
   count = mtype_stats_alloc (MTYPE_BGP_PEER);
   vty_out (vty, "%ld peers, using %s of memory%s", count,
            mtype_memstr (memstrbuf, sizeof (memstrbuf),
                          count * sizeof (struct peer)),
-           VTY_NEWLINE);
+           VTYNL);
 
   if ((count = mtype_stats_alloc (MTYPE_PEER_GROUP)))
     vty_out (vty, "%ld peer groups, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                            count * sizeof (struct peer_group)),
-             VTY_NEWLINE);
+             VTYNL);
 
   /* Other */
   if ((count = mtype_stats_alloc (MTYPE_HASH)))
     vty_out (vty, "%ld hash tables, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                            count * sizeof (struct hash)),
-             VTY_NEWLINE);
+             VTYNL);
   if ((count = mtype_stats_alloc (MTYPE_HASH_BACKET)))
     vty_out (vty, "%ld hash buckets, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                            count * sizeof (struct hash_backet)),
-             VTY_NEWLINE);
+             VTYNL);
   if ((count = mtype_stats_alloc (MTYPE_BGP_REGEXP)))
     vty_out (vty, "%ld compiled regexes, using %s of memory%s", count,
              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                            count * sizeof (regex_t)),
-             VTY_NEWLINE);
+             VTYNL);
   return CMD_SUCCESS;
 }
 
@@ -6893,7 +6893,7 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
                   vty_out (vty,
                            "BGP router identifier %s, local AS number %u vrf-id %d",
                            inet_ntoa (bgp->router_id), bgp->as, vrf_id_ui);
-                  vty_out (vty, "%s", VTY_NEWLINE);
+                  vty_out (vty, "%s", VTYNL);
                 }
 
               if (bgp_update_delay_configured(bgp))
@@ -6928,29 +6928,29 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
                   else
                     {
                       vty_out (vty, "Read-only mode update-delay limit: %d seconds%s",
-                               bgp->v_update_delay, VTY_NEWLINE);
+                               bgp->v_update_delay, VTYNL);
                       if (bgp->v_update_delay != bgp->v_establish_wait)
                         vty_out (vty, "                   Establish wait: %d seconds%s",
-                                 bgp->v_establish_wait, VTY_NEWLINE);
+                                 bgp->v_establish_wait, VTYNL);
 
                       if (bgp_update_delay_active(bgp))
                         {
                           vty_out (vty, "  First neighbor established: %s%s",
-                                   bgp->update_delay_begin_time, VTY_NEWLINE);
-                          vty_out (vty, "  Delay in progress%s", VTY_NEWLINE);
+                                   bgp->update_delay_begin_time, VTYNL);
+                          vty_out (vty, "  Delay in progress%s", VTYNL);
                         }
                       else
                         {
                           if (bgp->update_delay_over)
                             {
                               vty_out (vty, "  First neighbor established: %s%s",
-                                       bgp->update_delay_begin_time, VTY_NEWLINE);
+                                       bgp->update_delay_begin_time, VTYNL);
                               vty_out (vty, "          Best-paths resumed: %s%s",
-                                       bgp->update_delay_end_time, VTY_NEWLINE);
+                                       bgp->update_delay_end_time, VTYNL);
                               vty_out (vty, "        zebra update resumed: %s%s",
-                                       bgp->update_delay_zebra_resume_time, VTY_NEWLINE);
+                                       bgp->update_delay_zebra_resume_time, VTYNL);
                               vty_out (vty, "        peers update resumed: %s%s",
-                                       bgp->update_delay_peers_resume_time, VTY_NEWLINE);
+                                       bgp->update_delay_peers_resume_time, VTYNL);
                             }
                         }
                     }
@@ -6985,18 +6985,18 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
               else
                 {
                   if (bgp_maxmed_onstartup_configured(bgp) && bgp->maxmed_active)
-                    vty_out (vty, "Max-med on-startup active%s", VTY_NEWLINE);
+                    vty_out (vty, "Max-med on-startup active%s", VTYNL);
                   if (bgp->v_maxmed_admin)
-                    vty_out (vty, "Max-med administrative active%s", VTY_NEWLINE);
+                    vty_out (vty, "Max-med administrative active%s", VTYNL);
 
                  vty_out(vty, "BGP table version %" PRIu64 "%s",
-                         bgp_table_version(bgp->rib[afi][safi]), VTY_NEWLINE);
+                         bgp_table_version(bgp->rib[afi][safi]), VTYNL);
 
                   ents = bgp_table_count (bgp->rib[afi][safi]);
                   vty_out (vty, "RIB entries %ld, using %s of memory%s", ents,
                            mtype_memstr (memstrbuf, sizeof (memstrbuf),
                                          ents * sizeof (struct bgp_node)),
-                           VTY_NEWLINE);
+                           VTYNL);
 
                   /* Peer related usage */
                   ents = listcount (bgp->peer);
@@ -7004,22 +7004,22 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
                            ents,
                            mtype_memstr (memstrbuf, sizeof (memstrbuf),
                                          ents * sizeof (struct peer)),
-                           VTY_NEWLINE);
+                           VTYNL);
 
                   if ((ents = listcount (bgp->group)))
                     vty_out (vty, "Peer groups %ld, using %s of memory%s", ents,
                              mtype_memstr (memstrbuf, sizeof (memstrbuf),
                                            ents * sizeof (struct peer_group)),
-                             VTY_NEWLINE);
+                             VTYNL);
 
                   if (CHECK_FLAG (bgp->af_flags[afi][safi], BGP_CONFIG_DAMPENING))
-                    vty_out (vty, "Dampening enabled.%s", VTY_NEWLINE);
-                  vty_out (vty, "%s", VTY_NEWLINE);
+                    vty_out (vty, "Dampening enabled.%s", VTYNL);
+                  vty_out (vty, "%s", VTYNL);
 
                   /* Subtract 8 here because 'Neighbor' is 8 characters */
                   vty_out (vty, "Neighbor");
                   vty_out (vty, "%*s", max_neighbor_width - 8, " ");
-                  vty_out (vty, "V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd%s", VTY_NEWLINE);
+                  vty_out (vty, "V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd%s", VTYNL);
                 }
             }
 
@@ -7114,7 +7114,7 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
                   else
                     vty_out (vty, " %12s", lookup_msg(bgp_status_msg, peer->status, NULL));
                 }
-              vty_out (vty, "%s", VTY_NEWLINE);
+              vty_out (vty, "%s", VTYNL);
             }
 	}
     }
@@ -7126,30 +7126,30 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
       json_object_int_add(json, "totalPeers", count);
       json_object_int_add(json, "dynamicPeers", dn_count);
 
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
     {
       if (count)
-        vty_out (vty, "%sTotal number of neighbors %d%s", VTY_NEWLINE,
-                count, VTY_NEWLINE);
+        vty_out (vty, "%sTotal number of neighbors %d%s", VTYNL,
+                count, VTYNL);
       else
         {
           if (use_json)
             vty_out(vty, "{\"error\": {\"message\": \"No %s neighbor configured\"}}%s",
-                    afi_safi_print(afi, safi), VTY_NEWLINE);
+                    afi_safi_print(afi, safi), VTYNL);
           else
             vty_out (vty, "No %s neighbor is configured%s",
-                     afi_safi_print(afi, safi), VTY_NEWLINE);
+                     afi_safi_print(afi, safi), VTYNL);
         }
 
       if (dn_count && ! use_json)
         {
-          vty_out(vty, "* - dynamic neighbor%s", VTY_NEWLINE);
+          vty_out(vty, "* - dynamic neighbor%s", VTYNL);
           vty_out(vty,
                   "%d dynamic neighbor(s), limit %d%s",
-                  dn_count, bgp->dynamic_neighbors_limit, VTY_NEWLINE);
+                  dn_count, bgp->dynamic_neighbors_limit, VTYNL);
         }
     }
 
@@ -7188,7 +7188,7 @@ bgp_show_summary_afi_safi (struct vty *vty, struct bgp *bgp, int afi, int safi,
   bool json_output = false;
 
   if (use_json && is_wildcard)
-    vty_out (vty, "{%s", VTY_NEWLINE);
+    vty_out (vty, "{%s", VTYNL);
   if (afi_wildcard)
     afi = 1;                    /* AFI_IP */
   while (afi < AFI_MAX)
@@ -7211,7 +7211,7 @@ bgp_show_summary_afi_safi (struct vty *vty, struct bgp *bgp, int afi, int safi,
                       json = json_object_new_object();
 
                       if (! is_first)
-                        vty_out (vty, ",%s", VTY_NEWLINE);
+                        vty_out (vty, ",%s", VTYNL);
                       else
                         is_first = 0;
 
@@ -7220,7 +7220,7 @@ bgp_show_summary_afi_safi (struct vty *vty, struct bgp *bgp, int afi, int safi,
                   else
                     {
                       vty_out (vty, "%s%s Summary:%s",
-                               VTY_NEWLINE, afi_safi_print(afi, safi), VTY_NEWLINE);
+                               VTYNL, afi_safi_print(afi, safi), VTYNL);
                     }
                 }
               bgp_show_summary (vty, bgp, afi, safi, use_json, json);
@@ -7239,9 +7239,9 @@ bgp_show_summary_afi_safi (struct vty *vty, struct bgp *bgp, int afi, int safi,
     }
 
   if (use_json && is_wildcard)
-    vty_out (vty, "}%s", VTY_NEWLINE);
+    vty_out (vty, "}%s", VTYNL);
   else if (use_json && !json_output)
-    vty_out (vty, "{}%s", VTY_NEWLINE);
+    vty_out (vty, "{}%s", VTYNL);
 }
 
 static void
@@ -7254,7 +7254,7 @@ bgp_show_all_instances_summary_vty (struct vty *vty, afi_t afi, safi_t safi,
   int is_first = 1;
 
   if (use_json)
-    vty_out (vty, "{%s", VTY_NEWLINE);
+    vty_out (vty, "{%s", VTYNL);
 
   for (ALL_LIST_ELEMENTS (bm->bgp, node, nnode, bgp))
     {
@@ -7263,7 +7263,7 @@ bgp_show_all_instances_summary_vty (struct vty *vty, afi_t afi, safi_t safi,
           json = json_object_new_object();
 
           if (! is_first)
-            vty_out (vty, ",%s", VTY_NEWLINE);
+            vty_out (vty, ",%s", VTYNL);
           else
             is_first = 0;
 
@@ -7273,15 +7273,15 @@ bgp_show_all_instances_summary_vty (struct vty *vty, afi_t afi, safi_t safi,
       else
         {
           vty_out (vty, "%sInstance %s:%s",
-                   VTY_NEWLINE,
+                   VTYNL,
                    (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)
-                   ? "Default" : bgp->name, VTY_NEWLINE);
+                   ? "Default" : bgp->name, VTYNL);
         }
       bgp_show_summary_afi_safi (vty, bgp, afi, safi, use_json, json);
     }
 
   if (use_json)
-    vty_out (vty, "}%s", VTY_NEWLINE);
+    vty_out (vty, "}%s", VTYNL);
 
 }
 
@@ -7305,9 +7305,9 @@ bgp_show_summary_vty (struct vty *vty, const char *name,
           if (! bgp)
             {
               if (use_json)
-                vty_out (vty, "{}%s", VTY_NEWLINE);
+                vty_out (vty, "{}%s", VTYNL);
               else
-                vty_out (vty, "%% No such BGP instance exist%s", VTY_NEWLINE);
+                vty_out (vty, "%% No such BGP instance exist%s", VTYNL);
               return CMD_WARNING;
             }
 
@@ -7458,7 +7458,7 @@ bgp_show_peer_afi_orf_cap (struct vty *vty, struct peer *p, afi_t afi, safi_t sa
 	    vty_out (vty, "%sreceived",
 		     CHECK_FLAG (p->af_cap[afi][safi], adv_smcap) ?
 	             ", " : "");
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_out (vty, "%s", VTYNL);
         }
     }
 
@@ -7484,7 +7484,7 @@ bgp_show_peer_afi_orf_cap (struct vty *vty, struct peer *p, afi_t afi, safi_t sa
             vty_out (vty, "%sreceived",
                      CHECK_FLAG (p->af_cap[afi][safi], adv_rmcap) ?
                      ", " : "");
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_out (vty, "%s", VTYNL);
         }
     }
 }
@@ -7690,22 +7690,22 @@ bgp_show_peer_afi (struct vty *vty, struct peer *p, afi_t afi, safi_t safi,
       filter = &p->filter[afi][safi];
 
       vty_out (vty, " For address family: %s%s", afi_safi_print (afi, safi),
-	       VTY_NEWLINE);
+	       VTYNL);
 
       if (peer_group_active(p))
-        vty_out (vty, "  %s peer-group member%s", p->group->name, VTY_NEWLINE);
+        vty_out (vty, "  %s peer-group member%s", p->group->name, VTYNL);
 
       paf = peer_af_find(p, afi, safi);
       if (paf && PAF_SUBGRP(paf))
         {
           vty_out (vty, "  Update group %" PRIu64 ", subgroup %" PRIu64 "%s",
-	           PAF_UPDGRP(paf)->id, PAF_SUBGRP(paf)->id, VTY_NEWLINE);
+	           PAF_UPDGRP(paf)->id, PAF_SUBGRP(paf)->id, VTYNL);
           vty_out (vty, "  Packet Queue length %d%s",
-                   bpacket_queue_virtual_length(paf), VTY_NEWLINE);
+                   bpacket_queue_virtual_length(paf), VTYNL);
         }
       else
         {
-          vty_out(vty, "  Not part of any update group%s", VTY_NEWLINE);
+          vty_out(vty, "  Not part of any update group%s", VTYNL);
         }
       if (CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_ADV)
           || CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_RCV)
@@ -7713,7 +7713,7 @@ bgp_show_peer_afi (struct vty *vty, struct peer *p, afi_t afi, safi_t safi,
           || CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_ADV)
           || CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_RCV)
           || CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_OLD_RCV))
-        vty_out (vty, "  AF-dependant capabilities:%s", VTY_NEWLINE);
+        vty_out (vty, "  AF-dependant capabilities:%s", VTYNL);
 
       if (CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_ADV)
           || CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_SM_RCV)
@@ -7721,7 +7721,7 @@ bgp_show_peer_afi (struct vty *vty, struct peer *p, afi_t afi, safi_t safi,
           || CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_RCV))
         {
           vty_out (vty, "    Outbound Route Filter (ORF) type (%d) Prefix-list:%s",
-                   ORF_TYPE_PREFIX, VTY_NEWLINE);
+                   ORF_TYPE_PREFIX, VTYNL);
           bgp_show_peer_afi_orf_cap (vty, p, afi, safi,
 				     PEER_CAP_ORF_PREFIX_SM_ADV,
 				     PEER_CAP_ORF_PREFIX_RM_ADV,
@@ -7734,7 +7734,7 @@ bgp_show_peer_afi (struct vty *vty, struct peer *p, afi_t afi, safi_t safi,
           || CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ORF_PREFIX_RM_OLD_RCV))
         {
           vty_out (vty, "    Outbound Route Filter (ORF) type (%d) Prefix-list:%s",
-	           ORF_TYPE_PREFIX_OLD, VTY_NEWLINE);
+	           ORF_TYPE_PREFIX_OLD, VTYNL);
           bgp_show_peer_afi_orf_cap (vty, p, afi, safi,
 				     PEER_CAP_ORF_PREFIX_SM_ADV,
 				     PEER_CAP_ORF_PREFIX_RM_ADV,
@@ -7753,45 +7753,45 @@ bgp_show_peer_afi (struct vty *vty, struct peer *p, afi_t afi, safi_t safi,
 	      vty_out (vty, " sent;");
           if (orf_pfx_count)
             vty_out (vty, " received (%d entries)", orf_pfx_count);
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_out (vty, "%s", VTYNL);
         }
       if (CHECK_FLAG (p->af_sflags[afi][safi], PEER_STATUS_ORF_WAIT_REFRESH))
-          vty_out (vty, "  First update is deferred until ORF or ROUTE-REFRESH is received%s", VTY_NEWLINE);
+          vty_out (vty, "  First update is deferred until ORF or ROUTE-REFRESH is received%s", VTYNL);
 
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_REFLECTOR_CLIENT))
-        vty_out (vty, "  Route-Reflector Client%s", VTY_NEWLINE);
+        vty_out (vty, "  Route-Reflector Client%s", VTYNL);
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_RSERVER_CLIENT))
-        vty_out (vty, "  Route-Server Client%s", VTY_NEWLINE);
+        vty_out (vty, "  Route-Server Client%s", VTYNL);
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_SOFT_RECONFIG))
-        vty_out (vty, "  Inbound soft reconfiguration allowed%s", VTY_NEWLINE);
+        vty_out (vty, "  Inbound soft reconfiguration allowed%s", VTYNL);
 
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_REMOVE_PRIVATE_AS_ALL_REPLACE))
-        vty_out (vty, "  Private AS numbers (all) replaced in updates to this neighbor%s", VTY_NEWLINE);
+        vty_out (vty, "  Private AS numbers (all) replaced in updates to this neighbor%s", VTYNL);
       else if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_REMOVE_PRIVATE_AS_REPLACE))
-        vty_out (vty, "  Private AS numbers replaced in updates to this neighbor%s", VTY_NEWLINE);
+        vty_out (vty, "  Private AS numbers replaced in updates to this neighbor%s", VTYNL);
       else if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_REMOVE_PRIVATE_AS_ALL))
-        vty_out (vty, "  Private AS numbers (all) removed in updates to this neighbor%s", VTY_NEWLINE);
+        vty_out (vty, "  Private AS numbers (all) removed in updates to this neighbor%s", VTYNL);
       else if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_REMOVE_PRIVATE_AS))
-        vty_out (vty, "  Private AS numbers removed in updates to this neighbor%s", VTY_NEWLINE);
+        vty_out (vty, "  Private AS numbers removed in updates to this neighbor%s", VTYNL);
 
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_ADDPATH_TX_ALL_PATHS))
-        vty_out (vty, "  Advertise all paths via addpath%s", VTY_NEWLINE);
+        vty_out (vty, "  Advertise all paths via addpath%s", VTYNL);
 
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_ADDPATH_TX_BESTPATH_PER_AS))
-        vty_out (vty, "  Advertise bestpath per AS via addpath%s", VTY_NEWLINE);
+        vty_out (vty, "  Advertise bestpath per AS via addpath%s", VTYNL);
 
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_AS_OVERRIDE))
-        vty_out (vty, "  Override ASNs in outbound updates if aspath equals remote-as%s", VTY_NEWLINE);
+        vty_out (vty, "  Override ASNs in outbound updates if aspath equals remote-as%s", VTYNL);
 
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_NEXTHOP_SELF) ||
           CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_FORCE_NEXTHOP_SELF))
-        vty_out (vty, "  NEXT_HOP is always this router%s", VTY_NEWLINE);
+        vty_out (vty, "  NEXT_HOP is always this router%s", VTYNL);
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_AS_PATH_UNCHANGED))
-        vty_out (vty, "  AS_PATH is propagated unchanged to this neighbor%s", VTY_NEWLINE);
+        vty_out (vty, "  AS_PATH is propagated unchanged to this neighbor%s", VTYNL);
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_NEXTHOP_UNCHANGED))
-        vty_out (vty, "  NEXT_HOP is propagated unchanged to this neighbor%s", VTY_NEWLINE);
+        vty_out (vty, "  NEXT_HOP is propagated unchanged to this neighbor%s", VTYNL);
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_MED_UNCHANGED))
-        vty_out (vty, "  MED is propagated unchanged to this neighbor%s", VTY_NEWLINE);
+        vty_out (vty, "  MED is propagated unchanged to this neighbor%s", VTYNL);
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_SEND_COMMUNITY)
           || CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_SEND_EXT_COMMUNITY)
           || CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_SEND_LARGE_COMMUNITY))
@@ -7800,13 +7800,13 @@ bgp_show_peer_afi (struct vty *vty, struct peer *p, afi_t afi, safi_t safi,
           if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_SEND_COMMUNITY)
               && CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_SEND_EXT_COMMUNITY)
               && CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_SEND_LARGE_COMMUNITY))
-            vty_out (vty, "(all)%s", VTY_NEWLINE);
+            vty_out (vty, "(all)%s", VTYNL);
           else if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_SEND_LARGE_COMMUNITY))
-            vty_out (vty, "(large)%s", VTY_NEWLINE);
+            vty_out (vty, "(large)%s", VTYNL);
           else if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_SEND_EXT_COMMUNITY))
-	    vty_out (vty, "(extended)%s", VTY_NEWLINE);
+	    vty_out (vty, "(extended)%s", VTYNL);
           else
-	    vty_out (vty, "(standard)%s", VTY_NEWLINE);
+	    vty_out (vty, "(standard)%s", VTYNL);
         }
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_DEFAULT_ORIGINATE))
         {
@@ -7817,94 +7817,94 @@ bgp_show_peer_afi (struct vty *vty, struct peer *p, afi_t afi, safi_t safi,
 	             p->default_rmap[afi][safi].map ? "*" : "",
 	             p->default_rmap[afi][safi].name);
           if (paf && PAF_SUBGRP(paf) && CHECK_FLAG(PAF_SUBGRP(paf)->sflags, SUBGRP_STATUS_DEFAULT_ORIGINATE))
-            vty_out (vty, " default sent%s", VTY_NEWLINE);
+            vty_out (vty, " default sent%s", VTYNL);
           else
-            vty_out (vty, " default not sent%s", VTY_NEWLINE);
+            vty_out (vty, " default not sent%s", VTYNL);
         }
 
       if (filter->plist[FILTER_IN].name
           || filter->dlist[FILTER_IN].name
           || filter->aslist[FILTER_IN].name
           || filter->map[RMAP_IN].name)
-        vty_out (vty, "  Inbound path policy configured%s", VTY_NEWLINE);
+        vty_out (vty, "  Inbound path policy configured%s", VTYNL);
       if (filter->plist[FILTER_OUT].name
           || filter->dlist[FILTER_OUT].name
           || filter->aslist[FILTER_OUT].name
           || filter->map[RMAP_OUT].name
           || filter->usmap.name)
-        vty_out (vty, "  Outbound path policy configured%s", VTY_NEWLINE);
+        vty_out (vty, "  Outbound path policy configured%s", VTYNL);
 
       /* prefix-list */
       if (filter->plist[FILTER_IN].name)
         vty_out (vty, "  Incoming update prefix filter list is %s%s%s",
 	         filter->plist[FILTER_IN].plist ? "*" : "",
 	         filter->plist[FILTER_IN].name,
-	         VTY_NEWLINE);
+	         VTYNL);
       if (filter->plist[FILTER_OUT].name)
         vty_out (vty, "  Outgoing update prefix filter list is %s%s%s",
 	         filter->plist[FILTER_OUT].plist ? "*" : "",
 	         filter->plist[FILTER_OUT].name,
-	         VTY_NEWLINE);
+	         VTYNL);
 
       /* distribute-list */
       if (filter->dlist[FILTER_IN].name)
         vty_out (vty, "  Incoming update network filter list is %s%s%s",
 	         filter->dlist[FILTER_IN].alist ? "*" : "",
 	         filter->dlist[FILTER_IN].name,
-	         VTY_NEWLINE);
+	         VTYNL);
       if (filter->dlist[FILTER_OUT].name)
         vty_out (vty, "  Outgoing update network filter list is %s%s%s",
 	         filter->dlist[FILTER_OUT].alist ? "*" : "",
 	         filter->dlist[FILTER_OUT].name,
-	         VTY_NEWLINE);
+	         VTYNL);
 
       /* filter-list. */
       if (filter->aslist[FILTER_IN].name)
         vty_out (vty, "  Incoming update AS path filter list is %s%s%s",
 	         filter->aslist[FILTER_IN].aslist ? "*" : "",
 	         filter->aslist[FILTER_IN].name,
-	         VTY_NEWLINE);
+	         VTYNL);
       if (filter->aslist[FILTER_OUT].name)
         vty_out (vty, "  Outgoing update AS path filter list is %s%s%s",
 	         filter->aslist[FILTER_OUT].aslist ? "*" : "",
 	         filter->aslist[FILTER_OUT].name,
-	         VTY_NEWLINE);
+	         VTYNL);
 
       /* route-map. */
       if (filter->map[RMAP_IN].name)
         vty_out (vty, "  Route map for incoming advertisements is %s%s%s",
                  filter->map[RMAP_IN].map ? "*" : "",
                  filter->map[RMAP_IN].name,
-	         VTY_NEWLINE);
+	         VTYNL);
       if (filter->map[RMAP_OUT].name)
         vty_out (vty, "  Route map for outgoing advertisements is %s%s%s",
                  filter->map[RMAP_OUT].map ? "*" : "",
                  filter->map[RMAP_OUT].name,
-                 VTY_NEWLINE);
+                 VTYNL);
 
       /* unsuppress-map */
       if (filter->usmap.name)
         vty_out (vty, "  Route map for selective unsuppress is %s%s%s",
 	         filter->usmap.map ? "*" : "",
-	         filter->usmap.name, VTY_NEWLINE);
+	         filter->usmap.name, VTYNL);
 
       /* Receive prefix count */
-      vty_out (vty, "  %ld accepted prefixes%s", p->pcount[afi][safi], VTY_NEWLINE);
+      vty_out (vty, "  %ld accepted prefixes%s", p->pcount[afi][safi], VTYNL);
 
       /* Maximum prefix */
       if (CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_MAX_PREFIX))
         {
           vty_out (vty, "  Maximum prefixes allowed %ld%s%s", p->pmax[afi][safi],
 	           CHECK_FLAG (p->af_flags[afi][safi], PEER_FLAG_MAX_PREFIX_WARNING)
-	           ? " (warning-only)" : "", VTY_NEWLINE);
+	           ? " (warning-only)" : "", VTYNL);
           vty_out (vty, "  Threshold for warning message %d%%",
 	           p->pmax_threshold[afi][safi]);
           if (p->pmax_restart[afi][safi])
             vty_out (vty, ", restart interval %d min", p->pmax_restart[afi][safi]);
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_out (vty, "%s", VTYNL);
         }
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 }
 
@@ -7991,9 +7991,9 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
       else
         {
           if (CHECK_FLAG(bgp->config, BGP_CONFIG_CONFEDERATION))
-            vty_out (vty, "confed-internal link%s", VTY_NEWLINE);
+            vty_out (vty, "confed-internal link%s", VTYNL);
           else
-            vty_out (vty, "internal link%s", VTY_NEWLINE);
+            vty_out (vty, "internal link%s", VTYNL);
         }
     }
   else
@@ -8008,9 +8008,9 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
       else
         {
          if (bgp_confederation_peers_check(bgp, p->as))
-           vty_out (vty, "confed-external link%s", VTY_NEWLINE);
+           vty_out (vty, "confed-external link%s", VTYNL);
          else
-           vty_out (vty, "external link%s", VTY_NEWLINE);
+           vty_out (vty, "external link%s", VTYNL);
         }
     }
 
@@ -8020,7 +8020,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
       if (use_json)
         json_object_string_add(json_neigh, "nbrDesc", p->desc);
       else
-        vty_out (vty, " Description: %s%s", p->desc, VTY_NEWLINE);
+        vty_out (vty, " Description: %s%s", p->desc, VTYNL);
     }
 
   if (p->hostname)
@@ -8037,9 +8037,9 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         {
           if (p->domainname && (p->domainname[0] != '\0'))
             vty_out(vty, "Hostname: %s.%s%s", p->hostname, p->domainname,
-                    VTY_NEWLINE);
+                    VTYNL);
           else
-            vty_out(vty, "Hostname: %s%s", p->hostname, VTY_NEWLINE);
+            vty_out(vty, "Hostname: %s%s", p->hostname, VTYNL);
         }
 
     }
@@ -8068,7 +8068,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
       else
         {
           vty_out (vty, " Member of peer-group %s for session parameters%s",
-                   p->group->name, VTY_NEWLINE);
+                   p->group->name, VTYNL);
 
           if (dn_flag[0])
             {
@@ -8080,7 +8080,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
               if (range)
                 {
                   prefix2str(range, buf1, sizeof(buf1));
-                  vty_out (vty, " Belongs to the subnet range group: %s%s", buf1, VTY_NEWLINE);
+                  vty_out (vty, " Belongs to the subnet range group: %s%s", buf1, VTYNL);
                 }
             }
         }
@@ -8161,18 +8161,18 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
     {
       /* Administrative shutdown. */
       if (CHECK_FLAG (p->flags, PEER_FLAG_SHUTDOWN))
-        vty_out (vty, " Administratively shut down%s", VTY_NEWLINE);
+        vty_out (vty, " Administratively shut down%s", VTYNL);
 
       /* BGP Version. */
       vty_out (vty, "  BGP version 4");
       vty_out (vty, ", remote router ID %s%s",
                inet_ntop (AF_INET, &p->remote_id, buf1, sizeof(buf1)),
-               VTY_NEWLINE);
+               VTYNL);
 
       /* Confederation */
       if (CHECK_FLAG (bgp->config, BGP_CONFIG_CONFEDERATION)
           && bgp_confederation_peers_check (bgp, p->as))
-        vty_out (vty, "  Neighbor under common administration%s", VTY_NEWLINE);
+        vty_out (vty, "  Neighbor under common administration%s", VTYNL);
 
       /* Status. */
       vty_out (vty, "  BGP state = %s", lookup_msg(bgp_status_msg, p->status, NULL));
@@ -8187,21 +8187,21 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         else if (CHECK_FLAG (p->sflags, PEER_STATUS_NSF_WAIT))
                vty_out (vty, " (NSF passive)");
         }
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
 
       /* read timer */
       vty_out (vty, "  Last read %s", peer_uptime (p->readtime, timebuf, BGP_UPTIME_LEN, 0, NULL));
       vty_out (vty, ", Last write %s%s",
-               peer_uptime (p->last_write, timebuf, BGP_UPTIME_LEN, 0, NULL), VTY_NEWLINE);
+               peer_uptime (p->last_write, timebuf, BGP_UPTIME_LEN, 0, NULL), VTYNL);
 
       /* Configured timer values. */
       vty_out (vty, "  Hold time is %d, keepalive interval is %d seconds%s",
-	       p->v_holdtime, p->v_keepalive, VTY_NEWLINE);
+	       p->v_holdtime, p->v_keepalive, VTYNL);
       if (CHECK_FLAG (p->config, PEER_CONFIG_TIMER))
         {
           vty_out (vty, "  Configured hold time is %d", p->holdtime);
           vty_out (vty, ", keepalive interval is %d seconds%s",
-	           p->keepalive, VTY_NEWLINE);
+	           p->keepalive, VTYNL);
         }
     }
   /* Capability. */
@@ -8433,7 +8433,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
             }
           else
             {
-	      vty_out (vty, "  Neighbor capabilities:%s", VTY_NEWLINE);
+	      vty_out (vty, "  Neighbor capabilities:%s", VTYNL);
 
 	      /* AS4 */
 	      if (CHECK_FLAG (p->cap, PEER_CAP_AS4_RCV)
@@ -8445,14 +8445,14 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
 	          if (CHECK_FLAG (p->cap, PEER_CAP_AS4_RCV))
 		    vty_out (vty, " %sreceived",
 			     CHECK_FLAG (p->cap, PEER_CAP_AS4_ADV) ? "and " : "");
-	          vty_out (vty, "%s", VTY_NEWLINE);
+	          vty_out (vty, "%s", VTYNL);
 	        }
 
 	      /* AddPath */
 	      if (CHECK_FLAG (p->cap, PEER_CAP_ADDPATH_RCV)
 	          || CHECK_FLAG (p->cap, PEER_CAP_ADDPATH_ADV))
                 {
-	          vty_out (vty, "    AddPath:%s", VTY_NEWLINE);
+	          vty_out (vty, "    AddPath:%s", VTYNL);
 
                   for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
                     for (safi = SAFI_UNICAST ; safi < SAFI_MAX ; safi++)
@@ -8468,7 +8468,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
                             if (CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ADDPATH_AF_TX_RCV))
                               vty_out (vty, "%sreceived", CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ADDPATH_AF_TX_ADV) ? " and " : "" );
 
-                            vty_out (vty, "%s", VTY_NEWLINE);
+                            vty_out (vty, "%s", VTYNL);
                           }
 
                         if (CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ADDPATH_AF_RX_ADV) ||
@@ -8482,7 +8482,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
                             if (CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ADDPATH_AF_RX_RCV))
                               vty_out (vty, "%sreceived", CHECK_FLAG (p->af_cap[afi][safi], PEER_CAP_ADDPATH_AF_RX_ADV) ? " and " : "" );
 
-                            vty_out (vty, "%s", VTY_NEWLINE);
+                            vty_out (vty, "%s", VTYNL);
                           }
                       }
                 }
@@ -8497,7 +8497,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
 	          if (CHECK_FLAG (p->cap, PEER_CAP_DYNAMIC_RCV))
 		    vty_out (vty, " %sreceived",
 			     CHECK_FLAG (p->cap, PEER_CAP_DYNAMIC_ADV) ? "and " : "");
-	          vty_out (vty, "%s", VTY_NEWLINE);
+	          vty_out (vty, "%s", VTYNL);
 	        }
 
 	      /* Extended nexthop */
@@ -8510,15 +8510,15 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
 	          if (CHECK_FLAG (p->cap, PEER_CAP_ENHE_RCV))
 		    vty_out (vty, " %sreceived",
 			     CHECK_FLAG (p->cap, PEER_CAP_ENHE_ADV) ? "and " : "");
-	          vty_out (vty, "%s", VTY_NEWLINE);
+	          vty_out (vty, "%s", VTYNL);
 
                   if (CHECK_FLAG (p->cap, PEER_CAP_ENHE_RCV))
 		    {
-		      vty_out (vty, "      Address families by peer:%s        ", VTY_NEWLINE);
+		      vty_out (vty, "      Address families by peer:%s        ", VTYNL);
                       for (safi = SAFI_UNICAST ; safi < SAFI_MAX ; safi++)
                         if (CHECK_FLAG (p->af_cap[AFI_IP][safi], PEER_CAP_ENHE_AF_RCV))
                           vty_out (vty, "           %s%s",
-                                   afi_safi_print (AFI_IP, safi), VTY_NEWLINE);
+                                   afi_safi_print (AFI_IP, safi), VTYNL);
                     }
 	        }
 
@@ -8538,7 +8538,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
                              && CHECK_FLAG (p->cap, PEER_CAP_REFRESH_NEW_RCV)) ?
                              "old & new" : CHECK_FLAG (p->cap, PEER_CAP_REFRESH_OLD_RCV) ? "old" : "new");
 
-                  vty_out (vty, "%s", VTY_NEWLINE);
+                  vty_out (vty, "%s", VTYNL);
                 }
 
 	      /* Multiprotocol Extensions */
@@ -8551,7 +8551,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
 		        vty_out (vty, " advertised");
 		      if (p->afc_recv[afi][safi])
 		        vty_out (vty, " %sreceived", p->afc_adv[afi][safi] ? "and " : "");
-		      vty_out (vty, "%s", VTY_NEWLINE);
+		      vty_out (vty, "%s", VTYNL);
 		    }
 
               /* Hostname capability */
@@ -8564,7 +8564,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
                   if (CHECK_FLAG (p->cap, PEER_CAP_HOSTNAME_RCV))
                     vty_out (vty, " %sreceived",
                              CHECK_FLAG (p->cap, PEER_CAP_HOSTNAME_ADV) ? "and " : "");
-                  vty_out (vty, "%s", VTY_NEWLINE);
+                  vty_out (vty, "%s", VTYNL);
                 }
 
 	      /* Gracefull Restart */
@@ -8577,15 +8577,15 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
 	          if (CHECK_FLAG (p->cap, PEER_CAP_RESTART_RCV))
 		    vty_out (vty, " %sreceived",
 			     CHECK_FLAG (p->cap, PEER_CAP_RESTART_ADV) ? "and " : "");
-	          vty_out (vty, "%s", VTY_NEWLINE);
+	          vty_out (vty, "%s", VTYNL);
 
 	          if (CHECK_FLAG (p->cap, PEER_CAP_RESTART_RCV))
 		    {
 		      int restart_af_count = 0;
 
 		      vty_out (vty, "      Remote Restart timer is %d seconds%s",
-			       p->v_gr_restart, VTY_NEWLINE);
-		      vty_out (vty, "      Address families by peer:%s        ", VTY_NEWLINE);
+			       p->v_gr_restart, VTYNL);
+		      vty_out (vty, "      Address families by peer:%s        ", VTYNL);
 
 		      for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
 		        for (safi = SAFI_UNICAST ; safi < SAFI_MAX ; safi++)
@@ -8599,7 +8599,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
 			    }
 		      if (! restart_af_count)
 		        vty_out (vty, "none");
-		      vty_out (vty, "%s", VTY_NEWLINE);
+		      vty_out (vty, "%s", VTYNL);
 	            }
 	        }
             }
@@ -8662,7 +8662,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         }
       else
         {
-          vty_out (vty, "  Graceful restart informations:%s", VTY_NEWLINE);
+          vty_out (vty, "  Graceful restart informations:%s", VTYNL);
           if (p->status == Established)
 	    {
 	      vty_out (vty, "    End-of-RIB send: ");
@@ -8678,7 +8678,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
 		        }
                     }
                 }
-	      vty_out (vty, "%s", VTY_NEWLINE);
+	      vty_out (vty, "%s", VTYNL);
 	      vty_out (vty, "    End-of-RIB received: ");
 	      for (afi = AFI_IP ; afi < AFI_MAX ; afi++)
 	        {
@@ -8692,16 +8692,16 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
                         }
 		    }
                 }
-	      vty_out (vty, "%s", VTY_NEWLINE);
+	      vty_out (vty, "%s", VTYNL);
             }
 
           if (p->t_gr_restart)
             vty_out (vty, "    The remaining time of restart timer is %ld%s",
-                     thread_timer_remain_second (p->t_gr_restart), VTY_NEWLINE);
+                     thread_timer_remain_second (p->t_gr_restart), VTYNL);
 
           if (p->t_gr_stale)
             vty_out (vty, "    The remaining time of stalepath timer is %ld%s",
-                     thread_timer_remain_second (p->t_gr_stale), VTY_NEWLINE);
+                     thread_timer_remain_second (p->t_gr_stale), VTYNL);
         }
     }
   if (use_json)
@@ -8730,20 +8730,20 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
   else
     {
       /* Packet counts. */
-      vty_out (vty, "  Message statistics:%s", VTY_NEWLINE);
-      vty_out (vty, "    Inq depth is 0%s", VTY_NEWLINE);
-      vty_out (vty, "    Outq depth is %lu%s", (unsigned long) p->obuf->count, VTY_NEWLINE);
-      vty_out (vty, "                         Sent       Rcvd%s", VTY_NEWLINE);
-      vty_out (vty, "    Opens:         %10d %10d%s", p->open_out, p->open_in, VTY_NEWLINE);
-      vty_out (vty, "    Notifications: %10d %10d%s", p->notify_out, p->notify_in, VTY_NEWLINE);
-      vty_out (vty, "    Updates:       %10d %10d%s", p->update_out, p->update_in, VTY_NEWLINE);
-      vty_out (vty, "    Keepalives:    %10d %10d%s", p->keepalive_out, p->keepalive_in, VTY_NEWLINE);
-      vty_out (vty, "    Route Refresh: %10d %10d%s", p->refresh_out, p->refresh_in, VTY_NEWLINE);
-      vty_out (vty, "    Capability:    %10d %10d%s", p->dynamic_cap_out, p->dynamic_cap_in, VTY_NEWLINE);
+      vty_out (vty, "  Message statistics:%s", VTYNL);
+      vty_out (vty, "    Inq depth is 0%s", VTYNL);
+      vty_out (vty, "    Outq depth is %lu%s", (unsigned long) p->obuf->count, VTYNL);
+      vty_out (vty, "                         Sent       Rcvd%s", VTYNL);
+      vty_out (vty, "    Opens:         %10d %10d%s", p->open_out, p->open_in, VTYNL);
+      vty_out (vty, "    Notifications: %10d %10d%s", p->notify_out, p->notify_in, VTYNL);
+      vty_out (vty, "    Updates:       %10d %10d%s", p->update_out, p->update_in, VTYNL);
+      vty_out (vty, "    Keepalives:    %10d %10d%s", p->keepalive_out, p->keepalive_in, VTYNL);
+      vty_out (vty, "    Route Refresh: %10d %10d%s", p->refresh_out, p->refresh_in, VTYNL);
+      vty_out (vty, "    Capability:    %10d %10d%s", p->dynamic_cap_out, p->dynamic_cap_in, VTYNL);
       vty_out (vty, "    Total:         %10d %10d%s", p->open_out + p->notify_out +
                p->update_out + p->keepalive_out + p->refresh_out + p->dynamic_cap_out,
                p->open_in + p->notify_in + p->update_in + p->keepalive_in + p->refresh_in +
-               p->dynamic_cap_in, VTY_NEWLINE);
+               p->dynamic_cap_in, VTYNL);
     }
 
   if (use_json)
@@ -8764,7 +8764,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
     {
       /* advertisement-interval */
       vty_out (vty, "  Minimum time between advertisement runs is %d seconds%s",
-               p->v_routeadv, VTY_NEWLINE);
+               p->v_routeadv, VTYNL);
 
       /* Update-source. */
       if (p->update_if || p->update_source)
@@ -8774,10 +8774,10 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
             vty_out (vty, "%s", p->update_if);
           else if (p->update_source)
             vty_out (vty, "%s", sockunion2str (p->update_source, buf1, SU_ADDRSTRLEN));
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_out (vty, "%s", VTYNL);
         }
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 
   /* Address Family Information */
@@ -8799,14 +8799,14 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
     }
   else
     vty_out (vty, "  Connections established %d; dropped %d%s", p->established, p->dropped,
-	     VTY_NEWLINE);
+	     VTYNL);
 
   if (! p->last_reset)
     {
       if (use_json)
         json_object_string_add(json_neigh, "lastReset", "never");
       else
-        vty_out (vty, "  Last reset never%s", VTY_NEWLINE);
+        vty_out (vty, "  Last reset never%s", VTYNL);
     }
   else
     {
@@ -8861,7 +8861,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
               subcode_str = bgp_notify_subcode_str(p->notify.code, p->notify.subcode);
               vty_out (vty, "due to NOTIFICATION %s (%s%s)%s",
                        p->last_reset == PEER_DOWN_NOTIFY_SEND ? "sent" : "received",
-                       code_str, subcode_str, VTY_NEWLINE);
+                       code_str, subcode_str, VTYNL);
               if (p->last_reset == PEER_DOWN_NOTIFY_RECEIVED
                   && p->notify.code == BGP_NOTIFY_CEASE
                   && (p->notify.subcode == BGP_NOTIFY_CEASE_ADMIN_SHUTDOWN
@@ -8874,19 +8874,19 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
                   msg_str = bgp_notify_admin_message(msgbuf, sizeof(msgbuf),
                                                      (u_char*)p->notify.data, p->notify.length);
                   if (msg_str)
-                    vty_out (vty, "    Message: \"%s\"%s", msg_str, VTY_NEWLINE);
+                    vty_out (vty, "    Message: \"%s\"%s", msg_str, VTYNL);
                 }
             }
           else
             {
               vty_out (vty, "due to %s%s",
-                       peer_down_str[(int) p->last_reset], VTY_NEWLINE);
+                       peer_down_str[(int) p->last_reset], VTYNL);
             }
 
           if (p->last_reset_cause_size)
             {
               msg = p->last_reset_cause;
-              vty_out(vty, "  Message received that caused BGP to send a NOTIFICATION:%s    ", VTY_NEWLINE);
+              vty_out(vty, "  Message received that caused BGP to send a NOTIFICATION:%s    ", VTYNL);
               for (i = 1; i <= p->last_reset_cause_size; i++)
                 {
                   vty_out(vty, "%02X", *msg++);
@@ -8895,7 +8895,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
                     {
                       if (i % 16 == 0)
                         {
-                          vty_out(vty, "%s    ", VTY_NEWLINE);
+                          vty_out(vty, "%s    ", VTYNL);
                         }
                       else if (i % 4 == 0)
                         {
@@ -8903,7 +8903,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
                         }
                     }
                 }
-              vty_out(vty, "%s", VTY_NEWLINE);
+              vty_out(vty, "%s", VTYNL);
             }
         }
     }
@@ -8913,7 +8913,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
       if (use_json)
         json_object_boolean_true_add(json_neigh, "prefixesConfigExceedMax");
       else
-        vty_out (vty, "  Peer had exceeded the max. no. of prefixes configured.%s", VTY_NEWLINE);
+        vty_out (vty, "  Peer had exceeded the max. no. of prefixes configured.%s", VTYNL);
 
       if (p->t_pmax_restart)
         {
@@ -8925,7 +8925,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
           else
             vty_out (vty, "  Reduce the no. of prefix from %s, will restart in %ld seconds%s",
                      p->host, thread_timer_remain_second (p->t_pmax_restart),
-                     VTY_NEWLINE);
+                     VTYNL);
         }
       else
         {
@@ -8933,7 +8933,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
             json_object_boolean_true_add(json_neigh, "reducePrefixNumAndClearIpBgp");
           else
             vty_out (vty, "  Reduce the no. of prefix and clear ip bgp %s to restore peering%s",
-	             p->host, VTY_NEWLINE);
+	             p->host, VTYNL);
         }
     }
 
@@ -8951,10 +8951,10 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         {
           if (p->gtsm_hops > 0)
             vty_out (vty, "  External BGP neighbor may be up to %d hops away.%s",
-                     p->gtsm_hops, VTY_NEWLINE);
+                     p->gtsm_hops, VTYNL);
           else if (p->ttl > 1)
             vty_out (vty, "  External BGP neighbor may be up to %d hops away.%s",
-                     p->ttl, VTY_NEWLINE);
+                     p->ttl, VTYNL);
         }
     }
   else
@@ -8965,7 +8965,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
             json_object_int_add(json_neigh, "internalBgpNbrMaxHopsAway", p->gtsm_hops);
           else
             vty_out (vty, "  Internal BGP neighbor may be up to %d hops away.%s",
-                     p->gtsm_hops, VTY_NEWLINE);
+                     p->gtsm_hops, VTYNL);
         }
     }
 
@@ -8981,7 +8981,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         vty_out (vty, "Local host: %s, Local port: %d%s",
 	         sockunion2str (p->su_local, buf1, SU_ADDRSTRLEN),
 	         ntohs (p->su_local->sin.sin_port),
-	         VTY_NEWLINE);
+	         VTYNL);
     }
 
   /* Remote address. */
@@ -8996,7 +8996,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         vty_out (vty, "Foreign host: %s, Foreign port: %d%s",
 	       sockunion2str (p->su_remote, buf1, SU_ADDRSTRLEN),
 	       ntohs (p->su_remote->sin.sin_port),
-	       VTY_NEWLINE);
+	       VTYNL);
     }
 
   /* Nexthop display. */
@@ -9019,16 +9019,16 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         {
           vty_out (vty, "Nexthop: %s%s",
                    inet_ntop (AF_INET, &p->nexthop.v4, buf1, sizeof(buf1)),
-                   VTY_NEWLINE);
+                   VTYNL);
           vty_out (vty, "Nexthop global: %s%s",
                    inet_ntop (AF_INET6, &p->nexthop.v6_global, buf1, sizeof(buf1)),
-                   VTY_NEWLINE);
+                   VTYNL);
           vty_out (vty, "Nexthop local: %s%s",
                    inet_ntop (AF_INET6, &p->nexthop.v6_local, buf1, sizeof(buf1)),
-                   VTY_NEWLINE);
+                   VTYNL);
           vty_out (vty, "BGP connection: %s%s",
                    p->shared_network ? "shared network" : "non shared network",
-                   VTY_NEWLINE);
+                   VTYNL);
         }
     }
 
@@ -9062,27 +9062,27 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
   else
     {
       vty_out (vty, "BGP Connect Retry Timer in Seconds: %d%s",
-	       p->v_connect, VTY_NEWLINE);
+	       p->v_connect, VTYNL);
       if (p->status == Established && p->rtt)
         vty_out (vty, "Estimated round trip time: %d ms%s",
-                 p->rtt, VTY_NEWLINE);
+                 p->rtt, VTYNL);
       if (p->t_start)
         vty_out (vty, "Next start timer due in %ld seconds%s",
-                 thread_timer_remain_second (p->t_start), VTY_NEWLINE);
+                 thread_timer_remain_second (p->t_start), VTYNL);
       if (p->t_connect)
         vty_out (vty, "Next connect timer due in %ld seconds%s",
-                 thread_timer_remain_second (p->t_connect), VTY_NEWLINE);
+                 thread_timer_remain_second (p->t_connect), VTYNL);
       if (p->t_routeadv)
         vty_out (vty, "MRAI (interval %u) timer expires in %ld seconds%s",
                  p->v_routeadv, thread_timer_remain_second (p->t_routeadv),
-                 VTY_NEWLINE);
+                 VTYNL);
       if (p->password)
-	vty_out (vty, "Peer Authentication Enabled%s", VTY_NEWLINE);
+	vty_out (vty, "Peer Authentication Enabled%s", VTYNL);
 
       vty_out (vty, "Read thread: %s  Write thread: %s%s",
                p->t_read ? "on" : "off",
                p->t_write ? "on" : "off",
-               VTY_NEWLINE);
+               VTYNL);
     }
 
   if (p->notify.code == BGP_NOTIFY_OPEN_ERR
@@ -9090,7 +9090,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
     bgp_capability_vty_out (vty, p, use_json, json_neigh);
 
   if (!use_json)
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 
   /* BFD information. */
   bgp_bfd_show_info(vty, p, use_json, json_neigh);
@@ -9149,17 +9149,17 @@ bgp_show_neighbor (struct vty *vty, struct bgp *bgp, enum show_type type,
       if (use_json)
         json_object_boolean_true_add(json, "bgpNoSuchNeighbor");
       else
-        vty_out (vty, "%% No such neighbor%s", VTY_NEWLINE);
+        vty_out (vty, "%% No such neighbor%s", VTYNL);
     }
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
     {
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 
   return CMD_SUCCESS;
@@ -9174,7 +9174,7 @@ bgp_show_all_instances_neighbors_vty (struct vty *vty, u_char use_json)
   int is_first = 1;
 
   if (use_json)
-    vty_out (vty, "{%s", VTY_NEWLINE);
+    vty_out (vty, "{%s", VTYNL);
 
   for (ALL_LIST_ELEMENTS (bm->bgp, node, nnode, bgp))
     {
@@ -9185,7 +9185,7 @@ bgp_show_all_instances_neighbors_vty (struct vty *vty, u_char use_json)
               zlog_err("Unable to allocate memory for JSON object");
               vty_out (vty,
                        "{\"error\": {\"message:\": \"Unable to allocate memory for JSON object\"}}}%s",
-                       VTY_NEWLINE);
+                       VTYNL);
               return;
             }
 
@@ -9197,7 +9197,7 @@ bgp_show_all_instances_neighbors_vty (struct vty *vty, u_char use_json)
                                  ? "Default" : bgp->name);
 
           if (! is_first)
-            vty_out (vty, ",%s", VTY_NEWLINE);
+            vty_out (vty, ",%s", VTYNL);
           else
             is_first = 0;
 
@@ -9207,16 +9207,16 @@ bgp_show_all_instances_neighbors_vty (struct vty *vty, u_char use_json)
       else
         {
           vty_out (vty, "%sInstance %s:%s",
-                   VTY_NEWLINE,
+                   VTYNL,
                    (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)
                    ? "Default" : bgp->name,
-                   VTY_NEWLINE);
+                   VTYNL);
         }
       bgp_show_neighbor (vty, bgp, show_all, NULL, NULL, use_json, json);
     }
 
   if (use_json)
-    vty_out (vty, "}%s", VTY_NEWLINE);
+    vty_out (vty, "}%s", VTYNL);
 }
 
 static int
@@ -9244,11 +9244,11 @@ bgp_show_neighbor_vty (struct vty *vty, const char *name,
                 {
                   json = json_object_new_object();
                   json_object_boolean_true_add(json, "bgpNoSuchInstance");
-                  vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+                  vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
                   json_object_free(json);
                 }
               else
-                vty_out (vty, "%% No such BGP instance exist%s", VTY_NEWLINE);
+                vty_out (vty, "%% No such BGP instance exist%s", VTYNL);
 
               return CMD_WARNING;
             }
@@ -9338,7 +9338,7 @@ DEFUN (show_ip_bgp_paths,
        BGP_SAFI_HELP_STR
        "Path information\n")
 {
-  vty_out (vty, "Address Refcnt Path%s", VTY_NEWLINE);
+  vty_out (vty, "Address Refcnt Path%s", VTYNL);
   aspath_print_all_vty (vty);
   return CMD_SUCCESS;
 }
@@ -9352,7 +9352,7 @@ community_show_all_iterator (struct hash_backet *backet, struct vty *vty)
 
   com = (struct community *) backet->data;
   vty_out (vty, "[%p] (%ld) %s%s", (void *)backet, com->refcnt,
-	   community_str (com), VTY_NEWLINE);
+	   community_str (com), VTYNL);
 }
 
 /* Show BGP's community internal data. */
@@ -9364,7 +9364,7 @@ DEFUN (show_ip_bgp_community_info,
        BGP_STR
        "List all bgp community information\n")
 {
-  vty_out (vty, "Address Refcnt Community%s", VTY_NEWLINE);
+  vty_out (vty, "Address Refcnt Community%s", VTYNL);
 
   hash_iterate (community_hash (),
 		(void (*) (struct hash_backet *, void *))
@@ -9381,7 +9381,7 @@ lcommunity_show_all_iterator (struct hash_backet *backet, struct vty *vty)
 
   lcom = (struct lcommunity *) backet->data;
   vty_out (vty, "[%p] (%ld) %s%s", (void *)backet, lcom->refcnt,
-           lcommunity_str (lcom), VTY_NEWLINE);
+           lcommunity_str (lcom), VTYNL);
 }
 
 /* Show BGP's community internal data. */
@@ -9393,7 +9393,7 @@ DEFUN (show_ip_bgp_lcommunity_info,
        BGP_STR
        "List all bgp large-community information\n")
 {
-  vty_out (vty, "Address Refcnt Large-community%s", VTY_NEWLINE);
+  vty_out (vty, "Address Refcnt Large-community%s", VTYNL);
 
   hash_iterate (lcommunity_hash (),
                 (void (*) (struct hash_backet *, void *))
@@ -9425,9 +9425,9 @@ bgp_show_all_instances_updgrps_vty (struct vty *vty, afi_t afi, safi_t safi)
   for (ALL_LIST_ELEMENTS (bm->bgp, node, nnode, bgp))
     {
       vty_out (vty, "%sInstance %s:%s",
-               VTY_NEWLINE,
+               VTYNL,
                (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) ? "Default" : bgp->name,
-               VTY_NEWLINE);
+               VTYNL);
       update_group_show(bgp, afi, safi, vty, 0);
     }
 }
@@ -9813,19 +9813,19 @@ bgp_show_one_peer_group (struct vty *vty, struct peer_group *group)
   if (conf->as_type == AS_SPECIFIED ||
       conf->as_type == AS_EXTERNAL) {
   vty_out (vty, "%sBGP peer-group %s, remote AS %d%s",
-           VTY_NEWLINE, group->name, conf->as, VTY_NEWLINE);
+           VTYNL, group->name, conf->as, VTYNL);
   } else if (conf->as_type == AS_INTERNAL) {
     vty_out (vty, "%sBGP peer-group %s, remote AS %d%s",
-	     VTY_NEWLINE, group->name, group->bgp->as, VTY_NEWLINE);
+	     VTYNL, group->name, group->bgp->as, VTYNL);
   } else {
     vty_out (vty, "%sBGP peer-group %s%s",
-	     VTY_NEWLINE, group->name, VTY_NEWLINE);
+	     VTYNL, group->name, VTYNL);
   }
 
   if ((group->bgp->as == conf->as) || (conf->as_type == AS_INTERNAL))
-    vty_out (vty, "  Peer-group type is internal%s", VTY_NEWLINE);
+    vty_out (vty, "  Peer-group type is internal%s", VTYNL);
   else
-    vty_out (vty, "  Peer-group type is external%s", VTY_NEWLINE);
+    vty_out (vty, "  Peer-group type is external%s", VTYNL);
 
   /* Display AFs configured. */
   vty_out (vty, "  Configured address-families:");
@@ -9839,9 +9839,9 @@ bgp_show_one_peer_group (struct vty *vty, struct peer_group *group)
           }
       }
   if (!af_cfgd)
-    vty_out (vty, " none%s", VTY_NEWLINE);
+    vty_out (vty, " none%s", VTYNL);
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 
   /* Display listen ranges (for dynamic neighbors), if any */
   for (afi = AFI_IP; afi < AFI_MAX; afi++)
@@ -9857,14 +9857,14 @@ bgp_show_one_peer_group (struct vty *vty, struct peer_group *group)
         {
           vty_out(vty,
                   "  %d %s listen range(s)%s",
-                  lr_count, af_str, VTY_NEWLINE);
+                  lr_count, af_str, VTYNL);
 
 
           for (ALL_LIST_ELEMENTS (group->listen_range[afi], node,
                                   nnode, range))
             {
               prefix2str(range, buf, sizeof(buf));
-              vty_out(vty, "    %s%s", buf, VTY_NEWLINE);
+              vty_out(vty, "    %s%s", buf, VTYNL);
             }
         }
     }
@@ -9872,7 +9872,7 @@ bgp_show_one_peer_group (struct vty *vty, struct peer_group *group)
   /* Display group members and their status */
   if (listcount(group->peer))
     {
-      vty_out (vty, "  Peer-group members:%s", VTY_NEWLINE);
+      vty_out (vty, "  Peer-group members:%s", VTYNL);
       for (ALL_LIST_ELEMENTS (group->peer, node, nnode, peer))
         {
           if (CHECK_FLAG (peer->flags, PEER_FLAG_SHUTDOWN))
@@ -9885,7 +9885,7 @@ bgp_show_one_peer_group (struct vty *vty, struct peer_group *group)
           dynamic = peer_dynamic_neighbor(peer);
           vty_out (vty, "    %s %s %s %s",
                    peer->host, dynamic ? "(dynamic)" : "",
-                   peer_status, VTY_NEWLINE);
+                   peer_status, VTYNL);
         }
     }
 
@@ -9925,7 +9925,7 @@ bgp_show_peer_group (struct vty *vty, struct bgp *bgp,
     }
 
   if (type == show_peer_group && ! find)
-    vty_out (vty, "%% No such peer-group%s", VTY_NEWLINE);
+    vty_out (vty, "%% No such peer-group%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -9944,7 +9944,7 @@ bgp_show_peer_group_vty (struct vty *vty, const char *name,
 
   if (! bgp)
     {
-      vty_out (vty, "%% No such BGP instance exist%s", VTY_NEWLINE);
+      vty_out (vty, "%% No such BGP instance exist%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -9989,7 +9989,7 @@ DEFUN (bgp_redistribute_ipv4,
   type = proto_redistnum (AFI_IP, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
   bgp_redist_add(bgp, AFI_IP, type, 0);
@@ -10019,7 +10019,7 @@ DEFUN (bgp_redistribute_ipv4_rmap,
   type = proto_redistnum (AFI_IP, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -10054,7 +10054,7 @@ DEFUN (bgp_redistribute_ipv4_metric,
   type = proto_redistnum (AFI_IP, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
   metric = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -10093,7 +10093,7 @@ DEFUN (bgp_redistribute_ipv4_rmap_metric,
   type = proto_redistnum (AFI_IP, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
   metric = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -10135,7 +10135,7 @@ DEFUN (bgp_redistribute_ipv4_metric_rmap,
   type = proto_redistnum (AFI_IP, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
   metric = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -10425,7 +10425,7 @@ DEFUN (no_bgp_redistribute_ipv4,
   type = proto_redistnum (AFI_IP, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
   return bgp_redistribute_unset (bgp, AFI_IP, type, 0);
@@ -10455,7 +10455,7 @@ DEFUN (bgp_redistribute_ipv6,
   type = proto_redistnum (AFI_IP6, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -10480,7 +10480,7 @@ DEFUN (bgp_redistribute_ipv6_rmap,
   type = proto_redistnum (AFI_IP6, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -10507,7 +10507,7 @@ DEFUN (bgp_redistribute_ipv6_metric,
   type = proto_redistnum (AFI_IP6, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
   metric = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -10538,7 +10538,7 @@ DEFUN (bgp_redistribute_ipv6_rmap_metric,
   type = proto_redistnum (AFI_IP6, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
   metric = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -10570,7 +10570,7 @@ DEFUN (bgp_redistribute_ipv6_metric_rmap,
   type = proto_redistnum (AFI_IP6, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
   metric = strtoul(argv[idx_number]->arg, NULL, 10);
@@ -10599,7 +10599,7 @@ DEFUN (no_bgp_redistribute_ipv6,
   type = proto_redistnum (AFI_IP6, argv[idx_protocol]->text);
   if (type < 0)
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_out (vty, "%% Invalid route type%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -10642,7 +10642,7 @@ bgp_config_write_redistribute (struct vty *vty, struct bgp *bgp, afi_t afi,
                 vty_out (vty, " metric %u", red->redist_metric);
               if (red->rmap.name)
                 vty_out (vty, " route-map %s", red->rmap.name);
-              vty_out (vty, "%s", VTY_NEWLINE);
+              vty_out (vty, "%s", VTYNL);
             }
 	}
     }
@@ -11814,16 +11814,16 @@ community_list_perror (struct vty *vty, int ret)
   switch (ret)
     {
     case COMMUNITY_LIST_ERR_CANT_FIND_LIST:
-      vty_out (vty, "%% Can't find community-list%s", VTY_NEWLINE);
+      vty_out (vty, "%% Can't find community-list%s", VTYNL);
       break;
     case COMMUNITY_LIST_ERR_MALFORMED_VAL:
-      vty_out (vty, "%% Malformed community-list value%s", VTY_NEWLINE);
+      vty_out (vty, "%% Malformed community-list value%s", VTYNL);
       break;
     case COMMUNITY_LIST_ERR_STANDARD_CONFLICT:
-      vty_out (vty, "%% Community name conflict, previously defined as standard community%s", VTY_NEWLINE);
+      vty_out (vty, "%% Community name conflict, previously defined as standard community%s", VTYNL);
       break;
     case COMMUNITY_LIST_ERR_EXPANDED_CONFLICT:
-      vty_out (vty, "%% Community name conflict, previously defined as expanded community%s", VTY_NEWLINE);
+      vty_out (vty, "%% Community name conflict, previously defined as expanded community%s", VTYNL);
       break;
     }
 }
@@ -12003,22 +12003,22 @@ community_list_show (struct vty *vty, struct community_list *list)
 	    vty_out (vty, "Community %s list %s%s",
 		     entry->style == COMMUNITY_LIST_STANDARD ?
 		     "standard" : "(expanded) access",
-		     list->name, VTY_NEWLINE);
+		     list->name, VTYNL);
 	  else
 	    vty_out (vty, "Named Community %s list %s%s",
 		     entry->style == COMMUNITY_LIST_STANDARD ?
 		     "standard" : "expanded",
-		     list->name, VTY_NEWLINE);
+		     list->name, VTYNL);
 	}
       if (entry->any)
 	vty_out (vty, "    %s%s",
-		 community_direct_str (entry->direct), VTY_NEWLINE);
+		 community_direct_str (entry->direct), VTYNL);
       else
 	vty_out (vty, "    %s %s%s",
 		 community_direct_str (entry->direct),
 		 entry->style == COMMUNITY_LIST_STANDARD
 		 ? community_str (entry->u.com) : entry->config,
-		 VTY_NEWLINE);
+		 VTYNL);
     }
 }
 
@@ -12060,7 +12060,7 @@ DEFUN (show_ip_community_list_arg,
   list = community_list_lookup (bgp_clist, argv[idx_comm_list]->arg, COMMUNITY_LIST_MASTER);
   if (! list)
     {
-      vty_out (vty, "%% Can't find community-list%s", VTY_NEWLINE);
+      vty_out (vty, "%% Can't find community-list%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -12092,7 +12092,7 @@ lcommunity_list_set_vty (struct vty *vty, int argc, struct cmd_token **argv,
   cl_name = argv[idx]->arg;
   if (reject_all_digit_name && all_digit (cl_name))
     {
-      vty_out (vty, "%% Community name cannot have all digits%s", VTY_NEWLINE);
+      vty_out (vty, "%% Community name cannot have all digits%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -12349,22 +12349,22 @@ lcommunity_list_show (struct vty *vty, struct community_list *list)
             vty_out (vty, "Large community %s list %s%s",
                      entry->style == EXTCOMMUNITY_LIST_STANDARD ?
                      "standard" : "(expanded) access",
-                     list->name, VTY_NEWLINE);
+                     list->name, VTYNL);
           else
             vty_out (vty, "Named large community %s list %s%s",
                      entry->style == EXTCOMMUNITY_LIST_STANDARD ?
                      "standard" : "expanded",
-                     list->name, VTY_NEWLINE);
+                     list->name, VTYNL);
         }
       if (entry->any)
         vty_out (vty, "    %s%s",
-                 community_direct_str (entry->direct), VTY_NEWLINE);
+                 community_direct_str (entry->direct), VTYNL);
       else
         vty_out (vty, "    %s %s%s",
                  community_direct_str (entry->direct),
                  entry->style == EXTCOMMUNITY_LIST_STANDARD ?
                  entry->u.ecom->str : entry->config,
-                 VTY_NEWLINE);
+                 VTYNL);
     }
 }
 
@@ -12405,7 +12405,7 @@ DEFUN (show_ip_lcommunity_list_arg,
   list = community_list_lookup (bgp_clist, argv[3]->arg, LARGE_COMMUNITY_LIST_MASTER);
   if (! list)
     {
-      vty_out (vty, "%% Can't find extcommunity-list%s", VTY_NEWLINE);
+      vty_out (vty, "%% Can't find extcommunity-list%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -12585,22 +12585,22 @@ extcommunity_list_show (struct vty *vty, struct community_list *list)
 	    vty_out (vty, "Extended community %s list %s%s",
 		     entry->style == EXTCOMMUNITY_LIST_STANDARD ?
 		     "standard" : "(expanded) access",
-		     list->name, VTY_NEWLINE);
+		     list->name, VTYNL);
 	  else
 	    vty_out (vty, "Named extended community %s list %s%s",
 		     entry->style == EXTCOMMUNITY_LIST_STANDARD ?
 		     "standard" : "expanded",
-		     list->name, VTY_NEWLINE);
+		     list->name, VTYNL);
 	}
       if (entry->any)
 	vty_out (vty, "    %s%s",
-		 community_direct_str (entry->direct), VTY_NEWLINE);
+		 community_direct_str (entry->direct), VTYNL);
       else
 	vty_out (vty, "    %s %s%s",
 		 community_direct_str (entry->direct),
 		 entry->style == EXTCOMMUNITY_LIST_STANDARD ?
 		 entry->u.ecom->str : entry->config,
-		 VTY_NEWLINE);
+		 VTYNL);
     }
 }
 
@@ -12642,7 +12642,7 @@ DEFUN (show_ip_extcommunity_list_arg,
   list = community_list_lookup (bgp_clist, argv[idx_comm_list]->arg, EXTCOMMUNITY_LIST_MASTER);
   if (! list)
     {
-      vty_out (vty, "%% Can't find extcommunity-list%s", VTY_NEWLINE);
+      vty_out (vty, "%% Can't find extcommunity-list%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -12687,7 +12687,7 @@ community_list_config_write (struct vty *vty)
 	vty_out (vty, "ip community-list %s %s %s%s",
 		 list->name, community_direct_str (entry->direct),
 		 community_list_config_str (entry),
-		 VTY_NEWLINE);
+		 VTYNL);
 	write++;
       }
   for (list = cm->str.head; list; list = list->next)
@@ -12698,7 +12698,7 @@ community_list_config_write (struct vty *vty)
 		 ? "standard" : "expanded",
 		 list->name, community_direct_str (entry->direct),
 		 community_list_config_str (entry),
-		 VTY_NEWLINE);
+		 VTYNL);
 	write++;
       }
 
@@ -12710,7 +12710,7 @@ community_list_config_write (struct vty *vty)
       {
 	vty_out (vty, "ip extcommunity-list %s %s %s%s",
 		 list->name, community_direct_str (entry->direct),
-		 community_list_config_str (entry), VTY_NEWLINE);
+		 community_list_config_str (entry), VTYNL);
 	write++;
       }
   for (list = cm->str.head; list; list = list->next)
@@ -12720,7 +12720,7 @@ community_list_config_write (struct vty *vty)
 		 entry->style == EXTCOMMUNITY_LIST_STANDARD
 		 ? "standard" : "expanded",
 		 list->name, community_direct_str (entry->direct),
-		 community_list_config_str (entry), VTY_NEWLINE);
+		 community_list_config_str (entry), VTYNL);
 	write++;
       }
 
@@ -12733,7 +12733,7 @@ community_list_config_write (struct vty *vty)
       {
         vty_out (vty, "ip large-community-list %s %s %s%s",
                  list->name, community_direct_str (entry->direct),
-                 community_list_config_str (entry), VTY_NEWLINE);
+                 community_list_config_str (entry), VTYNL);
         write++;
       }
   for (list = cm->str.head; list; list = list->next)
@@ -12743,7 +12743,7 @@ community_list_config_write (struct vty *vty)
                  entry->style == LARGE_COMMUNITY_LIST_STANDARD
                  ? "standard" : "expanded",
                  list->name, community_direct_str (entry->direct),
-                 community_list_config_str (entry), VTY_NEWLINE);
+                 community_list_config_str (entry), VTYNL);
         write++;
       }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6584,7 +6584,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
           if_ras_printed = TRUE;
         }
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   /* remote-as and peer-group */
@@ -6597,24 +6597,23 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
         {
           if (peer->as_type == AS_SPECIFIED)
             {
-              vty_out (vty, " neighbor %s remote-as %u%s", addr, peer->as,
-                       VTY_NEWLINE);
+              vty_outln (vty, " neighbor %s remote-as %u", addr,peer->as);
             }
           else if (peer->as_type == AS_INTERNAL)
             {
-              vty_out (vty, " neighbor %s remote-as internal%s", addr, VTY_NEWLINE);
+              vty_outln (vty, " neighbor %s remote-as internal", addr);
             }
           else if (peer->as_type == AS_EXTERNAL)
             {
-              vty_out (vty, " neighbor %s remote-as external%s", addr, VTY_NEWLINE);
+              vty_outln (vty, " neighbor %s remote-as external", addr);
             }
         }
 
       /* For swpX peers we displayed the peer-group
        * via 'neighbor swpX interface peer-group WORD' */
       if (!if_pg_printed)
-          vty_out (vty, " neighbor %s peer-group %s%s", addr,
-                   peer->group->name, VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s peer-group %s", addr,
+                   peer->group->name);
     }
 
   /* peer is NOT a member of a peer-group */
@@ -6623,24 +6622,22 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       /* peer is a peer-group, declare the peer-group */
       if (CHECK_FLAG (peer->sflags, PEER_STATUS_GROUP))
         {
-          vty_out (vty, " neighbor %s peer-group%s", addr,
-                   VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s peer-group",addr);
         }
 
       if (!if_ras_printed)
         {
           if (peer->as_type == AS_SPECIFIED)
             {
-              vty_out (vty, " neighbor %s remote-as %u%s", addr, peer->as,
-                       VTY_NEWLINE);
+              vty_outln (vty, " neighbor %s remote-as %u", addr,peer->as);
             }
           else if (peer->as_type == AS_INTERNAL)
             {
-              vty_out (vty, " neighbor %s remote-as internal%s", addr, VTY_NEWLINE);
+              vty_outln (vty, " neighbor %s remote-as internal", addr);
             }
           else if (peer->as_type == AS_EXTERNAL)
             {
-              vty_out (vty, " neighbor %s remote-as external%s", addr, VTY_NEWLINE);
+              vty_outln (vty, " neighbor %s remote-as external", addr);
             }
         }
     }
@@ -6655,20 +6652,18 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
           || (CHECK_FLAG (peer->flags, PEER_FLAG_LOCAL_AS_REPLACE_AS) !=
               CHECK_FLAG (g_peer->flags, PEER_FLAG_LOCAL_AS_REPLACE_AS)))
         {
-          vty_out (vty, " neighbor %s local-as %u%s%s%s", addr,
+          vty_outln (vty, " neighbor %s local-as %u%s%s", addr,
                    peer->change_local_as,
                    CHECK_FLAG (peer->flags, PEER_FLAG_LOCAL_AS_NO_PREPEND) ?
                    " no-prepend" : "",
-                   CHECK_FLAG (peer->flags, PEER_FLAG_LOCAL_AS_REPLACE_AS) ?
-                   " replace-as" : "", VTY_NEWLINE);
+                   CHECK_FLAG(peer->flags, PEER_FLAG_LOCAL_AS_REPLACE_AS) ? " replace-as" : "");
         }
     }
 
   /* description */
   if (peer->desc)
     {
-      vty_out (vty, " neighbor %s description %s%s", addr, peer->desc,
-               VTY_NEWLINE);
+      vty_outln (vty, " neighbor %s description %s", addr,peer->desc);
     }
 
   /* shutdown */
@@ -6679,10 +6674,10 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
           peer->tx_shutdown_message)
         {
           if (peer->tx_shutdown_message)
-            vty_out (vty, " neighbor %s shutdown message %s%s", addr,
-                     peer->tx_shutdown_message, VTY_NEWLINE);
+            vty_outln (vty, " neighbor %s shutdown message %s", addr,
+                     peer->tx_shutdown_message);
           else
-            vty_out (vty, " neighbor %s shutdown%s", addr, VTY_NEWLINE);
+            vty_outln (vty, " neighbor %s shutdown", addr);
         }
     }
 
@@ -6702,8 +6697,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
           || ! g_peer->password
           || strcmp (peer->password, g_peer->password) != 0)
         {
-          vty_out (vty, " neighbor %s password %s%s", addr, peer->password,
-                   VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s password %s", addr,peer->password);
         }
     }
 
@@ -6712,22 +6706,20 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
     {
       if (!peer_group_active (peer))
         {
-          vty_out (vty, " neighbor %s solo%s", addr, VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s solo", addr);
         }
     }
 
   /* BGP port */
   if (peer->port != BGP_PORT_DEFAULT)
     {
-      vty_out (vty, " neighbor %s port %d%s", addr, peer->port,
-               VTY_NEWLINE);
+      vty_outln (vty, " neighbor %s port %d", addr,peer->port);
     }
 
   /* Local interface name */
   if (peer->ifname)
     {
-      vty_out (vty, " neighbor %s interface %s%s", addr, peer->ifname,
-               VTY_NEWLINE);
+      vty_outln (vty, " neighbor %s interface %s", addr,peer->ifname);
     }
 
   /* passive */
@@ -6736,7 +6728,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       if (! peer_group_active (peer) ||
           ! CHECK_FLAG (g_peer->flags, PEER_FLAG_PASSIVE))
         {
-          vty_out (vty, " neighbor %s passive%s", addr, VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s passive", addr);
         }
     }
 
@@ -6746,8 +6738,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
     {
       if (! peer_group_active (peer) || g_peer->ttl != peer->ttl)
         {
-          vty_out (vty, " neighbor %s ebgp-multihop %d%s", addr, peer->ttl,
-                   VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s ebgp-multihop %d", addr,peer->ttl);
         }
     }
 
@@ -6756,8 +6747,8 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
     {
       if (! peer_group_active (peer) || g_peer->gtsm_hops != peer->gtsm_hops)
         {
-          vty_out (vty, " neighbor %s ttl-security hops %d%s", addr,
-                   peer->gtsm_hops, VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s ttl-security hops %d", addr,
+                   peer->gtsm_hops);
         }
     }
 
@@ -6767,7 +6758,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       if (! peer_group_active (peer) ||
           ! CHECK_FLAG (g_peer->flags, PEER_FLAG_DISABLE_CONNECTED_CHECK))
         {
-          vty_out (vty, " neighbor %s disable-connected-check%s", addr, VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s disable-connected-check", addr);
         }
     }
 
@@ -6777,8 +6768,8 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       if (! peer_group_active (peer) || ! g_peer->update_if
           || strcmp (g_peer->update_if, peer->update_if) != 0)
         {
-          vty_out (vty, " neighbor %s update-source %s%s", addr,
-                   peer->update_if, VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s update-source %s", addr,
+                   peer->update_if);
         }
     }
   if (peer->update_source)
@@ -6787,9 +6778,8 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
           || sockunion_cmp (g_peer->update_source,
                             peer->update_source) != 0)
         {
-          vty_out (vty, " neighbor %s update-source %s%s", addr,
-                   sockunion2str (peer->update_source, buf, SU_ADDRSTRLEN),
-                   VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s update-source %s", addr,
+                   sockunion2str(peer->update_source, buf, SU_ADDRSTRLEN));
         }
     }
 
@@ -6798,8 +6788,8 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       ((! peer_group_active (peer) && peer->v_routeadv != BGP_DEFAULT_EBGP_ROUTEADV) ||
        (peer_group_active (peer) && peer->v_routeadv != g_peer->v_routeadv)))
     {
-      vty_out (vty, " neighbor %s advertisement-interval %u%s",
-               addr, peer->v_routeadv, VTY_NEWLINE);
+      vty_outln (vty, " neighbor %s advertisement-interval %u",
+               addr, peer->v_routeadv);
     }
 
   /* timers */
@@ -6807,8 +6797,8 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       ((! peer_group_active (peer) && (peer->keepalive != BGP_DEFAULT_KEEPALIVE || peer->holdtime != BGP_DEFAULT_HOLDTIME)) ||
        (peer_group_active (peer) && (peer->keepalive != g_peer->keepalive || peer->holdtime != g_peer->holdtime))))
     {
-      vty_out (vty, " neighbor %s timers %u %u%s", addr,
-               peer->keepalive, peer->holdtime, VTY_NEWLINE);
+      vty_outln (vty, " neighbor %s timers %u %u", addr,
+               peer->keepalive, peer->holdtime);
     }
 
   if (CHECK_FLAG (peer->config, PEER_CONFIG_CONNECT) &&
@@ -6816,8 +6806,8 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
        (peer_group_active (peer) && peer->connect != g_peer->connect)))
 
     {
-      vty_out (vty, " neighbor %s timers connect %u%s", addr,
-               peer->connect, VTY_NEWLINE);
+      vty_outln (vty, " neighbor %s timers connect %u", addr,
+               peer->connect);
     }
 
   /* capability dynamic */
@@ -6826,8 +6816,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       if (! peer_group_active (peer) ||
           ! CHECK_FLAG (g_peer->flags, PEER_FLAG_DYNAMIC_CAPABILITY))
         {
-          vty_out (vty, " neighbor %s capability dynamic%s", addr,
-                   VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s capability dynamic",addr);
         }
     }
 
@@ -6837,8 +6826,8 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       if (! peer_group_active (peer) ||
           ! CHECK_FLAG (g_peer->flags, PEER_FLAG_CAPABILITY_ENHE))
         {
-          vty_out (vty, " no neighbor %s capability extended-nexthop%s", addr,
-                   VTY_NEWLINE);
+          vty_outln (vty, " no neighbor %s capability extended-nexthop",
+                     addr);
         }
     }
 
@@ -6847,8 +6836,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       if (! peer_group_active (peer) ||
           ! CHECK_FLAG (g_peer->flags, PEER_FLAG_CAPABILITY_ENHE))
         {
-          vty_out (vty, " neighbor %s capability extended-nexthop%s", addr,
-                   VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s capability extended-nexthop",addr);
         }
     }
 
@@ -6858,8 +6846,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       if (! peer_group_active (peer) ||
           ! CHECK_FLAG (g_peer->flags, PEER_FLAG_DONT_CAPABILITY))
         {
-          vty_out (vty, " neighbor %s dont-capability-negotiate%s", addr,
-                   VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s dont-capability-negotiate",addr);
         }
     }
 
@@ -6869,8 +6856,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       if (! peer_group_active (peer) ||
           ! CHECK_FLAG (g_peer->flags, PEER_FLAG_OVERRIDE_CAPABILITY))
         {
-          vty_out (vty, " neighbor %s override-capability%s", addr,
-                   VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s override-capability",addr);
         }
     }
 
@@ -6880,8 +6866,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
       if (! peer_group_active (peer) ||
           ! CHECK_FLAG (g_peer->flags, PEER_FLAG_STRICT_CAP_MATCH))
         {
-          vty_out (vty, " neighbor %s strict-capability-match%s", addr,
-                   VTY_NEWLINE);
+          vty_outln (vty, " neighbor %s strict-capability-match",addr);
         }
     }
 }
@@ -6989,7 +6974,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
 	vty_out (vty, " send");
       else
 	vty_out (vty, " receive");
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   /* Route reflector client. */
@@ -7136,7 +7121,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
                           "  neighbor %s default-originate", addr);
       if (peer->default_rmap[afi][safi].name)
 	vty_out (vty, " route-map %s", peer->default_rmap[afi][safi].name);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   /* Soft reconfiguration inbound. */
@@ -7164,7 +7149,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
 	  vty_out (vty, " warning-only");
 	if (peer->pmax_restart[afi][safi])
 	  vty_out (vty, " restart %u", peer->pmax_restart[afi][safi]);
-	vty_out (vty, "%s", VTY_NEWLINE);
+	vty_outln (vty, "");
       }
 
   /* Route server client. */
@@ -7269,7 +7254,7 @@ bgp_config_write_family_header (struct vty *vty, afi_t afi, safi_t safi,
   if (*write)
     return;
 
-  vty_out (vty, " !%s address-family ", VTY_NEWLINE);
+  vty_outln (vty, " !%s address-family ", VTY_NEWLINE);
 
   if (afi == AFI_IP)
     {
@@ -7302,7 +7287,7 @@ bgp_config_write_family_header (struct vty *vty, afi_t afi, safi_t safi,
       if (safi == SAFI_EVPN)
 	vty_out (vty, "l2vpn evpn");
     }
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   *write = 1;
 }
@@ -7341,7 +7326,7 @@ bgp_config_write_family (struct vty *vty, struct bgp *bgp, afi_t afi,
   bgp_config_write_table_map (vty, bgp, afi, safi, &write);
 
   if (write)
-    vty_out (vty, " exit-address-family%s", VTY_NEWLINE);
+    vty_outln (vty, " exit-address-family");
 
   return write;
 }
@@ -7359,26 +7344,25 @@ bgp_config_write (struct vty *vty)
   /* BGP Multiple instance. */
   if (!bgp_option_check (BGP_OPT_MULTIPLE_INSTANCE))
     {    
-      vty_out (vty, "no bgp multiple-instance%s", VTY_NEWLINE);
+      vty_outln (vty, "no bgp multiple-instance");
       write++;
     }
 
   /* BGP Config type. */
   if (bgp_option_check (BGP_OPT_CONFIG_CISCO))
     {    
-      vty_out (vty, "bgp config-type cisco%s", VTY_NEWLINE);
+      vty_outln (vty, "bgp config-type cisco");
       write++;
     }
 
   if (bm->rmap_update_timer != RMAP_DEFAULT_UPDATE_TIMER)
-    vty_out (vty, "bgp route-map delay-timer %u%s", bm->rmap_update_timer,
-             VTY_NEWLINE);
+    vty_outln (vty, "bgp route-map delay-timer %u",bm->rmap_update_timer);
 
   /* BGP configuration. */
   for (ALL_LIST_ELEMENTS (bm->bgp, mnode, mnnode, bgp))
     {
       if (write)
-	vty_out (vty, "!%s", VTY_NEWLINE);
+	vty_outln (vty, "!");
 
       /* Router bgp ASN */
       vty_out (vty, "router bgp %u", bgp->as);
@@ -7390,70 +7374,66 @@ bgp_config_write (struct vty *vty)
                      (bgp->inst_type == BGP_INSTANCE_TYPE_VIEW) ?
                      "view" : "vrf", bgp->name);
 	}
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
 
       /* No Synchronization */
       if (bgp_option_check (BGP_OPT_CONFIG_CISCO))
-	vty_out (vty, " no synchronization%s", VTY_NEWLINE);
+	vty_outln (vty, " no synchronization");
 
       /* BGP fast-external-failover. */
       if (CHECK_FLAG (bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER))
-	vty_out (vty, " no bgp fast-external-failover%s", VTY_NEWLINE); 
+	vty_outln (vty, " no bgp fast-external-failover"); 
 
       /* BGP router ID. */
       if (bgp->router_id_static.s_addr != 0)
-	vty_out (vty, " bgp router-id %s%s",
-                 inet_ntoa (bgp->router_id_static), VTY_NEWLINE);
+	vty_outln (vty, " bgp router-id %s",
+                 inet_ntoa(bgp->router_id_static));
 
       /* BGP log-neighbor-changes. */
       if (!!bgp_flag_check (bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES)
           != DFLT_BGP_LOG_NEIGHBOR_CHANGES)
-        vty_out (vty, " %sbgp log-neighbor-changes%s",
-                 bgp_flag_check (bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES) ? "" : "no ",
-                 VTY_NEWLINE);
+        vty_outln (vty, " %sbgp log-neighbor-changes",
+                 bgp_flag_check(bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES) ? "" : "no ");
 
       /* BGP configuration. */
       if (bgp_flag_check (bgp, BGP_FLAG_ALWAYS_COMPARE_MED))
-	vty_out (vty, " bgp always-compare-med%s", VTY_NEWLINE);
+	vty_outln (vty, " bgp always-compare-med");
 
       /* BGP default ipv4-unicast. */
       if (bgp_flag_check (bgp, BGP_FLAG_NO_DEFAULT_IPV4))
-	vty_out (vty, " no bgp default ipv4-unicast%s", VTY_NEWLINE);
+	vty_outln (vty, " no bgp default ipv4-unicast");
 
       /* BGP default local-preference. */
       if (bgp->default_local_pref != BGP_DEFAULT_LOCAL_PREF)
-	vty_out (vty, " bgp default local-preference %u%s",
-		 bgp->default_local_pref, VTY_NEWLINE);
+	vty_outln (vty, " bgp default local-preference %u",
+		 bgp->default_local_pref);
 
       /* BGP default show-hostname */
       if (!!bgp_flag_check(bgp, BGP_FLAG_SHOW_HOSTNAME)
           != DFLT_BGP_SHOW_HOSTNAME)
-        vty_out (vty, " %sbgp default show-hostname%s",
-                 bgp_flag_check (bgp, BGP_FLAG_SHOW_HOSTNAME) ? "" : "no ",
-                 VTY_NEWLINE);
+        vty_outln (vty, " %sbgp default show-hostname",
+                 bgp_flag_check(bgp, BGP_FLAG_SHOW_HOSTNAME) ? "" : "no ");
 
       /* BGP default subgroup-pkt-queue-max. */
       if (bgp->default_subgroup_pkt_queue_max != BGP_DEFAULT_SUBGROUP_PKT_QUEUE_MAX)
-	vty_out (vty, " bgp default subgroup-pkt-queue-max %u%s",
-		 bgp->default_subgroup_pkt_queue_max, VTY_NEWLINE);
+	vty_outln (vty, " bgp default subgroup-pkt-queue-max %u",
+		 bgp->default_subgroup_pkt_queue_max);
 
       /* BGP client-to-client reflection. */
       if (bgp_flag_check (bgp, BGP_FLAG_NO_CLIENT_TO_CLIENT))
-	vty_out (vty, " no bgp client-to-client reflection%s", VTY_NEWLINE);
+	vty_outln (vty, " no bgp client-to-client reflection");
       
       /* BGP cluster ID. */
       if (CHECK_FLAG (bgp->config, BGP_CONFIG_CLUSTER_ID))
-	vty_out (vty, " bgp cluster-id %s%s", inet_ntoa (bgp->cluster_id),
-		 VTY_NEWLINE);
+	vty_outln (vty, " bgp cluster-id %s",inet_ntoa(bgp->cluster_id));
 
       /* Disable ebgp connected nexthop check */
       if (bgp_flag_check (bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
-	vty_out (vty, " bgp disable-ebgp-connected-route-check%s", VTY_NEWLINE);
+	vty_outln (vty, " bgp disable-ebgp-connected-route-check");
 
       /* Confederation identifier*/
       if (CHECK_FLAG (bgp->config, BGP_CONFIG_CONFEDERATION))
-       vty_out (vty, " bgp confederation identifier %i%s", bgp->confed_id,
-                VTY_NEWLINE);
+       vty_outln (vty, " bgp confederation identifier %i",bgp->confed_id);
 
       /* Confederation peer */
       if (bgp->confed_peers_cnt > 0)
@@ -7465,19 +7445,18 @@ bgp_config_write (struct vty *vty)
          for (i = 0; i < bgp->confed_peers_cnt; i++)
            vty_out(vty, " %u", bgp->confed_peers[i]);
 
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
 	}
 
       /* BGP enforce-first-as. */
       if (bgp_flag_check (bgp, BGP_FLAG_ENFORCE_FIRST_AS))
-	vty_out (vty, " bgp enforce-first-as%s", VTY_NEWLINE);
+	vty_outln (vty, " bgp enforce-first-as");
 
       /* BGP deterministic-med. */
       if (!!bgp_flag_check (bgp, BGP_FLAG_DETERMINISTIC_MED)
           != DFLT_BGP_DETERMINISTIC_MED)
-        vty_out (vty, " %sbgp deterministic-med%s",
-                 bgp_flag_check (bgp, BGP_FLAG_DETERMINISTIC_MED) ? "" : "no ",
-                 VTY_NEWLINE);
+        vty_outln (vty, " %sbgp deterministic-med",
+                 bgp_flag_check(bgp, BGP_FLAG_DETERMINISTIC_MED) ? "" : "no ");
 
       /* BGP update-delay. */
       bgp_config_write_update_delay (vty, bgp);
@@ -7487,14 +7466,14 @@ bgp_config_write (struct vty *vty)
           vty_out (vty, " bgp max-med on-startup %u", bgp->v_maxmed_onstartup);
           if (bgp->maxmed_onstartup_value != BGP_MAXMED_VALUE_DEFAULT)
             vty_out (vty, " %u", bgp->maxmed_onstartup_value);
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
         }
       if (bgp->v_maxmed_admin != BGP_MAXMED_ADMIN_UNCONFIGURED)
         {
           vty_out (vty, " bgp max-med administrative");
           if (bgp->maxmed_admin_value != BGP_MAXMED_VALUE_DEFAULT)
             vty_out (vty, " %u", bgp->maxmed_admin_value);
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
         }
 
       /* write quanta */
@@ -7505,42 +7484,42 @@ bgp_config_write (struct vty *vty)
 
       /* BGP graceful-restart. */
       if (bgp->stalepath_time != BGP_DEFAULT_STALEPATH_TIME)
-	vty_out (vty, " bgp graceful-restart stalepath-time %u%s",
-		 bgp->stalepath_time, VTY_NEWLINE);
+	vty_outln (vty, " bgp graceful-restart stalepath-time %u",
+		 bgp->stalepath_time);
       if (bgp->restart_time != BGP_DEFAULT_RESTART_TIME)
-	vty_out (vty, " bgp graceful-restart restart-time %u%s",
-		 bgp->restart_time, VTY_NEWLINE);
+	vty_outln (vty, " bgp graceful-restart restart-time %u",
+		 bgp->restart_time);
       if (bgp_flag_check (bgp, BGP_FLAG_GRACEFUL_RESTART))
-       vty_out (vty, " bgp graceful-restart%s", VTY_NEWLINE);
+       vty_outln (vty, " bgp graceful-restart");
 
       /* BGP graceful-restart Preserve State F bit. */
       if (bgp_flag_check (bgp, BGP_FLAG_GR_PRESERVE_FWD))
-       vty_out (vty, " bgp graceful-restart preserve-fw-state%s", VTY_NEWLINE);
+       vty_outln (vty, " bgp graceful-restart preserve-fw-state");
 
       /* BGP bestpath method. */
       if (bgp_flag_check (bgp, BGP_FLAG_ASPATH_IGNORE))
-	vty_out (vty, " bgp bestpath as-path ignore%s", VTY_NEWLINE);
+	vty_outln (vty, " bgp bestpath as-path ignore");
       if (bgp_flag_check (bgp, BGP_FLAG_ASPATH_CONFED))
-	vty_out (vty, " bgp bestpath as-path confed%s", VTY_NEWLINE);
+	vty_outln (vty, " bgp bestpath as-path confed");
 
       if (bgp_flag_check (bgp, BGP_FLAG_ASPATH_MULTIPATH_RELAX))
         {
           if (bgp_flag_check (bgp, BGP_FLAG_MULTIPATH_RELAX_AS_SET))
             {
-              vty_out (vty, " bgp bestpath as-path multipath-relax as-set%s", VTY_NEWLINE);
+              vty_outln (vty,
+                         " bgp bestpath as-path multipath-relax as-set");
             }
           else
             {
-              vty_out (vty, " bgp bestpath as-path multipath-relax%s", VTY_NEWLINE);
+              vty_outln (vty, " bgp bestpath as-path multipath-relax");
             }
         }
 
       if (bgp_flag_check (bgp, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY)) {
-	vty_out (vty, " bgp route-reflector allow-outbound-policy%s",
-		 VTY_NEWLINE);
+	vty_outln (vty," bgp route-reflector allow-outbound-policy");
       }
       if (bgp_flag_check (bgp, BGP_FLAG_COMPARE_ROUTER_ID))
-	vty_out (vty, " bgp bestpath compare-routerid%s", VTY_NEWLINE);
+	vty_outln (vty, " bgp bestpath compare-routerid");
       if (bgp_flag_check (bgp, BGP_FLAG_MED_CONFED)
 	  || bgp_flag_check (bgp, BGP_FLAG_MED_MISSING_AS_WORST))
 	{
@@ -7549,15 +7528,14 @@ bgp_config_write (struct vty *vty)
 	    vty_out (vty, " confed");
 	  if (bgp_flag_check (bgp, BGP_FLAG_MED_MISSING_AS_WORST))
 	    vty_out (vty, " missing-as-worst");
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_outln (vty, "");
 	}
 
       /* BGP network import check. */
       if (!!bgp_flag_check (bgp, BGP_FLAG_IMPORT_CHECK)
           != DFLT_BGP_IMPORT_CHECK)
-        vty_out (vty, " %sbgp network import-check%s",
-                 bgp_flag_check (bgp, BGP_FLAG_IMPORT_CHECK) ? "" : "no ",
-                 VTY_NEWLINE);
+        vty_outln (vty, " %sbgp network import-check",
+                 bgp_flag_check(bgp, BGP_FLAG_IMPORT_CHECK) ? "" : "no ");
 
       /* BGP flag dampening. */
       if (CHECK_FLAG (bgp->af_flags[AFI_IP][SAFI_UNICAST],
@@ -7567,8 +7545,8 @@ bgp_config_write (struct vty *vty)
       /* BGP timers configuration. */
       if (bgp->default_keepalive != BGP_DEFAULT_KEEPALIVE
 	  && bgp->default_holdtime != BGP_DEFAULT_HOLDTIME)
-	vty_out (vty, " timers bgp %u %u%s", bgp->default_keepalive,
-		 bgp->default_holdtime, VTY_NEWLINE);
+	vty_outln (vty, " timers bgp %u %u", bgp->default_keepalive,
+		 bgp->default_holdtime);
 
       /* peer-group */
       for (ALL_LIST_ELEMENTS (bgp->group, node, nnode, group))
@@ -7588,7 +7566,7 @@ bgp_config_write (struct vty *vty)
 
       /* No auto-summary */
       if (bgp_option_check (BGP_OPT_CONFIG_CISCO))
-	vty_out (vty, " no auto-summary%s", VTY_NEWLINE);
+	vty_outln (vty, " no auto-summary");
 
       /* IPv4 unicast configuration.  */
       write += bgp_config_write_family (vty, bgp, AFI_IP, SAFI_UNICAST);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6584,7 +6584,7 @@ bgp_config_write_peer_global (struct vty *vty, struct bgp *bgp,
           if_ras_printed = TRUE;
         }
 
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   /* remote-as and peer-group */
@@ -6974,7 +6974,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
 	vty_out (vty, " send");
       else
 	vty_out (vty, " receive");
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   /* Route reflector client. */
@@ -7121,7 +7121,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
                           "  neighbor %s default-originate", addr);
       if (peer->default_rmap[afi][safi].name)
 	vty_out (vty, " route-map %s", peer->default_rmap[afi][safi].name);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   /* Soft reconfiguration inbound. */
@@ -7149,7 +7149,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
 	  vty_out (vty, " warning-only");
 	if (peer->pmax_restart[afi][safi])
 	  vty_out (vty, " restart %u", peer->pmax_restart[afi][safi]);
-	vty_outln (vty, "");
+	vty_out (vty, VTYNL);
       }
 
   /* Route server client. */
@@ -7287,7 +7287,7 @@ bgp_config_write_family_header (struct vty *vty, afi_t afi, safi_t safi,
       if (safi == SAFI_EVPN)
 	vty_out (vty, "l2vpn evpn");
     }
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   *write = 1;
 }
@@ -7374,7 +7374,7 @@ bgp_config_write (struct vty *vty)
                      (bgp->inst_type == BGP_INSTANCE_TYPE_VIEW) ?
                      "view" : "vrf", bgp->name);
 	}
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
 
       /* No Synchronization */
       if (bgp_option_check (BGP_OPT_CONFIG_CISCO))
@@ -7445,7 +7445,7 @@ bgp_config_write (struct vty *vty)
          for (i = 0; i < bgp->confed_peers_cnt; i++)
            vty_out(vty, " %u", bgp->confed_peers[i]);
 
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
 	}
 
       /* BGP enforce-first-as. */
@@ -7466,14 +7466,14 @@ bgp_config_write (struct vty *vty)
           vty_out (vty, " bgp max-med on-startup %u", bgp->v_maxmed_onstartup);
           if (bgp->maxmed_onstartup_value != BGP_MAXMED_VALUE_DEFAULT)
             vty_out (vty, " %u", bgp->maxmed_onstartup_value);
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
         }
       if (bgp->v_maxmed_admin != BGP_MAXMED_ADMIN_UNCONFIGURED)
         {
           vty_out (vty, " bgp max-med administrative");
           if (bgp->maxmed_admin_value != BGP_MAXMED_VALUE_DEFAULT)
             vty_out (vty, " %u", bgp->maxmed_admin_value);
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
         }
 
       /* write quanta */
@@ -7528,7 +7528,7 @@ bgp_config_write (struct vty *vty)
 	    vty_out (vty, " confed");
 	  if (bgp_flag_check (bgp, BGP_FLAG_MED_MISSING_AS_WORST))
 	    vty_out (vty, " missing-as-worst");
-	  vty_outln (vty, "");
+	  vty_out (vty, VTYNL);
 	}
 
       /* BGP network import check. */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6461,14 +6461,14 @@ bgp_config_write_filter (struct vty *vty, struct peer *peer,
       {
         afi_header_vty_out (vty, afi, safi, write,
                             "  neighbor %s distribute-list %s in%s",
-                            addr, filter->dlist[in].name, VTY_NEWLINE);
+                            addr, filter->dlist[in].name, VTYNL);
       }
 
   if (filter->dlist[out].name && ! gfilter)
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s distribute-list %s out%s",
-                          addr, filter->dlist[out].name, VTY_NEWLINE);
+                          addr, filter->dlist[out].name, VTYNL);
     }
 
   /* prefix-list. */
@@ -6478,14 +6478,14 @@ bgp_config_write_filter (struct vty *vty, struct peer *peer,
       {
         afi_header_vty_out (vty, afi, safi, write,
                             "  neighbor %s prefix-list %s in%s",
-                            addr, filter->plist[in].name, VTY_NEWLINE);
+                            addr, filter->plist[in].name, VTYNL);
       }
 
   if (filter->plist[out].name && ! gfilter)
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s prefix-list %s out%s",
-                          addr, filter->plist[out].name, VTY_NEWLINE);
+                          addr, filter->plist[out].name, VTYNL);
     }
 
   /* route-map. */
@@ -6495,7 +6495,7 @@ bgp_config_write_filter (struct vty *vty, struct peer *peer,
       {
         afi_header_vty_out (vty, afi, safi, write,
                             "  neighbor %s route-map %s in%s",
-                            addr, filter->map[RMAP_IN].name, VTY_NEWLINE);
+                            addr, filter->map[RMAP_IN].name, VTYNL);
       }
 
   if (filter->map[RMAP_OUT].name)
@@ -6504,7 +6504,7 @@ bgp_config_write_filter (struct vty *vty, struct peer *peer,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s route-map %s out%s",
-                          addr, filter->map[RMAP_OUT].name, VTY_NEWLINE);
+                          addr, filter->map[RMAP_OUT].name, VTYNL);
     }
 
   /* unsuppress-map */
@@ -6512,7 +6512,7 @@ bgp_config_write_filter (struct vty *vty, struct peer *peer,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s unsuppress-map %s%s",
-                          addr, filter->usmap.name, VTY_NEWLINE);
+                          addr, filter->usmap.name, VTYNL);
     }
 
   /* filter-list. */
@@ -6522,14 +6522,14 @@ bgp_config_write_filter (struct vty *vty, struct peer *peer,
       {
         afi_header_vty_out (vty, afi, safi, write,
                             "  neighbor %s filter-list %s in%s",
-                            addr, filter->aslist[in].name, VTY_NEWLINE);
+                            addr, filter->aslist[in].name, VTYNL);
       }
 
   if (filter->aslist[out].name && ! gfilter)
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s filter-list %s out%s",
-                          addr, filter->aslist[out].name, VTY_NEWLINE);
+                          addr, filter->aslist[out].name, VTYNL);
     }
 }
 
@@ -6901,7 +6901,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
         {
           afi_header_vty_out (vty, afi, safi, write,
                               "  no neighbor %s activate%s",
-                              addr, VTY_NEWLINE);
+                              addr, VTYNL);
         }
 
       /* If the peer-group is not active but peer is, print an 'activate' */
@@ -6909,7 +6909,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
         {
           afi_header_vty_out (vty, afi, safi, write,
                               "  neighbor %s activate%s",
-                              addr, VTY_NEWLINE);
+                              addr, VTYNL);
         }
     }
   else
@@ -6922,13 +6922,13 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
                 {
                   afi_header_vty_out(vty, afi, safi, write,
                                      "  neighbor %s activate%s",
-                                     addr, VTY_NEWLINE);
+                                     addr, VTYNL);
                 }
             }
           else
             afi_header_vty_out (vty, afi, safi, write,
                                 "  neighbor %s activate%s",
-                                addr, VTY_NEWLINE);
+                                addr, VTYNL);
         }
       else
 	{
@@ -6938,7 +6938,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
 		{
 		  afi_header_vty_out (vty, afi, safi, write,
 				      "  no neighbor %s activate%s",
-				      addr, VTY_NEWLINE);
+				      addr, VTYNL);
 		}
 	    }
 	}
@@ -6949,14 +6949,14 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s addpath-tx-all-paths%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   if (peergroup_af_flag_check (peer, afi, safi, PEER_FLAG_ADDPATH_TX_BESTPATH_PER_AS))
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s addpath-tx-bestpath-per-AS%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   /* ORF capability.  */
@@ -6982,7 +6982,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s route-reflector-client%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   /* next-hop-self force */
@@ -6990,7 +6990,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s next-hop-self force%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   /* next-hop-self */
@@ -6998,7 +6998,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s next-hop-self%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   /* remove-private-AS */
@@ -7006,28 +7006,28 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s remove-private-AS all replace-AS%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   else if (peergroup_af_flag_check (peer, afi, safi, PEER_FLAG_REMOVE_PRIVATE_AS_REPLACE))
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s remove-private-AS replace-AS%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   else if (peergroup_af_flag_check (peer, afi, safi, PEER_FLAG_REMOVE_PRIVATE_AS_ALL))
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s remove-private-AS all%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   else if (peergroup_af_flag_check (peer, afi, safi, PEER_FLAG_REMOVE_PRIVATE_AS))
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s remove-private-AS%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   /* as-override */
@@ -7035,7 +7035,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s as-override%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   /* send-community print. */
@@ -7047,25 +7047,25 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
         {
           afi_header_vty_out (vty, afi, safi, write,
                               "  neighbor %s send-community all%s",
-                              addr, VTY_NEWLINE);
+                              addr, VTYNL);
         }
       else if (peergroup_af_flag_check (peer, afi, safi, PEER_FLAG_SEND_LARGE_COMMUNITY))
         {
           afi_header_vty_out (vty, afi, safi, write,
                               "  neighbor %s send-community large%s",
-                              addr, VTY_NEWLINE);
+                              addr, VTYNL);
         }
       else if (peergroup_af_flag_check (peer, afi, safi, PEER_FLAG_SEND_EXT_COMMUNITY))
         {
           afi_header_vty_out (vty, afi, safi, write,
                               "  neighbor %s send-community extended%s",
-                              addr, VTY_NEWLINE);
+                              addr, VTYNL);
         }
       else if (peergroup_af_flag_check (peer, afi, safi, PEER_FLAG_SEND_COMMUNITY))
         {
           afi_header_vty_out (vty, afi, safi, write,
                               "  neighbor %s send-community%s",
-                              addr, VTY_NEWLINE);
+                              addr, VTYNL);
         }
     }
   else
@@ -7079,7 +7079,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
         {
           afi_header_vty_out (vty, afi, safi, write,
                               "  no neighbor %s send-community all%s",
-                              addr, VTY_NEWLINE);
+                              addr, VTYNL);
         }
       else
         {
@@ -7088,7 +7088,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
             {
               afi_header_vty_out (vty, afi, safi, write,
                                   "  no neighbor %s send-community large%s",
-                                  addr, VTY_NEWLINE);
+                                  addr, VTYNL);
             }
 
           if (!peer_af_flag_check (peer, afi, safi, PEER_FLAG_SEND_EXT_COMMUNITY) &&
@@ -7096,7 +7096,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
             {
               afi_header_vty_out (vty, afi, safi, write,
                                   "  no neighbor %s send-community extended%s",
-                                  addr, VTY_NEWLINE);
+                                  addr, VTYNL);
             }
 
           if (!peer_af_flag_check (peer, afi, safi, PEER_FLAG_SEND_COMMUNITY) &&
@@ -7104,7 +7104,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
             {
               afi_header_vty_out (vty, afi, safi, write,
                                   "  no neighbor %s send-community%s",
-                                  addr, VTY_NEWLINE);
+                                  addr, VTYNL);
             }
         }
     }
@@ -7129,7 +7129,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s soft-reconfiguration inbound%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   /* maximum-prefix. */
@@ -7157,7 +7157,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s route-server-client%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   /* Nexthop-local unchanged. */
@@ -7165,7 +7165,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
     {
       afi_header_vty_out (vty, afi, safi, write,
                           "  neighbor %s nexthop-local unchanged%s",
-                          addr, VTY_NEWLINE);
+                          addr, VTYNL);
     }
 
   /* allowas-in <1-10> */
@@ -7179,13 +7179,13 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
             {
               afi_header_vty_out (vty, afi, safi, write,
                                   "  neighbor %s allowas-in%s",
-                                  addr, VTY_NEWLINE);
+                                  addr, VTYNL);
             }
           else
             {
               afi_header_vty_out (vty, afi, safi, write,
                                   "  neighbor %s allowas-in %d%s",
-                                  addr, peer->allowas_in[afi][safi], VTY_NEWLINE);
+                                  addr, peer->allowas_in[afi][safi], VTYNL);
             }
         }
     }
@@ -7198,7 +7198,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
         {
           afi_header_vty_out (vty, afi, safi, write,
                               "  neighbor %s allowas-in origin%s",
-                              addr, VTY_NEWLINE);
+                              addr, VTYNL);
         }
     }
 
@@ -7212,7 +7212,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
           {
             afi_header_vty_out (vty, afi, safi, write,
                                 "  neighbor %s weight %lu%s",
-                                addr, peer->weight[afi][safi], VTY_NEWLINE);
+                                addr, peer->weight[afi][safi], VTYNL);
           }
       }
 
@@ -7230,7 +7230,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
         {
 	  afi_header_vty_out (vty, afi, safi, write,
                               "  neighbor %s attribute-unchanged%s",
-                              addr, VTY_NEWLINE);
+                              addr, VTYNL);
         }
       else
         {
@@ -7241,7 +7241,7 @@ bgp_config_write_peer_af (struct vty *vty, struct bgp *bgp,
 	       peergroup_af_flag_check (peer, afi, safi, PEER_FLAG_NEXTHOP_UNCHANGED) ?
 	       " next-hop" : "",
 	       peergroup_af_flag_check (peer, afi, safi, PEER_FLAG_MED_UNCHANGED) ?
-	       " med" : "", VTY_NEWLINE);
+	       " med" : "", VTYNL);
         }
     }
 }
@@ -7254,7 +7254,7 @@ bgp_config_write_family_header (struct vty *vty, afi_t afi, safi_t safi,
   if (*write)
     return;
 
-  vty_outln (vty, " !%s address-family ", VTY_NEWLINE);
+  vty_outln (vty, " !%s address-family ", VTYNL);
 
   if (afi == AFI_IP)
     {

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2433,7 +2433,7 @@ DEFUN_NOSH (vnc_nve_group,
       if (!rfg)
         {
           /* Error out of memory */
-          vty_out (vty, "Can't allocate memory for NVE group%s", VTY_NEWLINE);
+          vty_out (vty, "Can't allocate memory for NVE group%s", VTYNL);
           return CMD_WARNING;
         }
 
@@ -3258,7 +3258,7 @@ DEFUN_NOSH (vnc_vrf_policy,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_out (vty, "No BGP process is configured%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -3271,7 +3271,7 @@ DEFUN_NOSH (vnc_vrf_policy,
       if (!rfg)
         {
           /* Error out of memory */
-          vty_out (vty, "Can't allocate memory for NVE group%s", VTY_NEWLINE);
+          vty_out (vty, "Can't allocate memory for NVE group%s", VTYNL);
           return CMD_WARNING;
         }
     }
@@ -3401,7 +3401,7 @@ DEFUN (vnc_vrf_policy_nexthop,
 
   if (!str2prefix (argv[1]->arg, &p) && p.family)
     {
-      //vty_out (vty, "Nexthop set to self%s", VTY_NEWLINE);
+      //vty_out (vty, "Nexthop set to self%s", VTYNL);
       SET_FLAG (rfg->flags, RFAPI_RFG_VPN_NH_SELF);
       memset(&rfg->vn_prefix, 0, sizeof(struct prefix));
     }
@@ -3745,7 +3745,7 @@ DEFUN_NOSH (vnc_l2_group,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_out (vty, "No BGP process is configured%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -3758,7 +3758,7 @@ DEFUN_NOSH (vnc_l2_group,
       if (!rfg)
         {
           /* Error out of memory */
-          vty_out (vty, "Can't allocate memory for L2 group%s", VTY_NEWLINE);
+          vty_out (vty, "Can't allocate memory for L2 group%s", VTYNL);
           return CMD_WARNING;
         }
       rfg->name = strdup (argv[1]->arg);
@@ -4300,7 +4300,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                 inet_ntop(rfg->vn_prefix.family, &rfg->vn_prefix.u.prefix, buf, sizeof(buf));
                 if (!buf[0] || buf[BUFSIZ - 1])
                   {
-                    //vty_out (vty, "nexthop self%s", VTY_NEWLINE);
+                    //vty_out (vty, "nexthop self%s", VTYNL);
                   }
                 else
                   {

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2623,7 +2623,7 @@ bgp_rfapi_delete_nve_group (
             vty_out (vty, " un=");
           rfapiPrintRfapiIpAddr (vty, &rfd->un_addr);
           if (vty)
-            vty_outln (vty, "");
+            vty_out (vty, VTYNL);
         }
       list_delete (orphaned_nves);
     }
@@ -4463,7 +4463,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                   {
                     vty_out (vty, "%hu ", (uint16_t) ((uintptr_t) data));
                   }
-                vty_outln (vty, "");
+                vty_out (vty, VTYNL);
               }
 
             if (rfg->rt_import_list && rfg->rt_export_list &&
@@ -4550,7 +4550,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
               vty_out (vty, "%d", hc->default_response_lifetime);
             else
               vty_out (vty, "infinite");
-            vty_outln (vty, "");
+            vty_out (vty, VTYNL);
           }
         if (hc->default_rt_import_list && hc->default_rt_export_list &&
             ecommunity_cmp (hc->default_rt_import_list,
@@ -4665,7 +4665,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
               vty_out (vty, "%d", rfg->response_lifetime);
             else
               vty_out (vty, "infinite");
-            vty_outln (vty, "");
+            vty_out (vty, VTYNL);
           }
 
         if (rfg->rt_import_list && rfg->rt_export_list &&
@@ -5035,7 +5035,7 @@ bgp_rfapi_show_summary (struct bgp *bgp, struct vty *vty)
            (hc->rfp_cfg.ftd_advertisement_interval == RFAPI_RFP_CFG_DEFAULT_FTD_ADVERTISEMENT_INTERVAL ? "(default)" : ""));
   vty_outln (vty, "%-39s %d seconds", "Default RFP response lifetime:",
            hc->default_response_lifetime);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   return;
 }
 

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -299,7 +299,7 @@ DEFUN (vnc_advertise_un_method,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "VNC not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "VNC not configured");
       return CMD_WARNING;
     }
 
@@ -345,7 +345,7 @@ set_ecom_list (
       ecomadd = ecommunity_str2com (argv[0]->arg, ECOMMUNITY_ROUTE_TARGET, 0);
       if (!ecomadd)
         {
-          vty_out (vty, "Malformed community-list value%s", VTY_NEWLINE);
+          vty_outln (vty, "Malformed community-list value");
           if (ecom)
             ecommunity_free (&ecom);
           return CMD_WARNING;
@@ -435,13 +435,13 @@ DEFUN (vnc_defaults_rd,
 
       if (!argv[1]->arg[8] || *end)
         {
-          vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed rd");
           return CMD_WARNING;
         }
       if (value32 > 0xffff)
         {
-          vty_out (vty, "%% Malformed rd (must be less than %u%s",
-                   0x0ffff, VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed rd (must be less than %u",
+                   0x0ffff);
           return CMD_WARNING;
         }
 
@@ -460,7 +460,7 @@ DEFUN (vnc_defaults_rd,
       ret = str2prefix_rd (argv[1]->arg, &prd);
       if (!ret)
         {
-          vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed rd");
           return CMD_WARNING;
         }
     }
@@ -491,15 +491,14 @@ DEFUN (vnc_defaults_l2rd,
       value = value_l & 0xff;
       if (!argv[1]->arg[0] || *end)
         {
-          vty_out (vty, "%% Malformed l2 nve ID \"%s\"%s", argv[1]->arg,
-                   VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed l2 nve ID \"%s\"",argv[1]->arg);
           return CMD_WARNING;
         }
       if ((value_l < 1) || (value_l > 0xff))
         {
-          vty_out (vty,
-                   "%% Malformed l2 nve id (must be greater than 0 and less than %u%s",
-                   0x100, VTY_NEWLINE);
+          vty_outln (vty,
+                   "%% Malformed l2 nve id (must be greater than 0 and less than %u",
+                   0x100);
           return CMD_WARNING;
         }
     }
@@ -801,20 +800,20 @@ DEFUN (vnc_redistribute_rh_roo_localadmin,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "RFAPI not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "RFAPI not configured");
       return CMD_WARNING;
     }
 
   localadmin = strtoul (argv[4]->arg, &endptr, 0);
   if (!argv[4]->arg[0] || *endptr)
     {
-      vty_out (vty, "%% Malformed value%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed value");
       return CMD_WARNING;
     }
 
   if (localadmin > 0xffff)
     {
-      vty_out (vty, "%% Value out of range (0-%d)%s", 0xffff, VTY_NEWLINE);
+      vty_outln (vty, "%% Value out of range (0-%d)", 0xffff);
       return CMD_WARNING;
     }
 
@@ -857,7 +856,7 @@ DEFUN (vnc_redistribute_mode,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "RFAPI not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "RFAPI not configured");
       return CMD_WARNING;
     }
 
@@ -877,7 +876,7 @@ DEFUN (vnc_redistribute_mode,
       break;
 
     default:
-      vty_out (vty, "unknown redistribute mode%s", VTY_NEWLINE);
+      vty_outln (vty, "unknown redistribute mode");
       return CMD_WARNING;
     }
 
@@ -912,13 +911,13 @@ DEFUN (vnc_redistribute_protocol,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "RFAPI not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "RFAPI not configured");
       return CMD_WARNING;
     }
 
   if (rfapi_str2route_type (argv[2]->arg, argv[3]->arg, &afi, &type))
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Invalid route type");
       return CMD_WARNING;
     }
 
@@ -960,13 +959,13 @@ DEFUN (vnc_no_redistribute_protocol,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "RFAPI not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "RFAPI not configured");
       return CMD_WARNING;
     }
 
   if (rfapi_str2route_type (argv[3]->arg, argv[4]->arg, &afi, &type))
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Invalid route type");
       return CMD_WARNING;
     }
 
@@ -1001,13 +1000,13 @@ DEFUN (vnc_redistribute_bgp_exterior,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "RFAPI not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "RFAPI not configured");
       return CMD_WARNING;
     }
 
   if (rfapi_str2route_type (argv[2]->arg, "bgp-direct-to-nve-groups", &afi, &type))
     {
-      vty_out (vty, "%% Invalid route type%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Invalid route type");
       return CMD_WARNING;
     }
 
@@ -1033,7 +1032,7 @@ DEFUN (vnc_redistribute_nvegroup,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1066,7 +1065,7 @@ DEFUN (vnc_redistribute_no_nvegroup,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1096,7 +1095,7 @@ DEFUN (vnc_redistribute_lifetime,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1136,7 +1135,7 @@ DEFUN (vnc_redist_bgpdirect_no_prefixlist,
 
   if (!(hc = bgp->rfapi_cfg))
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1189,7 +1188,7 @@ DEFUN (vnc_redist_bgpdirect_prefixlist,
 
   if (!(hc = bgp->rfapi_cfg))
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1239,7 +1238,7 @@ DEFUN (vnc_redist_bgpdirect_no_routemap,
 
   if (!(hc = bgp->rfapi_cfg))
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1279,7 +1278,7 @@ DEFUN (vnc_redist_bgpdirect_routemap,
 
   if (!(hc = bgp->rfapi_cfg))
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1324,7 +1323,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_no_prefixlist,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1332,7 +1331,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_no_prefixlist,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -1373,7 +1372,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_prefixlist,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1381,7 +1380,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_prefixlist,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -1421,7 +1420,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_no_routemap,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1429,7 +1428,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_no_routemap,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -1457,7 +1456,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_routemap,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1465,7 +1464,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_routemap,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -1506,7 +1505,7 @@ DEFUN (vnc_export_mode,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "VNC not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "VNC not configured");
       return CMD_WARNING;
     }
 
@@ -1528,13 +1527,13 @@ DEFUN (vnc_export_mode,
           newmode = BGP_VNC_CONFIG_EXPORT_BGP_MODE_RH;
           break;
         default:
-          vty_out (vty, "Invalid mode specified%s", VTY_NEWLINE);
+          vty_outln (vty, "Invalid mode specified");
           return CMD_WARNING;
         }
 
       if (newmode == oldmode)
         {
-          vty_out (vty, "Mode unchanged%s", VTY_NEWLINE);
+          vty_outln (vty, "Mode unchanged");
           return CMD_SUCCESS;
         }
 
@@ -1552,8 +1551,7 @@ DEFUN (vnc_export_mode,
       /*
        * export to zebra with RH mode is not yet implemented
        */
-      vty_out (vty, "Changing modes for zebra export not implemented yet%s",
-               VTY_NEWLINE);
+      vty_outln (vty,"Changing modes for zebra export not implemented yet");
       return CMD_WARNING;
 
       oldmode = bgp->rfapi_cfg->flags & BGP_VNC_CONFIG_EXPORT_ZEBRA_MODE_BITS;
@@ -1593,7 +1591,7 @@ DEFUN (vnc_export_mode,
             }
           break;
         default:
-          vty_out (vty, "Invalid mode%s", VTY_NEWLINE);
+          vty_outln (vty, "Invalid mode");
           return CMD_WARNING;
         }
     }
@@ -1628,7 +1626,7 @@ DEFUN (vnc_export_nvegroup,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1730,7 +1728,7 @@ DEFUN (vnc_no_export_nvegroup,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1791,7 +1789,7 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1799,7 +1797,7 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -1860,7 +1858,7 @@ DEFUN (vnc_nve_group_export_prefixlist,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1868,7 +1866,7 @@ DEFUN (vnc_nve_group_export_prefixlist,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -1917,7 +1915,7 @@ DEFUN (vnc_nve_group_export_no_routemap,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1925,7 +1923,7 @@ DEFUN (vnc_nve_group_export_no_routemap,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -1976,7 +1974,7 @@ DEFUN (vnc_nve_group_export_routemap,
 
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -1984,7 +1982,7 @@ DEFUN (vnc_nve_group_export_routemap,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -2027,7 +2025,7 @@ DEFUN (vnc_nve_export_no_prefixlist,
 
   if (!(hc = bgp->rfapi_cfg))
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -2089,7 +2087,7 @@ DEFUN (vnc_nve_export_prefixlist,
 
   if (!(hc = bgp->rfapi_cfg))
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -2136,7 +2134,7 @@ DEFUN (vnc_nve_export_no_routemap,
 
   if (!(hc = bgp->rfapi_cfg))
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -2188,7 +2186,7 @@ DEFUN (vnc_nve_export_routemap,
 
   if (!(hc = bgp->rfapi_cfg))
     {
-      vty_out (vty, "rfapi not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "rfapi not configured");
       return CMD_WARNING;
     }
 
@@ -2611,8 +2609,7 @@ bgp_rfapi_delete_nve_group (
                 vty_out (vty, " un=");
               rfapiPrintRfapiIpAddr (vty, &rfd->un_addr);
               if (vty)
-                vty_out (vty, " to new group \"%s\"%s", rfd->rfg->name,
-                         VTY_NEWLINE);
+                vty_outln (vty, " to new group \"%s\"",rfd->rfg->name);
 
             }
         }
@@ -2626,7 +2623,7 @@ bgp_rfapi_delete_nve_group (
             vty_out (vty, " un=");
           rfapiPrintRfapiIpAddr (vty, &rfd->un_addr);
           if (vty)
-            vty_out (vty, "%s", VTY_NEWLINE);
+            vty_outln (vty, "");
         }
       list_delete (orphaned_nves);
     }
@@ -2650,8 +2647,7 @@ bgp_rfapi_delete_named_nve_group (
       if (!rfg)
         {
           if (vty)
-            vty_out (vty, "No NVE group named \"%s\"%s", rfg_name,
-                     VTY_NEWLINE);
+            vty_outln (vty, "No NVE group named \"%s\"",rfg_name);
           return CMD_WARNING;
         }
     }
@@ -2741,20 +2737,20 @@ DEFUN (vnc_nve_group_prefix,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
   if (!str2prefix (argv[2]->arg, &p))
     {
-      vty_out (vty, "Malformed prefix \"%s\"%s", argv[2]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix \"%s\"", argv[2]->arg);
       return CMD_WARNING;
     }
 
   afi = family2afi (p.family);
   if (!afi)
     {
-      vty_out (vty, "Unsupported address family%s", VTY_NEWLINE);
+      vty_outln (vty, "Unsupported address family");
       return CMD_WARNING;
     }
 
@@ -2780,9 +2776,9 @@ DEFUN (vnc_nve_group_prefix,
           /*
            * different group name: fail
            */
-          vty_out (vty, "nve group \"%s\" already has \"%s\" prefix %s%s",
+          vty_outln (vty, "nve group \"%s\" already has \"%s\" prefix %s",
                    ((struct rfapi_nve_group_cfg *) (rn->info))->name,
-                   argv[1]->arg, argv[2]->arg, VTY_NEWLINE);
+                   argv[1]->arg, argv[2]->arg);
           return CMD_WARNING;
         }
       else
@@ -2860,7 +2856,7 @@ DEFUN (vnc_nve_group_rt_import,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -2926,7 +2922,7 @@ DEFUN (vnc_nve_group_rt_export,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -2964,7 +2960,7 @@ DEFUN (vnc_nve_group_rt_both,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3045,7 +3041,7 @@ DEFUN (vnc_nve_group_l2rd,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3061,15 +3057,14 @@ DEFUN (vnc_nve_group_l2rd,
 
       if (!argv[1]->arg[0] || *end)
         {
-          vty_out (vty, "%% Malformed l2 nve ID \"%s\"%s", argv[1]->arg,
-                   VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed l2 nve ID \"%s\"",argv[1]->arg);
           return CMD_WARNING;
         }
       if ((value_l < 1) || (value_l > 0xff))
         {
-          vty_out (vty,
-                   "%% Malformed l2 nve id (must be greater than 0 and less than %u%s",
-                   0x100, VTY_NEWLINE);
+          vty_outln (vty,
+                   "%% Malformed l2 nve id (must be greater than 0 and less than %u",
+                   0x100);
           return CMD_WARNING;
         }
 
@@ -3093,7 +3088,7 @@ DEFUN (vnc_nve_group_no_l2rd,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3118,7 +3113,7 @@ DEFUN (vnc_nve_group_rd,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3134,13 +3129,13 @@ DEFUN (vnc_nve_group_rd,
 
       if (!argv[1]->arg[8] || *end)
         {
-          vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed rd");
           return CMD_WARNING;
         }
       if (value32 > 0xffff)
         {
-          vty_out (vty, "%% Malformed rd (must be less than %u%s",
-                   0x0ffff, VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed rd (must be less than %u",
+                   0x0ffff);
           return CMD_WARNING;
         }
 
@@ -3159,7 +3154,7 @@ DEFUN (vnc_nve_group_rd,
       ret = str2prefix_rd (argv[1]->arg, &prd);
       if (!ret)
         {
-          vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed rd");
           return CMD_WARNING;
         }
     }
@@ -3194,7 +3189,7 @@ DEFUN (vnc_nve_group_responselifetime,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3300,7 +3295,7 @@ DEFUN (vnc_no_vrf_policy,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
   return bgp_rfapi_delete_named_nve_group (vty, bgp, argv[2]->arg, RFAPI_GROUP_CFG_VRF);
@@ -3319,7 +3314,7 @@ DEFUN (vnc_vrf_policy_label,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -3327,7 +3322,7 @@ DEFUN (vnc_vrf_policy_label,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3360,7 +3355,7 @@ DEFUN (vnc_vrf_policy_no_label,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current VRF group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current VRF group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3395,7 +3390,7 @@ DEFUN (vnc_vrf_policy_nexthop,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current VRF no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current VRF no longer exists");
       return CMD_WARNING;
     }
 
@@ -3445,7 +3440,7 @@ DEFUN (vnc_vrf_policy_rt_import,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -3453,7 +3448,7 @@ DEFUN (vnc_vrf_policy_rt_import,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3517,7 +3512,7 @@ DEFUN (vnc_vrf_policy_rt_export,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -3525,7 +3520,7 @@ DEFUN (vnc_vrf_policy_rt_export,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3561,7 +3556,7 @@ DEFUN (vnc_vrf_policy_rt_both,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -3569,7 +3564,7 @@ DEFUN (vnc_vrf_policy_rt_both,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3649,7 +3644,7 @@ DEFUN (vnc_vrf_policy_rd,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -3657,7 +3652,7 @@ DEFUN (vnc_vrf_policy_rd,
   if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3673,13 +3668,13 @@ DEFUN (vnc_vrf_policy_rd,
 
       if (!*(argv[1]->arg + 5) || *end)
         {
-          vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed rd");
           return CMD_WARNING;
         }
       if (value32 > 0xffff)
         {
-          vty_out (vty, "%% Malformed rd (must be less than %u%s",
-                   0x0ffff, VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed rd (must be less than %u",
+                   0x0ffff);
           return CMD_WARNING;
         }
 
@@ -3698,7 +3693,7 @@ DEFUN (vnc_vrf_policy_rd,
       ret = str2prefix_rd (argv[1]->arg, &prd);
       if (!ret)
         {
-          vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed rd");
           return CMD_WARNING;
         }
     }
@@ -3816,8 +3811,7 @@ bgp_rfapi_delete_named_l2_group (
       if (!rfg)
         {
           if (vty)
-            vty_out (vty, "No L2 group named \"%s\"%s", rfg_name,
-                     VTY_NEWLINE);
+            vty_outln (vty, "No L2 group named \"%s\"",rfg_name);
           return CMD_WARNING;
         }
     }
@@ -3842,7 +3836,7 @@ DEFUN (vnc_no_l2_group,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
   return bgp_rfapi_delete_named_l2_group (vty, bgp, argv[3]->arg);
@@ -3860,7 +3854,7 @@ DEFUN (vnc_l2_group_lni,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -3868,7 +3862,7 @@ DEFUN (vnc_l2_group_lni,
   if (!listnode_lookup (bgp->rfapi_cfg->l2_groups, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current L2 group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current L2 group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3889,7 +3883,7 @@ DEFUN (vnc_l2_group_labels,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -3897,7 +3891,7 @@ DEFUN (vnc_l2_group_labels,
   if (!listnode_lookup (bgp->rfapi_cfg->l2_groups, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current L2 group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current L2 group no longer exists");
       return CMD_WARNING;
     }
 
@@ -3934,7 +3928,7 @@ DEFUN (vnc_l2_group_no_labels,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -3942,14 +3936,14 @@ DEFUN (vnc_l2_group_no_labels,
   if (!listnode_lookup (bgp->rfapi_cfg->l2_groups, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current L2 group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current L2 group no longer exists");
       return CMD_WARNING;
     }
 
   ll = rfg->labels;
   if (ll == NULL)
     {
-      vty_out (vty, "Label no longer associated with group%s", VTY_NEWLINE);
+      vty_outln (vty, "Label no longer associated with group");
       return CMD_WARNING;
     }
 
@@ -3991,13 +3985,13 @@ DEFUN (vnc_l2_group_rt,
       do_export = 1;
       break;
     default:
-      vty_out (vty, "Unknown option, %s%s", argv[1]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Unknown option, %s", argv[1]->arg);
       return CMD_ERR_NO_MATCH;
 
     }
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
 
@@ -4005,7 +3999,7 @@ DEFUN (vnc_l2_group_rt,
   if (!listnode_lookup (bgp->rfapi_cfg->l2_groups, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current L2 group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current L2 group no longer exists");
       return CMD_WARNING;
     }
 
@@ -4281,20 +4275,20 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
   if (bgp->rfapi == NULL || hc == NULL)
     return write;
 
-  vty_out (vty, "!%s", VTY_NEWLINE);
+  vty_outln (vty, "!");
   for (ALL_LIST_ELEMENTS (hc->nve_groups_sequential, node, nnode, rfg))
     if (rfg->type == RFAPI_GROUP_CFG_VRF)
       {
         ++write;
-        vty_out (vty, " vrf-policy %s%s", rfg->name, VTY_NEWLINE);
+        vty_outln (vty, " vrf-policy %s", rfg->name);
         if (rfg->label <= MPLS_LABEL_MAX)
           {
-            vty_out (vty, "  label %u%s", rfg->label, VTY_NEWLINE);
+            vty_outln (vty, "  label %u", rfg->label);
 
           }
         if (CHECK_FLAG (rfg->flags, RFAPI_RFG_VPN_NH_SELF))
           {
-            vty_out (vty, "  nexthop self%s", VTY_NEWLINE);
+            vty_outln (vty, "  nexthop self");
 
           }
         else 
@@ -4310,7 +4304,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                   }
                 else
                   {
-                    vty_out (vty, "  nexthop %s%s", buf, VTY_NEWLINE);
+                    vty_outln (vty, "  nexthop %s", buf);
                   }
               }
           }
@@ -4328,7 +4322,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                 value = ((rfg->rd.val[6] << 8) & 0x0ff00) |
                   (rfg->rd.val[7] & 0x0ff);
 
-                vty_out (vty, "  rd auto:nh:%d%s", value, VTY_NEWLINE);
+                vty_outln (vty, "  rd auto:nh:%d", value);
 
               }
             else
@@ -4338,11 +4332,11 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                     !buf[0] || buf[BUFSIZ - 1])
                   {
 
-                    vty_out (vty, "!Error: Can't convert rd%s", VTY_NEWLINE);
+                    vty_outln (vty, "!Error: Can't convert rd");
                   }
                 else
                   {
-                    vty_out (vty, "  rd %s%s", buf, VTY_NEWLINE);
+                    vty_outln (vty, "  rd %s", buf);
                   }
               }
           }
@@ -4352,7 +4346,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
           {
             char *b = ecommunity_ecom2str (rfg->rt_import_list,
                                            ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-            vty_out (vty, "  rt both %s%s", b, VTY_NEWLINE);
+            vty_outln (vty, "  rt both %s", b);
             XFREE (MTYPE_ECOMMUNITY_STR, b);
           }
         else
@@ -4361,14 +4355,14 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
               {
                 char *b = ecommunity_ecom2str (rfg->rt_import_list,
                                                ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-                vty_out (vty, "  rt import %s%s", b, VTY_NEWLINE);
+                vty_outln (vty, "  rt import %s", b);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
             if (rfg->rt_export_list)
               {
                 char *b = ecommunity_ecom2str (rfg->rt_export_list,
                                                ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-                vty_out (vty, "  rt export %s%s", b, VTY_NEWLINE);
+                vty_outln (vty, "  rt export %s", b);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
           }
@@ -4383,15 +4377,13 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
 
             if (rfg->plist_export_bgp_name[afi])
               {
-                vty_out (vty, "  export bgp %s prefix-list %s%s",
-                         afistr, rfg->plist_export_bgp_name[afi],
-                         VTY_NEWLINE);
+                vty_outln (vty, "  export bgp %s prefix-list %s",
+                         afistr,rfg->plist_export_bgp_name[afi]);
               }
             if (rfg->plist_export_zebra_name[afi])
               {
-                vty_out (vty, "  export zebra %s prefix-list %s%s",
-                         afistr, rfg->plist_export_zebra_name[afi],
-                         VTY_NEWLINE);
+                vty_outln (vty, "  export zebra %s prefix-list %s",
+                         afistr,rfg->plist_export_zebra_name[afi]);
               }
             /*
              * currently we only support redist plists for bgp-direct.
@@ -4400,50 +4392,46 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
              */
             if (rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi])
               {
-                vty_out (vty, "  redistribute bgp-direct %s prefix-list %s%s",
+                vty_outln (vty, "  redistribute bgp-direct %s prefix-list %s",
                          afistr,
-                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi],
-                         VTY_NEWLINE);
+                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi]);
               }
             if (rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT][afi])
               {
-                vty_out (vty,
-                         "  redistribute bgp-direct-to-nve-groups %s prefix-list %s%s",
+                vty_outln (vty,
+                         "  redistribute bgp-direct-to-nve-groups %s prefix-list %s",
                          afistr,
-                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT]
-                         [afi], VTY_NEWLINE);
+                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT][afi]);
               }
           }
 
         if (rfg->routemap_export_bgp_name)
           {
-            vty_out (vty, "  export bgp route-map %s%s",
-                     rfg->routemap_export_bgp_name, VTY_NEWLINE);
+            vty_outln (vty, "  export bgp route-map %s",
+                     rfg->routemap_export_bgp_name);
           }
         if (rfg->routemap_export_zebra_name)
           {
-            vty_out (vty, "  export zebra route-map %s%s",
-                     rfg->routemap_export_zebra_name, VTY_NEWLINE);
+            vty_outln (vty, "  export zebra route-map %s",
+                     rfg->routemap_export_zebra_name);
           }
         if (rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT])
           {
-            vty_out (vty, "  redistribute bgp-direct route-map %s%s",
-                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT],
-                     VTY_NEWLINE);
+            vty_outln (vty, "  redistribute bgp-direct route-map %s",
+                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT]);
           }
         if (rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT])
           {
-            vty_out (vty,
-                     "  redistribute bgp-direct-to-nve-groups route-map %s%s",
-                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT],
-                     VTY_NEWLINE);
+            vty_outln (vty,
+                     "  redistribute bgp-direct-to-nve-groups route-map %s",
+                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT]);
           }
-        vty_out (vty, "  exit-vrf-policy%s", VTY_NEWLINE);
-        vty_out (vty, "!%s", VTY_NEWLINE);
+        vty_outln (vty, "  exit-vrf-policy");
+        vty_outln (vty, "!");
       }
   if (hc->flags & BGP_VNC_CONFIG_ADV_UN_METHOD_ENCAP)
     {
-      vty_out (vty, " vnc advertise-un-method encap-safi%s", VTY_NEWLINE);
+      vty_outln (vty, " vnc advertise-un-method encap-safi");
       write++;
     }
 
@@ -4453,7 +4441,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
       write += (bgp->rfapi->rfp_methods.cfg_cb) (vty, bgp->rfapi->rfp);
 
     if (write)
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_outln (vty, "!");
 
     if (hc->l2_groups)
       {
@@ -4464,10 +4452,10 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
             struct listnode *lnode;
             void *data;
             ++write;
-            vty_out (vty, " vnc l2-group %s%s", rfg->name, VTY_NEWLINE);
+            vty_outln (vty, " vnc l2-group %s", rfg->name);
             if (rfg->logical_net_id != 0)
-              vty_out (vty, "   logical-network-id %u%s", rfg->logical_net_id,
-                       VTY_NEWLINE);
+              vty_outln (vty, "   logical-network-id %u",
+                         rfg->logical_net_id);
             if (rfg->labels != NULL && listhead (rfg->labels) != NULL)
               {
                 vty_out (vty, "   labels ");
@@ -4475,7 +4463,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                   {
                     vty_out (vty, "%hu ", (uint16_t) ((uintptr_t) data));
                   }
-                vty_out (vty, "%s", VTY_NEWLINE);
+                vty_outln (vty, "");
               }
 
             if (rfg->rt_import_list && rfg->rt_export_list &&
@@ -4483,7 +4471,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
               {
                 char *b = ecommunity_ecom2str (rfg->rt_import_list,
                                                ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-                vty_out (vty, "   rt both %s%s", b, VTY_NEWLINE);
+                vty_outln (vty, "   rt both %s", b);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
             else
@@ -4492,14 +4480,14 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                   {
                     char *b = ecommunity_ecom2str (rfg->rt_import_list,
                                                    ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-                    vty_out (vty, "  rt import %s%s", b, VTY_NEWLINE);
+                    vty_outln (vty, "  rt import %s", b);
                     XFREE (MTYPE_ECOMMUNITY_STR, b);
                   }
                 if (rfg->rt_export_list)
                   {
                     char *b = ecommunity_ecom2str (rfg->rt_export_list,
                                                    ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-                    vty_out (vty, "  rt export %s%s", b, VTY_NEWLINE);
+                    vty_outln (vty, "  rt export %s", b);
                     XFREE (MTYPE_ECOMMUNITY_STR, b);
                   }
               }
@@ -4510,8 +4498,8 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                                                         RFAPI_RFP_CFG_GROUP_L2,
                                                         rfg->name,
                                                         rfg->rfp_cfg);
-            vty_out (vty, "   exit-vnc%s", VTY_NEWLINE);
-            vty_out (vty, "!%s", VTY_NEWLINE);
+            vty_outln (vty, "   exit-vnc");
+            vty_outln (vty, "!");
           }
       }
 
@@ -4523,7 +4511,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
 
 
         ++write;
-        vty_out (vty, " vnc defaults%s", VTY_NEWLINE);
+        vty_outln (vty, " vnc defaults");
 
         if (hc->default_rd.prefixlen)
           {
@@ -4537,7 +4525,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                 value = ((hc->default_rd.val[6] << 8) & 0x0ff00) |
                   (hc->default_rd.val[7] & 0x0ff);
 
-                vty_out (vty, "  rd auto:vn:%d%s", value, VTY_NEWLINE);
+                vty_outln (vty, "  rd auto:vn:%d", value);
 
               }
             else
@@ -4547,11 +4535,11 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                     !buf[0] || buf[BUFSIZ - 1])
                   {
 
-                    vty_out (vty, "!Error: Can't convert rd%s", VTY_NEWLINE);
+                    vty_outln (vty, "!Error: Can't convert rd");
                   }
                 else
                   {
-                    vty_out (vty, "  rd %s%s", buf, VTY_NEWLINE);
+                    vty_outln (vty, "  rd %s", buf);
                   }
               }
           }
@@ -4562,7 +4550,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
               vty_out (vty, "%d", hc->default_response_lifetime);
             else
               vty_out (vty, "infinite");
-            vty_out (vty, "%s", VTY_NEWLINE);
+            vty_outln (vty, "");
           }
         if (hc->default_rt_import_list && hc->default_rt_export_list &&
             ecommunity_cmp (hc->default_rt_import_list,
@@ -4570,7 +4558,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
           {
             char *b = ecommunity_ecom2str (hc->default_rt_import_list,
                                            ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-            vty_out (vty, "  rt both %s%s", b, VTY_NEWLINE);
+            vty_outln (vty, "  rt both %s", b);
             XFREE (MTYPE_ECOMMUNITY_STR, b);
           }
         else
@@ -4579,14 +4567,14 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
               {
                 char *b = ecommunity_ecom2str (hc->default_rt_import_list,
                                                ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-                vty_out (vty, "  rt import %s%s", b, VTY_NEWLINE);
+                vty_outln (vty, "  rt import %s", b);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
             if (hc->default_rt_export_list)
               {
                 char *b = ecommunity_ecom2str (hc->default_rt_export_list,
                                                ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-                vty_out (vty, "  rt export %s%s", b, VTY_NEWLINE);
+                vty_outln (vty, "  rt export %s", b);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
           }
@@ -4597,15 +4585,15 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                                                     RFAPI_RFP_CFG_GROUP_DEFAULT,
                                                     NULL,
                                                     bgp->rfapi_cfg->default_rfp_cfg);
-        vty_out (vty, "  exit-vnc%s", VTY_NEWLINE);
-        vty_out (vty, "!%s", VTY_NEWLINE);
+        vty_outln (vty, "  exit-vnc");
+        vty_outln (vty, "!");
       }
 
     for (ALL_LIST_ELEMENTS (hc->nve_groups_sequential, node, nnode, rfg))
       if (rfg->type == RFAPI_GROUP_CFG_NVE)
       {
         ++write;
-        vty_out (vty, " vnc nve-group %s%s", rfg->name, VTY_NEWLINE);
+        vty_outln (vty, " vnc nve-group %s", rfg->name);
 
         if (rfg->vn_prefix.family && rfg->vn_node)
           {
@@ -4615,11 +4603,11 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
             prefix2str (&rfg->vn_prefix, buf, BUFSIZ);
             if (!buf[0] || buf[BUFSIZ - 1])
               {
-                vty_out (vty, "!Error: Can't convert prefix%s", VTY_NEWLINE);
+                vty_outln (vty, "!Error: Can't convert prefix");
               }
             else
               {
-                vty_out (vty, "  prefix %s %s%s", "vn", buf, VTY_NEWLINE);
+                vty_outln (vty, "  prefix %s %s", "vn", buf);
               }
           }
 
@@ -4630,11 +4618,11 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
             prefix2str (&rfg->un_prefix, buf, BUFSIZ);
             if (!buf[0] || buf[BUFSIZ - 1])
               {
-                vty_out (vty, "!Error: Can't convert prefix%s", VTY_NEWLINE);
+                vty_outln (vty, "!Error: Can't convert prefix");
               }
             else
               {
-                vty_out (vty, "  prefix %s %s%s", "un", buf, VTY_NEWLINE);
+                vty_outln (vty, "  prefix %s %s", "un", buf);
               }
           }
 
@@ -4652,7 +4640,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                 value = ((rfg->rd.val[6] << 8) & 0x0ff00) |
                   (rfg->rd.val[7] & 0x0ff);
 
-                vty_out (vty, "  rd auto:vn:%d%s", value, VTY_NEWLINE);
+                vty_outln (vty, "  rd auto:vn:%d", value);
 
               }
             else
@@ -4662,11 +4650,11 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                     !buf[0] || buf[BUFSIZ - 1])
                   {
 
-                    vty_out (vty, "!Error: Can't convert rd%s", VTY_NEWLINE);
+                    vty_outln (vty, "!Error: Can't convert rd");
                   }
                 else
                   {
-                    vty_out (vty, "  rd %s%s", buf, VTY_NEWLINE);
+                    vty_outln (vty, "  rd %s", buf);
                   }
               }
           }
@@ -4677,7 +4665,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
               vty_out (vty, "%d", rfg->response_lifetime);
             else
               vty_out (vty, "infinite");
-            vty_out (vty, "%s", VTY_NEWLINE);
+            vty_outln (vty, "");
           }
 
         if (rfg->rt_import_list && rfg->rt_export_list &&
@@ -4686,7 +4674,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
             char *b = ecommunity_ecom2str (rfg->rt_import_list,
                                            ECOMMUNITY_FORMAT_ROUTE_MAP,
                                            ECOMMUNITY_ROUTE_TARGET);
-            vty_out (vty, "  rt both %s%s", b, VTY_NEWLINE);
+            vty_outln (vty, "  rt both %s", b);
             XFREE (MTYPE_ECOMMUNITY_STR, b);
           }
         else
@@ -4696,14 +4684,14 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                 char *b = ecommunity_ecom2str (rfg->rt_import_list,
                                                ECOMMUNITY_FORMAT_ROUTE_MAP,
                                                ECOMMUNITY_ROUTE_TARGET);
-                vty_out (vty, "  rt import %s%s", b, VTY_NEWLINE);
+                vty_outln (vty, "  rt import %s", b);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
             if (rfg->rt_export_list)
               {
                 char *b = ecommunity_ecom2str (rfg->rt_export_list,
                                                ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
-                vty_out (vty, "  rt export %s%s", b, VTY_NEWLINE);
+                vty_outln (vty, "  rt export %s", b);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
           }
@@ -4718,15 +4706,13 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
 
             if (rfg->plist_export_bgp_name[afi])
               {
-                vty_out (vty, "  export bgp %s prefix-list %s%s",
-                         afistr, rfg->plist_export_bgp_name[afi],
-                         VTY_NEWLINE);
+                vty_outln (vty, "  export bgp %s prefix-list %s",
+                         afistr,rfg->plist_export_bgp_name[afi]);
               }
             if (rfg->plist_export_zebra_name[afi])
               {
-                vty_out (vty, "  export zebra %s prefix-list %s%s",
-                         afistr, rfg->plist_export_zebra_name[afi],
-                         VTY_NEWLINE);
+                vty_outln (vty, "  export zebra %s prefix-list %s",
+                         afistr,rfg->plist_export_zebra_name[afi]);
               }
             /*
              * currently we only support redist plists for bgp-direct.
@@ -4735,43 +4721,39 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
              */
             if (rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi])
               {
-                vty_out (vty, "  redistribute bgp-direct %s prefix-list %s%s",
+                vty_outln (vty, "  redistribute bgp-direct %s prefix-list %s",
                          afistr,
-                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi],
-                         VTY_NEWLINE);
+                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi]);
               }
             if (rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT][afi])
               {
-                vty_out (vty,
-                         "  redistribute bgp-direct-to-nve-groups %s prefix-list %s%s",
+                vty_outln (vty,
+                         "  redistribute bgp-direct-to-nve-groups %s prefix-list %s",
                          afistr,
-                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT]
-                         [afi], VTY_NEWLINE);
+                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT][afi]);
               }
           }
 
         if (rfg->routemap_export_bgp_name)
           {
-            vty_out (vty, "  export bgp route-map %s%s",
-                     rfg->routemap_export_bgp_name, VTY_NEWLINE);
+            vty_outln (vty, "  export bgp route-map %s",
+                     rfg->routemap_export_bgp_name);
           }
         if (rfg->routemap_export_zebra_name)
           {
-            vty_out (vty, "  export zebra route-map %s%s",
-                     rfg->routemap_export_zebra_name, VTY_NEWLINE);
+            vty_outln (vty, "  export zebra route-map %s",
+                     rfg->routemap_export_zebra_name);
           }
         if (rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT])
           {
-            vty_out (vty, "  redistribute bgp-direct route-map %s%s",
-                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT],
-                     VTY_NEWLINE);
+            vty_outln (vty, "  redistribute bgp-direct route-map %s",
+                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT]);
           }
         if (rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT])
           {
-            vty_out (vty,
-                     "  redistribute bgp-direct-to-nve-groups route-map %s%s",
-                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT],
-                     VTY_NEWLINE);
+            vty_outln (vty,
+                     "  redistribute bgp-direct-to-nve-groups route-map %s",
+                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT]);
           }
         if (bgp->rfapi->rfp_methods.cfg_group_cb)
           write +=
@@ -4779,8 +4761,8 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                                                     bgp->rfapi->rfp,
                                                     RFAPI_RFP_CFG_GROUP_NVE,
                                                     rfg->name, rfg->rfp_cfg);
-        vty_out (vty, "  exit-vnc%s", VTY_NEWLINE);
-        vty_out (vty, "!%s", VTY_NEWLINE);
+        vty_outln (vty, "  exit-vnc");
+        vty_outln (vty, "!");
       }
   }                             /* have listen ports */
 
@@ -4789,24 +4771,24 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
    */
   if (VNC_EXPORT_BGP_GRP_ENABLED (hc))
     {
-      vty_out (vty, " vnc export bgp mode group-nve%s", VTY_NEWLINE);
+      vty_outln (vty, " vnc export bgp mode group-nve");
     }
   else if (VNC_EXPORT_BGP_RH_ENABLED (hc))
     {
-      vty_out (vty, " vnc export bgp mode registering-nve%s", VTY_NEWLINE);
+      vty_outln (vty, " vnc export bgp mode registering-nve");
     }
   else if (VNC_EXPORT_BGP_CE_ENABLED (hc))
     {
-      vty_out (vty, " vnc export bgp mode ce%s", VTY_NEWLINE);
+      vty_outln (vty, " vnc export bgp mode ce");
     }
 
   if (VNC_EXPORT_ZEBRA_GRP_ENABLED (hc))
     {
-      vty_out (vty, " vnc export zebra mode group-nve%s", VTY_NEWLINE);
+      vty_outln (vty, " vnc export zebra mode group-nve");
     }
   else if (VNC_EXPORT_ZEBRA_RH_ENABLED (hc))
     {
-      vty_out (vty, " vnc export zebra mode registering-nve%s", VTY_NEWLINE);
+      vty_outln (vty, " vnc export zebra mode registering-nve");
     }
 
   if (hc->rfg_export_direct_bgp_l)
@@ -4814,8 +4796,8 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
       for (ALL_LIST_ELEMENTS (hc->rfg_export_direct_bgp_l, node, nnode, rfgn))
         {
 
-          vty_out (vty, " vnc export bgp group-nve group %s%s",
-                   rfgn->name, VTY_NEWLINE);
+          vty_outln (vty, " vnc export bgp group-nve group %s",
+                   rfgn->name);
         }
     }
 
@@ -4824,28 +4806,28 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
       for (ALL_LIST_ELEMENTS (hc->rfg_export_zebra_l, node, nnode, rfgn))
         {
 
-          vty_out (vty, " vnc export zebra group-nve group %s%s",
-                   rfgn->name, VTY_NEWLINE);
+          vty_outln (vty, " vnc export zebra group-nve group %s",
+                   rfgn->name);
         }
     }
 
 
   if (hc->rfg_redist_name)
     {
-      vty_out (vty, " vnc redistribute nve-group %s%s",
-               hc->rfg_redist_name, VTY_NEWLINE);
+      vty_outln (vty, " vnc redistribute nve-group %s",
+               hc->rfg_redist_name);
     }
   if (hc->redist_lifetime)
     {
-      vty_out (vty, " vnc redistribute lifetime %d%s",
-               hc->redist_lifetime, VTY_NEWLINE);
+      vty_outln (vty, " vnc redistribute lifetime %d",
+               hc->redist_lifetime);
     }
   if (hc->resolve_nve_roo_local_admin !=
       BGP_VNC_CONFIG_RESOLVE_NVE_ROO_LOCAL_ADMIN_DEFAULT)
     {
 
-      vty_out (vty, " vnc redistribute resolve-nve roo-ec-local-admin %d%s",
-               hc->resolve_nve_roo_local_admin, VTY_NEWLINE);
+      vty_outln (vty, " vnc redistribute resolve-nve roo-ec-local-admin %d",
+               hc->resolve_nve_roo_local_admin);
     }
 
   if (hc->redist_mode)          /* ! default */
@@ -4866,7 +4848,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
         }
       if (s)
         {
-          vty_out (vty, " vnc redistribute mode %s%s", s, VTY_NEWLINE);
+          vty_outln (vty, " vnc redistribute mode %s", s);
         }
     }
 
@@ -4880,36 +4862,35 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
 
       if (hc->plist_export_bgp_name[afi])
         {
-          vty_out (vty, " vnc export bgp %s prefix-list %s%s",
-                   afistr, hc->plist_export_bgp_name[afi], VTY_NEWLINE);
+          vty_outln (vty, " vnc export bgp %s prefix-list %s",
+                   afistr, hc->plist_export_bgp_name[afi]);
         }
       if (hc->plist_export_zebra_name[afi])
         {
-          vty_out (vty, " vnc export zebra %s prefix-list %s%s",
-                   afistr, hc->plist_export_zebra_name[afi], VTY_NEWLINE);
+          vty_outln (vty, " vnc export zebra %s prefix-list %s",
+                   afistr, hc->plist_export_zebra_name[afi]);
         }
       if (hc->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi])
         {
-          vty_out (vty, " vnc redistribute bgp-direct %s prefix-list %s%s",
-                   afistr, hc->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi],
-                   VTY_NEWLINE);
+          vty_outln (vty, " vnc redistribute bgp-direct %s prefix-list %s",
+                   afistr,hc->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi]);
         }
     }
 
   if (hc->routemap_export_bgp_name)
     {
-      vty_out (vty, " vnc export bgp route-map %s%s",
-               hc->routemap_export_bgp_name, VTY_NEWLINE);
+      vty_outln (vty, " vnc export bgp route-map %s",
+               hc->routemap_export_bgp_name);
     }
   if (hc->routemap_export_zebra_name)
     {
-      vty_out (vty, " vnc export zebra route-map %s%s",
-               hc->routemap_export_zebra_name, VTY_NEWLINE);
+      vty_outln (vty, " vnc export zebra route-map %s",
+               hc->routemap_export_zebra_name);
     }
   if (hc->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT])
     {
-      vty_out (vty, " vnc redistribute bgp-direct route-map %s%s",
-               hc->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT], VTY_NEWLINE);
+      vty_outln (vty, " vnc redistribute bgp-direct route-map %s",
+               hc->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT]);
     }
 
   for (afi = AFI_IP; afi < AFI_MAX; ++afi)
@@ -4921,16 +4902,16 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
               if (type == ZEBRA_ROUTE_BGP_DIRECT_EXT &&
                   hc->redist_bgp_exterior_view_name)
                 {
-                  vty_out (vty, " vnc redistribute %s %s view %s%s",
+                  vty_outln (vty, " vnc redistribute %s %s view %s",
                            ((afi == AFI_IP) ? "ipv4" : "ipv6"),
                            zebra_route_string (type),
-                           hc->redist_bgp_exterior_view_name, VTY_NEWLINE);
+                           hc->redist_bgp_exterior_view_name);
                 }
               else
                 {
-                  vty_out (vty, " vnc redistribute %s %s%s",
+                  vty_outln (vty, " vnc redistribute %s %s",
                            ((afi == AFI_IP) ? "ipv4" : "ipv6"),
-                           zebra_route_string (type), VTY_NEWLINE);
+                           zebra_route_string(type));
                 }
             }
         }
@@ -4947,12 +4928,10 @@ bgp_rfapi_show_summary (struct bgp *bgp, struct vty *vty)
   if (hc == NULL)
     return;
 
-  vty_out (vty, "%-39s %-19s %s%s", "VNC Advertise method:",
+  vty_outln (vty, "%-39s %-19s %s", "VNC Advertise method:",
            (hc->flags & BGP_VNC_CONFIG_ADV_UN_METHOD_ENCAP
             ? "Encapsulation SAFI" : "Tunnel Encap attribute"),
-           ((hc->flags & BGP_VNC_CONFIG_ADV_UN_METHOD_ENCAP) ==
-            (BGP_VNC_CONFIG_ADV_UN_METHOD_ENCAP &
-             BGP_VNC_CONFIG_FLAGS_DEFAULT) ? "(default)" : ""), VTY_NEWLINE);
+           ((hc->flags & BGP_VNC_CONFIG_ADV_UN_METHOD_ENCAP) == (BGP_VNC_CONFIG_ADV_UN_METHOD_ENCAP & BGP_VNC_CONFIG_FLAGS_DEFAULT) ? "(default)" : ""));
   /* export */
   vty_out (vty, "%-39s ", "Export from VNC:");
   /*
@@ -5016,8 +4995,8 @@ bgp_rfapi_show_summary (struct bgp *bgp, struct vty *vty)
       vty_out (vty, "%sToZebra {Registering NVE}", (redist == 1 ? "" : " "));
       /* note filters, route-maps not shown */
     }
-  vty_out (vty, "%-19s %s%s", (redist ? "" : "Off"),
-           (redist ? "" : "(default)"), VTY_NEWLINE);
+  vty_outln (vty, "%-19s %s", (redist ? "" : "Off"),
+           (redist ? "" : "(default)"));
 
   /* Redistribution */
   redist = 0;
@@ -5035,34 +5014,28 @@ bgp_rfapi_show_summary (struct bgp *bgp, struct vty *vty)
             }
         }
     }
-  vty_out (vty, "%-19s %s%s", (redist ? "" : "Off"),
-           (redist ? "" : "(default)"), VTY_NEWLINE);
+  vty_outln (vty, "%-19s %s", (redist ? "" : "Off"),
+           (redist ? "" : "(default)"));
 
-  vty_out (vty, "%-39s %3u%-16s %s%s", "RFP Registration Hold-Down Factor:",
+  vty_outln (vty, "%-39s %3u%-16s %s", "RFP Registration Hold-Down Factor:",
            hc->rfp_cfg.holddown_factor, "%",
-           (hc->rfp_cfg.holddown_factor ==
-            RFAPI_RFP_CFG_DEFAULT_HOLDDOWN_FACTOR ? "(default)" : ""),
-           VTY_NEWLINE);
-  vty_out (vty, "%-39s %-19s %s%s", "RFP Updated responses:",
+           (hc->rfp_cfg.holddown_factor == RFAPI_RFP_CFG_DEFAULT_HOLDDOWN_FACTOR ? "(default)" : ""));
+  vty_outln (vty, "%-39s %-19s %s", "RFP Updated responses:",
            (hc->rfp_cfg.use_updated_response == 0 ? "Off" : "On"),
-           (hc->rfp_cfg.use_updated_response == 0 ? "(default)" : ""),
-           VTY_NEWLINE);
-  vty_out (vty, "%-39s %-19s %s%s", "RFP Removal responses:",
+           (hc->rfp_cfg.use_updated_response == 0 ? "(default)" : ""));
+  vty_outln (vty, "%-39s %-19s %s", "RFP Removal responses:",
            (hc->rfp_cfg.use_removes == 0 ? "Off" : "On"),
-           (hc->rfp_cfg.use_removes == 0 ? "(default)" : ""), VTY_NEWLINE);
-  vty_out (vty, "%-39s %-19s %s%s", "RFP Full table download:",
+           (hc->rfp_cfg.use_removes == 0 ? "(default)" : ""));
+  vty_outln (vty, "%-39s %-19s %s", "RFP Full table download:",
            (hc->rfp_cfg.download_type ==
             RFAPI_RFP_DOWNLOAD_FULL ? "On" : "Off"),
-           (hc->rfp_cfg.download_type ==
-            RFAPI_RFP_DOWNLOAD_PARTIAL ? "(default)" : ""), VTY_NEWLINE);
+           (hc->rfp_cfg.download_type == RFAPI_RFP_DOWNLOAD_PARTIAL ? "(default)" : ""));
   sprintf (tmp, "%u seconds", hc->rfp_cfg.ftd_advertisement_interval);
-  vty_out (vty, "%-39s %-19s %s%s", "    Advertisement Interval:", tmp,
-           (hc->rfp_cfg.ftd_advertisement_interval ==
-            RFAPI_RFP_CFG_DEFAULT_FTD_ADVERTISEMENT_INTERVAL
-            ? "(default)" : ""), VTY_NEWLINE);
-  vty_out (vty, "%-39s %d seconds%s", "Default RFP response lifetime:",
-           hc->default_response_lifetime, VTY_NEWLINE);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "%-39s %-19s %s", "    Advertisement Interval:", tmp,
+           (hc->rfp_cfg.ftd_advertisement_interval == RFAPI_RFP_CFG_DEFAULT_FTD_ADVERTISEMENT_INTERVAL ? "(default)" : ""));
+  vty_outln (vty, "%-39s %d seconds", "Default RFP response lifetime:",
+           hc->default_response_lifetime);
+  vty_outln (vty, "");
   return;
 }
 

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -3144,7 +3144,7 @@ test_nexthops_callback (
 
   fp (out, "Nexthops Callback, Target=(");
   //rfapiPrintRfapiIpAddr(stream, target);
-  fp (out, ")%s", VTY_NEWLINE);
+  fp (out, ")%s", VTYNL);
 
   rfapiPrintNhl (stream, next_hops);
 
@@ -3838,7 +3838,7 @@ DEFUN (debug_rfapi_show_import,
               if (first_l2)
                 {
                   vty_outln (vty, "%sLNI-based Ethernet Tables:",
-                           VTY_NEWLINE);
+                           VTYNL);
                   first_l2 = 0;
                 }
               snprintf (buf, BUFSIZ, "L2VPN LNI=%u", lni);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -3101,12 +3101,12 @@ DEFUN (
 
   if (!str2prefix (argv[5]->arg, &pfx))
     {
-      vty_out (vty, "Malformed address \"%s\"%s", argv[5]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Malformed address \"%s\"", argv[5]->arg);
       return CMD_WARNING;
     }
   if (pfx.family != AF_INET && pfx.family != AF_INET6)
     {
-      vty_out (vty, "Invalid address \"%s\"%s", argv[5]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Invalid address \"%s\"", argv[5]->arg);
       return CMD_WARNING;
     }
 
@@ -3185,12 +3185,12 @@ DEFUN (debug_rfapi_open,
   rc = rfapi_open (rfapi_get_rfp_start_val_by_bgp (bgp_get_default ()),
                    &vn, &un, /*&uo */ NULL, &lifetime, NULL, &handle);
 
-  vty_out (vty, "rfapi_open: status %d, handle %p, lifetime %d%s",
-           rc, handle, lifetime, VTY_NEWLINE);
+  vty_outln (vty, "rfapi_open: status %d, handle %p, lifetime %d",
+           rc, handle, lifetime);
 
   rc = rfapi_set_response_cb (handle, test_nexthops_callback);
 
-  vty_out (vty, "rfapi_set_response_cb: status %d%s", rc, VTY_NEWLINE);
+  vty_outln (vty, "rfapi_set_response_cb: status %d", rc);
 
   return CMD_SUCCESS;
 }
@@ -3230,15 +3230,14 @@ DEFUN (debug_rfapi_close_vn_un,
 
   if (rfapi_find_handle_vty (vty, &vn, &un, &handle))
     {
-      vty_out (vty, "can't locate handle matching vn=%s, un=%s%s",
-               argv[4]->arg, argv[6]->arg, VTY_NEWLINE);
+      vty_outln (vty, "can't locate handle matching vn=%s, un=%s",
+               argv[4]->arg, argv[6]->arg);
       return CMD_WARNING;
     }
 
   rc = rfapi_close (handle);
 
-  vty_out (vty, "rfapi_close(handle=%p): status %d%s", handle, rc,
-           VTY_NEWLINE);
+  vty_outln (vty, "rfapi_close(handle=%p): status %d", handle,rc);
 
   return CMD_SUCCESS;
 }
@@ -3259,14 +3258,13 @@ DEFUN (debug_rfapi_close_rfd,
 
   if (*endptr != '\0' || (uintptr_t) handle == UINTPTR_MAX)
     {
-      vty_out (vty, "Invalid value: %s%s", argv[4]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Invalid value: %s", argv[4]->arg);
       return CMD_WARNING;
     }
 
   rc = rfapi_close (handle);
 
-  vty_out (vty, "rfapi_close(handle=%p): status %d%s", handle, rc,
-           VTY_NEWLINE);
+  vty_outln (vty, "rfapi_close(handle=%p): status %d", handle,rc);
 
   return CMD_SUCCESS;
 }
@@ -3313,8 +3311,8 @@ DEFUN (debug_rfapi_register_vn_un,
 
   if (rfapi_find_handle_vty (vty, &vn, &un, &handle))
     {
-      vty_out (vty, "can't locate handle matching vn=%s, un=%s%s",
-               argv[4]->arg, argv[6]->arg, VTY_NEWLINE);
+      vty_outln (vty, "can't locate handle matching vn=%s, un=%s",
+               argv[4]->arg, argv[6]->arg);
       return CMD_WARNING;
     }
 
@@ -3323,12 +3321,12 @@ DEFUN (debug_rfapi_register_vn_un,
    */
   if (!str2prefix (argv[8]->arg, &pfx))
     {
-      vty_out (vty, "Malformed prefix \"%s\"%s", argv[8]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix \"%s\"", argv[8]->arg);
       return CMD_WARNING;
     }
   if (pfx.family != AF_INET && pfx.family != AF_INET6)
     {
-      vty_out (vty, "Bad family for prefix \"%s\"%s", argv[8]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Bad family for prefix \"%s\"", argv[8]->arg);
       return CMD_WARNING;
     }
   rfapiQprefix2Rprefix (&pfx, &hpfx);
@@ -3346,8 +3344,8 @@ DEFUN (debug_rfapi_register_vn_un,
   rc = rfapi_register (handle, &hpfx, lifetime, NULL, NULL, 0);
   if (rc)
     {
-      vty_out (vty, "rfapi_register failed with rc=%d (%s)%s", rc,
-               strerror (rc), VTY_NEWLINE);
+      vty_outln (vty, "rfapi_register failed with rc=%d (%s)", rc,
+               strerror(rc));
     }
 
   return CMD_SUCCESS;
@@ -3402,8 +3400,8 @@ DEFUN (debug_rfapi_register_vn_un_l2o,
 
   if (rfapi_find_handle_vty (vty, &vn, &un, &handle))
     {
-      vty_out (vty, "can't locate handle matching vn=%s, un=%s%s",
-               argv[4]->arg, argv[6]->arg, VTY_NEWLINE);
+      vty_outln (vty, "can't locate handle matching vn=%s, un=%s",
+               argv[4]->arg, argv[6]->arg);
       return CMD_WARNING;
     }
 
@@ -3412,12 +3410,12 @@ DEFUN (debug_rfapi_register_vn_un_l2o,
    */
   if (!str2prefix (argv[8]->arg, &pfx))
     {
-      vty_out (vty, "Malformed prefix \"%s\"%s", argv[8]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix \"%s\"", argv[8]->arg);
       return CMD_WARNING;
     }
   if (pfx.family != AF_INET && pfx.family != AF_INET6)
     {
-      vty_out (vty, "Bad family for prefix \"%s\"%s", argv[8]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Bad family for prefix \"%s\"", argv[8]->arg);
       return CMD_WARNING;
     }
   rfapiQprefix2Rprefix (&pfx, &hpfx);
@@ -3436,7 +3434,7 @@ DEFUN (debug_rfapi_register_vn_un_l2o,
   optary[opt_next].v.l2addr.logical_net_id = strtoul(argv[14]->arg, NULL, 10);
   if ((rc = rfapiStr2EthAddr (argv[12]->arg, &optary[opt_next].v.l2addr.macaddr)))
     {
-      vty_out (vty, "Bad mac address \"%s\"%s", argv[12]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Bad mac address \"%s\"", argv[12]->arg);
       return CMD_WARNING;
     }
   optary[opt_next].type = RFAPI_VN_OPTION_TYPE_L2ADDR;
@@ -3455,8 +3453,8 @@ DEFUN (debug_rfapi_register_vn_un_l2o,
   rc = rfapi_register (handle, &hpfx, lifetime, NULL /* &uo */ , opt, 0);
   if (rc)
     {
-      vty_out (vty, "rfapi_register failed with rc=%d (%s)%s", rc,
-               strerror (rc), VTY_NEWLINE);
+      vty_outln (vty, "rfapi_register failed with rc=%d (%s)", rc,
+               strerror(rc));
     }
 
   return CMD_SUCCESS;
@@ -3498,8 +3496,8 @@ DEFUN (debug_rfapi_unregister_vn_un,
 
   if (rfapi_find_handle_vty (vty, &vn, &un, &handle))
     {
-      vty_out (vty, "can't locate handle matching vn=%s, un=%s%s",
-               argv[4]->arg, argv[6]->arg, VTY_NEWLINE);
+      vty_outln (vty, "can't locate handle matching vn=%s, un=%s",
+               argv[4]->arg, argv[6]->arg);
       return CMD_WARNING;
     }
 
@@ -3508,12 +3506,12 @@ DEFUN (debug_rfapi_unregister_vn_un,
    */
   if (!str2prefix (argv[8]->arg, &pfx))
     {
-      vty_out (vty, "Malformed prefix \"%s\"%s", argv[8]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix \"%s\"", argv[8]->arg);
       return CMD_WARNING;
     }
   if (pfx.family != AF_INET && pfx.family != AF_INET6)
     {
-      vty_out (vty, "Bad family for prefix \"%s\"%s", argv[8]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Bad family for prefix \"%s\"", argv[8]->arg);
       return CMD_WARNING;
     }
   rfapiQprefix2Rprefix (&pfx, &hpfx);
@@ -3569,8 +3567,8 @@ DEFUN (debug_rfapi_query_vn_un,
 
   if (rfapi_find_handle_vty (vty, &vn, &un, &handle))
     {
-      vty_out (vty, "can't locate handle matching vn=%s, un=%s%s",
-               argv[4]->arg, argv[6]->arg, VTY_NEWLINE);
+      vty_outln (vty, "can't locate handle matching vn=%s, un=%s",
+               argv[4]->arg, argv[6]->arg);
       return CMD_WARNING;
     }
 
@@ -3581,8 +3579,8 @@ DEFUN (debug_rfapi_query_vn_un,
 
   if (rc)
     {
-      vty_out (vty, "rfapi_query failed with rc=%d (%s)%s", rc,
-               strerror (rc), VTY_NEWLINE);
+      vty_outln (vty, "rfapi_query failed with rc=%d (%s)", rc,
+               strerror(rc));
     }
   else
     {
@@ -3644,14 +3642,14 @@ DEFUN (debug_rfapi_query_vn_un_l2o,
   if ((rc = rfapiCliGetRfapiIpAddr (vty, argv[2], &target)))
     return rc;
 #else
-  vty_out (vty, "%% This command is broken.%s", VTY_NEWLINE);
+  vty_outln (vty, "%% This command is broken.");
   return CMD_WARNING;
 #endif
 
   if (rfapi_find_handle_vty (vty, &vn, &un, &handle))
     {
-      vty_out (vty, "can't locate handle matching vn=%s, un=%s%s",
-               argv[4]->arg, argv[6]->arg, VTY_NEWLINE);
+      vty_outln (vty, "can't locate handle matching vn=%s, un=%s",
+               argv[4]->arg, argv[6]->arg);
       return CMD_WARNING;
     }
 
@@ -3661,7 +3659,7 @@ DEFUN (debug_rfapi_query_vn_un_l2o,
   memset (&l2o_buf, 0, sizeof (l2o_buf));
   if (rfapiStr2EthAddr (argv[10]->arg, &l2o_buf.macaddr))
     {
-      vty_out (vty, "Bad mac address \"%s\"%s", argv[10]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Bad mac address \"%s\"", argv[10]->arg);
       return CMD_WARNING;
     }
 
@@ -3690,8 +3688,8 @@ DEFUN (debug_rfapi_query_vn_un_l2o,
 
   if (rc)
     {
-      vty_out (vty, "rfapi_query failed with rc=%d (%s)%s", rc,
-               strerror (rc), VTY_NEWLINE);
+      vty_outln (vty, "rfapi_query failed with rc=%d (%s)", rc,
+               strerror(rc));
     }
   else
     {
@@ -3752,8 +3750,8 @@ DEFUN (debug_rfapi_query_done_vn_un,
 
   if (rfapi_find_handle_vty (vty, &vn, &un, &handle))
     {
-      vty_out (vty, "can't locate handle matching vn=%s, un=%s%s",
-               argv[5]->arg, argv[7]->arg, VTY_NEWLINE);
+      vty_outln (vty, "can't locate handle matching vn=%s, un=%s",
+               argv[5]->arg, argv[7]->arg);
       return CMD_WARNING;
     }
 
@@ -3762,7 +3760,7 @@ DEFUN (debug_rfapi_query_done_vn_un,
    */
   rc = rfapi_query_done (handle, &target);
 
-  vty_out (vty, "rfapi_query_done returned %d%s", rc, VTY_NEWLINE);
+  vty_outln (vty, "rfapi_query_done returned %d", rc);
 
   return CMD_SUCCESS;
 }
@@ -3788,14 +3786,14 @@ DEFUN (debug_rfapi_show_import,
   bgp = bgp_get_default ();     /* assume 1 instance for now */
   if (!bgp)
     {
-      vty_out (vty, "No BGP instance%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP instance");
       return CMD_WARNING;
     }
 
   h = bgp->rfapi;
   if (!h)
     {
-      vty_out (vty, "No RFAPI instance%s", VTY_NEWLINE);
+      vty_outln (vty, "No RFAPI instance");
       return CMD_WARNING;
     }
 
@@ -3809,7 +3807,7 @@ DEFUN (debug_rfapi_show_import,
     {
       s = ecommunity_ecom2str (it->rt_import_list,
                                ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
-      vty_out (vty, "Import Table %p, RTs: %s%s", it, s, VTY_NEWLINE);
+      vty_outln (vty, "Import Table %p, RTs: %s", it, s);
       XFREE (MTYPE_ECOMMUNITY_STR, s);
 
       rfapiShowImportTable (vty, "IP VPN", it->imported_vpn[AFI_IP], 1);
@@ -3839,8 +3837,8 @@ DEFUN (debug_rfapi_show_import,
               lni = lni_as_ptr;
               if (first_l2)
                 {
-                  vty_out (vty, "%sLNI-based Ethernet Tables:%s",
-                           VTY_NEWLINE, VTY_NEWLINE);
+                  vty_outln (vty, "%sLNI-based Ethernet Tables:",
+                           VTY_NEWLINE);
                   first_l2 = 0;
                 }
               snprintf (buf, BUFSIZ, "L2VPN LNI=%u", lni);
@@ -3891,8 +3889,8 @@ DEFUN (debug_rfapi_show_import_vn_un,
 
   if (rfapi_find_handle_vty (vty, &vn, &un, &handle))
     {
-      vty_out (vty, "can't locate handle matching vn=%s, un=%s%s",
-               argv[5]->arg, argv[7]->arg, VTY_NEWLINE);
+      vty_outln (vty, "can't locate handle matching vn=%s, un=%s",
+               argv[5]->arg, argv[7]->arg);
       return CMD_WARNING;
     }
 
@@ -3922,12 +3920,12 @@ DEFUN (debug_rfapi_response_omit_self,
 
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
   if (!bgp->rfapi_cfg)
     {
-      vty_out (vty, "VNC not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "VNC not configured");
       return CMD_WARNING;
     }
 
@@ -4193,7 +4191,7 @@ rfapi_rfp_get_or_init_group_config_nve (
   if (!rfg || !listnode_lookup (rfc->nve_groups_sequential, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current NVE group no longer exists");
       return NULL;
     }
 
@@ -4218,7 +4216,7 @@ rfapi_rfp_get_or_init_group_config_l2 (
   if (!rfg || !listnode_lookup (rfc->l2_groups, rfg))
     {
       /* Not in list anymore */
-      vty_out (vty, "Current L2 group no longer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "Current L2 group no longer exists");
       return NULL;
     }
   if (rfg->rfp_cfg == NULL && size > 0)

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -2294,7 +2294,7 @@ rfapiRibShowResponsesSummary (void *stream)
   fp (out, "%-24s ", "Responses: (Prefixes)");
   fp (out, "%-8s %-8u ", "Active:", bgp->rfapi->rib_prefix_count_total);
   fp (out, "%-8s %-8u", "Maximum:", bgp->rfapi->rib_prefix_count_total_max);
-  fp (out, "%s", VTY_NEWLINE);
+  fp (out, "%s", VTYNL);
 
   fp (out, "%-24s ", "           (Updated)");
   fp (out, "%-8s %-8u ", "Update:",
@@ -2304,7 +2304,7 @@ rfapiRibShowResponsesSummary (void *stream)
   fp (out, "%-8s %-8u", "Total:",
       bgp->rfapi->stat.count_updated_response_updates +
       bgp->rfapi->stat.count_updated_response_deletes);
-  fp (out, "%s", VTY_NEWLINE);
+  fp (out, "%s", VTYNL);
 
   fp (out, "%-24s ", "           (NVEs)");
   for (ALL_LIST_ELEMENTS_RO (&bgp->rfapi->descriptors, node, rfd))
@@ -2315,7 +2315,7 @@ rfapiRibShowResponsesSummary (void *stream)
     }
   fp (out, "%-8s %-8u ", "Active:", nves_with_nonempty_ribs);
   fp (out, "%-8s %-8u", "Total:", nves);
-  fp (out, "%s", VTY_NEWLINE);
+  fp (out, "%s", VTYNL);
 
 }
 
@@ -2388,7 +2388,7 @@ print_rib_sl (
       fp (out, " %c %-20s %-15s %-15s %-4u %-8s %-8s%s%s",
           deleted ? 'r' : ' ',
           *printedprefix ? "" : str_pfx,
-          str_vn, str_un, ri->cost, str_lifetime, str_age, str_rd, VTY_NEWLINE);
+          str_vn, str_un, ri->cost, str_lifetime, str_age, str_rd, VTYNL);
 
       if (!*printedprefix)
         *printedprefix = 1;
@@ -2501,10 +2501,10 @@ rfapiRibShowResponses (
                   ++printedheader;
 
                   fp (out, "%s[%s]%s",
-                      VTY_NEWLINE,
-                      show_removed ? "Removed" : "Active", VTY_NEWLINE);
+                      VTYNL,
+                      show_removed ? "Removed" : "Active", VTYNL);
                   fp (out, "%-15s %-15s%s", "Querying VN", "Querying UN",
-                      VTY_NEWLINE);
+                      VTYNL);
                   fp (out, "   %-20s %-15s %-15s %4s %-8s %-8s%s",
                       "Prefix", "Registered VN", "Registered UN", "Cost",
                       "Lifetime",
@@ -2513,7 +2513,7 @@ rfapiRibShowResponses (
 #else
                       "Remaining",
 #endif
-                      VTY_NEWLINE);
+                      VTYNL);
                 }
               if (!printednve)
                 {
@@ -2526,11 +2526,11 @@ rfapiRibShowResponses (
                   fp (out, "%-15s %-15s%s",
                       rfapiRfapiIpAddr2Str (&rfd->vn_addr, str_vn, BUFSIZ),
                       rfapiRfapiIpAddr2Str (&rfd->un_addr, str_un, BUFSIZ),
-                      VTY_NEWLINE);
+                      VTYNL);
 
                 }
               prefix2str (&rn->p, str_pfx, BUFSIZ);
-              //fp(out, "  %s%s", buf, VTY_NEWLINE);  /* prefix */
+              //fp(out, "  %s%s", buf, VTYNL);  /* prefix */
 
               routes_displayed++;
               nhs_displayed += print_rib_sl (fp, vty, out, sl,
@@ -2542,12 +2542,12 @@ rfapiRibShowResponses (
 
   if (routes_total)
     {
-      fp (out, "%s", VTY_NEWLINE);
+      fp (out, "%s", VTYNL);
       fp (out, "Displayed %u NVEs, and %u out of %u %s prefixes",
           nves_displayed, routes_displayed,
           routes_total, show_removed ? "removed" : "active");
       if (nhs_displayed != routes_displayed || nhs_total != routes_total)
         fp (out, " with %u out of %u next hops", nhs_displayed, nhs_total);
-      fp (out, "%s", VTY_NEWLINE);
+      fp (out, "%s", VTYNL);
     }
 }

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -385,14 +385,14 @@ rfapiStdioPrintf (void *stream, const char *format, ...)
 /* Fake out for debug logging */
 static struct vty vty_dummy_zlog;
 static struct vty vty_dummy_stdio;
-#define HVTY_NEWLINE ((vty == &vty_dummy_zlog)? "": VTY_NEWLINE)
+#define HVTYNL ((vty == &vty_dummy_zlog)? "": VTYNL)
 
 static const char *
 str_vty_newline (struct vty *vty)
 {
   if (vty == &vty_dummy_zlog)
     return "";
-  return VTY_NEWLINE;
+  return VTYNL;
 }
 
 int
@@ -406,7 +406,7 @@ rfapiStream2Vty (
 
   if (!stream)
     {
-      vty_dummy_zlog.type = VTY_SHELL;  /* for VTY_NEWLINE */
+      vty_dummy_zlog.type = VTY_SHELL;  /* for VTYNL */
       *vty = &vty_dummy_zlog;
       *fp = (int (*)(void *, const char *,...)) rfapiDebugPrintf;
       *outstream = NULL;
@@ -418,7 +418,7 @@ rfapiStream2Vty (
       ((uintptr_t) stream == (uintptr_t) 2))
     {
 
-      vty_dummy_stdio.type = VTY_SHELL; /* for VTY_NEWLINE */
+      vty_dummy_stdio.type = VTY_SHELL; /* for VTYNL */
       *vty = &vty_dummy_stdio;
       *fp = (int (*)(void *, const char *,...)) rfapiStdioPrintf;
       *outstream = stream;
@@ -428,7 +428,7 @@ rfapiStream2Vty (
 
   if (stream)
     {
-      *vty = stream;            /* VTY_NEWLINE requires vty to be legit */
+      *vty = stream;            /* VTYNL requires vty to be legit */
       *fp = (int (*)(void *, const char *,...)) vty_out;
       *outstream = stream;
       *vty_newline = str_vty_newline (*vty);
@@ -488,7 +488,7 @@ rfapi_vty_out_vncinfo (
   vty_out (vty, " type=%s, subtype=%d",
            zebra_route_string (bi->type), bi->sub_type);
 
-  vty_out (vty, "%s", HVTY_NEWLINE);
+  vty_out (vty, "%s", HVTYNL);
 }
 
 void
@@ -505,27 +505,27 @@ rfapiPrintAttrPtrs (void *stream, struct attr *attr)
   if (rfapiStream2Vty (stream, &fp, &vty, &out, &vty_newline) == 0)
     return;
 
-  fp (out, "Attr[%p]:%s", attr, HVTY_NEWLINE);
+  fp (out, "Attr[%p]:%s", attr, HVTYNL);
   if (!attr)
     return;
 
   /* IPv4 Nexthop */
   inet_ntop (AF_INET, &attr->nexthop, buf, BUFSIZ);
-  fp (out, "  nexthop=%s%s", buf, HVTY_NEWLINE);
+  fp (out, "  nexthop=%s%s", buf, HVTYNL);
 
   fp (out, "  aspath=%p, refcnt=%d%s", attr->aspath,
-      (attr->aspath ? attr->aspath->refcnt : 0), HVTY_NEWLINE);
+      (attr->aspath ? attr->aspath->refcnt : 0), HVTYNL);
   fp (out, "  community=%p, refcnt=%d%s", attr->community,
-      (attr->community ? attr->community->refcnt : 0), HVTY_NEWLINE);
+      (attr->community ? attr->community->refcnt : 0), HVTYNL);
 
   if ((ae = attr->extra))
     {
       fp (out, "  ecommunity=%p, refcnt=%d%s", ae->ecommunity,
-          (ae->ecommunity ? ae->ecommunity->refcnt : 0), HVTY_NEWLINE);
+          (ae->ecommunity ? ae->ecommunity->refcnt : 0), HVTYNL);
       fp (out, "  cluster=%p, refcnt=%d%s", ae->cluster,
-          (ae->cluster ? ae->cluster->refcnt : 0), HVTY_NEWLINE);
+          (ae->cluster ? ae->cluster->refcnt : 0), HVTYNL);
       fp (out, "  transit=%p, refcnt=%d%s", ae->transit,
-          (ae->transit ? ae->transit->refcnt : 0), HVTY_NEWLINE);
+          (ae->transit ? ae->transit->refcnt : 0), HVTYNL);
     }
 }
 
@@ -726,7 +726,7 @@ rfapiPrintBi (void *stream, struct bgp_info *bi)
     snprintf (p, REMAIN, " %c:%u", zebra_route_char (bi->type), bi->sub_type);
   INCP;
 
-  fp (out, "%s%s", line, HVTY_NEWLINE);
+  fp (out, "%s%s", line, HVTYNL);
 
   if (has_macaddr)
     {
@@ -735,7 +735,7 @@ rfapiPrintBi (void *stream, struct bgp_info *bi)
           macaddr.octet[0],
           macaddr.octet[1],
           macaddr.octet[2],
-          macaddr.octet[3], macaddr.octet[4], macaddr.octet[5], HVTY_NEWLINE);
+          macaddr.octet[3], macaddr.octet[4], macaddr.octet[5], HVTYNL);
     }
 
   if (!rfapiGetL2o (bi->attr, &l2o_buf))
@@ -745,7 +745,7 @@ rfapiPrintBi (void *stream, struct bgp_info *bi)
           l2o_buf.macaddr.octet[0], l2o_buf.macaddr.octet[1],
           l2o_buf.macaddr.octet[2], l2o_buf.macaddr.octet[3],
           l2o_buf.macaddr.octet[4], l2o_buf.macaddr.octet[5], l2o_buf.label,
-          l2o_buf.logical_net_id, l2o_buf.local_nve_id, HVTY_NEWLINE);
+          l2o_buf.logical_net_id, l2o_buf.local_nve_id, HVTYNL);
     }
   if (bi->extra && bi->extra->vnc.import.aux_prefix.family)
     {
@@ -758,7 +758,7 @@ rfapiPrintBi (void *stream, struct bgp_info *bi)
       buf[BUFSIZ - 1] = 0;
       if (sp)
         {
-          fp (out, "        IP: %s%s", sp, HVTY_NEWLINE);
+          fp (out, "        IP: %s%s", sp, HVTYNL);
         }
     }
   {
@@ -807,7 +807,7 @@ rfapiDebugPrintMonitorVpn (void *stream, struct rfapi_monitor_vpn *m)
     return;
 
   rfapiMonitorVpn2Str (m, buf, BUFSIZ);
-  fp (out, "    Mon %s%s", buf, HVTY_NEWLINE);
+  fp (out, "    Mon %s%s", buf, HVTYNL);
 }
 
 static void
@@ -822,7 +822,7 @@ rfapiDebugPrintMonitorEncap (void *stream, struct rfapi_monitor_encap *m)
     return;
 
   fp (out, "    Mon m=%p, next=%p, node=%p, bi=%p%s",
-      m, m->next, m->node, m->bi, HVTY_NEWLINE);
+      m, m->next, m->node, m->bi, HVTYNL);
 }
 
 void
@@ -841,7 +841,7 @@ rfapiShowItNode (void *stream, struct route_node *rn)
 
   fp (out, "%s/%d @%p #%d%s",
       rfapi_ntop (rn->p.family, &rn->p.u.prefix, buf, BUFSIZ),
-      rn->p.prefixlen, rn, rn->lock, HVTY_NEWLINE);
+      rn->p.prefixlen, rn, rn->lock, HVTYNL);
 
   for (bi = rn->info; bi; bi = bi->next)
     {
@@ -869,7 +869,7 @@ rfapiShowImportTable (
   if (rfapiStream2Vty (stream, &fp, &vty, &out, &vty_newline) == 0)
     return;
 
-  fp (out, "Import Table [%s]%s", label, HVTY_NEWLINE);
+  fp (out, "Import Table [%s]%s", label, HVTYNL);
 
   for (rn = route_top (rt); rn; rn = route_next (rn))
     {
@@ -885,7 +885,7 @@ rfapiShowImportTable (
         }
 
       fp (out, "%s/%d @%p #%d%s", buf, rn->p.prefixlen, rn, rn->lock - 1,       /* account for loop iterator locking */
-          HVTY_NEWLINE);
+          HVTYNL);
 
       for (bi = rn->info; bi; bi = bi->next)
         {
@@ -995,10 +995,10 @@ rfapiShowVncQueries (void *stream, struct prefix *pfx_match)
               if (!printedheader)
                 {
                   ++printedheader;
-                  fp (out, "%s", VTY_NEWLINE);
+                  fp (out, "%s", VTYNL);
                   fp (out, "%-15s %-15s %-15s %-10s%s",
                       "VN Address", "UN Address",
-                      "Target", "Remaining", VTY_NEWLINE);
+                      "Target", "Remaining", VTYNL);
                 }
 
               if (!printedquerier)
@@ -1024,7 +1024,7 @@ rfapiShowVncQueries (void *stream, struct prefix *pfx_match)
                 }
               fp (out, " %-15s %-10s%s",
                   inet_ntop (m->p.family, &m->p.u.prefix, buf_pfx, BUFSIZ),
-                  buf_remain, VTY_NEWLINE);
+                  buf_remain, VTYNL);
             }
         }
 
@@ -1070,10 +1070,10 @@ rfapiShowVncQueries (void *stream, struct prefix *pfx_match)
               if (!printedheader)
                 {
                   ++printedheader;
-                  fp (out, "%s", VTY_NEWLINE);
+                  fp (out, "%s", VTYNL);
                   fp (out, "%-15s %-15s %-17s %10s %-10s%s",
                       "VN Address", "UN Address",
-                      "Target", "LNI", "Remaining", VTY_NEWLINE);
+                      "Target", "LNI", "Remaining", VTYNL);
                 }
 
               if (!printedquerier)
@@ -1100,16 +1100,16 @@ rfapiShowVncQueries (void *stream, struct prefix *pfx_match)
               fp (out, " %-17s %10d %-10s%s",
                   rfapi_ntop (pfx_mac.family, &pfx_mac.u.prefix, buf_pfx,
                               BUFSIZ), mon_eth->logical_net_id, buf_remain,
-                  VTY_NEWLINE);
+                  VTYNL);
             }
         }
     }
 
   if (queries_total)
     {
-      fp (out, "%s", VTY_NEWLINE);
+      fp (out, "%s", VTYNL);
       fp (out, "Displayed %d out of %d total queries%s",
-          queries_displayed, queries_total, VTY_NEWLINE);
+          queries_displayed, queries_total, VTYNL);
     }
   return CMD_SUCCESS;
 }
@@ -1277,7 +1277,7 @@ rfapiPrintRemoteRegBi (
         }
       fp (out, "%-10s ", buf_age);
     }
-  fp (out, "%s", HVTY_NEWLINE);
+  fp (out, "%s", HVTYNL);
 
   if (rn->p.family == AF_ETHERNET)
     {
@@ -1314,7 +1314,7 @@ rfapiPrintRemoteRegBi (
         }
     }
   if (nlines > 1)
-    fp (out, "%s", HVTY_NEWLINE);
+    fp (out, "%s", HVTYNL);
 
   return 1;
 }
@@ -1438,12 +1438,12 @@ rfapiShowRemoteRegistrationsIt (
                   if (pLni)
                     {
                       fp (out, "%s[%s] L2VPN Network 0x%x (%u) RT={%s}",
-                          HVTY_NEWLINE, type, *pLni, (*pLni & 0xfff), s);
+                          HVTYNL, type, *pLni, (*pLni & 0xfff), s);
                     }
                   else
                     {
                       fp (out, "%s[%s] Prefix RT={%s}",
-                          HVTY_NEWLINE, type, s);
+                          HVTYNL, type, s);
                     }
                   XFREE (MTYPE_ECOMMUNITY_STR, s);
 
@@ -1454,7 +1454,7 @@ rfapiShowRemoteRegistrationsIt (
                            "VRF" : "NVE group"),
                           it->rfg->name);
                     }
-                  fp (out, "%s", HVTY_NEWLINE);
+                  fp (out, "%s", HVTYNL);
                   if (show_expiring)
                     {
 #if RFAPI_REGISTRATIONS_REPORT_AGE
@@ -1473,7 +1473,7 @@ rfapiShowRemoteRegistrationsIt (
                   fp (out, "%-20s %-15s %-15s %4s %-10s %-10s%s",
                       (pLni ? "L2 Address/IP" : "Prefix"),
                       "VN Address", "UN Address", "Cost",
-                      "Lifetime", agetype, HVTY_NEWLINE);
+                      "Lifetime", agetype, HVTYNL);
                 }
               printed += rfapiPrintRemoteRegBi (bgp, stream, rn, bi);
             }
@@ -1509,9 +1509,9 @@ rfapiShowRemoteRegistrationsIt (
         }
 
       fp (out, "Displayed %d out of %d %s%s",
-          printed, total, type, HVTY_NEWLINE);
+          printed, total, type, HVTYNL);
 #if DEBUG_SHOW_EXTRA
-      fp(out, "IT table above: it=%p%s", it, HVTY_NEWLINE);
+      fp(out, "IT table above: it=%p%s", it, HVTYNL);
 #endif
     }
   return printed;
@@ -1751,7 +1751,7 @@ rfapiPrintAdvertisedInfo (
     }
   bn = bgp_afi_node_get (bgp->rib[afi][safi], afi, safi, p, prd);
 
-  vty_out (vty, "  bn=%p%s", bn, HVTY_NEWLINE);
+  vty_out (vty, "  bn=%p%s", bn, HVTYNL);
 
   for (bi = bn->info; bi; bi = bi->next)
     {
@@ -1768,7 +1768,7 @@ rfapiPrintAdvertisedInfo (
 
   if (!printed)
     {
-      vty_out (vty, "    --?--%s", HVTY_NEWLINE);
+      vty_out (vty, "    --?--%s", HVTYNL);
       return;
     }
 
@@ -1798,9 +1798,9 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
   rfapiPrintRd (vty, &rfd->rd);
   vty_out (vty, " %d", rfd->response_lifetime);
   vty_out (vty, " %s", (rfd->rfg ? rfd->rfg->name : "<orphaned>"));
-  vty_out (vty, "%s", HVTY_NEWLINE);
+  vty_out (vty, "%s", HVTYNL);
 
-  vty_out (vty, " Peer %p #%d%s", rfd->peer, rfd->peer->lock, HVTY_NEWLINE);
+  vty_out (vty, " Peer %p #%d%s", rfd->peer, rfd->peer->lock, HVTYNL);
 
   /* export RT list */
   if (rfd->rt_export_list)
@@ -1808,12 +1808,12 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
       s =
         ecommunity_ecom2str (rfd->rt_export_list,
                              ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
-      vty_out (vty, " Export %s%s", s, HVTY_NEWLINE);
+      vty_out (vty, " Export %s%s", s, HVTYNL);
       XFREE (MTYPE_ECOMMUNITY_STR, s);
     }
   else
     {
-      vty_out (vty, " Export (nil)%s", HVTY_NEWLINE);
+      vty_out (vty, " Export (nil)%s", HVTYNL);
     }
 
   /* import RT list */
@@ -1821,12 +1821,12 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
     {
       s = ecommunity_ecom2str (rfd->import_table->rt_import_list,
                                ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
-      vty_out (vty, " Import %s%s", s, HVTY_NEWLINE);
+      vty_out (vty, " Import %s%s", s, HVTYNL);
       XFREE (MTYPE_ECOMMUNITY_STR, s);
     }
   else
     {
-      vty_out (vty, " Import (nil)%s", HVTY_NEWLINE);
+      vty_out (vty, " Import (nil)%s", HVTYNL);
     }
 
   for (afi = AFI_IP; afi < AFI_MAX; ++afi)
@@ -1853,7 +1853,7 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
           prefix2str (&adb->u.s.prefix_ip, buf, BUFSIZ);
           buf[BUFSIZ - 1] = 0;  /* guarantee NUL-terminated */
 
-          vty_out (vty, "  Adv Pfx: %s%s", buf, HVTY_NEWLINE);
+          vty_out (vty, "  Adv Pfx: %s%s", buf, HVTYNL);
           rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->u.s.prefix_ip);
         }
     }
@@ -1868,13 +1868,13 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
       prefix2str (&adb->u.s.prefix_eth, buf, BUFSIZ);
       buf[BUFSIZ - 1] = 0;      /* guarantee NUL-terminated */
 
-      vty_out (vty, "  Adv Pfx: %s%s", buf, HVTY_NEWLINE);
+      vty_out (vty, "  Adv Pfx: %s%s", buf, HVTYNL);
 
       /* TBD update the following function to print ethernet info */
       /* Also need to pass/use rd */
       rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->u.s.prefix_ip);
     }
-  vty_out (vty, "%s", HVTY_NEWLINE);
+  vty_out (vty, "%s", HVTYNL);
 }
 
 /*
@@ -1925,7 +1925,7 @@ rfapiPrintMatchingDescriptors (struct vty *vty,
           vty_out (vty,
                    "%s %s %s %s %s %s %s %s%s",
                    "descriptor", "un-addr", "vn-addr", "callback", "cookie",
-                   "RD", "lifetime", "group", HVTY_NEWLINE);
+                   "RD", "lifetime", "group", HVTYNL);
         }
       rfapiPrintDescriptor (vty, rfd);
       printed = 1;
@@ -1941,7 +1941,7 @@ rfapiCliGetPrefixAddr (struct vty *vty, const char *str, struct prefix *p)
 {
   if (!str2prefix (str, p))
     {
-      vty_out (vty, "Malformed address \"%s\"%s", str, HVTY_NEWLINE);
+      vty_out (vty, "Malformed address \"%s\"%s", str, HVTYNL);
       return CMD_WARNING;
     }
   switch (p->family)
@@ -1949,19 +1949,19 @@ rfapiCliGetPrefixAddr (struct vty *vty, const char *str, struct prefix *p)
     case AF_INET:
       if (p->prefixlen != 32)
         {
-          vty_out (vty, "Not a host address: \"%s\"%s", str, HVTY_NEWLINE);
+          vty_out (vty, "Not a host address: \"%s\"%s", str, HVTYNL);
           return CMD_WARNING;
         }
       break;
     case AF_INET6:
       if (p->prefixlen != 128)
         {
-          vty_out (vty, "Not a host address: \"%s\"%s", str, HVTY_NEWLINE);
+          vty_out (vty, "Not a host address: \"%s\"%s", str, HVTYNL);
           return CMD_WARNING;
         }
       break;
     default:
-      vty_out (vty, "Invalid address \"%s\"%s", str, HVTY_NEWLINE);
+      vty_out (vty, "Invalid address \"%s\"%s", str, HVTYNL);
       return CMD_WARNING;
     }
   return 0;
@@ -2066,7 +2066,7 @@ rfapiPrintNhl (void *stream, struct rfapi_next_hop_entry *next_hops)
 
     truncate:
       line[BUFSIZ - 1] = 0;
-      fp (out, "%s%s", line, HVTY_NEWLINE);
+      fp (out, "%s%s", line, HVTYNL);
 
       /*
        * options
@@ -2088,18 +2088,18 @@ rfapiPrintNhl (void *stream, struct rfapi_next_hop_entry *next_hops)
                   fp (out, "%sL2 %s LBL=0x%06x NETID=0x%06x NVEID=%d%s",
                       offset, pbuf, (vo->v.l2addr.label & 0x00ffffff),
                       (vo->v.l2addr.logical_net_id & 0x00ffffff),
-                      vo->v.l2addr.local_nve_id, HVTY_NEWLINE);
+                      vo->v.l2addr.local_nve_id, HVTYNL);
                   break;
 
                 case RFAPI_VN_OPTION_TYPE_LOCAL_NEXTHOP:
                   prefix2str (&vo->v.local_nexthop.addr, pbuf, sizeof (pbuf));
                   fp (out, "%sLNH %s cost=%d%s",
-                      offset, pbuf, vo->v.local_nexthop.cost, HVTY_NEWLINE);
+                      offset, pbuf, vo->v.local_nexthop.cost, HVTYNL);
                   break;
 
                 default:
                   fp (out, "%svn option type %d (unknown)%s",
-                      offset, vo->type, HVTY_NEWLINE);
+                      offset, vo->type, HVTYNL);
                   break;
                 }
             }
@@ -3701,7 +3701,7 @@ clear_vnc_prefix (struct rfapi_local_reg_delete_arg *cda)
 static void
 print_cleared_stats (struct rfapi_local_reg_delete_arg *cda)
 {
-  struct vty *vty = cda->vty;   /* for benefit of VTY_NEWLINE */
+  struct vty *vty = cda->vty;   /* for benefit of VTYNL */
 
   /* Our special element-deleting function counts nves */
   if (cda->nves)

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -939,14 +939,14 @@ rfapiShowVncQueries (void *stream, struct prefix *pfx_match)
   bgp = bgp_get_default ();     /* assume 1 instance for now */
   if (!bgp)
     {
-      vty_out (vty, "No BGP instance%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP instance");
       return CMD_WARNING;
     }
 
   h = bgp->rfapi;
   if (!h)
     {
-      vty_out (vty, "No RFAPI instance%s", VTY_NEWLINE);
+      vty_outln (vty, "No RFAPI instance");
       return CMD_WARNING;
     }
 
@@ -2221,7 +2221,7 @@ register_add (
        if (!bgp)
          {
            if (vty)
-             vty_out (vty, "BGP not configured%s", VTY_NEWLINE);
+             vty_outln (vty, "BGP not configured");
            return CMD_WARNING;
          }
 
@@ -2230,7 +2230,7 @@ register_add (
        if (!h || !rfapi_cfg)
          {
            if (vty)
-             vty_out (vty, "RFAPI not configured%s", VTY_NEWLINE);
+             vty_outln (vty, "RFAPI not configured");
            return CMD_WARNING;
          }
 
@@ -2240,14 +2240,12 @@ register_add (
              {
                if (arg_lnh)
                  {
-                   vty_out (vty, "local-next-hop specified more than once%s",
-                            VTY_NEWLINE);
+                   vty_outln (vty,"local-next-hop specified more than once");
                    return CMD_WARNING;
                  }
                if (argc <= 1)
                  {
-                   vty_out (vty, "Missing parameter for local-next-hop%s",
-                            VTY_NEWLINE);
+                   vty_outln (vty,"Missing parameter for local-next-hop");
                    return CMD_WARNING;
                  }
                ++argv, --argc;
@@ -2257,14 +2255,12 @@ register_add (
              {
                if (arg_lnh_cost)
                  {
-                   vty_out (vty, "local-cost specified more than once%s",
-                            VTY_NEWLINE);
+                   vty_outln (vty,"local-cost specified more than once");
                    return CMD_WARNING;
                  }
                if (argc <= 1)
                  {
-                   vty_out (vty, "Missing parameter for local-cost%s",
-                            VTY_NEWLINE);
+                   vty_outln (vty,"Missing parameter for local-cost");
                    return CMD_WARNING;
                  }
                ++argv, --argc;
@@ -2292,8 +2288,7 @@ register_add (
                arg_prefix = "0::0/128";
                break;
              default:
-               vty_out (vty, "Internal error, unknown VN address family%s",
-                        VTY_NEWLINE);
+               vty_outln (vty,"Internal error, unknown VN address family");
                return CMD_WARNING;
              }
 
@@ -2301,15 +2296,14 @@ register_add (
 
        if (!str2prefix (arg_prefix, &pfx))
          {
-           vty_out (vty, "Malformed prefix \"%s\"%s", arg_prefix,
-                    VTY_NEWLINE);
+           vty_outln (vty, "Malformed prefix \"%s\"",arg_prefix);
            goto fail;
          }
        if (pfx.family != AF_INET
            && pfx.family != AF_INET6)
          {
-           vty_out (vty, "prefix \"%s\" has invalid address family%s",
-                    arg_prefix, VTY_NEWLINE);
+           vty_outln (vty, "prefix \"%s\" has invalid address family",
+                    arg_prefix);
            goto fail;
          }
 
@@ -2322,7 +2316,7 @@ register_add (
            cost = strtoul (arg_cost, &endptr, 10);
            if (*endptr != '\0' || cost > 255)
              {
-               vty_out (vty, "%% Invalid %s value%s", "cost", VTY_NEWLINE);
+               vty_outln (vty, "%% Invalid %s value", "cost");
                goto fail;
              }
          }
@@ -2343,8 +2337,7 @@ register_add (
                lifetime = strtoul (arg_lifetime, &endptr, 10);
                if (*endptr != '\0')
                  {
-                   vty_out (vty, "%% Invalid %s value%s", "lifetime",
-                            VTY_NEWLINE);
+                   vty_outln (vty, "%% Invalid %s value","lifetime");
                    goto fail;
                  }
              }
@@ -2358,17 +2351,16 @@ register_add (
          {
            if (!arg_lnh)
              {
-               vty_out (vty,
-                        "%% %s may only be specified with local-next-hop%s",
-                        "local-cost", VTY_NEWLINE);
+               vty_outln (vty,
+                        "%% %s may only be specified with local-next-hop",
+                        "local-cost");
                goto fail;
              }
            endptr = NULL;
            lnh_cost = strtoul (arg_lnh_cost, &endptr, 10);
            if (*endptr != '\0' || lnh_cost > 255)
              {
-               vty_out (vty, "%% Invalid %s value%s", "local-cost",
-                        VTY_NEWLINE);
+               vty_outln (vty, "%% Invalid %s value","local-cost");
                goto fail;
              }
          }
@@ -2381,8 +2373,8 @@ register_add (
          {
            if (!arg_prefix)
              {
-               vty_out (vty, "%% %s may only be specified with prefix%s",
-                        "local-next-hop", VTY_NEWLINE);
+               vty_outln (vty, "%% %s may only be specified with prefix",
+                        "local-next-hop");
                goto fail;
              }
            if ((rc = rfapiCliGetPrefixAddr (vty, arg_lnh,
@@ -2409,8 +2401,8 @@ register_add (
 
        if (arg_vni && !arg_macaddr)
          {
-           vty_out (vty, "%% %s may only be specified with mac address%s",
-                    "virtual-network-identifier", VTY_NEWLINE);
+           vty_outln (vty, "%% %s may only be specified with mac address",
+                    "virtual-network-identifier");
            goto fail;
          }
 
@@ -2418,9 +2410,8 @@ register_add (
          {
            if (!arg_vni)
              {
-               vty_out (vty,
-                        "Missing \"vni\" parameter (mandatory with mac)%s",
-                        VTY_NEWLINE);
+               vty_outln (vty,
+                        "Missing \"vni\" parameter (mandatory with mac)");
                return CMD_WARNING;
              }
            optary[opt_next].v.l2addr.logical_net_id = strtoul(arg_vni, NULL,
@@ -2429,8 +2420,7 @@ register_add (
            if ((rc = rfapiStr2EthAddr (arg_macaddr,
                                        &optary[opt_next].v.l2addr.macaddr)))
              {
-               vty_out (vty, "Invalid %s value%s", "mac address",
-                        VTY_NEWLINE);
+               vty_outln (vty, "Invalid %s value","mac address");
                goto fail;
              }
            /* TBD label, NVE ID */
@@ -2482,16 +2472,16 @@ register_add (
                                 &rfd);
                if (rc)
                  {
-                   vty_out (vty, "Can't open session for this NVE: %s%s",
-                            rfapi_error_str (rc), VTY_NEWLINE);
+                   vty_outln (vty, "Can't open session for this NVE: %s",
+                            rfapi_error_str(rc));
                    rc = CMD_WARNING;
                    goto fail;
                  }
              }
            else
              {
-               vty_out (vty, "Can't find session for this NVE: %s%s",
-                        rfapi_error_str (rc), VTY_NEWLINE);
+               vty_outln (vty, "Can't find session for this NVE: %s",
+                        rfapi_error_str(rc));
                goto fail;
              }
          }
@@ -2526,11 +2516,10 @@ register_add (
          }
 
        vnc_zlog_debug_verbose ("%s: rfapi_register failed", __func__);
-       vty_out (vty, "%s", VTY_NEWLINE);
-       vty_out (vty, "Registration failed.%s", VTY_NEWLINE);
-       vty_out (vty,
-                "Confirm that either the VN or UN address matches a configured NVE group.%s",
-                VTY_NEWLINE);
+       vty_outln (vty, "");
+       vty_outln (vty, "Registration failed.");
+       vty_outln (vty,
+                "Confirm that either the VN or UN address matches a configured NVE group.");
        return CMD_WARNING;
 
      fail:
@@ -3145,7 +3134,7 @@ parse_deleter_args (
 
       if (!str2prefix (arg_prefix, &rcdarg->prefix))
         {
-          vty_out (vty, "Malformed prefix \"%s\"%s", arg_prefix, VTY_NEWLINE);
+          vty_outln (vty, "Malformed prefix \"%s\"", arg_prefix);
           return rc;
         }
     }
@@ -3154,15 +3143,15 @@ parse_deleter_args (
     {
       if (!arg_vni)
         {
-          vty_out (vty, "Missing VNI%s", VTY_NEWLINE);
+          vty_outln (vty, "Missing VNI");
           return rc;
         }
       if (strcmp (arg_l2addr, "*"))
         {
           if ((rc = rfapiStr2EthAddr (arg_l2addr, &rcdarg->l2o.o.macaddr)))
             {
-              vty_out (vty, "Malformed L2 Address \"%s\"%s",
-                       arg_l2addr, VTY_NEWLINE);
+              vty_outln (vty, "Malformed L2 Address \"%s\"",
+                       arg_l2addr);
               return rc;
             }
           rcdarg->l2o.flags |= RFAPI_L2O_MACADDR;
@@ -3177,8 +3166,8 @@ parse_deleter_args (
     {
       if (!str2prefix_rd (arg_rd, &rcdarg->rd))
         {
-          vty_out (vty, "Malformed RD \"%s\"%s",
-                   arg_rd, VTY_NEWLINE);
+          vty_outln (vty, "Malformed RD \"%s\"",
+                   arg_rd);
           return rc;
         }
     }
@@ -3721,23 +3710,21 @@ print_cleared_stats (struct rfapi_local_reg_delete_arg *cda)
       cda->nves = NULL;
     }
   if (cda->failed_pfx_count)
-      vty_out (vty, "Failed to delete %d prefixes%s",
-               cda->failed_pfx_count, VTY_NEWLINE);
+      vty_outln (vty, "Failed to delete %d prefixes",
+               cda->failed_pfx_count);
 
   /* left as "prefixes" even in single case for ease of machine parsing */
-  vty_out (vty,
-           "[Local] Cleared %u registrations, %u prefixes, %u responses from %d NVEs%s",
-           cda->reg_count, cda->pfx_count, cda->query_count, cda->nve_count,
-           VTY_NEWLINE);
+  vty_outln (vty,
+           "[Local] Cleared %u registrations, %u prefixes, %u responses from %d NVEs",
+           cda->reg_count, cda->pfx_count, cda->query_count,cda->nve_count);
 
 /*
  * We don't currently allow deletion of active remote prefixes from
  * the command line
  */
 
-  vty_out (vty, "[Holddown] Cleared %u prefixes from %u NVEs%s",
-           cda->remote_holddown_pfx_count, cda->remote_holddown_nve_count,
-           VTY_NEWLINE);
+  vty_outln (vty, "[Holddown] Cleared %u prefixes from %u NVEs",
+           cda->remote_holddown_pfx_count,cda->remote_holddown_nve_count);
 }
 
 /* 
@@ -4414,9 +4401,8 @@ check_and_display_is_vnc_running (struct vty *vty)
 
   if (vty)
     {
-      vty_out (vty,
-               "VNC is not configured. (There are no configured BGP VPN SAFI peers.)%s",
-               VTY_NEWLINE);
+      vty_outln (vty,
+               "VNC is not configured. (There are no configured BGP VPN SAFI peers.)");
     }
   return 0;                     /* not running */
 }
@@ -4479,10 +4465,10 @@ rfapi_vty_show_nve_summary (struct vty *vty, show_nve_summary_t show_type)
                        h->stat.count_registrations_failed);
               vty_out (vty, "%-8s %-8u", "Total:",
                        h->stat.count_registrations);
-              vty_out (vty, "%s", VTY_NEWLINE);
+              vty_outln (vty, "");
             }
           vty_out (vty, "%-24s ", "Prefixes registered:");
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
 
           rfapiCountAllItRoutes (&active_local_routes,
                                  &active_remote_routes,
@@ -4494,16 +4480,16 @@ rfapi_vty_show_nve_summary (struct vty *vty, show_nve_summary_t show_type)
             {
               vty_out (vty, "    %-20s ", "Locally:");
               vty_out (vty, "%-8s %-8u ", "Active:", active_local_routes);
-              vty_out (vty, "%s", VTY_NEWLINE);
+              vty_outln (vty, "");
             }
 
 
           vty_out (vty, "    %-20s ", "Remotely:");
           vty_out (vty, "%-8s %-8u", "Active:", active_remote_routes);
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
           vty_out (vty, "    %-20s ", "In Holddown:");
           vty_out (vty, "%-8s %-8u", "Active:", holddown_remote_routes);
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
           vty_out (vty, "    %-20s ", "Imported:");
           vty_out (vty, "%-8s %-8u", "Active:", imported_remote_routes);
           break;
@@ -4522,12 +4508,12 @@ rfapi_vty_show_nve_summary (struct vty *vty, show_nve_summary_t show_type)
         default:
           break;
         }
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
   return 0;
 
 notcfg:
-  vty_out (vty, "VNC is not configured.%s", VTY_NEWLINE);
+  vty_outln (vty, "VNC is not configured.");
   return CMD_WARNING;
 }
 
@@ -4594,34 +4580,34 @@ rfapi_show_nves (
       if (!printed)
         {
           /* print out a header */
-          vty_out (vty, "                                "
-                   "Active      Next Hops%s", VTY_NEWLINE);
-          vty_out (vty, "%-15s %-15s %-5s %-5s %-6s %-6s %s%s",
+          vty_outln (vty,
+                     "                                " "Active      Next Hops");
+          vty_outln (vty, "%-15s %-15s %-5s %-5s %-6s %-6s %s",
                    "VN Address",
                    "UN Address",
-                   "Regis", "Resps", "Reach", "Remove", "Age", VTY_NEWLINE);
+                   "Regis", "Resps", "Reach", "Remove", "Age");
         }
 
       ++printed;
 
-      vty_out (vty, "%-15s %-15s %-5u %-5u %-6u %-6u %s%s",
+      vty_outln (vty, "%-15s %-15s %-5u %-5u %-6u %-6u %s",
                vn_addr_buf,
                un_addr_buf,
                rfapiApCount (rfd),
                rfapi_monitor_count (rfd),
                rfd->stat_count_nh_reachable,
                rfd->stat_count_nh_removal,
-               rfapiFormatAge (rfd->open_time, age, 10), VTY_NEWLINE);
+               rfapiFormatAge(rfd->open_time, age, 10));
     }
 
   if (printed > 0 || vn_prefix || un_prefix)
-    vty_out (vty, "Displayed %d out of %d active NVEs%s",
-             printed, total, VTY_NEWLINE);
+    vty_outln (vty, "Displayed %d out of %d active NVEs",
+             printed, total);
 
   return 0;
 
 notcfg:
-  vty_out (vty, "VNC is not configured.%s", VTY_NEWLINE);
+  vty_outln (vty, "VNC is not configured.");
   return CMD_WARNING;
 }
 
@@ -4636,7 +4622,7 @@ DEFUN (vnc_show_summary,
   if (!check_and_display_is_vnc_running (vty))
     return CMD_SUCCESS;
   bgp_rfapi_show_summary (bgp_get_default (), vty);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
   rfapi_vty_show_nve_summary (vty, SHOW_NVE_SUMMARY_ACTIVE_NVES);
   rfapi_vty_show_nve_summary (vty, SHOW_NVE_SUMMARY_QUERIES);
   rfapi_vty_show_nve_summary (vty, SHOW_NVE_SUMMARY_RESPONSES);
@@ -4673,12 +4659,12 @@ DEFUN (vnc_show_nves_ptct,
 
   if (!str2prefix (argv[4]->arg, &pfx))
     {
-      vty_out (vty, "Malformed address \"%s\"%s", argv[4]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Malformed address \"%s\"", argv[4]->arg);
       return CMD_WARNING;
     }
   if (pfx.family != AF_INET && pfx.family != AF_INET6)
     {
-      vty_out (vty, "Invalid address \"%s\"%s", argv[4]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Invalid address \"%s\"", argv[4]->arg);
       return CMD_WARNING;
     }
 
@@ -4733,7 +4719,7 @@ rfapi_show_registrations (
     }
   if (!printed)
     {
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 }
 
@@ -4754,7 +4740,7 @@ DEFUN (vnc_show_registrations_pfx,
     {
       if (!str2prefix (argv[3]->arg, &p))
         {
-          vty_out (vty, "Invalid prefix: %s%s", argv[3]->arg, VTY_NEWLINE);
+          vty_outln (vty, "Invalid prefix: %s", argv[3]->arg);
           return CMD_SUCCESS;
         }
       else
@@ -4794,7 +4780,7 @@ DEFUN (vnc_show_registrations_some_pfx,
     {
       if (!str2prefix (argv[4]->arg, &p))
         {
-          vty_out (vty, "Invalid prefix: %s%s", argv[4]->arg, VTY_NEWLINE);
+          vty_outln (vty, "Invalid prefix: %s", argv[4]->arg);
           return CMD_SUCCESS;
         }
       else
@@ -4851,7 +4837,7 @@ DEFUN (vnc_show_responses_pfx,
     {
       if (!str2prefix (argv[3]->arg, &p))
         {
-          vty_out (vty, "Invalid prefix: %s%s", argv[3]->arg, VTY_NEWLINE);
+          vty_outln (vty, "Invalid prefix: %s", argv[3]->arg);
           return CMD_SUCCESS;
         }
       else
@@ -4894,7 +4880,7 @@ DEFUN (vnc_show_responses_some_pfx,
     {
       if (!str2prefix (argv[4]->arg, &p))
         {
-          vty_out (vty, "Invalid prefix: %s%s", argv[4]->arg, VTY_NEWLINE);
+          vty_outln (vty, "Invalid prefix: %s", argv[4]->arg);
           return CMD_SUCCESS;
         }
       else
@@ -4943,7 +4929,7 @@ DEFUN (show_vnc_queries_pfx,
     {
       if (!str2prefix (argv[3]->arg, &pfx))
         {
-          vty_out (vty, "Invalid prefix: %s%s", argv[3]->arg, VTY_NEWLINE);
+          vty_outln (vty, "Invalid prefix: %s", argv[3]->arg);
           return CMD_WARNING;
         }
       p = &pfx;
@@ -4996,7 +4982,7 @@ DEFUN (vnc_clear_counters,
   return CMD_SUCCESS;
 
 notcfg:
-  vty_out (vty, "VNC is not configured.%s", VTY_NEWLINE);
+  vty_outln (vty, "VNC is not configured.");
   return CMD_WARNING;
 }
 
@@ -5026,12 +5012,12 @@ vnc_add_vrf_prefix (struct vty *vty,
   bgp = bgp_get_default (); /* assume main instance for now */
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
   if (!bgp->rfapi || !bgp->rfapi_cfg)
     {
-      vty_out (vty, "VRF support not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "VRF support not configured");
       return CMD_WARNING;
     }
 
@@ -5039,32 +5025,32 @@ vnc_add_vrf_prefix (struct vty *vty,
   /* arg checks */
   if (!rfg)
     {
-      vty_out (vty, "VRF \"%s\" appears not to be configured.%s",
-               arg_vrf, VTY_NEWLINE);
+      vty_outln (vty, "VRF \"%s\" appears not to be configured.",
+               arg_vrf);
           return CMD_WARNING;
     }
   if (!rfg->rt_export_list || !rfg->rfapi_import_table)
     {
-      vty_out (vty, "VRF \"%s\" is missing RT import/export RT configuration.%s",
-               arg_vrf, VTY_NEWLINE);
+      vty_outln (vty, "VRF \"%s\" is missing RT import/export RT configuration.",
+               arg_vrf);
       return CMD_WARNING;
     }
   if (!rfg->rd.family && !arg_rd)
     {
-      vty_out (vty, "VRF \"%s\" isn't configured with an RD, so RD must be provided.%s",
-               arg_vrf, VTY_NEWLINE);
+      vty_outln (vty, "VRF \"%s\" isn't configured with an RD, so RD must be provided.",
+               arg_vrf);
       return CMD_WARNING;
     }
   if (rfg->label > MPLS_LABEL_MAX && !arg_label)
     {
-      vty_out (vty, "VRF \"%s\" isn't configured with a default labels, so a label must be provided.%s",
-               arg_vrf, VTY_NEWLINE);
+      vty_outln (vty, "VRF \"%s\" isn't configured with a default labels, so a label must be provided.",
+               arg_vrf);
       return CMD_WARNING;
     }
   if (!str2prefix (arg_prefix, &pfx))
     {
-      vty_out (vty, "Malformed prefix \"%s\"%s",
-               arg_prefix, VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix \"%s\"",
+               arg_prefix);
       return CMD_WARNING;
     }
   rfapiQprefix2Rprefix (&pfx, &rpfx);
@@ -5077,8 +5063,8 @@ vnc_add_vrf_prefix (struct vty *vty,
       opt->type = RFAPI_VN_OPTION_TYPE_INTERNAL_RD;
       if (!str2prefix_rd (arg_rd, &opt->v.internal_rd))
         {
-          vty_out (vty, "Malformed RD \"%s\"%s",
-                   arg_rd, VTY_NEWLINE);
+          vty_outln (vty, "Malformed RD \"%s\"",
+                   arg_rd);
           return CMD_WARNING;
         }
     }
@@ -5105,7 +5091,8 @@ vnc_add_vrf_prefix (struct vty *vty,
       pref = strtoul (arg_pref, &endptr, 10);
       if (*endptr != '\0')
         {
-          vty_out (vty, "%% Invalid local-preference value \"%s\"%s", arg_pref, VTY_NEWLINE);
+          vty_outln (vty, "%% Invalid local-preference value \"%s\"",
+                     arg_pref);
           return CMD_WARNING;
          }
     }
@@ -5169,7 +5156,7 @@ vnc_add_vrf_prefix (struct vty *vty,
     }
 
   vnc_zlog_debug_verbose ("%s: rfapi_register failed", __func__);
-  vty_out (vty, "Add failed.%s", VTY_NEWLINE);
+  vty_outln (vty, "Add failed.");
   return CMD_WARNING;
 }
 
@@ -5279,20 +5266,20 @@ vnc_clear_vrf (struct vty *vty,
     bgp = bgp_get_default (); /* assume main instance for now */
   if (!bgp)
     {
-      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
   if (!bgp->rfapi || !bgp->rfapi_cfg)
     {
-      vty_out (vty, "VRF support not configured%s", VTY_NEWLINE);
+      vty_outln (vty, "VRF support not configured");
       return CMD_WARNING;
     }
   rfg = bgp_rfapi_cfg_match_byname (bgp,  arg_vrf, RFAPI_GROUP_CFG_VRF);
   /* arg checks */
   if (!rfg)
     {
-      vty_out (vty, "VRF \"%s\" appears not to be configured.%s",
-               arg_vrf, VTY_NEWLINE);
+      vty_outln (vty, "VRF \"%s\" appears not to be configured.",
+               arg_vrf);
           return CMD_WARNING;
     }
   rc = parse_deleter_args (vty, bgp, arg_prefix, NULL, NULL, NULL, NULL,
@@ -5303,8 +5290,8 @@ vnc_clear_vrf (struct vty *vty,
   start_count = rfapi_cfg_group_it_count(rfg);
   clear_vnc_prefix (&cda);
   clear_vnc_vrf_closer (rfg);
-  vty_out (vty, "Cleared %u out of %d prefixes.%s", 
-           cda.pfx_count, start_count, VTY_NEWLINE);
+  vty_outln (vty, "Cleared %u out of %d prefixes.", 
+           cda.pfx_count, start_count);
   return CMD_SUCCESS;
 }
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -2516,7 +2516,7 @@ register_add (
          }
 
        vnc_zlog_debug_verbose ("%s: rfapi_register failed", __func__);
-       vty_outln (vty, "");
+       vty_out (vty, VTYNL);
        vty_outln (vty, "Registration failed.");
        vty_outln (vty,
                 "Confirm that either the VN or UN address matches a configured NVE group.");
@@ -4465,10 +4465,10 @@ rfapi_vty_show_nve_summary (struct vty *vty, show_nve_summary_t show_type)
                        h->stat.count_registrations_failed);
               vty_out (vty, "%-8s %-8u", "Total:",
                        h->stat.count_registrations);
-              vty_outln (vty, "");
+              vty_out (vty, VTYNL);
             }
           vty_out (vty, "%-24s ", "Prefixes registered:");
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
 
           rfapiCountAllItRoutes (&active_local_routes,
                                  &active_remote_routes,
@@ -4480,16 +4480,16 @@ rfapi_vty_show_nve_summary (struct vty *vty, show_nve_summary_t show_type)
             {
               vty_out (vty, "    %-20s ", "Locally:");
               vty_out (vty, "%-8s %-8u ", "Active:", active_local_routes);
-              vty_outln (vty, "");
+              vty_out (vty, VTYNL);
             }
 
 
           vty_out (vty, "    %-20s ", "Remotely:");
           vty_out (vty, "%-8s %-8u", "Active:", active_remote_routes);
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
           vty_out (vty, "    %-20s ", "In Holddown:");
           vty_out (vty, "%-8s %-8u", "Active:", holddown_remote_routes);
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
           vty_out (vty, "    %-20s ", "Imported:");
           vty_out (vty, "%-8s %-8u", "Active:", imported_remote_routes);
           break;
@@ -4508,7 +4508,7 @@ rfapi_vty_show_nve_summary (struct vty *vty, show_nve_summary_t show_type)
         default:
           break;
         }
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   return 0;
 
@@ -4622,7 +4622,7 @@ DEFUN (vnc_show_summary,
   if (!check_and_display_is_vnc_running (vty))
     return CMD_SUCCESS;
   bgp_rfapi_show_summary (bgp_get_default (), vty);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   rfapi_vty_show_nve_summary (vty, SHOW_NVE_SUMMARY_ACTIVE_NVES);
   rfapi_vty_show_nve_summary (vty, SHOW_NVE_SUMMARY_QUERIES);
   rfapi_vty_show_nve_summary (vty, SHOW_NVE_SUMMARY_RESPONSES);
@@ -4719,7 +4719,7 @@ rfapi_show_registrations (
     }
   if (!printed)
     {
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 }
 

--- a/bgpd/rfapi/vnc_debug.c
+++ b/bgpd/rfapi/vnc_debug.c
@@ -79,13 +79,13 @@ DEFUN (debug_bgp_vnc,
 	  else
 	    {
 	      term_vnc_debug |= vncdebug[i].bit;
-	      vty_out (vty, "BGP vnc %s debugging is on%s",
-		vncdebug[i].name, VTY_NEWLINE);
+	      vty_outln (vty, "BGP vnc %s debugging is on",
+		vncdebug[i].name);
 	    }
 	  return CMD_SUCCESS;
 	}
     }
-  vty_out (vty, "Unknown debug flag: %s%s", argv[3]->arg, VTY_NEWLINE);
+  vty_outln (vty, "Unknown debug flag: %s", argv[3]->arg);
   return CMD_WARNING;
 }
 
@@ -118,13 +118,13 @@ DEFUN (no_debug_bgp_vnc,
 	  else
 	    {
 	      term_vnc_debug &= ~vncdebug[i].bit;
-	      vty_out (vty, "BGP vnc %s debugging is off%s",
-		vncdebug[i].name, VTY_NEWLINE);
+	      vty_outln (vty, "BGP vnc %s debugging is off",
+		vncdebug[i].name);
 	    }
 	  return CMD_SUCCESS;
 	}
     }
-  vty_out (vty, "Unknown debug flag: %s%s", argv[3]->arg, VTY_NEWLINE);
+  vty_outln (vty, "Unknown debug flag: %s", argv[3]->arg);
   return CMD_WARNING;
 }
 
@@ -144,7 +144,7 @@ DEFUN (no_debug_bgp_vnc_all,
        VNC_STR)
 {
   term_vnc_debug = 0;
-  vty_out (vty, "All possible VNC debugging has been turned off%s", VTY_NEWLINE);
+  vty_outln (vty, "All possible VNC debugging has been turned off");
       
   return CMD_SUCCESS;
 }
@@ -163,17 +163,17 @@ DEFUN (show_debugging_bgp_vnc,
 {
   size_t	i;
 
-  vty_out (vty, "BGP VNC debugging status:%s", VTY_NEWLINE);
+  vty_outln (vty, "BGP VNC debugging status:");
 
   for (i = 0; i < (sizeof(vncdebug) / sizeof(struct vnc_debug)); ++i)
     {
       if (term_vnc_debug & vncdebug[i].bit)
 	{
-	  vty_out (vty, "  BGP VNC %s debugging is on%s",
-	    vncdebug[i].name, VTY_NEWLINE);
+	  vty_outln (vty, "  BGP VNC %s debugging is on",
+	    vncdebug[i].name);
 	}
     }
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
   return CMD_SUCCESS;
 }
 
@@ -187,7 +187,7 @@ bgp_vnc_config_write_debug (struct vty *vty)
     {
       if (conf_vnc_debug & vncdebug[i].bit)
 	{
-	  vty_out (vty, "debug bgp vnc %s%s", vncdebug[i].name, VTY_NEWLINE);
+	  vty_outln (vty, "debug bgp vnc %s", vncdebug[i].name);
 	  write++;
 	}
     }

--- a/bgpd/rfapi/vnc_debug.c
+++ b/bgpd/rfapi/vnc_debug.c
@@ -173,7 +173,7 @@ DEFUN (show_debugging_bgp_vnc,
 	    vncdebug[i].name);
 	}
     }
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   return CMD_SUCCESS;
 }
 

--- a/bgpd/rfp-example/librfp/rfp_example.c
+++ b/bgpd/rfp-example/librfp/rfp_example.c
@@ -197,7 +197,7 @@ rfp_cfg_write_cb (struct vty *vty, void *rfp_start_val)
   if (rfi->config_var != 0)
     {
       vty_out (vty, " rfp example-config-value %u", rfi->config_var);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
       write++;
     }
 

--- a/bgpd/rfp-example/librfp/rfp_example.c
+++ b/bgpd/rfp-example/librfp/rfp_example.c
@@ -197,7 +197,7 @@ rfp_cfg_write_cb (struct vty *vty, void *rfp_start_val)
   if (rfi->config_var != 0)
     {
       vty_out (vty, " rfp example-config-value %u", rfi->config_var);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       write++;
     }
 

--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -84,9 +84,8 @@ config_write_debug (struct vty *vty)
     if (conf_debug_eigrp_packet[i] == 0 && term_debug_eigrp_packet[i] == 0 )
       continue;
 
-    vty_out (vty, "debug eigrp packet %s%s%s",
-             type_str[i], detail_str[conf_debug_eigrp_packet[i]],
-             VTY_NEWLINE);
+    vty_outln (vty, "debug eigrp packet %s%s",
+             type_str[i],detail_str[conf_debug_eigrp_packet[i]]);
     write = 1;
   }
 
@@ -211,13 +210,13 @@ void
 show_ip_eigrp_interface_header (struct vty *vty, struct eigrp *eigrp)
 {
 
-  vty_out (vty, "%s%s%d%s%s%s %-10s %-10s %-10s %-6s %-12s %-7s %-14s %-12s %-8s %-8s %-8s%s %-39s %-12s %-7s %-14s %-12s %-8s%s",
+  vty_outln (vty, "%s%s%d%s%s%s %-10s %-10s %-10s %-6s %-12s %-7s %-14s %-12s %-8s %-8s %-8s%s %-39s %-12s %-7s %-14s %-12s %-8s",
            VTY_NEWLINE,
            "EIGRP interfaces for AS(",eigrp->AS,")",VTY_NEWLINE,VTY_NEWLINE,
            "Interface", "Bandwidth", "Delay", "Peers", "Xmit Queue", "Mean",
            "Pacing Time", "Multicast", "Pending", "Hello", "Holdtime",
-           VTY_NEWLINE,"","Un/Reliable","SRTT","Un/Reliable","Flow Timer","Routes",
-           VTY_NEWLINE);
+           VTY_NEWLINE,"","Un/Reliable","SRTT","Un/Reliable","Flow Timer",
+           "Routes");
 }
 
 void
@@ -230,40 +229,40 @@ show_ip_eigrp_interface_sub (struct vty *vty, struct eigrp *eigrp,
   vty_out (vty, "%-7u", ei->nbrs->count);
   vty_out (vty, "%u %c %-10u",0,'/', eigrp_neighbor_packet_queue_sum (ei));
   vty_out (vty, "%-7u %-14u %-12u %-8u", 0, 0, 0, 0);
-  vty_out (vty, "%-8u %-8u %s",
+  vty_outln (vty, "%-8u %-8u ",
            IF_DEF_PARAMS (ei->ifp)->v_hello,
-           IF_DEF_PARAMS (ei->ifp)->v_wait,VTY_NEWLINE);
+           IF_DEF_PARAMS(ei->ifp)->v_wait);
 }
 
 void
 show_ip_eigrp_interface_detail (struct vty *vty, struct eigrp *eigrp,
                                 struct eigrp_interface *ei)
 {
-  vty_out (vty, "%-2s %s %d %-3s %s","","Hello interval is ", 0, " sec", VTY_NEWLINE);
-  vty_out (vty, "%-2s %s %s %s","", "Next xmit serial","<none>", VTY_NEWLINE);
-  vty_out (vty, "%-2s %s %d %s %d %s %d %s %d %s",
+  vty_outln (vty, "%-2s %s %d %-3s ","","Hello interval is ", 0, " sec");
+  vty_outln (vty, "%-2s %s %s ","", "Next xmit serial","<none>");
+  vty_outln (vty, "%-2s %s %d %s %d %s %d %s %d ",
            "", "Un/reliable mcasts: ", 0, "/", 0, "Un/reliable ucasts: ",
-           0, "/", 0, VTY_NEWLINE);
-  vty_out (vty, "%-2s %s %d %s %d %s %d %s",
+           0, "/", 0);
+  vty_outln (vty, "%-2s %s %d %s %d %s %d ",
            "", "Mcast exceptions: ", 0, "  CR packets: ",
-           0, "  ACKs supressed: ", 0, VTY_NEWLINE);
-  vty_out (vty, "%-2s %s %d %s %d %s",
+           0, "  ACKs supressed: ", 0);
+  vty_outln (vty, "%-2s %s %d %s %d ",
            "", "Retransmissions sent: ", 0, "Out-of-sequence rcvd: ",
-           0 ,VTY_NEWLINE);
-  vty_out (vty, "%-2s %s %s %s %s",
-           "", "Authentication mode is ", "not","set", VTY_NEWLINE);
-  vty_out (vty, "%-2s %s %s", "", "Use multicast", VTY_NEWLINE);
+           0);
+  vty_outln (vty, "%-2s %s %s %s ",
+           "", "Authentication mode is ", "not","set");
+  vty_outln (vty, "%-2s %s ", "", "Use multicast");
 }
 
 void
 show_ip_eigrp_neighbor_header (struct vty *vty, struct eigrp *eigrp)
 {
-  vty_out (vty, "%s%s%d%s%s%s%-3s %-17s %-20s %-6s %-8s %-6s %-5s %-5s %-5s%s %-41s %-6s %-8s %-6s %-4s %-6s %-5s %s",
+  vty_outln (vty, "%s%s%d%s%s%s%-3s %-17s %-20s %-6s %-8s %-6s %-5s %-5s %-5s%s %-41s %-6s %-8s %-6s %-4s %-6s %-5s ",
            VTY_NEWLINE,
            "EIGRP neighbors for AS(",eigrp->AS,")",VTY_NEWLINE,VTY_NEWLINE,
            "H", "Address", "Interface", "Hold", "Uptime",
            "SRTT", "RTO", "Q", "Seq", VTY_NEWLINE
-           ,"","(sec)","","(ms)","","Cnt","Num", VTY_NEWLINE);
+           ,"","(sec)","","(ms)","","Cnt","Num");
 }
 
 void
@@ -276,7 +275,7 @@ show_ip_eigrp_neighbor_sub (struct vty *vty, struct eigrp_neighbor *nbr,
   vty_out (vty,"%-7lu", thread_timer_remain_second (nbr->t_holddown));
   vty_out (vty,"%-8u %-6u %-5u", 0, 0, EIGRP_PACKET_RETRANS_TIME);
   vty_out (vty,"%-7lu", nbr->retrans_queue->count);
-  vty_out (vty,"%u%s", nbr->recv_sequence_number, VTY_NEWLINE);
+  vty_outln (vty,"%u", nbr->recv_sequence_number);
 
 
   if (detail)
@@ -286,7 +285,7 @@ show_ip_eigrp_neighbor_sub (struct vty *vty, struct eigrp_neighbor *nbr,
               nbr->tlv_rel_major, nbr->tlv_rel_minor);
       vty_out(vty,", Retrans: %lu, Retries: %lu",
               nbr->retrans_queue->count, 0UL);
-      vty_out(vty,", %s%s", eigrp_nbr_state_str(nbr), VTY_NEWLINE);
+      vty_outln (vty,", %s", eigrp_nbr_state_str(nbr));
     }
 }
 
@@ -299,11 +298,11 @@ show_ip_eigrp_topology_header (struct vty *vty, struct eigrp *eigrp)
   struct in_addr router_id;
   router_id.s_addr = eigrp->router_id;
 
-  vty_out (vty, "%sEIGRP Topology Table for AS(%d)/ID(%s)%s%s",
-           VTY_NEWLINE, eigrp->AS, inet_ntoa(router_id), VTY_NEWLINE, VTY_NEWLINE);
-  vty_out (vty, "Codes: P - Passive, A - Active, U - Update, Q - Query, "
-           "R - Reply%s       r - reply Status, s - sia Status%s%s",
-           VTY_NEWLINE, VTY_NEWLINE,VTY_NEWLINE);
+  vty_outln (vty, "%sEIGRP Topology Table for AS(%d)/ID(%s)%s",
+           VTY_NEWLINE, eigrp->AS, inet_ntoa(router_id), VTY_NEWLINE);
+  vty_outln (vty, "Codes: P - Passive, A - Active, U - Update, Q - Query, "
+           "R - Reply%s       r - reply Status, s - sia Status%s",
+           VTY_NEWLINE, VTY_NEWLINE);
 }
 
 void
@@ -316,7 +315,7 @@ show_ip_eigrp_prefix_entry (struct vty *vty, struct eigrp_prefix_entry *tn)
   vty_out (vty, "%s/%u, ",
 	   inet_ntoa (tn->destination_ipv4->prefix), tn->destination_ipv4->prefixlen);
   vty_out (vty, "%u successors, ", successors->count);
-  vty_out (vty, "FD is %u, serno: %" PRIu64 " %s", tn->fdistance, tn->serno, VTY_NEWLINE);
+  vty_outln (vty, "FD is %u, serno: %" PRIu64 " ", tn->fdistance, tn->serno);
 
   list_delete(successors);
 }
@@ -335,15 +334,15 @@ show_ip_eigrp_neighbor_entry (struct vty *vty, struct eigrp *eigrp,
     }
 
   if (te->adv_router == eigrp->neighbor_self)
-    vty_out (vty, "%-7s%s, %s%s", " ", "via Connected",
-             eigrp_if_name_string (te->ei), VTY_NEWLINE);
-  else
-    {
-      vty_out (vty, "%-7s%s%s (%u/%u), %s%s",
-               " ", "via ", inet_ntoa (te->adv_router->src),
-               te->distance, te->reported_distance,
-               eigrp_if_name_string (te->ei), VTY_NEWLINE);
-    }
+    vty_outln (vty, "%-7s%s, %s", " ", "via Connected",
+             eigrp_if_name_string(te->ei));
+      else
+      {
+        vty_outln (vty, "%-7s%s%s (%u/%u), %s",
+	               " ", "via ", inet_ntoa (te->adv_router->src),
+	               te->distance, te->reported_distance,
+	               eigrp_if_name_string(te->ei));
+      }
 }
 
 
@@ -356,11 +355,11 @@ DEFUN (show_debugging_eigrp,
 {
   int i;
 
-  vty_out (vty, "EIGRP debugging status:%s", VTY_NEWLINE);
+  vty_outln (vty, "EIGRP debugging status:");
 
   /* Show debug status for events. */
   if (IS_DEBUG_EIGRP(event,EVENT))
-    vty_out (vty, "  EIGRP event debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  EIGRP event debugging is on");
 
   /* Show debug status for EIGRP Packets. */
   for (i = 0; i < 11 ; i++)
@@ -370,23 +369,20 @@ DEFUN (show_debugging_eigrp,
 
       if (IS_DEBUG_EIGRP_PACKET (i, SEND) && IS_DEBUG_EIGRP_PACKET (i, RECV))
         {
-          vty_out (vty, "  EIGRP packet %s%s debugging is on%s",
-                   lookup_msg(eigrp_packet_type_str, i + 1, NULL),
-                   IS_DEBUG_EIGRP_PACKET (i, PACKET_DETAIL) ? " detail" : "",
-                   VTY_NEWLINE);
+          vty_outln (vty, "  EIGRP packet %s%s debugging is on",
+                     lookup_msg(eigrp_packet_type_str, i + 1, NULL),
+                     IS_DEBUG_EIGRP_PACKET (i, PACKET_DETAIL) ? " detail" : "");
         }
       else
         {
           if (IS_DEBUG_EIGRP_PACKET (i, SEND))
-            vty_out (vty, "  EIGRP packet %s send%s debugging is on%s",
-                     lookup_msg(eigrp_packet_type_str, i + 1, NULL),
-                     IS_DEBUG_EIGRP_PACKET (i, PACKET_DETAIL) ? " detail" : "",
-                     VTY_NEWLINE);
+            vty_outln (vty, "  EIGRP packet %s send%s debugging is on",
+                       lookup_msg(eigrp_packet_type_str, i + 1, NULL),
+                       IS_DEBUG_EIGRP_PACKET (i, PACKET_DETAIL) ? " detail" : "");
           if (IS_DEBUG_EIGRP_PACKET (i, RECV))
-            vty_out (vty, "  EIGRP packet %s receive%s debugging is on%s",
-                     lookup_msg(eigrp_packet_type_str, i + 1, NULL),
-                     IS_DEBUG_EIGRP_PACKET (i, PACKET_DETAIL) ? " detail" : "",
-                     VTY_NEWLINE);
+            vty_outln (vty, "  EIGRP packet %s receive%s debugging is on%s",
+                       lookup_msg(eigrp_packet_type_str, i + 1, NULL),
+                       IS_DEBUG_EIGRP_PACKET (i, PACKET_DETAIL) ? " detail" : "");
         }
     }
 

--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -211,11 +211,11 @@ show_ip_eigrp_interface_header (struct vty *vty, struct eigrp *eigrp)
 {
 
   vty_outln (vty, "%s%s%d%s%s%s %-10s %-10s %-10s %-6s %-12s %-7s %-14s %-12s %-8s %-8s %-8s%s %-39s %-12s %-7s %-14s %-12s %-8s",
-           VTY_NEWLINE,
-           "EIGRP interfaces for AS(",eigrp->AS,")",VTY_NEWLINE,VTY_NEWLINE,
+           VTYNL,
+           "EIGRP interfaces for AS(",eigrp->AS,")",VTYNL,VTYNL,
            "Interface", "Bandwidth", "Delay", "Peers", "Xmit Queue", "Mean",
            "Pacing Time", "Multicast", "Pending", "Hello", "Holdtime",
-           VTY_NEWLINE,"","Un/Reliable","SRTT","Un/Reliable","Flow Timer",
+           VTYNL,"","Un/Reliable","SRTT","Un/Reliable","Flow Timer",
            "Routes");
 }
 
@@ -258,10 +258,10 @@ void
 show_ip_eigrp_neighbor_header (struct vty *vty, struct eigrp *eigrp)
 {
   vty_outln (vty, "%s%s%d%s%s%s%-3s %-17s %-20s %-6s %-8s %-6s %-5s %-5s %-5s%s %-41s %-6s %-8s %-6s %-4s %-6s %-5s ",
-           VTY_NEWLINE,
-           "EIGRP neighbors for AS(",eigrp->AS,")",VTY_NEWLINE,VTY_NEWLINE,
+           VTYNL,
+           "EIGRP neighbors for AS(",eigrp->AS,")",VTYNL,VTYNL,
            "H", "Address", "Interface", "Hold", "Uptime",
-           "SRTT", "RTO", "Q", "Seq", VTY_NEWLINE
+           "SRTT", "RTO", "Q", "Seq", VTYNL
            ,"","(sec)","","(ms)","","Cnt","Num");
 }
 
@@ -299,10 +299,10 @@ show_ip_eigrp_topology_header (struct vty *vty, struct eigrp *eigrp)
   router_id.s_addr = eigrp->router_id;
 
   vty_outln (vty, "%sEIGRP Topology Table for AS(%d)/ID(%s)%s",
-           VTY_NEWLINE, eigrp->AS, inet_ntoa(router_id), VTY_NEWLINE);
+           VTYNL, eigrp->AS, inet_ntoa(router_id), VTYNL);
   vty_outln (vty, "Codes: P - Passive, A - Active, U - Update, Q - Query, "
            "R - Reply%s       r - reply Status, s - sia Status%s",
-           VTY_NEWLINE, VTY_NEWLINE);
+           VTYNL, VTYNL);
 }
 
 void
@@ -380,7 +380,7 @@ DEFUN (show_debugging_eigrp,
                        lookup_msg(eigrp_packet_type_str, i + 1, NULL),
                        IS_DEBUG_EIGRP_PACKET (i, PACKET_DETAIL) ? " detail" : "");
           if (IS_DEBUG_EIGRP_PACKET (i, RECV))
-            vty_outln (vty, "  EIGRP packet %s receive%s debugging is on%s",
+            vty_outln (vty, "  EIGRP packet %s receive%s debugging is on",
                        lookup_msg(eigrp_packet_type_str, i + 1, NULL),
                        IS_DEBUG_EIGRP_PACKET (i, PACKET_DETAIL) ? " detail" : "");
         }

--- a/eigrpd/eigrp_neighbor.c
+++ b/eigrpd/eigrp_neighbor.c
@@ -366,10 +366,9 @@ void eigrp_nbr_hard_restart(struct eigrp_neighbor *nbr, struct vty *vty)
   if(vty != NULL)
     {
       vty_time_print (vty, 0);
-      vty_out (vty, "Neighbor %s (%s) is down: manually cleared%s",
+      vty_outln (vty, "Neighbor %s (%s) is down: manually cleared",
                inet_ntoa (nbr->src),
-               ifindex2ifname (nbr->ei->ifp->ifindex, VRF_DEFAULT),
-               VTY_NEWLINE);
+               ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
     }
 
   /* send Hello with Peer Termination TLV */

--- a/eigrpd/eigrp_routemap.c
+++ b/eigrpd/eigrp_routemap.c
@@ -154,10 +154,10 @@ eigrp_route_match_add (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_out (vty, "%% Can't find rule.%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Can't find rule.");
           return CMD_WARNING;
         case RMAP_COMPILE_ERROR:
-          vty_out (vty, "%% Argument is malformed.%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Argument is malformed.");
           return CMD_WARNING;
         }
     }
@@ -176,10 +176,10 @@ eigrp_route_match_delete (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_out (vty, "%% Can't find rule.%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Can't find rule.");
           return CMD_WARNING;
         case RMAP_COMPILE_ERROR:
-          vty_out (vty, "%% Argument is malformed.%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Argument is malformed.");
           return CMD_WARNING;
         }
     }
@@ -199,7 +199,7 @@ eigrp_route_set_add (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_out (vty, "%% Can't find rule.%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Can't find rule.");
           return CMD_WARNING;
         case RMAP_COMPILE_ERROR:
           /* rip, ripng and other protocols share the set metric command
@@ -207,7 +207,7 @@ eigrp_route_set_add (struct vty *vty, struct route_map_index *index,
              if metric is out of range for rip and ripng, it is not for
              other protocols. Do not return an error */
           if (strcmp(command, "metric")) {
-            vty_out (vty, "%% Argument is malformed.%s", VTY_NEWLINE);
+            vty_outln (vty, "%% Argument is malformed.");
             return CMD_WARNING;
           }
         }
@@ -228,10 +228,10 @@ eigrp_route_set_delete (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_out (vty, "%% Can't find rule.%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Can't find rule.");
           return CMD_WARNING;
         case RMAP_COMPILE_ERROR:
-          vty_out (vty, "%% Argument is malformed.%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Argument is malformed.");
           return CMD_WARNING;
         }
     }
@@ -1124,7 +1124,7 @@ DEFUN (set_ip_nexthop,
   ret = str2sockunion (argv[0], &su);
   if (ret < 0)
     {
-      vty_out (vty, "%% Malformed next-hop address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed next-hop address");
       return CMD_WARNING;
     }
 

--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -1047,10 +1047,9 @@ eigrp_update_send_GR (struct eigrp_neighbor *nbr, enum GR_type gr_type, struct v
       if(vty != NULL)
         {
           vty_time_print (vty, 0);
-          vty_out (vty, "Neighbor %s (%s) is resync: manually cleared%s",
+          vty_outln (vty, "Neighbor %s (%s) is resync: manually cleared",
                    inet_ntoa (nbr->src),
-                   ifindex2ifname (nbr->ei->ifp->ifindex, VRF_DEFAULT),
-                   VTY_NEWLINE);
+                   ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
         }
     }
 

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -65,18 +65,18 @@ config_write_network (struct vty *vty, struct eigrp *eigrp)
     if (rn->info)
       {
         /* Network print. */
-        vty_out (vty, " network %s/%d %s",
-                 inet_ntoa (rn->p.u.prefix4), rn->p.prefixlen, VTY_NEWLINE);
+        vty_outln (vty, " network %s/%d ",
+                 inet_ntoa (rn->p.u.prefix4), rn->p.prefixlen);
       }
 
   if (eigrp->max_paths != EIGRP_MAX_PATHS_DEFAULT)
-    vty_out (vty, " maximum-paths %d%s", eigrp->max_paths, VTY_NEWLINE);
+    vty_outln (vty, " maximum-paths %d", eigrp->max_paths);
 
   if (eigrp->variance != EIGRP_VARIANCE_DEFAULT)
-    vty_out (vty, " variance %d%s", eigrp->variance, VTY_NEWLINE);
+    vty_outln (vty, " variance %d", eigrp->variance);
 
   /*Separate EIGRP configuration from the rest of the config*/
-  vty_out (vty, "!%s", VTY_NEWLINE);
+  vty_outln (vty, "!");
 
   return 0;
 }
@@ -89,35 +89,39 @@ config_write_interfaces (struct vty *vty, struct eigrp *eigrp)
 
   for (ALL_LIST_ELEMENTS_RO (eigrp->eiflist, node, ei))
     {
-      vty_out (vty, "interface %s%s", ei->ifp->name, VTY_NEWLINE);
+      vty_outln (vty, "interface %s", ei->ifp->name);
 
       if ((IF_DEF_PARAMS (ei->ifp)->auth_type) == EIGRP_AUTH_TYPE_MD5)
         {
-          vty_out (vty, " ip authentication mode eigrp %d md5%s", eigrp->AS, VTY_NEWLINE);
+          vty_outln (vty, " ip authentication mode eigrp %d md5", eigrp->AS);
         }
 
       if ((IF_DEF_PARAMS (ei->ifp)->auth_type) == EIGRP_AUTH_TYPE_SHA256)
         {
-          vty_out (vty, " ip authentication mode eigrp %d hmac-sha-256%s", eigrp->AS, VTY_NEWLINE);
+          vty_outln (vty, " ip authentication mode eigrp %d hmac-sha-256",
+                     eigrp->AS);
         }
 
       if(IF_DEF_PARAMS (ei->ifp)->auth_keychain)
         {
-          vty_out (vty, " ip authentication key-chain eigrp %d %s%s",eigrp->AS,IF_DEF_PARAMS (ei->ifp)->auth_keychain, VTY_NEWLINE);
+          vty_outln (vty, " ip authentication key-chain eigrp %d %s",eigrp->AS,
+                     IF_DEF_PARAMS(ei->ifp)->auth_keychain);
         }
 
       if ((IF_DEF_PARAMS (ei->ifp)->v_hello) != EIGRP_HELLO_INTERVAL_DEFAULT)
         {
-          vty_out (vty, " ip hello-interval eigrp %d%s", IF_DEF_PARAMS (ei->ifp)->v_hello, VTY_NEWLINE);
+          vty_outln (vty, " ip hello-interval eigrp %d",
+                     IF_DEF_PARAMS(ei->ifp)->v_hello);
         }
 
       if ((IF_DEF_PARAMS (ei->ifp)->v_wait) != EIGRP_HOLD_INTERVAL_DEFAULT)
         {
-          vty_out (vty, " ip hold-time eigrp %d%s", IF_DEF_PARAMS (ei->ifp)->v_wait, VTY_NEWLINE);
+          vty_outln (vty, " ip hold-time eigrp %d",
+                     IF_DEF_PARAMS(ei->ifp)->v_wait);
         }
 
       /*Separate this EIGRP interface configuration from the others*/
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_outln (vty, "!");
     }
 
   return 0;
@@ -130,26 +134,23 @@ eigrp_write_interface (struct vty *vty)
   struct interface *ifp;
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist(VRF_DEFAULT), node, ifp)) {
-    vty_out (vty, "interface %s%s", ifp->name,
-             VTY_NEWLINE);
+    vty_outln (vty, "interface %s",ifp->name);
 
     if (ifp->desc)
-      vty_out (vty, " description %s%s", ifp->desc,
-               VTY_NEWLINE);
+      vty_outln (vty, " description %s",ifp->desc);
 
     if (IF_DEF_PARAMS (ifp)->bandwidth != EIGRP_BANDWIDTH_DEFAULT)
-      vty_out (vty, " bandwidth %u%s", IF_DEF_PARAMS (ifp)->bandwidth,
-               VTY_NEWLINE);
+      vty_outln (vty, " bandwidth %u",IF_DEF_PARAMS(ifp)->bandwidth);
     if (IF_DEF_PARAMS (ifp)->delay != EIGRP_DELAY_DEFAULT)
-      vty_out (vty, " delay %u%s", IF_DEF_PARAMS (ifp)->delay, VTY_NEWLINE);
+      vty_outln (vty, " delay %u", IF_DEF_PARAMS(ifp)->delay);
     if (IF_DEF_PARAMS (ifp)->v_hello != EIGRP_HELLO_INTERVAL_DEFAULT)
-      vty_out (vty, " ip hello-interval eigrp %u%s",
-               IF_DEF_PARAMS (ifp)->v_hello, VTY_NEWLINE);
+      vty_outln (vty, " ip hello-interval eigrp %u",
+               IF_DEF_PARAMS(ifp)->v_hello);
     if (IF_DEF_PARAMS (ifp)->v_wait != EIGRP_HOLD_INTERVAL_DEFAULT)
-      vty_out (vty, " ip hold-time eigrp %u%s",
-               IF_DEF_PARAMS (ifp)->v_wait, VTY_NEWLINE);
+      vty_outln (vty, " ip hold-time eigrp %u",
+               IF_DEF_PARAMS(ifp)->v_wait);
 
-    vty_out (vty, "!%s", VTY_NEWLINE);
+    vty_outln (vty, "!");
   }
 
   return 0;
@@ -178,7 +179,7 @@ config_write_eigrp_router (struct vty *vty, struct eigrp *eigrp)
   int write=0;
 
   /* `router eigrp' print. */
-  vty_out (vty, "router eigrp %d%s", eigrp->AS, VTY_NEWLINE);
+  vty_outln (vty, "router eigrp %d", eigrp->AS);
 
   write++;
 
@@ -190,8 +191,8 @@ config_write_eigrp_router (struct vty *vty, struct eigrp *eigrp)
     {
       struct in_addr router_id_static;
       router_id_static.s_addr = htonl(eigrp->router_id_static);
-      vty_out (vty, " eigrp router-id %s%s",
-               inet_ntoa (router_id_static), VTY_NEWLINE);
+      vty_outln (vty, " eigrp router-id %s",
+               inet_ntoa(router_id_static));
     }
 
   /* Network area print. */
@@ -201,7 +202,7 @@ config_write_eigrp_router (struct vty *vty, struct eigrp *eigrp)
   config_write_eigrp_distribute (vty, eigrp);
 
   /*Separate EIGRP configuration from the rest of the config*/
-  vty_out (vty, "!%s", VTY_NEWLINE);
+  vty_outln (vty, "!");
 
   return write;
 }
@@ -234,8 +235,7 @@ DEFUN (no_router_eigrp,
   eigrp = eigrp_lookup ();
   if (eigrp->AS != atoi (argv[3]->arg))
     {
-      vty_out (vty, "%% Attempting to deconfigure non-existent AS%s",
-               VTY_NEWLINE);
+      vty_outln (vty,"%% Attempting to deconfigure non-existent AS");
       return CMD_WARNING;
     }
 
@@ -393,7 +393,7 @@ DEFUN (eigrp_network,
 
   if (ret == 0)
     {
-      vty_out (vty, "There is already same network statement.%s", VTY_NEWLINE);
+      vty_outln (vty, "There is already same network statement.");
       return CMD_WARNING;
     }
 
@@ -417,7 +417,7 @@ DEFUN (no_eigrp_network,
 
   if (ret == 0)
   {
-    vty_out (vty,"Can't find specified network configuration.%s", VTY_NEWLINE);
+    vty_outln (vty,"Can't find specified network configuration.");
     return CMD_WARNING;
   }
 
@@ -465,7 +465,7 @@ DEFUN (show_ip_eigrp_topology,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -521,7 +521,7 @@ DEFUN (show_ip_eigrp_interfaces,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, "EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -568,7 +568,7 @@ DEFUN (show_ip_eigrp_neighbors,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -607,7 +607,7 @@ DEFUN (eigrp_if_delay,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
 
       return CMD_SUCCESS;
     }
@@ -633,7 +633,7 @@ DEFUN (no_eigrp_if_delay,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
 
       return CMD_SUCCESS;
     }
@@ -658,7 +658,7 @@ DEFUN (eigrp_if_bandwidth,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -684,7 +684,7 @@ DEFUN (no_eigrp_if_bandwidth,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -709,7 +709,7 @@ DEFUN (eigrp_if_ip_hellointerval,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -737,7 +737,7 @@ DEFUN (no_eigrp_if_ip_hellointerval,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -771,7 +771,7 @@ DEFUN (eigrp_if_ip_holdinterval,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -798,7 +798,7 @@ DEFUN (eigrp_ip_summary_address,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -826,7 +826,7 @@ DEFUN (no_eigrp_ip_summary_address,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -852,7 +852,7 @@ DEFUN (no_eigrp_if_ip_holdinterval,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -899,7 +899,7 @@ DEFUN (eigrp_authentication_mode,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -929,7 +929,7 @@ DEFUN (no_eigrp_authentication_mode,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -955,7 +955,7 @@ DEFUN (eigrp_authentication_keychain,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, "EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -971,7 +971,7 @@ DEFUN (eigrp_authentication_keychain,
         IF_DEF_PARAMS (ifp)->auth_keychain = strdup(keychain->name);
     }
   else
-    vty_out(vty,"Key chain with specified name not found%s", VTY_NEWLINE);
+    vty_outln (vty,"Key chain with specified name not found");
 
   return CMD_SUCCESS;
 }
@@ -993,7 +993,7 @@ DEFUN (no_eigrp_authentication_keychain,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, "EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1004,7 +1004,8 @@ DEFUN (no_eigrp_authentication_keychain,
       IF_DEF_PARAMS (ifp)->auth_keychain = NULL;
     }
   else
-    vty_out(vty,"Key chain with specified name not configured on interface%s", VTY_NEWLINE);
+    vty_outln (vty,
+              "Key chain with specified name not configured on interface");
 
   return CMD_SUCCESS;
 }
@@ -1079,7 +1080,7 @@ DEFUN (eigrp_variance,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, "EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
   variance = atoi(argv[1]->arg);
@@ -1102,7 +1103,7 @@ DEFUN (no_eigrp_variance,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, "EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1125,7 +1126,7 @@ DEFUN (eigrp_maximum_paths,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, "EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1150,7 +1151,7 @@ DEFUN (no_eigrp_maximum_paths,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, "EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1181,7 +1182,7 @@ DEFUN (clear_ip_eigrp_neighbors,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1200,10 +1201,9 @@ DEFUN (clear_ip_eigrp_neighbors,
                           inet_ntoa (nbr->src),
                           ifindex2ifname (nbr->ei->ifp->ifindex, VRF_DEFAULT));
               vty_time_print (vty, 0);
-              vty_out (vty, "Neighbor %s (%s) is down: manually cleared%s",
+              vty_outln (vty, "Neighbor %s (%s) is down: manually cleared",
                        inet_ntoa (nbr->src),
-                       ifindex2ifname (nbr->ei->ifp->ifindex, VRF_DEFAULT),
-                       VTY_NEWLINE);
+                       ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
 
               /* set neighbor to DOWN */
               nbr->state = EIGRP_NEIGHBOR_DOWN;
@@ -1238,7 +1238,7 @@ DEFUN (clear_ip_eigrp_neighbors_int,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1247,7 +1247,7 @@ DEFUN (clear_ip_eigrp_neighbors_int,
   ei = eigrp_if_lookup_by_name(eigrp, argv[idx]->arg);
   if(ei == NULL)
     {
-      vty_out (vty, " Interface (%s) doesn't exist%s", argv[idx]->arg, VTY_NEWLINE);
+      vty_outln (vty, " Interface (%s) doesn't exist", argv[idx]->arg);
       return CMD_WARNING;
     }
 
@@ -1263,10 +1263,9 @@ DEFUN (clear_ip_eigrp_neighbors_int,
                       inet_ntoa (nbr->src),
                       ifindex2ifname (nbr->ei->ifp->ifindex, VRF_DEFAULT));
           vty_time_print (vty, 0);
-          vty_out (vty, "Neighbor %s (%s) is down: manually cleared%s",
+          vty_outln (vty, "Neighbor %s (%s) is down: manually cleared",
                    inet_ntoa (nbr->src),
-                   ifindex2ifname (nbr->ei->ifp->ifindex, VRF_DEFAULT),
-                   VTY_NEWLINE);
+                   ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
 
           /* set neighbor to DOWN */
           nbr->state = EIGRP_NEIGHBOR_DOWN;
@@ -1300,7 +1299,7 @@ DEFUN (clear_ip_eigrp_neighbors_IP,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1310,7 +1309,7 @@ DEFUN (clear_ip_eigrp_neighbors_IP,
   /* if neighbor doesn't exists, notify user and exit */
   if(nbr == NULL)
     {
-      vty_out (vty, "Neighbor with entered address doesn't exists.%s", VTY_NEWLINE);
+      vty_outln (vty, "Neighbor with entered address doesn't exists.");
       return CMD_WARNING;
     }
 
@@ -1338,7 +1337,7 @@ DEFUN (clear_ip_eigrp_neighbors_soft,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1368,7 +1367,7 @@ DEFUN (clear_ip_eigrp_neighbors_int_soft,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1376,7 +1375,7 @@ DEFUN (clear_ip_eigrp_neighbors_int_soft,
   ei = eigrp_if_lookup_by_name(eigrp, argv[4]->arg);
   if(ei == NULL)
     {
-      vty_out (vty, " Interface (%s) doesn't exist%s", argv[4]->arg, VTY_NEWLINE);
+      vty_outln (vty, " Interface (%s) doesn't exist", argv[4]->arg);
       return CMD_WARNING;
     }
 
@@ -1408,7 +1407,7 @@ DEFUN (clear_ip_eigrp_neighbors_IP_soft,
   eigrp = eigrp_lookup ();
   if (eigrp == NULL)
     {
-      vty_out (vty, " EIGRP Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, " EIGRP Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -1418,7 +1417,7 @@ DEFUN (clear_ip_eigrp_neighbors_IP_soft,
   /* if neighbor doesn't exists, notify user and exit */
   if(nbr == NULL)
     {
-      vty_out (vty, "Neighbor with entered address doesn't exists.%s", VTY_NEWLINE);
+      vty_outln (vty, "Neighbor with entered address doesn't exists.");
       return CMD_WARNING;
     }
 

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -402,13 +402,13 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
       else
 	vty_out (vty, "-        ");
       vty_out (vty, "%-10s", snpa_print (adj->snpa));
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   if (detail == ISIS_UI_LEVEL_DETAIL)
     {
       level = adj->level;
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       if (adj->circuit)
 	vty_out (vty, "    Interface: %s", adj->circuit->interface->name);
       else
@@ -421,13 +421,13 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
 		 time2string (adj->last_upd + adj->hold_time - now));
       else
 	vty_out (vty, ", Expires in %s", time2string (adj->hold_time));
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       vty_out (vty, "    Adjacency flaps: %u", adj->flaps);
       vty_out (vty, ", Last: %s ago", time2string (now - adj->last_flap));
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       vty_out (vty, "    Circuit type: %s", circuit_t2string (adj->circuit_t));
       vty_out (vty, ", Speaks: %s", nlpid2string (&adj->nlpids));
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       if (adj->mt_count != 1 || adj->mt_set[0] != ISIS_MT_IPV4_UNICAST)
         {
           vty_outln (vty, "    Topologies:");
@@ -445,7 +445,7 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
           vty_out (vty, ", LAN id: %s.%02x",
               sysid_print (adj->lanid), adj->lanid[ISIS_SYS_ID_LEN]);
 
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
         vty_out (vty, "    LAN Priority: %u", adj->prio[adj->level - 1]);
 
         vty_out (vty, ", %s, DIS flaps: %u, Last: %s ago",
@@ -455,7 +455,7 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
               (adj->dis_record[ISIS_LEVELS + level - 1].
                last_dis_change)));
       }
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
 
       if (adj->area_addrs && listcount (adj->area_addrs) > 0)
         {
@@ -480,7 +480,7 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
 	      vty_outln (vty, "      %s", ip6);
 	    }
 	}
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   return;
 }

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -402,13 +402,13 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
       else
 	vty_out (vty, "-        ");
       vty_out (vty, "%-10s", snpa_print (adj->snpa));
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   if (detail == ISIS_UI_LEVEL_DETAIL)
     {
       level = adj->level;
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
       if (adj->circuit)
 	vty_out (vty, "    Interface: %s", adj->circuit->interface->name);
       else
@@ -421,18 +421,18 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
 		 time2string (adj->last_upd + adj->hold_time - now));
       else
 	vty_out (vty, ", Expires in %s", time2string (adj->hold_time));
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
       vty_out (vty, "    Adjacency flaps: %u", adj->flaps);
       vty_out (vty, ", Last: %s ago", time2string (now - adj->last_flap));
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
       vty_out (vty, "    Circuit type: %s", circuit_t2string (adj->circuit_t));
       vty_out (vty, ", Speaks: %s", nlpid2string (&adj->nlpids));
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
       if (adj->mt_count != 1 || adj->mt_set[0] != ISIS_MT_IPV4_UNICAST)
         {
-          vty_out (vty, "    Topologies:%s", VTY_NEWLINE);
+          vty_outln (vty, "    Topologies:");
           for (unsigned int i = 0; i < adj->mt_count; i++)
-            vty_out (vty, "      %s%s", isis_mtid2str(adj->mt_set[i]), VTY_NEWLINE);
+            vty_outln (vty, "      %s", isis_mtid2str(adj->mt_set[i]));
         }
       vty_out (vty, "    SNPA: %s", snpa_print (adj->snpa));
       if (adj->circuit && (adj->circuit->circ_type == CIRCUIT_T_BROADCAST))
@@ -445,7 +445,7 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
           vty_out (vty, ", LAN id: %s.%02x",
               sysid_print (adj->lanid), adj->lanid[ISIS_SYS_ID_LEN]);
 
-        vty_out (vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "");
         vty_out (vty, "    LAN Priority: %u", adj->prio[adj->level - 1]);
 
         vty_out (vty, ", %s, DIS flaps: %u, Last: %s ago",
@@ -455,32 +455,32 @@ isis_adj_print_vty (struct isis_adjacency *adj, struct vty *vty, char detail)
               (adj->dis_record[ISIS_LEVELS + level - 1].
                last_dis_change)));
       }
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
 
       if (adj->area_addrs && listcount (adj->area_addrs) > 0)
         {
           struct area_addr *area_addr;
-          vty_out (vty, "    Area Address(es):%s", VTY_NEWLINE);
+          vty_outln (vty, "    Area Address(es):");
           for (ALL_LIST_ELEMENTS_RO (adj->area_addrs, node, area_addr))
-            vty_out (vty, "      %s%s", isonet_print (area_addr->area_addr,
-                     area_addr->addr_len), VTY_NEWLINE);
+            vty_outln (vty, "      %s",
+                       isonet_print(area_addr->area_addr, area_addr->addr_len));
         }
       if (adj->ipv4_addrs && listcount (adj->ipv4_addrs) > 0)
 	{
-	  vty_out (vty, "    IPv4 Address(es):%s", VTY_NEWLINE);
+	  vty_outln (vty, "    IPv4 Address(es):");
 	  for (ALL_LIST_ELEMENTS_RO (adj->ipv4_addrs, node, ip_addr))
-            vty_out (vty, "      %s%s", inet_ntoa (*ip_addr), VTY_NEWLINE);
+            vty_outln (vty, "      %s", inet_ntoa(*ip_addr));
 	}
       if (adj->ipv6_addrs && listcount (adj->ipv6_addrs) > 0)
 	{
-	  vty_out (vty, "    IPv6 Address(es):%s", VTY_NEWLINE);
+	  vty_outln (vty, "    IPv6 Address(es):");
 	  for (ALL_LIST_ELEMENTS_RO (adj->ipv6_addrs, node, ipv6_addr))
 	    {
 	      inet_ntop (AF_INET6, ipv6_addr, (char *)ip6, INET6_ADDRSTRLEN);
-	      vty_out (vty, "      %s%s", ip6, VTY_NEWLINE);
+	      vty_outln (vty, "      %s", ip6);
 	    }
 	}
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
   return;
 }

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -878,7 +878,7 @@ isis_circuit_print_vty (struct isis_circuit *circuit, struct vty *vty,
       vty_out (vty, "%-9s", circuit_state2string (circuit->state));
       vty_out (vty, "%-9s", circuit_type2string (circuit->circ_type));
       vty_out (vty, "%-9s", circuit_t2string (circuit->is_type));
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   if (detail == ISIS_UI_LEVEL_DETAIL)
@@ -894,15 +894,15 @@ isis_circuit_print_vty (struct isis_circuit *circuit, struct vty *vty,
       else
         vty_out (vty, ", Active");
       vty_out (vty, ", Circuit Id: 0x%x", circuit->circuit_id);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
       vty_out (vty, "    Type: %s", circuit_type2string (circuit->circ_type));
       vty_out (vty, ", Level: %s", circuit_t2string (circuit->is_type));
       if (circuit->circ_type == CIRCUIT_T_BROADCAST)
         vty_out (vty, ", SNPA: %-10s", snpa_print (circuit->u.bc.snpa));
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
       if (circuit->is_type & IS_LEVEL_1)
         {
-          vty_out (vty, "    Level-1 Information:%s", VTY_NEWLINE);
+          vty_outln (vty, "    Level-1 Information:");
           if (circuit->area->newmetric)
             vty_out (vty, "      Metric: %d", circuit->te_metric[0]);
           else
@@ -910,32 +910,30 @@ isis_circuit_print_vty (struct isis_circuit *circuit, struct vty *vty,
                      circuit->metric[0]);
           if (!circuit->is_passive)
             {
-              vty_out (vty, ", Active neighbors: %u%s",
-                       circuit->upadjcount[0], VTY_NEWLINE);
-              vty_out (vty, "      Hello interval: %u, "
-                            "Holddown count: %u %s%s",
+              vty_outln (vty, ", Active neighbors: %u",
+                       circuit->upadjcount[0]);
+              vty_outln (vty, "      Hello interval: %u, "
+                            "Holddown count: %u %s",
                        circuit->hello_interval[0],
                        circuit->hello_multiplier[0],
-                       (circuit->pad_hellos ? "(pad)" : "(no-pad)"),
-                       VTY_NEWLINE);
-              vty_out (vty, "      CNSP interval: %u, "
-                            "PSNP interval: %u%s",
+                       (circuit->pad_hellos ? "(pad)" : "(no-pad)"));
+              vty_outln (vty, "      CNSP interval: %u, "
+                            "PSNP interval: %u",
                        circuit->csnp_interval[0],
-                       circuit->psnp_interval[0], VTY_NEWLINE);
+                       circuit->psnp_interval[0]);
               if (circuit->circ_type == CIRCUIT_T_BROADCAST)
-                vty_out (vty, "      LAN Priority: %u, %s%s",
+                vty_outln (vty, "      LAN Priority: %u, %s",
                          circuit->priority[0],
-                         (circuit->u.bc.is_dr[0] ? \
-                          "is DIS" : "is not DIS"), VTY_NEWLINE);
+                         (circuit->u.bc.is_dr[0] ? "is DIS" : "is not DIS"));
             }
           else
             {
-              vty_out (vty, "%s", VTY_NEWLINE);
+              vty_outln (vty, "");
             }
         }
       if (circuit->is_type & IS_LEVEL_2)
         {
-          vty_out (vty, "    Level-2 Information:%s", VTY_NEWLINE);
+          vty_outln (vty, "    Level-2 Information:");
           if (circuit->area->newmetric)
             vty_out (vty, "      Metric: %d", circuit->te_metric[1]);
           else
@@ -943,58 +941,56 @@ isis_circuit_print_vty (struct isis_circuit *circuit, struct vty *vty,
                      circuit->metric[1]);
           if (!circuit->is_passive)
             {
-              vty_out (vty, ", Active neighbors: %u%s",
-                       circuit->upadjcount[1], VTY_NEWLINE);
-              vty_out (vty, "      Hello interval: %u, "
-                            "Holddown count: %u %s%s",
+              vty_outln (vty, ", Active neighbors: %u",
+                       circuit->upadjcount[1]);
+              vty_outln (vty, "      Hello interval: %u, "
+                            "Holddown count: %u %s",
                        circuit->hello_interval[1],
                        circuit->hello_multiplier[1],
-                       (circuit->pad_hellos ? "(pad)" : "(no-pad)"),
-                       VTY_NEWLINE);
-              vty_out (vty, "      CNSP interval: %u, "
-                            "PSNP interval: %u%s",
+                       (circuit->pad_hellos ? "(pad)" : "(no-pad)"));
+              vty_outln (vty, "      CNSP interval: %u, "
+                            "PSNP interval: %u",
                        circuit->csnp_interval[1],
-                       circuit->psnp_interval[1], VTY_NEWLINE);
+                       circuit->psnp_interval[1]);
               if (circuit->circ_type == CIRCUIT_T_BROADCAST)
-                vty_out (vty, "      LAN Priority: %u, %s%s",
+                vty_outln (vty, "      LAN Priority: %u, %s",
                          circuit->priority[1],
-                         (circuit->u.bc.is_dr[1] ? \
-                          "is DIS" : "is not DIS"), VTY_NEWLINE);
+                         (circuit->u.bc.is_dr[1] ? "is DIS" : "is not DIS"));
             }
           else
             {
-              vty_out (vty, "%s", VTY_NEWLINE);
+              vty_outln (vty, "");
             }
         }
       if (circuit->ip_addrs && listcount (circuit->ip_addrs) > 0)
         {
-          vty_out (vty, "    IP Prefix(es):%s", VTY_NEWLINE);
+          vty_outln (vty, "    IP Prefix(es):");
           for (ALL_LIST_ELEMENTS_RO (circuit->ip_addrs, node, ip_addr))
             {
               prefix2str (ip_addr, buf, sizeof (buf)),
-              vty_out (vty, "      %s%s", buf, VTY_NEWLINE);
+              vty_outln (vty, "      %s", buf);
             }
         }
       if (circuit->ipv6_link && listcount(circuit->ipv6_link) > 0)
         {
-          vty_out(vty, "    IPv6 Link-Locals:%s", VTY_NEWLINE);
+          vty_outln (vty, "    IPv6 Link-Locals:");
           for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_link, node, ip_addr))
             {
               prefix2str(ip_addr, (char*)buf, BUFSIZ),
-              vty_out(vty, "      %s%s", buf, VTY_NEWLINE);
+              vty_outln (vty, "      %s", buf);
             }
         }
       if (circuit->ipv6_non_link && listcount(circuit->ipv6_non_link) > 0)
         {
-          vty_out(vty, "    IPv6 Prefixes:%s", VTY_NEWLINE);
+          vty_outln (vty, "    IPv6 Prefixes:");
           for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_non_link, node, ip_addr))
             {
               prefix2str(ip_addr, (char*)buf, BUFSIZ),
-              vty_out(vty, "      %s%s", buf, VTY_NEWLINE);
+              vty_outln (vty, "      %s", buf);
             }
         }
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
   return;
 }
@@ -1015,12 +1011,12 @@ isis_interface_config_write (struct vty *vty)
         continue;
 
       /* IF name */
-      vty_out (vty, "interface %s%s", ifp->name, VTY_NEWLINE);
+      vty_outln (vty, "interface %s", ifp->name);
       write++;
       /* IF desc */
       if (ifp->desc)
         {
-          vty_out (vty, " description %s%s", ifp->desc, VTY_NEWLINE);
+          vty_outln (vty, " description %s", ifp->desc);
           write++;
         }
       /* ISIS Circuit */
@@ -1031,39 +1027,36 @@ isis_interface_config_write (struct vty *vty)
             continue;
           if (circuit->ip_router)
             {
-              vty_out (vty, " ip router isis %s%s", area->area_tag,
-                       VTY_NEWLINE);
+              vty_outln (vty, " ip router isis %s",area->area_tag);
               write++;
             }
           if (circuit->is_passive)
             {
-              vty_out (vty, " isis passive%s", VTY_NEWLINE);
+              vty_outln (vty, " isis passive");
               write++;
             }
           if (circuit->circ_type_config == CIRCUIT_T_P2P)
             {
-              vty_out (vty, " isis network point-to-point%s", VTY_NEWLINE);
+              vty_outln (vty, " isis network point-to-point");
               write++;
             }
           if (circuit->ipv6_router)
             {
-              vty_out (vty, " ipv6 router isis %s%s", area->area_tag,
-                  VTY_NEWLINE);
+              vty_outln (vty, " ipv6 router isis %s",area->area_tag);
               write++;
             }
 
           /* ISIS - circuit type */
           if (circuit->is_type == IS_LEVEL_1)
             {
-              vty_out (vty, " isis circuit-type level-1%s", VTY_NEWLINE);
+              vty_outln (vty, " isis circuit-type level-1");
               write++;
             }
           else
             {
               if (circuit->is_type == IS_LEVEL_2)
                 {
-                  vty_out (vty, " isis circuit-type level-2-only%s",
-                           VTY_NEWLINE);
+                  vty_outln (vty," isis circuit-type level-2-only");
                   write++;
                 }
             }
@@ -1073,8 +1066,8 @@ isis_interface_config_write (struct vty *vty)
             {
               if (circuit->csnp_interval[0] != DEFAULT_CSNP_INTERVAL)
                 {
-                  vty_out (vty, " isis csnp-interval %d%s",
-                           circuit->csnp_interval[0], VTY_NEWLINE);
+                  vty_outln (vty, " isis csnp-interval %d",
+                           circuit->csnp_interval[0]);
                   write++;
                 }
             }
@@ -1084,8 +1077,8 @@ isis_interface_config_write (struct vty *vty)
               {
                 if (circuit->csnp_interval[i] != DEFAULT_CSNP_INTERVAL)
                   {
-                    vty_out (vty, " isis csnp-interval %d level-%d%s",
-                             circuit->csnp_interval[i], i + 1, VTY_NEWLINE);
+                    vty_outln (vty, " isis csnp-interval %d level-%d",
+                             circuit->csnp_interval[i], i + 1);
                     write++;
                   }
               }
@@ -1096,8 +1089,8 @@ isis_interface_config_write (struct vty *vty)
             {
               if (circuit->psnp_interval[0] != DEFAULT_PSNP_INTERVAL)
                 {
-                  vty_out (vty, " isis psnp-interval %d%s",
-                           circuit->psnp_interval[0], VTY_NEWLINE);
+                  vty_outln (vty, " isis psnp-interval %d",
+                           circuit->psnp_interval[0]);
                   write++;
                 }
             }
@@ -1107,8 +1100,8 @@ isis_interface_config_write (struct vty *vty)
                 {
                   if (circuit->psnp_interval[i] != DEFAULT_PSNP_INTERVAL)
                   {
-                    vty_out (vty, " isis psnp-interval %d level-%d%s",
-                             circuit->psnp_interval[i], i + 1, VTY_NEWLINE);
+                    vty_outln (vty, " isis psnp-interval %d level-%d",
+                             circuit->psnp_interval[i], i + 1);
                     write++;
                   }
                 }
@@ -1117,7 +1110,7 @@ isis_interface_config_write (struct vty *vty)
           /* ISIS - Hello padding - Defaults to true so only display if false */
           if (circuit->pad_hellos == 0)
             {
-              vty_out (vty, " no isis hello padding%s", VTY_NEWLINE);
+              vty_outln (vty, " no isis hello padding");
               write++;
             }
 
@@ -1126,8 +1119,8 @@ isis_interface_config_write (struct vty *vty)
             {
               if (circuit->hello_interval[0] != DEFAULT_HELLO_INTERVAL)
                 {
-                  vty_out (vty, " isis hello-interval %d%s",
-                           circuit->hello_interval[0], VTY_NEWLINE);
+                  vty_outln (vty, " isis hello-interval %d",
+                           circuit->hello_interval[0]);
                   write++;
                 }
             }
@@ -1137,8 +1130,8 @@ isis_interface_config_write (struct vty *vty)
                 {
                   if (circuit->hello_interval[i] != DEFAULT_HELLO_INTERVAL)
                     {
-                      vty_out (vty, " isis hello-interval %d level-%d%s",
-                               circuit->hello_interval[i], i + 1, VTY_NEWLINE);
+                      vty_outln (vty, " isis hello-interval %d level-%d",
+                               circuit->hello_interval[i], i + 1);
                       write++;
                     }
                 }
@@ -1149,8 +1142,8 @@ isis_interface_config_write (struct vty *vty)
             {
               if (circuit->hello_multiplier[0] != DEFAULT_HELLO_MULTIPLIER)
                 {
-                  vty_out (vty, " isis hello-multiplier %d%s",
-                           circuit->hello_multiplier[0], VTY_NEWLINE);
+                  vty_outln (vty, " isis hello-multiplier %d",
+                           circuit->hello_multiplier[0]);
                   write++;
                 }
             }
@@ -1160,9 +1153,8 @@ isis_interface_config_write (struct vty *vty)
                 {
                   if (circuit->hello_multiplier[i] != DEFAULT_HELLO_MULTIPLIER)
                     {
-                      vty_out (vty, " isis hello-multiplier %d level-%d%s",
-                               circuit->hello_multiplier[i], i + 1,
-                               VTY_NEWLINE);
+                      vty_outln (vty, " isis hello-multiplier %d level-%d",
+                               circuit->hello_multiplier[i],i + 1);
                       write++;
                     }
                 }
@@ -1173,8 +1165,8 @@ isis_interface_config_write (struct vty *vty)
             {
               if (circuit->priority[0] != DEFAULT_PRIORITY)
                 {
-                  vty_out (vty, " isis priority %d%s",
-                           circuit->priority[0], VTY_NEWLINE);
+                  vty_outln (vty, " isis priority %d",
+                           circuit->priority[0]);
                   write++;
                 }
             }
@@ -1184,8 +1176,8 @@ isis_interface_config_write (struct vty *vty)
                 {
                   if (circuit->priority[i] != DEFAULT_PRIORITY)
                     {
-                      vty_out (vty, " isis priority %d level-%d%s",
-                               circuit->priority[i], i + 1, VTY_NEWLINE);
+                      vty_outln (vty, " isis priority %d level-%d",
+                               circuit->priority[i], i + 1);
                       write++;
                     }
                 }
@@ -1196,8 +1188,7 @@ isis_interface_config_write (struct vty *vty)
             {
               if (circuit->te_metric[0] != DEFAULT_CIRCUIT_METRIC)
                 {
-                  vty_out (vty, " isis metric %d%s", circuit->te_metric[0],
-                           VTY_NEWLINE);
+                  vty_outln (vty, " isis metric %d",circuit->te_metric[0]);
                   write++;
                 }
             }
@@ -1207,27 +1198,27 @@ isis_interface_config_write (struct vty *vty)
                 {
                   if (circuit->te_metric[i] != DEFAULT_CIRCUIT_METRIC)
                     {
-                      vty_out (vty, " isis metric %d level-%d%s",
-                               circuit->te_metric[i], i + 1, VTY_NEWLINE);
+                      vty_outln (vty, " isis metric %d level-%d",
+                               circuit->te_metric[i], i + 1);
                       write++;
                     }
                 }
             }
           if (circuit->passwd.type == ISIS_PASSWD_TYPE_HMAC_MD5)
             {
-              vty_out (vty, " isis password md5 %s%s", circuit->passwd.passwd,
-                       VTY_NEWLINE);
+              vty_outln (vty, " isis password md5 %s",
+                         circuit->passwd.passwd);
               write++;
             }
           else if (circuit->passwd.type == ISIS_PASSWD_TYPE_CLEARTXT)
             {
-              vty_out (vty, " isis password clear %s%s", circuit->passwd.passwd,
-                       VTY_NEWLINE);
+              vty_outln (vty, " isis password clear %s",
+                         circuit->passwd.passwd);
               write++;
             }
           write += circuit_write_mt_settings(circuit, vty);
         }
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_outln (vty, "!");
     }
 
   return write;

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -878,7 +878,7 @@ isis_circuit_print_vty (struct isis_circuit *circuit, struct vty *vty,
       vty_out (vty, "%-9s", circuit_state2string (circuit->state));
       vty_out (vty, "%-9s", circuit_type2string (circuit->circ_type));
       vty_out (vty, "%-9s", circuit_t2string (circuit->is_type));
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   if (detail == ISIS_UI_LEVEL_DETAIL)
@@ -894,12 +894,12 @@ isis_circuit_print_vty (struct isis_circuit *circuit, struct vty *vty,
       else
         vty_out (vty, ", Active");
       vty_out (vty, ", Circuit Id: 0x%x", circuit->circuit_id);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       vty_out (vty, "    Type: %s", circuit_type2string (circuit->circ_type));
       vty_out (vty, ", Level: %s", circuit_t2string (circuit->is_type));
       if (circuit->circ_type == CIRCUIT_T_BROADCAST)
         vty_out (vty, ", SNPA: %-10s", snpa_print (circuit->u.bc.snpa));
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       if (circuit->is_type & IS_LEVEL_1)
         {
           vty_outln (vty, "    Level-1 Information:");
@@ -928,7 +928,7 @@ isis_circuit_print_vty (struct isis_circuit *circuit, struct vty *vty,
             }
           else
             {
-              vty_outln (vty, "");
+              vty_out (vty, VTYNL);
             }
         }
       if (circuit->is_type & IS_LEVEL_2)
@@ -959,7 +959,7 @@ isis_circuit_print_vty (struct isis_circuit *circuit, struct vty *vty,
             }
           else
             {
-              vty_outln (vty, "");
+              vty_out (vty, VTYNL);
             }
         }
       if (circuit->ip_addrs && listcount (circuit->ip_addrs) > 0)
@@ -990,7 +990,7 @@ isis_circuit_print_vty (struct isis_circuit *circuit, struct vty *vty,
             }
         }
 
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   return;
 }

--- a/isisd/isis_dynhn.c
+++ b/isisd/isis_dynhn.c
@@ -159,15 +159,13 @@ dynhn_print_all (struct vty *vty)
   struct listnode *node;
   struct isis_dynhn *dyn;
 
-  vty_out (vty, "Level  System ID      Dynamic Hostname%s", VTY_NEWLINE);
+  vty_outln (vty, "Level  System ID      Dynamic Hostname");
   for (ALL_LIST_ELEMENTS_RO (dyn_cache, node, dyn))
     {
       vty_out (vty, "%-7d", dyn->level);
-      vty_out (vty, "%-15s%-15s%s", sysid_print (dyn->id), dyn->name.name,
-	       VTY_NEWLINE);
+      vty_outln (vty, "%-15s%-15s", sysid_print (dyn->id),dyn->name.name);
     }
 
-  vty_out (vty, "     * %s %s%s", sysid_print (isis->sysid), unix_hostname (),
-	   VTY_NEWLINE);
+  vty_outln (vty, "     * %s %s", sysid_print (isis->sysid),unix_hostname());
   return;
 }

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1079,7 +1079,7 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
   for (ALL_LIST_ELEMENTS_RO (lsp->tlv_data.mt_ipv4_reachs, lnode, mt_ipv4_reachs))
     lsp_print_mt_ipv4_reach(mt_ipv4_reachs->list, vty, mt_ipv4_reachs->mtid);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   return;
 }

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -824,8 +824,8 @@ lsp_print (struct isis_lsp *lsp, struct vty *vty, char dynhost)
     }
   else
     vty_out (vty, " %5u    ", ntohs (lsp->lsp_header->rem_lifetime));
-  vty_out (vty, "%s%s",
-           lsp_bits2string (&lsp->lsp_header->lsp_bits), VTY_NEWLINE);
+  vty_outln (vty, "%s",
+           lsp_bits2string(&lsp->lsp_header->lsp_bits));
 }
 
 static void
@@ -842,14 +842,14 @@ lsp_print_mt_reach(struct list *list, struct vty *vty,
       lspid_print(neigh->neigh_id, lspid, dynhost, 0);
       if (mtid == ISIS_MT_IPV4_UNICAST)
         {
-          vty_out(vty, "  Metric      : %-8u IS-Extended   : %s%s",
-                  GET_TE_METRIC(neigh), lspid, VTY_NEWLINE);
+          vty_outln(vty, "  Metric      : %-8u IS-Extended   : %s",
+                    GET_TE_METRIC(neigh), lspid);
         }
       else
         {
-          vty_out(vty, "  Metric      : %-8u MT-Reach      : %s %s%s",
-                  GET_TE_METRIC(neigh), lspid,
-                  isis_mtid2str(mtid), VTY_NEWLINE);
+          vty_outln(vty, "  Metric      : %-8u MT-Reach      : %s %s",
+                    GET_TE_METRIC(neigh), lspid,
+                    isis_mtid2str(mtid));
         }
       if (IS_MPLS_TE(isisMplsTE))
         mpls_te_print_detail(vty, neigh);
@@ -874,27 +874,27 @@ lsp_print_mt_ipv6_reach(struct list *list, struct vty *vty, uint16_t mtid)
         {
           if ((ipv6_reach->control_info &
                CTRL_INFO_DISTRIBUTION) == DISTRIBUTION_INTERNAL)
-            vty_out (vty, "  Metric      : %-8" PRIu32 " IPv6-Internal : %s/%d%s",
-                     ntohl (ipv6_reach->metric),
-                     buff, ipv6_reach->prefix_len, VTY_NEWLINE);
+            vty_outln (vty, "  Metric      : %-8" PRIu32 " IPv6-Internal : %s/%d",
+                       ntohl (ipv6_reach->metric),
+                       buff, ipv6_reach->prefix_len);
           else
-            vty_out (vty, "  Metric      : %-8" PRIu32 " IPv6-External : %s/%d%s",
-                     ntohl (ipv6_reach->metric),
-                     buff, ipv6_reach->prefix_len, VTY_NEWLINE);
+            vty_outln (vty, "  Metric      : %-8" PRIu32 " IPv6-External : %s/%d",
+                       ntohl (ipv6_reach->metric),
+                       buff, ipv6_reach->prefix_len);
         }
       else
         {
           if ((ipv6_reach->control_info &
                CTRL_INFO_DISTRIBUTION) == DISTRIBUTION_INTERNAL)
-            vty_out (vty, "  Metric      : %-8" PRIu32 " IPv6-MT-Int   : %s/%d %s%s",
-                     ntohl (ipv6_reach->metric),
-                     buff, ipv6_reach->prefix_len,
-                     isis_mtid2str(mtid), VTY_NEWLINE);
+            vty_outln (vty, "  Metric      : %-8" PRIu32 " IPv6-MT-Int   : %s/%d %s",
+                       ntohl (ipv6_reach->metric),
+                       buff, ipv6_reach->prefix_len,
+                       isis_mtid2str(mtid));
           else
-            vty_out (vty, "  Metric      : %-8" PRIu32 " IPv6-MT-Ext   : %s/%d %s%s",
-                     ntohl (ipv6_reach->metric),
-                     buff, ipv6_reach->prefix_len,
-                     isis_mtid2str(mtid), VTY_NEWLINE);
+            vty_outln (vty, "  Metric      : %-8" PRIu32 " IPv6-MT-Ext   : %s/%d %s",
+                       ntohl (ipv6_reach->metric),
+                       buff, ipv6_reach->prefix_len,
+                       isis_mtid2str(mtid));
         }
     }
 }
@@ -910,21 +910,21 @@ lsp_print_mt_ipv4_reach(struct list *list, struct vty *vty, uint16_t mtid)
       if (mtid == ISIS_MT_IPV4_UNICAST)
         {
           /* FIXME: There should be better way to output this stuff. */
-          vty_out (vty, "  Metric      : %-8" PRIu32 " IPv4-Extended : %s/%d%s",
-                   ntohl (te_ipv4_reach->te_metric),
-                   inet_ntoa (newprefix2inaddr (&te_ipv4_reach->prefix_start,
-                                                te_ipv4_reach->control)),
-                   te_ipv4_reach->control & 0x3F, VTY_NEWLINE);
+          vty_outln (vty, "  Metric      : %-8" PRIu32 " IPv4-Extended : %s/%d",
+                     ntohl (te_ipv4_reach->te_metric),
+                     inet_ntoa (newprefix2inaddr (&te_ipv4_reach->prefix_start,
+                                                  te_ipv4_reach->control)),
+                     te_ipv4_reach->control & 0x3F);
         }
       else
         {
           /* FIXME: There should be better way to output this stuff. */
-          vty_out (vty, "  Metric      : %-8" PRIu32 " IPv4-MT       : %s/%d %s%s",
-                   ntohl (te_ipv4_reach->te_metric),
-                   inet_ntoa (newprefix2inaddr (&te_ipv4_reach->prefix_start,
-                                                te_ipv4_reach->control)),
-                   te_ipv4_reach->control & 0x3F,
-                   isis_mtid2str(mtid), VTY_NEWLINE);
+          vty_outln (vty, "  Metric      : %-8" PRIu32 " IPv4-MT       : %s/%d %s",
+                     ntohl (te_ipv4_reach->te_metric),
+                     inet_ntoa (newprefix2inaddr (&te_ipv4_reach->prefix_start,
+                                                  te_ipv4_reach->control)),
+                     te_ipv4_reach->control & 0x3F,
+                     isis_mtid2str(mtid));
         }
     }
 }
@@ -955,9 +955,8 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
   if (lsp->tlv_data.area_addrs)
     for (ALL_LIST_ELEMENTS_RO (lsp->tlv_data.area_addrs, lnode, area_addr))
       {
-	vty_out (vty, "  Area Address: %s%s",
-		 isonet_print (area_addr->area_addr, area_addr->addr_len),
-		 VTY_NEWLINE);
+	vty_outln (vty, "  Area Address: %s",
+		 isonet_print(area_addr->area_addr, area_addr->addr_len));
       }
   
   /* for the nlpid tlv */
@@ -969,11 +968,11 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
 	    {
 	    case NLPID_IP:
 	    case NLPID_IPV6:
-	      vty_out (vty, "  NLPID       : 0x%X%s",
-		       lsp->tlv_data.nlpids->nlpids[i], VTY_NEWLINE);
+	      vty_outln (vty, "  NLPID       : 0x%X",
+		       lsp->tlv_data.nlpids->nlpids[i]);
 	      break;
 	    default:
-	      vty_out (vty, "  NLPID       : %s%s", "unknown", VTY_NEWLINE);
+	      vty_outln (vty, "  NLPID       : %s", "unknown");
 	      break;
 	    }
 	}
@@ -981,10 +980,9 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
 
   for (ALL_LIST_ELEMENTS_RO(lsp->tlv_data.mt_router_info, lnode, mt_router_info))
     {
-      vty_out (vty, "  MT          : %s%s%s",
+      vty_outln (vty, "  MT          : %s%s",
                isis_mtid2str(mt_router_info->mtid),
-               mt_router_info->overload ? " (overload)" : "",
-               VTY_NEWLINE);
+               mt_router_info->overload ? " (overload)" : "");
     }
 
   /* for the hostname tlv */
@@ -993,16 +991,16 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
       bzero (hostname, sizeof (hostname));
       memcpy (hostname, lsp->tlv_data.hostname->name,
 	      lsp->tlv_data.hostname->namelen);
-      vty_out (vty, "  Hostname    : %s%s", hostname, VTY_NEWLINE);
+      vty_outln (vty, "  Hostname    : %s", hostname);
     }
 
   /* authentication tlv */
   if (lsp->tlv_data.auth_info.type != ISIS_PASSWD_TYPE_UNUSED)
     {
       if (lsp->tlv_data.auth_info.type == ISIS_PASSWD_TYPE_HMAC_MD5)
-        vty_out (vty, "  Auth type   : md5%s", VTY_NEWLINE);
+        vty_outln (vty, "  Auth type   : md5");
       else if (lsp->tlv_data.auth_info.type == ISIS_PASSWD_TYPE_CLEARTXT)
-        vty_out (vty, "  Auth type   : clear text%s", VTY_NEWLINE);
+        vty_outln (vty, "  Auth type   : clear text");
     }
 
   /* TE router id */
@@ -1010,14 +1008,14 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
     {
       memcpy (ipv4_address, inet_ntoa (lsp->tlv_data.router_id->id),
 	      sizeof (ipv4_address));
-      vty_out (vty, "  Router ID   : %s%s", ipv4_address, VTY_NEWLINE);
+      vty_outln (vty, "  Router ID   : %s", ipv4_address);
     }
 
   if (lsp->tlv_data.ipv4_addrs)
     for (ALL_LIST_ELEMENTS_RO (lsp->tlv_data.ipv4_addrs, lnode, ipv4_addr))
       {
         memcpy (ipv4_address, inet_ntoa (*ipv4_addr), sizeof (ipv4_address));
-        vty_out (vty, "  IPv4 Address: %s%s", ipv4_address, VTY_NEWLINE);
+        vty_outln (vty, "  IPv4 Address: %s", ipv4_address);
       }
 
   /* for the IS neighbor tlv */
@@ -1025,8 +1023,8 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
     for (ALL_LIST_ELEMENTS_RO (lsp->tlv_data.is_neighs, lnode, is_neigh))
       {
 	lspid_print (is_neigh->neigh_id, LSPid, dynhost, 0);
-	vty_out (vty, "  Metric      : %-8" PRIu8 " IS            : %s%s",
-		 is_neigh->metrics.metric_default, LSPid, VTY_NEWLINE);
+	vty_outln (vty, "  Metric      : %-8" PRIu8 " IS            : %s",
+		   is_neigh->metrics.metric_default, LSPid);
       }
   
   /* for the internal reachable tlv */
@@ -1038,9 +1036,9 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
 	      sizeof (ipv4_reach_prefix));
       memcpy (ipv4_reach_mask, inet_ntoa (ipv4_reach->mask),
 	      sizeof (ipv4_reach_mask));
-      vty_out (vty, "  Metric      : %-8" PRIu8 " IPv4-Internal : %s %s%s",
-	       ipv4_reach->metrics.metric_default, ipv4_reach_prefix,
-	       ipv4_reach_mask, VTY_NEWLINE);
+      vty_outln (vty, "  Metric      : %-8" PRIu8 " IPv4-Internal : %s %s",
+	         ipv4_reach->metrics.metric_default, ipv4_reach_prefix,
+	         ipv4_reach_mask);
     }
 
   /* for the external reachable tlv */
@@ -1052,9 +1050,9 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
 	      sizeof (ipv4_reach_prefix));
       memcpy (ipv4_reach_mask, inet_ntoa (ipv4_reach->mask),
 	      sizeof (ipv4_reach_mask));
-      vty_out (vty, "  Metric      : %-8" PRIu8 " IPv4-External : %s %s%s",
-	       ipv4_reach->metrics.metric_default, ipv4_reach_prefix,
-	       ipv4_reach_mask, VTY_NEWLINE);
+      vty_outln (vty, "  Metric      : %-8" PRIu8 " IPv4-External : %s %s",
+	         ipv4_reach->metrics.metric_default, ipv4_reach_prefix,
+	         ipv4_reach_mask);
     }
 
   /* IPv6 tlv */
@@ -1081,7 +1079,7 @@ lsp_print_detail (struct isis_lsp *lsp, struct vty *vty, char dynhost)
   for (ALL_LIST_ELEMENTS_RO (lsp->tlv_data.mt_ipv4_reachs, lnode, mt_ipv4_reachs))
     lsp_print_mt_ipv4_reach(mt_ipv4_reachs->list, vty, mt_ipv4_reachs->mtid);
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   return;
 }

--- a/isisd/isis_mt.c
+++ b/isisd/isis_mt.c
@@ -193,9 +193,8 @@ area_write_mt_settings(struct isis_area *area, struct vty *vty)
         {
           if (setting->mtid == ISIS_MT_IPV4_UNICAST)
             continue; /* always enabled, no need to write out config */
-          vty_out (vty, " topology %s%s%s", name,
-                   setting->overload ? " overload" : "",
-                   VTY_NEWLINE);
+          vty_outln (vty, " topology %s%s", name,
+                   setting->overload ? " overload" : "");
           written++;
         }
     }
@@ -326,7 +325,7 @@ circuit_write_mt_settings(struct isis_circuit *circuit, struct vty *vty)
       const char *name = isis_mtid2str(setting->mtid);
       if (name && !setting->enabled)
         {
-          vty_out (vty, " no isis topology %s%s", name, VTY_NEWLINE);
+          vty_outln (vty, " no isis topology %s", name);
           written++;
         }
     }

--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -796,7 +796,7 @@ isis_redist_config_write(struct vty *vty, struct isis_area *area,
             vty_out(vty, " metric %u", redist->metric);
           if (redist->map_name)
             vty_out(vty, " route-map %s", redist->map_name);
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
           write++;
         }
     }
@@ -814,7 +814,7 @@ isis_redist_config_write(struct vty *vty, struct isis_area *area,
         vty_out(vty, " metric %u", redist->metric);
       if (redist->map_name)
         vty_out(vty, " route-map %s", redist->map_name);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       write++;
     }
 

--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -600,7 +600,7 @@ DEFUN (isis_redistribute,
 
   if ((area->is_type & level) != level)
     {
-      vty_out(vty, "Node is not a level-%d IS%s", level, VTY_NEWLINE);
+      vty_outln (vty, "Node is not a level-%d IS", level);
       return CMD_WARNING;
     }
 
@@ -702,7 +702,7 @@ DEFUN (isis_default_originate,
 
   if ((area->is_type & level) != level)
     {
-      vty_out(vty, "Node is not a level-%d IS%s", level, VTY_NEWLINE);
+      vty_outln (vty, "Node is not a level-%d IS", level);
       return CMD_WARNING;
     }
 
@@ -722,8 +722,9 @@ DEFUN (isis_default_originate,
 
   if (family == AF_INET6 && originate_type != DEFAULT_ORIGINATE_ALWAYS)
     {
-      vty_out(vty, "Zebra doesn't implement default-originate for IPv6 yet%s", VTY_NEWLINE);
-      vty_out(vty, "so use with care or use default-originate always.%s", VTY_NEWLINE);
+      vty_outln (vty,
+                "Zebra doesn't implement default-originate for IPv6 yet");
+      vty_outln (vty, "so use with care or use default-originate always.");
     }
 
   isis_redist_set(area, level, family, DEFAULT_ROUTE, metric, routemap, originate_type);
@@ -795,7 +796,7 @@ isis_redist_config_write(struct vty *vty, struct isis_area *area,
             vty_out(vty, " metric %u", redist->metric);
           if (redist->map_name)
             vty_out(vty, " route-map %s", redist->map_name);
-          vty_out(vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
           write++;
         }
     }
@@ -813,7 +814,7 @@ isis_redist_config_write(struct vty *vty, struct isis_area *area,
         vty_out(vty, " metric %u", redist->metric);
       if (redist->map_name)
         vty_out(vty, " route-map %s", redist->map_name);
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
       write++;
     }
 

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1321,8 +1321,8 @@ isis_print_paths (struct vty *vty, struct list *paths, u_char *root_sysid)
   struct isis_adjacency *adj;
   char buff[PREFIX2STR_BUFFER];
 
-  vty_out (vty, "Vertex               Type         Metric "
-                "Next-Hop             Interface Parent%s", VTY_NEWLINE);
+  vty_outln (vty,
+             "Vertex               Type         Metric " "Next-Hop             Interface Parent");
 
   for (ALL_LIST_ELEMENTS_RO (paths, node, vertex)) {
       if (memcmp (vertex->N.id, root_sysid, ISIS_SYS_ID_LEN) == 0) {
@@ -1336,7 +1336,7 @@ isis_print_paths (struct vty *vty, struct list *paths, u_char *root_sysid)
 	for (ALL_LIST_ELEMENTS_RO (vertex->Adj_N, anode, adj)) {
 	  if (adj) {
 	    if (rows) {
-		vty_out (vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		vty_out (vty, "%-20s %-12s %-6s ", "", "", "");
 	    }
 	    vty_out (vty, "%-20s %-9s ",
@@ -1356,7 +1356,7 @@ isis_print_paths (struct vty *vty, struct list *paths, u_char *root_sysid)
 	int rows = 0;
 	for (ALL_LIST_ELEMENTS_RO (vertex->parents, pnode, pvertex)) {
 	  if (rows) {
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_outln (vty, "");
 	    vty_out (vty, "%-72s", "");
 	  }
 	  vty_out (vty, "%s(%d)",
@@ -1367,7 +1367,7 @@ isis_print_paths (struct vty *vty, struct list *paths, u_char *root_sysid)
 	vty_out (vty, "  NULL ");
       }
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 }
 
@@ -1396,8 +1396,7 @@ DEFUN (show_isis_topology,
 
   for (ALL_LIST_ELEMENTS_RO (isis->area_list, node, area))
     {
-      vty_out (vty, "Area %s:%s", area->area_tag ? area->area_tag : "null",
-	       VTY_NEWLINE);
+      vty_outln (vty, "Area %s:",area->area_tag ? area->area_tag : "null");
 
       for (int level = ISIS_LEVEL1; level <= ISIS_LEVELS; level++)
 	{
@@ -1407,23 +1406,23 @@ DEFUN (show_isis_topology,
 	  if (area->ip_circuits > 0 && area->spftree[level-1]
 	      && area->spftree[level-1]->paths->count > 0)
 	    {
-	      vty_out (vty, "IS-IS paths to level-%d routers that speak IP%s",
-		       level, VTY_NEWLINE);
+	      vty_outln (vty, "IS-IS paths to level-%d routers that speak IP",
+		       level);
 	      isis_print_paths (vty, area->spftree[level-1]->paths, isis->sysid);
-	      vty_out (vty, "%s", VTY_NEWLINE);
+	      vty_outln (vty, "");
 	    }
 	  if (area->ipv6_circuits > 0 && area->spftree6[level-1]
 	      && area->spftree6[level-1]->paths->count > 0)
 	    {
-	      vty_out (vty,
-		       "IS-IS paths to level-%d routers that speak IPv6%s",
-		       level, VTY_NEWLINE);
+	      vty_outln (vty,
+		       "IS-IS paths to level-%d routers that speak IPv6",
+		       level);
 	      isis_print_paths (vty, area->spftree6[level-1]->paths, isis->sysid);
-	      vty_out (vty, "%s", VTY_NEWLINE);
+	      vty_outln (vty, "");
 	    }
 	}
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   return CMD_SUCCESS;

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1336,7 +1336,7 @@ isis_print_paths (struct vty *vty, struct list *paths, u_char *root_sysid)
 	for (ALL_LIST_ELEMENTS_RO (vertex->Adj_N, anode, adj)) {
 	  if (adj) {
 	    if (rows) {
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		vty_out (vty, "%-20s %-12s %-6s ", "", "", "");
 	    }
 	    vty_out (vty, "%-20s %-9s ",
@@ -1356,7 +1356,7 @@ isis_print_paths (struct vty *vty, struct list *paths, u_char *root_sysid)
 	int rows = 0;
 	for (ALL_LIST_ELEMENTS_RO (vertex->parents, pnode, pvertex)) {
 	  if (rows) {
-	    vty_outln (vty, "");
+	    vty_out (vty, VTYNL);
 	    vty_out (vty, "%-72s", "");
 	  }
 	  vty_out (vty, "%s(%d)",
@@ -1367,7 +1367,7 @@ isis_print_paths (struct vty *vty, struct list *paths, u_char *root_sysid)
 	vty_out (vty, "  NULL ");
       }
 
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 }
 
@@ -1409,7 +1409,7 @@ DEFUN (show_isis_topology,
 	      vty_outln (vty, "IS-IS paths to level-%d routers that speak IP",
 		       level);
 	      isis_print_paths (vty, area->spftree[level-1]->paths, isis->sysid);
-	      vty_outln (vty, "");
+	      vty_out (vty, VTYNL);
 	    }
 	  if (area->ipv6_circuits > 0 && area->spftree6[level-1]
 	      && area->spftree6[level-1]->paths->count > 0)
@@ -1418,11 +1418,11 @@ DEFUN (show_isis_topology,
 		       "IS-IS paths to level-%d routers that speak IPv6",
 		       level);
 	      isis_print_paths (vty, area->spftree6[level-1]->paths, isis->sysid);
-	      vty_outln (vty, "");
+	      vty_out (vty, VTYNL);
 	    }
 	}
 
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   return CMD_SUCCESS;

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -685,11 +685,11 @@ show_vty_subtlv_admin_grp (struct vty *vty, struct te_subtlv_admin_grp *tlv)
 {
 
   if (vty != NULL)
-    vty_out (vty, "    Administrative Group: 0x%x%s",
-             (u_int32_t) ntohl (tlv->value), VTY_NEWLINE);
-  else
-    zlog_debug ("      Administrative Group: 0x%x",
-                (u_int32_t) ntohl (tlv->value));
+    vty_outln (vty, "    Administrative Group: 0x%x",
+             (u_int32_t)ntohl(tlv->value));
+      else
+        zlog_debug ("      Administrative Group: 0x%x",
+		                (u_int32_t) ntohl (tlv->value));
 
   return (SUBTLV_HDR_SIZE + SUBTLV_DEF_SIZE);
 }
@@ -699,10 +699,9 @@ show_vty_subtlv_llri (struct vty *vty, struct te_subtlv_llri *tlv)
 {
   if (vty != NULL)
     {
-      vty_out (vty, "    Link Local  ID: %d%s", (u_int32_t) ntohl (tlv->local),
-               VTY_NEWLINE);
-      vty_out (vty, "    Link Remote ID: %d%s", (u_int32_t) ntohl (tlv->remote),
-               VTY_NEWLINE);
+      vty_outln (vty, "    Link Local  ID: %d",(u_int32_t)ntohl(tlv->local));
+      vty_outln (vty, "    Link Remote ID: %d",
+                 (u_int32_t)ntohl(tlv->remote));
     }
   else
     {
@@ -717,9 +716,10 @@ static u_char
 show_vty_subtlv_local_ipaddr (struct vty *vty, struct te_subtlv_local_ipaddr *tlv)
 {
   if (vty != NULL)
-    vty_out (vty, "    Local Interface IP Address(es): %s%s", inet_ntoa (tlv->value), VTY_NEWLINE);
-  else
-    zlog_debug ("      Local Interface IP Address(es): %s", inet_ntoa (tlv->value));
+    vty_outln (vty, "    Local Interface IP Address(es): %s",
+               inet_ntoa(tlv->value));
+    else
+      zlog_debug ("      Local Interface IP Address(es): %s", inet_ntoa (tlv->value));
 
   return (SUBTLV_HDR_SIZE + SUBTLV_DEF_SIZE);
 }
@@ -728,9 +728,10 @@ static u_char
 show_vty_subtlv_rmt_ipaddr (struct vty *vty, struct te_subtlv_rmt_ipaddr *tlv)
 {
   if (vty != NULL)
-    vty_out (vty, "    Remote Interface IP Address(es): %s%s", inet_ntoa (tlv->value), VTY_NEWLINE);
-  else
-    zlog_debug ("      Remote Interface IP Address(es): %s", inet_ntoa (tlv->value));
+    vty_outln (vty, "    Remote Interface IP Address(es): %s",
+               inet_ntoa(tlv->value));
+    else
+      zlog_debug ("      Remote Interface IP Address(es): %s", inet_ntoa (tlv->value));
 
   return (SUBTLV_HDR_SIZE + SUBTLV_DEF_SIZE);
 }
@@ -743,7 +744,7 @@ show_vty_subtlv_max_bw (struct vty *vty, struct te_subtlv_max_bw *tlv)
   fval = ntohf (tlv->value);
 
   if (vty != NULL)
-    vty_out (vty, "    Maximum Bandwidth: %g (Bytes/sec)%s", fval, VTY_NEWLINE);
+    vty_outln (vty, "    Maximum Bandwidth: %g (Bytes/sec)", fval);
   else
     zlog_debug ("      Maximum Bandwidth: %g (Bytes/sec)", fval);
 
@@ -758,8 +759,7 @@ show_vty_subtlv_max_rsv_bw (struct vty *vty, struct te_subtlv_max_rsv_bw *tlv)
   fval = ntohf (tlv->value);
 
   if (vty != NULL)
-    vty_out (vty, "    Maximum Reservable Bandwidth: %g (Bytes/sec)%s", fval,
-             VTY_NEWLINE);
+    vty_outln (vty, "    Maximum Reservable Bandwidth: %g (Bytes/sec)",fval);
   else
     zlog_debug ("      Maximum Reservable Bandwidth: %g (Bytes/sec)", fval);
 
@@ -773,7 +773,7 @@ show_vty_subtlv_unrsv_bw (struct vty *vty, struct te_subtlv_unrsv_bw *tlv)
   int i;
 
   if (vty != NULL)
-    vty_out (vty, "    Unreserved Bandwidth:%s",VTY_NEWLINE);
+    vty_outln (vty, "    Unreserved Bandwidth:");
   else
     zlog_debug ("      Unreserved Bandwidth:");
 
@@ -782,7 +782,8 @@ show_vty_subtlv_unrsv_bw (struct vty *vty, struct te_subtlv_unrsv_bw *tlv)
       fval1 = ntohf (tlv->value[i]);
       fval2 = ntohf (tlv->value[i+1]);
       if (vty != NULL)
-        vty_out (vty, "      [%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)%s", i, fval1, i+1, fval2, VTY_NEWLINE);
+        vty_outln (vty, "      [%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)", i, fval1, i+1,
+                   fval2);
       else
         zlog_debug ("        [%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)", i, fval1, i+1, fval2);
     }
@@ -797,7 +798,7 @@ show_vty_subtlv_te_metric (struct vty *vty, struct te_subtlv_te_metric *tlv)
 
   te_metric = tlv->value[2] | tlv->value[1] << 8 | tlv->value[0] << 16;
   if (vty != NULL)
-    vty_out (vty, "    Traffic Engineering Metric: %u%s", te_metric, VTY_NEWLINE);
+    vty_outln (vty, "    Traffic Engineering Metric: %u", te_metric);
   else
     zlog_debug ("      Traffic Engineering Metric: %u", te_metric);
 
@@ -808,9 +809,10 @@ static u_char
 show_vty_subtlv_ras (struct vty *vty, struct te_subtlv_ras *tlv)
 {
   if (vty != NULL)
-    vty_out (vty, "    Inter-AS TE Remote AS number: %u%s", ntohl (tlv->value), VTY_NEWLINE);
-  else
-    zlog_debug ("      Inter-AS TE Remote AS number: %u", ntohl (tlv->value));
+    vty_outln (vty, "    Inter-AS TE Remote AS number: %u",
+               ntohl(tlv->value));
+    else
+      zlog_debug ("      Inter-AS TE Remote AS number: %u", ntohl (tlv->value));
 
   return (SUBTLV_HDR_SIZE + SUBTLV_DEF_SIZE);
 }
@@ -819,9 +821,10 @@ static u_char
 show_vty_subtlv_rip (struct vty *vty, struct te_subtlv_rip *tlv)
 {
   if (vty != NULL)
-    vty_out (vty, "    Inter-AS TE Remote ASBR IP address: %s%s", inet_ntoa (tlv->value), VTY_NEWLINE);
-  else
-    zlog_debug ("      Inter-AS TE Remote ASBR IP address: %s", inet_ntoa (tlv->value));
+    vty_outln (vty, "    Inter-AS TE Remote ASBR IP address: %s",
+               inet_ntoa(tlv->value));
+    else
+      zlog_debug ("      Inter-AS TE Remote ASBR IP address: %s", inet_ntoa (tlv->value));
 
   return (SUBTLV_HDR_SIZE + SUBTLV_DEF_SIZE);
 }
@@ -836,7 +839,8 @@ show_vty_subtlv_av_delay (struct vty *vty, struct te_subtlv_av_delay *tlv)
   A = (u_int32_t) ntohl (tlv->value) & TE_EXT_ANORMAL;
 
   if (vty != NULL)
-    vty_out (vty, "    %s Average Link Delay: %d (micro-sec)%s", A ? "Anomalous" : "Normal", delay, VTY_NEWLINE);
+    vty_outln (vty, "    %s Average Link Delay: %d (micro-sec)", A ? "Anomalous" : "Normal",
+               delay);
   else
     zlog_debug ("      %s Average Link Delay: %d (micro-sec)", A ? "Anomalous" : "Normal", delay);
 
@@ -854,7 +858,8 @@ show_vty_subtlv_mm_delay (struct vty *vty, struct te_subtlv_mm_delay *tlv)
   high = (u_int32_t) ntohl (tlv->high) & TE_EXT_MASK;
 
   if (vty != NULL)
-    vty_out (vty, "    %s Min/Max Link Delay: %d / %d (micro-sec)%s", A ? "Anomalous" : "Normal", low, high, VTY_NEWLINE);
+    vty_outln (vty, "    %s Min/Max Link Delay: %d / %d (micro-sec)", A ? "Anomalous" : "Normal", low,
+               high);
   else
     zlog_debug ("      %s Min/Max Link Delay: %d / %d (micro-sec)", A ? "Anomalous" : "Normal", low, high);
 
@@ -869,7 +874,7 @@ show_vty_subtlv_delay_var (struct vty *vty, struct te_subtlv_delay_var *tlv)
   jitter = (u_int32_t) ntohl (tlv->value) & TE_EXT_MASK;
 
   if (vty != NULL)
-    vty_out (vty, "    Delay Variation: %d (micro-sec)%s", jitter, VTY_NEWLINE);
+    vty_outln (vty, "    Delay Variation: %d (micro-sec)", jitter);
   else
     zlog_debug ("      Delay Variation: %d (micro-sec)", jitter);
 
@@ -888,7 +893,8 @@ show_vty_subtlv_pkt_loss (struct vty *vty, struct te_subtlv_pkt_loss *tlv)
   A = (u_int32_t) ntohl (tlv->value) & TE_EXT_ANORMAL;
 
   if (vty != NULL)
-    vty_out (vty, "    %s Link Packet Loss: %g (%%)%s", A ? "Anomalous" : "Normal", fval, VTY_NEWLINE);
+    vty_outln (vty, "    %s Link Packet Loss: %g (%%)", A ? "Anomalous" : "Normal",
+               fval);
   else
     zlog_debug ("      %s Link Packet Loss: %g (%%)", A ? "Anomalous" : "Normal", fval);
 
@@ -903,7 +909,8 @@ show_vty_subtlv_res_bw (struct vty *vty, struct te_subtlv_res_bw *tlv)
   fval = ntohf(tlv->value);
 
   if (vty != NULL)
-    vty_out (vty, "    Unidirectional Residual Bandwidth: %g (Bytes/sec)%s", fval, VTY_NEWLINE);
+    vty_outln (vty, "    Unidirectional Residual Bandwidth: %g (Bytes/sec)",
+               fval);
   else
     zlog_debug ("      Unidirectional Residual Bandwidth: %g (Bytes/sec)", fval);
 
@@ -918,7 +925,8 @@ show_vty_subtlv_ava_bw (struct vty *vty, struct te_subtlv_ava_bw *tlv)
   fval = ntohf (tlv->value);
 
   if (vty != NULL)
-    vty_out (vty, "    Unidirectional Available Bandwidth: %g (Bytes/sec)%s", fval, VTY_NEWLINE);
+    vty_outln (vty, "    Unidirectional Available Bandwidth: %g (Bytes/sec)",
+               fval);
   else
     zlog_debug ("      Unidirectional Available Bandwidth: %g (Bytes/sec)", fval);
 
@@ -933,7 +941,8 @@ show_vty_subtlv_use_bw (struct vty *vty, struct te_subtlv_use_bw *tlv)
   fval = ntohf (tlv->value);
 
   if (vty != NULL)
-    vty_out (vty, "    Unidirectional Utilized Bandwidth: %g (Bytes/sec)%s", fval, VTY_NEWLINE);
+    vty_outln (vty, "    Unidirectional Utilized Bandwidth: %g (Bytes/sec)",
+               fval);
   else
     zlog_debug ("      Unidirectional Utilized Bandwidth: %g (Bytes/sec)", fval);
 
@@ -950,8 +959,8 @@ show_vty_unknown_tlv (struct vty *vty, struct subtlv_header *tlvh)
     {
       if (tlvh->length != 0)
         {
-          vty_out (vty, "    Unknown TLV: [type(%#.2x), length(%#.2x)]%s",
-              tlvh->type, tlvh->length, VTY_NEWLINE);
+          vty_outln (vty, "    Unknown TLV: [type(%#.2x), length(%#.2x)]",
+              tlvh->type, tlvh->length);
           vty_out(vty, "       Dump: [00]");
           rtn = 1;          /* initialize end of line counter */
           for (i = 0; i < tlvh->length; i++)
@@ -965,11 +974,11 @@ show_vty_unknown_tlv (struct vty *vty, struct subtlv_header *tlvh)
               else
                 rtn++;
             }
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
         }
       else
-        vty_out (vty, "    Unknown TLV: [type(%#.2x), length(%#.2x)]%s",
-            tlvh->type, tlvh->length, VTY_NEWLINE);
+        vty_outln (vty, "    Unknown TLV: [type(%#.2x), length(%#.2x)]",
+            tlvh->type, tlvh->length);
     }
   else
     {
@@ -1060,9 +1069,9 @@ isis_mpls_te_config_write_router (struct vty *vty)
 {
   if (IS_MPLS_TE(isisMplsTE))
     {
-      vty_out (vty, "  mpls-te on%s", VTY_NEWLINE);
-      vty_out (vty, "  mpls-te router-address %s%s",
-               inet_ntoa (isisMplsTE.router_id), VTY_NEWLINE);
+      vty_outln (vty, "  mpls-te on");
+      vty_outln (vty, "  mpls-te router-address %s",
+               inet_ntoa(isisMplsTE.router_id));
     }
 
   return;
@@ -1164,7 +1173,7 @@ DEFUN (isis_mpls_te_router_addr,
 
   if (! inet_aton (argv[idx_ipv4]->arg, &value))
     {
-      vty_out (vty, "Please specify Router-Addr by A.B.C.D%s", VTY_NEWLINE);
+      vty_outln (vty, "Please specify Router-Addr by A.B.C.D");
       return CMD_WARNING;
     }
 
@@ -1192,7 +1201,7 @@ DEFUN (isis_mpls_te_inter_as,
        "AREA native mode self originate INTER-AS LSP with L1 and L2 flooding scope)\n"
        "AS native mode self originate INTER-AS LSP with L2 only flooding scope\n")
 {
-  vty_out (vty, "Not yet supported%s", VTY_NEWLINE);
+  vty_outln (vty, "Not yet supported");
   return CMD_SUCCESS;
 }
 
@@ -1204,7 +1213,7 @@ DEFUN (no_isis_mpls_te_inter_as,
        "Disable MPLS-TE Inter-AS support\n")
 {
 
-  vty_out (vty, "Not yet supported%s", VTY_NEWLINE);
+  vty_outln (vty, "Not yet supported");
   return CMD_SUCCESS;
 }
 
@@ -1218,15 +1227,16 @@ DEFUN (show_isis_mpls_te_router,
 {
   if (IS_MPLS_TE(isisMplsTE))
     {
-      vty_out (vty, "--- MPLS-TE router parameters ---%s", VTY_NEWLINE);
+      vty_outln (vty, "--- MPLS-TE router parameters ---");
 
       if (ntohs (isisMplsTE.router_id.s_addr) != 0)
-        vty_out (vty, "  Router-Address: %s%s", inet_ntoa (isisMplsTE.router_id), VTY_NEWLINE);
-      else
-        vty_out (vty, "  N/A%s", VTY_NEWLINE);
+        vty_outln (vty, "  Router-Address: %s",
+                   inet_ntoa(isisMplsTE.router_id));
+        else
+          vty_outln (vty, "  N/A");
     }
   else
-    vty_out (vty, "  MPLS-TE is disable on this router%s", VTY_NEWLINE);
+    vty_outln (vty, "  MPLS-TE is disable on this router");
 
   return CMD_SUCCESS;
 }
@@ -1244,22 +1254,22 @@ show_mpls_te_sub (struct vty *vty, struct interface *ifp)
         {
           if (IS_INTER_AS(mtc->type))
             {
-              vty_out (vty, "-- Inter-AS TEv2 link parameters for %s --%s",
-                       ifp->name, VTY_NEWLINE);
+              vty_outln (vty, "-- Inter-AS TEv2 link parameters for %s --",
+                       ifp->name);
             }
           else
             {
               /* MPLS-TE is not activate on this interface */
               /* or this interface is passive and Inter-AS TEv2 is not activate */
-              vty_out (vty, "  %s: MPLS-TE is disabled on this interface%s",
-                       ifp->name, VTY_NEWLINE);
+              vty_outln (vty, "  %s: MPLS-TE is disabled on this interface",
+                       ifp->name);
               return;
             }
         }
       else
         {
-          vty_out (vty, "-- MPLS-TE link parameters for %s --%s",
-                   ifp->name, VTY_NEWLINE);
+          vty_outln (vty, "-- MPLS-TE link parameters for %s --",
+                   ifp->name);
         }
 
       show_vty_subtlv_admin_grp (vty, &mtc->admin_grp);
@@ -1289,12 +1299,12 @@ show_mpls_te_sub (struct vty *vty, struct interface *ifp)
       show_vty_subtlv_res_bw (vty, &mtc->res_bw);
       show_vty_subtlv_ava_bw (vty, &mtc->ava_bw);
       show_vty_subtlv_use_bw (vty, &mtc->use_bw);
-      vty_out (vty, "---------------%s%s", VTY_NEWLINE, VTY_NEWLINE);
+      vty_outln (vty, "---------------%s", VTY_NEWLINE);
     }
   else
     {
-      vty_out (vty, "  %s: MPLS-TE is disabled on this interface%s",
-               ifp->name, VTY_NEWLINE);
+      vty_outln (vty, "  %s: MPLS-TE is disabled on this interface",
+               ifp->name);
     }
 
   return;
@@ -1323,7 +1333,7 @@ DEFUN (show_isis_mpls_te_interface,
   else
     {
       if ((ifp = if_lookup_by_name (argv[idx_interface]->arg, VRF_DEFAULT)) == NULL)
-        vty_out (vty, "No such interface name%s", VTY_NEWLINE);
+        vty_outln (vty, "No such interface name");
       else
         show_mpls_te_sub (vty, ifp);
     }

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -974,7 +974,7 @@ show_vty_unknown_tlv (struct vty *vty, struct subtlv_header *tlvh)
               else
                 rtn++;
             }
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
         }
       else
         vty_outln (vty, "    Unknown TLV: [type(%#.2x), length(%#.2x)]",

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -968,7 +968,7 @@ show_vty_unknown_tlv (struct vty *vty, struct subtlv_header *tlvh)
               vty_out (vty, " %#.2x", v[i]);
               if (rtn == 8)
                 {
-                  vty_out (vty, "%s             [%.2x]", VTY_NEWLINE, i + 1);
+                  vty_out (vty, "%s             [%.2x]", VTYNL, i + 1);
                   rtn = 1;
                 }
               else
@@ -1299,7 +1299,7 @@ show_mpls_te_sub (struct vty *vty, struct interface *ifp)
       show_vty_subtlv_res_bw (vty, &mtc->res_bw);
       show_vty_subtlv_ava_bw (vty, &mtc->ava_bw);
       show_vty_subtlv_use_bw (vty, &mtc->use_bw);
-      vty_outln (vty, "---------------%s", VTY_NEWLINE);
+      vty_outln (vty, "---------------%s", VTYNL);
     }
   else
     {

--- a/isisd/isis_vty.c
+++ b/isisd/isis_vty.c
@@ -40,15 +40,15 @@ isis_circuit_lookup (struct vty *vty)
 
   if (!ifp)
     {
-      vty_out (vty, "Invalid interface %s", VTY_NEWLINE);
+      vty_outln (vty, "Invalid interface ");
       return NULL;
     }
 
   circuit = circuit_scan_by_ifp (ifp);
   if (!circuit)
     {
-      vty_out (vty, "ISIS is not enabled on circuit %s%s",
-               ifp->name, VTY_NEWLINE);
+      vty_outln (vty, "ISIS is not enabled on circuit %s",
+               ifp->name);
       return NULL;
     }
 
@@ -77,8 +77,8 @@ DEFUN (ip_router_isis,
     {
       if (strcmp (circuit->area->area_tag, area_tag))
         {
-          vty_out (vty, "ISIS circuit is already defined on %s%s",
-                   circuit->area->area_tag, VTY_NEWLINE);
+          vty_outln (vty, "ISIS circuit is already defined on %s",
+                   circuit->area->area_tag);
           return CMD_ERR_NOTHING_TODO;
         }
     }
@@ -92,7 +92,7 @@ DEFUN (ip_router_isis,
 
     if (circuit->state != C_STATE_CONF && circuit->state != C_STATE_UP)
       {
-        vty_out(vty, "Couldn't bring up interface, please check log.%s", VTY_NEWLINE);
+        vty_outln (vty, "Couldn't bring up interface, please check log.");
         return CMD_WARNING;
       }
   }
@@ -139,16 +139,16 @@ DEFUN (no_ip_router_isis,
   area = isis_area_lookup (area_tag);
   if (!area)
     {
-      vty_out (vty, "Can't find ISIS instance %s%s",
-               argv[idx_afi]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Can't find ISIS instance %s",
+               argv[idx_afi]->arg);
       return CMD_ERR_NO_MATCH;
     }
 
   circuit = circuit_lookup_by_ifp (ifp, area->circuit_list);
   if (!circuit)
     {
-      vty_out (vty, "ISIS is not enabled on circuit %s%s",
-               ifp->name, VTY_NEWLINE);
+      vty_outln (vty, "ISIS is not enabled on circuit %s",
+               ifp->name);
       return CMD_ERR_NO_MATCH;
     }
 
@@ -189,8 +189,7 @@ DEFUN (no_isis_passive,
 
   if (if_is_loopback (circuit->interface))
     {
-      vty_out (vty, "Can't set no passive for loopback interface%s",
-               VTY_NEWLINE);
+      vty_outln (vty,"Can't set no passive for loopback interface");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -216,7 +215,7 @@ DEFUN (isis_circuit_type,
   is_type = string2circuit_t (argv[idx_level]->arg);
   if (!is_type)
     {
-      vty_out (vty, "Unknown circuit-type %s", VTY_NEWLINE);
+      vty_outln (vty, "Unknown circuit-type ");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -224,8 +223,8 @@ DEFUN (isis_circuit_type,
       circuit->area->is_type != IS_LEVEL_1_AND_2 &&
       circuit->area->is_type != is_type)
     {
-      vty_out (vty, "Invalid circuit level for area %s.%s",
-               circuit->area->area_tag, VTY_NEWLINE);
+      vty_outln (vty, "Invalid circuit level for area %s.",
+               circuit->area->area_tag);
       return CMD_ERR_AMBIGUOUS;
     }
   isis_circuit_is_type_set (circuit, is_type);
@@ -273,9 +272,8 @@ DEFUN (isis_network,
 
   if (isis_circuit_circ_type_set(circuit, CIRCUIT_T_P2P))
     {
-      vty_out (vty, "isis network point-to-point "
-               "is valid only on broadcast interfaces%s",
-               VTY_NEWLINE);
+      vty_outln (vty,
+                 "isis network point-to-point " "is valid only on broadcast interfaces");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -296,9 +294,8 @@ DEFUN (no_isis_network,
 
   if (isis_circuit_circ_type_set(circuit, CIRCUIT_T_BROADCAST))
     {
-      vty_out (vty, "isis network point-to-point "
-               "is valid only on broadcast interfaces%s",
-               VTY_NEWLINE);
+      vty_outln (vty,
+                 "isis network point-to-point " "is valid only on broadcast interfaces");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -327,7 +324,7 @@ DEFUN (isis_passwd,
     rv = isis_circuit_passwd_cleartext_set(circuit, argv[idx_word]->arg);
   if (rv)
     {
-      vty_out (vty, "Too long circuit password (>254)%s", VTY_NEWLINE);
+      vty_outln (vty, "Too long circuit password (>254)");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -370,8 +367,8 @@ DEFUN (isis_priority,
   prio = atoi (argv[idx_number]->arg);
   if (prio < MIN_PRIORITY || prio > MAX_PRIORITY)
     {
-      vty_out (vty, "Invalid priority %d - should be <0-127>%s",
-               prio, VTY_NEWLINE);
+      vty_outln (vty, "Invalid priority %d - should be <0-127>",
+               prio);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -417,8 +414,8 @@ DEFUN (isis_priority_l1,
   prio = atoi (argv[idx_number]->arg);
   if (prio < MIN_PRIORITY || prio > MAX_PRIORITY)
     {
-      vty_out (vty, "Invalid priority %d - should be <0-127>%s",
-               prio, VTY_NEWLINE);
+      vty_outln (vty, "Invalid priority %d - should be <0-127>",
+               prio);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -463,8 +460,8 @@ DEFUN (isis_priority_l2,
   prio = atoi (argv[idx_number]->arg);
   if (prio < MIN_PRIORITY || prio > MAX_PRIORITY)
     {
-      vty_out (vty, "Invalid priority %d - should be <0-127>%s",
-               prio, VTY_NEWLINE);
+      vty_outln (vty, "Invalid priority %d - should be <0-127>",
+               prio);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -512,9 +509,9 @@ DEFUN (isis_metric,
   if (circuit->area && circuit->area->oldmetric == 1 &&
       met > MAX_NARROW_LINK_METRIC)
     {
-      vty_out (vty, "Invalid metric %d - should be <0-63> "
-               "when narrow metric type enabled%s",
-               met, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric %d - should be <0-63> "
+               "when narrow metric type enabled",
+               met);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -522,9 +519,9 @@ DEFUN (isis_metric,
   if (circuit->area && circuit->area->newmetric == 1 &&
       met > MAX_WIDE_LINK_METRIC)
     {
-      vty_out (vty, "Invalid metric %d - should be <0-16777215> "
-               "when wide metric type enabled%s",
-               met, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric %d - should be <0-16777215> "
+               "when wide metric type enabled",
+               met);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -572,9 +569,9 @@ DEFUN (isis_metric_l1,
   if (circuit->area && circuit->area->oldmetric == 1 &&
       met > MAX_NARROW_LINK_METRIC)
     {
-      vty_out (vty, "Invalid metric %d - should be <0-63> "
-               "when narrow metric type enabled%s",
-               met, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric %d - should be <0-63> "
+               "when narrow metric type enabled",
+               met);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -582,9 +579,9 @@ DEFUN (isis_metric_l1,
   if (circuit->area && circuit->area->newmetric == 1 &&
       met > MAX_WIDE_LINK_METRIC)
     {
-      vty_out (vty, "Invalid metric %d - should be <0-16777215> "
-               "when wide metric type enabled%s",
-               met, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric %d - should be <0-16777215> "
+               "when wide metric type enabled",
+               met);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -631,9 +628,9 @@ DEFUN (isis_metric_l2,
   if (circuit->area && circuit->area->oldmetric == 1 &&
       met > MAX_NARROW_LINK_METRIC)
     {
-      vty_out (vty, "Invalid metric %d - should be <0-63> "
-               "when narrow metric type enabled%s",
-               met, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric %d - should be <0-63> "
+               "when narrow metric type enabled",
+               met);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -641,9 +638,9 @@ DEFUN (isis_metric_l2,
   if (circuit->area && circuit->area->newmetric == 1 &&
       met > MAX_WIDE_LINK_METRIC)
     {
-      vty_out (vty, "Invalid metric %d - should be <0-16777215> "
-               "when wide metric type enabled%s",
-               met, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric %d - should be <0-16777215> "
+               "when wide metric type enabled",
+               met);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -688,8 +685,8 @@ DEFUN (isis_hello_interval,
   interval = atoi (argv[idx_number]->arg);
   if (interval < MIN_HELLO_INTERVAL || interval > MAX_HELLO_INTERVAL)
     {
-      vty_out (vty, "Invalid hello-interval %d - should be <1-600>%s",
-               interval, VTY_NEWLINE);
+      vty_outln (vty, "Invalid hello-interval %d - should be <1-600>",
+               interval);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -737,8 +734,8 @@ DEFUN (isis_hello_interval_l1,
   interval = atoi (argv[idx_number]->arg);
   if (interval < MIN_HELLO_INTERVAL || interval > MAX_HELLO_INTERVAL)
     {
-      vty_out (vty, "Invalid hello-interval %ld - should be <1-600>%s",
-               interval, VTY_NEWLINE);
+      vty_outln (vty, "Invalid hello-interval %ld - should be <1-600>",
+               interval);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -785,8 +782,8 @@ DEFUN (isis_hello_interval_l2,
   interval = atoi (argv[idx_number]->arg);
   if (interval < MIN_HELLO_INTERVAL || interval > MAX_HELLO_INTERVAL)
     {
-      vty_out (vty, "Invalid hello-interval %ld - should be <1-600>%s",
-               interval, VTY_NEWLINE);
+      vty_outln (vty, "Invalid hello-interval %ld - should be <1-600>",
+               interval);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -831,8 +828,8 @@ DEFUN (isis_hello_multiplier,
   mult = atoi (argv[idx_number]->arg);
   if (mult < MIN_HELLO_MULTIPLIER || mult > MAX_HELLO_MULTIPLIER)
     {
-      vty_out (vty, "Invalid hello-multiplier %d - should be <2-100>%s",
-               mult, VTY_NEWLINE);
+      vty_outln (vty, "Invalid hello-multiplier %d - should be <2-100>",
+               mult);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -879,8 +876,8 @@ DEFUN (isis_hello_multiplier_l1,
   mult = atoi (argv[idx_number]->arg);
   if (mult < MIN_HELLO_MULTIPLIER || mult > MAX_HELLO_MULTIPLIER)
     {
-      vty_out (vty, "Invalid hello-multiplier %d - should be <2-100>%s",
-               mult, VTY_NEWLINE);
+      vty_outln (vty, "Invalid hello-multiplier %d - should be <2-100>",
+               mult);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -926,8 +923,8 @@ DEFUN (isis_hello_multiplier_l2,
   mult = atoi (argv[idx_number]->arg);
   if (mult < MIN_HELLO_MULTIPLIER || mult > MAX_HELLO_MULTIPLIER)
     {
-      vty_out (vty, "Invalid hello-multiplier %d - should be <2-100>%s",
-               mult, VTY_NEWLINE);
+      vty_outln (vty, "Invalid hello-multiplier %d - should be <2-100>",
+               mult);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1007,8 +1004,8 @@ DEFUN (csnp_interval,
   interval = atol (argv[idx_number]->arg);
   if (interval < MIN_CSNP_INTERVAL || interval > MAX_CSNP_INTERVAL)
     {
-      vty_out (vty, "Invalid csnp-interval %lu - should be <1-600>%s",
-               interval, VTY_NEWLINE);
+      vty_outln (vty, "Invalid csnp-interval %lu - should be <1-600>",
+               interval);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1055,8 +1052,8 @@ DEFUN (csnp_interval_l1,
   interval = atol (argv[idx_number]->arg);
   if (interval < MIN_CSNP_INTERVAL || interval > MAX_CSNP_INTERVAL)
     {
-      vty_out (vty, "Invalid csnp-interval %lu - should be <1-600>%s",
-               interval, VTY_NEWLINE);
+      vty_outln (vty, "Invalid csnp-interval %lu - should be <1-600>",
+               interval);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1102,8 +1099,8 @@ DEFUN (csnp_interval_l2,
   interval = atol (argv[idx_number]->arg);
   if (interval < MIN_CSNP_INTERVAL || interval > MAX_CSNP_INTERVAL)
     {
-      vty_out (vty, "Invalid csnp-interval %lu - should be <1-600>%s",
-               interval, VTY_NEWLINE);
+      vty_outln (vty, "Invalid csnp-interval %lu - should be <1-600>",
+               interval);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1148,8 +1145,8 @@ DEFUN (psnp_interval,
   interval = atol (argv[idx_number]->arg);
   if (interval < MIN_PSNP_INTERVAL || interval > MAX_PSNP_INTERVAL)
     {
-      vty_out (vty, "Invalid psnp-interval %lu - should be <1-120>%s",
-               interval, VTY_NEWLINE);
+      vty_outln (vty, "Invalid psnp-interval %lu - should be <1-120>",
+               interval);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1196,8 +1193,8 @@ DEFUN (psnp_interval_l1,
   interval = atol (argv[idx_number]->arg);
   if (interval < MIN_PSNP_INTERVAL || interval > MAX_PSNP_INTERVAL)
     {
-      vty_out (vty, "Invalid psnp-interval %lu - should be <1-120>%s",
-               interval, VTY_NEWLINE);
+      vty_outln (vty, "Invalid psnp-interval %lu - should be <1-120>",
+               interval);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1243,8 +1240,8 @@ DEFUN (psnp_interval_l2,
   interval = atol (argv[idx_number]->arg);
   if (interval < MIN_PSNP_INTERVAL || interval > MAX_PSNP_INTERVAL)
     {
-      vty_out (vty, "Invalid psnp-interval %lu - should be <1-120>%s",
-               interval, VTY_NEWLINE);
+      vty_outln (vty, "Invalid psnp-interval %lu - should be <1-120>",
+               interval);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1287,13 +1284,14 @@ DEFUN (circuit_topology,
 
   if (circuit->area && circuit->area->oldmetric)
     {
-      vty_out (vty, "Multi topology IS-IS can only be used with wide metrics%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Multi topology IS-IS can only be used with wide metrics");
       return CMD_ERR_AMBIGUOUS;
     }
 
   if (mtid == (uint16_t)-1)
     {
-      vty_out (vty, "Don't know topology '%s'%s", arg, VTY_NEWLINE);
+      vty_outln (vty, "Don't know topology '%s'", arg);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1316,13 +1314,14 @@ DEFUN (no_circuit_topology,
 
   if (circuit->area && circuit->area->oldmetric)
     {
-      vty_out (vty, "Multi topology IS-IS can only be used with wide metrics%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Multi topology IS-IS can only be used with wide metrics");
       return CMD_ERR_AMBIGUOUS;
     }
 
   if (mtid == (uint16_t)-1)
     {
-      vty_out (vty, "Don't know topology '%s'%s", arg, VTY_NEWLINE);
+      vty_outln (vty, "Don't know topology '%s'", arg);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1340,7 +1339,7 @@ validate_metric_style_narrow (struct vty *vty, struct isis_area *area)
 
   if (! area)
     {
-      vty_out (vty, "ISIS area is invalid%s", VTY_NEWLINE);
+      vty_outln (vty, "ISIS area is invalid");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1350,16 +1349,16 @@ validate_metric_style_narrow (struct vty *vty, struct isis_area *area)
           (circuit->is_type & IS_LEVEL_1) &&
           (circuit->te_metric[0] > MAX_NARROW_LINK_METRIC))
         {
-          vty_out (vty, "ISIS circuit %s metric is invalid%s",
-                   circuit->interface->name, VTY_NEWLINE);
+          vty_outln (vty, "ISIS circuit %s metric is invalid",
+                   circuit->interface->name);
           return CMD_ERR_AMBIGUOUS;
         }
       if ((area->is_type & IS_LEVEL_2) &&
           (circuit->is_type & IS_LEVEL_2) &&
           (circuit->te_metric[1] > MAX_NARROW_LINK_METRIC))
         {
-          vty_out (vty, "ISIS circuit %s metric is invalid%s",
-                   circuit->interface->name, VTY_NEWLINE);
+          vty_outln (vty, "ISIS circuit %s metric is invalid",
+                   circuit->interface->name);
           return CMD_ERR_AMBIGUOUS;
         }
     }
@@ -1387,7 +1386,8 @@ DEFUN (metric_style,
 
   if (area_is_mt(area))
     {
-      vty_out (vty, "Narrow metrics cannot be used while multi topology IS-IS is active%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Narrow metrics cannot be used while multi topology IS-IS is active");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1415,7 +1415,8 @@ DEFUN (no_metric_style,
 
   if (area_is_mt(area))
     {
-      vty_out (vty, "Narrow metrics cannot be used while multi topology IS-IS is active%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Narrow metrics cannot be used while multi topology IS-IS is active");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1512,9 +1513,8 @@ static int area_lsp_mtu_set(struct vty *vty, unsigned int lsp_mtu)
         continue;
       if(lsp_mtu > isis_circuit_pdu_size(circuit))
         {
-          vty_out(vty, "ISIS area contains circuit %s, which has a maximum PDU size of %zu.%s",
-                  circuit->interface->name, isis_circuit_pdu_size(circuit),
-                  VTY_NEWLINE);
+          vty_outln (vty, "ISIS area contains circuit %s, which has a maximum PDU size of %zu.",
+                  circuit->interface->name,isis_circuit_pdu_size(circuit));
           return CMD_ERR_AMBIGUOUS;
         }
     }
@@ -1564,7 +1564,7 @@ DEFUN (is_type,
   type = string2circuit_t (argv[idx_level]->arg);
   if (!type)
     {
-      vty_out (vty, "Unknown IS level %s", VTY_NEWLINE);
+      vty_outln (vty, "Unknown IS level ");
       return CMD_SUCCESS;
     }
 
@@ -1613,9 +1613,9 @@ set_lsp_gen_interval (struct vty *vty, struct isis_area *area,
 
       if (interval >= area->lsp_refresh[lvl-1])
         {
-          vty_out (vty, "LSP gen interval %us must be less than "
-                   "the LSP refresh interval %us%s",
-                   interval, area->lsp_refresh[lvl-1], VTY_NEWLINE);
+          vty_outln (vty, "LSP gen interval %us must be less than "
+                   "the LSP refresh interval %us",
+                   interval, area->lsp_refresh[lvl - 1]);
           return CMD_ERR_AMBIGUOUS;
         }
     }
@@ -1852,19 +1852,18 @@ area_max_lsp_lifetime_set(struct vty *vty, int level,
 
       if (refresh_interval < area->lsp_refresh[lvl-1])
         {
-          vty_out (vty, "Level %d Max LSP lifetime %us must be 300s greater than "
-                   "the configured LSP refresh interval %us%s",
-                   lvl, interval, area->lsp_refresh[lvl-1], VTY_NEWLINE);
-          vty_out (vty, "Automatically reducing level %d LSP refresh interval "
-                   "to %us%s", lvl, refresh_interval, VTY_NEWLINE);
+          vty_outln (vty, "Level %d Max LSP lifetime %us must be 300s greater than "
+                   "the configured LSP refresh interval %us",
+                   lvl, interval, area->lsp_refresh[lvl - 1]);
+          vty_outln (vty, "Automatically reducing level %d LSP refresh interval "
+                   "to %us", lvl, refresh_interval);
           set_refresh_interval[lvl-1] = 1;
 
           if (refresh_interval <= area->lsp_gen_interval[lvl-1])
             {
-              vty_out (vty, "LSP refresh interval %us must be greater than "
-                       "the configured LSP gen interval %us%s",
-                       refresh_interval, area->lsp_gen_interval[lvl-1],
-                       VTY_NEWLINE);
+              vty_outln (vty, "LSP refresh interval %us must be greater than "
+                       "the configured LSP gen interval %us",
+                       refresh_interval,area->lsp_gen_interval[lvl - 1]);
               return CMD_ERR_AMBIGUOUS;
             }
         }
@@ -1937,18 +1936,16 @@ area_lsp_refresh_interval_set(struct vty *vty, int level, uint16_t interval)
         continue;
       if (interval <= area->lsp_gen_interval[lvl-1])
         {
-          vty_out (vty, "LSP refresh interval %us must be greater than "
-                   "the configured LSP gen interval %us%s",
-                   interval, area->lsp_gen_interval[lvl-1],
-                   VTY_NEWLINE);
+          vty_outln (vty, "LSP refresh interval %us must be greater than "
+                   "the configured LSP gen interval %us",
+                   interval,area->lsp_gen_interval[lvl - 1]);
           return CMD_ERR_AMBIGUOUS;
         }
       if (interval > (area->max_lsp_lifetime[lvl-1] - 300))
         {
-          vty_out (vty, "LSP refresh interval %us must be less than "
-                   "the configured LSP lifetime %us less 300%s",
-                   interval, area->max_lsp_lifetime[lvl-1],
-                   VTY_NEWLINE);
+          vty_outln (vty, "LSP refresh interval %us must be less than "
+                   "the configured LSP lifetime %us less 300",
+                   interval,area->max_lsp_lifetime[lvl - 1]);
           return CMD_ERR_AMBIGUOUS;
         }
     }
@@ -2014,7 +2011,7 @@ area_passwd_set(struct vty *vty, int level,
 
   if (passwd && strlen(passwd) > 254)
     {
-      vty_out (vty, "Too long area password (>254)%s", VTY_NEWLINE);
+      vty_outln (vty, "Too long area password (>254)");
       return CMD_ERR_AMBIGUOUS;
     }
 

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -1374,7 +1374,7 @@ DEFUN (show_isis_summary,
 
   vty_out (vty, "Up time         : ");
   vty_out_timestr(vty, isis->uptime);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   if (isis->area_list)
     vty_outln (vty, "Number of areas : %d",isis->area_list->count);
@@ -1409,12 +1409,12 @@ DEFUN (show_isis_summary,
           area->min_spf_interval[level - 1]);
       if (area->spf_delay_ietf[level - 1])
          vty_out (vty, " (not used, IETF SPF delay activated)");
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
 
       vty_outln (vty, "    IPv4 route computation:");
       vty_out (vty, "      last run elapsed  : ");
       vty_out_timestr(vty, spftree->last_run_timestamp);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
 
       vty_outln (vty, "      last run duration : %u usec",
                (u_int32_t)spftree->last_run_duration);
@@ -1427,7 +1427,7 @@ DEFUN (show_isis_summary,
 
       vty_out (vty, "      last run elapsed  : ");
       vty_out_timestr(vty, spftree->last_run_timestamp);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
 
       vty_outln (vty, "      last run duration : %llu msec",
                (unsigned long long)spftree->last_run_duration);
@@ -1436,7 +1436,7 @@ DEFUN (show_isis_summary,
           spftree->runcount);
     }
   }
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -2174,7 +2174,7 @@ isis_config_write (struct vty *vty)
 		else
 		  vty_out(vty, "send-only");
 	      }
-	    vty_outln (vty, "");
+	    vty_out (vty, VTYNL);
 	    write++; 
 	  }
         else if (area->area_passwd.type == ISIS_PASSWD_TYPE_CLEARTXT)
@@ -2188,7 +2188,7 @@ isis_config_write (struct vty *vty)
 		else
 		  vty_out(vty, "send-only");
 	      }
-	    vty_outln (vty, "");
+	    vty_out (vty, VTYNL);
 	    write++; 
           }
 	if (area->domain_passwd.type == ISIS_PASSWD_TYPE_HMAC_MD5)
@@ -2203,7 +2203,7 @@ isis_config_write (struct vty *vty)
 		else
 		  vty_out(vty, "send-only");
 	      }
-	    vty_outln (vty, "");
+	    vty_out (vty, VTYNL);
 	    write++;
 	  }
         else if (area->domain_passwd.type == ISIS_PASSWD_TYPE_CLEARTXT)
@@ -2218,7 +2218,7 @@ isis_config_write (struct vty *vty)
 		else
 		  vty_out(vty, "send-only");
 	      }
-	    vty_outln (vty, "");
+	    vty_out (vty, VTYNL);
 	    write++;
 	  }
 

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -218,7 +218,7 @@ isis_area_destroy (struct vty *vty, const char *area_tag)
 
   if (area == NULL)
     {
-      vty_out (vty, "Can't find ISIS instance %s", VTY_NEWLINE);
+      vty_outln (vty, "Can't find ISIS instance ");
       return CMD_ERR_NO_MATCH;
     }
 
@@ -352,8 +352,8 @@ area_net_title (struct vty *vty, const char *net_title)
   /* We check that we are not over the maximal number of addresses */
   if (listcount (area->area_addrs) >= isis->max_area_addrs)
     {
-      vty_out (vty, "Maximum of area addresses (%d) already reached %s",
-	       isis->max_area_addrs, VTY_NEWLINE);
+      vty_outln (vty, "Maximum of area addresses (%d) already reached ",
+	       isis->max_area_addrs);
       return CMD_ERR_NOTHING_TODO;
     }
 
@@ -366,16 +366,15 @@ area_net_title (struct vty *vty, const char *net_title)
 #endif /* EXTREME_DEBUG */
   if (addr->addr_len < 8 || addr->addr_len > 20)
     {
-      vty_out (vty, "area address must be at least 8..20 octets long (%d)%s",
-               addr->addr_len, VTY_NEWLINE);
+      vty_outln (vty, "area address must be at least 8..20 octets long (%d)",
+               addr->addr_len);
       XFREE (MTYPE_ISIS_AREA_ADDR, addr);
       return CMD_ERR_AMBIGUOUS;
     }
 
   if (addr->area_addr[addr->addr_len-1] != 0)
     {
-      vty_out (vty, "nsel byte (last byte) in area address must be 0%s",
-               VTY_NEWLINE);
+      vty_outln (vty,"nsel byte (last byte) in area address must be 0");
       XFREE (MTYPE_ISIS_AREA_ADDR, addr);
       return CMD_ERR_AMBIGUOUS;
     }
@@ -397,9 +396,8 @@ area_net_title (struct vty *vty, const char *net_title)
        */
       if (memcmp (isis->sysid, GETSYSID (addr), ISIS_SYS_ID_LEN))
 	{
-	  vty_out (vty,
-		   "System ID must not change when defining additional area"
-		   " addresses%s", VTY_NEWLINE);
+	  vty_outln (vty,
+		   "System ID must not change when defining additional area" " addresses");
 	  XFREE (MTYPE_ISIS_AREA_ADDR, addr);
 	  return CMD_ERR_AMBIGUOUS;
 	}
@@ -446,8 +444,8 @@ area_clear_net_title (struct vty *vty, const char *net_title)
   addr.addr_len = dotformat2buff (buff, net_title);
   if (addr.addr_len < 8 || addr.addr_len > 20)
     {
-      vty_out (vty, "Unsupported area address length %d, should be 8...20 %s",
-	       addr.addr_len, VTY_NEWLINE);
+      vty_outln (vty, "Unsupported area address length %d, should be 8...20 ",
+	       addr.addr_len);
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -460,8 +458,8 @@ area_clear_net_title (struct vty *vty, const char *net_title)
 
   if (!addrp)
     {
-      vty_out (vty, "No area address %s for area %s %s", net_title,
-	       area->area_tag, VTY_NEWLINE);
+      vty_outln (vty, "No area address %s for area %s ", net_title,
+	       area->area_tag);
       return CMD_ERR_NO_MATCH;
     }
 
@@ -495,17 +493,16 @@ show_isis_interface_common (struct vty *vty, const char *ifname, char detail)
 
   if (!isis)
     {
-      vty_out (vty, "IS-IS Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "IS-IS Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
   for (ALL_LIST_ELEMENTS_RO (isis->area_list, anode, area))
     {
-      vty_out (vty, "Area %s:%s", area->area_tag, VTY_NEWLINE);
+      vty_outln (vty, "Area %s:", area->area_tag);
 
       if (detail == ISIS_UI_LEVEL_BRIEF)
-        vty_out (vty, "  Interface   CircId   State    Type     Level%s",
-                 VTY_NEWLINE);
+        vty_outln (vty,"  Interface   CircId   State    Type     Level");
 
       for (ALL_LIST_ELEMENTS_RO (area->circuit_list, cnode, circuit))
         if (!ifname)
@@ -568,7 +565,7 @@ show_isis_neighbor_common (struct vty *vty, const char *id, char detail)
 
   if (!isis)
     {
-      vty_out (vty, "IS-IS Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "IS-IS Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -580,7 +577,7 @@ show_isis_neighbor_common (struct vty *vty, const char *id, char detail)
           dynhn = dynhn_find_by_name (id);
           if (dynhn == NULL)
             {
-              vty_out (vty, "Invalid system id %s%s", id, VTY_NEWLINE);
+              vty_outln (vty, "Invalid system id %s", id);
               return CMD_SUCCESS;
             }
           memcpy (sysid, dynhn->id, ISIS_SYS_ID_LEN);
@@ -589,11 +586,11 @@ show_isis_neighbor_common (struct vty *vty, const char *id, char detail)
 
   for (ALL_LIST_ELEMENTS_RO (isis->area_list, anode, area))
     {
-      vty_out (vty, "Area %s:%s", area->area_tag, VTY_NEWLINE);
+      vty_outln (vty, "Area %s:", area->area_tag);
 
       if (detail == ISIS_UI_LEVEL_BRIEF)
-        vty_out (vty, "  System Id           Interface   L  State"
-                      "        Holdtime SNPA%s", VTY_NEWLINE);
+        vty_outln (vty,
+                   "  System Id           Interface   L  State" "        Holdtime SNPA");
 
       for (ALL_LIST_ELEMENTS_RO (area->circuit_list, cnode, circuit))
         {
@@ -641,7 +638,7 @@ clear_isis_neighbor_common (struct vty *vty, const char *id)
 
   if (!isis)
     {
-      vty_out (vty, "IS-IS Routing Process not enabled%s", VTY_NEWLINE);
+      vty_outln (vty, "IS-IS Routing Process not enabled");
       return CMD_SUCCESS;
     }
 
@@ -653,7 +650,7 @@ clear_isis_neighbor_common (struct vty *vty, const char *id)
           dynhn = dynhn_find_by_name (id);
           if (dynhn == NULL)
             {
-              vty_out (vty, "Invalid system id %s%s", id, VTY_NEWLINE);
+              vty_outln (vty, "Invalid system id %s", id);
               return CMD_SUCCESS;
             }
           memcpy (sysid, dynhn->id, ISIS_SYS_ID_LEN);
@@ -760,42 +757,35 @@ print_debug (struct vty *vty, int flags, int onoff)
     strcpy (onoffs, "off");
 
   if (flags & DEBUG_ADJ_PACKETS)
-    vty_out (vty, "IS-IS Adjacency related packets debugging is %s%s", onoffs,
-	     VTY_NEWLINE);
+    vty_outln (vty, "IS-IS Adjacency related packets debugging is %s",
+               onoffs);
   if (flags & DEBUG_CHECKSUM_ERRORS)
-    vty_out (vty, "IS-IS checksum errors debugging is %s%s", onoffs,
-	     VTY_NEWLINE);
+    vty_outln (vty, "IS-IS checksum errors debugging is %s",onoffs);
   if (flags & DEBUG_LOCAL_UPDATES)
-    vty_out (vty, "IS-IS local updates debugging is %s%s", onoffs,
-	     VTY_NEWLINE);
+    vty_outln (vty, "IS-IS local updates debugging is %s",onoffs);
   if (flags & DEBUG_PROTOCOL_ERRORS)
-    vty_out (vty, "IS-IS protocol errors debugging is %s%s", onoffs,
-	     VTY_NEWLINE);
+    vty_outln (vty, "IS-IS protocol errors debugging is %s",onoffs);
   if (flags & DEBUG_SNP_PACKETS)
-    vty_out (vty, "IS-IS CSNP/PSNP packets debugging is %s%s", onoffs,
-	     VTY_NEWLINE);
+    vty_outln (vty, "IS-IS CSNP/PSNP packets debugging is %s",onoffs);
   if (flags & DEBUG_SPF_EVENTS)
-    vty_out (vty, "IS-IS SPF events debugging is %s%s", onoffs, VTY_NEWLINE);
+    vty_outln (vty, "IS-IS SPF events debugging is %s", onoffs);
   if (flags & DEBUG_SPF_STATS)
-    vty_out (vty, "IS-IS SPF Timing and Statistics Data debugging is %s%s",
-	     onoffs, VTY_NEWLINE);
+    vty_outln (vty, "IS-IS SPF Timing and Statistics Data debugging is %s",
+	     onoffs);
   if (flags & DEBUG_SPF_TRIGGERS)
-    vty_out (vty, "IS-IS SPF triggering events debugging is %s%s", onoffs,
-	     VTY_NEWLINE);
+    vty_outln (vty, "IS-IS SPF triggering events debugging is %s",onoffs);
   if (flags & DEBUG_UPDATE_PACKETS)
-    vty_out (vty, "IS-IS Update related packet debugging is %s%s", onoffs,
-	     VTY_NEWLINE);
+    vty_outln (vty, "IS-IS Update related packet debugging is %s",onoffs);
   if (flags & DEBUG_RTE_EVENTS)
-    vty_out (vty, "IS-IS Route related debuggin is %s%s", onoffs,
-	     VTY_NEWLINE);
+    vty_outln (vty, "IS-IS Route related debuggin is %s",onoffs);
   if (flags & DEBUG_EVENTS)
-    vty_out (vty, "IS-IS Event debugging is %s%s", onoffs, VTY_NEWLINE);
+    vty_outln (vty, "IS-IS Event debugging is %s", onoffs);
   if (flags & DEBUG_PACKET_DUMP)
-    vty_out (vty, "IS-IS Packet dump debugging is %s%s", onoffs, VTY_NEWLINE);
+    vty_outln (vty, "IS-IS Packet dump debugging is %s", onoffs);
   if (flags & DEBUG_LSP_GEN)
-    vty_out (vty, "IS-IS LSP generation debugging is %s%s", onoffs, VTY_NEWLINE);
+    vty_outln (vty, "IS-IS LSP generation debugging is %s", onoffs);
   if (flags & DEBUG_LSP_SCHED)
-    vty_out (vty, "IS-IS LSP scheduling debugging is %s%s", onoffs, VTY_NEWLINE);
+    vty_outln (vty, "IS-IS LSP scheduling debugging is %s", onoffs);
 }
 
 DEFUN (show_debugging,
@@ -806,7 +796,7 @@ DEFUN (show_debugging,
        ISIS_STR)
 {
   if (isis->debugs) {
-      vty_out (vty, "IS-IS:%s", VTY_NEWLINE);
+      vty_outln (vty, "IS-IS:");
       print_debug (vty, isis->debugs, 1);
   }
   return CMD_SUCCESS;
@@ -827,72 +817,72 @@ config_write_debug (struct vty *vty)
 
   if (flags & DEBUG_ADJ_PACKETS)
     {
-      vty_out (vty, "debug isis adj-packets%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis adj-packets");
       write++;
     }
   if (flags & DEBUG_CHECKSUM_ERRORS)
     {
-      vty_out (vty, "debug isis checksum-errors%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis checksum-errors");
       write++;
     }
   if (flags & DEBUG_LOCAL_UPDATES)
     {
-      vty_out (vty, "debug isis local-updates%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis local-updates");
       write++;
     }
   if (flags & DEBUG_PROTOCOL_ERRORS)
     {
-      vty_out (vty, "debug isis protocol-errors%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis protocol-errors");
       write++;
     }
   if (flags & DEBUG_SNP_PACKETS)
     {
-      vty_out (vty, "debug isis snp-packets%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis snp-packets");
       write++;
     }
   if (flags & DEBUG_SPF_EVENTS)
     {
-      vty_out (vty, "debug isis spf-events%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis spf-events");
       write++;
     }
   if (flags & DEBUG_SPF_STATS)
     {
-      vty_out (vty, "debug isis spf-statistics%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis spf-statistics");
       write++;
     }
   if (flags & DEBUG_SPF_TRIGGERS)
     {
-      vty_out (vty, "debug isis spf-triggers%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis spf-triggers");
       write++;
     }
   if (flags & DEBUG_UPDATE_PACKETS)
     {
-      vty_out (vty, "debug isis update-packets%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis update-packets");
       write++;
     }
   if (flags & DEBUG_RTE_EVENTS)
     {
-      vty_out (vty, "debug isis route-events%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis route-events");
       write++;
     }
   if (flags & DEBUG_EVENTS)
     {
-      vty_out (vty, "debug isis events%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis events");
       write++;
     }
   if (flags & DEBUG_PACKET_DUMP)
     {
-      vty_out (vty, "debug isis packet-dump%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis packet-dump");
       write++;
     }
   if (flags & DEBUG_LSP_GEN)
     {
-      vty_out (vty, "debug isis lsp-gen%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis lsp-gen");
       write++;
     }
   if (flags & DEBUG_LSP_SCHED)
     {
-      vty_out (vty, "debug isis lsp-sched%s", VTY_NEWLINE);
+      vty_outln (vty, "debug isis lsp-sched");
       write++;
     }
   write += spf_backoff_write_config(vty);
@@ -1322,7 +1312,7 @@ DEFUN (show_isis_spf_ietf,
 {
   if (!isis)
     {
-      vty_out (vty, "ISIS is not running%s", VTY_NEWLINE);
+      vty_outln (vty, "ISIS is not running");
       return CMD_SUCCESS;
     }
 
@@ -1331,33 +1321,31 @@ DEFUN (show_isis_spf_ietf,
 
   for (ALL_LIST_ELEMENTS_RO (isis->area_list, node, area))
     {
-      vty_out (vty, "Area %s:%s", area->area_tag ? area->area_tag : "null",
-               VTY_NEWLINE);
+      vty_outln (vty, "Area %s:",area->area_tag ? area->area_tag : "null");
 
       for (int level = ISIS_LEVEL1; level <= ISIS_LEVELS; level++)
         {
           if ((area->is_type & level) == 0)
             continue;
 
-          vty_out (vty, "  Level-%d:%s", level, VTY_NEWLINE);
+          vty_outln (vty, "  Level-%d:", level);
           vty_out (vty, "    SPF delay status: ");
           if (area->spf_timer[level -1])
             {
               struct timeval remain = thread_timer_remain(area->spf_timer[level - 1]);
-              vty_out(vty, "Pending, due in %ld msec%s",
-                      remain.tv_sec * 1000 + remain.tv_usec / 1000,
-                      VTY_NEWLINE);
+              vty_outln (vty, "Pending, due in %ld msec",
+                      remain.tv_sec * 1000 + remain.tv_usec / 1000);
             }
           else
             {
-              vty_out(vty, "Not scheduled%s", VTY_NEWLINE);
+              vty_outln (vty, "Not scheduled");
             }
 
           if (area->spf_delay_ietf[level - 1]) {
-            vty_out(vty,  "    Using draft-ietf-rtgwg-backoff-algo-04%s", VTY_NEWLINE);
+            vty_outln (vty,  "    Using draft-ietf-rtgwg-backoff-algo-04");
             spf_backoff_show(area->spf_delay_ietf[level - 1], vty, "    ");
           } else {
-            vty_out(vty,  "    Using legacy backoff algo%s", VTY_NEWLINE);
+            vty_outln (vty,  "    Using legacy backoff algo");
           }
         }
     }
@@ -1376,38 +1364,32 @@ DEFUN (show_isis_summary,
 
   if (isis == NULL)
   {
-    vty_out (vty, "ISIS is not running%s", VTY_NEWLINE);
+    vty_outln (vty, "ISIS is not running");
     return CMD_SUCCESS;
   }
 
-  vty_out (vty, "Process Id      : %ld%s", isis->process_id,
-      VTY_NEWLINE);
+  vty_outln (vty, "Process Id      : %ld",isis->process_id);
   if (isis->sysid_set)
-    vty_out (vty, "System Id       : %s%s", sysid_print (isis->sysid),
-        VTY_NEWLINE);
+    vty_outln (vty, "System Id       : %s",sysid_print(isis->sysid));
 
   vty_out (vty, "Up time         : ");
   vty_out_timestr(vty, isis->uptime);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   if (isis->area_list)
-    vty_out (vty, "Number of areas : %d%s", isis->area_list->count,
-        VTY_NEWLINE);
+    vty_outln (vty, "Number of areas : %d",isis->area_list->count);
 
   for (ALL_LIST_ELEMENTS_RO (isis->area_list, node, area))
   {
-    vty_out (vty, "Area %s:%s", area->area_tag ? area->area_tag : "null",
-        VTY_NEWLINE);
+    vty_outln (vty, "Area %s:",area->area_tag ? area->area_tag : "null");
 
     if (listcount (area->area_addrs) > 0)
     {
       struct area_addr *area_addr;
       for (ALL_LIST_ELEMENTS_RO (area->area_addrs, node2, area_addr))
       {
-        vty_out (vty, "  Net: %s%s",
-            isonet_print (area_addr->area_addr,
-              area_addr->addr_len + ISIS_SYS_ID_LEN +
-              1), VTY_NEWLINE);
+        vty_outln (vty, "  Net: %s",
+            isonet_print(area_addr->area_addr, area_addr->addr_len + ISIS_SYS_ID_LEN + 1));
       }
     }
 
@@ -1416,45 +1398,45 @@ DEFUN (show_isis_summary,
       if ((area->is_type & level) == 0)
         continue;
 
-      vty_out (vty, "  Level-%d:%s", level, VTY_NEWLINE);
+      vty_outln (vty, "  Level-%d:", level);
       spftree = area->spftree[level - 1];
       if (area->spf_timer[level - 1])
-        vty_out (vty, "    SPF: (pending)%s", VTY_NEWLINE);
+        vty_outln (vty, "    SPF: (pending)");
       else
-        vty_out (vty, "    SPF:%s", VTY_NEWLINE);
+        vty_outln (vty, "    SPF:");
 
       vty_out (vty, "      minimum interval  : %d",
           area->min_spf_interval[level - 1]);
       if (area->spf_delay_ietf[level - 1])
          vty_out (vty, " (not used, IETF SPF delay activated)");
-      vty_out (vty, VTY_NEWLINE);
+      vty_outln (vty, "");
 
-      vty_out (vty, "    IPv4 route computation:%s", VTY_NEWLINE);
+      vty_outln (vty, "    IPv4 route computation:");
       vty_out (vty, "      last run elapsed  : ");
       vty_out_timestr(vty, spftree->last_run_timestamp);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
 
-      vty_out (vty, "      last run duration : %u usec%s",
-               (u_int32_t)spftree->last_run_duration, VTY_NEWLINE);
+      vty_outln (vty, "      last run duration : %u usec",
+               (u_int32_t)spftree->last_run_duration);
 
-      vty_out (vty, "      run count         : %d%s",
-          spftree->runcount, VTY_NEWLINE);
+      vty_outln (vty, "      run count         : %d",
+          spftree->runcount);
 
       spftree = area->spftree6[level - 1];
-      vty_out (vty, "    IPv6 route computation:%s", VTY_NEWLINE);
+      vty_outln (vty, "    IPv6 route computation:");
 
       vty_out (vty, "      last run elapsed  : ");
       vty_out_timestr(vty, spftree->last_run_timestamp);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
 
-      vty_out (vty, "      last run duration : %llu msec%s",
-               (unsigned long long)spftree->last_run_duration, VTY_NEWLINE);
+      vty_outln (vty, "      last run duration : %llu msec",
+               (unsigned long long)spftree->last_run_duration);
 
-      vty_out (vty, "      run count         : %d%s",
-          spftree->runcount, VTY_NEWLINE);
+      vty_outln (vty, "      run count         : %d",
+          spftree->runcount);
     }
   }
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   return CMD_SUCCESS;
 }
@@ -1526,8 +1508,7 @@ show_isis_database (struct vty *vty, const char *argv, int ui_level)
 
   for (ALL_LIST_ELEMENTS_RO (isis->area_list, node, area))
     {
-      vty_out (vty, "Area %s:%s", area->area_tag ? area->area_tag : "null",
-               VTY_NEWLINE);
+      vty_outln (vty, "Area %s:",area->area_tag ? area->area_tag : "null");
 
       for (level = 0; level < ISIS_LEVELS; level++)
         {
@@ -1558,13 +1539,12 @@ show_isis_database (struct vty *vty, const char *argv, int ui_level)
 
               if (lsp != NULL || argv == NULL)
                 {
-                  vty_out (vty, "IS-IS Level-%d link-state database:%s",
-                           level + 1, VTY_NEWLINE);
+                  vty_outln (vty, "IS-IS Level-%d link-state database:",
+                           level + 1);
 
                   /* print the title in all cases */
-                  vty_out (vty, "LSP ID                  PduLen  "
-                           "SeqNumber   Chksum  Holdtime  ATT/P/OL%s",
-                           VTY_NEWLINE);
+                  vty_outln (vty,
+                             "LSP ID                  PduLen  " "SeqNumber   Chksum  Holdtime  ATT/P/OL");
                 }
 
               if (lsp)
@@ -1580,8 +1560,8 @@ show_isis_database (struct vty *vty, const char *argv, int ui_level)
                                              ui_level,
                                              area->dynhostname);
 
-                  vty_out (vty, "    %u LSPs%s%s",
-                           lsp_count, VTY_NEWLINE, VTY_NEWLINE);
+                  vty_outln (vty, "    %u LSPs%s",
+                           lsp_count, VTY_NEWLINE);
                 }
             }
         }
@@ -1672,18 +1652,19 @@ DEFUN (isis_topology,
 
   if (area->oldmetric)
     {
-      vty_out (vty, "Multi topology IS-IS can only be used with wide metrics%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Multi topology IS-IS can only be used with wide metrics");
       return CMD_ERR_AMBIGUOUS;
     }
 
   if (mtid == (uint16_t)-1)
     {
-      vty_out (vty, "Don't know topology '%s'%s", arg, VTY_NEWLINE);
+      vty_outln (vty, "Don't know topology '%s'", arg);
       return CMD_ERR_AMBIGUOUS;
     }
   if (mtid == ISIS_MT_IPV4_UNICAST)
     {
-      vty_out (vty, "Cannot configure IPv4 unicast topology%s", VTY_NEWLINE);
+      vty_outln (vty, "Cannot configure IPv4 unicast topology");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -1707,18 +1688,19 @@ DEFUN (no_isis_topology,
 
   if (area->oldmetric)
     {
-      vty_out (vty, "Multi topology IS-IS can only be used with wide metrics%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Multi topology IS-IS can only be used with wide metrics");
       return CMD_ERR_AMBIGUOUS;
     }
 
   if (mtid == (uint16_t)-1)
     {
-      vty_out (vty, "Don't know topology '%s'%s", arg, VTY_NEWLINE);
+      vty_outln (vty, "Don't know topology '%s'", arg);
       return CMD_ERR_AMBIGUOUS;
     }
   if (mtid == ISIS_MT_IPV4_UNICAST)
     {
-      vty_out (vty, "Cannot configure IPv4 unicast topology%s", VTY_NEWLINE);
+      vty_outln (vty, "Cannot configure IPv4 unicast topology");
       return CMD_ERR_AMBIGUOUS;
     }
 
@@ -2008,7 +1990,7 @@ isis_config_write (struct vty *vty)
       for (ALL_LIST_ELEMENTS_RO (isis->area_list, node, area))
       {
 	/* ISIS - Area name */
-	vty_out (vty, "router isis %s%s", area->area_tag, VTY_NEWLINE);
+	vty_outln (vty, "router isis %s", area->area_tag);
 	write++;
 	/* ISIS - Net */
 	if (listcount (area->area_addrs) > 0)
@@ -2016,10 +1998,8 @@ isis_config_write (struct vty *vty)
 	    struct area_addr *area_addr;
 	    for (ALL_LIST_ELEMENTS_RO (area->area_addrs, node2, area_addr))
 	      {
-		vty_out (vty, " net %s%s",
-			 isonet_print (area_addr->area_addr,
-				       area_addr->addr_len + ISIS_SYS_ID_LEN +
-				       1), VTY_NEWLINE);
+		vty_outln (vty, " net %s",
+			 isonet_print(area_addr->area_addr, area_addr->addr_len + ISIS_SYS_ID_LEN + 1));
 		write++;
 	      }
 	  }
@@ -2027,38 +2007,38 @@ isis_config_write (struct vty *vty)
 	 * false. */
 	if (!area->dynhostname)
 	  {
-	    vty_out (vty, " no hostname dynamic%s", VTY_NEWLINE);
+	    vty_outln (vty, " no hostname dynamic");
 	    write++;
 	  }
 	/* ISIS - Metric-Style - when true displays wide */
 	if (area->newmetric)
 	  {
 	    if (!area->oldmetric)
-	      vty_out (vty, " metric-style wide%s", VTY_NEWLINE);
+	      vty_outln (vty, " metric-style wide");
 	    else
-	      vty_out (vty, " metric-style transition%s", VTY_NEWLINE);
+	      vty_outln (vty, " metric-style transition");
 	    write++;
 	  }
 	else
 	  {
-	    vty_out (vty, " metric-style narrow%s", VTY_NEWLINE);
+	    vty_outln (vty, " metric-style narrow");
 	    write++;
 	  }
 	/* ISIS - overload-bit */
 	if (area->overload_bit)
 	  {
-	    vty_out (vty, " set-overload-bit%s", VTY_NEWLINE);
+	    vty_outln (vty, " set-overload-bit");
 	    write++;
 	  }
 	/* ISIS - Area is-type (level-1-2 is default) */
 	if (area->is_type == IS_LEVEL_1)
 	  {
-	    vty_out (vty, " is-type level-1%s", VTY_NEWLINE);
+	    vty_outln (vty, " is-type level-1");
 	    write++;
 	  }
 	else if (area->is_type == IS_LEVEL_2)
 	  {
-	    vty_out (vty, " is-type level-2-only%s", VTY_NEWLINE);
+	    vty_outln (vty, " is-type level-2-only");
 	    write++;
 	  }
 	write += isis_redist_config_write(vty, area, AF_INET);
@@ -2068,8 +2048,8 @@ isis_config_write (struct vty *vty)
 	  {
 	    if (area->lsp_gen_interval[0] != DEFAULT_MIN_LSP_GEN_INTERVAL)
 	      {
-		vty_out (vty, " lsp-gen-interval %d%s",
-			 area->lsp_gen_interval[0], VTY_NEWLINE);
+		vty_outln (vty, " lsp-gen-interval %d",
+			 area->lsp_gen_interval[0]);
 		write++;
 	      }
 	  }
@@ -2077,14 +2057,14 @@ isis_config_write (struct vty *vty)
 	  {
 	    if (area->lsp_gen_interval[0] != DEFAULT_MIN_LSP_GEN_INTERVAL)
 	      {
-		vty_out (vty, " lsp-gen-interval level-1 %d%s",
-			 area->lsp_gen_interval[0], VTY_NEWLINE);
+		vty_outln (vty, " lsp-gen-interval level-1 %d",
+			 area->lsp_gen_interval[0]);
 		write++;
 	      }
 	    if (area->lsp_gen_interval[1] != DEFAULT_MIN_LSP_GEN_INTERVAL)
 	      {
-		vty_out (vty, " lsp-gen-interval level-2 %d%s",
-			 area->lsp_gen_interval[1], VTY_NEWLINE);
+		vty_outln (vty, " lsp-gen-interval level-2 %d",
+			 area->lsp_gen_interval[1]);
 		write++;
 	      }
 	  }
@@ -2093,8 +2073,8 @@ isis_config_write (struct vty *vty)
 	  {
 	    if (area->max_lsp_lifetime[0] != DEFAULT_LSP_LIFETIME)
 	      {
-		vty_out (vty, " max-lsp-lifetime %u%s", area->max_lsp_lifetime[0],
-			 VTY_NEWLINE);
+		vty_outln (vty, " max-lsp-lifetime %u",
+                           area->max_lsp_lifetime[0]);
 		write++;
 	      }
 	  }
@@ -2102,14 +2082,14 @@ isis_config_write (struct vty *vty)
 	  {
 	    if (area->max_lsp_lifetime[0] != DEFAULT_LSP_LIFETIME)
 	      {
-		vty_out (vty, " max-lsp-lifetime level-1 %u%s",
-			 area->max_lsp_lifetime[0], VTY_NEWLINE);
+		vty_outln (vty, " max-lsp-lifetime level-1 %u",
+			 area->max_lsp_lifetime[0]);
 		write++;
 	      }
 	    if (area->max_lsp_lifetime[1] != DEFAULT_LSP_LIFETIME)
 	      {
-		vty_out (vty, " max-lsp-lifetime level-2 %u%s",
-			 area->max_lsp_lifetime[1], VTY_NEWLINE);
+		vty_outln (vty, " max-lsp-lifetime level-2 %u",
+			 area->max_lsp_lifetime[1]);
 		write++;
 	      }
 	  }
@@ -2118,8 +2098,8 @@ isis_config_write (struct vty *vty)
 	  {
 	    if (area->lsp_refresh[0] != DEFAULT_MAX_LSP_GEN_INTERVAL)
 	      {
-		vty_out (vty, " lsp-refresh-interval %u%s", area->lsp_refresh[0],
-			 VTY_NEWLINE);
+		vty_outln (vty, " lsp-refresh-interval %u",
+                           area->lsp_refresh[0]);
 		write++;
 	      }
 	  }
@@ -2127,20 +2107,20 @@ isis_config_write (struct vty *vty)
 	  {
 	    if (area->lsp_refresh[0] != DEFAULT_MAX_LSP_GEN_INTERVAL)
 	      {
-		vty_out (vty, " lsp-refresh-interval level-1 %u%s",
-			 area->lsp_refresh[0], VTY_NEWLINE);
+		vty_outln (vty, " lsp-refresh-interval level-1 %u",
+			 area->lsp_refresh[0]);
 		write++;
 	      }
 	    if (area->lsp_refresh[1] != DEFAULT_MAX_LSP_GEN_INTERVAL)
 	      {
-		vty_out (vty, " lsp-refresh-interval level-2 %u%s",
-			 area->lsp_refresh[1], VTY_NEWLINE);
+		vty_outln (vty, " lsp-refresh-interval level-2 %u",
+			 area->lsp_refresh[1]);
 		write++;
 	      }
 	  }
 	if (area->lsp_mtu != DEFAULT_LSP_MTU)
 	  {
-	    vty_out(vty, " lsp-mtu %u%s", area->lsp_mtu, VTY_NEWLINE);
+	    vty_outln (vty, " lsp-mtu %u", area->lsp_mtu);
 	    write++;
 	  }
 
@@ -2149,8 +2129,8 @@ isis_config_write (struct vty *vty)
 	  {
 	    if (area->min_spf_interval[0] != MINIMUM_SPF_INTERVAL)
 	      {
-		vty_out (vty, " spf-interval %d%s",
-			 area->min_spf_interval[0], VTY_NEWLINE);
+		vty_outln (vty, " spf-interval %d",
+			 area->min_spf_interval[0]);
 		write++;
 	      }
 	  }
@@ -2158,14 +2138,14 @@ isis_config_write (struct vty *vty)
 	  {
 	    if (area->min_spf_interval[0] != MINIMUM_SPF_INTERVAL)
 	      {
-		vty_out (vty, " spf-interval level-1 %d%s",
-			 area->min_spf_interval[0], VTY_NEWLINE);
+		vty_outln (vty, " spf-interval level-1 %d",
+			 area->min_spf_interval[0]);
 		write++;
 	      }
 	    if (area->min_spf_interval[1] != MINIMUM_SPF_INTERVAL)
 	      {
-		vty_out (vty, " spf-interval level-2 %d%s",
-			 area->min_spf_interval[1], VTY_NEWLINE);
+		vty_outln (vty, " spf-interval level-2 %d",
+			 area->min_spf_interval[1]);
 		write++;
 	      }
 	  }
@@ -2173,13 +2153,12 @@ isis_config_write (struct vty *vty)
 	/* IETF SPF interval */
 	if (area->spf_delay_ietf[0])
 	  {
-	    vty_out (vty, " spf-delay-ietf init-delay %ld short-delay %ld long-delay %ld holddown %ld time-to-learn %ld%s",
+	    vty_outln (vty, " spf-delay-ietf init-delay %ld short-delay %ld long-delay %ld holddown %ld time-to-learn %ld",
 	             spf_backoff_init_delay(area->spf_delay_ietf[0]),
 	             spf_backoff_short_delay(area->spf_delay_ietf[0]),
 	             spf_backoff_long_delay(area->spf_delay_ietf[0]),
 	             spf_backoff_holddown(area->spf_delay_ietf[0]),
-	             spf_backoff_timetolearn(area->spf_delay_ietf[0]),
-	             VTY_NEWLINE);
+	             spf_backoff_timetolearn(area->spf_delay_ietf[0]));
 	    write++;
 	  }
 
@@ -2195,7 +2174,7 @@ isis_config_write (struct vty *vty)
 		else
 		  vty_out(vty, "send-only");
 	      }
-	    vty_out(vty, "%s", VTY_NEWLINE);
+	    vty_outln (vty, "");
 	    write++; 
 	  }
         else if (area->area_passwd.type == ISIS_PASSWD_TYPE_CLEARTXT)
@@ -2209,7 +2188,7 @@ isis_config_write (struct vty *vty)
 		else
 		  vty_out(vty, "send-only");
 	      }
-	    vty_out(vty, "%s", VTY_NEWLINE);
+	    vty_outln (vty, "");
 	    write++; 
           }
 	if (area->domain_passwd.type == ISIS_PASSWD_TYPE_HMAC_MD5)
@@ -2224,7 +2203,7 @@ isis_config_write (struct vty *vty)
 		else
 		  vty_out(vty, "send-only");
 	      }
-	    vty_out(vty, "%s", VTY_NEWLINE);
+	    vty_outln (vty, "");
 	    write++;
 	  }
         else if (area->domain_passwd.type == ISIS_PASSWD_TYPE_CLEARTXT)
@@ -2239,13 +2218,13 @@ isis_config_write (struct vty *vty)
 		else
 		  vty_out(vty, "send-only");
 	      }
-	    vty_out(vty, "%s", VTY_NEWLINE);
+	    vty_outln (vty, "");
 	    write++;
 	  }
 
 	if (area->log_adj_changes)
 	  {
-	    vty_out (vty, " log-adjacency-changes%s", VTY_NEWLINE);
+	    vty_outln (vty, " log-adjacency-changes");
 	    write++;
 	  }
 

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -1561,7 +1561,7 @@ show_isis_database (struct vty *vty, const char *argv, int ui_level)
                                              area->dynhostname);
 
                   vty_outln (vty, "    %u LSPs%s",
-                           lsp_count, VTY_NEWLINE);
+                           lsp_count, VTYNL);
                 }
             }
         }

--- a/ldpd/ldp_debug.c
+++ b/ldpd/ldp_debug.c
@@ -105,33 +105,29 @@ ldp_vty_debug(struct vty *vty, int disable, const char *type_str,
 int
 ldp_vty_show_debugging(struct vty *vty)
 {
-	vty_out(vty, "LDP debugging status:%s", VTY_NEWLINE);
+	vty_outln (vty, "LDP debugging status:");
 
 	if (LDP_DEBUG(hello, HELLO_RECV))
-		vty_out(vty, "  LDP discovery debugging is on (inbound)%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,"  LDP discovery debugging is on (inbound)");
 	if (LDP_DEBUG(hello, HELLO_SEND))
-		vty_out(vty, "  LDP discovery debugging is on (outbound)%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,"  LDP discovery debugging is on (outbound)");
 	if (LDP_DEBUG(errors, ERRORS))
-		vty_out(vty, "  LDP errors debugging is on%s", VTY_NEWLINE);
+		vty_outln (vty, "  LDP errors debugging is on");
 	if (LDP_DEBUG(event, EVENT))
-		vty_out(vty, "  LDP events debugging is on%s", VTY_NEWLINE);
+		vty_outln (vty, "  LDP events debugging is on");
 	if (LDP_DEBUG(msg, MSG_RECV_ALL))
-		vty_out(vty, "  LDP detailed messages debugging is on "
-		    "(inbound)%s", VTY_NEWLINE);
+		vty_outln (vty,
+			  "  LDP detailed messages debugging is on " "(inbound)");
 	else if (LDP_DEBUG(msg, MSG_RECV))
-		vty_out(vty, "  LDP messages debugging is on (inbound)%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,"  LDP messages debugging is on (inbound)");
 	if (LDP_DEBUG(msg, MSG_SEND_ALL))
-		vty_out(vty, "  LDP detailed messages debugging is on "
-		    "(outbound)%s", VTY_NEWLINE);
+		vty_outln (vty,
+			  "  LDP detailed messages debugging is on " "(outbound)");
 	else if (LDP_DEBUG(msg, MSG_SEND))
-		vty_out(vty, "  LDP messages debugging is on (outbound)%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,"  LDP messages debugging is on (outbound)");
 	if (LDP_DEBUG(zebra, ZEBRA))
-		vty_out(vty, "  LDP zebra debugging is on%s", VTY_NEWLINE);
-	vty_out (vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "  LDP zebra debugging is on");
+	vty_outln (vty, "");
 
 	return (CMD_SUCCESS);
 }
@@ -142,45 +138,43 @@ ldp_debug_config_write(struct vty *vty)
 	int write = 0;
 
 	if (CONF_LDP_DEBUG(hello, HELLO_RECV)) {
-		vty_out(vty, "debug mpls ldp discovery hello recv%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,"debug mpls ldp discovery hello recv");
 		write = 1;
 	}
 
 	if (CONF_LDP_DEBUG(hello, HELLO_SEND)) {
-		vty_out(vty, "debug mpls ldp discovery hello sent%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,"debug mpls ldp discovery hello sent");
 		write = 1;
 	}
 
 	if (CONF_LDP_DEBUG(errors, ERRORS)) {
-		vty_out(vty, "debug mpls ldp errors%s", VTY_NEWLINE);
+		vty_outln (vty, "debug mpls ldp errors");
 		write = 1;
 	}
 
 	if (CONF_LDP_DEBUG(event, EVENT)) {
-		vty_out(vty, "debug mpls ldp event%s", VTY_NEWLINE);
+		vty_outln (vty, "debug mpls ldp event");
 		write = 1;
 	}
 
 	if (CONF_LDP_DEBUG(msg, MSG_RECV_ALL)) {
-		vty_out(vty, "debug mpls ldp messages recv all%s", VTY_NEWLINE);
+		vty_outln (vty, "debug mpls ldp messages recv all");
 		write = 1;
 	} else if (CONF_LDP_DEBUG(msg, MSG_RECV)) {
-		vty_out(vty, "debug mpls ldp messages recv%s", VTY_NEWLINE);
+		vty_outln (vty, "debug mpls ldp messages recv");
 		write = 1;
 	}
 
 	if (CONF_LDP_DEBUG(msg, MSG_SEND_ALL)) {
-		vty_out(vty, "debug mpls ldp messages sent all%s", VTY_NEWLINE);
+		vty_outln (vty, "debug mpls ldp messages sent all");
 		write = 1;
 	} else if (CONF_LDP_DEBUG(msg, MSG_SEND)) {
-		vty_out(vty, "debug mpls ldp messages sent%s", VTY_NEWLINE);
+		vty_outln (vty, "debug mpls ldp messages sent");
 		write = 1;
 	}
 
 	if (CONF_LDP_DEBUG(zebra, ZEBRA)) {
-		vty_out(vty, "debug mpls ldp zebra%s", VTY_NEWLINE);
+		vty_outln (vty, "debug mpls ldp zebra");
 		write = 1;
 	}
 

--- a/ldpd/ldp_debug.c
+++ b/ldpd/ldp_debug.c
@@ -127,7 +127,7 @@ ldp_vty_show_debugging(struct vty *vty)
 		vty_outln (vty,"  LDP messages debugging is on (outbound)");
 	if (LDP_DEBUG(zebra, ZEBRA))
 		vty_outln (vty, "  LDP zebra debugging is on");
-	vty_outln (vty, "");
+	vty_out (vty, VTYNL);
 
 	return (CMD_SUCCESS);
 }

--- a/ldpd/ldp_vty_conf.c
+++ b/ldpd/ldp_vty_conf.c
@@ -155,7 +155,7 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 		if (af_conf->acl_thello_accept_from[0] != '\0')
 			vty_out(vty, " from %s",
 			    af_conf->acl_thello_accept_from);
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 	}
 
 	if (af_conf->thello_holdtime != TARGETED_DFLT_HOLDTIME &&
@@ -182,7 +182,7 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 		else
 			vty_out(vty, " for %s",
 			    af_conf->acl_label_allocate_for);
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 	}
 
 	if (af_conf->acl_label_advertise_for[0] != '\0' ||
@@ -194,7 +194,7 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 		if (af_conf->acl_label_advertise_for[0] != '\0')
 			vty_out(vty, " for %s",
 			    af_conf->acl_label_advertise_for);
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 	}
 
 	if (af_conf->flags & F_LDPD_AF_EXPNULL) {
@@ -202,7 +202,7 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 		if (af_conf->acl_label_expnull_for[0] != '\0')
 			vty_out(vty, " for %s",
 			    af_conf->acl_label_expnull_for);
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 	}
 
 	if (af_conf->acl_label_accept_for[0] != '\0' ||
@@ -214,7 +214,7 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 		if (af_conf->acl_label_accept_for[0] != '\0')
 			vty_out(vty, " for %s",
 			    af_conf->acl_label_accept_for);
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 	}
 
 	if (af_conf->flags & F_LDPD_AF_NO_GTSM)

--- a/ldpd/ldp_vty_conf.c
+++ b/ldpd/ldp_vty_conf.c
@@ -115,17 +115,17 @@ ldp_af_iface_config_write(struct vty *vty, int af)
 		if (!ia->enabled)
 			continue;
 
-		vty_out(vty, "  !%s", VTY_NEWLINE);
-		vty_out(vty, "  interface %s%s", iface->name, VTY_NEWLINE);
+		vty_outln (vty, "  !");
+		vty_outln (vty, "  interface %s", iface->name);
 
 		if (ia->hello_holdtime != LINK_DFLT_HOLDTIME &&
 		    ia->hello_holdtime != 0)
-			vty_out(vty, "   discovery hello holdtime %u%s",
-			    ia->hello_holdtime, VTY_NEWLINE);
+			vty_outln (vty, "   discovery hello holdtime %u",
+			    ia->hello_holdtime);
 		if (ia->hello_interval != DEFAULT_HELLO_INTERVAL &&
 		    ia->hello_interval != 0)
-			vty_out(vty, "   discovery hello interval %u%s",
-			    ia->hello_interval, VTY_NEWLINE);
+			vty_outln (vty, "   discovery hello interval %u",
+			    ia->hello_interval);
 	}
 }
 
@@ -138,41 +138,41 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 	if (!(af_conf->flags & F_LDPD_AF_ENABLED))
 		return;
 
-	vty_out(vty, " !%s", VTY_NEWLINE);
-	vty_out(vty, " address-family %s%s", af_name(af), VTY_NEWLINE);
+	vty_outln (vty, " !");
+	vty_outln (vty, " address-family %s", af_name(af));
 
 	if (af_conf->lhello_holdtime != LINK_DFLT_HOLDTIME &&
 	    af_conf->lhello_holdtime != 0 )
-		vty_out(vty, "  discovery hello holdtime %u%s",
-		    af_conf->lhello_holdtime, VTY_NEWLINE);
+		vty_outln (vty, "  discovery hello holdtime %u",
+		    af_conf->lhello_holdtime);
 	if (af_conf->lhello_interval != DEFAULT_HELLO_INTERVAL &&
 	    af_conf->lhello_interval != 0)
-		vty_out(vty, "  discovery hello interval %u%s",
-		    af_conf->lhello_interval, VTY_NEWLINE);
+		vty_outln (vty, "  discovery hello interval %u",
+		    af_conf->lhello_interval);
 
 	if (af_conf->flags & F_LDPD_AF_THELLO_ACCEPT) {
 		vty_out(vty, "  discovery targeted-hello accept");
 		if (af_conf->acl_thello_accept_from[0] != '\0')
 			vty_out(vty, " from %s",
 			    af_conf->acl_thello_accept_from);
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 	}
 
 	if (af_conf->thello_holdtime != TARGETED_DFLT_HOLDTIME &&
 	    af_conf->thello_holdtime != 0)
-		vty_out(vty, "  discovery targeted-hello holdtime %u%s",
-		    af_conf->thello_holdtime, VTY_NEWLINE);
+		vty_outln (vty, "  discovery targeted-hello holdtime %u",
+		    af_conf->thello_holdtime);
 	if (af_conf->thello_interval != DEFAULT_HELLO_INTERVAL &&
 	    af_conf->thello_interval != 0)
-		vty_out(vty, "  discovery targeted-hello interval %u%s",
-		    af_conf->thello_interval, VTY_NEWLINE);
+		vty_outln (vty, "  discovery targeted-hello interval %u",
+		    af_conf->thello_interval);
 
 	if (ldp_addrisset(af, &af_conf->trans_addr))
-		vty_out(vty, "  discovery transport-address %s%s",
-		    log_addr(af, &af_conf->trans_addr), VTY_NEWLINE);
-	else
-		vty_out(vty, "  ! Incomplete config, specify a discovery "
-		    "transport-address%s", VTY_NEWLINE);
+		vty_outln (vty, "  discovery transport-address %s",
+		    log_addr(af, &af_conf->trans_addr));
+		else
+			vty_outln (vty,
+				  "  ! Incomplete config, specify a discovery " "transport-address");
 
 	if ((af_conf->flags & F_LDPD_AF_ALLOCHOSTONLY) ||
 	    af_conf->acl_label_allocate_for[0] != '\0') {
@@ -182,7 +182,7 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 		else
 			vty_out(vty, " for %s",
 			    af_conf->acl_label_allocate_for);
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 	}
 
 	if (af_conf->acl_label_advertise_for[0] != '\0' ||
@@ -194,7 +194,7 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 		if (af_conf->acl_label_advertise_for[0] != '\0')
 			vty_out(vty, " for %s",
 			    af_conf->acl_label_advertise_for);
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 	}
 
 	if (af_conf->flags & F_LDPD_AF_EXPNULL) {
@@ -202,7 +202,7 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 		if (af_conf->acl_label_expnull_for[0] != '\0')
 			vty_out(vty, " for %s",
 			    af_conf->acl_label_expnull_for);
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 	}
 
 	if (af_conf->acl_label_accept_for[0] != '\0' ||
@@ -214,27 +214,26 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 		if (af_conf->acl_label_accept_for[0] != '\0')
 			vty_out(vty, " for %s",
 			    af_conf->acl_label_accept_for);
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 	}
 
 	if (af_conf->flags & F_LDPD_AF_NO_GTSM)
-		vty_out(vty, "  ttl-security disable%s", VTY_NEWLINE);
+		vty_outln (vty, "  ttl-security disable");
 
 	if (af_conf->keepalive != DEFAULT_KEEPALIVE)
-		vty_out(vty, "  session holdtime %u%s", af_conf->keepalive,
-		    VTY_NEWLINE);
+		vty_outln (vty, "  session holdtime %u",af_conf->keepalive);
 
 	RB_FOREACH(tnbr, tnbr_head, &ldpd_conf->tnbr_tree) {
 		if (tnbr->af == af) {
-			vty_out(vty, "  !%s", VTY_NEWLINE);
-			vty_out(vty, "  neighbor %s targeted%s",
-			    log_addr(tnbr->af, &tnbr->addr), VTY_NEWLINE);
+			vty_outln (vty, "  !");
+			vty_outln (vty, "  neighbor %s targeted",
+			    log_addr(tnbr->af, &tnbr->addr));
 		}
 	}
 
 	ldp_af_iface_config_write(vty, af);
 
-	vty_out(vty, "  !%s", VTY_NEWLINE);
+	vty_outln (vty, "  !");
 }
 
 int
@@ -245,64 +244,61 @@ ldp_config_write(struct vty *vty)
 	if (!(ldpd_conf->flags & F_LDPD_ENABLED))
 		return (0);
 
-	vty_out(vty, "mpls ldp%s", VTY_NEWLINE);
+	vty_outln (vty, "mpls ldp");
 
 	if (ldpd_conf->rtr_id.s_addr != 0)
-		vty_out(vty, " router-id %s%s",
-		    inet_ntoa(ldpd_conf->rtr_id), VTY_NEWLINE);
+		vty_outln (vty, " router-id %s",
+		    inet_ntoa(ldpd_conf->rtr_id));
 
 	if (ldpd_conf->lhello_holdtime != LINK_DFLT_HOLDTIME &&
 	    ldpd_conf->lhello_holdtime != 0)
-		vty_out(vty, " discovery hello holdtime %u%s",
-		    ldpd_conf->lhello_holdtime, VTY_NEWLINE);
+		vty_outln (vty, " discovery hello holdtime %u",
+		    ldpd_conf->lhello_holdtime);
 	if (ldpd_conf->lhello_interval != DEFAULT_HELLO_INTERVAL &&
 	    ldpd_conf->lhello_interval != 0)
-		vty_out(vty, " discovery hello interval %u%s",
-		    ldpd_conf->lhello_interval, VTY_NEWLINE);
+		vty_outln (vty, " discovery hello interval %u",
+		    ldpd_conf->lhello_interval);
 
 	if (ldpd_conf->thello_holdtime != TARGETED_DFLT_HOLDTIME &&
 	    ldpd_conf->thello_holdtime != 0)
-		vty_out(vty, " discovery targeted-hello holdtime %u%s",
-		    ldpd_conf->thello_holdtime, VTY_NEWLINE);
+		vty_outln (vty, " discovery targeted-hello holdtime %u",
+		    ldpd_conf->thello_holdtime);
 	if (ldpd_conf->thello_interval != DEFAULT_HELLO_INTERVAL &&
 	    ldpd_conf->thello_interval != 0)
-		vty_out(vty, " discovery targeted-hello interval %u%s",
-		    ldpd_conf->thello_interval, VTY_NEWLINE);
+		vty_outln (vty, " discovery targeted-hello interval %u",
+		    ldpd_conf->thello_interval);
 
 	if (ldpd_conf->trans_pref == DUAL_STACK_LDPOV4)
-		vty_out(vty, " dual-stack transport-connection prefer ipv4%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,
+			  " dual-stack transport-connection prefer ipv4");
 
 	if (ldpd_conf->flags & F_LDPD_DS_CISCO_INTEROP)
-		vty_out(vty, " dual-stack cisco-interop%s", VTY_NEWLINE);
+		vty_outln (vty, " dual-stack cisco-interop");
 
 	RB_FOREACH(nbrp, nbrp_head, &ldpd_conf->nbrp_tree) {
 		if (nbrp->flags & F_NBRP_KEEPALIVE)
-			vty_out(vty, " neighbor %s session holdtime %u%s",
-			    inet_ntoa(nbrp->lsr_id), nbrp->keepalive,
-			    VTY_NEWLINE);
+			vty_outln (vty, " neighbor %s session holdtime %u",
+			    inet_ntoa(nbrp->lsr_id),nbrp->keepalive);
 
 		if (nbrp->flags & F_NBRP_GTSM) {
 			if (nbrp->gtsm_enabled)
-				vty_out(vty, " neighbor %s ttl-security hops "
-				    "%u%s",  inet_ntoa(nbrp->lsr_id),
-				    nbrp->gtsm_hops, VTY_NEWLINE);
+				vty_outln (vty, " neighbor %s ttl-security hops "
+				    "%u",  inet_ntoa(nbrp->lsr_id),
+				    nbrp->gtsm_hops);
 			else
-				vty_out(vty, " neighbor %s ttl-security "
-				    "disable%s", inet_ntoa(nbrp->lsr_id),
-				    VTY_NEWLINE);
+				vty_outln (vty, " neighbor %s ttl-security "
+				    "disable",inet_ntoa(nbrp->lsr_id));
 		}
 
 		if (nbrp->auth.method == AUTH_MD5SIG)
-			vty_out(vty, " neighbor %s password %s%s",
-			    inet_ntoa(nbrp->lsr_id), nbrp->auth.md5key,
-			    VTY_NEWLINE);
+			vty_outln (vty, " neighbor %s password %s",
+			    inet_ntoa(nbrp->lsr_id),nbrp->auth.md5key);
 	}
 
 	ldp_af_config_write(vty, AF_INET, ldpd_conf, &ldpd_conf->ipv4);
 	ldp_af_config_write(vty, AF_INET6, ldpd_conf, &ldpd_conf->ipv6);
-	vty_out(vty, " !%s", VTY_NEWLINE);
-	vty_out(vty, "!%s", VTY_NEWLINE);
+	vty_outln (vty, " !");
+	vty_outln (vty, "!");
 
 	return (1);
 }
@@ -313,36 +309,34 @@ ldp_l2vpn_pw_config_write(struct vty *vty, struct l2vpn_pw *pw)
 	int	 missing_lsrid = 0;
 	int	 missing_pwid = 0;
 
-	vty_out(vty, " !%s", VTY_NEWLINE);
-	vty_out(vty, " member pseudowire %s%s", pw->ifname, VTY_NEWLINE);
+	vty_outln (vty, " !");
+	vty_outln (vty, " member pseudowire %s", pw->ifname);
 
 	if (pw->lsr_id.s_addr != INADDR_ANY)
-		vty_out(vty, "  neighbor lsr-id %s%s", inet_ntoa(pw->lsr_id),
-		    VTY_NEWLINE);
-	else
-		missing_lsrid = 1;
+		vty_outln (vty, "  neighbor lsr-id %s",inet_ntoa(pw->lsr_id));
+		else
+			missing_lsrid = 1;
 
 	if (pw->flags & F_PW_STATIC_NBR_ADDR)
-		vty_out(vty, "  neighbor address %s%s", log_addr(pw->af,
-		    &pw->addr), VTY_NEWLINE);
+		vty_outln (vty, "  neighbor address %s",
+		          log_addr(pw->af, &pw->addr));
 
 	if (pw->pwid != 0)
-		vty_out(vty, "  pw-id %u%s", pw->pwid, VTY_NEWLINE);
+		vty_outln (vty, "  pw-id %u", pw->pwid);
 	else
 		missing_pwid = 1;
 
 	if (!(pw->flags & F_PW_CWORD_CONF))
-		vty_out(vty, "  control-word exclude%s", VTY_NEWLINE);
+		vty_outln (vty, "  control-word exclude");
 
 	if (!(pw->flags & F_PW_STATUSTLV_CONF))
-		vty_out(vty, "  pw-status disable%s", VTY_NEWLINE);
+		vty_outln (vty, "  pw-status disable");
 
 	if (missing_lsrid)
-		vty_out(vty, "  ! Incomplete config, specify a neighbor "
-		    "lsr-id%s", VTY_NEWLINE);
+		vty_outln (vty,
+		          "  ! Incomplete config, specify a neighbor " "lsr-id");
 	if (missing_pwid)
-		vty_out(vty, "  ! Incomplete config, specify a pw-id%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,"  ! Incomplete config, specify a pw-id");
 }
 
 int
@@ -353,29 +347,27 @@ ldp_l2vpn_config_write(struct vty *vty)
 	struct l2vpn_pw		*pw;
 
 	RB_FOREACH(l2vpn, l2vpn_head, &ldpd_conf->l2vpn_tree) {
-		vty_out(vty, "l2vpn %s type vpls%s", l2vpn->name, VTY_NEWLINE);
+		vty_outln (vty, "l2vpn %s type vpls", l2vpn->name);
 
 		if (l2vpn->pw_type != DEFAULT_PW_TYPE)
-			vty_out(vty, " vc type ethernet-tagged%s", VTY_NEWLINE);
+			vty_outln (vty, " vc type ethernet-tagged");
 
 		if (l2vpn->mtu != DEFAULT_L2VPN_MTU)
-			vty_out(vty, " mtu %u%s", l2vpn->mtu, VTY_NEWLINE);
+			vty_outln (vty, " mtu %u", l2vpn->mtu);
 
 		if (l2vpn->br_ifname[0] != '\0')
-			vty_out(vty, " bridge %s%s", l2vpn->br_ifname,
-			    VTY_NEWLINE);
+			vty_outln (vty, " bridge %s",l2vpn->br_ifname);
 
 		RB_FOREACH(lif, l2vpn_if_head, &l2vpn->if_tree)
-			vty_out(vty, " member interface %s%s", lif->ifname,
-			    VTY_NEWLINE);
+			vty_outln (vty, " member interface %s",lif->ifname);
 
 		RB_FOREACH(pw, l2vpn_pw_head, &l2vpn->pw_tree)
 			ldp_l2vpn_pw_config_write(vty, pw);
 		RB_FOREACH(pw, l2vpn_pw_head, &l2vpn->pw_inactive_tree)
 			ldp_l2vpn_pw_config_write(vty, pw);
 
-		vty_out(vty, " !%s", VTY_NEWLINE);
-		vty_out(vty, "!%s", VTY_NEWLINE);
+		vty_outln (vty, " !");
+		vty_outln (vty, "!");
 	}
 
 	return (0);
@@ -481,7 +473,7 @@ ldp_vty_disc_holdtime(struct vty *vty, int disable, const char *hello_type_str,
 
 	secs = strtol(seconds_str, &ep, 10);
 	if (*ep != '\0' || secs < MIN_HOLDTIME || secs > MAX_HOLDTIME) {
-		vty_out(vty, "%% Invalid holdtime%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Invalid holdtime");
 		return (CMD_WARNING);
 	}
 
@@ -576,7 +568,7 @@ ldp_vty_disc_interval(struct vty *vty, int disable, const char *hello_type_str,
 	secs = strtol(seconds_str, &ep, 10);
 	if (*ep != '\0' || secs < MIN_HELLO_INTERVAL ||
 	    secs > MAX_HELLO_INTERVAL) {
-		vty_out(vty, "%% Invalid interval%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Invalid interval");
 		return (CMD_WARNING);
 	}
 
@@ -694,13 +686,13 @@ ldp_vty_nbr_session_holdtime(struct vty *vty, int disable,
 
 	if (inet_pton(AF_INET, lsr_id_str, &lsr_id) != 1 ||
 	    bad_addr_v4(lsr_id)) {
-		vty_out(vty, "%% Malformed address%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed address");
 		return (CMD_WARNING);
 	}
 
 	secs = strtol(seconds_str, &ep, 10);
 	if (*ep != '\0' || secs < MIN_KEEPALIVE || secs > MAX_KEEPALIVE) {
-		vty_out(vty, "%% Invalid holdtime%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Invalid holdtime");
 		return (CMD_SUCCESS);
 	}
 
@@ -740,7 +732,7 @@ ldp_vty_af_session_holdtime(struct vty *vty, int disable,
 
 	secs = strtol(seconds_str, &ep, 10);
 	if (*ep != '\0' || secs < MIN_KEEPALIVE || secs > MAX_KEEPALIVE) {
-		vty_out(vty, "%% Invalid holdtime%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Invalid holdtime");
 		return (CMD_SUCCESS);
 	}
 
@@ -786,8 +778,7 @@ ldp_vty_interface(struct vty *vty, int disable, const char *ifname)
 
 	if (iface == NULL) {
 		if (ldp_iface_is_configured(vty_conf, ifname)) {
-			vty_out(vty, "%% Interface is already in use%s",
-			    VTY_NEWLINE);
+			vty_outln (vty,"%% Interface is already in use");
 			return (CMD_SUCCESS);
 		}
 
@@ -834,7 +825,7 @@ ldp_vty_trans_addr(struct vty *vty, int disable, const char *addr_str)
 	else {
 		if (inet_pton(af, addr_str, &af_conf->trans_addr) != 1 ||
 		    bad_addr(af, &af_conf->trans_addr)) {
-			vty_out(vty, "%% Malformed address%s", VTY_NEWLINE);
+			vty_outln (vty, "%% Malformed address");
 			return (CMD_SUCCESS);
 		}
 	}
@@ -855,11 +846,11 @@ ldp_vty_neighbor_targeted(struct vty *vty, int disable, const char *addr_str)
 
 	if (inet_pton(af, addr_str, &addr) != 1 ||
 	    bad_addr(af, &addr)) {
-		vty_out(vty, "%% Malformed address%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed address");
 		return (CMD_WARNING);
 	}
 	if (af == AF_INET6 && IN6_IS_SCOPE_EMBED(&addr.v6)) {
-		vty_out(vty, "%% Address can not be link-local%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Address can not be link-local");
 		return (CMD_WARNING);
 	}
 
@@ -1031,7 +1022,7 @@ ldp_vty_router_id(struct vty *vty, int disable, const char *addr_str)
 	else {
 		if (inet_pton(AF_INET, addr_str, &vty_conf->rtr_id) != 1 ||
 		    bad_addr_v4(vty_conf->rtr_id)) {
-			vty_out(vty, "%% Malformed address%s", VTY_NEWLINE);
+			vty_outln (vty, "%% Malformed address");
 			return (CMD_SUCCESS);
 		}
 	}
@@ -1077,7 +1068,7 @@ ldp_vty_neighbor_password(struct vty *vty, int disable, const char *lsr_id_str,
 
 	if (inet_pton(AF_INET, lsr_id_str, &lsr_id) != 1 ||
 	    bad_addr_v4(lsr_id)) {
-		vty_out(vty, "%% Malformed address%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed address");
 		return (CMD_WARNING);
 	}
 
@@ -1123,14 +1114,14 @@ ldp_vty_neighbor_ttl_security(struct vty *vty, int disable,
 
 	if (inet_pton(AF_INET, lsr_id_str, &lsr_id) != 1 ||
 	    bad_addr_v4(lsr_id)) {
-		vty_out(vty, "%% Malformed address%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed address");
 		return (CMD_WARNING);
 	}
 
 	if (hops_str) {
 		hops = strtol(hops_str, &ep, 10);
 		if (*ep != '\0' || hops < 1 || hops > 254) {
-			vty_out(vty, "%% Invalid hop count%s", VTY_NEWLINE);
+			vty_outln (vty, "%% Invalid hop count");
 			return (CMD_SUCCESS);
 		}
 	}
@@ -1235,7 +1226,7 @@ ldp_vty_l2vpn_mtu(struct vty *vty, int disable, const char *mtu_str)
 
 	mtu = strtol(mtu_str, &ep, 10);
 	if (*ep != '\0' || mtu < MIN_L2VPN_MTU || mtu > MAX_L2VPN_MTU) {
-		vty_out(vty, "%% Invalid MTU%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Invalid MTU");
 		return (CMD_WARNING);
 	}
 
@@ -1295,7 +1286,7 @@ ldp_vty_l2vpn_interface(struct vty *vty, int disable, const char *ifname)
 		return (CMD_SUCCESS);
 
 	if (ldp_iface_is_configured(vty_conf, ifname)) {
-		vty_out(vty, "%% Interface is already in use%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Interface is already in use");
 		return (CMD_SUCCESS);
 	}
 
@@ -1338,7 +1329,7 @@ ldp_vty_l2vpn_pseudowire(struct vty *vty, int disable, const char *ifname)
 	}
 
 	if (ldp_iface_is_configured(vty_conf, ifname)) {
-		vty_out(vty, "%% Interface is already in use%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Interface is already in use");
 		return (CMD_SUCCESS);
 	}
 
@@ -1382,7 +1373,7 @@ ldp_vty_l2vpn_pw_nbr_addr(struct vty *vty, int disable, const char *addr_str)
 
 	if (ldp_get_address(addr_str, &af, &addr) == -1 ||
 	    bad_addr(af, &addr)) {
-		vty_out(vty, "%% Malformed address%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed address");
 		return (CMD_WARNING);
 	}
 
@@ -1409,7 +1400,7 @@ ldp_vty_l2vpn_pw_nbr_id(struct vty *vty, int disable, const char *lsr_id_str)
 
 	if (inet_pton(AF_INET, lsr_id_str, &lsr_id) != 1 ||
 	    bad_addr_v4(lsr_id)) {
-		vty_out(vty, "%% Malformed address%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed address");
 		return (CMD_WARNING);
 	}
 
@@ -1432,7 +1423,7 @@ ldp_vty_l2vpn_pw_pwid(struct vty *vty, int disable, const char *pwid_str)
 
 	pwid = strtol(pwid_str, &ep, 10);
 	if (*ep != '\0' || pwid < MIN_PWID_ID || pwid > MAX_PWID_ID) {
-		vty_out(vty, "%% Invalid pw-id%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Invalid pw-id");
 		return (CMD_WARNING);
 	}
 

--- a/ldpd/ldp_vty_exec.c
+++ b/ldpd/ldp_vty_exec.c
@@ -211,7 +211,7 @@ show_discovery_msg(struct vty *vty, struct imsg *imsg,
 
 			vty_out(vty, "%-8s %-15s ", "Targeted", addr);
 			if (strlen(addr) > 15)
-				vty_out(vty, "%s%46s", VTY_NEWLINE, " ");
+				vty_out(vty, "%s%46s", VTYNL, " ");
 			break;
 		}
 		vty_outln (vty, "%9u", adj->holdtime);
@@ -232,23 +232,23 @@ show_discovery_detail_adj(struct vty *vty, char *buffer, struct ctl_adj *adj)
 	size_t	 buflen = strlen(buffer);
 
 	snprintf(buffer + buflen, LDPBUFSIZ - buflen,
-	    "      LSR Id: %s:0%s", inet_ntoa(adj->id), VTY_NEWLINE);
+	    "      LSR Id: %s:0%s", inet_ntoa(adj->id), VTYNL);
 	buflen = strlen(buffer);
 	snprintf(buffer + buflen, LDPBUFSIZ - buflen,
 	    "          Source address: %s%s",
-	    log_addr(adj->af, &adj->src_addr), VTY_NEWLINE);
+	    log_addr(adj->af, &adj->src_addr), VTYNL);
 	buflen = strlen(buffer);
 	snprintf(buffer + buflen, LDPBUFSIZ - buflen,
 	    "          Transport address: %s%s",
-	    log_addr(adj->af, &adj->trans_addr), VTY_NEWLINE);
+	    log_addr(adj->af, &adj->trans_addr), VTYNL);
 	buflen = strlen(buffer);
 	snprintf(buffer + buflen, LDPBUFSIZ - buflen,
 	    "          Hello hold time: %u secs (due in %u secs)%s",
-	    adj->holdtime, adj->holdtime_remaining, VTY_NEWLINE);
+	    adj->holdtime, adj->holdtime_remaining, VTYNL);
 	buflen = strlen(buffer);
 	snprintf(buffer + buflen, LDPBUFSIZ - buflen,
 	    "          Dual-stack capability TLV: %s%s",
-	    (adj->ds_tlv) ? "yes" : "no", VTY_NEWLINE);
+	    (adj->ds_tlv) ? "yes" : "no", VTYNL);
 }
 
 static int
@@ -280,7 +280,7 @@ show_discovery_detail_msg(struct vty *vty, struct imsg *imsg,
 		buflen = strlen(ifaces_buffer);
 		snprintf(ifaces_buffer + buflen, LDPBUFSIZ - buflen,
 		     "    %s: %s%s", iface->name, (iface->no_adj) ?
-		    "(no adjacencies)" : "", VTY_NEWLINE);
+		    "(no adjacencies)" : "", VTYNL);
 		break;
 	case IMSG_CTL_SHOW_DISC_TNBR:
 		tnbr = imsg->data;
@@ -294,7 +294,7 @@ show_discovery_detail_msg(struct vty *vty, struct imsg *imsg,
 		snprintf(tnbrs_buffer + buflen, LDPBUFSIZ - buflen,
 		    "    %s -> %s: %s%s", log_addr(tnbr->af, trans_addr),
 		    log_addr(tnbr->af, &tnbr->addr), (tnbr->no_adj) ?
-		    "(no adjacencies)" : "", VTY_NEWLINE);
+		    "(no adjacencies)" : "", VTYNL);
 		break;
 	case IMSG_CTL_SHOW_DISC_ADJ:
 		adj = imsg->data;
@@ -511,7 +511,7 @@ show_nbr_msg(struct vty *vty, struct imsg *imsg, struct show_params *params)
 		    af_name(nbr->af), inet_ntoa(nbr->id),
 		    nbr_state_name(nbr->nbr_state), addr);
 		if (strlen(addr) > 15)
-			vty_out(vty, "%s%48s", VTY_NEWLINE, " ");
+			vty_out(vty, "%s%48s", VTYNL, " ");
 		vty_outln (vty, " %8s", log_time(nbr->uptime));
 		break;
 	case IMSG_CTL_END:
@@ -531,12 +531,12 @@ show_nbr_detail_adj(struct vty *vty, char *buffer, struct ctl_adj *adj)
 	switch (adj->type) {
 	case HELLO_LINK:
 		snprintf(buffer + buflen, LDPBUFSIZ - buflen,
-		    "      Interface: %s%s", adj->ifname, VTY_NEWLINE);
+		    "      Interface: %s%s", adj->ifname, VTYNL);
 		break;
 	case HELLO_TARGETED:
 		snprintf(buffer + buflen, LDPBUFSIZ - buflen,
 		    "      Targeted Hello: %s%s", log_addr(adj->af,
-		    &adj->src_addr), VTY_NEWLINE);
+		    &adj->src_addr), VTYNL);
 		break;
 	}
 }
@@ -873,7 +873,7 @@ show_nbr_capabilities(struct vty *vty, struct ctl_nbr *nbr)
 	    "   - Dynamic Announcement (0x0506)%s"
 	    "   - Typed Wildcard (0x050B)%s"
 	    "   - Unrecognized Notification (0x0603)",
-	    VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+	    VTYNL, VTYNL, VTYNL);
 	vty_outln (vty, "  Capabilities Received:");
 	if (nbr->flags & F_NBR_CAP_DYNAMIC)
 		vty_outln (vty,"   - Dynamic Announcement (0x0506)");
@@ -1021,7 +1021,7 @@ show_lib_msg(struct vty *vty, struct imsg *imsg, struct show_params *params)
 
 		vty_out(vty, "%-4s %-20s", af_name(rt->af), dstnet);
 		if (strlen(dstnet) > 20)
-			vty_out(vty, "%s%25s", VTY_NEWLINE, " ");
+			vty_out(vty, "%s%25s", VTYNL, " ");
 		vty_outln (vty, " %-15s %-11s %-13s %6s", inet_ntoa(rt->nexthop),
 		    log_label(rt->local_label), log_label(rt->remote_label),
 		    rt->in_use ? "yes" : "no");
@@ -1077,7 +1077,7 @@ show_lib_detail_msg(struct vty *vty, struct imsg *imsg, struct show_params *para
 		upstream = 1;
 		buflen = strlen(sent_buffer);
 		snprintf(sent_buffer + buflen, LDPBUFSIZ - buflen,
-		    "%12s%s:0%s", "", inet_ntoa(rt->nexthop), VTY_NEWLINE);
+		    "%12s%s:0%s", "", inet_ntoa(rt->nexthop), VTYNL);
 		break;
 	case IMSG_CTL_SHOW_LIB_RCVD:
 		downstream = 1;
@@ -1085,7 +1085,7 @@ show_lib_detail_msg(struct vty *vty, struct imsg *imsg, struct show_params *para
 		snprintf(rcvd_buffer + buflen, LDPBUFSIZ - buflen,
 		    "%12s%s:0, label %s%s%s", "", inet_ntoa(rt->nexthop),
 		    log_label(rt->remote_label),
-		    rt->in_use ? " (in use)" : "", VTY_NEWLINE);
+		    rt->in_use ? " (in use)" : "", VTYNL);
 		break;
 	case IMSG_CTL_SHOW_LIB_END:
 		if (upstream) {
@@ -1698,8 +1698,8 @@ ldp_vty_show_capabilities(struct vty *vty, int json)
 	    "Supported LDP Capabilities%s"
 	    " * Dynamic Announcement (0x0506)%s"
 	    " * Typed Wildcard (0x050B)%s"
-	    " * Unrecognized Notification (0x0603)%s", VTY_NEWLINE,
-	    VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+	    " * Unrecognized Notification (0x0603)%s", VTYNL,
+	    VTYNL, VTYNL, VTYNL);
 
 	return (0);
 }

--- a/ldpd/ldp_vty_exec.c
+++ b/ldpd/ldp_vty_exec.c
@@ -128,14 +128,14 @@ show_interface_msg(struct vty *vty, struct imsg *imsg,
 		snprintf(timers, sizeof(timers), "%u/%u",
 		    iface->hello_interval, iface->hello_holdtime);
 
-		vty_out(vty, "%-4s %-11s %-6s %-8s %-12s %3u%s",
+		vty_outln (vty, "%-4s %-11s %-6s %-8s %-12s %3u",
 		    af_name(iface->af), iface->name,
 		    if_state_name(iface->state), iface->uptime == 0 ?
 		    "00:00:00" : log_time(iface->uptime), timers,
-		    iface->adj_cnt, VTY_NEWLINE);
+		    iface->adj_cnt);
 		break;
 	case IMSG_CTL_END:
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		return (1);
 	default:
 		break;
@@ -214,10 +214,10 @@ show_discovery_msg(struct vty *vty, struct imsg *imsg,
 				vty_out(vty, "%s%46s", VTY_NEWLINE, " ");
 			break;
 		}
-		vty_out(vty, "%9u%s", adj->holdtime, VTY_NEWLINE);
+		vty_outln (vty, "%9u", adj->holdtime);
 		break;
 	case IMSG_CTL_END:
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		return (1);
 	default:
 		break;
@@ -313,23 +313,20 @@ show_discovery_detail_msg(struct vty *vty, struct imsg *imsg,
 		break;
 	case IMSG_CTL_END:
 		rtr_id.s_addr = ldp_rtr_id_get(ldpd_conf);
-		vty_out(vty, "Local:%s", VTY_NEWLINE);
-		vty_out(vty, "  LSR Id: %s:0%s", inet_ntoa(rtr_id),
-		    VTY_NEWLINE);
+		vty_outln (vty, "Local:");
+		vty_outln (vty, "  LSR Id: %s:0",inet_ntoa(rtr_id));
 		if (ldpd_conf->ipv4.flags & F_LDPD_AF_ENABLED)
-			vty_out(vty, "  Transport Address (IPv4): %s%s",
-			    log_addr(AF_INET, &ldpd_conf->ipv4.trans_addr),
-			    VTY_NEWLINE);
+			vty_outln (vty, "  Transport Address (IPv4): %s",
+			    log_addr(AF_INET, &ldpd_conf->ipv4.trans_addr));
 		if (ldpd_conf->ipv6.flags & F_LDPD_AF_ENABLED)
-			vty_out(vty, "  Transport Address (IPv6): %s%s",
-			    log_addr(AF_INET6, &ldpd_conf->ipv6.trans_addr),
-			    VTY_NEWLINE);
-		vty_out(vty, "Discovery Sources:%s", VTY_NEWLINE);
-		vty_out(vty, "  Interfaces:%s", VTY_NEWLINE);
+			vty_outln (vty, "  Transport Address (IPv6): %s",
+			    log_addr(AF_INET6, &ldpd_conf->ipv6.trans_addr));
+		vty_outln (vty, "Discovery Sources:");
+		vty_outln (vty, "  Interfaces:");
 		vty_out(vty, "%s", ifaces_buffer);
-		vty_out(vty, "  Targeted Hellos:%s", VTY_NEWLINE);
+		vty_outln (vty, "  Targeted Hellos:");
 		vty_out(vty, "%s", tnbrs_buffer);
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		return (1);
 	default:
 		break;
@@ -515,7 +512,7 @@ show_nbr_msg(struct vty *vty, struct imsg *imsg, struct show_params *params)
 		    nbr_state_name(nbr->nbr_state), addr);
 		if (strlen(addr) > 15)
 			vty_out(vty, "%s%48s", VTY_NEWLINE, " ");
-		vty_out(vty, " %8s%s", log_time(nbr->uptime), VTY_NEWLINE);
+		vty_outln (vty, " %8s", log_time(nbr->uptime));
 		break;
 	case IMSG_CTL_END:
 		return (1);
@@ -560,45 +557,42 @@ show_nbr_detail_msg(struct vty *vty, struct imsg *imsg,
 
 		v4adjs_buffer[0] = '\0';
 		v6adjs_buffer[0] = '\0';
-		vty_out(vty, "Peer LDP Identifier: %s:0%s", inet_ntoa(nbr->id),
-		    VTY_NEWLINE);
-		vty_out(vty, "  TCP connection: %s:%u - %s:%u%s",
+		vty_outln (vty, "Peer LDP Identifier: %s:0",
+			  inet_ntoa(nbr->id));
+		vty_outln (vty, "  TCP connection: %s:%u - %s:%u",
 		    log_addr(nbr->af, &nbr->laddr), ntohs(nbr->lport),
-		    log_addr(nbr->af, &nbr->raddr), ntohs(nbr->rport),
-		    VTY_NEWLINE);
-		vty_out(vty, "  Authentication: %s%s",
-		    (nbr->auth_method == AUTH_MD5SIG) ? "TCP MD5 Signature" :
-		    "none", VTY_NEWLINE);
-		vty_out(vty, "  Session Holdtime: %u secs; "
-		    "KeepAlive interval: %u secs%s", nbr->holdtime,
-		    nbr->holdtime / KEEPALIVE_PER_PERIOD, VTY_NEWLINE);
-		vty_out(vty, "  State: %s; Downstream-Unsolicited%s",
-		    nbr_state_name(nbr->nbr_state), VTY_NEWLINE);
-		vty_out(vty, "  Up time: %s%s", log_time(nbr->uptime),
-		    VTY_NEWLINE);
+		    log_addr(nbr->af, &nbr->raddr),ntohs(nbr->rport));
+		vty_outln (vty, "  Authentication: %s",
+		    (nbr->auth_method == AUTH_MD5SIG) ? "TCP MD5 Signature" : "none");
+		vty_outln(vty, "  Session Holdtime: %u secs; "
+		    "KeepAlive interval: %u secs", nbr->holdtime,
+		    nbr->holdtime / KEEPALIVE_PER_PERIOD);
+		vty_outln(vty, "  State: %s; Downstream-Unsolicited",
+		    nbr_state_name(nbr->nbr_state));
+		vty_outln (vty, "  Up time: %s",log_time(nbr->uptime));
 
 		stats = &nbr->stats;
-		vty_out(vty, "  Messages sent/rcvd:%s", VTY_NEWLINE);
-		vty_out(vty, "   - Keepalive Messages: %u/%u%s",
-		    stats->kalive_sent, stats->kalive_rcvd, VTY_NEWLINE);
-		vty_out(vty, "   - Address Messages: %u/%u%s",
-		    stats->addr_sent, stats->addr_rcvd, VTY_NEWLINE);
-		vty_out(vty, "   - Address Withdraw Messages: %u/%u%s",
-		    stats->addrwdraw_sent, stats->addrwdraw_rcvd, VTY_NEWLINE);
-		vty_out(vty, "   - Notification Messages: %u/%u%s",
-		    stats->notif_sent, stats->notif_rcvd, VTY_NEWLINE);
-		vty_out(vty, "   - Capability Messages: %u/%u%s",
-		    stats->capability_sent, stats->capability_rcvd, VTY_NEWLINE);
-		vty_out(vty, "   - Label Mapping Messages: %u/%u%s",
-		    stats->labelmap_sent, stats->labelmap_rcvd, VTY_NEWLINE);
-		vty_out(vty, "   - Label Request Messages: %u/%u%s",
-		    stats->labelreq_sent, stats->labelreq_rcvd, VTY_NEWLINE);
-		vty_out(vty, "   - Label Withdraw Messages: %u/%u%s",
-		    stats->labelwdraw_sent, stats->labelwdraw_rcvd, VTY_NEWLINE);
-		vty_out(vty, "   - Label Release Messages: %u/%u%s",
-		    stats->labelrel_sent, stats->labelrel_rcvd, VTY_NEWLINE);
-		vty_out(vty, "   - Label Abort Request Messages: %u/%u%s",
-		    stats->labelabreq_sent, stats->labelabreq_rcvd, VTY_NEWLINE);
+		vty_outln (vty, "  Messages sent/rcvd:");
+		vty_outln (vty, "   - Keepalive Messages: %u/%u",
+		    stats->kalive_sent, stats->kalive_rcvd);
+		vty_outln (vty, "   - Address Messages: %u/%u",
+		    stats->addr_sent, stats->addr_rcvd);
+		vty_outln (vty, "   - Address Withdraw Messages: %u/%u",
+		    stats->addrwdraw_sent, stats->addrwdraw_rcvd);
+		vty_outln (vty, "   - Notification Messages: %u/%u",
+		    stats->notif_sent, stats->notif_rcvd);
+		vty_outln (vty, "   - Capability Messages: %u/%u",
+		    stats->capability_sent, stats->capability_rcvd);
+		vty_outln (vty, "   - Label Mapping Messages: %u/%u",
+		    stats->labelmap_sent, stats->labelmap_rcvd);
+		vty_outln (vty, "   - Label Request Messages: %u/%u",
+		    stats->labelreq_sent, stats->labelreq_rcvd);
+		vty_outln (vty, "   - Label Withdraw Messages: %u/%u",
+		    stats->labelwdraw_sent, stats->labelwdraw_rcvd);
+		vty_outln (vty, "   - Label Release Messages: %u/%u",
+		    stats->labelrel_sent, stats->labelrel_rcvd);
+		vty_outln (vty, "   - Label Abort Request Messages: %u/%u",
+		    stats->labelabreq_sent, stats->labelabreq_rcvd);
 
 		show_nbr_capabilities(vty, nbr);
 		break;
@@ -617,16 +611,16 @@ show_nbr_detail_msg(struct vty *vty, struct imsg *imsg,
 		}
 		break;
 	case IMSG_CTL_SHOW_NBR_END:
-		vty_out(vty, "  LDP Discovery Sources:%s", VTY_NEWLINE);
+		vty_outln (vty, "  LDP Discovery Sources:");
 		if (v4adjs_buffer[0] != '\0') {
-			vty_out(vty, "    IPv4:%s", VTY_NEWLINE);
+			vty_outln (vty, "    IPv4:");
 			vty_out(vty, "%s", v4adjs_buffer);
 		}
 		if (v6adjs_buffer[0] != '\0') {
-			vty_out(vty, "    IPv6:%s", VTY_NEWLINE);
+			vty_outln (vty, "    IPv6:");
 			vty_out(vty, "%s", v6adjs_buffer);
 		}
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		break;
 	case IMSG_CTL_END:
 		return (1);
@@ -875,20 +869,18 @@ show_nbr_detail_msg_json(struct imsg *imsg, struct show_params *params,
 void
 show_nbr_capabilities(struct vty *vty, struct ctl_nbr *nbr)
 {
-	vty_out(vty, "  Capabilities Sent:%s"
+	vty_outln (vty, "  Capabilities Sent:%s"
 	    "   - Dynamic Announcement (0x0506)%s"
 	    "   - Typed Wildcard (0x050B)%s"
-	    "   - Unrecognized Notification (0x0603)%s",
-	    VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
-	vty_out(vty, "  Capabilities Received:%s", VTY_NEWLINE);
+	    "   - Unrecognized Notification (0x0603)",
+	    VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+	vty_outln (vty, "  Capabilities Received:");
 	if (nbr->flags & F_NBR_CAP_DYNAMIC)
-		vty_out(vty, "   - Dynamic Announcement (0x0506)%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,"   - Dynamic Announcement (0x0506)");
 	if (nbr->flags & F_NBR_CAP_TWCARD)
-		vty_out(vty, "   - Typed Wildcard (0x050B)%s", VTY_NEWLINE);
+		vty_outln (vty, "   - Typed Wildcard (0x050B)");
 	if (nbr->flags & F_NBR_CAP_UNOTIF)
-		vty_out(vty, "   - Unrecognized Notification (0x0603)%s",
-		    VTY_NEWLINE);
+		vty_outln (vty,"   - Unrecognized Notification (0x0603)");
 }
 
 static int
@@ -903,13 +895,13 @@ show_nbr_capabilities_msg(struct vty *vty, struct imsg *imsg, struct show_params
 		if (nbr->nbr_state != NBR_STA_OPER)
 			break;
 
-		vty_out(vty, "Peer LDP Identifier: %s:0%s", inet_ntoa(nbr->id),
-		    VTY_NEWLINE);
+		vty_outln (vty, "Peer LDP Identifier: %s:0",
+			  inet_ntoa(nbr->id));
 		show_nbr_capabilities(vty, nbr);
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		break;
 	case IMSG_CTL_END:
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		return (1);
 	default:
 		break;
@@ -1030,12 +1022,12 @@ show_lib_msg(struct vty *vty, struct imsg *imsg, struct show_params *params)
 		vty_out(vty, "%-4s %-20s", af_name(rt->af), dstnet);
 		if (strlen(dstnet) > 20)
 			vty_out(vty, "%s%25s", VTY_NEWLINE, " ");
-		vty_out(vty, " %-15s %-11s %-13s %6s%s", inet_ntoa(rt->nexthop),
+		vty_outln (vty, " %-15s %-11s %-13s %6s", inet_ntoa(rt->nexthop),
 		    log_label(rt->local_label), log_label(rt->remote_label),
-		    rt->in_use ? "yes" : "no", VTY_NEWLINE);
+		    rt->in_use ? "yes" : "no");
 		break;
 	case IMSG_CTL_END:
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		return (1);
 	default:
 		break;
@@ -1077,9 +1069,9 @@ show_lib_detail_msg(struct vty *vty, struct imsg *imsg, struct show_params *para
 		snprintf(dstnet, sizeof(dstnet), "%s/%d",
 		    log_addr(rt->af, &rt->prefix), rt->prefixlen);
 
-		vty_out(vty, "%s%s", dstnet, VTY_NEWLINE);
-		vty_out(vty, "%-8sLocal binding: label: %s%s", "",
-		    log_label(rt->local_label), VTY_NEWLINE);
+		vty_outln (vty, "%s", dstnet);
+		vty_outln (vty, "%-8sLocal binding: label: %s", "",
+		    log_label(rt->local_label));
 		break;
 	case IMSG_CTL_SHOW_LIB_SENT:
 		upstream = 1;
@@ -1097,18 +1089,17 @@ show_lib_detail_msg(struct vty *vty, struct imsg *imsg, struct show_params *para
 		break;
 	case IMSG_CTL_SHOW_LIB_END:
 		if (upstream) {
-			vty_out(vty, "%-8sAdvertised to:%s", "", VTY_NEWLINE);
+			vty_outln (vty, "%-8sAdvertised to:", "");
 			vty_out(vty, "%s", sent_buffer);
 		}
 		if (downstream) {
-			vty_out(vty, "%-8sRemote bindings:%s", "", VTY_NEWLINE);
+			vty_outln (vty, "%-8sRemote bindings:", "");
 			vty_out(vty, "%s", rcvd_buffer);
 		} else
-			vty_out(vty, "%-8sNo remote bindings%s", "",
-			    VTY_NEWLINE);
+			vty_outln (vty, "%-8sNo remote bindings","");
 		break;
 	case IMSG_CTL_END:
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		return (1);
 	default:
 		break;
@@ -1244,39 +1235,33 @@ show_l2vpn_binding_msg(struct vty *vty, struct imsg *imsg,
 	case IMSG_CTL_SHOW_L2VPN_BINDING:
 		pw = imsg->data;
 
-		vty_out(vty, "  Destination Address: %s, VC ID: %u%s",
-		    inet_ntoa(pw->lsr_id), pw->pwid, VTY_NEWLINE);
+		vty_outln (vty, "  Destination Address: %s, VC ID: %u",
+		    inet_ntoa(pw->lsr_id), pw->pwid);
 
 		/* local binding */
 		if (pw->local_label != NO_LABEL) {
-			vty_out(vty, "    Local Label:  %u%s", pw->local_label,
-			    VTY_NEWLINE);
-			vty_out(vty, "%-8sCbit: %u,    VC Type: %s,    "
-			    "GroupID: %u%s", "", pw->local_cword,
-			    pw_type_name(pw->type), pw->local_gid,
-			    VTY_NEWLINE);
-			vty_out(vty, "%-8sMTU: %u%s", "", pw->local_ifmtu,
-			    VTY_NEWLINE);
+			vty_outln (vty, "    Local Label:  %u",
+				  pw->local_label);
+			vty_outln (vty, "%-8sCbit: %u,    VC Type: %s,    "
+			    "GroupID: %u", "", pw->local_cword,
+			    pw_type_name(pw->type),pw->local_gid);
+			vty_outln (vty, "%-8sMTU: %u", "",pw->local_ifmtu);
 		} else
-			vty_out(vty, "    Local Label: unassigned%s",
-			    VTY_NEWLINE);
+			vty_outln (vty,"    Local Label: unassigned");
 
 		/* remote binding */
 		if (pw->remote_label != NO_LABEL) {
-			vty_out(vty, "    Remote Label: %u%s",
-			    pw->remote_label,  VTY_NEWLINE);
-			vty_out(vty, "%-8sCbit: %u,    VC Type: %s,    "
-			    "GroupID: %u%s", "", pw->remote_cword,
-			    pw_type_name(pw->type), pw->remote_gid,
-			    VTY_NEWLINE);
-			vty_out(vty, "%-8sMTU: %u%s", "", pw->remote_ifmtu,
-			    VTY_NEWLINE);
+			vty_outln (vty, "    Remote Label: %u",
+			    pw->remote_label);
+			vty_outln (vty, "%-8sCbit: %u,    VC Type: %s,    "
+			    "GroupID: %u", "", pw->remote_cword,
+			    pw_type_name(pw->type),pw->remote_gid);
+			vty_outln (vty, "%-8sMTU: %u", "",pw->remote_ifmtu);
 		} else
-			vty_out(vty, "    Remote Label: unassigned%s",
-			    VTY_NEWLINE);
+			vty_outln (vty,"    Remote Label: unassigned");
 		break;
 	case IMSG_CTL_END:
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		return (1);
 	default:
 		break;
@@ -1355,12 +1340,12 @@ show_l2vpn_pw_msg(struct vty *vty, struct imsg *imsg, struct show_params *params
 	case IMSG_CTL_SHOW_L2VPN_PW:
 		pw = imsg->data;
 
-		vty_out(vty, "%-9s %-15s %-10u %-16s %-10s%s", pw->ifname,
+		vty_outln (vty, "%-9s %-15s %-10u %-16s %-10s", pw->ifname,
 		    inet_ntoa(pw->lsr_id), pw->pwid, pw->l2vpn_name,
-		    (pw->status ? "UP" : "DOWN"), VTY_NEWLINE);
+		    (pw->status ? "UP" : "DOWN"));
 		break;
 	case IMSG_CTL_END:
-		vty_out(vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 		return (1);
 	default:
 		break;
@@ -1555,8 +1540,8 @@ ldp_vty_dispatch(struct vty *vty, struct imsgbuf *ibuf, enum show_command cmd,
  done:
 	close(ibuf->fd);
 	if (json) {
-		vty_out(vty, "%s%s", json_object_to_json_string_ext(json,
-		    JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+		vty_outln (vty, "%s",
+			  json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
 		json_object_free(json);
 	}
 
@@ -1599,9 +1584,9 @@ ldp_vty_show_binding(struct vty *vty, const char *af_str, int detail, int json)
 	params.json = json;
 
 	if (!params.detail && !params.json)
-		vty_out(vty, "%-4s %-20s %-15s %-11s %-13s %6s%s", "AF",
+		vty_outln (vty, "%-4s %-20s %-15s %-11s %-13s %6s", "AF",
 		    "Destination", "Nexthop", "Local Label", "Remote Label",
-		    "In Use", VTY_NEWLINE);
+		    "In Use");
 
 	imsg_compose(&ibuf, IMSG_CTL_SHOW_LIB, 0, 0, -1, NULL, 0);
 	return (ldp_vty_dispatch(vty, &ibuf, SHOW_LIB, &params));
@@ -1627,8 +1612,8 @@ ldp_vty_show_discovery(struct vty *vty, const char *af_str, int detail,
 	params.json = json;
 
 	if (!params.detail && !params.json)
-		vty_out(vty, "%-4s %-15s %-8s %-15s %9s%s",
-		    "AF", "ID", "Type", "Source", "Holdtime", VTY_NEWLINE);
+		vty_outln (vty, "%-4s %-15s %-8s %-15s %9s",
+		    "AF", "ID", "Type", "Source", "Holdtime");
 
 	if (params.detail)
 		imsg_compose(&ibuf, IMSG_CTL_SHOW_DISCOVERY_DTL, 0, 0, -1,
@@ -1658,9 +1643,8 @@ ldp_vty_show_interface(struct vty *vty, const char *af_str, int json)
 
 	/* header */
 	if (!params.json) {
-		vty_out(vty, "%-4s %-11s %-6s %-8s %-12s %3s%s", "AF",
-		    "Interface", "State", "Uptime", "Hello Timers", "ac",
-		    VTY_NEWLINE);
+		vty_outln (vty, "%-4s %-11s %-6s %-8s %-12s %3s", "AF",
+		    "Interface", "State", "Uptime", "Hello Timers","ac");
 	}
 
 	imsg_compose(&ibuf, IMSG_CTL_SHOW_INTERFACE, 0, 0, -1, &ifidx,
@@ -1704,18 +1688,18 @@ ldp_vty_show_capabilities(struct vty *vty, int json)
 		    "0x0603");
 		json_object_array_add(json_array, json_cap);
 
-		vty_out(vty, "%s%s", json_object_to_json_string_ext(json,
-		    JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+		vty_outln (vty, "%s",
+			  json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
 		json_object_free(json);
 		return (0);
 	}
 
-	vty_out(vty,
+	vty_outln (vty,
 	    "Supported LDP Capabilities%s"
 	    " * Dynamic Announcement (0x0506)%s"
 	    " * Typed Wildcard (0x050B)%s"
-	    " * Unrecognized Notification (0x0603)%s%s", VTY_NEWLINE,
-	    VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+	    " * Unrecognized Notification (0x0603)%s", VTY_NEWLINE,
+	    VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
 
 	return (0);
 }
@@ -1738,9 +1722,8 @@ ldp_vty_show_neighbor(struct vty *vty, int capabilities, int detail, int json)
 		params.detail = 1;
 
 	if (!params.detail && !params.json)
-		vty_out(vty, "%-4s %-15s %-11s %-15s %8s%s",
-		    "AF", "ID", "State", "Remote Address", "Uptime",
-		    VTY_NEWLINE);
+		vty_outln (vty, "%-4s %-15s %-11s %-15s %8s",
+		    "AF", "ID", "State", "Remote Address","Uptime");
 
 	imsg_compose(&ibuf, IMSG_CTL_SHOW_NBR, 0, 0, -1, NULL, 0);
 	return (ldp_vty_dispatch(vty, &ibuf, SHOW_NBR, &params));
@@ -1776,12 +1759,11 @@ ldp_vty_show_atom_vc(struct vty *vty, int json)
 
 	if (!params.json) {
 		/* header */
-		vty_out(vty, "%-9s %-15s %-10s %-16s %-10s%s",
-		    "Interface", "Peer ID", "VC ID", "Name", "Status",
-		    VTY_NEWLINE);
-		vty_out(vty, "%-9s %-15s %-10s %-16s %-10s%s",
+		vty_outln (vty, "%-9s %-15s %-10s %-16s %-10s",
+		    "Interface", "Peer ID", "VC ID", "Name","Status");
+		vty_outln (vty, "%-9s %-15s %-10s %-16s %-10s",
 		    "---------", "---------------", "----------",
-		    "----------------", "----------", VTY_NEWLINE);
+		    "----------------", "----------");
 	}
 
 	imsg_compose(&ibuf, IMSG_CTL_SHOW_L2VPN_PW, 0, 0, -1, NULL, 0);
@@ -1798,7 +1780,7 @@ ldp_vty_clear_nbr(struct vty *vty, const char *addr_str)
 	if (addr_str &&
 	    (ldp_get_address(addr_str, &nbr.af, &nbr.raddr) == -1 ||
 	    bad_addr(nbr.af, &nbr.raddr))) {
-		vty_out(vty, "%% Malformed address%s", VTY_NEWLINE);
+		vty_outln (vty, "%% Malformed address");
 		return (CMD_WARNING);
 	}
 

--- a/ldpd/ldp_vty_exec.c
+++ b/ldpd/ldp_vty_exec.c
@@ -135,7 +135,7 @@ show_interface_msg(struct vty *vty, struct imsg *imsg,
 		    iface->adj_cnt);
 		break;
 	case IMSG_CTL_END:
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		return (1);
 	default:
 		break;
@@ -217,7 +217,7 @@ show_discovery_msg(struct vty *vty, struct imsg *imsg,
 		vty_outln (vty, "%9u", adj->holdtime);
 		break;
 	case IMSG_CTL_END:
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		return (1);
 	default:
 		break;
@@ -326,7 +326,7 @@ show_discovery_detail_msg(struct vty *vty, struct imsg *imsg,
 		vty_out(vty, "%s", ifaces_buffer);
 		vty_outln (vty, "  Targeted Hellos:");
 		vty_out(vty, "%s", tnbrs_buffer);
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		return (1);
 	default:
 		break;
@@ -620,7 +620,7 @@ show_nbr_detail_msg(struct vty *vty, struct imsg *imsg,
 			vty_outln (vty, "    IPv6:");
 			vty_out(vty, "%s", v6adjs_buffer);
 		}
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		break;
 	case IMSG_CTL_END:
 		return (1);
@@ -898,10 +898,10 @@ show_nbr_capabilities_msg(struct vty *vty, struct imsg *imsg, struct show_params
 		vty_outln (vty, "Peer LDP Identifier: %s:0",
 			  inet_ntoa(nbr->id));
 		show_nbr_capabilities(vty, nbr);
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		break;
 	case IMSG_CTL_END:
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		return (1);
 	default:
 		break;
@@ -1027,7 +1027,7 @@ show_lib_msg(struct vty *vty, struct imsg *imsg, struct show_params *params)
 		    rt->in_use ? "yes" : "no");
 		break;
 	case IMSG_CTL_END:
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		return (1);
 	default:
 		break;
@@ -1099,7 +1099,7 @@ show_lib_detail_msg(struct vty *vty, struct imsg *imsg, struct show_params *para
 			vty_outln (vty, "%-8sNo remote bindings","");
 		break;
 	case IMSG_CTL_END:
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		return (1);
 	default:
 		break;
@@ -1261,7 +1261,7 @@ show_l2vpn_binding_msg(struct vty *vty, struct imsg *imsg,
 			vty_outln (vty,"    Remote Label: unassigned");
 		break;
 	case IMSG_CTL_END:
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		return (1);
 	default:
 		break;
@@ -1345,7 +1345,7 @@ show_l2vpn_pw_msg(struct vty *vty, struct imsg *imsg, struct show_params *params
 		    (pw->status ? "UP" : "DOWN"));
 		break;
 	case IMSG_CTL_END:
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 		return (1);
 	default:
 		break;

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -168,7 +168,7 @@ static int
 config_write_agentx (struct vty *vty)
 {
   if (agentx_enabled)
-      vty_out (vty, "agentx%s", VTY_NEWLINE);
+      vty_outln (vty, "agentx");
   return 1;
 }
 
@@ -186,7 +186,7 @@ DEFUN (agentx_enable,
       agentx_enabled = 1;
       return CMD_SUCCESS;
     }
-  vty_out (vty, "SNMP AgentX already enabled%s", VTY_NEWLINE);
+  vty_outln (vty, "SNMP AgentX already enabled");
   return CMD_SUCCESS;
 }
 
@@ -198,7 +198,7 @@ DEFUN (no_agentx,
        "SNMP AgentX settings\n")
 {
   if (!agentx_enabled) return CMD_SUCCESS;
-  vty_out (vty, "SNMP AgentX support cannot be disabled once enabled%s", VTY_NEWLINE);
+  vty_outln (vty, "SNMP AgentX support cannot be disabled once enabled");
   return CMD_WARNING;
 }
 

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -461,7 +461,7 @@ bfd_show_info(struct vty *vty, struct bfd_info *bfd_info, int multihop,
   if (use_json)
     json_object_object_add(json_obj, "peerBfdInfo", json_bfd);
   else
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
 }
 
 /*

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -394,11 +394,11 @@ bfd_show_param(struct vty *vty, struct bfd_info *bfd_info, int bfd_tag,
     }
   else
     {
-      vty_out (vty, "  %s%sDetect Mul: %d, Min Rx interval: %d,"
-                " Min Tx interval: %d%s",
+      vty_outln (vty, "  %s%sDetect Mul: %d, Min Rx interval: %d,"
+                " Min Tx interval: %d",
                     (extra_space) ? "  ": "", (bfd_tag) ? "BFD: " : "  ",
                     bfd_info->detect_mult, bfd_info->required_min_rx,
-                    bfd_info->desired_min_tx, VTY_NEWLINE);
+                    bfd_info->desired_min_tx);
     }
 }
 
@@ -423,9 +423,9 @@ bfd_show_status(struct vty *vty, struct bfd_info *bfd_info, int bfd_tag,
     }
   else
     {
-      vty_out (vty, "  %s%sStatus: %s, Last update: %s%s",
+      vty_outln (vty, "  %s%sStatus: %s, Last update: %s",
                   (extra_space) ? "  ": "", (bfd_tag) ? "BFD: " : "  ",
-                  bfd_get_status_str(bfd_info->status), time_buf, VTY_NEWLINE);
+                  bfd_get_status_str(bfd_info->status), time_buf);
     }
 }
 
@@ -451,8 +451,8 @@ bfd_show_info(struct vty *vty, struct bfd_info *bfd_info, int multihop,
     }
   else
     {
-      vty_out (vty, "  %sBFD: Type: %s%s", (extra_space) ? "  " : "",
-              (multihop) ? "multi hop" : "single hop", VTY_NEWLINE);
+      vty_outln (vty, "  %sBFD: Type: %s", (extra_space) ? "  " : "",
+              (multihop) ? "multi hop" : "single hop");
     }
 
   bfd_show_param(vty, bfd_info, 0, extra_space, use_json, json_bfd);
@@ -461,7 +461,7 @@ bfd_show_info(struct vty *vty, struct bfd_info *bfd_info, int multihop,
   if (use_json)
     json_object_object_add(json_obj, "peerBfdInfo", json_bfd);
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
 }
 
 /*

--- a/lib/command.c
+++ b/lib/command.c
@@ -1349,7 +1349,7 @@ DEFUN (show_version,
   vty_outln (vty, "%s %s (%s).", FRR_FULL_NAME, FRR_VERSION,
 	   host.name ? host.name : "");
   vty_outln (vty, "%s%s", FRR_COPYRIGHT, GIT_INFO);
-  vty_outln (vty, "configured with:%s    %s", VTY_NEWLINE,
+  vty_outln (vty, "configured with:%s    %s", VTYNL,
            FRR_CONFIG_ARGS);
 
   return CMD_SUCCESS;
@@ -1385,9 +1385,9 @@ command argument (e.g. 'show ?') and describes each possible%s\
 argument.%s\
 2. Partial help is provided when an abbreviated argument is entered%s\
    and you want to know what arguments match the input%s\
-   (e.g. 'show me?'.)%s", VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE,
-           VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE,
-           VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+   (e.g. 'show me?'.)%s", VTYNL, VTYNL, VTYNL,
+           VTYNL, VTYNL, VTYNL, VTYNL, VTYNL,
+           VTYNL, VTYNL, VTYNL, VTYNL);
   return CMD_SUCCESS;
 }
 
@@ -1488,7 +1488,7 @@ vty_write_config (struct vty *vty)
 
   if (vty->type == VTY_TERM)
     {
-      vty_outln (vty, "%sCurrent configuration:",VTY_NEWLINE);
+      vty_outln (vty, "%sCurrent configuration:",VTYNL);
       vty_outln (vty, "!");
     }
 

--- a/lib/command.c
+++ b/lib/command.c
@@ -463,7 +463,7 @@ config_write_host (struct vty *vty)
       if (zlog_default->maxlvl[ZLOG_DEST_FILE] != zlog_default->default_lvl)
         vty_out (vty, " %s",
                  zlog_priority[zlog_default->maxlvl[ZLOG_DEST_FILE]]);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   if (zlog_default->maxlvl[ZLOG_DEST_STDOUT] != ZLOG_DISABLED)
@@ -472,7 +472,7 @@ config_write_host (struct vty *vty)
       if (zlog_default->maxlvl[ZLOG_DEST_STDOUT] != zlog_default->default_lvl)
         vty_out (vty, " %s",
                  zlog_priority[zlog_default->maxlvl[ZLOG_DEST_STDOUT]]);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   if (zlog_default->maxlvl[ZLOG_DEST_MONITOR] == ZLOG_DISABLED)
@@ -487,7 +487,7 @@ config_write_host (struct vty *vty)
       if (zlog_default->maxlvl[ZLOG_DEST_SYSLOG] != zlog_default->default_lvl)
         vty_out (vty, " %s",
                  zlog_priority[zlog_default->maxlvl[ZLOG_DEST_SYSLOG]]);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   if (zlog_default->facility != LOG_DAEMON)
@@ -1421,7 +1421,7 @@ permute (struct graph_node *start, struct vty *vty)
       }
       if (gn == start)
         vty_out (vty, "...");
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
     else
     {
@@ -2012,7 +2012,7 @@ DEFUN (show_logging,
     vty_out (vty, "level %s, facility %s, ident %s",
              zlog_priority[zl->maxlvl[ZLOG_DEST_SYSLOG]],
              facility_name(zl->facility), zl->ident);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   vty_out (vty, "Stdout logging: ");
   if (zl->maxlvl[ZLOG_DEST_STDOUT] == ZLOG_DISABLED)
@@ -2020,7 +2020,7 @@ DEFUN (show_logging,
   else
     vty_out (vty, "level %s",
              zlog_priority[zl->maxlvl[ZLOG_DEST_STDOUT]]);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   vty_out (vty, "Monitor logging: ");
   if (zl->maxlvl[ZLOG_DEST_MONITOR] == ZLOG_DISABLED)
@@ -2028,7 +2028,7 @@ DEFUN (show_logging,
   else
     vty_out (vty, "level %s",
              zlog_priority[zl->maxlvl[ZLOG_DEST_MONITOR]]);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   vty_out (vty, "File logging: ");
   if ((zl->maxlvl[ZLOG_DEST_FILE] == ZLOG_DISABLED) ||
@@ -2038,7 +2038,7 @@ DEFUN (show_logging,
     vty_out (vty, "level %s, filename %s",
              zlog_priority[zl->maxlvl[ZLOG_DEST_FILE]],
              zl->filename);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   vty_outln (vty, "Protocol name: %s",
            zl->protoname);

--- a/lib/command.c
+++ b/lib/command.c
@@ -433,29 +433,28 @@ static int
 config_write_host (struct vty *vty)
 {
   if (host.name)
-    vty_out (vty, "hostname %s%s", host.name, VTY_NEWLINE);
+    vty_outln (vty, "hostname %s", host.name);
 
   if (host.encrypt)
     {
       if (host.password_encrypt)
-        vty_out (vty, "password 8 %s%s", host.password_encrypt, VTY_NEWLINE);
+        vty_outln (vty, "password 8 %s", host.password_encrypt);
       if (host.enable_encrypt)
-        vty_out (vty, "enable password 8 %s%s", host.enable_encrypt, VTY_NEWLINE);
+        vty_outln (vty, "enable password 8 %s", host.enable_encrypt);
     }
   else
     {
       if (host.password)
-        vty_out (vty, "password %s%s", host.password, VTY_NEWLINE);
+        vty_outln (vty, "password %s", host.password);
       if (host.enable)
-        vty_out (vty, "enable password %s%s", host.enable, VTY_NEWLINE);
+        vty_outln (vty, "enable password %s", host.enable);
     }
 
   if (zlog_default->default_lvl != LOG_DEBUG)
     {
-      vty_out (vty, "! N.B. The 'log trap' command is deprecated.%s",
-               VTY_NEWLINE);
-      vty_out (vty, "log trap %s%s",
-               zlog_priority[zlog_default->default_lvl], VTY_NEWLINE);
+      vty_outln (vty,"! N.B. The 'log trap' command is deprecated.");
+      vty_outln (vty, "log trap %s",
+               zlog_priority[zlog_default->default_lvl]);
     }
 
   if (host.logfile && (zlog_default->maxlvl[ZLOG_DEST_FILE] != ZLOG_DISABLED))
@@ -464,7 +463,7 @@ config_write_host (struct vty *vty)
       if (zlog_default->maxlvl[ZLOG_DEST_FILE] != zlog_default->default_lvl)
         vty_out (vty, " %s",
                  zlog_priority[zlog_default->maxlvl[ZLOG_DEST_FILE]]);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   if (zlog_default->maxlvl[ZLOG_DEST_STDOUT] != ZLOG_DISABLED)
@@ -473,14 +472,14 @@ config_write_host (struct vty *vty)
       if (zlog_default->maxlvl[ZLOG_DEST_STDOUT] != zlog_default->default_lvl)
         vty_out (vty, " %s",
                  zlog_priority[zlog_default->maxlvl[ZLOG_DEST_STDOUT]]);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   if (zlog_default->maxlvl[ZLOG_DEST_MONITOR] == ZLOG_DISABLED)
-    vty_out(vty,"no log monitor%s",VTY_NEWLINE);
+    vty_outln (vty,"no log monitor");
   else if (zlog_default->maxlvl[ZLOG_DEST_MONITOR] != zlog_default->default_lvl)
-    vty_out(vty,"log monitor %s%s",
-            zlog_priority[zlog_default->maxlvl[ZLOG_DEST_MONITOR]],VTY_NEWLINE);
+    vty_outln (vty,"log monitor %s",
+            zlog_priority[zlog_default->maxlvl[ZLOG_DEST_MONITOR]]);
 
   if (zlog_default->maxlvl[ZLOG_DEST_SYSLOG] != ZLOG_DISABLED)
     {
@@ -488,34 +487,33 @@ config_write_host (struct vty *vty)
       if (zlog_default->maxlvl[ZLOG_DEST_SYSLOG] != zlog_default->default_lvl)
         vty_out (vty, " %s",
                  zlog_priority[zlog_default->maxlvl[ZLOG_DEST_SYSLOG]]);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   if (zlog_default->facility != LOG_DAEMON)
-    vty_out (vty, "log facility %s%s",
-             facility_name(zlog_default->facility), VTY_NEWLINE);
+    vty_outln (vty, "log facility %s",
+             facility_name(zlog_default->facility));
 
   if (zlog_default->record_priority == 1)
-    vty_out (vty, "log record-priority%s", VTY_NEWLINE);
+    vty_outln (vty, "log record-priority");
 
   if (zlog_default->timestamp_precision > 0)
-    vty_out (vty, "log timestamp precision %d%s",
-             zlog_default->timestamp_precision, VTY_NEWLINE);
+    vty_outln (vty, "log timestamp precision %d",
+             zlog_default->timestamp_precision);
 
   if (host.advanced)
-    vty_out (vty, "service advanced-vty%s", VTY_NEWLINE);
+    vty_outln (vty, "service advanced-vty");
 
   if (host.encrypt)
-    vty_out (vty, "service password-encryption%s", VTY_NEWLINE);
+    vty_outln (vty, "service password-encryption");
 
   if (host.lines >= 0)
-    vty_out (vty, "service terminal-length %d%s", host.lines,
-             VTY_NEWLINE);
+    vty_outln (vty, "service terminal-length %d",host.lines);
 
   if (host.motdfile)
-    vty_out (vty, "banner motd file %s%s", host.motdfile, VTY_NEWLINE);
+    vty_outln (vty, "banner motd file %s", host.motdfile);
   else if (! host.motd)
-    vty_out (vty, "no banner motd%s", VTY_NEWLINE);
+    vty_outln (vty, "no banner motd");
 
   return 1;
 }
@@ -1151,7 +1149,7 @@ DEFUN (config_terminal,
     vty->node = CONFIG_NODE;
   else
     {
-      vty_out (vty, "VTY configuration is locked by other VTY%s", VTY_NEWLINE);
+      vty_outln (vty, "VTY configuration is locked by other VTY");
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -1348,12 +1346,11 @@ DEFUN (show_version,
        SHOW_STR
        "Displays zebra version\n")
 {
-  vty_out (vty, "%s %s (%s).%s", FRR_FULL_NAME, FRR_VERSION,
-	   host.name ? host.name : "",
-	   VTY_NEWLINE);
-  vty_out (vty, "%s%s%s", FRR_COPYRIGHT, GIT_INFO, VTY_NEWLINE);
-  vty_out (vty, "configured with:%s    %s%s", VTY_NEWLINE,
-           FRR_CONFIG_ARGS, VTY_NEWLINE);
+  vty_outln (vty, "%s %s (%s).", FRR_FULL_NAME, FRR_VERSION,
+	   host.name ? host.name : "");
+  vty_outln (vty, "%s%s", FRR_COPYRIGHT, GIT_INFO);
+  vty_outln (vty, "configured with:%s    %s", VTY_NEWLINE,
+           FRR_CONFIG_ARGS);
 
   return CMD_SUCCESS;
 }
@@ -1376,7 +1373,7 @@ DEFUN (config_help,
        "help",
        "Description of the interactive help system\n")
 {
-  vty_out (vty,
+  vty_outln (vty,
            "Quagga VTY provides advanced help feature.  When you need help,%s\
 anytime at the command line please press '?'.%s\
 %s\
@@ -1388,9 +1385,9 @@ command argument (e.g. 'show ?') and describes each possible%s\
 argument.%s\
 2. Partial help is provided when an abbreviated argument is entered%s\
    and you want to know what arguments match the input%s\
-   (e.g. 'show me?'.)%s%s", VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE,
+   (e.g. 'show me?'.)%s", VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE,
            VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE,
-           VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+           VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
   return CMD_SUCCESS;
 }
 
@@ -1424,7 +1421,7 @@ permute (struct graph_node *start, struct vty *vty)
       }
       if (gn == start)
         vty_out (vty, "...");
-      vty_out (vty, VTY_NEWLINE);
+      vty_outln (vty, "");
     }
     else
     {
@@ -1458,7 +1455,7 @@ cmd_list_cmds (struct vty *vty, int do_permute)
         if ((element = vector_slot (node->cmd_vector, i)) &&
              element->attr != CMD_ATTR_DEPRECATED &&
              element->attr != CMD_ATTR_HIDDEN)
-          vty_out (vty, "    %s%s", element->string, VTY_NEWLINE);
+          vty_outln (vty, "    %s", element->string);
   }
   return CMD_SUCCESS;
 }
@@ -1491,26 +1488,25 @@ vty_write_config (struct vty *vty)
 
   if (vty->type == VTY_TERM)
     {
-      vty_out (vty, "%sCurrent configuration:%s", VTY_NEWLINE,
-               VTY_NEWLINE);
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_outln (vty, "%sCurrent configuration:",VTY_NEWLINE);
+      vty_outln (vty, "!");
     }
 
-  vty_out (vty, "frr version %s%s", FRR_VER_SHORT, VTY_NEWLINE);
-  vty_out (vty, "frr defaults %s%s", DFLT_NAME, VTY_NEWLINE);
-  vty_out (vty, "!%s", VTY_NEWLINE);
+  vty_outln (vty, "frr version %s", FRR_VER_SHORT);
+  vty_outln (vty, "frr defaults %s", DFLT_NAME);
+  vty_outln (vty, "!");
 
   for (i = 0; i < vector_active (cmdvec); i++)
     if ((node = vector_slot (cmdvec, i)) && node->func
         && (node->vtysh || vty->type != VTY_SHELL))
       {
         if ((*node->func) (vty))
-          vty_out (vty, "!%s", VTY_NEWLINE);
+          vty_outln (vty, "!");
       }
 
   if (vty->type == VTY_TERM)
     {
-      vty_out (vty, "end%s",VTY_NEWLINE);
+      vty_outln (vty, "end");
     }
 }
 
@@ -1547,8 +1543,7 @@ DEFUN (config_write,
   /* Check and see if we are operating under vtysh configuration */
   if (host.config == NULL)
     {
-      vty_out (vty, "Can't save to configuration file, using vtysh.%s",
-               VTY_NEWLINE);
+      vty_outln (vty,"Can't save to configuration file, using vtysh.");
       return CMD_WARNING;
     }
 
@@ -1583,14 +1578,13 @@ DEFUN (config_write,
   fd = mkstemp (config_file_tmp);
   if (fd < 0)
     {
-      vty_out (vty, "Can't open configuration file %s.%s", config_file_tmp,
-               VTY_NEWLINE);
+      vty_outln (vty, "Can't open configuration file %s.",config_file_tmp);
       goto finished;
     }
   if (fchmod (fd, CONFIGFILE_MASK) != 0)
     {
-      vty_out (vty, "Can't chmod configuration file %s: %s (%d).%s",
-        config_file_tmp, safe_strerror(errno), errno, VTY_NEWLINE);
+      vty_outln (vty, "Can't chmod configuration file %s: %s (%d).",
+        config_file_tmp, safe_strerror(errno), errno);
       goto finished;
     }
 
@@ -1611,14 +1605,14 @@ DEFUN (config_write,
       if (unlink (config_file_sav) != 0)
         if (errno != ENOENT)
           {
-            vty_out (vty, "Can't unlink backup configuration file %s.%s", config_file_sav,
-                     VTY_NEWLINE);
+            vty_outln (vty, "Can't unlink backup configuration file %s.",
+                       config_file_sav);
             goto finished;
           }
       if (link (config_file, config_file_sav) != 0)
         {
-          vty_out (vty, "Can't backup old configuration file %s.%s", config_file_sav,
-                   VTY_NEWLINE);
+          vty_outln (vty, "Can't backup old configuration file %s.",
+                     config_file_sav);
           goto finished;
         }
       if (dirfd >= 0)
@@ -1626,15 +1620,13 @@ DEFUN (config_write,
     }
   if (rename (config_file_tmp, config_file) != 0)
     {
-      vty_out (vty, "Can't save configuration file %s.%s", config_file,
-               VTY_NEWLINE);
+      vty_outln (vty, "Can't save configuration file %s.",config_file);
       goto finished;
     }
   if (dirfd >= 0)
     fsync (dirfd);
 
-  vty_out (vty, "Configuration saved to %s%s", config_file,
-           VTY_NEWLINE);
+  vty_outln (vty, "Configuration saved to %s",config_file);
   ret = CMD_SUCCESS;
 
 finished:
@@ -1689,8 +1681,8 @@ DEFUN (show_startup_config,
   confp = fopen (host.config, "r");
   if (confp == NULL)
     {
-      vty_out (vty, "Can't open configuration file [%s] due to '%s'%s",
-               host.config, safe_strerror(errno), VTY_NEWLINE);
+      vty_outln (vty, "Can't open configuration file [%s] due to '%s'",
+               host.config, safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -1702,7 +1694,7 @@ DEFUN (show_startup_config,
         cp++;
       *cp = '\0';
 
-      vty_out (vty, "%s%s", buf, VTY_NEWLINE);
+      vty_outln (vty, "%s", buf);
     }
 
   fclose (confp);
@@ -1729,7 +1721,7 @@ DEFUN (config_hostname,
 
   if (!isalpha((int) word->arg[0]))
     {
-      vty_out (vty, "Please specify string starting with alphabet%s", VTY_NEWLINE);
+      vty_outln (vty, "Please specify string starting with alphabet");
       return CMD_WARNING;
     }
 
@@ -1769,8 +1761,8 @@ DEFUN (config_password,
 
   if (!isalnum (argv[idx_8]->arg[0]))
     {
-      vty_out (vty,
-               "Please specify string starting with alphanumeric%s", VTY_NEWLINE);
+      vty_outln (vty,
+               "Please specify string starting with alphanumeric");
       return CMD_WARNING;
     }
 
@@ -1819,15 +1811,15 @@ DEFUN (config_enable_password,
         }
       else
         {
-          vty_out (vty, "Unknown encryption type.%s", VTY_NEWLINE);
+          vty_outln (vty, "Unknown encryption type.");
           return CMD_WARNING;
         }
     }
 
   if (!isalnum (argv[idx_8]->arg[0]))
     {
-      vty_out (vty,
-               "Please specify string starting with alphanumeric%s", VTY_NEWLINE);
+      vty_outln (vty,
+               "Please specify string starting with alphanumeric");
       return CMD_WARNING;
     }
 
@@ -1976,8 +1968,8 @@ DEFUN_HIDDEN (do_echo,
 {
   char *message;
 
-  vty_out (vty, "%s%s", ((message = argv_concat (argv, argc, 1)) ? message : ""),
-           VTY_NEWLINE);
+  vty_outln (vty, "%s",
+             ((message = argv_concat(argv, argc, 1)) ? message : ""));
   if (message)
     XFREE(MTYPE_TMP, message);
   return CMD_SUCCESS;
@@ -2020,7 +2012,7 @@ DEFUN (show_logging,
     vty_out (vty, "level %s, facility %s, ident %s",
              zlog_priority[zl->maxlvl[ZLOG_DEST_SYSLOG]],
              facility_name(zl->facility), zl->ident);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   vty_out (vty, "Stdout logging: ");
   if (zl->maxlvl[ZLOG_DEST_STDOUT] == ZLOG_DISABLED)
@@ -2028,7 +2020,7 @@ DEFUN (show_logging,
   else
     vty_out (vty, "level %s",
              zlog_priority[zl->maxlvl[ZLOG_DEST_STDOUT]]);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   vty_out (vty, "Monitor logging: ");
   if (zl->maxlvl[ZLOG_DEST_MONITOR] == ZLOG_DISABLED)
@@ -2036,7 +2028,7 @@ DEFUN (show_logging,
   else
     vty_out (vty, "level %s",
              zlog_priority[zl->maxlvl[ZLOG_DEST_MONITOR]]);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   vty_out (vty, "File logging: ");
   if ((zl->maxlvl[ZLOG_DEST_FILE] == ZLOG_DISABLED) ||
@@ -2046,14 +2038,14 @@ DEFUN (show_logging,
     vty_out (vty, "level %s, filename %s",
              zlog_priority[zl->maxlvl[ZLOG_DEST_FILE]],
              zl->filename);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
-  vty_out (vty, "Protocol name: %s%s",
-           zl->protoname, VTY_NEWLINE);
-  vty_out (vty, "Record priority: %s%s",
-           (zl->record_priority ? "enabled" : "disabled"), VTY_NEWLINE);
-  vty_out (vty, "Timestamp precision: %d%s",
-           zl->timestamp_precision, VTY_NEWLINE);
+  vty_outln (vty, "Protocol name: %s",
+           zl->protoname);
+  vty_outln (vty, "Record priority: %s",
+           (zl->record_priority ? "enabled" : "disabled"));
+  vty_outln (vty, "Timestamp precision: %d",
+           zl->timestamp_precision);
 
   return CMD_SUCCESS;
 }

--- a/lib/distribute.c
+++ b/lib/distribute.c
@@ -349,7 +349,7 @@ DEFUN (no_distribute_list,
 
   if (! ret)
     {
-      vty_out (vty, "distribute list doesn't exist%s", VTY_NEWLINE);
+      vty_outln (vty, "distribute list doesn't exist");
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -393,9 +393,9 @@ config_show_distribute (struct vty *vty)
                                    DISTRIBUTE_V6_OUT, has_print);
     }
   if (has_print)
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
   else
-    vty_out (vty, " not set%s", VTY_NEWLINE);
+    vty_outln (vty, " not set");
 
   for (i = 0; i < disthash->size; i++)
     for (mp = disthash->index[i]; mp; mp = mp->next)
@@ -414,9 +414,9 @@ config_show_distribute (struct vty *vty)
             has_print = distribute_print(vty, dist->prefix, 1,
                                          DISTRIBUTE_V6_OUT, has_print);
             if (has_print)
-	      vty_out (vty, "%s", VTY_NEWLINE);
+	      vty_outln (vty, "");
             else
-              vty_out(vty, " nothing%s", VTY_NEWLINE);
+              vty_outln (vty, " nothing");
 	    }
       }
 
@@ -437,9 +437,9 @@ config_show_distribute (struct vty *vty)
                                    DISTRIBUTE_V6_IN, has_print);
     }
   if (has_print)
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
   else
-    vty_out (vty, " not set%s", VTY_NEWLINE);
+    vty_outln (vty, " not set");
 
   for (i = 0; i < disthash->size; i++)
     for (mp = disthash->index[i]; mp; mp = mp->next)
@@ -458,9 +458,9 @@ config_show_distribute (struct vty *vty)
             has_print = distribute_print(vty, dist->prefix, 1,
                                          DISTRIBUTE_V6_IN, has_print);
             if (has_print)
-	      vty_out (vty, "%s", VTY_NEWLINE);
+	      vty_outln (vty, "");
             else
-              vty_out(vty, " nothing%s", VTY_NEWLINE);
+              vty_outln (vty, " nothing");
 	    }
       }
   return 0;
@@ -487,12 +487,11 @@ config_write_distribute (struct vty *vty)
 	  if (dist->list[j]) {
 	    output = j == DISTRIBUTE_V4_OUT || j == DISTRIBUTE_V6_OUT;
             v6 = j == DISTRIBUTE_V6_IN || j == DISTRIBUTE_V6_OUT;
-	    vty_out (vty, " %sdistribute-list %s %s %s%s",
+	    vty_outln (vty, " %sdistribute-list %s %s %s",
                      v6 ? "ipv6 " : "",
 		     dist->list[j],
 		     output ? "out" : "in",
-		     dist->ifname ? dist->ifname : "",
-		     VTY_NEWLINE);
+		     dist->ifname ? dist->ifname : "");
 	    write++;
 	  }
 
@@ -500,12 +499,11 @@ config_write_distribute (struct vty *vty)
 	  if (dist->prefix[j]) {
 	    output = j == DISTRIBUTE_V4_OUT || j == DISTRIBUTE_V6_OUT;
             v6 = j == DISTRIBUTE_V6_IN || j == DISTRIBUTE_V6_OUT;
-	    vty_out (vty, " %sdistribute-list prefix %s %s %s%s",
+	    vty_outln (vty, " %sdistribute-list prefix %s %s %s",
                      v6 ? "ipv6 " : "",
 		     dist->prefix[j],
 		     output ? "out" : "in",
-		     dist->ifname ? dist->ifname : "",
-		     VTY_NEWLINE);
+		     dist->ifname ? dist->ifname : "");
 	    write++;
 	  }
       }

--- a/lib/distribute.c
+++ b/lib/distribute.c
@@ -393,7 +393,7 @@ config_show_distribute (struct vty *vty)
                                    DISTRIBUTE_V6_OUT, has_print);
     }
   if (has_print)
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
   else
     vty_outln (vty, " not set");
 
@@ -414,7 +414,7 @@ config_show_distribute (struct vty *vty)
             has_print = distribute_print(vty, dist->prefix, 1,
                                          DISTRIBUTE_V6_OUT, has_print);
             if (has_print)
-	      vty_outln (vty, "");
+	      vty_out (vty, VTYNL);
             else
               vty_outln (vty, " nothing");
 	    }
@@ -437,7 +437,7 @@ config_show_distribute (struct vty *vty)
                                    DISTRIBUTE_V6_IN, has_print);
     }
   if (has_print)
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
   else
     vty_outln (vty, " not set");
 
@@ -458,7 +458,7 @@ config_show_distribute (struct vty *vty)
             has_print = distribute_print(vty, dist->prefix, 1,
                                          DISTRIBUTE_V6_IN, has_print);
             if (has_print)
-	      vty_outln (vty, "");
+	      vty_out (vty, VTYNL);
             else
               vty_outln (vty, " nothing");
 	    }

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -576,8 +576,7 @@ vty_access_list_remark_unset (struct vty *vty, afi_t afi, const char *name)
   access = access_list_lookup (afi, name);
   if (! access)
     {
-      vty_out (vty, "%% access-list %s doesn't exist%s", name,
-	       VTY_NEWLINE);
+      vty_outln (vty, "%% access-list %s doesn't exist",name);
       return CMD_WARNING;
     }
 
@@ -616,23 +615,21 @@ filter_set_cisco (struct vty *vty, const char *name_str, const char *type_str,
     type = FILTER_DENY;
   else
     {
-      vty_out (vty, "%% filter type must be permit or deny%s", VTY_NEWLINE);
+      vty_outln (vty, "%% filter type must be permit or deny");
       return CMD_WARNING;
     }
 
   ret = inet_aton (addr_str, &addr);
   if (ret <= 0)
     {
-      vty_out (vty, "%%Inconsistent address and mask%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,"%%Inconsistent address and mask");
       return CMD_WARNING;
     }
 
   ret = inet_aton (addr_mask_str, &addr_mask);
   if (ret <= 0)
     {
-      vty_out (vty, "%%Inconsistent address and mask%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,"%%Inconsistent address and mask");
       return CMD_WARNING;
     }
 
@@ -641,16 +638,14 @@ filter_set_cisco (struct vty *vty, const char *name_str, const char *type_str,
       ret = inet_aton (mask_str, &mask);
       if (ret <= 0)
 	{
-	  vty_out (vty, "%%Inconsistent address and mask%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"%%Inconsistent address and mask");
 	  return CMD_WARNING;
 	}
 
       ret = inet_aton (mask_mask_str, &mask_mask);
       if (ret <= 0)
 	{
-	  vty_out (vty, "%%Inconsistent address and mask%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"%%Inconsistent address and mask");
 	  return CMD_WARNING;
 	}
     }
@@ -1261,9 +1256,9 @@ filter_set_zebra (struct vty *vty, const char *name_str, const char *type_str,
 
   if (strlen(name_str) > ACL_NAMSIZ)
     {
-      vty_out (vty, "%% ACL name %s is invalid: length exceeds "
-                    "%d characters%s",
-               name_str, ACL_NAMSIZ, VTY_NEWLINE);
+      vty_outln (vty, "%% ACL name %s is invalid: length exceeds "
+                    "%d characters",
+               name_str, ACL_NAMSIZ);
       return CMD_WARNING;
     }
 
@@ -1274,7 +1269,7 @@ filter_set_zebra (struct vty *vty, const char *name_str, const char *type_str,
     type = FILTER_DENY;
   else
     {
-      vty_out (vty, "filter type must be [permit|deny]%s", VTY_NEWLINE);
+      vty_outln (vty, "filter type must be [permit|deny]");
       return CMD_WARNING;
     }
 
@@ -1284,8 +1279,7 @@ filter_set_zebra (struct vty *vty, const char *name_str, const char *type_str,
       ret = str2prefix_ipv4 (prefix_str, (struct prefix_ipv4 *)&p);
       if (ret <= 0)
 	{
-	  vty_out (vty, "IP address prefix/prefixlen is malformed%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"IP address prefix/prefixlen is malformed");
 	  return CMD_WARNING;
 	}
     }
@@ -1294,8 +1288,7 @@ filter_set_zebra (struct vty *vty, const char *name_str, const char *type_str,
       ret = str2prefix_ipv6 (prefix_str, (struct prefix_ipv6 *) &p);
       if (ret <= 0)
 	{
-	  vty_out (vty, "IPv6 address prefix/prefixlen is malformed%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"IPv6 address prefix/prefixlen is malformed");
 		   return CMD_WARNING;
 	}
     }
@@ -1431,8 +1424,7 @@ DEFUN (no_access_list_all,
   access = access_list_lookup (AFI_IP, argv[idx_acl]->arg);
   if (access == NULL)
     {
-      vty_out (vty, "%% access-list %s doesn't exist%s", argv[idx_acl]->arg,
-	       VTY_NEWLINE);
+      vty_outln (vty, "%% access-list %s doesn't exist",argv[idx_acl]->arg);
       return CMD_WARNING;
     }
 
@@ -1609,8 +1601,7 @@ DEFUN (no_ipv6_access_list_all,
   access = access_list_lookup (AFI_IP6, argv[idx_word]->arg);
   if (access == NULL)
     {
-      vty_out (vty, "%% access-list %s doesn't exist%s", argv[idx_word]->arg,
-	       VTY_NEWLINE);
+      vty_outln (vty, "%% access-list %s doesn't exist",argv[idx_word]->arg);
       return CMD_WARNING;
     }
 
@@ -1697,7 +1688,7 @@ filter_show (struct vty *vty, const char *name, afi_t afi)
     return 0;
 
   /* Print the name of the protocol */
-  vty_out(vty, "%s:%s", frr_protoname, VTY_NEWLINE);
+  vty_outln (vty, "%s:", frr_protoname);
 
   for (access = master->num.head; access; access = access->next)
     {
@@ -1712,11 +1703,11 @@ filter_show (struct vty *vty, const char *name, afi_t afi)
 
 	  if (write)
 	    {
-	      vty_out (vty, "%s IP%s access list %s%s",
+	      vty_outln (vty, "%s IP%s access list %s",
 		       mfilter->cisco ? 
 		       (filter->extended ? "Extended" : "Standard") : "Zebra",
 		       afi == AFI_IP6 ? "v6" : "",
-		       access->name, VTY_NEWLINE);
+		       access->name);
 	      write = 0;
 	    }
 
@@ -1730,13 +1721,13 @@ filter_show (struct vty *vty, const char *name, afi_t afi)
 	  else
 	    {
 	      if (filter->addr_mask.s_addr == 0xffffffff)
-		vty_out (vty, " any%s", VTY_NEWLINE);
+		vty_outln (vty, " any");
 	      else
 		{
 		  vty_out (vty, " %s", inet_ntoa (filter->addr));
 		  if (filter->addr_mask.s_addr != 0)
 		    vty_out (vty, ", wildcard bits %s", inet_ntoa (filter->addr_mask));
-		  vty_out (vty, "%s", VTY_NEWLINE);
+		  vty_outln (vty, "");
 		}
 	    }
 	}
@@ -1755,11 +1746,11 @@ filter_show (struct vty *vty, const char *name, afi_t afi)
 
 	  if (write)
 	    {
-	      vty_out (vty, "%s IP%s access list %s%s",
+	      vty_outln (vty, "%s IP%s access list %s",
 		       mfilter->cisco ? 
 		       (filter->extended ? "Extended" : "Standard") : "Zebra",
 		       afi == AFI_IP6 ? "v6" : "",
-		       access->name, VTY_NEWLINE);
+		       access->name);
 	      write = 0;
 	    }
 
@@ -1773,13 +1764,13 @@ filter_show (struct vty *vty, const char *name, afi_t afi)
 	  else
 	    {
 	      if (filter->addr_mask.s_addr == 0xffffffff)
-		vty_out (vty, " any%s", VTY_NEWLINE);
+		vty_outln (vty, " any");
 	      else
 		{
 		  vty_out (vty, " %s", inet_ntoa (filter->addr));
 		  if (filter->addr_mask.s_addr != 0)
 		    vty_out (vty, ", wildcard bits %s", inet_ntoa (filter->addr_mask));
-		  vty_out (vty, "%s", VTY_NEWLINE);
+		  vty_outln (vty, "");
 		}
 	    }
 	}
@@ -1864,18 +1855,18 @@ config_write_access_cisco (struct vty *vty, struct filter *mfilter)
 	  vty_out (vty, " %s", inet_ntoa (filter->mask));
 	  vty_out (vty, " %s", inet_ntoa (filter->mask_mask));
 	}
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
   else
     {
       if (filter->addr_mask.s_addr == 0xffffffff)
-	vty_out (vty, " any%s", VTY_NEWLINE);
+	vty_outln (vty, " any");
       else
 	{
 	  vty_out (vty, " %s", inet_ntoa (filter->addr));
 	  if (filter->addr_mask.s_addr != 0)
 	    vty_out (vty, " %s", inet_ntoa (filter->addr_mask));
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_outln (vty, "");
 	}
     }
 }
@@ -1898,7 +1889,7 @@ config_write_access_zebra (struct vty *vty, struct filter *mfilter)
 	     p->prefixlen,
 	     filter->exact ? " exact-match" : "");
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 }
 
 static int
@@ -1917,10 +1908,9 @@ config_write_access (struct vty *vty, afi_t afi)
     {
       if (access->remark)
 	{
-	  vty_out (vty, "%saccess-list %s remark %s%s",
+	  vty_outln (vty, "%saccess-list %s remark %s",
 		   afi == AFI_IP ? "" : "ipv6 ",
-		   access->name, access->remark,
-		   VTY_NEWLINE);
+		   access->name,access->remark);
 	  write++;
 	}
 
@@ -1944,10 +1934,9 @@ config_write_access (struct vty *vty, afi_t afi)
     {
       if (access->remark)
 	{
-	  vty_out (vty, "%saccess-list %s remark %s%s",
+	  vty_outln (vty, "%saccess-list %s remark %s",
 		   afi == AFI_IP ? "" : "ipv6 ",
-		   access->name, access->remark,
-		   VTY_NEWLINE);
+		   access->name,access->remark);
 	  write++;
 	}
 

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -1727,7 +1727,7 @@ filter_show (struct vty *vty, const char *name, afi_t afi)
 		  vty_out (vty, " %s", inet_ntoa (filter->addr));
 		  if (filter->addr_mask.s_addr != 0)
 		    vty_out (vty, ", wildcard bits %s", inet_ntoa (filter->addr_mask));
-		  vty_outln (vty, "");
+		  vty_out (vty, VTYNL);
 		}
 	    }
 	}
@@ -1770,7 +1770,7 @@ filter_show (struct vty *vty, const char *name, afi_t afi)
 		  vty_out (vty, " %s", inet_ntoa (filter->addr));
 		  if (filter->addr_mask.s_addr != 0)
 		    vty_out (vty, ", wildcard bits %s", inet_ntoa (filter->addr_mask));
-		  vty_outln (vty, "");
+		  vty_out (vty, VTYNL);
 		}
 	    }
 	}
@@ -1855,7 +1855,7 @@ config_write_access_cisco (struct vty *vty, struct filter *mfilter)
 	  vty_out (vty, " %s", inet_ntoa (filter->mask));
 	  vty_out (vty, " %s", inet_ntoa (filter->mask_mask));
 	}
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   else
     {
@@ -1866,7 +1866,7 @@ config_write_access_cisco (struct vty *vty, struct filter *mfilter)
 	  vty_out (vty, " %s", inet_ntoa (filter->addr));
 	  if (filter->addr_mask.s_addr != 0)
 	    vty_out (vty, " %s", inet_ntoa (filter->addr_mask));
-	  vty_outln (vty, "");
+	  vty_out (vty, VTYNL);
 	}
     }
 }
@@ -1889,7 +1889,7 @@ config_write_access_zebra (struct vty *vty, struct filter *mfilter)
 	     p->prefixlen,
 	     filter->exact ? " exact-match" : "");
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 }
 
 static int

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -118,7 +118,7 @@ DEFUN (grammar_test_complete,
       // print completions
       for (i = 0; i < vector_active (comps); i++) {
         tkn = vector_slot (comps, i);
-        vty_out (vty, "  %-*s  %s%s", width, tkn->text, tkn->desc, VTY_NEWLINE);
+        vty_outln (vty, "  %-*s  %s", width, tkn->text, tkn->desc);
       }
 
       for (i = 0; i < vector_active (comps); i++)
@@ -126,7 +126,7 @@ DEFUN (grammar_test_complete,
       vector_free (comps);
     }
   else
-    vty_out (vty, "%% No match%s", VTY_NEWLINE);
+    vty_outln (vty, "%% No match");
 
   // free resources
   list_delete (completions);
@@ -164,13 +164,13 @@ DEFUN (grammar_test_match,
   // print completions or relevant error message
   if (element)
     {
-      vty_out (vty, "Matched: %s%s", element->string, VTY_NEWLINE);
+      vty_outln (vty, "Matched: %s", element->string);
       struct listnode *ln;
       struct cmd_token *token;
       for (ALL_LIST_ELEMENTS_RO(argvv,ln,token))
-        vty_out (vty, "%s -- %s%s", token->text, token->arg, VTY_NEWLINE);
+        vty_outln (vty, "%s -- %s", token->text, token->arg);
 
-      vty_out (vty, "func: %p%s", element->func, VTY_NEWLINE);
+      vty_outln (vty, "func: %p", element->func);
 
       list_delete (argvv);
     }
@@ -178,16 +178,16 @@ DEFUN (grammar_test_match,
      assert(MATCHER_ERROR(result));
      switch (result) {
        case MATCHER_NO_MATCH:
-          vty_out (vty, "%% Unknown command%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Unknown command");
           break;
        case MATCHER_INCOMPLETE:
-          vty_out (vty, "%% Incomplete command%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Incomplete command");
           break;
        case MATCHER_AMBIGUOUS:
-          vty_out (vty, "%% Ambiguous command%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Ambiguous command");
           break;
        default:
-          vty_out (vty, "%% Unknown error%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Unknown error");
           break;
      }
   }
@@ -401,7 +401,7 @@ DEFUN (grammar_findambig,
         nodegraph = cnode->cmdgraph;
         if (!nodegraph)
           continue;
-        vty_out (vty, "scanning node %d%s", scannode - 1, VTY_NEWLINE);
+        vty_outln (vty, "scanning node %d", scannode - 1);
       }
 
     commands = cmd_graph_permutations (nodegraph);
@@ -410,23 +410,25 @@ DEFUN (grammar_findambig,
       {
         int same = prev && !strcmp (prev->cmd, cur->cmd);
         if (printall && !same)
-          vty_out (vty, "'%s' [%x]%s", cur->cmd, cur->el->daemon, VTY_NEWLINE);
+          vty_outln (vty, "'%s' [%x]", cur->cmd, cur->el->daemon);
         if (same)
           {
-            vty_out (vty, "'%s' AMBIGUOUS:%s", cur->cmd, VTY_NEWLINE);
-            vty_out (vty, "  %s%s   '%s'%s", prev->el->name, VTY_NEWLINE, prev->el->string, VTY_NEWLINE);
-            vty_out (vty, "  %s%s   '%s'%s", cur->el->name,  VTY_NEWLINE, cur->el->string,  VTY_NEWLINE);
-            vty_out (vty, "%s", VTY_NEWLINE);
+            vty_outln (vty, "'%s' AMBIGUOUS:", cur->cmd);
+            vty_outln (vty, "  %s%s   '%s'", prev->el->name, VTY_NEWLINE,
+                       prev->el->string);
+            vty_outln (vty, "  %s%s   '%s'", cur->el->name,  VTY_NEWLINE,
+                       cur->el->string);
+            vty_outln (vty, "");
             ambig++;
           }
         prev = cur;
       }
     list_delete (commands);
 
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
   } while (scan && scannode < LINK_PARAMS_NODE);
 
-  vty_out (vty, "%d ambiguous commands found.%s", ambig, VTY_NEWLINE);
+  vty_outln (vty, "%d ambiguous commands found.", ambig);
 
   if (scan)
     nodegraph = NULL;
@@ -463,11 +465,11 @@ DEFUN (grammar_access,
   cnode = vector_slot (cmdvec, atoi (argv[2]->arg));
   if (!cnode)
     {
-      vty_out (vty, "%% no such node%s", VTY_NEWLINE);
+      vty_outln (vty, "%% no such node");
       return CMD_WARNING;
     }
 
-  vty_out (vty, "node %d%s", (int)cnode->node, VTY_NEWLINE);
+  vty_outln (vty, "node %d", (int)cnode->node);
   nodegraph = cnode->cmdgraph;
   return CMD_SUCCESS;
 }
@@ -532,7 +534,7 @@ pretty_print_graph (struct vty *vty, struct graph_node *start, int level,
 
   if (stackpos == MAXDEPTH)
     {
-      vty_out(vty, " -aborting! (depth limit)%s", VTY_NEWLINE);
+      vty_outln (vty, " -aborting! (depth limit)");
       return;
     }
   stack[stackpos++] = start;
@@ -541,7 +543,7 @@ pretty_print_graph (struct vty *vty, struct graph_node *start, int level,
   if (numto)
     {
       if (numto > 1)
-        vty_out(vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "");
       for (unsigned int i = 0; i < vector_active (start->to); i++)
         {
           struct graph_node *adj = vector_slot (start->to, i);
@@ -553,12 +555,12 @@ pretty_print_graph (struct vty *vty, struct graph_node *start, int level,
           if (adj == start)
             vty_out(vty, "*");
           else if (((struct cmd_token *)adj->data)->type == END_TKN)
-            vty_out(vty, "--END%s", VTY_NEWLINE);
+            vty_outln (vty, "--END");
           else {
             size_t k;
             for (k = 0; k < stackpos; k++)
               if (stack[k] == adj) {
-                vty_out(vty, "<<loop@%zu %s", k, VTY_NEWLINE);
+                vty_outln (vty, "<<loop@%zu ", k);
                 break;
               }
             if (k == stackpos)
@@ -567,7 +569,7 @@ pretty_print_graph (struct vty *vty, struct graph_node *start, int level,
        }
     }
   else
-    vty_out(vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
 }
 
 static void
@@ -650,5 +652,5 @@ init_cmdgraph (struct vty *vty, struct graph **graph)
   struct cmd_token *token = cmd_token_new (START_TKN, 0, NULL, NULL);
   graph_new_node (*graph, token, (void (*)(void *)) &cmd_token_del);
   if (vty)
-    vty_out (vty, "initialized graph%s", VTY_NEWLINE);
+    vty_outln (vty, "initialized graph");
 }

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -418,14 +418,14 @@ DEFUN (grammar_findambig,
                        prev->el->string);
             vty_outln (vty, "  %s%s   '%s'", cur->el->name,  VTYNL,
                        cur->el->string);
-            vty_outln (vty, "");
+            vty_out (vty, VTYNL);
             ambig++;
           }
         prev = cur;
       }
     list_delete (commands);
 
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
   } while (scan && scannode < LINK_PARAMS_NODE);
 
   vty_outln (vty, "%d ambiguous commands found.", ambig);
@@ -543,7 +543,7 @@ pretty_print_graph (struct vty *vty, struct graph_node *start, int level,
   if (numto)
     {
       if (numto > 1)
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
       for (unsigned int i = 0; i < vector_active (start->to); i++)
         {
           struct graph_node *adj = vector_slot (start->to, i);
@@ -569,7 +569,7 @@ pretty_print_graph (struct vty *vty, struct graph_node *start, int level,
        }
     }
   else
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
 }
 
 static void

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -414,9 +414,9 @@ DEFUN (grammar_findambig,
         if (same)
           {
             vty_outln (vty, "'%s' AMBIGUOUS:", cur->cmd);
-            vty_outln (vty, "  %s%s   '%s'", prev->el->name, VTY_NEWLINE,
+            vty_outln (vty, "  %s%s   '%s'", prev->el->name, VTYNL,
                        prev->el->string);
-            vty_outln (vty, "  %s%s   '%s'", cur->el->name,  VTY_NEWLINE,
+            vty_outln (vty, "  %s%s   '%s'", cur->el->name,  VTYNL,
                        cur->el->string);
             vty_outln (vty, "");
             ambig++;

--- a/lib/if.c
+++ b/lib/if.c
@@ -694,9 +694,9 @@ DEFUN (interface,
 
   if ((sl = strlen(ifname)) > INTERFACE_NAMSIZ)
     {
-      vty_out (vty, "%% Interface name %s is invalid: length exceeds "
-		    "%d characters%s",
-	       ifname, INTERFACE_NAMSIZ, VTY_NEWLINE);
+      vty_outln (vty, "%% Interface name %s is invalid: length exceeds "
+		    "%d characters",
+	       ifname, INTERFACE_NAMSIZ);
       return CMD_WARNING;
     }
 
@@ -713,7 +713,7 @@ DEFUN (interface,
 
   if (!ifp)
     {
-      vty_out (vty, "%% interface %s not in %s%s", ifname, vrfname, VTY_NEWLINE);
+      vty_outln (vty, "%% interface %s not in %s", ifname, vrfname);
       return CMD_WARNING;
     }
   VTY_PUSH_CONTEXT (INTERFACE_NODE, ifp);

--- a/lib/if.c
+++ b/lib/if.c
@@ -743,14 +743,14 @@ DEFUN_NOSH (no_interface,
 
   if (ifp == NULL)
     {
-      vty_out (vty, "%% Interface %s does not exist%s", ifname, VTY_NEWLINE);
+      vty_out (vty, "%% Interface %s does not exist%s", ifname, VTYNL);
       return CMD_WARNING;
     }
 
   if (CHECK_FLAG (ifp->status, ZEBRA_INTERFACE_ACTIVE)) 
     {
       vty_out (vty, "%% Only inactive interfaces can be deleted%s",
-	      VTY_NEWLINE);
+	      VTYNL);
       return CMD_WARNING;
     }
 
@@ -798,7 +798,7 @@ DEFUN (show_address,
 
 	  if (p->family == AF_INET)
 	    vty_out (vty, "%s/%d%s", inet_ntoa (p->u.prefix4), p->prefixlen,
-		     VTY_NEWLINE);
+		     VTYNL);
 	}
     }
   return CMD_SUCCESS;
@@ -823,8 +823,8 @@ DEFUN (show_address_vrf_all,
       if (!vrf->iflist || !listcount (vrf->iflist))
         continue;
 
-      vty_out (vty, "%sVRF %u%s%s", VTY_NEWLINE, vrf->vrf_id, VTY_NEWLINE,
-	       VTY_NEWLINE);
+      vty_out (vty, "%sVRF %u%s%s", VTYNL, vrf->vrf_id, VTYNL,
+	       VTYNL);
 
       for (ALL_LIST_ELEMENTS_RO (vrf->iflist, node, ifp))
         {
@@ -834,7 +834,7 @@ DEFUN (show_address_vrf_all,
 
               if (p->family == AF_INET)
                 vty_out (vty, "%s/%d%s", inet_ntoa (p->u.prefix4), p->prefixlen,
-                         VTY_NEWLINE);
+                         VTYNL);
             }
         }
     }

--- a/lib/if_rmap.c
+++ b/lib/if_rmap.c
@@ -228,7 +228,7 @@ DEFUN (if_rmap,
     type = IF_RMAP_OUT;
   else
     {
-      vty_out (vty, "route-map direction must be [in|out]%s", VTY_NEWLINE);
+      vty_outln (vty, "route-map direction must be [in|out]");
       return CMD_WARNING;
     }
 
@@ -259,14 +259,14 @@ DEFUN (no_if_rmap,
     type = IF_RMAP_OUT;
   else
     {
-      vty_out (vty, "route-map direction must be [in|out]%s", VTY_NEWLINE);
+      vty_outln (vty, "route-map direction must be [in|out]");
       return CMD_WARNING;
     }
 
   ret = if_rmap_unset (argv[idx_ifname]->arg, type, argv[idx_routemap_name]->arg);
   if (! ret)
     {
-      vty_out (vty, "route-map doesn't exist%s", VTY_NEWLINE);
+      vty_outln (vty, "route-map doesn't exist");
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -290,19 +290,17 @@ config_write_if_rmap (struct vty *vty)
 
 	if (if_rmap->routemap[IF_RMAP_IN])
 	  {
-	    vty_out (vty, " route-map %s in %s%s", 
+	    vty_outln (vty, " route-map %s in %s", 
 		     if_rmap->routemap[IF_RMAP_IN],
-		     if_rmap->ifname,
-		     VTY_NEWLINE);
+		     if_rmap->ifname);
 	    write++;
 	  }
 
 	if (if_rmap->routemap[IF_RMAP_OUT])
 	  {
-	    vty_out (vty, " route-map %s out %s%s", 
+	    vty_outln (vty, " route-map %s out %s", 
 		     if_rmap->routemap[IF_RMAP_OUT],
-		     if_rmap->ifname,
-		     VTY_NEWLINE);
+		     if_rmap->ifname);
 	    write++;
 	  }
       }

--- a/lib/keychain.c
+++ b/lib/keychain.c
@@ -271,7 +271,7 @@ DEFUN (no_key_chain,
 
   if (! keychain)
     {
-      vty_out (vty, "Can't find keychain %s%s", argv[idx_word]->arg, VTY_NEWLINE);
+      vty_outln (vty, "Can't find keychain %s", argv[idx_word]->arg);
       return CMD_WARNING;
     }
 
@@ -314,7 +314,7 @@ DEFUN (no_key,
   key = key_lookup (keychain, index);
   if (! key)
     {
-      vty_out (vty, "Can't find key %d%s", index, VTY_NEWLINE);
+      vty_outln (vty, "Can't find key %d", index);
       return CMD_WARNING;
     }
 
@@ -477,20 +477,20 @@ key_lifetime_set (struct vty *vty, struct key_range *krange,
   time_start = key_str2time (stime_str, sday_str, smonth_str, syear_str);
   if (time_start < 0)
     {
-      vty_out (vty, "Malformed time value%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed time value");
       return CMD_WARNING;
     }
   time_end = key_str2time (etime_str, eday_str, emonth_str, eyear_str);
 
   if (time_end < 0)
     {
-      vty_out (vty, "Malformed time value%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed time value");
       return CMD_WARNING;
     }
 
   if (time_end <= time_start)
     {
-      vty_out (vty, "Expire time is not later than start time%s", VTY_NEWLINE);
+      vty_outln (vty, "Expire time is not later than start time");
       return CMD_WARNING;
     }
 
@@ -512,7 +512,7 @@ key_lifetime_duration_set (struct vty *vty, struct key_range *krange,
   time_start = key_str2time (stime_str, sday_str, smonth_str, syear_str);
   if (time_start < 0)
     {
-      vty_out (vty, "Malformed time value%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed time value");
       return CMD_WARNING;
     }
   krange->start = time_start;
@@ -534,7 +534,7 @@ key_lifetime_infinite_set (struct vty *vty, struct key_range *krange,
   time_start = key_str2time (stime_str, sday_str, smonth_str, syear_str);
   if (time_start < 0)
     {
-      vty_out (vty, "Malformed time value%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed time value");
       return CMD_WARNING;
     }
   krange->start = time_start;
@@ -966,14 +966,14 @@ keychain_config_write (struct vty *vty)
 
   for (ALL_LIST_ELEMENTS_RO (keychain_list, node, keychain))
     {
-      vty_out (vty, "key chain %s%s", keychain->name, VTY_NEWLINE);
+      vty_outln (vty, "key chain %s", keychain->name);
       
       for (ALL_LIST_ELEMENTS_RO (keychain->key, knode, key))
 	{
-	  vty_out (vty, " key %d%s", key->index, VTY_NEWLINE);
+	  vty_outln (vty, " key %d", key->index);
 
 	  if (key->string)
-	    vty_out (vty, "  key-string %s%s", key->string, VTY_NEWLINE);
+	    vty_outln (vty, "  key-string %s", key->string);
 
 	  if (key->accept.start)
 	    {
@@ -990,7 +990,7 @@ keychain_config_write (struct vty *vty)
 		  keychain_strftime (buf, BUFSIZ, &key->accept.end);
 		  vty_out (vty, " %s", buf);
 		}
-	      vty_out (vty, "%s", VTY_NEWLINE);
+	      vty_outln (vty, "");
 	    }
 
 	  if (key->send.start)
@@ -1007,10 +1007,10 @@ keychain_config_write (struct vty *vty)
 		  keychain_strftime (buf, BUFSIZ, &key->send.end);
 		  vty_out (vty, " %s", buf);
 		}
-	      vty_out (vty, "%s", VTY_NEWLINE);
+	      vty_outln (vty, "");
 	    }
 	}
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_outln (vty, "!");
     }
 
   return 0;

--- a/lib/keychain.c
+++ b/lib/keychain.c
@@ -990,7 +990,7 @@ keychain_config_write (struct vty *vty)
 		  keychain_strftime (buf, BUFSIZ, &key->accept.end);
 		  vty_out (vty, " %s", buf);
 		}
-	      vty_outln (vty, "");
+	      vty_out (vty, VTYNL);
 	    }
 
 	  if (key->send.start)
@@ -1007,7 +1007,7 @@ keychain_config_write (struct vty *vty)
 		  keychain_strftime (buf, BUFSIZ, &key->send.end);
 		  vty_out (vty, " %s", buf);
 		}
-	      vty_outln (vty, "");
+	      vty_out (vty, VTYNL);
 	    }
 	}
       vty_outln (vty, "!");

--- a/lib/memory_vty.c
+++ b/lib/memory_vty.c
@@ -110,7 +110,7 @@ DEFUN (show_modules,
 
   vty_outln (vty, "%-12s %-25s %s%s",
                 "Module Name", "Version", "Description",
-                VTY_NEWLINE);
+                VTYNL);
   while (plug)
     {
       const struct frrmod_info *i = plug->info;

--- a/lib/memory_vty.c
+++ b/lib/memory_vty.c
@@ -44,36 +44,26 @@ show_memory_mallinfo (struct vty *vty)
   struct mallinfo minfo = mallinfo();
   char buf[MTYPE_MEMSTR_LEN];
   
-  vty_out (vty, "System allocator statistics:%s", VTY_NEWLINE);
-  vty_out (vty, "  Total heap allocated:  %s%s",
-           mtype_memstr (buf, MTYPE_MEMSTR_LEN, minfo.arena),
-           VTY_NEWLINE);
-  vty_out (vty, "  Holding block headers: %s%s",
-           mtype_memstr (buf, MTYPE_MEMSTR_LEN, minfo.hblkhd),
-           VTY_NEWLINE);
-  vty_out (vty, "  Used small blocks:     %s%s",
-           mtype_memstr (buf, MTYPE_MEMSTR_LEN, minfo.usmblks),
-           VTY_NEWLINE);
-  vty_out (vty, "  Used ordinary blocks:  %s%s",
-           mtype_memstr (buf, MTYPE_MEMSTR_LEN, minfo.uordblks),
-           VTY_NEWLINE);
-  vty_out (vty, "  Free small blocks:     %s%s",
-           mtype_memstr (buf, MTYPE_MEMSTR_LEN, minfo.fsmblks),
-           VTY_NEWLINE);
-  vty_out (vty, "  Free ordinary blocks:  %s%s",
-           mtype_memstr (buf, MTYPE_MEMSTR_LEN, minfo.fordblks),
-           VTY_NEWLINE);
-  vty_out (vty, "  Ordinary blocks:       %ld%s",
-           (unsigned long)minfo.ordblks,
-           VTY_NEWLINE);
-  vty_out (vty, "  Small blocks:          %ld%s",
-           (unsigned long)minfo.smblks,
-           VTY_NEWLINE);
-  vty_out (vty, "  Holding blocks:        %ld%s",
-           (unsigned long)minfo.hblks,
-           VTY_NEWLINE);
-  vty_out (vty, "(see system documentation for 'mallinfo' for meaning)%s",
-           VTY_NEWLINE);
+  vty_outln (vty, "System allocator statistics:");
+  vty_outln (vty, "  Total heap allocated:  %s",
+           mtype_memstr(buf, MTYPE_MEMSTR_LEN, minfo.arena));
+  vty_outln (vty, "  Holding block headers: %s",
+           mtype_memstr(buf, MTYPE_MEMSTR_LEN, minfo.hblkhd));
+  vty_outln (vty, "  Used small blocks:     %s",
+           mtype_memstr(buf, MTYPE_MEMSTR_LEN, minfo.usmblks));
+  vty_outln (vty, "  Used ordinary blocks:  %s",
+           mtype_memstr(buf, MTYPE_MEMSTR_LEN, minfo.uordblks));
+  vty_outln (vty, "  Free small blocks:     %s",
+           mtype_memstr(buf, MTYPE_MEMSTR_LEN, minfo.fsmblks));
+  vty_outln (vty, "  Free ordinary blocks:  %s",
+           mtype_memstr(buf, MTYPE_MEMSTR_LEN, minfo.fordblks));
+  vty_outln (vty, "  Ordinary blocks:       %ld",
+           (unsigned long)minfo.ordblks);
+  vty_outln (vty, "  Small blocks:          %ld",
+           (unsigned long)minfo.smblks);
+  vty_outln (vty, "  Holding blocks:        %ld",
+           (unsigned long)minfo.hblks);
+  vty_outln (vty,"(see system documentation for 'mallinfo' for meaning)");
   return 1;
 }
 #endif /* HAVE_MALLINFO */
@@ -82,16 +72,14 @@ static int qmem_walker(void *arg, struct memgroup *mg, struct memtype *mt)
 {
 	struct vty *vty = arg;
 	if (!mt)
-		vty_out (vty, "--- qmem %s ---%s", mg->name, VTY_NEWLINE);
+		vty_outln (vty, "--- qmem %s ---", mg->name);
 	else {
 		if (mt->n_alloc != 0) {
 			char size[32];
 			snprintf(size, sizeof(size), "%6zu", mt->size);
-			vty_out (vty, "%-30s: %10zu  %s%s",
+			vty_outln (vty, "%-30s: %10zu  %s",
 				 mt->name, mt->n_alloc,
-				 mt->size == 0 ? "" :
-				 mt->size == SIZE_VAR ? "(variably sized)" :
-				 size, VTY_NEWLINE);
+				 mt->size == 0 ? "" : mt->size == SIZE_VAR ? "(variably sized)" : size);
 		}
 	}
 	return 0;
@@ -120,15 +108,14 @@ DEFUN (show_modules,
 {
   struct frrmod_runtime *plug = frrmod_list;
 
-  vty_out (vty, "%-12s %-25s %s%s%s",
+  vty_outln (vty, "%-12s %-25s %s%s",
                 "Module Name", "Version", "Description",
-                VTY_NEWLINE, VTY_NEWLINE);
+                VTY_NEWLINE);
   while (plug)
     {
       const struct frrmod_info *i = plug->info;
 
-      vty_out (vty, "%-12s %-25s %s%s", i->name, i->version, i->description,
-                    VTY_NEWLINE);
+      vty_outln (vty, "%-12s %-25s %s", i->name, i->version,i->description);
       if (plug->dl_handle)
         {
 #ifdef HAVE_DLINFO_ORIGIN
@@ -142,13 +129,13 @@ DEFUN (show_modules,
             {
               name = strrchr(lm->l_name, '/');
               name = name ? name + 1 : lm->l_name;
-              vty_out (vty, "\tfrom: %s/%s%s", origin, name, VTY_NEWLINE);
+              vty_outln (vty, "\tfrom: %s/%s", origin, name);
             }
 # else
-          vty_out (vty, "\tfrom: %s %s", origin, plug->load_name, VTY_NEWLINE);
+          vty_outln (vty, "\tfrom: %s ", origin, plug->load_name);
 # endif
 #else
-          vty_out (vty, "\tfrom: %s%s", plug->load_name, VTY_NEWLINE);
+          vty_outln (vty, "\tfrom: %s", plug->load_name);
 #endif
         }
       plug = plug->next;

--- a/lib/ns.c
+++ b/lib/ns.c
@@ -325,7 +325,7 @@ DEFUN_NOSH (ns_netns,
   if (ns->name && strcmp (ns->name, pathname) != 0)
     {
       vty_out (vty, "NS %u is already configured with NETNS %s%s",
-               ns->ns_id, ns->name, VTY_NEWLINE);
+               ns->ns_id, ns->name, VTYNL);
       return CMD_WARNING;
     }
 
@@ -335,7 +335,7 @@ DEFUN_NOSH (ns_netns,
   if (!ns_enable (ns))
     {
       vty_out (vty, "Can not associate NS %u with NETNS %s%s",
-               ns->ns_id, ns->name, VTY_NEWLINE);
+               ns->ns_id, ns->name, VTYNL);
       return CMD_WARNING;
     }
 

--- a/lib/ns.c
+++ b/lib/ns.c
@@ -296,8 +296,7 @@ ns_netns_pathname (struct vty *vty, const char *name)
 
   if (! result)
     {
-      vty_out (vty, "Invalid pathname: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "Invalid pathname: %s",safe_strerror(errno));
       return NULL;
     }
   return pathname;
@@ -366,13 +365,13 @@ DEFUN (no_ns_netns,
 
   if (!ns)
     {
-      vty_out (vty, "NS %u is not found%s", ns_id, VTY_NEWLINE);
+      vty_outln (vty, "NS %u is not found", ns_id);
       return CMD_SUCCESS;
     }
 
   if (ns->name && strcmp (ns->name, pathname) != 0)
     {
-      vty_out (vty, "Incorrect NETNS file name%s", VTY_NEWLINE);
+      vty_outln (vty, "Incorrect NETNS file name");
       return CMD_WARNING;
     }
 
@@ -406,8 +405,7 @@ ns_config_write (struct vty *vty)
       if (ns->ns_id == NS_DEFAULT || ns->name == NULL)
 	continue;
 
-      vty_out (vty, "logical-router %u netns %s%s", ns->ns_id, ns->name,
-	       VTY_NEWLINE);
+      vty_outln (vty, "logical-router %u netns %s", ns->ns_id,ns->name);
       write = 1;
   }
 

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -882,8 +882,8 @@ prefix_entry_dup_check (struct prefix_list *plist,
 static int
 vty_invalid_prefix_range (struct vty *vty, const char *prefix)
 {
-  vty_out (vty, "%% Invalid prefix range for %s, make sure: len < ge-value <= le-value%s",
-           prefix, VTY_NEWLINE);
+  vty_outln (vty, "%% Invalid prefix range for %s, make sure: len < ge-value <= le-value",
+           prefix);
   return CMD_WARNING;
 }
 
@@ -920,7 +920,7 @@ vty_prefix_list_install (struct vty *vty, afi_t afi, const char *name,
     type = PREFIX_DENY;
   else
     {
-      vty_out (vty, "%% prefix type must be permit or deny%s", VTY_NEWLINE);
+      vty_outln (vty, "%% prefix type must be permit or deny");
       return CMD_WARNING;
     }
 
@@ -940,7 +940,7 @@ vty_prefix_list_install (struct vty *vty, afi_t afi, const char *name,
 
       if (ret <= 0)
 	{
-	  vty_out (vty, "%% Malformed IPv4 prefix%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Malformed IPv4 prefix");
 	  return CMD_WARNING;
 	}
 
@@ -962,7 +962,7 @@ vty_prefix_list_install (struct vty *vty, afi_t afi, const char *name,
 
       if (ret <= 0)
 	{
-	  vty_out (vty, "%% Malformed IPv6 prefix%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Malformed IPv6 prefix");
 	  return CMD_WARNING;
 	}
 
@@ -973,7 +973,7 @@ vty_prefix_list_install (struct vty *vty, afi_t afi, const char *name,
       break;
     case AFI_L2VPN:
     default:
-      vty_out (vty, "%% Unrecognized AFI (%d)%s", afi, VTY_NEWLINE);
+      vty_outln (vty, "%% Unrecognized AFI (%d)", afi);
       return CMD_WARNING;
       break;
     }
@@ -1042,7 +1042,7 @@ vty_prefix_list_uninstall (struct vty *vty, afi_t afi, const char *name,
   plist = prefix_list_lookup (afi, name);
   if (! plist)
     {
-      vty_out (vty, "%% Can't find specified prefix-list%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Can't find specified prefix-list");
       return CMD_WARNING;
     }
 
@@ -1057,7 +1057,7 @@ vty_prefix_list_uninstall (struct vty *vty, afi_t afi, const char *name,
   /* We must have, at a minimum, both the type and prefix here */
   if ((typestr == NULL) || (prefix == NULL))
     {
-      vty_out (vty, "%% Both prefix and type required%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Both prefix and type required");
       return CMD_WARNING;
     }
 
@@ -1078,7 +1078,7 @@ vty_prefix_list_uninstall (struct vty *vty, afi_t afi, const char *name,
     type = PREFIX_DENY;
   else
     {
-      vty_out (vty, "%% prefix type must be permit or deny%s", VTY_NEWLINE);
+      vty_outln (vty, "%% prefix type must be permit or deny");
       return CMD_WARNING;
     }
 
@@ -1096,7 +1096,7 @@ vty_prefix_list_uninstall (struct vty *vty, afi_t afi, const char *name,
 
       if (ret <= 0)
 	{
-	  vty_out (vty, "%% Malformed IPv4 prefix%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Malformed IPv4 prefix");
 	  return CMD_WARNING;
 	}
     }
@@ -1113,7 +1113,7 @@ vty_prefix_list_uninstall (struct vty *vty, afi_t afi, const char *name,
 
       if (ret <= 0)
 	{
-	  vty_out (vty, "%% Malformed IPv6 prefix%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Malformed IPv6 prefix");
 	  return CMD_WARNING;
 	}
     }
@@ -1123,7 +1123,7 @@ vty_prefix_list_uninstall (struct vty *vty, afi_t afi, const char *name,
 
   if (pentry == NULL)
     {
-      vty_out (vty, "%% Can't find specified prefix-list%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Can't find specified prefix-list");
       return CMD_WARNING;
     }
 
@@ -1141,7 +1141,7 @@ vty_prefix_list_desc_unset (struct vty *vty, afi_t afi, const char *name)
   plist = prefix_list_lookup (afi, name);
   if (! plist)
     {
-      vty_out (vty, "%% Can't find specified prefix-list%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Can't find specified prefix-list");
       return CMD_WARNING;
     }
 
@@ -1179,25 +1179,24 @@ vty_show_prefix_entry (struct vty *vty, afi_t afi, struct prefix_list *plist,
                                                                            
   if (dtype == normal_display)
     {
-      vty_out (vty, "ip%s prefix-list %s: %d entries%s",
+      vty_outln (vty, "ip%s prefix-list %s: %d entries",
 	       afi == AFI_IP ? "" : "v6",
-	       plist->name, plist->count, VTY_NEWLINE);
+	       plist->name, plist->count);
       if (plist->desc)
-	vty_out (vty, "   Description: %s%s", plist->desc, VTY_NEWLINE);
+	vty_outln (vty, "   Description: %s", plist->desc);
     }
   else if (dtype == summary_display || dtype == detail_display)
     {
-      vty_out (vty, "ip%s prefix-list %s:%s",
-	       afi == AFI_IP ? "" : "v6", plist->name, VTY_NEWLINE);
+      vty_outln (vty, "ip%s prefix-list %s:",
+	       afi == AFI_IP ? "" : "v6", plist->name);
 
       if (plist->desc)
-	vty_out (vty, "   Description: %s%s", plist->desc, VTY_NEWLINE);
+	vty_outln (vty, "   Description: %s", plist->desc);
 
-      vty_out (vty, "   count: %d, range entries: %d, sequences: %u - %u%s",
+      vty_outln (vty, "   count: %d, range entries: %d, sequences: %u - %u",
 	       plist->count, plist->rangecount, 
 	       plist->head ? plist->head->seq : 0, 
-	       plist->tail ? plist->tail->seq : 0,
-	       VTY_NEWLINE);
+	       plist->tail ? plist->tail->seq : 0);
     }
 
   if (dtype != summary_display)
@@ -1235,7 +1234,7 @@ vty_show_prefix_entry (struct vty *vty, afi_t afi, struct prefix_list *plist,
 	    vty_out (vty, " (hit count: %ld, refcount: %ld)", 
 		     pentry->hitcnt, pentry->refcnt);
 	  
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_outln (vty, "");
 	}
     }
 }
@@ -1260,7 +1259,7 @@ vty_show_prefix_list (struct vty *vty, afi_t afi, const char *name,
       plist = prefix_list_lookup (afi, name);
       if (! plist)
 	{
-	  vty_out (vty, "%% Can't find specified prefix-list%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Can't find specified prefix-list");
 	  return CMD_WARNING;
 	}
       vty_show_prefix_entry (vty, afi, plist, master, dtype, seqnum);
@@ -1270,8 +1269,8 @@ vty_show_prefix_list (struct vty *vty, afi_t afi, const char *name,
       if (dtype == detail_display || dtype == summary_display)
 	{
 	  if (master->recent)
-	    vty_out (vty, "Prefix-list with the last deletion/insertion: %s%s",
-		     master->recent->name, VTY_NEWLINE);
+	    vty_outln (vty, "Prefix-list with the last deletion/insertion: %s",
+		     master->recent->name);
 	}
 
       for (plist = master->num.head; plist; plist = plist->next)
@@ -1297,14 +1296,14 @@ vty_show_prefix_list_prefix (struct vty *vty, afi_t afi, const char *name,
   plist = prefix_list_lookup (afi, name);
   if (! plist)
     {
-      vty_out (vty, "%% Can't find specified prefix-list%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Can't find specified prefix-list");
       return CMD_WARNING;
     }
 
   ret = str2prefix (prefix, &p);
   if (ret <= 0)
     {
-      vty_out (vty, "%% prefix is malformed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% prefix is malformed");
       return CMD_WARNING;
     }
 
@@ -1347,7 +1346,7 @@ vty_show_prefix_list_prefix (struct vty *vty, afi_t afi, const char *name,
 	    vty_out (vty, " (hit count: %ld, refcount: %ld)", 
 		     pentry->hitcnt, pentry->refcnt);
 
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_outln (vty, "");
 
 	  if (type == first_match_display)
 	    return CMD_SUCCESS;
@@ -1385,7 +1384,7 @@ vty_clear_prefix_list (struct vty *vty, afi_t afi, const char *name,
       plist = prefix_list_lookup (afi, name);
       if (! plist)
 	{
-	  vty_out (vty, "%% Can't find specified prefix-list%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Can't find specified prefix-list");
 	  return CMD_WARNING;
 	}
 
@@ -1394,7 +1393,7 @@ vty_clear_prefix_list (struct vty *vty, afi_t afi, const char *name,
 	  ret = str2prefix (prefix, &p);
 	  if (ret <= 0)
 	    {
-	      vty_out (vty, "%% prefix is malformed%s", VTY_NEWLINE);
+	      vty_outln (vty, "%% prefix is malformed");
 	      return CMD_WARNING;
 	    }
 	}
@@ -1819,18 +1818,18 @@ config_write_prefix_afi (afi_t afi, struct vty *vty)
 
   if (! master->seqnum)
     {
-      vty_out (vty, "no ip%s prefix-list sequence-number%s", 
-	       afi == AFI_IP ? "" : "v6", VTY_NEWLINE);
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_outln (vty, "no ip%s prefix-list sequence-number", 
+	       afi == AFI_IP ? "" : "v6");
+      vty_outln (vty, "!");
     }
 
   for (plist = master->num.head; plist; plist = plist->next)
     {
       if (plist->desc)
 	{
-	  vty_out (vty, "ip%s prefix-list %s description %s%s",
+	  vty_outln (vty, "ip%s prefix-list %s description %s",
 		   afi == AFI_IP ? "" : "v6",
-		   plist->name, plist->desc, VTY_NEWLINE);
+		   plist->name, plist->desc);
 	  write++;
 	}
 
@@ -1861,7 +1860,7 @@ config_write_prefix_afi (afi_t afi, struct vty *vty)
 	      if (pentry->le)
 		vty_out (vty, " le %d", pentry->le);
 	    }
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_outln (vty, "");
 	  write++;
 	}
       /* vty_out (vty, "!%s", VTY_NEWLINE); */
@@ -1871,9 +1870,9 @@ config_write_prefix_afi (afi_t afi, struct vty *vty)
     {
       if (plist->desc)
 	{
-	  vty_out (vty, "ip%s prefix-list %s description %s%s",
+	  vty_outln (vty, "ip%s prefix-list %s description %s",
 		   afi == AFI_IP ? "" : "v6",
-		   plist->name, plist->desc, VTY_NEWLINE);
+		   plist->name, plist->desc);
 	  write++;
 	}
 
@@ -1904,7 +1903,7 @@ config_write_prefix_afi (afi_t afi, struct vty *vty)
 	      if (pentry->le)
 		vty_out (vty, " le %d", pentry->le);
 	    }
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_outln (vty, "");
 	  write++;
 	}
     }
@@ -2049,14 +2048,15 @@ prefix_bgp_show_prefix_list (struct vty *vty, afi_t afi, char *name, u_char use_
       else
         json_object_object_add(json, "ipv6PrefixList", json_prefix);
 
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free(json);
     }
   else
     {
-      vty_out (vty, "ip%s prefix-list %s: %d entries%s",
+      vty_outln (vty, "ip%s prefix-list %s: %d entries",
                afi == AFI_IP ? "" : "v6",
-               plist->name, plist->count, VTY_NEWLINE);
+               plist->name, plist->count);
 
       for (pentry = plist->head; pentry; pentry = pentry->next)
         {
@@ -2073,7 +2073,7 @@ prefix_bgp_show_prefix_list (struct vty *vty, afi_t afi, char *name, u_char use_
           if (pentry->le)
             vty_out (vty, " le %d", pentry->le);
 
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
         }
     }
   return plist->count;

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1863,7 +1863,7 @@ config_write_prefix_afi (afi_t afi, struct vty *vty)
 	  vty_outln (vty, "");
 	  write++;
 	}
-      /* vty_out (vty, "!%s", VTY_NEWLINE); */
+      /* vty_out (vty, "!%s", VTYNL); */
     }
 
   for (plist = master->str.head; plist; plist = plist->next)

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1234,7 +1234,7 @@ vty_show_prefix_entry (struct vty *vty, afi_t afi, struct prefix_list *plist,
 	    vty_out (vty, " (hit count: %ld, refcount: %ld)", 
 		     pentry->hitcnt, pentry->refcnt);
 	  
-	  vty_outln (vty, "");
+	  vty_out (vty, VTYNL);
 	}
     }
 }
@@ -1346,7 +1346,7 @@ vty_show_prefix_list_prefix (struct vty *vty, afi_t afi, const char *name,
 	    vty_out (vty, " (hit count: %ld, refcount: %ld)", 
 		     pentry->hitcnt, pentry->refcnt);
 
-	  vty_outln (vty, "");
+	  vty_out (vty, VTYNL);
 
 	  if (type == first_match_display)
 	    return CMD_SUCCESS;
@@ -1860,7 +1860,7 @@ config_write_prefix_afi (afi_t afi, struct vty *vty)
 	      if (pentry->le)
 		vty_out (vty, " le %d", pentry->le);
 	    }
-	  vty_outln (vty, "");
+	  vty_out (vty, VTYNL);
 	  write++;
 	}
       /* vty_out (vty, "!%s", VTYNL); */
@@ -1903,7 +1903,7 @@ config_write_prefix_afi (afi_t afi, struct vty *vty)
 	      if (pentry->le)
 		vty_out (vty, " le %d", pentry->le);
 	    }
-	  vty_outln (vty, "");
+	  vty_out (vty, VTYNL);
 	  write++;
 	}
     }
@@ -2073,7 +2073,7 @@ prefix_bgp_show_prefix_list (struct vty *vty, afi_t afi, char *name, u_char use_
           if (pentry->le)
             vty_out (vty, " le %d", pentry->le);
 
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
         }
     }
   return plist->count;

--- a/lib/route_types.pl
+++ b/lib/route_types.pl
@@ -123,7 +123,7 @@ sub codelist {
 	push @lines, "  \"       > - selected route, * - FIB route%s%s\", \\\n";
 	my @nl = ();
 	for (my $c = 0; $c < @lines + 1; $c++) {
-		push @nl, "VTY_NEWLINE"
+		push @nl, "VTYNL"
 	}
 	return join("", @lines) ."  ". join(", ", @nl);
 }

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -521,12 +521,11 @@ generic_match_add (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_out (vty, "%% [%s] Can't find rule.%s", frr_protonameinst,
-                   VTY_NEWLINE);
+          vty_outln (vty, "%% [%s] Can't find rule.", frr_protonameinst);
           return CMD_WARNING;
         case RMAP_COMPILE_ERROR:
-          vty_out (vty, "%% [%s] Argument form is unsupported or malformed.%s",
-                   frr_protonameinst, VTY_NEWLINE);
+          vty_outln (vty, "%% [%s] Argument form is unsupported or malformed.",
+                     frr_protonameinst);
           return CMD_WARNING;
         }
     }
@@ -569,8 +568,7 @@ generic_match_delete (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_out (vty, "%% [%s] Can't find rule.%s", frr_protonameinst,
-                   VTY_NEWLINE);
+          vty_outln (vty, "%% [%s] Can't find rule.%s", frr_protonameinst);
           break;
         case RMAP_COMPILE_ERROR:
           vty_out (vty, "%% [%s] Argument form is unsupported or malformed.%s",
@@ -607,12 +605,11 @@ generic_set_add (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_out (vty, "%% [%s] Can't find rule.%s", frr_protonameinst,
-                   VTY_NEWLINE);
+          vty_outln (vty, "%% [%s] Can't find rule.%s", frr_protonameinst);
           return CMD_WARNING;
         case RMAP_COMPILE_ERROR:
-          vty_out (vty, "%% [%s] Argument form is unsupported or malformed.%s",
-                   frr_protonameinst, VTY_NEWLINE);
+          vty_outln (vty, "%% [%s] Argument form is unsupported or malformed.",
+                     frr_protonameinst);
           return CMD_WARNING;
         }
     }
@@ -631,12 +628,11 @@ generic_set_delete (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_out (vty, "%% [%s] Can't find rule.%s", frr_protonameinst,
-                   VTY_NEWLINE);
+          vty_outln (vty, "%% [%s] Can't find rule.%s", frr_protonameinst);
           return CMD_WARNING;
         case RMAP_COMPILE_ERROR:
-          vty_out (vty, "%% [%s] Argument form is unsupported or malformed.%s",
-                   frr_protonameinst, VTY_NEWLINE);
+          vty_outln (vty, "%% [%s] Argument form is unsupported or malformed.%s",
+                     frr_protonameinst);
           return CMD_WARNING;
         }
     }
@@ -997,43 +993,43 @@ vty_show_route_map_entry (struct vty *vty, struct route_map *map)
   struct route_map_index *index;
   struct route_map_rule *rule;
 
-  vty_out (vty, "%s:%s", frr_protonameinst, VTY_NEWLINE);
+  vty_outln (vty, "%s:", frr_protonameinst);
 
   for (index = map->head; index; index = index->next)
     {
-      vty_out (vty, "route-map %s, %s, sequence %d%s",
+      vty_outln (vty, "route-map %s, %s, sequence %d",
                map->name, route_map_type_str (index->type),
-               index->pref, VTY_NEWLINE);
+               index->pref);
 
       /* Description */
       if (index->description)
-	vty_out (vty, "  Description:%s    %s%s", VTY_NEWLINE,
-		 index->description, VTY_NEWLINE);
+	vty_outln (vty, "  Description:%s    %s", VTY_NEWLINE,
+		 index->description);
       
       /* Match clauses */
-      vty_out (vty, "  Match clauses:%s", VTY_NEWLINE);
+      vty_outln (vty, "  Match clauses:");
       for (rule = index->match_list.head; rule; rule = rule->next)
-        vty_out (vty, "    %s %s%s", 
-                 rule->cmd->str, rule->rule_str, VTY_NEWLINE);
+        vty_outln (vty, "    %s %s", 
+                 rule->cmd->str, rule->rule_str);
       
-      vty_out (vty, "  Set clauses:%s", VTY_NEWLINE);
+      vty_outln (vty, "  Set clauses:");
       for (rule = index->set_list.head; rule; rule = rule->next)
-        vty_out (vty, "    %s %s%s",
-                 rule->cmd->str, rule->rule_str, VTY_NEWLINE);
+        vty_outln (vty, "    %s %s",
+                 rule->cmd->str, rule->rule_str);
       
       /* Call clause */
-      vty_out (vty, "  Call clause:%s", VTY_NEWLINE);
+      vty_outln (vty, "  Call clause:");
       if (index->nextrm)
-        vty_out (vty, "    Call %s%s", index->nextrm, VTY_NEWLINE);
+        vty_outln (vty, "    Call %s", index->nextrm);
       
       /* Exit Policy */
-      vty_out (vty, "  Action:%s", VTY_NEWLINE);
+      vty_outln (vty, "  Action:");
       if (index->exitpolicy == RMAP_GOTO)
-        vty_out (vty, "    Goto %d%s", index->nextpref, VTY_NEWLINE);
+        vty_outln (vty, "    Goto %d", index->nextpref);
       else if (index->exitpolicy == RMAP_NEXT)
-        vty_out (vty, "    Continue to next entry%s", VTY_NEWLINE);
+        vty_outln (vty, "    Continue to next entry");
       else if (index->exitpolicy == RMAP_EXIT)
-        vty_out (vty, "    Exit routemap%s", VTY_NEWLINE);
+        vty_outln (vty, "    Exit routemap");
     }
 }
 
@@ -1053,8 +1049,8 @@ vty_show_route_map (struct vty *vty, const char *name)
         }
       else
         {
-          vty_out (vty, "%s: 'route-map %s' not found%s", frr_protonameinst,
-                   name, VTY_NEWLINE);
+          vty_outln (vty, "%s: 'route-map %s' not found", frr_protonameinst,
+                   name);
           return CMD_SUCCESS;
         }
     }
@@ -2363,14 +2359,14 @@ DEFUN (set_ip_nexthop,
   ret = str2sockunion (argv[idx_ipv4]->arg, &su);
   if (ret < 0)
     {
-      vty_out (vty, "%% Malformed nexthop address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed nexthop address");
       return CMD_WARNING;
     }
   if (su.sin.sin_addr.s_addr == 0 ||
       IPV4_CLASS_DE(su.sin.sin_addr.s_addr))
     {
-      vty_out (vty, "%% nexthop address cannot be 0.0.0.0, multicast "
-               "or reserved%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "%% nexthop address cannot be 0.0.0.0, multicast " "or reserved");
       return CMD_WARNING;
     }
 
@@ -2420,12 +2416,12 @@ DEFUN (set_ipv6_nexthop_local,
   ret = inet_pton (AF_INET6, argv[idx_ipv6]->arg, &addr);
   if (!ret)
     {
-      vty_out (vty, "%% Malformed nexthop address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed nexthop address");
       return CMD_WARNING;
     }
   if (!IN6_IS_ADDR_LINKLOCAL(&addr))
     {
-      vty_out (vty, "%% Invalid link-local nexthop address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Invalid link-local nexthop address");
       return CMD_WARNING;
     }
 
@@ -2581,7 +2577,7 @@ DEFUN (no_route_map_all,
   map = route_map_lookup_by_name (mapname);
   if (map == NULL)
     {
-      vty_out (vty, "%% Could not find route-map %s%s", mapname, VTY_NEWLINE);
+      vty_outln (vty, "%% Could not find route-map %s", mapname);
       return CMD_WARNING;
     }
 
@@ -2616,7 +2612,7 @@ DEFUN (no_route_map,
   map = route_map_lookup_by_name (mapname);
   if (map == NULL)
     {
-      vty_out (vty, "%% Could not find route-map %s%s", mapname, VTY_NEWLINE);
+      vty_outln (vty, "%% Could not find route-map %s", mapname);
       return CMD_WARNING;
     }
 
@@ -2624,8 +2620,8 @@ DEFUN (no_route_map,
   index = route_map_index_lookup (map, permit, pref);
   if (index == NULL)
     {
-      vty_out (vty, "%% Could not find route-map entry %s %s%s", 
-	       mapname, prefstr, VTY_NEWLINE);
+      vty_outln (vty, "%% Could not find route-map entry %s %s", 
+	       mapname, prefstr);
       return CMD_WARNING;
     }
 
@@ -2652,8 +2648,7 @@ DEFUN (rmap_onmatch_next,
       if (index->type == RMAP_DENY)
         {
 	  /* Under a deny clause, match means it's finished. No need to set next */
-	  vty_out (vty, "on-match next not supported under route-map deny%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"on-match next not supported under route-map deny");
 	  return CMD_WARNING;
         }
       index->exitpolicy = RMAP_NEXT;
@@ -2694,8 +2689,7 @@ DEFUN (rmap_onmatch_goto,
       if (index->type == RMAP_DENY)
         {
 	  /* Under a deny clause, match means it's finished. No need to go anywhere */
-	  vty_out (vty, "on-match goto not supported under route-map deny%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"on-match goto not supported under route-map deny");
 	  return CMD_WARNING;
         }
 
@@ -2707,7 +2701,7 @@ DEFUN (rmap_onmatch_goto,
       if (d <= index->pref)
 	{
 	  /* Can't allow you to do that, Dave */
-	  vty_out (vty, "can't jump backwards in route-maps%s", VTY_NEWLINE);
+	  vty_outln (vty, "can't jump backwards in route-maps");
 	  return CMD_WARNING;
 	}
       else
@@ -2866,33 +2860,31 @@ route_map_config_write (struct vty *vty)
     for (index = map->head; index; index = index->next)
       {
 	if (!first)
-	  vty_out (vty, "!%s", VTY_NEWLINE);
+	  vty_outln (vty, "!");
 	else
 	  first = 0;
 
-	vty_out (vty, "route-map %s %s %d%s", 
+	vty_outln (vty, "route-map %s %s %d", 
 		 map->name,
 		 route_map_type_str (index->type),
-		 index->pref, VTY_NEWLINE);
+		 index->pref);
 
 	if (index->description)
-	  vty_out (vty, " description %s%s", index->description, VTY_NEWLINE);
+	  vty_outln (vty, " description %s", index->description);
 
 	for (rule = index->match_list.head; rule; rule = rule->next)
-	  vty_out (vty, " match %s %s%s", rule->cmd->str, 
-		   rule->rule_str ? rule->rule_str : "",
-		   VTY_NEWLINE);
+	  vty_outln (vty, " match %s %s", rule->cmd->str, 
+		   rule->rule_str ? rule->rule_str : "");
 
 	for (rule = index->set_list.head; rule; rule = rule->next)
-	  vty_out (vty, " set %s %s%s", rule->cmd->str,
-		   rule->rule_str ? rule->rule_str : "",
-		   VTY_NEWLINE);
+	  vty_outln (vty, " set %s %s", rule->cmd->str,
+		   rule->rule_str ? rule->rule_str : "");
    if (index->nextrm)
-     vty_out (vty, " call %s%s", index->nextrm, VTY_NEWLINE);
+     vty_outln (vty, " call %s", index->nextrm);
 	if (index->exitpolicy == RMAP_GOTO)
-      vty_out (vty, " on-match goto %d%s", index->nextpref, VTY_NEWLINE);
+      vty_outln (vty, " on-match goto %d", index->nextpref);
 	if (index->exitpolicy == RMAP_NEXT)
-	  vty_out (vty," on-match next%s", VTY_NEWLINE);
+	  vty_outln (vty," on-match next");
 	
 	write++;
       }

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -568,11 +568,11 @@ generic_match_delete (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_outln (vty, "%% [%s] Can't find rule.%s", frr_protonameinst);
+          vty_outln (vty, "%% [%s] Can't find rule.", frr_protonameinst);
           break;
         case RMAP_COMPILE_ERROR:
-          vty_out (vty, "%% [%s] Argument form is unsupported or malformed.%s",
-                   frr_protonameinst, VTY_NEWLINE);
+          vty_outln (vty, "%% [%s] Argument form is unsupported or malformed.",
+                     frr_protonameinst);
           break;
         }
       if (dep_name)
@@ -605,7 +605,7 @@ generic_set_add (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_outln (vty, "%% [%s] Can't find rule.%s", frr_protonameinst);
+          vty_outln (vty, "%% [%s] Can't find rule.", frr_protonameinst);
           return CMD_WARNING;
         case RMAP_COMPILE_ERROR:
           vty_outln (vty, "%% [%s] Argument form is unsupported or malformed.",
@@ -628,10 +628,10 @@ generic_set_delete (struct vty *vty, struct route_map_index *index,
       switch (ret)
         {
         case RMAP_RULE_MISSING:
-          vty_outln (vty, "%% [%s] Can't find rule.%s", frr_protonameinst);
+          vty_outln (vty, "%% [%s] Can't find rule.", frr_protonameinst);
           return CMD_WARNING;
         case RMAP_COMPILE_ERROR:
-          vty_outln (vty, "%% [%s] Argument form is unsupported or malformed.%s",
+          vty_outln (vty, "%% [%s] Argument form is unsupported or malformed.",
                      frr_protonameinst);
           return CMD_WARNING;
         }

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1003,7 +1003,7 @@ vty_show_route_map_entry (struct vty *vty, struct route_map *map)
 
       /* Description */
       if (index->description)
-	vty_outln (vty, "  Description:%s    %s", VTY_NEWLINE,
+	vty_outln (vty, "  Description:%s    %s", VTYNL,
 		 index->description);
       
       /* Match clauses */

--- a/lib/skiplist.c
+++ b/lib/skiplist.c
@@ -602,11 +602,10 @@ skiplist_debug(struct vty *vty, struct skiplist *l)
 
     if (!l)
 	l = skiplist_last_created;
-    vty_out(vty, "Skiplist %p has max level %d%s", l, l->level, VTY_NEWLINE);
+    vty_outln (vty, "Skiplist %p has max level %d", l, l->level);
     for (i = l->level; i >= 0; --i)
-	vty_out(vty, "  @%d: %ld%s",
-	    i, (long)((l->stats->forward[i]) - (struct skiplistnode *)NULL),
-	    VTY_NEWLINE);
+	vty_outln (vty, "  @%d: %ld",
+	    i,(long)((l->stats->forward[i]) - (struct skiplistnode *)NULL));
 }
 
 static void *

--- a/lib/smux.c
+++ b/lib/smux.c
@@ -1387,7 +1387,7 @@ config_write_smux (struct vty *vty)
 	  vty_out (vty, "%s%d", first ? "" : ".", (int) smux_oid[i]);
 	  first = 0;
 	}
-      vty_out (vty, " %s%s", smux_passwd, VTY_NEWLINE);
+      vty_outln (vty, " %s", smux_passwd);
     }
   return 0;
 }

--- a/lib/smux.c
+++ b/lib/smux.c
@@ -1278,7 +1278,7 @@ smux_peer_oid (struct vty *vty, const char *oid_str, const char *passwd_str)
   ret = smux_str2oid (oid_str, oid, &oid_len);
   if (ret != 0)
     {
-      vty_out (vty, "object ID malformed%s", VTY_NEWLINE);
+      vty_out (vty, "object ID malformed%s", VTYNL);
       return CMD_WARNING;
     }
 

--- a/lib/spf_backoff.c
+++ b/lib/spf_backoff.c
@@ -223,44 +223,44 @@ void
 spf_backoff_show(struct spf_backoff *backoff, struct vty *vty,
                  const char *prefix)
 {
-  vty_out(vty, "%sCurrent state:     %s%s", prefix,
-          spf_backoff_state2str(backoff->state), VTY_NEWLINE);
-  vty_out(vty, "%sInit timer:        %ld msec%s", prefix,
-          backoff->init_delay, VTY_NEWLINE);
-  vty_out(vty, "%sShort timer:       %ld msec%s", prefix,
-          backoff->short_delay, VTY_NEWLINE);
-  vty_out(vty, "%sLong timer:        %ld msec%s", prefix,
-          backoff->long_delay, VTY_NEWLINE);
-  vty_out(vty, "%sHolddown timer:    %ld msec%s", prefix,
-          backoff->holddown, VTY_NEWLINE);
+  vty_outln (vty, "%sCurrent state:     %s", prefix,
+          spf_backoff_state2str(backoff->state));
+  vty_outln (vty, "%sInit timer:        %ld msec", prefix,
+          backoff->init_delay);
+  vty_outln (vty, "%sShort timer:       %ld msec", prefix,
+          backoff->short_delay);
+  vty_outln (vty, "%sLong timer:        %ld msec", prefix,
+          backoff->long_delay);
+  vty_outln (vty, "%sHolddown timer:    %ld msec", prefix,
+          backoff->holddown);
   if (backoff->t_holddown)
     {
       struct timeval remain = thread_timer_remain(backoff->t_holddown);
-      vty_out(vty, "%s                   Still runs for %ld msec%s",
-              prefix, remain.tv_sec * 1000 + remain.tv_usec/1000, VTY_NEWLINE);
+      vty_outln (vty, "%s                   Still runs for %ld msec",
+              prefix, remain.tv_sec * 1000 + remain.tv_usec / 1000);
     }
   else
     {
-      vty_out(vty, "%s                   Inactive%s", prefix, VTY_NEWLINE);
+      vty_outln (vty, "%s                   Inactive", prefix);
     }
 
-  vty_out(vty, "%sTimeToLearn timer: %ld msec%s", prefix,
-          backoff->timetolearn, VTY_NEWLINE);
+  vty_outln (vty, "%sTimeToLearn timer: %ld msec", prefix,
+          backoff->timetolearn);
   if (backoff->t_timetolearn)
     {
       struct timeval remain = thread_timer_remain(backoff->t_timetolearn);
-      vty_out(vty, "%s                   Still runs for %ld msec%s",
-              prefix, remain.tv_sec * 1000 + remain.tv_usec/1000, VTY_NEWLINE);
+      vty_outln (vty, "%s                   Still runs for %ld msec",
+              prefix, remain.tv_sec * 1000 + remain.tv_usec / 1000);
     }
   else
     {
-      vty_out(vty, "%s                   Inactive%s", prefix, VTY_NEWLINE);
+      vty_outln (vty, "%s                   Inactive", prefix);
     }
 
-  vty_out(vty, "%sFirst event:       %s%s", prefix,
-          timeval_format(&backoff->first_event_time), VTY_NEWLINE);
-  vty_out(vty, "%sLast event:        %s%s", prefix,
-          timeval_format(&backoff->last_event_time), VTY_NEWLINE);
+  vty_outln (vty, "%sFirst event:       %s", prefix,
+          timeval_format(&backoff->first_event_time));
+  vty_outln (vty, "%sLast event:        %s", prefix,
+          timeval_format(&backoff->last_event_time));
 }
 
 DEFUN(spf_backoff_debug,
@@ -291,7 +291,7 @@ spf_backoff_write_config(struct vty *vty)
 
   if (debug_spf_backoff)
     {
-      vty_out(vty, "debug spf-delay-ietf%s", VTY_NEWLINE);
+      vty_outln (vty, "debug spf-delay-ietf");
       written++;
     }
 

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -96,13 +96,13 @@ vty_out_cpu_thread_history(struct vty* vty,
 	  a->total_active, a->cpu.total/1000, a->cpu.total%1000, a->total_calls,
 	  a->cpu.total/a->total_calls, a->cpu.max,
 	  a->real.total/a->total_calls, a->real.max);
-  vty_out(vty, " %c%c%c%c%c %s%s",
+  vty_outln (vty, " %c%c%c%c%c %s",
 	  a->types & (1 << THREAD_READ) ? 'R':' ',
 	  a->types & (1 << THREAD_WRITE) ? 'W':' ',
 	  a->types & (1 << THREAD_TIMER) ? 'T':' ',
 	  a->types & (1 << THREAD_EVENT) ? 'E':' ',
 	  a->types & (1 << THREAD_EXECUTE) ? 'X':' ',
-	  a->funcname, VTY_NEWLINE);
+	  a->funcname);
 }
 
 static void
@@ -137,11 +137,11 @@ cpu_record_print(struct vty *vty, thread_type filter)
   tmp.funcname = "TOTAL";
   tmp.types = filter;
 
-  vty_out(vty, "%21s %18s %18s%s",
-	  "", "CPU (user+system):", "Real (wall-clock):", VTY_NEWLINE);
+  vty_outln (vty, "%21s %18s %18s",
+	  "", "CPU (user+system):", "Real (wall-clock):");
   vty_out(vty, "Active   Runtime(ms)   Invoked Avg uSec Max uSecs");
   vty_out(vty, " Avg uSec Max uSecs");
-  vty_out(vty, "  Type  Thread%s", VTY_NEWLINE);
+  vty_outln (vty, "  Type  Thread");
 
   pthread_mutex_lock (&cpu_record_mtx);
   {
@@ -201,9 +201,9 @@ DEFUN (show_thread_cpu,
 	}
       if (filter == 0)
 	{
-	  vty_out(vty, "Invalid filter \"%s\" specified,"
-                  " must contain at least one of 'RWTEXB'%s",
-		  argv[idx_filter]->arg, VTY_NEWLINE);
+	  vty_outln (vty, "Invalid filter \"%s\" specified,"
+                  " must contain at least one of 'RWTEXB'",
+		  argv[idx_filter]->arg);
 	  return CMD_WARNING;
 	}
     }
@@ -289,9 +289,9 @@ DEFUN (clear_thread_cpu,
 	}
       if (filter == 0)
 	{
-	  vty_out(vty, "Invalid filter \"%s\" specified,"
-                  " must contain at least one of 'RWTEXB'%s",
-		  argv[idx_filter]->arg, VTY_NEWLINE);
+	  vty_outln (vty, "Invalid filter \"%s\" specified,"
+                  " must contain at least one of 'RWTEXB'",
+		  argv[idx_filter]->arg);
 	  return CMD_WARNING;
 	}
     }

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -475,7 +475,7 @@ DEFUN_NOSH (vrf,
     {
       vty_out (vty, "%% VRF name %s is invalid: length exceeds "
                     "%d characters%s",
-               vrfname, VRF_NAMSIZ, VTY_NEWLINE);
+               vrfname, VRF_NAMSIZ, VTYNL);
       return CMD_WARNING;
     }
 
@@ -501,14 +501,14 @@ DEFUN_NOSH (no_vrf,
 
   if (vrfp == NULL)
     {
-      vty_out (vty, "%% VRF %s does not exist%s", vrfname, VTY_NEWLINE);
+      vty_out (vty, "%% VRF %s does not exist%s", vrfname, VTYNL);
       return CMD_WARNING;
     }
 
   if (CHECK_FLAG (vrfp->status, VRF_ACTIVE))
     {
       vty_out (vty, "%% Only inactive VRFs can be deleted%s",
-              VTY_NEWLINE);
+              VTYNL);
       return CMD_WARNING;
     }
 

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -555,7 +555,7 @@ static int
 vrf_write_host (struct vty *vty)
 {
   if (debug_vrf)
-    vty_out (vty, "debug vrf%s", VTY_NEWLINE);
+    vty_outln (vty, "debug vrf");
 
   return 1;
 }

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -115,12 +115,12 @@ extern vrf_id_t vrf_name_to_id (const char *);
       struct vrf *vrf; \
       if (!(vrf = vrf_lookup_by_name(NAME))) \
         {                                                           \
-          vty_out (vty, "%% VRF %s not found%s", NAME, VTY_NEWLINE);\
+          vty_out (vty, "%% VRF %s not found%s", NAME, VTYNL);\
           return CMD_WARNING;                                       \
         }                                               \
       if (vrf->vrf_id == VRF_UNKNOWN) \
         { \
-          vty_out (vty, "%% VRF %s not active%s", NAME, VTY_NEWLINE);\
+          vty_out (vty, "%% VRF %s not active%s", NAME, VTYNL);\
           return CMD_WARNING;                                       \
         } \
       (V) = vrf->vrf_id; \

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -263,12 +263,12 @@ vty_hello (struct vty *vty)
               for (s = buf + strlen (buf); (s > buf) && isspace ((int)*(s - 1));
                    s--);
               *s = '\0';
-              vty_out (vty, "%s%s", buf, VTY_NEWLINE);
+              vty_outln (vty, "%s", buf);
             }
           fclose (f);
         }
       else
-        vty_out (vty, "MOTD file not found%s", VTY_NEWLINE);
+        vty_outln (vty, "MOTD file not found");
     }
   else if (host.motd)
     vty_out (vty, "%s", host.motd);
@@ -401,14 +401,14 @@ vty_auth (struct vty *vty, char *buf)
         {
           if (vty->node == AUTH_NODE)
             {
-              vty_out (vty, "%% Bad passwords, too many failures!%s", VTY_NEWLINE);
+              vty_outln (vty, "%% Bad passwords, too many failures!");
               vty->status = VTY_CLOSE;
             }
           else
             {
               /* AUTH_ENABLE_NODE */
               vty->fail = 0;
-              vty_out (vty, "%% Bad enable passwords, too many failures!%s", VTY_NEWLINE);
+              vty_outln (vty, "%% Bad enable passwords, too many failures!");
 	      vty->status = VTY_CLOSE;
             }
         }
@@ -493,16 +493,16 @@ vty_command (struct vty *vty, char *buf)
       {
       case CMD_WARNING:
         if (vty->type == VTY_FILE)
-          vty_out (vty, "Warning...%s", VTY_NEWLINE);
+          vty_outln (vty, "Warning...");
         break;
       case CMD_ERR_AMBIGUOUS:
-        vty_out (vty, "%% Ambiguous command.%s", VTY_NEWLINE);
+        vty_outln (vty, "%% Ambiguous command.");
         break;
       case CMD_ERR_NO_MATCH:
-        vty_out (vty, "%% [%s] Unknown command: %s%s", protocolname, buf, VTY_NEWLINE);
+        vty_outln (vty, "%% [%s] Unknown command: %s", protocolname, buf);
         break;
       case CMD_ERR_INCOMPLETE:
-        vty_out (vty, "%% Command incomplete.%s", VTY_NEWLINE);
+        vty_outln (vty, "%% Command incomplete.");
         break;
       }
   cmd_free_strvec (vline);
@@ -730,7 +730,7 @@ vty_backward_word (struct vty *vty)
 static void
 vty_down_level (struct vty *vty)
 {
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
   cmd_exit (vty);
   vty_prompt (vty);
   vty->cp = 0;
@@ -740,7 +740,7 @@ vty_down_level (struct vty *vty)
 static void
 vty_end_config (struct vty *vty)
 {
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   switch (vty->node)
     {
@@ -945,11 +945,11 @@ vty_complete_command (struct vty *vty)
 
   cmd_free_strvec (vline);
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
   switch (ret)
     {
     case CMD_ERR_AMBIGUOUS:
-      vty_out (vty, "%% Ambiguous command.%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Ambiguous command.");
       vty_prompt (vty);
       vty_redraw_line (vty);
       break;
@@ -962,7 +962,7 @@ vty_complete_command (struct vty *vty)
       if (!matched[0])
         {
           /* 2016-11-28 equinox -- need to debug, SEGV here */
-          vty_out (vty, "%% CLI BUG: FULL_MATCH with NULL str%s", VTY_NEWLINE);
+          vty_outln (vty, "%% CLI BUG: FULL_MATCH with NULL str");
           vty_prompt (vty);
           vty_redraw_line (vty);
           break;
@@ -985,11 +985,11 @@ vty_complete_command (struct vty *vty)
       for (i = 0; matched[i] != NULL; i++)
         {
           if (i != 0 && ((i % 6) == 0))
-            vty_out (vty, "%s", VTY_NEWLINE);
+            vty_outln (vty, "");
           vty_out (vty, "%-10s ", matched[i]);
           XFREE (MTYPE_COMPLETION, matched[i]);
         }
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
 
       vty_prompt (vty);
       vty_redraw_line (vty);
@@ -1017,7 +1017,7 @@ vty_describe_fold (struct vty *vty, int cmd_width,
 
   if (desc_width <= 0)
     {
-      vty_out (vty, "  %-*s  %s%s", cmd_width, cmd, token->desc, VTY_NEWLINE);
+      vty_outln (vty, "  %-*s  %s", cmd_width, cmd, token->desc);
       return;
     }
 
@@ -1034,12 +1034,12 @@ vty_describe_fold (struct vty *vty, int cmd_width,
 
       strncpy (buf, p, pos);
       buf[pos] = '\0';
-      vty_out (vty, "  %-*s  %s%s", cmd_width, cmd, buf, VTY_NEWLINE);
+      vty_outln (vty, "  %-*s  %s", cmd_width, cmd, buf);
 
       cmd = "";
     }
 
-  vty_out (vty, "  %-*s  %s%s", cmd_width, cmd, p, VTY_NEWLINE);
+  vty_outln (vty, "  %-*s  %s", cmd_width, cmd, p);
 
   XFREE (MTYPE_TMP, buf);
 }
@@ -1068,17 +1068,17 @@ vty_describe_command (struct vty *vty)
 
   describe = cmd_describe_command (vline, vty, &ret);
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   /* Ambiguous error. */
   switch (ret)
     {
     case CMD_ERR_AMBIGUOUS:
-      vty_out (vty, "%% Ambiguous command.%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Ambiguous command.");
       goto out;
       break;
     case CMD_ERR_NO_MATCH:
-      vty_out (vty, "%% There is no matched command.%s", VTY_NEWLINE);
+      vty_outln (vty, "%% There is no matched command.");
       goto out;
       break;
     }
@@ -1116,13 +1116,12 @@ vty_describe_command (struct vty *vty)
           }
 
         if (!token->desc)
-          vty_out (vty, "  %-s%s",
-                   token->text,
-                   VTY_NEWLINE);
+          vty_outln (vty, "  %-s",
+                   token->text);
         else if (desc_width >= strlen (token->desc))
-          vty_out (vty, "  %-*s  %s%s", width,
+          vty_outln (vty, "  %-*s  %s", width,
                    token->text,
-                   token->desc, VTY_NEWLINE);
+                   token->desc);
         else
           vty_describe_fold (vty, width, desc_width, token);
 
@@ -1142,7 +1141,7 @@ vty_describe_command (struct vty *vty)
                     vty_out(vty, " %s", item);
                     XFREE(MTYPE_COMPLETION, item);
                   }
-                vty_out(vty, "%s", VTY_NEWLINE);
+                vty_outln (vty, "");
               }
             vector_free(varcomps);
           }
@@ -1156,13 +1155,12 @@ vty_describe_command (struct vty *vty)
   if ((token = token_cr))
     {
       if (!token->desc)
-        vty_out (vty, "  %-s%s",
-                 token->text,
-                 VTY_NEWLINE);
+        vty_outln (vty, "  %-s",
+                 token->text);
       else if (desc_width >= strlen (token->desc))
-        vty_out (vty, "  %-*s  %s%s", width,
+        vty_outln (vty, "  %-*s  %s", width,
                  token->text,
-                 token->desc, VTY_NEWLINE);
+                 token->desc);
       else
         vty_describe_fold (vty, width, desc_width, token);
     }
@@ -1188,7 +1186,7 @@ vty_stop_input (struct vty *vty)
 {
   vty->cp = vty->length = 0;
   vty_clear_buf (vty);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   switch (vty->node)
     {
@@ -1299,20 +1297,20 @@ vty_telnet_option (struct vty *vty, unsigned char *buf, int nbytes)
           vty_out (vty, "SE ");
           break;
         case TELOPT_ECHO:
-          vty_out (vty, "TELOPT_ECHO %s", VTY_NEWLINE);
+          vty_outln (vty, "TELOPT_ECHO ");
           break;
         case TELOPT_SGA:
-          vty_out (vty, "TELOPT_SGA %s", VTY_NEWLINE);
+          vty_outln (vty, "TELOPT_SGA ");
           break;
         case TELOPT_NAWS:
-          vty_out (vty, "TELOPT_NAWS %s", VTY_NEWLINE);
+          vty_outln (vty, "TELOPT_NAWS ");
           break;
         default:
           vty_out (vty, "%x ", buf[i]);
           break;
         }
     }
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
 #endif /* TELNET_OPTION_DEBUG */
 
@@ -1349,9 +1347,9 @@ vty_telnet_option (struct vty *vty, unsigned char *buf, int nbytes)
                 vty->width = ((vty->sb_buf[1] << 8)|vty->sb_buf[2]);
                 vty->height = ((vty->sb_buf[3] << 8)|vty->sb_buf[4]);
 #ifdef TELNET_OPTION_DEBUG
-                vty_out(vty, "TELNET NAWS window size negotiation completed: "
-                              "width %d, height %d%s",
-                        vty->width, vty->height, VTY_NEWLINE);
+                vty_outln (vty, "TELNET NAWS window size negotiation completed: "
+                              "width %d, height %d",
+                        vty->width, vty->height);
 #endif
               }
             break;
@@ -1608,7 +1606,7 @@ vty_read (struct thread *thread)
           break;
         case '\n':
         case '\r':
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
           vty_execute (vty);
           break;
         case '\t':
@@ -1767,7 +1765,7 @@ vty_create (int vty_sock, union sockunion *su)
       /* Vty is not available if password isn't set. */
       if (host.password == NULL && host.password_encrypt == NULL)
         {
-          vty_out (vty, "Vty password is not set.%s", VTY_NEWLINE);
+          vty_outln (vty, "Vty password is not set.");
           vty->status = VTY_CLOSE;
           vty_close (vty);
           return NULL;
@@ -1777,7 +1775,8 @@ vty_create (int vty_sock, union sockunion *su)
   /* Say hello to the world. */
   vty_hello (vty);
   if (! no_password_check)
-    vty_out (vty, "%sUser Access Verification%s%s", VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+    vty_outln (vty, "%sUser Access Verification%s", VTY_NEWLINE,
+               VTY_NEWLINE);
 
   /* Setting up terminal. */
   vty_will_echo (vty);
@@ -2194,7 +2193,7 @@ vtysh_read (struct thread *thread)
       /* Clear command line buffer. */
       vty->cp = vty->length = 0;
       vty_clear_buf (vty);
-      vty_out (vty, "%% Command is too long.%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Command is too long.");
     }
   else
     {
@@ -2337,7 +2336,7 @@ vty_timeout (struct thread *thread)
 
   /* Clear buffer*/
   buffer_reset (vty->obuf);
-  vty_out (vty, "%sVty connection is timed out.%s", VTY_NEWLINE, VTY_NEWLINE);
+  vty_outln (vty, "%sVty connection is timed out.", VTY_NEWLINE);
 
   /* Close connection. */
   vty->status = VTY_CLOSE;
@@ -2818,8 +2817,7 @@ DEFUN (no_vty_access_class,
   const char *accesslist = (argc == 3) ? argv[idx_word]->arg : NULL;
   if (! vty_accesslist_name || (argc == 3 && strcmp(vty_accesslist_name, accesslist)))
     {
-      vty_out (vty, "Access-class is not currently applied to vty%s",
-               VTY_NEWLINE);
+      vty_outln (vty,"Access-class is not currently applied to vty");
       return CMD_WARNING;
     }
 
@@ -2862,8 +2860,7 @@ DEFUN (no_vty_ipv6_access_class,
   if (! vty_ipv6_accesslist_name ||
       (argc == 4 && strcmp(vty_ipv6_accesslist_name, accesslist)))
     {
-      vty_out (vty, "IPv6 access-class is not currently applied to vty%s",
-               VTY_NEWLINE);
+      vty_outln (vty,"IPv6 access-class is not currently applied to vty");
       return CMD_WARNING;
     }
 
@@ -2987,30 +2984,30 @@ DEFUN (log_commands,
 static int
 vty_config_write (struct vty *vty)
 {
-  vty_out (vty, "line vty%s", VTY_NEWLINE);
+  vty_outln (vty, "line vty");
 
   if (vty_accesslist_name)
-    vty_out (vty, " access-class %s%s",
-             vty_accesslist_name, VTY_NEWLINE);
+    vty_outln (vty, " access-class %s",
+             vty_accesslist_name);
 
   if (vty_ipv6_accesslist_name)
-    vty_out (vty, " ipv6 access-class %s%s",
-             vty_ipv6_accesslist_name, VTY_NEWLINE);
+    vty_outln (vty, " ipv6 access-class %s",
+             vty_ipv6_accesslist_name);
 
   /* exec-timeout */
   if (vty_timeout_val != VTY_TIMEOUT_DEFAULT)
-    vty_out (vty, " exec-timeout %ld %ld%s",
+    vty_outln (vty, " exec-timeout %ld %ld",
              vty_timeout_val / 60,
-             vty_timeout_val % 60, VTY_NEWLINE);
+             vty_timeout_val % 60);
 
   /* login */
   if (no_password_check)
-    vty_out (vty, " no login%s", VTY_NEWLINE);
+    vty_outln (vty, " no login");
 
   if (do_log_commands)
-    vty_out (vty, "log commands%s", VTY_NEWLINE);
+    vty_outln (vty, "log commands");
 
-  vty_out (vty, "!%s", VTY_NEWLINE);
+  vty_outln (vty, "!");
 
   return CMD_SUCCESS;
 }

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -730,7 +730,7 @@ vty_backward_word (struct vty *vty)
 static void
 vty_down_level (struct vty *vty)
 {
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   cmd_exit (vty);
   vty_prompt (vty);
   vty->cp = 0;
@@ -740,7 +740,7 @@ vty_down_level (struct vty *vty)
 static void
 vty_end_config (struct vty *vty)
 {
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   switch (vty->node)
     {
@@ -945,7 +945,7 @@ vty_complete_command (struct vty *vty)
 
   cmd_free_strvec (vline);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   switch (ret)
     {
     case CMD_ERR_AMBIGUOUS:
@@ -985,11 +985,11 @@ vty_complete_command (struct vty *vty)
       for (i = 0; matched[i] != NULL; i++)
         {
           if (i != 0 && ((i % 6) == 0))
-            vty_outln (vty, "");
+            vty_out (vty, VTYNL);
           vty_out (vty, "%-10s ", matched[i]);
           XFREE (MTYPE_COMPLETION, matched[i]);
         }
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
 
       vty_prompt (vty);
       vty_redraw_line (vty);
@@ -1068,7 +1068,7 @@ vty_describe_command (struct vty *vty)
 
   describe = cmd_describe_command (vline, vty, &ret);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   /* Ambiguous error. */
   switch (ret)
@@ -1141,7 +1141,7 @@ vty_describe_command (struct vty *vty)
                     vty_out(vty, " %s", item);
                     XFREE(MTYPE_COMPLETION, item);
                   }
-                vty_outln (vty, "");
+                vty_out (vty, VTYNL);
               }
             vector_free(varcomps);
           }
@@ -1186,7 +1186,7 @@ vty_stop_input (struct vty *vty)
 {
   vty->cp = vty->length = 0;
   vty_clear_buf (vty);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   switch (vty->node)
     {
@@ -1310,7 +1310,7 @@ vty_telnet_option (struct vty *vty, unsigned char *buf, int nbytes)
           break;
         }
     }
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
 #endif /* TELNET_OPTION_DEBUG */
 
@@ -1606,7 +1606,7 @@ vty_read (struct thread *thread)
           break;
         case '\n':
         case '\r':
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
           vty_execute (vty);
           break;
         case '\t':

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -169,7 +169,7 @@ vty_outln (struct vty *vty, const char *format, ...)
   len = vty_out_variadic (vty, format, args);
   va_end (args);
 
-  return len + vty_out (vty, "%s", VTY_NEWLINE);
+  return len + vty_out (vty, "%s", VTYNL);
 }
 
 static int
@@ -954,7 +954,7 @@ vty_complete_command (struct vty *vty)
       vty_redraw_line (vty);
       break;
     case CMD_ERR_NO_MATCH:
-      /* vty_out (vty, "%% There is no matched command.%s", VTY_NEWLINE); */
+      /* vty_out (vty, "%% There is no matched command.%s", VTYNL); */
       vty_prompt (vty);
       vty_redraw_line (vty);
       break;
@@ -1148,7 +1148,7 @@ vty_describe_command (struct vty *vty)
 #if 0
         vty_out (vty, "  %-*s %s%s", width
                  desc->cmd[0] == '.' ? desc->cmd + 1 : desc->cmd,
-                 desc->str ? desc->str : "", VTY_NEWLINE);
+                 desc->str ? desc->str : "", VTYNL);
 #endif /* 0 */
       }
 
@@ -1775,8 +1775,8 @@ vty_create (int vty_sock, union sockunion *su)
   /* Say hello to the world. */
   vty_hello (vty);
   if (! no_password_check)
-    vty_outln (vty, "%sUser Access Verification%s", VTY_NEWLINE,
-               VTY_NEWLINE);
+    vty_outln (vty, "%sUser Access Verification%s", VTYNL,
+               VTYNL);
 
   /* Setting up terminal. */
   vty_will_echo (vty);
@@ -2336,7 +2336,7 @@ vty_timeout (struct thread *thread)
 
   /* Clear buffer*/
   buffer_reset (vty->obuf);
-  vty_outln (vty, "%sVty connection is timed out.", VTY_NEWLINE);
+  vty_outln (vty, "%sVty connection is timed out.", VTYNL);
 
   /* Close connection. */
   vty->status = VTY_CLOSE;
@@ -2719,7 +2719,7 @@ DEFUN_NOSH (config_who,
     if ((v = vector_slot (vtyvec, i)) != NULL)
       vty_out (vty, "%svty[%d] connected from %s.%s",
                v->config ? "*" : " ",
-               i, v->address, VTY_NEWLINE);
+               i, v->address, VTYNL);
   return CMD_SUCCESS;
 }
 
@@ -2961,7 +2961,7 @@ DEFUN_NOSH (show_history,
         }
 
       if (vty->hist[index] != NULL)
-        vty_out (vty, "  %s%s", vty->hist[index], VTY_NEWLINE);
+        vty_out (vty, "  %s%s", vty->hist[index], VTYNL);
 
       index++;
     }

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -215,6 +215,7 @@ extern void vty_reset (void);
 extern struct vty *vty_new (void);
 extern struct vty *vty_stdio (void (*atclose)(void));
 extern int vty_out (struct vty *, const char *, ...) PRINTF_ATTRIBUTE(2, 3);
+extern int vty_outln (struct vty *, const char *, ...) PRINTF_ATTRIBUTE(2, 3);
 extern void vty_read_config (const char *, char *);
 extern void vty_time_print (struct vty *, int);
 extern void vty_serv_sock (const char *, unsigned short, const char *);

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -156,7 +156,7 @@ static inline void vty_push_context(struct vty *vty,
 #define VTY_CHECK_CONTEXT(ptr) \
 	if (!ptr) { \
 		vty_out (vty, "Current configuration object was deleted " \
-				"by another process.%s", VTY_NEWLINE); \
+				"by another process.%s", VTYNL); \
 		return CMD_WARNING; \
 	}
 
@@ -180,7 +180,7 @@ struct vty_arg
 #define INTEGRATE_DEFAULT_CONFIG "frr.conf"
 
 /* Small macro to determine newline is newline only or linefeed needed. */
-#define VTY_NEWLINE  ((vty->type == VTY_TERM) ? "\r\n" : "\n")
+#define VTYNL  ((vty->type == VTY_TERM) ? "\r\n" : "\n")
 
 /* Default time out value */
 #define VTY_TIMEOUT_DEFAULT 600

--- a/lib/workqueue.c
+++ b/lib/workqueue.c
@@ -191,23 +191,21 @@ DEFUN (show_work_queues,
   struct listnode *node;
   struct work_queue *wq;
   
-  vty_out (vty, 
-           "%c %8s %5s %8s %8s %21s%s",
-           ' ', "List","(ms) ","Q. Runs","Yields","Cycle Counts   ",
-           VTY_NEWLINE);
-  vty_out (vty,
-           "%c %8s %5s %8s %8s %7s %6s %8s %6s %s%s",
+  vty_outln (vty, 
+           "%c %8s %5s %8s %8s %21s",
+           ' ', "List","(ms) ","Q. Runs","Yields","Cycle Counts   ");
+  vty_outln (vty,
+           "%c %8s %5s %8s %8s %7s %6s %8s %6s %s",
            'P',
            "Items",
            "Hold",
            "Total","Total",
            "Best","Gran.","Total","Avg.",
-           "Name", 
-           VTY_NEWLINE);
+           "Name");
  
   for (ALL_LIST_ELEMENTS_RO (work_queues, node, wq))
     {
-      vty_out (vty,"%c %8d %5d %8ld %8ld %7d %6d %8ld %6u %s%s",
+      vty_outln (vty,"%c %8d %5d %8ld %8ld %7d %6d %8ld %6u %s",
                (CHECK_FLAG (wq->flags, WQ_UNPLUGGED) ? ' ' : 'P'),
                listcount (wq->items),
                wq->spec.hold,
@@ -215,8 +213,7 @@ DEFUN (show_work_queues,
                wq->cycles.best, wq->cycles.granularity, wq->cycles.total,
                  (wq->runs) ? 
                    (unsigned int) (wq->cycles.total / wq->runs) : 0,
-               wq->name,
-               VTY_NEWLINE);
+               wq->name);
     }
     
   return CMD_SUCCESS;

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -682,10 +682,10 @@ static void show_ip_opennhrp_cache(struct nhrp_cache *c, void *pctx)
 		  "Flags:%s%s%s"
 		  "Protocol-Address: %s/%zu",
 		  nhrp_cache_type_str[c->cur.type],
-		  VTY_NEWLINE,
+		  VTYNL,
 		  (c->cur.peer && c->cur.peer->online) ? " up": "",
 		  c->used ? " used": "",
-		  VTY_NEWLINE,
+		  VTYNL,
 		  sockunion2str(&c->remote_addr, buf, sizeof buf),
 		  8 * family2addrsize(sockunion_family(&c->remote_addr)));
 
@@ -731,7 +731,7 @@ DEFUN(show_ip_nhrp, show_ip_nhrp_cmd,
 	} else if (argv[3]->text[0] == 's') {
 		nhrp_shortcut_foreach(ctx.afi, show_ip_nhrp_shortcut, &ctx);
 	} else {
-		vty_outln (vty, "Status: ok%s", VTY_NEWLINE);
+		vty_outln (vty, "Status: ok%s", VTYNL);
 		ctx.count++;
 		for (ALL_LIST_ELEMENTS_RO(vrf_iflist(VRF_DEFAULT), node, ifp))
 			nhrp_cache_foreach(ifp, show_ip_opennhrp_cache, &ctx);

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -868,7 +868,7 @@ static int interface_config_write(struct vty *vty)
 			if (nifp->ipsec_fallback_profile)
 				vty_out(vty, " fallback-profile %s",
 					nifp->ipsec_fallback_profile);
-			vty_outln (vty, "");
+			vty_out (vty, VTYNL);
 		}
 		if (nifp->source)
 			vty_outln (vty, " tunnel source %s",

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -83,7 +83,7 @@ static int nhrp_vty_return(struct vty *vty, int ret)
 		snprintf(buf, sizeof(buf), "Unknown error %d", ret);
 	}
 
-	vty_out (vty, "%% %s%s", str, VTY_NEWLINE);
+	vty_outln (vty, "%% %s", str);
 
 	return CMD_WARNING;
 }
@@ -104,7 +104,7 @@ static int toggle_flag(
 		return CMD_SUCCESS;
 	}
 
-	vty_out(vty, "%% Invalid value %s%s", name, VTY_NEWLINE);
+	vty_outln (vty, "%% Invalid value %s", name);
 	return CMD_WARNING;
 }
 
@@ -118,7 +118,7 @@ DEFUN(show_debugging_nhrp, show_debugging_nhrp_cmd,
 {
 	int i;
 
-	vty_out(vty, "NHRP debugging status:%s", VTY_NEWLINE);
+	vty_outln (vty, "NHRP debugging status:");
 
 	for (i = 0; debug_flags_desc[i].str != NULL; i++) {
 		if (debug_flags_desc[i].key == NHRP_DEBUG_ALL)
@@ -126,8 +126,8 @@ DEFUN(show_debugging_nhrp, show_debugging_nhrp_cmd,
 		if (!(debug_flags_desc[i].key & debug_flags))
 			continue;
 
-		vty_out(vty, "  NHRP %s debugging is on%s",
-			debug_flags_desc[i].str, VTY_NEWLINE);
+		vty_outln (vty, "  NHRP %s debugging is on",
+			debug_flags_desc[i].str);
 	}
 
 	return CMD_SUCCESS;
@@ -158,7 +158,7 @@ static int nhrp_config_write(struct vty *vty)
 {
 #ifndef NO_DEBUG
 	if (debug_flags == NHRP_DEBUG_ALL) {
-		vty_out(vty, "debug nhrp all%s", VTY_NEWLINE);
+		vty_outln (vty, "debug nhrp all");
 	} else {
 		int i;
 
@@ -167,19 +167,20 @@ static int nhrp_config_write(struct vty *vty)
 				continue;
 			if (!(debug_flags & debug_flags_desc[i].key))
 				continue;
-			vty_out(vty, "debug nhrp %s%s", debug_flags_desc[i].str, VTY_NEWLINE);
+			vty_outln (vty, "debug nhrp %s",
+				  debug_flags_desc[i].str);
 		}
 	}
-	vty_out(vty, "!%s", VTY_NEWLINE);
+	vty_outln (vty, "!");
 #endif /* NO_DEBUG */
 
 	if (nhrp_event_socket_path) {
-		vty_out(vty, "nhrp event socket %s%s",
-			nhrp_event_socket_path, VTY_NEWLINE);
+		vty_outln (vty, "nhrp event socket %s",
+			nhrp_event_socket_path);
 	}
 	if (netlink_nflog_group) {
-		vty_out(vty, "nhrp nflog-group %d%s",
-			netlink_nflog_group, VTY_NEWLINE);
+		vty_outln (vty, "nhrp nflog-group %d",
+			netlink_nflog_group);
 	}
 
 	return 0;
@@ -597,18 +598,17 @@ static void show_ip_nhrp_cache(struct nhrp_cache *c, void *pctx)
 		return;
 
 	if (!ctx->count) {
-		vty_out(vty, "%-8s %-8s %-24s %-24s %-6s %s%s",
+		vty_outln (vty, "%-8s %-8s %-24s %-24s %-6s %s",
 			"Iface",
 			"Type",
 			"Protocol",
 			"NBMA",
 			"Flags",
-			"Identity",
-			VTY_NEWLINE);
+			"Identity");
 	}
 	ctx->count++;
 
-	vty_out(ctx->vty, "%-8s %-8s %-24s %-24s %c%c%c    %s%s",
+	vty_outln(ctx->vty, "%-8s %-8s %-24s %-24s %c%c%c    %s",
 		c->ifp->name,
 		nhrp_cache_type_str[c->cur.type],
 		sockunion2str(&c->remote_addr, buf[0], sizeof buf[0]),
@@ -616,8 +616,7 @@ static void show_ip_nhrp_cache(struct nhrp_cache *c, void *pctx)
 		c->used ? 'U' : ' ',
 		c->t_timeout ? 'T' : ' ',
 		c->t_auth ? 'A' : ' ',
-		c->cur.peer ? c->cur.peer->vc->remote.id : "-",
-		VTY_NEWLINE);
+		c->cur.peer ? c->cur.peer->vc->remote.id : "-");
 }
 
 static void show_ip_nhrp_nhs(struct nhrp_nhs *n, struct nhrp_registration *reg, void *pctx)
@@ -627,21 +626,22 @@ static void show_ip_nhrp_nhs(struct nhrp_nhs *n, struct nhrp_registration *reg, 
 	char buf[2][SU_ADDRSTRLEN];
 
 	if (!ctx->count) {
-		vty_out(vty, "%-8s %-24s %-16s %-16s%s",
+		vty_outln (vty, "%-8s %-24s %-16s %-16s",
 			"Iface",
 			"FQDN",
 			"NBMA",
-			"Protocol",
-			VTY_NEWLINE);
+			"Protocol");
 	}
 	ctx->count++;
 
-	vty_out(vty, "%-8s %-24s %-16s %-16s%s",
-		n->ifp->name,
-		n->nbma_fqdn,
-		(reg && reg->peer) ? sockunion2str(&reg->peer->vc->remote.nbma, buf[0], sizeof buf[0]) : "-",
-		sockunion2str(reg ? &reg->proto_addr : &n->proto_addr, buf[1], sizeof buf[1]),
-		VTY_NEWLINE);
+	vty_outln (vty, "%-8s %-24s %-16s %-16s",
+		   n->ifp->name,
+		   n->nbma_fqdn,
+		   (reg && reg->peer) ? sockunion2str(&reg->peer->vc->remote.nbma,
+		     				      buf[0], sizeof buf[0])
+		   		      : "-",
+		   sockunion2str(reg ? &reg->proto_addr : &n->proto_addr,
+		     		 buf[1], sizeof buf[1]));
 }
 
 static void show_ip_nhrp_shortcut(struct nhrp_shortcut *s, void *pctx)
@@ -652,22 +652,20 @@ static void show_ip_nhrp_shortcut(struct nhrp_shortcut *s, void *pctx)
 	char buf1[PREFIX_STRLEN], buf2[SU_ADDRSTRLEN];
 
 	if (!ctx->count) {
-		vty_out(vty, "%-8s %-24s %-24s %s%s",
+		vty_outln (vty, "%-8s %-24s %-24s %s",
 			"Type",
 			"Prefix",
 			"Via",
-			"Identity",
-			VTY_NEWLINE);
+			"Identity");
 	}
 	ctx->count++;
 
 	c = s->cache;
-	vty_out(ctx->vty, "%-8s %-24s %-24s %s%s",
+	vty_outln(ctx->vty, "%-8s %-24s %-24s %s",
 		nhrp_cache_type_str[s->type],
 		prefix2str(s->p, buf1, sizeof buf1),
 		c ? sockunion2str(&c->remote_addr, buf2, sizeof buf2) : "",
-		(c && c->cur.peer) ? c->cur.peer->vc->remote.id : "",
-		VTY_NEWLINE);
+		(c && c->cur.peer) ? c->cur.peer->vc->remote.id : "");
 }
 
 static void show_ip_opennhrp_cache(struct nhrp_cache *c, void *pctx)
@@ -679,34 +677,32 @@ static void show_ip_opennhrp_cache(struct nhrp_cache *c, void *pctx)
 	if (ctx->afi != family2afi(sockunion_family(&c->remote_addr)))
 		return;
 
-	vty_out(ctx->vty,
-		"Type: %s%s"
-		"Flags:%s%s%s"
-		"Protocol-Address: %s/%zu%s",
-		nhrp_cache_type_str[c->cur.type],
-		VTY_NEWLINE,
-		(c->cur.peer && c->cur.peer->online) ? " up": "",
-		c->used ? " used": "",
-		VTY_NEWLINE,
-		sockunion2str(&c->remote_addr, buf, sizeof buf),
-		8 * family2addrsize(sockunion_family(&c->remote_addr)),
-		VTY_NEWLINE);
+	vty_outln(ctx->vty,
+		  "Type: %s%s"
+		  "Flags:%s%s%s"
+		  "Protocol-Address: %s/%zu",
+		  nhrp_cache_type_str[c->cur.type],
+		  VTY_NEWLINE,
+		  (c->cur.peer && c->cur.peer->online) ? " up": "",
+		  c->used ? " used": "",
+		  VTY_NEWLINE,
+		  sockunion2str(&c->remote_addr, buf, sizeof buf),
+		  8 * family2addrsize(sockunion_family(&c->remote_addr)));
 
 	if (c->cur.peer) {
-		vty_out(ctx->vty,
-			"NBMA-Address: %s%s",
-			sockunion2str(&c->cur.peer->vc->remote.nbma, buf, sizeof buf),
-			VTY_NEWLINE);
+		vty_outln(ctx->vty,
+			  "NBMA-Address: %s",
+			  sockunion2str(&c->cur.peer->vc->remote.nbma,
+			    		buf, sizeof buf));
 	}
 
 	if (sockunion_family(&c->cur.remote_nbma_natoa) != AF_UNSPEC) {
-		vty_out(ctx->vty,
-			"NBMA-NAT-OA-Address: %s%s",
-			sockunion2str(&c->cur.remote_nbma_natoa, buf, sizeof buf),
-			VTY_NEWLINE);
+		vty_outln(ctx->vty,
+			"NBMA-NAT-OA-Address: %s",
+			sockunion2str(&c->cur.remote_nbma_natoa, buf, sizeof buf));
 	}
 
-	vty_out(ctx->vty, "%s", VTY_NEWLINE);
+	vty_outln(ctx->vty, VTYNL);
 }
 
 DEFUN(show_ip_nhrp, show_ip_nhrp_cmd,
@@ -735,14 +731,14 @@ DEFUN(show_ip_nhrp, show_ip_nhrp_cmd,
 	} else if (argv[3]->text[0] == 's') {
 		nhrp_shortcut_foreach(ctx.afi, show_ip_nhrp_shortcut, &ctx);
 	} else {
-		vty_out(vty, "Status: ok%s%s", VTY_NEWLINE, VTY_NEWLINE);
+		vty_outln (vty, "Status: ok%s", VTY_NEWLINE);
 		ctx.count++;
 		for (ALL_LIST_ELEMENTS_RO(vrf_iflist(VRF_DEFAULT), node, ifp))
 			nhrp_cache_foreach(ifp, show_ip_opennhrp_cache, &ctx);
 	}
 
 	if (!ctx.count) {
-		vty_out(vty, "%% No entries%s", VTY_NEWLINE);
+		vty_outln (vty, "%% No entries");
 		return CMD_WARNING;
 	}
 
@@ -754,13 +750,12 @@ static void show_dmvpn_entry(struct nhrp_vc *vc, void *ctx)
 	struct vty *vty = ctx;
 	char buf[2][SU_ADDRSTRLEN];
 
-	vty_out(vty, "%-24s %-24s %c      %-4d %-24s%s",
+	vty_outln (vty, "%-24s %-24s %c      %-4d %-24s",
 		sockunion2str(&vc->local.nbma, buf[0], sizeof buf[0]),
 		sockunion2str(&vc->remote.nbma, buf[1], sizeof buf[1]),
 		notifier_active(&vc->notifier_list) ? 'n' : ' ',
 		vc->ipsec,
-		vc->remote.id,
-		VTY_NEWLINE);
+		vc->remote.id);
 }
 
 DEFUN(show_dmvpn, show_dmvpn_cmd,
@@ -768,13 +763,12 @@ DEFUN(show_dmvpn, show_dmvpn_cmd,
 	SHOW_STR
 	"DMVPN information\n")
 {
-	vty_out(vty, "%-24s %-24s %-6s %-4s %-24s%s",
+	vty_outln (vty, "%-24s %-24s %-6s %-4s %-24s",
 		"Src",
 		"Dst",
 		"Flags",
 		"SAs",
-		"Identity",
-		VTY_NEWLINE);
+		"Identity");
 
 	nhrp_vc_foreach(show_dmvpn_entry, vty);
 
@@ -821,11 +815,11 @@ DEFUN(clear_nhrp, clear_nhrp_cmd,
 	}
 
 	if (!ctx.count) {
-		vty_out(vty, "%% No entries%s", VTY_NEWLINE);
+		vty_outln (vty, "%% No entries");
 		return CMD_WARNING;
 	}
 
-	vty_out(vty, "%% %d entries cleared%s", ctx.count, VTY_NEWLINE);
+	vty_outln (vty, "%% %d entries cleared", ctx.count);
 	return CMD_SUCCESS;
 }
 
@@ -844,12 +838,10 @@ static void interface_config_write_nhrp_map(struct nhrp_cache *c, void *data)
 	if (!c->map) return;
 	if (sockunion_family(&c->remote_addr) != ctx->family) return;
 
-	vty_out(vty, " %s nhrp map %s %s%s",
+	vty_outln (vty, " %s nhrp map %s %s",
 		ctx->aficmd,
 		sockunion2str(&c->remote_addr, buf[0], sizeof buf[0]),
-		c->cur.type == NHRP_CACHE_LOCAL ? "local" :
-		sockunion2str(&c->cur.peer->vc->remote.nbma, buf[1], sizeof buf[1]),
-		VTY_NEWLINE);
+		c->cur.type == NHRP_CACHE_LOCAL ? "local" : sockunion2str(&c->cur.peer->vc->remote.nbma, buf[1], sizeof buf[1]));
 }
 
 static int interface_config_write(struct vty *vty)
@@ -865,9 +857,9 @@ static int interface_config_write(struct vty *vty)
 	int i;
 
 	for (ALL_LIST_ELEMENTS_RO(vrf_iflist(VRF_DEFAULT), node, ifp)) {
-		vty_out(vty, "interface %s%s", ifp->name, VTY_NEWLINE);
+		vty_outln (vty, "interface %s", ifp->name);
 		if (ifp->desc)
-			vty_out(vty, " description %s%s", ifp->desc, VTY_NEWLINE);
+			vty_outln (vty, " description %s", ifp->desc);
 
 		nifp = ifp->info;
 		if (nifp->ipsec_profile) {
@@ -876,11 +868,11 @@ static int interface_config_write(struct vty *vty)
 			if (nifp->ipsec_fallback_profile)
 				vty_out(vty, " fallback-profile %s",
 					nifp->ipsec_fallback_profile);
-			vty_out(vty, "%s", VTY_NEWLINE);
+			vty_outln (vty, "");
 		}
 		if (nifp->source)
-			vty_out(vty, " tunnel source %s%s",
-				nifp->source, VTY_NEWLINE);
+			vty_outln (vty, " tunnel source %s",
+				nifp->source);
 
 		for (afi = 0; afi < AFI_MAX; afi++) {
 			struct nhrp_afi_data *ad = &nifp->afi[afi];
@@ -888,28 +880,25 @@ static int interface_config_write(struct vty *vty)
 			aficmd = afi_to_cmd(afi);
 
 			if (ad->network_id)
-				vty_out(vty, " %s nhrp network-id %u%s",
-					aficmd, ad->network_id,
-					VTY_NEWLINE);
+				vty_outln (vty, " %s nhrp network-id %u",
+					aficmd,ad->network_id);
 
 			if (ad->holdtime != NHRPD_DEFAULT_HOLDTIME)
-				vty_out(vty, " %s nhrp holdtime %u%s",
-					aficmd, ad->holdtime,
-					VTY_NEWLINE);
+				vty_outln (vty, " %s nhrp holdtime %u",
+					aficmd,ad->holdtime);
 
 			if (ad->configured_mtu < 0)
-				vty_out(vty, " %s nhrp mtu opennhrp%s",
-					aficmd, VTY_NEWLINE);
+				vty_outln (vty, " %s nhrp mtu opennhrp",
+					aficmd);
 			else if (ad->configured_mtu)
-				vty_out(vty, " %s nhrp mtu %u%s",
-					aficmd, ad->configured_mtu,
-					VTY_NEWLINE);
+				vty_outln (vty, " %s nhrp mtu %u",
+					aficmd,ad->configured_mtu);
 
 			for (i = 0; interface_flags_desc[i].str != NULL; i++) {
 				if (!(ad->flags & interface_flags_desc[i].key))
 					continue;
-				vty_out(vty, " %s nhrp %s%s",
-					aficmd, interface_flags_desc[i].str, VTY_NEWLINE);
+				vty_outln (vty, " %s nhrp %s",
+					aficmd, interface_flags_desc[i].str);
 			}
 
 			mapctx = (struct write_map_ctx) {
@@ -920,15 +909,14 @@ static int interface_config_write(struct vty *vty)
 			nhrp_cache_foreach(ifp, interface_config_write_nhrp_map, &mapctx);
 
 			list_for_each_entry(nhs, &ad->nhslist_head, nhslist_entry) {
-				vty_out(vty, " %s nhrp nhs %s nbma %s%s",
+				vty_outln (vty, " %s nhrp nhs %s nbma %s",
 					aficmd,
 					sockunion_family(&nhs->proto_addr) == AF_UNSPEC ? "dynamic" : sockunion2str(&nhs->proto_addr, buf, sizeof buf),
-					nhs->nbma_fqdn,
-					VTY_NEWLINE);
+					nhs->nbma_fqdn);
 			}
 		}
 
-		vty_out (vty, "!%s", VTY_NEWLINE);
+		vty_outln (vty, "!");
 	}
 
 	return 0;

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -396,18 +396,18 @@ ospf6_area_show (struct vty *vty, struct ospf6_area *oa)
       result = monotime_since(&oa->ts_spf, NULL);
       if (result/TIMER_SECOND_MICRO > 0)
 	{
-	  vty_out (vty, "SPF last executed %ld.%lds ago%s",
+	  vty_outln (vty, "SPF last executed %ld.%lds ago",
 		   result/TIMER_SECOND_MICRO,
-		   result%TIMER_SECOND_MICRO, VTY_NEWLINE);
+		   result % TIMER_SECOND_MICRO);
 	}
       else
 	{
-	  vty_out (vty, "SPF last executed %ldus ago%s",
-		   result, VTY_NEWLINE);
+	  vty_outln (vty, "SPF last executed %ldus ago",
+		   result);
 	}
     }
   else
-    vty_out (vty, "SPF has not been run%s", VTY_NEWLINE);
+    vty_outln (vty, "SPF has not been run");
 }
 
 
@@ -968,8 +968,7 @@ DEFUN (ospf6_area_stub,
 
   if (!ospf6_area_stub_set (ospf6, area))
     {
-      vty_out (vty, "First deconfigure all virtual link through this area%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,"First deconfigure all virtual link through this area");
       return CMD_WARNING;
     }
 
@@ -994,8 +993,7 @@ DEFUN (ospf6_area_stub_no_summary,
 
   if (!ospf6_area_stub_set (ospf6, area))
     {
-      vty_out (vty, "First deconfigure all virtual link through this area%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,"First deconfigure all virtual link through this area");
       return CMD_WARNING;
     }
 

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -295,11 +295,11 @@ ospf6_bfd_write_config(struct vty *vty, struct ospf6_interface *oi)
   bfd_info = (struct bfd_info *)oi->bfd_info;
 
   if (CHECK_FLAG(bfd_info->flags, BFD_FLAG_PARAM_CFG))
-    vty_out (vty, " ipv6 ospf6 bfd %d %d %d%s",
+    vty_outln (vty, " ipv6 ospf6 bfd %d %d %d",
               bfd_info->detect_mult, bfd_info->required_min_rx,
-              bfd_info->desired_min_tx, VTY_NEWLINE);
+              bfd_info->desired_min_tx);
   else
-    vty_out (vty, " ipv6 ospf6 bfd%s", VTY_NEWLINE);
+    vty_outln (vty, " ipv6 ospf6 bfd");
 }
 
 /*

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1307,7 +1307,7 @@ DEFUN (auto_cost_reference_bandwidth,
   refbw = strtol (argv[idx_number]->arg, NULL, 10);
   if (refbw < 1 || refbw > 4294967)
     {
-      vty_out (vty, "reference-bandwidth value is invalid%s", VTY_NEWLINE);
+      vty_outln (vty, "reference-bandwidth value is invalid");
       return CMD_WARNING;
     }
 

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -929,9 +929,9 @@ ospf6_spf_config_write (struct vty *vty)
   if (ospf6->spf_delay != OSPF_SPF_DELAY_DEFAULT ||
       ospf6->spf_holdtime != OSPF_SPF_HOLDTIME_DEFAULT ||
       ospf6->spf_max_holdtime != OSPF_SPF_MAX_HOLDTIME_DEFAULT)
-    vty_out (vty, " timers throttle spf %d %d %d%s",
+    vty_outln (vty, " timers throttle spf %d %d %d",
 	     ospf6->spf_delay, ospf6->spf_holdtime,
-	     ospf6->spf_max_holdtime, VTY_NEWLINE);
+	     ospf6->spf_max_holdtime);
 
 }
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -861,7 +861,7 @@ ospf6_show (struct vty *vty, struct ospf6 *o)
 	vty_outln (vty, " Adjacency changes are logged");
     }
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   for (ALL_LIST_ELEMENTS_RO (o->area_list, n, oa))
     ospf6_area_show (vty, oa);
@@ -992,7 +992,7 @@ ospf6_distance_config_write (struct vty *vty)
       if (ospf6->distance_external)
         vty_out (vty, " external %u", ospf6->distance_external);
 
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   for (rn = route_top (ospf6->distance_table); rn; rn = route_next (rn))

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -813,8 +813,7 @@ ospf6_show (struct vty *vty, struct ospf6 *o)
   /* Redistribute configuration */
   /* XXX */
 
-  vty_out (vty, " LSA minimum arrival %d msecs%s", o->lsa_minarrival,
-           VTY_NEWLINE);
+  vty_outln (vty, " LSA minimum arrival %d msecs",o->lsa_minarrival);
 
   /* Show SPF parameters */
   vty_out(vty, " Initial SPF scheduling delay %d millisec(s)%s"
@@ -857,12 +856,12 @@ ospf6_show (struct vty *vty, struct ospf6 *o)
   if (CHECK_FLAG(o->config_flags, OSPF6_LOG_ADJACENCY_CHANGES))
     {
       if (CHECK_FLAG(o->config_flags, OSPF6_LOG_ADJACENCY_DETAIL))
-	vty_out(vty, " All adjacency changes are logged%s",VTY_NEWLINE);
+	vty_outln (vty, " All adjacency changes are logged");
       else
-	vty_out(vty, " Adjacency changes are logged%s",VTY_NEWLINE);
+	vty_outln (vty, " Adjacency changes are logged");
     }
 
-  vty_out (vty, "%s",VTY_NEWLINE);
+  vty_outln (vty, "");
 
   for (ALL_LIST_ELEMENTS_RO (o->area_list, n, oa))
     ospf6_area_show (vty, oa);
@@ -978,7 +977,7 @@ ospf6_distance_config_write (struct vty *vty)
   struct ospf6_distance *odistance;
 
   if (ospf6->distance_all)
-    vty_out (vty, " distance %u%s", ospf6->distance_all, VTY_NEWLINE);
+    vty_outln (vty, " distance %u", ospf6->distance_all);
 
   if (ospf6->distance_intra
       || ospf6->distance_inter
@@ -993,7 +992,7 @@ ospf6_distance_config_write (struct vty *vty)
       if (ospf6->distance_external)
         vty_out (vty, " external %u", ospf6->distance_external);
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   for (rn = route_top (ospf6->distance_table); rn; rn = route_next (rn))
@@ -1001,10 +1000,9 @@ ospf6_distance_config_write (struct vty *vty)
       {
 	char buf[PREFIX_STRLEN];
 
-        vty_out (vty, " distance %u %s %s%s", odistance->distance,
+        vty_outln (vty, " distance %u %s %s", odistance->distance,
 		 prefix2str (&rn->p, buf, sizeof (buf)),
-                 odistance->access_list ? odistance->access_list : "",
-                 VTY_NEWLINE);
+                 odistance->access_list ? odistance->access_list : "");
       }
   return 0;
 }
@@ -1031,13 +1029,13 @@ config_write_ospf6 (struct vty *vty)
   if (CHECK_FLAG(ospf6->config_flags, OSPF6_LOG_ADJACENCY_CHANGES))
     {
       if (CHECK_FLAG(ospf6->config_flags, OSPF6_LOG_ADJACENCY_DETAIL))
-        vty_out(vty, " log-adjacency-changes detail%s", VTY_NEWLINE);
+        vty_outln (vty, " log-adjacency-changes detail");
       else if (!DFLT_OSPF6_LOG_ADJACENCY_CHANGES)
-        vty_out(vty, " log-adjacency-changes%s", VTY_NEWLINE);
+        vty_outln (vty, " log-adjacency-changes");
     }
   else if (DFLT_OSPF6_LOG_ADJACENCY_CHANGES)
     {
-      vty_out(vty, " no log-adjacency-changes%s", VTY_NEWLINE);
+      vty_outln (vty, " no log-adjacency-changes");
     }
 
   if (ospf6->ref_bandwidth != OSPF6_REFERENCE_BANDWIDTH)
@@ -1046,8 +1044,7 @@ config_write_ospf6 (struct vty *vty)
 
   /* LSA timers print. */
   if (ospf6->lsa_minarrival != OSPF_MIN_LS_ARRIVAL)
-    vty_out (vty, " timers lsa min-arrival %d%s", ospf6->lsa_minarrival,
-             VTY_NEWLINE);
+    vty_outln (vty, " timers lsa min-arrival %d",ospf6->lsa_minarrival);
 
   ospf6_stub_router_config_write (vty);
   ospf6_redistribute_config_write (vty);

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -683,7 +683,7 @@ ospf6_distance_set (struct vty *vty, struct ospf6 *o,
   ret = str2prefix_ipv6 (ip_str, &p);
   if (ret == 0)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
 
@@ -731,14 +731,14 @@ ospf6_distance_unset (struct vty *vty, struct ospf6 *o,
   ret = str2prefix_ipv6 (ip_str, &p);
   if (ret == 0)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
 
   rn = route_node_lookup (o->distance_table, (struct prefix *) &p);
   if (!rn)
     {
-      vty_out (vty, "Cant't find specified prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Cant't find specified prefix");
       return CMD_WARNING;
     }
 

--- a/ospf6d/ospf6d.h
+++ b/ospf6d/ospf6d.h
@@ -90,11 +90,11 @@ extern struct thread_master *master;
 #define OSPF6_ROUTER_ID_STR "Specify Router-ID\n"
 #define OSPF6_LS_ID_STR     "Specify Link State ID\n"
 
-#define VNL VTY_NEWLINE
+#define VNL VTYNL
 #define OSPF6_CMD_CHECK_RUNNING() \
   if (ospf6 == NULL) \
     { \
-      vty_out (vty, "OSPFv3 is not running%s", VTY_NEWLINE); \
+      vty_out (vty, "OSPFv3 is not running%s", VTYNL); \
       return CMD_SUCCESS; \
     }
 

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -2201,7 +2201,7 @@ ospf_apiserver_show_info (struct vty *vty, struct ospf_lsa *lsa)
 	{
 	  vty_out (vty, "0x%x ", olsa->data[i]);
 	}
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   else
     {

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -2192,17 +2192,16 @@ ospf_apiserver_show_info (struct vty *vty, struct ospf_lsa *lsa)
   if (vty != NULL)
     {
       int i;
-      vty_out (vty, "  Added using OSPF API: %u octets of opaque data %s%s",
+      vty_outln (vty, "  Added using OSPF API: %u octets of opaque data %s",
 	       opaquelen,
-	       VALID_OPAQUE_INFO_LEN (lsa->data) ? "" : "(Invalid length?)",
-	       VTY_NEWLINE);
+	       VALID_OPAQUE_INFO_LEN(lsa->data) ? "" : "(Invalid length?)");
       vty_out (vty, "  Opaque data: ");
 
       for (i = 0; i < opaquelen; i++)
 	{
 	  vty_out (vty, "0x%x ", olsa->data[i]);
 	}
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
   else
     {

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -307,11 +307,11 @@ ospf_bfd_write_config(struct vty *vty, struct ospf_if_params *params)
   bfd_info = (struct bfd_info *)params->bfd_info;
 
   if (CHECK_FLAG(bfd_info->flags, BFD_FLAG_PARAM_CFG))
-    vty_out (vty, " ip ospf bfd %d %d %d%s",
+    vty_outln (vty, " ip ospf bfd %d %d %d",
               bfd_info->detect_mult, bfd_info->required_min_rx,
-              bfd_info->desired_min_tx, VTY_NEWLINE);
+              bfd_info->desired_min_tx);
   else
-    vty_out (vty, " ip ospf bfd%s", VTY_NEWLINE);
+    vty_outln (vty, " ip ospf bfd");
 }
 
 /*

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -1568,95 +1568,92 @@ show_debugging_ospf_common (struct vty *vty, struct ospf *ospf)
   int i;
 
   if (ospf->instance)
-    vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-             VTY_NEWLINE, VTY_NEWLINE);
+    vty_outln (vty, "%sOSPF Instance: %d%s", VTY_NEWLINE, ospf->instance,
+             VTY_NEWLINE);
 
-  vty_out (vty, "OSPF debugging status:%s", VTY_NEWLINE);
+  vty_outln (vty, "OSPF debugging status:");
 
   /* Show debug status for events. */
   if (IS_DEBUG_OSPF(event,EVENT))
-    vty_out (vty, "  OSPF event debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  OSPF event debugging is on");
 
   /* Show debug status for ISM. */
   if (IS_DEBUG_OSPF (ism, ISM) == OSPF_DEBUG_ISM)
-    vty_out (vty, "  OSPF ISM debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  OSPF ISM debugging is on");
   else
     {
       if (IS_DEBUG_OSPF (ism, ISM_STATUS))
-	vty_out (vty, "  OSPF ISM status debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF ISM status debugging is on");
       if (IS_DEBUG_OSPF (ism, ISM_EVENTS))
-	vty_out (vty, "  OSPF ISM event debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF ISM event debugging is on");
       if (IS_DEBUG_OSPF (ism, ISM_TIMERS))
-	vty_out (vty, "  OSPF ISM timer debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF ISM timer debugging is on");
     }
 
   /* Show debug status for NSM. */
   if (IS_DEBUG_OSPF (nsm, NSM) == OSPF_DEBUG_NSM)
-    vty_out (vty, "  OSPF NSM debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  OSPF NSM debugging is on");
   else
     {
       if (IS_DEBUG_OSPF (nsm, NSM_STATUS))
-	vty_out (vty, "  OSPF NSM status debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF NSM status debugging is on");
       if (IS_DEBUG_OSPF (nsm, NSM_EVENTS))
-	vty_out (vty, "  OSPF NSM event debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF NSM event debugging is on");
       if (IS_DEBUG_OSPF (nsm, NSM_TIMERS))
-	vty_out (vty, "  OSPF NSM timer debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF NSM timer debugging is on");
     }
 
   /* Show debug status for OSPF Packets. */
   for (i = 0; i < 5; i++)
     if (IS_DEBUG_OSPF_PACKET (i, SEND) && IS_DEBUG_OSPF_PACKET (i, RECV))
       {
-	vty_out (vty, "  OSPF packet %s%s debugging is on%s",
-		 lookup_msg(ospf_packet_type_str, i + 1, NULL),
-		 IS_DEBUG_OSPF_PACKET (i, DETAIL) ? " detail" : "",
-		 VTY_NEWLINE);
+	vty_outln (vty, "  OSPF packet %s%s debugging is on",
+		   lookup_msg(ospf_packet_type_str, i + 1, NULL),
+		   IS_DEBUG_OSPF_PACKET (i, DETAIL) ? " detail" : "");
       }
     else
       {
 	if (IS_DEBUG_OSPF_PACKET (i, SEND))
-	  vty_out (vty, "  OSPF packet %s send%s debugging is on%s",
-		   lookup_msg(ospf_packet_type_str, i + 1, NULL),
-		   IS_DEBUG_OSPF_PACKET (i, DETAIL) ? " detail" : "",
-		   VTY_NEWLINE);
+	  vty_outln (vty, "  OSPF packet %s send%s debugging is on",
+		     lookup_msg(ospf_packet_type_str, i + 1, NULL),
+		     IS_DEBUG_OSPF_PACKET (i, DETAIL) ? " detail" : "");
 	if (IS_DEBUG_OSPF_PACKET (i, RECV))
-	  vty_out (vty, "  OSPF packet %s receive%s debugging is on%s",
-		   lookup_msg(ospf_packet_type_str, i + 1, NULL),
-		   IS_DEBUG_OSPF_PACKET (i, DETAIL) ? " detail" : "",
-		   VTY_NEWLINE);
+	  vty_outln (vty, "  OSPF packet %s receive%s debugging is on",
+		     lookup_msg(ospf_packet_type_str, i + 1, NULL),
+		     IS_DEBUG_OSPF_PACKET (i, DETAIL) ? " detail" : "");
       }
 
   /* Show debug status for OSPF LSAs. */
   if (IS_DEBUG_OSPF (lsa, LSA) == OSPF_DEBUG_LSA)
-    vty_out (vty, "  OSPF LSA debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  OSPF LSA debugging is on");
   else
     {
       if (IS_DEBUG_OSPF (lsa, LSA_GENERATE))
-	vty_out (vty, "  OSPF LSA generation debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF LSA generation debugging is on");
       if (IS_DEBUG_OSPF (lsa, LSA_FLOODING))
-	vty_out (vty, "  OSPF LSA flooding debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF LSA flooding debugging is on");
       if (IS_DEBUG_OSPF (lsa, LSA_INSTALL))
-	vty_out (vty, "  OSPF LSA install debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF LSA install debugging is on");
       if (IS_DEBUG_OSPF (lsa, LSA_REFRESH))
-	vty_out (vty, "  OSPF LSA refresh debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF LSA refresh debugging is on");
     }
 
   /* Show debug status for Zebra. */
   if (IS_DEBUG_OSPF (zebra, ZEBRA) == OSPF_DEBUG_ZEBRA)
-    vty_out (vty, "  OSPF Zebra debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  OSPF Zebra debugging is on");
   else
     {
       if (IS_DEBUG_OSPF (zebra, ZEBRA_INTERFACE))
-	vty_out (vty, "  OSPF Zebra interface debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF Zebra interface debugging is on");
       if (IS_DEBUG_OSPF (zebra, ZEBRA_REDISTRIBUTE))
-	vty_out (vty, "  OSPF Zebra redistribute debugging is on%s", VTY_NEWLINE);
+	vty_outln (vty, "  OSPF Zebra redistribute debugging is on");
     }
 
   /* Show debug status for NSSA. */
   if (IS_DEBUG_OSPF (nssa, NSSA) == OSPF_DEBUG_NSSA)
-    vty_out (vty, "  OSPF NSSA debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  OSPF NSSA debugging is on");
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   return CMD_SUCCESS;
 }
@@ -1725,56 +1722,56 @@ config_write_debug (struct vty *vty)
 
   /* debug ospf ism (status|events|timers). */
   if (IS_CONF_DEBUG_OSPF (ism, ISM) == OSPF_DEBUG_ISM)
-    vty_out (vty, "debug ospf%s ism%s", str, VTY_NEWLINE);
+    vty_outln (vty, "debug ospf%s ism", str);
   else
     {
       if (IS_CONF_DEBUG_OSPF (ism, ISM_STATUS))
-	vty_out (vty, "debug ospf%s ism status%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s ism status", str);
       if (IS_CONF_DEBUG_OSPF (ism, ISM_EVENTS))
-	vty_out (vty, "debug ospf%s ism event%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s ism event", str);
       if (IS_CONF_DEBUG_OSPF (ism, ISM_TIMERS))
-	vty_out (vty, "debug ospf%s ism timer%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s ism timer", str);
     }
 
   /* debug ospf nsm (status|events|timers). */
   if (IS_CONF_DEBUG_OSPF (nsm, NSM) == OSPF_DEBUG_NSM)
-    vty_out (vty, "debug ospf%s nsm%s", str, VTY_NEWLINE);
+    vty_outln (vty, "debug ospf%s nsm", str);
   else
     {
       if (IS_CONF_DEBUG_OSPF (nsm, NSM_STATUS))
-	vty_out (vty, "debug ospf%s nsm status%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s nsm status", str);
       if (IS_CONF_DEBUG_OSPF (nsm, NSM_EVENTS))
-	vty_out (vty, "debug ospf%s nsm event%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s nsm event", str);
       if (IS_CONF_DEBUG_OSPF (nsm, NSM_TIMERS))
-	vty_out (vty, "debug ospf%s nsm timer%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s nsm timer", str);
     }
 
   /* debug ospf lsa (generate|flooding|install|refresh). */
   if (IS_CONF_DEBUG_OSPF (lsa, LSA) == OSPF_DEBUG_LSA)
-    vty_out (vty, "debug ospf%s lsa%s", str, VTY_NEWLINE);
+    vty_outln (vty, "debug ospf%s lsa", str);
   else
     {
       if (IS_CONF_DEBUG_OSPF (lsa, LSA_GENERATE))
-	vty_out (vty, "debug ospf%s lsa generate%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s lsa generate", str);
       if (IS_CONF_DEBUG_OSPF (lsa, LSA_FLOODING))
-	vty_out (vty, "debug ospf%s lsa flooding%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s lsa flooding", str);
       if (IS_CONF_DEBUG_OSPF (lsa, LSA_INSTALL))
-	vty_out (vty, "debug ospf%s lsa install%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s lsa install", str);
       if (IS_CONF_DEBUG_OSPF (lsa, LSA_REFRESH))
-	vty_out (vty, "debug ospf%s lsa refresh%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s lsa refresh", str);
 
       write = 1;
     }
 
   /* debug ospf zebra (interface|redistribute). */
   if (IS_CONF_DEBUG_OSPF (zebra, ZEBRA) == OSPF_DEBUG_ZEBRA)
-    vty_out (vty, "debug ospf%s zebra%s", str, VTY_NEWLINE);
+    vty_outln (vty, "debug ospf%s zebra", str);
   else
     {
       if (IS_CONF_DEBUG_OSPF (zebra, ZEBRA_INTERFACE))
-	vty_out (vty, "debug ospf%s zebra interface%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s zebra interface", str);
       if (IS_CONF_DEBUG_OSPF (zebra, ZEBRA_REDISTRIBUTE))
-	vty_out (vty, "debug ospf%s zebra redistribute%s", str, VTY_NEWLINE);
+	vty_outln (vty, "debug ospf%s zebra redistribute", str);
 
       write = 1;
     }
@@ -1782,14 +1779,14 @@ config_write_debug (struct vty *vty)
   /* debug ospf event. */
   if (IS_CONF_DEBUG_OSPF (event, EVENT) == OSPF_DEBUG_EVENT)
     {
-      vty_out (vty, "debug ospf%s event%s", str, VTY_NEWLINE);
+      vty_outln (vty, "debug ospf%s event", str);
       write = 1;
     }
 
   /* debug ospf nssa. */
   if (IS_CONF_DEBUG_OSPF (nssa, NSSA) == OSPF_DEBUG_NSSA)
     {
-      vty_out (vty, "debug ospf%s nssa%s", str, VTY_NEWLINE);
+      vty_outln (vty, "debug ospf%s nssa", str);
       write = 1;
     }
   
@@ -1799,7 +1796,7 @@ config_write_debug (struct vty *vty)
     r &= conf_debug_ospf_packet[i] & (OSPF_DEBUG_SEND_RECV|OSPF_DEBUG_DETAIL);
   if (r == (OSPF_DEBUG_SEND_RECV|OSPF_DEBUG_DETAIL))
     {
-      vty_out (vty, "debug ospf%s packet all detail%s", str, VTY_NEWLINE);
+      vty_outln (vty, "debug ospf%s packet all detail", str);
       return 1;
     }
 
@@ -1809,12 +1806,11 @@ config_write_debug (struct vty *vty)
     r &= conf_debug_ospf_packet[i] & OSPF_DEBUG_SEND_RECV;
   if (r == OSPF_DEBUG_SEND_RECV)
     {
-      vty_out (vty, "debug ospf%s packet all%s", str, VTY_NEWLINE);
+      vty_outln (vty, "debug ospf%s packet all", str);
       for (i = 0; i < 5; i++)
 	if (conf_debug_ospf_packet[i] & OSPF_DEBUG_DETAIL)
-	  vty_out (vty, "debug ospf%s packet %s detail%s", str,
-		   type_str[i],
-		   VTY_NEWLINE);
+	  vty_outln (vty, "debug ospf%s packet %s detail", str,
+		   type_str[i]);
       return 1;
     }
 
@@ -1825,9 +1821,8 @@ config_write_debug (struct vty *vty)
       if (conf_debug_ospf_packet[i] == 0)
 	continue;
       
-      vty_out (vty, "debug ospf%s packet %s%s%s", str,
-	       type_str[i], detail_str[conf_debug_ospf_packet[i]],
-	       VTY_NEWLINE);
+      vty_outln (vty, "debug ospf%s packet %s%s", str,
+	       type_str[i],detail_str[conf_debug_ospf_packet[i]]);
       write = 1;
     }
 

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -1568,8 +1568,8 @@ show_debugging_ospf_common (struct vty *vty, struct ospf *ospf)
   int i;
 
   if (ospf->instance)
-    vty_outln (vty, "%sOSPF Instance: %d%s", VTY_NEWLINE, ospf->instance,
-             VTY_NEWLINE);
+    vty_outln (vty, "%sOSPF Instance: %d%s", VTYNL, ospf->instance,
+             VTYNL);
 
   vty_outln (vty, "OSPF debugging status:");
 

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -1653,7 +1653,7 @@ show_debugging_ospf_common (struct vty *vty, struct ospf *ospf)
   if (IS_DEBUG_OSPF (nssa, NSSA) == OSPF_DEBUG_NSSA)
     vty_outln (vty, "  OSPF NSSA debugging is on");
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   return CMD_SUCCESS;
 }

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1120,7 +1120,7 @@ ospf_opaque_config_write_router (struct vty *vty, struct ospf *ospf)
   struct list *funclist;
 
   if (CHECK_FLAG (ospf->config, OSPF_OPAQUE_CAPABLE))
-    vty_out (vty, " capability opaque%s", VTY_NEWLINE);
+    vty_outln (vty, " capability opaque");
 
   funclist = ospf_opaque_wildcard_funclist;
   opaque_lsa_config_write_router_callback (funclist, vty);
@@ -1189,14 +1189,13 @@ show_opaque_info_detail (struct vty *vty, struct ospf_lsa *lsa)
   /* Switch output functionality by vty address. */
   if (vty != NULL)
     {
-      vty_out (vty, "  Opaque-Type %u (%s)%s", opaque_type,
-	       ospf_opaque_type_name (opaque_type), VTY_NEWLINE);
-      vty_out (vty, "  Opaque-ID   0x%x%s", opaque_id, VTY_NEWLINE);
+      vty_outln (vty, "  Opaque-Type %u (%s)", opaque_type,
+	       ospf_opaque_type_name(opaque_type));
+      vty_outln (vty, "  Opaque-ID   0x%x", opaque_id);
 
-      vty_out (vty, "  Opaque-Info: %u octets of data%s%s",
+      vty_outln (vty, "  Opaque-Info: %u octets of data%s",
                ntohs (lsah->length) - OSPF_LSA_HEADER_SIZE,
-               VALID_OPAQUE_INFO_LEN(lsah) ? "" : "(Invalid length?)",
-               VTY_NEWLINE);
+               VALID_OPAQUE_INFO_LEN(lsah) ? "" : "(Invalid length?)");
     }
   else
     {

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -906,10 +906,9 @@ show_vty_router_cap (struct vty *vty, struct ri_tlv_header *tlvh)
   struct ri_tlv_router_cap *top = (struct ri_tlv_router_cap *) tlvh;
 
   if (vty != NULL)
-    vty_out (vty, "  Router Capabilities: 0x%x%s", ntohl (top->value),
-             VTY_NEWLINE);
-  else
-    zlog_debug ("    Router Capabilities: 0x%x", ntohl (top->value));
+    vty_outln (vty, "  Router Capabilities: 0x%x",ntohl(top->value));
+    else
+      zlog_debug ("    Router Capabilities: 0x%x", ntohl (top->value));
 
   return RI_TLV_SIZE (tlvh);
 }
@@ -922,20 +921,19 @@ show_vty_pce_subtlv_address (struct vty *vty, struct ri_tlv_header *tlvh)
   if (ntohs (top->address.type) == PCE_ADDRESS_TYPE_IPV4)
     {
       if (vty != NULL)
-        vty_out (vty, "  PCE Address: %s%s", inet_ntoa (top->address.value),
-                 VTY_NEWLINE);
-      else
-        zlog_debug ("    PCE Address: %s", inet_ntoa (top->address.value));
+        vty_outln (vty, "  PCE Address: %s",inet_ntoa(top->address.value));
+        else
+          zlog_debug ("    PCE Address: %s", inet_ntoa (top->address.value));
     }
   else
     {
       /* TODO: Add support to IPv6 with inet_ntop() */
       if (vty != NULL)
-        vty_out (vty, "  PCE Address: 0x%x%s",
-                 ntohl (top->address.value.s_addr), VTY_NEWLINE);
-      else
-        zlog_debug ("    PCE Address: 0x%x",
-                    ntohl (top->address.value.s_addr));
+        vty_outln (vty, "  PCE Address: 0x%x",
+                 ntohl(top->address.value.s_addr));
+        else
+          zlog_debug ("    PCE Address: 0x%x",
+	                    ntohl (top->address.value.s_addr));
     }
 
   return RI_TLV_SIZE (tlvh);
@@ -948,10 +946,9 @@ show_vty_pce_subtlv_path_scope (struct vty *vty, struct ri_tlv_header *tlvh)
     (struct ri_pce_subtlv_path_scope *) tlvh;
 
   if (vty != NULL)
-    vty_out (vty, "  PCE Path Scope: 0x%x%s", ntohl (top->value),
-             VTY_NEWLINE);
-  else
-    zlog_debug ("    PCE Path Scope: 0x%x", ntohl (top->value));
+    vty_outln (vty, "  PCE Path Scope: 0x%x",ntohl(top->value));
+    else
+      zlog_debug ("    PCE Path Scope: 0x%x", ntohl (top->value));
 
   return RI_TLV_SIZE (tlvh);
 }
@@ -966,18 +963,16 @@ show_vty_pce_subtlv_domain (struct vty *vty, struct ri_tlv_header *tlvh)
     {
       tmp.s_addr = top->value;
       if (vty != NULL)
-        vty_out (vty, "  PCE domain Area: %s%s", inet_ntoa (tmp),
-                 VTY_NEWLINE);
-      else
-        zlog_debug ("    PCE domain Area: %s", inet_ntoa (tmp));
+        vty_outln (vty, "  PCE domain Area: %s",inet_ntoa(tmp));
+        else
+          zlog_debug ("    PCE domain Area: %s", inet_ntoa (tmp));
     }
   else
     {
       if (vty != NULL)
-        vty_out (vty, "  PCE domain AS: %d%s", ntohl (top->value),
-                 VTY_NEWLINE);
-      else
-        zlog_debug ("    PCE domain AS: %d", ntohl (top->value));
+        vty_outln (vty, "  PCE domain AS: %d",ntohl(top->value));
+        else
+          zlog_debug ("    PCE domain AS: %d", ntohl (top->value));
     }
   return RI_TLV_SIZE (tlvh);
 }
@@ -993,18 +988,16 @@ show_vty_pce_subtlv_neighbor (struct vty *vty, struct ri_tlv_header *tlvh)
     {
       tmp.s_addr = top->value;
       if (vty != NULL)
-        vty_out (vty, "  PCE neighbor Area: %s%s", inet_ntoa (tmp),
-                 VTY_NEWLINE);
-      else
-        zlog_debug ("    PCE neighbor Area: %s", inet_ntoa (tmp));
+        vty_outln (vty, "  PCE neighbor Area: %s",inet_ntoa(tmp));
+        else
+          zlog_debug ("    PCE neighbor Area: %s", inet_ntoa (tmp));
     }
   else
     {
       if (vty != NULL)
-        vty_out (vty, "  PCE neighbor AS: %d%s", ntohl (top->value),
-                 VTY_NEWLINE);
-      else
-        zlog_debug ("    PCE neighbor AS: %d", ntohl (top->value));
+        vty_outln (vty, "  PCE neighbor AS: %d",ntohl(top->value));
+        else
+          zlog_debug ("    PCE neighbor AS: %d", ntohl (top->value));
     }
   return RI_TLV_SIZE (tlvh);
 }
@@ -1015,10 +1008,9 @@ show_vty_pce_subtlv_cap_flag (struct vty *vty, struct ri_tlv_header *tlvh)
   struct ri_pce_subtlv_cap_flag *top = (struct ri_pce_subtlv_cap_flag *) tlvh;
 
   if (vty != NULL)
-    vty_out (vty, "  PCE Capabilities Flag: 0x%x%s", ntohl (top->value),
-             VTY_NEWLINE);
-  else
-    zlog_debug ("    PCE Capabilities Flag: 0x%x", ntohl (top->value));
+    vty_outln (vty, "  PCE Capabilities Flag: 0x%x",ntohl(top->value));
+    else
+      zlog_debug ("    PCE Capabilities Flag: 0x%x", ntohl (top->value));
 
   return RI_TLV_SIZE (tlvh);
 }
@@ -1027,11 +1019,11 @@ static u_int16_t
 show_vty_unknown_tlv (struct vty *vty, struct ri_tlv_header *tlvh)
 {
   if (vty != NULL)
-    vty_out (vty, "  Unknown TLV: [type(0x%x), length(0x%x)]%s",
-             ntohs (tlvh->type), ntohs (tlvh->length), VTY_NEWLINE);
-  else
-    zlog_debug ("    Unknown TLV: [type(0x%x), length(0x%x)]",
-                ntohs (tlvh->type), ntohs (tlvh->length));
+    vty_outln (vty, "  Unknown TLV: [type(0x%x), length(0x%x)]",
+             ntohs (tlvh->type), ntohs(tlvh->length));
+    else
+      zlog_debug ("    Unknown TLV: [type(0x%x), length(0x%x)]",
+	                ntohs (tlvh->type), ntohs (tlvh->length));
 
   return RI_TLV_SIZE (tlvh);
 }
@@ -1113,18 +1105,16 @@ ospf_router_info_config_write_router (struct vty *vty)
   if (OspfRI.status == enabled)
     {
       if (OspfRI.scope == OSPF_OPAQUE_AS_LSA)
-        vty_out (vty, " router-info as%s", VTY_NEWLINE);
+        vty_outln (vty, " router-info as");
       else
-        vty_out (vty, " router-info area %s%s", inet_ntoa (OspfRI.area_id),
-                 VTY_NEWLINE);
+        vty_outln (vty, " router-info area %s",inet_ntoa(OspfRI.area_id));
 
       if (pce->pce_address.header.type != 0)
-        vty_out (vty, "  pce address %s%s",
-                 inet_ntoa (pce->pce_address.address.value), VTY_NEWLINE);
+        vty_outln (vty, "  pce address %s",
+                 inet_ntoa(pce->pce_address.address.value));
 
       if (pce->pce_cap_flag.header.type != 0)
-        vty_out (vty, "  pce flag 0x%x%s", ntohl (pce->pce_cap_flag.value),
-                 VTY_NEWLINE);
+        vty_outln (vty, "  pce flag 0x%x",ntohl(pce->pce_cap_flag.value));
 
       for (ALL_LIST_ELEMENTS_RO (pce->pce_domain, node, domain))
         {
@@ -1133,13 +1123,11 @@ ospf_router_info_config_write_router (struct vty *vty)
               if (domain->type == PCE_DOMAIN_TYPE_AREA)
                 {
                   tmp.s_addr = domain->value;
-                  vty_out (vty, "  pce domain area %s%s", inet_ntoa (tmp),
-                           VTY_NEWLINE);
+                  vty_outln (vty, "  pce domain area %s",inet_ntoa(tmp));
                 }
               else
                 {
-                  vty_out (vty, "  pce domain as %d%s", ntohl (domain->value),
-                           VTY_NEWLINE);
+                  vty_outln (vty, "  pce domain as %d",ntohl(domain->value));
                 }
             }
         }
@@ -1151,20 +1139,19 @@ ospf_router_info_config_write_router (struct vty *vty)
               if (neighbor->type == PCE_DOMAIN_TYPE_AREA)
                 {
                   tmp.s_addr = neighbor->value;
-                  vty_out (vty, "  pce neighbor area %s%s", inet_ntoa (tmp),
-                           VTY_NEWLINE);
+                  vty_outln (vty, "  pce neighbor area %s",inet_ntoa(tmp));
                 }
               else
                 {
-                  vty_out (vty, "  pce neighbor as %d%s",
-                           ntohl (neighbor->value), VTY_NEWLINE);
+                  vty_outln (vty, "  pce neighbor as %d",
+                           ntohl(neighbor->value));
                 }
             }
         }
 
       if (pce->pce_scope.header.type != 0)
-        vty_out (vty, "  pce scope 0x%x%s",
-                 ntohl (OspfRI.pce_info.pce_scope.value), VTY_NEWLINE);
+        vty_outln (vty, "  pce scope 0x%x",
+                 ntohl(OspfRI.pce_info.pce_scope.value));
     }
   return;
 }
@@ -1194,8 +1181,8 @@ DEFUN (router_info,
     {
       if (!inet_aton (area, &OspfRI.area_id))
         {
-          vty_out (vty, "%% specified Area ID %s is invalid%s",
-                   area, VTY_NEWLINE);
+          vty_outln (vty, "%% specified Area ID %s is invalid",
+                   area);
           return CMD_WARNING;
         }
       scope = OSPF_OPAQUE_AREA_LSA;
@@ -1270,7 +1257,7 @@ ospf_ri_enabled (struct vty *vty)
     return 1;
 
   if (vty)
-    vty_out (vty, "%% OSPF RI is not turned on%s", VTY_NEWLINE);
+    vty_outln (vty, "%% OSPF RI is not turned on");
 
   return 0;
 }
@@ -1291,7 +1278,7 @@ DEFUN (pce_address,
 
   if (!inet_aton (argv[idx_ipv4]->arg, &value))
     {
-      vty_out (vty, "Please specify PCE Address by A.B.C.D%s", VTY_NEWLINE);
+      vty_outln (vty, "Please specify PCE Address by A.B.C.D");
       return CMD_WARNING;
     }
 
@@ -1343,8 +1330,7 @@ DEFUN (pce_path_scope,
 
   if (sscanf (argv[idx_bitpattern]->arg, "0x%x", &scope) != 1)
     {
-      vty_out (vty, "pce_path_scope: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "pce_path_scope: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -1398,8 +1384,7 @@ DEFUN (pce_domain,
 
   if (sscanf (argv[idx_number]->arg, "%d", &as) != 1)
     {
-      vty_out (vty, "pce_domain: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "pce_domain: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -1436,8 +1421,7 @@ DEFUN (no_pce_domain,
 
   if (sscanf (argv[idx_number]->arg, "%d", &as) != 1)
     {
-      vty_out (vty, "no_pce_domain: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "no_pce_domain: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -1471,8 +1455,7 @@ DEFUN (pce_neigbhor,
 
   if (sscanf (argv[idx_number]->arg, "%d", &as) != 1)
     {
-      vty_out (vty, "pce_neighbor: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "pce_neighbor: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -1509,8 +1492,7 @@ DEFUN (no_pce_neighbor,
 
   if (sscanf (argv[idx_number]->arg, "%d", &as) != 1)
     {
-      vty_out (vty, "no_pce_neighbor: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "no_pce_neighbor: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -1541,8 +1523,7 @@ DEFUN (pce_cap_flag,
 
   if (sscanf (argv[idx_bitpattern]->arg, "0x%x", &cap) != 1)
     {
-      vty_out (vty, "pce_cap_flag: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "pce_cap_flag: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -1587,13 +1568,13 @@ DEFUN (show_ip_ospf_router_info,
 
   if (OspfRI.status == enabled)
     {
-      vty_out (vty, "--- Router Information parameters ---%s", VTY_NEWLINE);
+      vty_outln (vty, "--- Router Information parameters ---");
       show_vty_router_cap (vty, &OspfRI.router_cap.header);
     }
   else
     {
       if (vty != NULL)
-        vty_out (vty, "  Router Information is disabled on this router%s", VTY_NEWLINE);
+        vty_outln (vty, "  Router Information is disabled on this router");
     }
   return CMD_SUCCESS;
 }
@@ -1615,7 +1596,7 @@ DEFUN (show_ip_opsf_router_info_pce,
 
   if (OspfRI.status == enabled)
     {
-      vty_out (vty, "--- PCE parameters ---%s", VTY_NEWLINE);
+      vty_outln (vty, "--- PCE parameters ---");
 
       if (pce->pce_address.header.type != 0)
         show_vty_pce_subtlv_address (vty, &pce->pce_address.header);
@@ -1641,8 +1622,7 @@ DEFUN (show_ip_opsf_router_info_pce,
     }
   else
     {
-      vty_out (vty, "  Router Information is disabled on this router%s",
-               VTY_NEWLINE);
+      vty_outln (vty,"  Router Information is disabled on this router");
     }
 
   return CMD_SUCCESS;

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1671,10 +1671,9 @@ show_vty_router_addr (struct vty *vty, struct te_tlv_header *tlvh)
   struct te_tlv_router_addr *top = (struct te_tlv_router_addr *) tlvh;
 
   if (vty != NULL)
-    vty_out (vty, "  Router-Address: %s%s", inet_ntoa (top->value),
-             VTY_NEWLINE);
-  else
-    zlog_debug ("    Router-Address: %s", inet_ntoa (top->value));
+    vty_outln (vty, "  Router-Address: %s",inet_ntoa(top->value));
+    else
+      zlog_debug ("    Router-Address: %s", inet_ntoa (top->value));
 
   return TLV_SIZE (tlvh);
 }
@@ -1685,10 +1684,9 @@ show_vty_link_header (struct vty *vty, struct te_tlv_header *tlvh)
   struct te_tlv_link *top = (struct te_tlv_link *) tlvh;
 
   if (vty != NULL)
-    vty_out (vty, "  Link: %u octets of data%s", ntohs (top->header.length),
-             VTY_NEWLINE);
-  else
-    zlog_debug ("    Link: %u octets of data", ntohs (top->header.length));
+    vty_outln (vty, "  Link: %u octets of data",ntohs(top->header.length));
+    else
+      zlog_debug ("    Link: %u octets of data", ntohs (top->header.length));
 
   return TLV_HDR_SIZE;	/* Here is special, not "TLV_SIZE". */
 }
@@ -1713,8 +1711,7 @@ show_vty_link_subtlv_link_type (struct vty *vty, struct te_tlv_header *tlvh)
     }
 
   if (vty != NULL)
-    vty_out (vty, "  Link-Type: %s (%u)%s", cp, top->link_type.value,
-             VTY_NEWLINE);
+    vty_outln (vty, "  Link-Type: %s (%u)", cp,top->link_type.value);
   else
     zlog_debug ("    Link-Type: %s (%u)", cp, top->link_type.value);
 
@@ -1728,9 +1725,9 @@ show_vty_link_subtlv_link_id (struct vty *vty, struct te_tlv_header *tlvh)
 
   top = (struct te_link_subtlv_link_id *) tlvh;
   if (vty != NULL)
-    vty_out (vty, "  Link-ID: %s%s", inet_ntoa (top->value), VTY_NEWLINE);
-  else
-    zlog_debug ("    Link-ID: %s", inet_ntoa (top->value));
+    vty_outln (vty, "  Link-ID: %s", inet_ntoa(top->value));
+    else
+      zlog_debug ("    Link-ID: %s", inet_ntoa (top->value));
 
   return TLV_SIZE (tlvh);
 }
@@ -1746,17 +1743,16 @@ show_vty_link_subtlv_lclif_ipaddr (struct vty *vty,
   n = ntohs (tlvh->length) / sizeof (top->value[0]);
 
   if (vty != NULL)
-    vty_out (vty, "  Local Interface IP Address(es): %d%s", n, VTY_NEWLINE);
+    vty_outln (vty, "  Local Interface IP Address(es): %d", n);
   else
     zlog_debug ("    Local Interface IP Address(es): %d", n);
 
   for (i = 0; i < n; i++)
     {
       if (vty != NULL)
-        vty_out (vty, "    #%d: %s%s", i, inet_ntoa (top->value[i]),
-                 VTY_NEWLINE);
-      else
-        zlog_debug ("      #%d: %s", i, inet_ntoa (top->value[i]));
+        vty_outln (vty, "    #%d: %s", i,inet_ntoa(top->value[i]));
+        else
+          zlog_debug ("      #%d: %s", i, inet_ntoa (top->value[i]));
     }
   return TLV_SIZE (tlvh);
 }
@@ -1771,17 +1767,16 @@ show_vty_link_subtlv_rmtif_ipaddr (struct vty *vty,
   top = (struct te_link_subtlv_rmtif_ipaddr *) tlvh;
   n = ntohs (tlvh->length) / sizeof (top->value[0]);
   if (vty != NULL)
-    vty_out (vty, "  Remote Interface IP Address(es): %d%s", n, VTY_NEWLINE);
+    vty_outln (vty, "  Remote Interface IP Address(es): %d", n);
   else
     zlog_debug ("    Remote Interface IP Address(es): %d", n);
 
   for (i = 0; i < n; i++)
     {
       if (vty != NULL)
-        vty_out (vty, "    #%d: %s%s", i, inet_ntoa (top->value[i]),
-                 VTY_NEWLINE);
-      else
-        zlog_debug ("      #%d: %s", i, inet_ntoa (top->value[i]));
+        vty_outln (vty, "    #%d: %s", i,inet_ntoa(top->value[i]));
+        else
+          zlog_debug ("      #%d: %s", i, inet_ntoa (top->value[i]));
     }
   return TLV_SIZE (tlvh);
 }
@@ -1793,11 +1788,11 @@ show_vty_link_subtlv_te_metric (struct vty *vty, struct te_tlv_header *tlvh)
 
   top = (struct te_link_subtlv_te_metric *) tlvh;
   if (vty != NULL)
-    vty_out (vty, "  Traffic Engineering Metric: %u%s",
-             (u_int32_t) ntohl (top->value), VTY_NEWLINE);
-  else
-    zlog_debug ("    Traffic Engineering Metric: %u",
-                (u_int32_t) ntohl (top->value));
+    vty_outln (vty, "  Traffic Engineering Metric: %u",
+             (u_int32_t)ntohl(top->value));
+      else
+        zlog_debug ("    Traffic Engineering Metric: %u",
+		                (u_int32_t) ntohl (top->value));
 
   return TLV_SIZE (tlvh);
 }
@@ -1812,7 +1807,7 @@ show_vty_link_subtlv_max_bw (struct vty *vty, struct te_tlv_header *tlvh)
   fval = ntohf (top->value);
 
   if (vty != NULL)
-    vty_out (vty, "  Maximum Bandwidth: %g (Bytes/sec)%s", fval, VTY_NEWLINE);
+    vty_outln (vty, "  Maximum Bandwidth: %g (Bytes/sec)", fval);
   else
     zlog_debug ("    Maximum Bandwidth: %g (Bytes/sec)", fval);
 
@@ -1829,8 +1824,7 @@ show_vty_link_subtlv_max_rsv_bw (struct vty *vty, struct te_tlv_header *tlvh)
   fval = ntohf (top->value);
 
   if (vty != NULL)
-    vty_out (vty, "  Maximum Reservable Bandwidth: %g (Bytes/sec)%s", fval,
-             VTY_NEWLINE);
+    vty_outln (vty, "  Maximum Reservable Bandwidth: %g (Bytes/sec)",fval);
   else
     zlog_debug ("    Maximum Reservable Bandwidth: %g (Bytes/sec)", fval);
 
@@ -1846,7 +1840,7 @@ show_vty_link_subtlv_unrsv_bw (struct vty *vty, struct te_tlv_header *tlvh)
 
   top = (struct te_link_subtlv_unrsv_bw *) tlvh;
   if (vty != NULL)
-    vty_out (vty, "  Unreserved Bandwidth per Class Type in Byte/s:%s", VTY_NEWLINE);
+    vty_outln (vty, "  Unreserved Bandwidth per Class Type in Byte/s:");
   else
     zlog_debug ("    Unreserved Bandwidth per Class Type in Byte/s:");
   for (i = 0; i < MAX_CLASS_TYPE; i+=2)
@@ -1855,8 +1849,8 @@ show_vty_link_subtlv_unrsv_bw (struct vty *vty, struct te_tlv_header *tlvh)
       fval2 = ntohf (top->value[i+1]);
 
       if (vty != NULL)
-        vty_out(vty, "    [%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)%s",
-                i, fval1, i+1, fval2, VTY_NEWLINE);
+        vty_outln (vty, "    [%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)",
+                i, fval1, i+1, fval2);
       else
         zlog_debug ("      [%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)",
                     i, fval1, i+1, fval2);
@@ -1872,11 +1866,11 @@ show_vty_link_subtlv_rsc_clsclr (struct vty *vty, struct te_tlv_header *tlvh)
 
   top = (struct te_link_subtlv_rsc_clsclr *) tlvh;
   if (vty != NULL)
-    vty_out (vty, "  Resource class/color: 0x%x%s",
-             (u_int32_t) ntohl (top->value), VTY_NEWLINE);
-  else
-    zlog_debug ("    Resource Class/Color: 0x%x",
-                (u_int32_t) ntohl (top->value));
+    vty_outln (vty, "  Resource class/color: 0x%x",
+             (u_int32_t)ntohl(top->value));
+      else
+        zlog_debug ("    Resource Class/Color: 0x%x",
+		                (u_int32_t) ntohl (top->value));
 
   return TLV_SIZE (tlvh);
 }
@@ -1890,10 +1884,8 @@ show_vty_link_subtlv_lrrid (struct vty *vty, struct te_tlv_header *tlvh)
 
   if (vty != NULL)
     {
-      vty_out (vty, "  Local  TE Router ID: %s%s", inet_ntoa (top->local),
-               VTY_NEWLINE);
-      vty_out (vty, "  Remote TE Router ID: %s%s", inet_ntoa (top->remote),
-               VTY_NEWLINE);
+      vty_outln (vty, "  Local  TE Router ID: %s",inet_ntoa(top->local));
+      vty_outln (vty, "  Remote TE Router ID: %s",inet_ntoa(top->remote));
     }
   else
     {
@@ -1913,10 +1905,8 @@ show_vty_link_subtlv_llri (struct vty *vty, struct te_tlv_header *tlvh)
 
   if (vty != NULL)
     {
-      vty_out (vty, "  Link Local  ID: %d%s", (u_int32_t) ntohl (top->local),
-               VTY_NEWLINE);
-      vty_out (vty, "  Link Remote ID: %d%s", (u_int32_t) ntohl (top->remote),
-               VTY_NEWLINE);
+      vty_outln (vty, "  Link Local  ID: %d",(u_int32_t)ntohl(top->local));
+      vty_outln (vty, "  Link Remote ID: %d",(u_int32_t)ntohl(top->remote));
     }
   else
     {
@@ -1935,11 +1925,11 @@ show_vty_link_subtlv_rip (struct vty *vty, struct te_tlv_header *tlvh)
   top = (struct te_link_subtlv_rip *) tlvh;
 
   if (vty != NULL)
-    vty_out (vty, "  Inter-AS TE Remote ASBR IP address: %s%s",
-             inet_ntoa (top->value), VTY_NEWLINE);
-  else
-    zlog_debug ("    Inter-AS TE Remote ASBR IP address: %s",
-                inet_ntoa (top->value));
+    vty_outln (vty, "  Inter-AS TE Remote ASBR IP address: %s",
+             inet_ntoa(top->value));
+    else
+      zlog_debug ("    Inter-AS TE Remote ASBR IP address: %s",
+	                inet_ntoa (top->value));
 
   return TLV_SIZE (tlvh);
 }
@@ -1952,10 +1942,9 @@ show_vty_link_subtlv_ras (struct vty *vty, struct te_tlv_header *tlvh)
   top = (struct te_link_subtlv_ras *) tlvh;
 
   if (vty != NULL)
-    vty_out (vty, "  Inter-AS TE Remote AS number: %u%s", ntohl (top->value),
-             VTY_NEWLINE);
-  else
-    zlog_debug ("    Inter-AS TE Remote AS number: %u", ntohl (top->value));
+    vty_outln (vty, "  Inter-AS TE Remote AS number: %u",ntohl(top->value));
+    else
+      zlog_debug ("    Inter-AS TE Remote AS number: %u", ntohl (top->value));
 
   return TLV_SIZE (tlvh);
 }
@@ -1972,8 +1961,8 @@ show_vty_link_subtlv_av_delay (struct vty *vty, struct te_tlv_header *tlvh)
   anomalous = (u_int32_t) ntohl (top->value) & TE_EXT_ANORMAL;
 
   if (vty != NULL)
-    vty_out (vty, "  %s Average Link Delay: %d (micro-sec)%s",
-             anomalous ? "Anomalous" : "Normal", delay, VTY_NEWLINE);
+    vty_outln (vty, "  %s Average Link Delay: %d (micro-sec)",
+             anomalous ? "Anomalous" : "Normal", delay);
   else
     zlog_debug ("    %s Average Link Delay: %d (micro-sec)",
                 anomalous ? "Anomalous" : "Normal", delay);
@@ -1994,8 +1983,8 @@ show_vty_link_subtlv_mm_delay (struct vty *vty, struct te_tlv_header *tlvh)
   high = (u_int32_t) ntohl (top->high);
 
   if (vty != NULL)
-    vty_out (vty, "  %s Min/Max Link Delay: %d/%d (micro-sec)%s",
-             anomalous ? "Anomalous" : "Normal", low, high, VTY_NEWLINE);
+    vty_outln (vty, "  %s Min/Max Link Delay: %d/%d (micro-sec)",
+             anomalous ? "Anomalous" : "Normal", low, high);
   else
     zlog_debug ("    %s Min/Max Link Delay: %d/%d (micro-sec)",
                 anomalous ? "Anomalous" : "Normal", low, high);
@@ -2013,7 +2002,7 @@ show_vty_link_subtlv_delay_var (struct vty *vty, struct te_tlv_header *tlvh)
   jitter = (u_int32_t) ntohl (top->value) & TE_EXT_MASK;
 
   if (vty != NULL)
-    vty_out (vty, "  Delay Variation: %d (micro-sec)%s", jitter, VTY_NEWLINE);
+    vty_outln (vty, "  Delay Variation: %d (micro-sec)", jitter);
   else
     zlog_debug ("    Delay Variation: %d (micro-sec)", jitter);
 
@@ -2034,8 +2023,8 @@ show_vty_link_subtlv_pkt_loss (struct vty *vty, struct te_tlv_header *tlvh)
   anomalous = (u_int32_t) ntohl (top->value) & TE_EXT_ANORMAL;
 
   if (vty != NULL)
-    vty_out (vty, "  %s Link Loss: %g (%%)%s", anomalous ? "Anomalous" : "Normal",
-             fval, VTY_NEWLINE);
+    vty_outln (vty, "  %s Link Loss: %g (%%)", anomalous ? "Anomalous" : "Normal",
+             fval);
   else
     zlog_debug ("    %s Link Loss: %g (%%)", anomalous ? "Anomalous" : "Normal",
                 fval);
@@ -2053,8 +2042,8 @@ show_vty_link_subtlv_res_bw (struct vty *vty, struct te_tlv_header *tlvh)
   fval = ntohf (top->value);
 
   if (vty != NULL)
-    vty_out (vty, "  Unidirectional Residual Bandwidth: %g (Bytes/sec)%s",
-             fval, VTY_NEWLINE);
+    vty_outln (vty, "  Unidirectional Residual Bandwidth: %g (Bytes/sec)",
+             fval);
   else
     zlog_debug ("    Unidirectional Residual Bandwidth: %g (Bytes/sec)",
                 fval);
@@ -2072,8 +2061,8 @@ show_vty_link_subtlv_ava_bw (struct vty *vty, struct te_tlv_header *tlvh)
   fval = ntohf (top->value);
 
   if (vty != NULL)
-    vty_out (vty, "  Unidirectional Available Bandwidth: %g (Bytes/sec)%s",
-             fval, VTY_NEWLINE);
+    vty_outln (vty, "  Unidirectional Available Bandwidth: %g (Bytes/sec)",
+             fval);
   else
     zlog_debug ("    Unidirectional Available Bandwidth: %g (Bytes/sec)",
                 fval);
@@ -2091,8 +2080,8 @@ show_vty_link_subtlv_use_bw (struct vty *vty, struct te_tlv_header *tlvh)
   fval = ntohf (top->value);
 
   if (vty != NULL)
-    vty_out (vty, "  Unidirectional Utilized Bandwidth: %g (Bytes/sec)%s",
-             fval, VTY_NEWLINE);
+    vty_outln (vty, "  Unidirectional Utilized Bandwidth: %g (Bytes/sec)",
+             fval);
   else
     zlog_debug ("    Unidirectional Utilized Bandwidth: %g (Bytes/sec)",
                 fval);
@@ -2104,11 +2093,11 @@ static u_int16_t
 show_vty_unknown_tlv (struct vty *vty, struct te_tlv_header *tlvh)
 {
   if (vty != NULL)
-    vty_out (vty, "  Unknown TLV: [type(0x%x), length(0x%x)]%s",
-             ntohs (tlvh->type), ntohs (tlvh->length), VTY_NEWLINE);
-  else
-    zlog_debug ("    Unknown TLV: [type(0x%x), length(0x%x)]",
-                ntohs (tlvh->type), ntohs (tlvh->length));
+    vty_outln (vty, "  Unknown TLV: [type(0x%x), length(0x%x)]",
+             ntohs (tlvh->type), ntohs(tlvh->length));
+    else
+      zlog_debug ("    Unknown TLV: [type(0x%x), length(0x%x)]",
+	                ntohs (tlvh->type), ntohs (tlvh->length));
 
   return TLV_SIZE (tlvh);
 }
@@ -2241,16 +2230,16 @@ ospf_mpls_te_config_write_router (struct vty *vty)
 
   if (OspfMplsTE.status == enabled)
     {
-      vty_out (vty, " mpls-te on%s", VTY_NEWLINE);
-      vty_out (vty, " mpls-te router-address %s%s",
-               inet_ntoa (OspfMplsTE.router_addr.value), VTY_NEWLINE);
+      vty_outln (vty, " mpls-te on");
+      vty_outln (vty, " mpls-te router-address %s",
+               inet_ntoa(OspfMplsTE.router_addr.value));
     }
 
   if (OspfMplsTE.inter_as == AS)
-    vty_out (vty, "  mpls-te inter-as as%s", VTY_NEWLINE);
+    vty_outln (vty, "  mpls-te inter-as as");
   if (OspfMplsTE.inter_as == Area)
-    vty_out (vty, "  mpls-te inter-as area %s %s",
-             inet_ntoa (OspfMplsTE.interas_areaid), VTY_NEWLINE);
+    vty_outln (vty, "  mpls-te inter-as area %s ",
+             inet_ntoa(OspfMplsTE.interas_areaid));
 
   return;
 }
@@ -2336,7 +2325,7 @@ DEFUN (ospf_mpls_te_router_addr,
 
   if (! inet_aton (argv[idx_ipv4]->arg, &value))
     {
-      vty_out (vty, "Please specify Router-Addr by A.B.C.D%s", VTY_NEWLINE);
+      vty_outln (vty, "Please specify Router-Addr by A.B.C.D");
       return CMD_WARNING;
     }
 
@@ -2404,8 +2393,7 @@ set_inter_as_mode (struct vty *vty, const char *mode_name,
         }
       else
         {
-          vty_out (vty, "Unknown mode. Please choose between as or area%s",
-                   VTY_NEWLINE);
+          vty_outln (vty,"Unknown mode. Please choose between as or area");
           return CMD_WARNING;
         }
 
@@ -2416,8 +2404,8 @@ set_inter_as_mode (struct vty *vty, const char *mode_name,
       /* Register new callbacks regarding the flooding scope (AS or Area) */
       if (ospf_mpls_te_register (mode) < 0)
         {
-          vty_out (vty, "Internal error: Unable to register Inter-AS functions%s",
-                   VTY_NEWLINE);
+          vty_outln (vty,
+                     "Internal error: Unable to register Inter-AS functions");
           return CMD_WARNING;
         }
 
@@ -2440,14 +2428,14 @@ set_inter_as_mode (struct vty *vty, const char *mode_name,
         }
       else
         {
-          vty_out (vty, "Please change Inter-AS support to disable first before going to mode %s%s",
-                   mode2text[mode], VTY_NEWLINE);
+          vty_outln (vty, "Please change Inter-AS support to disable first before going to mode %s",
+                   mode2text[mode]);
           return CMD_WARNING;
         }
     }
   else
     {
-      vty_out (vty, "mpls-te has not been turned on%s", VTY_NEWLINE);
+      vty_outln (vty, "mpls-te has not been turned on");
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -2517,12 +2505,12 @@ DEFUN (show_ip_ospf_mpls_te_router,
 {
   if (OspfMplsTE.status == enabled)
     {
-      vty_out (vty, "--- MPLS-TE router parameters ---%s", VTY_NEWLINE);
+      vty_outln (vty, "--- MPLS-TE router parameters ---");
 
       if (ntohs (OspfMplsTE.router_addr.header.type) != 0)
         show_vty_router_addr (vty, &OspfMplsTE.router_addr.header);
       else if (vty != NULL)
-        vty_out (vty, "  N/A%s", VTY_NEWLINE);
+        vty_outln (vty, "  N/A");
     }
   return CMD_SUCCESS;
 }
@@ -2543,22 +2531,22 @@ show_mpls_te_link_sub (struct vty *vty, struct interface *ifp)
         {
           if (IS_INTER_AS (lp->type))
             {
-              vty_out (vty, "-- Inter-AS TEv2 link parameters for %s --%s",
-                       ifp->name, VTY_NEWLINE);
+              vty_outln (vty, "-- Inter-AS TEv2 link parameters for %s --",
+                       ifp->name);
             }
           else
             {
               /* MPLS-TE is not activate on this interface */
               /* or this interface is passive and Inter-AS TEv2 is not activate */
-              vty_out (vty, "  %s: MPLS-TE is disabled on this interface%s",
-                       ifp->name, VTY_NEWLINE);
+              vty_outln (vty, "  %s: MPLS-TE is disabled on this interface",
+                       ifp->name);
               return;
             }
         }
       else
         {
-      vty_out (vty, "-- MPLS-TE link parameters for %s --%s",
-               ifp->name, VTY_NEWLINE);
+      vty_outln (vty, "-- MPLS-TE link parameters for %s --",
+               ifp->name);
         }
 
       if (TLV_TYPE(lp->link_type) != 0)
@@ -2597,12 +2585,12 @@ show_mpls_te_link_sub (struct vty *vty, struct interface *ifp)
         show_vty_link_subtlv_ava_bw (vty, &lp->ava_bw.header);
       if (TLV_TYPE(lp->use_bw) != 0)
         show_vty_link_subtlv_use_bw (vty, &lp->use_bw.header);
-      vty_out (vty, "---------------%s%s", VTY_NEWLINE, VTY_NEWLINE);
+      vty_outln (vty, "---------------%s", VTY_NEWLINE);
     }
   else
     {
-      vty_out (vty, "  %s: MPLS-TE is disabled on this interface%s",
-               ifp->name, VTY_NEWLINE);
+      vty_outln (vty, "  %s: MPLS-TE is disabled on this interface",
+               ifp->name);
     }
 
   return;
@@ -2632,7 +2620,7 @@ DEFUN (show_ip_ospf_mpls_te_link,
   else
     {
       if ((ifp = if_lookup_by_name (argv[idx_interface]->arg, VRF_DEFAULT)) == NULL)
-        vty_out (vty, "No such interface name%s", VTY_NEWLINE);
+        vty_outln (vty, "No such interface name");
       else
         show_mpls_te_link_sub (vty, ifp);
     }

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -2585,7 +2585,7 @@ show_mpls_te_link_sub (struct vty *vty, struct interface *ifp)
         show_vty_link_subtlv_ava_bw (vty, &lp->ava_bw.header);
       if (TLV_TYPE(lp->use_bw) != 0)
         show_vty_link_subtlv_use_bw (vty, &lp->use_bw.header);
-      vty_outln (vty, "---------------%s", VTY_NEWLINE);
+      vty_outln (vty, "---------------%s", VTYNL);
     }
   else
     {

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -100,7 +100,7 @@ str2metric (const char *str, int *metric)
   *metric = strtol (str, NULL, 10);
   if (*metric < 0 && *metric > 16777214)
     {
-      /* vty_out (vty, "OSPF metric value is invalid%s", VTY_NEWLINE); */
+      /* vty_out (vty, "OSPF metric value is invalid%s", VTYNL); */
       return 0;
     }
 
@@ -150,7 +150,7 @@ DEFUN_NOSH (router_ospf,
   ospf = ospf_lookup();
   if (!ospf)
     {
-      vty_out (vty, "There isn't active ospf instance %s", VTY_NEWLINE);
+      vty_out (vty, "There isn't active ospf instance %s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -213,7 +213,7 @@ DEFUN (ospf_router_id,
   ret = inet_aton (argv[idx_ipv4]->arg, &router_id);
   if (!ret)
     {
-      vty_out (vty, "Please specify Router ID by A.B.C.D%s", VTY_NEWLINE);
+      vty_out (vty, "Please specify Router ID by A.B.C.D%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -223,7 +223,7 @@ DEFUN (ospf_router_id,
     if (area->full_nbrs)
       {
         vty_out (vty, "For this router-id change to take effect,"
-                 " save config and restart ospfd%s", VTY_NEWLINE);
+                 " save config and restart ospfd%s", VTYNL);
         return CMD_SUCCESS;
       }
 
@@ -248,7 +248,7 @@ DEFUN_HIDDEN (ospf_router_id_old,
   ret = inet_aton (argv[idx_ipv4]->arg, &router_id);
   if (!ret)
     {
-      vty_out (vty, "Please specify Router ID by A.B.C.D%s", VTY_NEWLINE);
+      vty_out (vty, "Please specify Router ID by A.B.C.D%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -258,7 +258,7 @@ DEFUN_HIDDEN (ospf_router_id_old,
     if (area->full_nbrs)
       {
         vty_out (vty, "For this router-id change to take effect,"
-                 " save config and restart ospfd%s", VTY_NEWLINE);
+                 " save config and restart ospfd%s", VTYNL);
         return CMD_SUCCESS;
       }
 
@@ -285,7 +285,7 @@ DEFUN (no_ospf_router_id,
     if (area->full_nbrs)
       {
         vty_out (vty, "For this router-id change to take effect,"
-                 " save config and restart ospfd%s", VTY_NEWLINE);
+                 " save config and restart ospfd%s", VTYNL);
         return CMD_SUCCESS;
       }
 
@@ -390,7 +390,7 @@ DEFUN (ospf_passive_interface,
       if (!ret)
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -460,7 +460,7 @@ DEFUN (no_ospf_passive_interface,
       if (!ret)
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -511,14 +511,14 @@ DEFUN (ospf_network_area,
   if (ospf->instance)
     {
       vty_out (vty, "The network command is not supported in multi-instance ospf%s",
-	       VTY_NEWLINE);
+	       VTYNL);
       return CMD_WARNING;
     }
 
   if (ospf->if_ospf_cli_count > 0)
     {
       vty_out (vty, "Please remove all ip ospf area x.x.x.x commands first.%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
@@ -529,7 +529,7 @@ DEFUN (ospf_network_area,
   ret = ospf_network_set (ospf, &p, area_id, format);
   if (ret == 0)
     {
-      vty_out (vty, "There is already same network statement.%s", VTY_NEWLINE);
+      vty_out (vty, "There is already same network statement.%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -556,7 +556,7 @@ DEFUN (no_ospf_network_area,
   if (ospf->instance)
     {
       vty_out (vty, "The network command is not supported in multi-instance ospf%s",
-	       VTY_NEWLINE);
+	       VTYNL);
       return CMD_WARNING;
     }
 
@@ -568,7 +568,7 @@ DEFUN (no_ospf_network_area,
   if (ret == 0)
     {
       vty_out (vty, "Can't find specified network area configuration.%s",
-	       VTY_NEWLINE);
+	       VTYNL);
       return CMD_WARNING;
     }
 
@@ -813,7 +813,7 @@ ospf_find_vl_data (struct ospf *ospf, struct ospf_vl_config_data *vl_config)
     {
       vty_out (vty, 
 	       "Configuring VLs over the backbone is not allowed%s",
-               VTY_NEWLINE);
+               VTYNL);
       return NULL;
     }
   area = ospf_area_get (ospf, area_id);
@@ -825,12 +825,12 @@ ospf_find_vl_data (struct ospf *ospf, struct ospf_vl_config_data *vl_config)
 	vty_out (vty, "Area %s is %s%s",
 		 inet_ntoa (area_id),
 		 area->external_routing == OSPF_AREA_NSSA?"nssa":"stub",
-		 VTY_NEWLINE);
+		 VTYNL);
       else
 	vty_out (vty, "Area %ld is %s%s",
 		 (u_long)ntohl (area_id.s_addr),
 		 area->external_routing == OSPF_AREA_NSSA?"nssa":"stub",
-		 VTY_NEWLINE);	
+		 VTYNL);	
       return NULL;
     }
   
@@ -876,7 +876,7 @@ ospf_vl_set_security (struct ospf_vl_data *vl_data,
 	  != NULL)
 	{
 	  vty_out (vty, "OSPF: Key %d already exists%s",
-		   vl_config->crypto_key_id, VTY_NEWLINE);
+		   vl_config->crypto_key_id, VTYNL);
 	  return CMD_WARNING;
 	}
       ck = ospf_crypt_key_new ();
@@ -894,7 +894,7 @@ ospf_vl_set_security (struct ospf_vl_data *vl_data,
 				 vl_config->crypto_key_id) == NULL)
 	{
 	  vty_out (vty, "OSPF: Key %d does not exist%s", 
-		   vl_config->crypto_key_id, VTY_NEWLINE);
+		   vl_config->crypto_key_id, VTYNL);
 	  return CMD_WARNING;
 	}
       
@@ -1037,7 +1037,7 @@ DEFUN (ospf_area_vlink,
                           &vl_config.area_id_fmt);
   if (ret < 0)
     {
-      vty_out (vty, "OSPF area ID is invalid%s", VTY_NEWLINE);
+      vty_out (vty, "OSPF area ID is invalid%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -1045,7 +1045,7 @@ DEFUN (ospf_area_vlink,
   if (! ret)
     {
       vty_out (vty, "Please specify valid Router ID as a.b.c.d%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
@@ -1060,7 +1060,7 @@ DEFUN (ospf_area_vlink,
   for (i=5; i < argc; i++)
     {
 
-      /* vty_out (vty, "argv[%d]->arg - %s%s", i, argv[i]->text, VTY_NEWLINE); */
+      /* vty_out (vty, "argv[%d]->arg - %s%s", i, argv[i]->text, VTYNL); */
 
       switch (argv[i]->arg[0])
 	{
@@ -1157,14 +1157,14 @@ DEFUN (no_ospf_area_vlink,
   ret = str2area_id (argv[idx_ipv4_number]->arg, &vl_config.area_id, &format);
   if (ret < 0)
     {
-      vty_out (vty, "OSPF area ID is invalid%s", VTY_NEWLINE);
+      vty_out (vty, "OSPF area ID is invalid%s", VTYNL);
       return CMD_WARNING;
     }
 
   area = ospf_area_lookup_by_area_id (ospf, vl_config.area_id);
   if (!area)
     {
-      vty_out (vty, "Area does not exist%s", VTY_NEWLINE);
+      vty_out (vty, "Area does not exist%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -1172,7 +1172,7 @@ DEFUN (no_ospf_area_vlink,
   if (! ret)
     {
       vty_out (vty, "Please specify valid Router ID as a.b.c.d%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
@@ -1193,7 +1193,7 @@ DEFUN (no_ospf_area_vlink,
   /* Deal with other parameters */
   for (i=6; i < argc; i++)
     {
-      /* vty_out (vty, "argv[%d] - %s%s", i, argv[i], VTY_NEWLINE); */
+      /* vty_out (vty, "argv[%d] - %s%s", i, argv[i], VTYNL); */
 
       switch (argv[i]->arg[0])
 	{
@@ -1257,14 +1257,14 @@ DEFUN (ospf_area_vlink_intervals,
   ret = str2area_id (area_id, &vl_config.area_id, &vl_config.area_id_fmt);
   if (ret < 0)
     {
-      vty_out (vty, "OSPF area ID is invalid%s", VTY_NEWLINE);
+      vty_out (vty, "OSPF area ID is invalid%s", VTYNL);
       return CMD_WARNING;
     }
 
   ret = inet_aton (router_id, &vl_config.vl_peer);
   if (! ret)
     {
-      vty_out (vty, "Please specify valid Router ID as a.b.c.d%s", VTY_NEWLINE);
+      vty_out (vty, "Please specify valid Router ID as a.b.c.d%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -1303,14 +1303,14 @@ DEFUN (no_ospf_area_vlink_intervals,
   ret = str2area_id (area_id, &vl_config.area_id, &vl_config.area_id_fmt);
   if (ret < 0)
     {
-      vty_out (vty, "OSPF area ID is invalid%s", VTY_NEWLINE);
+      vty_out (vty, "OSPF area ID is invalid%s", VTYNL);
       return CMD_WARNING;
     }
 
   ret = inet_aton (router_id, &vl_config.vl_peer);
   if (! ret)
     {
-      vty_out (vty, "Please specify valid Router ID as a.b.c.d%s", VTY_NEWLINE);
+      vty_out (vty, "Please specify valid Router ID as a.b.c.d%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -1368,7 +1368,7 @@ DEFUN (ospf_area_shortcut,
   if (ospf->abr_type != OSPF_ABR_SHORTCUT)
     vty_out (vty, "Shortcut area setting will take effect "
 	     "only when the router is configured as Shortcut ABR%s",
-	     VTY_NEWLINE);
+	     VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -1422,7 +1422,7 @@ DEFUN (ospf_area_stub,
   if (ret == 0)
     {
       vty_out (vty, "First deconfigure all virtual link through this area%s",
-	       VTY_NEWLINE);
+	       VTYNL);
       return CMD_WARNING;
     }
 
@@ -1452,7 +1452,7 @@ DEFUN (ospf_area_stub_no_summary,
   if (ret == 0)
     {
       vty_out (vty, "%% Area cannot be stub as it contains a virtual link%s",
-	       VTY_NEWLINE);
+	       VTYNL);
       return CMD_WARNING;
     }
 
@@ -1519,7 +1519,7 @@ ospf_area_nssa_cmd_handler (struct vty *vty, int argc, struct cmd_token **argv,
   if (ret == 0)
     {
       vty_out (vty, "%% Area cannot be nssa as it contains a virtual link%s",
-	       VTY_NEWLINE);
+	       VTYNL);
       return CMD_WARNING;
     }
 
@@ -1658,7 +1658,7 @@ DEFUN (ospf_area_default_cost,
 
   if (area->external_routing == OSPF_AREA_DEFAULT)
     {
-      vty_out (vty, "The area is neither stub, nor NSSA%s", VTY_NEWLINE);
+      vty_out (vty, "The area is neither stub, nor NSSA%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -1701,7 +1701,7 @@ DEFUN (no_ospf_area_default_cost,
 
   if (area->external_routing == OSPF_AREA_DEFAULT)
     {
-      vty_out (vty, "The area is neither stub, nor NSSA%s", VTY_NEWLINE);
+      vty_out (vty, "The area is neither stub, nor NSSA%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2205,7 +2205,7 @@ DEFUN (ospf_timers_min_ls_interval,
 
   if (argc < 5)
     {
-      vty_out (vty, "Insufficient arguments%s", VTY_NEWLINE);
+      vty_out (vty, "Insufficient arguments%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2247,7 +2247,7 @@ DEFUN (ospf_timers_min_ls_arrival,
 
   if (argc < 4)
     {
-      vty_out (vty, "Insufficient arguments%s", VTY_NEWLINE);
+      vty_out (vty, "Insufficient arguments%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2292,7 +2292,7 @@ DEFUN (ospf_timers_throttle_spf,
   
   if (argc < 6)
     {
-      vty_out (vty, "Insufficient arguments%s", VTY_NEWLINE);
+      vty_out (vty, "Insufficient arguments%s", VTYNL);
       return CMD_WARNING;
     }
   
@@ -2335,7 +2335,7 @@ DEFUN (ospf_timers_lsa,
 
   if (argc < 4)
     {
-      vty_out (vty, "Insufficient number of arguments%s", VTY_NEWLINE);
+      vty_out (vty, "Insufficient number of arguments%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2549,7 +2549,7 @@ DEFUN (ospf_auto_cost_reference_bandwidth,
   refbw = strtol (argv[idx_number]->arg, NULL, 10);
   if (refbw < 1 || refbw > 4294967)
     {
-      vty_out (vty, "reference-bandwidth value is invalid%s", VTY_NEWLINE);
+      vty_out (vty, "reference-bandwidth value is invalid%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2580,8 +2580,8 @@ DEFUN (no_ospf_auto_cost_reference_bandwidth,
     return CMD_SUCCESS;
   
   ospf->ref_bandwidth = OSPF_DEFAULT_REF_BANDWIDTH;
-  vty_out (vty, "%% OSPF: Reference bandwidth is changed.%s", VTY_NEWLINE);
-  vty_out (vty, "        Please ensure reference bandwidth is consistent across all routers%s", VTY_NEWLINE);
+  vty_out (vty, "%% OSPF: Reference bandwidth is changed.%s", VTYNL);
+  vty_out (vty, "        Please ensure reference bandwidth is consistent across all routers%s", VTYNL);
 
   for (ALL_LIST_ELEMENTS (om->iflist, node, nnode, ifp))
     ospf_if_recalculate_output_cost (ifp);
@@ -2608,7 +2608,7 @@ DEFUN (ospf_write_multiplier,
   write_oi_count = strtol (argv[idx_number]->arg, NULL, 10);
   if (write_oi_count < 1 || write_oi_count > 100)
     {
-      vty_out (vty, "write-multiplier value is invalid%s", VTY_NEWLINE);
+      vty_out (vty, "write-multiplier value is invalid%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2677,7 +2677,7 @@ show_ip_ospf_area (struct vty *vty, struct ospf_area *area, json_object *json_ar
       if (use_json)
         json_object_boolean_true_add(json_area, "backbone");
       else
-        vty_out (vty, " (Backbone)%s", VTY_NEWLINE);
+        vty_out (vty, " (Backbone)%s", VTYNL);
     }
   else
     {
@@ -2714,11 +2714,11 @@ show_ip_ospf_area (struct vty *vty, struct ospf_area *area, json_object *json_ar
                      area->no_summary ? ", no summary" : "",
                      area->shortcut_configured ? "; " : "");
 
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_out (vty, "%s", VTYNL);
           vty_out (vty, "   Shortcutting mode: %s",
                    ospf_shortcut_mode_descr_str[area->shortcut_configured]);
           vty_out (vty, ", S-bit consensus: %s%s",
-                   area->shortcut_capability ? "ok" : "no", VTY_NEWLINE);
+                   area->shortcut_capability ? "ok" : "no", VTYNL);
         }
     }
 
@@ -2731,7 +2731,7 @@ show_ip_ospf_area (struct vty *vty, struct ospf_area *area, json_object *json_ar
   else
     vty_out (vty, "   Number of interfaces in this area: Total: %d, "
              "Active: %d%s", listcount (area->oiflist),
-             area->act_ints, VTY_NEWLINE);
+             area->act_ints, VTYNL);
 
   if (area->external_routing == OSPF_AREA_NSSA)
     {
@@ -2759,29 +2759,29 @@ show_ip_ospf_area (struct vty *vty, struct ospf_area *area, json_object *json_ar
         }
       else
         {
-          vty_out (vty, "   It is an NSSA configuration. %s   Elected NSSA/ABR performs type-7/type-5 LSA translation. %s", VTY_NEWLINE, VTY_NEWLINE);
+          vty_out (vty, "   It is an NSSA configuration. %s   Elected NSSA/ABR performs type-7/type-5 LSA translation. %s", VTYNL, VTYNL);
           if (! IS_OSPF_ABR (area->ospf))
             vty_out (vty, "   It is not ABR, therefore not Translator. %s",
-                     VTY_NEWLINE);
+                     VTYNL);
           else if (area->NSSATranslatorState)
             {
               vty_out (vty, "   We are an ABR and ");
               if (area->NSSATranslatorRole == OSPF_NSSA_ROLE_CANDIDATE)
                 vty_out (vty, "the NSSA Elected Translator. %s",
-                         VTY_NEWLINE);
+                         VTYNL);
               else if (area->NSSATranslatorRole == OSPF_NSSA_ROLE_ALWAYS)
                 vty_out (vty, "always an NSSA Translator. %s",
-                         VTY_NEWLINE);
+                         VTYNL);
             }
           else
             {
               vty_out (vty, "   We are an ABR, but ");
               if (area->NSSATranslatorRole == OSPF_NSSA_ROLE_CANDIDATE)
                 vty_out (vty, "not the NSSA Elected Translator. %s",
-                         VTY_NEWLINE);
+                         VTYNL);
               else
                 vty_out (vty, "never an NSSA Translator. %s",
-                         VTY_NEWLINE);
+                         VTYNL);
             }
         }
     }
@@ -2806,14 +2806,14 @@ show_ip_ospf_area (struct vty *vty, struct ospf_area *area, json_object *json_ar
       else
         {
           vty_out (vty, "   Originating stub / maximum-distance Router-LSA%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           if (CHECK_FLAG(area->stub_router_state, OSPF_AREA_ADMIN_STUB_ROUTED))
             vty_out (vty, "     Administratively activated (indefinitely)%s",
-                     VTY_NEWLINE);
+                     VTYNL);
           if (area->t_stub_router)
             vty_out (vty, "     Active from startup, %s remaining%s",
                      ospf_timer_dump (area->t_stub_router, timebuf,
-                                      sizeof(timebuf)), VTY_NEWLINE);
+                                      sizeof(timebuf)), VTYNL);
         }
     }
 
@@ -2851,42 +2851,42 @@ show_ip_ospf_area (struct vty *vty, struct ospf_area *area, json_object *json_ar
     {
       /* Show number of fully adjacent neighbors. */
       vty_out (vty, "   Number of fully adjacent neighbors in this area:"
-               " %d%s", area->full_nbrs, VTY_NEWLINE);
+               " %d%s", area->full_nbrs, VTYNL);
 
       /* Show authentication type. */
       vty_out (vty, "   Area has ");
       if (area->auth_type == OSPF_AUTH_NULL)
-        vty_out (vty, "no authentication%s", VTY_NEWLINE);
+        vty_out (vty, "no authentication%s", VTYNL);
       else if (area->auth_type == OSPF_AUTH_SIMPLE)
-        vty_out (vty, "simple password authentication%s", VTY_NEWLINE);
+        vty_out (vty, "simple password authentication%s", VTYNL);
       else if (area->auth_type == OSPF_AUTH_CRYPTOGRAPHIC)
-        vty_out (vty, "message digest authentication%s", VTY_NEWLINE);
+        vty_out (vty, "message digest authentication%s", VTYNL);
 
       if (!OSPF_IS_AREA_BACKBONE (area))
         vty_out (vty, "   Number of full virtual adjacencies going through"
-                 " this area: %d%s", area->full_vls, VTY_NEWLINE);
+                 " this area: %d%s", area->full_vls, VTYNL);
 
       /* Show SPF calculation times. */
       vty_out (vty, "   SPF algorithm executed %d times%s",
-               area->spf_calculation, VTY_NEWLINE);
+               area->spf_calculation, VTYNL);
 
       /* Show number of LSA. */
-      vty_out (vty, "   Number of LSA %ld%s", area->lsdb->total, VTY_NEWLINE);
+      vty_out (vty, "   Number of LSA %ld%s", area->lsdb->total, VTYNL);
       vty_out (vty, "   Number of router LSA %ld. Checksum Sum 0x%08x%s",
                ospf_lsdb_count (area->lsdb, OSPF_ROUTER_LSA),
-               ospf_lsdb_checksum (area->lsdb, OSPF_ROUTER_LSA), VTY_NEWLINE);
+               ospf_lsdb_checksum (area->lsdb, OSPF_ROUTER_LSA), VTYNL);
       vty_out (vty, "   Number of network LSA %ld. Checksum Sum 0x%08x%s",
                ospf_lsdb_count (area->lsdb, OSPF_NETWORK_LSA),
-               ospf_lsdb_checksum (area->lsdb, OSPF_NETWORK_LSA), VTY_NEWLINE);
+               ospf_lsdb_checksum (area->lsdb, OSPF_NETWORK_LSA), VTYNL);
       vty_out (vty, "   Number of summary LSA %ld. Checksum Sum 0x%08x%s",
                ospf_lsdb_count (area->lsdb, OSPF_SUMMARY_LSA),
-               ospf_lsdb_checksum (area->lsdb, OSPF_SUMMARY_LSA), VTY_NEWLINE);
+               ospf_lsdb_checksum (area->lsdb, OSPF_SUMMARY_LSA), VTYNL);
       vty_out (vty, "   Number of ASBR summary LSA %ld. Checksum Sum 0x%08x%s",
                ospf_lsdb_count (area->lsdb, OSPF_ASBR_SUMMARY_LSA),
-               ospf_lsdb_checksum (area->lsdb, OSPF_ASBR_SUMMARY_LSA), VTY_NEWLINE);
+               ospf_lsdb_checksum (area->lsdb, OSPF_ASBR_SUMMARY_LSA), VTYNL);
       vty_out (vty, "   Number of NSSA LSA %ld. Checksum Sum 0x%08x%s",
                ospf_lsdb_count (area->lsdb, OSPF_AS_NSSA_LSA),
-               ospf_lsdb_checksum (area->lsdb, OSPF_AS_NSSA_LSA), VTY_NEWLINE);
+               ospf_lsdb_checksum (area->lsdb, OSPF_AS_NSSA_LSA), VTYNL);
     }
 
   if (use_json)
@@ -2900,16 +2900,16 @@ show_ip_ospf_area (struct vty *vty, struct ospf_area *area, json_object *json_ar
     {
       vty_out (vty, "   Number of opaque link LSA %ld. Checksum Sum 0x%08x%s",
                ospf_lsdb_count (area->lsdb, OSPF_OPAQUE_LINK_LSA),
-               ospf_lsdb_checksum (area->lsdb, OSPF_OPAQUE_LINK_LSA), VTY_NEWLINE);
+               ospf_lsdb_checksum (area->lsdb, OSPF_OPAQUE_LINK_LSA), VTYNL);
       vty_out (vty, "   Number of opaque area LSA %ld. Checksum Sum 0x%08x%s",
                ospf_lsdb_count (area->lsdb, OSPF_OPAQUE_AREA_LSA),
-               ospf_lsdb_checksum (area->lsdb, OSPF_OPAQUE_AREA_LSA), VTY_NEWLINE);
+               ospf_lsdb_checksum (area->lsdb, OSPF_OPAQUE_AREA_LSA), VTYNL);
     }
 
   if (use_json)
     json_object_object_add(json_areas, inet_ntoa (area->area_id), json_area);
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 }
 
 static int
@@ -2936,8 +2936,8 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
         }
       else
         {
-          vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-                   VTY_NEWLINE, VTY_NEWLINE);
+          vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+                   VTYNL, VTYNL);
         }
     }
 
@@ -2950,7 +2950,7 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
     {
       vty_out (vty, " OSPF Routing Process, Router ID: %s%s",
                inet_ntoa (ospf->router_id),
-               VTY_NEWLINE);
+               VTYNL);
     }
 
   /* Graceful shutdown */
@@ -2966,7 +2966,7 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
         {
           vty_out (vty, " Deferred shutdown in progress, %s remaining%s",
                    ospf_timer_dump (ospf->t_deferred_shutdown,
-                                    timebuf, sizeof (timebuf)), VTY_NEWLINE);
+                                    timebuf, sizeof (timebuf)), VTYNL);
         }
     }
 
@@ -2982,11 +2982,11 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
     }
   else
     {
-      vty_out (vty, " Supports only single TOS (TOS0) routes%s", VTY_NEWLINE);
-      vty_out (vty, " This implementation conforms to RFC2328%s", VTY_NEWLINE);
+      vty_out (vty, " Supports only single TOS (TOS0) routes%s", VTYNL);
+      vty_out (vty, " This implementation conforms to RFC2328%s", VTYNL);
       vty_out (vty, " RFC1583Compatibility flag is %s%s",
                CHECK_FLAG (ospf->config, OSPF_RFC1583_COMPATIBLE) ?
-               "enabled" : "disabled", VTY_NEWLINE);
+               "enabled" : "disabled", VTYNL);
     }
 
   if (use_json)
@@ -3000,7 +3000,7 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
     {
       vty_out (vty, " OpaqueCapability flag is %s%s",
                CHECK_FLAG (ospf->config, OSPF_OPAQUE_CAPABLE) ? "enabled" : "disabled",
-               VTY_NEWLINE);
+               VTYNL);
     }
 
   /* Show stub-router configuration */
@@ -3018,13 +3018,13 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
       else
         {
           vty_out (vty, " Stub router advertisement is configured%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           if (ospf->stub_router_startup_time != OSPF_STUB_ROUTER_UNCONFIGURED)
             vty_out (vty, "   Enabled for %us after start-up%s",
-                     ospf->stub_router_startup_time, VTY_NEWLINE);
+                     ospf->stub_router_startup_time, VTYNL);
           if (ospf->stub_router_shutdown_time != OSPF_STUB_ROUTER_UNCONFIGURED)
             vty_out (vty, "   Enabled for %us prior to full shutdown%s",
-                     ospf->stub_router_shutdown_time, VTY_NEWLINE);
+                     ospf->stub_router_shutdown_time, VTYNL);
         }
     }
 
@@ -3042,10 +3042,10 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
                     " Minimum hold time between consecutive SPFs %d millisec(s)%s"
                     " Maximum hold time between consecutive SPFs %d millisec(s)%s"
                     " Hold time multiplier is currently %d%s",
-               ospf->spf_delay, VTY_NEWLINE,
-               ospf->spf_holdtime, VTY_NEWLINE,
-               ospf->spf_max_holdtime, VTY_NEWLINE,
-               ospf->spf_hold_multiplier, VTY_NEWLINE);
+               ospf->spf_delay, VTYNL,
+               ospf->spf_holdtime, VTYNL,
+               ospf->spf_max_holdtime, VTYNL,
+               ospf->spf_hold_multiplier, VTYNL);
     }
 
   if (use_json)
@@ -3071,13 +3071,13 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
           monotime_since(&ospf->ts_spf, &result);
           vty_out (vty, "last executed %s ago%s",
                    ospf_timeval_dump (&result, timebuf, sizeof (timebuf)),
-                   VTY_NEWLINE);
+                   VTYNL);
           vty_out (vty, " Last SPF duration %s%s",
                    ospf_timeval_dump (&ospf->ts_spf_duration, timebuf, sizeof (timebuf)),
-                   VTY_NEWLINE);
+                   VTYNL);
         }
       else
-        vty_out (vty, "has not been run%s", VTY_NEWLINE);
+        vty_out (vty, "has not been run%s", VTYNL);
     }
 
   if (use_json)
@@ -3101,20 +3101,20 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
       vty_out (vty, " SPF timer %s%s%s",
                (ospf->t_spf_calc ? "due in " : "is "),
                ospf_timer_dump (ospf->t_spf_calc, timebuf, sizeof (timebuf)),
-               VTY_NEWLINE);
+               VTYNL);
 
       vty_out (vty, " LSA minimum interval %d msecs%s",
-	       ospf->min_ls_interval, VTY_NEWLINE);
+	       ospf->min_ls_interval, VTYNL);
       vty_out (vty, " LSA minimum arrival %d msecs%s",
-               ospf->min_ls_arrival, VTY_NEWLINE);
+               ospf->min_ls_arrival, VTYNL);
 
       /* Show write multiplier values */
       vty_out (vty, " Write Multiplier set to %d %s",
-               ospf->write_oi_count, VTY_NEWLINE);
+               ospf->write_oi_count, VTYNL);
 
       /* Show refresh parameters. */
       vty_out (vty, " Refresh timer %d secs%s",
-               ospf->lsa_refresh_interval, VTY_NEWLINE);
+               ospf->lsa_refresh_interval, VTYNL);
     }
 
   /* Show ABR/ASBR flags. */
@@ -3124,7 +3124,7 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
        json_object_string_add(json, "abrType", ospf_abr_type_descr_str[ospf->abr_type]);
      else
        vty_out (vty, " This router is an ABR, ABR type is: %s%s",
-                ospf_abr_type_descr_str[ospf->abr_type], VTY_NEWLINE);
+                ospf_abr_type_descr_str[ospf->abr_type], VTYNL);
     }
   if (CHECK_FLAG (ospf->flags, OSPF_FLAG_ASBR))
     {
@@ -3132,7 +3132,7 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
         json_object_string_add(json, "asbrRouter", "injectingExternalRoutingInformation");
       else
         vty_out (vty, " This router is an ASBR "
-                 "(injecting external routing information)%s", VTY_NEWLINE);
+                 "(injecting external routing information)%s", VTYNL);
     }
 
   /* Show Number of AS-external-LSAs. */
@@ -3147,7 +3147,7 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
     {
       vty_out (vty, " Number of external LSA %ld. Checksum Sum 0x%08x%s",
                ospf_lsdb_count (ospf->lsdb, OSPF_AS_EXTERNAL_LSA),
-               ospf_lsdb_checksum (ospf->lsdb, OSPF_AS_EXTERNAL_LSA), VTY_NEWLINE);
+               ospf_lsdb_checksum (ospf->lsdb, OSPF_AS_EXTERNAL_LSA), VTYNL);
     }
 
   if (use_json)
@@ -3161,7 +3161,7 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
     {
       vty_out (vty, " Number of opaque AS LSA %ld. Checksum Sum 0x%08x%s",
                ospf_lsdb_count (ospf->lsdb, OSPF_OPAQUE_AS_LSA),
-               ospf_lsdb_checksum (ospf->lsdb, OSPF_OPAQUE_AS_LSA), VTY_NEWLINE);
+               ospf_lsdb_checksum (ospf->lsdb, OSPF_OPAQUE_AS_LSA), VTYNL);
     }
 
   /* Show number of areas attached. */
@@ -3169,7 +3169,7 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
     json_object_int_add(json, "attachedAreaCounter", listcount (ospf->areas));
   else
     vty_out (vty, " Number of areas attached to this router: %d%s",
-             listcount (ospf->areas), VTY_NEWLINE);
+             listcount (ospf->areas), VTYNL);
 
   if (CHECK_FLAG(ospf->config, OSPF_LOG_ADJACENCY_CHANGES))
     {
@@ -3178,14 +3178,14 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
           if (use_json)
             json_object_boolean_true_add(json, "adjacencyChangesLoggedAll");
           else
-            vty_out(vty, " All adjacency changes are logged%s",VTY_NEWLINE);
+            vty_out(vty, " All adjacency changes are logged%s",VTYNL);
         }
       else
         {
           if (use_json)
             json_object_boolean_true_add(json, "adjacencyChangesLogged");
           else
-            vty_out(vty, " Adjacency changes are logged%s",VTY_NEWLINE);
+            vty_out(vty, " Adjacency changes are logged%s",VTYNL);
         }
     }
   /* Show each area status. */
@@ -3195,11 +3195,11 @@ show_ip_ospf_common (struct vty *vty, struct ospf *ospf, u_char use_json)
   if (use_json)
     {
       json_object_object_add(json, "areas", json_areas);
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
-    vty_out (vty, "%s",VTY_NEWLINE);
+    vty_out (vty, "%s",VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -3267,11 +3267,10 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
     }
   else
     {
-      vty_out (vty, "%s is %s%s", ifp->name,
-               ((is_up = if_is_operative(ifp)) ? "up" : "down"), VTY_NEWLINE);
-      vty_out (vty, "  ifindex %u, MTU %u bytes, BW %u Mbit %s%s",
-               ifp->ifindex, ifp->mtu, bandwidth, if_flag_dump(ifp->flags),
-               VTY_NEWLINE);
+      vty_outln (vty, "%s is %s", ifp->name,
+                 ((is_up = if_is_operative(ifp)) ? "up" : "down"));
+      vty_outln (vty, "  ifindex %u, MTU %u bytes, BW %u Mbit %s",
+                 ifp->ifindex, ifp->mtu, bandwidth, if_flag_dump(ifp->flags))
     }
 
   /* Is interface OSPF enabled? */
@@ -3294,13 +3293,13 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
     {
       if (ospf_oi_count(ifp) == 0)
         {
-          vty_out (vty, "  OSPF not enabled on this interface%s", VTY_NEWLINE);
+          vty_out (vty, "  OSPF not enabled on this interface%s", VTYNL);
           return;
         }
       else if (!is_up)
         {
           vty_out (vty, "  OSPF is enabled, but not running on this interface%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           return;
         }
     }
@@ -3376,27 +3375,25 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
         }
       else
         {
-          vty_out (vty, " Area %s%s", ospf_area_desc_string (oi->area),
-                   VTY_NEWLINE);
+          vty_outln (vty, " Area %s", ospf_area_desc_string (oi->area));
 
-          vty_out (vty, "  MTU mismatch detection:%s%s",
-                   OSPF_IF_PARAM(oi, mtu_ignore) ? "disabled" : "enabled", VTY_NEWLINE);
+          vty_outln (vty, "  MTU mismatch detection: %s",
+                     OSPF_IF_PARAM(oi, mtu_ignore) ? "disabled" : "enabled");
 
-          vty_out (vty, "  Router ID %s, Network Type %s, Cost: %d%s",
-                   inet_ntoa (ospf->router_id), ospf_network_type_str[oi->type],
-                   oi->output_cost, VTY_NEWLINE);
+          vty_outln (vty, "  Router ID %s, Network Type %s, Cost: %d",
+                     inet_ntoa (ospf->router_id), ospf_network_type_str[oi->type],
+                     oi->output_cost);
 
-          vty_out (vty, "  Transmit Delay is %d sec, State %s, Priority %d%s",
-                   OSPF_IF_PARAM (oi,transmit_delay), lookup_msg(ospf_ism_state_msg, oi->state, NULL),
-                   PRIORITY (oi), VTY_NEWLINE);
+          vty_outln (vty, "  Transmit Delay is %d sec, State %s, Priority %d",
+                     OSPF_IF_PARAM (oi,transmit_delay), lookup_msg(ospf_ism_state_msg, oi->state, NULL),
+                     PRIORITY (oi));
         }
 
   /* Show DR information. */
       if (DR (oi).s_addr == 0)
         {
           if (!use_json)
-            vty_out (vty, "  No backup designated router on this network%s",
-                     VTY_NEWLINE);
+            vty_outln (vty, "  No backup designated router on this network");
         }
       else
         {
@@ -3417,8 +3414,8 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
                 {
                   vty_out (vty, "  Backup Designated Router (ID) %s,",
                            inet_ntoa (nbr->router_id));
-                  vty_out (vty, " Interface Address %s%s",
-                           inet_ntoa (nbr->address.u.prefix4), VTY_NEWLINE);
+                  vty_outln (vty, " Interface Address %s",
+                             inet_ntoa (nbr->address.u.prefix4));
                 }
             }
         }
@@ -3430,7 +3427,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
             json_object_int_add(json_interface_sub, "networkLsaSequence", ntohl (oi->params->network_lsa_seqnum));
           else
             vty_out (vty, "  Saved Network-LSA sequence number 0x%x%s",
-                     ntohl (oi->params->network_lsa_seqnum), VTY_NEWLINE);
+                     ntohl (oi->params->network_lsa_seqnum), VTYNL);
         }
 
       if (use_json)
@@ -3457,7 +3454,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
             }
           else
             vty_out (vty, " <None>");
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_out (vty, "%s", VTYNL);
         }
 
       if (use_json)
@@ -3482,7 +3479,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
                    OSPF_IF_PARAM (oi, v_wait),
                    OSPF_IF_PARAM (oi, v_wait),
                    OSPF_IF_PARAM (oi, retransmit_interval),
-                   VTY_NEWLINE);
+                   VTYNL);
         }
 
       if (OSPF_IF_PASSIVE_STATUS (oi) == OSPF_IF_ACTIVE)
@@ -3498,14 +3495,14 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
           else
             vty_out (vty, "    Hello due in %s%s",
                      ospf_timer_dump (oi->t_hello, timebuf, sizeof(timebuf)),
-                     VTY_NEWLINE);
+                     VTYNL);
         }
       else /* passive-interface is set */
         {
           if (use_json)
             json_object_boolean_true_add(json_interface_sub, "timerPassiveIface");
           else
-            vty_out (vty, "    No Hellos (Passive interface)%s", VTY_NEWLINE);
+            vty_out (vty, "    No Hellos (Passive interface)%s", VTYNL);
         }
 
       if (use_json)
@@ -3516,7 +3513,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
       else
         vty_out (vty, "  Neighbor Count is %d, Adjacent neighbor count is %d%s",
                  ospf_nbr_count (oi, 0), ospf_nbr_count (oi, NSM_Full),
-                 VTY_NEWLINE);
+                 VTYNL);
       ospf_bfd_interface_show(vty, ifp, json_interface_sub, use_json);
     }
 }
@@ -3540,8 +3537,8 @@ show_ip_ospf_interface_common (struct vty *vty, struct ospf *ospf, int argc,
       if (use_json)
         json_object_int_add(json, "ospfInstance", ospf->instance);
       else
-        vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-                 VTY_NEWLINE, VTY_NEWLINE);
+        vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+                 VTYNL, VTYNL);
     }
 
   if (argc == iface_argv)
@@ -3569,7 +3566,7 @@ show_ip_ospf_interface_common (struct vty *vty, struct ospf *ospf, int argc,
           if (use_json)
               json_object_boolean_true_add(json, "noSuchIface");
           else
-              vty_out (vty, "No such interface name%s", VTY_NEWLINE);
+              vty_out (vty, "No such interface name%s", VTYNL);
         }
       else
         {
@@ -3585,11 +3582,11 @@ show_ip_ospf_interface_common (struct vty *vty, struct ospf *ospf, int argc,
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -3646,10 +3643,10 @@ static void
 show_ip_ospf_neighbour_header (struct vty *vty)
 {
   vty_out (vty, "%s%-15s %3s %-15s %9s %-15s %-20s %5s %5s %5s%s",
-           VTY_NEWLINE,
+           VTYNL,
            "Neighbor ID", "Pri", "State", "Dead Time",
            "Address", "Interface", "RXmtL", "RqstL", "DBsmL",
-           VTY_NEWLINE);
+           VTYNL);
 }
 
 static void
@@ -3713,7 +3710,7 @@ show_ip_ospf_neighbor_sub (struct vty *vty, struct ospf_interface *oi, json_obje
                       vty_out (vty, "%-20s %5ld %5ld %5d%s",
                                IF_NAME (oi), ospf_ls_retransmit_count (nbr),
                                ospf_ls_request_count (nbr), ospf_db_summary_count (nbr),
-                               VTY_NEWLINE);
+                               VTYNL);
                     }
                 }
             }
@@ -3738,8 +3735,8 @@ show_ip_ospf_neighbor_common (struct vty *vty, struct ospf *ospf, u_char use_jso
       if (use_json)
         json_object_int_add(json, "ospfInstance", ospf->instance);
       else
-        vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-                 VTY_NEWLINE, VTY_NEWLINE);
+        vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+                 VTYNL, VTYNL);
     }
 
   for (ALL_LIST_ELEMENTS_RO (ospf->oiflist, node, oi))
@@ -3747,11 +3744,11 @@ show_ip_ospf_neighbor_common (struct vty *vty, struct ospf *ospf, u_char use_jso
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -3818,8 +3815,8 @@ show_ip_ospf_neighbor_all_common (struct vty *vty, struct ospf *ospf, u_char use
       if (use_json)
         json_object_int_add(json, "ospfInstance", ospf->instance);
       else
-        vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-                 VTY_NEWLINE, VTY_NEWLINE);
+        vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+                 VTYNL, VTYNL);
     }
 
   for (ALL_LIST_ELEMENTS_RO (ospf->oiflist, node, oi))
@@ -3851,7 +3848,7 @@ show_ip_ospf_neighbor_all_common (struct vty *vty, struct ospf *ospf, u_char use
                            "-", nbr_nbma->priority, "Down", "-");
                   vty_out (vty, "%-15s %-20s %5d %5d %5d%s",
                            inet_ntoa (nbr_nbma->addr), IF_NAME (oi),
-                           0, 0, 0, VTY_NEWLINE);
+                           0, 0, 0, VTYNL);
                 }
             }
         }
@@ -3859,11 +3856,11 @@ show_ip_ospf_neighbor_all_common (struct vty *vty, struct ospf *ospf, u_char use
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -3928,8 +3925,8 @@ show_ip_ospf_neighbor_int_common (struct vty *vty, struct ospf *ospf, int arg_ba
       if (use_json)
         json_object_int_add(json, "ospfInstance", ospf->instance);
       else
-        vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-                 VTY_NEWLINE, VTY_NEWLINE);
+        vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+                 VTYNL, VTYNL);
     }
 
   ifp = if_lookup_by_name (argv[arg_base]->arg, VRF_DEFAULT);
@@ -3938,7 +3935,7 @@ show_ip_ospf_neighbor_int_common (struct vty *vty, struct ospf *ospf, int arg_ba
       if (use_json)
         json_object_boolean_true_add(json, "noSuchIface");
       else
-        vty_out (vty, "No such interface.%s", VTY_NEWLINE);
+        vty_out (vty, "No such interface.%s", VTYNL);
       return CMD_WARNING;
     }
   
@@ -3954,11 +3951,11 @@ show_ip_ospf_neighbor_int_common (struct vty *vty, struct ospf *ospf, int arg_ba
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -4022,7 +4019,7 @@ show_ip_ospf_nbr_nbma_detail_sub (struct vty *vty, struct ospf_interface *oi, st
     json_object_string_add(json_sub, "ifaceAddress", inet_ntoa (nbr_nbma->addr));
   else
     vty_out (vty, " interface address %s%s",
-             inet_ntoa (nbr_nbma->addr), VTY_NEWLINE);
+             inet_ntoa (nbr_nbma->addr), VTYNL);
 
   /* Show Area ID. */
   if (use_json)
@@ -4032,7 +4029,7 @@ show_ip_ospf_nbr_nbma_detail_sub (struct vty *vty, struct ospf_interface *oi, st
     }
   else
     vty_out (vty, "    In the area %s via interface %s%s",
-             ospf_area_desc_string (oi->area), IF_NAME (oi), VTY_NEWLINE);
+             ospf_area_desc_string (oi->area), IF_NAME (oi), VTYNL);
 
   /* Show neighbor priority and state. */
   if (use_json)
@@ -4048,13 +4045,13 @@ show_ip_ospf_nbr_nbma_detail_sub (struct vty *vty, struct ospf_interface *oi, st
   if (use_json)
     json_object_int_add(json_sub, "stateChangeCounter", nbr_nbma->state_change);
   else
-    vty_out (vty, " %d state changes%s", nbr_nbma->state_change, VTY_NEWLINE);
+    vty_out (vty, " %d state changes%s", nbr_nbma->state_change, VTYNL);
 
   /* Show PollInterval */
   if (use_json)
     json_object_int_add(json_sub, "pollInterval", nbr_nbma->v_poll);
   else
-    vty_out (vty, "    Poll interval %d%s", nbr_nbma->v_poll, VTY_NEWLINE);
+    vty_out (vty, "    Poll interval %d%s", nbr_nbma->v_poll, VTYNL);
 
   /* Show poll-interval timer. */
   if (use_json)
@@ -4066,7 +4063,7 @@ show_ip_ospf_nbr_nbma_detail_sub (struct vty *vty, struct ospf_interface *oi, st
   else
     vty_out (vty, "    Poll timer due in %s%s",
              ospf_timer_dump (nbr_nbma->t_poll, timebuf, sizeof(timebuf)),
-             VTY_NEWLINE);
+             VTYNL);
 
   /* Show poll-interval timer thread. */
   if (use_json)
@@ -4076,7 +4073,7 @@ show_ip_ospf_nbr_nbma_detail_sub (struct vty *vty, struct ospf_interface *oi, st
     }
   else
     vty_out (vty, "    Thread Poll Timer %s%s",
-             nbr_nbma->t_poll != NULL ? "on" : "off", VTY_NEWLINE);
+             nbr_nbma->t_poll != NULL ? "on" : "off", VTYNL);
 
   if (use_json)
     json_object_object_add(json, "noNbrId", json_sub);
@@ -4105,7 +4102,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
     json_object_string_add(json_sub, "ifaceAddress", inet_ntoa (nbr->address.u.prefix4));
   else
     vty_out (vty, " interface address %s%s",
-             inet_ntoa (nbr->address.u.prefix4), VTY_NEWLINE);
+             inet_ntoa (nbr->address.u.prefix4), VTYNL);
 
   /* Show Area ID. */
   if (use_json)
@@ -4115,7 +4112,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
     }
   else
     vty_out (vty, "    In the area %s via interface %s%s",
-             ospf_area_desc_string (oi->area), oi->ifp->name, VTY_NEWLINE);
+             ospf_area_desc_string (oi->area), oi->ifp->name, VTYNL);
 
   /* Show neighbor priority and state. */
   if (use_json)
@@ -4131,7 +4128,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
   if (use_json)
     json_object_int_add(json_sub, "stateChangeCounter", nbr->state_change);
   else
-    vty_out (vty, " %d state changes%s", nbr->state_change, VTY_NEWLINE);
+    vty_out (vty, " %d state changes%s", nbr->state_change, VTYNL);
 
   if (nbr->ts_last_progress.tv_sec || nbr->ts_last_progress.tv_usec)
     {
@@ -4146,10 +4143,10 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
       else
         {
           vty_out (vty, "    Most recent state change statistics:%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           vty_out (vty, "      Progressive change %s ago%s",
                    ospf_timeval_dump (&res, timebuf, sizeof(timebuf)),
-                   VTY_NEWLINE);
+                   VTYNL);
         }
     }
 
@@ -4170,7 +4167,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
           vty_out (vty, "      Regressive change %s ago, due to %s%s",
                    ospf_timeval_dump (&res, timebuf, sizeof(timebuf)),
                    (nbr->last_regress_str ? nbr->last_regress_str : "??"),
-                   VTY_NEWLINE);
+                   VTYNL);
         }
     }
 
@@ -4184,7 +4181,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
   if (use_json)
     json_object_string_add(json_sub, "routerDesignatedBackupId", inet_ntoa (nbr->bd_router));
   else
-    vty_out (vty, " BDR is %s%s", inet_ntoa (nbr->bd_router), VTY_NEWLINE);
+    vty_out (vty, " BDR is %s%s", inet_ntoa (nbr->bd_router), VTYNL);
 
   /* Show options. */
   if (use_json)
@@ -4194,7 +4191,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
     }
   else
     vty_out (vty, "    Options %d %s%s", nbr->options,
-             ospf_options_dump (nbr->options), VTY_NEWLINE);
+             ospf_options_dump (nbr->options), VTYNL);
 
   /* Show Router Dead interval timer. */
   if (use_json)
@@ -4211,28 +4208,28 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
   else
     vty_out (vty, "    Dead timer due in %s%s",
              ospf_timer_dump (nbr->t_inactivity, timebuf, sizeof (timebuf)),
-             VTY_NEWLINE);
+             VTYNL);
 
   /* Show Database Summary list. */
   if (use_json)
     json_object_int_add(json_sub, "databaseSummaryListCounter", ospf_db_summary_count (nbr));
   else
     vty_out (vty, "    Database Summary List %d%s",
-             ospf_db_summary_count (nbr), VTY_NEWLINE);
+             ospf_db_summary_count (nbr), VTYNL);
 
   /* Show Link State Request list. */
   if (use_json)
     json_object_int_add(json_sub, "linkStateRequestListCounter", ospf_ls_request_count (nbr));
   else
     vty_out (vty, "    Link State Request List %ld%s",
-             ospf_ls_request_count (nbr), VTY_NEWLINE);
+             ospf_ls_request_count (nbr), VTYNL);
 
   /* Show Link State Retransmission list. */
   if (use_json)
     json_object_int_add(json_sub, "linkStateRetransmissionListCounter", ospf_ls_retransmit_count (nbr));
   else
     vty_out (vty, "    Link State Retransmission List %ld%s",
-             ospf_ls_retransmit_count (nbr), VTY_NEWLINE);
+             ospf_ls_retransmit_count (nbr), VTYNL);
 
   /* Show inactivity timer thread. */
   if (use_json)
@@ -4242,7 +4239,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
     }
   else
     vty_out (vty, "    Thread Inactivity Timer %s%s",
-             nbr->t_inactivity != NULL ? "on" : "off", VTY_NEWLINE);
+             nbr->t_inactivity != NULL ? "on" : "off", VTYNL);
 
   /* Show Database Description retransmission thread. */
   if (use_json)
@@ -4252,7 +4249,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
     }
   else
     vty_out (vty, "    Thread Database Description Retransmision %s%s",
-             nbr->t_db_desc != NULL ? "on" : "off", VTY_NEWLINE);
+             nbr->t_db_desc != NULL ? "on" : "off", VTYNL);
 
   /* Show Link State Request Retransmission thread. */
   if (use_json)
@@ -4262,7 +4259,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
     }
   else
     vty_out (vty, "    Thread Link State Request Retransmission %s%s",
-             nbr->t_ls_req != NULL ? "on" : "off", VTY_NEWLINE);
+             nbr->t_ls_req != NULL ? "on" : "off", VTYNL);
 
   /* Show Link State Update Retransmission thread. */
   if (use_json)
@@ -4272,7 +4269,7 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
     }
   else
     vty_out (vty, "    Thread Link State Update Retransmission %s%s%s",
-             nbr->t_ls_upd != NULL ? "on" : "off", VTY_NEWLINE, VTY_NEWLINE);
+             nbr->t_ls_upd != NULL ? "on" : "off", VTYNL, VTYNL);
 
   if (use_json)
     {
@@ -4304,15 +4301,15 @@ show_ip_ospf_neighbor_id_common (struct vty *vty, struct ospf *ospf,
       if (use_json)
         json_object_int_add(json, "ospfInstance", ospf->instance);
       else
-        vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-                 VTY_NEWLINE, VTY_NEWLINE);
+        vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+                 VTYNL, VTYNL);
     }
 
   ret = inet_aton (argv[arg_base]->arg, &router_id);
   if (!ret)
     {
       if (!use_json)
-        vty_out (vty, "Please specify Neighbor ID by A.B.C.D%s", VTY_NEWLINE);
+        vty_out (vty, "Please specify Neighbor ID by A.B.C.D%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -4326,11 +4323,11 @@ show_ip_ospf_neighbor_id_common (struct vty *vty, struct ospf *ospf,
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -4392,8 +4389,8 @@ show_ip_ospf_neighbor_detail_common (struct vty *vty, struct ospf *ospf, u_char 
       if (use_json)
         json_object_int_add(json, "ospfInstance", ospf->instance);
       else
-        vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-                 VTY_NEWLINE, VTY_NEWLINE);
+        vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+                 VTYNL, VTYNL);
     }
 
   for (ALL_LIST_ELEMENTS_RO (ospf->oiflist, node, oi))
@@ -4418,11 +4415,11 @@ show_ip_ospf_neighbor_detail_common (struct vty *vty, struct ospf *ospf, u_char 
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -4484,8 +4481,8 @@ show_ip_ospf_neighbor_detail_all_common (struct vty *vty, struct ospf *ospf, u_c
       if (use_json)
         json_object_int_add(json, "ospfInstance", ospf->instance);
       else
-        vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-                 VTY_NEWLINE, VTY_NEWLINE);
+        vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+                 VTYNL, VTYNL);
     }
 
   for (ALL_LIST_ELEMENTS_RO (ospf->oiflist, node, oi))
@@ -4514,12 +4511,12 @@ show_ip_ospf_neighbor_detail_all_common (struct vty *vty, struct ospf *ospf, u_c
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
     {
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 
   return CMD_SUCCESS;
@@ -4587,15 +4584,15 @@ show_ip_ospf_neighbor_int_detail_common (struct vty *vty, struct ospf *ospf,
       if (use_json)
         json_object_int_add(json, "ospfInstance", ospf->instance);
       else
-        vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-                 VTY_NEWLINE, VTY_NEWLINE);
+        vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+                 VTYNL, VTYNL);
     }
 
   ifp = if_lookup_by_name (argv[arg_base]->arg, VRF_DEFAULT);
   if (!ifp)
     {
       if (!use_json)
-        vty_out (vty, "No such interface.%s", VTY_NEWLINE);
+        vty_out (vty, "No such interface.%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -4619,11 +4616,11 @@ show_ip_ospf_neighbor_int_detail_common (struct vty *vty, struct ospf *ospf,
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTYNL);
       json_object_free(json);
     }
   else
-    vty_out (vty, "%s", VTY_NEWLINE);
+    vty_out (vty, "%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -4729,7 +4726,7 @@ show_lsa_summary (struct vty *vty, struct ospf_lsa *lsa, int self)
 	  default:
 	    break;
 	  }
-	vty_out (vty, VTY_NEWLINE);
+	vty_out (vty, VTYNL);
       }
 
   return 0;
@@ -4772,15 +4769,13 @@ show_ip_ospf_database_header (struct vty *vty, struct ospf_lsa *lsa)
 {
   struct router_lsa *rlsa = (struct router_lsa*) lsa->data;
   
-  vty_out (vty, "  LS age: %d%s", LS_AGE (lsa), VTY_NEWLINE);
-  vty_out (vty, "  Options: 0x%-2x : %s%s", 
-           lsa->data->options,
-           ospf_options_dump(lsa->data->options), 
-           VTY_NEWLINE);
-  vty_out (vty, "  LS Flags: 0x%-2x %s%s",
-           lsa->flags,
-           ((lsa->flags & OSPF_LSA_LOCAL_XLT) ? "(Translated from Type-7)" : ""),
-           VTY_NEWLINE);
+  vty_outln (vty, "  LS age: %d", LS_AGE (lsa));
+  vty_outln (vty, "  Options: 0x%-2x : %s", lsa->data->options,
+           ospf_options_dump(lsa->data->options));
+  vty_outln (vty, "  LS Flags: 0x%-2x %s",
+             lsa->flags,
+             ((lsa->flags & OSPF_LSA_LOCAL_XLT) ?
+              "(Translated from Type-7)" : ""));
 
   if (lsa->data->type == OSPF_ROUTER_LSA)
     {
@@ -4793,19 +4788,16 @@ show_ip_ospf_database_header (struct vty *vty, struct ospf_lsa *lsa)
 		 IS_ROUTER_LSA_VIRTUAL (rlsa) ? " VL-endpoint" : "",
 		 IS_ROUTER_LSA_SHORTCUT (rlsa) ? " Shortcut" : "");
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
-  vty_out (vty, "  LS Type: %s%s",
-           lookup_msg(ospf_lsa_type_msg, lsa->data->type, NULL), VTY_NEWLINE);
-  vty_out (vty, "  Link State ID: %s %s%s", inet_ntoa (lsa->data->id),
-           lookup_msg(ospf_link_state_id_type_msg, lsa->data->type, NULL), VTY_NEWLINE);
-  vty_out (vty, "  Advertising Router: %s%s",
-           inet_ntoa (lsa->data->adv_router), VTY_NEWLINE);
-  vty_out (vty, "  LS Seq Number: %08lx%s", (u_long)ntohl (lsa->data->ls_seqnum),
-           VTY_NEWLINE);
-  vty_out (vty, "  Checksum: 0x%04x%s", ntohs (lsa->data->checksum),
-           VTY_NEWLINE);
-  vty_out (vty, "  Length: %d%s", ntohs (lsa->data->length), VTY_NEWLINE);
+  vty_outln (vty, "  LS Type: %s",
+             lookup_msg(ospf_lsa_type_msg, lsa->data->type, NULL));
+  vty_outln (vty, "  Link State ID: %s %s", inet_ntoa (lsa->data->id),
+             lookup_msg(ospf_link_state_id_type_msg, lsa->data->type, NULL));
+  vty_outln (vty, "  Advertising Router: %s", inet_ntoa (lsa->data->adv_router));
+  vty_outln (vty, "  LS Seq Number: %08lx", (u_long)ntohl (lsa->data->ls_seqnum));
+  vty_outln (vty, "  Checksum: 0x%04x", ntohs (lsa->data->checksum));
+  vty_outln (vty, "  Length: %d%s", ntohs (lsa->data->length), VTYNL);
 }
 
 const char *link_type_desc[] =
@@ -4849,15 +4841,15 @@ show_ip_ospf_database_router_links (struct vty *vty,
       type = rl->link[i].type;
 
       vty_out (vty, "    Link connected to: %s%s",
-	       link_type_desc[type], VTY_NEWLINE);
+	       link_type_desc[type], VTYNL);
       vty_out (vty, "     (Link ID) %s: %s%s", link_id_desc[type],
-	       inet_ntoa (rl->link[i].link_id), VTY_NEWLINE);
+	       inet_ntoa (rl->link[i].link_id), VTYNL);
       vty_out (vty, "     (Link Data) %s: %s%s", link_data_desc[type],
-	       inet_ntoa (rl->link[i].link_data), VTY_NEWLINE);
-      vty_out (vty, "      Number of TOS metrics: 0%s", VTY_NEWLINE);
+	       inet_ntoa (rl->link[i].link_data), VTYNL);
+      vty_out (vty, "      Number of TOS metrics: 0%s", VTYNL);
       vty_out (vty, "       TOS 0 Metric: %d%s",
-	       ntohs (rl->link[i].metric), VTY_NEWLINE);
-      vty_out (vty, "%s", VTY_NEWLINE);
+	       ntohs (rl->link[i].metric), VTYNL);
+      vty_out (vty, "%s", VTYNL);
     }
 }
 
@@ -4872,10 +4864,10 @@ show_router_lsa_detail (struct vty *vty, struct ospf_lsa *lsa)
       show_ip_ospf_database_header (vty, lsa);
           
       vty_out (vty, "   Number of Links: %d%s%s", ntohs (rl->links),
-	       VTY_NEWLINE, VTY_NEWLINE);
+	       VTYNL, VTYNL);
 
       show_ip_ospf_database_router_links (vty, rl);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 
   return 0;
@@ -4894,15 +4886,15 @@ show_network_lsa_detail (struct vty *vty, struct ospf_lsa *lsa)
       show_ip_ospf_database_header (vty, lsa);
 
       vty_out (vty, "  Network Mask: /%d%s",
-	       ip_masklen (nl->mask), VTY_NEWLINE);
+	       ip_masklen (nl->mask), VTYNL);
 
       length = ntohs (lsa->data->length) - OSPF_LSA_HEADER_SIZE - 4;
 
       for (i = 0; length > 0; i++, length -= 4)
 	vty_out (vty, "        Attached Router: %s%s",
-		 inet_ntoa (nl->routers[i]), VTY_NEWLINE);
+		 inet_ntoa (nl->routers[i]), VTYNL);
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 
   return 0;
@@ -4919,10 +4911,10 @@ show_summary_lsa_detail (struct vty *vty, struct ospf_lsa *lsa)
       show_ip_ospf_database_header (vty, lsa);
 
       vty_out (vty, "  Network Mask: /%d%s", ip_masklen (sl->mask),
-	       VTY_NEWLINE);
+	       VTYNL);
       vty_out (vty, "        TOS: 0  Metric: %d%s", GET_METRIC (sl->metric),
-	       VTY_NEWLINE);
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	       VTYNL);
+	  vty_out (vty, "%s", VTYNL);
     }
 
   return 0;
@@ -4939,10 +4931,10 @@ show_summary_asbr_lsa_detail (struct vty *vty, struct ospf_lsa *lsa)
       show_ip_ospf_database_header (vty, lsa);
 
       vty_out (vty, "  Network Mask: /%d%s",
-	       ip_masklen (sl->mask), VTY_NEWLINE);
+	       ip_masklen (sl->mask), VTYNL);
       vty_out (vty, "        TOS: 0  Metric: %d%s", GET_METRIC (sl->metric),
-	       VTY_NEWLINE);
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	       VTYNL);
+	  vty_out (vty, "%s", VTYNL);
     }
 
   return 0;
@@ -4959,18 +4951,18 @@ show_as_external_lsa_detail (struct vty *vty, struct ospf_lsa *lsa)
       show_ip_ospf_database_header (vty, lsa);
 
       vty_out (vty, "  Network Mask: /%d%s",
-	       ip_masklen (al->mask), VTY_NEWLINE);
+	       ip_masklen (al->mask), VTYNL);
       vty_out (vty, "        Metric Type: %s%s",
 	       IS_EXTERNAL_METRIC (al->e[0].tos) ?
-	       "2 (Larger than any link state path)" : "1", VTY_NEWLINE);
-      vty_out (vty, "        TOS: 0%s", VTY_NEWLINE);
+	       "2 (Larger than any link state path)" : "1", VTYNL);
+      vty_out (vty, "        TOS: 0%s", VTYNL);
       vty_out (vty, "        Metric: %d%s",
-	       GET_METRIC (al->e[0].metric), VTY_NEWLINE);
+	       GET_METRIC (al->e[0].metric), VTYNL);
       vty_out (vty, "        Forward Address: %s%s",
-	       inet_ntoa (al->e[0].fwd_addr), VTY_NEWLINE);
+	       inet_ntoa (al->e[0].fwd_addr), VTYNL);
 
       vty_out (vty, "        External Route Tag: %"ROUTE_TAG_PRI"%s%s",
-	       (route_tag_t)ntohl (al->e[0].route_tag), VTY_NEWLINE, VTY_NEWLINE);
+	       (route_tag_t)ntohl (al->e[0].route_tag), VTYNL, VTYNL);
     }
 
   return 0;
@@ -5011,18 +5003,18 @@ show_as_nssa_lsa_detail (struct vty *vty, struct ospf_lsa *lsa)
       show_ip_ospf_database_header (vty, lsa);
 
       vty_out (vty, "  Network Mask: /%d%s",
-	       ip_masklen (al->mask), VTY_NEWLINE);
+	       ip_masklen (al->mask), VTYNL);
       vty_out (vty, "        Metric Type: %s%s",
 	       IS_EXTERNAL_METRIC (al->e[0].tos) ?
-	       "2 (Larger than any link state path)" : "1", VTY_NEWLINE);
-      vty_out (vty, "        TOS: 0%s", VTY_NEWLINE);
+	       "2 (Larger than any link state path)" : "1", VTYNL);
+      vty_out (vty, "        TOS: 0%s", VTYNL);
       vty_out (vty, "        Metric: %d%s",
-	       GET_METRIC (al->e[0].metric), VTY_NEWLINE);
+	       GET_METRIC (al->e[0].metric), VTYNL);
       vty_out (vty, "        NSSA: Forward Address: %s%s",
-	       inet_ntoa (al->e[0].fwd_addr), VTY_NEWLINE);
+	       inet_ntoa (al->e[0].fwd_addr), VTYNL);
 
       vty_out (vty, "        External Route Tag: %"ROUTE_TAG_PRI"%s%s",
-	       (route_tag_t)ntohl (al->e[0].route_tag), VTY_NEWLINE, VTY_NEWLINE);
+	       (route_tag_t)ntohl (al->e[0].route_tag), VTYNL, VTYNL);
     }
 
   return 0;
@@ -5042,7 +5034,7 @@ show_opaque_lsa_detail (struct vty *vty, struct ospf_lsa *lsa)
       show_ip_ospf_database_header (vty, lsa);
       show_opaque_info_detail (vty, lsa);
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
   return 0;
 }
@@ -5122,15 +5114,15 @@ show_lsa_detail (struct vty *vty, struct ospf *ospf, int type,
     case OSPF_OPAQUE_AS_LSA:
       vty_out (vty, "                %s %s%s",
                show_database_desc[type],
-               VTY_NEWLINE, VTY_NEWLINE);
+               VTYNL, VTYNL);
       show_lsa_detail_proc (vty, AS_LSDB (ospf, type), id, adv_router);
       break;
     default:
       for (ALL_LIST_ELEMENTS_RO (ospf->areas, node, area))
         {
           vty_out (vty, "%s                %s (Area %s)%s%s",
-                   VTY_NEWLINE, show_database_desc[type],
-                   ospf_area_desc_string (area), VTY_NEWLINE, VTY_NEWLINE);
+                   VTYNL, show_database_desc[type],
+                   ospf_area_desc_string (area), VTYNL, VTYNL);
           show_lsa_detail_proc (vty, AREA_LSDB (area, type), id, adv_router);
         }
       break;
@@ -5169,7 +5161,7 @@ show_lsa_detail_adv_router (struct vty *vty, struct ospf *ospf, int type,
     case OSPF_OPAQUE_AS_LSA:
       vty_out (vty, "                %s %s%s",
                show_database_desc[type],
-               VTY_NEWLINE, VTY_NEWLINE);
+               VTYNL, VTYNL);
       show_lsa_detail_adv_router_proc (vty, AS_LSDB (ospf, type),
                                        adv_router);
       break;
@@ -5177,8 +5169,8 @@ show_lsa_detail_adv_router (struct vty *vty, struct ospf *ospf, int type,
       for (ALL_LIST_ELEMENTS_RO (ospf->areas, node, area))
         {
           vty_out (vty, "%s                %s (Area %s)%s%s",
-                   VTY_NEWLINE, show_database_desc[type],
-                   ospf_area_desc_string (area), VTY_NEWLINE, VTY_NEWLINE);
+                   VTYNL, show_database_desc[type],
+                   ospf_area_desc_string (area), VTYNL, VTYNL);
           show_lsa_detail_adv_router_proc (vty, AREA_LSDB (area, type),
                                            adv_router);
 	}
@@ -5213,13 +5205,13 @@ show_ip_ospf_database_summary (struct vty *vty, struct ospf *ospf, int self)
               vty_out (vty, "                %s (Area %s)%s%s",
                        show_database_desc[type],
 		       ospf_area_desc_string (area),
-                       VTY_NEWLINE, VTY_NEWLINE);
-              vty_out (vty, "%s%s", show_database_header[type], VTY_NEWLINE);
+                       VTYNL, VTYNL);
+              vty_out (vty, "%s%s", show_database_header[type], VTYNL);
 
 	      LSDB_LOOP (AREA_LSDB (area, type), rn, lsa)
 		show_lsa_summary (vty, lsa, self);
 
-              vty_out (vty, "%s", VTY_NEWLINE);
+              vty_out (vty, "%s", VTYNL);
 	  }
 	}
     }
@@ -5239,18 +5231,18 @@ show_ip_ospf_database_summary (struct vty *vty, struct ospf *ospf, int self)
         {
           vty_out (vty, "                %s%s%s",
 	       show_database_desc[type],
-	       VTY_NEWLINE, VTY_NEWLINE);
+	       VTYNL, VTYNL);
           vty_out (vty, "%s%s", show_database_header[type],
-	       VTY_NEWLINE);
+	       VTYNL);
 
 	  LSDB_LOOP (AS_LSDB (ospf, type), rn, lsa)
 	    show_lsa_summary (vty, lsa, self);
 
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_out (vty, "%s", VTYNL);
         }
     }
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_out (vty, "%s", VTYNL);
 }
 
 static void
@@ -5259,7 +5251,7 @@ show_ip_ospf_database_maxage (struct vty *vty, struct ospf *ospf)
   struct route_node *rn;
 
   vty_out (vty, "%s                MaxAge Link States:%s%s",
-           VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+           VTYNL, VTYNL, VTYNL);
 
   for (rn = route_top (ospf->maxage_lsa); rn; rn = route_next (rn))
     {
@@ -5267,13 +5259,13 @@ show_ip_ospf_database_maxage (struct vty *vty, struct ospf *ospf)
 
       if ((lsa = rn->info) != NULL)
 	{
-	  vty_out (vty, "Link type: %d%s", lsa->data->type, VTY_NEWLINE);
+	  vty_out (vty, "Link type: %d%s", lsa->data->type, VTYNL);
 	  vty_out (vty, "Link State ID: %s%s",
-		   inet_ntoa (lsa->data->id), VTY_NEWLINE);
+		   inet_ntoa (lsa->data->id), VTYNL);
 	  vty_out (vty, "Advertising Router: %s%s",
-		   inet_ntoa (lsa->data->adv_router), VTY_NEWLINE);
-	  vty_out (vty, "LSA lock count: %d%s", lsa->lock, VTY_NEWLINE);
-	  vty_out (vty, "%s", VTY_NEWLINE);
+		   inet_ntoa (lsa->data->adv_router), VTYNL);
+	  vty_out (vty, "LSA lock count: %d%s", lsa->lock, VTYNL);
+	  vty_out (vty, "%s", VTYNL);
 	}
     }
 }
@@ -5306,11 +5298,11 @@ show_ip_ospf_database_common (struct vty *vty, struct ospf *ospf,
   struct in_addr id, adv_router;
 
   if (ospf->instance)
-    vty_out (vty, "%sOSPF Instance: %d%s", VTY_NEWLINE, ospf->instance,
-             VTY_NEWLINE);
+    vty_out (vty, "%sOSPF Instance: %d%s", VTYNL, ospf->instance,
+             VTYNL);
 
-  vty_out (vty, "%s       OSPF Router with ID (%s)%s%s", VTY_NEWLINE,
-           inet_ntoa (ospf->router_id), VTY_NEWLINE, VTY_NEWLINE);
+  vty_out (vty, "%s       OSPF Router with ID (%s)%s%s", VTYNL,
+           inet_ntoa (ospf->router_id), VTYNL, VTYNL);
 
   /* Show all LSA. */
   if (argc == arg_base + 4)
@@ -5465,11 +5457,11 @@ show_ip_ospf_database_type_adv_router_common (struct vty *vty, struct ospf *ospf
   struct in_addr adv_router;
 
   if (ospf->instance)
-    vty_out (vty, "%sOSPF Instance: %d%s", VTY_NEWLINE, ospf->instance,
-             VTY_NEWLINE);
+    vty_out (vty, "%sOSPF Instance: %d%s", VTYNL, ospf->instance,
+             VTYNL);
 
-  vty_out (vty, "%s       OSPF Router with ID (%s)%s%s", VTY_NEWLINE,
-           inet_ntoa (ospf->router_id), VTY_NEWLINE, VTY_NEWLINE);
+  vty_out (vty, "%s       OSPF Router with ID (%s)%s%s", VTYNL,
+           inet_ntoa (ospf->router_id), VTYNL, VTYNL);
 
   if (argc != arg_base + 7)
     return CMD_WARNING;
@@ -5581,7 +5573,7 @@ DEFUN (ip_ospf_authentication_args,
       if (!ret)
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -5605,7 +5597,7 @@ DEFUN (ip_ospf_authentication_args,
       return CMD_SUCCESS;
     }
 
-  vty_out (vty, "You shouldn't get here!%s", VTY_NEWLINE);
+  vty_out (vty, "You shouldn't get here!%s", VTYNL);
   return CMD_WARNING;
 }
 
@@ -5631,7 +5623,7 @@ DEFUN (ip_ospf_authentication,
       if (!ret)
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -5673,14 +5665,14 @@ DEFUN (no_ip_ospf_authentication_args,
       if (!ret)
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
       params = ospf_lookup_if_params (ifp, addr);
       if (params == NULL)
 	{
-	  vty_out (vty, "Ip Address specified is unknown%s", VTY_NEWLINE);
+	  vty_out (vty, "Ip Address specified is unknown%s", VTYNL);
 	  return CMD_WARNING;
 	}
       params->auth_type = OSPF_AUTH_NOTSET;
@@ -5703,7 +5695,7 @@ DEFUN (no_ip_ospf_authentication_args,
 	}
       else
 	{
-	  vty_out (vty, "Unexpected input encountered%s", VTY_NEWLINE);
+	  vty_out (vty, "Unexpected input encountered%s", VTYNL);
 	  return CMD_WARNING;
 	}
       /*
@@ -5763,14 +5755,14 @@ DEFUN (no_ip_ospf_authentication,
       if (!ret)
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
       params = ospf_lookup_if_params (ifp, addr);
       if (params == NULL)
 	{
-	  vty_out (vty, "Ip Address specified is unknown%s", VTY_NEWLINE);
+	  vty_out (vty, "Ip Address specified is unknown%s", VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -5843,7 +5835,7 @@ DEFUN (ip_ospf_authentication_key,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -5889,7 +5881,7 @@ DEFUN (no_ip_ospf_authentication_key,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -5951,7 +5943,7 @@ DEFUN (ip_ospf_message_digest_key,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -5962,7 +5954,7 @@ DEFUN (ip_ospf_message_digest_key,
   key_id = strtol (keyid, NULL, 10);
   if (ospf_crypt_key_lookup (params->auth_crypt, key_id) != NULL)
     {
-      vty_out (vty, "OSPF: Key %d already exists%s", key_id, VTY_NEWLINE);
+      vty_out (vty, "OSPF: Key %d already exists%s", key_id, VTYNL);
       return CMD_WARNING;
     }
 
@@ -6018,7 +6010,7 @@ DEFUN (no_ip_ospf_message_digest_key,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6031,7 +6023,7 @@ DEFUN (no_ip_ospf_message_digest_key,
   ck = ospf_crypt_key_lookup (params->auth_crypt, key_id);
   if (ck == NULL)
     {
-      vty_out (vty, "OSPF: Key %d does not exist%s", key_id, VTY_NEWLINE);
+      vty_out (vty, "OSPF: Key %d does not exist%s", key_id, VTYNL);
       return CMD_WARNING;
     }
 
@@ -6086,7 +6078,7 @@ DEFUN (ip_ospf_cost,
       if(!inet_aton(ifaddr, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6141,7 +6133,7 @@ DEFUN (no_ip_ospf_cost,
       if (!inet_aton(ifaddr, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6213,7 +6205,7 @@ ospf_vty_dead_interval_set (struct vty *vty, const char *interval_str,
       if (!ret)
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6240,7 +6232,7 @@ ospf_vty_dead_interval_set (struct vty *vty, const char *interval_str,
   else
     {
       vty_out (vty, "Please specify dead-interval or hello-multiplier%s",
-              VTY_NEWLINE);
+              VTYNL);
       return CMD_WARNING;
     }
     
@@ -6340,7 +6332,7 @@ DEFUN (no_ip_ospf_dead_interval,
       if (!ret)
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6419,7 +6411,7 @@ DEFUN (ip_ospf_hello_interval,
       if(!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6466,7 +6458,7 @@ DEFUN (no_ip_ospf_hello_interval,
       if(!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6517,7 +6509,7 @@ DEFUN (ip_ospf_network,
 
   if (old_type == OSPF_IFTYPE_LOOPBACK)
     {
-      vty_out (vty, "This is a loopback interface. Can't set network type.%s", VTY_NEWLINE);
+      vty_out (vty, "This is a loopback interface. Can't set network type.%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -6646,7 +6638,7 @@ DEFUN (ip_ospf_priority,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6708,7 +6700,7 @@ DEFUN (no_ip_ospf_priority,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6779,7 +6771,7 @@ DEFUN (ip_ospf_retransmit_interval,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6826,7 +6818,7 @@ DEFUN (no_ip_ospf_retransmit_interval,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6883,7 +6875,7 @@ DEFUN (ip_ospf_transmit_delay,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -6929,7 +6921,7 @@ DEFUN (no_ip_ospf_transmit_delay,
       if (!inet_aton(argv[idx]->arg, &addr))
 	{
 	  vty_out (vty, "Please specify interface address by A.B.C.D%s",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  return CMD_WARNING;
 	}
 
@@ -7007,12 +6999,12 @@ DEFUN (ip_ospf_area,
   if (ret < 0)
     {
       vty_out (vty, "Please specify area by A.B.C.D|<0-4294967295>%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
   if (memcmp (ifp->name, "VLINK", 5) == 0)
     {
-      vty_out (vty, "Cannot enable OSPF on a virtual link.%s", VTY_NEWLINE);
+      vty_out (vty, "Cannot enable OSPF on a virtual link.%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -7021,7 +7013,7 @@ DEFUN (ip_ospf_area,
     {
       vty_out (vty,
                "Must remove previous area config before changing ospf area %s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
@@ -7044,7 +7036,7 @@ DEFUN (ip_ospf_area,
     {
       if (rn->info != NULL)
         {
-          vty_out (vty, "Please remove all network commands first.%s", VTY_NEWLINE);
+          vty_out (vty, "Please remove all network commands first.%s", VTYNL);
           return CMD_WARNING;
         }
     }
@@ -7097,8 +7089,7 @@ DEFUN (no_ip_ospf_area,
 
   if (!OSPF_IF_PARAM_CONFIGURED(params, if_area))
     {
-      vty_out (vty, "Can't find specified interface area configuration.%s",
-	       VTY_NEWLINE);
+      vty_outln (vty, "Can't find specified interface area configuration.");
       return CMD_WARNING;
     }  
 
@@ -7234,14 +7225,14 @@ DEFUN (ospf_redistribute_instance_source,
   if ((source == ZEBRA_ROUTE_OSPF) && !ospf->instance)
     {
       vty_out (vty, "Instance redistribution in non-instanced OSPF not allowed%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
   if ((source == ZEBRA_ROUTE_OSPF) && (ospf->instance == instance))
     {
       vty_out (vty, "Same instance OSPF redistribution not allowed%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
@@ -7300,14 +7291,14 @@ DEFUN (no_ospf_redistribute_instance_source,
   if ((source == ZEBRA_ROUTE_OSPF) && !ospf->instance)
     {
       vty_out (vty, "Instance redistribution in non-instanced OSPF not allowed%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
   if ((source == ZEBRA_ROUTE_OSPF) && (ospf->instance == instance))
     {
       vty_out (vty, "Same instance OSPF redistribution not allowed%s",
-               VTY_NEWLINE);
+               VTYNL);
       return CMD_WARNING;
     }
 
@@ -7672,7 +7663,7 @@ DEFUN (ip_ospf_mtu_ignore,
       if (!ret)
         {
           vty_out (vty, "Please specify interface address by A.B.C.D%s",
-                  VTY_NEWLINE);
+                  VTYNL);
           return CMD_WARNING;
         }
       params = ospf_get_if_params (ifp, addr);
@@ -7715,7 +7706,7 @@ DEFUN (no_ip_ospf_mtu_ignore,
       if (!ret)
         {
           vty_out (vty, "Please specify interface address by A.B.C.D%s",
-                  VTY_NEWLINE);
+                  VTYNL);
           return CMD_WARNING;
         }
       params = ospf_get_if_params (ifp, addr);
@@ -7895,16 +7886,16 @@ config_write_stub_router (struct vty *vty, struct ospf *ospf)
   
   if (ospf->stub_router_startup_time != OSPF_STUB_ROUTER_UNCONFIGURED)
     vty_out (vty, " max-metric router-lsa on-startup %u%s",
-             ospf->stub_router_startup_time, VTY_NEWLINE);
+             ospf->stub_router_startup_time, VTYNL);
   if (ospf->stub_router_shutdown_time != OSPF_STUB_ROUTER_UNCONFIGURED)
     vty_out (vty, " max-metric router-lsa on-shutdown %u%s",
-             ospf->stub_router_shutdown_time, VTY_NEWLINE);
+             ospf->stub_router_shutdown_time, VTYNL);
   for (ALL_LIST_ELEMENTS_RO (ospf->areas, ln, area))
     {
       if (CHECK_FLAG (area->stub_router_state, OSPF_AREA_ADMIN_STUB_ROUTED))
         {
           vty_out (vty, " max-metric router-lsa administrative%s",
-                   VTY_NEWLINE);
+                   VTYNL);
           break;
         }
     }
@@ -7920,7 +7911,7 @@ show_ip_ospf_route_network (struct vty *vty, struct route_table *rt)
   struct ospf_path *path;
 
   vty_out (vty, "============ OSPF network routing table ============%s",
-	   VTY_NEWLINE);
+	   VTYNL);
 
   for (rn = route_top (rt); rn; rn = route_next (rn))
     if ((or = rn->info) != NULL)
@@ -7934,13 +7925,13 @@ show_ip_ospf_route_network (struct vty *vty, struct route_table *rt)
 	  case OSPF_PATH_INTER_AREA:
 	    if (or->type == OSPF_DESTINATION_NETWORK)
 	      vty_out (vty, "N IA %-18s    [%d] area: %s%s", buf1, or->cost,
-		       inet_ntoa (or->u.std.area_id), VTY_NEWLINE);
+		       inet_ntoa (or->u.std.area_id), VTYNL);
 	    else if (or->type == OSPF_DESTINATION_DISCARD)
-	      vty_out (vty, "D IA %-18s    Discard entry%s", buf1, VTY_NEWLINE);
+	      vty_out (vty, "D IA %-18s    Discard entry%s", buf1, VTYNL);
 	    break;
 	  case OSPF_PATH_INTRA_AREA:
 	    vty_out (vty, "N    %-18s    [%d] area: %s%s", buf1, or->cost,
-		     inet_ntoa (or->u.std.area_id), VTY_NEWLINE);
+		     inet_ntoa (or->u.std.area_id), VTYNL);
 	    break;
 	  default:
 	    break;
@@ -7953,15 +7944,15 @@ show_ip_ospf_route_network (struct vty *vty, struct route_table *rt)
                 {
                   if (path->nexthop.s_addr == 0)
                     vty_out (vty, "%24s   directly attached to %s%s",
-                             "", ifindex2ifname (path->ifindex, VRF_DEFAULT), VTY_NEWLINE);
+                             "", ifindex2ifname (path->ifindex, VRF_DEFAULT), VTYNL);
                   else
                     vty_out (vty, "%24s   via %s, %s%s", "",
                              inet_ntoa (path->nexthop),
-			     ifindex2ifname (path->ifindex, VRF_DEFAULT), VTY_NEWLINE);
+			     ifindex2ifname (path->ifindex, VRF_DEFAULT), VTYNL);
                 }
             }
       }
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_out (vty, "%s", VTYNL);
 }
 
 static void
@@ -7974,7 +7965,7 @@ show_ip_ospf_route_router (struct vty *vty, struct route_table *rtrs)
   struct ospf_path *path;
 
   vty_out (vty, "============ OSPF router routing table =============%s",
-	   VTY_NEWLINE);
+	   VTYNL);
   for (rn = route_top (rtrs); rn; rn = route_next (rn))
     if (rn->info)
       {
@@ -7995,7 +7986,7 @@ show_ip_ospf_route_router (struct vty *vty, struct route_table *rtrs)
             vty_out (vty, "%s%s%s",
                      (or->u.std.flags & ROUTER_LSA_BORDER ? ", ABR" : ""),
                      (or->u.std.flags & ROUTER_LSA_EXTERNAL ? ", ASBR" : ""),
-                     VTY_NEWLINE);
+                     VTYNL);
                   
                   for (ALL_LIST_ELEMENTS_RO (or->paths, pnode, path))
                     {
@@ -8004,17 +7995,17 @@ show_ip_ospf_route_router (struct vty *vty, struct route_table *rtrs)
 			  if (path->nexthop.s_addr == 0)
 			    vty_out (vty, "%24s   directly attached to %s%s",
 				     "", ifindex2ifname (path->ifindex, VRF_DEFAULT),
-				     VTY_NEWLINE);
+				     VTYNL);
 			  else
 			    vty_out (vty, "%24s   via %s, %s%s", "",
 				     inet_ntoa (path->nexthop),
 				     ifindex2ifname (path->ifindex, VRF_DEFAULT),
-				     VTY_NEWLINE);
+				     VTYNL);
 			}
                     }
           }
       }
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_out (vty, "%s", VTYNL);
 }
 
 static void
@@ -8026,7 +8017,7 @@ show_ip_ospf_route_external (struct vty *vty, struct route_table *rt)
   struct ospf_path *path;
 
   vty_out (vty, "============ OSPF external routing table ===========%s",
-	   VTY_NEWLINE);
+	   VTYNL);
   for (rn = route_top (rt); rn; rn = route_next (rn))
     if ((er = rn->info) != NULL)
       {
@@ -8038,11 +8029,11 @@ show_ip_ospf_route_external (struct vty *vty, struct route_table *rt)
 	  {
 	  case OSPF_PATH_TYPE1_EXTERNAL:
 	    vty_out (vty, "N E1 %-18s    [%d] tag: %"ROUTE_TAG_PRI"%s", buf1,
-		     er->cost, er->u.ext.tag, VTY_NEWLINE);
+		     er->cost, er->u.ext.tag, VTYNL);
 	    break;
 	  case OSPF_PATH_TYPE2_EXTERNAL:
 	    vty_out (vty, "N E2 %-18s    [%d/%d] tag: %"ROUTE_TAG_PRI"%s", buf1, er->cost,
-		     er->u.ext.type2_cost, er->u.ext.tag, VTY_NEWLINE);
+		     er->u.ext.type2_cost, er->u.ext.tag, VTYNL);
 	    break;
 	  }
 
@@ -8052,28 +8043,28 @@ show_ip_ospf_route_external (struct vty *vty, struct route_table *rt)
               {
                 if (path->nexthop.s_addr == 0)
                   vty_out (vty, "%24s   directly attached to %s%s",
-                           "", ifindex2ifname (path->ifindex, VRF_DEFAULT), VTY_NEWLINE);
+                           "", ifindex2ifname (path->ifindex, VRF_DEFAULT), VTYNL);
                 else
                   vty_out (vty, "%24s   via %s, %s%s", "",
                            inet_ntoa (path->nexthop),
 			   ifindex2ifname (path->ifindex, VRF_DEFAULT),
-                           VTY_NEWLINE);
+                           VTYNL);
               }
            }
         }
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_out (vty, "%s", VTYNL);
 }
 
 static int
 show_ip_ospf_border_routers_common (struct vty *vty, struct ospf *ospf)
 {
   if (ospf->instance)
-    vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-             VTY_NEWLINE, VTY_NEWLINE);
+    vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+             VTYNL, VTYNL);
 
   if (ospf->new_table == NULL)
     {
-      vty_out (vty, "No OSPF routing information exist%s", VTY_NEWLINE);
+      vty_out (vty, "No OSPF routing information exist%s", VTYNL);
       return CMD_SUCCESS;
     }
 
@@ -8083,7 +8074,7 @@ show_ip_ospf_border_routers_common (struct vty *vty, struct ospf *ospf)
   /* Show Router routes. */
   show_ip_ospf_route_router (vty, ospf->new_rtrs);
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_out (vty, "%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -8128,12 +8119,12 @@ static int
 show_ip_ospf_route_common (struct vty *vty, struct ospf *ospf)
 {
   if (ospf->instance)
-    vty_out (vty, "%sOSPF Instance: %d%s%s", VTY_NEWLINE, ospf->instance,
-             VTY_NEWLINE, VTY_NEWLINE);
+    vty_out (vty, "%sOSPF Instance: %d%s%s", VTYNL, ospf->instance,
+             VTYNL, VTYNL);
 
   if (ospf->new_table == NULL)
     {
-      vty_out (vty, "No OSPF routing information exist%s", VTY_NEWLINE);
+      vty_out (vty, "No OSPF routing information exist%s", VTYNL);
       return CMD_SUCCESS;
     }
 
@@ -8146,7 +8137,7 @@ show_ip_ospf_route_common (struct vty *vty, struct ospf *ospf)
   /* Show AS External routes. */
   show_ip_ospf_route_external (vty, ospf->old_external_route);
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_out (vty, "%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -8234,12 +8225,12 @@ config_write_interface (struct vty *vty)
       if (ifp->ifindex == IFINDEX_DELETED)
         continue;
 
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_out (vty, "!%s", VTYNL);
       vty_out (vty, "interface %s%s", ifp->name,
-               VTY_NEWLINE);
+               VTYNL);
       if (ifp->desc)
         vty_out (vty, " description %s%s", ifp->desc,
-               VTY_NEWLINE);
+               VTYNL);
 
       write++;
 
@@ -8256,7 +8247,7 @@ config_write_interface (struct vty *vty)
 			 ospf_int_type_str[params->type]);
 		if (params != IF_DEF_PARAMS (ifp))
 		  vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-		vty_out (vty, "%s", VTY_NEWLINE);
+		vty_out (vty, "%s", VTYNL);
 	      }
 	  }
 	
@@ -8291,7 +8282,7 @@ config_write_interface (struct vty *vty)
 	    vty_out (vty, " ip ospf authentication%s", auth_str);
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 
 	/* Simple Authentication Password print. */
@@ -8302,7 +8293,7 @@ config_write_interface (struct vty *vty)
 		     params->auth_simple);
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 	
 	/* Cryptographic Authentication Key print. */
@@ -8312,7 +8303,7 @@ config_write_interface (struct vty *vty)
                      ck->key_id, ck->auth_key);
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 	
 	/* Interface Output Cost print. */
@@ -8321,7 +8312,7 @@ config_write_interface (struct vty *vty)
 	    vty_out (vty, " ip ospf cost %u", params->output_cost_cmd);
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 	
 	/* Hello Interval print. */
@@ -8331,7 +8322,7 @@ config_write_interface (struct vty *vty)
 	    vty_out (vty, " ip ospf hello-interval %u", params->v_hello);
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 	
 	
@@ -8350,7 +8341,7 @@ config_write_interface (struct vty *vty)
             
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 	
       /* Router Priority print. */
@@ -8360,7 +8351,7 @@ config_write_interface (struct vty *vty)
 	    vty_out (vty, " ip ospf priority %u", params->priority);
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 	
 	/* Retransmit Interval print. */
@@ -8371,7 +8362,7 @@ config_write_interface (struct vty *vty)
 		     params->retransmit_interval);
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 	
 	/* Transmit Delay print. */
@@ -8381,7 +8372,7 @@ config_write_interface (struct vty *vty)
 	    vty_out (vty, " ip ospf transmit-delay %u", params->transmit_delay);
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 
 	/* Area  print. */
@@ -8395,7 +8386,7 @@ config_write_interface (struct vty *vty)
 	    vty_out (vty, " area %s", inet_ntoa (params->if_area));
 	    if (params != IF_DEF_PARAMS (ifp))
 	      vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-            vty_out (vty, "%s", VTY_NEWLINE);
+            vty_out (vty, VTYNL);
 	  }
 
 	/* bfd  print. */
@@ -8411,7 +8402,7 @@ config_write_interface (struct vty *vty)
           vty_out (vty, " ip ospf mtu-ignore");
         if (params != IF_DEF_PARAMS (ifp))
            vty_out (vty, " %s", inet_ntoa (rn->p.u.prefix4));
-        vty_out (vty, "%s", VTY_NEWLINE);
+        vty_out (vty, "%s", VTYNL);
       }
 
 
@@ -8460,7 +8451,7 @@ config_write_network_area (struct vty *vty, struct ospf *ospf)
 	/* Network print. */
 	vty_out (vty, " network %s/%d area %s%s",
 		 inet_ntoa (rn->p.u.prefix4), rn->p.prefixlen,
-		 buf, VTY_NEWLINE);
+		 buf, VTYNL);
       }
 
   return 0;
@@ -8484,16 +8475,16 @@ config_write_ospf_area (struct vty *vty, struct ospf *ospf)
       if (area->auth_type != OSPF_AUTH_NULL)
 	{
 	  if (area->auth_type == OSPF_AUTH_SIMPLE)
-	    vty_out (vty, " area %s authentication%s", buf, VTY_NEWLINE);
+	    vty_out (vty, " area %s authentication%s", buf, VTYNL);
 	  else
 	    vty_out (vty, " area %s authentication message-digest%s",
-		     buf, VTY_NEWLINE);
+		     buf, VTYNL);
 	}
 
       if (area->shortcut_configured != OSPF_SHORTCUT_DEFAULT)
 	vty_out (vty, " area %s shortcut %s%s", buf,
 		 ospf_shortcut_mode_str[area->shortcut_configured],
-		 VTY_NEWLINE);
+		 VTYNL);
 
       if ((area->external_routing == OSPF_AREA_STUB)
 	  || (area->external_routing == OSPF_AREA_NSSA)
@@ -8521,11 +8512,11 @@ config_write_ospf_area (struct vty *vty, struct ospf *ospf)
 	  if (area->no_summary)
 	    vty_out (vty, " no-summary");
 
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_out (vty, "%s", VTYNL);
 
 	  if (area->default_cost != 1)
 	    vty_out (vty, " area %s default-cost %d%s", buf, 
-		     area->default_cost, VTY_NEWLINE);
+		     area->default_cost, VTYNL);
 	}
 
       for (rn1 = route_top (area->ranges); rn1; rn1 = route_next (rn1))
@@ -8546,24 +8537,24 @@ config_write_ospf_area (struct vty *vty, struct ospf *ospf)
 	      vty_out (vty, " substitute %s/%d",
 		       inet_ntoa (range->subst_addr), range->subst_masklen);
 
-	    vty_out (vty, "%s", VTY_NEWLINE);
+	    vty_out (vty, "%s", VTYNL);
 	  }
 
       if (EXPORT_NAME (area))
 	vty_out (vty, " area %s export-list %s%s", buf,
-		 EXPORT_NAME (area), VTY_NEWLINE);
+		 EXPORT_NAME (area), VTYNL);
 
       if (IMPORT_NAME (area))
 	vty_out (vty, " area %s import-list %s%s", buf,
-		 IMPORT_NAME (area), VTY_NEWLINE);
+		 IMPORT_NAME (area), VTYNL);
 
       if (PREFIX_NAME_IN (area))
 	vty_out (vty, " area %s filter-list prefix %s in%s", buf,
-		 PREFIX_NAME_IN (area), VTY_NEWLINE);
+		 PREFIX_NAME_IN (area), VTYNL);
 
       if (PREFIX_NAME_OUT (area))
 	vty_out (vty, " area %s filter-list prefix %s out%s", buf,
-		 PREFIX_NAME_OUT (area), VTY_NEWLINE);
+		 PREFIX_NAME_OUT (area), VTYNL);
     }
 
   return 0;
@@ -8587,7 +8578,7 @@ config_write_ospf_nbr_nbma (struct vty *vty, struct ospf *ospf)
 	if (nbr_nbma->v_poll != OSPF_POLL_INTERVAL_DEFAULT)
 	  vty_out (vty, " poll-interval %d", nbr_nbma->v_poll);
 
-	vty_out (vty, "%s", VTY_NEWLINE);
+	vty_out (vty, "%s", VTYNL);
       }
 
   return 0;
@@ -8626,17 +8617,17 @@ config_write_virtual_link (struct vty *vty, struct ospf *ospf)
 		     OSPF_IF_PARAM (oi, retransmit_interval),
 		     OSPF_IF_PARAM (oi, transmit_delay),
 		     OSPF_IF_PARAM (oi, v_wait),
-		     VTY_NEWLINE);
+		     VTYNL);
 	  else
 	    vty_out (vty, " area %s virtual-link %s%s", buf,
-		     inet_ntoa (vl_data->vl_peer), VTY_NEWLINE);
+		     inet_ntoa (vl_data->vl_peer), VTYNL);
 	  /* Auth key */
 	  if (IF_DEF_PARAMS (vl_data->vl_oi->ifp)->auth_simple[0] != '\0')
 	    vty_out (vty, " area %s virtual-link %s authentication-key %s%s",
 		     buf,
 		     inet_ntoa (vl_data->vl_peer),
 		     IF_DEF_PARAMS (vl_data->vl_oi->ifp)->auth_simple,
-		     VTY_NEWLINE);
+		     VTYNL);
 	  /* md5 keys */
 	  for (ALL_LIST_ELEMENTS_RO (IF_DEF_PARAMS (vl_data->vl_oi->ifp)->auth_crypt,
                                      n2, ck))
@@ -8644,7 +8635,7 @@ config_write_virtual_link (struct vty *vty, struct ospf *ospf)
                      " message-digest-key %d md5 %s%s",
                      buf,
                      inet_ntoa (vl_data->vl_peer),
-                     ck->key_id, ck->auth_key, VTY_NEWLINE);
+                     ck->key_id, ck->auth_key, VTYNL);
 	 
 	}
     }
@@ -8684,7 +8675,7 @@ config_write_ospf_redistribute (struct vty *vty, struct ospf *ospf)
           if (ROUTEMAP_NAME (red))
             vty_out (vty, " route-map %s", ROUTEMAP_NAME (red));
 
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_out (vty, "%s", VTYNL);
         }
     }
 
@@ -8696,7 +8687,7 @@ config_write_ospf_default_metric (struct vty *vty, struct ospf *ospf)
 {
   if (ospf->default_metric != -1)
     vty_out (vty, " default-metric %d%s", ospf->default_metric,
-	     VTY_NEWLINE);
+	     VTYNL);
   return 0;
 }
 
@@ -8713,7 +8704,7 @@ config_write_ospf_distribute (struct vty *vty, struct ospf *ospf)
 	if (DISTRIBUTE_NAME (ospf, type))
 	  vty_out (vty, " distribute-list %s out %s%s", 
 		   DISTRIBUTE_NAME (ospf, type),
-		   zebra_route_string(type), VTY_NEWLINE);
+		   zebra_route_string(type), VTYNL);
 
       /* default-information print. */
       if (ospf->default_originate != DEFAULT_ORIGINATE_NONE)
@@ -8736,7 +8727,7 @@ config_write_ospf_distribute (struct vty *vty, struct ospf *ospf)
                          ROUTEMAP_NAME (red));
             }
 	  
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_out (vty, "%s", VTYNL);
 	}
 
     }
@@ -8751,7 +8742,7 @@ config_write_ospf_distance (struct vty *vty, struct ospf *ospf)
   struct ospf_distance *odistance;
 
   if (ospf->distance_all)
-    vty_out (vty, " distance %d%s", ospf->distance_all, VTY_NEWLINE);
+    vty_out (vty, " distance %d%s", ospf->distance_all, VTYNL);
 
   if (ospf->distance_intra 
       || ospf->distance_inter 
@@ -8766,7 +8757,7 @@ config_write_ospf_distance (struct vty *vty, struct ospf *ospf)
       if (ospf->distance_external)
 	vty_out (vty, " external %d", ospf->distance_external);
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
   
   for (rn = route_top (ospf->distance_table); rn; rn = route_next (rn))
@@ -8775,7 +8766,7 @@ config_write_ospf_distance (struct vty *vty, struct ospf *ospf)
 	vty_out (vty, " distance %d %s/%d %s%s", odistance->distance,
 		 inet_ntoa (rn->p.u.prefix4), rn->p.prefixlen,
 		 odistance->access_list ? odistance->access_list : "",
-		 VTY_NEWLINE);
+		 VTYNL);
       }
   return 0;
 }
@@ -8795,9 +8786,9 @@ ospf_config_write (struct vty *vty)
     {
       /* `router ospf' print. */
       if (ospf->instance)
-        vty_out (vty, "router ospf %d%s", ospf->instance, VTY_NEWLINE);
+        vty_out (vty, "router ospf %d%s", ospf->instance, VTYNL);
       else
-        vty_out (vty, "router ospf%s", VTY_NEWLINE);
+        vty_out (vty, "router ospf%s", VTYNL);
 
       write++;
 
@@ -8807,37 +8798,37 @@ ospf_config_write (struct vty *vty)
       /* Router ID print. */
       if (ospf->router_id_static.s_addr != 0)
         vty_out (vty, " ospf router-id %s%s",
-                 inet_ntoa (ospf->router_id_static), VTY_NEWLINE);
+                 inet_ntoa (ospf->router_id_static), VTYNL);
 
       /* ABR type print. */
       if (ospf->abr_type != OSPF_ABR_DEFAULT)
         vty_out (vty, " ospf abr-type %s%s", 
-                 ospf_abr_type_str[ospf->abr_type], VTY_NEWLINE);
+                 ospf_abr_type_str[ospf->abr_type], VTYNL);
 
       /* log-adjacency-changes flag print. */
       if (CHECK_FLAG(ospf->config, OSPF_LOG_ADJACENCY_CHANGES))
 	{
 	  if (CHECK_FLAG(ospf->config, OSPF_LOG_ADJACENCY_DETAIL))
-	    vty_out(vty, " log-adjacency-changes detail%s", VTY_NEWLINE);
+	    vty_out(vty, " log-adjacency-changes detail%s", VTYNL);
 	  else if (!DFLT_OSPF_LOG_ADJACENCY_CHANGES)
-	    vty_out(vty, " log-adjacency-changes%s", VTY_NEWLINE);
+	    vty_out(vty, " log-adjacency-changes%s", VTYNL);
 	}
       else if (DFLT_OSPF_LOG_ADJACENCY_CHANGES)
         {
-	  vty_out(vty, " no log-adjacency-changes%s", VTY_NEWLINE);
+	  vty_out(vty, " no log-adjacency-changes%s", VTYNL);
         }
 
       /* RFC1583 compatibility flag print -- Compatible with CISCO 12.1. */
       if (CHECK_FLAG (ospf->config, OSPF_RFC1583_COMPATIBLE))
-	vty_out (vty, " compatible rfc1583%s", VTY_NEWLINE);
+	vty_out (vty, " compatible rfc1583%s", VTYNL);
 
       /* auto-cost reference-bandwidth configuration.  */
       if (ospf->ref_bandwidth != OSPF_DEFAULT_REF_BANDWIDTH)
         {
           vty_out (vty, "! Important: ensure reference bandwidth "
-                        "is consistent across all routers%s", VTY_NEWLINE);
+                        "is consistent across all routers%s", VTYNL);
           vty_out (vty, " auto-cost reference-bandwidth %d%s",
-		   ospf->ref_bandwidth, VTY_NEWLINE);
+		   ospf->ref_bandwidth, VTYNL);
         }
 
       /* SPF timers print. */
@@ -8846,20 +8837,20 @@ ospf_config_write (struct vty *vty)
 	  ospf->spf_max_holdtime != OSPF_SPF_MAX_HOLDTIME_DEFAULT)
 	vty_out (vty, " timers throttle spf %d %d %d%s",
 		 ospf->spf_delay, ospf->spf_holdtime,
-		 ospf->spf_max_holdtime, VTY_NEWLINE);
+		 ospf->spf_max_holdtime, VTYNL);
 
        /* LSA timers print. */
       if (ospf->min_ls_interval != OSPF_MIN_LS_INTERVAL)
 	vty_out (vty, " timers throttle lsa all %d%s",
-		 ospf->min_ls_interval, VTY_NEWLINE);
+		 ospf->min_ls_interval, VTYNL);
       if (ospf->min_ls_arrival != OSPF_MIN_LS_ARRIVAL)
 	vty_out (vty, " timers lsa min-arrival %d%s",
-		 ospf->min_ls_arrival, VTY_NEWLINE);
+		 ospf->min_ls_arrival, VTYNL);
 
       /* Write multiplier print. */
       if (ospf->write_oi_count != OSPF_WRITE_INTERFACE_COUNT_DEFAULT)
         vty_out (vty, " ospf write-multiplier %d%s",
-                 ospf->write_oi_count, VTY_NEWLINE);
+                 ospf->write_oi_count, VTYNL);
 
       /* Max-metric router-lsa print */
       config_write_stub_router (vty, ospf);
@@ -8867,14 +8858,14 @@ ospf_config_write (struct vty *vty)
       /* SPF refresh parameters print. */
       if (ospf->lsa_refresh_interval != OSPF_LSA_REFRESH_INTERVAL_DEFAULT)
 	vty_out (vty, " refresh timer %d%s",
-		 ospf->lsa_refresh_interval, VTY_NEWLINE);
+		 ospf->lsa_refresh_interval, VTYNL);
 
       /* Redistribute information print. */
       config_write_ospf_redistribute (vty, ospf);
 
       /* passive-interface print. */
       if (ospf->passive_interface_default == OSPF_IF_PASSIVE)
-        vty_out (vty, " passive-interface default%s", VTY_NEWLINE);
+        vty_out (vty, " passive-interface default%s", VTYNL);
       
       for (ALL_LIST_ELEMENTS_RO (om->iflist, node, ifp))
         if (OSPF_IF_PARAM_CONFIGURED (IF_DEF_PARAMS (ifp), passive_interface)
@@ -8883,7 +8874,7 @@ ospf_config_write (struct vty *vty)
           {
             vty_out (vty, " %spassive-interface %s%s",
                      IF_DEF_PARAMS (ifp)->passive_interface ? "" : "no ",
-                     ifp->name, VTY_NEWLINE);
+                     ifp->name, VTYNL);
           }
       for (ALL_LIST_ELEMENTS_RO (ospf->oiflist, node, oi))
         {
@@ -8901,7 +8892,7 @@ ospf_config_write (struct vty *vty)
           vty_out (vty, " %spassive-interface %s %s%s",
                    oi->params->passive_interface ? "" : "no ",
                    oi->ifp->name,
-                   inet_ntoa (oi->address->u.prefix4), VTY_NEWLINE);
+                   inet_ntoa (oi->address->u.prefix4), VTYNL);
         }
       
       /* Network area print. */
@@ -9132,7 +9123,7 @@ DEFUN (clear_ip_ospf_interface,
   else /* Interface name is specified. */
     {
       if ((ifp = if_lookup_by_name (argv[idx_ifname]->arg, VRF_DEFAULT)) == NULL)
-        vty_out (vty, "No such interface name%s", VTY_NEWLINE);
+        vty_out (vty, "No such interface name%s", VTYNL);
       else
         ospf_interface_clear(ifp);
     }

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4788,7 +4788,7 @@ show_ip_ospf_database_header (struct vty *vty, struct ospf_lsa *lsa)
 		 IS_ROUTER_LSA_VIRTUAL (rlsa) ? " VL-endpoint" : "",
 		 IS_ROUTER_LSA_SHORTCUT (rlsa) ? " Shortcut" : "");
 
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   vty_outln (vty, "  LS Type: %s",
              lookup_msg(ospf_lsa_type_msg, lsa->data->type, NULL));

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3270,7 +3270,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
       vty_outln (vty, "%s is %s", ifp->name,
                  ((is_up = if_is_operative(ifp)) ? "up" : "down"));
       vty_outln (vty, "  ifindex %u, MTU %u bytes, BW %u Mbit %s",
-                 ifp->ifindex, ifp->mtu, bandwidth, if_flag_dump(ifp->flags))
+                 ifp->ifindex, ifp->mtu, bandwidth, if_flag_dump(ifp->flags));
     }
 
   /* Is interface OSPF enabled? */
@@ -7025,8 +7025,7 @@ DEFUN (ip_ospf_area,
     if (OSPF_IF_PARAM_CONFIGURED(params, if_area))
       {
 	vty_out (vty,
-		 "Must remove previous area/address config before changing ospf area %s",
-		 VTY_NEWLINE);
+		 "Must remove previous area/address config before changing ospf area");
 	return CMD_WARNING;
       }
     ospf_if_update_params ((ifp), (addr));

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3404,8 +3404,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
           if (nbr == NULL)
             {
               if (!use_json)
-                vty_out (vty, "  No backup designated router on this network%s",
-                         VTY_NEWLINE);
+                vty_outln (vty, "  No backup designated router on this network");
             }
           else
             {

--- a/ospfd/ospf_vty.h
+++ b/ospfd/ospf_vty.h
@@ -28,7 +28,7 @@
   retv = str2area_id ((STR), &(V), &(F));                                     \
   if (retv < 0)                                                               \
     {                                                                         \
-      vty_out (vty, "%% Invalid OSPF area ID%s", VTY_NEWLINE);                \
+      vty_out (vty, "%% Invalid OSPF area ID%s", VTYNL);                \
       return CMD_WARNING;                                                     \
     }                                                                         \
 }
@@ -39,13 +39,13 @@
   retv = str2area_id ((STR), &(V), &(F));                                     \
   if (retv < 0)                                                               \
     {                                                                         \
-      vty_out (vty, "%% Invalid OSPF area ID%s", VTY_NEWLINE);                \
+      vty_out (vty, "%% Invalid OSPF area ID%s", VTYNL);                \
       return CMD_WARNING;                                                     \
     }                                                                         \
   if (OSPF_IS_AREA_ID_BACKBONE ((V)))                                         \
     {                                                                         \
       vty_out (vty, "%% You can't configure %s to backbone%s",                \
-               NAME, VTY_NEWLINE);                                            \
+               NAME, VTYNL);                                            \
     }                                                                         \
 }
 

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1445,7 +1445,7 @@ ospf_distance_set (struct vty *vty, struct ospf *ospf,
   ret = str2prefix_ipv4 (ip_str, &p);
   if (ret == 0)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
 
@@ -1493,14 +1493,14 @@ ospf_distance_unset (struct vty *vty, struct ospf *ospf,
   ret = str2prefix_ipv4 (ip_str, &p);
   if (ret == 0)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
 
   rn = route_node_lookup (ospf->distance_table, (struct prefix *) &p);
   if (!rn)
     {
-      vty_out (vty, "Can't find specified prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't find specified prefix");
       return CMD_WARNING;
     }
 

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -52,11 +52,11 @@ pim_bfd_write_config (struct vty *vty, struct interface *ifp)
     return;
 
   if (CHECK_FLAG (bfd_info->flags, BFD_FLAG_PARAM_CFG))
-    vty_out (vty, " ip pim bfd %d %d %d%s",
+    vty_outln (vty, " ip pim bfd %d %d %d",
              bfd_info->detect_mult, bfd_info->required_min_rx,
-             bfd_info->desired_min_tx, VTY_NEWLINE);
+             bfd_info->desired_min_tx);
   else
-    vty_out (vty, " ip pim bfd%s", VTY_NEWLINE);
+    vty_outln (vty, " ip pim bfd");
 }
 
 /*

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -505,8 +505,8 @@ static void pim_print_ifp_flags(struct vty *vty, struct interface *ifp, int mloo
   vty_outln (vty, "Multicast Loop  : %d", mloop);
   vty_outln (vty, "Promiscuous     : %s",
             (ifp->flags & IFF_PROMISC) ? "yes" : "no");
-  vty_outln (vty, "");
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
+  vty_out (vty, VTYNL);
 }
 
 static void igmp_show_interfaces(struct vty *vty, u_char uj)
@@ -665,8 +665,8 @@ static void igmp_show_interfaces_single(struct vty *vty, const char *ifname, u_c
                   inet_ntoa(pim_ifp->primary_address));
         vty_outln (vty, "Uptime    : %s", uptime);
         vty_outln (vty, "Version   : %d", pim_ifp->igmp_version);
-        vty_outln (vty, "");
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
+        vty_out (vty, VTYNL);
 
         vty_outln (vty, "Querier");
         vty_outln (vty, "-------");
@@ -675,8 +675,8 @@ static void igmp_show_interfaces_single(struct vty *vty, const char *ifname, u_c
         vty_outln (vty, "Start Count : %d", igmp->startup_query_count);
         vty_outln (vty, "Query Timer : %s", query_hhmmss);
         vty_outln (vty, "Other Timer : %s", other_hhmmss);
-        vty_outln (vty, "");
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
+        vty_out (vty, VTYNL);
 
         vty_outln (vty, "Timers");
         vty_outln (vty, "------");
@@ -695,8 +695,8 @@ static void igmp_show_interfaces_single(struct vty *vty, const char *ifname, u_c
         vty_outln (vty, "Robustness Variable            : %d",
                   igmp->querier_robustness_variable);
         vty_outln (vty, "Startup Query Interval         : %ds", sqi);
-        vty_outln (vty, "");
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
+        vty_out (vty, VTYNL);
 
         pim_print_ifp_flags(vty, ifp, mloop);
       }
@@ -941,7 +941,7 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
       } else {
         vty_outln (vty, "Address    : %s", inet_ntoa(ifaddr));
       }
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
 
       // PIM neighbors
       print_header = 1;
@@ -962,8 +962,8 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
       }
 
       if (!print_header) {
-        vty_outln (vty, "");
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
+        vty_out (vty, VTYNL);
       }
 
       vty_outln (vty, "Designated Router");
@@ -973,8 +973,8 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
       vty_outln (vty, "Uptime    : %s", dr_uptime);
       vty_outln (vty, "Elections : %d", pim_ifp->pim_dr_election_count);
       vty_outln (vty, "Changes   : %d", pim_ifp->pim_dr_election_changes);
-      vty_outln (vty, "");
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
+      vty_out (vty, VTYNL);
 
       // FHR
       print_header = 1;
@@ -998,8 +998,8 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
       }
 
       if (!print_header) {
-        vty_outln (vty, "");
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
+        vty_out (vty, VTYNL);
       }
 
       vty_outln (vty, "Hellos");
@@ -1014,8 +1014,8 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
       vty_outln (vty, "Send Failed    : %d",
                 pim_ifp->pim_ifstat_hello_sendfail);
       vty_outln (vty, "Generation ID  : %08x", pim_ifp->pim_generation_id);
-      vty_outln (vty, "");
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
+      vty_out (vty, VTYNL);
 
       pim_print_ifp_flags(vty, ifp, mloop);
 
@@ -1029,8 +1029,8 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
                 pim_if_effective_override_interval_msec(ifp));
       vty_outln (vty, "Join Prune Override Interval : %d msec",
                 pim_if_jp_override_interval_msec(ifp));
-      vty_outln (vty, "");
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
+      vty_out (vty, VTYNL);
 
       vty_outln (vty, "LAN Prune Delay");
       vty_outln (vty, "---------------");
@@ -1042,8 +1042,8 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
                 pim_ifp->pim_override_interval_msec);
       vty_outln (vty, "Override Interval (Highest) : %d msec",
                 pim_ifp->pim_neighbors_highest_override_interval_msec);
-      vty_outln (vty, "");
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
+      vty_out (vty, VTYNL);
     }
   }
 
@@ -1153,7 +1153,7 @@ static void pim_show_interface_traffic (struct vty *vty, u_char uj)
     json = json_object_new_object ();
   else
     {
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       vty_outln (vty, "%-12s%-17s%-17s%-17s%-17s%-17s%-17s", "Interface",
                "    HELLO", "    JOIN", "   PRUNE", "   REGISTER",
                "  REGISTER-STOP", "  ASSERT");
@@ -1227,7 +1227,7 @@ static void pim_show_interface_traffic_single (struct vty *vty, const char *ifna
     json = json_object_new_object ();
   else
     {
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
       vty_outln (vty, "%-12s%-17s%-17s%-17s%-17s%-17s%-17s", "Interface",
                "    HELLO", "    JOIN", "   PRUNE", "   REGISTER",
                "  REGISTER-STOP", "  ASSERT");
@@ -1537,7 +1537,7 @@ static void pim_show_neighbors_single(struct vty *vty, const char *neighbor, u_c
         vty_outln (vty, "    Hello Option - T-bit           : %s",
                   option_t_bit ? "yes" : "no");
         pim_bfd_show_info (vty, neigh->bfd_info, json_ifp, uj, 0);
-        vty_outln (vty, "");
+        vty_out (vty, VTYNL);
       }
     }
   }
@@ -1690,7 +1690,7 @@ pim_show_state(struct vty *vty, const char *src_or_group, const char *group, u_c
     }
 
     if (!uj)
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
   }
 
 
@@ -1699,7 +1699,7 @@ pim_show_state(struct vty *vty, const char *src_or_group, const char *group, u_c
                json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   } else {
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
   }
 }
 
@@ -2200,7 +2200,7 @@ static void pim_show_rpf(struct vty *vty, u_char uj)
     show_rpf_refresh_stats(vty, now, json);
   } else {
     show_rpf_refresh_stats(vty, now, json);
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
     vty_outln (vty,
             "Source          Group           RpfIface RpfAddress      RibNextHop      Metric Pref");
   }
@@ -2277,7 +2277,7 @@ pim_print_pnc_cache_walkcb (struct hash_backet *backet, void *arg)
       vty_out (vty, "%-15s ", inet_ntoa (pnc->rpf.rpf_addr.u.prefix4));
       vty_out (vty, "%-14s ", ifp ? ifp->name : "NULL");
       vty_out (vty, "%s ", inet_ntoa (nh_node->gate.ipv4));
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   return CMD_SUCCESS;
 }
@@ -3196,7 +3196,7 @@ static void show_multicast_interfaces(struct vty *vty)
   struct listnode  *node;
   struct interface *ifp;
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   
   vty_outln (vty,
             "Interface Address         ifi Vif  PktsIn PktsOut    BytesIn   BytesOut");
@@ -3256,16 +3256,16 @@ DEFUN (show_ip_multicast,
   vty_outln (vty, "Mroute socket uptime: %s",
           uptime);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   pim_zebra_zclient_update (vty);
   pim_zlookup_show_ip_multicast (vty);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   vty_outln (vty, "Maximum highest VifIndex: %d",
 	  PIM_MAX_USABLE_VIFS);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   vty_outln (vty, "Upstream Join Timer: %d secs",
            qpim_t_periodic);
   vty_outln (vty, "Join/Prune Holdtime: %d secs",
@@ -3275,11 +3275,11 @@ DEFUN (show_ip_multicast,
   vty_outln (vty, "PIM ECMP Rebalance: %s",
            qpim_ecmp_rebalance_enable ? "Enable" : "Disable");
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   show_rpf_refresh_stats(vty, now, NULL);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   show_scan_oil_stats(vty, now);
 
@@ -3587,7 +3587,7 @@ static void show_mroute_count(struct vty *vty)
   struct channel_oil *c_oil;
   struct static_route *s_route;
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   
   vty_outln (vty,
             "Source          Group           LastUsed Packets Bytes WrongIf  ");
@@ -6518,7 +6518,7 @@ ip_msdp_show_peers_detail(struct vty *vty, const char *peer, u_char uj)
           mp->ka_tx_cnt, mp->ka_rx_cnt);
       vty_outln (vty, "    SAs        : %10d %10d",
           mp->sa_tx_cnt, mp->sa_rx_cnt);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   }
 
@@ -6687,7 +6687,7 @@ ip_msdp_show_sa_entry_detail(struct pim_msdp_sa *sa, const char *src_str,
     vty_outln (vty, "  SPT Setup   : %s", spt_str);
     vty_outln (vty, "  Uptime      : %s", timebuf);
     vty_outln (vty, "  State Timer : %s", statetimer);
-    vty_outln (vty, "");
+    vty_out (vty, VTYNL);
   }
 }
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -173,9 +173,8 @@ static void pim_show_assert(struct vty *vty)
   
   now = pim_time_monotonic_sec();
 
-  vty_out(vty,
-	  "Interface Address         Source          Group           State  Winner          Uptime   Timer%s",
-	  VTY_NEWLINE);
+  vty_outln (vty,
+	  "Interface Address         Source          Group           State  Winner          Uptime   Timer");
 
   for (ALL_LIST_ELEMENTS_RO(pim_ifchannel_list, ch_node, ch)) {
     char ch_src_str[INET_ADDRSTRLEN];
@@ -202,7 +201,7 @@ static void pim_show_assert(struct vty *vty)
     pim_time_timer_to_mmss(timer, sizeof(timer),
 			   ch->t_ifassert_timer);
 
-    vty_out(vty, "%-9s %-15s %-15s %-15s %-6s %-15s %-8s %-5s%s",
+    vty_outln (vty, "%-9s %-15s %-15s %-15s %-6s %-15s %-8s %-5s",
 	    ch->interface->name,
 	    inet_ntoa(ifaddr),
 	    ch_src_str,
@@ -210,8 +209,7 @@ static void pim_show_assert(struct vty *vty)
 	    pim_ifchannel_ifassert_name(ch->ifassert_state),
 	    winner_str,
 	    uptime,
-	    timer,
-	    VTY_NEWLINE);
+	    timer);
   } /* scan interface channels */
 }
 
@@ -222,16 +220,15 @@ static void pim_show_assert_internal(struct vty *vty)
   struct pim_ifchannel *ch;
   struct in_addr ifaddr;
 
-  vty_out(vty,
+  vty_outln (vty,
 	  "CA:   CouldAssert%s"
 	  "ECA:  Evaluate CouldAssert%s"
 	  "ATD:  AssertTrackingDesired%s"
-	  "eATD: Evaluate AssertTrackingDesired%s%s",
-	  VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+	  "eATD: Evaluate AssertTrackingDesired%s",
+	  VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
 
-  vty_out(vty,
-	  "Interface Address         Source          Group           CA  eCA ATD eATD%s",
-	  VTY_NEWLINE);
+  vty_outln (vty,
+	  "Interface Address         Source          Group           CA  eCA ATD eATD");
 
   for (ALL_LIST_ELEMENTS_RO(pim_ifchannel_list, ch_node, ch)) {
     pim_ifp = ch->interface->info;
@@ -248,7 +245,7 @@ static void pim_show_assert_internal(struct vty *vty)
 		   ch_src_str, sizeof(ch_src_str));
     pim_inet4_dump("<ch_grp?>", ch->sg.grp,
 		   ch_grp_str, sizeof(ch_grp_str));
-    vty_out(vty, "%-9s %-15s %-15s %-15s %-3s %-3s %-3s %-4s%s",
+    vty_outln (vty, "%-9s %-15s %-15s %-15s %-3s %-3s %-3s %-4s",
 	    ch->interface->name,
 	    inet_ntoa(ifaddr),
 	    ch_src_str,
@@ -256,8 +253,7 @@ static void pim_show_assert_internal(struct vty *vty)
 	    PIM_IF_FLAG_TEST_COULD_ASSERT(ch->flags) ? "yes" : "no",
 	    pim_macro_ch_could_assert_eval(ch) ? "yes" : "no",
 	    PIM_IF_FLAG_TEST_ASSERT_TRACKING_DESIRED(ch->flags) ? "yes" : "no",
-	    pim_macro_assert_tracking_desired_eval(ch) ? "yes" : "no",
-	    VTY_NEWLINE);
+	    pim_macro_assert_tracking_desired_eval(ch) ? "yes" : "no");
   } /* scan interface channels */
 }
 
@@ -268,9 +264,8 @@ static void pim_show_assert_metric(struct vty *vty)
   struct pim_ifchannel *ch;
   struct in_addr ifaddr;
 
-  vty_out(vty,
-	  "Interface Address         Source          Group           RPT Pref Metric Address        %s",
-	  VTY_NEWLINE);
+  vty_outln (vty,
+	  "Interface Address         Source          Group           RPT Pref Metric Address        ");
 
   for (ALL_LIST_ELEMENTS_RO(pim_ifchannel_list, ch_node, ch)) {
     pim_ifp = ch->interface->info;
@@ -294,7 +289,7 @@ static void pim_show_assert_metric(struct vty *vty)
     pim_inet4_dump("<addr?>", am.ip_address,
 		   addr_str, sizeof(addr_str));
 
-    vty_out(vty, "%-9s %-15s %-15s %-15s %-3s %4u %6u %-15s%s",
+    vty_outln (vty, "%-9s %-15s %-15s %-15s %-3s %4u %6u %-15s",
 	    ch->interface->name,
 	    inet_ntoa(ifaddr),
 	    ch_src_str,
@@ -302,8 +297,7 @@ static void pim_show_assert_metric(struct vty *vty)
 	    am.rpt_bit_flag ? "yes" : "no",
 	    am.metric_preference,
 	    am.route_metric,
-	    addr_str,
-	    VTY_NEWLINE);
+	    addr_str);
     } /* scan interface channels */
 }
 
@@ -314,9 +308,8 @@ static void pim_show_assert_winner_metric(struct vty *vty)
   struct pim_ifchannel *ch;
   struct in_addr ifaddr;
   
-  vty_out(vty,
-	  "Interface Address         Source          Group           RPT Pref Metric Address        %s",
-	  VTY_NEWLINE);
+  vty_outln (vty,
+	  "Interface Address         Source          Group           RPT Pref Metric Address        ");
 
   for (ALL_LIST_ELEMENTS_RO(pim_ifchannel_list, ch_node, ch)) {
     pim_ifp = ch->interface->info;
@@ -352,7 +345,7 @@ static void pim_show_assert_winner_metric(struct vty *vty)
     else
       snprintf(metr_str, sizeof(metr_str), "%6u", am->route_metric);
 
-    vty_out(vty, "%-9s %-15s %-15s %-15s %-3s %-4s %-6s %-15s%s",
+    vty_outln (vty, "%-9s %-15s %-15s %-15s %-3s %-4s %-6s %-15s",
 	    ch->interface->name,
 	    inet_ntoa(ifaddr),
 	    ch_src_str,
@@ -360,8 +353,7 @@ static void pim_show_assert_winner_metric(struct vty *vty)
 	    am->rpt_bit_flag ? "yes" : "no",
 	    pref_str,
 	    metr_str,
-	    addr_str,
-	    VTY_NEWLINE);
+	    addr_str);
   } /* scan interface channels */
 }
 
@@ -439,11 +431,11 @@ static void pim_show_membership(struct vty *vty, u_char uj)
   } /* scan interface channels */
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
   } else {
-    vty_out(vty,
-            "Interface  Address          Source           Group            Membership%s",
-            VTY_NEWLINE);
+    vty_outln (vty,
+            "Interface  Address          Source           Group            Membership");
 
     /*
      * Example of the json data we are traversing
@@ -488,7 +480,7 @@ static void pim_show_membership(struct vty *vty, u_char uj)
           vty_out(vty, "%-15s  ", if_field_key);
 
           json_object_object_get_ex(if_field_val, "localMembership", &json_tmp);
-          vty_out(vty, "%-10s%s", json_object_get_string(json_tmp), VTY_NEWLINE);
+          vty_outln (vty, "%-10s", json_object_get_string(json_tmp));
         }
       }
     }
@@ -499,17 +491,22 @@ static void pim_show_membership(struct vty *vty, u_char uj)
 
 static void pim_print_ifp_flags(struct vty *vty, struct interface *ifp, int mloop)
 {
-  vty_out(vty, "Flags%s", VTY_NEWLINE);
-  vty_out(vty, "-----%s", VTY_NEWLINE);
-  vty_out(vty, "All Multicast   : %s%s", (ifp->flags & IFF_ALLMULTI) ? "yes" : "no", VTY_NEWLINE);
-  vty_out(vty, "Broadcast       : %s%s", if_is_broadcast(ifp)? "yes" : "no", VTY_NEWLINE);
-  vty_out(vty, "Deleted         : %s%s", PIM_IF_IS_DELETED(ifp) ? "yes" : "no", VTY_NEWLINE);
-  vty_out(vty, "Interface Index : %d%s", ifp->ifindex, VTY_NEWLINE);
-  vty_out(vty, "Multicast       : %s%s", if_is_multicast(ifp) ? "yes" : "no", VTY_NEWLINE);
-  vty_out(vty, "Multicast Loop  : %d%s", mloop, VTY_NEWLINE);
-  vty_out(vty, "Promiscuous     : %s%s", (ifp->flags & IFF_PROMISC) ? "yes" : "no", VTY_NEWLINE);
-  vty_out(vty, "%s", VTY_NEWLINE);
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "Flags");
+  vty_outln (vty, "-----");
+  vty_outln (vty, "All Multicast   : %s",
+            (ifp->flags & IFF_ALLMULTI) ? "yes" : "no");
+  vty_outln (vty, "Broadcast       : %s",
+            if_is_broadcast(ifp) ? "yes" : "no");
+  vty_outln (vty, "Deleted         : %s",
+            PIM_IF_IS_DELETED(ifp) ? "yes" : "no");
+  vty_outln (vty, "Interface Index : %d", ifp->ifindex);
+  vty_outln (vty, "Multicast       : %s",
+            if_is_multicast(ifp) ? "yes" : "no");
+  vty_outln (vty, "Multicast Loop  : %d", mloop);
+  vty_outln (vty, "Promiscuous     : %s",
+            (ifp->flags & IFF_PROMISC) ? "yes" : "no");
+  vty_outln (vty, "");
+  vty_outln (vty, "");
 }
 
 static void igmp_show_interfaces(struct vty *vty, u_char uj)
@@ -525,9 +522,8 @@ static void igmp_show_interfaces(struct vty *vty, u_char uj)
   if (uj)
     json = json_object_new_object();
   else
-    vty_out(vty,
-            "Interface  State          Address  V  Querier  Query Timer    Uptime%s",
-            VTY_NEWLINE);
+    vty_outln (vty,
+            "Interface  State          Address  V  Querier  Query Timer    Uptime");
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp)) {
     struct pim_interface *pim_ifp;
@@ -560,21 +556,21 @@ static void igmp_show_interfaces(struct vty *vty, u_char uj)
         json_object_object_add(json, ifp->name, json_row);
 
       } else {
-        vty_out(vty, "%-9s  %5s  %15s  %d  %7s  %11s  %8s%s",
+        vty_outln (vty, "%-9s  %5s  %15s  %d  %7s  %11s  %8s",
                 ifp->name,
                 if_is_up(ifp) ? "up" : "down",
                 inet_ntoa(igmp->ifaddr),
                 pim_ifp->igmp_version,
 	        igmp->t_igmp_query_timer ? "local" : "other",
 	        query_hhmmss,
-                uptime,
-                VTY_NEWLINE);
+                uptime);
       }
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -663,35 +659,44 @@ static void igmp_show_interfaces_single(struct vty *vty, const char *ifname, u_c
         json_object_object_add(json, ifp->name, json_row);
 
       } else {
-        vty_out(vty, "Interface : %s%s", ifp->name, VTY_NEWLINE);
-        vty_out(vty, "State     : %s%s", if_is_up(ifp) ? "up" : "down", VTY_NEWLINE);
-        vty_out(vty, "Address   : %s%s", inet_ntoa(pim_ifp->primary_address), VTY_NEWLINE);
-        vty_out(vty, "Uptime    : %s%s", uptime, VTY_NEWLINE);
-        vty_out(vty, "Version   : %d%s", pim_ifp->igmp_version, VTY_NEWLINE);
-        vty_out(vty, "%s", VTY_NEWLINE);
-        vty_out(vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "Interface : %s", ifp->name);
+        vty_outln (vty, "State     : %s", if_is_up(ifp) ? "up" : "down");
+        vty_outln (vty, "Address   : %s",
+                  inet_ntoa(pim_ifp->primary_address));
+        vty_outln (vty, "Uptime    : %s", uptime);
+        vty_outln (vty, "Version   : %d", pim_ifp->igmp_version);
+        vty_outln (vty, "");
+        vty_outln (vty, "");
 
-        vty_out(vty, "Querier%s", VTY_NEWLINE);
-        vty_out(vty, "-------%s", VTY_NEWLINE);
-        vty_out(vty, "Querier     : %s%s", igmp->t_igmp_query_timer ? "local" : "other", VTY_NEWLINE);
-        vty_out(vty, "Start Count : %d%s", igmp->startup_query_count, VTY_NEWLINE);
-        vty_out(vty, "Query Timer : %s%s", query_hhmmss, VTY_NEWLINE);
-        vty_out(vty, "Other Timer : %s%s", other_hhmmss, VTY_NEWLINE);
-        vty_out(vty, "%s", VTY_NEWLINE);
-        vty_out(vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "Querier");
+        vty_outln (vty, "-------");
+        vty_outln (vty, "Querier     : %s",
+                  igmp->t_igmp_query_timer ? "local" : "other");
+        vty_outln (vty, "Start Count : %d", igmp->startup_query_count);
+        vty_outln (vty, "Query Timer : %s", query_hhmmss);
+        vty_outln (vty, "Other Timer : %s", other_hhmmss);
+        vty_outln (vty, "");
+        vty_outln (vty, "");
 
-        vty_out(vty, "Timers%s", VTY_NEWLINE);
-        vty_out(vty, "------%s", VTY_NEWLINE);
-        vty_out(vty, "Group Membership Interval      : %lis%s", gmi_msec/1000, VTY_NEWLINE);
-        vty_out(vty, "Last Member Query Time         : %lis%s", lmqt_msec/1000, VTY_NEWLINE);
-        vty_out(vty, "Older Host Present Interval    : %lis%s", ohpi_msec/1000, VTY_NEWLINE);
-        vty_out(vty, "Other Querier Present Interval : %lis%s", oqpi_msec/1000, VTY_NEWLINE);
-        vty_out(vty, "Query Interval                 : %ds%s", igmp->querier_query_interval, VTY_NEWLINE);
-        vty_out(vty, "Query Response Interval        : %lis%s", qri_msec/1000, VTY_NEWLINE);
-        vty_out(vty, "Robustness Variable            : %d%s", igmp->querier_robustness_variable, VTY_NEWLINE);
-        vty_out(vty, "Startup Query Interval         : %ds%s", sqi, VTY_NEWLINE);
-        vty_out(vty, "%s", VTY_NEWLINE);
-        vty_out(vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "Timers");
+        vty_outln (vty, "------");
+        vty_outln (vty, "Group Membership Interval      : %lis",
+                  gmi_msec / 1000);
+        vty_outln (vty, "Last Member Query Time         : %lis",
+                  lmqt_msec / 1000);
+        vty_outln (vty, "Older Host Present Interval    : %lis",
+                  ohpi_msec / 1000);
+        vty_outln (vty, "Other Querier Present Interval : %lis",
+                  oqpi_msec / 1000);
+        vty_outln (vty, "Query Interval                 : %ds",
+                  igmp->querier_query_interval);
+        vty_outln (vty, "Query Response Interval        : %lis",
+                  qri_msec / 1000);
+        vty_outln (vty, "Robustness Variable            : %d",
+                  igmp->querier_robustness_variable);
+        vty_outln (vty, "Startup Query Interval         : %ds", sqi);
+        vty_outln (vty, "");
+        vty_outln (vty, "");
 
         pim_print_ifp_flags(vty, ifp, mloop);
       }
@@ -699,11 +704,12 @@ static void igmp_show_interfaces_single(struct vty *vty, const char *ifname, u_c
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   } else {
     if (!found_ifname)
-      vty_out (vty, "%% No such interface%s", VTY_NEWLINE);
+      vty_outln (vty, "%% No such interface");
   }
 }
 
@@ -715,9 +721,8 @@ static void igmp_show_interface_join(struct vty *vty)
   
   now = pim_time_monotonic_sec();
 
-  vty_out(vty,
-	  "Interface Address         Source          Group           Socket Uptime  %s",
-	  VTY_NEWLINE);
+  vty_outln (vty,
+	  "Interface Address         Source          Group           Socket Uptime  ");
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp)) {
     struct pim_interface *pim_ifp;
@@ -746,14 +751,13 @@ static void igmp_show_interface_join(struct vty *vty)
       pim_inet4_dump("<grp?>", ij->group_addr, group_str, sizeof(group_str));
       pim_inet4_dump("<src?>", ij->source_addr, source_str, sizeof(source_str));
       
-      vty_out(vty, "%-9s %-15s %-15s %-15s %6d %8s%s",
+      vty_outln (vty, "%-9s %-15s %-15s %-15s %6d %8s",
 	      ifp->name,
 	      pri_addr_str,
 	      source_str,
 	      group_str,
 	      ij->sock_fd,
-	      uptime,
-	      VTY_NEWLINE);
+	      uptime);
     } /* for (pim_ifp->igmp_join_list) */
 
   } /* for (iflist) */
@@ -921,25 +925,23 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
       json_object_object_add(json, ifp->name, json_row);
 
     } else {
-      vty_out(vty, "Interface  : %s%s", ifp->name, VTY_NEWLINE);
-      vty_out(vty, "State      : %s%s", if_is_up(ifp) ? "up" : "down", VTY_NEWLINE);
+      vty_outln (vty, "Interface  : %s", ifp->name);
+      vty_outln (vty, "State      : %s", if_is_up(ifp) ? "up" : "down");
       if (pim_ifp->update_source.s_addr != INADDR_ANY) {
-        vty_out(vty, "Use Source : %s%s", inet_ntoa(pim_ifp->update_source), VTY_NEWLINE);
+        vty_outln (vty, "Use Source : %s", inet_ntoa(pim_ifp->update_source));
       }
       if (pim_ifp->sec_addr_list) {
         char pbuf[PREFIX2STR_BUFFER];
-        vty_out(vty, "Address    : %s (primary)%s",
-                inet_ntoa(ifaddr), VTY_NEWLINE);
+        vty_outln (vty, "Address    : %s (primary)",
+                inet_ntoa(ifaddr));
         for (ALL_LIST_ELEMENTS_RO(pim_ifp->sec_addr_list, sec_node, sec_addr)) {
-          vty_out(vty, "             %s%s",
-                  prefix2str(&sec_addr->addr,
-			     pbuf,
-			     sizeof(pbuf)), VTY_NEWLINE);
+          vty_outln (vty, "             %s",
+                  prefix2str(&sec_addr->addr, pbuf, sizeof(pbuf)));
         }
       } else {
-        vty_out(vty, "Address    : %s%s", inet_ntoa(ifaddr), VTY_NEWLINE);
+        vty_outln (vty, "Address    : %s", inet_ntoa(ifaddr));
       }
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
 
       // PIM neighbors
       print_header = 1;
@@ -947,31 +949,32 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
       for (ALL_LIST_ELEMENTS_RO(pim_ifp->pim_neighbor_list, neighnode, neigh)) {
 
         if (print_header) {
-          vty_out(vty, "PIM Neighbors%s", VTY_NEWLINE);
-          vty_out(vty, "-------------%s", VTY_NEWLINE);
+          vty_outln (vty, "PIM Neighbors");
+          vty_outln (vty, "-------------");
           print_header = 0;
         }
 
         pim_inet4_dump("<src?>", neigh->source_addr, neigh_src_str, sizeof(neigh_src_str));
         pim_time_uptime(uptime, sizeof(uptime), now - neigh->creation);
         pim_time_timer_to_hhmmss(expire, sizeof(expire), neigh->t_expire_timer);
-        vty_out(vty, "%-15s : up for %s, holdtime expires in %s%s", neigh_src_str, uptime, expire, VTY_NEWLINE);
+        vty_outln (vty, "%-15s : up for %s, holdtime expires in %s", neigh_src_str, uptime,
+                  expire);
       }
 
       if (!print_header) {
-        vty_out(vty, "%s", VTY_NEWLINE);
-        vty_out(vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "");
+        vty_outln (vty, "");
       }
 
-      vty_out(vty, "Designated Router%s", VTY_NEWLINE);
-      vty_out(vty, "-----------------%s", VTY_NEWLINE);
-      vty_out(vty, "Address   : %s%s", dr_str, VTY_NEWLINE);
-      vty_out(vty, "Priority  : %d%s", pim_ifp->pim_dr_priority, VTY_NEWLINE);
-      vty_out(vty, "Uptime    : %s%s", dr_uptime, VTY_NEWLINE);
-      vty_out(vty, "Elections : %d%s", pim_ifp->pim_dr_election_count, VTY_NEWLINE);
-      vty_out(vty, "Changes   : %d%s", pim_ifp->pim_dr_election_changes, VTY_NEWLINE);
-      vty_out(vty, "%s", VTY_NEWLINE);
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "Designated Router");
+      vty_outln (vty, "-----------------");
+      vty_outln (vty, "Address   : %s", dr_str);
+      vty_outln (vty, "Priority  : %d", pim_ifp->pim_dr_priority);
+      vty_outln (vty, "Uptime    : %s", dr_uptime);
+      vty_outln (vty, "Elections : %d", pim_ifp->pim_dr_election_count);
+      vty_outln (vty, "Changes   : %d", pim_ifp->pim_dr_election_changes);
+      vty_outln (vty, "");
+      vty_outln (vty, "");
 
       // FHR
       print_header = 1;
@@ -980,65 +983,77 @@ static void pim_show_interfaces_single(struct vty *vty, const char *ifname, u_ch
           if (up->flags & PIM_UPSTREAM_FLAG_MASK_FHR) {
 
             if (print_header) {
-              vty_out(vty, "FHR - First Hop Router%s", VTY_NEWLINE);
-              vty_out(vty, "----------------------%s", VTY_NEWLINE);
+              vty_outln (vty, "FHR - First Hop Router");
+              vty_outln (vty, "----------------------");
               print_header = 0;
             }
 
             pim_inet4_dump("<src?>", up->sg.src, src_str, sizeof(src_str));
             pim_inet4_dump("<grp?>", up->sg.grp, grp_str, sizeof(grp_str));
             pim_time_uptime(uptime, sizeof(uptime), now - up->state_transition);
-            vty_out(vty, "%s : %s is a source, uptime is %s%s", grp_str, src_str, uptime, VTY_NEWLINE);
+            vty_outln (vty, "%s : %s is a source, uptime is %s", grp_str, src_str,
+                      uptime);
           }
         }
       }
 
       if (!print_header) {
-        vty_out(vty, "%s", VTY_NEWLINE);
-        vty_out(vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "");
+        vty_outln (vty, "");
       }
 
-      vty_out(vty, "Hellos%s", VTY_NEWLINE);
-      vty_out(vty, "------%s", VTY_NEWLINE);
-      vty_out(vty, "Period         : %d%s", pim_ifp->pim_hello_period, VTY_NEWLINE);
-      vty_out(vty, "Timer          : %s%s", hello_timer, VTY_NEWLINE);
-      vty_out(vty, "StatStart      : %s%s", stat_uptime, VTY_NEWLINE);
-      vty_out(vty, "Receive        : %d%s", pim_ifp->pim_ifstat_hello_recv, VTY_NEWLINE);
-      vty_out(vty, "Receive Failed : %d%s", pim_ifp->pim_ifstat_hello_recvfail, VTY_NEWLINE);
-      vty_out(vty, "Send           : %d%s", pim_ifp->pim_ifstat_hello_sent, VTY_NEWLINE);
-      vty_out(vty, "Send Failed    : %d%s", pim_ifp->pim_ifstat_hello_sendfail, VTY_NEWLINE);
-      vty_out(vty, "Generation ID  : %08x%s", pim_ifp->pim_generation_id, VTY_NEWLINE);
-      vty_out(vty, "%s", VTY_NEWLINE);
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "Hellos");
+      vty_outln (vty, "------");
+      vty_outln (vty, "Period         : %d", pim_ifp->pim_hello_period);
+      vty_outln (vty, "Timer          : %s", hello_timer);
+      vty_outln (vty, "StatStart      : %s", stat_uptime);
+      vty_outln (vty, "Receive        : %d", pim_ifp->pim_ifstat_hello_recv);
+      vty_outln (vty, "Receive Failed : %d",
+                pim_ifp->pim_ifstat_hello_recvfail);
+      vty_outln (vty, "Send           : %d", pim_ifp->pim_ifstat_hello_sent);
+      vty_outln (vty, "Send Failed    : %d",
+                pim_ifp->pim_ifstat_hello_sendfail);
+      vty_outln (vty, "Generation ID  : %08x", pim_ifp->pim_generation_id);
+      vty_outln (vty, "");
+      vty_outln (vty, "");
 
       pim_print_ifp_flags(vty, ifp, mloop);
 
-      vty_out(vty, "Join Prune Interval%s", VTY_NEWLINE);
-      vty_out(vty, "-------------------%s", VTY_NEWLINE);
-      vty_out(vty, "LAN Delay                    : %s%s", pim_if_lan_delay_enabled(ifp) ? "yes" : "no", VTY_NEWLINE);
-      vty_out(vty, "Effective Propagation Delay  : %d msec%s", pim_if_effective_propagation_delay_msec(ifp), VTY_NEWLINE);
-      vty_out(vty, "Effective Override Interval  : %d msec%s", pim_if_effective_override_interval_msec(ifp), VTY_NEWLINE);
-      vty_out(vty, "Join Prune Override Interval : %d msec%s", pim_if_jp_override_interval_msec(ifp), VTY_NEWLINE);
-      vty_out(vty, "%s", VTY_NEWLINE);
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "Join Prune Interval");
+      vty_outln (vty, "-------------------");
+      vty_outln (vty, "LAN Delay                    : %s",
+                pim_if_lan_delay_enabled(ifp) ? "yes" : "no");
+      vty_outln (vty, "Effective Propagation Delay  : %d msec",
+                pim_if_effective_propagation_delay_msec(ifp));
+      vty_outln (vty, "Effective Override Interval  : %d msec",
+                pim_if_effective_override_interval_msec(ifp));
+      vty_outln (vty, "Join Prune Override Interval : %d msec",
+                pim_if_jp_override_interval_msec(ifp));
+      vty_outln (vty, "");
+      vty_outln (vty, "");
 
-      vty_out(vty, "LAN Prune Delay%s", VTY_NEWLINE);
-      vty_out(vty, "---------------%s", VTY_NEWLINE);
-      vty_out(vty, "Propagation Delay           : %d msec%s", pim_ifp->pim_propagation_delay_msec, VTY_NEWLINE);
-      vty_out(vty, "Propagation Delay (Highest) : %d msec%s", pim_ifp->pim_neighbors_highest_propagation_delay_msec, VTY_NEWLINE);
-      vty_out(vty, "Override Interval           : %d msec%s", pim_ifp->pim_override_interval_msec, VTY_NEWLINE);
-      vty_out(vty, "Override Interval (Highest) : %d msec%s", pim_ifp->pim_neighbors_highest_override_interval_msec, VTY_NEWLINE);
-      vty_out(vty, "%s", VTY_NEWLINE);
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "LAN Prune Delay");
+      vty_outln (vty, "---------------");
+      vty_outln (vty, "Propagation Delay           : %d msec",
+                pim_ifp->pim_propagation_delay_msec);
+      vty_outln (vty, "Propagation Delay (Highest) : %d msec",
+                pim_ifp->pim_neighbors_highest_propagation_delay_msec);
+      vty_outln (vty, "Override Interval           : %d msec",
+                pim_ifp->pim_override_interval_msec);
+      vty_outln (vty, "Override Interval (Highest) : %d msec",
+                pim_ifp->pim_neighbors_highest_override_interval_msec);
+      vty_outln (vty, "");
+      vty_outln (vty, "");
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   } else {
     if (!found_ifname)
-      vty_out (vty, "%% No such interface%s", VTY_NEWLINE);
+      vty_outln (vty, "%% No such interface");
   }
 }
 
@@ -1090,9 +1105,11 @@ static void pim_show_interfaces(struct vty *vty, u_char uj)
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
   } else {
-    vty_out(vty, "Interface  State          Address  PIM Nbrs           PIM DR  FHR IfChannels%s", VTY_NEWLINE);
+    vty_outln (vty,
+              "Interface  State          Address  PIM Nbrs           PIM DR  FHR IfChannels");
 
     json_object_object_foreach(json, key, val) {
       vty_out(vty, "%-9s  ", key);
@@ -1117,7 +1134,7 @@ static void pim_show_interfaces(struct vty *vty, u_char uj)
       vty_out(vty, "%3d  ", json_object_get_int(json_tmp));
 
       json_object_object_get_ex(val, "pimIfChannels", &json_tmp);
-      vty_out(vty, "%9d%s", json_object_get_int(json_tmp), VTY_NEWLINE);
+      vty_outln (vty, "%9d", json_object_get_int(json_tmp));
     }
   }
 
@@ -1136,17 +1153,16 @@ static void pim_show_interface_traffic (struct vty *vty, u_char uj)
     json = json_object_new_object ();
   else
     {
-      vty_out (vty, "%s", VTY_NEWLINE);
-      vty_out (vty, "%-12s%-17s%-17s%-17s%-17s%-17s%-17s%s", "Interface",
+      vty_outln (vty, "");
+      vty_outln (vty, "%-12s%-17s%-17s%-17s%-17s%-17s%-17s", "Interface",
                "    HELLO", "    JOIN", "   PRUNE", "   REGISTER",
-               "  REGISTER-STOP", "  ASSERT", VTY_NEWLINE);
-      vty_out (vty,
-               "%-10s%-18s%-17s%-17s%-17s%-17s%-17s%s",
+               "  REGISTER-STOP", "  ASSERT");
+      vty_outln (vty,
+               "%-10s%-18s%-17s%-17s%-17s%-17s%-17s",
                "", "      Rx/Tx", "     Rx/Tx", "    Rx/Tx", "    Rx/Tx",
-               "     Rx/Tx", "    Rx/Tx", VTY_NEWLINE);
-      vty_out (vty,
-           "---------------------------------------------------------------------------------------------------------------%s",
-           VTY_NEWLINE);
+               "     Rx/Tx", "    Rx/Tx");
+      vty_outln (vty,
+           "---------------------------------------------------------------------------------------------------------------");
     }
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp))
@@ -1177,8 +1193,8 @@ static void pim_show_interface_traffic (struct vty *vty, u_char uj)
         }
       else
         {
-          vty_out (vty,
-               "%-10s %8u/%-8u %7u/%-7u %7u/%-7u %7u/%-7u %7u/%-7u %7u/%-7u %s",
+          vty_outln (vty,
+               "%-10s %8u/%-8u %7u/%-7u %7u/%-7u %7u/%-7u %7u/%-7u %7u/%-7u ",
                ifp->name, pim_ifp->pim_ifstat_hello_recv,
                pim_ifp->pim_ifstat_hello_sent, pim_ifp->pim_ifstat_join_recv,
                pim_ifp->pim_ifstat_join_send, pim_ifp->pim_ifstat_prune_recv,
@@ -1187,12 +1203,13 @@ static void pim_show_interface_traffic (struct vty *vty, u_char uj)
                pim_ifp->pim_ifstat_reg_stop_recv,
                pim_ifp->pim_ifstat_reg_stop_send,
                pim_ifp->pim_ifstat_assert_recv,
-               pim_ifp->pim_ifstat_assert_send, VTY_NEWLINE);
+               pim_ifp->pim_ifstat_assert_send);
         }
     }
   if (uj)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext (json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free (json);
     }
 }
@@ -1210,17 +1227,16 @@ static void pim_show_interface_traffic_single (struct vty *vty, const char *ifna
     json = json_object_new_object ();
   else
     {
-      vty_out (vty, "%s", VTY_NEWLINE);
-      vty_out (vty, "%-12s%-17s%-17s%-17s%-17s%-17s%-17s%s", "Interface",
+      vty_outln (vty, "");
+      vty_outln (vty, "%-12s%-17s%-17s%-17s%-17s%-17s%-17s", "Interface",
                "    HELLO", "    JOIN", "   PRUNE", "   REGISTER",
-               "  REGISTER-STOP", "  ASSERT", VTY_NEWLINE);
-      vty_out (vty,
-               "%-10s%-18s%-17s%-17s%-17s%-17s%-17s%s",
+               "  REGISTER-STOP", "  ASSERT");
+      vty_outln (vty,
+               "%-10s%-18s%-17s%-17s%-17s%-17s%-17s",
                "", "      Rx/Tx", "     Rx/Tx", "    Rx/Tx", "    Rx/Tx",
-               "     Rx/Tx", "    Rx/Tx", VTY_NEWLINE);
-      vty_out (vty,
-           "---------------------------------------------------------------------------------------------------------------%s",
-           VTY_NEWLINE);
+               "     Rx/Tx", "    Rx/Tx");
+      vty_outln (vty,
+           "---------------------------------------------------------------------------------------------------------------");
     }
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp))
@@ -1256,8 +1272,8 @@ static void pim_show_interface_traffic_single (struct vty *vty, const char *ifna
         }
       else
         {
-          vty_out (vty,
-               "%-10s %8u/%-8u %7u/%-7u %7u/%-7u %7u/%-7u %7u/%-7u %7u/%-7u %s",
+          vty_outln (vty,
+               "%-10s %8u/%-8u %7u/%-7u %7u/%-7u %7u/%-7u %7u/%-7u %7u/%-7u ",
                ifp->name, pim_ifp->pim_ifstat_hello_recv,
                pim_ifp->pim_ifstat_hello_sent, pim_ifp->pim_ifstat_join_recv,
                pim_ifp->pim_ifstat_join_send, pim_ifp->pim_ifstat_prune_recv,
@@ -1266,18 +1282,19 @@ static void pim_show_interface_traffic_single (struct vty *vty, const char *ifna
                pim_ifp->pim_ifstat_reg_stop_recv,
                pim_ifp->pim_ifstat_reg_stop_send,
                pim_ifp->pim_ifstat_assert_recv,
-               pim_ifp->pim_ifstat_assert_send, VTY_NEWLINE);
+               pim_ifp->pim_ifstat_assert_send);
         }
     }
   if (uj)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext (json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free (json);
     }
   else
     {
       if (!found_ifname)
-        vty_out (vty, "%% No such interface%s", VTY_NEWLINE);
+        vty_outln (vty, "%% No such interface");
     }
 }
 
@@ -1298,9 +1315,8 @@ static void pim_show_join(struct vty *vty, u_char uj)
   if (uj)
     json = json_object_new_object();
   else
-    vty_out(vty,
-            "Interface Address         Source          Group           State  Uptime   Expire Prune%s",
-            VTY_NEWLINE);
+    vty_outln (vty,
+            "Interface Address         Source          Group           State  Uptime   Expire Prune");
 
   for (ALL_LIST_ELEMENTS_RO(pim_ifchannel_list, ch_node, ch)) {
 
@@ -1358,7 +1374,7 @@ static void pim_show_join(struct vty *vty, u_char uj)
       else
         json_object_object_add(json_grp, ch_src_str, json_row);
     } else {
-      vty_out(vty, "%-9s %-15s %-15s %-15s %-6s %8s %-6s %5s%s",
+      vty_outln (vty, "%-9s %-15s %-15s %-15s %-6s %8s %-6s %5s",
 	      ch->interface->name,
 	      inet_ntoa(ifaddr),
 	      ch_src_str,
@@ -1366,13 +1382,13 @@ static void pim_show_join(struct vty *vty, u_char uj)
 	      pim_ifchannel_ifjoin_name(ch->ifjoin_state, ch->flags),
 	      uptime,
 	      expire,
-	      prune,
-	      VTY_NEWLINE);
+	      prune);
     }
   } /* scan interface channels */
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -1496,33 +1512,44 @@ static void pim_show_neighbors_single(struct vty *vty, const char *neighbor, u_c
         json_object_object_add(json_ifp, neigh_src_str, json_row);
 
       } else {
-        vty_out(vty, "Interface : %s%s", ifp->name, VTY_NEWLINE);
-        vty_out(vty, "Neighbor  : %s%s", neigh_src_str, VTY_NEWLINE);
-        vty_out(vty, "    Uptime                         : %s%s", uptime, VTY_NEWLINE);
-        vty_out(vty, "    Holdtime                       : %s%s", expire, VTY_NEWLINE);
-        vty_out(vty, "    DR Priority                    : %d%s", neigh->dr_priority, VTY_NEWLINE);
-        vty_out(vty, "    Generation ID                  : %08x%s", neigh->generation_id, VTY_NEWLINE);
-        vty_out(vty, "    Override Interval (msec)       : %d%s", neigh->override_interval_msec, VTY_NEWLINE);
-        vty_out(vty, "    Propagation Delay (msec)       : %d%s", neigh->propagation_delay_msec, VTY_NEWLINE);
-        vty_out(vty, "    Hello Option - Address List    : %s%s", option_address_list ? "yes" : "no", VTY_NEWLINE);
-        vty_out(vty, "    Hello Option - DR Priority     : %s%s", option_dr_priority ? "yes" : "no", VTY_NEWLINE);
-        vty_out(vty, "    Hello Option - Generation ID   : %s%s", option_generation_id? "yes" : "no", VTY_NEWLINE);
-        vty_out(vty, "    Hello Option - Holdtime        : %s%s", option_holdtime ? "yes" : "no", VTY_NEWLINE);
-        vty_out(vty, "    Hello Option - LAN Prune Delay : %s%s", option_lan_prune_delay ? "yes" : "no", VTY_NEWLINE);
-        vty_out(vty, "    Hello Option - T-bit           : %s%s", option_t_bit ? "yes" : "no", VTY_NEWLINE);
+        vty_outln (vty, "Interface : %s", ifp->name);
+        vty_outln (vty, "Neighbor  : %s", neigh_src_str);
+        vty_outln (vty, "    Uptime                         : %s", uptime);
+        vty_outln (vty, "    Holdtime                       : %s", expire);
+        vty_outln (vty, "    DR Priority                    : %d",
+                  neigh->dr_priority);
+        vty_outln (vty, "    Generation ID                  : %08x",
+                  neigh->generation_id);
+        vty_outln (vty, "    Override Interval (msec)       : %d",
+                  neigh->override_interval_msec);
+        vty_outln (vty, "    Propagation Delay (msec)       : %d",
+                  neigh->propagation_delay_msec);
+        vty_outln (vty, "    Hello Option - Address List    : %s",
+                  option_address_list ? "yes" : "no");
+        vty_outln (vty, "    Hello Option - DR Priority     : %s",
+                  option_dr_priority ? "yes" : "no");
+        vty_outln (vty, "    Hello Option - Generation ID   : %s",
+                  option_generation_id ? "yes" : "no");
+        vty_outln (vty, "    Hello Option - Holdtime        : %s",
+                  option_holdtime ? "yes" : "no");
+        vty_outln (vty, "    Hello Option - LAN Prune Delay : %s",
+                  option_lan_prune_delay ? "yes" : "no");
+        vty_outln (vty, "    Hello Option - T-bit           : %s",
+                  option_t_bit ? "yes" : "no");
         pim_bfd_show_info (vty, neigh->bfd_info, json_ifp, uj, 0);
-        vty_out(vty, "%s", VTY_NEWLINE);
+        vty_outln (vty, "");
       }
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   } else {
     {
       if (!found_neighbor)
-        vty_out (vty, "%% No such interface or neighbor%s", VTY_NEWLINE);
+        vty_outln (vty, "%% No such interface or neighbor");
     }
   }
 }
@@ -1545,7 +1572,8 @@ pim_show_state(struct vty *vty, const char *src_or_group, const char *group, u_c
     json = json_object_new_object();
   } else {
     vty_out(vty, "Codes: J -> Pim Join, I -> IGMP Report, S -> Source, * -> Inherited from (*,G)");
-    vty_out(vty, "%sInstalled Source           Group            IIF      OIL%s", VTY_NEWLINE, VTY_NEWLINE);
+    vty_outln (vty, "%sInstalled Source           Group            IIF      OIL",
+              VTY_NEWLINE);
   }
 
   for (ALL_LIST_ELEMENTS_RO(pim_channel_oil_list, node, c_oil)) {
@@ -1662,15 +1690,16 @@ pim_show_state(struct vty *vty, const char *src_or_group, const char *group, u_c
     }
 
     if (!uj)
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
   }
 
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   } else {
-    vty_out(vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "");
   }
 }
 
@@ -1694,7 +1723,7 @@ static void pim_show_neighbors(struct vty *vty, u_char uj)
   if (uj) {
     json = json_object_new_object();
   } else {
-    vty_out(vty, "Interface         Neighbor    Uptime  Holdtime  DR Pri%s", VTY_NEWLINE);
+    vty_outln (vty, "Interface         Neighbor    Uptime  Holdtime  DR Pri");
   }
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp)) {
@@ -1726,13 +1755,12 @@ static void pim_show_neighbors(struct vty *vty, u_char uj)
         json_object_object_add(json_ifp_rows, neigh_src_str, json_row);
 
       } else {
-        vty_out(vty, "%-9s  %15s  %8s  %8s  %6d%s",
+        vty_outln (vty, "%-9s  %15s  %8s  %8s  %6d",
                 ifp->name,
                 neigh_src_str,
                 uptime,
                 expire,
-                neigh->dr_priority,
-                VTY_NEWLINE);
+                neigh->dr_priority);
       }
     }
 
@@ -1743,7 +1771,8 @@ static void pim_show_neighbors(struct vty *vty, u_char uj)
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -1753,7 +1782,8 @@ static void pim_show_neighbors_secondary(struct vty *vty)
   struct listnode  *node;
   struct interface *ifp;
 
-  vty_out(vty, "Interface Address         Neighbor        Secondary      %s", VTY_NEWLINE);
+  vty_outln (vty,
+            "Interface Address         Neighbor        Secondary      ");
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp)) {
     struct pim_interface *pim_ifp;
@@ -1787,12 +1817,11 @@ static void pim_show_neighbors_secondary(struct vty *vty)
 
 	prefix2str(p, neigh_sec_str, sizeof(neigh_sec_str));
 
-	vty_out(vty, "%-9s %-15s %-15s %-15s%s",
+	vty_outln (vty, "%-9s %-15s %-15s %-15s",
 		ifp->name,
 		inet_ntoa(ifaddr),
 		neigh_src_str,
-		neigh_sec_str,
-		VTY_NEWLINE);
+		neigh_sec_str);
       }
     }
   }
@@ -1876,7 +1905,8 @@ static void pim_show_upstream(struct vty *vty, u_char uj)
   if (uj)
     json = json_object_new_object();
   else
-    vty_out(vty, "Iif       Source          Group           State       Uptime   JoinTimer RSTimer   KATimer   RefCnt%s", VTY_NEWLINE);
+    vty_outln (vty,
+              "Iif       Source          Group           State       Uptime   JoinTimer RSTimer   KATimer   RefCnt");
 
   for (ALL_LIST_ELEMENTS_RO(pim_upstream_list, upnode, up)) {
     char src_str[INET_ADDRSTRLEN];
@@ -1943,7 +1973,7 @@ static void pim_show_upstream(struct vty *vty, u_char uj)
       json_object_int_add(json_row, "sptBit", up->sptbit);
       json_object_object_add(json_group, src_str, json_row);
     } else {
-      vty_out(vty, "%-10s%-15s %-15s %-11s %-8s %-9s %-9s %-9s %6d%s",
+      vty_outln (vty, "%-10s%-15s %-15s %-11s %-8s %-9s %-9s %-9s %6d",
               up->rpf.source_nexthop.interface->name,
               src_str,
               grp_str,
@@ -1952,13 +1982,13 @@ static void pim_show_upstream(struct vty *vty, u_char uj)
               join_timer,
               rs_timer,
               ka_timer,
-              up->ref_count,
-              VTY_NEWLINE);
+              up->ref_count);
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -1977,9 +2007,8 @@ static void pim_show_join_desired(struct vty *vty, u_char uj)
   if (uj)
     json = json_object_new_object();
   else
-    vty_out(vty,
-            "Interface Source          Group           LostAssert Joins PimInclude JoinDesired EvalJD%s",
-            VTY_NEWLINE);
+    vty_outln (vty,
+            "Interface Source          Group           LostAssert Joins PimInclude JoinDesired EvalJD");
 
   /* scan per-interface (S,G) state */
   for (ALL_LIST_ELEMENTS_RO(pim_ifchannel_list, chnode, ch)) {
@@ -2022,7 +2051,7 @@ static void pim_show_join_desired(struct vty *vty, u_char uj)
       json_object_object_add(json_group, src_str, json_row);
 
     } else {
-      vty_out(vty, "%-9s %-15s %-15s %-10s %-5s %-10s %-11s %-6s%s",
+      vty_outln (vty, "%-9s %-15s %-15s %-10s %-5s %-10s %-11s %-6s",
 	      ch->interface->name,
 	      src_str,
 	      grp_str,
@@ -2030,13 +2059,13 @@ static void pim_show_join_desired(struct vty *vty, u_char uj)
 	      pim_macro_chisin_joins(ch) ? "yes" : "no",
 	      pim_macro_chisin_pim_include(ch) ? "yes" : "no",
 	      PIM_UPSTREAM_FLAG_TEST_DR_JOIN_DESIRED(up->flags) ? "yes" : "no",
-	      pim_upstream_evaluate_join_desired(up) ? "yes" : "no",
-	      VTY_NEWLINE);
+	      pim_upstream_evaluate_join_desired(up) ? "yes" : "no");
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -2052,9 +2081,8 @@ static void pim_show_upstream_rpf(struct vty *vty, u_char uj)
   if (uj)
     json = json_object_new_object();
   else
-    vty_out(vty,
-            "Source          Group           RpfIface RibNextHop      RpfAddress     %s",
-            VTY_NEWLINE);
+    vty_outln (vty,
+            "Source          Group           RpfIface RibNextHop      RpfAddress     ");
 
   for (ALL_LIST_ELEMENTS_RO(pim_upstream_list, upnode, up)) {
     char src_str[INET_ADDRSTRLEN];
@@ -2090,18 +2118,18 @@ static void pim_show_upstream_rpf(struct vty *vty, u_char uj)
         json_object_string_add(json_row, "rpfAddress", rpf_addr_str);
         json_object_object_add(json_group, src_str, json_row);
     } else {
-        vty_out(vty, "%-15s %-15s %-8s %-15s %-15s%s",
+        vty_outln (vty, "%-15s %-15s %-8s %-15s %-15s",
                 src_str,
                 grp_str,
                 rpf_ifname,
                 rpf_nexthop_str,
-                rpf_addr_str,
-                VTY_NEWLINE);
+                rpf_addr_str);
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -2121,21 +2149,21 @@ static void show_rpf_refresh_stats(struct vty *vty, time_t now, json_object *jso
     json_object_int_add(json, "nexthopLookups", qpim_nexthop_lookups);
     json_object_int_add(json, "nexthopLookupsAvoided", nexthop_lookups_avoided);
   } else {
-    vty_out(vty,
+    vty_outln (vty,
             "RPF Cache Refresh Delay:    %ld msecs%s"
             "RPF Cache Refresh Timer:    %ld msecs%s"
             "RPF Cache Refresh Requests: %lld%s"
             "RPF Cache Refresh Events:   %lld%s"
             "RPF Cache Refresh Last:     %s%s"
             "Nexthop Lookups:            %lld%s"
-	    "Nexthop Lookups Avoided:    %lld%s",
+	    "Nexthop Lookups Avoided:    %lld",
             qpim_rpf_cache_refresh_delay_msec, VTY_NEWLINE,
             pim_time_timer_remain_msec(qpim_rpf_cache_refresher), VTY_NEWLINE,
             (long long)qpim_rpf_cache_refresh_requests, VTY_NEWLINE,
             (long long)qpim_rpf_cache_refresh_events, VTY_NEWLINE,
             refresh_uptime, VTY_NEWLINE,
             (long long) qpim_nexthop_lookups, VTY_NEWLINE,
-	    (long long)nexthop_lookups_avoided, VTY_NEWLINE);
+	    (long long)nexthop_lookups_avoided);
   }
 }
 
@@ -2149,13 +2177,13 @@ static void show_scan_oil_stats(struct vty *vty, time_t now)
   pim_time_uptime_begin(uptime_mroute_add, sizeof(uptime_mroute_add), now, qpim_mroute_add_last);
   pim_time_uptime_begin(uptime_mroute_del, sizeof(uptime_mroute_del), now, qpim_mroute_del_last);
 
-  vty_out(vty,
+  vty_outln (vty,
           "Scan OIL - Last: %s  Events: %lld%s"
           "MFC Add  - Last: %s  Events: %lld%s"
-          "MFC Del  - Last: %s  Events: %lld%s",
+          "MFC Del  - Last: %s  Events: %lld",
           uptime_scan_oil,   (long long) qpim_scan_oil_events,   VTY_NEWLINE,
           uptime_mroute_add, (long long) qpim_mroute_add_events, VTY_NEWLINE,
-          uptime_mroute_del, (long long) qpim_mroute_del_events, VTY_NEWLINE);
+          uptime_mroute_del, (long long)qpim_mroute_del_events);
 }
 
 static void pim_show_rpf(struct vty *vty, u_char uj)
@@ -2172,10 +2200,9 @@ static void pim_show_rpf(struct vty *vty, u_char uj)
     show_rpf_refresh_stats(vty, now, json);
   } else {
     show_rpf_refresh_stats(vty, now, json);
-    vty_out(vty, "%s", VTY_NEWLINE);
-    vty_out(vty,
-            "Source          Group           RpfIface RpfAddress      RibNextHop      Metric Pref%s",
-            VTY_NEWLINE);
+    vty_outln (vty, "");
+    vty_outln (vty,
+            "Source          Group           RpfIface RpfAddress      RibNextHop      Metric Pref");
   }
 
   for (ALL_LIST_ELEMENTS_RO(pim_upstream_list, up_node, up)) {
@@ -2212,20 +2239,20 @@ static void pim_show_rpf(struct vty *vty, u_char uj)
       json_object_object_add(json_group, src_str, json_row);
 
     } else {
-      vty_out(vty, "%-15s %-15s %-8s %-15s %-15s %6d %4d%s",
+      vty_outln (vty, "%-15s %-15s %-8s %-15s %-15s %6d %4d",
               src_str,
               grp_str,
               rpf_ifname,
               rpf_addr_str,
               rib_nexthop_str,
               rpf->source_nexthop.mrib_route_metric,
-              rpf->source_nexthop.mrib_metric_preference,
-              VTY_NEWLINE);
+              rpf->source_nexthop.mrib_metric_preference);
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -2250,7 +2277,7 @@ pim_print_pnc_cache_walkcb (struct hash_backet *backet, void *arg)
       vty_out (vty, "%-15s ", inet_ntoa (pnc->rpf.rpf_addr.u.prefix4));
       vty_out (vty, "%-14s ", ifp ? ifp->name : "NULL");
       vty_out (vty, "%s ", inet_ntoa (nh_node->gate.ipv4));
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
   return CMD_SUCCESS;
 }
@@ -2261,14 +2288,14 @@ pim_show_nexthop (struct vty *vty)
 
   if (pimg && !pimg->rpf_hash)
     {
-      vty_out (vty, "no nexthop cache %s", VTY_NEWLINE);
+      vty_outln (vty, "no nexthop cache ");
       return;
     }
 
-  vty_out (vty, "Number of registered addresses: %lu %s",
-           pimg->rpf_hash->count, VTY_NEWLINE);
-  vty_out (vty, "Address         Interface      Nexthop%s", VTY_NEWLINE);
-  vty_out (vty, "-------------------------------------------%s", VTY_NEWLINE);
+  vty_outln (vty, "Number of registered addresses: %lu ",
+           pimg->rpf_hash->count);
+  vty_outln (vty, "Address         Interface      Nexthop");
+  vty_outln (vty, "-------------------------------------------");
 
   hash_walk (pimg->rpf_hash, pim_print_pnc_cache_walkcb, vty);
 
@@ -2288,7 +2315,8 @@ static void igmp_show_groups(struct vty *vty, u_char uj)
   if (uj)
     json = json_object_new_object();
   else
-    vty_out(vty, "Interface Address         Group           Mode Timer    Srcs V Uptime  %s", VTY_NEWLINE);
+    vty_outln (vty,
+              "Interface Address         Group           Mode Timer    Srcs V Uptime  ");
 
   /* scan interfaces */
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), ifnode, ifp)) {
@@ -2340,7 +2368,7 @@ static void igmp_show_groups(struct vty *vty, u_char uj)
             json_object_object_add(json_iface, group_str, json_row);
 
         } else {
-          vty_out(vty, "%-9s %-15s %-15s %4s %8s %4d %d %8s%s",
+          vty_outln (vty, "%-9s %-15s %-15s %4s %8s %4d %d %8s",
                   ifp->name,
                   ifaddr_str,
                   group_str,
@@ -2348,15 +2376,15 @@ static void igmp_show_groups(struct vty *vty, u_char uj)
                   hhmmss,
                   grp->group_source_list ? listcount(grp->group_source_list) : 0,
                   grp->igmp_version,
-                  uptime,
-                  VTY_NEWLINE);
+                  uptime);
         }
       } /* scan igmp groups */
     } /* scan igmp sockets */
   } /* scan interfaces */
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -2366,7 +2394,8 @@ static void igmp_show_group_retransmission(struct vty *vty)
   struct listnode  *ifnode;
   struct interface *ifp;
 
-  vty_out(vty, "Interface Address         Group           RetTimer Counter RetSrcs%s", VTY_NEWLINE);
+  vty_outln (vty,
+            "Interface Address         Group           RetTimer Counter RetSrcs");
 
   /* scan interfaces */
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), ifnode, ifp)) {
@@ -2404,14 +2433,13 @@ static void igmp_show_group_retransmission(struct vty *vty)
 	  }
 	}
 
-	vty_out(vty, "%-9s %-15s %-15s %-8s %7d %7d%s",
+	vty_outln (vty, "%-9s %-15s %-15s %-8s %7d %7d",
 		ifp->name,
 		ifaddr_str,
 		group_str,
 		grp_retr_mmss,
 		grp->group_specific_query_retransmit_count,
-		grp_retr_sources,
-		VTY_NEWLINE);
+		grp_retr_sources);
 
       } /* scan igmp groups */
     } /* scan igmp sockets */
@@ -2426,7 +2454,8 @@ static void igmp_show_sources(struct vty *vty)
 
   now = pim_time_monotonic_sec();
 
-  vty_out(vty, "Interface Address         Group           Source          Timer Fwd Uptime  %s", VTY_NEWLINE);
+  vty_outln (vty,
+            "Interface Address         Group           Source          Timer Fwd Uptime  ");
 
   /* scan interfaces */
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), ifnode, ifp)) {
@@ -2465,15 +2494,14 @@ static void igmp_show_sources(struct vty *vty)
 
 	  pim_time_uptime(uptime, sizeof(uptime), now - src->source_creation);
 
-	  vty_out(vty, "%-9s %-15s %-15s %-15s %5s %3s %8s%s",
+	  vty_outln (vty, "%-9s %-15s %-15s %-15s %5s %3s %8s",
 		  ifp->name,
 		  ifaddr_str,
 		  group_str,
 		  source_str,
 		  mmss,
 		  IGMP_SOURCE_TEST_FORWARDING(src->source_flags) ? "Y" : "N",
-		  uptime,
-		  VTY_NEWLINE);
+		  uptime);
 	  
 	} /* scan group sources */
       } /* scan igmp groups */
@@ -2486,7 +2514,8 @@ static void igmp_show_source_retransmission(struct vty *vty)
   struct listnode  *ifnode;
   struct interface *ifp;
 
-  vty_out(vty, "Interface Address         Group           Source          Counter%s", VTY_NEWLINE);
+  vty_outln (vty,
+            "Interface Address         Group           Source          Counter");
 
   /* scan interfaces */
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), ifnode, ifp)) {
@@ -2519,13 +2548,12 @@ static void igmp_show_source_retransmission(struct vty *vty)
 
 	  pim_inet4_dump("<source?>", src->source_addr, source_str, sizeof(source_str));
 
-	  vty_out(vty, "%-9s %-15s %-15s %-15s %7d%s",
+	  vty_outln (vty, "%-9s %-15s %-15s %-15s %7d",
 		  ifp->name,
 		  ifaddr_str,
 		  group_str,
 		  source_str,
-		  src->source_query_retransmit_count,
-		  VTY_NEWLINE);
+		  src->source_query_retransmit_count);
 	  
 	} /* scan group sources */
       } /* scan igmp groups */
@@ -3085,14 +3113,14 @@ DEFUN (show_ip_pim_nexthop_lookup,
   result = inet_pton (AF_INET, addr_str, &src_addr);
   if (result <= 0)
     {
-      vty_out (vty, "Bad unicast address %s: errno=%d: %s%s",
-               addr_str, errno, safe_strerror (errno), VTY_NEWLINE);
+      vty_outln (vty, "Bad unicast address %s: errno=%d: %s",
+               addr_str, errno, safe_strerror(errno));
       return CMD_WARNING;
     }
 
   if (pim_is_group_224_4 (src_addr))
     {
-      vty_out (vty, "Invalid argument. Expected Valid Source Address.%s", VTY_NEWLINE);
+      vty_outln (vty, "Invalid argument. Expected Valid Source Address.");
       return CMD_WARNING;
     }
 
@@ -3100,14 +3128,15 @@ DEFUN (show_ip_pim_nexthop_lookup,
   result = inet_pton (AF_INET, addr_str1, &grp_addr);
   if (result <= 0)
     {
-      vty_out (vty, "Bad unicast address %s: errno=%d: %s%s",
-               addr_str, errno, safe_strerror (errno), VTY_NEWLINE);
+      vty_outln (vty, "Bad unicast address %s: errno=%d: %s",
+               addr_str, errno, safe_strerror(errno));
       return CMD_WARNING;
     }
 
   if (!pim_is_group_224_4 (grp_addr))
     {
-      vty_out (vty, "Invalid argument. Expected Valid Multicast Group Address.%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Invalid argument. Expected Valid Multicast Group Address.");
       return CMD_WARNING;
     }
 
@@ -3134,8 +3163,8 @@ DEFUN (show_ip_pim_nexthop_lookup,
   pim_addr_dump ("<grp?>", &grp, grp_str, sizeof (grp_str));
   pim_addr_dump ("<nexthop?>", &nexthop.mrib_nexthop_addr,
                  nexthop_addr_str, sizeof (nexthop_addr_str));
-  vty_out (vty, "Group %s --- Nexthop %s Interface %s %s", grp_str,
-           nexthop_addr_str, nexthop.interface->name, VTY_NEWLINE);
+  vty_outln (vty, "Group %s --- Nexthop %s Interface %s ", grp_str,
+           nexthop_addr_str, nexthop.interface->name);
 
   return CMD_SUCCESS;
 }
@@ -3167,10 +3196,10 @@ static void show_multicast_interfaces(struct vty *vty)
   struct listnode  *node;
   struct interface *ifp;
 
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
   
-  vty_out(vty, "Interface Address         ifi Vif  PktsIn PktsOut    BytesIn   BytesOut%s",
-	  VTY_NEWLINE);
+  vty_outln (vty,
+            "Interface Address         ifi Vif  PktsIn PktsOut    BytesIn   BytesOut");
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp)) {
     struct pim_interface *pim_ifp;
@@ -3197,7 +3226,7 @@ static void show_multicast_interfaces(struct vty *vty)
 
     ifaddr = pim_ifp->primary_address;
 
-    vty_out(vty, "%-9s %-15s %3d %3d %7lu %7lu %10lu %10lu%s",
+    vty_outln (vty, "%-9s %-15s %3d %3d %7lu %7lu %10lu %10lu",
 	    ifp->name,
 	    inet_ntoa(ifaddr),
 	    ifp->ifindex,
@@ -3205,8 +3234,7 @@ static void show_multicast_interfaces(struct vty *vty)
 	    (unsigned long) vreq.icount,
 	    (unsigned long) vreq.ocount,
 	    (unsigned long) vreq.ibytes,
-	    (unsigned long) vreq.obytes,
-	    VTY_NEWLINE);
+	    (unsigned long)vreq.obytes);
   }
 }
 
@@ -3221,40 +3249,37 @@ DEFUN (show_ip_multicast,
 
   char uptime[10];
 
-  vty_out(vty, "Mroute socket descriptor: %d%s",
-          qpim_mroute_socket_fd,
-          VTY_NEWLINE);
+  vty_outln (vty, "Mroute socket descriptor: %d",
+          qpim_mroute_socket_fd);
 
   pim_time_uptime(uptime, sizeof(uptime), now - qpim_mroute_socket_creation);
-  vty_out(vty, "Mroute socket uptime: %s%s",
-          uptime,
-          VTY_NEWLINE);
+  vty_outln (vty, "Mroute socket uptime: %s",
+          uptime);
 
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   pim_zebra_zclient_update (vty);
   pim_zlookup_show_ip_multicast (vty);
 
-  vty_out(vty, "%s", VTY_NEWLINE);
-  vty_out(vty, "Maximum highest VifIndex: %d%s",
-	  PIM_MAX_USABLE_VIFS,
-	  VTY_NEWLINE);
+  vty_outln (vty, "");
+  vty_outln (vty, "Maximum highest VifIndex: %d",
+	  PIM_MAX_USABLE_VIFS);
 
-  vty_out (vty, "%s", VTY_NEWLINE);
-  vty_out (vty, "Upstream Join Timer: %d secs%s",
-           qpim_t_periodic, VTY_NEWLINE);
-  vty_out (vty, "Join/Prune Holdtime: %d secs%s",
-           PIM_JP_HOLDTIME, VTY_NEWLINE);
-  vty_out (vty, "PIM ECMP: %s%s",
-           qpim_ecmp_enable ? "Enable" : "Disable", VTY_NEWLINE);
-  vty_out (vty, "PIM ECMP Rebalance: %s%s",
-           qpim_ecmp_rebalance_enable ? "Enable" : "Disable", VTY_NEWLINE);
+  vty_outln (vty, "");
+  vty_outln (vty, "Upstream Join Timer: %d secs",
+           qpim_t_periodic);
+  vty_outln (vty, "Join/Prune Holdtime: %d secs",
+           PIM_JP_HOLDTIME);
+  vty_outln (vty, "PIM ECMP: %s",
+           qpim_ecmp_enable ? "Enable" : "Disable");
+  vty_outln (vty, "PIM ECMP Rebalance: %s",
+           qpim_ecmp_rebalance_enable ? "Enable" : "Disable");
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   show_rpf_refresh_stats(vty, now, NULL);
 
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   show_scan_oil_stats(vty, now);
 
@@ -3287,8 +3312,8 @@ static void show_mroute(struct vty *vty, u_char uj)
   if (uj) {
     json = json_object_new_object();
   } else {
-    vty_out(vty, "Source          Group           Proto  Input      Output     TTL  Uptime%s",
-            VTY_NEWLINE);
+    vty_outln (vty,
+              "Source          Group           Proto  Input      Output     TTL  Uptime");
   }
 
   now = pim_time_monotonic_sec();
@@ -3399,15 +3424,14 @@ static void show_mroute(struct vty *vty, u_char uj)
           strcpy(proto, "STAR");
         }
 
-        vty_out(vty, "%-15s %-15s %-6s %-10s %-10s %-3d  %8s%s",
+        vty_outln (vty, "%-15s %-15s %-6s %-10s %-10s %-3d  %8s",
                 src_str,
                 grp_str,
                 proto,
                 in_ifname,
                 out_ifname,
                 ttl,
-                oif_uptime,
-                VTY_NEWLINE);
+                oif_uptime);
 
         if (first)
 	  {
@@ -3420,15 +3444,14 @@ static void show_mroute(struct vty *vty, u_char uj)
     }
 
     if (!uj && !found_oif) {
-      vty_out(vty, "%-15s %-15s %-6s %-10s %-10s %-3d  %8s%s",
+      vty_outln (vty, "%-15s %-15s %-6s %-10s %-10s %-3d  %8s",
               src_str,
               grp_str,
               "none",
               in_ifname,
               "none",
               0,
-              "--:--:--",
-              VTY_NEWLINE);
+              "--:--:--");
     }
   }
 
@@ -3508,15 +3531,14 @@ static void show_mroute(struct vty *vty, u_char uj)
         }
         json_object_object_add(json_oil, out_ifname, json_ifp_out);
       } else {
-        vty_out(vty, "%-15s %-15s %-6s %-10s %-10s %-3d  %8s%s",
+        vty_outln (vty, "%-15s %-15s %-6s %-10s %-10s %-3d  %8s",
                 src_str,
                 grp_str,
                 proto,
                 in_ifname,
                 out_ifname,
                 ttl,
-                oif_uptime,
-                VTY_NEWLINE);
+                oif_uptime);
 	if (first)
           {
 	    src_str[0] = '\0';
@@ -3528,20 +3550,20 @@ static void show_mroute(struct vty *vty, u_char uj)
     }
 
     if (!uj && !found_oif) {
-        vty_out(vty, "%-15s %-15s %-6s %-10s %-10s %-3d  %8s%s",
+        vty_outln (vty, "%-15s %-15s %-6s %-10s %-10s %-3d  %8s",
                 src_str,
                 grp_str,
                 proto,
                 in_ifname,
                 "none",
                 0,
-                "--:--:--",
-                VTY_NEWLINE);
+                "--:--:--");
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -3565,10 +3587,10 @@ static void show_mroute_count(struct vty *vty)
   struct channel_oil *c_oil;
   struct static_route *s_route;
 
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
   
-  vty_out(vty, "Source          Group           LastUsed Packets Bytes WrongIf  %s",
-	  VTY_NEWLINE);
+  vty_outln (vty,
+            "Source          Group           LastUsed Packets Bytes WrongIf  ");
 
   /* Print PIM and IGMP route counts */
   for (ALL_LIST_ELEMENTS_RO(pim_channel_oil_list, node, c_oil)) {
@@ -3583,14 +3605,13 @@ static void show_mroute_count(struct vty *vty)
     pim_inet4_dump("<group?>", c_oil->oil.mfcc_mcastgrp, group_str, sizeof(group_str));
     pim_inet4_dump("<source?>", c_oil->oil.mfcc_origin, source_str, sizeof(source_str));
 
-    vty_out(vty, "%-15s %-15s %-8llu %-7ld %-10ld %-7ld%s",
+    vty_outln (vty, "%-15s %-15s %-8llu %-7ld %-10ld %-7ld",
 	    source_str,
 	    group_str,
 	    c_oil->cc.lastused/100,
 	    c_oil->cc.pktcnt,
 	    c_oil->cc.bytecnt,
-	    c_oil->cc.wrong_if,
-	    VTY_NEWLINE);
+	    c_oil->cc.wrong_if);
   }
 
    /* Print static route counts */
@@ -3606,14 +3627,13 @@ static void show_mroute_count(struct vty *vty)
     pim_inet4_dump("<group?>", s_route->c_oil.oil.mfcc_mcastgrp, group_str, sizeof(group_str));
     pim_inet4_dump("<source?>", s_route->c_oil.oil.mfcc_origin, source_str, sizeof(source_str));
 
-    vty_out(vty, "%-15s %-15s %-8llu %-7ld %-10ld %-7ld%s",
+    vty_outln (vty, "%-15s %-15s %-8llu %-7ld %-10ld %-7ld",
        source_str,
        group_str,
        s_route->c_oil.cc.lastused,
        s_route->c_oil.cc.pktcnt,
        s_route->c_oil.cc.bytecnt,
-       s_route->c_oil.cc.wrong_if,
-       VTY_NEWLINE);
+       s_route->c_oil.cc.wrong_if);
   }
 }
 
@@ -3648,30 +3668,29 @@ DEFUN (show_ip_rib,
   addr_str = argv[idx_ipv4]->arg;
   result = inet_pton(AF_INET, addr_str, &addr);
   if (result <= 0) {
-    vty_out(vty, "Bad unicast address %s: errno=%d: %s%s",
-	    addr_str, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "Bad unicast address %s: errno=%d: %s",
+	    addr_str, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
   if (pim_nexthop_lookup(&nexthop, addr, 0)) {
-    vty_out(vty, "Failure querying RIB nexthop for unicast address %s%s",
-	    addr_str, VTY_NEWLINE);
+    vty_outln (vty, "Failure querying RIB nexthop for unicast address %s",
+	    addr_str);
     return CMD_WARNING;
   }
 
-  vty_out(vty, "Address         NextHop         Interface Metric Preference%s",
-	  VTY_NEWLINE);
+  vty_outln (vty,
+            "Address         NextHop         Interface Metric Preference");
 
   pim_addr_dump("<nexthop?>", &nexthop.mrib_nexthop_addr,
 		nexthop_addr_str, sizeof(nexthop_addr_str));
 
-  vty_out(vty, "%-15s %-15s %-9s %6d %10d%s",
+  vty_outln (vty, "%-15s %-15s %-9s %6d %10d",
 	  addr_str,
 	  nexthop_addr_str,
 	  nexthop.interface ? nexthop.interface->name : "<ifname?>",
 	  nexthop.mrib_route_metric,
-	  nexthop.mrib_metric_preference,
-	  VTY_NEWLINE);
+	  nexthop.mrib_metric_preference);
 
   return CMD_SUCCESS;
 }
@@ -3682,8 +3701,8 @@ static void show_ssmpingd(struct vty *vty)
   struct ssmpingd_sock *ss;
   time_t                now;
 
-  vty_out(vty, "Source          Socket Address          Port Uptime   Requests%s",
-	  VTY_NEWLINE);
+  vty_outln (vty,
+            "Source          Socket Address          Port Uptime   Requests");
 
   if (!qpim_ssmpingd_list)
     return;
@@ -3700,21 +3719,20 @@ static void show_ssmpingd(struct vty *vty)
     pim_inet4_dump("<src?>", ss->source_addr, source_str, sizeof(source_str));
 
     if (pim_socket_getsockname(ss->sock_fd, (struct sockaddr *) &bind_addr, &len)) {
-      vty_out(vty, "%% Failure reading socket name for ssmpingd source %s on fd=%d%s",
-	      source_str, ss->sock_fd, VTY_NEWLINE);
+      vty_outln (vty, "%% Failure reading socket name for ssmpingd source %s on fd=%d",
+	      source_str, ss->sock_fd);
     }
 
     pim_inet4_dump("<addr?>", bind_addr.sin_addr, bind_addr_str, sizeof(bind_addr_str));
     pim_time_uptime(ss_uptime, sizeof(ss_uptime), now - ss->creation);
 
-    vty_out(vty, "%-15s %6d %-15s %5d %8s %8lld%s",
+    vty_outln (vty, "%-15s %6d %-15s %5d %8s %8lld",
 	    source_str,
 	    ss->sock_fd,
 	    bind_addr_str,
 	    ntohs(bind_addr.sin_port),
 	    ss_uptime,
-	    (long long)ss->requests,
-	    VTY_NEWLINE);
+	    (long long)ss->requests);
   }
 }
 
@@ -3738,43 +3756,45 @@ pim_rp_cmd_worker (struct vty *vty, const char *rp, const char *group, const cha
 
   if (result == PIM_MALLOC_FAIL)
     {
-      vty_out (vty, "%% Out of memory%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Out of memory");
       return CMD_WARNING;
     }
 
   if (result == PIM_GROUP_BAD_ADDRESS)
     {
-      vty_out (vty, "%% Bad group address specified: %s%s", group, VTY_NEWLINE);
+      vty_outln (vty, "%% Bad group address specified: %s", group);
       return CMD_WARNING;
     }
 
   if (result == PIM_RP_BAD_ADDRESS)
     {
-      vty_out (vty, "%% Bad RP address specified: %s%s", rp, VTY_NEWLINE);
+      vty_outln (vty, "%% Bad RP address specified: %s", rp);
       return CMD_WARNING;
     }
 
   if (result == PIM_RP_NO_PATH)
     {
-      vty_out (vty, "%% No Path to RP address specified: %s%s", rp, VTY_NEWLINE);
+      vty_outln (vty, "%% No Path to RP address specified: %s", rp);
       return CMD_WARNING;
     }
 
   if (result == PIM_GROUP_OVERLAP)
     {
-      vty_out (vty, "%% Group range specified cannot overlap%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Group range specified cannot overlap");
       return CMD_WARNING;
     }
 
   if (result == PIM_GROUP_PFXLIST_OVERLAP)
     {
-      vty_out (vty, "%% This group is already covered by a RP prefix-list%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "%% This group is already covered by a RP prefix-list");
       return CMD_WARNING;
     }
 
   if (result == PIM_RP_PFXLIST_IN_USE)
     {
-      vty_out (vty, "%% The same prefix-list cannot be applied to multiple RPs%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "%% The same prefix-list cannot be applied to multiple RPs");
       return CMD_WARNING;
     }
 
@@ -4022,19 +4042,19 @@ pim_no_rp_cmd_worker (struct vty *vty, const char *rp, const char *group,
 
   if (result == PIM_GROUP_BAD_ADDRESS)
     {
-      vty_out (vty, "%% Bad group address specified: %s%s", group, VTY_NEWLINE);
+      vty_outln (vty, "%% Bad group address specified: %s", group);
       return CMD_WARNING;
     }
 
   if (result == PIM_RP_BAD_ADDRESS)
     {
-      vty_out (vty, "%% Bad RP address specified: %s%s", rp, VTY_NEWLINE);
+      vty_outln (vty, "%% Bad RP address specified: %s", rp);
       return CMD_WARNING;
     }
 
   if (result == PIM_RP_NOT_FOUND)
     {
-      vty_out (vty, "%% Unable to find specified RP%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Unable to find specified RP");
       return CMD_WARNING;
     }
 
@@ -4084,13 +4104,13 @@ pim_ssm_cmd_worker (struct vty *vty, const char *plist)
   switch (result)
     {
     case PIM_SSM_ERR_NO_VRF:
-      vty_out (vty, "%% VRF doesn't exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% VRF doesn't exist");
       break;
     case PIM_SSM_ERR_DUP:
-      vty_out (vty, "%% duplicate config%s", VTY_NEWLINE);
+      vty_outln (vty, "%% duplicate config");
       break;
     default:
-      vty_out (vty, "%% ssm range config failed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% ssm range config failed");
     }
 
   return CMD_WARNING;
@@ -4135,8 +4155,8 @@ DEFUN (no_ip_pim_ssm_prefix_list_name,
   if (ssm->plist_name && !strcmp(ssm->plist_name, argv[0]->arg))
     return pim_ssm_cmd_worker (vty, NULL);
 
-  vty_out (vty, "%% pim ssm prefix-list %s doesn't exist%s",
-           argv[0]->arg, VTY_NEWLINE);
+  vty_outln (vty, "%% pim ssm prefix-list %s doesn't exist",
+           argv[0]->arg);
 
   return CMD_WARNING;
 }
@@ -4152,11 +4172,12 @@ ip_pim_ssm_show_group_range(struct vty *vty, u_char uj)
       json_object *json;
       json = json_object_new_object();
       json_object_string_add(json, "ssmGroups", range_str);
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free(json);
     }
   else
-    vty_out(vty, "SSM group range : %s%s", range_str, VTY_NEWLINE);
+    vty_outln (vty, "SSM group range : %s", range_str);
 }
 
 DEFUN (show_ip_pim_ssm_range,
@@ -4197,11 +4218,12 @@ ip_pim_ssm_show_group_type(struct vty *vty, u_char uj, const char *group)
       json_object *json;
       json = json_object_new_object();
       json_object_string_add(json, "groupType", type_str);
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free(json);
     }
   else
-    vty_out(vty, "Group type : %s%s", type_str, VTY_NEWLINE);
+    vty_outln (vty, "Group type : %s", type_str);
 }
 
 DEFUN (show_ip_pim_group_type,
@@ -4237,7 +4259,8 @@ DEFUN_HIDDEN (no_ip_multicast_routing,
               "Global IP configuration subcommands\n"
               "Enable IP multicast forwarding\n")
 {
-  vty_out (vty, "Command is Disabled and will be removed in a future version%s",  VTY_NEWLINE);
+  vty_outln (vty,
+             "Command is Disabled and will be removed in a future version");
   return CMD_SUCCESS;
 }
 
@@ -4255,15 +4278,15 @@ DEFUN (ip_ssmpingd,
 
   result = inet_pton(AF_INET, source_str, &source_addr);
   if (result <= 0) {
-    vty_out(vty, "%% Bad source address %s: errno=%d: %s%s",
-	    source_str, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "%% Bad source address %s: errno=%d: %s",
+	    source_str, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
   result = pim_ssmpingd_start(source_addr);
   if (result) {
-    vty_out(vty, "%% Failure starting ssmpingd for source %s: %d%s",
-	    source_str, result, VTY_NEWLINE);
+    vty_outln (vty, "%% Failure starting ssmpingd for source %s: %d",
+	    source_str, result);
     return CMD_WARNING;
   }
 
@@ -4285,15 +4308,15 @@ DEFUN (no_ip_ssmpingd,
 
   result = inet_pton(AF_INET, source_str, &source_addr);
   if (result <= 0) {
-    vty_out(vty, "%% Bad source address %s: errno=%d: %s%s",
-	    source_str, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "%% Bad source address %s: errno=%d: %s",
+	    source_str, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
   result = pim_ssmpingd_stop(source_addr);
   if (result) {
-    vty_out(vty, "%% Failure stopping ssmpingd for source %s: %d%s",
-	    source_str, result, VTY_NEWLINE);
+    vty_outln (vty, "%% Failure stopping ssmpingd for source %s: %d",
+	    source_str, result);
     return CMD_WARNING;
   }
 
@@ -4366,8 +4389,8 @@ pim_cmd_igmp_start (struct vty *vty, struct interface *ifp)
       pim_ifp = pim_if_new(ifp, 1 /* igmp=true */, 0 /* pim=false */);
       if (!pim_ifp)
         {
-          vty_out(vty, "Could not enable IGMP on interface %s%s",
-	      ifp->name, VTY_NEWLINE);
+          vty_outln (vty, "Could not enable IGMP on interface %s",
+	      ifp->name);
           return CMD_WARNING;
         }
       need_startup = 1;
@@ -4451,8 +4474,8 @@ DEFUN (interface_ip_igmp_join,
   group_str = argv[idx_ipv4]->arg;
   result = inet_pton(AF_INET, group_str, &group_addr);
   if (result <= 0) {
-    vty_out(vty, "Bad group address %s: errno=%d: %s%s",
-	    group_str, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "Bad group address %s: errno=%d: %s",
+	    group_str, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
@@ -4460,15 +4483,15 @@ DEFUN (interface_ip_igmp_join,
   source_str = argv[idx_ipv4_2]->arg;
   result = inet_pton(AF_INET, source_str, &source_addr);
   if (result <= 0) {
-    vty_out(vty, "Bad source address %s: errno=%d: %s%s",
-	    source_str, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "Bad source address %s: errno=%d: %s",
+	    source_str, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
   result = pim_if_igmp_join_add(ifp, group_addr, source_addr);
   if (result) {
-    vty_out(vty, "%% Failure joining IGMP group %s source %s on interface %s: %d%s",
-	    group_str, source_str, ifp->name, result, VTY_NEWLINE);
+    vty_outln (vty, "%% Failure joining IGMP group %s source %s on interface %s: %d",
+	    group_str, source_str, ifp->name, result);
     return CMD_WARNING;
   }
 
@@ -4498,8 +4521,8 @@ DEFUN (interface_no_ip_igmp_join,
   group_str = argv[idx_ipv4]->arg;
   result = inet_pton(AF_INET, group_str, &group_addr);
   if (result <= 0) {
-    vty_out(vty, "Bad group address %s: errno=%d: %s%s",
-	    group_str, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "Bad group address %s: errno=%d: %s",
+	    group_str, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
@@ -4507,15 +4530,15 @@ DEFUN (interface_no_ip_igmp_join,
   source_str = argv[idx_ipv4_2]->arg;
   result = inet_pton(AF_INET, source_str, &source_addr);
   if (result <= 0) {
-    vty_out(vty, "Bad source address %s: errno=%d: %s%s",
-	    source_str, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "Bad source address %s: errno=%d: %s",
+	    source_str, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
   result = pim_if_igmp_join_del(ifp, group_addr, source_addr);
   if (result) {
-    vty_out(vty, "%% Failure leaving IGMP group %s source %s on interface %s: %d%s",
-	    group_str, source_str, ifp->name, result, VTY_NEWLINE);
+    vty_outln (vty, "%% Failure leaving IGMP group %s source %s on interface %s: %d",
+	    group_str, source_str, ifp->name, result);
     return CMD_WARNING;
   }
 
@@ -4682,25 +4705,22 @@ DEFUN (interface_ip_igmp_query_interval,
     already, but we verify them anyway for extra safety.
   */
   if (query_interval < IGMP_QUERY_INTERVAL_MIN) {
-    vty_out(vty, "General query interval %d lower than minimum %d%s",
+    vty_outln (vty, "General query interval %d lower than minimum %d",
 	    query_interval,
-	    IGMP_QUERY_INTERVAL_MIN,
-	    VTY_NEWLINE);
+	    IGMP_QUERY_INTERVAL_MIN);
     return CMD_WARNING;
   }
   if (query_interval > IGMP_QUERY_INTERVAL_MAX) {
-    vty_out(vty, "General query interval %d higher than maximum %d%s",
+    vty_outln (vty, "General query interval %d higher than maximum %d",
 	    query_interval,
-	    IGMP_QUERY_INTERVAL_MAX,
-	    VTY_NEWLINE);
+	    IGMP_QUERY_INTERVAL_MAX);
     return CMD_WARNING;
   }
 
   if (query_interval_dsec <= pim_ifp->igmp_query_max_response_time_dsec) {
-    vty_out(vty,
-	    "Can't set general query interval %d dsec <= query max response time %d dsec.%s",
-	    query_interval_dsec, pim_ifp->igmp_query_max_response_time_dsec,
-	    VTY_NEWLINE);
+    vty_outln (vty,
+	    "Can't set general query interval %d dsec <= query max response time %d dsec.",
+	    query_interval_dsec,pim_ifp->igmp_query_max_response_time_dsec);
     return CMD_WARNING;
   }
 
@@ -4727,10 +4747,10 @@ DEFUN (interface_no_ip_igmp_query_interval,
   default_query_interval_dsec = IGMP_GENERAL_QUERY_INTERVAL * 10;
 
   if (default_query_interval_dsec <= pim_ifp->igmp_query_max_response_time_dsec) {
-    vty_out(vty,
-	    "Can't set default general query interval %d dsec <= query max response time %d dsec.%s",
-	    default_query_interval_dsec, pim_ifp->igmp_query_max_response_time_dsec,
-	    VTY_NEWLINE);
+    vty_outln (vty,
+	    "Can't set default general query interval %d dsec <= query max response time %d dsec.",
+	    default_query_interval_dsec,
+	    pim_ifp->igmp_query_max_response_time_dsec);
     return CMD_WARNING;
   }
 
@@ -4826,10 +4846,9 @@ DEFUN (interface_ip_igmp_query_max_response_time,
   query_max_response_time = atoi(argv[3]->arg);
 
   if (query_max_response_time >= pim_ifp->igmp_default_query_interval * 10) {
-    vty_out(vty,
-	    "Can't set query max response time %d sec >= general query interval %d sec%s",
-	    query_max_response_time, pim_ifp->igmp_default_query_interval,
-	    VTY_NEWLINE);
+    vty_outln (vty,
+	    "Can't set query max response time %d sec >= general query interval %d sec",
+	    query_max_response_time,pim_ifp->igmp_default_query_interval);
     return CMD_WARNING;
   }
 
@@ -4887,10 +4906,9 @@ DEFUN_HIDDEN (interface_ip_igmp_query_max_response_time_dsec,
   default_query_interval_dsec = 10 * pim_ifp->igmp_default_query_interval;
 
   if (query_max_response_time_dsec >= default_query_interval_dsec) {
-    vty_out(vty,
-	    "Can't set query max response time %d dsec >= general query interval %d dsec%s",
-	    query_max_response_time_dsec, default_query_interval_dsec,
-	    VTY_NEWLINE);
+    vty_outln (vty,
+	    "Can't set query max response time %d dsec >= general query interval %d dsec",
+	    query_max_response_time_dsec,default_query_interval_dsec);
     return CMD_WARNING;
   }
 
@@ -4932,7 +4950,7 @@ DEFUN (interface_ip_pim_drprio,
   uint32_t old_dr_prio;
 
   if (!pim_ifp) {
-    vty_out(vty, "Please enable PIM on interface, first%s", VTY_NEWLINE);
+    vty_outln (vty, "Please enable PIM on interface, first");
     return CMD_WARNING;
   }
 
@@ -4961,7 +4979,7 @@ DEFUN (interface_no_ip_pim_drprio,
   struct pim_interface *pim_ifp = ifp->info;
 
   if (!pim_ifp) {
-    vty_out(vty, "Pim not enabled on this interface%s", VTY_NEWLINE);
+    vty_outln (vty, "Pim not enabled on this interface");
     return CMD_WARNING;
   }
 
@@ -5004,11 +5022,12 @@ DEFUN_HIDDEN (interface_ip_pim_ssm,
   VTY_DECLVAR_CONTEXT(interface, ifp);
 
   if (!pim_cmd_interface_add(ifp)) {
-    vty_out(vty, "Could not enable PIM SM on interface%s", VTY_NEWLINE);
+    vty_outln (vty, "Could not enable PIM SM on interface");
     return CMD_WARNING;
   }
 
-  vty_out(vty, "WARN: Enabled PIM SM on interface; configure PIM SSM range if needed%s", VTY_NEWLINE);
+  vty_outln(vty, "WARN: Enabled PIM SM on interface; configure PIM SSM "
+                 "range if needed");
   return CMD_SUCCESS;
 }
 
@@ -5021,7 +5040,7 @@ DEFUN (interface_ip_pim_sm,
 {
   VTY_DECLVAR_CONTEXT(interface, ifp);
   if (!pim_cmd_interface_add(ifp)) {
-    vty_out(vty, "Could not enable PIM SM on interface%s", VTY_NEWLINE);
+    vty_outln (vty, "Could not enable PIM SM on interface");
     return CMD_WARNING;
   }
 
@@ -5066,7 +5085,7 @@ DEFUN_HIDDEN (interface_no_ip_pim_ssm,
 {
   VTY_DECLVAR_CONTEXT(interface, ifp);
   if (!pim_cmd_interface_delete(ifp)) {
-    vty_out(vty, "Unable to delete interface information%s", VTY_NEWLINE);
+    vty_outln (vty, "Unable to delete interface information");
     return CMD_WARNING;
   }
 
@@ -5083,7 +5102,7 @@ DEFUN (interface_no_ip_pim_sm,
 {
   VTY_DECLVAR_CONTEXT(interface, ifp);
   if (!pim_cmd_interface_delete(ifp)) {
-    vty_out(vty, "Unable to delete interface information%s", VTY_NEWLINE);
+    vty_outln (vty, "Unable to delete interface information");
     return CMD_WARNING;
   }
 
@@ -5111,23 +5130,23 @@ DEFUN (interface_ip_mroute,
    oifname = argv[idx_interface]->arg;
    oif = if_lookup_by_name(oifname, VRF_DEFAULT);
    if (!oif) {
-     vty_out(vty, "No such interface name %s%s",
-        oifname, VTY_NEWLINE);
+     vty_outln (vty, "No such interface name %s",
+        oifname);
      return CMD_WARNING;
    }
 
    grp_str = argv[idx_ipv4]->arg;
    result = inet_pton(AF_INET, grp_str, &grp_addr);
    if (result <= 0) {
-     vty_out(vty, "Bad group address %s: errno=%d: %s%s",
-        grp_str, errno, safe_strerror(errno), VTY_NEWLINE);
+     vty_outln (vty, "Bad group address %s: errno=%d: %s",
+        grp_str, errno, safe_strerror(errno));
      return CMD_WARNING;
    }
 
    src_addr.s_addr = INADDR_ANY;
 
    if (pim_static_add(iif, oif, grp_addr, src_addr)) {
-      vty_out(vty, "Failed to add route%s", VTY_NEWLINE);
+      vty_outln (vty, "Failed to add route");
       return CMD_WARNING;
    }
 
@@ -5158,29 +5177,29 @@ DEFUN (interface_ip_mroute_source,
    oifname = argv[idx_interface]->arg;
    oif = if_lookup_by_name(oifname, VRF_DEFAULT);
    if (!oif) {
-     vty_out(vty, "No such interface name %s%s",
-        oifname, VTY_NEWLINE);
+     vty_outln (vty, "No such interface name %s",
+        oifname);
      return CMD_WARNING;
    }
 
    grp_str = argv[idx_ipv4]->arg;
    result = inet_pton(AF_INET, grp_str, &grp_addr);
    if (result <= 0) {
-     vty_out(vty, "Bad group address %s: errno=%d: %s%s",
-        grp_str, errno, safe_strerror(errno), VTY_NEWLINE);
+     vty_outln (vty, "Bad group address %s: errno=%d: %s",
+        grp_str, errno, safe_strerror(errno));
      return CMD_WARNING;
    }
 
    src_str = argv[idx_ipv4_2]->arg;
    result = inet_pton(AF_INET, src_str, &src_addr);
    if (result <= 0) {
-     vty_out(vty, "Bad source address %s: errno=%d: %s%s",
-        src_str, errno, safe_strerror(errno), VTY_NEWLINE);
+     vty_outln (vty, "Bad source address %s: errno=%d: %s",
+        src_str, errno, safe_strerror(errno));
      return CMD_WARNING;
    }
 
    if (pim_static_add(iif, oif, grp_addr, src_addr)) {
-      vty_out(vty, "Failed to add route%s", VTY_NEWLINE);
+      vty_outln (vty, "Failed to add route");
       return CMD_WARNING;
    }
 
@@ -5209,23 +5228,23 @@ DEFUN (interface_no_ip_mroute,
    oifname = argv[idx_interface]->arg;
    oif = if_lookup_by_name(oifname, VRF_DEFAULT);
    if (!oif) {
-     vty_out(vty, "No such interface name %s%s",
-        oifname, VTY_NEWLINE);
+     vty_outln (vty, "No such interface name %s",
+        oifname);
      return CMD_WARNING;
    }
 
    grp_str = argv[idx_ipv4]->arg;
    result = inet_pton(AF_INET, grp_str, &grp_addr);
    if (result <= 0) {
-     vty_out(vty, "Bad group address %s: errno=%d: %s%s",
-        grp_str, errno, safe_strerror(errno), VTY_NEWLINE);
+     vty_outln (vty, "Bad group address %s: errno=%d: %s",
+        grp_str, errno, safe_strerror(errno));
      return CMD_WARNING;
    }
 
    src_addr.s_addr = INADDR_ANY;
 
    if (pim_static_del(iif, oif, grp_addr, src_addr)) {
-      vty_out(vty, "Failed to remove route%s", VTY_NEWLINE);
+      vty_outln (vty, "Failed to remove route");
       return CMD_WARNING;
    }
 
@@ -5257,29 +5276,29 @@ DEFUN (interface_no_ip_mroute_source,
    oifname = argv[idx_interface]->arg;
    oif = if_lookup_by_name(oifname, VRF_DEFAULT);
    if (!oif) {
-     vty_out(vty, "No such interface name %s%s",
-        oifname, VTY_NEWLINE);
+     vty_outln (vty, "No such interface name %s",
+        oifname);
      return CMD_WARNING;
    }
 
    grp_str = argv[idx_ipv4]->arg;
    result = inet_pton(AF_INET, grp_str, &grp_addr);
    if (result <= 0) {
-     vty_out(vty, "Bad group address %s: errno=%d: %s%s",
-        grp_str, errno, safe_strerror(errno), VTY_NEWLINE);
+     vty_outln (vty, "Bad group address %s: errno=%d: %s",
+        grp_str, errno, safe_strerror(errno));
      return CMD_WARNING;
    }
 
    src_str = argv[idx_ipv4_2]->arg;
    result = inet_pton(AF_INET, src_str, &src_addr);
    if (result <= 0) {
-     vty_out(vty, "Bad source address %s: errno=%d: %s%s",
-        src_str, errno, safe_strerror(errno), VTY_NEWLINE);
+     vty_outln (vty, "Bad source address %s: errno=%d: %s",
+        src_str, errno, safe_strerror(errno));
      return CMD_WARNING;
    }
 
    if (pim_static_del(iif, oif, grp_addr, src_addr)) {
-      vty_out(vty, "Failed to remove route%s", VTY_NEWLINE);
+      vty_outln (vty, "Failed to remove route");
       return CMD_WARNING;
    }
 
@@ -5304,7 +5323,7 @@ DEFUN (interface_ip_pim_hello,
     {
       if (!pim_cmd_interface_add(ifp))
         {
-          vty_out(vty, "Could not enable PIM SM on interface%s", VTY_NEWLINE);
+          vty_outln (vty, "Could not enable PIM SM on interface");
           return CMD_WARNING;
         }
     }
@@ -5334,7 +5353,7 @@ DEFUN (interface_no_ip_pim_hello,
   struct pim_interface *pim_ifp = ifp->info;
 
   if (!pim_ifp) {
-    vty_out(vty, "Pim not enabled on this interface%s", VTY_NEWLINE);
+    vty_outln (vty, "Pim not enabled on this interface");
     return CMD_WARNING;
   }
 
@@ -5579,22 +5598,22 @@ DEFUN (debug_pim_packets,
   if (argv_find (argv, argc, "hello", &idx))
     {
       PIM_DO_DEBUG_PIM_HELLO;
-      vty_out (vty, "PIM Hello debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "PIM Hello debugging is on");
     }
   else if (argv_find (argv, argc ,"joins", &idx))
     {
       PIM_DO_DEBUG_PIM_J_P;
-      vty_out (vty, "PIM Join/Prune debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "PIM Join/Prune debugging is on");
     }
   else if (argv_find (argv, argc, "register", &idx))
     {
       PIM_DO_DEBUG_PIM_REG;
-      vty_out (vty, "PIM Register debugging is on%s", VTY_NEWLINE);
+      vty_outln (vty, "PIM Register debugging is on");
     }
   else
     {
       PIM_DO_DEBUG_PIM_PACKETS;
-      vty_out (vty, "PIM Packet debugging is on %s", VTY_NEWLINE);
+      vty_outln (vty, "PIM Packet debugging is on ");
     }
   return CMD_SUCCESS;
 }
@@ -5614,17 +5633,17 @@ DEFUN (no_debug_pim_packets,
   if (argv_find (argv, argc,"hello",&idx))
     {
       PIM_DONT_DEBUG_PIM_HELLO;
-      vty_out (vty, "PIM Hello debugging is off %s", VTY_NEWLINE);
+      vty_outln (vty, "PIM Hello debugging is off ");
     }
   else if (argv_find (argv, argc, "joins", &idx))
     {
       PIM_DONT_DEBUG_PIM_J_P;
-      vty_out (vty, "PIM Join/Prune debugging is off %s", VTY_NEWLINE);
+      vty_outln (vty, "PIM Join/Prune debugging is off ");
     }
   else if (argv_find (argv, argc, "register", &idx))
     {
       PIM_DONT_DEBUG_PIM_REG;
-      vty_out (vty, "PIM Register debugging is off%s", VTY_NEWLINE);
+      vty_outln (vty, "PIM Register debugging is off");
     }
   else
     PIM_DONT_DEBUG_PIM_PACKETS;
@@ -5866,8 +5885,8 @@ interface_pim_use_src_cmd_worker(struct vty *vty, const char *source)
 
   result = inet_pton(AF_INET, source, &source_addr);
   if (result <= 0) {
-    vty_out(vty, "%% Bad source address %s: errno=%d: %s%s",
-        source, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "%% Bad source address %s: errno=%d: %s",
+        source, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
@@ -5876,13 +5895,13 @@ interface_pim_use_src_cmd_worker(struct vty *vty, const char *source)
     case PIM_SUCCESS:
       break;
    case PIM_IFACE_NOT_FOUND:
-      vty_out(vty, "Pim not enabled on this interface%s", VTY_NEWLINE);
+      vty_outln (vty, "Pim not enabled on this interface");
       break;
     case PIM_UPDATE_SOURCE_DUP:
-      vty_out(vty, "%% Source already set to %s%s", source, VTY_NEWLINE);
+      vty_outln (vty, "%% Source already set to %s", source);
       break;
     default:
-      vty_out(vty, "%% Source set failed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Source set failed");
   }
 
   return result?CMD_WARNING:CMD_SUCCESS;
@@ -6006,15 +6025,15 @@ ip_msdp_peer_cmd_worker (struct vty *vty, const char *peer, const char *local)
 
   result = inet_pton(AF_INET, peer, &peer_addr);
   if (result <= 0) {
-    vty_out(vty, "%% Bad peer address %s: errno=%d: %s%s",
-        peer, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "%% Bad peer address %s: errno=%d: %s",
+        peer, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
   result = inet_pton(AF_INET, local, &local_addr);
   if (result <= 0) {
-    vty_out(vty, "%% Bad source address %s: errno=%d: %s%s",
-        local, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "%% Bad source address %s: errno=%d: %s",
+        local, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
@@ -6023,16 +6042,16 @@ ip_msdp_peer_cmd_worker (struct vty *vty, const char *peer, const char *local)
     case PIM_MSDP_ERR_NONE:
       break;
     case PIM_MSDP_ERR_OOM:
-      vty_out(vty, "%% Out of memory%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Out of memory");
       break;
     case PIM_MSDP_ERR_PEER_EXISTS:
-      vty_out(vty, "%% Peer exists%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Peer exists");
       break;
     case PIM_MSDP_ERR_MAX_MESH_GROUPS:
-      vty_out(vty, "%% Only one mesh-group allowed currently%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Only one mesh-group allowed currently");
       break;
     default:
-      vty_out(vty, "%% peer add failed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% peer add failed");
   }
 
   return result?CMD_WARNING:CMD_SUCCESS;
@@ -6059,8 +6078,8 @@ ip_no_msdp_peer_cmd_worker (struct vty *vty, const char *peer)
 
   result = inet_pton(AF_INET, peer, &peer_addr);
   if (result <= 0) {
-    vty_out(vty, "%% Bad peer address %s: errno=%d: %s%s",
-        peer, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "%% Bad peer address %s: errno=%d: %s",
+        peer, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
@@ -6069,10 +6088,10 @@ ip_no_msdp_peer_cmd_worker (struct vty *vty, const char *peer)
     case PIM_MSDP_ERR_NONE:
       break;
     case PIM_MSDP_ERR_NO_PEER:
-      vty_out(vty, "%% Peer does not exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Peer does not exist");
       break;
     default:
-      vty_out(vty, "%% peer del failed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% peer del failed");
   }
 
   return result?CMD_WARNING:CMD_SUCCESS;
@@ -6098,8 +6117,8 @@ ip_msdp_mesh_group_member_cmd_worker(struct vty *vty, const char *mg, const char
 
   result = inet_pton(AF_INET, mbr, &mbr_ip);
   if (result <= 0) {
-    vty_out(vty, "%% Bad member address %s: errno=%d: %s%s",
-        mbr, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "%% Bad member address %s: errno=%d: %s",
+        mbr, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
@@ -6108,16 +6127,16 @@ ip_msdp_mesh_group_member_cmd_worker(struct vty *vty, const char *mg, const char
     case PIM_MSDP_ERR_NONE:
       break;
     case PIM_MSDP_ERR_OOM:
-      vty_out(vty, "%% Out of memory%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Out of memory");
       break;
     case PIM_MSDP_ERR_MG_MBR_EXISTS:
-      vty_out(vty, "%% mesh-group member exists%s", VTY_NEWLINE);
+      vty_outln (vty, "%% mesh-group member exists");
       break;
     case PIM_MSDP_ERR_MAX_MESH_GROUPS:
-      vty_out(vty, "%% Only one mesh-group allowed currently%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Only one mesh-group allowed currently");
       break;
     default:
-      vty_out(vty, "%% member add failed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% member add failed");
   }
 
   return result?CMD_WARNING:CMD_SUCCESS;
@@ -6144,8 +6163,8 @@ ip_no_msdp_mesh_group_member_cmd_worker(struct vty *vty, const char *mg, const c
 
   result = inet_pton(AF_INET, mbr, &mbr_ip);
   if (result <= 0) {
-    vty_out(vty, "%% Bad member address %s: errno=%d: %s%s",
-        mbr, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "%% Bad member address %s: errno=%d: %s",
+        mbr, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
@@ -6154,13 +6173,13 @@ ip_no_msdp_mesh_group_member_cmd_worker(struct vty *vty, const char *mg, const c
     case PIM_MSDP_ERR_NONE:
       break;
     case PIM_MSDP_ERR_NO_MG:
-      vty_out(vty, "%% mesh-group does not exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% mesh-group does not exist");
       break;
     case PIM_MSDP_ERR_NO_MG_MBR:
-      vty_out(vty, "%% mesh-group member does not exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% mesh-group member does not exist");
       break;
     default:
-      vty_out(vty, "%% mesh-group member del failed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% mesh-group member del failed");
   }
 
   return result?CMD_WARNING:CMD_SUCCESS;
@@ -6187,8 +6206,8 @@ ip_msdp_mesh_group_source_cmd_worker(struct vty *vty, const char *mg, const char
 
   result = inet_pton(AF_INET, src, &src_ip);
   if (result <= 0) {
-    vty_out(vty, "%% Bad source address %s: errno=%d: %s%s",
-        src, errno, safe_strerror(errno), VTY_NEWLINE);
+    vty_outln (vty, "%% Bad source address %s: errno=%d: %s",
+        src, errno, safe_strerror(errno));
     return CMD_WARNING;
   }
 
@@ -6197,13 +6216,13 @@ ip_msdp_mesh_group_source_cmd_worker(struct vty *vty, const char *mg, const char
     case PIM_MSDP_ERR_NONE:
       break;
     case PIM_MSDP_ERR_OOM:
-      vty_out(vty, "%% Out of memory%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Out of memory");
       break;
     case PIM_MSDP_ERR_MAX_MESH_GROUPS:
-      vty_out(vty, "%% Only one mesh-group allowed currently%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Only one mesh-group allowed currently");
       break;
     default:
-      vty_out(vty, "%% source add failed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% source add failed");
   }
 
   return result?CMD_WARNING:CMD_SUCCESS;
@@ -6233,10 +6252,10 @@ ip_no_msdp_mesh_group_source_cmd_worker(struct vty *vty, const char *mg)
     case PIM_MSDP_ERR_NONE:
       break;
     case PIM_MSDP_ERR_NO_MG:
-      vty_out(vty, "%% mesh-group does not exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% mesh-group does not exist");
       break;
     default:
-      vty_out(vty, "%% mesh-group source del failed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% mesh-group source del failed");
   }
 
   return result?CMD_WARNING:CMD_SUCCESS;
@@ -6252,10 +6271,10 @@ ip_no_msdp_mesh_group_cmd_worker(struct vty *vty, const char *mg)
     case PIM_MSDP_ERR_NONE:
       break;
     case PIM_MSDP_ERR_NO_MG:
-      vty_out(vty, "%% mesh-group does not exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% mesh-group does not exist");
       break;
     default:
-      vty_out(vty, "%% mesh-group source del failed%s", VTY_NEWLINE);
+      vty_outln (vty, "%% mesh-group source del failed");
   }
 
   return result ? CMD_WARNING : CMD_SUCCESS;
@@ -6283,7 +6302,8 @@ print_empty_json_obj(struct vty *vty)
 {
   json_object *json;
   json = json_object_new_object();
-  vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+  vty_outln (vty, "%s",
+             json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
   json_object_free(json);
 }
 
@@ -6317,9 +6337,9 @@ ip_msdp_show_mesh_group(struct vty *vty, u_char uj)
     json_object_string_add(json_mg_row, "name", mg->mesh_group_name);
     json_object_string_add(json_mg_row, "source", src_str);
   } else {
-    vty_out(vty, "Mesh group : %s%s", mg->mesh_group_name, VTY_NEWLINE);
-    vty_out(vty, "  Source : %s%s", src_str, VTY_NEWLINE);
-    vty_out(vty, "  Member                 State%s", VTY_NEWLINE);
+    vty_outln (vty, "Mesh group : %s", mg->mesh_group_name);
+    vty_outln (vty, "  Source : %s", src_str);
+    vty_outln (vty, "  Member                 State");
   }
 
   for (ALL_LIST_ELEMENTS_RO(mg->mbr_list, mbrnode, mbr)) {
@@ -6340,14 +6360,15 @@ ip_msdp_show_mesh_group(struct vty *vty, u_char uj)
       }
       json_object_object_add(json_members, mbr_str, json_row);
     } else {
-      vty_out(vty, "  %-15s  %11s%s",
-          mbr_str, state_str, VTY_NEWLINE);
+      vty_outln (vty, "  %-15s  %11s",
+          mbr_str, state_str);
     }
   }
 
   if (uj) {
     json_object_object_add(json, mg->mesh_group_name, json_mg_row);
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -6384,7 +6405,8 @@ ip_msdp_show_peers(struct vty *vty, u_char uj)
   if (uj) {
     json = json_object_new_object();
   } else {
-    vty_out(vty, "Peer                       Local        State    Uptime   SaCnt%s", VTY_NEWLINE);
+    vty_outln (vty,
+              "Peer                       Local        State    Uptime   SaCnt");
   }
 
   for (ALL_LIST_ELEMENTS_RO(msdp->peer_list, mpnode, mp)) {
@@ -6406,14 +6428,15 @@ ip_msdp_show_peers(struct vty *vty, u_char uj)
       json_object_int_add(json_row, "saCount", mp->sa_cnt);
       json_object_object_add(json, peer_str, json_row);
     } else {
-      vty_out(vty, "%-15s  %15s  %11s  %8s  %6d%s",
+      vty_outln (vty, "%-15s  %15s  %11s  %8s  %6d",
           peer_str, local_str, state_str,
-          timebuf, mp->sa_cnt, VTY_NEWLINE);
+          timebuf, mp->sa_cnt);
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -6476,31 +6499,32 @@ ip_msdp_show_peers_detail(struct vty *vty, const char *peer, u_char uj)
       json_object_int_add(json_row, "saRcvd", mp->sa_rx_cnt);
       json_object_object_add(json, peer_str, json_row);
     } else {
-      vty_out(vty, "Peer : %s%s", peer_str, VTY_NEWLINE);
-      vty_out(vty, "  Local               : %s%s", local_str, VTY_NEWLINE);
-      vty_out(vty, "  Mesh Group          : %s%s", mp->mesh_group_name, VTY_NEWLINE);
-      vty_out(vty, "  State               : %s%s", state_str, VTY_NEWLINE);
-      vty_out(vty, "  Uptime              : %s%s", timebuf, VTY_NEWLINE);
+      vty_outln (vty, "Peer : %s", peer_str);
+      vty_outln (vty, "  Local               : %s", local_str);
+      vty_outln (vty, "  Mesh Group          : %s", mp->mesh_group_name);
+      vty_outln (vty, "  State               : %s", state_str);
+      vty_outln (vty, "  Uptime              : %s", timebuf);
 
-      vty_out(vty, "  Keepalive Timer     : %s%s", katimer, VTY_NEWLINE);
-      vty_out(vty, "  Conn Retry Timer    : %s%s", crtimer, VTY_NEWLINE);
-      vty_out(vty, "  Hold Timer          : %s%s", holdtimer, VTY_NEWLINE);
-      vty_out(vty, "  Last Reset          : %s%s", mp->last_reset, VTY_NEWLINE);
-      vty_out(vty, "  Conn Attempts       : %d%s", mp->conn_attempts, VTY_NEWLINE);
-      vty_out(vty, "  Established Changes : %d%s", mp->est_flaps, VTY_NEWLINE);
-      vty_out(vty, "  SA Count            : %d%s", mp->sa_cnt, VTY_NEWLINE);
-      vty_out(vty, "  Statistics          :%s", VTY_NEWLINE);
-      vty_out(vty, "                       Sent       Rcvd%s", VTY_NEWLINE);
-      vty_out(vty, "    Keepalives : %10d %10d%s",
-          mp->ka_tx_cnt, mp->ka_rx_cnt, VTY_NEWLINE);
-      vty_out(vty, "    SAs        : %10d %10d%s",
-          mp->sa_tx_cnt, mp->sa_rx_cnt, VTY_NEWLINE);
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "  Keepalive Timer     : %s", katimer);
+      vty_outln (vty, "  Conn Retry Timer    : %s", crtimer);
+      vty_outln (vty, "  Hold Timer          : %s", holdtimer);
+      vty_outln (vty, "  Last Reset          : %s", mp->last_reset);
+      vty_outln (vty, "  Conn Attempts       : %d", mp->conn_attempts);
+      vty_outln (vty, "  Established Changes : %d", mp->est_flaps);
+      vty_outln (vty, "  SA Count            : %d", mp->sa_cnt);
+      vty_outln (vty, "  Statistics          :");
+      vty_outln (vty, "                       Sent       Rcvd");
+      vty_outln (vty, "    Keepalives : %10d %10d",
+          mp->ka_tx_cnt, mp->ka_rx_cnt);
+      vty_outln (vty, "    SAs        : %10d %10d",
+          mp->sa_tx_cnt, mp->sa_rx_cnt);
+      vty_outln (vty, "");
     }
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -6547,7 +6571,8 @@ ip_msdp_show_sa(struct vty *vty, u_char uj)
   if (uj) {
     json = json_object_new_object();
   } else {
-    vty_out(vty, "Source                     Group               RP  Local  SPT    Uptime%s", VTY_NEWLINE);
+    vty_outln (vty,
+              "Source                     Group               RP  Local  SPT    Uptime");
   }
 
   for (ALL_LIST_ELEMENTS_RO(msdp->sa_list, sanode, sa)) {
@@ -6588,14 +6613,15 @@ ip_msdp_show_sa(struct vty *vty, u_char uj)
       json_object_string_add(json_row, "upTime", timebuf);
       json_object_object_add(json_group, src_str, json_row);
     } else {
-      vty_out(vty, "%-15s  %15s  %15s  %5c  %3c  %8s%s",
-          src_str, grp_str, rp_str, local_str[0], spt_str[0], timebuf, VTY_NEWLINE);
+      vty_outln (vty, "%-15s  %15s  %15s  %5c  %3c  %8s",
+          src_str, grp_str, rp_str, local_str[0], spt_str[0], timebuf);
     }
   }
 
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -6654,14 +6680,14 @@ ip_msdp_show_sa_entry_detail(struct pim_msdp_sa *sa, const char *src_str,
     json_object_string_add(json_row, "stateTimer", statetimer);
     json_object_object_add(json_group, src_str, json_row);
   } else {
-    vty_out(vty, "SA : %s%s", sa->sg_str, VTY_NEWLINE);
-    vty_out(vty, "  RP          : %s%s", rp_str, VTY_NEWLINE);
-    vty_out(vty, "  Peer        : %s%s", peer_str, VTY_NEWLINE);
-    vty_out(vty, "  Local       : %s%s", local_str, VTY_NEWLINE);
-    vty_out(vty, "  SPT Setup   : %s%s", spt_str, VTY_NEWLINE);
-    vty_out(vty, "  Uptime      : %s%s", timebuf, VTY_NEWLINE);
-    vty_out(vty, "  State Timer : %s%s", statetimer, VTY_NEWLINE);
-    vty_out(vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "SA : %s", sa->sg_str);
+    vty_outln (vty, "  RP          : %s", rp_str);
+    vty_outln (vty, "  Peer        : %s", peer_str);
+    vty_outln (vty, "  Local       : %s", local_str);
+    vty_outln (vty, "  SPT Setup   : %s", spt_str);
+    vty_outln (vty, "  Uptime      : %s", timebuf);
+    vty_outln (vty, "  State Timer : %s", statetimer);
+    vty_outln (vty, "");
   }
 }
 
@@ -6685,7 +6711,8 @@ ip_msdp_show_sa_detail(struct vty *vty, u_char uj)
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -6728,7 +6755,8 @@ ip_msdp_show_sa_addr(struct vty *vty, const char *addr, u_char uj)
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }
@@ -6755,7 +6783,8 @@ ip_msdp_show_sa_sg(struct vty *vty, const char *src, const char *grp, u_char uj)
   }
 
   if (uj) {
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -225,7 +225,7 @@ static void pim_show_assert_internal(struct vty *vty)
 	  "ECA:  Evaluate CouldAssert%s"
 	  "ATD:  AssertTrackingDesired%s"
 	  "eATD: Evaluate AssertTrackingDesired%s",
-	  VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+	  VTYNL, VTYNL, VTYNL, VTYNL);
 
   vty_outln (vty,
 	  "Interface Address         Source          Group           CA  eCA ATD eATD");
@@ -1573,7 +1573,7 @@ pim_show_state(struct vty *vty, const char *src_or_group, const char *group, u_c
   } else {
     vty_out(vty, "Codes: J -> Pim Join, I -> IGMP Report, S -> Source, * -> Inherited from (*,G)");
     vty_outln (vty, "%sInstalled Source           Group            IIF      OIL",
-              VTY_NEWLINE);
+              VTYNL);
   }
 
   for (ALL_LIST_ELEMENTS_RO(pim_channel_oil_list, node, c_oil)) {
@@ -2157,12 +2157,12 @@ static void show_rpf_refresh_stats(struct vty *vty, time_t now, json_object *jso
             "RPF Cache Refresh Last:     %s%s"
             "Nexthop Lookups:            %lld%s"
 	    "Nexthop Lookups Avoided:    %lld",
-            qpim_rpf_cache_refresh_delay_msec, VTY_NEWLINE,
-            pim_time_timer_remain_msec(qpim_rpf_cache_refresher), VTY_NEWLINE,
-            (long long)qpim_rpf_cache_refresh_requests, VTY_NEWLINE,
-            (long long)qpim_rpf_cache_refresh_events, VTY_NEWLINE,
-            refresh_uptime, VTY_NEWLINE,
-            (long long) qpim_nexthop_lookups, VTY_NEWLINE,
+            qpim_rpf_cache_refresh_delay_msec, VTYNL,
+            pim_time_timer_remain_msec(qpim_rpf_cache_refresher), VTYNL,
+            (long long)qpim_rpf_cache_refresh_requests, VTYNL,
+            (long long)qpim_rpf_cache_refresh_events, VTYNL,
+            refresh_uptime, VTYNL,
+            (long long) qpim_nexthop_lookups, VTYNL,
 	    (long long)nexthop_lookups_avoided);
   }
 }
@@ -2181,8 +2181,8 @@ static void show_scan_oil_stats(struct vty *vty, time_t now)
           "Scan OIL - Last: %s  Events: %lld%s"
           "MFC Add  - Last: %s  Events: %lld%s"
           "MFC Del  - Last: %s  Events: %lld",
-          uptime_scan_oil,   (long long) qpim_scan_oil_events,   VTY_NEWLINE,
-          uptime_mroute_add, (long long) qpim_mroute_add_events, VTY_NEWLINE,
+          uptime_scan_oil,   (long long) qpim_scan_oil_events,   VTYNL,
+          uptime_mroute_add, (long long) qpim_mroute_add_events, VTYNL,
           uptime_mroute_del, (long long)qpim_mroute_del_events);
 }
 
@@ -3221,7 +3221,7 @@ static void show_multicast_interfaces(struct vty *vty)
 		pim_ifp->mroute_vif_index,
 		errno,
 		safe_strerror(errno),
-		VTY_NEWLINE);
+		VTYNL);
     }
 
     ifaddr = pim_ifp->primary_address;

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1533,15 +1533,15 @@ pim_msdp_config_write(struct vty *vty)
 
   if (mg->src_ip.s_addr != INADDR_ANY) {
     pim_inet4_dump("<src?>", mg->src_ip, src_str, sizeof(src_str));
-    vty_out(vty, "ip msdp mesh-group %s source %s%s",
-        mg->mesh_group_name, src_str, VTY_NEWLINE);
+    vty_outln (vty, "ip msdp mesh-group %s source %s",
+        mg->mesh_group_name, src_str);
     ++count;
   }
 
   for (ALL_LIST_ELEMENTS_RO(mg->mbr_list, mbrnode, mbr)) {
     pim_inet4_dump("<mbr?>", mbr->mbr_ip, mbr_str, sizeof(mbr_str));
-    vty_out(vty, "ip msdp mesh-group %s member %s%s",
-        mg->mesh_group_name, mbr_str, VTY_NEWLINE);
+    vty_outln (vty, "ip msdp mesh-group %s member %s",
+        mg->mesh_group_name, mbr_str);
     ++count;
   }
   return count;

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -821,13 +821,13 @@ pim_rp_config_write (struct vty *vty)
         continue;
 
       if (rp_info->plist)
-        vty_out(vty, "ip pim rp %s prefix-list %s%s",
+        vty_outln (vty, "ip pim rp %s prefix-list %s",
                 inet_ntop(AF_INET, &rp_info->rp.rpf_addr.u.prefix4, rp_buffer, 32),
-                rp_info->plist, VTY_NEWLINE);
+                rp_info->plist);
       else
-        vty_out(vty, "ip pim rp %s %s%s",
+        vty_outln (vty, "ip pim rp %s %s",
                 inet_ntop(AF_INET, &rp_info->rp.rpf_addr.u.prefix4, rp_buffer, 32),
-                prefix2str(&rp_info->group, group_buffer, 32), VTY_NEWLINE);
+                prefix2str(&rp_info->group, group_buffer, 32));
       count++;
     }
 
@@ -878,7 +878,8 @@ pim_rp_show_information (struct vty *vty, u_char uj)
   if (uj)
     json = json_object_new_object();
   else
-    vty_out (vty, "RP address       group/prefix-list   OIF         I am RP%s", VTY_NEWLINE);
+    vty_outln (vty,
+               "RP address       group/prefix-list   OIF         I am RP");
 
   for (ALL_LIST_ELEMENTS_RO (qpim_rp_list, node, rp_info))
     {
@@ -930,9 +931,9 @@ pim_rp_show_information (struct vty *vty, u_char uj)
 		vty_out (vty, "%-10s  ", "(Unknown)");
 
               if (rp_info->i_am_rp)
-                vty_out (vty, "yes%s", VTY_NEWLINE);
+                vty_outln (vty, "yes");
               else
-                vty_out (vty, "no%s", VTY_NEWLINE);
+                vty_outln (vty, "no");
             }
 
           prev_rp_info = rp_info;
@@ -943,7 +944,8 @@ pim_rp_show_information (struct vty *vty, u_char uj)
     if (prev_rp_info && json_rp_rows)
       json_object_object_add(json, inet_ntoa (prev_rp_info->rp.rpf_addr.u.prefix4), json_rp_rows);
 
-    vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+    vty_outln (vty, "%s",
+               json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
     json_object_free(json);
   }
 }

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -337,9 +337,10 @@ pim_static_write_mroute (struct vty *vty, struct interface *ifp)
               {
                 struct interface *oifp = pim_if_find_by_vif_index (i);
                 if (sroute->source.s_addr == 0)
-                  vty_out (vty, " ip mroute %s %s%s", oifp->name, gbuf, VTY_NEWLINE);
+                  vty_outln (vty, " ip mroute %s %s", oifp->name, gbuf);
                 else
-                  vty_out (vty, " ip mroute %s %s %s%s", oifp->name, gbuf, sbuf, VTY_NEWLINE);
+                  vty_outln (vty, " ip mroute %s %s %s", oifp->name, gbuf,
+                             sbuf);
                 count ++;
               }
         }

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -46,97 +46,97 @@ pim_debug_config_write (struct vty *vty)
   int writes = 0;
 
   if (PIM_DEBUG_MSDP_EVENTS) {
-    vty_out(vty, "debug msdp events%s", VTY_NEWLINE);
+    vty_outln (vty, "debug msdp events");
     ++writes;
   }
   if (PIM_DEBUG_MSDP_PACKETS) {
-    vty_out(vty, "debug msdp packets%s", VTY_NEWLINE);
+    vty_outln (vty, "debug msdp packets");
     ++writes;
   }
   if (PIM_DEBUG_MSDP_INTERNAL) {
-    vty_out(vty, "debug msdp internal%s", VTY_NEWLINE);
+    vty_outln (vty, "debug msdp internal");
     ++writes;
   }
   if (PIM_DEBUG_IGMP_EVENTS) {
-    vty_out(vty, "debug igmp events%s", VTY_NEWLINE);
+    vty_outln (vty, "debug igmp events");
     ++writes;
   }
   if (PIM_DEBUG_IGMP_PACKETS) {
-    vty_out(vty, "debug igmp packets%s", VTY_NEWLINE);
+    vty_outln (vty, "debug igmp packets");
     ++writes;
   }
   if (PIM_DEBUG_IGMP_TRACE) {
-    vty_out(vty, "debug igmp trace%s", VTY_NEWLINE);
+    vty_outln (vty, "debug igmp trace");
     ++writes;
   }
   if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
-    vty_out(vty, "debug igmp trace detail%s", VTY_NEWLINE);
+    vty_outln (vty, "debug igmp trace detail");
     ++writes;
   }
 
   if (PIM_DEBUG_MROUTE) {
-    vty_out(vty, "debug mroute%s", VTY_NEWLINE);
+    vty_outln (vty, "debug mroute");
     ++writes;
   }
 
   if (PIM_DEBUG_MROUTE_DETAIL) {
-    vty_out (vty, "debug mroute detail%s", VTY_NEWLINE);
+    vty_outln (vty, "debug mroute detail");
     ++writes;
   }
 
   if (PIM_DEBUG_PIM_EVENTS) {
-    vty_out(vty, "debug pim events%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim events");
     ++writes;
   }
   if (PIM_DEBUG_PIM_PACKETS) {
-    vty_out(vty, "debug pim packets%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim packets");
     ++writes;
   }
   if (PIM_DEBUG_PIM_PACKETDUMP_SEND) {
-    vty_out(vty, "debug pim packet-dump send%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim packet-dump send");
     ++writes;
   }
   if (PIM_DEBUG_PIM_PACKETDUMP_RECV) {
-    vty_out(vty, "debug pim packet-dump receive%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim packet-dump receive");
     ++writes;
   }
 
   if (PIM_DEBUG_PIM_TRACE) {
-    vty_out(vty, "debug pim trace%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim trace");
     ++writes;
   }
   if (PIM_DEBUG_PIM_TRACE_DETAIL) {
-    vty_out(vty, "debug pim trace detail%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim trace detail");
     ++writes;
   }
 
   if (PIM_DEBUG_ZEBRA) {
-    vty_out(vty, "debug pim zebra%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim zebra");
     ++writes;
   }
 
   if (PIM_DEBUG_SSMPINGD) {
-    vty_out(vty, "debug ssmpingd%s", VTY_NEWLINE);
+    vty_outln (vty, "debug ssmpingd");
     ++writes;
   }
 
   if (PIM_DEBUG_PIM_HELLO) {
-    vty_out (vty, "debug pim packets hello%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim packets hello");
     ++writes;
   }
 
   if (PIM_DEBUG_PIM_J_P) {
-    vty_out (vty, "debug pim packets joins%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim packets joins");
     ++writes;
   }
 
   if (PIM_DEBUG_PIM_REG) {
-    vty_out (vty, "debug pim packets register%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim packets register");
     ++writes;
   }
 
   if (PIM_DEBUG_STATIC) {
-    vty_out (vty, "debug pim static%s", VTY_NEWLINE);
+    vty_outln (vty, "debug pim static");
     ++writes;
   }
 
@@ -152,7 +152,7 @@ int pim_global_config_write(struct vty *vty)
 
   if (!pimg->send_v6_secondary)
     {
-      vty_out (vty, "no ip pim send-v6-secondary%s", VTY_NEWLINE);
+      vty_outln (vty, "no ip pim send-v6-secondary");
       ++writes;
     }
 
@@ -160,63 +160,62 @@ int pim_global_config_write(struct vty *vty)
 
   if (qpim_register_suppress_time != PIM_REGISTER_SUPPRESSION_TIME_DEFAULT)
     {
-      vty_out (vty, "ip pim register-suppress-time %d%s",
-	       qpim_register_suppress_time, VTY_NEWLINE);
+      vty_outln (vty, "ip pim register-suppress-time %d",
+	       qpim_register_suppress_time);
       ++writes;
     }
   if (qpim_t_periodic != PIM_DEFAULT_T_PERIODIC)
     {
-      vty_out (vty, "ip pim join-prune-interval %d%s",
-	       qpim_t_periodic, VTY_NEWLINE);
+      vty_outln (vty, "ip pim join-prune-interval %d",
+	       qpim_t_periodic);
       ++writes;
     }
   if (qpim_keep_alive_time != PIM_KEEPALIVE_PERIOD)
     {
-      vty_out (vty, "ip pim keep-alive-timer %d%s",
-               qpim_keep_alive_time, VTY_NEWLINE);
+      vty_outln (vty, "ip pim keep-alive-timer %d",
+               qpim_keep_alive_time);
       ++writes;
     }
   if (qpim_packet_process != PIM_DEFAULT_PACKET_PROCESS)
     {
-      vty_out (vty, "ip pim packets %d%s",
-	       qpim_packet_process, VTY_NEWLINE);
+      vty_outln (vty, "ip pim packets %d",
+	       qpim_packet_process);
       ++writes;
     }
   if (ssm->plist_name)
     {
-      vty_out (vty, "ip pim ssm prefix-list %s%s",
-               ssm->plist_name, VTY_NEWLINE);
+      vty_outln (vty, "ip pim ssm prefix-list %s",
+               ssm->plist_name);
       ++writes;
     }
   if (pimg->spt.switchover == PIM_SPT_INFINITY)
     {
       if (pimg->spt.plist)
-        vty_out (vty, "ip pim spt-switchover infinity-and-beyond prefix-list %s%s",
-                 pimg->spt.plist, VTY_NEWLINE);
+        vty_outln (vty, "ip pim spt-switchover infinity-and-beyond prefix-list %s",
+                 pimg->spt.plist);
       else
-        vty_out (vty, "ip pim spt-switchover infinity-and-beyond%s",
-                 VTY_NEWLINE);
+        vty_outln (vty,"ip pim spt-switchover infinity-and-beyond");
       ++writes;
     }
   if (qpim_ecmp_rebalance_enable)
     {
-      vty_out (vty, "ip pim ecmp rebalance%s", VTY_NEWLINE);
+      vty_outln (vty, "ip pim ecmp rebalance");
       ++writes;
     }
   else if (qpim_ecmp_enable)
     {
-      vty_out (vty, "ip pim ecmp%s", VTY_NEWLINE);
+      vty_outln (vty, "ip pim ecmp");
       ++writes;
     }
   if (qpim_ssmpingd_list) {
     struct listnode *node;
     struct ssmpingd_sock *ss;
-    vty_out(vty, "!%s", VTY_NEWLINE);
+    vty_outln (vty, "!");
     ++writes;
     for (ALL_LIST_ELEMENTS_RO(qpim_ssmpingd_list, node, ss)) {
       char source_str[INET_ADDRSTRLEN];
       pim_inet4_dump("<src?>", ss->source_addr, source_str, sizeof(source_str));
-      vty_out(vty, "ip ssmpingd %s%s", source_str, VTY_NEWLINE);
+      vty_outln (vty, "ip ssmpingd %s", source_str);
       ++writes;
     }
   }
@@ -233,21 +232,20 @@ int pim_interface_config_write(struct vty *vty)
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp)) {
 
     /* IF name */
-    vty_out(vty, "interface %s%s", ifp->name, VTY_NEWLINE);
+    vty_outln (vty, "interface %s", ifp->name);
     ++writes;
 
     if (ifp->info) {
       struct pim_interface *pim_ifp = ifp->info;
 
       if (PIM_IF_TEST_PIM(pim_ifp->options)) {
-	vty_out(vty, " ip pim sm%s", VTY_NEWLINE);
+	vty_outln (vty, " ip pim sm");
 	++writes;
       }
 
       /* IF ip pim drpriority */
       if (pim_ifp->pim_dr_priority != PIM_DEFAULT_DR_PRIORITY) {
-	vty_out(vty, " ip pim drpriority %u%s", pim_ifp->pim_dr_priority,
-		VTY_NEWLINE);
+	vty_outln (vty, " ip pim drpriority %u",pim_ifp->pim_dr_priority);
 	++writes;
       }
 
@@ -256,7 +254,7 @@ int pim_interface_config_write(struct vty *vty)
 	vty_out(vty, " ip pim hello %d", pim_ifp->pim_hello_period);
 	if (pim_ifp->pim_default_holdtime != -1)
 	  vty_out(vty, " %d", pim_ifp->pim_default_holdtime);
-	vty_out(vty, "%s", VTY_NEWLINE);
+	vty_outln (vty, "");
       }
 
       /* update source */
@@ -264,40 +262,37 @@ int pim_interface_config_write(struct vty *vty)
         char src_str[INET_ADDRSTRLEN];
         pim_inet4_dump("<src?>", pim_ifp->update_source, src_str,
             sizeof(src_str));
-        vty_out(vty, " ip pim use-source %s%s", src_str, VTY_NEWLINE);
+        vty_outln (vty, " ip pim use-source %s", src_str);
         ++writes;
       }
 
       /* IF ip igmp */
       if (PIM_IF_TEST_IGMP(pim_ifp->options)) {
-	vty_out(vty, " ip igmp%s", VTY_NEWLINE);
+	vty_outln (vty, " ip igmp");
 	++writes;
       }
 
       /* ip igmp version */
       if (pim_ifp->igmp_version != IGMP_DEFAULT_VERSION)
         {
-          vty_out(vty, " ip igmp version %d%s",
-                  pim_ifp->igmp_version,
-                  VTY_NEWLINE);
+          vty_outln (vty, " ip igmp version %d",
+                  pim_ifp->igmp_version);
           ++writes;
         }
 
       /* IF ip igmp query-interval */
       if (pim_ifp->igmp_default_query_interval != IGMP_GENERAL_QUERY_INTERVAL)
 	{
-	  vty_out(vty, " ip igmp query-interval %d%s",
-		  pim_ifp->igmp_default_query_interval,
-		  VTY_NEWLINE);
+	  vty_outln (vty, " ip igmp query-interval %d",
+		  pim_ifp->igmp_default_query_interval);
 	  ++writes;
 	}
 
       /* IF ip igmp query-max-response-time */
       if (pim_ifp->igmp_query_max_response_time_dsec != IGMP_QUERY_MAX_RESPONSE_TIME_DSEC)
 	{
-	  vty_out(vty, " ip igmp query-max-response-time %d%s",
-		  pim_ifp->igmp_query_max_response_time_dsec,
-		  VTY_NEWLINE);
+	  vty_outln (vty, " ip igmp query-max-response-time %d",
+		  pim_ifp->igmp_query_max_response_time_dsec);
 	  ++writes;
 	}
 
@@ -310,16 +305,15 @@ int pim_interface_config_write(struct vty *vty)
 	  char source_str[INET_ADDRSTRLEN];
 	  pim_inet4_dump("<grp?>", ij->group_addr, group_str, sizeof(group_str));
           inet_ntop(AF_INET, &ij->source_addr, source_str, sizeof(source_str));
-	  vty_out(vty, " ip igmp join %s %s%s",
-		  group_str, source_str,
-		  VTY_NEWLINE);
+	  vty_outln (vty, " ip igmp join %s %s",
+		  group_str,source_str);
 	  ++writes;
 	}
       }
 
 	writes += pim_static_write_mroute (vty, ifp);
     }
-    vty_out(vty, "!%s", VTY_NEWLINE);
+    vty_outln (vty, "!");
     ++writes;
     /* PIM BFD write */
     pim_bfd_write_config (vty, ifp);

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -254,7 +254,7 @@ int pim_interface_config_write(struct vty *vty)
 	vty_out(vty, " ip pim hello %d", pim_ifp->pim_hello_period);
 	if (pim_ifp->pim_default_holdtime != -1)
 	  vty_out(vty, " %d", pim_ifp->pim_default_holdtime);
-	vty_outln (vty, "");
+	vty_out (vty, VTYNL);
       }
 
       /* update source */

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -1151,11 +1151,11 @@ pim_zebra_zclient_update (struct vty *vty)
   vty_out(vty, "Zclient update socket: ");
 
   if (zclient) {
-    vty_out(vty, "%d failures=%d%s", zclient->sock,
-	    zclient->fail, VTY_NEWLINE);
+    vty_outln (vty, "%d failures=%d", zclient->sock,
+	    zclient->fail);
   }
   else {
-    vty_out(vty, "<null zclient>%s", VTY_NEWLINE);
+    vty_outln (vty, "<null zclient>");
   }
 }
 

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -438,11 +438,11 @@ pim_zlookup_show_ip_multicast (struct vty *vty)
 {
   vty_out(vty, "Zclient lookup socket: ");
   if (zlookup) {
-    vty_out(vty, "%d failures=%d%s", zlookup->sock,
-            zlookup->fail, VTY_NEWLINE);
+    vty_outln (vty, "%d failures=%d", zlookup->sock,
+            zlookup->fail);
   }
   else {
-    vty_out(vty, "<null zclient>%s", VTY_NEWLINE);
+    vty_outln (vty, "<null zclient>");
   }
 }
 

--- a/python/clidef.py
+++ b/python/clidef.py
@@ -142,8 +142,8 @@ $argdecls
 			continue;
 		_fail = 0;$argblocks
 		if (_fail)
-			vty_out (vty, "%% invalid input for %s: %s%s",
-				argv[_i]->varname, argv[_i]->arg, VTY_NEWLINE);
+			vty_outln (vty, "%% invalid input for %s: %s",
+				   argv[_i]->varname, argv[_i]->arg);
 		_failcnt += _fail;
 	}
 	if (_failcnt)

--- a/ripd/rip_debug.c
+++ b/ripd/rip_debug.c
@@ -34,31 +34,28 @@ DEFUN (show_debugging_rip,
        DEBUG_STR
        RIP_STR)
 {
-  vty_out (vty, "RIP debugging status:%s", VTY_NEWLINE);
+  vty_outln (vty, "RIP debugging status:");
 
   if (IS_RIP_DEBUG_EVENT)
-    vty_out (vty, "  RIP event debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  RIP event debugging is on");
 
   if (IS_RIP_DEBUG_PACKET)
     {
       if (IS_RIP_DEBUG_SEND && IS_RIP_DEBUG_RECV)
 	{
-	  vty_out (vty, "  RIP packet debugging is on%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"  RIP packet debugging is on");
 	}
       else
 	{
 	  if (IS_RIP_DEBUG_SEND)
-	    vty_out (vty, "  RIP packet send debugging is on%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty,"  RIP packet send debugging is on");
 	  else
-	    vty_out (vty, "  RIP packet receive debugging is on%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty,"  RIP packet receive debugging is on");
 	}
     }
 
   if (IS_RIP_DEBUG_ZEBRA)
-    vty_out (vty, "  RIP zebra debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  RIP zebra debugging is on");
 
   return CMD_SUCCESS;
 }
@@ -195,31 +192,28 @@ config_write_debug (struct vty *vty)
 
   if (IS_RIP_DEBUG_EVENT)
     {
-      vty_out (vty, "debug rip events%s", VTY_NEWLINE);
+      vty_outln (vty, "debug rip events");
       write++;
     }
   if (IS_RIP_DEBUG_PACKET)
     {
       if (IS_RIP_DEBUG_SEND && IS_RIP_DEBUG_RECV)
 	{
-	  vty_out (vty, "debug rip packet%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"debug rip packet");
 	  write++;
 	}
       else
 	{
 	  if (IS_RIP_DEBUG_SEND)
-	    vty_out (vty, "debug rip packet send%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty,"debug rip packet send");
 	  else
-	    vty_out (vty, "debug rip packet recv%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty,"debug rip packet recv");
 	  write++;
 	}
     }
   if (IS_RIP_DEBUG_ZEBRA)
     {
-      vty_out (vty, "debug rip zebra%s", VTY_NEWLINE);
+      vty_outln (vty, "debug rip zebra");
       write++;
     }
   return write;

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -1922,7 +1922,7 @@ rip_interface_config_write (struct vty *vty)
             vty_out (vty, " auth-length old-ripd");
           else 
             vty_out (vty, " auth-length rfc");
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
         }
 
       if (ri->auth_str)

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -1233,8 +1233,8 @@ DEFUN (rip_network,
 
   if (ret < 0)
     {
-      vty_out (vty, "There is a same network configuration %s%s", argv[idx_ipv4_word]->arg,
-	       VTY_NEWLINE);
+      vty_outln (vty, "There is a same network configuration %s",
+                 argv[idx_ipv4_word]->arg);
       return CMD_WARNING;
     }
 
@@ -1263,8 +1263,8 @@ DEFUN (no_rip_network,
 
   if (ret < 0)
     {
-      vty_out (vty, "Can't find network configuration %s%s", argv[idx_ipv4_word]->arg,
-	       VTY_NEWLINE);
+      vty_outln (vty, "Can't find network configuration %s",
+                 argv[idx_ipv4_word]->arg);
       return CMD_WARNING;
     }
 
@@ -1286,7 +1286,7 @@ DEFUN (rip_neighbor,
 
   if (ret <= 0)
     {
-      vty_out (vty, "Please specify address by A.B.C.D%s", VTY_NEWLINE);
+      vty_outln (vty, "Please specify address by A.B.C.D");
       return CMD_WARNING;
     }
 
@@ -1311,7 +1311,7 @@ DEFUN (no_rip_neighbor,
 
   if (ret <= 0)
     {
-      vty_out (vty, "Please specify address by A.B.C.D%s", VTY_NEWLINE);
+      vty_outln (vty, "Please specify address by A.B.C.D");
       return CMD_WARNING;
     }
 
@@ -1574,7 +1574,7 @@ DEFUN (ip_rip_authentication_mode,
   {
     if (auth_type != RIP_AUTH_MD5)
     {
-      vty_out (vty, "auth length argument only valid for md5%s", VTY_NEWLINE);
+      vty_outln (vty, "auth length argument only valid for md5");
       return CMD_WARNING;
     }
     if (strmatch ("rfc", authlen))
@@ -1631,14 +1631,14 @@ DEFUN (ip_rip_authentication_string,
 
   if (strlen (argv[idx_line]->arg) > 16)
     {
-      vty_out (vty, "%% RIPv2 authentication string must be shorter than 16%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,
+                 "%% RIPv2 authentication string must be shorter than 16");
       return CMD_WARNING;
     }
 
   if (ri->key_chain)
     {
-      vty_out (vty, "%% key-chain configuration exists%s", VTY_NEWLINE);
+      vty_outln (vty, "%% key-chain configuration exists");
       return CMD_WARNING;
     }
 
@@ -1691,8 +1691,7 @@ DEFUN (ip_rip_authentication_key_chain,
 
   if (ri->auth_str)
     {
-      vty_out (vty, "%% authentication string configuration exists%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,"%% authentication string configuration exists");
       return CMD_WARNING;
     }
 
@@ -1878,48 +1877,43 @@ rip_interface_config_write (struct vty *vty)
           (!ri->key_chain)                                 )
         continue;
 
-      vty_out (vty, "interface %s%s", ifp->name,
-	       VTY_NEWLINE);
+      vty_outln (vty, "interface %s",ifp->name);
 
       if (ifp->desc)
-	vty_out (vty, " description %s%s", ifp->desc,
-		 VTY_NEWLINE);
+	vty_outln (vty, " description %s",ifp->desc);
 
       /* Split horizon. */
       if (ri->split_horizon != ri->split_horizon_default)
 	{
           switch (ri->split_horizon) {
           case RIP_SPLIT_HORIZON:
-            vty_out (vty, " ip rip split-horizon%s", VTY_NEWLINE);
+            vty_outln (vty, " ip rip split-horizon");
             break;
           case RIP_SPLIT_HORIZON_POISONED_REVERSE:
-            vty_out (vty, " ip rip split-horizon poisoned-reverse%s",
-                          VTY_NEWLINE);
+            vty_outln (vty," ip rip split-horizon poisoned-reverse");
             break;
           case RIP_NO_SPLIT_HORIZON:
           default:
-            vty_out (vty, " no ip rip split-horizon%s", VTY_NEWLINE);
+            vty_outln (vty, " no ip rip split-horizon");
             break;
           }
 	}
 
       /* RIP version setting. */
       if (ri->ri_send != RI_RIP_UNSPEC)
-	vty_out (vty, " ip rip send version %s%s",
-		 lookup_msg(ri_version_msg, ri->ri_send, NULL),
-		 VTY_NEWLINE);
+	vty_outln (vty, " ip rip send version %s",
+		   lookup_msg(ri_version_msg, ri->ri_send, NULL));
 
       if (ri->ri_receive != RI_RIP_UNSPEC)
-	vty_out (vty, " ip rip receive version %s%s",
-		 lookup_msg(ri_version_msg, ri->ri_receive, NULL),
-		 VTY_NEWLINE);
+	vty_outln (vty, " ip rip receive version %s ",
+		   lookup_msg(ri_version_msg, ri->ri_receive, NULL));
 
       if (ri->v2_broadcast)
-	vty_out (vty, " ip rip v2-broadcast%s", VTY_NEWLINE);
+	vty_outln (vty, " ip rip v2-broadcast");
 
       /* RIP authentication. */
       if (ri->auth_type == RIP_AUTH_SIMPLE_PASSWORD)
-	vty_out (vty, " ip rip authentication mode text%s", VTY_NEWLINE);
+	vty_outln (vty, " ip rip authentication mode text");
 
       if (ri->auth_type == RIP_AUTH_MD5)
         {
@@ -1928,18 +1922,18 @@ rip_interface_config_write (struct vty *vty)
             vty_out (vty, " auth-length old-ripd");
           else 
             vty_out (vty, " auth-length rfc");
-          vty_out (vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
         }
 
       if (ri->auth_str)
-	vty_out (vty, " ip rip authentication string %s%s",
-		 ri->auth_str, VTY_NEWLINE);
+	vty_outln (vty, " ip rip authentication string %s",
+		 ri->auth_str);
 
       if (ri->key_chain)
-	vty_out (vty, " ip rip authentication key-chain %s%s",
-		 ri->key_chain, VTY_NEWLINE);
+	vty_outln (vty, " ip rip authentication key-chain %s",
+		 ri->key_chain);
 
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_outln (vty, "!");
     }
   return 0;
 }
@@ -1954,36 +1948,33 @@ config_write_rip_network (struct vty *vty, int config_mode)
   /* Network type RIP enable interface statement. */
   for (node = route_top (rip_enable_network); node; node = route_next (node))
     if (node->info)
-      vty_out (vty, "%s%s/%d%s", 
+      vty_outln (vty, "%s%s/%d", 
 	       config_mode ? " network " : "    ",
 	       inet_ntoa (node->p.u.prefix4),
-	       node->p.prefixlen,
-	       VTY_NEWLINE);
+	       node->p.prefixlen);
 
   /* Interface name RIP enable statement. */
   for (i = 0; i < vector_active (rip_enable_interface); i++)
     if ((ifname = vector_slot (rip_enable_interface, i)) != NULL)
-      vty_out (vty, "%s%s%s",
+      vty_outln (vty, "%s%s",
 	       config_mode ? " network " : "    ",
-	       ifname,
-	       VTY_NEWLINE);
+	       ifname);
 
   /* RIP neighbors listing. */
   for (node = route_top (rip->neighbor); node; node = route_next (node))
     if (node->info)
-      vty_out (vty, "%s%s%s", 
+      vty_outln (vty, "%s%s", 
 	       config_mode ? " neighbor " : "    ",
-	       inet_ntoa (node->p.u.prefix4),
-	       VTY_NEWLINE);
+	       inet_ntoa(node->p.u.prefix4));
 
   /* RIP passive interface listing. */
   if (config_mode) {
     if (passive_default)
-      vty_out (vty, " passive-interface default%s", VTY_NEWLINE);
+      vty_outln (vty, " passive-interface default");
     for (i = 0; i < vector_active (Vrip_passive_nondefault); i++)
       if ((ifname = vector_slot (Vrip_passive_nondefault, i)) != NULL)
-	vty_out (vty, " %spassive-interface %s%s",
-		 (passive_default ? "no " : ""), ifname, VTY_NEWLINE);
+	vty_outln (vty, " %spassive-interface %s",
+		 (passive_default ? "no " : ""), ifname);
   }
 
   return 0;

--- a/ripd/rip_offset.c
+++ b/ripd/rip_offset.c
@@ -117,7 +117,7 @@ rip_offset_list_set (struct vty *vty, const char *alist, const char *direct_str,
     direct = RIP_OFFSET_LIST_OUT;
   else
     {
-      vty_out (vty, "Invalid direction: %s%s", direct_str, VTY_NEWLINE);
+      vty_outln (vty, "Invalid direction: %s", direct_str);
       return CMD_WARNING;
     }
 
@@ -125,7 +125,7 @@ rip_offset_list_set (struct vty *vty, const char *alist, const char *direct_str,
   metric = atoi (metric_str);
   if (metric < 0 || metric > 16)
     {
-      vty_out (vty, "Invalid metric: %s%s", metric_str, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric: %s", metric_str);
       return CMD_WARNING;
     }
 
@@ -156,7 +156,7 @@ rip_offset_list_unset (struct vty *vty, const char *alist,
     direct = RIP_OFFSET_LIST_OUT;
   else
     {
-      vty_out (vty, "Invalid direction: %s%s", direct_str, VTY_NEWLINE);
+      vty_outln (vty, "Invalid direction: %s", direct_str);
       return CMD_WARNING;
     }
 
@@ -164,7 +164,7 @@ rip_offset_list_unset (struct vty *vty, const char *alist,
   metric = atoi (metric_str);
   if (metric < 0 || metric > 16)
     {
-      vty_out (vty, "Invalid metric: %s%s", metric_str, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric: %s", metric_str);
       return CMD_WARNING;
     }
 
@@ -188,7 +188,7 @@ rip_offset_list_unset (struct vty *vty, const char *alist,
     }
   else
     {
-      vty_out (vty, "Can't find offset-list%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't find offset-list");
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -397,28 +397,26 @@ config_write_rip_offset_list (struct vty *vty)
       if (! offset->ifname)
 	{
 	  if (offset->direct[RIP_OFFSET_LIST_IN].alist_name)
-	    vty_out (vty, " offset-list %s in %d%s",
+	    vty_outln (vty, " offset-list %s in %d",
 		     offset->direct[RIP_OFFSET_LIST_IN].alist_name,
-		     offset->direct[RIP_OFFSET_LIST_IN].metric,
-		     VTY_NEWLINE);
+		     offset->direct[RIP_OFFSET_LIST_IN].metric);
 	  if (offset->direct[RIP_OFFSET_LIST_OUT].alist_name)
-	    vty_out (vty, " offset-list %s out %d%s",
+	    vty_outln (vty, " offset-list %s out %d",
 		     offset->direct[RIP_OFFSET_LIST_OUT].alist_name,
-		     offset->direct[RIP_OFFSET_LIST_OUT].metric,
-		     VTY_NEWLINE);
+		     offset->direct[RIP_OFFSET_LIST_OUT].metric);
 	}
       else
 	{
 	  if (offset->direct[RIP_OFFSET_LIST_IN].alist_name)
-	    vty_out (vty, " offset-list %s in %d %s%s",
+	    vty_outln (vty, " offset-list %s in %d %s",
 		     offset->direct[RIP_OFFSET_LIST_IN].alist_name,
 		     offset->direct[RIP_OFFSET_LIST_IN].metric,
-		     offset->ifname, VTY_NEWLINE);
+		     offset->ifname);
 	  if (offset->direct[RIP_OFFSET_LIST_OUT].alist_name)
-	    vty_out (vty, " offset-list %s out %d %s%s",
+	    vty_outln (vty, " offset-list %s out %d %s",
 		     offset->direct[RIP_OFFSET_LIST_OUT].alist_name,
 		     offset->direct[RIP_OFFSET_LIST_OUT].metric,
-		     offset->ifname, VTY_NEWLINE);
+		     offset->ifname);
 	}
     }
 

--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -185,11 +185,10 @@ rip_peer_display (struct vty *vty)
 
   for (ALL_LIST_ELEMENTS (peer_list, node, nnode, peer))
     {
-      vty_out (vty, "    %-16s %9d %9d %9d   %s%s", inet_ntoa (peer->addr),
+      vty_outln (vty, "    %-16s %9d %9d %9d   %s", inet_ntoa (peer->addr),
 	       peer->recv_badpackets, peer->recv_badroutes,
 	       ZEBRA_RIP_DISTANCE_DEFAULT,
-	       rip_peer_uptime (peer, timebuf, RIP_UPTIME_LEN),
-	       VTY_NEWLINE);
+	       rip_peer_uptime(peer, timebuf, RIP_UPTIME_LEN));
     }
 }
 

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -347,8 +347,7 @@ DEFUN (rip_redistribute_type,
 	}
     }
 
-  vty_out(vty, "Invalid type %s%s", argv[1]->arg,
-	  VTY_NEWLINE);
+  vty_outln (vty, "Invalid type %s",argv[1]->arg);
 
   return CMD_WARNING;
 }
@@ -374,8 +373,7 @@ DEFUN (no_rip_redistribute_type,
         }
     }
 
-  vty_out(vty, "Invalid type %s%s", argv[2]->arg,
-	  VTY_NEWLINE);
+  vty_outln (vty, "Invalid type %s",argv[2]->arg);
 
   return CMD_WARNING;
 }
@@ -402,7 +400,7 @@ DEFUN (rip_redistribute_type_routemap,
       }
   }
 
-  vty_out(vty, "Invalid type %s%s", argv[idx_protocol]->text, VTY_NEWLINE);
+  vty_outln (vty, "Invalid type %s", argv[idx_protocol]->text);
 
   return CMD_WARNING;
 }
@@ -430,7 +428,7 @@ DEFUN (no_rip_redistribute_type_routemap,
       }
   }
 
-  vty_out(vty, "Invalid type %s%s", argv[idx_protocol]->text, VTY_NEWLINE);
+  vty_outln (vty, "Invalid type %s", argv[idx_protocol]->text);
 
   return CMD_WARNING;
 }
@@ -460,7 +458,7 @@ DEFUN (rip_redistribute_type_metric,
       }
   }
 
-  vty_out(vty, "Invalid type %s%s", argv[idx_protocol]->text, VTY_NEWLINE);
+  vty_outln (vty, "Invalid type %s", argv[idx_protocol]->text);
 
   return CMD_WARNING;
 }
@@ -488,7 +486,7 @@ DEFUN (no_rip_redistribute_type_metric,
       }
   }
 
-  vty_out(vty, "Invalid type %s%s", argv[idx_protocol]->text, VTY_NEWLINE);
+  vty_outln (vty, "Invalid type %s", argv[idx_protocol]->text);
 
   return CMD_WARNING;
 }
@@ -522,7 +520,7 @@ DEFUN (rip_redistribute_type_metric_routemap,
       }
   }
 
-  vty_out(vty, "Invalid type %s%s", argv[idx_protocol]->text, VTY_NEWLINE);
+  vty_outln (vty, "Invalid type %s", argv[idx_protocol]->text);
 
   return CMD_WARNING;
 }
@@ -559,7 +557,7 @@ DEFUN (no_rip_redistribute_type_metric_routemap,
       }
     }
 
-  vty_out(vty, "Invalid type %s%s", argv[idx_protocol]->text, VTY_NEWLINE);
+  vty_outln (vty, "Invalid type %s", argv[idx_protocol]->text);
 
   return CMD_WARNING;
 }
@@ -616,13 +614,13 @@ config_write_zebra (struct vty *vty)
 {
   if (! zclient->enable)
     {
-      vty_out (vty, "no router zebra%s", VTY_NEWLINE);
+      vty_outln (vty, "no router zebra");
       return 1;
     }
   else if (! vrf_bitmap_check (zclient->redist[AFI_IP][ZEBRA_ROUTE_RIP], VRF_DEFAULT))
     {
-      vty_out (vty, "router zebra%s", VTY_NEWLINE);
-      vty_out (vty, " no redistribute rip%s", VTY_NEWLINE);
+      vty_outln (vty, "router zebra");
+      vty_outln (vty, " no redistribute rip");
       return 1;
     }
   return 0;
@@ -642,24 +640,20 @@ config_write_rip_redistribute (struct vty *vty, int config_mode)
 	    if (rip->route_map[i].metric_config)
 	      {
 		if (rip->route_map[i].name)
-		  vty_out (vty, " redistribute %s metric %d route-map %s%s",
+		  vty_outln (vty, " redistribute %s metric %d route-map %s",
 			   zebra_route_string(i), rip->route_map[i].metric,
-			   rip->route_map[i].name,
-			   VTY_NEWLINE);
+			   rip->route_map[i].name);
 		else
-		  vty_out (vty, " redistribute %s metric %d%s",
-			   zebra_route_string(i), rip->route_map[i].metric,
-			   VTY_NEWLINE);
+		  vty_outln (vty, " redistribute %s metric %d",
+			   zebra_route_string(i),rip->route_map[i].metric);
 	      }
 	    else
 	      {
 		if (rip->route_map[i].name)
-		  vty_out (vty, " redistribute %s route-map %s%s",
-			   zebra_route_string(i), rip->route_map[i].name,
-			   VTY_NEWLINE);
+		  vty_outln (vty, " redistribute %s route-map %s",
+			   zebra_route_string(i),rip->route_map[i].name);
 		else
-		  vty_out (vty, " redistribute %s%s", zebra_route_string(i),
-			   VTY_NEWLINE);
+		  vty_outln (vty, " redistribute %s",zebra_route_string(i));
 	      }
 	  }
 	else

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3534,7 +3534,7 @@ DEFUN (show_ip_rip,
 	    vty_out (vty, "%3"ROUTE_TAG_PRI, (route_tag_t)rinfo->tag);
 	  }
 
-	vty_outln (vty, "");
+	vty_out (vty, VTYNL);
       }
   return CMD_SUCCESS;
 }
@@ -3576,7 +3576,7 @@ DEFUN (show_ip_rip_status,
   /* Redistribute information. */
   vty_out (vty, "  Redistributing:");
   config_write_rip_redistribute (vty, 0);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   vty_out (vty, "  Default version control: send version %s,",
 	   lookup_msg(ri_version_msg,rip->version_send, NULL));

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3479,7 +3479,7 @@ DEFUN (show_ip_rip,
            "      (n) - normal, (s) - static, (d) - default, (r) - redistribute,%s"
 	   "      (i) - interface%s%s"
 	   "     Network            Next Hop         Metric From            Tag Time",
-	   VTY_NEWLINE, VTY_NEWLINE,  VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+	   VTYNL, VTYNL,  VTYNL, VTYNL, VTYNL);
   
   for (np = route_top (rip->table); np; np = route_next (np))
     if ((list = np->info) != NULL)

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2847,8 +2847,7 @@ DEFUN (rip_version,
   version = atoi (argv[idx_number]->arg);
   if (version != RIPv1 && version != RIPv2)
     {
-      vty_out (vty, "invalid rip version %d%s", version,
-	       VTY_NEWLINE);
+      vty_outln (vty, "invalid rip version %d",version);
       return CMD_WARNING;
     }
   rip->version_send = version;
@@ -2886,7 +2885,7 @@ DEFUN (rip_route,
   ret = str2prefix_ipv4 (argv[idx_ipv4_prefixlen]->arg, &p);
   if (ret < 0)
     {
-      vty_out (vty, "Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed address");
       return CMD_WARNING;
     }
   apply_mask_ipv4 (&p);
@@ -2896,7 +2895,7 @@ DEFUN (rip_route,
 
   if (node->info)
     {
-      vty_out (vty, "There is already same static route.%s", VTY_NEWLINE);
+      vty_outln (vty, "There is already same static route.");
       route_unlock_node (node);
       return CMD_WARNING;
     }
@@ -2923,7 +2922,7 @@ DEFUN (no_rip_route,
   ret = str2prefix_ipv4 (argv[idx_ipv4_prefixlen]->arg, &p);
   if (ret < 0)
     {
-      vty_out (vty, "Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed address");
       return CMD_WARNING;
     }
   apply_mask_ipv4 (&p);
@@ -2932,8 +2931,7 @@ DEFUN (no_rip_route,
   node = route_node_lookup (rip->route, (struct prefix *) &p);
   if (! node)
     {
-      vty_out (vty, "Can't find route %s.%s", argv[idx_ipv4_prefixlen]->arg,
-	       VTY_NEWLINE);
+      vty_outln (vty, "Can't find route %s.",argv[idx_ipv4_prefixlen]->arg);
       return CMD_WARNING;
     }
 
@@ -3016,21 +3014,21 @@ DEFUN (rip_timers,
   update = strtoul (argv[idx_number]->arg, &endptr, 10);
   if (update > RIP_TIMER_MAX || update < RIP_TIMER_MIN || *endptr != '\0')  
     {
-      vty_out (vty, "update timer value error%s", VTY_NEWLINE);
+      vty_outln (vty, "update timer value error");
       return CMD_WARNING;
     }
   
   timeout = strtoul (argv[idx_number_2]->arg, &endptr, 10);
   if (timeout > RIP_TIMER_MAX || timeout < RIP_TIMER_MIN || *endptr != '\0') 
     {
-      vty_out (vty, "timeout timer value error%s", VTY_NEWLINE);
+      vty_outln (vty, "timeout timer value error");
       return CMD_WARNING;
     }
   
   garbage = strtoul (argv[idx_number_3]->arg, &endptr, 10);
   if (garbage > RIP_TIMER_MAX || garbage < RIP_TIMER_MIN || *endptr != '\0') 
     {
-      vty_out (vty, "garbage timer value error%s", VTY_NEWLINE);
+      vty_outln (vty, "garbage timer value error");
       return CMD_WARNING;
     }
 
@@ -3104,7 +3102,7 @@ rip_distance_set (struct vty *vty, const char *distance_str, const char *ip_str,
   ret = str2prefix_ipv4 (ip_str, &p);
   if (ret == 0)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
 
@@ -3150,14 +3148,14 @@ rip_distance_unset (struct vty *vty, const char *distance_str,
   ret = str2prefix_ipv4 (ip_str, &p);
   if (ret == 0)
     {
-      vty_out (vty, "Malformed prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed prefix");
       return CMD_WARNING;
     }
 
   rn = route_node_lookup (rip_distance_table, (struct prefix *)&p);
   if (! rn)
     {
-      vty_out (vty, "Can't find specified prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't find specified prefix");
       return CMD_WARNING;
     }
 
@@ -3243,24 +3241,21 @@ rip_distance_show (struct vty *vty)
   int header = 1;
   char buf[BUFSIZ];
   
-  vty_out (vty, "  Distance: (default is %d)%s",
-	   rip->distance ? rip->distance :ZEBRA_RIP_DISTANCE_DEFAULT,
-	   VTY_NEWLINE);
+  vty_outln (vty, "  Distance: (default is %d)",
+	   rip->distance ? rip->distance : ZEBRA_RIP_DISTANCE_DEFAULT);
 
   for (rn = route_top (rip_distance_table); rn; rn = route_next (rn))
     if ((rdistance = rn->info) != NULL)
       {
 	if (header)
 	  {
-	    vty_out (vty, "    Address           Distance  List%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty,"    Address           Distance  List");
 	    header = 0;
 	  }
 	sprintf (buf, "%s/%d", inet_ntoa (rn->p.u.prefix4), rn->p.prefixlen);
-	vty_out (vty, "    %-20s  %4d  %s%s",
+	vty_outln (vty, "    %-20s  %4d  %s",
 		 buf, rdistance->distance,
-		 rdistance->access_list ? rdistance->access_list : "",
-		 VTY_NEWLINE);
+		 rdistance->access_list ? rdistance->access_list : "");
       }
 }
 
@@ -3391,7 +3386,7 @@ DEFUN (rip_allow_ecmp,
 {
   if (rip->ecmp)
     {
-      vty_out (vty, "ECMP is already enabled.%s", VTY_NEWLINE);
+      vty_outln (vty, "ECMP is already enabled.");
       return CMD_WARNING;
     }
 
@@ -3408,7 +3403,7 @@ DEFUN (no_rip_allow_ecmp,
 {
   if (!rip->ecmp)
     {
-      vty_out (vty, "ECMP is already disabled.%s", VTY_NEWLINE);
+      vty_outln (vty, "ECMP is already disabled.");
       return CMD_WARNING;
     }
 
@@ -3479,12 +3474,12 @@ DEFUN (show_ip_rip,
   if (! rip)
     return CMD_SUCCESS;
 
-  vty_out (vty, "Codes: R - RIP, C - connected, S - Static, O - OSPF, B - BGP%s"
+  vty_outln (vty, "Codes: R - RIP, C - connected, S - Static, O - OSPF, B - BGP%s"
 	   "Sub-codes:%s"
            "      (n) - normal, (s) - static, (d) - default, (r) - redistribute,%s"
 	   "      (i) - interface%s%s"
-	   "     Network            Next Hop         Metric From            Tag Time%s",
-	   VTY_NEWLINE, VTY_NEWLINE,  VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+	   "     Network            Next Hop         Metric From            Tag Time",
+	   VTY_NEWLINE, VTY_NEWLINE,  VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
   
   for (np = route_top (rip->table); np; np = route_next (np))
     if ((list = np->info) != NULL)
@@ -3539,7 +3534,7 @@ DEFUN (show_ip_rip,
 	    vty_out (vty, "%3"ROUTE_TAG_PRI, (route_tag_t)rinfo->tag);
 	  }
 
-	vty_out (vty, "%s", VTY_NEWLINE);
+	vty_outln (vty, "");
       }
   return CMD_SUCCESS;
 }
@@ -3563,37 +3558,35 @@ DEFUN (show_ip_rip_status,
   if (! rip)
     return CMD_SUCCESS;
 
-  vty_out (vty, "Routing Protocol is \"rip\"%s", VTY_NEWLINE);
+  vty_outln (vty, "Routing Protocol is \"rip\"");
   vty_out (vty, "  Sending updates every %ld seconds with +/-50%%,",
 	   rip->update_time);
-  vty_out (vty, " next due in %lu seconds%s", 
-	   thread_timer_remain_second(rip->t_update),
-	   VTY_NEWLINE);
+  vty_outln (vty, " next due in %lu seconds", 
+	   thread_timer_remain_second(rip->t_update));
   vty_out (vty, "  Timeout after %ld seconds,", rip->timeout_time);
-  vty_out (vty, " garbage collect after %ld seconds%s", rip->garbage_time,
-	   VTY_NEWLINE);
+  vty_outln (vty, " garbage collect after %ld seconds",rip->garbage_time);
 
   /* Filtering status show. */
   config_show_distribute (vty);
 		 
   /* Default metric information. */
-  vty_out (vty, "  Default redistribution metric is %d%s",
-	   rip->default_metric, VTY_NEWLINE);
+  vty_outln (vty, "  Default redistribution metric is %d",
+	   rip->default_metric);
 
   /* Redistribute information. */
   vty_out (vty, "  Redistributing:");
   config_write_rip_redistribute (vty, 0);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   vty_out (vty, "  Default version control: send version %s,",
 	   lookup_msg(ri_version_msg,rip->version_send, NULL));
   if (rip->version_recv == RI_RIP_VERSION_1_AND_2)
-    vty_out (vty, " receive any version %s", VTY_NEWLINE);
+    vty_outln (vty, " receive any version ");
   else
-    vty_out (vty, " receive version %s %s",
-	     lookup_msg(ri_version_msg,rip->version_recv, NULL), VTY_NEWLINE);
+    vty_outln (vty, " receive version %s ",
+	       lookup_msg(ri_version_msg,rip->version_recv, NULL));
 
-  vty_out (vty, "    Interface        Send  Recv   Key-chain%s", VTY_NEWLINE);
+  vty_outln (vty, "    Interface        Send  Recv   Key-chain");
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp))
     {
@@ -3614,15 +3607,14 @@ DEFUN (show_ip_rip_status,
 	  else
 	    receive_version = lookup_msg(ri_version_msg, ri->ri_receive, NULL);
 	
-	  vty_out (vty, "    %-17s%-3s   %-3s    %s%s", ifp->name,
+	  vty_outln (vty, "    %-17s%-3s   %-3s    %s", ifp->name,
 		   send_version,
 		   receive_version,
-		   ri->key_chain ? ri->key_chain : "",
-		   VTY_NEWLINE);
+		   ri->key_chain ? ri->key_chain : "");
 	}
     }
 
-  vty_out (vty, "  Routing for Networks:%s", VTY_NEWLINE);
+  vty_outln (vty, "  Routing for Networks:");
   config_write_rip_network (vty, 0);  
 
   {
@@ -3635,16 +3627,17 @@ DEFUN (show_ip_rip_status,
 	  {
 	    if (!found_passive)
 	      {
-		vty_out (vty, "  Passive Interface(s):%s", VTY_NEWLINE);
+		vty_outln (vty, "  Passive Interface(s):");
 		found_passive = 1;
 	      }
-	    vty_out (vty, "    %s%s", ifp->name, VTY_NEWLINE);
+	    vty_outln (vty, "    %s", ifp->name);
 	  }
       }
   }
 
-  vty_out (vty, "  Routing Information Sources:%s", VTY_NEWLINE);
-  vty_out (vty, "    Gateway          BadPackets BadRoutes  Distance Last Update%s", VTY_NEWLINE);
+  vty_outln (vty, "  Routing Information Sources:");
+  vty_outln (vty,
+             "    Gateway          BadPackets BadRoutes  Distance Last Update");
   rip_peer_display (vty);
 
   rip_distance_show (vty);
@@ -3663,34 +3656,31 @@ config_write_rip (struct vty *vty)
   if (rip)
     {
       /* Router RIP statement. */
-      vty_out (vty, "router rip%s", VTY_NEWLINE);
+      vty_outln (vty, "router rip");
       write++;
   
       /* RIP version statement.  Default is RIP version 2. */
       if (rip->version_send != RI_RIP_VERSION_2
 	  || rip->version_recv != RI_RIP_VERSION_1_AND_2)
-	vty_out (vty, " version %d%s", rip->version_send,
-		 VTY_NEWLINE);
+	vty_outln (vty, " version %d",rip->version_send);
  
       /* RIP timer configuration. */
       if (rip->update_time != RIP_UPDATE_TIMER_DEFAULT 
 	  || rip->timeout_time != RIP_TIMEOUT_TIMER_DEFAULT 
 	  || rip->garbage_time != RIP_GARBAGE_TIMER_DEFAULT)
-	vty_out (vty, " timers basic %lu %lu %lu%s",
+	vty_outln (vty, " timers basic %lu %lu %lu",
 		 rip->update_time,
 		 rip->timeout_time,
-		 rip->garbage_time,
-		 VTY_NEWLINE);
+		 rip->garbage_time);
 
       /* Default information configuration. */
       if (rip->default_information)
 	{
 	  if (rip->default_information_route_map)
-	    vty_out (vty, " default-information originate route-map %s%s",
-		     rip->default_information_route_map, VTY_NEWLINE);
+	    vty_outln (vty, " default-information originate route-map %s",
+		     rip->default_information_route_map);
 	  else
-	    vty_out (vty, " default-information originate%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty," default-information originate");
 	}
 
       /* Redistribute configuration. */
@@ -3704,8 +3694,8 @@ config_write_rip (struct vty *vty)
 			
       /* RIP default metric configuration */
       if (rip->default_metric != RIP_DEFAULT_METRIC_DEFAULT)
-        vty_out (vty, " default-metric %d%s",
-		 rip->default_metric, VTY_NEWLINE);
+        vty_outln (vty, " default-metric %d",
+		 rip->default_metric);
 
       /* Distribute configuration. */
       write += config_write_distribute (vty);
@@ -3715,27 +3705,25 @@ config_write_rip (struct vty *vty)
 
       /* Distance configuration. */
       if (rip->distance)
-	vty_out (vty, " distance %d%s", rip->distance, VTY_NEWLINE);
+	vty_outln (vty, " distance %d", rip->distance);
 
       /* RIP source IP prefix distance configuration. */
       for (rn = route_top (rip_distance_table); rn; rn = route_next (rn))
 	if ((rdistance = rn->info) != NULL)
-	  vty_out (vty, " distance %d %s/%d %s%s", rdistance->distance,
+	  vty_outln (vty, " distance %d %s/%d %s", rdistance->distance,
 		   inet_ntoa (rn->p.u.prefix4), rn->p.prefixlen,
-		   rdistance->access_list ? rdistance->access_list : "",
-		   VTY_NEWLINE);
+		   rdistance->access_list ? rdistance->access_list : "");
 
       /* ECMP configuration. */
       if (rip->ecmp)
-        vty_out (vty, " allow-ecmp%s", VTY_NEWLINE);
+        vty_outln (vty, " allow-ecmp");
 
       /* RIP static route configuration. */
       for (rn = route_top (rip->route); rn; rn = route_next (rn))
 	if (rn->info)
-	  vty_out (vty, " route %s/%d%s", 
+	  vty_outln (vty, " route %s/%d", 
 		   inet_ntoa (rn->p.u.prefix4),
-		   rn->p.prefixlen,
-		   VTY_NEWLINE);
+		   rn->p.prefixlen);
 
     }
   return write;

--- a/ripngd/ripng_debug.c
+++ b/ripngd/ripng_debug.c
@@ -35,31 +35,28 @@ DEFUN (show_debugging_ripng,
        DEBUG_STR
        "RIPng configuration\n")
 {
-  vty_out (vty, "RIPng debugging status:%s", VTY_NEWLINE);
+  vty_outln (vty, "RIPng debugging status:");
 
   if (IS_RIPNG_DEBUG_EVENT)
-    vty_out (vty, "  RIPng event debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  RIPng event debugging is on");
 
   if (IS_RIPNG_DEBUG_PACKET)
     {
       if (IS_RIPNG_DEBUG_SEND && IS_RIPNG_DEBUG_RECV)
 	{
-	  vty_out (vty, "  RIPng packet debugging is on%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"  RIPng packet debugging is on");
 	}
       else
 	{
 	  if (IS_RIPNG_DEBUG_SEND)
-	    vty_out (vty, "  RIPng packet send debugging is on%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty,"  RIPng packet send debugging is on");
 	  else
-	    vty_out (vty, "  RIPng packet receive debugging is on%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty,"  RIPng packet receive debugging is on");
 	}
     }
 
   if (IS_RIPNG_DEBUG_ZEBRA)
-    vty_out (vty, "  RIPng zebra debugging is on%s", VTY_NEWLINE);
+    vty_outln (vty, "  RIPng zebra debugging is on");
 
   return CMD_SUCCESS;
 }
@@ -197,31 +194,28 @@ config_write_debug (struct vty *vty)
 
   if (IS_RIPNG_DEBUG_EVENT)
     {
-      vty_out (vty, "debug ripng events%s", VTY_NEWLINE);
+      vty_outln (vty, "debug ripng events");
       write++;
     }
   if (IS_RIPNG_DEBUG_PACKET)
     {
       if (IS_RIPNG_DEBUG_SEND && IS_RIPNG_DEBUG_RECV)
 	{
-	  vty_out (vty, "debug ripng packet%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,"debug ripng packet");
 	  write++;
 	}
       else
 	{
 	  if (IS_RIPNG_DEBUG_SEND)
-	    vty_out (vty, "debug ripng packet send%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty,"debug ripng packet send");
 	  else
-	    vty_out (vty, "debug ripng packet recv%s",
-		     VTY_NEWLINE);
+	    vty_outln (vty,"debug ripng packet recv");
 	  write++;
 	}
     }
   if (IS_RIPNG_DEBUG_ZEBRA)
     {
-      vty_out (vty, "debug ripng zebra%s", VTY_NEWLINE);
+      vty_outln (vty, "debug ripng zebra");
       write++;
     }
   return write;

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -916,27 +916,25 @@ ripng_network_write (struct vty *vty, int config_mode)
     if (node->info)
       {
 	struct prefix *p = &node->p;
-	vty_out (vty, "%s%s/%d%s", 
+	vty_outln (vty, "%s%s/%d", 
 		 config_mode ? " network " : "    ",
 		 inet_ntop (p->family, &p->u.prefix, buf, BUFSIZ),
-		 p->prefixlen,
-		 VTY_NEWLINE);
+		 p->prefixlen);
 
       }
   
   /* Write enable interface. */
   for (i = 0; i < vector_active (ripng_enable_if); i++)
     if ((ifname = vector_slot (ripng_enable_if, i)) != NULL)
-      vty_out (vty, "%s%s%s",
+      vty_outln (vty, "%s%s",
 	       config_mode ? " network " : "    ",
-	       ifname,
-	       VTY_NEWLINE);
+	       ifname);
 
   /* Write passive interface. */
   if (config_mode)
     for (i = 0; i < vector_active (Vripng_passive_interface); i++)
       if ((ifname = vector_slot (Vripng_passive_interface, i)) != NULL)
-        vty_out (vty, " passive-interface %s%s", ifname, VTY_NEWLINE);
+        vty_outln (vty, " passive-interface %s", ifname);
 
   return 0;
 }
@@ -962,8 +960,8 @@ DEFUN (ripng_network,
 
   if (ret < 0)
     {
-      vty_out (vty, "There is same network configuration %s%s", argv[idx_if_or_addr]->arg,
-	       VTY_NEWLINE);
+      vty_outln (vty, "There is same network configuration %s",
+                 argv[idx_if_or_addr]->arg);
       return CMD_WARNING;
     }
 
@@ -992,8 +990,7 @@ DEFUN (no_ripng_network,
 
   if (ret < 0)
     {
-      vty_out (vty, "can't find network %s%s", argv[idx_if_or_addr]->arg,
-	       VTY_NEWLINE);
+      vty_outln (vty, "can't find network %s",argv[idx_if_or_addr]->arg);
       return CMD_WARNING;
     }
   
@@ -1124,31 +1121,28 @@ interface_config_write (struct vty *vty)
           (ri->split_horizon == ri->split_horizon_default))
         continue;
 
-      vty_out (vty, "interface %s%s", ifp->name,
-	       VTY_NEWLINE);
+      vty_outln (vty, "interface %s",ifp->name);
       if (ifp->desc)
-	vty_out (vty, " description %s%s", ifp->desc,
-		 VTY_NEWLINE);
+	vty_outln (vty, " description %s",ifp->desc);
 
       /* Split horizon. */
       if (ri->split_horizon != ri->split_horizon_default)
 	{
           switch (ri->split_horizon) {
           case RIPNG_SPLIT_HORIZON:
-            vty_out (vty, " ipv6 ripng split-horizon%s", VTY_NEWLINE);
+            vty_outln (vty, " ipv6 ripng split-horizon");
             break;
           case RIPNG_SPLIT_HORIZON_POISONED_REVERSE:
-            vty_out (vty, " ipv6 ripng split-horizon poisoned-reverse%s",
-                          VTY_NEWLINE);
+            vty_outln (vty," ipv6 ripng split-horizon poisoned-reverse");
             break;
           case RIPNG_NO_SPLIT_HORIZON:
           default:
-            vty_out (vty, " no ipv6 ripng split-horizon%s", VTY_NEWLINE);
+            vty_outln (vty, " no ipv6 ripng split-horizon");
             break;
           }
 	}
 
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_outln (vty, "!");
 
       write++;
     }

--- a/ripngd/ripng_offset.c
+++ b/ripngd/ripng_offset.c
@@ -125,7 +125,7 @@ ripng_offset_list_set (struct vty *vty, const char *alist,
     direct = RIPNG_OFFSET_LIST_OUT;
   else
     {
-      vty_out (vty, "Invalid direction: %s%s", direct_str, VTY_NEWLINE);
+      vty_outln (vty, "Invalid direction: %s", direct_str);
       return CMD_WARNING;
     }
 
@@ -133,7 +133,7 @@ ripng_offset_list_set (struct vty *vty, const char *alist,
   metric = atoi (metric_str);
   if (metric < 0 || metric > 16)
     {
-      vty_out (vty, "Invalid metric: %s%s", metric_str, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric: %s", metric_str);
       return CMD_WARNING;
     }
 
@@ -164,7 +164,7 @@ ripng_offset_list_unset (struct vty *vty, const char *alist,
     direct = RIPNG_OFFSET_LIST_OUT;
   else
     {
-      vty_out (vty, "Invalid direction: %s%s", direct_str, VTY_NEWLINE);
+      vty_outln (vty, "Invalid direction: %s", direct_str);
       return CMD_WARNING;
     }
 
@@ -172,7 +172,7 @@ ripng_offset_list_unset (struct vty *vty, const char *alist,
   metric = atoi (metric_str);
   if (metric < 0 || metric > 16)
     {
-      vty_out (vty, "Invalid metric: %s%s", metric_str, VTY_NEWLINE);
+      vty_outln (vty, "Invalid metric: %s", metric_str);
       return CMD_WARNING;
     }
 
@@ -196,7 +196,7 @@ ripng_offset_list_unset (struct vty *vty, const char *alist,
     }
   else
     {
-      vty_out (vty, "Can't find offset-list%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't find offset-list");
       return CMD_WARNING;
     }
   return CMD_SUCCESS;
@@ -405,28 +405,26 @@ config_write_ripng_offset_list (struct vty *vty)
       if (! offset->ifname)
 	{
 	  if (offset->direct[RIPNG_OFFSET_LIST_IN].alist_name)
-	    vty_out (vty, " offset-list %s in %d%s",
+	    vty_outln (vty, " offset-list %s in %d",
 		     offset->direct[RIPNG_OFFSET_LIST_IN].alist_name,
-		     offset->direct[RIPNG_OFFSET_LIST_IN].metric,
-		     VTY_NEWLINE);
+		     offset->direct[RIPNG_OFFSET_LIST_IN].metric);
 	  if (offset->direct[RIPNG_OFFSET_LIST_OUT].alist_name)
-	    vty_out (vty, " offset-list %s out %d%s",
+	    vty_outln (vty, " offset-list %s out %d",
 		     offset->direct[RIPNG_OFFSET_LIST_OUT].alist_name,
-		     offset->direct[RIPNG_OFFSET_LIST_OUT].metric,
-		     VTY_NEWLINE);
+		     offset->direct[RIPNG_OFFSET_LIST_OUT].metric);
 	}
       else
 	{
 	  if (offset->direct[RIPNG_OFFSET_LIST_IN].alist_name)
-	    vty_out (vty, " offset-list %s in %d %s%s",
+	    vty_outln (vty, " offset-list %s in %d %s",
 		     offset->direct[RIPNG_OFFSET_LIST_IN].alist_name,
 		     offset->direct[RIPNG_OFFSET_LIST_IN].metric,
-		     offset->ifname, VTY_NEWLINE);
+		     offset->ifname);
 	  if (offset->direct[RIPNG_OFFSET_LIST_OUT].alist_name)
-	    vty_out (vty, " offset-list %s out %d %s%s",
+	    vty_outln (vty, " offset-list %s out %d %s",
 		     offset->direct[RIPNG_OFFSET_LIST_OUT].alist_name,
 		     offset->direct[RIPNG_OFFSET_LIST_OUT].metric,
-		     offset->ifname, VTY_NEWLINE);
+		     offset->ifname);
 	}
     }
 

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -193,12 +193,11 @@ ripng_peer_display (struct vty *vty)
 
   for (ALL_LIST_ELEMENTS (peer_list, node, nnode, peer))
     {
-      vty_out (vty, "    %s %s%14s %10d %10d %10d      %s%s", inet6_ntoa (peer->addr),
+      vty_outln (vty, "    %s %s%14s %10d %10d %10d      %s", inet6_ntoa (peer->addr),
                VTY_NEWLINE, " ",
 	       peer->recv_badpackets, peer->recv_badroutes,
 	       ZEBRA_RIPNG_DISTANCE_DEFAULT,
-	       ripng_peer_uptime (peer, timebuf, RIPNG_UPTIME_LEN),
-	       VTY_NEWLINE);
+	       ripng_peer_uptime(peer, timebuf, RIPNG_UPTIME_LEN));
     }
 }
 

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -194,7 +194,7 @@ ripng_peer_display (struct vty *vty)
   for (ALL_LIST_ELEMENTS (peer_list, node, nnode, peer))
     {
       vty_outln (vty, "    %s %s%14s %10d %10d %10d      %s", inet6_ntoa (peer->addr),
-               VTY_NEWLINE, " ",
+               VTYNL, " ",
 	       peer->recv_badpackets, peer->recv_badroutes,
 	       ZEBRA_RIPNG_DISTANCE_DEFAULT,
 	       ripng_peer_uptime(peer, timebuf, RIPNG_UPTIME_LEN));

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -337,7 +337,7 @@ DEFUN (ripng_redistribute_type,
 
   if (type < 0)
     {
-      vty_out(vty, "Invalid type %s%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "Invalid type %s", proto);
       return CMD_WARNING;
     }
 
@@ -363,7 +363,7 @@ DEFUN (no_ripng_redistribute_type,
 
   if (type < 0)
     {
-      vty_out(vty, "Invalid type %s%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "Invalid type %s", proto);
       return CMD_WARNING;
     }
 
@@ -391,7 +391,7 @@ DEFUN (ripng_redistribute_type_metric,
 
   if (type < 0)
     {
-      vty_out(vty, "Invalid type %s%s", argv[idx_protocol]->text, VTY_NEWLINE);
+      vty_outln (vty, "Invalid type %s", argv[idx_protocol]->text);
       return CMD_WARNING;
     }
 
@@ -417,7 +417,7 @@ DEFUN (ripng_redistribute_type_routemap,
 
   if (type < 0)
     {
-      vty_out(vty, "Invalid type %s%s", argv[idx_protocol]->text, VTY_NEWLINE);
+      vty_outln (vty, "Invalid type %s", argv[idx_protocol]->text);
       return CMD_WARNING;
     }
 
@@ -448,7 +448,7 @@ DEFUN (ripng_redistribute_type_metric_routemap,
 
   if (type < 0)
     {
-      vty_out(vty, "Invalid type %s%s", argv[idx_protocol]->text, VTY_NEWLINE);
+      vty_outln (vty, "Invalid type %s", argv[idx_protocol]->text);
       return CMD_WARNING;
     }
 
@@ -472,23 +472,20 @@ ripng_redistribute_write (struct vty *vty, int config_mode)
 	  if (ripng->route_map[i].metric_config)
 	    {
 	      if (ripng->route_map[i].name)
-		vty_out (vty, " redistribute %s metric %d route-map %s%s",
+		vty_outln (vty, " redistribute %s metric %d route-map %s",
 			 zebra_route_string(i), ripng->route_map[i].metric,
-			ripng->route_map[i].name, VTY_NEWLINE);
+			ripng->route_map[i].name);
 	      else
-		vty_out (vty, " redistribute %s metric %d%s",
-			zebra_route_string(i), ripng->route_map[i].metric,
-			VTY_NEWLINE);
+		vty_outln (vty, " redistribute %s metric %d",
+			zebra_route_string(i),ripng->route_map[i].metric);
 	    }
 	  else
 	    {
 	      if (ripng->route_map[i].name)
-		vty_out (vty, " redistribute %s route-map %s%s",
-			 zebra_route_string(i), ripng->route_map[i].name,
-			 VTY_NEWLINE);
+		vty_outln (vty, " redistribute %s route-map %s",
+			 zebra_route_string(i),ripng->route_map[i].name);
 	      else
-		vty_out (vty, " redistribute %s%s", zebra_route_string(i),
-			 VTY_NEWLINE);
+		vty_outln (vty, " redistribute %s",zebra_route_string(i));
 	    }
 	}
       else
@@ -502,13 +499,13 @@ zebra_config_write (struct vty *vty)
 {
   if (! zclient->enable)
     {
-      vty_out (vty, "no router zebra%s", VTY_NEWLINE);
+      vty_outln (vty, "no router zebra");
       return 1;
     }
   else if (! vrf_bitmap_check (zclient->redist[AFI_IP6][ZEBRA_ROUTE_RIPNG], VRF_DEFAULT))
     {
-      vty_out (vty, "router zebra%s", VTY_NEWLINE);
-      vty_out (vty, " no redistribute ripng%s", VTY_NEWLINE);
+      vty_outln (vty, "router zebra");
+      vty_outln (vty, " no redistribute ripng");
       return 1;
     }
   return 0;

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2026,7 +2026,7 @@ DEFUN (show_ipv6_ripng,
 	  vty_out (vty, "R(a) %s/%d ",
 			 inet6_ntoa (p->prefix), p->prefixlen);
 #endif /* DEBUG */
-	  vty_outln (vty, "");
+	  vty_out (vty, VTYNL);
 	  vty_out (vty, "%*s", 18, " ");
 
 	  vty_out (vty, "%*s", 28, " ");
@@ -2051,7 +2051,7 @@ DEFUN (show_ipv6_ripng,
 			 ripng_route_subtype_print(rinfo),
 			 inet6_ntoa (p->prefix), p->prefixlen);
 #endif /* DEBUG */
-	  vty_outln (vty, "");
+	  vty_out (vty, VTYNL);
 	  vty_out (vty, "%*s", 18, " ");
 	  len = vty_out (vty, "%s", inet6_ntoa (rinfo->nexthop));
 
@@ -2089,7 +2089,7 @@ DEFUN (show_ipv6_ripng,
 	    ripng_vty_out_uptime (vty, rinfo);
 	  }
 
-	  vty_outln (vty, "");
+	  vty_out (vty, VTYNL);
 	}
     }
 
@@ -2128,7 +2128,7 @@ DEFUN (show_ipv6_ripng_status,
   /* Redistribute information. */
   vty_out (vty, "  Redistributing:");
   ripng_redistribute_write (vty, 0);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   vty_out (vty, "  Default version control: send version %d,", ripng->version);
   vty_outln (vty, " receive version %d ",ripng->version);

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2009,8 +2009,8 @@ DEFUN (show_ipv6_ripng,
 	   "      (n) - normal, (s) - static, (d) - default, (r) - redistribute,%s"
 	   "      (i) - interface, (a/S) - aggregated/Suppressed%s%s"
 	   "   Network      Next Hop                      Via     Metric Tag Time",
-	   VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE,
-	   VTY_NEWLINE, VTY_NEWLINE);
+	   VTYNL, VTYNL, VTYNL,
+	   VTYNL, VTYNL);
   
   for (rp = route_top (ripng->table); rp; rp = route_next (rp))
     {
@@ -2425,7 +2425,7 @@ DEFUN (ripng_update_timer,
   update = strtoul (argv[0], &endptr, 10);
   if (update == ULONG_MAX || *endptr != '\0')
     {
-      vty_out (vty, "update timer value error%s", VTY_NEWLINE);
+      vty_out (vty, "update timer value error%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2460,7 +2460,7 @@ DEFUN (ripng_timeout_timer,
   timeout = strtoul (argv[0], &endptr, 10);
   if (timeout == ULONG_MAX || *endptr != '\0')
     {
-      vty_out (vty, "timeout timer value error%s", VTY_NEWLINE);
+      vty_out (vty, "timeout timer value error%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2493,7 +2493,7 @@ DEFUN (ripng_garbage_timer,
   garbage = strtoul (argv[0], &endptr, 10);
   if (garbage == ULONG_MAX || *endptr != '\0')
     {
-      vty_out (vty, "garbage timer value error%s", VTY_NEWLINE);
+      vty_out (vty, "garbage timer value error%s", VTYNL);
       return CMD_WARNING;
     }
 
@@ -2577,16 +2577,16 @@ DEFUN (show_ipv6_protocols,
   if (! ripng)
     return CMD_SUCCESS;
 
-  vty_out (vty, "Routing Protocol is \"ripng\"%s", VTY_NEWLINE);
+  vty_out (vty, "Routing Protocol is \"ripng\"%s", VTYNL);
   
   vty_out (vty, "Sending updates every %ld seconds, next due in %d seconds%s",
 	   ripng->update_time, 0,
-	   VTY_NEWLINE);
+	   VTYNL);
 
   vty_out (vty, "Timerout after %ld seconds, garbage correct %ld%s",
 	   ripng->timeout_time,
 	   ripng->garbage_time,
-	   VTY_NEWLINE);
+	   VTYNL);
 
   vty_out (vty, "Outgoing update filter list for all interfaces is not set");
   vty_out (vty, "Incoming update filter list for all interfaces is not set");
@@ -2767,13 +2767,13 @@ ripng_config_write (struct vty *vty)
 #if 0
       if (ripng->update_time != RIPNG_UPDATE_TIMER_DEFAULT)
 	vty_out (vty, " update-timer %d%s", ripng->update_time,
-		 VTY_NEWLINE);
+		 VTYNL);
       if (ripng->timeout_time != RIPNG_TIMEOUT_TIMER_DEFAULT)
 	vty_out (vty, " timeout-timer %d%s", ripng->timeout_time,
-		 VTY_NEWLINE);
+		 VTYNL);
       if (ripng->garbage_time != RIPNG_GARBAGE_TIMER_DEFAULT)
 	vty_out (vty, " garbage-timer %d%s", ripng->garbage_time,
-		 VTY_NEWLINE);
+		 VTYNL);
 #endif /* 0 */
 
       write += config_write_distribute (vty);

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2004,13 +2004,13 @@ DEFUN (show_ipv6_ripng,
     return CMD_SUCCESS;
 
   /* Header of display. */ 
-  vty_out (vty, "Codes: R - RIPng, C - connected, S - Static, O - OSPF, B - BGP%s"
+  vty_outln (vty, "Codes: R - RIPng, C - connected, S - Static, O - OSPF, B - BGP%s"
 	   "Sub-codes:%s"
 	   "      (n) - normal, (s) - static, (d) - default, (r) - redistribute,%s"
 	   "      (i) - interface, (a/S) - aggregated/Suppressed%s%s"
-	   "   Network      Next Hop                      Via     Metric Tag Time%s",
+	   "   Network      Next Hop                      Via     Metric Tag Time",
 	   VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE,
-	   VTY_NEWLINE, VTY_NEWLINE, VTY_NEWLINE);
+	   VTY_NEWLINE, VTY_NEWLINE);
   
   for (rp = route_top (ripng->table); rp; rp = route_next (rp))
     {
@@ -2026,13 +2026,12 @@ DEFUN (show_ipv6_ripng,
 	  vty_out (vty, "R(a) %s/%d ",
 			 inet6_ntoa (p->prefix), p->prefixlen);
 #endif /* DEBUG */
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_outln (vty, "");
 	  vty_out (vty, "%*s", 18, " ");
 
 	  vty_out (vty, "%*s", 28, " ");
-	  vty_out (vty, "self      %2d  %3"ROUTE_TAG_PRI"%s", aggregate->metric,
-		   (route_tag_t)aggregate->tag,
-		   VTY_NEWLINE);
+	  vty_outln (vty, "self      %2d  %3"ROUTE_TAG_PRI"", aggregate->metric,
+		   (route_tag_t)aggregate->tag);
 	}
 
       if ((list = rp->info) != NULL)
@@ -2052,7 +2051,7 @@ DEFUN (show_ipv6_ripng,
 			 ripng_route_subtype_print(rinfo),
 			 inet6_ntoa (p->prefix), p->prefixlen);
 #endif /* DEBUG */
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_outln (vty, "");
 	  vty_out (vty, "%*s", 18, " ");
 	  len = vty_out (vty, "%s", inet6_ntoa (rinfo->nexthop));
 
@@ -2090,7 +2089,7 @@ DEFUN (show_ipv6_ripng,
 	    ripng_vty_out_uptime (vty, rinfo);
 	  }
 
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_outln (vty, "");
 	}
     }
 
@@ -2111,33 +2110,30 @@ DEFUN (show_ipv6_ripng_status,
   if (! ripng)
     return CMD_SUCCESS;
 
-  vty_out (vty, "Routing Protocol is \"RIPng\"%s", VTY_NEWLINE);
+  vty_outln (vty, "Routing Protocol is \"RIPng\"");
   vty_out (vty, "  Sending updates every %ld seconds with +/-50%%,",
            ripng->update_time);
-  vty_out (vty, " next due in %lu seconds%s",
-           thread_timer_remain_second (ripng->t_update),
-           VTY_NEWLINE);
+  vty_outln (vty, " next due in %lu seconds",
+           thread_timer_remain_second(ripng->t_update));
   vty_out (vty, "  Timeout after %ld seconds,", ripng->timeout_time);
-  vty_out (vty, " garbage collect after %ld seconds%s", ripng->garbage_time,
-           VTY_NEWLINE);
+  vty_outln (vty, " garbage collect after %ld seconds",ripng->garbage_time);
 
   /* Filtering status show. */
   config_show_distribute (vty);
 
   /* Default metric information. */
-  vty_out (vty, "  Default redistribution metric is %d%s",
-           ripng->default_metric, VTY_NEWLINE);
+  vty_outln (vty, "  Default redistribution metric is %d",
+           ripng->default_metric);
 
   /* Redistribute information. */
   vty_out (vty, "  Redistributing:");
   ripng_redistribute_write (vty, 0);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   vty_out (vty, "  Default version control: send version %d,", ripng->version);
-  vty_out (vty, " receive version %d %s", ripng->version,
-           VTY_NEWLINE);
+  vty_outln (vty, " receive version %d ",ripng->version);
 
-  vty_out (vty, "    Interface        Send  Recv%s", VTY_NEWLINE);
+  vty_outln (vty, "    Interface        Send  Recv");
 
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (VRF_DEFAULT), node, ifp))
     {
@@ -2148,18 +2144,18 @@ DEFUN (show_ipv6_ripng_status,
       if (ri->enable_network || ri->enable_interface)
 	{
 
-	  vty_out (vty, "    %-17s%-3d   %-3d%s", ifp->name,
+	  vty_outln (vty, "    %-17s%-3d   %-3d", ifp->name,
 		   ripng->version,
-		   ripng->version,
-		   VTY_NEWLINE);
+		   ripng->version);
 	}
     }
 
-  vty_out (vty, "  Routing for Networks:%s", VTY_NEWLINE);
+  vty_outln (vty, "  Routing for Networks:");
   ripng_network_write (vty, 0);
 
-  vty_out (vty, "  Routing Information Sources:%s", VTY_NEWLINE);
-  vty_out (vty, "    Gateway          BadPackets BadRoutes  Distance Last Update%s", VTY_NEWLINE);
+  vty_outln (vty, "  Routing Information Sources:");
+  vty_outln (vty,
+             "    Gateway          BadPackets BadRoutes  Distance Last Update");
   ripng_peer_display (vty);
 
   return CMD_SUCCESS;  
@@ -2264,7 +2260,7 @@ DEFUN (ripng_route,
   ret = str2prefix_ipv6 (argv[idx_ipv6addr]->arg, (struct prefix_ipv6 *)&p);
   if (ret <= 0)
     {
-      vty_out (vty, "Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed address");
       return CMD_WARNING;
     }
   apply_mask_ipv6 (&p);
@@ -2272,7 +2268,7 @@ DEFUN (ripng_route,
   rp = route_node_get (ripng->route, (struct prefix *) &p);
   if (rp->info)
     {
-      vty_out (vty, "There is already same static route.%s", VTY_NEWLINE);
+      vty_outln (vty, "There is already same static route.");
       route_unlock_node (rp);
       return CMD_WARNING;
     }
@@ -2298,7 +2294,7 @@ DEFUN (no_ripng_route,
   ret = str2prefix_ipv6 (argv[idx_ipv6addr]->arg, (struct prefix_ipv6 *)&p);
   if (ret <= 0)
     {
-      vty_out (vty, "Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed address");
       return CMD_WARNING;
     }
   apply_mask_ipv6 (&p);
@@ -2306,7 +2302,7 @@ DEFUN (no_ripng_route,
   rp = route_node_lookup (ripng->route, (struct prefix *) &p);
   if (! rp)
     {
-      vty_out (vty, "Can't find static route.%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't find static route.");
       return CMD_WARNING;
     }
 
@@ -2333,7 +2329,7 @@ DEFUN (ripng_aggregate_address,
   ret = str2prefix_ipv6 (argv[idx_ipv6_prefixlen]->arg, (struct prefix_ipv6 *)&p);
   if (ret <= 0)
     {
-      vty_out (vty, "Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed address");
       return CMD_WARNING;
     }
 
@@ -2341,7 +2337,7 @@ DEFUN (ripng_aggregate_address,
   node = route_node_get (ripng->aggregate, &p);
   if (node->info)
     {
-      vty_out (vty, "There is already same aggregate route.%s", VTY_NEWLINE);
+      vty_outln (vty, "There is already same aggregate route.");
       route_unlock_node (node);
       return CMD_WARNING;
     }
@@ -2367,14 +2363,14 @@ DEFUN (no_ripng_aggregate_address,
   ret = str2prefix_ipv6 (argv[idx_ipv6_prefixlen]->arg, (struct prefix_ipv6 *) &p);
   if (ret <= 0)
     {
-      vty_out (vty, "Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed address");
       return CMD_WARNING;
     }
 
   rn = route_node_lookup (ripng->aggregate, &p);
   if (! rn)
     {
-      vty_out (vty, "Can't find aggregate route.%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't find aggregate route.");
       return CMD_WARNING;
     }
   route_unlock_node (rn);
@@ -2684,7 +2680,7 @@ DEFUN (ripng_allow_ecmp,
 {
   if (ripng->ecmp)
     {
-      vty_out (vty, "ECMP is already enabled.%s", VTY_NEWLINE);
+      vty_outln (vty, "ECMP is already enabled.");
       return CMD_WARNING;
     }
 
@@ -2701,7 +2697,7 @@ DEFUN (no_ripng_allow_ecmp,
 {
   if (!ripng->ecmp)
     {
-      vty_out (vty, "ECMP is already disabled.%s", VTY_NEWLINE);
+      vty_outln (vty, "ECMP is already disabled.");
       return CMD_WARNING;
     }
 
@@ -2724,17 +2720,17 @@ ripng_config_write (struct vty *vty)
     {
 
       /* RIPng router. */
-      vty_out (vty, "router ripng%s", VTY_NEWLINE);
+      vty_outln (vty, "router ripng");
 
       if (ripng->default_information)
-	vty_out (vty, " default-information originate%s", VTY_NEWLINE);
+	vty_outln (vty, " default-information originate");
 
       ripng_network_write (vty, 1);
 
       /* RIPng default metric configuration */
       if (ripng->default_metric != RIPNG_DEFAULT_METRIC_DEFAULT)
-        vty_out (vty, " default-metric %d%s",
-		 ripng->default_metric, VTY_NEWLINE);
+        vty_outln (vty, " default-metric %d",
+		 ripng->default_metric);
 
       ripng_redistribute_write (vty, 1);
 
@@ -2744,33 +2740,29 @@ ripng_config_write (struct vty *vty)
       /* RIPng aggregate routes. */
       for (rp = route_top (ripng->aggregate); rp; rp = route_next (rp))
 	if (rp->info != NULL)
-	  vty_out (vty, " aggregate-address %s/%d%s", 
+	  vty_outln (vty, " aggregate-address %s/%d", 
 		   inet6_ntoa (rp->p.u.prefix6),
-		   rp->p.prefixlen, 
-
-		   VTY_NEWLINE);
+		   rp->p.prefixlen);
 
       /* ECMP configuration. */
       if (ripng->ecmp)
-        vty_out (vty, " allow-ecmp%s", VTY_NEWLINE);
+        vty_outln (vty, " allow-ecmp");
 
       /* RIPng static routes. */
       for (rp = route_top (ripng->route); rp; rp = route_next (rp))
 	if (rp->info != NULL)
-	  vty_out (vty, " route %s/%d%s", inet6_ntoa (rp->p.u.prefix6),
-		   rp->p.prefixlen,
-		   VTY_NEWLINE);
+	  vty_outln (vty, " route %s/%d", inet6_ntoa (rp->p.u.prefix6),
+		   rp->p.prefixlen);
 
       /* RIPng timers configuration. */
       if (ripng->update_time != RIPNG_UPDATE_TIMER_DEFAULT ||
 	  ripng->timeout_time != RIPNG_TIMEOUT_TIMER_DEFAULT ||
 	  ripng->garbage_time != RIPNG_GARBAGE_TIMER_DEFAULT)
 	{
-	  vty_out (vty, " timers basic %ld %ld %ld%s",
+	  vty_outln (vty, " timers basic %ld %ld %ld",
 		   ripng->update_time,
 		   ripng->timeout_time,
-		   ripng->garbage_time,
-		   VTY_NEWLINE);
+		   ripng->garbage_time);
 	}
 #if 0
       if (ripng->update_time != RIPNG_UPDATE_TIMER_DEFAULT)

--- a/tests/lib/cli/common_cli.c
+++ b/tests/lib/cli/common_cli.c
@@ -36,10 +36,10 @@ int dump_args(struct vty *vty, const char *descr,
               int argc, struct cmd_token *argv[])
 {
   int i;
-  vty_out (vty, "%s with %d args.%s", descr, argc, VTY_NEWLINE);
+  vty_outln (vty, "%s with %d args.", descr, argc);
   for (i = 0; i < argc; i++)
     {
-      vty_out (vty, "[%02d] %s@%s: %s%s", i, argv[i]->text, argv[i]->varname, argv[i]->arg, VTY_NEWLINE);
+      vty_outln (vty, "[%02d] %s@%s: %s", i, argv[i]->text, argv[i]->varname, argv[i]->arg);
     }
 
   return CMD_SUCCESS;

--- a/tests/lib/cli/test_cli.c
+++ b/tests/lib/cli/test_cli.c
@@ -47,10 +47,10 @@ DEFPY(magic_test, magic_test_cmd,
 	"1\n2\n3\n4\n5\n")
 {
   char buf[256];
-  vty_out(vty, "def: %s%s", self->string, VTY_NEWLINE);
-  vty_out(vty, "num: %ld%s", magic, VTY_NEWLINE);
-  vty_out(vty, "ipv4: %s%s", prefix2str(ipv4net, buf, sizeof(buf)), VTY_NEWLINE);
-  vty_out(vty, "ipv6: %s%s", inet_ntop(AF_INET6, &ipv6, buf, sizeof(buf)), VTY_NEWLINE);
+  vty_outln(vty, "def: %s", self->string);
+  vty_outln(vty, "num: %ld", magic);
+  vty_outln(vty, "ipv4: %s", prefix2str(ipv4net, buf, sizeof(buf)));
+  vty_outln(vty, "ipv6: %s", inet_ntop(AF_INET6, &ipv6, buf, sizeof(buf)));
   return CMD_SUCCESS;
 }
 

--- a/tests/lib/test_heavy.c
+++ b/tests/lib/test_heavy.c
@@ -63,7 +63,7 @@ slow_func (struct vty *vty, const char *str, const int i)
     printf ("%s: hard error\n", __func__);
   
   if ((i % ITERS_PRINT) == 0)
-    printf ("%s did %d, x = %g%s", str, i, x, VTY_NEWLINE);  
+    printf ("%s did %d, x = %g%s", str, i, x, VTYNL);  
 }
 
 static void

--- a/tests/lib/test_heavy.c
+++ b/tests/lib/test_heavy.c
@@ -88,7 +88,7 @@ DEFUN (clear_foo,
   char *str;
   if (!argc)
     {
-      vty_out (vty, "%% string argument required%s", VTY_NEWLINE);
+      vty_outln (vty, "%% string argument required");
       return CMD_WARNING;
     }
   

--- a/tests/lib/test_heavy_thread.c
+++ b/tests/lib/test_heavy_thread.c
@@ -112,7 +112,7 @@ DEFUN (clear_foo,
 
   if (!argc)
     {
-      vty_out (vty, "%% string argument required%s", VTY_NEWLINE);
+      vty_outln (vty, "%% string argument required");
       return CMD_WARNING;
     }
   

--- a/tests/lib/test_heavy_wq.c
+++ b/tests/lib/test_heavy_wq.c
@@ -146,7 +146,7 @@ DEFUN (clear_foo,
   char *str;
   if (!argc)
     {
-      vty_out (vty, "%% string argument required%s", VTY_NEWLINE);
+      vty_outln (vty, "%% string argument required");
       return CMD_WARNING;
     }
   

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -814,7 +814,7 @@ vtysh_rl_describe (void)
                     fprintf (stdout, " %s", item);
                     XFREE (MTYPE_COMPLETION, item);
                   }
-                vty_outln (vty, "");
+                vty_out (vty, VTYNL);
               }
             vector_free (varcomps);
           }
@@ -2806,7 +2806,7 @@ DEFUN (vtysh_show_daemons,
   for (i = 0; i < array_size(vtysh_client); i++)
     if ( vtysh_client[i].fd >= 0 )
       vty_out(vty, " %s", vtysh_client[i].name);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   return CMD_SUCCESS;
 }

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2503,7 +2503,7 @@ DEFUN (vtysh_write_terminal,
     fp = stdout;
 
   vty_outln (vty, "Building configuration...");
-  vty_outln (vty, "%sCurrent configuration:",VTY_NEWLINE);
+  vty_outln (vty, "%sCurrent configuration:",VTYNL);
   vty_outln (vty, "!");
 
   for (i = 0; i < array_size(vtysh_client); i++)

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -814,7 +814,7 @@ vtysh_rl_describe (void)
                     fprintf (stdout, " %s", item);
                     XFREE (MTYPE_COMPLETION, item);
                   }
-                vty_out (vty, "%s", VTY_NEWLINE);
+                vty_outln (vty, "");
               }
             vector_free (varcomps);
           }
@@ -2502,10 +2502,9 @@ DEFUN (vtysh_write_terminal,
   else
     fp = stdout;
 
-  vty_out (vty, "Building configuration...%s", VTY_NEWLINE);
-  vty_out (vty, "%sCurrent configuration:%s", VTY_NEWLINE,
-           VTY_NEWLINE);
-  vty_out (vty, "!%s", VTY_NEWLINE);
+  vty_outln (vty, "Building configuration...");
+  vty_outln (vty, "%sCurrent configuration:",VTY_NEWLINE);
+  vty_outln (vty, "!");
 
   for (i = 0; i < array_size(vtysh_client); i++)
     if ((argc < 3 ) || (strmatch (vtysh_client[i].name, argv[2]->text)))
@@ -2527,7 +2526,7 @@ DEFUN (vtysh_write_terminal,
       fp = NULL;
     }
 
-  vty_out (vty, "end%s", VTY_NEWLINE);
+  vty_outln (vty, "end");
   return CMD_SUCCESS;
 }
 
@@ -2760,7 +2759,7 @@ DEFUN (vtysh_terminal_length,
   lines = strtol (argv[idx_number]->arg, &endptr, 10);
   if (lines < 0 || lines > 512 || *endptr != '\0')
     {
-      vty_out (vty, "length is malformed%s", VTY_NEWLINE);
+      vty_outln (vty, "length is malformed");
       return CMD_WARNING;
     }
 
@@ -2807,7 +2806,7 @@ DEFUN (vtysh_show_daemons,
   for (i = 0; i < array_size(vtysh_client); i++)
     if ( vtysh_client[i].fd >= 0 )
       vty_out(vty, " %s", vtysh_client[i].name);
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
   return CMD_SUCCESS;
 }

--- a/watchfrr/watchfrr_vty.c
+++ b/watchfrr/watchfrr_vty.c
@@ -41,8 +41,7 @@ DEFUN(config_write_integrated,
 	sigset_t oldmask, sigmask;
 
 	if (integrated_write_pid != -1) {
-		vty_out(vty, "%% configuration write already in progress.%s",
-			VTY_NEWLINE);
+		vty_outln (vty,"%% configuration write already in progress.");
 		return CMD_WARNING;
 	}
 
@@ -60,8 +59,8 @@ DEFUN(config_write_integrated,
 
 	child = fork();
 	if (child == -1) {
-		vty_out(vty, "%% configuration write fork() failed: %s.%s",
-			safe_strerror(errno), VTY_NEWLINE);
+		vty_outln (vty, "%% configuration write fork() failed: %s.",
+			safe_strerror(errno));
 		sigprocmask(SIG_SETMASK, &oldmask, NULL);
 		return CMD_WARNING;
 	}

--- a/zebra/debug.c
+++ b/zebra/debug.c
@@ -39,10 +39,10 @@ DEFUN (show_debugging_zebra,
        "Debugging information\n"
        "Zebra configuration\n")
 {
-  vty_out (vty, "Zebra debugging status:%s", VTY_NEWLINE);
+  vty_out (vty, "Zebra debugging status:%s", VTYNL);
 
   if (IS_ZEBRA_DEBUG_EVENT)
-    vty_out (vty, "  Zebra event debugging is on%s", VTY_NEWLINE);
+    vty_out (vty, "  Zebra event debugging is on%s", VTYNL);
 
   if (IS_ZEBRA_DEBUG_PACKET)
     {
@@ -50,40 +50,40 @@ DEFUN (show_debugging_zebra,
 	{
 	  vty_out (vty, "  Zebra packet%s debugging is on%s",
 		   IS_ZEBRA_DEBUG_DETAIL ? " detail" : "",
-		   VTY_NEWLINE);
+		   VTYNL);
 	}
       else
 	{
 	  if (IS_ZEBRA_DEBUG_SEND)
 	    vty_out (vty, "  Zebra packet send%s debugging is on%s",
 		     IS_ZEBRA_DEBUG_DETAIL ? " detail" : "",
-		     VTY_NEWLINE);
+		     VTYNL);
 	  else
 	    vty_out (vty, "  Zebra packet receive%s debugging is on%s",
 		     IS_ZEBRA_DEBUG_DETAIL ? " detail" : "",
-		     VTY_NEWLINE);
+		     VTYNL);
 	}
     }
 
   if (IS_ZEBRA_DEBUG_KERNEL)
-    vty_out (vty, "  Zebra kernel debugging is on%s", VTY_NEWLINE);
+    vty_out (vty, "  Zebra kernel debugging is on%s", VTYNL);
   if (IS_ZEBRA_DEBUG_KERNEL_MSGDUMP_SEND)
-    vty_out (vty, "  Zebra kernel netlink message dumps (send) are on%s", VTY_NEWLINE);
+    vty_out (vty, "  Zebra kernel netlink message dumps (send) are on%s", VTYNL);
   if (IS_ZEBRA_DEBUG_KERNEL_MSGDUMP_RECV)
-    vty_out (vty, "  Zebra kernel netlink message dumps (recv) are on%s", VTY_NEWLINE);
+    vty_out (vty, "  Zebra kernel netlink message dumps (recv) are on%s", VTYNL);
 
   /* Check here using flags as the 'macro' does an OR */
   if (CHECK_FLAG (zebra_debug_rib, ZEBRA_DEBUG_RIB))
-    vty_out (vty, "  Zebra RIB debugging is on%s", VTY_NEWLINE);
+    vty_out (vty, "  Zebra RIB debugging is on%s", VTYNL);
   if (CHECK_FLAG (zebra_debug_rib, ZEBRA_DEBUG_RIB_DETAILED))
-    vty_out (vty, "  Zebra RIB detailed debugging is on%s", VTY_NEWLINE);
+    vty_out (vty, "  Zebra RIB detailed debugging is on%s", VTYNL);
 
   if (IS_ZEBRA_DEBUG_FPM)
-    vty_out (vty, "  Zebra FPM debugging is on%s", VTY_NEWLINE);
+    vty_out (vty, "  Zebra FPM debugging is on%s", VTYNL);
   if (IS_ZEBRA_DEBUG_NHT)
-    vty_out (vty, "  Zebra next-hop tracking debugging is on%s", VTY_NEWLINE);
+    vty_out (vty, "  Zebra next-hop tracking debugging is on%s", VTYNL);
   if (IS_ZEBRA_DEBUG_MPLS)
-    vty_out (vty, "  Zebra MPLS debugging is on%s", VTY_NEWLINE);
+    vty_out (vty, "  Zebra MPLS debugging is on%s", VTYNL);
 
   return CMD_SUCCESS;
 }
@@ -353,7 +353,7 @@ config_write_debug (struct vty *vty)
 
   if (IS_ZEBRA_DEBUG_EVENT)
     {
-      vty_out (vty, "debug zebra events%s", VTY_NEWLINE);
+      vty_out (vty, "debug zebra events%s", VTYNL);
       write++;
     }
   if (IS_ZEBRA_DEBUG_PACKET)
@@ -362,7 +362,7 @@ config_write_debug (struct vty *vty)
 	{
 	  vty_out (vty, "debug zebra packet%s%s",
 		   IS_ZEBRA_DEBUG_DETAIL ? " detail" : "",
-		   VTY_NEWLINE);
+		   VTYNL);
 	  write++;
 	}
       else
@@ -370,53 +370,53 @@ config_write_debug (struct vty *vty)
 	  if (IS_ZEBRA_DEBUG_SEND)
 	    vty_out (vty, "debug zebra packet send%s%s",
 		     IS_ZEBRA_DEBUG_DETAIL ? " detail" : "",
-		     VTY_NEWLINE);
+		     VTYNL);
 	  else
 	    vty_out (vty, "debug zebra packet recv%s%s",
 		     IS_ZEBRA_DEBUG_DETAIL ? " detail" : "",
-		     VTY_NEWLINE);
+		     VTYNL);
 	  write++;
 	}
     }
   if (IS_ZEBRA_DEBUG_KERNEL)
     {
-      vty_out (vty, "debug zebra kernel%s", VTY_NEWLINE);
+      vty_out (vty, "debug zebra kernel%s", VTYNL);
       write++;
     }
   if (IS_ZEBRA_DEBUG_KERNEL_MSGDUMP_RECV)
     {
-      vty_out (vty, "debug zebra kernel msgdump recv%s", VTY_NEWLINE);
+      vty_out (vty, "debug zebra kernel msgdump recv%s", VTYNL);
       write++;
     }
   if (IS_ZEBRA_DEBUG_KERNEL_MSGDUMP_SEND)
     {
-      vty_out (vty, "debug zebra kernel msgdump send%s", VTY_NEWLINE);
+      vty_out (vty, "debug zebra kernel msgdump send%s", VTYNL);
       write++;
     }
   /* Check here using flags as the 'macro' does an OR */
   if (CHECK_FLAG (zebra_debug_rib, ZEBRA_DEBUG_RIB))
     {
-      vty_out (vty, "debug zebra rib%s", VTY_NEWLINE);
+      vty_out (vty, "debug zebra rib%s", VTYNL);
       write++;
     }
   if (CHECK_FLAG (zebra_debug_rib, ZEBRA_DEBUG_RIB_DETAILED))
     {
-      vty_out (vty, "debug zebra rib detailed%s", VTY_NEWLINE);
+      vty_out (vty, "debug zebra rib detailed%s", VTYNL);
       write++;
     }
   if (IS_ZEBRA_DEBUG_FPM)
     {
-      vty_out (vty, "debug zebra fpm%s", VTY_NEWLINE);
+      vty_out (vty, "debug zebra fpm%s", VTYNL);
       write++;
     }
   if (IS_ZEBRA_DEBUG_NHT)
     {
-      vty_out (vty, "debug zebra nht%s", VTY_NEWLINE);
+      vty_out (vty, "debug zebra nht%s", VTYNL);
       write++;
     }
   if (IS_ZEBRA_DEBUG_MPLS)
     {
-      vty_out (vty, "debug zebra mpls%s", VTY_NEWLINE);
+      vty_out (vty, "debug zebra mpls%s", VTYNL);
       write++;
     }
   return write;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -944,7 +944,7 @@ connected_dump_vty (struct vty *vty, struct connected *connected)
   if (connected->label)
     vty_out (vty, " %s", connected->label);
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 }
 
 /* Dump interface neighbor address information to vty. */
@@ -959,7 +959,7 @@ nbr_connected_dump_vty (struct vty *vty, struct nbr_connected *connected)
   prefix_vty_out (vty, p);
   vty_out (vty, "/%d", p->prefixlen);
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 }
 
 #if defined (HAVE_RTADV)
@@ -976,53 +976,46 @@ nd_dump_vty (struct vty *vty, struct interface *ifp)
 
   if (rtadv->AdvSendAdvertisements)
     {
-      vty_out (vty, "  ND advertised reachable time is %d milliseconds%s",
-	       rtadv->AdvReachableTime, VTY_NEWLINE);
-      vty_out (vty, "  ND advertised retransmit interval is %d milliseconds%s",
-	       rtadv->AdvRetransTimer, VTY_NEWLINE);
-      vty_out (vty, "  ND router advertisements sent: %d rcvd: %d%s",
-	       zif->ra_sent, zif->ra_rcvd, VTY_NEWLINE);
+      vty_outln (vty, "  ND advertised reachable time is %d milliseconds",
+	       rtadv->AdvReachableTime);
+      vty_outln (vty, "  ND advertised retransmit interval is %d milliseconds",
+	       rtadv->AdvRetransTimer);
+      vty_outln (vty, "  ND router advertisements sent: %d rcvd: %d",
+	       zif->ra_sent, zif->ra_rcvd);
       interval = rtadv->MaxRtrAdvInterval;
       if (interval % 1000)
-        vty_out (vty, "  ND router advertisements are sent every "
-			"%d milliseconds%s", interval,
-		 VTY_NEWLINE);
+        vty_outln (vty, "  ND router advertisements are sent every "
+			"%d milliseconds",interval);
       else
-        vty_out (vty, "  ND router advertisements are sent every "
-			"%d seconds%s", interval / 1000,
-		 VTY_NEWLINE);
+        vty_outln (vty, "  ND router advertisements are sent every "
+			"%d seconds",interval / 1000);
       if (rtadv->AdvDefaultLifetime != -1)
-	vty_out (vty, "  ND router advertisements live for %d seconds%s",
-		 rtadv->AdvDefaultLifetime, VTY_NEWLINE);
+	vty_outln (vty, "  ND router advertisements live for %d seconds",
+		 rtadv->AdvDefaultLifetime);
       else
-	vty_out (vty, "  ND router advertisements lifetime tracks ra-interval%s",
-		 VTY_NEWLINE);
-      vty_out (vty, "  ND router advertisement default router preference is "
-			"%s%s", rtadv_pref_strs[rtadv->DefaultPreference],
-		 VTY_NEWLINE);
+	vty_outln (vty,
+                   "  ND router advertisements lifetime tracks ra-interval");
+      vty_outln (vty, "  ND router advertisement default router preference is "
+			"%s",rtadv_pref_strs[rtadv->DefaultPreference]);
       if (rtadv->AdvManagedFlag)
-	vty_out (vty, "  Hosts use DHCP to obtain routable addresses.%s",
-		 VTY_NEWLINE);
+	vty_outln (vty,"  Hosts use DHCP to obtain routable addresses.");
       else
-	vty_out (vty, "  Hosts use stateless autoconfig for addresses.%s",
-		 VTY_NEWLINE);
+	vty_outln (vty,"  Hosts use stateless autoconfig for addresses.");
       if (rtadv->AdvHomeAgentFlag)
       {
-      	vty_out (vty, "  ND router advertisements with "
-				"Home Agent flag bit set.%s",
-		 VTY_NEWLINE);
+      	vty_outln (vty,
+                         "  ND router advertisements with " "Home Agent flag bit set.");
 	if (rtadv->HomeAgentLifetime != -1)
-	  vty_out (vty, "  Home Agent lifetime is %u seconds%s",
-	           rtadv->HomeAgentLifetime, VTY_NEWLINE);
+	  vty_outln (vty, "  Home Agent lifetime is %u seconds",
+	           rtadv->HomeAgentLifetime);
 	else
-	  vty_out (vty, "  Home Agent lifetime tracks ra-lifetime%s",
-	           VTY_NEWLINE);
-	vty_out (vty, "  Home Agent preference is %u%s",
-	         rtadv->HomeAgentPreference, VTY_NEWLINE);
+	  vty_outln (vty,"  Home Agent lifetime tracks ra-lifetime");
+	vty_outln (vty, "  Home Agent preference is %u",
+	         rtadv->HomeAgentPreference);
       }
       if (rtadv->AdvIntervalOption)
-      	vty_out (vty, "  ND router advertisements with Adv. Interval option.%s",
-		 VTY_NEWLINE);
+      	vty_outln (vty,
+                         "  ND router advertisements with Adv. Interval option.");
     }
 }
 #endif /* HAVE_RTADV */
@@ -1046,39 +1039,37 @@ if_dump_vty (struct vty *vty, struct interface *ifp)
     
     if (CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_LINKDETECTION)) {
       if (if_is_running(ifp))
-       vty_out (vty, "is up%s", VTY_NEWLINE);
+       vty_outln (vty, "is up");
       else
-	vty_out (vty, "is down%s", VTY_NEWLINE);
+	vty_outln (vty, "is down");
     } else {
-      vty_out (vty, "detection is disabled%s", VTY_NEWLINE);
+      vty_outln (vty, "detection is disabled");
     }
   } else {
-    vty_out (vty, "down%s", VTY_NEWLINE);
+    vty_outln (vty, "down");
   }
 
-  vty_out (vty, "  Link ups:   %5u    last: %s%s", zebra_if->up_count,
-           zebra_if->up_last[0] ? zebra_if->up_last : "(never)", VTY_NEWLINE);
-  vty_out (vty, "  Link downs: %5u    last: %s%s", zebra_if->down_count,
-           zebra_if->down_last[0] ? zebra_if->down_last : "(never)", VTY_NEWLINE);
+  vty_outln (vty, "  Link ups:   %5u    last: %s", zebra_if->up_count,
+           zebra_if->up_last[0] ? zebra_if->up_last : "(never)");
+  vty_outln (vty, "  Link downs: %5u    last: %s", zebra_if->down_count,
+           zebra_if->down_last[0] ? zebra_if->down_last : "(never)");
 
   zebra_ptm_show_status(vty, ifp);
 
   vrf = vrf_lookup_by_id (ifp->vrf_id);
-  vty_out (vty, "  vrf: %s%s", vrf->name, VTY_NEWLINE);
+  vty_outln (vty, "  vrf: %s", vrf->name);
 
   if (ifp->desc)
-    vty_out (vty, "  Description: %s%s", ifp->desc,
-	     VTY_NEWLINE);
+    vty_outln (vty, "  Description: %s",ifp->desc);
   if (ifp->ifindex == IFINDEX_INTERNAL)
     {
-      vty_out(vty, "  pseudo interface%s", VTY_NEWLINE);
+      vty_outln (vty, "  pseudo interface");
       return;
     }
   else if (! CHECK_FLAG (ifp->status, ZEBRA_INTERFACE_ACTIVE))
     {
-      vty_out(vty, "  index %d inactive interface%s", 
-	      ifp->ifindex, 
-	      VTY_NEWLINE);
+      vty_outln (vty, "  index %d inactive interface", 
+	      ifp->ifindex);
       return;
     }
 
@@ -1086,11 +1077,11 @@ if_dump_vty (struct vty *vty, struct interface *ifp)
 	   ifp->ifindex, ifp->metric, ifp->mtu, ifp->speed);
   if (ifp->mtu6 != ifp->mtu)
     vty_out (vty, "mtu6 %d ", ifp->mtu6);
-  vty_out (vty, "%s  flags: %s%s", VTY_NEWLINE,
-           if_flag_dump (ifp->flags), VTY_NEWLINE);
+  vty_outln (vty, "%s  flags: %s", VTY_NEWLINE,
+           if_flag_dump(ifp->flags));
   
   /* Hardware address. */
-  vty_out (vty, "  Type: %s%s", if_link_type_str (ifp->ll_type), VTY_NEWLINE);
+  vty_outln (vty, "  Type: %s", if_link_type_str(ifp->ll_type));
   if (ifp->hw_addr_len != 0)
     {
       int i;
@@ -1098,14 +1089,14 @@ if_dump_vty (struct vty *vty, struct interface *ifp)
       vty_out (vty, "  HWaddr: ");
       for (i = 0; i < ifp->hw_addr_len; i++)
 	vty_out (vty, "%s%02x", i == 0 ? "" : ":", ifp->hw_addr[i]);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
   
   /* Bandwidth in Mbps */
   if (ifp->bandwidth != 0)
     {
       vty_out(vty, "  bandwidth %u Mbps", ifp->bandwidth);
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   for (rn = route_top (zebra_if->ipv4_subnets); rn; rn = route_next (rn))
@@ -1128,22 +1119,23 @@ if_dump_vty (struct vty *vty, struct interface *ifp)
     {
       int i;
       struct if_link_params *iflp = ifp->link_params;
-      vty_out(vty, "  Traffic Engineering Link Parameters:%s", VTY_NEWLINE);
+      vty_outln (vty, "  Traffic Engineering Link Parameters:");
       if (IS_PARAM_SET(iflp, LP_TE_METRIC))
-        vty_out(vty, "    TE metric %u%s",iflp->te_metric, VTY_NEWLINE);
+        vty_outln (vty, "    TE metric %u",iflp->te_metric);
       if (IS_PARAM_SET(iflp, LP_MAX_BW))
-        vty_out(vty, "    Maximum Bandwidth %g (Byte/s)%s", iflp->max_bw, VTY_NEWLINE);
+        vty_outln (vty, "    Maximum Bandwidth %g (Byte/s)", iflp->max_bw);
       if (IS_PARAM_SET(iflp, LP_MAX_RSV_BW))
-        vty_out(vty, "    Maximum Reservable Bandwidth %g (Byte/s)%s", iflp->max_rsv_bw, VTY_NEWLINE);
+        vty_outln (vty, "    Maximum Reservable Bandwidth %g (Byte/s)",
+                  iflp->max_rsv_bw);
       if (IS_PARAM_SET(iflp, LP_UNRSV_BW)) {
-        vty_out(vty, "    Unreserved Bandwidth per Class Type in Byte/s:%s", VTY_NEWLINE);
+        vty_outln (vty, "    Unreserved Bandwidth per Class Type in Byte/s:");
         for (i = 0; i < MAX_CLASS_TYPE; i+=2)
-          vty_out(vty, "      [%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)%s",
-                  i, iflp->unrsv_bw[i], i+1, iflp->unrsv_bw[i+1], VTY_NEWLINE);
+          vty_outln (vty, "      [%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)",
+                  i, iflp->unrsv_bw[i], i+1, iflp->unrsv_bw[i + 1]);
       }
 
       if (IS_PARAM_SET(iflp, LP_ADM_GRP))
-        vty_out(vty, "    Administrative Group:%u%s", iflp->admin_grp, VTY_NEWLINE);
+        vty_outln (vty, "    Administrative Group:%u", iflp->admin_grp);
       if (IS_PARAM_SET(iflp, LP_DELAY))
         {
           vty_out(vty, "    Link Delay Average: %u (micro-sec.)", iflp->av_delay);
@@ -1152,20 +1144,22 @@ if_dump_vty (struct vty *vty, struct interface *ifp)
               vty_out(vty, " Min:  %u (micro-sec.)", iflp->min_delay);
               vty_out(vty, " Max:  %u (micro-sec.)", iflp->max_delay);
             }
-          vty_out(vty, "%s", VTY_NEWLINE);
+          vty_outln (vty, "");
         }
       if (IS_PARAM_SET(iflp, LP_DELAY_VAR))
-        vty_out(vty, "    Link Delay Variation %u (micro-sec.)%s", iflp->delay_var, VTY_NEWLINE);
+        vty_outln (vty, "    Link Delay Variation %u (micro-sec.)",
+                  iflp->delay_var);
       if (IS_PARAM_SET(iflp, LP_PKT_LOSS))
-        vty_out(vty, "    Link Packet Loss %g (in %%)%s", iflp->pkt_loss, VTY_NEWLINE);
+        vty_outln (vty, "    Link Packet Loss %g (in %%)", iflp->pkt_loss);
       if (IS_PARAM_SET(iflp, LP_AVA_BW))
-        vty_out(vty, "    Available Bandwidth %g (Byte/s)%s", iflp->ava_bw, VTY_NEWLINE);
+        vty_outln (vty, "    Available Bandwidth %g (Byte/s)", iflp->ava_bw);
       if (IS_PARAM_SET(iflp, LP_RES_BW))
-        vty_out(vty, "    Residual Bandwidth %g (Byte/s)%s", iflp->res_bw, VTY_NEWLINE);
+        vty_outln (vty, "    Residual Bandwidth %g (Byte/s)", iflp->res_bw);
       if (IS_PARAM_SET(iflp, LP_USE_BW))
-        vty_out(vty, "    Utilized Bandwidth %g (Byte/s)%s", iflp->use_bw, VTY_NEWLINE);
+        vty_outln (vty, "    Utilized Bandwidth %g (Byte/s)", iflp->use_bw);
       if (IS_PARAM_SET(iflp, LP_RMT_AS))
-        vty_out(vty, "    Neighbor ASBR IP: %s AS: %u %s", inet_ntoa(iflp->rmt_ip), iflp->rmt_as, VTY_NEWLINE);
+        vty_outln (vty, "    Neighbor ASBR IP: %s AS: %u ", inet_ntoa(iflp->rmt_ip),
+                  iflp->rmt_as);
     }
 
  #ifdef RTADV
@@ -1175,86 +1169,83 @@ if_dump_vty (struct vty *vty, struct interface *ifp)
   nd_dump_vty (vty, ifp);
 #endif /* HAVE_RTADV */
   if (listhead(ifp->nbr_connected))
-    vty_out (vty, "  Neighbor address(s):%s", VTY_NEWLINE);
+    vty_outln (vty, "  Neighbor address(s):");
   for (ALL_LIST_ELEMENTS_RO (ifp->nbr_connected, node, nbr_connected))
     nbr_connected_dump_vty (vty, nbr_connected);
 
 #ifdef HAVE_PROC_NET_DEV
   /* Statistics print out using proc file system. */
-  vty_out (vty, "    %lu input packets (%lu multicast), %lu bytes, "
-	   "%lu dropped%s",
+  vty_outln (vty, "    %lu input packets (%lu multicast), %lu bytes, "
+	   "%lu dropped",
 	   ifp->stats.rx_packets, ifp->stats.rx_multicast,
-	   ifp->stats.rx_bytes, ifp->stats.rx_dropped, VTY_NEWLINE);
+	   ifp->stats.rx_bytes, ifp->stats.rx_dropped);
 
-  vty_out (vty, "    %lu input errors, %lu length, %lu overrun,"
-	   " %lu CRC, %lu frame%s",
+  vty_outln (vty, "    %lu input errors, %lu length, %lu overrun,"
+	   " %lu CRC, %lu frame",
 	   ifp->stats.rx_errors, ifp->stats.rx_length_errors,
 	   ifp->stats.rx_over_errors, ifp->stats.rx_crc_errors,
-	   ifp->stats.rx_frame_errors, VTY_NEWLINE);
+	   ifp->stats.rx_frame_errors);
 
-  vty_out (vty, "    %lu fifo, %lu missed%s", ifp->stats.rx_fifo_errors,
-	   ifp->stats.rx_missed_errors, VTY_NEWLINE);
+  vty_outln (vty, "    %lu fifo, %lu missed", ifp->stats.rx_fifo_errors,
+	   ifp->stats.rx_missed_errors);
 
-  vty_out (vty, "    %lu output packets, %lu bytes, %lu dropped%s",
+  vty_outln (vty, "    %lu output packets, %lu bytes, %lu dropped",
 	   ifp->stats.tx_packets, ifp->stats.tx_bytes,
-	   ifp->stats.tx_dropped, VTY_NEWLINE);
+	   ifp->stats.tx_dropped);
 
-  vty_out (vty, "    %lu output errors, %lu aborted, %lu carrier,"
-	   " %lu fifo, %lu heartbeat%s",
+  vty_outln (vty, "    %lu output errors, %lu aborted, %lu carrier,"
+	   " %lu fifo, %lu heartbeat",
 	   ifp->stats.tx_errors, ifp->stats.tx_aborted_errors,
 	   ifp->stats.tx_carrier_errors, ifp->stats.tx_fifo_errors,
-	   ifp->stats.tx_heartbeat_errors, VTY_NEWLINE);
+	   ifp->stats.tx_heartbeat_errors);
 
-  vty_out (vty, "    %lu window, %lu collisions%s",
-	   ifp->stats.tx_window_errors, ifp->stats.collisions, VTY_NEWLINE);
+  vty_outln (vty, "    %lu window, %lu collisions",
+	   ifp->stats.tx_window_errors, ifp->stats.collisions);
 #endif /* HAVE_PROC_NET_DEV */
 
 #ifdef HAVE_NET_RT_IFLIST
 #if defined (__bsdi__) || defined (__NetBSD__)
   /* Statistics print out using sysctl (). */
-  vty_out (vty, "    input packets %llu, bytes %llu, dropped %llu,"
-           " multicast packets %llu%s",
+  vty_outln (vty, "    input packets %llu, bytes %llu, dropped %llu,"
+           " multicast packets %llu",
            (unsigned long long)ifp->stats.ifi_ipackets,
            (unsigned long long)ifp->stats.ifi_ibytes,
            (unsigned long long)ifp->stats.ifi_iqdrops,
-           (unsigned long long)ifp->stats.ifi_imcasts,
-           VTY_NEWLINE);
+           (unsigned long long)ifp->stats.ifi_imcasts);
 
-  vty_out (vty, "    input errors %llu%s",
-           (unsigned long long)ifp->stats.ifi_ierrors, VTY_NEWLINE);
+  vty_outln (vty, "    input errors %llu",
+           (unsigned long long)ifp->stats.ifi_ierrors);
 
-  vty_out (vty, "    output packets %llu, bytes %llu,"
-           " multicast packets %llu%s",
+  vty_outln (vty, "    output packets %llu, bytes %llu,"
+           " multicast packets %llu",
            (unsigned long long)ifp->stats.ifi_opackets,
            (unsigned long long)ifp->stats.ifi_obytes,
-           (unsigned long long)ifp->stats.ifi_omcasts,
-           VTY_NEWLINE);
+           (unsigned long long)ifp->stats.ifi_omcasts);
 
-  vty_out (vty, "    output errors %llu%s",
-           (unsigned long long)ifp->stats.ifi_oerrors, VTY_NEWLINE);
+  vty_outln (vty, "    output errors %llu",
+           (unsigned long long)ifp->stats.ifi_oerrors);
 
-  vty_out (vty, "    collisions %llu%s",
-           (unsigned long long)ifp->stats.ifi_collisions, VTY_NEWLINE);
+  vty_outln (vty, "    collisions %llu",
+           (unsigned long long)ifp->stats.ifi_collisions);
 #else
   /* Statistics print out using sysctl (). */
-  vty_out (vty, "    input packets %lu, bytes %lu, dropped %lu,"
-	   " multicast packets %lu%s",
+  vty_outln (vty, "    input packets %lu, bytes %lu, dropped %lu,"
+	   " multicast packets %lu",
 	   ifp->stats.ifi_ipackets, ifp->stats.ifi_ibytes,
-	   ifp->stats.ifi_iqdrops, ifp->stats.ifi_imcasts,
-	   VTY_NEWLINE);
+	   ifp->stats.ifi_iqdrops,ifp->stats.ifi_imcasts);
 
-  vty_out (vty, "    input errors %lu%s",
-	   ifp->stats.ifi_ierrors, VTY_NEWLINE);
+  vty_outln (vty, "    input errors %lu",
+	   ifp->stats.ifi_ierrors);
 
-  vty_out (vty, "    output packets %lu, bytes %lu, multicast packets %lu%s",
+  vty_outln (vty, "    output packets %lu, bytes %lu, multicast packets %lu",
 	   ifp->stats.ifi_opackets, ifp->stats.ifi_obytes,
-	   ifp->stats.ifi_omcasts, VTY_NEWLINE);
+	   ifp->stats.ifi_omcasts);
 
-  vty_out (vty, "    output errors %lu%s",
-	   ifp->stats.ifi_oerrors, VTY_NEWLINE);
+  vty_outln (vty, "    output errors %lu",
+	   ifp->stats.ifi_oerrors);
 
-  vty_out (vty, "    collisions %lu%s",
-	   ifp->stats.ifi_collisions, VTY_NEWLINE);
+  vty_outln (vty, "    collisions %lu",
+	   ifp->stats.ifi_collisions);
 #endif /* __bsdi__ || __NetBSD__ */
 #endif /* HAVE_NET_RT_IFLIST */
 }
@@ -1349,8 +1340,7 @@ DEFUN (show_interface_name_vrf,
   ifp = if_lookup_by_name (argv[idx_ifname]->arg, vrf_id);
   if (ifp == NULL)
     {
-      vty_out (vty, "%% Can't find interface %s%s", argv[idx_ifname]->arg,
-               VTY_NEWLINE);
+      vty_outln (vty, "%% Can't find interface %s",argv[idx_ifname]->arg);
       return CMD_WARNING;
     }
   if_dump_vty (vty, ifp);
@@ -1388,7 +1378,7 @@ DEFUN (show_interface_name_vrf_all,
 
   if (!found)
     {
-      vty_out (vty, "%% Can't find interface %s%s", argv[idx_ifname]->arg, VTY_NEWLINE);
+      vty_outln (vty, "%% Can't find interface %s", argv[idx_ifname]->arg);
       return CMD_WARNING;
     }
 
@@ -1402,7 +1392,7 @@ if_show_description (struct vty *vty, vrf_id_t vrf_id)
   struct listnode *node;
   struct interface *ifp;
 
-  vty_out (vty, "Interface       Status  Protocol  Description%s", VTY_NEWLINE);
+  vty_outln (vty, "Interface       Status  Protocol  Description");
   for (ALL_LIST_ELEMENTS_RO (vrf_iflist (vrf_id), node, ifp))
     {
       int len;
@@ -1432,7 +1422,7 @@ if_show_description (struct vty *vty, vrf_id_t vrf_id)
 
       if (ifp->desc)
 	vty_out (vty, "%s", ifp->desc);
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 }
 
@@ -1468,8 +1458,8 @@ DEFUN (show_interface_desc_vrf_all,
   RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
     if (!list_isempty (vrf->iflist))
       {
-        vty_out (vty, "%s\tVRF %u%s%s", VTY_NEWLINE, vrf->vrf_id,
-		 VTY_NEWLINE, VTY_NEWLINE);
+        vty_outln (vty, "%s\tVRF %u%s", VTY_NEWLINE, vrf->vrf_id,
+		 VTY_NEWLINE);
         if_show_description (vty, vrf->vrf_id);
       }
 
@@ -1490,7 +1480,7 @@ DEFUN (multicast,
       ret = if_set_flags (ifp, IFF_MULTICAST);
       if (ret < 0)
 	{
-	  vty_out (vty, "Can't set multicast flag%s", VTY_NEWLINE);
+	  vty_outln (vty, "Can't set multicast flag");
 	  return CMD_WARNING;
 	}
       if_refresh (ifp);
@@ -1516,7 +1506,7 @@ DEFUN (no_multicast,
       ret = if_unset_flags (ifp, IFF_MULTICAST);
       if (ret < 0)
 	{
-	  vty_out (vty, "Can't unset multicast flag%s", VTY_NEWLINE);
+	  vty_outln (vty, "Can't unset multicast flag");
 	  return CMD_WARNING;
 	}
       if_refresh (ifp);
@@ -1582,7 +1572,7 @@ DEFUN (shutdown_if,
         ret = if_unset_flags (ifp, IFF_UP);
         if (ret < 0)
           {
-            vty_out (vty, "Can't shutdown interface%s", VTY_NEWLINE);
+            vty_outln (vty, "Can't shutdown interface");
             return CMD_WARNING;
           }
         if_refresh (ifp);
@@ -1608,7 +1598,7 @@ DEFUN (no_shutdown_if,
       ret = if_set_flags (ifp, IFF_UP | IFF_RUNNING);
       if (ret < 0)
 	{
-	  vty_out (vty, "Can't up interface%s", VTY_NEWLINE);
+	  vty_outln (vty, "Can't up interface");
 	  return CMD_WARNING;
 	}
       if_refresh (ifp);
@@ -1640,7 +1630,7 @@ DEFUN (bandwidth_if,
   /* bandwidth range is <1-100000> */
   if (bandwidth < 1 || bandwidth > 100000)
     {
-      vty_out (vty, "Bandwidth is invalid%s", VTY_NEWLINE);
+      vty_outln (vty, "Bandwidth is invalid");
       return CMD_WARNING;
     }
   
@@ -1842,8 +1832,7 @@ DEFUN (link_params_maxbw,
 
   if (sscanf (argv[idx_bandwidth]->arg, "%g", &bw) != 1)
     {
-      vty_out (vty, "link_params_maxbw: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "link_params_maxbw: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -1861,9 +1850,8 @@ DEFUN (link_params_maxbw,
       || (bw <= iflp->res_bw)
       || (bw <= iflp->use_bw))
     {
-      vty_out (vty,
-               "Maximum Bandwidth could not be lower than others bandwidth%s",
-               VTY_NEWLINE);
+      vty_outln (vty,
+               "Maximum Bandwidth could not be lower than others bandwidth");
       return CMD_WARNING;
     }
 
@@ -1886,17 +1874,17 @@ DEFUN (link_params_max_rsv_bw,
 
   if (sscanf (argv[idx_bandwidth]->arg, "%g", &bw) != 1)
     {
-      vty_out (vty, "link_params_max_rsv_bw: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "link_params_max_rsv_bw: fscanf: %s",
+                 safe_strerror(errno));
       return CMD_WARNING;
     }
 
   /* Check that bandwidth is not greater than maximum bandwidth parameter */
   if (bw > iflp->max_bw)
     {
-      vty_out (vty,
-               "Maximum Reservable Bandwidth could not be greater than Maximum Bandwidth (%g)%s",
-               iflp->max_bw, VTY_NEWLINE);
+      vty_outln (vty,
+               "Maximum Reservable Bandwidth could not be greater than Maximum Bandwidth (%g)",
+               iflp->max_bw);
       return CMD_WARNING;
     }
 
@@ -1923,24 +1911,24 @@ DEFUN (link_params_unrsv_bw,
   /* We don't have to consider about range check here. */
   if (sscanf (argv[idx_number]->arg, "%d", &priority) != 1)
     {
-      vty_out (vty, "link_params_unrsv_bw: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "link_params_unrsv_bw: fscanf: %s",
+                 safe_strerror(errno));
       return CMD_WARNING;
     }
 
   if (sscanf (argv[idx_bandwidth]->arg, "%g", &bw) != 1)
     {
-      vty_out (vty, "link_params_unrsv_bw: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "link_params_unrsv_bw: fscanf: %s",
+                 safe_strerror(errno));
       return CMD_WARNING;
     }
 
   /* Check that bandwidth is not greater than maximum bandwidth parameter */
   if (bw > iflp->max_bw)
     {
-      vty_out (vty,
-               "UnReserved Bandwidth could not be greater than Maximum Bandwidth (%g)%s",
-               iflp->max_bw, VTY_NEWLINE);
+      vty_outln (vty,
+               "UnReserved Bandwidth could not be greater than Maximum Bandwidth (%g)",
+               iflp->max_bw);
       return CMD_WARNING;
     }
 
@@ -1963,8 +1951,8 @@ DEFUN (link_params_admin_grp,
 
   if (sscanf (argv[idx_bitpattern]->arg, "0x%lx", &value) != 1)
     {
-      vty_out (vty, "link_params_admin_grp: fscanf: %s%s",
-               safe_strerror (errno), VTY_NEWLINE);
+      vty_outln (vty, "link_params_admin_grp: fscanf: %s",
+               safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -2007,7 +1995,7 @@ DEFUN (link_params_inter_as,
 
   if (!inet_aton (argv[idx_ipv4]->arg, &addr))
     {
-      vty_out (vty, "Please specify Router-Addr by A.B.C.D%s", VTY_NEWLINE);
+      vty_outln (vty, "Please specify Router-Addr by A.B.C.D");
       return CMD_WARNING;
     }
 
@@ -2081,8 +2069,8 @@ DEFUN (link_params_delay,
     if (IS_PARAM_SET(iflp, LP_MM_DELAY)
         && (delay <= iflp->min_delay || delay >= iflp->max_delay))
       {
-        vty_out (vty, "Average delay should be comprise between Min (%d) and Max (%d) delay%s",
-                 iflp->min_delay, iflp->max_delay, VTY_NEWLINE);
+        vty_outln (vty, "Average delay should be comprise between Min (%d) and Max (%d) delay",
+                 iflp->min_delay, iflp->max_delay);
         return CMD_WARNING;
       }
     /* Update delay if value is not set or change */
@@ -2106,8 +2094,8 @@ DEFUN (link_params_delay,
     /* Check new delays value coherency */
     if (delay <= low || delay >= high)
       {
-        vty_out (vty, "Average delay should be comprise between Min (%d) and Max (%d) delay%s",
-                 low, high, VTY_NEWLINE);
+        vty_outln (vty, "Average delay should be comprise between Min (%d) and Max (%d) delay",
+                 low, high);
         return CMD_WARNING;
       }
     /* Update Delays if needed */
@@ -2202,8 +2190,8 @@ DEFUN (link_params_pkt_loss,
 
   if (sscanf (argv[idx_percentage]->arg, "%g", &fval) != 1)
     {
-      vty_out (vty, "link_params_pkt_loss: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "link_params_pkt_loss: fscanf: %s",
+                 safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -2243,17 +2231,16 @@ DEFUN (link_params_res_bw,
 
   if (sscanf (argv[idx_bandwidth]->arg, "%g", &bw) != 1)
     {
-      vty_out (vty, "link_params_res_bw: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "link_params_res_bw: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
   /* Check that bandwidth is not greater than maximum bandwidth parameter */
   if (bw > iflp->max_bw)
     {
-      vty_out (vty,
-               "Residual Bandwidth could not be greater than Maximum Bandwidth (%g)%s",
-               iflp->max_bw, VTY_NEWLINE);
+      vty_outln (vty,
+               "Residual Bandwidth could not be greater than Maximum Bandwidth (%g)",
+               iflp->max_bw);
       return CMD_WARNING;
     }
 
@@ -2290,17 +2277,16 @@ DEFUN (link_params_ava_bw,
 
   if (sscanf (argv[idx_bandwidth]->arg, "%g", &bw) != 1)
     {
-      vty_out (vty, "link_params_ava_bw: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "link_params_ava_bw: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
   /* Check that bandwidth is not greater than maximum bandwidth parameter */
   if (bw > iflp->max_bw)
     {
-      vty_out (vty,
-               "Available Bandwidth could not be greater than Maximum Bandwidth (%g)%s",
-               iflp->max_bw, VTY_NEWLINE);
+      vty_outln (vty,
+               "Available Bandwidth could not be greater than Maximum Bandwidth (%g)",
+               iflp->max_bw);
       return CMD_WARNING;
     }
 
@@ -2337,17 +2323,16 @@ DEFUN (link_params_use_bw,
 
   if (sscanf (argv[idx_bandwidth]->arg, "%g", &bw) != 1)
     {
-      vty_out (vty, "link_params_use_bw: fscanf: %s%s", safe_strerror (errno),
-               VTY_NEWLINE);
+      vty_outln (vty, "link_params_use_bw: fscanf: %s",safe_strerror(errno));
       return CMD_WARNING;
     }
 
   /* Check that bandwidth is not greater than maximum bandwidth parameter */
   if (bw > iflp->max_bw)
     {
-      vty_out (vty,
-               "Utilised Bandwidth could not be greater than Maximum Bandwidth (%g)%s",
-               iflp->max_bw, VTY_NEWLINE);
+      vty_outln (vty,
+               "Utilised Bandwidth could not be greater than Maximum Bandwidth (%g)",
+               iflp->max_bw);
       return CMD_WARNING;
     }
 
@@ -2387,13 +2372,13 @@ ip_address_install (struct vty *vty, struct interface *ifp,
   ret = str2prefix_ipv4 (addr_str, &cp);
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed address %s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed address ");
       return CMD_WARNING;
     }
 
   if (ipv4_martian(&cp.prefix))
     {
-      vty_out (vty, "%% Invalid address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Invalid address");
       return CMD_WARNING;
     }
 
@@ -2444,8 +2429,8 @@ ip_address_install (struct vty *vty, struct interface *ifp,
       ret = if_set_prefix (ifp, ifc);
       if (ret < 0)
 	{
-	  vty_out (vty, "%% Can't set interface IP address: %s.%s", 
-		   safe_strerror(errno), VTY_NEWLINE);
+	  vty_outln (vty, "%% Can't set interface IP address: %s.", 
+		   safe_strerror(errno));
 	  return CMD_WARNING;
 	}
 
@@ -2471,7 +2456,7 @@ ip_address_uninstall (struct vty *vty, struct interface *ifp,
   ret = str2prefix_ipv4 (addr_str, &cp);
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed address %s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed address ");
       return CMD_WARNING;
     }
 
@@ -2479,7 +2464,7 @@ ip_address_uninstall (struct vty *vty, struct interface *ifp,
   ifc = connected_check (ifp, (struct prefix *) &cp);
   if (! ifc)
     {
-      vty_out (vty, "%% Can't find address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Can't find address");
       return CMD_WARNING;
     }
 
@@ -2502,8 +2487,8 @@ ip_address_uninstall (struct vty *vty, struct interface *ifp,
   ret = if_unset_prefix (ifp, ifc);
   if (ret < 0)
     {
-      vty_out (vty, "%% Can't unset interface IP address: %s.%s", 
-	       safe_strerror(errno), VTY_NEWLINE);
+      vty_outln (vty, "%% Can't unset interface IP address: %s.", 
+	       safe_strerror(errno));
       return CMD_WARNING;
     }
   UNSET_FLAG (ifc->conf, ZEBRA_IFC_QUEUED);
@@ -2587,13 +2572,13 @@ ipv6_address_install (struct vty *vty, struct interface *ifp,
   ret = str2prefix_ipv6 (addr_str, &cp);
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed address %s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed address ");
       return CMD_WARNING;
     }
 
   if (ipv6_martian(&cp.prefix))
     {
-      vty_out (vty, "%% Invalid address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Invalid address");
       return CMD_WARNING;
     }
 
@@ -2640,8 +2625,8 @@ ipv6_address_install (struct vty *vty, struct interface *ifp,
 
       if (ret < 0)
 	{
-	  vty_out (vty, "%% Can't set interface IP address: %s.%s", 
-		   safe_strerror(errno), VTY_NEWLINE);
+	  vty_outln (vty, "%% Can't set interface IP address: %s.", 
+		   safe_strerror(errno));
 	  return CMD_WARNING;
 	}
 
@@ -2680,7 +2665,7 @@ ipv6_address_uninstall (struct vty *vty, struct interface *ifp,
   ret = str2prefix_ipv6 (addr_str, &cp);
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed address %s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed address ");
       return CMD_WARNING;
     }
 
@@ -2688,7 +2673,7 @@ ipv6_address_uninstall (struct vty *vty, struct interface *ifp,
   ifc = connected_check (ifp, (struct prefix *) &cp);
   if (! ifc)
     {
-      vty_out (vty, "%% Can't find address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Can't find address");
       return CMD_WARNING;
     }
 
@@ -2711,8 +2696,8 @@ ipv6_address_uninstall (struct vty *vty, struct interface *ifp,
   ret = if_prefix_delete_ipv6 (ifp, ifc);
   if (ret < 0)
     {
-      vty_out (vty, "%% Can't unset interface IP address: %s.%s", 
-	       safe_strerror(errno), VTY_NEWLINE);
+      vty_outln (vty, "%% Can't unset interface IP address: %s.", 
+	       safe_strerror(errno));
       return CMD_WARNING;
     }
 
@@ -2757,23 +2742,23 @@ link_params_config_write (struct vty *vty, struct interface *ifp)
 
   struct if_link_params *iflp = ifp->link_params;
 
-  vty_out (vty, " link-params%s", VTY_NEWLINE);
-  vty_out(vty, "  enable%s", VTY_NEWLINE);
+  vty_outln (vty, " link-params");
+  vty_outln (vty, "  enable");
   if (IS_PARAM_SET(iflp, LP_TE_METRIC) && iflp->te_metric != ifp->metric)
-    vty_out(vty, "  metric %u%s",iflp->te_metric, VTY_NEWLINE);
+    vty_outln (vty, "  metric %u",iflp->te_metric);
   if (IS_PARAM_SET(iflp, LP_MAX_BW) && iflp->max_bw != iflp->default_bw)
-    vty_out(vty, "  max-bw %g%s", iflp->max_bw, VTY_NEWLINE);
+    vty_outln (vty, "  max-bw %g", iflp->max_bw);
   if (IS_PARAM_SET(iflp, LP_MAX_RSV_BW) && iflp->max_rsv_bw != iflp->default_bw)
-    vty_out(vty, "  max-rsv-bw %g%s", iflp->max_rsv_bw, VTY_NEWLINE);
+    vty_outln (vty, "  max-rsv-bw %g", iflp->max_rsv_bw);
   if (IS_PARAM_SET(iflp, LP_UNRSV_BW))
     {
       for (i = 0; i < 8; i++)
 	if (iflp->unrsv_bw[i] != iflp->default_bw)
-	  vty_out(vty, "  unrsv-bw %d %g%s",
-		  i, iflp->unrsv_bw[i], VTY_NEWLINE);
+	  vty_outln (vty, "  unrsv-bw %d %g",
+		  i, iflp->unrsv_bw[i]);
     }
   if (IS_PARAM_SET(iflp, LP_ADM_GRP))
-    vty_out(vty, "  admin-grp 0x%x%s", iflp->admin_grp, VTY_NEWLINE);
+    vty_outln (vty, "  admin-grp 0x%x", iflp->admin_grp);
   if (IS_PARAM_SET(iflp, LP_DELAY))
     {
       vty_out(vty, "  delay %u", iflp->av_delay);
@@ -2782,22 +2767,22 @@ link_params_config_write (struct vty *vty, struct interface *ifp)
           vty_out(vty, " min %u", iflp->min_delay);
           vty_out(vty, " max %u", iflp->max_delay);
         }
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
   if (IS_PARAM_SET(iflp, LP_DELAY_VAR))
-    vty_out(vty, "  delay-variation %u%s", iflp->delay_var, VTY_NEWLINE);
+    vty_outln (vty, "  delay-variation %u", iflp->delay_var);
   if (IS_PARAM_SET(iflp, LP_PKT_LOSS))
-    vty_out(vty, "  packet-loss %g%s", iflp->pkt_loss, VTY_NEWLINE);
+    vty_outln (vty, "  packet-loss %g", iflp->pkt_loss);
   if (IS_PARAM_SET(iflp, LP_AVA_BW))
-    vty_out(vty, "  ava-bw %g%s", iflp->ava_bw, VTY_NEWLINE);
+    vty_outln (vty, "  ava-bw %g", iflp->ava_bw);
   if (IS_PARAM_SET(iflp, LP_RES_BW))
-    vty_out(vty, "  res-bw %g%s", iflp->res_bw, VTY_NEWLINE);
+    vty_outln (vty, "  res-bw %g", iflp->res_bw);
   if (IS_PARAM_SET(iflp, LP_USE_BW))
-    vty_out(vty, "  use-bw %g%s", iflp->use_bw, VTY_NEWLINE);
+    vty_outln (vty, "  use-bw %g", iflp->use_bw);
   if (IS_PARAM_SET(iflp, LP_RMT_AS))
-    vty_out(vty, "  neighbor %s as %u%s", inet_ntoa(iflp->rmt_ip),
-        iflp->rmt_as, VTY_NEWLINE);
-  vty_out(vty, "  exit-link-params%s", VTY_NEWLINE);
+    vty_outln (vty, "  neighbor %s as %u", inet_ntoa(iflp->rmt_ip),
+        iflp->rmt_as);
+  vty_outln (vty, "  exit-link-params");
   return 0;
 }
 
@@ -2823,30 +2808,28 @@ if_config_write (struct vty *vty)
       vrf = vrf_lookup_by_id (ifp->vrf_id);
 
       if (ifp->vrf_id == VRF_DEFAULT)
-        vty_out (vty, "interface %s%s", ifp->name, VTY_NEWLINE);
+        vty_outln (vty, "interface %s", ifp->name);
       else
-        vty_out (vty, "interface %s vrf %s%s", ifp->name, vrf->name,
-                 VTY_NEWLINE);
+        vty_outln (vty, "interface %s vrf %s", ifp->name,vrf->name);
 
       if (if_data)
 	{
 	  if (if_data->shutdown == IF_ZEBRA_SHUTDOWN_ON)
-	    vty_out (vty, " shutdown%s", VTY_NEWLINE);
+	    vty_outln (vty, " shutdown");
 
           zebra_ptm_if_write(vty, if_data);
 	}
 
       if (ifp->desc)
-	vty_out (vty, " description %s%s", ifp->desc,
-		 VTY_NEWLINE);
+	vty_outln (vty, " description %s",ifp->desc);
 
       /* Assign bandwidth here to avoid unnecessary interface flap
 	 while processing config script */
       if (ifp->bandwidth != 0)
-	vty_out(vty, " bandwidth %u%s", ifp->bandwidth, VTY_NEWLINE); 
+	vty_outln (vty, " bandwidth %u", ifp->bandwidth); 
 
       if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_LINKDETECTION))
-        vty_out(vty, " no link-detect%s", VTY_NEWLINE);
+        vty_outln (vty, " no link-detect");
 
       for (ALL_LIST_ELEMENTS_RO (ifp->connected, addrnode, ifc))
 	  {
@@ -2861,16 +2844,15 @@ if_config_write (struct vty *vty)
 		if (ifc->label)
 		  vty_out (vty, " label %s", ifc->label);
 
-		vty_out (vty, "%s", VTY_NEWLINE);
+		vty_outln (vty, "");
 	      }
 	  }
 
       if (if_data)
 	{
 	  if (if_data->multicast != IF_ZEBRA_MULTICAST_UNSPEC)
-	    vty_out (vty, " %smulticast%s",
-		     if_data->multicast == IF_ZEBRA_MULTICAST_ON ? "" : "no ",
-		     VTY_NEWLINE);
+	    vty_outln (vty, " %smulticast",
+		     if_data->multicast == IF_ZEBRA_MULTICAST_ON ? "" : "no ");
 	}
 
 #if defined (HAVE_RTADV)
@@ -2883,7 +2865,7 @@ if_config_write (struct vty *vty)
 
       link_params_config_write (vty, ifp);
 
-      vty_out (vty, "!%s", VTY_NEWLINE);
+      vty_outln (vty, "!");
     }
   return 0;
 }

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1077,7 +1077,7 @@ if_dump_vty (struct vty *vty, struct interface *ifp)
 	   ifp->ifindex, ifp->metric, ifp->mtu, ifp->speed);
   if (ifp->mtu6 != ifp->mtu)
     vty_out (vty, "mtu6 %d ", ifp->mtu6);
-  vty_outln (vty, "%s  flags: %s", VTY_NEWLINE,
+  vty_outln (vty, "%s  flags: %s", VTYNL,
            if_flag_dump(ifp->flags));
   
   /* Hardware address. */
@@ -1458,8 +1458,8 @@ DEFUN (show_interface_desc_vrf_all,
   RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
     if (!list_isempty (vrf->iflist))
       {
-        vty_outln (vty, "%s\tVRF %u%s", VTY_NEWLINE, vrf->vrf_id,
-		 VTY_NEWLINE);
+        vty_outln (vty, "%s\tVRF %u%s", VTYNL, vrf->vrf_id,
+		 VTYNL);
         if_show_description (vty, vrf->vrf_id);
       }
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -944,7 +944,7 @@ connected_dump_vty (struct vty *vty, struct connected *connected)
   if (connected->label)
     vty_out (vty, " %s", connected->label);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 }
 
 /* Dump interface neighbor address information to vty. */
@@ -959,7 +959,7 @@ nbr_connected_dump_vty (struct vty *vty, struct nbr_connected *connected)
   prefix_vty_out (vty, p);
   vty_out (vty, "/%d", p->prefixlen);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 }
 
 #if defined (HAVE_RTADV)
@@ -1089,14 +1089,14 @@ if_dump_vty (struct vty *vty, struct interface *ifp)
       vty_out (vty, "  HWaddr: ");
       for (i = 0; i < ifp->hw_addr_len; i++)
 	vty_out (vty, "%s%02x", i == 0 ? "" : ":", ifp->hw_addr[i]);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   
   /* Bandwidth in Mbps */
   if (ifp->bandwidth != 0)
     {
       vty_out(vty, "  bandwidth %u Mbps", ifp->bandwidth);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   for (rn = route_top (zebra_if->ipv4_subnets); rn; rn = route_next (rn))
@@ -1144,7 +1144,7 @@ if_dump_vty (struct vty *vty, struct interface *ifp)
               vty_out(vty, " Min:  %u (micro-sec.)", iflp->min_delay);
               vty_out(vty, " Max:  %u (micro-sec.)", iflp->max_delay);
             }
-          vty_outln (vty, "");
+          vty_out (vty, VTYNL);
         }
       if (IS_PARAM_SET(iflp, LP_DELAY_VAR))
         vty_outln (vty, "    Link Delay Variation %u (micro-sec.)",
@@ -1422,7 +1422,7 @@ if_show_description (struct vty *vty, vrf_id_t vrf_id)
 
       if (ifp->desc)
 	vty_out (vty, "%s", ifp->desc);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 }
 
@@ -2767,7 +2767,7 @@ link_params_config_write (struct vty *vty, struct interface *ifp)
           vty_out(vty, " min %u", iflp->min_delay);
           vty_out(vty, " max %u", iflp->max_delay);
         }
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
   if (IS_PARAM_SET(iflp, LP_DELAY_VAR))
     vty_outln (vty, "  delay-variation %u", iflp->delay_var);
@@ -2844,7 +2844,7 @@ if_config_write (struct vty *vty)
 		if (ifc->label)
 		  vty_out (vty, " label %s", ifc->label);
 
-		vty_outln (vty, "");
+		vty_out (vty, VTYNL);
 	      }
 	  }
 

--- a/zebra/irdp_interface.c
+++ b/zebra/irdp_interface.c
@@ -343,30 +343,29 @@ void irdp_config_write (struct vty *vty, struct interface *ifp)
   if(irdp->flags & IF_ACTIVE || irdp->flags & IF_SHUTDOWN) {
 
     if( irdp->flags & IF_SHUTDOWN)
-      vty_out (vty, " ip irdp shutdown %s",  VTY_NEWLINE);
+      vty_outln (vty, " ip irdp shutdown ");
 
     if( irdp->flags & IF_BROADCAST)
-      vty_out (vty, " ip irdp broadcast%s",  VTY_NEWLINE);
+      vty_outln (vty, " ip irdp broadcast");
     else
-      vty_out (vty, " ip irdp multicast%s",  VTY_NEWLINE);
+      vty_outln (vty, " ip irdp multicast");
 
-    vty_out (vty, " ip irdp preference %ld%s",
-	     irdp->Preference, VTY_NEWLINE);
+    vty_outln (vty, " ip irdp preference %ld",
+	     irdp->Preference);
 
     for (ALL_LIST_ELEMENTS_RO (irdp->AdvPrefList, node, adv))
-      vty_out (vty, " ip irdp address %s preference %d%s",
+      vty_outln (vty, " ip irdp address %s preference %d",
                     inet_2a(adv->ip.s_addr, b1),
-                    adv->pref,
-                    VTY_NEWLINE);
+                    adv->pref);
 
-    vty_out (vty, " ip irdp holdtime %d%s",
-	     irdp->Lifetime, VTY_NEWLINE);
+    vty_outln (vty, " ip irdp holdtime %d",
+	     irdp->Lifetime);
 
-    vty_out (vty, " ip irdp minadvertinterval %ld%s",
-	     irdp->MinAdvertInterval, VTY_NEWLINE);
+    vty_outln (vty, " ip irdp minadvertinterval %ld",
+	     irdp->MinAdvertInterval);
 
-    vty_out (vty, " ip irdp maxadvertinterval %ld%s",
-	     irdp->MaxAdvertInterval, VTY_NEWLINE);
+    vty_outln (vty, " ip irdp maxadvertinterval %ld",
+	     irdp->MaxAdvertInterval);
 
   }
 }
@@ -479,8 +478,8 @@ DEFUN (ip_irdp_minadvertinterval,
       return CMD_SUCCESS;
   }
   else {
-      vty_out (vty, "%% MinAdvertInterval must be less than or equal to "
-                    "MaxAdvertInterval%s", VTY_NEWLINE);
+      vty_outln (vty, "%% MinAdvertInterval must be less than or equal to "
+                      "MaxAdvertInterval");
       return CMD_WARNING;
   }
 }
@@ -506,8 +505,8 @@ DEFUN (ip_irdp_maxadvertinterval,
       return CMD_SUCCESS;
   }
   else {
-      vty_out (vty, "%% MaxAdvertInterval must be greater than or equal to "
-                    "MinAdvertInterval%s", VTY_NEWLINE);
+      vty_outln (vty, "%% MaxAdvertInterval must be greater than or equal to "
+                      "MinAdvertInterval");
       return CMD_WARNING;
   }
 }

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -698,7 +698,7 @@ zebra_import_table_config (struct vty *vty)
               if (rmap_name)
 	        vty_out(vty, " route-map %s", rmap_name);
 
-	      vty_outln (vty, "");
+	      vty_out (vty, VTYNL);
 	      write = 1;
 	    }
 	}

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -698,7 +698,7 @@ zebra_import_table_config (struct vty *vty)
               if (rmap_name)
 	        vty_out(vty, " route-map %s", rmap_name);
 
-	      vty_out(vty, "%s", VTY_NEWLINE);
+	      vty_outln (vty, "");
 	      write = 1;
 	    }
 	}

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -202,14 +202,12 @@ router_id_write (struct vty *vty)
       if (zvrf->rid_user_assigned.u.prefix4.s_addr)
         {
           if (zvrf_id (zvrf) == VRF_DEFAULT)
-            vty_out (vty, "router-id %s%s",
-                     inet_ntoa (zvrf->rid_user_assigned.u.prefix4),
-                     VTY_NEWLINE);
-          else
-            vty_out (vty, "router-id %s vrf %s%s",
-                     inet_ntoa (zvrf->rid_user_assigned.u.prefix4),
-                     zvrf_name (zvrf),
-                     VTY_NEWLINE);
+            vty_outln (vty, "router-id %s",
+                     inet_ntoa(zvrf->rid_user_assigned.u.prefix4));
+            else
+              vty_outln (vty, "router-id %s vrf %s",
+	                     inet_ntoa (zvrf->rid_user_assigned.u.prefix4),
+	                     zvrf_name(zvrf));
         }
 }
 

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -1561,7 +1561,7 @@ rtadv_config_write (struct vty *vty, struct interface *ifp)
 	vty_out (vty, " no-autoconfig");
       if (rprefix->AdvRouterAddressFlag)
 	vty_out (vty, " router-address");
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 }
 

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -877,7 +877,8 @@ DEFUN (ipv6_nd_suppress_ra,
   if (if_is_loopback (ifp) ||
       CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK))
     {
-      vty_out (vty, "Cannot configure IPv6 Router Advertisements on this  interface%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Cannot configure IPv6 Router Advertisements on this  interface");
       return CMD_WARNING;
     }
 
@@ -900,7 +901,8 @@ DEFUN (no_ipv6_nd_suppress_ra,
   if (if_is_loopback (ifp) ||
       CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK))
     {
-      vty_out (vty, "Cannot configure IPv6 Router Advertisements on this interface%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "Cannot configure IPv6 Router Advertisements on this interface");
       return CMD_WARNING;
     }
 
@@ -929,7 +931,8 @@ DEFUN (ipv6_nd_ra_interval_msec,
   interval = strtoul(argv[idx_number]->arg, NULL, 10);
   if ((zif->rtadv.AdvDefaultLifetime != -1 && interval > (unsigned)zif->rtadv.AdvDefaultLifetime * 1000))
   {
-    vty_out (vty, "This ra-interval would conflict with configured ra-lifetime!%s", VTY_NEWLINE);
+    vty_outln (vty,
+               "This ra-interval would conflict with configured ra-lifetime!");
     return CMD_WARNING;
   }
 
@@ -965,7 +968,8 @@ DEFUN (ipv6_nd_ra_interval,
   interval = strtoul(argv[idx_number]->arg, NULL, 10);
   if ((zif->rtadv.AdvDefaultLifetime != -1 && interval > (unsigned)zif->rtadv.AdvDefaultLifetime))
   {
-    vty_out (vty, "This ra-interval would conflict with configured ra-lifetime!%s", VTY_NEWLINE);
+    vty_outln (vty,
+               "This ra-interval would conflict with configured ra-lifetime!");
     return CMD_WARNING;
   }
 
@@ -1032,7 +1036,8 @@ DEFUN (ipv6_nd_ra_lifetime,
    * MaxRtrAdvInterval and 9000 seconds. -- RFC4861, 6.2.1 */
   if ((lifetime != 0 && lifetime * 1000 < zif->rtadv.MaxRtrAdvInterval))
     {
-      vty_out (vty, "This ra-lifetime would conflict with configured ra-interval%s", VTY_NEWLINE);
+      vty_outln (vty,
+                 "This ra-lifetime would conflict with configured ra-interval");
       return CMD_WARNING;
     }
 
@@ -1328,7 +1333,7 @@ DEFUN (ipv6_nd_prefix,
   ret = str2prefix_ipv6 (prefix, &rp.prefix);
   if (!ret)
     {
-      vty_out (vty, "Malformed IPv6 prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed IPv6 prefix");
       return CMD_WARNING;
     }
   apply_mask_ipv6 (&rp.prefix); /* RFC4861 4.6.2 */
@@ -1344,7 +1349,7 @@ DEFUN (ipv6_nd_prefix,
     rp.AdvPreferredLifetime = strmatch (preflifetime, "infinite") ? UINT32_MAX : strtoll (preflifetime, NULL, 10);
     if (rp.AdvPreferredLifetime > rp.AdvValidLifetime)
       {
-        vty_out (vty, "Invalid preferred lifetime%s", VTY_NEWLINE);
+        vty_outln (vty, "Invalid preferred lifetime");
         return CMD_WARNING;
       }
   }
@@ -1381,7 +1386,7 @@ DEFUN (no_ipv6_nd_prefix,
   ret = str2prefix_ipv6 (prefix, &rp.prefix);
   if (!ret)
     {
-      vty_out (vty, "Malformed IPv6 prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed IPv6 prefix");
       return CMD_WARNING;
     }
   apply_mask_ipv6 (&rp.prefix); /* RFC4861 4.6.2 */
@@ -1389,7 +1394,7 @@ DEFUN (no_ipv6_nd_prefix,
   ret = rtadv_prefix_reset (zebra_if, &rp);
   if (!ret)
     {
-      vty_out (vty, "Non-existant IPv6 prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Non-existant IPv6 prefix");
       return CMD_WARNING;
     }
 
@@ -1490,53 +1495,49 @@ rtadv_config_write (struct vty *vty, struct interface *ifp)
         CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK)))
     {
       if (zif->rtadv.AdvSendAdvertisements)
-        vty_out (vty, " no ipv6 nd suppress-ra%s", VTY_NEWLINE);
+        vty_outln (vty, " no ipv6 nd suppress-ra");
     }
   
   interval = zif->rtadv.MaxRtrAdvInterval;
   if (interval % 1000)
-    vty_out (vty, " ipv6 nd ra-interval msec %d%s", interval,
-	     VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd ra-interval msec %d",interval);
   else
     if (interval != RTADV_MAX_RTR_ADV_INTERVAL)
-      vty_out (vty, " ipv6 nd ra-interval %d%s", interval / 1000,
-	     VTY_NEWLINE);
+      vty_outln (vty, " ipv6 nd ra-interval %d",interval / 1000);
 
   if (zif->rtadv.AdvIntervalOption)
-    vty_out (vty, " ipv6 nd adv-interval-option%s", VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd adv-interval-option");
 
   if (zif->rtadv.AdvDefaultLifetime != -1)
-    vty_out (vty, " ipv6 nd ra-lifetime %d%s", zif->rtadv.AdvDefaultLifetime,
-	     VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd ra-lifetime %d",zif->rtadv.AdvDefaultLifetime);
 
   if (zif->rtadv.HomeAgentPreference)
-    vty_out (vty, " ipv6 nd home-agent-preference %u%s",
-	     zif->rtadv.HomeAgentPreference, VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd home-agent-preference %u",
+	     zif->rtadv.HomeAgentPreference);
 
   if (zif->rtadv.HomeAgentLifetime != -1)
-    vty_out (vty, " ipv6 nd home-agent-lifetime %u%s",
-	     zif->rtadv.HomeAgentLifetime, VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd home-agent-lifetime %u",
+	     zif->rtadv.HomeAgentLifetime);
 
   if (zif->rtadv.AdvHomeAgentFlag)
-    vty_out (vty, " ipv6 nd home-agent-config-flag%s", VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd home-agent-config-flag");
 
   if (zif->rtadv.AdvReachableTime)
-    vty_out (vty, " ipv6 nd reachable-time %d%s", zif->rtadv.AdvReachableTime,
-	     VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd reachable-time %d",
+               zif->rtadv.AdvReachableTime);
 
   if (zif->rtadv.AdvManagedFlag)
-    vty_out (vty, " ipv6 nd managed-config-flag%s", VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd managed-config-flag");
 
   if (zif->rtadv.AdvOtherConfigFlag)
-    vty_out (vty, " ipv6 nd other-config-flag%s", VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd other-config-flag");
 
   if (zif->rtadv.DefaultPreference != RTADV_PREF_MEDIUM)
-    vty_out (vty, " ipv6 nd router-preference %s%s",
-	     rtadv_pref_strs[zif->rtadv.DefaultPreference],
-	     VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd router-preference %s",
+	     rtadv_pref_strs[zif->rtadv.DefaultPreference]);
 
   if (zif->rtadv.AdvLinkMTU)
-    vty_out (vty, " ipv6 nd mtu %d%s", zif->rtadv.AdvLinkMTU, VTY_NEWLINE);
+    vty_outln (vty, " ipv6 nd mtu %d", zif->rtadv.AdvLinkMTU);
 
   for (ALL_LIST_ELEMENTS_RO (zif->rtadv.AdvPrefixList, node, rprefix))
     {
@@ -1560,7 +1561,7 @@ rtadv_config_write (struct vty *vty, struct interface *ifp)
 	vty_out (vty, " no-autoconfig");
       if (rprefix->AdvRouterAddressFlag)
 	vty_out (vty, " router-address");
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 }
 

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1438,8 +1438,8 @@ zfpm_start_stats_timer (void)
  */
 #define ZFPM_SHOW_STAT(counter)						\
   do {									\
-    vty_out (vty, "%-40s %10lu %16lu%s", #counter, total_stats.counter,	\
-	     zfpm_g->last_ivl_stats.counter, VTY_NEWLINE);		\
+    vty_outln (vty, "%-40s %10lu %16lu", #counter, total_stats.counter,	\
+	     zfpm_g->last_ivl_stats.counter);		\
   } while (0)
 
 /*
@@ -1451,8 +1451,8 @@ zfpm_show_stats (struct vty *vty)
   zfpm_stats_t total_stats;
   time_t elapsed;
 
-  vty_out (vty, "%s%-40s %10s     Last %2d secs%s%s", VTY_NEWLINE, "Counter",
-	   "Total", ZFPM_STATS_IVL_SECS, VTY_NEWLINE, VTY_NEWLINE);
+  vty_outln (vty, "%s%-40s %10s     Last %2d secs%s", VTY_NEWLINE, "Counter",
+	   "Total", ZFPM_STATS_IVL_SECS, VTY_NEWLINE);
 
   /*
    * Compute the total stats up to this instant.
@@ -1490,8 +1490,8 @@ zfpm_show_stats (struct vty *vty)
 
   elapsed = zfpm_get_elapsed_time (zfpm_g->last_stats_clear_time);
 
-  vty_out (vty, "%sStats were cleared %lu seconds ago%s", VTY_NEWLINE,
-	   (unsigned long) elapsed, VTY_NEWLINE);
+  vty_outln (vty, "%sStats were cleared %lu seconds ago", VTY_NEWLINE,
+	   (unsigned long)elapsed);
 }
 
 /*
@@ -1502,7 +1502,7 @@ zfpm_clear_stats (struct vty *vty)
 {
   if (!zfpm_is_enabled ())
     {
-      vty_out (vty, "The FPM module is not enabled...%s", VTY_NEWLINE);
+      vty_outln (vty, "The FPM module is not enabled...");
       return;
     }
 
@@ -1515,7 +1515,7 @@ zfpm_clear_stats (struct vty *vty)
 
   zfpm_g->last_stats_clear_time = monotime(NULL);
 
-  vty_out (vty, "Cleared FPM stats%s", VTY_NEWLINE);
+  vty_outln (vty, "Cleared FPM stats");
 }
 
 /*
@@ -1671,7 +1671,8 @@ static int fpm_remote_srv_write (struct vty *vty)
 
    if (zfpm_g->fpm_server != FPM_DEFAULT_IP || 
           zfpm_g->fpm_port != FPM_DEFAULT_PORT)
-      vty_out (vty,"fpm connection ip %s port %d%s", inet_ntoa (in),zfpm_g->fpm_port,VTY_NEWLINE);
+      vty_outln (vty,"fpm connection ip %s port %d", inet_ntoa (in),
+                 zfpm_g->fpm_port);
 
    return 0;
 }

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1451,8 +1451,8 @@ zfpm_show_stats (struct vty *vty)
   zfpm_stats_t total_stats;
   time_t elapsed;
 
-  vty_outln (vty, "%s%-40s %10s     Last %2d secs%s", VTY_NEWLINE, "Counter",
-	   "Total", ZFPM_STATS_IVL_SECS, VTY_NEWLINE);
+  vty_outln (vty, "%s%-40s %10s     Last %2d secs%s", VTYNL, "Counter",
+	   "Total", ZFPM_STATS_IVL_SECS, VTYNL);
 
   /*
    * Compute the total stats up to this instant.
@@ -1490,7 +1490,7 @@ zfpm_show_stats (struct vty *vty)
 
   elapsed = zfpm_get_elapsed_time (zfpm_g->last_stats_clear_time);
 
-  vty_outln (vty, "%sStats were cleared %lu seconds ago", VTY_NEWLINE,
+  vty_outln (vty, "%sStats were cleared %lu seconds ago", VTYNL,
 	   (unsigned long)elapsed);
 }
 

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -534,14 +534,14 @@ fec_print (zebra_fec_t *fec, struct vty *vty)
   vty_out(vty, "  Label: %s", label2str(fec->label, buf, BUFSIZ));
   if (fec->label_index != MPLS_INVALID_LABEL_INDEX)
     vty_out(vty, ", Label Index: %u", fec->label_index);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   if (!list_isempty(fec->client_list))
     {
       vty_out(vty, "  Client list:");
       for (ALL_LIST_ELEMENTS_RO(fec->client_list, node, client))
         vty_out(vty, " %s(fd %d)",
                 zebra_route_string(client->proto), client->sock);
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 }
 
@@ -1422,7 +1422,7 @@ nhlfe_print (zebra_nhlfe_t *nhlfe, struct vty *vty)
     }
   vty_out(vty, "%s", CHECK_FLAG (nhlfe->flags, NHLFE_FLAG_INSTALLED) ?
           " (installed)" : "");
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 }
 
 /*
@@ -2875,7 +2875,7 @@ zebra_mpls_print_lsp_table (struct vty *vty, struct zebra_vrf *zvrf,
             }
         }
 
-      vty_outln (vty, "");
+      vty_out (vty, VTYNL);
     }
 
   list_delete (lsp_list);

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -530,18 +530,18 @@ fec_print (zebra_fec_t *fec, struct vty *vty)
 
   rn = fec->rn;
   prefix2str(&rn->p, buf, BUFSIZ);
-  vty_out(vty, "%s%s", buf, VTY_NEWLINE);
+  vty_outln (vty, "%s", buf);
   vty_out(vty, "  Label: %s", label2str(fec->label, buf, BUFSIZ));
   if (fec->label_index != MPLS_INVALID_LABEL_INDEX)
     vty_out(vty, ", Label Index: %u", fec->label_index);
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
   if (!list_isempty(fec->client_list))
     {
       vty_out(vty, "  Client list:");
       for (ALL_LIST_ELEMENTS_RO(fec->client_list, node, client))
         vty_out(vty, " %s(fd %d)",
                 zebra_route_string(client->proto), client->sock);
-      vty_out(vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 }
 
@@ -1398,10 +1398,10 @@ nhlfe_print (zebra_nhlfe_t *nhlfe, struct vty *vty)
   if (!nexthop || !nexthop->nh_label) // unexpected
     return;
 
-  vty_out(vty, " type: %s remote label: %s distance: %d%s",
+  vty_outln (vty, " type: %s remote label: %s distance: %d",
           nhlfe_type2str(nhlfe->type),
           label2str(nexthop->nh_label->label[0], buf, BUFSIZ),
-          nhlfe->distance, VTY_NEWLINE);
+          nhlfe->distance);
   switch (nexthop->type)
     {
     case NEXTHOP_TYPE_IPV4:
@@ -1422,7 +1422,7 @@ nhlfe_print (zebra_nhlfe_t *nhlfe, struct vty *vty)
     }
   vty_out(vty, "%s", CHECK_FLAG (nhlfe->flags, NHLFE_FLAG_INSTALLED) ?
           " (installed)" : "");
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 }
 
 /*
@@ -1436,10 +1436,9 @@ lsp_print (zebra_lsp_t *lsp, void *ctxt)
 
   vty = (struct vty *) ctxt;
 
-  vty_out(vty, "Local label: %u%s%s",
+  vty_outln (vty, "Local label: %u%s",
           lsp->ile.in_label,
-          CHECK_FLAG (lsp->flags, LSP_FLAG_INSTALLED) ? " (installed)" : "",
-          VTY_NEWLINE);
+          CHECK_FLAG(lsp->flags, LSP_FLAG_INSTALLED) ? " (installed)" : "");
 
   for (nhlfe = lsp->nhlfe_list; nhlfe; nhlfe = nhlfe->next)
     nhlfe_print (nhlfe, vty);
@@ -2239,8 +2238,8 @@ zebra_mpls_write_fec_config (struct vty *vty, struct zebra_vrf *zvrf)
 
           write = 1;
           prefix2str(&rn->p, buf, BUFSIZ);
-          vty_out(vty, "mpls label bind %s %s%s", buf,
-                  label2str(fec->label, lstr, BUFSIZ), VTY_NEWLINE);
+          vty_outln (vty, "mpls label bind %s %s", buf,
+                  label2str(fec->label, lstr, BUFSIZ));
         }
     }
 
@@ -2810,7 +2809,8 @@ zebra_mpls_print_lsp (struct vty *vty, struct zebra_vrf *zvrf, mpls_label_t labe
   if (use_json)
     {
       json = lsp_json(lsp);
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free(json);
     }
   else
@@ -2840,14 +2840,15 @@ zebra_mpls_print_lsp_table (struct vty *vty, struct zebra_vrf *zvrf,
         json_object_object_add(json, label2str(lsp->ile.in_label, buf, BUFSIZ),
                                lsp_json(lsp));
 
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free(json);
     }
   else
     {
-      vty_out (vty, " Inbound                            Outbound%s", VTY_NEWLINE);
-      vty_out (vty, "   Label     Type          Nexthop     Label%s", VTY_NEWLINE);
-      vty_out (vty, "--------  -------  ---------------  --------%s", VTY_NEWLINE);
+      vty_outln (vty, " Inbound                            Outbound");
+      vty_outln (vty, "   Label     Type          Nexthop     Label");
+      vty_outln (vty, "--------  -------  ---------------  --------");
 
       for (ALL_LIST_ELEMENTS_RO(lsp_list, node, lsp))
         {
@@ -2870,11 +2871,11 @@ zebra_mpls_print_lsp_table (struct vty *vty, struct zebra_vrf *zvrf,
                   break;
                 }
 
-              vty_out (vty, "  %8d%s", nexthop->nh_label->label[0], VTY_NEWLINE);
+              vty_outln (vty, "  %8d", nexthop->nh_label->label[0]);
             }
         }
 
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_outln (vty, "");
     }
 
   list_delete (lsp_list);
@@ -2912,8 +2913,8 @@ zebra_mpls_write_lsp_config (struct vty *vty, struct zebra_vrf *zvrf)
 		break;
 	    }
 
-            vty_out (vty, "mpls lsp %u %s %s%s",
-                     slsp->ile.in_label, buf, lstr, VTY_NEWLINE);
+            vty_outln (vty, "mpls lsp %u %s %s",
+                     slsp->ile.in_label, buf, lstr);
           }
       }
 
@@ -2962,9 +2963,8 @@ zebra_mpls_write_label_block_config (struct vty *vty, struct zebra_vrf *zvrf)
   if ((zvrf->mpls_srgb.start_label != MPLS_DEFAULT_MIN_SRGB_LABEL) ||
       (zvrf->mpls_srgb.end_label != MPLS_DEFAULT_MAX_SRGB_LABEL))
     {
-      vty_out(vty, "mpls label global-block %u %u%s",
-              zvrf->mpls_srgb.start_label, zvrf->mpls_srgb.end_label,
-              VTY_NEWLINE);
+      vty_outln (vty, "mpls label global-block %u %u",
+              zvrf->mpls_srgb.start_label,zvrf->mpls_srgb.end_label);
     }
 
   return 1;

--- a/zebra/zebra_mpls_vty.c
+++ b/zebra/zebra_mpls_vty.c
@@ -53,21 +53,20 @@ zebra_mpls_transit_lsp (struct vty *vty, int add_cmd, const char *inlabel_str,
 
   if (!mpls_enabled)
     {
-      vty_out (vty, "%% MPLS not turned on in kernel, ignoring command%s",
-	       VTY_NEWLINE);
+      vty_outln (vty,"%% MPLS not turned on in kernel, ignoring command");
       return CMD_WARNING;
     }
 
   zvrf = vrf_info_lookup(VRF_DEFAULT);
   if (!zvrf)
     {
-      vty_out (vty, "%% Default VRF does not exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Default VRF does not exist");
       return CMD_WARNING;
     }
 
   if (!inlabel_str)
     {
-      vty_out (vty, "%% No Label Information%s", VTY_NEWLINE);
+      vty_outln (vty, "%% No Label Information");
       return CMD_WARNING;
     }
 
@@ -75,7 +74,7 @@ zebra_mpls_transit_lsp (struct vty *vty, int add_cmd, const char *inlabel_str,
   label = atoi(inlabel_str);
   if (!IS_MPLS_UNRESERVED_LABEL(label))
     {
-      vty_out (vty, "%% Invalid label%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Invalid label");
       return CMD_WARNING;
     }
 
@@ -83,12 +82,12 @@ zebra_mpls_transit_lsp (struct vty *vty, int add_cmd, const char *inlabel_str,
     {
       if (!gate_str)
         {
-          vty_out (vty, "%% No Nexthop Information%s", VTY_NEWLINE);
+          vty_outln (vty, "%% No Nexthop Information");
           return CMD_WARNING;
         }
       if (!outlabel_str)
         {
-          vty_out (vty, "%% No Outgoing label Information%s", VTY_NEWLINE);
+          vty_outln (vty, "%% No Outgoing label Information");
           return CMD_WARNING;
         }
     }
@@ -109,7 +108,7 @@ zebra_mpls_transit_lsp (struct vty *vty, int add_cmd, const char *inlabel_str,
             gtype = NEXTHOP_TYPE_IPV4;
           else
             {
-              vty_out (vty, "%% Invalid nexthop%s", VTY_NEWLINE);
+              vty_outln (vty, "%% Invalid nexthop");
               return CMD_WARNING;
             }
         }
@@ -134,8 +133,7 @@ zebra_mpls_transit_lsp (struct vty *vty, int add_cmd, const char *inlabel_str,
       if (!zebra_mpls_lsp_label_consistent (zvrf, in_label, out_label, gtype,
                                             &gate, 0))
         {
-          vty_out (vty, "%% Label value not consistent%s",
-                   VTY_NEWLINE);
+          vty_outln (vty,"%% Label value not consistent");
           return CMD_WARNING;
         }
 #endif /* HAVE_CUMULUS */
@@ -148,8 +146,8 @@ zebra_mpls_transit_lsp (struct vty *vty, int add_cmd, const char *inlabel_str,
 
   if (ret)
     {
-      vty_out (vty, "%% LSP cannot be %s%s",
-               add_cmd ? "added" : "deleted", VTY_NEWLINE);
+      vty_outln (vty, "%% LSP cannot be %s",
+               add_cmd ? "added" : "deleted");
       return CMD_WARNING;
     }
 
@@ -220,7 +218,7 @@ zebra_mpls_bind (struct vty *vty, int add_cmd, const char *prefix,
   zvrf = vrf_info_lookup(VRF_DEFAULT);
   if (!zvrf)
     {
-      vty_out (vty, "%% Default VRF does not exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Default VRF does not exist");
       return CMD_WARNING;
     }
 
@@ -228,7 +226,7 @@ zebra_mpls_bind (struct vty *vty, int add_cmd, const char *prefix,
   ret = str2prefix(prefix, &p);
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed address");
       return CMD_WARNING;
     }
 
@@ -236,7 +234,7 @@ zebra_mpls_bind (struct vty *vty, int add_cmd, const char *prefix,
     {
       if (!label_str)
         {
-          vty_out (vty, "%% No label binding specified%s", VTY_NEWLINE);
+          vty_outln (vty, "%% No label binding specified");
           return CMD_WARNING;
         }
 
@@ -254,13 +252,12 @@ zebra_mpls_bind (struct vty *vty, int add_cmd, const char *prefix,
           label = atoi(label_str);
           if (!IS_MPLS_UNRESERVED_LABEL(label))
             {
-              vty_out (vty, "%% Invalid label%s", VTY_NEWLINE);
+              vty_outln (vty, "%% Invalid label");
               return CMD_WARNING;
             }
           if (zebra_mpls_label_already_bound (zvrf, label))
             {
-              vty_out (vty, "%% Label already bound to a FEC%s",
-                       VTY_NEWLINE);
+              vty_outln (vty,"%% Label already bound to a FEC");
               return CMD_WARNING;
             }
         }
@@ -272,8 +269,8 @@ zebra_mpls_bind (struct vty *vty, int add_cmd, const char *prefix,
 
   if (ret)
     {
-      vty_out (vty, "%% FEC to label binding cannot be %s%s",
-               add_cmd ? "added" : "deleted", VTY_NEWLINE);
+      vty_outln (vty, "%% FEC to label binding cannot be %s",
+               add_cmd ? "added" : "deleted");
       return CMD_WARNING;
     }
 
@@ -877,7 +874,7 @@ DEFUN (show_mpls_fec,
       ret = str2prefix(argv[3]->arg, &p);
       if (ret <= 0)
         {
-          vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed address");
           return CMD_WARNING;
         }
       zebra_mpls_print_fec (vty, zvrf, &p);
@@ -928,8 +925,8 @@ DEFUN (show_mpls_status,
        "MPLS information\n"
        "MPLS status\n")
 {
-  vty_out (vty, "MPLS support enabled: %s%s", (mpls_enabled) ? "yes" :
-	   "no (mpls kernel extensions not detected)", VTY_NEWLINE);
+  vty_outln (vty, "MPLS support enabled: %s",
+             (mpls_enabled) ? "yes" : "no (mpls kernel extensions not detected)");
   return CMD_SUCCESS;
 }
 
@@ -945,7 +942,7 @@ zebra_mpls_global_block (struct vty *vty, int add_cmd,
   zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
   if (!zvrf)
     {
-      vty_out (vty, "%% Default VRF does not exist%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Default VRF does not exist");
       return CMD_WARNING;
     }
 
@@ -953,7 +950,7 @@ zebra_mpls_global_block (struct vty *vty, int add_cmd,
     {
       if (!start_label_str || !end_label_str)
         {
-          vty_out (vty, "%% Labels not specified%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Labels not specified");
           return CMD_WARNING;
         }
 
@@ -962,13 +959,12 @@ zebra_mpls_global_block (struct vty *vty, int add_cmd,
       if (!IS_MPLS_UNRESERVED_LABEL(start_label) ||
           !IS_MPLS_UNRESERVED_LABEL(end_label))
         {
-          vty_out (vty, "%% Invalid label%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Invalid label");
           return CMD_WARNING;
         }
       if (end_label < start_label)
         {
-          vty_out (vty, "%% End label is less than Start label%s",
-                   VTY_NEWLINE);
+          vty_outln (vty,"%% End label is less than Start label");
           return CMD_WARNING;
         }
 
@@ -979,8 +975,8 @@ zebra_mpls_global_block (struct vty *vty, int add_cmd,
 
   if (ret)
     {
-      vty_out (vty, "%% Global label block could not be %s%s",
-               add_cmd ? "added" : "deleted", VTY_NEWLINE);
+      vty_outln (vty, "%% Global label block could not be %s",
+               add_cmd ? "added" : "deleted");
       return CMD_WARNING;
     }
 

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -374,7 +374,7 @@ void
 zebra_ptm_write (struct vty *vty)
 {
   if (ptm_cb.ptm_enable)
-    vty_out (vty, "ptm-enable%s", VTY_NEWLINE);
+    vty_outln (vty, "ptm-enable");
 
   return;
 }
@@ -1089,10 +1089,9 @@ zebra_ptm_show_status(struct vty *vty, struct interface *ifp)
 {
   vty_out (vty, "  PTM status: ");
   if (ifp->ptm_enable) {
-    vty_out (vty, "%s%s", zebra_ptm_get_status_str (ifp->ptm_status),
-                          VTY_NEWLINE);
+    vty_outln (vty, "%s",zebra_ptm_get_status_str(ifp->ptm_status));
   } else {
-    vty_out (vty, "disabled%s", VTY_NEWLINE);
+    vty_outln (vty, "disabled");
   }
 }
 
@@ -1162,5 +1161,5 @@ void
 zebra_ptm_if_write (struct vty *vty, struct zebra_if *zebra_ifp)
 {
   if (zebra_ifp->ptm_enable == ZEBRA_IF_PTM_ENABLE_OFF)
-    vty_out (vty, " no ptm-enable%s", VTY_NEWLINE);
+    vty_outln (vty, " no ptm-enable");
 }

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -996,7 +996,7 @@ print_nh (struct nexthop *nexthop, struct vty *vty)
     default:
       break;
     }
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_out(vty, "%s", VTYNL);
 }
 
 static void
@@ -1011,18 +1011,18 @@ print_rnh (struct route_node *rn, struct vty *vty)
   rnh = rn->info;
   vty_out(vty, "%s%s%s", inet_ntop(rn->p.family, &rn->p.u.prefix, buf, BUFSIZ),
 	  CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED) ? "(Connected)" : "",
-	  VTY_NEWLINE);
+	  VTYNL);
   if (rnh->state)
     {
       vty_out(vty, " resolved via %s%s",
-	      zebra_route_string(rnh->state->type), VTY_NEWLINE);
+	      zebra_route_string(rnh->state->type), VTYNL);
       for (nexthop = rnh->state->nexthop; nexthop; nexthop = nexthop->next)
 	print_nh(nexthop, vty);
     }
   else
     vty_out(vty, " unresolved%s%s",
 	    CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED) ? "(Connected)" : "",
-	    VTY_NEWLINE);
+	    VTYNL);
 
   vty_out(vty, " Client list:");
   for (ALL_LIST_ELEMENTS_RO(rnh->client_list, node, client))
@@ -1030,5 +1030,5 @@ print_rnh (struct route_node *rn, struct vty *vty)
 	    client->sock, rnh->filtered[client->proto] ? "(filtered)" : "");
   if (!list_isempty(rnh->zebra_static_route_list))
     vty_out(vty, " zebra%s", rnh->filtered[ZEBRA_ROUTE_STATIC] ? "(filtered)" : "");
-  vty_out(vty, "%s", VTY_NEWLINE);
+  vty_out(vty, "%s", VTYNL);
 }

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -73,10 +73,10 @@ zebra_route_match_add(struct vty *vty,
       switch (ret)
 	{
 	case RMAP_RULE_MISSING:
-	  vty_out (vty, "%% Zebra Can't find rule.%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Zebra Can't find rule.");
 	  return CMD_WARNING;
 	case RMAP_COMPILE_ERROR:
-	  vty_out (vty, "%% Zebra Argument is malformed.%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Zebra Argument is malformed.");
 	  return CMD_WARNING;
 	}
     }
@@ -121,10 +121,10 @@ zebra_route_match_delete (struct vty *vty,
       switch (ret)
 	{
 	case RMAP_RULE_MISSING:
-	  vty_out (vty, "%% Zebra Can't find rule.%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Zebra Can't find rule.");
 	  return CMD_WARNING;
 	case RMAP_COMPILE_ERROR:
-	  vty_out (vty, "%% Zebra Argument is malformed.%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% Zebra Argument is malformed.");
 	  return CMD_WARNING;
 	}
     }
@@ -302,7 +302,7 @@ DEFUN (match_source_protocol,
   i = proto_name2num(proto);
   if (i < 0)
     {
-      vty_out (vty, "invalid protocol name \"%s\"%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "invalid protocol name \"%s\"", proto);
       return CMD_WARNING;
     }
   return zebra_route_match_add (vty, "source-protocol", proto, RMAP_EVENT_MATCH_ADDED);
@@ -350,7 +350,7 @@ DEFUN (set_src,
     {
       if (inet_pton(AF_INET6, argv[idx_ip]->arg, &src.ipv6) != 1)
 	{
-	  vty_out (vty, "%% not a valid IPv4/v6 address%s", VTY_NEWLINE);
+	  vty_outln (vty, "%% not a valid IPv4/v6 address");
 	  return CMD_WARNING;
 	}
 
@@ -367,7 +367,7 @@ DEFUN (set_src,
 
   if (!zebra_check_addr(&p))
     {
-      vty_out (vty, "%% not a valid source IPv4/v6 address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% not a valid source IPv4/v6 address");
       return CMD_WARNING;
     }
 
@@ -386,7 +386,7 @@ DEFUN (set_src,
 
   if (!pif)
     {
-      vty_out (vty, "%% not a local address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% not a local address");
       return CMD_WARNING;
     }
 
@@ -459,7 +459,7 @@ DEFUN (ip_protocol,
     i = proto_name2num(proto);
   if (i < 0)
     {
-      vty_out (vty, "invalid protocol name \"%s\"%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "invalid protocol name \"%s\"", proto);
       return CMD_WARNING;
     }
   if (proto_rm[AFI_IP][i])
@@ -500,7 +500,7 @@ DEFUN (no_ip_protocol,
 
   if (i < 0)
     {
-      vty_out (vty, "invalid protocol name \"%s\"%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "invalid protocol name \"%s\"", proto);
      return CMD_WARNING;
     }
 
@@ -529,22 +529,20 @@ DEFUN (show_ip_protocol,
 {
     int i;
 
-    vty_out(vty, "Protocol    : route-map %s", VTY_NEWLINE);
-    vty_out(vty, "------------------------%s", VTY_NEWLINE);
+    vty_outln (vty, "Protocol    : route-map ");
+    vty_outln (vty, "------------------------");
     for (i=0;i<ZEBRA_ROUTE_MAX;i++)
     {
         if (proto_rm[AFI_IP][i])
-          vty_out (vty, "%-10s  : %-10s%s", zebra_route_string(i),
-					proto_rm[AFI_IP][i],
-					VTY_NEWLINE);
+          vty_outln (vty, "%-10s  : %-10s", zebra_route_string(i),
+					proto_rm[AFI_IP][i]);
         else
-          vty_out (vty, "%-10s  : none%s", zebra_route_string(i), VTY_NEWLINE);
+          vty_outln (vty, "%-10s  : none", zebra_route_string(i));
     }
     if (proto_rm[AFI_IP][i])
-      vty_out (vty, "%-10s  : %-10s%s", "any", proto_rm[AFI_IP][i],
-					VTY_NEWLINE);
+      vty_outln (vty, "%-10s  : %-10s", "any",proto_rm[AFI_IP][i]);
     else
-      vty_out (vty, "%-10s  : none%s", "any", VTY_NEWLINE);
+      vty_outln (vty, "%-10s  : none", "any");
 
     return CMD_SUCCESS;
 }
@@ -568,7 +566,7 @@ DEFUN (ipv6_protocol,
     i = proto_name2num(proto);
   if (i < 0)
     {
-      vty_out (vty, "invalid protocol name \"%s\"%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "invalid protocol name \"%s\"", proto);
       return CMD_WARNING;
     }
   if (proto_rm[AFI_IP6][i])
@@ -608,7 +606,7 @@ DEFUN (no_ipv6_protocol,
     i = proto_name2num(proto);
   if (i < 0)
     {
-      vty_out (vty, "invalid protocol name \"%s\"%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "invalid protocol name \"%s\"", proto);
      return CMD_WARNING;
     }
   if (!proto_rm[AFI_IP6][i])
@@ -637,22 +635,20 @@ DEFUN (show_ipv6_protocol,
 {
     int i;
 
-    vty_out(vty, "Protocol    : route-map %s", VTY_NEWLINE);
-    vty_out(vty, "------------------------%s", VTY_NEWLINE);
+    vty_outln (vty, "Protocol    : route-map ");
+    vty_outln (vty, "------------------------");
     for (i=0;i<ZEBRA_ROUTE_MAX;i++)
     {
         if (proto_rm[AFI_IP6][i])
-          vty_out (vty, "%-10s  : %-10s%s", zebra_route_string(i),
-					proto_rm[AFI_IP6][i],
-					VTY_NEWLINE);
+          vty_outln (vty, "%-10s  : %-10s", zebra_route_string(i),
+					proto_rm[AFI_IP6][i]);
         else
-          vty_out (vty, "%-10s  : none%s", zebra_route_string(i), VTY_NEWLINE);
+          vty_outln (vty, "%-10s  : none", zebra_route_string(i));
     }
     if (proto_rm[AFI_IP6][i])
-      vty_out (vty, "%-10s  : %-10s%s", "any", proto_rm[AFI_IP6][i],
-					VTY_NEWLINE);
+      vty_outln (vty, "%-10s  : %-10s", "any",proto_rm[AFI_IP6][i]);
     else
-      vty_out (vty, "%-10s  : none%s", "any", VTY_NEWLINE);
+      vty_outln (vty, "%-10s  : none", "any");
 
     return CMD_SUCCESS;
 }
@@ -676,7 +672,7 @@ DEFUN (ip_protocol_nht_rmap,
     i = proto_name2num(proto);
   if (i < 0)
     {
-      vty_out (vty, "invalid protocol name \"%s\"%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "invalid protocol name \"%s\"", proto);
       return CMD_WARNING;
     }
   if (nht_rm[AFI_IP][i])
@@ -711,7 +707,7 @@ DEFUN (no_ip_protocol_nht_rmap,
 
   if (i < 0)
     {
-      vty_out (vty, "invalid protocol name \"%s\"%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "invalid protocol name \"%s\"", proto);
       return CMD_WARNING;
     }
 
@@ -737,22 +733,20 @@ DEFUN (show_ip_protocol_nht,
 {
     int i;
 
-    vty_out(vty, "Protocol    : route-map %s", VTY_NEWLINE);
-    vty_out(vty, "------------------------%s", VTY_NEWLINE);
+    vty_outln (vty, "Protocol    : route-map ");
+    vty_outln (vty, "------------------------");
     for (i=0;i<ZEBRA_ROUTE_MAX;i++)
     {
         if (nht_rm[AFI_IP][i])
-          vty_out (vty, "%-10s  : %-10s%s", zebra_route_string(i),
-					nht_rm[AFI_IP][i],
-					VTY_NEWLINE);
+          vty_outln (vty, "%-10s  : %-10s", zebra_route_string(i),
+					nht_rm[AFI_IP][i]);
         else
-          vty_out (vty, "%-10s  : none%s", zebra_route_string(i), VTY_NEWLINE);
+          vty_outln (vty, "%-10s  : none", zebra_route_string(i));
     }
     if (nht_rm[AFI_IP][i])
-      vty_out (vty, "%-10s  : %-10s%s", "any", nht_rm[AFI_IP][i],
-					VTY_NEWLINE);
+      vty_outln (vty, "%-10s  : %-10s", "any",nht_rm[AFI_IP][i]);
     else
-      vty_out (vty, "%-10s  : none%s", "any", VTY_NEWLINE);
+      vty_outln (vty, "%-10s  : none", "any");
 
     return CMD_SUCCESS;
 }
@@ -776,7 +770,7 @@ DEFUN (ipv6_protocol_nht_rmap,
     i = proto_name2num(proto);
   if (i < 0)
     {
-      vty_out (vty, "invalid protocol name \"%s\"%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "invalid protocol name \"%s\"", proto);
       return CMD_WARNING;
     }
   if (nht_rm[AFI_IP6][i])
@@ -807,13 +801,13 @@ DEFUN (no_ipv6_protocol_nht_rmap,
     i = proto_name2num(proto);
   if (i < 0)
     {
-      vty_out (vty, "invalid protocol name \"%s\"%s", proto, VTY_NEWLINE);
+      vty_outln (vty, "invalid protocol name \"%s\"", proto);
       return CMD_WARNING;
     }
 
   if (nht_rm[AFI_IP6][i] && rmap && strcmp(rmap, nht_rm[AFI_IP6][i]))
     {
-      vty_out (vty, "invalid route-map \"%s\"%s", rmap, VTY_NEWLINE);
+      vty_outln (vty, "invalid route-map \"%s\"", rmap);
       return CMD_WARNING;
     }
 
@@ -838,22 +832,20 @@ DEFUN (show_ipv6_protocol_nht,
 {
     int i;
 
-    vty_out(vty, "Protocol    : route-map %s", VTY_NEWLINE);
-    vty_out(vty, "------------------------%s", VTY_NEWLINE);
+    vty_outln (vty, "Protocol    : route-map ");
+    vty_outln (vty, "------------------------");
     for (i=0;i<ZEBRA_ROUTE_MAX;i++)
     {
         if (nht_rm[AFI_IP6][i])
-          vty_out (vty, "%-10s  : %-10s%s", zebra_route_string(i),
-					nht_rm[AFI_IP6][i],
-					VTY_NEWLINE);
+          vty_outln (vty, "%-10s  : %-10s", zebra_route_string(i),
+					nht_rm[AFI_IP6][i]);
         else
-          vty_out (vty, "%-10s  : none%s", zebra_route_string(i), VTY_NEWLINE);
+          vty_outln (vty, "%-10s  : none", zebra_route_string(i));
     }
     if (nht_rm[AFI_IP][i])
-      vty_out (vty, "%-10s  : %-10s%s", "any", nht_rm[AFI_IP6][i],
-					VTY_NEWLINE);
+      vty_outln (vty, "%-10s  : %-10s", "any",nht_rm[AFI_IP6][i]);
     else
-      vty_out (vty, "%-10s  : none%s", "any", VTY_NEWLINE);
+      vty_outln (vty, "%-10s  : none", "any");
 
     return CMD_SUCCESS;
 }
@@ -1302,8 +1294,8 @@ void
 zebra_route_map_write_delay_timer (struct vty *vty)
 {
   if (vty && (zebra_rmap_update_timer != ZEBRA_RMAP_DEFAULT_UPDATE_TIMER))
-    vty_out (vty, "zebra route-map delay-timer %d%s", zebra_rmap_update_timer,
-	     VTY_NEWLINE);
+    vty_outln (vty, "zebra route-map delay-timer %d",
+               zebra_rmap_update_timer);
   return;
 }
 
@@ -1439,41 +1431,41 @@ zebra_routemap_config_write_protocol (struct vty *vty)
   for (i=0;i<ZEBRA_ROUTE_MAX;i++)
     {
       if (proto_rm[AFI_IP][i])
-        vty_out (vty, "ip protocol %s route-map %s%s", zebra_route_string(i),
-                 proto_rm[AFI_IP][i], VTY_NEWLINE);
+        vty_outln (vty, "ip protocol %s route-map %s", zebra_route_string(i),
+                 proto_rm[AFI_IP][i]);
 
       if (proto_rm[AFI_IP6][i])
-        vty_out (vty, "ipv6 protocol %s route-map %s%s", zebra_route_string(i),
-                 proto_rm[AFI_IP6][i], VTY_NEWLINE);
+        vty_outln (vty, "ipv6 protocol %s route-map %s", zebra_route_string(i),
+                 proto_rm[AFI_IP6][i]);
 
       if (nht_rm[AFI_IP][i])
-        vty_out (vty, "ip nht %s route-map %s%s", zebra_route_string(i),
-                 nht_rm[AFI_IP][i], VTY_NEWLINE);
+        vty_outln (vty, "ip nht %s route-map %s", zebra_route_string(i),
+                 nht_rm[AFI_IP][i]);
 
       if (nht_rm[AFI_IP6][i])
-        vty_out (vty, "ipv6 nht %s route-map %s%s", zebra_route_string(i),
-                 nht_rm[AFI_IP6][i], VTY_NEWLINE);
+        vty_outln (vty, "ipv6 nht %s route-map %s", zebra_route_string(i),
+                 nht_rm[AFI_IP6][i]);
     }
 
   if (proto_rm[AFI_IP][ZEBRA_ROUTE_MAX])
-      vty_out (vty, "ip protocol %s route-map %s%s", "any",
-               proto_rm[AFI_IP][ZEBRA_ROUTE_MAX], VTY_NEWLINE);
+      vty_outln (vty, "ip protocol %s route-map %s", "any",
+               proto_rm[AFI_IP][ZEBRA_ROUTE_MAX]);
 
   if (proto_rm[AFI_IP6][ZEBRA_ROUTE_MAX])
-      vty_out (vty, "ipv6 protocol %s route-map %s%s", "any",
-               proto_rm[AFI_IP6][ZEBRA_ROUTE_MAX], VTY_NEWLINE);
+      vty_outln (vty, "ipv6 protocol %s route-map %s", "any",
+               proto_rm[AFI_IP6][ZEBRA_ROUTE_MAX]);
 
   if (nht_rm[AFI_IP][ZEBRA_ROUTE_MAX])
-      vty_out (vty, "ip nht %s route-map %s%s", "any",
-               nht_rm[AFI_IP][ZEBRA_ROUTE_MAX], VTY_NEWLINE);
+      vty_outln (vty, "ip nht %s route-map %s", "any",
+               nht_rm[AFI_IP][ZEBRA_ROUTE_MAX]);
 
   if (nht_rm[AFI_IP6][ZEBRA_ROUTE_MAX])
-      vty_out (vty, "ipv6 nht %s route-map %s%s", "any",
-               nht_rm[AFI_IP6][ZEBRA_ROUTE_MAX], VTY_NEWLINE);
+      vty_outln (vty, "ipv6 nht %s route-map %s", "any",
+               nht_rm[AFI_IP6][ZEBRA_ROUTE_MAX]);
 
   if (zebra_rmap_update_timer != ZEBRA_RMAP_DEFAULT_UPDATE_TIMER)
-    vty_out (vty, "zebra route-map delay-timer %d%s", zebra_rmap_update_timer,
-	     VTY_NEWLINE);
+    vty_outln (vty, "zebra route-map delay-timer %d",
+               zebra_rmap_update_timer);
 }
 
 void

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -524,8 +524,8 @@ vrf_config_write (struct vty *vty)
       zvrf = vrf->info;
       if (! zvrf || strcmp (zvrf_name (zvrf), VRF_DEFAULT_NAME))
         {
-          vty_out (vty, "vrf %s%s", zvrf_name (zvrf), VTY_NEWLINE);
-          vty_out (vty, "!%s", VTY_NEWLINE);
+          vty_outln (vty, "vrf %s", zvrf_name(zvrf));
+          vty_outln (vty, "!");
         }
     }
   return 0;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -665,7 +665,7 @@ vty_show_ip_route_detail (struct vty *vty, struct route_node *rn, int mcast)
 
       vty_out (vty, "Routing entry for %s%s%s",
 	       srcdest_rnode2str(rn, buf, sizeof(buf)), mcast_info,
-	       VTY_NEWLINE);
+	       VTYNL);
       vty_out (vty, "  Known via \"%s", zebra_route_string (re->type));
       if (re->instance)
         vty_out (vty, "[%d]", re->instance);
@@ -688,7 +688,7 @@ vty_show_ip_route_detail (struct vty *vty, struct route_node *rn, int mcast)
        vty_out (vty, ", blackhole");
       if (CHECK_FLAG (re->flags, ZEBRA_FLAG_REJECT))
        vty_out (vty, ", reject");
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
 
       if (re->type == ZEBRA_ROUTE_RIP
 	  || re->type == ZEBRA_ROUTE_OSPF
@@ -716,7 +716,7 @@ vty_show_ip_route_detail (struct vty *vty, struct route_node *rn, int mcast)
 	    vty_out (vty, "%02dw%dd%02dh",
 		     tm->tm_yday/7,
 		     tm->tm_yday - ((tm->tm_yday/7) * 7), tm->tm_hour);
-	  vty_out (vty, " ago%s", VTY_NEWLINE);
+	  vty_out (vty, " ago%s", VTYNL);
 	}
 
       for (ALL_NEXTHOPS_RO(re->nexthop, nexthop, tnexthop, recursing))
@@ -795,9 +795,9 @@ vty_show_ip_route_detail (struct vty *vty, struct route_node *rn, int mcast)
                                       nexthop->nh_label->label, buf, sizeof buf, 1));
            }
 
-	  vty_out (vty, "%s", VTY_NEWLINE);
+	  vty_out (vty, "%s", VTYNL);
 	}
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 }
 
@@ -1085,7 +1085,7 @@ vty_show_ip_route (struct vty *vty, struct route_node *rn, struct route_entry *r
 		     tm->tm_yday/7,
 		     tm->tm_yday - ((tm->tm_yday/7) * 7), tm->tm_hour);
 	}
-      vty_out (vty, "%s", VTY_NEWLINE);
+      vty_out (vty, "%s", VTYNL);
     }
 }
 
@@ -1190,7 +1190,7 @@ do_show_ip_route (struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,
                     vty_out (vty, SHOW_ROUTE_V6_HEADER);
 
                   if (zvrf_id (zvrf) != VRF_DEFAULT)
-                    vty_outln (vty, "%sVRF %s:", VTY_NEWLINE,
+                    vty_outln (vty, "%sVRF %s:", VTYNL,
                                zvrf_name(zvrf));
 
                   first = 0;
@@ -1251,7 +1251,7 @@ DEFUN (show_ip_nht_vrf_all,
   RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
     if ((zvrf = vrf->info) != NULL)
       {
-        vty_outln (vty, "%sVRF %s:", VTY_NEWLINE, zvrf_name(zvrf));
+        vty_outln (vty, "%sVRF %s:", VTYNL, zvrf_name(zvrf));
         zebra_print_rnh_table(zvrf_id (zvrf), AF_INET, vty, RNH_NEXTHOP_TYPE);
       }
 
@@ -1291,7 +1291,7 @@ DEFUN (show_ipv6_nht_vrf_all,
   RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
     if ((zvrf = vrf->info) != NULL)
       {
-        vty_outln (vty, "%sVRF %s:", VTY_NEWLINE, zvrf_name(zvrf));
+        vty_outln (vty, "%sVRF %s:", VTYNL, zvrf_name(zvrf));
         zebra_print_rnh_table(zvrf_id (zvrf), AF_INET6, vty, RNH_NEXTHOP_TYPE);
       }
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1635,7 +1635,7 @@ vty_show_ip_route_summary (struct vty *vty, struct route_table *table)
   vty_outln (vty, "------");
   vty_outln (vty, "%-20s %-20d %-20d ", "Totals", rib_cnt[ZEBRA_ROUTE_TOTAL],
            fib_cnt[ZEBRA_ROUTE_TOTAL]);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 }
 
 /*
@@ -1713,7 +1713,7 @@ vty_show_ip_route_summary_prefix (struct vty *vty, struct route_table *table)
   vty_outln (vty, "------");
   vty_outln (vty, "%-20s %-20d %-20d ", "Totals", rib_cnt[ZEBRA_ROUTE_TOTAL],
 	   fib_cnt[ZEBRA_ROUTE_TOTAL]);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 }
 
 /* Show route summary.  */
@@ -1966,7 +1966,7 @@ static_config (struct vty *vty, afi_t afi, safi_t safi, const char *cmd)
                        mpls_label2str (si->snh_label.num_labels,
                                        si->snh_label.label, buf, sizeof buf, 0));
 
-            vty_outln (vty, "");
+            vty_out (vty, VTYNL);
 
             write = 1;
           }
@@ -3057,7 +3057,7 @@ DEFUN (show_vrf,
        vty_out (vty, "inactive");
      else
        vty_out (vty, "id %u table %u", zvrf_id (zvrf), zvrf->table_id);
-     vty_outln (vty, "");
+     vty_out (vty, VTYNL);
 
     }
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -79,7 +79,7 @@ zebra_static_ipv4 (struct vty *vty, safi_t safi, int add_cmd,
   ret = str2prefix (dest_str, &p);
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed address");
       return CMD_WARNING;
     }
 
@@ -89,7 +89,7 @@ zebra_static_ipv4 (struct vty *vty, safi_t safi, int add_cmd,
       ret = inet_aton (mask_str, &mask);
       if (ret == 0)
         {
-          vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed address");
           return CMD_WARNING;
         }
       p.prefixlen = ip_masklen (mask);
@@ -113,7 +113,7 @@ zebra_static_ipv4 (struct vty *vty, safi_t safi, int add_cmd,
 
   if (!zvrf)
     {
-      vty_out (vty, "%% vrf %s is not defined%s", vrf_id_str, VTY_NEWLINE);
+      vty_outln (vty, "%% vrf %s is not defined", vrf_id_str);
       return CMD_WARNING;
     }
 
@@ -122,8 +122,8 @@ zebra_static_ipv4 (struct vty *vty, safi_t safi, int add_cmd,
     {
       if (!mpls_enabled)
 	{
-	  vty_out (vty, "%% MPLS not turned on in kernel, ignoring command%s",
-		   VTY_NEWLINE);
+	  vty_outln (vty,
+                     "%% MPLS not turned on in kernel, ignoring command");
 	  return CMD_WARNING;
 	}
       int rc = mpls_str2label (label_str, &snh_label.num_labels,
@@ -132,16 +132,15 @@ zebra_static_ipv4 (struct vty *vty, safi_t safi, int add_cmd,
         {
           switch (rc) {
           case -1:
-            vty_out (vty, "%% Malformed label(s)%s", VTY_NEWLINE);
+            vty_outln (vty, "%% Malformed label(s)");
             break;
           case -2:
-            vty_out (vty, "%% Cannot use reserved label(s) (%d-%d)%s",
-                     MPLS_MIN_RESERVED_LABEL, MPLS_MAX_RESERVED_LABEL,
-                     VTY_NEWLINE);
+            vty_outln (vty, "%% Cannot use reserved label(s) (%d-%d)",
+                     MPLS_MIN_RESERVED_LABEL,MPLS_MAX_RESERVED_LABEL);
             break;
           case -3:
-            vty_out (vty, "%% Too many labels. Enter %d or fewer%s",
-                     MPLS_MAX_LABELS, VTY_NEWLINE);
+            vty_outln (vty, "%% Too many labels. Enter %d or fewer",
+                     MPLS_MAX_LABELS);
             break;
           }
           return CMD_WARNING;
@@ -153,7 +152,7 @@ zebra_static_ipv4 (struct vty *vty, safi_t safi, int add_cmd,
     {
       if (flag_str)
         {
-          vty_out (vty, "%% can not have flag %s with Null0%s", flag_str, VTY_NEWLINE);
+          vty_outln (vty, "%% can not have flag %s with Null0", flag_str);
           return CMD_WARNING;
         }
       if (add_cmd)
@@ -177,7 +176,7 @@ zebra_static_ipv4 (struct vty *vty, safi_t safi, int add_cmd,
         SET_FLAG (flag, ZEBRA_FLAG_BLACKHOLE);
         break;
       default:
-        vty_out (vty, "%% Malformed flag %s %s", flag_str, VTY_NEWLINE);
+        vty_outln (vty, "%% Malformed flag %s ", flag_str);
         return CMD_WARNING;
     }
   }
@@ -202,7 +201,7 @@ zebra_static_ipv4 (struct vty *vty, safi_t safi, int add_cmd,
       struct interface *ifp = if_lookup_by_name (gate_str, zvrf_id (zvrf));
       if (!ifp)
         {
-	  vty_out (vty, "%% Unknown interface: %s%s", gate_str, VTY_NEWLINE);
+	  vty_outln (vty, "%% Unknown interface: %s", gate_str);
           ifindex = IFINDEX_DELETED;
         }
       else
@@ -287,7 +286,7 @@ DEFUN (ip_multicast_mode,
     multicast_mode_ipv4_set (MCAST_MIX_PFXLEN);
   else
     {
-      vty_out (vty, "Invalid mode specified%s", VTY_NEWLINE);
+      vty_outln (vty, "Invalid mode specified");
       return CMD_WARNING;
     }
 
@@ -341,7 +340,7 @@ DEFUN (show_ip_rpf_addr,
   ret = inet_aton (argv[idx_ipv4]->arg, &addr);
   if (ret == 0)
     {
-      vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed address");
       return CMD_WARNING;
     }
 
@@ -350,7 +349,7 @@ DEFUN (show_ip_rpf_addr,
   if (re)
     vty_show_ip_route_detail (vty, rn, 1);
   else
-    vty_out (vty, "%% No match for RPF lookup%s", VTY_NEWLINE);
+    vty_outln (vty, "%% No match for RPF lookup");
 
   return CMD_SUCCESS;
 }
@@ -1115,18 +1114,18 @@ do_show_ip_route (struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,
   if (!(zvrf = zebra_vrf_lookup_by_name (vrf_name)))
     {
       if (use_json)
-        vty_out (vty, "{}%s", VTY_NEWLINE);
+        vty_outln (vty, "{}");
       else
-        vty_out (vty, "vrf %s not defined%s", vrf_name, VTY_NEWLINE);
+        vty_outln (vty, "vrf %s not defined", vrf_name);
       return CMD_SUCCESS;
     }
 
   if (zvrf_id (zvrf) == VRF_UNKNOWN)
     {
       if (use_json)
-        vty_out (vty, "{}%s", VTY_NEWLINE);
+        vty_outln (vty, "{}");
       else
-        vty_out (vty, "vrf %s inactive%s", vrf_name, VTY_NEWLINE);
+        vty_outln (vty, "vrf %s inactive", vrf_name);
       return CMD_SUCCESS;
     }
 
@@ -1134,7 +1133,7 @@ do_show_ip_route (struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,
   if (! table)
     {
       if (use_json)
-        vty_out (vty, "{}%s", VTY_NEWLINE);
+        vty_outln (vty, "{}");
       return CMD_SUCCESS;
     }
 
@@ -1191,7 +1190,8 @@ do_show_ip_route (struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,
                     vty_out (vty, SHOW_ROUTE_V6_HEADER);
 
                   if (zvrf_id (zvrf) != VRF_DEFAULT)
-                    vty_out (vty, "%sVRF %s:%s", VTY_NEWLINE, zvrf_name (zvrf), VTY_NEWLINE);
+                    vty_outln (vty, "%sVRF %s:", VTY_NEWLINE,
+                               zvrf_name(zvrf));
 
                   first = 0;
                 }
@@ -1210,7 +1210,8 @@ do_show_ip_route (struct vty *vty, const char *vrf_name, afi_t afi, safi_t safi,
 
   if (use_json)
     {
-      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      vty_outln (vty, "%s",
+                 json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY));
       json_object_free(json);
     }
 
@@ -1250,7 +1251,7 @@ DEFUN (show_ip_nht_vrf_all,
   RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
     if ((zvrf = vrf->info) != NULL)
       {
-        vty_out (vty, "%sVRF %s:%s", VTY_NEWLINE, zvrf_name (zvrf), VTY_NEWLINE);
+        vty_outln (vty, "%sVRF %s:", VTY_NEWLINE, zvrf_name(zvrf));
         zebra_print_rnh_table(zvrf_id (zvrf), AF_INET, vty, RNH_NEXTHOP_TYPE);
       }
 
@@ -1290,7 +1291,7 @@ DEFUN (show_ipv6_nht_vrf_all,
   RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
     if ((zvrf = vrf->info) != NULL)
       {
-        vty_out (vty, "%sVRF %s:%s", VTY_NEWLINE, zvrf_name (zvrf), VTY_NEWLINE);
+        vty_outln (vty, "%sVRF %s:", VTY_NEWLINE, zvrf_name(zvrf));
         zebra_print_rnh_table(zvrf_id (zvrf), AF_INET6, vty, RNH_NEXTHOP_TYPE);
       }
 
@@ -1447,7 +1448,7 @@ DEFUN (show_ip_route,
 
       if (type < 0)
         {
-          vty_out (vty, "Unknown route type%s", VTY_NEWLINE);
+          vty_outln (vty, "Unknown route type");
           return CMD_WARNING;
         }
     }
@@ -1500,7 +1501,7 @@ DEFUN (show_ip_route_addr,
 
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed IPv4 address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed IPv4 address");
       return CMD_WARNING;
     }
 
@@ -1511,7 +1512,7 @@ DEFUN (show_ip_route_addr,
   rn = route_node_match (table, (struct prefix *) &p);
   if (! rn)
     {
-      vty_out (vty, "%% Network not in table%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Network not in table");
       return CMD_WARNING;
     }
 
@@ -1549,7 +1550,7 @@ DEFUN (show_ip_route_prefix,
 
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed IPv4 address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed IPv4 address");
       return CMD_WARNING;
     }
 
@@ -1560,7 +1561,7 @@ DEFUN (show_ip_route_prefix,
   rn = route_node_match (table, (struct prefix *) &p);
   if (! rn || rn->p.prefixlen != p.prefixlen)
     {
-      vty_out (vty, "%% Network not in table%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Network not in table");
       return CMD_WARNING;
     }
 
@@ -1609,10 +1610,9 @@ vty_show_ip_route_summary (struct vty *vty, struct route_table *table)
           }
       }
 
-  vty_out (vty, "%-20s %-20s %s  (vrf %s)%s",
+  vty_outln (vty, "%-20s %-20s %s  (vrf %s)",
            "Route Source", "Routes", "FIB",
-           zvrf_name (((rib_table_info_t *)table->info)->zvrf),
-           VTY_NEWLINE);
+           zvrf_name(((rib_table_info_t *)table->info)->zvrf));
 
   for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
     {
@@ -1621,23 +1621,21 @@ vty_show_ip_route_summary (struct vty *vty, struct route_table *table)
         {
           if (i == ZEBRA_ROUTE_BGP)
             {
-              vty_out (vty, "%-20s %-20d %-20d %s", "ebgp",
-                       rib_cnt[ZEBRA_ROUTE_BGP], fib_cnt[ZEBRA_ROUTE_BGP],
-                       VTY_NEWLINE);
-              vty_out (vty, "%-20s %-20d %-20d %s", "ibgp",
-                       rib_cnt[ZEBRA_ROUTE_IBGP], fib_cnt[ZEBRA_ROUTE_IBGP],
-                       VTY_NEWLINE);
+              vty_outln (vty, "%-20s %-20d %-20d ", "ebgp",
+                       rib_cnt[ZEBRA_ROUTE_BGP],fib_cnt[ZEBRA_ROUTE_BGP]);
+              vty_outln (vty, "%-20s %-20d %-20d ", "ibgp",
+                       rib_cnt[ZEBRA_ROUTE_IBGP],fib_cnt[ZEBRA_ROUTE_IBGP]);
             }
           else
-            vty_out (vty, "%-20s %-20d %-20d %s", zebra_route_string(i),
-                     rib_cnt[i], fib_cnt[i], VTY_NEWLINE);
+            vty_outln (vty, "%-20s %-20d %-20d ", zebra_route_string(i),
+                     rib_cnt[i], fib_cnt[i]);
         }
     }
 
-  vty_out (vty, "------%s", VTY_NEWLINE);
-  vty_out (vty, "%-20s %-20d %-20d %s", "Totals", rib_cnt[ZEBRA_ROUTE_TOTAL],
-           fib_cnt[ZEBRA_ROUTE_TOTAL], VTY_NEWLINE);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "------");
+  vty_outln (vty, "%-20s %-20d %-20d ", "Totals", rib_cnt[ZEBRA_ROUTE_TOTAL],
+           fib_cnt[ZEBRA_ROUTE_TOTAL]);
+  vty_outln (vty, "");
 }
 
 /*
@@ -1690,10 +1688,9 @@ vty_show_ip_route_summary_prefix (struct vty *vty, struct route_table *table)
 	     }
       }
 
-  vty_out (vty, "%-20s %-20s %s  (vrf %s)%s",
+  vty_outln (vty, "%-20s %-20s %s  (vrf %s)",
            "Route Source", "Prefix Routes", "FIB",
-           zvrf_name (((rib_table_info_t *)table->info)->zvrf),
-           VTY_NEWLINE);
+           zvrf_name(((rib_table_info_t *)table->info)->zvrf));
 
   for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
     {
@@ -1701,24 +1698,22 @@ vty_show_ip_route_summary_prefix (struct vty *vty, struct route_table *table)
 	{
 	  if (i == ZEBRA_ROUTE_BGP)
 	    {
-	      vty_out (vty, "%-20s %-20d %-20d %s", "ebgp",
+	      vty_outln (vty, "%-20s %-20d %-20d ", "ebgp",
 		       rib_cnt[ZEBRA_ROUTE_BGP] - rib_cnt[ZEBRA_ROUTE_IBGP],
-		       fib_cnt[ZEBRA_ROUTE_BGP] - fib_cnt[ZEBRA_ROUTE_IBGP],
-		       VTY_NEWLINE);
-	      vty_out (vty, "%-20s %-20d %-20d %s", "ibgp",
-		       rib_cnt[ZEBRA_ROUTE_IBGP], fib_cnt[ZEBRA_ROUTE_IBGP],
-		       VTY_NEWLINE);
+		       fib_cnt[ZEBRA_ROUTE_BGP] - fib_cnt[ZEBRA_ROUTE_IBGP]);
+	      vty_outln (vty, "%-20s %-20d %-20d ", "ibgp",
+		       rib_cnt[ZEBRA_ROUTE_IBGP],fib_cnt[ZEBRA_ROUTE_IBGP]);
 	    }
 	  else
-	    vty_out (vty, "%-20s %-20d %-20d %s", zebra_route_string(i),
-		     rib_cnt[i], fib_cnt[i], VTY_NEWLINE);
+	    vty_outln (vty, "%-20s %-20d %-20d ", zebra_route_string(i),
+		     rib_cnt[i], fib_cnt[i]);
 	}
     }
 
-  vty_out (vty, "------%s", VTY_NEWLINE);
-  vty_out (vty, "%-20s %-20d %-20d %s", "Totals", rib_cnt[ZEBRA_ROUTE_TOTAL],
-	   fib_cnt[ZEBRA_ROUTE_TOTAL], VTY_NEWLINE);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "------");
+  vty_outln (vty, "%-20s %-20d %-20d ", "Totals", rib_cnt[ZEBRA_ROUTE_TOTAL],
+	   fib_cnt[ZEBRA_ROUTE_TOTAL]);
+  vty_outln (vty, "");
 }
 
 /* Show route summary.  */
@@ -1793,7 +1788,7 @@ DEFUN (show_ip_route_vrf_all_addr,
   ret = str2prefix_ipv4 (argv[idx_ipv4]->arg, &p);
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed IPv4 address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed IPv4 address");
       return CMD_WARNING;
     }
 
@@ -1835,7 +1830,7 @@ DEFUN (show_ip_route_vrf_all_prefix,
   ret = str2prefix_ipv4 (argv[idx_ipv4_prefixlen]->arg, &p);
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed IPv4 address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed IPv4 address");
       return CMD_WARNING;
     }
 
@@ -1971,7 +1966,7 @@ static_config (struct vty *vty, afi_t afi, safi_t safi, const char *cmd)
                        mpls_label2str (si->snh_label.num_labels,
                                        si->snh_label.label, buf, sizeof buf, 0));
 
-            vty_out (vty, "%s", VTY_NEWLINE);
+            vty_outln (vty, "");
 
             write = 1;
           }
@@ -2005,7 +2000,7 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
   ret = str2prefix (dest_str, &p);
   if (ret <= 0)
     {
-      vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Malformed address");
       return CMD_WARNING;
     }
 
@@ -2014,7 +2009,7 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
       ret = str2prefix (src_str, &src);
       if (ret <= 0 || src.family != AF_INET6)
         {
-          vty_out (vty, "%% Malformed source address%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed source address");
           return CMD_WARNING;
         }
       src_p = (struct prefix_ipv6*)&src;
@@ -2042,7 +2037,7 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
 
   if (!zvrf)
     {
-      vty_out (vty, "%% vrf %s is not defined%s", vrf_id_str, VTY_NEWLINE);
+      vty_outln (vty, "%% vrf %s is not defined", vrf_id_str);
       return CMD_WARNING;
     }
 
@@ -2052,8 +2047,8 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
     {
       if (!mpls_enabled)
         {
-          vty_out (vty, "%% MPLS not turned on in kernel, ignoring command%s",
-                   VTY_NEWLINE);
+          vty_outln (vty,
+                     "%% MPLS not turned on in kernel, ignoring command");
           return CMD_WARNING;
         }
       int rc = mpls_str2label (label_str, &snh_label.num_labels,
@@ -2062,16 +2057,15 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
         {
           switch (rc) {
           case -1:
-            vty_out (vty, "%% Malformed label(s)%s", VTY_NEWLINE);
+            vty_outln (vty, "%% Malformed label(s)");
             break;
           case -2:
-            vty_out (vty, "%% Cannot use reserved label(s) (%d-%d)%s",
-                     MPLS_MIN_RESERVED_LABEL, MPLS_MAX_RESERVED_LABEL,
-                     VTY_NEWLINE);
+            vty_outln (vty, "%% Cannot use reserved label(s) (%d-%d)",
+                     MPLS_MIN_RESERVED_LABEL,MPLS_MAX_RESERVED_LABEL);
             break;
           case -3:
-            vty_out (vty, "%% Too many labels. Enter %d or fewer%s",
-                     MPLS_MAX_LABELS, VTY_NEWLINE);
+            vty_outln (vty, "%% Too many labels. Enter %d or fewer",
+                     MPLS_MAX_LABELS);
             break;
           }
           return CMD_WARNING;
@@ -2083,7 +2077,7 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
     {
       if (flag_str)
         {
-          vty_out (vty, "%% can not have flag %s with Null0%s", flag_str, VTY_NEWLINE);
+          vty_outln (vty, "%% can not have flag %s with Null0", flag_str);
           return CMD_WARNING;
         }
       if (add_cmd)
@@ -2107,7 +2101,7 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
         SET_FLAG (flag, ZEBRA_FLAG_BLACKHOLE);
         break;
       default:
-        vty_out (vty, "%% Malformed flag %s %s", flag_str, VTY_NEWLINE);
+        vty_outln (vty, "%% Malformed flag %s ", flag_str);
         return CMD_WARNING;
     }
   }
@@ -2118,7 +2112,7 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
          address. */
       if (ret != 1)
         {
-          vty_out (vty, "%% Malformed address%s", VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed address");
           return CMD_WARNING;
         }
       type = STATIC_IPV6_GATEWAY_IFINDEX;
@@ -2126,7 +2120,7 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
       ifp = if_lookup_by_name (ifname, zvrf_id (zvrf));
       if (!ifp)
         {
-          vty_out (vty, "%% Malformed Interface name %s%s", ifname, VTY_NEWLINE);
+          vty_outln (vty, "%% Malformed Interface name %s", ifname);
           return CMD_WARNING;
         }
       ifindex = ifp->ifindex;
@@ -2144,7 +2138,7 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
           ifp = if_lookup_by_name (gate_str, zvrf_id (zvrf));
           if (!ifp)
             {
-              vty_out (vty, "%% Malformed Interface name %s%s", gate_str, VTY_NEWLINE);
+              vty_outln (vty, "%% Malformed Interface name %s", gate_str);
               ifindex = IFINDEX_DELETED;
             }
           else
@@ -2641,7 +2635,7 @@ DEFUN (show_ipv6_route,
 
       if (type < 0)
         {
-          vty_out (vty, "Unknown route type%s", VTY_NEWLINE);
+          vty_outln (vty, "Unknown route type");
           return CMD_WARNING;
         }
     }
@@ -2694,7 +2688,7 @@ DEFUN (show_ipv6_route_addr,
 
   if (ret <= 0)
     {
-      vty_out (vty, "Malformed IPv6 address%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed IPv6 address");
       return CMD_WARNING;
     }
 
@@ -2705,7 +2699,7 @@ DEFUN (show_ipv6_route_addr,
   rn = route_node_match (table, (struct prefix *) &p);
   if (! rn)
     {
-      vty_out (vty, "%% Network not in table%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Network not in table");
       return CMD_WARNING;
     }
 
@@ -2741,7 +2735,7 @@ DEFUN (show_ipv6_route_prefix,
 
   if (ret <= 0)
     {
-      vty_out (vty, "Malformed IPv6 prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed IPv6 prefix");
       return CMD_WARNING;
     }
 
@@ -2752,7 +2746,7 @@ DEFUN (show_ipv6_route_prefix,
   rn = route_node_match (table, (struct prefix *) &p);
   if (! rn || rn->p.prefixlen != p.prefixlen)
     {
-      vty_out (vty, "%% Network not in table%s", VTY_NEWLINE);
+      vty_outln (vty, "%% Network not in table");
       return CMD_WARNING;
     }
 
@@ -2876,7 +2870,7 @@ DEFUN (show_ipv6_route_vrf_all_addr,
   ret = str2prefix_ipv6 (argv[idx_ipv6]->arg, &p);
   if (ret <= 0)
     {
-      vty_out (vty, "Malformed IPv6 address%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed IPv6 address");
       return CMD_WARNING;
     }
 
@@ -2918,7 +2912,7 @@ DEFUN (show_ipv6_route_vrf_all_prefix,
   ret = str2prefix_ipv6 (argv[idx_ipv6_prefixlen]->arg, &p);
   if (ret <= 0)
     {
-      vty_out (vty, "Malformed IPv6 prefix%s", VTY_NEWLINE);
+      vty_outln (vty, "Malformed IPv6 prefix");
       return CMD_WARNING;
     }
 
@@ -3063,7 +3057,7 @@ DEFUN (show_vrf,
        vty_out (vty, "inactive");
      else
        vty_out (vty, "id %u table %u", zvrf_id (zvrf), zvrf->table_id);
-     vty_out (vty, "%s", VTY_NEWLINE);
+     vty_outln (vty, "");
 
     }
 
@@ -3108,15 +3102,15 @@ DEFUN (ip_zebra_import_table_distance,
 
   if (!is_zebra_valid_kernel_table(table_id))
     {
-      vty_out(vty, "Invalid routing table ID, %d. Must be in range 1-252%s",
-	      table_id, VTY_NEWLINE);
+      vty_outln (vty, "Invalid routing table ID, %d. Must be in range 1-252",
+	      table_id);
       return CMD_WARNING;
     }
 
   if (is_zebra_main_routing_table(table_id))
     {
-      vty_out(vty, "Invalid routing table ID, %d. Must be non-default table%s",
-              table_id, VTY_NEWLINE);
+      vty_outln (vty, "Invalid routing table ID, %d. Must be non-default table",
+              table_id);
       return CMD_WARNING;
     }
 
@@ -3144,15 +3138,14 @@ DEFUN (no_ip_zebra_import_table,
 
   if (!is_zebra_valid_kernel_table(table_id))
     {
-      vty_out(vty, "Invalid routing table ID. Must be in range 1-252%s",
-	      VTY_NEWLINE);
+      vty_outln (vty,"Invalid routing table ID. Must be in range 1-252");
       return CMD_WARNING;
     }
 
   if (is_zebra_main_routing_table(table_id))
     {
-      vty_out(vty, "Invalid routing table ID, %d. Must be non-default table%s",
-	      table_id, VTY_NEWLINE);
+      vty_outln (vty, "Invalid routing table ID, %d. Must be non-default table",
+	      table_id);
       return CMD_WARNING;
     }
 
@@ -3166,24 +3159,19 @@ static int
 config_write_protocol (struct vty *vty)
 {
   if (allow_delete)
-    vty_out(vty, "allow-external-route-update%s", VTY_NEWLINE);
+    vty_outln (vty, "allow-external-route-update");
 
   if (zebra_rnh_ip_default_route)
-    vty_out(vty, "ip nht resolve-via-default%s", VTY_NEWLINE);
+    vty_outln (vty, "ip nht resolve-via-default");
 
   if (zebra_rnh_ipv6_default_route)
-    vty_out(vty, "ipv6 nht resolve-via-default%s", VTY_NEWLINE);
+    vty_outln (vty, "ipv6 nht resolve-via-default");
 
   enum multicast_mode ipv4_multicast_mode = multicast_mode_ipv4_get ();
 
   if (ipv4_multicast_mode != MCAST_NO_CONFIG)
-    vty_out (vty, "ip multicast rpf-lookup-mode %s%s",
-             ipv4_multicast_mode == MCAST_URIB_ONLY ? "urib-only" :
-             ipv4_multicast_mode == MCAST_MRIB_ONLY ? "mrib-only" :
-             ipv4_multicast_mode == MCAST_MIX_MRIB_FIRST ? "mrib-then-urib" :
-             ipv4_multicast_mode == MCAST_MIX_DISTANCE ? "lower-distance" :
-             "longer-prefix",
-             VTY_NEWLINE);
+    vty_outln (vty, "ip multicast rpf-lookup-mode %s",
+             ipv4_multicast_mode == MCAST_URIB_ONLY ? "urib-only" : ipv4_multicast_mode == MCAST_MRIB_ONLY ? "mrib-only" : ipv4_multicast_mode == MCAST_MIX_MRIB_FIRST ? "mrib-then-urib" : ipv4_multicast_mode == MCAST_MIX_DISTANCE ? "lower-distance" : "longer-prefix");
 
   zebra_routemap_config_write_protocol(vty);
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -2674,7 +2674,7 @@ zebra_show_client_detail (struct vty *vty, struct zserv *client)
   vty_out (vty, "Client: %s", zebra_route_string(client->proto));
   if (client->instance)
     vty_out (vty, " Instance: %d", client->instance);
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   vty_outln (vty, "------------------------ ");
   vty_outln (vty, "FD: %d ", client->sock);
@@ -2705,7 +2705,7 @@ zebra_show_client_detail (struct vty *vty, struct zserv *client)
   if (client->last_write_time)
     vty_outln (vty, "Last Sent Cmd: %s ",
 	     zserv_command_string(client->last_write_cmd));
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
 
   vty_outln (vty, "Type        Add        Update     Del ");
   vty_outln (vty, "================================================== ");
@@ -2724,7 +2724,7 @@ zebra_show_client_detail (struct vty *vty, struct zserv *client)
   vty_outln (vty, "Interface Up Notifications: %d",client->ifup_cnt);
   vty_outln (vty, "Interface Down Notifications: %d",client->ifdown_cnt);
 
-  vty_outln (vty, "");
+  vty_out (vty, VTYNL);
   return;
 }
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -2674,64 +2674,57 @@ zebra_show_client_detail (struct vty *vty, struct zserv *client)
   vty_out (vty, "Client: %s", zebra_route_string(client->proto));
   if (client->instance)
     vty_out (vty, " Instance: %d", client->instance);
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
 
-  vty_out (vty, "------------------------ %s", VTY_NEWLINE);
-  vty_out (vty, "FD: %d %s", client->sock, VTY_NEWLINE);
-  vty_out (vty, "Route Table ID: %d %s", client->rtm_table, VTY_NEWLINE);
+  vty_outln (vty, "------------------------ ");
+  vty_outln (vty, "FD: %d ", client->sock);
+  vty_outln (vty, "Route Table ID: %d ", client->rtm_table);
 
-  vty_out (vty, "Connect Time: %s %s",
-	   zserv_time_buf(&client->connect_time, cbuf, ZEBRA_TIME_BUF),
-	   VTY_NEWLINE);
+  vty_outln (vty, "Connect Time: %s ",
+	   zserv_time_buf(&client->connect_time, cbuf, ZEBRA_TIME_BUF));
   if (client->nh_reg_time)
     {
-      vty_out (vty, "Nexthop Registry Time: %s %s",
-	       zserv_time_buf(&client->nh_reg_time, nhbuf, ZEBRA_TIME_BUF),
-	       VTY_NEWLINE);
+      vty_outln (vty, "Nexthop Registry Time: %s ",
+	       zserv_time_buf(&client->nh_reg_time, nhbuf, ZEBRA_TIME_BUF));
       if (client->nh_last_upd_time)
-	vty_out (vty, "Nexthop Last Update Time: %s %s",
-		 zserv_time_buf(&client->nh_last_upd_time, mbuf, ZEBRA_TIME_BUF),
-		 VTY_NEWLINE);
-      else
-	vty_out (vty, "No Nexthop Update sent%s", VTY_NEWLINE);
+	vty_outln (vty, "Nexthop Last Update Time: %s ",
+		 zserv_time_buf(&client->nh_last_upd_time, mbuf, ZEBRA_TIME_BUF));
+	else
+		vty_outln (vty, "No Nexthop Update sent");
     }
   else
-    vty_out (vty, "Not registered for Nexthop Updates%s", VTY_NEWLINE);
+    vty_outln (vty, "Not registered for Nexthop Updates");
 
-  vty_out (vty, "Last Msg Rx Time: %s %s",
-	   zserv_time_buf(&client->last_read_time, rbuf, ZEBRA_TIME_BUF),
-	   VTY_NEWLINE);
-  vty_out (vty, "Last Msg Tx Time: %s %s",
-	   zserv_time_buf(&client->last_write_time, wbuf, ZEBRA_TIME_BUF),
-	   VTY_NEWLINE);
+  vty_outln (vty, "Last Msg Rx Time: %s ",
+	   zserv_time_buf(&client->last_read_time, rbuf, ZEBRA_TIME_BUF));
+  vty_outln (vty, "Last Msg Tx Time: %s ",
+	   zserv_time_buf(&client->last_write_time, wbuf, ZEBRA_TIME_BUF));
   if (client->last_read_time)
-    vty_out (vty, "Last Rcvd Cmd: %s %s",
-	     zserv_command_string(client->last_read_cmd), VTY_NEWLINE);
+    vty_outln (vty, "Last Rcvd Cmd: %s ",
+	     zserv_command_string(client->last_read_cmd));
   if (client->last_write_time)
-    vty_out (vty, "Last Sent Cmd: %s %s",
-	     zserv_command_string(client->last_write_cmd), VTY_NEWLINE);
-  vty_out (vty, "%s", VTY_NEWLINE);
+    vty_outln (vty, "Last Sent Cmd: %s ",
+	     zserv_command_string(client->last_write_cmd));
+  vty_outln (vty, "");
 
-  vty_out (vty, "Type        Add        Update     Del %s", VTY_NEWLINE);
-  vty_out (vty, "================================================== %s", VTY_NEWLINE);
-  vty_out (vty, "IPv4        %-12d%-12d%-12d%s", client->v4_route_add_cnt,
-	   client->v4_route_upd8_cnt, client->v4_route_del_cnt, VTY_NEWLINE);
-  vty_out (vty, "IPv6        %-12d%-12d%-12d%s", client->v6_route_add_cnt,
-	   client->v6_route_upd8_cnt, client->v6_route_del_cnt, VTY_NEWLINE);
-  vty_out (vty, "Redist:v4   %-12d%-12d%-12d%s", client->redist_v4_add_cnt, 0,
-	   client->redist_v4_del_cnt, VTY_NEWLINE);
-  vty_out (vty, "Redist:v6   %-12d%-12d%-12d%s", client->redist_v6_add_cnt, 0,
-	   client->redist_v6_del_cnt, VTY_NEWLINE);
-  vty_out (vty, "Connected   %-12d%-12d%-12d%s", client->ifadd_cnt, 0,
-	   client->ifdel_cnt, VTY_NEWLINE);
-  vty_out (vty, "BFD peer    %-12d%-12d%-12d%s", client->bfd_peer_add_cnt,
-       client->bfd_peer_upd8_cnt, client->bfd_peer_del_cnt, VTY_NEWLINE);
-  vty_out (vty, "Interface Up Notifications: %d%s", client->ifup_cnt,
-	   VTY_NEWLINE);
-  vty_out (vty, "Interface Down Notifications: %d%s", client->ifdown_cnt,
-	   VTY_NEWLINE);
+  vty_outln (vty, "Type        Add        Update     Del ");
+  vty_outln (vty, "================================================== ");
+  vty_outln (vty, "IPv4        %-12d%-12d%-12d", client->v4_route_add_cnt,
+	   client->v4_route_upd8_cnt, client->v4_route_del_cnt);
+  vty_outln (vty, "IPv6        %-12d%-12d%-12d", client->v6_route_add_cnt,
+	   client->v6_route_upd8_cnt, client->v6_route_del_cnt);
+  vty_outln (vty, "Redist:v4   %-12d%-12d%-12d", client->redist_v4_add_cnt, 0,
+	   client->redist_v4_del_cnt);
+  vty_outln (vty, "Redist:v6   %-12d%-12d%-12d", client->redist_v6_add_cnt, 0,
+	   client->redist_v6_del_cnt);
+  vty_outln (vty, "Connected   %-12d%-12d%-12d", client->ifadd_cnt, 0,
+	   client->ifdel_cnt);
+  vty_outln (vty, "BFD peer    %-12d%-12d%-12d", client->bfd_peer_add_cnt,
+       client->bfd_peer_upd8_cnt, client->bfd_peer_del_cnt);
+  vty_outln (vty, "Interface Up Notifications: %d",client->ifup_cnt);
+  vty_outln (vty, "Interface Down Notifications: %d",client->ifdown_cnt);
 
-  vty_out (vty, "%s", VTY_NEWLINE);
+  vty_outln (vty, "");
   return;
 }
 
@@ -2741,7 +2734,7 @@ zebra_show_client_brief (struct vty *vty, struct zserv *client)
   char cbuf[ZEBRA_TIME_BUF], rbuf[ZEBRA_TIME_BUF];
   char wbuf[ZEBRA_TIME_BUF];
 
-  vty_out (vty, "%-8s%12s %12s%12s%8d/%-8d%8d/%-8d%s",
+  vty_outln (vty, "%-8s%12s %12s%12s%8d/%-8d%8d/%-8d",
 	   zebra_route_string(client->proto),
 	   zserv_time_buf(&client->connect_time, cbuf, ZEBRA_TIME_BUF),
 	   zserv_time_buf(&client->last_read_time, rbuf, ZEBRA_TIME_BUF),
@@ -2749,7 +2742,7 @@ zebra_show_client_brief (struct vty *vty, struct zserv *client)
 	   client->v4_route_add_cnt+client->v4_route_upd8_cnt,
 	   client->v4_route_del_cnt,
 	   client->v6_route_add_cnt+client->v6_route_upd8_cnt,
-	   client->v6_route_del_cnt, VTY_NEWLINE);
+	   client->v6_route_del_cnt);
 
 }
 
@@ -2776,8 +2769,7 @@ DEFUN (show_table,
        SHOW_STR
        "default routing table to use for all clients\n")
 {
-  vty_out (vty, "table %d%s", zebrad.rtm_table_default,
-	   VTY_NEWLINE);
+  vty_outln (vty, "table %d",zebrad.rtm_table_default);
   return CMD_SUCCESS;
 }
 
@@ -2817,7 +2809,7 @@ DEFUN (ip_forwarding,
 
   if (ret == 0)
     {
-      vty_out (vty, "Can't turn on IP forwarding%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't turn on IP forwarding");
       return CMD_WARNING;
     }
 
@@ -2839,7 +2831,7 @@ DEFUN (no_ip_forwarding,
 
   if (ret != 0)
     {
-      vty_out (vty, "Can't turn off IP forwarding%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't turn off IP forwarding");
       return CMD_WARNING;
     }
 
@@ -2854,15 +2846,16 @@ DEFUN (show_zebra,
 {
   struct vrf *vrf;
 
-  vty_out (vty, "                            Route      Route      Neighbor   LSP        LSP%s", VTY_NEWLINE);
-  vty_out (vty, "VRF                         Installs   Removals    Updates   Installs   Removals%s", VTY_NEWLINE);
+  vty_outln (vty,
+             "                            Route      Route      Neighbor   LSP        LSP");
+  vty_outln (vty,
+             "VRF                         Installs   Removals    Updates   Installs   Removals");
   RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
     {
       struct zebra_vrf *zvrf = vrf->info;
-      vty_out (vty,"%-25s %10" PRIu64 " %10" PRIu64 " %10" PRIu64 " %10" PRIu64 " %10" PRIu64 "%s",
+      vty_outln (vty,"%-25s %10" PRIu64 " %10" PRIu64 " %10" PRIu64 " %10" PRIu64 " %10" PRIu64 "",
                vrf->name, zvrf->installs, zvrf->removals,
-               zvrf->neigh_updates, zvrf->lsp_installs, zvrf->lsp_removals,
-               VTY_NEWLINE);
+               zvrf->neigh_updates, zvrf->lsp_installs,zvrf->lsp_removals);
     }
 
   return CMD_SUCCESS;
@@ -2897,15 +2890,15 @@ DEFUN (show_zebra_client_summary,
   struct listnode *node;
   struct zserv *client;
 
-  vty_out (vty, "Name    Connect Time    Last Read  Last Write  IPv4 Routes       IPv6 Routes    %s",
-	   VTY_NEWLINE);
-  vty_out (vty,"--------------------------------------------------------------------------------%s",
-	   VTY_NEWLINE);
+  vty_outln (vty,
+             "Name    Connect Time    Last Read  Last Write  IPv4 Routes       IPv6 Routes    ");
+  vty_outln (vty,
+             "--------------------------------------------------------------------------------");
 
   for (ALL_LIST_ELEMENTS_RO (zebrad.client_list, node, client))
     zebra_show_client_brief(vty, client);
 
-  vty_out (vty, "Routes column shows (added+updated)/deleted%s", VTY_NEWLINE);
+  vty_outln (vty, "Routes column shows (added+updated)/deleted");
   return CMD_SUCCESS;
 }
 
@@ -2914,8 +2907,7 @@ static int
 config_write_table (struct vty *vty)
 {
   if (zebrad.rtm_table_default)
-    vty_out (vty, "table %d%s", zebrad.rtm_table_default,
-	     VTY_NEWLINE);
+    vty_outln (vty, "table %d",zebrad.rtm_table_default);
   return 0;
 }
 
@@ -2940,9 +2932,9 @@ DEFUN (show_ip_forwarding,
   ret = ipforward ();
 
   if (ret == 0)
-    vty_out (vty, "IP forwarding is off%s", VTY_NEWLINE);
+    vty_outln (vty, "IP forwarding is off");
   else
-    vty_out (vty, "IP forwarding is on%s", VTY_NEWLINE);
+    vty_outln (vty, "IP forwarding is on");
   return CMD_SUCCESS;
 }
 
@@ -2961,16 +2953,16 @@ DEFUN (show_ipv6_forwarding,
   switch (ret)
     {
     case -1:
-      vty_out (vty, "ipv6 forwarding is unknown%s", VTY_NEWLINE);
+      vty_outln (vty, "ipv6 forwarding is unknown");
       break;
     case 0:
-      vty_out (vty, "ipv6 forwarding is %s%s", "off", VTY_NEWLINE);
+      vty_outln (vty, "ipv6 forwarding is %s", "off");
       break;
     case 1:
-      vty_out (vty, "ipv6 forwarding is %s%s", "on", VTY_NEWLINE);
+      vty_outln (vty, "ipv6 forwarding is %s", "on");
       break;
     default:
-      vty_out (vty, "ipv6 forwarding is %s%s", "off", VTY_NEWLINE);
+      vty_outln (vty, "ipv6 forwarding is %s", "off");
       break;
     }
   return CMD_SUCCESS;
@@ -2990,7 +2982,7 @@ DEFUN (ipv6_forwarding,
 
   if (ret == 0)
     {
-      vty_out (vty, "Can't turn on IPv6 forwarding%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't turn on IPv6 forwarding");
       return CMD_WARNING;
     }
 
@@ -3012,7 +3004,7 @@ DEFUN (no_ipv6_forwarding,
 
   if (ret != 0)
     {
-      vty_out (vty, "Can't turn off IPv6 forwarding%s", VTY_NEWLINE);
+      vty_outln (vty, "Can't turn off IPv6 forwarding");
       return CMD_WARNING;
     }
 
@@ -3027,10 +3019,10 @@ config_write_forwarding (struct vty *vty)
   router_id_write (vty);
 
   if (!ipforward ())
-    vty_out (vty, "no ip forwarding%s", VTY_NEWLINE);
+    vty_outln (vty, "no ip forwarding");
   if (!ipforward_ipv6 ())
-    vty_out (vty, "no ipv6 forwarding%s", VTY_NEWLINE);
-  vty_out (vty, "!%s", VTY_NEWLINE);
+    vty_outln (vty, "no ipv6 forwarding");
+  vty_outln (vty, "!");
   return 0;
 }
 


### PR DESCRIPTION
* Add `vty_outln()` which will print the correct newline for you at EOL
* Refactor `VTY_NEWLINE` → `VTYNL`
* Refactor `char[]` used as format strings into macros to suppress Clang security warnings