### PR TITLE
lib: actually exit when asked to 'do' so

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2212,7 +2212,10 @@ vtysh_read (struct thread *thread)
         }
     }
 
-  vty_event (VTYSH_READ, sock, vty);
+  if (vty->status == VTY_CLOSE)
+    vty_close (vty);
+  else
+    vty_event (VTYSH_READ, sock, vty);
 
   return 0;
 }


### PR DESCRIPTION
When vtysh sends 'exit' to a daemon, we set the `vty->status` to
`VTY_CLOSE` but never actually close the connection.

Among other things this means `do exit` gets us into an inconsistent state where vtysh switches nodes (because in certain cases it can't handle `do` commands due to needing to switch nodes) and the daemon "exits" (it actually just sets `VTY_CLOSE` and leaves the connection open and stays in the node its in) so that we're no longer in sync with nodes.

Example:
```
ubuntu@ubuntu-xenial ~> sudo vtysh

Hello, this is FRRouting (version 3.1-dev).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

ubuntu-xenial# conf t
ubuntu-xenial(config)# do exit
ubuntu-xenial# conf t
% [BGP] Unknown command: conf t
ubuntu-xenial(config)#
```

you might be wondering why vtysh doesn't exit also, well, the answer is...

because reasons

New behavior is to do the right thing and actually kill the vty session.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>