### PR TITLE
use argv->text where appropriate

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -629,9 +629,9 @@ DEFUN_HIDDEN (neighbor_bfd_type,
   if (!peer)
     return CMD_WARNING;
 
-  if (!strcmp(argv[idx_hop]->arg, "singlehop"))
+  if (strmatch(argv[idx_hop]->text, "singlehop"))
     type = BFD_TYPE_SINGLEHOP;
-  else if (!strcmp(argv[idx_hop]->arg, "multihop"))
+  else if (strmatch(argv[idx_hop]->text, "multihop"))
     type = BFD_TYPE_MULTIHOP;
   else
     return CMD_WARNING;

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -753,7 +753,7 @@ DEFUN (dump_bgp_all,
   const struct bgp_dump_type_map *map = NULL;
 
   for (map = bgp_dump_type_map; map->str; map++)
-    if (strcmp(argv[idx_dump_routes]->arg, map->str) == 0)
+    if (strmatch(argv[idx_dump_routes]->text, map->str))
       bgp_dump_type = map->type;
 
   switch (bgp_dump_type)
@@ -800,7 +800,7 @@ DEFUN (no_dump_bgp_all,
   struct bgp_dump *bgp_dump_struct = NULL;
 
   for (map = bgp_dump_type_map; map->str; map++)
-    if (strcmp(argv[idx_dump_routes]->arg, map->str) == 0)
+    if (strmatch(argv[idx_dump_routes]->text, map->str))
       bgp_dump_type = map->type;
 
   switch (bgp_dump_type)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8867,7 +8867,7 @@ bgp_show_community (struct vty *vty, struct bgp *bgp, int argc,
         buffer_putc (b, ' ');
       else
 	{
-	  if ((strcmp (argv[i]->arg, "unicast") == 0) || (strcmp (argv[i]->arg, "multicast") == 0))
+	  if (strmatch(argv[i]->text, "unicast") || strmatch(argv[i]->text, "multicast"))
 	    continue;
 	  first = 1;
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8463,7 +8463,7 @@ DEFUN (show_ip_bgp_large_community_list,
   {
     afi = strmatch(argv[idx]->text, "ipv6") ? AFI_IP6 : AFI_IP;
     if (argv_find (argv, argc, "unicast", &idx) || argv_find (argv, argc, "multicast", &idx))
-      safi = bgp_vty_safi_from_arg (argv[idx]->text);
+      safi = bgp_vty_safi_from_str (argv[idx]->text);
   }
 
   int uj = use_json (argc, argv);
@@ -8508,7 +8508,7 @@ DEFUN (show_ip_bgp_large_community,
   {
     afi = strmatch(argv[idx]->text, "ipv6") ? AFI_IP6 : AFI_IP;
     if (argv_find (argv, argc, "unicast", &idx) || argv_find (argv, argc, "multicast", &idx))
-      safi = bgp_vty_safi_from_arg (argv[idx]->text);
+      safi = bgp_vty_safi_from_str (argv[idx]->text);
   }
 
   int uj = use_json (argc, argv);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -166,31 +166,23 @@ bgp_node_safi (struct vty *vty)
   return safi;
 }
 
-/* supports <ipv4|ipv6> */
+/**
+ * Converts an AFI in string form to afi_t
+ *
+ * @param afi string, one of
+ *  - "ipv4"
+ *  - "ipv6"
+ * @return the corresponding afi_t
+ */
 afi_t
-bgp_vty_afi_from_arg(const char *afi_str)
+bgp_vty_afi_from_str(const char *afi_str)
 {
-  afi_t afi = AFI_MAX;       /* unknown */
-  if (!strcmp(afi_str, "ipv4")) {
+  afi_t afi = AFI_MAX; /* unknown */
+  if (strmatch(afi_str, "ipv4"))
     afi = AFI_IP;
-    }
-  else if (!strcmp(afi_str, "ipv6")) {
+  else if (strmatch(afi_str, "ipv6"))
     afi = AFI_IP6;
-  }
-  else if (!strcmp(afi_str, "l2vpn")) {
-    afi = AFI_L2VPN;
-  }
   return afi;
-}
-
-int
-bgp_parse_afi(const char *str, afi_t *afi)
-{
-  *afi = bgp_vty_afi_from_arg(str);
-  if (*afi != AFI_MAX)
-    return 0;
-  else
-    return -1;
 }
 
 int
@@ -214,7 +206,7 @@ argv_find_and_parse_afi(struct cmd_token **argv, int argc, int *index, afi_t *af
 
 /* supports <unicast|multicast|vpn|labeled-unicast> */
 safi_t
-bgp_vty_safi_from_arg(const char *safi_str)
+bgp_vty_safi_from_str(const char *safi_str)
 {
   safi_t safi = SAFI_MAX;       /* unknown */
   if (strmatch (safi_str, "multicast"))
@@ -255,12 +247,6 @@ argv_find_and_parse_safi (struct cmd_token **argv, int argc, int *index, safi_t 
       ret = 1;
       if (safi)
         *safi = SAFI_MPLS_VPN;
-    }
-  else if (argv_find (argv, argc, "evpn", index))
-    {
-      ret = 1;
-      if (safi)
-        *safi = SAFI_EVPN;
     }
   return ret;
 }
@@ -6225,7 +6211,7 @@ DEFUN_NOSH (address_family_ipv4_safi,
 
   if (argc == 3)
     {
-      safi_t safi = bgp_vty_safi_from_arg(argv[2]->arg);
+      safi_t safi = bgp_vty_safi_from_str (argv[2]->text);
       vty->node = bgp_node_type(AFI_IP, safi);
     }
   else
@@ -6243,7 +6229,7 @@ DEFUN_NOSH (address_family_ipv6_safi,
 {
   if (argc == 3)
     {
-      safi_t safi = bgp_vty_safi_from_arg(argv[2]->arg);
+      safi_t safi = bgp_vty_safi_from_str (argv[2]->text);
       vty->node = bgp_node_type(AFI_IP6, safi);
     }
   else
@@ -6531,7 +6517,7 @@ DEFUN (clear_bgp_ipv6_safi_prefix,
   int idx_safi = 3;
   int idx_ipv6_prefixlen = 5;
   return bgp_clear_prefix (vty, NULL, argv[idx_ipv6_prefixlen]->arg, AFI_IP6,
-                           bgp_vty_safi_from_arg(argv[idx_safi]->arg), NULL);
+                           bgp_vty_safi_from_str(argv[idx_safi]->text), NULL);
 }
 
 DEFUN (clear_bgp_instance_ipv6_safi_prefix,
@@ -6550,7 +6536,7 @@ DEFUN (clear_bgp_instance_ipv6_safi_prefix,
   int idx_safi = 5;
   int idx_ipv6_prefixlen = 7;
   return bgp_clear_prefix (vty, argv[idx_word]->arg, argv[idx_ipv6_prefixlen]->arg, AFI_IP6,
-                           bgp_vty_safi_from_arg(argv[idx_safi]->arg), NULL);
+                           bgp_vty_safi_from_str(argv[idx_safi]->text), NULL);
 }
 
 DEFUN (show_bgp_views,
@@ -9665,8 +9651,8 @@ DEFUN (show_bgp_updgrps_afi_adj,
   int idx_safi = 3;
   int idx_type = 5;
   show_bgp_updgrps_adj_info_aux(vty, NULL,
-                                bgp_vty_afi_from_arg(argv[idx_afi]->arg),
-                                bgp_vty_safi_from_arg(argv[idx_safi]->arg),
+                                bgp_vty_afi_from_str(argv[idx_afi]->text),
+                                bgp_vty_safi_from_str(argv[idx_safi]->text),
                                 argv[idx_type]->arg, 0);
   return CMD_SUCCESS;
 }
@@ -9776,8 +9762,8 @@ DEFUN (show_bgp_updgrps_afi_adj_s,
   VTY_GET_ULL("subgroup-id", subgrp_id, argv[idx_subgroup_id]->arg);
 
   show_bgp_updgrps_adj_info_aux(vty, NULL, 
-                                bgp_vty_afi_from_arg(argv[idx_afi]->arg),
-                                bgp_vty_safi_from_arg(argv[idx_safi]->arg),
+                                bgp_vty_afi_from_str(argv[idx_afi]->text),
+                                bgp_vty_safi_from_str(argv[idx_safi]->text),
                                 argv[idx_type]->arg, subgrp_id);
   return CMD_SUCCESS;
 }

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -48,14 +48,11 @@ extern int bgp_vty_return (struct vty *vty, int ret);
 extern struct peer *
 peer_and_group_lookup_vty (struct vty *vty, const char *peer_str);
 
-extern int
-bgp_parse_afi(const char *str, afi_t *afi);
-
 extern afi_t
-bgp_vty_afi_from_arg(const char *afi_str);
+bgp_vty_afi_from_str(const char *afi_str);
 
 extern safi_t
-bgp_vty_safi_from_arg(const char *safi_str);
+bgp_vty_safi_from_str(const char *safi_str);
 
 extern int
 argv_find_and_parse_afi(struct cmd_token **argv, int argc, int *index, afi_t *afi);

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -479,7 +479,7 @@ DEFUN (vnc_defaults_l2rd,
   VTY_DECLVAR_CONTEXT(bgp, bgp);
   uint8_t value = 0;
 
-  if (!strcmp (argv[1]->arg, "auto-vn"))
+  if (strmatch(argv[1]->text, "auto-vn"))
     {
       value = 0;
     }
@@ -539,7 +539,7 @@ DEFUN (vnc_defaults_responselifetime,
   if (!h)
     return CMD_WARNING;
 
-  if (!strcmp (argv[1]->arg, "infinite"))
+  if (strmatch(argv[1]->text, "infinite"))
     {
       rspint = RFAPI_INFINITE_LIFETIME;
     }
@@ -1102,7 +1102,7 @@ DEFUN (vnc_redistribute_lifetime,
 
   vnc_redistribute_prechange (bgp);
 
-  if (!strcmp (argv[3]->arg, "infinite"))
+  if (strmatch(argv[3]->text, "infinite"))
     {
       bgp->rfapi_cfg->redist_lifetime = RFAPI_INFINITE_LIFETIME;
     }
@@ -1141,7 +1141,7 @@ DEFUN (vnc_redist_bgpdirect_no_prefixlist,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[3]->arg, "bgp-direct"))
+  if (strmatch(argv[3]->text, "bgp-direct"))
     {
       route_type = ZEBRA_ROUTE_BGP_DIRECT;
     }
@@ -1150,7 +1150,7 @@ DEFUN (vnc_redist_bgpdirect_no_prefixlist,
       route_type = ZEBRA_ROUTE_BGP_DIRECT_EXT;
     }
 
-  if (!strcmp (argv[4]->arg, "ipv4"))
+  if (strmatch(argv[4]->text, "ipv4"))
     {
       afi = AFI_IP;
     }
@@ -1194,7 +1194,7 @@ DEFUN (vnc_redist_bgpdirect_prefixlist,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[2]->arg, "bgp-direct"))
+  if (strmatch(argv[2]->text, "bgp-direct"))
     {
       route_type = ZEBRA_ROUTE_BGP_DIRECT;
     }
@@ -1203,7 +1203,7 @@ DEFUN (vnc_redist_bgpdirect_prefixlist,
       route_type = ZEBRA_ROUTE_BGP_DIRECT_EXT;
     }
 
-  if (!strcmp (argv[3]->arg, "ipv4"))
+  if (strmatch(argv[3]->text, "ipv4"))
     {
       afi = AFI_IP;
     }
@@ -1244,7 +1244,7 @@ DEFUN (vnc_redist_bgpdirect_no_routemap,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[3]->arg, "bgp-direct"))
+  if (strmatch(argv[3]->text, "bgp-direct"))
     {
       route_type = ZEBRA_ROUTE_BGP_DIRECT;
     }
@@ -1284,7 +1284,7 @@ DEFUN (vnc_redist_bgpdirect_routemap,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[2]->arg, "bgp-direct"))
+  if (strmatch(argv[2]->text, "bgp-direct"))
     {
       route_type = ZEBRA_ROUTE_BGP_DIRECT;
     }
@@ -1337,7 +1337,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_no_prefixlist,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[3]->arg, "ipv4"))
+  if (strmatch(argv[3]->text, "ipv4"))
     {
       afi = AFI_IP;
     }
@@ -1386,7 +1386,7 @@ DEFUN (vnc_nve_group_redist_bgpdirect_prefixlist,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[2]->arg, "ipv4"))
+  if (strmatch(argv[2]->text, "ipv4"))
     {
       afi = AFI_IP;
     }
@@ -1804,7 +1804,7 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[3]->arg, "ipv4"))
+  if (strmatch(argv[3]->text, "ipv4"))
     {
       afi = AFI_IP;
     }
@@ -1816,7 +1816,7 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
   if (argv[2]->arg[0] == 'b')
     {
       if (((argc > 5)
-           && !strcmp (argv[5]->arg, rfg->plist_export_bgp_name[afi]))
+           && strmatch(argv[5]->text, rfg->plist_export_bgp_name[afi]))
           || (argc <= 5))
         {
 
@@ -1831,7 +1831,7 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
   else
     {
       if (((argc > 5)
-           && !strcmp (argv[5]->arg, rfg->plist_export_zebra_name[afi]))
+           && strmatch(argv[5]->text, rfg->plist_export_zebra_name[afi]))
           || (argc <= 5))
         {
           if (rfg->plist_export_zebra_name[afi])
@@ -1873,7 +1873,7 @@ DEFUN (vnc_nve_group_export_prefixlist,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[2]->arg, "ipv4"))
+  if (strmatch(argv[2]->text, "ipv4"))
     {
       afi = AFI_IP;
     }
@@ -1933,7 +1933,7 @@ DEFUN (vnc_nve_group_export_no_routemap,
   if (argv[2]->arg[0] == 'b')
     {
       if (((argc > 4)
-           && !strcmp (argv[4]->arg, rfg->routemap_export_bgp_name))
+           && strmatch(argv[4]->text, rfg->routemap_export_bgp_name))
           || (argc <= 4))
         {
 
@@ -1949,7 +1949,7 @@ DEFUN (vnc_nve_group_export_no_routemap,
   else
     {
       if (((argc > 4)
-           && !strcmp (argv[4]->arg, rfg->routemap_export_zebra_name))
+           && strmatch(argv[4]->text, rfg->routemap_export_zebra_name))
           || (argc <= 4))
         {
           if (rfg->routemap_export_zebra_name)
@@ -2032,7 +2032,7 @@ DEFUN (vnc_nve_export_no_prefixlist,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[4]->arg, "ipv4"))
+  if (strmatch(argv[4]->text, "ipv4"))
     {
       afi = AFI_IP;
     }
@@ -2045,7 +2045,7 @@ DEFUN (vnc_nve_export_no_prefixlist,
     {
       if (((argc > 6)
            && hc->plist_export_bgp_name[afi]
-           && !strcmp (argv[6]->arg, hc->plist_export_bgp_name[afi]))
+           && strmatch(argv[6]->text, hc->plist_export_bgp_name[afi]))
           || (argc <= 6))
         {
 
@@ -2059,7 +2059,7 @@ DEFUN (vnc_nve_export_no_prefixlist,
     {
       if (((argc > 6)
            && hc->plist_export_zebra_name[afi]
-           && !strcmp (argv[6]->arg, hc->plist_export_zebra_name[afi]))
+           && strmatch(argv[6]->text, hc->plist_export_zebra_name[afi]))
           || (argc <= 6))
         {
 
@@ -2094,7 +2094,7 @@ DEFUN (vnc_nve_export_prefixlist,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[3]->arg, "ipv4"))
+  if (strmatch(argv[3]->text, "ipv4"))
     {
       afi = AFI_IP;
     }
@@ -2145,7 +2145,7 @@ DEFUN (vnc_nve_export_no_routemap,
     {
       if (((argc > 5)
            && hc->routemap_export_bgp_name
-           && !strcmp (argv[5]->arg, hc->routemap_export_bgp_name))
+           && strmatch(argv[5]->text, hc->routemap_export_bgp_name))
           || (argc <= 5))
         {
 
@@ -2160,7 +2160,7 @@ DEFUN (vnc_nve_export_no_routemap,
     {
       if (((argc > 5)
            && hc->routemap_export_zebra_name
-           && !strcmp (argv[5]->arg, hc->routemap_export_zebra_name))
+           && strmatch(argv[5]->text, hc->routemap_export_zebra_name))
           || (argc <= 5))
         {
 
@@ -3050,7 +3050,7 @@ DEFUN (vnc_nve_group_l2rd,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[1]->arg, "auto:vn"))
+  if (strmatch(argv[1]->text, "auto:vn"))
     {
       rfg->l2rd = 0;
     }
@@ -3199,7 +3199,7 @@ DEFUN (vnc_nve_group_responselifetime,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[1]->arg, "infinite"))
+  if (strmatch(argv[1]->text, "infinite"))
     {
       rspint = RFAPI_INFINITE_LIFETIME;
     }

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -3333,7 +3333,7 @@ DEFUN (debug_rfapi_register_vn_un,
     }
   rfapiQprefix2Rprefix (&pfx, &hpfx);
 
-  if (!strcmp (argv[10]->arg, "infinite"))
+  if (strmatch(argv[10]->text, "infinite"))
     {
       lifetime = RFAPI_INFINITE_LIFETIME;
     }
@@ -3422,7 +3422,7 @@ DEFUN (debug_rfapi_register_vn_un_l2o,
     }
   rfapiQprefix2Rprefix (&pfx, &hpfx);
 
-  if (!strcmp (argv[10]->arg, "infinite"))
+  if (strmatch(argv[10]->text, "infinite"))
     {
       lifetime = RFAPI_INFINITE_LIFETIME;
     }
@@ -3932,7 +3932,7 @@ DEFUN (debug_rfapi_response_omit_self,
       return CMD_WARNING;
     }
 
-  if (!strcmp (argv[3]->arg, "on"))
+  if (strmatch(argv[3]->text, "on"))
     SET_FLAG (bgp->rfapi_cfg->flags, BGP_VNC_CONFIG_FILTER_SELF_FROM_RSP);
   else
     UNSET_FLAG (bgp->rfapi_cfg->flags, BGP_VNC_CONFIG_FILTER_SELF_FROM_RSP);

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -2236,7 +2236,7 @@ register_add (
 
        for (; argc; --argc, ++argv)
          {
-           if (!strcmp (argv[0]->arg, "local-next-hop"))
+           if (strmatch(argv[0]->text, "local-next-hop"))
              {
                if (arg_lnh)
                  {
@@ -2253,7 +2253,7 @@ register_add (
                ++argv, --argc;
                arg_lnh = argv[0]->arg;
              }
-           if (!strcmp (argv[0]->arg, "local-cost"))
+           if (strmatch(argv[0]->text, "local-cost"))
              {
                if (arg_lnh_cost)
                  {

--- a/bgpd/rfapi/vnc_debug.c
+++ b/bgpd/rfapi/vnc_debug.c
@@ -69,7 +69,7 @@ DEFUN (debug_bgp_vnc,
 
   for (i = 0; i < (sizeof(vncdebug) / sizeof(struct vnc_debug)); ++i)
     {
-      if (!strcmp(argv[3]->arg, vncdebug[i].name))
+      if (strmatch(argv[3]->text, vncdebug[i].name))
 	{
 	  if (vty->node == CONFIG_NODE)
 	    {
@@ -104,11 +104,11 @@ DEFUN (no_debug_bgp_vnc,
 {
   size_t	i;
 
-  if (!strcmp(argv[0]->arg, "no"))
+  if (strmatch(argv[0]->text, "no"))
     argc--, argv++;
   for (i = 0; i < (sizeof(vncdebug) / sizeof(struct vnc_debug)); ++i)
     {
-      if (!strcmp(argv[3]->arg, vncdebug[i].name))
+      if (strmatch(argv[3]->text, vncdebug[i].name))
 	{
 	  if (vty->node == CONFIG_NODE)
 	    {

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1386,7 +1386,7 @@ DEFUN (show_isis_topology,
 
   if (argc < 4)
     levels = ISIS_LEVEL1|ISIS_LEVEL2;
-  else if (!strcmp(argv[3]->arg, "level-1"))
+  else if (strmatch(argv[3]->text, "level-1"))
     levels = ISIS_LEVEL1;
   else
     levels = ISIS_LEVEL2;

--- a/lib/command.c
+++ b/lib/command.c
@@ -1534,8 +1534,8 @@ DEFUN (config_write,
   struct stat conf_stat;
 
   // if command was 'write terminal' or 'show running-config'
-  if (argc == 2 && (!strcmp(argv[idx_type]->text, "terminal") ||
-                    !strcmp(argv[0]->text, "show")))
+  if (argc == 2 && (strmatch(argv[idx_type]->text, "terminal") ||
+                    strmatch(argv[0]->text, "show")))
     {
       vty_write_config (vty);
       return CMD_SUCCESS;

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -493,7 +493,7 @@ DEFUN(if_nhrp_map, if_nhrp_map_cmd,
 		return nhrp_vty_return(vty, NHRP_ERR_FAIL);
 
 	c->map = 1;
-	if (strcmp(argv[4]->text, "local") == 0) {
+	if (strmatch(argv[4]->text, "local")) {
 		nhrp_cache_update_binding(c, NHRP_CACHE_LOCAL, 0, NULL, 0, NULL);
 	} else{
 		if (str2sockunion(argv[4]->arg, &nbma_addr) < 0)

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -850,11 +850,11 @@ DEFUN (debug_ospf6_lsa_type,
 
   if (argc == 5)
     {
-      if (! strcmp (argv[idx_type]->text, "originate"))
+      if (strmatch(argv[idx_type]->text, "originate"))
         SET_FLAG (handler->debug, OSPF6_LSA_DEBUG_ORIGINATE);
-      else if (! strcmp (argv[idx_type]->text, "examine"))
+      else if (strmatch(argv[idx_type]->text, "examine"))
         SET_FLAG (handler->debug, OSPF6_LSA_DEBUG_EXAMIN);
-      else if (! strcmp (argv[idx_type]->text, "flooding"))
+      else if (strmatch(argv[idx_type]->text, "flooding"))
         SET_FLAG (handler->debug, OSPF6_LSA_DEBUG_FLOOD);
     }
   else
@@ -903,11 +903,11 @@ DEFUN (no_debug_ospf6_lsa_type,
 
   if (argc == 6)
     {
-      if (! strcmp (argv[idx_type]->text, "originate"))
+      if (strmatch(argv[idx_type]->text, "originate"))
         UNSET_FLAG (handler->debug, OSPF6_LSA_DEBUG_ORIGINATE);
-      if (! strcmp (argv[idx_type]->text, "examine"))
+      if (strmatch(argv[idx_type]->text, "examine"))
         UNSET_FLAG (handler->debug, OSPF6_LSA_DEBUG_EXAMIN);
-      if (! strcmp (argv[idx_type]->text, "flooding"))
+      if (strmatch(argv[idx_type]->text, "flooding"))
         UNSET_FLAG (handler->debug, OSPF6_LSA_DEBUG_FLOOD);
     }
   else

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -1313,43 +1313,43 @@ ospf6_route_table_show (struct vty *vty, int argc_start, int argc, struct cmd_to
 
   for (i = argc_start; i < argc; i++)
     {
-      if (! strcmp (argv[i]->arg, "summary"))
+      if (strmatch(argv[i]->text, "summary"))
         {
           summary++;
           continue;
         }
 
-      if (! strcmp (argv[i]->arg, "intra-area"))
+      if (strmatch(argv[i]->text, "intra-area"))
         {
           type = OSPF6_PATH_TYPE_INTRA;
           continue;
         }
 
-      if (! strcmp (argv[i]->arg, "inter-area"))
+      if (strmatch(argv[i]->text, "inter-area"))
         {
           type = OSPF6_PATH_TYPE_INTER;
           continue;
         }
 
-      if (! strcmp (argv[i]->arg, "external-1"))
+      if (strmatch(argv[i]->text, "external-1"))
         {
           type = OSPF6_PATH_TYPE_EXTERNAL1;
           continue;
         }
 
-      if (! strcmp (argv[i]->arg, "external-2"))
+      if (strmatch(argv[i]->text, "external-2"))
         {
           type = OSPF6_PATH_TYPE_EXTERNAL2;
           continue;
         }
 
-      if (! strcmp (argv[i]->arg, "detail"))
+      if (strmatch(argv[i]->text, "detail"))
         {
           detail++;
           continue;
         }
 
-      if (! strcmp (argv[i]->arg, "match"))
+      if (strmatch(argv[i]->text, "match"))
         {
           match++;
           continue;
@@ -1488,7 +1488,7 @@ ospf6_linkstate_table_show (struct vty *vty, int idx_ipv4, int argc,
 
   for (i = idx_ipv4; i < argc; i++)
     {
-      if (! strcmp (argv[i]->arg, "detail"))
+      if (strmatch(argv[i]->text, "detail"))
         {
           detail++;
           continue;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -374,7 +374,7 @@ DEFUN (ospf_passive_interface,
   struct ospf_if_params *params;
   struct route_node *rn;
 
-  if (strcmp (argv[1]->text, "default") == 0)
+  if (strmatch(argv[1]->text, "default"))
     {
       ospf_passive_interface_default (ospf, OSPF_IF_PASSIVE);
       return CMD_SUCCESS;
@@ -444,7 +444,7 @@ DEFUN (no_ospf_passive_interface,
   int ret;
   struct route_node *rn;
 
-  if (strcmp (argv[2]->text, "default") == 0)
+  if (strmatch(argv[2]->text, "default"))
     {
       ospf_passive_interface_default (ospf, OSPF_IF_ACTIVE);
       return CMD_SUCCESS;
@@ -1090,7 +1090,7 @@ DEFUN (ospf_area_vlink,
 		      i++;
 		    }
 		  else if (strncmp (argv[i+1]->arg, "m", 1) == 0
-			   && strcmp (argv[i+1]->arg, "message-digest-") != 0)
+			   && !strmatch(argv[i + 1]->text, "message-digest-"))
 		    {
 		      /* "authentication message-digest" */ 
 		      vl_config.auth_type = OSPF_AUTH_CRYPTOGRAPHIC;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2185,7 +2185,7 @@ DEFUN (ipv6_route,
   int idx_curr;
   char *src, *tag, *distance, *vrf;
 
-  if (!strcmp(argv[3]->text, "from"))
+  if (strmatch(argv[3]->text, "from"))
     {
       src = argv[4]->arg;
       idx_ipv6_ifname = 5;
@@ -2234,7 +2234,7 @@ DEFUN (ipv6_route_flags,
   int idx_curr;
   char *src, *tag, *distance, *vrf;
 
-  if (!strcmp(argv[3]->text, "from"))
+  if (strmatch(argv[3]->text, "from"))
     {
       src = argv[4]->arg;
       idx_ipv6_ifname = 5;
@@ -2283,7 +2283,7 @@ DEFUN (ipv6_route_ifname,
   int idx_curr = 5;
   char *src, *tag, *distance, *vrf;
 
-  if (!strcmp(argv[3]->text, "from"))
+  if (strmatch(argv[3]->text, "from"))
     {
       src = argv[4]->arg;
       idx_ipv6 = 5;
@@ -2335,7 +2335,7 @@ DEFUN (ipv6_route_ifname_flags,
   int idx_curr;
   char *src, *tag, *distance, *vrf;
 
-  if (!strcmp(argv[3]->text, "from"))
+  if (strmatch(argv[3]->text, "from"))
     {
       src = argv[4]->arg;
       idx_ipv6 = 5;
@@ -2387,7 +2387,7 @@ DEFUN (no_ipv6_route,
   int idx_curr;
   char *src, *tag, *distance, *vrf;
 
-  if (!strcmp(argv[4]->text, "from"))
+  if (strmatch(argv[4]->text, "from"))
     {
       src = argv[5]->arg;
       idx_ipv6_ifname = 6;
@@ -2436,7 +2436,7 @@ DEFUN (no_ipv6_route_flags,
   int idx_curr;
   char *src, *tag, *distance, *vrf;
 
-  if (!strcmp(argv[4]->text, "from"))
+  if (strmatch(argv[4]->text, "from"))
     {
       src = argv[5]->arg;
       idx_ipv6_ifname = 6;
@@ -2486,7 +2486,7 @@ DEFUN (no_ipv6_route_ifname,
   int idx_curr;
   char *src, *tag, *distance, *vrf;
 
-  if (!strcmp(argv[4]->text, "from"))
+  if (strmatch(argv[4]->text, "from"))
     {
       src = argv[5]->arg;
       idx_ipv6 = 6;
@@ -2539,7 +2539,7 @@ DEFUN (no_ipv6_route_ifname_flags,
   int idx_curr;
   char *src, *tag, *distance, *vrf;
 
-  if (!strcmp(argv[4]->text, "from"))
+  if (strmatch(argv[4]->text, "from"))
     {
       src = argv[5]->arg;
       idx_ipv6 = 6;


### PR DESCRIPTION
plus some drive-by cli fixups for bgpd

spatch:

```

@asdf@
expression idx;
@@
<...
 strcmp (
- argv[idx]->arg,
+ argv[idx]->text,
  ...)
...>

@depends on asdf@
expression idx;
@@
<...
- !strcmp (argv[idx]->text,
+ strmatch (argv[idx]->text,
           ...)
...>

@depends on asdf@
expression idx;
expression arg;
@@
<...
- strcmp (argv[idx]->text, arg) == 0
+ strmatch (argv[idx]->text, arg)
...>

@depends on asdf@
expression idx;
expression arg;
@@
<...
- strcmp (argv[idx]->text, arg) != 0
+ !strmatch (argv[idx]->text, arg)
...>
```