### PR TITLE
vtysh: Sort ordering of vtysh_cmd.c

### DIFF
--- a/vtysh/extract.pl.in
+++ b/vtysh/extract.pl.in
@@ -198,7 +198,7 @@ foreach (keys %odefun) {
 }
 
 # Output DEFSH
-foreach (keys %live) {
+foreach (sort keys %live) {
     my ($proto);
     my ($key);
     $key = $live{$_};
@@ -213,7 +213,7 @@ vtysh_init_cmd ()
 {
 EOF
 
-foreach (keys %odefun) {
+foreach (sort keys %odefun) {
     my ($node, $str) = (split (/,/));
     $cmd = $ocmd{$_};
     $cmd =~ s/_cmd/_cmd_vtysh/;


### PR DESCRIPTION
When we created the vtysh_cmd.c file the vtysh_cmd.c output
is slightly different for every run, even when none of the
inputs have changed.

Add the ability to sort the output so that the output is
the same for every build.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>