### PR TITLE
redhat: Fix fallout from PR722 (accidently disabled PIMd on non-Redha…

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -67,8 +67,8 @@
 #### Check for RedHat 6.x or CentOS 6.x - they are too old to support PIM. 
 ####   Always disable it on these old systems unconditionally
 #
-# if CentOS 6 / RedHat 6, then disable PIMd
-%if 0%{?rhel} < 7
+# if CentOS / RedHat and version < 7, then disable PIMd (too old, won't work)
+%if 0%{?rhel} && 0%{?rhel} < 7
     %global  with_pimd  0
 %endif
 


### PR DESCRIPTION
PR722 (merged previously) accidently disabled PIMd for all non-Redhat/CentOS systems because of a bad check. rhel is undefined on Fedora Systems and 0%{?rhel} will evaluate to 0 which
was smaller than 7 --> disabling PIMd

This commit fixes it.

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>