### PR TITLE
ospfd: Bring in some OSPF changes lost during Quagga fork

### DIFF
--- a/doc/ospfd.texi
+++ b/doc/ospfd.texi
@@ -223,6 +223,7 @@ OSPF domain.
 @deffnx {OSPF Command} {network @var{a.b.c.d/m} area @var{<0-4294967295>}} {}
 @deffnx {OSPF Command} {no network @var{a.b.c.d/m} area @var{a.b.c.d}} {}
 @deffnx {OSPF Command} {no network @var{a.b.c.d/m} area @var{<0-4294967295>}} {}
+@anchor{OSPF network command}
 This command specifies the OSPF enabled interface(s).  If the interface has
 an address from range 192.168.1.0/24 then the command below enables ospf
 on this interface so router can provide network information to the other
@@ -246,6 +247,10 @@ Currently, if a peer prefix has been configured,
 then we test whether the prefix in the network command contains
 the destination prefix.  Otherwise, we test whether the network command prefix
 contains the local address prefix of the interface. 
+
+In some cases it may be more convenient to enable OSPF on a per
+interface/subnet basis (@pxref{OSPF ip ospf area command}).
+
 @end deffn
 
 @node OSPF area
@@ -412,6 +417,19 @@ settings will override any per-area authentication setting.
 
 @node OSPF interface
 @section OSPF interface
+
+@deffn {Interface Command} {ip ospf area @var{AREA} [@var{ADDR}]} {} 
+@deffnx {Interface Command} {no ip ospf area [@var{ADDR}]} {}
+@anchor{OSPF ip ospf area command}
+
+Enable OSPF on the interface, optionally restricted to just the IP address
+given by @var{ADDR}, putting it in the @var{AREA} area. Per interface area
+settings take precedence to network commands (@pxref{OSPF network command}).
+
+If you have a lot of interfaces, and/or a lot of subnets, then enabling OSPF
+via this command may result in a slight performance improvement.
+
+@end deffn
 
 @deffn {Interface Command} {ip ospf authentication-key @var{AUTH_KEY}} {}
 @deffnx {Interface Command} {no ip ospf authentication-key} {}

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -31,8 +31,17 @@
 #define IF_DEF_PARAMS(I) (IF_OSPF_IF_INFO (I)->def_params)
 #define IF_OIFS(I)  (IF_OSPF_IF_INFO (I)->oifs)
 #define IF_OIFS_PARAMS(I) (IF_OSPF_IF_INFO (I)->params)
-			    
+
+/* Despite the name, this macro probably is for specialist use only */
 #define OSPF_IF_PARAM_CONFIGURED(S, P) ((S) && (S)->P##__config)
+
+/* Test whether an OSPF interface parameter is set, generally, given some
+ * existing ospf interface
+ */
+#define OSPF_IF_PARAM_IS_SET(O,P) \
+      (OSPF_IF_PARAM_CONFIGURED ((O)->params, P) || \
+      OSPF_IF_PARAM_CONFIGURED(IF_DEF_PARAMS((O)->ifp)->P))
+
 #define OSPF_IF_PARAM(O, P) \
         (OSPF_IF_PARAM_CONFIGURED ((O)->params, P)?\
                         (O)->params->P:IF_DEF_PARAMS((O)->ifp)->P)

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7031,7 +7031,7 @@ DEFUN (ip_ospf_area,
 
   // Check if we have an address arg and proccess it
   if (argc == idx + 3) {
-    VTY_GET_IPV4_ADDRESS("interface address", addr, argv[(idx+2)]->arg);
+    inet_aton(argv[idx+2]->arg, &addr);
     // update/create address-level params
     params = ospf_get_if_params ((ifp), (addr));
     if (OSPF_IF_PARAM_CONFIGURED(params, if_area))
@@ -7091,7 +7091,7 @@ DEFUN (no_ip_ospf_area,
 
   // Check if we have an address arg and proccess it
   if (argc == idx + 3) {
-    VTY_GET_IPV4_ADDRESS("interface address", addr, argv[(idx+2)]->arg);
+    inet_aton(argv[idx+2]->arg, &addr);
     params = ospf_lookup_if_params (ifp, addr);
     if ((params) == NULL)
       return CMD_SUCCESS;

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -558,10 +558,11 @@ extern struct ospf_area *ospf_area_lookup_by_area_id (struct ospf *,
 extern void ospf_area_add_if (struct ospf_area *, struct ospf_interface *);
 extern void ospf_area_del_if (struct ospf_area *, struct ospf_interface *);
 
+extern void ospf_interface_area_set (struct interface *);
+extern void ospf_interface_area_unset (struct interface *);
+
 extern void ospf_route_map_init (void);
 
 extern void ospf_master_init (struct thread_master *master);
 
-extern int ospf_interface_set (struct interface *ifp, struct in_addr area_id);
-extern int ospf_interface_unset (struct interface *ifp);
 #endif /* _ZEBRA_OSPFD_H */


### PR DESCRIPTION
  Several changes were made from the original patch to resolve conflicts
  and also to fix various issues that were discovered during testing. Below
  is the original commit message minus a few parts that correspond to code
  that was dropped during bug fixing.

  Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>

  ospfd: Extend 'ip ospf area' to take address argument + rationalise ospf enable
* ospfd.c: (general) Clean up the whole running of OSPF on interfaces.
  (add_ospf_interface) taking (struct interface *) arg is pointless here.
  (ospf_is_ready) new helper.
  (ospf_network_run_subnet) Put all the code for choosing whether to enable
  OSPF on a subnet, and if so which area configuration to use, here. If a
  subnet should not be enabled, ensure an existing oi is freed.
  (ospf_network_run_interface) Just call run_subnet for all subnets on an
  interface.
  (ospf_network_run) Just call run_interface for all interfaces.
  (ospf_if_update) Just call run_interface for the given interface.
  (ospf_network_unset) Just call run_subnet for existing ois.
  (ospf_update_interface_area) helper: update area on an oi, or create it.
  (ospf_interface_set) renamed to ospf_interface_area_set for clarity.
  Ensures OSPF is created, then into if_update.
  (ospf_interface_unset) renamed to ospf_interface_area_unset and collapses
  down to simple loop to call run_subnet for all ois.
* ospf_interface.h: add a more general OSPF_IF_PARAM_IS_SET, which does the
  right thing and takes default config into account.
* doc/ospfd.texi: add 'ip ospf area' command.

  Acked-by: Donald Sharp <sharpd@cumulusnetworks.com>

  This patch has been part of Quagga since October 2015

  Orignial Author:    Paul Jakma <paul@quagga.net>
  Date:      Thu Aug 27 16:51:42 2009 +0100