### PR TITLE
bgpd, lib, zebra: Fix if_update function to represent what it does

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -581,7 +581,7 @@ bgp_interface_vrf_update (int command, struct zclient *zclient, zebra_size_t len
       }
   }
 
-  if_update (ifp, ifp->name, strlen (ifp->name), new_vrf_id);
+  if_update_to_new_vrf (ifp, new_vrf_id);
 
   bgp = bgp_lookup_by_vrf_id (new_vrf_id);
   if (!bgp)

--- a/lib/if.c
+++ b/lib/if.c
@@ -158,7 +158,7 @@ if_create (const char *name, int namelen, vrf_id_t vrf_id)
 
 /* Create new interface structure. */
 void
-if_update (struct interface *ifp, const char *name, int namelen, vrf_id_t vrf_id)
+if_update_to_new_vrf (struct interface *ifp, vrf_id_t vrf_id)
 {
   struct list *intf_list = vrf_iflist_get (vrf_id);
 
@@ -166,10 +166,6 @@ if_update (struct interface *ifp, const char *name, int namelen, vrf_id_t vrf_id
   if (vrf_iflist (ifp->vrf_id))
     listnode_delete (vrf_iflist (ifp->vrf_id), ifp);
 
-  assert (name);
-  assert (namelen <= INTERFACE_NAMSIZ);	/* Need space for '\0' at end. */
-  strncpy (ifp->name, name, namelen);
-  ifp->name[namelen] = '\0';
   ifp->vrf_id = vrf_id;
   if (if_lookup_by_name (ifp->name, vrf_id) == NULL)
     listnode_add_sort (intf_list, ifp);
@@ -453,7 +449,7 @@ if_get_by_name_len (const char *name, size_t namelen, vrf_id_t vrf_id, int vty)
                 }
 	      else
 		{
-		  if_update (ifp, name, namelen, vrf_id);
+		  if_update_to_new_vrf (ifp, vrf_id);
 		  return ifp;
 		}
 	    }

--- a/lib/if.h
+++ b/lib/if.h
@@ -393,8 +393,7 @@ struct nbr_connected
 /* Prototypes. */
 extern int if_cmp_name_func (char *, char *);
 
-extern void if_update (struct interface *, const char *name, int namelen,
-                       vrf_id_t vrf_id);
+extern void if_update_to_new_vrf (struct interface *, vrf_id_t vrf_id);
 extern struct interface *if_create (const char *name, int namelen,
                                     vrf_id_t vrf_id);
 extern struct interface *if_lookup_by_index (ifindex_t, vrf_id_t vrf_id);

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -774,7 +774,7 @@ netlink_link_change (struct sockaddr_nl *snl, struct nlmsghdr *h,
             {
               /* pre-configured interface, learnt now */
               if (ifp->vrf_id != vrf_id)
-                if_update (ifp, name, strlen(name), vrf_id);
+                if_update_to_new_vrf (ifp, vrf_id);
             }
 
           /* Update interface information. */

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -737,7 +737,7 @@ if_handle_vrf_change (struct interface *ifp, vrf_id_t vrf_id)
   zebra_interface_vrf_update_del (ifp, vrf_id);
 
   /* update VRF */
-  if_update (ifp, ifp->name, strlen (ifp->name), vrf_id);
+  if_update_to_new_vrf (ifp, vrf_id);
 
   /* Send out notification on interface VRF change. */
   /* This is to issue an ADD, if needed. */


### PR DESCRIPTION
The if_update function was taking the interface name as
input and reapplying it, using strncpy to reapply the name.
This has several issues.  strncpy should not be used
to copy memory in place.  The second issue is that
the interface name is not actually changing when we
update interface to be in the new vrf.

Since every usage of if_update was just reapplying the same
name the interface actually had, just remove that part of
the function and rename it to if_update_to_new_vrf
to represent what it is actually doing.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>