### PR TITLE
lib: always use 64-bit integers for json

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6405,7 +6405,7 @@ peer_uptime (time_t uptime2, char *buf, size_t len, u_char use_json, json_object
     {
       epoch_tbuf = time(NULL) - uptime1;
       json_object_string_add(json, "peerUptime", buf);
-      json_object_long_add(json, "peerUptimeMsec", uptime1 * 1000);
+      json_object_int_add(json, "peerUptimeMsec", uptime1 * 1000);
       json_object_int_add(json, "peerUptimeEstablishedEpoch", epoch_tbuf);
     }
 

--- a/lib/json.c
+++ b/lib/json.c
@@ -48,13 +48,7 @@ json_object_string_add(struct json_object* obj, const char *key,
 }
 
 void
-json_object_int_add(struct json_object* obj, const char *key, int32_t i)
-{
-  json_object_object_add(obj, key, json_object_new_int(i));
-}
-
-void
-json_object_long_add(struct json_object* obj, const char *key, int64_t i)
+json_object_int_add(struct json_object* obj, const char *key, int64_t i)
 {
 #if defined(HAVE_JSON_C_JSON_H)
   json_object_object_add(obj, key, json_object_new_int64(i));

--- a/lib/json.h
+++ b/lib/json.h
@@ -43,8 +43,6 @@ extern int use_json(const int argc, struct cmd_token *argv[]);
 extern void json_object_string_add(struct json_object* obj, const char *key,
                                    const char *s);
 extern void json_object_int_add(struct json_object* obj, const char *key,
-                                int32_t i);
-extern void json_object_long_add(struct json_object* obj, const char *key,
                                  int64_t i);
 extern void json_object_boolean_false_add(struct json_object* obj,
                                           const char *key);


### PR DESCRIPTION
json-c does not (yet) offer support for unsigned integer types, and
furthermore, the docs state that all integers are stored internally as
64-bit. So there's never a case in which we would want to limit,
implicitly or otherwise, the range of an integer when adding it to a
json object.

Among other things this fixes the display of ASN values greater than
(1/2) * (2^32 - 1)

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>