### PR TITLE
lib: printf bugfixes & improvement

### DIFF
--- a/lib/termtable.h
+++ b/lib/termtable.h
@@ -20,6 +20,8 @@
 #ifndef _TERMTABLE_H_
 #define _TERMTABLE_H_
 
+#include <zebra.h>
+
 enum ttable_align {
 	LEFT,
 	RIGHT,
@@ -131,7 +133,8 @@ void ttable_cell_del(struct ttable_cell *cell);
  * columns were specified
  */
 struct ttable_cell *ttable_insert_row(struct ttable *tt, unsigned int row,
-				      const char *format, ...);
+				      const char *format, ...)
+				      PRINTF_ATTRIBUTE(3, 4);
 /**
  * Inserts a new row at the end of the table.
  *
@@ -156,7 +159,8 @@ struct ttable_cell *ttable_insert_row(struct ttable *tt, unsigned int row,
  * @return pointer to the first cell in the created row, or NULL if not enough
  * columns were specified
  */
-struct ttable_cell *ttable_add_row(struct ttable *tt, const char *format, ...);
+struct ttable_cell *ttable_add_row(struct ttable *tt, const char *format, ...)
+				   PRINTF_ATTRIBUTE(2, 3);
 
 /**
  * Removes a row from the table.

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -271,7 +271,7 @@ DEFUN (show_thread_cpu,
     filter = parse_filter (argv[idx]->arg);
     if (!filter) {
       vty_outln(vty, "Invalid filter \"%s\" specified; must contain at least"
-                     "one of 'RWTEXB'%s", argv[idx]->arg);
+                     "one of 'RWTEXB'", argv[idx]->arg);
       return CMD_WARNING;
     }
   }
@@ -295,7 +295,7 @@ DEFUN (clear_thread_cpu,
     filter = parse_filter (argv[idx]->arg);
     if (!filter) {
       vty_outln(vty, "Invalid filter \"%s\" specified; must contain at least"
-                     "one of 'RWTEXB'%s", argv[idx]->arg);
+                     "one of 'RWTEXB'", argv[idx]->arg);
       return CMD_WARNING;
     }
   }

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -197,13 +197,6 @@ struct vty_arg
 #define IS_DIRECTORY_SEP(c) ((c) == DIRECTORY_SEP)
 #endif
 
-/* GCC have printf type attribute check.  */
-#ifdef __GNUC__
-#define PRINTF_ATTRIBUTE(a,b) __attribute__ ((__format__ (__printf__, a, b)))
-#else
-#define PRINTF_ATTRIBUTE(a,b)
-#endif /* __GNUC__ */
-
 /* Exported variables */
 extern char integrate_default[];
 

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -247,6 +247,12 @@ size_t strlcpy (char *__restrict dest, const char *__restrict src, size_t size);
 #endif /* HAVE_BROKEN_CMSG_FIRSTHDR */
 
 
+/* GCC have printf type attribute check.  */
+#ifdef __GNUC__
+#define PRINTF_ATTRIBUTE(a,b) __attribute__ ((__format__ (__printf__, a, b)))
+#else
+#define PRINTF_ATTRIBUTE(a,b)
+#endif /* __GNUC__ */
 
 /* 
  * RFC 3542 defines several macros for using struct cmsghdr.


### PR DESCRIPTION
* Fix bad format specifier in thread.[ch]
* Move PRINTF_ATTRIBUTE macro to zebra.h
* Use PRINTF_ATTRIBUTE on termtable printers

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>