### PR TITLE
*: simplify log message lookup [3.0]

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -78,9 +78,9 @@ static const struct message attr_str [] =
 #if ENABLE_BGP_VNC
   { BGP_ATTR_VNC,              "VNC" },
 #endif
-  { BGP_ATTR_LARGE_COMMUNITIES, "LARGE_COMMUNITY" }
+  { BGP_ATTR_LARGE_COMMUNITIES, "LARGE_COMMUNITY" },
+  { 0 }
 };
-static const int attr_str_max = array_size(attr_str);
 
 static const struct message attr_flag_str[] =
 {
@@ -89,6 +89,7 @@ static const struct message attr_flag_str[] =
   { BGP_ATTR_FLAG_PARTIAL,  "Partial" },
   /* bgp_attr_flags_diagnose() relies on this bit being last in this list */
   { BGP_ATTR_FLAG_EXTLEN,   "Extended Length" },
+  { 0 }
 };
 
 static struct hash *cluster_hash;
@@ -1253,7 +1254,7 @@ bgp_attr_flags_diagnose (struct bgp_attr_parser_args *args,
     )
     {
       zlog_err ("%s attribute must%s be flagged as \"%s\"",
-                LOOKUP (attr_str, attr_code),
+                lookup_msg(attr_str, attr_code, NULL),
                 CHECK_FLAG (desired_flags, attr_flag_str[i].key) ? "" : " not",
                 attr_flag_str[i].str);
       seen = 1;
@@ -1262,7 +1263,7 @@ bgp_attr_flags_diagnose (struct bgp_attr_parser_args *args,
     {
       zlog_debug ("Strange, %s called for attr %s, but no problem found with flags"
                   " (real flags 0x%x, desired 0x%x)",
-                  __func__, LOOKUP (attr_str, attr_code),
+                  __func__, lookup_msg(attr_str, attr_code, NULL),
                   real_flags, desired_flags);
     }
 }
@@ -1310,7 +1311,7 @@ bgp_attr_flag_invalid (struct bgp_attr_parser_args *args)
       && !CHECK_FLAG (BGP_ATTR_FLAG_TRANS, flags))
     {
       zlog_err ("%s well-known attributes must have transitive flag set (%x)",
-                LOOKUP (attr_str, attr_code), flags);
+                lookup_msg(attr_str, attr_code, NULL), flags);
       return 1;
     }
   
@@ -1323,7 +1324,7 @@ bgp_attr_flag_invalid (struct bgp_attr_parser_args *args)
         {
           zlog_err ("%s well-known attribute "
                     "must NOT have the partial flag set (%x)",
-                    LOOKUP (attr_str, attr_code), flags);
+                    lookup_msg(attr_str, attr_code, NULL), flags);
           return 1;
         }
       if (CHECK_FLAG (flags, BGP_ATTR_FLAG_OPTIONAL)
@@ -1331,7 +1332,7 @@ bgp_attr_flag_invalid (struct bgp_attr_parser_args *args)
         {
           zlog_err ("%s optional + transitive attribute "
                     "must NOT have the partial flag set (%x)",
-                    LOOKUP (attr_str, attr_code), flags);
+                    lookup_msg(attr_str, attr_code, NULL), flags);
           return 1;
         }
     }
@@ -2374,7 +2375,7 @@ bgp_attr_check (struct peer *peer, struct attr *attr)
   if (type)
     {
       zlog_warn ("%s Missing well-known attribute %s.", peer->host,
-                 LOOKUP (attr_str, type));
+                 lookup_msg(attr_str, type, NULL));
       bgp_notify_send_with_data (peer,
 				 BGP_NOTIFY_UPDATE_ERR,
 				 BGP_NOTIFY_UPDATE_MISS_ATTR,
@@ -2590,7 +2591,7 @@ bgp_attr_parse (struct peer *peer, struct attr *attr, bgp_size_t size,
         {
           zlog_warn ("%s: Attribute %s, parse error", 
                      peer->host, 
-                     LOOKUP (attr_str, type));
+                     lookup_msg(attr_str, type, NULL));
           if (as4_path)
             aspath_unintern (&as4_path);
           return ret;
@@ -2600,7 +2601,7 @@ bgp_attr_parse (struct peer *peer, struct attr *attr, bgp_size_t size,
           
           zlog_warn ("%s: Attribute %s, parse error - treating as withdrawal",
                      peer->host,
-                     LOOKUP (attr_str, type));
+                     lookup_msg(attr_str, type, NULL));
           if (as4_path)
             aspath_unintern (&as4_path);
           return ret;
@@ -2610,7 +2611,7 @@ bgp_attr_parse (struct peer *peer, struct attr *attr, bgp_size_t size,
       if (BGP_INPUT_PNT (peer) != attr_endp)
 	{
 	  zlog_warn ("%s: BGP attribute %s, fetch error",
-                     peer->host, LOOKUP (attr_str, type));
+                     peer->host, lookup_msg(attr_str, type, NULL));
 	  bgp_notify_send (peer, 
 			   BGP_NOTIFY_UPDATE_ERR, 
 			   BGP_NOTIFY_UPDATE_ATTR_LENG_ERR);
@@ -2624,7 +2625,7 @@ bgp_attr_parse (struct peer *peer, struct attr *attr, bgp_size_t size,
   if (BGP_INPUT_PNT (peer) != endp)
     {
       zlog_warn ("%s: BGP attribute %s, length mismatch",
-	         peer->host, LOOKUP (attr_str, type));
+	         peer->host, lookup_msg(attr_str, type, NULL));
       bgp_notify_send (peer, 
 		       BGP_NOTIFY_UPDATE_ERR, 
 		       BGP_NOTIFY_UPDATE_ATTR_LENG_ERR);

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -85,8 +85,8 @@ const struct message bgp_status_msg[] =
   { Established, "Established" },
   { Clearing,    "Clearing"    },
   { Deleted,     "Deleted"     },
+  { 0 }
 };
-const int bgp_status_msg_max = BGP_STATUS_MAX;
 
 /* BGP message type string. */
 const char *bgp_type_str[] =
@@ -110,16 +110,16 @@ static const struct message bgp_notify_msg[] =
   { BGP_NOTIFY_FSM_ERR, "Neighbor Events Error"},
   { BGP_NOTIFY_CEASE, "Cease"},
   { BGP_NOTIFY_CAPABILITY_ERR, "CAPABILITY Message Error"},
+  { 0 }
 };
-static const int bgp_notify_msg_max = BGP_NOTIFY_MAX;
 
 static const struct message bgp_notify_head_msg[] = 
 {
   { BGP_NOTIFY_HEADER_NOT_SYNC, "/Connection Not Synchronized"},
   { BGP_NOTIFY_HEADER_BAD_MESLEN, "/Bad Message Length"},
-  { BGP_NOTIFY_HEADER_BAD_MESTYPE, "/Bad Message Type"}
+  { BGP_NOTIFY_HEADER_BAD_MESTYPE, "/Bad Message Type"},
+  { 0 }
 };
-static const int bgp_notify_head_msg_max = BGP_NOTIFY_HEADER_MAX;
 
 static const struct message bgp_notify_open_msg[] = 
 {
@@ -131,8 +131,8 @@ static const struct message bgp_notify_open_msg[] =
   { BGP_NOTIFY_OPEN_AUTH_FAILURE, "/Authentication Failure"},
   { BGP_NOTIFY_OPEN_UNACEP_HOLDTIME, "/Unacceptable Hold Time"}, 
   { BGP_NOTIFY_OPEN_UNSUP_CAPBL, "/Unsupported Capability"},
+  { 0 }
 };
-static const int bgp_notify_open_msg_max = BGP_NOTIFY_OPEN_MAX;
 
 static const struct message bgp_notify_update_msg[] = 
 {
@@ -148,8 +148,8 @@ static const struct message bgp_notify_update_msg[] =
   { BGP_NOTIFY_UPDATE_OPT_ATTR_ERR, "/Optional Attribute Error"},
   { BGP_NOTIFY_UPDATE_INVAL_NETWORK, "/Invalid Network Field"},
   { BGP_NOTIFY_UPDATE_MAL_AS_PATH, "/Malformed AS_PATH"},
+  { 0 }
 };
-static const int bgp_notify_update_msg_max = BGP_NOTIFY_UPDATE_MAX;
 
 static const struct message bgp_notify_cease_msg[] =
 {
@@ -162,8 +162,8 @@ static const struct message bgp_notify_cease_msg[] =
   { BGP_NOTIFY_CEASE_CONFIG_CHANGE, "/Other Configuration Change"},
   { BGP_NOTIFY_CEASE_COLLISION_RESOLUTION, "/Connection collision resolution"},
   { BGP_NOTIFY_CEASE_OUT_OF_RESOURCE, "/Out of Resource"},
+  { 0 }
 };
-static const int bgp_notify_cease_msg_max = BGP_NOTIFY_CEASE_MAX;
 
 static const struct message bgp_notify_capability_msg[] = 
 {
@@ -171,8 +171,8 @@ static const struct message bgp_notify_capability_msg[] =
   { BGP_NOTIFY_CAPABILITY_INVALID_ACTION, "/Invalid Action Value" },
   { BGP_NOTIFY_CAPABILITY_INVALID_LENGTH, "/Invalid Capability Length"},
   { BGP_NOTIFY_CAPABILITY_MALFORMED_CODE, "/Malformed Capability Value"},
+  { 0 }
 };
-static const int bgp_notify_capability_msg_max = BGP_NOTIFY_CAPABILITY_MAX;
 
 /* Origin strings. */
 const char *bgp_origin_str[] = {"i","e","?"};
@@ -457,7 +457,7 @@ bgp_dump_attr (struct peer *peer, struct attr *attr, char *buf, size_t size)
 const char *
 bgp_notify_code_str (char code)
 {
-  return LOOKUP_DEF (bgp_notify_msg, code, "Unrecognized Error Code");
+  return lookup_msg (bgp_notify_msg, code, "Unrecognized Error Code");
 }
 
 const char *
@@ -467,23 +467,23 @@ bgp_notify_subcode_str (char code, char subcode)
   switch (code)
     {
     case BGP_NOTIFY_HEADER_ERR:
-      return LOOKUP_DEF (bgp_notify_head_msg, subcode,
+      return lookup_msg (bgp_notify_head_msg, subcode,
                          "Unrecognized Error Subcode");
     case BGP_NOTIFY_OPEN_ERR:
-      return LOOKUP_DEF (bgp_notify_open_msg, subcode,
+      return lookup_msg (bgp_notify_open_msg, subcode,
                          "Unrecognized Error Subcode");
     case BGP_NOTIFY_UPDATE_ERR:
-      return LOOKUP_DEF (bgp_notify_update_msg, subcode,
+      return lookup_msg (bgp_notify_update_msg, subcode,
                          "Unrecognized Error Subcode");
     case BGP_NOTIFY_HOLD_ERR:
       break;
     case BGP_NOTIFY_FSM_ERR:
       break;
     case BGP_NOTIFY_CEASE:
-      return LOOKUP_DEF (bgp_notify_cease_msg, subcode,
+      return lookup_msg (bgp_notify_cease_msg, subcode,
                          "Unrecognized Error Subcode");
     case BGP_NOTIFY_CAPABILITY_ERR:
-      return LOOKUP_DEF (bgp_notify_capability_msg, subcode,
+      return lookup_msg (bgp_notify_capability_msg, subcode,
                          "Unrecognized Error Subcode");
     }
   return "";

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -145,7 +145,6 @@ extern const char *bgp_notify_subcode_str(char, char);
 extern void bgp_notify_print (struct peer *, struct bgp_notify *, const char *);
 
 extern const struct message bgp_status_msg[];
-extern const int bgp_status_msg_max;
 extern int bgp_debug_neighbor_events(struct peer *peer);
 extern int bgp_debug_keepalive(struct peer *peer);
 extern int bgp_debug_update(struct peer *peer, struct prefix *p,

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -972,8 +972,8 @@ bgp_fsm_change_status (struct peer *peer, int status)
   if (bgp_debug_neighbor_events(peer))
     zlog_debug ("%s went from %s to %s",
 		peer->host,
-		LOOKUP (bgp_status_msg, peer->ostatus),
-		LOOKUP (bgp_status_msg, peer->status));
+		lookup_msg(bgp_status_msg, peer->ostatus, NULL),
+		lookup_msg(bgp_status_msg, peer->status, NULL));
 }
 
 /* Flush the event queue and ensure the peer is shut down */
@@ -1412,7 +1412,7 @@ static int
 bgp_fsm_event_error (struct peer *peer)
 {
   zlog_err ("%s [FSM] unexpected packet received in state %s",
-	    peer->host, LOOKUP (bgp_status_msg, peer->status));
+	    peer->host, lookup_msg(bgp_status_msg, peer->status, NULL));
 
   return bgp_stop_with_notify (peer, BGP_NOTIFY_FSM_ERR, 0);
 }
@@ -1598,7 +1598,7 @@ bgp_ignore (struct peer *peer)
 {
   zlog_err ("%s [FSM] Ignoring event %s in state %s, prior events %s, %s, fd %d",
              peer->host, bgp_event_str[peer->cur_event],
-	     LOOKUP (bgp_status_msg, peer->status),
+	     lookup_msg(bgp_status_msg, peer->status, NULL),
              bgp_event_str[peer->last_event],
              bgp_event_str[peer->last_major_event], peer->fd);
   return 0;
@@ -1610,7 +1610,7 @@ bgp_fsm_exeption (struct peer *peer)
 {
   zlog_err ("%s [FSM] Unexpected event %s in state %s, prior events %s, %s, fd %d",
              peer->host, bgp_event_str[peer->cur_event],
-	     LOOKUP (bgp_status_msg, peer->status),
+	     lookup_msg(bgp_status_msg, peer->status, NULL),
              bgp_event_str[peer->last_event],
              bgp_event_str[peer->last_major_event], peer->fd);
   return(bgp_stop (peer));
@@ -1836,8 +1836,8 @@ bgp_event_update (struct peer *peer, int event)
   if (bgp_debug_neighbor_events(peer) && peer->status != next)
     zlog_debug ("%s [FSM] %s (%s->%s), fd %d", peer->host,
 	       bgp_event_str[event],
-	       LOOKUP (bgp_status_msg, peer->status),
-	       LOOKUP (bgp_status_msg, next), peer->fd);
+	       lookup_msg(bgp_status_msg, peer->status, NULL),
+	       lookup_msg(bgp_status_msg, next, NULL), peer->fd);
 
   peer->last_event = peer->cur_event;
   peer->cur_event = event;
@@ -1872,7 +1872,7 @@ bgp_event_update (struct peer *peer, int event)
       zlog_err ("%s [FSM] Failure handling event %s in state %s, "
                  "prior events %s, %s, fd %d",
                  peer->host, bgp_event_str[peer->cur_event],
-	         LOOKUP (bgp_status_msg, peer->status),
+	         lookup_msg(bgp_status_msg, peer->status, NULL),
                  bgp_event_str[peer->last_event],
                  bgp_event_str[peer->last_major_event], peer->fd);
       bgp_stop (peer);

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -245,16 +245,16 @@ static const struct message orf_type_str[] =
 {
   { ORF_TYPE_PREFIX,		"Prefixlist"		},
   { ORF_TYPE_PREFIX_OLD,	"Prefixlist (old)"	},
+  { 0 }
 };
-static const int orf_type_str_max = array_size(orf_type_str);
 
 static const struct message orf_mode_str[] =
 {
   { ORF_MODE_RECEIVE,	"Receive"	},
   { ORF_MODE_SEND,	"Send"		},
   { ORF_MODE_BOTH,	"Both"		},
+  { 0 }
 };
-static const int orf_mode_str_max = array_size(orf_mode_str);
 
 static int
 bgp_capability_orf_entry (struct peer *peer, struct capability_header *hdr)
@@ -359,8 +359,8 @@ bgp_capability_orf_entry (struct peer *peer, struct capability_header *hdr)
       if (bgp_debug_neighbor_events(peer))
         zlog_debug ("%s OPEN has %s ORF capability"
                     " as %s for afi/safi: %d/%d",
-                    peer->host, LOOKUP (orf_type_str, type),
-                    LOOKUP (orf_mode_str, mode),
+                    peer->host, lookup_msg(orf_type_str, type, NULL),
+                    lookup_msg(orf_mode_str, mode, NULL),
                     pkt_afi, pkt_safi);
 
       if (hdr->code == CAPABILITY_CODE_ORF)
@@ -709,9 +709,9 @@ bgp_capability_hostname (struct peer *peer, struct capability_header *hdr)
   { CAPABILITY_CODE_DYNAMIC_OLD,	"Dynamic (Old)"			},
   { CAPABILITY_CODE_REFRESH_OLD,	"Route Refresh (Old)"		},
   { CAPABILITY_CODE_ORF_OLD,		"ORF (Old)"			},
-  { CAPABILITY_CODE_FQDN,               "FQDN"                          },
+  { CAPABILITY_CODE_FQDN,               "FQDN"				},
+  { 0 }
 };
-static const int capcode_str_max = array_size(capcode_str);
 
 /* Minimum sizes for length field of each cap (so not inc. the header) */
 static const size_t cap_minsizes[] = 
@@ -798,7 +798,7 @@ bgp_capability_parse (struct peer *peer, size_t length, int *mp_capability,
       if (bgp_debug_neighbor_events(peer))
 	zlog_debug ("%s OPEN has %s capability (%u), length %u",
 		   peer->host,
-		   LOOKUP (capcode_str, caphdr.code),
+		   lookup_msg(capcode_str, caphdr.code, NULL),
 		   caphdr.code, caphdr.length);
       
       /* Length sanity check, type-specific, for known capabilities */
@@ -822,7 +822,7 @@ bgp_capability_parse (struct peer *peer, size_t length, int *mp_capability,
                   zlog_info ("%s %s Capability length error: got %u,"
                              " expected at least %u",
                              peer->host, 
-                             LOOKUP (capcode_str, caphdr.code),
+                             lookup_msg(capcode_str, caphdr.code, NULL),
                              caphdr.length, 
 			     (unsigned) cap_minsizes[caphdr.code]);
                   bgp_notify_send (peer, BGP_NOTIFY_OPEN_ERR, BGP_NOTIFY_OPEN_MALFORMED_ATTR);
@@ -834,7 +834,7 @@ bgp_capability_parse (struct peer *peer, size_t length, int *mp_capability,
                   zlog_info ("%s %s Capability length error: got %u,"
                              " expected a multiple of %u",
                              peer->host,
-                             LOOKUP (capcode_str, caphdr.code),
+                             lookup_msg(capcode_str, caphdr.code, NULL),
                              caphdr.length,
 			     (unsigned) cap_modsizes[caphdr.code]);
                   bgp_notify_send (peer, BGP_NOTIFY_OPEN_ERR,
@@ -933,7 +933,7 @@ bgp_capability_parse (struct peer *peer, size_t length, int *mp_capability,
         {
           if (stream_get_getp(s) > (start + caphdr.length))
             zlog_warn ("%s Cap-parser for %s read past cap-length, %u!",
-                       peer->host, LOOKUP (capcode_str, caphdr.code),
+                       peer->host, lookup_msg(capcode_str, caphdr.code, NULL),
                        caphdr.length);
           stream_set_getp (s, start + caphdr.length);
         }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1377,7 +1377,7 @@ bgp_update_receive (struct peer *peer, bgp_size_t size)
   if (peer->status != Established) 
     {
       zlog_err ("%s [FSM] Update packet received under status %s",
-		peer->host, LOOKUP (bgp_status_msg, peer->status));
+		peer->host, lookup_msg(bgp_status_msg, peer->status, NULL));
       bgp_notify_send (peer, BGP_NOTIFY_FSM_ERR, 0);
       return -1;
     }
@@ -1743,7 +1743,7 @@ bgp_route_refresh_receive (struct peer *peer, bgp_size_t size)
   if (peer->status != Established) 
     {
       zlog_err ("%s [Error] Route refresh packet received under status %s",
-		peer->host, LOOKUP (bgp_status_msg, peer->status));
+		peer->host, lookup_msg(bgp_status_msg, peer->status, NULL));
       bgp_notify_send (peer, BGP_NOTIFY_FSM_ERR, 0);
       return;
     }
@@ -2072,7 +2072,7 @@ bgp_capability_receive (struct peer *peer, bgp_size_t size)
   if (peer->status != Established)
     {
       zlog_err ("%s [Error] Dynamic capability packet received under status %s",
-                peer->host, LOOKUP (bgp_status_msg, peer->status));
+                peer->host, lookup_msg(bgp_status_msg, peer->status, NULL));
       bgp_notify_send (peer, BGP_NOTIFY_FSM_ERR, 0);
       return -1;
     }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6545,7 +6545,7 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
               else if (CHECK_FLAG (peer->sflags, PEER_STATUS_PREFIX_OVERFLOW))
                 json_object_string_add(json_peer, "state", "Idle (PfxCt)");
               else
-                json_object_string_add(json_peer, "state", LOOKUP(bgp_status_msg, peer->status));
+                json_object_string_add(json_peer, "state", lookup_msg(bgp_status_msg, peer->status, NULL));
 
               if (peer->conf_if)
                 json_object_string_add(json_peer, "idType", "interface");
@@ -6597,7 +6597,7 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
                   else if (CHECK_FLAG (peer->sflags, PEER_STATUS_PREFIX_OVERFLOW))
                     vty_out (vty, " Idle (PfxCt)");
                   else
-                    vty_out (vty, " %12s", LOOKUP(bgp_status_msg, peer->status));
+                    vty_out (vty, " %12s", lookup_msg(bgp_status_msg, peer->status, NULL));
                 }
               vty_out (vty, "%s", VTY_NEWLINE);
             }
@@ -7576,7 +7576,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         json_object_boolean_true_add(json_neigh, "nbrCommonAdmin");
 
       /* Status. */
-      json_object_string_add(json_neigh, "bgpState", LOOKUP (bgp_status_msg, p->status));
+      json_object_string_add(json_neigh, "bgpState", lookup_msg(bgp_status_msg, p->status, NULL));
 
       if (p->status == Established)
         {
@@ -7649,7 +7649,7 @@ bgp_show_peer (struct vty *vty, struct peer *p, u_char use_json, json_object *js
         vty_out (vty, "  Neighbor under common administration%s", VTY_NEWLINE);
 
       /* Status. */
-      vty_out (vty, "  BGP state = %s", LOOKUP (bgp_status_msg, p->status));
+      vty_out (vty, "  BGP state = %s", lookup_msg(bgp_status_msg, p->status, NULL));
 
       if (p->status == Established)
         vty_out (vty, ", up for %8s", peer_uptime (p->uptime, timebuf, BGP_UPTIME_LEN, 0, NULL));
@@ -9350,7 +9350,7 @@ bgp_show_one_peer_group (struct vty *vty, struct peer_group *group)
           else if (CHECK_FLAG (peer->sflags, PEER_STATUS_PREFIX_OVERFLOW))
             peer_status = "Idle (PfxCt)";
           else
-            peer_status = LOOKUP(bgp_status_msg, peer->status);
+            peer_status = lookup_msg(bgp_status_msg, peer->status, NULL);
 
           dynamic = peer_dynamic_neighbor(peer);
           vty_out (vty, "    %s %s %s %s",

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -988,7 +988,6 @@ struct bgp_nlri
 #define BGP_NOTIFY_FSM_ERR                       5
 #define BGP_NOTIFY_CEASE                         6
 #define BGP_NOTIFY_CAPABILITY_ERR                7
-#define BGP_NOTIFY_MAX	                         8
 
 #define BGP_NOTIFY_SUBCODE_UNSPECIFIC            0
 
@@ -996,7 +995,6 @@ struct bgp_nlri
 #define BGP_NOTIFY_HEADER_NOT_SYNC               1
 #define BGP_NOTIFY_HEADER_BAD_MESLEN             2
 #define BGP_NOTIFY_HEADER_BAD_MESTYPE            3
-#define BGP_NOTIFY_HEADER_MAX                    4
 
 /* BGP_NOTIFY_OPEN_ERR sub codes.  */
 #define BGP_NOTIFY_OPEN_MALFORMED_ATTR           0
@@ -1007,7 +1005,6 @@ struct bgp_nlri
 #define BGP_NOTIFY_OPEN_AUTH_FAILURE             5
 #define BGP_NOTIFY_OPEN_UNACEP_HOLDTIME          6
 #define BGP_NOTIFY_OPEN_UNSUP_CAPBL              7
-#define BGP_NOTIFY_OPEN_MAX                      8
 
 /* BGP_NOTIFY_UPDATE_ERR sub codes.  */
 #define BGP_NOTIFY_UPDATE_MAL_ATTR               1
@@ -1021,7 +1018,6 @@ struct bgp_nlri
 #define BGP_NOTIFY_UPDATE_OPT_ATTR_ERR           9
 #define BGP_NOTIFY_UPDATE_INVAL_NETWORK         10
 #define BGP_NOTIFY_UPDATE_MAL_AS_PATH           11
-#define BGP_NOTIFY_UPDATE_MAX                   12
 
 /* BGP_NOTIFY_CEASE sub codes (RFC 4486).  */
 #define BGP_NOTIFY_CEASE_MAX_PREFIX              1
@@ -1032,13 +1028,11 @@ struct bgp_nlri
 #define BGP_NOTIFY_CEASE_CONFIG_CHANGE           6
 #define BGP_NOTIFY_CEASE_COLLISION_RESOLUTION    7
 #define BGP_NOTIFY_CEASE_OUT_OF_RESOURCE         8
-#define BGP_NOTIFY_CEASE_MAX                     9
 
 /* BGP_NOTIFY_CAPABILITY_ERR sub codes (draft-ietf-idr-dynamic-cap-02). */
 #define BGP_NOTIFY_CAPABILITY_INVALID_ACTION     1
 #define BGP_NOTIFY_CAPABILITY_INVALID_LENGTH     2
 #define BGP_NOTIFY_CAPABILITY_MALFORMED_CODE     3
-#define BGP_NOTIFY_CAPABILITY_MAX                4
 
 /* BGP finite state machine status.  */
 #define Idle                                     1

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -3244,7 +3244,7 @@ rfapiBgpInfoFilteredImportEncap (
   rn = route_node_lookup (rt, p);
 
 #if DEBUG_ENCAP_MONITOR
-  vnc_zlog_debug_verbose ("%s: initial encap lookup (it=%p) rn=%p",
+  vnc_zlog_debug_verbose ("%s: initial encap lookup(it=%p) rn=%p",
               __func__, import_table, rn);
 #endif
 

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -504,9 +504,8 @@ struct message tokennames[] = {
   item(JOIN_TKN),
   item(START_TKN),        // first token in line
   item(END_TKN),          // last token in line
-  { 0, NULL }
+  { 0 }
 };
-size_t tokennames_max = array_size(tokennames);
 
 /**
  * Pretty-prints a graph, assuming it is a tree.
@@ -523,7 +522,7 @@ pretty_print_graph (struct vty *vty, struct graph_node *start, int level,
   struct cmd_token *tok = start->data;
 
   snprintf(tokennum, sizeof(tokennum), "%d?", tok->type);
-  vty_out(vty, "%s", LOOKUP_DEF(tokennames, tok->type, tokennum));
+  vty_out(vty, "%s", lookup_msg(tokennames, tok->type, NULL));
   if (tok->text)
     vty_out(vty, ":\"%s\"", tok->text);
   if (desc)
@@ -590,7 +589,7 @@ pretty_print_dot (FILE *ofd, unsigned opts, struct graph_node *start,
   snprintf(tokennum, sizeof(tokennum), "%d?", tok->type);
   fprintf(ofd, "  n%p [ shape=box, label=<", start);
 
-  fprintf(ofd, "<b>%s</b>", LOOKUP_DEF(tokennames, tok->type, tokennum));
+  fprintf(ofd, "<b>%s</b>", lookup_msg(tokennames, tok->type, NULL));
   if (tok->attr == CMD_ATTR_DEPRECATED)
     fprintf(ofd, " (d)");
   else if (tok->attr == CMD_ATTR_HIDDEN)

--- a/lib/log.c
+++ b/lib/log.c
@@ -86,8 +86,33 @@ static void write_wrapper (int fd, const void *buf, size_t count)
   return;
 }
 
-/* For time string format. */
+/**
+ * Looks up a message in a message list by key.
+ *
+ * If the message is not found, returns the provided error message.
+ *
+ * Terminates when it hits a struct message that's all zeros.
+ *
+ * @param mz the message list
+ * @param kz the message key
+ * @param nf the message to return if not found
+ * @return the message
+ */
+const char *
+lookup_msg(const struct message *mz, int kz, const char *nf)
+{
+  static struct message nt = { 0 };
+  const char *rz = nf ? nf : "(no message found)";
+  const struct message *pnt;
+  for (pnt = mz; memcmp(pnt, &nt, sizeof(struct message)); pnt++)
+    if (pnt->key == kz) {
+      rz = pnt->str ? pnt->str : rz;
+      break;
+    }
+  return rz;
+}
 
+/* For time string format. */
 size_t
 quagga_timestamp(int timestamp_precision, char *buf, size_t buflen)
 {
@@ -845,61 +870,6 @@ zlog_rotate (void)
     }
 
   return 1;
-}
-
-/* Message lookup function. */
-const char *
-lookup (const struct message *mes, int key)
-{
-  const struct message *pnt;
-
-  for (pnt = mes; pnt->key != 0; pnt++) 
-    if (pnt->key == key) 
-      return pnt->str;
-
-  return "";
-}
-
-/* Older/faster version of message lookup function, but requires caller to pass
- * in the array size (instead of relying on a 0 key to terminate the search). 
- *
- * The return value is the message string if found, or the 'none' pointer
- * provided otherwise.
- */
-const char *
-mes_lookup (const struct message *meslist, int max, int index,
-  const char *none, const char *mesname)
-{
-  int pos = index - meslist[0].key;
-  
-  /* first check for best case: index is in range and matches the key
-   * value in that slot.
-   * NB: key numbering might be offset from 0. E.g. protocol constants
-   * often start at 1.
-   */
-  if ((pos >= 0) && (pos < max)
-      && (meslist[pos].key == index))
-    return meslist[pos].str;
-
-  /* fall back to linear search */
-  {
-    int i;
-
-    for (i = 0; i < max; i++, meslist++)
-      {
-	if (meslist->key == index)
-	  {
-	    const char *str = (meslist->str ? meslist->str : none);
-	    
-	    zlog_debug ("message index %d [%s] found in %s at position %d (max is %d)",
-		      index, str, mesname, i, max);
-	    return str;
-	  }
-      }
-  }
-  zlog_err("message index %d not found in %s (max is %d)", index, mesname, max);
-  assert (none);
-  return none;
 }
 
 /* Wrapper around strerror to handle case where it returns NULL. */

--- a/lib/log.h
+++ b/lib/log.h
@@ -101,14 +101,7 @@ extern int zlog_reset_file (void);
 /* Rotate log. */
 extern int zlog_rotate (void);
 
-/* For hackey message lookup and check */
-#define LOOKUP_DEF(x, y, def) mes_lookup(x, x ## _max, y, def, #x)
-#define LOOKUP(x, y) LOOKUP_DEF(x, y, "(no item found)")
-
-extern const char *lookup (const struct message *, int);
-extern const char *mes_lookup (const struct message *meslist, 
-                               int max, int index,
-                               const char *no_item, const char *mesname);
+const char *lookup_msg (const struct message *mz, int kz, const char *nf);
 
 /* Safe version of strerror -- never returns NULL. */
 extern const char *safe_strerror(int errnum);

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -46,14 +46,14 @@ static const struct message debug_flags_desc[] = {
 	{ NHRP_DEBUG_ROUTE, "route" },
 	{ NHRP_DEBUG_VICI, "vici" },
 	{ NHRP_DEBUG_EVENT, "event" },
-	{ 0, NULL },
+	{ 0 }
 };
 
 static const struct message interface_flags_desc[] = {
 	{ NHRP_IFF_SHORTCUT, "shortcut" },
 	{ NHRP_IFF_REDIRECT, "redirect" },
 	{ NHRP_IFF_REG_NO_UNIQUE, "registration no-unique" },
-	{ 0, NULL },
+	{ 0 }
 };
 
 static int nhrp_vty_return(struct vty *vty, int ret)

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -57,8 +57,8 @@ static const struct message ospf6_message_type_str [] =
   { OSPF6_MESSAGE_TYPE_LSREQ,    "LSReq"    },
   { OSPF6_MESSAGE_TYPE_LSUPDATE, "LSUpdate" },
   { OSPF6_MESSAGE_TYPE_LSACK,    "LSAck"    },
+  { 0 }
 };
-static const size_t ospf6_message_type_str_max = array_size(ospf6_message_type_str);
 
 /* Minimum (besides the standard OSPF packet header) lengths for OSPF
    packets of particular types, offset is the "type" field. */
@@ -1211,7 +1211,7 @@ ospf6_packet_examin (struct ospf6_header *oh, const unsigned bytesonwire)
   {
     if (IS_OSPF6_DEBUG_MESSAGE (OSPF6_MESSAGE_TYPE_UNKNOWN, RECV))
       zlog_debug ("%s: undersized (%u B) %s packet", __func__,
-                  bytesonwire, LOOKUP (ospf6_message_type_str, oh->type));
+                  bytesonwire, lookup_msg(ospf6_message_type_str, oh->type, NULL));
     return MSG_NG;
   }
   /* type-specific deeper validation */
@@ -1224,7 +1224,7 @@ ospf6_packet_examin (struct ospf6_header *oh, const unsigned bytesonwire)
       return MSG_OK;
     if (IS_OSPF6_DEBUG_MESSAGE (OSPF6_MESSAGE_TYPE_UNKNOWN, RECV))
       zlog_debug ("%s: alignment error in %s packet",
-                  __func__, LOOKUP (ospf6_message_type_str, oh->type));
+                  __func__, lookup_msg(ospf6_message_type_str, oh->type, NULL));
     return MSG_NG;
   case OSPF6_MESSAGE_TYPE_DBDESC:
     /* RFC5340 A.3.3, packet header + OSPF6_DB_DESC_MIN_SIZE bytes followed
@@ -1243,7 +1243,7 @@ ospf6_packet_examin (struct ospf6_header *oh, const unsigned bytesonwire)
       return MSG_OK;
     if (IS_OSPF6_DEBUG_MESSAGE (OSPF6_MESSAGE_TYPE_UNKNOWN, RECV))
       zlog_debug ("%s: alignment error in %s packet",
-                  __func__, LOOKUP (ospf6_message_type_str, oh->type));
+                  __func__, lookup_msg(ospf6_message_type_str, oh->type, NULL));
     return MSG_NG;
   case OSPF6_MESSAGE_TYPE_LSUPDATE:
     /* RFC5340 A.3.5, packet header + OSPF6_LS_UPD_MIN_SIZE bytes followed
@@ -1273,7 +1273,7 @@ ospf6_packet_examin (struct ospf6_header *oh, const unsigned bytesonwire)
     return MSG_NG;
   }
   if (test != MSG_OK && IS_OSPF6_DEBUG_MESSAGE (OSPF6_MESSAGE_TYPE_UNKNOWN, RECV))
-    zlog_debug ("%s: anomaly in %s packet", __func__, LOOKUP (ospf6_message_type_str, oh->type));
+    zlog_debug ("%s: anomaly in %s packet", __func__, lookup_msg(ospf6_message_type_str, oh->type, NULL));
   return test;
 }
 
@@ -1581,7 +1581,7 @@ ospf6_receive (struct thread *thread)
       inet_ntop (AF_INET6, &src, srcname, sizeof (srcname));
       inet_ntop (AF_INET6, &dst, dstname, sizeof (dstname));
       zlog_debug ("%s received on %s",
-                 LOOKUP (ospf6_message_type_str, oh->type), oi->interface->name);
+                 lookup_msg(ospf6_message_type_str, oh->type, NULL), oi->interface->name);
       zlog_debug ("    src: %s", srcname);
       zlog_debug ("    dst: %s", dstname);
 
@@ -1669,7 +1669,7 @@ ospf6_send (struct in6_addr *src, struct in6_addr *dst,
       else
         memset (srcname, 0, sizeof (srcname));
       zlog_debug ("%s send on %s",
-                 LOOKUP (ospf6_message_type_str, oh->type), oi->interface->name);
+                 lookup_msg(ospf6_message_type_str, oh->type, NULL), oi->interface->name);
       zlog_debug ("    src: %s", srcname);
       zlog_debug ("    dst: %s", dstname);
 

--- a/ospfclient/ospfclient.c
+++ b/ospfclient/ospfclient.c
@@ -252,7 +252,7 @@ ism_change_callback (struct in_addr ifaddr, struct in_addr area_id,
 {
   printf ("ism_change: ifaddr: %s ", inet_ntoa (ifaddr));
   printf ("area_id: %s\n", inet_ntoa (area_id));
-  printf ("state: %d [%s]\n", state, LOOKUP (ospf_ism_state_msg, state));
+  printf ("state: %d [%s]\n", state, lookup_msg(ospf_ism_state_msg, state, NULL));
 }
 
 static void
@@ -262,7 +262,7 @@ nsm_change_callback (struct in_addr ifaddr, struct in_addr nbraddr,
   printf ("nsm_change: ifaddr: %s ", inet_ntoa (ifaddr));
   printf ("nbraddr: %s\n", inet_ntoa (nbraddr));
   printf ("router_id: %s\n", inet_ntoa (router_id));
-  printf ("state: %d [%s]\n", state, LOOKUP (ospf_nsm_state_msg, state));
+  printf ("state: %d [%s]\n", state, lookup_msg(ospf_nsm_state_msg, state, NULL));
 }
 
 

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -154,8 +154,8 @@ ospf_nbr_state_message (struct ospf_neighbor *nbr, char *buf, size_t size)
   memset (buf, 0, size);
 
   snprintf (buf, size, "%s/%s",
-	    LOOKUP (ospf_nsm_state_msg, nbr->state),
-	    LOOKUP (ospf_ism_state_msg, state));
+	    lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
+	    lookup_msg(ospf_ism_state_msg, state, NULL));
 }
 
 const char *
@@ -560,12 +560,12 @@ ospf_header_dump (struct ospf_header *ospfh)
   zlog_debug ("Header");
   zlog_debug ("  Version %d", ospfh->version);
   zlog_debug ("  Type %d (%s)", ospfh->type,
-	     LOOKUP (ospf_packet_type_str, ospfh->type));
+	     lookup_msg(ospf_packet_type_str, ospfh->type, NULL));
   zlog_debug ("  Packet Len %d", ntohs (ospfh->length));
   zlog_debug ("  Router ID %s", inet_ntoa (ospfh->router_id));
   zlog_debug ("  Area ID %s", inet_ntoa (ospfh->area_id));
   zlog_debug ("  Checksum 0x%x", ntohs (ospfh->checksum));
-  zlog_debug ("  AuType %s", LOOKUP (ospf_auth_type_str, auth_type));
+  zlog_debug ("  AuType %s", lookup_msg(ospf_auth_type_str, auth_type, NULL));
 
   switch (auth_type)
     {
@@ -1609,7 +1609,7 @@ show_debugging_ospf_common (struct vty *vty, struct ospf *ospf)
     if (IS_DEBUG_OSPF_PACKET (i, SEND) && IS_DEBUG_OSPF_PACKET (i, RECV))
       {
 	vty_out (vty, "  OSPF packet %s%s debugging is on%s",
-		 LOOKUP (ospf_packet_type_str, i + 1),
+		 lookup_msg(ospf_packet_type_str, i + 1, NULL),
 		 IS_DEBUG_OSPF_PACKET (i, DETAIL) ? " detail" : "",
 		 VTY_NEWLINE);
       }
@@ -1617,12 +1617,12 @@ show_debugging_ospf_common (struct vty *vty, struct ospf *ospf)
       {
 	if (IS_DEBUG_OSPF_PACKET (i, SEND))
 	  vty_out (vty, "  OSPF packet %s send%s debugging is on%s",
-		   LOOKUP (ospf_packet_type_str, i + 1),
+		   lookup_msg(ospf_packet_type_str, i + 1, NULL),
 		   IS_DEBUG_OSPF_PACKET (i, DETAIL) ? " detail" : "",
 		   VTY_NEWLINE);
 	if (IS_DEBUG_OSPF_PACKET (i, RECV))
 	  vty_out (vty, "  OSPF packet %s receive%s debugging is on%s",
-		   LOOKUP (ospf_packet_type_str, i + 1),
+		   lookup_msg(ospf_packet_type_str, i + 1, NULL),
 		   IS_DEBUG_OSPF_PACKET (i, DETAIL) ? " detail" : "",
 		   VTY_NEWLINE);
       }

--- a/ospfd/ospf_dump_api.c
+++ b/ospfd/ospf_dump_api.c
@@ -40,8 +40,8 @@ const struct message ospf_ism_state_msg[] =
   { ISM_DROther,      "DROther" },
   { ISM_Backup,       "Backup" },
   { ISM_DR,           "DR" },
+  { 0 }
 };
-const int ospf_ism_state_msg_max = OSPF_ISM_STATE_MAX;
 
 const struct message ospf_nsm_state_msg[] =
 {
@@ -55,8 +55,8 @@ const struct message ospf_nsm_state_msg[] =
   { NSM_Exchange,   "Exchange" },
   { NSM_Loading,    "Loading" },
   { NSM_Full,       "Full" },
+  { 0 }
 };
-const int ospf_nsm_state_msg_max = OSPF_NSM_STATE_MAX;
 
 const struct message ospf_lsa_type_msg[] =
 {
@@ -72,8 +72,8 @@ const struct message ospf_lsa_type_msg[] =
   { OSPF_OPAQUE_LINK_LSA,  "Link-Local Opaque-LSA" },
   { OSPF_OPAQUE_AREA_LSA,  "Area-Local Opaque-LSA" },
   { OSPF_OPAQUE_AS_LSA,    "AS-external Opaque-LSA" },
+  { 0 }
 };
-const int ospf_lsa_type_msg_max = OSPF_MAX_LSA;
 
 const struct message ospf_link_state_id_type_msg[] =
 {
@@ -89,8 +89,8 @@ const struct message ospf_link_state_id_type_msg[] =
   { OSPF_OPAQUE_LINK_LSA,  "(Link-Local Opaque-Type/ID)" },
   { OSPF_OPAQUE_AREA_LSA,  "(Area-Local Opaque-Type/ID)" },
   { OSPF_OPAQUE_AS_LSA,    "(AS-external Opaque-Type/ID)" },
+  { 0 }
 };
-const int ospf_link_state_id_type_msg_max = OSPF_MAX_LSA;
 
 const struct message ospf_network_type_msg[] =
 {
@@ -100,8 +100,8 @@ const struct message ospf_network_type_msg[] =
   { OSPF_IFTYPE_NBMA,             "NBMA" },
   { OSPF_IFTYPE_POINTOMULTIPOINT, "Point-to-MultiPoint" },
   { OSPF_IFTYPE_VIRTUALLINK,      "Virtual-Link" },
+  { 0 }
 };
-const int ospf_network_type_msg_max = OSPF_IFTYPE_MAX;
 
 /* AuType */
 const struct message ospf_auth_type_str[] =
@@ -109,9 +109,8 @@ const struct message ospf_auth_type_str[] =
   { OSPF_AUTH_NULL,          "Null"          },
   { OSPF_AUTH_SIMPLE,        "Simple"        },
   { OSPF_AUTH_CRYPTOGRAPHIC, "Cryptographic" },
+  { 0 }
 };
-const size_t ospf_auth_type_str_max = sizeof (ospf_auth_type_str) /
-  sizeof (ospf_auth_type_str[0]);
 
 #define OSPF_OPTION_STR_MAXLEN		24
 
@@ -135,7 +134,7 @@ ospf_options_dump (u_char options)
 void
 ospf_lsa_header_dump (struct lsa_header *lsah)
 {
-  const char *lsah_type = LOOKUP (ospf_lsa_type_msg, lsah->type);
+  const char *lsah_type = lookup_msg(ospf_lsa_type_msg, lsah->type, NULL);
 
   zlog_debug ("  LSA Header");
   zlog_debug ("    LS age %d", ntohs (lsah->ls_age));

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -256,7 +256,7 @@ ospf_flood (struct ospf *ospf, struct ospf_neighbor *nbr,
   if (IS_DEBUG_OSPF_EVENT)
     zlog_debug ("LSA[Flooding]: start, NBR %s (%s), cur(%p), New-LSA[%s]",
                inet_ntoa (nbr->router_id),
-               LOOKUP (ospf_nsm_state_msg, nbr->state),
+               lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
                (void *)current,
                dump_lsa_key (new));
 
@@ -380,7 +380,7 @@ ospf_flood_through_interface (struct ospf_interface *oi,
       if (IS_DEBUG_OSPF_EVENT)
 	zlog_debug ("ospf_flood_through_interface(): considering nbr %s (%s)",
 		   inet_ntoa (onbr->router_id),
-                   LOOKUP (ospf_nsm_state_msg, onbr->state));
+                   lookup_msg(ospf_nsm_state_msg, onbr->state, NULL));
 
       /* If the neighbor is in a lesser state than Exchange, it
 	 does not participate in flooding, and the next neighbor

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -541,8 +541,8 @@ ism_change_state (struct ospf_interface *oi, int state)
   /* Logging change of state. */
   if (IS_DEBUG_OSPF (ism, ISM_STATUS))
     zlog_debug("ISM[%s]: State change %s -> %s", IF_NAME(oi),
-               LOOKUP(ospf_ism_state_msg, oi->state),
-               LOOKUP(ospf_ism_state_msg, state));
+               lookup_msg(ospf_ism_state_msg, oi->state, NULL),
+               lookup_msg(ospf_ism_state_msg, state, NULL));
 
   old_state = oi->state;
   oi->state = state;
@@ -607,7 +607,7 @@ ospf_ism_event (struct thread *thread)
 
   if (IS_DEBUG_OSPF (ism, ISM_EVENTS))
     zlog_debug("ISM[%s]: %s (%s)", IF_NAME(oi),
-               LOOKUP(ospf_ism_state_msg, oi->state),
+               lookup_msg(ospf_ism_state_msg, oi->state, NULL),
                ospf_ism_event_str[event]);
 
   /* If state is changed. */

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2760,13 +2760,13 @@ ospf_lsa_install (struct ospf *ospf, struct ospf_interface *oi,
         case OSPF_AS_NSSA_LSA:
           zlog_debug ("LSA[%s]: Install %s",
                  dump_lsa_key (new),
-                 LOOKUP (ospf_lsa_type_msg, new->data->type));
+                 lookup_msg(ospf_lsa_type_msg, new->data->type, NULL));
           break;
         default:
 	  strcpy (area_str, inet_ntoa (new->area->area_id));
           zlog_debug ("LSA[%s]: Install %s to Area %s",
                  dump_lsa_key (new),
-                 LOOKUP (ospf_lsa_type_msg, new->data->type), area_str);
+                 lookup_msg(ospf_lsa_type_msg, new->data->type, NULL), area_str);
           break;
         }
     }

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -617,8 +617,8 @@ nsm_notice_state_change (struct ospf_neighbor *nbr, int next_state, int event)
   if (IS_DEBUG_OSPF (nsm, NSM_STATUS))
     zlog_debug ("NSM[%s:%s]: State change %s -> %s (%s)",
                IF_NAME (nbr->oi), inet_ntoa (nbr->router_id),
-               LOOKUP (ospf_nsm_state_msg, nbr->state),
-               LOOKUP (ospf_nsm_state_msg, next_state),
+               lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
+               lookup_msg(ospf_nsm_state_msg, next_state, NULL),
                ospf_nsm_event_str [event]);
 
   /* Optionally notify about adjacency changes */
@@ -627,8 +627,8 @@ nsm_notice_state_change (struct ospf_neighbor *nbr, int next_state, int event)
        (next_state == NSM_Full) || (next_state < nbr->state)))
     zlog_notice("AdjChg: Nbr %s on %s: %s -> %s (%s)",
                 inet_ntoa (nbr->router_id), IF_NAME (nbr->oi),
-                LOOKUP (ospf_nsm_state_msg, nbr->state),
-                LOOKUP (ospf_nsm_state_msg, next_state),
+                lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
+                lookup_msg(ospf_nsm_state_msg, next_state, NULL),
                 ospf_nsm_event_str [event]);
 
   /* Advance in NSM */
@@ -736,8 +736,8 @@ nsm_change_state (struct ospf_neighbor *nbr, int state)
       zlog_info ("nsm_change_state(%s, %s -> %s): "
 		 "scheduling new router-LSA origination",
 		 inet_ntoa (nbr->router_id),
-		 LOOKUP(ospf_nsm_state_msg, old_state),
-		 LOOKUP(ospf_nsm_state_msg, state));
+		 lookup_msg(ospf_nsm_state_msg, old_state, NULL),
+		 lookup_msg(ospf_nsm_state_msg, state, NULL));
 
       ospf_router_lsa_update_area (oi->area);
 
@@ -808,7 +808,7 @@ ospf_nsm_event (struct thread *thread)
   if (IS_DEBUG_OSPF (nsm, NSM_EVENTS))
     zlog_debug ("NSM[%s:%s]: %s (%s)", IF_NAME (nbr->oi),
 	       inet_ntoa (nbr->router_id),
-	       LOOKUP (ospf_nsm_state_msg, nbr->state),
+	       lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 	       ospf_nsm_event_str [event]);
   
   next_state = NSM [nbr->state][event].next_state;
@@ -830,9 +830,9 @@ ospf_nsm_event (struct thread *thread)
           zlog_warn ("NSM[%s:%s]: %s (%s): "
                      "Warning: action tried to change next_state to %s",
                      IF_NAME (nbr->oi), inet_ntoa (nbr->router_id),
-                     LOOKUP (ospf_nsm_state_msg, nbr->state),
+                     lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
                      ospf_nsm_event_str [event],
-                     LOOKUP (ospf_nsm_state_msg, func_state));
+                     lookup_msg(ospf_nsm_state_msg, func_state, NULL));
         }
     }
 

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -79,9 +79,8 @@ const struct message ospf_packet_type_str[] =
   { OSPF_MSG_LS_REQ,  "Link State Request"        },
   { OSPF_MSG_LS_UPD,  "Link State Update"         },
   { OSPF_MSG_LS_ACK,  "Link State Acknowledgment" },
+  { 0 }
 };
-const size_t ospf_packet_type_str_max = sizeof (ospf_packet_type_str) /
-  sizeof (ospf_packet_type_str[0]);
 
 /* Minimum (besides OSPF_HEADER_SIZE) lengths for OSPF packets of
    particular types, offset is the "type" field of a packet. */
@@ -256,8 +255,8 @@ ospf_packet_add (struct ospf_interface *oi, struct ospf_packet *op)
       zlog_err("ospf_packet_add(interface %s in state %d [%s], packet type %s, "
 	       "destination %s) called with NULL obuf, ignoring "
 	       "(please report this bug)!\n",
-	       IF_NAME(oi), oi->state, LOOKUP (ospf_ism_state_msg, oi->state),
-	       LOOKUP (ospf_packet_type_str, stream_getc_from(op->s, 1)),
+	       IF_NAME(oi), oi->state, lookup_msg(ospf_ism_state_msg, oi->state, NULL),
+	       lookup_msg(ospf_packet_type_str, stream_getc_from(op->s, 1), NULL),
 	       inet_ntoa (op->dst));
       return;
     }
@@ -277,8 +276,8 @@ ospf_packet_add_top (struct ospf_interface *oi, struct ospf_packet *op)
       zlog_err("ospf_packet_add(interface %s in state %d [%s], packet type %s, "
 	       "destination %s) called with NULL obuf, ignoring "
 	       "(please report this bug)!\n",
-	       IF_NAME(oi), oi->state, LOOKUP (ospf_ism_state_msg, oi->state),
-	       LOOKUP (ospf_packet_type_str, stream_getc_from(op->s, 1)),
+	       IF_NAME(oi), oi->state, lookup_msg(ospf_ism_state_msg, oi->state, NULL),
+               lookup_msg(ospf_packet_type_str, stream_getc_from(op->s, 1), NULL),
 	       inet_ntoa (op->dst));
       return;
     }
@@ -815,7 +814,8 @@ ospf_write (struct thread *thread)
 	    }
 
           zlog_debug ("%s sent to [%s] via [%s].",
-		     LOOKUP (ospf_packet_type_str, type), inet_ntoa (op->dst),
+                     lookup_msg(ospf_packet_type_str, type, NULL),
+                     inet_ntoa (op->dst),
 		     IF_NAME (oi));
 
           if (IS_DEBUG_OSPF_PACKET (type - 1, DETAIL))
@@ -879,7 +879,7 @@ ospf_hello (struct ip *iph, struct ospf_header *ospfh,
         {
           zlog_debug ("ospf_header[%s/%s]: selforiginated, "
                      "dropping.",
-                     LOOKUP (ospf_packet_type_str, ospfh->type),
+                     lookup_msg(ospf_packet_type_str, ospfh->type, NULL),
                      inet_ntoa (iph->ip_src));
         }
       return;
@@ -1317,7 +1317,7 @@ ospf_db_desc (struct ip *iph, struct ospf_header *ospfh,
     case NSM_TwoWay:
       zlog_warn ("Packet[DD]: Neighbor %s state is %s, packet discarded.",
 		 inet_ntoa(nbr->router_id),
-		 LOOKUP (ospf_nsm_state_msg, nbr->state));
+		 lookup_msg(ospf_nsm_state_msg, nbr->state, NULL));
       break;
     case NSM_Init:
       OSPF_NSM_EVENT_EXECUTE (nbr, NSM_TwoWayReceived);
@@ -1537,7 +1537,7 @@ ospf_ls_req (struct ip *iph, struct ospf_header *ospfh,
       zlog_warn ("Link State Request received from %s: "
       		 "Neighbor state is %s, packet discarded.",
 		 inet_ntoa (ospfh->router_id),
-		 LOOKUP (ospf_nsm_state_msg, nbr->state));
+		 lookup_msg(ospf_nsm_state_msg, nbr->state, NULL));
       return;
     }
 
@@ -1772,7 +1772,7 @@ ospf_ls_upd (struct ospf *ospf, struct ip *iph, struct ospf_header *ospfh,
 	zlog_debug ("Link State Update: "
 		    "Neighbor[%s] state %s is less than Exchange",
 		    inet_ntoa (ospfh->router_id),
-		    LOOKUP(ospf_nsm_state_msg, nbr->state));
+		    lookup_msg(ospf_nsm_state_msg, nbr->state, NULL));
       return;
     }
 
@@ -2117,7 +2117,7 @@ ospf_ls_ack (struct ip *iph, struct ospf_header *ospfh,
 	zlog_debug ("Link State Acknowledgment: "
 		    "Neighbor[%s] state %s is less than Exchange",
 		    inet_ntoa (ospfh->router_id),
-		    LOOKUP(ospf_nsm_state_msg, nbr->state));
+		    lookup_msg(ospf_nsm_state_msg, nbr->state, NULL));
       return;
     }
   
@@ -2332,7 +2332,7 @@ ospf_check_auth (struct ospf_interface *oi, struct ospf_header *ospfh)
     {
       if (IS_DEBUG_OSPF_PACKET (ospfh->type - 1, RECV))
         zlog_warn ("interface %s: auth-type mismatch, local %s, rcvd Null",
-                   IF_NAME (oi), LOOKUP (ospf_auth_type_str, iface_auth_type));
+                   IF_NAME (oi), lookup_msg(ospf_auth_type_str, iface_auth_type, NULL));
       return 0;
     }
     if (! ospf_check_sum (ospfh))
@@ -2348,7 +2348,7 @@ ospf_check_auth (struct ospf_interface *oi, struct ospf_header *ospfh)
     {
       if (IS_DEBUG_OSPF_PACKET (ospfh->type - 1, RECV))
         zlog_warn ("interface %s: auth-type mismatch, local %s, rcvd Simple",
-                   IF_NAME (oi), LOOKUP (ospf_auth_type_str, iface_auth_type));
+                   IF_NAME (oi), lookup_msg(ospf_auth_type_str, iface_auth_type, NULL));
       return 0;
     }
     if (memcmp (OSPF_IF_PARAM (oi, auth_simple), ospfh->u.auth_data, OSPF_AUTH_SIMPLE_SIZE))
@@ -2370,7 +2370,7 @@ ospf_check_auth (struct ospf_interface *oi, struct ospf_header *ospfh)
     {
       if (IS_DEBUG_OSPF_PACKET (ospfh->type - 1, RECV))
         zlog_warn ("interface %s: auth-type mismatch, local %s, rcvd Cryptographic",
-                   IF_NAME (oi), LOOKUP (ospf_auth_type_str, iface_auth_type));
+                   IF_NAME (oi), lookup_msg(ospf_auth_type_str, iface_auth_type, NULL));
       return 0;
     }
     if (ospfh->checksum)
@@ -2479,7 +2479,7 @@ ospf_lsa_examin (struct lsa_header * lsah, const u_int16_t lsalen, const u_char 
   {
     if (IS_DEBUG_OSPF_PACKET (0, RECV))
       zlog_debug ("%s: undersized (%u B) %s",
-                  __func__, lsalen, LOOKUP (ospf_lsa_type_msg, lsah->type));
+                  __func__, lsalen, lookup_msg(ospf_lsa_type_msg, lsah->type, NULL));
     return MSG_NG;
   }
   switch (lsah->type)
@@ -2529,7 +2529,7 @@ ospf_lsa_examin (struct lsa_header * lsah, const u_int16_t lsalen, const u_char 
   }
   if (ret != MSG_OK && IS_DEBUG_OSPF_PACKET (0, RECV))
     zlog_debug ("%s: alignment error in %s",
-                __func__, LOOKUP (ospf_lsa_type_msg, lsah->type));
+                __func__, lookup_msg(ospf_lsa_type_msg, lsah->type, NULL));
   return ret;
 }
 
@@ -2668,7 +2668,7 @@ ospf_packet_examin (struct ospf_header * oh, const unsigned bytesonwire)
   {
     if (IS_DEBUG_OSPF_PACKET (0, RECV))
       zlog_debug ("%s: undersized (%u B) %s packet", __func__,
-                  bytesdeclared, LOOKUP (ospf_packet_type_str, oh->type));
+                  bytesdeclared, lookup_msg(ospf_packet_type_str, oh->type, NULL));
     return MSG_NG;
   }
   switch (oh->type)
@@ -2722,7 +2722,7 @@ ospf_packet_examin (struct ospf_header * oh, const unsigned bytesonwire)
     return MSG_NG;
   }
   if (ret != MSG_OK && IS_DEBUG_OSPF_PACKET (0, RECV))
-    zlog_debug ("%s: malformed %s packet", __func__, LOOKUP (ospf_packet_type_str, oh->type));
+    zlog_debug ("%s: malformed %s packet", __func__, lookup_msg(ospf_packet_type_str, oh->type, NULL));
   return ret;
 }
 
@@ -2911,7 +2911,7 @@ ospf_read (struct thread *thread)
     {
       zlog_warn ("Dropping packet for AllDRouters from [%s] via [%s] (ISM: %s)",
                  inet_ntoa (iph->ip_src), IF_NAME (oi),
-                 LOOKUP (ospf_ism_state_msg, oi->state));
+                 lookup_msg(ospf_ism_state_msg, oi->state, NULL));
       /* Try to fix multicast membership. */
       SET_FLAG(oi->multicast_memberships, MEMBER_DROUTERS);
       ospf_if_set_multicast(oi);
@@ -2939,7 +2939,7 @@ ospf_read (struct thread *thread)
         }
 
       zlog_debug ("%s received from [%s] via [%s]",
-                 LOOKUP (ospf_packet_type_str, ospfh->type),
+                 lookup_msg(ospf_packet_type_str, ospfh->type, NULL),
                  inet_ntoa (ospfh->router_id), IF_NAME (oi));
       zlog_debug (" src [%s],", inet_ntoa (iph->ip_src));
       zlog_debug (" dst [%s]", inet_ntoa (iph->ip_dst));

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -2730,7 +2730,7 @@ ospfTrapIfStateChange (struct ospf_interface *oi)
 
   zlog_info("ospfTrapIfStateChange trap sent: %s now %s",
             inet_ntoa(oi->address->u.prefix4),
-            LOOKUP(ospf_ism_state_msg, oi->state));
+            lookup_msg(ospf_ism_state_msg, oi->state, NULL));
   
   oid_copy_addr (index, &(oi->address->u.prefix4), IN_ADDR_SIZE);
   index[IN_ADDR_SIZE] = 0;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3374,7 +3374,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
           json_object_string_add(json_interface_sub, "networkType", ospf_network_type_str[oi->type]);
           json_object_int_add(json_interface_sub, "cost", oi->output_cost);
           json_object_int_add(json_interface_sub, "transmitDelayMsecs", 1000 / OSPF_IF_PARAM (oi,transmit_delay));
-          json_object_string_add(json_interface_sub, "state", LOOKUP (ospf_ism_state_msg, oi->state));
+          json_object_string_add(json_interface_sub, "state", lookup_msg(ospf_ism_state_msg, oi->state, NULL));
           json_object_int_add(json_interface_sub, "priority", PRIORITY (oi));
         }
       else
@@ -3390,7 +3390,7 @@ show_ip_ospf_interface_sub (struct vty *vty, struct ospf *ospf, struct interface
                    oi->output_cost, VTY_NEWLINE);
 
           vty_out (vty, "  Transmit Delay is %d sec, State %s, Priority %d%s",
-                   OSPF_IF_PARAM (oi,transmit_delay), LOOKUP (ospf_ism_state_msg, oi->state),
+                   OSPF_IF_PARAM (oi,transmit_delay), lookup_msg(ospf_ism_state_msg, oi->state, NULL),
                    PRIORITY (oi), VTY_NEWLINE);
         }
 
@@ -4125,11 +4125,11 @@ show_ip_ospf_neighbor_detail_sub (struct vty *vty, struct ospf_interface *oi,
   if (use_json)
     {
       json_object_int_add(json_sub, "nbrPriority", nbr->priority);
-      json_object_string_add(json_sub, "nbrState", LOOKUP (ospf_nsm_state_msg, nbr->state));
+      json_object_string_add(json_sub, "nbrState", lookup_msg(ospf_nsm_state_msg, nbr->state, NULL));
     }
   else
     vty_out (vty, "    Neighbor priority is %d, State is %s,",
-             nbr->priority, LOOKUP (ospf_nsm_state_msg, nbr->state));
+             nbr->priority, lookup_msg(ospf_nsm_state_msg, nbr->state, NULL));
 
   /* Show state changes. */
   if (use_json)
@@ -4800,9 +4800,9 @@ show_ip_ospf_database_header (struct vty *vty, struct ospf_lsa *lsa)
       vty_out (vty, "%s", VTY_NEWLINE);
     }
   vty_out (vty, "  LS Type: %s%s",
-           LOOKUP (ospf_lsa_type_msg, lsa->data->type), VTY_NEWLINE);
+           lookup_msg(ospf_lsa_type_msg, lsa->data->type, NULL), VTY_NEWLINE);
   vty_out (vty, "  Link State ID: %s %s%s", inet_ntoa (lsa->data->id),
-           LOOKUP (ospf_link_state_id_type_msg, lsa->data->type), VTY_NEWLINE);
+           lookup_msg(ospf_link_state_id_type_msg, lsa->data->type, NULL), VTY_NEWLINE);
   vty_out (vty, "  Advertising Router: %s%s",
            inet_ntoa (lsa->data->adv_router), VTY_NEWLINE);
   vty_out (vty, "  LS Seq Number: %08lx%s", (u_long)ntohl (lsa->data->ls_seqnum),

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1264,8 +1264,8 @@ static const struct message ospf_area_type_msg[] =
   { OSPF_AREA_DEFAULT,	"Default" },
   { OSPF_AREA_STUB,     "Stub" },
   { OSPF_AREA_NSSA,     "NSSA" },
+  { 0 }
 };
-static const int ospf_area_type_msg_max = OSPF_AREA_TYPE_MAX;
 
 static void
 ospf_area_type_set (struct ospf_area *area, int type)
@@ -1285,7 +1285,7 @@ ospf_area_type_set (struct ospf_area *area, int type)
 
   if (IS_DEBUG_OSPF_EVENT)
     zlog_debug ("Area[%s]: Configured as %s", inet_ntoa (area->area_id),
-	       LOOKUP (ospf_area_type_msg, type));
+	       lookup_msg(ospf_area_type_msg, type, NULL));
 
   switch (area->external_routing)
     {

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -59,6 +59,7 @@ const struct message ri_version_msg[] =
   {RI_RIP_VERSION_2,       "2"},
   {RI_RIP_VERSION_1_AND_2, "1 2"},
   {RI_RIP_VERSION_NONE,    "none"},
+  { 0 }
 };
 
 extern struct zebra_privs_t ripd_privs;
@@ -1907,12 +1908,12 @@ rip_interface_config_write (struct vty *vty)
       /* RIP version setting. */
       if (ri->ri_send != RI_RIP_UNSPEC)
 	vty_out (vty, " ip rip send version %s%s",
-		 lookup (ri_version_msg, ri->ri_send),
+		 lookup_msg(ri_version_msg, ri->ri_send, NULL),
 		 VTY_NEWLINE);
 
       if (ri->ri_receive != RI_RIP_UNSPEC)
 	vty_out (vty, " ip rip receive version %s%s",
-		 lookup (ri_version_msg, ri->ri_receive),
+		 lookup_msg(ri_version_msg, ri->ri_receive, NULL),
 		 VTY_NEWLINE);
 
       if (ri->v2_broadcast)

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -87,7 +87,7 @@ static const struct message rip_msg[] =
   {RIP_TRACEOFF,   "TRACEOFF"},
   {RIP_POLL,       "POLL"},
   {RIP_POLL_ENTRY, "POLL ENTRY"},
-  {0, NULL},
+  { 0 }
 };
 
 /* Utility function to set boradcast option to the socket. */
@@ -702,7 +702,7 @@ rip_packet_dump (struct rip_packet *packet, int size, const char *sndrcv)
 
   /* Set command string. */
   if (packet->command > 0 && packet->command < RIP_COMMAND_MAX)
-    command_str = lookup (rip_msg, packet->command);
+    command_str = lookup_msg (rip_msg, packet->command, NULL);
   else
     command_str = "unknown";
 
@@ -2045,12 +2045,12 @@ rip_read (struct thread *t)
     case RIP_TRACEON:
     case RIP_TRACEOFF:
       zlog_info ("Obsolete command %s received, please sent it to routed", 
-		 lookup (rip_msg, packet->command));
+		 lookup_msg (rip_msg, packet->command, NULL));
       rip_peer_bad_packet (&from);
       break;
     case RIP_POLL_ENTRY:
       zlog_info ("Obsolete command %s received", 
-		 lookup (rip_msg, packet->command));
+		 lookup_msg (rip_msg, packet->command, NULL));
       rip_peer_bad_packet (&from);
       break;
     default:
@@ -3587,12 +3587,12 @@ DEFUN (show_ip_rip_status,
   vty_out (vty, "%s", VTY_NEWLINE);
 
   vty_out (vty, "  Default version control: send version %s,",
-	   lookup(ri_version_msg,rip->version_send));
+	   lookup_msg(ri_version_msg,rip->version_send, NULL));
   if (rip->version_recv == RI_RIP_VERSION_1_AND_2)
     vty_out (vty, " receive any version %s", VTY_NEWLINE);
   else
     vty_out (vty, " receive version %s %s",
-	     lookup(ri_version_msg,rip->version_recv), VTY_NEWLINE);
+	     lookup_msg(ri_version_msg,rip->version_recv, NULL), VTY_NEWLINE);
 
   vty_out (vty, "    Interface        Send  Recv   Key-chain%s", VTY_NEWLINE);
 
@@ -3606,14 +3606,14 @@ DEFUN (show_ip_rip_status,
       if (ri->enable_network || ri->enable_interface)
 	{
 	  if (ri->ri_send == RI_RIP_UNSPEC)
-	    send_version = lookup (ri_version_msg, rip->version_send);
+	    send_version = lookup_msg(ri_version_msg, rip->version_send, NULL);
 	  else
-	    send_version = lookup (ri_version_msg, ri->ri_send);
+	    send_version = lookup_msg(ri_version_msg, ri->ri_send, NULL);
 
 	  if (ri->ri_receive == RI_RIP_UNSPEC)
-	    receive_version = lookup (ri_version_msg, rip->version_recv);
+	    receive_version = lookup_msg(ri_version_msg, rip->version_recv, NULL);
 	  else
-	    receive_version = lookup (ri_version_msg, ri->ri_receive);
+	    receive_version = lookup_msg(ri_version_msg, ri->ri_receive, NULL);
 	
 	  vty_out (vty, "    %-17s%-3s   %-3s    %s%s", ifp->name,
 		   send_version,

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -84,7 +84,7 @@ static const struct message nlmsg_str[] = {
   {RTM_NEWNEIGH, "RTM_NEWNEIGH"},
   {RTM_DELNEIGH, "RTM_DELNEIGH"},
   {RTM_GETNEIGH, "RTM_GETNEIGH"},
-  {0, NULL}
+  { 0 }
 };
 
 static const struct message rtproto_str[] = {
@@ -100,7 +100,7 @@ static const struct message rtproto_str[] = {
   {RTPROT_BIRD,     "BIRD"},
 #endif /* RTPROT_BIRD */
   {RTPROT_MROUTED,  "mroute"},
-  {0,               NULL}
+  { 0 }
 };
 
 static const struct message family_str[] = {
@@ -109,13 +109,13 @@ static const struct message family_str[] = {
   {AF_BRIDGE,         "bridge"},
   {RTNL_FAMILY_IPMR,  "ipv4MR"},
   {RTNL_FAMILY_IP6MR, "ipv6MR"},
-  {0,                 NULL},
+  { 0 }
 };
 
 static const struct message rttype_str[] = {
   {RTN_UNICAST,   "unicast"},
   {RTN_MULTICAST, "multicast"},
-  {0,             NULL},
+  { 0 }
 };
 
 extern struct thread_master *master;
@@ -420,25 +420,25 @@ rta_nest_end(struct rtattr *rta, struct rtattr *nest)
 const char *
 nl_msg_type_to_str (uint16_t msg_type)
 {
-  return lookup (nlmsg_str, msg_type);
+  return lookup_msg (nlmsg_str, msg_type, "");
 }
 
 const char *
 nl_rtproto_to_str (u_char rtproto)
 {
-  return lookup (rtproto_str, rtproto);
+  return lookup_msg (rtproto_str, rtproto, "");
 }
 
 const char *
 nl_family_to_str (u_char family)
 {
-  return lookup (family_str, family);
+  return lookup_msg (family_str, family, "");
 }
 
 const char *
 nl_rttype_to_str (u_char rttype)
 {
-  return lookup (rttype_str, rttype);
+  return lookup_msg (rttype_str, rttype, "");
 }
 
 /*

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -220,7 +220,7 @@ const struct message rtm_type_str[] =
 #ifdef RTM_IFANNOUNCE
   {RTM_IFANNOUNCE, "RTM_IFANNOUNCE"},
 #endif /* RTM_IFANNOUNCE */
-  {0,            NULL}
+  { 0 }
 };
 
 static const struct message rtm_flag_str[] =
@@ -278,7 +278,7 @@ static const struct message rtm_flag_str[] =
 #ifdef RTF_SETSRC
   {RTF_SETSRC,    "SETSRC"},
 #endif /* RTF_SETSRC */
-  {0,             NULL}
+  { 0 }
 };
 
 /* Kernel routing update socket. */
@@ -875,7 +875,7 @@ rtm_read (struct rt_msghdr *rtm)
     return;
   if (IS_ZEBRA_DEBUG_KERNEL)
     zlog_debug ("%s: got rtm of type %d (%s)", __func__, rtm->rtm_type,
-      lookup (rtm_type_str, rtm->rtm_type));
+      lookup_msg(rtm_type_str, rtm->rtm_type, NULL));
 
 #ifdef RTF_CLONED	/*bsdi, netbsd 1.6*/
   if (flags & RTF_CLONED)
@@ -940,17 +940,17 @@ rtm_read (struct rt_msghdr *rtm)
             {
               case ZEBRA_RIB_NOTFOUND:
                 zlog_debug ("%s: %s %s: desync: RR isn't yet in RIB, while already in FIB",
-                  __func__, lookup (rtm_type_str, rtm->rtm_type), buf);
+                  __func__, lookup_msg(rtm_type_str, rtm->rtm_type, NULL), buf);
                 break;
               case ZEBRA_RIB_FOUND_CONNECTED:
               case ZEBRA_RIB_FOUND_NOGATE:
                 inet_ntop (AF_INET, &gate.sin.sin_addr, gate_buf, INET_ADDRSTRLEN);
                 zlog_debug ("%s: %s %s: desync: RR is in RIB, but gate differs (ours is %s)",
-                  __func__, lookup (rtm_type_str, rtm->rtm_type), buf, gate_buf);
+                  __func__, lookup_msg(rtm_type_str, rtm->rtm_type, NULL), buf, gate_buf);
                 break;
               case ZEBRA_RIB_FOUND_EXACT: /* RIB RR == FIB RR */
                 zlog_debug ("%s: %s %s: done Ok",
-                  __func__, lookup (rtm_type_str, rtm->rtm_type), buf);
+                  __func__, lookup_msg(rtm_type_str, rtm->rtm_type, NULL), buf);
                 rib_lookup_and_dump ((struct prefix_ipv4 *)&p, VRF_DEFAULT);
                 return;
                 break;
@@ -963,18 +963,18 @@ rtm_read (struct rt_msghdr *rtm)
             {
               case ZEBRA_RIB_FOUND_EXACT:
                 zlog_debug ("%s: %s %s: desync: RR is still in RIB, while already not in FIB",
-                  __func__, lookup (rtm_type_str, rtm->rtm_type), buf);
+                  __func__, lookup_msg(rtm_type_str, rtm->rtm_type, NULL), buf);
                 rib_lookup_and_dump ((struct prefix_ipv4 *)&p, VRF_DEFAULT);
                 break;
               case ZEBRA_RIB_FOUND_CONNECTED:
               case ZEBRA_RIB_FOUND_NOGATE:
                 zlog_debug ("%s: %s %s: desync: RR is still in RIB, plus gate differs",
-                  __func__, lookup (rtm_type_str, rtm->rtm_type), buf);
+                  __func__, lookup_msg(rtm_type_str, rtm->rtm_type, NULL), buf);
                 rib_lookup_and_dump ((struct prefix_ipv4 *)&p, VRF_DEFAULT);
                 break;
               case ZEBRA_RIB_NOTFOUND: /* RIB RR == FIB RR */
                 zlog_debug ("%s: %s %s: done Ok",
-                  __func__, lookup (rtm_type_str, rtm->rtm_type), buf);
+                  __func__, lookup_msg(rtm_type_str, rtm->rtm_type, NULL), buf);
                 rib_lookup_and_dump ((struct prefix_ipv4 *)&p, VRF_DEFAULT);
                 return;
                 break;
@@ -982,7 +982,7 @@ rtm_read (struct rt_msghdr *rtm)
             break;
           default:
             zlog_debug ("%s: %s: warning: loopback RTM of type %s received",
-              __func__, buf, lookup (rtm_type_str, rtm->rtm_type));
+              __func__, buf, lookup_msg(rtm_type_str, rtm->rtm_type, NULL));
         }
         return;
       }
@@ -1203,7 +1203,7 @@ rtm_write (int message,
 static void
 rtmsg_debug (struct rt_msghdr *rtm)
 {
-  zlog_debug ("Kernel: Len: %d Type: %s", rtm->rtm_msglen, lookup (rtm_type_str, rtm->rtm_type));
+  zlog_debug ("Kernel: Len: %d Type: %s", rtm->rtm_msglen, lookup_msg(rtm_type_str, rtm->rtm_type, NULL));
   rtm_flag_dump (rtm->rtm_flags);
   zlog_debug ("Kernel: message seq %d", rtm->rtm_seq);
   zlog_debug ("Kernel: pid %lld, rtm_addrs 0x%x",

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -219,14 +219,14 @@ kernel_rtm_ipv4 (int cmd, struct prefix *p, struct rib *rib)
              default:
                zlog_err ("%s: %s: rtm_write() unexpectedly returned %d for command %s",
                  __func__, prefix2str(p, prefix_buf, sizeof(prefix_buf)),
-                 error, lookup (rtm_type_str, cmd));
+                 error, lookup_msg(rtm_type_str, cmd, NULL));
                break;
            }
          } /* if (cmd and flags make sense) */
        else
          if (IS_ZEBRA_DEBUG_RIB)
            zlog_debug ("%s: odd command %s for flags %d",
-             __func__, lookup (rtm_type_str, cmd), nexthop->flags);
+             __func__, lookup_msg(rtm_type_str, cmd, NULL), nexthop->flags);
      } /* for (ALL_NEXTHOPS_RO(...))*/
  
    /* If there was no useful nexthop, then complain. */


### PR DESCRIPTION
This is a backported security fix.

----------
log.c provides functionality for associating a constant (typically a
protocol constant) with a string and finding the string given the
constant. However this is highly delicate code that is extremely prone
to stack overflows and off-by-one's due to requiring the developer to
always remember to update the array size constant and to do so correctly
which, as shown by example, is never a good idea.b

The original goal of this code was to try to implement lookups in O(1)
time without a linear search through the message array. Since this code
is used 99% of the time for debugs, it's worth the 5-6 additional cmp's
worst case if it means we avoid explitable bugs due to oversights...

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>