### PR TITLE
zebra: fix mpls_str2label()

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -1774,7 +1774,7 @@ mpls_str2label (const char *label_str, u_int8_t *num_labels,
 
   if (!rc)
     {
-      *num_labels = i + 1;
+      *num_labels = i;
       memcpy (labels, pl, *num_labels * sizeof (mpls_label_t));
     }
 


### PR DESCRIPTION
When making improvements to error handling in this code I accidentally
introduced an off-by-one. Fix it.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>