### PR TITLE
bgpd: "address-family" not displayed in configuration

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7254,7 +7254,7 @@ bgp_config_write_family_header (struct vty *vty, afi_t afi, safi_t safi,
   if (*write)
     return;
 
-  vty_outln (vty, " !%s address-family ", VTYNL);
+  vty_out (vty, " !%s address-family ", VTYNL);
 
   if (afi == AFI_IP)
     {


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>
Reviewed-by:   Donald Sharp <sharpd@cumulusnetworks.com>