### PR TITLE
lib: fix vty_out with >1024 bytes of output

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -107,7 +107,7 @@ vty_out_variadic (struct vty *vty, const char *format, va_list args)
     {
       /* Try to write to initial buffer.  */
       va_copy (cp, args);
-      len = vsnprintf (buf, sizeof(buf), format, args);
+      len = vsnprintf (buf, sizeof(buf), format, cp);
       va_end (cp);
 
       /* Initial buffer is not enough.  */
@@ -124,7 +124,9 @@ vty_out_variadic (struct vty *vty, const char *format, va_list args)
               if (! p)
                 return -1;
 
-              len = vsnprintf (p, size, format, args);
+              va_copy (cp, args);
+              len = vsnprintf (p, size, format, cp);
+              va_end (cp);
 
               if (len > -1 && len < size)
                 break;


### PR DESCRIPTION
Consuming va_args modifies its internal bits, hence the need to copy
it... but the copying wasn't quite right just yet.

Fixes: 4d5f445 ("lib: add vty_outln()")
Signed-off-by: David Lamparter <equinox@opensourcerouting.org>