### PR TITLE
bgpd: peer-group members 'activate' when they shouldn't

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2714,6 +2714,8 @@ peer_group_bind (struct bgp *bgp, union sockunion *su, struct peer *peer,
                     peer_group2peer_config_copy_af (group, peer, afi, safi);
                   }
               }
+            else if (peer->afc[afi][safi])
+              peer_deactivate (peer, afi, safi);
           }
 
       if (peer->group)
@@ -2794,6 +2796,8 @@ peer_group_bind (struct bgp *bgp, union sockunion *su, struct peer *peer,
               peer_af_create(peer, afi, safi);
               peer_group2peer_config_copy_af (group, peer, afi, safi);
             }
+          else if (peer->afc[afi][safi])
+            peer_deactivate (peer, afi, safi);
 
       SET_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE);
 


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>
Reviewed-by:   Donald Sharp <sharpd@cumulusnetworks.com>

Today if you configure the following where the 'fabric' peer-group has
been deactivated for ipv4 unicast and then assign swp1/swp2 to that
peer-group we end up activating those two peers for ipv4 unicast.
```
conf t
no router bgp 100
router bgp 100
  neighbor fabric peer-group
  neighbor fabric capability extended-nexthop
  neighbor fabric remote-as external
  !
  address-family ipv4 unicast
    no neighbor fabric activate
  !
  neighbor swp1 interface peer-group fabric
  neighbor swp2 interface peer-group fabric
  neighbor 1.1.1.1 peer-group fabric
end

cel-redxp-10# show run bgp
!
router bgp 100
 neighbor fabric peer-group
 neighbor fabric remote-as external
 neighbor fabric capability extended-nexthop
 neighbor swp1 interface peer-group fabric
 neighbor swp2 interface peer-group fabric
 neighbor 1.1.1.1 peer-group fabric
 !
 address-family ipv4 unicast
  no neighbor fabric activate
  neighbor swp1 activate
  neighbor swp2 activate
 exit-address-family
!
cel-redxp-10#
```
With the patch we do not activate swp1/swp2
```
cel-redxp-10# show run bgp
!
router bgp 100
 neighbor fabric peer-group
 neighbor fabric remote-as external
 neighbor fabric capability extended-nexthop
 neighbor swp1 interface peer-group fabric
 neighbor swp2 interface peer-group fabric
 neighbor 1.1.1.1 peer-group fabric
 !
 address-family ipv4 unicast
  no neighbor fabric activate
 exit-address-family
!
cel-redxp-10#
```