### PR TITLE
*: clean up config paths & global variables

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -150,7 +150,7 @@ main(int argc, char **argv)
 {
     int rc;
 
-    frr_preinit (&babeld_di, argc, argv);
+    frr_preinit (&babeld_di, argv[0]);
     frr_opt_add ("", longopts, "");
   
     babel_init_random();

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -138,7 +138,9 @@ sighup (void)
   zlog_info ("bgpd restarting!");
 
   /* Reload config file. */
-  vty_read_config (bgpd_di.config_file, config_default);
+  char defaultconf[MAXPATHLEN];
+  frr_daemon_conf(defaultconf, sizeof(defaultconf));
+  vty_read_config (bgpd_di.config_file, defaultconf);
 
   /* Try to return to normal operation. */
 }
@@ -357,7 +359,7 @@ main (int argc, char **argv)
   int no_fib_flag = 0;
   int skip_runas = 0;
 
-  frr_preinit(&bgpd_di, argc, argv);
+  frr_preinit (&bgpd_di, argv[0]);
   frr_opt_add("p:l:rne:", longopts,
 	"  -p, --bgp_port     Set bgp protocol's port number\n"
 	"  -l, --listenon     Listen on specified address (implies -n)\n"

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -154,7 +154,7 @@ FRR_DAEMON_INFO(eigrpd, EIGRP,
 int
 main (int argc, char **argv, char **envp)
 {
-  frr_preinit (&eigrpd_di, argc, argv);
+  frr_preinit (&eigrpd_di, argv[0]);
   frr_opt_add ("", longopts, "");
 
   while (1)

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -178,7 +178,7 @@ main (int argc, char **argv, char **envp)
 {
   int opt;
 
-  frr_preinit (&isisd_di, argc, argv);
+  frr_preinit (&isisd_di, argv[0]);
   frr_opt_add ("", longopts, "");
 
   /* Command line argument treatment. */

--- a/isisd/isis_misc.c
+++ b/isisd/isis_misc.c
@@ -27,6 +27,7 @@
 #include "vty.h"
 #include "hash.h"
 #include "if.h"
+#include "libfrr.h"
 #include "command.h"
 
 #include "isisd/dict.h"
@@ -529,7 +530,7 @@ newprefix2inaddr (u_char * prefix_start, u_char prefix_masklen)
 }
 
 /*
- * Returns host.name if any, otherwise
+ * Returns frr.host.name if any, otherwise
  * it returns the system hostname.
  */
 const char *
@@ -538,7 +539,7 @@ unix_hostname (void)
   static struct utsname names;
   const char *hostname;
 
-  hostname = host.name;
+  hostname = frr.host.name;
   if (!hostname)
     {
       uname (&names);

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -136,8 +136,10 @@ sighup(void)
 	 * Do a full configuration reload. In other words, reset vty_conf
 	 * and build a new configuartion from scratch.
 	 */
+	char defaultconf[MAXPATHLEN];
+	frr_daemon_conf(defaultconf, sizeof(defaultconf));
 	ldp_config_reset(vty_conf);
-	vty_read_config(ldpd_di.config_file, config_default);
+	vty_read_config(ldpd_di.config_file, defaultconf);
 	ldp_config_apply(NULL, vty_conf);
 }
 
@@ -203,7 +205,7 @@ main(int argc, char *argv[])
 	if (saved_argv0 == NULL)
 		saved_argv0 = (char *)"ldpd";
 
-	frr_preinit(&ldpd_di, argc, argv);
+	frr_preinit (&ldpd_di, argv[0]);
 	frr_opt_add("LEn:", longopts,
 		"      --ctl_socket   Override ctl socket path\n"
 		"-n,   --instance     Instance id\n");

--- a/lib/command.h
+++ b/lib/command.h
@@ -36,39 +36,6 @@ DECLARE_MTYPE(COMPLETION)
 /* for test-commands.c */
 DECLARE_MTYPE(STRVEC)
 
-/* Host configuration variable */
-struct host
-{
-  /* Host name of this router. */
-  char *name;
-
-  /* Password for vty interface. */
-  char *password;
-  char *password_encrypt;
-
-  /* Enable password */
-  char *enable;
-  char *enable_encrypt;
-
-  /* System wide terminal lines. */
-  int lines;
-
-  /* Log filename. */
-  char *logfile;
-
-  /* config file name of this host */
-  char *config;
-  int noconfig;
-
-  /* Flags for services */
-  int advanced;
-  int encrypt;
-
-  /* Banner configuration. */
-  const char *motd;
-  char *motdfile;
-};
-
 /* There are some command levels which called from command node. */
 enum node_type
 {

--- a/lib/grammar_sandbox_main.c
+++ b/lib/grammar_sandbox_main.c
@@ -25,6 +25,7 @@
 
 #include "command.h"
 #include "memory_vty.h"
+#include "libfrr.h"
 
 static void vty_do_exit(void)
 {
@@ -48,7 +49,7 @@ int main(int argc, char **argv)
 
   /* Library inits. */
   cmd_init (1);
-  host.name = strdup ("test");
+  frr.host.name = strdup ("test");
 
   vty_init (master);
   memory_init ();

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -65,6 +65,69 @@ struct frr_daemon_info {
 	struct zebra_privs_t *privs;
 };
 
+/* Global data structure holding:
+ *  - Configuration file names and paths
+ *  - Hostname
+ *  - Miscellaneous runtime configuration options
+ *
+ * XXX: struct host has been moved from command.h without changes. Some of its
+ * fields probably make more sense in daemon_info.
+ */
+struct frr {
+	struct {
+		/* FRR configuration directory without trailing backslash. This
+		 * defaults to SYSCONFDIR, which is defined at compile time by
+		 * the --sysconfdir option.  */
+		char dir[MAXPATHLEN];
+
+		/* Basename of integrated config file */
+		char integrated[MAXPATHLEN];
+
+	} config;
+
+	/* VTY socket directory */
+	char vtydir[MAXPATHLEN];
+
+	/* Module directory */
+	char moduledir[MAXPATHLEN];
+
+	/* Daemon-specific information */
+	struct frr_daemon_info *daemon;
+
+	struct {
+		/* Host name of this router */
+		char *name;
+		
+		/* Password for vty interface */
+		char *password;
+		char *password_encrypt;
+		
+		/* Enable password */
+		char *enable;
+		char *enable_encrypt;
+		
+		/* System wide terminal lines */
+		int lines;
+		
+		/* Log filename */
+		char *logfile;
+		
+		/* config file name of this host */
+		char *config;
+		int noconfig;
+		
+		/* Flags for services */
+		int advanced;
+		int encrypt;
+		
+		/* Banner configuration. */
+		const char *motd;
+		char *motdfile;
+	} host;
+};
+
+extern struct frr frr;
+
 /* execname is the daemon's executable (and pidfile and configfile) name,
  * i.e. "zebra" or "bgpd"
  * constname is the daemons source-level name, primarily for the logging ID,
@@ -88,8 +151,7 @@ struct frr_daemon_info {
 	) \
 	/* end */
 
-extern void frr_preinit(struct frr_daemon_info *daemon,
-		int argc, char **argv);
+extern void frr_preinit (struct frr_daemon_info *daemon, const char *name);
 extern void frr_opt_add(const char *optstr,
 		const struct option *longopts, const char *helpstr);
 extern int frr_getopt(int argc, char * const argv[], int *longindex);
@@ -105,10 +167,9 @@ extern void frr_vty_serv(void);
 /* note: contains call to frr_vty_serv() */
 extern void frr_run(struct thread_master *master);
 
-extern char config_default[256];
-extern const char frr_sysconfdir[];
-extern const char frr_vtydir[];
-extern const char frr_moduledir[];
+extern void frr_update_confdir(const char *);
+extern void frr_integrated_conf(char *buf, size_t len);
+extern void frr_daemon_conf(char *buf, size_t len);
 
 extern char frr_protoname[];
 extern char frr_protonameinst[];

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -176,9 +176,6 @@ struct vty_arg
   int argc;
 };
 
-/* Integrated configuration file. */
-#define INTEGRATE_DEFAULT_CONFIG "frr.conf"
-
 /* Small macro to determine newline is newline only or linefeed needed. */
 #define VTYNL  ((vty->type == VTY_TERM) ? "\r\n" : "\n")
 
@@ -209,7 +206,7 @@ extern struct vty *vty_new (void);
 extern struct vty *vty_stdio (void (*atclose)(void));
 extern int vty_out (struct vty *, const char *, ...) PRINTF_ATTRIBUTE(2, 3);
 extern int vty_outln (struct vty *, const char *, ...) PRINTF_ATTRIBUTE(2, 3);
-extern void vty_read_config (const char *, char *);
+extern void vty_read_config (const char *, const char *);
 extern void vty_time_print (struct vty *, int);
 extern void vty_serv_sock (const char *, unsigned short, const char *);
 extern void vty_close (struct vty *);

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -121,7 +121,7 @@ FRR_DAEMON_INFO(nhrpd, NHRP,
 
 int main(int argc, char **argv)
 {
-	frr_preinit(&nhrpd_di, argc, argv);
+	frr_preinit (&nhrpd_di, argv[0]);
 	frr_opt_add("", longopts, "");
 
 	parse_arguments(argc, argv);

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -193,7 +193,7 @@ main (int argc, char *argv[], char *envp[])
 {
   int opt;
 
-  frr_preinit (&ospf6d_di, argc, argv);
+  frr_preinit (&ospf6d_di, argv[0]);
   frr_opt_add ("", longopts, "");
 
   /* Command line argument treatment. */

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -156,7 +156,7 @@ main (int argc, char **argv)
   ospf_apiserver_enable = 0;
 #endif /* SUPPORT_OSPF_API */
 
-  frr_preinit (&ospfd_di, argc, argv);
+  frr_preinit (&ospfd_di, argv[0]);
   frr_opt_add ("n:a", longopts,
 	"  -n, --instance     Set the instance id\n"
 	"  -a, --apiserver    Enable OSPF apiserver\n");

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -90,7 +90,7 @@ FRR_DAEMON_INFO(pimd, PIM,
 
 
 int main(int argc, char** argv, char** envp) {
-  frr_preinit(&pimd_di, argc, argv);
+  frr_preinit (&pimd_di, argv[0]);
   frr_opt_add("", longopts, "");
 
   /* this while just reads the options */

--- a/ripd/rip_main.c
+++ b/ripd/rip_main.c
@@ -86,7 +86,9 @@ sighup (void)
   zlog_info ("ripd restarting!");
 
   /* Reload config file. */
-  vty_read_config (ripd_di.config_file, config_default);
+  char defaultconf[MAXPATHLEN];
+  frr_daemon_conf(defaultconf, sizeof(defaultconf));
+  vty_read_config (ripd_di.config_file, defaultconf);
 
   /* Try to return to normal operation. */
 }
@@ -147,7 +149,7 @@ FRR_DAEMON_INFO(ripd, RIP,
 int
 main (int argc, char **argv)
 {
-  frr_preinit (&ripd_di, argc, argv);
+  frr_preinit (&ripd_di, argv[0]);
   frr_opt_add ("r", longopts,
 	"  -r, --retain       When program terminates, retain added route by ripd.\n");
 

--- a/ripngd/ripng_main.c
+++ b/ripngd/ripng_main.c
@@ -89,7 +89,9 @@ sighup (void)
   ripng_reset ();
 
   /* Reload config file. */
-  vty_read_config (ripngd_di.config_file, config_default);
+  char defaultconf[MAXPATHLEN];
+  frr_daemon_conf(defaultconf, sizeof(defaultconf));
+  vty_read_config (ripngd_di.config_file, defaultconf);
 
   /* Try to return to normal operation. */
 }
@@ -149,7 +151,7 @@ FRR_DAEMON_INFO(ripngd, RIPNG,
 int
 main (int argc, char **argv)
 {
-  frr_preinit (&ripngd_di, argc, argv);
+  frr_preinit (&ripngd_di, argv[0]);
   frr_opt_add ("r", longopts,
 	"  -r, --retain       When program terminates, retain added route by ripd.\n");
 

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -51,7 +51,6 @@ DECLARE_MGROUP(MVTYSH)
 
 /* vtysh local configuration file. */
 #define VTYSH_DEFAULT_CONFIG "vtysh.conf"
-#define FRR_DEFAULT_CONFIG "frr.conf"
 
 enum vtysh_write_integrated {
 	WRITE_INTEGRATED_UNSPECIFIED,
@@ -60,8 +59,6 @@ enum vtysh_write_integrated {
 };
 
 extern enum vtysh_write_integrated vtysh_write_integrated;
-
-extern char *quagga_config;
 
 void vtysh_init_vty (void);
 void vtysh_init_cmd (void);

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -23,6 +23,7 @@
 #include "command.h"
 #include "linklist.h"
 #include "memory.h"
+#include "libfrr.h"
 
 #include "vtysh/vtysh.h"
 #include "vtysh/vtysh_user.h"
@@ -417,11 +418,10 @@ void
 vtysh_config_write ()
 {
   char line[81];
-  extern struct host host;
 
-  if (host.name)
+  if (frr.host.name)
     {
-      sprintf (line, "hostname %s", host.name);
+      sprintf (line, "hostname %s", frr.host.name);
       vtysh_config_parse_line(NULL, line);
     }
   if (vtysh_write_integrated == WRITE_INTEGRATED_NO)

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -1057,7 +1057,7 @@ int main(int argc, char **argv)
 	const char *special = "zebra";
 	const char *blankstr = NULL;
 
-	frr_preinit(&watchfrr_di, argc, argv);
+	frr_preinit (&watchfrr_di, argv[0]);
 	progname = watchfrr_di.progname;
 
 	frr_opt_add("aAb:dek:l:i:p:r:R:S:s:t:T:z", longopts, "");

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -221,7 +221,7 @@ main (int argc, char **argv)
   /* Socket to external label manager */
   char *lblmgr_path = NULL;
 
-  frr_preinit(&zebra_di, argc, argv);
+  frr_preinit (&zebra_di, argv[0]);
 
   frr_opt_add("bakz:e:l:r"
 #ifdef HAVE_NETLINK


### PR DESCRIPTION
This patch cleans up an overgrown mess of configuration paths and global
variables and integrates them into libfrr.h where they rightly belong.

* Add a new singleton struct to act as a container for general purpose
  global variables
* Move the 'host' struct into the singleton (further organizational
  changes to come later on)
* Move a few miscellaneous globals externed from libfrr.c into the
  singleton
* Reduce frr_preinit() arguments to what is used at the moment

Among other things this helps eliminate duplicate code in vtysh,
specifically related to the location of integrated config file and
vtysh.conf

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>