### PR TITLE
A couple of compatibility/style fixes

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -380,3 +380,24 @@ CLI's are a complicated ugly beast.  Additions or changes to the CLI
 should use a DEFUN to encapsulate one setting as much as is possible.
 Additionally as new DEFUN's are added to the system, documentation
 should be provided for the new commands.
+
+### Backwards Compatibility
+
+As a general principle, changes to CLI and code in the lib/ directory
+should be made in a backwards compatible fashion. This means that
+changes that are purely stylistic in nature should be avoided, e.g.,
+renaming an existing macro or library function name without any
+functional change. When adding new parameters to common functions, it is
+also good to consider if this too should be done in a backward
+compatible fashion, e.g., by preserving the old form in addition to
+adding the new form.
+
+This is not to say that minor or even major functional changes to CLI
+and common code should be avoided, but rather that the benefit gained
+from a change should be weighed against the added cost/complexity to
+existing code.  Also, that when making such changes, it is good to
+preserve compatibility when possible to do so without introducing
+maintenance overhead/cost.  It is also important to keep in mind,
+existing code includes code that may reside in private repositories (and
+is yet to be submitted) or code that has yet to be migrated from Quagga
+to FRR.

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7365,7 +7365,7 @@ afi_safi_print (afi_t afi, safi_t safi)
   else if (afi == AFI_IP && safi == SAFI_MULTICAST)
     return "IPv4 Multicast";
   else if (afi == AFI_IP && safi == SAFI_LABELED_UNICAST)
-    return "IPv4 labeled-unicast";
+    return "IPv4 Labeled Unicast";
   else if (afi == AFI_IP && safi == SAFI_MPLS_VPN)
     return "IPv4 VPN";
   else if (afi == AFI_IP && safi == SAFI_ENCAP)
@@ -7375,7 +7375,7 @@ afi_safi_print (afi_t afi, safi_t safi)
   else if (afi == AFI_IP6 && safi == SAFI_MULTICAST)
     return "IPv6 Multicast";
   else if (afi == AFI_IP6 && safi == SAFI_LABELED_UNICAST)
-    return "IPv6 labeled-unicast";
+    return "IPv6 Labeled Unicast";
   else if (afi == AFI_IP6 && safi == SAFI_MPLS_VPN)
     return "IPv6 VPN";
   else if (afi == AFI_IP6 && safi == SAFI_ENCAP)

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -186,6 +186,10 @@ struct vty_arg
 #define VTY_NEWLINE                               VTYNL
 #define VTY_GET_INTEGER(desc,v,str)               {(v)=strtoul ((str), NULL, 10);}
 #define VTY_GET_INTEGER_RANGE(desc,v,str,min,max) {(v)=strtoul ((str), NULL, 10);}
+#define VTY_GET_ULONG(desc,v,str)                 {(v)=strtoul ((str), NULL, 10);}
+#define VTY_GET_ULL(desc,v,str)                   {(v)=strtoull ((str), NULL, 10);}
+#define VTY_GET_IPV4_ADDRESS(desc,v,str)          inet_aton ((str), &(v))
+#define VTY_GET_IPV4_PREFIX(desc,v,str)           str2prefix_ipv4 ((str), &(v))
 
 /* Default time out value */
 #define VTY_TIMEOUT_DEFAULT 600

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -182,6 +182,11 @@ struct vty_arg
 /* Small macro to determine newline is newline only or linefeed needed. */
 #define VTYNL  ((vty->type == VTY_TERM) ? "\r\n" : "\n")
 
+/* for compatibility */
+#define VTY_NEWLINE                               VTYNL
+#define VTY_GET_INTEGER(desc,v,str)               {(v)=strtoul ((str), NULL, 10);}
+#define VTY_GET_INTEGER_RANGE(desc,v,str,min,max) {(v)=strtoul ((str), NULL, 10);}
+
 /* Default time out value */
 #define VTY_TIMEOUT_DEFAULT 600
 


### PR DESCRIPTION
vty: add some defines for backwards compatibility
bgpd: have labeled unicast print consistent with other safis
