### PR TITLE
lib: init & cleanup fixes

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -428,6 +428,13 @@ DEFUN(show_hash_stats,
   long double ssq;    // ssq casted to long double
 
   pthread_mutex_lock (&_hashes_mtx);
+  if (!_hashes)
+    {
+      pthread_mutex_unlock (&_hashes_mtx);
+      vty_outln (vty, "No hash tables in use.");
+      return CMD_SUCCESS;
+    }
+
   for (ALL_LIST_ELEMENTS_RO (_hashes, ln, h))
     {
       if (!h->name)
@@ -482,6 +489,5 @@ DEFUN(show_hash_stats,
 void
 hash_cmd_init ()
 {
-  _hashes = list_new();
   install_element (ENABLE_NODE, &show_hash_stats_cmd);
 }

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -564,6 +564,12 @@ thread_master_free_unused (struct thread_master *m)
 void
 thread_master_free (struct thread_master *m)
 {
+  pthread_mutex_lock (&masters_mtx);
+  {
+    listnode_delete (masters, m);
+  }
+  pthread_mutex_unlock (&masters_mtx);
+
   thread_array_free (m, m->read);
   thread_array_free (m, m->write);
   thread_queue_free (m, m->timer);


### PR DESCRIPTION
hash_cmd_init will overwrite _hashes with a new list, while _hashes
already has been initialised from cmd_init(), thread_master_create(), or
any other function that may have created a hash.

Found while valgrind'ing ospf6d/test_lsdb.

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>