### PR TITLE
minor build-fixes

### DIFF
--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -126,7 +126,7 @@ typedef unsigned char   u_int8_t;
 #define __APPLE_USE_RFC_3542
 #endif
 
-#include "lib/openbsd-tree.h"
+#include "openbsd-tree.h"
 
 #include <netinet/in.h>
 #include <netinet/in_systm.h>

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -148,7 +148,9 @@ EXTRA_DIST = \
     lib/test_stream.refout \
     lib/test_table.py \
     lib/test_timer_correctness.py \
-    lib/test_ttable.py
+    lib/test_ttable.py \
+    lib/test_ttable.refout \
+    # end
 
 .PHONY: tests.xml
 tests.xml: $(check_PROGRAMS)


### PR DESCRIPTION
"$(top_srcdir)" is not on the include path, but "$(top_srcdir)/lib" is.
This is relevant when building with a separate build directory.

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>