### PR TITLE
lib: use 32-bit atomics, s/pow/mul

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -87,13 +87,8 @@ hash_alloc_intern (void *arg)
 }
 
 #define hash_update_ssq(hz, old, new) \
-  do { \
-    long double res; \
-    res = powl(old, 2.0); \
-    hz->stats.ssq -= (uint64_t) res;\
-    res = powl(new, 2.0); \
-    hz->stats.ssq += (uint64_t) res; \
-  } while (0); \
+    atomic_fetch_add_explicit(&hz->stats.ssq, (new + old)*(new - old),\
+                              memory_order_relaxed);
 
 /* Expand hash if the chain length exceeds the threshold. */
 static void hash_expand (struct hash *hash)

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -53,9 +53,9 @@ struct hash_backet
 struct hashstats
 {
   /* number of empty hash buckets */
-  _Atomic int empty;
+  _Atomic uint_fast32_t empty;
   /* sum of squares of bucket length */
-  _Atomic uint64_t ssq;
+  _Atomic uint_fast32_t ssq;
 };
 
 struct hash


### PR DESCRIPTION
Some platforms don't support 64-bit atomics, missed converting a
floating point pow() to an integral mul when changing SD algo.

cf. #790 

Some cursory performance analysis, insertion of 10000000 (ten million) integers. I hacked this into grammar_sandbox just for convenience.

```
diff --git a/lib/grammar_sandbox_main.c b/lib/grammar_sandbox_main.c
index 02aefd6..cb4fad6 100644
--- a/lib/grammar_sandbox_main.c
+++ b/lib/grammar_sandbox_main.c
@@ -25,6 +25,7 @@
 
 #include "command.h"
 #include "memory_vty.h"
+#include "hash.h"
 
 static void vty_do_exit(void)
 {
@@ -32,6 +33,18 @@ static void vty_do_exit(void)
   exit (0);
 }
 
+static unsigned int hash_key(void *obj)
+{
+  return (unsigned long) obj;
+}
+
+static int hash_cmp(const void *a, const void *b)
+{
+  int as = *((int *)a);
+  int af = *((int *)b);
+  return as == af ? 0 : as > af;
+}
+
 struct thread_master *master;
 
 int main(int argc, char **argv)
@@ -55,6 +68,15 @@ int main(int argc, char **argv)
 
   vty_stdio (vty_do_exit);
 
+  struct hash *h = hash_create(hash_key, hash_cmp, NULL);
+  int els = 10000000;
+  int *asdf = malloc(els * sizeof(int));
+  for (int i = 0; i < els; i++) {
+    asdf[i] = i;
+    hash_get (h, &asdf[i], hash_alloc_intern);
+  }
+  exit(0);
+
   /* Fetch next active thread. */
   while (thread_fetch (master, &thread))
     thread_call (&thread);
```

Looks like roughly a quarter second difference over ten million elements, I think this is acceptable, open to discussion.

With stats code
-------------------------------------------------
```
vagrant@frrdev ~/f/lib> for i in (seq 1 10)
                            sudo time ./grammar_sandbox
                        end
Run #1

end.
2.32user 0.13system 0:02.47elapsed 99%CPU (0avgtext+0avgdata 544520maxresident)k
0inputs+0outputs (0major+125294minor)pagefaults 0swaps
Run #2

end.
2.18user 0.13system 0:02.32elapsed 99%CPU (0avgtext+0avgdata 544676maxresident)k
0inputs+0outputs (0major+125813minor)pagefaults 0swaps
Run #3

end.
2.20user 0.14system 0:02.35elapsed 99%CPU (0avgtext+0avgdata 544520maxresident)k
0inputs+0outputs (0major+125303minor)pagefaults 0swaps
Run #4

end.
2.17user 0.16system 0:02.34elapsed 99%CPU (0avgtext+0avgdata 544600maxresident)k
0inputs+0outputs (0major+125818minor)pagefaults 0swaps
Run #5

end.
2.12user 0.16system 0:02.29elapsed 99%CPU (0avgtext+0avgdata 544636maxresident)k
0inputs+0outputs (0major+125819minor)pagefaults 0swaps
Run #6

end.
2.07user 0.17system 0:02.26elapsed 99%CPU (0avgtext+0avgdata 544580maxresident)k
0inputs+0outputs (0major+125823minor)pagefaults 0swaps
Run #7

end.
2.10user 0.15system 0:02.27elapsed 99%CPU (0avgtext+0avgdata 544516maxresident)k
0inputs+0outputs (0major+125807minor)pagefaults 0swaps
Run #8

end.
2.11user 0.17system 0:02.30elapsed 99%CPU (0avgtext+0avgdata 544636maxresident)k
0inputs+0outputs (0major+125807minor)pagefaults 0swaps
Run #9

end.
2.10user 0.18system 0:02.30elapsed 99%CPU (0avgtext+0avgdata 544672maxresident)k
0inputs+0outputs (0major+125825minor)pagefaults 0swaps
Run #10

end.
2.38user 0.15system 0:02.55elapsed 99%CPU (0avgtext+0avgdata 544628maxresident)k
0inputs+0outputs (0major+125839minor)pagefaults 0swaps
```


Without stats code
---------------------------------------
```
vagrant@frrdev ~/f/lib> for i in (seq 1 10)
                            sudo time ./grammar_sandbox
                        end

Run #1

end.
1.94user 0.14system 0:02.10elapsed 99%CPU (0avgtext+0avgdata 544540maxresident)k
0inputs+40outputs (0major+128320minor)pagefaults 0swaps
Run #2

end.
1.92user 0.16system 0:02.10elapsed 99%CPU (0avgtext+0avgdata 544540maxresident)k
0inputs+0outputs (0major+125816minor)pagefaults 0swaps
Run #3

end.
1.95user 0.14system 0:02.10elapsed 99%CPU (0avgtext+0avgdata 544664maxresident)k
0inputs+0outputs (0major+125806minor)pagefaults 0swaps
Run #4

end.
1.95user 0.15system 0:02.11elapsed 99%CPU (0avgtext+0avgdata 544524maxresident)k
0inputs+0outputs (0major+123766minor)pagefaults 0swaps
Run #5

end.
1.96user 0.14system 0:02.11elapsed 99%CPU (0avgtext+0avgdata 544428maxresident)k
0inputs+0outputs (0major+125825minor)pagefaults 0swaps
Run #6

end.
1.97user 0.13system 0:02.11elapsed 99%CPU (0avgtext+0avgdata 544512maxresident)k
0inputs+0outputs (0major+125809minor)pagefaults 0swaps
Run #7

end.
1.89user 0.16system 0:02.06elapsed 99%CPU (0avgtext+0avgdata 544572maxresident)k
0inputs+0outputs (0major+125806minor)pagefaults 0swaps
Run #8

end.
1.96user 0.12system 0:02.10elapsed 99%CPU (0avgtext+0avgdata 544628maxresident)k
0inputs+0outputs (0major+125809minor)pagefaults 0swaps
Run #9

end.
1.97user 0.12system 0:02.11elapsed 99%CPU (0avgtext+0avgdata 544500maxresident)k
0inputs+0outputs (0major+125302minor)pagefaults 0swaps
Run #10

end.
1.96user 0.12system 0:02.10elapsed 99%CPU (0avgtext+0avgdata 544596maxresident)k
0inputs+0outputs (0major+125816minor)pagefaults 0swaps
```

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>