### PR TITLE
bgpd: show bgp ipv4 label-unicast does not provide any output

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9182,21 +9182,25 @@ bgp_table_stats (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi)
 {
   struct bgp_table_stats ts;
   unsigned int i;
-  
+
   if (!bgp->rib[afi][safi])
     {
       vty_outln (vty, "%% No RIB exist's for the AFI(%d)/SAFI(%d)",
 	       afi, safi);
       return CMD_WARNING;
     }
-  
+
+  vty_outln (vty, "BGP %s RIB statistics%s",
+           afi_safi_print (afi, safi), VTYNL);
+
+  /* labeled-unicast routes live in the unicast table */
+  if (safi == SAFI_LABELED_UNICAST)
+    safi = SAFI_UNICAST;
+
   memset (&ts, 0, sizeof (ts));
   ts.table = bgp->rib[afi][safi];
   thread_execute (bm->master, bgp_table_stats_walker, &ts, 0);
 
-  vty_outln (vty, "BGP %s RIB statistics%s",
-           afi_safi_print (afi, safi), VTYNL);
-  
   for (i = 0; i < BGP_STATS_MAX; i++)
     {
       if (!table_stats_strs[i])
@@ -9968,10 +9972,6 @@ static int
 bgp_show_neighbor_route (struct vty *vty, struct peer *peer, afi_t afi,
 			 safi_t safi, enum bgp_show_type type, u_char use_json)
 {
-  /* labeled-unicast routes live in the unicast table */
-  if (safi == SAFI_LABELED_UNICAST)
-    safi = SAFI_UNICAST;
-
   if (! peer || ! peer->afc[afi][safi])
     {
       if (use_json)
@@ -9986,6 +9986,10 @@ bgp_show_neighbor_route (struct vty *vty, struct peer *peer, afi_t afi,
         vty_outln (vty, "%% No such neighbor or address family");
       return CMD_WARNING;
     }
+
+  /* labeled-unicast routes live in the unicast table */
+  if (safi == SAFI_LABELED_UNICAST)
+    safi = SAFI_UNICAST;
 
   return bgp_show (vty, peer->bgp, afi, safi, type, &peer->su, use_json);
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8067,12 +8067,16 @@ bgp_show (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
         vty_outln (vty, "No BGP process is configured");
       return CMD_WARNING;
     }
+
   /* use MPLS and ENCAP specific shows until they are merged */
   if (safi == SAFI_MPLS_VPN) 
     {
       return bgp_show_mpls_vpn(vty, afi, NULL, type, output_arg,
                                0, use_json);
     }
+  /* labeled-unicast routes live in the unicast table */
+  else if (safi == SAFI_LABELED_UNICAST)
+    safi = SAFI_UNICAST;
 
   table = bgp->rib[afi][safi];
 
@@ -8390,6 +8394,10 @@ bgp_show_route (struct vty *vty, struct bgp *bgp, const char *ip_str,
   if (!bgp)
     bgp = bgp_get_default ();
 
+  /* labeled-unicast routes live in the unicast table */
+  if (safi == SAFI_LABELED_UNICAST)
+    safi = SAFI_UNICAST;
+
   return bgp_show_route_in_table (vty, bgp, bgp->rib[afi][safi], ip_str, 
                                   afi, safi, prd, prefix_check, pathtype,
                                   use_json);
@@ -8453,13 +8461,13 @@ bgp_show_lcommunity_list (struct vty *vty, struct bgp *bgp, const char *lcom,
 
 DEFUN (show_ip_bgp_large_community_list,
        show_ip_bgp_large_community_list_cmd,
-       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]] large-community-list <(1-500)|WORD> [json]",
+       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]] large-community-list <(1-500)|WORD> [json]",
        SHOW_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        BGP_AFI_HELP_STR
-       BGP_SAFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
        "Display routes matching the large-community-list\n"
        "large-community-list number\n"
        "large-community-list name\n"
@@ -8495,13 +8503,13 @@ DEFUN (show_ip_bgp_large_community_list,
 }
 DEFUN (show_ip_bgp_large_community,
        show_ip_bgp_large_community_cmd,
-       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]] large-community [AA:BB:CC] [json]",
+       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]] large-community [AA:BB:CC] [json]",
        SHOW_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        BGP_AFI_HELP_STR
-       BGP_SAFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
        "Display routes matching the large-communities\n"
        "List of large-community numbers\n"
        JSON_STR)
@@ -8542,7 +8550,7 @@ static int bgp_table_stats (struct vty *vty, struct bgp *bgp, afi_t afi, safi_t 
 /* BGP route print out function. */
 DEFUN (show_ip_bgp,
        show_ip_bgp_cmd,
-       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]]\
+       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]]\
           [<\
              cidr-only\
              |dampening <flap-statistics|dampened-paths|parameters>\
@@ -8560,7 +8568,7 @@ DEFUN (show_ip_bgp,
        BGP_STR
        BGP_INSTANCE_HELP_STR
        BGP_AFI_HELP_STR
-       BGP_SAFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
        "Display only routes with non-natural netmasks\n"
        "Display detailed information about dampening\n"
        "Display flap statistics of routes\n"
@@ -8663,14 +8671,14 @@ DEFUN (show_ip_bgp,
 
 DEFUN (show_ip_bgp_route,
        show_ip_bgp_route_cmd,
-       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]]"
+       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]]"
        "<A.B.C.D|A.B.C.D/M|X:X::X:X|X:X::X:X/M> [<bestpath|multipath>] [json]",
        SHOW_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        BGP_AFI_HELP_STR
-       BGP_SAFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
        "Network in the BGP routing table to display\n"
        "IPv4 prefix\n"
        "Network in the BGP routing table to display\n"
@@ -8735,13 +8743,13 @@ DEFUN (show_ip_bgp_route,
 
 DEFUN (show_ip_bgp_regexp,
        show_ip_bgp_regexp_cmd,
-       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]] regexp REGEX...",
+       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]] regexp REGEX...",
        SHOW_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        BGP_AFI_HELP_STR
-       BGP_SAFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
        "Display routes matching the AS path regular expression\n"
        "A regular-expression to match the BGP AS paths\n")
 {
@@ -8766,13 +8774,13 @@ DEFUN (show_ip_bgp_regexp,
 
 DEFUN (show_ip_bgp_instance_all,
        show_ip_bgp_instance_all_cmd,
-       "show [ip] bgp <view|vrf> all ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]] [json]",
+       "show [ip] bgp <view|vrf> all ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]] [json]",
        SHOW_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_ALL_HELP_STR
        BGP_AFI_HELP_STR
-       BGP_SAFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
        JSON_STR)
 {
   afi_t afi = AFI_IP;
@@ -9777,6 +9785,10 @@ peer_adj_routes (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
   if (use_json)
     json = json_object_new_object();
 
+  /* labeled-unicast routes live in the unicast table */
+  if (safi == SAFI_LABELED_UNICAST)
+    safi = SAFI_UNICAST;
+
   if (!peer || !peer->afc[afi][safi])
     {
       if (use_json)
@@ -9812,14 +9824,14 @@ peer_adj_routes (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
 
 DEFUN (show_ip_bgp_instance_neighbor_advertised_route,
        show_ip_bgp_instance_neighbor_advertised_route_cmd,
-       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]] "
+       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]] "
        "neighbors <A.B.C.D|X:X::X:X|WORD> <received-routes|advertised-routes> [route-map WORD] [json]",
        SHOW_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        BGP_AFI_HELP_STR
-       BGP_SAFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -9956,6 +9968,10 @@ static int
 bgp_show_neighbor_route (struct vty *vty, struct peer *peer, afi_t afi,
 			 safi_t safi, enum bgp_show_type type, u_char use_json)
 {
+  /* labeled-unicast routes live in the unicast table */
+  if (safi == SAFI_LABELED_UNICAST)
+    safi = SAFI_UNICAST;
+
   if (! peer || ! peer->afc[afi][safi])
     {
       if (use_json)
@@ -9976,14 +9992,14 @@ bgp_show_neighbor_route (struct vty *vty, struct peer *peer, afi_t afi,
 
 DEFUN (show_ip_bgp_neighbor_routes,
        show_ip_bgp_neighbor_routes_cmd,
-       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]] "
+       "show [ip] bgp [<view|vrf> VIEWVRFNAME] ["BGP_AFI_CMD_STR" ["BGP_SAFI_WITH_LABEL_CMD_STR"]] "
        "neighbors <A.B.C.D|X:X::X:X|WORD> <flap-statistics|dampened-routes|routes> [json]",
        SHOW_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        BGP_AFI_HELP_STR
-       BGP_SAFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6815,8 +6815,17 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
   int neighbor_col_default_width = 16;
   int len;
   int max_neighbor_width = 0;
+  int pfx_rcd_safi;
   json_object *json_peer = NULL;
   json_object *json_peers = NULL;
+
+  /* labeled-unicast routes are installed in the unicast table so in order to
+   * display the correct PfxRcd value we must look at SAFI_UNICAST
+   */
+  if (safi == SAFI_LABELED_UNICAST)
+    pfx_rcd_safi = SAFI_UNICAST;
+  else
+    pfx_rcd_safi = safi;
 
   if (use_json)
     {
@@ -7050,7 +7059,7 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
               json_object_int_add(json_peer, "outq", peer->obuf->count);
               json_object_int_add(json_peer, "inq", 0);
               peer_uptime (peer->uptime, timebuf, BGP_UPTIME_LEN, use_json, json_peer);
-              json_object_int_add(json_peer, "prefixReceivedCount", peer->pcount[afi][safi]);
+              json_object_int_add(json_peer, "prefixReceivedCount", peer->pcount[afi][pfx_rcd_safi]);
 
               if (CHECK_FLAG (peer->flags, PEER_FLAG_SHUTDOWN))
                 json_object_string_add(json_peer, "state", "Idle (Admin)");
@@ -7101,7 +7110,7 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
                        peer_uptime (peer->uptime, timebuf, BGP_UPTIME_LEN, 0, NULL));
 
               if (peer->status == Established)
-                  vty_out (vty, " %12ld", peer->pcount[afi][safi]);
+                  vty_out (vty, " %12ld", peer->pcount[afi][pfx_rcd_safi]);
               else
                 {
                   if (CHECK_FLAG (peer->flags, PEER_FLAG_SHUTDOWN))


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>
Reviewed-by:   Donald Sharp <sharpd@cumulusnetworks.com>

labeled-unicast routes are installed in the unicast table, to make
troubleshooting easier we need "show bgp ipv4 labeled-unicast x.x.x.x"
to show the x.x.x.x route in the unicast table.