### PR TITLE
lib, vtysh: pretty-print variable autocompletions

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -715,6 +715,41 @@ cmd_variable_complete (struct cmd_token *token, const char *arg, vector comps)
   vector_free(tmpcomps);
 }
 
+#define AUTOCOMP_INDENT 5
+
+char *
+cmd_variable_comp2str(vector comps, unsigned short cols, const char nl[])
+{
+  size_t bsz = 16;
+  char *buf = XCALLOC(MTYPE_TMP, bsz);
+  int lc = AUTOCOMP_INDENT;
+  size_t cs = AUTOCOMP_INDENT;
+  size_t nllen = strlen(nl);
+  size_t itemlen;
+  snprintf(buf, bsz, "%*s", AUTOCOMP_INDENT, "");
+  for (size_t j = 0; j < vector_active (comps); j++)
+    {
+      char *item = vector_slot (comps, j);
+      itemlen = strlen(item);
+
+      if (cs + itemlen + nllen + AUTOCOMP_INDENT + 2 >= bsz)
+        buf = XREALLOC(MTYPE_TMP, buf, (bsz *= 2));
+
+      if (lc + itemlen + 1 >= cols)
+        {
+          cs += snprintf(&buf[cs], bsz - cs, "%s%*s", nl, AUTOCOMP_INDENT, "");
+          lc = AUTOCOMP_INDENT;
+        }
+
+      size_t written = snprintf(&buf[cs], bsz - cs, "%s ", item);
+      lc += written;
+      cs += written;
+      XFREE (MTYPE_COMPLETION, item);
+      vector_set_index (comps, j, NULL);
+    }
+  return buf;
+}
+
 void
 cmd_variable_handler_register (const struct cmd_variable_handler *cvh)
 {

--- a/lib/command.h
+++ b/lib/command.h
@@ -404,5 +404,6 @@ struct cmd_variable_handler {
 
 extern void cmd_variable_complete (struct cmd_token *token, const char *arg, vector comps);
 extern void cmd_variable_handler_register (const struct cmd_variable_handler *cvh);
+extern char *cmd_variable_comp2str (vector comps, unsigned short cols, const char nl[]);
 
 #endif /* _ZEBRA_COMMAND_H */

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -1134,17 +1134,13 @@ vty_describe_command (struct vty *vty)
             vector varcomps = vector_init (VECTOR_MIN_SIZE);
             cmd_variable_complete (token, ref, varcomps);
 
-            if (vector_active(varcomps) > 0)
+            if (vector_active (varcomps) > 0)
               {
-                vty_out(vty, "     ");
-                for (size_t j = 0; j < vector_active (varcomps); j++)
-                  {
-                    char *item = vector_slot (varcomps, j);
-                    vty_out(vty, " %s", item);
-                    XFREE(MTYPE_COMPLETION, item);
-                  }
-                vty_out (vty, VTYNL);
+                char *ac = cmd_variable_comp2str(varcomps, vty->width, VTYNL);
+                vty_outln(vty, "%s", ac);
+                XFREE(MTYPE_TMP, ac);
               }
+
             vector_free(varcomps);
           }
 #if 0

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -771,7 +771,7 @@ vtysh_rl_describe (void)
       rl_on_new_line ();
       return 0;
       break;
-    }  
+    }
 
   /* Get width of command string. */
   width = 0;
@@ -808,15 +808,14 @@ vtysh_rl_describe (void)
 
             if (vector_active (varcomps) > 0)
               {
-                fprintf(stdout, "     ");
-                for (size_t j = 0; j < vector_active (varcomps); j++)
-                  {
-                    char *item = vector_slot (varcomps, j);
-                    fprintf (stdout, " %s", item);
-                    XFREE (MTYPE_COMPLETION, item);
-                  }
-                vty_out (vty, VTYNL);
+                int rows, cols;
+                rl_get_screen_size(&rows, &cols);
+
+                char *ac = cmd_variable_comp2str(varcomps, cols, "\n");
+                fprintf(stdout, "%s\n", ac);
+                XFREE(MTYPE_TMP, ac);
               }
+
             vector_free (varcomps);
           }
       }


### PR DESCRIPTION
Pretty-prints variable autocompletions by breaking them up into multiple
lines, indenting them consistently and respecting the column width of
the terminal.

Before:
```
dell-s6000-16# show interface
  <cr>
  IFNAME       Interface name
     eth0 lo swp1s0 swp1s1 swp1s2 swp1s3 swp2 swp3 swp4 swp5 swp6 swp7 swp8 swp9 swp10 swp11 swp12 swp13
swp14 swp15 swp16 swp17 swp18s0 swp18s1 swp18s2 swp18s3 swp19 swp20 swp21 swp22 swp23 swp24 swp25 swp26 s
wp27 swp28 swp29 swp30 swp31 swp32
  description  Interface description
  vrf          Specify the VRF
dell-s6000-16#
```

After
```
dell-s6000-16# show interface
  <cr>
  IFNAME       Interface name
     eth0 lo swp1s0 swp1s1 swp1s2 swp1s3 swp2 swp3 swp4 swp5 swp6 swp7 swp8 swp9 swp10 swp11 swp12
     swp13 swp14 swp15 swp16 swp17 swp18s0 swp18s1 swp18s2 swp18s3 swp19 swp20 swp21 swp22 swp23 swp24
     swp25 swp26 swp27 swp28 swp29 swp30 swp31 swp32
  description  Interface description
  vrf          Specify the VRF
dell-s6000-16#
```

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>