### PR TITLE
vtysh: fixup password commands

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2445,20 +2445,10 @@ DEFUNSH (VTYSH_ALL,
 DEFUNSH (VTYSH_ALL,
 	 vtysh_config_password,
 	 vtysh_password_cmd,
-	 "password [(8-8)] WORD",
+	 "password [(8-8)] LINE",
 	 "Assign the terminal connection password\n"
 	 "Specifies a HIDDEN password will follow\n"
-	 "The HIDDEN line password string\n")
-{
-  return CMD_SUCCESS;
-}
-
-DEFUNSH (VTYSH_ALL,
-	 vtysh_password_text,
-	 vtysh_password_text_cmd,
-	 "password LINE",
-	 "Assign the terminal connection password\n"
-	 "The UNENCRYPTED (cleartext) line password\n")
+	 "The password string\n")
 {
   return CMD_SUCCESS;
 }
@@ -2466,22 +2456,11 @@ DEFUNSH (VTYSH_ALL,
 DEFUNSH (VTYSH_ALL,
 	 vtysh_config_enable_password,
 	 vtysh_enable_password_cmd,
-	 "enable password (8-8) WORD",
+	 "enable password [(8-8)] LINE",
 	 "Modify enable password parameters\n"
 	 "Assign the privileged level password\n"
 	 "Specifies a HIDDEN password will follow\n"
-	 "The HIDDEN 'enable' password string\n")
-{
-  return CMD_SUCCESS;
-}
-
-DEFUNSH (VTYSH_ALL,
-	 vtysh_enable_password_text,
-	 vtysh_enable_password_text_cmd,
-	 "enable password LINE",
-	 "Modify enable password parameters\n"
-	 "Assign the privileged level password\n"
-	 "The UNENCRYPTED (cleartext) 'enable' password\n")
+	 "The 'enable' password string\n")
 {
   return CMD_SUCCESS;
 }
@@ -3630,8 +3609,6 @@ vtysh_init_vty (void)
   install_element (CONFIG_NODE, &no_vtysh_service_password_encrypt_cmd);
 
   install_element (CONFIG_NODE, &vtysh_password_cmd);
-  install_element (CONFIG_NODE, &vtysh_password_text_cmd);
   install_element (CONFIG_NODE, &vtysh_enable_password_cmd);
-  install_element (CONFIG_NODE, &vtysh_enable_password_text_cmd);
   install_element (CONFIG_NODE, &no_vtysh_enable_password_cmd);
 }


### PR DESCRIPTION
`password` and `enable password` commands got a bit broken in an earlier
commit, fix 'em up.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>