### PR TITLE
babeld: Allow babel to redistribute v6 routes

### DIFF
--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -227,6 +227,7 @@ DEFUN (babel_redistribute_type,
     }
 
     zclient_redistribute (ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP, type, 0, VRF_DEFAULT);
+    zclient_redistribute (ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP6, type, 0, VRF_DEFAULT);
     return CMD_SUCCESS;
 }
 
@@ -248,6 +249,7 @@ DEFUN (no_babel_redistribute_type,
     }
 
     zclient_redistribute (ZEBRA_REDISTRIBUTE_DELETE, zclient, AFI_IP, type, 0, VRF_DEFAULT);
+    zclient_redistribute (ZEBRA_REDISTRIBUTE_DELETE, zclient, AFI_IP6, type, 0, VRF_DEFAULT);
     /* perhaps should we remove xroutes having the same type... */
     return CMD_SUCCESS;
 }


### PR DESCRIPTION
Turn on the ability in babel to receive v6 routes when requested.

robot# show babel route
192.168.201.0/24 metric 0 (exported)
2606:a000:111d:803e::/64 metric 0 (exported)
robot# conf t
robot(config)# int enp3s0
robot(config-if)# ipv6 addr 2404:4000:991d:804c:c32:ee94:742c:4d5/73
robot(config-if)# end
robot# show babel route
192.168.201.0/24 metric 0 (exported)
2606:a000:111d:803e::/64 metric 0 (exported)
2404:4000:991d:804c:c00::/73 metric 0 (exported)
robot#

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>