### PR TITLE
bgpd: fix peer startup for labeled-unicast if linklocal address not f…

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1151,6 +1151,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	/* Verify valid local address present based on negotiated
 	 * address-families. */
 	if (peer->afc_nego[AFI_IP][SAFI_UNICAST]
+	    || peer->afc_nego[AFI_IP][SAFI_LABELED_UNICAST]
 	    || peer->afc_nego[AFI_IP][SAFI_MULTICAST]
 	    || peer->afc_nego[AFI_IP][SAFI_MPLS_VPN]
 	    || peer->afc_nego[AFI_IP][SAFI_ENCAP]) {
@@ -1166,6 +1167,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		}
 	}
 	if (peer->afc_nego[AFI_IP6][SAFI_UNICAST]
+	    || peer->afc_nego[AFI_IP6][SAFI_LABELED_UNICAST]
 	    || peer->afc_nego[AFI_IP6][SAFI_MULTICAST]
 	    || peer->afc_nego[AFI_IP6][SAFI_MPLS_VPN]
 	    || peer->afc_nego[AFI_IP6][SAFI_ENCAP]) {


### PR DESCRIPTION
…ound

Problem found in testing where ipv6 labeled-unicast prefixes were not received
on the peers if a "service networking restart" was issued.  Same problem would
happen with an ifdown/ifup on the link to the peer.  Found the problem to be
that peers would establish for labeled-unicast even if a link-local address was
not yet available on the interface toward the peer, causing updates to be sent
without a nexthop value. These were then rejected by the peer. Fix is to delay
peer establishment until after the link-local addresses are available.

Ticket: CM-16779
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Reviewed By: Donald Sharp <sharpd@cumulusnetworks.com>
Testing Done: Manual testing successful.  Bgp-smoke completed with no new failures