### PR TITLE
OSPF OPAQUE, TE and RI macro refactoring & cleanup

### DIFF
--- a/ospfd/ospf_opaque.h
+++ b/ospfd/ospf_opaque.h
@@ -82,33 +82,31 @@
  * used for various LSA opaque usage e.g. Traffic Engineering.
  */
 struct tlv_header {
-  u_int16_t     type;                   /* Type of Value */
-  u_int16_t     length;                 /* Length of Value portion only, in bytes */
+	u_int16_t type;		/* Type of Value */
+	u_int16_t length;	/* Length of Value portion only, in bytes */
 };
 
-#define TLV_HDR_SIZE \
-        (sizeof (struct tlv_header))
+#define TLV_HDR_SIZE	(sizeof(struct tlv_header))
 
 #define TLV_BODY_SIZE(tlvh) \
-        (ROUNDUP (ntohs ((tlvh)->length), sizeof (u_int32_t)))
+	(ROUNDUP(ntohs((tlvh)->length), sizeof(u_int32_t)))
 
-#define TLV_SIZE(tlvh) \
-        (TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
+#define TLV_SIZE(tlvh)	(TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
 
 #define TLV_HDR_TOP(lsah) \
-        (struct tlv_header *)((char *)(lsah) + OSPF_LSA_HEADER_SIZE)
+	(struct tlv_header *)((char *)(lsah) + OSPF_LSA_HEADER_SIZE)
 
 #define TLV_HDR_NEXT(tlvh) \
-        (struct tlv_header *)((char *)(tlvh) + TLV_SIZE(tlvh))
+	(struct tlv_header *)((char *)(tlvh) + TLV_SIZE(tlvh))
 
 #define TLV_HDR_SUBTLV(tlvh) \
-        (struct tlv_header *)((char *)(tlvh) + TLV_HDR_SIZE)
+	(struct tlv_header *)((char *)(tlvh) + TLV_HDR_SIZE)
 
-#define TLV_DATA(tlvh)     (void *)((char *)(tlvh) + TLV_HDR_SIZE)
+#define TLV_DATA(tlvh)	(void *)((char *)(tlvh) + TLV_HDR_SIZE)
 
-#define TLV_TYPE(tlvh)     tlvh.header.type
-#define TLV_LEN(tlvh)      tlvh.header.length
-#define TLV_HDR(tlvh)      tlvh.header
+#define TLV_TYPE(tlvh)	tlvh.header.type
+#define TLV_LEN(tlvh)	tlvh.header.length
+#define TLV_HDR(tlvh)	tlvh.header
 
 /* Following declaration concerns the Opaque LSA management */
 enum lsa_opcode {
@@ -148,7 +146,7 @@ extern int ospf_opaque_new_if(struct interface *ifp);
 extern int ospf_opaque_del_if(struct interface *ifp);
 extern void ospf_opaque_ism_change(struct ospf_interface *oi, int old_status);
 extern void ospf_opaque_nsm_change(struct ospf_neighbor *nbr, int old_status);
-extern void ospf_opaque_config_write_router(struct vty *vty, struct ospf *);
+extern void ospf_opaque_config_write_router(struct vty *vty, struct ospf *ospf);
 extern void ospf_opaque_config_write_if(struct vty *vty, struct interface *ifp);
 extern void ospf_opaque_config_write_debug(struct vty *vty);
 extern void show_opaque_info_detail(struct vty *vty, struct ospf_lsa *lsa);
@@ -156,7 +154,7 @@ extern void ospf_opaque_lsa_dump(struct stream *s, u_int16_t length);
 
 extern void ospf_opaque_lsa_originate_schedule(struct ospf_interface *oi,
 					       int *init_delay);
-extern struct ospf_lsa *ospf_opaque_lsa_install(struct ospf_lsa *,
+extern struct ospf_lsa *ospf_opaque_lsa_install(struct ospf_lsa *lsa,
 						int rt_recalc);
 extern struct ospf_lsa *ospf_opaque_lsa_refresh(struct ospf_lsa *lsa);
 

--- a/ospfd/ospf_opaque.h
+++ b/ospfd/ospf_opaque.h
@@ -81,8 +81,7 @@
  * Following section defines generic TLV (type, length, value) macros,
  * used for various LSA opaque usage e.g. Traffic Engineering.
  */
-struct tlv_header
-{
+struct tlv_header {
   u_int16_t     type;                   /* Type of Value */
   u_int16_t     length;                 /* Length of Value portion only, in bytes */
 };
@@ -112,11 +111,11 @@ struct tlv_header
 #define TLV_HDR(tlvh)      tlvh.header
 
 /* Following declaration concerns the Opaque LSA management */
-typedef enum _opcode_t {
+enum lsa_opcode {
 	REORIGINATE_THIS_LSA,
 	REFRESH_THIS_LSA,
 	FLUSH_THIS_LSA
-} opcode_t;
+};
 
 /* Prototypes. */
 

--- a/ospfd/ospf_opaque.h
+++ b/ospfd/ospf_opaque.h
@@ -77,6 +77,47 @@
 	((ntohs((lsahdr)->length) >= sizeof(struct lsa_header))                \
 	 && ((ntohs((lsahdr)->length) % sizeof(u_int32_t)) == 0))
 
+/*
+ * Following section defines generic TLV (type, length, value) macros,
+ * used for various LSA opaque usage e.g. Traffic Engineering.
+ */
+struct tlv_header
+{
+  u_int16_t     type;                   /* Type of Value */
+  u_int16_t     length;                 /* Length of Value portion only, in bytes */
+};
+
+#define TLV_HDR_SIZE \
+        (sizeof (struct tlv_header))
+
+#define TLV_BODY_SIZE(tlvh) \
+        (ROUNDUP (ntohs ((tlvh)->length), sizeof (u_int32_t)))
+
+#define TLV_SIZE(tlvh) \
+        (TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
+
+#define TLV_HDR_TOP(lsah) \
+        (struct tlv_header *)((char *)(lsah) + OSPF_LSA_HEADER_SIZE)
+
+#define TLV_HDR_NEXT(tlvh) \
+        (struct tlv_header *)((char *)(tlvh) + TLV_SIZE(tlvh))
+
+#define TLV_HDR_SUBTLV(tlvh) \
+        (struct tlv_header *)((char *)(tlvh) + TLV_HDR_SIZE)
+
+#define TLV_DATA(tlvh)     (void *)((char *)(tlvh) + TLV_HDR_SIZE)
+
+#define TLV_TYPE(tlvh)     tlvh.header.type
+#define TLV_LEN(tlvh)      tlvh.header.length
+#define TLV_HDR(tlvh)      tlvh.header
+
+/* Following declaration concerns the Opaque LSA management */
+typedef enum _opcode_t {
+	REORIGINATE_THIS_LSA,
+	REFRESH_THIS_LSA,
+	FLUSH_THIS_LSA
+} opcode_t;
+
 /* Prototypes. */
 
 extern void ospf_opaque_init(void);

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -506,7 +506,7 @@ static void build_tlv(struct stream *s, struct tlv_header *tlvh)
 
 	if (ntohs(tlvh->type) != 0) {
 		build_tlv_header(s, tlvh);
-		stream_put(s, tlvh + 1, TLV_BODY_SIZE(tlvh));
+		stream_put(s, TLV_DATA(tlvh), TLV_BODY_SIZE(tlvh));
 	}
 	return;
 }

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -58,9 +58,9 @@
 #include "ospfd/ospf_ri.h"
 #include "ospfd/ospf_te.h"
 
+/* Store Router Information PCE TLV and SubTLV in network byte order. */
 struct ospf_pce_info {
-
-	/* Store Router Information PCE TLV and SubTLV in network byte order. */
+	status_t status;
 	struct ri_tlv_pce pce_header;
 	struct ri_pce_subtlv_address pce_address;
 	struct ri_pce_subtlv_path_scope pce_scope;
@@ -77,9 +77,8 @@ struct ospf_router_info {
 	u_int8_t scope;
 
 /* Flags to manage this router information. */
-#define RIFLG_LOOKUP_DONE			0x1
-#define RIFLG_LSA_ENGAGED			0x2
-#define RIFLG_LSA_FORCED_REFRESH	0x4
+#define RIFLG_LSA_ENGAGED			0x1
+#define RIFLG_LSA_FORCED_REFRESH	0x2
 	u_int32_t flags;
 
 	/* area pointer if flooding is Type 10 Null if flooding is AS scope */
@@ -120,12 +119,13 @@ int ospf_router_info_init(void)
 {
 
 	memset(&OspfRI, 0, sizeof(struct ospf_router_info));
-	OspfRI.status = disabled;
+	OspfRI.status = disable;
 	OspfRI.registered = 0;
 	OspfRI.scope = OSPF_OPAQUE_AS_LSA;
 	OspfRI.flags = 0;
 
 	/* Initialize pce domain and neighbor list */
+	OspfRI.pce_info.status = disable;
 	OspfRI.pce_info.pce_domain = list_new();
 	OspfRI.pce_info.pce_domain->del = del_pce_info;
 	OspfRI.pce_info.pce_neighbor = list_new();
@@ -141,7 +141,7 @@ static int ospf_router_info_register(u_int8_t scope)
 	int rc = 0;
 
 	if (OspfRI.registered)
-		return 0;
+		return rc;
 
 	zlog_info("Register Router Information with scope %s(%d)",
 		  scope == OSPF_OPAQUE_AREA_LSA ? "Area" : "AS", scope);
@@ -165,7 +165,7 @@ static int ospf_router_info_register(u_int8_t scope)
 
 	OspfRI.registered = 1;
 	OspfRI.scope = scope;
-	return 0;
+	return rc;
 }
 
 static int ospf_router_info_unregister()
@@ -193,7 +193,7 @@ void ospf_router_info_term(void)
 
 	OspfRI.pce_info.pce_domain = NULL;
 	OspfRI.pce_info.pce_neighbor = NULL;
-	OspfRI.status = disabled;
+	OspfRI.status = disable;
 
 	ospf_router_info_unregister();
 
@@ -229,34 +229,36 @@ static int set_pce_header(struct ospf_pce_info *pce)
 
 	/* PCE Address */
 	if (ntohs(pce->pce_address.header.type) != 0)
-		length += RI_TLV_SIZE(&pce->pce_address.header);
+		length += TLV_SIZE(&pce->pce_address.header);
 
 	/* PCE Path Scope */
 	if (ntohs(pce->pce_scope.header.type) != 0)
-		length += RI_TLV_SIZE(&pce->pce_scope.header);
+		length += TLV_SIZE(&pce->pce_scope.header);
 
 	/* PCE Domain */
 	for (ALL_LIST_ELEMENTS_RO(pce->pce_domain, node, domain)) {
 		if (ntohs(domain->header.type) != 0)
-			length += RI_TLV_SIZE(&domain->header);
+			length += TLV_SIZE(&domain->header);
 	}
 
 	/* PCE Neighbor */
 	for (ALL_LIST_ELEMENTS_RO(pce->pce_neighbor, node, neighbor)) {
 		if (ntohs(neighbor->header.type) != 0)
-			length += RI_TLV_SIZE(&neighbor->header);
+			length += TLV_SIZE(&neighbor->header);
 	}
 
 	/* PCE Capabilities */
 	if (ntohs(pce->pce_cap_flag.header.type) != 0)
-		length += RI_TLV_SIZE(&pce->pce_cap_flag.header);
+		length += TLV_SIZE(&pce->pce_cap_flag.header);
 
 	if (length != 0) {
 		pce->pce_header.header.type = htons(RI_TLV_PCE);
 		pce->pce_header.header.length = htons(length);
+		pce->status = enable;
 	} else {
 		pce->pce_header.header.type = 0;
 		pce->pce_header.header.length = 0;
+		pce->status = disable;
 	}
 
 	return length;
@@ -279,8 +281,6 @@ static void set_pce_address(struct in_addr ipv4, struct ospf_pce_info *pce)
 static void set_pce_path_scope(u_int32_t scope, struct ospf_pce_info *pce)
 {
 
-	/* Enable PCE Info */
-	pce->pce_header.header.type = htons(RI_TLV_PCE);
 	/* Set PCE Scope */
 	pce->pce_scope.header.type = htons(RI_PCE_SUBTLV_PATH_SCOPE);
 	pce->pce_scope.header.length = htons(RI_TLV_LENGTH);
@@ -294,9 +294,6 @@ static void set_pce_domain(u_int16_t type, u_int32_t domain,
 {
 
 	struct ri_pce_subtlv_domain *new;
-
-	/* Enable PCE Info */
-	pce->pce_header.header.type = htons(RI_TLV_PCE);
 
 	/* Create new domain info */
 	new = XCALLOC(MTYPE_OSPF_PCE_PARAMS,
@@ -348,9 +345,6 @@ static void set_pce_neighbor(u_int16_t type, u_int32_t domain,
 
 	struct ri_pce_subtlv_neighbor *new;
 
-	/* Enable PCE Info */
-	pce->pce_header.header.type = htons(RI_TLV_PCE);
-
 	/* Create new neighbor info */
 	new = XCALLOC(MTYPE_OSPF_PCE_PARAMS,
 		      sizeof(struct ri_pce_subtlv_neighbor));
@@ -399,8 +393,6 @@ static void unset_pce_neighbor(u_int16_t type, u_int32_t domain,
 static void set_pce_cap_flag(u_int32_t cap, struct ospf_pce_info *pce)
 {
 
-	/* Enable PCE Info */
-	pce->pce_header.header.type = htons(RI_TLV_PCE);
 	/* Set PCE Capabilities flag */
 	pce->pce_cap_flag.header.type = htons(RI_PCE_SUBTLV_CAP_FLAG);
 	pce->pce_cap_flag.header.length = htons(RI_TLV_LENGTH);
@@ -410,12 +402,12 @@ static void set_pce_cap_flag(u_int32_t cap, struct ospf_pce_info *pce)
 }
 
 
-static void unset_param(struct ri_tlv_header *tlv)
+static void unset_param(struct tlv_header *tlv)
 {
 
 	tlv->type = 0;
 	/* Fill the Value to 0 */
-	memset((tlv + RI_TLV_HDR_SIZE), 0, RI_TLV_BODY_SIZE(tlv));
+	memset(TLV_DATA(tlv), 0, TLV_BODY_SIZE(tlv));
 	tlv->length = 0;
 
 	return;
@@ -423,14 +415,13 @@ static void unset_param(struct ri_tlv_header *tlv)
 
 static void initialize_params(struct ospf_router_info *ori)
 {
-	u_int32_t cap;
+	u_int32_t cap = 0;
 	struct ospf *top;
 
 	/*
 	 * Initialize default Router Information Capabilities.
 	 */
-	cap = 0;
-	cap = cap | RI_TE_SUPPORT;
+	cap = RI_TE_SUPPORT;
 
 	set_router_info_capabilities(&ori->router_cap, cap);
 
@@ -462,9 +453,6 @@ static void initialize_params(struct ospf_router_info *ori)
 	      | PCE_CAP_ADDITIVE | PCE_CAP_MULTIPLE_REQ;
 	set_pce_cap_flag(cap, &ori->pce_info);
 
-	/* Finally compute PCE header */
-	set_pce_header(&ori->pce_info);
-
 	return;
 }
 
@@ -473,16 +461,15 @@ static int is_mandated_params_set(struct ospf_router_info ori)
 	int rc = 0;
 
 	if (ntohs(ori.router_cap.header.type) == 0)
-		goto out;
+		return rc;
 
 	if ((ntohs(ori.pce_info.pce_header.header.type) == RI_TLV_PCE)
 	    && (ntohs(ori.pce_info.pce_address.header.type) == 0)
 	    && (ntohs(ori.pce_info.pce_cap_flag.header.type) == 0))
-		goto out;
+		return rc;
 
 	rc = 1;
 
-out:
 	return rc;
 }
 
@@ -499,7 +486,6 @@ static void ospf_router_info_ism_change(struct ospf_interface *oi,
 static void ospf_router_info_nsm_change(struct ospf_neighbor *nbr,
 					int old_state)
 {
-
 	/* So far, nothing to do here. */
 	return;
 }
@@ -508,19 +494,19 @@ static void ospf_router_info_nsm_change(struct ospf_neighbor *nbr,
  * Followings are OSPF protocol processing functions for ROUTER INFORMATION
  *------------------------------------------------------------------------*/
 
-static void build_tlv_header(struct stream *s, struct ri_tlv_header *tlvh)
+static void build_tlv_header(struct stream *s, struct tlv_header *tlvh)
 {
 
-	stream_put(s, tlvh, sizeof(struct ri_tlv_header));
+	stream_put(s, tlvh, sizeof(struct tlv_header));
 	return;
 }
 
-static void build_tlv(struct stream *s, struct ri_tlv_header *tlvh)
+static void build_tlv(struct stream *s, struct tlv_header *tlvh)
 {
 
 	if (ntohs(tlvh->type) != 0) {
 		build_tlv_header(s, tlvh);
-		stream_put(s, tlvh + 1, RI_TLV_BODY_SIZE(tlvh));
+		stream_put(s, tlvh + 1, TLV_BODY_SIZE(tlvh));
 	}
 	return;
 }
@@ -535,9 +521,11 @@ static void ospf_router_info_lsa_body_set(struct stream *s)
 	/* Build Router Information TLV */
 	build_tlv(s, &OspfRI.router_cap.header);
 
-	/* Add RI PCE TLV if it is set */
 	/* Compute PCE Info header first */
-	if ((set_pce_header(&OspfRI.pce_info)) != 0) {
+	set_pce_header (&OspfRI.pce_info);
+
+	/* Add RI PCE TLV if it is set */
+	if (OspfRI.pce_info.status == enable) {
 
 		/* Build PCE TLV */
 		build_tlv_header(s, &OspfRI.pce_info.pce_header.header);
@@ -580,7 +568,7 @@ static struct ospf_lsa *ospf_router_info_lsa_new()
 	/* Create a stream for LSA. */
 	if ((s = stream_new(OSPF_MAX_LSA_SIZE)) == NULL) {
 		zlog_warn("ospf_router_info_lsa_new: stream_new() ?");
-		goto out;
+		return NULL;
 	}
 	lsah = (struct lsa_header *)STREAM_DATA(s);
 
@@ -614,14 +602,14 @@ static struct ospf_lsa *ospf_router_info_lsa_new()
 	if ((new = ospf_lsa_new()) == NULL) {
 		zlog_warn("ospf_router_info_lsa_new: ospf_lsa_new() ?");
 		stream_free(s);
-		goto out;
+		return NULL;
 	}
 	if ((new->data = ospf_lsa_data_new(length)) == NULL) {
 		zlog_warn("ospf_router_info_lsa_new: ospf_lsa_data_new() ?");
 		ospf_lsa_unlock(&new);
 		new = NULL;
 		stream_free(s);
-		goto out;
+		return new;
 	}
 
 	new->area = OspfRI.area; /* Area must be null if the Opaque type is AS
@@ -631,7 +619,6 @@ static struct ospf_lsa *ospf_router_info_lsa_new()
 	memcpy(new->data, lsah, length);
 	stream_free(s);
 
-out:
 	return new;
 }
 
@@ -648,7 +635,7 @@ static int ospf_router_info_lsa_originate1(void *arg)
 		if (area->area_id.s_addr != OspfRI.area_id.s_addr) {
 			zlog_debug(
 				"RI -> This is not the Router Information Area. Stop processing");
-			goto out;
+			return rc;
 		}
 		OspfRI.area = area;
 	}
@@ -657,7 +644,7 @@ static int ospf_router_info_lsa_originate1(void *arg)
 	if ((new = ospf_router_info_lsa_new()) == NULL) {
 		zlog_warn(
 			"ospf_router_info_lsa_originate1: ospf_router_info_lsa_new() ?");
-		goto out;
+		return rc;
 	}
 
 	/* Get ospf info */
@@ -668,7 +655,7 @@ static int ospf_router_info_lsa_originate1(void *arg)
 		zlog_warn(
 			"ospf_router_info_lsa_originate1: ospf_lsa_install() ?");
 		ospf_lsa_unlock(&new);
-		goto out;
+		return rc;
 	}
 
 	/* Now this Router Info parameter entry has associated LSA. */
@@ -691,7 +678,6 @@ static int ospf_router_info_lsa_originate1(void *arg)
 	}
 
 	rc = 0;
-out:
 	return rc;
 }
 
@@ -700,17 +686,17 @@ static int ospf_router_info_lsa_originate(void *arg)
 
 	int rc = -1;
 
-	if (OspfRI.status == disabled) {
+	if (OspfRI.status == disable) {
 		zlog_info(
 			"ospf_router_info_lsa_originate: ROUTER INFORMATION is disabled now.");
 		rc = 0; /* This is not an error case. */
-		goto out;
+		return rc;
 	}
 
 	/* Check if Router Information LSA is already engaged */
-	if (OspfRI.flags & RIFLG_LSA_ENGAGED) {
-		if (OspfRI.flags & RIFLG_LSA_FORCED_REFRESH) {
-			OspfRI.flags &= ~RIFLG_LSA_FORCED_REFRESH;
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED) {
+		if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_FORCED_REFRESH) {
+			UNSET_FLAG(OspfRI.flags, RIFLG_LSA_FORCED_REFRESH);
 			ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 		}
 	} else {
@@ -720,11 +706,10 @@ static int ospf_router_info_lsa_originate(void *arg)
 
 		/* Ok, let's try to originate an LSA */
 		if (ospf_router_info_lsa_originate1(arg) != 0)
-			goto out;
+			return rc;
 	}
 
 	rc = 0;
-out:
 	return rc;
 }
 
@@ -733,7 +718,7 @@ static struct ospf_lsa *ospf_router_info_lsa_refresh(struct ospf_lsa *lsa)
 	struct ospf_lsa *new = NULL;
 	struct ospf *top;
 
-	if (OspfRI.status == disabled) {
+	if (OspfRI.status == disable) {
 		/*
 		 * This LSA must have flushed before due to ROUTER INFORMATION
 		 * status change.
@@ -749,21 +734,21 @@ static struct ospf_lsa *ospf_router_info_lsa_refresh(struct ospf_lsa *lsa)
 	if (GET_OPAQUE_ID(ntohl(lsa->data->id.s_addr)) != 0) {
 		zlog_warn(
 			"ospf_router_info_lsa_refresh: Unsupported Router Information ID");
-		goto out;
+		return NULL;
 	}
 
 	/* If the lsa's age reached to MaxAge, start flushing procedure. */
 	if (IS_LSA_MAXAGE(lsa)) {
-		OspfRI.flags &= ~RIFLG_LSA_ENGAGED;
+		UNSET_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED);
 		ospf_opaque_lsa_flush_schedule(lsa);
-		goto out;
+		return NULL;
 	}
 
 	/* Create new Opaque-LSA/ROUTER INFORMATION instance. */
 	if ((new = ospf_router_info_lsa_new()) == NULL) {
 		zlog_warn(
 			"ospf_router_info_lsa_refresh: ospf_router_info_lsa_new() ?");
-		goto out;
+		return NULL;
 	}
 	new->data->ls_seqnum = lsa_seqnum_increment(lsa);
 
@@ -773,7 +758,7 @@ static struct ospf_lsa *ospf_router_info_lsa_refresh(struct ospf_lsa *lsa)
 	if (ospf_lsa_install(top, NULL /*oi */, new) == NULL) {
 		zlog_warn("ospf_router_info_lsa_refresh: ospf_lsa_install() ?");
 		ospf_lsa_unlock(&new);
-		goto out;
+		return new;
 	}
 
 	/* Flood updated LSA through AS or AREA depending of OspfRI.scope. */
@@ -790,7 +775,6 @@ static struct ospf_lsa *ospf_router_info_lsa_refresh(struct ospf_lsa *lsa)
 		ospf_lsa_header_dump(new->data);
 	}
 
-out:
 	return new;
 }
 
@@ -808,6 +792,13 @@ static void ospf_router_info_lsa_schedule(opcode_t opcode)
 		   opcode == REORIGINATE_THIS_LSA ? "Re-Originate" : "",
 		   opcode == REFRESH_THIS_LSA ? "Refresh" : "",
 		   opcode == FLUSH_THIS_LSA ? "Flush" : "");
+
+	/* Check LSA flags state coherence */
+	if (!CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED) && (opcode != REORIGINATE_THIS_LSA))
+		return;
+
+	if (CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED) && (opcode == REORIGINATE_THIS_LSA))
+		opcode = REFRESH_THIS_LSA;
 
 	top = ospf_lookup();
 	if ((OspfRI.scope == OSPF_OPAQUE_AREA_LSA) && (OspfRI.area == NULL)) {
@@ -838,7 +829,7 @@ static void ospf_router_info_lsa_schedule(opcode_t opcode)
 		ospf_opaque_lsa_refresh_schedule(&lsa);
 		break;
 	case FLUSH_THIS_LSA:
-		OspfRI.flags &= ~RIFLG_LSA_ENGAGED;
+		UNSET_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED);
 		ospf_opaque_lsa_flush_schedule(&lsa);
 		break;
 	default:
@@ -855,7 +846,7 @@ static void ospf_router_info_lsa_schedule(opcode_t opcode)
  *------------------------------------------------------------------------*/
 
 static u_int16_t show_vty_router_cap(struct vty *vty,
-				     struct ri_tlv_header *tlvh)
+				     struct tlv_header *tlvh)
 {
 	struct ri_tlv_router_cap *top = (struct ri_tlv_router_cap *)tlvh;
 
@@ -865,11 +856,11 @@ static u_int16_t show_vty_router_cap(struct vty *vty,
 	else
 		zlog_debug("    Router Capabilities: 0x%x", ntohl(top->value));
 
-	return RI_TLV_SIZE(tlvh);
+	return TLV_SIZE(tlvh);
 }
 
 static u_int16_t show_vty_pce_subtlv_address(struct vty *vty,
-					     struct ri_tlv_header *tlvh)
+					     struct tlv_header *tlvh)
 {
 	struct ri_pce_subtlv_address *top =
 		(struct ri_pce_subtlv_address *)tlvh;
@@ -891,11 +882,11 @@ static u_int16_t show_vty_pce_subtlv_address(struct vty *vty,
 				   ntohl(top->address.value.s_addr));
 	}
 
-	return RI_TLV_SIZE(tlvh);
+	return TLV_SIZE(tlvh);
 }
 
 static u_int16_t show_vty_pce_subtlv_path_scope(struct vty *vty,
-						struct ri_tlv_header *tlvh)
+						struct tlv_header *tlvh)
 {
 	struct ri_pce_subtlv_path_scope *top =
 		(struct ri_pce_subtlv_path_scope *)tlvh;
@@ -905,11 +896,11 @@ static u_int16_t show_vty_pce_subtlv_path_scope(struct vty *vty,
 	else
 		zlog_debug("    PCE Path Scope: 0x%x", ntohl(top->value));
 
-	return RI_TLV_SIZE(tlvh);
+	return TLV_SIZE(tlvh);
 }
 
 static u_int16_t show_vty_pce_subtlv_domain(struct vty *vty,
-					    struct ri_tlv_header *tlvh)
+					    struct tlv_header *tlvh)
 {
 	struct ri_pce_subtlv_domain *top = (struct ri_pce_subtlv_domain *)tlvh;
 	struct in_addr tmp;
@@ -927,11 +918,11 @@ static u_int16_t show_vty_pce_subtlv_domain(struct vty *vty,
 		else
 			zlog_debug("    PCE domain AS: %d", ntohl(top->value));
 	}
-	return RI_TLV_SIZE(tlvh);
+	return TLV_SIZE(tlvh);
 }
 
 static u_int16_t show_vty_pce_subtlv_neighbor(struct vty *vty,
-					      struct ri_tlv_header *tlvh)
+					      struct tlv_header *tlvh)
 {
 
 	struct ri_pce_subtlv_neighbor *top =
@@ -953,11 +944,11 @@ static u_int16_t show_vty_pce_subtlv_neighbor(struct vty *vty,
 			zlog_debug("    PCE neighbor AS: %d",
 				   ntohl(top->value));
 	}
-	return RI_TLV_SIZE(tlvh);
+	return TLV_SIZE(tlvh);
 }
 
 static u_int16_t show_vty_pce_subtlv_cap_flag(struct vty *vty,
-					      struct ri_tlv_header *tlvh)
+					      struct tlv_header *tlvh)
 {
 	struct ri_pce_subtlv_cap_flag *top =
 		(struct ri_pce_subtlv_cap_flag *)tlvh;
@@ -969,11 +960,11 @@ static u_int16_t show_vty_pce_subtlv_cap_flag(struct vty *vty,
 		zlog_debug("    PCE Capabilities Flag: 0x%x",
 			   ntohl(top->value));
 
-	return RI_TLV_SIZE(tlvh);
+	return TLV_SIZE(tlvh);
 }
 
 static u_int16_t show_vty_unknown_tlv(struct vty *vty,
-				      struct ri_tlv_header *tlvh)
+				      struct tlv_header *tlvh)
 {
 	if (vty != NULL)
 		vty_out(vty, "  Unknown TLV: [type(0x%x), length(0x%x)]\n",
@@ -982,16 +973,16 @@ static u_int16_t show_vty_unknown_tlv(struct vty *vty,
 		zlog_debug("    Unknown TLV: [type(0x%x), length(0x%x)]",
 			   ntohs(tlvh->type), ntohs(tlvh->length));
 
-	return RI_TLV_SIZE(tlvh);
+	return TLV_SIZE(tlvh);
 }
 
-static u_int16_t show_vty_pce_info(struct vty *vty, struct ri_tlv_header *ri,
+static u_int16_t show_vty_pce_info(struct vty *vty, struct tlv_header *ri,
 				   uint32_t total)
 {
-	struct ri_tlv_header *tlvh;
+	struct tlv_header *tlvh;
 	u_int16_t sum = 0;
 
-	for (tlvh = ri; sum < total; tlvh = RI_TLV_HDR_NEXT(tlvh)) {
+	for (tlvh = ri; sum < total; tlvh = TLV_HDR_NEXT(tlvh)) {
 		switch (ntohs(tlvh->type)) {
 		case RI_PCE_SUBTLV_ADDRESS:
 			sum += show_vty_pce_subtlv_address(vty, tlvh);
@@ -1019,21 +1010,21 @@ static u_int16_t show_vty_pce_info(struct vty *vty, struct ri_tlv_header *ri,
 static void ospf_router_info_show_info(struct vty *vty, struct ospf_lsa *lsa)
 {
 	struct lsa_header *lsah = (struct lsa_header *)lsa->data;
-	struct ri_tlv_header *tlvh;
+	struct tlv_header *tlvh;
 	u_int16_t length = 0, sum = 0;
 
 	/* Initialize TLV browsing */
 	length = ntohs(lsah->length) - OSPF_LSA_HEADER_SIZE;
 
-	for (tlvh = RI_TLV_HDR_TOP(lsah); sum < length;
-	     tlvh = RI_TLV_HDR_NEXT(tlvh)) {
+	for (tlvh = TLV_HDR_TOP(lsah); sum < length;
+	     tlvh = TLV_HDR_NEXT(tlvh)) {
 		switch (ntohs(tlvh->type)) {
 		case RI_TLV_CAPABILITIES:
 			sum += show_vty_router_cap(vty, tlvh);
 			break;
 		case RI_TLV_PCE:
 			tlvh++;
-			sum += RI_TLV_HDR_SIZE;
+			sum += TLV_HDR_SIZE;
 			sum += show_vty_pce_info(vty, tlvh, length - sum);
 			break;
 		default:
@@ -1053,50 +1044,53 @@ static void ospf_router_info_config_write_router(struct vty *vty)
 	struct ri_pce_subtlv_neighbor *neighbor;
 	struct in_addr tmp;
 
-	if (OspfRI.status == enabled) {
+	if (OspfRI.status == enable) {
 		if (OspfRI.scope == OSPF_OPAQUE_AS_LSA)
 			vty_out(vty, " router-info as\n");
 		else
 			vty_out(vty, " router-info area %s\n",
 				inet_ntoa(OspfRI.area_id));
 
-		if (pce->pce_address.header.type != 0)
-			vty_out(vty, "  pce address %s\n",
-				inet_ntoa(pce->pce_address.address.value));
+		if (OspfRI.pce_info.status == enable) {
 
-		if (pce->pce_cap_flag.header.type != 0)
-			vty_out(vty, "  pce flag 0x%x\n",
-				ntohl(pce->pce_cap_flag.value));
+			if (pce->pce_address.header.type != 0)
+				vty_out(vty, "  pce address %s\n",
+					inet_ntoa(pce->pce_address.address.value));
 
-		for (ALL_LIST_ELEMENTS_RO(pce->pce_domain, node, domain)) {
-			if (domain->header.type != 0) {
-				if (domain->type == PCE_DOMAIN_TYPE_AREA) {
-					tmp.s_addr = domain->value;
-					vty_out(vty, "  pce domain area %s\n",
-						inet_ntoa(tmp));
-				} else {
-					vty_out(vty, "  pce domain as %d\n",
-						ntohl(domain->value));
+			if (pce->pce_cap_flag.header.type != 0)
+				vty_out(vty, "  pce flag 0x%x\n",
+					ntohl(pce->pce_cap_flag.value));
+
+			for (ALL_LIST_ELEMENTS_RO(pce->pce_domain, node, domain)) {
+				if (domain->header.type != 0) {
+					if (domain->type == PCE_DOMAIN_TYPE_AREA) {
+						tmp.s_addr = domain->value;
+						vty_out(vty, "  pce domain area %s\n",
+							inet_ntoa(tmp));
+					} else {
+						vty_out(vty, "  pce domain as %d\n",
+							ntohl(domain->value));
+					}
 				}
 			}
-		}
 
-		for (ALL_LIST_ELEMENTS_RO(pce->pce_neighbor, node, neighbor)) {
-			if (neighbor->header.type != 0) {
-				if (neighbor->type == PCE_DOMAIN_TYPE_AREA) {
-					tmp.s_addr = neighbor->value;
-					vty_out(vty, "  pce neighbor area %s\n",
-						inet_ntoa(tmp));
-				} else {
-					vty_out(vty, "  pce neighbor as %d\n",
-						ntohl(neighbor->value));
+			for (ALL_LIST_ELEMENTS_RO(pce->pce_neighbor, node, neighbor)) {
+				if (neighbor->header.type != 0) {
+					if (neighbor->type == PCE_DOMAIN_TYPE_AREA) {
+						tmp.s_addr = neighbor->value;
+						vty_out(vty, "  pce neighbor area %s\n",
+							inet_ntoa(tmp));
+					} else {
+						vty_out(vty, "  pce neighbor as %d\n",
+							ntohl(neighbor->value));
+					}
 				}
 			}
-		}
 
-		if (pce->pce_scope.header.type != 0)
-			vty_out(vty, "  pce scope 0x%x\n",
-				ntohl(OspfRI.pce_info.pce_scope.value));
+			if (pce->pce_scope.header.type != 0)
+				vty_out(vty, "  pce scope 0x%x\n",
+					ntohl(OspfRI.pce_info.pce_scope.value));
+		}
 	}
 	return;
 }
@@ -1118,7 +1112,7 @@ DEFUN (router_info,
 
 	u_int8_t scope;
 
-	if (OspfRI.status == enabled)
+	if (OspfRI.status == enable)
 		return CMD_SUCCESS;
 
 	/* Check and get Area value if present */
@@ -1137,11 +1131,11 @@ DEFUN (router_info,
 	/* First start to register Router Information callbacks */
 	if ((ospf_router_info_register(scope)) != 0) {
 		zlog_warn(
-			"Enable to register Router Information callbacks. Abort!");
+			"Unable to register Router Information callbacks. Abort!");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	OspfRI.status = enabled;
+	OspfRI.status = enable;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("RI-> Router Information (%s flooding): OFF -> ON",
@@ -1160,7 +1154,10 @@ DEFUN (router_info,
 	initialize_params(&OspfRI);
 
 	/* Refresh RI LSA if already engaged */
-	if (OspfRI.flags & RIFLG_LSA_ENGAGED) {
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED) {
+		zlog_debug ("RI-> Refresh LSA following configuration");
+		ospf_router_info_lsa_schedule (REFRESH_THIS_LSA);
+	} else {
 		zlog_debug("RI-> Initial origination following configuration");
 		ospf_router_info_lsa_schedule(REORIGINATE_THIS_LSA);
 	}
@@ -1175,26 +1172,26 @@ DEFUN (no_router_info,
        "Disable the Router Information functionality\n")
 {
 
-	if (OspfRI.status == disabled)
+	if (OspfRI.status == disable)
 		return CMD_SUCCESS;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("RI-> Router Information: ON -> OFF");
 
-	if (OspfRI.flags & RIFLG_LSA_ENGAGED)
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 		ospf_router_info_lsa_schedule(FLUSH_THIS_LSA);
 
 	/* Unregister the callbacks */
 	ospf_router_info_unregister();
 
-	OspfRI.status = disabled;
+	OspfRI.status = disable;
 
 	return CMD_SUCCESS;
 }
 
 static int ospf_ri_enabled(struct vty *vty)
 {
-	if (OspfRI.status == enabled)
+	if (OspfRI.status == enable)
 		return 1;
 
 	if (vty)
@@ -1229,7 +1226,7 @@ DEFUN (pce_address,
 		set_pce_address(value, pi);
 
 		/* Refresh RI LSA if already engaged */
-		if (OspfRI.flags & RIFLG_LSA_ENGAGED)
+		if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 			ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 	}
 
@@ -1248,7 +1245,7 @@ DEFUN (no_pce_address,
 	unset_param(&OspfRI.pce_info.pce_address.header);
 
 	/* Refresh RI LSA if already engaged */
-	if ((OspfRI.status == enabled) && (OspfRI.flags & RIFLG_LSA_ENGAGED))
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 		ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 
 	return CMD_SUCCESS;
@@ -1279,7 +1276,7 @@ DEFUN (pce_path_scope,
 		set_pce_path_scope(scope, pi);
 
 		/* Refresh RI LSA if already engaged */
-		if (OspfRI.flags & RIFLG_LSA_ENGAGED)
+		if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 			ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 	}
 
@@ -1298,7 +1295,7 @@ DEFUN (no_pce_path_scope,
 	unset_param(&OspfRI.pce_info.pce_address.header);
 
 	/* Refresh RI LSA if already engaged */
-	if ((OspfRI.status == enabled) && (OspfRI.flags & RIFLG_LSA_ENGAGED))
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 		ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 
 	return CMD_SUCCESS;
@@ -1337,7 +1334,7 @@ DEFUN (pce_domain,
 	set_pce_domain(PCE_DOMAIN_TYPE_AS, as, pce);
 
 	/* Refresh RI LSA if already engaged */
-	if (OspfRI.flags & RIFLG_LSA_ENGAGED)
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 		ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 
 	return CMD_SUCCESS;
@@ -1367,7 +1364,7 @@ DEFUN (no_pce_domain,
 	unset_pce_domain(PCE_DOMAIN_TYPE_AS, as, pce);
 
 	/* Refresh RI LSA if already engaged */
-	if ((OspfRI.status == enabled) && (OspfRI.flags & RIFLG_LSA_ENGAGED))
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 		ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 
 	return CMD_SUCCESS;
@@ -1407,7 +1404,7 @@ DEFUN (pce_neigbhor,
 	set_pce_neighbor(PCE_DOMAIN_TYPE_AS, as, pce);
 
 	/* Refresh RI LSA if already engaged */
-	if (OspfRI.flags & RIFLG_LSA_ENGAGED)
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 		ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 
 	return CMD_SUCCESS;
@@ -1437,7 +1434,7 @@ DEFUN (no_pce_neighbor,
 	unset_pce_neighbor(PCE_DOMAIN_TYPE_AS, as, pce);
 
 	/* Refresh RI LSA if already engaged */
-	if ((OspfRI.status == enabled) && (OspfRI.flags & RIFLG_LSA_ENGAGED))
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 		ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 
 	return CMD_SUCCESS;
@@ -1469,7 +1466,7 @@ DEFUN (pce_cap_flag,
 		set_pce_cap_flag(cap, pce);
 
 		/* Refresh RI LSA if already engaged */
-		if (OspfRI.flags & RIFLG_LSA_ENGAGED)
+		if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 			ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 	}
 
@@ -1487,7 +1484,7 @@ DEFUN (no_pce_cap_flag,
 	unset_param(&OspfRI.pce_info.pce_cap_flag.header);
 
 	/* Refresh RI LSA if already engaged */
-	if ((OspfRI.status == enabled) && (OspfRI.flags & RIFLG_LSA_ENGAGED))
+	if CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED)
 		ospf_router_info_lsa_schedule(REFRESH_THIS_LSA);
 
 	return CMD_SUCCESS;
@@ -1502,7 +1499,7 @@ DEFUN (show_ip_ospf_router_info,
        "Router Information\n")
 {
 
-	if (OspfRI.status == enabled) {
+	if (OspfRI.status == enable) {
 		vty_out(vty, "--- Router Information parameters ---\n");
 		show_vty_router_cap(vty, &OspfRI.router_cap.header);
 	} else {
@@ -1528,7 +1525,7 @@ DEFUN (show_ip_opsf_router_info_pce,
 	struct ri_pce_subtlv_domain *domain;
 	struct ri_pce_subtlv_neighbor *neighbor;
 
-	if (OspfRI.status == enabled) {
+	if (OspfRI.status == enable) {
 		vty_out(vty, "--- PCE parameters ---\n");
 
 		if (pce->pce_address.header.type != 0)

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -111,7 +111,7 @@ static void ospf_router_info_config_write_router(struct vty *vty);
 static void ospf_router_info_show_info(struct vty *vty, struct ospf_lsa *lsa);
 static int ospf_router_info_lsa_originate(void *arg);
 static struct ospf_lsa *ospf_router_info_lsa_refresh(struct ospf_lsa *lsa);
-static void ospf_router_info_lsa_schedule(opcode_t opcode);
+static void ospf_router_info_lsa_schedule(enum lsa_opcode opcode);
 static void ospf_router_info_register_vty(void);
 static void del_pce_info(void *val);
 
@@ -778,7 +778,7 @@ static struct ospf_lsa *ospf_router_info_lsa_refresh(struct ospf_lsa *lsa)
 	return new;
 }
 
-static void ospf_router_info_lsa_schedule(opcode_t opcode)
+static void ospf_router_info_lsa_schedule(enum lsa_opcode opcode)
 {
 	struct ospf_lsa lsa;
 	struct lsa_header lsah;

--- a/ospfd/ospf_ri.h
+++ b/ospfd/ospf_ri.h
@@ -65,21 +65,6 @@
  */
 
 /*
- * Following section defines TLV (tag, length, value) structures,
- * used for Router Information.
- */
-struct ri_tlv_header {
-	u_int16_t type;   /* RI_TLV_XXX (see below) */
-	u_int16_t length; /* Value portion only, in byte */
-};
-
-#define RI_TLV_HDR_SIZE (sizeof (struct ri_tlv_header))
-#define RI_TLV_BODY_SIZE(tlvh) (ROUNDUP (ntohs ((tlvh)->length), sizeof (u_int32_t)))
-#define RI_TLV_SIZE(tlvh) (RI_TLV_HDR_SIZE + RI_TLV_BODY_SIZE(tlvh))
-#define RI_TLV_HDR_TOP(lsah) (struct ri_tlv_header *)((char *)(lsah) + OSPF_LSA_HEADER_SIZE)
-#define RI_TLV_HDR_NEXT(tlvh) (struct ri_tlv_header *)((char *)(tlvh) + RI_TLV_SIZE(tlvh))
-
-/*
  * Following section defines TLV body parts.
  */
 
@@ -91,7 +76,7 @@ struct ri_tlv_header {
 #define RI_TLV_CAPABILITIES		1
 
 struct ri_tlv_router_cap {
-	struct ri_tlv_header header; /* Value length is 4 bytes. */
+	struct tlv_header header; /* Value length is 4 bytes. */
 	u_int32_t value;
 };
 
@@ -109,23 +94,19 @@ struct ri_tlv_router_cap {
 #define RI_TLV_PCE			6
 
 struct ri_tlv_pce {
-	struct ri_tlv_header header;
+	struct tlv_header header;
 	/* A set of PCE-sub-TLVs will follow. */
 };
 
 /* PCE Address Sub-TLV */ /* Mandatory */
 #define	RI_PCE_SUBTLV_ADDRESS		1
 struct ri_pce_subtlv_address {
-	struct ri_tlv_header
-		header; /* Type = 1; Length is 8 (IPv4) or 20 (IPv6) bytes. */
-			/* $FRR indent$ */
-			/* clang-format off */
+	/* Type = 1; Length is 8 (IPv4) or 20 (IPv6) bytes. */
+	struct tlv_header header;
 #define	PCE_ADDRESS_LENGTH_IPV4		8
 #define	PCE_ADDRESS_LENGTH_IPV6		20
 	struct {
 		u_int16_t type; /* Address type: 1 = IPv4, 2 = IPv6 */
-				/* $FRR indent$ */
-				/* clang-format off */
 #define	PCE_ADDRESS_TYPE_IPV4		1
 #define	PCE_ADDRESS_TYPE_IPV6		2
 		u_int16_t reserved;
@@ -136,9 +117,12 @@ struct ri_pce_subtlv_address {
 /* PCE Path-Scope Sub-TLV */ /* Mandatory */
 #define	RI_PCE_SUBTLV_PATH_SCOPE	2
 struct ri_pce_subtlv_path_scope {
-	struct ri_tlv_header header; /* Type = 2; Length = 4 bytes. */
-	u_int32_t value; /* L, R, Rd, S, Sd, Y, PrefL, PrefR, PrefS and PrefY
-			    bits see RFC5088 page 9 */
+	struct tlv_header header; /* Type = 2; Length = 4 bytes. */
+	/*
+	 * L, R, Rd, S, Sd, Y, PrefL, PrefR, PrefS and PrefY bits:
+	 * see RFC5088 page 9
+	 */
+	u_int32_t value;
 };
 
 /* PCE Domain Sub-TLV */ /* Optional */
@@ -148,7 +132,7 @@ struct ri_pce_subtlv_path_scope {
 #define	PCE_DOMAIN_TYPE_AS			2
 
 struct ri_pce_subtlv_domain {
-	struct ri_tlv_header header; /* Type = 3; Length = 8 bytes. */
+	struct tlv_header header; /* Type = 3; Length = 8 bytes. */
 	u_int16_t type; /* Domain type: 1 = OSPF Area ID, 2 = AS Number */
 	u_int16_t reserved;
 	u_int32_t value;
@@ -157,7 +141,7 @@ struct ri_pce_subtlv_domain {
 /* PCE Neighbor Sub-TLV */ /* Mandatory if R or S bit is set */
 #define RI_PCE_SUBTLV_NEIGHBOR		4
 struct ri_pce_subtlv_neighbor {
-	struct ri_tlv_header header; /* Type = 4; Length = 8 bytes. */
+	struct tlv_header header; /* Type = 4; Length = 8 bytes. */
 	u_int16_t type; /* Domain type: 1 = OSPF Area ID, 2 = AS Number */
 	u_int16_t reserved;
 	u_int32_t value;
@@ -177,7 +161,7 @@ struct ri_pce_subtlv_neighbor {
 #define PCE_CAP_MULTIPLE_REQ	0x0100
 
 struct ri_pce_subtlv_cap_flag {
-	struct ri_tlv_header header; /* Type = 5; Length = n x 4 bytes. */
+	struct tlv_header header; /* Type = 5; Length = n x 4 bytes. */
 	u_int32_t value;
 };
 

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -68,9 +68,7 @@
  */
 struct ospf_mpls_te OspfMplsTE;
 
-const char *mode2text[] = {"Disable", "AS", "Area", "Emulate"};
-
-enum oifstate { OI_ANY, OI_DOWN, OI_UP };
+const char *mode2text[] = {"Off", "AS", "Area"};
 
 /*------------------------------------------------------------------------*
  * Followings are initialize/terminate functions for MPLS-TE handling.
@@ -106,29 +104,28 @@ int ospf_mpls_te_init(void)
 	if (rc != 0) {
 		zlog_warn(
 			"ospf_mpls_te_init: Failed to register Traffic Engineering functions");
-		goto out;
+		return rc;
 	}
 
 	memset(&OspfMplsTE, 0, sizeof(struct ospf_mpls_te));
-	OspfMplsTE.status = disabled;
-	OspfMplsTE.inter_as = Disable;
+	OspfMplsTE.status = disable;
+	OspfMplsTE.inter_as = Off;
 	OspfMplsTE.iflist = list_new();
 	OspfMplsTE.iflist->del = del_mpls_te_link;
 
 	ospf_mpls_te_register_vty();
 
-out:
 	return rc;
 }
 
 /* Additional register for RFC5392 support */
 static int ospf_mpls_te_register(enum inter_as_mode mode)
 {
-	int rc;
+	int rc = 0;
 	u_int8_t scope;
 
-	if (OspfMplsTE.inter_as != Disable)
-		return 0;
+	if (OspfMplsTE.inter_as != Off)
+		return rc;
 
 	if (mode == AS)
 		scope = OSPF_OPAQUE_AS_LSA;
@@ -147,14 +144,14 @@ static int ospf_mpls_te_register(enum inter_as_mode mode)
 		return rc;
 	}
 
-	return 0;
+	return rc;
 }
 
 static int ospf_mpls_te_unregister()
 {
 	u_int8_t scope;
 
-	if (OspfMplsTE.inter_as == Disable)
+	if (OspfMplsTE.inter_as == Off)
 		return 0;
 
 	if (OspfMplsTE.inter_as == AS)
@@ -174,10 +171,10 @@ void ospf_mpls_te_term(void)
 
 	ospf_delete_opaque_functab(OSPF_OPAQUE_AREA_LSA,
 				   OPAQUE_TYPE_TRAFFIC_ENGINEERING_LSA);
-	OspfMplsTE.status = disabled;
+	OspfMplsTE.status = disable;
 
 	ospf_mpls_te_unregister();
-	OspfMplsTE.inter_as = Disable;
+	OspfMplsTE.inter_as = Off;
 
 	return;
 }
@@ -192,7 +189,7 @@ static void del_mpls_te_link(void *val)
 	return;
 }
 
-u_int32_t get_mpls_te_instance_value(void)
+static u_int32_t get_mpls_te_instance_value(void)
 {
 	static u_int32_t seqno = 0;
 
@@ -202,41 +199,6 @@ u_int32_t get_mpls_te_instance_value(void)
 		seqno = 1; /* Avoid zero. */
 
 	return seqno;
-}
-
-static struct ospf_interface *lookup_oi_by_ifp(struct interface *ifp,
-					       struct ospf_area *area,
-					       enum oifstate oifstate)
-{
-	struct ospf_interface *oi = NULL;
-	struct route_node *rn;
-
-	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
-		if ((oi = rn->info) == NULL)
-			continue;
-
-		switch (oifstate) {
-		case OI_ANY:
-			break;
-		case OI_DOWN:
-			if (ospf_if_is_enable(oi))
-				continue;
-			break;
-		case OI_UP:
-			if (!ospf_if_is_enable(oi))
-				continue;
-			break;
-		default:
-			zlog_warn("lookup_oi_by_ifp: Unknown oifstate: %x",
-				  oifstate);
-			goto out;
-		}
-
-		if (area == NULL || oi->area == area)
-			return oi;
-	}
-out:
-	return NULL;
 }
 
 static struct mpls_te_link *lookup_linkparams_by_ifp(struct interface *ifp)
@@ -793,14 +755,25 @@ static void update_linkparams(struct mpls_te_link *lp)
 static void initialize_linkparams(struct mpls_te_link *lp)
 {
 	struct interface *ifp = lp->ifp;
-	struct ospf_interface *oi;
+	struct ospf_interface *oi = NULL;
+	struct route_node *rn;
 
 	if (IS_DEBUG_OSPF_TE)
 		zlog_debug(
 			"MPLS-TE(initialize_linkparams) Initialize Link Parameters for interface %s",
 			ifp->name);
 
-	if ((oi = lookup_oi_by_ifp(ifp, NULL, OI_ANY)) == NULL) {
+	/* Search OSPF Interface parameters for this interface */
+	for (rn = route_top (IF_OIFS (ifp)); rn; rn = route_next (rn)) {
+
+		if ((oi = rn->info) == NULL)
+			continue;
+
+		if (oi->ifp == ifp)
+			break;
+	}
+
+	if ((oi == NULL) || (oi->ifp != ifp)) {
 		if (IS_DEBUG_OSPF_TE)
 			zlog_warn(
 				"MPLS-TE(initialize_linkparams) Could not find corresponding OSPF Interface for %s",
@@ -818,7 +791,7 @@ static void initialize_linkparams(struct mpls_te_link *lp)
 	set_linkparams_lclif_ipaddr(lp, oi->address->u.prefix4);
 
 	/* Set Remote IP addr if Point to Point Interface */
-	if (oi->type == LINK_TYPE_SUBTLV_VALUE_PTP) {
+	if (oi->type == OSPF_IFTYPE_POINTOPOINT) {
 		struct prefix *pref = CONNECTED_PREFIX(oi->connected);
 		if (pref != NULL)
 			set_linkparams_rmtif_ipaddr(lp, pref->u.prefix4);
@@ -837,21 +810,20 @@ static int is_mandated_params_set(struct mpls_te_link *lp)
 	if (ntohs(OspfMplsTE.router_addr.header.type) == 0) {
 		zlog_warn(
 			"MPLS-TE(is_mandated_params_set) Missing Router Address");
-		goto out;
+		return rc;
 	}
 
 	if (ntohs(lp->link_type.header.type) == 0) {
 		zlog_warn("MPLS-TE(is_mandated_params_set) Missing Link Type");
-		goto out;
+		return rc;
 	}
 
 	if (!IS_INTER_AS(lp->type) && (ntohs(lp->link_id.header.type) == 0)) {
 		zlog_warn("MPLS-TE(is_mandated_params_set) Missing Link ID");
-		goto out;
+		return rc;
 	}
 
 	rc = 1;
-out:
 	return rc;
 }
 
@@ -873,14 +845,14 @@ static int ospf_mpls_te_new_if(struct interface *ifp)
 		zlog_warn("ospf_mpls_te_new_if: ifp(%p) already in use?",
 			  (void *)ifp);
 		rc = 0; /* Do nothing here. */
-		goto out;
+		return rc;
 	}
 
 	new = XCALLOC(MTYPE_OSPF_MPLS_TE, sizeof(struct mpls_te_link));
 	if (new == NULL) {
 		zlog_warn("ospf_mpls_te_new_if: XMALLOC: %s",
 			  safe_strerror(errno));
-		goto out;
+		return rc;
 	}
 
 	new->instance = get_mpls_te_instance_value();
@@ -909,7 +881,6 @@ static int ospf_mpls_te_new_if(struct interface *ifp)
 	/* Schedule Opaque-LSA refresh. */ /* XXX */
 
 	rc = 0;
-out:
 	return rc;
 }
 
@@ -934,7 +905,6 @@ static int ospf_mpls_te_del_if(struct interface *ifp)
 	/* Schedule Opaque-LSA refresh. */ /* XXX */
 
 	rc = 0;
-	/*out:*/
 	return rc;
 }
 
@@ -952,10 +922,9 @@ void ospf_mpls_te_update_if(struct interface *ifp)
 
 	/* Get Link context from interface */
 	if ((lp = lookup_linkparams_by_ifp(ifp)) == NULL) {
-		if (IS_DEBUG_OSPF_TE)
-			zlog_warn(
-				"OSPF MPLS-TE Update: Did not find Link Parameters context for interface %s",
-				ifp->name);
+		zlog_warn(
+			"OSPF MPLS-TE Update: Did not find Link Parameters context for interface %s",
+			ifp->name);
 		return;
 	}
 
@@ -968,7 +937,7 @@ void ospf_mpls_te_update_if(struct interface *ifp)
 
 		/* Finally Re-Originate or Refresh Opaque LSA if MPLS_TE is
 		 * enabled */
-		if (OspfMplsTE.status == enabled)
+		if (OspfMplsTE.status == enable)
 			if (lp->area != NULL) {
 				if
 					CHECK_FLAG(lp->flags, LPFLG_LSA_ENGAGED)
@@ -1000,14 +969,14 @@ static void ospf_mpls_te_ism_change(struct ospf_interface *oi, int old_state)
 		zlog_warn(
 			"ospf_mpls_te_ism_change: Cannot get linkparams from OI(%s)?",
 			IF_NAME(oi));
-		goto out;
+		return;
 	}
 
 	if (oi->area == NULL || oi->area->ospf == NULL) {
 		zlog_warn(
 			"ospf_mpls_te_ism_change: Cannot refer to OSPF from OI(%s)?",
 			IF_NAME(oi));
-		goto out;
+		return;
 	}
 #ifdef notyet
 	if ((lp->area != NULL
@@ -1076,7 +1045,6 @@ static void ospf_mpls_te_ism_change(struct ospf_interface *oi, int old_state)
 		break;
 	}
 
-out:
 	return;
 }
 
@@ -1090,15 +1058,15 @@ static void ospf_mpls_te_nsm_change(struct ospf_neighbor *nbr, int old_state)
  * Followings are OSPF protocol processing functions for MPLS-TE.
  *------------------------------------------------------------------------*/
 
-static void build_tlv_header(struct stream *s, struct te_tlv_header *tlvh)
+static void build_tlv_header(struct stream *s, struct tlv_header *tlvh)
 {
-	stream_put(s, tlvh, sizeof(struct te_tlv_header));
+	stream_put(s, tlvh, sizeof(struct tlv_header));
 	return;
 }
 
 static void build_router_tlv(struct stream *s)
 {
-	struct te_tlv_header *tlvh = &OspfMplsTE.router_addr.header;
+	struct tlv_header *tlvh = &OspfMplsTE.router_addr.header;
 	if (ntohs(tlvh->type) != 0) {
 		build_tlv_header(s, tlvh);
 		stream_put(s, tlvh + 1, TLV_BODY_SIZE(tlvh));
@@ -1106,7 +1074,7 @@ static void build_router_tlv(struct stream *s)
 	return;
 }
 
-static void build_link_subtlv(struct stream *s, struct te_tlv_header *tlvh)
+static void build_link_subtlv(struct stream *s, struct tlv_header *tlvh)
 {
 
 	if ((tlvh != NULL) && (ntohs(tlvh->type) != 0)) {
@@ -1177,7 +1145,7 @@ static struct ospf_lsa *ospf_mpls_te_lsa_new(struct ospf_area *area,
 	/* Create a stream for LSA. */
 	if ((s = stream_new(OSPF_MAX_LSA_SIZE)) == NULL) {
 		zlog_warn("ospf_mpls_te_lsa_new: stream_new() ?");
-		goto out;
+		return NULL;
 	}
 	lsah = (struct lsa_header *)STREAM_DATA(s);
 
@@ -1233,14 +1201,14 @@ static struct ospf_lsa *ospf_mpls_te_lsa_new(struct ospf_area *area,
 	if ((new = ospf_lsa_new()) == NULL) {
 		zlog_warn("ospf_mpls_te_lsa_new: ospf_lsa_new() ?");
 		stream_free(s);
-		goto out;
+		return NULL;
 	}
 	if ((new->data = ospf_lsa_data_new(length)) == NULL) {
 		zlog_warn("ospf_mpls_te_lsa_new: ospf_lsa_data_new() ?");
 		ospf_lsa_unlock(&new);
 		new = NULL;
 		stream_free(s);
-		goto out;
+		return new;
 	}
 
 	new->area = area;
@@ -1248,7 +1216,6 @@ static struct ospf_lsa *ospf_mpls_te_lsa_new(struct ospf_area *area,
 	memcpy(new->data, lsah, length);
 	stream_free(s);
 
-out:
 	return new;
 }
 
@@ -1262,14 +1229,14 @@ static int ospf_mpls_te_lsa_originate1(struct ospf_area *area,
 	if ((new = ospf_mpls_te_lsa_new(area, lp)) == NULL) {
 		zlog_warn(
 			"ospf_mpls_te_lsa_originate1: ospf_mpls_te_lsa_new() ?");
-		goto out;
+		return rc;
 	}
 
 	/* Install this LSA into LSDB. */
 	if (ospf_lsa_install(area->ospf, NULL /*oi*/, new) == NULL) {
 		zlog_warn("ospf_mpls_te_lsa_originate1: ospf_lsa_install() ?");
 		ospf_lsa_unlock(&new);
-		goto out;
+		return rc;
 	}
 
 	/* Now this link-parameter entry has associated LSA. */
@@ -1291,7 +1258,6 @@ static int ospf_mpls_te_lsa_originate1(struct ospf_area *area,
 	}
 
 	rc = 0;
-out:
 	return rc;
 }
 
@@ -1302,11 +1268,11 @@ static int ospf_mpls_te_lsa_originate_area(void *arg)
 	struct mpls_te_link *lp;
 	int rc = -1;
 
-	if (OspfMplsTE.status == disabled) {
+	if (OspfMplsTE.status == disable) {
 		zlog_info(
 			"ospf_mpls_te_lsa_originate_area: MPLS-TE is disabled now.");
 		rc = 0; /* This is not an error case. */
-		goto out;
+		return rc;
 	}
 
 	for (ALL_LIST_ELEMENTS(OspfMplsTE.iflist, node, nnode, lp)) {
@@ -1352,11 +1318,10 @@ static int ospf_mpls_te_lsa_originate_area(void *arg)
 				lp->instance, inet_ntoa(area->area_id),
 				lp->ifp ? lp->ifp->name : "?");
 		if (ospf_mpls_te_lsa_originate1(area, lp) != 0)
-			goto out;
+			return rc;
 	}
 
 	rc = 0;
-out:
 	return rc;
 }
 
@@ -1370,14 +1335,14 @@ static int ospf_mpls_te_lsa_originate2(struct ospf *top,
 	if ((new = ospf_mpls_te_lsa_new(NULL, lp)) == NULL) {
 		zlog_warn(
 			"ospf_mpls_te_lsa_originate2: ospf_router_info_lsa_new() ?");
-		goto out;
+		return rc;
 	}
 
 	/* Install this LSA into LSDB. */
 	if (ospf_lsa_install(top, NULL /*oi */, new) == NULL) {
 		zlog_warn("ospf_mpls_te_lsa_originate2: ospf_lsa_install() ?");
 		ospf_lsa_unlock(&new);
-		goto out;
+		return rc;
 	}
 
 	/* Now this Router Info parameter entry has associated LSA. */
@@ -1396,7 +1361,6 @@ static int ospf_mpls_te_lsa_originate2(struct ospf *top,
 	}
 
 	rc = 0;
-out:
 	return rc;
 }
 
@@ -1408,12 +1372,12 @@ static int ospf_mpls_te_lsa_originate_as(void *arg)
 	struct mpls_te_link *lp;
 	int rc = -1;
 
-	if ((OspfMplsTE.status == disabled)
-	    || (OspfMplsTE.inter_as == Disable)) {
+	if ((OspfMplsTE.status == disable)
+	    || (OspfMplsTE.inter_as == Off)) {
 		zlog_info(
 			"ospf_mpls_te_lsa_originate_as: MPLS-TE Inter-AS is disabled for now.");
 		rc = 0; /* This is not an error case. */
-		goto out;
+		return rc;
 	}
 
 	for (ALL_LIST_ELEMENTS(OspfMplsTE.iflist, node, nnode, lp)) {
@@ -1462,7 +1426,6 @@ static int ospf_mpls_te_lsa_originate_as(void *arg)
 	}
 
 	rc = 0;
-out:
 	return rc;
 }
 
@@ -1473,7 +1436,7 @@ static struct ospf_lsa *ospf_mpls_te_lsa_refresh(struct ospf_lsa *lsa)
 	struct ospf *top;
 	struct ospf_lsa *new = NULL;
 
-	if (OspfMplsTE.status == disabled) {
+	if (OspfMplsTE.status == disable) {
 		/*
 		 * This LSA must have flushed before due to MPLS-TE status
 		 * change.
@@ -1504,13 +1467,13 @@ static struct ospf_lsa *ospf_mpls_te_lsa_refresh(struct ospf_lsa *lsa)
 		if (lp)
 			UNSET_FLAG(lp->flags, LPFLG_LSA_ENGAGED);
 		ospf_opaque_lsa_flush_schedule(lsa);
-		goto out;
+		return NULL;
 	}
 
 	/* Create new Opaque-LSA/MPLS-TE instance. */
 	if ((new = ospf_mpls_te_lsa_new(area, lp)) == NULL) {
 		zlog_warn("ospf_mpls_te_lsa_refresh: ospf_mpls_te_lsa_new() ?");
-		goto out;
+		return NULL;
 	}
 	new->data->ls_seqnum = lsa_seqnum_increment(lsa);
 
@@ -1526,7 +1489,7 @@ static struct ospf_lsa *ospf_mpls_te_lsa_refresh(struct ospf_lsa *lsa)
 	if (ospf_lsa_install(top, NULL /*oi */, new) == NULL) {
 		zlog_warn("ospf_mpls_te_lsa_refresh: ospf_lsa_install() ?");
 		ospf_lsa_unlock(&new);
-		goto out;
+		return NULL;
 	}
 
 	/* Flood updated LSA through AS or Area depending of the RFC of the link
@@ -1543,7 +1506,6 @@ static struct ospf_lsa *ospf_mpls_te_lsa_refresh(struct ospf_lsa *lsa)
 		ospf_lsa_header_dump(new->data);
 	}
 
-out:
 	return new;
 }
 
@@ -1636,7 +1598,7 @@ void ospf_mpls_te_lsa_schedule(struct mpls_te_link *lp, opcode_t opcode)
  *------------------------------------------------------------------------*/
 
 static u_int16_t show_vty_router_addr(struct vty *vty,
-				      struct te_tlv_header *tlvh)
+				      struct tlv_header *tlvh)
 {
 	struct te_tlv_router_addr *top = (struct te_tlv_router_addr *)tlvh;
 
@@ -1649,7 +1611,7 @@ static u_int16_t show_vty_router_addr(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_header(struct vty *vty,
-				      struct te_tlv_header *tlvh)
+				      struct tlv_header *tlvh)
 {
 	struct te_tlv_link *top = (struct te_tlv_link *)tlvh;
 
@@ -1664,7 +1626,7 @@ static u_int16_t show_vty_link_header(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_link_type(struct vty *vty,
-						struct te_tlv_header *tlvh)
+						struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_link_type *top;
 	const char *cp = "Unknown";
@@ -1691,7 +1653,7 @@ static u_int16_t show_vty_link_subtlv_link_type(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_link_id(struct vty *vty,
-					      struct te_tlv_header *tlvh)
+					      struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_link_id *top;
 
@@ -1705,7 +1667,7 @@ static u_int16_t show_vty_link_subtlv_link_id(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_lclif_ipaddr(struct vty *vty,
-						   struct te_tlv_header *tlvh)
+						   struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_lclif_ipaddr *top;
 	int i, n;
@@ -1730,7 +1692,7 @@ static u_int16_t show_vty_link_subtlv_lclif_ipaddr(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_rmtif_ipaddr(struct vty *vty,
-						   struct te_tlv_header *tlvh)
+						   struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_rmtif_ipaddr *top;
 	int i, n;
@@ -1754,7 +1716,7 @@ static u_int16_t show_vty_link_subtlv_rmtif_ipaddr(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_te_metric(struct vty *vty,
-						struct te_tlv_header *tlvh)
+						struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_te_metric *top;
 
@@ -1770,7 +1732,7 @@ static u_int16_t show_vty_link_subtlv_te_metric(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_max_bw(struct vty *vty,
-					     struct te_tlv_header *tlvh)
+					     struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_max_bw *top;
 	float fval;
@@ -1787,7 +1749,7 @@ static u_int16_t show_vty_link_subtlv_max_bw(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_max_rsv_bw(struct vty *vty,
-						 struct te_tlv_header *tlvh)
+						 struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_max_rsv_bw *top;
 	float fval;
@@ -1806,7 +1768,7 @@ static u_int16_t show_vty_link_subtlv_max_rsv_bw(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_unrsv_bw(struct vty *vty,
-					       struct te_tlv_header *tlvh)
+					       struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_unrsv_bw *top;
 	float fval1, fval2;
@@ -1837,7 +1799,7 @@ static u_int16_t show_vty_link_subtlv_unrsv_bw(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_rsc_clsclr(struct vty *vty,
-						 struct te_tlv_header *tlvh)
+						 struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_rsc_clsclr *top;
 
@@ -1853,7 +1815,7 @@ static u_int16_t show_vty_link_subtlv_rsc_clsclr(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_lrrid(struct vty *vty,
-					    struct te_tlv_header *tlvh)
+					    struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_lrrid *top;
 
@@ -1875,7 +1837,7 @@ static u_int16_t show_vty_link_subtlv_lrrid(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_llri(struct vty *vty,
-					   struct te_tlv_header *tlvh)
+					   struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_llri *top;
 
@@ -1897,7 +1859,7 @@ static u_int16_t show_vty_link_subtlv_llri(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_rip(struct vty *vty,
-					  struct te_tlv_header *tlvh)
+					  struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_rip *top;
 
@@ -1914,7 +1876,7 @@ static u_int16_t show_vty_link_subtlv_rip(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_ras(struct vty *vty,
-					  struct te_tlv_header *tlvh)
+					  struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_ras *top;
 
@@ -1931,7 +1893,7 @@ static u_int16_t show_vty_link_subtlv_ras(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_av_delay(struct vty *vty,
-					       struct te_tlv_header *tlvh)
+					       struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_av_delay *top;
 	u_int32_t delay;
@@ -1952,7 +1914,7 @@ static u_int16_t show_vty_link_subtlv_av_delay(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_mm_delay(struct vty *vty,
-					       struct te_tlv_header *tlvh)
+					       struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_mm_delay *top;
 	u_int32_t low, high;
@@ -1974,7 +1936,7 @@ static u_int16_t show_vty_link_subtlv_mm_delay(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_delay_var(struct vty *vty,
-						struct te_tlv_header *tlvh)
+						struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_delay_var *top;
 	u_int32_t jitter;
@@ -1991,7 +1953,7 @@ static u_int16_t show_vty_link_subtlv_delay_var(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_pkt_loss(struct vty *vty,
-					       struct te_tlv_header *tlvh)
+					       struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_pkt_loss *top;
 	u_int32_t loss;
@@ -2014,7 +1976,7 @@ static u_int16_t show_vty_link_subtlv_pkt_loss(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_res_bw(struct vty *vty,
-					     struct te_tlv_header *tlvh)
+					     struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_res_bw *top;
 	float fval;
@@ -2035,7 +1997,7 @@ static u_int16_t show_vty_link_subtlv_res_bw(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_ava_bw(struct vty *vty,
-					     struct te_tlv_header *tlvh)
+					     struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_ava_bw *top;
 	float fval;
@@ -2056,7 +2018,7 @@ static u_int16_t show_vty_link_subtlv_ava_bw(struct vty *vty,
 }
 
 static u_int16_t show_vty_link_subtlv_use_bw(struct vty *vty,
-					     struct te_tlv_header *tlvh)
+					     struct tlv_header *tlvh)
 {
 	struct te_link_subtlv_use_bw *top;
 	float fval;
@@ -2077,7 +2039,7 @@ static u_int16_t show_vty_link_subtlv_use_bw(struct vty *vty,
 }
 
 static u_int16_t show_vty_unknown_tlv(struct vty *vty,
-				      struct te_tlv_header *tlvh)
+				      struct tlv_header *tlvh)
 {
 	if (vty != NULL)
 		vty_out(vty, "  Unknown TLV: [type(0x%x), length(0x%x)]\n",
@@ -2090,11 +2052,11 @@ static u_int16_t show_vty_unknown_tlv(struct vty *vty,
 }
 
 static u_int16_t ospf_mpls_te_show_link_subtlv(struct vty *vty,
-					       struct te_tlv_header *tlvh0,
+					       struct tlv_header *tlvh0,
 					       u_int16_t subtotal,
 					       u_int16_t total)
 {
-	struct te_tlv_header *tlvh, *next;
+	struct tlv_header *tlvh, *next;
 	u_int16_t sum = subtotal;
 
 	for (tlvh = tlvh0; sum < total;
@@ -2172,9 +2134,9 @@ static u_int16_t ospf_mpls_te_show_link_subtlv(struct vty *vty,
 static void ospf_mpls_te_show_info(struct vty *vty, struct ospf_lsa *lsa)
 {
 	struct lsa_header *lsah = (struct lsa_header *)lsa->data;
-	struct te_tlv_header *tlvh, *next;
+	struct tlv_header *tlvh, *next;
 	u_int16_t sum, total;
-	u_int16_t (*subfunc)(struct vty * vty, struct te_tlv_header * tlvh,
+	u_int16_t (*subfunc)(struct vty * vty, struct tlv_header * tlvh,
 			     u_int16_t subtotal, u_int16_t total) = NULL;
 
 	sum = 0;
@@ -2184,7 +2146,7 @@ static void ospf_mpls_te_show_info(struct vty *vty, struct ospf_lsa *lsa)
 	     tlvh = (next ? next : TLV_HDR_NEXT(tlvh))) {
 		if (subfunc != NULL) {
 			sum = (*subfunc)(vty, tlvh, sum, total);
-			next = (struct te_tlv_header *)((char *)tlvh + sum);
+			next = (struct tlv_header *)((char *)tlvh + sum);
 			subfunc = NULL;
 			continue;
 		}
@@ -2210,7 +2172,7 @@ static void ospf_mpls_te_show_info(struct vty *vty, struct ospf_lsa *lsa)
 static void ospf_mpls_te_config_write_router(struct vty *vty)
 {
 
-	if (OspfMplsTE.status == enabled) {
+	if (OspfMplsTE.status == enable) {
 		vty_out(vty, " mpls-te on\n");
 		vty_out(vty, " mpls-te router-address %s\n",
 			inet_ntoa(OspfMplsTE.router_addr.value));
@@ -2239,20 +2201,20 @@ DEFUN (ospf_mpls_te_on,
 	struct listnode *node;
 	struct mpls_te_link *lp;
 
-	if (OspfMplsTE.status == enabled)
+	if (OspfMplsTE.status == enable)
 		return CMD_SUCCESS;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("MPLS-TE: OFF -> ON");
 
-	OspfMplsTE.status = enabled;
+	OspfMplsTE.status = enable;
 
 	/* Reoriginate RFC3630 & RFC6827 Links */
 	ospf_mpls_te_foreach_area(ospf_mpls_te_lsa_schedule,
 				  REORIGINATE_THIS_LSA);
 
 	/* Reoriginate LSA if INTER-AS is always on */
-	if (OspfMplsTE.inter_as != Disable) {
+	if (OspfMplsTE.inter_as != Off) {
 		for (ALL_LIST_ELEMENTS_RO(OspfMplsTE.iflist, node, lp)) {
 			if (IS_INTER_AS(lp->type)) {
 				ospf_mpls_te_lsa_schedule(lp,
@@ -2275,13 +2237,13 @@ DEFUN (no_ospf_mpls_te,
 	struct listnode *node, *nnode;
 	struct mpls_te_link *lp;
 
-	if (OspfMplsTE.status == disabled)
+	if (OspfMplsTE.status == disable)
 		return CMD_SUCCESS;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("MPLS-TE: ON -> OFF");
 
-	OspfMplsTE.status = disabled;
+	OspfMplsTE.status = disable;
 
 	for (ALL_LIST_ELEMENTS(OspfMplsTE.iflist, node, nnode, lp))
 		if
@@ -2317,8 +2279,8 @@ DEFUN (ospf_mpls_te_router_addr,
 
 		set_mpls_te_router_addr(value);
 
-		if (OspfMplsTE.status == disabled)
-			goto out;
+		if (OspfMplsTE.status == disable)
+			return CMD_SUCCESS;
 
 		for (ALL_LIST_ELEMENTS(OspfMplsTE.iflist, node, nnode, lp)) {
 			if ((lp->area == NULL) || IS_FLOOD_AS(lp->type))
@@ -2344,7 +2306,7 @@ DEFUN (ospf_mpls_te_router_addr,
 			ospf_mpls_te_foreach_area(ospf_mpls_te_lsa_schedule,
 						  REORIGINATE_THIS_LSA);
 	}
-out:
+
 	return CMD_SUCCESS;
 }
 
@@ -2356,7 +2318,7 @@ static int set_inter_as_mode(struct vty *vty, const char *mode_name,
 	struct mpls_te_link *lp;
 	int format;
 
-	if (OspfMplsTE.status == enabled) {
+	if (OspfMplsTE.status == enable) {
 
 		/* Read and Check inter_as mode */
 		if (strcmp(mode_name, "as") == 0)
@@ -2385,7 +2347,7 @@ static int set_inter_as_mode(struct vty *vty, const char *mode_name,
 		}
 
 		/* Enable mode and re-originate LSA if needed */
-		if ((OspfMplsTE.inter_as == Disable)
+		if ((OspfMplsTE.inter_as == Off)
 		    && (mode != OspfMplsTE.inter_as)) {
 			OspfMplsTE.inter_as = mode;
 			/* Re-originate all InterAS-TEv2 LSA */
@@ -2451,9 +2413,9 @@ DEFUN (no_ospf_mpls_te_inter_as,
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("MPLS-TE: Inter-AS support OFF");
 
-	if ((OspfMplsTE.status == enabled)
-	    && (OspfMplsTE.inter_as != Disable)) {
-		OspfMplsTE.inter_as = Disable;
+	if ((OspfMplsTE.status == enable)
+	    && (OspfMplsTE.inter_as != Off)) {
+		OspfMplsTE.inter_as = Off;
 		/* Flush all Inter-AS LSA */
 		for (ALL_LIST_ELEMENTS(OspfMplsTE.iflist, node, nnode, lp))
 			if (IS_INTER_AS(lp->type)
@@ -2476,7 +2438,7 @@ DEFUN (show_ip_ospf_mpls_te_router,
        "MPLS-TE information\n"
        "MPLS-TE Router parameters\n")
 {
-	if (OspfMplsTE.status == enabled) {
+	if (OspfMplsTE.status == enable) {
 		vty_out(vty, "--- MPLS-TE router parameters ---\n");
 
 		if (ntohs(OspfMplsTE.router_addr.header.type) != 0)
@@ -2492,7 +2454,7 @@ static void show_mpls_te_link_sub(struct vty *vty, struct interface *ifp)
 {
 	struct mpls_te_link *lp;
 
-	if ((OspfMplsTE.status == enabled) && HAS_LINK_PARAMS(ifp)
+	if ((OspfMplsTE.status == enable) && HAS_LINK_PARAMS(ifp)
 	    && !if_is_loopback(ifp) && if_is_up(ifp)
 	    && ((lp = lookup_linkparams_by_ifp(ifp)) != NULL)) {
 		/* Continue only if interface is not passive or support Inter-AS

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -229,8 +229,8 @@ static struct mpls_te_link *lookup_linkparams_by_instance(struct ospf_lsa *lsa)
 }
 
 static void ospf_mpls_te_foreach_area(void (*func)(struct mpls_te_link *lp,
-						   opcode_t sched_opcode),
-				      opcode_t sched_opcode)
+					enum lsa_opcode sched_opcode),
+				      enum lsa_opcode sched_opcode)
 {
 	struct listnode *node, *nnode;
 	struct listnode *node2;
@@ -1509,7 +1509,7 @@ static struct ospf_lsa *ospf_mpls_te_lsa_refresh(struct ospf_lsa *lsa)
 	return new;
 }
 
-void ospf_mpls_te_lsa_schedule(struct mpls_te_link *lp, opcode_t opcode)
+void ospf_mpls_te_lsa_schedule(struct mpls_te_link *lp, enum lsa_opcode opcode)
 {
 	struct ospf_lsa lsa;
 	struct lsa_header lsah;

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1065,7 +1065,7 @@ static void build_router_tlv(struct stream *s)
 	struct tlv_header *tlvh = &OspfMplsTE.router_addr.header;
 	if (ntohs(tlvh->type) != 0) {
 		build_tlv_header(s, tlvh);
-		stream_put(s, tlvh + 1, TLV_BODY_SIZE(tlvh));
+		stream_put(s, TLV_DATA(tlvh), TLV_BODY_SIZE(tlvh));
 	}
 	return;
 }
@@ -1075,7 +1075,7 @@ static void build_link_subtlv(struct stream *s, struct tlv_header *tlvh)
 
 	if ((tlvh != NULL) && (ntohs(tlvh->type) != 0)) {
 		build_tlv_header(s, tlvh);
-		stream_put(s, tlvh + 1, TLV_BODY_SIZE(tlvh));
+		stream_put(s, TLV_DATA(tlvh), TLV_BODY_SIZE(tlvh));
 	}
 	return;
 }
@@ -2141,7 +2141,7 @@ static void ospf_mpls_te_show_info(struct vty *vty, struct ospf_lsa *lsa)
 		case TE_TLV_LINK:
 			sum += show_vty_link_header(vty, tlvh);
 			subfunc = ospf_mpls_te_show_link_subtlv;
-			next = tlvh + 1;
+			next = TLV_DATA(tlvh);
 			break;
 		default:
 			sum += show_vty_unknown_tlv(vty, tlvh);

--- a/ospfd/ospf_te.h
+++ b/ospfd/ospf_te.h
@@ -408,7 +408,7 @@ extern int ospf_mpls_te_init(void);
 extern void ospf_mpls_te_term(void);
 extern struct ospf_mpls_te *get_ospf_mpls_te(void);
 extern void ospf_mpls_te_update_if(struct interface *);
-extern void ospf_mpls_te_lsa_schedule(struct mpls_te_link *, opcode_t);
+extern void ospf_mpls_te_lsa_schedule(struct mpls_te_link *, enum lsa_opcode);
 extern void set_linkparams_llri(struct mpls_te_link *, u_int32_t, u_int32_t);
 extern void set_linkparams_lrrid(struct mpls_te_link *, struct in_addr,
 				 struct in_addr);

--- a/ospfd/ospf_te.h
+++ b/ospfd/ospf_te.h
@@ -78,7 +78,7 @@
 #define FLOOD_AS	0x20
 #define EMULATED	0x80
 
-#define IS_STD_TE(x)	        (x & STD_TE)
+#define IS_STD_TE(x)	    (x & STD_TE)
 #define IS_PSEUDO_TE(x)		(x & PSEUDO_TE)
 #define IS_INTER_AS(x) 		(x & INTER_AS)
 #define IS_EMULATED(x)		(x & EMULATED)
@@ -95,57 +95,31 @@
 #define LPFLG_LSA_FORCED_REFRESH	0x8
 
 /*
- * Following section defines TLV (tag, length, value) structures,
- * used for Traffic Engineering.
- */
-struct te_tlv_header {
-	u_int16_t type;   /* TE_TLV_XXX (see below) */
-	u_int16_t length; /* Value portion only, in octets */
-};
-
-#define TLV_HDR_SIZE (sizeof(struct te_tlv_header))
-
-#define TLV_BODY_SIZE(tlvh) (ROUNDUP(ntohs((tlvh)->length), sizeof(u_int32_t)))
-
-#define TLV_SIZE(tlvh) (TLV_HDR_SIZE + TLV_BODY_SIZE(tlvh))
-
-#define TLV_HDR_TOP(lsah)                                                      \
-	(struct te_tlv_header *)((char *)(lsah) + OSPF_LSA_HEADER_SIZE)
-
-#define TLV_HDR_NEXT(tlvh)                                                     \
-	(struct te_tlv_header *)((char *)(tlvh) + TLV_SIZE(tlvh))
-
-#define TLV_HDR_SUBTLV(tlvh)                                                   \
-	(struct te_tlv_header *)((char *)(tlvh) + TLV_HDR_SIZE)
-
-#define TLV_TYPE(tlvh)     tlvh.header.type
-#define TLV_LEN(tlvh)      tlvh.header.length
-#define TLV_HDR(tlvh)      tlvh.header
-
-/*
  * Following section defines TLV body parts.
  */
+
 /* Router Address TLV */ /* Mandatory */
 #define	TE_TLV_ROUTER_ADDR		1
 struct te_tlv_router_addr {
-	struct te_tlv_header header; /* Value length is 4 octets. */
+	struct tlv_header header; /* Value length is 4 octets. */
 	struct in_addr value;
 };
 
 /* Link TLV */
 #define	TE_TLV_LINK			2
 struct te_tlv_link {
-	struct te_tlv_header header;
+	struct tlv_header header;
 	/* A set of link-sub-TLVs will follow. */
 };
 
+/* Default TE TLV size */
 #define TE_LINK_SUBTLV_DEF_SIZE		4
 
 /* Link Type Sub-TLV */ /* Mandatory */
 #define	TE_LINK_SUBTLV_LINK_TYPE	1
 #define TE_LINK_SUBTLV_TYPE_SIZE	1
 struct te_link_subtlv_link_type {
-	struct te_tlv_header header; /* Value length is 1 octet. */
+	struct tlv_header header; /* Value length is 1 octet. */
 	struct {
 #define	LINK_TYPE_SUBTLV_VALUE_PTP	1
 #define	LINK_TYPE_SUBTLV_VALUE_MA	2
@@ -157,42 +131,42 @@ struct te_link_subtlv_link_type {
 /* Link Sub-TLV: Link ID */ /* Mandatory */
 #define	TE_LINK_SUBTLV_LINK_ID		2
 struct te_link_subtlv_link_id {
-	struct te_tlv_header header; /* Value length is 4 octets. */
+	struct tlv_header header; /* Value length is 4 octets. */
 	struct in_addr value;	/* Same as router-lsa's link-id. */
 };
 
 /* Link Sub-TLV: Local Interface IP Address */ /* Optional */
 #define	TE_LINK_SUBTLV_LCLIF_IPADDR	3
 struct te_link_subtlv_lclif_ipaddr {
-	struct te_tlv_header header; /* Value length is 4 x N octets. */
+	struct tlv_header header; /* Value length is 4 x N octets. */
 	struct in_addr value[1];     /* Local IP address(es). */
 };
 
 /* Link Sub-TLV: Remote Interface IP Address */ /* Optional */
 #define	TE_LINK_SUBTLV_RMTIF_IPADDR	4
 struct te_link_subtlv_rmtif_ipaddr {
-	struct te_tlv_header header; /* Value length is 4 x N octets. */
+	struct tlv_header header; /* Value length is 4 x N octets. */
 	struct in_addr value[1];     /* Neighbor's IP address(es). */
 };
 
 /* Link Sub-TLV: Traffic Engineering Metric */ /* Optional */
 #define	TE_LINK_SUBTLV_TE_METRIC	5
 struct te_link_subtlv_te_metric {
-	struct te_tlv_header header; /* Value length is 4 octets. */
+	struct tlv_header header; /* Value length is 4 octets. */
 	u_int32_t value;	     /* Link metric for TE purpose. */
 };
 
 /* Link Sub-TLV: Maximum Bandwidth */ /* Optional */
 #define	TE_LINK_SUBTLV_MAX_BW		6
 struct te_link_subtlv_max_bw {
-	struct te_tlv_header header; /* Value length is 4 octets. */
+	struct tlv_header header; /* Value length is 4 octets. */
 	float value;		     /* bytes/sec */
 };
 
 /* Link Sub-TLV: Maximum Reservable Bandwidth */ /* Optional */
 #define	TE_LINK_SUBTLV_MAX_RSV_BW	7
 struct te_link_subtlv_max_rsv_bw {
-	struct te_tlv_header header; /* Value length is 4 octets. */
+	struct tlv_header header; /* Value length is 4 octets. */
 	float value;		     /* bytes/sec */
 };
 
@@ -200,14 +174,14 @@ struct te_link_subtlv_max_rsv_bw {
 #define	TE_LINK_SUBTLV_UNRSV_BW		8
 #define TE_LINK_SUBTLV_UNRSV_SIZE	32
 struct te_link_subtlv_unrsv_bw {
-	struct te_tlv_header header; /* Value length is 32 octets. */
+	struct tlv_header header; /* Value length is 32 octets. */
 	float value[MAX_CLASS_TYPE]; /* One for each priority level. */
 };
 
 /* Link Sub-TLV: Resource Class/Color */ /* Optional */
 #define	TE_LINK_SUBTLV_RSC_CLSCLR	9
 struct te_link_subtlv_rsc_clsclr {
-	struct te_tlv_header header; /* Value length is 4 octets. */
+	struct tlv_header header; /* Value length is 4 octets. */
 	u_int32_t value;	     /* Admin. group membership. */
 };
 
@@ -216,7 +190,7 @@ struct te_link_subtlv_rsc_clsclr {
 #define TE_LINK_SUBTLV_LRRID		10
 #define TE_LINK_SUBTLV_LRRID_SIZE	8
 struct te_link_subtlv_lrrid {
-	struct te_tlv_header header; /* Value length is 8 octets. */
+	struct tlv_header header; /* Value length is 8 octets. */
 	struct in_addr local;	/* Local TE Router Identifier */
 	struct in_addr remote;       /* Remote TE Router Identifier */
 };
@@ -225,7 +199,7 @@ struct te_link_subtlv_lrrid {
 #define TE_LINK_SUBTLV_LLRI		11
 #define TE_LINK_SUBTLV_LLRI_SIZE	8
 struct te_link_subtlv_llri {
-	struct te_tlv_header header; /* Value length is 8 octets. */
+	struct tlv_header header; /* Value length is 8 octets. */
 	u_int32_t local;	     /* Link Local Identifier */
 	u_int32_t remote;	    /* Link Remote Identifier */
 };
@@ -240,14 +214,14 @@ struct te_link_subtlv_llri {
 /* Remote AS Number sub-TLV */
 #define TE_LINK_SUBTLV_RAS		21
 struct te_link_subtlv_ras {
-	struct te_tlv_header header; /* Value length is 4 octets. */
+	struct tlv_header header; /* Value length is 4 octets. */
 	u_int32_t value;	     /* Remote AS number */
 };
 
 /* IPv4 Remote ASBR ID Sub-TLV */
 #define TE_LINK_SUBTLV_RIP		22
 struct te_link_subtlv_rip {
-	struct te_tlv_header header; /* Value length is 4 octets. */
+	struct tlv_header header; /* Value length is 4 octets. */
 	struct in_addr value;	/* Remote ASBR IP address */
 };
 
@@ -261,63 +235,69 @@ struct te_link_subtlv_rip {
 /* Link Sub-TLV: Average Link Delay */ /* Optional */
 #define TE_LINK_SUBTLV_AV_DELAY		27
 struct te_link_subtlv_av_delay {
-	struct te_tlv_header header; /* Value length is 4 bytes. */
-	u_int32_t
-		value; /* delay in micro-seconds only 24 bits => 0 ... 16777215
-			  with Anomalous Bit as Upper most bit */
+	struct tlv_header header; /* Value length is 4 bytes. */
+	/*
+	 * delay in micro-seconds only 24 bits => 0 ... 16777215
+	 * with Anomalous Bit as Upper most bit
+	 */
+	u_int32_t value;
 };
 
 /* Link Sub-TLV: Low/High Link Delay */
 #define TE_LINK_SUBTLV_MM_DELAY         28
 #define TE_LINK_SUBTLV_MM_DELAY_SIZE    8
 struct te_link_subtlv_mm_delay {
-	struct te_tlv_header header; /* Value length is 8 bytes. */
-	u_int32_t low;  /* low delay in micro-seconds only 24 bits => 0 ...
-			   16777215
-			   with Anomalous Bit (A) as Upper most bit */
-	u_int32_t high; /* high delay in micro-seconds only 24 bits => 0 ...
-			   16777215 */
+	struct tlv_header header; /* Value length is 8 bytes. */
+	/*
+	 * low delay in micro-seconds only 24 bits => 0 ... 16777215
+	 * with Anomalous Bit (A) as Upper most bit
+	 */
+	u_int32_t low;
+	/* high delay in micro-seconds only 24 bits => 0 ... 16777215 */
+	u_int32_t high;
 };
 
 /* Link Sub-TLV: Link Delay Variation i.e. Jitter */
 #define TE_LINK_SUBTLV_DELAY_VAR	29
 struct te_link_subtlv_delay_var {
-	struct te_tlv_header header; /* Value length is 4 bytes. */
-	u_int32_t value; /* interval in micro-seconds only 24 bits => 0 ...
-			    16777215 */
+	struct tlv_header header; /* Value length is 4 bytes. */
+	/* interval in micro-seconds only 24 bits => 0 ... 16777215 */
+	u_int32_t value;
 };
 
 /* Link Sub-TLV: Routine Unidirectional Link Packet Loss */
 #define TE_LINK_SUBTLV_PKT_LOSS		30
 struct te_link_subtlv_pkt_loss {
-	struct te_tlv_header header; /* Value length is 4 bytes. */
-	u_int32_t
-		value; /* in percentage of total traffic only 24 bits (2^24 - 2)
-			  with Anomalous Bit as Upper most bit */
+	struct tlv_header header; /* Value length is 4 bytes. */
+	/*
+	 * in percentage of total traffic only 24 bits (2^24 - 2)
+	 * with Anomalous Bit as Upper most bit
+	 */
+	u_int32_t value;
 };
 
 /* Link Sub-TLV: Unidirectional Residual Bandwidth */ /* Optional */
 #define TE_LINK_SUBTLV_RES_BW		31
 struct te_link_subtlv_res_bw {
-	struct te_tlv_header header; /* Value length is 4 bytes. */
-	float value; /* bandwidth in IEEE floating point format with units in
-			bytes per second */
+	struct tlv_header header; /* Value length is 4 bytes. */
+	/* bandwidth in IEEE floating point format with units in bytes/second */
+	float value;
 };
 
 /* Link Sub-TLV: Unidirectional Available Bandwidth */ /* Optional */
 #define TE_LINK_SUBTLV_AVA_BW		32
 struct te_link_subtlv_ava_bw {
-	struct te_tlv_header header; /* Value length is 4 octets. */
-	float value; /* bandwidth in IEEE floating point format with units in
-			bytes per second */
+	struct tlv_header header; /* Value length is 4 octets. */
+	/* bandwidth in IEEE floating point format with units in bytes/second */
+	float value;
 };
 
 /* Link Sub-TLV: Unidirectional Utilized Bandwidth */ /* Optional */
 #define TE_LINK_SUBTLV_USE_BW           33
 struct te_link_subtlv_use_bw {
-	struct te_tlv_header header; /* Value length is 4 octets. */
-	float value; /* bandwidth in IEEE floating point format with units in
-			bytes per second */
+	struct tlv_header header; /* Value length is 4 octets. */
+	/* bandwidth in IEEE floating point format with units in bytes/second */
+	float value;
 };
 
 #define TE_LINK_SUBTLV_MAX		34      /* Last SUBTLV + 1 */
@@ -325,20 +305,11 @@ struct te_link_subtlv_use_bw {
 /* Here are "non-official" architectural constants. */
 #define MPLS_TE_MINIMUM_BANDWIDTH	1.0	/* Reasonable? *//* XXX */
 
-/* Following declaration concerns the MPLS-TE and LINk-TE management */
-typedef enum _opcode_t {
-	REORIGINATE_THIS_LSA,
-	REFRESH_THIS_LSA,
-	FLUSH_THIS_LSA
-} opcode_t;
-
-typedef enum _status_t { disabled, enabled } status_t;
-
 /* Mode for Inter-AS Opaque-LSA */
-enum inter_as_mode { Disable, AS, Area };
+enum inter_as_mode { Off, AS, Area };
 
 struct te_link_subtlv {
-	struct te_tlv_header header;
+	struct tlv_header header;
 	union {
 		u_int32_t link_type;
 		struct in_addr link_id;
@@ -438,7 +409,6 @@ extern void ospf_mpls_te_term(void);
 extern struct ospf_mpls_te *get_ospf_mpls_te(void);
 extern void ospf_mpls_te_update_if(struct interface *);
 extern void ospf_mpls_te_lsa_schedule(struct mpls_te_link *, opcode_t);
-extern u_int32_t get_mpls_te_instance_value(void);
 extern void set_linkparams_llri(struct mpls_te_link *, u_int32_t, u_int32_t);
 extern void set_linkparams_lrrid(struct mpls_te_link *, struct in_addr,
 				 struct in_addr);

--- a/ospfd/ospf_te.h
+++ b/ospfd/ospf_te.h
@@ -337,7 +337,7 @@ struct te_link_subtlv {
 /* Following structure are internal use only. */
 struct ospf_mpls_te {
 	/* Status of MPLS-TE: enable or disbale */
-	status_t status;
+	bool enabled;
 
 	/* RFC5392 */
 	enum inter_as_mode inter_as;

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -84,6 +84,9 @@ struct ospf_external {
 	struct route_table *external_info;
 };
 
+/* Status of various sub function e.g. TE */
+typedef enum _status_t {disable, enable} status_t;
+
 /* OSPF master for system wide configuration and variables. */
 struct ospf_master {
 	/* OSPF instance. */

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -84,9 +84,6 @@ struct ospf_external {
 	struct route_table *external_info;
 };
 
-/* Status of various sub function e.g. TE */
-typedef enum _status_t {disable, enable} status_t;
-
 /* OSPF master for system wide configuration and variables. */
 struct ospf_master {
 	/* OSPF instance. */
@@ -104,7 +101,7 @@ struct ospf_master {
 
 	/* Various OSPF global configuration. */
 	u_char options;
-#define OSPF_MASTER_SHUTDOWN (1 << 0) /* deferred-shutdown */  
+#define OSPF_MASTER_SHUTDOWN (1 << 0) /* deferred-shutdown */
 };
 
 struct ospf_redist {


### PR DESCRIPTION
 * TLV macros where define itwice in ospf_te.h and in ospf_ri.h
 * Merge both definition in ospf_opaque.h and adjust accordingly RI and TE
 * Same for typedef status_t which is move in ospfd.h
 * Remove also all 'goto' statement in ospf_te.c and ospf_ri.c
 * Remove strange function lookup_oi_by_ifp() in ospf_te.c and replace it
by a valid code in initialize_linkparams() function

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>