### PR TITLE
zebra: fetch interface speed on *BSD

### DIFF
--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -628,6 +628,7 @@ ifm_read (struct if_msghdr *ifm)
 #ifdef HAVE_NET_RT_IFLIST
   ifp->stats = ifm->ifm_data;
 #endif /* HAVE_NET_RT_IFLIST */
+  ifp->speed = ifm->ifm_data.ifi_baudrate / 1000000;
 
   if (IS_ZEBRA_DEBUG_KERNEL)
     zlog_debug ("%s: interface %s index %d", 


### PR DESCRIPTION
Fixes #407 for FreeBSD and NetBSD.

OpenBSD uses ioctl to fetch interface information on startup and the
SIOCGIFMEDIA command is just too cumbersome to use.

The best way to fix the problem for OpenBSD is probably to stop treating
it differently from the other BSDs for no apparent reason.  There should
be nothing preventing us to make OpenBSD use the routing socket to fetch
interface information on startup (we already do it to detect runtime
changes). This is something that should be done in a separate commit
after a careful analysis.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>