### PR TITLE
bgpd/eigrpd: fix crashes found by the CLI fuzzer

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -207,8 +207,6 @@ main(int argc, char **argv)
 
     schedule_neighbours_check(5000, 1);
 
-    zlog_notice ("BABELd %s starting: vty@%d", BABEL_VERSION, babel_vty_port);
-
     frr_config_fork();
     frr_run(master);
 

--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -76,6 +76,7 @@ static int
 babel_config_write (struct vty *vty)
 {
     int lines = 0;
+    int afi;
     int i;
 
     /* list enabled debug modes */
@@ -108,13 +109,17 @@ babel_config_write (struct vty *vty)
     /* list enabled interfaces */
     lines = 1 + babel_enable_if_config_write (vty);
     /* list redistributed protocols */
-    for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
-        if (i != zclient->redist_default &&
-	    vrf_bitmap_check (zclient->redist[AFI_IP][i], VRF_DEFAULT))
-        {
-            vty_out (vty, " redistribute %s\n", zebra_route_string(i));
-            lines++;
+    for (afi = AFI_IP; afi <= AFI_IP6; afi++) {
+        for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
+            if (i != zclient->redist_default &&
+                vrf_bitmap_check (zclient->redist[afi][i], VRF_DEFAULT)) {
+                vty_out (vty, " redistribute %s %s\n",
+                         (afi == AFI_IP) ? "ipv4" : "ipv6",
+                         zebra_route_string(i));
+                lines++;
+            }
         }
+    }
 
     lines += config_write_distribute (vty);
 

--- a/babeld/babeld.h
+++ b/babeld/babeld.h
@@ -90,7 +90,6 @@ THE SOFTWARE.
 
 #define BABEL_VTY_PORT 2609
 #define BABEL_DEFAULT_CONFIG "babeld.conf"
-#define BABEL_VERSION "0.1 for quagga"
 
 /* Values in milliseconds */
 #define BABEL_DEFAULT_HELLO_INTERVAL 4000

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -347,6 +347,8 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 	if (bgp == NULL) {
 		if (!use_json)
 			vty_out(vty, "No BGP process is configured\n");
+		else
+			vty_out(vty, "{}\n");
 		return CMD_WARNING;
 	}
 

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -374,6 +374,8 @@ int bgp_show_mpls_vpn(struct vty *vty, afi_t afi, struct prefix_rd *prd,
 	if (bgp == NULL) {
 		if (!use_json)
 			vty_out(vty, "No BGP process is configured\n");
+		else
+			vty_out(vty, "{}\n");
 		return CMD_WARNING;
 	}
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8617,8 +8617,14 @@ static int bgp_show_route(struct vty *vty, struct bgp *bgp, const char *ip_str,
 			  int prefix_check, enum bgp_path_type pathtype,
 			  u_char use_json)
 {
-	if (!bgp)
+	if (!bgp) {
 		bgp = bgp_get_default();
+		if (!bgp) {
+			if (!use_json)
+				vty_out(vty, "No BGP process is configured\n");
+			return CMD_WARNING;
+		}
+	}
 
 	/* labeled-unicast routes live in the unicast table */
 	if (safi == SAFI_LABELED_UNICAST)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8257,6 +8257,8 @@ static int bgp_show(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 	if (bgp == NULL) {
 		if (!use_json)
 			vty_out(vty, "No BGP process is configured\n");
+		else
+			vty_out(vty, "{}\n");
 		return CMD_WARNING;
 	}
 
@@ -8622,6 +8624,8 @@ static int bgp_show_route(struct vty *vty, struct bgp *bgp, const char *ip_str,
 		if (!bgp) {
 			if (!use_json)
 				vty_out(vty, "No BGP process is configured\n");
+			else
+				vty_out(vty, "{}\n");
 			return CMD_WARNING;
 		}
 	}

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -51,6 +51,8 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 	if (bgp == NULL) {
 		if (!use_json)
 			vty_out(vty, "No BGP process is configured\n");
+		else
+			vty_out(vty, "{}\n");
 		return CMD_WARNING;
 	}
 

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -2236,9 +2236,12 @@ void rfapiRibShowResponsesSummary(void *stream)
 	struct rfapi_descriptor *rfd;
 	struct listnode *node;
 
-
 	if (rfapiStream2Vty(stream, &fp, &vty, &out, &vty_newline) == 0)
 		return;
+	if (!bgp) {
+		fp(out, "Unable to find default BGP instance\n");
+		return;
+	}
 
 	fp(out, "%-24s ", "Responses: (Prefixes)");
 	fp(out, "%-8s %-8u ", "Active:", bgp->rfapi->rib_prefix_count_total);
@@ -2388,6 +2391,11 @@ void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 
 	if (rfapiStream2Vty(stream, &fp, &vty, &out, &vty_newline) == 0)
 		return;
+	if (!bgp) {
+		fp(out, "Unable to find default BGP instance\n");
+		return;
+	}
+
 	/*
 	 * loop over NVEs
 	 */

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -237,6 +237,11 @@ DEFUN (no_router_eigrp,
 	struct eigrp *eigrp;
 
 	eigrp = eigrp_lookup();
+	if (eigrp == NULL) {
+		vty_out(vty, " EIGRP Routing Process not enabled\n");
+		return CMD_SUCCESS;
+	}
+
 	if (eigrp->AS != atoi(argv[3]->arg)) {
 		vty_out(vty, "%% Attempting to deconfigure non-existent AS\n");
 		return CMD_WARNING_CONFIG_FAILED;

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -1005,9 +1005,11 @@ DEFUN (eigrp_redistribute_source_metric,
 
 	/* Get distribute source. */
 	argv_find(argv, argc, "redistribute", &idx);
-	source = proto_redistnum(AFI_IP, argv[idx + 1]->arg);
-	if (source < 0)
+	source = proto_redistnum(AFI_IP, argv[idx + 1]->text);
+	if (source < 0) {
+		vty_out(vty, "%% Invalid route type\n");
 		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	/* Get metrics values */
 
@@ -1034,9 +1036,11 @@ DEFUN (no_eigrp_redistribute_source_metric,
 
 	/* Get distribute source. */
 	argv_find(argv, argc, "redistribute", &idx);
-	source = proto_redistnum(AFI_IP, argv[idx + 1]->arg);
-	if (source < 0)
+	source = proto_redistnum(AFI_IP, argv[idx + 1]->text);
+	if (source < 0) {
+		vty_out(vty, "%% Invalid route type\n");
 		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	/* Get metrics values */
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4402,6 +4402,10 @@ static int show_ip_ospf_neighbor_id_common(struct vty *vty, struct ospf *ospf,
 	if (!ret) {
 		if (!use_json)
 			vty_out(vty, "Please specify Neighbor ID by A.B.C.D\n");
+		else {
+			vty_out(vty, "{}\n");
+			json_object_free(json);
+		}
 		return CMD_WARNING;
 	}
 
@@ -4682,6 +4686,10 @@ static int show_ip_ospf_neighbor_int_detail_common(struct vty *vty,
 	if (!ifp) {
 		if (!use_json)
 			vty_out(vty, "No such interface.\n");
+		else {
+			vty_out(vty, "{}\n");
+			json_object_free(json);
+		}
 		return CMD_WARNING;
 	}
 


### PR DESCRIPTION
Fixes the following crashes:
* bgpd aborted: vtysh  -c "show ip bgp l2vpn evpn all 1.1.1.1 json"
* bgpd aborted: vtysh  -c "show ip bgp l2vpn evpn all 1.1.1.1"
* bgpd aborted: vtysh  -c "show ip bgp l2vpn evpn all 1.1.1.1/32 json"
* bgpd aborted: vtysh  -c "show ip bgp l2vpn evpn all 1.1.1.1/32"
* bgpd aborted: vtysh  -c "show bgp l2vpn evpn all 1.1.1.1 json"
* bgpd aborted: vtysh  -c "show bgp l2vpn evpn all 1.1.1.1"
* bgpd aborted: vtysh  -c "show bgp l2vpn evpn all 1.1.1.1/32 json"
* bgpd aborted: vtysh  -c "show bgp l2vpn evpn all 1.1.1.1/32"
* bgpd aborted: vtysh  -c "show bgp ipv4 vpn rd 1:1 1.1.1.1/32 json"
* bgpd aborted: vtysh  -c "show bgp ipv4 vpn rd 1:1 1.1.1.1/32"
* bgpd aborted: vtysh  -c "show bgp ipv4 vpn rd 1:1 2001:db8::1/128 json"
* bgpd aborted: vtysh  -c "show bgp ipv4 vpn rd 1:1 2001:db8::1/128"
* bgpd aborted: vtysh  -c "show bgp ipv6 vpn rd 1:1 1.1.1.1/32 json"
* bgpd aborted: vtysh  -c "show bgp ipv6 vpn rd 1:1 1.1.1.1/32"
* bgpd aborted: vtysh  -c "show bgp ipv6 vpn rd 1:1 2001:db8::1/128 json"
* bgpd aborted: vtysh  -c "show bgp ipv6 vpn rd 1:1 2001:db8::1/128"
* bgpd aborted: vtysh  -c "show vnc responses 1.1.1.1/32"
* bgpd aborted: vtysh  -c "show vnc responses 2001:db8::1/128"
* bgpd aborted: vtysh  -c "show vnc responses 11:11:11:11:11:11"
* bgpd aborted: vtysh  -c "show vnc responses"
* eigrpd aborted: vtysh -c "configure terminal" -c "no router eigrp 65535"

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>