### PR TITLE
redhat: Make the init script flush routes for all associated protocols

### DIFF
--- a/doc/Building_FRR_on_CentOS6.md
+++ b/doc/Building_FRR_on_CentOS6.md
@@ -17,6 +17,9 @@ CentOS 6 restrictions:
 - Zebra is unable to detect what bridge/vrf an interface is associcated
   with (IFLA_INFO_SLAVE_KIND does not exist in the kernel headers, you
   can use a newer kernel + headers to get this functionality)
+- frr_reload.py will not work, as this requires Python 2.7, and CentOS 6
+  only has 2.6.  You can install Python 2.7 via IUS, but it won't work
+  properly unless you compile and install the ipaddr package for it.
 
 Install required packages
 -------------------------

--- a/redhat/frr.init
+++ b/redhat/frr.init
@@ -515,6 +515,18 @@ case "$1" in
         if [ -z "$dmn" -o "$dmn" = "zebra" ]; then
             echo "Removing all routes made by zebra."
             ip route flush proto zebra
+            # At least in CentOS/RHEL 6, iproute2 doesn't know
+            # about the new protocol names, so we have to flush them
+            # by number (it also doesn't support rt_protos.d
+            ip route flush proto 186
+            ip route flush proto 187
+            ip route flush proto 188
+            ip route flush proto 189
+            ip route flush proto 190
+            ip route flush proto 191
+            ip route flush proto 192
+            ip route flush proto 193
+            ip route flush proto 194
         else
             [ -n "$dmn" ] && eval "${dmn/-/_}=0"
             start_watchfrr


### PR DESCRIPTION
The RHEL init script was only flushing routes that were added directly by zebra.  It was not flushing routes that were added by other daemons (such as bgp). 

RHEL lacks a clean way of letting iproute2 know about other RTPROTO defines, so we have to flush these by ID.