### PR TITLE
Bgp -> Allow comparison of correct v6 nexthop

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -269,8 +269,6 @@ static int bgp_interface_delete(int command, struct zclient *zclient,
 	if (!ifp) /* This may happen if we've just unregistered for a VRF. */
 		return 0;
 
-	ifp->ifindex = IFINDEX_DELETED;
-
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("Rx Intf del VRF %u IF %s", vrf_id, ifp->name);
 
@@ -279,6 +277,8 @@ static int bgp_interface_delete(int command, struct zclient *zclient,
 		return 0;
 
 	bgp_update_interface_nbrs(bgp, ifp, NULL);
+
+	ifp->ifindex = IFINDEX_DELETED;
 	return 0;
 }
 


### PR DESCRIPTION
When we were comparing v6 nexthops to decide what to use, if we had both a LL and a Global we would compare the global then the LL if the global was the same to see if the nexthops were the same.  The problem is that, if we were using the LL to install into zebra, and the globals were different, then we would assume we have multiple paths when we did not.