### PR TITLE
LDP config issues (Issue #858)

### DIFF
--- a/ldpd/ldp_vty_cmds.c
+++ b/ldpd/ldp_vty_cmds.c
@@ -80,6 +80,16 @@ DEFUN_NOSH(ldp_address_family,
 	return (ldp_vty_address_family(vty, negate, af));
 }
 
+DEFUN_NOSH(ldp_exit_address_family,
+       ldp_exit_address_family_cmd,
+       "exit-address-family",
+       "Exit from Address Family configuration mode\n")
+{
+	if (vty->node == LDP_IPV4_NODE || vty->node == LDP_IPV6_NODE)
+		vty->node = LDP_NODE;
+	return CMD_SUCCESS;
+}
+
 DEFUN  (ldp_discovery_holdtime,
 	ldp_discovery_holdtime_cmd,
 	"[no] discovery <hello|targeted-hello> holdtime (1-65535)",
@@ -1082,6 +1092,7 @@ ldp_vty_init (void)
 	install_element(LDP_IPV4_NODE, &ldp_interface_cmd);
 	install_element(LDP_IPV4_NODE, &ldp_session_holdtime_cmd);
 	install_element(LDP_IPV4_NODE, &ldp_neighbor_ipv4_targeted_cmd);
+	install_element(LDP_IPV4_NODE, &ldp_exit_address_family_cmd);
 
 	install_element(LDP_IPV6_NODE, &ldp_discovery_holdtime_cmd);
 	install_element(LDP_IPV6_NODE, &ldp_discovery_interval_cmd);
@@ -1095,6 +1106,7 @@ ldp_vty_init (void)
 	install_element(LDP_IPV6_NODE, &ldp_interface_cmd);
 	install_element(LDP_IPV6_NODE, &ldp_session_holdtime_cmd);
 	install_element(LDP_IPV6_NODE, &ldp_neighbor_ipv6_targeted_cmd);
+	install_element(LDP_IPV6_NODE, &ldp_exit_address_family_cmd);
 
 	install_element(LDP_IPV4_IFACE_NODE, &ldp_discovery_holdtime_cmd);
 	install_element(LDP_IPV4_IFACE_NODE, &ldp_discovery_interval_cmd);

--- a/ldpd/ldp_vty_conf.c
+++ b/ldpd/ldp_vty_conf.c
@@ -233,7 +233,7 @@ ldp_af_config_write(struct vty *vty, int af, struct ldpd_conf *conf,
 
 	ldp_af_iface_config_write(vty, af);
 
-	vty_out (vty, "  !\n");
+	vty_out(vty, " exit-address-family\n");
 }
 
 int

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -498,6 +498,29 @@ int vtysh_mark_file(const char *filename)
 		strcpy(vty_buf_copy, vty->buf);
 		vty_buf_trimmed = trim(vty_buf_copy);
 
+		switch (vty->node) {
+		case LDP_IPV4_IFACE_NODE:
+			if (strncmp(vty_buf_copy, "   ", 3)) {
+				fprintf(stdout, "  end\n");
+				vty->node = LDP_IPV4_NODE;
+			}
+			break;
+		case LDP_IPV6_IFACE_NODE:
+			if (strncmp(vty_buf_copy, "   ", 3)) {
+				fprintf(stdout, "  end\n");
+				vty->node = LDP_IPV6_NODE;
+			}
+			break;
+		case LDP_PSEUDOWIRE_NODE:
+			if (strncmp(vty_buf_copy, "  ", 2)) {
+				fprintf(stdout, " end\n");
+				vty->node = LDP_L2VPN_NODE;
+			}
+			break;
+		default:
+			break;
+		}
+
 		if (vty_buf_trimmed[0] == '!' || vty_buf_trimmed[0] == '#') {
 			fprintf(stdout, "%s", vty->buf);
 			continue;

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -303,7 +303,9 @@ static int vtysh_execute_func(const char *line, int pager)
 		     || saved_node == BGP_IPV4L_NODE
 		     || saved_node == BGP_IPV6L_NODE
 		     || saved_node == BGP_IPV6M_NODE
-		     || saved_node == BGP_EVPN_NODE)
+		     || saved_node == BGP_EVPN_NODE
+		     || saved_node == LDP_IPV4_NODE
+		     || saved_node == LDP_IPV6_NODE)
 		    && (tried == 1)) {
 			vtysh_execute("exit-address-family");
 		} else if ((saved_node == BGP_EVPN_VNI_NODE) && (tried == 1)) {
@@ -1265,6 +1267,14 @@ DEFUNSH(VTYSH_LDPD, ldp_address_family_ipv6, ldp_address_family_ipv6_cmd,
 	"IPv6\n")
 {
 	vty->node = LDP_IPV6_NODE;
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_LDPD, ldp_exit_address_family, ldp_exit_address_family_cmd,
+	"exit-address-family", "Exit from Address Family configuration mode\n")
+{
+	if (vty->node == LDP_IPV4_NODE || vty->node == LDP_IPV6_NODE)
+		vty->node = LDP_NODE;
 	return CMD_SUCCESS;
 }
 
@@ -2945,8 +2955,10 @@ void vtysh_init_vty(void)
 	install_element(LDP_NODE, &vtysh_quit_ldpd_cmd);
 	install_element(LDP_IPV4_NODE, &vtysh_exit_ldpd_cmd);
 	install_element(LDP_IPV4_NODE, &vtysh_quit_ldpd_cmd);
+	install_element(LDP_IPV4_NODE, &ldp_exit_address_family_cmd);
 	install_element(LDP_IPV6_NODE, &vtysh_exit_ldpd_cmd);
 	install_element(LDP_IPV6_NODE, &vtysh_quit_ldpd_cmd);
+	install_element(LDP_IPV6_NODE, &ldp_exit_address_family_cmd);
 	install_element(LDP_IPV4_IFACE_NODE, &vtysh_exit_ldpd_cmd);
 	install_element(LDP_IPV4_IFACE_NODE, &vtysh_quit_ldpd_cmd);
 	install_element(LDP_IPV6_IFACE_NODE, &vtysh_exit_ldpd_cmd);


### PR DESCRIPTION
ldpd's running config:
```
mpls ldp
 !
 address-family ipv4
  discovery transport-address 1.1.1.1
  !
  interface eth1
   discovery hello interval 3
  !
  interface eth2
 exit-address-family
 !
 address-family ipv6
  discovery transport-address 2001:db8:1000::1
  !
  interface eth1
  !
  interface eth2
  !
  interface eth9
 exit-address-family
 !
!
l2vpn CUST_A type vpls
 bridge br0
 member interface eth3
 !
 member pseudowire mpw0
  neighbor lsr-id 2.2.2.2
  pw-id 100
 !
 member pseudowire mpw1
  neighbor lsr-id 3.3.3.3
  pw-id 100
 !
!
```

Output of vtysh -m:
```
mpls ldp
 !
 address-family ipv4
  discovery transport-address 1.1.1.1
  !
  interface eth1
   discovery hello interval 3
  end
  !
  interface eth2
  end
 exit-address-family
 !
 address-family ipv6
  discovery transport-address 2001:db8:1000::1
  !
  interface eth1
  end
  !
  interface eth2
  end
  !
  interface eth9
  end
 exit-address-family
 !
!
!
end
l2vpn CUST_A type vpls
 bridge br0
 member interface eth3
 !
 member pseudowire mpw0
  neighbor lsr-id 2.2.2.2
  pw-id 100
 end
 !
 member pseudowire mpw1
  neighbor lsr-id 3.3.3.3
  pw-id 100
 end
 !
!
end
```

The second commit feels ugly and hacky but it's the only solution I found to provide the beautiful markfile output above...