### PR TITLE
ospf6d: New version of GCC with new warnings

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1437,7 +1437,7 @@ static void ospf6_brouter_debug_print(struct ospf6_route *brouter)
 	char brouter_name[16];
 	char area_name[16];
 	char destination[64];
-	char installed[16], changed[16];
+	char installed[64], changed[64];
 	struct timeval now, res;
 	char id[16], adv_router[16];
 	char capa[16], options[16];

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -467,7 +467,7 @@ void ospf6_lsa_show(struct vty *vty, struct ospf6_lsa *lsa)
 	char adv_router[64], id[64];
 	struct ospf6_lsa_handler *handler;
 	struct timeval now, res;
-	char duration[16];
+	char duration[64];
 
 	assert(lsa && lsa->header);
 

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -582,10 +582,10 @@ int inactivity_timer(struct thread *thread)
 static void ospf6_neighbor_show(struct vty *vty, struct ospf6_neighbor *on)
 {
 	char router_id[16];
-	char duration[16];
+	char duration[64];
 	struct timeval res;
 	char nstate[16];
-	char deadtime[16];
+	char deadtime[64];
 	long h, m, s;
 
 	/* Router-ID (Name) */
@@ -640,7 +640,7 @@ static void ospf6_neighbor_show_drchoice(struct vty *vty,
 {
 	char router_id[16];
 	char drouter[16], bdrouter[16];
-	char duration[16];
+	char duration[64];
 	struct timeval now, res;
 
 	/*

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -945,7 +945,7 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route)
 {
 	int i;
 	char destination[PREFIX2STR_BUFFER], nexthop[64];
-	char duration[16];
+	char duration[64];
 	const char *ifname;
 	struct timeval now, res;
 	struct listnode *node;
@@ -991,7 +991,7 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route)
 	char destination[PREFIX2STR_BUFFER], nexthop[64];
 	char area_id[16], id[16], adv_router[16], capa[16], options[16];
 	struct timeval now, res;
-	char duration[16];
+	char duration[64];
 	struct listnode *node;
 	struct ospf6_nexthop *nh;
 


### PR DESCRIPTION
GCC 7.1.1 returned warnings about buffer sizes
not being big enough to handle the full string
that could be generated.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>