### PR TITLE
Switch to using syslog for logging as the default

### DIFF
--- a/debian/frr.logrotate
+++ b/debian/frr.logrotate
@@ -7,11 +7,21 @@
         create 640 frr frrvty
 
         postrotate
-		for i in zebra bgpd ripd ospfd ripngd ospf6d isisd pimd; do
-                        if [ -e /var/run/frr/$i.pid ] ; then
-				kill -USR1 `cat /var/run/frr/$i.pid`
-                        fi
-
-                done
+            pid=$(lsof -t -a -c /syslog/ /var/log/frr/* 2>/dev/null)
+            if [ -n "$pid" ]
+            then # using syslog
+                 kill -HUP $pid
+            fi
+            # in case using file logging; if switching back and forth
+            # between file and syslog, rsyslogd might still have file
+            # open, as well as the daemons, so always signal the daemons.
+            # It's safe, a NOP if (only) syslog is being used.
+            for i in babeld bgpd eigrpd isisd ldpd nhrpd ospf6d ospfd \
+                pimd ripd ripngd zebra ; do
+                if [ -e /var/run/frr/$i.pid ] ; then
+                    pids="$pids $(cat /var/run/frr/$i.pid)"
+                fi
+            done
+            [ -n "$pids" ] && kill -USR1 $pids
         endscript
 }

--- a/redhat/frr.logrotate
+++ b/redhat/frr.logrotate
@@ -1,3 +1,11 @@
+/var/log/frr/frr.log {
+    notifempty
+    missingok
+    postrotate
+	/bin/kill -HUP `cat /var/run/*syslog*.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}
+
 /var/log/frr/zebra.log {
     notifempty
     missingok

--- a/tools/etc/frr/frr.conf
+++ b/tools/etc/frr/frr.conf
@@ -1,2 +1,3 @@
-log file /var/log/frr/frr.log
-log timestamp precision 6
+# default to using syslog. /etc/rsyslog.d/45-frr.conf places the log
+# in /var/log/frr/frr.log
+log syslog informational

--- a/tools/etc/rsyslog.d/45-frr.conf
+++ b/tools/etc/rsyslog.d/45-frr.conf
@@ -1,0 +1,36 @@
+# The lines below cause all FRR daemons and process to go
+# to /var/log/frr/frr.log, then drops the message so it does
+# not also go to /var/log/syslog, so the messages are not duplicated
+
+$outchannel frr_log,/var/log/frr/frr.log
+if  $programname == 'babeld' or
+    $programname == 'bgpd' or
+    $programname == 'eigrpd' or
+    $programname == 'frr' or
+    $programname == 'isisd' or
+    $programname == 'ldpd' or
+    $programname == 'nhrpd' or
+    $programname == 'ospf6d' or
+    $programname == 'ospfd' or
+    $programname == 'pimd' or
+    $programname == 'ripd' or
+    $programname == 'ripngd' or
+    $programname == 'watchfrr' or
+    $programname == 'zebra'
+    then :omfile:$frr_log
+
+if  $programname == 'babeld' or
+    $programname == 'bgpd' or
+    $programname == 'eigrpd' or
+    $programname == 'frr' or
+    $programname == 'isisd' or
+    $programname == 'ldpd' or
+    $programname == 'nhrpd' or
+    $programname == 'ospf6d' or
+    $programname == 'ospfd' or
+    $programname == 'pimd' or
+    $programname == 'ripd' or
+    $programname == 'ripngd' or
+    $programname == 'watchfrr' or
+    $programname == 'zebra'
+    then stop


### PR DESCRIPTION
Switch to using syslog as the default logging mechanism, rather than
the log file mechanism.

Send SIGHUP to syslog (any process with syslog in the name) if they have
files open in /var/log/frr/* (for debian, using lsof).  For redhat, add
sending HUP to any of the pids in /var/run/*syslog*pid, for /var/log/frr/frr.log

Updated logrotate.d/frr to handle all the new daemons for debian; redhat
already had them.

Continue to send SIGUSR1 to all running frr daemons even when syslog is
in use, in case logging has been switched from file to syslog or vice versa.
For debian, accumulate all the PIDs and use a single kill command.

Add /etc/rsyslogd.d/45-frr.conf to have all frr daemons (and tag
frr) logs go to /var/log/frr/frr.log.  If other syslog daemons are
used, logs will go to default log file.

Signed-off-by: Dave Olson <olson@cumulusnetworks.com>