### PR TITLE
Fix debug directive

### DIFF
--- a/lib/libospf.h
+++ b/lib/libospf.h
@@ -35,7 +35,7 @@
 
 /* Architectual Constants */
 #ifdef DEBUG
-#define OSPF_LS_REFRESH_TIME                    60
+#define OSPF_LS_REFRESH_TIME                   120
 #else
 #define OSPF_LS_REFRESH_TIME                  1800
 #endif

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -92,8 +92,7 @@ _lsdb_count_assert (struct ospf6_lsdb *lsdb)
              lsdb, lsdb->count, num);
   for (debug = ospf6_lsdb_head (lsdb); debug;
        debug = ospf6_lsdb_next (debug))
-    zlog_debug ("%p %p %s lsdb[%p]", debug->prev, debug->next, debug->name,
-               debug->lsdb);
+    zlog_debug ("%s lsdb[%p]", debug->name, debug->lsdb);
   zlog_debug ("DUMP END");
 
   assert (num == lsdb->count);


### PR DESCRIPTION
Compiling with `DEBUG` macro set gives some errors. It seems that this option is not actually being used (not sure), so instead of these fixes maybe it would be better to just completely remove this dead code.