### PR TITLE
bgpd: multipath change for VRF route is not updated in zebra

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2078,7 +2078,7 @@ static wq_item_status bgp_process_main(struct work_queue *wq, void *data)
 			vnc_import_bgp_add_route(bgp, p, old_select);
 			vnc_import_bgp_exterior_add_route(bgp, p, old_select);
 #endif
-			if (bgp_fibupd_safi(safi) && !bgp->name
+			if (bgp_fibupd_safi(safi)
 			    && !bgp_option_check(BGP_OPT_NO_FIB)
 			    && new_select->type == ZEBRA_ROUTE_BGP
 			    && new_select->sub_type == BGP_ROUTE_NORMAL)


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

If you are doing multipath in a VRF and bounce one of the multipaths for
a prefix, bgp is not updating the zebra entry for that prefix with the
new multipaths. We start with:
```
cel-redxp-10# show bgp vrf RED  ipv4 unicast 6.0.0.16/32
BGP routing table entry for 6.0.0.16/32
Paths: (4 available, best #4, table RED)
  Advertised to non peer-group peers:
  spine-1(swp1) spine-2(swp2) spine-3(swp3) spine-4(swp4)
  104 65104 65002
    fe80::202:ff:fe00:2d from spine-4(swp4) (6.0.0.12)
    (fe80::202:ff:fe00:2d) (used)
      Origin incomplete, localpref 100, valid, external, multipath, bestpath-from-AS 104
      AddPath ID: RX 0, TX 21
      Last update: Tue Aug  1 18:28:33 2017

  102 65104 65002
    fe80::202:ff:fe00:25 from spine-2(swp2) (6.0.0.10)
    (fe80::202:ff:fe00:25) (used)
      Origin incomplete, localpref 100, valid, external, multipath, bestpath-from-AS 102
      AddPath ID: RX 0, TX 20
      Last update: Tue Aug  1 18:28:33 2017

  103 65104 65002
    fe80::202:ff:fe00:29 from spine-3(swp3) (6.0.0.11)
    (fe80::202:ff:fe00:29) (used)
      Origin incomplete, localpref 100, valid, external, multipath, bestpath-from-AS 103
      AddPath ID: RX 0, TX 17
      Last update: Tue Aug  1 18:28:33 2017

  101 65104 65002
    fe80::202:ff:fe00:21 from spine-1(swp1) (6.0.0.9)
    (fe80::202:ff:fe00:21) (used)
      Origin incomplete, localpref 100, valid, external, multipath, bestpath-from-AS 101, best
      AddPath ID: RX 0, TX 8
      Last update: Tue Aug  1 18:28:33 2017

cel-redxp-10#
cel-redxp-10# show ip route vrf RED 6.0.0.16/32
Routing entry for 6.0.0.16/32
  Known via "bgp", distance 20, metric 0, vrf RED, best
  Last update 00:00:25 ago
  * fe80::202:ff:fe00:21, via swp1
  * fe80::202:ff:fe00:25, via swp2
  * fe80::202:ff:fe00:29, via swp3
  * fe80::202:ff:fe00:2d, via swp4

cel-redxp-10#
```

And then on spine-1 we bounce all peers
```
spine-1# clear ip bgp *
spine-1#
```

On the leaf (cel-redxp-10) we remove the route from spine-1
```
cel-redxp-10# show ip route vrf RED 6.0.0.16/32
Routing entry for 6.0.0.16/32
  Known via "bgp", distance 20, metric 0, vrf RED, best
  Last update 00:00:01 ago
  * fe80::202:ff:fe00:25, via swp2
  * fe80::202:ff:fe00:29, via swp3
  * fe80::202:ff:fe00:2d, via swp4

cel-redxp-10#
```
So far so good. The problem is when the session to spine-1 comes back up
bgp will mark the flag from spine-1 as `multipath` but does not update
zebra. We end up in a state where BGP has 4 paths flags as multipath but
only 3 paths are in the RIB.