### PR TITLE
lib: Remove sockopt_cork functionality

### DIFF
--- a/lib/sockunion.c
+++ b/lib/sockunion.c
@@ -354,13 +354,19 @@ int sockopt_ttl(int family, int sock, int ttl)
 	return 0;
 }
 
+/*
+ * This function called setsockopt(.., TCP_CORK,...)
+ * Which on linux is a no-op since it is enabled by
+ * default and on BSD it uses TCP_NOPUSH to do
+ * the same thing( which it was not configured to
+ * use).  This cleanup of the api occured on 8/1/17
+ * I imagine if after more than 1 year of no-one
+ * complaining, and a major upgrade release we
+ * can deprecate and remove this function call
+ */
 int sockopt_cork(int sock, int onoff)
 {
-#ifdef TCP_CORK
-	return setsockopt(sock, IPPROTO_TCP, TCP_CORK, &onoff, sizeof(onoff));
-#else
 	return 0;
-#endif
 }
 
 int sockopt_mark_default(int sock, int mark, struct zebra_privs_t *cap)


### PR DESCRIPTION
Linux -> TCP_CORK is enabled by default
*BSD -> The equivalent is TCP_NOPUSH

As such sockopt_cork is effectively useless
especially since the two places it is used
do it right before TCP writes then disable
it right after the writes are over.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>