### PR TITLE
pimd: Squash some more memory leaks

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -696,7 +696,7 @@ void igmp_startup_mode_on(struct igmp_sock *igmp)
 
 static void igmp_group_free(struct igmp_group *group)
 {
-	list_free(group->group_source_list);
+	list_delete(group->group_source_list);
 
 	XFREE(MTYPE_PIM_IGMP_GROUP, group);
 }
@@ -748,7 +748,7 @@ void igmp_sock_free(struct igmp_sock *igmp)
 	zassert(igmp->igmp_group_list);
 	zassert(!listcount(igmp->igmp_group_list));
 
-	list_free(igmp->igmp_group_list);
+	list_delete(igmp->igmp_group_list);
 	hash_free(igmp->igmp_group_hash);
 
 	XFREE(MTYPE_PIM_IGMP_SOCKET, igmp);

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -48,7 +48,7 @@ static void pim_instance_terminate(struct pim_instance *pim)
 	}
 
 	if (pim->static_routes)
-		list_free(pim->static_routes);
+		list_delete(pim->static_routes);
 
 	pim_rp_free(pim);
 

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -108,6 +108,7 @@ void pim_jp_agg_clear_group(struct list *group)
 			js->up = NULL;
 			XFREE(MTYPE_PIM_JP_AGG_SOURCE, js);
 		}
+		list_delete(jag->sources);
 		jag->sources = NULL;
 		listnode_delete(group, jag);
 		XFREE(MTYPE_PIM_JP_AGG_GROUP, jag);

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1261,7 +1261,7 @@ static void pim_msdp_mg_free(struct pim_instance *pim, struct pim_msdp_mg *mg)
 		XFREE(MTYPE_PIM_MSDP_MG_NAME, mg->mesh_group_name);
 
 	if (mg->mbr_list)
-		list_free(mg->mbr_list);
+		list_delete(mg->mbr_list);
 
 	XFREE(MTYPE_PIM_MSDP_MG, mg);
 	pim->msdp.mg = NULL;

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -123,7 +123,7 @@ void pim_oil_init(struct pim_instance *pim)
 void pim_oil_terminate(struct pim_instance *pim)
 {
 	if (pim->channel_oil_list)
-		list_free(pim->channel_oil_list);
+		list_delete(pim->channel_oil_list);
 	pim->channel_oil_list = NULL;
 
 	if (pim->channel_oil_hash)

--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -51,7 +51,7 @@ void pim_ssmpingd_init(struct pim_instance *pim)
 void pim_ssmpingd_destroy(struct pim_instance *pim)
 {
 	if (pim->ssmpingd_list) {
-		list_free(pim->ssmpingd_list);
+		list_delete(pim->ssmpingd_list);
 		pim->ssmpingd_list = 0;
 	}
 }

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -2432,6 +2432,7 @@ static int zebra_client_read(struct thread *thread)
 		break;
 	case ZEBRA_REMOTE_MACIP_DEL:
 		zebra_vxlan_remote_macip_del(client, sock, length, zvrf);
+		break;
 	case ZEBRA_INTERFACE_SET_MASTER:
 		zread_interface_set_master(client, sock, length);
 		break;


### PR DESCRIPTION
When a interface is flapped we were leaking some memory
associated with link lists.  Especially in the jp_agg
code.  If your network was/is stable and you are not
running at any scale you probably would not see this
as impactful at all.

Ticket: CM-16392
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>