### PR TITLE
Fix Crash and Convert to ETH_ALEN

### DIFF
--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -42,7 +42,7 @@ void bgp_add_routermac_ecom(struct attr *attr, struct ethaddr *routermac)
 	memset(&routermac_ecom, 0, sizeof(struct ecommunity_val));
 	routermac_ecom.val[0] = ECOMMUNITY_ENCODE_EVPN;
 	routermac_ecom.val[1] = ECOMMUNITY_EVPN_SUBTYPE_ROUTERMAC;
-	memcpy(&routermac_ecom.val[2], routermac->octet, ETHER_ADDR_LEN);
+	memcpy(&routermac_ecom.val[2], routermac->octet, ETH_ALEN);
 	if (!attr->ecommunity)
 		attr->ecommunity = ecommunity_new();
 	ecommunity_add_val(attr->ecommunity, &routermac_ecom);

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -351,7 +351,7 @@ static int bgp_zebra_send_remote_macip(struct bgp *bgp, struct bgpevpn *vpn,
 		s, add ? ZEBRA_REMOTE_MACIP_ADD : ZEBRA_REMOTE_MACIP_DEL,
 		bgp->vrf_id);
 	stream_putl(s, vpn->vni);
-	stream_put(s, &p->prefix.mac.octet, ETHER_ADDR_LEN); /* Mac Addr */
+	stream_put(s, &p->prefix.mac.octet, ETH_ALEN); /* Mac Addr */
 	/* IP address length and IP address, if any. */
 	if (IS_EVPN_PREFIX_IPADDR_NONE(p))
 		stream_putl(s, 0);
@@ -1812,9 +1812,9 @@ static int process_type2_route(struct peer *peer, afi_t afi, safi_t safi,
 	macaddr_len = *pfx++;
 
 	/* Get the MAC Addr */
-	if (macaddr_len == (ETHER_ADDR_LEN * 8)) {
-		memcpy(&p.prefix.mac.octet, pfx, ETHER_ADDR_LEN);
-		pfx += ETHER_ADDR_LEN;
+	if (macaddr_len == (ETH_ALEN * 8)) {
+		memcpy(&p.prefix.mac.octet, pfx, ETH_ALEN);
+		pfx += ETH_ALEN;
 	} else {
 		zlog_err(
 			"%u:%s - Rx EVPN Type-2 NLRI with unsupported MAC address length %d",
@@ -2186,7 +2186,7 @@ char *bgp_evpn_route2str(struct prefix_evpn *p, char *buf, int len)
 	} else if (p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE) {
 		if (IS_EVPN_PREFIX_IPADDR_NONE(p))
 			snprintf(buf, len, "[%d]:[0]:[0]:[%d]:[%s]",
-				 p->prefix.route_type, 8 * ETHER_ADDR_LEN,
+				 p->prefix.route_type, 8 * ETH_ALEN,
 				 prefix_mac2str(&p->prefix.mac, buf1,
 						sizeof(buf1)));
 		else {
@@ -2195,7 +2195,7 @@ char *bgp_evpn_route2str(struct prefix_evpn *p, char *buf, int len)
 			family = IS_EVPN_PREFIX_IPADDR_V4(p) ? AF_INET
 							     : AF_INET6;
 			snprintf(buf, len, "[%d]:[0]:[0]:[%d]:[%s]:[%d]:[%s]",
-				 p->prefix.route_type, 8 * ETHER_ADDR_LEN,
+				 p->prefix.route_type, 8 * ETH_ALEN,
 				 prefix_mac2str(&p->prefix.mac, buf1,
 						sizeof(buf1)),
 				 family == AF_INET ? IPV4_MAX_BITLEN
@@ -2237,7 +2237,7 @@ void bgp_evpn_encode_prefix(struct stream *s, struct prefix *p,
 		stream_put(s, prd->val, 8);	 /* RD */
 		stream_put(s, 0, 10);		    /* ESI */
 		stream_putl(s, 0);		    /* Ethernet Tag ID */
-		stream_putc(s, 8 * ETHER_ADDR_LEN); /* Mac Addr Len - bits */
+		stream_putc(s, 8 * ETH_ALEN); /* Mac Addr Len - bits */
 		stream_put(s, evp->prefix.mac.octet, 6); /* Mac Addr */
 		stream_putc(s, 8 * ipa_len);		 /* IP address Length */
 		if (ipa_len)

--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -174,7 +174,7 @@ static inline void build_evpn_type2_prefix(struct prefix_evpn *p,
 	p->family = AF_ETHERNET;
 	p->prefixlen = EVPN_TYPE_2_ROUTE_PREFIXLEN;
 	p->prefix.route_type = BGP_EVPN_MAC_IP_ROUTE;
-	memcpy(&p->prefix.mac.octet, mac->octet, ETHER_ADDR_LEN);
+	memcpy(&p->prefix.mac.octet, mac->octet, ETH_ALEN);
 	p->prefix.ip.ipa_type = IPADDR_NONE;
 	if (ip)
 		memcpy(&p->prefix.ip, ip, sizeof(*ip));

--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -98,7 +98,7 @@ void decode_rd_vnc_eth(u_char *pnt, struct rd_vnc_eth *rd_vnc_eth)
 {
 	rd_vnc_eth->type = RD_TYPE_VNC_ETH;
 	rd_vnc_eth->local_nve_id = pnt[1];
-	memcpy(rd_vnc_eth->macaddr.octet, pnt + 2, ETHER_ADDR_LEN);
+	memcpy(rd_vnc_eth->macaddr.octet, pnt + 2, ETH_ALEN);
 }
 #endif
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4775,7 +4775,7 @@ int bgp_static_set_safi(afi_t afi, safi_t safi, struct vty *vty,
 			}
 			if (routermac) {
 				bgp_static->router_mac =
-					XCALLOC(MTYPE_ATTR, ETHER_ADDR_LEN + 1);
+					XCALLOC(MTYPE_ATTR, ETH_ALEN + 1);
 				prefix_str2mac(routermac,
 					       bgp_static->router_mac);
 			}

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2125,7 +2125,7 @@ static int bgp_zebra_process_local_macip(int command, struct zclient *zclient,
 	memset(&ip, 0, sizeof(ip));
 	s = zclient->ibuf;
 	vni = stream_getl(s);
-	stream_get(&mac.octet, s, ETHER_ADDR_LEN);
+	stream_get(&mac.octet, s, ETH_ALEN);
 	ipa_len = stream_getl(s);
 	if (ipa_len != 0 && ipa_len != IPV4_MAX_BYTELEN
 	    && ipa_len != IPV6_MAX_BYTELEN) {

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -1568,7 +1568,7 @@ rfapi_query_inner(void *handle, struct rfapi_ip_addr *target,
 
 	if (l2o) {
 		if (!memcmp(l2o->macaddr.octet, rfapi_ethaddr0.octet,
-			    ETHER_ADDR_LEN)) {
+			    ETH_ALEN)) {
 			eth_is_0 = 1;
 		}
 		/* per t/c Paul/Lou 151022 */
@@ -3416,7 +3416,7 @@ DEFUN (debug_rfapi_query_vn_un_l2o,
 	/* construct option chain */
 
 	memset(valbuf, 0, sizeof(valbuf));
-	memcpy(valbuf, &l2o_buf.macaddr.octet, ETHER_ADDR_LEN);
+	memcpy(valbuf, &l2o_buf.macaddr.octet, ETH_ALEN);
 	valbuf[11] = (l2o_buf.logical_net_id >> 16) & 0xff;
 	valbuf[12] = (l2o_buf.logical_net_id >> 8) & 0xff;
 	valbuf[13] = l2o_buf.logical_net_id & 0xff;

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -308,7 +308,7 @@ int rfapiGetL2o(struct attr *attr, struct rfapi_l2address_option *l2o)
 					if (pEncap->value[1] == 14) {
 						memcpy(l2o->macaddr.octet,
 						       pEncap->value + 2,
-						       ETHER_ADDR_LEN);
+						       ETH_ALEN);
 						l2o->label =
 							((pEncap->value[10]
 							  >> 4)
@@ -1327,7 +1327,7 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 		vo->type = RFAPI_VN_OPTION_TYPE_L2ADDR;
 
 		memcpy(&vo->v.l2addr.macaddr, &rn->p.u.prefix_eth.octet,
-		       ETHER_ADDR_LEN);
+		       ETH_ALEN);
 		/* only low 3 bytes of this are significant */
 		if (bi->attr) {
 			(void)rfapiEcommunityGetLNI(

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -805,7 +805,7 @@ void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd, struct prefix *p)
 						 (void **)&mon_eth, &cursor)) {
 
 			if (!memcmp(mon_eth->macaddr.octet,
-				    p->u.prefix_eth.octet, ETHER_ADDR_LEN)) {
+				    p->u.prefix_eth.octet, ETH_ALEN)) {
 
 				rfapiMonitorEthTimerRestart(mon_eth);
 			}
@@ -1117,7 +1117,7 @@ static int mon_eth_cmp(void *a, void *b)
 	/*
 	 * compare ethernet addresses
 	 */
-	for (i = 0; i < ETHER_ADDR_LEN; ++i) {
+	for (i = 0; i < ETH_ALEN; ++i) {
 		if (m1->macaddr.octet[i] != m2->macaddr.octet[i])
 			return (m1->macaddr.octet[i] - m2->macaddr.octet[i]);
 	}

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -687,7 +687,7 @@ static void rfapiRibBi2Ri(struct bgp_info *bi, struct rfapi_info *ri,
 		/* copy from RD already stored in bi, so we don't need it_node
 		 */
 		memcpy(&vo->v.l2addr.macaddr, bi->extra->vnc.import.rd.val + 2,
-		       ETHER_ADDR_LEN);
+		       ETH_ALEN);
 
 		if (bi->attr) {
 			(void)rfapiEcommunityGetLNI(

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -3092,7 +3092,7 @@ static int rfapiDeleteLocalPrefixesByRFD(struct rfapi_local_reg_delete_arg *cda,
 					if (memcmp(cda->l2o.o.macaddr.octet,
 						   adb->u.s.prefix_eth.u
 							   .prefix_eth.octet,
-						   ETHER_ADDR_LEN)) {
+						   ETH_ALEN)) {
 #if DEBUG_L2_EXTRA
 						vnc_zlog_debug_verbose(
 							"%s: adb=%p, macaddr doesn't match, skipping",
@@ -3211,7 +3211,7 @@ static int rfapiDeleteLocalPrefixesByRFD(struct rfapi_local_reg_delete_arg *cda,
 							   adb->u.s.prefix_eth.u
 								   .prefix_eth
 								   .octet,
-							   ETHER_ADDR_LEN)) {
+							   ETH_ALEN)) {
 
 							continue;
 						}

--- a/isisd/isis_bpf.c
+++ b/isisd/isis_bpf.c
@@ -250,8 +250,8 @@ int isis_recv_pdu_bcast(struct isis_circuit *circuit, u_char *ssnpa)
 		     bpf_hdr->bh_caplen - LLC_LEN - ETHER_HDR_LEN);
 	stream_set_getp(circuit->rcv_stream, 0);
 
-	memcpy(ssnpa, readbuff + bpf_hdr->bh_hdrlen + ETHER_ADDR_LEN,
-	       ETHER_ADDR_LEN);
+	memcpy(ssnpa, readbuff + bpf_hdr->bh_hdrlen + ETH_ALEN,
+	       ETH_ALEN);
 
 	if (ioctl(circuit->fd, BIOCFLUSH, &one) < 0)
 		zlog_warn("Flushing failed: %s", safe_strerror(errno));
@@ -281,10 +281,10 @@ int isis_send_pdu_bcast(struct isis_circuit *circuit, int level)
 	 */
 	eth = (struct ether_header *)sock_buff;
 	if (level == 1)
-		memcpy(eth->ether_dhost, ALL_L1_ISS, ETHER_ADDR_LEN);
+		memcpy(eth->ether_dhost, ALL_L1_ISS, ETH_ALEN);
 	else
-		memcpy(eth->ether_dhost, ALL_L2_ISS, ETHER_ADDR_LEN);
-	memcpy(eth->ether_shost, circuit->u.bc.snpa, ETHER_ADDR_LEN);
+		memcpy(eth->ether_dhost, ALL_L2_ISS, ETH_ALEN);
+	memcpy(eth->ether_shost, circuit->u.bc.snpa, ETH_ALEN);
 	size_t frame_size = stream_get_endp(circuit->snd_stream) + LLC_LEN;
 	eth->ether_type = htons(isis_ethertype(frame_size));
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -26,10 +26,6 @@
 #include <netinet/if_ether.h>
 #endif
 
-#ifndef ETHER_ADDR_LEN
-#define	ETHER_ADDR_LEN	ETHERADDRL
-#endif
-
 #include "log.h"
 #include "memory.h"
 #include "vrf.h"

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -26,6 +26,7 @@
 #include "vty.h"
 #include "if.h"
 #include "qobj.h"
+#include "prefix.h"
 
 #include "isis_constants.h"
 #include "isis_common.h"

--- a/isisd/isis_constants.h
+++ b/isisd/isis_constants.h
@@ -167,10 +167,6 @@
 	((if_is_broadcast((C)->interface)) ? (C->interface->mtu - LLC_LEN)     \
 					   : (C->interface->mtu))
 
-#ifndef ETH_ALEN
-#define ETH_ALEN 6
-#endif
-
 #define MAX_LLC_LEN 0x5ff
 #define ETHERTYPE_EXT_LLC 0x8870
 

--- a/ldpd/address.c
+++ b/ldpd/address.c
@@ -160,7 +160,7 @@ send_mac_withdrawal(struct nbr *nbr, struct map *fec, uint8_t *mac)
 	size = LDP_HDR_SIZE + LDP_MSG_SIZE + ADDR_LIST_SIZE + len_fec_tlv(fec) +
 	    TLV_HDR_SIZE;
 	if (mac)
-		size += ETHER_ADDR_LEN;
+		size += ETH_ALEN;
 
 	if ((buf = ibuf_open(size)) == NULL)
 		fatal(__func__);
@@ -372,10 +372,10 @@ gen_mac_list_tlv(struct ibuf *buf, uint8_t *mac)
 	memset(&tlv, 0, sizeof(tlv));
 	tlv.type = htons(TLV_TYPE_MAC_LIST);
 	if (mac)
-		tlv.length = htons(ETHER_ADDR_LEN);
+		tlv.length = htons(ETH_ALEN);
 	err = ibuf_add(buf, &tlv, sizeof(tlv));
 	if (mac)
-		err |= ibuf_add(buf, mac, ETHER_ADDR_LEN);
+		err |= ibuf_add(buf, mac, ETH_ALEN);
 
 	return (err);
 }

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -64,7 +64,7 @@ ifp2kif(struct interface *ifp, struct kif *kif)
 	kif->ifindex = ifp->ifindex;
 	kif->operative = if_is_operative(ifp);
 	if (ifp->ll_type == ZEBRA_LLT_ETHER)
-		memcpy(kif->mac, ifp->hw_addr, ETHER_ADDR_LEN);
+		memcpy(kif->mac, ifp->hw_addr, ETH_ALEN);
 }
 
 static void

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -389,7 +389,7 @@ struct l2vpn_if {
 	char			 ifname[IF_NAMESIZE];
 	unsigned int		 ifindex;
 	int			 operative;
-	uint8_t			 mac[ETHER_ADDR_LEN];
+	uint8_t			 mac[ETH_ALEN];
 	QOBJ_FIELDS
 };
 RB_HEAD(l2vpn_if_head, l2vpn_if);
@@ -566,7 +566,7 @@ struct kif {
 	unsigned short		 ifindex;
 	int			 flags;
 	int			 operative;
-	uint8_t			 mac[ETHER_ADDR_LEN];
+	uint8_t			 mac[ETH_ALEN];
 	int			 mtu;
 };
 

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1062,7 +1062,7 @@ int prefix_blen(const struct prefix *p)
 		return IPV6_MAX_BYTELEN;
 		break;
 	case AF_ETHERNET:
-		return ETHER_ADDR_LEN;
+		return ETH_ALEN;
 	}
 	return 0;
 }

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -34,21 +34,39 @@
 #include "sockunion.h"
 #include "ipaddr.h"
 
-#ifndef ETHER_ADDR_LEN
-#ifdef ETHERADDRL
-#define ETHER_ADDR_LEN  ETHERADDRL
-#else
-#define ETHER_ADDR_LEN 6
-#endif
+#ifndef ETH_ALEN
+#define ETH_ALEN 6
 #endif
 
-#define ETHER_ADDR_STRLEN (3*ETHER_ADDR_LEN)
+/* for compatibility */
+#if defined(__ICC)
+#define CPP_WARN_STR(X) #X
+#define CPP_WARN(text) _Pragma(CPP_WARN_STR(message __FILE__ ": " text))
+
+#elif (defined(__GNUC__)                                                       \
+       && (__GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)))           \
+	|| (defined(__clang__)                                                 \
+	    && (__clang_major__ >= 4                                           \
+		|| (__clang_major__ == 3 && __clang_minor__ >= 5)))
+#define CPP_WARN_STR(X) #X
+#define CPP_WARN(text) _Pragma(CPP_WARN_STR(GCC warning text))
+
+#else
+#define CPP_WARN(text)
+#endif
+
+#ifdef ETHER_ADDR_LEN
+#undef ETHER_ADDR_LEN
+#endif
+#define ETHER_ADDR_LEN 6 CPP_WARN("ETHER_ADDR_LEN is being replaced by ETH_ALEN.\\n")
+
+#define ETHER_ADDR_STRLEN (3*ETH_ALEN)
 /*
  * there isn't a portable ethernet address type. We define our
  * own to simplify internal handling
  */
 struct ethaddr {
-	u_char octet[ETHER_ADDR_LEN];
+	u_char octet[ETH_ALEN];
 } __attribute__((packed));
 
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1704,7 +1704,7 @@ static int netlink_macfdb_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 		return 0;
 	}
 
-	if (RTA_PAYLOAD(tb[NDA_LLADDR]) != ETHER_ADDR_LEN) {
+	if (RTA_PAYLOAD(tb[NDA_LLADDR]) != ETH_ALEN) {
 		zlog_warn(
 			"%s family %s IF %s(%u) brIF %u - LLADDR is not MAC, len %ld",
 			nl_msg_type_to_str(h->nlmsg_type),
@@ -1714,7 +1714,7 @@ static int netlink_macfdb_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 		return 0;
 	}
 
-	memcpy(&mac, RTA_DATA(tb[NDA_LLADDR]), ETHER_ADDR_LEN);
+	memcpy(&mac, RTA_DATA(tb[NDA_LLADDR]), ETH_ALEN);
 
 	if ((NDA_VLAN <= NDA_MAX) && tb[NDA_VLAN]) {
 		vid_present = 1;
@@ -2033,7 +2033,7 @@ static int netlink_ipneigh_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 
 	if (h->nlmsg_type == RTM_NEWNEIGH) {
 		if (tb[NDA_LLADDR]) {
-			if (RTA_PAYLOAD(tb[NDA_LLADDR]) != ETHER_ADDR_LEN) {
+			if (RTA_PAYLOAD(tb[NDA_LLADDR]) != ETH_ALEN) {
 				zlog_warn(
 					"%s family %s IF %s(%u) - LLADDR is not MAC, len %ld",
 					nl_msg_type_to_str(h->nlmsg_type),
@@ -2044,7 +2044,7 @@ static int netlink_ipneigh_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 			}
 
 			mac_present = 1;
-			memcpy(&mac, RTA_DATA(tb[NDA_LLADDR]), ETHER_ADDR_LEN);
+			memcpy(&mac, RTA_DATA(tb[NDA_LLADDR]), ETH_ALEN);
 		}
 
 		ext_learned = (ndm->ndm_flags & NTF_EXT_LEARNED) ? 1 : 0;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -469,7 +469,7 @@ static int zvni_macip_send_msg_to_client(struct zebra_vrf *zvrf, vni_t vni,
 
 	zserv_create_header(s, cmd, zvrf_id(zvrf));
 	stream_putl(s, vni);
-	stream_put(s, macaddr->octet, ETHER_ADDR_LEN);
+	stream_put(s, macaddr->octet, ETH_ALEN);
 	if (ip) {
 		ipa_len = 0;
 		if (IS_IPADDR_V4(ip))
@@ -778,7 +778,7 @@ static unsigned int mac_hash_keymake(void *p)
 	zebra_mac_t *pmac = p;
 	const void *pnt = (void *)pmac->macaddr.octet;
 
-	return jhash(pnt, ETHER_ADDR_LEN, 0xa5a5a55a);
+	return jhash(pnt, ETH_ALEN, 0xa5a5a55a);
 }
 
 /*
@@ -796,7 +796,7 @@ static int mac_cmp(const void *p1, const void *p2)
 		return 0;
 
 	return (memcmp(pmac1->macaddr.octet, pmac2->macaddr.octet,
-		       ETHER_ADDR_LEN)
+		       ETH_ALEN)
 		== 0);
 }
 
@@ -823,7 +823,7 @@ static zebra_mac_t *zvni_mac_add(zebra_vni_t *zvni, struct ethaddr *macaddr)
 	zebra_mac_t *mac = NULL;
 
 	memset(&tmp_mac, 0, sizeof(zebra_mac_t));
-	memcpy(&tmp_mac.macaddr, macaddr, ETHER_ADDR_LEN);
+	memcpy(&tmp_mac.macaddr, macaddr, ETH_ALEN);
 	mac = hash_get(zvni->mac_table, &tmp_mac, zvni_mac_alloc);
 	assert(mac);
 
@@ -931,7 +931,7 @@ static zebra_mac_t *zvni_mac_lookup(zebra_vni_t *zvni, struct ethaddr *mac)
 	zebra_mac_t *pmac;
 
 	memset(&tmp, 0, sizeof(tmp));
-	memcpy(&tmp.macaddr, mac, ETHER_ADDR_LEN);
+	memcpy(&tmp.macaddr, mac, ETH_ALEN);
 	pmac = hash_lookup(zvni->mac_table, &tmp);
 
 	return pmac;
@@ -1967,7 +1967,7 @@ int zebra_vxlan_local_neigh_add_update(struct interface *ifp,
 	if (n) {
 		if (CHECK_FLAG(n->flags, ZEBRA_NEIGH_LOCAL)) {
 			if (memcmp(n->emac.octet, macaddr->octet,
-				   ETHER_ADDR_LEN)
+				   ETH_ALEN)
 			    == 0) {
 				if (n->ifindex == ifp->ifindex)
 					/* we're not interested in whatever has
@@ -2013,7 +2013,7 @@ int zebra_vxlan_local_neigh_add_update(struct interface *ifp,
 
 	/* Set "local" forwarding info. */
 	SET_FLAG(n->flags, ZEBRA_NEIGH_LOCAL);
-	memcpy(&n->emac, macaddr, ETHER_ADDR_LEN);
+	memcpy(&n->emac, macaddr, ETH_ALEN);
 	n->ifindex = ifp->ifindex;
 
 	/* Inform BGP if required. */
@@ -2053,14 +2053,14 @@ int zebra_vxlan_remote_macip_del(struct zserv *client, int sock, u_short length,
 		n = NULL;
 		memset(&ip, 0, sizeof(ip));
 		vni = (vni_t)stream_getl(s);
-		stream_get(&macaddr.octet, s, ETHER_ADDR_LEN);
+		stream_get(&macaddr.octet, s, ETH_ALEN);
 		ipa_len = stream_getl(s);
 		if (ipa_len) {
 			ip.ipa_type = (ipa_len == IPV4_MAX_BYTELEN) ? IPADDR_V4
 								    : IPADDR_V6;
 			stream_get(&ip.ip.addr, s, ipa_len);
 		}
-		l += 4 + ETHER_ADDR_LEN + 4 + ipa_len;
+		l += 4 + ETH_ALEN + 4 + ipa_len;
 		vtep_ip.s_addr = stream_get_ipv4(s);
 		l += IPV4_MAX_BYTELEN;
 
@@ -2139,7 +2139,7 @@ int zebra_vxlan_remote_macip_del(struct zserv *client, int sock, u_short length,
 			 */
 			if (CHECK_FLAG(n->flags, ZEBRA_NEIGH_REMOTE)
 			    && (memcmp(n->emac.octet, macaddr.octet,
-				       ETHER_ADDR_LEN)
+				       ETH_ALEN)
 				== 0)) {
 				zvni_neigh_uninstall(zvni, n);
 				zvni_neigh_del(zvni, n);
@@ -2196,14 +2196,14 @@ int zebra_vxlan_remote_macip_add(struct zserv *client, int sock, u_short length,
 		n = NULL;
 		memset(&ip, 0, sizeof(ip));
 		vni = (vni_t)stream_getl(s);
-		stream_get(&macaddr.octet, s, ETHER_ADDR_LEN);
+		stream_get(&macaddr.octet, s, ETH_ALEN);
 		ipa_len = stream_getl(s);
 		if (ipa_len) {
 			ip.ipa_type = (ipa_len == IPV4_MAX_BYTELEN) ? IPADDR_V4
 								    : IPADDR_V6;
 			stream_get(&ip.ip.addr, s, ipa_len);
 		}
-		l += 4 + ETHER_ADDR_LEN + 4 + ipa_len;
+		l += 4 + ETH_ALEN + 4 + ipa_len;
 		vtep_ip.s_addr = stream_get_ipv4(s);
 		l += IPV4_MAX_BYTELEN;
 
@@ -2354,7 +2354,7 @@ int zebra_vxlan_remote_macip_add(struct zserv *client, int sock, u_short length,
 			/* Set "remote" forwarding info. */
 			UNSET_FLAG(n->flags, ZEBRA_NEIGH_LOCAL);
 			/* TODO: Handle MAC change. */
-			memcpy(&n->emac, &macaddr, ETHER_ADDR_LEN);
+			memcpy(&n->emac, &macaddr, ETH_ALEN);
 			n->r_vtep_ip = vtep_ip;
 			SET_FLAG(n->flags, ZEBRA_NEIGH_REMOTE);
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -776,18 +776,9 @@ static void zvni_install_neigh_hash(struct hash_backet *backet, void *ctxt)
 static unsigned int mac_hash_keymake(void *p)
 {
 	zebra_mac_t *pmac = p;
-	char *pnt = (char *)pmac->macaddr.octet;
-	unsigned int key = 0;
-	int c = 0;
+	const void *pnt = (void *)pmac->macaddr.octet;
 
-	key += pnt[c];
-	key += pnt[c + 1];
-	key += pnt[c + 2];
-	key += pnt[c + 3];
-	key += pnt[c + 4];
-	key += pnt[c + 5];
-
-	return (key);
+	return jhash(pnt, ETHER_ADDR_LEN, 0xa5a5a55a);
 }
 
 /*


### PR DESCRIPTION
Two Fixes:
1) Fix crash in zebra when we have choosen a hashing function poorly
2) Convert code to ETH_ALEN and deprecate ETHER_ADDR_LEN