### PR TITLE
lib: add missed apply_mask()

### DIFF
--- a/lib/table.c
+++ b/lib/table.c
@@ -88,6 +88,7 @@ static struct route_node *route_node_set(struct route_table *table,
 	node = route_node_new(table);
 
 	prefix_copy(&node->p, prefix);
+	apply_mask(&node->p);
 	node->table = table;
 
 	inserted = hash_get(node->table->hash, node, hash_alloc_intern);


### PR DESCRIPTION
Now that we use a hash table to back routing tables we have to make an executive decision whether to apply the mask or not before table insertion and lookup. The decision by consensus seems to be that we're applying the mask. Looks like we missed a spot.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>