### PR TITLE
bgpd: remove bogus change in attrhash_key_make()

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -566,12 +566,6 @@ unsigned int attrhash_key_make(void *p)
 	MIX(attr->nexthop.s_addr);
 	MIX(attr->med);
 	MIX(attr->local_pref);
-
-	key += attr->origin;
-	key += attr->nexthop.s_addr;
-	key += attr->med;
-	key += attr->local_pref;
-
 	MIX(attr->aggregator_as);
 	MIX(attr->aggregator_addr.s_addr);
 	MIX(attr->weight);


### PR DESCRIPTION
Commit c8e7b895 ("bgpd: use Jenkins hash for BGP transit, cluster and
attr hashes") changed attrhash_key_make() to use Jenkins hash, commit
c8f3fe30 ("bgpd: Remove AS Path limit/TTL functionality") introduced
a bogus change with a snippet of code that was deleted in the first
one.

Signed-off-by: Jorge Boncompte <jbonor@gmail.com>