### PR TITLE
lib: cli: don't run off graph "pre-end"

### DIFF
--- a/lib/command_graph.c
+++ b/lib/command_graph.c
@@ -385,7 +385,6 @@ static void cmd_node_names(struct graph_node *gn, struct graph_node *join,
 		break;
 
 	case START_TKN:
-	case END_TKN:
 	case JOIN_TKN:
 		/* "<foo|bar> WORD" -> word is not "bar" or "foo" */
 		prevname = NULL;
@@ -405,6 +404,9 @@ static void cmd_node_names(struct graph_node *gn, struct graph_node *join,
 			cmd_token_varname_set(tailtok, jointok->varname);
 		}
 		break;
+
+	case END_TKN:
+		return;
 	}
 
 	for (i = 0; i < vector_active(gn->to); i++) {


### PR DESCRIPTION
Behind END_TKN, there is another graph node whose data pointer is
actually struct cmd_element instead of struct cmd_token.  Don't try to
interpret that as cmd_token.  This causes very interesting crashes when
ASLR decides to give one of the strings of a command definition a lower
32-bit value that is a valid cmd_token_type (e.g. FORK_TKN).

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>