### PR TITLE
rhel: Don't obsolete bird

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -168,7 +168,8 @@ Requires(pre):      initscripts >= 5.60
 %endif
 Provides:           routingdaemon = %{version}-%{release}
 BuildRoot:          %{_tmppath}/%{name}-%{version}-root
-Obsoletes:          bird gated mrt zebra frr-sysvinit
+Obsoletes:          gated mrt zebra frr-sysvinit
+Conflicts:          bird
 
 %description
 FRRouting is a free software that manages TCP/IP based routing


### PR DESCRIPTION
The FRR RPM was obsoleting BIRD, which meant that as soon as you added a FRR RPM to a repository, you could no longer install BIRD.  This patch switches it over to Conflicts instead, which should be much nicer behavior