### PR TITLE
*: Define the number of seconds in a Day, Week and year

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -543,8 +543,6 @@ static const char *bgp_get_reuse_time(unsigned int penalty, char *buf,
 		reuse_time = 0;
 
 /* Making formatted timer strings. */
-#define ONE_DAY_SECOND 60*60*24
-#define ONE_WEEK_SECOND 60*60*24*7
 	if (reuse_time == 0) {
 		if (use_json)
 			json_object_int_add(json, "reuseTimerMsecs", 0);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6110,11 +6110,6 @@ char *peer_uptime(time_t uptime2, char *buf, size_t len, u_char use_json,
 	uptime1 -= uptime2;
 	tm = gmtime(&uptime1);
 
-/* Making formatted timer strings. */
-#define ONE_DAY_SECOND 60*60*24
-#define ONE_WEEK_SECOND ONE_DAY_SECOND*7
-#define ONE_YEAR_SECOND ONE_DAY_SECOND*365
-
 	if (uptime1 < ONE_DAY_SECOND)
 		snprintf(buf, len, "%02d:%02d:%02d", tm->tm_hour, tm->tm_min,
 			 tm->tm_sec);

--- a/isisd/isis_misc.c
+++ b/isisd/isis_misc.c
@@ -609,8 +609,6 @@ void vty_out_timestr(struct vty *vty, time_t uptime)
 	difftime -= uptime;
 	tm = gmtime(&difftime);
 
-#define ONE_DAY_SECOND 60*60*24
-#define ONE_WEEK_SECOND 60*60*24*7
 	if (difftime < ONE_DAY_SECOND)
 		vty_out(vty, "%02d:%02d:%02d", tm->tm_hour, tm->tm_min,
 			tm->tm_sec);

--- a/lib/monotime.h
+++ b/lib/monotime.h
@@ -49,6 +49,10 @@ static inline time_t monotime(struct timeval *tvo)
 	return ts.tv_sec;
 }
 
+#define ONE_DAY_SECOND 60*60*24
+#define ONE_WEEK_SECOND ONE_DAY_SECOND*7
+#define ONE_YEAR_SECOND ONE_DAY_SECOND*365
+
 /* the following two return microseconds, not time_t!
  *
  * also, they're negative forms of each other, but having both makes the

--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -143,10 +143,6 @@ static char *rip_peer_uptime(struct rip_peer *peer, char *buf, size_t len)
 	uptime -= peer->uptime;
 	tm = gmtime(&uptime);
 
-/* Making formatted timer strings. */
-#define ONE_DAY_SECOND 60*60*24
-#define ONE_WEEK_SECOND 60*60*24*7
-
 	if (uptime < ONE_DAY_SECOND)
 		snprintf(buf, len, "%02d:%02d:%02d", tm->tm_hour, tm->tm_min,
 			 tm->tm_sec);

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -151,10 +151,6 @@ static char *ripng_peer_uptime(struct ripng_peer *peer, char *buf, size_t len)
 	uptime -= peer->uptime;
 	tm = gmtime(&uptime);
 
-/* Making formatted timer strings. */
-#define ONE_DAY_SECOND 60*60*24
-#define ONE_WEEK_SECOND 60*60*24*7
-
 	if (uptime < ONE_DAY_SECOND)
 		snprintf(buf, len, "%02d:%02d:%02d", tm->tm_hour, tm->tm_min,
 			 tm->tm_sec);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -55,9 +55,6 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
 static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 				     int mcast);
 
-#define ONE_DAY_SECOND 60*60*24
-#define ONE_WEEK_SECOND 60*60*24*7
-
 /* VNI range as per RFC 7432 */
 #define CMD_VNI_RANGE "(1-16777215)"
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -2647,10 +2647,6 @@ static char *zserv_time_buf(time_t *time1, char *buf, int buflen)
 	now -= *time1;
 	tm = gmtime(&now);
 
-/* Making formatted timer strings. */
-#define ONE_DAY_SECOND 60*60*24
-#define ONE_WEEK_SECOND 60*60*24*7
-
 	if (now < ONE_DAY_SECOND)
 		snprintf(buf, buflen, "%02d:%02d:%02d", tm->tm_hour, tm->tm_min,
 			 tm->tm_sec);


### PR DESCRIPTION
The defines:

ONE_DAY_SECOND
ONE_WEEK_SECOND
ONE_YEAR_SECOND

were being defined all over the system, move the
define to a central location.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>