### PR TITLE
lib/hash.c: temp bandaid fix to infinite hash expansion

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -49,6 +49,7 @@ struct hash *hash_create_size(unsigned int size,
 	hash->index =
 		XCALLOC(MTYPE_HASH_INDEX, sizeof(struct hash_backet *) * size);
 	hash->size = size;
+	hash->max_size = size<<8;
 	hash->hash_key = hash_key;
 	hash->hash_cmp = hash_cmp;
 	hash->count = 0;


### PR DESCRIPTION
limit the expansion of hash tables to size*2^8 (table is expand 2* per expand call)

Can be removed once have more complete fix from @qlyoung 