### PR TITLE
configure: restore support for --with-rfp-path= broken by PR784 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1817,6 +1817,11 @@ AC_CONFIG_FILES([Makefile
 	  pkgsrc/ripd.sh pkgsrc/ripngd.sh pkgsrc/zebra.sh
 	  pkgsrc/eigrpd.sh])
 
+if test "${enable_bgp_vnc}" != "no"; then
+   if test "${with_rfp_path}" != "bgpd/rfp-example" ; then
+      AC_CONFIG_FILES([${with_rfp_path}/rfptest/Makefile ${with_rfp_path}/librfp/Makefile])
+   fi
+fi
 
 AC_CONFIG_FILES([solaris/Makefile])
 


### PR DESCRIPTION
    configure: restore support for --with-rfp-path= broken by PR784 (revised fix for that issue is TBD)
