### PR TITLE
bgpd: do not bounce peer when re-binding to current peer-group

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2523,7 +2523,8 @@ int peer_group_bind(struct bgp *bgp, union sockunion *su, struct peer *peer,
 		if (peer_group_active(peer)) {
 
 			/* The peer is already bound to the peer-group,
-			 * nothing to do */
+			 * nothing to do
+			 */
 			if (strcmp(peer->group->name, group->name) == 0)
 				return 0;
 			else

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2518,11 +2518,17 @@ int peer_group_bind(struct bgp *bgp, union sockunion *su, struct peer *peer,
 
 	/* The peer exist, bind it to the peer-group */
 	if (peer) {
-		/* When the peer already belongs to peer group, check the
+		/* When the peer already belongs to a peer-group, check the
 		 * consistency.  */
-		if (peer_group_active(peer)
-		    && strcmp(peer->group->name, group->name) != 0)
-			return BGP_ERR_PEER_GROUP_CANT_CHANGE;
+		if (peer_group_active(peer)) {
+
+			/* The peer is already bound to the peer-group,
+			 * nothing to do */
+			if (strcmp(peer->group->name, group->name) == 0)
+				return 0;
+			else
+				return BGP_ERR_PEER_GROUP_CANT_CHANGE;
+		}
 
 		/* The peer has not specified a remote-as, inherit it from the
 		 * peer-group */


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

If  peer is a member of peer-group FOO and you re-configure "neighbor x.x.x.x peer-group FOO" it will bounce the peer.