### PR TITLE
eigrpd: Add missing install_element for debug eigrp transmit

### DIFF
--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -616,5 +616,6 @@ void eigrp_debug_init()
 	install_element(CONFIG_NODE, &show_debugging_eigrp_cmd);
 	install_element(CONFIG_NODE, &debug_eigrp_packets_all_cmd);
 	install_element(CONFIG_NODE, &no_debug_eigrp_packets_all_cmd);
+	install_element(CONFIG_NODE, &debug_eigrp_transmit_cmd);
 	install_element(CONFIG_NODE, &no_debug_eigrp_transmit_cmd);
 }


### PR DESCRIPTION
debug eigrp transmit command is added to the ENABLE_NODE list, but not
CONFIG_NODE. As a result the command cannot be used in the
configuration file. Add the missing call.

Signed-off-by: Andrew Lunn <andrew@lunn.ch>