### PR TITLE
lib, bgpd: fix `set ip next-hop peer-address`

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3499,14 +3499,20 @@ DEFUN (no_match_origin,
 
 DEFUN (set_ip_nexthop_peer,
        set_ip_nexthop_peer_cmd,
-       "set ip next-hop peer-address",
+       "[no] set ip next-hop peer-address",
+       NO_STR
        SET_STR
        IP_STR
        "Next hop address\n"
        "Use peer address (for BGP only)\n")
 {
-	return generic_set_add(vty, VTY_GET_CONTEXT(route_map_index),
-			       "ip next-hop", "peer-address");
+	int (*func)(struct vty *, struct route_map_index *, const char *,
+		     const char *) = strmatch(argv[0]->text, "no")
+					     ? generic_set_delete
+					     : generic_set_add;
+
+	return func(vty, VTY_GET_CONTEXT(route_map_index), "ip next-hop",
+		    "peer-address");
 }
 
 DEFUN (set_ip_nexthop_unchanged,

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3517,14 +3517,20 @@ DEFUN (set_ip_nexthop_peer,
 
 DEFUN (set_ip_nexthop_unchanged,
        set_ip_nexthop_unchanged_cmd,
-       "set ip next-hop unchanged",
+       "[no] set ip next-hop unchanged",
+       NO_STR
        SET_STR
        IP_STR
        "Next hop address\n"
        "Don't modify existing Next hop address\n")
 {
-	return generic_set_add(vty, VTY_GET_CONTEXT(route_map_index),
-			       "ip next-hop", "unchanged");
+	int (*func)(struct vty *, struct route_map_index *, const char *,
+		     const char *) = strmatch(argv[0]->text, "no")
+					     ? generic_set_delete
+					     : generic_set_add;
+
+	return func(vty, VTY_GET_CONTEXT(route_map_index), "ip next-hop",
+		    "unchanged");
 }
 
 

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -2194,24 +2194,24 @@ DEFUN (set_ip_nexthop,
 
 DEFUN (no_set_ip_nexthop,
        no_set_ip_nexthop_cmd,
-       "no set ip next-hop [<peer-address|A.B.C.D>]",
+       "no set ip next-hop [A.B.C.D]",
        NO_STR
        SET_STR
        IP_STR
        "Next hop address\n"
-       "Use peer address (for BGP only)\n"
        "IP address of next hop\n")
 {
-	int idx_peer = 4;
+	int idx;
 	VTY_DECLVAR_CONTEXT(route_map_index, index);
+	const char *arg = NULL;
 
-	if (rmap_match_set_hook.no_set_ip_nexthop) {
-		if (argc <= idx_peer)
-			return rmap_match_set_hook.no_set_ip_nexthop(
-				vty, index, "ip next-hop", NULL);
+	if (argv_find(argv, argc, "A.B.C.D", &idx))
+		arg = argv[idx]->arg;
+
+	if (rmap_match_set_hook.no_set_ip_nexthop)
 		return rmap_match_set_hook.no_set_ip_nexthop(
-			vty, index, "ip next-hop", argv[idx_peer]->arg);
-	}
+			vty, index, "ip next-hop", arg);
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
This bgp-specific command had its positive form defined only in bgpd and
its negative form defined only in lib, which broke the whole rule for
other daemons.

Also adds a missing `no` for `set ip next-hop unchanged` in bgp.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>