### PR TITLE
libfrr: restore old Standard I/O (stdout/stderr) handling

### DIFF
--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -49,6 +49,7 @@ struct frr_daemon_info {
 	char *vty_sock_path;
 	bool dryrun;
 	bool daemon_mode;
+	bool stdio;
 	bool terminal;
 	const char *config_file;
 	const char *pid_file;


### PR DESCRIPTION
	via the -I, --stdio command line option.

	Broken/Changed by:
	   lib: close stdin/out/err in non-terminal case

