### PR TITLE
eigrpd: fix spelling of "bandwidth"

### DIFF
--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -265,7 +265,7 @@ int eigrp_if_up(struct eigrp_interface *ei)
 	thread_add_event(master, eigrp_hello_timer, ei, (1), NULL);
 
 	/*Prepare metrics*/
-	metric.bandwith =
+	metric.bandwidth =
 		eigrp_bandwidth_to_scaled(EIGRP_IF_PARAM(ei, bandwidth));
 	metric.delay = eigrp_delay_to_scaled(EIGRP_IF_PARAM(ei, delay));
 	metric.load = EIGRP_IF_PARAM(ei, load);

--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -392,9 +392,9 @@ u_int32_t eigrp_calculate_metrics(struct eigrp *eigrp,
 	// {K1*BW+[(K2*BW)/(256-load)]+(K3*delay)}*{K5/(reliability+K4)}
 
 	if (eigrp->k_values[0])
-		temp_metric += (eigrp->k_values[0] * metric.bandwith);
+		temp_metric += (eigrp->k_values[0] * metric.bandwidth);
 	if (eigrp->k_values[1])
-		temp_metric += ((eigrp->k_values[1] * metric.bandwith)
+		temp_metric += ((eigrp->k_values[1] * metric.bandwidth)
 				/ (256 - metric.load));
 	if (eigrp->k_values[2])
 		temp_metric += (eigrp->k_values[2] * metric.delay);
@@ -425,9 +425,9 @@ u_int32_t eigrp_calculate_total_metrics(struct eigrp *eigrp,
 
 	u_int32_t bw =
 		eigrp_bandwidth_to_scaled(EIGRP_IF_PARAM(entry->ei, bandwidth));
-	entry->total_metric.bandwith = entry->total_metric.bandwith > bw
+	entry->total_metric.bandwidth = entry->total_metric.bandwidth > bw
 					       ? bw
-					       : entry->total_metric.bandwith;
+					       : entry->total_metric.bandwidth;
 
 	return eigrp_calculate_metrics(eigrp, entry->total_metric);
 }
@@ -435,7 +435,7 @@ u_int32_t eigrp_calculate_total_metrics(struct eigrp *eigrp,
 u_char eigrp_metrics_is_same(struct eigrp_metrics metric1,
 			     struct eigrp_metrics metric2)
 {
-	if ((metric1.bandwith == metric2.bandwith)
+	if ((metric1.bandwidth == metric2.bandwidth)
 	    && (metric1.delay == metric2.delay)
 	    && (metric1.hop_count == metric2.hop_count)
 	    && (metric1.load == metric2.load)

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -1141,7 +1141,7 @@ struct TLV_IPv4_Internal_type *eigrp_read_ipv4_tlv(struct stream *s)
 	tlv->length = stream_getw(s);
 	tlv->forward.s_addr = stream_getl(s);
 	tlv->metric.delay = stream_getl(s);
-	tlv->metric.bandwith = stream_getl(s);
+	tlv->metric.bandwidth = stream_getl(s);
 	tlv->metric.mtu[0] = stream_getc(s);
 	tlv->metric.mtu[1] = stream_getc(s);
 	tlv->metric.mtu[2] = stream_getc(s);
@@ -1210,7 +1210,7 @@ u_int16_t eigrp_add_internalTLV_to_stream(struct stream *s,
 
 	/*Metric*/
 	stream_putl(s, pe->reported_metric.delay);
-	stream_putl(s, pe->reported_metric.bandwith);
+	stream_putl(s, pe->reported_metric.bandwidth);
 	stream_putc(s, pe->reported_metric.mtu[2]);
 	stream_putc(s, pe->reported_metric.mtu[1]);
 	stream_putc(s, pe->reported_metric.mtu[0]);

--- a/eigrpd/eigrp_structs.h
+++ b/eigrpd/eigrp_structs.h
@@ -59,7 +59,7 @@ struct eigrp_master {
 
 struct eigrp_metrics {
 	u_int32_t delay;
-	u_int32_t bandwith;
+	u_int32_t bandwidth;
 	unsigned char mtu[3];
 	u_char hop_count;
 	u_char reliability;


### PR DESCRIPTION
There are a number of spelling errors in eigrp. But this one is
particular annoying because it is a variable name, not in a comment.

Signed-off-by: Andrew Lunn <andrew@lunn.ch>