### PR TITLE
ospfd: fix crash due to conflicting router-id, fix MI-OSPF cli in lib commands and fix memory leaks

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1062,7 +1062,8 @@ int cmd_execute_command(vector vline, struct vty *vty,
 	if (vtysh)
 		return saved_ret;
 
-	if (ret != CMD_SUCCESS && ret != CMD_WARNING) {
+	if (ret != CMD_SUCCESS && ret != CMD_WARNING
+	    && ret != CMD_NOT_MY_INSTANCE && ret != CMD_WARNING_CONFIG_FAILED) {
 		/* This assumes all nodes above CONFIG_NODE are childs of
 		 * CONFIG_NODE */
 		while (vty->node > CONFIG_NODE) {
@@ -1070,7 +1071,9 @@ int cmd_execute_command(vector vline, struct vty *vty,
 			vty->node = try_node;
 			ret = cmd_execute_command_real(vline, FILTER_RELAXED,
 						       vty, cmd);
-			if (ret == CMD_SUCCESS || ret == CMD_WARNING)
+			if (ret == CMD_SUCCESS || ret == CMD_WARNING
+			    || ret == CMD_NOT_MY_INSTANCE
+			    || ret == CMD_WARNING_CONFIG_FAILED)
 				return ret;
 		}
 		/* no command succeeded, reset the vty to the original node */
@@ -1134,6 +1137,8 @@ int command_config_read_one_line(struct vty *vty,
 	if (!(use_daemon && ret == CMD_SUCCESS_DAEMON)
 	    && !(!use_daemon && ret == CMD_ERR_NOTHING_TODO)
 	    && ret != CMD_SUCCESS && ret != CMD_WARNING
+	    && ret != CMD_NOT_MY_INSTANCE
+	    && ret != CMD_WARNING_CONFIG_FAILED
 	    && vty->node != CONFIG_NODE) {
 
 		saved_node = vty->node;

--- a/ospfd/ospf_neighbor.c
+++ b/ospfd/ospf_neighbor.c
@@ -269,7 +269,8 @@ void ospf_nbr_add_self(struct ospf_interface *oi, struct in_addr router_id)
 	rn = route_node_get(oi->nbrs, &p);
 	if (rn->info) {
 		/* There is already pseudo neighbor. */
-		assert(oi->nbr_self == rn->info);
+		zlog_warn("router_id %s already present in neighbor table. node refcount %u",
+			  inet_ntoa(router_id), rn->lock);
 		route_unlock_node(rn);
 	} else
 		rn->info = oi->nbr_self;

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -401,6 +401,8 @@ static void ospf_spf_flush_parents(struct vertex *w)
 	/* delete the existing nexthops */
 	for (ALL_LIST_ELEMENTS(w->parents, ln, nn, vp)) {
 		list_delete_node(w->parents, ln);
+		if (vp->nexthop)
+			vertex_nexthop_free(vp->nexthop);
 		vertex_parent_free(vp);
 	}
 }

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -715,6 +715,7 @@ void ospf_redist_del(struct ospf *ospf, u_char type, u_short instance)
 			list_free(ospf->redist[type]);
 			ospf->redist[type] = NULL;
 		}
+		ospf_routemap_unset(red);
 		XFREE(MTYPE_OSPF_REDISTRIBUTE, red);
 	}
 }

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1187,7 +1187,7 @@ void ospf_ls_upd_queue_empty(struct ospf_interface *oi)
 		if ((lst = (struct list *)rn->info)) {
 			for (ALL_LIST_ELEMENTS(lst, node, nnode, lsa))
 				ospf_lsa_unlock(&lsa); /* oi->ls_upd_queue */
-			list_free(lst);
+			list_delete(lst);
 			rn->info = NULL;
 		}
 


### PR DESCRIPTION
Fix OSPFd crashes upon configuring multi-instance ospf i.e 'router ospf x'. As part of PR #912, OSPFd can return CMD_NOT_MY_INSTANCE which is not supported in lib/commands.
Support following two error codes: CMD_NOT_MY_INSTANCE and CMD_WARNING_CONFIG_FAILED  in lib/commands.c
- Testing: Validated various Muli-instance OSPF configuration/show commands with this fix with instance id out of bound. 

Fix OSPFd crash upon configuring same router-id as neighbor's.
The assert is in the path of router_id_update.
Remove the assert , log a warning message, and do not bring up neighbor-ship. 
-Testing: bring up point-to-point  router x - router y with different router-id. Both are Full-Neighbor. Change router-id on router x to same as router y. The warning message is seen in logs and OSPF neigbor-ship does not come up. 

Address various memory leaks. 
