### PR TITLE
[3.0] lib: fix prefix list trie corruption

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -538,7 +538,8 @@ static void trie_install_fn(struct prefix_list_entry *object,
 			return;
 		if ((*updptr)->prefix.prefixlen < object->prefix.prefixlen)
 			break;
-		if ((*updptr)->seq > object->seq)
+		if ((*updptr)->prefix.prefixlen == object->prefix.prefixlen
+		    && (*updptr)->seq > object->seq)
 			break;
 		updptr = &(*updptr)->next_best;
 	}


### PR DESCRIPTION
The specific code here needs to establish an absolute order of more
specific to less specific possible matches in a prefix list.  This is
indirectly checked by an assert on insertion, because the "next best"
entry is required to be consistent even when joining multiple chains
of candidates.

Unfortunately, trie_install_fn() would insert entries too far ahead in
the chain if another entry with higher sequence number was seen.  This
breaks the trie and (rightfully) triggers the assertion failure on
insert.

Fixes: #962
Signed-off-by: David Lamparter <equinox@opensourcerouting.org>