### PR TITLE
zebra: don't raise privileges when creating unix zserv socket

### DIFF
--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -2645,7 +2645,7 @@ void zebra_zserv_socket_init(char *path)
 			unlink(suna->sun_path);
 	}
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
+	if (sa.ss_family != AF_UNIX && zserv_privs.change(ZPRIVS_RAISE))
 		zlog_err("Can't raise privileges");
 
 	ret = bind(sock, (struct sockaddr *)&sa, sa_len);
@@ -2657,7 +2657,7 @@ void zebra_zserv_socket_init(char *path)
 		close(sock);
 		return;
 	}
-	if (zserv_privs.change(ZPRIVS_LOWER))
+	if (sa.ss_family != AF_UNIX && zserv_privs.change(ZPRIVS_LOWER))
 		zlog_err("Can't lower privileges");
 
 	ret = listen(sock, 5);


### PR DESCRIPTION
Raising privileges is only necessary when binding to a TCP/UDP privileged
port (< 1024).

This solves a problem where the zserv.api socket was being created with
root ownership, preventing the client daemons to connect to zebra.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>