### PR TITLE
pimd: Ensure cleanup of S,G on ifchannel failure to create

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -553,6 +553,9 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp,
 			"%s: could not attach upstream (S,G)=%s on interface %s",
 			__PRETTY_FUNCTION__, pim_str_sg_dump(sg), ifp->name);
 
+		if (ch->parent)
+			listnode_delete(ch->parent->sources, ch);
+
 		pim_ifchannel_remove_children(ch);
 		if (ch->sources)
 			list_delete(ch->sources);


### PR DESCRIPTION
There exists a path for ifchannel creation that if a S,G
fails to create and a corresponding *,G ifchannel is there,
the S,G will be deleted but we were leaving the S,G in the
*,G ifchannel sources list.  Remove from the list in this case

Ticket: CM-17605
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>