### PR TITLE
tests: fix clippy include paths / double-build

### DIFF
--- a/tests/lib/cli/test_cli.c
+++ b/tests/lib/cli/test_cli.c
@@ -41,7 +41,7 @@ DUMMY_DEFUN(cmd13, "alt a X:X::X:X");
 DUMMY_DEFUN(cmd14,
 	    "pat g {  foo A.B.C.D$foo|foo|bar   X:X::X:X$bar| baz } [final]");
 
-#include "tests/lib/cli/test_cli_clippy.c"
+#include "lib/cli/test_cli_clippy.c"
 
 DEFPY(magic_test, magic_test_cmd,
 	"magic (0-100) {ipv4net A.B.C.D/M|X:X::X:X$ipv6}",

--- a/tests/ospf6d/test_lsdb.c
+++ b/tests/ospf6d/test_lsdb.c
@@ -29,7 +29,7 @@
 #include "ospf6d/ospf6_lsdb.h"
 
 #include "tests/lib/cli/common_cli.h"
-#include "tests/ospf6d/test_lsdb_clippy.c"
+#include "ospf6d/test_lsdb_clippy.c"
 
 static struct ospf6_lsdb *lsdb;
 


### PR DESCRIPTION
A mismatch between the make rule and the include path causes dependency
tracking to try to build the clippy.c file twice (at the same time),
which results in spurious build failures.

Fixes: #971
Signed-off-by: David Lamparter <equinox@opensourcerouting.org>