### PR TITLE
ospfd: Fix ospfd crash in free_nexthop

### DIFF
--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -136,8 +136,10 @@ static void ospf_canonical_nexthops_free(struct vertex *root)
 
 		/* Free child nexthops pointing back to this root vertex */
 		for (ALL_LIST_ELEMENTS(child->parents, n2, nn2, vp))
-			if (vp->parent == root && vp->nexthop)
+			if (vp->parent == root && vp->nexthop) {
 				vertex_nexthop_free(vp->nexthop);
+				vp->nexthop = NULL;
+			}
 	}
 }
 
@@ -401,8 +403,6 @@ static void ospf_spf_flush_parents(struct vertex *w)
 	/* delete the existing nexthops */
 	for (ALL_LIST_ELEMENTS(w->parents, ln, nn, vp)) {
 		list_delete_node(w->parents, ln);
-		if (vp->nexthop)
-			vertex_nexthop_free(vp->nexthop);
 		vertex_parent_free(vp);
 	}
 }


### PR DESCRIPTION
Fix ANVL-OSPF-5.1 reported ospfd crash.

vertex_nexthop_free was added in ospf_spf_flush_parents() as valgrind reported potential
memory leak.
The actual nexthop free is part of ospf_canonical_nexthops_free(),
upon trying to free, qfree checks mtype count becomes 0 and asserts.
Removing vertex_nexthop_free() from ospf_spf_flush_parents().

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>