### PR TITLE
ospfd: remember area-id format for ifaces

### DIFF
--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -66,6 +66,8 @@ struct ospf_if_params {
 	DECLARE_IF_PARAM(u_char, priority); /* OSPF Interface priority */
 	/* Enable OSPF on this interface with area if_area */
 	DECLARE_IF_PARAM(struct in_addr, if_area);
+	u_int32_t if_area_id_fmt;
+
 	DECLARE_IF_PARAM(u_char, type); /* type of interface */
 #define OSPF_IF_ACTIVE                  0
 #define OSPF_IF_PASSIVE		        1

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -6971,6 +6971,7 @@ DEFUN (ip_ospf_area,
 	/* enable ospf on this interface with area_id */
 	SET_IF_PARAM(params, if_area);
 	params->if_area = area_id;
+	params->if_area_id_fmt = format;
 	ospf_interface_area_set(ifp);
 	ospf->if_ospf_cli_count++;
 
@@ -8312,8 +8313,13 @@ static int config_write_interface(struct vty *vty)
 				else
 					vty_out(vty, " ip ospf");
 
-				vty_out(vty, " area %s",
-					inet_ntoa(params->if_area));
+
+				size_t buflen = MAX(strlen("4294967295"),
+						    strlen("255.255.255.255"));
+				char buf[buflen];
+				area_id2str(buf, sizeof(buf), &params->if_area,
+					    params->if_area_id_fmt);
+				vty_out(vty, " area %s", buf);
 				if (params != IF_DEF_PARAMS(ifp))
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));


### PR DESCRIPTION
Display dotted quad or decimal back in the config depending on what the
user enters.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>