### PR TITLE
nhrpd: use hop count 1 for registration requests

### DIFF
--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -171,7 +171,7 @@ static int nhrp_reg_send_req(struct thread *t)
 
 	zb = zbuf_alloc(1400);
 	hdr = nhrp_packet_push(zb, NHRP_PACKET_REGISTRATION_REQUEST, &nifp->nbma, &if_ad->addr, dst_proto);
-	hdr->hop_count = 0;
+	hdr->hop_count = 1;
 	if (!(if_ad->flags & NHRP_IFF_REG_NO_UNIQUE))
 		hdr->flags |= htons(NHRP_FLAG_REGISTRATION_UNIQUE);
 


### PR DESCRIPTION
Cisco has a bug that it rejects packets with zero hop count.
Use one to avoid potential forwarding of registration requests.

Fixes #951

Signed-off-by: Timo Teräs <timo.teras@iki.fi>