### PR TITLE
pimd: "No Path to RP address specified" should exit 0

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5066,7 +5066,7 @@ static int pim_rp_cmd_worker(struct pim_instance *pim, struct vty *vty,
 
 	if (result == PIM_RP_NO_PATH) {
 		vty_out(vty, "%% No Path to RP address specified: %s\n", rp);
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	if (result == PIM_GROUP_OVERLAP) {


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

This could happen if routing isn't up yet but the command did take so we
should exit 0 here.  Testing:

root@cel-redxp-10[frr-dwalton76]# vtysh -c 'conf t' -c' ip pim rp
11.11.11.11'
% No Path to RP address specified: 11.11.11.11
root@cel-redxp-10[frr-dwalton76]# echo $?
0
root@cel-redxp-10[frr-dwalton76]#