### PR TITLE
vtysh: vtysh -f FOO should exit non-zero if it hits an error

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -1162,19 +1162,11 @@ if __name__ == '__main__':
                         for line in lines_to_configure:
                             fh.write(line + '\n')
 
-                    output = subprocess.check_output(['/usr/bin/vtysh', '-f', filename])
-
-                    # exit non-zero if we see these errors
-                    for x in ('BGP instance name and AS number mismatch',
-                              'BGP instance is already running',
-                              '% not a local address'):
-                        for line in output.splitlines():
-                            if x in line:
-                                msg = "ERROR: %s" % x
-                                log.error(msg)
-                                print msg
-                                reload_ok = False
-
+                    try:
+                        subprocess.check_output(['/usr/bin/vtysh', '-f', filename])
+                    except subprocess.CalledProcessError as e:
+                        log.warning("frr-reload.py failed due to\n%s" % e.output)
+                        reload_ok = False
                     os.unlink(filename)
 
         # Make these changes persistent

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -752,6 +752,7 @@ int vtysh_config_from_file(struct vty *vty, FILE *fp)
 							lineno, cmd_stat,
 							vtysh_client[i].name,
 							vty->buf);
+						retcode = cmd_stat;
 						break;
 					}
 				}


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

Today if we hit an error while applying the contents of file FOO that error
does not bubble up to a non-zero exit.  This means that frr-reload.py will
exit 0 even if there was an error.