### PR TITLE
bgpd: Fix bgp clear help string

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6145,6 +6145,8 @@ DEFUN (clear_ip_bgp_all,
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
+       BGP_AFI_HELP_STR
+       BGP_SAFI_WITH_LABEL_HELP_STR
        "Clear all peers\n"
        "BGP neighbor address to clear\n"
        "BGP IPv6 neighbor to clear\n"
@@ -6153,8 +6155,6 @@ DEFUN (clear_ip_bgp_all,
        "Clear all external peers\n"
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
-       BGP_AFI_HELP_STR
-       BGP_SAFI_WITH_LABEL_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR
        BGP_SOFT_OUT_STR


### PR DESCRIPTION
The bgp clear help string was misordered.

New output:
```
robot.cumulusnetworks.com# clear bgp
  (1-4294967295)  Clear peers with the AS number
  *               Clear all peers
  A.B.C.D         BGP neighbor address to clear
  WORD            BGP neighbor on interface to clear
  X:X::X:X        BGP IPv6 neighbor to clear
  external        Clear all external peers
  ipv4            Address Family
  ipv6            Address Family
  peer-group      Clear all members of peer-group
  prefix          Clear bestpath and re-advertise
  view            BGP view
  vrf             BGP VRF
```

Fixes: #1005
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>