### PR TITLE
eigrpd: Setup eigrp to send FRR version

### DIFF
--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -439,8 +439,6 @@ static u_int16_t eigrp_sw_version_encode(struct stream *s)
 	stream_putw(s, EIGRP_TLV_SW_VERSION);
 	stream_putw(s, length);
 
-	// encode the version of quagga we're running
-	// DVS: need to figure out a cleaner way to do this
 	stream_putc(s, FRR_MAJOR);  //!< major os version
 	stream_putc(s, FRR_MINOR); //!< minor os version
 

--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -405,6 +405,20 @@ void eigrp_hello_receive(struct eigrp *eigrp, struct ip *iph,
 			   inet_ntoa(nbr->src));
 }
 
+u_int32_t FRR_MAJOR;
+u_int32_t FRR_MINOR;
+
+void eigrp_sw_version_initialize(void)
+{
+	char ver_string[] = VERSION;
+	char *dash = strstr(ver_string, "-");
+
+	if (dash)
+		dash[0] = '\0';
+
+	sscanf(ver_string, "%d.%d", &FRR_MAJOR, &FRR_MINOR);
+}
+
 /**
  * @fn eigrp_sw_version_encode
  *
@@ -427,8 +441,8 @@ static u_int16_t eigrp_sw_version_encode(struct stream *s)
 
 	// encode the version of quagga we're running
 	// DVS: need to figure out a cleaner way to do this
-	stream_putc(s, 0);  //!< major os version
-	stream_putc(s, 99); //!< minor os version
+	stream_putc(s, FRR_MAJOR);  //!< major os version
+	stream_putc(s, FRR_MINOR); //!< minor os version
 
 	/* and the core eigrp version */
 	stream_putc(s, EIGRP_MAJOR_VERSION);

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -159,6 +159,8 @@ int main(int argc, char **argv, char **envp)
 		}
 	}
 
+	eigrp_sw_version_initialize();
+
 	/* EIGRP master init. */
 	eigrp_master_init();
 	eigrp_om->master = frr_init();

--- a/eigrpd/eigrp_packet.h
+++ b/eigrpd/eigrp_packet.h
@@ -71,6 +71,7 @@ extern int eigrp_unack_multicast_packet_retrans(struct thread *);
  * untill there is reason to have their own header, these externs are found in
  * eigrp_hello.c
  */
+extern void eigrp_sw_version_initialize(void);
 extern void eigrp_hello_send(struct eigrp_interface *, u_char,
 			     struct in_addr *);
 extern void eigrp_hello_send_ack(struct eigrp_neighbor *);


### PR DESCRIPTION
Send to our peer the major/minor version of FRR that we are
working with.  I decided to use FRR instead of the os major/minor
because the os itself doesn't tell you what version of EIGRP
you are actually using.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>