### PR TITLE
Fix up error on exit when user id not set via zprivs, fixes valgrind loss introduced with pr 929

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -142,8 +142,6 @@ __attribute__((__noreturn__)) void sigint(void)
 
 	if (!retain_mode) {
 		bgp_terminate();
-		if (bgpd_privs.user) /* NULL if skip_runas flag set */
-			zprivs_terminate(&bgpd_privs);
 	}
 
 	bgp_exit(0);

--- a/lib/privs.c
+++ b/lib/privs.c
@@ -856,7 +856,8 @@ void zprivs_terminate(struct zebra_privs_t *zprivs)
 	}
 
 #ifdef HAVE_CAPABILITIES
-	zprivs_caps_terminate();
+	if (zprivs->user) /* NULL if skip_runas flag set */
+		zprivs_caps_terminate();
 #else  /* !HAVE_CAPABILITIES */
 	/* only change uid if we don't have the correct one */
 	if ((zprivs_state.zuid) && (zprivs_state.zsuid != zprivs_state.zuid)) {


### PR DESCRIPTION
libfrr: don't call zprivs_terminate when user privs not changed