### PR TITLE
lib: ZeroMQ read handler, v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -320,6 +320,8 @@ AC_ARG_WITH(rfp-path,
   AS_HELP_STRING([--with-rfp-path[=DIR]],[path to replaced stub RFP used with BGP VNC]))
 AC_ARG_ENABLE(snmp,
   AS_HELP_STRING([--enable-snmp=ARG], [enable SNMP support (smux or agentx)]))
+AC_ARG_ENABLE(zeromq,
+  AS_HELP_STRING([--enable-zeromq], [enable ZeroMQ handler (libfrrzmq)]))
 AC_ARG_WITH(libpam,
   AS_HELP_STRING([--with-libpam], [use libpam for PAM support in vtysh]))
 AC_ARG_ENABLE(ospfapi,
@@ -1713,6 +1715,21 @@ AC_CHECK_HEADER([malloc.h],
        AC_MSG_RESULT(no)
   )
  ], [], FRR_INCLUDES)
+
+dnl ------
+dnl ZeroMQ
+dnl ------
+if test "x$enable_zeromq" != "xno"; then
+  PKG_CHECK_MODULES(ZEROMQ, [libzmq >= 4.0.0], [
+    AC_DEFINE(HAVE_ZEROMQ, 1, [Enable ZeroMQ support])
+    ZEROMQ=true
+  ], [
+    if test "x$enable_zeromq" = "xyes"; then
+      AC_MSG_ERROR([configuration specifies --enable-zeromq but libzmq was not found])
+    fi
+  ])
+fi
+AM_CONDITIONAL([ZEROMQ], test "x$ZEROMQ" = "xtrue")
 
 dnl ----------
 dnl configure date

--- a/lib/frr_zmq.c
+++ b/lib/frr_zmq.c
@@ -1,0 +1,191 @@
+/*
+ * libzebra ZeroMQ bindings
+ * Copyright (C) 2015  David Lamparter
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+#include <zmq.h>
+
+#include "thread.h"
+#include "memory.h"
+#include "frr_zmq.h"
+#include "log.h"
+
+DEFINE_MTYPE_STATIC(LIB, ZEROMQ_CB, "ZeroMQ callback")
+
+/* libzmq's context */
+void *frrzmq_context = NULL;
+static unsigned frrzmq_initcount = 0;
+
+void frrzmq_init(void)
+{
+	if (frrzmq_initcount++ == 0) {
+		frrzmq_context = zmq_ctx_new();
+		zmq_ctx_set(frrzmq_context, ZMQ_IPV6, 1);
+	}
+}
+
+void frrzmq_finish(void)
+{
+	if (--frrzmq_initcount == 0) {
+		zmq_ctx_term(frrzmq_context);
+		frrzmq_context = NULL;
+	}
+}
+
+/* read callback integration */
+struct frrzmq_cb {
+	struct thread *thread;
+	void *zmqsock;
+	void *arg;
+	int fd;
+
+	bool cancelled;
+
+	void (*cb_msg)(void *arg, void *zmqsock);
+	void (*cb_part)(void *arg, void *zmqsock,
+			zmq_msg_t *msg, unsigned partnum);
+};
+
+
+static int frrzmq_read_msg(struct thread *t)
+{
+	struct frrzmq_cb *cb = THREAD_ARG(t);
+	zmq_msg_t msg;
+	unsigned partno;
+	int ret, more;
+	size_t moresz;
+
+	while (1) {
+		zmq_pollitem_t polli = {
+			.socket = cb->zmqsock,
+			.events = ZMQ_POLLIN
+		};
+		ret = zmq_poll(&polli, 1, 0);
+
+		if (ret < 0)
+			goto out_err;
+		if (!(polli.revents & ZMQ_POLLIN))
+			break;
+
+		if (cb->cb_msg) {
+			cb->cb_msg(cb->arg, cb->zmqsock);
+
+			if (cb->cancelled) {
+				XFREE(MTYPE_ZEROMQ_CB, cb);
+				return 0;
+			}
+			continue;
+		}
+
+		partno = 0;
+		if (zmq_msg_init(&msg))
+			goto out_err;
+		do {
+			ret = zmq_msg_recv(&msg, cb->zmqsock, ZMQ_NOBLOCK);
+			if (ret < 0) {
+				if (errno == EAGAIN)
+					break;
+
+				zmq_msg_close(&msg);
+				goto out_err;
+			}
+
+			cb->cb_part(cb->arg, cb->zmqsock, &msg, partno);
+			if (cb->cancelled) {
+				zmq_msg_close(&msg);
+				XFREE(MTYPE_ZEROMQ_CB, cb);
+				return 0;
+			}
+
+			/* cb_part may have read additional parts of the
+			 * message; don't use zmq_msg_more here */
+			moresz = sizeof(more);
+			more = 0;
+			ret = zmq_getsockopt(cb->zmqsock, ZMQ_RCVMORE,
+					     &more, &moresz);
+			if (ret < 0) {
+				zmq_msg_close(&msg);
+				goto out_err;
+			}
+
+			partno++;
+		} while (more);
+		zmq_msg_close(&msg);
+	}
+
+	funcname_thread_add_read_write(THREAD_READ, t->master, frrzmq_read_msg,
+			cb, cb->fd, &cb->thread, t->funcname, t->schedfrom,
+			t->schedfrom_line);
+	return 0;
+
+out_err:
+	zlog_err("ZeroMQ error: %s(%d)", strerror (errno), errno);
+	return 0;
+}
+
+struct frrzmq_cb *funcname_frrzmq_thread_add_read(
+		struct thread_master *master,
+		void (*msgfunc)(void *arg, void *zmqsock),
+		void (*partfunc)(void *arg, void *zmqsock,
+				 zmq_msg_t *msg, unsigned partnum),
+		void *arg, void *zmqsock, debugargdef)
+{
+	int fd, events;
+	size_t len;
+	struct frrzmq_cb *cb;
+
+	if (!(msgfunc || partfunc) || (msgfunc && partfunc))
+		return NULL;
+	len = sizeof(fd);
+	if (zmq_getsockopt(zmqsock, ZMQ_FD, &fd, &len))
+		return NULL;
+	len = sizeof(events);
+	if (zmq_getsockopt(zmqsock, ZMQ_EVENTS, &events, &len))
+		return NULL;
+
+	cb = XCALLOC(MTYPE_ZEROMQ_CB, sizeof(struct frrzmq_cb));
+	if (!cb)
+		return NULL;
+
+	cb->arg = arg;
+	cb->zmqsock = zmqsock;
+	cb->cb_msg = msgfunc;
+	cb->cb_part = partfunc;
+	cb->fd = fd;
+
+	if (events & ZMQ_POLLIN)
+		funcname_thread_add_event(master,
+				frrzmq_read_msg, cb, fd, &cb->thread,
+				funcname, schedfrom, fromln);
+	else
+		funcname_thread_add_read_write(THREAD_READ, master,
+				frrzmq_read_msg, cb, fd, &cb->thread,
+				funcname, schedfrom, fromln);
+	return cb;
+}
+
+void frrzmq_thread_cancel(struct frrzmq_cb *cb)
+{
+	if (!cb->thread) {
+		/* canceling from within callback */
+		cb->cancelled = 1;
+		return;
+	}
+	thread_cancel(cb->thread);
+	XFREE(MTYPE_ZEROMQ_CB, cb);
+}

--- a/lib/frr_zmq.h
+++ b/lib/frr_zmq.h
@@ -1,0 +1,50 @@
+/*
+ * libzebra ZeroMQ bindings
+ * Copyright (C) 2015  David Lamparter
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _FRRZMQ_H
+#define _FRRZMQ_H
+
+#include "thread.h"
+#include <zmq.h>
+
+/* libzmq's context */
+extern void *frrzmq_context;
+
+extern void frrzmq_init (void);
+extern void frrzmq_finish (void);
+
+#define debugargdef const char *funcname, const char *schedfrom, int fromln
+
+#define frrzmq_thread_add_read_msg(m,f,a,z) funcname_frrzmq_thread_add_read( \
+				m,f,NULL,a,z,#f,__FILE__,__LINE__)
+#define frrzmq_thread_add_read_part(m,f,a,z) funcname_frrzmq_thread_add_read( \
+				m,NULL,f,a,z,#f,__FILE__,__LINE__)
+
+struct frrzmq_cb;
+
+extern struct frrzmq_cb *funcname_frrzmq_thread_add_read(
+		struct thread_master *master,
+		void (*msgfunc)(void *arg, void *zmqsock),
+		void (*partfunc)(void *arg, void *zmqsock,
+				 zmq_msg_t *msg, unsigned partnum),
+		void *arg, void *zmqsock, debugargdef);
+
+extern void frrzmq_thread_cancel(struct frrzmq_cb *cb);
+
+#endif /* _FRRZMQ_H */

--- a/lib/frr_zmq.h
+++ b/lib/frr_zmq.h
@@ -23,7 +23,21 @@
 #include "thread.h"
 #include <zmq.h>
 
-/* libzmq's context */
+/* linking/packaging note:  this is a separate library that needs to be
+ * linked into any daemon/library/module that wishes to use its
+ * functionality.  The purpose of this is to encapsulate the libzmq
+ * dependency and not make libfrr/FRR itself depend on libzmq.
+ *
+ * libfrrzmq should be put in LDFLAGS/LIBADD *before* either libfrr or
+ * libzmq, and both of these should always be listed, e.g.
+ *   foo_LDFLAGS = libfrrzmq.la libfrr.la $(ZEROMQ_LIBS)
+ */
+
+/* libzmq's context
+ *
+ * this is mostly here as a convenience, it has IPv6 enabled but nothing
+ * else is tied to it;  you can use a separate context without problems
+ */
 extern void *frrzmq_context;
 
 extern void frrzmq_init (void);
@@ -31,6 +45,7 @@ extern void frrzmq_finish (void);
 
 #define debugargdef const char *funcname, const char *schedfrom, int fromln
 
+/* core event registration, one of these 2 macros should be used */
 #define frrzmq_thread_add_read_msg(m,f,a,z) funcname_frrzmq_thread_add_read( \
 				m,f,NULL,a,z,#f,__FILE__,__LINE__)
 #define frrzmq_thread_add_read_part(m,f,a,z) funcname_frrzmq_thread_add_read( \
@@ -38,6 +53,29 @@ extern void frrzmq_finish (void);
 
 struct frrzmq_cb;
 
+/* Set up a POLLIN notification to be called from the libfrr main loop.
+ * This has the following properties:
+ *
+ * - since ZeroMQ works with edge triggered notifications, it will loop and
+ *   dispatch as many events as ZeroMQ has pending at the time libfrr calls
+ *   into this code
+ * - due to this looping (which means it non-single-issue), the callback is
+ *   also persistent.  Do _NOT_ re-register the event inside of your
+ *   callback function.
+ * - either msgfunc or partfunc will be called (only one can be specified)
+ *   - msgfunc is called once for each incoming message
+ *   - if partfunc is specified, the message is read and partfunc is called
+ *     for each ZeroMQ multi-part subpart.  Note that you can't send replies
+ *     before all parts have been read because that violates the ZeroMQ FSM.
+ * - you can safely cancel the callback from within itself
+ * - installing a callback will check for pending events (ZMQ_EVENTS) and
+ *   may schedule the event to run as soon as libfrr is back in its main
+ *   loop.
+ *
+ * TODO #1: add ZMQ_POLLERR / error callback
+ * TODO #2: add frrzmq_check_events() function to check for edge triggered
+ *          things that may have happened after a zmq_send() call or so
+ */
 extern struct frrzmq_cb *funcname_frrzmq_thread_add_read(
 		struct thread_master *master,
 		void (*msgfunc)(void *arg, void *zmqsock),

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -184,6 +184,21 @@ lib_libfrrsnmp_la_SOURCES = \
 	# end
 
 #
+# ZeroMQ support
+#
+if ZEROMQ
+lib_LTLIBRARIES += lib/libfrrzmq.la
+pkginclude_HEADERS += lib/frr_zmq.h
+endif
+
+lib_libfrrzmq_la_CFLAGS = $(WERROR) $(ZEROMQ_CFLAGS)
+lib_libfrrzmq_la_LDFLAGS = -version-info 0:0:0
+lib_libfrrzmq_la_LIBADD = lib/libfrr.la $(ZEROMQ_LIBS)
+lib_libfrrzmq_la_SOURCES = \
+	lib/frr_zmq.c \
+	#end
+
+#
 # CLI utilities
 #
 noinst_PROGRAMS += \

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -45,4 +45,5 @@ __pycache__
 /lib/test_timer_correctness
 /lib/test_timer_performance
 /lib/test_ttable
+/lib/test_zmq
 /ospf6d/test_lsdb

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -119,6 +119,7 @@ lib_test_timer_performance_SOURCES = lib/test_timer_performance.c \
                                      helpers/c/prng.c
 lib_test_ttable_SOURCES = lib/test_ttable.c
 lib_test_zmq_SOURCES = lib/test_zmq.c
+lib_test_zmq_CFLAGS = $(AM_CFLAGS) $(ZEROMQ_CFLAGS)
 lib_cli_test_cli_SOURCES = lib/cli/test_cli.c lib/cli/common_cli.c
 lib_cli_test_commands_SOURCES = lib/cli/test_commands_defun.c \
                                 lib/cli/test_commands.c \
@@ -154,7 +155,7 @@ lib_test_table_LDADD = $(ALL_TESTS_LDADD) -lm
 lib_test_timer_correctness_LDADD = $(ALL_TESTS_LDADD)
 lib_test_timer_performance_LDADD = $(ALL_TESTS_LDADD)
 lib_test_ttable_LDADD = $(ALL_TESTS_LDADD)
-lib_test_zmq_LDADD = $(ALL_TESTS_LDADD) ../lib/libfrrzmq.la
+lib_test_zmq_LDADD = ../lib/libfrrzmq.la $(ALL_TESTS_LDADD) $(ZEROMQ_LIBS)
 lib_cli_test_cli_LDADD = $(ALL_TESTS_LDADD)
 lib_cli_test_commands_LDADD = $(ALL_TESTS_LDADD)
 bgpd_test_aspath_LDADD = $(BGP_TEST_LDADD)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -72,6 +72,12 @@ check_PROGRAMS = \
 	$(TESTS_OSPF6D) \
 	# end
 
+if ZEROMQ
+check_PROGRAMS += \
+	lib/test_zmq \
+	# end
+endif
+
 ../vtysh/vtysh_cmd.c:
 	$(MAKE) -C ../vtysh vtysh_cmd.c
 
@@ -112,6 +118,7 @@ lib_test_timer_correctness_SOURCES = lib/test_timer_correctness.c \
 lib_test_timer_performance_SOURCES = lib/test_timer_performance.c \
                                      helpers/c/prng.c
 lib_test_ttable_SOURCES = lib/test_ttable.c
+lib_test_zmq_SOURCES = lib/test_zmq.c
 lib_cli_test_cli_SOURCES = lib/cli/test_cli.c lib/cli/common_cli.c
 lib_cli_test_commands_SOURCES = lib/cli/test_commands_defun.c \
                                 lib/cli/test_commands.c \
@@ -147,6 +154,7 @@ lib_test_table_LDADD = $(ALL_TESTS_LDADD) -lm
 lib_test_timer_correctness_LDADD = $(ALL_TESTS_LDADD)
 lib_test_timer_performance_LDADD = $(ALL_TESTS_LDADD)
 lib_test_ttable_LDADD = $(ALL_TESTS_LDADD)
+lib_test_zmq_LDADD = $(ALL_TESTS_LDADD) ../lib/libfrrzmq.la
 lib_cli_test_cli_LDADD = $(ALL_TESTS_LDADD)
 lib_cli_test_commands_LDADD = $(ALL_TESTS_LDADD)
 bgpd_test_aspath_LDADD = $(BGP_TEST_LDADD)

--- a/tests/lib/cli/test_commands.py
+++ b/tests/lib/cli/test_commands.py
@@ -8,4 +8,4 @@ class TestCommands(frrtest.TestRefOut):
     @pytest.mark.skipif('QUAGGA_TEST_COMMANDS' not in os.environ,
                         reason='QUAGGA_TEST_COMMANDS not set')
     def test_refout(self):
-        return super(TestCommands, self).test_refout(self)
+        return super(TestCommands, self).test_refout()

--- a/tests/lib/test_zmq.c
+++ b/tests/lib/test_zmq.c
@@ -1,0 +1,212 @@
+/*
+ * ZeroMQ event test
+ * Copyright (C) 2017  David Lamparter, for NetDEF, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+#include "memory.h"
+#include "sigevent.h"
+#include "frr_zmq.h"
+
+DEFINE_MTYPE_STATIC(LIB, TESTBUF, "zmq test buffer")
+
+static struct thread_master *master;
+
+static void msg_buf_free(void *data, void *hint)
+{
+	XFREE(MTYPE_TESTBUF, data);
+}
+
+static void run_client(int syncfd)
+{
+	int i, j;
+	char buf[32];
+	char dummy;
+	void *zmqctx = NULL;
+	void *zmqsock;
+
+	read(syncfd, &dummy, 1);
+
+	zmqctx = zmq_ctx_new();
+	zmq_ctx_set(zmqctx, ZMQ_IPV6, 1);
+
+	zmqsock = zmq_socket(zmqctx, ZMQ_REQ);
+	if (zmq_connect(zmqsock, "tcp://127.0.0.1:17171")) {
+		perror("zmq_connect");
+		exit(1);
+	}
+
+	/* single-part */
+	for (i = 0; i < 8; i++) {
+		snprintf(buf, sizeof(buf), "msg #%d %c%c%c",
+			 i, 'a' + i, 'b' + i, 'c' + i);
+		printf("client send: %s\n", buf);
+		fflush(stdout);
+	        zmq_send(zmqsock, buf, strlen(buf) + 1, 0);
+	        zmq_recv(zmqsock, buf, sizeof(buf), 0);
+		printf("client recv: %s\n", buf);
+	}
+
+	/* multipart */
+	for (i = 2; i < 5; i++) {
+		int more;
+
+		printf("---\n");
+		for (j = 1; j <= i; j++) {
+			zmq_msg_t part;
+			char *dyn = XMALLOC(MTYPE_TESTBUF, 32);
+
+			snprintf(dyn, 32, "part %d/%d", j, i);
+			printf("client send: %s\n", dyn);
+			fflush(stdout);
+
+			zmq_msg_init_data(&part, dyn, strlen(dyn) + 1,
+					  msg_buf_free, NULL);
+			zmq_msg_send(&part, zmqsock, j < i ? ZMQ_SNDMORE : 0);
+		}
+
+		zmq_msg_t part;
+		do {
+			char *data;
+
+			zmq_msg_recv(&part, zmqsock, 0);
+			data = zmq_msg_data(&part);
+			more = zmq_msg_more(&part);
+			printf("client recv (more: %d): %s\n", more, data);
+		} while (more);
+		zmq_msg_close(&part);
+	}
+	zmq_close(zmqsock);
+	zmq_ctx_term(zmqctx);
+}
+
+static struct frrzmq_cb *cb;
+
+static void serverpartfn(void *arg, void *zmqsock, zmq_msg_t *msg,
+			unsigned partnum)
+{
+	int more = zmq_msg_more(msg);
+	char *in = zmq_msg_data(msg);
+	size_t i;
+	zmq_msg_t reply;
+	char *out;
+
+	printf("server recv part %u (more: %d): %s\n", partnum, more, in);
+	fflush(stdout);
+	/* REQ-REP doesn't allow sending a reply here */
+	if (more)
+		return;
+
+	out = XMALLOC(MTYPE_TESTBUF, strlen(in) + 1);
+	for (i = 0; i < strlen(in); i++)
+		out[i] = toupper(in[i]);
+	out[i] = '\0';
+	zmq_msg_init_data(&reply, out, strlen(out) + 1, msg_buf_free, NULL);
+	zmq_msg_send(&reply, zmqsock, ZMQ_SNDMORE);
+
+	out = XMALLOC(MTYPE_TESTBUF, 32);
+	snprintf(out, 32, "msg# was %u", partnum);
+	zmq_msg_init_data(&reply, out, strlen(out) + 1, msg_buf_free, NULL);
+	zmq_msg_send(&reply, zmqsock, 0);
+}
+
+static void serverfn(void *arg, void *zmqsock)
+{
+	static int num = 0;
+
+	char buf[32];
+	size_t i;
+	zmq_recv(zmqsock, buf, sizeof(buf), 0);
+
+	printf("server recv: %s\n", buf);
+	fflush(stdout);
+	for (i = 0; i < strlen(buf); i++)
+		buf[i] = toupper(buf[i]);
+	zmq_send(zmqsock, buf, strlen(buf) + 1, 0);
+
+	if (++num < 4)
+		return;
+
+	/* change to multipart callback */
+	frrzmq_thread_cancel(cb);
+
+	cb = frrzmq_thread_add_read_part(master, serverpartfn, NULL, zmqsock);
+}
+
+static void sigchld(void)
+{
+	printf("child exited.\n");
+	frrzmq_thread_cancel(cb);
+}
+
+static struct quagga_signal_t sigs[] = {
+	{
+		.signal = SIGCHLD,
+		.handler = sigchld,
+	},
+};
+
+static void run_server(int syncfd)
+{
+	void *zmqsock;
+	char dummy = 0;
+	struct thread t;
+
+	master = thread_master_create(NULL);
+	signal_init(master, array_size(sigs), sigs);
+	frrzmq_init();
+
+	zmqsock = zmq_socket(frrzmq_context, ZMQ_REP);
+	if (zmq_bind(zmqsock, "tcp://*:17171")) {
+		perror("zmq_bind");
+		exit(1);
+	}
+
+	cb = frrzmq_thread_add_read_msg(master, serverfn, NULL, zmqsock);
+
+	write(syncfd, &dummy, sizeof(dummy));
+	while (thread_fetch(master, &t))
+		thread_call(&t);
+
+	zmq_close(zmqsock);
+	frrzmq_finish();
+	thread_master_free(master);
+	log_memstats_stderr("test");
+}
+
+int main(void)
+{
+	int syncpipe[2];
+	pid_t child;
+
+	if (pipe(syncpipe)) {
+		perror("pipe");
+		exit(1);
+	}
+
+	child = fork();
+	if (child < 0) {
+		perror("fork");
+		exit(1);
+	} else if (child == 0) {
+		run_client(syncpipe[0]);
+		exit(0);
+	}
+
+	run_server(syncpipe[1]);
+	exit(0);
+}

--- a/tests/lib/test_zmq.py
+++ b/tests/lib/test_zmq.py
@@ -1,0 +1,11 @@
+import frrtest
+import pytest
+import os
+
+class TestZMQ(frrtest.TestRefOut):
+    program = './test_zmq'
+
+    @pytest.mark.skipif('S["ZEROMQ_TRUE"]=""\n' not in open('../config.status').readlines(),
+                        reason='ZEROMQ not enabled')
+    def test_refout(self):
+        return super(TestZMQ, self).test_refout()

--- a/tests/lib/test_zmq.refout
+++ b/tests/lib/test_zmq.refout
@@ -1,0 +1,50 @@
+client send: msg #0 abc
+server recv: msg #0 abc
+client recv: MSG #0 ABC
+client send: msg #1 bcd
+server recv: msg #1 bcd
+client recv: MSG #1 BCD
+client send: msg #2 cde
+server recv: msg #2 cde
+client recv: MSG #2 CDE
+client send: msg #3 def
+server recv: msg #3 def
+client recv: MSG #3 DEF
+client send: msg #4 efg
+server recv part 0 (more: 0): msg #4 efg
+client recv: MSG #4 EFG
+client send: msg #5 fgh
+client recv: msg# was 0
+client send: msg #6 ghi
+server recv part 0 (more: 0): msg #6 ghi
+client recv: MSG #6 GHI
+client send: msg #7 hij
+client recv: msg# was 0
+---
+client send: part 1/2
+client send: part 2/2
+server recv part 0 (more: 1): part 1/2
+server recv part 1 (more: 0): part 2/2
+client recv (more: 1): PART 2/2
+client recv (more: 0): msg# was 1
+---
+client send: part 1/3
+client send: part 2/3
+client send: part 3/3
+server recv part 0 (more: 1): part 1/3
+server recv part 1 (more: 1): part 2/3
+server recv part 2 (more: 0): part 3/3
+client recv (more: 1): PART 3/3
+client recv (more: 0): msg# was 2
+---
+client send: part 1/4
+client send: part 2/4
+client send: part 3/4
+client send: part 4/4
+server recv part 0 (more: 1): part 1/4
+server recv part 1 (more: 1): part 2/4
+server recv part 2 (more: 1): part 3/4
+server recv part 3 (more: 0): part 4/4
+client recv (more: 1): PART 4/4
+client recv (more: 0): msg# was 3
+child exited.


### PR DESCRIPTION
This uses zmq_getsockopt(ZMQ_FD) to create a libfrr read event, which
then wraps zmq_poll and calls an user-specified ZeroMQ read handler.
It's wrapped in a separate library in order to make ZeroMQ support an
installation-time option instead of build-time.

Extended to support per-message and per-fragment callbacks as discussed
with Bingen in PR #566.

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>