### PR TITLE
lib: fix const-check in route_node

### DIFF
--- a/lib/table.h
+++ b/lib/table.h
@@ -227,7 +227,7 @@ extern void route_table_iter_cleanup(route_table_iter_t *iter);
 /* Lock node. */
 static inline struct route_node *route_lock_node(struct route_node *node)
 {
-	node->lock++;
+	(*(unsigned *)&node->lock)++;
 	return node;
 }
 
@@ -235,7 +235,7 @@ static inline struct route_node *route_lock_node(struct route_node *node)
 static inline void route_unlock_node(struct route_node *node)
 {
 	assert(node->lock > 0);
-	node->lock--;
+	(*(unsigned *)&node->lock)--;
 
 	if (node->lock == 0)
 		route_node_delete(node);


### PR DESCRIPTION
route_node->lock is "const" if --enable-dev-build is used.  This is done
to deter people from messing with internals of the route_table...
unfortunately, the inline'd route_[un]lock_node runs into this.

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>