### PR TITLE
ospfd, ospf6d: cleanup some `no` commands

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1171,8 +1171,7 @@ DEFUN (ipv6_ospf6_cost,
        IP6_STR
        OSPF6_STR
        "Interface cost\n"
-       "Outgoing metric of this interface\n"
-       )
+       "Outgoing metric of this interface\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	int idx_number = 3;
@@ -1206,12 +1205,12 @@ DEFUN (ipv6_ospf6_cost,
 
 DEFUN (no_ipv6_ospf6_cost,
        no_ipv6_ospf6_cost_cmd,
-       "no ipv6 ospf6 cost",
+       "no ipv6 ospf6 cost [(1-65535)]",
        NO_STR
        IP6_STR
        OSPF6_STR
        "Calculate interface cost from bandwidth\n"
-       )
+       "Outgoing metric of this interface\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct ospf6_interface *oi;
@@ -1654,11 +1653,13 @@ DEFUN (ipv6_ospf6_network,
 
 DEFUN (no_ipv6_ospf6_network,
        no_ipv6_ospf6_network_cmd,
-       "no ipv6 ospf6 network",
+       "no ipv6 ospf6 network [<broadcast|point-to-point>]",
        NO_STR
        IP6_STR
        OSPF6_STR
-       "Set default network type\n")
+       "Set default network type\n"
+       "Specify OSPF6 broadcast network\n"
+       "Specify OSPF6 point-to-point network\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	struct ospf6_interface *oi;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1897,7 +1897,8 @@ DEFUN (no_ospf_area_filter_list,
 
 DEFUN (ospf_area_authentication_message_digest,
        ospf_area_authentication_message_digest_cmd,
-       "area <A.B.C.D|(0-4294967295)> authentication message-digest",
+       "[no] area <A.B.C.D|(0-4294967295)> authentication message-digest",
+       NO_STR
        "OSPF area parameters\n"
        "OSPF area ID in IP address format\n"
        "OSPF area ID as a decimal value\n"
@@ -1914,7 +1915,7 @@ DEFUN (ospf_area_authentication_message_digest,
 
 	area = ospf_area_get(ospf, area_id);
 	ospf_area_display_format_set(ospf, area, format);
-	area->auth_type = OSPF_AUTH_CRYPTOGRAPHIC;
+	area->auth_type = strmatch(argv[0]->text, "no") ? OSPF_AUTH_NULL : OSPF_AUTH_CRYPTOGRAPHIC;
 
 	return CMD_SUCCESS;
 }
@@ -6887,10 +6888,12 @@ DEFUN (no_ip_ospf_transmit_delay,
 
 DEFUN_HIDDEN (no_ospf_transmit_delay,
               no_ospf_transmit_delay_cmd,
-              "no ospf transmit-delay",
+              "no ospf transmit-delay [(1-65535) [A.B.C.D]]",
               NO_STR
               "OSPF interface commands\n"
-              "Link state transmit delay\n")
+              "Link state transmit delay\n"
+              "Seconds\n"
+              "Address of interface")
 {
 	return no_ip_ospf_transmit_delay(self, vty, argc, argv);
 }


### PR DESCRIPTION
Just makes some `no` commands symmetric with their positive counterparts. Also allows to unset area authentication type.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>