### PR TITLE
zebra: increase maximum label stack depth

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -1671,27 +1671,20 @@ int mpls_str2label(const char *label_str, u_int8_t *num_labels,
 char *mpls_label2str(u_int8_t num_labels, mpls_label_t *labels, char *buf,
 		     int len, int pretty)
 {
-	char *buf_ptr = buf;
+	char label_buf[BUFSIZ];
+	int i;
+
 	buf[0] = '\0';
-
-	if (pretty) {
-		if (num_labels == 1) {
-			label2str(labels[0], buf, len);
-		} else if (num_labels == 2) {
-			label2str(labels[0], buf, len);
-			buf_ptr += strlen(buf);
-
-			snprintf(buf_ptr, len, "/");
-			buf_ptr++;
-
-			label2str(labels[1], buf_ptr, len);
-		}
-	} else {
-		if (num_labels == 1)
-			snprintf(buf, len, "%u", labels[0]);
-		else if (num_labels == 2)
-			snprintf(buf, len, "%u/%u", labels[0], labels[1]);
+	for (i = 0; i < num_labels; i++) {
+		if (i != 0)
+			strlcat(buf, "/", len);
+		if (pretty)
+			label2str(labels[i], label_buf, sizeof(label_buf));
+		else
+			snprintf(label_buf, sizeof(label_buf), "%u", labels[i]);
+		strlcat(buf, label_buf, len);
 	}
+
 	return buf;
 }
 

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -37,7 +37,7 @@
 
 /* Definitions and macros. */
 
-#define MPLS_MAX_LABELS 2  /* Maximum # labels that can be pushed. */
+#define MPLS_MAX_LABELS 16  /* Maximum # labels that can be pushed. */
 
 #define NHLFE_FAMILY(nhlfe)                                                    \
 	(((nhlfe)->nexthop->type == NEXTHOP_TYPE_IPV6                          \

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -256,6 +256,15 @@ static int kernel_lsp_cmd(int action, zebra_lsp_t *lsp)
 		    || (action == RTM_DELETE
 			&& (CHECK_FLAG(nhlfe->flags, NHLFE_FLAG_INSTALLED)
 			    && CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB)))) {
+			if (nhlfe->nexthop->nh_label->num_labels > 1) {
+				zlog_warn(
+					"%s: can't push %u labels at once "
+					"(maximum is 1)",
+					__func__,
+					nhlfe->nexthop->nh_label->num_labels);
+				continue;
+			}
+
 			nexthop_num++;
 
 			switch (NHLFE_FAMILY(nhlfe)) {

--- a/zebra/zebra_static.h
+++ b/zebra/zebra_static.h
@@ -22,11 +22,13 @@
 #ifndef __ZEBRA_STATIC_H__
 #define __ZEBRA_STATIC_H__
 
+#include "zebra/zebra_mpls.h"
+
 /* Static route label information */
 struct static_nh_label {
 	u_int8_t num_labels;
 	u_int8_t reserved[3];
-	mpls_label_t label[2];
+	mpls_label_t label[MPLS_MAX_LABELS];
 };
 
 typedef enum {


### PR DESCRIPTION
* Bump MPLS_MAX_LABELS from 2 to 16;
* Adjust the static_nh_label structure and the mpls_label2str() function;
* On OpenBSD, print an error message when trying to push more than one
  label at once (kernel limitation). While here, add support for MPLSv6
  FTNs in OpenBSD.

This is not the full package. We still can't pop multiple labels at once,
or do things like swap a label and push other ones. We'll address that
in the future.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>