### PR TITLE
bgpd: fix file descriptor leak

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3087,6 +3087,8 @@ int bgp_delete(struct bgp *bgp)
 	 * routes to be processed still referencing the struct bgp.
 	 */
 	listnode_delete(bm->bgp, bgp);
+	if (list_isempty(bm->bgp))
+		bgp_close();
 
 	/* Deregister from Zebra, if needed */
 	if (IS_BGP_INST_KNOWN_TO_ZEBRA(bgp))


### PR DESCRIPTION
Bug introduced by commit 37d361e7. Removing the call to bgp_close()
from bgp_delete() was a mistake.

Reported-by: Don Slice <dslice@cumulusnetworks.com>
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>