### PR TITLE
eigrpd: add correct interface metrics when interface comes up

### DIFF
--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -307,6 +307,7 @@ int eigrp_if_up(struct eigrp_interface *ei)
 		pe->nt = EIGRP_TOPOLOGY_TYPE_CONNECTED;
 
 		ne->prefix = pe;
+		pe->reported_metric = metric;
 		pe->state = EIGRP_FSM_STATE_PASSIVE;
 		pe->fdistance = eigrp_calculate_metrics(eigrp, metric);
 		pe->req_action |= EIGRP_FSM_NEED_UPDATE;


### PR DESCRIPTION
Problem noticed where we were not sending the correct metric values
to our peers for connected interfaces.  Found that we were not storing
these values on the structure used to send the update packets.

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>