### PR TITLE
ospfd: fix route_node_get

### DIFF
--- a/lib/table.c
+++ b/lib/table.c
@@ -281,7 +281,7 @@ struct route_node *route_node_get(struct route_table *const table,
 	u_char prefixlen = p->prefixlen;
 	const u_char *prefix = &p->u.prefix;
 
-	apply_mask((struct prefix *)&p);
+	apply_mask((struct prefix *)p);
 	node = hash_get(table->hash, (void *)p, NULL);
 	if (node && node->info)
 		return route_lock_node(node);

--- a/lib/table.c
+++ b/lib/table.c
@@ -281,6 +281,7 @@ struct route_node *route_node_get(struct route_table *const table,
 	u_char prefixlen = p->prefixlen;
 	const u_char *prefix = &p->u.prefix;
 
+	apply_mask((struct prefix *)&p);
 	node = hash_get(table->hash, (void *)p, NULL);
 	if (node && node->info)
 		return route_lock_node(node);

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -76,6 +76,7 @@ static void ospf_area_range_add(struct ospf_area *area,
 	p.family = AF_INET;
 	p.prefixlen = range->masklen;
 	p.prefix = range->addr;
+	apply_mask_ipv4(&p);
 
 	rn = route_node_get(area->ranges, (struct prefix *)&p);
 	if (rn->info)
@@ -123,6 +124,7 @@ struct ospf_area_range *ospf_area_range_lookup_next(struct ospf_area *area,
 	p.family = AF_INET;
 	p.prefixlen = IPV4_MAX_BITLEN;
 	p.prefix = *range_net;
+	apply_mask_ipv4(&p);
 
 	if (first)
 		rn = route_top(area->ranges);

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -171,6 +171,7 @@ static void ospf_add_to_if(struct interface *ifp, struct ospf_interface *oi)
 
 	p = *oi->address;
 	p.prefixlen = IPV4_MAX_PREFIXLEN;
+	apply_mask(&p);
 
 	rn = route_node_get(IF_OIFS(ifp), &p);
 	/* rn->info should either be NULL or equal to this oi
@@ -562,6 +563,7 @@ struct ospf_if_params *ospf_get_if_params(struct interface *ifp,
 	p.family = AF_INET;
 	p.prefixlen = IPV4_MAX_PREFIXLEN;
 	p.prefix = addr;
+	apply_mask_ipv4(&p);
 
 	rn = route_node_get(IF_OIFS_PARAMS(ifp), (struct prefix *)&p);
 

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -356,6 +356,7 @@ void ospf_intra_add_router(struct route_table *rt, struct vertex *v,
 	p.family = AF_INET;
 	p.prefix = v->id;
 	p.prefixlen = IPV4_MAX_BITLEN;
+	apply_mask_ipv4(&p);
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("ospf_intra_add_router: talking about %s/%d",


### PR DESCRIPTION
Call apply_mask() where route_node_get() is performed,
for the prefix to fetch correct node.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>