### PR TITLE
ospf6d: fix prefix list name SEGV

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -643,9 +643,9 @@ void ospf6_area_plist_update(struct prefix_list *plist, int add)
 	const char *name = prefix_list_name(plist);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, n, oa)) {
-		if (!strcmp(PREFIX_NAME_IN(oa), name))
+		if (PREFIX_NAME_IN(oa) && !strcmp(PREFIX_NAME_IN(oa), name))
 			PREFIX_LIST_IN(oa) = add ? plist : NULL;
-		if (!strcmp(PREFIX_NAME_OUT(oa), name))
+		if (PREFIX_NAME_OUT(oa) && !strcmp(PREFIX_NAME_OUT(oa), name))
 			PREFIX_LIST_OUT(oa) = add ? plist : NULL;
 	}
 }


### PR DESCRIPTION
Oops, I tested this with prefix lists configured and failed to notice it
blows up when nothing is set...

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>