### PR TITLE
lib, ospfd, ripd, ripngd:  Fix 'set metric'

### DIFF
--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -192,7 +192,15 @@ extern int route_map_delete_set(struct route_map_index *index,
 /* Install rule command to the match list. */
 extern void route_map_install_match(struct route_map_rule_cmd *cmd);
 
-/* Install rule command to the set list. */
+/*
+ * Install rule command to the set list.
+ *
+ * When installing a particular item, Allow a difference of handling
+ * of bad cli inputted(return NULL) -vs- this particular daemon cannot use
+ * this form of the command(return a pointer and handle it appropriately
+ * in the apply command).  See 'set metric' command
+ * as it is handled in ripd/ripngd and ospfd.
+ */
 extern void route_map_install_set(struct route_map_rule_cmd *cmd);
 
 /* Lookup route map by name. */

--- a/ripd/rip_routemap.c
+++ b/ripd/rip_routemap.c
@@ -36,8 +36,8 @@
 
 struct rip_metric_modifier {
 	enum { metric_increment, metric_decrement, metric_absolute } type;
-
-	u_char metric;
+	bool used;
+	u_int8_t metric;
 };
 
 /* Hook function for updating route_map assignment. */
@@ -365,6 +365,9 @@ static route_map_result_t route_set_metric(void *rule, struct prefix *prefix,
 		mod = rule;
 		rinfo = object;
 
+		if (!mod->used)
+			return RMAP_OKAY;
+
 		if (mod->type == metric_increment)
 			rinfo->metric_out += mod->metric;
 		else if (mod->type == metric_decrement)
@@ -387,43 +390,49 @@ static void *route_set_metric_compile(const char *arg)
 {
 	int len;
 	const char *pnt;
-	int type;
 	long metric;
 	char *endptr = NULL;
 	struct rip_metric_modifier *mod;
+
+	mod = XMALLOC(MTYPE_ROUTE_MAP_COMPILED,
+		      sizeof(struct rip_metric_modifier));
+	mod->used = false;
 
 	len = strlen(arg);
 	pnt = arg;
 
 	if (len == 0)
-		return NULL;
+		return mod;
 
 	/* Examine first character. */
 	if (arg[0] == '+') {
-		type = metric_increment;
+		mod->type = metric_increment;
 		pnt++;
 	} else if (arg[0] == '-') {
-		type = metric_decrement;
+		mod->type = metric_decrement;
 		pnt++;
 	} else
-		type = metric_absolute;
+		mod->type = metric_absolute;
 
 	/* Check beginning with digit string. */
 	if (*pnt < '0' || *pnt > '9')
-		return NULL;
+		return mod;
 
 	/* Convert string to integer. */
 	metric = strtol(pnt, &endptr, 10);
 
-	if (metric == LONG_MAX || *endptr != '\0')
-		return NULL;
-	if (metric < 0 || metric > RIP_METRIC_INFINITY)
-		return NULL;
+	if (*endptr != '\0' || mod->metric < 0) {
+		metric = 0;
+		return mod;
+	}
+	if (metric > RIP_METRIC_INFINITY) {
+		zlog_info("%s: Metric specified: %ld is greater than RIP_METRIC_INFINITY, using INFINITY instead",
+			   __PRETTY_FUNCTION__, metric);
+		mod->metric = RIP_METRIC_INFINITY;
+	} else
+		mod->metric = metric;
 
-	mod = XMALLOC(MTYPE_ROUTE_MAP_COMPILED,
-		      sizeof(struct rip_metric_modifier));
-	mod->type = type;
-	mod->metric = metric;
+	mod->used = true;
 
 	return mod;
 }


### PR DESCRIPTION
There are a variety of cli's associated with the
'set metric ...' command.  The problem that we
are experiencing is that not all the daemons
support all the varieties of the set metric
and the returned of NULL during the XXX_compile
phase for these unsupported commands is causing
issues.  Modify the code base to only return
NULL if we encounter a true parsing issue.
Else we need to keep track if this metric
applies to us or not.

In the case of rip or ripngd if the metric
passed to us is greater than 16 just turn
it internally into a MAX_METRIC.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>