### PR TITLE
*: return CMD_WARNING if command was already configured

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -292,7 +292,7 @@ DEFUN (babel_network,
     if (ret < 0) {
         vty_out (vty, "There is same network configuration %s\n",
                    argv[1]->arg);
-        return CMD_WARNING_CONFIG_FAILED;
+        return CMD_WARNING;
     }
 
     return CMD_SUCCESS;

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -400,7 +400,7 @@ DEFUN (eigrp_network,
 
 	if (ret == 0) {
 		vty_out(vty, "There is already same network statement.\n");
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	return CMD_SUCCESS;

--- a/lib/ns.c
+++ b/lib/ns.c
@@ -312,7 +312,7 @@ DEFUN_NOSH (ns_netns,
 	if (ns->name && strcmp(ns->name, pathname) != 0) {
 		vty_out(vty, "NS %u is already configured with NETNS %s\n",
 			ns->ns_id, ns->name);
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	if (!ns->name)

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -507,7 +507,7 @@ DEFUN (ospf_network_area,
 	ret = ospf_network_set(ospf, &p, area_id, format);
 	if (ret == 0) {
 		vty_out(vty, "There is already same network statement.\n");
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	return CMD_SUCCESS;
@@ -847,7 +847,7 @@ static int ospf_vl_set_security(struct ospf_vl_data *vl_data,
 		    != NULL) {
 			vty_out(vty, "OSPF: Key %d already exists\n",
 				vl_config->crypto_key_id);
-			return CMD_WARNING_CONFIG_FAILED;
+			return CMD_WARNING;
 		}
 		ck = ospf_crypt_key_new();
 		ck->key_id = vl_config->crypto_key_id;
@@ -5950,7 +5950,7 @@ DEFUN (ip_ospf_message_digest_key,
 	key_id = strtol(keyid, NULL, 10);
 	if (ospf_crypt_key_lookup(params->auth_crypt, key_id) != NULL) {
 		vty_out(vty, "OSPF: Key %d already exists\n", key_id);
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	ck = ospf_crypt_key_new();

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2880,7 +2880,7 @@ DEFUN (rip_route,
 	if (node->info) {
 		vty_out(vty, "There is already same static route.\n");
 		route_unlock_node(node);
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	node->info = (void *)1;
@@ -3352,7 +3352,7 @@ DEFUN (rip_allow_ecmp,
 {
 	if (rip->ecmp) {
 		vty_out(vty, "ECMP is already enabled.\n");
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	rip->ecmp = 1;
@@ -3368,7 +3368,7 @@ DEFUN (no_rip_allow_ecmp,
 {
 	if (!rip->ecmp) {
 		vty_out(vty, "ECMP is already disabled.\n");
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	rip->ecmp = 0;

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2215,7 +2215,7 @@ DEFUN (ripng_route,
 	if (rp->info) {
 		vty_out(vty, "There is already same static route.\n");
 		route_unlock_node(rp);
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 	rp->info = (void *)1;
 
@@ -2283,7 +2283,7 @@ DEFUN (ripng_aggregate_address,
 	if (node->info) {
 		vty_out(vty, "There is already same aggregate route.\n");
 		route_unlock_node(node);
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 	node->info = (void *)1;
 
@@ -2619,7 +2619,7 @@ DEFUN (ripng_allow_ecmp,
 {
 	if (ripng->ecmp) {
 		vty_out(vty, "ECMP is already enabled.\n");
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	ripng->ecmp = 1;
@@ -2635,7 +2635,7 @@ DEFUN (no_ripng_allow_ecmp,
 {
 	if (!ripng->ecmp) {
 		vty_out(vty, "ECMP is already disabled.\n");
-		return CMD_WARNING_CONFIG_FAILED;
+		return CMD_WARNING;
 	}
 
 	ripng->ecmp = 0;


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

If the user configures some command that is already in the config we
should return CMD_WARNING instead of CMD_WARNING_CONFIG_FAILED