### PR TITLE
Set permissions on systemd service file

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -326,7 +326,7 @@ rm -f %{buildroot}%{_libdir}/frr/modules/*.la
 # install /etc sources
 %if "%{initsystem}" == "systemd"
 mkdir -p %{buildroot}%{_unitdir}
-install %{zeb_rh_src}/frr.service \
+install -m644 %{zeb_rh_src}/frr.service \
     %{buildroot}%{_unitdir}/frr.service
 install %{zeb_rh_src}/frr.init \
     %{buildroot}%{_sbindir}/frr


### PR DESCRIPTION
Systemd on CentOS 7.3 logs a warning about the execute bit being
set every time the frr service file is invoked by systemctl.
Modify the spec file to explicitly set the permissions to 644.