### PR TITLE
zebra: Dissallow some static route options

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -329,20 +329,16 @@ DEFUN (show_ip_rpf_addr,
 	return CMD_SUCCESS;
 }
 
-/* Static route configuration.  */
-DEFPY (ip_route,
-       ip_route_cmd,
+DEFPY (ip_route_reject,
+       ip_route_reject_cmd,
        "[no] ip route\
-          <A.B.C.D/M$prefix|A.B.C.D$prefix A.B.C.D$mask>\
-          <\
-            {A.B.C.D$gate|INTERFACE$ifname}\
-            |<null0|reject|blackhole>$flag\
-          >\
-          [{\
-            tag (1-4294967295)\
-            |(1-255)$distance\
-            |vrf NAME\
-            |label WORD\
+          <A.B.C.D/M$prefix|A.B.C.D$prefix A.B.C.D$mask>	\
+          <null0|reject|blackhole>$flag				\
+          [{							\
+            tag (1-4294967295)					\
+            |(1-255)$distance					\
+            |vrf NAME						\
+            |label WORD						\
           }]",
        NO_STR
        IP_STR
@@ -350,8 +346,6 @@ DEFPY (ip_route,
        "IP destination prefix (e.g. 10.0.0.0/8)\n"
        "IP destination prefix\n"
        "IP destination prefix mask\n"
-       "IP gateway address\n"
-       "IP gateway interface name\n"
        "Null interface\n"
        "Emit an ICMP unreachable when matched\n"
        "Silently discard pkts when matched\n"
@@ -362,9 +356,39 @@ DEFPY (ip_route,
        MPLS_LABEL_HELPSTR)
 {
 	return zebra_static_route(vty, AFI_IP, SAFI_UNICAST, no, prefix,
-				  mask_str, NULL, gate_str, ifname, flag,
+				  mask_str, NULL, NULL, NULL, flag,
 				  tag_str, distance_str, vrf, label);
-	return 0;
+}
+
+/* Static route configuration.  */
+DEFPY (ip_route,
+       ip_route_cmd,
+       "[no] ip route\
+          <A.B.C.D/M$prefix|A.B.C.D$prefix A.B.C.D$mask>	\
+          {A.B.C.D$gate|INTERFACE$ifname}			\
+          [{							\
+            tag (1-4294967295)					\
+            |(1-255)$distance					\
+            |vrf NAME						\
+            |label WORD						\
+          }]",
+       NO_STR
+       IP_STR
+       "Establish static routes\n"
+       "IP destination prefix (e.g. 10.0.0.0/8)\n"
+       "IP destination prefix\n"
+       "IP destination prefix mask\n"
+       "IP gateway address\n"
+       "IP gateway interface name\n"
+       "Set tag for this route\n"
+       "Tag value\n"
+       "Distance value for this route\n"
+       VRF_CMD_HELP_STR
+       MPLS_LABEL_HELPSTR)
+{
+	return zebra_static_route(vty, AFI_IP, SAFI_UNICAST, no, prefix,
+				  mask_str, NULL, gate_str, ifname, NULL,
+				  tag_str, distance_str, vrf, label);
 }
 
 /* New RIB.  Detailed information for IPv4 route. */
@@ -1767,18 +1791,45 @@ static int static_config(struct vty *vty, afi_t afi, safi_t safi,
 	return write;
 }
 
+DEFPY (ipv6_route_reject,
+       ipv6_route_reject_cmd,
+       "[no] ipv6 route X:X::X:X/M$prefix [from X:X::X:X/M]\
+          <null0|reject|blackhole>$flag			   \
+          [{						   \
+            tag (1-4294967295)				   \
+            |(1-255)$distance				   \
+            |vrf NAME					   \
+            |label WORD					   \
+          }]",
+       NO_STR
+       IPV6_STR
+       "Establish static routes\n"
+       "IPv6 destination prefix (e.g. 3ffe:506::/32)\n"
+       "IPv6 source-dest route\n"
+       "IPv6 source prefix\n"
+       "Null interface\n"
+       "Emit an ICMP unreachable when matched\n"
+       "Silently discard pkts when matched\n"
+       "Set tag for this route\n"
+       "Tag value\n"
+       "Distance value for this prefix\n"
+       VRF_CMD_HELP_STR
+       MPLS_LABEL_HELPSTR)
+{
+	return zebra_static_route(vty, AFI_IP6, SAFI_UNICAST, no, prefix_str,
+				  NULL, from_str, NULL, NULL, flag,
+				  tag_str, distance_str, vrf, label);
+}
+
 DEFPY (ipv6_route,
        ipv6_route_cmd,
        "[no] ipv6 route X:X::X:X/M$prefix [from X:X::X:X/M]\
-          <\
-            {X:X::X:X$gate|INTERFACE$ifname}\
-            |<null0|reject|blackhole>$flag\
-          >\
-          [{\
-            tag (1-4294967295)\
-            |(1-255)$distance\
-            |vrf NAME\
-            |label WORD\
+          {X:X::X:X$gate|INTERFACE$ifname}		   \
+          [{						   \
+            tag (1-4294967295)				   \
+            |(1-255)$distance				   \
+            |vrf NAME					   \
+            |label WORD					   \
           }]",
        NO_STR
        IPV6_STR
@@ -1798,7 +1849,7 @@ DEFPY (ipv6_route,
        MPLS_LABEL_HELPSTR)
 {
 	return zebra_static_route(vty, AFI_IP6, SAFI_UNICAST, no, prefix_str,
-				  NULL, from_str, gate_str, ifname, flag,
+				  NULL, from_str, gate_str, ifname, NULL,
 				  tag_str, distance_str, vrf, label);
 }
 
@@ -2679,6 +2730,7 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &ip_multicast_mode_cmd);
 	install_element(CONFIG_NODE, &no_ip_multicast_mode_cmd);
 	install_element(CONFIG_NODE, &ip_route_cmd);
+	install_element(CONFIG_NODE, &ip_route_reject_cmd);
 	install_element(CONFIG_NODE, &ip_zebra_import_table_distance_cmd);
 	install_element(CONFIG_NODE, &no_ip_zebra_import_table_cmd);
 
@@ -2702,6 +2754,7 @@ void zebra_vty_init(void)
 	install_element(VIEW_NODE, &show_ip_route_vrf_all_summary_prefix_cmd);
 
 	install_element(CONFIG_NODE, &ipv6_route_cmd);
+	install_element(CONFIG_NODE, &ipv6_route_reject_cmd);
 	install_element(CONFIG_NODE, &ip_nht_default_route_cmd);
 	install_element(CONFIG_NODE, &no_ip_nht_default_route_cmd);
 	install_element(CONFIG_NODE, &ipv6_nht_default_route_cmd);


### PR DESCRIPTION
Currently it is legal to specify a gateway and/or interface
with the `blackhole|null0|reject`.  As such:

`ip route 4.3.2.1/32 10.0.4.2 reject`
is a legal command to enter.

This has two issues:
1) Specifying either a gateway or an interface when attempting
to specify a blachole or reject route makes no sense
2) When entering the above command it is accepted, nvgenned
and silently ignored.

Modify both v4 and v6 code cli to not allow `reject|blackhole|null0`
to be accepted when you enter an nexthop or interface.  This
should solve the issues.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>