### PR TITLE
zebra: Allow bh_type to override nexthop selection

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -384,16 +384,23 @@ static int netlink_route_change_read_unicast(struct sockaddr_nl *snl,
 			size_t sz = (afi == AFI_IP) ? 4 : 16;
 
 			memset(&nh, 0, sizeof(nh));
-			if (index && !gate)
-				nh.type = NEXTHOP_TYPE_IFINDEX;
-			else if (index && gate)
-				nh.type = (afi == AFI_IP)
-						  ? NEXTHOP_TYPE_IPV4_IFINDEX
-						  : NEXTHOP_TYPE_IPV6_IFINDEX;
-			else if (!index && gate)
-				nh.type = (afi == AFI_IP) ? NEXTHOP_TYPE_IPV4
-							  : NEXTHOP_TYPE_IPV6;
-			else {
+
+			if (bh_type == BLACKHOLE_UNSPEC) {
+				if (index && !gate)
+					nh.type = NEXTHOP_TYPE_IFINDEX;
+				else if (index && gate)
+					nh.type = (afi == AFI_IP) ?
+						? NEXTHOP_TYPE_IPV4_IFINDEX
+						: NEXTHOP_TYPE_IPV6_IFINDEX;
+				else if (!index && gate)
+					nh.type = (afi == AFI_IP) ?
+						? NEXTHOP_TYPE_IPV4
+						: NEXTHOP_TYPE_IPV6;
+				else {
+					nh.type = NEXTHOP_TYPE_BLACKHOLE;
+					nh.bh_type = bh_type;
+				}
+			} else {
 				nh.type = NEXTHOP_TYPE_BLACKHOLE;
 				nh.bh_type = bh_type;
 			}


### PR DESCRIPTION
If we've set the bh_type to something besides BLACKHOLE_UNSPEC
due to the received route type being RTN_BLACKHOLE,
RTN_UNREACHABLE or RTN_PROHIBIT then just trust that
the nexthop is just what it is and set accordingly.

Fixes: #1082
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>