### PR TITLE
lib: fix thread scheduling weirdness

### DIFF
--- a/lib/thread.h
+++ b/lib/thread.h
@@ -70,7 +70,6 @@ struct cancel_req {
 struct thread_master {
 	char *name;
 
-	int tick_since_io;
 	struct thread **read;
 	struct thread **write;
 	struct pqueue *timer;


### PR DESCRIPTION
Restores 3.0 behavior in terms of thread scheduling & prioritization. Earlier changes were causing issues with order of events in OSPF and BGP.

Fixes #1053 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>