### PR TITLE
zebra: fix compiler error introduced by previous commit

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -389,13 +389,13 @@ static int netlink_route_change_read_unicast(struct sockaddr_nl *snl,
 				if (index && !gate)
 					nh.type = NEXTHOP_TYPE_IFINDEX;
 				else if (index && gate)
-					nh.type = (afi == AFI_IP) ?
+					nh.type = (afi == AFI_IP)
 						? NEXTHOP_TYPE_IPV4_IFINDEX
 						: NEXTHOP_TYPE_IPV6_IFINDEX;
 				else if (!index && gate)
-					nh.type = (afi == AFI_IP) ?
-						? NEXTHOP_TYPE_IPV4
-						: NEXTHOP_TYPE_IPV6;
+					nh.type = (afi == AFI_IP)
+							  ? NEXTHOP_TYPE_IPV4
+							  : NEXTHOP_TYPE_IPV6;
 				else {
 					nh.type = NEXTHOP_TYPE_BLACKHOLE;
 					nh.bh_type = bh_type;


### PR DESCRIPTION
Lesson learned: always wait for the CI tests to finish before merging :)

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>