### PR TITLE
zebra: display static blackhole routes consistently

### DIFF
--- a/zebra/zebra_static.c
+++ b/zebra/zebra_static.c
@@ -45,6 +45,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 	struct route_table *table;
 	struct prefix nh_p;
 	struct nexthop *nexthop = NULL;
+	enum blackhole_type bh_type = 0;
 
 	/* Lookup table.  */
 	table = zebra_vrf_table(afi, safi, si->vrf_id);
@@ -52,6 +53,17 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 		return;
 
 	memset(&nh_p, 0, sizeof(nh_p));
+	if (si->type == STATIC_BLACKHOLE) {
+		switch (si->bh_type) {
+		case STATIC_BLACKHOLE_DROP:
+		case STATIC_BLACKHOLE_NULL:
+			bh_type = BLACKHOLE_NULL;
+			break;
+		case STATIC_BLACKHOLE_REJECT:
+			bh_type = BLACKHOLE_REJECT;
+			break;
+		}
+	}
 
 	/* Lookup existing route */
 	rn = srcdest_rnode_get(table, p, src_p);
@@ -92,7 +104,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 			break;
 		case STATIC_BLACKHOLE:
 			nexthop = route_entry_nexthop_blackhole_add(
-				re, si->bh_type);
+				re, bh_type);
 			break;
 		case STATIC_IPV6_GATEWAY:
 			nexthop = route_entry_nexthop_ipv6_add(re,
@@ -168,7 +180,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 			break;
 		case STATIC_BLACKHOLE:
 			nexthop = route_entry_nexthop_blackhole_add(
-				re, si->bh_type);
+				re, bh_type);
 			break;
 		case STATIC_IPV6_GATEWAY:
 			nexthop = route_entry_nexthop_ipv6_add(re,
@@ -363,7 +375,7 @@ void static_uninstall_route(afi_t afi, safi_t safi, struct prefix *p,
 
 int static_add_route(afi_t afi, safi_t safi, u_char type, struct prefix *p,
 		     struct prefix_ipv6 *src_p, union g_addr *gate,
-		     const char *ifname, enum blackhole_type bh_type,
+		     const char *ifname, enum static_blackhole_type bh_type,
 		     route_tag_t tag, u_char distance, struct zebra_vrf *zvrf,
 		     struct static_nh_label *snh_label)
 {

--- a/zebra/zebra_static.h
+++ b/zebra/zebra_static.h
@@ -31,6 +31,12 @@ struct static_nh_label {
 	mpls_label_t label[MPLS_MAX_LABELS];
 };
 
+enum static_blackhole_type {
+	STATIC_BLACKHOLE_DROP = 0,
+	STATIC_BLACKHOLE_NULL,
+	STATIC_BLACKHOLE_REJECT
+};
+
 typedef enum {
 	STATIC_IFNAME,
 	STATIC_IPV4_GATEWAY,
@@ -61,7 +67,7 @@ struct static_route {
 	/*
 	 * Nexthop value.
 	 */
-	enum blackhole_type bh_type;
+	enum static_blackhole_type bh_type;
 	union g_addr addr;
 	ifindex_t ifindex;
 
@@ -80,9 +86,9 @@ extern void static_uninstall_route(afi_t afi, safi_t safi, struct prefix *p,
 
 extern int static_add_route(afi_t, safi_t safi, u_char type, struct prefix *p,
 			    struct prefix_ipv6 *src_p, union g_addr *gate,
-			    const char *ifname, enum blackhole_type bh_type,
-			    route_tag_t tag, u_char distance,
-			    struct zebra_vrf *zvrf,
+			    const char *ifname,
+			    enum static_blackhole_type bh_type, route_tag_t tag,
+			    u_char distance, struct zebra_vrf *zvrf,
 			    struct static_nh_label *snh_label);
 
 extern int static_delete_route(afi_t, safi_t safi, u_char type,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -165,14 +165,18 @@ static int zebra_static_route(struct vty *vty, afi_t afi, safi_t safi,
 		}
 	}
 
+	/* Null0 static route.  */
+	if ((ifname != NULL)
+	    && (strncasecmp(ifname, "Null0", strlen(ifname)) == 0)) {
+		bh_type = STATIC_BLACKHOLE_NULL;
+		ifname = NULL;
+	}
+
 	/* Route flags */
 	if (flag_str) {
 		switch (flag_str[0]) {
 		case 'r':
 			bh_type = STATIC_BLACKHOLE_REJECT;
-			break;
-		case 'n':
-			bh_type = STATIC_BLACKHOLE_NULL;
 			break;
 		case 'b':
 			bh_type = STATIC_BLACKHOLE_DROP;
@@ -334,7 +338,8 @@ DEFPY(ip_route, ip_route_cmd,
           <A.B.C.D/M$prefix|A.B.C.D$prefix A.B.C.D$mask>\
           <\
             {A.B.C.D$gate|INTERFACE$ifname}\
-            |<null0|reject|blackhole>$flag\
+            |null0$ifname\
+            |<reject|blackhole>$flag\
           >\
           [{\
             tag (1-4294967295)\
@@ -1715,7 +1720,7 @@ static int static_config(struct vty *vty, afi_t afi, safi_t safi,
 						vty_out(vty, " blackhole");
 						break;
 					case STATIC_BLACKHOLE_NULL:
-						vty_out(vty, " null0");
+						vty_out(vty, " Null0");
 						break;
 					case STATIC_BLACKHOLE_REJECT:
 						vty_out(vty, " reject");
@@ -1772,7 +1777,8 @@ DEFPY(ipv6_route,
       "[no] ipv6 route X:X::X:X/M$prefix [from X:X::X:X/M]\
           <\
             {X:X::X:X$gate|INTERFACE$ifname}\
-            |<null0|reject|blackhole>$flag\
+            |null0$ifname\
+            |<reject|blackhole>$flag\
           >\
           [{\
             tag (1-4294967295)\

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -74,7 +74,7 @@ static int zebra_static_route(struct vty *vty, afi_t afi, safi_t safi,
 	union g_addr gate;
 	union g_addr *gatep = NULL;
 	struct in_addr mask;
-	enum blackhole_type bh_type = 0;
+	enum static_blackhole_type bh_type = 0;
 	route_tag_t tag = 0;
 	struct zebra_vrf *zvrf;
 	u_char type;
@@ -169,14 +169,13 @@ static int zebra_static_route(struct vty *vty, afi_t afi, safi_t safi,
 	if (flag_str) {
 		switch (flag_str[0]) {
 		case 'r':
-		case 'R': /* XXX */
-			bh_type = BLACKHOLE_REJECT;
+			bh_type = STATIC_BLACKHOLE_REJECT;
 			break;
 		case 'n':
-		case 'N' /* XXX */:
+			bh_type = STATIC_BLACKHOLE_NULL;
+			break;
 		case 'b':
-		case 'B': /* XXX */
-			bh_type = BLACKHOLE_NULL;
+			bh_type = STATIC_BLACKHOLE_DROP;
 			break;
 		default:
 			vty_out(vty, "%% Malformed flag %s \n", flag_str);
@@ -1712,11 +1711,14 @@ static int static_config(struct vty *vty, afi_t afi, safi_t safi,
 					break;
 				case STATIC_BLACKHOLE:
 					switch (si->bh_type) {
-					case BLACKHOLE_REJECT:
-						vty_out(vty, " reject");
-						break;
-					default:
+					case STATIC_BLACKHOLE_DROP:
 						vty_out(vty, " blackhole");
+						break;
+					case STATIC_BLACKHOLE_NULL:
+						vty_out(vty, " null0");
+						break;
+					case STATIC_BLACKHOLE_REJECT:
+						vty_out(vty, " reject");
 						break;
 					}
 					break;


### PR DESCRIPTION
If we configure a static route pointing to null0 and zebra displays
it with the 'blackhole' keyword in the running configuration, the
frr-reload.py script will have issues.

Fixes #1091 (except that Null0 is still unsupported in order to keep
the code simple - null0 should be used instead).

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>