### PR TITLE
tests: skip isis tlv fuzztest on SunOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -880,6 +880,7 @@ case "$host_os" in
     AC_DEFINE(KAME,1,KAME IPv6)
     ;;
 esac
+AM_CONDITIONAL(SOLARIS, test "${SOLARIS}" = "solaris")
 
 AC_SYS_LARGEFILE
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -25,8 +25,12 @@ TESTS_BGPD =
 endif
 
 if ISISD
+if SOLARIS
+TESTS_ISISD =
+else
 TESTS_ISISD = \
 	isisd/test_fuzz_isis_tlv
+endif
 else
 TESTS_ISISD =
 endif

--- a/tests/isisd/test_fuzz_isis_tlv.py
+++ b/tests/isisd/test_fuzz_isis_tlv.py
@@ -1,6 +1,15 @@
 import frrtest
 
-class TestFuzzIsisTLV(frrtest.TestMultiOut):
-    program = './test_fuzz_isis_tlv'
+import pytest
+import platform
 
-TestFuzzIsisTLV.exit_cleanly()
+if platform.uname()[0] == 'SunOS':
+    class TestFuzzIsisTLV:
+        @pytest.mark.skipif(True, reason='Test unsupported on SunOS')
+        def test_exit_cleanly(self):
+            pass
+else:
+    class TestFuzzIsisTLV(frrtest.TestMultiOut):
+        program = './test_fuzz_isis_tlv'
+
+    TestFuzzIsisTLV.exit_cleanly()


### PR DESCRIPTION
The fuzztest is not platform specific and uses functionality which is not available on solaris. Therefore, just skip it on this platform.