### PR TITLE
ripd: Fix warning about metric value less than 0

### DIFF
--- a/ripd/rip_routemap.c
+++ b/ripd/rip_routemap.c
@@ -421,8 +421,7 @@ static void *route_set_metric_compile(const char *arg)
 	/* Convert string to integer. */
 	metric = strtol(pnt, &endptr, 10);
 
-	if (*endptr != '\0' || mod->metric < 0) {
-		metric = 0;
+	if (*endptr != '\0' || metric < 0) {
 		return mod;
 	}
 	if (metric > RIP_METRIC_INFINITY) {


### PR DESCRIPTION
RIP is testing to ensure that the metric returned
isn't negative.  We should be looking at the returned
value from the cli strtol.

If we get a metric value that is less than zero that
means that we shouldn't use this value in RIP currently.
So signify that by returning mod here.

Fixes: #1107
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>