### PR TITLE
[3.0] kill bgp_attr_refcount()

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -832,47 +832,6 @@ struct attr *bgp_attr_intern(struct attr *attr)
 	return find;
 }
 
-/**
- * Increment the refcount on various structures that attr holds.
- * Note on usage: call _only_ when the 'attr' object has already
- * been 'intern'ed and exists in 'attrhash' table. The function
- * serves to hold a reference to that (real) object.
- * Note also that the caller can safely call bgp_attr_unintern()
- * after calling bgp_attr_refcount(). That would release the
- * reference and could result in a free() of the attr object.
- */
-struct attr *bgp_attr_refcount(struct attr *attr)
-{
-	/* Intern referenced strucutre. */
-	if (attr->aspath)
-		attr->aspath->refcnt++;
-
-	if (attr->community)
-		attr->community->refcnt++;
-
-	if (attr->extra) {
-		struct attr_extra *attre = attr->extra;
-		if (attre->ecommunity)
-			attre->ecommunity->refcnt++;
-
-		if (attre->cluster)
-			attre->cluster->refcnt++;
-
-		if (attre->transit)
-			attre->transit->refcnt++;
-
-		if (attre->encap_subtlvs)
-			attre->encap_subtlvs->refcnt++;
-
-#if ENABLE_BGP_VNC
-		if (attre->vnc_subtlvs)
-			attre->vnc_subtlvs->refcnt++;
-#endif
-	}
-	attr->refcnt++;
-	return attr;
-}
-
 /* Make network statement's attribute. */
 struct attr *bgp_attr_default_set(struct attr *attr, u_char origin)
 {

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -551,6 +551,9 @@ void bgp_attr_deep_dup(struct attr *new, struct attr *orig)
 		if (orig->extra->ecommunity)
 			new->extra->ecommunity =
 				ecommunity_dup(orig->extra->ecommunity);
+		if (orig->extra->lcommunity)
+			new->extra->lcommunity =
+				lcommunity_dup(orig->extra->lcommunity);
 		if (orig->extra->cluster)
 			new->extra->cluster = cluster_dup(orig->extra->cluster);
 		if (orig->extra->transit)
@@ -577,6 +580,8 @@ void bgp_attr_deep_free(struct attr *attr)
 	if (attr->extra) {
 		if (attr->extra->ecommunity)
 			ecommunity_free(&attr->extra->ecommunity);
+		if (attr->extra->lcommunity)
+			lcommunity_free(&attr->extra->lcommunity);
 		if (attr->extra->cluster)
 			cluster_free(attr->extra->cluster);
 		if (attr->extra->transit)

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -225,7 +225,6 @@ extern void bgp_attr_dup(struct attr *, struct attr *);
 extern void bgp_attr_deep_dup(struct attr *, struct attr *);
 extern void bgp_attr_deep_free(struct attr *);
 extern struct attr *bgp_attr_intern(struct attr *attr);
-extern struct attr *bgp_attr_refcount(struct attr *attr);
 extern void bgp_attr_unintern_sub(struct attr *);
 extern void bgp_attr_unintern(struct attr **);
 extern void bgp_attr_flush(struct attr *);

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1196,7 +1196,7 @@ static void update_subgroup_copy_adj_out(struct update_subgroup *source,
 		aout_copy =
 			bgp_adj_out_alloc(dest, aout->rn, aout->addpath_tx_id);
 		aout_copy->attr =
-			aout->attr ? bgp_attr_refcount(aout->attr) : NULL;
+			aout->attr ? bgp_attr_intern(aout->attr) : NULL;
 	}
 }
 


### PR DESCRIPTION
This attempt at optimization has cost us more than a week's worth of
time on several people hunting down the subtle bug that it was missing
an increment on attr->lcommunity.

This is absolutely not worth the maintenance cost.

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>