### PR TITLE
pimd: We do not need to BINDTODEVICE for default vrf

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -720,7 +720,8 @@ int pim_mroute_socket_enable(struct pim_instance *pim)
 	}
 
 #ifdef SO_BINDTODEVICE
-	if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, pim->vrf->name,
+	if (pim->vrf->vrf_id != VRF_DEFAULT &&
+	    setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, pim->vrf->name,
 		       strlen(pim->vrf->name))) {
 		zlog_warn("Could not setsockopt SO_BINDTODEVICE: %s",
 			  safe_strerror(errno));


### PR DESCRIPTION
The changes introduced in PR #1044 caused pim to notice
when a setsockopt call failed.  The kicker here is that
this used to just work because we ignored the issue
pre.  So VRF's need to BINDTODEVICE to get igmp callbacks
but the default vrf does not need to do so.

With the fix we now see IGMP group join:
root@dell-s6000-02 ~/frr# vtysh -c "show ip igmp group"
Interface Address         Group           Mode Timer    Srcs V Uptime
br1       20.0.11.1       232.2.3.4       EXCL 00:04:14    1 3 00:00:05

Fixes: #1121
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>