### PR TITLE
Enable FRR service

### DIFF
--- a/doc/Building_FRR_on_Ubuntu1604.md
+++ b/doc/Building_FRR_on_Ubuntu1604.md
@@ -136,13 +136,15 @@ For example.
     ripngd=yes
     isisd=yes
 
-### Enable the systemd serivce
+### Enable the systemd service
 Edit `/etc/systemd/system/frr.service` and remove the line **OnFailure=heartbeat-failed@%n.service**  
 For example.
 
     [Unit]  
     Description=Cumulus Linux FRR  
     After=syslog.target networking.service  
+
+- systemctl enable frr
     
 ### Start the systemd service
 - systemctl start frr


### PR DESCRIPTION
In order for the frr service to come up automatically, the service needs to be enabled which will create a symlink from /etc/systemd/system/network-online.target.wants/frr.service to /etc/systemd/system/frr.service