### PR TITLE
zebra: allow multiple connected routes for the same prefix

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2475,10 +2475,11 @@ int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type, u_short instance,
 			return 0;
 		/*
 		 * Nexthop is different. Remove the old route unless it's
-		 * a link-local route.
+		 * a connected route. This exception is necessary because
+		 * of IPv6 link-local routes and unnumbered interfaces on
+		 * Linux.
 		 */
-		else if (afi != AFI_IP6
-			 || !IN6_IS_ADDR_LINKLOCAL(&p->u.prefix6))
+		else if (type != ZEBRA_ROUTE_CONNECT)
 			same = re;
 	}
 


### PR DESCRIPTION
With unnumbered interfaces on Linux we have the same IP address configured
on several different interfaces and hence multiple connected routes for
the same prefix.

With that said, add an exception in rib_add() to allow zebra to keep
track of all connected routes. We don't need to worry about the bugs
reported in a3d18ce because connected routes are always added from the
connected_up() function, and connected_update() already takes care of
handling duplicate addresses per interface.

Fixes #1112.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>