### PR TITLE
Build FRR using branch stable/3.0

### DIFF
--- a/doc/Building_FRR_on_Debian8.md
+++ b/doc/Building_FRR_on_Debian8.md
@@ -41,6 +41,7 @@ an example.)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     ./configure \
         --enable-exampledir=/usr/share/doc/frr/examples/ \

--- a/doc/Building_FRR_on_FreeBSD10.md
+++ b/doc/Building_FRR_on_FreeBSD10.md
@@ -43,6 +43,7 @@ an example)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     export MAKE=gmake
     export LDFLAGS="-L/usr/local/lib"

--- a/doc/Building_FRR_on_FreeBSD11.md
+++ b/doc/Building_FRR_on_FreeBSD11.md
@@ -43,6 +43,7 @@ an example)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     export MAKE=gmake
     export LDFLAGS="-L/usr/local/lib"

--- a/doc/Building_FRR_on_FreeBSD9.md
+++ b/doc/Building_FRR_on_FreeBSD9.md
@@ -51,6 +51,7 @@ an example)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     export MAKE=gmake
     export LDFLAGS="-L/usr/local/lib"

--- a/doc/Building_FRR_on_NetBSD6.md
+++ b/doc/Building_FRR_on_NetBSD6.md
@@ -47,6 +47,7 @@ an example)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     MAKE=gmake
     export LDFLAGS="-L/usr/pkg/lib -R/usr/pkg/lib"

--- a/doc/Building_FRR_on_NetBSD7.md
+++ b/doc/Building_FRR_on_NetBSD7.md
@@ -41,6 +41,7 @@ an example)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     MAKE=gmake
     export LDFLAGS="-L/usr/pkg/lib -R/usr/pkg/lib"

--- a/doc/Building_FRR_on_OmniOS.md
+++ b/doc/Building_FRR_on_OmniOS.md
@@ -89,6 +89,7 @@ an example)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     export MAKE=gmake
     export LDFLAGS="-L/opt/csw/lib"

--- a/doc/Building_FRR_on_OpenBSD6.md
+++ b/doc/Building_FRR_on_OpenBSD6.md
@@ -36,6 +36,7 @@ an example)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     export AUTOCONF_VERSION="2.69"
     export AUTOMAKE_VERSION="1.15"
     ./bootstrap.sh

--- a/doc/Building_FRR_on_Ubuntu1204.md
+++ b/doc/Building_FRR_on_Ubuntu1204.md
@@ -75,6 +75,7 @@ an example.)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     ./configure \
         --prefix=/usr \

--- a/doc/Building_FRR_on_Ubuntu1404.md
+++ b/doc/Building_FRR_on_Ubuntu1404.md
@@ -35,6 +35,7 @@ an example.)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     ./configure \
         --prefix=/usr \

--- a/doc/Building_FRR_on_Ubuntu1604.md
+++ b/doc/Building_FRR_on_Ubuntu1604.md
@@ -36,6 +36,7 @@ an example.)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
+    git checkout stable/3.0
     ./bootstrap.sh
     ./configure \
         --prefix=/usr \


### PR DESCRIPTION
This is the documentation for Ubuntu 16.04 in branch stable/3.0. Hence it is important to checkout the respective branch before building FRR.