### PR TITLE
lib: Allow free'd streams to be cached for next stream_new

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -35,6 +35,7 @@
 #include "log_int.h"
 #include "module.h"
 #include "network.h"
+#include "stream.h"
 
 DEFINE_HOOK(frr_late_init, (struct thread_master * tm), (tm))
 DEFINE_KOOH(frr_early_fini, (), ())
@@ -587,6 +588,8 @@ struct thread_master *frr_init(void)
 	vty_init(master);
 	memory_init();
 
+	stream_init();
+
 	return master;
 }
 
@@ -886,6 +889,7 @@ void frr_fini(void)
 	zprivs_terminate(di->privs);
 	/* signal_init -> nothing needed */
 	thread_master_free(master);
+	stream_fini();
 	closezlog();
 	/* frrmod_init -> nothing needed / hooks */
 

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -239,4 +239,10 @@ extern struct stream *stream_fifo_head(struct stream_fifo *fifo);
 extern void stream_fifo_clean(struct stream_fifo *fifo);
 extern void stream_fifo_free(struct stream_fifo *fifo);
 
+/*
+ * Initialization and shutdown handlers
+ * Should only be called from libfrr
+ */
+extern void stream_init(void);
+extern void stream_fini(void);
 #endif /* _ZEBRA_STREAM_H */


### PR DESCRIPTION
streamcache -> Is an attempt to speed up buffer lookup
When we do a stream_free, if the size spot in streamcache
is not being used, then save the stream pointer
(clearing it up first).  Thus when we do a stream_new
lookup in the streamcache.

The belief here is that:
a) caching the size is faster then the FREE + MALLOC
   for the next one.
b) The daemon is going to allocate the same size
   more frequently than random sizes.

Recent perf tests show that stream_new and stream_free
were being called at a significant pace.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>