### PR TITLE
Multithreaded BGPD

### DIFF
--- a/bgpd/Makefile.am
+++ b/bgpd/Makefile.am
@@ -85,7 +85,8 @@ libbgp_a_SOURCES = \
 	bgp_damp.c bgp_table.c bgp_advertise.c bgp_vty.c bgp_mpath.c \
 	bgp_nht.c bgp_updgrp.c bgp_updgrp_packet.c bgp_updgrp_adv.c bgp_bfd.c \
 	bgp_encap_tlv.c $(BGP_VNC_RFAPI_SRC) bgp_attr_evpn.c \
-	bgp_evpn.c bgp_evpn_vty.c bgp_vpn.c bgp_label.c bgp_rd.c
+	bgp_evpn.c bgp_evpn_vty.c bgp_vpn.c bgp_label.c bgp_rd.c \
+	bgp_keepalives.c
 
 noinst_HEADERS = \
 	bgp_memory.h \
@@ -97,7 +98,7 @@ noinst_HEADERS = \
 	bgp_advertise.h bgp_vty.h bgp_mpath.h bgp_nht.h \
 	bgp_updgrp.h bgp_bfd.h bgp_encap_tlv.h bgp_encap_types.h \
 	$(BGP_VNC_RFAPI_HD) bgp_attr_evpn.h bgp_evpn.h bgp_evpn_vty.h \
-        bgp_vpn.h bgp_label.h bgp_rd.h bgp_evpn_private.h
+        bgp_vpn.h bgp_label.h bgp_rd.h bgp_evpn_private.h bgp_keepalives.h \
 
 bgpd_SOURCES = bgp_main.c
 bgpd_LDADD = libbgp.a  $(BGP_VNC_RFP_LIB) ../lib/libfrr.la @LIBCAP@ @LIBM@

--- a/bgpd/Makefile.am
+++ b/bgpd/Makefile.am
@@ -86,7 +86,7 @@ libbgp_a_SOURCES = \
 	bgp_nht.c bgp_updgrp.c bgp_updgrp_packet.c bgp_updgrp_adv.c bgp_bfd.c \
 	bgp_encap_tlv.c $(BGP_VNC_RFAPI_SRC) bgp_attr_evpn.c \
 	bgp_evpn.c bgp_evpn_vty.c bgp_vpn.c bgp_label.c bgp_rd.c \
-	bgp_keepalives.c
+	bgp_keepalives.c bgp_io.c
 
 noinst_HEADERS = \
 	bgp_memory.h \
@@ -99,6 +99,7 @@ noinst_HEADERS = \
 	bgp_updgrp.h bgp_bfd.h bgp_encap_tlv.h bgp_encap_types.h \
 	$(BGP_VNC_RFAPI_HD) bgp_attr_evpn.h bgp_evpn.h bgp_evpn_vty.h \
         bgp_vpn.h bgp_label.h bgp_rd.h bgp_evpn_private.h bgp_keepalives.h \
+	bgp_io.h
 
 bgpd_SOURCES = bgp_main.c
 bgpd_LDADD = libbgp.a  $(BGP_VNC_RFP_LIB) ../lib/libfrr.la @LIBCAP@ @LIBM@

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1156,7 +1156,7 @@ static int bgp_attr_aspath(struct bgp_attr_parser_args *args)
 	 * peer with AS4 => will get 4Byte ASnums
 	 * otherwise, will get 16 Bit
 	 */
-	attr->aspath = aspath_parse(peer->ibuf, length,
+	attr->aspath = aspath_parse(peer->curr, length,
 				    CHECK_FLAG(peer->cap, PEER_CAP_AS4_RCV));
 
 	/* In case of IBGP, length will be zero. */
@@ -1230,7 +1230,7 @@ static int bgp_attr_as4_path(struct bgp_attr_parser_args *args,
 	struct attr *const attr = args->attr;
 	const bgp_size_t length = args->length;
 
-	*as4_path = aspath_parse(peer->ibuf, length, 1);
+	*as4_path = aspath_parse(peer->curr, length, 1);
 
 	/* In case of IBGP, length will be zero. */
 	if (!*as4_path) {
@@ -1271,7 +1271,7 @@ static bgp_attr_parse_ret_t bgp_attr_nexthop(struct bgp_attr_parser_args *args)
 	   logged locally (this is implemented somewhere else). The UPDATE
 	   message
 	   gets ignored in any of these cases. */
-	nexthop_n = stream_get_ipv4(peer->ibuf);
+	nexthop_n = stream_get_ipv4(peer->curr);
 	nexthop_h = ntohl(nexthop_n);
 	if ((IPV4_NET0(nexthop_h) || IPV4_NET127(nexthop_h)
 	     || IPV4_CLASS_DE(nexthop_h))
@@ -1307,7 +1307,7 @@ static bgp_attr_parse_ret_t bgp_attr_med(struct bgp_attr_parser_args *args)
 					  args->total);
 	}
 
-	attr->med = stream_getl(peer->ibuf);
+	attr->med = stream_getl(peer->curr);
 
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
 
@@ -1333,11 +1333,11 @@ bgp_attr_local_pref(struct bgp_attr_parser_args *args)
 	   external peer, then this attribute MUST be ignored by the
 	   receiving speaker. */
 	if (peer->sort == BGP_PEER_EBGP) {
-		stream_forward_getp(peer->ibuf, length);
+		stream_forward_getp(peer->curr, length);
 		return BGP_ATTR_PARSE_PROCEED;
 	}
 
-	attr->local_pref = stream_getl(peer->ibuf);
+	attr->local_pref = stream_getl(peer->curr);
 
 	/* Set the local-pref flag. */
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF);
@@ -1386,10 +1386,10 @@ static int bgp_attr_aggregator(struct bgp_attr_parser_args *args)
 	}
 
 	if (CHECK_FLAG(peer->cap, PEER_CAP_AS4_RCV))
-		attr->aggregator_as = stream_getl(peer->ibuf);
+		attr->aggregator_as = stream_getl(peer->curr);
 	else
-		attr->aggregator_as = stream_getw(peer->ibuf);
-	attr->aggregator_addr.s_addr = stream_get_ipv4(peer->ibuf);
+		attr->aggregator_as = stream_getw(peer->curr);
+	attr->aggregator_addr.s_addr = stream_get_ipv4(peer->curr);
 
 	/* Set atomic aggregate flag. */
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
@@ -1413,8 +1413,8 @@ bgp_attr_as4_aggregator(struct bgp_attr_parser_args *args,
 					  0);
 	}
 
-	*as4_aggregator_as = stream_getl(peer->ibuf);
-	as4_aggregator_addr->s_addr = stream_get_ipv4(peer->ibuf);
+	*as4_aggregator_as = stream_getl(peer->curr);
+	as4_aggregator_addr->s_addr = stream_get_ipv4(peer->curr);
 
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AS4_AGGREGATOR);
 
@@ -1540,10 +1540,10 @@ bgp_attr_community(struct bgp_attr_parser_args *args)
 	}
 
 	attr->community =
-		community_parse((u_int32_t *)stream_pnt(peer->ibuf), length);
+		community_parse((u_int32_t *)stream_pnt(peer->curr), length);
 
 	/* XXX: fix community_parse to use stream API and remove this */
-	stream_forward_getp(peer->ibuf, length);
+	stream_forward_getp(peer->curr, length);
 
 	if (!attr->community)
 		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_OPT_ATTR_ERR,
@@ -1570,7 +1570,7 @@ bgp_attr_originator_id(struct bgp_attr_parser_args *args)
 					  args->total);
 	}
 
-	attr->originator_id.s_addr = stream_get_ipv4(peer->ibuf);
+	attr->originator_id.s_addr = stream_get_ipv4(peer->curr);
 
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID);
 
@@ -1594,10 +1594,10 @@ bgp_attr_cluster_list(struct bgp_attr_parser_args *args)
 	}
 
 	attr->cluster =
-		cluster_parse((struct in_addr *)stream_pnt(peer->ibuf), length);
+		cluster_parse((struct in_addr *)stream_pnt(peer->curr), length);
 
 	/* XXX: Fix cluster_parse to use stream API and then remove this */
-	stream_forward_getp(peer->ibuf, length);
+	stream_forward_getp(peer->curr, length);
 
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_CLUSTER_LIST);
 
@@ -1778,7 +1778,7 @@ int bgp_mp_unreach_parse(struct bgp_attr_parser_args *args,
 	struct attr *const attr = args->attr;
 	const bgp_size_t length = args->length;
 
-	s = peer->ibuf;
+	s = peer->curr;
 
 #define BGP_MP_UNREACH_MIN_SIZE 3
 	if ((length > STREAM_READABLE(s)) || (length < BGP_MP_UNREACH_MIN_SIZE))
@@ -1832,9 +1832,9 @@ bgp_attr_large_community(struct bgp_attr_parser_args *args)
 	}
 
 	attr->lcommunity =
-		lcommunity_parse((u_int8_t *)stream_pnt(peer->ibuf), length);
+		lcommunity_parse((u_int8_t *)stream_pnt(peer->curr), length);
 	/* XXX: fix ecommunity_parse to use stream API */
-	stream_forward_getp(peer->ibuf, length);
+	stream_forward_getp(peer->curr, length);
 
 	if (!attr->lcommunity)
 		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_OPT_ATTR_ERR,
@@ -1861,9 +1861,9 @@ bgp_attr_ext_communities(struct bgp_attr_parser_args *args)
 	}
 
 	attr->ecommunity =
-		ecommunity_parse((u_int8_t *)stream_pnt(peer->ibuf), length);
+		ecommunity_parse((u_int8_t *)stream_pnt(peer->curr), length);
 	/* XXX: fix ecommunity_parse to use stream API */
-	stream_forward_getp(peer->ibuf, length);
+	stream_forward_getp(peer->curr, length);
 
 	if (!attr->ecommunity)
 		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_OPT_ATTR_ERR,
@@ -1957,7 +1957,7 @@ static int bgp_attr_encap(uint8_t type, struct peer *peer, /* IN */
 				      + sublength);
 		tlv->type = subtype;
 		tlv->length = sublength;
-		stream_get(tlv->value, peer->ibuf, sublength);
+		stream_get(tlv->value, peer->curr, sublength);
 		length -= sublength;
 
 		/* attach tlv to encap chain */
@@ -2025,8 +2025,8 @@ bgp_attr_prefix_sid(struct bgp_attr_parser_args *args,
 
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_PREFIX_SID);
 
-	type = stream_getc(peer->ibuf);
-	length = stream_getw(peer->ibuf);
+	type = stream_getc(peer->curr);
+	length = stream_getw(peer->curr);
 
 	if (type == BGP_PREFIX_SID_LABEL_INDEX) {
 		if (length != BGP_PREFIX_SID_LABEL_INDEX_LENGTH) {
@@ -2039,11 +2039,11 @@ bgp_attr_prefix_sid(struct bgp_attr_parser_args *args,
 		}
 
 		/* Ignore flags and reserved */
-		stream_getc(peer->ibuf);
-		stream_getw(peer->ibuf);
+		stream_getc(peer->curr);
+		stream_getw(peer->curr);
 
 		/* Fetch the label index and see if it is valid. */
-		label_index = stream_getl(peer->ibuf);
+		label_index = stream_getl(peer->curr);
 		if (label_index == BGP_INVALID_LABEL_INDEX)
 			return bgp_attr_malformed(
 				args, BGP_NOTIFY_UPDATE_OPT_ATTR_ERR,
@@ -2074,16 +2074,16 @@ bgp_attr_prefix_sid(struct bgp_attr_parser_args *args,
 		}
 
 		/* Ignore reserved */
-		stream_getc(peer->ibuf);
-		stream_getw(peer->ibuf);
+		stream_getc(peer->curr);
+		stream_getw(peer->curr);
 
-		stream_get(&ipv6_sid, peer->ibuf, 16);
+		stream_get(&ipv6_sid, peer->curr, 16);
 	}
 
 	/* Placeholder code for the Originator SRGB type */
 	else if (type == BGP_PREFIX_SID_ORIGINATOR_SRGB) {
 		/* Ignore flags */
-		stream_getw(peer->ibuf);
+		stream_getw(peer->curr);
 
 		length -= 2;
 
@@ -2099,8 +2099,8 @@ bgp_attr_prefix_sid(struct bgp_attr_parser_args *args,
 		srgb_count = length / BGP_PREFIX_SID_ORIGINATOR_SRGB_LENGTH;
 
 		for (int i = 0; i < srgb_count; i++) {
-			stream_get(&srgb_base, peer->ibuf, 3);
-			stream_get(&srgb_range, peer->ibuf, 3);
+			stream_get(&srgb_base, peer->curr, 3);
+			stream_get(&srgb_range, peer->curr, 3);
 		}
 	}
 
@@ -2125,7 +2125,7 @@ static bgp_attr_parse_ret_t bgp_attr_unknown(struct bgp_attr_parser_args *args)
 			peer->host, type, length);
 
 	/* Forward read pointer of input stream. */
-	stream_forward_getp(peer->ibuf, length);
+	stream_forward_getp(peer->curr, length);
 
 	/* If any of the mandatory well-known attributes are not recognized,
 	   then the Error Subcode is set to Unrecognized Well-known

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -181,6 +181,8 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 		while (from_peer->ibuf->head)
 			stream_fifo_push(peer->ibuf,
 					 stream_fifo_pop(from_peer->ibuf));
+
+		stream_copy(peer->ibuf_work, from_peer->ibuf_work);
 	}
 	pthread_mutex_unlock(&from_peer->io_mtx);
 	pthread_mutex_unlock(&peer->io_mtx);

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -138,11 +138,11 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	BGP_TIMER_OFF(from_peer->t_connect);
 	BGP_TIMER_OFF(from_peer->t_connect_check);
 
-	// At this point in time, it is possible that there are packets pending
-	// on
-	// various buffers. Those need to be transferred or dropped, otherwise
-	// we'll
-	// get spurious failures during session establishment.
+	/*
+	 * At this point in time, it is possible that there are packets pending
+	 * on various buffers. Those need to be transferred or dropped,
+	 * otherwise we'll get spurious failures during session establishment.
+	 */
 	pthread_mutex_lock(&peer->io_mtx);
 	pthread_mutex_lock(&from_peer->io_mtx);
 	{
@@ -154,10 +154,11 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 		stream_fifo_clean(peer->obuf);
 		stream_reset(peer->ibuf_work);
 
-		// this should never happen, since bgp_process_packet() is the
-		// only task
-		// that sets and unsets the current packet and it runs in our
-		// pthread.
+		/*
+		 * this should never happen, since bgp_process_packet() is the
+		 * only task that sets and unsets the current packet and it
+		 * runs in our pthread.
+		 */
 		if (peer->curr) {
 			zlog_err(
 				"[%s] Dropping pending packet on connection transfer:",
@@ -1407,9 +1408,10 @@ int bgp_start(struct peer *peer)
 				 peer->fd);
 			return -1;
 		}
-		// when the socket becomes ready (or fails to connect),
-		// bgp_connect_check
-		// will be called.
+		/*
+		 * when the socket becomes ready (or fails to connect),
+		 * bgp_connect_check will be called.
+		 */
 		thread_add_read(bm->master, bgp_connect_check, peer, peer->fd,
 				&peer->t_connect_check);
 		break;
@@ -1898,13 +1900,13 @@ int bgp_event_update(struct peer *peer, int event)
 		if (next != peer->status) {
 			bgp_fsm_change_status(peer, next);
 
-			/* If we're going to ESTABLISHED then we executed a peer
-			 * transfer. In
-			 * this case we can either return FSM_PEER_TRANSITIONED
-			 * or
-			 * FSM_PEER_TRANSFERRED. Opting for TRANSFERRED since
-			 * transfer implies
-			 * session establishment. */
+			/*
+			 * If we're going to ESTABLISHED then we executed a
+			 * peer transfer. In this case we can either return
+			 * FSM_PEER_TRANSITIONED or FSM_PEER_TRANSFERRED.
+			 * Opting for TRANSFERRED since transfer implies
+			 * session establishment.
+			 */
 			if (ret != FSM_PEER_TRANSFERRED)
 				ret = FSM_PEER_TRANSITIONED;
 		}
@@ -1913,13 +1915,13 @@ int bgp_event_update(struct peer *peer, int event)
 		bgp_timer_set(peer);
 
 	} else {
-		/* If we got a return value of -1, that means there was an
-		 * error, restart
-		 * the FSM. Since bgp_stop() was called on the peer. only a few
-		 * fields
-		 * are safe to access here. In any case we need to indicate that
-		 * the peer
-		 * was stopped in the return code. */
+		/*
+		 * If we got a return value of -1, that means there was an
+		 * error, restart the FSM. Since bgp_stop() was called on the
+		 * peer. only a few fields are safe to access here. In any case
+		 * we need to indicate that the peer was stopped in the return
+		 * code.
+		 */
 		if (!dyn_nbr && !passive_conn && peer->bgp) {
 			zlog_err(
 				"%s [FSM] Failure handling event %s in state %s, "

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -49,6 +49,7 @@
 #include "bgpd/bgp_nht.h"
 #include "bgpd/bgp_bfd.h"
 #include "bgpd/bgp_memory.h"
+#include "bgpd/bgp_keepalives.h"
 
 DEFINE_HOOK(peer_backward_transition, (struct peer * peer), (peer))
 DEFINE_HOOK(peer_established, (struct peer * peer), (peer))
@@ -86,7 +87,6 @@ int bgp_event(struct thread *);
 static int bgp_start_timer(struct thread *);
 static int bgp_connect_timer(struct thread *);
 static int bgp_holdtime_timer(struct thread *);
-static int bgp_keepalive_timer(struct thread *);
 
 /* BGP FSM functions. */
 static int bgp_start(struct peer *);
@@ -253,7 +253,7 @@ void bgp_timer_set(struct peer *peer)
 		}
 		BGP_TIMER_OFF(peer->t_connect);
 		BGP_TIMER_OFF(peer->t_holdtime);
-		BGP_TIMER_OFF(peer->t_keepalive);
+		peer_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 
@@ -265,7 +265,7 @@ void bgp_timer_set(struct peer *peer)
 		BGP_TIMER_ON(peer->t_connect, bgp_connect_timer,
 			     peer->v_connect);
 		BGP_TIMER_OFF(peer->t_holdtime);
-		BGP_TIMER_OFF(peer->t_keepalive);
+		peer_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 
@@ -282,7 +282,7 @@ void bgp_timer_set(struct peer *peer)
 				     peer->v_connect);
 		}
 		BGP_TIMER_OFF(peer->t_holdtime);
-		BGP_TIMER_OFF(peer->t_keepalive);
+		peer_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 
@@ -296,7 +296,7 @@ void bgp_timer_set(struct peer *peer)
 		} else {
 			BGP_TIMER_OFF(peer->t_holdtime);
 		}
-		BGP_TIMER_OFF(peer->t_keepalive);
+		peer_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 
@@ -309,12 +309,11 @@ void bgp_timer_set(struct peer *peer)
 		   timer and KeepAlive timers are not started. */
 		if (peer->v_holdtime == 0) {
 			BGP_TIMER_OFF(peer->t_holdtime);
-			BGP_TIMER_OFF(peer->t_keepalive);
+			peer_keepalives_off(peer);
 		} else {
 			BGP_TIMER_ON(peer->t_holdtime, bgp_holdtime_timer,
 				     peer->v_holdtime);
-			BGP_TIMER_ON(peer->t_keepalive, bgp_keepalive_timer,
-				     peer->v_keepalive);
+			peer_keepalives_on(peer);
 		}
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
@@ -329,12 +328,11 @@ void bgp_timer_set(struct peer *peer)
 		   and keepalive must be turned off. */
 		if (peer->v_holdtime == 0) {
 			BGP_TIMER_OFF(peer->t_holdtime);
-			BGP_TIMER_OFF(peer->t_keepalive);
+			peer_keepalives_off(peer);
 		} else {
 			BGP_TIMER_ON(peer->t_holdtime, bgp_holdtime_timer,
 				     peer->v_holdtime);
-			BGP_TIMER_ON(peer->t_keepalive, bgp_keepalive_timer,
-				     peer->v_keepalive);
+			peer_keepalives_on(peer);
 		}
 		break;
 	case Deleted:
@@ -346,7 +344,7 @@ void bgp_timer_set(struct peer *peer)
 		BGP_TIMER_OFF(peer->t_start);
 		BGP_TIMER_OFF(peer->t_connect);
 		BGP_TIMER_OFF(peer->t_holdtime);
-		BGP_TIMER_OFF(peer->t_keepalive);
+		peer_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 	}
@@ -407,24 +405,6 @@ static int bgp_holdtime_timer(struct thread *thread)
 			   peer->host);
 
 	THREAD_VAL(thread) = Hold_Timer_expired;
-	bgp_event(thread); /* bgp_event unlocks peer */
-
-	return 0;
-}
-
-/* BGP keepalive fire ! */
-static int bgp_keepalive_timer(struct thread *thread)
-{
-	struct peer *peer;
-
-	peer = THREAD_ARG(thread);
-	peer->t_keepalive = NULL;
-
-	if (bgp_debug_neighbor_events(peer))
-		zlog_debug("%s [FSM] Timer (keepalive timer expire)",
-			   peer->host);
-
-	THREAD_VAL(thread) = KeepAlive_timer_expired;
 	bgp_event(thread); /* bgp_event unlocks peer */
 
 	return 0;
@@ -963,9 +943,6 @@ int bgp_stop(struct peer *peer)
 	char orf_name[BUFSIZ];
 	int ret = 0;
 
-	// immediately remove from threads
-	peer_writes_off(peer);
-
 	if (peer_dynamic_neighbor(peer)
 	    && !(CHECK_FLAG(peer->flags, PEER_FLAG_DELETE))) {
 		if (bgp_debug_neighbor_events(peer))
@@ -1053,7 +1030,7 @@ int bgp_stop(struct peer *peer)
 	BGP_TIMER_OFF(peer->t_start);
 	BGP_TIMER_OFF(peer->t_connect);
 	BGP_TIMER_OFF(peer->t_holdtime);
-	BGP_TIMER_OFF(peer->t_keepalive);
+	peer_keepalives_off(peer);
 	BGP_TIMER_OFF(peer->t_routeadv);
 
 	/* Stream reset. */
@@ -1398,13 +1375,6 @@ static int bgp_fsm_open(struct peer *peer)
 	/* Reset holdtimer value. */
 	BGP_TIMER_OFF(peer->t_holdtime);
 
-	return 0;
-}
-
-/* Keepalive send to peer. */
-static int bgp_fsm_keepalive_expire(struct peer *peer)
-{
-	bgp_keepalive_send(peer);
 	return 0;
 }
 
@@ -1761,9 +1731,8 @@ static const struct {
 		{bgp_stop, Clearing},      /* TCP_fatal_error              */
 		{bgp_stop, Clearing},      /* ConnectRetry_timer_expired   */
 		{bgp_fsm_holdtime_expire, Clearing}, /* Hold_Timer_expired */
-		{bgp_fsm_keepalive_expire,
-		 Established},	/* KeepAlive_timer_expired      */
-		{bgp_stop, Clearing}, /* Receive_OPEN_message         */
+		{bgp_ignore, Established}, /* KeepAlive_timer_expired      */
+		{bgp_stop, Clearing},      /* Receive_OPEN_message         */
 		{bgp_fsm_keepalive,
 		 Established}, /* Receive_KEEPALIVE_message    */
 		{bgp_fsm_update, Established}, /* Receive_UPDATE_message */

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -457,7 +457,7 @@ int bgp_routeadv_timer(struct thread *thread)
 
 	peer->synctime = bgp_clock();
 
-	thread_add_background(bm->master, bgp_generate_updgrp_packets, peer, 0,
+	thread_add_timer_msec(bm->master, bgp_generate_updgrp_packets, peer, 0,
 			      &peer->t_generate_updgrp_packets);
 
 	/* MRAI timer will be started again when FIFO is built, no need to
@@ -665,7 +665,7 @@ void bgp_adjust_routeadv(struct peer *peer)
 			BGP_TIMER_OFF(peer->t_routeadv);
 
 		peer->synctime = bgp_clock();
-		thread_add_background(bm->master, bgp_generate_updgrp_packets,
+		thread_add_timer_msec(bm->master, bgp_generate_updgrp_packets,
 				      peer, 0,
 				      &peer->t_generate_updgrp_packets);
 		return;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -285,7 +285,7 @@ void bgp_timer_set(struct peer *peer)
 		}
 		BGP_TIMER_OFF(peer->t_connect);
 		BGP_TIMER_OFF(peer->t_holdtime);
-		peer_keepalives_off(peer);
+		bgp_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 
@@ -297,7 +297,7 @@ void bgp_timer_set(struct peer *peer)
 		BGP_TIMER_ON(peer->t_connect, bgp_connect_timer,
 			     peer->v_connect);
 		BGP_TIMER_OFF(peer->t_holdtime);
-		peer_keepalives_off(peer);
+		bgp_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 
@@ -314,7 +314,7 @@ void bgp_timer_set(struct peer *peer)
 				     peer->v_connect);
 		}
 		BGP_TIMER_OFF(peer->t_holdtime);
-		peer_keepalives_off(peer);
+		bgp_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 
@@ -328,7 +328,7 @@ void bgp_timer_set(struct peer *peer)
 		} else {
 			BGP_TIMER_OFF(peer->t_holdtime);
 		}
-		peer_keepalives_off(peer);
+		bgp_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 
@@ -341,11 +341,11 @@ void bgp_timer_set(struct peer *peer)
 		   timer and KeepAlive timers are not started. */
 		if (peer->v_holdtime == 0) {
 			BGP_TIMER_OFF(peer->t_holdtime);
-			peer_keepalives_off(peer);
+			bgp_keepalives_off(peer);
 		} else {
 			BGP_TIMER_ON(peer->t_holdtime, bgp_holdtime_timer,
 				     peer->v_holdtime);
-			peer_keepalives_on(peer);
+			bgp_keepalives_on(peer);
 		}
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
@@ -360,11 +360,11 @@ void bgp_timer_set(struct peer *peer)
 		   and keepalive must be turned off. */
 		if (peer->v_holdtime == 0) {
 			BGP_TIMER_OFF(peer->t_holdtime);
-			peer_keepalives_off(peer);
+			bgp_keepalives_off(peer);
 		} else {
 			BGP_TIMER_ON(peer->t_holdtime, bgp_holdtime_timer,
 				     peer->v_holdtime);
-			peer_keepalives_on(peer);
+			bgp_keepalives_on(peer);
 		}
 		break;
 	case Deleted:
@@ -376,7 +376,7 @@ void bgp_timer_set(struct peer *peer)
 		BGP_TIMER_OFF(peer->t_start);
 		BGP_TIMER_OFF(peer->t_connect);
 		BGP_TIMER_OFF(peer->t_holdtime);
-		peer_keepalives_off(peer);
+		bgp_keepalives_off(peer);
 		BGP_TIMER_OFF(peer->t_routeadv);
 		break;
 	}
@@ -1065,7 +1065,7 @@ int bgp_stop(struct peer *peer)
 	}
 
 	/* stop keepalives */
-	peer_keepalives_off(peer);
+	bgp_keepalives_off(peer);
 
 	/* Stop read and write threads. */
 	bgp_writes_off(peer);

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -138,17 +138,22 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	from_peer->fd = fd;
 	stream_reset(peer->ibuf);
 
+	// At this point in time, it is possible that there are packets pending
+	// on
+	// from_peer->obuf. These need to be transferred to the new peer struct.
 	pthread_mutex_lock(&peer->obuf_mtx);
-	{
-		stream_fifo_clean(peer->obuf);
-	}
-	pthread_mutex_unlock(&peer->obuf_mtx);
-
 	pthread_mutex_lock(&from_peer->obuf_mtx);
 	{
-		stream_fifo_clean(from_peer->obuf);
+		// wipe new peer's packet queue
+		stream_fifo_clean(peer->obuf);
+
+		// copy each packet from old peer's queue to new peer's queue
+		while (from_peer->obuf->head)
+			stream_fifo_push(peer->obuf,
+					 stream_fifo_pop(from_peer->obuf));
 	}
 	pthread_mutex_unlock(&from_peer->obuf_mtx);
+	pthread_mutex_unlock(&peer->obuf_mtx);
 
 	peer->as = from_peer->as;
 	peer->v_holdtime = from_peer->v_holdtime;
@@ -1398,8 +1403,12 @@ static int bgp_fsm_holdtime_expire(struct peer *peer)
 	return bgp_stop_with_notify(peer, BGP_NOTIFY_HOLD_ERR, 0);
 }
 
-/* Status goes to Established.  Send keepalive packet then make first
-   update information. */
+/**
+ * Transition to Established state.
+ *
+ * Convert peer from stub to full fledged peer, set some timers, and generate
+ * initial updates.
+ */
 static int bgp_establish(struct peer *peer)
 {
 	afi_t afi;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1619,11 +1619,6 @@ static int bgp_establish(struct peer *peer)
 /* Keepalive packet is received. */
 static int bgp_fsm_keepalive(struct peer *peer)
 {
-	bgp_update_implicit_eors(peer);
-
-	/* peer count update */
-	peer->keepalive_in++;
-
 	BGP_TIMER_OFF(peer->t_holdtime);
 	return 0;
 }
@@ -1650,6 +1645,7 @@ static int bgp_ignore(struct peer *peer)
 /* This is to handle unexpected events.. */
 static int bgp_fsm_exeption(struct peer *peer)
 {
+	zlog_err("%s [FSM] cur_event: %d", peer->host, peer->cur_event);
 	zlog_err(
 		"%s [FSM] Unexpected event %s in state %s, prior events %s, %s, fd %d",
 		peer->host, bgp_event_str[peer->cur_event],
@@ -1864,6 +1860,9 @@ int bgp_event_update(struct peer *peer, int event)
 	int passive_conn = 0;
 	int dyn_nbr;
 
+	/* default return code */
+	ret = FSM_PEER_NOOP;
+
 	other = peer->doppelganger;
 	passive_conn =
 		(CHECK_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER)) ? 1 : 0;
@@ -1885,18 +1884,29 @@ int bgp_event_update(struct peer *peer, int event)
 	if (FSM[peer->status - 1][event - 1].func)
 		ret = (*(FSM[peer->status - 1][event - 1].func))(peer);
 
-	/* When function do not want proceed next job return -1. */
 	if (ret >= 0) {
 		if (ret == 1 && next == Established) {
 			/* The case when doppelganger swap accurred in
 			   bgp_establish.
 			   Update the peer pointer accordingly */
+			ret = FSM_PEER_TRANSFERRED;
 			peer = other;
 		}
 
 		/* If status is changed. */
-		if (next != peer->status)
+		if (next != peer->status) {
 			bgp_fsm_change_status(peer, next);
+
+			/* If we're going to ESTABLISHED then we executed a peer
+			 * transfer. In
+			 * this case we can either return FSM_PEER_TRANSITIONED
+			 * or
+			 * FSM_PEER_TRANSFERRED. Opting for TRANSFERRED since
+			 * transfer implies
+			 * session establishment. */
+			if (ret != FSM_PEER_TRANSFERRED)
+				ret = FSM_PEER_TRANSITIONED;
+		}
 
 		/* Make sure timer is set. */
 		bgp_timer_set(peer);

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -139,6 +139,7 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	BGP_TIMER_OFF(from_peer->t_connect);
 	BGP_TIMER_OFF(from_peer->t_connect_check_r);
 	BGP_TIMER_OFF(from_peer->t_connect_check_w);
+	BGP_TIMER_OFF(from_peer->t_process_packet);
 
 	/*
 	 * At this point in time, it is possible that there are packets pending
@@ -265,6 +266,8 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 
 	bgp_reads_on(peer);
 	bgp_writes_on(peer);
+	thread_add_timer_msec(bm->master, bgp_process_packet, peer, 0,
+			      &peer->t_process_packet);
 
 	if (from_peer)
 		peer_xfer_stats(peer, from_peer);

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1176,6 +1176,48 @@ static int bgp_stop_with_notify(struct peer *peer, u_char code, u_char sub_code)
 	return (bgp_stop(peer));
 }
 
+/**
+ * Determines whether a TCP session has successfully established for a peer and
+ * events as appropriate.
+ *
+ * This function is called when setting up a new session. After connect() is
+ * called on the peer's socket (in bgp_start()), the fd is passed to select()
+ * to wait for connection success or failure. When select() returns, this
+ * function is called to evaluate the result.
+ */
+static int bgp_connect_check(struct thread *thread)
+{
+	int status;
+	socklen_t slen;
+	int ret;
+	struct peer *peer;
+
+	peer = THREAD_ARG(thread);
+
+	/* Check file descriptor. */
+	slen = sizeof(status);
+	ret = getsockopt(peer->fd, SOL_SOCKET, SO_ERROR, (void *)&status,
+			 &slen);
+
+	/* If getsockopt is fail, this is fatal error. */
+	if (ret < 0) {
+		zlog_info("can't get sockopt for nonblocking connect");
+		BGP_EVENT_ADD(peer, TCP_fatal_error);
+		return -1;
+	}
+
+	/* When status is 0 then TCP connection is established. */
+	if (status == 0) {
+		BGP_EVENT_ADD(peer, TCP_connection_open);
+		return 1;
+	} else {
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("%s [Event] Connect failed (%s)", peer->host,
+				   safe_strerror(errno));
+		BGP_EVENT_ADD(peer, TCP_connection_open_failed);
+		return 0;
+	}
+}
 
 /* TCP connection open.  Next we send open message to remote peer. And
    add read thread for reading open message. */
@@ -1329,8 +1371,10 @@ int bgp_start(struct peer *peer)
 				 peer->fd);
 			return -1;
 		}
-		BGP_READ_ON(peer->t_read, bgp_read, peer->fd);
-		peer_writes_on(peer);
+		// when the socket becomes ready (or fails to connect),
+		// bgp_connect_check
+		// will be called.
+		thread_add_read(bm->master, bgp_connect_check, peer, peer->fd);
 		break;
 	}
 	return 0;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1176,6 +1176,10 @@ static int bgp_connect_check(struct thread *thread)
 
 	peer = THREAD_ARG(thread);
 
+	/* This value needs to be unset in order for bgp_read() to be scheduled
+	 */
+	BGP_READ_OFF(peer->t_read);
+
 	/* Check file descriptor. */
 	slen = sizeof(status);
 	ret = getsockopt(peer->fd, SOL_SOCKET, SO_ERROR, (void *)&status,
@@ -1356,7 +1360,7 @@ int bgp_start(struct peer *peer)
 		// when the socket becomes ready (or fails to connect),
 		// bgp_connect_check
 		// will be called.
-		thread_add_read(bm->master, bgp_connect_check, peer, peer->fd);
+		BGP_READ_ON(peer->t_read, bgp_connect_check, peer->fd);
 		break;
 	}
 	return 0;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -360,11 +360,9 @@ void bgp_timer_set(struct peer *peer)
 		   and keepalive must be turned off. */
 		if (peer->v_holdtime == 0) {
 			BGP_TIMER_OFF(peer->t_holdtime);
-			bgp_keepalives_off(peer);
 		} else {
 			BGP_TIMER_ON(peer->t_holdtime, bgp_holdtime_timer,
 				     peer->v_holdtime);
-			bgp_keepalives_on(peer);
 		}
 		break;
 	case Deleted:
@@ -1553,7 +1551,10 @@ static int bgp_establish(struct peer *peer)
 
 	hook_call(peer_established, peer);
 
-	/* Reset uptime, send keepalive, send current table. */
+	/* Reset uptime, turn on keepalives, send current table. */
+	if (!peer->v_holdtime)
+		bgp_keepalives_on(peer);
+
 	peer->uptime = bgp_clock();
 
 	/* Send route-refresh when ORF is enabled */

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -50,6 +50,7 @@
 #include "bgpd/bgp_bfd.h"
 #include "bgpd/bgp_memory.h"
 #include "bgpd/bgp_keepalives.h"
+#include "bgpd/bgp_io.h"
 
 DEFINE_HOOK(peer_backward_transition, (struct peer * peer), (peer))
 DEFINE_HOOK(peer_established, (struct peer * peer), (peer))
@@ -1037,6 +1038,7 @@ int bgp_stop(struct peer *peer)
 	BGP_TIMER_OFF(peer->t_holdtime);
 	peer_keepalives_off(peer);
 	BGP_TIMER_OFF(peer->t_routeadv);
+	BGP_TIMER_OFF(peer->t_generate_updgrp_packets);
 
 	/* Stream reset. */
 	peer->packet_size = 0;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -126,35 +126,61 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 			   from_peer->host, from_peer, from_peer->fd, peer,
 			   peer->fd);
 
-	peer_writes_off(peer);
-	BGP_READ_OFF(peer->t_read);
-	peer_writes_off(from_peer);
-	BGP_READ_OFF(from_peer->t_read);
+	bgp_writes_off(peer);
+	bgp_reads_off(peer);
+	bgp_writes_off(from_peer);
+	bgp_reads_off(from_peer);
 
 	BGP_TIMER_OFF(peer->t_routeadv);
+	BGP_TIMER_OFF(peer->t_connect);
+	BGP_TIMER_OFF(peer->t_connect_check);
 	BGP_TIMER_OFF(from_peer->t_routeadv);
-
-	fd = peer->fd;
-	peer->fd = from_peer->fd;
-	from_peer->fd = fd;
-	stream_reset(peer->ibuf);
+	BGP_TIMER_OFF(from_peer->t_connect);
+	BGP_TIMER_OFF(from_peer->t_connect_check);
 
 	// At this point in time, it is possible that there are packets pending
 	// on
-	// from_peer->obuf. These need to be transferred to the new peer struct.
-	pthread_mutex_lock(&peer->obuf_mtx);
-	pthread_mutex_lock(&from_peer->obuf_mtx);
+	// various buffers. Those need to be transferred or dropped, otherwise
+	// we'll
+	// get spurious failures during session establishment.
+	pthread_mutex_lock(&peer->io_mtx);
+	pthread_mutex_lock(&from_peer->io_mtx);
 	{
-		// wipe new peer's packet queue
-		stream_fifo_clean(peer->obuf);
+		fd = peer->fd;
+		peer->fd = from_peer->fd;
+		from_peer->fd = fd;
 
-		// copy each packet from old peer's queue to new peer's queue
+		stream_fifo_clean(peer->ibuf);
+		stream_fifo_clean(peer->obuf);
+		stream_reset(peer->ibuf_work);
+
+		// this should never happen, since bgp_process_packet() is the
+		// only task
+		// that sets and unsets the current packet and it runs in our
+		// pthread.
+		if (peer->curr) {
+			zlog_err(
+				"[%s] Dropping pending packet on connection transfer:",
+				peer->host);
+			u_int16_t type = stream_getc_from(peer->curr,
+							  BGP_MARKER_SIZE + 2);
+			bgp_dump_packet(peer, type, peer->curr);
+			stream_free(peer->curr);
+			peer->curr = NULL;
+		}
+
+		// copy each packet from old peer's output queue to new peer
 		while (from_peer->obuf->head)
 			stream_fifo_push(peer->obuf,
 					 stream_fifo_pop(from_peer->obuf));
+
+		// copy each packet from old peer's input queue to new peer
+		while (from_peer->ibuf->head)
+			stream_fifo_push(peer->ibuf,
+					 stream_fifo_pop(from_peer->ibuf));
 	}
-	pthread_mutex_unlock(&from_peer->obuf_mtx);
-	pthread_mutex_unlock(&peer->obuf_mtx);
+	pthread_mutex_unlock(&from_peer->io_mtx);
+	pthread_mutex_unlock(&peer->io_mtx);
 
 	peer->as = from_peer->as;
 	peer->v_holdtime = from_peer->v_holdtime;
@@ -232,8 +258,8 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 		}
 	}
 
-	BGP_READ_ON(peer->t_read, bgp_read, peer->fd);
-	peer_writes_on(peer);
+	bgp_reads_on(peer);
+	bgp_writes_on(peer);
 
 	if (from_peer)
 		peer_xfer_stats(peer, from_peer);
@@ -381,6 +407,10 @@ static int bgp_connect_timer(struct thread *thread)
 	int ret;
 
 	peer = THREAD_ARG(thread);
+
+	assert(!peer->t_write);
+	assert(!peer->t_read);
+
 	peer->t_connect = NULL;
 
 	if (bgp_debug_neighbor_events(peer))
@@ -428,6 +458,9 @@ int bgp_routeadv_timer(struct thread *thread)
 			   peer->host);
 
 	peer->synctime = bgp_clock();
+
+	thread_add_background(bm->master, bgp_generate_updgrp_packets, peer, 0,
+			      &peer->t_generate_updgrp_packets);
 
 	/* MRAI timer will be started again when FIFO is built, no need to
 	 * do it here.
@@ -634,6 +667,9 @@ void bgp_adjust_routeadv(struct peer *peer)
 			BGP_TIMER_OFF(peer->t_routeadv);
 
 		peer->synctime = bgp_clock();
+		thread_add_background(bm->master, bgp_generate_updgrp_packets,
+				      peer, 0,
+				      &peer->t_generate_updgrp_packets);
 		return;
 	}
 
@@ -1028,33 +1064,40 @@ int bgp_stop(struct peer *peer)
 		bgp_bfd_deregister_peer(peer);
 	}
 
-	/* Stop read and write threads when exists. */
-	BGP_READ_OFF(peer->t_read);
-	peer_writes_off(peer);
+	/* stop keepalives */
+	peer_keepalives_off(peer);
+
+	/* Stop read and write threads. */
+	bgp_writes_off(peer);
+	bgp_reads_off(peer);
+
+	THREAD_OFF(peer->t_connect_check);
 
 	/* Stop all timers. */
 	BGP_TIMER_OFF(peer->t_start);
 	BGP_TIMER_OFF(peer->t_connect);
 	BGP_TIMER_OFF(peer->t_holdtime);
-	peer_keepalives_off(peer);
 	BGP_TIMER_OFF(peer->t_routeadv);
-	BGP_TIMER_OFF(peer->t_generate_updgrp_packets);
-
-	/* Stream reset. */
-	peer->packet_size = 0;
 
 	/* Clear input and output buffer.  */
-	if (peer->ibuf)
-		stream_reset(peer->ibuf);
-	if (peer->work)
-		stream_reset(peer->work);
-
-	pthread_mutex_lock(&peer->obuf_mtx);
+	pthread_mutex_lock(&peer->io_mtx);
 	{
+		if (peer->ibuf)
+			stream_fifo_clean(peer->ibuf);
 		if (peer->obuf)
 			stream_fifo_clean(peer->obuf);
+
+		if (peer->ibuf_work)
+			stream_reset(peer->ibuf_work);
+		if (peer->obuf_work)
+			stream_reset(peer->obuf_work);
+
+		if (peer->curr) {
+			stream_free(peer->curr);
+			peer->curr = NULL;
+		}
 	}
-	pthread_mutex_unlock(&peer->obuf_mtx);
+	pthread_mutex_unlock(&peer->io_mtx);
 
 	/* Close of file descriptor. */
 	if (peer->fd >= 0) {
@@ -1177,10 +1220,12 @@ static int bgp_connect_check(struct thread *thread)
 	struct peer *peer;
 
 	peer = THREAD_ARG(thread);
+	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_READS_ON));
+	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON));
+	assert(!peer->t_read);
+	assert(!peer->t_write);
 
-	/* This value needs to be unset in order for bgp_read() to be scheduled
-	 */
-	BGP_READ_OFF(peer->t_read);
+	peer->t_connect_check = NULL;
 
 	/* Check file descriptor. */
 	slen = sizeof(status);
@@ -1218,17 +1263,16 @@ static int bgp_connect_success(struct peer *peer)
 		return -1;
 	}
 
-	peer_writes_on(peer);
-
 	if (bgp_getsockname(peer) < 0) {
 		zlog_err("%s: bgp_getsockname(): failed for peer %s, fd %d",
 			 __FUNCTION__, peer->host, peer->fd);
 		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR,
 				0); /* internal error */
+		bgp_writes_on(peer);
 		return -1;
 	}
 
-	BGP_READ_ON(peer->t_read, bgp_read, peer->fd);
+	bgp_reads_on(peer);
 
 	if (bgp_debug_neighbor_events(peer)) {
 		char buf1[SU_ADDRSTRLEN];
@@ -1332,6 +1376,10 @@ int bgp_start(struct peer *peer)
 #endif
 	}
 
+	assert(!peer->t_write);
+	assert(!peer->t_read);
+	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON));
+	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_READS_ON));
 	status = bgp_connect(peer);
 
 	switch (status) {
@@ -1362,7 +1410,8 @@ int bgp_start(struct peer *peer)
 		// when the socket becomes ready (or fails to connect),
 		// bgp_connect_check
 		// will be called.
-		BGP_READ_ON(peer->t_read, bgp_connect_check, peer->fd);
+		thread_add_read(bm->master, bgp_connect_check, peer, peer->fd,
+				&peer->t_connect_check);
 		break;
 	}
 	return 0;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -125,9 +125,9 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 			   from_peer->host, from_peer, from_peer->fd, peer,
 			   peer->fd);
 
-	BGP_WRITE_OFF(peer->t_write);
+	peer_writes_off(peer);
 	BGP_READ_OFF(peer->t_read);
-	BGP_WRITE_OFF(from_peer->t_write);
+	peer_writes_off(from_peer);
 	BGP_READ_OFF(from_peer->t_read);
 
 	BGP_TIMER_OFF(peer->t_routeadv);
@@ -137,8 +137,18 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	peer->fd = from_peer->fd;
 	from_peer->fd = fd;
 	stream_reset(peer->ibuf);
-	stream_fifo_clean(peer->obuf);
-	stream_fifo_clean(from_peer->obuf);
+
+	pthread_mutex_lock(&peer->obuf_mtx);
+	{
+		stream_fifo_clean(peer->obuf);
+	}
+	pthread_mutex_unlock(&peer->obuf_mtx);
+
+	pthread_mutex_lock(&from_peer->obuf_mtx);
+	{
+		stream_fifo_clean(from_peer->obuf);
+	}
+	pthread_mutex_unlock(&from_peer->obuf_mtx);
 
 	peer->as = from_peer->as;
 	peer->v_holdtime = from_peer->v_holdtime;
@@ -217,7 +227,7 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	}
 
 	BGP_READ_ON(peer->t_read, bgp_read, peer->fd);
-	BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
+	peer_writes_on(peer);
 
 	if (from_peer)
 		peer_xfer_stats(peer, from_peer);
@@ -433,8 +443,6 @@ int bgp_routeadv_timer(struct thread *thread)
 
 	peer->synctime = bgp_clock();
 
-	BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
-
 	/* MRAI timer will be started again when FIFO is built, no need to
 	 * do it here.
 	 */
@@ -640,7 +648,6 @@ void bgp_adjust_routeadv(struct peer *peer)
 			BGP_TIMER_OFF(peer->t_routeadv);
 
 		peer->synctime = bgp_clock();
-		BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
 		return;
 	}
 
@@ -956,6 +963,9 @@ int bgp_stop(struct peer *peer)
 	char orf_name[BUFSIZ];
 	int ret = 0;
 
+	// immediately remove from threads
+	peer_writes_off(peer);
+
 	if (peer_dynamic_neighbor(peer)
 	    && !(CHECK_FLAG(peer->flags, PEER_FLAG_DELETE))) {
 		if (bgp_debug_neighbor_events(peer))
@@ -1037,7 +1047,7 @@ int bgp_stop(struct peer *peer)
 
 	/* Stop read and write threads when exists. */
 	BGP_READ_OFF(peer->t_read);
-	BGP_WRITE_OFF(peer->t_write);
+	peer_writes_off(peer);
 
 	/* Stop all timers. */
 	BGP_TIMER_OFF(peer->t_start);
@@ -1054,8 +1064,13 @@ int bgp_stop(struct peer *peer)
 		stream_reset(peer->ibuf);
 	if (peer->work)
 		stream_reset(peer->work);
-	if (peer->obuf)
-		stream_fifo_clean(peer->obuf);
+
+	pthread_mutex_lock(&peer->obuf_mtx);
+	{
+		if (peer->obuf)
+			stream_fifo_clean(peer->obuf);
+	}
+	pthread_mutex_unlock(&peer->obuf_mtx);
 
 	/* Close of file descriptor. */
 	if (peer->fd >= 0) {
@@ -1172,6 +1187,8 @@ static int bgp_connect_success(struct peer *peer)
 		bgp_stop(peer);
 		return -1;
 	}
+
+	peer_writes_on(peer);
 
 	if (bgp_getsockname(peer) < 0) {
 		zlog_err("%s: bgp_getsockname(): failed for peer %s, fd %d",
@@ -1313,7 +1330,7 @@ int bgp_start(struct peer *peer)
 			return -1;
 		}
 		BGP_READ_ON(peer->t_read, bgp_read, peer->fd);
-		BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
+		peer_writes_on(peer);
 		break;
 	}
 	return 0;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -360,9 +360,11 @@ void bgp_timer_set(struct peer *peer)
 		   and keepalive must be turned off. */
 		if (peer->v_holdtime == 0) {
 			BGP_TIMER_OFF(peer->t_holdtime);
+			bgp_keepalives_off(peer);
 		} else {
 			BGP_TIMER_ON(peer->t_holdtime, bgp_holdtime_timer,
 				     peer->v_holdtime);
+			bgp_keepalives_on(peer);
 		}
 		break;
 	case Deleted:
@@ -1645,7 +1647,6 @@ static int bgp_ignore(struct peer *peer)
 /* This is to handle unexpected events.. */
 static int bgp_fsm_exeption(struct peer *peer)
 {
-	zlog_err("%s [FSM] cur_event: %d", peer->host, peer->cur_event);
 	zlog_err(
 		"%s [FSM] Unexpected event %s in state %s, prior events %s, %s, fd %d",
 		peer->host, bgp_event_str[peer->cur_event],
@@ -1911,21 +1912,29 @@ int bgp_event_update(struct peer *peer, int event)
 		/* Make sure timer is set. */
 		bgp_timer_set(peer);
 
-	} else if (!dyn_nbr && !passive_conn && peer->bgp) {
+	} else {
 		/* If we got a return value of -1, that means there was an
 		 * error, restart
-		 * the FSM. If the peer structure was deleted
-		 */
-		zlog_err(
-			"%s [FSM] Failure handling event %s in state %s, "
-			"prior events %s, %s, fd %d",
-			peer->host, bgp_event_str[peer->cur_event],
-			lookup_msg(bgp_status_msg, peer->status, NULL),
-			bgp_event_str[peer->last_event],
-			bgp_event_str[peer->last_major_event], peer->fd);
-		bgp_stop(peer);
-		bgp_fsm_change_status(peer, Idle);
-		bgp_timer_set(peer);
+		 * the FSM. Since bgp_stop() was called on the peer. only a few
+		 * fields
+		 * are safe to access here. In any case we need to indicate that
+		 * the peer
+		 * was stopped in the return code. */
+		if (!dyn_nbr && !passive_conn && peer->bgp) {
+			zlog_err(
+				"%s [FSM] Failure handling event %s in state %s, "
+				"prior events %s, %s, fd %d",
+				peer->host, bgp_event_str[peer->cur_event],
+				lookup_msg(bgp_status_msg, peer->status, NULL),
+				bgp_event_str[peer->last_event],
+				bgp_event_str[peer->last_major_event],
+				peer->fd);
+			bgp_stop(peer);
+			bgp_fsm_change_status(peer, Idle);
+			bgp_timer_set(peer);
+		}
+		ret = FSM_PEER_STOPPED;
 	}
+
 	return ret;
 }

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -50,6 +50,12 @@
 
 #define BGP_MSEC_JITTER 10
 
+/* Status codes for bgp_event_update() */
+#define FSM_PEER_NOOP           0
+#define FSM_PEER_STOPPED        1
+#define FSM_PEER_TRANSFERRED    2
+#define FSM_PEER_TRANSITIONED   3
+
 /* Prototypes. */
 extern void bgp_fsm_nht_update(struct peer *, int valid);
 extern int bgp_event(struct thread *);

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -23,24 +23,6 @@
 #define _QUAGGA_BGP_FSM_H
 
 /* Macro for BGP read, write and timer thread.  */
-#define BGP_READ_ON(T, F, V)                                                   \
-	do {                                                                   \
-		if ((peer->status != Deleted))                                 \
-			thread_add_read(bm->master, (F), peer, (V), &(T));     \
-	} while (0)
-
-#define BGP_READ_OFF(T)                                                        \
-	do {                                                                   \
-		if (T)                                                         \
-			THREAD_READ_OFF(T);                                    \
-	} while (0)
-
-#define BGP_WRITE_OFF(T)                                                       \
-	do {                                                                   \
-		if (T)                                                         \
-			THREAD_WRITE_OFF(T);                                   \
-	} while (0)
-
 #define BGP_TIMER_ON(T, F, V)                                                  \
 	do {                                                                   \
 		if ((peer->status != Deleted))                                 \

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -35,18 +35,6 @@
 			THREAD_READ_OFF(T);                                    \
 	} while (0)
 
-#define BGP_WRITE_ON(T, F, V)                                                  \
-	do {                                                                   \
-		if ((peer)->status != Deleted)                                 \
-			thread_add_write(bm->master, (F), (peer), (V), &(T));  \
-	} while (0)
-
-#define BGP_PEER_WRITE_ON(T, F, V, peer)                                       \
-	do {                                                                   \
-		if ((peer)->status != Deleted)                                 \
-			thread_add_write(bm->master, (F), (peer), (V), &(T));  \
-	} while (0)
-
 #define BGP_WRITE_OFF(T)                                                       \
 	do {                                                                   \
 		if (T)                                                         \

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -18,24 +18,24 @@
  * MA 02110-1301 USA
  */
 
-#include <zebra.h>
-#include <sys/time.h>
 #include <pthread.h>
+#include <sys/time.h>
+#include <zebra.h>
 
-#include "thread.h"
 #include "hash.h"
-#include "stream.h"
-#include "memory.h"
 #include "log.h"
+#include "memory.h"
 #include "monotime.h"
 #include "network.h"
 #include "pqueue.h"
+#include "stream.h"
+#include "thread.h"
 
-#include "bgpd/bgpd.h"
-#include "bgpd/bgp_io.h"
 #include "bgpd/bgp_debug.h"
-#include "bgpd/bgp_packet.h"
 #include "bgpd/bgp_fsm.h"
+#include "bgpd/bgp_io.h"
+#include "bgpd/bgp_packet.h"
+#include "bgpd/bgpd.h"
 
 /* forward declarations */
 static uint16_t bgp_write(struct peer *);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -344,8 +344,8 @@ static int bgp_process_reads(struct thread *thread)
 		thread_add_read(fpt->master, bgp_process_reads, peer, peer->fd,
 				&peer->t_read);
 		if (added_pkt)
-			thread_add_event(bm->master, bgp_process_packet, peer,
-					 0, NULL);
+			thread_add_timer_msec(bm->master, bgp_process_packet,
+					      peer, 0, &peer->t_process_packet);
 	}
 
 	return 0;

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -185,7 +185,6 @@ void bgp_reads_off(struct peer *peer)
 
 /**
  * Called from I/O pthread when a file descriptor has become ready for writing.
- * HUP is not handled here,
  */
 static int bgp_process_writes(struct thread *thread)
 {
@@ -318,7 +317,8 @@ static int bgp_process_reads(struct thread *thread)
 			break;
 	}
 
-	/* After reading:
+	/*
+	 * After reading:
 	 * 1. Move unread data to stream start to make room for more.
 	 * 2. Reschedule and return when we have additional data.
 	 *
@@ -421,9 +421,7 @@ static uint16_t bgp_write(struct peer *peer)
 				peer->v_start = (60 * 2);
 
 			/* Handle Graceful Restart case where the state changes
-			   to
-			   Connect instead of Idle */
-			/* Flush any existing events */
+			 * to Connect instead of Idle */
 			BGP_EVENT_ADD(peer, BGP_Stop);
 			goto done;
 
@@ -531,7 +529,7 @@ static uint16_t bgp_read(struct peer *peer)
  */
 static bool validate_header(struct peer *peer)
 {
-	u_int16_t size, type;
+	uint16_t size, type;
 	struct stream *pkt = peer->ibuf_work;
 	size_t getp = stream_get_getp(pkt);
 
@@ -580,7 +578,6 @@ static bool validate_header(struct peer *peer)
 	    || (type == BGP_MSG_CAPABILITY
 		&& size < BGP_MSG_CAPABILITY_MIN_SIZE)) {
 		if (bgp_debug_neighbor_events(peer)) {
-			// XXX: zlog is not MT-safe
 			zlog_debug("%s bad message length - %d for %s",
 				   peer->host, size,
 				   type == 128 ? "ROUTE-REFRESH"

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -522,13 +522,15 @@ static bool validate_header(struct peer *peer)
 {
 	u_int16_t size, type;
 
-	/* Marker check */
-	for (int i = 0; i < BGP_MARKER_SIZE; i++)
-		if (peer->ibuf_work->data[i] != 0xff) {
-			bgp_notify_send(peer, BGP_NOTIFY_HEADER_ERR,
-					BGP_NOTIFY_HEADER_NOT_SYNC);
-			return false;
-		}
+	static uint8_t marker[BGP_MARKER_SIZE] = {
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+	if (memcmp(marker, peer->ibuf_work->data, BGP_MARKER_SIZE) != 0) {
+		bgp_notify_send(peer, BGP_NOTIFY_HEADER_ERR,
+				BGP_NOTIFY_HEADER_NOT_SYNC);
+		return false;
+	}
 
 	/* Get size and type. */
 	size = stream_getw_from(peer->ibuf_work, BGP_MARKER_SIZE);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -120,7 +120,8 @@ void bgp_writes_on(struct peer *peer)
 	assert(peer->obuf);
 	assert(peer->ibuf);
 	assert(peer->ibuf_work);
-	assert(!peer->t_connect_check);
+	assert(!peer->t_connect_check_r);
+	assert(!peer->t_connect_check_w);
 	assert(peer->fd);
 
 	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);
@@ -156,7 +157,8 @@ void bgp_reads_on(struct peer *peer)
 	assert(peer->ibuf_work);
 	assert(stream_get_endp(peer->ibuf_work) == 0);
 	assert(peer->obuf);
-	assert(!peer->t_connect_check);
+	assert(!peer->t_connect_check_r);
+	assert(!peer->t_connect_check_w);
 	assert(peer->fd);
 
 	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -18,24 +18,23 @@
  * MA 02110-1301 USA
  */
 
-#include <pthread.h>
-#include <sys/time.h>
 #include <zebra.h>
+#include <pthread.h> // for pthread_mutex_unlock, pthread_mutex_lock
 
-#include "hash.h"
-#include "log.h"
-#include "memory.h"
-#include "monotime.h"
-#include "network.h"
-#include "pqueue.h"
-#include "stream.h"
-#include "thread.h"
+#include "frr_pthread.h" // for frr_pthread_get, frr_pthread
+#include "linklist.h"    // for list_delete, list_delete_all_node, lis...
+#include "log.h"	 // for zlog_debug, safe_strerror, zlog_err
+#include "memory.h"      // for MTYPE_TMP, XCALLOC, XFREE
+#include "network.h"     // for ERRNO_IO_RETRY
+#include "stream.h"      // for stream_get_endp, stream_getw_from, str...
+#include "thread.h"      // for THREAD_OFF, THREAD_ARG, thread, thread...
+#include "zassert.h"     // for assert
 
-#include "bgpd/bgp_debug.h"
-#include "bgpd/bgp_fsm.h"
 #include "bgpd/bgp_io.h"
-#include "bgpd/bgp_packet.h"
-#include "bgpd/bgpd.h"
+#include "bgpd/bgp_debug.h"  // for bgp_debug_neighbor_events, bgp_type_str
+#include "bgpd/bgp_fsm.h"    // for BGP_EVENT_ADD, bgp_event
+#include "bgpd/bgp_packet.h" // for bgp_notify_send_with_data, bgp_notify...
+#include "bgpd/bgpd.h"       // for peer, BGP_MARKER_SIZE, bgp_master, bm
 
 /* forward declarations */
 static uint16_t bgp_write(struct peer *);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -155,7 +155,6 @@ void bgp_reads_on(struct peer *peer)
 	assert(peer->ibuf);
 	assert(peer->fd);
 	assert(peer->ibuf_work);
-	assert(stream_get_endp(peer->ibuf_work) == 0);
 	assert(peer->obuf);
 	assert(!peer->t_connect_check_r);
 	assert(!peer->t_connect_check_w);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -218,12 +218,9 @@ static int bgp_process_writes(struct thread *thread)
 	if (reschedule) {
 		thread_add_write(fpt->master, bgp_process_writes, peer,
 				 peer->fd, &peer->t_write);
-	}
-
-	if (!fatal) {
-		thread_add_timer_msec(bm->master, bgp_generate_updgrp_packets,
-				      peer, 0,
-				      &peer->t_generate_updgrp_packets);
+	} else if (!fatal) {
+		BGP_TIMER_ON(peer->t_generate_updgrp_packets,
+			     bgp_generate_updgrp_packets, 0);
 	}
 
 	return 0;

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -1,8 +1,10 @@
 /*
   BGP I/O.
-  Implements a consumer thread to flush packets destined for remote peers.
 
+  Implements packet I/O in a consumer pthread.
+  --------------------------------------------
   Copyright (C) 2017  Cumulus Networks
+  Quentin Young
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -31,7 +33,7 @@
 #include "log.h"
 #include "monotime.h"
 #include "network.h"
-#include "frr_pthread.h"
+#include "pqueue.h"
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_io.h"
@@ -39,172 +41,278 @@
 #include "bgpd/bgp_packet.h"
 #include "bgpd/bgp_fsm.h"
 
-static int bgp_write(struct peer *);
-static void peer_process_writes(struct hash_backet *, void *);
+/* forward declarations */
+static uint16_t bgp_write(struct peer *);
+static uint16_t bgp_read(struct peer *);
+static int bgp_process_writes(struct thread *);
+static int bgp_process_reads(struct thread *);
+static bool validate_header(struct peer *);
 
-bool bgp_packet_writes_thread_run = false;
+/* generic i/o status codes */
+#define BGP_IO_TRANS_ERR        (1 << 1) // EAGAIN or similar occurred
+#define BGP_IO_FATAL_ERR        (1 << 2) // some kind of fatal TCP error
 
-/* Hash table of peers to operate on, associated synchronization primitives and
- * hash table callbacks.
+/* bgp_read() status codes */
+#define BGP_IO_READ_HEADER      (1 << 3) // when read a full packet header
+#define BGP_IO_READ_FULLPACKET  (1 << 4) // read a full packet
+
+/* Start and stop routines for I/O pthread + control variables
  * ------------------------------------------------------------------------ */
-static struct hash *peerhash;
-/* Mutex to protect hash table */
-static pthread_mutex_t *peerhash_mtx;
-/* Condition variable used to notify the write thread that there is work to do
- */
-static pthread_cond_t *write_cond;
+bool bgp_packet_write_thread_run = false;
+pthread_mutex_t *work_mtx;
 
-static unsigned int peer_hash_key_make(void *p)
+static struct list *read_cancel;
+static struct list *write_cancel;
+
+void bgp_io_init()
 {
-	struct peer *peer = p;
-	return sockunion_hash(&peer->su);
+	work_mtx = XCALLOC(MTYPE_TMP, sizeof(pthread_mutex_t));
+	pthread_mutex_init(work_mtx, NULL);
+
+	read_cancel = list_new();
+	write_cancel = list_new();
 }
 
-static int peer_hash_cmp(const void *p1, const void *p2)
+void *bgp_io_start(void *arg)
 {
-	const struct peer *peer1 = p1;
-	const struct peer *peer2 = p2;
-	return (sockunion_same(&peer1->su, &peer2->su)
-		&& CHECK_FLAG(peer1->flags, PEER_FLAG_CONFIG_NODE)
-			   == CHECK_FLAG(peer2->flags, PEER_FLAG_CONFIG_NODE));
-}
-/* ------------------------------------------------------------------------ */
+	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);
 
-void peer_writes_init(void)
-{
-	peerhash_mtx = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_mutex_t));
-	write_cond = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_cond_t));
+	// we definitely don't want to handle signals
+	fpt->master->handle_signals = false;
 
-	// initialize mutex
-	pthread_mutex_init(peerhash_mtx, NULL);
+	bgp_packet_write_thread_run = true;
+	struct thread task;
 
-	// use monotonic clock with condition variable
-	pthread_condattr_t attrs;
-	pthread_condattr_init(&attrs);
-	pthread_condattr_setclock(&attrs, CLOCK_MONOTONIC);
-	pthread_cond_init(write_cond, &attrs);
-	pthread_condattr_destroy(&attrs);
+	while (bgp_packet_write_thread_run) {
+		if (thread_fetch(fpt->master, &task)) {
+			pthread_mutex_lock(work_mtx);
+			{
+				bool cancel = false;
+				struct peer *peer = THREAD_ARG(&task);
+				if ((task.func == bgp_process_reads
+				     && listnode_lookup(read_cancel, peer))
+				    || (task.func == bgp_process_writes
+					&& listnode_lookup(write_cancel, peer)))
+					cancel = true;
 
-	// initialize peerhash
-	peerhash = hash_create_size(2048, peer_hash_key_make, peer_hash_cmp);
-}
+				list_delete_all_node(write_cancel);
+				list_delete_all_node(read_cancel);
 
-static void peer_writes_finish(void *arg)
-{
-	bgp_packet_writes_thread_run = false;
-
-	if (peerhash)
-		hash_free(peerhash);
-
-	peerhash = NULL;
-
-	pthread_mutex_unlock(peerhash_mtx);
-	pthread_mutex_destroy(peerhash_mtx);
-	pthread_cond_destroy(write_cond);
-
-	XFREE(MTYPE_PTHREAD, peerhash_mtx);
-	XFREE(MTYPE_PTHREAD, write_cond);
-}
-
-void *peer_writes_start(void *arg)
-{
-	struct timeval currtime = {0, 0};
-	struct timeval sleeptime = {0, 500};
-	struct timespec next_update = {0, 0};
-
-	pthread_mutex_lock(peerhash_mtx);
-
-	// register cleanup handler
-	pthread_cleanup_push(&peer_writes_finish, NULL);
-
-	bgp_packet_writes_thread_run = true;
-
-	while (bgp_packet_writes_thread_run) {
-		// wait around until next update time
-		if (peerhash->count > 0)
-			pthread_cond_timedwait(write_cond, peerhash_mtx,
-					       &next_update);
-		else // wait around until we have some peers
-			while (peerhash->count == 0
-			       && bgp_packet_writes_thread_run)
-				pthread_cond_wait(write_cond, peerhash_mtx);
-
-		hash_iterate(peerhash, peer_process_writes, NULL);
-
-		monotime(&currtime);
-		timeradd(&currtime, &sleeptime, &currtime);
-		TIMEVAL_TO_TIMESPEC(&currtime, &next_update);
+				if (!cancel)
+					thread_call(&task);
+			}
+			pthread_mutex_unlock(work_mtx);
+		}
 	}
-
-	// clean up
-	pthread_cleanup_pop(1);
 
 	return NULL;
 }
 
-int peer_writes_stop(void **result)
+int bgp_io_stop(void **result, struct frr_pthread *fpt)
 {
-	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_WRITE);
-	bgp_packet_writes_thread_run = false;
-	peer_writes_wake();
+	fpt->master->spin = false;
+	bgp_packet_write_thread_run = false;
+	pthread_kill(fpt->thread, SIGINT);
 	pthread_join(fpt->thread, result);
+
+	pthread_mutex_unlock(work_mtx);
+	pthread_mutex_destroy(work_mtx);
+
+	list_delete(read_cancel);
+	list_delete(write_cancel);
+	XFREE(MTYPE_TMP, work_mtx);
 	return 0;
 }
+/* ------------------------------------------------------------------------ */
 
-void peer_writes_on(struct peer *peer)
+void bgp_writes_on(struct peer *peer)
 {
-	if (peer->status == Deleted)
-		return;
+	assert(peer->status != Deleted);
+	assert(peer->obuf);
+	assert(peer->ibuf);
+	assert(peer->ibuf_work);
+	assert(!peer->t_connect_check);
+	assert(peer->fd);
 
-	pthread_mutex_lock(peerhash_mtx);
+	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);
+
+	pthread_mutex_lock(work_mtx);
 	{
-		if (!hash_lookup(peerhash, peer)) {
-			hash_get(peerhash, peer, hash_alloc_intern);
-			peer_lock(peer);
-		}
-
+		listnode_delete(write_cancel, peer);
+		thread_add_write(fpt->master, bgp_process_writes, peer,
+				 peer->fd, &peer->t_write);
 		SET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
 	}
-	pthread_mutex_unlock(peerhash_mtx);
-	peer_writes_wake();
+	pthread_mutex_unlock(work_mtx);
 }
 
-void peer_writes_off(struct peer *peer)
+void bgp_writes_off(struct peer *peer)
 {
-	pthread_mutex_lock(peerhash_mtx);
+	pthread_mutex_lock(work_mtx);
 	{
-		if (hash_release(peerhash, peer)) {
-			peer_unlock(peer);
-			fprintf(stderr, "Releasing %p\n", peer);
-		}
+		THREAD_OFF(peer->t_write);
+		THREAD_OFF(peer->t_generate_updgrp_packets);
+		listnode_add(write_cancel, peer);
 
+		// peer access by us after this point will result in pain
 		UNSET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
 	}
-	pthread_mutex_unlock(peerhash_mtx);
+	pthread_mutex_unlock(work_mtx);
+	/* upon return, i/o thread must not access the peer */
 }
 
-void peer_writes_wake()
+void bgp_reads_on(struct peer *peer)
 {
-	pthread_cond_signal(write_cond);
+	assert(peer->status != Deleted);
+	assert(peer->ibuf);
+	assert(peer->fd);
+	assert(peer->ibuf_work);
+	assert(stream_get_endp(peer->ibuf_work) == 0);
+	assert(peer->obuf);
+	assert(!peer->t_connect_check);
+	assert(peer->fd);
+
+	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);
+
+	pthread_mutex_lock(work_mtx);
+	{
+		listnode_delete(read_cancel, peer);
+		thread_add_read(fpt->master, bgp_process_reads, peer, peer->fd,
+				&peer->t_read);
+		SET_FLAG(peer->thread_flags, PEER_THREAD_READS_ON);
+	}
+	pthread_mutex_unlock(work_mtx);
+}
+
+void bgp_reads_off(struct peer *peer)
+{
+	pthread_mutex_lock(work_mtx);
+	{
+		THREAD_OFF(peer->t_read);
+		THREAD_OFF(peer->t_process_packet);
+		listnode_add(read_cancel, peer);
+
+		// peer access by us after this point will result in pain
+		UNSET_FLAG(peer->thread_flags, PEER_THREAD_READS_ON);
+	}
+	pthread_mutex_unlock(work_mtx);
 }
 
 /**
- * Callback for hash_iterate. Takes a hash bucket, unwraps it into a peer and
- * synchronously calls bgp_write() on the peer.
+ * Called from PTHREAD_IO when select() or poll() determines that the file
+ * descriptor is ready to be written to.
  */
-static void peer_process_writes(struct hash_backet *hb, void *arg)
+static int bgp_process_writes(struct thread *thread)
 {
 	static struct peer *peer;
-	peer = hb->data;
-	pthread_mutex_lock(&peer->obuf_mtx);
-	{
-		bgp_write(peer);
-	}
-	pthread_mutex_unlock(&peer->obuf_mtx);
+	peer = THREAD_ARG(thread);
+	uint16_t status;
 
-	// dispatch job on main thread
-	BGP_TIMER_ON(peer->t_generate_updgrp_packets,
-		     bgp_generate_updgrp_packets, 100);
+	if (peer->fd < 0)
+		return -1;
+
+	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);
+
+	bool reschedule;
+	pthread_mutex_lock(&peer->io_mtx);
+	{
+		status = bgp_write(peer);
+		reschedule = (stream_fifo_head(peer->obuf) != NULL);
+	}
+	pthread_mutex_unlock(&peer->io_mtx);
+
+	if (CHECK_FLAG(status, BGP_IO_TRANS_ERR)) { /* no problem */
+	}
+
+	if (CHECK_FLAG(status, BGP_IO_FATAL_ERR))
+		reschedule = 0; // problem
+
+	if (reschedule) {
+		thread_add_write(fpt->master, bgp_process_writes, peer,
+				 peer->fd, &peer->t_write);
+		thread_add_background(bm->master, bgp_generate_updgrp_packets,
+				      peer, 0,
+				      &peer->t_generate_updgrp_packets);
+	}
+
+	return 0;
+}
+
+/**
+ * Called from PTHREAD_IO when select() or poll() determines that the file
+ * descriptor is ready to be read from.
+ */
+static int bgp_process_reads(struct thread *thread)
+{
+	static struct peer *peer;
+	peer = THREAD_ARG(thread);
+	uint16_t status;
+
+	if (peer->fd < 0)
+		return -1;
+
+	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);
+
+	bool reschedule = true;
+
+	// execute read
+	pthread_mutex_lock(&peer->io_mtx);
+	{
+		status = bgp_read(peer);
+	}
+	pthread_mutex_unlock(&peer->io_mtx);
+
+	// check results of read
+	bool header_valid = true;
+
+	if (CHECK_FLAG(status, BGP_IO_TRANS_ERR)) { /* no problem */
+	}
+
+	if (CHECK_FLAG(status, BGP_IO_FATAL_ERR))
+		reschedule = false; // problem
+
+	if (CHECK_FLAG(status, BGP_IO_READ_HEADER)) {
+		header_valid = validate_header(peer);
+		if (!header_valid) {
+			bgp_size_t packetsize =
+				MIN((int)stream_get_endp(peer->ibuf_work),
+				    BGP_MAX_PACKET_SIZE);
+			memcpy(peer->last_reset_cause, peer->ibuf_work->data,
+			       packetsize);
+			peer->last_reset_cause_size = packetsize;
+			// We're tearing the session down, no point in
+			// rescheduling.
+			// Additionally, bgp_read() will use the TLV if it's
+			// present to
+			// determine how much to read; if this is corrupt, we'll
+			// crash the
+			// program.
+			reschedule = false;
+		}
+	}
+
+	// if we read a full packet, push it onto peer->ibuf, reset our WiP
+	// buffer
+	// and schedule a job to process it on the main thread
+	if (header_valid && CHECK_FLAG(status, BGP_IO_READ_FULLPACKET)) {
+		pthread_mutex_lock(&peer->io_mtx);
+		{
+			stream_fifo_push(peer->ibuf,
+					 stream_dup(peer->ibuf_work));
+		}
+		pthread_mutex_unlock(&peer->io_mtx);
+		stream_reset(peer->ibuf_work);
+		assert(stream_get_endp(peer->ibuf_work) == 0);
+
+		thread_add_background(bm->master, bgp_process_packet, peer, 0,
+				      &peer->t_process_packet);
+	}
+
+	if (reschedule)
+		thread_add_read(fpt->master, bgp_process_reads, peer, peer->fd,
+				&peer->t_read);
+
+	return 0;
 }
 
 /**
@@ -212,14 +320,14 @@ static void peer_process_writes(struct hash_backet *hb, void *arg)
  *
  * This function pops packets off of peer->obuf and writes them to peer->fd.
  * The amount of packets written is equal to the minimum of peer->wpkt_quanta
- * and the number of packets on the output buffer.
+ * and the number of packets on the output buffer, unless an error occurs.
  *
  * If write() returns an error, the appropriate FSM event is generated.
  *
  * The return value is equal to the number of packets written
  * (which may be zero).
  */
-static int bgp_write(struct peer *peer)
+static uint16_t bgp_write(struct peer *peer)
 {
 	u_char type;
 	struct stream *s;
@@ -227,10 +335,8 @@ static int bgp_write(struct peer *peer)
 	int update_last_write = 0;
 	unsigned int count = 0;
 	unsigned int oc = 0;
+	uint16_t status = 0;
 
-	/* Write packets. The number of packets written is the value of
-	 * bgp->wpkt_quanta or the size of the output buffer, whichever is
-	 * smaller.*/
 	while (count < peer->bgp->wpkt_quanta
 	       && (s = stream_fifo_head(peer->obuf))) {
 		int writenum;
@@ -239,8 +345,12 @@ static int bgp_write(struct peer *peer)
 			num = write(peer->fd, STREAM_PNT(s), writenum);
 
 			if (num < 0) {
-				if (!ERRNO_IO_RETRY(errno))
+				if (!ERRNO_IO_RETRY(errno)) {
 					BGP_EVENT_ADD(peer, TCP_fatal_error);
+					SET_FLAG(status, BGP_IO_FATAL_ERR);
+				} else {
+					SET_FLAG(status, BGP_IO_TRANS_ERR);
+				}
 
 				goto done;
 			} else if (num != writenum) // incomplete write
@@ -288,7 +398,7 @@ static int bgp_write(struct peer *peer)
 		}
 
 		count++;
-		/* OK we send packet so delete it. */
+
 		stream_free(stream_fifo_pop(peer->obuf));
 		update_last_write = 1;
 	}
@@ -303,5 +413,170 @@ done : {
 		peer->last_write = bgp_clock();
 }
 
-	return count;
+	return status;
+}
+
+/**
+ * Reads <= 1 packet worth of data from peer->fd into peer->ibuf_work.
+ *
+ * @return whether a full packet was read
+ */
+static uint16_t bgp_read(struct peer *peer)
+{
+	int readsize; // how many bytes we want to read
+	int nbytes;   // how many bytes we actually read
+	bool have_header = false;
+	uint16_t status = 0;
+
+	if (stream_get_endp(peer->ibuf_work) < BGP_HEADER_SIZE)
+		readsize = BGP_HEADER_SIZE - stream_get_endp(peer->ibuf_work);
+	else {
+		// retrieve packet length from tlv and compute # bytes we still
+		// need
+		u_int16_t mlen =
+			stream_getw_from(peer->ibuf_work, BGP_MARKER_SIZE);
+		readsize = mlen - stream_get_endp(peer->ibuf_work);
+		have_header = true;
+	}
+
+	nbytes = stream_read_try(peer->ibuf_work, peer->fd, readsize);
+
+	if (nbytes <= 0) // handle errors
+	{
+		switch (nbytes) {
+		case -1: // fatal error; tear down the session
+			zlog_err("%s [Error] bgp_read_packet error: %s",
+				 peer->host, safe_strerror(errno));
+
+			if (peer->status == Established) {
+				if (CHECK_FLAG(peer->sflags,
+					       PEER_STATUS_NSF_MODE)) {
+					peer->last_reset =
+						PEER_DOWN_NSF_CLOSE_SESSION;
+					SET_FLAG(peer->sflags,
+						 PEER_STATUS_NSF_WAIT);
+				} else
+					peer->last_reset =
+						PEER_DOWN_CLOSE_SESSION;
+			}
+
+			BGP_EVENT_ADD(peer, TCP_fatal_error);
+			SET_FLAG(status, BGP_IO_FATAL_ERR);
+			break;
+
+		case 0: // TCP session closed
+			if (bgp_debug_neighbor_events(peer))
+				zlog_debug(
+					"%s [Event] BGP connection closed fd %d",
+					peer->host, peer->fd);
+
+			if (peer->status == Established) {
+				if (CHECK_FLAG(peer->sflags,
+					       PEER_STATUS_NSF_MODE)) {
+					peer->last_reset =
+						PEER_DOWN_NSF_CLOSE_SESSION;
+					SET_FLAG(peer->sflags,
+						 PEER_STATUS_NSF_WAIT);
+				} else
+					peer->last_reset =
+						PEER_DOWN_CLOSE_SESSION;
+			}
+
+			BGP_EVENT_ADD(peer, TCP_connection_closed);
+			SET_FLAG(status, BGP_IO_FATAL_ERR);
+			break;
+
+		case -2: // temporary error; come back later
+			SET_FLAG(status, BGP_IO_TRANS_ERR);
+			break;
+		default:
+			break;
+		}
+
+		return status;
+	}
+
+	// If we didn't have the header before read(), and now we do, set the
+	// appropriate flag. The caller must validate the header for us.
+	if (!have_header
+	    && stream_get_endp(peer->ibuf_work) >= BGP_HEADER_SIZE) {
+		SET_FLAG(status, BGP_IO_READ_HEADER);
+		have_header = true;
+	}
+	// If we read the # of bytes specified in the tlv, we have read a full
+	// packet.
+	//
+	// Note that the header may not have been validated here. This flag
+	// means
+	// ONLY that we read the # of bytes specified in the header; if the
+	// header is
+	// not valid, the packet MUST NOT be processed further.
+	if (have_header && (stream_getw_from(peer->ibuf_work, BGP_MARKER_SIZE)
+			    == stream_get_endp(peer->ibuf_work)))
+		SET_FLAG(status, BGP_IO_READ_FULLPACKET);
+
+	return status;
+}
+
+/*
+ * Called after we have read a BGP packet header. Validates marker, message
+ * type and packet length. If any of these aren't correct, sends a notify.
+ */
+static bool validate_header(struct peer *peer)
+{
+	u_int16_t size, type;
+
+	/* Marker check */
+	for (int i = 0; i < BGP_MARKER_SIZE; i++)
+		if (peer->ibuf_work->data[i] != 0xff) {
+			bgp_notify_send(peer, BGP_NOTIFY_HEADER_ERR,
+					BGP_NOTIFY_HEADER_NOT_SYNC);
+			return false;
+		}
+
+	/* Get size and type. */
+	size = stream_getw_from(peer->ibuf_work, BGP_MARKER_SIZE);
+	type = stream_getc_from(peer->ibuf_work, BGP_MARKER_SIZE + 2);
+
+	/* BGP type check. */
+	if (type != BGP_MSG_OPEN && type != BGP_MSG_UPDATE
+	    && type != BGP_MSG_NOTIFY && type != BGP_MSG_KEEPALIVE
+	    && type != BGP_MSG_ROUTE_REFRESH_NEW
+	    && type != BGP_MSG_ROUTE_REFRESH_OLD
+	    && type != BGP_MSG_CAPABILITY) {
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("%s unknown message type 0x%02x", peer->host,
+				   type);
+
+		bgp_notify_send_with_data(peer, BGP_NOTIFY_HEADER_ERR,
+					  BGP_NOTIFY_HEADER_BAD_MESTYPE,
+					  (u_char *)&type, 1);
+		return false;
+	}
+
+	/* Mimimum packet length check. */
+	if ((size < BGP_HEADER_SIZE) || (size > BGP_MAX_PACKET_SIZE)
+	    || (type == BGP_MSG_OPEN && size < BGP_MSG_OPEN_MIN_SIZE)
+	    || (type == BGP_MSG_UPDATE && size < BGP_MSG_UPDATE_MIN_SIZE)
+	    || (type == BGP_MSG_NOTIFY && size < BGP_MSG_NOTIFY_MIN_SIZE)
+	    || (type == BGP_MSG_KEEPALIVE && size != BGP_MSG_KEEPALIVE_MIN_SIZE)
+	    || (type == BGP_MSG_ROUTE_REFRESH_NEW
+		&& size < BGP_MSG_ROUTE_REFRESH_MIN_SIZE)
+	    || (type == BGP_MSG_ROUTE_REFRESH_OLD
+		&& size < BGP_MSG_ROUTE_REFRESH_MIN_SIZE)
+	    || (type == BGP_MSG_CAPABILITY
+		&& size < BGP_MSG_CAPABILITY_MIN_SIZE)) {
+		if (bgp_debug_neighbor_events(peer))
+			zlog_debug("%s bad message length - %d for %s",
+				   peer->host, size,
+				   type == 128 ? "ROUTE-REFRESH"
+					       : bgp_type_str[(int)type]);
+
+		bgp_notify_send_with_data(peer, BGP_NOTIFY_HEADER_ERR,
+					  BGP_NOTIFY_HEADER_BAD_MESLEN,
+					  (u_char *)&size, 2);
+		return false;
+	}
+
+	return true;
 }

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -327,13 +327,6 @@ static int bgp_process_reads(struct thread *thread)
 
 	/* handle invalid header */
 	if (fatal) {
-		if (!header_valid) {
-			bgp_size_t pktsize = BGP_HEADER_SIZE;
-			stream_get(peer->last_reset_cause, peer->ibuf_work,
-				   pktsize);
-			peer->last_reset_cause_size = pktsize;
-		}
-
 		/* wipe buffer just in case someone screwed up */
 		stream_reset(peer->ibuf_work);
 	} else {

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -1,0 +1,307 @@
+/*
+  BGP I/O.
+  Implements a consumer thread to flush packets destined for remote peers.
+
+  Copyright (C) 2017  Cumulus Networks
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; see the file COPYING; if not, write to the
+  Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+  MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+#include <sys/time.h>
+#include <pthread.h>
+
+#include "thread.h"
+#include "hash.h"
+#include "stream.h"
+#include "memory.h"
+#include "log.h"
+#include "monotime.h"
+#include "network.h"
+#include "frr_pthread.h"
+
+#include "bgpd/bgpd.h"
+#include "bgpd/bgp_io.h"
+#include "bgpd/bgp_debug.h"
+#include "bgpd/bgp_packet.h"
+#include "bgpd/bgp_fsm.h"
+
+static int bgp_write(struct peer *);
+static void peer_process_writes(struct hash_backet *, void *);
+
+bool bgp_packet_writes_thread_run = false;
+
+/* Hash table of peers to operate on, associated synchronization primitives and
+ * hash table callbacks.
+ * ------------------------------------------------------------------------ */
+static struct hash *peerhash;
+/* Mutex to protect hash table */
+static pthread_mutex_t *peerhash_mtx;
+/* Condition variable used to notify the write thread that there is work to do
+ */
+static pthread_cond_t *write_cond;
+
+static unsigned int peer_hash_key_make(void *p)
+{
+	struct peer *peer = p;
+	return sockunion_hash(&peer->su);
+}
+
+static int peer_hash_cmp(const void *p1, const void *p2)
+{
+	const struct peer *peer1 = p1;
+	const struct peer *peer2 = p2;
+	return (sockunion_same(&peer1->su, &peer2->su)
+		&& CHECK_FLAG(peer1->flags, PEER_FLAG_CONFIG_NODE)
+			   == CHECK_FLAG(peer2->flags, PEER_FLAG_CONFIG_NODE));
+}
+/* ------------------------------------------------------------------------ */
+
+void peer_writes_init(void)
+{
+	peerhash_mtx = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_mutex_t));
+	write_cond = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_cond_t));
+
+	// initialize mutex
+	pthread_mutex_init(peerhash_mtx, NULL);
+
+	// use monotonic clock with condition variable
+	pthread_condattr_t attrs;
+	pthread_condattr_init(&attrs);
+	pthread_condattr_setclock(&attrs, CLOCK_MONOTONIC);
+	pthread_cond_init(write_cond, &attrs);
+	pthread_condattr_destroy(&attrs);
+
+	// initialize peerhash
+	peerhash = hash_create_size(2048, peer_hash_key_make, peer_hash_cmp);
+}
+
+static void peer_writes_finish(void *arg)
+{
+	bgp_packet_writes_thread_run = false;
+
+	if (peerhash)
+		hash_free(peerhash);
+
+	peerhash = NULL;
+
+	pthread_mutex_unlock(peerhash_mtx);
+	pthread_mutex_destroy(peerhash_mtx);
+	pthread_cond_destroy(write_cond);
+
+	XFREE(MTYPE_PTHREAD, peerhash_mtx);
+	XFREE(MTYPE_PTHREAD, write_cond);
+}
+
+void *peer_writes_start(void *arg)
+{
+	struct timeval currtime = {0, 0};
+	struct timeval sleeptime = {0, 500};
+	struct timespec next_update = {0, 0};
+
+	pthread_mutex_lock(peerhash_mtx);
+
+	// register cleanup handler
+	pthread_cleanup_push(&peer_writes_finish, NULL);
+
+	bgp_packet_writes_thread_run = true;
+
+	while (bgp_packet_writes_thread_run) {
+		// wait around until next update time
+		if (peerhash->count > 0)
+			pthread_cond_timedwait(write_cond, peerhash_mtx,
+					       &next_update);
+		else // wait around until we have some peers
+			while (peerhash->count == 0
+			       && bgp_packet_writes_thread_run)
+				pthread_cond_wait(write_cond, peerhash_mtx);
+
+		hash_iterate(peerhash, peer_process_writes, NULL);
+
+		monotime(&currtime);
+		timeradd(&currtime, &sleeptime, &currtime);
+		TIMEVAL_TO_TIMESPEC(&currtime, &next_update);
+	}
+
+	// clean up
+	pthread_cleanup_pop(1);
+
+	return NULL;
+}
+
+int peer_writes_stop(void **result)
+{
+	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_WRITE);
+	bgp_packet_writes_thread_run = false;
+	peer_writes_wake();
+	pthread_join(fpt->thread, result);
+	return 0;
+}
+
+void peer_writes_on(struct peer *peer)
+{
+	if (peer->status == Deleted)
+		return;
+
+	pthread_mutex_lock(peerhash_mtx);
+	{
+		if (!hash_lookup(peerhash, peer)) {
+			hash_get(peerhash, peer, hash_alloc_intern);
+			peer_lock(peer);
+		}
+
+		SET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
+	}
+	pthread_mutex_unlock(peerhash_mtx);
+	peer_writes_wake();
+}
+
+void peer_writes_off(struct peer *peer)
+{
+	pthread_mutex_lock(peerhash_mtx);
+	{
+		if (hash_release(peerhash, peer)) {
+			peer_unlock(peer);
+			fprintf(stderr, "Releasing %p\n", peer);
+		}
+
+		UNSET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
+	}
+	pthread_mutex_unlock(peerhash_mtx);
+}
+
+void peer_writes_wake()
+{
+	pthread_cond_signal(write_cond);
+}
+
+/**
+ * Callback for hash_iterate. Takes a hash bucket, unwraps it into a peer and
+ * synchronously calls bgp_write() on the peer.
+ */
+static void peer_process_writes(struct hash_backet *hb, void *arg)
+{
+	static struct peer *peer;
+	peer = hb->data;
+	pthread_mutex_lock(&peer->obuf_mtx);
+	{
+		bgp_write(peer);
+	}
+	pthread_mutex_unlock(&peer->obuf_mtx);
+
+	// dispatch job on main thread
+	BGP_TIMER_ON(peer->t_generate_updgrp_packets,
+		     bgp_generate_updgrp_packets, 100);
+}
+
+/**
+ * Flush peer output buffer.
+ *
+ * This function pops packets off of peer->obuf and writes them to peer->fd.
+ * The amount of packets written is equal to the minimum of peer->wpkt_quanta
+ * and the number of packets on the output buffer.
+ *
+ * If write() returns an error, the appropriate FSM event is generated.
+ *
+ * The return value is equal to the number of packets written
+ * (which may be zero).
+ */
+static int bgp_write(struct peer *peer)
+{
+	u_char type;
+	struct stream *s;
+	int num;
+	int update_last_write = 0;
+	unsigned int count = 0;
+	unsigned int oc = 0;
+
+	/* Write packets. The number of packets written is the value of
+	 * bgp->wpkt_quanta or the size of the output buffer, whichever is
+	 * smaller.*/
+	while (count < peer->bgp->wpkt_quanta
+	       && (s = stream_fifo_head(peer->obuf))) {
+		int writenum;
+		do {
+			writenum = stream_get_endp(s) - stream_get_getp(s);
+			num = write(peer->fd, STREAM_PNT(s), writenum);
+
+			if (num < 0) {
+				if (!ERRNO_IO_RETRY(errno))
+					BGP_EVENT_ADD(peer, TCP_fatal_error);
+
+				goto done;
+			} else if (num != writenum) // incomplete write
+				stream_forward_getp(s, num);
+
+		} while (num != writenum);
+
+		/* Retrieve BGP packet type. */
+		stream_set_getp(s, BGP_MARKER_SIZE + 2);
+		type = stream_getc(s);
+
+		switch (type) {
+		case BGP_MSG_OPEN:
+			peer->open_out++;
+			break;
+		case BGP_MSG_UPDATE:
+			peer->update_out++;
+			break;
+		case BGP_MSG_NOTIFY:
+			peer->notify_out++;
+			/* Double start timer. */
+			peer->v_start *= 2;
+
+			/* Overflow check. */
+			if (peer->v_start >= (60 * 2))
+				peer->v_start = (60 * 2);
+
+			/* Handle Graceful Restart case where the state changes
+			   to
+			   Connect instead of Idle */
+			/* Flush any existing events */
+			BGP_EVENT_ADD(peer, BGP_Stop);
+			goto done;
+
+		case BGP_MSG_KEEPALIVE:
+			peer->keepalive_out++;
+			break;
+		case BGP_MSG_ROUTE_REFRESH_NEW:
+		case BGP_MSG_ROUTE_REFRESH_OLD:
+			peer->refresh_out++;
+			break;
+		case BGP_MSG_CAPABILITY:
+			peer->dynamic_cap_out++;
+			break;
+		}
+
+		count++;
+		/* OK we send packet so delete it. */
+		stream_free(stream_fifo_pop(peer->obuf));
+		update_last_write = 1;
+	}
+
+done : {
+	/* Update last_update if UPDATEs were written. */
+	if (peer->update_out > oc)
+		peer->last_update = bgp_clock();
+
+	/* If we TXed any flavor of packet update last_write */
+	if (update_last_write)
+		peer->last_write = bgp_clock();
+}
+
+	return count;
+}

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -1,25 +1,21 @@
-/*
-  BGP I/O.
-
-  Implements packet I/O in a consumer pthread.
-  --------------------------------------------
-  Copyright (C) 2017  Cumulus Networks
-  Quentin Young
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful, but
-  WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; see the file COPYING; if not, write to the
-  Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-  MA 02110-1301 USA
+/* BGP I/O.
+ * Implements packet I/O in a consumer pthread.
+ * Copyright (C) 2017  Cumulus Networks
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+ * MA 02110-1301 USA
  */
 
 #include <zebra.h>

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -67,6 +67,7 @@ void bgp_io_init()
 void *bgp_io_start(void *arg)
 {
 	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);
+	fpt->master->owner = pthread_self();
 
 	// we definitely don't want to handle signals
 	fpt->master->handle_signals = false;

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -381,9 +381,13 @@ static uint16_t bgp_write(struct peer *peer)
 	unsigned int count = 0;
 	unsigned int oc = 0;
 	uint16_t status = 0;
+	uint32_t wpkt_quanta_old;
 
-	while (count < peer->bgp->wpkt_quanta
-	       && (s = stream_fifo_head(peer->obuf))) {
+	// cache current write quanta
+	wpkt_quanta_old = atomic_load_explicit(&peer->bgp->wpkt_quanta,
+					       memory_order_relaxed);
+
+	while (count < wpkt_quanta_old && (s = stream_fifo_head(peer->obuf))) {
 		int writenum;
 		do {
 			writenum = stream_get_endp(s) - stream_get_getp(s);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -18,23 +18,25 @@
  * MA 02110-1301 USA
  */
 
+/* clang-format off */
 #include <zebra.h>
-#include <pthread.h> // for pthread_mutex_unlock, pthread_mutex_lock
+#include <pthread.h>		// for pthread_mutex_unlock, pthread_mutex_lock
 
-#include "frr_pthread.h" // for frr_pthread_get, frr_pthread
-#include "linklist.h"    // for list_delete, list_delete_all_node, lis...
-#include "log.h"	 // for zlog_debug, safe_strerror, zlog_err
-#include "memory.h"      // for MTYPE_TMP, XCALLOC, XFREE
-#include "network.h"     // for ERRNO_IO_RETRY
-#include "stream.h"      // for stream_get_endp, stream_getw_from, str...
-#include "thread.h"      // for THREAD_OFF, THREAD_ARG, thread, thread...
-#include "zassert.h"     // for assert
+#include "frr_pthread.h"	// for frr_pthread_get, frr_pthread
+#include "linklist.h"		// for list_delete, list_delete_all_node, lis...
+#include "log.h"		// for zlog_debug, safe_strerror, zlog_err
+#include "memory.h"		// for MTYPE_TMP, XCALLOC, XFREE
+#include "network.h"		// for ERRNO_IO_RETRY
+#include "stream.h"		// for stream_get_endp, stream_getw_from, str...
+#include "thread.h"		// for THREAD_OFF, THREAD_ARG, thread, thread...
+#include "zassert.h"		// for assert
 
 #include "bgpd/bgp_io.h"
-#include "bgpd/bgp_debug.h"  // for bgp_debug_neighbor_events, bgp_type_str
-#include "bgpd/bgp_fsm.h"    // for BGP_EVENT_ADD, bgp_event
-#include "bgpd/bgp_packet.h" // for bgp_notify_send_with_data, bgp_notify...
-#include "bgpd/bgpd.h"       // for peer, BGP_MARKER_SIZE, bgp_master, bm
+#include "bgpd/bgp_debug.h"	// for bgp_debug_neighbor_events, bgp_type_str
+#include "bgpd/bgp_fsm.h"	// for BGP_EVENT_ADD, bgp_event
+#include "bgpd/bgp_packet.h"	// for bgp_notify_send_with_data, bgp_notify...
+#include "bgpd/bgpd.h"		// for peer, BGP_MARKER_SIZE, bgp_master, bm
+/* clang-format on */
 
 /* forward declarations */
 static uint16_t bgp_write(struct peer *);
@@ -44,8 +46,8 @@ static int bgp_process_reads(struct thread *);
 static bool validate_header(struct peer *);
 
 /* generic i/o status codes */
-#define BGP_IO_TRANS_ERR        (1 << 0) // EAGAIN or similar occurred
-#define BGP_IO_FATAL_ERR        (1 << 1) // some kind of fatal TCP error
+#define BGP_IO_TRANS_ERR (1 << 0) // EAGAIN or similar occurred
+#define BGP_IO_FATAL_ERR (1 << 1) // some kind of fatal TCP error
 
 /* Start and stop routines for I/O pthread + control variables
  * ------------------------------------------------------------------------ */

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -150,7 +150,7 @@ void bgp_reads_on(struct peer *peer)
 	{
 		thread_add_read(fpt->master, bgp_process_reads, peer, peer->fd,
 				&peer->t_read);
-		thread_add_background(bm->master, bgp_process_packet, peer, 0,
+		thread_add_timer_msec(bm->master, bgp_process_packet, peer, 0,
 				      &peer->t_process_packet);
 		SET_FLAG(peer->thread_flags, PEER_THREAD_READS_ON);
 	}
@@ -205,7 +205,7 @@ static int bgp_process_writes(struct thread *thread)
 	if (reschedule) {
 		thread_add_write(fpt->master, bgp_process_writes, peer,
 				 peer->fd, &peer->t_write);
-		thread_add_background(bm->master, bgp_generate_updgrp_packets,
+		thread_add_timer_msec(bm->master, bgp_generate_updgrp_packets,
 				      peer, 0,
 				      &peer->t_generate_updgrp_packets);
 	}
@@ -334,9 +334,6 @@ static int bgp_process_reads(struct thread *thread)
 		if (added_pkt)
 			thread_add_event(bm->master, bgp_process_packet, peer,
 					 0, NULL);
-		//                        thread_add_background(bm->master,
-		//                        bgp_process_packet, peer,
-		//                                         0, NULL);
 	}
 
 	return 0;

--- a/bgpd/bgp_io.h
+++ b/bgpd/bgp_io.h
@@ -23,13 +23,13 @@
 #ifndef _FRR_BGP_IO_H
 #define _FRR_BGP_IO_H
 
+#include "frr_pthread.h"
 #include "bgpd/bgpd.h"
 
 /**
  * Control variable for write thread.
  *
- * Setting this variable to false and calling peer_writes_wake() will
- * eventually result in thread termination.
+ * Setting this variable to false will eventually result in thread termination.
  */
 extern bool bgp_packet_writes_thread_run;
 
@@ -37,35 +37,32 @@ extern bool bgp_packet_writes_thread_run;
  * Initializes data structures and flags for the write thread.
  *
  * This function should be called from the main thread before
- * peer_writes_start() is invoked.
+ * bgp_writes_start() is invoked.
  */
-extern void peer_writes_init(void);
+extern void bgp_io_init(void);
 
 /**
  * Start function for write thread.
  *
- * This function should be passed to pthread_create() during BGP startup.
+ * @param arg - unused
  */
-extern void *peer_writes_start(void *arg);
+extern void *bgp_io_start(void *arg);
 
 /**
  * Start function for write thread.
  *
  * Uninitializes all resources and stops the thread.
  *
- * @param result -- where to store data result, unused
+ * @param result - where to store data result, unused
  */
-extern int peer_writes_stop(void **result);
+extern int bgp_io_stop(void **result, struct frr_pthread *fpt);
 
 /**
- * Registers a peer with the write thread.
- *
- * This function adds the peer to an internal data structure, which must be
- * locked for write access. This call will block until the structure can be
- * locked.
+ * Turns on packet writing for a peer.
  *
  * After this function is called, any packets placed on peer->obuf will be
- * written to peer->fd at regular intervals.
+ * written to peer->fd at regular intervals. Additionally it becomes unsafe to
+ * use peer->fd with select() or poll().
  *
  * This function increments the peer reference counter with peer_lock().
  *
@@ -73,17 +70,51 @@ extern int peer_writes_stop(void **result);
  *
  * @param peer - peer to register
  */
-extern void peer_writes_on(struct peer *peer);
+extern void bgp_writes_on(struct peer *peer);
 
 /**
- * Deregisters a peer with the write thread.
- *
- * This function removes the peer from an internal data structure, which must
- * be locked for write access. This call will block until the structure can be
- * locked.
+ * Turns off packet writing for a peer.
  *
  * After this function is called, any packets placed on peer->obuf will not be
- * written to peer->fd.
+ * written to peer->fd. After this function returns it is safe to use peer->fd
+ * with select() or poll().
+ *
+ * If the flush = true, a last-ditch effort will be made to flush any remaining
+ * packets to peer->fd. Upon encountering any error whatsoever, the attempt
+ * will abort. If the caller wishes to know whether the flush succeeded they
+ * may check peer->obuf->count against zero.
+ *
+ * If the peer is not registered, nothing happens.
+ *
+ * @param peer - peer to deregister
+ * @param flush - as described
+ */
+extern void bgp_writes_off(struct peer *peer);
+
+/**
+ * Turns on packet reading for a peer.
+ *
+ * After this function is called, any packets received on peer->fd will be read
+ * and copied into the FIFO queue peer->ibuf. Additionally it becomes unsafe to
+ * use peer->fd with select() or poll().
+ *
+ * When a full packet is read, bgp_process_packet() will be scheduled on the
+ * main thread.
+ *
+ * This function increments the peer reference counter with peer_lock().
+ *
+ * If the peer is already registered, nothing happens.
+ *
+ * @param peer - peer to register
+ */
+extern void bgp_reads_on(struct peer *peer);
+
+/**
+ * Turns off packet reading for a peer.
+ *
+ * After this function is called, any packets received on peer->fd will not be
+ * read. After this function returns it is safe to use peer->fd with select()
+ * or poll().
  *
  * This function decrements the peer reference counter with peer_unlock().
  *
@@ -91,14 +122,6 @@ extern void peer_writes_on(struct peer *peer);
  *
  * @param peer - peer to deregister
  */
-extern void peer_writes_off(struct peer *peer);
-
-/**
- * Notifies the write thread that there is work to be done.
- *
- * This function has the effect of waking the write thread if it is sleeping.
- * If the thread is not sleeping, this signal will be ignored.
- */
-extern void peer_writes_wake(void);
+extern void bgp_reads_off(struct peer *peer);
 
 #endif /* _FRR_BGP_IO_H */

--- a/bgpd/bgp_io.h
+++ b/bgpd/bgp_io.h
@@ -1,23 +1,22 @@
-/*
-  BGP I/O.
-  Implements a consumer thread to flush packets destined for remote peers.
-
-  Copyright (C) 2017  Cumulus Networks
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful, but
-  WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; see the file COPYING; if not, write to the
-  Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-  MA 02110-1301 USA
+/* BGP I/O.
+ * Implements packet I/O in a pthread.
+ * Copyright (C) 2017  Cumulus Networks
+ * Quentin Young
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+ * MA 02110-1301 USA
  */
 
 #ifndef _FRR_BGP_IO_H
@@ -64,12 +63,9 @@ extern int bgp_io_stop(void **result, struct frr_pthread *fpt);
  * Turns on packet writing for a peer.
  *
  * After this function is called, any packets placed on peer->obuf will be
- * written to peer->fd at regular intervals. Additionally it becomes unsafe to
- * use peer->fd with select() or poll().
+ * written to peer->fd until no more packets remain.
  *
- * This function increments the peer reference counter with peer_lock().
- *
- * If the peer is already registered, nothing happens.
+ * Additionally, it becomes unsafe to perform socket actions on peer->fd.
  *
  * @param peer - peer to register
  */
@@ -78,16 +74,11 @@ extern void bgp_writes_on(struct peer *peer);
 /**
  * Turns off packet writing for a peer.
  *
- * After this function is called, any packets placed on peer->obuf will not be
- * written to peer->fd. After this function returns it is safe to use peer->fd
- * with select() or poll().
+ * After this function returns, packets placed on peer->obuf will not be
+ * written to peer->fd by the I/O thread.
  *
- * If the flush = true, a last-ditch effort will be made to flush any remaining
- * packets to peer->fd. Upon encountering any error whatsoever, the attempt
- * will abort. If the caller wishes to know whether the flush succeeded they
- * may check peer->obuf->count against zero.
- *
- * If the peer is not registered, nothing happens.
+ * After this function returns it becomes safe to perform socket actions on
+ * peer->fd.
  *
  * @param peer - peer to deregister
  * @param flush - as described
@@ -98,15 +89,14 @@ extern void bgp_writes_off(struct peer *peer);
  * Turns on packet reading for a peer.
  *
  * After this function is called, any packets received on peer->fd will be read
- * and copied into the FIFO queue peer->ibuf. Additionally it becomes unsafe to
- * use peer->fd with select() or poll().
+ * and copied into the FIFO queue peer->ibuf.
  *
- * When a full packet is read, bgp_process_packet() will be scheduled on the
- * main thread.
+ * Additionally, it becomes unsafe to perform socket actions on peer->fd.
  *
- * This function increments the peer reference counter with peer_lock().
+ * Whenever one or more packets are placed onto peer->ibuf, a task of type
+ * THREAD_EVENT will be placed on the main thread whose handler is
  *
- * If the peer is already registered, nothing happens.
+ *   bgp_packet.c:bgp_process_packet()
  *
  * @param peer - peer to register
  */
@@ -116,12 +106,10 @@ extern void bgp_reads_on(struct peer *peer);
  * Turns off packet reading for a peer.
  *
  * After this function is called, any packets received on peer->fd will not be
- * read. After this function returns it is safe to use peer->fd with select()
- * or poll().
+ * read by the I/O thread.
  *
- * This function decrements the peer reference counter with peer_unlock().
- *
- * If the peer is not registered, nothing happens.
+ * After this function returns it becomes safe to perform socket actions on
+ * peer->fd.
  *
  * @param peer - peer to deregister
  */

--- a/bgpd/bgp_io.h
+++ b/bgpd/bgp_io.h
@@ -23,8 +23,8 @@
 #ifndef _FRR_BGP_IO_H
 #define _FRR_BGP_IO_H
 
-#include "frr_pthread.h"
 #include "bgpd/bgpd.h"
+#include "frr_pthread.h"
 
 /**
  * Control variable for write thread.

--- a/bgpd/bgp_io.h
+++ b/bgpd/bgp_io.h
@@ -1,0 +1,104 @@
+/*
+  BGP I/O.
+  Implements a consumer thread to flush packets destined for remote peers.
+
+  Copyright (C) 2017  Cumulus Networks
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; see the file COPYING; if not, write to the
+  Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+  MA 02110-1301 USA
+ */
+
+#ifndef _FRR_BGP_IO_H
+#define _FRR_BGP_IO_H
+
+#include "bgpd/bgpd.h"
+
+/**
+ * Control variable for write thread.
+ *
+ * Setting this variable to false and calling peer_writes_wake() will
+ * eventually result in thread termination.
+ */
+extern bool bgp_packet_writes_thread_run;
+
+/**
+ * Initializes data structures and flags for the write thread.
+ *
+ * This function should be called from the main thread before
+ * peer_writes_start() is invoked.
+ */
+extern void peer_writes_init(void);
+
+/**
+ * Start function for write thread.
+ *
+ * This function should be passed to pthread_create() during BGP startup.
+ */
+extern void *peer_writes_start(void *arg);
+
+/**
+ * Start function for write thread.
+ *
+ * Uninitializes all resources and stops the thread.
+ *
+ * @param result -- where to store data result, unused
+ */
+extern int peer_writes_stop(void **result);
+
+/**
+ * Registers a peer with the write thread.
+ *
+ * This function adds the peer to an internal data structure, which must be
+ * locked for write access. This call will block until the structure can be
+ * locked.
+ *
+ * After this function is called, any packets placed on peer->obuf will be
+ * written to peer->fd at regular intervals.
+ *
+ * This function increments the peer reference counter with peer_lock().
+ *
+ * If the peer is already registered, nothing happens.
+ *
+ * @param peer - peer to register
+ */
+extern void peer_writes_on(struct peer *peer);
+
+/**
+ * Deregisters a peer with the write thread.
+ *
+ * This function removes the peer from an internal data structure, which must
+ * be locked for write access. This call will block until the structure can be
+ * locked.
+ *
+ * After this function is called, any packets placed on peer->obuf will not be
+ * written to peer->fd.
+ *
+ * This function decrements the peer reference counter with peer_unlock().
+ *
+ * If the peer is not registered, nothing happens.
+ *
+ * @param peer - peer to deregister
+ */
+extern void peer_writes_off(struct peer *peer);
+
+/**
+ * Notifies the write thread that there is work to be done.
+ *
+ * This function has the effect of waking the write thread if it is sleeping.
+ * If the thread is not sleeping, this signal will be ignored.
+ */
+extern void peer_writes_wake(void);
+
+#endif /* _FRR_BGP_IO_H */

--- a/bgpd/bgp_io.h
+++ b/bgpd/bgp_io.h
@@ -23,6 +23,9 @@
 #ifndef _FRR_BGP_IO_H
 #define _FRR_BGP_IO_H
 
+#define BGP_WRITE_PACKET_MAX 10U
+#define BGP_READ_PACKET_MAX  10U
+
 #include "bgpd/bgpd.h"
 #include "frr_pthread.h"
 

--- a/bgpd/bgp_io.h
+++ b/bgpd/bgp_io.h
@@ -29,13 +29,6 @@
 #include "frr_pthread.h"
 
 /**
- * Control variable for write thread.
- *
- * Setting this variable to false will eventually result in thread termination.
- */
-extern bool bgp_packet_writes_thread_run;
-
-/**
  * Initializes data structures and flags for the write thread.
  *
  * This function should be called from the main thread before

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -232,6 +232,11 @@ void bgp_keepalives_on(struct peer *peer)
 	/* placeholder bucket data to use for fast key lookups */
 	static struct pkat holder = {0};
 
+	if (!peerhash_mtx) {
+		zlog_warn("%s: call bgp_keepalives_init() first", __func__);
+		return;
+	}
+
 	pthread_mutex_lock(peerhash_mtx);
 	{
 		holder.peer = peer;
@@ -250,6 +255,11 @@ void bgp_keepalives_off(struct peer *peer)
 {
 	/* placeholder bucket data to use for fast key lookups */
 	static struct pkat holder = {0};
+
+	if (!peerhash_mtx) {
+		zlog_warn("%s: call bgp_keepalives_init() first", __func__);
+		return;
+	}
 
 	pthread_mutex_lock(peerhash_mtx);
 	{

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -20,22 +20,21 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+/* clang-format off */
 #include <zebra.h>
-#include <signal.h>
-#include <sys/time.h>
+#include <pthread.h>		// for pthread_mutex_lock, pthread_mutex_unlock
 
-#include "thread.h"
-#include "log.h"
-#include "vty.h"
-#include "monotime.h"
-#include "hash.h"
-#include "frr_pthread.h"
+#include "frr_pthread.h"        // for frr_pthread
+#include "hash.h"		// for hash, hash_clean, hash_create_size...
+#include "log.h"		// for zlog_debug
+#include "memory.h"		// for MTYPE_TMP, XFREE, XCALLOC, XMALLOC
+#include "monotime.h"		// for monotime, monotime_since
 
-#include "bgpd/bgpd.h"
+#include "bgpd/bgpd.h"          // for peer, PEER_THREAD_KEEPALIVES_ON, peer...
+#include "bgpd/bgp_debug.h"	// for bgp_debug_neighbor_events
+#include "bgpd/bgp_packet.h"	// for bgp_keepalive_send
 #include "bgpd/bgp_keepalives.h"
-#include "bgpd/bgp_debug.h"
-#include "bgpd/bgp_attr.h"
-#include "bgpd/bgp_packet.h"
+/* clang-format on */
 
 /**
  * Peer KeepAlive Timer.

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -1,27 +1,25 @@
-/*
-  BGP Keepalives.
-
-  Implements a producer thread to generate BGP keepalives for peers.
-  ----------------------------------------
-  Copyright (C) 2017 Cumulus Networks, Inc.
-  Quentin Young
-
-  This file is part of FRRouting.
-
-  FRRouting is free software; you can redistribute it and/or modify it under
-  the terms of the GNU General Public License as published by the Free
-  Software Foundation; either version 2, or (at your option) any later
-  version.
-
-  FRRouting is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
-  details.
-
-  You should have received a copy of the GNU General Public License along with
-  FRRouting; see the file COPYING.  If not, write to the Free Software
-  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+/* BGP Keepalives.
+ * Implements a producer thread to generate BGP keepalives for peers.
+ * Copyright (C) 2017 Cumulus Networks, Inc.
+ * Quentin Young
+ *
+ * This file is part of FRRouting.
+ *
+ * FRRouting is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any later
+ * version.
+ *
+ * FRRouting is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #include <zebra.h>
 #include <signal.h>
 #include <sys/time.h>

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -1,0 +1,247 @@
+/* BGP Keepalives.
+ *
+ * Implemented server-style in a pthread.
+ * --------------------------------------
+ * Copyright (C) 2017 Cumulus Networks, Inc.
+ *
+ * This file is part of Free Range Routing.
+ *
+ * Free Range Routing is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any later
+ * version.
+ *
+ * Free Range Routing is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GN5U General Public License along
+ * with Free Range Routing; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+#include <zebra.h>
+#include <signal.h>
+#include <sys/time.h>
+
+#include "thread.h"
+#include "log.h"
+#include "vty.h"
+#include "monotime.h"
+
+#include "bgpd/bgpd.h"
+#include "bgpd/bgp_keepalives.h"
+#include "bgpd/bgp_debug.h"
+#include "bgpd/bgp_attr.h"
+#include "bgpd/bgp_packet.h"
+
+/**
+ * Peer KeepAlive Timer.
+ * Associates a peer with the time of its last keepalive.
+ */
+struct pkat {
+	// the peer to send keepalives to
+	struct peer *peer;
+	// absolute time of last keepalive sent
+	struct timeval last;
+};
+
+/* List of peers we are sending keepalives for, and associated mutex. */
+static pthread_mutex_t peerlist_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t peerlist_cond;
+static struct list *peerlist;
+
+/* Thread control flag. */
+bool bgp_keepalives_thread_run;
+
+static struct pkat *pkat_new(struct peer *peer)
+{
+	struct pkat *pkat = XMALLOC(MTYPE_TMP, sizeof(struct pkat));
+	pkat->peer = peer;
+	monotime(&pkat->last);
+	return pkat;
+}
+
+static void pkat_del(void *pkat)
+{
+	XFREE(MTYPE_TMP, pkat);
+}
+/**
+ * Cleanup thread resources at termination.
+ *
+ * @param arg not used
+ */
+static void cleanup_handler(void *arg)
+{
+	if (peerlist)
+		list_delete(peerlist);
+
+	peerlist = NULL;
+
+	pthread_mutex_unlock(&peerlist_mtx);
+	pthread_cond_destroy(&peerlist_cond);
+	memset(&peerlist_cond, 0, sizeof(peerlist_cond));
+}
+
+/*
+ * Walks the list of peers, sending keepalives to those that are due for them.
+ *
+ * For any given peer, if the elapsed time since its last keepalive exceeds its
+ * configured keepalive timer, a keepalive is sent to the peer and its
+ * last-sent time is reset. Additionally, If the elapsed time does not exceed
+ * the configured keepalive timer, but the time until the next keepalive is due
+ * is within a hardcoded tolerance, a keepalive is sent as if the configured
+ * timer was exceeded. Doing this helps alleviate nanosecond sleeps between
+ * ticks by grouping together peers who are due for keepalives at roughly the
+ * same time. This tolerance value is arbitrarily chosen to be 100ms.
+ *
+ * In addition, this function calculates the maximum amount of time that the
+ * keepalive thread can sleep before another tick needs to take place. This is
+ * equivalent to shortest time until a keepalive is due for any one peer.
+ *
+ * @return maximum time to wait until next update (0 if infinity)
+ */
+static struct timeval update()
+{
+	struct listnode *ln;
+	struct pkat *pkat;
+
+	int update_set = 0;		// whether next_update has been set
+	struct timeval next_update;     // max sleep until next tick
+	static struct timeval elapsed;  // elapsed time since keepalive
+	static struct timeval ka = {0}; // peer->v_keepalive as a timeval
+	static struct timeval diff;     // ka - elapsed
+
+	// see function comment
+	static struct timeval tolerance = {0, 100000};
+
+	for (ALL_LIST_ELEMENTS_RO(peerlist, ln, pkat)) {
+		// calculate elapsed time since last keepalive
+		monotime_since(&pkat->last, &elapsed);
+
+		// calculate difference between elapsed time and configured time
+		ka.tv_sec = pkat->peer->v_keepalive;
+		timersub(&ka, &elapsed, &diff);
+
+		int send_keepalive = elapsed.tv_sec >= ka.tv_sec
+				     || timercmp(&diff, &tolerance, <);
+
+		if (send_keepalive) {
+			if (bgp_debug_neighbor_events(pkat->peer))
+				zlog_debug(
+					"%s [FSM] Timer (keepalive timer expire)",
+					pkat->peer->host);
+
+			bgp_keepalive_send(pkat->peer);
+			monotime(&pkat->last);
+			memset(&elapsed, 0x00, sizeof(struct timeval));
+			diff = ka; // time until next keepalive == peer
+				   // keepalive time
+		}
+
+		// if calculated next update for this peer < current delay, use
+		// it
+		if (!update_set || timercmp(&diff, &next_update, <)) {
+			next_update = diff;
+			update_set = 1;
+		}
+	}
+
+	return next_update;
+}
+
+void *peer_keepalives_start(void *arg)
+{
+	struct timeval currtime = {0, 0};
+	struct timeval next_update = {0, 0};
+	struct timespec next_update_ts = {0, 0};
+
+	// initialize synchronization primitives
+	pthread_mutex_lock(&peerlist_mtx);
+
+	// use monotonic clock with condition variable
+	pthread_condattr_t attrs;
+	pthread_condattr_init(&attrs);
+	pthread_condattr_setclock(&attrs, CLOCK_MONOTONIC);
+	pthread_cond_init(&peerlist_cond, &attrs);
+
+	// initialize peerlist
+	peerlist = list_new();
+	peerlist->del = pkat_del;
+
+	// register cleanup handlers
+	pthread_cleanup_push(&cleanup_handler, NULL);
+
+	bgp_keepalives_thread_run = true;
+
+	while (bgp_keepalives_thread_run) {
+		if (peerlist->count > 0)
+			pthread_cond_timedwait(&peerlist_cond, &peerlist_mtx,
+					       &next_update_ts);
+		else
+			while (peerlist->count == 0
+			       && bgp_keepalives_thread_run)
+				pthread_cond_wait(&peerlist_cond,
+						  &peerlist_mtx);
+
+		monotime(&currtime);
+		next_update = update();
+		timeradd(&currtime, &next_update, &next_update);
+		TIMEVAL_TO_TIMESPEC(&next_update, &next_update_ts);
+	}
+
+	// clean up
+	pthread_cleanup_pop(1);
+
+	return NULL;
+}
+
+/* --- thread external functions ------------------------------------------- */
+
+void peer_keepalives_on(struct peer *peer)
+{
+	pthread_mutex_lock(&peerlist_mtx);
+	{
+		struct listnode *ln, *nn;
+		struct pkat *pkat;
+
+		for (ALL_LIST_ELEMENTS(peerlist, ln, nn, pkat))
+			if (pkat->peer == peer) {
+				pthread_mutex_unlock(&peerlist_mtx);
+				return;
+			}
+
+		pkat = pkat_new(peer);
+		listnode_add(peerlist, pkat);
+		peer_lock(peer);
+	}
+	pthread_mutex_unlock(&peerlist_mtx);
+	peer_keepalives_wake();
+}
+
+void peer_keepalives_off(struct peer *peer)
+{
+	pthread_mutex_lock(&peerlist_mtx);
+	{
+		struct listnode *ln, *nn;
+		struct pkat *pkat;
+
+		for (ALL_LIST_ELEMENTS(peerlist, ln, nn, pkat))
+			if (pkat->peer == peer) {
+				XFREE(MTYPE_TMP, pkat);
+				list_delete_node(peerlist, ln);
+				peer_unlock(peer);
+			}
+	}
+	pthread_mutex_unlock(&peerlist_mtx);
+}
+
+void peer_keepalives_wake()
+{
+	pthread_mutex_lock(&peerlist_mtx);
+	{
+		pthread_cond_signal(&peerlist_cond);
+	}
+	pthread_mutex_unlock(&peerlist_mtx);
+}

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -215,6 +215,7 @@ void peer_keepalives_on(struct peer *peer)
 		pkat = pkat_new(peer);
 		listnode_add(peerlist, pkat);
 		peer_lock(peer);
+		SET_FLAG(peer->thread_flags, PEER_THREAD_KEEPALIVES_ON);
 	}
 	pthread_mutex_unlock(&peerlist_mtx);
 	peer_keepalives_wake();
@@ -233,6 +234,8 @@ void peer_keepalives_off(struct peer *peer)
 				list_delete_node(peerlist, ln);
 				peer_unlock(peer);
 			}
+
+		UNSET_FLAG(peer->thread_flags, PEER_THREAD_KEEPALIVES_ON);
 	}
 	pthread_mutex_unlock(&peerlist_mtx);
 }

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -31,6 +31,7 @@
 #include "vty.h"
 #include "monotime.h"
 #include "hash.h"
+#include "frr_pthread.h"
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_keepalives.h"
@@ -272,4 +273,13 @@ void peer_keepalives_wake()
 		pthread_cond_signal(peerhash_cond);
 	}
 	pthread_mutex_unlock(peerhash_mtx);
+}
+
+int peer_keepalives_stop(void **result)
+{
+	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_KEEPALIVES);
+	bgp_keepalives_thread_run = false;
+	peer_keepalives_wake();
+	pthread_join(fpt->thread, result);
+	return 0;
 }

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -155,7 +155,7 @@ void bgp_keepalives_init()
 	pthread_condattr_destroy(&attrs);
 
 	// initialize peer hashtable
-	peerhash = hash_create_size(2048, peer_hash_key, peer_hash_cmp);
+	peerhash = hash_create_size(2048, peer_hash_key, peer_hash_cmp, NULL);
 }
 
 static void bgp_keepalives_finish(void *arg)

--- a/bgpd/bgp_keepalives.h
+++ b/bgpd/bgp_keepalives.h
@@ -87,4 +87,7 @@ extern void *peer_keepalives_start(void *arg);
  */
 extern void peer_keepalives_wake(void);
 
+/* stop function */
+int peer_keepalives_stop(void **result);
+
 #endif /* _BGP_KEEPALIVES_H */

--- a/bgpd/bgp_keepalives.h
+++ b/bgpd/bgp_keepalives.h
@@ -24,6 +24,7 @@
 #ifndef _BGP_KEEPALIVES_H_
 #define _BGP_KEEPALIVES_H_
 
+#include "frr_pthread.h"
 #include "bgpd.h"
 
 /* Thread control flag.
@@ -88,6 +89,6 @@ extern void *peer_keepalives_start(void *arg);
 extern void peer_keepalives_wake(void);
 
 /* stop function */
-int peer_keepalives_stop(void **result);
+int peer_keepalives_stop(void **result, struct frr_pthread *fpt);
 
 #endif /* _BGP_KEEPALIVES_H */

--- a/bgpd/bgp_keepalives.h
+++ b/bgpd/bgp_keepalives.h
@@ -1,0 +1,83 @@
+/* BGP Keepalives.
+ *
+ * Implemented server-style in a pthread.
+ * --------------------------------------
+ * Copyright (C) 2017 Cumulus Networks, Inc.
+ *
+ * This file is part of Free Range Routing.
+ *
+ * Free Range Routing is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any later
+ * version.
+ *
+ * Free Range Routing is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GN5U General Public License along
+ * with Free Range Routing; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+#ifndef _BGP_KEEPALIVES_H_
+#define _BGP_KEEPALIVES_H_
+
+#include "bgpd.h"
+
+/* Thread control flag.
+ *
+ * Setting this flag to 'false' while the thread is running will result in
+ * thread termination.
+ */
+extern bool bgp_keepalives_thread_run;
+
+/* Turns on keepalives for a peer.
+ *
+ * This function adds the peer to an internal list of peers to generate
+ * keepalives for.
+ *
+ * At set intervals, a BGP KEEPALIVE packet is generated and placed on
+ * peer->obuf. This operation is thread-safe with respect to peer->obuf.
+ *
+ * peer->v_keepalive determines the interval. Changing this value before
+ * unregistering this peer with peer_keepalives_off() results in undefined
+ * behavior.
+ *
+ * If the peer is already registered for keepalives via this function, nothing
+ * happens.
+ */
+extern void peer_keepalives_on(struct peer *);
+
+/* Turns off keepalives for a peer.
+ *
+ * Removes the peer from the internal list of peers to generate keepalives for.
+ *
+ * If the peer is already unregistered for keepalives, nothing happens.
+ */
+extern void peer_keepalives_off(struct peer *);
+
+/* Entry function for keepalives pthread.
+ *
+ * This function loops over an internal list of peers, generating keepalives at
+ * regular intervals as determined by each peer's keepalive timer.
+ *
+ * See peer_keepalives_on() for additional details.
+ *
+ * @param arg pthread arg, not used
+ */
+extern void *peer_keepalives_start(void *arg);
+
+/* Poking function for keepalives pthread.
+ *
+ * Under normal circumstances the pthread will automatically wake itself
+ * whenever it is necessary to do work. This function may be used to force the
+ * thread to wake up and see if there is any work to do, or if it is time to
+ * die.
+ *
+ * It is not necessary to call this after peer_keepalives_on().
+ */
+extern void peer_keepalives_wake(void);
+
+#endif /* _BGP_KEEPALIVES_H */

--- a/bgpd/bgp_keepalives.h
+++ b/bgpd/bgp_keepalives.h
@@ -43,13 +43,13 @@ extern bool bgp_keepalives_thread_run;
  * peer->obuf. This operation is thread-safe with respect to peer->obuf.
  *
  * peer->v_keepalive determines the interval. Changing this value before
- * unregistering this peer with peer_keepalives_off() results in undefined
+ * unregistering this peer with bgp_keepalives_off() results in undefined
  * behavior.
  *
  * If the peer is already registered for keepalives via this function, nothing
  * happens.
  */
-extern void peer_keepalives_on(struct peer *);
+extern void bgp_keepalives_on(struct peer *);
 
 /* Turns off keepalives for a peer.
  *
@@ -57,25 +57,25 @@ extern void peer_keepalives_on(struct peer *);
  *
  * If the peer is already unregistered for keepalives, nothing happens.
  */
-extern void peer_keepalives_off(struct peer *);
+extern void bgp_keepalives_off(struct peer *);
 
 /* Pre-run initialization function for keepalives pthread.
  *
  * Initializes synchronization primitives. This should be called before
  * anything else to avoid race conditions.
  */
-extern void peer_keepalives_init(void);
+extern void bgp_keepalives_init(void);
 
 /* Entry function for keepalives pthread.
  *
  * This function loops over an internal list of peers, generating keepalives at
  * regular intervals as determined by each peer's keepalive timer.
  *
- * See peer_keepalives_on() for additional details.
+ * See bgp_keepalives_on() for additional details.
  *
  * @param arg pthread arg, not used
  */
-extern void *peer_keepalives_start(void *arg);
+extern void *bgp_keepalives_start(void *arg);
 
 /* Poking function for keepalives pthread.
  *
@@ -84,11 +84,11 @@ extern void *peer_keepalives_start(void *arg);
  * thread to wake up and see if there is any work to do, or if it is time to
  * die.
  *
- * It is not necessary to call this after peer_keepalives_on().
+ * It is not necessary to call this after bgp_keepalives_on().
  */
-extern void peer_keepalives_wake(void);
+extern void bgp_keepalives_wake(void);
 
 /* stop function */
-int peer_keepalives_stop(void **result, struct frr_pthread *fpt);
+int bgp_keepalives_stop(void **result, struct frr_pthread *fpt);
 
 #endif /* _BGP_KEEPALIVES_H */

--- a/bgpd/bgp_keepalives.h
+++ b/bgpd/bgp_keepalives.h
@@ -20,13 +20,14 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef _BGP_KEEPALIVES_H_
-#define _BGP_KEEPALIVES_H_
+#ifndef _FRR_BGP_KEEPALIVES_H
+#define _FRR_BGP_KEEPALIVES_H
 
 #include "frr_pthread.h"
 #include "bgpd.h"
 
-/* Turns on keepalives for a peer.
+/**
+ * Turns on keepalives for a peer.
  *
  * This function adds the peer to an internal list of peers to generate
  * keepalives for.
@@ -43,7 +44,8 @@
  */
 extern void bgp_keepalives_on(struct peer *);
 
-/* Turns off keepalives for a peer.
+/**
+ * Turns off keepalives for a peer.
  *
  * Removes the peer from the internal list of peers to generate keepalives for.
  *
@@ -51,14 +53,16 @@ extern void bgp_keepalives_on(struct peer *);
  */
 extern void bgp_keepalives_off(struct peer *);
 
-/* Pre-run initialization function for keepalives pthread.
+/**
+ * Pre-run initialization function for keepalives pthread.
  *
  * Initializes synchronization primitives. This should be called before
  * anything else to avoid race conditions.
  */
 extern void bgp_keepalives_init(void);
 
-/* Entry function for keepalives pthread.
+/**
+ * Entry function for keepalives pthread.
  *
  * This function loops over an internal list of peers, generating keepalives at
  * regular intervals as determined by each peer's keepalive timer.
@@ -69,7 +73,8 @@ extern void bgp_keepalives_init(void);
  */
 extern void *bgp_keepalives_start(void *arg);
 
-/* Poking function for keepalives pthread.
+/**
+ * Poking function for keepalives pthread.
  *
  * Under normal circumstances the pthread will automatically wake itself
  * whenever it is necessary to do work. This function may be used to force the
@@ -85,4 +90,4 @@ extern void bgp_keepalives_wake(void);
  */
 int bgp_keepalives_stop(void **result, struct frr_pthread *fpt);
 
-#endif /* _BGP_KEEPALIVES_H */
+#endif /* _FRR_BGP_KEEPALIVES_H */

--- a/bgpd/bgp_keepalives.h
+++ b/bgpd/bgp_keepalives.h
@@ -58,6 +58,13 @@ extern void peer_keepalives_on(struct peer *);
  */
 extern void peer_keepalives_off(struct peer *);
 
+/* Pre-run initialization function for keepalives pthread.
+ *
+ * Initializes synchronization primitives. This should be called before
+ * anything else to avoid race conditions.
+ */
+extern void peer_keepalives_init(void);
+
 /* Entry function for keepalives pthread.
  *
  * This function loops over an internal list of peers, generating keepalives at

--- a/bgpd/bgp_keepalives.h
+++ b/bgpd/bgp_keepalives.h
@@ -1,38 +1,30 @@
 /* BGP Keepalives.
- *
- * Implemented server-style in a pthread.
- * --------------------------------------
+ * Implements a producer thread to generate BGP keepalives for peers.
  * Copyright (C) 2017 Cumulus Networks, Inc.
+ * Quentin Young
  *
- * This file is part of Free Range Routing.
+ * This file is part of FRRouting.
  *
- * Free Range Routing is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any later
+ * FRRouting is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any later
  * version.
  *
- * Free Range Routing is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
+ * FRRouting is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
  *
- * You should have received a copy of the GN5U General Public License along
- * with Free Range Routing; see the file COPYING.  If not, write to the Free
- * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
+
 #ifndef _BGP_KEEPALIVES_H_
 #define _BGP_KEEPALIVES_H_
 
 #include "frr_pthread.h"
 #include "bgpd.h"
-
-/* Thread control flag.
- *
- * Setting this flag to 'false' while the thread is running will result in
- * thread termination.
- */
-extern bool bgp_keepalives_thread_run;
 
 /* Turns on keepalives for a peer.
  *
@@ -88,7 +80,9 @@ extern void *bgp_keepalives_start(void *arg);
  */
 extern void bgp_keepalives_wake(void);
 
-/* stop function */
+/**
+ * Stops the thread and blocks until it terminates.
+ */
 int bgp_keepalives_stop(void **result, struct frr_pthread *fpt);
 
 #endif /* _BGP_KEEPALIVES_H */

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -20,6 +20,7 @@
 
 #include <zebra.h>
 
+#include <pthread.h>
 #include "vector.h"
 #include "command.h"
 #include "getopt.h"
@@ -55,6 +56,7 @@
 #include "bgpd/bgp_filter.h"
 #include "bgpd/bgp_zebra.h"
 #include "bgpd/bgp_packet.h"
+#include "bgpd/bgp_keepalives.h"
 
 #ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/rfapi_backend.h"
@@ -393,8 +395,9 @@ int main(int argc, char **argv)
 	snprintf(bgpd_di.startinfo, sizeof(bgpd_di.startinfo), ", bgp@%s:%d",
 		 (bm->address ? bm->address : "<all>"), bm->port);
 
-	pthread_t packet_writes;
+	pthread_t packet_writes, keepalives;
 	pthread_create(&packet_writes, NULL, &peer_writes_start, NULL);
+	pthread_create(&keepalives, NULL, &keepalives_start, NULL);
 
 	frr_config_fork();
 	frr_run(bm->master);

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -194,6 +194,9 @@ static __attribute__((__noreturn__)) void bgp_exit(int status)
 	/* reverse bgp_attr_init */
 	bgp_attr_finish();
 
+	/* stop pthreads */
+	bgp_pthreads_finish();
+
 	/* reverse access_list_init */
 	access_list_add_hook(NULL);
 	access_list_delete_hook(NULL);
@@ -395,11 +398,9 @@ int main(int argc, char **argv)
 	snprintf(bgpd_di.startinfo, sizeof(bgpd_di.startinfo), ", bgp@%s:%d",
 		 (bm->address ? bm->address : "<all>"), bm->port);
 
-	pthread_t packet_writes, keepalives;
-	pthread_create(&packet_writes, NULL, &peer_writes_start, NULL);
-	pthread_create(&keepalives, NULL, &keepalives_start, NULL);
-
 	frr_config_fork();
+	/* must be called after fork() */
+	bgp_pthreads_init();
 	frr_run(bm->master);
 
 	/* Not reached. */

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -54,6 +54,7 @@
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_filter.h"
 #include "bgpd/bgp_zebra.h"
+#include "bgpd/bgp_packet.h"
 
 #ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/rfapi_backend.h"
@@ -391,6 +392,9 @@ int main(int argc, char **argv)
 
 	snprintf(bgpd_di.startinfo, sizeof(bgpd_di.startinfo), ", bgp@%s:%d",
 		 (bm->address ? bm->address : "<all>"), bm->port);
+
+	pthread_t packet_writes;
+	pthread_create(&packet_writes, NULL, &peer_writes_start, NULL);
 
 	frr_config_fork();
 	frr_run(bm->master);

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -400,7 +400,7 @@ int main(int argc, char **argv)
 
 	frr_config_fork();
 	/* must be called after fork() */
-	bgp_pthreads_init();
+	bgp_pthreads_run();
 	frr_run(bm->master);
 
 	/* Not reached. */

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -550,6 +550,8 @@ static int bgp_update_source(struct peer *peer)
 /* BGP try to connect to the peer.  */
 int bgp_connect(struct peer *peer)
 {
+	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON));
+	assert(!CHECK_FLAG(peer->thread_flags, PEER_THREAD_READS_ON));
 	ifindex_t ifindex = 0;
 
 	if (peer->conf_if && BGP_PEER_SU_UNSPEC(peer)) {

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -514,6 +514,7 @@ static int bgp_write_notify(struct peer *peer)
 	/* only connection reset/close gets counted as TCP_fatal_error, failure
 	 * to write the entire NOTIFY doesn't get different FSM treatment */
 	if (ret <= 0) {
+		stream_free(s);
 		BGP_EVENT_ADD(peer, TCP_fatal_error);
 		return 0;
 	}
@@ -542,6 +543,8 @@ static int bgp_write_notify(struct peer *peer)
 	/* Handle Graceful Restart case where the state changes to
 	   Connect instead of Idle */
 	BGP_EVENT_ADD(peer, BGP_Stop);
+
+	stream_free(s);
 
 	return 0;
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2362,6 +2362,8 @@ void peer_writes_on(struct peer *peer)
 
 		peer_lock(peer);
 		listnode_add(plist, peer);
+
+		SET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
 	}
 	pthread_mutex_unlock(&plist_mtx);
 	peer_writes_wake();
@@ -2382,6 +2384,8 @@ void peer_writes_off(struct peer *peer)
 				peer_unlock(peer);
 				break;
 			}
+
+		UNSET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
 	}
 	pthread_mutex_unlock(&plist_mtx);
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2079,22 +2079,6 @@ int bgp_process_packet(struct thread *thread)
 	rpkt_quanta_old = atomic_load_explicit(&peer->bgp->rpkt_quanta,
 					       memory_order_relaxed);
 
-	/*
-	 * XXX: At present multiple packet reads per input cycle are
-	 * problematic. The issue is that some of the packet processing
-	 * functions perform their own FSM checks, that arguably should be
-	 * located in bgp_fsm.c. For example if we are in OpenConfirm process a
-	 * Keepalive, then a keepalive-received event is placed on the event
-	 * queue to handle later. If we then process an Update before that
-	 * event has popped, the update function checks that the peer status is
-	 * in Established and if not tears down the session. Therefore we'll
-	 * limit input processing to 1 packet per cycle, as it traditionally
-	 * was, until this problem is rectified.
-	 *
-	 * @qlyoung June 2017
-	 */
-	rpkt_quanta_old = 1;
-
 	/* Guard against scheduled events that occur after peer deletion. */
 	if (peer->status == Deleted || peer->status == Clearing)
 		return 0;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -58,6 +58,7 @@
 #include "bgpd/bgp_updgrp.h"
 #include "bgpd/bgp_label.h"
 #include "bgpd/bgp_io.h"
+#include "bgpd/bgp_keepalives.h"
 
 /**
  * Sets marker and type fields for a BGP message.
@@ -654,6 +655,14 @@ void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 
 	/* Set BGP packet length. */
 	length = bgp_packet_set_size(s);
+
+	/*
+	 * Turn off keepalive generation for peer. This is necessary because
+	 * otherwise between the time we wipe the output buffer and the time we
+	 * push the NOTIFY onto it, the KA generation thread could have pushed
+	 * a KEEPALIVE in the middle.
+	 */
+	bgp_keepalives_off(peer);
 
 	/* wipe output buffer */
 	pthread_mutex_lock(&peer->io_mtx);

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -305,6 +305,59 @@ int bgp_nlri_parse(struct peer *peer, struct attr *attr,
 	return -1;
 }
 
+/* The next action for the peer from a write perspective */
+static void bgp_write_proceed_actions(struct peer *peer)
+{
+	afi_t afi;
+	safi_t safi;
+	struct peer_af *paf;
+	struct bpacket *next_pkt;
+	struct update_subgroup *subgrp;
+
+	for (afi = AFI_IP; afi < AFI_MAX; afi++)
+		for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
+			paf = peer_af_find(peer, afi, safi);
+			if (!paf)
+				continue;
+			subgrp = paf->subgroup;
+			if (!subgrp)
+				continue;
+
+			next_pkt = paf->next_pkt_to_send;
+			if (next_pkt && next_pkt->buffer) {
+				BGP_TIMER_ON(peer->t_generate_updgrp_packets,
+					     bgp_generate_updgrp_packets, 0);
+				return;
+			}
+
+			/* No packets readily available for AFI/SAFI, are there
+			 * subgroup packets
+			 * that need to be generated? */
+			if (bpacket_queue_is_full(SUBGRP_INST(subgrp),
+						  SUBGRP_PKTQ(subgrp))
+			    || subgroup_packets_to_build(subgrp)) {
+				BGP_TIMER_ON(peer->t_generate_updgrp_packets,
+					     bgp_generate_updgrp_packets, 0);
+				return;
+			}
+
+			/* No packets to send, see if EOR is pending */
+			if (CHECK_FLAG(peer->cap, PEER_CAP_RESTART_RCV)) {
+				if (!subgrp->t_coalesce
+				    && peer->afc_nego[afi][safi]
+				    && peer->synctime
+				    && !CHECK_FLAG(peer->af_sflags[afi][safi],
+						   PEER_STATUS_EOR_SEND)
+				    && safi != SAFI_MPLS_VPN) {
+					BGP_TIMER_ON(
+						peer->t_generate_updgrp_packets,
+						bgp_generate_updgrp_packets, 0);
+					return;
+				}
+			}
+		}
+}
+
 /**
  * Enqueue onto the peer's output buffer any packets which are pending for the
  * update group it is a member of.
@@ -406,6 +459,8 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 				bpacket_queue_advance_peer(paf);
 			}
 	} while (s);
+
+	bgp_write_proceed_actions(peer);
 
 	return 0;
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1963,15 +1963,35 @@ int bgp_process_packet(struct thread *thread)
 {
 	/* Yes first of all get peer pointer. */
 	struct peer *peer;
+	uint32_t rpkt_quanta_old;
+
 	peer = THREAD_ARG(thread);
+	rpkt_quanta_old = atomic_load_explicit(&peer->bgp->rpkt_quanta,
+					       memory_order_relaxed);
+
+	/*
+	 * XXX: At present multiple packet reads per input cycle are
+	 * problematic. The issue is that some of the packet processing
+	 * functions perform their own FSM checks, that arguably should be
+	 * located in bgp_fsm.c. For example if we are in OpenConfirm process a
+	 * Keepalive, then a keepalive-received event is placed on the event
+	 * queue to handle later. If we then process an Update before that
+	 * event has popped, the update function checks that the peer status is
+	 * in Established and if not tears down the session. Therefore we'll
+	 * limit input processing to 1 packet per cycle, as it traditionally
+	 * was, until this problem is rectified.
+	 *
+	 * @qlyoung June 2017
+	 */
+	rpkt_quanta_old = 1;
 
 	/* Guard against scheduled events that occur after peer deletion. */
 	if (peer->status == Deleted || peer->status == Clearing)
 		return 0;
 
-	int processed = 0;
+	unsigned int processed = 0;
 
-	while (processed < 5 && peer->ibuf->count > 0) {
+	while (processed < rpkt_quanta_old) {
 		u_char type = 0;
 		bgp_size_t size;
 		char notify_data_length[2];
@@ -2054,10 +2074,13 @@ int bgp_process_packet(struct thread *thread)
 		}
 	}
 
-	if (peer->ibuf->count > 0) { // more work to do, come back later
-		thread_add_background(bm->master, bgp_process_packet, peer, 0,
-				      &peer->t_process_packet);
+	pthread_mutex_lock(&peer->io_mtx);
+	{
+		if (peer->ibuf->count > 0) // more work to do, come back later
+			thread_add_event(bm->master, bgp_process_packet, peer,
+					 0, NULL);
 	}
+	pthread_mutex_unlock(&peer->io_mtx);
 
 	return 0;
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1,4 +1,6 @@
 /* BGP packet management routine.
+ * Contains utility functions for constructing and consuming BGP messages.
+ * Copyright (C) 2017 Cumulus Networks
  * Copyright (C) 1999 Kunihiro Ishiguro
  *
  * This file is part of GNU Zebra.
@@ -34,7 +36,6 @@
 #include "plist.h"
 #include "queue.h"
 #include "filter.h"
-#include "lib/frr_pthread.h"
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_table.h"
@@ -56,6 +57,7 @@
 #include "bgpd/bgp_vty.h"
 #include "bgpd/bgp_updgrp.h"
 #include "bgpd/bgp_label.h"
+#include "bgpd/bgp_io.h"
 
 /* Linked list of active peers */
 static pthread_mutex_t *plist_mtx;
@@ -99,17 +101,6 @@ int bgp_packet_set_size(struct stream *s)
 	return cp;
 }
 
-/**
- * Push a packet onto the beginning of the peer's output queue.
- * Must be externally synchronized around 'peer'.
- */
-static void bgp_packet_add_unsafe(struct peer *peer, struct stream *s)
-{
-	/* Add packet to the end of list. */
-	stream_fifo_push(peer->obuf, s);
-	peer_writes_wake();
-}
-
 /*
  * Push a packet onto the beginning of the peer's output queue.
  * This function acquires the peer's write mutex before proceeding.
@@ -117,17 +108,10 @@ static void bgp_packet_add_unsafe(struct peer *peer, struct stream *s)
 static void bgp_packet_add(struct peer *peer, struct stream *s)
 {
 	pthread_mutex_lock(&peer->obuf_mtx);
-	bgp_packet_add_unsafe(peer, s);
+	stream_fifo_push(peer->obuf, s);
 	pthread_mutex_unlock(&peer->obuf_mtx);
-}
 
-/**
- * Pop a packet off the end of the peer's output queue.
- * Must be externally synchronized around 'peer'.
- */
-static void bgp_packet_delete_unsafe(struct peer *peer)
-{
-	stream_free(stream_fifo_pop(peer->obuf));
+	peer_writes_wake();
 }
 
 static struct stream *bgp_update_packet_eor(struct peer *peer, afi_t afi,
@@ -172,10 +156,18 @@ static struct stream *bgp_update_packet_eor(struct peer *peer, afi_t afi,
 	return s;
 }
 
-/* Get next packet to be written.  */
-static struct stream *bgp_write_packet(struct peer *peer)
+/*
+ * Enqueue onto the peer's output buffer any packets which are pending for the
+ * update group it is a member of.
+ *
+ * XXX: Severely needs performance work.
+ */
+int bgp_generate_updgrp_packets(struct thread *thread)
 {
-	struct stream *s = NULL;
+	struct peer *peer = THREAD_ARG(thread);
+	peer->t_generate_updgrp_packets = NULL;
+
+	struct stream *s;
 	struct peer_af *paf;
 	struct bpacket *next_pkt;
 	afi_t afi;
@@ -187,103 +179,85 @@ static struct stream *bgp_write_packet(struct peer *peer)
 	 * update-delay post processing).
 	 */
 	if (peer->status != Established)
-		return NULL;
+		return 0;
 
 	if (peer->bgp && peer->bgp->main_peers_update_hold)
-		return NULL;
+		return 0;
 
-	FOREACH_AFI_SAFI (afi, safi) {
-		paf = peer_af_find(peer, afi, safi);
-		if (!paf || !PAF_SUBGRP(paf))
-			continue;
-		next_pkt = paf->next_pkt_to_send;
-
-		/* Try to generate a packet for the peer if we are at
-		 * the end of
-		 * the list. Always try to push out WITHDRAWs first. */
-		if (!next_pkt || !next_pkt->buffer) {
-			next_pkt = subgroup_withdraw_packet(PAF_SUBGRP(paf));
-			if (!next_pkt || !next_pkt->buffer)
-				subgroup_update_packet(PAF_SUBGRP(paf));
-			next_pkt = paf->next_pkt_to_send;
-		}
-
-			/* Try to generate a packet for the peer if we are at
-			 * the end of
-			 * the list. Always try to push out WITHDRAWs first. */
-			if (!next_pkt || !next_pkt->buffer) {
-				next_pkt = subgroup_withdraw_packet(
-					PAF_SUBGRP(paf));
-				if (!next_pkt || !next_pkt->buffer)
-					subgroup_update_packet(PAF_SUBGRP(paf));
+	do {
+		s = NULL;
+		for (afi = AFI_IP; afi < AFI_MAX; afi++)
+			for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
+				paf = peer_af_find(peer, afi, safi);
+				if (!paf || !PAF_SUBGRP(paf))
+					continue;
 				next_pkt = paf->next_pkt_to_send;
-			}
 
-			/* If we still don't have a packet to send to the peer,
-			 * then
-			 * try to find out out if we have to send eor or if not,
-			 * skip to
-			 * the next AFI, SAFI.
-			 * Don't send the EOR prematurely... if the subgroup's
-			 * coalesce
-			 * timer is running, the adjacency-out structure is not
-			 * created
-			 * yet.
-			 */
-			if (!next_pkt || !next_pkt->buffer) {
-				if (CHECK_FLAG(peer->cap,
-					       PEER_CAP_RESTART_RCV)) {
-					if (!(PAF_SUBGRP(paf))->t_coalesce
-					    && peer->afc_nego[afi][safi]
-					    && peer->synctime
-					    && !CHECK_FLAG(
-						       peer->af_sflags[afi]
-								      [safi],
-						       PEER_STATUS_EOR_SEND)) {
-						SET_FLAG(peer->af_sflags[afi]
-									[safi],
-							 PEER_STATUS_EOR_SEND);
-
-						if ((s = bgp_update_packet_eor(
-							     peer, afi, safi)))
-							bgp_packet_add(peer, s);
-
-						return s;
-					}
+				/* Try to generate a packet for the peer if we
+				 * are at the end of
+				 * the list. Always try to push out WITHDRAWs
+				 * first. */
+				if (!next_pkt || !next_pkt->buffer) {
+					next_pkt = subgroup_withdraw_packet(
+						PAF_SUBGRP(paf));
+					if (!next_pkt || !next_pkt->buffer)
+						subgroup_update_packet(
+							PAF_SUBGRP(paf));
+					next_pkt = paf->next_pkt_to_send;
 				}
+
+				/* If we still don't have a packet to send to
+				 * the peer, then
+				 * try to find out out if we have to send eor or
+				 * if not, skip to
+				 * the next AFI, SAFI.
+				 * Don't send the EOR prematurely... if the
+				 * subgroup's coalesce
+				 * timer is running, the adjacency-out structure
+				 * is not created
+				 * yet.
+				 */
+				if (!next_pkt || !next_pkt->buffer) {
+					if (CHECK_FLAG(peer->cap,
+						       PEER_CAP_RESTART_RCV)) {
+						if (!(PAF_SUBGRP(paf))
+							     ->t_coalesce
+						    && peer->afc_nego[afi][safi]
+						    && peer->synctime
+						    && !CHECK_FLAG(
+							       peer->af_sflags
+								       [afi]
+								       [safi],
+							       PEER_STATUS_EOR_SEND)) {
+							SET_FLAG(
+								peer->af_sflags
+									[afi]
+									[safi],
+								PEER_STATUS_EOR_SEND);
+
+							if ((s = bgp_update_packet_eor(
+								     peer, afi,
+								     safi)))
+								bgp_packet_add(
+									peer,
+									s);
+						}
+					}
+					continue;
+				}
+
+
+				/* Found a packet template to send, overwrite
+				 * packet with appropriate
+				 * attributes from peer and advance peer */
+				s = bpacket_reformat_for_peer(next_pkt, paf);
+				bgp_packet_add(peer, s);
+				bpacket_queue_advance_peer(paf);
 			}
-			continue;
-		}
+	} while (s);
 
-
-			/* Found a packet template to send, overwrite packet
-			 * with appropriate
-			 * attributes from peer and advance peer */
-			s = bpacket_reformat_for_peer(next_pkt, paf);
-			bgp_packet_add(peer, s);
-			bpacket_queue_advance_peer(paf);
-			return s;
-		}
-
-	return NULL;
-}
-
-static int bgp_generate_updgrp_packets(struct thread *thread)
-{
-	struct listnode *ln;
-	struct peer *peer;
-	pthread_mutex_lock(plist_mtx);
-	{
-		for (ALL_LIST_ELEMENTS_RO(plist, ln, peer))
-			while (bgp_write_packet(peer))
-				;
-
-		t_generate_updgrp_packets = NULL;
-	}
-	pthread_mutex_unlock(plist_mtx);
 	return 0;
 }
-
 
 /*
  * Creates a BGP Keepalive packet and appends it to the peer's output queue.
@@ -2166,268 +2140,5 @@ done:
 		peer->last_reset_cause_size = peer->packet_size;
 	}
 
-	return 0;
-}
-
-/* ------------- write thread ------------------ */
-
-/**
- * Flush peer output buffer.
- *
- * This function pops packets off of peer->obuf and writes them to peer->fd.
- * The amount of packets written is equal to the minimum of peer->wpkt_quanta
- * and the number of packets on the output buffer.
- *
- * If write() returns an error, the appropriate FSM event is generated.
- *
- * The return value is equal to the number of packets written
- * (which may be zero).
- */
-static int bgp_write(struct peer *peer)
-{
-	u_char type;
-	struct stream *s;
-	int num;
-	int update_last_write = 0;
-	unsigned int count = 0;
-	unsigned int oc = 0;
-
-	/* Write packets. The number of packets written is the value of
-	 * bgp->wpkt_quanta or the size of the output buffer, whichever is
-	 * smaller.*/
-	while (count < peer->bgp->wpkt_quanta
-	       && (s = stream_fifo_head(peer->obuf))) {
-		int writenum;
-		do { // write a full packet, or return on error
-			writenum = stream_get_endp(s) - stream_get_getp(s);
-			num = write(peer->fd, STREAM_PNT(s), writenum);
-
-			if (num < 0) {
-				if (!ERRNO_IO_RETRY(errno))
-					BGP_EVENT_ADD(peer, TCP_fatal_error);
-
-				goto done;
-			} else if (num != writenum) // incomplete write
-				stream_forward_getp(s, num);
-
-		} while (num != writenum);
-
-		/* Retrieve BGP packet type. */
-		stream_set_getp(s, BGP_MARKER_SIZE + 2);
-		type = stream_getc(s);
-
-		switch (type) {
-		case BGP_MSG_OPEN:
-			peer->open_out++;
-			break;
-		case BGP_MSG_UPDATE:
-			peer->update_out++;
-			break;
-		case BGP_MSG_NOTIFY:
-			peer->notify_out++;
-			/* Double start timer. */
-			peer->v_start *= 2;
-
-			/* Overflow check. */
-			if (peer->v_start >= (60 * 2))
-				peer->v_start = (60 * 2);
-
-			/* Handle Graceful Restart case where the state changes
-			   to
-			   Connect instead of Idle */
-			/* Flush any existing events */
-			BGP_EVENT_ADD(peer, BGP_Stop);
-			goto done;
-
-		case BGP_MSG_KEEPALIVE:
-			peer->keepalive_out++;
-			break;
-		case BGP_MSG_ROUTE_REFRESH_NEW:
-		case BGP_MSG_ROUTE_REFRESH_OLD:
-			peer->refresh_out++;
-			break;
-		case BGP_MSG_CAPABILITY:
-			peer->dynamic_cap_out++;
-			break;
-		}
-
-		count++;
-		/* OK we send packet so delete it. */
-		bgp_packet_delete_unsafe(peer);
-		update_last_write = 1;
-	}
-
-done : {
-	/* Update last_update if UPDATEs were written. */
-	if (peer->update_out > oc)
-		peer->last_update = bgp_clock();
-
-	/* If we TXed any flavor of packet update last_write */
-	if (update_last_write)
-		peer->last_write = bgp_clock();
-}
-
-	return count;
-}
-
-void peer_writes_init(void)
-{
-	plist_mtx = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_mutex_t));
-	write_cond = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_cond_t));
-
-	// initialize mutex
-	pthread_mutex_init(plist_mtx, NULL);
-
-	// use monotonic clock with condition variable
-	pthread_condattr_t attrs;
-	pthread_condattr_init(&attrs);
-	pthread_condattr_setclock(&attrs, CLOCK_MONOTONIC);
-	pthread_cond_init(write_cond, &attrs);
-	pthread_condattr_destroy(&attrs);
-
-	// initialize peerlist
-	plist = list_new();
-}
-
-static void peer_writes_finish(void *arg)
-{
-	bgp_packet_writes_thread_run = false;
-
-	if (plist)
-		list_delete(plist);
-
-	plist = NULL;
-
-	pthread_mutex_unlock(plist_mtx);
-	pthread_mutex_destroy(plist_mtx);
-	pthread_cond_destroy(write_cond);
-
-	XFREE(MTYPE_PTHREAD, plist_mtx);
-	XFREE(MTYPE_PTHREAD, write_cond);
-}
-
-/**
- * Entry function for peer packet flushing pthread.
- *
- * peer_writes_init() must be called prior to this.
- */
-void *peer_writes_start(void *arg)
-{
-	struct timeval currtime = {0, 0};
-	struct timeval sleeptime = {0, 500};
-	struct timespec next_update = {0, 0};
-
-	struct listnode *ln;
-	struct peer *peer;
-
-	pthread_mutex_lock(plist_mtx);
-
-	// register cleanup handler
-	pthread_cleanup_push(&peer_writes_finish, NULL);
-
-	bgp_packet_writes_thread_run = true;
-
-	while (bgp_packet_writes_thread_run) { // wait around until next update
-					       // time
-		if (plist->count > 0)
-			pthread_cond_timedwait(write_cond, plist_mtx,
-					       &next_update);
-		else // wait around until we have some peers
-			while (plist->count == 0
-			       && bgp_packet_writes_thread_run)
-				pthread_cond_wait(write_cond, plist_mtx);
-
-		for (ALL_LIST_ELEMENTS_RO(plist, ln, peer)) {
-			pthread_mutex_lock(&peer->obuf_mtx);
-			{
-				bgp_write(peer);
-			}
-			pthread_mutex_unlock(&peer->obuf_mtx);
-
-			if (!bgp_packet_writes_thread_run)
-				break;
-		}
-
-		// schedule update packet generation on main thread
-		if (!t_generate_updgrp_packets)
-			t_generate_updgrp_packets = thread_add_event(
-				bm->master, bgp_generate_updgrp_packets, NULL,
-				0);
-
-		monotime(&currtime);
-		timeradd(&currtime, &sleeptime, &currtime);
-		TIMEVAL_TO_TIMESPEC(&currtime, &next_update);
-	}
-
-	// clean up
-	pthread_cleanup_pop(1);
-
-	return NULL;
-}
-
-/**
- * Turns on packet writing for a peer.
- */
-void peer_writes_on(struct peer *peer)
-{
-	if (peer->status == Deleted)
-		return;
-
-	pthread_mutex_lock(plist_mtx);
-	{
-		struct listnode *ln, *nn;
-		struct peer *p;
-
-		// make sure this peer isn't already in the list
-		for (ALL_LIST_ELEMENTS(plist, ln, nn, p))
-			if (p == peer) {
-				pthread_mutex_unlock(plist_mtx);
-				return;
-			}
-
-		peer_lock(peer);
-		listnode_add(plist, peer);
-
-		SET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
-	}
-	pthread_mutex_unlock(plist_mtx);
-	peer_writes_wake();
-}
-
-/**
- * Turns off packet writing for a peer.
- */
-void peer_writes_off(struct peer *peer)
-{
-	struct listnode *ln, *nn;
-	struct peer *p;
-	pthread_mutex_lock(plist_mtx);
-	{
-		for (ALL_LIST_ELEMENTS(plist, ln, nn, p))
-			if (p == peer) {
-				list_delete_node(plist, ln);
-				peer_unlock(peer);
-				break;
-			}
-
-		UNSET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
-	}
-	pthread_mutex_unlock(plist_mtx);
-}
-
-/**
- * Wakes up the write thread to do work.
- */
-void peer_writes_wake()
-{
-	pthread_cond_signal(write_cond);
-}
-
-int peer_writes_stop(void **result)
-{
-	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_WRITE);
-	bgp_packet_writes_thread_run = false;
-	peer_writes_wake();
-	pthread_join(fpt->thread, result);
 	return 0;
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -59,7 +59,13 @@
 #include "bgpd/bgp_label.h"
 #include "bgpd/bgp_io.h"
 
-/* Set up BGP packet marker and packet type. */
+/**
+ * Sets marker and type fields for a BGP message.
+ *
+ * @param s the stream containing the packet
+ * @param type the packet type
+ * @return the size of the stream
+ */
 int bgp_packet_set_marker(struct stream *s, u_char type)
 {
 	int i;
@@ -78,8 +84,14 @@ int bgp_packet_set_marker(struct stream *s, u_char type)
 	return stream_get_endp(s);
 }
 
-/* Set BGP packet header size entry.  If size is zero then use current
-   stream size. */
+/**
+ * Sets size field for a BGP message.
+ *
+ * Size field is set to the size of the stream passed.
+ *
+ * @param s the stream containing the packet
+ * @return the size of the stream
+ */
 int bgp_packet_set_size(struct stream *s)
 {
 	int cp;
@@ -142,6 +154,149 @@ static struct stream *bgp_update_packet_eor(struct peer *peer, afi_t afi,
 
 	bgp_packet_set_size(s);
 	return s;
+}
+
+/* Called when there is a change in the EOR(implicit or explicit) status of a
+ * peer. Ends the update-delay if all expected peers are done with EORs. */
+void bgp_check_update_delay(struct bgp *bgp)
+{
+	struct listnode *node, *nnode;
+	struct peer *peer = NULL;
+
+	if (bgp_debug_neighbor_events(peer))
+		zlog_debug("Checking update delay, T: %d R: %d I:%d E: %d",
+			   bgp->established, bgp->restarted_peers,
+			   bgp->implicit_eors, bgp->explicit_eors);
+
+	if (bgp->established
+	    <= bgp->restarted_peers + bgp->implicit_eors + bgp->explicit_eors) {
+		/* This is an extra sanity check to make sure we wait for all
+		   the
+		   eligible configured peers. This check is performed if
+		   establish wait
+		   timer is on, or establish wait option is not given with the
+		   update-delay command */
+		if (bgp->t_establish_wait
+		    || (bgp->v_establish_wait == bgp->v_update_delay))
+			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
+				if (CHECK_FLAG(peer->flags,
+					       PEER_FLAG_CONFIG_NODE)
+				    && !CHECK_FLAG(peer->flags,
+						   PEER_FLAG_SHUTDOWN)
+				    && !peer->update_delay_over) {
+					if (bgp_debug_neighbor_events(peer))
+						zlog_debug(
+							" Peer %s pending, continuing read-only mode",
+							peer->host);
+					return;
+				}
+			}
+
+		zlog_info(
+			"Update delay ended, restarted: %d, EORs implicit: %d, explicit: %d",
+			bgp->restarted_peers, bgp->implicit_eors,
+			bgp->explicit_eors);
+		bgp_update_delay_end(bgp);
+	}
+}
+
+/* Called if peer is known to have restarted. The restart-state bit in
+   Graceful-Restart capability is used for that */
+void bgp_update_restarted_peers(struct peer *peer)
+{
+	if (!bgp_update_delay_active(peer->bgp))
+		return; /* BGP update delay has ended */
+	if (peer->update_delay_over)
+		return; /* This peer has already been considered */
+
+	if (bgp_debug_neighbor_events(peer))
+		zlog_debug("Peer %s: Checking restarted", peer->host);
+
+	if (peer->status == Established) {
+		peer->update_delay_over = 1;
+		peer->bgp->restarted_peers++;
+		bgp_check_update_delay(peer->bgp);
+	}
+}
+
+/* Called as peer receives a keep-alive. Determines if this occurence can be
+   taken as an implicit EOR for this peer.
+   NOTE: The very first keep-alive after the Established state of a peer is
+	 considered implicit EOR for the update-delay purposes */
+void bgp_update_implicit_eors(struct peer *peer)
+{
+	if (!bgp_update_delay_active(peer->bgp))
+		return; /* BGP update delay has ended */
+	if (peer->update_delay_over)
+		return; /* This peer has already been considered */
+
+	if (bgp_debug_neighbor_events(peer))
+		zlog_debug("Peer %s: Checking implicit EORs", peer->host);
+
+	if (peer->status == Established) {
+		peer->update_delay_over = 1;
+		peer->bgp->implicit_eors++;
+		bgp_check_update_delay(peer->bgp);
+	}
+}
+
+/* Should be called only when there is a change in the EOR_RECEIVED status
+   for any afi/safi on a peer */
+static void bgp_update_explicit_eors(struct peer *peer)
+{
+	afi_t afi;
+	safi_t safi;
+
+	if (!bgp_update_delay_active(peer->bgp))
+		return; /* BGP update delay has ended */
+	if (peer->update_delay_over)
+		return; /* This peer has already been considered */
+
+	if (bgp_debug_neighbor_events(peer))
+		zlog_debug("Peer %s: Checking explicit EORs", peer->host);
+
+	for (afi = AFI_IP; afi < AFI_MAX; afi++)
+		for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
+			if (peer->afc_nego[afi][safi]
+			    && !CHECK_FLAG(peer->af_sflags[afi][safi],
+					   PEER_STATUS_EOR_RECEIVED)) {
+				if (bgp_debug_neighbor_events(peer))
+					zlog_debug(
+						"   afi %d safi %d didnt receive EOR",
+						afi, safi);
+				return;
+			}
+		}
+
+	peer->update_delay_over = 1;
+	peer->bgp->explicit_eors++;
+	bgp_check_update_delay(peer->bgp);
+}
+
+/**
+ * Frontend for NLRI parsing, to fan-out to AFI/SAFI specific parsers.
+ *
+ * mp_withdraw, if set, is used to nullify attr structure on most of the
+ * calling safi function and for evpn, passed as parameter
+ */
+int bgp_nlri_parse(struct peer *peer, struct attr *attr,
+		   struct bgp_nlri *packet, int mp_withdraw)
+{
+	switch (packet->safi) {
+	case SAFI_UNICAST:
+	case SAFI_MULTICAST:
+		return bgp_nlri_parse_ip(peer, mp_withdraw ? NULL : attr,
+					 packet);
+	case SAFI_LABELED_UNICAST:
+		return bgp_nlri_parse_label(peer, mp_withdraw ? NULL : attr,
+					    packet);
+	case SAFI_MPLS_VPN:
+		return bgp_nlri_parse_vpn(peer, mp_withdraw ? NULL : attr,
+					  packet);
+	case SAFI_EVPN:
+		return bgp_nlri_parse_evpn(peer, attr, packet, mp_withdraw);
+	}
+	return -1;
 }
 
 /*
@@ -432,6 +587,18 @@ void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 		stream_fifo_clean(peer->obuf);
 	}
 	pthread_mutex_unlock(&peer->io_mtx);
+
+	/* If possible, store last packet for debugging purposes. This check is
+	 * in
+	 * place because we are sometimes called with a doppelganger peer, who
+	 * tends
+	 * to have a plethora of fields nulled out. */
+	if (peer->curr && peer->last_reset_cause_size) {
+		size_t packetsize = stream_get_endp(peer->curr);
+		assert(packetsize <= peer->last_reset_cause_size);
+		memcpy(peer->last_reset_cause, peer->curr->data, packetsize);
+		peer->last_reset_cause_size = packetsize;
+	}
 
 	/* For debug */
 	{
@@ -739,6 +906,42 @@ static int bgp_collision_detect(struct peer *new, struct in_addr remote_id)
 	return 0;
 }
 
+/* Packet processing routines ---------------------------------------------- */
+/*
+ * This is a family of functions designed to be called from
+ * bgp_process_packet(). These functions all share similar behavior and should
+ * adhere to the following invariants and restrictions:
+ *
+ * Return codes
+ * ------------
+ * The return code of any one of those functions should be one of the FSM event
+ * codes specified in bgpd.h. If a NOTIFY was sent, this event code MUST be
+ * BGP_Stop. Otherwise, the code SHOULD correspond to the function's expected
+ * packet type. For example, bgp_open_receive() should return BGP_Stop upon
+ * error and Receive_OPEN_message otherwise.
+ *
+ * If no action is necessary, the correct return code is BGP_PACKET_NOOP as
+ * defined below.
+ *
+ * Side effects
+ * ------------
+ * - May send NOTIFY messages
+ * - May not modify peer->status
+ * - May not call bgp_event_update()
+ */
+
+#define BGP_PACKET_NOOP 0
+
+/**
+ * Process BGP OPEN message for peer.
+ *
+ * If any errors are encountered in the OPEN message, immediately sends NOTIFY
+ * and returns BGP_Stop.
+ *
+ * @param peer
+ * @param size size of the packet
+ * @return as in summary
+ */
 static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 {
 	int ret;
@@ -781,7 +984,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		if (STREAM_READABLE(peer->curr) < optlen) {
 			bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
 					BGP_NOTIFY_OPEN_MALFORMED_ATTR);
-			return -1;
+			return BGP_Stop;
 		}
 
 		/* We need the as4 capability value *right now* because
@@ -801,7 +1004,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 					  BGP_NOTIFY_OPEN_BAD_PEER_AS,
 					  notify_data_remote_as4, 4);
-		return -1;
+		return BGP_Stop;
 	}
 
 	if (remote_as == BGP_AS_TRANS) {
@@ -816,7 +1019,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 			bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 						  BGP_NOTIFY_OPEN_BAD_PEER_AS,
 						  notify_data_remote_as4, 4);
-			return -1;
+			return BGP_Stop;
 		}
 
 		if (!as4 && BGP_DEBUG(as4, AS4))
@@ -846,7 +1049,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 			bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 						  BGP_NOTIFY_OPEN_BAD_PEER_AS,
 						  notify_data_remote_as4, 4);
-			return -1;
+			return BGP_Stop;
 		}
 	}
 
@@ -859,7 +1062,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 					  BGP_NOTIFY_OPEN_BAD_BGP_IDENT,
 					  notify_data_remote_id, 4);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* Set remote router-id */
@@ -877,7 +1080,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 					  BGP_NOTIFY_OPEN_UNSUP_VERSION,
 					  (u_int8_t *)&maxver, 2);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* Check neighbor as number. */
@@ -889,7 +1092,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 					  BGP_NOTIFY_OPEN_BAD_PEER_AS,
 					  notify_data_remote_as, 2);
-		return -1;
+		return BGP_Stop;
 	} else if (peer->as_type == AS_INTERNAL) {
 		if (remote_as != peer->bgp->as) {
 			if (bgp_debug_neighbor_events(peer))
@@ -899,7 +1102,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 			bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 						  BGP_NOTIFY_OPEN_BAD_PEER_AS,
 						  notify_data_remote_as, 2);
-			return -1;
+			return BGP_Stop;
 		}
 		peer->as = peer->local_as;
 	} else if (peer->as_type == AS_EXTERNAL) {
@@ -911,7 +1114,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 			bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 						  BGP_NOTIFY_OPEN_BAD_PEER_AS,
 						  notify_data_remote_as, 2);
-			return -1;
+			return BGP_Stop;
 		}
 		peer->as = remote_as;
 	} else if ((peer->as_type == AS_SPECIFIED) && (remote_as != peer->as)) {
@@ -921,7 +1124,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 					  BGP_NOTIFY_OPEN_BAD_PEER_AS,
 					  notify_data_remote_as, 2);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* From the rfc: Upon receipt of an OPEN message, a BGP speaker MUST
@@ -935,7 +1138,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		bgp_notify_send_with_data(peer, BGP_NOTIFY_OPEN_ERR,
 					  BGP_NOTIFY_OPEN_UNACEP_HOLDTIME,
 					  (u_char *)holdtime_ptr, 2);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* From the rfc: A reasonable maximum time between KEEPALIVE messages
@@ -964,7 +1167,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	if (optlen != 0) {
 		if ((ret = bgp_open_option_parse(peer, optlen, &mp_capability))
 		    < 0)
-			return ret;
+			return BGP_Stop;
 	} else {
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s rcvd OPEN w/ OPTION parameter len: 0",
@@ -998,13 +1201,13 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	   immidiately. */
 	ret = bgp_collision_detect(peer, remote_id);
 	if (ret < 0)
-		return ret;
+		return BGP_Stop;
 
 	/* Get sockname. */
 	if ((ret = bgp_getsockname(peer)) < 0) {
 		zlog_err("%s: bgp_getsockname() failed for peer: %s",
 			 __FUNCTION__, peer->host);
-		return (ret);
+		return BGP_Stop;
 	}
 
 	/* Verify valid local address present based on negotiated
@@ -1021,7 +1224,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 				peer->host, peer->fd);
 			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
 					BGP_NOTIFY_SUBCODE_UNSPECIFIC);
-			return -1;
+			return BGP_Stop;
 #endif
 		}
 	}
@@ -1037,166 +1240,42 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 				peer->host, peer->fd);
 			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
 					BGP_NOTIFY_SUBCODE_UNSPECIFIC);
-			return -1;
+			return BGP_Stop;
 #endif
 		}
 	}
 	peer->rtt = sockopt_tcp_rtt(peer->fd);
 
-	if ((ret = bgp_event_update(peer, Receive_OPEN_message)) < 0) {
-		zlog_err("%s: BGP event update failed for peer: %s",
-			 __FUNCTION__, peer->host);
-		/* DD: bgp send notify and reset state */
-		return (ret);
-	}
-
-	return 0;
+	return Receive_OPEN_message;
 }
 
-/* Called when there is a change in the EOR(implicit or explicit) status of a
-   peer.
-   Ends the update-delay if all expected peers are done with EORs. */
-void bgp_check_update_delay(struct bgp *bgp)
-{
-	struct listnode *node, *nnode;
-	struct peer *peer = NULL;
-
-	if (bgp_debug_neighbor_events(peer))
-		zlog_debug("Checking update delay, T: %d R: %d I:%d E: %d",
-			   bgp->established, bgp->restarted_peers,
-			   bgp->implicit_eors, bgp->explicit_eors);
-
-	if (bgp->established
-	    <= bgp->restarted_peers + bgp->implicit_eors + bgp->explicit_eors) {
-		/* This is an extra sanity check to make sure we wait for all
-		   the
-		   eligible configured peers. This check is performed if
-		   establish wait
-		   timer is on, or establish wait option is not given with the
-		   update-delay command */
-		if (bgp->t_establish_wait
-		    || (bgp->v_establish_wait == bgp->v_update_delay))
-			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-				if (CHECK_FLAG(peer->flags,
-					       PEER_FLAG_CONFIG_NODE)
-				    && !CHECK_FLAG(peer->flags,
-						   PEER_FLAG_SHUTDOWN)
-				    && !peer->update_delay_over) {
-					if (bgp_debug_neighbor_events(peer))
-						zlog_debug(
-							" Peer %s pending, continuing read-only mode",
-							peer->host);
-					return;
-				}
-			}
-
-		zlog_info(
-			"Update delay ended, restarted: %d, EORs implicit: %d, explicit: %d",
-			bgp->restarted_peers, bgp->implicit_eors,
-			bgp->explicit_eors);
-		bgp_update_delay_end(bgp);
-	}
-}
-
-/* Called if peer is known to have restarted. The restart-state bit in
-   Graceful-Restart capability is used for that */
-void bgp_update_restarted_peers(struct peer *peer)
-{
-	if (!bgp_update_delay_active(peer->bgp))
-		return; /* BGP update delay has ended */
-	if (peer->update_delay_over)
-		return; /* This peer has already been considered */
-
-	if (bgp_debug_neighbor_events(peer))
-		zlog_debug("Peer %s: Checking restarted", peer->host);
-
-	if (peer->status == Established) {
-		peer->update_delay_over = 1;
-		peer->bgp->restarted_peers++;
-		bgp_check_update_delay(peer->bgp);
-	}
-}
-
-/* Called as peer receives a keep-alive. Determines if this occurence can be
-   taken as an implicit EOR for this peer.
-   NOTE: The very first keep-alive after the Established state of a peer is
-	 considered implicit EOR for the update-delay purposes */
-void bgp_update_implicit_eors(struct peer *peer)
-{
-	if (!bgp_update_delay_active(peer->bgp))
-		return; /* BGP update delay has ended */
-	if (peer->update_delay_over)
-		return; /* This peer has already been considered */
-
-	if (bgp_debug_neighbor_events(peer))
-		zlog_debug("Peer %s: Checking implicit EORs", peer->host);
-
-	if (peer->status == Established) {
-		peer->update_delay_over = 1;
-		peer->bgp->implicit_eors++;
-		bgp_check_update_delay(peer->bgp);
-	}
-}
-
-/* Should be called only when there is a change in the EOR_RECEIVED status
-   for any afi/safi on a peer */
-static void bgp_update_explicit_eors(struct peer *peer)
-{
-	afi_t afi;
-	safi_t safi;
-
-	if (!bgp_update_delay_active(peer->bgp))
-		return; /* BGP update delay has ended */
-	if (peer->update_delay_over)
-		return; /* This peer has already been considered */
-
-	if (bgp_debug_neighbor_events(peer))
-		zlog_debug("Peer %s: Checking explicit EORs", peer->host);
-
-	FOREACH_AFI_SAFI (afi, safi) {
-		if (peer->afc_nego[afi][safi]
-		    && !CHECK_FLAG(peer->af_sflags[afi][safi],
-				   PEER_STATUS_EOR_RECEIVED)) {
-			if (bgp_debug_neighbor_events(peer))
-				zlog_debug(
-					"   afi %d safi %d didnt receive EOR",
-					afi, safi);
-			return;
-		}
-	}
-
-	peer->update_delay_over = 1;
-	peer->bgp->explicit_eors++;
-	bgp_check_update_delay(peer->bgp);
-}
-
-/* Frontend for NLRI parsing, to fan-out to AFI/SAFI specific parsers
- * mp_withdraw, if set, is used to nullify attr structure on most of the calling
- * safi function
- * and for evpn, passed as parameter
+/**
+ * Process BGP KEEPALIVE message for peer.
+ *
+ * @param peer
+ * @param size size of the packet
+ * @return as in summary
  */
-int bgp_nlri_parse(struct peer *peer, struct attr *attr,
-		   struct bgp_nlri *packet, int mp_withdraw)
+static int bgp_keepalive_receive(struct peer *peer, bgp_size_t size)
 {
-	switch (packet->safi) {
-	case SAFI_UNICAST:
-	case SAFI_MULTICAST:
-		return bgp_nlri_parse_ip(peer, mp_withdraw ? NULL : attr,
-					 packet);
-	case SAFI_LABELED_UNICAST:
-		return bgp_nlri_parse_label(peer, mp_withdraw ? NULL : attr,
-					    packet);
-	case SAFI_MPLS_VPN:
-		return bgp_nlri_parse_vpn(peer, mp_withdraw ? NULL : attr,
-					  packet);
-	case SAFI_EVPN:
-		return bgp_nlri_parse_evpn(peer, attr, packet, mp_withdraw);
-	default:
-		return -1;
-	}
+	if (bgp_debug_keepalive(peer))
+		zlog_debug("%s KEEPALIVE rcvd", peer->host);
+
+	bgp_update_implicit_eors(peer);
+
+	return Receive_KEEPALIVE_message;
 }
 
-/* Parse BGP Update packet and make attribute object. */
+
+/**
+ * Process BGP UPDATE message for peer.
+ *
+ * Parses UPDATE and creates attribute object.
+ *
+ * @param peer
+ * @param size size of the packet
+ * @return as in summary
+ */
 static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 {
 	int ret, nlri_ret;
@@ -1222,7 +1301,7 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			 peer->host,
 			 lookup_msg(bgp_status_msg, peer->status, NULL));
 		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR, 0);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* Set initial values. */
@@ -1247,7 +1326,7 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			peer->host);
 		bgp_notify_send(peer, BGP_NOTIFY_UPDATE_ERR,
 				BGP_NOTIFY_UPDATE_MAL_ATTR);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* Unfeasible Route Length. */
@@ -1261,7 +1340,7 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			peer->host, withdraw_len);
 		bgp_notify_send(peer, BGP_NOTIFY_UPDATE_ERR,
 				BGP_NOTIFY_UPDATE_MAL_ATTR);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* Unfeasible Route packet format check. */
@@ -1281,7 +1360,7 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			peer->host);
 		bgp_notify_send(peer, BGP_NOTIFY_UPDATE_ERR,
 				BGP_NOTIFY_UPDATE_MAL_ATTR);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* Fetch attribute total length. */
@@ -1295,7 +1374,7 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			peer->host, attribute_len);
 		bgp_notify_send(peer, BGP_NOTIFY_UPDATE_ERR,
 				BGP_NOTIFY_UPDATE_MAL_ATTR);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* Certain attribute parsing errors should not be considered bad enough
@@ -1318,7 +1397,7 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 						&nlris[NLRI_MP_WITHDRAW]);
 		if (attr_parse_ret == BGP_ATTR_PARSE_ERROR) {
 			bgp_attr_unintern_sub(&attr);
-			return -1;
+			return BGP_Stop;
 		}
 	}
 
@@ -1397,7 +1476,7 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 						? BGP_NOTIFY_UPDATE_INVAL_NETWORK
 						: BGP_NOTIFY_UPDATE_OPT_ATTR_ERR);
 			bgp_attr_unintern_sub(&attr);
-			return -1;
+			return BGP_Stop;
 		}
 	}
 
@@ -1453,24 +1532,23 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 	   interned in bgp_attr_parse(). */
 	bgp_attr_unintern_sub(&attr);
 
-	/* If peering is stopped due to some reason, do not generate BGP
-	   event.  */
-	if (peer->status != Established)
-		return 0;
-
-	/* Increment packet counter. */
-	peer->update_in++;
 	peer->update_time = bgp_clock();
 
 	/* Rearm holdtime timer */
 	BGP_TIMER_OFF(peer->t_holdtime);
 	bgp_timer_set(peer);
 
-	return 0;
+	return Receive_UPDATE_message;
 }
 
-/* Notify message treatment function. */
-static void bgp_notify_receive(struct peer *peer, bgp_size_t size)
+/**
+ * Process BGP NOTIFY message for peer.
+ *
+ * @param peer
+ * @param size size of the packet
+ * @return as in summary
+ */
+static int bgp_notify_receive(struct peer *peer, bgp_size_t size)
 {
 	struct bgp_notify bgp_notify;
 
@@ -1539,20 +1617,17 @@ static void bgp_notify_receive(struct peer *peer, bgp_size_t size)
 	    && bgp_notify.subcode == BGP_NOTIFY_OPEN_UNSUP_PARAM)
 		UNSET_FLAG(peer->sflags, PEER_STATUS_CAPABILITY_OPEN);
 
-	BGP_EVENT_ADD(peer, Receive_NOTIFICATION_message);
+	return Receive_NOTIFICATION_message;
 }
 
-/* Keepalive treatment function -- get keepalive send keepalive */
-static void bgp_keepalive_receive(struct peer *peer, bgp_size_t size)
-{
-	if (bgp_debug_keepalive(peer))
-		zlog_debug("%s KEEPALIVE rcvd", peer->host);
-
-	BGP_EVENT_ADD(peer, Receive_KEEPALIVE_message);
-}
-
-/* Route refresh message is received. */
-static void bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
+/**
+ * Process BGP ROUTEREFRESH message for peer.
+ *
+ * @param peer
+ * @param size size of the packet
+ * @return as in summary
+ */
+static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 {
 	iana_afi_t pkt_afi;
 	afi_t afi;
@@ -1569,7 +1644,7 @@ static void bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 			 peer->host);
 		bgp_notify_send(peer, BGP_NOTIFY_HEADER_ERR,
 				BGP_NOTIFY_HEADER_BAD_MESTYPE);
-		return;
+		return BGP_Stop;
 	}
 
 	/* Status must be Established. */
@@ -1579,7 +1654,7 @@ static void bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 			peer->host,
 			lookup_msg(bgp_status_msg, peer->status, NULL));
 		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR, 0);
-		return;
+		return BGP_Stop;
 	}
 
 	s = peer->curr;
@@ -1598,7 +1673,7 @@ static void bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 		zlog_info(
 			"%s REFRESH_REQ for unrecognized afi/safi: %d/%d - ignored",
 			peer->host, pkt_afi, pkt_safi);
-		return;
+		return BGP_PACKET_NOOP;
 	}
 
 	if (size != BGP_MSG_ROUTE_REFRESH_MIN_SIZE - BGP_HEADER_SIZE) {
@@ -1612,7 +1687,7 @@ static void bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 			zlog_info("%s ORF route refresh length error",
 				  peer->host);
 			bgp_notify_send(peer, BGP_NOTIFY_CEASE, 0);
-			return;
+			return BGP_Stop;
 		}
 
 		when_to_refresh = stream_getc(s);
@@ -1783,7 +1858,7 @@ static void bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 					   ? "Defer"
 					   : "Immediate");
 		if (when_to_refresh == REFRESH_DEFER)
-			return;
+			return BGP_PACKET_NOOP;
 	}
 
 	/* First update is deferred until ORF or ROUTE-REFRESH is received */
@@ -1814,8 +1889,18 @@ static void bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 
 	/* Perform route refreshment to the peer */
 	bgp_announce_route(peer, afi, safi);
+
+	/* No FSM action necessary */
+	return BGP_PACKET_NOOP;
 }
 
+/**
+ * Parse BGP CAPABILITY message for peer.
+ *
+ * @param peer
+ * @param size size of the packet
+ * @return as in summary
+ */
 static int bgp_capability_msg_parse(struct peer *peer, u_char *pnt,
 				    bgp_size_t length)
 {
@@ -1836,7 +1921,7 @@ static int bgp_capability_msg_parse(struct peer *peer, u_char *pnt,
 		if (pnt + 3 > end) {
 			zlog_info("%s Capability length error", peer->host);
 			bgp_notify_send(peer, BGP_NOTIFY_CEASE, 0);
-			return -1;
+			return BGP_Stop;
 		}
 		action = *pnt;
 		hdr = (struct capability_header *)(pnt + 1);
@@ -1847,7 +1932,7 @@ static int bgp_capability_msg_parse(struct peer *peer, u_char *pnt,
 			zlog_info("%s Capability Action Value error %d",
 				  peer->host, action);
 			bgp_notify_send(peer, BGP_NOTIFY_CEASE, 0);
-			return -1;
+			return BGP_Stop;
 		}
 
 		if (bgp_debug_neighbor_events(peer))
@@ -1859,7 +1944,7 @@ static int bgp_capability_msg_parse(struct peer *peer, u_char *pnt,
 		if ((pnt + hdr->length + 3) > end) {
 			zlog_info("%s Capability length error", peer->host);
 			bgp_notify_send(peer, BGP_NOTIFY_CEASE, 0);
-			return -1;
+			return BGP_Stop;
 		}
 
 		/* Fetch structure to the byte stream. */
@@ -1910,7 +1995,7 @@ static int bgp_capability_msg_parse(struct peer *peer, u_char *pnt,
 				if (peer_active_nego(peer))
 					bgp_clear_route(peer, afi, safi);
 				else
-					BGP_EVENT_ADD(peer, BGP_Stop);
+					return BGP_Stop;
 			}
 		} else {
 			zlog_warn(
@@ -1918,12 +2003,19 @@ static int bgp_capability_msg_parse(struct peer *peer, u_char *pnt,
 				peer->host, hdr->code);
 		}
 	}
-	return 0;
+
+	/* No FSM action necessary */
+	return BGP_PACKET_NOOP;
 }
 
-/* Dynamic Capability is received.
+/**
+ * Parse BGP CAPABILITY message for peer.
  *
- * This is exported for unit-test purposes
+ * Exported for unit testing.
+ *
+ * @param peer
+ * @param size size of the packet
+ * @return as in summary
  */
 int bgp_capability_receive(struct peer *peer, bgp_size_t size)
 {
@@ -1941,7 +2033,7 @@ int bgp_capability_receive(struct peer *peer, bgp_size_t size)
 			 peer->host);
 		bgp_notify_send(peer, BGP_NOTIFY_HEADER_ERR,
 				BGP_NOTIFY_HEADER_BAD_MESTYPE);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* Status must be Established. */
@@ -1951,19 +2043,34 @@ int bgp_capability_receive(struct peer *peer, bgp_size_t size)
 			peer->host,
 			lookup_msg(bgp_status_msg, peer->status, NULL));
 		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR, 0);
-		return -1;
+		return BGP_Stop;
 	}
 
 	/* Parse packet. */
 	return bgp_capability_msg_parse(peer, pnt, size);
 }
 
-/* Starting point of packet process function. */
+/**
+ * Processes a peer's input buffer.
+ *
+ * This function sidesteps the event loop and directly calls bgp_event_update()
+ * after processing each BGP message. This is necessary to ensure proper
+ * ordering of FSM events and unifies the behavior that was present previously,
+ * whereby some of the packet handling functions would update the FSM and some
+ * would not, making event flow difficult to understand. Please think twice
+ * before hacking this.
+ *
+ * Thread type: THREAD_EVENT
+ * @param thread
+ * @return 0
+ */
 int bgp_process_packet(struct thread *thread)
 {
 	/* Yes first of all get peer pointer. */
-	struct peer *peer;
-	uint32_t rpkt_quanta_old;
+	struct peer *peer;	// peer
+	uint32_t rpkt_quanta_old; // how many packets to read
+	int fsm_update_result;    // return code of bgp_event_update()
+	int mprc;		  // message processing return code
 
 	peer = THREAD_ARG(thread);
 	rpkt_quanta_old = atomic_load_explicit(&peer->bgp->rpkt_quanta,
@@ -1995,11 +2102,6 @@ int bgp_process_packet(struct thread *thread)
 		u_char type = 0;
 		bgp_size_t size;
 		char notify_data_length[2];
-		u_int32_t notify_out;
-
-		/* Note notify_out so we can check later to see if we sent
-		 * another one */
-		notify_out = peer->notify_out;
 
 		pthread_mutex_lock(&peer->io_mtx);
 		{
@@ -2009,8 +2111,6 @@ int bgp_process_packet(struct thread *thread)
 
 		if (peer->curr == NULL) // no packets to process, hmm...
 			return 0;
-
-		bgp_size_t actual_size = stream_get_endp(peer->curr);
 
 		/* skip the marker and copy the packet length */
 		stream_forward_getp(peer->curr, BGP_MARKER_SIZE);
@@ -2031,56 +2131,85 @@ int bgp_process_packet(struct thread *thread)
 		switch (type) {
 		case BGP_MSG_OPEN:
 			peer->open_in++;
-			bgp_open_receive(peer,
-					 size); /* XXX return value ignored! */
+			mprc = bgp_open_receive(peer, size);
+			if (mprc == BGP_Stop)
+				zlog_err(
+					"%s: BGP OPEN receipt failed for peer: %s",
+					__FUNCTION__, peer->host);
 			break;
 		case BGP_MSG_UPDATE:
+			peer->update_in++;
 			peer->readtime = monotime(NULL);
-			bgp_update_receive(peer, size);
+			mprc = bgp_update_receive(peer, size);
+			if (mprc == BGP_Stop)
+				zlog_err(
+					"%s: BGP UPDATE receipt failed for peer: %s",
+					__FUNCTION__, peer->host);
 			break;
 		case BGP_MSG_NOTIFY:
-			bgp_notify_receive(peer, size);
+			peer->notify_in++;
+			mprc = bgp_notify_receive(peer, size);
+			if (mprc == BGP_Stop)
+				zlog_err(
+					"%s: BGP NOTIFY receipt failed for peer: %s",
+					__FUNCTION__, peer->host);
 			break;
 		case BGP_MSG_KEEPALIVE:
 			peer->readtime = monotime(NULL);
-			bgp_keepalive_receive(peer, size);
+			peer->keepalive_in++;
+			mprc = bgp_keepalive_receive(peer, size);
+			if (mprc == BGP_Stop)
+				zlog_err(
+					"%s: BGP KEEPALIVE receipt failed for peer: %s",
+					__FUNCTION__, peer->host);
 			break;
 		case BGP_MSG_ROUTE_REFRESH_NEW:
 		case BGP_MSG_ROUTE_REFRESH_OLD:
 			peer->refresh_in++;
-			bgp_route_refresh_receive(peer, size);
+			mprc = bgp_route_refresh_receive(peer, size);
+			if (mprc == BGP_Stop)
+				zlog_err(
+					"%s: BGP ROUTEREFRESH receipt failed for peer: %s",
+					__FUNCTION__, peer->host);
 			break;
 		case BGP_MSG_CAPABILITY:
 			peer->dynamic_cap_in++;
-			bgp_capability_receive(peer, size);
+			mprc = bgp_capability_receive(peer, size);
+			if (mprc == BGP_Stop)
+				zlog_err(
+					"%s: BGP CAPABILITY receipt failed for peer: %s",
+					__FUNCTION__, peer->host);
 			break;
 		}
 
-		/* If reading this packet caused us to send a NOTIFICATION then
-		 * store a copy
-		 * of the packet for troubleshooting purposes
-		 */
-		if (notify_out < peer->notify_out) {
-			memcpy(peer->last_reset_cause, peer->curr->data,
-			       actual_size);
-			peer->last_reset_cause_size = actual_size;
-		}
+		/* delete processed packet */
+		stream_free(peer->curr);
+		peer->curr = NULL;
+		processed++;
 
-		/* Delete packet and carry on. */
-		if (peer->curr) {
-			stream_free(peer->curr);
-			peer->curr = NULL;
-			processed++;
-		}
+		/* Update FSM */
+		if (mprc != BGP_PACKET_NOOP)
+			fsm_update_result = bgp_event_update(peer, mprc);
+
+		/* If peer was deleted, do not process any more packets. This is
+		 * usually
+		 * due to executing BGP_Stop or a stub deletion. */
+		if (fsm_update_result == FSM_PEER_TRANSFERRED
+		    || fsm_update_result == FSM_PEER_STOPPED)
+			break;
 	}
 
-	pthread_mutex_lock(&peer->io_mtx);
-	{
-		if (peer->ibuf->count > 0) // more work to do, come back later
-			thread_add_event(bm->master, bgp_process_packet, peer,
-					 0, NULL);
+	if (fsm_update_result != FSM_PEER_TRANSFERRED
+	    && fsm_update_result != FSM_PEER_STOPPED) {
+		pthread_mutex_lock(&peer->io_mtx);
+		{
+			if (peer->ibuf->count
+			    > 0) // more work to do, come back later
+				thread_add_event(bm->master, bgp_process_packet,
+						 peer, 0, NULL);
+		}
+		pthread_mutex_unlock(&peer->io_mtx);
 	}
-	pthread_mutex_unlock(&peer->io_mtx);
 
 	return 0;
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2318,6 +2318,9 @@ void *peer_writes_start(void *arg)
 				bgp_write(peer);
 			}
 			pthread_mutex_unlock(&peer->obuf_mtx);
+
+			if (!bgp_packet_writes_thread_run)
+				break;
 		}
 
 		// schedule update packet generation on main thread

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -57,14 +57,14 @@
 #include "bgpd/bgp_label.h"
 
 /* Linked list of active peers */
-static pthread_mutex_t plist_mtx = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t write_cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t *plist_mtx;
+static pthread_cond_t *write_cond;
 static struct list *plist;
 
 /* periodically scheduled thread to generate update-group updates */
 static struct thread *t_generate_updgrp_packets;
 
-bool bgp_packet_writes_thread_run;
+bool bgp_packet_writes_thread_run = false;
 
 /* Set up BGP packet marker and packet type. */
 int bgp_packet_set_marker(struct stream *s, u_char type)
@@ -271,7 +271,7 @@ static int bgp_generate_updgrp_packets(struct thread *thread)
 {
 	struct listnode *ln;
 	struct peer *peer;
-	pthread_mutex_lock(&plist_mtx);
+	pthread_mutex_lock(plist_mtx);
 	{
 		for (ALL_LIST_ELEMENTS_RO(plist, ln, peer))
 			while (bgp_write_packet(peer))
@@ -279,7 +279,7 @@ static int bgp_generate_updgrp_packets(struct thread *thread)
 
 		t_generate_updgrp_packets = NULL;
 	}
-	pthread_mutex_unlock(&plist_mtx);
+	pthread_mutex_unlock(plist_mtx);
 	return 0;
 }
 
@@ -2270,20 +2270,46 @@ done : {
 	return count;
 }
 
-static void cleanup_handler(void *arg)
+void peer_writes_init(void)
 {
+	plist_mtx = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_mutex_t));
+	write_cond = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_cond_t));
+
+	// initialize mutex
+	pthread_mutex_init(plist_mtx, NULL);
+
+	// use monotonic clock with condition variable
+	pthread_condattr_t attrs;
+	pthread_condattr_init(&attrs);
+	pthread_condattr_setclock(&attrs, CLOCK_MONOTONIC);
+	pthread_cond_init(write_cond, &attrs);
+	pthread_condattr_destroy(&attrs);
+
+	// initialize peerlist
+	plist = list_new();
+}
+
+static void peer_writes_finish(void *arg)
+{
+	bgp_packet_writes_thread_run = false;
+
 	if (plist)
 		list_delete(plist);
 
 	plist = NULL;
 
-	pthread_mutex_unlock(&plist_mtx);
+	pthread_mutex_unlock(plist_mtx);
+	pthread_mutex_destroy(plist_mtx);
+	pthread_cond_destroy(write_cond);
+
+	XFREE(MTYPE_PTHREAD, plist_mtx);
+	XFREE(MTYPE_PTHREAD, write_cond);
 }
 
 /**
  * Entry function for peer packet flushing pthread.
  *
- * The plist must be initialized before calling this.
+ * peer_writes_init() must be called prior to this.
  */
 void *peer_writes_start(void *arg)
 {
@@ -2291,26 +2317,25 @@ void *peer_writes_start(void *arg)
 	struct timeval sleeptime = {0, 500};
 	struct timespec next_update = {0, 0};
 
-	// initialize
-	pthread_mutex_lock(&plist_mtx);
-	plist = list_new();
-
 	struct listnode *ln;
 	struct peer *peer;
 
-	pthread_cleanup_push(&cleanup_handler, NULL);
+	pthread_mutex_lock(plist_mtx);
+
+	// register cleanup handler
+	pthread_cleanup_push(&peer_writes_finish, NULL);
 
 	bgp_packet_writes_thread_run = true;
 
 	while (bgp_packet_writes_thread_run) { // wait around until next update
 					       // time
 		if (plist->count > 0)
-			pthread_cond_timedwait(&write_cond, &plist_mtx,
+			pthread_cond_timedwait(write_cond, plist_mtx,
 					       &next_update);
 		else // wait around until we have some peers
 			while (plist->count == 0
 			       && bgp_packet_writes_thread_run)
-				pthread_cond_wait(&write_cond, &plist_mtx);
+				pthread_cond_wait(write_cond, plist_mtx);
 
 		for (ALL_LIST_ELEMENTS_RO(plist, ln, peer)) {
 			pthread_mutex_lock(&peer->obuf_mtx);
@@ -2329,7 +2354,7 @@ void *peer_writes_start(void *arg)
 				bm->master, bgp_generate_updgrp_packets, NULL,
 				0);
 
-		gettimeofday(&currtime, NULL);
+		monotime(&currtime);
 		timeradd(&currtime, &sleeptime, &currtime);
 		TIMEVAL_TO_TIMESPEC(&currtime, &next_update);
 	}
@@ -2348,7 +2373,7 @@ void peer_writes_on(struct peer *peer)
 	if (peer->status == Deleted)
 		return;
 
-	pthread_mutex_lock(&plist_mtx);
+	pthread_mutex_lock(plist_mtx);
 	{
 		struct listnode *ln, *nn;
 		struct peer *p;
@@ -2356,7 +2381,7 @@ void peer_writes_on(struct peer *peer)
 		// make sure this peer isn't already in the list
 		for (ALL_LIST_ELEMENTS(plist, ln, nn, p))
 			if (p == peer) {
-				pthread_mutex_unlock(&plist_mtx);
+				pthread_mutex_unlock(plist_mtx);
 				return;
 			}
 
@@ -2365,7 +2390,7 @@ void peer_writes_on(struct peer *peer)
 
 		SET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
 	}
-	pthread_mutex_unlock(&plist_mtx);
+	pthread_mutex_unlock(plist_mtx);
 	peer_writes_wake();
 }
 
@@ -2376,7 +2401,7 @@ void peer_writes_off(struct peer *peer)
 {
 	struct listnode *ln, *nn;
 	struct peer *p;
-	pthread_mutex_lock(&plist_mtx);
+	pthread_mutex_lock(plist_mtx);
 	{
 		for (ALL_LIST_ELEMENTS(plist, ln, nn, p))
 			if (p == peer) {
@@ -2387,7 +2412,7 @@ void peer_writes_off(struct peer *peer)
 
 		UNSET_FLAG(peer->thread_flags, PEER_THREAD_WRITES_ON);
 	}
-	pthread_mutex_unlock(&plist_mtx);
+	pthread_mutex_unlock(plist_mtx);
 }
 
 /**
@@ -2395,5 +2420,5 @@ void peer_writes_off(struct peer *peer)
  */
 void peer_writes_wake()
 {
-	pthread_cond_signal(&write_cond);
+	pthread_cond_signal(write_cond);
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -19,6 +19,7 @@
  */
 
 #include <zebra.h>
+#include <sys/time.h>
 
 #include "thread.h"
 #include "stream.h"
@@ -55,6 +56,13 @@
 #include "bgpd/bgp_updgrp.h"
 #include "bgpd/bgp_label.h"
 
+/* Linked list of active peers */
+static pthread_mutex_t plist_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t write_cond = PTHREAD_COND_INITIALIZER;
+static struct list *plist;
+
+bool bgp_packet_writes_thread_run;
+
 /* Set up BGP packet marker and packet type. */
 int bgp_packet_set_marker(struct stream *s, u_char type)
 {
@@ -87,21 +95,40 @@ int bgp_packet_set_size(struct stream *s)
 	return cp;
 }
 
-/* Add new packet to the peer. */
-void bgp_packet_add(struct peer *peer, struct stream *s)
+/**
+ * Push a packet onto the beginning of the peer's output queue.
+ * Must be externally synchronized around 'peer'.
+ */
+static void bgp_packet_add_unsafe(struct peer *peer, struct stream *s)
 {
 	/* Add packet to the end of list. */
 	stream_fifo_push(peer->obuf, s);
+	peer_writes_wake();
 }
 
-/* Free first packet. */
-static void bgp_packet_delete(struct peer *peer)
+/*
+ * Push a packet onto the beginning of the peer's output queue.
+ * This function acquires the peer's write mutex before proceeding.
+ */
+static void bgp_packet_add(struct peer *peer, struct stream *s)
+{
+	pthread_mutex_lock(&peer->obuf_mtx);
+	bgp_packet_add_unsafe(peer, s);
+	pthread_mutex_unlock(&peer->obuf_mtx);
+}
+
+/**
+ * Pop a packet off the end of the peer's output queue.
+ * Must be externally synchronized around 'peer'.
+ */
+static void bgp_packet_delete_unsafe(struct peer *peer)
 {
 	stream_free(stream_fifo_pop(peer->obuf));
 }
 
+
 /* Check file descriptor whether connect is established. */
-int bgp_connect_check(struct peer *peer, int change_state)
+static int bgp_connect_check(struct peer *peer, int change_state)
 {
 	int status;
 	socklen_t slen;
@@ -109,7 +136,6 @@ int bgp_connect_check(struct peer *peer, int change_state)
 
 	/* Anyway I have to reset read and write thread. */
 	BGP_READ_OFF(peer->t_read);
-	BGP_WRITE_OFF(peer->t_write);
 
 	/* Check file descriptor. */
 	slen = sizeof(status);
@@ -176,7 +202,7 @@ static struct stream *bgp_update_packet_eor(struct peer *peer, afi_t afi,
 	}
 
 	bgp_packet_set_size(s);
-	bgp_packet_add(peer, s);
+	bgp_packet_add_unsafe(peer, s);
 	return s;
 }
 
@@ -248,246 +274,21 @@ static struct stream *bgp_write_packet(struct peer *peer)
 		}
 
 
-		/*
-		 * Found a packet template to send, overwrite packet
-		 * with appropriate
-		 * attributes from peer and advance peer
-		 */
-		s = bpacket_reformat_for_peer(next_pkt, paf);
-		bpacket_queue_advance_peer(paf);
-		return s;
-	}
+			/* Found a packet template to send, overwrite packet
+			 * with appropriate
+			 * attributes from peer and advance peer */
+			s = bpacket_reformat_for_peer(next_pkt, paf);
+			bgp_packet_add_unsafe(peer, s);
+			bpacket_queue_advance_peer(paf);
+			return s;
+		}
 
 	return NULL;
 }
 
-/* The next action for the peer from a write perspective */
-static void bgp_write_proceed_actions(struct peer *peer)
-{
-	afi_t afi;
-	safi_t safi;
-	struct peer_af *paf;
-	struct bpacket *next_pkt;
-	int fullq_found = 0;
-	struct update_subgroup *subgrp;
-
-	if (stream_fifo_head(peer->obuf)) {
-		BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
-		return;
-	}
-
-	FOREACH_AFI_SAFI (afi, safi) {
-		paf = peer_af_find(peer, afi, safi);
-		if (!paf)
-			continue;
-		subgrp = paf->subgroup;
-		if (!subgrp)
-			continue;
-
-		next_pkt = paf->next_pkt_to_send;
-		if (next_pkt && next_pkt->buffer) {
-			BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
-			return;
-		}
-
-		/* No packets readily available for AFI/SAFI, are there
-		 * subgroup packets
-		 * that need to be generated? */
-		if (bpacket_queue_is_full(SUBGRP_INST(subgrp),
-					  SUBGRP_PKTQ(subgrp)))
-			fullq_found = 1;
-		else if (subgroup_packets_to_build(subgrp)) {
-			BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
-			return;
-		}
-
-		/* No packets to send, see if EOR is pending */
-		if (CHECK_FLAG(peer->cap, PEER_CAP_RESTART_RCV)) {
-			if (!subgrp->t_coalesce && peer->afc_nego[afi][safi]
-			    && peer->synctime
-			    && !CHECK_FLAG(peer->af_sflags[afi][safi],
-					   PEER_STATUS_EOR_SEND)
-			    && safi != SAFI_MPLS_VPN) {
-				BGP_WRITE_ON(peer->t_write, bgp_write,
-					     peer->fd);
-				return;
-			}
-		}
-	}
-	if (fullq_found) {
-		BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
-		return;
-	}
-}
-
-/* Write packet to the peer. */
-int bgp_write(struct thread *thread)
-{
-	struct peer *peer;
-	u_char type;
-	struct stream *s;
-	int num;
-	int update_last_write = 0;
-	unsigned int count = 0;
-	unsigned int oc = 0;
-
-	/* Yes first of all get peer pointer. */
-	peer = THREAD_ARG(thread);
-	peer->t_write = NULL;
-
-	/* For non-blocking IO check. */
-	if (peer->status == Connect) {
-		bgp_connect_check(peer, 1);
-		return 0;
-	}
-
-	s = bgp_write_packet(peer);
-	if (!s) {
-		bgp_write_proceed_actions(peer);
-		return 0;
-	}
-
-	sockopt_cork(peer->fd, 1);
-
-	oc = peer->update_out;
-
-	/* Nonblocking write until TCP output buffer is full.  */
-	do {
-		int writenum;
-
-		/* Number of bytes to be sent.  */
-		writenum = stream_get_endp(s) - stream_get_getp(s);
-
-		/* Call write() system call.  */
-		num = write(peer->fd, STREAM_PNT(s), writenum);
-		if (num < 0) {
-			/* write failed either retry needed or error */
-			if (ERRNO_IO_RETRY(errno))
-				break;
-
-			BGP_EVENT_ADD(peer, TCP_fatal_error);
-			return 0;
-		}
-
-		if (num != writenum) {
-			/* Partial write */
-			stream_forward_getp(s, num);
-			break;
-		}
-
-		/* Retrieve BGP packet type. */
-		stream_set_getp(s, BGP_MARKER_SIZE + 2);
-		type = stream_getc(s);
-
-		switch (type) {
-		case BGP_MSG_OPEN:
-			peer->open_out++;
-			break;
-		case BGP_MSG_UPDATE:
-			peer->update_out++;
-			break;
-		case BGP_MSG_NOTIFY:
-			peer->notify_out++;
-			/* Double start timer. */
-			peer->v_start *= 2;
-
-			/* Overflow check. */
-			if (peer->v_start >= (60 * 2))
-				peer->v_start = (60 * 2);
-
-			/* Flush any existing events */
-			BGP_EVENT_ADD(peer, BGP_Stop);
-			goto done;
-
-		case BGP_MSG_KEEPALIVE:
-			peer->keepalive_out++;
-			break;
-		case BGP_MSG_ROUTE_REFRESH_NEW:
-		case BGP_MSG_ROUTE_REFRESH_OLD:
-			peer->refresh_out++;
-			break;
-		case BGP_MSG_CAPABILITY:
-			peer->dynamic_cap_out++;
-			break;
-		}
-
-		/* OK we send packet so delete it. */
-		bgp_packet_delete(peer);
-		update_last_write = 1;
-	} while (++count < peer->bgp->wpkt_quanta
-		 && (s = bgp_write_packet(peer)) != NULL);
-
-	bgp_write_proceed_actions(peer);
-
-done:
-	/* Update last_update if UPDATEs were written. */
-	if (peer->update_out > oc)
-		peer->last_update = bgp_clock();
-
-	/* If we TXed any flavor of packet update last_write */
-	if (update_last_write)
-		peer->last_write = bgp_clock();
-
-	sockopt_cork(peer->fd, 0);
-	return 0;
-}
-
-/* This is only for sending NOTIFICATION message to neighbor. */
-static int bgp_write_notify(struct peer *peer)
-{
-	int ret, val;
-	u_char type;
-	struct stream *s;
-
-	/* There should be at least one packet. */
-	s = stream_fifo_head(peer->obuf);
-	if (!s)
-		return 0;
-	assert(stream_get_endp(s) >= BGP_HEADER_SIZE);
-
-	/* Stop collecting data within the socket */
-	sockopt_cork(peer->fd, 0);
-
-	/* socket is in nonblocking mode, if we can't deliver the NOTIFY, well,
-	 * we only care about getting a clean shutdown at this point. */
-	ret = write(peer->fd, STREAM_DATA(s), stream_get_endp(s));
-
-	/* only connection reset/close gets counted as TCP_fatal_error, failure
-	 * to write the entire NOTIFY doesn't get different FSM treatment */
-	if (ret <= 0) {
-		BGP_EVENT_ADD(peer, TCP_fatal_error);
-		return 0;
-	}
-
-	/* Disable Nagle, make NOTIFY packet go out right away */
-	val = 1;
-	(void)setsockopt(peer->fd, IPPROTO_TCP, TCP_NODELAY, (char *)&val,
-			 sizeof(val));
-
-	/* Retrieve BGP packet type. */
-	stream_set_getp(s, BGP_MARKER_SIZE + 2);
-	type = stream_getc(s);
-
-	assert(type == BGP_MSG_NOTIFY);
-
-	/* Type should be notify. */
-	peer->notify_out++;
-
-	/* Double start timer. */
-	peer->v_start *= 2;
-
-	/* Overflow check. */
-	if (peer->v_start >= (60 * 2))
-		peer->v_start = (60 * 2);
-
-	/* Handle Graceful Restart case where the state changes to
-	   Connect instead of Idle */
-	BGP_EVENT_ADD(peer, BGP_Stop);
-
-	return 0;
-}
-
-/* Make keepalive packet and send it to the peer. */
+/*
+ * Creates a BGP Keepalive packet and appends it to the peer's output queue.
+ */
 void bgp_keepalive_send(struct peer *peer)
 {
 	struct stream *s;
@@ -508,11 +309,12 @@ void bgp_keepalive_send(struct peer *peer)
 
 	/* Add packet to the peer. */
 	bgp_packet_add(peer, s);
-
-	BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
 }
 
-/* Make open packet and send it to the peer. */
+/*
+ * Creates a BGP Open packet and appends it to the peer's output queue.
+ * Sets capabilities as necessary.
+ */
 void bgp_open_send(struct peer *peer)
 {
 	struct stream *s;
@@ -560,11 +362,20 @@ void bgp_open_send(struct peer *peer)
 
 	/* Add packet to the peer. */
 	bgp_packet_add(peer, s);
-
-	BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
 }
 
-/* Send BGP notify packet with data potion. */
+/*
+ * Creates a BGP Notify and appends it to the peer's output queue.
+ *
+ * This function awakens the write thread to ensure the packet
+ * gets out ASAP.
+ *
+ * @param peer
+ * @param code      BGP error code
+ * @param sub_code  BGP error subcode
+ * @param data      Data portion
+ * @param datalen   length of data portion
+ */
 void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 			       u_char *data, size_t datalen)
 {
@@ -574,7 +385,7 @@ void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 	/* Allocate new stream. */
 	s = stream_new(BGP_MAX_PACKET_SIZE);
 
-	/* Make nitify packet. */
+	/* Make notify packet. */
 	bgp_packet_set_marker(s, BGP_MSG_NOTIFY);
 
 	/* Set notify packet values. */
@@ -589,8 +400,9 @@ void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 	length = bgp_packet_set_size(s);
 
 	/* Add packet to the peer. */
+	pthread_mutex_lock(&peer->obuf_mtx);
 	stream_fifo_clean(peer->obuf);
-	bgp_packet_add(peer, s);
+	pthread_mutex_unlock(&peer->obuf_mtx);
 
 	/* For debug */
 	{
@@ -641,19 +453,37 @@ void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 	} else
 		peer->last_reset = PEER_DOWN_NOTIFY_SEND;
 
-	/* Call immediately. */
-	BGP_WRITE_OFF(peer->t_write);
-
-	bgp_write_notify(peer);
+	/* Add packet to peer's output queue */
+	bgp_packet_add(peer, s);
+	/* Wake up the write thread to get the notify out ASAP */
+	peer_writes_wake();
 }
 
-/* Send BGP notify packet. */
+/*
+ * Creates a BGP Notify and appends it to the peer's output queue.
+ *
+ * This function awakens the write thread to ensure the packet
+ * gets out ASAP.
+ *
+ * @param peer
+ * @param code      BGP error code
+ * @param sub_code  BGP error subcode
+ */
 void bgp_notify_send(struct peer *peer, u_char code, u_char sub_code)
 {
 	bgp_notify_send_with_data(peer, code, sub_code, NULL, 0);
 }
 
-/* Send route refresh message to the peer. */
+/*
+ * Creates BGP Route Refresh packet and appends it to the peer's output queue.
+ *
+ * @param peer
+ * @param afi               Address Family Identifier
+ * @param safi              Subsequent Address Family Identifier
+ * @param orf_type          Outbound Route Filtering type
+ * @param when_to_refresh   Whether to refresh immediately or defer
+ * @param remove            Whether to remove ORF for specified AFI/SAFI
+ */
 void bgp_route_refresh_send(struct peer *peer, afi_t afi, safi_t safi,
 			    u_char orf_type, u_char when_to_refresh, int remove)
 {
@@ -741,11 +571,17 @@ void bgp_route_refresh_send(struct peer *peer, afi_t afi, safi_t safi,
 
 	/* Add packet to the peer. */
 	bgp_packet_add(peer, s);
-
-	BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
 }
 
-/* Send capability message to the peer. */
+/*
+ * Create a BGP Capability packet and append it to the peer's output queue.
+ *
+ * @param peer
+ * @param afi              Address Family Identifier
+ * @param safi             Subsequent Address Family Identifier
+ * @param capability_code  BGP Capability Code
+ * @param action           Set or Remove capability
+ */
 void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
 			 int capability_code, int action)
 {
@@ -784,8 +620,6 @@ void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
 
 	/* Add packet to the peer. */
 	bgp_packet_add(peer, s);
-
-	BGP_WRITE_ON(peer->t_write, bgp_write, peer->fd);
 }
 
 /* RFC1771 6.8 Connection collision detection. */
@@ -2339,4 +2173,227 @@ done:
 	}
 
 	return 0;
+}
+
+/* ------------- write thread ------------------ */
+
+/**
+ * Flush peer output buffer.
+ *
+ * This function pops packets off of peer->obuf and writes them to peer->fd.
+ * The amount of packets written is equal to the minimum of peer->wpkt_quanta
+ * and the number of packets on the output buffer.
+ *
+ * If write() returns an error, the appropriate FSM event is generated.
+ *
+ * The return value is equal to the number of packets written
+ * (which may be zero).
+ */
+static int bgp_write(struct peer *peer)
+{
+	u_char type;
+	struct stream *s;
+	int num;
+	int update_last_write = 0;
+	unsigned int count = 0;
+	unsigned int oc = 0;
+
+	/* For non-blocking IO check. */
+	if (peer->status == Connect) {
+		bgp_connect_check(peer, 1);
+		return 0;
+	}
+
+	/* Write packets. The number of packets written is the value of
+	 * bgp->wpkt_quanta or the size of the output buffer, whichever is
+	 * smaller.*/
+	while (count < peer->bgp->wpkt_quanta
+	       && (s = bgp_write_packet(peer)) != NULL) {
+		int writenum;
+		do { // write a full packet, or return on error
+			writenum = stream_get_endp(s) - stream_get_getp(s);
+			num = write(peer->fd, STREAM_PNT(s), writenum);
+
+			if (num < 0) {
+				if (ERRNO_IO_RETRY(errno))
+					continue;
+
+				BGP_EVENT_ADD(peer, TCP_fatal_error);
+				goto done;
+			} else if (num != writenum) // incomplete write
+				stream_forward_getp(s, num);
+
+		} while (num != writenum);
+
+		/* Retrieve BGP packet type. */
+		stream_set_getp(s, BGP_MARKER_SIZE + 2);
+		type = stream_getc(s);
+
+		switch (type) {
+		case BGP_MSG_OPEN:
+			peer->open_out++;
+			break;
+		case BGP_MSG_UPDATE:
+			peer->update_out++;
+			break;
+		case BGP_MSG_NOTIFY:
+			peer->notify_out++;
+			/* Double start timer. */
+			peer->v_start *= 2;
+
+			/* Overflow check. */
+			if (peer->v_start >= (60 * 2))
+				peer->v_start = (60 * 2);
+
+			/* Handle Graceful Restart case where the state changes
+			   to
+			   Connect instead of Idle */
+			/* Flush any existing events */
+			BGP_EVENT_ADD(peer, BGP_Stop);
+			goto done;
+
+		case BGP_MSG_KEEPALIVE:
+			peer->keepalive_out++;
+			break;
+		case BGP_MSG_ROUTE_REFRESH_NEW:
+		case BGP_MSG_ROUTE_REFRESH_OLD:
+			peer->refresh_out++;
+			break;
+		case BGP_MSG_CAPABILITY:
+			peer->dynamic_cap_out++;
+			break;
+		}
+
+		count++;
+		/* OK we send packet so delete it. */
+		bgp_packet_delete_unsafe(peer);
+		update_last_write = 1;
+	}
+
+done : {
+	/* Update last_update if UPDATEs were written. */
+	if (peer->update_out > oc)
+		peer->last_update = bgp_clock();
+
+	/* If we TXed any flavor of packet update last_write */
+	if (update_last_write)
+		peer->last_write = bgp_clock();
+}
+
+	return count;
+}
+
+static void cleanup_handler(void *arg)
+{
+	if (plist)
+		list_delete(plist);
+
+	plist = NULL;
+
+	pthread_mutex_unlock(&plist_mtx);
+}
+
+/**
+ * Entry function for peer packet flushing pthread.
+ *
+ * The plist must be initialized before calling this.
+ */
+void *peer_writes_start(void *arg)
+{
+	struct timeval currtime = {0, 0};
+	struct timeval sleeptime = {0, 500};
+	struct timespec next_update = {0, 0};
+
+	// initialize
+	pthread_mutex_lock(&plist_mtx);
+	plist = list_new();
+
+	struct listnode *ln;
+	struct peer *peer;
+
+	pthread_cleanup_push(&cleanup_handler, NULL);
+
+	bgp_packet_writes_thread_run = true;
+
+	while (bgp_packet_writes_thread_run) { // wait around until next update
+					       // time
+		if (plist->count > 0)
+			pthread_cond_timedwait(&write_cond, &plist_mtx,
+					       &next_update);
+		else // wait around until we have some peers
+			while (plist->count == 0
+			       && bgp_packet_writes_thread_run)
+				pthread_cond_wait(&write_cond, &plist_mtx);
+
+		for (ALL_LIST_ELEMENTS_RO(plist, ln, peer)) {
+			pthread_mutex_lock(&peer->obuf_mtx);
+			{
+				bgp_write(peer);
+			}
+			pthread_mutex_unlock(&peer->obuf_mtx);
+		}
+
+		gettimeofday(&currtime, NULL);
+		timeradd(&currtime, &sleeptime, &currtime);
+		TIMEVAL_TO_TIMESPEC(&currtime, &next_update);
+	}
+
+	// clean up
+	pthread_cleanup_pop(1);
+
+	return NULL;
+}
+
+/**
+ * Turns on packet writing for a peer.
+ */
+void peer_writes_on(struct peer *peer)
+{
+	if (peer->status == Deleted)
+		return;
+
+	pthread_mutex_lock(&plist_mtx);
+	{
+		struct listnode *ln, *nn;
+		struct peer *p;
+
+		// make sure this peer isn't already in the list
+		for (ALL_LIST_ELEMENTS(plist, ln, nn, p))
+			if (p == peer) {
+				pthread_mutex_unlock(&plist_mtx);
+				return;
+			}
+
+		peer_lock(peer);
+		listnode_add(plist, peer);
+	}
+	pthread_mutex_unlock(&plist_mtx);
+	peer_writes_wake();
+}
+
+/**
+ * Turns off packet writing for a peer.
+ */
+void peer_writes_off(struct peer *peer)
+{
+	struct listnode *ln, *nn;
+	struct peer *p;
+	pthread_mutex_lock(&plist_mtx);
+	{
+		for (ALL_LIST_ELEMENTS(plist, ln, nn, p))
+			if (p == peer) {
+				list_delete_node(plist, ln);
+				peer_unlock(peer);
+				break;
+			}
+	}
+	pthread_mutex_unlock(&plist_mtx);
+}
+
+/**
+ * Wakes up the write thread to do work.
+ */
+void peer_writes_wake()
+{
+	pthread_cond_signal(&write_cond);
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2270,8 +2270,9 @@ int bgp_process_packet(struct thread *thread)
 		{
 			// more work to do, come back later
 			if (peer->ibuf->count > 0)
-				thread_add_event(bm->master, bgp_process_packet,
-						 peer, 0, NULL);
+				thread_add_timer_msec(
+					bm->master, bgp_process_packet, peer, 0,
+					&peer->t_process_packet);
 		}
 		pthread_mutex_unlock(&peer->io_mtx);
 	}

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -59,16 +59,6 @@
 #include "bgpd/bgp_label.h"
 #include "bgpd/bgp_io.h"
 
-/* Linked list of active peers */
-static pthread_mutex_t *plist_mtx;
-static pthread_cond_t *write_cond;
-static struct list *plist;
-
-/* periodically scheduled thread to generate update-group updates */
-static struct thread *t_generate_updgrp_packets;
-
-bool bgp_packet_writes_thread_run = false;
-
 /* Set up BGP packet marker and packet type. */
 int bgp_packet_set_marker(struct stream *s, u_char type)
 {
@@ -107,11 +97,9 @@ int bgp_packet_set_size(struct stream *s)
  */
 static void bgp_packet_add(struct peer *peer, struct stream *s)
 {
-	pthread_mutex_lock(&peer->obuf_mtx);
+	pthread_mutex_lock(&peer->io_mtx);
 	stream_fifo_push(peer->obuf, s);
-	pthread_mutex_unlock(&peer->obuf_mtx);
-
-	peer_writes_wake();
+	pthread_mutex_unlock(&peer->io_mtx);
 }
 
 static struct stream *bgp_update_packet_eor(struct peer *peer, afi_t afi,
@@ -165,7 +153,6 @@ static struct stream *bgp_update_packet_eor(struct peer *peer, afi_t afi,
 int bgp_generate_updgrp_packets(struct thread *thread)
 {
 	struct peer *peer = THREAD_ARG(thread);
-	peer->t_generate_updgrp_packets = NULL;
 
 	struct stream *s;
 	struct peer_af *paf;
@@ -237,10 +224,13 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 
 							if ((s = bgp_update_packet_eor(
 								     peer, afi,
-								     safi)))
+								     safi))) {
 								bgp_packet_add(
 									peer,
 									s);
+								bgp_writes_on(
+									peer);
+							}
 						}
 					}
 					continue;
@@ -252,6 +242,7 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 				 * attributes from peer and advance peer */
 				s = bpacket_reformat_for_peer(next_pkt, paf);
 				bgp_packet_add(peer, s);
+				bgp_writes_on(peer);
 				bpacket_queue_advance_peer(paf);
 			}
 	} while (s);
@@ -282,6 +273,8 @@ void bgp_keepalive_send(struct peer *peer)
 
 	/* Add packet to the peer. */
 	bgp_packet_add(peer, s);
+
+	bgp_writes_on(peer);
 }
 
 /*
@@ -335,6 +328,67 @@ void bgp_open_send(struct peer *peer)
 
 	/* Add packet to the peer. */
 	bgp_packet_add(peer, s);
+
+	bgp_writes_on(peer);
+}
+
+/* This is only for sending NOTIFICATION message to neighbor. */
+static int bgp_write_notify(struct peer *peer)
+{
+	int ret, val;
+	u_char type;
+	struct stream *s;
+
+	pthread_mutex_lock(&peer->io_mtx);
+	{
+		/* There should be at least one packet. */
+		s = stream_fifo_pop(peer->obuf);
+		if (!s)
+			return 0;
+		assert(stream_get_endp(s) >= BGP_HEADER_SIZE);
+	}
+	pthread_mutex_unlock(&peer->io_mtx);
+
+	/* Stop collecting data within the socket */
+	sockopt_cork(peer->fd, 0);
+
+	/* socket is in nonblocking mode, if we can't deliver the NOTIFY, well,
+	 * we only care about getting a clean shutdown at this point. */
+	ret = write(peer->fd, STREAM_DATA(s), stream_get_endp(s));
+
+	/* only connection reset/close gets counted as TCP_fatal_error, failure
+	 * to write the entire NOTIFY doesn't get different FSM treatment */
+	if (ret <= 0) {
+		BGP_EVENT_ADD(peer, TCP_fatal_error);
+		return 0;
+	}
+
+	/* Disable Nagle, make NOTIFY packet go out right away */
+	val = 1;
+	(void)setsockopt(peer->fd, IPPROTO_TCP, TCP_NODELAY, (char *)&val,
+			 sizeof(val));
+
+	/* Retrieve BGP packet type. */
+	stream_set_getp(s, BGP_MARKER_SIZE + 2);
+	type = stream_getc(s);
+
+	assert(type == BGP_MSG_NOTIFY);
+
+	/* Type should be notify. */
+	peer->notify_out++;
+
+	/* Double start timer. */
+	peer->v_start *= 2;
+
+	/* Overflow check. */
+	if (peer->v_start >= (60 * 2))
+		peer->v_start = (60 * 2);
+
+	/* Handle Graceful Restart case where the state changes to
+	   Connect instead of Idle */
+	BGP_EVENT_ADD(peer, BGP_Stop);
+
+	return 0;
 }
 
 /*
@@ -372,10 +426,12 @@ void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 	/* Set BGP packet length. */
 	length = bgp_packet_set_size(s);
 
-	/* Add packet to the peer. */
-	pthread_mutex_lock(&peer->obuf_mtx);
-	stream_fifo_clean(peer->obuf);
-	pthread_mutex_unlock(&peer->obuf_mtx);
+	/* wipe output buffer */
+	pthread_mutex_lock(&peer->io_mtx);
+	{
+		stream_fifo_clean(peer->obuf);
+	}
+	pthread_mutex_unlock(&peer->io_mtx);
 
 	/* For debug */
 	{
@@ -428,8 +484,8 @@ void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 
 	/* Add packet to peer's output queue */
 	bgp_packet_add(peer, s);
-	/* Wake up the write thread to get the notify out ASAP */
-	peer_writes_wake();
+
+	bgp_write_notify(peer);
 }
 
 /*
@@ -544,6 +600,8 @@ void bgp_route_refresh_send(struct peer *peer, afi_t afi, safi_t safi,
 
 	/* Add packet to the peer. */
 	bgp_packet_add(peer, s);
+
+	bgp_writes_on(peer);
 }
 
 /*
@@ -593,6 +651,8 @@ void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
 
 	/* Add packet to the peer. */
 	bgp_packet_add(peer, s);
+
+	bgp_writes_on(peer);
 }
 
 /* RFC1771 6.8 Connection collision detection. */
@@ -696,13 +756,13 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	u_int16_t *holdtime_ptr;
 
 	/* Parse open packet. */
-	version = stream_getc(peer->ibuf);
-	memcpy(notify_data_remote_as, stream_pnt(peer->ibuf), 2);
-	remote_as = stream_getw(peer->ibuf);
-	holdtime_ptr = (u_int16_t *)stream_pnt(peer->ibuf);
-	holdtime = stream_getw(peer->ibuf);
-	memcpy(notify_data_remote_id, stream_pnt(peer->ibuf), 4);
-	remote_id.s_addr = stream_get_ipv4(peer->ibuf);
+	version = stream_getc(peer->curr);
+	memcpy(notify_data_remote_as, stream_pnt(peer->curr), 2);
+	remote_as = stream_getw(peer->curr);
+	holdtime_ptr = (u_int16_t *)stream_pnt(peer->curr);
+	holdtime = stream_getw(peer->curr);
+	memcpy(notify_data_remote_id, stream_pnt(peer->curr), 4);
+	remote_id.s_addr = stream_get_ipv4(peer->curr);
 
 	/* Receive OPEN message log  */
 	if (bgp_debug_neighbor_events(peer))
@@ -714,11 +774,11 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 
 	/* BEGIN to read the capability here, but dont do it yet */
 	mp_capability = 0;
-	optlen = stream_getc(peer->ibuf);
+	optlen = stream_getc(peer->curr);
 
 	if (optlen != 0) {
 		/* If not enough bytes, it is an error. */
-		if (STREAM_READABLE(peer->ibuf) < optlen) {
+		if (STREAM_READABLE(peer->curr) < optlen) {
 			bgp_notify_send(peer, BGP_NOTIFY_OPEN_ERR,
 					BGP_NOTIFY_OPEN_MALFORMED_ATTR);
 			return -1;
@@ -990,10 +1050,6 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		return (ret);
 	}
 
-	peer->packet_size = 0;
-	if (peer->ibuf)
-		stream_reset(peer->ibuf);
-
 	return 0;
 }
 
@@ -1177,7 +1233,7 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 	memset(peer->rcvd_attr_str, 0, BUFSIZ);
 	peer->rcvd_attr_printed = 0;
 
-	s = peer->ibuf;
+	s = peer->curr;
 	end = stream_pnt(s) + size;
 
 	/* RFC1771 6.3 If the Unfeasible Routes Length or Total Attribute
@@ -1424,8 +1480,8 @@ static void bgp_notify_receive(struct peer *peer, bgp_size_t size)
 		peer->notify.length = 0;
 	}
 
-	bgp_notify.code = stream_getc(peer->ibuf);
-	bgp_notify.subcode = stream_getc(peer->ibuf);
+	bgp_notify.code = stream_getc(peer->curr);
+	bgp_notify.subcode = stream_getc(peer->curr);
 	bgp_notify.length = size - 2;
 	bgp_notify.data = NULL;
 
@@ -1436,7 +1492,7 @@ static void bgp_notify_receive(struct peer *peer, bgp_size_t size)
 	if (bgp_notify.length) {
 		peer->notify.length = size - 2;
 		peer->notify.data = XMALLOC(MTYPE_TMP, size - 2);
-		memcpy(peer->notify.data, stream_pnt(peer->ibuf), size - 2);
+		memcpy(peer->notify.data, stream_pnt(peer->curr), size - 2);
 	}
 
 	/* For debug */
@@ -1451,12 +1507,12 @@ static void bgp_notify_receive(struct peer *peer, bgp_size_t size)
 			for (i = 0; i < bgp_notify.length; i++)
 				if (first) {
 					sprintf(c, " %02x",
-						stream_getc(peer->ibuf));
+						stream_getc(peer->curr));
 					strcat(bgp_notify.data, c);
 				} else {
 					first = 1;
 					sprintf(c, "%02x",
-						stream_getc(peer->ibuf));
+						stream_getc(peer->curr));
 					strcpy(bgp_notify.data, c);
 				}
 			bgp_notify.raw_data = (u_char *)peer->notify.data;
@@ -1526,7 +1582,7 @@ static void bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 		return;
 	}
 
-	s = peer->ibuf;
+	s = peer->curr;
 
 	/* Parse packet. */
 	pkt_afi = stream_getw(s);
@@ -1874,7 +1930,7 @@ int bgp_capability_receive(struct peer *peer, bgp_size_t size)
 	u_char *pnt;
 
 	/* Fetch pointer. */
-	pnt = stream_pnt(peer->ibuf);
+	pnt = stream_pnt(peer->curr);
 
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s rcv CAPABILITY", peer->host);
@@ -1902,188 +1958,50 @@ int bgp_capability_receive(struct peer *peer, bgp_size_t size)
 	return bgp_capability_msg_parse(peer, pnt, size);
 }
 
-/* BGP read utility function. */
-static int bgp_read_packet(struct peer *peer)
+/* Starting point of packet process function. */
+int bgp_process_packet(struct thread *thread)
 {
-	int nbytes;
-	int readsize;
+	/* Yes first of all get peer pointer. */
+	struct peer *peer;
+	peer = THREAD_ARG(thread);
 
-	readsize = peer->packet_size - stream_get_endp(peer->ibuf);
-
-	/* If size is zero then return. */
-	if (!readsize)
+	/* Guard against scheduled events that occur after peer deletion. */
+	if (peer->status == Deleted)
 		return 0;
 
-	/* Read packet from fd. */
-	nbytes = stream_read_try(peer->ibuf, peer->fd, readsize);
-
-	/* If read byte is smaller than zero then error occured. */
-	if (nbytes < 0) {
-		/* Transient error should retry */
-		if (nbytes == -2)
-			return -1;
-
-		zlog_err("%s [Error] bgp_read_packet error: %s", peer->host,
-			 safe_strerror(errno));
-
-		if (peer->status == Established) {
-			if (CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_MODE)) {
-				peer->last_reset = PEER_DOWN_NSF_CLOSE_SESSION;
-				SET_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT);
-			} else
-				peer->last_reset = PEER_DOWN_CLOSE_SESSION;
-		}
-
-		BGP_EVENT_ADD(peer, TCP_fatal_error);
-		return -1;
-	}
-
-	/* When read byte is zero : clear bgp peer and return */
-	if (nbytes == 0) {
-		if (bgp_debug_neighbor_events(peer))
-			zlog_debug("%s [Event] BGP connection closed fd %d",
-				   peer->host, peer->fd);
-
-		if (peer->status == Established) {
-			if (CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_MODE)) {
-				peer->last_reset = PEER_DOWN_NSF_CLOSE_SESSION;
-				SET_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT);
-			} else
-				peer->last_reset = PEER_DOWN_CLOSE_SESSION;
-		}
-
-		BGP_EVENT_ADD(peer, TCP_connection_closed);
-		return -1;
-	}
-
-	/* We read partial packet. */
-	if (stream_get_endp(peer->ibuf) != peer->packet_size)
-		return -1;
-
-	return 0;
-}
-
-/* Marker check. */
-static int bgp_marker_all_one(struct stream *s, int length)
-{
-	int i;
-
-	for (i = 0; i < length; i++)
-		if (s->data[i] != 0xff)
-			return 0;
-
-	return 1;
-}
-
-/* Starting point of packet process function. */
-int bgp_read(struct thread *thread)
-{
-	int ret;
 	u_char type = 0;
-	struct peer *peer;
 	bgp_size_t size;
 	char notify_data_length[2];
 	u_int32_t notify_out;
-
-	/* Yes first of all get peer pointer. */
-	peer = THREAD_ARG(thread);
-	peer->t_read = NULL;
 
 	/* Note notify_out so we can check later to see if we sent another one
 	 */
 	notify_out = peer->notify_out;
 
-	if (peer->fd < 0) {
-		zlog_err("bgp_read(): peer's fd is negative value %d",
-			 peer->fd);
-		return -1;
+	pthread_mutex_lock(&peer->io_mtx);
+	{
+		peer->curr = stream_fifo_pop(peer->ibuf);
 	}
+	pthread_mutex_unlock(&peer->io_mtx);
 
-	BGP_READ_ON(peer->t_read, bgp_read, peer->fd);
+	if (peer->curr == NULL) // no packets to process, hmm...
+		return 0;
 
-	/* Read packet header to determine type of the packet */
-	if (peer->packet_size == 0)
-		peer->packet_size = BGP_HEADER_SIZE;
+	bgp_size_t actual_size = stream_get_endp(peer->curr);
 
-	if (stream_get_endp(peer->ibuf) < BGP_HEADER_SIZE) {
-		ret = bgp_read_packet(peer);
+	/* skip the marker and copy the packet length */
+	stream_forward_getp(peer->curr, BGP_MARKER_SIZE);
+	memcpy(notify_data_length, stream_pnt(peer->curr), 2);
 
-		/* Header read error or partial read packet. */
-		if (ret < 0)
-			goto done;
-
-		/* Get size and type. */
-		stream_forward_getp(peer->ibuf, BGP_MARKER_SIZE);
-		memcpy(notify_data_length, stream_pnt(peer->ibuf), 2);
-		size = stream_getw(peer->ibuf);
-		type = stream_getc(peer->ibuf);
-
-		/* Marker check */
-		if (((type == BGP_MSG_OPEN) || (type == BGP_MSG_KEEPALIVE))
-		    && !bgp_marker_all_one(peer->ibuf, BGP_MARKER_SIZE)) {
-			bgp_notify_send(peer, BGP_NOTIFY_HEADER_ERR,
-					BGP_NOTIFY_HEADER_NOT_SYNC);
-			goto done;
-		}
-
-		/* BGP type check. */
-		if (type != BGP_MSG_OPEN && type != BGP_MSG_UPDATE
-		    && type != BGP_MSG_NOTIFY && type != BGP_MSG_KEEPALIVE
-		    && type != BGP_MSG_ROUTE_REFRESH_NEW
-		    && type != BGP_MSG_ROUTE_REFRESH_OLD
-		    && type != BGP_MSG_CAPABILITY) {
-			if (bgp_debug_neighbor_events(peer))
-				zlog_debug("%s unknown message type 0x%02x",
-					   peer->host, type);
-			bgp_notify_send_with_data(peer, BGP_NOTIFY_HEADER_ERR,
-						  BGP_NOTIFY_HEADER_BAD_MESTYPE,
-						  &type, 1);
-			goto done;
-		}
-		/* Mimimum packet length check. */
-		if ((size < BGP_HEADER_SIZE) || (size > BGP_MAX_PACKET_SIZE)
-		    || (type == BGP_MSG_OPEN && size < BGP_MSG_OPEN_MIN_SIZE)
-		    || (type == BGP_MSG_UPDATE
-			&& size < BGP_MSG_UPDATE_MIN_SIZE)
-		    || (type == BGP_MSG_NOTIFY
-			&& size < BGP_MSG_NOTIFY_MIN_SIZE)
-		    || (type == BGP_MSG_KEEPALIVE
-			&& size != BGP_MSG_KEEPALIVE_MIN_SIZE)
-		    || (type == BGP_MSG_ROUTE_REFRESH_NEW
-			&& size < BGP_MSG_ROUTE_REFRESH_MIN_SIZE)
-		    || (type == BGP_MSG_ROUTE_REFRESH_OLD
-			&& size < BGP_MSG_ROUTE_REFRESH_MIN_SIZE)
-		    || (type == BGP_MSG_CAPABILITY
-			&& size < BGP_MSG_CAPABILITY_MIN_SIZE)) {
-			if (bgp_debug_neighbor_events(peer))
-				zlog_debug("%s bad message length - %d for %s",
-					   peer->host, size,
-					   type == 128
-						   ? "ROUTE-REFRESH"
-						   : bgp_type_str[(int)type]);
-			bgp_notify_send_with_data(peer, BGP_NOTIFY_HEADER_ERR,
-						  BGP_NOTIFY_HEADER_BAD_MESLEN,
-						  (u_char *)notify_data_length,
-						  2);
-			goto done;
-		}
-
-		/* Adjust size to message length. */
-		peer->packet_size = size;
-	}
-
-	ret = bgp_read_packet(peer);
-	if (ret < 0)
-		goto done;
-
-	/* Get size and type again. */
-	(void)stream_getw_from(peer->ibuf, BGP_MARKER_SIZE);
-	type = stream_getc_from(peer->ibuf, BGP_MARKER_SIZE + 2);
+	/* read in the packet length and type */
+	size = stream_getw(peer->curr);
+	type = stream_getc(peer->curr);
 
 	/* BGP packet dump function. */
-	bgp_dump_packet(peer, type, peer->ibuf);
+	bgp_dump_packet(peer, type, peer->curr);
 
-	size = (peer->packet_size - BGP_HEADER_SIZE);
+	/* adjust size to exclude the marker + length + type */
+	size -= BGP_HEADER_SIZE;
 
 	/* Read rest of the packet and call each sort of packet routine */
 	switch (type) {
@@ -2118,26 +2036,14 @@ int bgp_read(struct thread *thread)
 	 * of the packet for troubleshooting purposes
 	 */
 	if (notify_out < peer->notify_out) {
-		memcpy(peer->last_reset_cause, peer->ibuf->data,
-		       peer->packet_size);
-		peer->last_reset_cause_size = peer->packet_size;
-		notify_out = peer->notify_out;
+		memcpy(peer->last_reset_cause, peer->curr->data, actual_size);
+		peer->last_reset_cause_size = actual_size;
 	}
 
-	/* Clear input buffer. */
-	peer->packet_size = 0;
-	if (peer->ibuf)
-		stream_reset(peer->ibuf);
-
-done:
-	/* If reading this packet caused us to send a NOTIFICATION then store a
-	 * copy
-	 * of the packet for troubleshooting purposes
-	 */
-	if (notify_out < peer->notify_out) {
-		memcpy(peer->last_reset_cause, peer->ibuf->data,
-		       peer->packet_size);
-		peer->last_reset_cause_size = peer->packet_size;
+	/* Delete packet and carry on. */
+	if (peer->curr) {
+		stream_free(peer->curr);
+		peer->curr = NULL;
 	}
 
 	return 0;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -34,6 +34,7 @@
 #include "plist.h"
 #include "queue.h"
 #include "filter.h"
+#include "lib/frr_pthread.h"
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_table.h"
@@ -2420,4 +2421,13 @@ void peer_writes_off(struct peer *peer)
 void peer_writes_wake()
 {
 	pthread_cond_signal(write_cond);
+}
+
+int peer_writes_stop(void **result)
+{
+	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_WRITE);
+	bgp_packet_writes_thread_run = false;
+	peer_writes_wake();
+	pthread_join(fpt->thread, result);
+	return 0;
 }

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -170,12 +170,12 @@ void bgp_check_update_delay(struct bgp *bgp)
 
 	if (bgp->established
 	    <= bgp->restarted_peers + bgp->implicit_eors + bgp->explicit_eors) {
-		/* This is an extra sanity check to make sure we wait for all
-		   the
-		   eligible configured peers. This check is performed if
-		   establish wait
-		   timer is on, or establish wait option is not given with the
-		   update-delay command */
+		/*
+		 * This is an extra sanity check to make sure we wait for all
+		 * the eligible configured peers. This check is performed if
+		 * establish wait timer is on, or establish wait option is not
+		 * given with the update-delay command
+		 */
 		if (bgp->t_establish_wait
 		    || (bgp->v_establish_wait == bgp->v_update_delay))
 			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
@@ -200,8 +200,10 @@ void bgp_check_update_delay(struct bgp *bgp)
 	}
 }
 
-/* Called if peer is known to have restarted. The restart-state bit in
-   Graceful-Restart capability is used for that */
+/*
+ * Called if peer is known to have restarted. The restart-state bit in
+ * Graceful-Restart capability is used for that
+ */
 void bgp_update_restarted_peers(struct peer *peer)
 {
 	if (!bgp_update_delay_active(peer->bgp))
@@ -219,10 +221,12 @@ void bgp_update_restarted_peers(struct peer *peer)
 	}
 }
 
-/* Called as peer receives a keep-alive. Determines if this occurence can be
-   taken as an implicit EOR for this peer.
-   NOTE: The very first keep-alive after the Established state of a peer is
-	 considered implicit EOR for the update-delay purposes */
+/*
+ * Called as peer receives a keep-alive. Determines if this occurence can be
+ * taken as an implicit EOR for this peer.
+ * NOTE: The very first keep-alive after the Established state of a peer is
+ * considered implicit EOR for the update-delay purposes
+ */
 void bgp_update_implicit_eors(struct peer *peer)
 {
 	if (!bgp_update_delay_active(peer->bgp))
@@ -240,8 +244,10 @@ void bgp_update_implicit_eors(struct peer *peer)
 	}
 }
 
-/* Should be called only when there is a change in the EOR_RECEIVED status
-   for any afi/safi on a peer */
+/*
+ * Should be called only when there is a change in the EOR_RECEIVED status
+ * for any afi/safi on a peer.
+ */
 static void bgp_update_explicit_eors(struct peer *peer)
 {
 	afi_t afi;
@@ -299,7 +305,7 @@ int bgp_nlri_parse(struct peer *peer, struct attr *attr,
 	return -1;
 }
 
-/*
+/**
  * Enqueue onto the peer's output buffer any packets which are pending for the
  * update group it is a member of.
  *
@@ -335,10 +341,11 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 					continue;
 				next_pkt = paf->next_pkt_to_send;
 
-				/* Try to generate a packet for the peer if we
-				 * are at the end of
-				 * the list. Always try to push out WITHDRAWs
-				 * first. */
+				/*
+				 * Try to generate a packet for the peer if we
+				 * are at the end of the list. Always try to
+				 * push out WITHDRAWs first.
+				 */
 				if (!next_pkt || !next_pkt->buffer) {
 					next_pkt = subgroup_withdraw_packet(
 						PAF_SUBGRP(paf));
@@ -348,15 +355,13 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 					next_pkt = paf->next_pkt_to_send;
 				}
 
-				/* If we still don't have a packet to send to
-				 * the peer, then
-				 * try to find out out if we have to send eor or
-				 * if not, skip to
-				 * the next AFI, SAFI.
-				 * Don't send the EOR prematurely... if the
-				 * subgroup's coalesce
-				 * timer is running, the adjacency-out structure
-				 * is not created
+				/*
+				 * If we still don't have a packet to send to
+				 * the peer, then try to find out out if we
+				 * have to send eor or if not, skip to the next
+				 * AFI, SAFI. Don't send the EOR prematurely...
+				 * if the subgroup's coalesce timer is running,
+				 * the adjacency-out structure is not created
 				 * yet.
 				 */
 				if (!next_pkt || !next_pkt->buffer) {
@@ -393,8 +398,8 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 
 
 				/* Found a packet template to send, overwrite
-				 * packet with appropriate
-				 * attributes from peer and advance peer */
+				 * packet with appropriate attributes from peer
+				 * and advance peer */
 				s = bpacket_reformat_for_peer(next_pkt, paf);
 				bgp_packet_add(peer, s);
 				bgp_writes_on(peer);
@@ -507,12 +512,16 @@ static int bgp_write_notify(struct peer *peer)
 	/* Stop collecting data within the socket */
 	sockopt_cork(peer->fd, 0);
 
-	/* socket is in nonblocking mode, if we can't deliver the NOTIFY, well,
-	 * we only care about getting a clean shutdown at this point. */
+	/*
+	 * socket is in nonblocking mode, if we can't deliver the NOTIFY, well,
+	 * we only care about getting a clean shutdown at this point.
+	 */
 	ret = write(peer->fd, STREAM_DATA(s), stream_get_endp(s));
 
-	/* only connection reset/close gets counted as TCP_fatal_error, failure
-	 * to write the entire NOTIFY doesn't get different FSM treatment */
+	/*
+	 * only connection reset/close gets counted as TCP_fatal_error, failure
+	 * to write the entire NOTIFY doesn't get different FSM treatment
+	 */
 	if (ret <= 0) {
 		stream_free(s);
 		BGP_EVENT_ADD(peer, TCP_fatal_error);
@@ -540,8 +549,10 @@ static int bgp_write_notify(struct peer *peer)
 	if (peer->v_start >= (60 * 2))
 		peer->v_start = (60 * 2);
 
-	/* Handle Graceful Restart case where the state changes to
-	   Connect instead of Idle */
+	/*
+	 * Handle Graceful Restart case where the state changes to
+	 * Connect instead of Idle
+	 */
 	BGP_EVENT_ADD(peer, BGP_Stop);
 
 	stream_free(s);
@@ -552,8 +563,8 @@ static int bgp_write_notify(struct peer *peer)
 /*
  * Creates a BGP Notify and appends it to the peer's output queue.
  *
- * This function awakens the write thread to ensure the packet
- * gets out ASAP.
+ * This function attempts to write the packet from the thread it is called
+ * from, to ensure the packet gets out ASAP.
  *
  * @param peer
  * @param code      BGP error code
@@ -591,11 +602,11 @@ void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 	}
 	pthread_mutex_unlock(&peer->io_mtx);
 
-	/* If possible, store last packet for debugging purposes. This check is
-	 * in
-	 * place because we are sometimes called with a doppelganger peer, who
-	 * tends
-	 * to have a plethora of fields nulled out. */
+	/*
+	 * If possible, store last packet for debugging purposes. This check is
+	 * in place because we are sometimes called with a doppelganger peer,
+	 * who tends to have a plethora of fields nulled out.
+	 */
 	if (peer->curr && peer->last_reset_cause_size) {
 		size_t packetsize = stream_get_endp(peer->curr);
 		assert(packetsize <= peer->last_reset_cause_size);
@@ -661,8 +672,8 @@ void bgp_notify_send_with_data(struct peer *peer, u_char code, u_char sub_code,
 /*
  * Creates a BGP Notify and appends it to the peer's output queue.
  *
- * This function awakens the write thread to ensure the packet
- * gets out ASAP.
+ * This function attempts to write the packet from the thread it is called
+ * from, to ensure the packet gets out ASAP.
  *
  * @param peer
  * @param code      BGP error code
@@ -2169,11 +2180,12 @@ int bgp_process_packet(struct thread *thread)
 					__FUNCTION__, peer->host);
 			break;
 		default:
-			/* The message type should have been sanitized before we
-			 * ever got
-			 * here. Receipt of a message with an invalid header at
-			 * this point is
-			 * indicative of a security issue. */
+			/*
+			 * The message type should have been sanitized before
+			 * we ever got here. Receipt of a message with an
+			 * invalid header at this point is indicative of a
+			 * security issue.
+			 */
 			assert (!"Message of invalid type received during input processing");
 		}
 
@@ -2188,9 +2200,10 @@ int bgp_process_packet(struct thread *thread)
 		else
 			continue;
 
-		/* If peer was deleted, do not process any more packets. This is
-		 * usually
-		 * due to executing BGP_Stop or a stub deletion. */
+		/*
+		 * If peer was deleted, do not process any more packets. This
+		 * is usually due to executing BGP_Stop or a stub deletion.
+		 */
 		if (fsm_update_result == FSM_PEER_TRANSFERRED
 		    || fsm_update_result == FSM_PEER_STOPPED)
 			break;
@@ -2200,8 +2213,8 @@ int bgp_process_packet(struct thread *thread)
 	    && fsm_update_result != FSM_PEER_STOPPED) {
 		pthread_mutex_lock(&peer->io_mtx);
 		{
-			if (peer->ibuf->count
-			    > 0) // more work to do, come back later
+			// more work to do, come back later
+			if (peer->ibuf->count > 0)
 				thread_add_event(bm->master, bgp_process_packet,
 						 peer, 0, NULL);
 		}

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -129,43 +129,6 @@ static void bgp_packet_delete_unsafe(struct peer *peer)
 	stream_free(stream_fifo_pop(peer->obuf));
 }
 
-
-/* Check file descriptor whether connect is established. */
-static int bgp_connect_check(struct peer *peer, int change_state)
-{
-	int status;
-	socklen_t slen;
-	int ret;
-
-	/* Anyway I have to reset read and write thread. */
-	BGP_READ_OFF(peer->t_read);
-
-	/* Check file descriptor. */
-	slen = sizeof(status);
-	ret = getsockopt(peer->fd, SOL_SOCKET, SO_ERROR, (void *)&status,
-			 &slen);
-
-	/* If getsockopt is fail, this is fatal error. */
-	if (ret < 0) {
-		zlog_info("can't get sockopt for nonblocking connect");
-		BGP_EVENT_ADD(peer, TCP_fatal_error);
-		return -1;
-	}
-
-	/* When status is 0 then TCP connection is established. */
-	if (status == 0) {
-		BGP_EVENT_ADD(peer, TCP_connection_open);
-		return 1;
-	} else {
-		if (bgp_debug_neighbor_events(peer))
-			zlog_debug("%s [Event] Connect failed (%s)", peer->host,
-				   safe_strerror(errno));
-		if (change_state)
-			BGP_EVENT_ADD(peer, TCP_connection_open_failed);
-		return 0;
-	}
-}
-
 static struct stream *bgp_update_packet_eor(struct peer *peer, afi_t afi,
 					    safi_t safi)
 {
@@ -2055,18 +2018,13 @@ int bgp_read(struct thread *thread)
 	 */
 	notify_out = peer->notify_out;
 
-	/* For non-blocking IO check. */
-	if (peer->status == Connect) {
-		bgp_connect_check(peer, 1);
-		goto done;
-	} else {
-		if (peer->fd < 0) {
-			zlog_err("bgp_read peer's fd is negative value %d",
-				 peer->fd);
-			return -1;
-		}
-		BGP_READ_ON(peer->t_read, bgp_read, peer->fd);
+	if (peer->fd < 0) {
+		zlog_err("bgp_read(): peer's fd is negative value %d",
+			 peer->fd);
+		return -1;
 	}
+
+	BGP_READ_ON(peer->t_read, bgp_read, peer->fd);
 
 	/* Read packet header to determine type of the packet */
 	if (peer->packet_size == 0)
@@ -2232,12 +2190,6 @@ static int bgp_write(struct peer *peer)
 	int update_last_write = 0;
 	unsigned int count = 0;
 	unsigned int oc = 0;
-
-	/* For non-blocking IO check. */
-	if (peer->status == Connect) {
-		bgp_connect_check(peer, 1);
-		return 0;
-	}
 
 	/* Write packets. The number of packets written is the value of
 	 * bgp->wpkt_quanta or the size of the output buffer, whichever is

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2202,10 +2202,9 @@ static int bgp_write(struct peer *peer)
 			num = write(peer->fd, STREAM_PNT(s), writenum);
 
 			if (num < 0) {
-				if (ERRNO_IO_RETRY(errno))
-					continue;
+				if (!ERRNO_IO_RETRY(errno))
+					BGP_EVENT_ADD(peer, TCP_fatal_error);
 
-				BGP_EVENT_ADD(peer, TCP_fatal_error);
 				goto done;
 			} else if (num != writenum) // incomplete write
 				stream_forward_getp(s, num);

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1966,84 +1966,97 @@ int bgp_process_packet(struct thread *thread)
 	peer = THREAD_ARG(thread);
 
 	/* Guard against scheduled events that occur after peer deletion. */
-	if (peer->status == Deleted)
+	if (peer->status == Deleted || peer->status == Clearing)
 		return 0;
 
-	u_char type = 0;
-	bgp_size_t size;
-	char notify_data_length[2];
-	u_int32_t notify_out;
+	int processed = 0;
 
-	/* Note notify_out so we can check later to see if we sent another one
-	 */
-	notify_out = peer->notify_out;
+	while (processed < 5 && peer->ibuf->count > 0) {
+		u_char type = 0;
+		bgp_size_t size;
+		char notify_data_length[2];
+		u_int32_t notify_out;
 
-	pthread_mutex_lock(&peer->io_mtx);
-	{
-		peer->curr = stream_fifo_pop(peer->ibuf);
+		/* Note notify_out so we can check later to see if we sent
+		 * another one */
+		notify_out = peer->notify_out;
+
+		pthread_mutex_lock(&peer->io_mtx);
+		{
+			peer->curr = stream_fifo_pop(peer->ibuf);
+		}
+		pthread_mutex_unlock(&peer->io_mtx);
+
+		if (peer->curr == NULL) // no packets to process, hmm...
+			return 0;
+
+		bgp_size_t actual_size = stream_get_endp(peer->curr);
+
+		/* skip the marker and copy the packet length */
+		stream_forward_getp(peer->curr, BGP_MARKER_SIZE);
+		memcpy(notify_data_length, stream_pnt(peer->curr), 2);
+
+		/* read in the packet length and type */
+		size = stream_getw(peer->curr);
+		type = stream_getc(peer->curr);
+
+		/* BGP packet dump function. */
+		bgp_dump_packet(peer, type, peer->curr);
+
+		/* adjust size to exclude the marker + length + type */
+		size -= BGP_HEADER_SIZE;
+
+		/* Read rest of the packet and call each sort of packet routine
+		 */
+		switch (type) {
+		case BGP_MSG_OPEN:
+			peer->open_in++;
+			bgp_open_receive(peer,
+					 size); /* XXX return value ignored! */
+			break;
+		case BGP_MSG_UPDATE:
+			peer->readtime = monotime(NULL);
+			bgp_update_receive(peer, size);
+			break;
+		case BGP_MSG_NOTIFY:
+			bgp_notify_receive(peer, size);
+			break;
+		case BGP_MSG_KEEPALIVE:
+			peer->readtime = monotime(NULL);
+			bgp_keepalive_receive(peer, size);
+			break;
+		case BGP_MSG_ROUTE_REFRESH_NEW:
+		case BGP_MSG_ROUTE_REFRESH_OLD:
+			peer->refresh_in++;
+			bgp_route_refresh_receive(peer, size);
+			break;
+		case BGP_MSG_CAPABILITY:
+			peer->dynamic_cap_in++;
+			bgp_capability_receive(peer, size);
+			break;
+		}
+
+		/* If reading this packet caused us to send a NOTIFICATION then
+		 * store a copy
+		 * of the packet for troubleshooting purposes
+		 */
+		if (notify_out < peer->notify_out) {
+			memcpy(peer->last_reset_cause, peer->curr->data,
+			       actual_size);
+			peer->last_reset_cause_size = actual_size;
+		}
+
+		/* Delete packet and carry on. */
+		if (peer->curr) {
+			stream_free(peer->curr);
+			peer->curr = NULL;
+			processed++;
+		}
 	}
-	pthread_mutex_unlock(&peer->io_mtx);
 
-	if (peer->curr == NULL) // no packets to process, hmm...
-		return 0;
-
-	bgp_size_t actual_size = stream_get_endp(peer->curr);
-
-	/* skip the marker and copy the packet length */
-	stream_forward_getp(peer->curr, BGP_MARKER_SIZE);
-	memcpy(notify_data_length, stream_pnt(peer->curr), 2);
-
-	/* read in the packet length and type */
-	size = stream_getw(peer->curr);
-	type = stream_getc(peer->curr);
-
-	/* BGP packet dump function. */
-	bgp_dump_packet(peer, type, peer->curr);
-
-	/* adjust size to exclude the marker + length + type */
-	size -= BGP_HEADER_SIZE;
-
-	/* Read rest of the packet and call each sort of packet routine */
-	switch (type) {
-	case BGP_MSG_OPEN:
-		peer->open_in++;
-		bgp_open_receive(peer, size); /* XXX return value ignored! */
-		break;
-	case BGP_MSG_UPDATE:
-		peer->readtime = monotime(NULL);
-		bgp_update_receive(peer, size);
-		break;
-	case BGP_MSG_NOTIFY:
-		bgp_notify_receive(peer, size);
-		break;
-	case BGP_MSG_KEEPALIVE:
-		peer->readtime = monotime(NULL);
-		bgp_keepalive_receive(peer, size);
-		break;
-	case BGP_MSG_ROUTE_REFRESH_NEW:
-	case BGP_MSG_ROUTE_REFRESH_OLD:
-		peer->refresh_in++;
-		bgp_route_refresh_receive(peer, size);
-		break;
-	case BGP_MSG_CAPABILITY:
-		peer->dynamic_cap_in++;
-		bgp_capability_receive(peer, size);
-		break;
-	}
-
-	/* If reading this packet caused us to send a NOTIFICATION then store a
-	 * copy
-	 * of the packet for troubleshooting purposes
-	 */
-	if (notify_out < peer->notify_out) {
-		memcpy(peer->last_reset_cause, peer->curr->data, actual_size);
-		peer->last_reset_cause_size = actual_size;
-	}
-
-	/* Delete packet and carry on. */
-	if (peer->curr) {
-		stream_free(peer->curr);
-		peer->curr = NULL;
+	if (peer->ibuf->count > 0) { // more work to do, come back later
+		thread_add_background(bm->master, bgp_process_packet, peer, 0,
+				      &peer->t_process_packet);
 	}
 
 	return 0;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2142,8 +2142,22 @@ int bgp_process_packet(struct thread *thread)
 	int mprc;		  // message processing return code
 
 	peer = THREAD_ARG(thread);
+/*
+ * This functionality is presently disabled. Unfortunately due to the
+ * way bgpd is structured, reading more than one packet per input cycle
+ * severely impacts convergence time. This is because advancing the
+ * state of the routing table based on prefixes learned from one peer
+ * prior to all (or at least most) peers being established and placed
+ * into an update-group will make UPDATE generation starve
+ * bgp_accept(), delaying convergence. This is a deficiency that needs
+ * to be fixed elsewhere in the codebase, but for now our hand is
+ * forced.
+ */
+#if 0
 	rpkt_quanta_old = atomic_load_explicit(&peer->bgp->rpkt_quanta,
 					       memory_order_relaxed);
+#endif
+	rpkt_quanta_old = 1;
 	fsm_update_result = 0;
 
 	/* Guard against scheduled events that occur after peer deletion. */

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2156,22 +2156,8 @@ int bgp_process_packet(struct thread *thread)
 	int mprc;		  // message processing return code
 
 	peer = THREAD_ARG(thread);
-/*
- * This functionality is presently disabled. Unfortunately due to the
- * way bgpd is structured, reading more than one packet per input cycle
- * severely impacts convergence time. This is because advancing the
- * state of the routing table based on prefixes learned from one peer
- * prior to all (or at least most) peers being established and placed
- * into an update-group will make UPDATE generation starve
- * bgp_accept(), delaying convergence. This is a deficiency that needs
- * to be fixed elsewhere in the codebase, but for now our hand is
- * forced.
- */
-#if 0
 	rpkt_quanta_old = atomic_load_explicit(&peer->bgp->rpkt_quanta,
 					       memory_order_relaxed);
-#endif
-	rpkt_quanta_old = 1;
 	fsm_update_result = 0;
 
 	/* Guard against scheduled events that occur after peer deletion. */

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -371,8 +371,13 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 	struct stream *s;
 	struct peer_af *paf;
 	struct bpacket *next_pkt;
+	uint32_t wpq;
+	uint32_t generated = 0;
 	afi_t afi;
 	safi_t safi;
+
+	wpq = atomic_load_explicit(&peer->bgp->wpkt_quanta,
+				   memory_order_relaxed);
 
 	/*
 	 * The code beyond this part deals with update packets, proceed only
@@ -458,7 +463,7 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 				bgp_writes_on(peer);
 				bpacket_queue_advance_peer(paf);
 			}
-	} while (s);
+	} while (s && (++generated < wpq));
 
 	bgp_write_proceed_actions(peer);
 

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -38,8 +38,6 @@
 #define ORF_COMMON_PART_DENY       0x20 
 
 /* Packet send and receive function prototypes. */
-extern int bgp_read(struct thread *);
-
 extern void bgp_keepalive_send(struct peer *);
 extern void bgp_open_send(struct peer *);
 extern void bgp_notify_send(struct peer *, u_int8_t, u_int8_t);
@@ -68,5 +66,6 @@ extern int bgp_packet_set_size(struct stream *s);
 extern bool bgp_packet_writes_thread_run;
 
 extern int bgp_generate_updgrp_packets(struct thread *);
+extern int bgp_process_packet(struct thread *);
 
 #endif /* _QUAGGA_BGP_PACKET_H */

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -72,5 +72,6 @@ extern void *peer_writes_start(void *arg);
 extern void peer_writes_on(struct peer *peer);
 extern void peer_writes_off(struct peer *peer);
 extern void peer_writes_wake(void);
+extern int peer_writes_stop(void **result);
 
 #endif /* _QUAGGA_BGP_PACKET_H */

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -67,6 +67,7 @@ extern int bgp_packet_set_size(struct stream *s);
 /* Control variable for write thread. */
 extern bool bgp_packet_writes_thread_run;
 
+extern void peer_writes_init(void);
 extern void *peer_writes_start(void *arg);
 extern void peer_writes_on(struct peer *peer);
 extern void peer_writes_off(struct peer *peer);

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -39,8 +39,6 @@
 
 /* Packet send and receive function prototypes. */
 extern int bgp_read(struct thread *);
-extern int bgp_write(struct thread *);
-extern int bgp_connect_check(struct peer *, int change_state);
 
 extern void bgp_keepalive_send(struct peer *);
 extern void bgp_open_send(struct peer *);
@@ -65,6 +63,13 @@ extern void bgp_check_update_delay(struct bgp *);
 
 extern int bgp_packet_set_marker(struct stream *s, u_char type);
 extern int bgp_packet_set_size(struct stream *s);
-extern void bgp_packet_add(struct peer *peer, struct stream *s);
+
+/* Control variable for write thread. */
+extern bool bgp_packet_writes_thread_run;
+
+extern void *peer_writes_start(void *arg);
+extern void peer_writes_on(struct peer *peer);
+extern void peer_writes_off(struct peer *peer);
+extern void peer_writes_wake(void);
 
 #endif /* _QUAGGA_BGP_PACKET_H */

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -67,11 +67,6 @@ extern int bgp_packet_set_size(struct stream *s);
 /* Control variable for write thread. */
 extern bool bgp_packet_writes_thread_run;
 
-extern void peer_writes_init(void);
-extern void *peer_writes_start(void *arg);
-extern void peer_writes_on(struct peer *peer);
-extern void peer_writes_off(struct peer *peer);
-extern void peer_writes_wake(void);
-extern int peer_writes_stop(void **result);
+extern int bgp_generate_updgrp_packets(struct thread *);
 
 #endif /* _QUAGGA_BGP_PACKET_H */

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -61,9 +61,6 @@ extern void bgp_check_update_delay(struct bgp *);
 extern int bgp_packet_set_marker(struct stream *s, u_char type);
 extern int bgp_packet_set_size(struct stream *s);
 
-/* Control variable for write thread. */
-extern bool bgp_packet_writes_thread_run;
-
 extern int bgp_generate_updgrp_packets(struct thread *);
 extern int bgp_process_packet(struct thread *);
 

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -24,7 +24,6 @@
 #define BGP_NLRI_LENGTH       1U
 #define BGP_TOTAL_ATTR_LEN    2U
 #define BGP_UNFEASIBLE_LEN    2U
-#define BGP_WRITE_PACKET_MAX 10U
 
 /* When to refresh */
 #define REFRESH_IMMEDIATE 1

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1867,23 +1867,6 @@ void peer_af_announce_route(struct peer_af *paf, int combine)
 			    subgrp->peer_count - 1);
 }
 
-void subgroup_trigger_write(struct update_subgroup *subgrp)
-{
-	struct peer_af *paf;
-
-#if 0
-  if (bgp_debug_update(NULL, NULL, subgrp->update_group, 0))
-    zlog_debug("u%llu:s%llu scheduling write thread for peers",
-               subgrp->update_group->id, subgrp->id);
-#endif
-	SUBGRP_FOREACH_PEER (subgrp, paf) {
-		if (paf->peer->status == Established) {
-			BGP_PEER_WRITE_ON(paf->peer->t_write, bgp_write,
-					  paf->peer->fd, paf->peer);
-		}
-	}
-}
-
 int update_group_clear_update_dbg(struct update_group *updgrp, void *arg)
 {
 	UPDGRP_PEER_DBG_OFF(updgrp);

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1872,10 +1872,11 @@ void subgroup_trigger_write(struct update_subgroup *subgrp)
 {
 	struct peer_af *paf;
 
-	/* For each peer in the subgroup, schedule a job to pull packets from
-	 * the
-	 * subgroup output queue into their own output queue. This action will
-	 * trigger a write job on the I/O thread. */
+	/*
+	 * For each peer in the subgroup, schedule a job to pull packets from
+	 * the subgroup output queue into their own output queue. This action
+	 * will trigger a write job on the I/O thread.
+	 */
 	SUBGRP_FOREACH_PEER(subgrp, paf)
 	if (paf->peer->status == Established)
 		thread_add_timer_msec(bm->master, bgp_generate_updgrp_packets,

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -29,7 +29,27 @@
 
 #include "bgp_advertise.h"
 
-#define BGP_DEFAULT_SUBGROUP_COALESCE_TIME 200
+/*
+ * The following three heuristic constants determine how long advertisement to
+ * a subgroup will be delayed after it is created. The intent is to allow
+ * transient changes in peer state (primarily session establishment) to settle,
+ * so that more peers can be grouped together and benefit from sharing
+ * advertisement computations with the subgroup.
+ *
+ * These values have a very large impact on initial convergence time; any
+ * changes should be accompanied by careful performance testing at all scales.
+ *
+ * The coalesce time 'C' for a new subgroup within a particular BGP instance
+ * 'B' with total number of known peers 'P', established or not, is computed as
+ * follows:
+ *
+ * C = MIN(BGP_MAX_SUBGROUP_COALESCE_TIME,
+ *         BGP_DEFAULT_SUBGROUP_COALESCE_TIME +
+ *         (P*BGP_PEER_ADJUST_SUBGROUP_COALESCE_TIME))
+ */
+#define BGP_DEFAULT_SUBGROUP_COALESCE_TIME 1000
+#define BGP_MAX_SUBGROUP_COALESCE_TIME 10000
+#define BGP_PEER_ADJUST_SUBGROUP_COALESCE_TIME 50
 
 #define PEER_UPDGRP_FLAGS                                                      \
 	(PEER_FLAG_LOCAL_AS_NO_PREPEND | PEER_FLAG_LOCAL_AS_REPLACE_AS)

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -442,6 +442,7 @@ extern void bgp_adj_out_unset_subgroup(struct bgp_node *rn,
 				       char withdraw, u_int32_t addpath_tx_id);
 void subgroup_announce_table(struct update_subgroup *subgrp,
 			     struct bgp_table *table);
+extern void subgroup_trigger_write(struct update_subgroup *subgrp);
 
 extern int update_group_clear_update_dbg(struct update_group *updgrp,
 					 void *arg);

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -179,7 +179,7 @@ struct update_subgroup {
 	struct stream *work;
 
 	/* We use a separate stream to encode MP_REACH_NLRI for efficient
-	 * NLRI packing. peer->work stores all the other attributes. The
+	 * NLRI packing. peer->obuf_work stores all the other attributes. The
 	 * actual packet is then constructed by concatenating the two.
 	 */
 	struct stream *scratch;

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -442,7 +442,6 @@ extern void bgp_adj_out_unset_subgroup(struct bgp_node *rn,
 				       char withdraw, u_int32_t addpath_tx_id);
 void subgroup_announce_table(struct update_subgroup *subgrp,
 			     struct bgp_table *table);
-extern void subgroup_trigger_write(struct update_subgroup *subgrp);
 
 extern int update_group_clear_update_dbg(struct update_group *updgrp,
 					 void *arg);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -483,6 +483,7 @@ void bgp_adj_out_unset_subgroup(struct bgp_node *rn,
 {
 	struct bgp_adj_out *adj;
 	struct bgp_advertise *adv;
+	bool trigger_write;
 
 	if (DISABLE_BGP_ANNOUNCE)
 		return;
@@ -500,9 +501,16 @@ void bgp_adj_out_unset_subgroup(struct bgp_node *rn,
 			adv->rn = rn;
 			adv->adj = adj;
 
+			/* Note if we need to trigger a packet write */
+			trigger_write =
+				BGP_ADV_FIFO_EMPTY(&subgrp->sync->withdraw);
+
 			/* Add to synchronization entry for withdraw
 			 * announcement.  */
 			BGP_ADV_FIFO_ADD(&subgrp->sync->withdraw, &adv->fifo);
+
+			if (trigger_write)
+				subgroup_trigger_write(subgrp);
 		} else {
 			/* Remove myself from adjacency. */
 			BGP_ADJ_OUT_DEL(rn, adj);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -483,7 +483,6 @@ void bgp_adj_out_unset_subgroup(struct bgp_node *rn,
 {
 	struct bgp_adj_out *adj;
 	struct bgp_advertise *adv;
-	char trigger_write;
 
 	if (DISABLE_BGP_ANNOUNCE)
 		return;
@@ -501,20 +500,9 @@ void bgp_adj_out_unset_subgroup(struct bgp_node *rn,
 			adv->rn = rn;
 			adv->adj = adj;
 
-			/* Note if we need to trigger a packet write */
-			if (BGP_ADV_FIFO_EMPTY(&subgrp->sync->withdraw))
-				trigger_write = 1;
-			else
-				trigger_write = 0;
-
 			/* Add to synchronization entry for withdraw
 			 * announcement.  */
 			BGP_ADV_FIFO_ADD(&subgrp->sync->withdraw, &adv->fifo);
-
-			/* Schedule packet write, if FIFO is getting its first
-			 * entry. */
-			if (trigger_write)
-				subgroup_trigger_write(subgrp);
 		} else {
 			/* Remove myself from adjacency. */
 			BGP_ADJ_OUT_DEL(rn, adj);

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -1148,6 +1148,7 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
 	bgp_packet_set_size(s);
 
 	(void)bpacket_queue_add(SUBGRP_PKTQ(subgrp), s, &vecarr);
+	subgroup_trigger_write(subgrp);
 }
 
 void subgroup_default_withdraw_packet(struct update_subgroup *subgrp)
@@ -1240,6 +1241,7 @@ void subgroup_default_withdraw_packet(struct update_subgroup *subgrp)
 	bgp_packet_set_size(s);
 
 	(void)bpacket_queue_add(SUBGRP_PKTQ(subgrp), s, NULL);
+	subgroup_trigger_write(subgrp);
 }
 
 static void

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -633,7 +633,6 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 		}
 	}
 
-	bgp_packet_add(peer, s);
 	return s;
 }
 
@@ -1149,7 +1148,6 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
 	bgp_packet_set_size(s);
 
 	(void)bpacket_queue_add(SUBGRP_PKTQ(subgrp), s, &vecarr);
-	subgroup_trigger_write(subgrp);
 }
 
 void subgroup_default_withdraw_packet(struct update_subgroup *subgrp)
@@ -1242,7 +1240,6 @@ void subgroup_default_withdraw_packet(struct update_subgroup *subgrp)
 	bgp_packet_set_size(s);
 
 	(void)bpacket_queue_add(SUBGRP_PKTQ(subgrp), s, NULL);
-	subgroup_trigger_write(subgrp);
 }
 
 static void

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1367,7 +1367,7 @@ void bgp_config_write_wpkt_quanta(struct vty *vty, struct bgp *bgp)
 	uint32_t quanta =
 		atomic_load_explicit(&bgp->wpkt_quanta, memory_order_relaxed);
 	if (quanta != BGP_WRITE_PACKET_MAX)
-		vty_out(vty, " write-quanta %d%s", quanta, VTY_NEWLINE);
+		vty_out(vty, " write-quanta %d\n", quanta);
 }
 
 void bgp_config_write_rpkt_quanta(struct vty *vty, struct bgp *bgp)
@@ -1375,7 +1375,7 @@ void bgp_config_write_rpkt_quanta(struct vty *vty, struct bgp *bgp)
 	uint32_t quanta =
 		atomic_load_explicit(&bgp->rpkt_quanta, memory_order_relaxed);
 	if (quanta != BGP_READ_PACKET_MAX)
-		vty_out(vty, " read-quanta %d%s", quanta, VTY_NEWLINE);
+		vty_out(vty, " read-quanta %d\n", quanta);
 }
 
 /* Packet quanta configuration */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7068,14 +7068,40 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 
 			vty_out(vty, "4 %10u %7u %7u %8" PRIu64 " %4d %4zd %8s",
 				peer->as,
-				peer->open_in + peer->update_in
-					+ peer->keepalive_in + peer->notify_in
-					+ peer->refresh_in
-					+ peer->dynamic_cap_in,
-				peer->open_out + peer->update_out
-					+ peer->keepalive_out + peer->notify_out
-					+ peer->refresh_out
-					+ peer->dynamic_cap_out,
+				atomic_load_explicit(&peer->open_in,
+						     memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->update_in,
+						  memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->keepalive_in,
+						  memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->notify_in,
+						  memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->refresh_in,
+						  memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->dynamic_cap_in,
+						  memory_order_relaxed),
+				atomic_load_explicit(&peer->open_out,
+						     memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->update_out,
+						  memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->keepalive_out,
+						  memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->notify_out,
+						  memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->refresh_out,
+						  memory_order_relaxed)
+					+ atomic_load_explicit(
+						  &peer->dynamic_cap_out,
+						  memory_order_relaxed),
 				peer->version[afi][safi], 0, peer->obuf->count,
 				peer_uptime(peer->uptime, timebuf,
 					    BGP_UPTIME_LEN, 0, NULL));

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9657,7 +9657,8 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, u_char use_json,
 			json_object_string_add(json_neigh, "readThread", "on");
 		else
 			json_object_string_add(json_neigh, "readThread", "off");
-		if (p->t_write)
+
+		if (CHECK_FLAG(p->thread_flags, PEER_THREAD_WRITES_ON))
 			json_object_string_add(json_neigh, "writeThread", "on");
 		else
 			json_object_string_add(json_neigh, "writeThread",
@@ -9683,7 +9684,10 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, u_char use_json,
 			vty_out(vty, "Peer Authentication Enabled\n");
 
 		vty_out(vty, "Read thread: %s  Write thread: %s\n",
-			p->t_read ? "on" : "off", p->t_write ? "on" : "off");
+			p->t_read ? "on" : "off",
+			CHECK_FLAG(p->thread_flags, PEER_THREAD_WRITES_ON)
+				? "on"
+				: "off");
 	}
 
 	if (p->notify.code == BGP_NOTIFY_OPEN_ERR

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -48,6 +48,7 @@ extern const char *afi_safi_print(afi_t, safi_t);
 extern const char *afi_safi_json(afi_t, safi_t);
 extern void bgp_config_write_update_delay(struct vty *, struct bgp *);
 extern void bgp_config_write_wpkt_quanta(struct vty *vty, struct bgp *bgp);
+extern void bgp_config_write_rpkt_quanta(struct vty *vty, struct bgp *bgp);
 extern void bgp_config_write_listen(struct vty *vty, struct bgp *bgp);
 extern void bgp_config_write_coalesce_time(struct vty *vty, struct bgp *bgp);
 extern int bgp_vty_return(struct vty *vty, int ret);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -77,6 +77,7 @@
 #include "bgpd/bgp_memory.h"
 #include "bgpd/bgp_evpn_vty.h"
 #include "bgpd/bgp_keepalives.h"
+#include "bgpd/bgp_io.h"
 
 
 DEFINE_MTYPE_STATIC(BGPD, PEER_TX_SHUTDOWN_MSG, "Peer shutdown message (TX)");

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7404,7 +7404,7 @@ static const struct cmd_variable_handler bgp_viewvrf_var_handlers[] = {
 	{.completions = NULL},
 };
 
-void bgp_pthreads_init()
+static void bgp_pthreads_init()
 {
 	frr_pthread_init();
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -990,7 +990,7 @@ static void peer_free(struct peer *peer)
 	 */
 	bgp_timer_set(peer);
 	BGP_READ_OFF(peer->t_read);
-	BGP_WRITE_OFF(peer->t_write);
+	peer_writes_off(peer);
 	BGP_EVENT_FLUSH(peer);
 
 	/* Free connected nexthop, if present */
@@ -1137,6 +1137,7 @@ struct peer *peer_new(struct bgp *bgp)
 	/* Create buffers.  */
 	peer->ibuf = stream_new(BGP_MAX_PACKET_SIZE);
 	peer->obuf = stream_fifo_new();
+	pthread_mutex_init(&peer->obuf_mtx, NULL);
 
 	/* We use a larger buffer for peer->work in the event that:
 	 * - We RX a BGP_UPDATE where the attributes alone are just

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7407,10 +7407,10 @@ void bgp_pthreads_init()
 	frr_pthread_new("BGP i/o thread", PTHREAD_IO, bgp_io_start,
 			bgp_io_stop);
 	frr_pthread_new("BGP keepalives thread", PTHREAD_KEEPALIVES,
-			peer_keepalives_start, peer_keepalives_stop);
+			bgp_keepalives_start, bgp_keepalives_stop);
 
 	/* pre-run initialization */
-	peer_keepalives_init();
+	bgp_keepalives_init();
 	bgp_io_init();
 }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -75,6 +75,7 @@
 #include "bgpd/bgp_bfd.h"
 #include "bgpd/bgp_memory.h"
 #include "bgpd/bgp_evpn_vty.h"
+#include "bgpd/bgp_keepalives.h"
 
 
 DEFINE_MTYPE_STATIC(BGPD, PEER_TX_SHUTDOWN_MSG, "Peer shutdown message (TX)");
@@ -7326,6 +7327,8 @@ void bgp_master_init(struct thread_master *master)
 	bm->start_time = bgp_clock();
 	bm->t_rmap_update = NULL;
 	bm->rmap_update_timer = RMAP_DEFAULT_UPDATE_TIMER;
+	bm->t_bgp_keepalives = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_t));
+	bm->t_bgp_packet_writes = XCALLOC(MTYPE_PTHREAD, sizeof(pthread_t));
 
 	bgp_process_queue_init();
 
@@ -7381,6 +7384,32 @@ static const struct cmd_variable_handler bgp_viewvrf_var_handlers[] = {
 	{.tokenname = "VIEWVRFNAME", .completions = bgp_viewvrf_autocomplete},
 	{.completions = NULL},
 };
+
+void bgp_pthreads_init()
+{
+	/* init write & keepalive threads */
+	pthread_create(bm->t_bgp_keepalives, NULL, &peer_keepalives_start,
+		       NULL);
+	pthread_create(bm->t_bgp_packet_writes, NULL, &peer_writes_start, NULL);
+}
+
+void bgp_pthreads_finish()
+{
+	/* set thread cancellation flags */
+	bgp_keepalives_thread_run = false;
+	bgp_packet_writes_thread_run = false;
+
+	/* wake them up */
+	peer_writes_wake();
+	peer_keepalives_wake();
+
+	/* join */
+	pthread_join(*bm->t_bgp_keepalives, NULL);
+	pthread_join(*bm->t_bgp_packet_writes, NULL);
+
+	XFREE(MTYPE_PTHREAD, bm->t_bgp_keepalives);
+	XFREE(MTYPE_PTHREAD, bm->t_bgp_packet_writes);
+}
 
 void bgp_init(void)
 {

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7387,7 +7387,14 @@ static const struct cmd_variable_handler bgp_viewvrf_var_handlers[] = {
 
 void bgp_pthreads_init()
 {
-	/* init write & keepalive threads */
+	/* pre-run initialization */
+	peer_keepalives_init();
+	peer_writes_init();
+}
+
+void bgp_pthreads_run()
+{
+	/* run threads */
 	pthread_create(bm->t_bgp_keepalives, NULL, &peer_keepalives_start,
 		       NULL);
 	pthread_create(bm->t_bgp_packet_writes, NULL, &peer_writes_start, NULL);
@@ -7416,6 +7423,9 @@ void bgp_init(void)
 
 	/* allocates some vital data structures used by peer commands in
 	 * vty_init */
+
+	/* pre-init pthreads */
+	bgp_pthreads_init();
 
 	/* Init zebra. */
 	bgp_zebra_init(bm->master);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1162,9 +1162,8 @@ struct peer *peer_new(struct bgp *bgp)
 	 */
 	peer->obuf_work =
 		stream_new(BGP_MAX_PACKET_SIZE + BGP_MAX_PACKET_SIZE_OVERFLOW);
-	peer->ibuf_work = stream_new(BGP_MAX_PACKET_SIZE);
+	peer->ibuf_work = stream_new(BGP_MAX_PACKET_SIZE * 5);
 	peer->scratch = stream_new(BGP_MAX_PACKET_SIZE);
-
 
 	bgp_sync_init(peer);
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1474,6 +1474,11 @@ struct peer *peer_create(union sockunion *su, const char *conf_if,
 	listnode_add_sort(bgp->peer, peer);
 	hash_get(bgp->peerhash, peer, hash_alloc_intern);
 
+	/* Adjust update-group coalesce timer heuristics for # peers. */
+	long ct = BGP_DEFAULT_SUBGROUP_COALESCE_TIME
+		  + (bgp->peer->count * BGP_PEER_ADJUST_SUBGROUP_COALESCE_TIME);
+	bgp->coalesce_time = MIN(BGP_MAX_SUBGROUP_COALESCE_TIME, ct);
+
 	active = peer_active(peer);
 
 	/* Last read and reset time set */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -378,7 +378,9 @@ struct bgp {
 #define BGP_FLAG_IBGP_MULTIPATH_SAME_CLUSTERLEN (1 << 0)
 	} maxpaths[AFI_MAX][SAFI_MAX];
 
-	u_int32_t wpkt_quanta; /* per peer packet quanta to write */
+	_Atomic uint32_t wpkt_quanta; // max # packets to write per i/o cycle
+	_Atomic uint32_t rpkt_quanta; // max # packets to read per i/o cycle
+
 	u_int32_t coalesce_time;
 
 	u_int32_t addpath_tx_id;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -100,9 +100,9 @@ struct bgp_master {
 	/* BGP thread master.  */
 	struct thread_master *master;
 
-	/* BGP pthreads. */
-	pthread_t *t_bgp_keepalives;
-	pthread_t *t_bgp_packet_writes;
+/* BGP pthreads. */
+#define PTHREAD_WRITE           (1 << 1)
+#define PTHREAD_KEEPALIVES      (1 << 2)
 
 	/* work queues */
 	struct work_queue *process_main_queue;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -22,6 +22,8 @@
 #define _QUAGGA_BGPD_H
 
 #include "qobj.h"
+#include <pthread.h>
+
 #include "lib/json.h"
 #include "vrf.h"
 #include "vty.h"
@@ -584,6 +586,7 @@ struct peer {
 
 	/* Packet receive and send buffer. */
 	struct stream *ibuf;
+	pthread_mutex_t obuf_mtx;
 	struct stream_fifo *obuf;
 	struct stream *work;
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -100,6 +100,10 @@ struct bgp_master {
 	/* BGP thread master.  */
 	struct thread_master *master;
 
+	/* BGP pthreads. */
+	pthread_t *t_bgp_keepalives;
+	pthread_t *t_bgp_packet_writes;
+
 	/* work queues */
 	struct work_queue *process_main_queue;
 
@@ -1254,6 +1258,8 @@ extern int bgp_config_write(struct vty *);
 extern void bgp_master_init(struct thread_master *master);
 
 extern void bgp_init(void);
+extern void bgp_pthreads_init(void);
+extern void bgp_pthreads_finish(void);
 extern void bgp_route_map_init(void);
 extern void bgp_session_reset(struct peer *);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -806,6 +806,7 @@ struct peer {
 	struct thread *t_pmax_restart;
 	struct thread *t_gr_restart;
 	struct thread *t_gr_stale;
+	struct thread *t_generate_updgrp_packets;
 
 	/* Thread flags. */
 	u_int16_t thread_flags;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -789,19 +789,19 @@ struct peer {
 	(CHECK_FLAG(peer->config, PEER_CONFIG_TIMER)			     \
 	 || CHECK_FLAG(peer->config, PEER_GROUP_CONFIG_TIMER))
 
-	u_int32_t holdtime;
-	u_int32_t keepalive;
-	u_int32_t connect;
-	u_int32_t routeadv;
+	_Atomic uint32_t holdtime;
+	_Atomic uint32_t keepalive;
+	_Atomic uint32_t connect;
+	_Atomic uint32_t routeadv;
 
 	/* Timer values. */
-	u_int32_t v_start;
-	u_int32_t v_connect;
-	u_int32_t v_holdtime;
-	u_int32_t v_keepalive;
-	u_int32_t v_routeadv;
-	u_int32_t v_pmax_restart;
-	u_int32_t v_gr_restart;
+	_Atomic uint32_t v_start;
+	_Atomic uint32_t v_connect;
+	_Atomic uint32_t v_holdtime;
+	_Atomic uint32_t v_keepalive;
+	_Atomic uint32_t v_routeadv;
+	_Atomic uint32_t v_pmax_restart;
+	_Atomic uint32_t v_gr_restart;
 
 	/* Threads. */
 	struct thread *t_read;
@@ -818,7 +818,7 @@ struct peer {
 	struct thread *t_process_packet;
 
 	/* Thread flags. */
-	u_int16_t thread_flags;
+	_Atomic uint16_t thread_flags;
 #define PEER_THREAD_WRITES_ON         (1 << 0)
 #define PEER_THREAD_READS_ON          (1 << 1)
 #define PEER_THREAD_KEEPALIVES_ON     (1 << 2)
@@ -826,19 +826,19 @@ struct peer {
 	struct work_queue *clear_node_queue;
 
 	/* Statistics field */
-	u_int32_t open_in;	 /* Open message input count */
-	u_int32_t open_out;	/* Open message output count */
-	u_int32_t update_in;       /* Update message input count */
-	u_int32_t update_out;      /* Update message ouput count */
-	time_t update_time;	/* Update message received time. */
-	u_int32_t keepalive_in;    /* Keepalive input count */
-	u_int32_t keepalive_out;   /* Keepalive output count */
-	u_int32_t notify_in;       /* Notify input count */
-	u_int32_t notify_out;      /* Notify output count */
-	u_int32_t refresh_in;      /* Route Refresh input count */
-	u_int32_t refresh_out;     /* Route Refresh output count */
-	u_int32_t dynamic_cap_in;  /* Dynamic Capability input count.  */
-	u_int32_t dynamic_cap_out; /* Dynamic Capability output count.  */
+	_Atomic uint32_t open_in;         /* Open message input count */
+	_Atomic uint32_t open_out;        /* Open message output count */
+	_Atomic uint32_t update_in;       /* Update message input count */
+	_Atomic uint32_t update_out;      /* Update message ouput count */
+	_Atomic time_t update_time;       /* Update message received time. */
+	_Atomic uint32_t keepalive_in;    /* Keepalive input count */
+	_Atomic uint32_t keepalive_out;   /* Keepalive output count */
+	_Atomic uint32_t notify_in;       /* Notify input count */
+	_Atomic uint32_t notify_out;      /* Notify output count */
+	_Atomic uint32_t refresh_in;      /* Route Refresh input count */
+	_Atomic uint32_t refresh_out;     /* Route Refresh output count */
+	_Atomic uint32_t dynamic_cap_in;  /* Dynamic Capability input count.  */
+	_Atomic uint32_t dynamic_cap_out; /* Dynamic Capability output count.  */
 
 	/* BGP state count */
 	u_int32_t established; /* Established */
@@ -851,8 +851,10 @@ struct peer {
 	/* Syncronization list and time.  */
 	struct bgp_synchronize *sync[AFI_MAX][SAFI_MAX];
 	time_t synctime;
-	time_t last_write;  /* timestamp when the last msg was written */
-	time_t last_update; /* timestamp when the last UPDATE msg was written */
+	/* timestamp when the last UPDATE msg was written */
+	_Atomic time_t last_write;
+	/* timestamp when the last msg was written */
+	_Atomic time_t last_update;
 
 	/* Send prefix count. */
 	unsigned long scount[AFI_MAX][SAFI_MAX];

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -819,9 +819,9 @@ struct peer {
 
 	/* Thread flags. */
 	u_int16_t thread_flags;
-#define PEER_THREAD_WRITES_ON         (1 << 1)
-#define PEER_THREAD_READS_ON          (1 << 2)
-#define PEER_THREAD_KEEPALIVES_ON     (1 << 3)
+#define PEER_THREAD_WRITES_ON         (1 << 0)
+#define PEER_THREAD_READS_ON          (1 << 1)
+#define PEER_THREAD_KEEPALIVES_ON     (1 << 2)
 	/* workqueues */
 	struct work_queue *clear_node_queue;
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -799,16 +799,18 @@ struct peer {
 
 	/* Threads. */
 	struct thread *t_read;
-	struct thread *t_write;
 	struct thread *t_start;
 	struct thread *t_connect;
 	struct thread *t_holdtime;
-	struct thread *t_keepalive;
 	struct thread *t_routeadv;
 	struct thread *t_pmax_restart;
 	struct thread *t_gr_restart;
 	struct thread *t_gr_stale;
 
+	/* Thread flags. */
+	u_int16_t thread_flags;
+#define PEER_THREAD_WRITES_ON         (1 << 0)
+#define PEER_THREAD_KEEPALIVES_ON     (1 << 1)
 	/* workqueues */
 	struct work_queue *clear_node_queue;
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -807,7 +807,8 @@ struct peer {
 	struct thread *t_read;
 	struct thread *t_write;
 	struct thread *t_start;
-	struct thread *t_connect_check;
+	struct thread *t_connect_check_r;
+	struct thread *t_connect_check_w;
 	struct thread *t_connect;
 	struct thread *t_holdtime;
 	struct thread *t_routeadv;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -101,7 +101,7 @@ struct bgp_master {
 	struct thread_master *master;
 
 /* BGP pthreads. */
-#define PTHREAD_WRITE           (1 << 1)
+#define PTHREAD_IO              (1 << 1)
 #define PTHREAD_KEEPALIVES      (1 << 2)
 
 	/* work queues */
@@ -589,13 +589,17 @@ struct peer {
 	struct in_addr local_id;
 
 	/* Packet receive and send buffer. */
-	struct stream *ibuf;
-	pthread_mutex_t obuf_mtx;
-	struct stream_fifo *obuf;
-	struct stream *work;
+	pthread_mutex_t io_mtx;   // guards ibuf, obuf
+	struct stream_fifo *ibuf; // packets waiting to be processed
+	struct stream_fifo *obuf; // packets waiting to be written
+
+	struct stream *ibuf_work; // WiP buffer used by bgp_read() only
+	struct stream *obuf_work; // WiP buffer used to construct packets
+
+	struct stream *curr; // the current packet being parsed
 
 	/* We use a separate stream to encode MP_REACH_NLRI for efficient
-	 * NLRI packing. peer->work stores all the other attributes. The
+	 * NLRI packing. peer->obuf_work stores all the other attributes. The
 	 * actual packet is then constructed by concatenating the two.
 	 */
 	struct stream *scratch;
@@ -799,7 +803,9 @@ struct peer {
 
 	/* Threads. */
 	struct thread *t_read;
+	struct thread *t_write;
 	struct thread *t_start;
+	struct thread *t_connect_check;
 	struct thread *t_connect;
 	struct thread *t_holdtime;
 	struct thread *t_routeadv;
@@ -807,11 +813,13 @@ struct peer {
 	struct thread *t_gr_restart;
 	struct thread *t_gr_stale;
 	struct thread *t_generate_updgrp_packets;
+	struct thread *t_process_packet;
 
 	/* Thread flags. */
 	u_int16_t thread_flags;
-#define PEER_THREAD_WRITES_ON         (1 << 0)
-#define PEER_THREAD_KEEPALIVES_ON     (1 << 1)
+#define PEER_THREAD_WRITES_ON         (1 << 1)
+#define PEER_THREAD_READS_ON          (1 << 2)
+#define PEER_THREAD_KEEPALIVES_ON     (1 << 3)
 	/* workqueues */
 	struct work_queue *clear_node_queue;
 
@@ -852,9 +860,6 @@ struct peer {
 
 	/* Notify data. */
 	struct bgp_notify notify;
-
-	/* Whole packet size to be read. */
-	unsigned long packet_size;
 
 	/* Filter structure. */
 	struct bgp_filter filter[AFI_MAX][SAFI_MAX];
@@ -1149,7 +1154,7 @@ enum bgp_clear_type {
 };
 
 /* Macros. */
-#define BGP_INPUT(P)         ((P)->ibuf)
+#define BGP_INPUT(P)         ((P)->curr)
 #define BGP_INPUT_PNT(P)     (STREAM_PNT(BGP_INPUT(P)))
 #define BGP_IS_VALID_STATE_FOR_NOTIF(S)                                        \
 	(((S) == OpenSent) || ((S) == OpenConfirm) || ((S) == Established))

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1260,7 +1260,7 @@ extern int bgp_config_write(struct vty *);
 extern void bgp_master_init(struct thread_master *master);
 
 extern void bgp_init(void);
-extern void bgp_pthreads_init(void);
+extern void bgp_pthreads_run(void);
 extern void bgp_pthreads_finish(void);
 extern void bgp_route_map_init(void);
 extern void bgp_session_reset(struct peer *);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -1304,18 +1304,29 @@ static int rfapi_open_inner(struct rfapi_descriptor *rfd, struct bgp *bgp,
 	rfd->peer = peer_new(bgp);
 	rfd->peer->status = Established; /* keep bgp core happy */
 	bgp_sync_delete(rfd->peer);      /* don't need these */
-	if (rfd->peer->ibuf) {
-		stream_free(rfd->peer->ibuf); /* don't need it */
+
+	// since this peer is not on the I/O thread, this lock is not strictly
+	// necessary, but serves as a reminder to those who may meddle...
+	pthread_mutex_lock(&rfd->peer->io_mtx);
+	{
+		// we don't need any I/O related facilities
+		if (rfd->peer->ibuf)
+			stream_fifo_free(rfd->peer->ibuf);
+		if (rfd->peer->obuf)
+			stream_fifo_free(rfd->peer->obuf);
+
+		if (rfd->peer->ibuf_work)
+			stream_free(rfd->peer->ibuf_work);
+		if (rfd->peer->obuf_work)
+			stream_free(rfd->peer->obuf_work);
+
 		rfd->peer->ibuf = NULL;
-	}
-	if (rfd->peer->obuf) {
-		stream_fifo_free(rfd->peer->obuf); /* don't need it */
 		rfd->peer->obuf = NULL;
+		rfd->peer->obuf_work = NULL;
+		rfd->peer->ibuf_work = NULL;
 	}
-	if (rfd->peer->work) {
-		stream_free(rfd->peer->work); /* don't need it */
-		rfd->peer->work = NULL;
-	}
+	pthread_mutex_unlock(&rfd->peer->io_mtx);
+
 	{ /* base code assumes have valid host pointer */
 		char buf[BUFSIZ];
 		buf[0] = 0;

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -1305,8 +1305,10 @@ static int rfapi_open_inner(struct rfapi_descriptor *rfd, struct bgp *bgp,
 	rfd->peer->status = Established; /* keep bgp core happy */
 	bgp_sync_delete(rfd->peer);      /* don't need these */
 
-	// since this peer is not on the I/O thread, this lock is not strictly
-	// necessary, but serves as a reminder to those who may meddle...
+	/*
+	 * since this peer is not on the I/O thread, this lock is not strictly
+	 * necessary, but serves as a reminder to those who may meddle...
+	 */
 	pthread_mutex_lock(&rfd->peer->io_mtx);
 	{
 		// we don't need any I/O related facilities

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -184,10 +184,11 @@ static void vnc_redistribute_add(struct prefix *p, u_int32_t metric,
 				Established; /* keep bgp core happy */
 			bgp_sync_delete(vncHD1VR.peer); /* don't need these */
 
-			// since this peer is not on the I/O thread, this lock
-			// is not strictly
-			// necessary, but serves as a reminder to those who may
-			// meddle...
+			/*
+			 * since this peer is not on the I/O thread, this lock
+			 * is not strictly necessary, but serves as a reminder
+			 * to those who may meddle...
+			 */
 			pthread_mutex_lock(&vncHD1VR.peer->io_mtx);
 			{
 				// we don't need any I/O related facilities

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -36,7 +36,6 @@
 DEFINE_MTYPE_STATIC(LIB, THREAD, "Thread")
 DEFINE_MTYPE_STATIC(LIB, THREAD_MASTER, "Thread master")
 DEFINE_MTYPE_STATIC(LIB, THREAD_STATS, "Thread stats")
-DEFINE_MTYPE(LIB, PTHREAD, "POSIX Thread")
 
 #if defined(__APPLE__)
 #include <mach/mach.h>

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -36,6 +36,7 @@
 DEFINE_MTYPE_STATIC(LIB, THREAD, "Thread")
 DEFINE_MTYPE_STATIC(LIB, THREAD_MASTER, "Thread master")
 DEFINE_MTYPE_STATIC(LIB, THREAD_STATS, "Thread stats")
+DEFINE_MTYPE(LIB, PTHREAD, "POSIX Thread")
 
 #if defined(__APPLE__)
 #include <mach/mach.h>

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -26,6 +26,9 @@
 #include <poll.h>
 #include "monotime.h"
 
+#include "memory.h"
+DECLARE_MTYPE(PTHREAD)
+
 struct rusage_t {
 	struct rusage cpu;
 	struct timeval real;

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -26,9 +26,6 @@
 #include <poll.h>
 #include "monotime.h"
 
-#include "memory.h"
-DECLARE_MTYPE(PTHREAD)
-
 struct rusage_t {
 	struct rusage cpu;
 	struct timeval real;

--- a/ospfd/ospf_vty_clippy.c
+++ b/ospfd/ospf_vty_clippy.c
@@ -1,0 +1,92 @@
+/* ospf_router_id => "ospf router-id A.B.C.D" */
+DEFUN_CMD_FUNC_DECL(ospf_router_id)
+#define funcdecl_ospf_router_id static int ospf_router_id_magic(\
+	const struct cmd_element *self __attribute__ ((unused)),\
+	struct vty *vty __attribute__ ((unused)),\
+	int argc __attribute__ ((unused)),\
+	struct cmd_token *argv[] __attribute__ ((unused)),\
+	struct in_addr router_id,\
+	const char * router_id_str __attribute__ ((unused)))
+funcdecl_ospf_router_id;
+DEFUN_CMD_FUNC_TEXT(ospf_router_id)
+{
+#if 1 /* anything to parse? */
+	int _i;
+#if 1 /* anything that can fail? */
+	unsigned _fail = 0, _failcnt = 0;
+#endif
+	struct in_addr router_id = { INADDR_ANY };
+	const char *router_id_str = NULL;
+
+	for (_i = 0; _i < argc; _i++) {
+		if (!argv[_i]->varname)
+			continue;
+#if 1 /* anything that can fail? */
+		_fail = 0;
+#endif
+
+		if (!strcmp(argv[_i]->varname, "router_id")) {
+			router_id_str = argv[_i]->arg;
+			_fail = !inet_aton(argv[_i]->arg, &router_id);
+		}
+#if 1 /* anything that can fail? */
+		if (_fail)
+			vty_out (vty, "%% invalid input for %s: %s\n",
+				   argv[_i]->varname, argv[_i]->arg);
+		_failcnt += _fail;
+#endif
+	}
+#if 1 /* anything that can fail? */
+	if (_failcnt)
+		return CMD_WARNING;
+#endif
+#endif
+	return ospf_router_id_magic(self, vty, argc, argv, router_id, router_id_str);
+}
+
+/* no_ospf_router_id => "no ospf router-id [A.B.C.D]" */
+DEFUN_CMD_FUNC_DECL(no_ospf_router_id)
+#define funcdecl_no_ospf_router_id static int no_ospf_router_id_magic(\
+	const struct cmd_element *self __attribute__ ((unused)),\
+	struct vty *vty __attribute__ ((unused)),\
+	int argc __attribute__ ((unused)),\
+	struct cmd_token *argv[] __attribute__ ((unused)),\
+	struct in_addr router_id,\
+	const char * router_id_str __attribute__ ((unused)))
+funcdecl_no_ospf_router_id;
+DEFUN_CMD_FUNC_TEXT(no_ospf_router_id)
+{
+#if 1 /* anything to parse? */
+	int _i;
+#if 1 /* anything that can fail? */
+	unsigned _fail = 0, _failcnt = 0;
+#endif
+	struct in_addr router_id = { INADDR_ANY };
+	const char *router_id_str = NULL;
+
+	for (_i = 0; _i < argc; _i++) {
+		if (!argv[_i]->varname)
+			continue;
+#if 1 /* anything that can fail? */
+		_fail = 0;
+#endif
+
+		if (!strcmp(argv[_i]->varname, "router_id")) {
+			router_id_str = argv[_i]->arg;
+			_fail = !inet_aton(argv[_i]->arg, &router_id);
+		}
+#if 1 /* anything that can fail? */
+		if (_fail)
+			vty_out (vty, "%% invalid input for %s: %s\n",
+				   argv[_i]->varname, argv[_i]->arg);
+		_failcnt += _fail;
+#endif
+	}
+#if 1 /* anything that can fail? */
+	if (_failcnt)
+		return CMD_WARNING;
+#endif
+#endif
+	return no_ospf_router_id_magic(self, vty, argc, argv, router_id, router_id_str);
+}
+

--- a/tests/bgpd/test_aspath.c
+++ b/tests/bgpd/test_aspath.c
@@ -1274,20 +1274,20 @@ static int handle_attr_test(struct aspath_tests *t)
 
 	asp = make_aspath(t->segment->asdata, t->segment->len, 0);
 
-	peer.ibuf = stream_new(BGP_MAX_PACKET_SIZE);
+	peer.curr = stream_new(BGP_MAX_PACKET_SIZE);
 	peer.obuf = stream_fifo_new();
 	peer.bgp = &bgp;
 	peer.host = (char *)"none";
 	peer.fd = -1;
 	peer.cap = t->cap;
 
-	stream_write(peer.ibuf, t->attrheader, t->len);
-	datalen = aspath_put(peer.ibuf, asp, t->as4 == AS4_DATA);
+	stream_write(peer.curr, t->attrheader, t->len);
+	datalen = aspath_put(peer.curr, asp, t->as4 == AS4_DATA);
 	if (t->old_segment) {
 		char dummyaspath[] = {BGP_ATTR_FLAG_TRANS, BGP_ATTR_AS_PATH,
 				      t->old_segment->len};
-		stream_write(peer.ibuf, dummyaspath, sizeof(dummyaspath));
-		stream_write(peer.ibuf, t->old_segment->asdata,
+		stream_write(peer.curr, dummyaspath, sizeof(dummyaspath));
+		stream_write(peer.curr, t->old_segment->asdata,
 			     t->old_segment->len);
 		datalen += sizeof(dummyaspath) + t->old_segment->len;
 	}
@@ -1342,7 +1342,6 @@ int main(void)
 	master = bm->master;
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 	bgp_attr_init();
-	peer_writes_init();
 
 	while (test_segments[i].name) {
 		printf("test %u\n", i);

--- a/tests/bgpd/test_aspath.c
+++ b/tests/bgpd/test_aspath.c
@@ -29,6 +29,7 @@
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_aspath.h"
 #include "bgpd/bgp_attr.h"
+#include "bgpd/bgp_packet.h"
 
 #define VT100_RESET "\x1b[0m"
 #define VT100_RED "\x1b[31m"
@@ -1341,6 +1342,7 @@ int main(void)
 	master = bm->master;
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 	bgp_attr_init();
+	peer_writes_init();
 
 	while (test_segments[i].name) {
 		printf("test %u\n", i);

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -866,11 +866,11 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 		failed++;
 	}
 
-	/* Some of the functions used return BGP_Stop on error and some return
-	 * -1. If
-	 * we have -1, keep it; if we have BGP_Stop, transform it to the correct
-	 * pass/fail code */
-
+	/*
+	 * Some of the functions used return BGP_Stop on error and some return
+	 * -1. If we have -1, keep it; if we have BGP_Stop, transform it to the
+	 * correct pass/fail code
+	 */
 	if (ret != -1)
 		ret = (ret == BGP_Stop) ? -1 : 0;
 

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -903,6 +903,7 @@ int main(void)
 	bgp_master_init(master);
 	vrf_init(NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
+	peer_writes_init();
 
 	if (fileno(stdout) >= 0)
 		tty = isatty(fileno(stdout));

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -796,14 +796,15 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 	int oldfailed = failed;
 	int len = t->len;
 #define RANDOM_FUZZ 35
-	stream_reset(peer->ibuf);
-	stream_put(peer->ibuf, NULL, RANDOM_FUZZ);
-	stream_set_getp(peer->ibuf, RANDOM_FUZZ);
+
+	stream_reset(peer->curr);
+	stream_put(peer->curr, NULL, RANDOM_FUZZ);
+	stream_set_getp(peer->curr, RANDOM_FUZZ);
 
 	switch (type) {
 	case CAPABILITY:
-		stream_putc(peer->ibuf, BGP_OPEN_OPT_CAP);
-		stream_putc(peer->ibuf, t->len);
+		stream_putc(peer->curr, BGP_OPEN_OPT_CAP);
+		stream_putc(peer->curr, t->len);
 		break;
 	case DYNCAP:
 		/*        for (i = 0; i < BGP_MARKER_SIZE; i++)
@@ -812,7 +813,7 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 			stream_putc (s, BGP_MSG_CAPABILITY);*/
 		break;
 	}
-	stream_write(peer->ibuf, t->data, t->len);
+	stream_write(peer->curr, t->data, t->len);
 
 	printf("%s: %s\n", t->name, t->desc);
 
@@ -825,7 +826,7 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 		as4 = peek_for_as4_capability(peer, len);
 		printf("peek_for_as4: as4 is %u\n", as4);
 		/* and it should leave getp as it found it */
-		assert(stream_get_getp(peer->ibuf) == RANDOM_FUZZ);
+		assert(stream_get_getp(peer->curr) == RANDOM_FUZZ);
 
 		ret = bgp_open_option_parse(peer, len, &capability);
 		break;
@@ -837,7 +838,7 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 		exit(1);
 	}
 
-	if (!ret && t->validate_afi) {
+	if (ret != BGP_Stop && t->validate_afi) {
 		afi_t afi;
 		safi_t safi;
 
@@ -865,10 +866,20 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 		failed++;
 	}
 
+	/* Some of the functions used return BGP_Stop on error and some return
+	 * -1. If
+	 * we have -1, keep it; if we have BGP_Stop, transform it to the correct
+	 * pass/fail code */
+
+	if (ret != -1)
+		ret = (ret == BGP_Stop) ? -1 : 0;
+
 	printf("parsed?: %s\n", ret ? "no" : "yes");
 
-	if (ret != t->parses)
+	if (ret != t->parses) {
+		printf("t->parses: %d\nret: %d\n", t->parses, ret);
 		failed++;
+	}
 
 	if (tty)
 		printf("%s",
@@ -903,7 +914,6 @@ int main(void)
 	bgp_master_init(master);
 	vrf_init(NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
-	peer_writes_init();
 
 	if (fileno(stdout) >= 0)
 		tty = isatty(fileno(stdout));
@@ -919,6 +929,8 @@ int main(void)
 			peer->afc[i][j] = 1;
 			peer->afc_adv[i][j] = 1;
 		}
+
+	peer->curr = stream_new(BGP_MAX_PACKET_SIZE);
 
 	i = 0;
 	while (mp_segments[i].name)

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -36,6 +36,7 @@
 #include "bgpd/bgp_packet.h"
 #include "bgpd/bgp_mplsvpn.h"
 #include "bgpd/bgp_nexthop.h"
+#include "bgpd/bgp_vty.h"
 
 #define VT100_RESET "\x1b[0m"
 #define VT100_RED "\x1b[31m"
@@ -1045,11 +1046,11 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 		.startp = BGP_INPUT_PNT(peer),
 	};
 #define RANDOM_FUZZ 35
-	stream_reset(peer->ibuf);
-	stream_put(peer->ibuf, NULL, RANDOM_FUZZ);
-	stream_set_getp(peer->ibuf, RANDOM_FUZZ);
+	stream_reset(peer->curr);
+	stream_put(peer->curr, NULL, RANDOM_FUZZ);
+	stream_set_getp(peer->curr, RANDOM_FUZZ);
 
-	stream_write(peer->ibuf, t->data, t->len);
+	stream_write(peer->curr, t->data, t->len);
 
 	printf("%s: %s\n", t->name, t->desc);
 
@@ -1097,7 +1098,9 @@ int main(void)
 	term_bgp_debug_as4 = -1UL;
 
 	qobj_init();
-	master = thread_master_create(NULL);
+	cmd_init(0);
+	bgp_vty_init();
+	master = thread_master_create();
 	bgp_master_init(master);
 	vrf_init(NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
@@ -1112,6 +1115,7 @@ int main(void)
 	peer = peer_create_accept(bgp);
 	peer->host = (char *)"foo";
 	peer->status = Established;
+	peer->curr = stream_new(BGP_MAX_PACKET_SIZE);
 
 	for (i = AFI_IP; i < AFI_MAX; i++)
 		for (j = SAFI_UNICAST; j < SAFI_MAX; j++) {

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -1100,7 +1100,7 @@ int main(void)
 	qobj_init();
 	cmd_init(0);
 	bgp_vty_init();
-	master = thread_master_create();
+	master = thread_master_create("test mp attr");
 	bgp_master_init(master);
 	vrf_init(NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);

--- a/tests/bgpd/test_packet.c
+++ b/tests/bgpd/test_packet.c
@@ -80,6 +80,6 @@ int main(int argc, char *argv[])
         peer->fd = open(argv[1], O_RDONLY|O_NONBLOCK);
 	t.arg = peer;
 	peer->t_read = &t;
- 
-	printf("bgp_read_packet returns: %d\n", bgp_read(&t));
+
+	// printf("bgp_read_packet returns: %d\n", bgp_read(&t));
 }


### PR DESCRIPTION
This patch implements multithreading for BGP keepalive generation and network I/O.

This is not a performance oriented patch set, although it does open the door for performance improvements in the future. The intent here is to greatly improve session stability and avoid session flaps when running at large scale. Without multithreading, long-running tasks such as UI commands or large routing table updates could cause sessions to flap since they blocked all network I/O for the duration of execution. This patch solves that issue; there should be no problems running the minimum allowable hold timer of 3 seconds under "reasonably" large scale. I specifically tested this up to 800 peers, although it should theoretically scale well beyond that.

--------------------

Keepalives 
------------ 
Implementation is in `bgp_keepalives.[ch]`. This is essentially a hash table with a mutex that holds peers who need keepalives and the time until they need one. To turn on keepalives for a peer call `bgp_keepalives_on(peer)`, which wakes the thread up, inserts the peer into the table, recalculates the smallest time until any one peer needs a KA and sleeps for that long. When the time has elapsed it wakes up, generates keepalives for as many peers as it can, calculates the new sleep time in the same pass, and goes back to sleep. Generating a keepalive is just making the packet and pushing it onto `peer->obuf`, after that the I/O thread handles the rest. 

I/O
---
Implementation is in `bgp_io.[ch]`. Thread runs its own event loop and communicates with the main thread by scheduling and receiving events. When a packet is pushed onto a peer's output buffer, `bgp_writes_on(peer)` is called from the owning  which pushes an event onto the I/O pthread's event queue, causing the peer socket to be added to the list of `poll()`'d file descriptors. At some point in the future the socket will become ready for writing (or the connection will die) at which point the output buffer is serviced. As many packets as possible are written either until the write quanta is reached or until a socket write becomes blocking. In either case the peer socket is rescheduled for writing until all packets on the output buffer have been written. Upon error a `BGP_Stop` event is generated on the main thread, write events are cancelled and session teardown proceeds as per usual. If the peer exhausts all the packets on its output buffer a new write event is not scheduled, `bgp_writes_on(peer)` must be called again to reschedule it. 

Reads operate differently, when a caller wants to receive packets from a peer's socket, they register the peer with `bgp_reads_on(peer)`. When the peer's socket becomes ready for reading, as much data as possible is read off the socket into a raw input buffer. It is then broken up into individual BGP messages, whose headers are validated before being pushed onto the packet input queue. When new data is available on this queue an event is generated on the main pthread that schedules `bgp_process_packets()`, which handles processing the actual content of the messages, updating any internal state, generating FSM events etc. Reads automatically reschedule forever until `bgp_reads_off()` is called, or an error is encountered. If an error is encountered rescheduling stops and a `BGP_Stop` event is generated on the main pthread. 

Some changes to the structure of packet processing routines have been made to clean up their return codes, improve documentation and improve organization.