### PR TITLE
Recursive blackhole resolution

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -357,6 +357,10 @@ static void nexthop_set_resolved(afi_t afi, struct nexthop *newhop,
 		resolved_hop->ifindex = newhop->ifindex;
 	}
 
+	if (newhop->type == NEXTHOP_TYPE_BLACKHOLE) {
+		resolved_hop->type = NEXTHOP_TYPE_BLACKHOLE;
+		resolved_hop->bh_type = nexthop->bh_type;
+	}
 	resolved_hop->rparent = nexthop;
 	nexthop_add(&nexthop->resolved, resolved_hop);
 }
@@ -484,8 +488,6 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 		} else if (CHECK_FLAG(re->flags, ZEBRA_FLAG_INTERNAL)) {
 			resolved = 0;
 			for (ALL_NEXTHOPS(match->nexthop, newhop)) {
-				if (newhop->type == NEXTHOP_TYPE_BLACKHOLE)
-					continue;
 				if (!CHECK_FLAG(newhop->flags,
 						NEXTHOP_FLAG_FIB))
 					continue;
@@ -509,8 +511,6 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 		} else if (re->type == ZEBRA_ROUTE_STATIC) {
 			resolved = 0;
 			for (ALL_NEXTHOPS(match->nexthop, newhop)) {
-				if (newhop->type == NEXTHOP_TYPE_BLACKHOLE)
-					continue;
 				if (!CHECK_FLAG(newhop->flags,
 						NEXTHOP_FLAG_FIB))
 					continue;


### PR DESCRIPTION
This changeset allows zebra to consider blackhole nexthops for recursive route resolution.  Suppose you have this config: 
``` address-family ipv4 unicast
  network 10.0.0.7/32
  neighbor 10.7.8.2 soft-reconfiguration inbound
  neighbor 10.7.8.2 route-map BOGONS in
 exit-address-family
!
ip route 192.0.2.1/32 Null0
!
ip community-list 10 permit 0:10
!
route-map BOGONS deny 5
 match ip address prefix-list IPV4-MARTIAN
!
route-map BOGONS permit 10
 description Filter bogons learned from cymru.com bogon route-servers
 match community 10
 set ip next-hop 192.0.2.1```

So the desired output is to blackhole some routes from a bgp peer( This peer in particular is telling us what routes to blackhole as what it sends us ).