### PR TITLE
doc: remove --enable-tcp-zebra from the build instructions (3.0)

### DIFF
--- a/doc/Building_FRR_on_CentOS6.md
+++ b/doc/Building_FRR_on_CentOS6.md
@@ -104,7 +104,6 @@ an example.)
         --enable-rtadv \
         --disable-exampledir \
         --enable-watchfrr \
-        --enable-tcp-zebra \
         --disable-ldpd \
         --enable-fpm \
         --enable-nhrpd \

--- a/doc/Building_FRR_on_CentOS7.md
+++ b/doc/Building_FRR_on_CentOS7.md
@@ -62,7 +62,6 @@ an example.)
         --enable-rtadv \
         --disable-exampledir \
         --enable-watchfrr \
-        --enable-tcp-zebra \
         --disable-ldpd \
         --enable-fpm \
         --enable-nhrpd \

--- a/doc/Building_FRR_on_Debian8.md
+++ b/doc/Building_FRR_on_Debian8.md
@@ -61,7 +61,6 @@ an example.)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --enable-ldpd \
         --with-pkg-git-version \

--- a/doc/Building_FRR_on_Fedora24.md
+++ b/doc/Building_FRR_on_Fedora24.md
@@ -55,7 +55,6 @@ an example.)
         --enable-rtadv \
         --disable-exampledir \
         --enable-watchfrr \
-        --enable-tcp-zebra \
         --enable-ldpd \
         --enable-fpm \
         --enable-nhrpd \

--- a/doc/Building_FRR_on_FreeBSD10.md
+++ b/doc/Building_FRR_on_FreeBSD10.md
@@ -62,7 +62,6 @@ an example)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --with-pkg-git-version \
         --with-pkg-extra-version=-MyOwnFRRVersion   

--- a/doc/Building_FRR_on_FreeBSD11.md
+++ b/doc/Building_FRR_on_FreeBSD11.md
@@ -62,7 +62,6 @@ an example)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --with-pkg-git-version \
         --with-pkg-extra-version=-MyOwnFRRVersion   

--- a/doc/Building_FRR_on_FreeBSD9.md
+++ b/doc/Building_FRR_on_FreeBSD9.md
@@ -70,7 +70,6 @@ an example)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --with-pkg-git-version \
         --with-pkg-extra-version=-MyOwnFRRVersion   

--- a/doc/Building_FRR_on_NetBSD6.md
+++ b/doc/Building_FRR_on_NetBSD6.md
@@ -66,7 +66,6 @@ an example)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --with-pkg-git-version \
         --with-pkg-extra-version=-MyOwnFRRVersion   

--- a/doc/Building_FRR_on_NetBSD7.md
+++ b/doc/Building_FRR_on_NetBSD7.md
@@ -60,7 +60,6 @@ an example)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --with-pkg-git-version \
         --with-pkg-extra-version=-MyOwnFRRVersion   

--- a/doc/Building_FRR_on_OmniOS.md
+++ b/doc/Building_FRR_on_OmniOS.md
@@ -111,7 +111,6 @@ an example)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --with-pkg-git-version \
         --with-pkg-extra-version=-MyOwnFRRVersion   

--- a/doc/Building_FRR_on_OpenBSD6.md
+++ b/doc/Building_FRR_on_OpenBSD6.md
@@ -55,7 +55,6 @@ an example)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --with-pkg-git-version \
         --with-pkg-extra-version=-MyOwnFRRVersion   

--- a/doc/Building_FRR_on_Ubuntu1204.md
+++ b/doc/Building_FRR_on_Ubuntu1204.md
@@ -94,7 +94,6 @@ an example.)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --with-pkg-git-version \
         --with-pkg-extra-version=-MyOwnFRRVersion   

--- a/doc/Building_FRR_on_Ubuntu1404.md
+++ b/doc/Building_FRR_on_Ubuntu1404.md
@@ -54,7 +54,6 @@ an example.)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --enable-ldpd \
         --with-pkg-git-version \

--- a/doc/Building_FRR_on_Ubuntu1604.md
+++ b/doc/Building_FRR_on_Ubuntu1604.md
@@ -55,7 +55,6 @@ an example.)
         --enable-configfile-mask=0640 \
         --enable-logfile-mask=0640 \
         --enable-rtadv \
-        --enable-tcp-zebra \
         --enable-fpm \
         --enable-systemd=yes \
         --with-pkg-git-version \


### PR DESCRIPTION
This parameter was removed by commit 01c9f29.

Fixes #1146.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>