### PR TITLE
bgpd: fix show ip bgp vrf <vrf> nexthop

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -580,7 +580,11 @@ DEFUN (show_ip_bgp_nexthop,
        "Show detailed information\n")
 {
 	int idx = 0;
-	char *vrf = argv_find(argv, argc, "WORD", &idx) ? argv[idx]->arg : NULL;
+	char *vrf = NULL;
+
+	if (argv_find(argv, argc, "view", &idx)
+	    || argv_find(argv, argc, "vrf", &idx))
+		vrf = argv[++idx]->arg;
 	int detail = argv_find(argv, argc, "detail", &idx) ? 1 : 0;
 	return show_ip_bgp_nexthop_table(vty, vrf, detail);
 }


### PR DESCRIPTION
Problem with not finding the correct bgp instance when doing the command
"show ip bgp vrf <vrf> nexthop" resolved by setting up the arg values
correctly.  Manual testing fine.  bgp-smoke had no new failures.

Ticket: CM-17454
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Reviewed-by: CCR-6664