### PR TITLE
*: make all daemons call frr_fini() on exit

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -335,6 +335,7 @@ babel_exit_properly(void)
     babel_save_state_file();
     debugf(BABEL_DEBUG_COMMON, "Remove pid file.");
     debugf(BABEL_DEBUG_COMMON, "Done.");
+    frr_fini();
 
     exit(0);
 }

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -42,6 +42,7 @@
 #include "plist.h"
 #include "sockopt.h"
 #include "keychain.h"
+#include "libfrr.h"
 
 #include "eigrpd/eigrp_structs.h"
 #include "eigrpd/eigrpd.h"
@@ -241,12 +242,10 @@ void eigrp_terminate(void)
 
 	SET_FLAG(eigrp_om->options, EIGRP_MASTER_SHUTDOWN);
 
-	/* exit immediately if EIGRP not actually running */
-	if (listcount(eigrp_om->eigrp) == 0)
-		exit(0);
-
 	for (ALL_LIST_ELEMENTS(eigrp_om->eigrp, node, nnode, eigrp))
 		eigrp_finish(eigrp);
+
+	frr_fini();
 }
 
 void eigrp_finish(struct eigrp *eigrp)

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -35,6 +35,7 @@
 #include "linklist.h"
 #include "nexthop.h"
 #include "vrf.h"
+#include "libfrr.h"
 
 #include "isisd/dict.h"
 #include "isisd/isis_constants.h"
@@ -427,4 +428,5 @@ void isis_zebra_stop(void)
 {
 	zclient_stop(zclient);
 	zclient_free(zclient);
+	frr_fini();
 }

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -35,6 +35,7 @@
 #include "plist.h"
 #include "sockopt.h"
 #include "bfd.h"
+#include "libfrr.h"
 #include "defaults.h"
 
 #include "ospfd/ospfd.h"
@@ -489,6 +490,8 @@ void ospf_terminate(void)
 	 */
 	zclient_stop(zclient);
 	zclient_free(zclient);
+
+	frr_fini();
 }
 
 void ospf_finish(struct ospf *ospf)

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -139,4 +139,6 @@ void pim_terminate()
 		zclient_stop(zclient);
 		zclient_free(zclient);
 	}
+
+	frr_fini();
 }

--- a/ripd/rip_main.c
+++ b/ripd/rip_main.c
@@ -89,6 +89,7 @@ static void sigint(void)
 		rip_clean();
 
 	rip_zclient_stop();
+	frr_fini();
 
 	exit(0);
 }

--- a/ripngd/ripng_main.c
+++ b/ripngd/ripng_main.c
@@ -92,6 +92,7 @@ static void sigint(void)
 		ripng_clean();
 
 	ripng_zebra_stop();
+	frr_fini();
 	exit(0);
 }
 


### PR DESCRIPTION
This allow us to find real leaks more easily with tools like valgrind.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>