### PR TITLE
bgpd: Fix warning introduced by PR #1133

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -84,6 +84,7 @@ static void display_import_rt(struct vty *vty, struct irt_node *irt,
 	if (sub_type != ECOMMUNITY_ROUTE_TARGET)
 		return;
 
+	memset(&eas, 0, sizeof(eas));
 	switch (type) {
 	case ECOMMUNITY_ENCODE_AS:
 		eas.as = (*pnt++ << 8);


### PR DESCRIPTION
I am merely fixing the compiler warning.  I do not
understand what the as value should be for output
to the end user or where it should be retrieved
from.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>