### PR TITLE
ospf6d: Fix crash in prefix-list handling

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -642,6 +642,9 @@ void ospf6_area_plist_update(struct prefix_list *plist, int add)
 	struct listnode *n;
 	const char *name = prefix_list_name(plist);
 
+	if (!ospf6)
+		return;
+
 	for (ALL_LIST_ELEMENTS_RO(ospf6->area_list, n, oa)) {
 		if (PREFIX_NAME_IN(oa) && !strcmp(PREFIX_NAME_IN(oa), name))
 			PREFIX_LIST_IN(oa) = add ? plist : NULL;


### PR DESCRIPTION
Commit 427f8e61bb711b51 introduced prefix list callbacks
to handle when a prefix list is changed.  Unfortunately
if you have ospf6 running but not configured it crashes.

Modify ospf6d to not crash when we are not properly configured
yet for prefix-lists handling.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>