### PR TITLE
lib, doc: increase maximum cli tokens

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -75,6 +75,9 @@ Some general notes:
   configuration items should be defined in separate commands. Clarity is
   preferred over LOC (within reason).
 
+* The maximum number of space-separated tokens that can be entered is presently
+  limited to 256. Please keep this limit in mind when implementing new CLI.
+
 Variable Names
 --------------
 The parser tries to fill the "varname" field on each token.  This can happen

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -28,7 +28,7 @@
 
 DEFINE_MTYPE_STATIC(LIB, CMD_MATCHSTACK, "Command Match Stack")
 
-#define MAXDEPTH 64
+#define MAXDEPTH 256
 
 #ifdef TRACE_MATCHER
 #define TM 1


### PR DESCRIPTION
When matching user input against a CLI graph, we keep a stack of tokens
matched. Stack size was limited to 64, making the effective number of
tokens that could be entered on a line 64. This is too limiting in some
circumstances, so bump it to 256 (and document it).

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>