### PR TITLE
Refactor the 'show ip route' commands using DEFPY

### DIFF
--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -51,6 +51,7 @@ enum { IFLA_VRF_UNSPEC, IFLA_VRF_TABLE, __IFLA_VRF_MAX };
  */
 #define VRF_CMD_HELP_STR    "Specify the VRF\nThe VRF name\n"
 #define VRF_ALL_CMD_HELP_STR    "Specify the VRF\nAll VRFs\n"
+#define VRF_FULL_CMD_HELP_STR   "Specify the VRF\nThe VRF name\nAll VRFs\n"
 
 /*
  * Pass some OS specific data up through

--- a/python/clidef.py
+++ b/python/clidef.py
@@ -188,8 +188,6 @@ def process_file(fn, ofd, dumpfd, all_defun):
     for entry in filedata['data']:
         if entry['type'] == 'DEFPY' or (all_defun and entry['type'].startswith('DEFUN')):
             cmddef = entry['args'][2]
-            for i in cmddef:
-                assert i.startswith('"') and i.endswith('"')
             cmddef = ''.join([i[1:-1] for i in cmddef])
 
             graph = clippy.Graph(cmddef)

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1202,19 +1202,21 @@ DEFPY (show_route,
        "show\
          <\
 	  ip$ipv4 <fib$fib|route> [vrf <NAME$vrf_name|all$vrf_all>]\
-	   [\
+	   [{\
 	    tag (1-4294967295)\
 	    |A.B.C.D/M$prefix longer-prefixes\
 	    |supernets-only$supernets_only\
-	    |" FRR_IP_REDIST_STR_ZEBRA "$type_str\
+	   }]\
+	   [<\
+	    " FRR_IP_REDIST_STR_ZEBRA "$type_str\
 	    |ospf$type_str (1-65535)$ospf_instance_id\
-	   ]\
+	   >]\
           |ipv6$ipv6 <fib$fib|route> [vrf <NAME$vrf_name|all$vrf_all>]\
-	   [\
+	   [{\
 	    tag (1-4294967295)\
 	    |X:X::X:X/M$prefix longer-prefixes\
-	    |" FRR_IP6_REDIST_STR_ZEBRA "$type_str\
-	   ]\
+	   }]\
+	   [" FRR_IP6_REDIST_STR_ZEBRA "$type_str]\
 	 >\
         [json$json]",
        SHOW_STR

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1360,6 +1360,8 @@ DEFUN (show_ip_route_prefix,
 
 	rn = route_node_match(table, (struct prefix *)&p);
 	if (!rn || rn->p.prefixlen != p.prefixlen) {
+		if (rn)
+			route_unlock_node(rn);
 		vty_out(vty, "%% Network not in table\n");
 		return CMD_WARNING;
 	}
@@ -1947,6 +1949,8 @@ DEFUN (show_ipv6_route_prefix,
 
 	rn = route_node_match(table, (struct prefix *)&p);
 	if (!rn || rn->p.prefixlen != p.prefixlen) {
+		if (rn)
+			route_unlock_node(rn);
 		vty_out(vty, "%% Network not in table\n");
 		return CMD_WARNING;
 	}


### PR DESCRIPTION
With this patchset we go from 18 DEFUNs to 3 DEFPYs (regular/tabular output, detailed output and summary output). The main goal is to reduce code duplication and improve maintainability.

Please don't merge this yet as there's an issue with clippy that needs to be addressed first (I had to remove one assert in clidef.py and I'm not sure if that's ok, I'll talk to David about it).