### PR TITLE
isisd: generate unique circuit ids

### DIFF
--- a/isisd/isis_csm.c
+++ b/isisd/isis_csm.c
@@ -87,6 +87,13 @@ isis_csm_state_change(int event, struct isis_circuit *circuit, void *arg)
 		case IF_UP_FROM_Z:
 			circuit = isis_circuit_new();
 			isis_circuit_if_add(circuit, (struct interface *)arg);
+			if (!circuit->circuit_id) {
+				isis_circuit_if_del(circuit,
+						    (struct interface *)arg);
+				isis_circuit_del(circuit);
+				circuit = NULL;
+				break;
+			}
 			listnode_add(isis->init_circ_list, circuit);
 			circuit->state = C_STATE_INIT;
 			break;
@@ -137,6 +144,8 @@ isis_csm_state_change(int event, struct isis_circuit *circuit, void *arg)
 			break;
 		case IF_UP_FROM_Z:
 			isis_circuit_if_add(circuit, (struct interface *)arg);
+			if (!circuit->circuit_id)
+				break;
 			if (isis_circuit_up(circuit) != ISIS_OK) {
 				zlog_err(
 					"Could not bring up %s because of invalid config.",

--- a/isisd/isis_flags.h
+++ b/isisd/isis_flags.h
@@ -41,17 +41,22 @@ long int flags_get_index(struct flags *flags);
 void flags_free_index(struct flags *flags, long int index);
 int flags_any_set(u_int32_t *flags);
 
-#define ISIS_SET_FLAG(F, C)                                                    \
-	{                                                                      \
-		F[C->idx >> 5] |= (1 << (C->idx & 0x1F));                      \
+#define _ISIS_SET_FLAG(F, C)                          \
+	{                                             \
+		F[(C) >> 5] |= (1 << ((C) & 0x1F));   \
 	}
+#define ISIS_SET_FLAG(F, C) _ISIS_SET_FLAG(F, C->idx)
 
-#define ISIS_CLEAR_FLAG(F, C)                                                  \
-	{                                                                      \
-		F[C->idx >> 5] &= ~(1 << (C->idx & 0x1F));                     \
+
+#define _ISIS_CLEAR_FLAG(F, C)                        \
+	{                                             \
+		F[(C) >> 5] &= ~(1 << ((C) & 0x1F));  \
 	}
+#define ISIS_CLEAR_FLAG(F, C) _ISIS_CLEAR_FLAG(F, C->idx)
 
-#define ISIS_CHECK_FLAG(F, C)  (F[(C)->idx>>5] & (1<<(C->idx & 0x1F)))
+
+#define _ISIS_CHECK_FLAG(F, C)  (F[(C)>>5] & (1<<((C) & 0x1F)))
+#define ISIS_CHECK_FLAG(F, C) _ISIS_CHECK_FLAG(F, C->idx)
 
 /* sets all u_32int_t flags to 1 */
 #define ISIS_FLAGS_SET_ALL(FLAGS)                                              \

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -52,7 +52,8 @@ struct isis {
 	struct area_addr *man_area_addrs; /* manualAreaAddresses */
 	u_int32_t debugs;		  /* bitmap for debug */
 	time_t uptime;			  /* when did we start */
-	struct thread *t_dync_clean; /* dynamic hostname cache cleanup thread */
+	struct thread *t_dync_clean;      /* dynamic hostname cache cleanup thread */
+	uint32_t circuit_ids_used[8];     /* 256 bits to track circuit ids 0 through 255 */
 
 	struct route_table *ext_info[REDIST_PROTOCOL_COUNT];
 


### PR DESCRIPTION
Circuit IDs need to be unique, otherwise mayhem will ensue.

Renato discovered that `isisd` would sometimes not converge during his testing with netgen. Debugging this issue I realized that frr is deducing circuit ids from interface names and did not ensure that circuit ids are unique.