### PR TITLE
bgpd: Do not put on outgoing stream type 5 route 2 times

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2047,7 +2047,6 @@ static void evpn_mpattr_encode_type5(struct stream *s, struct prefix *p,
 		len = 8; /* ipv4 */
 	else
 		len = 32; /* ipv6 */
-	stream_putc(s, BGP_EVPN_IP_PREFIX_ROUTE);
 	/* Prefix contains RD, ESI, EthTag, IP length, IP, GWIP and VNI */
 	stream_putc(s, 8 + 10 + 4 + 1 + len + 3);
 	stream_put(s, prd->val, 8);


### PR DESCRIPTION
With the change to allow bgp_evpn.c to support 2,3 and 5 evpn routes
the output of the route type is being done by bgp_evpn_encode_prefix
instead of the individual route encoder functions.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com.