### PR TITLE
bgpd: fix uninitialized value in show cmd

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2287,6 +2287,8 @@ char *bgp_evpn_route2str(struct prefix_evpn *p, char *buf, int len)
 		}
 	} else {
 		/* For EVPN route types not supported yet. */
+		snprintf(buf, len, "(unsupported route type %d)",
+			 p->prefix.route_type);
 	}
 
 	return (buf);


### PR DESCRIPTION
When unsupported EVPN route types are are received / displayed with a
show command we print an uninitialized stack buffer.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>