### PR TITLE
lib: CMD_FERR_RETURN should return CMD_WARNING_CONFIG_FAILED

### DIFF
--- a/lib/ferr.h
+++ b/lib/ferr.h
@@ -162,7 +162,7 @@ void vty_print_error(struct vty *vty, ferr_r err, const char *msg, ...);
 	} while (0)
 
 #define CMD_FERR_RETURN(func, ...) \
-	CMD_FERR_DO(func, return CMD_WARNING, __VA_ARGS__)
+	CMD_FERR_DO(func, return CMD_WARNING_CONFIG_FAILED, __VA_ARGS__)
 #define CMD_FERR_GOTO(func, label, ...) \
 	CMD_FERR_DO(func, goto label, __VA_ARGS__)
 


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

Testing the patch:

root@cel-redxp-10[frr-dwalton76]# vtysh -c 'conf t' -c ' int vlan2' -c
'ip igmp join 233.200.0.1 10.1.1.1'
Failure joining IGMP group: multicast not enabled on interface vlan2
root@cel-redxp-10[frr-dwalton76]# echo $?
1
root@cel-redxp-10[frr-dwalton76]