### PR TITLE
vtysh: warn on cli targeting non-running daemon

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -425,6 +425,12 @@ static int vtysh_execute_func(const char *line, int pager)
 		cmd_stat = CMD_SUCCESS;
 		for (i = 0; i < array_size(vtysh_client); i++) {
 			if (cmd->daemon & vtysh_client[i].flag) {
+				if (vtysh_client[i].fd < 0
+				    && (cmd->daemon == vtysh_client[i].flag)) {
+					fprintf(stderr, "%s is not running\n",
+						vtysh_client[i].name);
+					continue;
+				}
 				cmd_stat = vtysh_client_execute(
 					&vtysh_client[i], line, fp);
 				if (cmd_stat != CMD_SUCCESS)


### PR DESCRIPTION
Presently CLI entered for daemons which are not running is accepted
quietly, which can be confusing for users. This patch warns about it
when possible.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>