### PR TITLE
bgpd: rfapi - fix 'add vnc' command not picking up RD from vrf-policy

### DIFF
--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -4093,7 +4093,7 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 			}
 		}
 
-		if (hc->default_rd.family || hc->default_response_lifetime
+		if (hc->default_rd.prefixlen || hc->default_response_lifetime
 		    || hc->default_rt_import_list || hc->default_rt_export_list
 		    || hc->nve_groups_sequential->count) {
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -4671,7 +4671,7 @@ static int vnc_add_vrf_prefix(struct vty *vty, const char *arg_vrf,
 			arg_vrf);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
-	if (!rfg->rd.family && !arg_rd) {
+	if (!rfg->rd.prefixlen && !arg_rd) {
 		vty_out(vty,
 			"VRF \"%s\" isn't configured with an RD, so RD must be provided.\n",
 			arg_vrf);


### PR DESCRIPTION
due to check against rfapi internal rd type flag vs if rd set.