### PR TITLE
bgpd: Reduce multiaccess_check_v4 overhead for subgroups

### DIFF
--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -82,6 +82,8 @@ extern int bgp_nexthop_lookup(afi_t, struct peer *peer, struct bgp_info *,
 			      int *, int *);
 extern void bgp_connected_add(struct bgp *bgp, struct connected *c);
 extern void bgp_connected_delete(struct bgp *bgp, struct connected *c);
+extern int bgp_subgrp_multiaccess_check_v4(struct in_addr nexthop,
+					   struct update_subgroup *subgrp);
 extern int bgp_multiaccess_check_v4(struct in_addr, struct peer *);
 extern int bgp_config_write_scan_time(struct vty *);
 extern int bgp_nexthop_self(struct bgp *, struct in_addr);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1319,7 +1319,6 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_info *ri,
 	struct peer *onlypeer;
 	struct bgp *bgp;
 	struct attr *riattr;
-	struct peer_af *paf;
 	char buf[PREFIX_STRLEN];
 	int ret;
 	int transparent;
@@ -1710,16 +1709,12 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_info *ri,
 			 * Note: 3rd party nexthop currently implemented for
 			 * IPv4 only.
 			 */
-			SUBGRP_FOREACH_PEER (subgrp, paf) {
-				if (bgp_multiaccess_check_v4(riattr->nexthop,
-							     paf->peer))
-					break;
-			}
-			if (!paf)
+			if (!bgp_subgrp_multiaccess_check_v4(riattr->nexthop,
+							     subgrp))
 				subgroup_announce_reset_nhop(
 					(peer_cap_enhe(peer, afi, safi)
-						 ? AF_INET6
-						 : p->family),
+					 ? AF_INET6
+					 : p->family),
 					attr);
 		}
 		/* If IPv6/MP and nexthop does not have any override and happens


### PR DESCRIPTION
Perf results at scale( >1k peers) showed a non-trivial
amount of time spent in bgp_multiaccess_check_v4.  Upon
function examination we are looking up the nexthops
connected node in each call as well as having to unlock
it after each iteration.  Rewrite to lookup the nexthop
node once.

This should reduce the node lookup by aproximately 1/2
which should yield some performance results.  There are
probably better things to do here but would require
deeper thought.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>