### PR TITLE
lib/vty: add separate output fd support to VTYs

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2184,6 +2184,7 @@ static void vty_read_file(FILE *confp)
 	 * vty->fd will be -1 from vty_new()
 	 */
 	vty->wfd = STDERR_FILENO;
+	vty->fd = STDIN_FILENO;
 	vty->type = VTY_FILE;
 	vty->node = CONFIG_NODE;
 


### PR DESCRIPTION
to be used with stdin/stdout terminals, this adds support for writing to
a different FD than we're reading from.  Also fixes error messages from
config load being written to stdin.

[v2: fixed config write]
Signed-off-by: David Lamparter <equinox@opensourcerouting.org>

(cherry picked from commit 4715a53b4d390e72a06c864a6a505971841e3dc9)