### PR TITLE
bgpd: Intialize all the variables used in argv_find.

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2347,7 +2347,7 @@ DEFUN(show_bgp_l2vpn_evpn_route,
       JSON_STR)
 {
 	struct bgp *bgp;
-	int type_idx;
+	int type_idx = 0;
 	int type = 0;
 	u_char uj = 0;
 	json_object *json = NULL;

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -1368,7 +1368,7 @@ DEFUN (access_list_exact,
        "Prefix to match. e.g. 10.0.0.0/8\n"
        "Exact match of the prefixes\n")
 {
-	int idx;
+	int idx = 0;
 	int exact = 0;
 	int idx_word = 1;
 	int idx_permit_deny = 2;
@@ -1410,7 +1410,7 @@ DEFUN (no_access_list_exact,
        "Prefix to match. e.g. 10.0.0.0/8\n"
        "Exact match of the prefixes\n")
 {
-	int idx;
+	int idx = 0;
 	int exact = 0;
 	int idx_word = 2;
 	int idx_permit_deny = 3;
@@ -1549,7 +1549,7 @@ DEFUN (ipv6_access_list_exact,
        "IPv6 prefix\n"
        "Exact match of the prefixes\n")
 {
-	int idx;
+	int idx = 0;
 	int exact = 0;
 	int idx_word = 2;
 	int idx_allow = 3;
@@ -1592,7 +1592,7 @@ DEFUN (no_ipv6_access_list_exact,
        "Prefix to match. e.g. 3ffe:506::/32\n"
        "Exact match of the prefixes\n")
 {
-	int idx;
+	int idx = 0;
 	int exact = 0;
 	int idx_word = 3;
 	int idx_permit_deny = 4;


### PR DESCRIPTION
Ticket: CM-17706
Review: CCR-6639
Testing: Manual (test failing in min test for ARM)

Signed-off-by: Mitesh Kanjariya <mitesh@cumulusnetworks.com>