### PR TITLE
zebra: Nexthop APIs to use correct vrf_id

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -261,7 +261,7 @@ struct nexthop *route_entry_nexthop_ipv4_ifindex_add(struct route_entry *re,
 	if (src)
 		nexthop->src.ipv4 = *src;
 	nexthop->ifindex = ifindex;
-	ifp = if_lookup_by_index(nexthop->ifindex, VRF_DEFAULT);
+	ifp = if_lookup_by_index(nexthop->ifindex, re->vrf_id);
 	/*Pending: need to think if null ifp here is ok during bootup?
 	  There was a crash because ifp here was coming to be NULL */
 	if (ifp)
@@ -417,7 +417,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 	 * address in the routing table.
 	 */
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK)) {
-		ifp = if_lookup_by_index(nexthop->ifindex, VRF_DEFAULT);
+		ifp = if_lookup_by_index(nexthop->ifindex, re->vrf_id);
 		if (ifp && connected_is_unnumbered(ifp)) {
 			if (if_is_operative(ifp))
 				return 1;


### PR DESCRIPTION
For unnumbered interface lookup vrf aware interface
info.
Pass vrf aware interface info for route entry's nexthop
ifindex in route add path.

Before change output:
spine-1# show ip route  vrf red
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, P - PIM, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel,
       > - selected route, * - FIB route
VRF red:
K>* 0.0.0.0/0 [0/8192] unreachable (ICMP unreachable)
O   8.0.0.1/32 [110/10] via 0.0.0.0, **red inactive**, 13:11:22
C>* 8.0.0.1/32 is directly connected, red
O   8.0.0.5/32 [110/20] via 8.0.0.5, **swp1 inactive**, 00:07:03
C>* 10.0.1.0/24 is directly connected, swp7

After change output:
spine-1# show ip route vrf red
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, P - PIM, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel,
       > - selected route, * - FIB route
VRF red:
K>* 0.0.0.0/0 [0/8192] unreachable (ICMP unreachable)
O   8.0.0.1/32 [110/10] via 0.0.0.0, **red onlink**, 00:00:09
C>* 8.0.0.1/32 is directly connected, red
O>* 8.0.0.5/32 [110/20] via 8.0.0.5, **swp1 onlink**, 00:00:01
C>* 10.0.1.0/24 is directly connected, swp7



Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>