### PR TITLE
zebra: Do not allow same rib_dest_t be queued multiple times to meta …

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -135,6 +135,8 @@ typedef struct rib_dest_t_ {
 } rib_dest_t;
 
 #define RIB_ROUTE_QUEUED(x)	(1 << (x))
+// If MQ_SIZE is modified this value needs to be updated.
+#define RIB_ROUTE_ANY_QUEUED    0x1F
 
 /*
  * The maximum qindex that can be used.

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2552,6 +2552,15 @@ static void rib_update_table(struct route_table *table,
 	 * the trigger event.
 	 */
 	for (rn = route_top(table); rn; rn = srcdest_route_next(rn)) {
+		/*
+		 * If we are looking at a route node and the node
+		 * has already been queued  we don't
+		 * need to queue it up again
+		 */
+		if (rn->info
+		    && CHECK_FLAG(rib_dest_from_rnode(rn)->flags,
+				  RIB_ROUTE_ANY_QUEUED))
+			continue;
 		switch (event) {
 		case RIB_UPDATE_IF_CHANGE:
 			/* Examine all routes that won't get processed by the


### PR DESCRIPTION
…queue

If we have already scheduled a node to be on the meta_queue, there is no
need to schedule it up again.

On startup we are calling rib_update() multiple times per connected route.
Due to the multiple ways we can get callbacks for adding a connected route
I decided it was best to just improve meta_queue performance as opposed
to trying to figure out all the different ways across all the platforms
that we can decide that a connected route has changed.  This appears
to solve the issue with a very large # of interfaces coming up
at the same time on startup.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>