### PR TITLE
zebra: Modify metric read to be admin distance and metric

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -71,7 +71,7 @@ struct route_entry {
 	u_int32_t nexthop_mtu;
 
 	/* Distance. */
-	u_char distance;
+	uint8_t distance;
 
 	/* Flags of this route.
 	 * This flag's definition is in lib/zebra.h ZEBRA_FLAG_* and is exposed
@@ -294,7 +294,7 @@ extern int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 		   u_short instance, int flags, struct prefix *p,
 		   struct prefix_ipv6 *src_p, const struct nexthop *nh,
 		   u_int32_t table_id, u_int32_t metric, u_int32_t mtu,
-		   u_char distance);
+		   uint8_t distance);
 
 extern int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *,
 			     struct prefix_ipv6 *src_p, struct route_entry *);
@@ -328,7 +328,7 @@ extern void rib_unlink(struct route_node *, struct route_entry *);
 extern int rib_gc_dest(struct route_node *rn);
 extern struct route_table *rib_tables_iter_next(rib_tables_iter_t *iter);
 
-extern u_char route_distance(int type);
+extern uint8_t route_distance(int type);
 
 /*
  * Inline functions.

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -129,9 +129,9 @@ _rnode_zlog(const char *_func, vrf_id_t vrf_id, struct route_node *rn,
 #define rnode_info(node, ...)                                                  \
 	_rnode_zlog(__func__, vrf_id, node, LOG_INFO, __VA_ARGS__)
 
-u_char route_distance(int type)
+uint8_t route_distance(int type)
 {
-	u_char distance;
+	uint8_t distance;
 
 	if ((unsigned)type >= array_size(route_info))
 		distance = 150;
@@ -2434,7 +2434,7 @@ void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type, u_short instance,
 	    int flags, struct prefix *p, struct prefix_ipv6 *src_p,
 	    const struct nexthop *nh, u_int32_t table_id, u_int32_t metric,
-	    u_int32_t mtu, u_char distance)
+	    u_int32_t mtu, uint8_t distance)
 {
 	struct route_entry *re;
 	struct route_entry *same = NULL;


### PR DESCRIPTION
For ZEBRA_ROUTE_KERNEL types:

The metric/priority of the route received from the kernel
is a 32 bit number.  We are going to interpret the high
order byte as the Admin Distance and the low order 3 bytes
as the metric.

This will allow us to do two things:
1) Allow the creation of kernel routes that can be
   overridden by zebra.
2) Allow the old behavior for 'most' kernel route types
   if a user enters 'ip route ...' v4 routes get a metric
   of 0 and v6 routes get a metric of 1024.  Both of these
   values will end up with a admin distance of 0, which
   will cause them to win for the purposes of zebra.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>