### PR TITLE
bgpd: vty command fixup for evpn rt5

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1118,17 +1118,18 @@ DEFUN(evpnrt5_network,
       "Name of the route map\n")
 {
 	int idx_ipv4_prefixlen = 1;
-	int idx_ext_community = 3;
-	int idx_word = 7;
+	int idx_route_distinguisher = 3;
+	int idx_label = 7;
 	int idx_esi = 9;
 	int idx_gwip = 11;
 	int idx_ethtag = 5;
 	int idx_routermac = 13;
 	int idx_rmap = 15;
+
 	return bgp_static_set_safi(
 		AFI_L2VPN, SAFI_EVPN, vty, argv[idx_ipv4_prefixlen]->arg,
-		argv[idx_ext_community]->arg, argv[idx_word]->arg,
-		argv[idx_rmap] ? argv[idx_gwip]->arg : NULL,
+		argv[idx_route_distinguisher]->arg, argv[idx_label]->arg,
+		NULL,
 		BGP_EVPN_IP_PREFIX_ROUTE, argv[idx_esi]->arg,
 		argv[idx_gwip]->arg, argv[idx_ethtag]->arg,
 		argv[idx_routermac]->arg);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11129,11 +11129,23 @@ static void bgp_config_write_network_evpn(struct vty *vty, struct bgp *bgp,
 
 			/* "network" configuration display.  */
 			prefix_rd2str(prd, rdbuf, RD_ADDRSTRLEN);
+			if (p->u.prefix_evpn.route_type == 5) {
+				char local_buf[PREFIX_STRLEN];
+				uint8_t family = IS_EVPN_PREFIX_IPADDR_V4((struct prefix_evpn *)p)
+					? AF_INET
+					: AF_INET6;
+				inet_ntop(family, &p->u.prefix_evpn.ip.ip.addr, local_buf,
+					  PREFIX_STRLEN);
+				sprintf(buf, "%s/%u", local_buf,p->u.prefix_evpn.ip_prefix_length);
+			} else {
+				prefix2str(p, buf, sizeof(buf));
+			}
 
-			inet_ntop(AF_INET, &bgp_static->igpnexthop, buf2,
-				  SU_ADDRSTRLEN);
-
-			prefix2str(p, buf, sizeof(buf));
+			if (bgp_static->gatewayIp.family == AF_INET ||
+			    bgp_static->gatewayIp.family == AF_INET6)
+				inet_ntop(bgp_static->gatewayIp.family,
+					  &bgp_static->gatewayIp.u.prefix, buf2,
+					  sizeof(buf2));
 			vty_out(vty,
 				" network %s rd %s ethtag %u tag %u esi %s gwip %s routermac %s\n",
 				buf, rdbuf, p->u.prefix_evpn.eth_tag,


### PR DESCRIPTION
evpn vty command can be used to configure evpn rt5 entries.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>