### PR TITLE
bgpd: skip run as option can be reused

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -320,7 +320,7 @@ int main(int argc, char **argv)
 
 	frr_preinit(&bgpd_di, argc, argv);
 	frr_opt_add(
-		"p:l:rne:", longopts,
+		"p:l:rSne:", longopts,
 		"  -p, --bgp_port     Set bgp protocol's port number\n"
 		"  -l, --listenon     Listen on specified address (implies -n)\n"
 		"  -r, --retain       When program terminates, retain added route by bgpd.\n"


### PR DESCRIPTION
the '-S' option was not usable, whereas it was shown on the vty.
Enable the '-S' option.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>