### PR TITLE
lib: destroy threadmaster condition variable

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -567,6 +567,7 @@ void thread_master_free(struct thread_master *m)
 	thread_list_free(m, &m->ready);
 	thread_list_free(m, &m->unuse);
 	pthread_mutex_destroy(&m->mtx);
+	pthread_cond_destroy(&m->cancel_cond);
 	close(m->io_pipe[0]);
 	close(m->io_pipe[1]);
 	list_delete(m->cancel_req);


### PR DESCRIPTION
Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>