### PR TITLE
tools: Fix route flush

### DIFF
--- a/tools/etc/iproute2/rt_protos.d/frr.conf
+++ b/tools/etc/iproute2/rt_protos.d/frr.conf
@@ -8,4 +8,3 @@
 191  nhrp
 192  eigrp
 193  ldp
-194  babel

--- a/tools/frr
+++ b/tools/frr
@@ -544,13 +544,15 @@ case "$1" in
 
         if [ -z "$dmn" -o "$dmn" = "zebra" ]; then
           echo "Removing all routes made by FRR."
-          ip route flush proto bgp
-          ip route flush proto ospf
-          ip route flush proto static
-          ip route flush proto rip
-          ip route flush proto ripng
-          ip route flush proto zebra
-          ip route flush proto isis
+          ip route flush proto 186
+          ip route flush proto 188
+          ip route flush proto 4
+          ip route flush proto 189
+          ip route flush proto 190
+          ip route flush proto 11
+          ip route flush proto 187
+          ip route flush proto 192
+          ip route flush proto 194
 
        else
          [ -n "$dmn" ] && eval "${dmn/-/_}=0"

--- a/tools/frr
+++ b/tools/frr
@@ -553,6 +553,7 @@ case "$1" in
           ip route flush proto 187
           ip route flush proto 192
           ip route flush proto 42
+          ip route flush proto 191
        else
          [ -n "$dmn" ] && eval "${dmn/-/_}=0"
          start_watchfrr

--- a/tools/frr
+++ b/tools/frr
@@ -552,8 +552,7 @@ case "$1" in
           ip route flush proto 11
           ip route flush proto 187
           ip route flush proto 192
-          ip route flush proto 194
-
+          ip route flush proto 42
        else
          [ -n "$dmn" ] && eval "${dmn/-/_}=0"
          start_watchfrr

--- a/tools/frr
+++ b/tools/frr
@@ -544,6 +544,12 @@ case "$1" in
 
         if [ -z "$dmn" -o "$dmn" = "zebra" ]; then
           echo "Removing all routes made by FRR."
+	  # Specific values for each proto can be found
+	  # in /etc/iproute2/rt_protos as well as FRR
+	  # specific ones in /etc/iproute2/rt_protos.d
+	  # Additionally if a new protocol is added
+	  # we need to add it here as well as
+	  # in rt_netlink.h( follow the directions! )
           ip route flush proto 186
           ip route flush proto 188
           ip route flush proto 4

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -27,14 +27,26 @@
 
 #define NL_DEFAULT_ROUTE_METRIC 20
 
-/* Additional protocol strings to push into routes */
+/*
+ * Additional protocol strings to push into routes
+ * If we add anything new here please make sure
+ * to update:
+ * zebra2proto                 Function
+ * proto2zebra                 Function
+ * is_selfroute                Function
+ * tools/frr                   To flush the route upon exit
+ *
+ * Finally update this file to allow iproute2 to
+ * know about this new route.
+ * tools/etc/iproute2/rt_protos.d
+ */
 #define RTPROT_BGP         186
 #define RTPROT_ISIS        187
 #define RTPROT_OSPF        188
 #define RTPROT_RIP         189
 #define RTPROT_RIPNG       190
 #if !defined(RTPROT_BABEL)
-#define RTPROT_BABEL              42
+#define RTPROT_BABEL        42
 #endif
 #define RTPROT_NHRP        191
 #define RTPROT_EIGRP       192


### PR DESCRIPTION
This commit does two things:

1) Flush by proto number not string
   This is useful because not all systems might have the proto
   values installed, or a version of iproute2 that they might
   be installed with.
2) Flush missing routes that might have been installed( eigrp
   and nhrp )

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>