### PR TITLE
OSPFv2 and OSPFv3 cleanup interface config upon deleting instance

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -164,6 +164,7 @@ void ospf6_delete(struct ospf6 *o)
 {
 	struct listnode *node, *nnode;
 	struct ospf6_area *oa;
+	struct interface *ifp = NULL;
 
 	QOBJ_UNREG(o);
 	ospf6_disable(ospf6);
@@ -171,8 +172,14 @@ void ospf6_delete(struct ospf6 *o)
 	for (ALL_LIST_ELEMENTS(o->area_list, node, nnode, oa))
 		ospf6_area_delete(oa);
 
-
 	list_delete(o->area_list);
+
+	for (ALL_LIST_ELEMENTS_RO(vrf_iflist(VRF_DEFAULT), node, ifp)) {
+		if (ifp->info != NULL) {
+			ospf6_interface_delete(ifp->info);
+			ifp->info = NULL;
+		}
+	}
 
 	ospf6_lsdb_delete(o->lsdb);
 	ospf6_lsdb_delete(o->lsdb_self);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -556,6 +556,8 @@ static void ospf_finish_final(struct ospf *ospf)
 		params = IF_DEF_PARAMS(ifp);
 		if (OSPF_IF_PARAM_CONFIGURED(params, if_area))
 			UNSET_IF_PARAM(params, if_area);
+
+		IF_DEF_PARAMS(ifp)->type = ospf_default_iftype(ifp);
 	}
 
 	/* Reset interface. */


### PR DESCRIPTION
Upon removing OSPFv2 and OSPv3 instance, ospf interface configuration was not cleaned up.

1)Cleanup ospf6 interface config upon deleting ospf6 instance as part of 'no router ospf6' command.

2) Assign default_type (i.e BROADCAST) to interface config params, as part of ospf instance cleanup. This would trigger to remove 'ip ospf network point-to-point' configuration under interface

Signed-off-by:Chirag Shah <chirag@cumulusnetworks.com>