### PR TITLE
pimd: add support for boundaries

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6462,6 +6462,58 @@ DEFUN (interface_no_ip_pim_sm,
 	return CMD_SUCCESS;
 }
 
+/* boundaries */
+DEFUN(interface_ip_pim_boundary_oil,
+      interface_ip_pim_boundary_oil_cmd,
+      "ip multicast boundary oil WORD",
+      IP_STR
+      "Generic multicast configuration options\n"
+      "Define multicast boundary\n"
+      "Filter OIL by group using prefix list\n"
+      "Prefix list to filter OIL with")
+{
+	VTY_DECLVAR_CONTEXT(interface, iif);
+	struct pim_interface *pim_ifp;
+	int idx = 0;
+
+	argv_find(argv, argc, "WORD", &idx);
+
+	PIM_GET_PIM_INTERFACE(pim_ifp, iif);
+
+	if (pim_ifp->boundary_oil_plist)
+		XFREE(MTYPE_PIM_INTERFACE, pim_ifp->boundary_oil_plist);
+
+	pim_ifp->boundary_oil_plist =
+		XSTRDUP(MTYPE_PIM_INTERFACE, argv[idx]->arg);
+
+	/* Interface will be pruned from OIL on next Join */
+	return CMD_SUCCESS;
+}
+
+DEFUN(interface_no_ip_pim_boundary_oil,
+      interface_no_ip_pim_boundary_oil_cmd,
+      "no ip multicast boundary oil [WORD]",
+      NO_STR
+      IP_STR
+      "Generic multicast configuration options\n"
+      "Define multicast boundary\n"
+      "Filter OIL by group using prefix list\n"
+      "Prefix list to filter OIL with")
+{
+	VTY_DECLVAR_CONTEXT(interface, iif);
+	struct pim_interface *pim_ifp;
+	int idx;
+
+	argv_find(argv, argc, "WORD", &idx);
+
+	PIM_GET_PIM_INTERFACE(pim_ifp, iif);
+
+	if (pim_ifp->boundary_oil_plist)
+		XFREE(MTYPE_PIM_INTERFACE, pim_ifp->boundary_oil_plist);
+
+	return CMD_SUCCESS;
+}
+
 DEFUN (interface_ip_mroute,
        interface_ip_mroute_cmd,
        "ip mroute INTERFACE A.B.C.D",
@@ -8564,6 +8616,8 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_no_ip_pim_drprio_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_hello_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ip_pim_hello_cmd);
+	install_element(INTERFACE_NODE, &interface_ip_pim_boundary_oil_cmd);
+	install_element(INTERFACE_NODE, &interface_no_ip_pim_boundary_oil_cmd);
 
 	// Static mroutes NEB
 	install_element(INTERFACE_NODE, &interface_ip_mroute_cmd);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -246,6 +246,9 @@ void pim_if_delete(struct interface *ifp)
 	list_delete(pim_ifp->upstream_switch_list);
 	list_delete(pim_ifp->sec_addr_list);
 
+	if (pim_ifp->boundary_oil_plist)
+		XFREE(MTYPE_PIM_INTERFACE, pim_ifp->boundary_oil_plist);
+
 	while ((ch = RB_ROOT(pim_ifchannel_rb,
 			     &pim_ifp->ifchannel_rb)) != NULL)
 		pim_ifchannel_delete(ch);

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -122,6 +122,9 @@ struct pim_interface {
 	uint32_t pim_dr_priority;	  /* config */
 	int pim_dr_num_nondrpri_neighbors; /* neighbors without dr_pri */
 
+	/* boundary prefix-list */
+	char *boundary_oil_plist;
+
 	int64_t pim_ifstat_start; /* start timestamp for stats */
 	uint32_t pim_ifstat_hello_sent;
 	uint32_t pim_ifstat_hello_sendfail;

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -299,22 +299,19 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 		return -1;
 	}
 
-	/* RFC 3376 defines some guidelines on operating in backwards
-	 * compatibility
-	 * with older versions of IGMP but there are some gaps in the logic:
+	/*
+	 * RFC 3376 defines some guidelines on operating in backwards
+	 * compatibility with older versions of IGMP but there are some gaps in
+	 * the logic:
 	 *
 	 * - once we drop from say version 3 to version 2 we will never go back
-	 * to
-	 *   version 3 even if the node that TXed an IGMP v2 query upgrades to
-	 * v3
+	 *   to version 3 even if the node that TXed an IGMP v2 query upgrades
+	 *   to v3
 	 *
 	 * - The node with the lowest IP is the querier so we will only know to
-	 * drop
-	 *   from v3 to v2 if the node that is the querier is also the one that
-	 * is
-	 *   running igmp v2.  If a non-querier only supports igmp v2 we will
-	 * have
-	 *   no way of knowing.
+	 *   drop from v3 to v2 if the node that is the querier is also the one
+	 *   that is running igmp v2.  If a non-querier only supports igmp v2
+	 *   we will have no way of knowing.
 	 *
 	 * For now we will simplify things and inform the user that they need to
 	 * configure all PIM routers to use the same version of IGMP.
@@ -402,6 +399,9 @@ static int igmp_v1_recv_report(struct igmp_sock *igmp, struct in_addr from,
 	}
 
 	memcpy(&group_addr, igmp_msg + 4, sizeof(struct in_addr));
+
+	if (pim_is_group_filtered(ifp->info, &group_addr))
+		return -1;
 
 	/* non-existant group is created as INCLUDE {empty} */
 	group = igmp_add_group_by_addr(igmp, group_addr);

--- a/pimd/pim_util.h
+++ b/pimd/pim_util.h
@@ -25,6 +25,8 @@
 #include <zebra.h>
 
 #include "checksum.h"
+#include "pimd.h"
+#include "pim_iface.h"
 
 uint8_t igmp_msg_encode16to8(uint16_t value);
 uint16_t igmp_msg_decode8to16(uint8_t code);
@@ -33,4 +35,5 @@ void pim_pkt_dump(const char *label, const uint8_t *buf, int size);
 
 int pim_is_group_224_0_0_0_24(struct in_addr group_addr);
 int pim_is_group_224_4(struct in_addr group_addr);
+bool pim_is_group_filtered(struct pim_interface *pim_ifp, struct in_addr *grp);
 #endif /* PIM_UTIL_H */

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -285,6 +285,7 @@ int pim_interface_config_write(struct vty *vty)
 						vty_out(vty, " %d",
 							pim_ifp->pim_default_holdtime);
 					vty_out(vty, "\n");
+					++writes;
 				}
 
 				/* update source */
@@ -356,6 +357,14 @@ int pim_interface_config_write(struct vty *vty)
 							group_str, source_str);
 						++writes;
 					}
+				}
+
+				/* boundary */
+				if (pim_ifp->boundary_oil_plist) {
+					vty_out(vty,
+						" ip pim boundary oil %s\n",
+						pim_ifp->boundary_oil_plist);
+					++writes;
 				}
 
 				writes +=


### PR DESCRIPTION
Adds the ability to filter PIM Joins & IGMP reports on an interface.
Enabling a multicast boundary on an interface for a particular group
will prevent the interface from appearing in the group's OIL.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>