### PR TITLE
ospfd: fix virtual-link config command

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -983,7 +983,8 @@ DEFUN (ospf_area_vlink,
        "Key ID\n"
        "Use MD5 algorithm\n"
        "The OSPF password (key)\n"
-       "Authentication password (key)")
+       "Authentication password (key)\n"
+       "The OSPF password (key)")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	int idx_ipv4_number = 1;
@@ -1032,23 +1033,19 @@ DEFUN (ospf_area_vlink,
 	}
 
 	if (argv_find(argv, argc, "message-digest-key", &idx)) {
-		idx = idx + 1; /* Fetch key_id */
-
 		vl_config.md5_key = NULL;
-		vl_config.crypto_key_id = strtol(argv[idx]->arg, NULL, 10);
+		vl_config.crypto_key_id = strtol(argv[idx + 1]->arg, NULL, 10);
 		if (vl_config.crypto_key_id < 0)
 			return CMD_WARNING_CONFIG_FAILED;
 
-		idx = idx + 1; /* Fetch md5_key */
 		memset(md5_key, 0, OSPF_AUTH_MD5_SIZE + 1);
-		strncpy(md5_key, argv[idx]->arg, OSPF_AUTH_MD5_SIZE);
+		strncpy(md5_key, argv[idx + 3]->arg, OSPF_AUTH_MD5_SIZE);
 		vl_config.md5_key = md5_key;
 	}
 
 	if (argv_find(argv, argc, "authentication-key", &idx)) {
-		idx = idx + 1;
 		memset(auth_key, 0, OSPF_AUTH_SIMPLE_SIZE + 1);
-		strncpy(auth_key, argv[idx]->text, OSPF_AUTH_SIMPLE_SIZE);
+		strncpy(auth_key, argv[idx + 1]->arg, OSPF_AUTH_SIMPLE_SIZE);
 		vl_config.auth_key = auth_key;
 	}
 
@@ -1069,7 +1066,8 @@ DEFUN (no_ospf_area_vlink,
        "Key ID\n" \
        "Use MD5 algorithm\n" \
        "The OSPF password (key)\n" \
-       "Authentication password (key)")
+       "Authentication password (key)\n" \
+       "The OSPF password (key)")
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	int idx_ipv4_number = 2;
@@ -1123,15 +1121,14 @@ DEFUN (no_ospf_area_vlink,
 	}
 
 	if (argv_find(argv, argc, "message-digest-key", &idx)) {
-		idx = idx + 1; /* Fetch key_id */
 		vl_config.md5_key = NULL;
-		vl_config.crypto_key_id = strtol(argv[idx]->arg, NULL, 10);
+		vl_config.crypto_key_id = strtol(argv[idx + 1]->arg, NULL, 10);
 		if (vl_config.crypto_key_id < 0)
 			return CMD_WARNING_CONFIG_FAILED;
 	}
 
 	if (argv_find(argv, argc, "authentication-key", &idx)) {
-		idx = idx + 1;
+		/* Reset authentication-key to 0 */
 		memset(auth_key, 0, OSPF_AUTH_SIMPLE_SIZE + 1);
 		vl_config.auth_key = auth_key;
 	}

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -963,14 +963,13 @@ static int ospf_vl_set(struct ospf *ospf, struct ospf_vl_config_data *vl_config)
 
 #define VLINK_HELPSTR_AUTH_SIMPLE                                              \
 	"Authentication password (key)\n"                                      \
-	"The OSPF password (key)"
+	"The OSPF password (key)\n"
 
 #define VLINK_HELPSTR_AUTH_MD5                                                 \
 	"Message digest authentication password (key)\n"                       \
-	"dummy string \n"                                                      \
 	"Key ID\n"                                                             \
 	"Use MD5 algorithm\n"                                                  \
-	"The OSPF password (key)"
+	"The OSPF password (key)\n"
 
 DEFUN (ospf_area_vlink,
        ospf_area_vlink_cmd,
@@ -979,12 +978,8 @@ DEFUN (ospf_area_vlink,
        "Enable authentication on this virtual link\n"
        "Use message-digest authentication\n"
        "Use null authentication\n"
-       "Message digest authentication password (key)\n"
-       "Key ID\n"
-       "Use MD5 algorithm\n"
-       "The OSPF password (key)\n"
-       "Authentication password (key)\n"
-       "The OSPF password (key)")
+       VLINK_HELPSTR_AUTH_MD5
+       VLINK_HELPSTR_AUTH_SIMPLE)
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	int idx_ipv4_number = 1;
@@ -1024,8 +1019,7 @@ DEFUN (ospf_area_vlink,
 	}
 
 	if (argv_find(argv, argc, "message-digest", &idx)) {
-		/* authentication  - this option can only occur
-		at start of command line */
+		/* authentication message-digest */
 		vl_config.auth_type = OSPF_AUTH_CRYPTOGRAPHIC;
 	} else if (argv_find(argv, argc, "null", &idx)) {
 		/* "authentication null" */
@@ -1062,12 +1056,8 @@ DEFUN (no_ospf_area_vlink,
        "Enable authentication on this virtual link\n" \
        "Use message-digest authentication\n" \
        "Use null authentication\n" \
-       "Message digest authentication password (key)\n" \
-       "Key ID\n" \
-       "Use MD5 algorithm\n" \
-       "The OSPF password (key)\n" \
-       "Authentication password (key)\n" \
-       "The OSPF password (key)")
+       VLINK_HELPSTR_AUTH_MD5
+       VLINK_HELPSTR_AUTH_SIMPLE)
 {
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	int idx_ipv4_number = 2;
@@ -5808,8 +5798,7 @@ DEFUN_HIDDEN (ospf_authentication_key,
               ospf_authentication_key_cmd,
               "ospf authentication-key AUTH_KEY [A.B.C.D]",
               "OSPF interface commands\n"
-              "Authentication password (key)\n"
-              "The OSPF password (key)\n"
+              VLINK_HELPSTR_AUTH_SIMPLE
               "Address of interface\n")
 {
 	return ip_ospf_authentication_key(self, vty, argc, argv);
@@ -5821,8 +5810,8 @@ DEFUN (no_ip_ospf_authentication_key,
        NO_STR
        "IP Information\n"
        "OSPF interface commands\n"
-       "Authentication password (key)\n"
-       "The OSPF password (key)")
+       VLINK_HELPSTR_AUTH_SIMPLE
+       "Address of interface\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	int idx = 0;
@@ -5858,8 +5847,8 @@ DEFUN_HIDDEN (no_ospf_authentication_key,
               "no ospf authentication-key [AUTH_KEY [A.B.C.D]]",
               NO_STR
               "OSPF interface commands\n"
-              "Authentication password (key)\n"
-              "The OSPF password (key)")
+              VLINK_HELPSTR_AUTH_SIMPLE
+	      "Address of interface\n")
 {
 	return no_ip_ospf_authentication_key(self, vty, argc, argv);
 }

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -992,7 +992,7 @@ DEFUN (ospf_area_vlink,
 	char auth_key[OSPF_AUTH_SIMPLE_SIZE + 1];
 	char md5_key[OSPF_AUTH_MD5_SIZE + 1];
 	int ret;
-	int idx;
+	int idx = 0;
 
 	ospf_vl_config_data_init(&vl_config, vty);
 
@@ -1022,7 +1022,6 @@ DEFUN (ospf_area_vlink,
 		vl_config.auth_type = OSPF_AUTH_SIMPLE;
 	}
 
-	idx = 2;
 	if (argv_find(argv, argc, "message-digest", &idx)) {
 		/* authentication  - this option can only occur
 		at start of command line */
@@ -1032,7 +1031,6 @@ DEFUN (ospf_area_vlink,
 		vl_config.auth_type = OSPF_AUTH_NULL;
 	}
 
-	idx = 3;
 	if (argv_find(argv, argc, "message-digest-key", &idx)) {
 		idx = idx + 1; /* Fetch key_id */
 
@@ -1047,7 +1045,6 @@ DEFUN (ospf_area_vlink,
 		vl_config.md5_key = md5_key;
 	}
 
-	idx = 3;
 	if (argv_find(argv, argc, "authentication-key", &idx)) {
 		idx = idx + 1;
 		memset(auth_key, 0, OSPF_AUTH_SIMPLE_SIZE + 1);
@@ -1125,7 +1122,6 @@ DEFUN (no_ospf_area_vlink,
 		vl_config.auth_type = OSPF_AUTH_NOTSET;
 	}
 
-	idx = 3;
 	if (argv_find(argv, argc, "message-digest-key", &idx)) {
 		idx = idx + 1; /* Fetch key_id */
 		vl_config.md5_key = NULL;
@@ -1134,7 +1130,6 @@ DEFUN (no_ospf_area_vlink,
 			return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	idx = 3;
 	if (argv_find(argv, argc, "authentication-key", &idx)) {
 		idx = idx + 1;
 		memset(auth_key, 0, OSPF_AUTH_SIMPLE_SIZE + 1);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1016,7 +1016,7 @@ DEFUN (ospf_area_vlink,
 	}
 
 	/* Deal with other parameters */
-	for (i = 5; i < argc; i++) {
+	for (i = 4; i < argc; i++) {
 
 		/* vty_out (vty, "argv[%d]->arg - %s\n", i, argv[i]->text); */
 
@@ -1027,10 +1027,8 @@ DEFUN (ospf_area_vlink,
 			    || strncmp(argv[i]->arg, "authentication-", 15)
 				       == 0) {
 				/* authentication-key - this option can occur
-				   anywhere on
-							command line.  At start
-				   of command line
-							must check for
+				   anywhere on command line.  At start
+				   of command line must check for
 				   authentication option. */
 				memset(auth_key, 0, OSPF_AUTH_SIMPLE_SIZE + 1);
 				strncpy(auth_key, argv[i + 1]->text,
@@ -1040,8 +1038,7 @@ DEFUN (ospf_area_vlink,
 			} else if (strncmp(argv[i]->arg, "authentication", 14)
 				   == 0) {
 				/* authentication  - this option can only occur
-				   at start
-						     of command line */
+				   at start of command line */
 				vl_config.auth_type = OSPF_AUTH_SIMPLE;
 				if ((i + 1) < argc) {
 					if (strncmp(argv[i + 1]->arg, "n", 1)
@@ -1054,9 +1051,9 @@ DEFUN (ospf_area_vlink,
 						strncmp(argv[i + 1]->arg, "m",
 							1)
 							== 0
-						&& !strmatch(
+						&& strmatch(
 							   argv[i + 1]->text,
-							   "message-digest-")) {
+							   "message-digest")) {
 						/* "authentication
 						 * message-digest" */
 						vl_config.auth_type =
@@ -1153,29 +1150,28 @@ DEFUN (no_ospf_area_vlink,
 	/* If we are down here, we are reseting parameters */
 
 	/* Deal with other parameters */
-	for (i = 6; i < argc; i++) {
+	for (i = 5; i < argc; i++) {
 		/* vty_out (vty, "argv[%d] - %s\n", i, argv[i]); */
 
 		switch (argv[i]->arg[0]) {
 
 		case 'a':
-			if (i > 2
+			if (i > 6
 			    || strncmp(argv[i]->text, "authentication-", 15)
 				       == 0) {
 				/* authentication-key - this option can occur
-				   anywhere on
-							command line.  At start
-				   of command line
-							must check for
+				   anywhere on command line.  At start
+				   of command line must check for
 				   authentication option. */
 				memset(auth_key, 0, OSPF_AUTH_SIMPLE_SIZE + 1);
 				vl_config.auth_key = auth_key;
 			} else if (strncmp(argv[i]->text, "authentication", 14)
 				   == 0) {
 				/* authentication  - this option can only occur
-				   at start
-						     of command line */
+				   at start of command line */
 				vl_config.auth_type = OSPF_AUTH_NOTSET;
+				if ((i + 1) < argc)
+					i++;
 			}
 			break;
 
@@ -1186,6 +1182,7 @@ DEFUN (no_ospf_area_vlink,
 			if (i < argc) {
 				vl_config.crypto_key_id =
 					strtol(argv[i]->arg, NULL, 10);
+				i++; /* skip md5_key arg for delete */
 				if (vl_config.crypto_key_id < 0)
 					return CMD_WARNING_CONFIG_FAILED;
 				vl_config.md5_key = NULL;


### PR DESCRIPTION
Under router ospf fix parsing of area virtual-link related commands and related options

[no] area 1.1.1.1 virtual-link 10.1.1.1 authentication message-digest-key 255 md5 key2,
[no] area 4294967295 virtual-link 10.1.1.1 authentication message-digest-key 255 md5   key2
..


Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>