### PR TITLE
zebra: Fix irdp so it doesn't crash when looked at

### DIFF
--- a/zebra/irdp.h
+++ b/zebra/irdp.h
@@ -111,6 +111,8 @@
 */
 
 struct irdp_interface {
+	bool started;
+
 	unsigned long MaxAdvertInterval;
 	unsigned long MinAdvertInterval;
 	unsigned long Preference;


### PR DESCRIPTION
irdp is crashing because it assumes that people have
configured it in a certain way.  Ensure that this
'way' is honored at least enough so that we don't
crash.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>