### PR TITLE
vtysh: remove extra / in config path

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -534,7 +534,7 @@ struct thread_master *frr_init(void)
 		snprintf(p_pathspace, sizeof(p_pathspace), "/%s",
 			 di->pathspace);
 
-	snprintf(config_default, sizeof(config_default), "%s%s/%s%s.conf",
+	snprintf(config_default, sizeof(config_default), "%s%s%s%s.conf",
 		 frr_sysconfdir, p_pathspace, di->name, p_instance);
 	snprintf(pidfile_default, sizeof(pidfile_default), "%s%s/%s%s.pid",
 		 frr_vtydir, p_pathspace, di->name, p_instance);

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -404,9 +404,9 @@ int main(int argc, char **argv, char **env)
 			"NOT SUPPORTED since its\nresults are inconsistent!\n");
 	}
 
-	snprintf(vtysh_config, sizeof(vtysh_config), "%s%s/%s", sysconfdir,
+	snprintf(vtysh_config, sizeof(vtysh_config), "%s%s%s", sysconfdir,
 		 pathspace, VTYSH_CONFIG_NAME);
-	snprintf(frr_config, sizeof(frr_config), "%s%s/%s", sysconfdir,
+	snprintf(frr_config, sizeof(frr_config), "%s%s%s", sysconfdir,
 		 pathspace, FRR_CONFIG_NAME);
 	strlcat(vtydir, pathspace, sizeof(vtydir));
 


### PR DESCRIPTION
before:

```
frrdev# do wr
Note: this version of vtysh never writes vtysh.conf
Building Configuration...
Integrated configuration saved to /etc/frr//frr.conf
[OK]
frrdev#
```

after:

```
frrdev# do wr
Note: this version of vtysh never writes vtysh.conf
Building Configuration...
Integrated configuration saved to /etc/frr/frr.conf
[OK]
frrdev#
```

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>