### PR TITLE
vtysh: 'x not running' redux

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -226,7 +226,8 @@ static int vtysh_client_run_all(struct vtysh_client *head_client,
 			wrong_instance++;
 			continue;
 		}
-		correct_instance++;
+		if (client->fd > 0)
+			correct_instance++;
 		if (rc != CMD_SUCCESS) {
 			if (!continue_on_err)
 				return rc;
@@ -433,11 +434,12 @@ static int vtysh_execute_func(const char *line, int pager)
 					     vc = vc->next)
 						any_inst = any_inst
 							   || (vc->fd > 0);
-					if (!any_inst)
+					if (!any_inst) {
 						fprintf(stderr,
 							"%s is not running\n",
 							vtysh_client[i].name);
-					continue;
+						continue;
+					}
 				}
 				cmd_stat = vtysh_client_execute(
 					&vtysh_client[i], line, fp);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -423,12 +423,20 @@ static int vtysh_execute_func(const char *line, int pager)
 		}
 
 		cmd_stat = CMD_SUCCESS;
+		struct vtysh_client *vc;
 		for (i = 0; i < array_size(vtysh_client); i++) {
 			if (cmd->daemon & vtysh_client[i].flag) {
 				if (vtysh_client[i].fd < 0
 				    && (cmd->daemon == vtysh_client[i].flag)) {
-					fprintf(stderr, "%s is not running\n",
-						vtysh_client[i].name);
+					bool any_inst = false;
+					for (vc = &vtysh_client[i]; vc;
+					     vc = vc->next)
+						any_inst = any_inst
+							   || (vc->fd > 0);
+					if (!any_inst)
+						fprintf(stderr,
+							"%s is not running\n",
+							vtysh_client[i].name);
 					continue;
 				}
 				cmd_stat = vtysh_client_execute(


### PR DESCRIPTION
when warning about daemons that are not running, make sure to handle the
multi instance case

plus some other stuff

fixes #1223 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>