### PR TITLE
debian: Fix logrotate when FRR is not running

### DIFF
--- a/debian/frr.logrotate
+++ b/debian/frr.logrotate
@@ -22,6 +22,6 @@
                     pids="$pids $(cat /var/run/frr/$i.pid)"
                 fi
             done
-            [ -n "$pids" ] && kill -USR1 $pids
+            [ -n "$pids" ] && kill -USR1 $pids || true
         endscript
 }


### PR DESCRIPTION
Fix the logrotate script to complete successfully even
if FRR is not currently running.

Signed-off-by: Dave Olson <olson@cumulusnetworks.com>