### PR TITLE
Linklist api cleanup

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -288,7 +288,7 @@ static void unmap_vni_from_rt(struct bgp *bgp, struct bgpevpn *vpn,
 	/* Delete VNI from hash list for this RT. */
 	listnode_delete(irt->vnis, vpn);
 	if (!listnode_head(irt->vnis)) {
-		list_free(irt->vnis);
+		list_delete_and_null(&irt->vnis);
 		import_rt_free(bgp, irt);
 	}
 }

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2609,10 +2609,8 @@ void bgp_evpn_free(struct bgp *bgp, struct bgpevpn *vpn)
 {
 	bgp_table_unlock(vpn->route_table);
 	bgp_evpn_unmap_vni_from_its_rts(bgp, vpn);
-	list_delete(vpn->import_rtl);
-	list_delete(vpn->export_rtl);
-	vpn->import_rtl = NULL;
-	vpn->export_rtl = NULL;
+	list_delete_and_null(&vpn->import_rtl);
+	list_delete_and_null(&vpn->export_rtl);
 	bf_release_index(bgp->rd_idspace, vpn->rd_id);
 	hash_release(bgp->vnihash, vpn);
 	QOBJ_UNREG(vpn);

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -215,7 +215,7 @@ static __attribute__((__noreturn__)) void bgp_exit(int status)
 #endif
 	bgp_zebra_destroy();
 
-	list_delete(bm->bgp);
+	list_delete_and_null(&bm->bgp);
 	memset(bm, 0, sizeof(*bm));
 
 	frr_fini();

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1290,10 +1290,8 @@ static void bgp_redist_del(struct bgp *bgp, afi_t afi, u_char type,
 	if (red) {
 		listnode_delete(bgp->redist[afi][type], red);
 		XFREE(MTYPE_BGP_REDIST, red);
-		if (!bgp->redist[afi][type]->count) {
-			list_free(bgp->redist[afi][type]);
-			bgp->redist[afi][type] = NULL;
-		}
+		if (!bgp->redist[afi][type]->count)
+			list_delete_and_null(&bgp->redist[afi][type]);
 	}
 }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7454,8 +7454,7 @@ void bgp_terminate(void)
 	/* reverse bgp_master_init */
 	bgp_close();
 	if (bm->listen_sockets)
-		list_free(bm->listen_sockets);
-	bm->listen_sockets = NULL;
+		list_delete_and_null(&bm->listen_sockets);
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, mnode, mnnode, bgp))
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2436,14 +2436,14 @@ int peer_group_delete(struct peer_group *group)
 			peer_delete(other);
 		}
 	}
-	list_delete(group->peer);
+	list_delete_and_null(&group->peer);
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
 		for (ALL_LIST_ELEMENTS(group->listen_range[afi], node, nnode,
 				       prefix)) {
 			prefix_free(prefix);
 		}
-		list_delete(group->listen_range[afi]);
+		list_delete_and_null(&group->listen_range[afi]);
 	}
 
 	XFREE(MTYPE_PEER_GROUP_HOST, group->name);
@@ -3193,8 +3193,8 @@ void bgp_free(struct bgp *bgp)
 
 	QOBJ_UNREG(bgp);
 
-	list_delete(bgp->group);
-	list_delete(bgp->peer);
+	list_delete_and_null(&bgp->group);
+	list_delete_and_null(&bgp->peer);
 
 	if (bgp->peerhash) {
 		hash_free(bgp->peerhash);

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2327,8 +2327,7 @@ static void bgp_rfapi_delete_nve_group(struct vty *vty, /* NULL = no output */
 			listnode_delete(rfg->nves, rfd);
 			listnode_add(orphaned_nves, rfd);
 		}
-		list_delete(rfg->nves);
-		rfg->nves = NULL;
+		list_delete_and_null(&rfg->nves);
 	}
 
 	/* delete it */
@@ -2405,7 +2404,7 @@ static void bgp_rfapi_delete_nve_group(struct vty *vty, /* NULL = no output */
 			if (vty)
 				vty_out(vty, "\n");
 		}
-		list_delete(orphaned_nves);
+		list_delete_and_null(&orphaned_nves);
 	}
 }
 
@@ -3420,7 +3419,7 @@ static void bgp_rfapi_delete_l2_group(struct vty *vty, /* NULL = no output */
 	if (rfg->rt_export_list)
 		ecommunity_free(&rfg->rt_export_list);
 	if (rfg->labels)
-		list_delete(rfg->labels);
+		list_delete_and_null(&rfg->labels);
 	if (rfg->rfp_cfg)
 		XFREE(MTYPE_RFAPI_RFP_GROUP_CFG, rfg->rfp_cfg);
 	listnode_delete(bgp->rfapi_cfg->l2_groups, rfg);
@@ -3825,10 +3824,10 @@ void bgp_rfapi_cfg_destroy(struct bgp *bgp, struct rfapi_cfg *h)
 	bgp_rfapi_delete_named_nve_group(NULL, bgp, NULL, RFAPI_GROUP_CFG_MAX);
 	bgp_rfapi_delete_named_l2_group(NULL, bgp, NULL);
 	if (h->l2_groups != NULL)
-		list_delete(h->l2_groups);
-	list_delete(h->nve_groups_sequential);
-	list_delete(h->rfg_export_direct_bgp_l);
-	list_delete(h->rfg_export_zebra_l);
+		list_delete_and_null(&h->l2_groups);
+	list_delete_and_null(&h->nve_groups_sequential);
+	list_delete_and_null(&h->rfg_export_direct_bgp_l);
+	list_delete_and_null(&h->rfg_export_zebra_l);
 	if (h->default_rt_export_list)
 		ecommunity_free(&h->default_rt_export_list);
 	if (h->default_rt_import_list)

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -490,7 +490,8 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 		 * Delete local_nexthops list
 		 */
 		if (bi->extra && bi->extra->vnc.export.local_nexthops) {
-			list_delete(bi->extra->vnc.export.local_nexthops);
+			list_delete_and_null(
+				&bi->extra->vnc.export.local_nexthops);
 		}
 
 		bgp_aggregate_decrement(bgp, p, bi, afi, safi);

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -510,13 +510,12 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 				 */
 				if (pn->info) {
 					if (pn->info != (void *)1) {
-						list_delete(
-							(struct list
-								 *)(pn->info));
+						list_delete_and_null(
+							(struct list **)(&pn->info));
 					}
 					pn->info = NULL;
-					route_unlock_node(
-						pn); /* linklist or 1 deleted */
+					/* linklist or 1 deleted */
+					route_unlock_node(pn);
 				}
 			}
 		}
@@ -1435,7 +1434,7 @@ callback:
 		}
 
 		delete_list->del = (void (*)(void *))rfapi_info_free;
-		list_delete(delete_list);
+		list_delete_and_null(&delete_list);
 	}
 
 	RFAPI_RIB_CHECK_COUNTS(0, 0);
@@ -1450,7 +1449,7 @@ callback:
 		route_unlock_node(pn);
 	}
 	if (lPendCost) {
-		list_delete(lPendCost);
+		list_delete_and_null(&lPendCost);
 		pn->info = NULL;
 		route_unlock_node(pn);
 	}
@@ -1634,7 +1633,7 @@ void rfapiRibUpdatePendingNode(
 	 */
 	if (pn->info) {
 		if (pn->info != (void *)1) {
-			list_delete((struct list *)(pn->info));
+			list_delete_and_null((struct list **)(&pn->info));
 		}
 		pn->info = NULL;
 		route_unlock_node(pn); /* linklist or 1 deleted */

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -3274,7 +3274,7 @@ static int rfapiDeleteLocalPrefixesByRFD(struct rfapi_local_reg_delete_arg *cda,
 				}
 				list_delete_all_node(adb_delete_list);
 			}
-			list_delete(adb_delete_list);
+			list_delete_and_null(&adb_delete_list);
 		}
 
 

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1544,7 +1544,7 @@ void vnc_direct_bgp_vpn_disable(struct bgp *bgp, afi_t afi)
 		if (nve_list) {
 			vnc_direct_bgp_unexport_table(
 				afi, it->imported_vpn[afi], nve_list);
-			list_free(nve_list);
+			list_delete_and_null(&nve_list);
 		}
 	}
 }

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -2426,7 +2426,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 			skiplist_delete(it->monitor_exterior_orphans,
 					bi_exterior, NULL);
 		}
-		list_delete(list_adopted);
+		list_delete_and_null(&list_adopted);
 	}
 }
 

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -584,7 +584,7 @@ static void vnc_zebra_add_del_prefix(struct bgp *bgp,
 		nve_list_to_nh_array(rn->p.family, nves, &nexthop_count,
 				     &nh_ary, &nhp_ary);
 
-		list_delete(nves);
+		list_delete_and_null(&nves);
 
 		if (nexthop_count)
 			vnc_zebra_route_msg(&rn->p, nexthop_count, nhp_ary,
@@ -753,7 +753,7 @@ static void vnc_zebra_add_del_group_afi(struct bgp *bgp,
 		vnc_zlog_debug_verbose("%s: family: %d, nve count: %d",
 				       __func__, family, nexthop_count);
 
-		list_delete(nves);
+		list_delete_and_null(&nves);
 
 		if (nexthop_count) {
 			/*

--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -301,7 +301,7 @@ void show_ip_eigrp_prefix_entry(struct vty *vty, struct eigrp_prefix_entry *tn)
 		tn->serno);
 
 	if (successors)
-		list_delete(successors);
+		list_delete_and_null(&successors);
 }
 
 void show_ip_eigrp_nexthop_entry(struct vty *vty, struct eigrp *eigrp,

--- a/eigrpd/eigrp_fsm.c
+++ b/eigrpd/eigrp_fsm.c
@@ -366,7 +366,7 @@ int eigrp_fsm_event_nq_fcn(struct eigrp_fsm_action_message *msg)
 					 // neighbors left
 	}
 
-	list_delete(successors);
+	list_delete_and_null(&successors);
 
 	return 1;
 }
@@ -393,7 +393,7 @@ int eigrp_fsm_event_q_fcn(struct eigrp_fsm_action_message *msg)
 					 // neighbors left
 	}
 
-	list_delete(successors);
+	list_delete_and_null(&successors);
 
 	return 1;
 }
@@ -445,7 +445,7 @@ int eigrp_fsm_event_lr(struct eigrp_fsm_action_message *msg)
 		ne = listnode_head(successors);
 		eigrp_send_reply(ne->adv_router,
 				 prefix);
-		list_delete(successors);
+		list_delete_and_null(&successors);
 	}
 
 	prefix->state = EIGRP_FSM_STATE_PASSIVE;
@@ -475,7 +475,7 @@ int eigrp_fsm_event_dinc(struct eigrp_fsm_action_message *msg)
 			msg);
 
 
-	list_delete(successors);
+	list_delete_and_null(&successors);
 	return 1;
 }
 
@@ -500,7 +500,7 @@ int eigrp_fsm_event_lr_fcs(struct eigrp_fsm_action_message *msg)
 		eigrp_send_reply(ne->adv_router,
 				 prefix);
 
-		list_delete(successors);
+		list_delete_and_null(&successors);
 	}
 	prefix->req_action |= EIGRP_FSM_NEED_UPDATE;
 	listnode_add(eigrp->topology_changes_internalIPV4, prefix);
@@ -536,7 +536,7 @@ int eigrp_fsm_event_lr_fcn(struct eigrp_fsm_action_message *msg)
 					 // neighbors left
 	}
 
-	list_delete(successors);
+	list_delete_and_null(&successors);
 
 	return 1;
 }
@@ -552,6 +552,6 @@ int eigrp_fsm_event_qact(struct eigrp_fsm_action_message *msg)
 	msg->prefix->state = EIGRP_FSM_STATE_ACTIVE_2;
 	msg->prefix->distance = ne->distance;
 
-	list_delete(successors);
+	list_delete_and_null(&successors);
 	return 1;
 }

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -109,7 +109,7 @@ int eigrp_if_delete_hook(struct interface *ifp)
 	if (!ei)
 		return 0;
 
-	list_delete(ei->nbrs);
+	list_delete_and_null(&ei->nbrs);
 
 	eigrp = ei->eigrp;
 	listnode_delete(eigrp->eiflist, ei);
@@ -354,7 +354,7 @@ void eigrp_if_free(struct eigrp_interface *ei,
 
 	eigrp_if_down(ei);
 
-	list_delete(ei->nbrs);
+	list_delete_and_null(&ei->nbrs);
 	listnode_delete(ei->eigrp->eiflist, ei);
 }
 

--- a/eigrpd/eigrp_topology.c
+++ b/eigrpd/eigrp_topology.c
@@ -101,8 +101,7 @@ static int eigrp_prefix_entry_cmp(struct eigrp_prefix_entry *node1,
 
 static void eigrp_prefix_entry_del(struct eigrp_prefix_entry *node)
 {
-	list_delete_all_node(node->entries);
-	list_free(node->entries);
+	list_delete_and_null(&node->entries);
 }
 
 /*
@@ -158,7 +157,7 @@ struct eigrp_nexthop_entry *eigrp_nexthop_entry_new()
  */
 void eigrp_topology_free(struct list *list)
 {
-	list_free(list);
+	list_delete_and_null(&list);
 }
 
 /*
@@ -217,9 +216,8 @@ void eigrp_prefix_entry_delete(struct list *topology,
 	listnode_delete(eigrp->topology_changes_internalIPV4, node);
 
 	if (listnode_lookup(topology, node) != NULL) {
-		list_delete_all_node(node->entries);
-		list_free(node->entries);
-		list_free(node->rij);
+		list_delete_and_null(&node->entries);
+		list_delete_and_null(&node->rij);
 		listnode_delete(topology, node);
 		eigrp_zebra_route_delete(node->destination);
 		XFREE(MTYPE_EIGRP_PREFIX_ENTRY, node);

--- a/eigrpd/eigrp_topology.c
+++ b/eigrpd/eigrp_topology.c
@@ -199,7 +199,7 @@ void eigrp_nexthop_entry_add(struct eigrp_prefix_entry *node,
 		eigrp_zebra_route_add(node->destination, l);
 	}
 
-	list_delete(l);
+	list_delete_and_null(&l);
 }
 
 /*
@@ -296,7 +296,7 @@ struct list *eigrp_topology_get_successor(struct eigrp_prefix_entry *table_node)
 	 * If we have no successors return NULL
 	 */
 	if (!successors->count) {
-		list_delete(successors);
+		list_delete_and_null(&successors);
 		successors = NULL;
 	}
 
@@ -475,7 +475,7 @@ void eigrp_update_routing_table(struct eigrp_prefix_entry *prefix)
 		for (ALL_LIST_ELEMENTS_RO(successors, node, entry))
 			entry->flags |= EIGRP_NEXTHOP_ENTRY_INTABLE_FLAG;
 
-		list_delete(successors);
+		list_delete_and_null(&successors);
 	} else {
 		eigrp_zebra_route_delete(prefix->destination);
 		for (ALL_LIST_ELEMENTS_RO(prefix->entries, node, entry))

--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -411,7 +411,7 @@ void eigrp_update_receive(struct eigrp *eigrp, struct ip *iph,
 	eigrp_update_send_all(eigrp, ei);
 
 	if (nbr_prefixes)
-		list_delete(nbr_prefixes);
+		list_delete_and_null(&nbr_prefixes);
 }
 
 /*send EIGRP Update packet*/

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -282,10 +282,10 @@ void eigrp_finish_final(struct eigrp *eigrp)
 	THREAD_OFF(eigrp->t_read);
 	close(eigrp->fd);
 
-	list_delete(eigrp->eiflist);
-	list_delete(eigrp->oi_write_q);
-	list_delete(eigrp->topology_changes_externalIPV4);
-	list_delete(eigrp->topology_changes_internalIPV4);
+	list_delete_and_null(&eigrp->eiflist);
+	list_delete_and_null(&eigrp->oi_write_q);
+	list_delete_and_null(&eigrp->topology_changes_externalIPV4);
+	list_delete_and_null(&eigrp->topology_changes_internalIPV4);
 
 	eigrp_topology_cleanup(eigrp->topology_table);
 	eigrp_topology_free(eigrp->topology_table);

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -453,19 +453,19 @@ void isis_circuit_if_del(struct isis_circuit *circuit, struct interface *ifp)
 
 	if (circuit->ip_addrs) {
 		assert(listcount(circuit->ip_addrs) == 0);
-		list_delete(circuit->ip_addrs);
+		list_delete_and_null(&circuit->ip_addrs);
 		circuit->ip_addrs = NULL;
 	}
 
 	if (circuit->ipv6_link) {
 		assert(listcount(circuit->ipv6_link) == 0);
-		list_delete(circuit->ipv6_link);
+		list_delete_and_null(&circuit->ipv6_link);
 		circuit->ipv6_link = NULL;
 	}
 
 	if (circuit->ipv6_non_link) {
 		assert(listcount(circuit->ipv6_non_link) == 0);
-		list_delete(circuit->ipv6_non_link);
+		list_delete_and_null(&circuit->ipv6_non_link);
 		circuit->ipv6_non_link = NULL;
 	}
 
@@ -692,22 +692,22 @@ void isis_circuit_down(struct isis_circuit *circuit)
 	if (circuit->circ_type == CIRCUIT_T_BROADCAST) {
 		/* destroy neighbour lists */
 		if (circuit->u.bc.lan_neighs[0]) {
-			list_delete(circuit->u.bc.lan_neighs[0]);
+			list_delete_and_null(&circuit->u.bc.lan_neighs[0]);
 			circuit->u.bc.lan_neighs[0] = NULL;
 		}
 		if (circuit->u.bc.lan_neighs[1]) {
-			list_delete(circuit->u.bc.lan_neighs[1]);
+			list_delete_and_null(&circuit->u.bc.lan_neighs[1]);
 			circuit->u.bc.lan_neighs[1] = NULL;
 		}
 		/* destroy adjacency databases */
 		if (circuit->u.bc.adjdb[0]) {
 			circuit->u.bc.adjdb[0]->del = isis_delete_adj;
-			list_delete(circuit->u.bc.adjdb[0]);
+			list_delete_and_null(&circuit->u.bc.adjdb[0]);
 			circuit->u.bc.adjdb[0] = NULL;
 		}
 		if (circuit->u.bc.adjdb[1]) {
 			circuit->u.bc.adjdb[1]->del = isis_delete_adj;
-			list_delete(circuit->u.bc.adjdb[1]);
+			list_delete_and_null(&circuit->u.bc.adjdb[1]);
 			circuit->u.bc.adjdb[1] = NULL;
 		}
 		if (circuit->u.bc.is_dr[0]) {
@@ -745,8 +745,7 @@ void isis_circuit_down(struct isis_circuit *circuit)
 	THREAD_OFF(circuit->t_read);
 
 	if (circuit->lsp_queue) {
-		list_delete(circuit->lsp_queue);
-		circuit->lsp_queue = NULL;
+		list_delete_and_null(&circuit->lsp_queue);
 	}
 
 	if (circuit->lsp_hash) {

--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -135,7 +135,7 @@ int isis_dr_elect(struct isis_circuit *circuit, int level)
 
 	if (!adjdb) {
 		zlog_warn("isis_dr_elect() adjdb == NULL");
-		list_delete(list);
+		list_delete_and_null(&list);
 		return ISIS_WARNING;
 	}
 	isis_adj_build_up_list(adjdb, list);
@@ -177,7 +177,7 @@ int isis_dr_elect(struct isis_circuit *circuit, int level)
 		 */
 		if (circuit->u.bc.is_dr[level - 1])
 			retval = isis_dr_resign(circuit, level);
-		list_delete(list);
+		list_delete_and_null(&list);
 		return retval;
 	}
 
@@ -217,7 +217,7 @@ int isis_dr_elect(struct isis_circuit *circuit, int level)
 		if (circuit->u.bc.is_dr[level - 1])
 			retval = isis_dr_resign(circuit, level);
 	}
-	list_delete(list);
+	list_delete_and_null(&list);
 	return retval;
 }
 

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -132,10 +132,8 @@ static void circuit_resign_level(struct isis_circuit *circuit, int level)
 		THREAD_TIMER_OFF(circuit->u.bc.t_refresh_pseudo_lsp[idx]);
 		circuit->lsp_regenerate_pending[idx] = 0;
 		circuit->u.bc.run_dr_elect[idx] = 0;
-		if (circuit->u.bc.lan_neighs[idx] != NULL) {
-			list_delete(circuit->u.bc.lan_neighs[idx]);
-			circuit->u.bc.lan_neighs[idx] = NULL;
-		}
+		if (circuit->u.bc.lan_neighs[idx] != NULL)
+			list_delete_and_null(&circuit->u.bc.lan_neighs[idx]);
 	}
 
 	return;

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -126,7 +126,7 @@ static void lsp_destroy(struct isis_lsp *lsp)
 	lsp_clear_data(lsp);
 
 	if (LSP_FRAGMENT(lsp->hdr.lsp_id) == 0 && lsp->lspu.frags) {
-		list_delete(lsp->lspu.frags);
+		list_delete_and_null(&lsp->lspu.frags);
 		lsp->lspu.frags = NULL;
 	}
 
@@ -1143,7 +1143,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 		frag->tlvs = tlvs;
 	}
 
-	list_delete(fragments);
+	list_delete_and_null(&fragments);
 	lsp_debug("ISIS (%s): LSP construction is complete. Serializing...",
 		  area->area_tag);
 	return;
@@ -1521,7 +1521,7 @@ static void lsp_build_pseudo(struct isis_lsp *lsp, struct isis_circuit *circuit,
 				LSP_PSEUDO_ID(ne_id));
 		}
 	}
-	list_delete(adj_list);
+	list_delete_and_null(&adj_list);
 	return;
 }
 
@@ -1905,7 +1905,7 @@ int lsp_tick(struct thread *thread)
 		}
 	}
 
-	list_delete(lsp_list);
+	list_delete_and_null(&lsp_list);
 
 	return ISIS_OK;
 }

--- a/isisd/isis_mt.c
+++ b/isisd/isis_mt.c
@@ -151,8 +151,7 @@ void area_mt_init(struct isis_area *area)
 
 void area_mt_finish(struct isis_area *area)
 {
-	list_delete(area->mt_settings);
-	area->mt_settings = NULL;
+	list_delete_and_null(&area->mt_settings);
 }
 
 struct isis_area_mt_setting *area_get_mt_setting(struct isis_area *area,
@@ -275,8 +274,7 @@ void circuit_mt_init(struct isis_circuit *circuit)
 
 void circuit_mt_finish(struct isis_circuit *circuit)
 {
-	list_delete(circuit->mt_settings);
-	circuit->mt_settings = NULL;
+	list_delete_and_null(&circuit->mt_settings);
 }
 
 struct isis_circuit_mt_setting *

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -1292,7 +1292,7 @@ static int process_snp(uint8_t pdu_type, struct isis_circuit *circuit,
 		for (ALL_LIST_ELEMENTS_RO(lsp_list, node, lsp))
 			ISIS_SET_FLAG(lsp->SRMflags, circuit);
 		/* lets free it */
-		list_delete(lsp_list);
+		list_delete_and_null(&lsp_list);
 	}
 
 	retval = ISIS_OK;

--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -289,13 +289,13 @@ static void isis_route_info_delete(struct isis_route_info *route_info)
 	if (route_info->nexthops) {
 		route_info->nexthops->del =
 			(void (*)(void *))isis_nexthop_delete;
-		list_delete(route_info->nexthops);
+		list_delete_and_null(&route_info->nexthops);
 	}
 
 	if (route_info->nexthops6) {
 		route_info->nexthops6->del =
 			(void (*)(void *))isis_nexthop6_delete;
-		list_delete(route_info->nexthops6);
+		list_delete_and_null(&route_info->nexthops6);
 	}
 
 	XFREE(MTYPE_ISIS_ROUTE_INFO, route_info);

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -205,10 +205,8 @@ static void isis_vertex_queue_free(struct isis_vertex_queue *queue)
 	if (queue->insert_counter) {
 		skiplist_free(queue->l.slist);
 		queue->l.slist = NULL;
-	} else {
-		list_delete(queue->l.list);
-		queue->l.list = NULL;
-	}
+	} else
+		list_delete_and_null(&queue->l.list);
 }
 
 static unsigned int isis_vertex_queue_count(struct isis_vertex_queue *queue)
@@ -437,10 +435,8 @@ static struct isis_vertex *isis_vertex_new(void *id, enum vertextype vtype)
 
 static void isis_vertex_del(struct isis_vertex *vertex)
 {
-	list_delete(vertex->Adj_N);
-	vertex->Adj_N = NULL;
-	list_delete(vertex->parents);
-	vertex->parents = NULL;
+	list_delete_and_null(&vertex->Adj_N);
+	list_delete_and_null(&vertex->parents);
 
 	memset(vertex, 0, sizeof(struct isis_vertex));
 	XFREE(MTYPE_ISIS_VERTEX, vertex);
@@ -1038,7 +1034,7 @@ static int isis_spf_preload_tent(struct isis_spftree *spftree,
 			adjdb = circuit->u.bc.adjdb[spftree->level - 1];
 			isis_adj_build_up_list(adjdb, adj_list);
 			if (listcount(adj_list) == 0) {
-				list_delete(adj_list);
+				list_delete_and_null(&adj_list);
 				if (isis->debugs & DEBUG_SPF_EVENTS)
 					zlog_debug(
 						"ISIS-Spf: no L%d adjacencies on circuit %s",
@@ -1102,7 +1098,7 @@ static int isis_spf_preload_tent(struct isis_spftree *spftree,
 						"isis_spf_preload_tent unknow adj type");
 				}
 			}
-			list_delete(adj_list);
+			list_delete_and_null(&adj_list);
 			/*
 			 * Add the pseudonode
 			 */

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -2397,8 +2397,7 @@ struct list *isis_fragment_tlvs(struct isis_tlvs *tlvs, size_t size)
 		struct listnode *node;
 		for (ALL_LIST_ELEMENTS_RO(rv, node, fragment_tlvs))
 			isis_free_tlvs(fragment_tlvs);
-		list_delete(rv);
-		rv = NULL;
+		list_delete_and_null(&rv);
 	}
 
 	stream_free(dummy_stream);

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -220,8 +220,7 @@ int isis_area_destroy(struct vty *vty, const char *area_tag)
 			circuit->ipv6_router = 0;
 			isis_csm_state_change(ISIS_DISABLE, circuit, area);
 		}
-		list_delete(area->circuit_list);
-		area->circuit_list = NULL;
+		list_delete_and_null(&area->circuit_list);
 	}
 
 	if (area->lspdb[0] != NULL) {

--- a/lib/command.c
+++ b/lib/command.c
@@ -686,7 +686,7 @@ static vector cmd_complete_command_real(vector vline, struct vty *vty,
 	}
 
 	vector comps = completions_to_vec(completions);
-	list_delete(completions);
+	list_delete_and_null(&completions);
 
 	// set status code appropriately
 	switch (vector_active(comps)) {
@@ -1006,7 +1006,7 @@ static int cmd_execute_command_real(vector vline, enum filter_type filter,
 	// if matcher error, return corresponding CMD_ERR
 	if (MATCHER_ERROR(status)) {
 		if (argv_list)
-			list_delete(argv_list);
+			list_delete_and_null(&argv_list);
 		switch (status) {
 		case MATCHER_INCOMPLETE:
 			return CMD_ERR_INCOMPLETE;
@@ -1035,7 +1035,7 @@ static int cmd_execute_command_real(vector vline, enum filter_type filter,
 		ret = matched_element->func(matched_element, vty, argc, argv);
 
 	// delete list and cmd_token's in it
-	list_delete(argv_list);
+	list_delete_and_null(&argv_list);
 	XFREE(MTYPE_TMP, argv);
 
 	return ret;
@@ -2730,6 +2730,6 @@ void cmd_terminate()
 	if (host.config)
 		XFREE(MTYPE_HOST, host.config);
 
-	list_delete(varhandlers);
+	list_delete_and_null(&varhandlers);
 	qobj_finish();
 }

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -333,7 +333,7 @@ static enum matcher_rv command_match_r(struct graph_node *start, vector vline,
 		status = MATCHER_INCOMPLETE;
 
 	// cleanup
-	list_delete(next);
+	list_delete_and_null(&next);
 
 	return status;
 }
@@ -366,7 +366,7 @@ enum matcher_rv command_complete(struct graph *graph, vector vline,
 
 	unsigned int idx;
 	for (idx = 0; idx < vector_active(vline) && next->count > 0; idx++) {
-		list_delete(current);
+		list_delete_and_null(&current);
 		current = next;
 		next = list_new();
 		next->del = stack_del;
@@ -457,8 +457,8 @@ enum matcher_rv command_complete(struct graph *graph, vector vline,
 		}
 	}
 
-	list_delete(current);
-	list_delete(next);
+	list_delete_and_null(&current);
+	list_delete_and_null(&next);
 
 	return mrv;
 }
@@ -648,7 +648,7 @@ static void del_arglist(struct list *list)
 	list_delete_node(list, tail);
 
 	// delete the rest of the list as usual
-	list_delete(list);
+	list_delete_and_null(&list);
 }
 
 /*---------- token level matching functions ----------*/

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -141,7 +141,7 @@ DEFUN (grammar_test_complete,
 		vty_out(vty, "%% No match\n");
 
 	// free resources
-	list_delete(completions);
+	list_delete_and_null(&completions);
 	cmd_free_strvec(command);
 	XFREE(MTYPE_TMP, cmdstr);
 
@@ -185,7 +185,7 @@ DEFUN (grammar_test_match,
 
 		vty_out(vty, "func: %p\n", element->func);
 
-		list_delete(argvv);
+		list_delete_and_null(&argvv);
 	} else {
 		assert(MATCHER_ERROR(result));
 		switch (result) {
@@ -426,7 +426,7 @@ DEFUN (grammar_findambig,
 			}
 			prev = cur;
 		}
-		list_delete(commands);
+		list_delete_and_null(&commands);
 
 		vty_out(vty, "\n");
 	} while (scan && scannode < LINK_PARAMS_NODE);

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -318,8 +318,7 @@ void hash_free(struct hash *hash)
 		if (_hashes) {
 			listnode_delete(_hashes, hash);
 			if (_hashes->count == 0) {
-				list_delete(_hashes);
-				_hashes = NULL;
+				list_delete_and_null(&_hashes);
 			}
 		}
 	}

--- a/lib/if.c
+++ b/lib/if.c
@@ -191,8 +191,8 @@ void if_delete(struct interface *ifp)
 
 	if_delete_retain(ifp);
 
-	list_free(ifp->connected);
-	list_free(ifp->nbr_connected);
+	list_delete_and_null(&ifp->connected);
+	list_delete_and_null(&ifp->nbr_connected);
 
 	if_link_params_free(ifp);
 

--- a/lib/if.c
+++ b/lib/if.c
@@ -1095,8 +1095,7 @@ void if_terminate(struct list **intf_list)
 		if_delete(ifp);
 	}
 
-	list_delete(*intf_list);
-	*intf_list = NULL;
+	list_delete_and_null(intf_list);
 }
 
 const char *if_link_type_str(enum zebra_link_type llt)

--- a/lib/keychain.c
+++ b/lib/keychain.c
@@ -119,7 +119,7 @@ static void keychain_delete(struct keychain *keychain)
 	if (keychain->name)
 		XFREE(MTYPE_KEYCHAIN, keychain->name);
 
-	list_delete(keychain->key);
+	list_delete_and_null(&keychain->key);
 	listnode_delete(keychain_list, keychain);
 	keychain_free(keychain);
 }

--- a/lib/linklist.c
+++ b/lib/linklist.c
@@ -33,7 +33,7 @@ struct list *list_new(void)
 }
 
 /* Free list. */
-void list_free(struct list *l)
+static void list_free_internal(struct list *l)
 {
 	XFREE(MTYPE_LINK_LIST, l);
 }
@@ -252,7 +252,7 @@ void list_delete_and_null(struct list **list)
 {
 	assert(*list);
 	list_delete_all_node(*list);
-	list_free(*list);
+	list_free_internal(*list);
 	*list = NULL;
 }
 

--- a/lib/linklist.c
+++ b/lib/linklist.c
@@ -239,7 +239,7 @@ void list_delete_all_node(struct list *list)
 	assert(list);
 	for (node = list->head; node; node = next) {
 		next = node->next;
-		if (list->del)
+		if (*list->del)
 			(*list->del)(node->data);
 		listnode_free(node);
 	}
@@ -248,11 +248,17 @@ void list_delete_all_node(struct list *list)
 }
 
 /* Delete all listnode then free list itself. */
-void list_delete(struct list *list)
+void list_delete_and_null(struct list **list)
 {
-	assert(list);
-	list_delete_all_node(list);
-	list_free(list);
+	assert(*list);
+	list_delete_all_node(*list);
+	list_free(*list);
+	*list = NULL;
+}
+
+void list_delete_original(struct list *list)
+{
+	list_delete_and_null(&list);
 }
 
 /* Lookup the node which has given data. */

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -74,7 +74,20 @@ extern void listnode_delete(struct list *, void *);
 extern struct listnode *listnode_lookup(struct list *, void *);
 extern void *listnode_head(struct list *);
 
-extern void list_delete(struct list *);
+/*
+ * The usage of list_delete is being transitioned to pass in
+ * the double pointer to remove use after free's.
+ * In Oct of 2018, rename list_delete_and_null to list_delete
+ * and remove list_delete_original and the list_delete #define
+ */
+#if CONFDATE > 20181001
+CPP_NOTICE("list_delete without double pointer is deprecated, please fixup")
+#endif
+extern void list_delete_and_null(struct list **);
+extern void list_delete_original(struct list *);
+#define list_delete(X) list_delete_original((X))  \
+	CPP_WARN("Please transition to using list_delete_and_null")
+
 extern void list_delete_all_node(struct list *);
 
 /* For ospfd and ospf6d. */

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -61,7 +61,6 @@ struct list {
 /* Prototypes. */
 extern struct list *
 list_new(void); /* encouraged: set list.del callback on new lists */
-extern void list_free(struct list *);
 
 extern void listnode_add(struct list *, void *);
 extern void listnode_add_sort(struct list *, void *);
@@ -77,16 +76,22 @@ extern void *listnode_head(struct list *);
 /*
  * The usage of list_delete is being transitioned to pass in
  * the double pointer to remove use after free's.
+ * list_free usage is deprecated, it leads to memory leaks
+ * of the linklist nodes.  Please use list_delete_and_null
+ *
  * In Oct of 2018, rename list_delete_and_null to list_delete
  * and remove list_delete_original and the list_delete #define
+ * Additionally remove list_free entirely
  */
 #if CONFDATE > 20181001
 CPP_NOTICE("list_delete without double pointer is deprecated, please fixup")
 #endif
 extern void list_delete_and_null(struct list **);
 extern void list_delete_original(struct list *);
-#define list_delete(X) list_delete_original((X))  \
+#define list_delete(X) list_delete_original((X))			\
 	CPP_WARN("Please transition to using list_delete_and_null")
+#define list_free(X) list_delete_original((X))				\
+	CPP_WARN("Please transition tousing list_delete_and_null")
 
 extern void list_delete_all_node(struct list *);
 

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -554,8 +554,7 @@ void thread_master_free(struct thread_master *m)
 	{
 		listnode_delete(masters, m);
 		if (masters->count == 0) {
-			list_free(masters);
-			masters = NULL;
+			list_delete_and_null(&masters);
 		}
 	}
 	pthread_mutex_unlock(&masters_mtx);

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -570,7 +570,7 @@ void thread_master_free(struct thread_master *m)
 	pthread_cond_destroy(&m->cancel_cond);
 	close(m->io_pipe[0]);
 	close(m->io_pipe[1]);
-	list_delete(m->cancel_req);
+	list_delete_and_null(&m->cancel_req);
 	m->cancel_req = NULL;
 
 	hash_clean(m->cpu_record, cpu_record_hash_free);

--- a/lib/wheel.c
+++ b/lib/wheel.c
@@ -99,7 +99,7 @@ void wheel_delete(struct timer_wheel *wheel)
 	int i;
 
 	for (i = 0; i < wheel->slots; i++) {
-		list_delete(wheel->wheel_slot_lists[i]);
+		list_delete_and_null(&wheel->wheel_slot_lists[i]);
 	}
 
 	THREAD_OFF(wheel->timer);

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -123,8 +123,7 @@ void redist_del_instance(struct redist_proto *red, u_short instance)
 	XFREE(MTYPE_REDIST_INST, id);
 	if (!red->instances->count) {
 		red->enabled = 0;
-		list_free(red->instances);
-		red->instances = NULL;
+		list_delete_and_null(&red->instances);
 	}
 }
 

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -272,7 +272,7 @@ void ospf6_area_delete(struct ospf6_area *oa)
 	for (ALL_LIST_ELEMENTS_RO(oa->if_list, n, oi))
 		oi->area = NULL;
 
-	list_delete(oa->if_list);
+	list_delete_and_null(&oa->if_list);
 
 	ospf6_lsdb_delete(oa->lsdb);
 	ospf6_lsdb_delete(oa->lsdb_self);

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -242,7 +242,7 @@ void ospf6_interface_delete(struct ospf6_interface *oi)
 	for (ALL_LIST_ELEMENTS(oi->neighbor_list, node, nnode, on))
 		ospf6_neighbor_delete(on);
 
-	list_delete(oi->neighbor_list);
+	list_delete_and_null(&oi->neighbor_list);
 
 	THREAD_OFF(oi->thread_send_hello);
 	THREAD_OFF(oi->thread_send_lsupdate);

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -353,7 +353,7 @@ void ospf6_route_delete(struct ospf6_route *route)
 {
 	if (route) {
 		if (route->nh_list)
-			list_delete(route->nh_list);
+			list_delete_and_null(&route->nh_list);
 		XFREE(MTYPE_OSPF6_ROUTE, route);
 	}
 }

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -152,8 +152,8 @@ static struct ospf6_vertex *ospf6_vertex_create(struct ospf6_lsa *lsa)
 
 static void ospf6_vertex_delete(struct ospf6_vertex *v)
 {
-	list_delete(v->nh_list);
-	list_delete(v->child_list);
+	list_delete_and_null(&v->nh_list);
+	list_delete_and_null(&v->child_list);
 	XFREE(MTYPE_OSPF6_VERTEX, v);
 }
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -172,7 +172,7 @@ void ospf6_delete(struct ospf6 *o)
 		ospf6_area_delete(oa);
 
 
-	list_delete(o->area_list);
+	list_delete_and_null(&o->area_list);
 
 	ospf6_lsdb_delete(o->lsdb);
 	ospf6_lsdb_delete(o->lsdb_self);

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -180,7 +180,7 @@ void ospf_apiserver_term(void)
 
 	/* Free client list itself */
 	if (apiserver_list)
-		list_delete(apiserver_list);
+		list_delete_and_null(&apiserver_list);
 
 	/* Free wildcard list */
 	/* XXX  */

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -98,7 +98,7 @@ struct ospf_route *ospf_find_asbr_route(struct ospf *ospf,
 		}
 
 	if (chosen != rn->info)
-		list_delete(chosen);
+		list_delete_and_null(&chosen);
 
 	return best;
 }
@@ -761,7 +761,7 @@ void ospf_ase_external_lsas_finish(struct route_table *rt)
 		if ((lst = rn->info) != NULL) {
 			for (ALL_LIST_ELEMENTS(lst, node, nnode, lsa))
 				ospf_lsa_unlock(&lsa); /* external_lsas lst */
-			list_delete(lst);
+			list_delete_and_null(&lst);
 		}
 
 	route_table_finish(rt);

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -77,7 +77,7 @@ struct ospf_route *ospf_find_asbr_route(struct ospf *ospf,
 
 	/* If none is found -- look through all. */
 	if (listcount(chosen) == 0) {
-		list_free(chosen);
+		list_delete_and_null(&chosen);
 		chosen = rn->info;
 	}
 

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -313,10 +313,10 @@ void ospf_if_free(struct ospf_interface *oi)
 	route_table_finish(oi->ls_upd_queue);
 
 	/* Free any lists that should be freed */
-	list_free(oi->nbr_nbma);
+	list_delete_and_null(&oi->nbr_nbma);
 
-	list_free(oi->ls_ack);
-	list_free(oi->ls_ack_direct.ls_ack);
+	list_delete_and_null(&oi->ls_ack);
+	list_delete_and_null(&oi->ls_ack_direct.ls_ack);
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: ospf interface %s vrf %s id %u deleted",

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -509,7 +509,7 @@ static struct ospf_if_params *ospf_new_if_params(void)
 
 void ospf_del_if_params(struct ospf_if_params *oip)
 {
-	list_delete(oip->auth_crypt);
+	list_delete_and_null(&oip->auth_crypt);
 	bfd_info_free(&(oip->bfd_info));
 	XFREE(MTYPE_OSPF_IF_PARAMS, oip);
 }

--- a/ospfd/ospf_ism.c
+++ b/ospfd/ospf_ism.c
@@ -104,7 +104,7 @@ static struct ospf_neighbor *ospf_elect_dr(struct ospf_interface *oi,
 	else
 		DR(oi).s_addr = 0;
 
-	list_delete(dr_list);
+	list_delete_and_null(&dr_list);
 
 	return dr;
 }
@@ -144,8 +144,8 @@ static struct ospf_neighbor *ospf_elect_bdr(struct ospf_interface *oi,
 	else
 		BDR(oi).s_addr = 0;
 
-	list_delete(bdr_list);
-	list_delete(no_dr_list);
+	list_delete_and_null(&bdr_list);
+	list_delete_and_null(&no_dr_list);
 
 	return bdr;
 }
@@ -232,7 +232,7 @@ static int ospf_dr_election(struct ospf_interface *oi)
 		zlog_debug("DR-Election[2nd]: DR     %s", inet_ntoa(DR(oi)));
 	}
 
-	list_delete(el_list);
+	list_delete_and_null(&el_list);
 
 	/* if DR or BDR changes, cause AdjOK? neighbor event. */
 	if (!IPV4_ADDR_SAME(&old_dr, &DR(oi))

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3707,7 +3707,7 @@ int ospf_lsa_refresh_walker(struct thread *t)
 			&lsa); /* lsa_refresh_queue & temp for lsa_to_refresh*/
 	}
 
-	list_delete(lsa_to_refresh);
+	list_delete_and_null(&lsa_to_refresh);
 
 	if (IS_DEBUG_OSPF(lsa, LSA_REFRESH))
 		zlog_debug("LSA[Refresh]: ospf_lsa_refresh_walker(): end");

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3622,7 +3622,7 @@ void ospf_refresher_unregister_lsa(struct ospf *ospf, struct ospf_lsa *lsa)
 			ospf->lsa_refresh_queue.qs[lsa->refresh_list];
 		listnode_delete(refresh_list, lsa);
 		if (!listcount(refresh_list)) {
-			list_free(refresh_list);
+			list_delete_and_null(&refresh_list);
 			ospf->lsa_refresh_queue.qs[lsa->refresh_list] = NULL;
 		}
 		ospf_lsa_unlock(&lsa); /* lsa_refresh_queue */
@@ -3691,7 +3691,7 @@ int ospf_lsa_refresh_walker(struct thread *t)
 				lsa->refresh_list = -1;
 				listnode_add(lsa_to_refresh, lsa);
 			}
-			list_free(refresh_list);
+			list_delete_and_null(&refresh_list);
 		}
 	}
 

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -113,7 +113,7 @@ void ospf_opaque_term(void)
 int ospf_opaque_type9_lsa_init(struct ospf_interface *oi)
 {
 	if (oi->opaque_lsa_self != NULL)
-		list_delete(oi->opaque_lsa_self);
+		list_delete_and_null(&oi->opaque_lsa_self);
 
 	oi->opaque_lsa_self = list_new();
 	oi->opaque_lsa_self->del = free_opaque_info_per_type;
@@ -125,7 +125,7 @@ void ospf_opaque_type9_lsa_term(struct ospf_interface *oi)
 {
 	OSPF_TIMER_OFF(oi->t_opaque_lsa_self);
 	if (oi->opaque_lsa_self != NULL)
-		list_delete(oi->opaque_lsa_self);
+		list_delete_and_null(&oi->opaque_lsa_self);
 	oi->opaque_lsa_self = NULL;
 	return;
 }
@@ -133,7 +133,7 @@ void ospf_opaque_type9_lsa_term(struct ospf_interface *oi)
 int ospf_opaque_type10_lsa_init(struct ospf_area *area)
 {
 	if (area->opaque_lsa_self != NULL)
-		list_delete(area->opaque_lsa_self);
+		list_delete_and_null(&area->opaque_lsa_self);
 
 	area->opaque_lsa_self = list_new();
 	area->opaque_lsa_self->del = free_opaque_info_per_type;
@@ -154,15 +154,14 @@ void ospf_opaque_type10_lsa_term(struct ospf_area *area)
 
 	OSPF_TIMER_OFF(area->t_opaque_lsa_self);
 	if (area->opaque_lsa_self != NULL)
-		list_delete(area->opaque_lsa_self);
-	area->opaque_lsa_self = NULL;
+		list_delete_and_null(&area->opaque_lsa_self);
 	return;
 }
 
 int ospf_opaque_type11_lsa_init(struct ospf *top)
 {
 	if (top->opaque_lsa_self != NULL)
-		list_delete(top->opaque_lsa_self);
+		list_delete_and_null(&top->opaque_lsa_self);
 
 	top->opaque_lsa_self = list_new();
 	top->opaque_lsa_self->del = free_opaque_info_per_type;
@@ -183,8 +182,7 @@ void ospf_opaque_type11_lsa_term(struct ospf *top)
 
 	OSPF_TIMER_OFF(top->t_opaque_lsa_self);
 	if (top->opaque_lsa_self != NULL)
-		list_delete(top->opaque_lsa_self);
-	top->opaque_lsa_self = NULL;
+		list_delete_and_null(&top->opaque_lsa_self);
 	return;
 }
 
@@ -287,16 +285,16 @@ static void ospf_opaque_funclist_term(void)
 	struct list *funclist;
 
 	funclist = ospf_opaque_wildcard_funclist;
-	list_delete(funclist);
+	list_delete_and_null(&funclist);
 
 	funclist = ospf_opaque_type9_funclist;
-	list_delete(funclist);
+	list_delete_and_null(&funclist);
 
 	funclist = ospf_opaque_type10_funclist;
-	list_delete(funclist);
+	list_delete_and_null(&funclist);
 
 	funclist = ospf_opaque_type11_funclist;
-	list_delete(funclist);
+	list_delete_and_null(&funclist);
 	return;
 }
 
@@ -616,7 +614,7 @@ static void free_opaque_info_per_type(void *val)
 	}
 
 	OSPF_TIMER_OFF(oipt->t_opaque_lsa_self);
-	list_delete(oipt->id_list);
+	list_delete_and_null(&oipt->id_list);
 	XFREE(MTYPE_OPAQUE_INFO_PER_TYPE, oipt);
 	return;
 }

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1617,7 +1617,7 @@ static void ospf_ls_req(struct ip *iph, struct ospf_header *ospfh,
 
 		list_delete_and_null(&ls_upd);
 	} else
-		list_free(ls_upd);
+		list_delete_and_null(&ls_upd);
 }
 
 /* Get the list of LSAs from Link State Update packet.

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -188,11 +188,9 @@ static int ospf_router_info_unregister()
 void ospf_router_info_term(void)
 {
 
-	list_delete(OspfRI.pce_info.pce_domain);
-	list_delete(OspfRI.pce_info.pce_neighbor);
+	list_delete_and_null(&OspfRI.pce_info.pce_domain);
+	list_delete_and_null(&OspfRI.pce_info.pce_neighbor);
 
-	OspfRI.pce_info.pce_domain = NULL;
-	OspfRI.pce_info.pce_neighbor = NULL;
 	OspfRI.enabled = false;
 
 	ospf_router_info_unregister();

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -54,7 +54,7 @@ struct ospf_route *ospf_route_new()
 void ospf_route_free(struct ospf_route * or)
 {
 	if (or->paths)
-		list_delete(or->paths);
+		list_delete_and_null(&or->paths);
 
 	XFREE(MTYPE_OSPF_ROUTE, or);
 }
@@ -902,7 +902,7 @@ void ospf_prune_unreachable_routers(struct route_table *rtrs)
 				zlog_debug("Pruning router node %s",
 					   inet_ntoa(rn->p.u.prefix4));
 
-			list_delete(paths);
+			list_delete_and_null(&paths);
 			rn->info = NULL;
 			route_unlock_node(rn);
 		}

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -210,12 +210,10 @@ static void ospf_vertex_free(void *data)
 	// assert (listcount (v->parents) == 0);
 
 	if (v->children)
-		list_delete(v->children);
-	v->children = NULL;
+		list_delete_and_null(&v->children);
 
 	if (v->parents)
-		list_delete(v->parents);
-	v->parents = NULL;
+		list_delete_and_null(&v->parents);
 
 	v->lsa = NULL;
 
@@ -1089,7 +1087,7 @@ void ospf_rtrs_free(struct route_table *rtrs)
 			for (ALL_LIST_ELEMENTS(or_list, node, nnode, or))
 				ospf_route_free(or);
 
-			list_delete(or_list);
+			list_delete_and_null(&or_list);
 
 			/* Unlock the node. */
 			rn->info = NULL;

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -166,8 +166,7 @@ static int ospf_mpls_te_unregister()
 
 void ospf_mpls_te_term(void)
 {
-	list_delete(OspfMplsTE.iflist);
-	OspfMplsTE.iflist = NULL;
+	list_delete_and_null(&OspfMplsTE.iflist);
 
 	ospf_delete_opaque_functab(OSPF_OPAQUE_AREA_LSA,
 				   OPAQUE_TYPE_TRAFFIC_ENGINEERING_LSA);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -574,8 +574,7 @@ void ospf_external_del(u_char type, u_short instance)
 
 		listnode_delete(om->external[type], ext);
 		if (!om->external[type]->count) {
-			list_free(om->external[type]);
-			om->external[type] = NULL;
+			list_delete_and_null(&om->external[type]);
 		}
 		XFREE(MTYPE_OSPF_EXTERNAL, ext);
 	}
@@ -633,8 +632,7 @@ void ospf_redist_del(struct ospf *ospf, u_char type, u_short instance)
 	if (red) {
 		listnode_delete(ospf->redist[type], red);
 		if (!ospf->redist[type]->count) {
-			list_free(ospf->redist[type]);
-			ospf->redist[type] = NULL;
+			list_delete_and_null(&ospf->redist[type]);
 		}
 		ospf_routemap_unset(red);
 		XFREE(MTYPE_OSPF_REDISTRIBUTE, red);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -620,7 +620,7 @@ static void ospf_finish_final(struct ospf *ospf)
 	for (ALL_LIST_ELEMENTS(ospf->vlinks, node, nnode, vl_data))
 		ospf_vl_delete(ospf, vl_data);
 
-	list_delete(ospf->vlinks);
+	list_delete_and_null(&ospf->vlinks);
 
 	/* Remove any ospf interface config params */
 	for (ALL_LIST_ELEMENTS_RO(vrf_iflist(ospf->vrf_id), node, ifp)) {
@@ -734,9 +734,9 @@ static void ospf_finish_final(struct ospf *ospf)
 		ospf_ase_external_lsas_finish(ospf->external_lsas);
 	}
 
-	list_delete(ospf->areas);
-	list_delete(ospf->oi_write_q);
-	list_delete(ospf->oiflist);
+	list_delete_and_null(&ospf->areas);
+	list_delete_and_null(&ospf->oi_write_q);
+	list_delete_and_null(&ospf->oiflist);
 
 	for (i = ZEBRA_ROUTE_SYSTEM; i <= ZEBRA_ROUTE_MAX; i++) {
 		struct list *ext_list;
@@ -852,7 +852,7 @@ static void ospf_area_free(struct ospf_area *area)
 	ospf_lsa_unlock(&area->router_lsa_self);
 
 	route_table_finish(area->ranges);
-	list_delete(area->oiflist);
+	list_delete_and_null(&area->oiflist);
 
 	if (EXPORT_NAME(area))
 		free(EXPORT_NAME(area));
@@ -1276,7 +1276,7 @@ void ospf_ls_upd_queue_empty(struct ospf_interface *oi)
 		if ((lst = (struct list *)rn->info)) {
 			for (ALL_LIST_ELEMENTS(lst, node, nnode, lsa))
 				ospf_lsa_unlock(&lsa); /* oi->ls_upd_queue */
-			list_delete(lst);
+			list_delete_and_null(&lst);
 			rn->info = NULL;
 		}
 

--- a/pimd/pim_hello.c
+++ b/pimd/pim_hello.c
@@ -125,9 +125,9 @@ static void tlv_trace_list(const char *label, const char *tlv_name,
 	}
 }
 
-#define FREE_ADDR_LIST                                                         \
-	if (hello_option_addr_list) {                                          \
-		list_delete(hello_option_addr_list);                           \
+#define FREE_ADDR_LIST							\
+	if (hello_option_addr_list) {					\
+		list_delete_and_null(&hello_option_addr_list);		\
 	}
 
 #define FREE_ADDR_LIST_THEN_RETURN(code)                                       \

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -71,19 +71,19 @@ static void *if_list_clean(struct pim_interface *pim_ifp)
 	struct pim_ifchannel *ch;
 
 	if (pim_ifp->igmp_join_list)
-		list_delete(pim_ifp->igmp_join_list);
+		list_delete_and_null(&pim_ifp->igmp_join_list);
 
 	if (pim_ifp->igmp_socket_list)
-		list_delete(pim_ifp->igmp_socket_list);
+		list_delete_and_null(&pim_ifp->igmp_socket_list);
 
 	if (pim_ifp->pim_neighbor_list)
-		list_delete(pim_ifp->pim_neighbor_list);
+		list_delete_and_null(&pim_ifp->pim_neighbor_list);
 
 	if (pim_ifp->upstream_switch_list)
-		list_delete(pim_ifp->upstream_switch_list);
+		list_delete_and_null(&pim_ifp->upstream_switch_list);
 
 	if (pim_ifp->sec_addr_list)
-		list_delete(pim_ifp->sec_addr_list);
+		list_delete_and_null(&pim_ifp->sec_addr_list);
 
 	while ((ch = RB_ROOT(pim_ifchannel_rb,
 			     &pim_ifp->ifchannel_rb)) != NULL)
@@ -241,10 +241,10 @@ void pim_if_delete(struct interface *ifp)
 
 	pim_if_del_vif(ifp);
 
-	list_delete(pim_ifp->igmp_socket_list);
-	list_delete(pim_ifp->pim_neighbor_list);
-	list_delete(pim_ifp->upstream_switch_list);
-	list_delete(pim_ifp->sec_addr_list);
+	list_delete_and_null(&pim_ifp->igmp_socket_list);
+	list_delete_and_null(&pim_ifp->pim_neighbor_list);
+	list_delete_and_null(&pim_ifp->upstream_switch_list);
+	list_delete_and_null(&pim_ifp->sec_addr_list);
 
 	if (pim_ifp->boundary_oil_plist)
 		XFREE(MTYPE_PIM_INTERFACE, pim_ifp->boundary_oil_plist);
@@ -1373,7 +1373,7 @@ int pim_if_igmp_join_del(struct interface *ifp, struct in_addr group_addr,
 	listnode_delete(pim_ifp->igmp_join_list, ij);
 	igmp_join_free(ij);
 	if (listcount(pim_ifp->igmp_join_list) < 1) {
-		list_delete(pim_ifp->igmp_join_list);
+		list_delete_and_null(&pim_ifp->igmp_join_list);
 		pim_ifp->igmp_join_list = 0;
 	}
 

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -169,7 +169,7 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 	pim_ifchannel_remove_children(ch);
 
 	if (ch->sources)
-		list_delete(ch->sources);
+		list_delete_and_null(&ch->sources);
 
 	listnode_delete(ch->upstream->ifchannels, ch);
 
@@ -571,7 +571,7 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp,
 
 		pim_ifchannel_remove_children(ch);
 		if (ch->sources)
-			list_delete(ch->sources);
+			list_delete_and_null(&ch->sources);
 
 		THREAD_OFF(ch->t_ifjoin_expiry_timer);
 		THREAD_OFF(ch->t_ifjoin_prune_pending_timer);

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -696,7 +696,7 @@ void igmp_startup_mode_on(struct igmp_sock *igmp)
 
 static void igmp_group_free(struct igmp_group *group)
 {
-	list_delete(group->group_source_list);
+	list_delete_and_null(&group->group_source_list);
 
 	XFREE(MTYPE_PIM_IGMP_GROUP, group);
 }
@@ -748,7 +748,7 @@ void igmp_sock_free(struct igmp_sock *igmp)
 	zassert(igmp->igmp_group_list);
 	zassert(!listcount(igmp->igmp_group_list));
 
-	list_delete(igmp->igmp_group_list);
+	list_delete_and_null(&igmp->igmp_group_list);
 	hash_free(igmp->igmp_group_hash);
 
 	XFREE(MTYPE_PIM_IGMP_SOCKET, igmp);

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -48,7 +48,7 @@ static void pim_instance_terminate(struct pim_instance *pim)
 	}
 
 	if (pim->static_routes)
-		list_delete(pim->static_routes);
+		list_delete_and_null(&pim->static_routes);
 
 	pim_rp_free(pim);
 

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -32,7 +32,7 @@
 
 void pim_jp_agg_group_list_free(struct pim_jp_agg_group *jag)
 {
-	list_delete(jag->sources);
+	list_delete_and_null(&jag->sources);
 
 	XFREE(MTYPE_PIM_JP_AGG_GROUP, jag);
 }
@@ -108,8 +108,7 @@ void pim_jp_agg_clear_group(struct list *group)
 			js->up = NULL;
 			XFREE(MTYPE_PIM_JP_AGG_SOURCE, js);
 		}
-		list_delete(jag->sources);
-		jag->sources = NULL;
+		list_delete_and_null(&jag->sources);
 		listnode_delete(group, jag);
 		XFREE(MTYPE_PIM_JP_AGG_GROUP, jag);
 	}
@@ -169,8 +168,7 @@ void pim_jp_agg_remove_group(struct list *group, struct pim_upstream *up)
 	}
 
 	if (jag->sources->count == 0) {
-		list_delete(jag->sources);
-		jag->sources = NULL;
+		list_delete_and_null(&jag->sources);
 		listnode_delete(group, jag);
 		XFREE(MTYPE_PIM_JP_AGG_GROUP, jag);
 	}

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1261,7 +1261,7 @@ static void pim_msdp_mg_free(struct pim_instance *pim, struct pim_msdp_mg *mg)
 		XFREE(MTYPE_PIM_MSDP_MG_NAME, mg->mesh_group_name);
 
 	if (mg->mbr_list)
-		list_delete(mg->mbr_list);
+		list_delete_and_null(&mg->mbr_list);
 
 	XFREE(MTYPE_PIM_MSDP_MG, mg);
 	pim->msdp.mg = NULL;
@@ -1619,8 +1619,7 @@ void pim_msdp_exit(struct pim_instance *pim)
 	}
 
 	if (pim->msdp.peer_list) {
-		list_delete(pim->msdp.peer_list);
-		pim->msdp.peer_list = NULL;
+		list_delete_and_null(&pim->msdp.peer_list);
 	}
 
 	if (pim->msdp.sa_hash) {
@@ -1629,7 +1628,6 @@ void pim_msdp_exit(struct pim_instance *pim)
 	}
 
 	if (pim->msdp.sa_list) {
-		list_delete(pim->msdp.sa_list);
-		pim->msdp.sa_list = NULL;
+		list_delete_and_null(&pim->msdp.sa_list);
 	}
 }

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -401,8 +401,7 @@ static void delete_prefix_list(struct pim_neighbor *neigh)
 		}
 #endif
 
-		list_delete(neigh->prefix_list);
-		neigh->prefix_list = 0;
+		list_delete_and_null(&neigh->prefix_list);
 	}
 }
 
@@ -412,7 +411,7 @@ void pim_neighbor_free(struct pim_neighbor *neigh)
 
 	delete_prefix_list(neigh);
 
-	list_delete(neigh->upstream_jp_agg);
+	list_delete_and_null(&neigh->upstream_jp_agg);
 	THREAD_OFF(neigh->jp_timer);
 
 	XFREE(MTYPE_PIM_NEIGHBOR, neigh);

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -236,7 +236,7 @@ void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
 			pim_sendmsg_zebra_rnh(pim, zclient, pnc,
 					      ZEBRA_NEXTHOP_UNREGISTER);
 
-			list_delete(pnc->rp_list);
+			list_delete_and_null(&pnc->rp_list);
 			hash_free(pnc->upstream_hash);
 
 			hash_release(pim->rpf_hash, pnc);

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -123,8 +123,7 @@ void pim_oil_init(struct pim_instance *pim)
 void pim_oil_terminate(struct pim_instance *pim)
 {
 	if (pim->channel_oil_list)
-		list_delete(pim->channel_oil_list);
-	pim->channel_oil_list = NULL;
+		list_delete_and_null(&pim->channel_oil_list);
 
 	if (pim->channel_oil_hash)
 		hash_free(pim->channel_oil_hash);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -51,8 +51,7 @@ void pim_rp_list_hash_clean(void *data)
 {
 	struct pim_nexthop_cache *pnc = (struct pim_nexthop_cache *)data;
 
-	list_delete(pnc->rp_list);
-	pnc->rp_list = NULL;
+	list_delete_and_null(&pnc->rp_list);
 
 	hash_clean(pnc->upstream_hash, NULL);
 	hash_free(pnc->upstream_hash);
@@ -110,7 +109,7 @@ void pim_rp_init(struct pim_instance *pim)
 	pim->rp_table = route_table_init();
 	if (!pim->rp_table) {
 		zlog_err("Unable to alloc rp_table");
-		list_delete(pim->rp_list);
+		list_delete_and_null(&pim->rp_list);
 		return;
 	}
 
@@ -119,13 +118,13 @@ void pim_rp_init(struct pim_instance *pim)
 	if (!rp_info) {
 		zlog_err("Unable to alloc rp_info");
 		route_table_finish(pim->rp_table);
-		list_delete(pim->rp_list);
+		list_delete_and_null(&pim->rp_list);
 		return;
 	}
 
 	if (!str2prefix("224.0.0.0/4", &rp_info->group)) {
 		zlog_err("Unable to convert 224.0.0.0/4 to prefix");
-		list_delete(pim->rp_list);
+		list_delete_and_null(&pim->rp_list);
 		route_table_finish(pim->rp_table);
 		XFREE(MTYPE_PIM_RP, rp_info);
 		return;
@@ -140,7 +139,7 @@ void pim_rp_init(struct pim_instance *pim)
 	rn = route_node_get(pim->rp_table, &rp_info->group);
 	if (!rn) {
 		zlog_err("Failure to get route node for pim->rp_table");
-		list_delete(pim->rp_list);
+		list_delete_and_null(&pim->rp_list);
 		route_table_finish(pim->rp_table);
 		XFREE(MTYPE_PIM_RP, rp_info);
 		return;
@@ -155,8 +154,7 @@ void pim_rp_init(struct pim_instance *pim)
 void pim_rp_free(struct pim_instance *pim)
 {
 	if (pim->rp_list)
-		list_delete(pim->rp_list);
-	pim->rp_list = NULL;
+		list_delete_and_null(&pim->rp_list);
 }
 
 /*

--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -50,10 +50,8 @@ void pim_ssmpingd_init(struct pim_instance *pim)
 
 void pim_ssmpingd_destroy(struct pim_instance *pim)
 {
-	if (pim->ssmpingd_list) {
-		list_delete(pim->ssmpingd_list);
-		pim->ssmpingd_list = 0;
-	}
+	if (pim->ssmpingd_list)
+		list_delete_and_null(&pim->ssmpingd_list);
 }
 
 static struct ssmpingd_sock *ssmpingd_find(struct pim_instance *pim,

--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -654,12 +654,12 @@ int pim_parse_addr_source(struct prefix_sg *sg, uint8_t *flags,
 	return addr - buf;
 }
 
-#define FREE_ADDR_LIST(hello_option_addr_list)                                 \
-	{                                                                      \
-		if (hello_option_addr_list) {                                  \
-			list_delete(hello_option_addr_list);                   \
-			hello_option_addr_list = 0;                            \
-		}                                                              \
+#define FREE_ADDR_LIST(hello_option_addr_list)				\
+	{								\
+		if (hello_option_addr_list) {				\
+			list_delete_and_null(&hello_option_addr_list);	\
+			hello_option_addr_list = 0;			\
+		}							\
 	}
 
 int pim_tlv_parse_addr_list(const char *ifname, struct in_addr src_addr,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -82,8 +82,7 @@ static void pim_upstream_remove_children(struct pim_instance *pim,
 		if (child)
 			child->parent = NULL;
 	}
-	list_delete(up->sources);
-	up->sources = NULL;
+	list_delete_and_null(&up->sources);
 }
 
 /*
@@ -203,13 +202,12 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 
 	pim_upstream_remove_children(pim, up);
 	if (up->sources)
-		list_delete(up->sources);
-	up->sources = NULL;
+		list_delete_and_null(&up->sources);
+
 	pim_mroute_del(up->channel_oil, __PRETTY_FUNCTION__);
 	upstream_channel_oil_detach(up);
 
-	list_delete(up->ifchannels);
-	up->ifchannels = NULL;
+	list_delete_and_null(&up->ifchannels);
 
 	/*
 	  notice that listnode_delete() can't be moved
@@ -696,9 +694,9 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 
 		pim_upstream_remove_children(pim, up);
 		if (up->sources)
-			list_delete(up->sources);
+			list_delete_and_null(&up->sources);
 
-		list_delete(up->ifchannels);
+		list_delete_and_null(&up->ifchannels);
 
 		hash_release(pim->upstream_hash, up);
 		XFREE(MTYPE_PIM_UPSTREAM, up);
@@ -1548,8 +1546,7 @@ unsigned int pim_upstream_hash_key(void *arg)
 void pim_upstream_terminate(struct pim_instance *pim)
 {
 	if (pim->upstream_list)
-		list_delete(pim->upstream_list);
-	pim->upstream_list = NULL;
+		list_delete_and_null(&pim->upstream_list);
 
 	if (pim->upstream_hash)
 		hash_free(pim->upstream_hash);

--- a/ripd/rip_offset.c
+++ b/ripd/rip_offset.c
@@ -363,7 +363,7 @@ void rip_offset_init()
 
 void rip_offset_clean()
 {
-	list_delete(rip_offset_list_master);
+	list_delete_and_null(&rip_offset_list_master);
 
 	rip_offset_list_master = list_new();
 	rip_offset_list_master->cmp = (int (*)(void *, void *))offset_list_cmp;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -132,8 +132,7 @@ static int rip_garbage_collect(struct thread *t)
 	/* Unlock route_node. */
 	listnode_delete(rp->info, rinfo);
 	if (list_isempty((struct list *)rp->info)) {
-		list_free(rp->info);
-		rp->info = NULL;
+		list_delete_and_null((struct list **)&rp->info);
 		route_unlock_node(rp);
 	}
 

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3809,7 +3809,7 @@ void rip_clean(void)
 					RIP_TIMER_OFF(rinfo->t_garbage_collect);
 					rip_info_free(rinfo);
 				}
-				list_delete(list);
+				list_delete_and_null(&list);
 				rp->info = NULL;
 				route_unlock_node(rp);
 			}

--- a/ripngd/ripng_nexthop.c
+++ b/ripngd/ripng_nexthop.c
@@ -72,7 +72,7 @@ struct list *ripng_rte_new(void)
 
 void ripng_rte_free(struct list *ripng_rte_list)
 {
-	list_delete(ripng_rte_list);
+	list_delete_and_null(&ripng_rte_list);
 }
 
 /* Delete RTE */

--- a/ripngd/ripng_offset.c
+++ b/ripngd/ripng_offset.c
@@ -375,7 +375,7 @@ void ripng_offset_init(void)
 
 void ripng_offset_clean(void)
 {
-	list_delete(ripng_offset_list_master);
+	list_delete_and_null(&ripng_offset_list_master);
 
 	ripng_offset_list_master = list_new();
 	ripng_offset_list_master->cmp =

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -407,8 +407,7 @@ static int ripng_garbage_collect(struct thread *t)
 	/* Unlock route_node. */
 	listnode_delete(rp->info, rinfo);
 	if (list_isempty((struct list *)rp->info)) {
-		list_free(rp->info);
-		rp->info = NULL;
+		list_delete_and_null((struct list **)&rp->info);
 		route_unlock_node(rp);
 	}
 
@@ -2150,7 +2149,7 @@ DEFUN (clear_ipv6_rip,
 		}
 
 		if (list_isempty(list)) {
-			list_free(list);
+			list_delete_and_null(&list);
 			rp->info = NULL;
 			route_unlock_node(rp);
 		}

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2829,7 +2829,7 @@ void ripng_clean()
 						rinfo->t_garbage_collect);
 					ripng_info_free(rinfo);
 				}
-				list_delete(list);
+				list_delete_and_null(&list);
 				rp->info = NULL;
 				route_unlock_node(rp);
 			}

--- a/tests/isisd/test_fuzz_isis_tlv.c
+++ b/tests/isisd/test_fuzz_isis_tlv.c
@@ -166,7 +166,7 @@ static int test(FILE *input, FILE *output)
 		sbuf_push(&fragment_format, 0, "%s", isis_format_tlvs(tlvs));
 		isis_free_tlvs(tlvs);
 	}
-	list_delete(fragments);
+	list_delete_and_null(&fragments);
 	stream_free(s);
 
 	char *fragment_content = sortlines((char *)sbuf_buf(&fragment_format));

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -73,7 +73,7 @@ static int config_cmp(struct config *c1, struct config *c2)
 
 static void config_del(struct config *config)
 {
-	list_delete(config->line);
+	list_delete_and_null(&config->line);
 	if (config->name)
 		XFREE(MTYPE_VTYSH_CONFIG_LINE, config->name);
 	XFREE(MTYPE_VTYSH_CONFIG, config);
@@ -365,7 +365,7 @@ void vtysh_config_dump(FILE *fp)
 
 	for (i = 0; i < vector_active(configvec); i++)
 		if ((master = vector_slot(configvec, i)) != NULL) {
-			list_delete(master);
+			list_delete_and_null(&master);
 			vector_slot(configvec, i) = NULL;
 		}
 	list_delete_all_node(config_top);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -138,7 +138,7 @@ static int if_zebra_delete_hook(struct interface *ifp)
 		struct rtadvconf *rtadv;
 
 		rtadv = &zebra_if->rtadv;
-		list_free(rtadv->AdvPrefixList);
+		list_delete_and_null(&rtadv->AdvPrefixList);
 #endif /* HAVE_RTADV */
 
 		XFREE(MTYPE_TMP, zebra_if);
@@ -322,7 +322,7 @@ int if_subnet_delete(struct interface *ifp, struct connected *ifc)
 	}
 
 	/* Otherwise, free list and route node. */
-	list_free(addr_list);
+	list_delete_and_null(&addr_list);
 	rn->info = NULL;
 	route_unlock_node(rn);
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -64,7 +64,7 @@ static void zebra_if_node_destroy(route_table_delegate_t *delegate,
 				  struct route_node *node)
 {
 	if (node->info)
-		list_delete(node->info);
+		list_delete_and_null((struct list **)&node->info);
 	route_node_destroy(delegate, table, node);
 }
 
@@ -627,7 +627,7 @@ static void if_delete_connected(struct interface *ifp)
 				}
 
 				/* Free chain list and respective route node. */
-				list_delete(addr_list);
+				list_delete_and_null(&addr_list);
 				rn->info = NULL;
 				route_unlock_node(rn);
 			} else if (cp.family == AF_INET6) {

--- a/zebra/irdp_interface.c
+++ b/zebra/irdp_interface.c
@@ -311,8 +311,7 @@ static void irdp_if_stop(struct interface *ifp)
 
 	irdp_advert_off(ifp);
 
-	list_delete(irdp->AdvPrefList);
-	irdp->AdvPrefList = NULL;
+	list_delete_and_null(&irdp->AdvPrefList);
 
 	irdp->flags = 0;
 }

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -375,5 +375,5 @@ int release_daemon_chunks(u_char proto, u_short instance)
 
 void label_manager_close()
 {
-	list_delete(lbl_mgr.lc_list);
+	list_delete_and_null(&lbl_mgr.lc_list);
 }

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -145,7 +145,7 @@ static void sigint(void)
 	prefix_list_reset();
 	route_map_finish();
 
-	list_delete(zebrad.client_list);
+	list_delete_and_null(&zebrad.client_list);
 	work_queue_free(zebrad.ribq);
 	if (zebrad.lsp_process_q)
 		work_queue_free(zebrad.lsp_process_q);

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2701,7 +2701,7 @@ void zebra_mpls_print_lsp_table(struct vty *vty, struct zebra_vrf *zvrf,
 		vty_out(vty, "\n");
 	}
 
-	list_delete(lsp_list);
+	list_delete_and_null(&lsp_list);
 }
 
 /*
@@ -2740,7 +2740,7 @@ int zebra_mpls_write_lsp_config(struct vty *vty, struct zebra_vrf *zvrf)
 		}
 	}
 
-	list_delete(slsp_list);
+	list_delete_and_null(&slsp_list);
 	return (zvrf->slsp_table->count ? 1 : 0);
 }
 

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -554,7 +554,7 @@ static zebra_fec_t *fec_add(struct route_table *table, struct prefix *p,
  */
 static int fec_del(zebra_fec_t *fec)
 {
-	list_free(fec->client_list);
+	list_delete_and_null(&fec->client_list);
 	fec->rn->info = NULL;
 	route_unlock_node(fec->rn);
 	XFREE(MTYPE_FEC, fec);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1875,7 +1875,7 @@ void meta_queue_free(struct meta_queue *mq)
 	unsigned i;
 
 	for (i = 0; i < MQ_SIZE; i++)
-		list_delete(mq->subq[i]);
+		list_delete_and_null(&mq->subq[i]);
 
 	XFREE(MTYPE_WORK_QUEUE, mq);
 }

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -160,9 +160,9 @@ struct rnh *zebra_lookup_rnh(struct prefix *p, vrf_id_t vrfid, rnh_type_t type)
 void zebra_free_rnh(struct rnh *rnh)
 {
 	rnh->flags |= ZEBRA_NHT_DELETED;
-	list_free(rnh->client_list);
-	list_free(rnh->zebra_static_route_list);
-	list_free(rnh->zebra_pseudowire_list);
+	list_delete_and_null(&rnh->client_list);
+	list_delete_and_null(&rnh->zebra_static_route_list);
+	list_delete_and_null(&rnh->zebra_pseudowire_list);
 	free_state(rnh->vrf_id, rnh->state, rnh->node);
 	XFREE(MTYPE_RNH, rnh);
 }

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1587,7 +1587,7 @@ static int zvni_mac_del(zebra_vni_t *zvni, zebra_mac_t *mac)
 {
 	zebra_mac_t *tmp_mac;
 
-	list_delete(mac->neigh_list);
+	list_delete_and_null(&mac->neigh_list);
 
 	/* Free the VNI hash entry and allocated memory. */
 	tmp_mac = hash_release(zvni->mac_table, mac);


### PR DESCRIPTION
The linklist api has these two functions:

1) list_delete -> The pointer being freed was not implicitly null'ing the list pointer.  As such we keep rnning across instance of people using a list after free causing a crash.  By changing to this we will force a crash in development( hopefully ) or it will be abundantly clear what has gone wrong

2) list_free -> The `struct list *` was being freed, but the individual linklist nodes were not being freed.  This function, I imagine, was a 'cheat' function to be used when you knew the linklist was empty.  The problem of course is that people searching in linklist.h ran across list_free before list_delete and used the wrong one, leaving memory orphaned.  Only provide one api to remove the link list.