### PR TITLE
ldpd: add more filtering options in some "show" commands

### DIFF
--- a/ldpd/adjacency.c
+++ b/ldpd/adjacency.c
@@ -60,11 +60,11 @@ adj_compare(const struct adj *a, const struct adj *b)
 
 	switch (a->source.type) {
 	case HELLO_LINK:
-		if (strcmp(a->source.link.ia->iface->name,
-		    b->source.link.ia->iface->name) < 0)
+		if (if_cmp_name_func((char *)a->source.link.ia->iface->name,
+		    (char *)b->source.link.ia->iface->name) < 0)
 			return (-1);
-		if (strcmp(a->source.link.ia->iface->name,
-		    b->source.link.ia->iface->name) > 0)
+		if (if_cmp_name_func((char *)a->source.link.ia->iface->name,
+		    (char *)b->source.link.ia->iface->name) > 0)
 			return (1);
 		return (ldp_addrcmp(a->source.link.ia->af,
 		    &a->source.link.src_addr, &b->source.link.src_addr));

--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -45,7 +45,7 @@ RB_GENERATE(iface_head, iface, entry, iface_compare)
 static __inline int
 iface_compare(const struct iface *a, const struct iface *b)
 {
-	return (strcmp(a->name, b->name));
+	return (if_cmp_name_func((char *)a->name, (char *)b->name));
 }
 
 struct iface *

--- a/ldpd/l2vpn.c
+++ b/ldpd/l2vpn.c
@@ -114,7 +114,7 @@ l2vpn_exit(struct l2vpn *l2vpn)
 static __inline int
 l2vpn_if_compare(const struct l2vpn_if *a, const struct l2vpn_if *b)
 {
-	return (strcmp(a->ifname, b->ifname));
+	return (if_cmp_name_func((char *)a->ifname, (char *)b->ifname));
 }
 
 struct l2vpn_if *
@@ -177,7 +177,7 @@ l2vpn_if_update(struct l2vpn_if *lif)
 static __inline int
 l2vpn_pw_compare(const struct l2vpn_pw *a, const struct l2vpn_pw *b)
 {
-	return (strcmp(a->ifname, b->ifname));
+	return (if_cmp_name_func((char *)a->ifname, (char *)b->ifname));
 }
 
 struct l2vpn_pw *

--- a/ldpd/ldp_vty.h
+++ b/ldpd/ldp_vty.h
@@ -69,13 +69,16 @@ int	 ldp_vty_l2vpn_pw_pwid(struct vty *, const char *, long);
 int	 ldp_vty_l2vpn_pw_pwstatus(struct vty *, const char *);
 int	 ldp_vty_clear_nbr(struct vty *, const char *);
 int	 ldp_vty_debug(struct vty *, const char *, const char *, const char *, const char *);
-int	 ldp_vty_show_binding(struct vty *, const char *, const char *, const char *);
+int	 ldp_vty_show_binding(struct vty *, const char *, const char *, int,
+	    const char *, unsigned long, unsigned long, const char *, const char *);
 int	 ldp_vty_show_discovery(struct vty *, const char *, const char *, const char *);
 int	 ldp_vty_show_interface(struct vty *, const char *, const char *);
 int	 ldp_vty_show_capabilities(struct vty *, const char *);
-int	 ldp_vty_show_neighbor(struct vty *, int, const char *, const char *);
-int	 ldp_vty_show_atom_binding(struct vty *, const char *);
-int	 ldp_vty_show_atom_vc(struct vty *, const char *);
+int	 ldp_vty_show_neighbor(struct vty *, const char *, int, const char *, const char *);
+int	 ldp_vty_show_atom_binding(struct vty *, const char *, unsigned long,
+	    unsigned long, const char *);
+int	 ldp_vty_show_atom_vc(struct vty *, const char *, const char *,
+	    const char *, const char *);
 int	 ldp_vty_show_debugging(struct vty *);
 
 void	 ldp_vty_init(void);

--- a/ldpd/ldp_vty_cmds.c
+++ b/ldpd/ldp_vty_cmds.c
@@ -581,17 +581,38 @@ DEFPY  (ldp_debug_mpls_ldp_messages_sent,
 
 DEFPY  (ldp_show_mpls_ldp_binding,
 	ldp_show_mpls_ldp_binding_cmd,
-	"show mpls ldp [<ipv4|ipv6>]$af binding [detail]$detail [json]$json",
+	"show mpls ldp [<ipv4|ipv6>]$af binding\
+	  [<A.B.C.D/M|X:X::X:X/M>$prefix [longer-prefixes$longer_prefixes]]\
+	  [{\
+	    neighbor A.B.C.D$nbr\
+	    |local-label (0-1048575)$local_label\
+	    |remote-label (0-1048575)$remote_label\
+	  }]\
+	 [detail]$detail [json]$json",
 	"Show running system information\n"
 	"MPLS information\n"
 	"Label Distribution Protocol\n"
 	"IPv4 Address Family\n"
 	"IPv6 Address Family\n"
 	"Label Information Base (LIB) information\n"
+	"Destination prefix (IPv4)\n"
+	"Destination prefix (IPv6)\n"
+	"Include longer matches\n"
+	"Display labels from LDP neighbor\n"
+	"Neighbor LSR-ID\n"
+	"Match locally assigned label values\n"
+	"Locally assigned label value\n"
+	"Match remotely assigned label values\n"
+	"Remotely assigned label value\n"
 	"Show detailed information\n"
 	JSON_STR)
 {
-	return (ldp_vty_show_binding(vty, af, detail, json));
+	if (!local_label_str)
+		local_label = NO_LABEL;
+	if (!remote_label_str)
+		remote_label = NO_LABEL;
+	return (ldp_vty_show_binding(vty, af, prefix_str, !!longer_prefixes,
+	    nbr_str, local_label, remote_label, detail, json));
 }
 
 DEFPY  (ldp_show_mpls_ldp_discovery,
@@ -637,52 +658,81 @@ DEFPY  (ldp_show_mpls_ldp_capabilities,
 
 DEFPY  (ldp_show_mpls_ldp_neighbor,
 	ldp_show_mpls_ldp_neighbor_cmd,
-	"show mpls ldp neighbor [detail]$detail [json]$json",
+	"show mpls ldp neighbor [A.B.C.D]$lsr_id [detail]$detail [json]$json",
 	"Show running system information\n"
 	"MPLS information\n"
 	"Label Distribution Protocol\n"
 	"Neighbor information\n"
+	"Neighbor LSR-ID\n"
 	"Show detailed information\n"
 	JSON_STR)
 {
-	return (ldp_vty_show_neighbor(vty, 0, detail, json));
+	return (ldp_vty_show_neighbor(vty, lsr_id_str, 0, detail, json));
 }
 
 DEFPY  (ldp_show_mpls_ldp_neighbor_capabilities,
 	ldp_show_mpls_ldp_neighbor_capabilities_cmd,
-	"show mpls ldp neighbor capabilities [json]$json",
+	"show mpls ldp neighbor [A.B.C.D]$lsr_id capabilities [json]$json",
 	"Show running system information\n"
 	"MPLS information\n"
 	"Label Distribution Protocol\n"
 	"Neighbor information\n"
+	"Neighbor LSR-ID\n"
 	"Display neighbor capability information\n"
 	JSON_STR)
 {
-	return (ldp_vty_show_neighbor(vty, 1, NULL, json));
+	return (ldp_vty_show_neighbor(vty, lsr_id_str, 1, NULL, json));
 }
 
 DEFPY  (ldp_show_l2vpn_atom_binding,
 	ldp_show_l2vpn_atom_binding_cmd,
-	"show l2vpn atom binding [json]$json",
+	"show l2vpn atom binding\
+	  [{\
+	    A.B.C.D$peer\
+	    |local-label (16-1048575)$local_label\
+	    |remote-label (16-1048575)$remote_label\
+	  }]\
+	 [json]$json",
 	"Show running system information\n"
 	"Show information about Layer2 VPN\n"
 	"Show Any Transport over MPLS information\n"
 	"Show AToM label binding information\n"
+	"Destination address of the VC\n"
+	"Match locally assigned label values\n"
+	"Locally assigned label value\n"
+	"Match remotely assigned label values\n"
+	"Remotely assigned label value\n"
 	JSON_STR)
 {
-	return (ldp_vty_show_atom_binding(vty, json));
+	if (!local_label_str)
+		local_label = NO_LABEL;
+	if (!remote_label_str)
+		remote_label = NO_LABEL;
+	return (ldp_vty_show_atom_binding(vty, peer_str, local_label,
+	    remote_label, json));
 }
 
 DEFPY  (ldp_show_l2vpn_atom_vc,
 	ldp_show_l2vpn_atom_vc_cmd,
-	"show l2vpn atom vc [json]$json",
+	"show l2vpn atom vc\
+	  [{\
+	    A.B.C.D$peer\
+	    |interface IFNAME$ifname\
+	    |vc-id (1-4294967295)$vcid\
+	  }]\
+	 [json]$json",
 	"Show running system information\n"
 	"Show information about Layer2 VPN\n"
 	"Show Any Transport over MPLS information\n"
 	"Show AToM virtual circuit information\n"
+	"Destination address of the VC\n"
+	"Local interface of the pseudowire\n"
+	"Interface's name\n"
+	"VC ID\n"
+	"VC ID\n"
 	JSON_STR)
 {
-	return (ldp_vty_show_atom_vc(vty, json));
+	return (ldp_vty_show_atom_vc(vty, peer_str, ifname, vcid_str, json));
 }
 
 DEFUN_NOSH (ldp_show_debugging_mpls_ldp,


### PR DESCRIPTION
Being able to filter the output of some "show" commands is super useful
when troubleshooting large MPLS networks.

Examples:
```
# show mpls ldp binding 10.0.0.48/29 longer-prefixes neighbor 192.168.0.5
AF   Destination          Nexthop         Local Label Remote Label  In Use
ipv4 10.0.0.48/30         192.168.0.5     24          26                no
ipv4 10.0.0.52/30         192.168.0.5     25          27                no

# show mpls ldp binding 10.0.0.48/29 longer-prefixes neighbor 192.168.0.5 detail json
{
  "10.0.0.48\/30":{
    "localLabel":"24",
    "advertisedTo":[
      {
        "neighborId":"192.168.0.5"
      }
    ],
    "remoteLabels":[
      {
        "neighborId":"192.168.0.5",
        "label":"26",
        "inUse":0
      }
    ]
  },
  "10.0.0.52\/30":{
    "localLabel":"25",
    "advertisedTo":[
      {
        "neighborId":"192.168.0.5"
      }
    ],
    "remoteLabels":[
      {
        "neighborId":"192.168.0.5",
        "label":"27",
        "inUse":0
      }
    ]
  }
}
```

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>