### PR TITLE
lib: Fix abbreviation

### DIFF
--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -367,7 +367,7 @@ void bfd_show_param(struct vty *vty, struct bfd_info *bfd_info, int bfd_tag,
 					       json_bfd);
 	} else {
 		vty_out(vty,
-			"  %s%sDetect Mul: %d, Min Rx interval: %d,"
+			"  %s%sDetect Multiplier: %d, Min Rx interval: %d,"
 			" Min Tx interval: %d\n",
 			(extra_space) ? "  " : "", (bfd_tag) ? "BFD: " : "  ",
 			bfd_info->detect_mult, bfd_info->required_min_rx,


### PR DESCRIPTION
The word Multiplier has been abbreviated to 'Mul' in
the output.  This apparently is causing people
angst.  Write word out.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>