### PR TITLE
isisd: fix vertex queue comparator

### DIFF
--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -153,7 +153,7 @@ static int isis_vertex_queue_tent_cmp(void *a, void *b)
 	if (va->insert_counter > vb->insert_counter)
 		return 1;
 
-	assert(!"Vertizes should be strictly ordered");
+	return 0;
 }
 
 static struct skiplist *isis_vertex_queue_skiplist(void)

--- a/tests/isisd/test_isis_vertex_queue.c
+++ b/tests/isisd/test_isis_vertex_queue.c
@@ -89,7 +89,7 @@ static void test_ordered(void)
 	assert(isis_vertex_queue_pop(&q) == vertices[1]);
 	assert(isis_find_vertex(&q, vertices[1]->N.id, vertices[1]->type) == NULL);
 
-	assert(isis_vertex_queue_pop(&q) == vertices[4]);
+	isis_vertex_queue_delete(&q, vertices[4]);
 	assert(isis_find_vertex(&q, vertices[4]->N.id, vertices[4]->type) == NULL);
 
 	assert(isis_vertex_queue_count(&q) == 0);


### PR DESCRIPTION
While vertizes should be strictly ordered on insertion, deletion
will of course encouter equality.

Signed-off-by: Christian Franke <chris@opensourcerouting.org>