### PR TITLE
Zebra crash and valgrind issues

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -676,16 +676,21 @@ int netlink_talk(int (*filter)(struct sockaddr_nl *, struct nlmsghdr *, ns_id_t,
 {
 	int status;
 	struct sockaddr_nl snl;
-	struct iovec iov = {.iov_base = (void *)n, .iov_len = n->nlmsg_len};
-	struct msghdr msg = {
-		.msg_name = (void *)&snl,
-		.msg_namelen = sizeof snl,
-		.msg_iov = &iov,
-		.msg_iovlen = 1,
-	};
+	struct iovec iov;
+	struct msghdr msg;
 	int save_errno;
 
 	memset(&snl, 0, sizeof snl);
+	memset(&iov, 0, sizeof iov);
+	memset(&msg, 0, sizeof msg);
+
+	iov.iov_base = n;
+	iov.iov_len = n->nlmsg_len;
+	msg.msg_name = (void *)&snl;
+	msg.msg_namelen = sizeof snl;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
 	snl.nl_family = AF_NETLINK;
 
 	n->nlmsg_seq = ++nl->seq;

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -127,8 +127,8 @@ static void sigint(void)
 
 	frr_early_fini();
 
-	zebra_ptm_finish();
 	list_delete_all_node(zebrad.client_list);
+	zebra_ptm_finish();
 
 	if (retain_mode)
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -176,11 +176,13 @@ static void rtadv_send_packet(int sock, struct interface *ifp)
 	 */
 	if (adata == NULL) {
 		/* XXX Free on shutdown. */
-		adata = malloc(CMSG_SPACE(sizeof(struct in6_pktinfo)));
+		adata = calloc(1, CMSG_SPACE(sizeof(struct in6_pktinfo)));
 
-		if (adata == NULL)
+		if (adata == NULL) {
 			zlog_err(
 				"rtadv_send_packet: can't malloc control data");
+			exit(-1);
+		}
 	}
 
 	/* Logging of packet. */


### PR DESCRIPTION
These commits clean up shutdown in zebra.  We had multiple cases of use after free as well as unintialized data being passed to the kernel.