### PR TITLE
Eigrp interface cleanup

### DIFF
--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -210,14 +210,14 @@ void show_ip_eigrp_interface_sub(struct vty *vty, struct eigrp *eigrp,
 				 struct eigrp_interface *ei)
 {
 	vty_out(vty, "%-11s ", eigrp_if_name_string(ei));
-	vty_out(vty, "%-11u", IF_DEF_PARAMS(ei->ifp)->bandwidth);
-	vty_out(vty, "%-11u", IF_DEF_PARAMS(ei->ifp)->delay);
+	vty_out(vty, "%-11u", ei->params.bandwidth);
+	vty_out(vty, "%-11u", ei->params.delay);
 	vty_out(vty, "%-7u", ei->nbrs->count);
 	vty_out(vty, "%u %c %-10u", 0, '/',
 		eigrp_neighbor_packet_queue_sum(ei));
 	vty_out(vty, "%-7u %-14u %-12u %-8u", 0, 0, 0, 0);
-	vty_out(vty, "%-8u %-8u \n", IF_DEF_PARAMS(ei->ifp)->v_hello,
-		IF_DEF_PARAMS(ei->ifp)->v_wait);
+	vty_out(vty, "%-8u %-8u \n", ei->params.v_hello,
+		ei->params.v_wait);
 }
 
 void show_ip_eigrp_interface_detail(struct vty *vty, struct eigrp *eigrp,

--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -89,7 +89,7 @@ int eigrp_hello_timer(struct thread *thread)
 
 	if (IS_DEBUG_EIGRP(0, TIMERS))
 		zlog_debug("Start Hello Timer (%s) Expire [%u]", IF_NAME(ei),
-			   EIGRP_IF_PARAM(ei, v_hello));
+			   ei->params.v_hello);
 
 	/* Sending hello packet. */
 	eigrp_hello_send(ei, EIGRP_HELLO_NORMAL, NULL);
@@ -97,7 +97,7 @@ int eigrp_hello_timer(struct thread *thread)
 	/* Hello timer set. */
 	ei->t_hello = NULL;
 	thread_add_timer(master, eigrp_hello_timer, ei,
-			 EIGRP_IF_PARAM(ei, v_hello), &ei->t_hello);
+			 ei->params.v_hello, &ei->t_hello);
 
 	return 0;
 }
@@ -600,7 +600,7 @@ static u_int16_t eigrp_hello_parameter_encode(struct eigrp_interface *ei,
 	}
 
 	// and set hold time value..
-	stream_putw(s, IF_DEF_PARAMS(ei->ifp)->v_wait);
+	stream_putw(s, ei->params.v_wait);
 
 	return length;
 }
@@ -637,12 +637,12 @@ static struct eigrp_packet *eigrp_hello_encode(struct eigrp_interface *ei,
 		eigrp_packet_header_init(EIGRP_OPC_HELLO, ei->eigrp, ep->s, 0, 0, ack);
 
 		// encode Authentication TLV
-		if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-		    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+		if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+		    && (ei->params.auth_keychain != NULL)) {
 			length += eigrp_add_authTLV_MD5_to_stream(ep->s, ei);
-		} else if ((IF_DEF_PARAMS(ei->ifp)->auth_type
+		} else if ((ei->params.auth_type
 			    == EIGRP_AUTH_TYPE_SHA256)
-			   && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+			   && (ei->params.auth_keychain != NULL)) {
 			length += eigrp_add_authTLV_SHA256_to_stream(ep->s, ei);
 		}
 
@@ -676,13 +676,13 @@ static struct eigrp_packet *eigrp_hello_encode(struct eigrp_interface *ei,
 		// set soruce address for the hello packet
 		ep->dst.s_addr = addr;
 
-		if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-		    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+		if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+		    && (ei->params.auth_keychain != NULL)) {
 			eigrp_make_md5_digest(ei, ep->s,
 					      EIGRP_AUTH_BASIC_HELLO_FLAG);
-		} else if ((IF_DEF_PARAMS(ei->ifp)->auth_type
+		} else if ((ei->params.auth_type
 			    == EIGRP_AUTH_TYPE_SHA256)
-			   && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+			   && (ei->params.auth_keychain != NULL)) {
 			eigrp_make_sha256_digest(ei, ep->s,
 						 EIGRP_AUTH_BASIC_HELLO_FLAG);
 		}

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -159,7 +159,7 @@ int eigrp_if_new_hook(struct interface *ifp)
 {
 	int rc = 0;
 
-	ifp->info = XCALLOC(MTYPE_EIGRP_IF_INFO, sizeof(struct eigrp_if_info));
+	ifp->info = XCALLOC(MTYPE_EIGRP_IF_INFO, sizeof(struct eigrp_interface));
 
 	IF_OIFS(ifp) = route_table_init();
 	IF_OIFS_PARAMS(ifp) = route_table_init();

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -55,41 +55,22 @@
 #include "eigrpd/eigrp_memory.h"
 #include "eigrpd/eigrp_fsm.h"
 
-static void eigrp_delete_from_if(struct interface *, struct eigrp_interface *);
-
-static void eigrp_add_to_if(struct interface *ifp, struct eigrp_interface *ei)
-{
-	struct route_node *rn;
-	struct prefix p;
-
-	p = *ei->address;
-	p.prefixlen = IPV4_MAX_PREFIXLEN;
-
-	rn = route_node_get(IF_OIFS(ifp), &p);
-	/* rn->info should either be NULL or equal to this ei
-	 * as route_node_get may return an existing node
-	 */
-	assert(!rn->info || rn->info == ei);
-	rn->info = ei;
-}
-
 struct eigrp_interface *eigrp_if_new(struct eigrp *eigrp, struct interface *ifp,
 				     struct prefix *p)
 {
-	struct eigrp_interface *ei;
+	struct eigrp_interface *ei = ifp->info;
 	int i;
 
-	if ((ei = eigrp_if_table_lookup(ifp, p)) == NULL) {
-		ei = XCALLOC(MTYPE_EIGRP_IF, sizeof(struct eigrp_interface));
-		memset(ei, 0, sizeof(struct eigrp_interface));
-	} else
+	if (ei)
 		return ei;
+
+	ei = XCALLOC(MTYPE_EIGRP_IF, sizeof(struct eigrp_interface));
 
 	/* Set zebra interface pointer. */
 	ei->ifp = ifp;
 	ei->address = p;
 
-	eigrp_add_to_if(ifp, ei);
+	ifp->info = ei;
 	listnode_add(eigrp->eiflist, ei);
 
 	ei->type = EIGRP_IFTYPE_BROADCAST;
@@ -106,39 +87,32 @@ struct eigrp_interface *eigrp_if_new(struct eigrp *eigrp, struct interface *ifp,
 		ei->routemap[i] = NULL;
 	}
 
+	ei->eigrp = eigrp;
+
+	ei->params.v_hello = EIGRP_HELLO_INTERVAL_DEFAULT;
+	ei->params.v_wait = EIGRP_HOLD_INTERVAL_DEFAULT;
+	ei->params.bandwidth = EIGRP_BANDWIDTH_DEFAULT;
+	ei->params.delay = EIGRP_DELAY_DEFAULT;
+	ei->params.reliability = EIGRP_RELIABILITY_DEFAULT;
+	ei->params.load = EIGRP_LOAD_DEFAULT;
+	ei->params.auth_type = EIGRP_AUTH_TYPE_NONE;
+	ei->params.auth_keychain = NULL;
+
 	return ei;
-}
-
-/* lookup ei for specified prefix/ifp */
-struct eigrp_interface *eigrp_if_table_lookup(struct interface *ifp,
-					      struct prefix *prefix)
-{
-	struct prefix p;
-	struct route_node *rn;
-	struct eigrp_interface *rninfo = NULL;
-
-	p = *prefix;
-	p.prefixlen = IPV4_MAX_PREFIXLEN;
-
-	/* route_node_get implicitly locks */
-	if ((rn = route_node_lookup(IF_OIFS(ifp), &p))) {
-		rninfo = (struct eigrp_interface *)rn->info;
-		route_unlock_node(rn);
-	}
-
-	return rninfo;
 }
 
 int eigrp_if_delete_hook(struct interface *ifp)
 {
-	struct route_node *rn;
+	struct eigrp_interface *ei = ifp->info;
+	struct eigrp *eigrp;
 
-	route_table_finish(IF_OIFS(ifp));
+	if (!ei)
+		return 0;
 
-	for (rn = route_top(IF_OIFS_PARAMS(ifp)); rn; rn = route_next(rn))
-		if (rn->info)
-			eigrp_del_if_params(rn->info);
-	route_table_finish(IF_OIFS_PARAMS(ifp));
+	list_delete(ei->nbrs);
+
+	eigrp = ei->eigrp;
+	listnode_delete(eigrp->eiflist, ei);
 
 	XFREE(MTYPE_EIGRP_IF_INFO, ifp->info);
 	ifp->info = NULL;
@@ -151,95 +125,16 @@ struct list *eigrp_iflist;
 void eigrp_if_init()
 {
 	/* Initialize Zebra interface data structure. */
-	hook_register_prio(if_add, 0, eigrp_if_new_hook);
+	//hook_register_prio(if_add, 0, eigrp_if_new);
 	hook_register_prio(if_del, 0, eigrp_if_delete_hook);
 }
 
-int eigrp_if_new_hook(struct interface *ifp)
-{
-	int rc = 0;
 
-	ifp->info = XCALLOC(MTYPE_EIGRP_IF_INFO, sizeof(struct eigrp_interface));
-
-	IF_OIFS(ifp) = route_table_init();
-	IF_OIFS_PARAMS(ifp) = route_table_init();
-
-	IF_DEF_PARAMS(ifp) = eigrp_new_if_params();
-
-	SET_IF_PARAM(IF_DEF_PARAMS(ifp), v_hello);
-	IF_DEF_PARAMS(ifp)->v_hello = (u_int32_t)EIGRP_HELLO_INTERVAL_DEFAULT;
-
-	SET_IF_PARAM(IF_DEF_PARAMS(ifp), v_wait);
-	IF_DEF_PARAMS(ifp)->v_wait = (u_int16_t)EIGRP_HOLD_INTERVAL_DEFAULT;
-
-	SET_IF_PARAM(IF_DEF_PARAMS(ifp), bandwidth);
-	IF_DEF_PARAMS(ifp)->bandwidth = (u_int32_t)EIGRP_BANDWIDTH_DEFAULT;
-
-	SET_IF_PARAM(IF_DEF_PARAMS(ifp), delay);
-	IF_DEF_PARAMS(ifp)->delay = (u_int32_t)EIGRP_DELAY_DEFAULT;
-
-	SET_IF_PARAM(IF_DEF_PARAMS(ifp), reliability);
-	IF_DEF_PARAMS(ifp)->reliability = (u_char)EIGRP_RELIABILITY_DEFAULT;
-
-	SET_IF_PARAM(IF_DEF_PARAMS(ifp), load);
-	IF_DEF_PARAMS(ifp)->load = (u_char)EIGRP_LOAD_DEFAULT;
-
-	SET_IF_PARAM(IF_DEF_PARAMS(ifp), auth_type);
-	IF_DEF_PARAMS(ifp)->auth_type = EIGRP_AUTH_TYPE_NONE;
-
-	SET_IF_PARAM(IF_DEF_PARAMS(ifp), auth_keychain);
-	IF_DEF_PARAMS(ifp)->auth_keychain = NULL;
-
-	return rc;
-}
-
-struct eigrp_if_params *eigrp_new_if_params(void)
-{
-	struct eigrp_if_params *eip;
-
-	eip = XCALLOC(MTYPE_EIGRP_IF_PARAMS, sizeof(struct eigrp_if_params));
-	if (!eip)
-		return NULL;
-
-	UNSET_IF_PARAM(eip, passive_interface);
-	UNSET_IF_PARAM(eip, v_hello);
-	UNSET_IF_PARAM(eip, v_wait);
-	UNSET_IF_PARAM(eip, bandwidth);
-	UNSET_IF_PARAM(eip, delay);
-	UNSET_IF_PARAM(eip, reliability);
-	UNSET_IF_PARAM(eip, load);
-	UNSET_IF_PARAM(eip, auth_keychain);
-	UNSET_IF_PARAM(eip, auth_type);
-
-	return eip;
-}
 
 void eigrp_del_if_params(struct eigrp_if_params *eip)
 {
 	if (eip->auth_keychain)
 		free(eip->auth_keychain);
-
-	XFREE(MTYPE_EIGRP_IF_PARAMS, eip);
-}
-
-struct eigrp_if_params *eigrp_lookup_if_params(struct interface *ifp,
-					       struct in_addr addr)
-{
-	struct prefix p;
-	struct route_node *rn;
-
-	p.family = AF_INET;
-	p.prefixlen = IPV4_MAX_PREFIXLEN;
-	p.u.prefix4 = addr;
-
-	rn = route_node_lookup(IF_OIFS_PARAMS(ifp), &p);
-
-	if (rn) {
-		route_unlock_node(rn);
-		return rn->info;
-	}
-
-	return NULL;
 }
 
 int eigrp_if_up(struct eigrp_interface *ei)
@@ -266,10 +161,10 @@ int eigrp_if_up(struct eigrp_interface *ei)
 
 	/*Prepare metrics*/
 	metric.bandwidth =
-		eigrp_bandwidth_to_scaled(EIGRP_IF_PARAM(ei, bandwidth));
-	metric.delay = eigrp_delay_to_scaled(EIGRP_IF_PARAM(ei, delay));
-	metric.load = EIGRP_IF_PARAM(ei, load);
-	metric.reliability = EIGRP_IF_PARAM(ei, reliability);
+		eigrp_bandwidth_to_scaled(ei->params.bandwidth);
+	metric.delay = eigrp_delay_to_scaled(ei->params.delay);
+	metric.load = ei->params.load;
+	metric.reliability = ei->params.reliability;
 	metric.mtu[0] = 0xDC;
 	metric.mtu[1] = 0x05;
 	metric.mtu[2] = 0x00;
@@ -387,33 +282,43 @@ void eigrp_if_stream_unset(struct eigrp_interface *ei)
 	}
 }
 
+bool eigrp_if_is_passive(struct eigrp_interface *ei)
+{
+	if (ei->params.passive_interface == EIGRP_IF_ACTIVE)
+		return false;
+
+	if (ei->eigrp->passive_interface_default == EIGRP_IF_ACTIVE)
+		return false;
+
+	return true;
+}
+
 void eigrp_if_set_multicast(struct eigrp_interface *ei)
 {
-	if ((EIGRP_IF_PASSIVE_STATUS(ei) == EIGRP_IF_ACTIVE)) {
+	if (!eigrp_if_is_passive(ei)) {
 		/* The interface should belong to the EIGRP-all-routers group.
 		 */
-		if (!EI_MEMBER_CHECK(ei, MEMBER_ALLROUTERS)
+		if (!ei->member_allrouters
 		    && (eigrp_if_add_allspfrouters(ei->eigrp, ei->address,
 						   ei->ifp->ifindex)
 			>= 0))
 			/* Set the flag only if the system call to join
 			 * succeeded. */
-			EI_MEMBER_JOINED(ei, MEMBER_ALLROUTERS);
+			ei->member_allrouters = true;
 	} else {
 		/* The interface should NOT belong to the EIGRP-all-routers
 		 * group. */
-		if (EI_MEMBER_CHECK(ei, MEMBER_ALLROUTERS)) {
+		if (ei->member_allrouters) {
 			/* Only actually drop if this is the last reference */
-			if (EI_MEMBER_COUNT(ei, MEMBER_ALLROUTERS) == 1)
-				eigrp_if_drop_allspfrouters(ei->eigrp,
-							    ei->address,
-							    ei->ifp->ifindex);
+			eigrp_if_drop_allspfrouters(ei->eigrp,
+						    ei->address,
+						    ei->ifp->ifindex);
 			/* Unset the flag regardless of whether the system call
 			   to leave
 			   the group succeeded, since it's much safer to assume
 			   that
 			   we are not a member. */
-			EI_MEMBER_LEFT(ei, MEMBER_ALLROUTERS);
+			ei->member_allrouters = false;
 		}
 	}
 }
@@ -428,7 +333,8 @@ u_char eigrp_default_iftype(struct interface *ifp)
 		return EIGRP_IFTYPE_BROADCAST;
 }
 
-void eigrp_if_free(struct eigrp_interface *ei, int source)
+void eigrp_if_free(struct eigrp_interface *ei,
+		   int source)
 {
 	struct prefix dest_addr;
 	struct eigrp_prefix_entry *pe;
@@ -449,47 +355,20 @@ void eigrp_if_free(struct eigrp_interface *ei, int source)
 	eigrp_if_down(ei);
 
 	list_delete(ei->nbrs);
-	eigrp_delete_from_if(ei->ifp, ei);
 	listnode_delete(ei->eigrp->eiflist, ei);
-
-	thread_cancel_event(master, ei);
-
-	memset(ei, 0, sizeof(*ei));
-	XFREE(MTYPE_EIGRP_IF, ei);
-}
-
-static void eigrp_delete_from_if(struct interface *ifp,
-				 struct eigrp_interface *ei)
-{
-	struct route_node *rn;
-	struct prefix p;
-
-	p = *ei->address;
-	p.prefixlen = IPV4_MAX_PREFIXLEN;
-
-	rn = route_node_lookup(IF_OIFS(ei->ifp), &p);
-	assert(rn);
-	assert(rn->info);
-	rn->info = NULL;
-	route_unlock_node(rn);
-	route_unlock_node(rn);
 }
 
 /* Simulate down/up on the interface.  This is needed, for example, when
    the MTU changes. */
 void eigrp_if_reset(struct interface *ifp)
 {
-	struct route_node *rn;
+	struct eigrp_interface *ei = ifp->info;
 
-	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
-		struct eigrp_interface *ei;
+	if (!ei)
+		return;
 
-		if ((ei = rn->info) == NULL)
-			continue;
-
-		eigrp_if_down(ei);
-		eigrp_if_up(ei);
-	}
+	eigrp_if_down(ei);
+	eigrp_if_up(ei);
 }
 
 struct eigrp_interface *eigrp_if_lookup_by_local_addr(struct eigrp *eigrp,
@@ -536,41 +415,6 @@ struct eigrp_interface *eigrp_if_lookup_by_name(struct eigrp *eigrp,
 	}
 
 	return NULL;
-}
-
-/* determine receiving interface by ifp and source address */
-struct eigrp_interface *eigrp_if_lookup_recv_if(struct eigrp *eigrp,
-						struct in_addr src,
-						struct interface *ifp)
-{
-	struct route_node *rn;
-	struct prefix addr;
-	struct eigrp_interface *ei, *match;
-
-	addr.family = AF_INET;
-	addr.u.prefix4 = src;
-	addr.prefixlen = IPV4_MAX_BITLEN;
-
-	match = NULL;
-
-	for (rn = route_top(IF_OIFS(ifp)); rn; rn = route_next(rn)) {
-		ei = rn->info;
-
-		if (!ei) /* oi can be NULL for PtP aliases */
-			continue;
-
-		if (if_is_loopback(ei->ifp))
-			continue;
-
-		if (prefix_match(CONNECTED_PREFIX(ei->connected),
-				 &addr)) {
-			if ((match == NULL) || (match->address->prefixlen
-						< ei->address->prefixlen))
-				match = ei;
-		}
-	}
-
-	return match;
 }
 
 u_int32_t eigrp_bandwidth_to_scaled(u_int32_t bandwidth)

--- a/eigrpd/eigrp_interface.h
+++ b/eigrpd/eigrp_interface.h
@@ -37,14 +37,10 @@ extern void eigrp_if_init(void);
 extern int eigrp_if_new_hook(struct interface *);
 extern int eigrp_if_delete_hook(struct interface *);
 
+extern bool eigrp_if_is_passive(struct eigrp_interface *ei);
 extern void eigrp_del_if_params(struct eigrp_if_params *);
-extern struct eigrp_if_params *eigrp_new_if_params(void);
 extern struct eigrp_interface *eigrp_if_new(struct eigrp *, struct interface *,
 					    struct prefix *);
-extern struct eigrp_interface *eigrp_if_table_lookup(struct interface *,
-						     struct prefix *);
-extern struct eigrp_if_params *eigrp_lookup_if_params(struct interface *,
-						      struct in_addr);
 extern int eigrp_if_up(struct eigrp_interface *);
 extern void eigrp_if_stream_set(struct eigrp_interface *);
 extern void eigrp_if_set_multicast(struct eigrp_interface *);
@@ -58,8 +54,6 @@ extern struct eigrp_interface *eigrp_if_lookup_by_local_addr(struct eigrp *,
 							     struct in_addr);
 extern struct eigrp_interface *eigrp_if_lookup_by_name(struct eigrp *,
 						       const char *);
-struct eigrp_interface *eigrp_if_lookup_recv_if(struct eigrp *, struct in_addr,
-						struct interface *);
 
 /* Simulate down/up on the interface. */
 extern void eigrp_if_reset(struct interface *);

--- a/eigrpd/eigrp_macros.h
+++ b/eigrpd/eigrp_macros.h
@@ -44,38 +44,14 @@
 		 ? (O)->params->P                                              \
 		 : IF_DEF_PARAMS((O)->ifp)->P)
 
-#define EIGRP_IF_PASSIVE_STATUS(O)                                             \
-	(EIGRP_IF_PARAM_CONFIGURED((O)->params, passive_interface)             \
-		 ? (O)->params->passive_interface                              \
-		 : (EIGRP_IF_PARAM_CONFIGURED(IF_DEF_PARAMS((O)->ifp),         \
-					      passive_interface)               \
-			    ? IF_DEF_PARAMS((O)->ifp)->passive_interface       \
-			    : (O)->eigrp->passive_interface_default))
 
 //------------------------------------------------------------------------------------------------------------------------------------
 
 #define EIGRP_IF_STRING_MAXLEN  40
 #define IF_NAME(I)      eigrp_if_name_string ((I))
 
-//------------------------------------------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------
 
-/*Macros for EIGRP interface multicast membership*/
-#define EI_MEMBER_FLAG(M) (1 << (M))
-#define EI_MEMBER_COUNT(O,M) (IF_EIGRP_IF_INFO(ei->ifp)->membership_counts[(M)])
-#define EI_MEMBER_CHECK(O, M)                                                  \
-	(CHECK_FLAG((O)->multicast_memberships, EI_MEMBER_FLAG(M)))
-#define EI_MEMBER_JOINED(O, M)                                                 \
-	do {                                                                   \
-		SET_FLAG((O)->multicast_memberships, EI_MEMBER_FLAG(M));       \
-		IF_EIGRP_IF_INFO((O)->ifp)->membership_counts[(M)]++;          \
-	} while (0)
-#define EI_MEMBER_LEFT(O, M)                                                   \
-	do {                                                                   \
-		UNSET_FLAG((O)->multicast_memberships, EI_MEMBER_FLAG(M));     \
-		IF_EIGRP_IF_INFO((O)->ifp)->membership_counts[(M)]--;          \
-	} while (0)
-
-//-----------------------------------------------------------------------------------------------------------------------------------
 /* Topology Macros */
 
 

--- a/eigrpd/eigrp_macros.h
+++ b/eigrpd/eigrp_macros.h
@@ -28,24 +28,8 @@
 #ifndef _ZEBRA_EIGRP_MACROS_H_
 #define _ZEBRA_EIGRP_MACROS_H_
 
-#define DECLARE_IF_PARAM(T, P) T P; u_char P##__config:1
-#define IF_EIGRP_IF_INFO(I) ((struct eigrp_interface *)((I)->info))
-#define IF_OIFS(I)  (IF_EIGRP_IF_INFO (I)->eifs)
-#define IF_OIFS_PARAMS(I) (IF_EIGRP_IF_INFO (I)->eparams)
 
-#define SET_IF_PARAM(S, P) ((S)->P##__config) = 1
-#define IF_DEF_PARAMS(I) (IF_EIGRP_IF_INFO (I)->def_params)
-
-#define UNSET_IF_PARAM(S, P) ((S)->P##__config) = 0
-
-#define EIGRP_IF_PARAM_CONFIGURED(S, P) ((S) && (S)->P##__config)
-#define EIGRP_IF_PARAM(O, P)                                                   \
-	(EIGRP_IF_PARAM_CONFIGURED((O)->params, P)                             \
-		 ? (O)->params->P                                              \
-		 : IF_DEF_PARAMS((O)->ifp)->P)
-
-
-//------------------------------------------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------
 
 #define EIGRP_IF_STRING_MAXLEN  40
 #define IF_NAME(I)      eigrp_if_name_string ((I))

--- a/eigrpd/eigrp_macros.h
+++ b/eigrpd/eigrp_macros.h
@@ -29,9 +29,9 @@
 #define _ZEBRA_EIGRP_MACROS_H_
 
 #define DECLARE_IF_PARAM(T, P) T P; u_char P##__config:1
-#define IF_EIGRP_IF_INFO(I) ((struct eigrp_if_info *)((I)->info))
+#define IF_EIGRP_IF_INFO(I) ((struct eigrp_interface *)((I)->info))
 #define IF_OIFS(I)  (IF_EIGRP_IF_INFO (I)->eifs)
-#define IF_OIFS_PARAMS(I) (IF_EIGRP_IF_INFO (I)->params)
+#define IF_OIFS_PARAMS(I) (IF_EIGRP_IF_INFO (I)->eparams)
 
 #define SET_IF_PARAM(S, P) ((S)->P##__config) = 1
 #define IF_DEF_PARAMS(I) (IF_EIGRP_IF_INFO (I)->def_params)

--- a/eigrpd/eigrp_query.c
+++ b/eigrpd/eigrp_query.c
@@ -175,8 +175,8 @@ void eigrp_send_query(struct eigrp_interface *ei)
 				 ei->eigrp->sequence_number, 0);
 
 	// encode Authentication TLV, if needed
-	if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+	if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (ei->params.auth_keychain != NULL)) {
 		length += eigrp_add_authTLV_MD5_to_stream(ep->s, ei);
 	}
 
@@ -199,8 +199,8 @@ void eigrp_send_query(struct eigrp_interface *ei)
 		return;
 	}
 
-	if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+	if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && ei->params.auth_keychain != NULL) {
 		eigrp_make_md5_digest(ei, ep->s, EIGRP_AUTH_UPDATE_FLAG);
 	}
 

--- a/eigrpd/eigrp_reply.c
+++ b/eigrpd/eigrp_reply.c
@@ -1,5 +1,5 @@
 /*
- * EIGRP Sending and Receiving EIGRP Reply Packets.
+ * Eigrp Sending and Receiving EIGRP Reply Packets.
  * Copyright (C) 2013-2016
  * Authors:
  *   Donnie Savage
@@ -94,16 +94,16 @@ void eigrp_send_reply(struct eigrp_neighbor *nbr, struct eigrp_prefix_entry *pe)
 				 eigrp->sequence_number, 0);
 
 	// encode Authentication TLV, if needed
-	if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+	if (ei->params.auth_type == EIGRP_AUTH_TYPE_MD5
+	    && (ei->params.auth_keychain != NULL)) {
 		length += eigrp_add_authTLV_MD5_to_stream(ep->s, ei);
 	}
 
 
 	length += eigrp_add_internalTLV_to_stream(ep->s, pe2);
 
-	if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+	if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (ei->params.auth_keychain != NULL)) {
 		eigrp_make_md5_digest(ei, ep->s, EIGRP_AUTH_UPDATE_FLAG);
 	}
 

--- a/eigrpd/eigrp_siaquery.c
+++ b/eigrpd/eigrp_siaquery.c
@@ -126,15 +126,15 @@ void eigrp_send_siaquery(struct eigrp_neighbor *nbr,
 				 nbr->ei->eigrp->sequence_number, 0);
 
 	// encode Authentication TLV, if needed
-	if ((IF_DEF_PARAMS(nbr->ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(nbr->ei->ifp)->auth_keychain != NULL)) {
+	if ((nbr->ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (nbr->ei->params.auth_keychain != NULL)) {
 		length += eigrp_add_authTLV_MD5_to_stream(ep->s, nbr->ei);
 	}
 
 	length += eigrp_add_internalTLV_to_stream(ep->s, pe);
 
-	if ((IF_DEF_PARAMS(nbr->ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(nbr->ei->ifp)->auth_keychain != NULL)) {
+	if ((nbr->ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (nbr->ei->params.auth_keychain != NULL)) {
 		eigrp_make_md5_digest(nbr->ei, ep->s, EIGRP_AUTH_UPDATE_FLAG);
 	}
 

--- a/eigrpd/eigrp_siareply.c
+++ b/eigrpd/eigrp_siareply.c
@@ -125,15 +125,15 @@ void eigrp_send_siareply(struct eigrp_neighbor *nbr,
 				 nbr->ei->eigrp->sequence_number, 0);
 
 	// encode Authentication TLV, if needed
-	if ((IF_DEF_PARAMS(nbr->ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(nbr->ei->ifp)->auth_keychain != NULL)) {
+	if (nbr->ei->params.auth_type == EIGRP_AUTH_TYPE_MD5
+	    && nbr->ei->params.auth_keychain != NULL) {
 		length += eigrp_add_authTLV_MD5_to_stream(ep->s, nbr->ei);
 	}
 
 	length += eigrp_add_internalTLV_to_stream(ep->s, pe);
 
-	if ((IF_DEF_PARAMS(nbr->ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(nbr->ei->ifp)->auth_keychain != NULL)) {
+	if ((nbr->ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (nbr->ei->params.auth_keychain != NULL)) {
 		eigrp_make_md5_digest(nbr->ei, ep->s, EIGRP_AUTH_UPDATE_FLAG);
 	}
 

--- a/eigrpd/eigrp_structs.h
+++ b/eigrpd/eigrp_structs.h
@@ -135,10 +135,39 @@ struct eigrp {
 	QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(eigrp)
-//------------------------------------------------------------------------------------------------------------------------------------------
+
+struct eigrp_if_params {
+	DECLARE_IF_PARAM(u_char, passive_interface); /* EIGRP Interface is
+							passive: no sending or
+							receiving (no need to
+							join multicast groups)
+							*/
+	DECLARE_IF_PARAM(u_int32_t, v_hello);	/* Hello Interval */
+	DECLARE_IF_PARAM(u_int16_t, v_wait); /* Router Hold Time Interval */
+	DECLARE_IF_PARAM(u_char, type);      /* type of interface */
+	DECLARE_IF_PARAM(u_int32_t, bandwidth);
+	DECLARE_IF_PARAM(u_int32_t, delay);
+	DECLARE_IF_PARAM(u_char, reliability);
+	DECLARE_IF_PARAM(u_char, load);
+
+	DECLARE_IF_PARAM(char *,
+			 auth_keychain); /* Associated keychain with interface*/
+	DECLARE_IF_PARAM(int, auth_type); /* EIGRP authentication type */
+};
+
+enum { MEMBER_ALLROUTERS = 0,
+       MEMBER_MAX,
+};
 
 /*EIGRP interface structure*/
 struct eigrp_interface {
+	struct eigrp_if_params *def_params;
+	struct route_table *eparams;
+	struct route_table *eifs;
+
+	/*multicast group refcnts */
+	unsigned int membership_counts[MEMBER_MAX];
+	
 	/* This interface's parent eigrp instance. */
 	struct eigrp *eigrp;
 
@@ -195,39 +224,6 @@ struct eigrp_interface {
 	/* Route-map. */
 	struct route_map *routemap[EIGRP_FILTER_MAX];
 };
-
-struct eigrp_if_params {
-	DECLARE_IF_PARAM(u_char, passive_interface); /* EIGRP Interface is
-							passive: no sending or
-							receiving (no need to
-							join multicast groups)
-							*/
-	DECLARE_IF_PARAM(u_int32_t, v_hello);	/* Hello Interval */
-	DECLARE_IF_PARAM(u_int16_t, v_wait); /* Router Hold Time Interval */
-	DECLARE_IF_PARAM(u_char, type);      /* type of interface */
-	DECLARE_IF_PARAM(u_int32_t, bandwidth);
-	DECLARE_IF_PARAM(u_int32_t, delay);
-	DECLARE_IF_PARAM(u_char, reliability);
-	DECLARE_IF_PARAM(u_char, load);
-
-	DECLARE_IF_PARAM(char *,
-			 auth_keychain); /* Associated keychain with interface*/
-	DECLARE_IF_PARAM(int, auth_type); /* EIGRP authentication type */
-};
-
-enum { MEMBER_ALLROUTERS = 0,
-       MEMBER_MAX,
-};
-
-struct eigrp_if_info {
-	struct eigrp_if_params *def_params;
-	struct route_table *params;
-	struct route_table *eifs;
-	unsigned int
-		membership_counts[MEMBER_MAX]; /* multicast group refcnts */
-};
-
-//------------------------------------------------------------------------------------------------------------------------------------------
 
 /* Determines if it is first or last packet
  * when packet consists of multiple packet

--- a/eigrpd/eigrp_structs.h
+++ b/eigrpd/eigrp_structs.h
@@ -137,22 +137,17 @@ struct eigrp {
 DECLARE_QOBJ_TYPE(eigrp)
 
 struct eigrp_if_params {
-	DECLARE_IF_PARAM(u_char, passive_interface); /* EIGRP Interface is
-							passive: no sending or
-							receiving (no need to
-							join multicast groups)
-							*/
-	DECLARE_IF_PARAM(u_int32_t, v_hello);	/* Hello Interval */
-	DECLARE_IF_PARAM(u_int16_t, v_wait); /* Router Hold Time Interval */
-	DECLARE_IF_PARAM(u_char, type);      /* type of interface */
-	DECLARE_IF_PARAM(u_int32_t, bandwidth);
-	DECLARE_IF_PARAM(u_int32_t, delay);
-	DECLARE_IF_PARAM(u_char, reliability);
-	DECLARE_IF_PARAM(u_char, load);
+	u_char passive_interface;
+	u_int32_t v_hello;
+	u_int16_t v_wait;
+	u_char type;      /* type of interface */
+	u_int32_t bandwidth;
+	u_int32_t delay;
+	u_char reliability;
+	u_char load;
 
-	DECLARE_IF_PARAM(char *,
-			 auth_keychain); /* Associated keychain with interface*/
-	DECLARE_IF_PARAM(int, auth_type); /* EIGRP authentication type */
+	char *auth_keychain; /* Associated keychain with interface*/
+	int auth_type; /* EIGRP authentication type */
 };
 
 enum { MEMBER_ALLROUTERS = 0,
@@ -161,12 +156,10 @@ enum { MEMBER_ALLROUTERS = 0,
 
 /*EIGRP interface structure*/
 struct eigrp_interface {
-	struct eigrp_if_params *def_params;
-	struct route_table *eparams;
-	struct route_table *eifs;
+	struct eigrp_if_params params;
 
 	/*multicast group refcnts */
-	unsigned int membership_counts[MEMBER_MAX];
+	bool member_allrouters;
 	
 	/* This interface's parent eigrp instance. */
 	struct eigrp *eigrp;
@@ -179,8 +172,6 @@ struct eigrp_interface {
 
 	/* To which multicast groups do we currently belong? */
 
-	/* Configured varables. */
-	struct eigrp_if_params *params;
 
 	u_char multicast_memberships;
 

--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -434,8 +434,8 @@ void eigrp_update_send_init(struct eigrp_neighbor *nbr)
 				 nbr->recv_sequence_number);
 
 	// encode Authentication TLV, if needed
-	if ((IF_DEF_PARAMS(nbr->ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(nbr->ei->ifp)->auth_keychain != NULL)) {
+	if ((nbr->ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (nbr->ei->params.auth_keychain != NULL)) {
 		length += eigrp_add_authTLV_MD5_to_stream(ep->s, nbr->ei);
 		eigrp_make_md5_digest(nbr->ei, ep->s,
 				      EIGRP_AUTH_UPDATE_INIT_FLAG);
@@ -467,8 +467,8 @@ static void eigrp_update_place_on_nbr_queue(struct eigrp_neighbor *nbr,
 					    u_int32_t seq_no,
 					    int length)
 {
-	if((IF_DEF_PARAMS (nbr->ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5) &&
-	   (IF_DEF_PARAMS (nbr->ei->ifp)->auth_keychain != NULL)) {
+	if((nbr->ei->params.auth_type == EIGRP_AUTH_TYPE_MD5) &&
+	   (nbr->ei->params.auth_keychain != NULL)) {
 		eigrp_make_md5_digest(nbr->ei,ep->s, EIGRP_AUTH_UPDATE_FLAG);
 	}
 
@@ -544,8 +544,8 @@ void eigrp_update_send_EOT(struct eigrp_neighbor *nbr)
 				 seq_no, nbr->recv_sequence_number);
 
 	// encode Authentication TLV, if needed
-	if((IF_DEF_PARAMS (ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5) &&
-	   (IF_DEF_PARAMS (ei->ifp)->auth_keychain != NULL)) {
+	if((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5) &&
+	   (ei->params.auth_keychain != NULL)) {
 		length += eigrp_add_authTLV_MD5_to_stream(ep->s,ei);
 	}
 
@@ -564,8 +564,8 @@ void eigrp_update_send_EOT(struct eigrp_neighbor *nbr)
 							 ep->s, EIGRP_EOT_FLAG,
 							 seq_no, nbr->recv_sequence_number);
 
-				if((IF_DEF_PARAMS (ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5) &&
-				   (IF_DEF_PARAMS (ei->ifp)->auth_keychain != NULL))
+				if((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5) &&
+				   (ei->params.auth_keychain != NULL))
 				{
 					length += eigrp_add_authTLV_MD5_to_stream(ep->s,ei);
 				}
@@ -610,8 +610,8 @@ void eigrp_update_send(struct eigrp_interface *ei)
 				 ep->s, 0, seq_no, 0);
 
 	// encode Authentication TLV, if needed
-	if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+	if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (ei->params.auth_keychain != NULL)) {
 		length += eigrp_add_authTLV_MD5_to_stream(ep->s, ei);
 	}
 
@@ -628,8 +628,8 @@ void eigrp_update_send(struct eigrp_interface *ei)
 			continue;
 
 		if ((length + 0x001D) > (u_int16_t)ei->ifp->mtu) {
-			if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-			    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+			if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+			    && (ei->params.auth_keychain != NULL)) {
 				eigrp_make_md5_digest(ei, ep->s, EIGRP_AUTH_UPDATE_FLAG);
 			}
 
@@ -646,8 +646,8 @@ void eigrp_update_send(struct eigrp_interface *ei)
 			ep = eigrp_packet_new(ei->ifp->mtu, NULL);
 			eigrp_packet_header_init(EIGRP_OPC_UPDATE, eigrp,
 						 ep->s, 0, seq_no, 0);
-			if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-			    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+			if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+			    && (ei->params.auth_keychain != NULL)) {
 				length += eigrp_add_authTLV_MD5_to_stream(ep->s, ei);
 			}
 			has_tlv = 0;
@@ -672,8 +672,8 @@ void eigrp_update_send(struct eigrp_interface *ei)
 		return;
 	}
 
-	if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+	if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (ei->params.auth_keychain != NULL)) {
 		eigrp_make_md5_digest(ei, ep->s, EIGRP_AUTH_UPDATE_FLAG);
 	}
 
@@ -790,8 +790,8 @@ static void eigrp_update_send_GR_part(struct eigrp_neighbor *nbr)
 				 nbr->recv_sequence_number);
 
 	// encode Authentication TLV, if needed
-	if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+	if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (ei->params.auth_keychain != NULL)) {
 		length += eigrp_add_authTLV_MD5_to_stream(ep->s, ei);
 	}
 
@@ -856,8 +856,8 @@ static void eigrp_update_send_GR_part(struct eigrp_neighbor *nbr)
 	}
 
 	/* compute Auth digest */
-	if ((IF_DEF_PARAMS(ei->ifp)->auth_type == EIGRP_AUTH_TYPE_MD5)
-	    && (IF_DEF_PARAMS(ei->ifp)->auth_keychain != NULL)) {
+	if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
+	    && (ei->params.auth_keychain != NULL)) {
 		eigrp_make_md5_digest(ei, ep->s, EIGRP_AUTH_UPDATE_FLAG);
 	}
 

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -95,36 +95,32 @@ static int config_write_interfaces(struct vty *vty, struct eigrp *eigrp)
 	for (ALL_LIST_ELEMENTS_RO(eigrp->eiflist, node, ei)) {
 		vty_frame(vty, "interface %s\n", ei->ifp->name);
 
-		if ((IF_DEF_PARAMS(ei->ifp)->auth_type)
-		    == EIGRP_AUTH_TYPE_MD5) {
+		if (ei->params.auth_type == EIGRP_AUTH_TYPE_MD5) {
 			vty_out(vty, " ip authentication mode eigrp %d md5\n",
 				eigrp->AS);
 		}
 
-		if ((IF_DEF_PARAMS(ei->ifp)->auth_type)
-		    == EIGRP_AUTH_TYPE_SHA256) {
+		if (ei->params.auth_type == EIGRP_AUTH_TYPE_SHA256) {
 			vty_out(vty,
 				" ip authentication mode eigrp %d hmac-sha-256\n",
 				eigrp->AS);
 		}
 
-		if (IF_DEF_PARAMS(ei->ifp)->auth_keychain) {
+		if (ei->params.auth_keychain) {
 			vty_out(vty,
 				" ip authentication key-chain eigrp %d %s\n",
 				eigrp->AS,
-				IF_DEF_PARAMS(ei->ifp)->auth_keychain);
+				ei->params.auth_keychain);
 		}
 
-		if ((IF_DEF_PARAMS(ei->ifp)->v_hello)
-		    != EIGRP_HELLO_INTERVAL_DEFAULT) {
+		if (ei->params.v_hello != EIGRP_HELLO_INTERVAL_DEFAULT) {
 			vty_out(vty, " ip hello-interval eigrp %d\n",
-				IF_DEF_PARAMS(ei->ifp)->v_hello);
+				ei->params.v_hello);
 		}
 
-		if ((IF_DEF_PARAMS(ei->ifp)->v_wait)
-		    != EIGRP_HOLD_INTERVAL_DEFAULT) {
+		if (ei->params.v_wait != EIGRP_HOLD_INTERVAL_DEFAULT) {
 			vty_out(vty, " ip hold-time eigrp %d\n",
-				IF_DEF_PARAMS(ei->ifp)->v_wait);
+				ei->params.v_wait);
 		}
 
 		/*Separate this EIGRP interface configuration from the others*/
@@ -138,24 +134,29 @@ static int eigrp_write_interface(struct vty *vty)
 {
 	struct listnode *node;
 	struct interface *ifp;
+	struct eigrp_interface *ei;
 
 	for (ALL_LIST_ELEMENTS_RO(vrf_iflist(VRF_DEFAULT), node, ifp)) {
+		ei = ifp->info;
+		if (!ei)
+			continue;
+
 		vty_frame(vty, "interface %s\n", ifp->name);
 
 		if (ifp->desc)
 			vty_out(vty, " description %s\n", ifp->desc);
 
-		if (IF_DEF_PARAMS(ifp)->bandwidth != EIGRP_BANDWIDTH_DEFAULT)
+		if (ei->params.bandwidth != EIGRP_BANDWIDTH_DEFAULT)
 			vty_out(vty, " bandwidth %u\n",
-				IF_DEF_PARAMS(ifp)->bandwidth);
-		if (IF_DEF_PARAMS(ifp)->delay != EIGRP_DELAY_DEFAULT)
-			vty_out(vty, " delay %u\n", IF_DEF_PARAMS(ifp)->delay);
-		if (IF_DEF_PARAMS(ifp)->v_hello != EIGRP_HELLO_INTERVAL_DEFAULT)
+				ei->params.bandwidth);
+		if (ei->params.delay != EIGRP_DELAY_DEFAULT)
+			vty_out(vty, " delay %u\n", ei->params.delay);
+		if (ei->params.v_hello != EIGRP_HELLO_INTERVAL_DEFAULT)
 			vty_out(vty, " ip hello-interval eigrp %u\n",
-				IF_DEF_PARAMS(ifp)->v_hello);
-		if (IF_DEF_PARAMS(ifp)->v_wait != EIGRP_HOLD_INTERVAL_DEFAULT)
+				ei->params.v_hello);
+		if (ei->params.v_wait != EIGRP_HOLD_INTERVAL_DEFAULT)
 			vty_out(vty, " ip hold-time eigrp %u\n",
-				IF_DEF_PARAMS(ifp)->v_wait);
+				ei->params.v_wait);
 
 		vty_endframe(vty, "!\n");
 	}
@@ -291,8 +292,10 @@ DEFUN (eigrp_passive_interface,
 	char *ifname = argv[1]->arg;
 
 	for (ALL_LIST_ELEMENTS_RO(eigrp->eiflist, node, ei)) {
-		if (strcmp(ifname, ei->ifp->name) == 0)
-			SET_IF_PARAM(IF_DEF_PARAMS(ei->ifp), passive_interface);
+		if (strcmp(ifname, ei->ifp->name) == 0) {
+			ei->params.passive_interface = EIGRP_IF_PASSIVE;
+			return CMD_SUCCESS;
+		}
 	}
 	return CMD_SUCCESS;
 }
@@ -310,9 +313,10 @@ DEFUN (no_eigrp_passive_interface,
 	char *ifname = argv[2]->arg;
 
 	for (ALL_LIST_ELEMENTS_RO(eigrp->eiflist, node, ei)) {
-		if (strcmp(ifname, ei->ifp->name) == 0)
-			UNSET_IF_PARAM(IF_DEF_PARAMS(ei->ifp),
-				       passive_interface);
+		if (strcmp(ifname, ei->ifp->name) == 0) {
+			ei->params.passive_interface = EIGRP_IF_ACTIVE;
+			return CMD_SUCCESS;
+		}
 	}
 
 	return CMD_SUCCESS;
@@ -599,6 +603,7 @@ DEFUN (eigrp_if_delay,
        "Throughput delay (tens of microseconds)\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	struct eigrp *eigrp;
 	u_int32_t delay;
 
@@ -609,9 +614,13 @@ DEFUN (eigrp_if_delay,
 		return CMD_SUCCESS;
 	}
 
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
 	delay = atoi(argv[1]->arg);
 
-	IF_DEF_PARAMS(ifp)->delay = delay;
+	ei->params.delay = delay;
 	eigrp_if_reset(ifp);
 
 	return CMD_SUCCESS;
@@ -625,6 +634,7 @@ DEFUN (no_eigrp_if_delay,
        "Throughput delay (tens of microseconds)\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	struct eigrp *eigrp;
 
 	eigrp = eigrp_lookup();
@@ -633,8 +643,12 @@ DEFUN (no_eigrp_if_delay,
 
 		return CMD_SUCCESS;
 	}
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
 
-	IF_DEF_PARAMS(ifp)->delay = EIGRP_DELAY_DEFAULT;
+	ei->params.delay = EIGRP_DELAY_DEFAULT;
 	eigrp_if_reset(ifp);
 
 	return CMD_SUCCESS;
@@ -648,6 +662,7 @@ DEFUN (eigrp_if_bandwidth,
        "Bandwidth in kilobits\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	u_int32_t bandwidth;
 	struct eigrp *eigrp;
 
@@ -657,9 +672,14 @@ DEFUN (eigrp_if_bandwidth,
 		return CMD_SUCCESS;
 	}
 
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
+
 	bandwidth = atoi(argv[1]->arg);
 
-	IF_DEF_PARAMS(ifp)->bandwidth = bandwidth;
+	ei->params.bandwidth = bandwidth;
 	eigrp_if_reset(ifp);
 
 	return CMD_SUCCESS;
@@ -674,6 +694,7 @@ DEFUN (no_eigrp_if_bandwidth,
        "Bandwidth in kilobits\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	struct eigrp *eigrp;
 
 	eigrp = eigrp_lookup();
@@ -682,7 +703,12 @@ DEFUN (no_eigrp_if_bandwidth,
 		return CMD_SUCCESS;
 	}
 
-	IF_DEF_PARAMS(ifp)->bandwidth = EIGRP_BANDWIDTH_DEFAULT;
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
+
+	ei->params.bandwidth = EIGRP_BANDWIDTH_DEFAULT;
 	eigrp_if_reset(ifp);
 
 	return CMD_SUCCESS;
@@ -697,6 +723,7 @@ DEFUN (eigrp_if_ip_hellointerval,
        "Seconds between hello transmissions\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	u_int32_t hello;
 	struct eigrp *eigrp;
 
@@ -706,9 +733,14 @@ DEFUN (eigrp_if_ip_hellointerval,
 		return CMD_SUCCESS;
 	}
 
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
+
 	hello = atoi(argv[3]->arg);
 
-	IF_DEF_PARAMS(ifp)->v_hello = hello;
+	ei->params.v_hello = hello;
 
 	return CMD_SUCCESS;
 }
@@ -723,9 +755,8 @@ DEFUN (no_eigrp_if_ip_hellointerval,
        "Seconds between hello transmissions\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	struct eigrp *eigrp;
-	struct eigrp_interface *ei;
-	struct listnode *node, *nnode;
 
 	eigrp = eigrp_lookup();
 	if (eigrp == NULL) {
@@ -733,16 +764,16 @@ DEFUN (no_eigrp_if_ip_hellointerval,
 		return CMD_SUCCESS;
 	}
 
-	IF_DEF_PARAMS(ifp)->v_hello = EIGRP_HELLO_INTERVAL_DEFAULT;
-
-	for (ALL_LIST_ELEMENTS(eigrp->eiflist, node, nnode, ei)) {
-		if (ei->ifp == ifp) {
-			THREAD_TIMER_OFF(ei->t_hello);
-			thread_add_timer(master, eigrp_hello_timer, ei, 1,
-					 &ei->t_hello);
-			break;
-		}
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
 	}
+
+	ei->params.v_hello = EIGRP_HELLO_INTERVAL_DEFAULT;
+
+	THREAD_TIMER_OFF(ei->t_hello);
+	thread_add_timer(master, eigrp_hello_timer, ei, 1,
+			 &ei->t_hello);
 
 	return CMD_SUCCESS;
 }
@@ -756,6 +787,7 @@ DEFUN (eigrp_if_ip_holdinterval,
        "Seconds before neighbor is considered down\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	u_int32_t hold;
 	struct eigrp *eigrp;
 
@@ -765,9 +797,14 @@ DEFUN (eigrp_if_ip_holdinterval,
 		return CMD_SUCCESS;
 	}
 
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
+
 	hold = atoi(argv[3]->arg);
 
-	IF_DEF_PARAMS(ifp)->v_wait = hold;
+	ei->params.v_wait = hold;
 
 	return CMD_SUCCESS;
 }
@@ -835,6 +872,7 @@ DEFUN (no_eigrp_if_ip_holdinterval,
        "Seconds before neighbor is considered down\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	struct eigrp *eigrp;
 
 	eigrp = eigrp_lookup();
@@ -843,22 +881,27 @@ DEFUN (no_eigrp_if_ip_holdinterval,
 		return CMD_SUCCESS;
 	}
 
-	IF_DEF_PARAMS(ifp)->v_wait = EIGRP_HOLD_INTERVAL_DEFAULT;
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
+
+	ei->params.v_wait = EIGRP_HOLD_INTERVAL_DEFAULT;
 
 	return CMD_SUCCESS;
 }
 
-static int str2auth_type(const char *str, struct interface *ifp)
+static int str2auth_type(const char *str, struct eigrp_interface *ei)
 {
 	/* Sanity check. */
 	if (str == NULL)
 		return CMD_WARNING_CONFIG_FAILED;
 
 	if (strncmp(str, "md5", 3) == 0) {
-		IF_DEF_PARAMS(ifp)->auth_type = EIGRP_AUTH_TYPE_MD5;
+		ei->params.auth_type = EIGRP_AUTH_TYPE_MD5;
 		return CMD_SUCCESS;
 	} else if (strncmp(str, "hmac-sha-256", 12) == 0) {
-		IF_DEF_PARAMS(ifp)->auth_type = EIGRP_AUTH_TYPE_SHA256;
+		ei->params.auth_type = EIGRP_AUTH_TYPE_SHA256;
 		return CMD_SUCCESS;
 	}
 
@@ -877,6 +920,7 @@ DEFUN (eigrp_authentication_mode,
        "HMAC SHA256 algorithm \n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	struct eigrp *eigrp;
 
 	eigrp = eigrp_lookup();
@@ -885,12 +929,17 @@ DEFUN (eigrp_authentication_mode,
 		return CMD_SUCCESS;
 	}
 
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
+
 	//  if(strncmp(argv[2], "md5",3))
 	//    IF_DEF_PARAMS (ifp)->auth_type = EIGRP_AUTH_TYPE_MD5;
 	//  else if(strncmp(argv[2], "hmac-sha-256",12))
 	//    IF_DEF_PARAMS (ifp)->auth_type = EIGRP_AUTH_TYPE_SHA256;
 
-	return str2auth_type(argv[5]->arg, ifp);
+	return str2auth_type(argv[5]->arg, ei);
 }
 
 DEFUN (no_eigrp_authentication_mode,
@@ -906,6 +955,7 @@ DEFUN (no_eigrp_authentication_mode,
        "HMAC SHA256 algorithm \n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	struct eigrp *eigrp;
 
 	eigrp = eigrp_lookup();
@@ -914,7 +964,12 @@ DEFUN (no_eigrp_authentication_mode,
 		return CMD_SUCCESS;
 	}
 
-	IF_DEF_PARAMS(ifp)->auth_type = EIGRP_AUTH_TYPE_NONE;
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
+
+	ei->params.auth_type = EIGRP_AUTH_TYPE_NONE;
 
 	return CMD_SUCCESS;
 }
@@ -930,6 +985,7 @@ DEFUN (eigrp_authentication_keychain,
        "Name of key-chain\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	struct eigrp *eigrp;
 	struct keychain *keychain;
 
@@ -939,14 +995,19 @@ DEFUN (eigrp_authentication_keychain,
 		return CMD_SUCCESS;
 	}
 
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
+
 	keychain = keychain_lookup(argv[4]->arg);
 	if (keychain != NULL) {
-		if (IF_DEF_PARAMS(ifp)->auth_keychain) {
-			free(IF_DEF_PARAMS(ifp)->auth_keychain);
-			IF_DEF_PARAMS(ifp)->auth_keychain =
+		if (ei->params.auth_keychain) {
+			free(ei->params.auth_keychain);
+			ei->params.auth_keychain =
 				strdup(keychain->name);
 		} else
-			IF_DEF_PARAMS(ifp)->auth_keychain =
+			ei->params.auth_keychain =
 				strdup(keychain->name);
 	} else
 		vty_out(vty, "Key chain with specified name not found\n");
@@ -966,6 +1027,7 @@ DEFUN (no_eigrp_authentication_keychain,
        "Name of key-chain\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
+	struct eigrp_interface *ei = ifp->info;
 	struct eigrp *eigrp;
 
 	eigrp = eigrp_lookup();
@@ -974,10 +1036,15 @@ DEFUN (no_eigrp_authentication_keychain,
 		return CMD_SUCCESS;
 	}
 
-	if ((IF_DEF_PARAMS(ifp)->auth_keychain != NULL)
-	    && (strcmp(IF_DEF_PARAMS(ifp)->auth_keychain, argv[5]->arg) == 0)) {
-		free(IF_DEF_PARAMS(ifp)->auth_keychain);
-		IF_DEF_PARAMS(ifp)->auth_keychain = NULL;
+	if (!ei) {
+		vty_out(vty, " EIGRP not configured on this interface\n");
+		return CMD_SUCCESS;
+	}
+
+	if ((ei->params.auth_keychain != NULL)
+	    && (strcmp(ei->params.auth_keychain, argv[5]->arg) == 0)) {
+		free(ei->params.auth_keychain);
+		ei->params.auth_keychain = NULL;
 	} else
 		vty_out(vty,
 			"Key chain with specified name not configured on interface\n");


### PR DESCRIPTION
EIGRP had an interesting approach to interfaces.  It created a ifp->info pointer that contained configuration information and it created a 'struct eigrp_interface *' pointer per connected address on an interface.  The `struct eigrp_interface` had data that should have been needed once per interface( in fact there really isn't a whole lot of need to track the connected data structures like they did.  

Glom the ifp->info pointer into `struct eigrp_interface` and then clean it up removing the levels of abstraction that made this possible.  

At this point in time.  This code passes the topotests.  I would not be surprised if we find an edge case of where this falls down.  In any event the code is in a better shape than what it was found in.