### PR TITLE
ldpd: Fix compiler warning about uninitialized rt

### DIFF
--- a/ldpd/ldp_vty_exec.c
+++ b/ldpd/ldp_vty_exec.c
@@ -1509,7 +1509,7 @@ ldp_vty_dispatch_lib(struct vty *vty, struct imsg *imsg,
     struct show_params *params, json_object *json)
 {
 	static bool	 filtered = false;
-	struct ctl_rt	*rt;
+	struct ctl_rt	*rt = NULL;
 	struct prefix	 prefix;
 	int		 ret;
 


### PR DESCRIPTION
Certain compilers cannot recognize that rt is
actually being init'ed, but let's set it to
NULL 'till we get them updated.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>