### PR TITLE
Add iproute2 as dependency alternative in Debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ XS-Testsuite: autopkgtest
 
 Package: frr
 Architecture: any
-Depends: ${shlibs:Depends}, logrotate (>= 3.2-11), iproute, ${misc:Depends}, libc-ares2
+Depends: ${shlibs:Depends}, logrotate (>= 3.2-11), iproute2 | iproute, ${misc:Depends}, libc-ares2
 Pre-Depends: adduser
 Conflicts: zebra, zebra-pj, quagga
 Replaces: zebra, zebra-pj


### PR DESCRIPTION
iproute has been a transitional package that only depends on iproute2
since Debian Jessie or Ubuntu 14.04. To avoid installing this transitional
dummy package on newer installations we add iproute2 as a dependency
alternative to iproute. The iproute dependency can be dropped when
wheezy / 12.04 support is no longer needed.