### PR TITLE
eigrpd: Convert topology list to a table

### DIFF
--- a/eigrpd/eigrp_structs.h
+++ b/eigrpd/eigrp_structs.h
@@ -100,7 +100,7 @@ struct eigrp {
 
 	struct route_table *networks; /* EIGRP config networks. */
 
-	struct list *topology_table;
+	struct route_table *topology_table;
 
 	uint64_t serno; /* Global serial number counter for topology entry
 			   changes*/

--- a/eigrpd/eigrp_topology.h
+++ b/eigrpd/eigrp_topology.h
@@ -33,23 +33,25 @@
 #define _ZEBRA_EIGRP_TOPOLOGY_H
 
 /* EIGRP Topology table related functions. */
-extern struct list *eigrp_topology_new(void);
-extern void eigrp_topology_init(struct list *);
+extern struct route_table *eigrp_topology_new(void);
+extern void eigrp_topology_init(struct route_table *table);
 extern struct eigrp_prefix_entry *eigrp_prefix_entry_new(void);
 extern struct eigrp_nexthop_entry *eigrp_nexthop_entry_new(void);
-extern void eigrp_topology_free(struct list *);
-extern void eigrp_topology_cleanup(struct list *);
-extern void eigrp_prefix_entry_add(struct list *, struct eigrp_prefix_entry *);
+extern void eigrp_topology_free(struct route_table *table);
+extern void eigrp_topology_cleanup(struct route_table *table);
+extern void eigrp_prefix_entry_add(struct route_table *table,
+				   struct eigrp_prefix_entry *pe);
 extern void eigrp_nexthop_entry_add(struct eigrp_prefix_entry *,
 				     struct eigrp_nexthop_entry *);
-extern void eigrp_prefix_entry_delete(struct list *,
-				      struct eigrp_prefix_entry *);
+extern void eigrp_prefix_entry_delete(struct route_table *table,
+				      struct eigrp_prefix_entry *pe);
 extern void eigrp_nexthop_entry_delete(struct eigrp_prefix_entry *,
 					struct eigrp_nexthop_entry *);
-extern void eigrp_topology_delete_all(struct list *);
+extern void eigrp_topology_delete_all(struct route_table *table);
 extern unsigned int eigrp_topology_table_isempty(struct list *);
 extern struct eigrp_prefix_entry *
-eigrp_topology_table_lookup_ipv4(struct list *, struct prefix *);
+eigrp_topology_table_lookup_ipv4(struct route_table *table,
+				 struct prefix *p);
 extern struct list *eigrp_topology_get_successor(struct eigrp_prefix_entry *);
 extern struct list *
 eigrp_topology_get_successor_max(struct eigrp_prefix_entry *pe,
@@ -64,7 +66,7 @@ extern enum metric_change eigrp_topology_update_distance(struct eigrp_fsm_action
 extern void eigrp_update_routing_table(struct eigrp_prefix_entry *);
 extern void eigrp_topology_neighbor_down(struct eigrp *,
 					 struct eigrp_neighbor *);
-extern void eigrp_update_topology_table_prefix(struct list *,
-					       struct eigrp_prefix_entry *);
+extern void eigrp_update_topology_table_prefix(struct route_table *table,
+					       struct eigrp_prefix_entry *pe);
 
 #endif

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -466,9 +466,10 @@ DEFUN (show_ip_eigrp_topology,
        "Show all links in topology table\n")
 {
 	struct eigrp *eigrp;
-	struct listnode *node, *node2;
+	struct listnode *node;
 	struct eigrp_prefix_entry *tn;
 	struct eigrp_nexthop_entry *te;
+	struct route_node *rn;
 	int first;
 
 	eigrp = eigrp_lookup();
@@ -479,9 +480,13 @@ DEFUN (show_ip_eigrp_topology,
 
 	show_ip_eigrp_topology_header(vty, eigrp);
 
-	for (ALL_LIST_ELEMENTS_RO(eigrp->topology_table, node, tn)) {
+	for (rn = route_top(eigrp->topology_table); rn; rn = route_next(rn)) {
+		if (!rn->info)
+			continue;
+
+		tn = rn->info;
 		first = 1;
-		for (ALL_LIST_ELEMENTS_RO(tn->entries, node2, te)) {
+		for (ALL_LIST_ELEMENTS_RO(tn->entries, node, te)) {
 			if (argc == 5
 			    || (((te->flags
 				  & EIGRP_NEXTHOP_ENTRY_SUCCESSOR_FLAG)

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -158,7 +158,7 @@ static struct eigrp *eigrp_new(const char *AS)
 	/* init internal data structures */
 	eigrp->eiflist = list_new();
 	eigrp->passive_interface_default = EIGRP_IF_ACTIVE;
-	eigrp->networks = route_table_init();
+	eigrp->networks = eigrp_topology_new();
 
 	if ((eigrp_socket = eigrp_sock_init()) < 0) {
 		zlog_err(
@@ -181,7 +181,7 @@ static struct eigrp *eigrp_new(const char *AS)
 	thread_add_read(master, eigrp_read, eigrp, eigrp->fd, &eigrp->t_read);
 	eigrp->oi_write_q = list_new();
 
-	eigrp->topology_table = eigrp_topology_new();
+	eigrp->topology_table = route_table_init();
 
 	eigrp->neighbor_self = eigrp_nbr_new(NULL);
 	eigrp->neighbor_self->src.s_addr = INADDR_ANY;


### PR DESCRIPTION
The EIGRP topology list is an extremely inefficient
way to store data about the known routes.  Convert
to using a table.

Signed-off-by: Donald Sharp <sharpd@cumulusnetorks.com>