### PR TITLE
ospf6d: fix ospf6d crash during sigterm/shutdown

### DIFF
--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -125,7 +125,6 @@ static void sigint(void)
 static void sigterm(void)
 {
 	zlog_notice("Terminating on signal SIGTERM");
-	ospf6_clean();
 	ospf6_exit(0);
 }
 

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -683,9 +683,9 @@ struct ospf6_route *ospf6_route_add(struct ospf6_route *route,
 
 	/* Else, this is the brand new route regarding to the prefix */
 	if (IS_OSPF6_DEBUG_ROUTE(MEMORY))
-		zlog_debug("%s %p: route add %p: brand new route",
+		zlog_debug("%s %p: route add %p %s : brand new route",
 			   ospf6_route_table_name(table), (void *)table,
-			   (void *)route);
+			   (void *)route, buf);
 	else if (IS_OSPF6_DEBUG_ROUTE(TABLE))
 		zlog_debug("%s: route add: brand new route",
 			   ospf6_route_table_name(table));
@@ -760,9 +760,9 @@ void ospf6_route_remove(struct ospf6_route *route,
 		prefix2str(&route->prefix, buf, sizeof(buf));
 
 	if (IS_OSPF6_DEBUG_ROUTE(MEMORY))
-		zlog_debug("%s %p: route remove %p: %s rnode refcount %u",
+		zlog_debug("%s %p: route remove %p: %s refcount %u",
 			   ospf6_route_table_name(table), (void *)table,
-			   (void *)route, buf, route->rnode->lock);
+			   (void *)route, buf, route->lock);
 	else if (IS_OSPF6_DEBUG_ROUTE(TABLE))
 		zlog_debug("%s: route remove: %s",
 			   ospf6_route_table_name(table), buf);
@@ -801,6 +801,7 @@ void ospf6_route_remove(struct ospf6_route *route,
 
 	SET_FLAG(route->flag, OSPF6_ROUTE_WAS_REMOVED);
 
+	/* Note hook_remove may call ospf6_route_remove */
 	if (table->hook_remove)
 		(*table->hook_remove)(route);
 


### PR DESCRIPTION
During signterm (shutdown) ospf6_clean calls route_remove for brouter_table,
during route_remove brouter_table remove hook function is invoked
which in turns calls router_remove is any of the LSA has max age or
cost is infinity, which leads to stack corruption trying to delete
same route node.
Similar to 'no router ospf6' or 'no area ..' command where LSDB is
cleaned up then brouter route table clean up is called.
Clean some of route trace to have route related fields.

==7900== Invalid read of size 8
==7900==    at 0x129FED: **ospf6_route_remove** (ospf6_route.c:763)
==7900==    by 0x12A401: ospf6_route_remove_all (ospf6_route.c:929)
==7900==    by 0x115A73: sigterm (ospf6_main.c:128)
==7900==    by 0x4E7BBDB: quagga_sigevent_process (sigevent.c:103)
==7900==    by 0x4E853E7: thread_fetch (thread.c:1321)
==7900==    by 0x4E6AB42: frr_run (libfrr.c:899)
==7900==    by 0x115411: main (ospf6_main.c:209)
==7900==  Address 0xa37fa20 is 0 bytes inside a block of size 184 free'd
==7900==    at 0x4C29E90: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7900==    by 0x12A120: **ospf6_route_remove** (ospf6_route.c:807)
==7900==    by 0x13337E: ospf6_abr_examin_summary (ospf6_abr.c:770)
==7900==    by 0x13378D: ospf6_abr_examin_brouter (ospf6_abr.c:969)
==7900==    by 0x12D84D: ospf6_top_brouter_hook_remove (ospf6_top.c:106)
==7900==    by 0x12A118: ospf6_route_remove (ospf6_route.c:805)
==7900==    by 0x12A401: ospf6_route_remove_all (ospf6_route.c:929)
==7900==    by 0x115A73: sigterm (ospf6_main.c:128)



Ticket:CM-17932

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>