### PR TITLE
ospfd: fix ospf nssa command

### DIFF
--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -524,7 +524,7 @@ extern int ospf_area_stub_unset(struct ospf *, struct in_addr);
 extern int ospf_area_no_summary_set(struct ospf *, struct in_addr);
 extern int ospf_area_no_summary_unset(struct ospf *, struct in_addr);
 extern int ospf_area_nssa_set(struct ospf *, struct in_addr);
-extern int ospf_area_nssa_unset(struct ospf *, struct in_addr);
+extern int ospf_area_nssa_unset(struct ospf *, struct in_addr, int);
 extern int ospf_area_nssa_translator_role_set(struct ospf *, struct in_addr,
 					      int);
 extern int ospf_area_export_list_set(struct ospf *, struct ospf_area *,
@@ -574,4 +574,6 @@ extern void ospf_vrf_terminate(void);
 extern void ospf_vrf_link(struct ospf *ospf, struct vrf *vrf);
 extern void ospf_vrf_unlink(struct ospf *ospf, struct vrf *vrf);
 const char *ospf_vrf_id_to_name(vrf_id_t vrf_id);
+int ospf_area_nssa_no_summary_set(struct ospf *, struct in_addr);
+
 #endif /* _ZEBRA_OSPFD_H */


### PR DESCRIPTION
-Fix ordering of nssa command with translate options
and no-summary option.
Just like ospf stub no-summary keep the order order
of nssa no-summary.
- Fix NSSA options.
- Avoid displaying translate-candiate (default) option
in running-config.

cumulus(config-router)# area 2.2.2.2 nssa
  <cr>
  no-summary           Do not inject inter-area routes into nssa
  translate-always     Configure NSSA-ABR to always translate
  translate-candidate  Configure NSSA-ABR for translate election (default)
  translate-never      Configure NSSA-ABR to never translate

Running-config output:
router ospf
 area 2.2.2.2 nssa translate-always
 area 2.2.2.2 nssa no-summary

Ticket:CM-8312

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>