### PR TITLE
lib: linklist avoid access NULL->data

### DIFF
--- a/lib/csv.c
+++ b/lib/csv.c
@@ -284,6 +284,8 @@ csv_record_t *csv_encode_record(csv_t *csv, csv_record_t *rec, int count, ...)
 
 	va_start(list, count);
 	str = csv_field_iter(rec, &fld);
+	if (!fld)
+		return NULL;
 	for (tempc = 0; tempc < count; tempc++) {
 		col = va_arg(list, char *);
 		for (i = 0; i < fld->field_len; i++) {

--- a/lib/ferr.c
+++ b/lib/ferr.c
@@ -74,6 +74,7 @@ static ferr_r ferr_set_va(const char *file, int line, const char *func,
 			/* we're screwed */
 			zlog_err("out of memory while allocating error info");
 			raise(SIGSEGV);
+			abort(); /* raise() can return, but raise(SIGSEGV) shall not */
 		}
 
 		pthread_setspecific(errkey, error);

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -56,7 +56,8 @@ struct list {
 #define listtail(X) ((X) ? ((X)->tail) : NULL)
 #define listcount(X) ((X)->count)
 #define list_isempty(X) ((X)->head == NULL && (X)->tail == NULL)
-#define listgetdata(X) (assert((X)->data != NULL), (X)->data)
+/* return X->data only if X and X->data are not NULL */
+#define listgetdata(X) (assert(X), assert((X)->data != NULL), (X)->data)
 
 /* Prototypes. */
 extern struct list *

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -128,7 +128,7 @@ int nexthop_labels_match(struct nexthop *nh1, struct nexthop *nh2)
 
 	nhl1 = nh1->nh_label;
 	nhl2 = nh2->nh_label;
-	if ((nhl1 && !nhl2) || (!nhl1 && nhl2))
+	if (!nhl1 || !nhl2)
 		return 0;
 
 	if (nhl1->num_labels != nhl2->num_labels)


### PR DESCRIPTION
Let's assert(NULL) if the datastructure is not set.
The code assumes that the pointer is always non NULL. So, let's enforce
this semantic.

Signed-off-by: Vincent Jardin <vincent.jardin@6wind.com>