### PR TITLE
ospf6d: Fix snmp compile breakage

### DIFF
--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -155,7 +155,7 @@ struct ospf6_lsa_handler {
 };
 
 #define OSPF6_LSA_IS_KNOWN(t)                                                  \
-	(ospf6_get_lsa_handler(t).lh_type != OSPF6_LSTYPE_UNKNOWN ? 1 : 0)
+	(ospf6_get_lsa_handler(t)->lh_type != OSPF6_LSTYPE_UNKNOWN ? 1 : 0)
 
 extern vector ospf6_lsa_handler_vector;
 


### PR DESCRIPTION
The recent clang fixes for Static Analysis were run without
compiling `--enable-snmp` these changes broke the snmp build.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>