### PR TITLE
bgpd: only allow unicast|multicast config commands in non-core BGP instances

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6045,7 +6045,13 @@ DEFUN_NOSH (address_family_ipv4_safi,
 {
 
 	if (argc == 3) {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
 		safi_t safi = bgp_vty_safi_from_str(argv[2]->text);
+		if (bgp->inst_type != BGP_INSTANCE_TYPE_DEFAULT &&
+		    safi != SAFI_UNICAST && safi != SAFI_MULTICAST) {
+			vty_out(vty, "Only Unicast and Multicast SAFIs supported in non-core instances.\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
 		vty->node = bgp_node_type(AFI_IP, safi);
 	} else
 		vty->node = BGP_IPV4_NODE;
@@ -6061,7 +6067,13 @@ DEFUN_NOSH (address_family_ipv6_safi,
        BGP_SAFI_WITH_LABEL_HELP_STR)
 {
 	if (argc == 3) {
+		VTY_DECLVAR_CONTEXT(bgp, bgp);
 		safi_t safi = bgp_vty_safi_from_str(argv[2]->text);
+		if (bgp->inst_type != BGP_INSTANCE_TYPE_DEFAULT &&
+		    safi != SAFI_UNICAST && safi != SAFI_MULTICAST) {
+			vty_out(vty, "Only Unicast and Multicast SAFIs supported in non-core instances.\n");
+			return CMD_WARNING_CONFIG_FAILED;
+		}
 		vty->node = bgp_node_type(AFI_IP6, safi);
 	} else
 		vty->node = BGP_IPV6_NODE;
@@ -6100,6 +6112,11 @@ DEFUN_NOSH (address_family_evpn,
        "Address Family\n"
        "Address Family modifier\n")
 {
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	if (bgp->inst_type != BGP_INSTANCE_TYPE_DEFAULT) {
+		vty_out(vty, "Only Unicast and Multicast SAFIs supported in non-core instances.\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 	vty->node = BGP_EVPN_NODE;
 	return CMD_SUCCESS;
 }

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -122,7 +122,7 @@ int rfapi_get_response_lifetime_default(void *rfp_start_val)
 /*------------------------------------------
  * rfapi_is_vnc_configured
  *
- * Returns if VNC (BGP VPN messaging /VPN & encap SAFIs) are configured
+ * Returns if VNC is configured
  *
  * input:
  *    rfp_start_val     value returned by rfp_start or
@@ -137,7 +137,9 @@ int rfapi_get_response_lifetime_default(void *rfp_start_val)
 int rfapi_is_vnc_configured(void *rfp_start_val)
 {
 	struct bgp *bgp = rfapi_bgp_lookup_by_rfp(rfp_start_val);
-	return bgp_rfapi_is_vnc_configured(bgp);
+	if (bgp_rfapi_is_vnc_configured(bgp) == 0)
+		return 0;
+	return ENXIO;
 }
 
 

--- a/bgpd/rfapi/rfapi.h
+++ b/bgpd/rfapi/rfapi.h
@@ -862,7 +862,7 @@ extern int rfapi_get_response_lifetime_default(void *rfp_start_val);
 /*------------------------------------------
  * rfapi_is_vnc_configured
  *
- * Returns if VNC (BGP VPN messaging /VPN & encap SAFIs) are configured
+ * Returns if VNC is configured
  *
  * input:
  *    rfp_start_val     value returned by rfp_start or

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -3530,7 +3530,8 @@ void rfapiBgpInfoFilteredImportVPN(
 			 * Compare types. Doing so prevents a RFP-originated
 			 * route from matching an imported route, for example.
 			 */
-			if (bi->type != type) /* should be handled by RDs, but warn for now */
+			if (VNC_DEBUG(VERBOSE) && bi->type != type)
+				/* should be handled by RDs, but warn for now */
 				zlog_warn("%s: type mismatch! (bi=%d, arg=%d)",
 					  __func__, bi->type, type);
 

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -3530,7 +3530,9 @@ void rfapiBgpInfoFilteredImportVPN(
 			 * Compare types. Doing so prevents a RFP-originated
 			 * route from matching an imported route, for example.
 			 */
-			assert(bi->type == type);
+			if (bi->type != type) /* should be handled by RDs, but warn for now */
+				zlog_warn("%s: type mismatch! (bi=%d, arg=%d)",
+					  __func__, bi->type, type);
 
 			vnc_zlog_debug_verbose("%s: found matching bi",
 					       __func__);

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -4078,8 +4078,7 @@ static int check_and_display_is_vnc_running(struct vty *vty)
 		return 1; /* is running */
 
 	if (vty) {
-		vty_out(vty,
-			"VNC is not configured.\n");
+		vty_out(vty, "VNC is not configured.\n");
 	}
 	return 0; /* not running */
 }

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -4074,12 +4074,12 @@ DEFUN (clear_vnc_mac_all_prefix,
 /* copied from rfp_vty.c */
 static int check_and_display_is_vnc_running(struct vty *vty)
 {
-	if (!bgp_rfapi_is_vnc_configured(NULL))
+	if (bgp_rfapi_is_vnc_configured(NULL) == 0)
 		return 1; /* is running */
 
 	if (vty) {
 		vty_out(vty,
-			"VNC is not configured. (There are no configured BGP VPN SAFI peers.)\n");
+			"VNC is not configured.\n");
 	}
 	return 0; /* not running */
 }
@@ -4089,7 +4089,7 @@ static int rfapi_vty_show_nve_summary(struct vty *vty,
 {
 	struct bgp *bgp_default = bgp_get_default();
 	struct rfapi *h;
-	int is_vnc_running = !bgp_rfapi_is_vnc_configured(bgp_default);
+	int is_vnc_running = (bgp_rfapi_is_vnc_configured(bgp_default) == 0);
 
 	int active_local_routes;
 	int active_remote_routes;


### PR DESCRIPTION
also remove an RFAPI assert blcoking a valid use case.