### PR TITLE
babeld: Do not copy beyond end of data

### DIFF
--- a/babeld/babel_interface.h
+++ b/babeld/babel_interface.h
@@ -50,7 +50,7 @@ struct babel_interface {
     char have_buffered_id;
     char have_buffered_nh;
     char have_buffered_prefix;
-    unsigned char buffered_id[16];
+    unsigned char buffered_id[8];
     unsigned char buffered_nh[4];
     unsigned char buffered_prefix[16];
     unsigned char *sendbuf;

--- a/babeld/message.c
+++ b/babeld/message.c
@@ -1080,7 +1080,7 @@ really_send_update(struct interface *ifp,
             accumulate_bytes(ifp, id, 8);
             end_message(ifp, MESSAGE_ROUTER_ID, 10);
         }
-        memcpy(babel_ifp->buffered_id, id, 16);
+        memcpy(babel_ifp->buffered_id, id, sizeof(babel_ifp->buffered_id));
         babel_ifp->have_buffered_id = 1;
     }
 


### PR DESCRIPTION
The function really_send_update takes a 'const unsigned char *id'.
and is called with myid(a 8 byte array) and route->src->id(an 8
byte array), but we copy these pointers into
babel_ifp->buffered_id which is a 16 byte array.

Adjust the size of buffered_id to be 8 bytes and fix the copy
to only copy the 8 bytes.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>