### PR TITLE
bgpd: fix werror warning for potentially uninitialized variable

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -651,7 +651,7 @@ int bgp_show_mpls_vpn(struct vty *vty, afi_t afi, struct prefix_rd *prd,
 
 					if (rd_header) {
 						u_int16_t type;
-						struct rd_as rd_as;
+						struct rd_as rd_as = {0};
 						struct rd_ip rd_ip = {0};
 #if ENABLE_BGP_VNC
 						struct rd_vnc_eth rd_vnc_eth = {


### PR DESCRIPTION
This fixes an error I get with -werror build:

	bgp_mplsvpn.c: In function ‘bgp_show_mpls_vpn’:
	bgp_mplsvpn.c:709:9: error: ‘rd_as.as’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
			 vty_out(vty,
			 ^
	bgp_mplsvpn.c:709:9: error: ‘rd_as.val’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
	cc1: all warnings being treated as errors
