### PR TITLE
ospf6d: Make ospf6_prefix have an empty v6 addr at end

### DIFF
--- a/ospf6d/ospf6_proto.h
+++ b/ospf6d/ospf6_proto.h
@@ -62,6 +62,7 @@ struct ospf6_prefix {
 #define prefix_metric        u._prefix_metric
 #define prefix_refer_lstype  u._prefix_referenced_lstype
 	/* followed by one address_prefix */
+	struct in6_addr addr[];
 };
 
 #define OSPF6_PREFIX_OPTION_NU (1 << 0)  /* No Unicast */


### PR DESCRIPTION
The `struct ospf6_prefix` type expects to have space allocated
at the end of the structure for a v6 prefix.  So let's tell
the compiler that there might be more there.  This is to fix
a coverity scan warning.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>