### PR TITLE
lib: Allow hash_get to sidestep expensive hash key generation in some…

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -143,6 +143,9 @@ void *hash_get(struct hash *hash, void *data, void *(*alloc_func)(void *))
 	void *newdata;
 	struct hash_backet *backet;
 
+	if (!alloc_func && !hash->count)
+		return NULL;
+
 	key = (*hash->hash_key)(data);
 	index = key & (hash->size - 1);
 

--- a/lib/table.c
+++ b/lib/table.c
@@ -74,7 +74,6 @@ static struct route_node *route_node_set(struct route_table *table,
 	node = route_node_new(table);
 
 	prefix_copy(&node->p, prefix);
-	apply_mask(&node->p);
 	node->table = table;
 
 	inserted = hash_get(node->table->hash, node, hash_alloc_intern);


### PR DESCRIPTION
… cases

There is no need to generate a hash key *if* the hash_alloc_function
is NULL and the hash is empty.

This changed showed a measurable increase in performance for
table hash lookup for tables that were meant to be empty in
bgp( the distance commands ).

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>