### PR TITLE
ospf6d: Handle lsupdate upto max ospf6 payload

### DIFF
--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -240,7 +240,8 @@ static char *ospf6_lsdesc_backlink(struct ospf6_lsa *lsa, caddr_t lsdesc,
 	}
 
 	if (IS_OSPF6_DEBUG_SPF(PROCESS))
-		zlog_debug("  Backlink %s", (found ? "OK" : "FAIL"));
+		zlog_debug("Vertex %s Lsa %s Backlink %s", v->name, lsa->name,
+			   (found ? "OK" : "FAIL"));
 
 	return found;
 }


### PR DESCRIPTION
While traversing LSUpdate list, if LSUpdate message fills up (w/ LSAs) to the interface MTU size,
Send the existing filled LSUpdate message if max payload exceeds max ospf6 payload,
reset sendbuf (buffer) to fill rest of the remaining LSAs.
Add relevant fields to debugs.

Ticket:CM-18069

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>