### PR TITLE
lib: Fix small memory leak when using command_py.c

### DIFF
--- a/lib/command_py.c
+++ b/lib/command_py.c
@@ -250,6 +250,8 @@ static PyObject *graph_parse(PyTypeObject *type, PyObject *args,
 static void graph_wrap_free(void *arg)
 {
 	struct wrap_graph *wgraph = arg;
+
+	graph_delete_graph(wgraph->graph);
 	free(wgraph->nodewrappers);
 	free(wgraph->definition);
 }


### PR DESCRIPTION
When free'ing memory associated with the wgraph, also
free memory malloced during the initialization.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>