### PR TITLE
Large number

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7068,7 +7068,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				vty_out(vty, "%*s", max_neighbor_width - len,
 					" ");
 
-			vty_out(vty, "4 %10u %7d %7d %8" PRIu64 " %4d %4zd %8s",
+			vty_out(vty, "4 %10u %7u %7u %8" PRIu64 " %4d %4zd %8s",
 				peer->as,
 				peer->open_in + peer->update_in
 					+ peer->keepalive_in + peer->notify_in

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -89,7 +89,7 @@ static void cpu_record_hash_free(void *a)
 static void vty_out_cpu_thread_history(struct vty *vty,
 				       struct cpu_thread_history *a)
 {
-	vty_out(vty, "%5d %10ld.%03ld %9d %8ld %9ld %8ld %9ld", a->total_active,
+	vty_out(vty, "%5d %10lu.%03lu %9u %8lu %9lu %8lu %9lu", a->total_active,
 		a->cpu.total / 1000, a->cpu.total % 1000, a->total_calls,
 		a->cpu.total / a->total_calls, a->cpu.max,
 		a->real.total / a->total_calls, a->real.max);


### PR DESCRIPTION
During a debug session today, I noticed that some display values for a couple commands were not displaying properly because of unsigned values being displayed as signed.