### PR TITLE
bgpd: set timers correctly

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -534,6 +534,10 @@ void bgp_open_send(struct peer *peer)
 	else
 		send_holdtime = peer->bgp->default_holdtime;
 
+	/* set our hold time to the hold time we advertise */
+	peer->v_holdtime = peer->bgp->default_holdtime;
+	peer->v_keepalive = peer->bgp->default_keepalive;
+
 	/* local-as Change */
 	if (peer->change_local_as)
 		local_as = peer->change_local_as;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4581,8 +4581,6 @@ int peer_timers_set(struct peer *peer, u_int32_t keepalive, u_int32_t holdtime)
 	SET_FLAG(peer->config, PEER_CONFIG_TIMER);
 	peer->holdtime = holdtime;
 	peer->keepalive = (keepalive < holdtime / 3 ? keepalive : holdtime / 3);
-	peer->v_holdtime = peer->holdtime;
-	peer->v_keepalive = peer->keepalive;
 
 	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
 		return 0;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4581,6 +4581,8 @@ int peer_timers_set(struct peer *peer, u_int32_t keepalive, u_int32_t holdtime)
 	SET_FLAG(peer->config, PEER_CONFIG_TIMER);
 	peer->holdtime = holdtime;
 	peer->keepalive = (keepalive < holdtime / 3 ? keepalive : holdtime / 3);
+	peer->v_holdtime = peer->holdtime;
+	peer->v_keepalive = peer->keepalive;
 
 	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
 		return 0;


### PR DESCRIPTION
When timers are manually configured differently from the default, we
never set the effective values on the peer. Instead we wait until the
negotiation step upon receipt of an OPEN message from the remote peer.

Among other things, this can cause us to wait the wrong amount of time
in OpenSent before closing the connection in case we never receive an
OPEN.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>