### PR TITLE
Peer name

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -249,10 +249,6 @@ static route_map_result_t route_match_peer(void *rule, struct prefix *prefix,
 		su = &pc->su;
 		peer = ((struct bgp_info *)object)->peer;
 
-		if (!CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IMPORT)
-		    && !CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_EXPORT))
-			return RMAP_NOMATCH;
-
 		if (pc->interface) {
 			if (!peer->conf_if)
 				return RMAP_NOMATCH;

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11334,6 +11334,7 @@ static void bgp_ac_neighbor(vector comps, struct cmd_token *token)
 static const struct cmd_variable_handler bgp_var_neighbor[] = {
 	{.varname = "neighbor", .completions = bgp_ac_neighbor},
 	{.varname = "neighbors", .completions = bgp_ac_neighbor},
+	{.varname = "peer", .completions = bgp_ac_neighbor},
 	{.completions = NULL}};
 
 void bgp_vty_init(void)

--- a/doc/routemap.texi
+++ b/doc/routemap.texi
@@ -5,8 +5,8 @@ Route maps provide a means to both filter and/or apply actions to
 route, hence allowing policy to be applied to routes.
 
 @menu
-* Route Map Command::           
-* Route Map Match Command::     
+* Route Map Command::
+* Route Map Match Command::
 * Route Map Set Command::
 * Route Map Call Command::
 * Route Map Exit Action Command::
@@ -157,6 +157,22 @@ Matches the specified @var{local-preference}.
 
 @deffn {Route-map Command} {match community @var{community_list}} {}
 Matches the specified  @var{community_list}
+@end deffn
+
+@deffn {Route-map Command} {match peer @var{ipv4_addr}} {}
+This is a BGP specific match command.  Matches the peer ip address
+if the neighbor was specified in this manner.
+@end deffn
+
+@deffn {Route-map Command} {match peer @var{ipv6_addr}} {}
+This is a BGP specific match command.  Matches the peer ipv6
+address if the neighbor was specified in this manner.
+@end deffn
+
+@deffn {Route-map Command} {match peer @var{interface_name}} {}
+This is a BGP specific match command.  Matches the peer
+interface name specified if the neighbor was specified
+in this manner.
 @end deffn
 
 @node Route Map Set Command


### PR DESCRIPTION
1) Allow user to specify interface name for `match peer ....`
2) Allow auto-complete `match peer .... ` to work
3) Allow `match peer ..` to be applied to all bgp route-maps if configured.