### PR TITLE
ospf6d: Divide LSupdate to keep size small

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -234,6 +234,7 @@ struct ospf6_area *ospf6_area_create(u_int32_t area_id, struct ospf6 *o, int df)
 	oa->summary_prefix->scope = oa;
 	oa->summary_router = OSPF6_ROUTE_TABLE_CREATE(AREA, SUMMARY_ROUTERS);
 	oa->summary_router->scope = oa;
+	oa->router_lsa_size_limit = 1024 + 256;
 
 	/* set default options */
 	if (CHECK_FLAG(o->flag, OSPF6_STUB_ROUTER)) {


### PR DESCRIPTION
Within OSPFv3 area, Disect Router LSA and
Intra-prefix LSA in order to keep LSA size Small.
Each LSA has unique Link State ID assigned.

Intra-Area-Prefix LSA:
Spread prefixes across multiple intra-area-prefix-LSAs.

This should address  #1218 
Ticket:CM-18069
Testing Done:
Tested 92 ospf6 enabled (point-to-point) interfaces
between two routers.
92 adajancy comes up with Full Neighborship.
Validated 'show ipv6 ospf6 database router detail' &
'show ipv6 ospf6 database intra-prefix detail', each adv-router
has two distinct LSA of such catgory.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>