### PR TITLE
bgpd: Note routemap information even if peer not activated.

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2913,10 +2913,6 @@ static void bgp_route_map_process_update(struct bgp *bgp, const char *rmap_name,
 
 		for (afi = AFI_IP; afi < AFI_MAX; afi++)
 			for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
-				/* Ignore inactive AFI/SAFI */
-				if (!peer->afc[afi][safi])
-					continue;
-
 				/* process in/out/import/export/default-orig
 				 * route-maps */
 				bgp_route_map_process_peer(rmap_name, map, peer,


### PR DESCRIPTION
If upon bgp startup we have this config:

router bgp 64540
 neighbor 192.168.201.134 remote-as external
 !
 address-family ipv4 unicast
  no neighbor 192.168.201.134 activate
  neighbor 192.168.201.134 route-map NEXTHOP in
 exit-address-family

The route-map map pointer for the incoming(or outgoing)
filter was not being saved due to a pre-mature optimization
of not handling the routemap callback if the peer is not
activated.  The function that handles the peers route-maps
is making sure that the peer is in established state
before attempting to actually apply anything so just
call it to set the map pointer.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>