### PR TITLE
bgpd: bump listen() backlog

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -675,7 +675,7 @@ static int bgp_listener(int sock, struct sockaddr *sa, socklen_t salen)
 		return ret;
 	}
 
-	ret = listen(sock, 3);
+	ret = listen(sock, SOMAXCONN);
 	if (ret < 0) {
 		zlog_err("listen: %s", safe_strerror(errno));
 		return ret;


### PR DESCRIPTION
While experimenting with BGPerf I noticed a big convergence time when using a configuration with a lot of BGP test peers, especially when starting them all simultaneously. After investigation I found that the peers where getting connections rejected and they kept waiting to try again. This PR aims to solve this problem by increasing the socket connection backlog queue.

Note: I chose SOMAXCONN which is the plataform definition of the maximum number of connections in the backlog and it was enough for my case, which should also address some workloads with bad links and a lot of peers.

Here is a reduced graph from the data I got:

![elapsed](https://user-images.githubusercontent.com/205063/31842791-8b2b4ed8-b5ce-11e7-9e1e-7a323672a54f.png)