### PR TITLE
Allow FPM to block kernel insertion

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -229,7 +229,7 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 	ri->af = rib_dest_af(dest);
 
 	ri->nlmsg_type = cmd;
-	ri->rtm_table = zvrf_id(rib_dest_vrf(dest));
+	ri->rtm_table = rib_dest_vrf(dest)->table_id;
 	ri->rtm_protocol = RTPROT_UNSPEC;
 
 	/*

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1033,8 +1033,10 @@ int rib_install_kernel(struct route_node *rn, struct route_entry *re,
 	 * Make sure we update the FPM any time we send new information to
 	 * the kernel.
 	 */
-	hook_call(rib_update, rn, "installing in kernel");
-	ret = kernel_route_rib(p, src_p, old, re);
+	if (hook_call(rib_update, rn, "installing in kernel") == 0)
+		ret = kernel_route_rib(p, src_p, old, re);
+	else
+		ret = 0;
 	zvrf->installs++;
 
 	/* If install succeeds, update FIB flag for nexthops. */
@@ -1074,8 +1076,10 @@ int rib_uninstall_kernel(struct route_node *rn, struct route_entry *re)
 	 * Make sure we update the FPM any time we send new information to
 	 * the kernel.
 	 */
-	hook_call(rib_update, rn, "uninstalling from kernel");
-	ret = kernel_route_rib(p, src_p, re, NULL);
+	if (hook_call(rib_update, rn, "uninstalling from kernel") == 0)
+		ret = kernel_route_rib(p, src_p, re, NULL);
+	else
+		ret = 0;
 	zvrf->removals++;
 
 	for (ALL_NEXTHOPS(re->nexthop, nexthop))


### PR DESCRIPTION
We're playing with FIB optimizations through FPM. In so doing, we need a way to make the FPM responsible for keeping the kernel routing table updated instead of FRR; we don't want them to compete in the same routing table.

This PR is one way to achieve that goal; by enabling the FPM with the syntax ```-M fpm:netlink:1```, routes will no longer be automatically inserted into the kernel by FRR. The return from the ```zfpm_trigger_update``` hook, if 1, will tell the calling site to not inject into kernel.

A toy example of how to use this was done by extending fpm-stub: https://github.com/medallia/fpm-stub/commit/e6b7443e36af0c1b4ace994aa160d65d4fe110f6

I'm not entirely happy about the code; the ```strstr(reason, "kernel")``` is pretty ugly, and the (ab)use of 1 as a return value from the hook doesn't feel entirely clean. I'm not familiar enough with the codebase to suggest what the cleanest approach is, or if the current approach is acceptable. Suggestions?

This also fixes a bug in ```zebra_fpm_netlink.c```; if this PR needs extensive rework, I'll pull that fix out as a separate PR.