### PR TITLE
ospfd: show comand for ospf packet stats

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -453,6 +453,15 @@ struct ospf_interface *ospf_if_lookup_recv_if(struct ospf *ospf,
 	return match;
 }
 
+static void ospf_if_reset_stats(struct ospf_interface *oi)
+{
+	oi->hello_in = oi->hello_out = 0;
+	oi->db_desc_in = oi->db_desc_out = 0;
+	oi->ls_req_in = oi->ls_req_out = 0;
+	oi->ls_upd_in = oi->ls_upd_out = 0;
+	oi->ls_ack_in = oi->ls_ack_out = 0;
+}
+
 void ospf_if_stream_set(struct ospf_interface *oi)
 {
 	/* set output fifo queue. */
@@ -467,6 +476,9 @@ void ospf_if_stream_unset(struct ospf_interface *oi)
 	if (oi->obuf) {
 		ospf_fifo_free(oi->obuf);
 		oi->obuf = NULL;
+
+		/*reset protocol stats */
+		ospf_if_reset_stats(oi);
 
 		if (oi->on_write_q) {
 			listnode_delete(ospf->oi_write_q, oi);

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -825,6 +825,26 @@ static int ospf_write(struct thread *thread)
 					"-----------------------------------------------------");
 		}
 
+		switch (type) {
+			case OSPF_MSG_HELLO:
+				oi->hello_out++;
+				break;
+			case OSPF_MSG_DB_DESC:
+				oi->db_desc_out++;
+				break;
+			case OSPF_MSG_LS_REQ:
+				oi->ls_req_out++;
+				break;
+			case OSPF_MSG_LS_UPD:
+				oi->ls_upd_out++;
+				break;
+			case OSPF_MSG_LS_ACK:
+				oi->ls_ack_out++;
+				break;
+			default:
+				break;
+		}
+
 		/* Now delete packet from queue. */
 		ospf_packet_delete(oi);
 


### PR DESCRIPTION
Display OSPFv2 Protocol packets stats per interface.

tor-1# show ip ospf vrf all interface traffic

Interface    HELLO    DB-Desc   LS-Req LS-Update   LS-Ack
             Rx/Tx    Rx/Tx     Rx/Tx  Rx/Tx       Rx/Tx
------------------------------------------------------------
swp1         1/0      2/3       1/1    2/2         1/1
swp2         6/0      2/7       1/1    1/4         3/2

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>