### PR TITLE
Isis lsp_tick fix and improve perfomance for processing LSP updates

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -676,7 +676,7 @@ int isis_circuit_up(struct isis_circuit *circuit)
 
 	circuit->lsp_queue = list_new();
 	circuit->lsp_hash = isis_lsp_hash_new();
-	monotime(&circuit->lsp_queue_last_cleared);
+	circuit->lsp_queue_last_push = monotime(NULL);
 
 	return ISIS_OK;
 }

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -84,7 +84,7 @@ struct isis_circuit {
 	struct thread *t_send_lsp;
 	struct list *lsp_queue;	/* LSPs to be txed (both levels) */
 	struct isis_lsp_hash *lsp_hash; /* Hashtable synchronized with lsp_queue */
-	struct timeval lsp_queue_last_cleared; /* timestamp used to enforce transmit
+	time_t lsp_queue_last_push;    /* timestamp used to enforce transmit
 					* interval;
 					* for scalability, use one timestamp per
 					* circuit, instead of one per lsp per

--- a/isisd/isis_constants.h
+++ b/isisd/isis_constants.h
@@ -73,7 +73,7 @@
 #define MAX_MIN_LSP_GEN_INTERVAL      120  /* RFC 4444 says 65535 */
 #define DEFAULT_MIN_LSP_GEN_INTERVAL  30
 
-#define MIN_LSP_TRANS_INTERVAL        20000 /* Microseconds */
+#define MIN_LSP_RETRANS_INTERVAL      5 /* Seconds */
 
 #define MIN_CSNP_INTERVAL             1
 #define MAX_CSNP_INTERVAL             600

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1805,6 +1805,7 @@ int lsp_tick(struct thread *thread)
 	dnode_t *dnode, *dnode_next;
 	int level;
 	u_int16_t rem_lifetime;
+        time_t now = monotime(NULL);
 
 	lsp_list = list_new();
 
@@ -1883,11 +1884,12 @@ int lsp_tick(struct thread *thread)
 					if (!circuit->lsp_queue)
 						continue;
 
-					if (monotime_since(
-						  &circuit->lsp_queue_last_cleared,
-						  NULL) < MIN_LSP_TRANS_INTERVAL) {
+					if (now - circuit->lsp_queue_last_push
+					    < MIN_LSP_RETRANS_INTERVAL) {
 						continue;
 					}
+
+					circuit->lsp_queue_last_push = now;
 
 					for (ALL_LIST_ELEMENTS_RO(
 						     lsp_list, lspnode, lsp)) {

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -2056,12 +2056,8 @@ int send_lsp(struct thread *thread)
 	lsp = isis_circuit_lsp_queue_pop(circuit);
 	if (!lsp)
 		return ISIS_OK;
-	/* Set the last-cleared time if the queue is empty. */
-	/* TODO: Is is possible that new lsps keep being added to the queue
-	 * that the queue is never empty? */
-	if (list_isempty(circuit->lsp_queue)) {
-		monotime(&circuit->lsp_queue_last_cleared);
-	} else {
+
+	if (!list_isempty(circuit->lsp_queue)) {
 		isis_circuit_schedule_lsp_send(circuit);
 	}
 


### PR DESCRIPTION
<pre>commit 58e1623702c828d286773da0c188af9ba176c030
Author: Christian Franke <chris@opensourcerouting.org>
Date:   Tue Oct 3 01:42:22 2017 +0200

    isisd: optimize per interface lsp send-queue creation</pre>

Introduced a bug which would cause huge churn in the flooding part of IS-IS, since I confused which aspect the timer I modified influences. This pull-request fixes this and also optimizes the processing of LSP updates.