### PR TITLE
Show advertised routes

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -822,6 +822,32 @@ void bgp_attr_unintern_sub(struct attr *attr)
 #endif
 }
 
+/*
+ * We have some show commands that let you experimentally
+ * apply a route-map.  When we apply the route-map
+ * we are reseting values but not saving them for
+ * posterity via intern'ing( because route-maps don't
+ * do that) but at this point in time we need
+ * to compare the new attr to the old and if the
+ * routemap has changed it we need to, as Snoop Dog says,
+ * Drop it like it's hot
+ */
+void bgp_attr_undup(struct attr *new, struct attr *old)
+{
+	if (new->aspath != old->aspath)
+		aspath_free(new->aspath);
+
+	if (new->community != old->community)
+		community_free(new->community);
+
+	if (new->ecommunity != old->ecommunity)
+		ecommunity_free(&new->ecommunity);
+
+	if (new->lcommunity != old->lcommunity)
+		lcommunity_free(&new->lcommunity);
+
+}
+
 /* Free bgp attribute and aspath. */
 void bgp_attr_unintern(struct attr **pattr)
 {

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -239,6 +239,7 @@ extern bgp_attr_parse_ret_t bgp_attr_parse(struct peer *, struct attr *,
 					   bgp_size_t, struct bgp_nlri *,
 					   struct bgp_nlri *);
 extern void bgp_attr_dup(struct attr *, struct attr *);
+extern void bgp_attr_undup(struct attr *new, struct attr *old);
 extern struct attr *bgp_attr_intern(struct attr *attr);
 extern void bgp_attr_unintern_sub(struct attr *);
 extern void bgp_attr_unintern(struct attr **);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10247,6 +10247,9 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 							output_count++;
 						} else
 							filtered_count++;
+
+						bgp_attr_undup(&attr,
+							       adj->attr);
 					}
 				}
 		}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1160,6 +1160,7 @@ static int bgp_output_modifier(struct peer *peer, struct prefix *p,
 	struct bgp_info info;
 	route_map_result_t ret;
 	struct route_map *rmap = NULL;
+	u_char rmap_type;
 
 	/*
 	 * So if we get to this point and have no rmap_name
@@ -1188,12 +1189,13 @@ static int bgp_output_modifier(struct peer *peer, struct prefix *p,
 	info.peer = peer;
 	info.attr = attr;
 
+	rmap_type = peer->rmap_type;
 	SET_FLAG(peer->rmap_type, PEER_RMAP_TYPE_OUT);
 
 	/* Apply BGP route map to the attribute. */
 	ret = route_map_apply(rmap, p, RMAP_BGP, &info);
 
-	peer->rmap_type = 0;
+	peer->rmap_type = rmap_type;
 
 	if (ret == RMAP_DENYMATCH)
 		/*

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10180,70 +10180,72 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 			}
 		} else {
 			for (adj = rn->adj_out; adj; adj = adj->next)
-				SUBGRP_FOREACH_PEER (adj->subgroup, paf)
-					if (paf->peer == peer) {
-						if (header1) {
-							if (use_json) {
-								json_object_int_add(
-									json,
-									"bgpTableVersion",
-									table->version);
-								json_object_string_add(
-									json,
-									"bgpLocalRouterId",
-									inet_ntoa(
-										bgp->router_id));
-								json_object_object_add(
-									json,
-									"bgpStatusCodes",
-									json_scode);
-								json_object_object_add(
-									json,
-									"bgpOriginCodes",
-									json_ocode);
-							} else {
-								vty_out(vty,
-									"BGP table version is %" PRIu64
-									", local router ID is %s\n",
-									table->version,
-									inet_ntoa(
-										bgp->router_id));
-								vty_out(vty,
-									BGP_SHOW_SCODE_HEADER);
-								vty_out(vty,
-									BGP_SHOW_OCODE_HEADER);
-							}
-							header1 = 0;
-						}
+				SUBGRP_FOREACH_PEER (adj->subgroup, paf) {
+					if (paf->peer != peer)
+						continue;
 
-						if (header2) {
-							if (!use_json)
-								vty_out(vty,
-									BGP_SHOW_HEADER);
-							header2 = 0;
+					if (header1) {
+						if (use_json) {
+							json_object_int_add(
+								json,
+								"bgpTableVersion",
+								table->version);
+							json_object_string_add(
+								json,
+								"bgpLocalRouterId",
+								inet_ntoa(
+									bgp->router_id));
+							json_object_object_add(
+								json,
+								"bgpStatusCodes",
+								json_scode);
+							json_object_object_add(
+								json,
+								"bgpOriginCodes",
+								json_ocode);
+						} else {
+							vty_out(vty,
+								"BGP table version is %" PRIu64
+								", local router ID is %s\n",
+								table->version,
+								inet_ntoa(
+									bgp->router_id));
+							vty_out(vty,
+								BGP_SHOW_SCODE_HEADER);
+							vty_out(vty,
+								BGP_SHOW_OCODE_HEADER);
 						}
-
-						if (adj->attr) {
-							bgp_attr_dup(&attr,
-								     adj->attr);
-							ret = bgp_output_modifier(
-								peer, &rn->p,
-								&attr, afi,
-								safi,
-								rmap_name);
-							if (ret != RMAP_DENY) {
-								route_vty_out_tmp(
-									vty,
-									&rn->p,
-									&attr,
-									safi,
-									use_json,
-									json_ar);
-								output_count++;
-							} else
-								filtered_count++;
-						}
+						header1 = 0;
 					}
+
+					if (header2) {
+						if (!use_json)
+							vty_out(vty,
+								BGP_SHOW_HEADER);
+						header2 = 0;
+					}
+
+					if (adj->attr) {
+						bgp_attr_dup(&attr,
+							     adj->attr);
+						ret = bgp_output_modifier(
+							peer, &rn->p,
+							&attr, afi,
+							safi,
+							rmap_name);
+						if (ret != RMAP_DENY) {
+							route_vty_out_tmp(
+								vty,
+								&rn->p,
+								&attr,
+								safi,
+								use_json,
+								json_ar);
+							output_count++;
+						} else
+							filtered_count++;
+					}
+				}
 		}
 	}
 	if (use_json)


### PR DESCRIPTION
So we have the ability to display information about what we send to our peer.  These series of commits fixes some severe issues with this code.

1) We were re-applying the existing route-map on some show commands.  This is already applied no need to do it again. This was the source of a memory leak

2) We were messing with the peer->rmap_type without storing the original, messing up later work that may or may not happen.

3) When we applied a speculative route-map we were mallocing memory without ever free'ing it.