### PR TITLE
pimd: Cleanup vrf SA issues exposed by recent commits

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -797,7 +797,11 @@ void pim_if_addr_del_all(struct interface *ifp)
 	struct listnode *node;
 	struct listnode *nextnode;
 	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
-	struct pim_instance *pim = vrf->info;
+	struct pim_instance *pim;
+
+	if (!vrf)
+		return;
+	pim = vrf->info;
 
 	/* PIM/IGMP enabled ? */
 	if (!ifp->info)
@@ -860,11 +864,14 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 {
 	struct connected *ifc;
 	struct listnode *node;
-	struct in_addr addr;
+	struct in_addr addr = {0};
 	int v4_addrs = 0;
 	int v6_addrs = 0;
 	struct pim_interface *pim_ifp = ifp->info;
 	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+
+	if (!vrf)
+		return addr;
 
 	if (pim_ifp && PIM_INADDR_ISNOT_ANY(pim_ifp->update_source)) {
 		return pim_ifp->update_source;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -648,7 +648,11 @@ int pim_parse_nexthop_update(int command, struct zclient *zclient,
 	struct interface *ifp = NULL;
 	struct interface *ifp1 = NULL;
 	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
-	struct pim_instance *pim = vrf->info;
+	struct pim_instance *pim;
+
+	if (!vrf)
+		return 0;
+	pim = vrf->info;
 
 	s = zclient->ibuf;
 	memset(&p, 0, sizeof(struct prefix));

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -348,7 +348,11 @@ static int pim_zebra_if_address_del(int command, struct zclient *client,
 	struct connected *c;
 	struct prefix *p;
 	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
-	struct pim_instance *pim = vrf->info;
+	struct pim_instance *pim;
+
+	if (!vrf)
+		return 0;
+	pim = vrf->info;
 
 	/*
 	  zebra api notifies address adds/dels events by using the same call


### PR DESCRIPTION
A recent commit has shown that we were not consistent with
handling of the vrf lookup.  Adjust pim to do the right
thing with vrf lookup to be consistent and to make SA
happier.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>