### PR TITLE
bgpd: Treat empty reachable NLRI as a EOR

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -227,6 +227,7 @@ typedef enum {
 	/* only used internally, send notify + convert to BGP_ATTR_PARSE_ERROR
 	   */
 	BGP_ATTR_PARSE_ERROR_NOTIFYPLS = -3,
+	BGP_ATTR_PARSE_EOR = -4,
 } bgp_attr_parse_ret_t;
 
 struct bpacket_attr_vec_arr;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1553,7 +1553,9 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 	 * Non-MP IPv4/Unicast EoR is a completely empty UPDATE
 	 * and MP EoR should have only an empty MP_UNREACH
 	 */
-	if (!update_len && !withdraw_len && nlris[NLRI_MP_UPDATE].length == 0) {
+	if ((!update_len && !withdraw_len &&
+	     nlris[NLRI_MP_UPDATE].length == 0) ||
+	    (attr_parse_ret == BGP_ATTR_PARSE_EOR)) {
 		afi_t afi = 0;
 		safi_t safi;
 
@@ -1568,6 +1570,9 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			   && nlris[NLRI_MP_WITHDRAW].length == 0) {
 			afi = nlris[NLRI_MP_WITHDRAW].afi;
 			safi = nlris[NLRI_MP_WITHDRAW].safi;
+		} else if (attr_parse_ret == BGP_ATTR_PARSE_EOR) {
+			afi = nlris[NLRI_MP_UPDATE].afi;
+			safi = nlris[NLRI_MP_UPDATE].safi;
 		}
 
 		if (afi && peer->afc[afi][safi]) {


### PR DESCRIPTION
This issue was discovered on a live session with an extremely
old cisco 7206VXR router running 12.2(33)SRE4.  The sending router
is sending us an empty NLRI that is MP_REACH.  From RFC
exploration(thanks Russ!) it appears that this was
considered a 'valid' way to send EOR.

Following discussion decided that we should treat
this situation as a EOR marker instead of bringing
down the session.

Applying this fix on the FRR router seeing this issue
allows it to continue it's peering relationship with
the ASR.  Since this is a point fix I do not see
a high likelihood of further fallout.

Fixes: #1258
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>