### PR TITLE
bgpd: fix various problems with hold/keepalive timers

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1096,7 +1096,7 @@ int bgp_stop(struct peer *peer)
 		}
 
 	/* Reset keepalive and holdtime */
-	if (CHECK_FLAG(peer->config, PEER_CONFIG_TIMER)) {
+	if (PEER_OR_GROUP_TIMER_SET(peer)) {
 		peer->v_keepalive = peer->keepalive;
 		peer->v_holdtime = peer->holdtime;
 	} else {

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -529,7 +529,7 @@ void bgp_open_send(struct peer *peer)
 	u_int16_t send_holdtime;
 	as_t local_as;
 
-	if (CHECK_FLAG(peer->config, PEER_CONFIG_TIMER))
+	if (PEER_OR_GROUP_TIMER_SET(peer))
 		send_holdtime = peer->holdtime;
 	else
 		send_holdtime = peer->bgp->default_holdtime;
@@ -1087,7 +1087,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	   implementation MAY adjust the rate at which it sends KEEPALIVE
 	   messages as a function of the Hold Time interval. */
 
-	if (CHECK_FLAG(peer->config, PEER_CONFIG_TIMER))
+	if (PEER_OR_GROUP_TIMER_SET(peer))
 		send_holdtime = peer->holdtime;
 	else
 		send_holdtime = peer->bgp->default_holdtime;
@@ -1097,7 +1097,8 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	else
 		peer->v_holdtime = send_holdtime;
 
-	if (CHECK_FLAG(peer->config, PEER_CONFIG_TIMER))
+	if ((PEER_OR_GROUP_TIMER_SET(peer))
+	    && (peer->keepalive < peer->v_holdtime / 3))
 		peer->v_keepalive = peer->keepalive;
 	else
 		peer->v_keepalive = peer->v_holdtime / 3;

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -615,14 +615,14 @@ static u_char *bgpPeerTable(struct variable *v, oid name[], size_t *length,
 		break;
 	case BGPPEERHOLDTIMECONFIGURED:
 		*write_method = write_bgpPeerTable;
-		if (CHECK_FLAG(peer->config, PEER_CONFIG_TIMER))
+		if (PEER_OR_GROUP_TIMER_SET(peer))
 			return SNMP_INTEGER(peer->holdtime);
 		else
 			return SNMP_INTEGER(peer->v_holdtime);
 		break;
 	case BGPPEERKEEPALIVECONFIGURED:
 		*write_method = write_bgpPeerTable;
-		if (CHECK_FLAG(peer->config, PEER_CONFIG_TIMER))
+		if (PEER_OR_GROUP_TIMER_SET(peer))
 			return SNMP_INTEGER(peer->keepalive);
 		else
 			return SNMP_INTEGER(peer->v_keepalive);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8272,7 +8272,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, u_char use_json,
 				    "bgpTimerKeepAliveIntervalMsecs",
 				    p->v_keepalive * 1000);
 
-		if (CHECK_FLAG(p->config, PEER_CONFIG_TIMER)) {
+		if (PEER_OR_GROUP_TIMER_SET(p)) {
 			json_object_int_add(json_neigh,
 					    "bgpTimerConfiguredHoldTimeMsecs",
 					    p->holdtime * 1000);
@@ -8280,6 +8280,16 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, u_char use_json,
 				json_neigh,
 				"bgpTimerConfiguredKeepAliveIntervalMsecs",
 				p->keepalive * 1000);
+		} else if ((bgp->default_holdtime != BGP_DEFAULT_HOLDTIME)
+			   || (bgp->default_keepalive !=
+			       BGP_DEFAULT_KEEPALIVE)) {
+			json_object_int_add(json_neigh,
+					    "bgpTimerConfiguredHoldTimeMsecs",
+					    bgp->default_holdtime);
+			json_object_int_add(
+				json_neigh,
+				"bgpTimerConfiguredKeepAliveIntervalMsecs",
+				bgp->default_keepalive);
 		}
 	} else {
 		/* Administrative shutdown. */
@@ -8326,11 +8336,18 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, u_char use_json,
 		vty_out(vty,
 			"  Hold time is %d, keepalive interval is %d seconds\n",
 			p->v_holdtime, p->v_keepalive);
-		if (CHECK_FLAG(p->config, PEER_CONFIG_TIMER)) {
+		if (PEER_OR_GROUP_TIMER_SET(p)) {
 			vty_out(vty, "  Configured hold time is %d",
 				p->holdtime);
 			vty_out(vty, ", keepalive interval is %d seconds\n",
 				p->keepalive);
+		} else if ((bgp->default_holdtime != BGP_DEFAULT_HOLDTIME)
+			   || (bgp->default_keepalive !=
+			       BGP_DEFAULT_KEEPALIVE)) {
+			vty_out(vty, "  Configured hold time is %d",
+				bgp->default_holdtime);
+			vty_out(vty, ", keepalive interval is %d seconds\n",
+				bgp->default_keepalive);
 		}
 	}
 	/* Capability. */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -771,6 +771,11 @@ struct peer {
 #define PEER_CONFIG_TIMER             (1 << 0) /* keepalive & holdtime */
 #define PEER_CONFIG_CONNECT           (1 << 1) /* connect */
 #define PEER_CONFIG_ROUTEADV          (1 << 2) /* route advertise */
+#define PEER_GROUP_CONFIG_TIMER       (1 << 3) /* timers from peer-group */
+
+#define PEER_OR_GROUP_TIMER_SET(peer)                                        \
+	(CHECK_FLAG(peer->config, PEER_CONFIG_TIMER)			     \
+	 || CHECK_FLAG(peer->config, PEER_GROUP_CONFIG_TIMER))
 
 	u_int32_t holdtime;
 	u_int32_t keepalive;


### PR DESCRIPTION
Problem reported that we weren't adjusting the keepalive timer
correctly when we negotiated a lower hold time learned from a
peer.  While working on this, found we didn't do inheritance
correctly at all.  This fix solves the first problem and also
ensures that the timers are configured correctly based on this
priority order - peer defined > peer-group defined > global config.
This fix also displays the timers as "configured" regardless of
which of the three locations above is used.

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Testing-performed:  Manual testing successful, fix tested by
submitter, bgp-smoke completed successfully