### PR TITLE
bgpd: exit on socket bind failures

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -740,8 +740,10 @@ int bgp_socket(unsigned short port, const char *address)
 	}
 	freeaddrinfo(ainfo_save);
 	if (count == 0) {
-		zlog_err("%s: no usable addresses", __func__);
-		return -1;
+		zlog_err("%s: no usable addresses please check other programs usage of specified port %d",
+			 __func__, port);
+		zlog_err("%s: Program cannot continue", __func__);
+		exit(-1);
 	}
 
 	return 0;


### PR DESCRIPTION
When we fail to bind to port 179 we are left in a situation
where we have not saved the bgp pointer created and when
the bgp cli mode is exited we leak the memory.

Additionally there is no recovery situation here that
could be easily programmed without fundamentally changing
the code.

So let's exit and output to the log file some useful
information to hopefully clue the user in on what is
going wrong.

Fixes: #1130
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>