### PR TITLE
ldpd, zebra: Allow clippy files to be included in dist

### DIFF
--- a/ldpd/ldp_vty_cmds.c
+++ b/ldpd/ldp_vty_cmds.c
@@ -25,7 +25,9 @@
 
 #include "ldpd/ldpd.h"
 #include "ldpd/ldp_vty.h"
+#ifndef VTYSH_EXTRACT_PL
 #include "ldpd/ldp_vty_cmds_clippy.c"
+#endif
 
 DEFUN_NOSH(ldp_mpls_ldp,
 	ldp_mpls_ldp_cmd,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -43,7 +43,9 @@
 #include "zebra/zebra_static.h"
 #include "lib/json.h"
 #include "zebra/zebra_vxlan.h"
+#ifndef VTYSH_EXTRACT_PL
 #include "zebra/zebra_vty_clippy.c"
+#endif
 #include "zebra/zserv.h"
 
 extern int allow_delete;


### PR DESCRIPTION
1) Allow generated clippy files to be included in `make dist`
2) On a make clean( of some sort ) clean up the generated files

Fixes: #1373
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>