### PR TITLE
ospfd: add vrf option to operational command

### DIFF
--- a/ospfd/ospf_network.c
+++ b/ospfd/ospf_network.c
@@ -184,11 +184,8 @@ int ospf_bind_vrfdevice(struct ospf *ospf, int ospf_sock)
 			zlog_warn("%s: Could not setsockopt SO_BINDTODEVICE %s",
 					__PRETTY_FUNCTION__,
 					safe_strerror(save_errno));
-		} else {
-			zlog_debug("%s: Bind socket %d to vrf %s id %u device",
-				   __PRETTY_FUNCTION__, ospf_sock,
-				   ospf->name, ospf->vrf_id);
 		}
+
 	}
 #endif
 	return ret;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4132,119 +4132,113 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 				      json_object *json, u_char use_json)
 {
 	struct route_node *rn;
-	struct ospf_neighbor *nbr;
+	struct ospf_neighbor *nbr, *prev_nbr = NULL;
 	char msgbuf[16];
 	char timebuf[OSPF_TIME_DUMP_SIZE];
-	json_object *json_neighbor = NULL;
+	json_object *json_neighbor = NULL, *json_neigh_array = NULL;
 
 	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
 		if ((nbr = rn->info)) {
 			/* Do not show myself. */
-			if (nbr != oi->nbr_self) {
-				/* Down state is not shown. */
-				if (nbr->state != NSM_Down) {
-					if (use_json) {
-						json_neighbor =
-							json_object_new_object();
-						ospf_nbr_state_message(
-							nbr, msgbuf, 16);
+			if (nbr == oi->nbr_self)
+				continue;
+			/* Down state is not shown. */
+			if (nbr->state == NSM_Down)
+				continue;
+			if (use_json) {
+				char neigh_str[INET_ADDRSTRLEN];
 
-						long time_store;
-
-						time_store =
-							monotime_until(
-								&nbr->t_inactivity
-									 ->u
-									 .sands,
-								NULL)
-							/ 1000LL;
-
-						json_object_int_add(
-							json_neighbor,
-							"priority",
-							nbr->priority);
-						json_object_string_add(
-							json_neighbor, "state",
-							msgbuf);
-						json_object_int_add(
-							json_neighbor,
-							"deadTimeMsecs",
-							time_store);
-						json_object_string_add(
-							json_neighbor,
-							"address",
-							inet_ntoa(nbr->src));
-						json_object_string_add(
-							json_neighbor,
-							"ifaceName",
-							IF_NAME(oi));
-						json_object_int_add(
-							json_neighbor,
-							"retransmitCounter",
-							ospf_ls_retransmit_count(
-								nbr));
-						json_object_int_add(
-							json_neighbor,
-							"requestCounter",
-							ospf_ls_request_count(
-								nbr));
-						json_object_int_add(
-							json_neighbor,
-							"dbSummaryCounter",
-							ospf_db_summary_count(
-								nbr));
-						if (nbr->state == NSM_Attempt
-						    && nbr->router_id.s_addr
-							       == 0)
-							json_object_object_add(
-								json,
-								"neighbor",
-								json_neighbor);
-						else
-							json_object_object_add(
-								json,
-								inet_ntoa(
-									nbr->router_id),
-								json_neighbor);
-					} else {
-						ospf_nbr_state_message(
-							nbr, msgbuf, 16);
-
-						if (nbr->state == NSM_Attempt
-						    && nbr->router_id.s_addr
-							       == 0)
-							vty_out(vty,
-								"%-15s %3d %-15s ",
-								"-",
-								nbr->priority,
-								msgbuf);
-						else
-							vty_out(vty,
-								"%-15s %3d %-15s ",
-								inet_ntoa(
-									nbr->router_id),
-								nbr->priority,
-								msgbuf);
-
-						vty_out(vty, "%9s ",
-							ospf_timer_dump(
-								nbr->t_inactivity,
-								timebuf,
-								sizeof(timebuf)));
-						vty_out(vty, "%-15s ",
-							inet_ntoa(nbr->src));
-						vty_out(vty,
-							"%-20s %5ld %5ld %5d\n",
-							IF_NAME(oi),
-							ospf_ls_retransmit_count(
-								nbr),
-							ospf_ls_request_count(
-								nbr),
-							ospf_db_summary_count(
-								nbr));
-					}
+				if (prev_nbr &&
+				    !IPV4_ADDR_SAME(&prev_nbr->src, &nbr->src)) {
+					/* Start new neigh list */
+					json_neigh_array = NULL;
 				}
+
+				if (nbr->state == NSM_Attempt &&
+				    nbr->router_id.s_addr == 0)
+					strncpy(neigh_str, "neighbor",
+						INET_ADDRSTRLEN);
+				else
+					strncpy(neigh_str,
+						inet_ntoa(nbr->router_id),
+						INET_ADDRSTRLEN);
+
+				json_object_object_get_ex(json, neigh_str,
+							  &json_neigh_array);
+
+				if (!json_neigh_array) {
+					json_neigh_array = json_object_new_array();
+					json_object_object_add(json, neigh_str,
+							json_neigh_array);
+				}
+
+				json_neighbor =
+					json_object_new_object();
+
+				ospf_nbr_state_message(nbr, msgbuf, 16);
+
+				long time_store;
+
+				time_store = monotime_until(
+						&nbr->t_inactivity->u.sands,
+						       NULL) / 1000LL;
+
+				json_object_int_add(json_neighbor,
+						    "priority",
+						    nbr->priority);
+				json_object_string_add(json_neighbor, "state",
+						       msgbuf);
+				json_object_int_add(json_neighbor,
+						    "deadTimeMsecs",
+						    time_store);
+				json_object_string_add(json_neighbor,
+						       "address",
+						       inet_ntoa(nbr->src));
+				json_object_string_add(json_neighbor,
+						       "ifaceName",
+						       IF_NAME(oi));
+				json_object_int_add(json_neighbor,
+						"retransmitCounter",
+						ospf_ls_retransmit_count(nbr));
+				json_object_int_add(json_neighbor,
+						"requestCounter",
+						ospf_ls_request_count(nbr));
+				json_object_int_add(json_neighbor,
+						"dbSummaryCounter",
+						ospf_db_summary_count(nbr));
+
+				json_object_array_add(json_neigh_array,
+						      json_neighbor);
+			} else {
+				ospf_nbr_state_message(nbr, msgbuf, 16);
+
+				if (nbr->state == NSM_Attempt &&
+				    nbr->router_id.s_addr == 0)
+					vty_out(vty,
+						"%-15s %3d %-15s ",
+						"-",
+						nbr->priority,
+						msgbuf);
+				else
+					vty_out(vty,
+						"%-15s %3d %-15s ",
+						inet_ntoa(nbr->router_id),
+						nbr->priority,
+						msgbuf);
+
+				vty_out(vty, "%9s ",
+					ospf_timer_dump(nbr->t_inactivity,
+							timebuf,
+							sizeof(timebuf)));
+				vty_out(vty, "%-15s ", inet_ntoa(nbr->src));
+				vty_out(vty,
+					"%-20s %5ld %5ld %5d\n",
+					IF_NAME(oi),
+					ospf_ls_retransmit_count(nbr),
+					ospf_ls_request_count(nbr),
+					ospf_db_summary_count(nbr));
 			}
+			prev_nbr = nbr;
 		}
 	}
 }


### PR DESCRIPTION
Seperate the display option in both vty and json
case 'vrf' is used in show command.
   show ip ospf 'vrf all' [json]
   Display vrf name as key object in json and vrf name
   in vty output.
case 'vrf' is not used then only display default
   vrf ospf instance and vrf name is not shown in vty and
   json.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>


show ip ospf vrf all 
VRF Name: default
 OSPF Routing Process, Router ID: 0.2.0.2
 Supports only single TOS (TOS0) routes
 This implementation conforms to RFC2328
 RFC1583Compatibility flag is disabled
 OpaqueCapability flag is disabled
 Initial SPF scheduling delay 0 millisec(s)
 Minimum hold time between consecutive SPFs 50 millisec(s)
 Maximum hold time between consecutive SPFs 5000 millisec(s)
 Hold time multiplier is currently 1
 SPF algorithm last executed 12.793s ago
 Last SPF duration 206 usecs
 SPF timer is inactive
 LSA minimum interval 5000 msecs
 LSA minimum arrival 1000 msecs
 Write Multiplier set to 20 
 Refresh timer 10 secs
 Number of external LSA 0. Checksum Sum 0x00000000
 Number of opaque AS LSA 0. Checksum Sum 0x00000000
 Number of areas attached to this router: 1
 All adjacency changes are logged
 Area ID: 0.0.0.0 (Backbone)
   Number of interfaces in this area: Total: 1, Active: 1
   Number of fully adjacent neighbors in this area: 1
   Area has no authentication
   SPF algorithm executed 3 times
   Number of LSA 3
   Number of router LSA 2. Checksum Sum 0x000107c4
   Number of network LSA 1. Checksum Sum 0x00003013
   Number of summary LSA 0. Checksum Sum 0x00000000
   Number of ASBR summary LSA 0. Checksum Sum 0x00000000
   Number of NSSA LSA 0. Checksum Sum 0x00000000
   Number of opaque link LSA 0. Checksum Sum 0x00000000
   Number of opaque area LSA 0. Checksum Sum 0x00000000


VRF Name: red
 OSPF Routing Process, Router ID: 10.0.1.100
 Supports only single TOS (TOS0) routes
 This implementation conforms to RFC2328
 RFC1583Compatibility flag is disabled
 OpaqueCapability flag is disabled
 Initial SPF scheduling delay 0 millisec(s)
 Minimum hold time between consecutive SPFs 50 millisec(s)
 Maximum hold time between consecutive SPFs 5000 millisec(s)
 Hold time multiplier is currently 1
 SPF algorithm last executed 18.943s ago
 Last SPF duration 143 usecs
 SPF timer is inactive
 LSA minimum interval 5000 msecs
 LSA minimum arrival 1000 msecs
 Write Multiplier set to 20 
 Refresh timer 10 secs
 Number of external LSA 0. Checksum Sum 0x00000000
 Number of opaque AS LSA 0. Checksum Sum 0x00000000
 Number of areas attached to this router: 1
 All adjacency changes are logged
 Area ID: 0.0.0.0 (Backbone)
   Number of interfaces in this area: Total: 1, Active: 1
   Number of fully adjacent neighbors in this area: 1
   Area has no authentication
   SPF algorithm executed 4 times
   Number of LSA 3
   Number of router LSA 2. Checksum Sum 0x0000ba9e
   Number of network LSA 1. Checksum Sum 0x00003ca5
   Number of summary LSA 0. Checksum Sum 0x00000000
   Number of ASBR summary LSA 0. Checksum Sum 0x00000000
   Number of NSSA LSA 0. Checksum Sum 0x00000000
   Number of opaque link LSA 0. Checksum Sum 0x00000000
   Number of opaque area LSA 0. Checksum Sum 0x00000000


VRF Name: blue
 OSPF Routing Process, Router ID: 50.0.1.2
 Supports only single TOS (TOS0) routes
 This implementation conforms to RFC2328
 RFC1583Compatibility flag is disabled
 OpaqueCapability flag is disabled
 Initial SPF scheduling delay 0 millisec(s)
 Minimum hold time between consecutive SPFs 50 millisec(s)
 Maximum hold time between consecutive SPFs 5000 millisec(s)
 Hold time multiplier is currently 1
 SPF algorithm last executed 10.265s ago
 Last SPF duration 202 usecs
 SPF timer is inactive
 LSA minimum interval 5000 msecs
 LSA minimum arrival 1000 msecs
 Write Multiplier set to 20 
 Refresh timer 10 secs
 Number of external LSA 0. Checksum Sum 0x00000000
 Number of opaque AS LSA 0. Checksum Sum 0x00000000
 Number of areas attached to this router: 1
 All adjacency changes are logged
 Area ID: 0.0.0.0 (Backbone)
   Number of interfaces in this area: Total: 1, Active: 1
   Number of fully adjacent neighbors in this area: 1
   Area has no authentication
   SPF algorithm executed 4 times
   Number of LSA 3
   Number of router LSA 2. Checksum Sum 0x0000e9be
   Number of network LSA 1. Checksum Sum 0x0000dc17
   Number of summary LSA 0. Checksum Sum 0x00000000
   Number of ASBR summary LSA 0. Checksum Sum 0x00000000
   Number of NSSA LSA 0. Checksum Sum 0x00000000
   Number of opaque link LSA 0. Checksum Sum 0x00000000
   Number of opaque area LSA 0. Checksum Sum 0x00000000
s6000-07# show ip ospf vrf all json 
{
  "default":{
    "vrfName":"default",
    "vrfId":0,
    "routerId":"0.2.0.2",
    "tosRoutesOnly":true,
    "rfc2328Conform":true,
    "spfScheduleDelayMsecs":0,
    "holdtimeMinMsecs":50,
    "holdtimeMaxMsecs":5000,
    "holdtimeMultplier":1,
    "spfLastExecutedMsecs":64626,
    "spfLastDurationMsecs":0,
    "lsaMinIntervalMsecs":5000,
    "lsaMinArrivalMsecs":1000,
    "writeMultiplier":20,
    "refreshTimerMsecs":10000,
    "lsaExternalCounter":0,
    "lsaExternalChecksum":0,
    "lsaAsopaqueCounter":0,
    "lsaAsOpaqueChecksum":0,
    "attachedAreaCounter":1,
    "adjacencyChangesLoggedAll":true,
    "areas":{
      "0.0.0.0":{
        "backbone":true,
        "areaIfTotalCounter":1,
        "areaIfActiveCounter":1,
        "nbrFullAdjacentCounter":1,
        "authentication":"authenticationNone",
        "spfExecutedCounter":3,
        "lsaNumber":3,
        "lsaRouterNumber":2,
        "lsaRouterChecksum":67524,
        "lsaNetworkNumber":1,
        "lsaNetworkChecksum":12307,
        "lsaSummaryNumber":0,
        "lsaSummaryChecksum":0,
        "lsaAsbrNumber":0,
        "lsaAsbrChecksum":0,
        "lsaNssaNumber":0,
        "lsaNssaChecksum":0,
        "lsaOpaqueLinkNumber":0,
        "lsaOpaqueLinkChecksum":0,
        "lsaOpaqueAreaNumber":0,
        "lsaOpaqueAreaChecksum":0
      }
    }
  },
  "red":{
    "vrfName":"red",
    "vrfId":66,
    "routerId":"10.0.1.100",
    "tosRoutesOnly":true,
    "rfc2328Conform":true,
    "spfScheduleDelayMsecs":0,
    "holdtimeMinMsecs":50,
    "holdtimeMaxMsecs":5000,
    "holdtimeMultplier":1,
    "spfLastExecutedMsecs":70776,
    "spfLastDurationMsecs":0,
    "lsaMinIntervalMsecs":5000,
    "lsaMinArrivalMsecs":1000,
    "writeMultiplier":20,
    "refreshTimerMsecs":10000,
    "lsaExternalCounter":0,
    "lsaExternalChecksum":0,
    "lsaAsopaqueCounter":0,
    "lsaAsOpaqueChecksum":0,
    "attachedAreaCounter":1,
    "adjacencyChangesLoggedAll":true,
    "areas":{
      "0.0.0.0":{
        "backbone":true,
        "areaIfTotalCounter":1,
        "areaIfActiveCounter":1,
        "nbrFullAdjacentCounter":1,
        "authentication":"authenticationNone",
        "spfExecutedCounter":4,
        "lsaNumber":3,
        "lsaRouterNumber":2,
        "lsaRouterChecksum":47774,
        "lsaNetworkNumber":1,
        "lsaNetworkChecksum":15525,
        "lsaSummaryNumber":0,
        "lsaSummaryChecksum":0,
        "lsaAsbrNumber":0,
        "lsaAsbrChecksum":0,
        "lsaNssaNumber":0,
        "lsaNssaChecksum":0,
        "lsaOpaqueLinkNumber":0,
        "lsaOpaqueLinkChecksum":0,
        "lsaOpaqueAreaNumber":0,
        "lsaOpaqueAreaChecksum":0
      }
    }
  },
  "blue":{
    "vrfName":"blue",
    "vrfId":67,
    "routerId":"50.0.1.2",
    "tosRoutesOnly":true,
    "rfc2328Conform":true,
    "spfScheduleDelayMsecs":0,
    "holdtimeMinMsecs":50,
    "holdtimeMaxMsecs":5000,
    "holdtimeMultplier":1,
    "spfLastExecutedMsecs":62098,
    "spfLastDurationMsecs":0,
    "lsaMinIntervalMsecs":5000,
    "lsaMinArrivalMsecs":1000,
    "writeMultiplier":20,
    "refreshTimerMsecs":10000,
    "lsaExternalCounter":0,
    "lsaExternalChecksum":0,
    "lsaAsopaqueCounter":0,
    "lsaAsOpaqueChecksum":0,
    "attachedAreaCounter":1,
    "adjacencyChangesLoggedAll":true,
    "areas":{
      "0.0.0.0":{
        "backbone":true,
        "areaIfTotalCounter":1,
        "areaIfActiveCounter":1,
        "nbrFullAdjacentCounter":1,
        "authentication":"authenticationNone",
        "spfExecutedCounter":4,
        "lsaNumber":3,
        "lsaRouterNumber":2,
        "lsaRouterChecksum":59838,
        "lsaNetworkNumber":1,
        "lsaNetworkChecksum":56343,
        "lsaSummaryNumber":0,
        "lsaSummaryChecksum":0,
        "lsaAsbrNumber":0,
        "lsaAsbrChecksum":0,
        "lsaNssaNumber":0,
        "lsaNssaChecksum":0,
        "lsaOpaqueLinkNumber":0,
        "lsaOpaqueLinkChecksum":0,
        "lsaOpaqueAreaNumber":0,
        "lsaOpaqueAreaChecksum":0
      }
    }
  }
}


s6000-07# show ip ospf 
 OSPF Routing Process, Router ID: 0.2.0.2
 Supports only single TOS (TOS0) routes
 This implementation conforms to RFC2328
 RFC1583Compatibility flag is disabled
 OpaqueCapability flag is disabled
 Initial SPF scheduling delay 0 millisec(s)
 Minimum hold time between consecutive SPFs 50 millisec(s)
 Maximum hold time between consecutive SPFs 5000 millisec(s)
 Hold time multiplier is currently 1
 SPF algorithm last executed 1m30s ago
 Last SPF duration 206 usecs
 SPF timer is inactive
 LSA minimum interval 5000 msecs
 LSA minimum arrival 1000 msecs
 Write Multiplier set to 20 
 Refresh timer 10 secs
 Number of external LSA 0. Checksum Sum 0x00000000
 Number of opaque AS LSA 0. Checksum Sum 0x00000000
 Number of areas attached to this router: 1
 All adjacency changes are logged
 Area ID: 0.0.0.0 (Backbone)
   Number of interfaces in this area: Total: 1, Active: 1
   Number of fully adjacent neighbors in this area: 1
   Area has no authentication
   SPF algorithm executed 3 times
   Number of LSA 3
   Number of router LSA 2. Checksum Sum 0x000107c4
   Number of network LSA 1. Checksum Sum 0x00003013
   Number of summary LSA 0. Checksum Sum 0x00000000
   Number of ASBR summary LSA 0. Checksum Sum 0x00000000
   Number of NSSA LSA 0. Checksum Sum 0x00000000
   Number of opaque link LSA 0. Checksum Sum 0x00000000
   Number of opaque area LSA 0. Checksum Sum 0x00000000


s6000-07# show ip ospf json 
{
  "routerId":"0.2.0.2",
  "tosRoutesOnly":true,
  "rfc2328Conform":true,
  "spfScheduleDelayMsecs":0,
  "holdtimeMinMsecs":50,
  "holdtimeMaxMsecs":5000,
  "holdtimeMultplier":1,
  "spfLastExecutedMsecs":92494,
  "spfLastDurationMsecs":0,
  "lsaMinIntervalMsecs":5000,
  "lsaMinArrivalMsecs":1000,
  "writeMultiplier":20,
  "refreshTimerMsecs":10000,
  "lsaExternalCounter":0,
  "lsaExternalChecksum":0,
  "lsaAsopaqueCounter":0,
  "lsaAsOpaqueChecksum":0,
  "attachedAreaCounter":1,
  "adjacencyChangesLoggedAll":true,
  "areas":{
    "0.0.0.0":{
      "backbone":true,
      "areaIfTotalCounter":1,
      "areaIfActiveCounter":1,
      "nbrFullAdjacentCounter":1,
      "authentication":"authenticationNone",
      "spfExecutedCounter":3,
      "lsaNumber":3,
      "lsaRouterNumber":2,
      "lsaRouterChecksum":67524,
      "lsaNetworkNumber":1,
      "lsaNetworkChecksum":12307,
      "lsaSummaryNumber":0,
      "lsaSummaryChecksum":0,
      "lsaAsbrNumber":0,
      "lsaAsbrChecksum":0,
      "lsaNssaNumber":0,
      "lsaNssaChecksum":0,
      "lsaOpaqueLinkNumber":0,
      "lsaOpaqueLinkChecksum":0,
      "lsaOpaqueAreaNumber":0,
      "lsaOpaqueAreaChecksum":0
    }
  }
}



s6000-07# show ip ospf neighbor 

Neighbor ID     Pri State           Dead Time Address         Interface            RXmtL RqstL DBsmL
192.168.0.15      1 Full/DR           34.465s 7.0.6.15        swp2s3:7.0.6.16          0     0     0

s6000-07# show ip ospf neighbor json 
{
  "192.168.0.15":{
    "priority":1,
    "state":"Full\/DR",
    "deadTimeMsecs":33014,
    "address":"7.0.6.15",
    "ifaceName":"swp2s3:7.0.6.16",
    "retransmitCounter":0,
    "requestCounter":0,
    "dbSummaryCounter":0
  }
}
s6000-07# show ip ospf vrf all neighbor 
VRF Name: default

Neighbor ID     Pri State           Dead Time Address         Interface            RXmtL RqstL DBsmL
192.168.0.15      1 Full/DR           36.839s 7.0.6.15        swp2s3:7.0.6.16          0     0     0

VRF Name: red

Neighbor ID     Pri State           Dead Time Address         Interface            RXmtL RqstL DBsmL
192.168.0.15      1 Full/DR           35.692s 8.0.0.14        swp2s0:8.0.0.16          0     0     0

VRF Name: blue

Neighbor ID     Pri State           Dead Time Address         Interface            RXmtL RqstL DBsmL
10.0.1.2          1 Full/DR           34.375s 7.0.0.14        swp2s1:7.0.0.16          0     0     0

s6000-07# show ip ospf vrf all neighbor json 
{
  "default":{
    "vrfName":"default",
    "vrfId":0,
    "192.168.0.15":{
      "priority":1,
      "state":"Full\/DR",
      "deadTimeMsecs":35171,
      "address":"7.0.6.15",
      "ifaceName":"swp2s3:7.0.6.16",
      "retransmitCounter":0,
      "requestCounter":0,
      "dbSummaryCounter":0
    }
  },
  "red":{
    "vrfName":"red",
    "vrfId":66,
    "192.168.0.15":{
      "priority":1,
      "state":"Full\/DR",
      "deadTimeMsecs":34024,
      "address":"8.0.0.14",
      "ifaceName":"swp2s0:8.0.0.16",
      "retransmitCounter":0,
      "requestCounter":0,
      "dbSummaryCounter":0
    }
  },
  "blue":{
    "vrfName":"blue",
    "vrfId":67,
    "10.0.1.2":{
      "priority":1,
      "state":"Full\/DR",
      "deadTimeMsecs":32708,
      "address":"7.0.0.14",
      "ifaceName":"swp2s1:7.0.0.16",
      "retransmitCounter":0,
      "requestCounter":0,
      "dbSummaryCounter":0
    }
  }
}



s6000-07# show ip ospf interface traffic 

Interface       HELLO            DB-Desc         LS-Req           LS-Update        LS-Ack        
                Rx/Tx            Rx/Tx            Rx/Tx            Rx/Tx            Rx/Tx        
--------------------------------------------------------------------------------------------
swp2s3           22/23             2/3             0/3             3/2             2/3      
 
s6000-07# show ip ospf interface traffic json 
{
  "swp2s3":{
    "ifIndex":7,
    "helloIn":23,
    "helloOut":24,
    "dbDescIn":2,
    "dbDescOut":3,
    "lsReqIn":0,
    "lsReqOut":3,
    "lsUpdIn":3,
    "lsUpdOut":2,
    "lsAckIn":2,
    "lsAckOut":3
  }
}
s6000-07# show ip ospf vrf all interface traffic 

Interface       HELLO            DB-Desc         LS-Req           LS-Update        LS-Ack        
                Rx/Tx            Rx/Tx            Rx/Tx            Rx/Tx            Rx/Tx        
--------------------------------------------------------------------------------------------
VRF Name: default
swp2s3           24/24             2/3             0/3             3/2             2/3      

VRF Name: red
swp2s0           25/26             2/3             1/1             3/3             2/2      

VRF Name: blue
swp2s1           24/25             3/2             1/1             3/3             2/2      

s6000-07# show ip ospf vrf all interface traffic json 
{
  "default":{
    "vrfName":"default",
    "vrfId":0,
    "swp2s3":{
      "ifIndex":7,
      "helloIn":24,
      "helloOut":25,
      "dbDescIn":2,
      "dbDescOut":3,
      "lsReqIn":0,
      "lsReqOut":3,
      "lsUpdIn":3,
      "lsUpdOut":2,
      "lsAckIn":2,
      "lsAckOut":3
    }
  },
  "red":{
    "vrfName":"red",
    "vrfId":66,
    "swp2s0":{
      "ifIndex":4,
      "helloIn":25,
      "helloOut":26,
      "dbDescIn":2,
      "dbDescOut":3,
      "lsReqIn":1,
      "lsReqOut":1,
      "lsUpdIn":3,
      "lsUpdOut":3,
      "lsAckIn":2,
      "lsAckOut":2
    }
  },
  "blue":{
    "vrfName":"blue",
    "vrfId":67,
    "swp2s1":{
      "ifIndex":5,
      "helloIn":24,
      "helloOut":25,
      "dbDescIn":3,
      "dbDescOut":2,
      "lsReqIn":1,
      "lsReqOut":1,
      "lsUpdIn":3,
      "lsUpdOut":3,
      "lsAckIn":2,
      "lsAckOut":2
    }
  }
}

