### PR TITLE
isisd: free-up circuit ip entries when addresses are deleted

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -292,6 +292,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 
 		if (ip) {
 			listnode_delete(circuit->ip_addrs, ip);
+			prefix_ipv4_free(ip);
 			if (circuit->area)
 				lsp_regenerate_schedule(circuit->area,
 							circuit->is_type, 0);
@@ -327,6 +328,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 			}
 			if (ip6) {
 				listnode_delete(circuit->ipv6_link, ip6);
+				prefix_ipv6_free(ip6);
 				found = 1;
 			}
 		} else {
@@ -338,6 +340,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 			}
 			if (ip6) {
 				listnode_delete(circuit->ipv6_non_link, ip6);
+				prefix_ipv6_free(ip6);
 				found = 1;
 			}
 		}


### PR DESCRIPTION
This addresses a memory leak mentioned in #1251 