### PR TITLE
configure, zebra: Add some debug code to allow for fuzzing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -381,6 +381,8 @@ AC_ARG_ENABLE(cumulus,
   AS_HELP_STRING([--enable-cumulus], [enable Cumulus Switch Special Extensions]))
 AC_ARG_ENABLE(datacenter,
   AS_HELP_STRING([--enable-datacenter], [enable Compilation for Data Center Extensions]))
+AC_ARG_ENABLE(fuzzing,
+  AS_HELP_STRING([--enable-fuzzing], [enable ability to fuzz various parts of FRR]))
 AC_ARG_ENABLE(rr-semantics,
   AS_HELP_STRING([--disable-rr-semantics], [disable the v6 Route Replace semantics]))
 AC_ARG_ENABLE([protobuf],
@@ -430,6 +432,10 @@ if test "${enable_datacenter}" = "yes" ; then
   DFLT_NAME="datacenter"
 else
   DFLT_NAME="traditional"
+fi
+
+if test "${enable_fuzzing}" = "yes" ; then
+  AC_DEFINE(HANDLE_ZAPI_FUZZING,,Compile extensions to use with a fuzzer)
 fi
 
 if test "${enable_cumulus}" = "yes" ; then

--- a/doc/install.texi
+++ b/doc/install.texi
@@ -101,6 +101,10 @@ needs libexecinfo, while on glibc support for this is part of libc itself.
 Turn on some options for compiling FRR within a development environment in
 mind.  Specifically turn on -g3 -O0 for compiling options and add inclusion
 of grammar sandbox.
+@item --enable-fuzzing
+Turn on some compile options to allow you to run fuzzing tools
+against the system.  This tools is intended as a developer
+only tool and should not be used for normal operations
 @end table
 
 You may specify any combination of the above options to the configure

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -193,4 +193,8 @@ extern int zebra_server_send_message(struct zserv *client);
 
 extern struct zserv *zebra_find_client(u_char proto);
 
+#if defined(HANDLE_ZAPI_FUZZING)
+extern void zserv_read_file(char *input);
+#endif
+
 #endif /* _ZEBRA_ZEBRA_H */


### PR DESCRIPTION
1) Write zserv api commands( one of each type ) to the side.  This will allow
us to use them as input for a fuzzer.

2) Add -c <file to pass to zapi read process> into zebra as a run-time
option of we've turned on fuzzing.

While in and of itself these are not terribly useful( you still need
an external fuzzer ), they provide an infrastructure to allow
tools like afl to test the zapi.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>