### PR TITLE
pimd: Fix crash with debug and ifp changes

### DIFF
--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -599,7 +599,9 @@ void pim_scan_individual_oil(struct channel_oil *c_oil, int in_vif_index)
 		zlog_debug(
 			"%s %s: (S,G)=(%s,%s) input interface changed from %s vif_index=%d to %s vif_index=%d",
 			__FILE__, __PRETTY_FUNCTION__, source_str, group_str,
-			old_iif->name, c_oil->oil.mfcc_parent, new_iif->name,
+			(old_iif) ? old_iif->name : "<old_iif?>",
+			c_oil->oil.mfcc_parent,
+			(new_iif) ? new_iif->name : "<new_iif?>",
 			input_iface_vif_index);
 	}
 
@@ -618,7 +620,8 @@ void pim_scan_individual_oil(struct channel_oil *c_oil, int in_vif_index)
 			zlog_debug(
 				"%s %s: (S,G)=(%s,%s) new iif loops to existing oif: %s vif_index=%d",
 				__FILE__, __PRETTY_FUNCTION__, source_str,
-				group_str, new_iif->name,
+				group_str,
+				(new_iif) ? new_iif->name : "<new_iif?>",
 				input_iface_vif_index);
 		}
 	}


### PR DESCRIPTION
Certain interface flapping events can cause a lookup
that does not find any ifp pointer.  This is only causing
a crash in the `debug pim zebra` command due to only needing
to lookup the interface for it's name.

Modify code to ensure we have a valid pointer.  Follow other
debug statements lead in the same function for what to display
when an interface does not currently exist.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>