### PR TITLE
Support vrf export/import based on vrf-policy

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,7 +1,8 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 ;;; Match project coding conventions
+
 ((c-mode
   (indent-tabs-mode . t)
+  (show-trailing-whitespace . t)
   (c-basic-offset . 8)))
-

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1638,7 +1638,10 @@ int bgp_mp_reach_parse(struct bgp_attr_parser_args *args,
 	case BGP_ATTR_NHLEN_VPNV4:
 		stream_getl(s); /* RD high */
 		stream_getl(s); /* RD low */
-		/* NOTE: intentional fall through - for consistency in rx processing */
+		/*
+		 * NOTE: intentional fall through
+		 * - for consistency in rx processing
+		 */
 	case BGP_ATTR_NHLEN_IPV4:
 		stream_get(&attr->mp_nexthop_global_in, s, IPV4_MAX_BYTELEN);
 		/* Probably needed for RFC 2283 */

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1635,17 +1635,16 @@ int bgp_mp_reach_parse(struct bgp_attr_parser_args *args,
 
 	/* Nexthop length check. */
 	switch (attr->mp_nexthop_len) {
+	case BGP_ATTR_NHLEN_VPNV4:
+		stream_getl(s); /* RD high */
+		stream_getl(s); /* RD low */
+		/* NOTE: intentional fall through - for consistency in rx processing */
 	case BGP_ATTR_NHLEN_IPV4:
 		stream_get(&attr->mp_nexthop_global_in, s, IPV4_MAX_BYTELEN);
 		/* Probably needed for RFC 2283 */
 		if (attr->nexthop.s_addr == 0)
 			memcpy(&attr->nexthop.s_addr,
 			       &attr->mp_nexthop_global_in, IPV4_MAX_BYTELEN);
-		break;
-	case BGP_ATTR_NHLEN_VPNV4:
-		stream_getl(s); /* RD high */
-		stream_getl(s); /* RD low */
-		stream_get(&attr->mp_nexthop_global_in, s, IPV4_MAX_BYTELEN);
 		break;
 	case BGP_ATTR_NHLEN_IPV6_GLOBAL:
 	case BGP_ATTR_NHLEN_VPNV6_GLOBAL:

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -2048,14 +2048,14 @@ const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
 	}
 
 	if (prd)
-		snprintf(str, size, "RD %s %s%s%s",
+		snprintf(str, size, "RD %s %s%s%s %s %s",
 			 prefix_rd2str(prd, rd_buf, sizeof(rd_buf)),
 			 prefix2str(pu, pfx_buf, sizeof(pfx_buf)), tag_buf,
-			 pathid_buf);
+			 pathid_buf, afi2str(afi), safi2str(safi));
 	else
-		snprintf(str, size, "%s%s%s",
+		snprintf(str, size, "%s%s%s %s %s",
 			 prefix2str(pu, pfx_buf, sizeof(pfx_buf)), tag_buf,
-			 pathid_buf);
+			 pathid_buf, afi2str(afi), safi2str(safi));
 
 	return str;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2788,7 +2788,8 @@ int bgp_update(struct peer *peer, struct prefix *p, u_int32_t addpath_id,
 	}
 
 	/* next hop check.  */
-	if (bgp_update_martian_nexthop(bgp, afi, safi, &new_attr)) {
+	if (!CHECK_FLAG(peer->flags, PEER_FLAG_IS_RFAPI_HD) && /* allow vpn->vrf import */
+	    bgp_update_martian_nexthop(bgp, afi, safi, &new_attr)) {
 		reason = "martian or self next-hop;";
 		bgp_attr_flush(&new_attr);
 		goto filtered;
@@ -3031,7 +3032,8 @@ int bgp_update(struct peer *peer, struct prefix *p, u_int32_t addpath_id,
 				connected = 0;
 
 			if (bgp_find_or_add_nexthop(bgp, afi, ri, NULL,
-						    connected))
+						    connected) ||
+			    CHECK_FLAG(peer->flags, PEER_FLAG_IS_RFAPI_HD))
 				bgp_info_set_flag(rn, ri, BGP_INFO_VALID);
 			else {
 				if (BGP_DEBUG(nht, NHT)) {
@@ -3143,7 +3145,8 @@ int bgp_update(struct peer *peer, struct prefix *p, u_int32_t addpath_id,
 		else
 			connected = 0;
 
-		if (bgp_find_or_add_nexthop(bgp, afi, new, NULL, connected))
+		if (bgp_find_or_add_nexthop(bgp, afi, new, NULL, connected) ||
+		    CHECK_FLAG(peer->flags, PEER_FLAG_IS_RFAPI_HD))
 			bgp_info_set_flag(rn, new, BGP_INFO_VALID);
 		else {
 			if (BGP_DEBUG(nht, NHT)) {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2788,7 +2788,7 @@ int bgp_update(struct peer *peer, struct prefix *p, u_int32_t addpath_id,
 	}
 
 	/* next hop check.  */
-	if (!CHECK_FLAG(peer->flags, PEER_FLAG_IS_RFAPI_HD) && /* allow vpn->vrf import */
+	if (!CHECK_FLAG(peer->flags, PEER_FLAG_IS_RFAPI_HD) &&
 	    bgp_update_martian_nexthop(bgp, afi, safi, &new_attr)) {
 		reason = "martian or self next-hop;";
 		bgp_attr_flush(&new_attr);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -699,9 +699,8 @@ struct peer {
 #define PEER_FLAG_DYNAMIC_NEIGHBOR          (1 << 12) /* dynamic neighbor */
 #define PEER_FLAG_CAPABILITY_ENHE           (1 << 13) /* Extended next-hop (rfc 5549)*/
 #define PEER_FLAG_IFPEER_V6ONLY             (1 << 14) /* if-based peer is v6 only */
-#if ENABLE_BGP_VNC
 #define PEER_FLAG_IS_RFAPI_HD		    (1 << 15) /* attached to rfapi HD */
-#endif
+
 	/* outgoing message sent in CEASE_ADMIN_SHUTDOWN notify */
 	char *tx_shutdown_message;
 

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -1752,7 +1752,7 @@ DEFUN (vnc_nve_group_export_no_routemap,
 		is_bgp = 0;
 		/* fall thru */
 	case 'b':
-		idx +=2;
+		idx += 2;
 		break;
 	default:		/* route-map */
 		idx++;

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -1466,7 +1466,7 @@ DEFUN (vnc_export_nvegroup,
 	}
 
 	if (rfg_new == NULL) {
-		vty_out(vty, "Can't group named \"%s\".\n", argv[5]->arg);
+		vty_out(vty, "Can't find group named \"%s\".\n", argv[5]->arg);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -32,6 +32,7 @@
 #include "bgpd/bgp_route.h"
 #include "bgpd/bgp_mplsvpn.h"
 
+#include "bgpd/bgp_vty.h"
 #include "bgpd/bgp_ecommunity.h"
 #include "bgpd/rfapi/rfapi.h"
 #include "bgpd/rfapi/bgp_rfapi_cfg.h"
@@ -1602,6 +1603,8 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	VTY_DECLVAR_CONTEXT_SUB(rfapi_nve_group_cfg, rfg);
+	int idx = 0;
+	int is_bgp = 1;
 	afi_t afi;
 
 	VNC_VTY_CONFIG_CHECK(bgp);
@@ -1613,17 +1616,15 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	if (strmatch(argv[3]->text, "ipv4")) {
-		afi = AFI_IP;
-	} else {
-		afi = AFI_IP6;
-	}
+	argv_find_and_parse_afi(argv, argc, &idx, &afi);
+	if (argv[idx-1]->text[0] == 'z')
+		is_bgp = 0;
+	idx += 2;		/* skip afi and keyword */
 
-	if (argv[2]->arg[0] == 'b') {
-		if (((argc > 5) && strmatch(argv[5]->text,
-					    rfg->plist_export_bgp_name[afi]))
-		    || (argc <= 5)) {
-
+	if (is_bgp) {
+		if (idx == argc ||
+		    strmatch(argv[idx]->arg,
+			     rfg->plist_export_bgp_name[afi])) {
 			if (rfg->plist_export_bgp_name[afi])
 				free(rfg->plist_export_bgp_name[afi]);
 			rfg->plist_export_bgp_name[afi] = NULL;
@@ -1632,9 +1633,9 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
 			vnc_direct_bgp_reexport_group_afi(bgp, rfg, afi);
 		}
 	} else {
-		if (((argc > 5) && strmatch(argv[5]->text,
-					    rfg->plist_export_zebra_name[afi]))
-		    || (argc <= 5)) {
+		if (idx == argc ||
+		    strmatch(argv[idx]->arg,
+			     rfg->plist_export_zebra_name[afi])) {
 			if (rfg->plist_export_zebra_name[afi])
 				free(rfg->plist_export_zebra_name[afi]);
 			rfg->plist_export_zebra_name[afi] = NULL;
@@ -1645,6 +1646,15 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
 	}
 	return CMD_SUCCESS;
 }
+
+ALIAS (vnc_nve_group_export_no_prefixlist,
+       vnc_vrf_policy_export_no_prefixlist_cmd,
+       "no export <ipv4|ipv6> prefix-list [NAME]",
+       NO_STR
+       "Export to VRF\n"
+       "IPv4 routes\n"
+       "IPv6 routes\n"
+       "Prefix-list for filtering exported routes\n" "prefix list name\n")
 
 DEFUN (vnc_nve_group_export_prefixlist,
        vnc_nve_group_export_prefixlist_cmd,
@@ -1658,6 +1668,8 @@ DEFUN (vnc_nve_group_export_prefixlist,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	VTY_DECLVAR_CONTEXT_SUB(rfapi_nve_group_cfg, rfg);
+	int idx = 0;
+	int is_bgp = 1;
 	afi_t afi;
 
 	VNC_VTY_CONFIG_CHECK(bgp);
@@ -1669,32 +1681,39 @@ DEFUN (vnc_nve_group_export_prefixlist,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	if (strmatch(argv[2]->text, "ipv4")) {
-		afi = AFI_IP;
-	} else {
-		afi = AFI_IP6;
-	}
+	argv_find_and_parse_afi(argv, argc, &idx, &afi);
+	if (argv[idx-1]->text[0] == 'z')
+		is_bgp = 0;
+	idx = argc - 1;
 
-	if (argv[1]->arg[0] == 'b') {
+	if (is_bgp) {
 		if (rfg->plist_export_bgp_name[afi])
 			free(rfg->plist_export_bgp_name[afi]);
-		rfg->plist_export_bgp_name[afi] = strdup(argv[4]->arg);
+		rfg->plist_export_bgp_name[afi] = strdup(argv[idx]->arg);
 		rfg->plist_export_bgp[afi] =
-			prefix_list_lookup(afi, argv[4]->arg);
+			prefix_list_lookup(afi, argv[idx]->arg);
 
 		vnc_direct_bgp_reexport_group_afi(bgp, rfg, afi);
 
 	} else {
 		if (rfg->plist_export_zebra_name[afi])
 			free(rfg->plist_export_zebra_name[afi]);
-		rfg->plist_export_zebra_name[afi] = strdup(argv[4]->arg);
+		rfg->plist_export_zebra_name[afi] = strdup(argv[idx]->arg);
 		rfg->plist_export_zebra[afi] =
-			prefix_list_lookup(afi, argv[4]->arg);
+			prefix_list_lookup(afi, argv[idx]->arg);
 
 		vnc_zebra_reexport_group_afi(bgp, rfg, afi);
 	}
 	return CMD_SUCCESS;
 }
+
+ALIAS (vnc_nve_group_export_prefixlist,
+       vnc_vrf_policy_export_prefixlist_cmd,
+       "export <ipv4|ipv6> prefix-list NAME",
+       "Export to VRF\n"
+       "IPv4 routes\n"
+       "IPv6 routes\n"
+       "Prefix-list for filtering exported routes\n" "prefix list name\n")
 
 DEFUN (vnc_nve_group_export_no_routemap,
        vnc_nve_group_export_no_routemap_cmd,
@@ -1707,6 +1726,8 @@ DEFUN (vnc_nve_group_export_no_routemap,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	VTY_DECLVAR_CONTEXT_SUB(rfapi_nve_group_cfg, rfg);
+	int idx = 2;
+	int is_bgp = 1;
 
 	VNC_VTY_CONFIG_CHECK(bgp);
 
@@ -1716,12 +1737,21 @@ DEFUN (vnc_nve_group_export_no_routemap,
 		vty_out(vty, "Current NVE group no longer exists\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+	switch (argv[idx]->text[0]) {
+	case 'z':
+		is_bgp = 0;
+		/* fall thru */
+	case 'b':
+		idx +=2;
+		break;
+	default:		/* route-map */
+		idx++;
+		break;
+	}
 
-	if (argv[2]->arg[0] == 'b') {
-		if (((argc > 4)
-		     && strmatch(argv[4]->text, rfg->routemap_export_bgp_name))
-		    || (argc <= 4)) {
-
+	if (is_bgp) {
+		if (idx == argc ||
+		    strmatch(argv[idx]->arg, rfg->routemap_export_bgp_name)) {
 			if (rfg->routemap_export_bgp_name)
 				free(rfg->routemap_export_bgp_name);
 			rfg->routemap_export_bgp_name = NULL;
@@ -1731,9 +1761,9 @@ DEFUN (vnc_nve_group_export_no_routemap,
 			vnc_direct_bgp_reexport_group_afi(bgp, rfg, AFI_IP6);
 		}
 	} else {
-		if (((argc > 4) && strmatch(argv[4]->text,
-					    rfg->routemap_export_zebra_name))
-		    || (argc <= 4)) {
+		if (idx == argc ||
+		    strmatch(argv[idx]->arg,
+			     rfg->routemap_export_zebra_name)) {
 			if (rfg->routemap_export_zebra_name)
 				free(rfg->routemap_export_zebra_name);
 			rfg->routemap_export_zebra_name = NULL;
@@ -1746,6 +1776,13 @@ DEFUN (vnc_nve_group_export_no_routemap,
 	return CMD_SUCCESS;
 }
 
+ALIAS (vnc_nve_group_export_no_routemap,
+       vnc_vrf_policy_export_no_routemap_cmd,
+       "no export route-map [NAME]",
+       NO_STR
+       "Export to VRF\n"
+       "Route-map for filtering exported routes\n" "route map name\n")
+
 DEFUN (vnc_nve_group_export_routemap,
        vnc_nve_group_export_routemap_cmd,
        "export <bgp|zebra> route-map NAME",
@@ -1756,6 +1793,8 @@ DEFUN (vnc_nve_group_export_routemap,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	VTY_DECLVAR_CONTEXT_SUB(rfapi_nve_group_cfg, rfg);
+	int idx = 0;
+	int is_bgp = 1;
 
 	VNC_VTY_CONFIG_CHECK(bgp);
 
@@ -1766,25 +1805,35 @@ DEFUN (vnc_nve_group_export_routemap,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	if (argv[1]->arg[0] == 'b') {
+	if (argv[1]->text[0] == 'z')
+		is_bgp = 0;
+	idx = argc - 1;
+
+	if (is_bgp) {
 		if (rfg->routemap_export_bgp_name)
 			free(rfg->routemap_export_bgp_name);
-		rfg->routemap_export_bgp_name = strdup(argv[3]->arg);
+		rfg->routemap_export_bgp_name = strdup(argv[idx]->arg);
 		rfg->routemap_export_bgp =
-			route_map_lookup_by_name(argv[3]->arg);
+			route_map_lookup_by_name(argv[idx]->arg);
 		vnc_direct_bgp_reexport_group_afi(bgp, rfg, AFI_IP);
 		vnc_direct_bgp_reexport_group_afi(bgp, rfg, AFI_IP6);
 	} else {
 		if (rfg->routemap_export_zebra_name)
 			free(rfg->routemap_export_zebra_name);
-		rfg->routemap_export_zebra_name = strdup(argv[3]->arg);
+		rfg->routemap_export_zebra_name = strdup(argv[idx]->arg);
 		rfg->routemap_export_zebra =
-			route_map_lookup_by_name(argv[3]->arg);
+			route_map_lookup_by_name(argv[idx]->arg);
 		vnc_zebra_reexport_group_afi(bgp, rfg, AFI_IP);
 		vnc_zebra_reexport_group_afi(bgp, rfg, AFI_IP6);
 	}
 	return CMD_SUCCESS;
 }
+
+ALIAS (vnc_nve_group_export_routemap,
+       vnc_vrf_policy_export_routemap_cmd,
+       "export route-map NAME",
+       "Export to VRF\n"
+       "Route-map for filtering exported routes\n" "route map name\n")
 
 DEFUN (vnc_nve_export_no_prefixlist,
        vnc_nve_export_no_prefixlist_cmd,
@@ -3687,6 +3736,14 @@ void bgp_rfapi_cfg_init(void)
 	install_element(BGP_VRF_POLICY_NODE, &vnc_vrf_policy_rt_export_cmd);
 	install_element(BGP_VRF_POLICY_NODE, &vnc_vrf_policy_rt_both_cmd);
 	install_element(BGP_VRF_POLICY_NODE, &vnc_vrf_policy_rd_cmd);
+	install_element(BGP_VRF_POLICY_NODE,
+			&vnc_vrf_policy_export_prefixlist_cmd);
+	install_element(BGP_VRF_POLICY_NODE,
+			&vnc_vrf_policy_export_routemap_cmd);
+	install_element(BGP_VRF_POLICY_NODE,
+			&vnc_vrf_policy_export_no_prefixlist_cmd);
+	install_element(BGP_VRF_POLICY_NODE,
+			&vnc_vrf_policy_export_no_routemap_cmd);
 	install_element(BGP_VRF_POLICY_NODE, &exit_vrf_policy_cmd);
 
 	install_element(BGP_VNC_L2_GROUP_NODE, &vnc_l2_group_lni_cmd);
@@ -3880,14 +3937,16 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 
 				if (rfg->plist_export_bgp_name[afi]) {
 					vty_out(vty,
-						"  export bgp %s prefix-list %s\n",
+						"  export %s%s prefix-list %s\n",
+						(rfg->type == RFAPI_GROUP_CFG_VRF ? "" : "bgp "),
 						afistr,
 						rfg->plist_export_bgp_name
 							[afi]);
 				}
 				if (rfg->plist_export_zebra_name[afi]) {
 					vty_out(vty,
-						"  export zebra %s prefix-list %s\n",
+						"  export %s%s prefix-list %s\n",
+						(rfg->type == RFAPI_GROUP_CFG_VRF ? "" : "zebra "),
 						afistr,
 						rfg->plist_export_zebra_name
 							[afi]);
@@ -3921,11 +3980,13 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 			}
 
 			if (rfg->routemap_export_bgp_name) {
-				vty_out(vty, "  export bgp route-map %s\n",
+				vty_out(vty, "  export %sroute-map %s\n",
+					(rfg->type == RFAPI_GROUP_CFG_VRF ? "" : "bgp "),
 					rfg->routemap_export_bgp_name);
 			}
 			if (rfg->routemap_export_zebra_name) {
-				vty_out(vty, "  export zebra route-map %s\n",
+				vty_out(vty, "  export %sroute-map %s\n",
+					(rfg->type == RFAPI_GROUP_CFG_VRF ? "" : "zebra "),
 					rfg->routemap_export_zebra_name);
 			}
 			if (rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT]) {

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -1459,6 +1459,14 @@ DEFUN (vnc_export_nvegroup,
 
 	rfg_new = bgp_rfapi_cfg_match_byname(bgp, argv[5]->arg,
 					     RFAPI_GROUP_CFG_NVE);
+	if (rfg_new == NULL)
+		rfg_new = bgp_rfapi_cfg_match_byname(bgp, argv[5]->arg,
+						     RFAPI_GROUP_CFG_VRF);
+
+	if (rfg_new == NULL) {
+		vty_out(vty, "Can't group named \"%s\".\n", argv[5]->arg);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	if (argv[2]->arg[0] == 'b') {
 

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -3973,9 +3973,6 @@ void rfapiProcessUpdate(struct peer *peer,
 
 	if (safi == SAFI_MPLS_VPN) {
 		vnc_direct_bgp_rh_add_route(bgp, afi, p, peer, attr);
-	}
-
-	if (safi == SAFI_MPLS_VPN) {
 		rfapiBgpInfoFilteredImportVPN(
 			bgp->rfapi->it_ce, FIF_ACTION_UPDATE, peer, rfd,
 			p, /* prefix */

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -345,6 +345,7 @@ extern void rfapi_un_options_free(struct rfapi_un_option *goner);
 
 extern void rfapi_vn_options_free(struct rfapi_vn_option *goner);
 
+extern void clear_vnc_vrf_closer(struct rfapi_nve_group_cfg *rfg);
 /*------------------------------------------
  * rfapi_extract_l2o
  *

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -345,6 +345,7 @@ extern void rfapi_un_options_free(struct rfapi_un_option *goner);
 
 extern void rfapi_vn_options_free(struct rfapi_vn_option *goner);
 
+extern void vnc_add_vrf_opener(struct bgp *bgp, struct rfapi_nve_group_cfg *rfg);
 extern void clear_vnc_vrf_closer(struct rfapi_nve_group_cfg *rfg);
 /*------------------------------------------
  * rfapi_extract_l2o

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -4632,6 +4632,8 @@ notcfg:
  * add [vrf <vrf-name>] prefix <prefix>
  *     [rd <value>] [label <value>] [local-preference <0-4294967295>]
  ************************************************************************/
+
+/* NOTE: this functions parallels vnc_direct_add_rn_group_rd */
 static int vnc_add_vrf_prefix(struct vty *vty, const char *arg_vrf,
 			      const char *arg_prefix,
 			      const char *arg_rd,    /* optional */
@@ -4847,7 +4849,7 @@ static int rfapi_cfg_group_it_count(struct rfapi_nve_group_cfg *rfg)
 	return count;
 }
 
-static void clear_vnc_vrf_closer(struct rfapi_nve_group_cfg *rfg)
+void clear_vnc_vrf_closer(struct rfapi_nve_group_cfg *rfg)
 {
 	struct rfapi_descriptor *rfd = rfg->rfd;
 	afi_t afi;

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -4634,10 +4634,10 @@ notcfg:
  ************************************************************************/
 void vnc_add_vrf_opener(struct bgp *bgp, struct rfapi_nve_group_cfg *rfg)
 {
-	if (rfg->rfd == NULL) /* need new rfapi_handle */
-	{
+	if (rfg->rfd == NULL) {	/* need new rfapi_handle */
 		/* based on rfapi_open */
 		struct rfapi_descriptor *rfd;
+
 		rfd = XCALLOC(MTYPE_RFAPI_DESC,
 			      sizeof(struct rfapi_descriptor));
 		rfd->bgp = bgp;

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -779,7 +779,11 @@ void vnc_direct_bgp_add_prefix(struct bgp *bgp,
 		if (rfgn->rfg->type == RFAPI_GROUP_CFG_VRF) {
 			vnc_direct_add_rn_group_rd(bgp, rfgn->rfg, rn, &attr,
 						   afi, rfgn->rfg->rfd);
-			continue; /* yuck! - but consistent with rest of function */
+			/*
+			 * yuck!
+			 *  - but consistent with rest of function
+			 */
+			continue;
 		}
 		/*
 		 * For each NVE that is assigned to the export nve group,
@@ -880,7 +884,11 @@ void vnc_direct_bgp_del_prefix(struct bgp *bgp,
 				     BGP_ROUTE_REDISTRIBUTE,
 				     NULL,	/* RD not used for unicast */
 				     NULL, NULL); /* tag not used for unicast */
-			continue; /* yuck! - but consistent with rest of function */
+			/*
+			 * yuck!
+			 *  - but consistent with rest of function
+			 */
+			continue;
 		}
 		/*
 		 * For each NVE that is assigned to the export nve group,
@@ -1161,7 +1169,7 @@ static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 	if (irfd == NULL && rfg->type != RFAPI_GROUP_CFG_VRF) {
 		/* need new rfapi_handle, for peer strcture
 		 * -- based on vnc_add_vrf_prefi */
-		assert (rfg->rfd == NULL);
+		assert(rfg->rfd == NULL);
 
 		if (!rfg->rt_export_list || !rfg->rfapi_import_table) {
 			vnc_zlog_debug_verbose("%s: VRF \"%s\" is missing RT import/export configuration.\n",
@@ -1183,8 +1191,10 @@ static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 			      sizeof(struct rfapi_descriptor));
 		irfd->bgp = bgp;
 		rfg->rfd = irfd;
-		/* leave most fields empty as will get from (dynamic) config
-		 * when needed */
+		/*
+		 * leave most fields empty as will get from (dynamic) config
+		 * when needed
+		 */
 		irfd->default_tunneltype_option.type = BGP_ENCAP_TYPE_MPLS;
 		irfd->cookie = rfg;
 		if (rfg->vn_prefix.family
@@ -1224,23 +1234,21 @@ static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 
 	if (rfg->routemap_export_bgp) {
 		route_map_result_t ret;
+
 		info.peer = irfd->peer;
 		info.attr = &hattr;
-		ret = route_map_apply(
-				      rfg->routemap_export_bgp,
+		ret = route_map_apply(rfg->routemap_export_bgp,
 				      &rn->p, RMAP_BGP, &info);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
-			vnc_zlog_debug_verbose(
-					       "%s: route map says DENY, so not calling bgp_update",
+			vnc_zlog_debug_verbose("%s: route map says DENY, so not calling bgp_update",
 					       __func__);
 			return;
 		}
 	}
 
 	if (VNC_DEBUG(EXPORT_BGP_DIRECT_ADD)) {
-		vnc_zlog_debug_any(
-				   "%s: hattr after route_map_apply:",
+		vnc_zlog_debug_any("%s: hattr after route_map_apply:",
 				   __func__);
 		rfapiPrintAttrPtrs(NULL, &hattr);
 	}
@@ -1321,7 +1329,11 @@ static void vnc_direct_bgp_add_group_afi(struct bgp *bgp,
 			if (rfg->type == RFAPI_GROUP_CFG_VRF) {
 				vnc_direct_add_rn_group_rd(bgp, rfg, rn, &attr,
 							   afi, rfg->rfd);
-				continue; /* yuck! - but consistent with rest of function */
+				/*
+				 * yuck!
+				 *  - but consistent with rest of function
+				 */
+				continue;
 			}
 			/*
 			 * For each NVE that is assigned to the export nve
@@ -1331,7 +1343,7 @@ static void vnc_direct_bgp_add_group_afi(struct bgp *bgp,
 			for (ln = listhead(rfg->nves); ln;
 			     ln = listnextnode(ln)) {
 				vnc_direct_add_rn_group_rd(bgp, rfg, rn, &attr,
-							   afi, listgetdata(ln));
+						   afi, listgetdata(ln));
 			}
 		}
 	}
@@ -1418,11 +1430,10 @@ static void vnc_direct_bgp_del_group_afi(struct bgp *bgp,
 				for (ln = listhead(rfg->nves); ln;
 				     ln = listnextnode(ln))
 					vnc_direct_del_rn_group_rd(bgp, rfg, rn,
-								   afi, listgetdata(ln));
+						afi, listgetdata(ln));
 			}
 		}
 }
-
 
 /*
  * Caller is responsible for ensuring that the specified nve-group

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -643,7 +643,7 @@ encap_attr_export(struct attr *new, struct attr *orig,
 	if (rn) {
 		ecom_ro = vnc_route_origin_ecom(rn);
 	} else {
-		/* TBD test/assert for IPv6 */
+		/* TBD  use lcom for IPv6 */
 		ecom_ro = vnc_route_origin_ecom_single(&use_nexthop->u.prefix4);
 	}
 	if (new->ecommunity) {

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1367,9 +1367,6 @@ static void vnc_direct_del_rn_group_rd(struct bgp *bgp,
 		     NULL, /* RD not used for unicast */
 		     NULL,
 		     NULL); /* tag not used for unicast */
-	if (rfg->type == RFAPI_GROUP_CFG_VRF) {
-		clear_vnc_vrf_closer(rfg);
-	}
 	return;
 }
 

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -573,7 +573,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve(
 	struct bgp_node *bnp; /* prd table node */
 
 	/*debugging */
-	{
+	if (VNC_DEBUG(VERBOSE)) {
 		char str_pfx[BUFSIZ];
 		char str_nh[BUFSIZ];
 		struct prefix nh;
@@ -2637,7 +2637,7 @@ void vnc_import_bgp_add_route(struct bgp *bgp, struct prefix *prefix,
 {
 	afi_t afi = family2afi(prefix->family);
 
-	{
+	if (VNC_DEBUG(VERBOSE)) {
 		struct prefix pfx_nexthop;
 		char buf[BUFSIZ];
 		char buf_nh[BUFSIZ];

--- a/doc/vnc.texi
+++ b/doc/vnc.texi
@@ -733,7 +733,7 @@ statement.
 Specify how routes should be exported to bgp or zebra.
 If the mode is @code{none}, routes are not exported.
 If the mode is @code{group-nve}, routes are exported according
-to nve-group configuration (@pxref{VNC NVE Group Configuration}): if a group is configured to
+to nve-group or vrf-policy group configuration (@pxref{VNC NVE Group Configuration}): if a group is configured to
 allow export, then each prefix visible to the group is exported
 with next hops set to the currently-registered NVEs.
 If the mode is @code{registering-nve}, then all VNC routes are
@@ -751,7 +751,8 @@ The default for both bgp and zebra is mode @code{none}.
 @deffn {VNC} {vnc export bgp|zebra group-nve group @var{group-name}}
 @deffnx {VNC} {vnc export bgp|zebra group-nve no group @var{group-name}}
 When export mode is @code{group-nve},
-export (or do not export) prefixes from the specified nve-group
+export (or do not export) prefixes from the specified nve-group or
+vrf-policy group
 to unicast BGP or to zebra.
 Repeat this statement as needed for each nve-group to be exported.
 Each VNC prefix that is exported will result in N exported routes to the
@@ -785,7 +786,7 @@ being exported to bgp or zebra.
 @end deffn
 
 When the export mode is @code{group-nve}, policy for exported
-routes is specified per-NVE-group inside a @code{nve-group} @var{RFG-NAME} block
+routes is specified per-NVE-group or vrf-policy group inside a @code{nve-group} @var{RFG-NAME} block
 via the following commands(@pxref{VNC NVE Group Configuration}):
 
 @deffn {VNC} {export bgp|zebra route-map MAP-NAME}


### PR DESCRIPTION
precursor to import/export of VRFs -- topotest is coming

to configure use:
vrf-policy "name"
    ...
   exit-vrf-policy
 
vnc export bgp mode group-nve
 vnc export bgp group-nve group "name"
 vnc redistribute mode resolve-nve
 vnc redistribute ipv4 bgp-direct
