### PR TITLE
lib: fix bug in cmd_complete_command_real()

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -682,7 +682,7 @@ static vector cmd_complete_command_real(vector vline, struct vty *vty,
 
 	if (MATCHER_ERROR(rv)) {
 		*status = CMD_ERR_NO_MATCH;
-		return NULL;
+		return vector_init(VECTOR_MIN_SIZE);
 	}
 
 	vector comps = completions_to_vec(completions);


### PR DESCRIPTION
If command_complete() failed. cmd_complete_command_real should return an
vector other than just return NULL. Returning NULL will cause a core
dump in vtysh_rl_describe() while vector_free() try to free a NULL
pointer.