### PR TITLE
vtysh: protect null deref for cli completions

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -820,7 +820,8 @@ static int vtysh_rl_describe(void)
 		break;
 	case CMD_ERR_NO_MATCH:
 		cmd_free_strvec(vline);
-		vector_free(describe);
+		if (describe)
+			vector_free(describe);
 		fprintf(stdout, "%% There is no matched command.\n");
 		rl_on_new_line();
 		return 0;


### PR DESCRIPTION
cmd_describe_command() returns NULL when there is no matched command, so
check the return value before trying to free it

#1393 redux

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>