### PR TITLE
ospfd: VRF aware Router-ID update

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -244,7 +244,6 @@ DEFUN (no_router_ospf,
 		else
 			return CMD_WARNING;
 	}
-	zlog_debug("%s: no router ospf ", __PRETTY_FUNCTION__);
 	ospf_finish(ospf);
 
 	return CMD_SUCCESS;
@@ -4151,12 +4150,12 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 
 				if (nbr->state == NSM_Attempt &&
 				    nbr->router_id.s_addr == 0)
-					strncpy(neigh_str, "neighbor",
-						INET_ADDRSTRLEN);
+					strlcpy(neigh_str, "neighbor",
+						sizeof(neigh_str));
 				else
-					strncpy(neigh_str,
+					strlcpy(neigh_str,
 						inet_ntoa(nbr->router_id),
-						INET_ADDRSTRLEN);
+						sizeof(neigh_str));
 
 				json_object_object_get_ex(json, neigh_str,
 							  &json_neigh_array);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -66,7 +66,6 @@ static struct ospf_master ospf_master;
 struct ospf_master *om;
 
 extern struct zclient *zclient;
-extern struct in_addr router_id_zebra;
 
 
 static void ospf_remove_vls_through_area(struct ospf *, struct ospf_area *);
@@ -117,12 +116,12 @@ void ospf_router_id_update(struct ospf *ospf)
 	else if (ospf->router_id.s_addr != 0)
 		router_id = ospf->router_id;
 	else
-		router_id = router_id_zebra;
+		router_id = ospf->router_id_zebra;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("Router-ID[OLD:%s]: Update to %s",
 			   inet_ntoa(ospf->router_id),
-			   inet_ntoa(router_id_old));
+			   inet_ntoa(router_id));
 
 	if (!IPV4_ADDR_SAME(&router_id_old, &router_id)) {
 
@@ -2056,6 +2055,7 @@ static int ospf_vrf_enable(struct vrf *vrf)
 			}
 
 			ospf->oi_running = 1;
+			ospf_zebra_vrf_register(ospf);
 			ospf_router_id_update(ospf);
 		}
 	}

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -134,6 +134,7 @@ struct ospf {
 	/* OSPF Router ID. */
 	struct in_addr router_id;	/* Configured automatically. */
 	struct in_addr router_id_static; /* Configured manually. */
+	struct in_addr router_id_zebra;
 
 	vrf_id_t vrf_id;  /* VRF Id */
 	char *name;       /* VRF name */


### PR DESCRIPTION
Ensure zebra received router-id isolated per vrf instance.
Store zebra received router-id within ospf instance.

Ticket:CM-18657
Reviewed By:
Testing Done:
Validated follwoing sequence
- Create vrf1111
- Create ospf vrf1111 with no router-id
- Assign ip to vrf111
- ospf is assigned zebra assigned router-id which is vrf ip.
- upon remvoing vrf ip, the router-id retained as same until
ospfd restarted.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>