### PR TITLE
bgpd: default originate issue with intf peers and global intf address

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -691,7 +691,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 	p.family = afi2family(afi);
 	p.prefixlen = 0;
 
-	if (afi == AFI_IP6) {
+	if ((afi == AFI_IP6) || peer_cap_enhe(peer, afi, safi)) {
 		/* IPv6 global nexthop must be included. */
 		attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
 


### PR DESCRIPTION
Problem reported that a receiver of a default route issued across bgp
unnumbered peering using default originate would have the route stay
as inactive.  Discovered we were messing up the nexthop value sent to
the peer in this one particular case.  Manual testing good, fix supplied
to the submitter and verified to resolve the problem.  bgp-smoke
completed successfully.

Ticket: CM-18634
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Reviewed-by: Donald Sharp <sharpd@cumulusnetworks.com>