### PR TITLE
bgpd: Fix crash with ecommunity string

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -702,8 +702,12 @@ char *ecommunity_ecom2str(struct ecommunity *ecom, int format, int filter)
 				len = sprintf(
 					str_buf + str_pnt,
 					"EVPN:%02x:%02x:%02x:%02x:%02x:%02x",
-					macaddr[0], macaddr[1], macaddr[2],
-					macaddr[3], macaddr[4], macaddr[5]);
+					(uint8_t)macaddr[0],
+					(uint8_t)macaddr[1],
+					(uint8_t)macaddr[2],
+					(uint8_t)macaddr[3],
+					(uint8_t)macaddr[4],
+					(uint8_t)macaddr[5]);
 			} else if (*pnt
 				   == ECOMMUNITY_EVPN_SUBTYPE_MACMOBILITY) {
 				u_int32_t seqnum;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2011,6 +2011,7 @@ static int bgp_capability_msg_parse(struct peer *peer, u_char *pnt,
 
 		/* Fetch structure to the byte stream. */
 		memcpy(&mpc, pnt + 3, sizeof(struct capability_mp_data));
+		pnt += hdr->length + 3;
 
 		/* We know MP Capability Code. */
 		if (hdr->code == CAPABILITY_CODE_MP) {
@@ -2063,7 +2064,6 @@ static int bgp_capability_msg_parse(struct peer *peer, u_char *pnt,
 				"%s unrecognized capability code: %d - ignored",
 				peer->host, hdr->code);
 		}
-		pnt += hdr->length + 3;
 	}
 	return 0;
 }


### PR DESCRIPTION
When we are displaying a extended community ECOMMUNITY_SITE_ORIGIN
the display sprintf is this:

len = sprintf(
	str_buf + str_pnt,
	"EVPN:%02x:%02x:%02x:%02x:%02x:%02x",
	macaddr[0], macaddr[1], macaddr[2],
	macaddr[3], macaddr[4], macaddr[5]);

The problem with this is that macaddr[0] is passed in as a integer
so the sprintf function thinks that the value to display is much
larger than it actually is.  The ECOMMUNITY_STR_DEFAULT_LEN is 27
So the resulting string no-longer fits in memory and we write
off the end of the buffer and can crash.  If we force the
passed in value to be a uint8_t then we get the expected output
since a single byte is displayed as 2 hex characters and the
resulting string fits in str_buf.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>