### PR TITLE
ospfd: flush self-originated LSAs upon Router-ID change/Restart frr

### DIFF
--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -361,9 +361,9 @@ static int ospf_flood_through_interface(struct ospf_interface *oi,
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
 			"ospf_flood_through_interface(): "
-			"considering int %s, INBR(%s), LSA[%s]",
+			"considering int %s, INBR(%s), LSA[%s] AGE %u",
 			IF_NAME(oi), inbr ? inet_ntoa(inbr->router_id) : "NULL",
-			dump_lsa_key(lsa));
+			dump_lsa_key(lsa), ntohs(lsa->data->ls_age));
 
 	if (!ospf_if_is_enable(oi))
 		return 0;
@@ -958,6 +958,9 @@ void ospf_lsa_flush_area(struct ospf_lsa *lsa, struct ospf_area *area)
 	   more time for the ACK to be received and avoid
 	   retransmissions */
 	lsa->data->ls_age = htons(OSPF_LSA_MAXAGE);
+	if (IS_DEBUG_OSPF_EVENT)
+		zlog_debug("%s: MAXAGE set to LSA %s", __PRETTY_FUNCTION__,
+			   inet_ntoa(lsa->data->id));
 	monotime(&lsa->tv_recv);
 	lsa->tv_orig = lsa->tv_recv;
 	ospf_flood_through_area(area, NULL, lsa);

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -3302,6 +3302,8 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 	struct route_node *rn;
 	int need_to_flush_ase = 0;
 
+	ospf->inst_shutdown = 1;
+
 	for (ALL_LIST_ELEMENTS(ospf->areas, node, nnode, area)) {
 		if ((lsa = area->router_lsa_self) != NULL) {
 			if (IS_DEBUG_OSPF_EVENT)

--- a/ospfd/ospf_packet.h
+++ b/ospfd/ospf_packet.h
@@ -152,7 +152,7 @@ extern void ospf_db_desc_resend(struct ospf_neighbor *);
 extern void ospf_ls_req_send(struct ospf_neighbor *);
 extern void ospf_ls_upd_send_lsa(struct ospf_neighbor *, struct ospf_lsa *,
 				 int);
-extern void ospf_ls_upd_send(struct ospf_neighbor *, struct list *, int);
+extern void ospf_ls_upd_send(struct ospf_neighbor *, struct list *, int, int);
 extern void ospf_ls_ack_send(struct ospf_neighbor *, struct ospf_lsa *);
 extern void ospf_ls_ack_send_delayed(struct ospf_interface *);
 extern void ospf_ls_retransmit(struct ospf_interface *, struct ospf_lsa *);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -596,8 +596,7 @@ static void ospf_finish_final(struct ospf *ospf)
 
 	ospf_opaque_type11_lsa_term(ospf);
 
-	/* be nice if this worked, but it doesn't */
-	/*ospf_flush_self_originated_lsas_now (ospf);*/
+	ospf_flush_self_originated_lsas_now(ospf);
 
 	/* Unregister redistribution */
 	for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -310,6 +310,10 @@ struct ospf {
 
 	struct route_table *distance_table;
 
+	/* Used during ospf instance going down send LSDB
+	 * update to neighbors immediatly */
+	uint8_t inst_shutdown;
+
 	QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(ospf)


### PR DESCRIPTION
Router-ID change or ospf instance going down,
send LS-Upd with MAXAGE to self origintated LSAs to
all ospf neighbors.

Ticket:CM-1576
Testing Done:
Bring R1 - R2, Change Router-ID on R2, restart frr on R2
Validated R1 ospf LSDB for max aged 3600 LSA from R2.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>