### PR TITLE
*: don't use deprecated stream.h macros

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2247,7 +2247,7 @@ bgp_attr_parse_ret_t bgp_attr_parse(struct peer *peer, struct attr *attr,
 				"%s: error BGP attribute length %lu is smaller than min len",
 				peer->host,
 				(unsigned long)(endp
-						- STREAM_PNT(BGP_INPUT(peer))));
+						- stream_pnt(BGP_INPUT(peer))));
 
 			bgp_notify_send(peer, BGP_NOTIFY_UPDATE_ERR,
 					BGP_NOTIFY_UPDATE_ATTR_LENG_ERR);
@@ -2269,7 +2269,7 @@ bgp_attr_parse_ret_t bgp_attr_parse(struct peer *peer, struct attr *attr,
 				"%s: Extended length set, but just %lu bytes of attr header",
 				peer->host,
 				(unsigned long)(endp
-						- STREAM_PNT(BGP_INPUT(peer))));
+						- stream_pnt(BGP_INPUT(peer))));
 
 			bgp_notify_send(peer, BGP_NOTIFY_UPDATE_ERR,
 					BGP_NOTIFY_UPDATE_ATTR_LENG_ERR);

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -962,7 +962,7 @@ struct bpacket *subgroup_withdraw_packet(struct update_subgroup *subgrp)
 		addpath_tx_id = adj->addpath_tx_id;
 
 		space_remaining =
-			STREAM_REMAIN(s) - BGP_MAX_PACKET_SIZE_OVERFLOW;
+			STREAM_WRITEABLE(s) - BGP_MAX_PACKET_SIZE_OVERFLOW;
 		space_needed =
 			BGP_NLRI_LENGTH + addpath_overhead + BGP_TOTAL_ATTR_LEN
 			+ bgp_packet_mpattr_prefix_size(afi, safi, &rn->p);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1160,7 +1160,7 @@ enum bgp_clear_type {
 
 /* Macros. */
 #define BGP_INPUT(P)         ((P)->curr)
-#define BGP_INPUT_PNT(P)     (STREAM_PNT(BGP_INPUT(P)))
+#define BGP_INPUT_PNT(P)     (stream_pnt(BGP_INPUT(P)))
 #define BGP_IS_VALID_STATE_FOR_NOTIF(S)                                        \
 	(((S) == OpenSent) || ((S) == OpenConfirm) || ((S) == Established))
 

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -425,7 +425,7 @@ int eigrp_write(struct thread *thread)
 
 	iov[0].iov_base = (char *)&iph;
 	iov[0].iov_len = iph.ip_hl << EIGRP_WRITE_IPHL_SHIFT;
-	iov[1].iov_base = STREAM_PNT(ep->s);
+	iov[1].iov_base = stream_pnt(ep->s);
 	iov[1].iov_len = ep->length;
 
 	/* send final fragment (could be first) */
@@ -555,7 +555,7 @@ int eigrp_read(struct thread *thread)
 	   by eigrp_recv_packet() to be correct). */
 
 	stream_forward_getp(ibuf, (iph->ip_hl * 4));
-	eigrph = (struct eigrp_header *)STREAM_PNT(ibuf);
+	eigrph = (struct eigrp_header *)stream_pnt(ibuf);
 
 	if (IS_DEBUG_EIGRP_TRANSMIT(0, RECV)
 	    && IS_DEBUG_EIGRP_TRANSMIT(0, PACKET_DETAIL))

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -123,9 +123,14 @@ struct stream_fifo {
 #define STREAM_CONCAT_REMAIN(S1, S2, size) ((size) - (S1)->endp - (S2)->endp)
 
 /* deprecated macros - do not use in new code */
+#if CONFDATE > 20181128
+CPP_NOTICE("lib: time to remove deprecated stream.h macros")
+#endif
 #define STREAM_PNT(S)   stream_pnt((S))
-#define STREAM_DATA(S)  ((S)->data)
 #define STREAM_REMAIN(S) STREAM_WRITEABLE((S))
+
+/* this macro is deprecated, but not slated for removal anytime soon */
+#define STREAM_DATA(S)  ((S)->data)
 
 /* Stream prototypes.
  * For stream_{put,get}S, the S suffix mean:

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -230,7 +230,7 @@ static void ospf_packet_hello_dump(struct stream *s, u_int16_t length)
 	struct ospf_hello *hello;
 	int i;
 
-	hello = (struct ospf_hello *)STREAM_PNT(s);
+	hello = (struct ospf_hello *)stream_pnt(s);
 
 	zlog_debug("Hello");
 	zlog_debug("  NetworkMask %s", inet_ntoa(hello->network_mask));
@@ -278,7 +278,7 @@ static void ospf_router_lsa_dump(struct stream *s, u_int16_t length)
 	struct router_lsa *rl;
 	int i, len;
 
-	rl = (struct router_lsa *)STREAM_PNT(s);
+	rl = (struct router_lsa *)stream_pnt(s);
 
 	zlog_debug("  Router-LSA");
 	zlog_debug("    flags %s",
@@ -303,7 +303,7 @@ static void ospf_network_lsa_dump(struct stream *s, u_int16_t length)
 	struct network_lsa *nl;
 	int i, cnt;
 
-	nl = (struct network_lsa *)STREAM_PNT(s);
+	nl = (struct network_lsa *)stream_pnt(s);
 	cnt = (ntohs(nl->header.length) - (OSPF_LSA_HEADER_SIZE + 4)) / 4;
 
 	zlog_debug("  Network-LSA");
@@ -325,7 +325,7 @@ static void ospf_summary_lsa_dump(struct stream *s, u_int16_t length)
 	int size;
 	int i;
 
-	sl = (struct summary_lsa *)STREAM_PNT(s);
+	sl = (struct summary_lsa *)stream_pnt(s);
 
 	zlog_debug("  Summary-LSA");
 	zlog_debug("    Network Mask %s", inet_ntoa(sl->mask));
@@ -342,7 +342,7 @@ static void ospf_as_external_lsa_dump(struct stream *s, u_int16_t length)
 	int size;
 	int i;
 
-	al = (struct as_external_lsa *)STREAM_PNT(s);
+	al = (struct as_external_lsa *)stream_pnt(s);
 	zlog_debug("  %s", ospf_lsa_type_msg[al->header.type].str);
 	zlog_debug("    Network Mask %s", inet_ntoa(al->mask));
 
@@ -366,7 +366,7 @@ static void ospf_lsa_header_list_dump(struct stream *s, u_int16_t length)
 
 	/* LSA Headers. */
 	while (length > 0) {
-		lsa = (struct lsa_header *)STREAM_PNT(s);
+		lsa = (struct lsa_header *)stream_pnt(s);
 		ospf_lsa_header_dump(lsa);
 
 		stream_forward_getp(s, OSPF_LSA_HEADER_SIZE);
@@ -382,7 +382,7 @@ static void ospf_packet_db_desc_dump(struct stream *s, u_int16_t length)
 	u_int32_t gp;
 
 	gp = stream_get_getp(s);
-	dd = (struct ospf_db_desc *)STREAM_PNT(s);
+	dd = (struct ospf_db_desc *)stream_pnt(s);
 
 	zlog_debug("Database Description");
 	zlog_debug("  Interface MTU %d", ntohs(dd->mtu));
@@ -452,7 +452,7 @@ static void ospf_packet_ls_upd_dump(struct stream *s, u_int16_t length)
 			break;
 		}
 
-		lsa = (struct lsa_header *)STREAM_PNT(s);
+		lsa = (struct lsa_header *)stream_pnt(s);
 		lsa_len = ntohs(lsa->length);
 		ospf_lsa_header_dump(lsa);
 
@@ -566,7 +566,7 @@ void ospf_packet_dump(struct stream *s)
 	gp = stream_get_getp(s);
 
 	/* OSPF Header dump. */
-	ospfh = (struct ospf_header *)STREAM_PNT(s);
+	ospfh = (struct ospf_header *)stream_pnt(s);
 
 	/* Until detail flag is set, return. */
 	if (!(term_debug_ospf_packet[ospfh->type - 1] & OSPF_DEBUG_DETAIL))

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -438,7 +438,7 @@ static char link_info_set(struct stream *s, struct in_addr id,
 		if (ret == OSPF_MAX_LSA_SIZE) {
 			zlog_warn(
 				"%s: Out of space in LSA stream, left %zd, size %zd",
-				__func__, STREAM_REMAIN(s), STREAM_SIZE(s));
+				__func__, STREAM_WRITEABLE(s), STREAM_SIZE(s));
 			return 0;
 		}
 	}

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1181,7 +1181,7 @@ void ospf_opaque_lsa_dump(struct stream *s, u_int16_t length)
 {
 	struct ospf_lsa lsa;
 
-	lsa.data = (struct lsa_header *)STREAM_PNT(s);
+	lsa.data = (struct lsa_header *)stream_pnt(s);
 	show_opaque_info_detail(NULL, &lsa);
 	return;
 }

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -617,7 +617,7 @@ static void ospf_write_frags(int fd, struct ospf_packet *op, struct ip *iph,
 
 		iph->ip_off += offset;
 		stream_forward_getp(op->s, iovp->iov_len);
-		iovp->iov_base = STREAM_PNT(op->s);
+		iovp->iov_base = stream_pnt(op->s);
 	}
 
 	/* setup for final fragment */
@@ -763,7 +763,7 @@ static int ospf_write(struct thread *thread)
 
 		iov[0].iov_base = (char *)&iph;
 		iov[0].iov_len = iph.ip_hl << OSPF_WRITE_IPHL_SHIFT;
-		iov[1].iov_base = STREAM_PNT(op->s);
+		iov[1].iov_base = stream_pnt(op->s);
 		iov[1].iov_len = op->length;
 
 #ifdef GNU_LINUX
@@ -891,7 +891,7 @@ static void ospf_hello(struct ip *iph, struct ospf_header *ospfh,
 	/* increment statistics. */
 	oi->hello_in++;
 
-	hello = (struct ospf_hello *)STREAM_PNT(s);
+	hello = (struct ospf_hello *)stream_pnt(s);
 
 	/* If Hello is myself, silently discard. */
 	if (IPV4_ADDR_SAME(&ospfh->router_id, &oi->ospf->router_id)) {
@@ -1119,7 +1119,7 @@ static void ospf_db_desc_proc(struct stream *s, struct ospf_interface *oi,
 	stream_forward_getp(s, OSPF_DB_DESC_MIN_SIZE);
 	for (size -= OSPF_DB_DESC_MIN_SIZE; size >= OSPF_LSA_HEADER_SIZE;
 	     size -= OSPF_LSA_HEADER_SIZE) {
-		lsah = (struct lsa_header *)STREAM_PNT(s);
+		lsah = (struct lsa_header *)stream_pnt(s);
 		stream_forward_getp(s, OSPF_LSA_HEADER_SIZE);
 
 		/* Unknown LS type. */
@@ -1268,7 +1268,7 @@ static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 	/* Increment statistics. */
 	oi->db_desc_in++;
 
-	dd = (struct ospf_db_desc *)STREAM_PNT(s);
+	dd = (struct ospf_db_desc *)stream_pnt(s);
 
 	nbr = ospf_nbr_lookup(oi, iph, ospfh);
 	if (nbr == NULL) {
@@ -1661,7 +1661,7 @@ static struct list *ospf_ls_upd_list_lsa(struct ospf_neighbor *nbr,
 
 	for (; size >= OSPF_LSA_HEADER_SIZE && count > 0;
 	     size -= length, stream_forward_getp(s, length), count--) {
-		lsah = (struct lsa_header *)STREAM_PNT(s);
+		lsah = (struct lsa_header *)stream_pnt(s);
 		length = ntohs(lsah->length);
 
 		if (length > size) {
@@ -2219,10 +2219,10 @@ static void ospf_ls_ack(struct ip *iph, struct ospf_header *ospfh,
 		struct ospf_lsa *lsa, *lsr;
 
 		lsa = ospf_lsa_new();
-		lsa->data = (struct lsa_header *)STREAM_PNT(s);
+		lsa->data = (struct lsa_header *)stream_pnt(s);
 		lsa->vrf_id = oi->ospf->vrf_id;
 
-		/* lsah = (struct lsa_header *) STREAM_PNT (s); */
+		/* lsah = (struct lsa_header *) stream_pnt (s); */
 		size -= OSPF_LSA_HEADER_SIZE;
 		stream_forward_getp(s, OSPF_LSA_HEADER_SIZE);
 
@@ -2936,7 +2936,7 @@ int ospf_read(struct thread *thread)
 	   by ospf_recv_packet() to be correct). */
 	stream_forward_getp(ibuf, iph->ip_hl * 4);
 
-	ospfh = (struct ospf_header *)STREAM_PNT(ibuf);
+	ospfh = (struct ospf_header *)stream_pnt(ibuf);
 	if (MSG_OK
 	    != ospf_packet_examin(
 		       ospfh, stream_get_endp(ibuf) - stream_get_getp(ibuf)))

--- a/pimd/pim_msdp_packet.c
+++ b/pimd/pim_msdp_packet.c
@@ -221,7 +221,7 @@ int pim_msdp_write(struct thread *thread)
 		writenum = stream_get_endp(s) - stream_get_getp(s);
 
 		/* Call write() system call */
-		num = write(mp->fd, STREAM_PNT(s), writenum);
+		num = write(mp->fd, stream_pnt(s), writenum);
 		if (num < 0) {
 			/* write failed either retry needed or error */
 			if (ERRNO_IO_RETRY(errno)) {

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -996,7 +996,7 @@ static int zfpm_write_cb(struct thread *thread)
 			break;
 
 		bytes_written =
-			write(zfpm_g->sock, STREAM_PNT(s), bytes_to_write);
+			write(zfpm_g->sock, stream_pnt(s), bytes_to_write);
 		zfpm_g->stats.write_calls++;
 		num_writes++;
 


### PR DESCRIPTION
Some of the deprecated stream.h macros see such little use that we may
as well just remove them and use the non-deprecated macros.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>