### PR TITLE
zebra: fix resolving nexthop through itself

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -449,9 +449,15 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 	while (rn) {
 		route_unlock_node(rn);
 
-		/* If lookup self prefix return immediately. */
-		if (rn == top)
-			return 0;
+		/* Lookup should halt if we've matched against ourselves ('top',
+		 * if specified) - i.e., we cannot have a nexthop NH1 is
+		 * resolved by a route NH1. The exception is if the route is a
+		 * host route.
+		 */
+		if (top && rn == top)
+			if (((afi == AFI_IP) && (rn->p.prefixlen != 32)) ||
+			    ((afi == AFI_IP6) && (rn->p.prefixlen != 128)))
+				return 0;
 
 		/* Pick up selected route. */
 		/* However, do not resolve over default route unless explicitly

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -376,7 +376,6 @@ static int zebra_rnh_apply_nht_rmap(int family, struct route_node *prn,
 static
 struct route_entry *zebra_rnh_resolve_import_entry(vrf_id_t vrfid,
 						   int family,
-						   rnh_type_t type,
 						   struct route_node *nrn,
 						   struct rnh *rnh,
 						   struct route_node **prn)
@@ -398,12 +397,8 @@ struct route_entry *zebra_rnh_resolve_import_entry(vrf_id_t vrfid,
 	/* Unlock route node - we don't need to lock when walking the tree. */
 	route_unlock_node(rn);
 
-	/* When resolving nexthops, do not resolve via the default route unless
-	 * 'ip nht resolve-via-default' is configured.
-	 */
-	if (((is_default_prefix(&rn->p)) ||
-	     ((CHECK_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH)) &&
-	     !prefix_same(&nrn->p, &rn->p))))
+	if (CHECK_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH) &&
+	     !prefix_same(&nrn->p, &rn->p))
 		return NULL;
 
 	/* Identify appropriate route entry. */
@@ -784,7 +779,7 @@ static void zebra_rnh_evaluate_entry(vrf_id_t vrfid, int family, int force,
 
 	/* Identify route entry (RE) resolving this tracked entry. */
 	if (type == RNH_IMPORT_CHECK_TYPE)
-		re = zebra_rnh_resolve_import_entry(vrfid, family, type, nrn,
+		re = zebra_rnh_resolve_import_entry(vrfid, family, nrn,
 						    rnh, &prn);
 	else
 		re = zebra_rnh_resolve_nexthop_entry(vrfid, family, nrn, rnh,
@@ -825,7 +820,7 @@ static void zebra_rnh_clear_nhc_flag(vrf_id_t vrfid, int family,
 
 	/* Identify route entry (RIB) resolving this tracked entry. */
 	if (type == RNH_IMPORT_CHECK_TYPE)
-		re = zebra_rnh_resolve_import_entry(vrfid, family, type, nrn,
+		re = zebra_rnh_resolve_import_entry(vrfid, family, nrn,
 						    rnh, &prn);
 	else
 		re = zebra_rnh_resolve_nexthop_entry(vrfid, family, nrn, rnh,


### PR DESCRIPTION
Problems reported with zebra nht oscillating when a nexthop is resolved
using the same address to reach the  nexthop (for example, 10.0.0.8 is
resolved via 10.0.0.8/32.)  This fix removes this attempt to resolve
thru itself unless the route being resolved is also a host route.
This fix also walks up the tree looking for a less specific route to
reach the nexthop if needed.  Smoke testing completed successfully.

Ticket: CM-8192
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Reviewed-by: CCR-6583
Testing done: Manual testing successful, bgp-min completed successfully
l3-smoke completed with two test changes required.