### PR TITLE
*: commit message example formatting

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -227,9 +227,11 @@ merged in a timely manner.
 Commit messages should be formatted in the same way as Linux kernel commit
 messages. The format is roughly
 
-``` dir: short summary
+```
+dir: short summary
 
-extended summary ```
+extended summary
+```
 
 `dir` should be the top level source directory under which the change was made.
 For example, a change in bgpd/rfapi would be formatted as:


### PR DESCRIPTION
Having triple backquotes on the same line as code block
does not agree with Markdown parser of the repo hosting
site.

Signed-off-by: Mladen Sablic <mladen.sablic@gmail.com>