### PR TITLE
bgpd: XMALLOC usage causes borken assumption in route_match_peer_free

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -299,7 +299,7 @@ static void *route_match_peer_compile(const char *arg)
 	struct bgp_match_peer_compiled *pc;
 	int ret;
 
-	pc = XMALLOC(MTYPE_ROUTE_MAP_COMPILED,
+	pc = XCALLOC(MTYPE_ROUTE_MAP_COMPILED,
 		     sizeof(struct bgp_match_peer_compiled));
 
 	ret = str2sockunion(strcmp(arg, "local") ? arg : "0.0.0.0", &pc->su);


### PR DESCRIPTION
The usage of XMALLOC for route_match_peer_compile causes
the pc->interface to be non-NULL.  The code assumes that
pc->interface will be NULL.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>