### PR TITLE
*: repaired internal link to dev guide

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -82,7 +82,7 @@ for the release notes.
 
 ### Pre-submission Checklist
 
-* Format code (see [Coding style requirements](#coding-style-requirements))
+* Format code (see [Developer's Guidelines](#developers-guidelines))
 * Verify and acknowledge license (see [License for contributions](#license-for-contributions))
 * Ensure you have properly signed off (see [Signing Off](#signing-off))
 * Test building with various configurations:


### PR DESCRIPTION
During renaming and expansion of Coding style
requirements, internal document link, from the
checklist, became unattached.

Signed-off-by: Mladen Sablic <mladen.sablic@gmail.com>