### PR TITLE
zebra: Fix bug adding PW

### DIFF
--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -132,6 +132,7 @@ void zebra_pw_change(struct zebra_pw *pw, ifindex_t ifindex, int type, int af,
 struct zebra_pw *zebra_pw_find(struct zebra_vrf *zvrf, const char *ifname)
 {
 	struct zebra_pw pw;
+	memset (&pw, 0, sizeof(struct zebra_pw));
 	strlcpy(pw.ifname, ifname, sizeof(pw.ifname));
 	return (RB_FIND(zebra_pw_head, &zvrf->pseudowires, &pw));
 }


### PR DESCRIPTION
Trying to find a PW, comparison was sometimes failing due to an
uninitialized structure.

Signed-off-by: ßingen <bingen@voltanet.io>