### PR TITLE
Southbound flags

### DIFF
--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -30,6 +30,17 @@
 #include "zebra/zebra_ns.h"
 #include "zebra/zebra_mpls.h"
 
+/*
+ * Philosophy Note:
+ *
+ * Flags being SET/UNSET do not belong in the South Bound
+ * Interface.  This Setting belongs at the calling level
+ * because we can and will have multiple different interfaces
+ * and we will have potentially multiple different
+ * modules/filters to call.  As such Setting/Unsetting
+ * success failure should be handled by the caller.
+ */
+
 extern int kernel_route_rib(struct prefix *, struct prefix *,
 			    struct route_entry *, struct route_entry *);
 

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -201,9 +201,6 @@ static int kernel_rtm_ipv4(int cmd, struct prefix *p, struct route_entry *re)
 					zlog_debug(
 						"%s: %s: successfully did NH %s",
 						__func__, prefix_buf, gate_buf);
-				if (cmd == RTM_ADD)
-					SET_FLAG(nexthop->flags,
-						 NEXTHOP_FLAG_FIB);
 				break;
 
 			/* The only valid case for this error is kernel's
@@ -315,11 +312,7 @@ static int kernel_rtm_ipv6(int cmd, struct prefix *p, struct route_entry *re)
 
 		if ((cmd == RTM_ADD
 		     && NEXTHOP_IS_ACTIVE(nexthop->flags))
-		    || (cmd == RTM_DELETE
-#if 0
-	      && CHECK_FLAG (nexthop->flags, NEXTHOP_FLAG_FIB)
-#endif
-			)) {
+		    || (cmd == RTM_DELETE)) {
 			if (nexthop->type == NEXTHOP_TYPE_IPV6
 			    || nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX) {
 				sin_gate.sin6_addr = nexthop->gate.ipv6;
@@ -331,9 +324,6 @@ static int kernel_rtm_ipv6(int cmd, struct prefix *p, struct route_entry *re)
 
 			if (nexthop->type == NEXTHOP_TYPE_BLACKHOLE)
 				bh_type = nexthop->bh_type;
-
-			if (cmd == RTM_ADD)
-				SET_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB);
 		}
 
 /* Under kame set interface index to link local address. */
@@ -371,16 +361,7 @@ static int kernel_rtm_ipv6(int cmd, struct prefix *p, struct route_entry *re)
 				  (union sockunion *)mask,
 				  gate ? (union sockunion *)&sin_gate : NULL,
 				  smplsp, ifindex, bh_type, re->metric);
-
-#if 0
-      if (error)
-	{
-	  zlog_info ("kernel_rtm_ipv6(): nexthop %d add error=%d.",
-	    nexthop_num, error);
-	}
-#else
 		(void)error;
-#endif
 
 		nexthop_num++;
 	}

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -909,32 +909,38 @@ static wq_item_status lsp_process(struct work_queue *wq, void *data)
 
 			if (!ret)
 				SET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
+			else
+				clear_nhlfe_installed(lsp);
 
 			zvrf->lsp_installs++;
 		}
 	} else {
 		/* Installed, may need an update and/or delete. */
 		if (!newbest) {
+
 			ret = kernel_del_lsp(lsp);
 
-			if (!ret)
+			if (!ret) {
 				UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
+				clear_nhlfe_installed(lsp);
+			}
+
 			zvrf->lsp_removals++;
 		} else if (CHECK_FLAG(lsp->flags, LSP_FLAG_CHANGED)) {
 
 			UNSET_FLAG(lsp->flags, LSP_FLAG_CHANGED);
 			UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
+
 			ret = kernel_upd_lsp(lsp);
 
 			if (!ret)
 				SET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
+			else
+				clear_nhlfe_installed(lsp);
 
 			zvrf->lsp_installs++;
 		}
 	}
-
-	if (!ret)
-		clear_nhlfe_installed(lsp);
 
 	return WQ_SUCCESS;
 }

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -846,8 +846,10 @@ static void lsp_uninstall_from_kernel(struct hash_backet *backet, void *ctxt)
 	if (CHECK_FLAG(lsp->flags, LSP_FLAG_INSTALLED)) {
 		ret = kernel_del_lsp(lsp);
 
-		if (!ret)
+		if (!ret) {
+			UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
 			clear_nhlfe_installed(lsp);
+		}
 	}
 }
 
@@ -901,16 +903,32 @@ static wq_item_status lsp_process(struct work_queue *wq, void *data)
 	if (!CHECK_FLAG(lsp->flags, LSP_FLAG_INSTALLED)) {
 		/* Not already installed */
 		if (newbest) {
+
+			UNSET_FLAG(lsp->flags, LSP_FLAG_CHANGED);
 			ret = kernel_add_lsp(lsp);
+
+			if (!ret)
+				SET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
+
 			zvrf->lsp_installs++;
 		}
 	} else {
 		/* Installed, may need an update and/or delete. */
 		if (!newbest) {
 			ret = kernel_del_lsp(lsp);
+
+			if (!ret)
+				UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
 			zvrf->lsp_removals++;
 		} else if (CHECK_FLAG(lsp->flags, LSP_FLAG_CHANGED)) {
+
+			UNSET_FLAG(lsp->flags, LSP_FLAG_CHANGED);
+			UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
 			ret = kernel_upd_lsp(lsp);
+
+			if (!ret)
+				SET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
+
 			zvrf->lsp_installs++;
 		}
 	}

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -299,10 +299,7 @@ int kernel_add_lsp(zebra_lsp_t *lsp)
 	if (!lsp || !lsp->best_nhlfe) // unexpected
 		return -1;
 
-	UNSET_FLAG(lsp->flags, LSP_FLAG_CHANGED);
 	ret = kernel_lsp_cmd(RTM_ADD, lsp);
-	if (!ret)
-		SET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
 
 	return ret;
 }
@@ -314,11 +311,7 @@ int kernel_upd_lsp(zebra_lsp_t *lsp)
 	if (!lsp || !lsp->best_nhlfe) // unexpected
 		return -1;
 
-	UNSET_FLAG(lsp->flags, LSP_FLAG_CHANGED);
-	UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
 	ret = kernel_lsp_cmd(RTM_CHANGE, lsp);
-	if (!ret)
-		SET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
 
 	return ret;
 }
@@ -334,8 +327,6 @@ int kernel_del_lsp(zebra_lsp_t *lsp)
 		return -1;
 
 	ret = kernel_lsp_cmd(RTM_DELETE, lsp);
-	if (!ret)
-		UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
 
 	return ret;
 }


### PR DESCRIPTION
Some needed rework and a bad bug fix.

1) Start cleanup of SET/UNSET flags from southbound interface such that the southbound interface is not in charge of setting flags.

2) Adding a mpls lsp successfully would cause it to not be thought to be installed.  As such when it was removed zebra would think it does not need to do anything and it would not be removed from the kernel