### PR TITLE
Json Stuff

### DIFF
--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -92,6 +92,7 @@ extern struct aspath *aspath_delete_confed_seq(struct aspath *);
 extern struct aspath *aspath_empty(void);
 extern struct aspath *aspath_empty_get(void);
 extern struct aspath *aspath_str2aspath(const char *);
+extern void aspath_str_update(struct aspath *as, bool make_json);
 extern void aspath_free(struct aspath *);
 extern struct aspath *aspath_intern(struct aspath *);
 extern void aspath_unintern(struct aspath **);

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -438,7 +438,7 @@ static int community_regexp_match(struct community *com, regex_t *reg)
 	if (com == NULL || com->size == 0)
 		str = "";
 	else
-		str = community_str(com);
+		str = community_str(com, false);
 
 	/* Regular expression match.  */
 	if (regexec(reg, str, 0, NULL, 0) == 0)

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -169,7 +169,6 @@ struct community *community_uniq_sort(struct community *com)
 		return NULL;
 
 	new = community_new();
-	;
 	new->json = NULL;
 
 	for (i = 0; i < com->size; i++) {
@@ -195,7 +194,7 @@ struct community *community_uniq_sort(struct community *com)
    0xFFFF0000      "graceful-shutdown"
 
    For other values, "AS:VAL" format is used.  */
-static void set_community_string(struct community *com)
+static void set_community_string(struct community *com, bool make_json)
 {
 	int i;
 	char *str;
@@ -211,16 +210,20 @@ static void set_community_string(struct community *com)
 	if (!com)
 		return;
 
-	com->json = json_object_new_object();
-	json_community_list = json_object_new_array();
+	if (make_json) {
+		com->json = json_object_new_object();
+		json_community_list = json_object_new_array();
+	}
 
 	/* When communities attribute is empty.  */
 	if (com->size == 0) {
 		str = XMALLOC(MTYPE_COMMUNITY_STR, 1);
 		str[0] = '\0';
 
-		json_object_string_add(com->json, "string", "");
-		json_object_object_add(com->json, "list", json_community_list);
+		if (make_json) {
+			json_object_string_add(com->json, "string", "");
+			json_object_object_add(com->json, "list", json_community_list);
+		}
 		com->str = str;
 		return;
 	}
@@ -273,47 +276,61 @@ static void set_community_string(struct community *com)
 		case COMMUNITY_INTERNET:
 			strcpy(pnt, "internet");
 			pnt += strlen("internet");
-			json_string = json_object_new_string("internet");
-			json_object_array_add(json_community_list, json_string);
+			if (make_json) {
+				json_string = json_object_new_string("internet");
+				json_object_array_add(json_community_list, json_string);
+			}
 			break;
 		case COMMUNITY_NO_EXPORT:
 			strcpy(pnt, "no-export");
 			pnt += strlen("no-export");
-			json_string = json_object_new_string("noExport");
-			json_object_array_add(json_community_list, json_string);
+			if (make_json) {
+				json_string = json_object_new_string("noExport");
+				json_object_array_add(json_community_list, json_string);
+			}
 			break;
 		case COMMUNITY_NO_ADVERTISE:
 			strcpy(pnt, "no-advertise");
 			pnt += strlen("no-advertise");
-			json_string = json_object_new_string("noAdvertise");
-			json_object_array_add(json_community_list, json_string);
+			if (make_json) {
+				json_string = json_object_new_string("noAdvertise");
+				json_object_array_add(json_community_list, json_string);
+			}
 			break;
 		case COMMUNITY_LOCAL_AS:
 			strcpy(pnt, "local-AS");
 			pnt += strlen("local-AS");
-			json_string = json_object_new_string("localAs");
-			json_object_array_add(json_community_list, json_string);
+			if (make_json) {
+				json_string = json_object_new_string("localAs");
+				json_object_array_add(json_community_list, json_string);
+			}
 			break;
 		case COMMUNITY_GSHUT:
 			strcpy(pnt, "graceful-shutdown");
 			pnt += strlen("graceful-shutdown");
-			json_string = json_object_new_string("gracefulShutdown");
-			json_object_array_add(json_community_list, json_string);
+			if (make_json) {
+				json_string = json_object_new_string("gracefulShutdown");
+				json_object_array_add(json_community_list, json_string);
+			}
 			break;
 		default:
 			as = (comval >> 16) & 0xFFFF;
 			val = comval & 0xFFFF;
 			sprintf(pnt, "%u:%d", as, val);
-			json_string = json_object_new_string(pnt);
-			json_object_array_add(json_community_list, json_string);
+			if (make_json) {
+				json_string = json_object_new_string(pnt);
+				json_object_array_add(json_community_list, json_string);
+			}
 			pnt += strlen(pnt);
 			break;
 		}
 	}
 	*pnt = '\0';
 
-	json_object_string_add(com->json, "string", str);
-	json_object_object_add(com->json, "list", json_community_list);
+	if (make_json) {
+		json_object_string_add(com->json, "string", str);
+		json_object_object_add(com->json, "list", json_community_list);
+	}
 	com->str = str;
 }
 
@@ -338,7 +355,7 @@ struct community *community_intern(struct community *com)
 
 	/* Make string.  */
 	if (!find->str)
-		set_community_string(find);
+		set_community_string(find, false);
 
 	return find;
 }
@@ -396,13 +413,16 @@ struct community *community_dup(struct community *com)
 }
 
 /* Retrun string representation of communities attribute. */
-char *community_str(struct community *com)
+char *community_str(struct community *com, bool make_json)
 {
 	if (!com)
 		return NULL;
 
+	if (make_json && !com->json && com->str)
+		XFREE(MTYPE_COMMUNITY_STR, com->str);
+
 	if (!com->str)
-		set_community_string(com);
+		set_community_string(com, make_json);
 	return com->str;
 }
 

--- a/bgpd/bgp_community.h
+++ b/bgpd/bgp_community.h
@@ -63,7 +63,7 @@ extern struct community *community_uniq_sort(struct community *);
 extern struct community *community_parse(u_int32_t *, u_short);
 extern struct community *community_intern(struct community *);
 extern void community_unintern(struct community **);
-extern char *community_str(struct community *);
+extern char *community_str(struct community *, bool make_json);
 extern unsigned int community_hash_make(struct community *);
 extern struct community *community_str2com(const char *);
 extern int community_match(const struct community *, const struct community *);

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -385,7 +385,8 @@ int bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES)))
 		snprintf(buf + strlen(buf), size - strlen(buf),
-			 ", community %s", community_str(attr->community));
+			 ", community %s", community_str(attr->community,
+							 false));
 
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES)))
 		snprintf(buf + strlen(buf), size - strlen(buf),

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7395,6 +7395,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 		/* Line1 display AS-path, Aggregator */
 		if (attr->aspath) {
 			if (json_paths) {
+				if (!attr->aspath->json)
+					aspath_str_update(attr->aspath, true);
 				json_object_lock(attr->aspath->json);
 				json_object_object_add(json_path, "aspath",
 						       attr->aspath->json);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8187,8 +8187,6 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 			continue;
 
 		display = 0;
-		if (!first && use_json)
-			vty_out(vty, ",");
 		if (use_json)
 			json_paths = json_object_new_array();
 		else
@@ -8384,7 +8382,11 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				inet_ntop(p->family, &p->u.prefix,
 					  buf, BUFSIZ),
 				p->prefixlen);
-			vty_out(vty, "\"%s\": ", buf2);
+			if (first)
+				vty_out(vty, "\"%s\": ", buf2);
+			else
+				vty_out(vty, ",\"%s\": ", buf2);
+
 			vty_out(vty, "%s",
 				json_object_to_json_string_ext(json_paths, JSON_C_TO_STRING_PRETTY));
 			json_object_free(json_paths);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7885,6 +7885,9 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 		/* Line 4 display Community */
 		if (attr->community) {
 			if (json_paths) {
+				if (!attr->community->json)
+					community_str(attr->community,
+						      true);
 				json_object_lock(attr->community->json);
 				json_object_object_add(json_path, "community",
 						       attr->community->json);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3813,7 +3813,7 @@ DEFUN (set_community,
 	}
 
 	/* Set communites attribute string.  */
-	str = community_str(com);
+	str = community_str(com, false);
 
 	if (additive) {
 		argstr = XCALLOC(MTYPE_TMP,

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10010,7 +10010,7 @@ static void community_show_all_iterator(struct hash_backet *backet,
 
 	com = (struct community *)backet->data;
 	vty_out(vty, "[%p] (%ld) %s\n", (void *)com, com->refcnt,
-		community_str(com));
+		community_str(com, false));
 }
 
 /* Show BGP's community internal data. */
@@ -12698,7 +12698,7 @@ static void community_list_show(struct vty *vty, struct community_list *list)
 			vty_out(vty, "    %s %s\n",
 				community_direct_str(entry->direct),
 				entry->style == COMMUNITY_LIST_STANDARD
-					? community_str(entry->u.com)
+					? community_str(entry->u.com, false)
 					: entry->config);
 	}
 }
@@ -13354,7 +13354,7 @@ static const char *community_list_config_str(struct community_entry *entry)
 		str = "";
 	else {
 		if (entry->style == COMMUNITY_LIST_STANDARD)
-			str = community_str(entry->u.com);
+			str = community_str(entry->u.com, false);
 		else
 			str = entry->config;
 	}


### PR DESCRIPTION
So both the aspath and community information we were storing json information for as soon as we created them.  Upon some investigation this functionality has these issues not going for it:
1) Memory usage ( A full bgp feed of aspath json information adds 300mb of memory usage!!!!)
2) Creation of the json object is incredibly slow and clearly shows up on a perf graph of the initial convergence

So Modify the code to not create the json object until it is actually needed, and if it is created store it for the next time we run the cli command again.

I believe these code changes will significantly reduce memory usage for large bgp feeds and also reduce convergence times.