### PR TITLE
ospf6d: SPF consider all Router LSAs

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -61,8 +61,8 @@ static void ospf6_area_lsdb_hook_add(struct ospf6_lsa *lsa)
 	case OSPF6_LSTYPE_ROUTER:
 	case OSPF6_LSTYPE_NETWORK:
 		if (IS_OSPF6_DEBUG_EXAMIN_TYPE(lsa->header->type)) {
-			zlog_debug("Examin %s", lsa->name);
-			zlog_debug("Schedule SPF Calculation for %s",
+			zlog_debug("%s Examin LSA %s", __PRETTY_FUNCTION__, lsa->name);
+			zlog_debug(" Schedule SPF Calculation for %s",
 				   OSPF6_AREA(lsa->lsdb->data)->name);
 		}
 		ospf6_spf_schedule(

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1316,7 +1316,7 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 		return;
 
 	if (IS_OSPF6_DEBUG_EXAMIN(INTRA_PREFIX))
-		zlog_debug("%s found", lsa->name);
+		zlog_debug("%s: LSA %s found", __PRETTY_FUNCTION__, lsa->name);
 
 	oa = OSPF6_AREA(lsa->lsdb->data);
 
@@ -1325,7 +1325,7 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 			lsa->header);
 	if (intra_prefix_lsa->ref_type == htons(OSPF6_LSTYPE_ROUTER))
 		ospf6_linkstate_prefix(intra_prefix_lsa->ref_adv_router,
-				       htonl(0), &ls_prefix);
+				       intra_prefix_lsa->ref_id, &ls_prefix);
 	else if (intra_prefix_lsa->ref_type == htons(OSPF6_LSTYPE_NETWORK))
 		ospf6_linkstate_prefix(intra_prefix_lsa->ref_adv_router,
 				       intra_prefix_lsa->ref_id, &ls_prefix);
@@ -1404,7 +1404,7 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 
 		if (IS_OSPF6_DEBUG_EXAMIN(INTRA_PREFIX)) {
 			prefix2str(&route->prefix, buf, sizeof(buf));
-			zlog_debug("  add %s", buf);
+			zlog_debug("  route %s add", buf);
 		}
 
 		ospf6_route_add(route, oa->route_table);

--- a/ospf6d/ospf6_spf.h
+++ b/ospf6d/ospf6_spf.h
@@ -68,6 +68,7 @@ struct ospf6_vertex {
 
 	/* nexthops to this node */
 	struct list *nh_list;
+	uint32_t link_id;
 };
 
 #define OSPF6_VERTEX_TYPE_ROUTER  0x01


### PR DESCRIPTION
Based on RFC-5340, there could be multiple Router LSAs
associated with Same Advertising Router. During SPF calculation
ensure first Root Vertex accommodates all Link state IDs for its
originated Router LSAs push them into priority queue.
Similarly follow for other Vertexes, considering Router LSAs
with multiple Link State IDs.

Ticket: CM-18069
Testing Done:
Topology: R1 === R2 -- R3

Validated with more than 100 Subinterfaces
between R1 === R2 with broadcast links,
Validated show ipv6 ospf6 spf tree containing all graph nodes.
Validated ip -6 route at R3 and all intra prefix LSAs route
installed with ospf6 as protocol.

2) Run R1 === R2 with Point-to-Point links.

3) Perform few other abr and ospf6 test cases of LSA ageout,
route install and delete cases.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>