### PR TITLE
debianpkg: Suppress frr-dbg debug-file-with-no-debug-symbols warning

### DIFF
--- a/debianpkg/frr-dbg.lintian-overrides
+++ b/debianpkg/frr-dbg.lintian-overrides
@@ -1,0 +1,1 @@
+frr-dbg: debug-file-with-no-debug-symbols usr/lib/debug/usr/lib/libfrrfpm_pb.so.0.0.0


### PR DESCRIPTION
Somehow missed this warning on the previous debian pkg PR for master.
This commit suppresses the warning as it is only happening with older lintian versions (ie on Ubuntu 14.04, but not 16.04 and Debian 8, but not Debian 9)

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>