### PR TITLE
ospfd: Make external routes in ospf VRF aware

### DIFF
--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -58,12 +58,15 @@ extern struct external_info *ospf_external_info_new(u_char, u_short);
 extern void ospf_reset_route_map_set_values(struct route_map_set_values *);
 extern int ospf_route_map_set_compare(struct route_map_set_values *,
 				      struct route_map_set_values *);
-extern struct external_info *ospf_external_info_add(u_char, u_short,
+extern struct external_info *ospf_external_info_add(struct ospf *,
+						    u_char, u_short,
 						    struct prefix_ipv4,
 						    ifindex_t, struct in_addr,
 						    route_tag_t);
-extern void ospf_external_info_delete(u_char, u_short, struct prefix_ipv4);
-extern struct external_info *ospf_external_info_lookup(u_char, u_short,
+extern void ospf_external_info_delete(struct ospf*, u_char, u_short,
+				      struct prefix_ipv4);
+extern struct external_info *ospf_external_info_lookup(struct ospf*, u_char,
+						       u_short,
 						       struct prefix_ipv4 *);
 extern struct ospf_route *ospf_external_route_lookup(struct ospf *,
 						     struct prefix_ipv4 *);

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -108,7 +108,7 @@ struct external_info *ospf_external_info_check(struct ospf *ospf,
 			struct listnode *node;
 			struct ospf_external *ext;
 
-			ext_list = om->external[type];
+			ext_list = ospf->external[type];
 			if (!ext_list)
 				continue;
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8361,10 +8361,10 @@ DEFUN (no_ospf_default_information_originate,
 
 	ospf_external_lsa_flush(ospf, DEFAULT_ROUTE, &p, 0);
 
-	if ((ext = ospf_external_lookup(DEFAULT_ROUTE, 0))
-	    && EXTERNAL_INFO(ext)) {
-		ospf_external_info_delete(DEFAULT_ROUTE, 0, p);
-		ospf_external_del(DEFAULT_ROUTE, 0);
+	ext = ospf_external_lookup(ospf, DEFAULT_ROUTE, 0);
+	if (ext && EXTERNAL_INFO(ext)) {
+		ospf_external_info_delete(ospf, DEFAULT_ROUTE, 0, p);
+		ospf_external_del(ospf, DEFAULT_ROUTE, 0);
 	}
 
 	red = ospf_redist_lookup(ospf, DEFAULT_ROUTE, 0);

--- a/ospfd/ospf_zebra.h
+++ b/ospfd/ospf_zebra.h
@@ -59,9 +59,10 @@ extern int ospf_is_type_redistributed(struct ospf *, int, u_short);
 extern void ospf_distance_reset(struct ospf *);
 extern u_char ospf_distance_apply(struct ospf *ospf, struct prefix_ipv4 *,
 				  struct ospf_route *);
-extern struct ospf_external *ospf_external_lookup(u_char, u_short);
-extern struct ospf_external *ospf_external_add(u_char, u_short);
-extern void ospf_external_del(u_char, u_short);
+extern struct ospf_external *ospf_external_lookup(struct ospf*, u_char,
+						  u_short);
+extern struct ospf_external *ospf_external_add(struct ospf*, u_char, u_short);
+extern void ospf_external_del(struct ospf *, u_char, u_short);
 extern struct ospf_redist *ospf_redist_lookup(struct ospf *, u_char, u_short);
 extern struct ospf_redist *ospf_redist_add(struct ospf *, u_char, u_short);
 extern void ospf_redist_del(struct ospf *, u_char, u_short);

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -93,11 +93,6 @@ struct ospf_master {
 	/* OSPF thread master. */
 	struct thread_master *master;
 
-
-	/* Redistributed external information. */
-	struct list *external[ZEBRA_ROUTE_MAX + 1];
-#define EXTERNAL_INFO(E)      (E->external_info)
-
 	/* Various OSPF global configuration. */
 	u_char options;
 #define OSPF_MASTER_SHUTDOWN (1 << 0) /* deferred-shutdown */
@@ -313,6 +308,10 @@ struct ospf {
 	/* Used during ospf instance going down send LSDB
 	 * update to neighbors immediatly */
 	uint8_t inst_shutdown;
+
+	/* Redistributed external information. */
+	struct list *external[ZEBRA_ROUTE_MAX + 1];
+#define EXTERNAL_INFO(E)      (E->external_info)
 
 	QOBJ_FIELDS
 };


### PR DESCRIPTION

    ospfd: Make external routes in ospf VRF aware

Currently, ospf external routers are part of struct ospf_master which is not VRF aware ospf instance.
    All ospf external routes are injected/leaked into all VRFs.
   Moved ospf external routes db to struct ospf to make VRF aware, such one external routes learn in one
   VRF is not leaked into another VRF.

    Ticket:CM-18855
    Testing Done:
    Inject external route in non-default VRF x, validated
    ospf database across the VRF x, validated ospf routes
    for VRF x.
