### PR TITLE
ospfd: Forward reference ospf area config

### DIFF
--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -305,7 +305,9 @@ struct ospf {
 	/* Statistics for LSA used for new instantiation. */
 	u_int32_t rx_lsa_count;
 
-	/* Counter of "ip ospf area x.x.x.x" */
+	/* Counter of "ip ospf area x.x.x.x" used
+	 * for multual exclusion of network command under
+	 * router ospf or ip ospf area x under interface. */
 	u_int32_t if_ospf_cli_count;
 
 	struct route_table *distance_table;


### PR DESCRIPTION
Upon restart frr interface configuration applied prior to 'router ospf' configuration.
 'ip ospf area x' config fails if ospf instance is not active.

Allow 'ip ospf area x' configuration to allow in absence of ospf instance. Upon 'router ospf' 
walk through VRF aware interfaces, active area configurations.
When VRF is enabled, router-id update also walk through VRF aware interfaces to enable 
area configuration via network_run_interface.

Ticket: CM-18927
Reviewed By:
Testing Done:
Configured multiple interfaces with 'ip ospf area x'
with multiple areas/interface combinations.
Upon router ospf enable along with VRF is active,
interfaces comes up in respective area, ospf neighborship
comes up fine.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>