### PR TITLE
ospfd:  Running-config display ospf (non active) vrf config, OSPF Route json support

### DIFF
--- a/lib/json.h
+++ b/lib/json.h
@@ -52,4 +52,19 @@ extern void json_object_free(struct json_object *obj);
 
 #define JSON_STR "JavaScript Object Notation\n"
 
+/* NOTE: json-c lib has following commit 316da85 which
+ * handles escape of forward slash.
+ * This allows prefix  "20.0.14.0\/24":{
+ * to  "20.0.14.0/24":{ some platforms do not have
+ * latest copy of json-c where defining below macro.
+ */
+
+#ifndef JSON_C_TO_STRING_NOSLASHESCAPE
+
+/**
+  * Don't escape forward slashes.
+  */
+#define JSON_C_TO_STRING_NOSLASHESCAPE (1<<4)
+#endif
+
 #endif /* _QUAGGA_JSON_H */

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10061,7 +10061,14 @@ static int ospf_config_write(struct vty *vty)
 		return write;
 
 	for (ALL_LIST_ELEMENTS_RO(om->ospf, ospf_node, ospf)) {
-		if (ospf->oi_running)
+		/* VRF Default check if it is running.
+		 * Upon daemon start, there could be default instance
+		 * in absence of 'router ospf'/oi_running is disabled. */
+		if (ospf->vrf_id == VRF_DEFAULT && ospf->oi_running)
+			write += ospf_config_write_one(vty, ospf);
+		/* For Non-Default VRF simply display the configuration,
+		 * even if it is not oi_running. */
+		else if (ospf->vrf_id != VRF_DEFAULT)
 			write += ospf_config_write_one(vty, ospf);
 	}
 	return write;


### PR DESCRIPTION
 1)   ospfd: show ip ospf route json support
    Define JSON_C_TO_STRING_NOSLASHESCAPE used for escaping forward slash.

    Disply json output for  'show ip ospf route [vrf all] json'

2)  ospfd: Running config to display VRF aware OSPF

    show running-config to display VRF aware ospf instances
    even if VRF is not active. This will allow the user to
    configured ospf instances configurations even if VRF is not
    active. 'show ip ospf vrf all' does not display until VRF
    is active.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>