### PR TITLE
ospfd: Display NSSA in show running-config

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1541,7 +1541,7 @@ DEFUN (ospf_area_nssa,
        "OSPF area ID as a decimal value\n"
        "Configure OSPF area as nssa\n")
 {
-	return ospf_area_nssa_cmd_handler(vty, argc, argv, 1, 0);
+	return ospf_area_nssa_cmd_handler(vty, argc, argv, 0, 0);
 }
 
 DEFUN (ospf_area_nssa_no_summary,
@@ -9632,6 +9632,9 @@ static int config_write_ospf_area(struct vty *vty, struct ospf *ospf)
 					vty_out(vty,
 						" area %s nssa translate-always\n",
 						buf);
+					break;
+				case OSPF_NSSA_ROLE_CANDIDATE:
+					vty_out(vty, " area %s nssa \n", buf);
 					break;
 				}
 				if (area->no_summary)


### PR DESCRIPTION
Display area x.x.x.x nssa configuration in
running-config. Using nssa translate candiate (default)
case to display 'area x nssa'.

Ticket:CM-18947
Reviewed By:
Testing Done:
Tried various combinations of nssa config,
verified show running-config ospfd output

router ospf
 area 2.2.2.2 nssa
  area 2.2.2.2 nssa no-summary

router ospf
 area 2.2.2.2 nssa translate-always
  area 2.2.2.2 nssa no-summary

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>