### PR TITLE
lib: Fix prefix-list where le is == prefixlen

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -933,7 +933,7 @@ static int vty_prefix_list_install(struct vty *vty, afi_t afi, const char *name,
 	if (genum && (genum <= p.prefixlen))
 		return vty_invalid_prefix_range(vty, prefix);
 
-	if (lenum && (lenum <= p.prefixlen))
+	if (lenum && (lenum < p.prefixlen))
 		return vty_invalid_prefix_range(vty, prefix);
 
 	if (lenum && (genum > lenum))


### PR DESCRIPTION
This should be allowed:

robot(config)# ip prefix-list outbound_asp_routes seq 33 permit 1.1.1.0/24 le 24
% Invalid prefix range for 1.1.1.0/24, make sure: len < ge-value <= le-value

This commit fixes the issue:

robot(config)# ip prefix-list outbound_asp_routes seq 33 permit 1.1.1.0/24 le 23
% Invalid prefix range for 1.1.1.0/24, make sure: len < ge-value <= le-value
robot(config)# ip prefix-list outbound_asp_routes seq 33 permit 1.1.1.0/24 le 24
robot(config)# ip prefix-list outbound_asp_routes seq 33 permit 1.1.1.0/24 le 25
robot(config)#

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>