### PR TITLE
Additional Southbound API changes

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -285,9 +285,9 @@ extern int zebra_check_addr(struct prefix *p);
 extern void rib_addnode(struct route_node *rn, struct route_entry *re,
 			int process);
 extern void rib_delnode(struct route_node *rn, struct route_entry *re);
-extern int rib_install_kernel(struct route_node *rn, struct route_entry *re,
-			      struct route_entry *old);
-extern int rib_uninstall_kernel(struct route_node *rn, struct route_entry *re);
+extern void rib_install_kernel(struct route_node *rn, struct route_entry *re,
+			       struct route_entry *old);
+extern void rib_uninstall_kernel(struct route_node *rn, struct route_entry *re);
 
 /* NOTE:
  * All rib_add function will not just add prefix into RIB, but

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -41,8 +41,36 @@
  * success failure should be handled by the caller.
  */
 
-extern int kernel_route_rib(struct prefix *, struct prefix *,
-			    struct route_entry *, struct route_entry *);
+
+enum southbound_results {
+	SOUTHBOUND_INSTALL_SUCCESS,
+	SOUTHBOUND_INSTALL_FAILURE,
+	SOUTHBOUND_DELETE_SUCCESS,
+	SOUTHBOUND_DELETE_FAILURE,
+};
+
+/*
+ * Install/delete the specified prefix p from the kernel
+ *
+ * old = NULL, new = pointer - Install new
+ * old = pointer, new = pointer - Route replace Old w/ New
+ * old = pointer, new = NULL, - Route Delete
+ *
+ * Please note not all kernels support route replace
+ * semantics so we will end up with a delete than
+ * a re-add.
+ */
+extern void kernel_route_rib(struct prefix *p, struct prefix *src_p,
+			     struct route_entry *old, struct route_entry *new);
+
+/*
+ * So route install/failure may not be immediately known
+ * so let's separate it out and allow the result to
+ * be passed back up.
+ */
+extern void kernel_route_rib_pass_fail(struct prefix *p,
+				       struct route_entry *re,
+				       enum southbound_results res);
 
 extern int kernel_address_add_ipv4(struct interface *, struct connected *);
 extern int kernel_address_delete_ipv4(struct interface *, struct connected *);

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -77,9 +77,23 @@ extern int kernel_address_delete_ipv4(struct interface *, struct connected *);
 extern int kernel_neigh_update(int, int, uint32_t, char *, int);
 extern int kernel_interface_set_master(struct interface *master,
 				       struct interface *slave);
-extern int kernel_add_lsp(zebra_lsp_t *);
-extern int kernel_upd_lsp(zebra_lsp_t *);
-extern int kernel_del_lsp(zebra_lsp_t *);
+
+extern void kernel_add_lsp(zebra_lsp_t *lsp);
+extern void kernel_upd_lsp(zebra_lsp_t *lsp);
+extern void kernel_del_lsp(zebra_lsp_t *lsp);
+
+/*
+ * Add the ability to pass back up the lsp install/delete
+ * success/failure.
+ *
+ * This functions goal is similiar to kernel_route_rib_pass_fail
+ * in that we are separating out the mechanics for
+ * the install/failure to set/unset flags and to notify
+ * as needed.
+ */
+extern void kernel_lsp_pass_fail(zebra_lsp_t *lsp,
+				 enum southbound_results res);
+
 extern int mpls_kernel_init(void);
 
 extern int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *mroute);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1598,33 +1598,51 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 	return suc;
 }
 
-int kernel_route_rib(struct prefix *p, struct prefix *src_p,
-		     struct route_entry *old, struct route_entry *new)
+void kernel_route_rib(struct prefix *p, struct prefix *src_p,
+		      struct route_entry *old, struct route_entry *new)
 {
+	int ret = 0;
+
 	assert(old || new);
 
-	if (!old && new)
-		return netlink_route_multipath(RTM_NEWROUTE, p, src_p, new, 0);
-	if (old && !new)
-		return netlink_route_multipath(RTM_DELROUTE, p, src_p, old, 0);
+	if (new) {
+		if (p->family == AF_INET)
+			ret = netlink_route_multipath(RTM_NEWROUTE, p, src_p,
+						      new, (old) ? 1 : 0);
+		else {
+			/*
+			 * So v6 route replace semantics are not in
+			 * the kernel at this point as I understand it.
+			 * So let's do a delete than an add.
+			 * In the future once v6 route replace semantics
+			 * are in we can figure out what to do here to
+			 * allow working with old and new kernels.
+			 *
+			 * I'm also intentionally ignoring the failure case
+			 * of the route delete.  If that happens yeah we're
+			 * screwed.
+			 */
+			if (old)
+				netlink_route_multipath(RTM_DELROUTE, p,
+							src_p, old, 0);
+			ret = netlink_route_multipath(RTM_NEWROUTE, p,
+						      src_p, new, 0);
+		}
+		kernel_route_rib_pass_fail(p, new,
+					   (!ret) ?
+					   SOUTHBOUND_INSTALL_SUCCESS :
+					   SOUTHBOUND_INSTALL_FAILURE);
+		return;
+	}
 
-	if (p->family == AF_INET)
-		return netlink_route_multipath(RTM_NEWROUTE, p, src_p, new, 1);
+	if (old) {
+		ret = netlink_route_multipath(RTM_DELROUTE, p, src_p, old, 0);
 
-	/*
-	 * So v6 route replace semantics are not in the kernel at this
-	 * point as I understand it.
-	 * So let's do a delete than an add.
-	 * In the future once v6 route replace semantics are in
-	 * we can figure out what to do here to allow working
-	 * with old and new kernels.
-	 *
-	 * I'm also intentionally ignoring the failure case
-	 * of the route delete.  If that happens yeah we're
-	 * screwed.
-	 */
-	netlink_route_multipath(RTM_DELROUTE, p, src_p, old, 0);
-	return netlink_route_multipath(RTM_NEWROUTE, p, src_p, new, 0);
+		kernel_route_rib_pass_fail(p, old,
+					   (!ret) ?
+					   SOUTHBOUND_DELETE_SUCCESS :
+					   SOUTHBOUND_DELETE_FAILURE);
+	}
 }
 
 int kernel_neigh_update(int add, int ifindex, uint32_t addr, char *lla,

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2432,17 +2432,6 @@ int netlink_mpls_multipath(int cmd, zebra_lsp_t *lsp)
 				_netlink_mpls_build_singlepath(routedesc, nhlfe,
 							       &req.n, &req.r,
 							       sizeof req, cmd);
-				if (cmd == RTM_NEWROUTE) {
-					SET_FLAG(nhlfe->flags,
-						 NHLFE_FLAG_INSTALLED);
-					SET_FLAG(nexthop->flags,
-						 NEXTHOP_FLAG_FIB);
-				} else {
-					UNSET_FLAG(nhlfe->flags,
-						   NHLFE_FLAG_INSTALLED);
-					UNSET_FLAG(nexthop->flags,
-						   NEXTHOP_FLAG_FIB);
-				}
 				nexthop_num++;
 				break;
 			}
@@ -2486,18 +2475,6 @@ int netlink_mpls_multipath(int cmd, zebra_lsp_t *lsp)
 							      rta, rtnh, &req.r,
 							      &src1);
 				rtnh = RTNH_NEXT(rtnh);
-
-				if (cmd == RTM_NEWROUTE) {
-					SET_FLAG(nhlfe->flags,
-						 NHLFE_FLAG_INSTALLED);
-					SET_FLAG(nexthop->flags,
-						 NEXTHOP_FLAG_FIB);
-				} else {
-					UNSET_FLAG(nhlfe->flags,
-						   NHLFE_FLAG_INSTALLED);
-					UNSET_FLAG(nexthop->flags,
-						   NEXTHOP_FLAG_FIB);
-				}
 			}
 		}
 

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -394,7 +394,7 @@ void kernel_route_rib(struct prefix *p, struct prefix *src_p,
 
 	if (src_p && src_p->prefixlen) {
 		zlog_err("route add: IPv6 sourcedest routes unsupported!");
-		return 1;
+		return;
 	}
 
 	if (zserv_privs.change(ZPRIVS_RAISE))
@@ -413,7 +413,7 @@ void kernel_route_rib(struct prefix *p, struct prefix *src_p,
 		kernel_route_rib_pass_fail(p, new,
 					   (!route) ?
 					   SOUTHBOUND_INSTALL_SUCCESS :
-					   SOUTBHOUND_INSTALL_FAILURE);
+					   SOUTHBOUND_INSTALL_FAILURE);
 	} else {
 		kernel_route_rib_pass_fail(p, old,
 					   (!route) ?

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -387,8 +387,8 @@ static int kernel_rtm(int cmd, struct prefix *p, struct route_entry *re)
 	return 0;
 }
 
-int kernel_route_rib(struct prefix *p, struct prefix *src_p,
-		     struct route_entry *old, struct route_entry *new)
+void kernel_route_rib(struct prefix *p, struct prefix *src_p,
+		      struct route_entry *old, struct route_entry *new)
 {
 	int route = 0;
 
@@ -409,7 +409,17 @@ int kernel_route_rib(struct prefix *p, struct prefix *src_p,
 	if (zserv_privs.change(ZPRIVS_LOWER))
 		zlog_err("Can't lower privileges");
 
-	return route;
+	if (new) {
+		kernel_route_rib_pass_fail(p, new,
+					   (!route) ?
+					   SOUTHBOUND_INSTALL_SUCCESS :
+					   SOUTBHOUND_INSTALL_FAILURE);
+	} else {
+		kernel_route_rib_pass_fail(p, old,
+					   (!route) ?
+					   SOUTHBOUND_DELETE_SUCCESS :
+					   SOUTHBOUND_DELETE_FAILURE);
+	}
 }
 
 int kernel_neigh_update(int add, int ifindex, uint32_t addr, char *lla,

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -839,18 +839,11 @@ static void lsp_select_best_nhlfe(zebra_lsp_t *lsp)
  */
 static void lsp_uninstall_from_kernel(struct hash_backet *backet, void *ctxt)
 {
-	int ret;
 	zebra_lsp_t *lsp;
 
 	lsp = (zebra_lsp_t *)backet->data;
-	if (CHECK_FLAG(lsp->flags, LSP_FLAG_INSTALLED)) {
-		ret = kernel_del_lsp(lsp);
-
-		if (!ret) {
-			UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
-			clear_nhlfe_installed(lsp);
-		}
-	}
+	if (CHECK_FLAG(lsp->flags, LSP_FLAG_INSTALLED))
+		kernel_del_lsp(lsp);
 }
 
 /*
@@ -871,7 +864,6 @@ static void lsp_schedule(struct hash_backet *backet, void *ctxt)
  */
 static wq_item_status lsp_process(struct work_queue *wq, void *data)
 {
-	int ret = 1;
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *oldbest, *newbest;
 	char buf[BUFSIZ], buf2[BUFSIZ];
@@ -905,12 +897,7 @@ static wq_item_status lsp_process(struct work_queue *wq, void *data)
 		if (newbest) {
 
 			UNSET_FLAG(lsp->flags, LSP_FLAG_CHANGED);
-			ret = kernel_add_lsp(lsp);
-
-			if (!ret)
-				SET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
-			else
-				clear_nhlfe_installed(lsp);
+			kernel_add_lsp(lsp);
 
 			zvrf->lsp_installs++;
 		}
@@ -918,12 +905,7 @@ static wq_item_status lsp_process(struct work_queue *wq, void *data)
 		/* Installed, may need an update and/or delete. */
 		if (!newbest) {
 
-			ret = kernel_del_lsp(lsp);
-
-			if (!ret) {
-				UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
-				clear_nhlfe_installed(lsp);
-			}
+			kernel_del_lsp(lsp);
 
 			zvrf->lsp_removals++;
 		} else if (CHECK_FLAG(lsp->flags, LSP_FLAG_CHANGED)) {
@@ -931,12 +913,7 @@ static wq_item_status lsp_process(struct work_queue *wq, void *data)
 			UNSET_FLAG(lsp->flags, LSP_FLAG_CHANGED);
 			UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
 
-			ret = kernel_upd_lsp(lsp);
-
-			if (!ret)
-				SET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
-			else
-				clear_nhlfe_installed(lsp);
+			kernel_upd_lsp(lsp);
 
 			zvrf->lsp_installs++;
 		}
@@ -1658,6 +1635,42 @@ static int mpls_processq_init(struct zebra_t *zebra)
 
 
 /* Public functions */
+
+void kernel_lsp_pass_fail(zebra_lsp_t *lsp,
+			  enum southbound_results res)
+{
+	struct nexthop *nexthop;
+	zebra_nhlfe_t *nhlfe;
+
+	if (!lsp)
+		return;
+
+	switch (res) {
+	case SOUTHBOUND_INSTALL_FAILURE:
+		UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
+		clear_nhlfe_installed(lsp);
+		zlog_warn("LSP Install Failure: %u", lsp->ile.in_label);
+		break;
+	case SOUTHBOUND_INSTALL_SUCCESS:
+		SET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
+		for (nhlfe = lsp->nhlfe_list; nhlfe; nhlfe = nhlfe->next) {
+			nexthop = nhlfe->nexthop;
+			if (!nexthop)
+				continue;
+
+			SET_FLAG(nhlfe->flags, NHLFE_FLAG_INSTALLED);
+			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB);
+		}
+		break;
+	case SOUTHBOUND_DELETE_SUCCESS:
+		UNSET_FLAG(lsp->flags, LSP_FLAG_INSTALLED);
+		clear_nhlfe_installed(lsp);
+		break;
+	case SOUTHBOUND_DELETE_FAILURE:
+		zlog_warn("LSP Deletion Failure: %u", lsp->ile.in_label);
+		break;
+	}
+}
 
 /*
  * String to label conversion, labels separated by '/'.

--- a/zebra/zebra_mpls_netlink.c
+++ b/zebra/zebra_mpls_netlink.c
@@ -60,27 +60,10 @@ void kernel_add_lsp(zebra_lsp_t *lsp)
 void kernel_upd_lsp(zebra_lsp_t *lsp)
 {
 	int ret;
-	zebra_nhlfe_t *nhlfe;
-	struct nexthop *nexthop;
 
 	if (!lsp || !lsp->best_nhlfe) { // unexpected
 		kernel_lsp_pass_fail(lsp, SOUTHBOUND_INSTALL_FAILURE);
 		return;
-	}
-
-	/* Any NHLFE that was installed but is not selected now needs to
-	 * have its flags updated.
-	 */
-	for (nhlfe = lsp->nhlfe_list; nhlfe; nhlfe = nhlfe->next) {
-		nexthop = nhlfe->nexthop;
-		if (!nexthop)
-			continue;
-
-		if (CHECK_FLAG(nhlfe->flags, NHLFE_FLAG_INSTALLED) &&
-		    !CHECK_FLAG(nhlfe->flags, NHLFE_FLAG_SELECTED)) {
-			UNSET_FLAG(nhlfe->flags, NHLFE_FLAG_INSTALLED);
-			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB);
-		}
 	}
 
 	ret = netlink_mpls_multipath(RTM_NEWROUTE, lsp);

--- a/zebra/zebra_mpls_netlink.c
+++ b/zebra/zebra_mpls_netlink.c
@@ -29,16 +29,21 @@
 /*
  * Install Label Forwarding entry into the kernel.
  */
-int kernel_add_lsp(zebra_lsp_t *lsp)
+void kernel_add_lsp(zebra_lsp_t *lsp)
 {
 	int ret;
 
-	if (!lsp || !lsp->best_nhlfe) // unexpected
-		return -1;
+	if (!lsp || !lsp->best_nhlfe) { // unexpected
+		kernel_lsp_pass_fail(lsp, SOUTHBOUND_INSTALL_FAILURE);
+		return;
+	}
 
 	ret = netlink_mpls_multipath(RTM_NEWROUTE, lsp);
 
-	return ret;
+	kernel_lsp_pass_fail(lsp,
+			     (!ret) ?
+			     SOUTHBOUND_INSTALL_SUCCESS :
+			     SOUTHBOUND_INSTALL_FAILURE);
 }
 
 /*
@@ -52,14 +57,16 @@ int kernel_add_lsp(zebra_lsp_t *lsp)
  * through the metric field (before kernel-MPLS). This shouldn't be an issue
  * any longer, so REPLACE can be reintroduced.
  */
-int kernel_upd_lsp(zebra_lsp_t *lsp)
+void kernel_upd_lsp(zebra_lsp_t *lsp)
 {
 	int ret;
 	zebra_nhlfe_t *nhlfe;
 	struct nexthop *nexthop;
 
-	if (!lsp || !lsp->best_nhlfe) // unexpected
-		return -1;
+	if (!lsp || !lsp->best_nhlfe) { // unexpected
+		kernel_lsp_pass_fail(lsp, SOUTHBOUND_INSTALL_FAILURE);
+		return;
+	}
 
 	/* Any NHLFE that was installed but is not selected now needs to
 	 * have its flags updated.
@@ -78,25 +85,37 @@ int kernel_upd_lsp(zebra_lsp_t *lsp)
 
 	ret = netlink_mpls_multipath(RTM_NEWROUTE, lsp);
 
-	return ret;
+	kernel_lsp_pass_fail(lsp,
+			     (!ret) ?
+			     SOUTHBOUND_INSTALL_SUCCESS :
+			     SOUTHBOUND_INSTALL_FAILURE);
 }
 
 /*
  * Delete Label Forwarding entry from the kernel.
  */
-int kernel_del_lsp(zebra_lsp_t *lsp)
+void kernel_del_lsp(zebra_lsp_t *lsp)
 {
 	int ret;
 
-	if (!lsp) // unexpected
-		return -1;
+	if (!lsp) { // unexpected
+		kernel_lsp_pass_fail(lsp,
+				     SOUTHBOUND_DELETE_FAILURE);
+		return;
+	}
 
-	if (!CHECK_FLAG(lsp->flags, LSP_FLAG_INSTALLED))
-		return -1;
+	if (!CHECK_FLAG(lsp->flags, LSP_FLAG_INSTALLED)) {
+		kernel_lsp_pass_fail(lsp,
+				     SOUTHBOUND_DELETE_FAILURE);
+		return;
+	}
 
 	ret = netlink_mpls_multipath(RTM_DELROUTE, lsp);
 
-	return ret;
+	kernel_lsp_pass_fail(lsp,
+			     (!ret) ?
+			     SOUTHBOUND_DELETE_SUCCESS :
+			     SOUTHBOUND_DELETE_FAILURE);
 }
 
 int mpls_kernel_init(void)

--- a/zebra/zebra_mpls_null.c
+++ b/zebra/zebra_mpls_null.c
@@ -24,17 +24,17 @@
 
 #if !defined(HAVE_NETLINK) && !defined(OPEN_BSD)
 
-int kernel_add_lsp(zebra_lsp_t *lsp)
+void kernel_add_lsp(zebra_lsp_t *lsp)
 {
-	return 0;
+	return;
 }
-int kernel_upd_lsp(zebra_lsp_t *lsp)
+void kernel_upd_lsp(zebra_lsp_t *lsp)
 {
-	return 0;
+	return;
 }
-int kernel_del_lsp(zebra_lsp_t *lsp)
+void kernel_del_lsp(zebra_lsp_t *lsp)
 {
-	return 0;
+	return;
 }
 int mpls_kernel_init(void)
 {


### PR DESCRIPTION
Add the ability to have the southbound api report success or failure separately from a simple return code.  In the future we plan to move the installation around a bit.

Additionally start removing flag SET/UNSET from the southbound api.  They do not own these flags, zebra does.