### PR TITLE
ospfd: Display all vrf aware ospf interface config

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9635,261 +9635,259 @@ const char *ospf_int_type_str[] = {"unknown", /* should never be used. */
 				   "virtual-link", /* should never be used. */
 				   "loopback"};
 
-static int config_write_interface_one(struct vty *vty, struct ospf *ospf)
+static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 {
-	struct vrf *vrf = NULL;
 	struct listnode *node;
 	struct interface *ifp;
 	struct crypt_key *ck;
 	struct route_node *rn = NULL;
 	struct ospf_if_params *params;
 	int write = 0;
+	struct ospf *ospf = vrf->info;
 
-	/* Display all VRF aware OSPF interface configuration */
-	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		FOR_ALL_INTERFACES (vrf, ifp) {
+	FOR_ALL_INTERFACES (vrf, ifp) {
 
-			if (memcmp(ifp->name, "VLINK", 5) == 0)
-				continue;
+		if (memcmp(ifp->name, "VLINK", 5) == 0)
+			continue;
 
-			vty_frame(vty, "!\n");
-			if (ifp->vrf_id == VRF_DEFAULT)
-				vty_frame(vty, "interface %s\n", ifp->name);
-			else
-				vty_frame(vty, "interface %s vrf %s\n",
-					ifp->name, vrf->name);
-			if (ifp->desc)
-				vty_out(vty, " description %s\n", ifp->desc);
+		vty_frame(vty, "!\n");
+		if (ifp->vrf_id == VRF_DEFAULT)
+			vty_frame(vty, "interface %s\n", ifp->name);
+		else
+			vty_frame(vty, "interface %s vrf %s\n",
+				ifp->name, vrf->name);
+		if (ifp->desc)
+			vty_out(vty, " description %s\n", ifp->desc);
 
-			write++;
+		write++;
 
-			params = IF_DEF_PARAMS(ifp);
+		params = IF_DEF_PARAMS(ifp);
 
-			do {
-				/* Interface Network print. */
-				if (OSPF_IF_PARAM_CONFIGURED(params, type)
-				    && params->type != OSPF_IFTYPE_LOOPBACK) {
-					if (params->type !=
-						ospf_default_iftype(ifp)) {
-						vty_out(vty, " ip ospf network %s",
-							ospf_int_type_str
-							[params->type]);
-						if (params != IF_DEF_PARAMS(ifp))
-							vty_out(vty, " %s",
-								inet_ntoa(
-								rn->p.u.prefix4));
-						vty_out(vty, "\n");
-					}
+		do {
+			/* Interface Network print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params, type)
+			    && params->type != OSPF_IFTYPE_LOOPBACK) {
+				if (params->type !=
+					ospf_default_iftype(ifp)) {
+					vty_out(vty, " ip ospf network %s",
+						ospf_int_type_str
+						[params->type]);
+					if (params != IF_DEF_PARAMS(ifp))
+						vty_out(vty, " %s",
+							inet_ntoa(
+							rn->p.u.prefix4));
+					vty_out(vty, "\n");
+				}
+			}
+
+			/* OSPF interface authentication print */
+			if (OSPF_IF_PARAM_CONFIGURED(params, auth_type)
+			&& params->auth_type != OSPF_AUTH_NOTSET) {
+				const char *auth_str;
+
+				/* Translation tables are not that much help
+				* here due to syntax
+				* of the simple option */
+				switch (params->auth_type) {
+
+				case OSPF_AUTH_NULL:
+					auth_str = " null";
+					break;
+
+				case OSPF_AUTH_SIMPLE:
+					auth_str = "";
+					break;
+
+				case OSPF_AUTH_CRYPTOGRAPHIC:
+					auth_str = " message-digest";
+					break;
+
+				default:
+					auth_str = "";
+					break;
 				}
 
-				/* OSPF interface authentication print */
-				if (OSPF_IF_PARAM_CONFIGURED(params, auth_type)
-				&& params->auth_type != OSPF_AUTH_NOTSET) {
-					const char *auth_str;
+				vty_out(vty, " ip ospf authentication%s",
+					auth_str);
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
+						inet_ntoa(rn->p.u.prefix4));
+				vty_out(vty, "\n");
+			}
 
-					/* Translation tables are not that much help
-					* here due to syntax
-					* of the simple option */
-					switch (params->auth_type) {
+			/* Simple Authentication Password print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params, auth_simple)
+				&& params->auth_simple[0] != '\0') {
+				vty_out(vty, " ip ospf authentication-key %s",
+					params->auth_simple);
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
+						inet_ntoa(rn->p.u.prefix4));
+				vty_out(vty, "\n");
+			}
 
-					case OSPF_AUTH_NULL:
-						auth_str = " null";
-						break;
-
-					case OSPF_AUTH_SIMPLE:
-						auth_str = "";
-						break;
-
-					case OSPF_AUTH_CRYPTOGRAPHIC:
-						auth_str = " message-digest";
-						break;
-
-					default:
-						auth_str = "";
-						break;
-					}
-
-					vty_out(vty, " ip ospf authentication%s",
-						auth_str);
+			/* Cryptographic Authentication Key print. */
+			if (params && params->auth_crypt) {
+				for (ALL_LIST_ELEMENTS_RO(
+						params->auth_crypt,
+						node, ck)) {
+					vty_out(vty,
+						" ip ospf message-digest-key %d md5 %s",
+						ck->key_id,
+						ck->auth_key);
 					if (params != IF_DEF_PARAMS(ifp))
 						vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 					vty_out(vty, "\n");
 				}
+			}
 
-				/* Simple Authentication Password print. */
-				if (OSPF_IF_PARAM_CONFIGURED(params, auth_simple)
-					&& params->auth_simple[0] != '\0') {
-					vty_out(vty, " ip ospf authentication-key %s",
-						params->auth_simple);
-					if (params != IF_DEF_PARAMS(ifp))
-						vty_out(vty, " %s",
+			/* Interface Output Cost print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params,
+					     output_cost_cmd)) {
+				vty_out(vty, " ip ospf cost %u",
+					params->output_cost_cmd);
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
-					vty_out(vty, "\n");
-				}
+				vty_out(vty, "\n");
+			}
 
-				/* Cryptographic Authentication Key print. */
-				if (params && params->auth_crypt) {
-					for (ALL_LIST_ELEMENTS_RO(
-							params->auth_crypt,
-							node, ck)) {
-						vty_out(vty,
-							" ip ospf message-digest-key %d md5 %s",
-							ck->key_id,
-							ck->auth_key);
-						if (params != IF_DEF_PARAMS(ifp))
-							vty_out(vty, " %s",
-							inet_ntoa(rn->p.u.prefix4));
-						vty_out(vty, "\n");
-					}
-				}
+			/* Hello Interval print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params, v_hello)
+				&& params->v_hello !=
+				OSPF_HELLO_INTERVAL_DEFAULT) {
+				vty_out(vty, " ip ospf hello-interval %u",
+					params->v_hello);
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
+						inet_ntoa(rn->p.u.prefix4));
+				vty_out(vty, "\n");
+			}
 
-				/* Interface Output Cost print. */
+
+			/* Router Dead Interval print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params, v_wait)
+				&& params->v_wait
+				!= OSPF_ROUTER_DEAD_INTERVAL_DEFAULT) {
+				vty_out(vty, " ip ospf dead-interval ");
+
+				/* fast hello ? */
 				if (OSPF_IF_PARAM_CONFIGURED(params,
-						     output_cost_cmd)) {
-					vty_out(vty, " ip ospf cost %u",
-						params->output_cost_cmd);
-					if (params != IF_DEF_PARAMS(ifp))
-						vty_out(vty, " %s",
+						     fast_hello))
+					vty_out(vty,
+						"minimal hello-multiplier %d",
+						params->fast_hello);
+				else
+					vty_out(vty, "%u",
+						params->v_wait);
+
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
-					vty_out(vty, "\n");
-				}
+				vty_out(vty, "\n");
+			}
 
-				/* Hello Interval print. */
-				if (OSPF_IF_PARAM_CONFIGURED(params, v_hello)
-					&& params->v_hello !=
-					OSPF_HELLO_INTERVAL_DEFAULT) {
-					vty_out(vty, " ip ospf hello-interval %u",
-						params->v_hello);
-					if (params != IF_DEF_PARAMS(ifp))
-						vty_out(vty, " %s",
+			/* Router Priority print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params, priority)
+				&& params->priority
+				!= OSPF_ROUTER_PRIORITY_DEFAULT) {
+				vty_out(vty, " ip ospf priority %u",
+					params->priority);
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
-					vty_out(vty, "\n");
-				}
+				vty_out(vty, "\n");
+			}
 
-
-				/* Router Dead Interval print. */
-				if (OSPF_IF_PARAM_CONFIGURED(params, v_wait)
-					&& params->v_wait
-					!= OSPF_ROUTER_DEAD_INTERVAL_DEFAULT) {
-					vty_out(vty, " ip ospf dead-interval ");
-
-					/* fast hello ? */
-					if (OSPF_IF_PARAM_CONFIGURED(params,
-							     fast_hello))
-						vty_out(vty,
-							"minimal hello-multiplier %d",
-							params->fast_hello);
-					else
-						vty_out(vty, "%u",
-							params->v_wait);
-
-					if (params != IF_DEF_PARAMS(ifp))
-						vty_out(vty, " %s",
+			/* Retransmit Interval print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params,
+					     retransmit_interval)
+				&& params->retransmit_interval
+				!= OSPF_RETRANSMIT_INTERVAL_DEFAULT) {
+				vty_out(vty, " ip ospf retransmit-interval %u",
+					params->retransmit_interval);
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
-					vty_out(vty, "\n");
-				}
+				vty_out(vty, "\n");
+			}
 
-				/* Router Priority print. */
-				if (OSPF_IF_PARAM_CONFIGURED(params, priority)
-					&& params->priority
-					!= OSPF_ROUTER_PRIORITY_DEFAULT) {
-					vty_out(vty, " ip ospf priority %u",
-						params->priority);
-					if (params != IF_DEF_PARAMS(ifp))
-						vty_out(vty, " %s",
-						inet_ntoa(rn->p.u.prefix4));
-					vty_out(vty, "\n");
-				}
+			/* Transmit Delay print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params,
+						     transmit_delay)
+				&& params->transmit_delay
+				!= OSPF_TRANSMIT_DELAY_DEFAULT) {
+				vty_out(vty, " ip ospf transmit-delay %u",
+					params->transmit_delay);
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
+					inet_ntoa(rn->p.u.prefix4));
+				vty_out(vty, "\n");
+			}
 
-				/* Retransmit Interval print. */
-				if (OSPF_IF_PARAM_CONFIGURED(params,
-						     retransmit_interval)
-					&& params->retransmit_interval
-					!= OSPF_RETRANSMIT_INTERVAL_DEFAULT) {
-					vty_out(vty, " ip ospf retransmit-interval %u",
-						params->retransmit_interval);
-					if (params != IF_DEF_PARAMS(ifp))
-						vty_out(vty, " %s",
-						inet_ntoa(rn->p.u.prefix4));
-					vty_out(vty, "\n");
-				}
-
-				/* Transmit Delay print. */
-				if (OSPF_IF_PARAM_CONFIGURED(params,
-							     transmit_delay)
-					&& params->transmit_delay
-					!= OSPF_TRANSMIT_DELAY_DEFAULT) {
-					vty_out(vty, " ip ospf transmit-delay %u",
-						params->transmit_delay);
-					if (params != IF_DEF_PARAMS(ifp))
-						vty_out(vty, " %s",
-						inet_ntoa(rn->p.u.prefix4));
-					vty_out(vty, "\n");
-				}
-
-				/* Area  print. */
-				if (OSPF_IF_PARAM_CONFIGURED(params, if_area)) {
-					if (ospf->instance)
-						vty_out(vty, " ip ospf %d",
-							ospf->instance);
-					else
-						vty_out(vty, " ip ospf");
+			/* Area  print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params, if_area)) {
+				if (ospf && ospf->instance)
+					vty_out(vty, " ip ospf %d",
+						ospf->instance);
+				else
+					vty_out(vty, " ip ospf");
 
 
-					size_t buflen = MAX(strlen("4294967295"),
-						    strlen("255.255.255.255"));
-					char buf[buflen];
+				size_t buflen = MAX(strlen("4294967295"),
+					    strlen("255.255.255.255"));
+				char buf[buflen];
 
-					area_id2str(buf, sizeof(buf),
-						    &params->if_area,
-							params->if_area_id_fmt);
-					vty_out(vty, " area %s", buf);
-					if (params != IF_DEF_PARAMS(ifp))
-						vty_out(vty, " %s",
-						inet_ntoa(rn->p.u.prefix4));
-					vty_out(vty, "\n");
-				}
+				area_id2str(buf, sizeof(buf),
+					    &params->if_area,
+						params->if_area_id_fmt);
+				vty_out(vty, " area %s", buf);
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
+					inet_ntoa(rn->p.u.prefix4));
+				vty_out(vty, "\n");
+			}
 
-				/* bfd  print. */
-				if (params->bfd_info)
-					ospf_bfd_write_config(vty, params);
+			/* bfd  print. */
+			if (params->bfd_info)
+				ospf_bfd_write_config(vty, params);
 
-				/* MTU ignore print. */
-				if (OSPF_IF_PARAM_CONFIGURED(params, mtu_ignore)
-					&& params->mtu_ignore !=
-					OSPF_MTU_IGNORE_DEFAULT) {
-					if (params->mtu_ignore == 0)
-						vty_out(vty, " no ip ospf mtu-ignore");
-					else
-						vty_out(vty, " ip ospf mtu-ignore");
-					if (params != IF_DEF_PARAMS(ifp))
-						vty_out(vty, " %s",
-						inet_ntoa(rn->p.u.prefix4));
-					vty_out(vty, "\n");
-				}
+			/* MTU ignore print. */
+			if (OSPF_IF_PARAM_CONFIGURED(params, mtu_ignore)
+				&& params->mtu_ignore !=
+				OSPF_MTU_IGNORE_DEFAULT) {
+				if (params->mtu_ignore == 0)
+					vty_out(vty, " no ip ospf mtu-ignore");
+				else
+					vty_out(vty, " ip ospf mtu-ignore");
+				if (params != IF_DEF_PARAMS(ifp))
+					vty_out(vty, " %s",
+					inet_ntoa(rn->p.u.prefix4));
+				vty_out(vty, "\n");
+			}
 
 
-				while (1) {
-					if (rn == NULL)
-						rn = route_top(
-							IF_OIFS_PARAMS(ifp));
-					else
-						rn = route_next(rn);
+			while (1) {
+				if (rn == NULL)
+					rn = route_top(
+						IF_OIFS_PARAMS(ifp));
+				else
+					rn = route_next(rn);
 
-					if (rn == NULL)
-						break;
-					params = rn->info;
-					if (params != NULL)
-						break;
-				}
-			} while (rn);
+				if (rn == NULL)
+					break;
+				params = rn->info;
+				if (params != NULL)
+					break;
+			}
+		} while (rn);
 
-			ospf_opaque_config_write_if(vty, ifp);
+		ospf_opaque_config_write_if(vty, ifp);
 
-			vty_endframe(vty, NULL);
-		}
+		vty_endframe(vty, NULL);
 	}
+
 	return write;
 }
 
@@ -9897,10 +9895,12 @@ static int config_write_interface_one(struct vty *vty, struct ospf *ospf)
 static int config_write_interface(struct vty *vty)
 {
 	int write = 0;
-	struct ospf *ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	struct vrf *vrf = NULL;
 
-	/* Pass Default ospf instances to display MI-OSPF instance id */
-	write += config_write_interface_one(vty, ospf);
+	/* Display all VRF aware OSPF interface configuration */
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		write += config_write_interface_one(vty, vrf);
+	}
 
 	return write;
 }


### PR DESCRIPTION
OSPF interface specific configuration can be done independent
of router ospf [vrf x] global config.
In cases where ospf interface non default vrf configuration
is done prior to 'router ospf vrf x', show running-config
would not display such configuration.

To display configuration now walk all vrfs and interface list
and only display where OSPF configure params are set.

Ticket:CM-18952
Testing Done:
Tried ospf interface specific configuration with VRF,
where router ospf vrf x is not present.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>