### PR TITLE
bgpd: Allow Address-Family activation to work in certain states

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1882,6 +1882,11 @@ static int peer_activate_af(struct peer *peer, afi_t afi, safi_t safi)
 						BGP_NOTIFY_CEASE_CONFIG_CHANGE);
 			}
 		}
+		if (peer->status == OpenSent || peer->status == OpenConfirm) {
+			peer->last_reset = PEER_DOWN_AF_ACTIVATE;
+			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
+					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
If we are in OpenSent or OpenConfirm peer state and we receive a new
address-family activation, we would end up ignoring the new activation
and not tell our peer about it.  You could notice this by seeing
the fact that a 'show bgp neighbor' command returns a 'Not in
any update group' for a particular family.

This modifies the code such that we now notice that we are in
either OpenSent or OpenConfirm state and reset the peer to
allow us to send them the new capability.

Ticket: CM-19021
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>