### PR TITLE
bgpd: fix potential deadlock

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -556,11 +556,13 @@ static int bgp_write_notify(struct peer *peer)
 	{
 		/* There should be at least one packet. */
 		s = stream_fifo_pop(peer->obuf);
-		if (!s)
-			return 0;
-		assert(stream_get_endp(s) >= BGP_HEADER_SIZE);
 	}
 	pthread_mutex_unlock(&peer->io_mtx);
+
+	if (!s)
+		return 0;
+
+	assert(stream_get_endp(s) >= BGP_HEADER_SIZE);
 
 	/* Stop collecting data within the socket */
 	sockopt_cork(peer->fd, 0);


### PR DESCRIPTION
With the way things are set up, this bit of code would never actually
cause a deadlock, but would be highly likely in the future.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>