### PR TITLE
Cleanup Some Code Issues

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -226,7 +226,7 @@ static void bgp_evpn_show_route_header(struct vty *vty, struct bgp *bgp,
 
 static void display_vni(struct vty *vty, struct bgpevpn *vpn, json_object *json)
 {
-	char buf1[INET6_ADDRSTRLEN];
+	char buf1[RD_ADDRSTRLEN];
 	char *ecom_str;
 	struct listnode *node, *nnode;
 	struct ecommunity *ecom;
@@ -241,7 +241,7 @@ static void display_vni(struct vty *vty, struct bgpevpn *vpn, json_object *json)
 				       is_vni_live(vpn) ? "Yes" : "No");
 		json_object_string_add(
 			json, "rd",
-			prefix_rd2str(&vpn->prd, buf1, RD_ADDRSTRLEN));
+			prefix_rd2str(&vpn->prd, buf1, sizeof(buf1)));
 		json_object_string_add(json, "originatorIp",
 				       inet_ntoa(vpn->originator_ip));
 		json_object_string_add(json, "advertiseGatewayMacip",
@@ -253,7 +253,7 @@ static void display_vni(struct vty *vty, struct bgpevpn *vpn, json_object *json)
 		vty_out(vty, "\n");
 
 		vty_out(vty, "  RD: %s\n",
-			prefix_rd2str(&vpn->prd, buf1, RD_ADDRSTRLEN));
+			prefix_rd2str(&vpn->prd, buf1, sizeof(buf1)));
 		vty_out(vty, "  Originator IP: %s\n",
 			inet_ntoa(vpn->originator_ip));
 		vty_out(vty, "  Advertise-gw-macip : %s\n",
@@ -419,7 +419,7 @@ static void show_vni_entry(struct hash_backet *backet, void *args[])
 	json_object *json_export_rtl;
 	struct bgpevpn *vpn = (struct bgpevpn *)backet->data;
 	char buf1[10];
-	char buf2[INET6_ADDRSTRLEN];
+	char buf2[RD_ADDRSTRLEN];
 	char rt_buf[25];
 	char *ecom_str;
 	struct listnode *node, *nnode;
@@ -446,11 +446,11 @@ static void show_vni_entry(struct hash_backet *backet, void *args[])
 				       inet_ntoa(vpn->originator_ip));
 		json_object_string_add(
 			json_vni, "rd",
-			prefix_rd2str(&vpn->prd, buf2, RD_ADDRSTRLEN));
+			prefix_rd2str(&vpn->prd, buf2, sizeof(buf2)));
 	} else {
 		vty_out(vty, "%-1s %-10u %-15s %-21s", buf1, vpn->vni,
 			inet_ntoa(vpn->originator_ip),
-			prefix_rd2str(&vpn->prd, buf2, RD_ADDRSTRLEN));
+			prefix_rd2str(&vpn->prd, buf2, sizeof(buf2)));
 	}
 
 	for (ALL_LIST_ELEMENTS(vpn->import_rtl, node, nnode, ecom)) {
@@ -2093,7 +2093,7 @@ static void evpn_unset_advertise_all_vni(struct bgp *bgp)
 
 static void write_vni_config(struct vty *vty, struct bgpevpn *vpn)
 {
-	char buf1[INET6_ADDRSTRLEN];
+	char buf1[RD_ADDRSTRLEN];
 	char *ecom_str;
 	struct listnode *node, *nnode;
 	struct ecommunity *ecom;
@@ -2102,7 +2102,7 @@ static void write_vni_config(struct vty *vty, struct bgpevpn *vpn)
 		vty_out(vty, "  vni %d\n", vpn->vni);
 		if (is_rd_configured(vpn))
 			vty_out(vty, "   rd %s\n",
-				prefix_rd2str(&vpn->prd, buf1, RD_ADDRSTRLEN));
+				prefix_rd2str(&vpn->prd, buf1, sizeof(buf1)));
 
 		if (is_import_rt_configured(vpn)) {
 			for (ALL_LIST_ELEMENTS(vpn->import_rtl, node, nnode,

--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -166,8 +166,7 @@ char *prefix_rd2str(struct prefix_rd *prd, char *buf, size_t size)
 	struct rd_as rd_as;
 	struct rd_ip rd_ip;
 
-	if (size < RD_ADDRSTRLEN)
-		return NULL;
+	assert(size >= RD_ADDRSTRLEN);
 
 	pnt = prd->val;
 
@@ -197,5 +196,7 @@ char *prefix_rd2str(struct prefix_rd *prd, char *buf, size_t size)
 		return buf;
 	}
 #endif
-	return NULL;
+
+	snprintf(buf, size, "Unknown Type: %d", type);
+	return buf;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10569,12 +10569,17 @@ DEFUN (show_bgp_afi_vpn_rd_route,
 	afi_t afi = AFI_MAX;
 	int idx = 0;
 
-	(void)argv_find_and_parse_afi(argv, argc, &idx, &afi);
+	if (!argv_find_and_parse_afi(argv, argc, &idx, &afi)) {
+		vty_out(vty, "%% Malformed Address Family\n");
+		return CMD_WARNING;
+	}
+
 	ret = str2prefix_rd(argv[5]->arg, &prd);
 	if (!ret) {
 		vty_out(vty, "%% Malformed Route Distinguisher\n");
 		return CMD_WARNING;
 	}
+
 	return bgp_show_route(vty, NULL, argv[6]->arg, afi, SAFI_MPLS_VPN, &prd,
 			      0, BGP_PATH_ALL, use_json(argc, argv));
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7388,7 +7388,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 				vty_out(vty, "  Imported from %s:%s\n",
 					prefix_rd2str(
 						(struct prefix_rd *)&prn->p,
-						buf1, RD_ADDRSTRLEN),
+						buf1, sizeof(buf1)),
 					buf2);
 			}
 		}
@@ -7601,7 +7601,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 					json_peer, "routerId",
 					inet_ntop(AF_INET,
 						  &binfo->peer->remote_id, buf1,
-						  BUFSIZ));
+						  sizeof(buf1)));
 
 				if (binfo->peer->hostname)
 					json_object_string_add(
@@ -7655,7 +7655,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 						inet_ntop(
 							AF_INET,
 							&binfo->peer->remote_id,
-							buf1, BUFSIZ));
+							buf1, sizeof(buf1)));
 			}
 		}
 
@@ -8447,13 +8447,10 @@ int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, safi_t safi,
 			continue;
 		if (rn->info != NULL) {
 			struct prefix_rd prd;
-			char rd[BUFSIZ];
+			char rd[RD_ADDRSTRLEN];
 
 			memcpy(&prd, &(rn->p), sizeof(struct prefix_rd));
-			if (prefix_rd2str(&prd, rd, BUFSIZ) == NULL)
-				sprintf(rd,
-					"Unknown Type: %u",
-					decode_rd_type(prd.val));
+			prefix_rd2str(&prd, rd, sizeof(rd));
 			bgp_show_table(vty, bgp, safi, rn->info, type,
 				       output_arg, use_json,
 				       rd, next == NULL,
@@ -8539,7 +8536,7 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 	struct prefix *p;
 	struct peer *peer;
 	struct listnode *node, *nnode;
-	char buf1[INET6_ADDRSTRLEN];
+	char buf1[RD_ADDRSTRLEN];
 	char buf2[INET6_ADDRSTRLEN];
 #if defined(HAVE_CUMULUS)
 	char buf3[EVPN_ROUTE_STRLEN];
@@ -8573,7 +8570,7 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 #if defined(HAVE_CUMULUS)
 		if (safi == SAFI_EVPN)
 			vty_out(vty, "BGP routing table entry for %s%s%s\n",
-				prd ? prefix_rd2str(prd, buf1, RD_ADDRSTRLEN)
+				prd ? prefix_rd2str(prd, buf1, sizeof(buf1))
 				    : "",
 				prd ? ":" : "",
 				bgp_evpn_route2str((struct prefix_evpn *)p,
@@ -8582,7 +8579,7 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 			vty_out(vty, "BGP routing table entry for %s%s%s/%d\n",
 				((safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP)
 					 ? prefix_rd2str(prd, buf1,
-							 RD_ADDRSTRLEN)
+							 sizeof(buf1))
 					 : ""),
 				safi == SAFI_MPLS_VPN ? ":" : "",
 				inet_ntop(p->family, &p->u.prefix, buf2,
@@ -8597,8 +8594,8 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 		vty_out(vty, "BGP routing table entry for %s%s%s/%d\n",
 			((safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP
 			  || safi == SAFI_EVPN)
-				 ? prefix_rd2str(prd, buf1, RD_ADDRSTRLEN)
-				 : ""),
+			 ? prefix_rd2str(prd, buf1, sizeof(buf1))
+			 : ""),
 			((safi == SAFI_MPLS_VPN) || (safi == SAFI_EVPN)) ? ":"
 									 : "",
 			buf2, p->prefixlen);
@@ -11144,7 +11141,7 @@ static void bgp_config_write_network_vpn(struct vty *vty, struct bgp *bgp,
 			prd = (struct prefix_rd *)&prn->p;
 
 			/* "network" configuration display.  */
-			prefix_rd2str(prd, rdbuf, RD_ADDRSTRLEN);
+			prefix_rd2str(prd, rdbuf, sizeof(rdbuf));
 			label = decode_label(&bgp_static->label);
 
 			vty_out(vty, "  network %s/%d rd %s",
@@ -11201,7 +11198,7 @@ static void bgp_config_write_network_evpn(struct vty *vty, struct bgp *bgp,
 			prd = (struct prefix_rd *)&prn->p;
 
 			/* "network" configuration display.  */
-			prefix_rd2str(prd, rdbuf, RD_ADDRSTRLEN);
+			prefix_rd2str(prd, rdbuf, sizeof(rdbuf));
 			if (p->u.prefix_evpn.route_type == 5) {
 				char local_buf[PREFIX_STRLEN];
 				uint8_t family = IS_EVPN_PREFIX_IPADDR_V4((struct prefix_evpn *)p)

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -3884,8 +3884,7 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 			}
 
 			if (rfg->rd.prefixlen) {
-				char buf[BUFSIZ];
-				buf[0] = buf[BUFSIZ - 1] = 0;
+				char buf[RD_ADDRSTRLEN];
 
 				if (AF_UNIX == rfg->rd.family) {
 
@@ -3898,18 +3897,10 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 					vty_out(vty, "  rd auto:nh:%d\n",
 						value);
 
-				} else {
-
-					if (!prefix_rd2str(&rfg->rd, buf,
-							   BUFSIZ)
-					    || !buf[0] || buf[BUFSIZ - 1]) {
-
-						vty_out(vty,
-							"!Error: Can't convert rd\n");
-					} else {
-						vty_out(vty, "  rd %s\n", buf);
-					}
-				}
+				} else
+					vty_out(vty, "  rd %s\n",
+						prefix_rd2str(&rfg->rd, buf,
+							      sizeof(buf)));
 			}
 
 			if (rfg->rt_import_list && rfg->rt_export_list
@@ -4107,8 +4098,7 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 			vty_out(vty, " vnc defaults\n");
 
 			if (hc->default_rd.prefixlen) {
-				char buf[BUFSIZ];
-				buf[0] = buf[BUFSIZ - 1] = 0;
+				char buf[RD_ADDRSTRLEN];
 
 				if (AF_UNIX == hc->default_rd.family) {
 					uint16_t value = 0;
@@ -4121,18 +4111,11 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 					vty_out(vty, "  rd auto:vn:%d\n",
 						value);
 
-				} else {
-
-					if (!prefix_rd2str(&hc->default_rd, buf,
-							   BUFSIZ)
-					    || !buf[0] || buf[BUFSIZ - 1]) {
-
-						vty_out(vty,
-							"!Error: Can't convert rd\n");
-					} else {
-						vty_out(vty, "  rd %s\n", buf);
-					}
-				}
+				} else
+					vty_out(vty, "  rd %s\n",
+						prefix_rd2str(&hc->default_rd,
+							      buf,
+							      sizeof(buf)));
 			}
 			if (hc->default_response_lifetime) {
 				vty_out(vty, "  response-lifetime ");
@@ -4206,8 +4189,7 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 
 
 				if (rfg->rd.prefixlen) {
-					char buf[BUFSIZ];
-					buf[0] = buf[BUFSIZ - 1] = 0;
+					char buf[RD_ADDRSTRLEN];
 
 					if (AF_UNIX == rfg->rd.family) {
 
@@ -4222,21 +4204,12 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 							"  rd auto:vn:%d\n",
 							value);
 
-					} else {
-
-						if (!prefix_rd2str(&rfg->rd,
-								   buf, BUFSIZ)
-						    || !buf[0]
-						    || buf[BUFSIZ - 1]) {
-
-							vty_out(vty,
-								"!Error: Can't convert rd\n");
-						} else {
-							vty_out(vty,
-								"  rd %s\n",
-								buf);
-						}
-					}
+					} else
+						vty_out(vty,
+							"  rd %s\n",
+							prefix_rd2str(&rfg->rd,
+								      buf,
+								      sizeof(buf)));
 				}
 				if (rfg->flags & RFAPI_RFG_RESPONSE_LIFETIME) {
 					vty_out(vty, "  response-lifetime ");

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -170,12 +170,12 @@ struct rfapi_nve_group_cfg *bgp_rfapi_cfg_match_group(struct rfapi_cfg *hc,
 
 #if BGP_VNC_DEBUG_MATCH_GROUP
 	{
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		prefix2str(vn, buf, BUFSIZ);
+		prefix2str(vn, buf, sizeof(buf));
 		vnc_zlog_debug_verbose("%s: vn prefix: %s", __func__, buf);
 
-		prefix2str(un, buf, BUFSIZ);
+		prefix2str(un, buf, sizeof(buf));
 		vnc_zlog_debug_verbose("%s: un prefix: %s", __func__, buf);
 
 		vnc_zlog_debug_verbose(
@@ -4187,32 +4187,21 @@ int bgp_rfapi_cfg_write(struct vty *vty, struct bgp *bgp)
 				vty_out(vty, " vnc nve-group %s\n", rfg->name);
 
 				if (rfg->vn_prefix.family && rfg->vn_node) {
-					char buf[BUFSIZ];
-					buf[0] = buf[BUFSIZ - 1] = 0;
+					char buf[PREFIX_STRLEN];
 
 					prefix2str(&rfg->vn_prefix, buf,
-						   BUFSIZ);
-					if (!buf[0] || buf[BUFSIZ - 1]) {
-						vty_out(vty,
-							"!Error: Can't convert prefix\n");
-					} else {
-						vty_out(vty, "  prefix %s %s\n",
-							"vn", buf);
-					}
+						   sizeof(buf));
+					vty_out(vty, "  prefix %s %s\n",
+						"vn", buf);
 				}
 
 				if (rfg->un_prefix.family && rfg->un_node) {
-					char buf[BUFSIZ];
-					buf[0] = buf[BUFSIZ - 1] = 0;
+					char buf[PREFIX_STRLEN];
+
 					prefix2str(&rfg->un_prefix, buf,
-						   BUFSIZ);
-					if (!buf[0] || buf[BUFSIZ - 1]) {
-						vty_out(vty,
-							"!Error: Can't convert prefix\n");
-					} else {
-						vty_out(vty, "  prefix %s %s\n",
-							"un", buf);
-					}
+						   sizeof(buf));
+					vty_out(vty, "  prefix %s %s\n",
+						"un", buf);
 				}
 
 

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -363,15 +363,12 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 	afi_t afi; /* of the VN address */
 	struct bgp_node *bn;
 	struct bgp_info *bi;
-	char buf[BUFSIZ];
+	char buf[PREFIX_STRLEN];
 	char buf2[BUFSIZ];
 	struct prefix_rd prd0;
 
-	prefix2str(p, buf, BUFSIZ);
-	buf[BUFSIZ - 1] = 0; /* guarantee NUL-terminated */
-
-	prefix_rd2str(prd, buf2, BUFSIZ);
-	buf2[BUFSIZ - 1] = 0;
+	prefix2str(p, buf, sizeof(buf));
+	prefix_rd2str(prd, buf2, sizeof(buf2));
 
 	afi = family2afi(p->family);
 	assert(afi == AFI_IP || afi == AFI_IP6);
@@ -464,11 +461,9 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 	rfapiProcessWithdraw(peer, rfd, p, prd, NULL, afi, safi, type, kill);
 
 	if (bi) {
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		prefix2str(p, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0; /* guarantee NUL-terminated */
-
+		prefix2str(p, buf, sizeof(buf));
 		vnc_zlog_debug_verbose(
 			"%s: Found route (safi=%d) to delete at prefix %s",
 			__func__, safi, buf);
@@ -593,7 +588,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	uint32_t label_val;
 
 	struct bgp_attr_encap_subtlv *encaptlv;
-	char buf[BUFSIZ];
+	char buf[PREFIX_STRLEN];
 	char buf2[BUFSIZ];
 #if 0 /* unused? */
   struct prefix pfx_buf;
@@ -650,9 +645,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	else
 		label_val = MPLS_LABEL_IMPLICIT_NULL;
 
-	prefix_rd2str(prd, buf2, BUFSIZ);
-	buf2[BUFSIZ - 1] = 0;
-
+	prefix_rd2str(prd, buf2, sizeof(buf2));
 
 	afi = family2afi(p->family);
 	assert(afi == AFI_IP || afi == AFI_IP6);
@@ -907,8 +900,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	}
 
 
-	prefix2str(p, buf, BUFSIZ);
-	buf[BUFSIZ - 1] = 0; /* guarantee NUL-terminated */
+	prefix2str(p, buf, sizeof(buf));
 
 	/*
 	 * At this point:
@@ -1611,11 +1603,10 @@ rfapi_query_inner(void *handle, struct rfapi_ip_addr *target,
 	}
 
 	{
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 		char *s;
 
-		prefix2str(&p, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0; /* guarantee NUL-terminated */
+		prefix2str(&p, buf, sizeof(buf));
 		vnc_zlog_debug_verbose("%s(rfd=%p, target=%s, ppNextHop=%p)",
 				       __func__, rfd, buf, ppNextHopEntry);
 
@@ -2434,10 +2425,9 @@ int rfapi_register(void *handle, struct rfapi_ip_prefix *prefix,
 
 
 	{
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		prefix2str(&p, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0; /* guarantee NUL-terminated */
+		prefix2str(&p, buf, sizeof(buf));
 		vnc_zlog_debug_verbose(
 			"%s(rfd=%p, pfx=%s, lifetime=%d, opts_un=%p, opts_vn=%p, action=%s)",
 			__func__, rfd, buf, lifetime, options_un, options_vn,

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -364,11 +364,10 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 	struct bgp_node *bn;
 	struct bgp_info *bi;
 	char buf[PREFIX_STRLEN];
-	char buf2[BUFSIZ];
+	char buf2[RD_ADDRSTRLEN];
 	struct prefix_rd prd0;
 
 	prefix2str(p, buf, sizeof(buf));
-	prefix_rd2str(prd, buf2, sizeof(buf2));
 
 	afi = family2afi(p->family);
 	assert(afi == AFI_IP || afi == AFI_IP6);
@@ -383,7 +382,8 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 
 	vnc_zlog_debug_verbose(
 		"%s: peer=%p, prefix=%s, prd=%s afi=%d, safi=%d bn=%p, bn->info=%p",
-		__func__, peer, buf, buf2, afi, safi, bn,
+		__func__, peer, buf,
+		prefix_rd2str(prd, buf2, sizeof(buf2)), afi, safi, bn,
 		(bn ? bn->info : NULL));
 
 	for (bi = (bn ? bn->info : NULL); bi; bi = bi->next) {
@@ -589,7 +589,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 
 	struct bgp_attr_encap_subtlv *encaptlv;
 	char buf[PREFIX_STRLEN];
-	char buf2[BUFSIZ];
+	char buf2[RD_ADDRSTRLEN];
 #if 0 /* unused? */
   struct prefix pfx_buf;
 #endif
@@ -3831,12 +3831,10 @@ int rfapi_set_autord_from_vn(struct prefix_rd *rd, struct rfapi_ip_addr *vn)
 		       4); /* low order 4 bytes */
 	}
 	{
-		char buf[BUFSIZ];
-		buf[0] = 0;
-		prefix_rd2str(rd, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0;
+		char buf[RD_ADDRSTRLEN];
+
 		vnc_zlog_debug_verbose("%s: auto-RD is set to %s", __func__,
-				       buf);
+				       prefix_rd2str(rd, buf, sizeof(buf)));
 	}
 	return 0;
 }

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -41,6 +41,7 @@
 #include "bgpd/bgp_route.h"
 #include "bgpd/bgp_mplsvpn.h" /* prefix_rd2str() */
 #include "bgpd/bgp_vnc_types.h"
+#include "bgpd/bgp_rd.h"
 
 #include "bgpd/rfapi/rfapi.h"
 #include "bgpd/rfapi/bgp_rfapi_cfg.h"
@@ -2132,10 +2133,12 @@ static void rfapiItBiIndexAdd(struct route_node *rn, /* Import table VPN node */
 	assert(bi->extra);
 
 	{
-		char buf[BUFSIZ];
-		prefix_rd2str(&bi->extra->vnc.import.rd, buf, BUFSIZ);
+		char buf[RD_ADDRSTRLEN];
+
 		vnc_zlog_debug_verbose("%s: bi %p, peer %p, rd %s", __func__,
-				       bi, bi->peer, buf);
+				       bi, bi->peer,
+				       prefix_rd2str(&bi->extra->vnc.import.rd,
+						     buf, sizeof(buf)));
 	}
 
 	sl = RFAPI_RDINDEX_W_ALLOC(rn);
@@ -2169,18 +2172,15 @@ static void rfapiItBiIndexDump(struct route_node *rn)
 	for (rc = skiplist_next(sl, (void **)&k, (void **)&v, &cursor); !rc;
 	     rc = skiplist_next(sl, (void **)&k, (void **)&v, &cursor)) {
 
-		char buf[BUFSIZ];
+		char buf[RD_ADDRSTRLEN];
 		char buf_aux_pfx[PREFIX_STRLEN];
 
-		prefix_rd2str(&k->extra->vnc.import.rd, buf, BUFSIZ);
-		buf_aux_pfx[0] = 0;
+		prefix_rd2str(&k->extra->vnc.import.rd, buf, sizeof(buf));
 		if (k->extra->vnc.import.aux_prefix.family) {
 			prefix2str(&k->extra->vnc.import.aux_prefix,
-				   buf_aux_pfx, sizeof(buf));
-		} else {
+				   buf_aux_pfx, sizeof(buf_aux_pfx));
+		} else
 			strncpy(buf_aux_pfx, "(none)", PREFIX_STRLEN);
-			buf_aux_pfx[PREFIX_STRLEN - 1] = 0;
-		}
 
 		vnc_zlog_debug_verbose("bi %p, peer %p, rd %s, aux_prefix %s",
 				       k, k->peer, buf, buf_aux_pfx);
@@ -2204,20 +2204,19 @@ static struct bgp_info *rfapiItBiIndexSearch(
 
 #if DEBUG_BI_SEARCH
 	{
-		char buf[BUFSIZ];
+		char buf[RD_ADDRSTRLEN];
 		char buf_aux_pfx[PREFIX_STRLEN];
 
-		prefix_rd2str(prd, buf, BUFSIZ);
 		if (aux_prefix) {
 			prefix2str(aux_prefix, buf_aux_pfx,
 				   sizeof(buf_aux_pfx));
-		} else {
-			strncpy(buf_aux_pfx, "(nil)", BUFSIZ - 1);
-			buf_aux_pfx[BUFSIZ - 1] = 0;
-		}
+		} else
+			strncpy(buf_aux_pfx, "(nil)", sizeof(buf_aux_pfx));
 
 		vnc_zlog_debug_verbose("%s want prd=%s, peer=%p, aux_prefix=%s",
-				       __func__, buf, peer, buf_aux_pfx);
+				       __func__,
+				       prefix_rd2str(prd, buf, sizeof(buf)),
+				       peer, buf_aux_pfx);
 		rfapiItBiIndexDump(rn);
 	}
 #endif
@@ -2232,12 +2231,14 @@ static struct bgp_info *rfapiItBiIndexSearch(
 		     bi_result = bi_result->next) {
 #if DEBUG_BI_SEARCH
 			{
-				char buf[BUFSIZ];
-				prefix_rd2str(&bi_result->extra->vnc.import.rd,
-					      buf, BUFSIZ);
+				char buf[RD_ADDRSTRLEN];
+
 				vnc_zlog_debug_verbose(
 					"%s: bi has prd=%s, peer=%p", __func__,
-					buf, bi_result->peer);
+					prefix_rd2str(&bi_result->extra->vnc.import.rd,
+						      buf,
+						      sizeof(buf)),
+					bi_result->peer);
 			}
 #endif
 			if (peer == bi_result->peer
@@ -2300,10 +2301,12 @@ static void rfapiItBiIndexDel(struct route_node *rn, /* Import table VPN node */
 	int rc;
 
 	{
-		char buf[BUFSIZ];
-		prefix_rd2str(&bi->extra->vnc.import.rd, buf, BUFSIZ);
+		char buf[RD_ADDRSTRLEN];
+
 		vnc_zlog_debug_verbose("%s: bi %p, peer %p, rd %s", __func__,
-				       bi, bi->peer, buf);
+				       bi, bi->peer,
+				       prefix_rd2str(&bi->extra->vnc.import.rd,
+						     buf, sizeof(buf)));
 	}
 
 	sl = RFAPI_RDINDEX(rn);

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -645,10 +645,9 @@ rfapiMonitorMoveShorter(struct route_node *original_vpn_node, int lockoffset)
 
 #if DEBUG_MONITOR_MOVE_SHORTER
 	{
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		prefix2str(&original_vpn_node->p, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0;
+		prefix2str(&original_vpn_node->p, buf, sizeof(buf));
 		vnc_zlog_debug_verbose("%s: called with node pfx=%s", __func__,
 				       buf);
 	}
@@ -779,10 +778,9 @@ rfapiMonitorMoveShorter(struct route_node *original_vpn_node, int lockoffset)
 
 #if DEBUG_MONITOR_MOVE_SHORTER
 	{
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		prefix2str(&par->p, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0;
+		prefix2str(&par->p, buf, sizeof(buf));
 		vnc_zlog_debug_verbose("%s: moved to node pfx=%s", __func__,
 				       buf);
 	}
@@ -1594,10 +1592,9 @@ static int rfapiNhlAddNodeRoutes(
 		}
 		if (!skiplist_search(seen_nexthops, &pfx_vn, NULL)) {
 #if DEBUG_RETURNED_NHL
-			char buf[BUFSIZ];
+			char buf[PREFIX_STRLEN];
 
-			prefix2str(&pfx_vn, buf, BUFSIZ);
-			buf[BUFSIZ - 1] = 0; /* guarantee NUL-terminated */
+			prefix2str(&pfx_vn, buf, sizeof(buf));
 			vnc_zlog_debug_verbose(
 				"%s: already put VN/nexthop %s, skip", __func__,
 				buf);
@@ -1760,10 +1757,9 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 
 #if DEBUG_RETURNED_NHL
 	{
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		prefix2str(&rn->p, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0;
+		prefix2str(&rn->p, buf, sizeof(buf));
 		vnc_zlog_debug_verbose("%s: called with node pfx=%s", __func__,
 				       buf);
 	}
@@ -2174,16 +2170,16 @@ static void rfapiItBiIndexDump(struct route_node *rn)
 	     rc = skiplist_next(sl, (void **)&k, (void **)&v, &cursor)) {
 
 		char buf[BUFSIZ];
-		char buf_aux_pfx[BUFSIZ];
+		char buf_aux_pfx[PREFIX_STRLEN];
 
 		prefix_rd2str(&k->extra->vnc.import.rd, buf, BUFSIZ);
 		buf_aux_pfx[0] = 0;
 		if (k->extra->vnc.import.aux_prefix.family) {
 			prefix2str(&k->extra->vnc.import.aux_prefix,
-				   buf_aux_pfx, BUFSIZ);
+				   buf_aux_pfx, sizeof(buf));
 		} else {
-			strncpy(buf_aux_pfx, "(none)", BUFSIZ);
-			buf_aux_pfx[BUFSIZ - 1] = 0;
+			strncpy(buf_aux_pfx, "(none)", PREFIX_STRLEN);
+			buf_aux_pfx[PREFIX_STRLEN - 1] = 0;
 		}
 
 		vnc_zlog_debug_verbose("bi %p, peer %p, rd %s, aux_prefix %s",
@@ -2209,11 +2205,12 @@ static struct bgp_info *rfapiItBiIndexSearch(
 #if DEBUG_BI_SEARCH
 	{
 		char buf[BUFSIZ];
-		char buf_aux_pfx[BUFSIZ];
+		char buf_aux_pfx[PREFIX_STRLEN];
 
 		prefix_rd2str(prd, buf, BUFSIZ);
 		if (aux_prefix) {
-			prefix2str(aux_prefix, buf_aux_pfx, BUFSIZ);
+			prefix2str(aux_prefix, buf_aux_pfx,
+				   sizeof(buf_aux_pfx));
 		} else {
 			strncpy(buf_aux_pfx, "(nil)", BUFSIZ - 1);
 			buf_aux_pfx[BUFSIZ - 1] = 0;
@@ -3671,9 +3668,9 @@ void rfapiBgpInfoFilteredImportVPN(
 		rfapiCopyUnEncap2VPN(ern->info, info_new);
 		route_unlock_node(ern); /* undo lock in route_note_match */
 	} else {
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
+
 		prefix2str(&vn_prefix, buf, sizeof(buf));
-		buf[BUFSIZ - 1] = 0;
 		/* Not a big deal, just means VPN route got here first */
 		vnc_zlog_debug_verbose("%s: no encap route for vn addr %s",
 				       __func__, buf);
@@ -4433,10 +4430,10 @@ static void rfapiDeleteRemotePrefixesIt(
 
 #if DEBUG_L2_EXTRA
 	{
-		char buf_pfx[BUFSIZ];
+		char buf_pfx[PREFIX_STRLEN];
 
 		if (p) {
-			prefix2str(p, buf_pfx, BUFSIZ);
+			prefix2str(p, buf_pfx, sizeof(buf_pfx));
 		} else {
 			buf_pfx[0] = '*';
 			buf_pfx[1] = 0;
@@ -4469,11 +4466,11 @@ static void rfapiDeleteRemotePrefixesIt(
 			struct bgp_info *next;
 
 			if (VNC_DEBUG(IMPORT_DEL_REMOTE)) {
-				char p1line[BUFSIZ];
-				char p2line[BUFSIZ];
+				char p1line[PREFIX_STRLEN];
+				char p2line[PREFIX_STRLEN];
 
-				prefix2str(p, p1line, BUFSIZ);
-				prefix2str(&rn->p, p2line, BUFSIZ);
+				prefix2str(p, p1line, sizeof(p1line));
+				prefix2str(&rn->p, p2line, sizeof(p2line));
 				vnc_zlog_debug_any("%s: want %s, have %s",
 						   __func__, p1line, p2line);
 			}
@@ -4482,8 +4479,9 @@ static void rfapiDeleteRemotePrefixesIt(
 				continue;
 
 			{
-				char buf_pfx[BUFSIZ];
-				prefix2str(&rn->p, buf_pfx, BUFSIZ);
+				char buf_pfx[PREFIX_STRLEN];
+
+				prefix2str(&rn->p, buf_pfx, sizeof(buf_pfx));
 				vnc_zlog_debug_verbose("%s: rn pfx=%s",
 						       __func__, buf_pfx);
 			}

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -839,7 +839,7 @@ void rfapiMonitorItNodeChanged(
 	struct bgp *bgp = bgp_get_default();
 	afi_t afi = family2afi(rn->p.family);
 #if DEBUG_L2_EXTRA
-	char buf_prefix[BUFSIZ];
+	char buf_prefix[PREFIX_STRLEN];
 #endif
 
 	assert(bgp);
@@ -848,7 +848,7 @@ void rfapiMonitorItNodeChanged(
 	nves_seen = skiplist_new(0, NULL, NULL);
 
 #if DEBUG_L2_EXTRA
-	prefix2str(&it_node->p, buf_prefix, BUFSIZ);
+	prefix2str(&it_node->p, buf_prefix, sizeof(buf_prefix));
 	vnc_zlog_debug_verbose("%s: it=%p, it_node=%p, it_node->prefix=%s",
 			       __func__, import_table, it_node, buf_prefix);
 #endif
@@ -926,22 +926,20 @@ void rfapiMonitorItNodeChanged(
 					assert(!skiplist_insert(nves_seen,
 								m->rfd, NULL));
 
-					{
-						char buf_attach_pfx[BUFSIZ];
-						char buf_target_pfx[BUFSIZ];
+					char buf_attach_pfx[PREFIX_STRLEN];
+					char buf_target_pfx[PREFIX_STRLEN];
 
-						prefix2str(&m->node->p,
-							   buf_attach_pfx,
-							   BUFSIZ);
-						prefix2str(&m->p,
-							   buf_target_pfx,
-							   BUFSIZ);
-						vnc_zlog_debug_verbose(
-							"%s: update rfd %p attached to pfx %s (targ=%s)",
-							__func__, m->rfd,
-							buf_attach_pfx,
-							buf_target_pfx);
-					}
+					prefix2str(&m->node->p,
+						   buf_attach_pfx,
+						   sizeof(buf_attach_pfx));
+					prefix2str(&m->p,
+						   buf_target_pfx,
+						   sizeof(buf_target_pfx));
+					vnc_zlog_debug_verbose(
+						"%s: update rfd %p attached to pfx %s (targ=%s)",
+						__func__, m->rfd,
+						buf_attach_pfx,
+						buf_target_pfx);
 
 					/*
 					 * update its RIB
@@ -1271,8 +1269,9 @@ static void rfapiMonitorEthDetachImport(
 	assert(rn);
 
 #if DEBUG_L2_EXTRA
-	char buf_prefix[BUFSIZ];
-	prefix2str(&rn->p, buf_prefix, BUFSIZ);
+	char buf_prefix[PREFIX_STRLEN];
+
+	prefix2str(&rn->p, buf_prefix, sizeof(buf_prefix));
 #endif
 
 	/*

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -342,7 +342,7 @@ rfapiRibStartTimer(struct rfapi_descriptor *rfd, struct rfapi_info *ri,
 {
 	struct thread *t = ri->timer;
 	struct rfapi_rib_tcb *tcb = NULL;
-	char buf_prefix[BUFSIZ];
+	char buf_prefix[PREFIX_STRLEN];
 
 	if (t) {
 		tcb = t->arg;
@@ -363,7 +363,7 @@ rfapiRibStartTimer(struct rfapi_descriptor *rfd, struct rfapi_info *ri,
 		UNSET_FLAG(tcb->flags, RFAPI_RIB_TCB_FLAG_DELETED);
 	}
 
-	prefix2str(&rn->p, buf_prefix, BUFSIZ);
+	prefix2str(&rn->p, buf_prefix, sizeof(buf_prefix));
 	vnc_zlog_debug_verbose("%s: rfd %p pfx %s life %u", __func__, rfd,
 			       buf_prefix, ri->lifetime);
 	ri->timer = NULL;
@@ -852,7 +852,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 	struct list *lPendCost = NULL;
 	struct list *delete_list = NULL;
 	int printedprefix = 0;
-	char buf_prefix[BUFSIZ];
+	char buf_prefix[PREFIX_STRLEN];
 	int rib_node_started_nonempty = 0;
 	int sendingsomeroutes = 0;
 
@@ -863,7 +863,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 #endif
 
 	assert(pn);
-	prefix2str(&pn->p, buf_prefix, BUFSIZ);
+	prefix2str(&pn->p, buf_prefix, sizeof(buf_prefix));
 	vnc_zlog_debug_verbose("%s: afi=%d, %s pn->info=%p", __func__, afi,
 			       buf_prefix, pn->info);
 
@@ -913,8 +913,8 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 			while (0
 			       == skiplist_first(slRibPt, NULL, (void **)&ri)) {
 
-				char buf[BUFSIZ];
-				char buf2[BUFSIZ];
+				char buf[PREFIX_STRLEN];
+				char buf2[PREFIX_STRLEN];
 
 				listnode_add(delete_list, ri);
 				vnc_zlog_debug_verbose(
@@ -932,8 +932,8 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 					ri->timer = NULL;
 				}
 
-				prefix2str(&ri->rk.vn, buf, BUFSIZ);
-				prefix2str(&ri->un, buf2, BUFSIZ);
+				prefix2str(&ri->rk.vn, buf, sizeof(buf));
+				prefix2str(&ri->un, buf2, sizeof(buf2));
 				vnc_zlog_debug_verbose(
 					"%s:   put dl pfx=%s vn=%s un=%s cost=%d life=%d vn_options=%p",
 					__func__, buf_prefix, buf, buf2,
@@ -1592,7 +1592,7 @@ void rfapiRibUpdatePendingNode(
 	afi_t afi;
 	uint32_t queued_flag;
 	int count = 0;
-	char buf[BUFSIZ];
+	char buf[PREFIX_STRLEN];
 
 	vnc_zlog_debug_verbose("%s: entry", __func__);
 
@@ -1605,7 +1605,7 @@ void rfapiRibUpdatePendingNode(
 
 	prefix = &it_node->p;
 	afi = family2afi(prefix->family);
-	prefix2str(prefix, buf, BUFSIZ);
+	prefix2str(prefix, buf, sizeof(buf));
 	vnc_zlog_debug_verbose("%s: prefix=%s", __func__, buf);
 
 	pn = route_node_get(rfd->rib_pending[afi], prefix);
@@ -1811,9 +1811,9 @@ int rfapiRibFTDFilterRecentPrefix(
 
 #if DEBUG_FTD_FILTER_RECENT
 	{
-		char buf_pfx[BUFSIZ];
+		char buf_pfx[PREFIX_STRLEN];
 
-		prefix2str(&it_rn->p, buf_pfx, BUFSIZ);
+		prefix2str(&it_rn->p, buf_pfx, sizeof(buf_pfx));
 		vnc_zlog_debug_verbose("%s: prefix %s", __func__, buf_pfx);
 	}
 #endif
@@ -1975,14 +1975,15 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 
 #if DEBUG_NHL
 		{
-			char str_vn[BUFSIZ];
-			char str_aux_prefix[BUFSIZ];
+			char str_vn[PREFIX_STRLEN];
+			char str_aux_prefix[PREFIX_STRLEN];
 
 			str_vn[0] = 0;
 			str_aux_prefix[0] = 0;
 
-			prefix2str(&rk.vn, str_vn, BUFSIZ);
-			prefix2str(&rk.aux_prefix, str_aux_prefix, BUFSIZ);
+			prefix2str(&rk.vn, str_vn, sizeof(str_vn));
+			prefix2str(&rk.aux_prefix, str_aux_prefix,
+				   sizeof(str_aux_prefix));
 
 			if (!rk.aux_prefix.family) {
 			}
@@ -2072,11 +2073,11 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 			route_unlock_node(trn);
 
 		{
-			char str_pfx[BUFSIZ];
-			char str_pfx_vn[BUFSIZ];
+			char str_pfx[PREFIX_STRLEN];
+			char str_pfx_vn[PREFIX_STRLEN];
 
-			prefix2str(&pfx, str_pfx, BUFSIZ);
-			prefix2str(&rk.vn, str_pfx_vn, BUFSIZ);
+			prefix2str(&pfx, str_pfx, sizeof(str_pfx));
+			prefix2str(&rk.vn, str_pfx_vn, sizeof(str_pfx_vn));
 			vnc_zlog_debug_verbose(
 				"%s:   added pfx=%s nh[vn]=%s, cost=%u, lifetime=%u, allowed=%d",
 				__func__, str_pfx, str_pfx_vn, nhp->prefix.cost,
@@ -2111,9 +2112,9 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 {
 	struct rfapi_descriptor *rfd;
 	struct listnode *node;
-	char buf[BUFSIZ];
+	char buf[PREFIX_STRLEN];
 
-	prefix2str(&it_node->p, buf, BUFSIZ);
+	prefix2str(&it_node->p, buf, sizeof(buf));
 	vnc_zlog_debug_verbose("%s: entry, it=%p, afi=%d, it_node=%p, pfx=%s",
 			       __func__, it, afi, it_node, buf);
 
@@ -2287,8 +2288,8 @@ static int print_rib_sl(int (*fp)(void *, const char *, ...), struct vty *vty,
 	for (rc = skiplist_next(sl, NULL, (void **)&ri, &cursor); !rc;
 	     rc = skiplist_next(sl, NULL, (void **)&ri, &cursor)) {
 
-		char str_vn[BUFSIZ];
-		char str_un[BUFSIZ];
+		char str_vn[PREFIX_STRLEN];
+		char str_un[PREFIX_STRLEN];
 		char str_lifetime[BUFSIZ];
 		char str_age[BUFSIZ];
 		char *p;
@@ -2296,12 +2297,12 @@ static int print_rib_sl(int (*fp)(void *, const char *, ...), struct vty *vty,
 
 		++routes_displayed;
 
-		prefix2str(&ri->rk.vn, str_vn, BUFSIZ);
+		prefix2str(&ri->rk.vn, str_vn, sizeof(str_vn));
 		p = index(str_vn, '/');
 		if (p)
 			*p = 0;
 
-		prefix2str(&ri->un, str_un, BUFSIZ);
+		prefix2str(&ri->un, str_un, sizeof(str_un));
 		p = index(str_un, '/');
 		if (p)
 			*p = 0;
@@ -2349,13 +2350,13 @@ static void rfapiRibShowRibSl(void *stream, struct prefix *pfx,
 	const char *vty_newline;
 
 	int nhs_displayed = 0;
-	char str_pfx[BUFSIZ];
+	char str_pfx[PREFIX_STRLEN];
 	int printedprefix = 0;
 
 	if (rfapiStream2Vty(stream, &fp, &vty, &out, &vty_newline) == 0)
 		return;
 
-	prefix2str(pfx, str_pfx, BUFSIZ);
+	prefix2str(pfx, str_pfx, sizeof(str_pfx));
 
 	nhs_displayed +=
 		print_rib_sl(fp, vty, out, sl, 0, str_pfx, &printedprefix);
@@ -2415,7 +2416,7 @@ void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 			     rn = route_next(rn)) {
 
 				struct skiplist *sl;
-				char str_pfx[BUFSIZ];
+				char str_pfx[PREFIX_STRLEN];
 				int printedprefix = 0;
 
 				if (!show_removed)
@@ -2469,7 +2470,7 @@ void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 								str_un,
 								BUFSIZ));
 				}
-				prefix2str(&rn->p, str_pfx, BUFSIZ);
+				prefix2str(&rn->p, str_pfx, sizeof(str_pfx));
 				// fp(out, "  %s\n", buf);  /* prefix */
 
 				routes_displayed++;

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -1123,7 +1123,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 
 			} else {
 
-				char buf_rd[BUFSIZ];
+				char buf_rd[RD_ADDRSTRLEN];
 
 				/* not found: add new route to RIB */
 				ori = rfapi_info_new();
@@ -1402,13 +1402,14 @@ callback:
 					ri->last_sent_time = rfapi_time(NULL);
 #if DEBUG_RIB_SL_RD
 					{
-						char buf_rd[BUFSIZ];
-						prefix_rd2str(&ri->rk.rd,
-							      buf_rd,
-							      sizeof(buf_rd));
+						char buf_rd[RD_ADDRSTRLEN];
+
 						vnc_zlog_debug_verbose(
 							"%s: move route to recently deleted list, rd=%s",
-							__func__, buf_rd);
+							__func__,
+							prefix_rd2str(&ri->rk.rd,
+								      buf_rd,
+								      sizeof(buf_rd)));
 					}
 #endif
 
@@ -2293,7 +2294,7 @@ static int print_rib_sl(int (*fp)(void *, const char *, ...), struct vty *vty,
 		char str_lifetime[BUFSIZ];
 		char str_age[BUFSIZ];
 		char *p;
-		char str_rd[BUFSIZ];
+		char str_rd[RD_ADDRSTRLEN];
 
 		++routes_displayed;
 
@@ -2323,11 +2324,10 @@ static int print_rib_sl(int (*fp)(void *, const char *, ...), struct vty *vty,
 
 		str_rd[0] = 0; /* start empty */
 #if DEBUG_RIB_SL_RD
-		str_rd[0] = ' ';
-		prefix_rd2str(&ri->rk.rd, str_rd + 1, BUFSIZ - 1);
+		prefix_rd2str(&ri->rk.rd, str_rd, sizeof(str_rd));
 #endif
 
-		fp(out, " %c %-20s %-15s %-15s %-4u %-8s %-8s%s\n",
+		fp(out, " %c %-20s %-15s %-15s %-4u %-8s %-8s %s\n",
 		   deleted ? 'r' : ' ', *printedprefix ? "" : str_pfx, str_vn,
 		   str_un, ri->cost, str_lifetime, str_age, str_rd);
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1599,7 +1599,7 @@ void rfapiPrintDescriptor(struct vty *vty, struct rfapi_descriptor *rfd)
 	int rc;
 	afi_t afi;
 	struct rfapi_adb *adb;
-	char buf[BUFSIZ];
+	char buf[PREFIX_STRLEN];
 
 	vty_out(vty, "%-10p ", rfd);
 	rfapiPrintRfapiIpAddr(vty, &rfd->un_addr);
@@ -1651,8 +1651,7 @@ void rfapiPrintDescriptor(struct vty *vty, struct rfapi_descriptor *rfd)
 			if (family != adb->u.s.prefix_ip.family)
 				continue;
 
-			prefix2str(&adb->u.s.prefix_ip, buf, BUFSIZ);
-			buf[BUFSIZ - 1] = 0; /* guarantee NUL-terminated */
+			prefix2str(&adb->u.s.prefix_ip, buf, sizeof(buf));
 
 			vty_out(vty, "  Adv Pfx: %s%s", buf, HVTYNL);
 			rfapiPrintAdvertisedInfo(vty, rfd, SAFI_MPLS_VPN,
@@ -1664,8 +1663,7 @@ void rfapiPrintDescriptor(struct vty *vty, struct rfapi_descriptor *rfd)
 	     rc == 0; rc = skiplist_next(rfd->advertised.ip0_by_ether, NULL,
 					 (void **)&adb, &cursor)) {
 
-		prefix2str(&adb->u.s.prefix_eth, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0; /* guarantee NUL-terminated */
+		prefix2str(&adb->u.s.prefix_eth, buf, sizeof(buf));
 
 		vty_out(vty, "  Adv Pfx: %s%s", buf, HVTYNL);
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1527,11 +1527,9 @@ void rfapiPrintRfapiIpPrefix(void *stream, struct rfapi_ip_prefix *p)
 
 void rfapiPrintRd(struct vty *vty, struct prefix_rd *prd)
 {
-	char buf[BUFSIZ];
+	char buf[RD_ADDRSTRLEN];
 
-	buf[0] = 0;
 	prefix_rd2str(prd, buf, BUFSIZ);
-	buf[BUFSIZ - 1] = 0;
 	vty_out(vty, "%s", buf);
 }
 

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -437,14 +437,11 @@ static void vnc_direct_bgp_vpn_enable_ce(struct bgp *bgp, afi_t afi)
 			continue;
 
 		{
-			char prefixstr[BUFSIZ];
+			char prefixstr[PREFIX_STRLEN];
 
-			prefixstr[0] = 0;
-			inet_ntop(rn->p.family, &rn->p.u.prefix, prefixstr,
-				  BUFSIZ);
-			vnc_zlog_debug_verbose("%s: checking prefix %s/%d",
-					       __func__, prefixstr,
-					       rn->p.prefixlen);
+			prefix2str(&rn->p, prefixstr, sizeof(prefixstr));
+			vnc_zlog_debug_verbose("%s: checking prefix %s",
+					       __func__, prefixstr);
 		}
 
 		for (ri = rn->info; ri; ri = ri->next) {
@@ -1856,14 +1853,13 @@ void vnc_direct_bgp_rh_vpn_enable(struct bgp *bgp, afi_t afi)
 				continue;
 
 			{
-				char prefixstr[BUFSIZ];
+				char prefixstr[PREFIX_STRLEN];
 
-				prefixstr[0] = 0;
-				inet_ntop(rn->p.family, &rn->p.u.prefix,
-					  prefixstr, BUFSIZ);
+				prefix2str(&rn->p, prefixstr,
+					   sizeof(prefixstr));
 				vnc_zlog_debug_verbose(
-					"%s: checking prefix %s/%d", __func__,
-					prefixstr, rn->p.prefixlen);
+					"%s: checking prefix %s", __func__,
+					prefixstr);
 			}
 
 			/*

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -205,15 +205,15 @@ static void print_rhn_list(const char *tag1, const char *tag2)
 
 	/* XXX uses secret knowledge of skiplist structure */
 	for (p = sl->header->forward[0]; p; p = p->forward[0]) {
-		char kbuf[BUFSIZ];
-		char hbuf[BUFSIZ];
-		char ubuf[BUFSIZ];
+		char kbuf[PREFIX_STRLEN];
+		char hbuf[PREFIX_STRLEN];
+		char ubuf[PREFIX_STRLEN];
 
 		pb = p->value;
 
-		prefix2str(p->key, kbuf, BUFSIZ);
-		prefix2str(&pb->hpfx, hbuf, BUFSIZ);
-		prefix2str(&pb->upfx, ubuf, BUFSIZ);
+		prefix2str(p->key, kbuf, sizeof(kbuf));
+		prefix2str(&pb->hpfx, hbuf, sizeof(hbuf));
+		prefix2str(&pb->upfx, ubuf, sizeof(ubuf));
 
 		vnc_zlog_debug_verbose(
 			"RHN Entry %d (q=%p): kpfx=%s, upfx=%s, hpfx=%s, ubi=%p",
@@ -259,14 +259,11 @@ static void vnc_rhnck(char *tag)
 		 * pfx */
 		assert(!vnc_prefix_cmp(&pb->hpfx, pkey));
 		if (vnc_prefix_cmp(&pb->hpfx, &pfx_orig_nexthop)) {
-			char str_onh[BUFSIZ];
-			char str_nve_pfx[BUFSIZ];
+			char str_onh[PREFIX_STRLEN];
+			char str_nve_pfx[PREFIX_STRLEN];
 
-			prefix2str(&pfx_orig_nexthop, str_onh, BUFSIZ);
-			str_onh[BUFSIZ - 1] = 0;
-
-			prefix2str(&pb->hpfx, str_nve_pfx, BUFSIZ);
-			str_nve_pfx[BUFSIZ - 1] = 0;
+			prefix2str(&pfx_orig_nexthop, str_onh, sizeof(str_onh));
+			prefix2str(&pb->hpfx, str_nve_pfx, sizeof(str_nve_pfx));
 
 			vnc_zlog_debug_verbose(
 				"%s: %s: FATAL: resolve_nve_nexthop list item bi nexthop %s != nve pfx %s",
@@ -529,10 +526,9 @@ static void vnc_import_bgp_add_route_mode_resolve_nve_one_rd(
 		return;
 
 	{
-		char str_nh[BUFSIZ];
+		char str_nh[PREFIX_STRLEN];
 
-		prefix2str(ubi_nexthop, str_nh, BUFSIZ);
-		str_nh[BUFSIZ - 1] = 0;
+		prefix2str(ubi_nexthop, str_nh, sizeof(str_nh));
 
 		vnc_zlog_debug_verbose("%s: ubi_nexthop=%s", __func__, str_nh);
 	}
@@ -574,18 +570,16 @@ static void vnc_import_bgp_add_route_mode_resolve_nve(
 
 	/*debugging */
 	if (VNC_DEBUG(VERBOSE)) {
-		char str_pfx[BUFSIZ];
-		char str_nh[BUFSIZ];
+		char str_pfx[PREFIX_STRLEN];
+		char str_nh[PREFIX_STRLEN];
 		struct prefix nh;
 
-		prefix2str(prefix, str_pfx, BUFSIZ);
-		str_pfx[BUFSIZ - 1] = 0;
+		prefix2str(prefix, str_pfx, sizeof(str_pfx));
 
 		nh.prefixlen = 0;
 		rfapiUnicastNexthop2Prefix(afi, info->attr, &nh);
 		if (nh.prefixlen) {
-			prefix2str(&nh, str_nh, BUFSIZ);
-			str_nh[BUFSIZ - 1] = 0;
+			prefix2str(&nh, str_nh, sizeof(str_nh));
 		} else {
 			str_nh[0] = '?';
 			str_nh[1] = 0;
@@ -718,11 +712,9 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 	uint32_t *med = NULL;
 
 	{
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		buf[0] = 0;
-		prefix2str(prefix, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0;
+		prefix2str(prefix, buf, sizeof(buf));
 		vnc_zlog_debug_verbose("%s(prefix=%s) entry", __func__, buf);
 	}
 
@@ -789,11 +781,9 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 	}
 
 	if (VNC_DEBUG(IMPORT_BGP_ADD_ROUTE)) {
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		buf[0] = 0;
-		prefix2str(vn_pfx, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0;
+		prefix2str(vn_pfx, buf, sizeof(buf));
 		vnc_zlog_debug_any("%s vn_pfx=%s", __func__, buf);
 	}
 
@@ -867,11 +857,9 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 	}
 
 	if (VNC_DEBUG(IMPORT_BGP_ADD_ROUTE)) {
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		buf[0] = 0;
-		rfapiRfapiIpAddr2Str(&vnaddr, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0;
+		rfapiRfapiIpAddr2Str(&vnaddr, buf, sizeof(buf));
 		vnc_zlog_debug_any("%s: setting vnaddr to %s", __func__, buf);
 	}
 
@@ -910,11 +898,9 @@ vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
 	uint32_t local_pref;
 
 	{
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		buf[0] = 0;
-		prefix2str(prefix, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0;
+		prefix2str(prefix, buf, sizeof(buf));
 		vnc_zlog_debug_verbose("%s(prefix=%s) entry", __func__, buf);
 	}
 
@@ -997,11 +983,9 @@ vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
 	}
 
 	if (VNC_DEBUG(IMPORT_BGP_ADD_ROUTE)) {
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 
-		buf[0] = 0;
-		prefix2str(vn_pfx, buf, BUFSIZ);
-		buf[BUFSIZ - 1] = 0;
+		prefix2str(vn_pfx, buf, sizeof(buf));
 		vnc_zlog_debug_any("%s vn_pfx=%s", __func__, buf);
 	}
 
@@ -1298,11 +1282,9 @@ static void vnc_import_bgp_del_route_mode_resolve_nve_one_rd(
 		return;
 
 	{
-		char str_nh[BUFSIZ];
+		char str_nh[PREFIX_STRLEN];
 
-		prefix2str(ubi_nexthop, str_nh, BUFSIZ);
-		str_nh[BUFSIZ - 1] = 0;
-
+		prefix2str(ubi_nexthop, str_nh, sizeof(str_nh));
 		vnc_zlog_debug_verbose("%s: ubi_nexthop=%s", __func__, str_nh);
 	}
 
@@ -1478,11 +1460,11 @@ void vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
 		       sizeof(struct prefix)); /* keep valgrind happy */
 
 		if (VNC_DEBUG(IMPORT_BGP_ADD_ROUTE)) {
-			char hbuf[BUFSIZ];
-			char ubuf[BUFSIZ];
+			char hbuf[PREFIX_STRLEN];
+			char ubuf[PREFIX_STRLEN];
 
-			prefix2str(&pb->hpfx, hbuf, BUFSIZ);
-			prefix2str(&pb->upfx, ubuf, BUFSIZ);
+			prefix2str(&pb->hpfx, hbuf, sizeof(hbuf));
+			prefix2str(&pb->upfx, ubuf, sizeof(ubuf));
 
 			vnc_zlog_debug_any(
 				"%s: examining RHN Entry (q=%p): upfx=%s, hpfx=%s, ubi=%p",
@@ -1510,14 +1492,12 @@ void vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
 		 * Sanity check
 		 */
 		if (vnc_prefix_cmp(&pfx_unicast_nexthop, prefix)) {
-			char str_unh[BUFSIZ];
-			char str_nve_pfx[BUFSIZ];
+			char str_unh[PREFIX_STRLEN];
+			char str_nve_pfx[PREFIX_STRLEN];
 
-			prefix2str(&pfx_unicast_nexthop, str_unh, BUFSIZ);
-			str_unh[BUFSIZ - 1] = 0;
-
-			prefix2str(prefix, str_nve_pfx, BUFSIZ);
-			str_nve_pfx[BUFSIZ - 1] = 0;
+			prefix2str(&pfx_unicast_nexthop, str_unh,
+				   sizeof(str_unh));
+			prefix2str(prefix, str_nve_pfx, sizeof(str_nve_pfx));
 
 			vnc_zlog_debug_verbose(
 				"%s: FATAL: resolve_nve_nexthop list item bi nexthop %s != nve pfx %s",
@@ -1536,9 +1516,9 @@ void vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
 #if DEBUG_RHN_LIST
 		/* debug */
 		{
-			char pbuf[BUFSIZ];
+			char pbuf[PREFIX_STRLEN];
 
-			prefix2str(prefix, pbuf, BUFSIZ);
+			prefix2str(prefix, pbuf, sizeof(pbuf));
 
 			vnc_zlog_debug_verbose(
 				"%s: advancing past RHN Entry (q=%p): with prefix %s",
@@ -1566,10 +1546,9 @@ void vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
 	int rc;
 
 	{
-		char str_pfx[BUFSIZ];
+		char str_pfx[PREFIX_STRLEN];
 
-		prefix2str(prefix, str_pfx, BUFSIZ);
-		str_pfx[BUFSIZ - 1] = 0;
+		prefix2str(prefix, str_pfx, sizeof(str_pfx));
 
 		vnc_zlog_debug_verbose("%s(bgp=%p, nve prefix=%s)", __func__,
 				       bgp, str_pfx);
@@ -1637,14 +1616,12 @@ void vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
 		 * Sanity check
 		 */
 		if (vnc_prefix_cmp(&pfx_unicast_nexthop, prefix)) {
-			char str_unh[BUFSIZ];
-			char str_nve_pfx[BUFSIZ];
+			char str_unh[PREFIX_STRLEN];
+			char str_nve_pfx[PREFIX_STRLEN];
 
-			prefix2str(&pfx_unicast_nexthop, str_unh, BUFSIZ);
-			str_unh[BUFSIZ - 1] = 0;
-
-			prefix2str(prefix, str_nve_pfx, BUFSIZ);
-			str_nve_pfx[BUFSIZ - 1] = 0;
+			prefix2str(&pfx_unicast_nexthop, str_unh,
+				   sizeof(str_unh));
+			prefix2str(prefix, str_nve_pfx, sizeof(str_nve_pfx));
 
 			vnc_zlog_debug_verbose(
 				"%s: FATAL: resolve_nve_nexthop list item bi nexthop %s != nve pfx %s",
@@ -2093,11 +2070,9 @@ void vnc_import_bgp_exterior_add_route_interior(
 
 	/*debugging */
 	{
-		char str_pfx[BUFSIZ];
+		char str_pfx[PREFIX_STRLEN];
 
-		prefix2str(&rn_interior->p, str_pfx, BUFSIZ);
-		str_pfx[BUFSIZ - 1] = 0;
-
+		prefix2str(&rn_interior->p, str_pfx, sizeof(str_pfx));
 		vnc_zlog_debug_verbose("%s: interior prefix=%s, bi type=%d",
 				       __func__, str_pfx, bi_interior->type);
 	}
@@ -2338,11 +2313,10 @@ void vnc_import_bgp_exterior_add_route_interior(
 				     (void **)&pfx_exterior, &cursor)) {
 
 		struct prefix pfx_nexthop;
-		char buf[BUFSIZ];
+		char buf[PREFIX_STRLEN];
 		afi_t afi_exterior = family2afi(pfx_exterior->family);
 
 		prefix2str(pfx_exterior, buf, sizeof(buf));
-		buf[sizeof(buf) - 1] = 0;
 		vnc_zlog_debug_verbose(
 			"%s: checking exterior orphan at prefix %s", __func__,
 			buf);
@@ -2481,10 +2455,9 @@ void vnc_import_bgp_exterior_del_route_interior(
 
 	/*debugging */
 	{
-		char str_pfx[BUFSIZ];
+		char str_pfx[PREFIX_STRLEN];
 
-		prefix2str(&rn_interior->p, str_pfx, BUFSIZ);
-		str_pfx[BUFSIZ - 1] = 0;
+		prefix2str(&rn_interior->p, str_pfx, sizeof(str_pfx));
 
 		vnc_zlog_debug_verbose("%s: interior prefix=%s, bi type=%d",
 				       __func__, str_pfx, bi_interior->type);
@@ -2640,12 +2613,12 @@ void vnc_import_bgp_add_route(struct bgp *bgp, struct prefix *prefix,
 
 	if (VNC_DEBUG(VERBOSE)) {
 		struct prefix pfx_nexthop;
-		char buf[BUFSIZ];
-		char buf_nh[BUFSIZ];
+		char buf[PREFIX_STRLEN];
+		char buf_nh[PREFIX_STRLEN];
 
-		prefix2str(prefix, buf, BUFSIZ);
+		prefix2str(prefix, buf, sizeof(buf));
 		rfapiUnicastNexthop2Prefix(afi, info->attr, &pfx_nexthop);
-		prefix2str(&pfx_nexthop, buf_nh, BUFSIZ);
+		prefix2str(&pfx_nexthop, buf_nh, sizeof(buf_nh));
 
 		vnc_zlog_debug_verbose("%s: pfx %s, nh %s", __func__, buf,
 				       buf_nh);
@@ -2710,12 +2683,12 @@ void vnc_import_bgp_del_route(struct bgp *bgp, struct prefix *prefix,
 
 	{
 		struct prefix pfx_nexthop;
-		char buf[BUFSIZ];
-		char buf_nh[BUFSIZ];
+		char buf[PREFIX_STRLEN];
+		char buf_nh[PREFIX_STRLEN];
 
-		prefix2str(prefix, buf, BUFSIZ);
+		prefix2str(prefix, buf, sizeof(buf));
 		rfapiUnicastNexthop2Prefix(afi, info->attr, &pfx_nexthop);
-		prefix2str(&pfx_nexthop, buf_nh, BUFSIZ);
+		prefix2str(&pfx_nexthop, buf_nh, sizeof(buf_nh));
 
 		vnc_zlog_debug_verbose("%s: pfx %s, nh %s", __func__, buf,
 				       buf_nh);

--- a/eigrpd/eigrp_reply.c
+++ b/eigrpd/eigrp_reply.c
@@ -170,9 +170,11 @@ void eigrp_reply_receive(struct eigrp *eigrp, struct ip *iph,
 		 */
 		if (!dest) {
 			char buf[PREFIX_STRLEN];
+
 			zlog_err("%s: Received prefix %s which we do not know about",
 				 __PRETTY_FUNCTION__,
-				 prefix2str(&dest_addr, buf, strlen(buf)));
+				 prefix2str(&dest_addr, buf, sizeof(buf)));
+			eigrp_IPv4_InternalTLV_free(tlv);
 			continue;
 		}
 


### PR DESCRIPTION
1) BGP is using BUFSIZ for prefix2str input.  Let's switch it up to PREFIX_STRLEN to make the code consistent.

2) EIGRP can crash and or leak some memory in some cases.

3) BGP may cause an out of bounds read, especially if code changes in the future.