### PR TITLE
zebra: do not display ipv6 ra commands created by bgpd

### DIFF
--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -170,7 +170,12 @@ struct rtadvconf {
 #define RTADV_PREF_MEDIUM 0x0 /* Per RFC4191. */
 
 	u_char inFastRexmit; /* True if we're rexmits faster than usual */
-	u_char configured;   /* Has operator configured RA? */
+
+	/* Track if RA was configured by BGP or by the Operator or both */
+	u_char ra_configured;     /* Was RA configured? */
+#define BGP_RA_CONFIGURED (1<<0)  /* BGP configured RA? */
+#define VTY_RA_CONFIGURED (1<<1)  /* Operator configured RA? */
+#define VTY_RA_INTERVAL_CONFIGURED (1<<2)  /* Operator configured RA interval */
 	int
 		NumFastReXmitsRemain; /* Loaded first with number of fast
 					 rexmits to do */


### PR DESCRIPTION
If the frr.conf file contains bgp unnumbered peering but the associated
interfaces do not have the commands "no ipv6 nd suppress-ra" and
"ipv6 nd ra-interval 10" configured, when frr-reload.py is issued the
interface commands are removed from the running config, causing peers to
go down and stay down after a link flap.  This situation can occur if
the frr.conf file is created manually or via automation (like ansible)
but a subsequent "wr mem" has not been performed.

This fix changes the behavior so that the interface ipv6 nd ra commands
created by bgp are not displayed.  Therefore, when the above condition
occurs, there is no difference between the running and stored configs
and peers work fine.  Manually configured values continue to be displayed.

Ticket: CM-18702
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Reviewed-by: CCR-7004
Testing-done:  Manual testing successful.  L3-smoke has no new failures