### PR TITLE
ldpd: Switch over to new debug style

### DIFF
--- a/ldpd/ldp_debug.c
+++ b/ldpd/ldp_debug.c
@@ -47,58 +47,58 @@ ldp_vty_debug(struct vty *vty, const char *negate, const char *type_str,
 
 		if (dir_str[0] == 'r') {
 			if (negate)
-				DEBUG_OFF(hello, HELLO_RECV);
+				DEBUG_OFF(hello, LDP_DEBUG_HELLO_RECV);
 			else
-				DEBUG_ON(hello, HELLO_RECV);
+				DEBUG_ON(hello, LDP_DEBUG_HELLO_RECV);
 		} else {
 			if (negate)
-				DEBUG_OFF(hello, HELLO_SEND);
+				DEBUG_OFF(hello, LDP_DEBUG_HELLO_SEND);
 			else
-				DEBUG_ON(hello, HELLO_SEND);
+				DEBUG_ON(hello, LDP_DEBUG_HELLO_SEND);
 		}
 	} else if (strcmp(type_str, "errors") == 0) {
 		if (negate)
-			DEBUG_OFF(errors, ERRORS);
+			DEBUG_OFF(errors, LDP_DEBUG_ERRORS);
 		else
-			DEBUG_ON(errors, ERRORS);
+			DEBUG_ON(errors, LDP_DEBUG_ERRORS);
 	} else if (strcmp(type_str, "event") == 0) {
 		if (negate)
-			DEBUG_OFF(event, EVENT);
+			DEBUG_OFF(event, LDP_DEBUG_EVENT);
 		else
-			DEBUG_ON(event, EVENT);
+			DEBUG_ON(event, LDP_DEBUG_EVENT);
 	} else if (strcmp(type_str, "labels") == 0) {
 		if (negate)
-			DEBUG_OFF(labels, LABELS);
+			DEBUG_OFF(labels, LDP_DEBUG_LABELS);
 		else
-			DEBUG_ON(labels, LABELS);
+			DEBUG_ON(labels, LDP_DEBUG_LABELS);
 	} else if (strcmp(type_str, "messages") == 0) {
 		if (dir_str == NULL)
 			return (CMD_WARNING_CONFIG_FAILED);
 
 		if (dir_str[0] == 'r') {
 			if (negate) {
-				DEBUG_OFF(msg, MSG_RECV);
-				DEBUG_OFF(msg, MSG_RECV_ALL);
+				DEBUG_OFF(msg, LDP_DEBUG_MSG_RECV);
+				DEBUG_OFF(msg, LDP_DEBUG_MSG_RECV_ALL);
 			} else {
-				DEBUG_ON(msg, MSG_RECV);
+				DEBUG_ON(msg, LDP_DEBUG_MSG_RECV);
 				if (all)
-					DEBUG_ON(msg, MSG_RECV_ALL);
+					DEBUG_ON(msg, LDP_DEBUG_MSG_RECV_ALL);
 			}
 		} else {
 			if (negate) {
-				DEBUG_OFF(msg, MSG_SEND);
-				DEBUG_OFF(msg, MSG_SEND_ALL);
+				DEBUG_OFF(msg, LDP_DEBUG_MSG_SEND);
+				DEBUG_OFF(msg, LDP_DEBUG_MSG_SEND_ALL);
 			} else {
-				DEBUG_ON(msg, MSG_SEND);
+				DEBUG_ON(msg, LDP_DEBUG_MSG_SEND);
 				if (all)
-					DEBUG_ON(msg, MSG_SEND_ALL);
+					DEBUG_ON(msg, LDP_DEBUG_MSG_SEND_ALL);
 			}
 		}
 	} else if (strcmp(type_str, "zebra") == 0) {
 		if (negate)
-			DEBUG_OFF(zebra, ZEBRA);
+			DEBUG_OFF(zebra, LDP_DEBUG_ZEBRA);
 		else
-			DEBUG_ON(zebra, ZEBRA);
+			DEBUG_ON(zebra, LDP_DEBUG_ZEBRA);
 	}
 
 	main_imsg_compose_both(IMSG_DEBUG_UPDATE, &ldp_debug,
@@ -112,27 +112,27 @@ ldp_vty_show_debugging(struct vty *vty)
 {
 	vty_out (vty, "LDP debugging status:\n");
 
-	if (LDP_DEBUG(hello, HELLO_RECV))
+	if (LDP_DEBUG(hello, LDP_DEBUG_HELLO_RECV))
 		vty_out (vty,"  LDP discovery debugging is on (inbound)\n");
-	if (LDP_DEBUG(hello, HELLO_SEND))
+	if (LDP_DEBUG(hello, LDP_DEBUG_HELLO_SEND))
 		vty_out (vty,"  LDP discovery debugging is on (outbound)\n");
-	if (LDP_DEBUG(errors, ERRORS))
+	if (LDP_DEBUG(errors, LDP_DEBUG_ERRORS))
 		vty_out (vty, "  LDP errors debugging is on\n");
-	if (LDP_DEBUG(event, EVENT))
+	if (LDP_DEBUG(event, LDP_DEBUG_EVENT))
 		vty_out (vty, "  LDP events debugging is on\n");
-	if (LDP_DEBUG(labels, LABELS))
+	if (LDP_DEBUG(labels, LDP_DEBUG_LABELS))
 		vty_out (vty, "  LDP labels debugging is on\n");
-	if (LDP_DEBUG(msg, MSG_RECV_ALL))
+	if (LDP_DEBUG(msg, LDP_DEBUG_MSG_RECV_ALL))
 		vty_out (vty,
 			  "  LDP detailed messages debugging is on (inbound)\n");
-	else if (LDP_DEBUG(msg, MSG_RECV))
+	else if (LDP_DEBUG(msg, LDP_DEBUG_MSG_RECV))
 		vty_out (vty,"  LDP messages debugging is on (inbound)\n");
-	if (LDP_DEBUG(msg, MSG_SEND_ALL))
+	if (LDP_DEBUG(msg, LDP_DEBUG_MSG_SEND_ALL))
 		vty_out (vty,
 			  "  LDP detailed messages debugging is on (outbound)\n");
-	else if (LDP_DEBUG(msg, MSG_SEND))
+	else if (LDP_DEBUG(msg, LDP_DEBUG_MSG_SEND))
 		vty_out (vty,"  LDP messages debugging is on (outbound)\n");
-	if (LDP_DEBUG(zebra, ZEBRA))
+	if (LDP_DEBUG(zebra, LDP_DEBUG_ZEBRA))
 		vty_out (vty, "  LDP zebra debugging is on\n");
 	vty_out (vty, "\n");
 
@@ -144,48 +144,48 @@ ldp_debug_config_write(struct vty *vty)
 {
 	int write = 0;
 
-	if (CONF_LDP_DEBUG(hello, HELLO_RECV)) {
+	if (CONF_LDP_DEBUG(hello, LDP_DEBUG_HELLO_RECV)) {
 		vty_out (vty,"debug mpls ldp discovery hello recv\n");
 		write = 1;
 	}
 
-	if (CONF_LDP_DEBUG(hello, HELLO_SEND)) {
+	if (CONF_LDP_DEBUG(hello, LDP_DEBUG_HELLO_SEND)) {
 		vty_out (vty,"debug mpls ldp discovery hello sent\n");
 		write = 1;
 	}
 
-	if (CONF_LDP_DEBUG(errors, ERRORS)) {
+	if (CONF_LDP_DEBUG(errors, LDP_DEBUG_ERRORS)) {
 		vty_out (vty, "debug mpls ldp errors\n");
 		write = 1;
 	}
 
-	if (CONF_LDP_DEBUG(event, EVENT)) {
+	if (CONF_LDP_DEBUG(event, LDP_DEBUG_EVENT)) {
 		vty_out (vty, "debug mpls ldp event\n");
 		write = 1;
 	}
 
-	if (CONF_LDP_DEBUG(labels, LABELS)) {
+	if (CONF_LDP_DEBUG(labels, LDP_DEBUG_LABELS)) {
 		vty_out (vty, "debug mpls ldp labels\n");
 		write = 1;
 	}
 
-	if (CONF_LDP_DEBUG(msg, MSG_RECV_ALL)) {
+	if (CONF_LDP_DEBUG(msg, LDP_DEBUG_MSG_RECV_ALL)) {
 		vty_out (vty, "debug mpls ldp messages recv all\n");
 		write = 1;
-	} else if (CONF_LDP_DEBUG(msg, MSG_RECV)) {
+	} else if (CONF_LDP_DEBUG(msg, LDP_DEBUG_MSG_RECV)) {
 		vty_out (vty, "debug mpls ldp messages recv\n");
 		write = 1;
 	}
 
-	if (CONF_LDP_DEBUG(msg, MSG_SEND_ALL)) {
+	if (CONF_LDP_DEBUG(msg, LDP_DEBUG_MSG_SEND_ALL)) {
 		vty_out (vty, "debug mpls ldp messages sent all\n");
 		write = 1;
-	} else if (CONF_LDP_DEBUG(msg, MSG_SEND)) {
+	} else if (CONF_LDP_DEBUG(msg, LDP_DEBUG_MSG_SEND)) {
 		vty_out (vty, "debug mpls ldp messages sent\n");
 		write = 1;
 	}
 
-	if (CONF_LDP_DEBUG(zebra, ZEBRA)) {
+	if (CONF_LDP_DEBUG(zebra, LDP_DEBUG_ZEBRA)) {
 		vty_out (vty, "debug mpls ldp zebra\n");
 		write = 1;
 	}

--- a/ldpd/ldp_debug.h
+++ b/ldpd/ldp_debug.h
@@ -46,11 +46,11 @@ struct ldp_debug {
 extern struct ldp_debug	 conf_ldp_debug;
 extern struct ldp_debug	 ldp_debug;
 
-#define CONF_DEBUG_ON(a, b)	(conf_ldp_debug.a |= (LDP_DEBUG_ ## b))
-#define CONF_DEBUG_OFF(a, b)	(conf_ldp_debug.a &= ~(LDP_DEBUG_ ## b))
+#define CONF_DEBUG_ON(a, b)	(conf_ldp_debug.a |= (b))
+#define CONF_DEBUG_OFF(a, b)	(conf_ldp_debug.a &= ~(b))
 
-#define TERM_DEBUG_ON(a, b)	(ldp_debug.a |= (LDP_DEBUG_ ## b))
-#define TERM_DEBUG_OFF(a, b)	(ldp_debug.a &= ~(LDP_DEBUG_ ## b))
+#define TERM_DEBUG_ON(a, b)	(ldp_debug.a |= (b))
+#define TERM_DEBUG_OFF(a, b)	(ldp_debug.a &= ~(b))
 
 #define DEBUG_ON(a, b)			\
     do {				\
@@ -66,48 +66,48 @@ extern struct ldp_debug	 ldp_debug;
 	TERM_DEBUG_OFF(a, b);		\
     } while (0)
 
-#define LDP_DEBUG(a, b)		(ldp_debug.a & LDP_DEBUG_ ## b)
-#define CONF_LDP_DEBUG(a, b)    (conf_ldp_debug.a & LDP_DEBUG_ ## b)
+#define LDP_DEBUG(a, b)		(ldp_debug.a & b)
+#define CONF_LDP_DEBUG(a, b)    (conf_ldp_debug.a & b)
 
 #define		 debug_hello_recv(emsg, ...)				\
 do {									\
-	if (LDP_DEBUG(hello, HELLO_RECV))				\
+	if (LDP_DEBUG(hello, LDP_DEBUG_HELLO_RECV))			\
 		log_debug("discovery[recv]: " emsg, __VA_ARGS__);	\
 } while (0)
 
 #define		 debug_hello_send(emsg, ...)				\
 do {									\
-	if (LDP_DEBUG(hello, HELLO_SEND))				\
+	if (LDP_DEBUG(hello, LDP_DEBUG_HELLO_SEND))			\
 		log_debug("discovery[send]: " emsg, __VA_ARGS__);	\
 } while (0)
 
 #define		 debug_err(emsg, ...)					\
 do {									\
-	if (LDP_DEBUG(errors, ERRORS))					\
+	if (LDP_DEBUG(errors, LDP_DEBUG_ERRORS))			\
 		log_debug("error: " emsg, __VA_ARGS__);			\
 } while (0)
 
 #define		 debug_evt(emsg, ...)					\
 do {									\
-	if (LDP_DEBUG(event, EVENT))					\
+	if (LDP_DEBUG(event, LDP_DEBUG_EVENT))				\
 		log_debug("event: " emsg, __VA_ARGS__);			\
 } while (0)
 
 #define		 debug_labels(emsg, ...)				\
 do {									\
-	if (LDP_DEBUG(labels, LABELS))					\
+	if (LDP_DEBUG(labels, LDP_DEBUG_LABELS))			\
 		log_debug("labels: " emsg, __VA_ARGS__);		\
 } while (0)
 
 #define		 debug_msg_recv(emsg, ...)				\
 do {									\
-	if (LDP_DEBUG(msg, MSG_RECV))					\
+	if (LDP_DEBUG(msg, LDP_DEBUG_MSG_RECV))				\
 		log_debug("msg[in]: " emsg, __VA_ARGS__);		\
 } while (0)
 
 #define		 debug_msg_send(emsg, ...)				\
 do {									\
-	if (LDP_DEBUG(msg, MSG_SEND))					\
+	if (LDP_DEBUG(msg, LDP_DEBUG_MSG_SEND))				\
 		log_debug("msg[out]: " emsg, __VA_ARGS__);		\
 } while (0)
 
@@ -121,25 +121,25 @@ do {									\
 
 #define		 debug_kalive_recv(emsg, ...)				\
 do {									\
-	if (LDP_DEBUG(msg, MSG_RECV_ALL))				\
+	if (LDP_DEBUG(msg, LDP_DEBUG_MSG_RECV_ALL))			\
 		log_debug("kalive[in]: " emsg, __VA_ARGS__);		\
 } while (0)
 
 #define		 debug_kalive_send(emsg, ...)				\
 do {									\
-	if (LDP_DEBUG(msg, MSG_SEND_ALL))				\
+	if (LDP_DEBUG(msg, LDP_DEBUG_MSG_SEND_ALL))			\
 		log_debug("kalive[out]: " emsg, __VA_ARGS__);		\
 } while (0)
 
 #define		 debug_zebra_in(emsg, ...)				\
 do {									\
-	if (LDP_DEBUG(zebra, ZEBRA))					\
+	if (LDP_DEBUG(zebra, LDP_DEBUG_ZEBRA))				\
 		log_debug("zebra[in]: " emsg, __VA_ARGS__);		\
 } while (0)
 
 #define		 debug_zebra_out(emsg, ...)				\
 do {									\
-	if (LDP_DEBUG(zebra, ZEBRA))					\
+	if (LDP_DEBUG(zebra, LDP_DEBUG_ZEBRA))				\
 		log_debug("zebra[out]: " emsg, __VA_ARGS__);		\
 } while (0)
 


### PR DESCRIPTION
When compiling ldpd on a mac, there exists a #define MSG_SEND
which conflicts with a define in ldp_debug.h.

During discussion about this we decided that it would be
better to remove the macro massaging that was going on and
to just call our own #define for it.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>