### PR TITLE
zebra: ipv6 addressing uses netlink socket instead of standard ioctl

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -838,6 +838,16 @@ int kernel_address_delete_ipv4(struct interface *ifp, struct connected *ifc)
 	return netlink_address(RTM_DELADDR, AF_INET, ifp, ifc);
 }
 
+int kernel_address_add_ipv6 (struct interface *ifp, struct connected *ifc)
+{
+  return netlink_address (RTM_NEWADDR, AF_INET6, ifp, ifc);
+}
+
+int kernel_address_delete_ipv6 (struct interface *ifp, struct connected *ifc)
+{
+  return netlink_address (RTM_DELADDR, AF_INET6, ifp, ifc);
+}
+
 int netlink_interface_addr(struct sockaddr_nl *snl, struct nlmsghdr *h,
 			   ns_id_t ns_id, int startup)
 {

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -461,6 +461,21 @@ struct in6_ifreq {
 };
 #endif /* _LINUX_IN6_H */
 
+#ifdef HAVE_NETLINK
+/* Interface address setting via netlink interface. */
+int
+if_prefix_add_ipv6 (struct interface *ifp, struct connected *ifc)
+{
+  return kernel_address_add_ipv6 (ifp, ifc);
+}
+
+/* Interface address is removed using netlink interface. */
+int
+if_prefix_delete_ipv6 (struct interface *ifp, struct connected *ifc)
+{
+  return kernel_address_delete_ipv6 (ifp, ifc);
+}
+#else /* ! HAVE_NETLINK */
 /* Interface's address add/delete functions. */
 int if_prefix_add_ipv6(struct interface *ifp, struct connected *ifc)
 {
@@ -499,6 +514,7 @@ int if_prefix_delete_ipv6(struct interface *ifp, struct connected *ifc)
 
 	return ret;
 }
+#endif /* ! HAVE_NETLINK */
 #else /* LINUX_IPV6 */
 #ifdef HAVE_STRUCT_IN6_ALIASREQ
 #ifndef ND6_INFINITE_LIFETIME

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -74,6 +74,8 @@ extern void kernel_route_rib_pass_fail(struct prefix *p,
 
 extern int kernel_address_add_ipv4(struct interface *, struct connected *);
 extern int kernel_address_delete_ipv4(struct interface *, struct connected *);
+extern int kernel_address_add_ipv6 (struct interface *, struct connected *);
+extern int kernel_address_delete_ipv6 (struct interface *, struct connected *);
 extern int kernel_neigh_update(int, int, uint32_t, char *, int);
 extern int kernel_interface_set_master(struct interface *master,
 				       struct interface *slave);


### PR DESCRIPTION
It is possible to configure IPv6 addresses from interfaces by using
netlink socket, intead of using standard sockets.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>