### PR TITLE
bgpd: fix config display of coalesce-time

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1423,8 +1423,8 @@ DEFUN (no_bgp_rpkt_quanta,
 
 void bgp_config_write_coalesce_time(struct vty *vty, struct bgp *bgp)
 {
-	if (bgp->coalesce_time != BGP_DEFAULT_SUBGROUP_COALESCE_TIME)
-		vty_out(vty, " coalesce-time %u\n", bgp->coalesce_time);
+	if (bgp->v_coalesce_time)
+		vty_out(vty, " coalesce-time %u\n", bgp->v_coalesce_time);
 }
 
 
@@ -1438,7 +1438,8 @@ DEFUN (bgp_coalesce_time,
 
 	int idx = 0;
 	argv_find(argv, argc, "(0-4294967295)", &idx);
-	bgp->coalesce_time = strtoul(argv[idx]->arg, NULL, 10);
+	bgp->coalesce_time = bgp->v_coalesce_time =
+		strtoul(argv[idx]->arg, NULL, 10);
 	return CMD_SUCCESS;
 }
 
@@ -1451,6 +1452,7 @@ DEFUN (no_bgp_coalesce_time,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
+	bgp->v_coalesce_time = 0;
 	bgp->coalesce_time = BGP_DEFAULT_SUBGROUP_COALESCE_TIME;
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1423,8 +1423,8 @@ DEFUN (no_bgp_rpkt_quanta,
 
 void bgp_config_write_coalesce_time(struct vty *vty, struct bgp *bgp)
 {
-	if (bgp->v_coalesce_time)
-		vty_out(vty, " coalesce-time %u\n", bgp->v_coalesce_time);
+	if (!bgp->heuristic_coalesce)
+		vty_out(vty, " coalesce-time %u\n", bgp->coalesce_time);
 }
 
 
@@ -1438,8 +1438,8 @@ DEFUN (bgp_coalesce_time,
 
 	int idx = 0;
 	argv_find(argv, argc, "(0-4294967295)", &idx);
-	bgp->coalesce_time = bgp->v_coalesce_time =
-		strtoul(argv[idx]->arg, NULL, 10);
+	bgp->heuristic_coalesce = false;
+	bgp->coalesce_time = strtoul(argv[idx]->arg, NULL, 10);
 	return CMD_SUCCESS;
 }
 
@@ -1452,7 +1452,7 @@ DEFUN (no_bgp_coalesce_time,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	bgp->v_coalesce_time = 0;
+	bgp->heuristic_coalesce = true;
 	bgp->coalesce_time = BGP_DEFAULT_SUBGROUP_COALESCE_TIME;
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1475,9 +1475,12 @@ struct peer *peer_create(union sockunion *su, const char *conf_if,
 	hash_get(bgp->peerhash, peer, hash_alloc_intern);
 
 	/* Adjust update-group coalesce timer heuristics for # peers. */
-	long ct = BGP_DEFAULT_SUBGROUP_COALESCE_TIME
-		  + (bgp->peer->count * BGP_PEER_ADJUST_SUBGROUP_COALESCE_TIME);
-	bgp->coalesce_time = MIN(BGP_MAX_SUBGROUP_COALESCE_TIME, ct);
+	if (!bgp->v_coalesce_time) {
+		long ct = BGP_DEFAULT_SUBGROUP_COALESCE_TIME
+			  + (bgp->peer->count
+			     * BGP_PEER_ADJUST_SUBGROUP_COALESCE_TIME);
+		bgp->coalesce_time = MIN(BGP_MAX_SUBGROUP_COALESCE_TIME, ct);
+	}
 
 	active = peer_active(peer);
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1475,7 +1475,7 @@ struct peer *peer_create(union sockunion *su, const char *conf_if,
 	hash_get(bgp->peerhash, peer, hash_alloc_intern);
 
 	/* Adjust update-group coalesce timer heuristics for # peers. */
-	if (!bgp->v_coalesce_time) {
+	if (bgp->heuristic_coalesce) {
 		long ct = BGP_DEFAULT_SUBGROUP_COALESCE_TIME
 			  + (bgp->peer->count
 			     * BGP_PEER_ADJUST_SUBGROUP_COALESCE_TIME);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -381,7 +381,10 @@ struct bgp {
 	_Atomic uint32_t wpkt_quanta; // max # packets to write per i/o cycle
 	_Atomic uint32_t rpkt_quanta; // max # packets to read per i/o cycle
 
-	u_int32_t coalesce_time;
+	/* Configured coalesce time */
+	uint32_t v_coalesce_time;
+	/* Actual coalesce time */
+	uint32_t coalesce_time;
 
 	u_int32_t addpath_tx_id;
 	int addpath_tx_used[AFI_MAX][SAFI_MAX];

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -381,8 +381,8 @@ struct bgp {
 	_Atomic uint32_t wpkt_quanta; // max # packets to write per i/o cycle
 	_Atomic uint32_t rpkt_quanta; // max # packets to read per i/o cycle
 
-	/* Configured coalesce time */
-	uint32_t v_coalesce_time;
+	/* Automatic coalesce adjust on/off */
+	bool heuristic_coalesce;
 	/* Actual coalesce time */
 	uint32_t coalesce_time;
 


### PR DESCRIPTION
Since coalesce time is now heuristically adjusted based on peer count,
we need to separate out specific configuration by the user from the
current value. Behavior established is to not adjust if the user has a
value set.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>