### PR TITLE
zebra: ipv6 addressing uses netlink socket instead of standard ioctl

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -838,6 +838,16 @@ int kernel_address_delete_ipv4(struct interface *ifp, struct connected *ifc)
 	return netlink_address(RTM_DELADDR, AF_INET, ifp, ifc);
 }
 
+int kernel_address_add_ipv6 (struct interface *ifp, struct connected *ifc)
+{
+  return netlink_address (RTM_NEWADDR, AF_INET6, ifp, ifc);
+}
+
+int kernel_address_delete_ipv6 (struct interface *ifp, struct connected *ifc)
+{
+  return netlink_address (RTM_DELADDR, AF_INET6, ifp, ifc);
+}
+
 int netlink_interface_addr(struct sockaddr_nl *snl, struct nlmsghdr *h,
 			   ns_id_t ns_id, int startup)
 {

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -78,6 +78,7 @@ int if_ioctl(u_long request, caddr_t buffer)
 	return 0;
 }
 
+#ifndef HAVE_NETLINK
 static int if_ioctl_ipv6(u_long request, caddr_t buffer)
 {
 	int sock;
@@ -108,6 +109,7 @@ static int if_ioctl_ipv6(u_long request, caddr_t buffer)
 	}
 	return 0;
 }
+#endif /* ! HAVE_NETLINK */
 
 /*
  * get interface metric
@@ -460,10 +462,12 @@ struct in6_ifreq {
 	int ifr6_ifindex;
 };
 #endif /* _LINUX_IN6_H */
-
 /* Interface's address add/delete functions. */
 int if_prefix_add_ipv6(struct interface *ifp, struct connected *ifc)
 {
+#ifdef HAVE_NETLINK
+	return kernel_address_add_ipv6 (ifp, ifc);
+#else /* ! HAVE_NETLINK */
 	int ret;
 	struct prefix_ipv6 *p;
 	struct in6_ifreq ifreq;
@@ -479,10 +483,14 @@ int if_prefix_add_ipv6(struct interface *ifp, struct connected *ifc)
 	ret = if_ioctl_ipv6(SIOCSIFADDR, (caddr_t)&ifreq);
 
 	return ret;
+#endif /* ! HAVE_NETLINK */
 }
 
 int if_prefix_delete_ipv6(struct interface *ifp, struct connected *ifc)
 {
+#ifdef HAVE_NETLINK
+	return kernel_address_delete_ipv6 (ifp, ifc);
+#else /* ! HAVE_NETLINK */
 	int ret;
 	struct prefix_ipv6 *p;
 	struct in6_ifreq ifreq;
@@ -498,6 +506,7 @@ int if_prefix_delete_ipv6(struct interface *ifp, struct connected *ifc)
 	ret = if_ioctl_ipv6(SIOCDIFADDR, (caddr_t)&ifreq);
 
 	return ret;
+#endif /* ! HAVE_NETLINK */
 }
 #else /* LINUX_IPV6 */
 #ifdef HAVE_STRUCT_IN6_ALIASREQ

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -74,6 +74,8 @@ extern void kernel_route_rib_pass_fail(struct prefix *p,
 
 extern int kernel_address_add_ipv4(struct interface *, struct connected *);
 extern int kernel_address_delete_ipv4(struct interface *, struct connected *);
+extern int kernel_address_add_ipv6 (struct interface *, struct connected *);
+extern int kernel_address_delete_ipv6 (struct interface *, struct connected *);
 extern int kernel_neigh_update(int, int, uint32_t, char *, int);
 extern int kernel_interface_set_master(struct interface *master,
 				       struct interface *slave);


### PR DESCRIPTION
It is possible to configure IPv6 addresses from interfaces by using
netlink socket, intead of using standard sockets.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>