### PR TITLE
debianpkg: Add missing frr-dbg.lintian-overrides to Makefile

### DIFF
--- a/debianpkg/Makefile.am
+++ b/debianpkg/Makefile.am
@@ -35,6 +35,7 @@ EXTRA_DIST = README.Debian README.Maintainer \
 	backports/ubuntu17.10/versionext \
 	frr-doc.docs frr-doc.info frr-doc.install \
 	frr-doc.lintian-overrides frr.conf \
+	frr-dbg.lintian-overrides \
 	frr.dirs frr.docs frr.install \
 	frr.lintian-overrides frr.logrotate \
 	frr.manpages frr.pam frr.postinst frr.postrm \


### PR DESCRIPTION
This fixes PR #1472 which missed adding the new lintian-overrides package to the distribution target.
Fixes all the recent lintian warnings as shown by the CI system

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>