### PR TITLE
bgpd: Speedup vtysh handling of 'show bgp afi safi json' display

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8394,7 +8394,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				vty_out(vty, ",\"%s\": ", buf2);
 
 			vty_out(vty, "%s",
-				json_object_to_json_string_ext(json_paths, JSON_C_TO_STRING_PRETTY));
+				json_object_to_json_string(json_paths));
 			json_object_free(json_paths);
 			first = 0;
 		}


### PR DESCRIPTION
When bgp has a metric butt-load of routes w/ ecmp, this command
can take an inordinate amount of time to run and complete via
vtysh.

Converting the bgp route output in this case back to not
using the json pretty-print drops ~2 minutes of runtime
off.

It is assumed that if users would like pretty output they
can run it through an appropriate tool via a pipe command.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>