### PR TITLE
bgpd: fix some coverity scan issues

### DIFF
--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -1626,7 +1626,11 @@ DEFUN (vnc_nve_group_export_no_prefixlist,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	argv_find_and_parse_afi(argv, argc, &idx, &afi);
+	if (!argv_find_and_parse_afi(argv, argc, &idx, &afi)) {
+		vty_out(vty, "%% Malformed Address Family\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
 	if (argv[idx-1]->text[0] == 'z')
 		is_bgp = 0;
 	idx += 2;		/* skip afi and keyword */
@@ -1691,7 +1695,11 @@ DEFUN (vnc_nve_group_export_prefixlist,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	argv_find_and_parse_afi(argv, argc, &idx, &afi);
+	if (!argv_find_and_parse_afi(argv, argc, &idx, &afi)) {
+		vty_out(vty, "%% Malformed Address Family\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
 	if (argv[idx-1]->text[0] == 'z')
 		is_bgp = 0;
 	idx = argc - 1;

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1529,7 +1529,7 @@ void rfapiPrintRd(struct vty *vty, struct prefix_rd *prd)
 {
 	char buf[RD_ADDRSTRLEN];
 
-	prefix_rd2str(prd, buf, BUFSIZ);
+	prefix_rd2str(prd, buf, sizeof(buf));
 	vty_out(vty, "%s", buf);
 }
 


### PR DESCRIPTION
This PR fix 2 issues pointed out by the coverity scan:

* `prefix_rd2str()` slip up: use size of buffer instead of hardcoded value
* Check for `argv_find_and_parse_afi()` return value before proceeding