### PR TITLE
Enlarge the vrf_id identifier from 16 to 32 bits, and rename vrf_id to lr_id

### DIFF
--- a/babeld/babel_filter.c
+++ b/babeld/babel_filter.c
@@ -32,7 +32,7 @@ int
 babel_filter(int output, const unsigned char *prefix, unsigned short plen,
              unsigned int ifindex)
 {
-    struct interface *ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
+    struct interface *ifp = if_lookup_by_index(ifindex, vrf_id_default);
     babel_interface_nfo *babel_ifp = ifp ? babel_get_if_nfo(ifp) : NULL;
     struct prefix p;
     struct distribute *dist;

--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -64,7 +64,7 @@ static struct cmd_node babel_interface_node =  /* babeld's interface node.    */
 
 
 int
-babel_interface_up (int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf)
+babel_interface_up (int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf)
 {
     struct stream *s = NULL;
     struct interface *ifp = NULL;
@@ -83,7 +83,7 @@ babel_interface_up (int cmd, struct zclient *client, zebra_size_t length, vrf_id
 }
 
 int
-babel_interface_down (int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf)
+babel_interface_down (int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf)
 {
     struct stream *s = NULL;
     struct interface *ifp = NULL;
@@ -102,7 +102,7 @@ babel_interface_down (int cmd, struct zclient *client, zebra_size_t length, vrf_
 }
 
 int
-babel_interface_add (int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf)
+babel_interface_add (int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf)
 {
     struct interface *ifp = NULL;
 
@@ -120,7 +120,7 @@ babel_interface_add (int cmd, struct zclient *client, zebra_size_t length, vrf_i
 }
 
 int
-babel_interface_delete (int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf)
+babel_interface_delete (int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf)
 {
     struct interface *ifp;
     struct stream *s;
@@ -145,7 +145,7 @@ babel_interface_delete (int cmd, struct zclient *client, zebra_size_t length, vr
 
 int
 babel_interface_address_add (int cmd, struct zclient *client,
-                             zebra_size_t length, vrf_id_t vrf)
+                             zebra_size_t length, lr_id_t vrf)
 {
     babel_interface_nfo *babel_ifp;
     struct connected *ifc;
@@ -182,7 +182,7 @@ babel_interface_address_add (int cmd, struct zclient *client,
 
 int
 babel_interface_address_delete (int cmd, struct zclient *client,
-                                zebra_size_t length, vrf_id_t vrf)
+                                zebra_size_t length, lr_id_t vrf)
 {
     babel_interface_nfo *babel_ifp;
     struct connected *ifc;
@@ -241,7 +241,7 @@ babel_enable_if_add (const char *ifname)
 
     vector_set (babel_enable_if, strdup (ifname));
 
-    ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+    ifp = if_lookup_by_name(ifname, vrf_id_default);
     if (ifp != NULL)
         interface_recalculate(ifp);
 
@@ -264,7 +264,7 @@ babel_enable_if_delete (const char *ifname)
     free (str);
     vector_unset (babel_enable_if, babel_enable_if_index);
 
-    ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+    ifp = if_lookup_by_name(ifname, vrf_id_default);
     if (ifp != NULL)
         interface_reset(ifp);
 
@@ -809,7 +809,7 @@ interface_reset(struct interface *ifp)
 void
 babel_interface_close_all(void)
 {
-    struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+    struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
     struct interface *ifp = NULL;
 
     FOR_ALL_INTERFACES(vrf, ifp) {
@@ -896,7 +896,7 @@ DEFUN (show_babel_interface,
        "Interface information\n"
        "Interface\n")
 {
-  struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+  struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
   struct interface *ifp;
 
   if (argc == 3)
@@ -905,7 +905,7 @@ DEFUN (show_babel_interface,
       show_babel_interface_sub (vty, ifp);
     return CMD_SUCCESS;
   }
-  if ((ifp = if_lookup_by_name (argv[3]->arg, VRF_DEFAULT)) == NULL)
+  if ((ifp = if_lookup_by_name (argv[3]->arg, vrf_id_default)) == NULL)
   {
     vty_out (vty, "No such interface name\n");
     return CMD_WARNING;
@@ -947,7 +947,7 @@ DEFUN (show_babel_neighbour,
         }
         return CMD_SUCCESS;
     }
-    if ((ifp = if_lookup_by_name (argv[3]->arg, VRF_DEFAULT)) == NULL)
+    if ((ifp = if_lookup_by_name (argv[3]->arg, vrf_id_default)) == NULL)
     {
         vty_out (vty, "No such interface name\n");
         return CMD_WARNING;
@@ -1316,7 +1316,7 @@ babeld-specific statement lines where appropriate. */
 static int
 interface_config_write (struct vty *vty)
 {
-    struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+    struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
     struct interface *ifp;
     int write = 0;
 

--- a/babeld/babel_interface.h
+++ b/babeld/babel_interface.h
@@ -114,12 +114,12 @@ struct buffered_update {
 void babel_if_init(void);
 
 /* Callback functions for zebra client */
-int babel_interface_up (int, struct zclient *, zebra_size_t, vrf_id_t);
-int babel_interface_down (int, struct zclient *, zebra_size_t, vrf_id_t);
-int babel_interface_add (int, struct zclient *, zebra_size_t, vrf_id_t);
-int babel_interface_delete (int, struct zclient *, zebra_size_t, vrf_id_t);
-int babel_interface_address_add (int, struct zclient *, zebra_size_t, vrf_id_t);
-int babel_interface_address_delete (int, struct zclient *, zebra_size_t, vrf_id_t);
+int babel_interface_up (int, struct zclient *, zebra_size_t, lr_id_t);
+int babel_interface_down (int, struct zclient *, zebra_size_t, lr_id_t);
+int babel_interface_add (int, struct zclient *, zebra_size_t, lr_id_t);
+int babel_interface_delete (int, struct zclient *, zebra_size_t, lr_id_t);
+int babel_interface_address_add (int, struct zclient *, zebra_size_t, lr_id_t);
+int babel_interface_address_delete (int, struct zclient *, zebra_size_t, lr_id_t);
 
 unsigned jitter(babel_interface_nfo *, int);
 unsigned update_jitter(babel_interface_nfo *babel_ifp, int urgent);

--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -57,7 +57,7 @@ static struct {
 /* Zebra route add and delete treatment. */
 static int
 babel_zebra_read_route (int command, struct zclient *zclient,
-		        zebra_size_t length, vrf_id_t vrf)
+		        zebra_size_t length, lr_id_t vrf)
 {
     struct zapi_route api;
 
@@ -112,9 +112,9 @@ DEFUN (babel_redistribute_type,
     }
 
     if (!negate)
-        zclient_redistribute (ZEBRA_REDISTRIBUTE_ADD, zclient, afi, type, 0, VRF_DEFAULT);
+        zclient_redistribute (ZEBRA_REDISTRIBUTE_ADD, zclient, afi, type, 0, vrf_id_default);
     else {
-        zclient_redistribute (ZEBRA_REDISTRIBUTE_DELETE, zclient, afi, type, 0, VRF_DEFAULT);
+        zclient_redistribute (ZEBRA_REDISTRIBUTE_DELETE, zclient, afi, type, 0, vrf_id_default);
         /* perhaps should we remove xroutes having the same type... */
     }
     return CMD_SUCCESS;
@@ -232,7 +232,7 @@ DEFUN_NOSH (show_debugging_babel,
 static void
 babel_zebra_connected (struct zclient *zclient)
 {
-  zclient_send_reg_requests (zclient, VRF_DEFAULT);
+  zclient_send_reg_requests (zclient, vrf_id_default);
 }
 
 void babelz_zebra_init(void)

--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -112,7 +112,7 @@ babel_config_write (struct vty *vty)
     for (afi = AFI_IP; afi <= AFI_IP6; afi++) {
         for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
             if (i != zclient->redist_default &&
-                vrf_bitmap_check (zclient->redist[afi][i], VRF_DEFAULT)) {
+                vrf_bitmap_check (zclient->redist[afi][i], vrf_id_default)) {
                 vty_out (vty, " redistribute %s %s\n",
                          (afi == AFI_IP) ? "ipv4" : "ipv6",
                          zebra_route_string(i));
@@ -164,7 +164,7 @@ static int
 babel_read_protocol (struct thread *thread)
 {
     int rc;
-    struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+    struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
     struct interface *ifp = NULL;
     struct sockaddr_in6 sin6;
 
@@ -214,7 +214,7 @@ babel_init_routing_process(struct thread *thread)
 static void
 babel_get_myid(void)
 {
-    struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+    struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
     struct interface *ifp = NULL;
     int rc;
     int i;
@@ -268,7 +268,7 @@ babel_get_myid(void)
 static void
 babel_initial_noise(void)
 {
-    struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+    struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
     struct interface *ifp = NULL;
 
     FOR_ALL_INTERFACES(vrf, ifp) {
@@ -319,7 +319,7 @@ static int
 babel_main_loop(struct thread *thread)
 {
     struct timeval tv;
-    struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+    struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
     struct interface *ifp = NULL;
 
     while(1) {
@@ -449,7 +449,7 @@ babel_fill_with_next_timeout(struct timeval *tv)
 #define printIfMin(a,b,c,d) \
   if (UNLIKELY(debug & BABEL_DEBUG_TIMEOUT)) {printIfMin(a,b,c,d);}
 
-    struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+    struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
     struct interface *ifp = NULL;
 
     *tv = check_neighbours_timeout;
@@ -542,7 +542,7 @@ babel_distribute_update (struct distribute *dist)
     if (! dist->ifname)
         return;
 
-    ifp = if_lookup_by_name (dist->ifname, VRF_DEFAULT);
+    ifp = if_lookup_by_name (dist->ifname, vrf_id_default);
     if (ifp == NULL)
         return;
 
@@ -578,7 +578,7 @@ babel_distribute_update_interface (struct interface *ifp)
 static void
 babel_distribute_update_all (struct prefix_list *notused)
 {
-    struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+    struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
     struct interface *ifp;
 
     FOR_ALL_INTERFACES (vrf, ifp)

--- a/babeld/kernel.c
+++ b/babeld/kernel.c
@@ -165,7 +165,7 @@ zebra_route(int add, int family, const unsigned char *pref, unsigned short plen,
     memset(&api, 0, sizeof(api));
     api.type  = ZEBRA_ROUTE_BABEL;
     api.safi = SAFI_UNICAST;
-    api.vrf_id = VRF_DEFAULT;
+    api.vrf_id.lr.id = LR_DEFAULT;
     api.prefix = quagga_prefix;
 
     if(metric >= KERNEL_INFINITY) {
@@ -205,7 +205,7 @@ zebra_route(int add, int family, const unsigned char *pref, unsigned short plen,
 int
 if_eui64(int ifindex, unsigned char *eui)
 {
-    struct interface *ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
+    struct interface *ifp = if_lookup_by_index(ifindex, vrf_id_default);
     if (ifp == NULL) {
         return -1;
     }

--- a/babeld/message.c
+++ b/babeld/message.c
@@ -1154,7 +1154,7 @@ flushupdates(struct interface *ifp)
     int i;
 
     if(ifp == NULL) {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
         struct interface *ifp_aux;
         FOR_ALL_INTERFACES(vrf, ifp_aux)
             flushupdates(ifp_aux);
@@ -1326,7 +1326,7 @@ send_update(struct interface *ifp, int urgent,
     babel_interface_nfo *babel_ifp = NULL;
 
     if(ifp == NULL) {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
         struct interface *ifp_aux;
         struct babel_route *route;
         FOR_ALL_INTERFACES(vrf, ifp_aux)
@@ -1387,7 +1387,7 @@ send_wildcard_retraction(struct interface *ifp)
 {
     babel_interface_nfo *babel_ifp = NULL;
     if(ifp == NULL) {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
         struct interface *ifp_aux;
         FOR_ALL_INTERFACES(vrf, ifp_aux)
             send_wildcard_retraction(ifp_aux);
@@ -1422,7 +1422,7 @@ send_self_update(struct interface *ifp)
 {
     struct xroute_stream *xroutes;
     if(ifp == NULL) {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
         struct interface *ifp_aux;
         FOR_ALL_INTERFACES(vrf, ifp_aux) {
             if(!if_up(ifp_aux))
@@ -1456,7 +1456,7 @@ send_ihu(struct neighbour *neigh, struct interface *ifp)
     int msglen;
 
     if(neigh == NULL && ifp == NULL) {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
         struct interface *ifp_aux;
         FOR_ALL_INTERFACES(vrf, ifp_aux) {
             if(if_up(ifp_aux))
@@ -1573,7 +1573,7 @@ send_request(struct interface *ifp,
     int v4, pb, len;
 
     if(ifp == NULL) {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
         struct interface *ifp_aux;
         FOR_ALL_INTERFACES(vrf, ifp_aux) {
             if(if_up(ifp_aux))
@@ -1648,7 +1648,7 @@ send_multihop_request(struct interface *ifp,
     flushupdates(ifp);
 
     if(ifp == NULL) {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
         struct interface *ifp_aux;
         FOR_ALL_INTERFACES(vrf, ifp_aux) {
             if(!if_up(ifp_aux))

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -96,7 +96,7 @@ int bgp_bfd_is_peer_multihop(struct peer *peer)
 static void bgp_bfd_peer_sendmsg(struct peer *peer, int command)
 {
 	struct bfd_info *bfd_info;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	lr_id_t vrf_id =  { .lr.id = LR_DEFAULT};
 	int multihop;
 
 	bfd_info = (struct bfd_info *)peer->bfd_info;
@@ -235,7 +235,7 @@ static void bgp_bfd_update_type(struct peer *peer)
  *                       to zebra
  */
 static int bgp_bfd_dest_replay(int command, struct zclient *client,
-			       zebra_size_t length, vrf_id_t vrf_id)
+			       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct listnode *mnode, *node, *nnode;
 	struct bgp *bgp;
@@ -288,7 +288,7 @@ static void bgp_bfd_peer_status_update(struct peer *peer, int status)
  *                       connectivity if the BFD session went down.
  */
 static int bgp_bfd_dest_update(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+			       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct prefix dp;
@@ -302,14 +302,14 @@ static int bgp_bfd_dest_update(int command, struct zclient *zclient,
 		prefix2str(&dp, buf[0], sizeof(buf[0]));
 		if (ifp) {
 			zlog_debug(
-				"Zebra: vrf %d interface %s bfd destination %s %s",
-				vrf_id, ifp->name, buf[0],
+				"Zebra: vrf %u interface %s bfd destination %s %s",
+				vrf_id.lr.id, ifp->name, buf[0],
 				bfd_get_status_str(status));
 		} else {
 			prefix2str(&sp, buf[1], sizeof(buf[1]));
 			zlog_debug(
-				"Zebra: vrf %d source %s bfd destination %s %s",
-				vrf_id, buf[1], buf[0],
+				"Zebra: vrf %u source %s bfd destination %s %s",
+				vrf_id.lr.id, buf[1], buf[0],
 				bfd_get_status_str(status));
 		}
 	}
@@ -367,8 +367,8 @@ static int bgp_bfd_dest_update(int command, struct zclient *zclient,
 					} else
 						continue;
 
-					if ((vrf_id != VRF_DEFAULT)
-					    && (peer->bgp->vrf_id != vrf_id))
+					if ((vrf_id.lr.id != LR_DEFAULT)
+					    && (peer->bgp->vrf_id.lr.id != vrf_id.lr.id))
 						continue;
 
 					bgp_bfd_peer_status_update(peer,

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -1448,7 +1448,7 @@ static int install_uninstall_routes_for_vni(struct bgp *bgp,
 					if (ret) {
 						zlog_err(
 							"%u: Failed to %s EVPN %s route in VNI %u",
-							bgp->vrf_id,
+							bgp->vrf_id.lr.id,
 							install ? "install"
 								: "uninstall",
 							rtype == BGP_EVPN_MAC_IP_ROUTE
@@ -1531,7 +1531,7 @@ static int install_uninstall_route_in_vnis(struct bgp *bgp, afi_t afi,
 
 		if (ret) {
 			zlog_err("%u: Failed to %s EVPN %s route in VNI %u",
-				 bgp->vrf_id, install ? "install" : "uninstall",
+				 bgp->vrf_id.lr.id, install ? "install" : "uninstall",
 				 evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE
 					 ? "MACIP"
 					 : "IMET",
@@ -1804,7 +1804,7 @@ static int process_type2_route(struct peer *peer, afi_t afi, safi_t safi,
 	if (psize != 33 && psize != 37 && psize != 49 && psize != 36
 	    && psize != 40 && psize != 52) {
 		zlog_err("%u:%s - Rx EVPN Type-2 NLRI with invalid length %d",
-			 peer->bgp->vrf_id, peer->host, psize);
+			 peer->bgp->vrf_id.lr.id, peer->host, psize);
 		return -1;
 	}
 
@@ -1836,7 +1836,7 @@ static int process_type2_route(struct peer *peer, afi_t afi, safi_t safi,
 	} else {
 		zlog_err(
 			"%u:%s - Rx EVPN Type-2 NLRI with unsupported MAC address length %d",
-			peer->bgp->vrf_id, peer->host, macaddr_len);
+			peer->bgp->vrf_id.lr.id, peer->host, macaddr_len);
 		return -1;
 	}
 
@@ -1847,7 +1847,7 @@ static int process_type2_route(struct peer *peer, afi_t afi, safi_t safi,
 	    && ipaddr_len != IPV6_MAX_BITLEN) {
 		zlog_err(
 			"%u:%s - Rx EVPN Type-2 NLRI with unsupported IP address length %d",
-			peer->bgp->vrf_id, peer->host, ipaddr_len);
+			peer->bgp->vrf_id.lr.id, peer->host, ipaddr_len);
 		return -1;
 	}
 
@@ -1893,7 +1893,7 @@ static int process_type3_route(struct peer *peer, afi_t afi, safi_t safi,
 	 */
 	if (psize != 17 && psize != 29) {
 		zlog_err("%u:%s - Rx EVPN Type-3 NLRI with invalid length %d",
-			 peer->bgp->vrf_id, peer->host, psize);
+			 peer->bgp->vrf_id.lr.id, peer->host, psize);
 		return -1;
 	}
 
@@ -1920,7 +1920,7 @@ static int process_type3_route(struct peer *peer, afi_t afi, safi_t safi,
 	} else {
 		zlog_err(
 			"%u:%s - Rx EVPN Type-3 NLRI with unsupported IP address length %d",
-			peer->bgp->vrf_id, peer->host, ipaddr_len);
+			peer->bgp->vrf_id.lr.id, peer->host, ipaddr_len);
 		return -1;
 	}
 
@@ -1958,7 +1958,7 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 	 */
 	if (psize != 34 && psize != 58) {
 		zlog_err("%u:%s - Rx EVPN Type-5 NLRI with invalid length %d",
-			 peer->bgp->vrf_id, peer->host, psize);
+			 peer->bgp->vrf_id.lr.id, peer->host, psize);
 		return -1;
 	}
 
@@ -1990,7 +1990,7 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 	if (ippfx_len > IPV6_MAX_BITLEN) {
 		zlog_err(
 			"%u:%s - Rx EVPN Type-5 NLRI with invalid IP Prefix length %d",
-			peer->bgp->vrf_id, peer->host, ippfx_len);
+			peer->bgp->vrf_id.lr.id, peer->host, ippfx_len);
 		return -1;
 	}
 	p.prefix.ip_prefix_length = ippfx_len;
@@ -2367,7 +2367,7 @@ int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 	/* Check peer status. */
 	if (peer->status != Established) {
 		zlog_err("%u:%s - EVPN update received in state %d",
-			 peer->bgp->vrf_id, peer->host, peer->status);
+			 peer->bgp->vrf_id.lr.id, peer->host, peer->status);
 		return -1;
 	}
 
@@ -2415,7 +2415,7 @@ int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 						psize, addpath_id)) {
 				zlog_err(
 					"%u:%s - Error in processing EVPN type-2 NLRI size %d",
-					peer->bgp->vrf_id, peer->host, psize);
+					peer->bgp->vrf_id.lr.id, peer->host, psize);
 				return -1;
 			}
 			break;
@@ -2426,7 +2426,7 @@ int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 						psize, addpath_id)) {
 				zlog_err(
 					"%u:%s - Error in processing EVPN type-3 NLRI size %d",
-					peer->bgp->vrf_id, peer->host, psize);
+					peer->bgp->vrf_id.lr.id, peer->host, psize);
 				return -1;
 			}
 			break;
@@ -2436,7 +2436,7 @@ int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 						psize, addpath_id, withdraw)) {
 				zlog_err(
 					"%u:%s - Error in processing EVPN type-5 NLRI size %d",
-					peer->bgp->vrf_id, peer->host, psize);
+					peer->bgp->vrf_id.lr.id, peer->host, psize);
 				return -1;
 			}
 			break;
@@ -2681,7 +2681,7 @@ int bgp_filter_evpn_routes_upon_martian_nh_change(struct bgp *bgp)
 							     NULL, 1))
 						zlog_debug(
 							"%u: prefix %s with attr %s - DENIED due to martian or self nexthop",
-							bgp->vrf_id,
+							bgp->vrf_id.lr.id,
 							prefix2str(
 								&rn->p, pbuf,
 								sizeof(pbuf)),
@@ -2710,7 +2710,7 @@ int bgp_evpn_local_macip_del(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 	struct prefix_evpn p;
 
 	if (!bgp->vnihash) {
-		zlog_err("%u: VNI hash not created", bgp->vrf_id);
+		zlog_err("%u: VNI hash not created", bgp->vrf_id.lr.id);
 		return -1;
 	}
 
@@ -2718,7 +2718,7 @@ int bgp_evpn_local_macip_del(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 	vpn = bgp_evpn_lookup_vni(bgp, vni);
 	if (!vpn || !is_vni_live(vpn)) {
 		zlog_warn("%u: VNI hash entry for VNI %u %s at MACIP DEL",
-			  bgp->vrf_id, vni, vpn ? "not live" : "not found");
+			  bgp->vrf_id.lr.id, vni, vpn ? "not live" : "not found");
 		return -1;
 	}
 
@@ -2739,7 +2739,7 @@ int bgp_evpn_local_macip_add(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 	struct prefix_evpn p;
 
 	if (!bgp->vnihash) {
-		zlog_err("%u: VNI hash not created", bgp->vrf_id);
+		zlog_err("%u: VNI hash not created", bgp->vrf_id.lr.id);
 		return -1;
 	}
 
@@ -2747,7 +2747,7 @@ int bgp_evpn_local_macip_add(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 	vpn = bgp_evpn_lookup_vni(bgp, vni);
 	if (!vpn || !is_vni_live(vpn)) {
 		zlog_warn("%u: VNI hash entry for VNI %u %s at MACIP ADD",
-			  bgp->vrf_id, vni, vpn ? "not live" : "not found");
+			  bgp->vrf_id.lr.id, vni, vpn ? "not live" : "not found");
 		return -1;
 	}
 
@@ -2759,7 +2759,7 @@ int bgp_evpn_local_macip_add(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 
 		zlog_err(
 			"%u:Failed to create Type-2 route, VNI %u %s MAC %s IP %s",
-			bgp->vrf_id, vpn->vni,
+			bgp->vrf_id.lr.id, vpn->vni,
 			CHECK_FLAG(flags, ZEBRA_MAC_TYPE_STICKY) ? "sticky gateway"
 								 : "",
 			prefix_mac2str(mac, buf, sizeof(buf)),
@@ -2778,7 +2778,7 @@ int bgp_evpn_local_vni_del(struct bgp *bgp, vni_t vni)
 	struct bgpevpn *vpn;
 
 	if (!bgp->vnihash) {
-		zlog_err("%u: VNI hash not created", bgp->vrf_id);
+		zlog_err("%u: VNI hash not created", bgp->vrf_id.lr.id);
 		return -1;
 	}
 
@@ -2786,7 +2786,7 @@ int bgp_evpn_local_vni_del(struct bgp *bgp, vni_t vni)
 	vpn = bgp_evpn_lookup_vni(bgp, vni);
 	if (!vpn) {
 		zlog_warn("%u: VNI hash entry for VNI %u not found at DEL",
-			  bgp->vrf_id, vni);
+			  bgp->vrf_id.lr.id, vni);
 		return 0;
 	}
 
@@ -2819,7 +2819,7 @@ int bgp_evpn_local_vni_add(struct bgp *bgp, vni_t vni,
 	struct prefix_evpn p;
 
 	if (!bgp->vnihash) {
-		zlog_err("%u: VNI hash not created", bgp->vrf_id);
+		zlog_err("%u: VNI hash not created", bgp->vrf_id.lr.id);
 		return -1;
 	}
 
@@ -2842,7 +2842,7 @@ int bgp_evpn_local_vni_add(struct bgp *bgp, vni_t vni,
 		if (!vpn) {
 			zlog_err(
 				"%u: Failed to allocate VNI entry for VNI %u - at Add",
-				bgp->vrf_id, vni);
+				bgp->vrf_id.lr.id, vni);
 			return -1;
 		}
 	}
@@ -2864,7 +2864,7 @@ int bgp_evpn_local_vni_add(struct bgp *bgp, vni_t vni,
 	build_evpn_type3_prefix(&p, vpn->originator_ip);
 	if (update_evpn_route(bgp, vpn, &p, 0)) {
 		zlog_err("%u: Type3 route creation failure for VNI %u",
-			 bgp->vrf_id, vni);
+			 bgp->vrf_id.lr.id, vni);
 		return -1;
 	}
 

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1018,7 +1018,7 @@ int bgp_stop(struct peer *peer)
 				"%%ADJCHANGE: neighbor %s(%s) in vrf %s Down %s",
 				peer->host,
 				(peer->hostname) ? peer->hostname : "Unknown",
-				vrf ? ((vrf->vrf_id != VRF_DEFAULT) ? vrf->name
+				vrf ? ((vrf->vrf_id.lr.id != LR_DEFAULT) ? vrf->name
 								    : "Default")
 				    : "",
 				peer_down_str[(int)peer->last_reset]);
@@ -1525,7 +1525,7 @@ static int bgp_establish(struct peer *peer)
 		zlog_info("%%ADJCHANGE: neighbor %s(%s) in vrf %s Up",
 			  peer->host,
 			  (peer->hostname) ? peer->hostname : "Unknown",
-			  vrf ? ((vrf->vrf_id != VRF_DEFAULT) ? vrf->name
+			  vrf ? ((vrf->vrf_id.lr.id != LR_DEFAULT) ? vrf->name
 							      : "Default")
 			      : "");
 	}

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -135,7 +135,7 @@ void bgp_reg_dereg_for_label(struct bgp_node *rn, struct bgp_info *ri, int reg)
 	s = zclient->obuf;
 	stream_reset(s);
 	command = (reg) ? ZEBRA_FEC_REGISTER : ZEBRA_FEC_UNREGISTER;
-	zclient_create_header(s, command, VRF_DEFAULT);
+	zclient_create_header(s, command, vrf_id_default);
 	flags_pos = stream_get_endp(s); /* save position of 'flags' */
 	stream_putw(s, flags);		/* initial flags */
 	stream_putw(s, PREFIX_FAMILY(p));

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -231,7 +231,7 @@ static __attribute__((__noreturn__)) void bgp_exit(int status)
 static int bgp_vrf_new(struct vrf *vrf)
 {
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("VRF Created: %s(%d)", vrf->name, vrf->vrf_id);
+		zlog_debug("VRF Created: %s(%u)", vrf->name, vrf->vrf_id.lr.id);
 
 	return 0;
 }
@@ -239,7 +239,7 @@ static int bgp_vrf_new(struct vrf *vrf)
 static int bgp_vrf_delete(struct vrf *vrf)
 {
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("VRF Deletion: %s(%d)", vrf->name, vrf->vrf_id);
+		zlog_debug("VRF Deletion: %s(%u)", vrf->name, vrf->vrf_id.lr.id);
 
 	return 0;
 }
@@ -247,19 +247,19 @@ static int bgp_vrf_delete(struct vrf *vrf)
 static int bgp_vrf_enable(struct vrf *vrf)
 {
 	struct bgp *bgp;
-	vrf_id_t old_vrf_id;
+	lr_id_t old_vrf_id;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("VRF enable add %s id %d", vrf->name, vrf->vrf_id);
+		zlog_debug("VRF enable add %s id %u", vrf->name, vrf->vrf_id.lr.id);
 
 	bgp = bgp_lookup_by_name(vrf->name);
 	if (bgp) {
-		old_vrf_id = bgp->vrf_id;
+		old_vrf_id.lr.id = bgp->vrf_id.lr.id;
 		/* We have instance configured, link to VRF and make it "up". */
 		bgp_vrf_link(bgp, vrf);
 
 		/* Update any redistribute vrf bitmaps if the vrf_id changed */
-		if (old_vrf_id != bgp->vrf_id)
+		if (old_vrf_id.lr.id != bgp->vrf_id.lr.id)
 			bgp_update_redist_vrf_bitmaps(bgp, old_vrf_id);
 		bgp_instance_up(bgp);
 	}
@@ -270,22 +270,22 @@ static int bgp_vrf_enable(struct vrf *vrf)
 static int bgp_vrf_disable(struct vrf *vrf)
 {
 	struct bgp *bgp;
-	vrf_id_t old_vrf_id;
+	lr_id_t old_vrf_id;
 
-	if (vrf->vrf_id == VRF_DEFAULT)
+	if (vrf->vrf_id.lr.id == LR_DEFAULT)
 		return 0;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("VRF disable %s id %d", vrf->name, vrf->vrf_id);
+		zlog_debug("VRF disable %s id %u", vrf->name, vrf->vrf_id.lr.id);
 
 	bgp = bgp_lookup_by_name(vrf->name);
 	if (bgp) {
-		old_vrf_id = bgp->vrf_id;
+		old_vrf_id.lr.id = bgp->vrf_id.lr.id;
 		/* We have instance configured, unlink from VRF and make it
 		 * "down". */
 		bgp_vrf_unlink(bgp, vrf);
 		/* Update any redistribute vrf bitmaps if the vrf_id changed */
-		if (old_vrf_id != bgp->vrf_id)
+		if (old_vrf_id.lr.id != bgp->vrf_id.lr.id)
 			bgp_update_redist_vrf_bitmaps(bgp, old_vrf_id);
 		bgp_instance_down(bgp);
 	}

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -238,7 +238,7 @@ static int bgp_get_instance_for_inc_conn(int sock, struct bgp **bgp_inst)
 	/* First try match to instance; if that fails, check for interfaces. */
 	bgp = bgp_lookup_by_name(name);
 	if (bgp) {
-		if (!bgp->vrf_id) // unexpected
+		if (!bgp->vrf_id.lr.id) // unexpected
 			return -1;
 		*bgp_inst = bgp;
 		return 0;
@@ -443,7 +443,7 @@ static int bgp_bind(struct peer *peer)
 	char *name = NULL;
 
 	/* If not bound to an interface or part of a VRF, we don't care. */
-	if (!peer->bgp->vrf_id && !peer->ifname && !peer->conf_if)
+	if (!peer->bgp->vrf_id.lr.id && !peer->ifname && !peer->conf_if)
 		return 0;
 
 	if (peer->su.sa.sa_family != AF_INET

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -318,7 +318,7 @@ void bgp_delete_connected_nexthop(afi_t afi, struct peer *peer)
 	}
 }
 
-void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
+void bgp_parse_nexthop_update(int command, lr_id_t vrf_id)
 {
 	struct stream *s;
 	struct bgp_node *rn = NULL;
@@ -336,8 +336,8 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 	bgp = bgp_lookup_by_vrf_id(vrf_id);
 	if (!bgp) {
 		zlog_err(
-			"parse nexthop update: instance not found for vrf_id %d",
-			vrf_id);
+			"parse nexthop update: instance not found for vrf_id %u",
+			vrf_id.lr.id);
 		return;
 	}
 
@@ -390,7 +390,7 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 		prefix2str(&p, buf, sizeof(buf));
 		zlog_debug(
 			"%d: Rcvd NH update %s - metric %d/%d #nhops %d/%d flags 0x%x",
-			vrf_id, buf, metric, bnc->metric, nexthop_num,
+			vrf_id.lr.id, buf, metric, bnc->metric, nexthop_num,
 			bnc->nexthop_num, bnc->flags);
 	}
 

--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -24,7 +24,7 @@
 /**
  * bgp_parse_nexthop_update() - parse a nexthop update message from Zebra.
  */
-extern void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id);
+extern void bgp_parse_nexthop_update(int command, lr_id_t vrf_id);
 
 /**
  * bgp_find_nexthop() - lookup the nexthop cache table for the bnc object

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8174,7 +8174,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 		vty_out(vty,
 			"{\n \"vrfId\": %d,\n \"vrfName\": \"%s\",\n \"tableVersion\": %" PRId64
 			",\n \"routerId\": \"%s\",\n \"routes\": { ",
-			bgp->vrf_id == VRF_UNKNOWN ? -1 : bgp->vrf_id,
+			bgp->vrf_id.lr.id == LR_UNKNOWN ? -1 : (int)bgp->vrf_id.lr.id,
 			bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT ? "Default"
 								    : bgp->name,
 			table->version, inet_ntoa(bgp->router_id));

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6505,7 +6505,7 @@ DEFUN (show_bgp_vrfs,
 			type = "VRF";
 		}
 
-		vrf_id_ui = (bgp->vrf_id == VRF_UNKNOWN) ? -1 : bgp->vrf_id;
+		vrf_id_ui = (bgp->vrf_id.lr.id == LR_UNKNOWN) ? -1 : (int)bgp->vrf_id.lr.id;
 		if (uj) {
 			json_object_string_add(json_vrf, "type", type);
 			json_object_int_add(json_vrf, "vrfId", vrf_id_ui);
@@ -6841,7 +6841,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 			int vrf_id_ui;
 
 			vrf_id_ui =
-				(bgp->vrf_id == VRF_UNKNOWN) ? -1 : bgp->vrf_id;
+				(bgp->vrf_id.lr.id == LR_UNKNOWN) ? -1 : (int)bgp->vrf_id.lr.id;
 
 			/* Usage summary and header */
 			if (use_json) {
@@ -9864,9 +9864,9 @@ static void bgp_show_all_instances_neighbors_vty(struct vty *vty,
 			}
 
 			json_object_int_add(json, "vrfId",
-					    (bgp->vrf_id == VRF_UNKNOWN)
+					    (bgp->vrf_id.lr.id == LR_UNKNOWN)
 						    ? -1
-						    : bgp->vrf_id);
+					    : (int)bgp->vrf_id.lr.id);
 			json_object_string_add(
 				json, "vrfName",
 				(bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -74,7 +74,7 @@ int zclient_num_connects;
 
 /* Router-id update message from zebra. */
 static int bgp_router_id_update(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+				zebra_size_t length, lr_id_t vrf_id)
 {
 	struct prefix router_id;
 
@@ -83,7 +83,7 @@ static int bgp_router_id_update(int command, struct zclient *zclient,
 	if (BGP_DEBUG(zebra, ZEBRA)) {
 		char buf[PREFIX2STR_BUFFER];
 		prefix2str(&router_id, buf, sizeof(buf));
-		zlog_debug("Rx Router Id update VRF %u Id %s", vrf_id, buf);
+		zlog_debug("Rx Router Id update VRF %u Id %s", vrf_id.lr.id, buf);
 	}
 
 	bgp_router_id_zebra_bump(vrf_id, &router_id);
@@ -92,14 +92,14 @@ static int bgp_router_id_update(int command, struct zclient *zclient,
 
 /* Nexthop update message from zebra. */
 static int bgp_read_nexthop_update(int command, struct zclient *zclient,
-				   zebra_size_t length, vrf_id_t vrf_id)
+				   zebra_size_t length, lr_id_t vrf_id)
 {
 	bgp_parse_nexthop_update(command, vrf_id);
 	return 0;
 }
 
 static int bgp_read_import_check_update(int command, struct zclient *zclient,
-					zebra_size_t length, vrf_id_t vrf_id)
+					zebra_size_t length, lr_id_t vrf_id)
 {
 	bgp_parse_nexthop_update(command, vrf_id);
 	return 0;
@@ -197,7 +197,7 @@ static void bgp_nbr_connected_delete(struct bgp *bgp, struct nbr_connected *ifc,
 
 /* Inteface addition message from zebra. */
 static int bgp_interface_add(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+			     zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct bgp *bgp;
@@ -207,7 +207,7 @@ static int bgp_interface_add(int command, struct zclient *zclient,
 		return 0;
 
 	if (BGP_DEBUG(zebra, ZEBRA) && ifp)
-		zlog_debug("Rx Intf add VRF %u IF %s", vrf_id, ifp->name);
+		zlog_debug("Rx Intf add VRF %u IF %s", vrf_id.lr.id, ifp->name);
 
 	bgp = bgp_lookup_by_vrf_id(vrf_id);
 	if (!bgp)
@@ -218,7 +218,7 @@ static int bgp_interface_add(int command, struct zclient *zclient,
 }
 
 static int bgp_interface_delete(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+				zebra_size_t length, lr_id_t vrf_id)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -234,7 +234,7 @@ static int bgp_interface_delete(int command, struct zclient *zclient,
 		return 0;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Rx Intf del VRF %u IF %s", vrf_id, ifp->name);
+		zlog_debug("Rx Intf del VRF %u IF %s", vrf_id.lr.id, ifp->name);
 
 	bgp_update_interface_nbrs(bgp, ifp, NULL);
 
@@ -243,7 +243,7 @@ static int bgp_interface_delete(int command, struct zclient *zclient,
 }
 
 static int bgp_interface_up(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+			    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -263,7 +263,7 @@ static int bgp_interface_up(int command, struct zclient *zclient,
 		return 0;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Rx Intf up VRF %u IF %s", vrf_id, ifp->name);
+		zlog_debug("Rx Intf up VRF %u IF %s", vrf_id.lr.id, ifp->name);
 
 	for (ALL_LIST_ELEMENTS(ifp->connected, node, nnode, c))
 		bgp_connected_add(bgp, c);
@@ -275,7 +275,7 @@ static int bgp_interface_up(int command, struct zclient *zclient,
 }
 
 static int bgp_interface_down(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+			      zebra_size_t length, lr_id_t vrf_id)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -294,7 +294,7 @@ static int bgp_interface_down(int command, struct zclient *zclient,
 		return 0;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Rx Intf down VRF %u IF %s", vrf_id, ifp->name);
+		zlog_debug("Rx Intf down VRF %u IF %s", vrf_id.lr.id, ifp->name);
 
 	for (ALL_LIST_ELEMENTS(ifp->connected, node, nnode, c))
 		bgp_connected_delete(bgp, c);
@@ -335,7 +335,7 @@ static int bgp_interface_down(int command, struct zclient *zclient,
 }
 
 static int bgp_interface_address_add(int command, struct zclient *zclient,
-				     zebra_size_t length, vrf_id_t vrf_id)
+				     zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *ifc;
 	struct bgp *bgp;
@@ -352,7 +352,7 @@ static int bgp_interface_address_add(int command, struct zclient *zclient,
 	if (bgp_debug_zebra(ifc->address)) {
 		char buf[PREFIX2STR_BUFFER];
 		prefix2str(ifc->address, buf, sizeof(buf));
-		zlog_debug("Rx Intf address add VRF %u IF %s addr %s", vrf_id,
+		zlog_debug("Rx Intf address add VRF %u IF %s addr %s", vrf_id.lr.id,
 			   ifc->ifp->name, buf);
 	}
 
@@ -372,7 +372,7 @@ static int bgp_interface_address_add(int command, struct zclient *zclient,
 }
 
 static int bgp_interface_address_delete(int command, struct zclient *zclient,
-					zebra_size_t length, vrf_id_t vrf_id)
+					zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *ifc;
 	struct bgp *bgp;
@@ -389,7 +389,7 @@ static int bgp_interface_address_delete(int command, struct zclient *zclient,
 	if (bgp_debug_zebra(ifc->address)) {
 		char buf[PREFIX2STR_BUFFER];
 		prefix2str(ifc->address, buf, sizeof(buf));
-		zlog_debug("Rx Intf address del VRF %u IF %s addr %s", vrf_id,
+		zlog_debug("Rx Intf address del VRF %u IF %s addr %s", vrf_id.lr.id,
 			   ifc->ifp->name, buf);
 	}
 
@@ -403,7 +403,7 @@ static int bgp_interface_address_delete(int command, struct zclient *zclient,
 }
 
 static int bgp_interface_nbr_address_add(int command, struct zclient *zclient,
-					 zebra_size_t length, vrf_id_t vrf_id)
+					 zebra_size_t length, lr_id_t vrf_id)
 {
 	struct nbr_connected *ifc = NULL;
 	struct bgp *bgp;
@@ -416,7 +416,7 @@ static int bgp_interface_nbr_address_add(int command, struct zclient *zclient,
 	if (bgp_debug_zebra(ifc->address)) {
 		char buf[PREFIX2STR_BUFFER];
 		prefix2str(ifc->address, buf, sizeof(buf));
-		zlog_debug("Rx Intf neighbor add VRF %u IF %s addr %s", vrf_id,
+		zlog_debug("Rx Intf neighbor add VRF %u IF %s addr %s", vrf_id.lr.id,
 			   ifc->ifp->name, buf);
 	}
 
@@ -432,7 +432,7 @@ static int bgp_interface_nbr_address_add(int command, struct zclient *zclient,
 static int bgp_interface_nbr_address_delete(int command,
 					    struct zclient *zclient,
 					    zebra_size_t length,
-					    vrf_id_t vrf_id)
+					    lr_id_t vrf_id)
 {
 	struct nbr_connected *ifc = NULL;
 	struct bgp *bgp;
@@ -445,7 +445,7 @@ static int bgp_interface_nbr_address_delete(int command,
 	if (bgp_debug_zebra(ifc->address)) {
 		char buf[PREFIX2STR_BUFFER];
 		prefix2str(ifc->address, buf, sizeof(buf));
-		zlog_debug("Rx Intf neighbor del VRF %u IF %s addr %s", vrf_id,
+		zlog_debug("Rx Intf neighbor del VRF %u IF %s addr %s", vrf_id.lr.id,
 			   ifc->ifp->name, buf);
 	}
 
@@ -462,10 +462,10 @@ static int bgp_interface_nbr_address_delete(int command,
 
 /* VRF update for an interface. */
 static int bgp_interface_vrf_update(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+				    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
-	vrf_id_t new_vrf_id;
+	lr_id_t new_vrf_id;
 	struct connected *c;
 	struct nbr_connected *nc;
 	struct listnode *node, *nnode;
@@ -477,8 +477,8 @@ static int bgp_interface_vrf_update(int command, struct zclient *zclient,
 		return 0;
 
 	if (BGP_DEBUG(zebra, ZEBRA) && ifp)
-		zlog_debug("Rx Intf VRF change VRF %u IF %s NewVRF %u", vrf_id,
-			   ifp->name, new_vrf_id);
+		zlog_debug("Rx Intf VRF change VRF %u IF %s NewVRF %u", vrf_id.lr.id,
+			   ifp->name, new_vrf_id.lr.id);
 
 	bgp = bgp_lookup_by_vrf_id(vrf_id);
 	if (!bgp)
@@ -522,7 +522,7 @@ static int bgp_interface_vrf_update(int command, struct zclient *zclient,
 
 /* Zebra route add and delete treatment. */
 static int zebra_read_route(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+			    zebra_size_t length, lr_id_t vrf_id)
 {
 	enum nexthop_types_t nhtype;
 	struct zapi_route api;
@@ -585,7 +585,7 @@ static int zebra_read_route(int command, struct zclient *zclient,
 		zlog_debug(
 			"Rx route %s VRF %u %s[%d] %s "
 			"nexthop %s metric %u tag %" ROUTE_TAG_PRI,
-			(add) ? "add" : "delete", vrf_id,
+			(add) ? "add" : "delete", vrf_id.lr.id,
 			zebra_route_string(api.type), api.instance, buf[0],
 			buf[1], api.metric, api.tag);
 	}
@@ -593,7 +593,7 @@ static int zebra_read_route(int command, struct zclient *zclient,
 	return 0;
 }
 
-struct interface *if_lookup_by_ipv4(struct in_addr *addr, vrf_id_t vrf_id)
+struct interface *if_lookup_by_ipv4(struct in_addr *addr, lr_id_t vrf_id)
 {
 	struct vrf *vrf;
 	struct listnode *cnode;
@@ -622,7 +622,7 @@ struct interface *if_lookup_by_ipv4(struct in_addr *addr, vrf_id_t vrf_id)
 	return NULL;
 }
 
-struct interface *if_lookup_by_ipv4_exact(struct in_addr *addr, vrf_id_t vrf_id)
+struct interface *if_lookup_by_ipv4_exact(struct in_addr *addr, lr_id_t vrf_id)
 {
 	struct vrf *vrf;
 	struct listnode *cnode;
@@ -647,7 +647,7 @@ struct interface *if_lookup_by_ipv4_exact(struct in_addr *addr, vrf_id_t vrf_id)
 }
 
 struct interface *if_lookup_by_ipv6(struct in6_addr *addr, ifindex_t ifindex,
-				    vrf_id_t vrf_id)
+				    lr_id_t vrf_id)
 {
 	struct vrf *vrf;
 	struct listnode *cnode;
@@ -683,7 +683,7 @@ struct interface *if_lookup_by_ipv6(struct in6_addr *addr, ifindex_t ifindex,
 }
 
 struct interface *if_lookup_by_ipv6_exact(struct in6_addr *addr,
-					  ifindex_t ifindex, vrf_id_t vrf_id)
+					  ifindex_t ifindex, lr_id_t vrf_id)
 {
 	struct vrf *vrf;
 	struct listnode *cnode;
@@ -1166,7 +1166,7 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 		prefix2str(&api.prefix, prefix_buf, sizeof(prefix_buf));
 		zlog_debug("Tx route %s VRF %u %s metric %u tag %" ROUTE_TAG_PRI
 			   " count %d",
-			   valid_nh_count ? "add" : "delete", bgp->vrf_id,
+			   valid_nh_count ? "add" : "delete", bgp->vrf_id.lr.id,
 			   prefix_buf, api.metric, api.tag, api.nexthop_num);
 		for (i = 0; i < api.nexthop_num; i++) {
 			api_nh = &api.nexthops[i];
@@ -1252,7 +1252,7 @@ void bgp_zebra_withdraw(struct prefix *p, struct bgp_info *info, safi_t safi)
 		char buf[PREFIX_STRLEN];
 
 		prefix2str(&api.prefix, buf, sizeof(buf));
-		zlog_debug("Tx route delete VRF %u %s", peer->bgp->vrf_id, buf);
+		zlog_debug("Tx route delete VRF %u %s", peer->bgp->vrf_id.lr.id, buf);
 	}
 
 	zclient_route_send(ZEBRA_ROUTE_DELETE, zclient, &api);
@@ -1330,7 +1330,7 @@ int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type, u_short instance)
 			return CMD_WARNING;
 
 #if ENABLE_BGP_VNC
-		if (bgp->vrf_id == VRF_DEFAULT
+		if (bgp->vrf_id.lr.id == LR_DEFAULT
 		    && type == ZEBRA_ROUTE_VNC_DIRECT) {
 			vnc_export_bgp_enable(
 				bgp, afi); /* only enables if mode bits cfg'd */
@@ -1351,7 +1351,7 @@ int bgp_redistribute_set(struct bgp *bgp, afi_t afi, int type, u_short instance)
 
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("Tx redistribute add VRF %u afi %d %s %d",
-			   bgp->vrf_id, afi, zebra_route_string(type),
+			   bgp->vrf_id.lr.id, afi, zebra_route_string(type),
 			   instance);
 
 	/* Send distribute add message to zebra. */
@@ -1372,7 +1372,7 @@ int bgp_redistribute_resend(struct bgp *bgp, afi_t afi, int type,
 
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("Tx redistribute del/add VRF %u afi %d %s %d",
-			   bgp->vrf_id, afi, zebra_route_string(type),
+			   bgp->vrf_id.lr.id, afi, zebra_route_string(type),
 			   instance);
 
 	/* Send distribute add message to zebra. */
@@ -1459,7 +1459,7 @@ int bgp_redistribute_unreg(struct bgp *bgp, afi_t afi, int type,
 	}
 
 #if ENABLE_BGP_VNC
-	if (bgp->vrf_id == VRF_DEFAULT && type == ZEBRA_ROUTE_VNC_DIRECT) {
+	if (bgp->vrf_id.lr.id == LR_DEFAULT && type == ZEBRA_ROUTE_VNC_DIRECT) {
 		vnc_export_bgp_disable(bgp, afi);
 	}
 #endif
@@ -1468,7 +1468,7 @@ int bgp_redistribute_unreg(struct bgp *bgp, afi_t afi, int type,
 		/* Send distribute delete message to zebra. */
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("Tx redistribute del VRF %u afi %d %s %d",
-				   bgp->vrf_id, afi, zebra_route_string(type),
+				   bgp->vrf_id.lr.id, afi, zebra_route_string(type),
 				   instance);
 		zebra_redistribute_send(ZEBRA_REDISTRIBUTE_DELETE, zclient, afi,
 					type, instance, bgp->vrf_id);
@@ -1509,7 +1509,7 @@ int bgp_redistribute_unset(struct bgp *bgp, afi_t afi, int type,
 
 /* Update redistribute vrf bitmap during triggers like
    restart networking or delete/add VRFs */
-void bgp_update_redist_vrf_bitmaps(struct bgp *bgp, vrf_id_t old_vrf_id)
+void bgp_update_redist_vrf_bitmaps(struct bgp *bgp, lr_id_t old_vrf_id)
 {
 	int i;
 	afi_t afi;
@@ -1542,7 +1542,7 @@ void bgp_zebra_instance_register(struct bgp *bgp)
 		return;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Registering VRF %u", bgp->vrf_id);
+		zlog_debug("Registering VRF %u", bgp->vrf_id.lr.id);
 
 	/* Register for router-id, interfaces, redistributed routes. */
 	zclient_send_reg_requests(zclient, bgp->vrf_id);
@@ -1564,7 +1564,7 @@ void bgp_zebra_instance_deregister(struct bgp *bgp)
 		return;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Deregistering VRF %u", bgp->vrf_id);
+		zlog_debug("Deregistering VRF %u", bgp->vrf_id.lr.id);
 
 	/* For default instance, unregister learning about VNIs, if appropriate.
 	 */
@@ -1585,7 +1585,7 @@ void bgp_zebra_initiate_radv(struct bgp *bgp, struct peer *peer)
 		return;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("%u: Initiating RA for peer %s", bgp->vrf_id,
+		zlog_debug("%u: Initiating RA for peer %s", bgp->vrf_id.lr.id,
 			   peer->host);
 
 	zclient_send_interface_radv_req(zclient, bgp->vrf_id, peer->ifp, 1,
@@ -1599,7 +1599,7 @@ void bgp_zebra_terminate_radv(struct bgp *bgp, struct peer *peer)
 		return;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("%u: Terminating RA for peer %s", bgp->vrf_id,
+		zlog_debug("%u: Terminating RA for peer %s", bgp->vrf_id.lr.id,
 			   peer->host);
 
 	zclient_send_interface_radv_req(zclient, bgp->vrf_id, peer->ifp, 0, 0);
@@ -1676,7 +1676,7 @@ static void bgp_zebra_connected(struct zclient *zclient)
 }
 
 static int bgp_zebra_process_local_vni(int command, struct zclient *zclient,
-				       zebra_size_t length, vrf_id_t vrf_id)
+				       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct stream *s;
 	vni_t vni;
@@ -1693,7 +1693,7 @@ static int bgp_zebra_process_local_vni(int command, struct zclient *zclient,
 
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("Rx VNI %s VRF %u VNI %u",
-			   (command == ZEBRA_VNI_ADD) ? "add" : "del", vrf_id,
+			   (command == ZEBRA_VNI_ADD) ? "add" : "del", vrf_id.lr.id,
 			   vni);
 
 	if (command == ZEBRA_VNI_ADD)
@@ -1704,7 +1704,7 @@ static int bgp_zebra_process_local_vni(int command, struct zclient *zclient,
 }
 
 static int bgp_zebra_process_local_macip(int command, struct zclient *zclient,
-					 zebra_size_t length, vrf_id_t vrf_id)
+					 zebra_size_t length, lr_id_t vrf_id)
 {
 	struct stream *s;
 	vni_t vni;
@@ -1724,7 +1724,7 @@ static int bgp_zebra_process_local_macip(int command, struct zclient *zclient,
 	if (ipa_len != 0 && ipa_len != IPV4_MAX_BYTELEN
 	    && ipa_len != IPV6_MAX_BYTELEN) {
 		zlog_err("%u:Recv MACIP %s with invalid IP addr length %d",
-			 vrf_id, (command == ZEBRA_MACIP_ADD) ? "Add" : "Del",
+			 vrf_id.lr.id, (command == ZEBRA_MACIP_ADD) ? "Add" : "Del",
 			 ipa_len);
 		return -1;
 	}
@@ -1742,7 +1742,7 @@ static int bgp_zebra_process_local_macip(int command, struct zclient *zclient,
 
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("%u:Recv MACIP %s flags 0x%x MAC %s IP %s VNI %u",
-			   vrf_id, (command == ZEBRA_MACIP_ADD) ? "Add" : "Del",
+			   vrf_id.lr.id, (command == ZEBRA_MACIP_ADD) ? "Add" : "Del",
 			   flags, prefix_mac2str(&mac, buf, sizeof(buf)),
 			   ipaddr2str(&ip, buf1, sizeof(buf1)), vni);
 

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -52,12 +52,12 @@ extern int bgp_redistribute_metric_set(struct bgp *, struct bgp_redist *, afi_t,
 extern int bgp_redistribute_unset(struct bgp *, afi_t, int, u_short);
 extern int bgp_redistribute_unreg(struct bgp *, afi_t, int, u_short);
 
-extern struct interface *if_lookup_by_ipv4(struct in_addr *, vrf_id_t);
-extern struct interface *if_lookup_by_ipv4_exact(struct in_addr *, vrf_id_t);
+extern struct interface *if_lookup_by_ipv4(struct in_addr *, lr_id_t);
+extern struct interface *if_lookup_by_ipv4_exact(struct in_addr *, lr_id_t);
 extern struct interface *if_lookup_by_ipv6(struct in6_addr *, ifindex_t,
-					   vrf_id_t);
+					   lr_id_t);
 extern struct interface *if_lookup_by_ipv6_exact(struct in6_addr *, ifindex_t,
-						 vrf_id_t);
+						 lr_id_t);
 
 extern int bgp_zebra_advertise_gw_macip(struct bgp *, int, vni_t);
 extern int bgp_zebra_advertise_all_vni(struct bgp *, int);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -240,12 +240,12 @@ static int bgp_router_id_set(struct bgp *bgp, const struct in_addr *id)
 	return 0;
 }
 
-void bgp_router_id_zebra_bump(vrf_id_t vrf_id, const struct prefix *router_id)
+void bgp_router_id_zebra_bump(lr_id_t vrf_id, const struct prefix *router_id)
 {
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
 
-	if (vrf_id == VRF_DEFAULT) {
+	if (vrf_id.lr.id == LR_DEFAULT) {
 		/* Router-id change for default VRF has to also update all
 		 * views. */
 		for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
@@ -2831,8 +2831,8 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 
 	bgp_lock(bgp);
 	bgp->inst_type = inst_type;
-	bgp->vrf_id = (inst_type == BGP_INSTANCE_TYPE_DEFAULT) ? VRF_DEFAULT
-							       : VRF_UNKNOWN;
+	bgp->vrf_id.lr.id = (inst_type == BGP_INSTANCE_TYPE_DEFAULT) ? LR_DEFAULT
+							       : LR_UNKNOWN;
 	bgp->peer_self = peer_new(bgp);
 	if (bgp->peer_self->host)
 		XFREE(MTYPE_BGP_PEER_HOST, bgp->peer_self->host);
@@ -2972,7 +2972,7 @@ struct bgp *bgp_lookup_by_name(const char *name)
 
 /* Lookup BGP instance based on VRF id. */
 /* Note: Only to be used for incoming messages from Zebra. */
-struct bgp *bgp_lookup_by_vrf_id(vrf_id_t vrf_id)
+struct bgp *bgp_lookup_by_vrf_id(lr_id_t vrf_id)
 {
 	struct vrf *vrf;
 
@@ -7397,7 +7397,7 @@ static void bgp_viewvrf_autocomplete(vector comps, struct cmd_token *token)
 	struct bgp *bgp;
 
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		if (vrf->vrf_id != VRF_DEFAULT)
+		if (vrf->vrf_id.lr.id != LR_DEFAULT)
 			vector_set(comps, XSTRDUP(MTYPE_COMPLETION, vrf->name));
 	}
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -181,7 +181,7 @@ struct bgp {
 
 	/* Type of instance and VRF id. */
 	enum bgp_instance_type inst_type;
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 
 	/* Reference count to allow peer_delete to finish after bgp_delete */
 	int lock;
@@ -417,7 +417,7 @@ DECLARE_QOBJ_TYPE(bgp)
 #define IS_BGP_INST_KNOWN_TO_ZEBRA(bgp)                                        \
 	(bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT                           \
 	 || (bgp->inst_type == BGP_INSTANCE_TYPE_VRF                           \
-	     && bgp->vrf_id != VRF_UNKNOWN))
+	     && bgp->vrf_id.lr.id != LR_UNKNOWN))
 
 /* BGP peer-group support. */
 struct peer_group {
@@ -1225,7 +1225,7 @@ extern int bgp_nexthop_set(union sockunion *, union sockunion *,
 extern struct bgp *bgp_get_default(void);
 extern struct bgp *bgp_lookup(as_t, const char *);
 extern struct bgp *bgp_lookup_by_name(const char *);
-extern struct bgp *bgp_lookup_by_vrf_id(vrf_id_t);
+extern struct bgp *bgp_lookup_by_vrf_id(lr_id_t);
 extern struct peer *peer_lookup(struct bgp *, union sockunion *);
 extern struct peer *peer_lookup_by_conf_if(struct bgp *, const char *);
 extern struct peer *peer_lookup_by_hostname(struct bgp *, const char *);
@@ -1289,7 +1289,7 @@ extern int bgp_flag_set(struct bgp *, int);
 extern int bgp_flag_unset(struct bgp *, int);
 extern int bgp_flag_check(struct bgp *, int);
 
-extern void bgp_router_id_zebra_bump(vrf_id_t, const struct prefix *);
+extern void bgp_router_id_zebra_bump(lr_id_t, const struct prefix *);
 extern int bgp_router_id_static_set(struct bgp *, struct in_addr);
 
 extern int bgp_cluster_id_set(struct bgp *, struct in_addr *);
@@ -1576,7 +1576,7 @@ static inline struct vrf *bgp_vrf_lookup_by_instance_type(struct bgp *bgp)
 	struct vrf *vrf;
 
 	if (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)
-		vrf = vrf_lookup_by_id(VRF_DEFAULT);
+		vrf = vrf_lookup_by_id(vrf_id_default);
 	else if (bgp->inst_type == BGP_INSTANCE_TYPE_VRF)
 		vrf = vrf_lookup_by_name(bgp->name);
 	else
@@ -1600,10 +1600,10 @@ static inline void bgp_vrf_unlink(struct bgp *bgp, struct vrf *vrf)
 		vrf->info = NULL;
 		bgp_unlock(bgp);
 	}
-	bgp->vrf_id = VRF_UNKNOWN;
+	bgp->vrf_id.lr.id = LR_UNKNOWN;
 }
 
-extern void bgp_update_redist_vrf_bitmaps(struct bgp *, vrf_id_t);
+extern void bgp_update_redist_vrf_bitmaps(struct bgp *, lr_id_t);
 
 /* For benefit of rfapi */
 extern struct peer *peer_new(struct bgp *bgp);

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -340,7 +340,7 @@ static void vnc_redistribute_withdraw(struct bgp *bgp, afi_t afi, uint8_t type)
  * Assumes 1 nexthop
  */
 static int vnc_zebra_read_route(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+				zebra_size_t length, lr_id_t vrf_id)
 {
 	struct zapi_route api;
 	int add;
@@ -392,7 +392,7 @@ static void vnc_zebra_route_msg(struct prefix *p, unsigned int nhp_count,
 	}
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id.lr.id = LR_DEFAULT;
 	api.type = ZEBRA_ROUTE_VNC;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *p;
@@ -836,7 +836,7 @@ int vnc_redistribute_set(struct bgp *bgp, afi_t afi, int type)
 	if (zclient_vnc->redist[afi][type])
 		return CMD_WARNING_CONFIG_FAILED;
 
-	vrf_bitmap_set(zclient_vnc->redist[afi][type], VRF_DEFAULT);
+	vrf_bitmap_set(zclient_vnc->redist[afi][type], vrf_id_default);
 
 	// zclient_vnc->redist[afi][type] = 1;
 
@@ -850,7 +850,7 @@ int vnc_redistribute_set(struct bgp *bgp, afi_t afi, int type)
 
 	/* Send distribute add message to zebra. */
 	zebra_redistribute_send(ZEBRA_REDISTRIBUTE_ADD, zclient_vnc, afi, type,
-				0, VRF_DEFAULT);
+				0, vrf_id_default);
 
 	return CMD_SUCCESS;
 }
@@ -882,7 +882,7 @@ int vnc_redistribute_unset(struct bgp *bgp, afi_t afi, int type)
 				"Zebra send: redistribute delete %s",
 				zebra_route_string(type));
 		zebra_redistribute_send(ZEBRA_REDISTRIBUTE_DELETE, zclient_vnc,
-					afi, type, 0, VRF_DEFAULT);
+					afi, type, 0, vrf_id_default);
 	}
 
 	/* Withdraw redistributed routes from current BGP's routing table. */

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -172,7 +172,7 @@ void eigrp_distribute_update(struct distribute *dist)
 		return;
 	}
 
-	ifp = if_lookup_by_name(dist->ifname, VRF_DEFAULT);
+	ifp = if_lookup_by_name(dist->ifname, vrf_id_default);
 	if (ifp == NULL)
 		return;
 
@@ -295,7 +295,7 @@ void eigrp_distribute_update_interface(struct interface *ifp)
  */
 void eigrp_distribute_update_all(struct prefix_list *notused)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)

--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -146,7 +146,7 @@ eigrp_hello_parameter_decode(struct eigrp_neighbor *nbr,
 			zlog_info("Neighbor %s (%s) is pending: new adjacency",
 				  inet_ntoa(nbr->src),
 				  ifindex2ifname(nbr->ei->ifp->ifindex,
-						 VRF_DEFAULT));
+						 vrf_id_default));
 
 			/* Expedited hello sent */
 			eigrp_hello_send(nbr->ei, EIGRP_HELLO_NORMAL, NULL);
@@ -166,7 +166,7 @@ eigrp_hello_parameter_decode(struct eigrp_neighbor *nbr,
 					"Neighbor %s (%s) is down: Interface PEER-TERMINATION received",
 					inet_ntoa(nbr->src),
 					ifindex2ifname(nbr->ei->ifp->ifindex,
-						       VRF_DEFAULT));
+						       vrf_id_default));
 				eigrp_nbr_delete(nbr);
 				return NULL;
 			} else {
@@ -174,7 +174,7 @@ eigrp_hello_parameter_decode(struct eigrp_neighbor *nbr,
 					"Neighbor %s (%s) going down: Kvalue mismatch",
 					inet_ntoa(nbr->src),
 					ifindex2ifname(nbr->ei->ifp->ifindex,
-						       VRF_DEFAULT));
+						       vrf_id_default));
 				eigrp_nbr_state_set(nbr, EIGRP_NEIGHBOR_DOWN);
 			}
 		}
@@ -253,7 +253,7 @@ static void eigrp_peer_termination_decode(struct eigrp_neighbor *nbr,
 	if (my_ip == received_ip) {
 		zlog_info("Neighbor %s (%s) is down: Peer Termination received",
 			  inet_ntoa(nbr->src),
-			  ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
+			  ifindex2ifname(nbr->ei->ifp->ifindex, vrf_id_default));
 		/* set neighbor to DOWN */
 		nbr->state = EIGRP_NEIGHBOR_DOWN;
 		/* delete neighbor */
@@ -329,7 +329,7 @@ void eigrp_hello_receive(struct eigrp *eigrp, struct ip *iph,
 
 	if (IS_DEBUG_EIGRP_PACKET(eigrph->opcode - 1, RECV))
 		zlog_debug("Processing Hello size[%u] int(%s) nbr(%s)", size,
-			   ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT),
+			   ifindex2ifname(nbr->ei->ifp->ifindex, vrf_id_default),
 			   inet_ntoa(nbr->src));
 
 	size -= EIGRP_HEADER_LEN;

--- a/eigrpd/eigrp_neighbor.c
+++ b/eigrpd/eigrp_neighbor.c
@@ -199,7 +199,7 @@ int holddown_timer_expired(struct thread *thread)
 
 	zlog_info("Neighbor %s (%s) is down: holding time expired",
 		  inet_ntoa(nbr->src),
-		  ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
+		  ifindex2ifname(nbr->ei->ifp->ifindex, vrf_id_default));
 	nbr->state = EIGRP_NEIGHBOR_DOWN;
 	eigrp_nbr_delete(nbr);
 
@@ -341,12 +341,12 @@ void eigrp_nbr_hard_restart(struct eigrp_neighbor *nbr, struct vty *vty)
 
 	zlog_debug("Neighbor %s (%s) is down: manually cleared",
 		   inet_ntoa(nbr->src),
-		   ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
+		   ifindex2ifname(nbr->ei->ifp->ifindex, vrf_id_default));
 	if (vty != NULL) {
 		vty_time_print(vty, 0);
 		vty_out(vty, "Neighbor %s (%s) is down: manually cleared\n",
 			inet_ntoa(nbr->src),
-			ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
+			ifindex2ifname(nbr->ei->ifp->ifindex, vrf_id_default));
 	}
 
 	/* send Hello with Peer Termination TLV */

--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -229,7 +229,7 @@ int eigrp_if_drop_allspfrouters(struct eigrp *top, struct prefix *p,
 
 int eigrp_network_set(struct eigrp *eigrp, struct prefix *p)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct route_node *rn;
 	struct interface *ifp;
 

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -521,7 +521,7 @@ int eigrp_read(struct thread *thread)
 		   ifindex
 		   retrieval but do not. */
 		c = if_lookup_address((void *)&iph->ip_src, AF_INET,
-				      VRF_DEFAULT);
+				      vrf_id_default);
 
 		if (c == NULL)
 			return 0;
@@ -769,7 +769,7 @@ static struct stream *eigrp_recv_packet(int fd, struct interface **ifp,
 
 	ifindex = getsockopt_ifindex(AF_INET, &msgh);
 
-	*ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
+	*ifp = if_lookup_by_index(ifindex, vrf_id_default);
 
 	if (ret != ip_len) {
 		zlog_warn(

--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -212,7 +212,7 @@ void eigrp_update_receive(struct eigrp *eigrp, struct ip *iph,
 		zlog_debug(
 			"Processing Update size[%u] int(%s) nbr(%s) seq [%u] flags [%0x]",
 			size,
-			ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT),
+			ifindex2ifname(nbr->ei->ifp->ifindex, vrf_id_default),
 			inet_ntoa(nbr->src), nbr->recv_sequence_number, flags);
 
 
@@ -222,7 +222,7 @@ void eigrp_update_receive(struct eigrp *eigrp, struct ip *iph,
 
 		zlog_info("Neighbor %s (%s) is resync: peer graceful-restart",
 			  inet_ntoa(nbr->src),
-			  ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
+			  ifindex2ifname(nbr->ei->ifp->ifindex, vrf_id_default));
 
 		/* get all prefixes from neighbor from topology table */
 		nbr_prefixes = eigrp_neighbor_prefixes_lookup(eigrp, nbr);
@@ -234,7 +234,7 @@ void eigrp_update_receive(struct eigrp *eigrp, struct ip *iph,
 
 		zlog_info("Neighbor %s (%s) is resync: peer graceful-restart",
 			  inet_ntoa(nbr->src),
-			  ifindex2ifname(nbr->ei->ifp->ifindex, VRF_DEFAULT));
+			  ifindex2ifname(nbr->ei->ifp->ifindex, vrf_id_default));
 
 		/* get all prefixes from neighbor from topology table */
 		nbr_prefixes = eigrp_neighbor_prefixes_lookup(eigrp, nbr);
@@ -283,12 +283,12 @@ void eigrp_update_receive(struct eigrp *eigrp, struct ip *iph,
 			zlog_info("Neighbor %s (%s) is down: peer restarted",
 				  inet_ntoa(nbr->src),
 				  ifindex2ifname(nbr->ei->ifp->ifindex,
-						 VRF_DEFAULT));
+						 vrf_id_default));
 			eigrp_nbr_state_set(nbr, EIGRP_NEIGHBOR_PENDING);
 			zlog_info("Neighbor %s (%s) is pending: new adjacency",
 				  inet_ntoa(nbr->src),
 				  ifindex2ifname(nbr->ei->ifp->ifindex,
-						 VRF_DEFAULT));
+						 vrf_id_default));
 			eigrp_update_send_init(nbr);
 		}
 	}
@@ -968,12 +968,12 @@ void eigrp_update_send_GR(struct eigrp_neighbor *nbr, enum GR_type gr_type,
 		zlog_info(
 			"Neighbor %s (%s) is resync: route configuration changed",
 			inet_ntoa(nbr->src),
-			ifindex2ifname(ei->ifp->ifindex, VRF_DEFAULT));
+			ifindex2ifname(ei->ifp->ifindex, vrf_id_default));
 	} else if (gr_type == EIGRP_GR_MANUAL) {
 		/* Graceful restart was called manually */
 		zlog_info("Neighbor %s (%s) is resync: manually cleared",
 			  inet_ntoa(nbr->src),
-			  ifindex2ifname(ei->ifp->ifindex, VRF_DEFAULT));
+			  ifindex2ifname(ei->ifp->ifindex, vrf_id_default));
 
 		if (vty != NULL) {
 			vty_time_print(vty, 0);
@@ -981,7 +981,7 @@ void eigrp_update_send_GR(struct eigrp_neighbor *nbr, enum GR_type gr_type,
 				"Neighbor %s (%s) is resync: manually cleared\n",
 				inet_ntoa(nbr->src),
 				ifindex2ifname(ei->ifp->ifindex,
-					       VRF_DEFAULT));
+					       vrf_id_default));
 		}
 	}
 

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -77,7 +77,7 @@ static int config_write_network(struct vty *vty, struct eigrp *eigrp)
 	for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
 		if (i != zclient->redist_default
 		    && vrf_bitmap_check(zclient->redist[AFI_IP][i],
-					VRF_DEFAULT))
+					vrf_id_default))
 			vty_out(vty, " redistribute %s\n",
 				zebra_route_string(i));
 
@@ -132,7 +132,7 @@ static int config_write_interfaces(struct vty *vty, struct eigrp *eigrp)
 
 static int eigrp_write_interface(struct vty *vty)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct eigrp_interface *ei;
 
@@ -1243,13 +1243,13 @@ DEFUN (clear_ip_eigrp_neighbors,
 					"Neighbor %s (%s) is down: manually cleared",
 					inet_ntoa(nbr->src),
 					ifindex2ifname(nbr->ei->ifp->ifindex,
-						       VRF_DEFAULT));
+						       vrf_id_default));
 				vty_time_print(vty, 0);
 				vty_out(vty,
 					"Neighbor %s (%s) is down: manually cleared\n",
 					inet_ntoa(nbr->src),
 					ifindex2ifname(nbr->ei->ifp->ifindex,
-						       VRF_DEFAULT));
+						       vrf_id_default));
 
 				/* set neighbor to DOWN */
 				nbr->state = EIGRP_NEIGHBOR_DOWN;
@@ -1304,13 +1304,13 @@ DEFUN (clear_ip_eigrp_neighbors_int,
 			zlog_debug("Neighbor %s (%s) is down: manually cleared",
 				   inet_ntoa(nbr->src),
 				   ifindex2ifname(nbr->ei->ifp->ifindex,
-						  VRF_DEFAULT));
+						  vrf_id_default));
 			vty_time_print(vty, 0);
 			vty_out(vty,
 				"Neighbor %s (%s) is down: manually cleared\n",
 				inet_ntoa(nbr->src),
 				ifindex2ifname(nbr->ei->ifp->ifindex,
-					       VRF_DEFAULT));
+					       vrf_id_default));
 
 			/* set neighbor to DOWN */
 			nbr->state = EIGRP_NEIGHBOR_DOWN;

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -53,21 +53,21 @@
 #include "eigrpd/eigrp_topology.h"
 #include "eigrpd/eigrp_fsm.h"
 
-static int eigrp_interface_add(int, struct zclient *, zebra_size_t, vrf_id_t);
+static int eigrp_interface_add(int, struct zclient *, zebra_size_t, lr_id_t);
 static int eigrp_interface_delete(int, struct zclient *, zebra_size_t,
-				  vrf_id_t);
+				  lr_id_t);
 static int eigrp_interface_address_add(int, struct zclient *, zebra_size_t,
-				       vrf_id_t vrf_id);
+				       lr_id_t vrf_id);
 static int eigrp_interface_address_delete(int, struct zclient *, zebra_size_t,
-					  vrf_id_t vrf_id);
+					  lr_id_t vrf_id);
 static int eigrp_interface_state_up(int, struct zclient *, zebra_size_t,
-				    vrf_id_t vrf_id);
+				    lr_id_t vrf_id);
 static int eigrp_interface_state_down(int, struct zclient *, zebra_size_t,
-				      vrf_id_t vrf_id);
+				      lr_id_t vrf_id);
 static struct interface *zebra_interface_if_lookup(struct stream *);
 
 static int eigrp_zebra_read_route(int, struct zclient *, zebra_size_t,
-				  vrf_id_t vrf_id);
+				  lr_id_t vrf_id);
 
 /* Zebra structure to hold current status. */
 struct zclient *zclient = NULL;
@@ -78,7 +78,7 @@ struct in_addr router_id_zebra;
 
 /* Router-id update message from zebra. */
 static int eigrp_router_id_update_zebra(int command, struct zclient *zclient,
-					zebra_size_t length, vrf_id_t vrf_id)
+					zebra_size_t length, lr_id_t vrf_id)
 {
 	struct eigrp *eigrp;
 	struct prefix router_id;
@@ -95,7 +95,7 @@ static int eigrp_router_id_update_zebra(int command, struct zclient *zclient,
 }
 
 static int eigrp_zebra_notify_owner(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+				    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct prefix p;
 	enum zapi_route_notify_owner note;
@@ -108,7 +108,7 @@ static int eigrp_zebra_notify_owner(int command, struct zclient *zclient,
 
 static void eigrp_zebra_connected(struct zclient *zclient)
 {
-	zclient_send_reg_requests(zclient, VRF_DEFAULT);
+	zclient_send_reg_requests(zclient, vrf_id_default);
 }
 
 void eigrp_zebra_init(void)
@@ -134,7 +134,7 @@ void eigrp_zebra_init(void)
 
 /* Zebra route add and delete treatment. */
 static int eigrp_zebra_read_route(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+				  zebra_size_t length, lr_id_t vrf_id)
 {
 	struct zapi_route api;
 	struct eigrp *eigrp;
@@ -160,7 +160,7 @@ static int eigrp_zebra_read_route(int command, struct zclient *zclient,
 
 /* Inteface addition message from zebra. */
 static int eigrp_interface_add(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+			       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct eigrp_interface *ei;
@@ -180,7 +180,7 @@ static int eigrp_interface_add(int command, struct zclient *zclient,
 }
 
 static int eigrp_interface_delete(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+				  zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -212,7 +212,7 @@ static int eigrp_interface_delete(int command, struct zclient *zclient,
 }
 
 static int eigrp_interface_address_add(int command, struct zclient *zclient,
-				       zebra_size_t length, vrf_id_t vrf_id)
+				       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *c;
 
@@ -234,7 +234,7 @@ static int eigrp_interface_address_add(int command, struct zclient *zclient,
 }
 
 static int eigrp_interface_address_delete(int command, struct zclient *zclient,
-					  zebra_size_t length, vrf_id_t vrf_id)
+					  zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *c;
 	struct interface *ifp;
@@ -266,7 +266,7 @@ static int eigrp_interface_address_delete(int command, struct zclient *zclient,
 }
 
 static int eigrp_interface_state_up(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+				    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -323,7 +323,7 @@ static int eigrp_interface_state_up(int command, struct zclient *zclient,
 }
 
 static int eigrp_interface_state_down(int command, struct zclient *zclient,
-				      zebra_size_t length, vrf_id_t vrf_id)
+				      zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -350,7 +350,7 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, VRF_DEFAULT);
+	return if_lookup_by_name(ifname_tmp, vrf_id_default);
 }
 
 void eigrp_zebra_route_add(struct prefix *p, struct list *successors)
@@ -365,7 +365,7 @@ void eigrp_zebra_route_add(struct prefix *p, struct list *successors)
 		return;
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id.lr.id = LR_DEFAULT;
 	api.type = ZEBRA_ROUTE_EIGRP;
 	api.safi = SAFI_UNICAST;
 	memcpy(&api.prefix, p, sizeof(*p));
@@ -406,7 +406,7 @@ void eigrp_zebra_route_delete(struct prefix *p)
 		return;
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id.lr.id = LR_DEFAULT;
 	api.type = ZEBRA_ROUTE_EIGRP;
 	api.safi = SAFI_UNICAST;
 	memcpy(&api.prefix, p, sizeof(*p));
@@ -425,9 +425,9 @@ int eigrp_is_type_redistributed(int type)
 {
 	return ((DEFAULT_ROUTE_TYPE(type))
 			? vrf_bitmap_check(zclient->default_information,
-					   VRF_DEFAULT)
+					   vrf_id_default)
 			: vrf_bitmap_check(zclient->redist[AFI_IP][type],
-					   VRF_DEFAULT));
+					   vrf_id_default));
 }
 
 int eigrp_redistribute_set(struct eigrp *eigrp, int type,
@@ -453,7 +453,7 @@ int eigrp_redistribute_set(struct eigrp *eigrp, int type,
 	eigrp->dmetric[type] = metric;
 
 	zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP, type, 0,
-			     VRF_DEFAULT);
+			     vrf_id_default);
 
 	++eigrp->redistribute;
 
@@ -466,7 +466,7 @@ int eigrp_redistribute_unset(struct eigrp *eigrp, int type)
 	if (eigrp_is_type_redistributed(type)) {
 		memset(&eigrp->dmetric[type], 0, sizeof(struct eigrp_metrics));
 		zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, zclient, AFI_IP,
-				     type, 0, VRF_DEFAULT);
+				     type, 0, vrf_id_default);
 		--eigrp->redistribute;
 	}
 

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -94,7 +94,7 @@ extern struct in_addr router_id_zebra;
  */
 void eigrp_router_id_update(struct eigrp *eigrp)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	u_int32_t router_id, router_id_old;
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -932,7 +932,7 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 
 int isis_interface_config_write(struct vty *vty)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	int write = 0;
 	struct listnode *node;
 	struct interface *ifp;

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1245,7 +1245,7 @@ DEFUN (show_isis_mpls_te_interface,
        "Interface information\n"
        "Interface name\n")
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	int idx_interface = 4;
 	struct interface *ifp;
 
@@ -1257,7 +1257,7 @@ DEFUN (show_isis_mpls_te_interface,
 	/* Interface name is specified. */
 	else {
 		if ((ifp = if_lookup_by_name(argv[idx_interface]->arg,
-					     VRF_DEFAULT))
+					     vrf_id_default))
 		    == NULL)
 			vty_out(vty, "No such interface name\n");
 		else

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -55,7 +55,7 @@ struct zclient *zclient = NULL;
 
 /* Router-id update message from zebra. */
 static int isis_router_id_update_zebra(int command, struct zclient *zclient,
-				       zebra_size_t length, vrf_id_t vrf_id)
+				       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct isis_area *area;
 	struct listnode *node;
@@ -81,7 +81,7 @@ static int isis_router_id_update_zebra(int command, struct zclient *zclient,
 }
 
 static int isis_zebra_if_add(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+			     zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -101,7 +101,7 @@ static int isis_zebra_if_add(int command, struct zclient *zclient,
 }
 
 static int isis_zebra_if_del(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+			     zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -134,7 +134,7 @@ static int isis_zebra_if_del(int command, struct zclient *zclient,
 }
 
 static int isis_zebra_if_state_up(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+				  zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -149,7 +149,7 @@ static int isis_zebra_if_state_up(int command, struct zclient *zclient,
 }
 
 static int isis_zebra_if_state_down(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+				    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
@@ -168,7 +168,7 @@ static int isis_zebra_if_state_down(int command, struct zclient *zclient,
 }
 
 static int isis_zebra_if_address_add(int command, struct zclient *zclient,
-				     zebra_size_t length, vrf_id_t vrf_id)
+				     zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *c;
 	struct prefix *p;
@@ -196,7 +196,7 @@ static int isis_zebra_if_address_add(int command, struct zclient *zclient,
 }
 
 static int isis_zebra_if_address_del(int command, struct zclient *client,
-				     zebra_size_t length, vrf_id_t vrf_id)
+				     zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *c;
 	struct interface *ifp;
@@ -260,7 +260,7 @@ static void isis_zebra_route_add_route(struct prefix *prefix,
 		return;
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id.lr.id = LR_DEFAULT;
 	api.type = ZEBRA_ROUTE_ISIS;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *prefix;
@@ -328,7 +328,7 @@ static void isis_zebra_route_del_route(struct prefix *prefix,
 		return;
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id.lr.id = LR_DEFAULT;
 	api.type = ZEBRA_ROUTE_ISIS;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *prefix;
@@ -350,7 +350,7 @@ void isis_zebra_route_update(struct prefix *prefix,
 }
 
 static int isis_zebra_read(int command, struct zclient *zclient,
-			   zebra_size_t length, vrf_id_t vrf_id)
+			   zebra_size_t length, lr_id_t vrf_id)
 {
 	struct zapi_route api;
 
@@ -388,25 +388,25 @@ void isis_zebra_redistribute_set(afi_t afi, int type)
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_ADD,
-					     zclient, VRF_DEFAULT);
+					     zclient, vrf_id_default);
 	else
 		zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, zclient, afi, type,
-				     0, VRF_DEFAULT);
+				     0, vrf_id_default);
 }
 
 void isis_zebra_redistribute_unset(afi_t afi, int type)
 {
 	if (type == DEFAULT_ROUTE)
 		zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_DELETE,
-					     zclient, VRF_DEFAULT);
+					     zclient, vrf_id_default);
 	else
 		zclient_redistribute(ZEBRA_REDISTRIBUTE_DELETE, zclient, afi,
-				     type, 0, VRF_DEFAULT);
+				     type, 0, vrf_id_default);
 }
 
 static void isis_zebra_connected(struct zclient *zclient)
 {
-	zclient_send_reg_requests(zclient, VRF_DEFAULT);
+	zclient_send_reg_requests(zclient, vrf_id_default);
 }
 
 void isis_zebra_init(struct thread_master *master)

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -39,21 +39,21 @@ static void	 ifc2kaddr(struct interface *, struct connected *,
 		    struct kaddr *);
 static int	 zebra_send_mpls_labels(int, struct kroute *);
 static int	 ldp_router_id_update(int, struct zclient *, zebra_size_t,
-		    vrf_id_t);
+		    lr_id_t);
 static int	 ldp_interface_add(int, struct zclient *, zebra_size_t,
-		    vrf_id_t);
+		    lr_id_t);
 static int	 ldp_interface_delete(int, struct zclient *, zebra_size_t,
-		    vrf_id_t);
+		    lr_id_t);
 static int	 ldp_interface_status_change(int command, struct zclient *,
-		    zebra_size_t, vrf_id_t);
+		    zebra_size_t, lr_id_t);
 static int	 ldp_interface_address_add(int, struct zclient *, zebra_size_t,
-		    vrf_id_t);
+		    lr_id_t);
 static int	 ldp_interface_address_delete(int, struct zclient *,
-		    zebra_size_t, vrf_id_t);
+		    zebra_size_t, lr_id_t);
 static int	 ldp_zebra_read_route(int, struct zclient *, zebra_size_t,
-		    vrf_id_t);
+		    lr_id_t);
 static int	 ldp_zebra_read_pw_status_update(int, struct zclient *,
-		    zebra_size_t, vrf_id_t);
+		    zebra_size_t, lr_id_t);
 static void	 ldp_zebra_connected(struct zclient *);
 
 static struct zclient	*zclient;
@@ -132,7 +132,7 @@ zebra_send_mpls_labels(int cmd, struct kroute *kr)
 	s = zclient->obuf;
 	stream_reset(s);
 
-	zclient_create_header(s, cmd, VRF_DEFAULT);
+	zclient_create_header(s, cmd, vrf_id_default);
 	stream_putc(s, ZEBRA_LSP_LDP);
 	stream_putl(s, kr->af);
 	switch (kr->af) {
@@ -212,7 +212,7 @@ kmpw_unset(struct zapi_pw *zpw)
 void
 kif_redistribute(const char *ifname)
 {
-	struct vrf		*vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf		*vrf = vrf_lookup_by_id(vrf_id_default);
 	struct listnode		*cnode;
 	struct interface	*ifp;
 	struct connected	*ifc;
@@ -236,7 +236,7 @@ kif_redistribute(const char *ifname)
 
 static int
 ldp_router_id_update(int command, struct zclient *zclient, zebra_size_t length,
-    vrf_id_t vrf_id)
+    lr_id_t vrf_id)
 {
 	struct prefix	 router_id;
 
@@ -256,7 +256,7 @@ ldp_router_id_update(int command, struct zclient *zclient, zebra_size_t length,
 
 static int
 ldp_interface_add(int command, struct zclient *zclient, zebra_size_t length,
-    vrf_id_t vrf_id)
+    lr_id_t vrf_id)
 {
 	struct interface	*ifp;
 	struct kif		 kif;
@@ -273,7 +273,7 @@ ldp_interface_add(int command, struct zclient *zclient, zebra_size_t length,
 
 static int
 ldp_interface_delete(int command, struct zclient *zclient, zebra_size_t length,
-    vrf_id_t vrf_id)
+    lr_id_t vrf_id)
 {
 	struct interface	*ifp;
 	struct kif		 kif;
@@ -298,7 +298,7 @@ ldp_interface_delete(int command, struct zclient *zclient, zebra_size_t length,
 
 static int
 ldp_interface_status_change(int command, struct zclient *zclient,
-    zebra_size_t length, vrf_id_t vrf_id)
+    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface	*ifp;
 	struct listnode		*node;
@@ -338,7 +338,7 @@ ldp_interface_status_change(int command, struct zclient *zclient,
 
 static int
 ldp_interface_address_add(int command, struct zclient *zclient,
-    zebra_size_t length, vrf_id_t vrf_id)
+    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected	*ifc;
 	struct interface	*ifp;
@@ -366,7 +366,7 @@ ldp_interface_address_add(int command, struct zclient *zclient,
 
 static int
 ldp_interface_address_delete(int command, struct zclient *zclient,
-    zebra_size_t length, vrf_id_t vrf_id)
+    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected	*ifc;
 	struct interface	*ifp;
@@ -395,7 +395,7 @@ ldp_interface_address_delete(int command, struct zclient *zclient,
 
 static int
 ldp_zebra_read_route(int command, struct zclient *zclient, zebra_size_t length,
-    vrf_id_t vrf_id)
+    lr_id_t vrf_id)
 {
 	struct zapi_route	 api;
 	struct zapi_nexthop	*api_nh;
@@ -503,7 +503,7 @@ ldp_zebra_read_route(int command, struct zclient *zclient, zebra_size_t length,
  */
 static int
 ldp_zebra_read_pw_status_update(int command, struct zclient *zclient,
-    zebra_size_t length, vrf_id_t vrf_id)
+    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct zapi_pw_status	 zpw;
 
@@ -520,11 +520,11 @@ ldp_zebra_read_pw_status_update(int command, struct zclient *zclient,
 static void
 ldp_zebra_connected(struct zclient *zclient)
 {
-	zclient_send_reg_requests(zclient, VRF_DEFAULT);
+	zclient_send_reg_requests(zclient, vrf_id_default);
 	zebra_redistribute_send(ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP,
-	    ZEBRA_ROUTE_ALL, 0, VRF_DEFAULT);
+	    ZEBRA_ROUTE_ALL, 0, vrf_id_default);
 	zebra_redistribute_send(ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP6,
-	    ZEBRA_ROUTE_ALL, 0, VRF_DEFAULT);
+	    ZEBRA_ROUTE_ALL, 0, vrf_id_default);
 }
 
 extern struct zebra_privs_t ldpd_privs;

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -129,7 +129,7 @@ void bfd_set_param(struct bfd_info **bfd_info, u_int32_t min_rx,
 void bfd_peer_sendmsg(struct zclient *zclient, struct bfd_info *bfd_info,
 		      int family, void *dst_ip, void *src_ip, char *if_name,
 		      int ttl, int multihop, int command, int set_flag,
-		      vrf_id_t vrf_id)
+		      lr_id_t vrf_id)
 {
 	struct stream *s;
 	int ret;
@@ -254,7 +254,7 @@ const char *bfd_get_command_dbg_str(int command)
  */
 struct interface *bfd_get_peer_info(struct stream *s, struct prefix *dp,
 				    struct prefix *sp, int *status,
-				    vrf_id_t vrf_id)
+				    lr_id_t vrf_id)
 {
 	unsigned int ifindex;
 	struct interface *ifp = NULL;
@@ -438,7 +438,7 @@ void bfd_client_sendmsg(struct zclient *zclient, int command)
 {
 	struct stream *s;
 	int ret;
-
+	
 	/* Check socket. */
 	if (!zclient || zclient->sock < 0) {
 		if (bfd_debug)
@@ -451,7 +451,8 @@ void bfd_client_sendmsg(struct zclient *zclient, int command)
 
 	s = zclient->obuf;
 	stream_reset(s);
-	zclient_create_header(s, command, VRF_DEFAULT);
+
+	zclient_create_header(s, command, vrf_id_default);
 
 	stream_putl(s, getpid());
 

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -79,13 +79,13 @@ extern void bfd_set_param(struct bfd_info **bfd_info, u_int32_t min_rx,
 extern void bfd_peer_sendmsg(struct zclient *zclient, struct bfd_info *bfd_info,
 			     int family, void *dst_ip, void *src_ip,
 			     char *if_name, int ttl, int multihop, int command,
-			     int set_flag, vrf_id_t vrf_id);
+			     int set_flag, lr_id_t vrf_id);
 
 extern const char *bfd_get_command_dbg_str(int command);
 
 extern struct interface *bfd_get_peer_info(struct stream *s, struct prefix *dp,
 					   struct prefix *sp, int *status,
-					   vrf_id_t vrf_id);
+					   lr_id_t vrf_id);
 
 const char *bfd_get_status_str(int status);
 

--- a/lib/if.h
+++ b/lib/if.h
@@ -284,7 +284,7 @@ struct interface {
 #endif /* HAVE_NET_RT_IFLIST */
 
 	struct route_node *node;
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 
 	QOBJ_FIELDS
 };
@@ -299,28 +299,28 @@ DECLARE_QOBJ_TYPE(interface)
 		zlog_err(                                                      \
 			"%s(%s): corruption detected -- interface with this "  \
 			"name exists already in VRF %u!",                      \
-			__func__, (ifp)->name, (ifp)->vrf_id);
+			__func__, (ifp)->name, (ifp)->vrf_id.lr.id);
 
 #define IFNAME_RB_REMOVE(vrf, ifp)                                             \
 	if (RB_REMOVE(if_name_head, &vrf->ifaces_by_name, (ifp)) == NULL)      \
 		zlog_err(                                                      \
 			"%s(%s): corruption detected -- interface with this "  \
 			"name doesn't exist in VRF %u!",                       \
-			__func__, (ifp)->name, (ifp)->vrf_id);
+			__func__, (ifp)->name, (ifp)->vrf_id.lr.id);
 
 #define IFINDEX_RB_INSERT(vrf, ifp)                                            \
 	if (RB_INSERT(if_index_head, &vrf->ifaces_by_index, (ifp)))            \
 		zlog_err(                                                      \
 			"%s(%u): corruption detected -- interface with this "  \
 			"ifindex exists already in VRF %u!",                   \
-			__func__, (ifp)->ifindex, (ifp)->vrf_id);
+			__func__, (ifp)->ifindex, (ifp)->vrf_id.lr.id);
 
 #define IFINDEX_RB_REMOVE(vrf, ifp)                                            \
 	if (RB_REMOVE(if_index_head, &vrf->ifaces_by_index, (ifp)) == NULL)    \
 		zlog_err(                                                      \
 			"%s(%u): corruption detected -- interface with this "  \
 			"ifindex doesn't exist in VRF %u!",                    \
-			__func__, (ifp)->ifindex, (ifp)->vrf_id);
+			__func__, (ifp)->ifindex, (ifp)->vrf_id.lr.id);
 
 #define FOR_ALL_INTERFACES(vrf, ifp)                                           \
 	if (vrf)                                                               \
@@ -452,21 +452,21 @@ struct nbr_connected {
 /* Prototypes. */
 extern int if_cmp_name_func(char *, char *);
 
-extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
-extern struct interface *if_create(const char *name,  vrf_id_t vrf_id);
-extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
+extern void if_update_to_new_vrf(struct interface *, lr_id_t vrf_id);
+extern struct interface *if_create(const char *name,  lr_id_t vrf_id);
+extern struct interface *if_lookup_by_index(ifindex_t, lr_id_t vrf_id);
 extern struct interface *if_lookup_exact_address(void *matchaddr, int family,
-						 vrf_id_t vrf_id);
+						 lr_id_t vrf_id);
 extern struct connected *if_lookup_address(void *matchaddr, int family,
-					   vrf_id_t vrf_id);
+					   lr_id_t vrf_id);
 extern struct interface *if_lookup_prefix(struct prefix *prefix,
-					  vrf_id_t vrf_id);
+					  lr_id_t vrf_id);
 
 /* These 3 functions are to be used when the ifname argument is terminated
    by a '\0' character: */
 extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
-extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
-extern struct interface *if_get_by_name(const char *ifname, vrf_id_t vrf_id,
+extern struct interface *if_lookup_by_name(const char *ifname, lr_id_t vrf_id);
+extern struct interface *if_get_by_name(const char *ifname, lr_id_t vrf_id,
 					int vty);
 extern void if_set_index(struct interface *ifp, ifindex_t ifindex);
 
@@ -497,12 +497,12 @@ extern const char *if_link_type_str(enum zebra_link_type);
 /* Please use ifindex2ifname instead of if_indextoname where possible;
    ifindex2ifname uses internal interface info, whereas if_indextoname must
    make a system call. */
-extern const char *ifindex2ifname(ifindex_t, vrf_id_t vrf_id);
+extern const char *ifindex2ifname(ifindex_t, lr_id_t vrf_id);
 
 /* Please use ifname2ifindex instead of if_nametoindex where possible;
    ifname2ifindex uses internal interface info, whereas if_nametoindex must
    make a system call. */
-extern ifindex_t ifname2ifindex(const char *ifname, vrf_id_t vrf_id);
+extern ifindex_t ifname2ifindex(const char *ifname, lr_id_t vrf_id);
 
 /* Connected address functions. */
 extern struct connected *connected_new(void);

--- a/lib/ns.h
+++ b/lib/ns.h
@@ -24,8 +24,8 @@
 
 #include "openbsd-tree.h"
 #include "linklist.h"
+#include "zebra.h"
 
-typedef u_int16_t ns_id_t;
 
 /* The default NS ID */
 #define NS_DEFAULT 0

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -174,37 +174,37 @@ struct zclient {
 
 	/* Pointer to the callback functions. */
 	void (*zebra_connected)(struct zclient *);
-	int (*router_id_update)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_add)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_delete)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_up)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_down)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_address_add)(int, struct zclient *, uint16_t, vrf_id_t);
+	int (*router_id_update)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*interface_add)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*interface_delete)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*interface_up)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*interface_down)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*interface_address_add)(int, struct zclient *, uint16_t, lr_id_t);
 	int (*interface_address_delete)(int, struct zclient *, uint16_t,
-					vrf_id_t);
+					lr_id_t);
 	int (*interface_link_params)(int, struct zclient *, uint16_t);
 	int (*interface_bfd_dest_update)(int, struct zclient *, uint16_t,
-					 vrf_id_t);
+					 lr_id_t);
 	int (*interface_nbr_address_add)(int, struct zclient *, uint16_t,
-					 vrf_id_t);
+					 lr_id_t);
 	int (*interface_nbr_address_delete)(int, struct zclient *, uint16_t,
-					    vrf_id_t);
-	int (*interface_vrf_update)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*nexthop_update)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*import_check_update)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*bfd_dest_replay)(int, struct zclient *, uint16_t, vrf_id_t);
+					    lr_id_t);
+	int (*interface_vrf_update)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*nexthop_update)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*import_check_update)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*bfd_dest_replay)(int, struct zclient *, uint16_t, lr_id_t);
 	int (*redistribute_route_add)(int, struct zclient *, uint16_t,
-				      vrf_id_t);
+				      lr_id_t);
 	int (*redistribute_route_del)(int, struct zclient *, uint16_t,
-				      vrf_id_t);
+				      lr_id_t);
 	int (*fec_update)(int, struct zclient *, uint16_t);
-	int (*local_vni_add)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*local_vni_del)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*local_macip_add)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*local_macip_del)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*pw_status_update)(int, struct zclient *, uint16_t, vrf_id_t);
+	int (*local_vni_add)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*local_vni_del)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*local_macip_add)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*local_macip_del)(int, struct zclient *, uint16_t, lr_id_t);
+	int (*pw_status_update)(int, struct zclient *, uint16_t, lr_id_t);
 	int (*notify_owner)(int command, struct zclient *zclient,
-			    uint16_t length, vrf_id_t vrf_id);
+			    uint16_t length, lr_id_t vrf_id);
 };
 
 /* Zebra API message flag. */
@@ -223,8 +223,8 @@ struct zserv_header {
 			 * always set to 255 in new zserv.
 			 */
 	uint8_t version;
-#define ZSERV_VERSION	4
-	vrf_id_t vrf_id;
+#define ZSERV_VERSION	5
+	lr_id_t vrf_id;
 	uint16_t command;
 };
 
@@ -276,7 +276,7 @@ struct zapi_route {
 
 	u_int32_t mtu;
 
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 };
 
 /* Zebra IPv4 route message API. */
@@ -307,7 +307,7 @@ struct zapi_ipv4 {
 
 	u_int32_t mtu;
 
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 };
 
 struct zapi_pw {
@@ -370,48 +370,48 @@ extern u_short *redist_check_instance(struct redist_proto *, u_short);
 extern void redist_add_instance(struct redist_proto *, u_short);
 extern void redist_del_instance(struct redist_proto *, u_short);
 
-extern void zclient_send_reg_requests(struct zclient *, vrf_id_t);
-extern void zclient_send_dereg_requests(struct zclient *, vrf_id_t);
+extern void zclient_send_reg_requests(struct zclient *, lr_id_t);
+extern void zclient_send_dereg_requests(struct zclient *, lr_id_t);
 
 extern void zclient_send_interface_radv_req(struct zclient *zclient,
-					    vrf_id_t vrf_id,
+					    lr_id_t vrf_id,
 					    struct interface *ifp, int enable,
 					    int ra_interval);
 
 /* Send redistribute command to zebra daemon. Do not update zclient state. */
 extern int zebra_redistribute_send(int command, struct zclient *, afi_t,
-				   int type, u_short instance, vrf_id_t vrf_id);
+				   int type, u_short instance, lr_id_t vrf_id);
 
 /* If state has changed, update state and call zebra_redistribute_send. */
 extern void zclient_redistribute(int command, struct zclient *, afi_t, int type,
-				 u_short instance, vrf_id_t vrf_id);
+				 u_short instance, lr_id_t vrf_id);
 
 /* If state has changed, update state and send the command to zebra. */
 extern void zclient_redistribute_default(int command, struct zclient *,
-					 vrf_id_t vrf_id);
+					 lr_id_t vrf_id);
 
 /* Send the message in zclient->obuf to the zebra daemon (or enqueue it).
    Returns 0 for success or -1 on an I/O error. */
 extern int zclient_send_message(struct zclient *);
 
 /* create header for command, length to be filled in by user later */
-extern void zclient_create_header(struct stream *, uint16_t, vrf_id_t);
+extern void zclient_create_header(struct stream *, uint16_t, lr_id_t);
 extern int zclient_read_header(struct stream *s, int sock, u_int16_t *size,
 			       u_char *marker, u_char *version,
-			       vrf_id_t *vrf_id, u_int16_t *cmd);
+			       lr_id_t *vrf_id, u_int16_t *cmd);
 
 extern void zclient_interface_set_master(struct zclient *client,
 					 struct interface *master,
 					 struct interface *slave);
-extern struct interface *zebra_interface_add_read(struct stream *, vrf_id_t);
-extern struct interface *zebra_interface_state_read(struct stream *s, vrf_id_t);
+extern struct interface *zebra_interface_add_read(struct stream *, lr_id_t);
+extern struct interface *zebra_interface_state_read(struct stream *s, lr_id_t);
 extern struct connected *zebra_interface_address_read(int, struct stream *,
-						      vrf_id_t);
+						      lr_id_t);
 extern struct nbr_connected *
-zebra_interface_nbr_address_read(int, struct stream *, vrf_id_t);
+zebra_interface_nbr_address_read(int, struct stream *, lr_id_t);
 extern struct interface *zebra_interface_vrf_update_read(struct stream *s,
-							 vrf_id_t vrf_id,
-							 vrf_id_t *new_vrf_id);
+							 lr_id_t vrf_id,
+							 lr_id_t *new_vrf_id);
 extern void zebra_interface_if_set_value(struct stream *, struct interface *);
 extern void zebra_router_id_update_read(struct stream *s, struct prefix *rid);
 extern int zapi_ipv4_route(u_char, struct zclient *, struct prefix_ipv4 *,
@@ -429,7 +429,7 @@ extern int lm_release_label_chunk(struct zclient *zclient, uint32_t start,
 extern int zebra_send_pw(struct zclient *zclient, int command,
 			 struct zapi_pw *pw);
 extern void zebra_read_pw_status_update(int command, struct zclient *zclient,
-					zebra_size_t length, vrf_id_t vrf_id,
+					zebra_size_t length, lr_id_t vrf_id,
 					struct zapi_pw_status *pw);
 
 /* IPv6 prefix add and delete function prototype. */
@@ -461,7 +461,7 @@ struct zapi_ipv6 {
 
 	u_int32_t mtu;
 
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 };
 
 extern int zapi_ipv6_route(u_char cmd, struct zclient *zclient,

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -484,8 +484,23 @@ typedef enum {
 typedef u_int16_t zebra_size_t;
 typedef u_int16_t zebra_command_t;
 
-/* VRF ID type. */
+/* VRF ID type within a network namespace */
 typedef u_int16_t vrf_id_t;
+
+/* NS ID Identifier */
+typedef u_int16_t ns_id_t;
+
+/* Logical Router Id */
+typedef struct
+{
+	union {
+		u_int32_t id;
+		struct {
+			vrf_id_t vrf_id;
+			ns_id_t ns_id;
+		} lr_id;
+	} lr;
+}lr_id_t;
 
 typedef uint32_t route_tag_t;
 #define ROUTE_TAG_MAX UINT32_MAX

--- a/nhrpd/netlink_arp.c
+++ b/nhrpd/netlink_arp.c
@@ -75,7 +75,7 @@ static void netlink_neigh_msg(struct nlmsghdr *msg, struct zbuf *zb)
 		}
 	}
 
-	ifp = if_lookup_by_index(ndm->ndm_ifindex, VRF_DEFAULT);
+	ifp = if_lookup_by_index(ndm->ndm_ifindex, vrf_id_default);
 	if (!ifp || sockunion_family(&addr) == AF_UNSPEC)
 		return;
 
@@ -185,7 +185,7 @@ static void netlink_log_indication(struct nlmsghdr *msg, struct zbuf *zb)
 	if (!pkthdr || !in_ndx || !zbuf_used(&pktpl))
 		return;
 
-	ifp = if_lookup_by_index(htonl(*in_ndx), VRF_DEFAULT);
+	ifp = if_lookup_by_index(htonl(*in_ndx), vrf_id_default);
 	if (!ifp)
 		return;
 

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -117,7 +117,7 @@ static void nhrp_interface_update_nbma(struct interface *ifp)
 	sockunion_family(&nbma) = AF_UNSPEC;
 
 	if (nifp->source)
-          nbmaifp = if_lookup_by_name(nifp->source, VRF_DEFAULT);
+          nbmaifp = if_lookup_by_name(nifp->source, vrf_id_default);
 
 	switch (ifp->ll_type) {
 	case ZEBRA_LLT_IPGRE: {
@@ -127,7 +127,7 @@ static void nhrp_interface_update_nbma(struct interface *ifp)
 			if (saddr.s_addr)
 				sockunion_set(&nbma, AF_INET, (u_char *) &saddr.s_addr, sizeof(saddr.s_addr));
 			else if (!nbmaifp && nifp->linkidx != IFINDEX_INTERNAL)
-                          nbmaifp = if_lookup_by_index(nifp->linkidx, VRF_DEFAULT);
+                          nbmaifp = if_lookup_by_index(nifp->linkidx, vrf_id_default);
 		}
 		break;
 	default:
@@ -269,7 +269,7 @@ void nhrp_interface_update(struct interface *ifp)
 	}
 }
 
-int nhrp_interface_add(int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf_id)
+int nhrp_interface_add(int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -288,7 +288,7 @@ int nhrp_interface_add(int cmd, struct zclient *client, zebra_size_t length, vrf
 }
 
 int nhrp_interface_delete(int cmd, struct zclient *client,
-			  zebra_size_t length, vrf_id_t vrf_id)
+			  zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -306,7 +306,7 @@ int nhrp_interface_delete(int cmd, struct zclient *client,
 }
 
 int nhrp_interface_up(int cmd, struct zclient *client,
-		      zebra_size_t length, vrf_id_t vrf_id)
+		      zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -321,7 +321,7 @@ int nhrp_interface_up(int cmd, struct zclient *client,
 }
 
 int nhrp_interface_down(int cmd, struct zclient *client,
-			zebra_size_t length, vrf_id_t vrf_id)
+			zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -335,7 +335,7 @@ int nhrp_interface_down(int cmd, struct zclient *client,
 }
 
 int nhrp_interface_address_add(int cmd, struct zclient *client,
-			       zebra_size_t length, vrf_id_t vrf_id)
+			       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *ifc;
 	char buf[PREFIX_STRLEN];
@@ -354,7 +354,7 @@ int nhrp_interface_address_add(int cmd, struct zclient *client,
 }
 
 int nhrp_interface_address_delete(int cmd, struct zclient *client,
-				  zebra_size_t length, vrf_id_t vrf_id)
+				  zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *ifc;
 	char buf[PREFIX_STRLEN];

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -352,7 +352,7 @@ int nhrp_nhs_free(struct nhrp_nhs *nhs)
 
 void nhrp_nhs_terminate(void)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct nhrp_interface *nifp;
 	struct nhrp_nhs *nhs, *tmp;

--- a/nhrpd/nhrp_packet.c
+++ b/nhrpd/nhrp_packet.c
@@ -291,7 +291,7 @@ static int nhrp_packet_recvraw(struct thread *t)
 		goto err;
 	}
 
-	ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
+	ifp = if_lookup_by_index(ifindex, vrf_id_default);
 	if (!ifp) goto err;
 
 	p = nhrp_peer_get(ifp, &remote_nbma);

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -167,7 +167,7 @@ void nhrp_route_announce(int add, enum nhrp_cache_type type, const struct prefix
 			   &api);
 }
 
-int nhrp_route_read(int cmd, struct zclient *zclient, zebra_size_t length, vrf_id_t vrf_id)
+int nhrp_route_read(int cmd, struct zclient *zclient, zebra_size_t length, lr_id_t vrf_id)
 {
 	struct zapi_route api;
 	struct zapi_nexthop *api_nh;
@@ -198,7 +198,7 @@ int nhrp_route_read(int cmd, struct zclient *zclient, zebra_size_t length, vrf_i
 		}
 
 		if (api_nh->ifindex != IFINDEX_INTERNAL)
-                       	ifp = if_lookup_by_index(api_nh->ifindex, VRF_DEFAULT);
+                       	ifp = if_lookup_by_index(api_nh->ifindex, vrf_id_default);
 	}
 
 	added = (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD);
@@ -302,11 +302,11 @@ enum nhrp_route_type nhrp_route_address(struct interface *in_ifp, union sockunio
 static void
 nhrp_zebra_connected (struct zclient *zclient)
 {
-	zclient_send_reg_requests(zclient, VRF_DEFAULT);
+	zclient_send_reg_requests(zclient, vrf_id_default);
 	zebra_redistribute_send(ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP,
-	    ZEBRA_ROUTE_ALL, 0, VRF_DEFAULT);
+	    ZEBRA_ROUTE_ALL, 0, vrf_id_default);
 	zebra_redistribute_send(ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP6,
-	    ZEBRA_ROUTE_ALL, 0, VRF_DEFAULT);
+	    ZEBRA_ROUTE_ALL, 0, vrf_id_default);
 }
 
 void nhrp_zebra_init(void)

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -712,7 +712,7 @@ DEFUN(show_ip_nhrp, show_ip_nhrp_cmd,
 	"Shortcut information\n"
 	"opennhrpctl style cache dump\n")
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct info_ctx ctx = {
 		.vty = vty,
@@ -796,7 +796,7 @@ DEFUN(clear_nhrp, clear_nhrp_cmd,
 	"Dynamic cache entries\n"
 	"Shortcut entries\n")
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct info_ctx ctx = {
 		.vty = vty,
@@ -843,7 +843,7 @@ static void interface_config_write_nhrp_map(struct nhrp_cache *c, void *data)
 
 static int interface_config_write(struct vty *vty)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct write_map_ctx mapctx;
 	struct interface *ifp;
 	struct nhrp_interface *nifp;

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -311,12 +311,12 @@ void nhrp_interface_init(void);
 void nhrp_interface_update(struct interface *ifp);
 void nhrp_interface_update_mtu(struct interface *ifp, afi_t afi);
 
-int nhrp_interface_add(int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf_id);
-int nhrp_interface_delete(int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf_id);
-int nhrp_interface_up(int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf_id);
-int nhrp_interface_down(int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf_id);
-int nhrp_interface_address_add(int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf_id);
-int nhrp_interface_address_delete(int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf_id);
+int nhrp_interface_add(int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf_id);
+int nhrp_interface_delete(int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf_id);
+int nhrp_interface_up(int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf_id);
+int nhrp_interface_down(int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf_id);
+int nhrp_interface_address_add(int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf_id);
+int nhrp_interface_address_delete(int cmd, struct zclient *client, zebra_size_t length, lr_id_t vrf_id);
 
 void nhrp_interface_notify_add(struct interface *ifp, struct notifier_block *n, notifier_fn_t fn);
 void nhrp_interface_notify_del(struct interface *ifp, struct notifier_block *n);
@@ -331,7 +331,7 @@ void nhrp_nhs_foreach(struct interface *ifp, afi_t afi, void (*cb)(struct nhrp_n
 
 void nhrp_route_update_nhrp(const struct prefix *p, struct interface *ifp);
 void nhrp_route_announce(int add, enum nhrp_cache_type type, const struct prefix *p, struct interface *ifp, const union sockunion *nexthop, uint32_t mtu);
-int nhrp_route_read(int command, struct zclient *zclient, zebra_size_t length, vrf_id_t vrf_id);
+int nhrp_route_read(int command, struct zclient *zclient, zebra_size_t length, lr_id_t vrf_id);
 int nhrp_route_get_nexthop(const union sockunion *addr, struct prefix *p, union sockunion *via, struct interface **ifp);
 enum nhrp_route_type nhrp_route_address(struct interface *in_ifp, union sockunion *addr, struct prefix *p, struct nhrp_peer **peer);
 

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -805,7 +805,7 @@ ospf6_routemap_rule_match_interface(void *rule, struct prefix *prefix,
 
 	if (type == RMAP_OSPF6) {
 		ei = ((struct ospf6_route *)object)->route_option;
-		ifp = if_lookup_by_name((char *)rule, VRF_DEFAULT);
+		ifp = if_lookup_by_name((char *)rule, vrf_id_default);
 
 		if (ifp != NULL && ei->ifindex == ifp->ifindex)
 			return RMAP_MATCH;

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -87,7 +87,7 @@ void ospf6_bfd_reg_dereg_nbr(struct ospf6_neighbor *on, int command)
 
 	bfd_peer_sendmsg(zclient, bfd_info, AF_INET6, &on->linklocal_addr,
 			 on->ospf6_if->linklocal_addr, ifp->name, 0, 0, command,
-			 0, VRF_DEFAULT);
+			 0, vrf_id_default);
 
 	if (command == ZEBRA_BFD_DEST_DEREGISTER)
 		bfd_info_free((struct bfd_info **)&on->bfd_info);
@@ -139,9 +139,9 @@ static void ospf6_bfd_reg_dereg_all_nbr(struct ospf6_interface *oi, int command)
  *                        to zebra
  */
 static int ospf6_bfd_nbr_replay(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+				zebra_size_t length, lr_id_t vrf_id)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct listnode *node;
 	struct interface *ifp;
 	struct ospf6_interface *oi;
@@ -183,7 +183,7 @@ static int ospf6_bfd_nbr_replay(int command, struct zclient *zclient,
  *                                   connectivity if BFD down is received.
  */
 static int ospf6_bfd_interface_dest_update(int command, struct zclient *zclient,
-					   zebra_size_t length, vrf_id_t vrf_id)
+					   zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct ospf6_interface *oi;

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -60,7 +60,7 @@ struct ospf6_interface *ospf6_interface_lookup_by_ifindex(ifindex_t ifindex)
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 
-	ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
+	ifp = if_lookup_by_index(ifindex, vrf_id_default);
 	if (ifp == NULL)
 		return (struct ospf6_interface *)NULL;
 
@@ -988,12 +988,12 @@ DEFUN (show_ipv6_ospf6_interface,
        INTERFACE_STR
        IFNAME_STR)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	int idx_ifname = 4;
 	struct interface *ifp;
 
 	if (argc == 5) {
-		ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+		ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id_default);
 		if (ifp == NULL) {
 			vty_out(vty, "No such Interface: %s\n",
 				argv[idx_ifname]->arg);
@@ -1027,7 +1027,7 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
 	struct interface *ifp;
 	struct ospf6_interface *oi;
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id_default);
 	if (ifp == NULL) {
 		vty_out(vty, "No such Interface: %s\n", argv[idx_ifname]->arg);
 		return CMD_WARNING;
@@ -1059,7 +1059,7 @@ DEFUN (show_ipv6_ospf6_interface_prefix,
        OSPF6_ROUTE_MATCH_STR
        "Display details of the prefixes\n")
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	int idx_prefix = 5;
 	struct ospf6_interface *oi;
 	struct interface *ifp;
@@ -1760,7 +1760,7 @@ DEFUN (no_ipv6_ospf6_network,
 
 static int config_write_ospf6_interface(struct vty *vty)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 
@@ -1910,7 +1910,7 @@ DEFUN (clear_ipv6_ospf6_interface,
        IFNAME_STR
        )
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	int idx_ifname = 4;
 	struct interface *ifp;
 
@@ -1921,7 +1921,7 @@ DEFUN (clear_ipv6_ospf6_interface,
 	} else /* Interface name is specified. */
 	{
 		if ((ifp = if_lookup_by_name(argv[idx_ifname]->arg,
-					     VRF_DEFAULT))
+					     vrf_id_default))
 		    == NULL) {
 			vty_out(vty, "No such Interface: %s\n",
 				argv[idx_ifname]->arg);

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1394,7 +1394,7 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 			ls_entry->path.cost + ntohs(op->prefix_metric);
 
 		if (direct_connect) {
-			ifp = if_lookup_prefix(&route->prefix, VRF_DEFAULT);
+			ifp = if_lookup_prefix(&route->prefix, vrf_id_default);
 			if (ifp)
 				ospf6_route_add_nexthop(route, ifp->ifindex,
 							NULL);

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -79,7 +79,7 @@ struct thread_master *master;
 
 static void __attribute__((noreturn)) ospf6_exit(int status)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	frr_early_fini();

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -308,7 +308,7 @@ void ospf6_route_zebra_copy_nexthops(struct ospf6_route *route,
 				inet_ntop(AF_INET6, &nh->address, buf,
 					  sizeof(buf));
 				ifname = ifindex2ifname(nh->ifindex,
-							VRF_DEFAULT);
+							vrf_id_default);
 				zlog_debug("  nexthop: %s%%%.*s(%d)", buf,
 					   IFNAMSIZ, ifname, nh->ifindex);
 			}
@@ -990,7 +990,7 @@ void ospf6_route_show(struct vty *vty, struct ospf6_route *route)
 	for (ALL_LIST_ELEMENTS_RO(route->nh_list, node, nh)) {
 		/* nexthop */
 		inet_ntop(AF_INET6, &nh->address, nexthop, sizeof(nexthop));
-		ifname = ifindex2ifname(nh->ifindex, VRF_DEFAULT);
+		ifname = ifindex2ifname(nh->ifindex, vrf_id_default);
 
 		if (!i) {
 			vty_out(vty, "%c%1s %2s %-30s %-25s %6.*s %s\n",
@@ -1089,7 +1089,7 @@ void ospf6_route_show_detail(struct vty *vty, struct ospf6_route *route)
 	for (ALL_LIST_ELEMENTS_RO(route->nh_list, node, nh)) {
 		/* nexthop */
 		inet_ntop(AF_INET6, &nh->address, nexthop, sizeof(nexthop));
-		ifname = ifindex2ifname(nh->ifindex, VRF_DEFAULT);
+		ifname = ifindex2ifname(nh->ifindex, vrf_id_default);
 		vty_out(vty, "  %s %.*s\n", nexthop, IFNAMSIZ, ifname);
 	}
 	vty_out(vty, "\n");

--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -837,7 +837,7 @@ static u_char *ospfv3WwLsdbEntry(struct variable *v, oid *name, size_t *length,
 				 int exact, size_t *var_len,
 				 WriteMethod **write_method)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct ospf6_lsa *lsa = NULL;
 	ifindex_t ifindex;
 	uint32_t area_id, id, instid, adv_router;
@@ -1042,7 +1042,7 @@ static u_char *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 			     int exact, size_t *var_len,
 			     WriteMethod **write_method)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	ifindex_t ifindex = 0;
 	unsigned int instid = 0;
 	struct ospf6_interface *oi = NULL;
@@ -1195,7 +1195,7 @@ static u_char *ospfv3NbrEntry(struct variable *v, oid *name, size_t *length,
 			      int exact, size_t *var_len,
 			      WriteMethod **write_method)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	ifindex_t ifindex = 0;
 	unsigned int instid, rtrid;
 	struct ospf6_interface *oi = NULL;

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -595,7 +595,7 @@ DEFUN (ospf6_interface_area,
 	u_int32_t area_id;
 
 	/* find/create ospf6 interface */
-	ifp = if_get_by_name(argv[idx_ifname]->arg, VRF_DEFAULT, 0);
+	ifp = if_get_by_name(argv[idx_ifname]->arg, vrf_id_default, 0);
 	oi = (struct ospf6_interface *)ifp->info;
 	if (oi == NULL)
 		oi = ospf6_interface_create(ifp);
@@ -653,7 +653,7 @@ DEFUN (no_ospf6_interface_area,
 	struct interface *ifp;
 	u_int32_t area_id;
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id_default);
 	if (ifp == NULL) {
 		vty_out(vty, "No such interface %s\n", argv[idx_ifname]->arg);
 		return CMD_SUCCESS;

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -48,7 +48,7 @@ extern void ospf6_zebra_route_update_remove(struct ospf6_route *request);
 extern void ospf6_zebra_redistribute(int);
 extern void ospf6_zebra_no_redistribute(int);
 #define ospf6_zebra_is_redistribute(type)                                      \
-	vrf_bitmap_check(zclient->redist[AFI_IP6][type], VRF_DEFAULT)
+	vrf_bitmap_check(zclient->redist[AFI_IP6][type], vrf_id_default)
 extern void ospf6_zebra_init(struct thread_master *);
 extern void ospf6_zebra_add_discard(struct ospf6_route *request);
 extern void ospf6_zebra_delete_discard(struct ospf6_route *request);

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -82,7 +82,7 @@ struct ospf_interface *ospf_apiserver_if_lookup_by_addr(struct in_addr address)
 	struct ospf_interface *oi;
 	struct ospf *ospf = NULL;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (!ospf)
 		return NULL;
 
@@ -100,7 +100,7 @@ struct ospf_interface *ospf_apiserver_if_lookup_by_ifp(struct interface *ifp)
 	struct ospf_interface *oi;
 	struct ospf *ospf = NULL;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (!ospf)
 		return NULL;
 
@@ -1001,7 +1001,7 @@ void ospf_apiserver_notify_ready_type9(struct ospf_apiserver *apiserv)
 	struct ospf_interface *oi;
 	struct registered_opaque_type *r;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	for (ALL_LIST_ELEMENTS(ospf->oiflist, node, nnode, oi)) {
 		/* Check if this interface is indeed ready for type 9 */
@@ -1049,7 +1049,7 @@ void ospf_apiserver_notify_ready_type10(struct ospf_apiserver *apiserv)
 	struct ospf *ospf;
 	struct ospf_area *area;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	for (ALL_LIST_ELEMENTS(ospf->areas, node, nnode, area)) {
 		struct registered_opaque_type *r;
@@ -1096,7 +1096,7 @@ void ospf_apiserver_notify_ready_type11(struct ospf_apiserver *apiserv)
 	struct ospf *ospf;
 	struct registered_opaque_type *r;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	/* Can type 11 be originated? */
 	if (!ospf_apiserver_is_ready_type11(ospf))
@@ -1273,7 +1273,7 @@ int ospf_apiserver_handle_sync_lsdb(struct ospf_apiserver *apiserv,
 	struct ospf *ospf;
 	struct ospf_area *area;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	/* Get request sequence number */
 	seqnum = msg_get_seq(msg);
@@ -1379,7 +1379,7 @@ struct ospf_lsa *ospf_apiserver_opaque_lsa_new(struct ospf_area *area,
 	if (oi && oi->ospf)
 		ospf = oi->ospf;
 	else
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	assert(ospf);
 
@@ -1504,7 +1504,7 @@ int ospf_apiserver_handle_originate_request(struct ospf_apiserver *apiserv,
 	int ready = 0;
 	int rc = 0;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	/* Extract opaque LSA data from message */
 	omsg = (struct msg_originate_request *)STREAM_DATA(msg->s);
@@ -1647,7 +1647,7 @@ void ospf_apiserver_flood_opaque_lsa(struct ospf_lsa *lsa)
 	case OSPF_OPAQUE_AS_LSA: {
 		struct ospf *ospf;
 
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		assert(ospf);
 
 		/* Increment counters? XXX */
@@ -1663,7 +1663,7 @@ int ospf_apiserver_originate1(struct ospf_lsa *lsa)
 {
 	struct ospf *ospf;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	assert(ospf);
 
 	/* Install this LSA into LSDB. */
@@ -1733,7 +1733,7 @@ struct ospf_lsa *ospf_apiserver_lsa_refresher(struct ospf_lsa *lsa)
 	struct ospf_lsa *new = NULL;
 	struct ospf *ospf;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	assert(ospf);
 
 	apiserv = lookup_apiserver_by_lsa(lsa);
@@ -1817,7 +1817,7 @@ int ospf_apiserver_handle_delete_request(struct ospf_apiserver *apiserv,
 	int rc = 0;
 	struct ospf *ospf;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	assert(ospf);
 
 	/* Extract opaque LSA from message */
@@ -1930,7 +1930,7 @@ void ospf_apiserver_flush_opaque_lsa(struct ospf_apiserver *apiserv,
 	struct ospf *ospf;
 	struct ospf_area *area;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	assert(ospf);
 
 	/* Set parameter struct. */

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -160,7 +160,7 @@ struct external_info *ospf_external_info_add(struct ospf *ospf, u_char type,
 			zlog_warn(
 				"Redistribute[%s][%d][%u]: %s/%d discarding old info with NH %s.",
 				ospf_redist_string(type), instance,
-				ospf->vrf_id, inet_ntoa(p.prefix),
+				ospf->vrf_id.lr.id, inet_ntoa(p.prefix),
 				p.prefixlen, inetbuf);
 			XFREE(MTYPE_OSPF_EXTERNAL_INFO, rn->info);
 			rn->info = NULL;
@@ -182,7 +182,7 @@ struct external_info *ospf_external_info_add(struct ospf *ospf, u_char type,
 			  INET6_BUFSIZ);
 		zlog_debug(
 			"Redistribute[%s][%u]: %s/%d external info created, with NH %s",
-			ospf_redist_string(type), ospf->vrf_id,
+			ospf_redist_string(type), ospf->vrf_id.lr.id,
 			inet_ntoa(p.prefix), p.prefixlen, inetbuf);
 	}
 	return new;

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -142,7 +142,7 @@ static int ospf_bfd_reg_dereg_all_nbr(struct interface *ifp, int command)
  *                       to zebra
  */
 static int ospf_bfd_nbr_replay(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+			       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct listnode *inode, *node, *onode;
 	struct ospf *ospf;
@@ -196,7 +196,7 @@ static int ospf_bfd_nbr_replay(int command, struct zclient *zclient,
  *                                  down.
  */
 static int ospf_bfd_interface_dest_update(int command, struct zclient *zclient,
-					  zebra_size_t length, vrf_id_t vrf_id)
+					  zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct ospf_interface *oi;

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -1607,7 +1607,7 @@ DEFUN_NOSH (show_debugging_ospf,
 {
 	struct ospf *ospf = NULL;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return CMD_SUCCESS;
 
@@ -1653,7 +1653,7 @@ static int config_write_debug(struct vty *vty)
 	char str[16];
 	memset(str, 0, 16);
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return CMD_SUCCESS;
 

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -246,7 +246,7 @@ struct ospf_interface *ospf_if_new(struct ospf *ospf, struct interface *ifp,
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: ospf interface %s vrf %s id %u created",
 			   __PRETTY_FUNCTION__, ifp->name,
-			   ospf_vrf_id_to_name(ospf->vrf_id), ospf->vrf_id);
+			   ospf_vrf_id_to_name(ospf->vrf_id), ospf->vrf_id.lr.id);
 
 	return oi;
 }
@@ -322,7 +322,7 @@ void ospf_if_free(struct ospf_interface *oi)
 		zlog_debug("%s: ospf interface %s vrf %s id %u deleted",
 			   __PRETTY_FUNCTION__, oi->ifp->name,
 			   ospf_vrf_id_to_name(oi->ifp->vrf_id),
-			   oi->ifp->vrf_id);
+			   oi->ifp->vrf_id.lr.id);
 
 	ospf_delete_from_if(oi->ifp, oi);
 
@@ -828,7 +828,7 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("ospf_vl_new(): creating pseudo zebra interface vrf id %u",
-			   ospf->vrf_id);
+			   ospf->vrf_id.lr.id);
 
 	snprintf(ifname, sizeof(ifname), "VLINK%d", vlink_count);
 	vi = if_create(ifname, ospf->vrf_id);

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -162,7 +162,7 @@ struct ospf_lsa *ospf_lsa_new()
 	monotime(&new->tv_recv);
 	new->tv_orig = new->tv_recv;
 	new->refresh_list = -1;
-	new->vrf_id = VRF_DEFAULT;
+	new->vrf_id.lr.id = LR_DEFAULT;
 
 	return new;
 }

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -113,7 +113,7 @@ struct ospf_lsa {
 	struct ospf_interface *oi;
 
 	/* VRF Id */
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 };
 
 /* OSPF LSA Link Type. */

--- a/ospfd/ospf_network.c
+++ b/ospfd/ospf_network.c
@@ -173,8 +173,8 @@ int ospf_bind_vrfdevice(struct ospf *ospf, int ospf_sock)
 
 #ifdef SO_BINDTODEVICE
 
-	if (ospf && ospf->vrf_id != VRF_DEFAULT &&
-	    ospf->vrf_id != VRF_UNKNOWN) {
+	if (ospf && ospf->vrf_id.lr.id != LR_DEFAULT &&
+	    ospf->vrf_id.lr.id != LR_UNKNOWN) {
 		ret = setsockopt(ospf_sock, SOL_SOCKET, SO_BINDTODEVICE,
 				 ospf->name,
 				 strlen(ospf->name));

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1803,7 +1803,7 @@ static struct ospf_lsa *pseudo_lsa(struct ospf_interface *oi,
 	lsa.oi = oi;
 	lsa.area = area;
 	lsa.data = &lsah;
-	lsa.vrf_id = VRF_DEFAULT;
+	lsa.vrf_id.lr.id = LR_DEFAULT;
 
 	lsah.type = lsa_type;
 	tmp = SET_OPAQUE_LSID(opaque_type, 0); /* Opaque-ID is unused here. */

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -3538,11 +3538,11 @@ static void ospf_hello_send_sub(struct ospf_interface *oi, in_addr_t addr)
 	op->dst.s_addr = addr;
 
 	if (IS_DEBUG_OSPF_EVENT) {
-		if (oi->ospf->vrf_id)
+		if (oi->ospf->vrf_id.lr.id)
 			zlog_debug("%s: Hello Tx interface %s ospf vrf %s id %u",
 				    __PRETTY_FUNCTION__, oi->ifp->name,
 				    ospf_vrf_id_to_name(oi->ospf->vrf_id),
-				    oi->ospf->vrf_id);
+				    oi->ospf->vrf_id.lr.id);
 	}
 	/* Add packet to the top of the interface output queue, so that they
 	 * can't get delayed by things like long queues of LS Update packets

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -425,7 +425,7 @@ static void initialize_params(struct ospf_router_info *ori)
 
 	/* If Area address is not null and exist, retrieve corresponding
 	 * structure */
-	top = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	top = ospf_lookup_by_vrf_id(vrf_id_default);
 	zlog_info("RI-> Initialize Router Info for %s scope within area %s",
 		  OspfRI.scope == OSPF_OPAQUE_AREA_LSA ? "Area" : "AS",
 		  inet_ntoa(OspfRI.area_id));
@@ -584,7 +584,7 @@ static struct ospf_lsa *ospf_router_info_lsa_new()
 			"LSA[Type%d:%s]: Create an Opaque-LSA/ROUTER INFORMATION instance",
 			lsa_type, inet_ntoa(lsa_id));
 
-	top = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	top = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	/* Set opaque-LSA header fields. */
 	lsa_header_set(s, options, lsa_type, lsa_id, top->router_id);
@@ -616,7 +616,7 @@ static struct ospf_lsa *ospf_router_info_lsa_new()
 	if (new->area && new->area->ospf)
 		new->vrf_id = new->area->ospf->vrf_id;
 	else
-		new->vrf_id = VRF_DEFAULT;
+		new->vrf_id.lr.id = LR_DEFAULT;
 
 	SET_FLAG(new->flags, OSPF_LSA_SELF);
 	memcpy(new->data, lsah, length);
@@ -631,7 +631,7 @@ static int ospf_router_info_lsa_originate1(void *arg)
 	struct ospf *top;
 	struct ospf_area *area;
 	int rc = -1;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	lr_id_t vrf_id = { .lr.id = LR_DEFAULT};
 
 	/* First check if the area is known if flooding scope is Area */
 	if (OspfRI.scope == OSPF_OPAQUE_AREA_LSA) {
@@ -658,7 +658,7 @@ static int ospf_router_info_lsa_originate1(void *arg)
 	top = ospf_lookup_by_vrf_id(vrf_id);
 	if (top == NULL) {
 		zlog_debug("%s: ospf instance not found for vrf id %u",
-			   __PRETTY_FUNCTION__, vrf_id);
+			   __PRETTY_FUNCTION__, vrf_id.lr.id);
 		ospf_lsa_unlock(&new);
 		return rc;
 	}
@@ -814,7 +814,7 @@ static void ospf_router_info_lsa_schedule(enum lsa_opcode opcode)
 	if (CHECK_FLAG(OspfRI.flags, RIFLG_LSA_ENGAGED) && (opcode == REORIGINATE_THIS_LSA))
 		opcode = REFRESH_THIS_LSA;
 
-	top = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	top = ospf_lookup_by_vrf_id(vrf_id_default);
 	if ((OspfRI.scope == OSPF_OPAQUE_AREA_LSA) && (OspfRI.area == NULL)) {
 		zlog_warn(
 			"ospf_router_info_lsa_schedule(): Router Info is Area scope flooding but area is not set");

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -532,7 +532,7 @@ static u_char *ospfGeneralGroup(struct variable *v, oid *name, size_t *length,
 {
 	struct ospf *ospf;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	/* Check whether the instance identifier is valid */
 	if (smux_header_generic(v, name, length, exact, var_len, write_method)
@@ -661,7 +661,7 @@ static struct ospf_area *ospfAreaLookup(struct variable *v, oid name[],
 	struct ospf_area *area;
 	int len;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -765,7 +765,7 @@ static struct ospf_area *ospf_stub_area_lookup_next(struct in_addr *area_id,
 	struct listnode *node;
 	struct ospf *ospf;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -792,7 +792,7 @@ static struct ospf_area *ospfStubAreaLookup(struct variable *v, oid name[],
 	struct ospf_area *area;
 	int len;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -934,7 +934,7 @@ static struct ospf_lsa *ospfLsdbLookup(struct variable *v, oid *name,
 	oid *offset;
 	int offsetlen;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 #define OSPF_LSDB_ENTRY_OFFSET (IN_ADDR_SIZE + 1 + IN_ADDR_SIZE + IN_ADDR_SIZE)
 
@@ -1084,7 +1084,7 @@ static u_char *ospfLsdbEntry(struct variable *v, oid *name, size_t *length,
 	memset(&router_id, 0, sizeof(struct in_addr));
 
 	/* Check OSPF instance. */
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -1145,7 +1145,7 @@ static struct ospf_area_range *ospfAreaRangeLookup(struct variable *v,
 	p.family = AF_INET;
 	p.prefixlen = IPV4_MAX_BITLEN;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	if (exact) {
 		/* Area ID + Range Network. */
@@ -1239,7 +1239,7 @@ static u_char *ospfAreaRangeEntry(struct variable *v, oid *name, size_t *length,
 		return NULL;
 
 	/* Check OSPF instance. */
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -1290,7 +1290,7 @@ static struct ospf_nbr_nbma *ospfHostLookup(struct variable *v, oid *name,
 	struct ospf_nbr_nbma *nbr_nbma;
 	struct ospf *ospf;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -1347,7 +1347,7 @@ static u_char *ospfHostEntry(struct variable *v, oid *name, size_t *length,
 		return NULL;
 
 	/* Check OSPF instance. */
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -1504,7 +1504,7 @@ static struct ospf_interface *ospf_snmp_if_lookup(struct in_addr *ifaddr,
 	struct listnode *node;
 	struct ospf_snmp_if *osif;
 	struct ospf_interface *oi = NULL;
-	struct ospf *ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	struct ospf *ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf_snmp_iflist, node, osif)) {
 		if (ifaddr->s_addr) {
@@ -1527,7 +1527,7 @@ static struct ospf_interface *ospf_snmp_if_lookup_next(struct in_addr *ifaddr,
 {
 	struct ospf_snmp_if *osif;
 	struct listnode *nn;
-	struct ospf *ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	struct ospf *ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	struct ospf_interface *oi = NULL;
 
 	if (ospf == NULL)
@@ -1675,7 +1675,7 @@ static u_char *ospfIfEntry(struct variable *v, oid *name, size_t *length,
 	memset(&ifaddr, 0, sizeof(struct in_addr));
 
 	/* Check OSPF instance. */
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -1845,7 +1845,7 @@ static u_char *ospfIfMetricEntry(struct variable *v, oid *name, size_t *length,
 	memset(&ifaddr, 0, sizeof(struct in_addr));
 
 	/* Check OSPF instance. */
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -2125,7 +2125,7 @@ static struct ospf_neighbor *ospf_snmp_nbr_lookup_next(struct in_addr *nbr_addr,
 	struct ospf_neighbor *min = NULL;
 	struct ospf *ospf = ospf;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	for (ALL_LIST_ELEMENTS_RO(ospf->oiflist, nn, oi)) {
 		for (rn = route_top(oi->nbrs); rn; rn = route_next(rn))
@@ -2165,7 +2165,7 @@ static struct ospf_neighbor *ospfNbrLookup(struct variable *v, oid *name,
 	struct ospf_neighbor *nbr;
 	struct ospf *ospf;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	if (!ospf)
 		return NULL;
@@ -2325,7 +2325,7 @@ static u_char *ospfVirtNbrEntry(struct variable *v, oid *name, size_t *length,
 	memset(&neighbor, 0, sizeof(struct in_addr));
 
 	/* Check OSPF instance. */
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 
@@ -2379,7 +2379,7 @@ static struct ospf_lsa *ospfExtLsdbLookup(struct variable *v, oid *name,
 	struct ospf_lsa *lsa;
 	struct ospf *ospf;
 
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (exact) {
 		if (*length != v->namelen + 1 + IN_ADDR_SIZE + IN_ADDR_SIZE)
 			return NULL;
@@ -2476,7 +2476,7 @@ static u_char *ospfExtLsdbEntry(struct variable *v, oid *name, size_t *length,
 	memset(&router_id, 0, sizeof(struct in_addr));
 
 	/* Check OSPF instance. */
-	ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 	if (ospf == NULL)
 		return NULL;
 

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1142,14 +1142,14 @@ ospf_rtrs_print (struct route_table *rtrs)
                 {
                   if (IS_DEBUG_OSPF_EVENT)
                     zlog_debug ("   directly attached to %s\r\n",
-				ifindex2ifname (path->ifindex), VRF_DEFAULT);
+				ifindex2ifname (path->ifindex), vrf_id_default);
                 }
               else
                 {
                   if (IS_DEBUG_OSPF_EVENT)
                     zlog_debug ("   via %s, %s\r\n",
 				inet_ntoa (path->nexthop),
-				ifindex2ifname (path->ifindex), VRF_DEFAULT);
+				ifindex2ifname (path->ifindex), vrf_id_default);
                 }
             }
         }
@@ -1344,7 +1344,7 @@ static int ospf_spf_calculate_timer(struct thread *thread)
 		zlog_debug("%s: ospf install new route, vrf %s id %u new_table count %lu",
 			   __PRETTY_FUNCTION__,
 			   ospf_vrf_id_to_name(ospf->vrf_id),
-			   ospf->vrf_id, new_table->count);
+			   ospf->vrf_id.lr.id, new_table->count);
 	/* Update routing table. */
 	monotime(&start_time);
 	ospf_route_install(ospf, new_table);

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -727,7 +727,7 @@ static void update_linkparams(struct mpls_te_link *lp)
 			else {
 				lp->flags = INTER_AS | FLOOD_AREA;
 				lp->area = ospf_area_lookup_by_area_id(
-					ospf_lookup_by_vrf_id(VRF_DEFAULT),
+					ospf_lookup_by_vrf_id(vrf_id_default),
 					OspfMplsTE.interas_areaid);
 			}
 		}
@@ -1508,7 +1508,7 @@ void ospf_mpls_te_lsa_schedule(struct mpls_te_link *lp, enum lsa_opcode opcode)
 
 	memset(&lsa, 0, sizeof(lsa));
 	memset(&lsah, 0, sizeof(lsah));
-	top = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	top = ospf_lookup_by_vrf_id(vrf_id_default);
 
 	/* Check if the pseudo link is ready to flood */
 	if (!(CHECK_FLAG(lp->flags, LPFLG_LSA_ACTIVE))

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -170,15 +170,15 @@ static void ospf_show_vrf_name(struct ospf *ospf, struct vty *vty,
 {
 	if (use_vrf) {
 		if (json) {
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				json_object_string_add(json, "vrfName",
 						       "default");
 			else
 				json_object_string_add(json, "vrfName",
 						       ospf->name);
-			json_object_int_add(json, "vrfId", ospf->vrf_id);
+			json_object_int_add(json, "vrfId", ospf->vrf_id.lr.id);
 		} else {
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				vty_out(vty, "VRF Name: %s\n", "default");
 			else if (ospf->name)
 				vty_out(vty, "VRF Name: %s\n", ospf->name);
@@ -215,12 +215,12 @@ DEFUN_NOSH (router_ospf,
 		VTY_PUSH_CONTEXT_NULL(OSPF_NODE);
 		ret = CMD_NOT_MY_INSTANCE;
 	} else {
-		if (ospf->vrf_id != VRF_UNKNOWN)
+		if (ospf->vrf_id.lr.id != LR_UNKNOWN)
 			ospf->oi_running = 1;
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug("Config command 'router ospf %d' received, vrf %s id %d oi_running %u",
 				   instance,  ospf->name ? ospf->name : "NIL",
-				   ospf->vrf_id, ospf->oi_running);
+				   ospf->vrf_id.lr.id, ospf->oi_running);
 		VTY_PUSH_CONTEXT(OSPF_NODE, ospf);
 
 		/* Activate 'ip ospf area x' configured interfaces for given
@@ -459,7 +459,7 @@ DEFUN (ospf_passive_interface,
 		ospf_passive_interface_default(ospf, OSPF_IF_PASSIVE);
 		return CMD_SUCCESS;
 	}
-	if (ospf->vrf_id != VRF_UNKNOWN)
+	if (ospf->vrf_id.lr.id != LR_UNKNOWN)
 		ifp = if_get_by_name(argv[1]->arg, ospf->vrf_id, 0);
 
 	if (ifp == NULL) {
@@ -533,7 +533,7 @@ DEFUN (no_ospf_passive_interface,
 		return CMD_SUCCESS;
 	}
 
-	if (ospf->vrf_id != VRF_UNKNOWN)
+	if (ospf->vrf_id.lr.id != LR_UNKNOWN)
 		ifp = if_get_by_name(argv[1]->arg, ospf->vrf_id, 0);
 
 	if (ifp == NULL) {
@@ -3239,7 +3239,7 @@ static int show_ip_ospf_common(struct vty *vty, struct ospf *ospf,
 	if (json) {
 		if (use_vrf) {
 			json_object_object_add(json_vrf, "areas", json_areas);
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				json_object_object_add(json, "default",
 						       json_vrf);
 			else
@@ -3308,7 +3308,7 @@ DEFUN (show_ip_ospf,
 			return CMD_SUCCESS;
 		}
 	} else {
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		/* Display default ospf (instance 0) info */
 		if (ospf == NULL || !ospf->oi_running) {
 			if (uj)
@@ -3754,7 +3754,7 @@ static int show_ip_ospf_interface_common(struct vty *vty, struct ospf *ospf,
 
 	if (use_json) {
 		if (use_vrf) {
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				json_object_object_add(json, "default",
 						       json_vrf);
 			else
@@ -3917,7 +3917,7 @@ static int show_ip_ospf_interface_traffic_common(struct vty *vty,
 
 	if (use_json) {
 		if (use_vrf) {
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				json_object_object_add(json, "default",
 						       json_vrf);
 			else
@@ -3996,7 +3996,7 @@ DEFUN (show_ip_ospf_interface,
 
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running) {
 			if (uj)
 				json_object_free(json);
@@ -4130,7 +4130,7 @@ DEFUN (show_ip_ospf_interface_traffic,
 							    display_once,
 							    use_vrf, uj);
 	} else {
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running) {
 			if (uj)
 				json_object_free(json);
@@ -4308,7 +4308,7 @@ static int show_ip_ospf_neighbor_common(struct vty *vty, struct ospf *ospf,
 
 	if (use_json) {
 		if (use_vrf) {
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				json_object_object_add(json, "default",
 						       json_vrf);
 			else
@@ -4378,7 +4378,7 @@ DEFUN (show_ip_ospf_neighbor,
 		}
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running) {
 			if (uj)
 				json_object_free(json);
@@ -4522,7 +4522,7 @@ static int show_ip_ospf_neighbor_all_common(struct vty *vty, struct ospf *ospf,
 
 	if (use_json) {
 		if (use_vrf) {
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				json_object_object_add(json, "default",
 						       json_vrf);
 			else
@@ -4595,7 +4595,7 @@ DEFUN (show_ip_ospf_neighbor_all,
 		}
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running) {
 			if (uj)
 				json_object_free(json);
@@ -4733,7 +4733,7 @@ DEFUN (show_ip_ospf_neighbor_int,
 	for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
 		if (!ospf->oi_running)
 			continue;
-		if (!ifp || ifp->vrf_id != ospf->vrf_id)
+		if (!ifp || ifp->vrf_id.lr.id != ospf->vrf_id.lr.id)
 			continue;
 		ret = show_ip_ospf_neighbor_int_common(vty, ospf,
 						       idx_ifname, argv, uj, 0);
@@ -5224,7 +5224,7 @@ static int show_ip_ospf_neighbor_detail_common(struct vty *vty,
 
 	if (use_json) {
 		if (use_vrf) {
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				json_object_object_add(json, "default",
 						       json_vrf);
 			else
@@ -5295,7 +5295,7 @@ DEFUN (show_ip_ospf_neighbor_detail,
 		}
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running) {
 			if (uj)
 				json_object_free(json);
@@ -5414,7 +5414,7 @@ static int show_ip_ospf_neighbor_detail_all_common(struct vty *vty,
 
 	if (use_json) {
 		if (use_vrf) {
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				json_object_object_add(json, "default",
 						       json_vrf);
 			else
@@ -5488,7 +5488,7 @@ DEFUN (show_ip_ospf_neighbor_detail_all,
 		}
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running) {
 			if (uj)
 				json_object_free(json);
@@ -6359,7 +6359,7 @@ DEFUN (show_ip_ospf_database_max,
 		}
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running)
 			return CMD_SUCCESS;
 		ret = show_ip_ospf_database_common(vty, ospf, 0, argc, argv,
@@ -6430,7 +6430,7 @@ DEFUN (show_ip_ospf_instance_database,
 		}
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running)
 			return CMD_SUCCESS;
 		ret = (show_ip_ospf_database_common(vty, ospf, 0, argc, argv,
@@ -6582,7 +6582,7 @@ DEFUN (show_ip_ospf_instance_database_type_adv_router,
 		}
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running)
 			return CMD_SUCCESS;
 		ret = show_ip_ospf_database_type_adv_router_common(vty, ospf,
@@ -7960,7 +7960,7 @@ DEFUN (ip_ospf_area,
 	argv_find(argv, argc, "area", &idx);
 	areaid = argv[idx + 1]->arg;
 
-	if (ifp->vrf_id && !instance)
+	if (ifp->vrf_id.lr.id && !instance)
 		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
 	else
 		ospf = ospf_lookup_instance(instance);
@@ -7969,7 +7969,7 @@ DEFUN (ip_ospf_area,
 		params = IF_DEF_PARAMS(ifp);
 		if (OSPF_IF_PARAM_CONFIGURED(params, if_area)) {
 			UNSET_IF_PARAM(params, if_area);
-			ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+			ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 			ospf_interface_area_unset(ospf, ifp);
 			ospf->if_ospf_cli_count--;
 		}
@@ -8057,7 +8057,7 @@ DEFUN (no_ip_ospf_area,
 	if (argv_find(argv, argc, "(1-65535)", &idx))
 		instance = strtol(argv[idx]->arg, NULL, 10);
 
-	if (ifp->vrf_id && !instance)
+	if (ifp->vrf_id.lr.id && !instance)
 		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
 	else
 		ospf = ospf_lookup_instance(instance);
@@ -9373,7 +9373,7 @@ DEFUN (show_ip_ospf_border_routers,
 		}
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running)
 			return CMD_SUCCESS;
 		ret = show_ip_ospf_border_routers_common(vty, ospf, use_vrf);
@@ -9442,7 +9442,7 @@ static int show_ip_ospf_route_common(struct vty *vty, struct ospf *ospf,
 	if (json) {
 		if (use_vrf) {
 			//json_object_object_add(json_vrf, "areas", json_areas);
-			if (ospf->vrf_id == VRF_DEFAULT)
+			if (ospf->vrf_id.lr.id == LR_DEFAULT)
 				json_object_object_add(json, "default",
 						       json_vrf);
 			else
@@ -9511,7 +9511,7 @@ DEFUN (show_ip_ospf_route,
 		}
 	} else {
 		/* Display default ospf (instance 0) info */
-		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+		ospf = ospf_lookup_by_vrf_id(vrf_id_default);
 		if (ospf == NULL || !ospf->oi_running) {
 			if (uj)
 				json_object_free(json);
@@ -9591,12 +9591,12 @@ DEFUN (show_ip_ospf_vrfs,
 		if (uj)
 			json_vrf = json_object_new_object();
 
-		if (ospf->vrf_id == 0)
+		if (ospf->vrf_id.lr.id == LR_DEFAULT)
 			name = VRF_DEFAULT_NAME;
 		else
 			name = ospf->name;
 
-		vrf_id_ui = (ospf->vrf_id == VRF_UNKNOWN) ? -1 : ospf->vrf_id;
+		vrf_id_ui = (ospf->vrf_id.lr.id == LR_UNKNOWN) ? -1 : (int)ospf->vrf_id.lr.id;
 
 		if (uj) {
 			json_object_int_add(json_vrf, "vrfId", vrf_id_ui);
@@ -9607,7 +9607,7 @@ DEFUN (show_ip_ospf_vrfs,
 
 		} else {
 			vty_out(vty, "%-25s  %-5d  %-16s  \n",
-				name, ospf->vrf_id, inet_ntoa(ospf->router_id));
+				name, ospf->vrf_id.lr.id, inet_ntoa(ospf->router_id));
 		}
 	}
 
@@ -9654,7 +9654,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 			continue;
 
 		vty_frame(vty, "!\n");
-		if (ifp->vrf_id == VRF_DEFAULT)
+		if (ifp->vrf_id.lr.id == LR_DEFAULT)
 			vty_frame(vty, "interface %s\n", ifp->name);
 		else
 			vty_frame(vty, "interface %s vrf %s\n",
@@ -10418,11 +10418,11 @@ static int ospf_config_write(struct vty *vty)
 		/* VRF Default check if it is running.
 		 * Upon daemon start, there could be default instance
 		 * in absence of 'router ospf'/oi_running is disabled. */
-		if (ospf->vrf_id == VRF_DEFAULT && ospf->oi_running)
+		if (ospf->vrf_id.lr.id == LR_DEFAULT && ospf->oi_running)
 			write += ospf_config_write_one(vty, ospf);
 		/* For Non-Default VRF simply display the configuration,
 		 * even if it is not oi_running. */
-		else if (ospf->vrf_id != VRF_DEFAULT)
+		else if (ospf->vrf_id.lr.id != LR_DEFAULT)
 			write += ospf_config_write_one(vty, ospf);
 	}
 	return write;

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -131,7 +131,7 @@ struct ospf {
 	struct in_addr router_id_static; /* Configured manually. */
 	struct in_addr router_id_zebra;
 
-	vrf_id_t vrf_id;  /* VRF Id */
+	lr_id_t vrf_id;  /* VRF Id */
 	char *name;       /* VRF name */
 
 	/* ABR/ASBR internal flags. */
@@ -517,7 +517,7 @@ extern struct ospf *ospf_get(u_short instance, const char *name);
 extern struct ospf *ospf_get_instance(u_short);
 extern struct ospf *ospf_lookup_by_inst_name(u_short instance,
 					     const char *name);
-extern struct ospf *ospf_lookup_by_vrf_id(vrf_id_t vrf_id);
+extern struct ospf *ospf_lookup_by_vrf_id(lr_id_t vrf_id);
 extern void ospf_finish(struct ospf *);
 extern void ospf_router_id_update(struct ospf *ospf);
 extern int ospf_network_set(struct ospf *, struct prefix_ipv4 *, struct in_addr,
@@ -580,7 +580,7 @@ extern void ospf_vrf_init(void);
 extern void ospf_vrf_terminate(void);
 extern void ospf_vrf_link(struct ospf *ospf, struct vrf *vrf);
 extern void ospf_vrf_unlink(struct ospf *ospf, struct vrf *vrf);
-const char *ospf_vrf_id_to_name(vrf_id_t vrf_id);
+const char *ospf_vrf_id_to_name(lr_id_t vrf_id);
 int ospf_area_nssa_no_summary_set(struct ospf *, struct in_addr);
 
 #endif /* _ZEBRA_OSPFD_H */

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -126,7 +126,7 @@ static void pim_bfd_reg_dereg_nbr(struct pim_neighbor *nbr, int command)
 			   bfd_get_command_dbg_str(command));
 	}
 	bfd_peer_sendmsg(zclient, bfd_info, AF_INET, &nbr->source_addr, NULL,
-			 nbr->interface->name, 0, 0, command, 0, VRF_DEFAULT);
+			 nbr->interface->name, 0, 0, command, 0, vrf_id_default);
 }
 
 /*
@@ -207,7 +207,7 @@ void pim_bfd_if_param_set(struct interface *ifp, u_int32_t min_rx,
  *                                  down.
  */
 static int pim_bfd_interface_dest_update(int command, struct zclient *zclient,
-					 zebra_size_t length, vrf_id_t vrf_id)
+					 zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp = NULL;
 	struct pim_interface *pim_ifp = NULL;
@@ -287,7 +287,7 @@ static int pim_bfd_interface_dest_update(int command, struct zclient *zclient,
  *                       to zebra
  */
 static int pim_bfd_nbr_replay(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+			      zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp = NULL;
 	struct pim_interface *pim_ifp = NULL;
@@ -322,7 +322,7 @@ static int pim_bfd_nbr_replay(int command, struct zclient *zclient,
 						       str, sizeof(str));
 					zlog_debug("%s: Replaying Pim Neigh %s to BFD vrf_id %u",
 						   __PRETTY_FUNCTION__, str,
-						   vrf->vrf_id);
+						   vrf->vrf_id.lr.id);
 				}
 				pim_bfd_reg_dereg_nbr(neigh,
 						      ZEBRA_BFD_DEST_UPDATE);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -80,7 +80,7 @@ static struct vrf *pim_cmd_lookup_vrf(struct vty *vty, struct cmd_token *argv[],
 	if (argv_find(argv, argc, "NAME", idx))
 		vrf = vrf_lookup_by_name(argv[*idx]->arg);
 	else
-		vrf = vrf_lookup_by_id(VRF_DEFAULT);
+		vrf = vrf_lookup_by_id(vrf_id_default);
 
 	if (!vrf)
 		vty_out(vty, "Specified VRF: %s does not exist\n",

--- a/pimd/pim_cmd.h
+++ b/pimd/pim_cmd.h
@@ -72,7 +72,7 @@ void pim_cmd_init(void);
 #define PIM_DECLVAR_CONTEXT(A, B)                                              \
 	struct vrf *A = VTY_GET_CONTEXT(vrf);                                  \
 	struct pim_instance *B =                                               \
-		(vrf) ? vrf->info : pim_get_pim_instance(VRF_DEFAULT);         \
+		(vrf) ? vrf->info : pim_get_pim_instance(vrf_id_default);         \
 	vrf = (vrf) ? vrf : pim->vrf;
 
 #endif /* PIM_CMD_H */

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -909,7 +909,7 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 	if (!v4_addrs && v6_addrs && !if_is_loopback(ifp)) {
 		struct interface *lo_ifp;
 		// DBS - Come back and check here
-		if (ifp->vrf_id == VRF_DEFAULT)
+		if (ifp->vrf_id.lr.id == LR_DEFAULT)
 			lo_ifp = if_lookup_by_name("lo", vrf->vrf_id);
 		else
 			lo_ifp = if_lookup_by_name(vrf->name, vrf->vrf_id);
@@ -1489,7 +1489,7 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 	char pimreg_name[INTERFACE_NAMSIZ];
 
 	if (!pim->regiface) {
-		if (pim->vrf_id == VRF_DEFAULT)
+		if (pim->vrf_id.lr.id == LR_DEFAULT)
 			strlcpy(pimreg_name, "pimreg", sizeof(pimreg_name));
 		else
 			snprintf(pimreg_name, sizeof(pimreg_name), "pimreg%u",

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -110,7 +110,7 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 
 	pim->send_v6_secondary = 1;
 
-	if (vrf->vrf_id == VRF_DEFAULT)
+	if (vrf->vrf_id.lr.id == LR_DEFAULT)
 		pimg = pim;
 
 	pim_rp_init(pim);
@@ -122,7 +122,7 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	return pim;
 }
 
-struct pim_instance *pim_get_pim_instance(vrf_id_t vrf_id)
+struct pim_instance *pim_get_pim_instance(lr_id_t vrf_id)
 {
 	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
@@ -136,7 +136,7 @@ static int pim_vrf_new(struct vrf *vrf)
 {
 	struct pim_instance *pim = pim_instance_init(vrf);
 
-	zlog_debug("VRF Created: %s(%d)", vrf->name, vrf->vrf_id);
+	zlog_debug("VRF Created: %s(%u)", vrf->name, vrf->vrf_id.lr.id);
 	if (pim == NULL) {
 		zlog_err("%s %s: pim class init failure ", __FILE__,
 			 __PRETTY_FUNCTION__);
@@ -148,7 +148,7 @@ static int pim_vrf_new(struct vrf *vrf)
 
 	vrf->info = (void *)pim;
 
-	if (vrf->vrf_id == VRF_DEFAULT)
+	if (vrf->vrf_id.lr.id == LR_DEFAULT)
 		pimg = pim;
 
 	pim_ssmpingd_init(pim);
@@ -159,7 +159,7 @@ static int pim_vrf_delete(struct vrf *vrf)
 {
 	struct pim_instance *pim = vrf->info;
 
-	zlog_debug("VRF Deletion: %s(%d)", vrf->name, vrf->vrf_id);
+	zlog_debug("VRF Deletion: %s(%u)", vrf->name, vrf->vrf_id.lr.id);
 
 	pim_ssmpingd_destroy(pim);
 	pim_instance_terminate(pim);
@@ -198,7 +198,7 @@ static int pim_vrf_config_write(struct vty *vty)
 		if (!pim)
 			continue;
 
-		if (vrf->vrf_id == VRF_DEFAULT)
+		if (vrf->vrf_id.lr.id == LR_DEFAULT)
 			continue;
 
 		vty_frame(vty, "vrf %s\n", vrf->name);

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -44,7 +44,7 @@ enum pim_spt_switchover {
 
 /* Per VRF PIM DB */
 struct pim_instance {
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 	struct vrf *vrf;
 
 	struct {
@@ -99,6 +99,6 @@ struct pim_instance {
 void pim_vrf_init(void);
 void pim_vrf_terminate(void);
 
-struct pim_instance *pim_get_pim_instance(vrf_id_t vrf_id);
+struct pim_instance *pim_get_pim_instance(lr_id_t vrf_id);
 
 #endif

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -54,7 +54,7 @@ static int pim_mroute_set(struct pim_instance *pim, int enable)
 	/*
 	 * We need to create the VRF table for the pim mroute_socket
 	 */
-	if (pim->vrf_id != VRF_DEFAULT) {
+	if (pim->vrf_id.lr.id != LR_DEFAULT) {
 		if (pimd_privs.change(ZPRIVS_RAISE))
 			zlog_err(
 				"pim_mroute_socket_enable: could not raise privs, %s",
@@ -720,7 +720,7 @@ int pim_mroute_socket_enable(struct pim_instance *pim)
 	}
 
 #ifdef SO_BINDTODEVICE
-	if (pim->vrf->vrf_id != VRF_DEFAULT &&
+	if (pim->vrf->vrf_id.lr.id != LR_DEFAULT &&
 	    setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, pim->vrf->name,
 		       strlen(pim->vrf->name))) {
 		zlog_warn("Could not setsockopt SO_BINDTODEVICE: %s",

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -150,7 +150,7 @@ int pim_msdp_sock_listen(struct pim_instance *pim)
 	sockopt_reuseaddr(sock);
 	sockopt_reuseport(sock);
 
-	if (pim->vrf_id != VRF_DEFAULT) {
+	if (pim->vrf_id.lr.id != LR_DEFAULT) {
 		struct interface *ifp =
 			if_lookup_by_name(pim->vrf->name, pim->vrf_id);
 		if (!ifp) {
@@ -234,7 +234,7 @@ int pim_msdp_sock_connect(struct pim_msdp_peer *mp)
 		return -1;
 	}
 
-	if (mp->pim->vrf_id != VRF_DEFAULT) {
+	if (mp->pim->vrf_id.lr.id != LR_DEFAULT) {
 		struct interface *ifp =
 			if_lookup_by_name(mp->pim->vrf->name, mp->pim->vrf_id);
 		if (!ifp) {

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -632,7 +632,7 @@ int pim_ecmp_nexthop_search(struct pim_instance *pim,
 /* This API is used to parse Registered address nexthop update coming from Zebra
  */
 int pim_parse_nexthop_update(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+			     zebra_size_t length, lr_id_t vrf_id)
 {
 	struct stream *s;
 	struct prefix p;
@@ -811,9 +811,9 @@ int pim_parse_nexthop_update(int command, struct zclient *zclient,
 		char buf[PREFIX2STR_BUFFER];
 		prefix2str(&p, buf, sizeof(buf));
 		zlog_debug(
-			"%s: NHT Update for %s(%s) num_nh %d num_pim_nh %d vrf:%d up %ld rp %d",
+			"%s: NHT Update for %s(%s) num_nh %d num_pim_nh %d vrf:%u up %ld rp %d",
 			__PRETTY_FUNCTION__, buf, pim->vrf->name, nexthop_num,
-			pnc->nexthop_num, vrf_id, pnc->upstream_hash->count,
+			pnc->nexthop_num, vrf_id.lr.id, pnc->upstream_hash->count,
 			listcount(pnc->rp_list));
 	}
 

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -47,7 +47,7 @@ struct pim_nexthop_cache {
 };
 
 int pim_parse_nexthop_update(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id);
+			     zebra_size_t length, lr_id_t vrf_id);
 int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
 			      struct pim_upstream *up, struct rp_info *rp,
 			      struct pim_nexthop_cache *out_pnc);

--- a/pimd/pim_ssm.c
+++ b/pimd/pim_ssm.c
@@ -104,13 +104,13 @@ int pim_is_grp_ssm(struct pim_instance *pim, struct in_addr group_addr)
 	return (prefix_list_apply(plist, &group) == PREFIX_PERMIT);
 }
 
-int pim_ssm_range_set(struct pim_instance *pim, vrf_id_t vrf_id,
+int pim_ssm_range_set(struct pim_instance *pim, lr_id_t vrf_id,
 		      const char *plist_name)
 {
 	struct pim_ssm *ssm;
 	int change = 0;
 
-	if (vrf_id != pim->vrf_id)
+	if (vrf_id.lr.id != pim->vrf_id.lr.id)
 		return PIM_SSM_ERR_NO_VRF;
 
 	ssm = pim->ssm_info;

--- a/pimd/pim_ssm.h
+++ b/pimd/pim_ssm.h
@@ -35,7 +35,7 @@ struct pim_ssm {
 void pim_ssm_prefix_list_update(struct pim_instance *pim,
 				struct prefix_list *plist);
 int pim_is_grp_ssm(struct pim_instance *pim, struct in_addr group_addr);
-int pim_ssm_range_set(struct pim_instance *pim, vrf_id_t vrf_id,
+int pim_ssm_range_set(struct pim_instance *pim, lr_id_t vrf_id,
 		      const char *plist_name);
 void *pim_ssm_init(void);
 void pim_ssm_terminate(struct pim_ssm *ssm);

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -102,7 +102,7 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 		return -4;
 	}
 #endif
-	if (iif->vrf_id != oif->vrf_id) {
+	if (iif->vrf_id.lr.id != oif->vrf_id.lr.id) {
 		return -3;
 	}
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -153,7 +153,7 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 	struct pim_ssm *ssm = pim->ssm_info;
 	char spaces[10];
 
-	if (pim->vrf_id == VRF_DEFAULT)
+	if (pim->vrf_id.lr.id == LR_DEFAULT)
 		sprintf(spaces, "%s", "");
 	else
 		sprintf(spaces, "%s", " ");
@@ -251,7 +251,7 @@ int pim_interface_config_write(struct vty *vty)
 
 		FOR_ALL_INTERFACES (pim->vrf, ifp) {
 			/* IF name */
-			if (vrf->vrf_id == VRF_DEFAULT)
+			if (vrf->vrf_id.lr.id == LR_DEFAULT)
 				vty_frame(vty, "interface %s\n", ifp->name);
 			else
 				vty_frame(vty, "interface %s vrf %s\n",

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -56,7 +56,7 @@ static struct zclient *zclient = NULL;
 
 /* Router-id update message from zebra. */
 static int pim_router_id_update_zebra(int command, struct zclient *zclient,
-				      zebra_size_t length, vrf_id_t vrf_id)
+				      zebra_size_t length, lr_id_t vrf_id)
 {
 	struct prefix router_id;
 
@@ -66,7 +66,7 @@ static int pim_router_id_update_zebra(int command, struct zclient *zclient,
 }
 
 static int pim_zebra_if_add(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+			    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -80,8 +80,8 @@ static int pim_zebra_if_add(int command, struct zclient *zclient,
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%d) flags %ld metric %d mtu %d operative %d",
-			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
+			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id.lr.id,
 			(long)ifp->flags, ifp->metric, ifp->mtu,
 			if_is_operative(ifp));
 	}
@@ -110,7 +110,7 @@ static int pim_zebra_if_add(int command, struct zclient *zclient,
 }
 
 static int pim_zebra_if_del(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+			    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -130,8 +130,8 @@ static int pim_zebra_if_del(int command, struct zclient *zclient,
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%d) flags %ld metric %d mtu %d operative %d",
-			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
+			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id.lr.id,
 			(long)ifp->flags, ifp->metric, ifp->mtu,
 			if_is_operative(ifp));
 	}
@@ -143,7 +143,7 @@ static int pim_zebra_if_del(int command, struct zclient *zclient,
 }
 
 static int pim_zebra_if_state_up(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+				 zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	uint32_t table_id;
@@ -158,8 +158,8 @@ static int pim_zebra_if_state_up(int command, struct zclient *zclient,
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%d) flags %ld metric %d mtu %d operative %d",
-			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
+			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id.lr.id,
 			(long)ifp->flags, ifp->metric, ifp->mtu,
 			if_is_operative(ifp));
 	}
@@ -180,7 +180,7 @@ static int pim_zebra_if_state_up(int command, struct zclient *zclient,
 		struct vrf *vrf;
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 			if ((table_id == vrf->data.l.table_id)
-			    && (ifp->vrf_id != vrf->vrf_id)) {
+			    && (ifp->vrf_id.lr.id != vrf->vrf_id.lr.id)) {
 				struct interface *master = if_lookup_by_name(
 					vrf->name, vrf->vrf_id);
 
@@ -199,7 +199,7 @@ static int pim_zebra_if_state_up(int command, struct zclient *zclient,
 }
 
 static int pim_zebra_if_state_down(int command, struct zclient *zclient,
-				   zebra_size_t length, vrf_id_t vrf_id)
+				   zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -213,8 +213,8 @@ static int pim_zebra_if_state_down(int command, struct zclient *zclient,
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%d) flags %ld metric %d mtu %d operative %d",
-			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
+			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id.lr.id,
 			(long)ifp->flags, ifp->metric, ifp->mtu,
 			if_is_operative(ifp));
 	}
@@ -269,7 +269,7 @@ static void dump_if_address(struct interface *ifp)
 #endif
 
 static int pim_zebra_if_address_add(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+				    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *c;
 	struct prefix *p;
@@ -293,8 +293,8 @@ static int pim_zebra_if_address_add(int command, struct zclient *zclient,
 	if (PIM_DEBUG_ZEBRA) {
 		char buf[BUFSIZ];
 		prefix2str(p, buf, BUFSIZ);
-		zlog_debug("%s: %s(%d) connected IP address %s flags %u %s",
-			   __PRETTY_FUNCTION__, c->ifp->name, vrf_id, buf,
+		zlog_debug("%s: %s(%u) connected IP address %s flags %u %s",
+			   __PRETTY_FUNCTION__, c->ifp->name, vrf_id.lr.id, buf,
 			   c->flags, CHECK_FLAG(c->flags, ZEBRA_IFA_SECONDARY)
 					     ? "secondary"
 					     : "primary");
@@ -330,7 +330,7 @@ static int pim_zebra_if_address_add(int command, struct zclient *zclient,
 		pim_rp_check_on_if_add(pim_ifp);
 
 	if (if_is_loopback(c->ifp)) {
-		struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+		struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 		struct interface *ifp;
 
 		FOR_ALL_INTERFACES (vrf, ifp) {
@@ -343,7 +343,7 @@ static int pim_zebra_if_address_add(int command, struct zclient *zclient,
 }
 
 static int pim_zebra_if_address_del(int command, struct zclient *client,
-				    zebra_size_t length, vrf_id_t vrf_id)
+				    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *c;
 	struct prefix *p;
@@ -372,8 +372,8 @@ static int pim_zebra_if_address_del(int command, struct zclient *client,
 			char buf[BUFSIZ];
 			prefix2str(p, buf, BUFSIZ);
 			zlog_debug(
-				"%s: %s(%d) disconnected IP address %s flags %u %s",
-				__PRETTY_FUNCTION__, c->ifp->name, vrf_id, buf,
+				"%s: %s(%u) disconnected IP address %s flags %u %s",
+				__PRETTY_FUNCTION__, c->ifp->name, vrf_id.lr.id, buf,
 				c->flags,
 				CHECK_FLAG(c->flags, ZEBRA_IFA_SECONDARY)
 					? "secondary"

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -146,7 +146,7 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 	uint16_t length;
 	u_char marker;
 	u_char version;
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 	uint16_t command = 0;
 	struct in_addr raddr;
 	uint8_t distance;
@@ -312,7 +312,7 @@ static int zclient_lookup_nexthop_once(struct pim_instance *pim,
 		return -1;
 	}
 
-	if (pim->vrf->vrf_id == VRF_UNKNOWN) {
+	if (pim->vrf->vrf_id.lr.id == LR_UNKNOWN) {
 		zlog_err(
 			"%s: VRF: %s does not fully exist yet, delaying lookup",
 			__PRETTY_FUNCTION__, pim->vrf->name);
@@ -515,7 +515,7 @@ int pim_zlookup_sg_statistics(struct channel_oil *c_oil)
 	while (command != ZEBRA_IPMR_ROUTE_STATS) {
 		int err;
 		uint16_t length = 0;
-		vrf_id_t vrf_id;
+		lr_id_t vrf_id;
 		u_char marker;
 		u_char version;
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -334,7 +334,7 @@ static int rip_if_ipv4_address_check(struct interface *ifp)
 /* Does this address belongs to me ? */
 int if_check_address(struct in_addr addr)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp) {
@@ -358,7 +358,7 @@ int if_check_address(struct in_addr addr)
 
 /* Inteface link down message processing. */
 int rip_interface_down(int command, struct zclient *zclient,
-		       zebra_size_t length, vrf_id_t vrf_id)
+		       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -385,7 +385,7 @@ int rip_interface_down(int command, struct zclient *zclient,
 
 /* Inteface link up message processing */
 int rip_interface_up(int command, struct zclient *zclient, zebra_size_t length,
-		     vrf_id_t vrf_id)
+		     lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -416,7 +416,7 @@ int rip_interface_up(int command, struct zclient *zclient, zebra_size_t length,
 
 /* Inteface addition message from zebra. */
 int rip_interface_add(int command, struct zclient *zclient, zebra_size_t length,
-		      vrf_id_t vrf_id)
+		      lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -446,7 +446,7 @@ int rip_interface_add(int command, struct zclient *zclient, zebra_size_t length,
 }
 
 int rip_interface_delete(int command, struct zclient *zclient,
-			 zebra_size_t length, vrf_id_t vrf_id)
+			 zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -488,7 +488,7 @@ static void rip_interface_clean(struct rip_interface *ri)
 
 void rip_interfaces_clean(void)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
@@ -540,7 +540,7 @@ static void rip_interface_reset(struct rip_interface *ri)
 
 void rip_interfaces_reset(void)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
@@ -581,7 +581,7 @@ int rip_if_down(struct interface *ifp)
 /* Needed for stop RIP process. */
 void rip_if_down_all()
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
@@ -622,7 +622,7 @@ static void rip_apply_address_add(struct connected *ifc)
 }
 
 int rip_interface_address_add(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+			      zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *ifc;
 	struct prefix *p;
@@ -674,7 +674,7 @@ static void rip_apply_address_del(struct connected *ifc)
 }
 
 int rip_interface_address_delete(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+				 zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *ifc;
 	struct prefix *p;
@@ -985,7 +985,7 @@ void rip_enable_apply(struct interface *ifp)
 /* Apply network configuration to all interface. */
 void rip_enable_apply_all()
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	/* Check each interface. */
@@ -1099,7 +1099,7 @@ void rip_passive_interface_apply(struct interface *ifp)
 
 static void rip_passive_interface_apply_all(void)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
@@ -1736,7 +1736,7 @@ DEFUN (no_rip_passive_interface,
 /* Write rip configuration of each interface. */
 static int rip_interface_config_write(struct vty *vty)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp) {

--- a/ripd/rip_interface.h
+++ b/ripd/rip_interface.h
@@ -20,13 +20,13 @@
 #ifndef _QUAGGA_RIP_INTERFACE_H
 #define _QUAGGA_RIP_INTERFACE_H
 
-extern int rip_interface_down(int, struct zclient *, zebra_size_t, vrf_id_t);
-extern int rip_interface_up(int, struct zclient *, zebra_size_t, vrf_id_t);
-extern int rip_interface_add(int, struct zclient *, zebra_size_t, vrf_id_t);
-extern int rip_interface_delete(int, struct zclient *, zebra_size_t, vrf_id_t);
+extern int rip_interface_down(int, struct zclient *, zebra_size_t, lr_id_t);
+extern int rip_interface_up(int, struct zclient *, zebra_size_t, lr_id_t);
+extern int rip_interface_add(int, struct zclient *, zebra_size_t, lr_id_t);
+extern int rip_interface_delete(int, struct zclient *, zebra_size_t, lr_id_t);
 extern int rip_interface_address_add(int, struct zclient *, zebra_size_t,
-				     vrf_id_t);
+				     lr_id_t);
 extern int rip_interface_address_delete(int, struct zclient *, zebra_size_t,
-					vrf_id_t);
+					lr_id_t);
 
 #endif /* _QUAGGA_RIP_INTERFACE_H */

--- a/ripd/rip_routemap.c
+++ b/ripd/rip_routemap.c
@@ -121,7 +121,7 @@ static route_map_result_t route_match_interface(void *rule,
 
 	if (type == RMAP_RIP) {
 		ifname = rule;
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifname, vrf_id_default);
 
 		if (!ifp)
 			return RMAP_NOMATCH;

--- a/ripd/rip_snmp.c
+++ b/ripd/rip_snmp.c
@@ -255,7 +255,7 @@ static struct interface *rip2IfLookup(struct variable *v, oid name[],
 		oid2in_addr(name + v->namelen, sizeof(struct in_addr), addr);
 
 		return if_lookup_exact_address((void *)addr, AF_INET,
-					       VRF_DEFAULT);
+					       vrf_id_default);
 	} else {
 		len = *length - v->namelen;
 		if (len > 4)

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -369,7 +369,7 @@ static int rip_filter(int rip_distribute, struct prefix_ipv4 *p,
 /* Check nexthop address validity. */
 static int rip_nexthop_check(struct in_addr *addr)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct listnode *cnode;
 	struct connected *ifc;
@@ -1109,7 +1109,7 @@ static void rip_response_process(struct rip_packet *packet, int size,
 	   whether the datagram is from a valid neighbor; the source of the
 	   datagram must be on a directly connected network (RFC2453 - Sec.
 	   3.9.2) */
-	if (if_lookup_address((void *)&from->sin_addr, AF_INET, VRF_DEFAULT)
+	if (if_lookup_address((void *)&from->sin_addr, AF_INET, vrf_id_default)
 	    == NULL) {
 		zlog_info(
 			"This datagram doesn't came from a valid neighbor: %s",
@@ -1192,7 +1192,7 @@ static void rip_response_process(struct rip_packet *packet, int size,
 			}
 
 			if (!if_lookup_address((void *)&rte->nexthop, AF_INET,
-					       VRF_DEFAULT)) {
+					       vrf_id_default)) {
 				struct route_node *rn;
 				struct rip_info *rinfo;
 
@@ -1562,7 +1562,7 @@ void rip_redistribute_delete(int type, int sub_type, struct prefix_ipv4 *p,
 						inet_ntoa(p->prefix),
 						p->prefixlen,
 						ifindex2ifname(ifindex,
-							       VRF_DEFAULT));
+							       vrf_id_default));
 
 				rip_event(RIP_TRIGGERED_UPDATE, 0);
 			}
@@ -1767,7 +1767,7 @@ static int rip_read(struct thread *t)
 	}
 
 	/* Which interface is this packet comes from. */
-	ifc = if_lookup_address((void *)&from.sin_addr, AF_INET, VRF_DEFAULT);
+	ifc = if_lookup_address((void *)&from.sin_addr, AF_INET, vrf_id_default);
 	if (ifc)
 		ifp = ifc->ifp;
 
@@ -2434,7 +2434,7 @@ static void rip_update_interface(struct connected *ifc, u_char version,
 /* Update send to all interface and neighbor. */
 static void rip_update_process(int route_type)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct listnode *ifnode, *ifnnode;
 	struct connected *connected;
 	struct interface *ifp;
@@ -2497,7 +2497,7 @@ static void rip_update_process(int route_type)
 			p = &rp->p;
 
 			connected = if_lookup_address(&p->u.prefix4, AF_INET,
-						      VRF_DEFAULT);
+						      vrf_id_default);
 			if (!connected) {
 				zlog_warn(
 					"Neighbor %s doesnt have connected interface!",
@@ -2641,7 +2641,7 @@ void rip_redistribute_withdraw(int type)
 						p->prefixlen,
 						ifindex2ifname(
 							rinfo->nh.ifindex,
-							VRF_DEFAULT));
+							vrf_id_default));
 				}
 
 				rip_event(RIP_TRIGGERED_UPDATE, 0);
@@ -3522,7 +3522,7 @@ DEFUN (show_ip_rip_status,
        "Show RIP routes\n"
        "IP routing protocol process parameters and statistics\n")
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct rip_interface *ri;
 	extern const struct message ri_version_msg[];
@@ -3721,7 +3721,7 @@ static void rip_distribute_update(struct distribute *dist)
 	if (!dist->ifname)
 		return;
 
-	ifp = if_lookup_by_name(dist->ifname, VRF_DEFAULT);
+	ifp = if_lookup_by_name(dist->ifname, vrf_id_default);
 	if (ifp == NULL)
 		return;
 
@@ -3781,7 +3781,7 @@ void rip_distribute_update_interface(struct interface *ifp)
 /* ARGSUSED */
 static void rip_distribute_update_all(struct prefix_list *notused)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
@@ -3906,7 +3906,7 @@ static void rip_if_rmap_update(struct if_rmap *if_rmap)
 	struct rip_interface *ri;
 	struct route_map *rmap;
 
-	ifp = if_lookup_by_name(if_rmap->ifname, VRF_DEFAULT);
+	ifp = if_lookup_by_name(if_rmap->ifname, vrf_id_default);
 	if (ifp == NULL)
 		return;
 
@@ -3957,7 +3957,7 @@ static void rip_routemap_update_redistribute(void)
 /* ARGSUSED */
 static void rip_routemap_update(const char *notused)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -190,7 +190,7 @@ static int ripng_if_down(struct interface *ifp)
 
 /* Inteface link up message processing. */
 int ripng_interface_up(int command, struct zclient *zclient,
-		       zebra_size_t length, vrf_id_t vrf_id)
+		       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -223,7 +223,7 @@ int ripng_interface_up(int command, struct zclient *zclient,
 
 /* Inteface link down message processing. */
 int ripng_interface_down(int command, struct zclient *zclient,
-			 zebra_size_t length, vrf_id_t vrf_id)
+			 zebra_size_t length, lr_id_t vrf_id)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -249,7 +249,7 @@ int ripng_interface_down(int command, struct zclient *zclient,
 
 /* Inteface addition message from zebra. */
 int ripng_interface_add(int command, struct zclient *zclient,
-			zebra_size_t length, vrf_id_t vrf_id)
+			zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -274,7 +274,7 @@ int ripng_interface_add(int command, struct zclient *zclient,
 }
 
 int ripng_interface_delete(int command, struct zclient *zclient,
-			   zebra_size_t length, vrf_id_t vrf_id)
+			   zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -304,7 +304,7 @@ int ripng_interface_delete(int command, struct zclient *zclient,
 
 void ripng_interface_clean(void)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct ripng_interface *ri;
 
@@ -324,7 +324,7 @@ void ripng_interface_clean(void)
 
 void ripng_interface_reset(void)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct ripng_interface *ri;
 
@@ -382,7 +382,7 @@ static void ripng_apply_address_add(struct connected *ifc)
 }
 
 int ripng_interface_address_add(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+				zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *c;
 	struct prefix *p;
@@ -446,7 +446,7 @@ static void ripng_apply_address_del(struct connected *ifc)
 }
 
 int ripng_interface_address_delete(int command, struct zclient *zclient,
-				   zebra_size_t length, vrf_id_t vrf_id)
+				   zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *ifc;
 	struct prefix *p;
@@ -758,7 +758,7 @@ void ripng_enable_apply(struct interface *ifp)
 /* Set distribute list to all interfaces. */
 static void ripng_enable_apply_all(void)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
@@ -819,7 +819,7 @@ void ripng_passive_interface_apply(struct interface *ifp)
 
 static void ripng_passive_interface_apply_all(void)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
@@ -1067,7 +1067,7 @@ static int ripng_if_delete_hook(struct interface *ifp)
 /* Configuration write function for ripngd. */
 static int interface_config_write(struct vty *vty)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct ripng_interface *ri;
 	int write = 0;

--- a/ripngd/ripng_routemap.c
+++ b/ripngd/ripng_routemap.c
@@ -96,7 +96,7 @@ static route_map_result_t route_match_interface(void *rule,
 
 	if (type == RMAP_RIPNG) {
 		ifname = rule;
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifname, vrf_id_default);
 
 		if (!ifp)
 			return RMAP_NOMATCH;

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -957,13 +957,13 @@ void ripng_redistribute_add(int type, int sub_type, struct prefix_ipv6 *p,
 			zlog_debug(
 				"Redistribute new prefix %s/%d on the interface %s",
 				inet6_ntoa(p->prefix), p->prefixlen,
-				ifindex2ifname(ifindex, VRF_DEFAULT));
+				ifindex2ifname(ifindex, vrf_id_default));
 		else
 			zlog_debug(
 				"Redistribute new prefix %s/%d with nexthop %s on the interface %s",
 				inet6_ntoa(p->prefix), p->prefixlen,
 				inet6_ntoa(*nexthop),
-				ifindex2ifname(ifindex, VRF_DEFAULT));
+				ifindex2ifname(ifindex, vrf_id_default));
 	}
 
 	ripng_event(RIPNG_TRIGGERED_UPDATE, 0);
@@ -1010,7 +1010,7 @@ void ripng_redistribute_delete(int type, int sub_type, struct prefix_ipv6 *p,
 						inet6_ntoa(p->prefix),
 						p->prefixlen,
 						ifindex2ifname(ifindex,
-							       VRF_DEFAULT));
+							       vrf_id_default));
 
 				ripng_event(RIPNG_TRIGGERED_UPDATE, 0);
 			}
@@ -1055,7 +1055,7 @@ void ripng_redistribute_withdraw(int type)
 						inet6_ntoa(p->prefix),
 						p->prefixlen,
 						ifindex2ifname(rinfo->ifindex,
-							       VRF_DEFAULT));
+							       vrf_id_default));
 				}
 
 				ripng_event(RIPNG_TRIGGERED_UPDATE, 0);
@@ -1315,7 +1315,7 @@ static int ripng_read(struct thread *thread)
 	}
 
 	packet = (struct ripng_packet *)STREAM_DATA(ripng->ibuf);
-	ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
+	ifp = if_lookup_by_index(ifindex, vrf_id_default);
 
 	/* RIPng packet received. */
 	if (IS_RIPNG_DEBUG_EVENT)
@@ -1381,7 +1381,7 @@ static void ripng_clear_changed_flag(void)
    enabled interface. */
 static int ripng_update(struct thread *t)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct ripng_interface *ri;
 
@@ -1449,7 +1449,7 @@ static int ripng_triggered_interval(struct thread *t)
 /* Execute triggered update. */
 int ripng_triggered_update(struct thread *t)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 	struct ripng_interface *ri;
 	int interval;
@@ -2022,7 +2022,7 @@ DEFUN (show_ipv6_ripng,
 					len = vty_out(
 						vty, "%s",
 						ifindex2ifname(rinfo->ifindex,
-							       VRF_DEFAULT));
+							       vrf_id_default));
 				} else if (rinfo->metric
 					   == RIPNG_METRIC_INFINITY) {
 					len = vty_out(vty, "kill");
@@ -2062,7 +2062,7 @@ DEFUN (show_ipv6_ripng_status,
        "Show RIPng routes\n"
        "IPv6 routing protocol process parameters and statistics\n")
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	if (!ripng)
@@ -2736,7 +2736,7 @@ static void ripng_distribute_update(struct distribute *dist)
 	if (!dist->ifname)
 		return;
 
-	ifp = if_lookup_by_name(dist->ifname, VRF_DEFAULT);
+	ifp = if_lookup_by_name(dist->ifname, vrf_id_default);
 	if (ifp == NULL)
 		return;
 
@@ -2795,7 +2795,7 @@ void ripng_distribute_update_interface(struct interface *ifp)
 /* Update all interface's distribute list. */
 static void ripng_distribute_update_all(struct prefix_list *notused)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
@@ -2922,7 +2922,7 @@ static void ripng_if_rmap_update(struct if_rmap *if_rmap)
 	struct ripng_interface *ri;
 	struct route_map *rmap;
 
-	ifp = if_lookup_by_name(if_rmap->ifname, VRF_DEFAULT);
+	ifp = if_lookup_by_name(if_rmap->ifname, vrf_id_default);
 	if (ifp == NULL)
 		return;
 
@@ -2972,7 +2972,7 @@ static void ripng_routemap_update_redistribute(void)
 
 static void ripng_routemap_update(const char *unused)
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp)

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -394,17 +394,17 @@ extern void ripng_packet_dump(struct ripng_packet *packet, int size,
 			      const char *sndrcv);
 
 extern int ripng_interface_up(int command, struct zclient *, zebra_size_t,
-			      vrf_id_t);
+			      lr_id_t);
 extern int ripng_interface_down(int command, struct zclient *, zebra_size_t,
-				vrf_id_t);
+				lr_id_t);
 extern int ripng_interface_add(int command, struct zclient *, zebra_size_t,
-			       vrf_id_t);
+			       lr_id_t);
 extern int ripng_interface_delete(int command, struct zclient *, zebra_size_t,
-				  vrf_id_t);
+				  lr_id_t);
 extern int ripng_interface_address_add(int command, struct zclient *,
-				       zebra_size_t, vrf_id_t);
+				       zebra_size_t, lr_id_t);
 extern int ripng_interface_address_delete(int command, struct zclient *,
-					  zebra_size_t, vrf_id_t);
+					  zebra_size_t, lr_id_t);
 
 extern int ripng_network_write(struct vty *, int);
 

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -51,12 +51,12 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, VRF_DEFAULT);
+	return if_lookup_by_name(ifname_tmp, vrf_id_default);
 }
 
 /* Inteface addition message from zebra. */
 static int interface_add(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+			       zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 
@@ -69,7 +69,7 @@ static int interface_add(int command, struct zclient *zclient,
 }
 
 static int interface_delete(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+			    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -88,7 +88,7 @@ static int interface_delete(int command, struct zclient *zclient,
 }
 
 static int interface_address_add(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+				 zebra_size_t length, lr_id_t vrf_id)
 {
 
 	zebra_interface_address_read(command, zclient->ibuf, vrf_id);
@@ -97,7 +97,7 @@ static int interface_address_add(int command, struct zclient *zclient,
 }
 
 static int interface_address_delete(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+				    zebra_size_t length, lr_id_t vrf_id)
 {
 	struct connected *c;
 
@@ -111,7 +111,7 @@ static int interface_address_delete(int command, struct zclient *zclient,
 }
 
 static int interface_state_up(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+			      zebra_size_t length, lr_id_t vrf_id)
 {
 
 	zebra_interface_if_lookup(zclient->ibuf);
@@ -120,7 +120,7 @@ static int interface_state_up(int command, struct zclient *zclient,
 }
 
 static int interface_state_down(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+				zebra_size_t length, lr_id_t vrf_id)
 {
 
 	zebra_interface_state_read(zclient->ibuf, vrf_id);
@@ -132,7 +132,7 @@ extern uint32_t total_routes;
 extern uint32_t installed_routes;
 
 static int notify_owner(int command, struct zclient *zclient,
-			zebra_size_t length, vrf_id_t vrf_id)
+			zebra_size_t length, lr_id_t vrf_id)
 {
 	struct prefix p;
 	enum zapi_route_notify_owner note;
@@ -149,7 +149,7 @@ static int notify_owner(int command, struct zclient *zclient,
 
 static void zebra_connected(struct zclient *zclient)
 {
-	zclient_send_reg_requests(zclient, VRF_DEFAULT);
+	zclient_send_reg_requests(zclient, vrf_id_default);
 }
 
 void route_add(struct prefix *p, struct nexthop *nh)
@@ -158,7 +158,7 @@ void route_add(struct prefix *p, struct nexthop *nh)
 	struct zapi_nexthop *api_nh;
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id.lr.id = LR_DEFAULT;
 	api.type = ZEBRA_ROUTE_SHARP;
 	api.safi = SAFI_UNICAST;
 	memcpy(&api.prefix, p, sizeof(*p));
@@ -179,7 +179,7 @@ void route_delete(struct prefix *p)
 	struct zapi_route api;
 
 	memset(&api, 0, sizeof(api));
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id.lr.id = LR_DEFAULT;
 	api.type = ZEBRA_ROUTE_SHARP;
 	api.safi = SAFI_UNICAST;
 	memcpy(&api.prefix, p, sizeof(*p));

--- a/zebra/client_main.c
+++ b/zebra/client_main.c
@@ -53,8 +53,7 @@ void zebra_test_ipv4(int command, int type, char *prefix, char *gateway,
 	}
 
 	gpnt = &gate;
-
-	api.vrf_id = VRF_DEFAULT;
+	api.vrf_id.lr.id = LR_DEFAULT;
 	api.type = type;
 	api.flags = 0;
 

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -248,18 +248,18 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 		char buf[PREFIX_STRLEN];
 
 		zlog_debug("%u: IF %s address %s add/up, scheduling RIB processing",
-			   ifp->vrf_id, ifp->name,
+			   ifp->vrf_id.lr.id, ifp->name,
 			   prefix2str(&p, buf, sizeof(buf)));
 	}
 	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
-	if (ifp->vrf_id == VRF_DEFAULT) {
+	if (ifp->vrf_id.lr.id == LR_DEFAULT) {
 		if (IS_ZEBRA_DEBUG_MPLS) {
 			char buf[PREFIX_STRLEN];
 
 			zlog_debug("%u: IF %s IP %s address add/up, scheduling MPLS processing",
-				   ifp->vrf_id, ifp->name,
+				   ifp->vrf_id.lr.id, ifp->name,
 				   prefix2str(&p, buf, sizeof(buf)));
 		}
 		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id));
@@ -405,19 +405,19 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 		char buf[PREFIX_STRLEN];
 
 		zlog_debug("%u: IF %s IP %s address down, scheduling RIB processing",
-			   ifp->vrf_id, ifp->name,
+			   ifp->vrf_id.lr.id, ifp->name,
 			   prefix2str(&p, buf, sizeof(buf)));
 	}
 
 	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
-	if (ifp->vrf_id == VRF_DEFAULT) {
+	if (ifp->vrf_id.lr.id == LR_DEFAULT) {
 		if (IS_ZEBRA_DEBUG_MPLS) {
 			char buf[PREFIX_STRLEN];
 
 			zlog_debug("%u: IF %s IP %s address down, scheduling MPLS processing",
-				   ifp->vrf_id, ifp->name,
+				   ifp->vrf_id.lr.id, ifp->name,
 				   prefix2str(&p, buf, sizeof(buf)));
 		}
 		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id));
@@ -438,18 +438,18 @@ static void connected_delete_helper(struct connected *ifc, struct prefix *p)
 		char buf[PREFIX_STRLEN];
 
 		zlog_debug("%u: IF %s IP %s address del, scheduling RIB processing",
-			   ifp->vrf_id, ifp->name,
+			   ifp->vrf_id.lr.id, ifp->name,
 			   prefix2str(p, buf, sizeof(buf)));
 	}
 	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
-	if (ifp->vrf_id == VRF_DEFAULT) {
+	if (ifp->vrf_id.lr.id == LR_DEFAULT) {
 		if (IS_ZEBRA_DEBUG_MPLS) {
 			char buf[PREFIX_STRLEN];
 
 			zlog_debug("%u: IF %s IP %s address delete, scheduling MPLS processing",
-				   ifp->vrf_id, ifp->name,
+				   ifp->vrf_id.lr.id, ifp->name,
 				   prefix2str(p, buf, sizeof(buf)));
 		}
 		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id));

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -105,7 +105,7 @@ static int interface_list_ioctl(void)
 		unsigned int size;
 
 		ifreq = (struct ifreq *)((caddr_t)ifconf.ifc_req + n);
-		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT, 0);
+		ifp = if_get_by_name(ifreq->ifr_name, vrf_id_default, 0);
 		if_add_update(ifp);
 		size = ifreq->ifr_addr.sa_len;
 		if (size < sizeof(ifreq->ifr_addr))
@@ -115,7 +115,7 @@ static int interface_list_ioctl(void)
 	}
 #else
 	for (n = 0; n < ifconf.ifc_len; n += sizeof(struct ifreq)) {
-		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT, 0);
+		ifp = if_get_by_name(ifreq->ifr_name, vrf_id_default, 0);
 		if_add_update(ifp);
 		ifreq++;
 	}
@@ -188,7 +188,7 @@ static int if_getaddrs(void)
 			continue;
 		}
 
-		ifp = if_lookup_by_name(ifap->ifa_name, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifap->ifa_name, vrf_id_default);
 		if (ifp == NULL) {
 			zlog_err("if_getaddrs(): Can't lookup interface %s\n",
 				 ifap->ifa_name);
@@ -262,7 +262,7 @@ static int if_getaddrs(void)
 /* Fetch interface information via ioctl(). */
 static void interface_info_ioctl()
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id_default);
 	struct interface *ifp;
 
 	FOR_ALL_INTERFACES (vrf, ifp) {

--- a/zebra/if_ioctl_solaris.c
+++ b/zebra/if_ioctl_solaris.c
@@ -170,7 +170,7 @@ calculate_lifc_len: /* must hold privileges to enter here */
 		       && (*(lifreq->lifr_name + normallen) != ':'))
 			normallen++;
 
-		ifp = if_get_by_name(lifreq->lifr_name, VRF_DEFAULT, 0);
+		ifp = if_get_by_name(lifreq->lifr_name, vrf_id_default, 0);
 
 		if (lifreq->lifr_addr.ss_family == AF_INET)
 			ifp->flags |= IFF_IPV4;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -262,7 +262,7 @@ static void netlink_determine_zebra_iftype(char *kind, zebra_iftype_t *zif_type)
 	netlink_parse_rtattr((tb), (max), RTA_DATA(rta), RTA_PAYLOAD(rta))
 
 static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
-			       const char *name)
+			       const char *name, ns_id_t ns_id)
 {
 	struct ifinfomsg *ifi;
 	struct rtattr *linkinfo[IFLA_INFO_MAX + 1];
@@ -270,6 +270,7 @@ static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
 	struct vrf *vrf;
 	struct zebra_vrf *zvrf;
 	u_int32_t nl_table_id;
+	lr_id_t vrf_id  = { .lr.lr_id.ns_id = ns_id};
 
 	ifi = NLMSG_DATA(h);
 
@@ -304,8 +305,8 @@ static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
 		/*
 		 * vrf_get is implied creation if it does not exist
 		 */
-		vrf = vrf_get((vrf_id_t)ifi->ifi_index,
-			      name); // It would create vrf
+		vrf_id.lr.lr_id.vrf_id = (vrf_id_t)ifi->ifi_index;
+		vrf = vrf_get(vrf_id, name); // It would create vrf
 		if (!vrf) {
 			zlog_err("VRF %s id %u not created", name,
 				 ifi->ifi_index);
@@ -332,8 +333,8 @@ static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug("RTM_DELLINK for VRF %s(%u)", name,
 				   ifi->ifi_index);
-
-		vrf = vrf_lookup_by_id((vrf_id_t)ifi->ifi_index);
+		vrf_id.lr.lr_id.vrf_id = (vrf_id_t) ifi->ifi_index;
+		vrf = vrf_lookup_by_id(vrf_id);
 
 		if (!vrf) {
 			zlog_warn("%s: vrf not found", __func__);
@@ -553,7 +554,7 @@ static int netlink_interface(struct sockaddr_nl *snl, struct nlmsghdr *h,
 	char *desc = NULL;
 	char *slave_kind = NULL;
 	struct zebra_ns *zns;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	lr_id_t vrf_id =  { .lr.id = LR_DEFAULT};
 	zebra_iftype_t zif_type = ZEBRA_IF_OTHER;
 	zebra_slave_iftype_t zif_slave_type = ZEBRA_IF_SLAVE_NONE;
 	ifindex_t bridge_ifindex = IFINDEX_INTERNAL;
@@ -611,14 +612,15 @@ static int netlink_interface(struct sockaddr_nl *snl, struct nlmsghdr *h,
 
 	/* If VRF, create the VRF structure itself. */
 	if (zif_type == ZEBRA_IF_VRF) {
-		netlink_vrf_change(h, tb[IFLA_LINKINFO], name);
-		vrf_id = (vrf_id_t)ifi->ifi_index;
+		netlink_vrf_change(h, tb[IFLA_LINKINFO], name, ns_id);
+		vrf_id.lr.lr_id.vrf_id = (vrf_id_t)ifi->ifi_index;
+		vrf_id.lr.lr_id.ns_id = ns_id;
 	}
 
 	if (tb[IFLA_MASTER]) {
 		if (slave_kind && (strcmp(slave_kind, "vrf") == 0)) {
 			zif_slave_type = ZEBRA_IF_SLAVE_VRF;
-			vrf_id = *(u_int32_t *)RTA_DATA(tb[IFLA_MASTER]);
+			vrf_id.lr.lr_id.vrf_id = *(u_int32_t *)RTA_DATA(tb[IFLA_MASTER]);
 		} else if (slave_kind && (strcmp(slave_kind, "bridge") == 0)) {
 			zif_slave_type = ZEBRA_IF_SLAVE_BRIDGE;
 			bridge_ifindex =
@@ -992,7 +994,7 @@ int netlink_link_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 	char *desc = NULL;
 	char *slave_kind = NULL;
 	struct zebra_ns *zns;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	lr_id_t vrf_id = { .lr.lr_id.ns_id = ns_id};
 	zebra_iftype_t zif_type = ZEBRA_IF_OTHER;
 	zebra_slave_iftype_t zif_slave_type = ZEBRA_IF_SLAVE_NONE;
 	ifindex_t bridge_ifindex = IFINDEX_INTERNAL;
@@ -1060,8 +1062,8 @@ int netlink_link_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 
 	/* If VRF, create or update the VRF structure itself. */
 	if (zif_type == ZEBRA_IF_VRF) {
-		netlink_vrf_change(h, tb[IFLA_LINKINFO], name);
-		vrf_id = (vrf_id_t)ifi->ifi_index;
+		netlink_vrf_change(h, tb[IFLA_LINKINFO], name, ns_id);
+		vrf_id.lr.lr_id.vrf_id = (vrf_id_t)ifi->ifi_index;
 	}
 
 	/* See if interface is present. */
@@ -1078,7 +1080,7 @@ int netlink_link_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 		if (tb[IFLA_MASTER]) {
 			if (slave_kind && (strcmp(slave_kind, "vrf") == 0)) {
 				zif_slave_type = ZEBRA_IF_SLAVE_VRF;
-				vrf_id =
+				vrf_id.lr.lr_id.vrf_id =
 					*(u_int32_t *)RTA_DATA(tb[IFLA_MASTER]);
 			} else if (slave_kind
 				   && (strcmp(slave_kind, "bridge") == 0)) {
@@ -1096,7 +1098,7 @@ int netlink_link_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 				zlog_debug(
 					"RTM_NEWLINK ADD for %s(%u) vrf_id %u type %d "
 					"sl_type %d master %u flags 0x%x",
-					name, ifi->ifi_index, vrf_id, zif_type,
+					name, ifi->ifi_index, vrf_id.lr.id, zif_type,
 					zif_slave_type, bridge_ifindex,
 					ifi->ifi_flags);
 
@@ -1105,7 +1107,7 @@ int netlink_link_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 				ifp = if_get_by_name(name, vrf_id, 0);
 			} else {
 				/* pre-configured interface, learnt now */
-				if (ifp->vrf_id != vrf_id)
+				if (ifp->vrf_id.lr.id != vrf_id.lr.id)
 					if_update_to_new_vrf(ifp, vrf_id);
 			}
 
@@ -1137,13 +1139,13 @@ int netlink_link_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 			if (IS_ZEBRA_IF_BRIDGE_SLAVE(ifp))
 				zebra_l2if_update_bridge_slave(ifp,
 							       bridge_ifindex);
-		} else if (ifp->vrf_id != vrf_id) {
+		} else if (ifp->vrf_id.lr.id != vrf_id.lr.id) {
 			/* VRF change for an interface. */
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug(
 					"RTM_NEWLINK vrf-change for %s(%u) "
 					"vrf_id %u -> %u flags 0x%x",
-					name, ifp->ifindex, ifp->vrf_id, vrf_id,
+					name, ifp->ifindex, ifp->vrf_id.lr.id, vrf_id.lr.id,
 					ifi->ifi_flags);
 
 			if_handle_vrf_change(ifp, vrf_id);

--- a/zebra/if_sysctl.c
+++ b/zebra/if_sysctl.c
@@ -70,7 +70,7 @@ void ifstat_update_sysctl(void)
 	for (end = buf + bufsiz; buf < end; buf += ifm->ifm_msglen) {
 		ifm = (struct if_msghdr *)buf;
 		if (ifm->ifm_type == RTM_IFINFO) {
-			ifp = if_lookup_by_index(ifm->ifm_index, VRF_DEFAULT);
+			ifp = if_lookup_by_index(ifm->ifm_index, vrf_id_default);
 			if (ifp)
 				ifp->stats = ifm->ifm_data;
 		}

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -502,7 +502,7 @@ void if_add_update(struct interface *ifp)
 				zlog_debug(
 					"interface %s vrf %u index %d is shutdown. "
 					"Won't wake it up.",
-					ifp->name, ifp->vrf_id, ifp->ifindex);
+					ifp->name, ifp->vrf_id.lr.id, ifp->ifindex);
 			return;
 		}
 
@@ -511,13 +511,13 @@ void if_add_update(struct interface *ifp)
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
 				"interface %s vrf %u index %d becomes active.",
-				ifp->name, ifp->vrf_id, ifp->ifindex);
+				ifp->name, ifp->vrf_id.lr.id, ifp->ifindex);
 
 		static_ifindex_update(ifp, true);
 	} else {
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug("interface %s vrf %u index %d is added.",
-				   ifp->name, ifp->vrf_id, ifp->ifindex);
+				   ifp->name, ifp->vrf_id.lr.id, ifp->ifindex);
 	}
 }
 
@@ -659,7 +659,7 @@ void if_delete_update(struct interface *ifp)
 	if (if_is_up(ifp)) {
 		zlog_err(
 			"interface %s vrf %u index %d is still up while being deleted.",
-			ifp->name, ifp->vrf_id, ifp->ifindex);
+			ifp->name, ifp->vrf_id.lr.id, ifp->ifindex);
 		return;
 	}
 
@@ -668,7 +668,7 @@ void if_delete_update(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_KERNEL)
 		zlog_debug("interface %s vrf %u index %d is now inactive.",
-			   ifp->name, ifp->vrf_id, ifp->ifindex);
+			   ifp->name, ifp->vrf_id.lr.id, ifp->ifindex);
 
 	static_ifindex_update(ifp, false);
 
@@ -690,8 +690,8 @@ void if_delete_update(struct interface *ifp)
 
 	/* if the ifp is in a vrf, move it to default so vrf can be deleted if
 	 * desired */
-	if (ifp->vrf_id)
-		if_handle_vrf_change(ifp, VRF_DEFAULT);
+	if (ifp->vrf_id.lr.id)
+		if_handle_vrf_change(ifp, vrf_id_default);
 
 	/* Reset some zebra interface params to default values. */
 	zif = ifp->info;
@@ -705,9 +705,9 @@ void if_delete_update(struct interface *ifp)
 }
 
 /* VRF change for an interface */
-void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
+void if_handle_vrf_change(struct interface *ifp, lr_id_t vrf_id)
 {
-	vrf_id_t old_vrf_id;
+	lr_id_t old_vrf_id;
 
 	old_vrf_id = ifp->vrf_id;
 
@@ -743,7 +743,7 @@ void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
 	 */
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 		zlog_debug("%u: IF %s VRF change, scheduling RIB processing",
-			   ifp->vrf_id, ifp->name);
+			   ifp->vrf_id.lr.id, ifp->name);
 	rib_update(old_vrf_id, RIB_UPDATE_IF_CHANGE);
 	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
 }
@@ -855,7 +855,7 @@ void if_up(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 		zlog_debug("%u: IF %s up, scheduling RIB processing",
-			   ifp->vrf_id, ifp->name);
+			   ifp->vrf_id.lr.id, ifp->name);
 	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
 
 	/* Handle interface up for specific types for EVPN. Non-VxLAN interfaces
@@ -912,7 +912,7 @@ void if_down(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 		zlog_debug("%u: IF %s down, scheduling RIB processing",
-			   ifp->vrf_id, ifp->name);
+			   ifp->vrf_id.lr.id, ifp->name);
 	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
 
 	if_nbr_ipv6ll_to_ipv4ll_neigh_del_all(ifp);
@@ -1319,7 +1319,7 @@ DEFUN (show_interface,
 {
 	struct vrf *vrf;
 	struct interface *ifp;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	lr_id_t vrf_id =  { .lr.id = LR_DEFAULT};
 
 	interface_update_stats();
 
@@ -1369,7 +1369,7 @@ DEFUN (show_interface_name_vrf,
 	int idx_ifname = 2;
 	int idx_name = 4;
 	struct interface *ifp;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	lr_id_t vrf_id =  { .lr.id = LR_DEFAULT};
 
 	interface_update_stats();
 
@@ -1423,7 +1423,7 @@ DEFUN (show_interface_name_vrf_all,
 }
 
 
-static void if_show_description(struct vty *vty, vrf_id_t vrf_id)
+static void if_show_description(struct vty *vty, lr_id_t vrf_id)
 {
 	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 	struct interface *ifp;
@@ -1464,7 +1464,7 @@ DEFUN (show_interface_desc,
        "Interface description\n"
        VRF_CMD_HELP_STR)
 {
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	lr_id_t vrf_id =  { .lr.id = LR_DEFAULT};
 
 	if (argc > 3)
 		VRF_GET_ID(vrf_id, argv[4]->arg);
@@ -1487,7 +1487,7 @@ DEFUN (show_interface_desc_vrf_all,
 
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
 		if (!RB_EMPTY (if_name_head, &vrf->ifaces_by_name)) {
-			vty_out(vty, "\n\tVRF %u\n\n", vrf->vrf_id);
+			vty_out(vty, "\n\tVRF %u\n\n", vrf->vrf_id.lr.id);
 			if_show_description(vty, vrf->vrf_id);
 		}
 
@@ -2845,7 +2845,7 @@ static int if_config_write(struct vty *vty)
 			if_data = ifp->info;
 			vrf = vrf_lookup_by_id(ifp->vrf_id);
 
-			if (ifp->vrf_id == VRF_DEFAULT)
+			if (ifp->vrf_id.lr.id == LR_DEFAULT)
 				vty_frame(vty, "interface %s\n", ifp->name);
 			else
 				vty_frame(vty, "interface %s vrf %s\n",

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -334,7 +334,7 @@ extern void if_flags_update(struct interface *, uint64_t);
 extern int if_subnet_add(struct interface *, struct connected *);
 extern int if_subnet_delete(struct interface *, struct connected *);
 extern int ipv6_address_configured(struct interface *ifp);
-extern void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id);
+extern void if_handle_vrf_change(struct interface *ifp, lr_id_t vrf_id);
 extern void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex);
 
 extern void vrf_add_update(struct vrf *vrfp);

--- a/zebra/irdp_packet.c
+++ b/zebra/irdp_packet.c
@@ -231,7 +231,7 @@ int irdp_read_raw(struct thread *r)
 	if (ret < 0)
 		zlog_warn("IRDP: RX Error length = %d", ret);
 
-	ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
+	ifp = if_lookup_by_index(ifindex, vrf_id_default);
 	if (!ifp)
 		return ret;
 

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -309,7 +309,7 @@ static int ifan_read(struct if_announcemsghdr *ifan)
 {
 	struct interface *ifp;
 
-	ifp = if_lookup_by_index(ifan->ifan_index, VRF_DEFAULT);
+	ifp = if_lookup_by_index(ifan->ifan_index, vrf_id_default);
 
 	if (ifp)
 		assert((ifp->ifindex == ifan->ifan_index)
@@ -323,7 +323,7 @@ static int ifan_read(struct if_announcemsghdr *ifan)
 				__func__, ifan->ifan_index, ifan->ifan_name);
 
 		/* Create Interface */
-		ifp = if_get_by_name(ifan->ifan_name, VRF_DEFAULT, 0);
+		ifp = if_get_by_name(ifan->ifan_name, vrf_id_default, 0);
 		if_set_index(ifp, ifan->ifan_index);
 
 		if_get_metric(ifp);
@@ -456,7 +456,7 @@ int ifm_read(struct if_msghdr *ifm)
 	 * messages, such as up/down status changes on NetBSD, do not include a
 	 * sockaddr_dl).
 	 */
-	if ((ifp = if_lookup_by_index(ifm->ifm_index, VRF_DEFAULT)) != NULL) {
+	if ((ifp = if_lookup_by_index(ifm->ifm_index, vrf_id_default)) != NULL) {
 		/* we have an ifp, verify that the name matches as some systems,
 		 * eg Solaris, have a 1:many association of ifindex:ifname
 		 * if they dont match, we dont have the correct ifp and should
@@ -485,7 +485,7 @@ int ifm_read(struct if_msghdr *ifm)
 	 * be filled in.
 	 */
 	if ((ifp == NULL) && ifnlen)
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifname, vrf_id_default);
 
 	/*
 	 * If ifp still does not exist or has an invalid index
@@ -514,7 +514,7 @@ int ifm_read(struct if_msghdr *ifm)
 		if (ifp == NULL) {
 			/* Interface that zebra was not previously aware of, so
 			 * create. */
-			ifp = if_create(ifname, VRF_DEFAULT);
+			ifp = if_create(ifname, vrf_id_default);
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug("%s: creating ifp for ifindex %d",
 					   __func__, ifm->ifm_index);
@@ -723,7 +723,7 @@ int ifam_read(struct ifa_msghdr *ifam)
 	/* Allocate and read address information. */
 	ifam_read_mesg(ifam, &addr, &mask, &brd, ifname, &ifnlen);
 
-	if ((ifp = if_lookup_by_index(ifam->ifam_index, VRF_DEFAULT)) == NULL) {
+	if ((ifp = if_lookup_by_index(ifam->ifam_index, vrf_id_default)) == NULL) {
 		zlog_warn("%s: no interface for ifname %s, index %d", __func__,
 			  ifname, ifam->ifam_index);
 		return -1;
@@ -937,7 +937,7 @@ void rtm_read(struct rt_msghdr *rtm)
 			if (!IS_ZEBRA_DEBUG_RIB)
 				return;
 			ret = rib_lookup_ipv4_route((struct prefix_ipv4 *)&p,
-						    &gate, VRF_DEFAULT);
+						    &gate, vrf_id_default);
 			prefix2str(&p, buf, sizeof(buf));
 			switch (rtm->rtm_type) {
 			case RTM_ADD:
@@ -976,7 +976,7 @@ void rtm_read(struct rt_msghdr *rtm)
 						buf);
 					rib_lookup_and_dump(
 						(struct prefix_ipv4 *)&p,
-						VRF_DEFAULT);
+						vrf_id_default);
 					return;
 					break;
 				}
@@ -996,7 +996,7 @@ void rtm_read(struct rt_msghdr *rtm)
 						buf);
 					rib_lookup_and_dump(
 						(struct prefix_ipv4 *)&p,
-						VRF_DEFAULT);
+						vrf_id_default);
 					break;
 				case ZEBRA_RIB_FOUND_CONNECTED:
 				case ZEBRA_RIB_FOUND_NOGATE:
@@ -1008,7 +1008,7 @@ void rtm_read(struct rt_msghdr *rtm)
 						buf);
 					rib_lookup_and_dump(
 						(struct prefix_ipv4 *)&p,
-						VRF_DEFAULT);
+						vrf_id_default);
 					break;
 				case ZEBRA_RIB_NOTFOUND: /* RIB RR == FIB RR */
 					zlog_debug(
@@ -1018,7 +1018,7 @@ void rtm_read(struct rt_msghdr *rtm)
 						buf);
 					rib_lookup_and_dump(
 						(struct prefix_ipv4 *)&p,
-						VRF_DEFAULT);
+						vrf_id_default);
 					return;
 					break;
 				}
@@ -1037,7 +1037,7 @@ void rtm_read(struct rt_msghdr *rtm)
 		 * to specify the route really
 		 */
 		if (rtm->rtm_type == RTM_CHANGE)
-			rib_delete(AFI_IP, SAFI_UNICAST, VRF_DEFAULT,
+			rib_delete(AFI_IP, SAFI_UNICAST, vrf_id_default,
 				   ZEBRA_ROUTE_KERNEL, 0, zebra_flags, &p, NULL,
 				   NULL, 0, 0, true);
 
@@ -1048,11 +1048,11 @@ void rtm_read(struct rt_msghdr *rtm)
 
 		if (rtm->rtm_type == RTM_GET || rtm->rtm_type == RTM_ADD
 		    || rtm->rtm_type == RTM_CHANGE)
-			rib_add(AFI_IP, SAFI_UNICAST, VRF_DEFAULT,
+			rib_add(AFI_IP, SAFI_UNICAST, vrf_id_default,
 				ZEBRA_ROUTE_KERNEL, 0, zebra_flags, &p, NULL,
 				&nh, 0, 0, 0, 0);
 		else
-			rib_delete(AFI_IP, SAFI_UNICAST, VRF_DEFAULT,
+			rib_delete(AFI_IP, SAFI_UNICAST, vrf_id_default,
 				   ZEBRA_ROUTE_KERNEL, 0, zebra_flags, &p, NULL,
 				   &nh, 0, 0, true);
 	}
@@ -1083,7 +1083,7 @@ void rtm_read(struct rt_msghdr *rtm)
 		 * to specify the route really
 		 */
 		if (rtm->rtm_type == RTM_CHANGE)
-			rib_delete(AFI_IP6, SAFI_UNICAST, VRF_DEFAULT,
+			rib_delete(AFI_IP6, SAFI_UNICAST, vrf_id_default,
 				   ZEBRA_ROUTE_KERNEL, 0, zebra_flags, &p, NULL,
 				   NULL, 0, 0, true);
 
@@ -1096,11 +1096,11 @@ void rtm_read(struct rt_msghdr *rtm)
 
 		if (rtm->rtm_type == RTM_GET || rtm->rtm_type == RTM_ADD
 		    || rtm->rtm_type == RTM_CHANGE)
-			rib_add(AFI_IP6, SAFI_UNICAST, VRF_DEFAULT,
+			rib_add(AFI_IP6, SAFI_UNICAST, vrf_id_default,
 				ZEBRA_ROUTE_KERNEL, 0, zebra_flags, &p, NULL,
 				&nh, 0, 0, 0, 0);
 		else
-			rib_delete(AFI_IP6, SAFI_UNICAST, VRF_DEFAULT,
+			rib_delete(AFI_IP6, SAFI_UNICAST, vrf_id_default,
 				   ZEBRA_ROUTE_KERNEL, 0, zebra_flags, &p, NULL,
 				   &nh, 0, 0, true);
 	}
@@ -1149,7 +1149,7 @@ int rtm_write(int message, union sockunion *dest, union sockunion *mask,
 		msg.rtm.rtm_inits |= RTV_HOPCOUNT;
 	}
 
-	ifp = if_lookup_by_index(index, VRF_DEFAULT);
+	ifp = if_lookup_by_index(index, vrf_id_default);
 
 	if (gate && (message == RTM_ADD || message == RTM_CHANGE))
 		msg.rtm.rtm_flags |= RTF_GATEWAY;

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -63,7 +63,7 @@ static int relay_response_back(struct zserv *zserv)
 	u_int16_t size = 0;
 	u_char marker;
 	u_char version;
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 	u_int16_t resp_cmd;
 
 	src = zclient->ibuf;
@@ -112,7 +112,7 @@ static int lm_zclient_read(struct thread *t)
 	return ret;
 }
 
-static int reply_error(int cmd, struct zserv *zserv, vrf_id_t vrf_id)
+static int reply_error(int cmd, struct zserv *zserv, lr_id_t vrf_id)
 {
 	struct stream *s;
 
@@ -141,7 +141,7 @@ static int reply_error(int cmd, struct zserv *zserv, vrf_id_t vrf_id)
  * @return 0 on success, -1 otherwise
  */
 int zread_relay_label_manager_request(int cmd, struct zserv *zserv,
-				      vrf_id_t vrf_id)
+				      lr_id_t vrf_id)
 {
 	struct stream *src, *dst;
 	int ret = 0;

--- a/zebra/label_manager.h
+++ b/zebra/label_manager.h
@@ -62,7 +62,7 @@ struct label_manager {
 bool lm_is_external;
 
 int zread_relay_label_manager_request(int cmd, struct zserv *zserv,
-				      vrf_id_t vrf_id);
+				      lr_id_t vrf_id);
 void label_manager_init(char *lm_zserv_path);
 struct label_manager_chunk *assign_label_chunk(u_char proto, u_short instance,
 					       u_char keep, uint32_t size);

--- a/zebra/redistribute.h
+++ b/zebra/redistribute.h
@@ -54,9 +54,9 @@ extern void zebra_interface_address_delete_update(struct interface *,
 						  struct connected *c);
 extern void zebra_interface_parameters_update(struct interface *);
 extern void zebra_interface_vrf_update_del(struct interface *,
-					   vrf_id_t new_vrf_id);
+					   lr_id_t new_vrf_id);
 extern void zebra_interface_vrf_update_add(struct interface *,
-					   vrf_id_t old_vrf_id);
+					   lr_id_t old_vrf_id);
 
 extern int zebra_import_table(afi_t afi, u_int32_t table_id, u_int32_t distance,
 			      const char *rmap_name, int add);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -58,7 +58,7 @@ struct route_entry {
 	u_short instance;
 
 	/* VRF identifier. */
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 
 	/* Which routing table */
 	uint32_t table;
@@ -215,7 +215,7 @@ typedef enum {
  * Routing Information Base.
  */
 typedef struct rib_tables_iter_t_ {
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 	int afi_safi_ix;
 
 	rib_tables_iter_state_t state;
@@ -267,11 +267,11 @@ enum multicast_mode {
 extern void multicast_mode_ipv4_set(enum multicast_mode mode);
 extern enum multicast_mode multicast_mode_ipv4_get(void);
 
-extern void rib_lookup_and_dump(struct prefix_ipv4 *, vrf_id_t);
-extern void rib_lookup_and_pushup(struct prefix_ipv4 *, vrf_id_t);
+extern void rib_lookup_and_dump(struct prefix_ipv4 *, lr_id_t);
+extern void rib_lookup_and_pushup(struct prefix_ipv4 *, lr_id_t);
 
 extern int rib_lookup_ipv4_route(struct prefix_ipv4 *, union sockunion *,
-				 vrf_id_t);
+				 lr_id_t);
 #define ZEBRA_RIB_LOOKUP_ERROR -1
 #define ZEBRA_RIB_FOUND_EXACT 0
 #define ZEBRA_RIB_FOUND_NOGATE 1
@@ -292,7 +292,7 @@ extern void rib_uninstall_kernel(struct route_node *rn, struct route_entry *re);
 /* NOTE:
  * All rib_add function will not just add prefix into RIB, but
  * also implicitly withdraw equal prefix of same type. */
-extern int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
+extern int rib_add(afi_t afi, safi_t safi, lr_id_t vrf_id, int type,
 		   u_short instance, int flags, struct prefix *p,
 		   struct prefix_ipv6 *src_p, const struct nexthop *nh,
 		   u_int32_t table_id, u_int32_t metric, u_int32_t mtu,
@@ -301,21 +301,21 @@ extern int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 extern int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *,
 			     struct prefix_ipv6 *src_p, struct route_entry *);
 
-extern void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
+extern void rib_delete(afi_t afi, safi_t safi, lr_id_t vrf_id, int type,
 		       u_short instance, int flags, struct prefix *p,
 		       struct prefix_ipv6 *src_p, const struct nexthop *nh,
 		       u_int32_t table_id, u_int32_t metric, bool fromkernel);
 
-extern struct route_entry *rib_match(afi_t afi, safi_t safi, vrf_id_t,
+extern struct route_entry *rib_match(afi_t afi, safi_t safi, lr_id_t,
 				     union g_addr *,
 				     struct route_node **rn_out);
-extern struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
+extern struct route_entry *rib_match_ipv4_multicast(lr_id_t vrf_id,
 						    struct in_addr addr,
 						    struct route_node **rn_out);
 
-extern struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *, vrf_id_t);
+extern struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *, lr_id_t);
 
-extern void rib_update(vrf_id_t, rib_update_event_t);
+extern void rib_update(lr_id_t, rib_update_event_t);
 extern void rib_weed_tables(void);
 extern void rib_sweep_route(void);
 extern void rib_close_table(struct route_table *);

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -71,7 +71,7 @@ static int router_id_bad_address(struct connected *ifc)
 	return 0;
 }
 
-void router_id_get(struct prefix *p, vrf_id_t vrf_id)
+void router_id_get(struct prefix *p, lr_id_t vrf_id)
 {
 	struct listnode *node;
 	struct connected *c;
@@ -94,7 +94,7 @@ void router_id_get(struct prefix *p, vrf_id_t vrf_id)
 	}
 }
 
-static void router_id_set(struct prefix *p, vrf_id_t vrf_id)
+static void router_id_set(struct prefix *p, lr_id_t vrf_id)
 {
 	struct prefix p2;
 	struct listnode *node;
@@ -190,7 +190,7 @@ void router_id_write(struct vty *vty)
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
 		if ((zvrf = vrf->info) != NULL)
 			if (zvrf->rid_user_assigned.u.prefix4.s_addr) {
-				if (zvrf_id(zvrf) == VRF_DEFAULT)
+				if (zvrf_id(zvrf).lr.id == LR_DEFAULT)
 					vty_out(vty, "router-id %s\n",
 						inet_ntoa(
 							zvrf->rid_user_assigned
@@ -215,7 +215,7 @@ DEFUN (router_id,
 	int idx_name = 3;
 
 	struct prefix rid;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	lr_id_t vrf_id = { .lr.id = LR_DEFAULT};
 
 	rid.u.prefix4.s_addr = inet_addr(argv[idx_ipv4]->arg);
 	if (!rid.u.prefix4.s_addr)
@@ -243,7 +243,7 @@ DEFUN (no_router_id,
 	int idx_name = 4;
 
 	struct prefix rid;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	lr_id_t vrf_id = { .lr.id = LR_DEFAULT};
 
 	rid.u.prefix4.s_addr = 0;
 	rid.prefixlen = 0;

--- a/zebra/router-id.h
+++ b/zebra/router-id.h
@@ -35,6 +35,6 @@ extern void router_id_del_address(struct connected *);
 extern void router_id_init(struct zebra_vrf *);
 extern void router_id_cmd_init(void);
 extern void router_id_write(struct vty *);
-extern void router_id_get(struct prefix *, vrf_id_t);
+extern void router_id_get(struct prefix *, lr_id_t);
 
 #endif

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -817,7 +817,7 @@ void zebra_interface_radv_set(struct zserv *client, u_short length,
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("%u: IF %u RA %s from client %s, interval %ds",
-			   zvrf_id(zvrf), ifindex,
+			   zvrf_id(zvrf).lr.id, ifindex,
 			   enable ? "enable" : "disable",
 			   zebra_route_string(client->proto), ra_interval);
 
@@ -825,14 +825,14 @@ void zebra_interface_radv_set(struct zserv *client, u_short length,
 	ifp = if_lookup_by_index_per_ns(zebra_ns_lookup(NS_DEFAULT), ifindex);
 	if (!ifp) {
 		zlog_warn("%u: IF %u RA %s client %s - interface unknown",
-			  zvrf_id(zvrf), ifindex, enable ? "enable" : "disable",
+			  zvrf_id(zvrf).lr.id, ifindex, enable ? "enable" : "disable",
 			  zebra_route_string(client->proto));
 		return;
 	}
-	if (ifp->vrf_id != zvrf_id(zvrf)) {
+	if (ifp->vrf_id.lr.id != zvrf_id(zvrf).lr.id) {
 		zlog_warn("%u: IF %u RA %s client %s - VRF mismatch, IF VRF %u",
-			  zvrf_id(zvrf), ifindex, enable ? "enable" : "disable",
-			  zebra_route_string(client->proto), ifp->vrf_id);
+			  zvrf_id(zvrf).lr.id, ifindex, enable ? "enable" : "disable",
+			  zebra_route_string(client->proto), ifp->vrf_id.lr.id);
 		return;
 	}
 

--- a/zebra/rtread_getmsg.c
+++ b/zebra/rtread_getmsg.c
@@ -97,7 +97,7 @@ static void handle_route_entry(mib2_ipRouteEntry_t *routeEntry)
 	nh.type = NEXTHOP_TYPE_IPV4;
 	nh.gate.ipv4.s_addr = routeEntry->ipRouteNextHop;
 
-	rib_add(AFI_IP, SAFI_UNICAST, VRF_DEFAULT, ZEBRA_ROUTE_KERNEL, 0,
+	rib_add(AFI_IP, SAFI_UNICAST, vrf_id_default, ZEBRA_ROUTE_KERNEL, 0,
 		zebra_flags, &prefix, NULL, &nh, 0, 0, 0, 0);
 }
 

--- a/zebra/zebra_fpm_dt.c
+++ b/zebra/zebra_fpm_dt.c
@@ -75,7 +75,7 @@ static int zfpm_dt_find_route(rib_dest_t **dest_p, struct route_entry **re_p)
 	struct route_entry *re;
 	int ret;
 
-	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, VRF_DEFAULT);
+	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, vrf_id_default);
 	if (!table)
 		return 0;
 

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -229,7 +229,7 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 	ri->af = rib_dest_af(dest);
 
 	ri->nlmsg_type = cmd;
-	ri->rtm_table = zvrf_id(rib_dest_vrf(dest));
+	ri->rtm_table = zvrf_id(rib_dest_vrf(dest)).lr.id;
 	ri->rtm_protocol = RTPROT_UNSPEC;
 
 	/*

--- a/zebra/zebra_fpm_protobuf.c
+++ b/zebra/zebra_fpm_protobuf.c
@@ -22,7 +22,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include <zebra.h>
-
 #include "log.h"
 #include "rib.h"
 #include "zserv.h"
@@ -52,7 +51,7 @@ static Fpm__DeleteRoute *create_delete_route_message(qpb_allocator_t *allocator,
 	}
 
 	fpm__delete_route__init(msg);
-	msg->vrf_id = zvrf_id(rib_dest_vrf(dest));
+	msg->vrf_id = zvrf_id(rib_dest_vrf(dest)).lr.id;
 
 	qpb_address_family_set(&msg->address_family, rib_dest_af(dest));
 
@@ -153,7 +152,7 @@ static Fpm__AddRoute *create_add_route_message(qpb_allocator_t *allocator,
 
 	fpm__add_route__init(msg);
 
-	msg->vrf_id = zvrf_id(rib_dest_vrf(dest));
+	msg->vrf_id = zvrf_id(rib_dest_vrf(dest)).lr.id;
 
 	qpb_address_family_set(&msg->address_family, rib_dest_af(dest));
 

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -457,7 +457,7 @@ static int fec_send(zebra_fec_t *fec, struct zserv *client)
 	s = client->obuf;
 	stream_reset(s);
 
-	zserv_create_header(s, ZEBRA_FEC_UPDATE, VRF_DEFAULT);
+	zserv_create_header(s, ZEBRA_FEC_UPDATE, vrf_id_default);
 
 	stream_putw(s, rn->p.family);
 	stream_put_prefix(s, &rn->p);
@@ -614,7 +614,7 @@ static int nhlfe_nexthop_active_ipv4(zebra_nhlfe_t *nhlfe,
 	struct route_entry *match;
 	struct nexthop *match_nh;
 
-	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, VRF_DEFAULT);
+	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, vrf_id_default);
 	if (!table)
 		return 0;
 
@@ -663,7 +663,7 @@ static int nhlfe_nexthop_active_ipv6(zebra_nhlfe_t *nhlfe,
 	struct route_node *rn;
 	struct route_entry *match;
 
-	table = zebra_vrf_table(AFI_IP6, SAFI_UNICAST, VRF_DEFAULT);
+	table = zebra_vrf_table(AFI_IP6, SAFI_UNICAST, vrf_id_default);
 	if (!table)
 		return 0;
 
@@ -728,7 +728,7 @@ static int nhlfe_nexthop_active(zebra_nhlfe_t *nhlfe)
 
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
 		if (IN6_IS_ADDR_LINKLOCAL(&nexthop->gate.ipv6)) {
-			ifp = if_lookup_by_index(nexthop->ifindex, VRF_DEFAULT);
+			ifp = if_lookup_by_index(nexthop->ifindex, vrf_id_default);
 			if (ifp && if_is_operative(ifp))
 				SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 			else
@@ -867,7 +867,7 @@ static wq_item_status lsp_process(struct work_queue *wq, void *data)
 	zebra_lsp_t *lsp;
 	zebra_nhlfe_t *oldbest, *newbest;
 	char buf[BUFSIZ], buf2[BUFSIZ];
-	struct zebra_vrf *zvrf = vrf_info_lookup(VRF_DEFAULT);
+	struct zebra_vrf *zvrf = vrf_info_lookup(vrf_id_default);
 
 	lsp = (zebra_lsp_t *)data;
 	if (!lsp) // unexpected
@@ -956,7 +956,7 @@ static void lsp_processq_del(struct work_queue *wq, void *data)
 	struct hash *lsp_table;
 	zebra_nhlfe_t *nhlfe, *nhlfe_next;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	assert(zvrf);
 
 	lsp_table = zvrf->lsp_table;
@@ -1326,7 +1326,7 @@ static json_object *nhlfe_json(zebra_nhlfe_t *nhlfe)
 		if (nexthop->ifindex)
 			json_object_string_add(
 				json_nhlfe, "interface",
-				ifindex2ifname(nexthop->ifindex, VRF_DEFAULT));
+				ifindex2ifname(nexthop->ifindex, vrf_id_default));
 		break;
 	default:
 		break;
@@ -1356,7 +1356,7 @@ static void nhlfe_print(zebra_nhlfe_t *nhlfe, struct vty *vty)
 		vty_out(vty, "  via %s", inet_ntoa(nexthop->gate.ipv4));
 		if (nexthop->ifindex)
 			vty_out(vty, " dev %s",
-				ifindex2ifname(nexthop->ifindex, VRF_DEFAULT));
+				ifindex2ifname(nexthop->ifindex, vrf_id_default));
 		break;
 	case NEXTHOP_TYPE_IPV6:
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
@@ -1364,7 +1364,7 @@ static void nhlfe_print(zebra_nhlfe_t *nhlfe, struct vty *vty)
 			inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf, BUFSIZ));
 		if (nexthop->ifindex)
 			vty_out(vty, " dev %s",
-				ifindex2ifname(nexthop->ifindex, VRF_DEFAULT));
+				ifindex2ifname(nexthop->ifindex, vrf_id_default));
 		break;
 	default:
 		break;
@@ -1626,7 +1626,7 @@ static char *snhlfe2str(zebra_snhlfe_t *snhlfe, char *buf, int size)
 		inet_ntop(AF_INET6, &snhlfe->gate.ipv6, buf, size);
 		if (snhlfe->ifindex)
 			strcat(buf,
-			       ifindex2ifname(snhlfe->ifindex, VRF_DEFAULT));
+			       ifindex2ifname(snhlfe->ifindex, vrf_id_default));
 		break;
 	default:
 		break;

--- a/zebra/zebra_mpls_vty.c
+++ b/zebra/zebra_mpls_vty.c
@@ -57,7 +57,7 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	if (!zvrf) {
 		vty_out(vty, "%% Default VRF does not exist\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -201,7 +201,7 @@ static int zebra_mpls_bind(struct vty *vty, int add_cmd, const char *prefix,
 	u_int32_t label;
 	int ret;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	if (!zvrf) {
 		vty_out(vty, "%% Default VRF does not exist\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -289,7 +289,7 @@ static int zebra_mpls_config(struct vty *vty)
 	int write = 0;
 	struct zebra_vrf *zvrf;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	if (!zvrf)
 		return 0;
 
@@ -312,7 +312,7 @@ DEFUN (show_mpls_fec,
 	struct prefix p;
 	int ret;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	if (!zvrf)
 		return 0;
 
@@ -342,7 +342,7 @@ DEFUN (show_mpls_table,
 	struct zebra_vrf *zvrf;
 	u_char uj = use_json(argc, argv);
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	zebra_mpls_print_lsp_table(vty, zvrf, uj);
 	return CMD_SUCCESS;
 }
@@ -360,7 +360,7 @@ DEFUN (show_mpls_table_lsp,
 	struct zebra_vrf *zvrf;
 	u_char uj = use_json(argc, argv);
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	label = atoi(argv[3]->arg);
 	zebra_mpls_print_lsp(vty, zvrf, label, uj);
 	return CMD_SUCCESS;
@@ -388,7 +388,7 @@ static int zebra_mpls_global_block(struct vty *vty, int add_cmd,
 	u_int32_t end_label;
 	struct zebra_vrf *zvrf;
 
-	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+	zvrf = zebra_vrf_lookup_by_id(vrf_id_default);
 	if (!zvrf) {
 		vty_out(vty, "%% Default VRF does not exist\n");
 		return CMD_WARNING_CONFIG_FAILED;

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -416,7 +416,7 @@ static void zebra_ptm_install_commands(void)
 /* BFD session goes down, send message to the protocols. */
 static void if_bfd_session_update(struct interface *ifp, struct prefix *dp,
 				  struct prefix *sp, int status,
-				  vrf_id_t vrf_id)
+				  lr_id_t vrf_id)
 {
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		char buf[2][INET6_ADDRSTRLEN];
@@ -432,13 +432,13 @@ static void if_bfd_session_update(struct interface *ifp, struct prefix *dp,
 		} else {
 			zlog_debug(
 				"MESSAGE: ZEBRA_INTERFACE_BFD_DEST_UPDATE %s/%d "
-				"with src %s/%d and vrf %d %s event",
+				"with src %s/%d and vrf %u %s event",
 				inet_ntop(dp->family, &dp->u.prefix, buf[0],
 					  INET6_ADDRSTRLEN),
 				dp->prefixlen,
 				inet_ntop(sp->family, &sp->u.prefix, buf[1],
 					  INET6_ADDRSTRLEN),
-				sp->prefixlen, vrf_id,
+				sp->prefixlen, vrf_id.lr.id,
 				bfd_get_status_str(status));
 		}
 	}
@@ -455,7 +455,7 @@ static int zebra_ptm_handle_bfd_msg(void *arg, void *in_ctxt,
 	char vrf_str[64];
 	struct prefix dest_prefix;
 	struct prefix src_prefix;
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 
 	ptm_lib_find_key_in_msg(in_ctxt, ZEBRA_PTM_BFDSTATUS_STR, bfdst_str);
 
@@ -769,7 +769,7 @@ int zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
 		ptm_lib_append_msg(ptm_hdl, out_ctxt,
 				   ZEBRA_PTM_BFD_MAX_HOP_CNT_FIELD, tmp_buf);
 
-		if (zvrf_id(zvrf) != VRF_DEFAULT)
+		if (zvrf_id(zvrf).lr.id != LR_DEFAULT)
 			ptm_lib_append_msg(ptm_hdl, out_ctxt,
 					   ZEBRA_PTM_BFD_VRF_NAME_FIELD,
 					   zvrf_name(zvrf));
@@ -902,7 +902,7 @@ int zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
 		ptm_lib_append_msg(ptm_hdl, out_ctxt,
 				   ZEBRA_PTM_BFD_SRC_IP_FIELD, buf);
 
-		if (zvrf_id(zvrf) != VRF_DEFAULT)
+		if (zvrf_id(zvrf).lr.id != LR_DEFAULT)
 			ptm_lib_append_msg(ptm_hdl, out_ctxt,
 					   ZEBRA_PTM_BFD_VRF_NAME_FIELD,
 					   zvrf_name(zvrf));

--- a/zebra/zebra_ptm_redistribute.c
+++ b/zebra/zebra_ptm_redistribute.c
@@ -29,7 +29,7 @@
 static int zsend_interface_bfd_update(int cmd, struct zserv *client,
 				      struct interface *ifp, struct prefix *dp,
 				      struct prefix *sp, int status,
-				      vrf_id_t vrf_id)
+				      lr_id_t vrf_id)
 {
 	int blen;
 	struct stream *s;
@@ -70,7 +70,7 @@ static int zsend_interface_bfd_update(int cmd, struct zserv *client,
 }
 
 void zebra_interface_bfd_update(struct interface *ifp, struct prefix *dp,
-				struct prefix *sp, int status, vrf_id_t vrf_id)
+				struct prefix *sp, int status, lr_id_t vrf_id)
 {
 	struct listnode *node, *nnode;
 	struct zserv *client;
@@ -97,7 +97,7 @@ static int zsend_bfd_peer_replay(int cmd, struct zserv *client)
 	stream_reset(s);
 
 	zserv_create_header(
-		s, cmd, VRF_DEFAULT); // Pending: adjust when multi-vrf bfd work
+		s, cmd, vrf_id_default); // Pending: adjust when multi-vrf bfd work
 
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));

--- a/zebra/zebra_ptm_redistribute.h
+++ b/zebra/zebra_ptm_redistribute.h
@@ -22,6 +22,6 @@
 #ifndef _ZEBRA_PTM_REDISTRIBUTE_H
 #define _ZEBRA_PTM_REDISTRIBUTE_H
 extern void zebra_interface_bfd_update(struct interface *, struct prefix *,
-				       struct prefix *, int, vrf_id_t);
+				       struct prefix *, int, lr_id_t);
 extern void zebra_bfd_peer_replay_req(void);
 #endif /* _ZEBRA_PTM_REDISTRIBUTE_H */

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -66,7 +66,7 @@ struct zebra_pw *zebra_pw_add(struct zebra_vrf *zvrf, const char *ifname,
 
 	if (IS_ZEBRA_DEBUG_PW)
 		zlog_debug("%u: adding pseudowire %s protocol %s",
-			   zvrf_id(zvrf), ifname, zebra_route_string(protocol));
+			   zvrf_id(zvrf).lr.id, ifname, zebra_route_string(protocol));
 
 	pw = XCALLOC(MTYPE_PW, sizeof(*pw));
 	strlcpy(pw->ifname, ifname, sizeof(pw->ifname));
@@ -90,7 +90,7 @@ struct zebra_pw *zebra_pw_add(struct zebra_vrf *zvrf, const char *ifname,
 void zebra_pw_del(struct zebra_vrf *zvrf, struct zebra_pw *pw)
 {
 	if (IS_ZEBRA_DEBUG_PW)
-		zlog_debug("%u: deleting pseudowire %s protocol %s", pw->vrf_id,
+		zlog_debug("%u: deleting pseudowire %s protocol %s", pw->vrf_id.lr.id,
 			   pw->ifname, zebra_route_string(pw->protocol));
 
 	/* remove nexthop tracking */
@@ -167,7 +167,7 @@ static void zebra_pw_install(struct zebra_pw *pw)
 {
 	if (IS_ZEBRA_DEBUG_PW)
 		zlog_debug("%u: installing pseudowire %s protocol %s",
-			   pw->vrf_id, pw->ifname,
+			   pw->vrf_id.lr.id, pw->ifname,
 			   zebra_route_string(pw->protocol));
 
 	if (hook_call(pw_install, pw)) {
@@ -186,7 +186,7 @@ static void zebra_pw_uninstall(struct zebra_pw *pw)
 
 	if (IS_ZEBRA_DEBUG_PW)
 		zlog_debug("%u: uninstalling pseudowire %s protocol %s",
-			   pw->vrf_id, pw->ifname,
+			   pw->vrf_id.lr.id, pw->ifname,
 			   zebra_route_string(pw->protocol));
 
 	/* ignore any possible error */
@@ -208,7 +208,7 @@ void zebra_pw_install_failure(struct zebra_pw *pw)
 		zlog_debug(
 			"%u: failed installing pseudowire %s, "
 			"scheduling retry in %u seconds",
-			pw->vrf_id, pw->ifname, PW_INSTALL_RETRY_INTERVAL);
+			pw->vrf_id.lr.id, pw->ifname, PW_INSTALL_RETRY_INTERVAL);
 
 	/* schedule to retry later */
 	THREAD_TIMER_OFF(pw->install_retry_timer);
@@ -310,7 +310,7 @@ DEFUN_NOSH (pseudowire_if,
 	int idx = 0;
 	const char *ifname;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	if (!zvrf)
 		return CMD_WARNING;
 
@@ -441,7 +441,7 @@ DEFUN (show_pseudowires,
 	struct zebra_vrf *zvrf;
 	struct zebra_pw *pw;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	if (!zvrf)
 		return 0;
 
@@ -479,7 +479,7 @@ static int zebra_pw_config(struct vty *vty)
 	struct zebra_vrf *zvrf;
 	struct zebra_pw *pw;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	if (!zvrf)
 		return 0;
 

--- a/zebra/zebra_pw.h
+++ b/zebra/zebra_pw.h
@@ -30,7 +30,7 @@
 
 struct zebra_pw {
 	RB_ENTRY(zebra_pw) pw_entry, static_pw_entry;
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 	char ifname[IF_NAMESIZE];
 	ifindex_t ifindex;
 	int type;

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -34,7 +34,7 @@ struct rnh {
 #define ZEBRA_NHT_EXACT_MATCH   0x4
 
 	/* VRF identifier. */
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 
 	struct route_entry *state;
 	struct prefix resolved_route;
@@ -54,30 +54,30 @@ typedef enum { RNH_NEXTHOP_TYPE, RNH_IMPORT_CHECK_TYPE } rnh_type_t;
 extern int zebra_rnh_ip_default_route;
 extern int zebra_rnh_ipv6_default_route;
 
-extern struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid,
+extern struct rnh *zebra_add_rnh(struct prefix *p, lr_id_t vrfid,
 				 rnh_type_t type);
-extern struct rnh *zebra_lookup_rnh(struct prefix *p, vrf_id_t vrfid,
+extern struct rnh *zebra_lookup_rnh(struct prefix *p, lr_id_t vrfid,
 				    rnh_type_t type);
 extern void zebra_free_rnh(struct rnh *rnh);
 extern void zebra_delete_rnh(struct rnh *rnh, rnh_type_t type);
 extern void zebra_add_rnh_client(struct rnh *rnh, struct zserv *client,
-				 rnh_type_t type, vrf_id_t vrfid);
-extern void zebra_register_rnh_static_nh(vrf_id_t, struct prefix *,
+				 rnh_type_t type, lr_id_t vrfid);
+extern void zebra_register_rnh_static_nh(lr_id_t, struct prefix *,
 					 struct route_node *);
-extern void zebra_deregister_rnh_static_nexthops(vrf_id_t,
+extern void zebra_deregister_rnh_static_nexthops(lr_id_t,
 						 struct nexthop *nexthop,
 						 struct route_node *rn);
-extern void zebra_deregister_rnh_static_nh(vrf_id_t, struct prefix *,
+extern void zebra_deregister_rnh_static_nh(lr_id_t, struct prefix *,
 					   struct route_node *);
-extern void zebra_register_rnh_pseudowire(vrf_id_t, struct zebra_pw *);
-extern void zebra_deregister_rnh_pseudowire(vrf_id_t, struct zebra_pw *);
+extern void zebra_register_rnh_pseudowire(lr_id_t, struct zebra_pw *);
+extern void zebra_deregister_rnh_pseudowire(lr_id_t, struct zebra_pw *);
 extern void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client,
 				    rnh_type_t type);
-extern void zebra_evaluate_rnh(vrf_id_t vrfid, int family, int force,
+extern void zebra_evaluate_rnh(lr_id_t vrfid, int family, int force,
 			       rnh_type_t type, struct prefix *p);
-extern void zebra_print_rnh_table(vrf_id_t vrfid, int family, struct vty *vty,
+extern void zebra_print_rnh_table(lr_id_t vrfid, int family, struct vty *vty,
 				  rnh_type_t);
 extern char *rnh_str(struct rnh *rnh, char *buf, int size);
-extern int zebra_cleanup_rnh_client(vrf_id_t vrf, int family,
+extern int zebra_cleanup_rnh_client(lr_id_t vrf, int family,
 				    struct zserv *client, rnh_type_t type);
 #endif /*_ZEBRA_RNH_H */

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -32,12 +32,12 @@ extern void zebra_route_map_write_delay_timer(struct vty *);
 
 extern route_map_result_t
 zebra_import_table_route_map_check(int family, int rib_type, struct prefix *p,
-				   struct nexthop *nexthop, vrf_id_t vrf_id,
+				   struct nexthop *nexthop, lr_id_t vrf_id,
 				   route_tag_t tag, const char *rmap_name);
 extern route_map_result_t zebra_route_map_check(int family, int rib_type,
 						struct prefix *p,
 						struct nexthop *nexthop,
-						vrf_id_t vrf_id,
+						lr_id_t vrf_id,
 						route_tag_t tag);
 extern route_map_result_t
 zebra_nht_route_map_check(int family, int client_proto, struct prefix *p,

--- a/zebra/zebra_snmp.c
+++ b/zebra/zebra_snmp.c
@@ -148,7 +148,7 @@ static u_char *ipFwNumber(struct variable *v, oid objid[], size_t *objid_len,
 	    == MATCH_FAILED)
 		return NULL;
 
-	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, VRF_DEFAULT);
+	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, vrf_id_default);
 	if (!table)
 		return NULL;
 
@@ -176,7 +176,7 @@ static u_char *ipCidrNumber(struct variable *v, oid objid[], size_t *objid_len,
 	    == MATCH_FAILED)
 		return NULL;
 
-	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, VRF_DEFAULT);
+	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, vrf_id_default);
 	if (!table)
 		return 0;
 
@@ -333,7 +333,7 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 	if (exact && (*objid_len != (unsigned)v->namelen + 10))
 		return;
 
-	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, VRF_DEFAULT);
+	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, vrf_id_default);
 	if (!table)
 		return;
 

--- a/zebra/zebra_static.c
+++ b/zebra/zebra_static.c
@@ -131,7 +131,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 					  INET6_ADDRSTRLEN);
 				zlog_debug(
 					"%u:%s/%d: Modifying route rn %p, re %p (type %d)",
-					si->vrf_id, buf, p->prefixlen, rn, re,
+					si->vrf_id.lr.id, buf, p->prefixlen, rn, re,
 					re->type);
 			}
 		}
@@ -156,7 +156,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 		re->mtu = 0;
 		re->vrf_id = si->vrf_id;
 		re->table =
-			si->vrf_id
+			si->vrf_id.lr.id
 				? (zebra_vrf_lookup_by_id(si->vrf_id))->table_id
 				: zebrad.rtm_table_default;
 		re->nexthop_num = 0;
@@ -209,7 +209,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 					  INET6_ADDRSTRLEN);
 				zlog_debug(
 					"%u:%s/%d: Inserting route rn %p, re %p (type %d)",
-					si->vrf_id, buf, p->prefixlen, rn, re,
+					si->vrf_id.lr.id, buf, p->prefixlen, rn, re,
 					re->type);
 			}
 		}
@@ -325,7 +325,7 @@ void static_uninstall_route(afi_t afi, safi_t safi, struct prefix *p,
 					  INET6_ADDRSTRLEN);
 				zlog_debug(
 					"%u:%s/%d: Modifying route rn %p, re %p (type %d)",
-					si->vrf_id, buf, p->prefixlen, rn, re,
+					si->vrf_id.lr.id, buf, p->prefixlen, rn, re,
 					re->type);
 			}
 		}

--- a/zebra/zebra_static.h
+++ b/zebra/zebra_static.h
@@ -53,7 +53,7 @@ struct static_route {
 	struct static_route *next;
 
 	/* VRF identifier. */
-	vrf_id_t vrf_id;
+	lr_id_t vrf_id;
 
 	/* Administrative distance. */
 	u_char distance;

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -122,7 +122,7 @@ struct zebra_vrf {
 	uint64_t lsp_removals;
 };
 
-static inline vrf_id_t zvrf_id(struct zebra_vrf *zvrf)
+static inline lr_id_t zvrf_id(struct zebra_vrf *zvrf)
 {
 	return zvrf->vrf->vrf_id;
 }
@@ -133,17 +133,17 @@ static inline const char *zvrf_name(struct zebra_vrf *zvrf)
 }
 
 struct route_table *zebra_vrf_table_with_table_id(afi_t afi, safi_t safi,
-						  vrf_id_t vrf_id,
+						  lr_id_t vrf_id,
 						  u_int32_t table_id);
 
 extern void zebra_vrf_update_all(struct zserv *client);
-extern struct zebra_vrf *zebra_vrf_lookup_by_id(vrf_id_t vrf_id);
+extern struct zebra_vrf *zebra_vrf_lookup_by_id(lr_id_t vrf_id);
 extern struct zebra_vrf *zebra_vrf_lookup_by_name(const char *);
 extern struct zebra_vrf *zebra_vrf_alloc(void);
-extern struct route_table *zebra_vrf_table(afi_t, safi_t, vrf_id_t);
+extern struct route_table *zebra_vrf_table(afi_t, safi_t, lr_id_t);
 extern struct route_table *zebra_vrf_static_table(afi_t, safi_t,
 						  struct zebra_vrf *zvrf);
 extern struct route_table *
-zebra_vrf_other_route_table(afi_t afi, u_int32_t table_id, vrf_id_t vrf_id);
+zebra_vrf_other_route_table(afi_t afi, u_int32_t table_id, lr_id_t vrf_id);
 extern void zebra_vrf_init(void);
 #endif

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -177,7 +177,7 @@ static int advertise_gw_macip_enabled(zebra_vni_t *zvni)
 {
 	struct zebra_vrf *zvrf;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	if (zvrf && zvrf->advertise_gw_macip)
 		return 1;
 
@@ -767,7 +767,7 @@ static int zvni_macip_send_msg_to_client(vni_t vni,
 	s = client->obuf;
 	stream_reset(s);
 
-	zserv_create_header(s, cmd, VRF_DEFAULT);
+	zserv_create_header(s, cmd, vrf_id_default);
 	stream_putl(s, vni);
 	stream_put(s, macaddr->octet, ETH_ALEN);
 	if (ip) {
@@ -2049,7 +2049,7 @@ static zebra_vni_t *zvni_lookup(vni_t vni)
 	zebra_vni_t tmp_vni;
 	zebra_vni_t *zvni = NULL;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	assert(zvrf);
 	memset(&tmp_vni, 0, sizeof(zebra_vni_t));
 	tmp_vni.vni = vni;
@@ -2067,7 +2067,7 @@ static zebra_vni_t *zvni_add(vni_t vni)
 	zebra_vni_t tmp_zvni;
 	zebra_vni_t *zvni = NULL;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	assert(zvrf);
 	memset(&tmp_zvni, 0, sizeof(zebra_vni_t));
 	tmp_zvni.vni = vni;
@@ -2093,7 +2093,7 @@ static int zvni_del(zebra_vni_t *zvni)
 	struct zebra_vrf *zvrf;
 	zebra_vni_t *tmp_zvni;
 
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zvrf = vrf_info_lookup(vrf_id_default);
 	assert(zvrf);
 
 	zvni->vxlan_if = NULL;
@@ -2130,7 +2130,7 @@ static int zvni_send_add_to_client(zebra_vni_t *zvni)
 	s = client->obuf;
 	stream_reset(s);
 
-	zserv_create_header(s, ZEBRA_VNI_ADD, VRF_DEFAULT);
+	zserv_create_header(s, ZEBRA_VNI_ADD, vrf_id_default);
 	stream_putl(s, zvni->vni);
 	stream_put_in_addr(s, &zvni->local_vtep_ip);
 
@@ -2162,7 +2162,7 @@ static int zvni_send_del_to_client(vni_t vni)
 	s = client->obuf;
 	stream_reset(s);
 
-	zserv_create_header(s, ZEBRA_VNI_DEL, VRF_DEFAULT);
+	zserv_create_header(s, ZEBRA_VNI_DEL, vrf_id_default);
 	stream_putl(s, vni);
 
 	/* Write packet size. */
@@ -3695,9 +3695,9 @@ int zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
 		return -1;
 	}
 
-	if (zvrf_id(zvrf) != VRF_DEFAULT) {
+	if (zvrf_id(zvrf).lr.id != LR_DEFAULT) {
 		zlog_err("Recv MACIP DEL for non-default VRF %u",
-			 zvrf_id(zvrf));
+			 zvrf_id(zvrf).lr.id);
 		return -1;
 	}
 
@@ -3779,9 +3779,9 @@ int zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
 		return -1;
 	}
 
-	if (zvrf_id(zvrf) != VRF_DEFAULT) {
+	if (zvrf_id(zvrf).lr.id != LR_DEFAULT) {
 		zlog_err("Recv MACIP ADD for non-default VRF %u",
-			 zvrf_id(zvrf));
+			 zvrf_id(zvrf).lr.id);
 		return -1;
 	}
 
@@ -4307,9 +4307,9 @@ int zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
 	zebra_vni_t *zvni = NULL;
 	struct interface *ifp = NULL;
 
-	if (zvrf_id(zvrf) != VRF_DEFAULT) {
+	if (zvrf_id(zvrf).lr.id != LR_DEFAULT) {
 		zlog_err("EVPN GW-MACIP Adv for non-default VRF %u",
-			 zvrf_id(zvrf));
+			 zvrf_id(zvrf).lr.id);
 		return -1;
 	}
 
@@ -4413,9 +4413,9 @@ int zebra_vxlan_advertise_all_vni(struct zserv *client,
 	struct stream *s;
 	int advertise;
 
-	if (zvrf_id(zvrf) != VRF_DEFAULT) {
+	if (zvrf_id(zvrf).lr.id != LR_DEFAULT) {
 		zlog_err("EVPN VNI Adv for non-default VRF %u",
-			 zvrf_id(zvrf));
+			 zvrf_id(zvrf).lr.id);
 		return -1;
 	}
 

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -39,7 +39,8 @@ static inline int
 is_evpn_enabled()
 {
 	struct zebra_vrf *zvrf = NULL;
-	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+	lr_id_t vrf_id_def = { .lr.id = LR_DEFAULT};
+	zvrf = zebra_vrf_lookup_by_id(vrf_id_def);
 	return zvrf ? zvrf->advertise_all_vni : 0;
 }
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -178,21 +178,21 @@ extern void nbr_connected_delete_ipv6(struct interface *, struct in6_addr *);
 extern int zsend_interface_update(int, struct zserv *, struct interface *);
 extern int zsend_redistribute_route(int, struct zserv *, struct prefix *,
 				    struct prefix *, struct route_entry *);
-extern int zsend_router_id_update(struct zserv *, struct prefix *, vrf_id_t);
+extern int zsend_router_id_update(struct zserv *, struct prefix *, lr_id_t);
 extern int zsend_interface_vrf_update(struct zserv *, struct interface *,
-				      vrf_id_t);
+				      lr_id_t);
 
 extern int zsend_interface_link_params(struct zserv *, struct interface *);
 extern int zsend_pw_update(struct zserv *, struct zebra_pw *);
 
 extern int zsend_route_notify_owner(u_char proto, u_short instance,
-				    vrf_id_t vrf_id, struct prefix *p,
+				    lr_id_t vrf_id, struct prefix *p,
 				    enum zapi_route_notify_owner note);
 
 extern pid_t pid;
 
 extern void zserv_create_header(struct stream *s, uint16_t cmd,
-				vrf_id_t vrf_id);
+				lr_id_t vrf_id);
 extern void zserv_nexthop_num_warn(const char *, const struct prefix *,
 				   const unsigned int);
 extern int zebra_server_send_message(struct zserv *client);


### PR DESCRIPTION
This is a preparatory work for configuring vrf/frr over netns
vrf structure is being associated a logical router id instead of a vrf_id.
this logical router id is a 32 bit integer that is made up of two parts:
- first part is the original vrf_id
the vrf_id is the representation of the vrf lite.
- second part is the network namespace identifier: the ns_id.

This work is provisioning only. that means that for now, ns_id valus is set to 0.
But this change will allow to combine both values:
- continue to map frr vrf over vrf lite from kernel
- make possible to map frr vrf over netns
- make possible to have nested vrf lite under netns.

This makes possible to have from a single set of daemons located in a single 
namespace to manager several VRFs either based on VRF lite or base on Namespaces.
