### PR TITLE
redhat: watchfrr is built by default, enable it to start at run time

### DIFF
--- a/redhat/daemons
+++ b/redhat/daemons
@@ -34,7 +34,7 @@
 # When using "vtysh" such a config file is also needed. It should be owned by
 # group "frrvty" and set to ug=rw,o= though. Check /etc/pam.d/frr, too.
 #
-watchfrr_enable=no
+watchfrr_enable=yes
 watchfrr_options=("-Az" "-b_" "-r/usr/lib/frr/frr_restart_%s" "-s/usr/lib/frr/frr_start_%s" "-k/usr/lib/frr/frr_stop_%s")
 #
 zebra=no


### PR DESCRIPTION
watchfrr has become a first class citizen of the FRR system.

Currently it's used to ensure that running daemons stay up and running
as well as to facilitate frr.conf being written.  In the future it is
going to be used to auto-start stop.  As such let's start getting
people to use it now.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>