### PR TITLE
ospfd: Set filter to unbound debug logs

### DIFF
--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -679,8 +679,9 @@ static int ospf_ase_calculate_timer(struct thread *t)
 
 		monotime(&stop_time);
 
-		zlog_info("SPF Processing Time(usecs): External Routes: %lld\n",
-			  (stop_time.tv_sec - start_time.tv_sec) * 1000000LL
+		if (IS_DEBUG_OSPF_EVENT)
+			zlog_info("SPF Processing Time(usecs): External Routes: %lld\n",
+				  (stop_time.tv_sec - start_time.tv_sec) * 1000000LL
 				  + (stop_time.tv_usec - start_time.tv_usec));
 	}
 	return 0;

--- a/ospfd/ospf_network.c
+++ b/ospfd/ospf_network.c
@@ -38,7 +38,7 @@
 #include "ospfd/ospf_lsdb.h"
 #include "ospfd/ospf_neighbor.h"
 #include "ospfd/ospf_packet.h"
-
+#include "ospfd/ospf_dump.h"
 
 /* Join to the OSPF ALL SPF ROUTERS multicast group. */
 int ospf_if_add_allspfrouters(struct ospf *top, struct prefix *p,
@@ -56,10 +56,11 @@ int ospf_if_add_allspfrouters(struct ospf *top, struct prefix *p,
 			"on # of multicast group memberships has been exceeded?",
 			top->fd, inet_ntoa(p->u.prefix4), ifindex,
 			safe_strerror(errno));
-	else
-		zlog_debug(
-			"interface %s [%u] join AllSPFRouters Multicast group.",
-			inet_ntoa(p->u.prefix4), ifindex);
+	else {
+		if (IS_DEBUG_OSPF_EVENT)
+			zlog_debug("interface %s [%u] join AllSPFRouters Multicast group.",
+				   inet_ntoa(p->u.prefix4), ifindex);
+	}
 
 	return ret;
 }
@@ -78,10 +79,11 @@ int ospf_if_drop_allspfrouters(struct ospf *top, struct prefix *p,
 			"ifindex %u, AllSPFRouters): %s",
 			top->fd, inet_ntoa(p->u.prefix4), ifindex,
 			safe_strerror(errno));
-	else
-		zlog_debug(
-			"interface %s [%u] leave AllSPFRouters Multicast group.",
-			inet_ntoa(p->u.prefix4), ifindex);
+	else {
+		if (IS_DEBUG_OSPF_EVENT)
+			zlog_debug("interface %s [%u] leave AllSPFRouters Multicast group.",
+				   inet_ntoa(p->u.prefix4), ifindex);
+	}
 
 	return ret;
 }

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -702,12 +702,12 @@ static void nsm_change_state(struct ospf_neighbor *nbr, int state)
 							oi->ospf);
 		}
 
-		zlog_info(
-			"nsm_change_state(%s, %s -> %s): "
-			"scheduling new router-LSA origination",
-			inet_ntoa(nbr->router_id),
-			lookup_msg(ospf_nsm_state_msg, old_state, NULL),
-			lookup_msg(ospf_nsm_state_msg, state, NULL));
+		if (CHECK_FLAG(oi->ospf->config, OSPF_LOG_ADJACENCY_DETAIL))
+			zlog_info("%s:(%s, %s -> %s): "
+				"scheduling new router-LSA origination",
+				__PRETTY_FUNCTION__, inet_ntoa(nbr->router_id),
+				lookup_msg(ospf_nsm_state_msg, old_state, NULL),
+				lookup_msg(ospf_nsm_state_msg, state, NULL));
 
 		ospf_router_lsa_update_area(oi->area);
 

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1363,9 +1363,11 @@ static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 			if (IPV4_ADDR_CMP(&nbr->router_id, &oi->ospf->router_id)
 			    > 0) {
 				/* We're Slave---obey */
-				zlog_info(
-					"Packet[DD]: Neighbor %s Negotiation done (Slave).",
-					inet_ntoa(nbr->router_id));
+				if (CHECK_FLAG(oi->ospf->config,
+					       OSPF_LOG_ADJACENCY_DETAIL))
+					zlog_info("Packet[DD]: Neighbor %s Negotiation done (Slave).",
+						  inet_ntoa(nbr->router_id));
+
 				nbr->dd_seqnum = ntohl(dd->dd_seqnum);
 
 				/* Reset I/MS */
@@ -1374,10 +1376,12 @@ static void ospf_db_desc(struct ip *iph, struct ospf_header *ospfh,
 			} else {
 				/* We're Master, ignore the initial DBD from
 				 * Slave */
-				zlog_info(
-					"Packet[DD]: Neighbor %s: Initial DBD from Slave, "
-					"ignoring.",
-					inet_ntoa(nbr->router_id));
+				if (CHECK_FLAG(oi->ospf->config,
+					       OSPF_LOG_ADJACENCY_DETAIL))
+					zlog_info(
+						"Packet[DD]: Neighbor %s: Initial DBD from Slave, "
+						"ignoring.",
+						inet_ntoa(nbr->router_id));
 				break;
 			}
 		}

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -2589,8 +2589,9 @@ static void ospfTrapNbrStateChange(struct ospf_neighbor *on)
 	char msgbuf[16];
 
 	ospf_nbr_state_message(on, msgbuf, sizeof(msgbuf));
-	zlog_info("ospfTrapNbrStateChange trap sent: %s now %s",
-		  inet_ntoa(on->address.u.prefix4), msgbuf);
+	if (IS_DEBUG_OSPF_EVENT)
+		zlog_info("%s: trap sent: %s now %s", __PRETTY_FUNCTION__,
+			  inet_ntoa(on->address.u.prefix4), msgbuf);
 
 	oid_copy_addr(index, &(on->address.u.prefix4), IN_ADDR_SIZE);
 	index[IN_ADDR_SIZE] = 0;
@@ -2646,9 +2647,10 @@ static void ospfTrapIfStateChange(struct ospf_interface *oi)
 {
 	oid index[sizeof(oid) * (IN_ADDR_SIZE + 1)];
 
-	zlog_info("ospfTrapIfStateChange trap sent: %s now %s",
-		  inet_ntoa(oi->address->u.prefix4),
-		  lookup_msg(ospf_ism_state_msg, oi->state, NULL));
+	if (IS_DEBUG_OSPF_EVENT)
+		zlog_info("%s: trap sent: %s now %s", __PRETTY_FUNCTION__,
+			  inet_ntoa(oi->address->u.prefix4),
+			  lookup_msg(ospf_ism_state_msg, oi->state, NULL));
 
 	oid_copy_addr(index, &(oi->address->u.prefix4), IN_ADDR_SIZE);
 	index[IN_ADDR_SIZE] = 0;

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1463,9 +1463,7 @@ void ospf_spf_calculate_schedule(struct ospf *ospf, ospf_spf_reason_t reason)
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("SPF: calculation timer delay = %ld", delay);
-
-	zlog_info("SPF: Scheduled in %ld msec", delay);
+		zlog_debug("SPF: calculation timer delay = %ld msec", delay);
 
 	ospf->t_spf_calc = NULL;
 	thread_add_timer_msec(master, ospf_spf_calculate_timer, ospf, delay,


### PR DESCRIPTION
Some of the OSPF debugs were not set with filter. Critical logs set under neighbor adjacency logs enabled via configuration. 

Ticket:CM-19213

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>