### PR TITLE
ospf6d: Fix ospf6 redist with route-map

### DIFF
--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -369,10 +369,21 @@ static void ospf6_asbr_routemap_update(const char *mapname)
 		return;
 
 	for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
-		if (ospf6->rmap[type].name)
+		if (ospf6->rmap[type].name) {
 			ospf6->rmap[type].map = route_map_lookup_by_name(
 				ospf6->rmap[type].name);
-		else
+
+			if (mapname && ospf6->rmap[type].map &&
+			    (strcmp(ospf6->rmap[type].name, mapname) == 0)) {
+				if (IS_OSPF6_DEBUG_ASBR)
+					zlog_debug("%s: route-map %s update, reset redist %s",
+						   __PRETTY_FUNCTION__, mapname,
+						   ZROUTE_NAME(type));
+
+				ospf6_zebra_no_redistribute(type);
+				ospf6_zebra_redistribute(type);
+			}
+		} else
 			ospf6->rmap[type].map = NULL;
 	}
 }


### PR DESCRIPTION
When ospf6 configure with redistribute connected/protocol with route-map. 
Upon restart of frr.service, ospf6 receives redistribute update then route-map update.
During redistribute route update, since route-map info is not filled,
route is suppressed from injected as external route.

Fix: reset redistribute when route-map update received 
matches with redistribution (type) and route-map name.

Ticket:CM-13800
Testing Done:
Configure ospf6 redistribute with route-map to inject
Type-2 external routes into database. Trigger frr restart
redistribute with route-map happens.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>