### PR TITLE
zebra: Fix dest dereference

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1471,7 +1471,14 @@ static void rib_process(struct route_node *rn)
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 		zlog_debug("%u:%s: Processing rn %p", vrf_id, buf, rn);
 
-	old_fib = dest->selected_fib;
+	/*
+	 * we can have rn's that have a NULL info pointer
+	 * (dest).  As such let's not let the deref happen
+	 * additionally we know RNODE_FOREACH_RE_SAFE
+	 * will not iterate so we are ok.
+	 */
+	if (dest)
+		old_fib = dest->selected_fib;
 
 	RNODE_FOREACH_RE_SAFE (rn, re, next) {
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)


### PR DESCRIPTION
The rn can not have an rn->info pointer and as
such the dest may be NULL.  Don't assign
the old_fib pointer if so.  This is ok
because we know RNODE_FOREACH... will not
iterate if dest is NULL.

Fixes: #1575
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>