### PR TITLE
bgpd: Fix peer uptime display in milliseconds

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8288,17 +8288,13 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, u_char use_json,
 
 		if (p->status == Established) {
 			time_t uptime;
-			struct tm *tm;
 
 			uptime = bgp_clock();
 			uptime -= p->uptime;
-			tm = gmtime(&uptime);
 			epoch_tbuf = time(NULL) - uptime;
 
 			json_object_int_add(json_neigh, "bgpTimerUp",
-					    (tm->tm_sec * 1000)
-						    + (tm->tm_min * 60000)
-						    + (tm->tm_hour * 3600000));
+					    uptime * 1000);
 			json_object_string_add(json_neigh, "bgpTimerUpString",
 					       peer_uptime(p->uptime, timebuf,
 							   BGP_UPTIME_LEN, 0,

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8293,7 +8293,23 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, u_char use_json,
 			uptime -= p->uptime;
 			epoch_tbuf = time(NULL) - uptime;
 
+#if CONFDATE > 20200101
+			CPP_NOTICE("bgpTimerUp should be deprecated and can be removed now");
+#endif
+			/*
+			 * bgpTimerUp was miliseconds that was accurate
+			 * up to 1 day, then the value returned
+			 * became garbage.  So in order to provide
+			 * some level of backwards compatability,
+			 * we still provde the data, but now
+			 * we are returning the correct value
+			 * and also adding a new bgpTimerUpMsec
+			 * which will allow us to deprecate
+			 * this eventually
+			 */
 			json_object_int_add(json_neigh, "bgpTimerUp",
+					    uptime * 1000);
+			json_object_int_add(json_neigh, "bgpTimerUpMsec",
 					    uptime * 1000);
 			json_object_string_add(json_neigh, "bgpTimerUpString",
 					       peer_uptime(p->uptime, timebuf,


### PR DESCRIPTION
For some reason bgp is calculating the peer uptime
in miliseconds incorrectly.  Additionally we have
the peer_uptime function call that should be doing this!
But since we've choosen different names for the json output
we cannot fix it at this point.

uptime contains the number of seconds of uptime here.  Just
multiply by 1k and display that( as peer_uptime does )

Fixes: #1585
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>