### PR TITLE
Netns Support / passing vrf_id_t to 32 bit work

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -302,13 +302,13 @@ static int bgp_bfd_dest_update(int command, struct zclient *zclient,
 		prefix2str(&dp, buf[0], sizeof(buf[0]));
 		if (ifp) {
 			zlog_debug(
-				"Zebra: vrf %d interface %s bfd destination %s %s",
+				"Zebra: vrf %u interface %s bfd destination %s %s",
 				vrf_id, ifp->name, buf[0],
 				bfd_get_status_str(status));
 		} else {
 			prefix2str(&sp, buf[1], sizeof(buf[1]));
 			zlog_debug(
-				"Zebra: vrf %d source %s bfd destination %s %s",
+				"Zebra: vrf %u source %s bfd destination %s %s",
 				vrf_id, buf[1], buf[0],
 				bfd_get_status_str(status));
 		}

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -232,7 +232,7 @@ static __attribute__((__noreturn__)) void bgp_exit(int status)
 static int bgp_vrf_new(struct vrf *vrf)
 {
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("VRF Created: %s(%d)", vrf->name, vrf->vrf_id);
+		zlog_debug("VRF Created: %s(%u)", vrf->name, vrf->vrf_id);
 
 	return 0;
 }
@@ -240,7 +240,7 @@ static int bgp_vrf_new(struct vrf *vrf)
 static int bgp_vrf_delete(struct vrf *vrf)
 {
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("VRF Deletion: %s(%d)", vrf->name, vrf->vrf_id);
+		zlog_debug("VRF Deletion: %s(%u)", vrf->name, vrf->vrf_id);
 
 	return 0;
 }
@@ -251,7 +251,7 @@ static int bgp_vrf_enable(struct vrf *vrf)
 	vrf_id_t old_vrf_id;
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("VRF enable add %s id %d", vrf->name, vrf->vrf_id);
+		zlog_debug("VRF enable add %s id %u", vrf->name, vrf->vrf_id);
 
 	bgp = bgp_lookup_by_name(vrf->name);
 	if (bgp) {

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -336,7 +336,7 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 	bgp = bgp_lookup_by_vrf_id(vrf_id);
 	if (!bgp) {
 		zlog_err(
-			"parse nexthop update: instance not found for vrf_id %d",
+			"parse nexthop update: instance not found for vrf_id %u",
 			vrf_id);
 		return;
 	}
@@ -389,7 +389,7 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 		char buf[PREFIX2STR_BUFFER];
 		prefix2str(&p, buf, sizeof(buf));
 		zlog_debug(
-			"%d: Rcvd NH update %s - metric %d/%d #nhops %d/%d flags 0x%x",
+			"%u: Rcvd NH update %s - metric %d/%d #nhops %d/%d flags 0x%x",
 			vrf_id, buf, metric, bnc->metric, nexthop_num,
 			bnc->nexthop_num, bnc->flags);
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7859,7 +7859,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 		vty_out(vty,
 			"{\n \"vrfId\": %d,\n \"vrfName\": \"%s\",\n \"tableVersion\": %" PRId64
 			",\n \"routerId\": \"%s\",\n \"routes\": { ",
-			bgp->vrf_id == VRF_UNKNOWN ? -1 : bgp->vrf_id,
+			bgp->vrf_id == VRF_UNKNOWN ? -1 : (int)bgp->vrf_id,
 			bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT ? "Default"
 								    : bgp->name,
 			table->version, inet_ntoa(bgp->router_id));

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -913,7 +913,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	 *  aspath: points to interned hash from aspath hash table
 	 */
 
-	red = bgp_redist_lookup(bgp, afi, type, VRF_DEFAULT);
+	red = bgp_redist_lookup(bgp, afi, type, 0);
 
 	if (red && red->redist_metric_flag) {
 		attr.med = red->redist_metric;

--- a/lib/ns.h
+++ b/lib/ns.h
@@ -25,10 +25,11 @@
 #include "openbsd-tree.h"
 #include "linklist.h"
 
-typedef u_int16_t ns_id_t;
+typedef u_int32_t ns_id_t;
 
-/* The default NS ID */
+/* the default NS ID */
 #define NS_DEFAULT 0
+#define NS_UNKNOWN UINT32_MAX
 
 /* Default netns directory (Linux) */
 #define NS_RUN_DIR         "/var/run/netns"

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -267,7 +267,7 @@ void *vrf_info_lookup(vrf_id_t vrf_id)
  * VRF bit-map
  */
 
-#define VRF_BITMAP_NUM_OF_GROUPS            8
+#define VRF_BITMAP_NUM_OF_GROUPS            1024
 #define VRF_BITMAP_NUM_OF_BITS_IN_GROUP (UINT32_MAX / VRF_BITMAP_NUM_OF_GROUPS)
 #define VRF_BITMAP_NUM_OF_BYTES_IN_GROUP                                       \
 	(VRF_BITMAP_NUM_OF_BITS_IN_GROUP / CHAR_BIT + 1) /* +1 for ensure */

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -94,7 +94,7 @@ struct vrf *vrf_get(vrf_id_t vrf_id, const char *name)
 	int new = 0;
 
 	if (debug_vrf)
-		zlog_debug("VRF_GET: %s(%d)", name, vrf_id);
+		zlog_debug("VRF_GET: %s(%u)", name, vrf_id);
 
 	/* Nothing to see, move along here */
 	if (!name && vrf_id == VRF_UNKNOWN)
@@ -268,7 +268,7 @@ void *vrf_info_lookup(vrf_id_t vrf_id)
  */
 
 #define VRF_BITMAP_NUM_OF_GROUPS            8
-#define VRF_BITMAP_NUM_OF_BITS_IN_GROUP (UINT16_MAX / VRF_BITMAP_NUM_OF_GROUPS)
+#define VRF_BITMAP_NUM_OF_BITS_IN_GROUP (UINT32_MAX / VRF_BITMAP_NUM_OF_GROUPS)
 #define VRF_BITMAP_NUM_OF_BYTES_IN_GROUP                                       \
 	(VRF_BITMAP_NUM_OF_BITS_IN_GROUP / CHAR_BIT + 1) /* +1 for ensure */
 
@@ -355,7 +355,7 @@ static void vrf_autocomplete(vector comps, struct cmd_token *token)
 	struct vrf *vrf = NULL;
 
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		if (vrf->vrf_id != 0)
+		if (vrf->vrf_id != VRF_DEFAULT)
 			vector_set(comps, XSTRDUP(MTYPE_COMPLETION, vrf->name));
 	}
 }

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -32,8 +32,7 @@
 
 /* The default VRF ID */
 #define VRF_DEFAULT 0
-#define VRF_UNKNOWN UINT16_MAX
-#define VRF_ALL UINT16_MAX - 1
+#define VRF_UNKNOWN UINT32_MAX
 
 /* Pending: May need to refine this. */
 #ifndef IFLA_VRF_MAX

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -291,7 +291,7 @@ void zclient_create_header(struct stream *s, uint16_t command, vrf_id_t vrf_id)
 	stream_putw(s, ZEBRA_HEADER_SIZE);
 	stream_putc(s, ZEBRA_HEADER_MARKER);
 	stream_putc(s, ZSERV_VERSION);
-	stream_putw(s, vrf_id);
+	stream_putl(s, vrf_id);
 	stream_putw(s, command);
 }
 
@@ -306,7 +306,7 @@ int zclient_read_header(struct stream *s, int sock, u_int16_t *size,
 	*size -= ZEBRA_HEADER_SIZE;
 	STREAM_GETC(s, *marker);
 	STREAM_GETC(s, *version);
-	STREAM_GETW(s, *vrf_id);
+	STREAM_GETL(s, *vrf_id);
 	STREAM_GETW(s, *cmd);
 
 	if (*version != ZSERV_VERSION || *marker != ZEBRA_HEADER_MARKER) {
@@ -1677,7 +1677,7 @@ struct interface *zebra_interface_vrf_update_read(struct stream *s,
 {
 	unsigned int ifindex;
 	struct interface *ifp;
-	vrf_id_t new_id = VRF_DEFAULT;
+	vrf_id_t new_id;
 
 	/* Get interface index. */
 	ifindex = stream_getl(s);
@@ -2043,7 +2043,7 @@ static int zclient_read(struct thread *thread)
 	length = stream_getw(zclient->ibuf);
 	marker = stream_getc(zclient->ibuf);
 	version = stream_getc(zclient->ibuf);
-	vrf_id = stream_getw(zclient->ibuf);
+	vrf_id = stream_getl(zclient->ibuf);
 	command = stream_getw(zclient->ibuf);
 
 	if (marker != ZEBRA_HEADER_MARKER || version != ZSERV_VERSION) {
@@ -2346,9 +2346,9 @@ void zclient_interface_set_master(struct zclient *client,
 
 	zclient_create_header(s, ZEBRA_INTERFACE_SET_MASTER, master->vrf_id);
 
-	stream_putw(s, master->vrf_id);
+	stream_putl(s, master->vrf_id);
 	stream_putl(s, master->ifindex);
-	stream_putw(s, slave->vrf_id);
+	stream_putl(s, slave->vrf_id);
 	stream_putl(s, slave->ifindex);
 
 	stream_putw_at(s, 0, stream_get_endp(s));

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -40,7 +40,7 @@
 #define ZEBRA_MAX_PACKET_SIZ          4096
 
 /* Zebra header size. */
-#define ZEBRA_HEADER_SIZE             8
+#define ZEBRA_HEADER_SIZE             10
 
 /* special socket path name to use TCP
  * @ is used as first character because that's abstract socket names on Linux
@@ -227,7 +227,7 @@ struct zserv_header {
 			 * always set to 255 in new zserv.
 			 */
 	uint8_t version;
-#define ZSERV_VERSION	4
+#define ZSERV_VERSION	5
 	vrf_id_t vrf_id;
 	uint16_t command;
 };

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -486,7 +486,7 @@ typedef u_int16_t zebra_size_t;
 typedef u_int16_t zebra_command_t;
 
 /* VRF ID type. */
-typedef u_int16_t vrf_id_t;
+typedef uint32_t vrf_id_t;
 
 typedef uint32_t route_tag_t;
 #define ROUTE_TAG_MAX UINT32_MAX

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -218,7 +218,7 @@ DEFUN_NOSH (router_ospf,
 		if (ospf->vrf_id != VRF_UNKNOWN)
 			ospf->oi_running = 1;
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("Config command 'router ospf %d' received, vrf %s id %d oi_running %u",
+			zlog_debug("Config command 'router ospf %d' received, vrf %s id %u oi_running %u",
 				   instance,  ospf->name ? ospf->name : "NIL",
 				   ospf->vrf_id, ospf->oi_running);
 		VTY_PUSH_CONTEXT(OSPF_NODE, ospf);
@@ -9600,7 +9600,7 @@ DEFUN (show_ip_ospf_vrfs,
 	for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
 		json_object *json_vrf = NULL;
 		const char *name = NULL;
-		int vrf_id_ui = 0;
+		int64_t vrf_id_ui = 0;
 
 		count++;
 
@@ -9614,7 +9614,8 @@ DEFUN (show_ip_ospf_vrfs,
 		else
 			name = ospf->name;
 
-		vrf_id_ui = (ospf->vrf_id == VRF_UNKNOWN) ? -1 : ospf->vrf_id;
+		vrf_id_ui = (ospf->vrf_id == VRF_UNKNOWN) ? -1 :
+			(int64_t) ospf->vrf_id;
 
 		if (uj) {
 			json_object_int_add(json_vrf, "vrfId", vrf_id_ui);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -240,7 +240,7 @@ static struct ospf *ospf_new(u_short instance, const char *name)
 		new->name = XSTRDUP(MTYPE_OSPF_TOP, name);
 		vrf = vrf_lookup_by_name(new->name);
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("%s: Create new ospf instance with vrf_name %s vrf_id %d",
+			zlog_debug("%s: Create new ospf instance with vrf_name %s vrf_id %u",
 				   __PRETTY_FUNCTION__, name, new->vrf_id);
 		if (vrf)
 			ospf_vrf_link(new, vrf);
@@ -2013,7 +2013,7 @@ void ospf_vrf_unlink(struct ospf *ospf, struct vrf *vrf)
 static int ospf_vrf_new(struct vrf *vrf)
 {
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: VRF Created: %s(%d)", __PRETTY_FUNCTION__,
+		zlog_debug("%s: VRF Created: %s(%u)", __PRETTY_FUNCTION__,
 			   vrf->name, vrf->vrf_id);
 
 	return 0;
@@ -2023,7 +2023,7 @@ static int ospf_vrf_new(struct vrf *vrf)
 static int ospf_vrf_delete(struct vrf *vrf)
 {
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: VRF Deletion: %s(%d)", __PRETTY_FUNCTION__,
+		zlog_debug("%s: VRF Deletion: %s(%u)", __PRETTY_FUNCTION__,
 			   vrf->name, vrf->vrf_id);
 
 	return 0;
@@ -2036,7 +2036,7 @@ static int ospf_vrf_enable(struct vrf *vrf)
 	vrf_id_t old_vrf_id = VRF_DEFAULT;
 
 	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug("%s: VRF %s id %d enabled",
+		zlog_debug("%s: VRF %s id %u enabled",
 			   __PRETTY_FUNCTION__, vrf->name, vrf->vrf_id);
 
 	ospf = ospf_lookup_by_name(vrf->name);
@@ -2045,7 +2045,7 @@ static int ospf_vrf_enable(struct vrf *vrf)
 		/* We have instance configured, link to VRF and make it "up". */
 		ospf_vrf_link(ospf, vrf);
 		if (IS_DEBUG_OSPF_EVENT)
-			zlog_debug("%s: ospf linked to vrf %s vrf_id %d (old id %d)",
+			zlog_debug("%s: ospf linked to vrf %s vrf_id %u (old id %u)",
 				   __PRETTY_FUNCTION__, vrf->name, ospf->vrf_id,
 				   old_vrf_id);
 

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -136,7 +136,7 @@ static int pim_vrf_new(struct vrf *vrf)
 {
 	struct pim_instance *pim = pim_instance_init(vrf);
 
-	zlog_debug("VRF Created: %s(%d)", vrf->name, vrf->vrf_id);
+	zlog_debug("VRF Created: %s(%u)", vrf->name, vrf->vrf_id);
 	if (pim == NULL) {
 		zlog_err("%s %s: pim class init failure ", __FILE__,
 			 __PRETTY_FUNCTION__);
@@ -159,7 +159,7 @@ static int pim_vrf_delete(struct vrf *vrf)
 {
 	struct pim_instance *pim = vrf->info;
 
-	zlog_debug("VRF Deletion: %s(%d)", vrf->name, vrf->vrf_id);
+	zlog_debug("VRF Deletion: %s(%u)", vrf->name, vrf->vrf_id);
 
 	pim_ssmpingd_destroy(pim);
 	pim_instance_terminate(pim);

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -811,7 +811,7 @@ int pim_parse_nexthop_update(int command, struct zclient *zclient,
 		char buf[PREFIX2STR_BUFFER];
 		prefix2str(&p, buf, sizeof(buf));
 		zlog_debug(
-			"%s: NHT Update for %s(%s) num_nh %d num_pim_nh %d vrf:%d up %ld rp %d",
+			"%s: NHT Update for %s(%s) num_nh %d num_pim_nh %d vrf:%u up %ld rp %d",
 			__PRETTY_FUNCTION__, buf, pim->vrf->name, nexthop_num,
 			pnc->nexthop_num, vrf_id, pnc->upstream_hash->count,
 			listcount(pnc->rp_list));

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -80,7 +80,7 @@ static int pim_zebra_if_add(int command, struct zclient *zclient,
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%d) flags %ld metric %d mtu %d operative %d",
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
 			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
 			(long)ifp->flags, ifp->metric, ifp->mtu,
 			if_is_operative(ifp));
@@ -130,7 +130,7 @@ static int pim_zebra_if_del(int command, struct zclient *zclient,
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%d) flags %ld metric %d mtu %d operative %d",
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
 			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
 			(long)ifp->flags, ifp->metric, ifp->mtu,
 			if_is_operative(ifp));
@@ -158,7 +158,7 @@ static int pim_zebra_if_state_up(int command, struct zclient *zclient,
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%d) flags %ld metric %d mtu %d operative %d",
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
 			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
 			(long)ifp->flags, ifp->metric, ifp->mtu,
 			if_is_operative(ifp));
@@ -213,7 +213,7 @@ static int pim_zebra_if_state_down(int command, struct zclient *zclient,
 
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
-			"%s: %s index %d(%d) flags %ld metric %d mtu %d operative %d",
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
 			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
 			(long)ifp->flags, ifp->metric, ifp->mtu,
 			if_is_operative(ifp));
@@ -293,7 +293,7 @@ static int pim_zebra_if_address_add(int command, struct zclient *zclient,
 	if (PIM_DEBUG_ZEBRA) {
 		char buf[BUFSIZ];
 		prefix2str(p, buf, BUFSIZ);
-		zlog_debug("%s: %s(%d) connected IP address %s flags %u %s",
+		zlog_debug("%s: %s(%u) connected IP address %s flags %u %s",
 			   __PRETTY_FUNCTION__, c->ifp->name, vrf_id, buf,
 			   c->flags, CHECK_FLAG(c->flags, ZEBRA_IFA_SECONDARY)
 					     ? "secondary"
@@ -372,7 +372,7 @@ static int pim_zebra_if_address_del(int command, struct zclient *client,
 			char buf[BUFSIZ];
 			prefix2str(p, buf, BUFSIZ);
 			zlog_debug(
-				"%s: %s(%d) disconnected IP address %s flags %u %s",
+				"%s: %s(%u) disconnected IP address %s flags %u %s",
 				__PRETTY_FUNCTION__, c->ifp->name, vrf_id, buf,
 				c->flags,
 				CHECK_FLAG(c->flags, ZEBRA_IFA_SECONDARY)

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -81,7 +81,7 @@ int zebra_ns_init(void)
 
 	zebra_vrf_init();
 
-	zebra_ns_enable(0, (void **)&dzns);
+	zebra_ns_enable(NS_DEFAULT, (void **)&dzns);
 
 	return 0;
 }

--- a/zebra/zebra_ns.h
+++ b/zebra/zebra_ns.h
@@ -57,9 +57,6 @@ struct zebra_ns {
 #endif /* HAVE_RTADV */
 };
 
-#define NS_DEFAULT 0
-#define NS_UNKNOWN UINT16_MAX
-
 struct zebra_ns *zebra_ns_lookup(ns_id_t ns_id);
 
 int zebra_ns_init(void);

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -432,7 +432,7 @@ static void if_bfd_session_update(struct interface *ifp, struct prefix *dp,
 		} else {
 			zlog_debug(
 				"MESSAGE: ZEBRA_INTERFACE_BFD_DEST_UPDATE %s/%d "
-				"with src %s/%d and vrf %d %s event",
+				"with src %s/%d and vrf %u %s event",
 				inet_ntop(dp->family, &dp->u.prefix, buf[0],
 					  INET6_ADDRSTRLEN),
 				dp->prefixlen,

--- a/zebra/zebra_static.c
+++ b/zebra/zebra_static.c
@@ -156,7 +156,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 		re->mtu = 0;
 		re->vrf_id = si->vrf_id;
 		re->table =
-			si->vrf_id
+			(si->vrf_id != VRF_DEFAULT)
 				? (zebra_vrf_lookup_by_id(si->vrf_id))->table_id
 				: zebrad.rtm_table_default;
 		re->nexthop_num = 0;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1181,7 +1181,7 @@ DEFUN (ip_nht_default_route,
 		return CMD_SUCCESS;
 
 	zebra_rnh_ip_default_route = 1;
-	zebra_evaluate_rnh(0, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(VRF_DEFAULT, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
 	return CMD_SUCCESS;
 }
 
@@ -1197,7 +1197,7 @@ DEFUN (no_ip_nht_default_route,
 		return CMD_SUCCESS;
 
 	zebra_rnh_ip_default_route = 0;
-	zebra_evaluate_rnh(0, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(VRF_DEFAULT, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
 	return CMD_SUCCESS;
 }
 
@@ -1212,7 +1212,7 @@ DEFUN (ipv6_nht_default_route,
 		return CMD_SUCCESS;
 
 	zebra_rnh_ipv6_default_route = 1;
-	zebra_evaluate_rnh(0, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(VRF_DEFAULT, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
 	return CMD_SUCCESS;
 }
 
@@ -1228,7 +1228,7 @@ DEFUN (no_ipv6_nht_default_route,
 		return CMD_SUCCESS;
 
 	zebra_rnh_ipv6_default_route = 0;
-	zebra_evaluate_rnh(0, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(VRF_DEFAULT, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
 	return CMD_SUCCESS;
 }
 
@@ -1890,7 +1890,7 @@ DEFUN (show_vrf,
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 		if (!(zvrf = vrf->info))
 			continue;
-		if (!zvrf_id(zvrf))
+		if (zvrf_id(zvrf) == VRF_DEFAULT)
 			continue;
 
 		vty_out(vty, "vrf %s ", zvrf_name(zvrf));

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -155,7 +155,7 @@ void zserv_create_header(struct stream *s, uint16_t cmd, vrf_id_t vrf_id)
 	stream_putw(s, ZEBRA_HEADER_SIZE);
 	stream_putc(s, ZEBRA_HEADER_MARKER);
 	stream_putc(s, ZSERV_VERSION);
-	stream_putw(s, vrf_id);
+	stream_putl(s, vrf_id);
 	stream_putw(s, cmd);
 }
 
@@ -508,7 +508,7 @@ int zsend_interface_vrf_update(struct zserv *client, struct interface *ifp,
 
 	/* Fill in the ifIndex of the interface and its new VRF (id) */
 	stream_putl(s, ifp->ifindex);
-	stream_putw(s, vrf_id);
+	stream_putl(s, vrf_id);
 
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
@@ -2472,11 +2472,11 @@ static int zread_interface_set_master(struct zserv *client,
 	int ifindex;
 	vrf_id_t vrf_id;
 
-	STREAM_GETW(s, vrf_id);
+	STREAM_GETL(s, vrf_id);
 	STREAM_GETL(s, ifindex);
 	master = if_lookup_by_index(ifindex, vrf_id);
 
-	STREAM_GETW(s, vrf_id);
+	STREAM_GETL(s, vrf_id);
 	STREAM_GETL(s, ifindex);
 	slave = if_lookup_by_index(ifindex, vrf_id);
 
@@ -2714,7 +2714,7 @@ static int zebra_client_read(struct thread *thread)
 		STREAM_GETW(client->ibuf, length);
 		STREAM_GETC(client->ibuf, marker);
 		STREAM_GETC(client->ibuf, version);
-		STREAM_GETW(client->ibuf, vrf_id);
+		STREAM_GETL(client->ibuf, vrf_id);
 		STREAM_GETW(client->ibuf, command);
 
 		if (marker != ZEBRA_HEADER_MARKER || version != ZSERV_VERSION) {


### PR DESCRIPTION
This is a preparatory work for configuring vrf/frr over netns
vrf structure is being changed to 32 bit to host both the vrf lite
concept and the netnamespace from kernel too.
this logical router id is a 32 bit integer that is made up of two parts:

This work is provisioning only. that means that for now, ns_id valus is
set to 0.
But this change will allow to combine both values:

continue to map frr vrf over vrf lite from kernel
make possible to map frr vrf over netns
make possible to have nested vrf lite under netns.
In all cases, a VRF in FRR will either be mapped to a vrf lite or a
netns, but not both at the same time.

the changes include the following:

the vrf structure has that identifier assigned, instead of the original vrf
zapi messages contain the vrf_id_t message
then 16 bit more is added ( + netns_id).
then the zapi version is incremented for that change
All function calls remain the same