### PR TITLE
bgpd: add PMSI_TUNNEL_ATTRIBUTE to EVPN IMET routes

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -74,6 +74,7 @@ static const struct message attr_str[] = {
 	{BGP_ATTR_AS4_PATH, "AS4_PATH"},
 	{BGP_ATTR_AS4_AGGREGATOR, "AS4_AGGREGATOR"},
 	{BGP_ATTR_AS_PATHLIMIT, "AS_PATHLIMIT"},
+	{BGP_ATTR_PMSI_TUNNEL, "PMSI_TUNNEL_ATTRIBUTE"},
 	{BGP_ATTR_ENCAP, "ENCAP"},
 #if ENABLE_BGP_VNC
 	{BGP_ATTR_VNC, "VNC"},
@@ -1033,6 +1034,8 @@ const u_int8_t attr_flags_values[] = {
 		[BGP_ATTR_AS4_PATH] =
 			BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANS,
 		[BGP_ATTR_AS4_AGGREGATOR] =
+			BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANS,
+		[BGP_ATTR_PMSI_TUNNEL] =
 			BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANS,
 		[BGP_ATTR_LARGE_COMMUNITIES] =
 			BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANS,
@@ -3244,6 +3247,17 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 		/* VNC attribute */
 		bgp_packet_mpattr_tea(bgp, peer, s, attr, BGP_ATTR_VNC);
 #endif
+	}
+
+	/* PMSI Tunnel */
+	if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_PMSI_TUNNEL)) {
+		stream_putc(s, BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANS);
+		stream_putc(s, BGP_ATTR_PMSI_TUNNEL);
+		stream_putc(s, 9); // Length
+		stream_putc(s, 0); // Flags
+		stream_putc(s, 6); // Tunnel type: Ingress Replication (6)
+		stream_put(s, &(attr->label), BGP_LABEL_BYTES); // MPLS Label / VXLAN VNI
+		stream_put_ipv4(s, attr->nexthop.s_addr); // Unicast tunnel endpoint IP address
 	}
 
 	/* Unknown transit attribute. */

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -834,6 +834,8 @@ static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 	attr.mp_nexthop_global_in = vpn->originator_ip;
 	attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV4;
 	attr.sticky = CHECK_FLAG(flags, ZEBRA_MAC_TYPE_STICKY) ? 1 : 0;
+	attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_PMSI_TUNNEL);
+	vni2label(vpn->vni, &(attr.label));
 
 	/* Set up RT and ENCAP extended community. */
 	build_evpn_route_extcomm(vpn, &attr);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1020,6 +1020,7 @@ struct bgp_nlri {
 #define BGP_ATTR_AS4_PATH                       17
 #define BGP_ATTR_AS4_AGGREGATOR                 18
 #define BGP_ATTR_AS_PATHLIMIT                   21
+#define BGP_ATTR_PMSI_TUNNEL                    22
 #define BGP_ATTR_ENCAP                          23
 #define BGP_ATTR_LARGE_COMMUNITIES              32
 #define BGP_ATTR_PREFIX_SID                     40


### PR DESCRIPTION
This patch adds the PMSI attribute to EVPN IMET (Type 3) routes originated by FRR, which is required by draft-ietf-bess-evpn-overlay-10. Other EVPN implementations need this attribute for proper traffic forwarding, see Issue #1487 for details.
Further work would be required to also process this attribute on incoming routes.

Fixes: #1487
Signed-off-by: Dario Wiesner <dario.wiesner@gmail.com>