### PR TITLE
bgpd: When I/O thread is not started up yield to let it get there

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -114,7 +114,7 @@ void bgp_writes_on(struct peer *peer)
 {
 	while (
 	    !atomic_load_explicit(&bgp_io_thread_started, memory_order_seq_cst))
-		;
+		frr_pthread_yield();
 
 	assert(peer->status != Deleted);
 	assert(peer->obuf);
@@ -135,7 +135,7 @@ void bgp_writes_off(struct peer *peer)
 {
 	while (
 	    !atomic_load_explicit(&bgp_io_thread_started, memory_order_seq_cst))
-		;
+		frr_pthread_yield();
 
 	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);
 
@@ -149,7 +149,7 @@ void bgp_reads_on(struct peer *peer)
 {
 	while (
 	    !atomic_load_explicit(&bgp_io_thread_started, memory_order_seq_cst))
-		;
+		frr_pthread_yield();
 
 	assert(peer->status != Deleted);
 	assert(peer->ibuf);
@@ -172,7 +172,7 @@ void bgp_reads_off(struct peer *peer)
 {
 	while (
 	    !atomic_load_explicit(&bgp_io_thread_started, memory_order_seq_cst))
-		;
+		frr_pthread_yield();
 
 	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);
 

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -19,6 +19,7 @@
 
 #include <zebra.h>
 #include <pthread.h>
+#include <sched.h>
 
 #include "frr_pthread.h"
 #include "memory.h"
@@ -181,4 +182,9 @@ void frr_pthread_stop_all()
 unsigned int frr_pthread_get_id()
 {
 	return next_id++;
+}
+
+void frr_pthread_yield(void)
+{
+	(void)sched_yield();
 }

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -130,6 +130,9 @@ int frr_pthread_stop(unsigned int id, void **result);
 /* Stops all frr_pthread's. */
 void frr_pthread_stop_all(void);
 
+/* Yields the current thread of execution */
+void frr_pthread_yield(void);
+
 /* Returns a unique identifier for use with frr_pthread_new().
  *
  * Internally, this is an integer that increments after each call to this


### PR DESCRIPTION
BGP starts with three threads of execution:
1) bgp_io
2) bgp_keepalive
3) Main( original thread )

Upon startup the 1 and 2 threads are pthread_create().  This schedules
the threads for execution but does not guarantee that they are
scheduled to run immediately.

It appears that when BGP is compiled statically that the bgp_io
thread sometimes does not run immediately(Why?  Dunno?).  In the normal
course of operations of startup given by issue #1573 once every
10-50 loops of startup BGP would take an inordinate amount of time
and we would get warnings from the threading system that a thread
took a long time to execute.  Upon investigation bgp_stop was
being called and eventually bgp_writes_off(), which would check
for the bgp_io thread actually being started up.  Then it would
do a busy loop over to wait for it to have started up.  I believe
that this busy loop was tying up system resources heavily and further
delaying the bgp_io pthread.

This code addition, modifies the bgp_io semantics to do a pthread_yield()
when it notices that the bgp_io thread is not started up and running.
This allows the bgp_io pthread to actually run and the busy loop
to allow other system events to happen.

Fixes: #1573
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>