### PR TITLE
ospfd: do not complain if same area is reconfigured

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -619,7 +619,7 @@ DEFUN (ospf_network_area,
 	ret = ospf_network_set(ospf, &p, area_id, format);
 	if (ret == 0) {
 		vty_out(vty, "There is already same network statement.\n");
-		return CMD_WARNING;
+		return CMD_WARNING_CONFIG_FAILED;
 	}
 
 	return CMD_SUCCESS;

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1031,9 +1031,15 @@ int ospf_network_set(struct ospf *ospf, struct prefix_ipv4 *p,
 
 	rn = route_node_get(ospf->networks, (struct prefix *)p);
 	if (rn->info) {
-		/* There is already same network statement. */
+		network = rn->info;
 		route_unlock_node(rn);
-		return 0;
+
+		if (IPV4_ADDR_SAME(&area_id, &network->area_id)) {
+			return 1;
+		} else {
+			/* There is already same network statement. */
+			return 0;
+		}
 	}
 
 	rn->info = network = ospf_network_new(area_id);


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

Before
------
cel-redxp-10(config)# router ospf vrf RED
cel-redxp-10(config-router)# network 1.1.1.1/32 area 0.0.0.0
cel-redxp-10(config-router)# network 1.1.1.1/32 area 0.0.0.0
There is already same network statement.
cel-redxp-10(config-router)#

When we see the "There is already same network statement." message
vtysh exits non-zero.  This scenario breaks frr-reload because
the command took and it in the config, it should exit zero here.

After
-----
cel-redxp-10(config)# router ospf vrf RED
cel-redxp-10(config-router)# network 1.1.1.1/32 area 0.0.0.0
cel-redxp-10(config-router)# network 1.1.1.1/32 area 0.0.0.0
cel-redxp-10(config-router)# network 1.1.1.1/32 area 0.0.0.0
cel-redxp-10(config-router)# network 1.1.1.1/32 area 0
cel-redxp-10(config-router)#
cel-redxp-10(config-router)# network 1.1.1.1/32 area 0.0.0.1
There is already same network statement.
cel-redxp-10(config-router)#