### PR TITLE
zebra route-leaking for static routes

### DIFF
--- a/babeld/kernel.c
+++ b/babeld/kernel.c
@@ -166,6 +166,7 @@ zebra_route(int add, int family, const unsigned char *pref, unsigned short plen,
     api.type  = ZEBRA_ROUTE_BABEL;
     api.safi = SAFI_UNICAST;
     api.vrf_id = VRF_DEFAULT;
+    api.nh_vrf_id = VRF_DEFAULT;
     api.prefix = quagga_prefix;
 
     if(metric >= KERNEL_INFINITY) {

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1001,6 +1001,7 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 	memset(&api, 0, sizeof(api));
 	memcpy(&api.rmac, &(info->attr->rmac), sizeof(struct ethaddr));
 	api.vrf_id = bgp->vrf_id;
+	api.nh_vrf_id = bgp->vrf_id;
 	api.type = ZEBRA_ROUTE_BGP;
 	api.safi = safi;
 	api.prefix = *p;
@@ -1253,6 +1254,7 @@ void bgp_zebra_withdraw(struct prefix *p, struct bgp_info *info, safi_t safi)
 	memset(&api, 0, sizeof(api));
 	memcpy(&api.rmac, &(info->attr->rmac), sizeof(struct ethaddr));
 	api.vrf_id = peer->bgp->vrf_id;
+	api.nh_vrf_id = peer->bgp->vrf_id;
 	api.type = ZEBRA_ROUTE_BGP;
 	api.safi = safi;
 	api.prefix = *p;

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -394,6 +394,7 @@ static void vnc_zebra_route_msg(struct prefix *p, unsigned int nhp_count,
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_VNC;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *p;

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -366,6 +366,7 @@ void eigrp_zebra_route_add(struct prefix *p, struct list *successors)
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_EIGRP;
 	api.safi = SAFI_UNICAST;
 	memcpy(&api.prefix, p, sizeof(*p));
@@ -407,6 +408,7 @@ void eigrp_zebra_route_delete(struct prefix *p)
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_EIGRP;
 	api.safi = SAFI_UNICAST;
 	memcpy(&api.prefix, p, sizeof(*p));

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -261,6 +261,7 @@ static void isis_zebra_route_add_route(struct prefix *prefix,
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_ISIS;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *prefix;
@@ -329,6 +330,7 @@ static void isis_zebra_route_del_route(struct prefix *prefix,
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_ISIS;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *prefix;

--- a/lib/if.c
+++ b/lib/if.c
@@ -219,6 +219,18 @@ struct interface *if_lookup_by_index(ifindex_t ifindex, vrf_id_t vrf_id)
 	struct vrf *vrf;
 	struct interface if_tmp;
 
+	if (vrf_id == VRF_UNKNOWN) {
+		struct interface *ifp;
+
+		RB_FOREACH(vrf, vrf_id_head, &vrfs_by_id) {
+			ifp = if_lookup_by_index(ifindex, vrf->vrf_id);
+			if (ifp)
+				return ifp;
+		}
+
+		return NULL;
+	}
+
 	vrf = vrf_lookup_by_id(vrf_id);
 	if (!vrf)
 		return NULL;

--- a/lib/if.h
+++ b/lib/if.h
@@ -452,6 +452,13 @@ struct nbr_connected {
 /* Prototypes. */
 extern int if_cmp_name_func(char *, char *);
 
+/*
+ * Passing in VRF_UNKNOWN is a valid thing to do, unless we
+ * are creating a new interface.
+ *
+ * This is useful for vrf route-leaking.  So more than anything
+ * else think before you use VRF_UNKNOWN
+ */
 extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
 extern struct interface *if_create(const char *name,  vrf_id_t vrf_id);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -942,6 +942,8 @@ int zapi_route_encode(u_char cmd, struct stream *s, struct zapi_route *api)
 		}
 
 		stream_putw(s, api->nexthop_num);
+		if (api->nexthop_num)
+			stream_putw(s, api->nh_vrf_id);
 
 		for (i = 0; i < api->nexthop_num; i++) {
 			api_nh = &api->nexthops[i];
@@ -1090,6 +1092,9 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 				  __func__, api->nexthop_num);
 			return -1;
 		}
+
+		if (api->nexthop_num)
+			STREAM_GETW(s, api->nh_vrf_id);
 
 		for (i = 0; i < api->nexthop_num; i++) {
 			api_nh = &api->nexthops[i];

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -281,6 +281,7 @@ struct zapi_route {
 	u_int32_t mtu;
 
 	vrf_id_t vrf_id;
+	vrf_id_t nh_vrf_id;
 
 	struct ethaddr rmac;
 };

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -420,6 +420,11 @@ extern struct interface *zebra_interface_vrf_update_read(struct stream *s,
 							 vrf_id_t *new_vrf_id);
 extern void zebra_interface_if_set_value(struct stream *, struct interface *);
 extern void zebra_router_id_update_read(struct stream *s, struct prefix *rid);
+
+#if CONFDATE > 20180823
+CPP_NOTICE("zapi_ipv4_route, zapi_ipv6_route, zapi_ipv4_route_ipv6_nexthop as well as the zapi_ipv4 and zapi_ipv6 data structures should be removed now");
+#endif
+
 extern int zapi_ipv4_route(u_char, struct zclient *, struct prefix_ipv4 *,
 			   struct zapi_ipv4 *) __attribute__((deprecated));
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -227,7 +227,7 @@ struct zserv_header {
 			 * always set to 255 in new zserv.
 			 */
 	uint8_t version;
-#define ZSERV_VERSION	4
+#define ZSERV_VERSION	5
 	vrf_id_t vrf_id;
 	uint16_t command;
 };

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -95,6 +95,8 @@ void nhrp_route_announce(int add, enum nhrp_cache_type type, const struct prefix
 	memset(&api, 0, sizeof(api));
 	api.type = ZEBRA_ROUTE_NHRP;
 	api.safi = SAFI_UNICAST;
+	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.prefix = *p;
 
 	switch (type) {

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -337,6 +337,7 @@ static void ospf6_zebra_route_update(int type, struct ospf6_route *request)
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_OSPF6;
 	api.safi = SAFI_UNICAST;
 	api.prefix = *dest;
@@ -387,6 +388,7 @@ void ospf6_zebra_add_discard(struct ospf6_route *request)
 	if (!CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
 		memset(&api, 0, sizeof(api));
 		api.vrf_id = VRF_DEFAULT;
+		api.nh_vrf_id = VRF_DEFAULT;
 		api.type = ZEBRA_ROUTE_OSPF6;
 		api.safi = SAFI_UNICAST;
 		api.prefix = *dest;
@@ -420,6 +422,7 @@ void ospf6_zebra_delete_discard(struct ospf6_route *request)
 	if (CHECK_FLAG(request->flag, OSPF6_ROUTE_BLACKHOLE_ADDED)) {
 		memset(&api, 0, sizeof(api));
 		api.vrf_id = VRF_DEFAULT;
+		api.nh_vrf_id = VRF_DEFAULT;
 		api.type = ZEBRA_ROUTE_OSPF6;
 		api.safi = SAFI_UNICAST;
 		api.prefix = *dest;

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -389,6 +389,7 @@ void ospf_zebra_add(struct ospf *ospf, struct prefix_ipv4 *p,
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = ospf->vrf_id;
+	api.nh_vrf_id = ospf->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF;
 	api.instance = ospf->instance;
 	api.safi = SAFI_UNICAST;
@@ -466,6 +467,7 @@ void ospf_zebra_delete(struct ospf *ospf, struct prefix_ipv4 *p,
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = ospf->vrf_id;
+	api.nh_vrf_id = ospf->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF;
 	api.instance = ospf->instance;
 	api.safi = SAFI_UNICAST;
@@ -487,6 +489,7 @@ void ospf_zebra_add_discard(struct ospf *ospf, struct prefix_ipv4 *p)
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = ospf->vrf_id;
+	api.nh_vrf_id = ospf->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF;
 	api.instance = ospf->instance;
 	api.safi = SAFI_UNICAST;
@@ -506,6 +509,7 @@ void ospf_zebra_delete_discard(struct ospf *ospf, struct prefix_ipv4 *p)
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = ospf->vrf_id;
+	api.nh_vrf_id = ospf->vrf_id;
 	api.type = ZEBRA_ROUTE_OSPF;
 	api.instance = ospf->instance;
 	api.safi = SAFI_UNICAST;

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -48,6 +48,7 @@ static void rip_zebra_ipv4_send(struct route_node *rp, u_char cmd)
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_RIP;
 	api.safi = SAFI_UNICAST;
 

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -48,6 +48,7 @@ static void ripng_zebra_ipv6_send(struct route_node *rp, u_char cmd)
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_RIPNG;
 	api.safi = SAFI_UNICAST;
 	api.prefix = rp->p;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -159,6 +159,7 @@ void route_add(struct prefix *p, struct nexthop *nh)
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_SHARP;
 	api.safi = SAFI_UNICAST;
 	memcpy(&api.prefix, p, sizeof(*p));
@@ -180,6 +181,7 @@ void route_delete(struct prefix *p)
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = VRF_DEFAULT;
+	api.nh_vrf_id = VRF_DEFAULT;
 	api.type = ZEBRA_ROUTE_SHARP;
 	api.safi = SAFI_UNICAST;
 	memcpy(&api.prefix, p, sizeof(*p));

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -238,10 +238,12 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 		break;
 	}
 
-	rib_add(afi, SAFI_UNICAST, ifp->vrf_id, ZEBRA_ROUTE_CONNECT, 0, 0,
+	rib_add(afi, SAFI_UNICAST, ifp->vrf_id, ifp->vrf_id,
+		ZEBRA_ROUTE_CONNECT, 0, 0,
 		&p, NULL, &nh, RT_TABLE_MAIN, ifp->metric, 0, 0, 0);
 
-	rib_add(afi, SAFI_MULTICAST, ifp->vrf_id, ZEBRA_ROUTE_CONNECT, 0, 0,
+	rib_add(afi, SAFI_MULTICAST, ifp->vrf_id, ifp->vrf_id,
+		ZEBRA_ROUTE_CONNECT, 0, 0,
 		&p, NULL, &nh, RT_TABLE_MAIN, ifp->metric, 0, 0, 0);
 
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED) {

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1048,7 +1048,7 @@ void rtm_read(struct rt_msghdr *rtm)
 
 		if (rtm->rtm_type == RTM_GET || rtm->rtm_type == RTM_ADD
 		    || rtm->rtm_type == RTM_CHANGE)
-			rib_add(AFI_IP, SAFI_UNICAST, VRF_DEFAULT,
+			rib_add(AFI_IP, SAFI_UNICAST, VRF_DEFAULT, VRF_DEFAULT,
 				ZEBRA_ROUTE_KERNEL, 0, zebra_flags, &p, NULL,
 				&nh, 0, 0, 0, 0, 0);
 		else
@@ -1096,7 +1096,7 @@ void rtm_read(struct rt_msghdr *rtm)
 
 		if (rtm->rtm_type == RTM_GET || rtm->rtm_type == RTM_ADD
 		    || rtm->rtm_type == RTM_CHANGE)
-			rib_add(AFI_IP6, SAFI_UNICAST, VRF_DEFAULT,
+			rib_add(AFI_IP6, SAFI_UNICAST, VRF_DEFAULT, VRF_DEFAULT,
 				ZEBRA_ROUTE_KERNEL, 0, zebra_flags, &p, NULL,
 				&nh, 0, 0, 0, 0, 0);
 		else

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -300,6 +300,13 @@ int main(int argc, char **argv)
 	zebra_if_init();
 	zebra_debug_init();
 	router_id_cmd_init();
+
+	/*
+	 * Initialize NS( and implicitly the VRF module), and make kernel
+	 * routing socket. */
+	zebra_ns_init();
+
+	zebra_vty_init();
 	access_list_init();
 	prefix_list_init();
 #if defined(HAVE_RTADV)
@@ -316,16 +323,6 @@ int main(int argc, char **argv)
 
 	/* For debug purpose. */
 	/* SET_FLAG (zebra_debug_event, ZEBRA_DEBUG_EVENT); */
-
-	/* Initialize NS( and implicitly the VRF module), and make kernel
-	 * routing socket. */
-	zebra_ns_init();
-
-	/*
-	 * Initialize show/config command after the vrf initialization is
-	 * complete
-	 */
-	zebra_vty_init();
 
 #if defined(HANDLE_ZAPI_FUZZING)
 	if (fuzzing) {

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -294,8 +294,8 @@ extern void rib_uninstall_kernel(struct route_node *rn, struct route_entry *re);
 /* NOTE:
  * All rib_add function will not just add prefix into RIB, but
  * also implicitly withdraw equal prefix of same type. */
-extern int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
-		   u_short instance, int flags, struct prefix *p,
+extern int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, vrf_id_t nh_vrf_id,
+		   int type, u_short instance, int flags, struct prefix *p,
 		   struct prefix_ipv6 *src_p, const struct nexthop *nh,
 		   u_int32_t table_id, u_int32_t metric, u_int32_t mtu,
 		   uint8_t distance, route_tag_t tag);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -440,6 +440,8 @@ DECLARE_HOOK(rib_update, (struct route_node * rn, const char *reason),
 
 
 extern void zebra_vty_init(void);
+extern int static_config(struct vty *vty, struct zebra_vrf *zvrf,
+			 afi_t afi, safi_t safi, const char *cmd);
 extern pid_t pid;
 
 #endif /*_ZEBRA_RIB_H */

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -59,6 +59,7 @@ struct route_entry {
 
 	/* VRF identifier. */
 	vrf_id_t vrf_id;
+	vrf_id_t nh_vrf_id;
 
 	/* Which routing table */
 	uint32_t table;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -453,6 +453,7 @@ static int netlink_route_change_read_unicast(struct sockaddr_nl *snl,
 			re->metric = metric;
 			re->mtu = mtu;
 			re->vrf_id = vrf_id;
+			re->nh_vrf_id = vrf_id;
 			re->table = table;
 			re->nexthop_num = 0;
 			re->uptime = time(NULL);

--- a/zebra/rtread_getmsg.c
+++ b/zebra/rtread_getmsg.c
@@ -97,8 +97,9 @@ static void handle_route_entry(mib2_ipRouteEntry_t *routeEntry)
 	nh.type = NEXTHOP_TYPE_IPV4;
 	nh.gate.ipv4.s_addr = routeEntry->ipRouteNextHop;
 
-	rib_add(AFI_IP, SAFI_UNICAST, VRF_DEFAULT, ZEBRA_ROUTE_KERNEL, 0,
-		zebra_flags, &prefix, NULL, &nh, 0, 0, 0, 0, 0);
+	rib_add(AFI_IP, SAFI_UNICAST, VRF_DEFAULT, VRF_DEFAULT,
+		ZEBRA_ROUTE_KERNEL, 0, zebra_flags, &prefix, NULL,
+		&nh, 0, 0, 0, 0, 0);
 }
 
 void route_read(struct zebra_ns *zns)

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2514,6 +2514,7 @@ int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type, u_short instance,
 	re->mtu = mtu;
 	re->table = table_id;
 	re->vrf_id = vrf_id;
+	re->nh_vrf_id = vrf_id;
 	re->nexthop_num = 0;
 	re->uptime = time(NULL);
 	re->tag = tag;

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -256,7 +256,7 @@ struct nexthop *route_entry_nexthop_ipv4_ifindex_add(struct route_entry *re,
 	if (src)
 		nexthop->src.ipv4 = *src;
 	nexthop->ifindex = ifindex;
-	ifp = if_lookup_by_index(nexthop->ifindex, re->vrf_id);
+	ifp = if_lookup_by_index(nexthop->ifindex, re->nh_vrf_id);
 	/*Pending: need to think if null ifp here is ok during bootup?
 	  There was a crash because ifp here was coming to be NULL */
 	if (ifp)
@@ -416,7 +416,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 	 * address in the routing table.
 	 */
 	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK)) {
-		ifp = if_lookup_by_index(nexthop->ifindex, re->vrf_id);
+		ifp = if_lookup_by_index(nexthop->ifindex, re->nh_vrf_id);
 		if (ifp && connected_is_unnumbered(ifp)) {
 			if (if_is_operative(ifp))
 				return 1;
@@ -444,7 +444,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 		break;
 	}
 	/* Lookup table.  */
-	table = zebra_vrf_table(afi, SAFI_UNICAST, re->vrf_id);
+	table = zebra_vrf_table(afi, SAFI_UNICAST, re->nh_vrf_id);
 	if (!table)
 		return 0;
 
@@ -832,7 +832,7 @@ static unsigned nexthop_active_check(struct route_node *rn,
 		family = 0;
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IFINDEX:
-		ifp = if_lookup_by_index(nexthop->ifindex, re->vrf_id);
+		ifp = if_lookup_by_index(nexthop->ifindex, re->nh_vrf_id);
 		if (ifp && if_is_operative(ifp))
 			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 		else
@@ -860,7 +860,8 @@ static unsigned nexthop_active_check(struct route_node *rn,
 		if (rn->p.family != AF_INET)
 			family = AFI_IP6;
 		if (IN6_IS_ADDR_LINKLOCAL(&nexthop->gate.ipv6)) {
-			ifp = if_lookup_by_index(nexthop->ifindex, re->vrf_id);
+			ifp = if_lookup_by_index(nexthop->ifindex,
+						 re->nh_vrf_id);
 			if (ifp && if_is_operative(ifp))
 				SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 			else

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -397,7 +397,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 
 	if (set) {
 		UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE);
-		zebra_deregister_rnh_static_nexthops(re->vrf_id,
+		zebra_deregister_rnh_static_nexthops(re->nh_vrf_id,
 						     nexthop->resolved, top);
 		nexthops_free(nexthop->resolved);
 		nexthop->resolved = NULL;
@@ -904,7 +904,7 @@ static unsigned nexthop_active_check(struct route_node *rn,
 	memset(&nexthop->rmap_src.ipv6, 0, sizeof(union g_addr));
 
 	/* It'll get set if required inside */
-	ret = zebra_route_map_check(family, re->type, p, nexthop, re->vrf_id,
+	ret = zebra_route_map_check(family, re->type, p, nexthop, re->nh_vrf_id,
 				    re->tag);
 	if (ret == RMAP_DENYMATCH) {
 		if (IS_ZEBRA_DEBUG_RIB) {

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2497,9 +2497,10 @@ void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 }
 
 
-int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type, u_short instance,
-	    int flags, struct prefix *p, struct prefix_ipv6 *src_p,
-	    const struct nexthop *nh, u_int32_t table_id, u_int32_t metric,
+int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, vrf_id_t nh_vrf_id,
+	    int type, u_short instance, int flags, struct prefix *p,
+	    struct prefix_ipv6 *src_p, const struct nexthop *nh,
+	    u_int32_t table_id, u_int32_t metric,
 	    u_int32_t mtu, uint8_t distance, route_tag_t tag)
 {
 	struct route_entry *re;
@@ -2515,7 +2516,7 @@ int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type, u_short instance,
 	re->mtu = mtu;
 	re->table = table_id;
 	re->vrf_id = vrf_id;
-	re->nh_vrf_id = vrf_id;
+	re->nh_vrf_id = nh_vrf_id;
 	re->nexthop_num = 0;
 	re->uptime = time(NULL);
 	re->tag = tag;

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -911,7 +911,8 @@ static unsigned nexthop_active_check(struct route_node *rn,
 			zlog_debug(
 				"%u:%s: Filtering out with NH out %s due to route map",
 				re->vrf_id, buf,
-				ifindex2ifname(nexthop->ifindex, re->vrf_id));
+				ifindex2ifname(nexthop->ifindex,
+					       re->nh_vrf_id));
 		}
 		UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 	}

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -951,6 +951,8 @@ static void copy_state(struct rnh *rnh, struct route_entry *re,
 	state->type = re->type;
 	state->distance = re->distance;
 	state->metric = re->metric;
+	state->vrf_id = re->vrf_id;
+	state->nh_vrf_id = re->vrf_id;
 
 	route_entry_copy_nexthops(state, re->nexthop);
 	rnh->state = state;

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1329,7 +1329,7 @@ route_map_result_t zebra_nht_route_map_check(int family, int client_proto,
 	struct nh_rmap_obj nh_obj;
 
 	nh_obj.nexthop = nexthop;
-	nh_obj.vrf_id = re->vrf_id;
+	nh_obj.vrf_id = re->nh_vrf_id;
 	nh_obj.source_protocol = re->type;
 	nh_obj.metric = re->metric;
 	nh_obj.tag = re->tag;

--- a/zebra/zebra_static.c
+++ b/zebra/zebra_static.c
@@ -91,7 +91,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 			nh_p.family = AF_INET;
 			nh_p.prefixlen = IPV4_MAX_BITLEN;
 			nh_p.u.prefix4 = si->addr.ipv4;
-			zebra_register_rnh_static_nh(si->vrf_id, &nh_p, rn);
+			zebra_register_rnh_static_nh(si->nh_vrf_id, &nh_p, rn);
 			break;
 		case STATIC_IPV4_GATEWAY_IFNAME:
 			nexthop = route_entry_nexthop_ipv4_ifindex_add(
@@ -111,7 +111,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 			nh_p.family = AF_INET6;
 			nh_p.prefixlen = IPV6_MAX_BITLEN;
 			nh_p.u.prefix6 = si->addr.ipv6;
-			zebra_register_rnh_static_nh(si->vrf_id, &nh_p, rn);
+			zebra_register_rnh_static_nh(si->nh_vrf_id, &nh_p, rn);
 			break;
 		case STATIC_IPV6_GATEWAY_IFNAME:
 			nexthop = route_entry_nexthop_ipv6_ifindex_add(
@@ -141,7 +141,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 		 */
 		if (si->type == STATIC_IPV4_GATEWAY
 		    || si->type == STATIC_IPV6_GATEWAY)
-			zebra_evaluate_rnh(si->vrf_id, nh_p.family, 1,
+			zebra_evaluate_rnh(si->nh_vrf_id, nh_p.family, 1,
 					   RNH_NEXTHOP_TYPE, &nh_p);
 		else
 			rib_queue_add(rn);
@@ -170,7 +170,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 			nh_p.family = AF_INET;
 			nh_p.prefixlen = IPV4_MAX_BITLEN;
 			nh_p.u.prefix4 = si->addr.ipv4;
-			zebra_register_rnh_static_nh(si->vrf_id, &nh_p, rn);
+			zebra_register_rnh_static_nh(si->nh_vrf_id, &nh_p, rn);
 			break;
 		case STATIC_IPV4_GATEWAY_IFNAME:
 			nexthop = route_entry_nexthop_ipv4_ifindex_add(
@@ -190,7 +190,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 			nh_p.family = AF_INET6;
 			nh_p.prefixlen = IPV6_MAX_BITLEN;
 			nh_p.u.prefix6 = si->addr.ipv6;
-			zebra_register_rnh_static_nh(si->vrf_id, &nh_p, rn);
+			zebra_register_rnh_static_nh(si->nh_vrf_id, &nh_p, rn);
 			break;
 		case STATIC_IPV6_GATEWAY_IFNAME:
 			nexthop = route_entry_nexthop_ipv6_ifindex_add(
@@ -222,7 +222,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 		if (si->type == STATIC_IPV4_GATEWAY
 		    || si->type == STATIC_IPV6_GATEWAY) {
 			rib_addnode(rn, re, 0);
-			zebra_evaluate_rnh(si->vrf_id, nh_p.family, 1,
+			zebra_evaluate_rnh(si->nh_vrf_id, nh_p.family, 1,
 					   RNH_NEXTHOP_TYPE, &nh_p);
 		} else
 			rib_addnode(rn, re, 1);

--- a/zebra/zebra_static.c
+++ b/zebra/zebra_static.c
@@ -155,7 +155,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 		re->metric = 0;
 		re->mtu = 0;
 		re->vrf_id = si->vrf_id;
-		re->nh_vrf_id = si->vrf_id;
+		re->nh_vrf_id = si->nh_vrf_id;
 		re->table =
 			si->vrf_id
 				? (zebra_vrf_lookup_by_id(si->vrf_id))->table_id
@@ -379,6 +379,7 @@ int static_add_route(afi_t afi, safi_t safi, u_char type, struct prefix *p,
 		     struct prefix_ipv6 *src_p, union g_addr *gate,
 		     const char *ifname, enum static_blackhole_type bh_type,
 		     route_tag_t tag, u_char distance, struct zebra_vrf *zvrf,
+		     struct zebra_vrf *nh_zvrf,
 		     struct static_nh_label *snh_label)
 {
 	struct route_node *rn;
@@ -440,6 +441,8 @@ int static_add_route(afi_t afi, safi_t safi, u_char type, struct prefix *p,
 	si->bh_type = bh_type;
 	si->tag = tag;
 	si->vrf_id = zvrf_id(zvrf);
+	si->nh_vrf_id = zvrf_id(nh_zvrf);
+
 	if (ifname)
 		strlcpy(si->ifname, ifname, sizeof(si->ifname));
 	si->ifindex = IFINDEX_INTERNAL;
@@ -494,7 +497,7 @@ int static_add_route(afi_t afi, safi_t safi, u_char type, struct prefix *p,
 	else {
 		struct interface *ifp;
 
-		ifp = if_lookup_by_name(ifname, zvrf_id(zvrf));
+		ifp = if_lookup_by_name(ifname, zvrf_id(nh_zvrf));
 		if (ifp && ifp->ifindex != IFINDEX_INTERNAL) {
 			si->ifindex = ifp->ifindex;
 			static_install_route(afi, safi, p, src_p, si);

--- a/zebra/zebra_static.c
+++ b/zebra/zebra_static.c
@@ -155,6 +155,7 @@ void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
 		re->metric = 0;
 		re->mtu = 0;
 		re->vrf_id = si->vrf_id;
+		re->nh_vrf_id = si->vrf_id;
 		re->table =
 			si->vrf_id
 				? (zebra_vrf_lookup_by_id(si->vrf_id))->table_id

--- a/zebra/zebra_static.h
+++ b/zebra/zebra_static.h
@@ -54,6 +54,7 @@ struct static_route {
 
 	/* VRF identifier. */
 	vrf_id_t vrf_id;
+	vrf_id_t nh_vrf_id;
 
 	/* Administrative distance. */
 	u_char distance;
@@ -89,6 +90,7 @@ extern int static_add_route(afi_t, safi_t safi, u_char type, struct prefix *p,
 			    const char *ifname,
 			    enum static_blackhole_type bh_type, route_tag_t tag,
 			    u_char distance, struct zebra_vrf *zvrf,
+			    struct zebra_vrf *nh_zvrf,
 			    struct static_nh_label *snh_label);
 
 extern int static_delete_route(afi_t, safi_t safi, u_char type,

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -476,13 +476,18 @@ static int vrf_config_write(struct vty *vty)
 		if (!zvrf)
 			continue;
 
-		if (vrf->vrf_id == VRF_DEFAULT)
-			continue;
+		if (vrf->vrf_id != VRF_DEFAULT)
+			vty_out(vty, "vrf %s\n", zvrf_name(zvrf));
 
-		vty_out(vty, "vrf %s\n", zvrf_name(zvrf));
-		if (zvrf->l3vni)
+		static_config(vty, zvrf, AFI_IP, SAFI_UNICAST, "ip route");
+		static_config(vty, zvrf, AFI_IP, SAFI_MULTICAST, "ip mroute");
+		static_config(vty, zvrf, AFI_IP6, SAFI_UNICAST, "ipv6 route");
+
+		if (vrf->vrf_id != VRF_DEFAULT && zvrf->l3vni)
 			vty_out(vty, " vni %u\n", zvrf->l3vni);
-		vty_out(vty, "!\n");
+
+		if (vrf->vrf_id != VRF_DEFAULT)
+			vty_out(vty, "!\n");
 	}
 	return 0;
 }

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -476,12 +476,13 @@ static int vrf_config_write(struct vty *vty)
 		if (!zvrf)
 			continue;
 
-		if (strcmp(zvrf_name(zvrf), VRF_DEFAULT_NAME)) {
-			vty_out(vty, "vrf %s\n", zvrf_name(zvrf));
-			if (zvrf->l3vni)
-				vty_out(vty, " vni %u\n", zvrf->l3vni);
-			vty_out(vty, "!\n");
-		}
+		if (vrf->vrf_id == VRF_DEFAULT)
+			continue;
+
+		vty_out(vty, "vrf %s\n", zvrf_name(zvrf));
+		if (zvrf->l3vni)
+			vty_out(vty, " vni %u\n", zvrf->l3vni);
+		vty_out(vty, "!\n");
 	}
 	return 0;
 }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -539,7 +539,7 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 				if (nexthop->ifindex)
 					vty_out(vty, ", via %s",
 						ifindex2ifname(nexthop->ifindex,
-							       re->vrf_id));
+							       re->nh_vrf_id));
 				break;
 			case NEXTHOP_TYPE_IPV6:
 			case NEXTHOP_TYPE_IPV6_IFINDEX:
@@ -549,12 +549,12 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 				if (nexthop->ifindex)
 					vty_out(vty, ", via %s",
 						ifindex2ifname(nexthop->ifindex,
-							       re->vrf_id));
+							       re->nh_vrf_id));
 				break;
 			case NEXTHOP_TYPE_IFINDEX:
 				vty_out(vty, " directly connected, %s",
 					ifindex2ifname(nexthop->ifindex,
-						       re->vrf_id));
+						       re->nh_vrf_id));
 				break;
 			case NEXTHOP_TYPE_BLACKHOLE:
 				vty_out(vty, " unreachable");
@@ -715,7 +715,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 					json_object_string_add(
 						json_nexthop, "interfaceName",
 						ifindex2ifname(nexthop->ifindex,
-							       re->vrf_id));
+							       re->nh_vrf_id));
 				}
 				break;
 			case NEXTHOP_TYPE_IPV6:
@@ -734,7 +734,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 					json_object_string_add(
 						json_nexthop, "interfaceName",
 						ifindex2ifname(nexthop->ifindex,
-							       re->vrf_id));
+							       re->nh_vrf_id));
 				}
 				break;
 
@@ -747,7 +747,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 				json_object_string_add(
 					json_nexthop, "interfaceName",
 					ifindex2ifname(nexthop->ifindex,
-						       re->vrf_id));
+						       re->nh_vrf_id));
 				break;
 			case NEXTHOP_TYPE_BLACKHOLE:
 				json_object_boolean_true_add(json_nexthop,
@@ -881,7 +881,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 			if (nexthop->ifindex)
 				vty_out(vty, ", %s",
 					ifindex2ifname(nexthop->ifindex,
-						       re->vrf_id));
+						       re->nh_vrf_id));
 			break;
 		case NEXTHOP_TYPE_IPV6:
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
@@ -891,12 +891,13 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 			if (nexthop->ifindex)
 				vty_out(vty, ", %s",
 					ifindex2ifname(nexthop->ifindex,
-						       re->vrf_id));
+						       re->nh_vrf_id));
 			break;
 
 		case NEXTHOP_TYPE_IFINDEX:
 			vty_out(vty, " is directly connected, %s",
-				ifindex2ifname(nexthop->ifindex, re->vrf_id));
+				ifindex2ifname(nexthop->ifindex,
+					       re->nh_vrf_id));
 			break;
 		case NEXTHOP_TYPE_BLACKHOLE:
 			vty_out(vty, " unreachable");

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -576,6 +576,14 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 			default:
 				break;
 			}
+
+			if (re->vrf_id != re->nh_vrf_id) {
+				struct vrf *vrf =
+					vrf_lookup_by_id(re->nh_vrf_id);
+
+				vty_out(vty, "(vrf %s)", vrf->name);
+			}
+
 			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
 				vty_out(vty, " (duplicate nexthop removed)");
 
@@ -774,6 +782,14 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 				break;
 			}
 
+			if (re->nh_vrf_id != re->vrf_id) {
+				struct vrf *vrf =
+					vrf_lookup_by_id(re->nh_vrf_id);
+
+				json_object_string_add(json_nexthop,
+						       "vrf",
+						       vrf->name);
+			}
 			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
 				json_object_boolean_true_add(json_nexthop,
 							     "duplicate");
@@ -918,6 +934,14 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		default:
 			break;
 		}
+
+		if (re->nh_vrf_id != re->vrf_id) {
+			struct vrf *vrf =
+				vrf_lookup_by_id(re->nh_vrf_id);
+
+			vty_out(vty, "(vrf %s)", vrf->name);
+		}
+
 		if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 			vty_out(vty, " inactive");
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -233,7 +233,8 @@ static int zebra_static_route_leak(struct vty *vty,
 
 	if (!negate)
 		static_add_route(afi, safi, type, &p, src_p, gatep, ifname,
-				 bh_type, tag, distance, zvrf, &snh_label);
+				 bh_type, tag, distance, zvrf, nh_zvrf,
+				 &snh_label);
 	else
 		static_delete_route(afi, safi, type, &p, src_p, gatep, ifname,
 				    tag, distance, zvrf, &snh_label);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1146,6 +1146,7 @@ static int zread_route_add(struct zserv *client, u_short length,
 	re->flags = api.flags;
 	re->uptime = time(NULL);
 	re->vrf_id = vrf_id;
+	re->nh_vrf_id = vrf_id;
 	re->table = zvrf->table_id;
 
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP)) {
@@ -1372,6 +1373,7 @@ static int zread_ipv4_add(struct zserv *client, u_short length,
 
 	/* VRF ID */
 	re->vrf_id = zvrf_id(zvrf);
+	re->nh_vrf_id = zvrf_id(zvrf);
 
 	/* Nexthop parse. */
 	if (CHECK_FLAG(message, ZAPI_MESSAGE_NEXTHOP)) {
@@ -1581,6 +1583,7 @@ static int zread_ipv4_route_ipv6_nexthop_add(struct zserv *client,
 
 	/* VRF ID */
 	re->vrf_id = zvrf_id(zvrf);
+	re->nh_vrf_id = zvrf_id(zvrf);
 
 	/* We need to give nh-addr, nh-ifindex with the same next-hop object
 	 * to the re to ensure that IPv6 multipathing works; need to coalesce
@@ -1866,6 +1869,8 @@ static int zread_ipv6_add(struct zserv *client, u_short length,
 
 	/* VRF ID */
 	re->vrf_id = zvrf_id(zvrf);
+	re->nh_vrf_id = zvrf_id(zvrf);
+
 	re->table = zvrf->table_id;
 
 	ret = rib_add_multipath(AFI_IP6, safi, &p, src_pp, re);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -602,6 +602,7 @@ int zsend_redistribute_route(int cmd, struct zserv *client, struct prefix *p,
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = re->vrf_id;
+	api.nh_vrf_id = re->nh_vrf_id;
 	api.type = re->type;
 	api.instance = re->instance;
 	api.flags = re->flags;
@@ -1146,7 +1147,7 @@ static int zread_route_add(struct zserv *client, u_short length,
 	re->flags = api.flags;
 	re->uptime = time(NULL);
 	re->vrf_id = vrf_id;
-	re->nh_vrf_id = vrf_id;
+	re->nh_vrf_id = api.nh_vrf_id;
 	re->table = zvrf->table_id;
 
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP)) {


### PR DESCRIPTION
This code allows zebra to read routes from the linux kernel that have nexthops in a different vrf and then properly display them in various 'show .. route' commands and to disseminate the nexthops vrf up to the different routing protocols.

Additionally routing protocols now have the ability to send to zebra routes that are leaked, currently no routing protocol takes advantage of this yet.

nexthops are currently limited to 1 vrf.

static routes can now be created that have nexthops in different vrfs.

This supersedes #1607