### PR TITLE
bgpd: 'summary' to show NoNeg if peer did not negotiate afi/safi

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7119,8 +7119,11 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					    BGP_UPTIME_LEN, 0, NULL));
 
 			if (peer->status == Established)
-				vty_out(vty, " %12ld",
-					peer->pcount[afi][pfx_rcd_safi]);
+				if (peer->afc_recv[afi][pfx_rcd_safi])
+					vty_out(vty, " %12ld",
+						peer->pcount[afi][pfx_rcd_safi]);
+				else
+					vty_out(vty, " NoNeg");
 			else {
 				if (CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN))
 					vty_out(vty, " Idle (Admin)");


### PR DESCRIPTION
If we have configured neighbor 1.1.1.1 for an afi/safi but they have not
activated that afi/safi with us then display "NoNeg" in the state column
of the summary output.  This is to make troubleshooting afi/safi
easier.

Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>