### PR TITLE
bgpd: fix updating redist bitmask when vrf_id changes

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1516,8 +1516,9 @@ void bgp_update_redist_vrf_bitmaps(struct bgp *bgp, vrf_id_t old_vrf_id)
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
-			if (vrf_bitmap_check(zclient->redist[afi][i],
-					     old_vrf_id)) {
+			if ((old_vrf_id == VRF_UNKNOWN)
+			    || vrf_bitmap_check(zclient->redist[afi][i],
+						old_vrf_id)) {
 				vrf_bitmap_unset(zclient->redist[afi][i],
 						 old_vrf_id);
 				vrf_bitmap_set(zclient->redist[afi][i],


### PR DESCRIPTION
Problem reported that when "systemctl restart networking" was
performed, prefixes previously redistributed into bgp from connected
were deleted from the bgp table.  Determined that we were not correctly
changing the redistribution bitmask when the vrf_id of the vrf was
changed. This patch corrects that behavior.

Manual tests look good. bgp-min and vrf-min completed with no new failures.

Ticket: CM-19369
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Reviewed-by: Donald Sharp <sharpd@cumulusnetworks.com>