### PR TITLE
lib, bgpd: fixup use of of CMD_ARGC_MAX

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1151,15 +1151,13 @@ struct peer *peer_new(struct bgp *bgp)
 	 * - We RX a BGP_UPDATE where the attributes alone are just
 	 *   under BGP_MAX_PACKET_SIZE
 	 * - The user configures an outbound route-map that does many as-path
-	 *   prepends or adds many communities.  At most they can have
-	 * CMD_ARGC_MAX
-	 *   args in a route-map so there is a finite limit on how large they
-	 * can
-	 *   make the attributes.
+	 *   prepends or adds many communities. At most they can have
+	 *   CMD_ARGC_MAX args in a route-map so there is a finite limit on how
+	 *   large they can make the attributes.
 	 *
 	 * Having a buffer with BGP_MAX_PACKET_SIZE_OVERFLOW allows us to avoid
-	 * bounds
-	 * checking for every single attribute as we construct an UPDATE.
+	 * bounds checking for every single attribute as we construct an
+	 * UPDATE.
 	 */
 	peer->obuf_work =
 		stream_new(BGP_MAX_PACKET_SIZE + BGP_MAX_PACKET_SIZE_OVERFLOW);

--- a/lib/command.h
+++ b/lib/command.h
@@ -190,7 +190,7 @@ struct cmd_node {
 #define CMD_NOT_MY_INSTANCE	14
 
 /* Argc max counts. */
-#define CMD_ARGC_MAX   25
+#define CMD_ARGC_MAX   256
 
 /* Turn off these macros when uisng cpp with extract.pl */
 #ifndef VTYSH_EXTRACT_PL

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -28,8 +28,6 @@
 
 DEFINE_MTYPE_STATIC(LIB, CMD_MATCHSTACK, "Command Match Stack")
 
-#define MAXDEPTH 256
-
 #ifdef TRACE_MATCHER
 #define TM 1
 #else
@@ -84,7 +82,7 @@ static enum match_type match_mac(const char *, bool);
 enum matcher_rv command_match(struct graph *cmdgraph, vector vline,
 			      struct list **argv, const struct cmd_element **el)
 {
-	struct graph_node *stack[MAXDEPTH];
+	struct graph_node *stack[CMD_ARGC_MAX];
 	enum matcher_rv status;
 	*argv = NULL;
 
@@ -200,7 +198,7 @@ static enum matcher_rv command_match_r(struct graph_node *start, vector vline,
 	/* check history/stack of tokens
 	 * this disallows matching the same one more than once if there is a
 	 * circle in the graph (used for keyword arguments) */
-	if (n == MAXDEPTH)
+	if (n == CMD_ARGC_MAX)
 		return MATCHER_NO_MATCH;
 	if (!token->allowrepeat)
 		for (size_t s = 0; s < n; s++)


### PR DESCRIPTION
The constant to limit # of allowed cli tokens on any one line was
defined in multiple places, all inconsistent with each other. Fix.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>