### PR TITLE
BGP auto-shutdown

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2677,6 +2677,19 @@ static int peer_remote_as_vty(struct vty *vty, const char *peer_str,
 	return bgp_vty_return(vty, ret);
 }
 
+DEFUN (bgp_default_shutdown,
+       bgp_default_shutdown_cmd,
+       "[no] bgp default shutdown",
+       NO_STR
+       BGP_STR
+       "Configure BGP defaults\n"
+       "Do not automatically activate peers upon configuration\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	bgp->autoshutdown = !strmatch(argv[0]->text, "no");
+	return CMD_SUCCESS;
+}
+
 DEFUN (neighbor_remote_as,
        neighbor_remote_as_cmd,
        "neighbor <A.B.C.D|X:X::X:X|WORD> remote-as <(1-4294967295)|internal|external>",
@@ -3222,7 +3235,6 @@ DEFUN (no_neighbor_password,
 	ret = peer_password_unset(peer);
 	return bgp_vty_return(vty, ret);
 }
-
 
 DEFUN (neighbor_activate,
        neighbor_activate_cmd,
@@ -11554,6 +11566,9 @@ void bgp_vty_init(void)
 	/* "bgp listen range" commands. */
 	install_element(BGP_NODE, &bgp_listen_range_cmd);
 	install_element(BGP_NODE, &no_bgp_listen_range_cmd);
+
+	/* "neighbors auto-shutdown" command */
+	install_element(BGP_NODE, &bgp_default_shutdown_cmd);
 
 	/* "neighbor remote-as" commands. */
 	install_element(BGP_NODE, &neighbor_remote_as_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1497,8 +1497,11 @@ struct peer *peer_create(union sockunion *su, const char *conf_if,
 		peer_af_create(peer, afi, safi);
 	}
 
+	/* auto shutdown if configured */
+	if (bgp->autoshutdown)
+		peer_flag_set(peer, PEER_FLAG_SHUTDOWN);
 	/* Set up peer's events and timers. */
-	if (!active && peer_active(peer))
+	else if (!active && peer_active(peer))
 		bgp_timer_set(peer);
 
 	return peer;
@@ -7139,6 +7142,10 @@ int bgp_config_write(struct vty *vty)
 		    != BGP_DEFAULT_SUBGROUP_PKT_QUEUE_MAX)
 			vty_out(vty, " bgp default subgroup-pkt-queue-max %u\n",
 				bgp->default_subgroup_pkt_queue_max);
+
+		/* BGP default autoshutdown neighbors */
+		if (bgp->autoshutdown)
+			vty_out(vty, " bgp default auto-shutdown\n");
 
 		/* BGP client-to-client reflection. */
 		if (bgp_flag_check(bgp, BGP_FLAG_NO_CLIENT_TO_CLIENT))

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -866,8 +866,7 @@ static void peer_af_flag_reset(struct peer *peer, afi_t afi, safi_t safi)
 /* peer global config reset */
 static void peer_global_config_reset(struct peer *peer)
 {
-
-	int v6only;
+	int saved_flags = 0;
 
 	peer->change_local_as = 0;
 	peer->ttl = (peer_sort(peer) == BGP_PEER_IBGP ? MAXTTL : 1);
@@ -885,13 +884,11 @@ static void peer_global_config_reset(struct peer *peer)
 	else
 		peer->v_routeadv = BGP_DEFAULT_EBGP_ROUTEADV;
 
-	/* This is a per-peer specific flag and so we must preserve it */
-	v6only = CHECK_FLAG(peer->flags, PEER_FLAG_IFPEER_V6ONLY);
-
+	/* These are per-peer specific flags and so we must preserve them */
+	saved_flags |= CHECK_FLAG(peer->flags, PEER_FLAG_IFPEER_V6ONLY);
+	saved_flags |= CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN);
 	peer->flags = 0;
-
-	if (v6only)
-		SET_FLAG(peer->flags, PEER_FLAG_IFPEER_V6ONLY);
+	SET_FLAG(peer->flags, saved_flags);
 
 	peer->config = 0;
 	peer->holdtime = 0;
@@ -2342,7 +2339,7 @@ static void peer_group2peer_config_copy(struct peer_group *group,
 					struct peer *peer)
 {
 	struct peer *conf;
-	int v6only;
+	int saved_flags = 0;
 
 	conf = group->conf;
 
@@ -2360,14 +2357,11 @@ static void peer_group2peer_config_copy(struct peer_group *group,
 	/* GTSM hops */
 	peer->gtsm_hops = conf->gtsm_hops;
 
-	/* this flag is per-neighbor and so has to be preserved */
-	v6only = CHECK_FLAG(peer->flags, PEER_FLAG_IFPEER_V6ONLY);
-
-	/* peer flags apply */
+	/* These are per-peer specific flags and so we must preserve them */
+	saved_flags |= CHECK_FLAG(peer->flags, PEER_FLAG_IFPEER_V6ONLY);
+	saved_flags |= CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN);
 	peer->flags = conf->flags;
-
-	if (v6only)
-		SET_FLAG(peer->flags, PEER_FLAG_IFPEER_V6ONLY);
+	SET_FLAG(peer->flags, saved_flags);
 
 	/* peer config apply */
 	peer->config = conf->config;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -386,6 +386,9 @@ struct bgp {
 	/* Actual coalesce time */
 	uint32_t coalesce_time;
 
+	/* Auto-shutdown new peers */
+	bool autoshutdown;
+
 	u_int32_t addpath_tx_id;
 	int addpath_tx_used[AFI_MAX][SAFI_MAX];
 


### PR DESCRIPTION
Adds ability to specify that peers should be administratively shutdown when first configured.

Depends #1625 
Closes #1475 