### PR TITLE
ospfd: show ip ospf interface json output format

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3693,14 +3693,15 @@ static int show_ip_ospf_interface_common(struct vty *vty, struct ospf *ospf,
 {
 	struct interface *ifp;
 	struct vrf *vrf = vrf_lookup_by_id(ospf->vrf_id);
-	json_object *json_vrf = NULL;
-	json_object *json_interface_sub = NULL;
+	json_object *json_vrf = NULL, *json_intf_array = NULL;
+	json_object *json_interface_sub = NULL, *json_interface = NULL;
 
 	if (use_json) {
 		if (use_vrf)
 			json_vrf = json_object_new_object();
 		else
 			json_vrf = json;
+		json_intf_array = json_object_new_array();
 	}
 
 	if (ospf->instance) {
@@ -3714,21 +3715,29 @@ static int show_ip_ospf_interface_common(struct vty *vty, struct ospf *ospf,
 	ospf_show_vrf_name(ospf, vty, json_vrf, use_vrf);
 
 	if (intf_name == NULL) {
+		if (use_json)
+			json_object_object_add(json_vrf, "interfaces",
+				       json_intf_array);
 		/* Show All Interfaces.*/
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			if (ospf_oi_count(ifp)) {
-				if (use_json)
+				if (use_json) {
+					json_interface =
+						json_object_new_object();
 					json_interface_sub =
 						json_object_new_object();
-
+				}
 				show_ip_ospf_interface_sub(vty, ospf, ifp,
 							   json_interface_sub,
 							   use_json);
 
-				if (use_json)
+				if (use_json) {
+					json_object_array_add(json_intf_array,
+							      json_interface);
 					json_object_object_add(
-						json_vrf, ifp->name,
+						json_interface, ifp->name,
 						json_interface_sub);
+				}
 			}
 		}
 	} else {
@@ -3741,15 +3750,23 @@ static int show_ip_ospf_interface_common(struct vty *vty, struct ospf *ospf,
 			else
 				vty_out(vty, "No such interface name\n");
 		} else {
-			if (use_json)
+			if (use_json) {
 				json_interface_sub = json_object_new_object();
+				json_interface = json_object_new_object();
+				json_object_object_add(json_vrf, "interfaces",
+						       json_intf_array);
+			}
 
 			show_ip_ospf_interface_sub(
 				vty, ospf, ifp, json_interface_sub, use_json);
 
-			if (use_json)
-				json_object_object_add(json_vrf, ifp->name,
+			if (use_json) {
+				json_object_array_add(json_intf_array,
+						      json_interface);
+				json_object_object_add(json_interface,
+						       ifp->name,
 						       json_interface_sub);
+			}
 		}
 	}
 


### PR DESCRIPTION
Current json output does not differentiate start of
interface objects. Adding "interfaces" keyword at the
beginning of the interface list. This is useful
when displaying vrf level output along with interface list.

Testing Done:
show ip ospf vrf all interface json
show ip ospf vrf all interface <specific intf> json
show ip ospf interface json
show ip ospf interface <specific intf> json

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>


  "vrf1014":{
    "vrfName":"vrf1014",
    "vrfId":23,
    "interfaces":[
      {
        "swp1.4":{
          "ifUp":true,
          "ifIndex":22,
          "mtuBytes":1500,
          "bandwidthMbit":1000,
          "ifFlags":"<UP,BROADCAST,RUNNING,MULTICAST>",
          "ospfEnabled":true,
          "ipAddress":"200.254.4.9",
          "ipAddressPrefixlen":30,
          "area":"0.0.0.0",
          "routerId":"9.9.14.7",
          "networkType":"POINTOPOINT",
          "cost":100,
          "transmitDelayMsecs":1000,
          "state":"Point-To-Point",
          "priority":1,
          "mcastMemberOspfAllRouters":true,
          "timerMsecs":100,
          "timerDeadMsecs":25,
          "timerWaitMsecs":25,
          "timerRetransmit":200,
          "timerHelloInMsecs":1079,
          "nbrCount":1,
          "nbrAdjacentCount":1
        }
      },
      {
        "swp2.4":{
          "ifUp":true,
          "ifIndex":24,
          "mtuBytes":1500,
          "bandwidthMbit":1000,
          "ifFlags":"<UP,BROADCAST,RUNNING,MULTICAST>",
          "ospfEnabled":true,
          "ipAddress":"200.254.4.13",
          "ipAddressPrefixlen":30,
          "area":"0.0.0.0",
          "routerId":"9.9.14.7",
          "networkType":"POINTOPOINT",
          "cost":100,
          "transmitDelayMsecs":1000,
          "state":"Point-To-Point",
          "priority":1,
          "mcastMemberOspfAllRouters":true,
          "timerMsecs":100,
          "timerDeadMsecs":25,
          "timerWaitMsecs":25,
          "timerRetransmit":200,
          "timerHelloInMsecs":1079,
          "nbrCount":1,
          "nbrAdjacentCount":1
        }
      },
      {
        "swp3.4":{
          "ifUp":true,
          "ifIndex":25,
          "mtuBytes":1500,
          "bandwidthMbit":1000,
          "ifFlags":"<UP,BROADCAST,RUNNING,MULTICAST>",
          "ospfEnabled":true,
          "ipAddress":"200.254.4.17",
          "ipAddressPrefixlen":30,
          "area":"0.0.0.0",
          "routerId":"9.9.14.7",
          "networkType":"POINTOPOINT",
          "cost":100,
          "transmitDelayMsecs":1000,
          "state":"Point-To-Point",
          "priority":1,
          "mcastMemberOspfAllRouters":true,
          "timerMsecs":100,
          "timerDeadMsecs":25,
          "timerWaitMsecs":25,
          "timerRetransmit":200,
          "timerHelloInMsecs":1079,
          "nbrCount":1,
          "nbrAdjacentCount":1
        }
      },
      {
        "vrf1014":{
          "ifUp":true,
          "ifIndex":23,
          "mtuBytes":65536,
          "bandwidthMbit":0,
          "ifFlags":"<UP,RUNNING,NOARP>",
          "ospfEnabled":true,
          "ifUnnumbered":true,
          "area":"0.0.0.0",
          "routerId":"9.9.14.7",
          "networkType":"BROADCAST",
          "cost":10,
          "transmitDelayMsecs":1000,
          "state":"DR",
          "priority":1,
          "mcastMemberOspfAllRouters":true,
          "mcastMemberOspfDesignatedRouters":true,
          "timerMsecs":100,
          "timerDeadMsecs":25,
          "timerWaitMsecs":25,
          "timerRetransmit":200,
          "timerHelloInMsecs":1079,
          "nbrCount":0,
          "nbrAdjacentCount":0
        }
      }
    ]
  }