### PR TITLE
ospfd: LSDB_LOOP treat it as a loop.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -57,3 +57,5 @@ ForEachMacros:
   - SUBGRP_FOREACH_ADJ_SAFE
   - AF_FOREACH
   - FOREACH_AFI_SAFI
+  # ospfd
+  - LSDB_LOOP

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -327,8 +327,7 @@ static int ospf_abr_nssa_am_elected(struct ospf_area *area)
 	struct router_lsa *rlsa;
 	struct in_addr *best = NULL;
 
-	LSDB_LOOP(ROUTER_LSDB(area), rn, lsa)
-	{
+	LSDB_LOOP (ROUTER_LSDB(area), rn, lsa) {
 		/* sanity checks */
 		if (!lsa || (lsa->data->type != OSPF_ROUTER_LSA)
 		    || IS_LSA_SELF(lsa))
@@ -978,7 +977,7 @@ static void ospf_abr_process_nssa_translates(struct ospf *ospf)
 				inet_ntoa(area->area_id));
 
 		LSDB_LOOP(NSSA_LSDB(area), rn, lsa)
-		ospf_abr_translate_nssa(area, lsa);
+			ospf_abr_translate_nssa(area, lsa);
 	}
 
 	if (IS_DEBUG_OSPF_NSSA)
@@ -1325,14 +1324,14 @@ ospf_abr_unapprove_translates(struct ospf *ospf) /* For NSSA Translations */
 	  and we would want to flush any residuals anyway */
 
 	LSDB_LOOP(EXTERNAL_LSDB(ospf), rn, lsa)
-	if (CHECK_FLAG(lsa->flags, OSPF_LSA_LOCAL_XLT)) {
-		UNSET_FLAG(lsa->flags, OSPF_LSA_APPROVED);
-		if (IS_DEBUG_OSPF_NSSA)
-			zlog_debug(
-				"ospf_abr_unapprove_translates(): "
-				"approved unset on link id %s",
-				inet_ntoa(lsa->data->id));
-	}
+		if (CHECK_FLAG(lsa->flags, OSPF_LSA_LOCAL_XLT)) {
+			UNSET_FLAG(lsa->flags, OSPF_LSA_APPROVED);
+			if (IS_DEBUG_OSPF_NSSA)
+				zlog_debug(
+					"ospf_abr_unapprove_translates(): "
+					"approved unset on link id %s",
+					inet_ntoa(lsa->data->id));
+		}
 
 	if (IS_DEBUG_OSPF_NSSA)
 		zlog_debug("ospf_abr_unapprove_translates(): Stop");
@@ -1355,24 +1354,24 @@ static void ospf_abr_unapprove_summaries(struct ospf *ospf)
 				"considering area %s",
 				inet_ntoa(area->area_id));
 		LSDB_LOOP(SUMMARY_LSDB(area), rn, lsa)
-		if (ospf_lsa_is_self_originated(ospf, lsa)) {
-			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_unapprove_summaries(): "
-					"approved unset on summary link id %s",
-					inet_ntoa(lsa->data->id));
-			UNSET_FLAG(lsa->flags, OSPF_LSA_APPROVED);
-		}
+			if (ospf_lsa_is_self_originated(ospf, lsa)) {
+				if (IS_DEBUG_OSPF_EVENT)
+					zlog_debug(
+						"ospf_abr_unapprove_summaries(): "
+						"approved unset on summary link id %s",
+						inet_ntoa(lsa->data->id));
+				UNSET_FLAG(lsa->flags, OSPF_LSA_APPROVED);
+			}
 
 		LSDB_LOOP(ASBR_SUMMARY_LSDB(area), rn, lsa)
-		if (ospf_lsa_is_self_originated(ospf, lsa)) {
-			if (IS_DEBUG_OSPF_EVENT)
-				zlog_debug(
-					"ospf_abr_unapprove_summaries(): "
-					"approved unset on asbr-summary link id %s",
-					inet_ntoa(lsa->data->id));
-			UNSET_FLAG(lsa->flags, OSPF_LSA_APPROVED);
-		}
+			if (ospf_lsa_is_self_originated(ospf, lsa)) {
+				if (IS_DEBUG_OSPF_EVENT)
+					zlog_debug(
+						"ospf_abr_unapprove_summaries(): "
+						"approved unset on asbr-summary link id %s",
+						inet_ntoa(lsa->data->id));
+				UNSET_FLAG(lsa->flags, OSPF_LSA_APPROVED);
+			}
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)
@@ -1633,7 +1632,7 @@ static void ospf_abr_remove_unapproved_translates(struct ospf *ospf)
 		zlog_debug("ospf_abr_remove_unapproved_translates(): Start");
 
 	LSDB_LOOP(EXTERNAL_LSDB(ospf), rn, lsa)
-	ospf_abr_remove_unapproved_translates_apply(ospf, lsa);
+		ospf_abr_remove_unapproved_translates_apply(ospf, lsa);
 
 	if (IS_DEBUG_OSPF_NSSA)
 		zlog_debug("ospf_abr_remove_unapproved_translates(): Stop");
@@ -1657,14 +1656,14 @@ static void ospf_abr_remove_unapproved_summaries(struct ospf *ospf)
 				inet_ntoa(area->area_id));
 
 		LSDB_LOOP(SUMMARY_LSDB(area), rn, lsa)
-		if (ospf_lsa_is_self_originated(ospf, lsa))
-			if (!CHECK_FLAG(lsa->flags, OSPF_LSA_APPROVED))
-				ospf_lsa_flush_area(lsa, area);
+			if (ospf_lsa_is_self_originated(ospf, lsa))
+				if (!CHECK_FLAG(lsa->flags, OSPF_LSA_APPROVED))
+					ospf_lsa_flush_area(lsa, area);
 
 		LSDB_LOOP(ASBR_SUMMARY_LSDB(area), rn, lsa)
-		if (ospf_lsa_is_self_originated(ospf, lsa))
-			if (!CHECK_FLAG(lsa->flags, OSPF_LSA_APPROVED))
-				ospf_lsa_flush_area(lsa, area);
+			if (ospf_lsa_is_self_originated(ospf, lsa))
+				if (!CHECK_FLAG(lsa->flags, OSPF_LSA_APPROVED))
+					ospf_lsa_flush_area(lsa, area);
 	}
 
 	if (IS_DEBUG_OSPF_EVENT)

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -1313,22 +1313,28 @@ int ospf_apiserver_handle_sync_lsdb(struct ospf_apiserver *apiserv,
 			/* Check msg type. */
 			if (mask & Power2[OSPF_ROUTER_LSA])
 				LSDB_LOOP(ROUTER_LSDB(area), rn, lsa)
-			apiserver_sync_callback(lsa, (void *)&param, seqnum);
+					apiserver_sync_callback(
+						lsa, (void *)&param, seqnum);
 			if (mask & Power2[OSPF_NETWORK_LSA])
 				LSDB_LOOP(NETWORK_LSDB(area), rn, lsa)
-			apiserver_sync_callback(lsa, (void *)&param, seqnum);
+					apiserver_sync_callback(
+						lsa, (void *)&param, seqnum);
 			if (mask & Power2[OSPF_SUMMARY_LSA])
 				LSDB_LOOP(SUMMARY_LSDB(area), rn, lsa)
-			apiserver_sync_callback(lsa, (void *)&param, seqnum);
+					apiserver_sync_callback(
+						lsa, (void *)&param, seqnum);
 			if (mask & Power2[OSPF_ASBR_SUMMARY_LSA])
 				LSDB_LOOP(ASBR_SUMMARY_LSDB(area), rn, lsa)
-			apiserver_sync_callback(lsa, (void *)&param, seqnum);
+					apiserver_sync_callback(
+						lsa, (void *)&param, seqnum);
 			if (mask & Power2[OSPF_OPAQUE_LINK_LSA])
 				LSDB_LOOP(OPAQUE_LINK_LSDB(area), rn, lsa)
-			apiserver_sync_callback(lsa, (void *)&param, seqnum);
+					apiserver_sync_callback(
+						lsa, (void *)&param, seqnum);
 			if (mask & Power2[OSPF_OPAQUE_AREA_LSA])
 				LSDB_LOOP(OPAQUE_AREA_LSDB(area), rn, lsa)
-			apiserver_sync_callback(lsa, (void *)&param, seqnum);
+					apiserver_sync_callback(
+						lsa, (void *)&param, seqnum);
 		}
 	}
 
@@ -1336,14 +1342,16 @@ int ospf_apiserver_handle_sync_lsdb(struct ospf_apiserver *apiserv,
 	if (ospf->lsdb) {
 		if (mask & Power2[OSPF_AS_EXTERNAL_LSA])
 			LSDB_LOOP(EXTERNAL_LSDB(ospf), rn, lsa)
-		apiserver_sync_callback(lsa, (void *)&param, seqnum);
+				apiserver_sync_callback(lsa, (void *)&param,
+							seqnum);
 	}
 
 	/* For AS-external opaque LSAs */
 	if (ospf->lsdb) {
 		if (mask & Power2[OSPF_OPAQUE_AS_LSA])
 			LSDB_LOOP(OPAQUE_AS_LSDB(ospf), rn, lsa)
-		apiserver_sync_callback(lsa, (void *)&param, seqnum);
+				apiserver_sync_callback(lsa, (void *)&param,
+							seqnum);
 	}
 
 	/* Send a reply back to client with return code */
@@ -1945,16 +1953,19 @@ void ospf_apiserver_flush_opaque_lsa(struct ospf_apiserver *apiserv,
 	case OSPF_OPAQUE_LINK_LSA:
 		for (ALL_LIST_ELEMENTS(ospf->areas, node, nnode, area))
 			LSDB_LOOP(OPAQUE_LINK_LSDB(area), rn, lsa)
-		apiserver_flush_opaque_type_callback(lsa, (void *)&param, 0);
+				apiserver_flush_opaque_type_callback(
+					lsa, (void *)&param, 0);
 		break;
 	case OSPF_OPAQUE_AREA_LSA:
 		for (ALL_LIST_ELEMENTS(ospf->areas, node, nnode, area))
 			LSDB_LOOP(OPAQUE_AREA_LSDB(area), rn, lsa)
-		apiserver_flush_opaque_type_callback(lsa, (void *)&param, 0);
+				apiserver_flush_opaque_type_callback(
+					lsa, (void *)&param, 0);
 		break;
 	case OSPF_OPAQUE_AS_LSA:
 		LSDB_LOOP(OPAQUE_LINK_LSDB(ospf), rn, lsa)
-		apiserver_flush_opaque_type_callback(lsa, (void *)&param, 0);
+			apiserver_flush_opaque_type_callback(lsa,
+							     (void *)&param, 0);
 		break;
 	default:
 		break;

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -649,7 +649,7 @@ static int ospf_ase_calculate_timer(struct thread *t)
 
 		/* Calculate external route for each AS-external-LSA */
 		LSDB_LOOP(EXTERNAL_LSDB(ospf), rn, lsa)
-		ospf_ase_calculate_route(ospf, lsa);
+			ospf_ase_calculate_route(ospf, lsa);
 
 		/*  This version simple adds to the table all NSSA areas  */
 		if (ospf->anyNSSA)
@@ -661,11 +661,12 @@ static int ospf_ase_calculate_timer(struct thread *t)
 
 				if (area->external_routing == OSPF_AREA_NSSA)
 					LSDB_LOOP(NSSA_LSDB(area), rn, lsa)
-				ospf_ase_calculate_route(ospf, lsa);
+						ospf_ase_calculate_route(ospf,
+									 lsa);
 			}
 		/* kevinm: And add the NSSA routes in ospf_top */
 		LSDB_LOOP(NSSA_LSDB(ospf), rn, lsa)
-		ospf_ase_calculate_route(ospf, lsa);
+			ospf_ase_calculate_route(ospf, lsa);
 
 		/* Compare old and new external routing table and install the
 		   difference info zebra/kernel */

--- a/ospfd/ospf_ia.c
+++ b/ospfd/ospf_ia.c
@@ -283,7 +283,7 @@ static void ospf_examine_summaries(struct ospf_area *area,
 	struct route_node *rn;
 
 	LSDB_LOOP(lsdb_rt, rn, lsa)
-	process_summary_lsa(area, rt, rtrs, lsa);
+		process_summary_lsa(area, rt, rtrs, lsa);
 }
 
 int ospf_area_is_transit(struct ospf_area *area)
@@ -583,7 +583,7 @@ static void ospf_examine_transit_summaries(struct ospf_area *area,
 	struct route_node *rn;
 
 	LSDB_LOOP(lsdb_rt, rn, lsa)
-	process_transit_summary_lsa(area, rt, rtrs, lsa);
+		process_transit_summary_lsa(area, rt, rtrs, lsa);
 }
 
 void ospf_ia_routing(struct ospf *ospf, struct route_table *rt,

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -1872,8 +1872,7 @@ struct ospf_lsa *ospf_translated_nssa_refresh(struct ospf *ospf,
 			if (area->external_routing != OSPF_AREA_NSSA && !type7)
 				continue;
 
-			LSDB_LOOP(NSSA_LSDB(area), rn, lsa)
-			{
+			LSDB_LOOP (NSSA_LSDB(area), rn, lsa) {
 				if (lsa->data->id.s_addr
 				    == type5->data->id.s_addr) {
 					type7 = lsa;
@@ -3007,27 +3006,27 @@ int ospf_lsa_maxage_walker(struct thread *thread)
 
 	for (ALL_LIST_ELEMENTS(ospf->areas, node, nnode, area)) {
 		LSDB_LOOP(ROUTER_LSDB(area), rn, lsa)
-		ospf_lsa_maxage_walker_remover(ospf, lsa);
+			ospf_lsa_maxage_walker_remover(ospf, lsa);
 		LSDB_LOOP(NETWORK_LSDB(area), rn, lsa)
-		ospf_lsa_maxage_walker_remover(ospf, lsa);
+			ospf_lsa_maxage_walker_remover(ospf, lsa);
 		LSDB_LOOP(SUMMARY_LSDB(area), rn, lsa)
-		ospf_lsa_maxage_walker_remover(ospf, lsa);
+			ospf_lsa_maxage_walker_remover(ospf, lsa);
 		LSDB_LOOP(ASBR_SUMMARY_LSDB(area), rn, lsa)
-		ospf_lsa_maxage_walker_remover(ospf, lsa);
+			ospf_lsa_maxage_walker_remover(ospf, lsa);
 		LSDB_LOOP(OPAQUE_AREA_LSDB(area), rn, lsa)
-		ospf_lsa_maxage_walker_remover(ospf, lsa);
+			ospf_lsa_maxage_walker_remover(ospf, lsa);
 		LSDB_LOOP(OPAQUE_LINK_LSDB(area), rn, lsa)
-		ospf_lsa_maxage_walker_remover(ospf, lsa);
+			ospf_lsa_maxage_walker_remover(ospf, lsa);
 		LSDB_LOOP(NSSA_LSDB(area), rn, lsa)
-		ospf_lsa_maxage_walker_remover(ospf, lsa);
+			ospf_lsa_maxage_walker_remover(ospf, lsa);
 	}
 
 	/* for AS-external-LSAs. */
 	if (ospf->lsdb) {
 		LSDB_LOOP(EXTERNAL_LSDB(ospf), rn, lsa)
-		ospf_lsa_maxage_walker_remover(ospf, lsa);
+			ospf_lsa_maxage_walker_remover(ospf, lsa);
 		LSDB_LOOP(OPAQUE_AS_LSDB(ospf), rn, lsa)
-		ospf_lsa_maxage_walker_remover(ospf, lsa);
+			ospf_lsa_maxage_walker_remover(ospf, lsa);
 	}
 
 	OSPF_TIMER_ON(ospf->t_maxage_walker, ospf_lsa_maxage_walker,
@@ -3350,20 +3349,20 @@ void ospf_flush_self_originated_lsas_now(struct ospf *ospf)
 		}
 
 		LSDB_LOOP(SUMMARY_LSDB(area), rn, lsa)
-		ospf_lsa_flush_schedule(ospf, lsa);
+			ospf_lsa_flush_schedule(ospf, lsa);
 		LSDB_LOOP(ASBR_SUMMARY_LSDB(area), rn, lsa)
-		ospf_lsa_flush_schedule(ospf, lsa);
+			ospf_lsa_flush_schedule(ospf, lsa);
 		LSDB_LOOP(OPAQUE_LINK_LSDB(area), rn, lsa)
-		ospf_lsa_flush_schedule(ospf, lsa);
+			ospf_lsa_flush_schedule(ospf, lsa);
 		LSDB_LOOP(OPAQUE_AREA_LSDB(area), rn, lsa)
-		ospf_lsa_flush_schedule(ospf, lsa);
+			ospf_lsa_flush_schedule(ospf, lsa);
 	}
 
 	if (need_to_flush_ase) {
 		LSDB_LOOP(EXTERNAL_LSDB(ospf), rn, lsa)
-		ospf_lsa_flush_schedule(ospf, lsa);
+			ospf_lsa_flush_schedule(ospf, lsa);
 		LSDB_LOOP(OPAQUE_AS_LSDB(ospf), rn, lsa)
-		ospf_lsa_flush_schedule(ospf, lsa);
+			ospf_lsa_flush_schedule(ospf, lsa);
 	}
 
 	/*

--- a/ospfd/ospf_nsm.c
+++ b/ospfd/ospf_nsm.c
@@ -280,37 +280,37 @@ static int nsm_negotiation_done(struct ospf_neighbor *nbr)
 	ospf_proactively_arp(nbr);
 
 	LSDB_LOOP(ROUTER_LSDB(area), rn, lsa)
-	ospf_db_summary_add(nbr, lsa);
+		ospf_db_summary_add(nbr, lsa);
 	LSDB_LOOP(NETWORK_LSDB(area), rn, lsa)
-	ospf_db_summary_add(nbr, lsa);
+		ospf_db_summary_add(nbr, lsa);
 	LSDB_LOOP(SUMMARY_LSDB(area), rn, lsa)
-	ospf_db_summary_add(nbr, lsa);
+		ospf_db_summary_add(nbr, lsa);
 	LSDB_LOOP(ASBR_SUMMARY_LSDB(area), rn, lsa)
-	ospf_db_summary_add(nbr, lsa);
+		ospf_db_summary_add(nbr, lsa);
 
 	/* Process only if the neighbor is opaque capable. */
 	if (CHECK_FLAG(nbr->options, OSPF_OPTION_O)) {
 		LSDB_LOOP(OPAQUE_LINK_LSDB(area), rn, lsa)
-		ospf_db_summary_add(nbr, lsa);
+			ospf_db_summary_add(nbr, lsa);
 		LSDB_LOOP(OPAQUE_AREA_LSDB(area), rn, lsa)
-		ospf_db_summary_add(nbr, lsa);
+			ospf_db_summary_add(nbr, lsa);
 	}
 
 	if (CHECK_FLAG(nbr->options, OSPF_OPTION_NP)) {
 		LSDB_LOOP(NSSA_LSDB(area), rn, lsa)
-		ospf_db_summary_add(nbr, lsa);
+			ospf_db_summary_add(nbr, lsa);
 	}
 
 	if (nbr->oi->type != OSPF_IFTYPE_VIRTUALLINK
 	    && area->external_routing == OSPF_AREA_DEFAULT)
 		LSDB_LOOP(EXTERNAL_LSDB(nbr->oi->ospf), rn, lsa)
-	ospf_db_summary_add(nbr, lsa);
+			ospf_db_summary_add(nbr, lsa);
 
 	if (CHECK_FLAG(nbr->options, OSPF_OPTION_O)
 	    && (nbr->oi->type != OSPF_IFTYPE_VIRTUALLINK
 		&& area->external_routing == OSPF_AREA_DEFAULT))
 		LSDB_LOOP(OPAQUE_AS_LSDB(nbr->oi->ospf), rn, lsa)
-	ospf_db_summary_add(nbr, lsa);
+			ospf_db_summary_add(nbr, lsa);
 
 	return 0;
 }

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -6167,7 +6167,7 @@ static void show_ip_ospf_database_summary(struct vty *vty, struct ospf *ospf,
 					show_database_header[type]);
 
 				LSDB_LOOP(AREA_LSDB(area, type), rn, lsa)
-				show_lsa_summary(vty, lsa, self);
+					show_lsa_summary(vty, lsa, self);
 
 				vty_out(vty, "\n");
 			}
@@ -6189,7 +6189,7 @@ static void show_ip_ospf_database_summary(struct vty *vty, struct ospf *ospf,
 			vty_out(vty, "%s\n", show_database_header[type]);
 
 			LSDB_LOOP(AS_LSDB(ospf, type), rn, lsa)
-			show_lsa_summary(vty, lsa, self);
+				show_lsa_summary(vty, lsa, self);
 
 			vty_out(vty, "\n");
 		}

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -159,8 +159,8 @@ void ospf_router_id_update(struct ospf *ospf)
 			struct ospf_lsa *lsa;
 
 			LSDB_LOOP(EXTERNAL_LSDB(ospf), rn, lsa)
-			if (IS_LSA_SELF(lsa))
-				ospf_lsa_flush_schedule(ospf, lsa);
+				if (IS_LSA_SELF(lsa))
+					ospf_lsa_flush_schedule(ospf, lsa);
 		}
 
 		ospf->router_id = router_id;
@@ -183,8 +183,7 @@ void ospf_router_id_update(struct ospf *ospf)
 			struct route_node *rn;
 			struct ospf_lsa *lsa;
 
-			LSDB_LOOP(EXTERNAL_LSDB(ospf), rn, lsa)
-			{
+			LSDB_LOOP (EXTERNAL_LSDB(ospf), rn, lsa) {
 				/* AdvRouter and Router ID is the same. */
 				if (IPV4_ADDR_SAME(&lsa->data->adv_router,
 						   &ospf->router_id)) {
@@ -693,9 +692,9 @@ static void ospf_finish_final(struct ospf *ospf)
 	stream_free(ospf->ibuf);
 
 	LSDB_LOOP(OPAQUE_AS_LSDB(ospf), rn, lsa)
-	ospf_discard_from_db(ospf, ospf->lsdb, lsa);
+		ospf_discard_from_db(ospf, ospf->lsdb, lsa);
 	LSDB_LOOP(EXTERNAL_LSDB(ospf), rn, lsa)
-	ospf_discard_from_db(ospf, ospf->lsdb, lsa);
+		ospf_discard_from_db(ospf, ospf->lsdb, lsa);
 
 	ospf_lsdb_delete_all(ospf->lsdb);
 	ospf_lsdb_free(ospf->lsdb);
@@ -830,20 +829,20 @@ static void ospf_area_free(struct ospf_area *area)
 
 	/* Free LSDBs. */
 	LSDB_LOOP(ROUTER_LSDB(area), rn, lsa)
-	ospf_discard_from_db(area->ospf, area->lsdb, lsa);
+		ospf_discard_from_db(area->ospf, area->lsdb, lsa);
 	LSDB_LOOP(NETWORK_LSDB(area), rn, lsa)
-	ospf_discard_from_db(area->ospf, area->lsdb, lsa);
+		ospf_discard_from_db(area->ospf, area->lsdb, lsa);
 	LSDB_LOOP(SUMMARY_LSDB(area), rn, lsa)
-	ospf_discard_from_db(area->ospf, area->lsdb, lsa);
+		ospf_discard_from_db(area->ospf, area->lsdb, lsa);
 	LSDB_LOOP(ASBR_SUMMARY_LSDB(area), rn, lsa)
-	ospf_discard_from_db(area->ospf, area->lsdb, lsa);
+		ospf_discard_from_db(area->ospf, area->lsdb, lsa);
 
 	LSDB_LOOP(NSSA_LSDB(area), rn, lsa)
-	ospf_discard_from_db(area->ospf, area->lsdb, lsa);
+		ospf_discard_from_db(area->ospf, area->lsdb, lsa);
 	LSDB_LOOP(OPAQUE_AREA_LSDB(area), rn, lsa)
-	ospf_discard_from_db(area->ospf, area->lsdb, lsa);
+		ospf_discard_from_db(area->ospf, area->lsdb, lsa);
 	LSDB_LOOP(OPAQUE_LINK_LSDB(area), rn, lsa)
-	ospf_discard_from_db(area->ospf, area->lsdb, lsa);
+		ospf_discard_from_db(area->ospf, area->lsdb, lsa);
 
 	ospf_opaque_type10_lsa_term(area);
 	ospf_lsdb_delete_all(area->lsdb);


### PR DESCRIPTION
Inform the .clang-format file about LSDB_LOOP and
put the proper indentation for this loop into the
code.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>