### PR TITLE
bgpd: Remove peer->hash as that it is unused

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -246,8 +246,6 @@ void bgp_sync_init(struct peer *peer)
 		BGP_ADV_FIFO_INIT(&sync->withdraw);
 		BGP_ADV_FIFO_INIT(&sync->withdraw_low);
 		peer->sync[afi][safi] = sync;
-		peer->hash[afi][safi] = hash_create(baa_hash_key, baa_hash_cmp,
-						    "BGP Sync Hash");
 	}
 }
 
@@ -260,9 +258,5 @@ void bgp_sync_delete(struct peer *peer)
 		if (peer->sync[afi][safi])
 			XFREE(MTYPE_BGP_SYNCHRONISE, peer->sync[afi][safi]);
 		peer->sync[afi][safi] = NULL;
-
-		if (peer->hash[afi][safi])
-			hash_free(peer->hash[afi][safi]);
-		peer->hash[afi][safi] = NULL;
 	}
 }

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -919,9 +919,6 @@ struct peer {
 	/* Send prefix count. */
 	unsigned long scount[AFI_MAX][SAFI_MAX];
 
-	/* Announcement attribute hash.  */
-	struct hash *hash[AFI_MAX][SAFI_MAX];
-
 	/* Notify data. */
 	struct bgp_notify notify;
 


### PR DESCRIPTION
The peer->hash pointer is allocating a bunch of memory
but is never used.  Remove.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>