### PR TITLE
ospfd: show ip ospf neighbor json output format

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -51,6 +51,28 @@ DEFINE_QOBJ_TYPE(ospf_interface)
 DEFINE_HOOK(ospf_vl_add, (struct ospf_vl_data * vd), (vd))
 DEFINE_HOOK(ospf_vl_delete, (struct ospf_vl_data * vd), (vd))
 
+int ospf_interface_neighbor_count(struct ospf_interface *oi)
+{
+	int count = 0;
+	struct route_node *rn;
+	struct ospf_neighbor *nbr = NULL;
+
+	for (rn = route_top(oi->nbrs); rn; rn = route_next(rn)) {
+		nbr = rn->info;
+		if (nbr) {
+			/* Do not show myself. */
+			if (nbr == oi->nbr_self)
+				continue;
+			/* Down state is not shown. */
+			if (nbr->state == NSM_Down)
+				continue;
+			count++;
+		}
+	}
+
+	return count;
+}
+
 int ospf_if_get_output_cost(struct ospf_interface *oi)
 {
 	/* If all else fails, use default OSPF cost */

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -314,8 +314,8 @@ extern struct crypt_key *ospf_crypt_key_lookup(struct list *, u_char);
 extern struct crypt_key *ospf_crypt_key_new(void);
 extern void ospf_crypt_key_add(struct list *, struct crypt_key *);
 extern int ospf_crypt_key_delete(struct list *, u_char);
-
 extern u_char ospf_default_iftype(struct interface *ifp);
+extern int ospf_interface_neighbor_count(struct ospf_interface *oi);
 
 /* Set all multicast memberships appropriately based on the type and
    state of the interface. */


### PR DESCRIPTION
Current json output does not differentiate start of
neighbor ip object. Adding "neighbors" keyword at the
beginning of neighbor list. This is useful when
displaying vrf level output along with neighbors
list.

Ticket:CM-19097
Testing Done:
show ip ospf neighbor json
show ip ospf vrf all neighbor json

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>


{
  "default":{
    "vrfName":"default",
    "vrfId":0,
    "neighbors":[
    ]
  },
  "vrf1012":{
    "vrfName":"vrf1012",
    "vrfId":9,
    "neighbors":[
      {
        "9.9.12.11":[
          {
            "priority":1,
            "state":"Full\/DROther",
            "deadTimeMsecs":30335,
            "address":"200.254.2.10",
            "ifaceName":"swp1.2:200.254.2.9",
            "retransmitCounter":0,
            "requestCounter":0,
            "dbSummaryCounter":0
          }
        ]
      },
      {
        "9.9.12.12":[
          {
            "priority":1,
            "state":"Full\/DROther",
            "deadTimeMsecs":30121,
            "address":"200.254.2.14",
            "ifaceName":"swp2.2:200.254.2.13",
            "retransmitCounter":0,
            "requestCounter":0,
            "dbSummaryCounter":0
          }
        ]
      },
      {
        "9.9.12.13":[
          {
            "priority":1,
            "state":"Full\/DROther",
            "deadTimeMsecs":35066,
            "address":"200.254.2.18",
            "ifaceName":"swp3.2:200.254.2.17",
            "retransmitCounter":0,
            "requestCounter":0,
            "dbSummaryCounter":0
          }
        ]
      }
    ]
  },
  "vrf1013":{
    "vrfName":"vrf1013",
    "vrfId":16,
    "neighbors":[
      {
        "9.9.13.11":[
          {
            "priority":1,
            "state":"Full\/DROther",
            "deadTimeMsecs":30335,
            "address":"200.254.3.10",
            "ifaceName":"swp1.3:200.254.3.9",
            "retransmitCounter":0,
            "requestCounter":0,
            "dbSummaryCounter":0
          }
        ]
      },
      {
        "9.9.13.12":[
          {
            "priority":1,
            "state":"Full\/DROther",
            "deadTimeMsecs":30122,
            "address":"200.254.3.14",
            "ifaceName":"swp2.3:200.254.3.13",
            "retransmitCounter":0,
            "requestCounter":0,
            "dbSummaryCounter":0
          }
        ]
      },
      {
        "9.9.13.13":[
          {
            "priority":1,
            "state":"Full\/DROther",
            "deadTimeMsecs":35067,
            "address":"200.254.3.18",
            "ifaceName":"swp3.3:200.254.3.17",
            "retransmitCounter":0,
            "requestCounter":0,
            "dbSummaryCounter":0
          }
        ]
      }
    ]
  },
  "vrf1014":{
    "vrfName":"vrf1014",
    "vrfId":23,
    "neighbors":[
      {
        "9.9.14.11":[
          {
            "priority":1,
            "state":"Full\/DROther",
            "deadTimeMsecs":30335,
            "address":"200.254.4.10",
            "ifaceName":"swp1.4:200.254.4.9",
            "retransmitCounter":0,
            "requestCounter":0,
            "dbSummaryCounter":0
          }
        ]
      },
      {
        "9.9.14.12":[
          {
            "priority":1,
            "state":"Full\/DROther",
            "deadTimeMsecs":30122,
            "address":"200.254.4.14",
            "ifaceName":"swp2.4:200.254.4.13",
            "retransmitCounter":0,
            "requestCounter":0,
            "dbSummaryCounter":0
          }
        ]
      },
      {
        "9.9.14.13":[
          {
            "priority":1,
            "state":"Full\/DROther",
            "deadTimeMsecs":35067,
            "address":"200.254.4.18",
            "ifaceName":"swp3.4:200.254.4.17",
            "retransmitCounter":0,
            "requestCounter":0,
            "dbSummaryCounter":0
          }
        ]
      }
    ]
  }
}
