### PR TITLE
zebra: Install connected routes during VRF change only if interface i…

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -768,7 +768,8 @@ void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
 	zebra_interface_vrf_update_add(ifp, old_vrf_id);
 
 	/* Install connected routes (in new VRF). */
-	if_install_connected(ifp);
+	if (if_is_operative(ifp))
+		if_install_connected(ifp);
 
 	static_ifindex_update(ifp, true);
 


### PR DESCRIPTION
…s up

During VRF change handling, the connected route for the interface should be
installed only if the interface is up. Otherwise, we end up with duplicate
connected routes which can lead to other problems.

Signed-off-by: Vivek Venkatraman <vivek@cumulusnetworks.com>
Reviewed-by:   Don Slice <dslice@cumulusnetworks.com>

Ticket: CM-19364
Reviewed By: CCR-7099
Testing Done: Manual verification