### PR TITLE
OSPFD: Solve Issue #1652

### DIFF
--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -589,30 +589,6 @@ static void free_opaque_info_per_type(void *val)
 		ospf_opaque_lsa_flush_schedule(lsa);
 	}
 
-	/* Remove "oipt" from its owner's self-originated LSA list. */
-	switch (oipt->lsa_type) {
-	case OSPF_OPAQUE_LINK_LSA: {
-		struct ospf_interface *oi =
-			(struct ospf_interface *)(oipt->owner);
-		listnode_delete(oi->opaque_lsa_self, oipt);
-		break;
-	}
-	case OSPF_OPAQUE_AREA_LSA: {
-		struct ospf_area *area = (struct ospf_area *)(oipt->owner);
-		listnode_delete(area->opaque_lsa_self, oipt);
-		break;
-	}
-	case OSPF_OPAQUE_AS_LSA: {
-		struct ospf *top = (struct ospf *)(oipt->owner);
-		listnode_delete(top->opaque_lsa_self, oipt);
-		break;
-	}
-	default:
-		zlog_warn("free_opaque_info_per_type: Unexpected LSA-type(%u)",
-			  oipt->lsa_type);
-		break; /* This case may not exist. */
-	}
-
 	OSPF_TIMER_OFF(oipt->t_opaque_lsa_self);
 	list_delete_and_null(&oipt->id_list);
 	XFREE(MTYPE_OPAQUE_INFO_PER_TYPE, oipt);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -845,7 +845,6 @@ static void ospf_area_free(struct ospf_area *area)
 	LSDB_LOOP(OPAQUE_LINK_LSDB(area), rn, lsa)
 	ospf_discard_from_db(area->ospf, area->lsdb, lsa);
 
-	ospf_opaque_type10_lsa_term(area);
 	ospf_lsdb_delete_all(area->lsdb);
 	ospf_lsdb_free(area->lsdb);
 


### PR DESCRIPTION
Issue 1652 was related to OSPF Crash on termination when ospf is
configured to flood self Opaque LSA e.g TE or RI Opaque LSA.

Analysis:
The problem resides in free_opaque_info_per_type() line 576 of
ospf_opaque.c. Once LSA flush, the function removes by calling
listnode_delete() function the opaque_info_per_type data structure.
However, this is also performed at the upper level function
ospf_opaque_type10lsa_term() which call list_delete_and_null() function.
This result into a double free pointer exception.

Solution:
Remove call to listnode_delete() calls in free_opaque_info_per_type()
function as it is done by list_delete_and_null(). Delete lines 592 - 615.
Remove also second call to ospf_opaque_type10lsa_term() in ospfd.c line 848.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>