### PR TITLE
bgpd: remove poorly located bestpath json output

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9847,7 +9847,6 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp,
 	}
 
 	if (use_json) {
-		bgp_show_bestpath_json(bgp, json);
 		vty_out(vty, "%s\n", json_object_to_json_string_ext(
 					     json, JSON_C_TO_STRING_PRETTY));
 		json_object_free(json);


### PR DESCRIPTION
The bestpath multipath-relax setting was added to the output of
"show ip bgp neighbor json" several months ago but this is not
the correct place to display that information and this fix removes
it from there.  The multipath-relax setting  was also added
to the output of "show ip bgp sum json" which is fine.

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>