### PR TITLE
zebra: Fix failure to parse src

### DIFF
--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1193,7 +1193,7 @@ static void *route_set_src_compile(const char *arg)
 	union g_addr src, *psrc;
 
 	if ((inet_pton(AF_INET6, arg, &src.ipv6) == 1)
-	    || (src.ipv4.s_addr && (inet_pton(AF_INET, arg, &src.ipv4) == 1))) {
+	    || (inet_pton(AF_INET, arg, &src.ipv4) == 1)) {
 		psrc = XMALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(union g_addr));
 		*psrc = src;
 		return psrc;


### PR DESCRIPTION
If src happens to point at all 0's due to not initializing
it and if the address passed in is not a v6 address then
we would not set src in the AF_INET6 call and would
fail the (src.ipv4.s_addr && inet_pton(AF_INET...)
call.  Thus causing us to return a NULL and make
the routemap code think there was an issue.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>