### PR TITLE
zebra: Fix to get correct nexthop-vrf

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -475,20 +475,21 @@ DEFPY(ip_route_address_interface,
 		ifname = NULL;
 	}
 
-	if (nexthop_vrf) {
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
-		if (!nh_zvrf) {
-			vty_out(vty, "%% nexthop vrf %s is not defined\n",
-				nexthop_vrf);
-			return CMD_WARNING_CONFIG_FAILED;
-		}
-	} else
-		nh_zvrf = zebra_vrf_lookup_by_name(vrf);
-
 	zvrf = zebra_vrf_lookup_by_name(vrf);
+	if (!zvrf) {
+		vty_out(vty, "%% vrf %s is not defined\n",
+			vrf);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (nexthop_vrf)
+		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+	else
+		nh_zvrf = zvrf;
+
 	if (!nh_zvrf) {
 		vty_out(vty, "%% nexthop vrf %s is not defined\n",
-			vrf);
+			nexthop_vrf);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
@@ -582,22 +583,24 @@ DEFPY(ip_route,
 		ifname = NULL;
 	}
 
-	if (nexthop_vrf) {
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
-		if (!nh_zvrf) {
-			vty_out(vty, "%% nexthop vrf %s is not defined\n",
-				nexthop_vrf);
-			return CMD_WARNING_CONFIG_FAILED;
-		}
-	} else
-		nh_zvrf = zebra_vrf_lookup_by_name(vrf);
-
 	zvrf = zebra_vrf_lookup_by_name(vrf);
-	if (!nh_zvrf) {
-		vty_out(vty, "%% nexthop vrf %s is not defined\n",
+	if (!zvrf) {
+		vty_out(vty, "%% vrf %s is not defined\n",
 			vrf);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	if (nexthop_vrf)
+		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+	else
+		nh_zvrf = zvrf;
+
+	if (!nh_zvrf) {
+		vty_out(vty, "%% nexthop vrf %s is not defined\n",
+			nexthop_vrf);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
 
 	return zebra_static_route_leak(vty, zvrf, nh_zvrf,
 				       AFI_IP, SAFI_UNICAST, no, prefix,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -475,12 +475,15 @@ DEFPY(ip_route_address_interface,
 		ifname = NULL;
 	}
 
-	nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
-	if (!nh_zvrf) {
-		vty_out(vty, "%% nexthop vrf %s is not defined\n",
-			nexthop_vrf);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
+	if (nexthop_vrf) {
+		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		if (!nh_zvrf) {
+			vty_out(vty, "%% nexthop vrf %s is not defined\n",
+				nexthop_vrf);
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else
+		nh_zvrf = zebra_vrf_lookup_by_name(vrf);
 
 	zvrf = zebra_vrf_lookup_by_name(vrf);
 	if (!nh_zvrf) {
@@ -579,12 +582,15 @@ DEFPY(ip_route,
 		ifname = NULL;
 	}
 
-	nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
-	if (!nh_zvrf) {
-		vty_out(vty, "%% nexthop vrf %s is not defined\n",
-			nexthop_vrf);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
+	if (nexthop_vrf) {
+		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		if (!nh_zvrf) {
+			vty_out(vty, "%% nexthop vrf %s is not defined\n",
+				nexthop_vrf);
+			return CMD_WARNING_CONFIG_FAILED;
+		}
+	} else
+		nh_zvrf = zebra_vrf_lookup_by_name(vrf);
 
 	zvrf = zebra_vrf_lookup_by_name(vrf);
 	if (!nh_zvrf) {


### PR DESCRIPTION
The nexthop_vrf should be looked up as appropriate,
If the nexthop_vrf was specified use that, else
use the vrf context of what was passed in.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>