### PR TITLE
zebra: Fix crash when dereferencing dest->selected_fib

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2098,6 +2098,9 @@ void rib_unlink(struct route_node *rn, struct route_entry *re)
 		dest->routes = re->next;
 	}
 
+	if (dest->selected_fib == re)
+		dest->selected_fib = NULL;
+
 	/* free RE and nexthops */
 	zebra_deregister_rnh_static_nexthops(re->vrf_id, re->nexthop, rn);
 	nexthops_free(re->nexthop);


### PR DESCRIPTION
When a rib_unlink() event is directly called for a
route_entry we need to see if the dest->selected_fib
is the same and just unset the dest->selected_fib.

This was happening for redistributed table 10 routes
into BGP.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>