### PR TITLE
zebra: Fix v6 nexthop-vrf and nexthop confusion

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2013,17 +2013,21 @@ DEFPY(ipv6_route_address_interface,
 	struct zebra_vrf *zvrf;
 	struct zebra_vrf *nh_zvrf;
 
-	nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
-	if (!nh_zvrf) {
-		vty_out(vty, "%% nexthop vrf %s is not defined\n",
-			nexthop_vrf);
+	zvrf = zebra_vrf_lookup_by_name(vrf);
+	if (!zvrf) {
+		vty_out(vty, "%% vrf %s is not defined\n",
+			vrf);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	if (nexthop_vrf)
+		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+	else
+		nh_zvrf = zvrf;
+
 	if (!nh_zvrf) {
 		vty_out(vty, "%% nexthop vrf %s is not defined\n",
-			vrf);
+			nexthop_vrf);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
@@ -2104,17 +2108,21 @@ DEFPY(ipv6_route,
 	struct zebra_vrf *zvrf;
 	struct zebra_vrf *nh_zvrf;
 
-	nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
-	if (!nh_zvrf) {
-		vty_out(vty, "%% nexthop vrf %s is not defined\n",
-			nexthop_vrf);
+	zvrf = zebra_vrf_lookup_by_name(vrf);
+	if (!zvrf) {
+		vty_out(vty, "%% vrf %s is not defined\n",
+			vrf);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	if (nexthop_vrf)
+		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+	else
+		nh_zvrf = zvrf;
+
 	if (!nh_zvrf) {
 		vty_out(vty, "%% nexthop vrf %s is not defined\n",
-			vrf);
+			nexthop_vrf);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 


### PR DESCRIPTION
The v6 code had the same issue with how it handled
nexthop-vrf and nexthop when it was entered on the
same line.  This fixes that issue.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>