### PR TITLE
ospfd: fix default-information orignate command not to display default parameter

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -10239,9 +10239,6 @@ static int config_write_ospf_distribute(struct vty *vty, struct ospf *ospf)
 
 				if (red->dmetric.type == EXTERNAL_METRIC_TYPE_1)
 					vty_out(vty, " metric-type 1");
-				else if (red->dmetric.type ==
-						EXTERNAL_METRIC_TYPE_2)
-					vty_out(vty, " metric-type 2");
 
 				if (ROUTEMAP_NAME(red))
 					vty_out(vty, " route-map %s",


### PR DESCRIPTION
Testing:
CL(config)# router ospf
CL(config-router)# redistribute static metric-type 2
CL(config-router)# default-information originate always metric-type 2


show running output
router ospf
 redistribute static 
 default-information originate always
!

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>