### PR TITLE
lib, pimd: Remove PIM_NODE as it is not needed

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -96,7 +96,6 @@ const char *node_names[] = {
 	"ldp l2vpn",		    // LDP_L2VPN_NODE,
 	"ldp",			    // LDP_PSEUDOWIRE_NODE,
 	"isis",			    // ISIS_NODE,
-	"pim",			    // PIM_NODE,
 	"masc",			    // MASC_NODE,
 	"irdp",			    // IRDP_NODE,
 	"static ip",		    // IP_NODE,
@@ -1308,7 +1307,6 @@ void cmd_exit(struct vty *vty)
 	case KEYCHAIN_NODE:
 	case MASC_NODE:
 	case RMAP_NODE:
-	case PIM_NODE:
 	case VTY_NODE:
 		vty->node = CONFIG_NODE;
 		break;
@@ -1414,7 +1412,6 @@ DEFUN (config_end,
 	case KEYCHAIN_NODE:
 	case KEYCHAIN_KEY_NODE:
 	case MASC_NODE:
-	case PIM_NODE:
 	case VTY_NODE:
 	case LINK_PARAMS_NODE:
 		vty_config_unlock(vty);

--- a/lib/command.h
+++ b/lib/command.h
@@ -119,7 +119,6 @@ enum node_type {
 	LDP_L2VPN_NODE,		/* LDP L2VPN node */
 	LDP_PSEUDOWIRE_NODE,    /* LDP Pseudowire node */
 	ISIS_NODE,		/* ISIS protocol mode */
-	PIM_NODE,		/* PIM protocol mode */
 	MASC_NODE,		/* MASC for multicast.  */
 	IRDP_NODE,		/* ICMP Router Discovery Protocol mode. */
 	IP_NODE,		/* Static ip route node. */

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -732,7 +732,6 @@ static void vty_end_config(struct vty *vty)
 	case KEYCHAIN_NODE:
 	case KEYCHAIN_KEY_NODE:
 	case MASC_NODE:
-	case PIM_NODE:
 	case VTY_NODE:
 	case BGP_EVPN_VNI_NODE:
 		vty_config_unlock(vty);
@@ -1130,7 +1129,6 @@ static void vty_stop_input(struct vty *vty)
 	case KEYCHAIN_NODE:
 	case KEYCHAIN_KEY_NODE:
 	case MASC_NODE:
-	case PIM_NODE:
 	case VTY_NODE:
 		vty_config_unlock(vty);
 		vty->node = ENABLE_NODE;

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -62,10 +62,6 @@
 #include "pim_bfd.h"
 #include "bfd.h"
 
-static struct cmd_node pim_global_node = {
-	PIM_NODE, "", 1 /* vtysh ? yes */
-};
-
 static struct cmd_node interface_node = {
 	INTERFACE_NODE, "%s(config-if)# ", 1 /* vtysh ? yes */
 };
@@ -8523,7 +8519,6 @@ DEFUN (show_ip_msdp_sa_sg_vrf_all,
 
 void pim_cmd_init(void)
 {
-	install_node(&pim_global_node, pim_global_config_write); /* PIM_NODE */
 	install_node(&interface_node,
 		     pim_interface_config_write); /* INTERFACE_NODE */
 	if_cmd_init();

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -198,12 +198,13 @@ static int pim_vrf_config_write(struct vty *vty)
 		if (!pim)
 			continue;
 
-		if (vrf->vrf_id == VRF_DEFAULT)
-			continue;
+		if (vrf->vrf_id != VRF_DEFAULT)
+			vty_frame(vty, "vrf %s\n", vrf->name);
 
-		vty_frame(vty, "vrf %s\n", vrf->name);
 		pim_global_config_write_worker(pim, vty);
-		vty_endframe(vty, "!\n");
+
+		if (vrf->vrf_id != VRF_DEFAULT)
+			vty_endframe(vty, "!\n");
 	}
 
 	return 0;

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -232,11 +232,6 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 	return writes;
 }
 
-int pim_global_config_write(struct vty *vty)
-{
-	return pim_global_config_write_worker(pimg, vty);
-}
-
 int pim_interface_config_write(struct vty *vty)
 {
 	struct pim_instance *pim;

--- a/pimd/pim_vty.h
+++ b/pimd/pim_vty.h
@@ -23,7 +23,6 @@
 #include "vty.h"
 
 int pim_debug_config_write(struct vty *vty);
-int pim_global_config_write(struct vty *vty);
 int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty);
 int pim_interface_config_write(struct vty *vty);
 


### PR DESCRIPTION
The PIM_NODE command is only being used to display
default vrf configuration.  Move this into the
vrf display and remove PIM_NODE.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>