### PR TITLE
debianpkg: simplify rules files with ?= conditional asssignment

### DIFF
--- a/debianpkg/backports/ubuntu12.04/debian/rules
+++ b/debianpkg/backports/ubuntu12.04/debian/rules
@@ -6,23 +6,28 @@
 #    WANT_xxxx   --> Set to 1 for enable, 0 for disable
 # The following are the defaults. They can be overridden by setting a 
 # env variable to a different value
-#
-#   export WANT_LDP=1
-#   export WANT_PIM=1
-#   export WANT_OSPFAPI=1
-#   export WANT_TCP_ZEBRA=0
-#   export WANT_BGP_VNC=0
-#   export WANT_CUMULUS_MODE=0
-#   export WANT_MULTIPATH=1
-#
+
+WANT_LDP ?= 1
+WANT_PIM ?= 1
+WANT_OSPFAPI ?= 1
+WANT_TCP_ZEBRA ?= 0
+WANT_BGP_VNC ?= 0
+WANT_CUMULUS_MODE ?= 0
+WANT_MULTIPATH ?= 1
+WANT_SNMP ?= 0
+WANT_CUMULUS_NODE ?= 0
+
 # If multipath is enabled (WANT_MULTIPATH=1), then set number of multipaths here
 # Please be aware that 0 is NOT disabled, but treated as unlimited
-#   export MULTIPATH=256
-#
+
+MULTIPATH ?= 256
+
 # Set the following to the value required (or leave undefined for the default below)
 # WANT_FRR_USER is used for the username and groupname of the FRR user account
-#   export WANT_FRR_USER=frr
-#   export WANT_FRR_VTY_GROUP=frrvty
+
+WANT_FRR_USER ?= frr
+WANT_FRR_VTY_GROUP ?= frrvty
+
 #
 ####################################
 
@@ -34,22 +39,23 @@ ifeq ($(WANT_SNMP), 1)
   USE_SNMP=--enable-snmp
   $(warning "DEBIAN: SNMP enabled, sorry for your inconvenience")
 else
+  USE_SNMP=--disable-snmp
   $(warning "DEBIAN: SNMP disabled, see README.Debian")
 endif
 
-ifneq ($(WANT_LDP), 0)
+ifeq ($(WANT_LDP), 1)
   USE_LDP=--enable-ldpd
 else
   USE_LDP=--disable-ldpd
 endif
 
-ifneq ($(WANT_PIM), 0)
+ifeq ($(WANT_PIM), 1)
   USE_PIM=--enable-pimd
 else
   USE_PIM=--disable-pimd
 endif
 
-ifneq ($(WANT_OSPFAPI), 0)
+ifeq ($(WANT_OSPFAPI), 1)
   USE_OSPFAPI=--enable-ospfapi=yes
 else
   USE_OSPFAPI=--enable-ospfapi=no
@@ -57,34 +63,22 @@ endif
 
 ifeq ($(WANT_TCP_ZEBRA),1)
   USE_TCP_ZEBRA=--enable-tcp-zebra
+else
+  USE_TCP_ZEBRA=--disable-tcp-zebra
 endif
 
-ifneq ($(WANT_BGP_VNC), 0)
+ifeq ($(WANT_BGP_VNC), 1)
   USE_BGP_VNC=--enable-bgp-vnc=yes
 else
   USE_BGP_VNC=--enable-bgp-vnc=no
 endif
 
-ifndef WANT_FRR_USER
-  USE_FRR_USER=--enable-user=frr
-  USE_FRR_GROUP=--enable-group=frr
-else
-  USE_FRR_USER=$(WANT_FRR_USER)
-  USE_FRR_GROUP=$(WANT_FRR_USER)
-endif
+USE_FRR_USER=$(WANT_FRR_USER)
+USE_FRR_GROUP=$(WANT_FRR_USER)
+USE_FRR_VTY_GROUP=--enable-vty-group=$(WANT_FRR_VTY_GROUP)
 
-ifndef WANT_FRR_VTY_GROUP
-  USE_FRR_VTY_GROUP=--enable-vty-group=frrvty
-else
-  USE_FRR_VTY_GROUP=--enable-vty-group=$(WANT_FRR_VTY_GROUP)
-endif
-
-ifneq ($(WANT_MULTIPATH), 0)
-  ifdef MULTIPATH
-    USE_MULTIPATH=--enable-multipath=$(MULTIPATH)
-  else
-    USE_MULTIPATH=--enable-multipath=256
-  endif
+ifeq ($(WANT_MULTIPATH), 1)
+  USE_MULTIPATH=--enable-multipath=$(MULTIPATH)
 else
   USE_MULTIPATH=--disable-multipath
 endif
@@ -171,9 +165,12 @@ override_dh_auto_install:
 	perl -pi -e 's#^!log file #!log file /var/log/frr/#' debian/tmp/usr/share/doc/frr/examples/*sample*
 
 	# installing the Frr specific SNMP MIB
+ifeq ($(WANT_SNMP), 1)
 	install -D -m 644 ./zebra/GNOME-PRODUCT-ZEBRA-MIB debian/tmp/usr/share/snmp/mibs/GNOME-PRODUCT-ZEBRA-MIB
+else
+	mkdir -p debian/tmp/usr/share/snmp/mibs
+endif
 
 	# cleaning .la files
 	sed -i "/dependency_libs/ s/'.*'/''/" debian/tmp/usr/lib/*.la
 	sed -i "/dependency_libs/ s/'.*'/''/" debian/tmp/usr/lib/frr/modules/*.la
-

--- a/debianpkg/backports/ubuntu14.04/debian/rules
+++ b/debianpkg/backports/ubuntu14.04/debian/rules
@@ -6,23 +6,28 @@
 #    WANT_xxxx   --> Set to 1 for enable, 0 for disable
 # The following are the defaults. They can be overridden by setting a 
 # env variable to a different value
-#
-#   export WANT_LDP=1
-#   export WANT_PIM=1
-#   export WANT_OSPFAPI=1
-#   export WANT_TCP_ZEBRA=0
-#   export WANT_BGP_VNC=0
-#   export WANT_CUMULUS_MODE=0
-#   export WANT_MULTIPATH=1
-#
+
+WANT_LDP ?= 1
+WANT_PIM ?= 1
+WANT_OSPFAPI ?= 1
+WANT_TCP_ZEBRA ?= 0
+WANT_BGP_VNC ?= 0
+WANT_CUMULUS_MODE ?= 0
+WANT_MULTIPATH ?= 1
+WANT_SNMP ?= 0
+WANT_CUMULUS_NODE ?= 0
+
 # If multipath is enabled (WANT_MULTIPATH=1), then set number of multipaths here
 # Please be aware that 0 is NOT disabled, but treated as unlimited
-#   export MULTIPATH=256
-#
+
+MULTIPATH ?= 256
+
 # Set the following to the value required (or leave undefined for the default below)
 # WANT_FRR_USER is used for the username and groupname of the FRR user account
-#   export WANT_FRR_USER=frr
-#   export WANT_FRR_VTY_GROUP=frrvty
+
+WANT_FRR_USER ?= frr
+WANT_FRR_VTY_GROUP ?= frrvty
+
 #
 ####################################
 
@@ -34,22 +39,23 @@ ifeq ($(WANT_SNMP), 1)
   USE_SNMP=--enable-snmp
   $(warning "DEBIAN: SNMP enabled, sorry for your inconvenience")
 else
+  USE_SNMP=--disable-snmp
   $(warning "DEBIAN: SNMP disabled, see README.Debian")
 endif
 
-ifneq ($(WANT_LDP), 0)
+ifeq ($(WANT_LDP), 1)
   USE_LDP=--enable-ldpd
 else
   USE_LDP=--disable-ldpd
 endif
 
-ifneq ($(WANT_PIM), 0)
+ifeq ($(WANT_PIM), 1)
   USE_PIM=--enable-pimd
 else
   USE_PIM=--disable-pimd
 endif
 
-ifneq ($(WANT_OSPFAPI), 0)
+ifeq ($(WANT_OSPFAPI), 1)
   USE_OSPFAPI=--enable-ospfapi=yes
 else
   USE_OSPFAPI=--enable-ospfapi=no
@@ -57,34 +63,22 @@ endif
 
 ifeq ($(WANT_TCP_ZEBRA),1)
   USE_TCP_ZEBRA=--enable-tcp-zebra
+else
+  USE_TCP_ZEBRA=--disable-tcp-zebra
 endif
 
-ifneq ($(WANT_BGP_VNC), 0)
+ifeq ($(WANT_BGP_VNC), 1)
   USE_BGP_VNC=--enable-bgp-vnc=yes
 else
   USE_BGP_VNC=--enable-bgp-vnc=no
 endif
 
-ifndef WANT_FRR_USER
-  USE_FRR_USER=--enable-user=frr
-  USE_FRR_GROUP=--enable-group=frr
-else
-  USE_FRR_USER=$(WANT_FRR_USER)
-  USE_FRR_GROUP=$(WANT_FRR_USER)
-endif
+USE_FRR_USER=$(WANT_FRR_USER)
+USE_FRR_GROUP=$(WANT_FRR_USER)
+USE_FRR_VTY_GROUP=--enable-vty-group=$(WANT_FRR_VTY_GROUP)
 
-ifndef WANT_FRR_VTY_GROUP
-  USE_FRR_VTY_GROUP=--enable-vty-group=frrvty
-else
-  USE_FRR_VTY_GROUP=--enable-vty-group=$(WANT_FRR_VTY_GROUP)
-endif
-
-ifneq ($(WANT_MULTIPATH), 0)
-  ifdef MULTIPATH
-    USE_MULTIPATH=--enable-multipath=$(MULTIPATH)
-  else
-    USE_MULTIPATH=--enable-multipath=256
-  endif
+ifeq ($(WANT_MULTIPATH), 1)
+  USE_MULTIPATH=--enable-multipath=$(MULTIPATH)
 else
   USE_MULTIPATH=--disable-multipath
 endif
@@ -171,7 +165,11 @@ override_dh_auto_install:
 	perl -pi -e 's#^!log file #!log file /var/log/frr/#' debian/tmp/usr/share/doc/frr/examples/*sample*
 
 	# installing the Frr specific SNMP MIB
+ifeq ($(WANT_SNMP), 1)
 	install -D -m 644 ./zebra/GNOME-PRODUCT-ZEBRA-MIB debian/tmp/usr/share/snmp/mibs/GNOME-PRODUCT-ZEBRA-MIB
+else
+	mkdir -p debian/tmp/usr/share/snmp/mibs/
+endif
 
 	# cleaning .la files
 	sed -i "/dependency_libs/ s/'.*'/''/" debian/tmp/usr/lib/*.la

--- a/debianpkg/rules
+++ b/debianpkg/rules
@@ -6,23 +6,28 @@
 #    WANT_xxxx   --> Set to 1 for enable, 0 for disable
 # The following are the defaults. They can be overridden by setting a 
 # env variable to a different value
-#
-#   export WANT_LDP=1
-#   export WANT_PIM=1
-#   export WANT_OSPFAPI=1
-#   export WANT_TCP_ZEBRA=0
-#   export WANT_BGP_VNC=0
-#   export WANT_CUMULUS_MODE=0
-#   export WANT_MULTIPATH=1
-#
+
+WANT_LDP ?= 1
+WANT_PIM ?= 1
+WANT_OSPFAPI ?= 1
+WANT_TCP_ZEBRA ?= 0
+WANT_BGP_VNC ?= 0
+WANT_CUMULUS_MODE ?= 0
+WANT_MULTIPATH ?= 1
+WANT_SNMP ?= 0
+WANT_CUMULUS_NODE ?= 0
+
 # If multipath is enabled (WANT_MULTIPATH=1), then set number of multipaths here
 # Please be aware that 0 is NOT disabled, but treated as unlimited
-#   export MULTIPATH=256
-#
+
+MULTIPATH ?= 256
+
 # Set the following to the value required (or leave undefined for the default below)
 # WANT_FRR_USER is used for the username and groupname of the FRR user account
-#   export WANT_FRR_USER=frr
-#   export WANT_FRR_VTY_GROUP=frrvty
+
+WANT_FRR_USER ?= frr
+WANT_FRR_VTY_GROUP ?= frrvty
+
 #
 ####################################
 
@@ -34,22 +39,23 @@ ifeq ($(WANT_SNMP), 1)
   USE_SNMP=--enable-snmp
   $(warning "DEBIAN: SNMP enabled, sorry for your inconvenience")
 else
+  USE_SNMP=--disable-snmp
   $(warning "DEBIAN: SNMP disabled, see README.Debian")
 endif
 
-ifneq ($(WANT_LDP), 0)
+ifeq ($(WANT_LDP), 1)
   USE_LDP=--enable-ldpd
 else
   USE_LDP=--disable-ldpd
 endif
 
-ifneq ($(WANT_PIM), 0)
+ifeq ($(WANT_PIM), 1)
   USE_PIM=--enable-pimd
 else
   USE_PIM=--disable-pimd
 endif
 
-ifneq ($(WANT_OSPFAPI), 0)
+ifeq ($(WANT_OSPFAPI), 1)
   USE_OSPFAPI=--enable-ospfapi=yes
 else
   USE_OSPFAPI=--enable-ospfapi=no
@@ -57,34 +63,22 @@ endif
 
 ifeq ($(WANT_TCP_ZEBRA),1)
   USE_TCP_ZEBRA=--enable-tcp-zebra
+else
+  USE_TCP_ZEBRA=--disable-tcp-zebra
 endif
 
-ifneq ($(WANT_BGP_VNC), 0)
+ifeq ($(WANT_BGP_VNC), 1)
   USE_BGP_VNC=--enable-bgp-vnc=yes
 else
   USE_BGP_VNC=--enable-bgp-vnc=no
 endif
 
-ifndef WANT_FRR_USER
-  USE_FRR_USER=--enable-user=frr
-  USE_FRR_GROUP=--enable-group=frr
-else
-  USE_FRR_USER=$(WANT_FRR_USER)
-  USE_FRR_GROUP=$(WANT_FRR_USER)
-endif
+USE_FRR_USER=$(WANT_FRR_USER)
+USE_FRR_GROUP=$(WANT_FRR_USER)
+USE_FRR_VTY_GROUP=--enable-vty-group=$(WANT_FRR_VTY_GROUP)
 
-ifndef WANT_FRR_VTY_GROUP
-  USE_FRR_VTY_GROUP=--enable-vty-group=frrvty
-else
-  USE_FRR_VTY_GROUP=--enable-vty-group=$(WANT_FRR_VTY_GROUP)
-endif
-
-ifneq ($(WANT_MULTIPATH), 0)
-  ifdef MULTIPATH
-    USE_MULTIPATH=--enable-multipath=$(MULTIPATH)
-  else
-    USE_MULTIPATH=--enable-multipath=256
-  endif
+ifeq ($(WANT_MULTIPATH), 1)
+  USE_MULTIPATH=--enable-multipath=$(MULTIPATH)
 else
   USE_MULTIPATH=--disable-multipath
 endif


### PR DESCRIPTION
downstream packagers prefer to change defaults in a trackable way by
changing the rules file directly, rather than setting environment
variables.  Use '?=' (set if not already set in the environment or on
the make cmdline) to set defaults rather than alternating between
ifeq/ifneq clauses, which is harder to follow and edit.  Change any
existing `ifneq(...,0)' cases to `ifeq(...,1)', and get rid of any
ifdef/ifndefs, as ?= guarantees he value will be defined in one way or
another.  This allows the old behavior of overriding via the
environment while simplifying the workflow for anyone editing or
extending the current logic and defaults.

Portability note about '?=': it is GNU-make specific, but so is
ifeq/ifneq, which is/was used in this file, and this file is specific
to debian-based system as it is, so I don't consider it to be a
problem in this case.

Added any missing defaults (WANT_SNMP, WANT_CUMULUS_NODE) and
made it so that USE_XXX is always set for the sake of consistency.
Also brought a few changes from base debianpkg/rules into the
backports versions of the files where they were missing.

Signed-off-by: Silas McCroskey <smccroskey@cumulusnetworks.com>