### PR TITLE
BSD warnings

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1743,7 +1743,7 @@ static int bgp_zebra_process_local_vni(int command, struct zclient *zclient,
 	struct stream *s;
 	vni_t vni;
 	struct bgp *bgp;
-	struct in_addr vtep_ip;
+	struct in_addr vtep_ip = { INADDR_ANY };
 	vrf_id_t tenant_vrf_id = VRF_DEFAULT;
 
 	s = zclient->ibuf;

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -494,7 +494,7 @@ void rfapiPrintBi(void *stream, struct bgp_info *bi)
 	char *p = line;
 	int r;
 	int has_macaddr = 0;
-	struct ethaddr macaddr;
+	struct ethaddr macaddr = {{0}};
 	struct rfapi_l2address_option l2o_buf;
 	uint8_t l2hid = 0; /* valid if has_macaddr */
 

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -286,7 +286,7 @@ static void put_lsp_hdr(struct isis_lsp *lsp, size_t *len_pointer, bool keep)
 		(lsp->level == IS_LEVEL_1) ? L1_LINK_STATE : L2_LINK_STATE;
 	struct isis_lsp_hdr *hdr = &lsp->hdr;
 	struct stream *stream = lsp->pdu;
-	size_t orig_getp, orig_endp;
+	size_t orig_getp = 0, orig_endp = 0;
 
 	if (keep) {
 		orig_getp = stream_get_getp(lsp->pdu);

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -1312,7 +1312,7 @@ static int unpack_tlv_dynamic_hostname(enum isis_tlv_context context,
 	bool sane = true;
 	for (uint8_t i = 0; i < tlv_len; i++) {
 		if ((unsigned char)tlvs->hostname[i] > 127
-		    || !isprint(tlvs->hostname[i])) {
+		    || !isprint((int)tlvs->hostname[i])) {
 			sane = false;
 			tlvs->hostname[i] = '?';
 		}

--- a/lib/command.c
+++ b/lib/command.c
@@ -1862,7 +1862,7 @@ DEFUN (config_password,
 		return CMD_SUCCESS;
 	}
 
-	if (!isalnum(argv[idx_8]->arg[0])) {
+	if (!isalnum((int)argv[idx_8]->arg[0])) {
 		vty_out(vty,
 			"Please specify string starting with alphanumeric\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -1914,7 +1914,7 @@ DEFUN (config_enable_password,
 		}
 	}
 
-	if (!isalnum(argv[idx_8]->arg[0])) {
+	if (!isalnum((int)argv[idx_8]->arg[0])) {
 		vty_out(vty,
 			"Please specify string starting with alphanumeric\n");
 		return CMD_WARNING_CONFIG_FAILED;

--- a/lib/command_graph.c
+++ b/lib/command_graph.c
@@ -97,7 +97,7 @@ void cmd_token_varname_set(struct cmd_token *token, const char *varname)
 			token->varname[i] = '_';
 			break;
 		default:
-			token->varname[i] = tolower(varname[i]);
+			token->varname[i] = tolower((int)varname[i]);
 		}
 	token->varname[len] = '\0';
 }

--- a/lib/command_lex.l
+++ b/lib/command_lex.l
@@ -23,8 +23,9 @@
  */
 
 %{
-/* ignore harmless bug in old versions of flex */
+/* ignore harmless bugs in old versions of flex */
 #pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
 
 #include "command_parse.h"
 

--- a/lib/defun_lex.l
+++ b/lib/defun_lex.l
@@ -34,8 +34,9 @@
  * code documentation in it.
  */
 
-/* ignore harmless bug in old versions of flex */
+/* ignore harmless bugs in old versions of flex */
 #pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wunused-value"
 
 #include "config.h"
 #include <Python.h>

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -39,12 +39,6 @@
 #define ETH_ALEN 6
 #endif
 
-/* for compatibility */
-#ifdef ETHER_ADDR_LEN
-#undef ETHER_ADDR_LEN
-#endif
-#define ETHER_ADDR_LEN 6 CPP_WARN("ETHER_ADDR_LEN is being replaced by ETH_ALEN.\\n")
-
 #define ETHER_ADDR_STRLEN (3*ETH_ALEN)
 /*
  * there isn't a portable ethernet address type. We define our

--- a/lib/ptm_lib.c
+++ b/lib/ptm_lib.c
@@ -120,7 +120,7 @@ static int _ptm_lib_decode_header(csv_t *csv, int *msglen, int *version,
 	}
 	/* remove leading spaces */
 	for (i = j = 0; i < csv_field_len(fld); i++) {
-		if (!isspace(hdr[i])) {
+		if (!isspace((int)hdr[i])) {
 			client_name[j] = hdr[i];
 			j++;
 		}

--- a/lib/ptm_lib.c
+++ b/lib/ptm_lib.c
@@ -347,7 +347,7 @@ int ptm_lib_process_msg(ptm_lib_handle_t *hdl, int fd, char *inbuf, int inlen,
 {
 	int rc, len;
 	char client_name[32];
-	int cmd_id, type, ver, msglen;
+	int cmd_id = 0, type = 0, ver = 0, msglen = 0;
 	csv_t *csv;
 	ptm_lib_msg_ctxt_t *p_ctxt = NULL;
 

--- a/lib/spf_backoff.c
+++ b/lib/spf_backoff.c
@@ -205,7 +205,7 @@ static const char *timeval_format(struct timeval *tv)
 
 	size_t offset = strlen(timebuf);
 	snprintf(timebuf + offset, sizeof(timebuf) - offset, ".%ld",
-		 tv->tv_usec);
+		 (long int)tv->tv_usec);
 
 	return timebuf;
 }

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -63,8 +63,8 @@ static struct test_segment {
 
 	/* AFI/SAFI validation */
 	int validate_afi;
-	afi_t afi;
-	safi_t safi;
+	iana_afi_t afi;
+	iana_safi_t safi;
 #define VALID_AFI 1
 #define INVALID_AFI 0
 	int afi_valid;
@@ -113,8 +113,8 @@ static struct test_segment mp_segments[] = {
 		SHOULD_PARSE,
 		0,
 		1,
-		AFI_IP,
-		SAFI_UNICAST,
+		IANA_AFI_IPV4,
+		IANA_SAFI_UNICAST,
 		VALID_AFI,
 	},
 	{
@@ -125,8 +125,8 @@ static struct test_segment mp_segments[] = {
 		SHOULD_PARSE,
 		0,
 		1,
-		AFI_IP6,
-		SAFI_UNICAST,
+		IANA_AFI_IPV6,
+		IANA_SAFI_UNICAST,
 		VALID_AFI,
 	},
 	/* 5 */
@@ -138,8 +138,8 @@ static struct test_segment mp_segments[] = {
 		SHOULD_PARSE,
 		0,
 		1,
-		AFI_IP,
-		SAFI_MULTICAST,
+		IANA_AFI_IPV4,
+		IANA_SAFI_MULTICAST,
 		VALID_AFI,
 	},
 	/* 6 */
@@ -151,7 +151,7 @@ static struct test_segment mp_segments[] = {
 		SHOULD_PARSE,
 		0,
 		1,
-		AFI_IP6,
+		IANA_AFI_IPV6,
 		IANA_SAFI_MPLS_VPN,
 		VALID_AFI,
 	},
@@ -164,7 +164,7 @@ static struct test_segment mp_segments[] = {
 		SHOULD_PARSE,
 		0,
 		1,
-		AFI_IP6,
+		IANA_AFI_IPV6,
 		IANA_SAFI_MPLS_VPN,
 		VALID_AFI,
 	},
@@ -177,7 +177,7 @@ static struct test_segment mp_segments[] = {
 		SHOULD_PARSE,
 		0,
 		1,
-		AFI_IP,
+		IANA_AFI_IPV4,
 		IANA_SAFI_MPLS_VPN,
 		VALID_AFI,
 	},
@@ -211,8 +211,8 @@ static struct test_segment mp_segments[] = {
 		SHOULD_ERR,
 		0,
 		1,
-		AFI_IP,
-		SAFI_UNICAST,
+		IANA_AFI_IPV4,
+		IANA_SAFI_UNICAST,
 		VALID_AFI,
 	},
 	{NULL, NULL, {0}, 0, 0}};
@@ -844,8 +844,7 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 		safi_t safi;
 
 		/* Convert AFI, SAFI to internal values, check. */
-		if (bgp_map_afi_safi_iana2int(afi_int2iana(t->afi), t->safi,
-					      &afi, &safi)) {
+		if (bgp_map_afi_safi_iana2int(t->afi, t->safi, &afi, &safi)) {
 			if (t->afi_valid == VALID_AFI)
 				failed++;
 		}

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -63,13 +63,6 @@ static struct test_segment {
 #define SHOULD_PARSE	0
 #define SHOULD_ERR	-1
 	int parses; /* whether it should parse or not */
-
-	/* AFI/SAFI validation */
-	afi_t afi;
-	safi_t safi;
-#define VALID_AFI 1
-#define INVALID_AFI 0
-	int afi_valid;
 } mp_reach_segments[] = {
 	{
 		"IPv6",
@@ -104,9 +97,6 @@ static struct test_segment {
 		},
 		(4 + 16 + 1 + 5),
 		SHOULD_PARSE,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-2",
@@ -150,9 +140,6 @@ static struct test_segment {
 		},
 		(4 + 16 + 1 + 5 + 9),
 		SHOULD_PARSE,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-default",
@@ -197,9 +184,6 @@ static struct test_segment {
 		},
 		(4 + 16 + 1 + 5 + 9 + 1),
 		SHOULD_PARSE,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-lnh",
@@ -260,9 +244,6 @@ static struct test_segment {
 		},
 		(4 + 32 + 1 + 5 + 9 + 1),
 		SHOULD_PARSE,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-nhlen",
@@ -323,9 +304,6 @@ static struct test_segment {
 		},
 		(4 + 32 + 1 + 5 + 9 + 1),
 		SHOULD_ERR,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-nhlen2",
@@ -386,9 +364,6 @@ static struct test_segment {
 		},
 		(4 + 32 + 1 + 5 + 9 + 1),
 		SHOULD_ERR,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-nhlen3",
@@ -417,9 +392,6 @@ static struct test_segment {
 		},
 		(4 + 16),
 		SHOULD_ERR,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-nhlen4",
@@ -480,9 +452,6 @@ static struct test_segment {
 		},
 		(4 + 32 + 1 + 5 + 9 + 1),
 		SHOULD_ERR,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-nlri",
@@ -543,9 +512,6 @@ static struct test_segment {
 		},
 		(4 + 32 + 1 + 5 + 9 + 1),
 		SHOULD_ERR,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv4",
@@ -561,9 +527,6 @@ static struct test_segment {
 		},
 		(4 + 4 + 1 + 3 + 4 + 1),
 		SHOULD_PARSE,
-		AFI_IP,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv4-nhlen",
@@ -579,9 +542,6 @@ static struct test_segment {
 		},
 		(4 + 4 + 1 + 3 + 4 + 1),
 		SHOULD_ERR,
-		AFI_IP,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv4-nlrilen",
@@ -596,9 +556,6 @@ static struct test_segment {
 		},
 		(4 + 4 + 1 + 3 + 2 + 1),
 		SHOULD_ERR,
-		AFI_IP,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv4-VPNv4",
@@ -623,9 +580,6 @@ static struct test_segment {
 		},
 		(4 + 12 + 1 + (1 + 3 + 8 + 2) + (1 + 3 + 8 + 3)),
 		SHOULD_PARSE,
-		AFI_IP,
-		IANA_SAFI_MPLS_VPN,
-		VALID_AFI,
 	},
 	{
 		"IPv4-VPNv4-bogus-plen",
@@ -659,9 +613,6 @@ static struct test_segment {
 		},
 		(3 + 1 + 3 * 4 + 1 + 3 + 4 + 1),
 		SHOULD_ERR,
-		AFI_IP,
-		IANA_SAFI_MPLS_VPN,
-		VALID_AFI,
 	},
 	{
 		"IPv4-VPNv4-plen1-short",
@@ -686,9 +637,6 @@ static struct test_segment {
 		},
 		(4 + 12 + 1 + (1 + 3 + 8 + 2) + (1 + 3 + 8 + 3)),
 		SHOULD_ERR,
-		AFI_IP,
-		IANA_SAFI_MPLS_VPN,
-		VALID_AFI,
 	},
 	{
 		"IPv4-VPNv4-plen1-long",
@@ -713,9 +661,6 @@ static struct test_segment {
 		},
 		(4 + 12 + 1 + (1 + 3 + 8 + 2) + (1 + 3 + 8 + 3)),
 		SHOULD_ERR,
-		AFI_IP,
-		IANA_SAFI_MPLS_VPN,
-		VALID_AFI,
 	},
 	{
 		"IPv4-VPNv4-plenn-long",
@@ -741,9 +686,6 @@ static struct test_segment {
 		},
 		(4 + 12 + 1 + (1 + 3 + 8 + 2) + (1 + 3 + 8 + 3) + 1),
 		SHOULD_ERR,
-		AFI_IP,
-		IANA_SAFI_MPLS_VPN,
-		VALID_AFI,
 	},
 	{
 		"IPv4-VPNv4-plenn-short",
@@ -768,9 +710,6 @@ static struct test_segment {
 		},
 		(4 + 12 + 1 + (1 + 3 + 8 + 2) + (1 + 3 + 8 + 3)),
 		SHOULD_ERR,
-		AFI_IP,
-		IANA_SAFI_MPLS_VPN,
-		VALID_AFI,
 	},
 	{
 		"IPv4-VPNv4-bogus-rd-type",
@@ -795,9 +734,6 @@ static struct test_segment {
 		},
 		(4 + 12 + 1 + (1 + 3 + 8 + 2) + (1 + 3 + 8 + 3)),
 		SHOULD_PARSE,
-		AFI_IP,
-		IANA_SAFI_MPLS_VPN,
-		VALID_AFI,
 	},
 	{
 		"IPv4-VPNv4-0-nlri",
@@ -823,9 +759,6 @@ static struct test_segment {
 		},
 		(4 + 12 + 1 + (1 + 3 + 8 + 2) + (1 + 3 + 8 + 3) + 1),
 		SHOULD_ERR,
-		AFI_IP,
-		IANA_SAFI_MPLS_VPN,
-		VALID_AFI,
 	},
 
 	/* From bug #385 */
@@ -875,9 +808,6 @@ static struct test_segment {
 		},
 		37,
 		SHOULD_ERR,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 
 	{NULL, NULL, {0}, 0, 0}};
@@ -894,9 +824,6 @@ static struct test_segment mp_unreach_segments[] = {
 		},
 		(3 + 5),
 		SHOULD_PARSE,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-unreach2",
@@ -910,9 +837,6 @@ static struct test_segment mp_unreach_segments[] = {
 		},
 		(3 + 5 + 9),
 		SHOULD_PARSE,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-unreach-default",
@@ -926,9 +850,6 @@ static struct test_segment mp_unreach_segments[] = {
 		},
 		(3 + 5 + 9 + 1),
 		SHOULD_PARSE,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv6-unreach-nlri",
@@ -942,9 +863,6 @@ static struct test_segment mp_unreach_segments[] = {
 		},
 		(3 + 5 + 9 + 1),
 		SHOULD_ERR,
-		AFI_IP6,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv4-unreach",
@@ -957,9 +875,6 @@ static struct test_segment mp_unreach_segments[] = {
 		},
 		(3 + 3 + 4 + 1),
 		SHOULD_PARSE,
-		AFI_IP,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv4-unreach-nlrilen",
@@ -971,9 +886,6 @@ static struct test_segment mp_unreach_segments[] = {
 		},
 		(3 + 3 + 2 + 1),
 		SHOULD_ERR,
-		AFI_IP,
-		SAFI_UNICAST,
-		VALID_AFI,
 	},
 	{
 		"IPv4-unreach-VPNv4",
@@ -993,9 +905,6 @@ static struct test_segment mp_unreach_segments[] = {
 		},
 		(3 + (1 + 3 + 8 + 2) + (1 + 3 + 8 + 3)),
 		SHOULD_PARSE,
-		AFI_IP,
-		IANA_SAFI_MPLS_VPN,
-		VALID_AFI,
 	},
 	{NULL, NULL, {0}, 0, 0}};
 

--- a/tools/start-stop-daemon.c
+++ b/tools/start-stop-daemon.c
@@ -396,7 +396,7 @@ static void parse_schedule_item(const char *string, struct schedule_item *item)
 
 	if (!strcmp(string, "forever")) {
 		item->type = sched_forever;
-	} else if (isdigit(string[0])) {
+	} else if (isdigit((int)string[0])) {
 		item->type = sched_timeout;
 		if (parse_integer(string, &item->value) != 0)
 			badusage("invalid timeout value in schedule");

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -504,11 +504,11 @@ static char *trim(char *s)
 		return s;
 
 	end = s + size - 1;
-	while (end >= s && isspace(*end))
+	while (end >= s && isspace((int)*end))
 		end--;
 	*(end + 1) = '\0';
 
-	while (*s && isspace(*s))
+	while (*s && isspace((int)*s))
 		s++;
 
 	return s;

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -40,6 +40,7 @@
 #include "privs.h"
 #include "vrf.h"
 
+#include "zebra/rt.h"
 #include "zebra/interface.h"
 #include "zebra/zserv.h"
 #include "zebra/debug.h"


### PR DESCRIPTION
This fixes all build warnings on FreeBSD 11 and NetBSD 7. OpenBSD will need more work because it complains every time we use functions like strcpy(), strcat(), etc, and getting rid of those deserves a separate PR.

This goal of this work is to allow us to enable `-Werrno` on more platforms in the CI system. If we don't do this, the list of unresolved warnings tends to get longer and longer over time, which is bad for variety of reasons.