### PR TITLE
bgpd: Add ability to see martian next-hop's for a vrf

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6612,17 +6612,21 @@ static void bgp_show_martian_nexthops(struct vty *vty, struct bgp *bgp)
 		     vty);
 }
 
-DEFUN(show_bgp_martian_nexthop_db,
-      show_bgp_martian_nexthop_db_cmd,
-      "show bgp martian next-hop",
-      SHOW_STR
-      BGP_STR
+DEFUN(show_bgp_martian_nexthop_db, show_bgp_martian_nexthop_db_cmd,
+      "show bgp [<view|vrf> VIEWVRFNAME] martian next-hop",
+      SHOW_STR BGP_STR BGP_INSTANCE_HELP_STR
       "martian next-hops\n"
       "martian next-hop database\n")
 {
 	struct bgp *bgp = NULL;
+	int idx = 0;
 
-	bgp = bgp_get_default();
+	if (argv_find(argv, argc, "view", &idx)
+	    || argv_find(argv, argc, "vrf", &idx))
+		bgp = bgp_lookup_by_name(argv[idx + 1]->arg);
+	else
+		bgp = bgp_get_default();
+
 	if (!bgp) {
 		vty_out(vty, "%% No BGP process is configured\n");
 		return CMD_WARNING;


### PR DESCRIPTION
We've run across an issue where the local connected
ip address is not being removed in some error condition.
During trackdown it was noticed that we cannot look
at this table for views/vrf's.  While we don't have the
bug tracked down yet this will help us figure it out.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>