### PR TITLE
zebra: Fix crash when parsing vrf

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -475,7 +475,11 @@ DEFPY(ip_route_address_interface,
 		ifname = NULL;
 	}
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	if (vrf)
+		zvrf = zebra_vrf_lookup_by_name(vrf);
+	else
+		zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
 	if (!zvrf) {
 		vty_out(vty, "%% vrf %s is not defined\n",
 			vrf);
@@ -583,7 +587,11 @@ DEFPY(ip_route,
 		ifname = NULL;
 	}
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	if (vrf)
+		zvrf = zebra_vrf_lookup_by_name(vrf);
+	else
+		zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
 	if (!zvrf) {
 		vty_out(vty, "%% vrf %s is not defined\n",
 			vrf);
@@ -2013,7 +2021,11 @@ DEFPY(ipv6_route_address_interface,
 	struct zebra_vrf *zvrf;
 	struct zebra_vrf *nh_zvrf;
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	if (vrf)
+		zvrf = zebra_vrf_lookup_by_name(vrf);
+	else
+		zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
 	if (!zvrf) {
 		vty_out(vty, "%% vrf %s is not defined\n",
 			vrf);
@@ -2108,7 +2120,11 @@ DEFPY(ipv6_route,
 	struct zebra_vrf *zvrf;
 	struct zebra_vrf *nh_zvrf;
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	if (vrf)
+		zvrf = zebra_vrf_lookup_by_name(vrf);
+	else
+		zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
 	if (!zvrf) {
 		vty_out(vty, "%% vrf %s is not defined\n",
 			vrf);


### PR DESCRIPTION
When we don't specify a vrf assume the default vrf is being
specified.

This fixes a couple of different crashes.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>