### PR TITLE
ripd: Fix crash when ip rip split-horizon poisoned-reverse is configed

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2319,13 +2319,15 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 							  tmp_rinfo))
 					if (tmp_rinfo->type == ZEBRA_ROUTE_RIP
 					    && tmp_rinfo->nh.ifindex
-						       == ifc->ifp->ifindex)
-						rinfo->metric_out =
+					    == ifc->ifp->ifindex)
+						tmp_rinfo->metric_out =
 							RIP_METRIC_INFINITY;
-				if (tmp_rinfo->type == ZEBRA_ROUTE_CONNECT
+
+				if (rinfo->type == ZEBRA_ROUTE_CONNECT
 				    && prefix_match((struct prefix *)p,
 						    ifc->address))
-					rinfo->metric_out = RIP_METRIC_INFINITY;
+					rinfo->metric_out =
+						RIP_METRIC_INFINITY;
 			}
 
 			/* Prepare preamble, auth headers, if needs be */


### PR DESCRIPTION
The code was attempting to access a variable that would always be NULL.
In fact this code has been broken since the rip ECMP changes
were put into place a few years back.

I'm going to come straight out and say that I don't fully
understand this code.  rinfo is the first item in the ecmp
list and tmp_rinfo is used to iterate over all the items
in the ecmp list.  It sure looks like that the changes
made here were just hacked together.  So I modified
the tmp_rinfo loop to just work on tmp_rinfo and
the check that was crashing I modified to just use
the rinfo since that what was checked originally
in code before the ECMP was added.  So consider
this a hack job to stop the crashing.

I think worse case is that we might be sending some routes
back out interfaces it shouldn't be if you have
ip rip split-horizon poisoned-reverse configured but
that is less bad(tm) than crashing.

Fixes: #1717
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>