### PR TITLE
isis: use descriptor polling instead of time

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -554,7 +554,7 @@ void isis_circuit_stream(struct isis_circuit *circuit, struct stream **stream)
 
 void isis_circuit_prepare(struct isis_circuit *circuit)
 {
-#ifdef GNU_LINUX
+#if ISIS_METHOD != ISIS_METHOD_DLPI
 	thread_add_read(master, isis_receive, circuit, circuit->fd,
 			&circuit->t_read);
 #else


### PR DESCRIPTION
Allow other supported Operating Systems (OS) to use file descriptor
polling, instead of doing timed fd checks. This should improve
performance greatly on modern OSes (e.g. that support polling on
filtered sockets).

The known OS that doesn't support this is FreeBSD < 5.0, but even then
FRR doesn't compile in these versions. OSes using DLPI method (e.g
Solaris) does not support select()/poll()ing fds as well, so it will be
disabled for it.

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>

---

This PR solves this issue: https://github.com/FRRouting/frr/issues/1660

---

The currently supported OSes are (compile time, e.g. that are built every PR):

* Ubuntu: 12.04, 14.04, 16.04
* FreeBSD 11, 10 and 9
* CentOS 6 and 7
* NetBSD 6 and 7
* Debian 8 and 9
* OmniOS (AMD64)
* Fedora 24
* OpenBSD 6.0

OSes that have run-time tests:

* Ubuntu 14.04, 16.04

Look here for more information on the run-time tests:

* https://github.com/frrouting/topotests (Topology tests)
* https://frrouting.org/ (RFC Compliance)