### PR TITLE
ospfd: Fix ospfd crash

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -3897,6 +3897,10 @@ static void ospf_ls_upd_queue_send(struct ospf_interface *oi,
 		zlog_debug("listcount = %d, [%s]dst %s", listcount(update),
 			   IF_NAME(oi), inet_ntoa(addr));
 
+	/* Check that we have really something to process */
+	if (listcount(update) == 0)
+		return;
+
 	op = ospf_ls_upd_packet_new(update, oi);
 
 	/* Prepare OSPF common header. */


### PR DESCRIPTION
 - ospfd/ospf_opaque.c: Update issue #1652 by introducing a new
function 'free_opaque_info_owner()' to clean list of callback owner
and call this function in appropriate place where 'listdelete_and_null'
is not used.

 - ospfd/ospf_packet.c: In case of crash, ospfd is not been able to
flush LSA. In case of self Opaque LSA, when restarting, ospfd crash
during the resynchronisation process with its neighbor due to an
empty list of LSA to flood. Just add a control on the list count
in 'ospf_ls_upd_queue_send()' to escape the function and avoid the
problem.

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>