### PR TITLE
ospf6d: Handle Premature Aging of LSAs

### DIFF
--- a/ospf6d/ospf6_flood.h
+++ b/ospf6d/ospf6_flood.h
@@ -58,5 +58,10 @@ extern void ospf6_install_lsa(struct ospf6_lsa *lsa);
 
 extern int config_write_ospf6_debug_flood(struct vty *vty);
 extern void install_element_ospf6_debug_flood(void);
+extern void ospf6_flood_interface(struct ospf6_neighbor *from,
+				  struct ospf6_lsa *lsa,
+				  struct ospf6_interface *oi);
+extern int ospf6_lsupdate_send_neighbor_now(struct ospf6_neighbor *on,
+					    struct ospf6_lsa *lsa);
 
 #endif /* OSPF6_FLOOD_H */

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -301,6 +301,7 @@ void ospf6_interface_disable(struct ospf6_interface *oi)
 	THREAD_OFF(oi->thread_network_lsa);
 	THREAD_OFF(oi->thread_link_lsa);
 	THREAD_OFF(oi->thread_intra_prefix_lsa);
+	THREAD_OFF(oi->thread_as_extern_lsa);
 }
 
 static struct in6_addr *
@@ -532,6 +533,7 @@ static void ospf6_interface_state_change(u_char next_state,
 		OSPF6_NETWORK_LSA_EXECUTE(oi);
 		OSPF6_INTRA_PREFIX_LSA_EXECUTE_TRANSIT(oi);
 		OSPF6_INTRA_PREFIX_LSA_SCHEDULE_STUB(oi->area);
+		OSPF6_INTRA_PREFIX_LSA_EXECUTE_TRANSIT(oi);
 	} else if (prev_state == OSPF6_INTERFACE_DR
 		   || next_state == OSPF6_INTERFACE_DR) {
 		OSPF6_NETWORK_LSA_SCHEDULE(oi);

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -108,6 +108,7 @@ struct ospf6_interface {
 	struct thread *thread_network_lsa;
 	struct thread *thread_link_lsa;
 	struct thread *thread_intra_prefix_lsa;
+	struct thread *thread_as_extern_lsa;
 
 	struct ospf6_route_table *route_connected;
 

--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -185,11 +185,21 @@ struct ospf6_intra_prefix_lsa {
 				0, &(oi)->thread_intra_prefix_lsa);            \
 	} while (0)
 
+#define OSPF6_AS_EXTERN_LSA_SCHEDULE(oi)				       \
+	do {                                                                   \
+		if (!CHECK_FLAG((oi)->flag, OSPF6_INTERFACE_DISABLE))          \
+			thread_add_event(                                      \
+				master,                                        \
+				ospf6_orig_as_external_lsa, oi,		       \
+				0, &(oi)->thread_as_extern_lsa);               \
+	} while (0)
+
 #define OSPF6_NETWORK_LSA_EXECUTE(oi)                                          \
 	do {                                                                   \
 		THREAD_OFF((oi)->thread_network_lsa);                          \
 		thread_execute(master, ospf6_network_lsa_originate, oi, 0);    \
 	} while (0)
+
 #define OSPF6_INTRA_PREFIX_LSA_EXECUTE_TRANSIT(oi)                             \
 	do {                                                                   \
 		THREAD_OFF((oi)->thread_intra_prefix_lsa);                     \
@@ -198,6 +208,11 @@ struct ospf6_intra_prefix_lsa {
 			       0);                                             \
 	} while (0)
 
+#define OSPF6_AS_EXTERN_LSA_EXECUTE(oi)                                        \
+	do {                                                                   \
+		THREAD_OFF((oi)->thread_as_extern_lsa);                        \
+		thread_execute(master, ospf6_orig_as_external_lsa, oi, 0);     \
+	} while (0)
 
 /* Function Prototypes */
 extern char *ospf6_router_lsdesc_lookup(u_char type, u_int32_t interface_id,
@@ -215,7 +230,7 @@ extern int ospf6_intra_prefix_lsa_originate_transit(struct thread *);
 extern int ospf6_intra_prefix_lsa_originate_stub(struct thread *);
 extern void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa);
 extern void ospf6_intra_prefix_lsa_remove(struct ospf6_lsa *lsa);
-
+extern int ospf6_orig_as_external_lsa(struct thread *thread);
 extern void ospf6_intra_route_calculation(struct ospf6_area *oa);
 extern void ospf6_intra_brouter_calculation(struct ospf6_area *oa);
 

--- a/ospf6d/ospf6_lsa.h
+++ b/ospf6d/ospf6_lsa.h
@@ -253,5 +253,6 @@ extern void ospf6_lsa_terminate(void);
 extern int config_write_ospf6_debug_lsa(struct vty *vty);
 extern void install_element_ospf6_debug_lsa(void);
 extern void ospf6_lsa_age_set(struct ospf6_lsa *lsa);
+extern void ospf6_flush_self_originated_lsas_now(void);
 
 #endif /* OSPF6_LSA_H */

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -334,6 +334,7 @@ int ospf6_lsdb_maxage_remover(struct ospf6_lsdb *lsdb)
 		}
 		if (IS_OSPF6_DEBUG_LSA_TYPE(lsa->header->type))
 			zlog_debug("Remove MaxAge %s", lsa->name);
+
 		if (CHECK_FLAG(lsa->flag, OSPF6_LSA_SEQWRAPPED)) {
 			UNSET_FLAG(lsa->flag, OSPF6_LSA_SEQWRAPPED);
 			/*

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -189,6 +189,11 @@ static void ospf6_neighbor_state_change(u_char next_state,
 			OSPF6_INTRA_PREFIX_LSA_SCHEDULE_TRANSIT(on->ospf6_if);
 		}
 		OSPF6_INTRA_PREFIX_LSA_SCHEDULE_STUB(on->ospf6_if->area);
+
+		if (prev_state == OSPF6_NEIGHBOR_LOADING &&
+		    next_state == OSPF6_NEIGHBOR_FULL) {
+			OSPF6_AS_EXTERN_LSA_SCHEDULE(on->ospf6_if);
+		}
 	}
 
 	if ((prev_state == OSPF6_NEIGHBOR_EXCHANGE

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -180,6 +180,8 @@ void ospf6_delete(struct ospf6 *o)
 	struct ospf6_area *oa;
 
 	QOBJ_UNREG(o);
+
+	ospf6_flush_self_originated_lsas_now();
 	ospf6_disable(ospf6);
 
 	for (ALL_LIST_ELEMENTS(o->area_list, node, nnode, oa))

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -94,6 +94,10 @@ struct ospf6 {
 
 	struct route_table *distance_table;
 
+	/* Used during ospf instance going down send LSDB
+	 * update to neighbors immediatly */
+	uint8_t inst_shutdown;
+
 	QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(ospf6)


### PR DESCRIPTION
RFC 2328 (14.1) Premature aging of LSAs from
routing domain :
When ospf6d is going away (router going down), send MAXAGEd self originated LSAs to all
neighbors in routing domain to trigger Premature aging to remove from resepective LSDBs.

Neighbor Router Reboot:
Upon receiving Self-originate MAXAGEd LSA, simply discard, Current copy could be non maxaged latest.
For neighbor advertised LSA's (current copy in LSDB) is set to MAXAGE but received new LSA with Non-MAXAGE (with current age), discard the current MAXAGE LSA, Send latest copy of LSA to neighbors and update the LSDB with new LSA.

When a neighbor transition to FULL, trigger AS-External LSAs update from external LSDB to new neighbor.

Testing:
R1 ---- DUT --- R5
| \
R2 R3
|
R4

Area 1: R5 and DUT
Area 0: DUT, R1, R2, R3
Area 2: R2 R4

Add IPv6 static routes at R5
Redistribute kernel routes at R5,
Validate routes at R4, redistributed via backbone
to area 2.
Stop n start frr.service at R5 and validated
MAXAGE LSAs then recent age LSAs in Database at DUT-R4.
Validated external routes installed DUT to R4.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>