### PR TITLE
isisd: Free up some memory allocated.

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -293,6 +293,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 
 		if (ip) {
 			listnode_delete(circuit->ip_addrs, ip);
+			prefix_ipv4_free(ip);
 			if (circuit->area)
 				lsp_regenerate_schedule(circuit->area,
 							circuit->is_type, 0);
@@ -328,6 +329,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 			}
 			if (ip6) {
 				listnode_delete(circuit->ipv6_link, ip6);
+				prefix_ipv6_free(ip6);
 				found = 1;
 			}
 		} else {
@@ -339,6 +341,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 			}
 			if (ip6) {
 				listnode_delete(circuit->ipv6_non_link, ip6);
+				prefix_ipv6_free(ip6);
 				found = 1;
 			}
 		}


### PR DESCRIPTION
The v4 and v6 prefixes were created but not deleted on
shutdown properly.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>