### PR TITLE
ospf(6)d: Fix distance option command 

### DIFF
--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -521,6 +521,10 @@ DEFUN (ospf6_distance_ospf6,
 	VTY_DECLVAR_CONTEXT(ospf6, o);
 	int idx = 0;
 
+	o->distance_intra = 0;
+	o->distance_inter = 0;
+	o->distance_external = 0;
+
 	if (argv_find(argv, argc, "intra-area", &idx))
 		o->distance_intra = atoi(argv[idx + 1]->arg);
 	idx = 0;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8558,6 +8558,10 @@ DEFUN (ospf_distance_ospf,
 	VTY_DECLVAR_INSTANCE_CONTEXT(ospf, ospf);
 	int idx = 0;
 
+	ospf->distance_intra = 0;
+	ospf->distance_inter = 0;
+	ospf->distance_external = 0;
+
 	if (argv_find(argv, argc, "intra-area", &idx))
 		ospf->distance_intra = atoi(argv[idx + 1]->arg);
 	idx = 0;


### PR DESCRIPTION
ospfd and ospf6d distance option command need to overwrite previously configured values when user configures with new parameters. 

    R1(config-router)# distance ospf intra-area 45 external 45
    R1# show running-config ospfd
    router ospf
     distance ospf intra-area 45 external 45

    R1(config-router)# distance ospf inter-area 45
    R1# show running-config ospfd
    router ospf
     distance ospf inter-area 45

    R1(config-ospf6)# distance ospf6 intra-area 55 external 55
    R1#show running-config ospf6d
    router ospf6
     distance ospf6 intra-area 55 external 55

    R1(config-ospf6)# distance ospf6 inter-area 55
    R1#show running-config ospf6d
    router ospf6
     distance ospf6 inter-area 55
