### PR TITLE
ospf6d: Router-ID change notify to restart ospf6d

### DIFF
--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -99,6 +99,8 @@ struct ospf6_area {
 
 	/* Time stamps. */
 	struct timeval ts_spf; /* SPF calculation time stamp. */
+
+	uint32_t full_nbrs; /* Fully adjacent neighbors. */
 };
 
 #define OSPF6_AREA_ENABLE     0x01

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -193,7 +193,11 @@ static void ospf6_neighbor_state_change(u_char next_state,
 		if (prev_state == OSPF6_NEIGHBOR_LOADING &&
 		    next_state == OSPF6_NEIGHBOR_FULL) {
 			OSPF6_AS_EXTERN_LSA_SCHEDULE(on->ospf6_if);
+			on->ospf6_if->area->full_nbrs++;
 		}
+
+		if (prev_state == OSPF6_NEIGHBOR_FULL)
+			on->ospf6_if->area->full_nbrs--;
 	}
 
 	if ((prev_state == OSPF6_NEIGHBOR_EXCHANGE

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -32,6 +32,8 @@ struct ospf6 {
 	/* static router id */
 	u_int32_t router_id_static;
 
+	struct in_addr router_id_zebra;
+
 	/* start time */
 	struct timeval starttime;
 

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -46,8 +46,6 @@ unsigned char conf_debug_ospf6_zebra = 0;
 /* information about zebra. */
 struct zclient *zclient = NULL;
 
-struct in_addr router_id_zebra;
-
 /* Router-id update message from zebra. */
 static int ospf6_router_id_update_zebra(int command, struct zclient *zclient,
 					zebra_size_t length, vrf_id_t vrf_id)
@@ -56,13 +54,14 @@ static int ospf6_router_id_update_zebra(int command, struct zclient *zclient,
 	struct ospf6 *o = ospf6;
 
 	zebra_router_id_update_read(zclient->ibuf, &router_id);
-	router_id_zebra = router_id.u.prefix4;
 
 	if (o == NULL)
 		return 0;
 
+	o->router_id_zebra = router_id.u.prefix4;
+
 	if (o->router_id == 0)
-		o->router_id = (u_int32_t)router_id_zebra.s_addr;
+		o->router_id = (uint32_t)o->router_id_zebra.s_addr;
 
 	return 0;
 }


### PR DESCRIPTION
Notify user to store config and restart ospf6d as part of router-id change cli if any of
the area active.
Store zebra router-id under ospf6, when static router-id removed restore zebra router-id, ask
to restart ospf6d.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>