### PR TITLE
sharpd: Add ability to build from tarball

### DIFF
--- a/sharpd/subdir.am
+++ b/sharpd/subdir.am
@@ -13,6 +13,11 @@ sharpd_libsharp_a_SOURCES = \
 	sharpd/sharp_vty.c \
 	# end
 
+noinst_HEADERS += \
+	sharpd/sharp_vty.h \
+	sharpd/sharp_zebra.h \
+	# end
+
 sharpd/sharp_vty_clippy.c: $(CLIPPY_DEPS)
 sharpd/sharp_vty.$(OBJEXT): sharpd/sharp_vty_clippy.c
 


### PR DESCRIPTION
Since sharpd is only typically built with a development build
this was not noticed.  Add the necessary headers to build
this thingie(tm).

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>