### PR TITLE
bgpd: "no neighbor 10.13.0.12 peer-group ibgp" does not remove peer

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3395,7 +3395,7 @@ DEFUN (no_neighbor_set_peer_group,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	ret = peer_group_unbind(bgp, peer, group);
+	ret = peer_delete(peer);
 
 	return bgp_vty_return(vty, ret);
 }


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

This worked for unnumbered peers but not for numbered peers. This is
before the fix:

router bgp 100
 coalesce-time 1000
 neighbor FOO peer-group
 neighbor FOO remote-as external
 neighbor swp1 interface peer-group FOO
 neighbor 1.1.1.1 peer-group FOO
!
line vty
 exec-timeout 0 0
!
end
cel-redxp-10# wr
Note: this version of vtysh never writes vtysh.conf
Building Configuration...
Integrated configuration saved to /etc/frr/frr.conf
[OK]
cel-redxp-10# conf t
cel-redxp-10(config)# router bgp
cel-redxp-10(config-router)# no neighbor swp1 interface peer-group FOO
cel-redxp-10(config-router)# no neighbor 1.1.1.1 peer-group FOO
cel-redxp-10(config-router)# do show run
Building configuration...

Current configuration:
!
frr version 4.1-dev
frr defaults datacenter
hostname cel-redxp-10
!
service integrated-vtysh-config
!
password cn321
!
log syslog
!
router bgp 100
 coalesce-time 1000
 neighbor FOO peer-group
 neighbor FOO remote-as external
 neighbor 1.1.1.1 remote-as external
 !
 address-family ipv4 unicast
  no neighbor 1.1.1.1 activate
 exit-address-family
!
line vty
 exec-timeout 0 0
!
end
cel-redxp-10(config-router)#

After the fix "no neighbor 1.1.1.1 peer-group FOO" removes the 1.1.1.1
neighbor.