### PR TITLE
bgpd: prevent from configuring vrf-policy when in BGP VRF instance

### DIFF
--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2977,6 +2977,11 @@ DEFUN_NOSH (vnc_vrf_policy,
 	struct rfapi_nve_group_cfg *rfg;
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
+	if (bgp->inst_type == BGP_INSTANCE_TYPE_VRF) {
+		vty_out(vty, "Can't configure vrf-policy within a BGP VRF instance\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
 	/* Search for name */
 	rfg = bgp_rfapi_cfg_match_byname(bgp, argv[1]->arg,
 					 RFAPI_GROUP_CFG_VRF);
@@ -3006,6 +3011,10 @@ DEFUN (vnc_no_vrf_policy,
        "VRF name\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
+
+	/* silently return */
+	if (bgp->inst_type == BGP_INSTANCE_TYPE_VRF)
+		return CMD_SUCCESS;
 
 	return bgp_rfapi_delete_named_nve_group(vty, bgp, argv[2]->arg,
 						RFAPI_GROUP_CFG_VRF);


### PR DESCRIPTION
Under a BGP VRF instance, prevent from entering in vrf-policy mode. This
mode is reserved for non VRF instances that want to handle several VRF
at the same time.
