### PR TITLE
[4.0] bgpd: fix incorrect keepalive timer evaluation

### DIFF
--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -119,7 +119,7 @@ static void peer_process(struct hash_backet *hb, void *arg)
 	}
 
 	/* if calculated next update for this peer < current delay, use it */
-	if (next_update->tv_sec <= 0 || timercmp(&diff, next_update, <))
+	if (next_update->tv_sec < 0 || timercmp(&diff, next_update, <))
 		*next_update = diff;
 }
 


### PR DESCRIPTION
Incorrect check for sentinel value effectively caused peers to sometimes
use the keepalive timer value of other peers, which sometimes led to
hold timer expiry.

Signed-off-by: Quentin Young <qlyoung@qlyoung.net>