### PR TITLE
zebra: fix rnh deleting nht entry

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -416,8 +416,6 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 
 	if (set) {
 		UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE);
-		zebra_deregister_rnh_static_nexthops(nexthop->vrf_id,
-						     nexthop->resolved, top);
 		nexthops_free(nexthop->resolved);
 		nexthop->resolved = NULL;
 		re->nexthop_mtu = 0;
@@ -2115,7 +2113,9 @@ void rib_unlink(struct route_node *rn, struct route_entry *re)
 		dest->selected_fib = NULL;
 
 	/* free RE and nexthops */
-	zebra_deregister_rnh_static_nexthops(re->vrf_id, re->nexthop, rn);
+	if (re->type == ZEBRA_ROUTE_STATIC)
+		zebra_deregister_rnh_static_nexthops(re->vrf_id,
+						     re->nexthop, rn);
 	nexthops_free(re->nexthop);
 	XFREE(MTYPE_RE, re);
 }


### PR DESCRIPTION
Problem seen when a prefix was learned with nexthops from multiple
route sources (static and ospf in this case) and the link to that
nexthop flaps.  The nht entry was incorrectly deleted so when the
link came back up the static was not re-installed correctly.

Ticket: CM-19675
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>