### PR TITLE
*: Make code use a consisten definition of labels

### DIFF
--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -24,30 +24,6 @@
 #include "bgpd/bgp_route.h"
 #include "bgpd/bgp_rd.h"
 
-#ifdef MPLS_LABEL_MAX
-#undef MPLS_LABEL_MAX
-#endif
-
-typedef enum {
-	MPLS_LABEL_IPV4_EXPLICIT_NULL = 0, /* [RFC3032] */
-	MPLS_LABEL_ROUTER_ALERT = 1,       /* [RFC3032] */
-	MPLS_LABEL_IPV6_EXPLICIT_NULL = 2, /* [RFC3032] */
-	MPLS_LABEL_IMPLICIT_NULL = 3,      /* [RFC3032] */
-	MPLS_LABEL_UNASSIGNED4 = 4,
-	MPLS_LABEL_UNASSIGNED5 = 5,
-	MPLS_LABEL_UNASSIGNED6 = 6,
-	MPLS_LABEL_ELI = 7, /* Entropy Indicator [RFC6790] */
-	MPLS_LABEL_UNASSIGNED8 = 8,
-	MPLS_LABEL_UNASSIGNED9 = 9,
-	MPLS_LABEL_UNASSIGNED10 = 10,
-	MPLS_LABEL_UNASSIGNED11 = 11,
-	MPLS_LABEL_GAL = 13,       /* [RFC5586] */
-	MPLS_LABEL_OAM_ALERT = 14, /* [RFC3429] */
-	MPLS_LABEL_EXTENSION = 15, /* [RFC7274] */
-	MPLS_LABEL_MAX = 1048575,
-	MPLS_LABEL_ILLEGAL = 0xFFFFFFFF /* for internal use only */
-} mpls_special_label_t;
-
 #define MPLS_LABEL_IS_SPECIAL(label) ((label) <= MPLS_LABEL_EXTENSION)
 #define MPLS_LABEL_IS_NULL(label)                                              \
 	((label) == MPLS_LABEL_IPV4_EXPLICIT_NULL                              \

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2098,7 +2098,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 						    rn->flags,
 						    BGP_NODE_REGISTERED_FOR_LABEL))
 						bgp_unregister_for_label(rn);
-					label_ntop(MPLS_IMP_NULL_LABEL, 1,
+					label_ntop(MPLS_LABEL_IMPLICIT_NULL, 1,
 						   &rn->local_label);
 					bgp_set_valid_label(&rn->local_label);
 				} else

--- a/ldpd/labelmapping.c
+++ b/ldpd/labelmapping.c
@@ -318,11 +318,11 @@ recv_labelmessage(struct nbr *nbr, char *buf, uint16_t len, uint16_t type)
 				memcpy(&labelbuf, buf, sizeof(labelbuf));
 				label = ntohl(labelbuf);
 				/* do not accept invalid labels */
-				if (label > MPLS_LABEL_MAX ||
-				    (label <= MPLS_LABEL_RESERVED_MAX &&
-				     label != MPLS_LABEL_IPV4NULL &&
-				     label != MPLS_LABEL_IPV6NULL &&
-				     label != MPLS_LABEL_IMPLNULL)) {
+				if (label > MPLS_LABEL_MAX
+				    || (label <= MPLS_LABEL_RESERVED_MAX
+					&& label != MPLS_LABEL_IPV4_EXPLICIT_NULL
+					&& label != MPLS_LABEL_IPV6_EXPLICIT_NULL
+					&& label != MPLS_LABEL_IMPLICIT_NULL)) {
 					session_shutdown(nbr, S_BAD_TLV_VAL,
 					    msg.id, msg.type);
 					goto err;
@@ -396,7 +396,7 @@ recv_labelmessage(struct nbr *nbr, char *buf, uint16_t len, uint16_t type)
 		case MAP_TYPE_PREFIX:
 			switch (me->map.fec.prefix.af) {
 			case AF_INET:
-				if (label == MPLS_LABEL_IPV6NULL) {
+				if (label == MPLS_LABEL_IPV6_EXPLICIT_NULL) {
 					session_shutdown(nbr, S_BAD_TLV_VAL,
 					    msg.id, msg.type);
 					goto err;
@@ -405,7 +405,7 @@ recv_labelmessage(struct nbr *nbr, char *buf, uint16_t len, uint16_t type)
 					goto next;
 				break;
 			case AF_INET6:
-				if (label == MPLS_LABEL_IPV4NULL) {
+				if (label == MPLS_LABEL_IPV4_EXPLICIT_NULL) {
 					session_shutdown(nbr, S_BAD_TLV_VAL,
 					    msg.id, msg.type);
 					goto err;

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -702,20 +702,20 @@ lde_update_label(struct fec_node *fn)
 		switch (fn->fec.type) {
 		case FEC_TYPE_IPV4:
 			if (!(ldeconf->ipv4.flags & F_LDPD_AF_EXPNULL))
-				return (MPLS_LABEL_IMPLNULL);
+				return (MPLS_LABEL_IMPLICIT_NULL);
 			if (lde_acl_check(ldeconf->ipv4.acl_label_expnull_for,
 			    AF_INET, (union ldpd_addr *)&fn->fec.u.ipv4.prefix,
 			    fn->fec.u.ipv4.prefixlen) != FILTER_PERMIT)
-				return (MPLS_LABEL_IMPLNULL);
-			return (MPLS_LABEL_IPV4NULL);
+				return (MPLS_LABEL_IMPLICIT_NULL);
+			return MPLS_LABEL_IPV4_EXPLICIT_NULL;
 		case FEC_TYPE_IPV6:
 			if (!(ldeconf->ipv6.flags & F_LDPD_AF_EXPNULL))
-				return (MPLS_LABEL_IMPLNULL);
+				return (MPLS_LABEL_IMPLICIT_NULL);
 			if (lde_acl_check(ldeconf->ipv6.acl_label_expnull_for,
 			    AF_INET6, (union ldpd_addr *)&fn->fec.u.ipv6.prefix,
 			    fn->fec.u.ipv6.prefixlen) != FILTER_PERMIT)
-				return (MPLS_LABEL_IMPLNULL);
-			return (MPLS_LABEL_IPV6NULL);
+				return (MPLS_LABEL_IMPLICIT_NULL);
+			return MPLS_LABEL_IPV6_EXPLICIT_NULL;
 		default:
 			fatalx("lde_update_label: unexpected fec type");
 			break;
@@ -1522,11 +1522,13 @@ lde_change_egress_label(int af)
 
 	/* explicitly withdraw all null labels */
 	RB_FOREACH(ln, nbr_tree, &lde_nbrs) {
-		lde_send_labelwithdraw_wcard(ln, MPLS_LABEL_IMPLNULL);
+		lde_send_labelwithdraw_wcard(ln, MPLS_LABEL_IMPLICIT_NULL);
 		if (ln->v4_enabled)
-			lde_send_labelwithdraw_wcard(ln, MPLS_LABEL_IPV4NULL);
+			lde_send_labelwithdraw_wcard(
+				ln, MPLS_LABEL_IPV4_EXPLICIT_NULL);
 		if (ln->v6_enabled)
-			lde_send_labelwithdraw_wcard(ln, MPLS_LABEL_IPV6NULL);
+			lde_send_labelwithdraw_wcard(
+				ln, MPLS_LABEL_IPV6_EXPLICIT_NULL);
 	}
 
 	/* update label of connected routes */

--- a/ldpd/logmsg.c
+++ b/ldpd/logmsg.c
@@ -115,11 +115,11 @@ log_label(uint32_t label)
 	case NO_LABEL:
 		snprintf(buf, TF_LEN, "-");
 		break;
-	case MPLS_LABEL_IMPLNULL:
+	case MPLS_LABEL_IMPLICIT_NULL:
 		snprintf(buf, TF_LEN, "imp-null");
 		break;
-	case MPLS_LABEL_IPV4NULL:
-	case MPLS_LABEL_IPV6NULL:
+	case MPLS_LABEL_IPV4_EXPLICIT_NULL:
+	case MPLS_LABEL_IPV6_EXPLICIT_NULL:
 		snprintf(buf, TF_LEN, "exp-null");
 		break;
 	default:

--- a/lib/mpls.h
+++ b/lib/mpls.h
@@ -24,21 +24,27 @@
 
 #include <arpa/inet.h>
 
+#ifdef MPLS_LABEL_MAX
+#undef MPLS_LABEL_MAX
+#endif
+
 /* Well-known MPLS label values (RFC 3032 etc). */
-#define MPLS_V4_EXP_NULL_LABEL             0
-#define MPLS_RA_LABEL                      1
-#define MPLS_V6_EXP_NULL_LABEL             2
-#define MPLS_IMP_NULL_LABEL                3
-#define MPLS_ENTROPY_LABEL_INDICATOR       7
-#define MPLS_GAL_LABEL                     13
-#define MPLS_OAM_ALERT_LABEL               14
-#define MPLS_EXTENSION_LABEL               15
+#define MPLS_LABEL_IPV4_EXPLICIT_NULL  0       /* [RFC3032] */
+#define MPLS_LABEL_ROUTER_ALERT        1       /* [RFC3032] */
+#define MPLS_LABEL_IPV6_EXPLICIT_NULL  2       /* [RFC3032] */
+#define MPLS_LABEL_IMPLICIT_NULL       3       /* [RFC3032] */
+#define MPLS_LABEL_ELI                 7       /* [RFC6790] */
+#define MPLS_LABEL_GAL                 13      /* [RFC5586] */
+#define MPLS_LABEL_OAM_ALERT           14      /* [RFC3429] */
+#define MPLS_LABEL_EXTENSION           15      /* [RFC7274] */
+#define MPLS_LABEL_MAX                 1048575
+#define MPLS_LABEL_ILLEGAL             0xFFFFFFFF /* for internal use only */
 
 /* Minimum and maximum label values */
-#define MPLS_MIN_RESERVED_LABEL            0
-#define MPLS_MAX_RESERVED_LABEL            15
-#define MPLS_MIN_UNRESERVED_LABEL          16
-#define MPLS_MAX_UNRESERVED_LABEL          1048575
+#define MPLS_LABEL_RESERVED_MIN            0
+#define MPLS_LABEL_RESERVED_MAX            15
+#define MPLS_LABEL_UNRESERVED_MIN          16
+#define MPLS_LABEL_UNRESERVED_MAX          1048575
 
 /* Default min and max SRGB label range */
 /* Even if the SRGB allows to manage different Label space between routers,
@@ -56,11 +62,11 @@
 #define MPLS_MAX_LABELS                    16
 
 #define IS_MPLS_RESERVED_LABEL(label)                                          \
-	(label >= MPLS_MIN_RESERVED_LABEL && label <= MPLS_MAX_RESERVED_LABEL)
+	(label >= MPLS_LABEL_RESERVED_MIN && label <= MPLS_LABEL_RESERVED_MAX)
 
 #define IS_MPLS_UNRESERVED_LABEL(label)                                        \
-	(label >= MPLS_MIN_UNRESERVED_LABEL                                    \
-	 && label <= MPLS_MAX_UNRESERVED_LABEL)
+	(label >= MPLS_LABEL_UNRESERVED_MIN                                    \
+	 && label <= MPLS_LABEL_UNRESERVED_MAX)
 
 /* Definitions for a MPLS label stack entry (RFC 3032). This encodes the
  * label, EXP, BOS and TTL fields.
@@ -153,28 +159,28 @@ static inline void mpls_lse_decode(mpls_lse_t lse, mpls_label_t *label,
 static inline char *label2str(mpls_label_t label, char *buf, size_t len)
 {
 	switch (label) {
-	case MPLS_V4_EXP_NULL_LABEL:
+	case MPLS_LABEL_IPV4_EXPLICIT_NULL:
 		strlcpy(buf, "IPv4 Explicit Null", len);
 		return (buf);
-	case MPLS_RA_LABEL:
+	case MPLS_LABEL_ROUTER_ALERT:
 		strlcpy(buf, "Router Alert", len);
 		return (buf);
-	case MPLS_V6_EXP_NULL_LABEL:
+	case MPLS_LABEL_IPV6_EXPLICIT_NULL:
 		strlcpy(buf, "IPv6 Explict Null", len);
 		return (buf);
-	case MPLS_IMP_NULL_LABEL:
+	case MPLS_LABEL_IMPLICIT_NULL:
 		strlcpy(buf, "implicit-null", len);
 		return (buf);
-	case MPLS_ENTROPY_LABEL_INDICATOR:
+	case MPLS_LABEL_ELI:
 		strlcpy(buf, "Entropy Label Indicator", len);
 		return (buf);
-	case MPLS_GAL_LABEL:
+	case MPLS_LABEL_GAL:
 		strlcpy(buf, "Generic Associated Channel", len);
 		return (buf);
-	case MPLS_OAM_ALERT_LABEL:
+	case MPLS_LABEL_OAM_ALERT:
 		strlcpy(buf, "OAM Alert", len);
 		return (buf);
-	case MPLS_EXTENSION_LABEL:
+	case MPLS_LABEL_EXTENSION:
 		strlcpy(buf, "Extension", len);
 		return (buf);
 	default:
@@ -186,13 +192,5 @@ static inline char *label2str(mpls_label_t label, char *buf, size_t len)
 	}
 }
 
-/* constants used by ldpd */
-#define MPLS_LABEL_IPV4NULL	0               /* IPv4 Explicit NULL Label */
-#define MPLS_LABEL_RTALERT	1               /* Router Alert Label       */
-#define MPLS_LABEL_IPV6NULL	2               /* IPv6 Explicit NULL Label */
-#define MPLS_LABEL_IMPLNULL	3               /* Implicit NULL Label      */
-	/*      MPLS_LABEL_RESERVED	4-15 */ /* Values 4-15 are reserved */
-#define MPLS_LABEL_RESERVED_MAX 15
-#define MPLS_LABEL_MAX		((1 << 20) - 1)
 
 #endif

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1913,8 +1913,8 @@ int lm_get_label_chunk(struct zclient *zclient, u_char keep,
 			__func__, *start, *end, keep, response_keep);
 	}
 	/* sanity */
-	if (*start > *end || *start < MPLS_MIN_UNRESERVED_LABEL
-	    || *end > MPLS_MAX_UNRESERVED_LABEL) {
+	if (*start > *end || *start < MPLS_LABEL_UNRESERVED_MIN
+	    || *end > MPLS_LABEL_UNRESERVED_MAX) {
 		zlog_err("%s: Invalid Label chunk: %u - %u", __func__, *start,
 			 *end);
 		return -1;

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -518,8 +518,8 @@ static int compute_link_nhlfe(struct sr_link *srl)
 		srl->nhlfe[1].label_in =
 			index2label(srl->sid[1], srl->srn->srgb);
 
-	srl->nhlfe[0].label_out = MPLS_IMP_NULL_LABEL;
-	srl->nhlfe[1].label_out = MPLS_IMP_NULL_LABEL;
+	srl->nhlfe[0].label_out = MPLS_LABEL_IMPLICIT_NULL;
+	srl->nhlfe[1].label_out = MPLS_LABEL_IMPLICIT_NULL;
 
 	rc = 1;
 	return rc;
@@ -606,7 +606,7 @@ static int compute_prefix_nhlfe(struct sr_prefix *srp)
 	 */
 	if ((srp->nexthop == NULL)
 	    && (!CHECK_FLAG(srp->flags, EXT_SUBTLV_PREFIX_SID_NPFLG)))
-		srp->nhlfe.label_out = MPLS_IMP_NULL_LABEL;
+		srp->nhlfe.label_out = MPLS_LABEL_IMPLICIT_NULL;
 	else if (CHECK_FLAG(srp->flags, EXT_SUBTLV_PREFIX_SID_VFLG))
 		srp->nhlfe.label_out = srp->sid;
 	else
@@ -701,7 +701,7 @@ static inline void add_sid_nhlfe(struct sr_nhlfe nhlfe)
 {
 	if ((nhlfe.label_in != 0) && (nhlfe.label_out != 0)) {
 		ospf_zebra_send_mpls_labels(ZEBRA_MPLS_LABELS_ADD, nhlfe);
-		if (nhlfe.label_out != MPLS_IMP_NULL_LABEL)
+		if (nhlfe.label_out != MPLS_LABEL_IMPLICIT_NULL)
 			ospf_zebra_send_mpls_ftn(ZEBRA_ROUTE_ADD, nhlfe);
 	}
 }
@@ -711,7 +711,7 @@ static inline void del_sid_nhlfe(struct sr_nhlfe nhlfe)
 {
 	if ((nhlfe.label_in != 0) && (nhlfe.label_out != 0)) {
 		ospf_zebra_send_mpls_labels(ZEBRA_MPLS_LABELS_DELETE, nhlfe);
-		if (nhlfe.label_out != MPLS_IMP_NULL_LABEL)
+		if (nhlfe.label_out != MPLS_LABEL_IMPLICIT_NULL)
 			ospf_zebra_send_mpls_ftn(ZEBRA_ROUTE_DELETE, nhlfe);
 	}
 }
@@ -1542,7 +1542,7 @@ void ospf_sr_update_prefix(struct interface *ifp, struct prefix *p)
 			    EXT_SUBTLV_PREFIX_SID_NPFLG)) {
 				srp->nhlfe.label_in = index2label(srp->sid,
 						OspfSR.self->srgb);
-				srp->nhlfe.label_out = MPLS_IMP_NULL_LABEL;
+				srp->nhlfe.label_out = MPLS_LABEL_IMPLICIT_NULL;
 				add_sid_nhlfe(srp->nhlfe);
 			}
 		}
@@ -1999,7 +1999,7 @@ DEFUN (sr_prefix_sid,
 	if (argv_find(argv, argc, "no-php-flag", &idx)) {
 		SET_FLAG(new->flags, EXT_SUBTLV_PREFIX_SID_NPFLG);
 		new->nhlfe.label_in = index2label(new->sid, OspfSR.self->srgb);
-		new->nhlfe.label_out = MPLS_IMP_NULL_LABEL;
+		new->nhlfe.label_out = MPLS_LABEL_IMPLICIT_NULL;
 	}
 
 	if (IS_DEBUG_OSPF_SR)
@@ -2209,7 +2209,7 @@ static void show_sr_node(struct vty *vty, struct json_object *json,
 			inet_ntoa(srp->nhlfe.prefv4.prefix),
 			srp->nhlfe.prefv4.prefixlen);
 		snprintf(sid, 22, "SR Pfx (idx %u)", srp->sid);
-		if (srp->nhlfe.label_out == MPLS_IMP_NULL_LABEL)
+		if (srp->nhlfe.label_out == MPLS_LABEL_IMPLICIT_NULL)
 			sprintf(label, "pop");
 		else
 			sprintf(label, "%u", srp->nhlfe.label_out);
@@ -2245,7 +2245,7 @@ static void show_sr_node(struct vty *vty, struct json_object *json,
 			inet_ntoa(srl->nhlfe[0].prefv4.prefix),
 			srl->nhlfe[0].prefv4.prefixlen);
 		snprintf(sid, 22, "SR Adj. (lbl %u)", srl->sid[0]);
-		if (srl->nhlfe[0].label_out == MPLS_IMP_NULL_LABEL)
+		if (srl->nhlfe[0].label_out == MPLS_LABEL_IMPLICIT_NULL)
 			sprintf(label, "pop");
 		else
 			sprintf(label, "%u", srl->nhlfe[0].label_out);
@@ -2272,7 +2272,7 @@ static void show_sr_node(struct vty *vty, struct json_object *json,
 			/* Backup Link */
 			json_obj = json_object_new_object();
 			snprintf(sid, 22, "SR Adj. (lbl %u)", srl->sid[1]);
-			if (srl->nhlfe[1].label_out == MPLS_IMP_NULL_LABEL)
+			if (srl->nhlfe[1].label_out == MPLS_LABEL_IMPLICIT_NULL)
 				sprintf(label, "pop");
 			else
 				sprintf(label, "%u", srl->nhlfe[0].label_out);
@@ -2293,7 +2293,7 @@ static void show_sr_node(struct vty *vty, struct json_object *json,
 				label, sid, itf ? itf->name : "-",
 				inet_ntoa(srl->nhlfe[0].nexthop));
 			snprintf(sid, 22, "SR Adj. (lbl %u)", srl->sid[1]);
-			if (srl->nhlfe[1].label_out == MPLS_IMP_NULL_LABEL)
+			if (srl->nhlfe[1].label_out == MPLS_LABEL_IMPLICIT_NULL)
 				sprintf(label, "pop");
 			else
 				sprintf(label, "%u", srl->nhlfe[1].label_out);

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1195,7 +1195,7 @@ int rtm_write(int message, union sockunion *dest, union sockunion *mask,
 		msg.rtm.rtm_flags |= RTF_MPLS;
 
 		if (mpls->smpls.smpls_label
-		    != htonl(MPLS_IMP_NULL_LABEL << MPLS_LABEL_OFFSET))
+		    != htonl(MPLS_LABEL_IMPLICIT_NULL << MPLS_LABEL_OFFSET))
 			msg.rtm.rtm_mpls = MPLS_OP_PUSH;
 	}
 #endif

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -283,13 +283,13 @@ struct label_manager_chunk *assign_label_chunk(u_char proto, u_short instance,
 		return NULL;
 
 	if (list_isempty(lbl_mgr.lc_list))
-		lmc->start = MPLS_MIN_UNRESERVED_LABEL;
+		lmc->start = MPLS_LABEL_UNRESERVED_MIN;
 	else
 		lmc->start = ((struct label_manager_chunk *)listgetdata(
 				      listtail(lbl_mgr.lc_list)))
 				     ->end
 			     + 1;
-	if (lmc->start > MPLS_MAX_UNRESERVED_LABEL - size + 1) {
+	if (lmc->start > MPLS_LABEL_UNRESERVED_MAX - size + 1) {
 		zlog_err("Reached max labels. Start: %u, size: %u", lmc->start,
 			 size);
 		XFREE(MTYPE_LM_CHUNK, lmc);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -852,7 +852,7 @@ static void _netlink_route_build_singlepath(const char *routedesc, int bytelen,
 		char label_buf1[20];
 
 		for (i = 0; i < nh_label->num_labels; i++) {
-			if (nh_label->label[i] != MPLS_IMP_NULL_LABEL) {
+			if (nh_label->label[i] != MPLS_LABEL_IMPLICIT_NULL) {
 				bos = ((i == (nh_label->num_labels - 1)) ? 1
 									 : 0);
 				out_lse[i] = mpls_lse_encode(nh_label->label[i],
@@ -1062,7 +1062,7 @@ static void _netlink_route_build_multipath(const char *routedesc, int bytelen,
 		char label_buf1[20];
 
 		for (i = 0; i < nh_label->num_labels; i++) {
-			if (nh_label->label[i] != MPLS_IMP_NULL_LABEL) {
+			if (nh_label->label[i] != MPLS_LABEL_IMPLICIT_NULL) {
 				bos = ((i == (nh_label->num_labels - 1)) ? 1
 									 : 0);
 				out_lse[i] = mpls_lse_encode(nh_label->label[i],

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -411,12 +411,13 @@ static int fec_change_update_lsp(struct zebra_vrf *zvrf, zebra_fec_t *fec,
 	afi_t afi;
 
 	/* Uninstall label forwarding entry, if previously installed. */
-	if (old_label != MPLS_INVALID_LABEL && old_label != MPLS_IMP_NULL_LABEL)
+	if (old_label != MPLS_INVALID_LABEL
+	    && old_label != MPLS_LABEL_IMPLICIT_NULL)
 		lsp_uninstall(zvrf, old_label);
 
 	/* Install label forwarding entry corr. to new label, if needed. */
 	if (fec->label == MPLS_INVALID_LABEL
-	    || fec->label == MPLS_IMP_NULL_LABEL)
+	    || fec->label == MPLS_LABEL_IMPLICIT_NULL)
 		return 0;
 
 	afi = family2afi(PREFIX_FAMILY(&fec->rn->p));
@@ -1793,7 +1794,7 @@ int zebra_mpls_lsp_install(struct zebra_vrf *zvrf, struct route_node *rn,
 	/* We cannot install a label forwarding entry if local label is the
 	 * implicit-null label.
 	 */
-	if (fec->label == MPLS_IMP_NULL_LABEL)
+	if (fec->label == MPLS_LABEL_IMPLICIT_NULL)
 		return 0;
 
 	if (lsp_install(zvrf, fec->label, rn, re))
@@ -2537,8 +2538,8 @@ int zebra_mpls_lsp_label_consistent(struct zebra_vrf *zvrf,
 			int cur_op, new_op;
 
 			cur_op = (slsp->snhlfe_list->out_label
-				  == MPLS_IMP_NULL_LABEL);
-			new_op = (out_label == MPLS_IMP_NULL_LABEL);
+				  == MPLS_LABEL_IMPLICIT_NULL);
+			new_op = (out_label == MPLS_LABEL_IMPLICIT_NULL);
 			if (cur_op != new_op)
 				return 0;
 		}
@@ -2810,11 +2811,11 @@ int zebra_mpls_write_lsp_config(struct vty *vty, struct zebra_vrf *zvrf)
 
 			snhlfe2str(snhlfe, buf, sizeof(buf));
 			switch (snhlfe->out_label) {
-			case MPLS_V4_EXP_NULL_LABEL:
-			case MPLS_V6_EXP_NULL_LABEL:
+			case MPLS_LABEL_IPV4_EXPLICIT_NULL:
+			case MPLS_LABEL_IPV6_EXPLICIT_NULL:
 				strlcpy(lstr, "explicit-null", sizeof(lstr));
 				break;
-			case MPLS_IMP_NULL_LABEL:
+			case MPLS_LABEL_IMPLICIT_NULL:
 				strlcpy(lstr, "implicit-null", sizeof(lstr));
 				break;
 			default:

--- a/zebra/zebra_mpls_vty.c
+++ b/zebra/zebra_mpls_vty.c
@@ -68,7 +68,7 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	out_label = MPLS_IMP_NULL_LABEL; /* as initialization */
+	out_label = MPLS_LABEL_IMPLICIT_NULL; /* as initialization */
 	label = atoi(inlabel_str);
 	if (!IS_MPLS_UNRESERVED_LABEL(label)) {
 		vty_out(vty, "%% Invalid label\n");
@@ -107,11 +107,11 @@ static int zebra_mpls_transit_lsp(struct vty *vty, int add_cmd,
 
 	if (outlabel_str) {
 		if (outlabel_str[0] == 'i')
-			out_label = MPLS_IMP_NULL_LABEL;
+			out_label = MPLS_LABEL_IMPLICIT_NULL;
 		else if (outlabel_str[0] == 'e' && gtype == NEXTHOP_TYPE_IPV4)
-			out_label = MPLS_V4_EXP_NULL_LABEL;
+			out_label = MPLS_LABEL_IPV4_EXPLICIT_NULL;
 		else if (outlabel_str[0] == 'e' && gtype == NEXTHOP_TYPE_IPV6)
-			out_label = MPLS_V6_EXP_NULL_LABEL;
+			out_label = MPLS_LABEL_IPV6_EXPLICIT_NULL;
 		else
 			out_label = atoi(outlabel_str);
 	}
@@ -221,12 +221,12 @@ static int zebra_mpls_bind(struct vty *vty, int add_cmd, const char *prefix,
 		}
 
 		if (!strcmp(label_str, "implicit-null"))
-			label = MPLS_IMP_NULL_LABEL;
+			label = MPLS_LABEL_IMPLICIT_NULL;
 		else if (!strcmp(label_str, "explicit-null")) {
 			if (p.family == AF_INET)
-				label = MPLS_V4_EXP_NULL_LABEL;
+				label = MPLS_LABEL_IPV4_EXPLICIT_NULL;
 			else
-				label = MPLS_V6_EXP_NULL_LABEL;
+				label = MPLS_LABEL_IPV6_EXPLICIT_NULL;
 		} else {
 			label = atoi(label_str);
 			if (!IS_MPLS_UNRESERVED_LABEL(label)) {

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -165,8 +165,8 @@ static int zebra_static_route_leak(struct vty *vty,
 			case -2:
 				vty_out(vty,
 					"%% Cannot use reserved label(s) (%d-%d)\n",
-					MPLS_MIN_RESERVED_LABEL,
-					MPLS_MAX_RESERVED_LABEL);
+					MPLS_LABEL_RESERVED_MIN,
+					MPLS_LABEL_RESERVED_MAX);
 				break;
 			case -3:
 				vty_out(vty,


### PR DESCRIPTION
Turns out we had 3 different ways to define labels
all of them overlapping with the same meanings.
Consolidate to 1.  This one choosen is consistent
naming wise with what the *bsd and linux kernels
use.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>