### PR TITLE
tools: fix that filters issues on resulting file only

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -72,7 +72,7 @@ else
     echo "Report for $(basename $file _cp)" 1>&2
     echo "===============================================" 1>&2
     if [ -a /tmp/f2/$(basename $file) ]; then
-      diff $file /tmp/f2/$(basename $file) | grep -v "normally be const" | grep -A3 "ERROR\|WARNING" 1>&2
+      diff $file /tmp/f2/$(basename $file) | grep -v "normally be const" | grep -A3 "ERROR\|WARNING" | grep -A2 -B2 '/tmp/f1' 1>&2
     else
       cat $file | grep -v "normally be const" | grep -A3 "ERROR\|WARNING" 1>&2
     fi


### PR DESCRIPTION
Because checkpatch result is applied to original and new file, the
analysis also parses what may be wrong with the original file.
Whereas the script should limit to analyse only what is wrong on new
file.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>