### PR TITLE
doc: Update centos7 build to include systemd

### DIFF
--- a/doc/Building_FRR_on_CentOS7.md
+++ b/doc/Building_FRR_on_CentOS7.md
@@ -20,7 +20,7 @@ Add packages:
     sudo yum install git autoconf automake libtool make gawk \
       readline-devel texinfo net-snmp-devel groff pkgconfig \
       json-c-devel pam-devel bison flex pytest c-ares-devel \
-      perl-XML-LibXML python-devel
+      perl-XML-LibXML python-devel systemd-devel
 
 Get FRR, compile it and install it (from Git)
 ---------------------------------------------
@@ -59,6 +59,7 @@ an example.)
         --enable-group=frr \
         --enable-vty-group=frrvt \
         --enable-rtadv \
+	--enable-systemd=yes \
         --disable-exampledir \
         --enable-watchfrr \
         --disable-ldpd \


### PR DESCRIPTION
Update the centos7 build instructions to include
data on how to build w/ systemd.  This is especially
useful because we tell the user to install the frr.service
file and the frr.service file expects systemd integration

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>