### PR TITLE
bgpd: use peer->ifp->ifindex instead of peer->ifindex

### DIFF
--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -465,7 +465,7 @@ static void bgp_dump_common(struct stream *obuf, struct peer *peer,
 	}
 
 	if (peer->su.sa.sa_family == AF_INET) {
-		stream_putw(obuf, peer->ifindex);
+		stream_putw(obuf, peer->ifp ? peer->ifp->ifindex : 0);
 		stream_putw(obuf, AFI_IP);
 
 		stream_put(obuf, &peer->su.sin.sin_addr, IPV4_MAX_BYTELEN);
@@ -477,7 +477,7 @@ static void bgp_dump_common(struct stream *obuf, struct peer *peer,
 			stream_put(obuf, empty, IPV4_MAX_BYTELEN);
 	} else if (peer->su.sa.sa_family == AF_INET6) {
 		/* Interface Index and Address family. */
-		stream_putw(obuf, peer->ifindex);
+		stream_putw(obuf, peer->ifp ? peer->ifp->ifindex : 0);
 		stream_putw(obuf, AFI_IP6);
 
 		/* Source IP Address and Destination IP Address. */

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -93,6 +93,26 @@ int bgp_maximum_paths_unset(struct bgp *bgp, afi_t afi, safi_t safi,
 }
 
 /*
+ * bgp_interface_same
+ *
+ * Return true if ifindex for ifp1 and ifp2 are the same, else return false.
+ */
+static int bgp_interface_same(struct interface *ifp1, struct interface *ifp2)
+{
+	if (!ifp1 && !ifp2)
+		return 1;
+
+	if (!ifp1 && ifp2)
+		return 0;
+
+	if (ifp1 && !ifp2)
+		return 0;
+
+	return (ifp1->ifindex == ifp2->ifindex);
+}
+
+
+/*
  * bgp_info_nexthop_cmp
  *
  * Compare the nexthops of two paths. Return value is less than, equal to,
@@ -130,7 +150,8 @@ int bgp_info_nexthop_cmp(struct bgp_info *bi1, struct bgp_info *bi2)
 
 				if (!bi1->attr->mp_nexthop_prefer_global &&
 				    !bi2->attr->mp_nexthop_prefer_global)
-					compare = !(bi1->peer->ifindex == bi2->peer->ifindex);
+					compare = !bgp_interface_same(bi1->peer->ifp, bi2->peer->ifp);
+
 				if (!compare)
 					compare = IPV6_ADDR_CMP(&addr1, &addr2);
 				break;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1200,7 +1200,6 @@ void peer_xfer_config(struct peer *peer_dst, struct peer *peer_src)
 	peer_dst->config = peer_src->config;
 
 	peer_dst->local_as = peer_src->local_as;
-	peer_dst->ifindex = peer_src->ifindex;
 	peer_dst->port = peer_src->port;
 	(void)peer_sort(peer_dst);
 	peer_dst->rmap_type = peer_src->rmap_type;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -686,7 +686,6 @@ struct peer {
 	time_t readtime;     /* Last read time */
 	time_t resettime;    /* Last reset time */
 
-	ifindex_t ifindex;     /* ifindex of the BGP connection. */
 	char *conf_if;	 /* neighbor interface config name. */
 	struct interface *ifp; /* corresponding interface */
 	char *ifname;	  /* bind interface name. */


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

peer->ifindex was only used in two places but it was never populated so
neither of them worked as they should.  'struct peer' also has a 'struct
interface' pointer which we can use to get the ifindex.