### PR TITLE
tools: Add helper frr-reload shell script for clean error

### DIFF
--- a/debianpkg/frr.install
+++ b/debianpkg/frr.install
@@ -19,4 +19,5 @@ usr/share/man/man8/frr-args.8
 usr/share/snmp/mibs/
 tools/etc/* etc/
 tools/*.service    lib/systemd/system
+tools/frr-reload   usr/lib/frr/
 debian/frr.conf  usr/lib/tmpfiles.d

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -570,6 +570,7 @@ rm -rf %{buildroot}
 %endif
 %config(noreplace) /etc/pam.d/frr
 %config(noreplace) %attr(640,root,root) /etc/logrotate.d/*
+%{_sbindir}/frr-reload
 
 %files contrib
 %defattr(-,root,root)

--- a/tools/frr-reload
+++ b/tools/frr-reload
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if test -e /usr/lib/frr/frr-reload.py; then
+   exec /usr/lib/frr/frr-reload.py --reload /etc/frr/frr.conf
+fi
+>&2 echo "Please install frr-pythontools package. Required for reload"
+exit 1

--- a/tools/frr.service
+++ b/tools/frr.service
@@ -17,6 +17,6 @@ Restart=on-abnormal
 LimitNOFILE=1024
 ExecStart=/usr/lib/frr/frr start
 ExecStop=/usr/lib/frr/frr stop
-ExecReload=/usr/lib/frr/frr-reload.py --reload /etc/frr/frr.conf
+ExecReload=/usr/lib/frr/frr-reload
 [Install]
 WantedBy=network-online.target

--- a/tools/subdir.am
+++ b/tools/subdir.am
@@ -5,6 +5,7 @@
 noinst_PROGRAMS += tools/permutations
 sbin_PROGRAMS += tools/ssd
 sbin_SCRIPTS += \
+        tools/frr-reload \
 	tools/frr-reload.py \
 	tools/frr \
 	# end
@@ -17,6 +18,7 @@ tools_ssd_SOURCES = tools/start-stop-daemon.c
 EXTRA_DIST += \
 	tools/etc \
 	tools/frr \
+	tools/frr-reload \
 	tools/frr-reload.py \
 	tools/frr.service \
 	tools/multiple-bgpd.sh \


### PR DESCRIPTION
Adding the shell script allows a clean error if frr-pythontools
is not installed.

This improves the error message as mentioned in PR #1689 

The PR adds a helper frr-reload shell script which is always installed and 
provides a helpful error in case the frr-pythontools is not installed.

### Without frr-pythontools installed:
```
root@ubuntu1604~# systemctl reload frr
Job for frr.service failed because the control process exited with error code. See "systemctl status frr.service" and "journalctl -xe" for details.
```

and  `systemctl status frr.service` shows:
```
Feb 28 11:32:27 ubuntu1604-pkg systemd[1]: Started FRRouting.
Feb 28 11:32:32 ubuntu1604-pkg systemd[1]: Reloading FRRouting.
Feb 28 11:32:32 ubuntu1604-pkg frr-reload[22975]: Please install frr-pythontools package. Required for reload
Feb 28 11:32:32 ubuntu1604-pkg systemd[1]: frr.service: Control process exited, code=exited status=1
Feb 28 11:32:32 ubuntu1604-pkg systemd[1]: Reload failed for FRRouting.
```

### With frr-pythontools installed, the reload will work as usual:
```
root@ubuntu1604~# systemctl reload frr
#
```

and  `systemctl status frr.service` shows normal reload:
```
Feb 28 11:32:50 ubuntu1604-pkg systemd[1]: Started FRRouting.
Feb 28 11:32:58 ubuntu1604-pkg systemd[1]: Reloading FRRouting.
Feb 28 11:32:59 ubuntu1604-pkg systemd[1]: Reloaded FRRouting.
```

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>