### PR TITLE
lib, zebra: Add type and instance to nexthop update message

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1266,6 +1266,8 @@ bool zapi_nexthop_update_decode(struct stream *s, struct zapi_route *nhr)
 		break;
 	}
 
+	STREAM_GETC(s, nhr->type);
+	STREAM_GETW(s, nhr->instance);
 	STREAM_GETC(s, nhr->distance);
 	STREAM_GETL(s, nhr->metric);
 	STREAM_GETC(s, nhr->nexthop_num);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1019,6 +1019,8 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 		break;
 	}
 	if (re) {
+		stream_putc(s, re->type);
+		stream_putw(s, re->instance);
 		stream_putc(s, re->distance);
 		stream_putl(s, re->metric);
 		num = 0;
@@ -1054,6 +1056,8 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 			}
 		stream_putc_at(s, nump, num);
 	} else {
+		stream_putc(s, 0); // type
+		stream_putw(s, 0); // instance
 		stream_putc(s, 0); // distance
 		stream_putl(s, 0); // metric
 		stream_putc(s, 0); // nexthops


### PR DESCRIPTION
Add the originating routes type and instance to the nexthop
update message.  This is necessary because there exist
scenarios where BGP needs to make a decision about the
originating route type and instance to know if it is
going to be doing a route replace to a route that would
resolve to itself.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>