### PR TITLE
ospf6d: assign zebra router-id to ospf6 instance

### DIFF
--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -202,6 +202,9 @@ int main(int argc, char *argv[], char *envp[])
 		exit(1);
 	}
 
+	/* OSPF6 master init. */
+	ospf6_master_init();
+
 	/* thread master */
 	master = frr_init();
 

--- a/ospf6d/ospf6_top.h
+++ b/ospf6d/ospf6_top.h
@@ -24,6 +24,11 @@
 #include "qobj.h"
 #include "routemap.h"
 
+struct ospf6_master {
+
+	uint32_t zebra_router_id;
+};
+
 /* OSPFv3 top level data structure */
 struct ospf6 {
 	/* my router id */
@@ -109,10 +114,13 @@ DECLARE_QOBJ_TYPE(ospf6)
 
 /* global pointer for OSPF top data structure */
 extern struct ospf6 *ospf6;
+extern struct ospf6_master *om6;
 
 /* prototypes */
+extern void ospf6_master_init(void);
 extern void ospf6_top_init(void);
 extern void ospf6_delete(struct ospf6 *o);
+extern void ospf6_router_id_update(void);
 
 extern void ospf6_maxage_remove(struct ospf6 *o);
 

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -55,13 +55,22 @@ static int ospf6_router_id_update_zebra(int command, struct zclient *zclient,
 
 	zebra_router_id_update_read(zclient->ibuf, &router_id);
 
+	om6->zebra_router_id = router_id.u.prefix4.s_addr;
+
 	if (o == NULL)
 		return 0;
 
 	o->router_id_zebra = router_id.u.prefix4;
+	if (IS_OSPF6_DEBUG_ZEBRA(RECV)) {
+		char buf[INET_ADDRSTRLEN];
 
-	if (o->router_id == 0)
-		o->router_id = (uint32_t)o->router_id_zebra.s_addr;
+		zlog_debug("%s: zebra router-id %s update",
+			   __PRETTY_FUNCTION__,
+			   inet_ntop(AF_INET, &router_id.u.prefix4,
+				     buf, INET_ADDRSTRLEN));
+	}
+
+	ospf6_router_id_update();
 
 	return 0;
 }


### PR DESCRIPTION
Store zebra router-id in global structure.
Before router ospf6 instance created, zebra router-id callback called.

During ospf6 main execution zebra init happens, but default instance does not execute until
cli replay 'router ospf6'.
Call ospf6_router_id_change during 'router ospf6'
to assign zebra router id to ospf6 instance.

Ticket:CM-19937
Testing Done:
Assign Loopback /32 (6.6.6.6/32) address,
restart frr with (router ospf6 in frr.conf).
ospf6 default instance assigned 6.6.6.6 router-id.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>