### PR TITLE
bgpd,ospfd: add sys_admin capabilities

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -106,7 +106,7 @@ static int retain_mode = 0;
 
 /* privileges */
 static zebra_capabilities_t _caps_p[] = {
-	ZCAP_BIND, ZCAP_NET_RAW, ZCAP_NET_ADMIN,
+	ZCAP_BIND, ZCAP_NET_RAW, ZCAP_NET_ADMIN, ZCAP_SYS_ADMIN
 };
 
 struct zebra_privs_t bgpd_privs = {

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -55,7 +55,7 @@
 
 /* ospfd privileges */
 zebra_capabilities_t _caps_p[] = {
-	ZCAP_NET_RAW, ZCAP_BIND, ZCAP_NET_ADMIN,
+	ZCAP_NET_RAW, ZCAP_BIND, ZCAP_NET_ADMIN, ZCAP_SYS_ADMIN
 };
 
 struct zebra_privs_t ospfd_privs = {


### PR DESCRIPTION
This capability, when used, is mapped over linux sys_admin capability.
This is necessary from the daemon perspective, in order to handle NETNS
based VRFs, because calling setns() requires sys admin capability.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>