### PR TITLE
Static stuff

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -446,6 +446,8 @@ DECLARE_HOOK(rib_update, (struct route_node * rn, const char *reason),
 extern void zebra_vty_init(void);
 extern int static_config(struct vty *vty, struct zebra_vrf *zvrf, afi_t afi,
 			 safi_t safi, const char *cmd);
+extern void static_config_install_delayed_routes(struct zebra_vrf *zvrf);
+
 extern pid_t pid;
 
 #endif /*_ZEBRA_RIB_H */

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -161,6 +161,12 @@ static int zebra_vrf_enable(struct vrf *vrf)
 				}
 		}
 
+	/*
+	 * We may have static routes that are now possible to
+	 * insert into the appropriate tables
+	 */
+	static_config_install_delayed_routes(zvrf);
+
 	/* Kick off any VxLAN-EVPN processing. */
 	zebra_vxlan_vrf_enable(zvrf);
 

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -568,7 +568,6 @@ static int vrf_config_write(struct vty *vty)
 						? " prefix-routes-only"
 						: "");
 			zebra_ns_config_write(vty, (struct ns *)vrf->ns_ctxt);
-			vty_out(vty, "!\n");
 		}
 
 		static_config(vty, zvrf, AFI_IP, SAFI_UNICAST, "ip route");


### PR DESCRIPTION
It is possible to cause zebra to crash when you have static routes configured under a non-fully initialized vrf.  These commits fix this issue.