### PR TITLE
stable/3.0 fix for #1803

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -474,7 +474,7 @@ int vtysh_mark_file(const char *filename)
 	}
 
 	vty = vty_new();
-	vty->fd = 0; /* stdout */
+	vty->wfd = STDERR_FILENO;
 	vty->type = VTY_TERM;
 	vty->node = CONFIG_NODE;
 


### PR DESCRIPTION
Command output should go to stderr, to not clutter the config
output on stdout.

Signed-off-by: Christian Franke <chris@opensourcerouting.org>