### PR TITLE
stable/3.0: fix reload of vnc commands

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -398,7 +398,7 @@ end
                 ctx_keys = []
                 current_context_lines = []
 
-            elif line == "exit-address-family" or line == "exit":
+            elif line in ["exit-address-family", "exit", "exit-vnc"]:
                 # if this exit is for address-family ipv4 unicast, ignore the pop
                 if main_ctx_key:
                     self.save_contexts(ctx_keys, current_context_lines)
@@ -419,7 +419,10 @@ end
                 new_ctx = False
                 log.debug('LINE %-50s: entering new context, %-50s', line, ctx_keys)
 
-            elif "address-family " in line:
+            elif (line.startswith("address-family ") or
+                  line.startswith("vnc defaults") or
+                  line.startswith("vnc l2-group") or
+                  line.startswith("vnc nve-group")):
                 main_ctx_key = []
 
                 # Save old context first


### PR DESCRIPTION
Investigating #1380, I found that frr-reload.py would generate incorrect configuration commands for any vnc related configs like following: <pre>router bgp 64600
 vnc defaults

router bgp 64600
 response-lifetime 3600</pre> Fix this by treating the vnc config sections as a subcontext.