### PR TITLE
zebra: giant zapi cleanup

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -1092,14 +1092,16 @@ void zlog_hexdump(const void *mem, unsigned int len)
 	unsigned long i = 0;
 	unsigned int j = 0;
 	unsigned int columns = 8;
-	/* 19 bytes for 0xADDRESS: */
-	/* 24 bytes for data; 2 chars plus a space per data byte */
-	/*  1 byte for space */
-	/*  8 bytes for ASCII representation */
-	/*  1 byte for a newline */
-	/* ===================== */
-	/* 53 bytes per 8 bytes of data */
-	/*  1 byte for null term */
+	/*
+	 * 19 bytes for 0xADDRESS:
+	 * 24 bytes for data; 2 chars plus a space per data byte
+	 *  1 byte for space
+	 *  8 bytes for ASCII representation
+	 *  1 byte for a newline
+	 * =====================
+	 * 53 bytes per 8 bytes of data
+	 *  1 byte for null term
+	 */
 	size_t bs = ((len / 8) + 1) * 53 + 1;
 	char buf[bs];
 	char *s = buf;

--- a/lib/log.c
+++ b/lib/log.c
@@ -1092,41 +1092,48 @@ void zlog_hexdump(const void *mem, unsigned int len)
 	unsigned long i = 0;
 	unsigned int j = 0;
 	unsigned int columns = 8;
-	char buf[(len * 4) + ((len / 4) * 20) + 30];
+	/* 19 bytes for 0xADDRESS: */
+	/* 24 bytes for data; 2 chars plus a space per data byte */
+	/*  1 byte for space */
+	/*  8 bytes for ASCII representation */
+	/*  1 byte for a newline */
+	/* ===================== */
+	/* 53 bytes per 8 bytes of data */
+	/*  1 byte for null term */
+	size_t bs = ((len / 8) + 1) * 53 + 1;
+	char buf[bs];
 	char *s = buf;
 
 	for (i = 0; i < len + ((len % columns) ? (columns - len % columns) : 0);
 	     i++) {
 		/* print offset */
 		if (i % columns == 0)
-			s += sprintf(s, "0x%016lx: ", (unsigned long)mem + i);
+			s += snprintf(s, bs - (s - buf),
+				      "0x%016lx: ", (unsigned long)mem + i);
 
 		/* print hex data */
 		if (i < len)
-			s += sprintf(s, "%02x ", 0xFF & ((const char *)mem)[i]);
+			s += snprintf(s, bs - (s - buf), "%02x ",
+				      0xFF & ((const char *)mem)[i]);
 
 		/* end of block, just aligning for ASCII dump */
 		else
-			s += sprintf(s, "   ");
+			s += snprintf(s, bs - (s - buf), "   ");
 
 		/* print ASCII dump */
 		if (i % columns == (columns - 1)) {
 			for (j = i - (columns - 1); j <= i; j++) {
-				if (j >= len) /* end of block, not really
-						 printing */
-					s += sprintf(s, " ");
-
-				else if (isprint((int)((const char *)mem)
-							 [j])) /* printable char
-								  */
-					s += sprintf(
-						s, "%c",
+				/* end of block not really printing */
+				if (j >= len)
+					s += snprintf(s, bs - (s - buf), " ");
+				else if (isprint((int)((const char *)mem)[j]))
+					s += snprintf(
+						s, bs - (s - buf), "%c",
 						0xFF & ((const char *)mem)[j]);
-
 				else /* other char */
-					s += sprintf(s, ".");
+					s += snprintf(s, bs - (s - buf), ".");
 			}
-			s += sprintf(s, "\n");
+			s += snprintf(s, bs - (s - buf), "\n");
 		}
 	}
 	zlog_debug("\n%s", buf);

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -322,6 +322,18 @@ stream_failure:
 	return 0;
 }
 
+bool zapi_parse_header(struct stream *zmsg, struct zmsghdr *hdr)
+{
+	STREAM_GETW(zmsg, hdr->length);
+	STREAM_GETC(zmsg, hdr->marker);
+	STREAM_GETC(zmsg, hdr->version);
+	STREAM_GETC(zmsg, hdr->vrf_id);
+	STREAM_GETW(zmsg, hdr->command);
+	return true;
+stream_failure:
+	return false;
+}
+
 /* Send simple Zebra message. */
 static int zebra_message_send(struct zclient *zclient, int command,
 			      vrf_id_t vrf_id)

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -327,7 +327,7 @@ bool zapi_parse_header(struct stream *zmsg, struct zmsghdr *hdr)
 	STREAM_GETW(zmsg, hdr->length);
 	STREAM_GETC(zmsg, hdr->marker);
 	STREAM_GETC(zmsg, hdr->version);
-	STREAM_GETC(zmsg, hdr->vrf_id);
+	STREAM_GETL(zmsg, hdr->vrf_id);
 	STREAM_GETW(zmsg, hdr->command);
 	return true;
 stream_failure:

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -237,7 +237,7 @@ struct zclient {
  */
 #define ZAPI_MESSAGE_TABLEID  0x80
 
-#define ZSERV_VERSION	5
+#define ZSERV_VERSION 5
 /* Zserv protocol message header */
 struct zmsghdr {
 	uint16_t length;

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -241,8 +241,7 @@ struct zclient {
 /* Zserv protocol message header */
 struct zmsghdr {
 	uint16_t length;
-	/* corresponds to command field in old zserv
-	 * always set to 255 in new zserv. */
+	/* Always set to 255 in new zserv */
 	uint8_t marker;
 	uint8_t version;
 	vrf_id_t vrf_id;
@@ -380,9 +379,11 @@ struct zclient_options {
 /* Prototypes of zebra client service functions. */
 extern struct zclient *zclient_new(struct thread_master *);
 
+/* clang-format off */
 #if CONFDATE > 20181101
 CPP_NOTICE("zclient_new_notify can take over or zclient_new now");
 #endif
+/* clang-format on */
 
 extern struct zclient_options zclient_options_default;
 
@@ -517,9 +518,11 @@ extern struct interface *zebra_interface_vrf_update_read(struct stream *s,
 extern void zebra_interface_if_set_value(struct stream *, struct interface *);
 extern void zebra_router_id_update_read(struct stream *s, struct prefix *rid);
 
+/* clang-format off */
 #if CONFDATE > 20180823
 CPP_NOTICE("zapi_ipv4_route, zapi_ipv6_route, zapi_ipv4_route_ipv6_nexthop as well as the zapi_ipv4 and zapi_ipv6 data structures should be removed now");
 #endif
+/* clang-format on */
 
 extern int zapi_ipv4_route(u_char, struct zclient *, struct prefix_ipv4 *,
 			   struct zapi_ipv4 *) __attribute__((deprecated));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -73,6 +73,7 @@ check_PROGRAMS = \
 	lib/test_timer_correctness \
 	lib/test_timer_performance \
 	lib/test_ttable \
+	lib/test_zlog \
 	lib/cli/test_cli \
 	lib/cli/test_commands \
 	$(TESTS_BGPD) \
@@ -115,9 +116,9 @@ lib_test_heavy_SOURCES = lib/test_heavy.c helpers/c/main.c
 lib_test_memory_SOURCES = lib/test_memory.c
 lib_test_nexthop_iter_SOURCES = lib/test_nexthop_iter.c helpers/c/prng.c
 lib_test_privs_SOURCES = lib/test_privs.c
+lib_test_ringbuf_SOURCES = lib/test_ringbuf.c
 lib_test_srcdest_table_SOURCES = lib/test_srcdest_table.c \
                                  helpers/c/prng.c
-lib_test_ringbuf_SOURCES = lib/test_ringbuf.c
 lib_test_segv_SOURCES = lib/test_segv.c
 lib_test_sig_SOURCES = lib/test_sig.c
 lib_test_stream_SOURCES = lib/test_stream.c
@@ -127,6 +128,7 @@ lib_test_timer_correctness_SOURCES = lib/test_timer_correctness.c \
 lib_test_timer_performance_SOURCES = lib/test_timer_performance.c \
                                      helpers/c/prng.c
 lib_test_ttable_SOURCES = lib/test_ttable.c
+lib_test_zlog_SOURCES = lib/test_zlog.c
 lib_test_zmq_SOURCES = lib/test_zmq.c
 lib_test_zmq_CFLAGS = $(AM_CFLAGS) $(ZEROMQ_CFLAGS)
 lib_cli_test_cli_SOURCES = lib/cli/test_cli.c lib/cli/common_cli.c
@@ -167,6 +169,7 @@ lib_test_table_LDADD = $(ALL_TESTS_LDADD) -lm
 lib_test_timer_correctness_LDADD = $(ALL_TESTS_LDADD)
 lib_test_timer_performance_LDADD = $(ALL_TESTS_LDADD)
 lib_test_ttable_LDADD = $(ALL_TESTS_LDADD)
+lib_test_zlog_LDADD = $(ALL_TESTS_LDADD)
 lib_test_zmq_LDADD = ../lib/libfrrzmq.la $(ALL_TESTS_LDADD) $(ZEROMQ_LIBS)
 lib_cli_test_cli_LDADD = $(ALL_TESTS_LDADD)
 lib_cli_test_commands_LDADD = $(ALL_TESTS_LDADD)
@@ -207,6 +210,7 @@ EXTRA_DIST = \
     lib/test_timer_correctness.py \
     lib/test_ttable.py \
     lib/test_ttable.refout \
+    lib/test_zlog.py \
     ospf6d/test_lsdb.py \
     ospf6d/test_lsdb.in \
     ospf6d/test_lsdb.refout \

--- a/tests/lib/test_zlog.c
+++ b/tests/lib/test_zlog.c
@@ -1,0 +1,61 @@
+/*
+ * Zlog tests.
+ * Copyright (C) 2018  Cumulus Networks, Inc.
+ *                     Quentin Young
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include <zebra.h>
+#include <memory.h>
+#include "log.h"
+
+/* maximum amount of data to hexdump */
+#define MAXDATA 16384
+
+/*
+ * Test hexdump functionality.
+ *
+ * At the moment, not crashing is considered success.
+ */
+static bool test_zlog_hexdump(void)
+{
+	unsigned int nl = 1;
+
+	do {
+		long d[nl];
+
+		for (unsigned int i = 0; i < nl; i++)
+			d[i] = random();
+		zlog_hexdump(d, nl * sizeof(long));
+	} while (++nl * sizeof(long) <= MAXDATA);
+
+	return true;
+}
+
+bool (*tests[])(void) = {
+	test_zlog_hexdump,
+};
+
+int main(int argc, char **argv)
+{
+	openzlog("testzlog", "NONE", 0, LOG_CONS | LOG_NDELAY | LOG_PID,
+		 LOG_ERR);
+	zlog_set_file("test_zlog.log", LOG_DEBUG);
+
+	for (unsigned int i = 0; i < array_size(tests); i++)
+		if (!tests[i]())
+			return 1;
+	return 0;
+}

--- a/tests/lib/test_zlog.py
+++ b/tests/lib/test_zlog.py
@@ -1,0 +1,4 @@
+import frrtest
+
+class TestZlog(frrtest.TestMultiOut):
+    program = './test_zlog'

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -249,9 +249,9 @@ void zebra_redistribute_add(ZAPI_HANDLER_ARGS)
 	int type = 0;
 	u_short instance;
 
-	STREAM_GETC(client->ibuf, afi);
-	STREAM_GETC(client->ibuf, type);
-	STREAM_GETW(client->ibuf, instance);
+	STREAM_GETC(msg, afi);
+	STREAM_GETC(msg, type);
+	STREAM_GETW(msg, instance);
 
 	if (afi == 0 || afi > AFI_MAX) {
 		zlog_warn("%s: Specified afi %d does not exist",
@@ -292,9 +292,9 @@ void zebra_redistribute_delete(ZAPI_HANDLER_ARGS)
 	int type = 0;
 	u_short instance;
 
-	STREAM_GETC(client->ibuf, afi);
-	STREAM_GETC(client->ibuf, type);
-	STREAM_GETW(client->ibuf, instance);
+	STREAM_GETC(msg, afi);
+	STREAM_GETC(msg, type);
+	STREAM_GETW(msg, instance);
 
 	if (afi == 0 || afi > AFI_MAX) {
 		zlog_warn("%s: Specified afi %d does not exist",

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -243,8 +243,7 @@ void redistribute_delete(struct prefix *p, struct prefix *src_p,
 	}
 }
 
-void zebra_redistribute_add(int command, struct zserv *client, int length,
-			    struct zebra_vrf *zvrf)
+void zebra_redistribute_add(ZAPI_HANDLER_ARGS)
 {
 	afi_t afi = 0;
 	int type = 0;
@@ -287,8 +286,7 @@ stream_failure:
 	return;
 }
 
-void zebra_redistribute_delete(int command, struct zserv *client, int length,
-			       struct zebra_vrf *zvrf)
+void zebra_redistribute_delete(ZAPI_HANDLER_ARGS)
 {
 	afi_t afi = 0;
 	int type = 0;
@@ -325,15 +323,13 @@ stream_failure:
 	return;
 }
 
-void zebra_redistribute_default_add(int command, struct zserv *client,
-				    int length, struct zebra_vrf *zvrf)
+void zebra_redistribute_default_add(ZAPI_HANDLER_ARGS)
 {
 	vrf_bitmap_set(client->redist_default, zvrf_id(zvrf));
 	zebra_redistribute_default(client, zvrf_id(zvrf));
 }
 
-void zebra_redistribute_default_delete(int command, struct zserv *client,
-				       int length, struct zebra_vrf *zvrf)
+void zebra_redistribute_default_delete(ZAPI_HANDLER_ARGS)
 {
 	vrf_bitmap_unset(client->redist_default, zvrf_id(zvrf));
 }

--- a/zebra/redistribute.h
+++ b/zebra/redistribute.h
@@ -27,15 +27,11 @@
 #include "vty.h"
 #include "vrf.h"
 
-extern void zebra_redistribute_add(int, struct zserv *, int,
-				   struct zebra_vrf *zvrf);
-extern void zebra_redistribute_delete(int, struct zserv *, int,
-				      struct zebra_vrf *zvrf);
-
-extern void zebra_redistribute_default_add(int, struct zserv *, int,
-					   struct zebra_vrf *zvrf);
-extern void zebra_redistribute_default_delete(int, struct zserv *, int,
-					      struct zebra_vrf *zvrf);
+/* zapi handlers */
+extern void zebra_redistribute_add(ZAPI_HANDLER_ARGS);
+extern void zebra_redistribute_delete(ZAPI_HANDLER_ARGS);
+extern void zebra_redistribute_default_add(ZAPI_HANDLER_ARGS);
+extern void zebra_redistribute_default_delete(ZAPI_HANDLER_ARGS);
 
 extern void redistribute_update(struct prefix *, struct prefix *,
 				struct route_entry *, struct route_entry *);

--- a/zebra/redistribute.h
+++ b/zebra/redistribute.h
@@ -27,11 +27,12 @@
 #include "vty.h"
 #include "vrf.h"
 
-/* zapi handlers */
+/* ZAPI command handlers */
 extern void zebra_redistribute_add(ZAPI_HANDLER_ARGS);
 extern void zebra_redistribute_delete(ZAPI_HANDLER_ARGS);
 extern void zebra_redistribute_default_add(ZAPI_HANDLER_ARGS);
 extern void zebra_redistribute_default_delete(ZAPI_HANDLER_ARGS);
+/* ----------------- */
 
 extern void redistribute_update(struct prefix *, struct prefix *,
 				struct route_entry *, struct route_entry *);

--- a/zebra/rtadv.h
+++ b/zebra/rtadv.h
@@ -103,8 +103,8 @@ typedef enum {
 extern void rtadv_init(struct zebra_ns *);
 extern void rtadv_terminate(struct zebra_ns *);
 extern void rtadv_cmd_init(void);
-extern void zebra_interface_radv_set(ZAPI_HANDLER_ARGS, int enable);
 extern void zebra_interface_radv_disable(ZAPI_HANDLER_ARGS);
 extern void zebra_interface_radv_enable(ZAPI_HANDLER_ARGS);
+
 
 #endif /* _ZEBRA_RTADV_H */

--- a/zebra/rtadv.h
+++ b/zebra/rtadv.h
@@ -103,7 +103,8 @@ typedef enum {
 extern void rtadv_init(struct zebra_ns *);
 extern void rtadv_terminate(struct zebra_ns *);
 extern void rtadv_cmd_init(void);
-extern void zebra_interface_radv_set(struct zserv *client, u_short length,
-				     struct zebra_vrf *zvrf, int enable);
+extern void zebra_interface_radv_set(ZAPI_HANDLER_ARGS, int enable);
+extern void zebra_interface_radv_disable(ZAPI_HANDLER_ARGS);
+extern void zebra_interface_radv_enable(ZAPI_HANDLER_ARGS);
 
 #endif /* _ZEBRA_RTADV_H */

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -455,8 +455,7 @@ static int fec_send(zebra_fec_t *fec, struct zserv *client)
 	rn = fec->rn;
 
 	/* Get output stream. */
-	s = client->obuf;
-	stream_reset(s);
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_FEC_UPDATE, VRF_DEFAULT);
 
@@ -464,7 +463,7 @@ static int fec_send(zebra_fec_t *fec, struct zserv *client)
 	stream_put_prefix(s, &rn->p);
 	stream_putl(s, fec->label);
 	stream_putw_at(s, 0, stream_get_endp(s));
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 /*

--- a/zebra/zebra_mroute.c
+++ b/zebra/zebra_mroute.c
@@ -31,9 +31,9 @@
 #include "zebra/zebra_mroute.h"
 #include "zebra/rt.h"
 #include "zebra/debug.h"
+#include "zebra/zserv.h"
 
-void zebra_ipmr_route_stats(struct zserv *client, u_short length,
-			    struct zebra_vrf *zvrf)
+void zebra_ipmr_route_stats(ZAPI_HANDLER_ARGS)
 {
 	struct mcast_route_data mroute;
 	struct stream *s;

--- a/zebra/zebra_mroute.c
+++ b/zebra/zebra_mroute.c
@@ -31,7 +31,6 @@
 #include "zebra/zebra_mroute.h"
 #include "zebra/rt.h"
 #include "zebra/debug.h"
-#include "zebra/zserv.h"
 
 void zebra_ipmr_route_stats(ZAPI_HANDLER_ARGS)
 {
@@ -40,9 +39,9 @@ void zebra_ipmr_route_stats(ZAPI_HANDLER_ARGS)
 	int suc = -1;
 
 	memset(&mroute, 0, sizeof(mroute));
-	STREAM_GET(&mroute.sg.src, client->ibuf, 4);
-	STREAM_GET(&mroute.sg.grp, client->ibuf, 4);
-	STREAM_GETL(client->ibuf, mroute.ifindex);
+	STREAM_GET(&mroute.sg.src, msg, 4);
+	STREAM_GET(&mroute.sg.grp, msg, 4);
+	STREAM_GETL(msg, mroute.ifindex);
 
 	if (IS_ZEBRA_DEBUG_KERNEL) {
 		char sbuf[40];
@@ -57,7 +56,7 @@ void zebra_ipmr_route_stats(ZAPI_HANDLER_ARGS)
 	suc = kernel_get_ipmr_sg_stats(zvrf, &mroute);
 
 stream_failure:
-	s = client->obuf;
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	stream_reset(s);
 
@@ -68,5 +67,5 @@ stream_failure:
 	stream_putl(s, suc);
 
 	stream_putw_at(s, 0, stream_get_endp(s));
-	zebra_server_send_message(client);
+	zebra_server_send_message(client, s);
 }

--- a/zebra/zebra_mroute.c
+++ b/zebra/zebra_mroute.c
@@ -32,8 +32,8 @@
 #include "zebra/rt.h"
 #include "zebra/debug.h"
 
-int zebra_ipmr_route_stats(struct zserv *client, u_short length,
-			   struct zebra_vrf *zvrf)
+void zebra_ipmr_route_stats(struct zserv *client, u_short length,
+			    struct zebra_vrf *zvrf)
 {
 	struct mcast_route_data mroute;
 	struct stream *s;
@@ -69,5 +69,4 @@ stream_failure:
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 	zebra_server_send_message(client);
-	return 0;
 }

--- a/zebra/zebra_mroute.h
+++ b/zebra/zebra_mroute.h
@@ -22,13 +22,14 @@
 #ifndef __ZEBRA_MROUTE_H__
 #define __ZEBRA_MROUTE_H__
 
+#include "zebra/zserv.h"
+
 struct mcast_route_data {
 	struct prefix_sg sg;
 	unsigned int ifindex;
 	unsigned long long lastused;
 };
 
-void zebra_ipmr_route_stats(struct zserv *client, u_short length,
-			    struct zebra_vrf *zvf);
+void zebra_ipmr_route_stats(ZAPI_HANDLER_ARGS);
 
 #endif

--- a/zebra/zebra_mroute.h
+++ b/zebra/zebra_mroute.h
@@ -28,7 +28,7 @@ struct mcast_route_data {
 	unsigned long long lastused;
 };
 
-int zebra_ipmr_route_stats(struct zserv *client, u_short length,
-			   struct zebra_vrf *zvf);
+void zebra_ipmr_route_stats(struct zserv *client, u_short length,
+			    struct zebra_vrf *zvf);
 
 #endif

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -661,8 +661,7 @@ int zebra_ptm_sock_read(struct thread *thread)
 }
 
 /* BFD peer/dst register/update */
-void zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
-				int command, struct zebra_vrf *zvrf)
+void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	struct prefix src_p;
@@ -680,14 +679,14 @@ void zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
 	int data_len = ZEBRA_PTM_SEND_MAX_SOCKBUF;
 	unsigned int pid;
 
-	if (command == ZEBRA_BFD_DEST_UPDATE)
+	if (hdr->command == ZEBRA_BFD_DEST_UPDATE)
 		client->bfd_peer_upd8_cnt++;
 	else
 		client->bfd_peer_add_cnt++;
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("bfd_dst_register msg from client %s: length=%d",
-			   zebra_route_string(client->proto), length);
+			   zebra_route_string(client->proto), hdr->length);
 
 	if (ptm_cb.ptm_sock == -1) {
 		ptm_cb.t_timer = NULL;
@@ -824,8 +823,7 @@ stream_failure:
 }
 
 /* BFD peer/dst deregister */
-void zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
-				  struct zebra_vrf *zvrf)
+void zebra_ptm_bfd_dst_deregister(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	struct prefix src_p;
@@ -843,7 +841,7 @@ void zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("bfd_dst_deregister msg from client %s: length=%d",
-			   zebra_route_string(client->proto), length);
+			   zebra_route_string(client->proto), hdr->length);
 
 	if (ptm_cb.ptm_sock == -1) {
 		ptm_cb.t_timer = NULL;
@@ -956,7 +954,7 @@ stream_failure:
 }
 
 /* BFD client register */
-void zebra_ptm_bfd_client_register(struct zserv *client, u_short length)
+void zebra_ptm_bfd_client_register(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	unsigned int pid;
@@ -968,7 +966,7 @@ void zebra_ptm_bfd_client_register(struct zserv *client, u_short length)
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("bfd_client_register msg from client %s: length=%d",
-			   zebra_route_string(client->proto), length);
+			   zebra_route_string(client->proto), hdr->length);
 
 	s = client->ibuf;
 	STREAM_GETL(s, pid);

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -702,7 +702,7 @@ void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_CLIENT_FIELD,
 			   tmp_buf);
 
-	s = client->ibuf;
+	s = msg;
 
 	STREAM_GETL(s, pid);
 	sprintf(tmp_buf, "%d", pid);
@@ -819,7 +819,6 @@ void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS)
 
 stream_failure:
 	ptm_lib_cleanup_msg(ptm_hdl, out_ctxt);
-	return;
 }
 
 /* BFD peer/dst deregister */
@@ -859,7 +858,7 @@ void zebra_ptm_bfd_dst_deregister(ZAPI_HANDLER_ARGS)
 	ptm_lib_append_msg(ptm_hdl, out_ctxt, ZEBRA_PTM_BFD_CLIENT_FIELD,
 			   tmp_buf);
 
-	s = client->ibuf;
+	s = msg;
 
 	STREAM_GETL(s, pid);
 	sprintf(tmp_buf, "%d", pid);
@@ -950,7 +949,6 @@ void zebra_ptm_bfd_dst_deregister(ZAPI_HANDLER_ARGS)
 
 stream_failure:
 	ptm_lib_cleanup_msg(ptm_hdl, out_ctxt);
-	return;
 }
 
 /* BFD client register */
@@ -968,7 +966,7 @@ void zebra_ptm_bfd_client_register(ZAPI_HANDLER_ARGS)
 		zlog_debug("bfd_client_register msg from client %s: length=%d",
 			   zebra_route_string(client->proto), hdr->length);
 
-	s = client->ibuf;
+	s = msg;
 	STREAM_GETL(s, pid);
 
 	if (ptm_cb.ptm_sock == -1) {

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -661,8 +661,8 @@ int zebra_ptm_sock_read(struct thread *thread)
 }
 
 /* BFD peer/dst register/update */
-int zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
-			       int command, struct zebra_vrf *zvrf)
+void zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
+				int command, struct zebra_vrf *zvrf)
 {
 	struct stream *s;
 	struct prefix src_p;
@@ -693,7 +693,7 @@ int zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
 		ptm_cb.t_timer = NULL;
 		thread_add_timer(zebrad.master, zebra_ptm_connect, NULL,
 				 ptm_cb.reconnect_time, &ptm_cb.t_timer);
-		return -1;
+		return;
 	}
 
 	ptm_lib_init_msg(ptm_hdl, 0, PTMLIB_MSG_TYPE_CMD, NULL, &out_ctxt);
@@ -816,16 +816,16 @@ int zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
 			   ptm_cb.out_data);
 	zebra_ptm_send_message(ptm_cb.out_data, data_len);
 
-	return 0;
+	return;
 
 stream_failure:
 	ptm_lib_cleanup_msg(ptm_hdl, out_ctxt);
-	return 0;
+	return;
 }
 
 /* BFD peer/dst deregister */
-int zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
-				 struct zebra_vrf *zvrf)
+void zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
+				  struct zebra_vrf *zvrf)
 {
 	struct stream *s;
 	struct prefix src_p;
@@ -849,7 +849,7 @@ int zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
 		ptm_cb.t_timer = NULL;
 		thread_add_timer(zebrad.master, zebra_ptm_connect, NULL,
 				 ptm_cb.reconnect_time, &ptm_cb.t_timer);
-		return -1;
+		return;
 	}
 
 	ptm_lib_init_msg(ptm_hdl, 0, PTMLIB_MSG_TYPE_CMD, NULL, &out_ctxt);
@@ -948,15 +948,15 @@ int zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
 
 	zebra_ptm_send_message(ptm_cb.out_data, data_len);
 
-	return 0;
+	return;
 
 stream_failure:
 	ptm_lib_cleanup_msg(ptm_hdl, out_ctxt);
-	return 0;
+	return;
 }
 
 /* BFD client register */
-int zebra_ptm_bfd_client_register(struct zserv *client, u_short length)
+void zebra_ptm_bfd_client_register(struct zserv *client, u_short length)
 {
 	struct stream *s;
 	unsigned int pid;
@@ -977,7 +977,7 @@ int zebra_ptm_bfd_client_register(struct zserv *client, u_short length)
 		ptm_cb.t_timer = NULL;
 		thread_add_timer(zebrad.master, zebra_ptm_connect, NULL,
 				 ptm_cb.reconnect_time, &ptm_cb.t_timer);
-		return -1;
+		return;
 	}
 
 	ptm_lib_init_msg(ptm_hdl, 0, PTMLIB_MSG_TYPE_CMD, NULL, &out_ctxt);
@@ -1003,7 +1003,7 @@ int zebra_ptm_bfd_client_register(struct zserv *client, u_short length)
 	SET_FLAG(ptm_cb.client_flags[client->proto],
 		 ZEBRA_PTM_BFD_CLIENT_FLAG_REG);
 
-	return 0;
+	return;
 
 stream_failure:
 	/*
@@ -1013,7 +1013,7 @@ stream_failure:
 	 * if (out_ctxt)
 	 *	ptm_lib_cleanup_msg(ptm_hdl, out_ctxt);
 	 */
-	return 0;
+	return;
 }
 
 /* BFD client deregister */

--- a/zebra/zebra_ptm.h
+++ b/zebra/zebra_ptm.h
@@ -62,12 +62,12 @@ int zebra_ptm_connect(struct thread *t);
 void zebra_ptm_write(struct vty *vty);
 int zebra_ptm_get_enable_state(void);
 
-int zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
-			       int command, struct zebra_vrf *zvrf);
-int zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
-				 struct zebra_vrf *zvrf);
+void zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
+				int command, struct zebra_vrf *zvrf);
+void zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
+				  struct zebra_vrf *zvrf);
 void zebra_ptm_show_status(struct vty *vty, struct interface *ifp);
-int zebra_ptm_bfd_client_register(struct zserv *client, u_short length);
+void zebra_ptm_bfd_client_register(struct zserv *client, u_short length);
 void zebra_ptm_if_init(struct zebra_if *zebra_ifp);
 void zebra_ptm_if_set_ptm_state(struct interface *ifp,
 				struct zebra_if *zebra_ifp);

--- a/zebra/zebra_ptm.h
+++ b/zebra/zebra_ptm.h
@@ -22,13 +22,13 @@
 #ifndef _ZEBRA_PTM_H
 #define _ZEBRA_PTM_H
 
-#include "zebra/zserv.h"
-
 extern const char ZEBRA_PTM_SOCK_NAME[];
 #define ZEBRA_PTM_MAX_SOCKBUF 3200 /* 25B *128 ports */
 #define ZEBRA_PTM_SEND_MAX_SOCKBUF 512
 
 #define ZEBRA_PTM_BFD_CLIENT_FLAG_REG   (1 << 1) /* client registered with BFD */
+
+#include "zebra/zserv.h"
 
 /* Zebra ptm context block */
 struct zebra_ptm_cb {
@@ -64,6 +64,7 @@ int zebra_ptm_connect(struct thread *t);
 void zebra_ptm_write(struct vty *vty);
 int zebra_ptm_get_enable_state(void);
 
+/* ZAPI message handlers */
 void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS);
 void zebra_ptm_bfd_dst_deregister(ZAPI_HANDLER_ARGS);
 void zebra_ptm_bfd_client_register(ZAPI_HANDLER_ARGS);

--- a/zebra/zebra_ptm.h
+++ b/zebra/zebra_ptm.h
@@ -22,6 +22,8 @@
 #ifndef _ZEBRA_PTM_H
 #define _ZEBRA_PTM_H
 
+#include "zebra/zserv.h"
+
 extern const char ZEBRA_PTM_SOCK_NAME[];
 #define ZEBRA_PTM_MAX_SOCKBUF 3200 /* 25B *128 ports */
 #define ZEBRA_PTM_SEND_MAX_SOCKBUF 512
@@ -62,12 +64,11 @@ int zebra_ptm_connect(struct thread *t);
 void zebra_ptm_write(struct vty *vty);
 int zebra_ptm_get_enable_state(void);
 
-void zebra_ptm_bfd_dst_register(struct zserv *client, u_short length,
-				int command, struct zebra_vrf *zvrf);
-void zebra_ptm_bfd_dst_deregister(struct zserv *client, u_short length,
-				  struct zebra_vrf *zvrf);
+void zebra_ptm_bfd_dst_register(ZAPI_HANDLER_ARGS);
+void zebra_ptm_bfd_dst_deregister(ZAPI_HANDLER_ARGS);
+void zebra_ptm_bfd_client_register(ZAPI_HANDLER_ARGS);
+
 void zebra_ptm_show_status(struct vty *vty, struct interface *ifp);
-void zebra_ptm_bfd_client_register(struct zserv *client, u_short length);
 void zebra_ptm_if_init(struct zebra_if *zebra_ifp);
 void zebra_ptm_if_set_ptm_state(struct interface *ifp,
 				struct zebra_if *zebra_ifp);

--- a/zebra/zebra_ptm_redistribute.c
+++ b/zebra/zebra_ptm_redistribute.c
@@ -38,8 +38,7 @@ static int zsend_interface_bfd_update(int cmd, struct zserv *client,
 	if (!client->ifinfo)
 		return 0;
 
-	s = client->obuf;
-	stream_reset(s);
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, vrf_id);
 	if (ifp)
@@ -66,7 +65,7 @@ static int zsend_interface_bfd_update(int cmd, struct zserv *client,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->if_bfd_cnt++;
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 void zebra_interface_bfd_update(struct interface *ifp, struct prefix *dp,
@@ -93,8 +92,7 @@ static int zsend_bfd_peer_replay(int cmd, struct zserv *client)
 {
 	struct stream *s;
 
-	s = client->obuf;
-	stream_reset(s);
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, VRF_DEFAULT);
 
@@ -102,7 +100,7 @@ static int zsend_bfd_peer_replay(int cmd, struct zserv *client)
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->bfd_peer_replay_cnt++;
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 void zebra_bfd_peer_replay_req(void)

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -995,8 +995,7 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 	re = rnh->state;
 
 	/* Get output stream. */
-	s = client->obuf;
-	stream_reset(s);
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, vrf_id);
 
@@ -1063,7 +1062,7 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 
 	client->nh_last_upd_time = monotime(NULL);
 	client->last_write_cmd = cmd;
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 static void print_nh(struct nexthop *nexthop, struct vty *vty)

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4863,8 +4863,8 @@ int zebra_vxlan_local_neigh_add_update(struct interface *ifp,
 /*
  * Handle message from client to delete a remote MACIP for a VNI.
  */
-int zebra_vxlan_remote_macip_del(struct zserv *client, u_short length,
-				 struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_macip_del(struct zserv *client, u_short length,
+				  struct zebra_vrf *zvrf)
 {
 	struct stream *s;
 	vni_t vni;
@@ -5008,7 +5008,7 @@ int zebra_vxlan_remote_macip_del(struct zserv *client, u_short length,
 	}
 
 stream_failure:
-	return 0;
+	return;
 }
 
 /*
@@ -5016,8 +5016,8 @@ stream_failure:
  * could be just the add of a MAC address or the add of a neighbor
  * (IP+MAC).
  */
-int zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
-				 struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
+				  struct zebra_vrf *zvrf)
 {
 	struct stream *s;
 	vni_t vni;
@@ -5045,7 +5045,7 @@ int zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
 		zlog_warn(
 			"%s: EVPN Not turned on yet we have received a remote_macip add zapi callback",
 			__PRETTY_FUNCTION__);
-		return -1;
+		return;
 	}
 
 	s = client->ibuf;
@@ -5159,7 +5159,7 @@ int zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
 						prefix_mac2str(&macaddr, buf,
 							       sizeof(buf)),
 						vni, inet_ntoa(vtep_ip));
-					return -1;
+					return;
 				}
 
 				/* Is this MAC created for a MACIP? */
@@ -5212,7 +5212,7 @@ int zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
 						prefix_mac2str(&macaddr, buf,
 							       sizeof(buf)),
 						vni, inet_ntoa(vtep_ip));
-					return -1;
+					return;
 				}
 
 			} else if (memcmp(&n->emac, &macaddr, sizeof(macaddr))
@@ -5240,7 +5240,7 @@ int zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
 	}
 
 stream_failure:
-	return 0;
+	return;
 }
 
 /*
@@ -5543,8 +5543,8 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 /*
  * Handle message from client to delete a remote VTEP for a VNI.
  */
-int zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
-				struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
+				 struct zebra_vrf *zvrf)
 {
 	struct stream *s;
 	u_short l = 0;
@@ -5559,13 +5559,13 @@ int zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
 		zlog_warn(
 			"%s: EVPN is not enabled yet we have received a vtep del command",
 			__PRETTY_FUNCTION__);
-		return -1;
+		return;
 	}
 
 	if (zvrf_id(zvrf) != VRF_DEFAULT) {
 		zlog_err("Recv MACIP DEL for non-default VRF %u",
 			 zvrf_id(zvrf));
-		return -1;
+		return;
 	}
 
 	s = client->ibuf;
@@ -5623,14 +5623,14 @@ int zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
 	}
 
 stream_failure:
-	return 0;
+	return;
 }
 
 /*
  * Handle message from client to add a remote VTEP for a VNI.
  */
-int zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
-				struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
+				 struct zebra_vrf *zvrf)
 {
 	struct stream *s;
 	u_short l = 0;
@@ -5644,13 +5644,13 @@ int zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
 		zlog_warn(
 			"%s: EVPN not enabled yet we received a vtep_add zapi call",
 			__PRETTY_FUNCTION__);
-		return -1;
+		return;
 	}
 
 	if (zvrf_id(zvrf) != VRF_DEFAULT) {
 		zlog_err("Recv MACIP ADD for non-default VRF %u",
 			 zvrf_id(zvrf));
-		return -1;
+		return;
 	}
 
 	s = client->ibuf;
@@ -5705,7 +5705,7 @@ int zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
 	}
 
 stream_failure:
-	return 0;
+	return;
 }
 
 /*
@@ -6512,8 +6512,8 @@ int zebra_vxlan_vrf_delete(struct zebra_vrf *zvrf)
  * Handle message from client to enable/disable advertisement of g/w macip
  * routes
  */
-int zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
-				 struct zebra_vrf *zvrf)
+void zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
+				  struct zebra_vrf *zvrf)
 {
 	struct stream *s;
 	int advertise;
@@ -6527,7 +6527,7 @@ int zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
 	if (zvrf_id(zvrf) != VRF_DEFAULT) {
 		zlog_err("EVPN GW-MACIP Adv for non-default VRF %u",
 			 zvrf_id(zvrf));
-		return -1;
+		return;
 	}
 
 	s = client->ibuf;
@@ -6536,10 +6536,10 @@ int zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
 
 	zvni = zvni_lookup(vni);
 	if (!zvni)
-		return 0;
+		return;
 
 	if (zvni->advertise_subnet == advertise)
-		return 0;
+		return;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug("EVPN subnet Adv %s on VNI %d , currently %s",
@@ -6551,35 +6551,35 @@ int zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
 
 	ifp = zvni->vxlan_if;
 	if (!ifp)
-		return 0;
+		return;
 
 	zif = ifp->info;
 
 	/* If down or not mapped to a bridge, we're done. */
 	if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
-		return 0;
+		return;
 
 	zl2_info = zif->l2info.vxl;
 
 	vlan_if =
 		zvni_map_to_svi(zl2_info.access_vlan, zif->brslave_info.br_if);
 	if (!vlan_if)
-		return 0;
+		return;
 
 	if (zvni->advertise_subnet)
 		zvni_advertise_subnet(zvni, vlan_if, 1);
 	else
 		zvni_advertise_subnet(zvni, vlan_if, 0);
 
-	return 0;
+	return;
 }
 
 /*
  * Handle message from client to enable/disable advertisement of g/w macip
  * routes
  */
-int zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
-				   struct zebra_vrf *zvrf)
+void zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
+				    struct zebra_vrf *zvrf)
 {
 	struct stream *s;
 	int advertise;
@@ -6590,7 +6590,7 @@ int zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
 	if (zvrf_id(zvrf) != VRF_DEFAULT) {
 		zlog_err("EVPN GW-MACIP Adv for non-default VRF %u",
 			 zvrf_id(zvrf));
-		return -1;
+		return;
 	}
 
 	s = client->ibuf;
@@ -6606,7 +6606,7 @@ int zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
 					   : "disabled");
 
 		if (zvrf->advertise_gw_macip == advertise)
-			return 0;
+			return;
 
 		zvrf->advertise_gw_macip = advertise;
 
@@ -6625,7 +6625,7 @@ int zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
 
 		zvni = zvni_lookup(vni);
 		if (!zvni)
-			return 0;
+			return;
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
@@ -6635,26 +6635,26 @@ int zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
 								 : "disabled");
 
 		if (zvni->advertise_gw_macip == advertise)
-			return 0;
+			return;
 
 		zvni->advertise_gw_macip = advertise;
 
 		ifp = zvni->vxlan_if;
 		if (!ifp)
-			return 0;
+			return;
 
 		zif = ifp->info;
 
 		/* If down or not mapped to a bridge, we're done. */
 		if (!if_is_operative(ifp) || !zif->brslave_info.br_if)
-			return 0;
+			return;
 
 		zl2_info = zif->l2info.vxl;
 
 		vlan_if = zvni_map_to_svi(zl2_info.access_vlan,
 					  zif->brslave_info.br_if);
 		if (!vlan_if)
-			return 0;
+			return;
 
 		if (advertise_gw_macip_enabled(zvni)) {
 			/* Add primary SVI MAC-IP */
@@ -6676,7 +6676,7 @@ int zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
 	}
 
 stream_failure:
-	return 0;
+	return;
 }
 
 
@@ -6686,8 +6686,8 @@ stream_failure:
  * when disabled, the entries should be deleted and remote VTEPs and MACs
  * uninstalled from the kernel.
  */
-int zebra_vxlan_advertise_all_vni(struct zserv *client, u_short length,
-				  struct zebra_vrf *zvrf)
+void zebra_vxlan_advertise_all_vni(struct zserv *client, u_short length,
+				   struct zebra_vrf *zvrf)
 {
 	struct stream *s = NULL;
 	int advertise = 0;
@@ -6695,7 +6695,7 @@ int zebra_vxlan_advertise_all_vni(struct zserv *client, u_short length,
 
 	if (zvrf_id(zvrf) != VRF_DEFAULT) {
 		zlog_err("EVPN VNI Adv for non-default VRF %u", zvrf_id(zvrf));
-		return -1;
+		return;
 	}
 
 	s = client->ibuf;
@@ -6707,7 +6707,7 @@ int zebra_vxlan_advertise_all_vni(struct zserv *client, u_short length,
 			   is_evpn_enabled() ? "enabled" : "disabled");
 
 	if (zvrf->advertise_all_vni == advertise)
-		return 0;
+		return;
 
 	zvrf->advertise_all_vni = advertise;
 	if (is_evpn_enabled()) {
@@ -6732,13 +6732,13 @@ int zebra_vxlan_advertise_all_vni(struct zserv *client, u_short length,
 		/* cleanup all l3vnis */
 		zns = zebra_ns_lookup(NS_DEFAULT);
 		if (!zns)
-			return -1;
+			return;
 
 		hash_iterate(zns->l3vni_table, zl3vni_cleanup_all, NULL);
 	}
 
 stream_failure:
-	return 0;
+	return;
 }
 
 /*

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -46,6 +46,7 @@
 #include "zebra/zebra_vxlan.h"
 #include "zebra/zebra_memory.h"
 #include "zebra/zebra_l2.h"
+#include "zebra/zserv.h"
 
 DEFINE_MTYPE_STATIC(ZEBRA, HOST_PREFIX, "host prefix");
 DEFINE_MTYPE_STATIC(ZEBRA, ZVNI, "VNI hash");
@@ -4863,8 +4864,7 @@ int zebra_vxlan_local_neigh_add_update(struct interface *ifp,
 /*
  * Handle message from client to delete a remote MACIP for a VNI.
  */
-void zebra_vxlan_remote_macip_del(struct zserv *client, u_short length,
-				  struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_macip_del(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	vni_t vni;
@@ -4886,7 +4886,7 @@ void zebra_vxlan_remote_macip_del(struct zserv *client, u_short length,
 
 	s = client->ibuf;
 
-	while (l < length) {
+	while (l < hdr->length) {
 		/* Obtain each remote MACIP and process. */
 		/* Message contains VNI, followed by MAC followed by IP (if any)
 		 * followed by remote VTEP IP.
@@ -5016,8 +5016,7 @@ stream_failure:
  * could be just the add of a MAC address or the add of a neighbor
  * (IP+MAC).
  */
-void zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
-				  struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_macip_add(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	vni_t vni;
@@ -5050,7 +5049,7 @@ void zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
 
 	s = client->ibuf;
 
-	while (l < length) {
+	while (l < hdr->length) {
 		/* Obtain each remote MACIP and process. */
 		/* Message contains VNI, followed by MAC followed by IP (if any)
 		 * followed by remote VTEP IP.
@@ -5543,8 +5542,7 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 /*
  * Handle message from client to delete a remote VTEP for a VNI.
  */
-void zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
-				 struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_vtep_del(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	u_short l = 0;
@@ -5570,7 +5568,7 @@ void zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
 
 	s = client->ibuf;
 
-	while (l < length) {
+	while (l < hdr->length) {
 		/* Obtain each remote VTEP and process. */
 		STREAM_GETL(s, vni);
 		l += 4;
@@ -5629,8 +5627,7 @@ stream_failure:
 /*
  * Handle message from client to add a remote VTEP for a VNI.
  */
-void zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
-				 struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_vtep_add(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	u_short l = 0;
@@ -5655,7 +5652,7 @@ void zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
 
 	s = client->ibuf;
 
-	while (l < length) {
+	while (l < hdr->length) {
 		/* Obtain each remote VTEP and process. */
 		STREAM_GETL(s, vni);
 		l += 4;
@@ -6512,8 +6509,7 @@ int zebra_vxlan_vrf_delete(struct zebra_vrf *zvrf)
  * Handle message from client to enable/disable advertisement of g/w macip
  * routes
  */
-void zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
-				  struct zebra_vrf *zvrf)
+void zebra_vxlan_advertise_subnet(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	int advertise;
@@ -6578,8 +6574,7 @@ void zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
  * Handle message from client to enable/disable advertisement of g/w macip
  * routes
  */
-void zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
-				    struct zebra_vrf *zvrf)
+void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
 	int advertise;
@@ -6686,8 +6681,8 @@ stream_failure:
  * when disabled, the entries should be deleted and remote VTEPs and MACs
  * uninstalled from the kernel.
  */
-void zebra_vxlan_advertise_all_vni(struct zserv *client, u_short length,
-				   struct zebra_vrf *zvrf)
+void zebra_vxlan_advertise_all_vni(ZAPI_HANDLER_ARGS)
+
 {
 	struct stream *s = NULL;
 	int advertise = 0;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -6612,7 +6612,7 @@ void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS)
 
 		zvni = zvni_lookup(vni);
 		if (!zvni)
-			return 0;
+			return;
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -51,6 +51,22 @@ static inline int is_evpn_enabled()
 
 #define VNI_STR_LEN 32
 
+/* zserv handlers */
+extern void zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
+					 struct zebra_vrf *zvrf);
+extern void zebra_vxlan_remote_macip_del(struct zserv *client, u_short length,
+					 struct zebra_vrf *zvrf);
+extern void zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
+					struct zebra_vrf *zvrf);
+extern void zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
+					struct zebra_vrf *zvrf);
+extern void zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
+					 struct zebra_vrf *zvrf);
+extern void zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
+					   struct zebra_vrf *zvrf);
+extern void zebra_vxlan_advertise_all_vni(struct zserv *client, u_short length,
+					  struct zebra_vrf *zvrf);
+
 extern int is_l3vni_for_prefix_routes_only(vni_t vni);
 extern ifindex_t get_l3vni_svi_ifindex(vrf_id_t vrf_id);
 extern int zebra_vxlan_vrf_delete(struct zebra_vrf *zvrf);
@@ -117,10 +133,6 @@ extern int zebra_vxlan_local_neigh_add_update(
 extern int zebra_vxlan_local_neigh_del(struct interface *ifp,
 				       struct interface *link_if,
 				       struct ipaddr *ip);
-extern int zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
-					struct zebra_vrf *zvrf);
-extern int zebra_vxlan_remote_macip_del(struct zserv *client, u_short length,
-					struct zebra_vrf *zvrf);
 extern int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 					    struct interface *br_if,
 					    struct ethaddr *mac, vlanid_t vid,
@@ -140,16 +152,6 @@ extern int zebra_vxlan_if_down(struct interface *ifp);
 extern int zebra_vxlan_if_add(struct interface *ifp);
 extern int zebra_vxlan_if_update(struct interface *ifp, u_int16_t chgflags);
 extern int zebra_vxlan_if_del(struct interface *ifp);
-extern int zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
-				       struct zebra_vrf *zvrf);
-extern int zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
-				       struct zebra_vrf *zvrf);
-extern int zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
-					struct zebra_vrf *zvrf);
-extern int zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
-					  struct zebra_vrf *zvrf);
-extern int zebra_vxlan_advertise_all_vni(struct zserv *client, u_short length,
-					 struct zebra_vrf *zvrf);
 extern int zebra_vxlan_process_vrf_vni_cmd(struct zebra_vrf *zvrf, vni_t vni,
 					   char *err, int err_str_sz,
 					   int filter, int add);

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -52,7 +52,7 @@ static inline int is_evpn_enabled()
 
 #define VNI_STR_LEN 32
 
-/* zserv handlers */
+/* ZAPI message handlers */
 extern void zebra_vxlan_remote_macip_add(ZAPI_HANDLER_ARGS);
 extern void zebra_vxlan_remote_macip_del(ZAPI_HANDLER_ARGS);
 extern void zebra_vxlan_remote_vtep_add(ZAPI_HANDLER_ARGS);
@@ -60,7 +60,6 @@ extern void zebra_vxlan_remote_vtep_del(ZAPI_HANDLER_ARGS);
 extern void zebra_vxlan_advertise_subnet(ZAPI_HANDLER_ARGS);
 extern void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS);
 extern void zebra_vxlan_advertise_all_vni(ZAPI_HANDLER_ARGS);
-
 
 extern int is_l3vni_for_prefix_routes_only(vni_t vni);
 extern ifindex_t get_l3vni_svi_ifindex(vrf_id_t vrf_id);

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -33,6 +33,7 @@
 
 #include "lib/json.h"
 #include "zebra/zebra_vrf.h"
+#include "zebra/zserv.h"
 
 /* Is EVPN enabled? */
 #define EVPN_ENABLED(zvrf)  (zvrf)->advertise_all_vni
@@ -52,20 +53,14 @@ static inline int is_evpn_enabled()
 #define VNI_STR_LEN 32
 
 /* zserv handlers */
-extern void zebra_vxlan_remote_macip_add(struct zserv *client, u_short length,
-					 struct zebra_vrf *zvrf);
-extern void zebra_vxlan_remote_macip_del(struct zserv *client, u_short length,
-					 struct zebra_vrf *zvrf);
-extern void zebra_vxlan_remote_vtep_add(struct zserv *client, u_short length,
-					struct zebra_vrf *zvrf);
-extern void zebra_vxlan_remote_vtep_del(struct zserv *client, u_short length,
-					struct zebra_vrf *zvrf);
-extern void zebra_vxlan_advertise_subnet(struct zserv *client, u_short length,
-					 struct zebra_vrf *zvrf);
-extern void zebra_vxlan_advertise_gw_macip(struct zserv *client, u_short length,
-					   struct zebra_vrf *zvrf);
-extern void zebra_vxlan_advertise_all_vni(struct zserv *client, u_short length,
-					  struct zebra_vrf *zvrf);
+extern void zebra_vxlan_remote_macip_add(ZAPI_HANDLER_ARGS);
+extern void zebra_vxlan_remote_macip_del(ZAPI_HANDLER_ARGS);
+extern void zebra_vxlan_remote_vtep_add(ZAPI_HANDLER_ARGS);
+extern void zebra_vxlan_remote_vtep_del(ZAPI_HANDLER_ARGS);
+extern void zebra_vxlan_advertise_subnet(ZAPI_HANDLER_ARGS);
+extern void zebra_vxlan_advertise_gw_macip(ZAPI_HANDLER_ARGS);
+extern void zebra_vxlan_advertise_all_vni(ZAPI_HANDLER_ARGS);
+
 
 extern int is_l3vni_for_prefix_routes_only(vni_t vni);
 extern ifindex_t get_l3vni_svi_ifindex(vrf_id_t vrf_id);

--- a/zebra/zebra_vxlan_null.c
+++ b/zebra/zebra_vxlan_null.c
@@ -117,14 +117,14 @@ int zebra_vxlan_svi_down(struct interface *ifp, struct interface *link_if)
 	return 0;
 }
 
-int zebra_vxlan_remote_macip_add(struct zserv *client, int sock, u_short length,
-				 struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_macip_add(struct zserv *client, int sock,
+				  u_short length, struct zebra_vrf *zvrf)
 {
 	return 0;
 }
 
-int zebra_vxlan_remote_macip_del(struct zserv *client, int sock, u_short length,
-				 struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_macip_del(struct zserv *client, int sock,
+				  u_short length, struct zebra_vrf *zvrf)
 {
 	return 0;
 }
@@ -182,20 +182,20 @@ int zebra_vxlan_if_del(struct interface *ifp)
 	return 0;
 }
 
-int zebra_vxlan_remote_vtep_add(struct zserv *client, int sock, u_short length,
-				struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_vtep_add(struct zserv *client, int sock, u_short length,
+				 struct zebra_vrf *zvrf)
 {
 	return 0;
 }
 
-int zebra_vxlan_remote_vtep_del(struct zserv *client, int sock, u_short length,
-				struct zebra_vrf *zvrf)
+void zebra_vxlan_remote_vtep_del(struct zserv *client, int sock, u_short length,
+				 struct zebra_vrf *zvrf)
 {
 	return 0;
 }
 
-int zebra_vxlan_advertise_all_vni(struct zserv *client, int sock,
-				  u_short length, struct zebra_vrf *zvrf)
+void zebra_vxlan_advertise_all_vni(struct zserv *client, int sock,
+				   u_short length, struct zebra_vrf *zvrf)
 {
 	return 0;
 }

--- a/zebra/zebra_vxlan_null.c
+++ b/zebra/zebra_vxlan_null.c
@@ -117,14 +117,14 @@ int zebra_vxlan_svi_down(struct interface *ifp, struct interface *link_if)
 	return 0;
 }
 
-void zebra_vxlan_remote_macip_add(struct zserv *client, int sock,
-				  u_short length, struct zebra_vrf *zvrf)
+int zebra_vxlan_remote_macip_add(struct zserv *client, int sock, u_short length,
+				 struct zebra_vrf *zvrf)
 {
 	return 0;
 }
 
-void zebra_vxlan_remote_macip_del(struct zserv *client, int sock,
-				  u_short length, struct zebra_vrf *zvrf)
+int zebra_vxlan_remote_macip_del(struct zserv *client, int sock, u_short length,
+				 struct zebra_vrf *zvrf)
 {
 	return 0;
 }
@@ -182,20 +182,20 @@ int zebra_vxlan_if_del(struct interface *ifp)
 	return 0;
 }
 
-void zebra_vxlan_remote_vtep_add(struct zserv *client, int sock, u_short length,
-				 struct zebra_vrf *zvrf)
+int zebra_vxlan_remote_vtep_add(struct zserv *client, int sock, u_short length,
+				struct zebra_vrf *zvrf)
 {
 	return 0;
 }
 
-void zebra_vxlan_remote_vtep_del(struct zserv *client, int sock, u_short length,
-				 struct zebra_vrf *zvrf)
+int zebra_vxlan_remote_vtep_del(struct zserv *client, int sock, u_short length,
+				struct zebra_vrf *zvrf)
 {
 	return 0;
 }
 
-void zebra_vxlan_advertise_all_vni(struct zserv *client, int sock,
-				   u_short length, struct zebra_vrf *zvrf)
+int zebra_vxlan_advertise_all_vni(struct zserv *client, int sock,
+				  u_short length, struct zebra_vrf *zvrf)
 {
 	return 0;
 }

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -636,7 +636,7 @@ static int zsend_ipv4_nexthop_lookup_mrib(struct zserv *client,
 		 * chain of nexthops. */
 		for (nexthop = re->ng.nexthop; nexthop; nexthop = nexthop->next)
 			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
-				num += zsend_write_nexthop(s, nexthop);
+				num += zserv_encode_nexthop(s, nexthop);
 
 		stream_putc_at(s, nump, num); /* store nexthop_num */
 	} else {
@@ -706,8 +706,8 @@ void zsend_rule_notify_owner(struct zebra_pbr_rule *rule,
 	struct stream *s;
 
 	if (IS_ZEBRA_DEBUG_PACKET) {
-		zlog_debug("%s: Notifying %u",
-			   __PRETTY_FUNCTION__, rule->unique);
+		zlog_debug("%s: Notifying %u", __PRETTY_FUNCTION__,
+			   rule->unique);
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(zebrad.client_list, node, client)) {
@@ -1089,7 +1089,6 @@ static void zread_fec_unregister(ZAPI_HANDLER_ARGS)
 stream_failure:
 	return;
 }
-
 
 
 /*

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -63,94 +63,23 @@
 #include "zebra/zebra_pbr.h"
 
 /* Event list of zebra. */
-enum event { ZEBRA_SERV, ZEBRA_READ, ZEBRA_WRITE };
-
-static void zebra_event(enum event event, int sock, struct zserv *client);
-
+enum event { ZEBRA_READ, ZEBRA_WRITE };
+/* privileges */
 extern struct zebra_privs_t zserv_privs;
+/* post event into client */
+static void zebra_event(struct zserv *client, enum event event);
 
-static void zebra_client_close(struct zserv *client);
 
-static int zserv_delayed_close(struct thread *thread)
+/* Public interface ======================================================== */
+
+int zebra_server_send_message(struct zserv *client, struct stream *msg)
 {
-	struct zserv *client = THREAD_ARG(thread);
-
-	client->t_suicide = NULL;
-	zebra_client_close(client);
+	stream_fifo_push(client->obuf_fifo, msg);
+	zebra_event(client, ZEBRA_WRITE);
 	return 0;
 }
 
-static int zserv_flush_data(struct thread *thread)
-{
-	struct zserv *client = THREAD_ARG(thread);
-
-	client->t_write = NULL;
-	if (client->t_suicide) {
-		zebra_client_close(client);
-		return -1;
-	}
-	switch (buffer_flush_available(client->wb, client->sock)) {
-	case BUFFER_ERROR:
-		zlog_warn(
-			"%s: buffer_flush_available failed on zserv client fd %d, "
-			"closing",
-			__func__, client->sock);
-		zebra_client_close(client);
-		client = NULL;
-		break;
-	case BUFFER_PENDING:
-		client->t_write = NULL;
-		thread_add_write(zebrad.master, zserv_flush_data, client,
-				 client->sock, &client->t_write);
-		break;
-	case BUFFER_EMPTY:
-		break;
-	}
-
-	if (client)
-		client->last_write_time = monotime(NULL);
-	return 0;
-}
-
-int zebra_server_send_message(struct zserv *client)
-{
-	if (client->t_suicide)
-		return -1;
-
-	if (client->is_synchronous)
-		return 0;
-
-	stream_set_getp(client->obuf, 0);
-	client->last_write_cmd = stream_getw_from(client->obuf, 6);
-	switch (buffer_write(client->wb, client->sock,
-			     STREAM_DATA(client->obuf),
-			     stream_get_endp(client->obuf))) {
-	case BUFFER_ERROR:
-		zlog_warn(
-			"%s: buffer_write failed to zserv client fd %d, closing",
-			__func__, client->sock);
-		/* Schedule a delayed close since many of the functions that
-		   call this
-		   one do not check the return code.  They do not allow for the
-		   possibility that an I/O error may have caused the client to
-		   be
-		   deleted. */
-		client->t_suicide = NULL;
-		thread_add_event(zebrad.master, zserv_delayed_close, client, 0,
-				 &client->t_suicide);
-		return -1;
-	case BUFFER_EMPTY:
-		THREAD_OFF(client->t_write);
-		break;
-	case BUFFER_PENDING:
-		thread_add_write(zebrad.master, zserv_flush_data, client,
-				 client->sock, &client->t_write);
-		break;
-	}
-
-	client->last_write_time = monotime(NULL);
-	return 0;
-}
+/* Encoding helpers -------------------------------------------------------- */
 
 static void zserv_encode_interface(struct stream *s, struct interface *ifp)
 {
@@ -202,6 +131,34 @@ static void zserv_encode_vrf(struct stream *s, struct zebra_vrf *zvrf)
 	stream_putw_at(s, 0, stream_get_endp(s));
 }
 
+static int zserv_encode_nexthop(struct stream *s, struct nexthop *nexthop)
+{
+	stream_putc(s, nexthop->type);
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		stream_put_in_addr(s, &nexthop->gate.ipv4);
+		stream_putl(s, nexthop->ifindex);
+		break;
+	case NEXTHOP_TYPE_IPV6:
+		stream_put(s, &nexthop->gate.ipv6, 16);
+		break;
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		stream_put(s, &nexthop->gate.ipv6, 16);
+		stream_putl(s, nexthop->ifindex);
+		break;
+	case NEXTHOP_TYPE_IFINDEX:
+		stream_putl(s, nexthop->ifindex);
+		break;
+	default:
+		/* do nothing */
+		break;
+	}
+	return 1;
+}
+
+/* Send handlers ----------------------------------------------------------- */
+
 /* Interface is added. Send ZEBRA_INTERFACE_ADD to client. */
 /*
  * This function is called in the following situations:
@@ -215,65 +172,54 @@ static void zserv_encode_vrf(struct stream *s, struct zebra_vrf *zvrf)
  */
 int zsend_interface_add(struct zserv *client, struct interface *ifp)
 {
-	struct stream *s;
-
-	s = client->obuf;
-	stream_reset(s);
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_INTERFACE_ADD, ifp->vrf_id);
 	zserv_encode_interface(s, ifp);
 
 	client->ifadd_cnt++;
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 /* Interface deletion from zebra daemon. */
 int zsend_interface_delete(struct zserv *client, struct interface *ifp)
 {
-	struct stream *s;
-
-	s = client->obuf;
-	stream_reset(s);
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_INTERFACE_DELETE, ifp->vrf_id);
 	zserv_encode_interface(s, ifp);
 
 	client->ifdel_cnt++;
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 int zsend_vrf_add(struct zserv *client, struct zebra_vrf *zvrf)
 {
-	struct stream *s;
-
-	s = client->obuf;
-	stream_reset(s);
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_VRF_ADD, zvrf_id(zvrf));
 	zserv_encode_vrf(s, zvrf);
 
 	client->vrfadd_cnt++;
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 /* VRF deletion from zebra daemon. */
 int zsend_vrf_delete(struct zserv *client, struct zebra_vrf *zvrf)
-{
-	struct stream *s;
 
-	s = client->obuf;
-	stream_reset(s);
+{
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_VRF_DELETE, zvrf_id(zvrf));
 	zserv_encode_vrf(s, zvrf);
 
 	client->vrfdel_cnt++;
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
 {
-	struct stream *s;
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	/* Check this client need interface information. */
 	if (!client->ifinfo)
@@ -281,8 +227,6 @@ int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
 
 	if (!ifp->link_params)
 		return 0;
-	s = client->obuf;
-	stream_reset(s);
 
 	zclient_create_header(s, ZEBRA_INTERFACE_LINK_PARAMS, ifp->vrf_id);
 
@@ -296,7 +240,7 @@ int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 /* Interface address is added/deleted. Send ZEBRA_INTERFACE_ADDRESS_ADD or
@@ -341,11 +285,8 @@ int zsend_interface_address(int cmd, struct zserv *client,
 			    struct interface *ifp, struct connected *ifc)
 {
 	int blen;
-	struct stream *s;
 	struct prefix *p;
-
-	s = client->obuf;
-	stream_reset(s);
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, ifp->vrf_id);
 	stream_putl(s, ifp->ifindex);
@@ -378,7 +319,7 @@ int zsend_interface_address(int cmd, struct zserv *client,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->connected_rt_add_cnt++;
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 static int zsend_interface_nbr_address(int cmd, struct zserv *client,
@@ -386,11 +327,8 @@ static int zsend_interface_nbr_address(int cmd, struct zserv *client,
 				       struct nbr_connected *ifc)
 {
 	int blen;
-	struct stream *s;
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 	struct prefix *p;
-
-	s = client->obuf;
-	stream_reset(s);
 
 	zclient_create_header(s, cmd, ifp->vrf_id);
 	stream_putl(s, ifp->ifindex);
@@ -412,7 +350,7 @@ static int zsend_interface_nbr_address(int cmd, struct zserv *client,
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 /* Interface address addition. */
@@ -498,10 +436,7 @@ int zsend_interface_addresses(struct zserv *client, struct interface *ifp)
 int zsend_interface_vrf_update(struct zserv *client, struct interface *ifp,
 			       vrf_id_t vrf_id)
 {
-	struct stream *s;
-
-	s = client->obuf;
-	stream_reset(s);
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_INTERFACE_VRF_UPDATE, ifp->vrf_id);
 
@@ -513,7 +448,7 @@ int zsend_interface_vrf_update(struct zserv *client, struct interface *ifp,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->if_vrfchg_cnt++;
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 /* Add new nbr connected IPv6 address */
@@ -575,10 +510,7 @@ void nbr_connected_delete_ipv6(struct interface *ifp, struct in6_addr *address)
  */
 int zsend_interface_update(int cmd, struct zserv *client, struct interface *ifp)
 {
-	struct stream *s;
-
-	s = client->obuf;
-	stream_reset(s);
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, ifp->vrf_id);
 	zserv_encode_interface(s, ifp);
@@ -588,7 +520,7 @@ int zsend_interface_update(int cmd, struct zserv *client, struct interface *ifp)
 	else
 		client->ifdown_cnt++;
 
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 int zsend_redistribute_route(int cmd, struct zserv *client, struct prefix *p,
@@ -660,301 +592,19 @@ int zsend_redistribute_route(int cmd, struct zserv *client, struct prefix *p,
 	SET_FLAG(api.message, ZAPI_MESSAGE_MTU);
 	api.mtu = re->mtu;
 
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+
 	/* Encode route and send. */
-	if (zapi_route_encode(cmd, client->obuf, &api) < 0)
+	if (zapi_route_encode(cmd, s, &api) < 0)
 		return -1;
-	return zebra_server_send_message(client);
-}
-
-static int zsend_write_nexthop(struct stream *s, struct nexthop *nexthop)
-{
-	stream_putc(s, nexthop->type);
-	switch (nexthop->type) {
-	case NEXTHOP_TYPE_IPV4:
-	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		stream_put_in_addr(s, &nexthop->gate.ipv4);
-		stream_putl(s, nexthop->ifindex);
-		break;
-	case NEXTHOP_TYPE_IPV6:
-		stream_put(s, &nexthop->gate.ipv6, 16);
-		break;
-	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		stream_put(s, &nexthop->gate.ipv6, 16);
-		stream_putl(s, nexthop->ifindex);
-		break;
-	case NEXTHOP_TYPE_IFINDEX:
-		stream_putl(s, nexthop->ifindex);
-		break;
-	default:
-		/* do nothing */
-		break;
-	}
-	return 1;
-}
-
-int cmd2type[] = {
-	[ZEBRA_NEXTHOP_REGISTER] = RNH_NEXTHOP_TYPE,
-	[ZEBRA_NEXTHOP_UNREGISTER] = RNH_NEXTHOP_TYPE,
-	[ZEBRA_IMPORT_ROUTE_REGISTER] = RNH_IMPORT_CHECK_TYPE,
-	[ZEBRA_IMPORT_ROUTE_UNREGISTER] = RNH_IMPORT_CHECK_TYPE,
-};
-
-/* Nexthop register */
-static void zserv_rnh_register(ZAPI_HANDLER_ARGS)
-{
-	struct rnh *rnh;
-	struct stream *s;
-	struct prefix p;
-	u_short l = 0;
-	u_char flags = 0;
-	uint16_t type = cmd2type[hdr->command];
-
-	if (IS_ZEBRA_DEBUG_NHT)
-		zlog_debug(
-			"rnh_register msg from client %s: length=%d, type=%s\n",
-			zebra_route_string(client->proto), hdr->length,
-			(type == RNH_NEXTHOP_TYPE) ? "nexthop" : "route");
-
-	s = client->ibuf;
-
-	client->nh_reg_time = monotime(NULL);
-
-	while (l < hdr->length) {
-		STREAM_GETC(s, flags);
-		STREAM_GETW(s, p.family);
-		STREAM_GETC(s, p.prefixlen);
-		l += 4;
-		if (p.family == AF_INET) {
-			if (p.prefixlen > IPV4_MAX_BITLEN) {
-				zlog_warn(
-					"%s: Specified prefix length %d is too large for a v4 address",
-					__PRETTY_FUNCTION__, p.prefixlen);
-				return;
-			}
-			STREAM_GET(&p.u.prefix4.s_addr, s, IPV4_MAX_BYTELEN);
-			l += IPV4_MAX_BYTELEN;
-		} else if (p.family == AF_INET6) {
-			if (p.prefixlen > IPV6_MAX_BITLEN) {
-				zlog_warn(
-					"%s: Specified prefix length %d is to large for a v6 address",
-					__PRETTY_FUNCTION__, p.prefixlen);
-				return;
-			}
-			STREAM_GET(&p.u.prefix6, s, IPV6_MAX_BYTELEN);
-			l += IPV6_MAX_BYTELEN;
-		} else {
-			zlog_err(
-				"rnh_register: Received unknown family type %d\n",
-				p.family);
-			return;
-		}
-		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), type);
-		if (type == RNH_NEXTHOP_TYPE) {
-			if (flags
-			    && !CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED))
-				SET_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED);
-			else if (!flags
-				 && CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED))
-				UNSET_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED);
-		} else if (type == RNH_IMPORT_CHECK_TYPE) {
-			if (flags
-			    && !CHECK_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH))
-				SET_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH);
-			else if (!flags && CHECK_FLAG(rnh->flags,
-						      ZEBRA_NHT_EXACT_MATCH))
-				UNSET_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH);
-		}
-
-		zebra_add_rnh_client(rnh, client, type, zvrf_id(zvrf));
-		/* Anything not AF_INET/INET6 has been filtered out above */
-		zebra_evaluate_rnh(zvrf_id(zvrf), p.family, 1, type, &p);
-	}
-
-stream_failure:
-	return;
-}
-
-/* Nexthop register */
-static void zserv_rnh_unregister(ZAPI_HANDLER_ARGS)
-{
-	struct rnh *rnh;
-	struct stream *s;
-	struct prefix p;
-	u_short l = 0;
-	uint16_t type = cmd2type[hdr->command];
-
-	if (IS_ZEBRA_DEBUG_NHT)
-		zlog_debug("rnh_unregister msg from client %s: length=%d\n",
-			   zebra_route_string(client->proto), hdr->length);
-
-	s = client->ibuf;
-
-	while (l < hdr->length) {
-		uint8_t flags;
-
-		STREAM_GETC(s, flags);
-		if (flags != 0)
-			goto stream_failure;
-
-		STREAM_GETW(s, p.family);
-		STREAM_GETC(s, p.prefixlen);
-		l += 4;
-		if (p.family == AF_INET) {
-			if (p.prefixlen > IPV4_MAX_BITLEN) {
-				zlog_warn(
-					"%s: Specified prefix length %d is to large for a v4 address",
-					__PRETTY_FUNCTION__, p.prefixlen);
-				return;
-			}
-			STREAM_GET(&p.u.prefix4.s_addr, s, IPV4_MAX_BYTELEN);
-			l += IPV4_MAX_BYTELEN;
-		} else if (p.family == AF_INET6) {
-			if (p.prefixlen > IPV6_MAX_BITLEN) {
-				zlog_warn(
-					"%s: Specified prefix length %d is to large for a v6 address",
-					__PRETTY_FUNCTION__, p.prefixlen);
-				return;
-			}
-			STREAM_GET(&p.u.prefix6, s, IPV6_MAX_BYTELEN);
-			l += IPV6_MAX_BYTELEN;
-		} else {
-			zlog_err(
-				"rnh_register: Received unknown family type %d\n",
-				p.family);
-			return;
-		}
-		rnh = zebra_lookup_rnh(&p, zvrf_id(zvrf), type);
-		if (rnh) {
-			client->nh_dereg_time = monotime(NULL);
-			zebra_remove_rnh_client(rnh, client, type);
-		}
-	}
-stream_failure:
-	return;
-}
-
-#define ZEBRA_MIN_FEC_LENGTH 5
-
-/* FEC register */
-static void zserv_fec_register(ZAPI_HANDLER_ARGS)
-{
-	struct stream *s;
-	u_short l = 0;
-	struct prefix p;
-	u_int16_t flags;
-	u_int32_t label_index = MPLS_INVALID_LABEL_INDEX;
-
-	s = client->ibuf;
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
-	if (!zvrf)
-		return;
-
-	/*
-	 * The minimum amount of data that can be sent for one fec
-	 * registration
-	 */
-	if (hdr->length < ZEBRA_MIN_FEC_LENGTH) {
-		zlog_err(
-			"fec_register: Received a fec register of length %d, it is of insufficient size to properly decode",
-			hdr->length);
-		return;
-	}
-
-	while (l < hdr->length) {
-		STREAM_GETW(s, flags);
-		memset(&p, 0, sizeof(p));
-		STREAM_GETW(s, p.family);
-		if (p.family != AF_INET && p.family != AF_INET6) {
-			zlog_err(
-				"fec_register: Received unknown family type %d\n",
-				p.family);
-			return;
-		}
-		STREAM_GETC(s, p.prefixlen);
-		if ((p.family == AF_INET && p.prefixlen > IPV4_MAX_BITLEN)
-		    || (p.family == AF_INET6
-			&& p.prefixlen > IPV6_MAX_BITLEN)) {
-			zlog_warn(
-				"%s: Specified prefix length: %d is to long for %d",
-				__PRETTY_FUNCTION__, p.prefixlen, p.family);
-			return;
-		}
-		l += 5;
-		STREAM_GET(&p.u.prefix, s, PSIZE(p.prefixlen));
-		l += PSIZE(p.prefixlen);
-		if (flags & ZEBRA_FEC_REGISTER_LABEL_INDEX) {
-			STREAM_GETL(s, label_index);
-			l += 4;
-		} else
-			label_index = MPLS_INVALID_LABEL_INDEX;
-		zebra_mpls_fec_register(zvrf, &p, label_index, client);
-	}
-
-stream_failure:
-	return;
-}
-
-/* FEC unregister */
-static void zserv_fec_unregister(ZAPI_HANDLER_ARGS)
-{
-	struct stream *s;
-	u_short l = 0;
-	struct prefix p;
-	uint16_t flags;
-
-	s = client->ibuf;
-	zvrf = vrf_info_lookup(VRF_DEFAULT);
-	if (!zvrf)
-		return;
-
-	/*
-	 * The minimum amount of data that can be sent for one
-	 * fec unregistration
-	 */
-	if (hdr->length < ZEBRA_MIN_FEC_LENGTH) {
-		zlog_err(
-			"fec_unregister: Received a fec unregister of length %d, it is of insufficient size to properly decode",
-			hdr->length);
-		return;
-	}
-
-	while (l < hdr->length) {
-		STREAM_GETW(s, flags);
-		if (flags != 0)
-			goto stream_failure;
-
-		memset(&p, 0, sizeof(p));
-		STREAM_GETW(s, p.family);
-		if (p.family != AF_INET && p.family != AF_INET6) {
-			zlog_err(
-				"fec_unregister: Received unknown family type %d\n",
-				p.family);
-			return;
-		}
-		STREAM_GETC(s, p.prefixlen);
-		if ((p.family == AF_INET && p.prefixlen > IPV4_MAX_BITLEN)
-		    || (p.family == AF_INET6
-			&& p.prefixlen > IPV6_MAX_BITLEN)) {
-			zlog_warn(
-				"%s: Received prefix length %d which is greater than %d can support",
-				__PRETTY_FUNCTION__, p.prefixlen, p.family);
-			return;
-		}
-		l += 5;
-		STREAM_GET(&p.u.prefix, s, PSIZE(p.prefixlen));
-		l += PSIZE(p.prefixlen);
-		zebra_mpls_fec_unregister(zvrf, &p, client);
-	}
-
-stream_failure:
-	return;
+	return zebra_server_send_message(client, s);
 }
 
 /*
-  Modified version of zsend_ipv4_nexthop_lookup():
-  Query unicast rib if nexthop is not found on mrib.
-  Returns both route metric and protocol distance.
-*/
+ * Modified version of zsend_ipv4_nexthop_lookup(): Query unicast rib if
+ * nexthop is not found on mrib. Returns both route metric and protocol
+ * distance.
+ */
 static int zsend_ipv4_nexthop_lookup_mrib(struct zserv *client,
 					  struct in_addr addr,
 					  struct route_entry *re,
@@ -966,7 +616,7 @@ static int zsend_ipv4_nexthop_lookup_mrib(struct zserv *client,
 	struct nexthop *nexthop;
 
 	/* Get output stream. */
-	s = client->obuf;
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 	stream_reset(s);
 
 	/* Fill in result. */
@@ -997,7 +647,7 @@ static int zsend_ipv4_nexthop_lookup_mrib(struct zserv *client,
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 int zsend_route_notify_owner(struct route_entry *re, struct prefix *p,
@@ -1028,7 +678,7 @@ int zsend_route_notify_owner(struct route_entry *re, struct prefix *p,
 			   re->table, note);
 	}
 
-	s = client->obuf;
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 	stream_reset(s);
 
 	zclient_create_header(s, ZEBRA_ROUTE_NOTIFY_OWNER, re->vrf_id);
@@ -1045,7 +695,7 @@ int zsend_route_notify_owner(struct route_entry *re, struct prefix *p,
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 void zsend_rule_notify_owner(struct zebra_pbr_rule *rule,
@@ -1068,7 +718,7 @@ void zsend_rule_notify_owner(struct zebra_pbr_rule *rule,
 	if (!client)
 		return;
 
-	s = client->obuf;
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 	stream_reset(s);
 
 	zclient_create_header(s, ZEBRA_RULE_NOTIFY_OWNER, VRF_DEFAULT);
@@ -1083,22 +733,20 @@ void zsend_rule_notify_owner(struct zebra_pbr_rule *rule,
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	zebra_server_send_message(client);
+	zebra_server_send_message(client, s);
 }
 
 /* Router-id is updated. Send ZEBRA_ROUTER_ID_ADD to client. */
 int zsend_router_id_update(struct zserv *client, struct prefix *p,
 			   vrf_id_t vrf_id)
 {
-	struct stream *s;
 	int blen;
 
 	/* Check this client need interface information. */
 	if (!vrf_bitmap_check(client->ridinfo, vrf_id))
 		return 0;
 
-	s = client->obuf;
-	stream_reset(s);
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	/* Message type. */
 	zclient_create_header(s, ZEBRA_ROUTER_ID_UPDATE, vrf_id);
@@ -1112,7 +760,7 @@ int zsend_router_id_update(struct zserv *client, struct prefix *p,
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
 /*
@@ -1120,10 +768,7 @@ int zsend_router_id_update(struct zserv *client, struct prefix *p,
  */
 int zsend_pw_update(struct zserv *client, struct zebra_pw *pw)
 {
-	struct stream *s;
-
-	s = client->obuf;
-	stream_reset(s);
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_PW_STATUS_UPDATE, pw->vrf_id);
 	stream_write(s, pw->ifname, IF_NAMESIZE);
@@ -1133,13 +778,325 @@ int zsend_pw_update(struct zserv *client, struct zebra_pw *pw)
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client);
+	return zebra_server_send_message(client, s);
 }
 
-/* Register zebra server interface information.  Send current all
-   interface and address information. */
-static void zread_interface_add(ZAPI_HANDLER_ARGS)
+/* Send response to a get label chunk request to client */
+static int zsend_assign_label_chunk_response(struct zserv *client,
+					     vrf_id_t vrf_id,
+					     struct label_manager_chunk *lmc)
+{
+	int ret;
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
+	zclient_create_header(s, ZEBRA_GET_LABEL_CHUNK, vrf_id);
+
+	if (lmc) {
+		/* keep */
+		stream_putc(s, lmc->keep);
+		/* start and end labels */
+		stream_putl(s, lmc->start);
+		stream_putl(s, lmc->end);
+	}
+
+	/* Write packet size. */
+	stream_putw_at(s, 0, stream_get_endp(s));
+
+	ret = writen(client->sock, s->data, stream_get_endp(s));
+	stream_free(s);
+	return ret;
+}
+
+/* Send response to a label manager connect request to client */
+static int zsend_label_manager_connect_response(struct zserv *client,
+						vrf_id_t vrf_id, u_short result)
+{
+	int ret;
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+
+	zclient_create_header(s, ZEBRA_LABEL_MANAGER_CONNECT, vrf_id);
+
+	/* result */
+	stream_putc(s, result);
+
+	/* Write packet size. */
+	stream_putw_at(s, 0, stream_get_endp(s));
+
+	ret = writen(client->sock, s->data, stream_get_endp(s));
+	stream_free(s);
+
+	return ret;
+}
+
+/* Inbound message handling ------------------------------------------------ */
+
+int cmd2type[] = {
+	[ZEBRA_NEXTHOP_REGISTER] = RNH_NEXTHOP_TYPE,
+	[ZEBRA_NEXTHOP_UNREGISTER] = RNH_NEXTHOP_TYPE,
+	[ZEBRA_IMPORT_ROUTE_REGISTER] = RNH_IMPORT_CHECK_TYPE,
+	[ZEBRA_IMPORT_ROUTE_UNREGISTER] = RNH_IMPORT_CHECK_TYPE,
+};
+
+/* Nexthop register */
+static void zread_rnh_register(ZAPI_HANDLER_ARGS)
+{
+	struct rnh *rnh;
+	struct stream *s;
+	struct prefix p;
+	u_short l = 0;
+	u_char flags = 0;
+	uint16_t type = cmd2type[hdr->command];
+
+	if (IS_ZEBRA_DEBUG_NHT)
+		zlog_debug(
+			"rnh_register msg from client %s: hdr->length=%d, type=%s\n",
+			zebra_route_string(client->proto), hdr->length,
+			(type == RNH_NEXTHOP_TYPE) ? "nexthop" : "route");
+
+	s = msg;
+
+	client->nh_reg_time = monotime(NULL);
+
+	while (l < hdr->length) {
+		STREAM_GETC(s, flags);
+		STREAM_GETW(s, p.family);
+		STREAM_GETC(s, p.prefixlen);
+		l += 4;
+		if (p.family == AF_INET) {
+			if (p.prefixlen > IPV4_MAX_BITLEN) {
+				zlog_warn(
+					"%s: Specified prefix hdr->length %d is too large for a v4 address",
+					__PRETTY_FUNCTION__, p.prefixlen);
+				return;
+			}
+			STREAM_GET(&p.u.prefix4.s_addr, s, IPV4_MAX_BYTELEN);
+			l += IPV4_MAX_BYTELEN;
+		} else if (p.family == AF_INET6) {
+			if (p.prefixlen > IPV6_MAX_BITLEN) {
+				zlog_warn(
+					"%s: Specified prefix hdr->length %d is to large for a v6 address",
+					__PRETTY_FUNCTION__, p.prefixlen);
+				return;
+			}
+			STREAM_GET(&p.u.prefix6, s, IPV6_MAX_BYTELEN);
+			l += IPV6_MAX_BYTELEN;
+		} else {
+			zlog_err(
+				"rnh_register: Received unknown family type %d\n",
+				p.family);
+			return;
+		}
+		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), type);
+		if (type == RNH_NEXTHOP_TYPE) {
+			if (flags
+			    && !CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED))
+				SET_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED);
+			else if (!flags
+				 && CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED))
+				UNSET_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED);
+		} else if (type == RNH_IMPORT_CHECK_TYPE) {
+			if (flags
+			    && !CHECK_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH))
+				SET_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH);
+			else if (!flags
+				 && CHECK_FLAG(rnh->flags,
+					       ZEBRA_NHT_EXACT_MATCH))
+				UNSET_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH);
+		}
+
+		zebra_add_rnh_client(rnh, client, type, zvrf_id(zvrf));
+		/* Anything not AF_INET/INET6 has been filtered out above */
+		zebra_evaluate_rnh(zvrf_id(zvrf), p.family, 1, type, &p);
+	}
+
+stream_failure:
+	return;
+}
+
+/* Nexthop register */
+static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
+{
+	struct rnh *rnh;
+	struct stream *s;
+	struct prefix p;
+	u_short l = 0;
+	uint16_t type = cmd2type[hdr->command];
+
+	if (IS_ZEBRA_DEBUG_NHT)
+		zlog_debug(
+			"rnh_unregister msg from client %s: hdr->length=%d\n",
+			zebra_route_string(client->proto), hdr->length);
+
+	s = msg;
+
+	while (l < hdr->length) {
+		uint8_t flags;
+
+		STREAM_GETC(s, flags);
+		if (flags != 0)
+			goto stream_failure;
+
+		STREAM_GETW(s, p.family);
+		STREAM_GETC(s, p.prefixlen);
+		l += 4;
+		if (p.family == AF_INET) {
+			if (p.prefixlen > IPV4_MAX_BITLEN) {
+				zlog_warn(
+					"%s: Specified prefix hdr->length %d is to large for a v4 address",
+					__PRETTY_FUNCTION__, p.prefixlen);
+				return;
+			}
+			STREAM_GET(&p.u.prefix4.s_addr, s, IPV4_MAX_BYTELEN);
+			l += IPV4_MAX_BYTELEN;
+		} else if (p.family == AF_INET6) {
+			if (p.prefixlen > IPV6_MAX_BITLEN) {
+				zlog_warn(
+					"%s: Specified prefix hdr->length %d is to large for a v6 address",
+					__PRETTY_FUNCTION__, p.prefixlen);
+				return;
+			}
+			STREAM_GET(&p.u.prefix6, s, IPV6_MAX_BYTELEN);
+			l += IPV6_MAX_BYTELEN;
+		} else {
+			zlog_err(
+				"rnh_register: Received unknown family type %d\n",
+				p.family);
+			return;
+		}
+		rnh = zebra_lookup_rnh(&p, zvrf_id(zvrf), type);
+		if (rnh) {
+			client->nh_dereg_time = monotime(NULL);
+			zebra_remove_rnh_client(rnh, client, type);
+		}
+	}
+stream_failure:
+	return;
+}
+
+#define ZEBRA_MIN_FEC_LENGTH 5
+
+/* FEC register */
+static void zread_fec_register(ZAPI_HANDLER_ARGS)
+{
+	struct stream *s;
+	u_short l = 0;
+	struct prefix p;
+	uint16_t flags;
+	uint32_t label_index = MPLS_INVALID_LABEL_INDEX;
+
+	s = msg;
+	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	if (!zvrf)
+		return; // unexpected
+
+	/*
+	 * The minimum amount of data that can be sent for one fec
+	 * registration
+	 */
+	if (hdr->length < ZEBRA_MIN_FEC_LENGTH) {
+		zlog_err(
+			"fec_register: Received a fec register of hdr->length %d, it is of insufficient size to properly decode",
+			hdr->length);
+		return;
+	}
+
+	while (l < hdr->length) {
+		STREAM_GETW(s, flags);
+		memset(&p, 0, sizeof(p));
+		STREAM_GETW(s, p.family);
+		if (p.family != AF_INET && p.family != AF_INET6) {
+			zlog_err(
+				"fec_register: Received unknown family type %d\n",
+				p.family);
+			return;
+		}
+		STREAM_GETC(s, p.prefixlen);
+		if ((p.family == AF_INET && p.prefixlen > IPV4_MAX_BITLEN)
+		    || (p.family == AF_INET6
+			&& p.prefixlen > IPV6_MAX_BITLEN)) {
+			zlog_warn(
+				"%s: Specified prefix hdr->length: %d is to long for %d",
+				__PRETTY_FUNCTION__, p.prefixlen, p.family);
+			return;
+		}
+		l += 5;
+		STREAM_GET(&p.u.prefix, s, PSIZE(p.prefixlen));
+		l += PSIZE(p.prefixlen);
+		if (flags & ZEBRA_FEC_REGISTER_LABEL_INDEX) {
+			STREAM_GETL(s, label_index);
+			l += 4;
+		} else
+			label_index = MPLS_INVALID_LABEL_INDEX;
+		zebra_mpls_fec_register(zvrf, &p, label_index, client);
+	}
+
+stream_failure:
+	return;
+}
+
+/* FEC unregister */
+static void zread_fec_unregister(ZAPI_HANDLER_ARGS)
+{
+	struct stream *s;
+	u_short l = 0;
+	struct prefix p;
+	uint16_t flags;
+
+	s = msg;
+	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	if (!zvrf)
+		return; // unexpected
+
+	/*
+	 * The minimum amount of data that can be sent for one
+	 * fec unregistration
+	 */
+	if (hdr->length < ZEBRA_MIN_FEC_LENGTH) {
+		zlog_err(
+			"fec_unregister: Received a fec unregister of hdr->length %d, it is of insufficient size to properly decode",
+			hdr->length);
+		return;
+	}
+
+	while (l < hdr->length) {
+		STREAM_GETW(s, flags);
+		if (flags != 0)
+			goto stream_failure;
+
+		memset(&p, 0, sizeof(p));
+		STREAM_GETW(s, p.family);
+		if (p.family != AF_INET && p.family != AF_INET6) {
+			zlog_err(
+				"fec_unregister: Received unknown family type %d\n",
+				p.family);
+			return;
+		}
+		STREAM_GETC(s, p.prefixlen);
+		if ((p.family == AF_INET && p.prefixlen > IPV4_MAX_BITLEN)
+		    || (p.family == AF_INET6
+			&& p.prefixlen > IPV6_MAX_BITLEN)) {
+			zlog_warn(
+				"%s: Received prefix hdr->length %d which is greater than %d can support",
+				__PRETTY_FUNCTION__, p.prefixlen, p.family);
+			return;
+		}
+		l += 5;
+		STREAM_GET(&p.u.prefix, s, PSIZE(p.prefixlen));
+		l += PSIZE(p.prefixlen);
+		zebra_mpls_fec_unregister(zvrf, &p, client);
+	}
+
+stream_failure:
+	return;
+}
+
+
+
+/*
+ * Register zebra server interface information.
+ * Send current all interface and address information.
+ */
+static void zread_interface_add(ZAPI_HANDLER_ARGS)
 {
 	struct vrf *vrf;
 	struct interface *ifp;
@@ -1153,14 +1110,10 @@ static void zread_interface_add(ZAPI_HANDLER_ARGS)
 			if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE))
 				continue;
 
-			if (zsend_interface_add(client, ifp) < 0)
-				return;
-
-			if (zsend_interface_addresses(client, ifp) < 0)
-				return;
+			zsend_interface_add(client, ifp);
+			zsend_interface_addresses(client, ifp);
 		}
 	}
-	return;
 }
 
 /* Unregister zebra server interface information. */
@@ -1193,9 +1146,8 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	int i, ret;
 	vrf_id_t vrf_id = 0;
 
-	s = client->ibuf;
-	if (zapi_route_decode(s, &api) < 0)
-		return;
+	s = msg;
+	zapi_route_decode(s, &api);
 
 	/* Allocate new route. */
 	vrf_id = zvrf_id(zvrf);
@@ -1342,7 +1294,7 @@ static void zread_route_del(ZAPI_HANDLER_ARGS)
 	afi_t afi;
 	struct prefix_ipv6 *src_p = NULL;
 
-	s = client->ibuf;
+	s = msg;
 	if (zapi_route_decode(s, &api) < 0)
 		return;
 
@@ -1368,8 +1320,6 @@ static void zread_route_del(ZAPI_HANDLER_ARGS)
 		client->v6_route_del_cnt++;
 		break;
 	}
-
-	return;
 }
 
 /* This function support multiple nexthop. */
@@ -1396,7 +1346,7 @@ static void zread_ipv4_add(ZAPI_HANDLER_ARGS)
 	enum blackhole_type bh_type = BLACKHOLE_NULL;
 
 	/* Get input stream.  */
-	s = client->ibuf;
+	s = msg;
 
 	/* Allocate new re. */
 	re = XCALLOC(MTYPE_RE, sizeof(struct route_entry));
@@ -1527,7 +1477,6 @@ static void zread_ipv4_add(ZAPI_HANDLER_ARGS)
 stream_failure:
 	nexthops_free(re->ng.nexthop);
 	XFREE(MTYPE_RE, re);
-	return;
 }
 
 /* Zebra server IPv4 prefix delete function. */
@@ -1538,7 +1487,7 @@ static void zread_ipv4_delete(ZAPI_HANDLER_ARGS)
 	struct prefix p;
 	u_int32_t table_id;
 
-	s = client->ibuf;
+	s = msg;
 
 	/* Type, flags, message. */
 	STREAM_GETC(s, api.type);
@@ -1574,10 +1523,9 @@ static void zread_ipv4_nexthop_lookup_mrib(ZAPI_HANDLER_ARGS)
 	struct in_addr addr;
 	struct route_entry *re;
 
-	STREAM_GET(&addr.s_addr, client->ibuf, IPV4_MAX_BYTELEN);
+	STREAM_GET(&addr.s_addr, msg, IPV4_MAX_BYTELEN);
 	re = rib_match_ipv4_multicast(zvrf_id(zvrf), addr, NULL);
 	zsend_ipv4_nexthop_lookup_mrib(client, addr, re, zvrf);
-	return;
 
 stream_failure:
 	return;
@@ -1605,7 +1553,7 @@ static void zread_ipv4_route_ipv6_nexthop_add(ZAPI_HANDLER_ARGS)
 	enum blackhole_type bh_type = BLACKHOLE_NULL;
 
 	/* Get input stream.  */
-	s = client->ibuf;
+	s = msg;
 
 	memset(&nhop_addr, 0, sizeof(struct in6_addr));
 
@@ -1618,7 +1566,6 @@ static void zread_ipv4_route_ipv6_nexthop_add(ZAPI_HANDLER_ARGS)
 		zlog_warn("%s: Specified route type: %d is not a legal value\n",
 			  __PRETTY_FUNCTION__, re->type);
 		XFREE(MTYPE_RE, re);
-
 		return;
 	}
 	STREAM_GETW(s, re->instance);
@@ -1754,7 +1701,6 @@ static void zread_ipv4_route_ipv6_nexthop_add(ZAPI_HANDLER_ARGS)
 stream_failure:
 	nexthops_free(re->ng.nexthop);
 	XFREE(MTYPE_RE, re);
-	return;
 }
 
 static void zread_ipv6_add(ZAPI_HANDLER_ARGS)
@@ -1780,7 +1726,7 @@ static void zread_ipv6_add(ZAPI_HANDLER_ARGS)
 	enum blackhole_type bh_type = BLACKHOLE_NULL;
 
 	/* Get input stream.  */
-	s = client->ibuf;
+	s = msg;
 
 	memset(&nhop_addr, 0, sizeof(struct in6_addr));
 
@@ -1947,8 +1893,6 @@ static void zread_ipv6_add(ZAPI_HANDLER_ARGS)
 stream_failure:
 	nexthops_free(re->ng.nexthop);
 	XFREE(MTYPE_RE, re);
-
-	return;
 }
 
 /* Zebra server IPv6 prefix delete function. */
@@ -1959,7 +1903,7 @@ static void zread_ipv6_delete(ZAPI_HANDLER_ARGS)
 	struct prefix p;
 	struct prefix_ipv6 src_p, *src_pp;
 
-	s = client->ibuf;
+	s = msg;
 
 	/* Type, flags, message. */
 	STREAM_GETC(s, api.type);
@@ -2020,9 +1964,9 @@ static void zread_hello(ZAPI_HANDLER_ARGS)
 	u_short instance;
 	u_char notify;
 
-	STREAM_GETC(client->ibuf, proto);
-	STREAM_GETW(client->ibuf, instance);
-	STREAM_GETC(client->ibuf, notify);
+	STREAM_GETC(msg, proto);
+	STREAM_GETW(msg, instance);
+	STREAM_GETC(msg, notify);
 	if (notify)
 		client->notify_owner = true;
 
@@ -2068,7 +2012,7 @@ static void zread_mpls_labels(ZAPI_HANDLER_ARGS)
 	u_int8_t distance;
 
 	/* Get input stream.  */
-	s = client->ibuf;
+	s = msg;
 
 	/* Get data. */
 	STREAM_GETC(s, type);
@@ -2139,27 +2083,9 @@ static void zread_mpls_labels(ZAPI_HANDLER_ARGS)
 stream_failure:
 	return;
 }
-/* Send response to a label manager connect request to client */
-static int zsend_label_manager_connect_response(struct zserv *client,
-						vrf_id_t vrf_id, u_short result)
-{
-	struct stream *s;
 
-	s = client->obuf;
-	stream_reset(s);
-
-	zclient_create_header(s, ZEBRA_LABEL_MANAGER_CONNECT, vrf_id);
-
-	/* result */
-	stream_putc(s, result);
-
-	/* Write packet size. */
-	stream_putw_at(s, 0, stream_get_endp(s));
-
-	return writen(client->sock, s->data, stream_get_endp(s));
-}
-
-static void zread_label_manager_connect(struct zserv *client, vrf_id_t vrf_id)
+static void zread_label_manager_connect(struct zserv *client,
+					struct stream *msg, vrf_id_t vrf_id)
 {
 	struct stream *s;
 	/* type of protocol (lib/zebra.h) */
@@ -2167,7 +2093,7 @@ static void zread_label_manager_connect(struct zserv *client, vrf_id_t vrf_id)
 	u_short instance;
 
 	/* Get input stream.  */
-	s = client->ibuf;
+	s = msg;
 
 	/* Get data. */
 	STREAM_GETC(s, proto);
@@ -2200,33 +2126,9 @@ static void zread_label_manager_connect(struct zserv *client, vrf_id_t vrf_id)
 stream_failure:
 	return;
 }
-/* Send response to a get label chunk request to client */
-static int zsend_assign_label_chunk_response(struct zserv *client,
-					     vrf_id_t vrf_id,
-					     struct label_manager_chunk *lmc)
-{
-	struct stream *s;
 
-	s = client->obuf;
-	stream_reset(s);
-
-	zclient_create_header(s, ZEBRA_GET_LABEL_CHUNK, vrf_id);
-
-	if (lmc) {
-		/* keep */
-		stream_putc(s, lmc->keep);
-		/* start and end labels */
-		stream_putl(s, lmc->start);
-		stream_putl(s, lmc->end);
-	}
-
-	/* Write packet size. */
-	stream_putw_at(s, 0, stream_get_endp(s));
-
-	return writen(client->sock, s->data, stream_get_endp(s));
-}
-
-static void zread_get_label_chunk(struct zserv *client, vrf_id_t vrf_id)
+static void zread_get_label_chunk(struct zserv *client, struct stream *msg,
+				  vrf_id_t vrf_id)
 {
 	struct stream *s;
 	u_char keep;
@@ -2234,7 +2136,7 @@ static void zread_get_label_chunk(struct zserv *client, vrf_id_t vrf_id)
 	struct label_manager_chunk *lmc;
 
 	/* Get input stream.  */
-	s = client->ibuf;
+	s = msg;
 
 	/* Get data. */
 	STREAM_GETC(s, keep);
@@ -2254,13 +2156,13 @@ stream_failure:
 	return;
 }
 
-static void zread_release_label_chunk(struct zserv *client)
+static void zread_release_label_chunk(struct zserv *client, struct stream *msg)
 {
 	struct stream *s;
 	uint32_t start, end;
 
 	/* Get input stream.  */
-	s = client->ibuf;
+	s = msg;
 
 	/* Get data. */
 	STREAM_GETL(s, start);
@@ -2284,7 +2186,7 @@ static void zread_label_manager_request(ZAPI_HANDLER_ARGS)
 	/* this is a label manager */
 	else {
 		if (hdr->command == ZEBRA_LABEL_MANAGER_CONNECT)
-			zread_label_manager_connect(client, zvrf_id(zvrf));
+			zread_label_manager_connect(client, msg, zvrf_id(zvrf));
 		else {
 			/* Sanity: don't allow 'unidentified' requests */
 			if (!client->proto) {
@@ -2293,9 +2195,10 @@ static void zread_label_manager_request(ZAPI_HANDLER_ARGS)
 				return;
 			}
 			if (hdr->command == ZEBRA_GET_LABEL_CHUNK)
-				zread_get_label_chunk(client, zvrf_id(zvrf));
+				zread_get_label_chunk(client, msg,
+						      zvrf_id(zvrf));
 			else if (hdr->command == ZEBRA_RELEASE_LABEL_CHUNK)
-				zread_release_label_chunk(client);
+				zread_release_label_chunk(client, msg);
 		}
 	}
 }
@@ -2316,7 +2219,7 @@ static void zread_pseudowire(ZAPI_HANDLER_ARGS)
 	struct zebra_pw *pw;
 
 	/* Get input stream.  */
-	s = client->ibuf;
+	s = msg;
 
 	/* Get data. */
 	STREAM_GET(ifname, s, IF_NAMESIZE);
@@ -2413,116 +2316,11 @@ static void zebra_client_close_cleanup_rnh(struct zserv *client)
 	}
 }
 
-/* free zebra client information. */
-static void zebra_client_free(struct zserv *client)
-{
-	/* Send client de-registration to BFD */
-	zebra_ptm_bfd_client_deregister(client->proto);
-
-	/* Cleanup any registered nexthops - across all VRFs. */
-	zebra_client_close_cleanup_rnh(client);
-
-	/* Release Label Manager chunks */
-	release_daemon_chunks(client->proto, client->instance);
-
-	/* Cleanup any FECs registered by this client. */
-	zebra_mpls_cleanup_fecs_for_client(vrf_info_lookup(VRF_DEFAULT),
-					   client);
-
-	/* Remove pseudowires associated with this client */
-	zebra_pw_client_close(client);
-
-	/* Close file descriptor. */
-	if (client->sock) {
-		unsigned long nroutes;
-
-		close(client->sock);
-		nroutes = rib_score_proto(client->proto, client->instance);
-		zlog_notice(
-			"client %d disconnected. %lu %s routes removed from the rib",
-			client->sock, nroutes,
-			zebra_route_string(client->proto));
-		client->sock = -1;
-	}
-
-	/* Free stream buffers. */
-	if (client->ibuf)
-		stream_free(client->ibuf);
-	if (client->obuf)
-		stream_free(client->obuf);
-	if (client->wb)
-		buffer_free(client->wb);
-
-	/* Release threads. */
-	if (client->t_read)
-		thread_cancel(client->t_read);
-	if (client->t_write)
-		thread_cancel(client->t_write);
-	if (client->t_suicide)
-		thread_cancel(client->t_suicide);
-
-	/* Free bitmaps. */
-	for (afi_t afi = AFI_IP; afi < AFI_MAX; afi++)
-		for (int i = 0; i < ZEBRA_ROUTE_MAX; i++)
-			vrf_bitmap_free(client->redist[afi][i]);
-
-	vrf_bitmap_free(client->redist_default);
-	vrf_bitmap_free(client->ifinfo);
-	vrf_bitmap_free(client->ridinfo);
-
-	XFREE(MTYPE_TMP, client);
-}
-
-static void zebra_client_close(struct zserv *client)
-{
-	listnode_delete(zebrad.client_list, client);
-	zebra_client_free(client);
-}
-
-/* Make new client. */
-static void zebra_client_create(int sock)
-{
-	struct zserv *client;
-	int i;
-	afi_t afi;
-
-	client = XCALLOC(MTYPE_TMP, sizeof(struct zserv));
-
-	/* Make client input/output buffer. */
-	client->sock = sock;
-	client->ibuf = stream_new(ZEBRA_MAX_PACKET_SIZ);
-	client->obuf = stream_new(ZEBRA_MAX_PACKET_SIZ);
-	client->wb = buffer_new(0);
-
-	/* Set table number. */
-	client->rtm_table = zebrad.rtm_table_default;
-
-	client->connect_time = monotime(NULL);
-	/* Initialize flags */
-	for (afi = AFI_IP; afi < AFI_MAX; afi++)
-		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
-			client->redist[afi][i] = vrf_bitmap_init();
-	client->redist_default = vrf_bitmap_init();
-	client->ifinfo = vrf_bitmap_init();
-	client->ridinfo = vrf_bitmap_init();
-
-	/* by default, it's not a synchronous client */
-	client->is_synchronous = 0;
-
-	/* Add this client to linked list. */
-	listnode_add(zebrad.client_list, client);
-
-	/* Make new read thread. */
-	zebra_event(ZEBRA_READ, sock, client);
-
-	zebra_vrf_update_all(client);
-}
-
 static void zread_interface_set_master(ZAPI_HANDLER_ARGS)
 {
 	struct interface *master;
 	struct interface *slave;
-	struct stream *s = client->ibuf;
+	struct stream *s = msg;
 	int ifindex;
 	vrf_id_t vrf_id;
 
@@ -2553,7 +2351,7 @@ static void zread_vrf_label(ZAPI_HANDLER_ARGS)
 	struct zebra_vrf *def_zvrf;
 	enum lsp_types_t ltype;
 
-	s = client->ibuf;
+	s = msg;
 	STREAM_GETL(s, nlabel);
 	STREAM_GETC(s, afi);
 	if (nlabel == zvrf->label[afi]) {
@@ -2619,7 +2417,7 @@ static inline void zread_rule(ZAPI_HANDLER_ARGS)
 	uint32_t total, i;
 	ifindex_t ifindex;
 
-	s = client->ibuf;
+	s = msg;
 	STREAM_GETL(s, total);
 
 	for (i = 0; i < total; i++) {
@@ -2670,23 +2468,6 @@ stream_failure:
 	return;
 }
 
-/*
- * Reads header from zmsg stream.
- *
- * Note this advances the stream getp by the size of the header.
- */
-static bool zserv_read_header(struct stream *msg, struct zmsghdr *hdr)
-{
-	STREAM_GETW(msg, hdr->length);
-	STREAM_GETC(msg, hdr->marker);
-	STREAM_GETC(msg, hdr->version);
-	STREAM_GETL(msg, hdr->vrf_id);
-	STREAM_GETW(msg, hdr->command);
-	return true;
-stream_failure:
-	return false;
-}
-
 void (*zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_ROUTER_ID_ADD] = zread_router_id_add,
 	[ZEBRA_ROUTER_ID_DELETE] = zread_router_id_delete,
@@ -2705,10 +2486,10 @@ void (*zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_REDISTRIBUTE_DEFAULT_DELETE] = zebra_redistribute_default_delete,
 	[ZEBRA_IPV4_NEXTHOP_LOOKUP_MRIB] = zread_ipv4_nexthop_lookup_mrib,
 	[ZEBRA_HELLO] = zread_hello,
-	[ZEBRA_NEXTHOP_REGISTER] = zserv_rnh_register,
-	[ZEBRA_NEXTHOP_UNREGISTER] = zserv_rnh_unregister,
-	[ZEBRA_IMPORT_ROUTE_REGISTER] = zserv_rnh_register,
-	[ZEBRA_IMPORT_ROUTE_UNREGISTER] = zserv_rnh_unregister,
+	[ZEBRA_NEXTHOP_REGISTER] = zread_rnh_register,
+	[ZEBRA_NEXTHOP_UNREGISTER] = zread_rnh_unregister,
+	[ZEBRA_IMPORT_ROUTE_REGISTER] = zread_rnh_register,
+	[ZEBRA_IMPORT_ROUTE_UNREGISTER] = zread_rnh_unregister,
 	[ZEBRA_BFD_DEST_UPDATE] = zebra_ptm_bfd_dst_register,
 	[ZEBRA_BFD_DEST_REGISTER] = zebra_ptm_bfd_dst_register,
 	[ZEBRA_BFD_DEST_DEREGISTER] = zebra_ptm_bfd_dst_deregister,
@@ -2728,8 +2509,8 @@ void (*zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_LABEL_MANAGER_CONNECT] = zread_label_manager_request,
 	[ZEBRA_GET_LABEL_CHUNK] = zread_label_manager_request,
 	[ZEBRA_RELEASE_LABEL_CHUNK] = zread_label_manager_request,
-	[ZEBRA_FEC_REGISTER] = zserv_fec_register,
-	[ZEBRA_FEC_UNREGISTER] = zserv_fec_unregister,
+	[ZEBRA_FEC_REGISTER] = zread_fec_register,
+	[ZEBRA_FEC_UNREGISTER] = zread_fec_unregister,
 	[ZEBRA_ADVERTISE_DEFAULT_GW] = zebra_vxlan_advertise_gw_macip,
 	[ZEBRA_ADVERTISE_SUBNET] = zebra_vxlan_advertise_subnet,
 	[ZEBRA_ADVERTISE_ALL_VNI] = zebra_vxlan_advertise_all_vni,
@@ -2746,19 +2527,255 @@ void (*zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_RULE_DELETE] = zread_rule,
 };
 
-static inline void zserv_handle_commands(struct zserv *client, uint16_t command,
-					 uint16_t length,
+static inline void zserv_handle_commands(struct zserv *client,
+					 struct zmsghdr *hdr,
+					 struct stream *msg,
 					 struct zebra_vrf *zvrf)
 {
-	struct zmsghdr hdr;
-
-	stream_set_getp(client->ibuf, 0);
-	zserv_read_header(client->ibuf, &hdr);
-	if (hdr.command > sizeof(zserv_handlers)
-	    || zserv_handlers[hdr.command] == NULL)
-		zlog_info("Zebra received unknown command %d", hdr.command);
+	if (hdr->command > sizeof(zserv_handlers)
+	    || zserv_handlers[hdr->command] == NULL)
+		zlog_info("Zebra received unknown command %d", hdr->command);
 	else
-		zserv_handlers[hdr.command](client, &hdr, zvrf);
+		zserv_handlers[hdr->command](client, hdr, msg, zvrf);
+
+	stream_free(msg);
+}
+
+/* Lifecycle ---------------------------------------------------------------- */
+
+/* free zebra client information. */
+static void zebra_client_free(struct zserv *client)
+{
+	/* Send client de-registration to BFD */
+	zebra_ptm_bfd_client_deregister(client->proto);
+
+	/* Cleanup any registered nexthops - across all VRFs. */
+	zebra_client_close_cleanup_rnh(client);
+
+	/* Release Label Manager chunks */
+	release_daemon_chunks(client->proto, client->instance);
+
+	/* Cleanup any FECs registered by this client. */
+	zebra_mpls_cleanup_fecs_for_client(vrf_info_lookup(VRF_DEFAULT),
+					   client);
+
+	/* Remove pseudowires associated with this client */
+	zebra_pw_client_close(client);
+
+	/* Close file descriptor. */
+	if (client->sock) {
+		unsigned long nroutes;
+
+		close(client->sock);
+		nroutes = rib_score_proto(client->proto, client->instance);
+		zlog_notice(
+			"client %d disconnected. %lu %s routes removed from the rib",
+			client->sock, nroutes,
+			zebra_route_string(client->proto));
+		client->sock = -1;
+	}
+
+	/* Free stream buffers. */
+	if (client->ibuf_work)
+		stream_free(client->ibuf_work);
+	if (client->obuf_work)
+		stream_free(client->obuf_work);
+	if (client->ibuf_fifo)
+		stream_fifo_free(client->ibuf_fifo);
+	if (client->obuf_fifo)
+		stream_fifo_free(client->obuf_fifo);
+	if (client->wb)
+		buffer_free(client->wb);
+
+	/* Release threads. */
+	if (client->t_read)
+		thread_cancel(client->t_read);
+	if (client->t_write)
+		thread_cancel(client->t_write);
+	if (client->t_suicide)
+		thread_cancel(client->t_suicide);
+
+	/* Free bitmaps. */
+	for (afi_t afi = AFI_IP; afi < AFI_MAX; afi++)
+		for (int i = 0; i < ZEBRA_ROUTE_MAX; i++)
+			vrf_bitmap_free(client->redist[afi][i]);
+
+	vrf_bitmap_free(client->redist_default);
+	vrf_bitmap_free(client->ifinfo);
+	vrf_bitmap_free(client->ridinfo);
+
+	XFREE(MTYPE_TMP, client);
+}
+
+/*
+ * Called from client thread to terminate itself.
+ */
+static void zebra_client_close(struct zserv *client)
+{
+	listnode_delete(zebrad.client_list, client);
+	zebra_client_free(client);
+}
+
+/* Make new client. */
+static void zebra_client_create(int sock)
+{
+	struct zserv *client;
+	int i;
+	afi_t afi;
+
+	client = XCALLOC(MTYPE_TMP, sizeof(struct zserv));
+
+	/* Make client input/output buffer. */
+	client->sock = sock;
+	client->ibuf_fifo = stream_fifo_new();
+	client->obuf_fifo = stream_fifo_new();
+	client->ibuf_work = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	client->obuf_work = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	client->wb = buffer_new(0);
+
+	/* Set table number. */
+	client->rtm_table = zebrad.rtm_table_default;
+
+	client->connect_time = monotime(NULL);
+	/* Initialize flags */
+	for (afi = AFI_IP; afi < AFI_MAX; afi++)
+		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
+			client->redist[afi][i] = vrf_bitmap_init();
+	client->redist_default = vrf_bitmap_init();
+	client->ifinfo = vrf_bitmap_init();
+	client->ridinfo = vrf_bitmap_init();
+
+	/* by default, it's not a synchronous client */
+	client->is_synchronous = 0;
+
+	/* Add this client to linked list. */
+	listnode_add(zebrad.client_list, client);
+
+	zebra_vrf_update_all(client);
+
+	/* start read loop */
+	zebra_event(client, ZEBRA_READ);
+}
+
+static int zserv_delayed_close(struct thread *thread)
+{
+	struct zserv *client = THREAD_ARG(thread);
+
+	client->t_suicide = NULL;
+	zebra_client_close(client);
+	return 0;
+}
+
+/*
+ * Log zapi message to zlog.
+ *
+ * errmsg (optional)
+ *    Debugging message
+ *
+ * msg
+ *    The message
+ *
+ * hdr (optional)
+ *    The message header
+ */
+static void zserv_log_message(const char *errmsg, struct stream *msg,
+			      struct zmsghdr *hdr)
+{
+	zlog_debug("Rx'd ZAPI message");
+	if (errmsg)
+		zlog_debug("%s", errmsg);
+	if (hdr) {
+		zlog_debug(" Length: %d", hdr->length);
+		zlog_debug("Command: %s", zserv_command_string(hdr->command));
+		zlog_debug("    VRF: %u", hdr->vrf_id);
+	}
+	zlog_hexdump(msg->data, STREAM_READABLE(msg));
+}
+
+static int zserv_flush_data(struct thread *thread)
+{
+	struct zserv *client = THREAD_ARG(thread);
+
+	client->t_write = NULL;
+	if (client->t_suicide) {
+		zebra_client_close(client);
+		return -1;
+	}
+	switch (buffer_flush_available(client->wb, client->sock)) {
+	case BUFFER_ERROR:
+		zlog_warn(
+			"%s: buffer_flush_available failed on zserv client fd %d, closing",
+			__func__, client->sock);
+		zebra_client_close(client);
+		client = NULL;
+		break;
+	case BUFFER_PENDING:
+		client->t_write = NULL;
+		thread_add_write(zebrad.master, zserv_flush_data, client,
+				 client->sock, &client->t_write);
+		break;
+	case BUFFER_EMPTY:
+		break;
+	}
+
+	if (client)
+		client->last_write_time = monotime(NULL);
+	return 0;
+}
+
+/*
+ * Write a single packet.
+ */
+static int zserv_write(struct thread *thread)
+{
+	struct zserv *client = THREAD_ARG(thread);
+	struct stream *msg;
+	int writerv;
+
+	if (client->t_suicide)
+		return -1;
+
+	if (client->is_synchronous)
+		return 0;
+
+	msg = stream_fifo_pop(client->obuf_fifo);
+	stream_set_getp(msg, 0);
+	client->last_write_cmd = stream_getw_from(msg, 6);
+
+	writerv = buffer_write(client->wb, client->sock, STREAM_DATA(msg),
+			       stream_get_endp(msg));
+
+	stream_free(msg);
+
+	switch (writerv) {
+	case BUFFER_ERROR:
+		zlog_warn(
+			"%s: buffer_write failed to zserv client fd %d, closing",
+			__func__, client->sock);
+		/*
+		 * Schedule a delayed close since many of the functions that
+		 * call this one do not check the return code. They do not
+		 * allow for the possibility that an I/O error may have caused
+		 * the client to be deleted.
+		 */
+		client->t_suicide = NULL;
+		thread_add_event(zebrad.master, zserv_delayed_close, client, 0,
+				 &client->t_suicide);
+		return -1;
+	case BUFFER_EMPTY:
+		THREAD_OFF(client->t_write);
+		break;
+	case BUFFER_PENDING:
+		thread_add_write(zebrad.master, zserv_flush_data, client,
+				 client->sock, &client->t_write);
+		break;
+	}
+
+	if (client->obuf_fifo->count)
+		zebra_event(client, ZEBRA_WRITE);
+
+	client->last_write_time = monotime(NULL);
+	return 0;
 }
 
 #if defined(HANDLE_ZAPI_FUZZING)
@@ -2781,26 +2798,66 @@ static void zserv_write_incoming(struct stream *orig, uint16_t command)
 }
 #endif
 
+static int zserv_process_messages(struct thread *thread)
+{
+	struct zserv *client = THREAD_ARG(thread);
+	struct zebra_vrf *zvrf;
+	struct zmsghdr hdr;
+	struct stream *msg;
+	bool hdrvalid;
+
+	do {
+		msg = stream_fifo_pop(client->ibuf_fifo);
+
+		/* break if out of messages */
+		if (!msg)
+			continue;
+
+		/* read & check header */
+		hdrvalid = zapi_parse_header(msg, &hdr);
+		if (!hdrvalid && IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV) {
+			const char *emsg = "Message has corrupt header";
+			zserv_log_message(emsg, msg, NULL);
+		}
+		if (!hdrvalid)
+			continue;
+
+		/* lookup vrf */
+		zvrf = zebra_vrf_lookup_by_id(hdr.vrf_id);
+		if (!zvrf && IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV) {
+			const char *emsg = "Message specifies unknown VRF";
+			zserv_log_message(emsg, msg, &hdr);
+		}
+		if (!zvrf)
+			continue;
+
+		/* process commands */
+		zserv_handle_commands(client, &hdr, msg, zvrf);
+
+	} while (msg);
+
+	return 0;
+}
+
 /* Handler of zebra service request. */
-static int zebra_client_read(struct thread *thread)
+static int zserv_read(struct thread *thread)
 {
 	int sock;
 	struct zserv *client;
 	size_t already;
-	uint16_t length, command;
-	uint8_t marker, version;
-	vrf_id_t vrf_id;
-	struct zebra_vrf *zvrf;
 #if defined(HANDLE_ZAPI_FUZZING)
 	int packets = 1;
 #else
 	int packets = zebrad.packets_to_process;
 #endif
+	struct zmsghdr hdr;
+	ssize_t nb;
+	bool hdrvalid;
+	char errmsg[256];
 
 	/* Get thread data.  Reset reading thread because I'm running. */
 	sock = THREAD_FD(thread);
 	client = THREAD_ARG(thread);
-	client->t_read = NULL;
 
 	if (client->t_suicide) {
 		zebra_client_close(client);
@@ -2808,88 +2865,84 @@ static int zebra_client_read(struct thread *thread)
 	}
 
 	while (packets) {
+		already = stream_get_endp(client->ibuf_work);
+
 		/* Read length and command (if we don't have it already). */
-		if ((already = stream_get_endp(client->ibuf))
-		    < ZEBRA_HEADER_SIZE) {
-			ssize_t nbyte;
-			if (((nbyte = stream_read_try(client->ibuf, sock,
-						      ZEBRA_HEADER_SIZE
-							      - already))
-			     == 0)
-			    || (nbyte == -1)) {
-				if (IS_ZEBRA_DEBUG_EVENT)
-					zlog_debug(
-						"connection closed socket [%d]",
-						sock);
-				zebra_client_close(client);
-				return -1;
-			}
-			if (nbyte != (ssize_t)(ZEBRA_HEADER_SIZE - already)) {
+		if (already < ZEBRA_HEADER_SIZE) {
+			nb = stream_read_try(client->ibuf_work, sock,
+					     ZEBRA_HEADER_SIZE - already);
+			if ((nb == 0 || nb == -1) && IS_ZEBRA_DEBUG_EVENT)
+				zlog_debug("connection closed socket [%d]",
+					   sock);
+			if ((nb == 0 || nb == -1))
+				goto zread_fail;
+			if (nb != (ssize_t)(ZEBRA_HEADER_SIZE - already)) {
 				/* Try again later. */
-				zebra_event(ZEBRA_READ, sock, client);
-				return 0;
+				break;
 			}
 			already = ZEBRA_HEADER_SIZE;
 		}
 
 		/* Reset to read from the beginning of the incoming packet. */
-		stream_set_getp(client->ibuf, 0);
+		stream_set_getp(client->ibuf_work, 0);
 
 		/* Fetch header values */
-		STREAM_GETW(client->ibuf, length);
-		STREAM_GETC(client->ibuf, marker);
-		STREAM_GETC(client->ibuf, version);
-		STREAM_GETL(client->ibuf, vrf_id);
-		STREAM_GETW(client->ibuf, command);
+		hdrvalid = zapi_parse_header(client->ibuf_work, &hdr);
 
-		if (marker != ZEBRA_HEADER_MARKER || version != ZSERV_VERSION) {
-			zlog_err(
-				"%s: socket %d version mismatch, marker %d, version %d",
-				__func__, sock, marker, version);
-			zebra_client_close(client);
-			return -1;
+		if (!hdrvalid) {
+			snprintf(errmsg, sizeof(errmsg),
+				 "%s: Message has corrupt header", __func__);
+			zserv_log_message(errmsg, client->ibuf_work, NULL);
+			goto zread_fail;
 		}
-		if (length < ZEBRA_HEADER_SIZE) {
-			zlog_warn(
-				"%s: socket %d message length %u is less than header size %d",
-				__func__, sock, length, ZEBRA_HEADER_SIZE);
-			zebra_client_close(client);
-			return -1;
+
+		/* Validate header */
+		if (hdr.marker != ZEBRA_HEADER_MARKER
+		    || hdr.version != ZSERV_VERSION) {
+			snprintf(
+				errmsg, sizeof(errmsg),
+				"Message has corrupt header\n%s: socket %d version mismatch, marker %d, version %d",
+				__func__, sock, hdr.marker, hdr.version);
+			zserv_log_message(errmsg, client->ibuf_work, &hdr);
+			goto zread_fail;
 		}
-		if (length > STREAM_SIZE(client->ibuf)) {
-			zlog_warn(
-				"%s: socket %d message length %u exceeds buffer size %lu",
-				__func__, sock, length,
-				(u_long)STREAM_SIZE(client->ibuf));
-			zebra_client_close(client);
-			return -1;
+		if (hdr.length < ZEBRA_HEADER_SIZE) {
+			snprintf(
+				errmsg, sizeof(errmsg),
+				"Message has corrupt header\n%s: socket %d message length %u is less than header size %d",
+				__func__, sock, hdr.length, ZEBRA_HEADER_SIZE);
+			zserv_log_message(errmsg, client->ibuf_work, &hdr);
+			goto zread_fail;
+		}
+		if (hdr.length > STREAM_SIZE(client->ibuf_work)) {
+			snprintf(
+				errmsg, sizeof(errmsg),
+				"Message has corrupt header\n%s: socket %d message length %u exceeds buffer size %lu",
+				__func__, sock, hdr.length,
+				(unsigned long)STREAM_SIZE(client->ibuf_work));
+			goto zread_fail;
 		}
 
 		/* Read rest of data. */
-		if (already < length) {
-			ssize_t nbyte;
-			if (((nbyte = stream_read_try(client->ibuf, sock,
-						      length - already))
-			     == 0)
-			    || (nbyte == -1)) {
-				if (IS_ZEBRA_DEBUG_EVENT)
-					zlog_debug(
-						"connection closed [%d] when reading zebra data",
-						sock);
-				zebra_client_close(client);
-				return -1;
-			}
-			if (nbyte != (ssize_t)(length - already)) {
+		if (already < hdr.length) {
+			nb = stream_read_try(client->ibuf_work, sock,
+					     hdr.length - already);
+			if ((nb == 0 || nb == -1) && IS_ZEBRA_DEBUG_EVENT)
+				zlog_debug(
+					"connection closed [%d] when reading zebra data",
+					sock);
+			if ((nb == 0 || nb == -1))
+				goto zread_fail;
+			if (nb != (ssize_t)(hdr.length - already)) {
 				/* Try again later. */
-				zebra_event(ZEBRA_READ, sock, client);
-				return 0;
+				break;
 			}
 		}
 
 #if defined(HANDLE_ZAPI_FUZZING)
-		zserv_write_incoming(client->ibuf, command);
+		zserv_write_incoming(client->ibuf_work, command);
 #endif
-		length -= ZEBRA_HEADER_SIZE;
+		hdr.length -= ZEBRA_HEADER_SIZE;
 
 		/* Debug packet information. */
 		if (IS_ZEBRA_DEBUG_EVENT)
@@ -2897,41 +2950,54 @@ static int zebra_client_read(struct thread *thread)
 				   sock);
 
 		if (IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV)
-			zlog_debug("zebra message received [%s] %d in VRF %u",
-				   zserv_command_string(command), length,
-				   vrf_id);
+			zserv_log_message(NULL, client->ibuf_work, &hdr);
 
 		client->last_read_time = monotime(NULL);
-		client->last_read_cmd = command;
+		client->last_read_cmd = hdr.command;
 
-		zvrf = zebra_vrf_lookup_by_id(vrf_id);
-		if (!zvrf) {
-			if (IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV)
-				zlog_debug("zebra received unknown VRF[%u]",
-					   vrf_id);
-			goto zclient_read_out;
-		}
+		stream_set_getp(client->ibuf_work, 0);
+		struct stream *msg = stream_dup(client->ibuf_work);
 
-		zserv_handle_commands(client, command, length, zvrf);
+		stream_fifo_push(client->ibuf_fifo, msg);
 
-		if (client->t_suicide) {
-			/* No need to wait for thread callback, just kill
-			 * immediately.
-			 */
-			zebra_client_close(client);
-			return -1;
-		}
-		packets -= 1;
-		stream_reset(client->ibuf);
+		if (client->t_suicide)
+			goto zread_fail;
+
+		--packets;
+		stream_reset(client->ibuf_work);
 	}
 
-stream_failure:
-zclient_read_out:
-	stream_reset(client->ibuf);
-	zebra_event(ZEBRA_READ, sock, client);
+	if (IS_ZEBRA_DEBUG_PACKET)
+		zlog_debug("Read %d packets",
+			   zebrad.packets_to_process - packets);
+
+	/* Schedule job to process those packets */
+	thread_add_event(zebrad.master, &zserv_process_messages, client, 0,
+			 NULL);
+
+	/* Reschedule ourselves */
+	zebra_event(client, ZEBRA_READ);
+
 	return 0;
+
+zread_fail:
+	zebra_client_close(client);
+	return -1;
 }
 
+static void zebra_event(struct zserv *client, enum event event)
+{
+	switch (event) {
+	case ZEBRA_READ:
+		thread_add_read(zebrad.master, zserv_read, client, client->sock,
+				&client->t_read);
+		break;
+	case ZEBRA_WRITE:
+		thread_add_write(zebrad.master, zserv_write, client,
+				 client->sock, &client->t_write);
+		break;
+	}
+}
 
 /* Accept code of zebra server socket. */
 static int zebra_accept(struct thread *thread)
@@ -2944,7 +3010,7 @@ static int zebra_accept(struct thread *thread)
 	accept_sock = THREAD_FD(thread);
 
 	/* Reregister myself. */
-	zebra_event(ZEBRA_SERV, accept_sock, NULL);
+	thread_add_read(zebrad.master, zebra_accept, NULL, accept_sock, NULL);
 
 	len = sizeof(struct sockaddr_in);
 	client_sock = accept(accept_sock, (struct sockaddr *)&client, &len);
@@ -3031,26 +3097,7 @@ void zebra_zserv_socket_init(char *path)
 
 	umask(old_mask);
 
-	zebra_event(ZEBRA_SERV, sock, NULL);
-}
-
-
-static void zebra_event(enum event event, int sock, struct zserv *client)
-{
-	switch (event) {
-	case ZEBRA_SERV:
-		thread_add_read(zebrad.master, zebra_accept, client, sock,
-				NULL);
-		break;
-	case ZEBRA_READ:
-		client->t_read = NULL;
-		thread_add_read(zebrad.master, zebra_client_read, client, sock,
-				&client->t_read);
-		break;
-	case ZEBRA_WRITE:
-		/**/
-		break;
-	}
+	thread_add_read(zebrad.master, zebra_accept, NULL, sock, NULL);
 }
 
 #define ZEBRA_TIME_BUF 32

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -2850,11 +2850,6 @@ static int zserv_read(struct thread *thread)
 #else
 	int packets = zebrad.packets_to_process;
 #endif
-	struct zmsghdr hdr;
-	ssize_t nb;
-	bool hdrvalid;
-	char errmsg[256];
-
 	/* Get thread data.  Reset reading thread because I'm running. */
 	sock = THREAD_FD(thread);
 	client = THREAD_ARG(thread);
@@ -2865,6 +2860,11 @@ static int zserv_read(struct thread *thread)
 	}
 
 	while (packets) {
+		struct zmsghdr hdr;
+		ssize_t nb;
+		bool hdrvalid;
+		char errmsg[256];
+
 		already = stream_get_endp(client->ibuf_work);
 
 		/* Read length and command (if we don't have it already). */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -138,6 +138,9 @@ struct zmsghdr {
 	uint16_t command;
 };
 
+#define ZAPI_HANDLER_ARGS                                                      \
+	struct zserv *client, struct zmsghdr *hdr, struct zebra_vrf *zvrf
+
 /* Zebra instance */
 struct zebra_t {
 	/* Thread master */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -47,8 +47,12 @@ struct zserv {
 	int sock;
 
 	/* Input/output buffer to the client. */
-	struct stream *ibuf;
-	struct stream *obuf;
+	struct stream_fifo *ibuf_fifo;
+	struct stream_fifo *obuf_fifo;
+
+	/* Private I/O buffers */
+	struct stream *ibuf_work;
+	struct stream *obuf_work;
 
 	/* Buffer of data waiting to be written to client. */
 	struct buffer *wb;
@@ -129,7 +133,7 @@ struct zserv {
 	int last_write_cmd;
 };
 
-/* ZAPI protocol message header */
+/* ZAPI protocol structs */
 struct zmsghdr {
 	uint16_t length;
 	uint8_t marker;
@@ -139,7 +143,8 @@ struct zmsghdr {
 };
 
 #define ZAPI_HANDLER_ARGS                                                      \
-	struct zserv *client, struct zmsghdr *hdr, struct zebra_vrf *zvrf
+	struct zserv *client, struct zmsghdr *hdr, struct stream *msg,         \
+		struct zebra_vrf *zvrf
 
 /* Zebra instance */
 struct zebra_t {
@@ -197,7 +202,7 @@ extern void zsend_rule_notify_owner(struct zebra_pbr_rule *rule,
 
 extern void zserv_nexthop_num_warn(const char *, const struct prefix *,
 				   const unsigned int);
-extern int zebra_server_send_message(struct zserv *client);
+extern int zebra_server_send_message(struct zserv *client, struct stream *msg);
 
 extern struct zserv *zebra_find_client(u_char proto, u_short instance);
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -133,15 +133,6 @@ struct zserv {
 	int last_write_cmd;
 };
 
-/* ZAPI protocol structs */
-struct zmsghdr {
-	uint16_t length;
-	uint8_t marker;
-	uint8_t version;
-	uint32_t vrf_id;
-	uint16_t command;
-};
-
 #define ZAPI_HANDLER_ARGS                                                      \
 	struct zserv *client, struct zmsghdr *hdr, struct stream *msg,         \
 		struct zebra_vrf *zvrf

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -129,6 +129,15 @@ struct zserv {
 	int last_write_cmd;
 };
 
+/* ZAPI protocol message header */
+struct zmsghdr {
+	uint16_t length;
+	uint8_t marker;
+	uint8_t version;
+	uint32_t vrf_id;
+	uint16_t command;
+};
+
 /* Zebra instance */
 struct zebra_t {
 	/* Thread master */


### PR DESCRIPTION
#### Standardize arguments for ZAPI message handlers

A lot of the handler functions that are called directly from the ZAPI
input processing code take different argument sets where they don't need
to. These functions are called from only one place and all have the same
fundamental information available to them to do their work. There is no
need to specialize what information is passed to them; it is cleaner and
easier to understand when they all accept the same base set of
information and extract what they need inline.

#### Eliminate the humongous switch-case in the dispatcher

After doing the above work it becomes possible to eliminate the big
switch-case statement and turn it into a lookup table keyed by ZAPI
message code. Granted the compiler usually optimizes switch-case
statements into jump tables anyway but it is better to make this a
strong guarantee by doing it in the source.

#### Allow batching ZAPI I/O

ZAPI's original I/O loop looks like:

`zserv_read`:
- Read one message
- Run message handler
- Schedule `zserv_read`

This has been changed to:

`zserv_handle_messages`:
- For each message on the input queue:
  - Pop the message
  - Run message handler

`zserv_read`:
- Read as many messages as available into input queue
- Schedule `zserv_handle_messages`
- Schedule `zserv_read`

This is more flexible as it decouples I/O from actual state changes inside
Zebra. Theoretically it also helps cache churn by grouping the same tasks
together instead of alternating between them.

#### Modify all handlers to stop accessing global client buffers

There is no reason for message handlers to look at a global data
structure that holds the last message received. Instead we can reduce
the amount of global state they need to know about by making them accept
a message stream, and not care about where it came from. This is also
necessary for the input queue changes above. It also moves us closer to
being able to unit test ZAPI message handlers.

#### Modify all handlers to not return an status code

All of the ZAPI message handlers return an integer that means different
things to each of them, but nobody ever reads these integers, so this is
technical debt that we can just eliminate outright.

#### Rename some functions to `zread_*` or `zsend_*` to clarify action

zserv.c functions are roughly organized into three kinds of functions:
- Functions that encode Zebra datastructures into ZAPI message
  equivalents
- Functions that build and send whole messages
- Functions that process received ZAPI messages

These are variously named with prefixes like "zserv", "zebra", "zread",
"zsend", etc. Organize them by using consistent naming prefixes;
`zserv_encode_*`, `zsend_*`, `zread_*` respectively for the three types given
above.

#### Organize `zserv.c` into logical sections

Group the above functions together by type, and group the plumbing for
the I/O code together as well.

#### Add `struct zmsghdr`

Formalize the ZAPI header by documenting it in code and providing it to
message handlers free of charge to reduce complexity.

#### Clean up zserv_read

Just some simplifications of the existing code intended to make it
easier to read, understand and debug. Also improved debugging output for
ZAPI messages by leveraging zmsghdr and making log messages consistent:

```
2018/03/05 16:00:12 OSPF: ospfd 4.1-dev starting: vty@2604
2018/03/05 16:00:12 ZEBRA: zebra message comes from socket [19]
2018/03/05 16:00:12 ZEBRA: Rx'd ZAPI message
2018/03/05 16:00:12 ZEBRA:  Length: 4
2018/03/05 16:00:12 ZEBRA: Command: ZEBRA_HELLO
2018/03/05 16:00:12 ZEBRA:     VRF: 0
2018/03/05 16:00:12 ZEBRA:
0x0000000001773ad0: 00 0e fe 05             ....

2018/03/05 16:00:12 ZEBRA: Read 1 packets
2018/03/05 16:00:12 ZEBRA: client 19 says hello and bids fair to announce only ospf routes
2018/03/05 16:00:12 ZEBRA: zebra message comes from socket [19]
2018/03/05 16:00:12 ZEBRA: Rx'd ZAPI message
2018/03/05 16:00:12 ZEBRA:  Length: 4
2018/03/05 16:00:12 ZEBRA: Command: ZEBRA_BFD_CLIENT_REGISTER
2018/03/05 16:00:12 ZEBRA:     VRF: 0
2018/03/05 16:00:12 ZEBRA:
0x0000000001773ad0: 00 0e fe 05             ....

2018/03/05 16:00:12 ZEBRA: Read 1 packets
2018/03/05 16:00:12 ZEBRA: bfd_client_register msg from client ospf: length=14
2018/03/05 16:00:12 ZEBRA: zebra message comes from socket [19]
2018/03/05 16:00:12 ZEBRA: Rx'd ZAPI message
2018/03/05 16:00:12 ZEBRA:  Length: 0
2018/03/05 16:00:12 ZEBRA: Command: ZEBRA_ROUTER_ID_ADD
2018/03/05 16:00:12 ZEBRA:     VRF: 0
2018/03/05 16:00:12 ZEBRA:

2018/03/05 16:00:12 ZEBRA: Read 1 packets
2018/03/05 16:00:12 ZEBRA: zebra message comes from socket [19]
2018/03/05 16:00:12 ZEBRA: Rx'd ZAPI message
2018/03/05 16:00:12 ZEBRA:  Length: 0
2018/03/05 16:00:12 ZEBRA: Command: ZEBRA_INTERFACE_ADD
2018/03/05 16:00:12 ZEBRA:     VRF: 0
2018/03/05 16:00:12 ZEBRA:
```

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>