### PR TITLE
ospfd: cancel SR thread at shutdown

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -707,6 +707,7 @@ static void ospf_finish_final(struct ospf *ospf)
 	OSPF_TIMER_OFF(ospf->t_read);
 	OSPF_TIMER_OFF(ospf->t_write);
 	OSPF_TIMER_OFF(ospf->t_opaque_lsa_self);
+	OSPF_TIMER_OFF(ospf->t_sr_update);
 
 	close(ospf->fd);
 	stream_free(ospf->ibuf);


### PR DESCRIPTION
Otherwise if it is scheduled the thread pointer will be accessed after
the shutdown task finishes accessing, having deleted the structure that
owns said pointer, which causes a heap UAF.

Fixes #1724 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>