### PR TITLE
zebra/ospfd:  Treat vrf interface similar to loopback

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -476,6 +476,12 @@ int if_is_loopback(struct interface *ifp)
 	return (ifp->flags & (IFF_LOOPBACK | IFF_NOXMIT | IFF_VIRTUAL));
 }
 
+/* Check interface is VRF */
+int if_is_vrf(struct interface *ifp)
+{
+	return CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK);
+}
+
 /* Does this interface support broadcast ? */
 int if_is_broadcast(struct interface *ifp)
 {

--- a/lib/if.h
+++ b/lib/if.h
@@ -288,6 +288,7 @@ struct interface {
 
 	QOBJ_FIELDS
 };
+
 RB_HEAD(if_name_head, interface);
 RB_PROTOTYPE(if_name_head, interface, name_entry, if_cmp_func);
 RB_HEAD(if_index_head, interface);
@@ -491,6 +492,7 @@ extern int if_is_running(struct interface *);
 extern int if_is_operative(struct interface *);
 extern int if_is_no_ptm_operative(struct interface *);
 extern int if_is_loopback(struct interface *);
+extern int if_is_vrf(struct interface *ifp);
 extern int if_is_broadcast(struct interface *);
 extern int if_is_pointopoint(struct interface *);
 extern int if_is_multicast(struct interface *);

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -459,7 +459,7 @@ struct ospf_interface *ospf_if_lookup_recv_if(struct ospf *ospf,
 		if (oi->type == OSPF_IFTYPE_VIRTUALLINK)
 			continue;
 
-		if (if_is_loopback(oi->ifp))
+		if (if_is_loopback(oi->ifp) || if_is_vrf(oi->ifp))
 			continue;
 
 		if (CHECK_FLAG(oi->connected->flags, ZEBRA_IFA_UNNUMBERED))
@@ -703,7 +703,7 @@ static int ospf_if_delete_hook(struct interface *ifp)
 
 int ospf_if_is_enable(struct ospf_interface *oi)
 {
-	if (!if_is_loopback(oi->ifp))
+	if (!(if_is_loopback(oi->ifp) || if_is_vrf(oi->ifp)))
 		if (if_is_up(oi->ifp))
 			return 1;
 
@@ -1206,7 +1206,7 @@ u_char ospf_default_iftype(struct interface *ifp)
 {
 	if (if_is_pointopoint(ifp))
 		return OSPF_IFTYPE_POINTOPOINT;
-	else if (if_is_loopback(ifp))
+	else if (if_is_loopback(ifp) || if_is_vrf(ifp))
 		return OSPF_IFTYPE_LOOPBACK;
 	else
 		return OSPF_IFTYPE_BROADCAST;

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -73,7 +73,8 @@ static void connected_announce(struct interface *ifp, struct connected *ifc)
 	if (!ifc)
 		return;
 
-	if (!if_is_loopback(ifp) && ifc->address->family == AF_INET) {
+	if (!if_is_loopback(ifp) && ifc->address->family == AF_INET &&
+	    !IS_ZEBRA_IF_VRF(ifp)) {
 		if (ifc->address->prefixlen == 32)
 			SET_FLAG(ifc->flags, ZEBRA_IFA_UNNUMBERED);
 		else

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -649,8 +649,6 @@ static int netlink_interface(struct sockaddr_nl *snl, struct nlmsghdr *h,
 	ifp = if_get_by_name(name, vrf_id, 0);
 	set_ifindex(ifp, ifi->ifi_index, zns);
 	ifp->flags = ifi->ifi_flags & 0x0000fffff;
-	if (IS_ZEBRA_IF_VRF(ifp))
-		SET_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK);
 	ifp->mtu6 = ifp->mtu = *(uint32_t *)RTA_DATA(tb[IFLA_MTU]);
 	ifp->metric = 0;
 	ifp->speed = get_iflink_speed(ifp);
@@ -661,6 +659,8 @@ static int netlink_interface(struct sockaddr_nl *snl, struct nlmsghdr *h,
 
 	/* Set zebra interface type */
 	zebra_if_set_ziftype(ifp, zif_type, zif_slave_type);
+	if (IS_ZEBRA_IF_VRF(ifp))
+		SET_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK);
 
 	/* Update link. */
 	zebra_if_update_link(ifp, link_ifindex);
@@ -1143,15 +1143,15 @@ int netlink_link_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
 			/* Update interface information. */
 			set_ifindex(ifp, ifi->ifi_index, zns);
 			ifp->flags = ifi->ifi_flags & 0x0000fffff;
-			if (IS_ZEBRA_IF_VRF(ifp))
-				SET_FLAG(ifp->status,
-					 ZEBRA_INTERFACE_VRF_LOOPBACK);
 			ifp->mtu6 = ifp->mtu = *(int *)RTA_DATA(tb[IFLA_MTU]);
 			ifp->metric = 0;
 			ifp->ptm_status = ZEBRA_PTM_STATUS_UNKNOWN;
 
 			/* Set interface type */
 			zebra_if_set_ziftype(ifp, zif_type, zif_slave_type);
+			if (IS_ZEBRA_IF_VRF(ifp))
+				SET_FLAG(ifp->status,
+					 ZEBRA_INTERFACE_VRF_LOOPBACK);
 
 			/* Update link. */
 			zebra_if_update_link(ifp, link_ifindex);


### PR DESCRIPTION
Zebra: Set VRF_LOOPBACK status after ziftype sets vrf type in netlink add/change interface. 
connected announce to check vrf flag for ifp similar to loopback and avoid sending unnumbered for vrf device. 

ospfd: set VRF interface iftype as loopback during interface add callback. 

Testing: 
Before:
vrf1014 is up
  ifindex 23, MTU 65536 bytes, BW 0 Mbit <UP,RUNNING,NOARP>
  **This interface is UNNUMBERED**, Area 0.0.0.0
  MTU mismatch detection: enabled
  Router ID 9.9.14.7, Network **Type BROADCAST**, Cost: 10
  Transmit Delay is 1 sec, State DR, Priority 1
  No backup designated router on this network
  Multicast group memberships: OSPFAllRouters OSPFDesignatedRouters
  Timer intervals configured, Hello 10s, Dead 40s, Wait 40s, Retransmit 5
    **Hello due in 7.981s**
  Neighbor Count is 0, Adjacent neighbor count is 0


l1# show ip ospf vrf vrf1014 route
...
N    9.9.14.7/32           [**10**] area: 0.0.0.0
                           directly attached to vrf1014

After:

vrf1014 is up
  ifindex 23, MTU 65536 bytes, BW 0 Mbit <UP,RUNNING,NOARP>
  Internet Address **9.9.14.7/32**, Area 0.0.0.0
  MTU mismatch detection: enabled
  Router ID 9.9.14.7, Network **Type LOOPBACK**, Cost: 10
  Transmit Delay is 1 sec, State Loopback, Priority 1
  No backup designated router on this network
  Multicast group memberships: <None>
  Timer intervals configured, Hello 10s, Dead 40s, Wait 40s, Retransmit 5
    **Hello due in inactive**
  Neighbor Count is 0, Adjacent neighbor count is 0

l1# show ip ospf vrf vrf1014 route
...
N    9.9.14.7/32           [**0**] area: 0.0.0.0
                           directly attached to vrf1014

Loopback interface output (current behavior):
lo is up
  ifindex 1, MTU 65536 bytes, BW 0 Mbit <UP,LOOPBACK,RUNNING>
  Internet Address **6.0.0.11/32**, Area 0.0.0.0
  MTU mismatch detection: enabled
  Router ID 6.0.0.11, Network **Type LOOPBACK**, Cost: 10
  Transmit Delay is 1 sec, State Loopback, Priority 1
  No backup designated router on this network
  Multicast group memberships: <None>
  Timer intervals configured, Hello 10s, Dead 40s, Wait 40s, Retransmit 5
    **Hello due in inactive**
  Neighbor Count is 0, Adjacent neighbor count is 0

