### PR TITLE
tools: add LeakSanitizer suppressions list [3.0]

### DIFF
--- a/tools/lsan-suppressions.txt
+++ b/tools/lsan-suppressions.txt
@@ -1,0 +1,1 @@
+leak:clippy


### PR DESCRIPTION
Building FRR with AddressSanitizer is kind of annoying since
libpython3.5 leaks memory, clippy links libpython3.5 and clippy runs as
part of the build process. LeakSanitizer has a way to suppress leaks at
runtime by setting the LSAN_OPTIONS environment variable to contain a
file path to a suppression list:

LSAN_OPTIONS=suppressions=path/to/suppr.txt

This commit provides the file. Setting this environment variable to

LSAN_OPTIONS=suppressions=../tools/lsan-suppressions.txt

before building should allow a clean build with ASAN enabled. The
relative path is there because LeakSanitizer looks at paths relative to
the binary it is sanitizing; clippy is in lib/ so the path is set
relative to lib/.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>