### PR TITLE
tools: fix indent.py to recognize all DEFUN types:

### DIFF
--- a/tools/indent.py
+++ b/tools/indent.py
@@ -6,7 +6,7 @@ import sys, re, subprocess, os
 
 # find all DEFUNs
 defun_re = re.compile(
-        r'^((DEF(UN(_NOSH|_HIDDEN)?|PY)|ALIAS)\s*\(.*?)^(?=\s*\{)',
+        r'^((DEF(UN(|_ATTR|_CMD_(ELEMENT|FUNC_(DECL|TEXT))|_DEPRECATED|_NOSH|_HIDDEN|SH(|_ATTR|_DEPRECATED|_HIDDEN))?|PY)|ALIAS)\s*\(.*?)^(?=\s*\{)',
         re.M | re.S)
 define_re = re.compile(
         r'((^#\s*define[^\n]+[^\\]\n)+)',


### PR DESCRIPTION
including: 
    DEFUN
    DEFUN_ATTR
    DEFUN_CMD_ELEMENT
    DEFUN_CMD_FUNC_DECL
    DEFUN_CMD_FUNC_TEXT
    DEFUN_DEPRECATED
    DEFUN_HIDDEN
    DEFUN_NOSH
    DEFUNSH
    DEFUNSH_ATTR
    DEFUNSH_DEPRECATED
    DEFUNSH_HIDDEN

Signed-off-by: Lou Berger <lberger@labn.net>