### PR TITLE
zebra/if_netlink: compile under musl-libc

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -30,6 +30,7 @@
  */
 #define _LINUX_IN6_H
 
+#include <netinet/if_ether.h>
 #include <linux/if_bridge.h>
 #include <linux/if_link.h>
 #include <net/if_arp.h>
@@ -362,7 +363,7 @@ static int get_iflink_speed(struct interface *interface)
 	/* initialize ethtool interface */
 	memset(&ecmd, 0, sizeof(ecmd));
 	ecmd.cmd = ETHTOOL_GSET; /* ETHTOOL_GLINK */
-	ifdata.ifr_data = (__caddr_t)&ecmd;
+	ifdata.ifr_data = (caddr_t)&ecmd;
 
 	/* use ioctl to get IP address of an interface */
 	if (zserv_privs.change(ZPRIVS_RAISE))


### PR DESCRIPTION
musl-libc is a lightweight libc used by alpine linux:

https://www.musl-libc.org/

AFAICT, this is the only change to the source needed to get
basic frr support compiling on musl.

Two changes in one patch, get ethhdr from netinet/if_ether.h
and replace the only __caddr_t I could find in the source base
with caddr_t.

Testing done:

Compiled apk packages using a docker environment (patches
coming soon) also compiled redhat and debian using a similar
docker environment (RFC patches for those changes are queued
up too)...

Issue: https://github.com/FRRouting/frr/issues/1859
Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>