### PR TITLE
alpine: minimal alpine packaging

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -1,0 +1,36 @@
+# Maintainer: Arthur Jones <arthur.jones@riverbed.com>
+pkgname=frr
+pkgver=@VERSION@
+pkgrel=0
+pkgdesc="Free Range Routing is a fork of quagga"
+url="https://frrouting.org/"
+arch="all"
+license="GPL-2.0"
+depends="iproute2 json-c c-ares ipsec-tools iproute2"
+makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
+    acct autoconf automake bash
+    binutils binutils-libs bison bsd-compat-headers build-base
+    c-ares c-ares-dev ca-certificates cryptsetup-libs curl
+    device-mapper-libs expat fakeroot flex fortify-headers gdbm
+    git gmp isl json-c-dev kmod lddtree libacl libatomic libattr
+    libblkid libburn libbz2 libc-dev libcap libcurl libedit libffi libgcc
+    libgomp libisoburn libisofs libltdl libressl libssh2
+    libstdc++ libtool libuuid linux-headers lzip lzo m4 make mkinitfs mpc1
+    mpfr3 mtools musl-dev ncurses-libs ncurses-terminfo ncurses-terminfo-base
+    patch pax-utils pcre perl pkgconf python2 python2-dev readline
+    readline-dev sqlite-libs squashfs-tools sudo tar texinfo xorriso xz-libs"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg"
+source="$pkgname-$pkgver.tar.gz"
+
+builddir="$srcdir"/$pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr || return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install || return 1
+}

--- a/configure.ac
+++ b/configure.ac
@@ -396,6 +396,8 @@ AC_ARG_ENABLE(rpki,
   AS_HELP_STRING([--enable-rpki], [enable RPKI prefix validation support]))
 AC_ARG_ENABLE([clippy-only],
   AS_HELP_STRING([--enable-clippy-only], [Only build clippy]))
+AC_ARG_ENABLE([numeric_version],
+  AS_HELP_STRING([--enable-numeric-version], [Only numeric digits allowed in version (for Alpine)]))
 
 AS_IF([test "${enable_clippy_only}" != "yes"], [
 AC_CHECK_HEADERS(json-c/json.h)
@@ -646,6 +648,14 @@ esac
 AC_DEFINE_UNQUOTED(MULTIPATH_NUM, $MPATH_NUM, Maximum number of paths for a route)
 
 AC_DEFINE_UNQUOTED(VTYSH_PAGER, "$VTYSH_PAGER", [What pager to use])
+
+dnl ------------------------------------
+dnl Alpine only accepts numeric versions
+dnl ------------------------------------
+if test "x${enable_numeric_version}" != "x" ; then
+  VERSION="`echo ${VERSION} | tr -c -d '[[.0-9]]'`"
+  PACKAGE_VERSION="`echo ${PACKAGE_VERSION} | tr -c -d '[[.0-9]]'`"
+fi
 
 dnl -----------------------------------
 dnl Add extra version string to package
@@ -1872,6 +1882,7 @@ AC_CONFIG_FILES([Makefile
 	  redhat/frr.spec
 	  debianpkg/Makefile
 	  debianpkg/changelog
+	  alpine/APKBUILD
 	  snapcraft/snapcraft.yaml
 	  lib/version.h
 	  tests/lib/cli/test_cli.refout


### PR DESCRIPTION
For building dev packages for alpine, we provide a minimal APKBUILD
file and add a configure option for only numeric versions in the
VERSION variable as alpine does not allow non-numeric characters
in the version string.

These changes allow alpine to be built, but don't yet provide a
mechanism to build.  Changes to do the build in docker are coming
soon...

Testing done:

Built alpine packages in local docker environment, packages
showed no "dev" in the package name.  Also built CentOS packages
with numeric version disabled and the "dev" is still in the package
name.

Issue: https://github.com/FRRouting/frr/issues/1859
Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>