### PR TITLE
zebra: pbr rule structure is being added fwmark tag

### DIFF
--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -57,6 +57,10 @@ uint32_t zebra_pbr_rules_hash_key(void *arg)
 	else
 		key = jhash_1word(0, key);
 
+	if (rule->filter.fwmark)
+		key = jhash_1word(rule->filter.fwmark, key);
+	else
+		key = jhash_1word(0, key);
 	return jhash_3words(rule->filter.src_port, rule->filter.dst_port,
 			    prefix_hash_key(&rule->filter.dst_ip),
 			    jhash_1word(rule->unique, key));
@@ -85,6 +89,9 @@ int zebra_pbr_rules_hash_equal(const void *arg1, const void *arg2)
 		return 0;
 
 	if (r1->filter.dst_port != r2->filter.dst_port)
+		return 0;
+
+	if (r1->filter.fwmark != r2->filter.fwmark)
 		return 0;
 
 	if (!prefix_same(&r1->filter.src_ip, &r2->filter.src_ip))

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -45,6 +45,7 @@ struct zebra_pbr_filter {
 #define PBR_FILTER_DST_IP     (1 << 1)
 #define PBR_FILTER_SRC_PORT   (1 << 2)
 #define PBR_FILTER_DST_PORT   (1 << 3)
+#define PBR_FILTER_FWMARK     (1 << 4)
 
 	/* Source and Destination IP address with masks. */
 	struct prefix src_ip;
@@ -53,6 +54,9 @@ struct zebra_pbr_filter {
 	/* Source and Destination higher-layer (TCP/UDP) port numbers. */
 	uint16_t src_port;
 	uint16_t dst_port;
+
+	/* Filter with fwmark */
+	uint32_t fwmark;
 };
 
 #define IS_RULE_FILTERING_ON_SRC_IP(r) \


### PR DESCRIPTION
PBR rule is being added a 32 bit value that can be used to record a rule
in the kernel, by using a fwmark information.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>