### PR TITLE
Fix zlog_hexdump

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -1092,14 +1092,16 @@ void zlog_hexdump(const void *mem, unsigned int len)
 	unsigned long i = 0;
 	unsigned int j = 0;
 	unsigned int columns = 8;
-	/* 19 bytes for 0xADDRESS: */
-	/* 24 bytes for data; 2 chars plus a space per data byte */
-	/*  1 byte for space */
-	/*  8 bytes for ASCII representation */
-	/*  1 byte for a newline */
-	/* ===================== */
-	/* 53 bytes per 8 bytes of data */
-	/*  1 byte for null term */
+	/*
+	 * 19 bytes for 0xADDRESS:
+	 * 24 bytes for data; 2 chars plus a space per data byte
+	 *  1 byte for space
+	 *  8 bytes for ASCII representation
+	 *  1 byte for a newline
+	 * =====================
+	 * 53 bytes per 8 bytes of data
+	 *  1 byte for null term
+	 */
 	size_t bs = ((len / 8) + 1) * 53 + 1;
 	char buf[bs];
 	char *s = buf;

--- a/lib/log.c
+++ b/lib/log.c
@@ -1092,41 +1092,50 @@ void zlog_hexdump(const void *mem, unsigned int len)
 	unsigned long i = 0;
 	unsigned int j = 0;
 	unsigned int columns = 8;
-	char buf[(len * 4) + ((len / 4) * 20) + 30];
+	/* 19 bytes for 0xADDRESS: */
+	/* 24 bytes for data; 2 chars plus a space per data byte */
+	/*  1 byte for space */
+	/*  8 bytes for ASCII representation */
+	/*  1 byte for a newline */
+	/* ===================== */
+	/* 53 bytes per 8 bytes of data */
+	/*  1 byte for null term */
+	size_t bs = ((len / 8) + 1) * 53 + 1;
+	char buf[bs];
 	char *s = buf;
+
+	memset(buf, 0, sizeof(buf));
 
 	for (i = 0; i < len + ((len % columns) ? (columns - len % columns) : 0);
 	     i++) {
 		/* print offset */
 		if (i % columns == 0)
-			s += sprintf(s, "0x%016lx: ", (unsigned long)mem + i);
+			s += snprintf(s, bs - (s - buf),
+				      "0x%016lx: ", (unsigned long)mem + i);
 
 		/* print hex data */
 		if (i < len)
-			s += sprintf(s, "%02x ", 0xFF & ((const char *)mem)[i]);
+			s += snprintf(s, bs - (s - buf), "%02x ",
+				      0xFF & ((const char *)mem)[i]);
 
 		/* end of block, just aligning for ASCII dump */
 		else
-			s += sprintf(s, "   ");
+			s += snprintf(s, bs - (s - buf), "   ");
 
 		/* print ASCII dump */
 		if (i % columns == (columns - 1)) {
 			for (j = i - (columns - 1); j <= i; j++) {
-				if (j >= len) /* end of block, not really
-						 printing */
-					s += sprintf(s, " ");
-
-				else if (isprint((int)((const char *)mem)
-							 [j])) /* printable char
-								  */
-					s += sprintf(
-						s, "%c",
+				/* end of block not really printing */
+				if (j >= len)
+					s += snprintf(s, bs - (s - buf), " ");
+				else if (isprint((int)((const char *)mem)[j]))
+					s += snprintf(
+						s, bs - (s - buf), "%c",
 						0xFF & ((const char *)mem)[j]);
-
 				else /* other char */
-					s += sprintf(s, ".");
+					s += snprintf(s, bs - (s - buf), ".");
 			}
-			s += sprintf(s, "\n");
+			s += snprintf(s, bs - (s - buf), "\n");
 		}
 	}
 	zlog_debug("\n%s", buf);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -73,6 +73,7 @@ check_PROGRAMS = \
 	lib/test_timer_correctness \
 	lib/test_timer_performance \
 	lib/test_ttable \
+	lib/test_zlog \
 	lib/cli/test_cli \
 	lib/cli/test_commands \
 	$(TESTS_BGPD) \
@@ -115,9 +116,9 @@ lib_test_heavy_SOURCES = lib/test_heavy.c helpers/c/main.c
 lib_test_memory_SOURCES = lib/test_memory.c
 lib_test_nexthop_iter_SOURCES = lib/test_nexthop_iter.c helpers/c/prng.c
 lib_test_privs_SOURCES = lib/test_privs.c
+lib_test_ringbuf_SOURCES = lib/test_ringbuf.c
 lib_test_srcdest_table_SOURCES = lib/test_srcdest_table.c \
                                  helpers/c/prng.c
-lib_test_ringbuf_SOURCES = lib/test_ringbuf.c
 lib_test_segv_SOURCES = lib/test_segv.c
 lib_test_sig_SOURCES = lib/test_sig.c
 lib_test_stream_SOURCES = lib/test_stream.c
@@ -127,6 +128,7 @@ lib_test_timer_correctness_SOURCES = lib/test_timer_correctness.c \
 lib_test_timer_performance_SOURCES = lib/test_timer_performance.c \
                                      helpers/c/prng.c
 lib_test_ttable_SOURCES = lib/test_ttable.c
+lib_test_zlog_SOURCES = lib/test_zlog.c
 lib_test_zmq_SOURCES = lib/test_zmq.c
 lib_test_zmq_CFLAGS = $(AM_CFLAGS) $(ZEROMQ_CFLAGS)
 lib_cli_test_cli_SOURCES = lib/cli/test_cli.c lib/cli/common_cli.c
@@ -167,6 +169,7 @@ lib_test_table_LDADD = $(ALL_TESTS_LDADD) -lm
 lib_test_timer_correctness_LDADD = $(ALL_TESTS_LDADD)
 lib_test_timer_performance_LDADD = $(ALL_TESTS_LDADD)
 lib_test_ttable_LDADD = $(ALL_TESTS_LDADD)
+lib_test_zlog_LDADD = $(ALL_TESTS_LDADD)
 lib_test_zmq_LDADD = ../lib/libfrrzmq.la $(ALL_TESTS_LDADD) $(ZEROMQ_LIBS)
 lib_cli_test_cli_LDADD = $(ALL_TESTS_LDADD)
 lib_cli_test_commands_LDADD = $(ALL_TESTS_LDADD)
@@ -207,6 +210,7 @@ EXTRA_DIST = \
     lib/test_timer_correctness.py \
     lib/test_ttable.py \
     lib/test_ttable.refout \
+    lib/test_zlog.py \
     ospf6d/test_lsdb.py \
     ospf6d/test_lsdb.in \
     ospf6d/test_lsdb.refout \

--- a/tests/lib/test_zlog.c
+++ b/tests/lib/test_zlog.c
@@ -1,0 +1,61 @@
+/*
+ * Zlog tests.
+ * Copyright (C) 2018  Cumulus Networks, Inc.
+ *                     Quentin Young
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include <zebra.h>
+#include <memory.h>
+#include "log.h"
+
+/* maximum amount of data to hexdump */
+#define MAXDATA 16384
+
+/*
+ * Test hexdump functionality.
+ *
+ * At the moment, not crashing is considered success.
+ */
+static bool test_zlog_hexdump(void)
+{
+	unsigned int nl = 1;
+
+	do {
+		long d[nl];
+
+		for (unsigned int i = 0; i < nl; i++)
+			d[i] = random();
+		zlog_hexdump(d, nl * sizeof(long));
+	} while (++nl * sizeof(long) <= MAXDATA);
+
+	return true;
+}
+
+bool (*tests[])(void) = {
+	test_zlog_hexdump,
+};
+
+int main(int argc, char **argv)
+{
+	openzlog("testzlog", "NONE", 0, LOG_CONS | LOG_NDELAY | LOG_PID,
+		 LOG_ERR);
+	zlog_set_file("test_zlog.log", LOG_DEBUG);
+
+	for (unsigned int i = 0; i < array_size(tests); i++)
+		if (!tests[i]())
+			return 1;
+	return 0;
+}

--- a/tests/lib/test_zlog.py
+++ b/tests/lib/test_zlog.py
@@ -1,0 +1,4 @@
+import frrtest
+
+class TestZlog(frrtest.TestMultiOut):
+    program = './test_zlog'


### PR DESCRIPTION
`zlog_hexdump` was occasionally not allocating the correct amount of memory due to an integer truncation in size calculation expression. Also add beginnings of zlog test suite to check for this in the future.