### PR TITLE
docker build: build Alpine Linux dev packages in docker

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -18,7 +18,8 @@ makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     libstdc++ libtool libuuid linux-headers lzip lzo m4 make mkinitfs mpc1
     mpfr3 mtools musl-dev ncurses-libs ncurses-terminfo ncurses-terminfo-base
     patch pax-utils pcre perl pkgconf python2 python2-dev readline
-    readline-dev sqlite-libs squashfs-tools sudo tar texinfo xorriso xz-libs"
+    readline-dev sqlite-libs squashfs-tools sudo tar texinfo xorriso xz-libs
+    py-sphinx"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg"
 source="$pkgname-$pkgver.tar.gz"
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -179,6 +179,7 @@ EXTRA_DIST = frr-sphinx.mk \
 	developer/OSPF-API.md \
 	developer/workflow.rst \
 	developer/Building_FRR_on_Ubuntu1404.rst \
+	developer/Building_FRR_on_Alpine.rst \
 	user/ospf_fundamentals.rst \
 	user/routemap.rst \
 	user/index.rst \

--- a/doc/developer/Building_FRR_on_Alpine.rst
+++ b/doc/developer/Building_FRR_on_Alpine.rst
@@ -1,0 +1,47 @@
+Building FRR dev packages on Alpine Linux from Git Source
+=========================================================
+
+For building Alpine Linux dev packages, we use docker.
+
+Install docker 17.05 or later
+-----------------------------
+
+Depending on your host, there are different ways of installing
+docker.  Refer to the documentation here for instructions on how
+to install a free version of docker: https://www.docker.com/community-edition
+
+Work with sources
+-----------------
+
+    git clone https://github.com/frrouting/frr.git frr
+    cd frr
+
+Build apk packages
+------------------
+
+    ./docker/alpine/build.sh
+
+This will put the apk packages in:
+
+    ./docker/pkgs/apk/x86_64/
+
+Usage
+-----
+
+To add the packages to a docker image, create a Dockerfile in ./docker/pkgs:
+
+    FROM alpine:3.7
+    RUN mkdir -p /pkgs
+    ADD apk/ /pkgs/
+    RUN apk add --no-cache --allow-untrusted /pkgs/x86_64/*.apk
+
+And build a docker image:
+
+    docker build --rm --force-rm -t alpine-dev-pkgs:latest docker/pkgs
+
+And run the image:
+
+    docker run -it --rm alpine-dev-pkgs:latest /bin/sh
+
+Currently, we only package the raw daemons and example files, so, you'll
+need to run the daemons by hand (or, better, orchestrate in the Dockerfile).

--- a/doc/developer/building.rst
+++ b/doc/developer/building.rst
@@ -5,6 +5,7 @@ Building FRR
    :maxdepth: 2
 
    Building_FRR_on_LEDE-OpenWRT
+   Building_FRR_on_Alpine
    Building_FRR_on_CentOS6
    Building_FRR_on_CentOS7
    Building_FRR_on_Debian8

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,2 @@
+src.tar
+pkgs/

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,0 +1,30 @@
+FROM alpine:3.7 as source-builder
+ARG commit
+RUN apk add --no-cache abuild acct alpine-sdk attr autoconf automake bash \
+    binutils binutils-libs bison bsd-compat-headers build-base \
+    c-ares c-ares-dev ca-certificates cryptsetup-libs curl \
+    device-mapper-libs expat fakeroot flex fortify-headers g++ gcc gdbm \
+    git gmp isl json-c json-c-dev kmod lddtree libacl libatomic libattr \
+    libblkid libburn libbz2 libc-dev libcap libcurl libedit libffi libgcc \
+    libgomp libisoburn libisofs libltdl libressl libssh2 \
+    libstdc++ libtool libuuid linux-headers lzip lzo m4 make mkinitfs mpc1 \
+    mpfr3 mtools musl-dev ncurses-libs ncurses-terminfo ncurses-terminfo-base \
+    patch pax-utils pcre perl pkgconf python2 python2-dev readline \
+    readline-dev sqlite-libs squashfs-tools sudo tar texinfo xorriso xz-libs \
+    groff gzip bc py-sphinx
+RUN mkdir -p /src
+ADD src.tar /src
+RUN (cd /src && \
+	./bootstrap.sh && \
+	./configure \
+		--enable-numeric-version \
+		--with-pkg-extra-version=_git$commit && \
+	make dist)
+FROM alpine:3.7 as alpine-builder
+RUN apk add --no-cache abuild alpine-sdk && mkdir -p /pkgs/apk
+ADD alpine-build.sh /usr/bin/
+ADD builder /etc/sudoers.d
+COPY --from=source-builder /src/*.tar.gz /src/alpine/APKBUILD /dist/
+RUN adduser -D -G abuild builder && chown -R builder /dist /pkgs
+USER builder
+RUN /usr/bin/alpine-build.sh

--- a/docker/alpine/alpine-build.sh
+++ b/docker/alpine/alpine-build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+cd /dist
+
+sudo apk --update add alpine-conf
+sudo setup-apkcache /var/cache/apk
+abuild-keygen -a -n
+abuild checksum
+abuild -r -P /pkgs/apk

--- a/docker/alpine/build.sh
+++ b/docker/alpine/build.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+set -v
+set -x
+
+##
+# commit must be converted to decimal
+##
+c=`git rev-parse --short=10 HEAD`
+commit=`printf '%u\n' 0x$c`
+git archive --format=tar $c > docker/alpine/src.tar
+(cd docker/alpine && \
+	docker build --build-arg commit=$commit --rm --force-rm -t \
+		frr:alpine-$c . && \
+	rm -f src.tar)
+
+id=`docker create frr:alpine-$c`
+docker cp ${id}:/pkgs/ docker
+docker rm $id
+docker rmi frr:alpine-$c

--- a/docker/alpine/builder
+++ b/docker/alpine/builder
@@ -1,0 +1,1 @@
+builder ALL=(ALL) NOPASSWD:ALL


### PR DESCRIPTION
Building alpine packages in a "standard" distro can be
complicated due to the limited scope of the distro (embedded
and small docker images).  Building in a VM is one possibility,
but docker support for alpine is very good (default docker images
come in alpine due to the very small size).

Here, we want to package up the current git repo into apk packages
that can be easily installed in alpine linux using the apk tool.
This support is not intended to package released versions of
apk packages, that, if it comes to be, should be done here:

git://git.alpinelinux.org/aports

We're content here to build packages that can be used by developers
to try out frr in docker and other alpine environments.

This is a very minimal environment, we don't support importing
keys (so, installing the packages with apk requires the
--allow-untrusted option).  In addition, we can't use the
git commit id in hex as version tag, as alpine doesn't support hex
digits in the version string.  So, we need to convert the git hash
to decimal before tagging the package with the extra version.
This is yucky, but I can't think of another way to get a
unique version per package.  The alpine way (using a numeric date),
only works for released packages, not for dev packages.

Issue: https://github.com/FRRouting/frr/issues/1859
Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>