### PR TITLE
lib: enforce vrf netns if setns() returns ok

### DIFF
--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -242,7 +242,8 @@ extern int vrf_switchback_to_initial(void);
 
 /* VRF vty command initialisation
  */
-extern void vrf_cmd_init(int (*writefunc)(struct vty *vty));
+extern void vrf_cmd_init(int (*writefunc)(struct vty *vty),
+			 struct zebra_privs_t *daemon_priv);
 
 /* VRF vty debugging
  */

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -214,7 +214,7 @@ void pim_vrf_init(void)
 {
 	vrf_init(pim_vrf_new, pim_vrf_enable, pim_vrf_disable, pim_vrf_delete);
 
-	vrf_cmd_init(pim_vrf_config_write);
+	vrf_cmd_init(pim_vrf_config_write, &pimd_privs);
 }
 
 void pim_vrf_terminate(void)

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -92,7 +92,11 @@ static void zebra_ns_notify_create_context_from_entry_name(const char *name)
 		zlog_warn("NS notify : failed to create VRF %s", name);
 		return;
 	}
+	if (zserv_privs.change(ZPRIVS_RAISE))
+		zlog_err("Can't raise privileges");
 	ret = vrf_netns_handler_create(NULL, vrf, netnspath, ns_id);
+	if (zserv_privs.change(ZPRIVS_LOWER))
+		zlog_err("Can't lower privileges");
 	if (ret != CMD_SUCCESS) {
 		zlog_warn("NS notify : failed to create NS %s", netnspath);
 		return;

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -39,6 +39,7 @@
 #include "zebra/interface.h"
 #include "zebra/zebra_mpls.h"
 #include "zebra/zebra_vxlan.h"
+#include "zebra/zebra_netns_notify.h"
 
 extern struct zebra_t zebrad;
 
@@ -587,5 +588,5 @@ void zebra_vrf_init(void)
 	vrf_init(zebra_vrf_new, zebra_vrf_enable, zebra_vrf_disable,
 		 zebra_vrf_delete);
 
-	vrf_cmd_init(vrf_config_write);
+	vrf_cmd_init(vrf_config_write, &zserv_privs);
 }


### PR DESCRIPTION
On some cases, having vrf netns support does not only rely on the
ability to have vrf on /var/run/netns. For each new netns detected,
a call to setns() will be done to check that the feature is well
available.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>