### PR TITLE
ospf6d: Stop debug messages happening in rare case

### DIFF
--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -1573,7 +1573,8 @@ int ospf6_receive(struct thread *thread)
 	oi = ospf6_interface_lookup_by_ifindex(ifindex);
 	if (oi == NULL || oi->area == NULL
 	    || CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE)) {
-		zlog_debug("Message received on disabled interface");
+		if (IS_OSPF6_DEBUG_MESSAGE(OSPF6_MESSAGE_TYPE_UNKNOWN, RECV))
+			zlog_debug("Message received on disabled interface");
 		return 0;
 	}
 	if (CHECK_FLAG(oi->flag, OSPF6_INTERFACE_PASSIVE)) {


### PR DESCRIPTION
When we have a interface disabled in ospfv3 and
we are receiving messages on it.  We will spam
the log file repeatedly.  Debug guard the message.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>