### PR TITLE
lib: Fixup strlcat and strlcpy to be a bit more descriptive

### DIFF
--- a/lib/strlcat.c
+++ b/lib/strlcat.c
@@ -28,23 +28,25 @@
 #ifndef HAVE_STRLCAT
 #undef strlcat
 
-size_t strlcat(char *__restrict dest, const char *__restrict src, size_t size);
+size_t strlcat(char *__restrict dest,
+	       const char *__restrict src, size_t destsize);
 
-size_t strlcat(char *__restrict dest, const char *__restrict src, size_t size)
+size_t strlcat(char *__restrict dest,
+	       const char *__restrict src, size_t destsize)
 {
 	size_t src_length = strlen(src);
 
 	/* Our implementation strlcat supports dest == NULL if size == 0
 	   (for consistency with snprintf and strlcpy), but strnlen does
 	   not, so we have to cover this case explicitly.  */
-	if (size == 0)
+	if (destsize == 0)
 		return src_length;
 
-	size_t dest_length = strnlen(dest, size);
-	if (dest_length != size) {
+	size_t dest_length = strnlen(dest, destsize);
+	if (dest_length != destsize) {
 		/* Copy at most the remaining number of characters in the
 		   destination buffer.  Leave for the NUL terminator.  */
-		size_t to_copy = size - dest_length - 1;
+		size_t to_copy = destsize - dest_length - 1;
 		/* But not more than what is available in the source string.  */
 		if (to_copy > src_length)
 			to_copy = src_length;

--- a/lib/strlcpy.c
+++ b/lib/strlcpy.c
@@ -27,23 +27,26 @@
 #ifndef HAVE_STRLCPY
 #undef strlcpy
 
-size_t strlcpy(char *__restrict dest, const char *__restrict src, size_t size);
+size_t strlcpy(char *__restrict dest,
+	       const char *__restrict src, size_t destsize);
 
-size_t strlcpy(char *__restrict dest, const char *__restrict src, size_t size)
+size_t strlcpy(char *__restrict dest,
+	       const char *__restrict src, size_t destsize)
 {
 	size_t src_length = strlen(src);
 
-	if (__builtin_expect(src_length >= size, 0)) {
-		if (size > 0) {
-			/* Copy the leading portion of the string.  The last
-			   character is subsequently overwritten with the NUL
-			   terminator, but the destination size is usually a
-			   multiple of a small power of two, so writing it twice
-			   should be more efficient than copying an odd number
-			   of
-			   bytes.  */
-			memcpy(dest, src, size);
-			dest[size - 1] = '\0';
+	if (__builtin_expect(src_length >= destsize, 0)) {
+		if (destsize > 0) {
+			/*
+			 * Copy the leading portion of the string.  The last
+			 * character is subsequently overwritten with the NUL
+			 * terminator, but the destination destsize is usually
+			 * a multiple of a small power of two, so writing it
+			 * twice should be more efficient than copying an odd
+			 * number of bytes.
+			 */
+			memcpy(dest, src, destsize);
+			dest[destsize - 1] = '\0';
 		}
 	} else
 		/* Copy the string and its terminating NUL character.  */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -232,10 +232,12 @@ typedef unsigned char u_int8_t;
 #include "zassert.h"
 
 #ifndef HAVE_STRLCAT
-size_t strlcat(char *__restrict dest, const char *__restrict src, size_t size);
+size_t strlcat(char *__restrict dest,
+	       const char *__restrict src, size_t destsize);
 #endif
 #ifndef HAVE_STRLCPY
-size_t strlcpy(char *__restrict dest, const char *__restrict src, size_t size);
+size_t strlcpy(char *__restrict dest,
+	       const char *__restrict src, size_t destsize);
 #endif
 
 #ifdef HAVE_BROKEN_CMSG_FIRSTHDR


### PR DESCRIPTION
When I use these functions and am programming on linux I
always have to pull up a man page for these two functions
since they exist in *BSD land only.

Modify the name of the size variable to destsize on
pass in to give me the small hint I need to know
what to do.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>