### PR TITLE
zebra: Auto create the nexthop-vrf if needed.

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -489,6 +489,34 @@ static int zebra_static_route_leak(
 	return CMD_SUCCESS;
 }
 
+static struct zebra_vrf *zebra_vty_get_unknown_vrf(struct vty *vty,
+						   const char *vrf_name)
+{
+	struct zebra_vrf *zvrf;
+	struct vrf *vrf;
+
+	zvrf = zebra_vrf_lookup_by_name(vrf_name);
+
+	if (zvrf)
+		return zvrf;
+
+	vrf = vrf_get(VRF_UNKNOWN, vrf_name);
+	if (!vrf) {
+		vty_out(vty, "%% Could not create vrf %s\n", vrf_name);
+		return NULL;
+	}
+	zvrf = vrf->info;
+	if (!zvrf) {
+		vty_out(vty, "%% Could not create vrf-info %s\n",
+			vrf_name);
+		return NULL;
+	}
+	/* Mark as having FRR configuration */
+	vrf_set_user_cfged(vrf);
+
+	return zvrf;
+}
+
 static int zebra_static_route(struct vty *vty, afi_t afi, safi_t safi,
 			      const char *negate, const char *dest_str,
 			      const char *mask_str, const char *src_str,
@@ -498,7 +526,6 @@ static int zebra_static_route(struct vty *vty, afi_t afi, safi_t safi,
 			      const char *label_str)
 {
 	struct zebra_vrf *zvrf;
-	struct vrf *vrf;
 
 	/* VRF id */
 	zvrf = zebra_vrf_lookup_by_name(vrf_name);
@@ -513,19 +540,9 @@ static int zebra_static_route(struct vty *vty, afi_t afi, safi_t safi,
 	 * Note: The VRF isn't active until we hear about it from the kernel.
 	 */
 	if (!zvrf) {
-		vrf = vrf_get(VRF_UNKNOWN, vrf_name);
-		if (!vrf) {
-			vty_out(vty, "%% Could not create vrf %s\n", vrf_name);
+		zvrf = zebra_vty_get_unknown_vrf(vty, vrf_name);
+		if (!zvrf)
 			return CMD_WARNING_CONFIG_FAILED;
-		}
-		zvrf = vrf->info;
-		if (!zvrf) {
-			vty_out(vty, "%% Could not create vrf-info %s\n",
-				vrf_name);
-			return CMD_WARNING_CONFIG_FAILED;
-		}
-		/* Mark as having FRR configuration */
-		vrf_set_user_cfged(vrf);
 	}
 	return zebra_static_route_leak(
 		vty, zvrf, zvrf, afi, safi, negate, dest_str, mask_str, src_str,
@@ -784,7 +801,7 @@ DEFPY(ip_route_address_interface,
 	}
 
 	if (nexthop_vrf)
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		nh_zvrf = zebra_vty_get_unknown_vrf(vty, nexthop_vrf);
 	else
 		nh_zvrf = zvrf;
 
@@ -835,7 +852,7 @@ DEFPY(ip_route_address_interface_vrf,
 	}
 
 	if (nexthop_vrf)
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		nh_zvrf = zebra_vty_get_unknown_vrf(vty, nexthop_vrf);
 	else
 		nh_zvrf = zvrf;
 
@@ -891,7 +908,7 @@ DEFPY(ip_route,
 	}
 
 	if (nexthop_vrf)
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		nh_zvrf = zebra_vty_get_unknown_vrf(vty, nexthop_vrf);
 	else
 		nh_zvrf = zvrf;
 
@@ -941,7 +958,7 @@ DEFPY(ip_route_vrf,
 	}
 
 	if (nexthop_vrf)
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		nh_zvrf = zebra_vty_get_unknown_vrf(vty, nexthop_vrf);
 	else
 		nh_zvrf = zvrf;
 
@@ -2395,7 +2412,7 @@ DEFPY(ipv6_route_address_interface,
 	}
 
 	if (nexthop_vrf)
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		nh_zvrf = zebra_vty_get_unknown_vrf(vty, nexthop_vrf);
 	else
 		nh_zvrf = zvrf;
 
@@ -2439,7 +2456,7 @@ DEFPY(ipv6_route_address_interface_vrf,
 	struct zebra_vrf *nh_zvrf;
 
 	if (nexthop_vrf)
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		nh_zvrf = zebra_vty_get_unknown_vrf(vty, nexthop_vrf);
 	else
 		nh_zvrf = zvrf;
 
@@ -2489,7 +2506,7 @@ DEFPY(ipv6_route,
 	}
 
 	if (nexthop_vrf)
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		nh_zvrf = zebra_vty_get_unknown_vrf(vty, nexthop_vrf);
 	else
 		nh_zvrf = zvrf;
 
@@ -2532,7 +2549,7 @@ DEFPY(ipv6_route_vrf,
 	struct zebra_vrf *nh_zvrf;
 
 	if (nexthop_vrf)
-		nh_zvrf = zebra_vrf_lookup_by_name(nexthop_vrf);
+		nh_zvrf = zebra_vty_get_unknown_vrf(vty, nexthop_vrf);
 	else
 		nh_zvrf = zvrf;
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -798,7 +798,7 @@ DEFPY(ip_route_address_interface,
 		ifname = NULL;
 	}
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	zvrf = zebra_vty_get_unknown_vrf(vty, vrf);
 	if (!zvrf) {
 		vty_out(vty, "%% vrf %s is not defined\n", vrf);
 		return CMD_WARNING_CONFIG_FAILED;
@@ -905,7 +905,7 @@ DEFPY(ip_route,
 		ifname = NULL;
 	}
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	zvrf = zebra_vty_get_unknown_vrf(vty, vrf);
 	if (!zvrf) {
 		vty_out(vty, "%% vrf %s is not defined\n", vrf);
 		return CMD_WARNING_CONFIG_FAILED;
@@ -2409,7 +2409,7 @@ DEFPY(ipv6_route_address_interface,
 	struct zebra_vrf *zvrf;
 	struct zebra_vrf *nh_zvrf;
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	zvrf = zebra_vty_get_unknown_vrf(vty, vrf);
 	if (!zvrf) {
 		vty_out(vty, "%% vrf %s is not defined\n", vrf);
 		return CMD_WARNING_CONFIG_FAILED;
@@ -2503,7 +2503,7 @@ DEFPY(ipv6_route,
 	struct zebra_vrf *zvrf;
 	struct zebra_vrf *nh_zvrf;
 
-	zvrf = zebra_vrf_lookup_by_name(vrf);
+	zvrf = zebra_vty_get_unknown_vrf(vty, vrf);
 	if (!zvrf) {
 		vty_out(vty, "%% vrf %s is not defined\n", vrf);
 		return CMD_WARNING_CONFIG_FAILED;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -249,7 +249,11 @@ static int zebra_static_route_holdem(struct zebra_vrf *zvrf,
 			return CMD_SUCCESS;
 		}
 
-		assert(!"We should not have found a duplicate and not remove it");
+		/*
+		 * If a person enters the same line again
+		 * we need to silently accept it
+		 */
+		return CMD_SUCCESS;
 	}
 
 	listnode_add_sort(static_list, shr);


### PR DESCRIPTION
Currently if I try to use a nexthop-vrf that has
not been specified yet we get a failure from the cli.

Add code to zebra so that if we fail to find the nexthop-vrf
we auto create it, instead of failing the install.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>