### PR TITLE
isisd: Fixed the way isis reads from bpf

### DIFF
--- a/isisd/isis_bpf.c
+++ b/isisd/isis_bpf.c
@@ -265,18 +265,18 @@ isis_recv_pdu_bcast (struct isis_circuit *circuit, u_char * ssnpa)
 
   while (buff_ptr < ((u_char*) readbuff) + bytesread)
     {
-      bpf_hdr = (struct bpf_hdr *) readbuff;
+      bpf_hdr = (struct bpf_hdr *) buff_ptr;
 
       assert (bpf_hdr->bh_caplen == bpf_hdr->bh_datalen);
 
       offset = bpf_hdr->bh_hdrlen + LLC_LEN + ETHER_HDR_LEN;
 
       /* then we lose the BPF, LLC and ethernet headers */
-      stream_write (circuit->rcv_stream, readbuff + offset, 
+      stream_write (circuit->rcv_stream, buff_ptr + offset, 
                     bpf_hdr->bh_caplen - LLC_LEN - ETHER_HDR_LEN);
       stream_set_getp (circuit->rcv_stream, 0);
 
-      memcpy (ssnpa, readbuff + bpf_hdr->bh_hdrlen + ETHER_ADDR_LEN,
+      memcpy (ssnpa, buff_ptr + bpf_hdr->bh_hdrlen + ETHER_ADDR_LEN,
         ETHER_ADDR_LEN);
 
       err = isis_handle_pdu (circuit, ssnpa);

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -2022,7 +2022,7 @@ process_psnp (int level, struct isis_circuit *circuit, const u_char *ssnpa)
  * PDU Dispatcher
  */
 
-static int
+int
 isis_handle_pdu (struct isis_circuit *circuit, u_char * ssnpa)
 {
   struct isis_fixed_hdr *hdr;
@@ -2152,9 +2152,6 @@ isis_receive (struct thread *thread)
   isis_circuit_stream(circuit, &circuit->rcv_stream);
 
   retval = circuit->rx (circuit, ssnpa);
-
-  if (retval == ISIS_OK)
-    retval = isis_handle_pdu (circuit, ssnpa);
 
   /* 
    * prepare for next packet. 

--- a/isisd/isis_pdu.h
+++ b/isisd/isis_pdu.h
@@ -270,5 +270,5 @@ int ack_lsp (struct isis_link_state_hdr *hdr,
 	     struct isis_circuit *circuit, int level);
 void fill_fixed_hdr (struct isis_fixed_hdr *hdr, u_char pdu_type);
 int send_hello (struct isis_circuit *circuit, int level);
-
+int isis_handle_pdu (struct isis_circuit *circuit, u_char * ssnpa);
 #endif /* _ZEBRA_ISIS_PDU_H */


### PR DESCRIPTION
With this fix, we parse through the bpf to process every packet read.

Signed-off-by: Ali Rezaee nlndipi@hotmail.com