### PR TITLE
bgpd: Clean up peer status checking for a received nlri

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3754,13 +3754,6 @@ int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 	u_char rlen;
 	struct prefix p;
 
-	/* Check peer status. */
-	if (peer->status != Established) {
-		zlog_err("%u:%s - EVPN update received in state %d",
-			 peer->bgp->vrf_id, peer->host, peer->status);
-		return -1;
-	}
-
 	/* Start processing the NLRI - there may be multiple in the MP_REACH */
 	pnt = packet->nlri;
 	lim = pnt + packet->length;

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -212,10 +212,6 @@ int bgp_nlri_parse_label(struct peer *peer, struct attr *attr,
 	mpls_label_t label = MPLS_INVALID_LABEL;
 	u_char llen;
 
-	/* Check peer status. */
-	if (peer->status != Established)
-		return 0;
-
 	pnt = packet->nlri;
 	lim = pnt + packet->length;
 	afi = packet->afi;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -109,10 +109,6 @@ int bgp_nlri_parse_vpn(struct peer *peer, struct attr *attr,
 	int addpath_encoded;
 	u_int32_t addpath_id;
 
-	/* Check peer status. */
-	if (peer->status != Established)
-		return 0;
-
 	/* Make prefix_rd */
 	prd.family = AF_UNSPEC;
 	prd.prefixlen = 64;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4060,10 +4060,6 @@ int bgp_nlri_parse_ip(struct peer *peer, struct attr *attr,
 	int addpath_encoded;
 	u_int32_t addpath_id;
 
-	/* Check peer status. */
-	if (peer->status != Established)
-		return 0;
-
 	pnt = packet->nlri;
 	lim = pnt + packet->length;
 	afi = packet->afi;


### PR DESCRIPTION
In bgp_update_receive the first thing we do is establish
that the peer->status is Established.  We then do a bunch
of work and call bgp_nlri_parse where we break out for
each address family.  Each AFI is then checking for
being peer->status is Established again.  There is no
point in checking this again.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>