### PR TITLE
bgpd: Move back nh_vrf setting to where it was

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1078,8 +1078,8 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 			continue;
 
 		api_nh = &api.nexthops[valid_nh_count];
-		api_nh->vrf_id = bgp->vrf_id;
-
+		api_nh->vrf_id = nh_othervrf ? info->extra->bgp_orig->vrf_id
+					     : bgp->vrf_id;
 		if (nh_family == AF_INET) {
 			struct in_addr *nexthop;
 
@@ -1129,11 +1129,8 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 			}
 
 			nexthop = &mpinfo_cp->attr->nexthop;
-
 			api_nh->gate.ipv4 = *nexthop;
-			api_nh->vrf_id = nh_othervrf
-						 ? info->extra->bgp_orig->vrf_id
-						 : bgp->vrf_id;
+
 			/* EVPN type-2 routes are
 			   programmed as onlink on l3-vni SVI
 			 */
@@ -1206,9 +1203,6 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 			api_nh->gate.ipv6 = *nexthop;
 			api_nh->ifindex = ifindex;
 			api_nh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
-			/* api_nh->vrf_id is not set for normal case? */
-			if (nh_othervrf)
-				api_nh->vrf_id = info->extra->bgp_orig->vrf_id;
 		}
 
 		if (mpinfo->extra


### PR DESCRIPTION
Place the nexthop vrf id setting outside the afi if split
so that each side does not need to keep track of this.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>