### PR TITLE
EVPN IPv6 external routing

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -865,7 +865,7 @@ static int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 	 */
 	if (old_select && old_select == new_select
 	    && old_select->type == ZEBRA_ROUTE_BGP
-	    && old_select->sub_type == BGP_ROUTE_NORMAL
+	    && old_select->sub_type == BGP_ROUTE_IMPORTED
 	    && !CHECK_FLAG(rn->flags, BGP_NODE_USER_CLEAR)
 	    && !CHECK_FLAG(old_select->flags, BGP_INFO_ATTR_CHANGED)
 	    && !bgp->addpath_tx_used[afi][safi]) {
@@ -901,7 +901,7 @@ static int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 	}
 
 	if (new_select && new_select->type == ZEBRA_ROUTE_BGP
-	    && new_select->sub_type == BGP_ROUTE_NORMAL) {
+	    && new_select->sub_type == BGP_ROUTE_IMPORTED) {
 		flags = 0;
 		if (new_select->attr->sticky)
 			SET_FLAG(flags, ZEBRA_MACIP_TYPE_STICKY);
@@ -922,7 +922,7 @@ static int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 			evpn_delete_old_local_route(bgp, vpn, rn, old_select);
 	} else {
 		if (old_select && old_select->type == ZEBRA_ROUTE_BGP
-		    && old_select->sub_type == BGP_ROUTE_NORMAL)
+		    && old_select->sub_type == BGP_ROUTE_IMPORTED)
 			ret = evpn_zebra_uninstall(bgp, vpn,
 						   (struct prefix_evpn *)&rn->p,
 						   old_select->attr->nexthop);
@@ -1142,7 +1142,7 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 			local_ri = tmp_ri;
 		if (vni_table) {
 			if (tmp_ri->type == ZEBRA_ROUTE_BGP
-			    && tmp_ri->sub_type == BGP_ROUTE_NORMAL
+			    && tmp_ri->sub_type == BGP_ROUTE_IMPORTED
 			    && CHECK_FLAG(tmp_ri->flags, BGP_INFO_VALID)) {
 				if (!remote_ri)
 					remote_ri = tmp_ri;
@@ -1843,7 +1843,7 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 		attr_new = bgp_attr_intern(&attr);
 
 		/* Create new route with its attribute. */
-		ri = info_make(parent_ri->type, parent_ri->sub_type, 0,
+		ri = info_make(parent_ri->type, BGP_ROUTE_IMPORTED, 0,
 			       parent_ri->peer, attr_new, rn);
 		SET_FLAG(ri->flags, BGP_INFO_VALID);
 		bgp_info_extra_get(ri);
@@ -1915,7 +1915,7 @@ static int install_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 		attr_new = bgp_attr_intern(parent_ri->attr);
 
 		/* Create new route with its attribute. */
-		ri = info_make(parent_ri->type, parent_ri->sub_type, 0,
+		ri = info_make(parent_ri->type, BGP_ROUTE_IMPORTED, 0,
 			       parent_ri->peer, attr_new, rn);
 		SET_FLAG(ri->flags, BGP_INFO_VALID);
 		bgp_info_extra_get(ri);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2766,7 +2766,7 @@ DEFUN (bgp_evpn_advertise_type5,
 		rmap_changed = 1;
 	}
 
-	if (!(afi == AFI_IP) || (afi == AFI_IP6)) {
+	if (!(afi == AFI_IP || afi == AFI_IP6)) {
 		vty_out(vty,
 			"%%only ipv4 or ipv6 address families are supported");
 		return CMD_WARNING;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -557,7 +557,8 @@ static int bgp_info_cmp(struct bgp *bgp, struct bgp_info *new,
 	 *  - BGP_ROUTE_AGGREGATE
 	 *  - BGP_ROUTE_REDISTRIBUTE
 	 */
-	if (!(new->sub_type == BGP_ROUTE_NORMAL)) {
+	if (!(new->sub_type == BGP_ROUTE_NORMAL ||
+	      new->sub_type == BGP_ROUTE_IMPORTED)) {
 		if (debug)
 			zlog_debug(
 				"%s: %s wins over %s due to preferred BGP_ROUTE type",
@@ -565,7 +566,8 @@ static int bgp_info_cmp(struct bgp *bgp, struct bgp_info *new,
 		return 1;
 	}
 
-	if (!(exist->sub_type == BGP_ROUTE_NORMAL)) {
+	if (!(exist->sub_type == BGP_ROUTE_NORMAL ||
+	      new->sub_type == BGP_ROUTE_IMPORTED)) {
 		if (debug)
 			zlog_debug(
 				"%s: %s loses to %s due to preferred BGP_ROUTE type",

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1043,7 +1043,7 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 	 * Currently presence of rmac in attr denotes
 	 * this is an EVPN type-2 route
 	 */
-	if (!is_zero_mac(&(info->attr->rmac)))
+	if (info->sub_type == BGP_ROUTE_IMPORTED)
 		SET_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE);
 
 	if (peer->sort == BGP_PEER_IBGP || peer->sort == BGP_PEER_CONFED
@@ -1349,7 +1349,7 @@ void bgp_zebra_withdraw(struct prefix *p, struct bgp_info *info, safi_t safi)
 	 * Currently presence of rmac in attr denotes
 	 * this is an EVPN type-2 route
 	 */
-	if (!is_zero_mac(&(info->attr->rmac)))
+	if (info->sub_type == BGP_ROUTE_IMPORTED)
 		SET_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE);
 
 	if (peer->sort == BGP_PEER_IBGP) {


### PR DESCRIPTION
Set EVPN routes imported into a VRF as "imported" and use this during route install. Also, fix an issue in the command handler with IPv6 prefix injection into EVPN.