### PR TITLE
bgpd: Fix warning on 32 bit systems

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -730,7 +730,7 @@ DEFPY (rpki_expire_interval,
        "Set expire interval\n"
        "Expire interval value\n")
 {
-	if (tmp >= polling_period) {
+	if ((unsigned int)tmp >= polling_period) {
 		expire_interval = tmp;
 		return CMD_SUCCESS;
 	}


### PR DESCRIPTION
We have a signed/unsigned comparison warning that this should
fix.

This should be ok because the range of input is a very limited
value and should never be of concern

Fixes: #1919
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>