### PR TITLE
isisd: Fixed the way isis reads from bpf

### DIFF
--- a/isisd/isis_bpf.c
+++ b/isisd/isis_bpf.c
@@ -216,7 +216,8 @@ end:
 
 int isis_recv_pdu_bcast(struct isis_circuit *circuit, u_char *ssnpa)
 {
-	int bytesread = 0, bytestoread, offset, one = 1;
+	int bytesread = 0, bytestoread, offset, one = 1, err = ISIS_OK;
+	u_char *buff_ptr;
 	struct bpf_hdr *bpf_hdr;
 
 	assert(circuit->fd > 0);
@@ -230,25 +231,33 @@ int isis_recv_pdu_bcast(struct isis_circuit *circuit, u_char *ssnpa)
 	}
 	if (bytesread < 0) {
 		zlog_warn("isis_recv_pdu_bcast(): read() failed: %s",
-			  safe_strerror(errno));
+				safe_strerror(errno));
 		return ISIS_WARNING;
 	}
 
 	if (bytesread == 0)
 		return ISIS_WARNING;
 
-	bpf_hdr = (struct bpf_hdr *)readbuff;
+	buff_ptr = readbuff;
+	while (buff_ptr < readbuff + bytesread) {
+		bpf_hdr = (struct bpf_hdr *) buff_ptr;
+		assert(bpf_hdr->bh_caplen == bpf_hdr->bh_datalen);
+		offset = bpf_hdr->bh_hdrlen + LLC_LEN + ETHER_HDR_LEN;
 
-	assert(bpf_hdr->bh_caplen == bpf_hdr->bh_datalen);
+		/* then we lose the BPF, LLC and ethernet headers */
+		stream_write(circuit->rcv_stream, buff_ptr + offset,
+			     bpf_hdr->bh_caplen - LLC_LEN - ETHER_HDR_LEN);
+		stream_set_getp(circuit->rcv_stream, 0);
 
-	offset = bpf_hdr->bh_hdrlen + LLC_LEN + ETHER_HDR_LEN;
+		memcpy(ssnpa, buff_ptr + bpf_hdr->bh_hdrlen + ETHER_ADDR_LEN,
+		ETHER_ADDR_LEN);
 
-	/* then we lose the BPF, LLC and ethernet headers */
-	stream_write(circuit->rcv_stream, readbuff + offset,
-		     bpf_hdr->bh_caplen - LLC_LEN - ETHER_HDR_LEN);
-	stream_set_getp(circuit->rcv_stream, 0);
+		err = isis_handle_pdu(circuit, ssnpa);
+		stream_reset(circuit->rcv_stream);
+		buff_ptr += BPF_WORDALIGN(bpf_hdr->bh_hdrlen +
+						bpf_hdr->bh_datalen);
+	}
 
-	memcpy(ssnpa, readbuff + bpf_hdr->bh_hdrlen + ETH_ALEN, ETH_ALEN);
 
 	if (ioctl(circuit->fd, BIOCFLUSH, &one) < 0)
 		zlog_warn("Flushing failed: %s", safe_strerror(errno));

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -1336,7 +1336,7 @@ static int pdu_size(uint8_t pdu_type, uint8_t *size)
  * PDU Dispatcher
  */
 
-static int isis_handle_pdu(struct isis_circuit *circuit, u_char *ssnpa)
+int isis_handle_pdu(struct isis_circuit *circuit, u_char *ssnpa)
 {
 	int retval = ISIS_OK;
 
@@ -1459,8 +1459,10 @@ int isis_receive(struct thread *thread)
 
 	retval = circuit->rx(circuit, ssnpa);
 
+#if ISIS_METHOD != ISIS_METHOD_BPF
 	if (retval == ISIS_OK)
 		retval = isis_handle_pdu(circuit, ssnpa);
+#endif //ISIS_METHOD != ISIS_METHOD_BPF
 
 	/*
 	 * prepare for next packet.

--- a/isisd/isis_pdu.h
+++ b/isisd/isis_pdu.h
@@ -215,5 +215,5 @@ int send_l2_psnp(struct thread *thread);
 int send_lsp(struct thread *thread);
 void fill_fixed_hdr(uint8_t pdu_type, struct stream *stream);
 int send_hello(struct isis_circuit *circuit, int level);
-
+int isis_handle_pdu(struct isis_circuit *circuit, u_char *ssnpa);
 #endif /* _ZEBRA_ISIS_PDU_H */


### PR DESCRIPTION
With this fix, we parse the bpf to process every packet read

Signed-off-by: Ali Rezaee nlndipi@hotmail.com

---

This PR is the same code as #1896 but with all commits squashed into one. This will make it easier to cherry-pick/create new PR for other branches if necessary.

All credits goes to @ipinlnd .