### PR TITLE
bgpd / flowspec / add an API to get incoming VRF from a RT

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1774,3 +1774,22 @@ void bgp_mplsvpn_init(void)
 			&show_ip_bgp_vpn_rd_neighbor_advertised_routes_cmd);
 #endif /* KEEP_OLD_VPN_COMMANDS */
 }
+
+vrf_id_t get_first_vrf_for_redirect_with_rt(struct ecommunity *eckey)
+{
+	struct listnode *mnode, *mnnode;
+	struct bgp *bgp;
+
+	for (ALL_LIST_ELEMENTS(bm->bgp, mnode, mnnode, bgp)) {
+		struct ecommunity *ec;
+
+		if (bgp->inst_type != BGP_INSTANCE_TYPE_VRF)
+			continue;
+
+		ec = bgp->vpn_policy[AFI_IP].import_redirect_rtlist;
+
+		if (ecom_intersect(ec, eckey))
+			return bgp->vrf_id;
+	}
+	return VRF_UNKNOWN;
+}

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -176,4 +176,6 @@ static inline void vpn_leak_postchange(vpn_policy_direction_t direction,
 
 extern void vpn_policy_routemap_event(const char *rmap_name);
 
+extern vrf_id_t get_first_vrf_for_redirect_with_rt(struct ecommunity *eckey);
+
 #endif /* _QUAGGA_BGP_MPLSVPN_H */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3272,6 +3272,14 @@ int bgp_delete(struct bgp *bgp)
 #endif
 	bgp_cleanup_routes(bgp);
 
+	for (afi = 0; afi < AFI_MAX; ++afi) {
+		if (!bgp->vpn_policy[afi].import_redirect_rtlist)
+			continue;
+		ecommunity_free(
+				&bgp->vpn_policy[afi]
+				.import_redirect_rtlist);
+		bgp->vpn_policy[afi].import_redirect_rtlist = NULL;
+	}
 	/* Remove visibility via the master list - there may however still be
 	 * routes to be processed still referencing the struct bgp.
 	 */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -465,6 +465,7 @@ struct bgp {
 	/* vpn-policy */
 	struct {
 		struct ecommunity *rtlist[BGP_VPN_POLICY_DIR_MAX];
+		struct ecommunity *import_redirect_rtlist;
 		char *rmap_name[BGP_VPN_POLICY_DIR_MAX];
 		struct route_map *rmap[BGP_VPN_POLICY_DIR_MAX];
 


### PR DESCRIPTION
This commit is relying on bgp vrf-policy that is present on VNC. VNC
here, is only used to store vrf configuration. Because flowspec input
information is a route target, the VRF that has registered with that
input RT will be selected. Then from the vrf name, a search will be done
to retrieve the global vrf identifier.
This commit brings the API.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>