### PR TITLE
redhat: build dist tarball in a chroot

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -146,6 +146,7 @@ Requires(post): /sbin/install-info
 BuildRequires:  gcc patch libcap-devel
 BuildRequires:  readline readline-devel ncurses ncurses-devel
 BuildRequires:  json-c-devel bison >= 2.7 flex make
+BuildRequires:  c-ares-devel texinfo
 %if 0%{?rhel} && 0%{?rhel} < 7
 #python27-devel is available from ius community repo for RedHat/CentOS 6
 BuildRequires:  python27-devel python27-sphinx


### PR DESCRIPTION
When building the rpms, we can use a chroot (in my case docker) to
ensure that the BuildRequires are complete.  This test failed with
errors like:

    checking for CARES... no
    configure: error: trying to build nhrpd, but libcares not found. install c-ares and its -dev headers.
    error: Bad exit status from /var/tmp/rpm-tmp.FewvLf (%build)

This is due to a couple missing BuildRequires in the spec file.  Here, we
add those in for RHEL 7 based builds only (all that I've tested).

Issue: https://github.com/FRRouting/frr/issues/1930
Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>