### PR TITLE
bgpd: Fix peer withdrawal and route leaking for vpn's and vrf's

### DIFF
--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -33,7 +33,8 @@ extern void bgp_config_write_redistribute(struct vty *, struct bgp *, afi_t,
 extern void bgp_zebra_announce(struct bgp_node *, struct prefix *,
 			       struct bgp_info *, struct bgp *, afi_t, safi_t);
 extern void bgp_zebra_announce_table(struct bgp *, afi_t, safi_t);
-extern void bgp_zebra_withdraw(struct prefix *, struct bgp_info *, safi_t);
+extern void bgp_zebra_withdraw(struct prefix *, struct bgp_info *,
+			       struct bgp *, safi_t);
 
 extern void bgp_zebra_initiate_radv(struct bgp *bgp, struct peer *peer);
 extern void bgp_zebra_terminate_radv(struct bgp *bgp, struct peer *peer);


### PR DESCRIPTION
When a peer is removed the routes are withdrawn via bgp_process_main_one
As such we need to put a bit of code in to handle this situation
for the vpn/vrf route leaking code.

I think this code path is also called for when a vrf's route is
changed and I believe we will end up putting a bit more code
here to handle the nexthop changes.

I've also started trying to document the bgp_process_main_one
function a bit better.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>