### PR TITLE
redhat: enable dist tarball to build in a chroot (stable/4.0)

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -139,6 +139,7 @@ Requires(post): /sbin/install-info
 BuildRequires:  gcc texi2html texinfo patch libcap-devel groff
 BuildRequires:  readline readline-devel ncurses ncurses-devel
 BuildRequires:  json-c-devel bison >= 2.7 flex make
+BuildRequires:  c-ares-devel texinfo
 %if 0%{?rhel} && 0%{?rhel} < 7
 #python27-devel is available from ius community repo for RedHat/CentOS 6
 BuildRequires:  python27-devel


### PR DESCRIPTION
When building the rpms, we can use a chroot (in my case docker) to
ensure that the BuildRequires are complete.  This test failed with
errors like:

    checking for CARES... no
    configure: error: trying to build nhrpd, but libcares not found. install c-ares and its -dev headers.
    error: Bad exit status from /var/tmp/rpm-tmp.FewvLf (%build)

This is due to a couple missing BuildRequires in the spec file.  Here, we
add those in for all RPM builds.

Testing done:

Ran a docker build on CentOS7 which succeeded.  Loaded the modules onto
CentOS6 to make sure they were at least valid there, that succeeded.

Issue: https://github.com/FRRouting/frr/issues/1930
Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>