### PR TITLE
watchfrr, vtysh: do not write config during crash

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2477,7 +2477,12 @@ DEFUN (vtysh_write_memory,
 						   "do write integrated",
 						   outputfile);
 
-		if (ret != CMD_SUCCESS) {
+		/*
+		 * If watchfrr returns CMD_WARNING_CONFIG_FAILED this means
+		 * that it could not write the config, but additionally
+		 * indicates that we should not try either
+		 */
+		if (ret != CMD_SUCCESS && ret != CMD_WARNING_CONFIG_FAILED) {
 			printf("\nWarning: attempting direct configuration write without "
 			       "watchfrr.\nFile permissions and ownership may be "
 			       "incorrect, or write may fail.\n\n");

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -899,6 +899,16 @@ static int wakeup_send_echo(struct thread *t_wakeup)
 	return 0;
 }
 
+bool check_all_up(void)
+{
+	struct daemon *dmn;
+
+	for (dmn = gs.daemons; dmn; dmn = dmn->next)
+		if (dmn->state != DAEMON_UP)
+			return false;
+	return true;
+}
+
 static void sigint(void)
 {
 	zlog_notice("Terminating on signal");

--- a/watchfrr/watchfrr.h
+++ b/watchfrr/watchfrr.h
@@ -25,5 +25,12 @@ extern void watchfrr_vty_init(void);
 
 extern pid_t integrated_write_pid;
 extern void integrated_write_sigchld(int status);
+/*
+ * Check if all daemons we are monitoring are in the DAEMON_UP state.
+ *
+ * Returns:
+ *    True if they are all DAEMON_UP, false otherwise.
+ */
+extern bool check_all_up(void);
 
 #endif /* FRR_WATCHFRR_H */


### PR DESCRIPTION
If a daemon is restarting, crashed, or otherwise in the process of
reconnecting to watchfrr and a user issues "write memory" or "write
file" the resulting config will not include the configuration of that
daemon. This is problematic because this output will overwrite the
previous config, potentially causing unintentional loss of configuration
stored only in the config file based upon timing.

This patch remedies that by making watchfrr check that all daemons are
up before attempting a configuration write, and updating vtysh so that
its failsafe respects this condition as well.

Note that this issue only manifests when using integrated config.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>