### PR TITLE
ripd: considering a interface with 2 or more IP

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2186,6 +2186,7 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 				 */
 				int suppress = 0;
 				struct rip_info *tmp_rinfo = NULL;
+				struct connected *tmp_ifc = NULL;
 
 				for (ALL_LIST_ELEMENTS_RO(list, listnode,
 							  tmp_rinfo))
@@ -2196,11 +2197,16 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 						break;
 					}
 
-				if (!suppress
-				    && rinfo->type == ZEBRA_ROUTE_CONNECT
-				    && prefix_match((struct prefix *)p,
-						    ifc->address))
-					suppress = 1;
+                if (!suppress
+                    && rinfo->type == ZEBRA_ROUTE_CONNECT) {
+    				for (ALL_LIST_ELEMENTS_RO(ifc->ifp->connected,
+                                listnode, tmp_ifc))
+                        if (prefix_match((struct prefix *)p,
+                                    tmp_ifc->address)) {
+                            suppress = 1;
+                            break;
+                        }
+                }
 
 				if (suppress)
 					continue;
@@ -2311,19 +2317,27 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 				 * configured on the same interface).
 				 */
 				struct rip_info *tmp_rinfo = NULL;
+				struct connected *tmp_ifc = NULL;
 
 				for (ALL_LIST_ELEMENTS_RO(list, listnode,
 							  tmp_rinfo))
 					if (tmp_rinfo->type == ZEBRA_ROUTE_RIP
 					    && tmp_rinfo->nh.ifindex
 						       == ifc->ifp->ifindex)
-						tmp_rinfo->metric_out =
+						rinfo->metric_out =
 							RIP_METRIC_INFINITY;
 
-				if (rinfo->type == ZEBRA_ROUTE_CONNECT
-				    && prefix_match((struct prefix *)p,
-						    ifc->address))
-					rinfo->metric_out = RIP_METRIC_INFINITY;
+                if (rinfo->metric_out != RIP_METRIC_INFINITY
+                    && rinfo->type == ZEBRA_ROUTE_CONNECT) {
+    				for (ALL_LIST_ELEMENTS_RO(ifc->ifp->connected,
+                                listnode, tmp_ifc))
+                        if (prefix_match((struct prefix *)p,
+                                    tmp_ifc->address)) {
+                            rinfo->metric_out =
+                                RIP_METRIC_INFINITY;
+                            break;
+                        }
+                }
 			}
 
 			/* Prepare preamble, auth headers, if needs be */


### PR DESCRIPTION
what a coincidence,
I met this bug last week and you have updated it.
But there need be some modifications.
first, "rinfo" is used for rip packet sending,
so edit it not "tmp_rinfo".
second, considering this situation:
a interface named "eth0",
with 2 IP, 192.6.6.6/24, 192.8.8.8/24,
in "RIP_SPLIT_HORIZON",
ripd will send update response msg from "eth0"
including ip6 and ip8 with metric 1;
in "RIP_SPLIT_HORIZON_POISONED_REVERSE",
ripd will send update response msg from "eth0",
a msg with metric of ip6 is 1,ip8 is 16,
another msg with metric of ip6 is 16,ip8 is 1.
after my modification:
in "RIP_SPLIT_HORIZON",
ripd send no update response msg from "eth0"
including ip6 and ip8;
in "RIP_SPLIT_HORIZON_POISONED_REVERSE",
ripd send msg with metric of ip6 and ip8
both setted 16.