### PR TITLE
zebra: fix config of vrf static routes

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -156,7 +156,7 @@ static int static_list_compare(void *arg1, void *arg2)
 	if (ret)
 		return ret;
 
-	ret = shr1->safi - shr2->afi;
+	ret = shr1->safi - shr2->safi;
 	if (ret)
 		return ret;
 
@@ -259,7 +259,8 @@ static int zebra_static_route_holdem(struct zebra_vrf *zvrf,
 		return CMD_SUCCESS;
 	}
 
-	listnode_add_sort(static_list, shr);
+	if (!negate)
+		listnode_add_sort(static_list, shr);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
This patch fixes two bugs with respect to static route configuration
inside vrf contexts:

* Entering a negative form of a static route created the static route.
* Once created, static routes could not be deleted.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>