### PR TITLE
frr: add configure flags for sanitizers, document sanitizers

### DIFF
--- a/common.am
+++ b/common.am
@@ -8,12 +8,13 @@ am__v_CLIPPY_ = $(am__v_CLIPPY_$(AM_DEFAULT_VERBOSITY))
 am__v_CLIPPY_0 = @echo "  CLIPPY  " $@;
 am__v_CLIPPY_1 =
 
+CLIPPY_SUPPRESSIONS = LSAN_OPTIONS="suppressions=$(top_builddir)/tools/lsan-suppressions.txt"
 CLIPPY_DEPS = $(HOSTTOOLS)lib/clippy $(top_srcdir)/python/clidef.py
 
 SUFFIXES = _clippy.c .proto .pb-c.c .pb-c.h .pb.h
 .c_clippy.c:
 	@{ test -x $(top_builddir)/$(HOSTTOOLS)lib/clippy || $(MAKE) -C $(top_builddir)/$(HOSTTOOLS) lib/clippy; }
-	$(AM_V_CLIPPY)$(top_builddir)/$(HOSTTOOLS)lib/clippy $(top_srcdir)/python/clidef.py -o $@ $<
+	$(AM_V_CLIPPY) $(CLIPPY_SUPPRESSIONS) $(top_builddir)/$(HOSTTOOLS)lib/clippy $(top_srcdir)/python/clidef.py -o $@ $<
 
 ## automake's "ylwrap" is a great piece of GNU software... not. 
 .l.c:

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,17 @@ CC="${CC% -std=c99}"
 
 AC_C_FLAG([-std=gnu11], [CC="$ac_cc"], [CC="$CC -std=gnu11"])
 
+dnl AddressSanitizer support
+AC_ARG_ENABLE([address-sanitizer], AS_HELP_STRING([--enable-address-sanitizer], \
+              [enabled AddressSanitizer support for detecting a wide variety of \
+               memory allocation and deallocation errors]), \
+              [AC_DEFINE(HAVE_ADDRESS_SANITIZER, 1, [enable AddressSanitizer])
+              CFLAGS="$CFLAGS -fsanitize=address"
+              CXXFLAGS="$CXXFLAGS -fsanitize=address"
+              AC_TRY_COMPILE([],[const int i=0;],[AC_MSG_NOTICE([Address Sanitizer Enabled])],
+                                                 [AC_MSG_ERROR([Address Sanitizer not available])])
+              ])
+
 dnl if the user has specified any CFLAGS, override our settings
 if test "x${enable_dev_build}" = "xyes"; then
    AC_DEFINE(DEV_BUILD,,Build for development)

--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,26 @@ AC_ARG_ENABLE([address-sanitizer], AS_HELP_STRING([--enable-address-sanitizer], 
                                                  [AC_MSG_ERROR([Address Sanitizer not available])])
               ])
 
+dnl ThreadSanitizer support
+AC_ARG_ENABLE([thread-sanitizer], AS_HELP_STRING([--enable-thread-sanitizer], \
+              [enabled ThreadSanitizer support for detecting data races]), \
+              [AC_DEFINE(HAVE_THREAD_SANITIZER, 1, [enable ThreadSanitizer])
+              CFLAGS="$CFLAGS -fsanitize=thread"
+              CXXFLAGS="$CXXFLAGS -fsanitize=thread"
+              AC_TRY_COMPILE([],[const int i=0;],[AC_MSG_NOTICE([Thread Sanitizer Enabled])],
+                                                 [AC_MSG_ERROR([Thread Sanitizer not available])])
+              ])
+
+dnl MemorySanitizer support
+AC_ARG_ENABLE([memory-sanitizer], AS_HELP_STRING([--enable-memory-sanitizer], \
+              [enabled MemorySanitizer support for detecting uninitialized memory reads]), \
+              [AC_DEFINE(HAVE_THREAD_SANITIZER, 1, [enable MemorySanitizer])
+              CFLAGS="$CFLAGS -fsanitize=memory -fPIE -pie"
+              CXXFLAGS="$CXXFLAGS -fsanitize=memory -fPIE -pie"
+              AC_TRY_COMPILE([],[const int i=0;],[AC_MSG_NOTICE([Memory Sanitizer Enabled])],
+                                                 [AC_MSG_ERROR([Memory Sanitizer not available])])
+              ])
+
 dnl if the user has specified any CFLAGS, override our settings
 if test "x${enable_dev_build}" = "xyes"; then
    AC_DEFINE(DEV_BUILD,,Build for development)

--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -578,6 +578,57 @@ can be turned off. FRR has the ability to turn on/off debugs from the
 CLI and it is expected that the developer will use this convention to
 allow control of their debugs.
 
+Static Analysis and Sanitizers
+------------------------------
+Clang/LLVM comes with a variety of tools that can be used to help find bugs in FRR.
+
+clang-analyze
+   This is a static analyzer that scans the source code looking for patterns
+   that are likely to be bugs. The tool is run automatically on pull requests
+   as part of CI and new static analysis warnings will be placed in the CI
+   results. FRR aims for absolutely zero static analysis errors. While the
+   project is not quite there, code that introduces new static analysis errors
+   is very unlikely to be merged.
+
+AddressSanitizer
+   This is an excellent tool that provides runtime instrumentation for
+   detecting memory errors. As part of CI FRR is built with this
+   instrumentation and run through a series of tests to look for any results.
+   Testing your own code with this tool before submission is encouraged. You
+   can enable it by passing::
+   
+      --enable-address-sanitizer
+
+   to ``configure``.
+
+ThreadSanitizer
+   Similar to AddressSanitizer, this tool provides runtime instrumentation for
+   detecting data races. If you are working on or around multithreaded code,
+   extensive testing with this instrumtation enabled is *highly* recommended.
+   You can enable it by passing::
+   
+      --enable-thread-sanitizer
+
+   to ``configure``.
+
+MemorySanitizer
+   Similar to AddressSanitizer, this tool provides runtime instrumentation for
+   detecting use of uninitialized heap memory. Testing your own code with this
+   tool before submission is encouraged. You can enable it by passing::
+   
+      --enable-memory-sanitizer
+
+   to ``configure``.
+
+All of the above tools are available in the Clang/LLVM toolchain since 3.4.
+AddressSanitizer and ThreadSanitizer are available in recent versions of GCC,
+but are no longer actively maintained. MemorySanitizer is not available in GCC.
+
+Additionally, the FRR codebase is regularly scanned with Coverity.
+Unfortunately Coverity does not have the ability to handle scanning pull
+requests, but after code is merged it will send an email notifying project
+members with Coverity access of newly introduced defects.
+
 CLI changes
 -----------
 


### PR DESCRIPTION
* Add `configure.ac` option to enable AddressSanitizer (`--enable-address-sanitizer`)
* Add `configure.ac` option to enable ThreadSanitizer (`--enable-thread-sanitizer`)
* Add `configure.ac` option to enable MemorySanitizer (`--enable-memory-sanitizer`)
* Add necessary clippy suppressions to `common.am`, shouldn't require anything manual to build with ASAN now
* Document all of this, plus Coverity and `clang-analyze`

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>