### PR TITLE
 VRF NETNS / add an indirection table for mapping NSID/VRFID

### DIFF
--- a/lib/netns_linux.c
+++ b/lib/netns_linux.c
@@ -65,7 +65,7 @@ struct ns_map_nsid {
 	ns_id_t ns_id;
 };
 
-static __inline int ns_map_compare(const struct ns_map_nsid *a,
+static inline int ns_map_compare(const struct ns_map_nsid *a,
 				   const struct ns_map_nsid *b)
 {
 	return (a->ns_id - b->ns_id);
@@ -288,7 +288,7 @@ static struct ns_map_nsid *ns_map_nsid_lookup_by_nsid(ns_id_t ns_id)
 	struct ns_map_nsid ns_map;
 
 	ns_map.ns_id = ns_id;
-	return (RB_FIND(ns_map_nsid_head, &ns_map_nsid_list, &ns_map));
+	return RB_FIND(ns_map_nsid_head, &ns_map_nsid_list, &ns_map);
 }
 
 ns_id_t ns_map_nsid_with_external(ns_id_t ns_id, bool maporunmap)

--- a/lib/netns_linux.c
+++ b/lib/netns_linux.c
@@ -291,13 +291,13 @@ static struct ns_map_nsid *ns_map_nsid_lookup_by_nsid(ns_id_t ns_id)
 	return RB_FIND(ns_map_nsid_head, &ns_map_nsid_list, &ns_map);
 }
 
-ns_id_t ns_map_nsid_with_external(ns_id_t ns_id, bool maporunmap)
+ns_id_t ns_map_nsid_with_external(ns_id_t ns_id, bool map)
 {
 	struct ns_map_nsid *ns_map;
 	vrf_id_t ns_id_external;
 
 	ns_map = ns_map_nsid_lookup_by_nsid(ns_id);
-	if (ns_map && !maporunmap) {
+	if (ns_map && !map) {
 		ns_id_external = ns_map->ns_id_external;
 		RB_REMOVE(ns_map_nsid_head, &ns_map_nsid_list, ns_map);
 		return ns_id_external;

--- a/lib/netns_other.c
+++ b/lib/netns_other.c
@@ -153,6 +153,11 @@ int ns_enable(struct ns *ns, int (*func)(ns_id_t, void *))
 	return 0;
 }
 
+ns_id_t ns_map_nsid_with_external(ns_id_t ns_id, bool maporunmap)
+{
+	return NS_UNKNOWN;
+}
+
 struct ns *ns_get_created(struct ns *ns, char *name, ns_id_t ns_id)
 {
 	return NULL;

--- a/lib/ns.h
+++ b/lib/ns.h
@@ -139,7 +139,7 @@ extern void *ns_info_lookup(ns_id_t ns_id);
 /* API to map internal ns id value with
  * user friendly ns id external value
  */
-extern ns_id_t ns_map_nsid_with_external(ns_id_t ns_id, bool maporunmap);
+extern ns_id_t ns_map_nsid_with_external(ns_id_t ns_id, bool map);
 
 /*
  * NS init routine

--- a/lib/ns.h
+++ b/lib/ns.h
@@ -46,6 +46,9 @@ struct ns {
 	/* Identifier, same as the vector index */
 	ns_id_t ns_id;
 
+	/* Identifier, mapped on the NSID value */
+	ns_id_t internal_ns_id;
+
 	/* Name */
 	char *name;
 
@@ -100,7 +103,7 @@ extern void ns_terminate(void);
 /* API to initialize NETNS managerment
  * parameter is the default ns_id
  */
-extern void ns_init_management(ns_id_t ns_id);
+extern void ns_init_management(ns_id_t ns_id, ns_id_t internal_ns_idx);
 
 
 /*
@@ -132,6 +135,11 @@ extern int ns_have_netns(void);
 
 /* API to get context information of a NS */
 extern void *ns_info_lookup(ns_id_t ns_id);
+
+/* API to map internal ns id value with
+ * user friendly ns id external value
+ */
+extern ns_id_t ns_map_nsid_with_external(ns_id_t ns_id, bool maporunmap);
 
 /*
  * NS init routine

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -159,11 +159,13 @@ struct vrf *vrf_get(vrf_id_t vrf_id, const char *name)
 	if (!name && vrf_id == VRF_UNKNOWN)
 		return NULL;
 
-	/* Try to find VRF both by ID and name */
-	if (vrf_id != VRF_UNKNOWN)
-		vrf = vrf_lookup_by_id(vrf_id);
-	if (!vrf && name)
+	/* attempt to find already available VRF
+	 */
+	if (name)
 		vrf = vrf_lookup_by_name(name);
+	/* Try to find VRF both by ID and name */
+	if (!vrf && vrf_id != VRF_UNKNOWN)
+		vrf = vrf_lookup_by_id(vrf_id);
 
 	if (vrf == NULL) {
 		vrf = XCALLOC(MTYPE_VRF, sizeof(struct vrf));

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -272,7 +272,8 @@ extern int vrf_handler_create(struct vty *vty, const char *name,
  * should be called from zebra only
  */
 extern int vrf_netns_handler_create(struct vty *vty, struct vrf *vrf,
-				    char *pathname, ns_id_t ns_id);
+				    char *pathname, ns_id_t ext_ns_id,
+				    ns_id_t ns_id);
 
 /* used internally to enable or disable VRF.
  * Notify a change in the VRF ID of the VRF

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -274,6 +274,7 @@ int zebra_ns_disable(ns_id_t ns_id, void **info)
 int zebra_ns_init(void)
 {
 	ns_id_t ns_id;
+	ns_id_t ns_id_external;
 
 	dzns = zebra_ns_alloc();
 
@@ -282,8 +283,8 @@ int zebra_ns_init(void)
 	ns_id = zebra_ns_id_get_default();
 	if (zserv_privs.change(ZPRIVS_LOWER))
 		zlog_err("Can't lower privileges");
-
-	ns_init_management(ns_id);
+	ns_id_external = ns_map_nsid_with_external(ns_id, true);
+	ns_init_management(ns_id_external, ns_id);
 
 	logicalrouter_init(logicalrouter_config_write);
 
@@ -295,7 +296,7 @@ int zebra_ns_init(void)
 	zebra_vrf_init();
 
 	/* Default NS is activated */
-	zebra_ns_enable(ns_id, (void **)&dzns);
+	zebra_ns_enable(ns_id_external, (void **)&dzns);
 
 	if (vrf_is_backend_netns()) {
 		ns_add_hook(NS_NEW_HOOK, zebra_ns_new);


### PR DESCRIPTION
The issue raised here is to deal with the need for zclient daemons to rely on zebra to get all vrf_ids, including the default VRF.

https://github.com/FRRouting/frr/issues/1949

default behaviour : 
- default VRF is set to 0 for all zclient daemons, so that zclient suppose 0 value is for default vrf.
- for BGP, there is a mechanism that permits swapping this mechanism.
