### PR TITLE
ospf6d: Retain inter area border router type-4

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -912,8 +912,9 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 		ospf6_route_merge_nexthops(old, route);
 
 		if (is_debug)
-			zlog_debug("%s: Update route: %s nh count %u",
-				   __PRETTY_FUNCTION__, buf,
+			zlog_debug("%s: Update route: %s old cost %u new cost %u nh count %u",
+				   __PRETTY_FUNCTION__,
+				   buf, old->path.cost, route->path.cost,
 				   listcount(route->nh_list));
 
 		/* Update RIB/FIB */
@@ -924,7 +925,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 		ospf6_route_delete(route);
 	} else {
 		if (is_debug)
-			zlog_debug("Install route: %s nh count %u", buf,
+			zlog_debug("%s: Install route: %s cost %u nh count %u",
+				   __PRETTY_FUNCTION__, buf, route->path.cost,
 				   listcount(route->nh_list));
 		/* ospf6_ia_add_nw_route (table, &prefix, route); */
 		ospf6_route_add(route, table);

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -719,10 +719,11 @@ struct ospf6_route *ospf6_route_add(struct ospf6_route *route,
 			SET_FLAG(route->flag, OSPF6_ROUTE_BEST);
 			if (IS_OSPF6_DEBUG_ROUTE(MEMORY))
 				zlog_info(
-					"%s %p: route add %p: replacing previous best: %p",
+					"%s %p: route add %p cost %u: replacing previous best: %p cost %u",
 					ospf6_route_table_name(table),
 					(void *)table, (void *)route,
-					(void *)next);
+					route->path.cost,
+					(void *)next, next->path.cost);
 		}
 
 		route->installed = now;
@@ -743,9 +744,9 @@ struct ospf6_route *ospf6_route_add(struct ospf6_route *route,
 
 	/* Else, this is the brand new route regarding to the prefix */
 	if (IS_OSPF6_DEBUG_ROUTE(MEMORY))
-		zlog_debug("%s %p: route add %p %s : brand new route",
+		zlog_debug("%s %p: route add %p %s cost %u: brand new route",
 			   ospf6_route_table_name(table), (void *)table,
-			   (void *)route, buf);
+			   (void *)route, buf, route->path.cost);
 	else if (IS_OSPF6_DEBUG_ROUTE(TABLE))
 		zlog_debug("%s: route add: brand new route",
 			   ospf6_route_table_name(table));


### PR DESCRIPTION
During Intra area border router calculation, all border routers are  marked for remove from brouter table.
Once SPF calculation is done, retain inter area border router if the adv. intra border router (abr)
is present in SPF table.

Testing Done:
Validated inter area ASBR (L1) is retained at
R1 and R2 post intra border router calculation.

L1 -- (area 1)-- L2 -- (area 0) -- R1 --- R2

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>