### PR TITLE
doc: tweak html body width

### DIFF
--- a/doc/developer/_static/overrides.css
+++ b/doc/developer/_static/overrides.css
@@ -1,0 +1,4 @@
+/* remove max-width restriction */
+div.body {
+    max-width: none;
+}

--- a/doc/developer/conf.py
+++ b/doc/developer/conf.py
@@ -188,7 +188,7 @@ html_favicon = '../figures/frr-logo-icon.png'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -339,3 +339,5 @@ def setup(app):
     # object type for FRR CLI commands, can be extended to document parent CLI
     # node later on
     app.add_object_type('clicmd', 'clicmd')
+    # css overrides for HTML theme
+    app.add_stylesheet('overrides.css')

--- a/doc/user/_static/overrides.css
+++ b/doc/user/_static/overrides.css
@@ -1,0 +1,4 @@
+/* remove max-width restriction */
+div.body {
+    max-width: none;
+}

--- a/doc/user/conf.py
+++ b/doc/user/conf.py
@@ -188,7 +188,7 @@ html_favicon = '../figures/frr-logo-icon.png'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -339,3 +339,5 @@ def setup(app):
     # object type for FRR CLI commands, can be extended to document parent CLI
     # node later on
     app.add_object_type('clicmd', 'clicmd')
+    # css overrides for HTML theme
+    app.add_stylesheet('overrides.css')


### PR DESCRIPTION
The default theme has a css rule that limits the body element width to
800px, which results in sizeable chunk of empty space to the right of
the docs. Add a small css override to remove this limit (like the [Python
docs](https://docs.python.org/2/library/index.html) do).

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>