### PR TITLE
bgpd: nexthop tracking with labels for vrf-vpn leaking

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4041,7 +4041,7 @@ struct bgpevpn *bgp_evpn_new(struct bgp *bgp, vni_t vni,
 	derive_rd_rt_for_vni(bgp, vpn);
 
 	/* Initialize EVPN route table. */
-	vpn->route_table = bgp_table_init(AFI_L2VPN, SAFI_EVPN);
+	vpn->route_table = bgp_table_init(bgp, AFI_L2VPN, SAFI_EVPN);
 
 	/* Add to hash */
 	if (!hash_get(bgp->vnihash, vpn, hash_alloc_intern)) {

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1394,7 +1394,7 @@ int bgp_start(struct peer *peer)
 	else
 		connected = 0;
 
-	if (!bgp_find_or_add_nexthop(peer->bgp,
+	if (!bgp_find_or_add_nexthop(peer->bgp, peer->bgp,
 				     family2afi(peer->su.sa.sa_family), NULL,
 				     peer, connected)) {
 #if defined(HAVE_CUMULUS)

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -632,10 +632,11 @@ void bgp_scan_init(struct bgp *bgp)
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
 		bgp->nexthop_cache_table[afi] =
-			bgp_table_init(afi, SAFI_UNICAST);
-		bgp->connected_table[afi] = bgp_table_init(afi, SAFI_UNICAST);
+			bgp_table_init(bgp, afi, SAFI_UNICAST);
+		bgp->connected_table[afi] = bgp_table_init(bgp, afi,
+			SAFI_UNICAST);
 		bgp->import_check_table[afi] =
-			bgp_table_init(afi, SAFI_UNICAST);
+			bgp_table_init(bgp, afi, SAFI_UNICAST);
 	}
 }
 

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -52,6 +52,7 @@ struct bgp_nexthop_cache {
 #define BGP_NEXTHOP_PEER_NOTIFIED     (1 << 3)
 #define BGP_STATIC_ROUTE              (1 << 4)
 #define BGP_STATIC_ROUTE_EXACT_MATCH  (1 << 5)
+#define BGP_NEXTHOP_LABELED_VALID     (1 << 6)
 
 	uint16_t change_flags;
 

--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -39,14 +39,16 @@ extern int bgp_find_nexthop(struct bgp_info *p, int connected);
  *  object. If not found, create a new object and register with ZEBRA for
  *  nexthop notification.
  * ARGUMENTS:
- *   bgp - BGP instance
+ *   bgp_route - BGP instance of route
+ *   bgp_nexthop - BGP instance of nexthop
  *   a - afi: AFI_IP or AF_IP6
  *   p - path for which the nexthop object is being looked up
  *   peer - The BGP peer associated with this NHT
  *   connected - True if NH MUST be a connected route
  */
-extern int bgp_find_or_add_nexthop(struct bgp *bgp, afi_t a, struct bgp_info *p,
-				   struct peer *peer, int connected);
+extern int bgp_find_or_add_nexthop(struct bgp *bgp_route,
+			struct bgp *bgp_nexthop, afi_t a, struct bgp_info *p,
+			struct peer *peer, int connected);
 
 /**
  * bgp_unlink_nexthop() - Unlink the nexthop object from the path structure.

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -115,7 +115,7 @@ struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
 		prn = bgp_node_get(table, (struct prefix *)prd);
 
 		if (prn->info == NULL)
-			prn->info = bgp_table_init(afi, safi);
+			prn->info = bgp_table_init(table->bgp, afi, safi);
 		else
 			bgp_unlock_node(prn);
 		table = prn->info;
@@ -1327,8 +1327,10 @@ void bgp_attr_add_gshut_community(struct attr *attr)
 
 static void subgroup_announce_reset_nhop(uint8_t family, struct attr *attr)
 {
-	if (family == AF_INET)
+	if (family == AF_INET) {
 		attr->nexthop.s_addr = 0;
+		attr->mp_nexthop_global_in.s_addr = 0;
+	}
 	if (family == AF_INET6)
 		memset(&attr->mp_nexthop_global, 0, IPV6_MAX_BYTELEN);
 }
@@ -1751,7 +1753,22 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_info *ri,
 						 ? AF_INET6
 						 : p->family),
 					attr);
+		} else if (CHECK_FLAG(ri->flags, BGP_INFO_ANNC_NH_SELF)) {
+			/*
+			 * This flag is used for leaked vpn-vrf routes
+			 */
+			int family = p->family;
+
+			if (peer_cap_enhe(peer, afi, safi))
+				family = AF_INET6;
+
+			if (bgp_debug_update(NULL, p, subgrp->update_group, 0))
+				zlog_debug(
+					"%s: BGP_INFO_ANNC_NH_SELF, family=%s",
+					__func__, family2str(family));
+			subgroup_announce_reset_nhop(family, attr);
 		}
+
 		/* If IPv6/MP and nexthop does not have any override and happens
 		 * to
 		 * be a link-local address, reset it so that we don't pass along
@@ -3161,8 +3178,13 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 			else
 				connected = 0;
 
-			if (bgp_find_or_add_nexthop(bgp, afi, ri, NULL,
-						    connected)
+			struct bgp *bgp_nexthop = bgp;
+
+			if (ri->extra && ri->extra->bgp_orig)
+				bgp_nexthop = ri->extra->bgp_orig;
+
+			if (bgp_find_or_add_nexthop(bgp, bgp_nexthop, afi,
+							ri, NULL, connected)
 			    || CHECK_FLAG(peer->flags, PEER_FLAG_IS_RFAPI_HD))
 				bgp_info_set_flag(rn, ri, BGP_INFO_VALID);
 			else {
@@ -3289,7 +3311,7 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 		else
 			connected = 0;
 
-		if (bgp_find_or_add_nexthop(bgp, afi, new, NULL, connected)
+		if (bgp_find_or_add_nexthop(bgp, bgp, afi, new, NULL, connected)
 		    || CHECK_FLAG(peer->flags, PEER_FLAG_IS_RFAPI_HD))
 			bgp_info_set_flag(rn, new, BGP_INFO_VALID);
 		else {
@@ -3716,12 +3738,14 @@ static wq_item_status bgp_clear_route_node(struct work_queue *wq, void *data)
 			/* Handle withdraw for VRF route-leaking and L3VPN */
 			if (SAFI_UNICAST == safi
 			    && (bgp->inst_type == BGP_INSTANCE_TYPE_VRF ||
-				bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT))
+				bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)) {
 				vpn_leak_from_vrf_withdraw(bgp_get_default(),
 							   bgp, ri);
+			}
 			if (SAFI_MPLS_VPN == safi &&
-			    bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)
+			    bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) {
 				vpn_leak_to_vrf_withdraw(bgp, ri);
+			}
 
 			bgp_rib_remove(rn, ri, peer, afi, safi);
 		}
@@ -4372,8 +4396,14 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 			if (bgp_flag_check(bgp, BGP_FLAG_IMPORT_CHECK)
 			    && (safi == SAFI_UNICAST
 				|| safi == SAFI_LABELED_UNICAST)) {
-				if (bgp_find_or_add_nexthop(bgp, afi, ri, NULL,
-							    0))
+
+				struct bgp *bgp_nexthop = bgp;
+
+				if (ri->extra && ri->extra->bgp_orig)
+					bgp_nexthop = ri->extra->bgp_orig;
+
+				if (bgp_find_or_add_nexthop(bgp, bgp_nexthop,
+					    afi, ri, NULL, 0))
 					bgp_info_set_flag(rn, ri,
 							  BGP_INFO_VALID);
 				else {
@@ -4424,7 +4454,7 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 	/* Nexthop reachability check. */
 	if (bgp_flag_check(bgp, BGP_FLAG_IMPORT_CHECK)
 	    && (safi == SAFI_UNICAST || safi == SAFI_LABELED_UNICAST)) {
-		if (bgp_find_or_add_nexthop(bgp, afi, new, NULL, 0))
+		if (bgp_find_or_add_nexthop(bgp, bgp, afi, new, NULL, 0))
 			bgp_info_set_flag(rn, new, BGP_INFO_VALID);
 		else {
 			if (BGP_DEBUG(nht, NHT)) {
@@ -5072,7 +5102,7 @@ int bgp_static_set_safi(afi_t afi, safi_t safi, struct vty *vty,
 	}
 	prn = bgp_node_get(bgp->route[afi][safi], (struct prefix *)&prd);
 	if (prn->info == NULL)
-		prn->info = bgp_table_init(afi, safi);
+		prn->info = bgp_table_init(bgp, afi, safi);
 	else
 		bgp_unlock_node(prn);
 	table = prn->info;
@@ -5170,7 +5200,7 @@ int bgp_static_unset_safi(afi_t afi, safi_t safi, struct vty *vty,
 
 	prn = bgp_node_get(bgp->route[afi][safi], (struct prefix *)&prd);
 	if (prn->info == NULL)
-		prn->info = bgp_table_init(afi, safi);
+		prn->info = bgp_table_init(bgp, afi, safi);
 	else
 		bgp_unlock_node(prn);
 	table = prn->info;
@@ -11368,7 +11398,7 @@ void bgp_route_init(void)
 
 	/* Init BGP distance table. */
 	FOREACH_AFI_SAFI (afi, safi)
-		bgp_distance_table[afi][safi] = bgp_table_init(afi, safi);
+		bgp_distance_table[afi][safi] = bgp_table_init(NULL, afi, safi);
 
 	/* IPv4 BGP commands. */
 	install_element(BGP_NODE, &bgp_table_map_cmd);

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -190,6 +190,7 @@ struct bgp_info {
 #define BGP_INFO_MULTIPATH      (1 << 11)
 #define BGP_INFO_MULTIPATH_CHG  (1 << 12)
 #define BGP_INFO_RIB_ATTR_CHG   (1 << 13)
+#define BGP_INFO_ANNC_NH_SELF   (1 << 14)
 
 	/* BGP route type.  This can be static, RIP, OSPF, BGP etc.  */
 	uint8_t type;

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -90,7 +90,7 @@ route_table_delegate_t bgp_table_delegate = {.create_node = bgp_node_create,
 /*
  * bgp_table_init
  */
-struct bgp_table *bgp_table_init(afi_t afi, safi_t safi)
+struct bgp_table *bgp_table_init(struct bgp *bgp, afi_t afi, safi_t safi)
 {
 	struct bgp_table *rt;
 
@@ -102,6 +102,11 @@ struct bgp_table *bgp_table_init(afi_t afi, safi_t safi)
 	 * Set up back pointer to bgp_table.
 	 */
 	rt->route_table->info = rt;
+
+	/*
+	 * pointer to bgp instance allows working back from bgp_info to bgp
+	 */
+	rt->bgp = bgp;
 
 	bgp_table_lock(rt);
 	rt->afi = afi;

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -26,6 +26,9 @@
 #include "queue.h"
 
 struct bgp_table {
+	/* table belongs to this instance */
+	struct bgp *bgp;
+
 	/* afi/safi of this table */
 	afi_t afi;
 	safi_t safi;
@@ -75,7 +78,7 @@ typedef struct bgp_table_iter_t_ {
 	route_table_iter_t rt_iter;
 } bgp_table_iter_t;
 
-extern struct bgp_table *bgp_table_init(afi_t, safi_t);
+extern struct bgp_table *bgp_table_init(struct bgp *bgp, afi_t, safi_t);
 extern void bgp_table_lock(struct bgp_table *);
 extern void bgp_table_unlock(struct bgp_table *);
 extern void bgp_table_finish(struct bgp_table **);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2905,9 +2905,9 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	bgp->group->cmp = (int (*)(void *, void *))peer_group_cmp;
 
 	FOREACH_AFI_SAFI (afi, safi) {
-		bgp->route[afi][safi] = bgp_table_init(afi, safi);
-		bgp->aggregate[afi][safi] = bgp_table_init(afi, safi);
-		bgp->rib[afi][safi] = bgp_table_init(afi, safi);
+		bgp->route[afi][safi] = bgp_table_init(bgp, afi, safi);
+		bgp->aggregate[afi][safi] = bgp_table_init(bgp, afi, safi);
+		bgp->rib[afi][safi] = bgp_table_init(bgp, afi, safi);
 
 		/* Enable maximum-paths */
 		bgp_maximum_paths_set(bgp, afi, safi, BGP_PEER_EBGP,

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2964,6 +2964,28 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 				 bgp->restart_time, &bgp->t_startup);
 	}
 
+	/* printable name we can use in debug messages */
+	if (inst_type == BGP_INSTANCE_TYPE_DEFAULT) {
+		bgp->name_pretty = XSTRDUP(MTYPE_BGP, "VRF default");
+	} else {
+		const char *n;
+		int len;
+
+		if (bgp->name)
+			n = bgp->name;
+		else
+			n = "?";
+
+		len = 4 + 1 + strlen(n) + 1;	/* "view foo\0" */
+
+		bgp->name_pretty = XCALLOC(MTYPE_BGP, len);
+		snprintf(bgp->name_pretty, len, "%s %s",
+			(bgp->inst_type == BGP_INSTANCE_TYPE_VRF)
+				? "VRF"
+				: "VIEW",
+			n);
+	}
+
 	atomic_store_explicit(&bgp->wpkt_quanta, BGP_WRITE_PACKET_MAX,
 			      memory_order_relaxed);
 	atomic_store_explicit(&bgp->rpkt_quanta, BGP_READ_PACKET_MAX,
@@ -3358,6 +3380,8 @@ void bgp_free(struct bgp *bgp)
 
 	if (bgp->name)
 		XFREE(MTYPE_BGP, bgp->name);
+	if (bgp->name_pretty)
+		XFREE(MTYPE_BGP, bgp->name_pretty);
 
 	XFREE(MTYPE_BGP, bgp);
 }

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -188,6 +188,7 @@ struct bgp {
 
 	/* Name of this BGP instance.  */
 	char *name;
+	char *name_pretty;	/* printable "VRF|VIEW name|default" */
 
 	/* Type of instance and VRF id. */
 	enum bgp_instance_type inst_type;

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -467,6 +467,21 @@ int str2family(const char *string)
 	return -1;
 }
 
+const char *family2str(int family)
+{
+	switch (family) {
+	case AF_INET:
+		return "IPv4";
+	case AF_INET6:
+		return "IPv6";
+	case AF_ETHERNET:
+		return "Ethernet";
+	case AF_EVPN:
+		return "Evpn";
+	}
+	return "?";
+}
+
 /* Address Famiy Identifier to Address Family converter. */
 int afi2family(afi_t afi)
 {

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -290,6 +290,7 @@ static inline void ipv4_addr_copy(struct in_addr *dst,
 extern int str2family(const char *);
 extern int afi2family(afi_t);
 extern afi_t family2afi(int);
+extern const char *family2str(int family);
 extern const char *safi2str(safi_t safi);
 extern const char *afi2str(afi_t afi);
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1289,8 +1289,12 @@ struct nexthop *nexthop_from_zapi_nexthop(struct zapi_nexthop *znh)
 	n->gate = znh->gate;
 
 	/*
-	 * This function does not currently handle labels
+	 * This function currently handles labels
 	 */
+	if (znh->label_num) {
+		nexthop_add_labels(n, ZEBRA_LSP_NONE, znh->label_num,
+			znh->labels);
+	}
 
 	return n;
 }

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -105,9 +105,10 @@ static struct bgp *bgp_create_fake(as_t *as, const char *name)
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)
 		for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++) {
-			bgp->route[afi][safi] = bgp_table_init(afi, safi);
-			bgp->aggregate[afi][safi] = bgp_table_init(afi, safi);
-			bgp->rib[afi][safi] = bgp_table_init(afi, safi);
+			bgp->route[afi][safi] = bgp_table_init(bgp, afi, safi);
+			bgp->aggregate[afi][safi] = bgp_table_init(
+				bgp, afi, safi);
+			bgp->rib[afi][safi] = bgp_table_init(bgp, afi, safi);
 			bgp->maxpaths[afi][safi].maxpaths_ebgp = MULTIPATH_NUM;
 			bgp->maxpaths[afi][safi].maxpaths_ibgp = MULTIPATH_NUM;
 		}


### PR DESCRIPTION
Routes that have labels must be sent via a nexthop that also has labels.  This change notes whether any path in a nexthop update from zebra contains labels. If so, then the nexthop is valid for routes that have labels.

If a nexthop update has no labeled paths, then any labeled routes referencing the nexthop are marked not valid.

Add a route flag BGP_INFO_ANNC_NH_SELF that means "advertise myself as nexthop when announcing" so that we can track our notion of the nexthop without revealing it to peers.