### PR TITLE
tools: Cleanup shutdown

### DIFF
--- a/tools/frr
+++ b/tools/frr
@@ -187,7 +187,7 @@ stop()
     else
         PIDFILE=`pidfile $inst`
         PID=`cat $PIDFILE 2>/dev/null`
-        ${SSD} --stop --quiet --retry=TERM/30/KILL/5 --oknodo --pidfile "$PIDFILE" --exec "$D_PATH/$1"
+        kill -2 $PID 2>/dev/null
         #
         #       Now we have to wait until $DAEMON has _really_ stopped.
         #


### PR DESCRIPTION
The shutdown code was sometimes taking 1 minute to run because
the ssd program was misbehaving after a make install.

This commit just removes the usage of ssd for shutdown
since we already have a pid file and we know that the
frr script cleans up the pid file as well.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>