### PR TITLE
lib: Remove backwards compatiblity at 1 year

### DIFF
--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -702,6 +702,13 @@ compiler/preprocessor annotations to print warnings at compile time,
 pointing to the appropriate update path. A ``-Werror`` build should fail
 if compatibility bits are used.
 
+Preferably, the shell script :file:`tools/fixup-deprecated.py` will be
+updated along with making non-backwards compatible code changes, or an
+alternate script should be introduced, to update the code to match the
+change.  When the script is updated, there is no need to preserve the
+deprecated code. Note that this does not apply to user interface
+changes, just internal code, macros and libraries.
+
 Miscellaneous
 -------------
 

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -189,45 +189,6 @@ struct vty_arg {
 /* Integrated configuration file. */
 #define INTEGRATE_DEFAULT_CONFIG "frr.conf"
 
-#if CONFDATE > 20180401
-CPP_NOTICE("It's probably time to remove VTY_NEWLINE compatibility foo.")
-#endif
-
-/* for compatibility */
-#define VNL "\n" CPP_WARN("VNL has been replaced with \\n.")
-#define VTYNL "\n" CPP_WARN("VTYNL has been replaced with \\n.")
-#define VTY_NEWLINE "\n" CPP_WARN("VTY_NEWLINE has been replaced with \\n.")
-#define VTY_GET_INTEGER(desc, v, str)                                          \
-	{                                                                      \
-		(v) = strtoul((str), NULL, 10);                                \
-	}                                                                      \
-	CPP_WARN("VTY_GET_INTEGER is no longer useful, use strtoul() or DEFPY.")
-#define VTY_GET_INTEGER_RANGE(desc, v, str, min, max)                          \
-	{                                                                      \
-		(v) = strtoul((str), NULL, 10);                                \
-	}                                                                      \
-	CPP_WARN(                                                              \
-		"VTY_GET_INTEGER_RANGE is no longer useful, use strtoul() or DEFPY.")
-#define VTY_GET_ULONG(desc, v, str)                                            \
-	{                                                                      \
-		(v) = strtoul((str), NULL, 10);                                \
-	}                                                                      \
-	CPP_WARN("VTY_GET_ULONG is no longer useful, use strtoul() or DEFPY.")
-#define VTY_GET_ULL(desc, v, str)                                              \
-	{                                                                      \
-		(v) = strtoull((str), NULL, 10);                               \
-	}                                                                      \
-	CPP_WARN("VTY_GET_ULL is no longer useful, use strtoull() or DEFPY.")
-#define VTY_GET_IPV4_ADDRESS(desc, v, str)                                     \
-	inet_aton((str), &(v)) CPP_WARN(                                       \
-		"VTY_GET_IPV4_ADDRESS is no longer useful, use inet_aton() or DEFPY.")
-#define VTY_GET_IPV4_PREFIX(desc, v, str)                                      \
-	str2prefix_ipv4((str), &(v)) CPP_WARN(                                 \
-		"VTY_GET_IPV4_PREFIX is no longer useful, use str2prefix_ipv4() or DEFPY.")
-#define vty_outln(vty, str, ...)                                               \
-	vty_out(vty, str "\n", ##__VA_ARGS__) CPP_WARN(                        \
-		"vty_outln is no longer useful, use vty_out(...\\n...)")
-
 /* Default time out value */
 #define VTY_TIMEOUT_DEFAULT 600
 

--- a/tools/fixup-deprecated.py
+++ b/tools/fixup-deprecated.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Script used to replace deprecated quagga/frr mactors/types/etc.
+#
+# loosly based on indent.py, 2017 by David Lamparter
+# 2018 by Lou Berger, placed in public domain
+
+import sys, re, subprocess, os
+
+class replaceEntry:
+    compiled = None    #compiled regex
+    repl    = None     #regex
+    def __init__(self, c, r):
+        self.compiled = c
+        self.repl = r
+
+rList = [
+    # old #define VNL, VTYNL, VTY_NEWLINE
+    replaceEntry(re.compile(r'(VNL|VTYNL|VTY_NEWLINE)'),
+                 r'"\\n"'),
+    # old #define VTY_GET_INTEGER(desc, v, str)
+    # old #define VTY_GET_INTEGER_RANGE(desc, v, str, min, max)
+    # old #define VTY_GET_ULONG(desc, v, str)
+    replaceEntry(re.compile(r'(VTY_GET_INTEGER(_RANGE|)|VTY_GET_ULONG)[\s\(]*(.*?)\s*,\s*(.*?)\s*,\s*(.*?)(\s*|)(\)|,).*?;', re.M | re.S),
+                 r'(\4) = strtoul((\5), NULL, 10);\t/* \3 */'),
+    # old #define VTY_GET_ULL(desc, v, str)
+    replaceEntry(re.compile(r'VTY_GET_ULL[\s\(]*(.*?)\s*,\s*(.*?)\s*,\s*(.*?)(\s*|)(\)|,).*?;', re.M | re.S),
+                 r'(\2) = strtoull((\3), NULL, 10);\t/* \1 */'),
+    # old #define VTY_GET_IPV4_ADDRESS(desc, v, str)
+    replaceEntry(re.compile(r'VTY_GET_IPV4_ADDRESS[\s\(]*(.*?)\s*,\s*(.*?)\s*,\s*(.*?)(\s*|)(\)|,).*?;', re.M | re.S),
+                 r'inet_aton((\3), &(\2));\t/* \1 */'),
+    # old #define VTY_GET_IPV4_PREFIX(desc, v, str)
+    replaceEntry(re.compile(r'VTY_GET_IPV4_PREFIX[\s\(]*(.*?)\s*,\s*(.*?)\s*,\s*(.*?)(\s*|)(\)|,).*?;', re.M | re.S),
+                 r'str2prefix_ipv4((\3), &(\2));\t/* \1 */'),
+    # old #define vty_outln(vty, str, ...)
+    replaceEntry(re.compile(r'vty_outln[\s\(]*(.*?)\s*,\s*(".*?"|.*?)\s*(\)|,)', re.M | re.S),
+                 r'vty_out(\1, \2 "\\n"\3'),
+        ]
+
+def fixup_file(fn):
+    with open(fn, 'r') as fd:
+        text = fd.read()
+
+        for re in rList:
+            text = re.compiled.sub(re.repl,text)
+
+        tmpname = fn + '.fixup'
+        with open(tmpname, 'w') as ofd:
+            ofd.write(text)
+        os.rename(tmpname, fn)
+
+if __name__ == '__main__':
+    for fn in sys.argv[1:]:
+        fixup_file(fn)


### PR DESCRIPTION
These macro's have existed for 1 year now and can be removed.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>