### PR TITLE
two zebra changes

### DIFF
--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -2927,6 +2927,7 @@ static int zserv_process_messages(struct thread *thread)
 		if (!hdrvalid)
 			continue;
 
+		hdr.length -= ZEBRA_HEADER_SIZE;
 		/* lookup vrf */
 		zvrf = zebra_vrf_lookup_by_id(hdr.vrf_id);
 		if (!zvrf && IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV) {
@@ -3047,7 +3048,6 @@ static int zserv_read(struct thread *thread)
 #if defined(HANDLE_ZAPI_FUZZING)
 		zserv_write_incoming(client->ibuf_work, command);
 #endif
-		hdr.length -= ZEBRA_HEADER_SIZE;
 
 		/* Debug packet information. */
 		if (IS_ZEBRA_DEBUG_EVENT)


### PR DESCRIPTION
1) Fix header subtraction so that we have correct header length for zapi reading

2) Add some additional debug information to 'debug zebra kernel` so that we can see the
table we are installing into as well as the nexthop vrf id's.