### PR TITLE
bgpd: Only supply ifindex for a v6 nexthop if LL

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1197,12 +1197,17 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 					ifindex = mpinfo->peer->nexthop.ifp
 							  ->ifindex;
 			}
-			if (ifindex == 0)
-				continue;
+
+			if (IN6_IS_ADDR_LINKLOCAL(nexthop)) {
+				if (ifindex == 0)
+					continue;
+			} else
+				ifindex = 0;
 
 			api_nh->gate.ipv6 = *nexthop;
 			api_nh->ifindex = ifindex;
-			api_nh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
+			api_nh->type = ifindex ? NEXTHOP_TYPE_IPV6_IFINDEX
+					       : NEXTHOP_TYPE_IPV6;
 		}
 
 		if (mpinfo->extra


### PR DESCRIPTION
BGP is calculating a v6 routes nexthop as the nexthop address
+ an ifindex.  The ifindex calculated comes from where we received
the route from as that we have to do this for LL addresses.

But a v6 address that is not a LL we do not need to provide
to zebra for nexthop resolution because a global address
by default can be looked up and resolved appropriately.

Modify the code so that we must have an ifindex for a v6 nexthop
if the address is LL, else don't pass the ifindex down to zebra.

Fixes: #1986
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>