### PR TITLE
Evpn fixes

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4336,6 +4336,7 @@ int bgp_evpn_local_l3vni_del(vni_t l3vni, vrf_id_t vrf_id)
 	struct bgp *bgp_vrf = NULL; /* bgp vrf instance */
 	struct bgp *bgp_def = NULL; /* default bgp instance */
 	struct listnode *node = NULL;
+	struct listnode *next = NULL;
 	struct bgpevpn *vpn = NULL;
 
 	bgp_vrf = bgp_lookup_by_vrf_id(vrf_id);
@@ -4385,6 +4386,10 @@ int bgp_evpn_local_l3vni_del(vni_t l3vni, vrf_id_t vrf_id)
 			update_routes_for_vni(bgp_def, vpn);
 		}
 	}
+
+	/* If any L2VNIs point to this instance, unlink them. */
+	for (ALL_LIST_ELEMENTS(bgp_vrf->l2vnis, node, next, vpn))
+		bgpevpn_unlink_from_l3vni(vpn);
 
 	/* Delete the instance if it was autocreated */
 	if (CHECK_FLAG(bgp_vrf->vrf_flags, BGP_VRF_AUTO))

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -74,6 +74,32 @@ static inline int advertise_type5_routes(struct bgp *bgp_vrf,
 	return 0;
 }
 
+/* Flag if the route's parent is a EVPN route. */
+static inline int is_route_parent_evpn(struct bgp_info *ri)
+{
+	struct bgp_info *parent_ri;
+	struct bgp_table *table;
+	struct bgp_node *rn;
+
+	/* If not imported (or doesn't have a parent), bail. */
+	if (ri->sub_type != BGP_ROUTE_IMPORTED ||
+	    !ri->extra ||
+	    !ri->extra->parent)
+		return 0;
+
+	/* See if the parent is of family L2VPN/EVPN */
+	parent_ri = (struct bgp_info *)ri->extra->parent;
+	rn = parent_ri->net;
+	if (!rn)
+		return 0;
+	table = bgp_node_table(rn);
+	if (table &&
+	    table->afi == AFI_L2VPN &&
+	    table->safi == SAFI_EVPN)
+		return 1;
+	return 0;
+}
+
 extern void bgp_evpn_advertise_type5_route(struct bgp *bgp_vrf,
 					   struct prefix *p,
 					   struct attr *src_attr, afi_t afi,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -567,7 +567,7 @@ static int bgp_info_cmp(struct bgp *bgp, struct bgp_info *new,
 	}
 
 	if (!(exist->sub_type == BGP_ROUTE_NORMAL ||
-	      new->sub_type == BGP_ROUTE_IMPORTED)) {
+	      exist->sub_type == BGP_ROUTE_IMPORTED)) {
 		if (debug)
 			zlog_debug(
 				"%s: %s loses to %s due to preferred BGP_ROUTE type",

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1097,11 +1097,8 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 	if (info->sub_type == BGP_ROUTE_AGGREGATE)
 		zapi_route_set_blackhole(&api, BLACKHOLE_NULL);
 
-	/* If it is an EVPN route mark as such.
-	 * Currently presence of rmac in attr denotes
-	 * this is an EVPN type-2 route
-	 */
-	if (info->sub_type == BGP_ROUTE_IMPORTED)
+	/* If the route's source is EVPN, flag as such. */
+	if (is_route_parent_evpn(info))
 		SET_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE);
 
 	if (peer->sort == BGP_PEER_IBGP || peer->sort == BGP_PEER_CONFED
@@ -1398,11 +1395,8 @@ void bgp_zebra_withdraw(struct prefix *p, struct bgp_info *info,
 	api.safi = safi;
 	api.prefix = *p;
 
-	/* If it is an EVPN route mark as such.
-	 * Currently presence of rmac in attr denotes
-	 * this is an EVPN type-2 route
-	 */
-	if (info->sub_type == BGP_ROUTE_IMPORTED)
+	/* If the route's source is EVPN, flag as such. */
+	if (is_route_parent_evpn(info))
 		SET_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE);
 
 	if (peer->sort == BGP_PEER_IBGP) {


### PR DESCRIPTION
This includes two main fixes:

1. Cleanup link between L2 VNIs and L3 VNIs (for EVPN symmetric routing) at deletion. This fixed a bgpd crash seen in testing.
2. Fix use of BGP_ROUTE_IMPORTED for EVPN - ensure EVPN routes are correctly identified.