### PR TITLE
zebra: avoid error when reading stream from add_rnh message

### DIFF
--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -864,7 +864,7 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 	struct rnh *rnh;
 	struct stream *s;
 	struct prefix p;
-	unsigned short l = 0;
+	unsigned short l = 10;
 	uint8_t flags = 0;
 	uint16_t type = cmd2type[hdr->command];
 


### PR DESCRIPTION
Because the length calculation ignores the header size, then the message
read ends with an error. The real header length is taken into account.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>