### PR TITLE
doc: cleanup documentation nits

### DIFF
--- a/doc/developer/building.rst
+++ b/doc/developer/building.rst
@@ -21,3 +21,4 @@ Building FRR
    building-frr-on-ubuntu1204
    building-frr-on-ubuntu1404
    building-frr-on-ubuntu1604
+   building-frr-on-ubuntu1804

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -232,7 +232,7 @@ Route Map Set Command
 .. index:: set ipv6 next-hop global IPV6_ADDRESS
 .. clicmd:: set ipv6 next-hop global IPV6_ADDRESS
 
-   Set the next-hop to the specified IPV6_ADDRESS.  For both incoming and
+   Set the next-hop to the specified IPV6_ADDRESS for both incoming and
    outgoing route-maps.
 
 .. index:: set local-preference LOCAL_PREF
@@ -259,11 +259,6 @@ Route Map Set Command
 .. clicmd:: set community COMMUNITY
 
    Set the BGP community attribute.
-
-.. index:: set ipv6 next-hop global IPV6_ADDRESS
-.. clicmd:: set ipv6 next-hop global IPV6_ADDRESS
-
-   Set the BGP-4+ global IPv6 nexthop address.
 
 .. index:: set ipv6 next-hop local IPV6_ADDRESS
 .. clicmd:: set ipv6 next-hop local IPV6_ADDRESS


### PR DESCRIPTION
* Ubuntu 18.04 build doc was not included in its toctree
* Duplicate definition of the same CLI command removed

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>