### PR TITLE
lib, vtysh: vrf walkup bugfix

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -642,6 +642,17 @@ int vrf_is_mapped_on_netns(vrf_id_t vrf_id)
 }
 
 /* vrf CLI commands */
+DEFUN_NOSH(vrf_exit,
+           vrf_exit_cmd,
+	   "exit-vrf",
+	   "Exit current mode and down to previous mode\n")
+{
+	/* We have to set vrf context to default vrf */
+	VTY_PUSH_CONTEXT(VRF_NODE, vrf_get(VRF_DEFAULT, VRF_DEFAULT_NAME));
+	vty->node = CONFIG_NODE;
+	return CMD_SUCCESS;
+}
+
 DEFUN_NOSH (vrf,
        vrf_cmd,
        "vrf NAME",
@@ -799,6 +810,7 @@ void vrf_cmd_init(int (*writefunc)(struct vty *vty),
 	install_element(CONFIG_NODE, &no_vrf_cmd);
 	install_node(&vrf_node, writefunc);
 	install_default(VRF_NODE);
+	install_element(VRF_NODE, &vrf_exit_cmd);
 	if (vrf_is_backend_netns() && ns_have_netns()) {
 		/* Install NS commands. */
 		vrf_daemon_privs = daemon_privs;

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -357,6 +357,8 @@ static int vtysh_execute_func(const char *line, int pager)
 			    || saved_node == BGP_VNC_L2_GROUP_NODE)
 			   && (tried == 1)) {
 			vtysh_execute("exit-vnc");
+		} else if (saved_node == VRF_NODE && (tried == 1)) {
+			vtysh_execute("exit-vrf");
 		} else if ((saved_node == KEYCHAIN_KEY_NODE
 			    || saved_node == LDP_PSEUDOWIRE_NODE
 			    || saved_node == LDP_IPV4_IFACE_NODE
@@ -632,6 +634,8 @@ int vtysh_mark_file(const char *filename)
 			} else if ((prev_node == BGP_EVPN_VNI_NODE)
 				   && (tried == 1)) {
 				fprintf(outputfile, "exit-vni\n");
+			} else if (prev_node == VRF_NODE) {
+				fprintf(outputfile, "exit-vrf\n");
 			} else if ((prev_node == KEYCHAIN_KEY_NODE)
 				   && (tried == 1)) {
 				fprintf(outputfile, "exit\n");
@@ -1613,8 +1617,16 @@ DEFUNSH(VTYSH_BGPD, exit_vnc_config, exit_vnc_config_cmd, "exit-vnc",
 	return CMD_SUCCESS;
 }
 
+DEFUNSH(VTYSH_PIMD|VTYSH_ZEBRA, exit_vrf_config, exit_vrf_config_cmd, "exit-vrf",
+	"Exit from VRF configuration mode\n")
+{
+	if (vty->node == VRF_NODE)
+		vty->node = CONFIG_NODE;
+	return CMD_SUCCESS;
+}
+
 DEFUNSH(VTYSH_BGPD, exit_vrf_policy, exit_vrf_policy_cmd, "exit-vrf-policy",
-	"Exit from VRF  configuration mode\n")
+	"Exit from VRF policy configuration mode\n")
 {
 	if (vty->node == BGP_VRF_POLICY_NODE)
 		vty->node = BGP_NODE;
@@ -3341,6 +3353,8 @@ void vtysh_init_vty(void)
 	install_element(INTERFACE_NODE, &vtysh_link_params_cmd);
 	install_element(ENABLE_NODE, &vtysh_show_running_config_cmd);
 	install_element(ENABLE_NODE, &vtysh_copy_running_config_cmd);
+
+	install_element(VRF_NODE, &exit_vrf_config_cmd);
 
 	install_element(CONFIG_NODE, &vtysh_vrf_cmd);
 	install_element(CONFIG_NODE, &vtysh_no_vrf_cmd);


### PR DESCRIPTION
Static route commands are now installed inside the VRF nodes. This has
quietly broken top-level static routes in certain scenarios due to
walkup logic resolving a static route configuration command inside
VRF_NODE first if the command is issued while in a CLI node lower than
VRF_NODE. To fix this VRF_NODE needs a special exit command, as has been
done for many other nodes with the same issue, to explicitly change the
vrf context to the default VRF so that when walkup resolves against the
VRF node it will configure against the default VRF as desired.

Of course this is a hack on top of a hack and the CLI walkup
implementation needs to be rewritten.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>