### PR TITLE
bgpd, pim: remove undebug

### DIFF
--- a/bgpd/rfapi/vnc_debug.c
+++ b/bgpd/rfapi/vnc_debug.c
@@ -85,10 +85,9 @@ DEFUN (debug_bgp_vnc,
 
 DEFUN (no_debug_bgp_vnc,
        no_debug_bgp_vnc_cmd,
-       "<no debug|undebug> bgp vnc <rfapi-query|import-bi-attach|import-del-remote|verbose>",
+       "no debug bgp vnc <rfapi-query|import-bi-attach|import-del-remote|verbose>",
        NO_STR
        DEBUG_STR
-       "Undebug\n"
        BGP_STR
        VNC_STR
        "rfapi query handling\n"
@@ -98,10 +97,8 @@ DEFUN (no_debug_bgp_vnc,
 {
 	size_t i;
 
-	if (strmatch(argv[0]->text, "no"))
-		argc--, argv++;
 	for (i = 0; i < (sizeof(vncdebug) / sizeof(struct vnc_debug)); ++i) {
-		if (strmatch(argv[3]->text, vncdebug[i].name)) {
+		if (strmatch(argv[argc - 1]->text, vncdebug[i].name)) {
 			if (vty->node == CONFIG_NODE) {
 				conf_vnc_debug &= ~vncdebug[i].bit;
 				term_vnc_debug &= ~vncdebug[i].bit;
@@ -117,6 +114,20 @@ DEFUN (no_debug_bgp_vnc,
 	return CMD_WARNING_CONFIG_FAILED;
 }
 
+#if CONFDATE > 20190402
+CPP_NOTICE("bgpd: time to remove undebug commands")
+#endif
+ALIAS_HIDDEN(no_debug_bgp_vnc,
+             undebug_bgp_vnc_cmd,
+	     "undebug bgp vnc <rfapi-query|import-bi-attach|import-del-remote|verbose>",
+             "Undebug\n"
+             BGP_STR
+             VNC_STR
+             "rfapi query handling\n"
+             "import BI atachment\n"
+             "import delete remote routes\n"
+             "verbose logging\n")
+
 
 /***********************************************************************
  *	no debug bgp vnc all
@@ -124,10 +135,9 @@ DEFUN (no_debug_bgp_vnc,
 
 DEFUN (no_debug_bgp_vnc_all,
        no_debug_bgp_vnc_all_cmd,
-       "<no debug|undebug> all bgp vnc",
+       "no debug all bgp vnc",
        NO_STR
        DEBUG_STR
-       "Undebug command\n"
        "Disable all VNC debugging\n"
        BGP_STR
        VNC_STR)
@@ -137,6 +147,17 @@ DEFUN (no_debug_bgp_vnc_all,
 
 	return CMD_SUCCESS;
 }
+
+#if CONFDATE > 20190402
+CPP_NOTICE("bgpd: time to remove undebug commands")
+#endif
+ALIAS_HIDDEN (no_debug_bgp_vnc_all,
+              undebug_bgp_vnc_all_cmd,
+              "undebug all bgp vnc",
+              "Undebug\n"
+              "Disable all VNC debugging\n"
+              BGP_STR
+              VNC_STR)
 
 /***********************************************************************
  *	show/save
@@ -188,6 +209,12 @@ void vnc_debug_init(void)
 	install_element(ENABLE_NODE, &debug_bgp_vnc_cmd);
 	install_element(CONFIG_NODE, &debug_bgp_vnc_cmd);
 	install_element(ENABLE_NODE, &no_debug_bgp_vnc_cmd);
+	install_element(CONFIG_NODE, &no_debug_bgp_vnc_cmd);
+	install_element(ENABLE_NODE, &undebug_bgp_vnc_cmd);
+	install_element(CONFIG_NODE, &undebug_bgp_vnc_cmd);
 
 	install_element(ENABLE_NODE, &no_debug_bgp_vnc_all_cmd);
+	install_element(CONFIG_NODE, &no_debug_bgp_vnc_all_cmd);
+	install_element(ENABLE_NODE, &undebug_bgp_vnc_all_cmd);
+	install_element(CONFIG_NODE, &undebug_bgp_vnc_all_cmd);
 }

--- a/lib/command.h
+++ b/lib/command.h
@@ -331,7 +331,7 @@ struct cmd_node {
 #define BGP_SOFT_RSCLIENT_RIB_STR "Soft reconfig for rsclient RIB\n"
 #define OSPF_STR "OSPF information\n"
 #define NEIGHBOR_STR "Specify neighbor router\n"
-#define DEBUG_STR "Debugging functions (see also 'undebug')\n"
+#define DEBUG_STR "Debugging functions\n"
 #define UNDEBUG_STR "Disable debugging functions (see also 'debug')\n"
 #define ROUTER_STR "Enable a routing process\n"
 #define AS_STR "AS number\n"

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -25,6 +25,8 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include "compiler.h"
+
 #ifdef SUNOS_5
 #define _XPG4_2
 typedef unsigned int uint32_t;

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7226,8 +7226,13 @@ DEFUN (no_debug_msdp,
 	return CMD_SUCCESS;
 }
 
-ALIAS(no_debug_msdp, undebug_msdp_cmd, "undebug msdp",
-      UNDEBUG_STR DEBUG_MSDP_STR)
+#if CONFDATE > 20190402
+CPP_NOTICE("bgpd: time to remove undebug commands")
+#endif
+ALIAS_HIDDEN (no_debug_msdp,
+              undebug_msdp_cmd,
+              "undebug msdp",
+              UNDEBUG_STR DEBUG_MSDP_STR)
 
 DEFUN (debug_msdp_events,
        debug_msdp_events_cmd,
@@ -7252,8 +7257,15 @@ DEFUN (no_debug_msdp_events,
 	return CMD_SUCCESS;
 }
 
-ALIAS(no_debug_msdp_events, undebug_msdp_events_cmd, "undebug msdp events",
-      UNDEBUG_STR DEBUG_MSDP_STR DEBUG_MSDP_EVENTS_STR)
+#if CONFDATE > 20190402
+CPP_NOTICE("bgpd: time to remove undebug commands")
+#endif
+ALIAS_HIDDEN (no_debug_msdp_events,
+              undebug_msdp_events_cmd,
+              "undebug msdp events",
+              UNDEBUG_STR
+              DEBUG_MSDP_STR
+              DEBUG_MSDP_EVENTS_STR)
 
 DEFUN (debug_msdp_packets,
        debug_msdp_packets_cmd,
@@ -7278,8 +7290,15 @@ DEFUN (no_debug_msdp_packets,
 	return CMD_SUCCESS;
 }
 
-ALIAS(no_debug_msdp_packets, undebug_msdp_packets_cmd, "undebug msdp packets",
-      UNDEBUG_STR DEBUG_MSDP_STR DEBUG_MSDP_PACKETS_STR)
+#if CONFDATE > 20190402
+CPP_NOTICE("bgpd: time to remove undebug commands")
+#endif
+ALIAS_HIDDEN (no_debug_msdp_packets,
+              undebug_msdp_packets_cmd,
+              "undebug msdp packets",
+              UNDEBUG_STR
+              DEBUG_MSDP_STR
+              DEBUG_MSDP_PACKETS_STR)
 
 DEFUN (debug_mtrace,
        debug_mtrace_cmd,


### PR DESCRIPTION
This 'undebug' syntax is only used in 5 commands and serves no apparent
purpose.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>