### PR TITLE
zebra: implement draft-bz-v4goawayflag-00

### DIFF
--- a/doc/user/ipv6.rst
+++ b/doc/user/ipv6.rst
@@ -184,6 +184,14 @@ Router Advertisement
             no ipv6 nd suppress-ra
             ipv6 nd prefix 2001:0DB8:5009::/64
 
+.. index:: [no] ipv6 nd v4 goaway
+.. clicmd:: [no] ipv6 nd v4 goaway
+
+   Set whether or not to transmit the V4 GoAway option. This option indicates
+   to the destination that they should disable IPv4 on the link.
+
+   Implements draft-bz-v4goawayflag-00.
+
 
 .. seealso::
 
@@ -191,3 +199,4 @@ Router Advertisement
    - :rfc:`4861` (Neighbor Discovery for IP Version 6 (IPv6))
    - :rfc:`6275` (Mobility Support in IPv6)
    - :rfc:`4191` (Default Router Preferences and More-Specific Routes)
+   - https://www.ietf.org/id/draft-bz-v4goawayflag-00.txt

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -45,6 +45,8 @@
 #include "zebra/zebra_vrf.h"
 
 extern struct zebra_privs_t zserv_privs;
+/* currently undefined in icmp6.h */
+bool AdvGoAwayFlag;
 
 #if defined(HAVE_RTADV)
 
@@ -224,6 +226,9 @@ static void rtadv_send_packet(int sock, struct interface *ifp)
 		rtadv->nd_ra_flags_reserved |= ND_RA_FLAG_OTHER;
 	if (zif->rtadv.AdvHomeAgentFlag)
 		rtadv->nd_ra_flags_reserved |= ND_RA_FLAG_HOME_AGENT;
+	if (AdvGoAwayFlag)
+		rtadv->nd_ra_flags_reserved |= ND_RA_FLAG_V4_GOAWAY;
+
 	/* Note that according to Neighbor Discovery (RFC 4861 [18]),
 	 * AdvDefaultLifetime is by default based on the value of
 	 * MaxRtrAdvInterval.  AdvDefaultLifetime is used in the Router Lifetime
@@ -1495,6 +1500,19 @@ DEFUN (no_ipv6_nd_mtu,
 	return CMD_SUCCESS;
 }
 
+DEFUN (ipv6_nd_v4_goaway,
+       ipv6_nd_v4_goaway_cmd,
+       "[no] ipv6 nd v4 goaway",
+       NO_STR
+       "Interface IPv6 config commands\n"
+       "Neighbor discovery\n"
+       "v4 RA flags\n"
+       "Set V4 GoAway Flag\n")
+{
+	AdvGoAwayFlag = !strmatch(argv[0]->text, "no");
+	return CMD_SUCCESS;
+}
+
 /* Dump interface ND information to vty. */
 static int nd_dump_vty(struct vty *vty, struct interface *ifp)
 {
@@ -1626,6 +1644,9 @@ static int rtadv_config_write(struct vty *vty, struct interface *ifp)
 	if (zif->rtadv.AdvLinkMTU)
 		vty_out(vty, " ipv6 nd mtu %d\n", zif->rtadv.AdvLinkMTU);
 
+	if (AdvGoAwayFlag)
+		vty_out(vty, " ipv6 nd v4 goaway\n");
+
 	for (ALL_LIST_ELEMENTS_RO(zif->rtadv.AdvPrefixList, node, rprefix)) {
 		vty_out(vty, " ipv6 nd prefix %s",
 			prefix2str(&rprefix->prefix, buf, sizeof(buf)));
@@ -1744,6 +1765,7 @@ void rtadv_cmd_init(void)
 	install_element(INTERFACE_NODE, &no_ipv6_nd_router_preference_cmd);
 	install_element(INTERFACE_NODE, &ipv6_nd_mtu_cmd);
 	install_element(INTERFACE_NODE, &no_ipv6_nd_mtu_cmd);
+	install_element(INTERFACE_NODE, &ipv6_nd_v4_goaway_cmd);
 }
 
 static int if_join_all_router(int sock, struct interface *ifp)

--- a/zebra/rtadv.h
+++ b/zebra/rtadv.h
@@ -28,6 +28,9 @@
 /* NB: RTADV is defined in zebra/interface.h above */
 #if defined(HAVE_RTADV)
 
+/* currently undefined in icmp6.h */
+#define ND_RA_FLAG_V4_GOAWAY 0x01
+
 /* Router advertisement prefix. */
 struct rtadv_prefix {
 	/* Prefix to be advertised. */


### PR DESCRIPTION
Adds support for V4 GoAway flag as described in
https://www.ietf.org/id/draft-bz-v4goawayflag-00.txt

This option allows advertising neighbors to indicate to recipients that
they should disable IPv4 on the link.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>