### PR TITLE
debianpkg: rules WANT_FRR_USER bug

### DIFF
--- a/debianpkg/backports/ubuntu12.04/debian/rules
+++ b/debianpkg/backports/ubuntu12.04/debian/rules
@@ -69,8 +69,8 @@ ifndef WANT_FRR_USER
   USE_FRR_USER=--enable-user=frr
   USE_FRR_GROUP=--enable-group=frr
 else
-  USE_FRR_USER=$(WANT_FRR_USER)
-  USE_FRR_GROUP=$(WANT_FRR_USER)
+  USE_FRR_USER=--enable-user=$(WANT_FRR_USER)
+  USE_FRR_GROUP=--enable-group=$(WANT_FRR_USER)
 endif
 
 ifndef WANT_FRR_VTY_GROUP

--- a/debianpkg/backports/ubuntu14.04/debian/rules
+++ b/debianpkg/backports/ubuntu14.04/debian/rules
@@ -78,8 +78,8 @@ ifndef WANT_FRR_USER
   USE_FRR_USER=--enable-user=frr
   USE_FRR_GROUP=--enable-group=frr
 else
-  USE_FRR_USER=$(WANT_FRR_USER)
-  USE_FRR_GROUP=$(WANT_FRR_USER)
+  USE_FRR_USER=--enable-user=$(WANT_FRR_USER)
+  USE_FRR_GROUP=--enable-group=$(WANT_FRR_USER)
 endif
 
 ifndef WANT_FRR_VTY_GROUP

--- a/debianpkg/rules
+++ b/debianpkg/rules
@@ -78,8 +78,8 @@ ifndef WANT_FRR_USER
   USE_FRR_USER=--enable-user=frr
   USE_FRR_GROUP=--enable-group=frr
 else
-  USE_FRR_USER=$(WANT_FRR_USER)
-  USE_FRR_GROUP=$(WANT_FRR_USER)
+  USE_FRR_USER=--enable-user=$(WANT_FRR_USER)
+  USE_FRR_GROUP=--enable-group=$(WANT_FRR_USER)
 endif
 
 ifndef WANT_FRR_VTY_GROUP


### PR DESCRIPTION
WANT_FRR_USER was not prepended by appropriate command line
option for configure.

Signed-off-by: Mladen Sablic <mladen.sablic@gmail.com>