### PR TITLE
lib: add compiler.h to zebra.h

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -29,6 +29,7 @@
 #include "memory.h"
 #include "hash.h"
 #include "command_graph.h"
+#include "compiler.h"
 
 DECLARE_MTYPE(HOST)
 DECLARE_MTYPE(COMPLETION)

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -25,6 +25,8 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include "compiler.h"
+
 #ifdef SUNOS_5
 #define _XPG4_2
 typedef unsigned int u_int32_t;


### PR DESCRIPTION
The definitions in compiler.h should be globally available.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>