### PR TITLE
4.0: ignore confdate expiration in non-dev branches

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,8 @@ include common.am
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/lib \
 	      -I$(top_builddir) -I$(top_builddir)/include -I$(top_builddir)/lib
 AM_CFLAGS = $(WERROR)
-DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\" -DCONFDATE=$(CONFDATE)
+VERSION_TYPE := $(shell if echo $(VERSION) | grep -q dev; then echo DEV ; else  echo RELEASE ; fi)
+DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\" -DCONFDATE=$(CONFDATE) -DVERSION_TYPE_$(VERSION_TYPE)
 LIBCAP = @LIBCAP@
 
 EXTRA_DIST =

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8299,7 +8299,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, u_char use_json,
 			uptime -= p->uptime;
 			epoch_tbuf = time(NULL) - uptime;
 
-#if CONFDATE > 20200101
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20200101
 			CPP_NOTICE("bgpTimerUp should be deprecated and can be removed now");
 #endif
 			/*

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -84,7 +84,7 @@ extern void *listnode_head(struct list *);
  * and remove list_delete_original and the list_delete #define
  * Additionally remove list_free entirely
  */
-#if CONFDATE > 20181001
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20181001
 CPP_NOTICE("list_delete without double pointer is deprecated, please fixup")
 #endif
 extern void list_delete_and_null(struct list **);

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -123,7 +123,7 @@ struct stream_fifo {
 #define STREAM_CONCAT_REMAIN(S1, S2, size) ((size) - (S1)->endp - (S2)->endp)
 
 /* deprecated macros - do not use in new code */
-#if CONFDATE > 20181128
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20181128
 CPP_NOTICE("lib: time to remove deprecated stream.h macros")
 #endif
 #define STREAM_PNT(S)   stream_pnt((S))

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -189,7 +189,7 @@ struct vty_arg {
 /* Integrated configuration file. */
 #define INTEGRATE_DEFAULT_CONFIG "frr.conf"
 
-#if CONFDATE > 20180401
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180401
 CPP_NOTICE("It's probably time to remove VTY_NEWLINE compatibility foo.")
 #endif
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -353,7 +353,7 @@ struct zclient_options {
 /* Prototypes of zebra client service functions. */
 extern struct zclient *zclient_new(struct thread_master *);
 
-#if CONFDATE > 20181101
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20181101
 CPP_NOTICE("zclient_new_notify can take over or zclient_new now");
 #endif
 
@@ -422,7 +422,7 @@ extern struct interface *zebra_interface_vrf_update_read(struct stream *s,
 extern void zebra_interface_if_set_value(struct stream *, struct interface *);
 extern void zebra_router_id_update_read(struct stream *s, struct prefix *rid);
 
-#if CONFDATE > 20180823
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180823
 CPP_NOTICE("zapi_ipv4_route, zapi_ipv6_route, zapi_ipv4_route_ipv6_nexthop as well as the zapi_ipv4 and zapi_ipv6 data structures should be removed now");
 #endif
 

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -363,7 +363,7 @@ DEFUN(no_ospf6_router_id,
 	return CMD_SUCCESS;
 }
 
-#if CONFDATE > 20180828
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180828
 CPP_NOTICE("ospf6: `router-id A.B.C.D` deprecated 2017/08/28")
 #endif
 ALIAS_HIDDEN(ospf6_router_id,
@@ -372,7 +372,7 @@ ALIAS_HIDDEN(ospf6_router_id,
 	     "Configure OSPF6 Router-ID\n"
 	     V4NOTATION_STR)
 
-#if CONFDATE > 20180828
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180828
 CPP_NOTICE("ospf6: `no router-id A.B.C.D` deprecated 2017/08/28")
 #endif
 ALIAS_HIDDEN(no_ospf6_router_id,

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2337,7 +2337,7 @@ DEFUN (no_ospf_timers_lsa_min_arrival,
 	return CMD_SUCCESS;
 }
 
-#if CONFDATE > 20180708
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180708
 CPP_NOTICE("ospf: `timers lsa arrival (0-1000)` deprecated 2017/07/08")
 #endif
 ALIAS_HIDDEN (ospf_timers_lsa_min_arrival,
@@ -2348,7 +2348,7 @@ ALIAS_HIDDEN (ospf_timers_lsa_min_arrival,
               "ospf minimum arrival interval delay\n"
               "delay (msec) between accepted lsas\n");
 
-#if CONFDATE > 20180708
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180708
 CPP_NOTICE("ospf: `no timers lsa arrival (0-1000)` deprecated 2017/07/08")
 #endif
 ALIAS_HIDDEN (no_ospf_timers_lsa_min_arrival,


### PR DESCRIPTION
4.0: alternative to #1983 as discussed in meeting and slack