### PR TITLE
doc: warn users about vtysh / telnet security

### DIFF
--- a/doc/manpages/vtysh.rst
+++ b/doc/manpages/vtysh.rst
@@ -55,7 +55,9 @@ OPTIONS available for the vtysh command:
 
 .. option:: -u, --user
 
-   Run as an unprivileged user. This limits access to non-privileged commands, i.e., the same commands when directly accessing a daemon   before running the enable command. It also provides the same limited security as such direct access.
+   Restrict access to configuration commands by preventing use of the "enable" command. This option provides the same limited "security" as password-protected telnet access. *This security should not be relied on in production environments.*
+
+   Caveat emptor: VTYSH was never designed to be a privilege broker and is not built using secure coding practices. No guarantees of security are provided for this option and under no circumstances should this option be used to provide any semblance of secure read-only access to FRR.
 
 .. option:: -h, --help
 

--- a/doc/user/vtysh.rst
+++ b/doc/user/vtysh.rst
@@ -33,6 +33,16 @@ daemons will change ownership of their sockets to).
 To restrict access to FRR configuration, make sure no unauthorized users are
 members of the |INSTALL_VTY_GROUP| group.
 
+.. warning::
+
+   VTYSH implements a CLI option ``-u, --user`` that disallows entering the
+   characters "en" on the command line, which ideally restricts access to
+   configuration commands. However, VTYSH was never designed to be a privilege
+   broker and is not built using secure coding practices. No guarantees of
+   security are provided for this option and under no circumstances should this
+   option be used to provide any semblance of security or read-only access to
+   FRR.
+
 PAM support (experimental)
 --------------------------
 


### PR DESCRIPTION
Users need to be made very very aware of the security implications of using VTYSH / legacy telnet password protection as any kind of privilege protection.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>