### PR TITLE
Use new way of avoiding deprecated related warnings in non-dev branches

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,8 @@ include common.am
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/lib \
 	      -I$(top_builddir) -I$(top_builddir)/include -I$(top_builddir)/lib
 AM_CFLAGS = $(WERROR)
-DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\" -DCONFDATE=$(CONFDATE)
+VERSION_TYPE := $(shell if echo $(VERSION) | grep -q dev; then echo DEV ; else  echo RELEASE ; fi)
+DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\" -DCONFDATE=$(CONFDATE) -DVERSION_TYPE_$(VERSION_TYPE)
 LIBCAP = @LIBCAP@
 
 EXTRA_DIST =

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8863,7 +8863,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint8_t use_json,
 			uptime -= p->uptime;
 			epoch_tbuf = time(NULL) - uptime;
 
-#if CONFDATE > 20200101
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20200101
 			CPP_NOTICE(
 				"bgpTimerUp should be deprecated and can be removed now");
 #endif

--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -708,7 +708,14 @@ either:
 In all cases, compatibility pieces should be marked with
 compiler/preprocessor annotations to print warnings at compile time,
 pointing to the appropriate update path. A ``-Werror`` build should fail
-if compatibility bits are used.
+if compatibility bits are used. To avoid compilation issues in released
+code, such compiler/preprocessor annotations must be ignored
+non-development branches. For example:
+
+    #if defined(VERSION_TYPE_DEV) && CONFDATE > 20180403
+    CPP_NOTICE("Use of <XYZ> is deprecated, please use <ABC>")
+    #endif
+
 
 Preferably, the shell script :file:`tools/fixup-deprecated.py` will be
 updated along with making non-backwards compatible code changes, or an

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -84,7 +84,7 @@ extern void *listnode_head(struct list *);
  * and remove list_delete_original and the list_delete #define
  * Additionally remove list_free entirely
  */
-#if CONFDATE > 20181001
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20181001
 CPP_NOTICE("list_delete without double pointer is deprecated, please fixup")
 #endif
 extern void list_delete_and_null(struct list **);

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -123,7 +123,7 @@ struct stream_fifo {
 #define STREAM_CONCAT_REMAIN(S1, S2, size) ((size) - (S1)->endp - (S2)->endp)
 
 /* deprecated macros - do not use in new code */
-#if CONFDATE > 20181128
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20181128
 CPP_NOTICE("lib: time to remove deprecated stream.h macros")
 #endif
 #define STREAM_PNT(S)   stream_pnt((S))

--- a/lib/workqueue.h
+++ b/lib/workqueue.h
@@ -154,7 +154,7 @@ extern struct work_queue *work_queue_new(struct thread_master *, const char *);
  * The usage of work_queue_free is being transitioned to pass
  * in the double pointer to remove use after free's.
  */
-#if CONFDATE > 20190205
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20190205
 CPP_NOTICE("work_queue_free without double pointer is deprecated, please fixup")
 #endif
 extern void work_queue_free_and_null(struct work_queue **);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -383,7 +383,7 @@ struct zclient_options {
 extern struct zclient *zclient_new(struct thread_master *);
 
 /* clang-format off */
-#if CONFDATE > 20181101
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20181101
 CPP_NOTICE("zclient_new_notify can take over or zclient_new now");
 #endif
 /* clang-format on */
@@ -524,7 +524,7 @@ extern void zebra_interface_if_set_value(struct stream *, struct interface *);
 extern void zebra_router_id_update_read(struct stream *s, struct prefix *rid);
 
 /* clang-format off */
-#if CONFDATE > 20180823
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180823
 CPP_NOTICE("zapi_ipv4_route, zapi_ipv6_route, zapi_ipv4_route_ipv6_nexthop as well as the zapi_ipv4 and zapi_ipv6 data structures should be removed now");
 #endif
 /* clang-format on */

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -422,13 +422,13 @@ DEFUN(no_ospf6_router_id,
 	return CMD_SUCCESS;
 }
 
-#if CONFDATE > 20180828
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180828
 CPP_NOTICE("ospf6: `router-id A.B.C.D` deprecated 2017/08/28")
 #endif
 ALIAS_HIDDEN(ospf6_router_id, ospf6_router_id_hdn_cmd, "router-id A.B.C.D",
 	     "Configure OSPF6 Router-ID\n" V4NOTATION_STR)
 
-#if CONFDATE > 20180828
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180828
 CPP_NOTICE("ospf6: `no router-id A.B.C.D` deprecated 2017/08/28")
 #endif
 ALIAS_HIDDEN(no_ospf6_router_id, no_ospf6_router_id_hdn_cmd,

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2338,7 +2338,7 @@ DEFUN (no_ospf_timers_lsa_min_arrival,
 	return CMD_SUCCESS;
 }
 
-#if CONFDATE > 20180708
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180708
 CPP_NOTICE("ospf: `timers lsa arrival (0-1000)` deprecated 2017/07/08")
 #endif
 ALIAS_HIDDEN(ospf_timers_lsa_min_arrival, ospf_timers_lsa_arrival_cmd,
@@ -2348,7 +2348,7 @@ ALIAS_HIDDEN(ospf_timers_lsa_min_arrival, ospf_timers_lsa_arrival_cmd,
 	     "ospf minimum arrival interval delay\n"
 	     "delay (msec) between accepted lsas\n");
 
-#if CONFDATE > 20180708
+#if defined(VERSION_TYPE_DEV) && CONFDATE > 20180708
 CPP_NOTICE("ospf: `no timers lsa arrival (0-1000)` deprecated 2017/07/08")
 #endif
 ALIAS_HIDDEN(no_ospf_timers_lsa_min_arrival, no_ospf_timers_lsa_arrival_cmd,


### PR DESCRIPTION
follow on to #1983 and #1984