### PR TITLE
ospf6d: ECMP for Intra Area Prefix routes

### DIFF
--- a/ospf6d/ospf6_intra.h
+++ b/ospf6d/ospf6_intra.h
@@ -231,6 +231,9 @@ extern void ospf6_intra_prefix_lsa_remove(struct ospf6_lsa *lsa);
 extern int ospf6_orig_as_external_lsa(struct thread *thread);
 extern void ospf6_intra_route_calculation(struct ospf6_area *oa);
 extern void ospf6_intra_brouter_calculation(struct ospf6_area *oa);
+extern void ospf6_intra_prefix_route_ecmp_path(struct ospf6_area *oa,
+					       struct ospf6_route *old,
+					       struct ospf6_route *route);
 
 extern void ospf6_intra_init(void);
 

--- a/ospf6d/ospf6_route.h
+++ b/ospf6d/ospf6_route.h
@@ -246,6 +246,7 @@ extern const char *ospf6_path_type_substr[OSPF6_PATH_TYPE_MAX];
 	((ra)->type == (rb)->type                                              \
 	 && memcmp(&(ra)->prefix, &(rb)->prefix, sizeof(struct prefix)) == 0   \
 	 && memcmp(&(ra)->path, &(rb)->path, sizeof(struct ospf6_path)) == 0   \
+	 && listcount(ra->paths) == listcount(rb->paths)		       \
 	 && ospf6_route_cmp_nexthops(ra, rb) == 0)
 
 #define ospf6_route_is_best(r) (CHECK_FLAG ((r)->flag, OSPF6_ROUTE_BEST))
@@ -340,5 +341,6 @@ extern void ospf6_route_init(void);
 extern void ospf6_clean(void);
 extern void ospf6_path_free(struct ospf6_path *op);
 extern struct ospf6_path *ospf6_path_dup(struct ospf6_path *path);
+extern void ospf6_copy_paths(struct list *dst, struct list *src);
 
 #endif /* OSPF6_ROUTE_H */


### PR DESCRIPTION
Handle ECMP for Intra Area Prefix LSA's routes.


Testing Done:
Configure ospf6 passive interface R2 and R3 with
same prefix address.
Check Intra Area Prefix LSA update  at R1 and R3
which would have ECMP paths with effective two
paths and two nexthops (from R2 and R4).
stop frr at R3 and R1 and R4 route changes back to
one nexthop and one paht.
R1 ---- R2
|       |
R3 ---- R4

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>