### PR TITLE
alpine packaging: use a more standard packaging format

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -4,9 +4,9 @@ pkgver=@VERSION@
 pkgrel=0
 pkgdesc="Free Range Routing is a fork of quagga"
 url="https://frrouting.org/"
-arch="all"
+arch="x86_64"
 license="GPL-2.0"
-depends="iproute2 json-c c-ares ipsec-tools iproute2"
+depends="json-c c-ares ipsec-tools iproute2 python py-ipaddr bash"
 makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     acct autoconf automake bash
     binutils binutils-libs bison bsd-compat-headers build-base
@@ -20,18 +20,42 @@ makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     patch pax-utils pcre perl pkgconf python2 python2-dev readline
     readline-dev sqlite-libs squashfs-tools sudo tar texinfo xorriso xz-libs
     py-sphinx"
+install="$pkgname.pre-install $pkgname.pre-deinstall $pkgname.post-deinstall"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg"
-source="$pkgname-$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz docker-start daemons daemons.conf"
 
 builddir="$srcdir"/$pkgname-$pkgver
 
+_sbindir=/usr/lib/frr
+_sysconfdir=/etc/frr
+_libdir=/usr/lib
+_localstatedir=/var/run/frr
+_user=frr
+
 build() {
 	cd "$builddir"
-	./configure --prefix=/usr || return 1
+	./configure \
+		--prefix=/usr \
+		--sbindir=$_sbindir \
+		--sysconfdir=$_sysconfdir \
+		--libdir=$_libdir \
+		--localstatedir=$_localstatedir \
+		--enable-systemd=no \
+		--enable-vtysh \
+		--enable-multipath=64 \
+		--enable-vty-group=frrvty \
+		--enable-user=$_user \
+		--enable-group=$_user || return 1
 	make || return 1
 }
 
 package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install || return 1
+
+	install -Dm755 "$srcdir"/docker-start "$pkgdir"$_sbindir
+	install -Dm644 "$srcdir"/daemons "$pkgdir"$_sysconfdir
+	install -Dm644 "$srcdir"/daemons.conf "$pkgdir"$_sysconfdir
+	install -d "$pkgdir"/etc/init.d
+	ln -s ${_sbindir}/frr "$pkgdir"/etc/init.d/frr
 }

--- a/alpine/docker-start
+++ b/alpine/docker-start
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+##
+# For volume mounts...
+##
+chown -R frr:frr /etc/frr
+/etc/init.d/frr start
+exec sleep 10000d

--- a/alpine/frr.post-deinstall
+++ b/alpine/frr.post-deinstall
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+getent passwd frr > /dev/null && deluser frr
+getent group frrvty > /dev/null && delgroup frrvty
+getent group frr > /dev/null && delgroup frr
+exit 0

--- a/alpine/frr.pre-deinstall
+++ b/alpine/frr.pre-deinstall
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+/etc/init.d/frr stop
+exit 0

--- a/alpine/frr.pre-install
+++ b/alpine/frr.pre-install
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+for g in frr frrvty; do
+	! getent group $g > /dev/null && addgroup -S $g
+done
+
+! getent passwd frr > /dev/null && \
+	adduser -S -D -h /var/run/frr -s /sbin/nologin -G frr -g frr frr
+
+adduser frr frrvty

--- a/doc/developer/building-frr-on-alpine.rst
+++ b/doc/developer/building-frr-on-alpine.rst
@@ -52,13 +52,32 @@ And to run the image:
 
 ::
 
-   docker run -it --rm frr:latest /bin/sh
+   docker run -it --rm --name frr frr:latest
 
-Currently, we only package the raw daemons and example files, so, you'll
-need to run the daemons by hand (or, better, orchestrate in the Dockerfile).
+In the default configuration, none of the frr daemons will  be running.
+To configure the daemons, exec into the container and edit the configuration
+files or mount a volume with configuration files into the container on
+startup.  To configure by hand:
 
-We can also build directly from docker-compose, with a docker-compose.yml file
-like this one:
+::
+
+   docker exec -it frr /bin/sh
+   vi /etc/frr/daemons
+   vi /etc/frr/daemons.conf
+   cp /etc/frr/zebra.conf.sample /etc/frr/zebra.conf
+   vi /etc/frr/zebra.conf
+   /etc/init.d/frr start
+
+Or, to configure the daemons using /etc/frr from a host volume, put the
+config files in, say, ./docker/etc and bind mount that into the
+container:
+
+::
+
+   docker run -it --rm -v `pwd`/docker/etc:/etc/frr frr:latest
+
+We can also build the base image directly from docker-compose, with a
+docker-compose.yml file like this one:
 
 ::
 

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -23,11 +23,13 @@ FROM alpine:3.7 as alpine-builder
 RUN apk add --no-cache abuild alpine-sdk && mkdir -p /pkgs/apk
 ADD docker/alpine/alpine-build.sh /usr/bin/
 ADD docker/alpine/builder /etc/sudoers.d
-COPY --from=source-builder /src/*.tar.gz /src/alpine/APKBUILD /dist/
+COPY --from=source-builder /src/*.tar.gz /src/alpine/* /src/tools/etc/frr/daemons* /dist/
 RUN adduser -D -G abuild builder && chown -R builder /dist /pkgs
 USER builder
 RUN /usr/bin/alpine-build.sh
 FROM alpine:3.7
 RUN mkdir -p /pkgs/apk
 COPY --from=alpine-builder /pkgs/apk/ /pkgs/apk/
+RUN apk add --no-cache tini
 RUN apk add --no-cache --allow-untrusted /pkgs/apk/x86_64/*.apk
+ENTRYPOINT [ "/sbin/tini", "--", "/usr/lib/frr/docker-start" ]

--- a/tools/frr
+++ b/tools/frr
@@ -25,7 +25,9 @@ DAEMONS="zebra bgpd ripd ripngd ospfd ospf6d isisd babeld pimd ldpd nhrpd eigrpd
 MAX_INSTANCES=5
 RELOAD_SCRIPT=/usr/lib/frr/frr-reload.py
 
-. /lib/lsb/init-functions
+if [ -e /lib/lsb/init-functions ]; then
+    . /lib/lsb/init-functions
+fi
 
 if [ -f /usr/lib/frr/ssd ]; then
     SSD=/usr/lib/frr/ssd


### PR DESCRIPTION
Currently, we just package the frr daemons, but we don't run
them.  This is fine for basic tests, but it is inconvenient to
orchestrate the daemons from downstream test environments.

Here, we follow the redhat and debianpkg formats more closely,
putting the daemons in /usr/lib/frr and including the frr user
in the package.  We also auto-launch and re-launch the daemons
using the runit package, which is very lightweight and is a
common docker daemon launch package.

Testing done:

Built packages, built base images, everything seems to work fine.
Uninstalled the package, all the daemons stopped.

Issue: https://github.com/FRRouting/frr/issues/2030
Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>