### PR TITLE
bgpd: don't add router's mac if all zero

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -695,7 +695,7 @@ static void build_evpn_route_extcomm(struct bgpevpn *vpn, struct attr *attr,
 	}
 
 	/* Add RMAC, if told to. */
-	if (add_l3_ecomm) {
+	if (add_l3_ecomm && !is_zero_mac(&attr->rmac)) {
 		memset(&ecom_rmac, 0, sizeof(ecom_rmac));
 		encode_rmac_extcomm(&eval_rmac, &attr->rmac);
 		ecom_rmac.size = 1;


### PR DESCRIPTION
If the router's MAC for L3VNI is all zero, it's unlikely we want to
send it.

This may not be the correct fix. I don't use L3VNI but I still get the `add_l3_ecomm` true. I suppose this is because the 0.0.0.0 IP is considered as a regular IPv4 but I don't know why I would get `VNI_FLAG_USE_TWO_LABELS` set.