### PR TITLE
bgpd: when showing routes, add nexthop vrf and announce-self flag

### DIFF
--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -54,10 +54,11 @@ enum bgp_show_type {
 
 
 #define BGP_SHOW_SCODE_HEADER                                                  \
-	"Status codes: s suppressed, d damped, "                               \
+	"Status codes:  s suppressed, d damped, "                              \
 	"h history, * valid, > best, = multipath,\n"                           \
-	"              i internal, r RIB-failure, S Stale, R Removed\n"
-#define BGP_SHOW_OCODE_HEADER "Origin codes: i - IGP, e - EGP, ? - incomplete\n\n"
+	"               i internal, r RIB-failure, S Stale, R Removed\n"
+#define BGP_SHOW_OCODE_HEADER "Origin codes:  i - IGP, e - EGP, ? - incomplete\n\n"
+#define BGP_SHOW_NCODE_HEADER "Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self\n"
 #define BGP_SHOW_HEADER "   Network          Next Hop            Metric LocPrf Weight Path\n"
 
 /* Maximum number of labels we can process or send with a prefix. We


### PR DESCRIPTION
As part of recent vpn-vrf leaking changes, it is now possible for a
route to refer to a nexthop in a different vrf. There is also a new
route flag that means "when announcing this route, indicate myself
as the next-hop."

route_vty_out(): nexthops are appended with:

    "@VRFID" (where VRFID is the numerical vrf id) when different from
    the route's vrf;

    "<" when the route's BGP_INFO_ANNC_NH_SELF is set

This change also shows the route table's vrf id in the table header.

route_vty_out_detail(): show nexthop's vrf and announce-nh-self flag if appropriate.

Both functions are also augmented to add json elements nhVrfId, nhVrfName,
and announceNexthopSelf as appropriate.

The intent of these changes is to make it easier to understand/debug
the relationship between a route and its nexthops.

IMPORTANT: this change breaks test scripts that expect the nexthop field to be a pure IP address, so merging should probably be coordinated with updates to the corresponding test scripts. For python and perl (and other?) regular expressions, `\b` might be useful to match on the end of the address part.