### PR TITLE
bgpd: vrf-vpn leak: when no export label is set, encode implicit-null correctly

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -665,8 +665,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,       /* to */
 
 	label_val = bgp_vrf->vpn_policy[afi].tovpn_label;
 	if (label_val == MPLS_LABEL_NONE) {
-		/* TBD get from label manager */
-		label = MPLS_LABEL_IMPLICIT_NULL;
+		encode_label(MPLS_LABEL_IMPLICIT_NULL, &label);
 	} else {
 		encode_label(label_val, &label);
 	}


### PR DESCRIPTION
Bugfix for vrf-to-vpn leaking. Labels stored in routes must be in encoded form. Encoding was done for configured static and auto values, but not for the non-configured case which uses implicit-null. Thanks to @rwestphal for identifying the problem and testing the fix.