### PR TITLE
ripd: rip_snmp.c - Remove not needed check

### DIFF
--- a/ripd/rip_snmp.c
+++ b/ripd/rip_snmp.c
@@ -207,7 +207,7 @@ static int rip_snmp_ifaddr_del(struct connected *ifc)
 	if (!rn)
 		return 0;
 	i = rn->info;
-	if (rn && !strncmp(i->name, ifp->name, INTERFACE_NAMSIZ)) {
+	if (!strncmp(i->name, ifp->name, INTERFACE_NAMSIZ)) {
 		rn->info = NULL;
 		route_unlock_node(rn);
 		route_unlock_node(rn);


### PR DESCRIPTION
rn cannot be null here

issue detected by cppcheck:

[ripd/rip_snmp.c:208] -> [ripd/rip_snmp.c:207]: (warning) Either the condition
'if(rn&&!strncmp(i->name,ifp->name,INTERFACE_NAMSIZ))' is redundant or there is
possible null pointer dereference: rn.

Signed-off-by: Ilya Shipitsin <chipitsine@gmail.com>