### PR TITLE
resolve issue found by cppcheck

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -5774,10 +5774,12 @@ int zebra_vxlan_add_del_gw_macip(struct interface *ifp, struct prefix *p,
 			NULL; /* link info for the SVI = bridge info */
 
 		svi_if_zif = ifp->info;
-		svi_if_link = if_lookup_by_index_per_ns(
-			zebra_ns_lookup(NS_DEFAULT), svi_if_zif->link_ifindex);
-		if (svi_if_zif && svi_if_link)
-			zvni = zvni_from_svi(ifp, svi_if_link);
+		if (svi_if_zif) {
+			svi_if_link = if_lookup_by_index_per_ns(
+				zebra_ns_lookup(NS_DEFAULT), svi_if_zif->link_ifindex);
+			if (svi_if_link)
+				zvni = zvni_from_svi(ifp, svi_if_link);
+		}
 	} else if (IS_ZEBRA_IF_BRIDGE(ifp)) {
 		zvni = zvni_from_svi(ifp, ifp);
 	}


### PR DESCRIPTION
[zebra/zebra_vxlan.c:5779] -> [zebra/zebra_vxlan.c:5778]:
(warning) Either the condition 'if(svi_if_zif&&svi_if_link)'
is redundant or there is possible null pointer dereference: svi_if_zif.