### PR TITLE
Fix pathspace option -N

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -531,12 +531,12 @@ struct thread_master *frr_init(void)
 		snprintf(p_instance, sizeof(p_instance), "-%d", di->instance);
 	}
 	if (di->pathspace)
-		snprintf(p_pathspace, sizeof(p_pathspace), "/%s",
+		snprintf(p_pathspace, sizeof(p_pathspace), "%s/",
 			 di->pathspace);
 
 	snprintf(config_default, sizeof(config_default), "%s%s%s%s.conf",
 		 frr_sysconfdir, p_pathspace, di->name, p_instance);
-	snprintf(pidfile_default, sizeof(pidfile_default), "%s%s/%s%s.pid",
+	snprintf(pidfile_default, sizeof(pidfile_default), "%s/%s%s%s.pid",
 		 frr_vtydir, p_pathspace, di->name, p_instance);
 
 	zprivs_preinit(di->privs);

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -306,6 +306,7 @@ int main(int argc, char **argv, char **env)
 	char *homedir = NULL;
 	int ditch_suid = 0;
 	char sysconfdir[MAXPATHLEN];
+	const char *pathspace_arg = NULL;
 	char pathspace[MAXPATHLEN] = "";
 
 	/* SUID: drop down to calling user & go back up when needed */
@@ -363,7 +364,8 @@ int main(int argc, char **argv, char **env)
 					"slashes or dots are not permitted in the --pathspace option.\n");
 				exit(1);
 			}
-			snprintf(pathspace, sizeof(pathspace), "/%s", optarg);
+			pathspace_arg = optarg;
+			snprintf(pathspace, sizeof(pathspace), "%s/", optarg);
 			break;
 		case 'd':
 			daemon_name = optarg;
@@ -419,7 +421,11 @@ int main(int argc, char **argv, char **env)
 		 pathspace, VTYSH_CONFIG_NAME);
 	snprintf(frr_config, sizeof(frr_config), "%s%s%s", sysconfdir,
 		 pathspace, FRR_CONFIG_NAME);
-	strlcat(vtydir, pathspace, sizeof(vtydir));
+
+	if (pathspace_arg) {
+		strlcat(vtydir, "/", sizeof(vtydir));
+		strlcat(vtydir, pathspace_arg, sizeof(vtydir));
+	}
 
 	/* Initialize user input buffer. */
 	line_read = NULL;


### PR DESCRIPTION
FRRouting daemons provide a pathspace option -N to unshare their filesystem related objects.
This is done by putting them in a subdirectory according to pathspace.

However, the option was broken, and this PR should be fixing it.