### PR TITLE
tools: frr-reload must consider "exit-vrf" as an equivalent to "end"

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -403,7 +403,7 @@ end
                 self.save_contexts(ctx_keys, current_context_lines)
                 new_ctx = True
 
-            elif line == "end":
+            elif line in ("end", "exit-vrf"):
                 self.save_contexts(ctx_keys, current_context_lines)
                 log.debug('LINE %-50s: exiting old context, %-50s', line, ctx_keys)
 


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>