### PR TITLE
ospf6d: router-id change to display msg to restart

### DIFF
--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -193,8 +193,9 @@ static void ospf6_neighbor_state_change(uint8_t next_state,
 
 		OSPF6_INTRA_PREFIX_LSA_SCHEDULE_STUB(on->ospf6_if->area);
 
-		if (prev_state == OSPF6_NEIGHBOR_LOADING
-		    && next_state == OSPF6_NEIGHBOR_FULL) {
+		if ((prev_state == OSPF6_NEIGHBOR_LOADING ||
+		     prev_state == OSPF6_NEIGHBOR_EXCHANGE) &&
+		    next_state == OSPF6_NEIGHBOR_FULL) {
 			OSPF6_AS_EXTERN_LSA_SCHEDULE(on->ospf6_if);
 			on->ospf6_if->area->full_nbrs++;
 		}


### PR DESCRIPTION
When neighbor state transition from LOADING to FULL state, active full neighbors count incremented.
The full neighbors count is used for router-id change if any full neighbor exist, displays message to restart ospf6/frr to activate new router-id.

In the case of P-t-P neighbor type neighbor transition
from EXCHANGE to FULL which missed full neighbors count.

 384                 if (oa->full_nbrs) {
 385                         vty_out(vty,
 386                                 "**For this router-id change to take effect,  save config and restart ospf6d**\n");
 388                         return CMD_SUCCESS;
 389                 }


Testing Done:
Initially, Bring up zebra assigned router-id in ospf6
with point-to-point link based neighbor.
Configure static router-id where restart of ospf6 message
is displayed.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>