### PR TITLE
redristribute and access list 

### DIFF
--- a/lib/route_types.pl
+++ b/lib/route_types.pl
@@ -54,15 +54,15 @@ while (<STDIN>) {
 
 	$_ =~ s/\s*,\s*/,/g;
 
-	# else: 7-field line
+	# else: 8-field line
 	my @f = split(/,/, $_);
-	unless (@f == 7 || @f == 8) {
+	unless (@f == 8 || @f == 9) {
 		die "invalid input on route_types line $.\n";
 	}
 
 	my $proto = $f[0];
 	$f[3] = $1 if ($f[3] =~ /^'(.*)'$/);
-	$f[6] = $1 if ($f[6] =~ /^"(.*)"$/);
+	$f[7] = $1 if ($f[7] =~ /^"(.*)"$/);
 
 	$protodetail{$proto} = {
 		"number" => scalar @protos,
@@ -72,8 +72,9 @@ while (<STDIN>) {
 		"char" => $f[3],
 		"ipv4" => int($f[4]),
 		"ipv6" => int($f[5]),
-		"shorthelp" => $f[6],
-		"restrict2" => $f[7],
+		"redist" => int($f[6]),
+		"shorthelp" => $f[7],
+		"restrict2" => $f[8],
 	};
 	push @protos, $proto;
 	$daemons{$f[2]} = {
@@ -136,8 +137,9 @@ sub collect {
 		next if ($protodetail{$p}->{"daemon"} eq $daemon && $daemon ne "zebra");
 		next if ($protodetail{$p}->{"restrict2"} ne "" && 
 		         $protodetail{$p}->{"restrict2"} ne $daemon);
+		next if ($protodetail{$p}->{"redist"} eq 0);
 		next unless (($ipv4 && $protodetail{$p}->{"ipv4"})
-				|| ($ipv6 && $protodetail{$p}->{"ipv6"}));
+			     || ($ipv6 && $protodetail{$p}->{"ipv6"}));
 		push @names, $protodetail{$p}->{"cname"};
 		push @help, "  \"".$protodetail{$p}->{"longhelp"}."\\n\"";
 	}

--- a/lib/route_types.txt
+++ b/lib/route_types.txt
@@ -7,8 +7,8 @@
 # Lines /beginning/ with # are comments.
 #
 ####
-# 7 field line has format:
-# ZServ route type, canonical name, daemon, route char, ipv4, ipv6, short desc
+# 9 field line has format:
+# ZServ route type, canonical name, daemon, route char, ipv4, ipv6, redist, short desc, Restrictions
 #
 # Zserv route type: 	Corresponding with zebra.h. Key field.
 # canonical name:	Typically derived from the route type definition.
@@ -25,9 +25,11 @@
 #			'X' is reserved as the 'not needed' placeholder.
 # ipv4:			IPv4 capable? yes/no, or 1/0.
 # ipv6:			IPv6 capable? ditto.
+# redist:               Allow this protocol to be used in redistribution statements
 # short desc:		Very brief description. Used in header of
 #			'show ip route'. May be specified as NULL
 #			if the canonical name suffices.
+# Restriction:          If this cannot be used with the listed protocol for redistribution events
 #
 # Key fields obviously must be a unique ASCII alpha-numeric word.
 #   Lower-case is required, brevity is optional but highly desirable.
@@ -43,43 +45,43 @@
 # If you add a new routing protocol here, make sure you also update
 # meta_queue_map in zebra_rib.c
 #
-##  type                cname      daemon  C    4  6  short help
-ZEBRA_ROUTE_SYSTEM,     system,    NULL,   'X', 0, 0, "Reserved"
-ZEBRA_ROUTE_KERNEL,     kernel,    zebra,  'K', 1, 1, "kernel route"
-ZEBRA_ROUTE_CONNECT,    connected, zebra,  'C', 1, 1, "connected"
-ZEBRA_ROUTE_STATIC,     static,    zebra,  'S', 1, 1, "static"
-ZEBRA_ROUTE_RIP,        rip,       ripd,   'R', 1, 0, "RIP"
-ZEBRA_ROUTE_RIPNG,      ripng,     ripngd, 'R', 0, 1, "RIPng"
-ZEBRA_ROUTE_OSPF,       ospf,      ospfd,  'O', 1, 0, "OSPF"
-ZEBRA_ROUTE_OSPF6,      ospf6,     ospf6d, 'O', 0, 1, "OSPFv3"
-ZEBRA_ROUTE_ISIS,       isis,      isisd,  'I', 1, 1, "IS-IS"
-ZEBRA_ROUTE_BGP,        bgp,       bgpd,   'B', 1, 1, "BGP"
-ZEBRA_ROUTE_PIM,	pim,	   pimd,   'P', 1, 0, "PIM"
-ZEBRA_ROUTE_EIGRP,      eigrp,     eigrpd, 'E', 1, 0, "EIGRP"
-ZEBRA_ROUTE_NHRP,       nhrp,      nhrpd,  'N', 1, 1, "NHRP"
+##  type                cname      daemon  C    4  6  Redist short help  Restrictions
+ZEBRA_ROUTE_SYSTEM,     system,    NULL,   'X', 0, 0, 0,     "Reserved"
+ZEBRA_ROUTE_KERNEL,     kernel,    zebra,  'K', 1, 1, 1,     "kernel route"
+ZEBRA_ROUTE_CONNECT,    connected, zebra,  'C', 1, 1, 1,     "connected"
+ZEBRA_ROUTE_STATIC,     static,    zebra,  'S', 1, 1, 1,     "static"
+ZEBRA_ROUTE_RIP,        rip,       ripd,   'R', 1, 0, 1,     "RIP"
+ZEBRA_ROUTE_RIPNG,      ripng,     ripngd, 'R', 0, 1, 1,     "RIPng"
+ZEBRA_ROUTE_OSPF,       ospf,      ospfd,  'O', 1, 0, 1,     "OSPF"
+ZEBRA_ROUTE_OSPF6,      ospf6,     ospf6d, 'O', 0, 1, 1,     "OSPFv3"
+ZEBRA_ROUTE_ISIS,       isis,      isisd,  'I', 1, 1, 1,     "IS-IS"
+ZEBRA_ROUTE_BGP,        bgp,       bgpd,   'B', 1, 1, 1,     "BGP"
+ZEBRA_ROUTE_PIM,	pim,	   pimd,   'P', 0, 0, 0,     "PIM"
+ZEBRA_ROUTE_EIGRP,      eigrp,     eigrpd, 'E', 1, 0, 1,     "EIGRP"
+ZEBRA_ROUTE_NHRP,       nhrp,      nhrpd,  'N', 1, 1, 1,     "NHRP"
 # HSLS and OLSR both are AFI independent (so: 1, 1), however
 # we want to disable for them for general Quagga distribution.
 # This at least makes it trivial for users of these protocols
 # to 'switch on' redist support (direct numeric entry remaining
 # possible).
-ZEBRA_ROUTE_HSLS,       hsls,      hslsd,  'H', 0, 0, "HSLS"
-ZEBRA_ROUTE_OLSR,       olsr,      olsrd,  'o', 0, 0, "OLSR"
-ZEBRA_ROUTE_TABLE,      table,     zebra,  'T', 1, 1, "Table"
-ZEBRA_ROUTE_LDP,        ldp,       ldpd,   'L', 0, 0, "LDP"
+ZEBRA_ROUTE_HSLS,       hsls,      hslsd,  'H', 0, 0, 0,     "HSLS"
+ZEBRA_ROUTE_OLSR,       olsr,      olsrd,  'o', 0, 0, 0,     "OLSR"
+ZEBRA_ROUTE_TABLE,      table,     zebra,  'T', 1, 1, 1,     "Table"
+ZEBRA_ROUTE_LDP,        ldp,       ldpd,   'L', 0, 0, 0,     "LDP"
 #vnc when sent to zebra 
-ZEBRA_ROUTE_VNC,        vnc,       NULL,   'v', 1, 1, "VNC"
+ZEBRA_ROUTE_VNC,        vnc,       NULL,   'v', 1, 1, 1,     "VNC"
 # vnc when sent to bgp
-ZEBRA_ROUTE_VNC_DIRECT, vnc-direct,NULL,   'V', 1, 1, "VNC-Direct", bgpd
+ZEBRA_ROUTE_VNC_DIRECT, vnc-direct,NULL,   'V', 1, 1, 1,     "VNC-Direct", bgpd
 # vnc when sent to bgp (resolve NVE mode)
-ZEBRA_ROUTE_VNC_DIRECT_RH, vnc-rn, NULL,   'V', 0, 0, "VNC-RN"
+ZEBRA_ROUTE_VNC_DIRECT_RH, vnc-rn, NULL,   'V', 0, 0, 0,     "VNC-RN"
 #  bgp unicast -> vnc 
-ZEBRA_ROUTE_BGP_DIRECT, bgp-direct, NULL,  'b', 0, 0, "BGP-Direct"
+ZEBRA_ROUTE_BGP_DIRECT, bgp-direct, NULL,  'b', 0, 0, 0,     "BGP-Direct"
 #  bgp unicast -> vnc 
-ZEBRA_ROUTE_BGP_DIRECT_EXT, bgp-direct-to-nve-groups, NULL, 'e', 0, 0, "BGP2VNC"
-ZEBRA_ROUTE_BABEL,      babel,     babeld, 'A', 1, 1, "Babel"
-ZEBRA_ROUTE_SHARP,    sharp,     sharpd, 'D', 1, 1, "SHARP"
-ZEBRA_ROUTE_PBR,      pbr,       pbrd, 'F', 1, 1, "PBR"
-ZEBRA_ROUTE_ALL,        wildcard,  none,   '-', 0, 0, "-"
+ZEBRA_ROUTE_BGP_DIRECT_EXT, bgp-direct-to-nve-groups, NULL, 'e', 0, 0, 0, "BGP2VNC"
+ZEBRA_ROUTE_BABEL,      babel,     babeld, 'A', 1, 1, 1,     "Babel"
+ZEBRA_ROUTE_SHARP,      sharp,     sharpd, 'D', 1, 1, 1,     "SHARP"
+ZEBRA_ROUTE_PBR,        pbr,       pbrd,   'F', 1, 1, 0,     "PBR"
+ZEBRA_ROUTE_ALL,        wildcard,  none,   '-', 0, 0, 0,     "-"
 
 
 ## help strings

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -152,6 +152,11 @@ int main(int argc, char **argv, char **envp)
 			   pbr_nhgroup_del_nexthop_cb,
 			   pbr_nhgroup_delete_cb);
 
+	/*
+	 * So we safely ignore these commands since
+	 * we are getting them at this point in time
+	 */
+	access_list_init();
 	pbr_nht_init();
 	pbr_map_init();
 	pbr_zebra_init();


### PR DESCRIPTION
1) The redistribution command was setting up pbr and pim as valid redistribution targets, modify the route_types.pl and the route_types.txt files to now be a bit smarter about what a valid redistribution event is. 

2) Allow PBR to gracefully understand access-list commands