### PR TITLE
zebra: Fix crash with certain types of tunnels

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -519,12 +519,18 @@ void connected_add_ipv6(struct interface *ifp, int flags, struct in6_addr *addr,
 	p->prefixlen = prefixlen;
 	ifc->address = (struct prefix *)p;
 
-	if (CHECK_FLAG(ifc->flags, ZEBRA_IFA_PEER)) {
+	if (broad) {
 		p = prefix_ipv6_new();
 		p->family = AF_INET6;
 		IPV6_ADDR_COPY(&p->prefix, broad);
 		p->prefixlen = prefixlen;
 		ifc->destination = (struct prefix *)p;
+	} else {
+		if (CHECK_FLAG(ifc->flags, ZEBRA_IFA_PEER)) {
+			zlog_warn("warning: %s called for interface %s with peer flag set, but no peer address supplied",
+				  __func__, ifp->name);
+			UNSET_FLAG(ifc->flags, ZEBRA_IFA_PEER);
+		}
 	}
 
 	/* Label of this address. */

--- a/zebra/connected.h
+++ b/zebra/connected.h
@@ -42,10 +42,11 @@ extern void connected_up(struct interface *ifp, struct connected *ifc);
 extern void connected_down(struct interface *ifp, struct connected *ifc);
 
 extern void connected_add_ipv6(struct interface *ifp, int flags,
-			       struct in6_addr *address, uint8_t prefixlen,
-			       const char *label);
+			       struct in6_addr *address, struct in6_addr *broad,
+			       uint8_t prefixlen, const char *label);
 extern void connected_delete_ipv6(struct interface *ifp,
-				  struct in6_addr *address, uint8_t prefixlen);
+				  struct in6_addr *address,
+				  struct in6_addr *broad, uint8_t prefixlen);
 
 extern int connected_is_unnumbered(struct interface *);
 

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -249,7 +249,7 @@ static int if_getaddrs(void)
 			}
 #endif
 
-			connected_add_ipv6(ifp, flags, &addr->sin6_addr,
+			connected_add_ipv6(ifp, flags, &addr->sin6_addr, NULL,
 					   prefixlen, NULL);
 		}
 	}

--- a/zebra/if_ioctl_solaris.c
+++ b/zebra/if_ioctl_solaris.c
@@ -315,7 +315,7 @@ static int if_get_addr(struct interface *ifp, struct sockaddr *addr,
 		connected_add_ipv4(ifp, flags, &SIN(addr)->sin_addr, prefixlen,
 				   (struct in_addr *)dest_pnt, label);
 	else if (af == AF_INET6)
-		connected_add_ipv6(ifp, flags, &SIN6(addr)->sin6_addr,
+		connected_add_ipv6(ifp, flags, &SIN6(addr)->sin6_addr, NULL,
 				   prefixlen, label);
 
 	return 0;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1006,9 +1006,11 @@ int netlink_interface_addr(struct sockaddr_nl *snl, struct nlmsghdr *h,
 			      & (IFA_F_DADFAILED | IFA_F_TENTATIVE)))
 				connected_add_ipv6(ifp, flags,
 						   (struct in6_addr *)addr,
+						   (struct in6_addr *)broad,
 						   ifa->ifa_prefixlen, label);
 		} else
 			connected_delete_ipv6(ifp, (struct in6_addr *)addr,
+					      (struct in6_addr *)broad,
 					      ifa->ifa_prefixlen);
 	}
 

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -771,10 +771,11 @@ int ifam_read(struct ifa_msghdr *ifam)
 
 		if (ifam->ifam_type == RTM_NEWADDR)
 			connected_add_ipv6(ifp, flags, &addr.sin6.sin6_addr,
+					   NULL,
 					   ip6_masklen(mask.sin6.sin6_addr),
 					   (isalias ? ifname : NULL));
 		else
-			connected_delete_ipv6(ifp, &addr.sin6.sin6_addr,
+			connected_delete_ipv6(ifp, &addr.sin6.sin6_addr, NULL,
 					      ip6_masklen(mask.sin6.sin6_addr));
 		break;
 	default:


### PR DESCRIPTION
Zebra did not have a handler for tunnels in v6 for
some reason.  Add code to handle the broadcast address
for both addition and deletion.

This appears to fix the crash.  There might still need
to be some work to make the code `work` properly for
this type of tunnel.

Fixes: #2063
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>