### PR TITLE
zebra: Leave some warning breadcrumbs

### DIFF
--- a/zebra/zebra_static.c
+++ b/zebra/zebra_static.c
@@ -516,7 +516,9 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 		if (ifp && ifp->ifindex != IFINDEX_INTERNAL) {
 			si->ifindex = ifp->ifindex;
 			static_install_route(afi, safi, p, src_p, si);
-		}
+		} else
+			zlog_warn("Static Route using %s interface not installed because the interface does not exist in specified vrf",
+				  ifname);
 	}
 
 	return 1;

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -207,6 +207,9 @@ static int zebra_static_route_holdem(
 	struct static_hold_route *shr, *lookup;
 	struct listnode *node;
 
+	zlog_warn("Static Route to %s not installed currently because dependent config not fully available",
+		  dest_str);
+
 	shr = XCALLOC(MTYPE_STATIC_ROUTE, sizeof(*shr));
 	shr->vrf_name = XSTRDUP(MTYPE_STATIC_ROUTE, zvrf->vrf->name);
 	shr->nhvrf_name = XSTRDUP(MTYPE_STATIC_ROUTE, nh_zvrf->vrf->name);


### PR DESCRIPTION
When a user specifies static routes, there are a couple of states
where we will store the route and display it as part of the 'show run'
but it will not be installed until such time that the dependant state
is created.  Add some breadcrumbs to the user so that they can figure
out WTF just happened.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>