### PR TITLE
zebra: fix flaw in fix for import-table crash

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -531,7 +531,7 @@ int zebra_add_import_table_entry(struct route_node *rn, struct route_entry *re,
 			re->tag, rmap_name);
 
 	if (ret != RMAP_MATCH) {
-		UNSET_FLAG(same->flags, ZEBRA_FLAG_SELECTED);
+		UNSET_FLAG(re->flags, ZEBRA_FLAG_SELECTED);
 		zebra_del_import_table_entry(rn, re);
 		return 0;
 	}


### PR DESCRIPTION
Realized (with coverity's help) the fix had a mistake by pasting in
the wrong route entry to unset the selected flag.  This fix takes
care of that mistake.

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>