### PR TITLE
Always explicitly exit vrf contexts

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -671,8 +671,6 @@ int vtysh_mark_file(const char *filename)
 			} else if ((prev_node == BGP_EVPN_VNI_NODE)
 				   && (tried == 1)) {
 				fprintf(outputfile, "exit-vni\n");
-			} else if (prev_node == VRF_NODE && (tried == 1)) {
-				fprintf(outputfile, "exit-vrf\n");
 			} else if ((prev_node == KEYCHAIN_KEY_NODE)
 				   && (tried == 1)) {
 				fprintf(outputfile, "exit\n");

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -671,7 +671,7 @@ int vtysh_mark_file(const char *filename)
 			} else if ((prev_node == BGP_EVPN_VNI_NODE)
 				   && (tried == 1)) {
 				fprintf(outputfile, "exit-vni\n");
-			} else if (prev_node == VRF_NODE) {
+			} else if (prev_node == VRF_NODE && (tried == 1)) {
 				fprintf(outputfile, "exit-vrf\n");
 			} else if ((prev_node == KEYCHAIN_KEY_NODE)
 				   && (tried == 1)) {

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -185,6 +185,12 @@ void vtysh_config_parse_line(void *arg, const char *line)
 					      == 0) {
 				config_add_line(config->line, line);
 				config->index = INTERFACE_NODE;
+			} else if (config->index == VRF_NODE
+				   && strncmp(line, " exit-vrf",
+					      strlen(" exit-vrf"))
+					      == 0) {
+				config_add_line(config->line, line);
+				config->index = CONFIG_NODE;
 			} else if (config->index == RMAP_NODE
 				   || config->index == INTERFACE_NODE
 				   || config->index == LOGICALROUTER_NODE

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -524,10 +524,8 @@ static int vrf_config_write(struct vty *vty)
 			if (zvrf->l3vni)
 				vty_out(vty, "vni %u\n", zvrf->l3vni);
 			vty_out(vty, "!\n");
-		}
-
-		if (vrf_is_user_cfged(vrf)) {
-			vty_out(vty, "vrf %s\n", zvrf_name(zvrf));
+		} else {
+			vty_frame(vty, "vrf %s\n", zvrf_name(zvrf));
 			if (zvrf->l3vni)
 				vty_out(vty, " vni %u%s\n", zvrf->l3vni,
 					is_l3vni_for_prefix_routes_only(
@@ -535,14 +533,15 @@ static int vrf_config_write(struct vty *vty)
 						? " prefix-routes-only"
 						: "");
 			zebra_ns_config_write(vty, (struct ns *)vrf->ns_ctxt);
+
 		}
 
 		static_config(vty, zvrf, AFI_IP, SAFI_UNICAST, "ip route");
 		static_config(vty, zvrf, AFI_IP, SAFI_MULTICAST, "ip mroute");
 		static_config(vty, zvrf, AFI_IP6, SAFI_UNICAST, "ipv6 route");
 
-		if (vrf->vrf_id != VRF_DEFAULT)
-			vty_out(vty, "!\n");
+		if (zvrf_id(zvrf) != VRF_DEFAULT)
+			vty_endframe(vty, " exit-vrf\n!\n");
 	}
 	return 0;
 }


### PR DESCRIPTION
VRF context blocks require an explicit `exit-vrf` statement to avoid visual confusion with top-level constructs. Example:
```
vrf blue
  ip route 1.2.3.0/24 blackhole
!
ip route 1.2.3.0/24 eth0
```
While it looks like the first static route is inside the VRF context and the second is not, both are inside it. While we can't stop users from writing their own configs like this, at least when we print them out there will be a very clear delimiter as to where the VRF context ends. In the above example, a show run would look like this:
```
vrf blue
  ip route 1.2.3.0/24 blackhole
  ip route 1.2.3.0/24 eth0
  exit-vrf
```
So while the user may be surprised at first, they can reason that moving their static route after the `exit-vrf` command should work.

Finally this fixes the ambiguity introduced when a user configures all of this from VTY and then writes it, resulting in the context clashes; this was an actual bug.