### PR TITLE
configure: allow to override CC to compile clippy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,8 @@ AS_IF([test "$host" != "$build"], [
   ( CPPFLAGS="$HOST_CPPFLAGS"; \
     CFLAGS="$HOST_CFLAGS"; \
     LDFLAGS="$HOST_LDFLAGS"; \
+    CC="$HOST_CC"; \
+    LD="$HOST_LD"; \
     cd hosttools; "${abssrc}/configure" "--host=$build" "--build=$build" "--enable-clippy-only" "--disable-nhrpd" "--disable-vtysh"; )
 
   AC_MSG_NOTICE([...])


### PR DESCRIPTION
The compiler CC might be set in a cross compilation environment.
Let the user override the compiler for the host so that it can
be set to native compiler to build clippy.

Signed-off-by: Jean-Mickael Guerin <jean-mickael.guerin@6wind.com>