### PR TITLE
zebra: Add pass up through zapi what zebra is capable of handling

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2480,6 +2480,25 @@ void zebra_read_pw_status_update(int command, struct zclient *zclient,
 	pw->status = stream_getl(s);
 }
 
+static void zclient_capability_decode(int command, struct zclient *zclient,
+				      zebra_size_t length, vrf_id_t vrf_id)
+{
+	struct zclient_capabilities cap;
+	struct stream *s = zclient->ibuf;
+	uint8_t mpls_enabled;
+
+	memset(&cap, 0, sizeof(cap));
+	STREAM_GETC(s, mpls_enabled);
+	cap.mpls_enabled = !!mpls_enabled;
+	STREAM_GETL(s, cap.ecmp);
+
+	if (zclient->zebra_capabilities)
+		(*zclient->zebra_capabilities)(&cap);
+
+stream_failure:
+	return;
+}
+
 /* Zebra client message read function. */
 static int zclient_read(struct thread *thread)
 {
@@ -2577,6 +2596,9 @@ static int zclient_read(struct thread *thread)
 			   (void *)zclient, command, vrf_id);
 
 	switch (command) {
+	case ZEBRA_CAPABILITIES:
+		zclient_capability_decode(command, zclient, length, vrf_id);
+		break;
 	case ZEBRA_ROUTER_ID_UPDATE:
 		if (zclient->router_id_update)
 			(*zclient->router_id_update)(command, zclient, length,

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -85,6 +85,7 @@ typedef enum {
 	ZEBRA_ROUTER_ID_DELETE,
 	ZEBRA_ROUTER_ID_UPDATE,
 	ZEBRA_HELLO,
+	ZEBRA_CAPABILITIES,
 	ZEBRA_NEXTHOP_REGISTER,
 	ZEBRA_NEXTHOP_UNREGISTER,
 	ZEBRA_NEXTHOP_UPDATE,
@@ -162,6 +163,11 @@ struct redist_proto {
 	struct list *instances;
 };
 
+struct zclient_capabilities {
+	uint32_t ecmp;
+	bool mpls_enabled;
+};
+
 /* Structure for the zebra client. */
 struct zclient {
 	/* The thread master we schedule ourselves on */
@@ -206,6 +212,7 @@ struct zclient {
 
 	/* Pointer to the callback functions. */
 	void (*zebra_connected)(struct zclient *);
+	void (*zebra_capabilities)(struct zclient_capabilities *cap);
 	int (*router_id_update)(int, struct zclient *, uint16_t, vrf_id_t);
 	int (*interface_add)(int, struct zclient *, uint16_t, vrf_id_t);
 	int (*interface_delete)(int, struct zclient *, uint16_t, vrf_id_t);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -2148,6 +2148,18 @@ static void zread_router_id_delete(ZAPI_HANDLER_ARGS)
 	vrf_bitmap_unset(client->ridinfo, zvrf_id(zvrf));
 }
 
+static void zsend_capabilities(struct zserv *client, struct zebra_vrf *zvrf)
+{
+	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+
+	zclient_create_header(s, ZEBRA_CAPABILITIES, zvrf->vrf->vrf_id);
+	stream_putc(s, mpls_enabled);
+	stream_putl(s, multipath_num);
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+	zebra_server_send_message(client, s);
+}
+
 /* Tie up route-type and client->sock */
 static void zread_hello(ZAPI_HANDLER_ARGS)
 {
@@ -2175,6 +2187,7 @@ static void zread_hello(ZAPI_HANDLER_ARGS)
 		client->instance = instance;
 	}
 
+	zsend_capabilities(client, zvrf);
 stream_failure:
 	return;
 }


### PR DESCRIPTION
Zebra is starting to have some run-time capabilites that would be
useful to pass up to the higher level protocols so that they
can act in an appropriate manner when needed.

Send the ecmp value zebra is being run with and whether or not
we believe mpls is enabled in the kernel or not.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>