### PR TITLE
resolve possible null pointer dereference

### DIFF
--- a/isisd/dict.c
+++ b/isisd/dict.c
@@ -1323,9 +1323,8 @@ static void construct(dict_t *d)
 				free(val);
 				if (dn)
 					dnode_destroy(dn);
-			}
-
-			dict_load_next(&dl, dn, key);
+			} else
+				dict_load_next(&dl, dn, key);
 			break;
 		default:
 			putchar('?');


### PR DESCRIPTION
issue found by cppcheck

[isisd/dict.c:1320] -> [isisd/dict.c:1065]:
(warning) Either the condition '!dn' is redundant or
there is possible null pointer dereference: newnode.

[isisd/dict.c:1320] -> [isisd/dict.c:1068]:
(warning) Either the condition '!dn' is redundant or
there is possible null pointer dereference: newnode.

Signed-off-by: Ilya Shipitsin <chipitsine@gmail.com>