### PR TITLE
bgpd: bugfix: vpn-vrf leak: set origin bgp to origin vrf for vrf-vpn-vrf

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -999,6 +999,7 @@ static void vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,       /* to */
 	int nexthop_self_flag = 1;
 	struct bgp_info *bi_ultimate = NULL;
 	int origin_local = 0;
+	struct bgp *src_vrf;
 
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_TO_VRF);
 
@@ -1131,10 +1132,15 @@ static void vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,       /* to */
 			   num_labels);
 	}
 
+	if (info_vpn->extra && info_vpn->extra->bgp_orig)
+		src_vrf = info_vpn->extra->bgp_orig;
+	else
+		src_vrf = bgp_vpn;
+
 	leak_update(bgp_vrf, bn, new_attr, afi, safi, info_vpn,
 		pLabels, num_labels,
 		info_vpn, /* parent */
-		bgp_vpn, &nexthop_orig, nexthop_self_flag, debug);
+		src_vrf, &nexthop_orig, nexthop_self_flag, debug);
 }
 
 void vpn_leak_to_vrf_update(struct bgp *bgp_vpn,       /* from */


### PR DESCRIPTION
bgp route extra->bgp_orig for routes leaked vpn->vrf should be set
to original extra->bgp_orig if it is set, not vpn's bgp instance.

The initial leak is OK because it goes through a loopback path
in the vrf->vpn leaking code, but it is possible later re-leaks (e.g.,
if the destination vrf's leak configuration is changed) could
set the wrong extra->bgp_orig and break the route's nexthop.