### PR TITLE
lib: table.h needs to include prefix.h

### DIFF
--- a/lib/table.h
+++ b/lib/table.h
@@ -24,6 +24,7 @@
 
 #include "memory.h"
 #include "hash.h"
+#include "prefix.h"
 DECLARE_MTYPE(ROUTE_TABLE)
 DECLARE_MTYPE(ROUTE_NODE)
 


### PR DESCRIPTION
For the last six years this source file has been using a type defined in
a header it did not include.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>