### PR TITLE
frrzmq: properly init args to zmq_getsockopt()

### DIFF
--- a/lib/frr_zmq.c
+++ b/lib/frr_zmq.c
@@ -338,6 +338,7 @@ void frrzmq_check_events(struct frrzmq_cb **cbp, struct cb_core *core,
 	if (!cb || !cb->zmqsock)
 		return;
 
+	len = sizeof(events);
 	if (zmq_getsockopt(cb->zmqsock, ZMQ_EVENTS, &events, &len))
 		return;
 	if (events & event && core->thread && !core->cancelled) {


### PR DESCRIPTION
zmq read events get lost if zmq_getsockopt() silently fails in
frrzmq_check_events().

Signed-off-by: Mark Stapp <mjs@voltanet.io>