### PR TITLE
lib: fix heap corruption in stream_fifo_free

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -1113,6 +1113,7 @@ void stream_fifo_push(struct stream_fifo *fifo, struct stream *s)
 		fifo->head = s;
 
 	fifo->tail = s;
+	fifo->tail->next = NULL;
 
 	fifo->count++;
 }
@@ -1131,6 +1132,9 @@ struct stream *stream_fifo_pop(struct stream_fifo *fifo)
 			fifo->tail = NULL;
 
 		fifo->count--;
+
+		/* ensure stream is scrubbed of references to this fifo */
+		s->next = NULL;
 	}
 
 	return s;


### PR DESCRIPTION
When popping a stream from a stream_fifo, the stream->next pointer is
not NULL'd out. If this same stream is subsequently pushed onto a
stream_fifo (either the same one or a different one), because
stream_fifo's use tail insertion the ->next pointer is not updated and
thus will point to whatever the next stream in the first stream_fifo
was. stream_fifo_free does not check the count of the stream_fifo when
freeing its constituent elements, and instead walks the linked list.
Consequently it will continue walking into the first stream_fifo from
which the last stream was popped, freeing each stream contained there.
This leads to use-after-free errors.

This patch makes sure to set the ->next pointer to NULL when doing tail
insertion in stream_fifo_push and when popping a stream from a
stream_fifo in stream_fifo_pop.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>