### PR TITLE
Multithreaded Zserv

### DIFF
--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -350,7 +350,7 @@ void label_manager_init(char *lm_zserv_path)
 
 	obuf = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	hook_register(zapi_client_close, release_daemon_label_chunks);
+	hook_register(zserv_client_close, release_daemon_label_chunks);
 }
 
 /**

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -99,7 +99,7 @@ static int relay_response_back(void)
 	proto_str = zebra_route_string(proto);
 
 	/* lookup the client to relay the msg to */
-	zserv = zebra_find_client(proto, instance);
+	zserv = zserv_find_client(proto, instance);
 	if (!zserv) {
 		zlog_err(
 			"Error relaying LM response: can't find client %s, instance %u",

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -37,6 +37,7 @@
 #include "logicalrouter.h"
 #include "libfrr.h"
 #include "routemap.h"
+#include "frr_pthread.h"
 
 #include "zebra/rib.h"
 #include "zebra/zserv.h"
@@ -377,6 +378,8 @@ int main(int argc, char **argv)
 
 	/* Needed for BSD routing socket. */
 	pid = getpid();
+
+	frr_pthread_init();
 
 	/* This must be done only after locking pidfile (bug #403). */
 	zebra_zserv_socket_init(zserv_path);

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -379,10 +379,11 @@ int main(int argc, char **argv)
 	/* Needed for BSD routing socket. */
 	pid = getpid();
 
+	/* Intialize pthread library */
 	frr_pthread_init();
 
-	/* This must be done only after locking pidfile (bug #403). */
-	zebra_zserv_socket_init(zserv_path);
+	/* Start Zebra API server */
+	zserv_start(zserv_path);
 
 	/* Init label manager */
 	label_manager_init(lblmgr_path);

--- a/zebra/table_manager.c
+++ b/zebra/table_manager.c
@@ -78,7 +78,7 @@ void table_manager_enable(ns_id_t ns_id)
 		return;
 	tbl_mgr.lc_list = list_new();
 	tbl_mgr.lc_list->del = delete_table_chunk;
-	hook_register(zapi_client_close, release_daemon_table_chunks);
+	hook_register(zserv_client_close, release_daemon_table_chunks);
 }
 
 /**

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -162,7 +162,7 @@ int zsend_interface_add(struct zserv *client, struct interface *ifp)
 	zserv_encode_interface(s, ifp);
 
 	client->ifadd_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /* Interface deletion from zebra daemon. */
@@ -174,7 +174,7 @@ int zsend_interface_delete(struct zserv *client, struct interface *ifp)
 	zserv_encode_interface(s, ifp);
 
 	client->ifdel_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 int zsend_vrf_add(struct zserv *client, struct zebra_vrf *zvrf)
@@ -185,7 +185,7 @@ int zsend_vrf_add(struct zserv *client, struct zebra_vrf *zvrf)
 	zserv_encode_vrf(s, zvrf);
 
 	client->vrfadd_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /* VRF deletion from zebra daemon. */
@@ -198,7 +198,7 @@ int zsend_vrf_delete(struct zserv *client, struct zebra_vrf *zvrf)
 	zserv_encode_vrf(s, zvrf);
 
 	client->vrfdel_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
@@ -230,7 +230,7 @@ int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /* Interface address is added/deleted. Send ZEBRA_INTERFACE_ADDRESS_ADD or
@@ -309,7 +309,7 @@ int zsend_interface_address(int cmd, struct zserv *client,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->connected_rt_add_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 static int zsend_interface_nbr_address(int cmd, struct zserv *client,
@@ -340,7 +340,7 @@ static int zsend_interface_nbr_address(int cmd, struct zserv *client,
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /* Interface address addition. */
@@ -438,7 +438,7 @@ int zsend_interface_vrf_update(struct zserv *client, struct interface *ifp,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->if_vrfchg_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /* Add new nbr connected IPv6 address */
@@ -511,7 +511,7 @@ int zsend_interface_update(int cmd, struct zserv *client, struct interface *ifp)
 	else
 		client->ifdown_cnt++;
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 int zsend_redistribute_route(int cmd, struct zserv *client, struct prefix *p,
@@ -602,7 +602,7 @@ int zsend_redistribute_route(int cmd, struct zserv *client, struct prefix *p,
 			   zebra_route_string(api.type), api.vrf_id,
 			   buf_prefix);
 	}
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /*
@@ -655,7 +655,7 @@ static int zsend_ipv4_nexthop_lookup_mrib(struct zserv *client,
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 int zsend_route_notify_owner(struct route_entry *re, struct prefix *p,
@@ -665,7 +665,7 @@ int zsend_route_notify_owner(struct route_entry *re, struct prefix *p,
 	struct stream *s;
 	uint8_t blen;
 
-	client = zebra_find_client(re->type, re->instance);
+	client = zserv_find_client(re->type, re->instance);
 	if (!client || !client->notify_owner) {
 		if (IS_ZEBRA_DEBUG_PACKET) {
 			char buff[PREFIX_STRLEN];
@@ -703,7 +703,7 @@ int zsend_route_notify_owner(struct route_entry *re, struct prefix *p,
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 void zsend_rule_notify_owner(struct zebra_pbr_rule *rule,
@@ -739,7 +739,7 @@ void zsend_rule_notify_owner(struct zebra_pbr_rule *rule,
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	zebra_server_send_message(client, s);
+	zserv_send_message(client, s);
 }
 
 void zsend_ipset_notify_owner(struct zebra_pbr_ipset *ipset,
@@ -769,7 +769,7 @@ void zsend_ipset_notify_owner(struct zebra_pbr_ipset *ipset,
 	stream_put(s, ipset->ipset_name, ZEBRA_IPSET_NAME_SIZE);
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	zebra_server_send_message(client, s);
+	zserv_send_message(client, s);
 }
 
 void zsend_ipset_entry_notify_owner(struct zebra_pbr_ipset_entry *ipset,
@@ -799,7 +799,7 @@ void zsend_ipset_entry_notify_owner(struct zebra_pbr_ipset_entry *ipset,
 	stream_put(s, ipset->backpointer->ipset_name, ZEBRA_IPSET_NAME_SIZE);
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	zebra_server_send_message(client, s);
+	zserv_send_message(client, s);
 }
 
 void zsend_iptable_notify_owner(struct zebra_pbr_iptable *iptable,
@@ -828,7 +828,7 @@ void zsend_iptable_notify_owner(struct zebra_pbr_iptable *iptable,
 	stream_putl(s, iptable->unique);
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	zebra_server_send_message(client, s);
+	zserv_send_message(client, s);
 }
 
 /* Router-id is updated. Send ZEBRA_ROUTER_ID_ADD to client. */
@@ -855,7 +855,7 @@ int zsend_router_id_update(struct zserv *client, struct prefix *p,
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /*
@@ -873,7 +873,7 @@ int zsend_pw_update(struct zserv *client, struct zebra_pw *pw)
 	/* Put length at the first point of the stream. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /* Send response to a get label chunk request to client */
@@ -952,7 +952,7 @@ static int zsend_assign_table_chunk_response(struct zserv *client,
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 static int zsend_table_manager_connect_response(struct zserv *client,
@@ -968,7 +968,7 @@ static int zsend_table_manager_connect_response(struct zserv *client,
 
 	stream_putw_at(s, 0, stream_get_endp(s));
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /* Inbound message handling ------------------------------------------------ */
@@ -2194,7 +2194,7 @@ static void zsend_capabilities(struct zserv *client, struct zebra_vrf *zvrf)
 	stream_putl(s, multipath_num);
 
 	stream_putw_at(s, 0, stream_get_endp(s));
-	zebra_server_send_message(client, s);
+	zserv_send_message(client, s);
 }
 
 /* Tie up route-type and client->sock */

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3017,14 +3017,27 @@ void (*zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_IPTABLE_DELETE] = zread_iptable,
 };
 
-void zserv_handle_commands(struct zserv *client, struct zmsghdr *hdr,
-			   struct stream *msg, struct zebra_vrf *zvrf)
+void zserv_handle_commands(struct zserv *client, struct stream *msg)
 {
-	if (hdr->command > array_size(zserv_handlers)
-	    || zserv_handlers[hdr->command] == NULL)
-		zlog_info("Zebra received unknown command %d", hdr->command);
-	else
-		zserv_handlers[hdr->command](client, hdr, msg, zvrf);
+	struct zmsghdr hdr;
+	struct zebra_vrf *zvrf;
 
-	stream_free(msg);
+	zapi_parse_header(msg, &hdr);
+
+	hdr.length -= ZEBRA_HEADER_SIZE;
+
+	/* lookup vrf */
+	zvrf = zebra_vrf_lookup_by_id(hdr.vrf_id);
+	if (!zvrf) {
+		if (IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV)
+			zlog_warn("ZAPI message specifies unknown VRF: %d",
+				  hdr.vrf_id);
+		return;
+	}
+
+	if (hdr.command > array_size(zserv_handlers)
+	    || zserv_handlers[hdr.command] == NULL)
+		zlog_info("Zebra received unknown command %d", hdr.command);
+	else
+		zserv_handlers[hdr.command](client, &hdr, msg, zvrf);
 }

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -35,17 +35,10 @@
  * client
  *    the client datastructure
  *
- * hdr
- *    the message header
- *
  * msg
- *    the message contents, without the header
- *
- * zvrf
- *    the vrf
+ *    the message
  */
-extern void zserv_handle_commands(struct zserv *client, struct zmsghdr *hdr,
-				  struct stream *msg, struct zebra_vrf *zvrf);
+extern void zserv_handle_commands(struct zserv *client, struct stream *msg);
 
 extern int zsend_vrf_add(struct zserv *zclient, struct zebra_vrf *zvrf);
 extern int zsend_vrf_delete(struct zserv *zclient, struct zebra_vrf *zvrf);

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -463,7 +463,7 @@ static int fec_send(zebra_fec_t *fec, struct zserv *client)
 	stream_put_prefix(s, &rn->p);
 	stream_putl(s, fec->label);
 	stream_putw_at(s, 0, stream_get_endp(s));
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /*
@@ -2916,5 +2916,5 @@ void zebra_mpls_init(void)
 	if (!mpls_processq_init(&zebrad))
 		mpls_enabled = 1;
 
-	hook_register(zapi_client_close, zebra_mpls_cleanup_fecs_for_client);
+	hook_register(zserv_client_close, zebra_mpls_cleanup_fecs_for_client);
 }

--- a/zebra/zebra_mroute.c
+++ b/zebra/zebra_mroute.c
@@ -67,5 +67,5 @@ stream_failure:
 	stream_putl(s, suc);
 
 	stream_putw_at(s, 0, stream_get_endp(s));
-	zebra_server_send_message(client, s);
+	zserv_send_message(client, s);
 }

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -30,6 +30,7 @@
 #include "zebra/rt.h"
 #include "zebra/zapi_msg.h"
 #include "zebra/zebra_memory.h"
+#include "zebra/zserv.h"
 
 /* definitions */
 DEFINE_MTYPE_STATIC(ZEBRA, PBR_IPTABLE_IFNAME, "PBR interface list")
@@ -463,7 +464,7 @@ static int zebra_pbr_client_close_cleanup(struct zserv *client)
 
 void zebra_pbr_init(void)
 {
-	hook_register(zapi_client_close, zebra_pbr_client_close_cleanup);
+	hook_register(zserv_client_close, zebra_pbr_client_close_cleanup);
 }
 
 static void *pbr_ipset_alloc_intern(void *arg)

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -126,7 +126,7 @@ void zebra_ptm_init(void)
 
 	ptm_cb.ptm_sock = -1;
 
-	hook_register(zapi_client_close, zebra_ptm_bfd_client_deregister);
+	hook_register(zserv_client_close, zebra_ptm_bfd_client_deregister);
 }
 
 void zebra_ptm_finish(void)

--- a/zebra/zebra_ptm_redistribute.c
+++ b/zebra/zebra_ptm_redistribute.c
@@ -66,7 +66,7 @@ static int zsend_interface_bfd_update(int cmd, struct zserv *client,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->if_bfd_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 void zebra_interface_bfd_update(struct interface *ifp, struct prefix *dp,
@@ -101,7 +101,7 @@ static int zsend_bfd_peer_replay(int cmd, struct zserv *client)
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	client->bfd_peer_replay_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 void zebra_bfd_peer_replay_req(void)

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -292,7 +292,7 @@ void zebra_pw_init(struct zebra_vrf *zvrf)
 	RB_INIT(zebra_pw_head, &zvrf->pseudowires);
 	RB_INIT(zebra_static_pw_head, &zvrf->static_pseudowires);
 
-	hook_register(zapi_client_close, zebra_pw_client_close);
+	hook_register(zserv_client_close, zebra_pw_client_close);
 }
 
 void zebra_pw_exit(struct zebra_vrf *zvrf)

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -73,7 +73,7 @@ int zebra_rnh_ipv6_default_route = 0;
 
 void zebra_rnh_init(void)
 {
-	hook_register(zapi_client_close, zebra_client_cleanup_rnh);
+	hook_register(zserv_client_close, zebra_client_cleanup_rnh);
 }
 
 static inline struct route_table *get_rnh_table(vrf_id_t vrfid, int family,
@@ -1106,7 +1106,7 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 
 	client->nh_last_upd_time = monotime(NULL);
 	client->last_write_cmd = cmd;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 static void print_nh(struct nexthop *nexthop, struct vty *vty)

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3360,7 +3360,8 @@ DEFUN_HIDDEN (zebra_packet_process,
 {
 	uint32_t packets = strtoul(argv[2]->arg, NULL, 10);
 
-	zebrad.packets_to_process = packets;
+	atomic_store_explicit(&zebrad.packets_to_process, packets,
+			      memory_order_relaxed);
 
 	return CMD_SUCCESS;
 }
@@ -3373,7 +3374,9 @@ DEFUN_HIDDEN (no_zebra_packet_process,
 	      "Zapi Protocol\n"
 	      "Number of packets to process before relinquishing thread\n")
 {
-	zebrad.packets_to_process = ZEBRA_ZAPI_PACKETS_TO_PROCESS;
+	atomic_store_explicit(&zebrad.packets_to_process,
+			      ZEBRA_ZAPI_PACKETS_TO_PROCESS,
+			      memory_order_relaxed);
 
 	return CMD_SUCCESS;
 }

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1195,7 +1195,7 @@ static int zvni_macip_send_msg_to_client(vni_t vni, struct ethaddr *macaddr,
 	struct zserv *client = NULL;
 	struct stream *s = NULL;
 
-	client = zebra_find_client(ZEBRA_ROUTE_BGP, 0);
+	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
 	/* BGP may not be running. */
 	if (!client)
 		return 0;
@@ -1237,7 +1237,7 @@ static int zvni_macip_send_msg_to_client(vni_t vni, struct ethaddr *macaddr,
 	else
 		client->macipdel_cnt++;
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /*
@@ -2779,7 +2779,7 @@ static int zvni_send_add_to_client(zebra_vni_t *zvni)
 	struct zserv *client;
 	struct stream *s;
 
-	client = zebra_find_client(ZEBRA_ROUTE_BGP, 0);
+	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
 	/* BGP may not be running. */
 	if (!client)
 		return 0;
@@ -2801,7 +2801,7 @@ static int zvni_send_add_to_client(zebra_vni_t *zvni)
 			   zebra_route_string(client->proto));
 
 	client->vniadd_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /*
@@ -2812,7 +2812,7 @@ static int zvni_send_del_to_client(vni_t vni)
 	struct zserv *client;
 	struct stream *s;
 
-	client = zebra_find_client(ZEBRA_ROUTE_BGP, 0);
+	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
 	/* BGP may not be running. */
 	if (!client)
 		return 0;
@@ -2831,7 +2831,7 @@ static int zvni_send_del_to_client(vni_t vni)
 			   zebra_route_string(client->proto));
 
 	client->vnidel_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /*
@@ -3745,7 +3745,7 @@ static int zl3vni_send_add_to_client(zebra_l3vni_t *zl3vni)
 	struct ethaddr rmac;
 	char buf[ETHER_ADDR_STRLEN];
 
-	client = zebra_find_client(ZEBRA_ROUTE_BGP, 0);
+	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
 	/* BGP may not be running. */
 	if (!client)
 		return 0;
@@ -3777,7 +3777,7 @@ static int zl3vni_send_add_to_client(zebra_l3vni_t *zl3vni)
 			zebra_route_string(client->proto));
 
 	client->l3vniadd_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /*
@@ -3788,7 +3788,7 @@ static int zl3vni_send_del_to_client(zebra_l3vni_t *zl3vni)
 	struct stream *s = NULL;
 	struct zserv *client = NULL;
 
-	client = zebra_find_client(ZEBRA_ROUTE_BGP, 0);
+	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
 	/* BGP may not be running. */
 	if (!client)
 		return 0;
@@ -3807,7 +3807,7 @@ static int zl3vni_send_del_to_client(zebra_l3vni_t *zl3vni)
 			   zebra_route_string(client->proto));
 
 	client->l3vnidel_cnt++;
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 static void zebra_vxlan_process_l3vni_oper_up(zebra_l3vni_t *zl3vni)
@@ -3920,7 +3920,7 @@ static int ip_prefix_send_to_client(vrf_id_t vrf_id, struct prefix *p,
 	struct stream *s = NULL;
 	char buf[PREFIX_STRLEN];
 
-	client = zebra_find_client(ZEBRA_ROUTE_BGP, 0);
+	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
 	/* BGP may not be running. */
 	if (!client)
 		return 0;
@@ -3944,7 +3944,7 @@ static int ip_prefix_send_to_client(vrf_id_t vrf_id, struct prefix *p,
 	else
 		client->prefixdel_cnt++;
 
-	return zebra_server_send_message(client, s);
+	return zserv_send_message(client, s);
 }
 
 /* re-add remote rmac if needed */

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -885,7 +885,7 @@ static void zebra_show_client_detail(struct vty *vty, struct zserv *client)
 
 	last_read_time = (time_t) atomic_load_explicit(&client->last_read_time,
 						       memory_order_relaxed);
-	last_read_time = (time_t) atomic_load_explicit(&client->last_write_time,
+	last_write_time = (time_t) atomic_load_explicit(&client->last_write_time,
 						       memory_order_relaxed);
 
 	last_read_cmd = atomic_load_explicit(&client->last_read_cmd,
@@ -938,11 +938,11 @@ static void zebra_show_client_brief(struct vty *vty, struct zserv *client)
 	char wbuf[ZEBRA_TIME_BUF];
 	time_t connect_time, last_read_time, last_write_time;
 
-	connect_time = (time_t) atomic_load_explicit(&client->connect_time,
-						     memory_order_relaxed);
-	last_read_time = (time_t) atomic_load_explicit(&client->last_read_time,
-						       memory_order_relaxed);
-	last_read_time = (time_t) atomic_load_explicit(&client->last_write_time,
+	connect_time = (time_t)atomic_load_explicit(&client->connect_time,
+						    memory_order_relaxed);
+	last_read_time = (time_t)atomic_load_explicit(&client->last_read_time,
+						      memory_order_relaxed);
+	last_write_time = (time_t)atomic_load_explicit(&client->last_write_time,
 						       memory_order_relaxed);
 
 	vty_out(vty, "%-8s%12s %12s%12s%8d/%-8d%8d/%-8d\n",

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -299,7 +299,7 @@ static int zserv_read(struct thread *thread)
 	sock = THREAD_FD(thread);
 	client = THREAD_ARG(thread);
 
-	while (p2p--) {
+	while (p2p) {
 		ssize_t nb;
 		bool hdrvalid;
 		char errmsg[256];
@@ -392,6 +392,7 @@ static int zserv_read(struct thread *thread)
 
 		stream_fifo_push(cache, msg);
 		stream_reset(client->ibuf_work);
+		p2p--;
 	}
 
 	if (p2p < p2p_orig) {

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -892,9 +892,9 @@ static void zebra_show_client_detail(struct vty *vty, struct zserv *client)
 	} else
 		vty_out(vty, "Not registered for Nexthop Updates\n");
 
-	last_read_time = (time_t) atomic_load_explicit(&client->last_read_time,
-						       memory_order_relaxed);
-	last_write_time = (time_t) atomic_load_explicit(&client->last_write_time,
+	last_read_time = (time_t)atomic_load_explicit(&client->last_read_time,
+						      memory_order_relaxed);
+	last_write_time = (time_t)atomic_load_explicit(&client->last_write_time,
 						       memory_order_relaxed);
 
 	last_read_cmd = atomic_load_explicit(&client->last_read_cmd,

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -109,6 +109,14 @@ static void zebra_client_free(struct zserv *client)
 	assert(!client->t_read);
 	assert(!client->t_write);
 
+	/*
+	 * Ensure these have been nulled. This does not equate to the
+	 * associated task(s) being scheduled or unscheduled on the client
+	 * pthread's threadmaster.
+	 */
+	assert(!client->t_read);
+	assert(!client->t_write);
+
 	/* Close file descriptor. */
 	if (client->sock) {
 		unsigned long nroutes;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -72,6 +72,7 @@ struct zserv {
 	/* Threads for read/write. */
 	struct thread *t_read;
 	struct thread *t_write;
+	struct thread *t_flush;
 
 	/* default routing table this client munges */
 	int rtm_table;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -53,6 +53,9 @@ struct zserv {
 	/* Client pthread */
 	struct frr_pthread *pthread;
 
+	/* Whether the thread is waiting to be killed */
+	_Atomic bool dead;
+
 	/* Client file descriptor. */
 	int sock;
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -53,9 +53,6 @@ struct zserv {
 	/* Client pthread */
 	struct frr_pthread *pthread;
 
-	/* Whether the thread is waiting to be killed */
-	_Atomic bool dead;
-
 	/* Client file descriptor. */
 	int sock;
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -72,7 +72,6 @@ struct zserv {
 	/* Threads for read/write. */
 	struct thread *t_read;
 	struct thread *t_write;
-	struct thread *t_flush;
 
 	/* default routing table this client munges */
 	int rtm_table;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -160,14 +160,17 @@ struct zserv {
 		struct zebra_vrf *zvrf
 
 /* Hooks for client connect / disconnect */
-DECLARE_HOOK(zapi_client_connect, (struct zserv *client), (client));
-DECLARE_KOOH(zapi_client_close, (struct zserv *client), (client));
+DECLARE_HOOK(zserv_client_connect, (struct zserv *client), (client));
+DECLARE_KOOH(zserv_client_close, (struct zserv *client), (client));
 
 /* Zebra instance */
 struct zebra_t {
 	/* Thread master */
 	struct thread_master *master;
 	struct list *client_list;
+
+	/* Socket */
+	int sock;
 
 	/* default table */
 	uint32_t rtm_table_default;
@@ -186,12 +189,48 @@ struct zebra_t {
 extern struct zebra_t zebrad;
 extern unsigned int multipath_num;
 
-/* Prototypes. */
+/*
+ * Initialize Zebra API server.
+ *
+ * Installs CLI commands and creates the client list.
+ */
 extern void zserv_init(void);
-extern void zebra_zserv_socket_init(char *path);
-extern int zebra_server_send_message(struct zserv *client, struct stream *msg);
 
-extern struct zserv *zebra_find_client(uint8_t proto, unsigned short instance);
+/*
+ * Start Zebra API server.
+ *
+ * Allocates resources, creates the server socket and begins listening on the
+ * socket.
+ *
+ * path
+ *    where to place the Unix domain socket
+ */
+extern void zserv_start(char *path);
+
+/*
+ * Send a message to a connected Zebra API client.
+ *
+ * client
+ *    the client to send to
+ *
+ * msg
+ *    the message to send
+ */
+extern int zserv_send_message(struct zserv *client, struct stream *msg);
+
+/*
+ * Retrieve a client by its protocol and instance number.
+ *
+ * proto
+ *    protocol number
+ *
+ * instance
+ *    instance number
+ *
+ * Returns:
+ *    The Zebra API client.
+ */
+extern struct zserv *zserv_find_client(uint8_t proto, unsigned short instance);
 
 #if defined(HANDLE_ZAPI_FUZZING)
 extern void zserv_read_file(char *input);

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -73,9 +73,6 @@ struct zserv {
 	struct thread *t_read;
 	struct thread *t_write;
 
-	/* Thread for delayed close. */
-	struct thread *t_suicide;
-
 	/* default routing table this client munges */
 	int rtm_table;
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -183,8 +183,8 @@ struct zebra_t {
 	/* LSP work queue */
 	struct work_queue *lsp_process_q;
 
-#define ZEBRA_ZAPI_PACKETS_TO_PROCESS 10
-	uint32_t packets_to_process;
+#define ZEBRA_ZAPI_PACKETS_TO_PROCESS 100000
+	_Atomic uint32_t packets_to_process;
 };
 extern struct zebra_t zebrad;
 extern unsigned int multipath_num;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -131,15 +131,28 @@ struct zserv {
 	uint32_t prefixadd_cnt;
 	uint32_t prefixdel_cnt;
 
-	time_t connect_time;
-	time_t last_read_time;
-	time_t last_write_time;
 	time_t nh_reg_time;
 	time_t nh_dereg_time;
 	time_t nh_last_upd_time;
 
-	int last_read_cmd;
-	int last_write_cmd;
+	/*
+	 * Session information.
+	 *
+	 * These are not synchronous with respect to each other. For instance,
+	 * last_read_cmd may contain a value that has been read in the future
+	 * relative to last_read_time.
+	 */
+
+	/* monotime of client creation */
+	_Atomic uint32_t connect_time;
+	/* monotime of last message received */
+	_Atomic uint32_t last_read_time;
+	/* monotime of last message sent */
+	_Atomic uint32_t last_write_time;
+	/* command code of last message read */
+	_Atomic uint16_t last_read_cmd;
+	/* command code of last message written */
+	_Atomic uint16_t last_write_cmd;
 };
 
 #define ZAPI_HANDLER_ARGS                                                      \

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -50,11 +50,16 @@
 
 /* Client structure. */
 struct zserv {
+	/* Client pthread */
+	struct frr_pthread *pthread;
+
 	/* Client file descriptor. */
 	int sock;
 
 	/* Input/output buffer to the client. */
+	pthread_mutex_t ibuf_mtx;
 	struct stream_fifo *ibuf_fifo;
+	pthread_mutex_t obuf_mtx;
 	struct stream_fifo *obuf_fifo;
 
 	/* Private I/O buffers */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -186,7 +186,7 @@ struct zebra_t {
 	/* LSP work queue */
 	struct work_queue *lsp_process_q;
 
-#define ZEBRA_ZAPI_PACKETS_TO_PROCESS 100000
+#define ZEBRA_ZAPI_PACKETS_TO_PROCESS 1000
 	_Atomic uint32_t packets_to_process;
 };
 extern struct zebra_t zebrad;


### PR DESCRIPTION
This patch implements multithreading for the Zebra API server. The main thread accepts connections on the ZAPI socket and dynamically spins up a thread to handle session management and I/O for each client as they connect.

Basic testing with route injection via sharpd shows ~600% performance gains when installing routes. I benchmarked this by installing and then deleting 100,000 routes in a loop 50 times. On my machine this takes master about 58 seconds; with this patch it takes roughly 8 seconds. This is measuring only time to insert the last route sent into the RIB processing queue. Once ZAPI messages are received, sanitized and placed on the client input buffer processing proceeds on Zebra's primary thread as usual. The offloading of all I/O work onto separate threads allows the primary thread to spend more time on other processing tasks.

File organization overview might help with knowing what's where:
```
    zserv.c:
     ,---------------------------------.
    / include statements               |
    | ...                              |
    | ...                              |
    | -------------------------------- |
    | Client pthread server functions  |
    | ...                              |
    | ...                              |
    | -------------------------------- |
    | Main pthread server functions    |
    | ...                              |
    | ...                              |
    | -------------------------------- |
    | CLI commands, other              |
    | ...                              |
    | ...                              |
    \_________________________________/
```