### PR TITLE
lib: fix clippy build w/ gcc under certain configs

### DIFF
--- a/lib/command_graph.c
+++ b/lib/command_graph.c
@@ -25,8 +25,6 @@
 #include <zebra.h>
 
 #include "command_graph.h"
-#include "command.h"
-#include "log.h"
 
 DEFINE_MTYPE_STATIC(LIB, CMD_TOKENS, "Command Tokens")
 DEFINE_MTYPE_STATIC(LIB, CMD_DESC, "Command Token Text")
@@ -461,6 +459,9 @@ void cmd_graph_names(struct graph *graph)
 }
 
 #ifndef BUILDING_CLIPPY
+
+#include "command.h"
+#include "log.h"
 
 void cmd_graph_node_print_cb(struct graph_node *gn, struct buffer *buf)
 {


### PR DESCRIPTION
GCC's linker driver sometimes gets confused when building clippy.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>