### PR TITLE
Fix broken label manager (proxy-mode) and improve of proxy function

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2027,11 +2027,24 @@ static void bgp_zebra_process_label_chunk(
 	uint8_t response_keep;
 	uint32_t first;
 	uint32_t last;
+	uint8_t proto;
+	unsigned short instance;
 
 	s = zclient->ibuf;
+	STREAM_GETC(s, proto);
+	STREAM_GETW(s, instance);
 	STREAM_GETC(s, response_keep);
 	STREAM_GETL(s, first);
 	STREAM_GETL(s, last);
+
+	if (zclient->redist_default != proto) {
+		zlog_err("Got LM msg with wrong proto %u", proto);
+		return;
+	}
+	if (zclient->instance != instance) {
+		zlog_err("Got LM msg with wrong instance %u", proto);
+		return;
+	}
 
 	if (first > last ||
 		first < MPLS_LABEL_UNRESERVED_MIN ||

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1231,9 +1231,8 @@ stream_failure:
 	return 0;
 }
 
-static void zapi_encode_prefix(struct stream *s,
-			      struct prefix *p,
-			      uint8_t family)
+static void zapi_encode_prefix(struct stream *s, struct prefix *p,
+			       uint8_t family)
 {
 	struct prefix any;
 
@@ -1248,8 +1247,7 @@ static void zapi_encode_prefix(struct stream *s,
 	stream_put(s, &p->u.prefix, prefix_blen(p));
 }
 
-int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s,
-			 struct pbr_rule *zrule)
+int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s, struct pbr_rule *zrule)
 {
 	stream_reset(s);
 	zclient_create_header(s, cmd, zrule->vrf_id);
@@ -1265,11 +1263,11 @@ int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s,
 
 	zapi_encode_prefix(s, &(zrule->filter.src_ip),
 			   zrule->filter.src_ip.family);
-	stream_putw(s, zrule->filter.src_port);  /* src port */
+	stream_putw(s, zrule->filter.src_port); /* src port */
 	zapi_encode_prefix(s, &(zrule->filter.dst_ip),
 			   zrule->filter.src_ip.family);
-	stream_putw(s, zrule->filter.dst_port);  /* dst port */
-	stream_putw(s, zrule->filter.fwmark);    /* fwmark */
+	stream_putw(s, zrule->filter.dst_port); /* dst port */
+	stream_putw(s, zrule->filter.fwmark);   /* fwmark */
 
 	stream_putl(s, zrule->action.table);
 	stream_putl(s, zrule->ifindex);
@@ -1317,8 +1315,8 @@ bool zapi_rule_notify_decode(struct stream *s, uint32_t *seqno,
 	STREAM_GETL(s, ifi);
 
 	if (zclient_debug)
-		zlog_debug("%s: %u %u %u %u", __PRETTY_FUNCTION__,
-			   seq, prio, uni, ifi);
+		zlog_debug("%s: %u %u %u %u", __PRETTY_FUNCTION__, seq, prio,
+			   uni, ifi);
 	*seqno = seq;
 	*priority = prio;
 	*unique = uni;
@@ -1330,9 +1328,8 @@ stream_failure:
 	return false;
 }
 
-bool zapi_ipset_notify_decode(struct stream *s,
-			      uint32_t *unique,
-			     enum zapi_ipset_notify_owner *note)
+bool zapi_ipset_notify_decode(struct stream *s, uint32_t *unique,
+			      enum zapi_ipset_notify_owner *note)
 {
 	uint32_t uni;
 
@@ -1350,10 +1347,9 @@ stream_failure:
 	return false;
 }
 
-bool zapi_ipset_entry_notify_decode(struct stream *s,
-		uint32_t *unique,
-		char *ipset_name,
-		enum zapi_ipset_entry_notify_owner *note)
+bool zapi_ipset_entry_notify_decode(struct stream *s, uint32_t *unique,
+				    char *ipset_name,
+				    enum zapi_ipset_entry_notify_owner *note)
 {
 	uint32_t uni;
 
@@ -1361,8 +1357,7 @@ bool zapi_ipset_entry_notify_decode(struct stream *s,
 
 	STREAM_GETL(s, uni);
 
-	STREAM_GET(ipset_name, s,
-		   ZEBRA_IPSET_NAME_SIZE);
+	STREAM_GET(ipset_name, s, ZEBRA_IPSET_NAME_SIZE);
 
 	if (zclient_debug)
 		zlog_debug("%s: %u", __PRETTY_FUNCTION__, uni);
@@ -1388,7 +1383,7 @@ struct nexthop *nexthop_from_zapi_nexthop(struct zapi_nexthop *znh)
 	 */
 	if (znh->label_num) {
 		nexthop_add_labels(n, ZEBRA_LSP_NONE, znh->label_num,
-			znh->labels);
+				   znh->labels);
 	}
 
 	return n;
@@ -1449,7 +1444,7 @@ bool zapi_nexthop_update_decode(struct stream *s, struct zapi_route *nhr)
 		if (nhr->nexthops[i].label_num)
 			STREAM_GET(&nhr->nexthops[i].labels[0], s,
 				   nhr->nexthops[i].label_num
-				   * sizeof(mpls_label_t));
+					   * sizeof(mpls_label_t));
 	}
 
 	return true;
@@ -1872,8 +1867,9 @@ struct connected *zebra_interface_address_read(int type, struct stream *s,
 				zlog_warn(
 					"warning: interface %s address %s "
 					"with peer flag set, but no peer address!",
-					ifp->name, prefix2str(ifc->address, buf,
-							      sizeof buf));
+					ifp->name,
+					prefix2str(ifc->address, buf,
+						   sizeof buf));
 				UNSET_FLAG(ifc->flags, ZEBRA_IFA_PEER);
 			}
 		}
@@ -2086,17 +2082,18 @@ int lm_label_manager_connect(struct zclient *zclient)
 
 	/* sanity */
 	if (proto != zclient->redist_default)
-		zlog_err("Wrong proto (%u) in LM connect response. Should be %u",
-				proto, zclient->redist_default);
+		zlog_err(
+			"Wrong proto (%u) in LM connect response. Should be %u",
+			proto, zclient->redist_default);
 	if (instance != zclient->instance)
-		zlog_err("Wrong instId (%u) in LM connect response. Should be %u",
-				instance, zclient->instance);
+		zlog_err(
+			"Wrong instId (%u) in LM connect response. Should be %u",
+			instance, zclient->instance);
 
 	/* result code */
 	result = stream_getc(s);
 	if (zclient_debug)
-		zlog_debug(
-			"LM connect-response received, result %u", result);
+		zlog_debug("LM connect-response received, result %u", result);
 
 	return (int)result;
 }
@@ -2109,10 +2106,8 @@ int lm_label_manager_connect(struct zclient *zclient)
  * @param chunk_size Amount of labels requested
  * @result 0 on success, -1 otherwise
  */
-int zclient_send_get_label_chunk(
-	struct zclient	*zclient,
-	uint8_t		keep,
-	uint32_t	chunk_size)
+int zclient_send_get_label_chunk(struct zclient *zclient, uint8_t keep,
+				 uint32_t chunk_size)
 {
 	struct stream *s;
 
@@ -2210,10 +2205,10 @@ int lm_get_label_chunk(struct zclient *zclient, uint8_t keep,
 	/* sanities */
 	if (proto != zclient->redist_default)
 		zlog_err("Wrong proto (%u) in get chunk response. Should be %u",
-			proto, zclient->redist_default);
+			 proto, zclient->redist_default);
 	if (instance != zclient->instance)
 		zlog_err("Wrong instId (%u) in get chunk response Should be %u",
-			instance, zclient->instance);
+			 instance, zclient->instance);
 
 	/* keep */
 	response_keep = stream_getc(s);
@@ -2334,8 +2329,7 @@ int tm_table_manager_connect(struct zclient *zclient)
 		return -1;
 
 	if (zclient_debug)
-		zlog_debug("%s: Table manager connect request sent",
-			   __func__);
+		zlog_debug("%s: Table manager connect request sent", __func__);
 
 	/* read response */
 	if (zclient_read_sync_response(zclient, ZEBRA_TABLE_MANAGER_CONNECT)
@@ -2798,7 +2792,7 @@ static int zclient_read(struct thread *thread)
 	case ZEBRA_GET_LABEL_CHUNK:
 		if (zclient->label_chunk)
 			(*zclient->label_chunk)(command, zclient, length,
-						      vrf_id);
+						vrf_id);
 		break;
 	default:
 		break;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2079,8 +2079,21 @@ int lm_label_manager_connect(struct zclient *zclient)
 	    != 0)
 		return -1;
 
-	/* result */
 	s = zclient->ibuf;
+
+	/* read instance and proto */
+	uint8_t proto = stream_getc(s);
+	uint16_t instance = stream_getw(s);
+
+	/* sanity */
+	if (proto != zclient->redist_default)
+		zlog_err("Wrong proto (%u) in lm_connect response. Should be %u",
+				proto, zclient->redist_default);
+	if (instance != zclient->instance)
+		zlog_err("Wrong instId (%u) in lm_connect response Should be %u",
+				instance, zclient->instance);
+
+	/* result code */
 	result = stream_getc(s);
 	if (zclient_debug)
 		zlog_debug(
@@ -2115,6 +2128,10 @@ int zclient_send_get_label_chunk(
 	stream_reset(s);
 
 	zclient_create_header(s, ZEBRA_GET_LABEL_CHUNK, VRF_DEFAULT);
+	/* proto */
+	stream_putc(s, zclient->redist_default);
+	/* instance */
+	stream_putw(s, zclient->instance);
 	stream_putc(s, keep);
 	stream_putl(s, chunk_size);
 
@@ -2154,6 +2171,10 @@ int lm_get_label_chunk(struct zclient *zclient, uint8_t keep,
 	s = zclient->obuf;
 	stream_reset(s);
 	zclient_create_header(s, ZEBRA_GET_LABEL_CHUNK, VRF_DEFAULT);
+	/* proto */
+	stream_putc(s, zclient->redist_default);
+	/* instance */
+	stream_putw(s, zclient->instance);
 	/* keep */
 	stream_putc(s, keep);
 	/* chunk size */
@@ -2182,7 +2203,21 @@ int lm_get_label_chunk(struct zclient *zclient, uint8_t keep,
 	if (zclient_read_sync_response(zclient, ZEBRA_GET_LABEL_CHUNK) != 0)
 		return -1;
 
+	/* parse response */
 	s = zclient->ibuf;
+
+	/* read proto and instance */
+	uint8_t proto = stream_getc(s);
+	uint16_t instance = stream_getw(s);
+
+	/* sanities */
+	if (proto != zclient->redist_default)
+		zlog_err("Wrong proto (%u) in get chunk response. Should be %u",
+			proto, zclient->redist_default);
+	if (instance != zclient->instance)
+		zlog_err("Wrong instId (%u) in get chunk response Should be %u",
+			instance, zclient->instance);
+
 	/* keep */
 	response_keep = stream_getc(s);
 	/* start and end labels */
@@ -2235,6 +2270,10 @@ int lm_release_label_chunk(struct zclient *zclient, uint32_t start,
 	stream_reset(s);
 	zclient_create_header(s, ZEBRA_RELEASE_LABEL_CHUNK, VRF_DEFAULT);
 
+	/* proto */
+	stream_putc(s, zclient->redist_default);
+	/* instance */
+	stream_putw(s, zclient->instance);
 	/* start */
 	stream_putl(s, start);
 	/* end */

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2039,7 +2039,7 @@ int lm_label_manager_connect(struct zclient *zclient)
 	uint8_t result;
 
 	if (zclient_debug)
-		zlog_debug("Connecting to Label Manager");
+		zlog_debug("Connecting to Label Manager (LM)");
 
 	if (zclient->sock < 0)
 		return -1;
@@ -2059,20 +2059,19 @@ int lm_label_manager_connect(struct zclient *zclient)
 
 	ret = writen(zclient->sock, s->data, stream_get_endp(s));
 	if (ret < 0) {
-		zlog_err("%s: can't write to zclient->sock", __func__);
+		zlog_err("Can't write to zclient sock");
 		close(zclient->sock);
 		zclient->sock = -1;
 		return -1;
 	}
 	if (ret == 0) {
-		zlog_err("%s: zclient->sock connection closed", __func__);
+		zlog_err("Zclient sock closed");
 		close(zclient->sock);
 		zclient->sock = -1;
 		return -1;
 	}
 	if (zclient_debug)
-		zlog_debug("%s: Label manager connect request (%d bytes) sent",
-			   __func__, ret);
+		zlog_debug("LM connect request sent (%d bytes)", ret);
 
 	/* read response */
 	if (zclient_read_sync_response(zclient, ZEBRA_LABEL_MANAGER_CONNECT)
@@ -2087,18 +2086,17 @@ int lm_label_manager_connect(struct zclient *zclient)
 
 	/* sanity */
 	if (proto != zclient->redist_default)
-		zlog_err("Wrong proto (%u) in lm_connect response. Should be %u",
+		zlog_err("Wrong proto (%u) in LM connect response. Should be %u",
 				proto, zclient->redist_default);
 	if (instance != zclient->instance)
-		zlog_err("Wrong instId (%u) in lm_connect response Should be %u",
+		zlog_err("Wrong instId (%u) in LM connect response. Should be %u",
 				instance, zclient->instance);
 
 	/* result code */
 	result = stream_getc(s);
 	if (zclient_debug)
 		zlog_debug(
-			"%s: Label Manager connect response received, result %u",
-			__func__, result);
+			"LM connect-response received, result %u", result);
 
 	return (int)result;
 }
@@ -2184,20 +2182,19 @@ int lm_get_label_chunk(struct zclient *zclient, uint8_t keep,
 
 	ret = writen(zclient->sock, s->data, stream_get_endp(s));
 	if (ret < 0) {
-		zlog_err("%s: can't write to zclient->sock", __func__);
+		zlog_err("Can't write to zclient sock");
 		close(zclient->sock);
 		zclient->sock = -1;
 		return -1;
 	}
 	if (ret == 0) {
-		zlog_err("%s: zclient->sock connection closed", __func__);
+		zlog_err("Zclient sock closed");
 		close(zclient->sock);
 		zclient->sock = -1;
 		return -1;
 	}
 	if (zclient_debug)
-		zlog_debug("%s: Label chunk request (%d bytes) sent", __func__,
-			   ret);
+		zlog_debug("Label chunk request (%d bytes) sent", ret);
 
 	/* read response */
 	if (zclient_read_sync_response(zclient, ZEBRA_GET_LABEL_CHUNK) != 0)
@@ -2227,19 +2224,18 @@ int lm_get_label_chunk(struct zclient *zclient, uint8_t keep,
 	/* not owning this response */
 	if (keep != response_keep) {
 		zlog_err(
-			"%s: Invalid Label chunk: %u - %u, keeps mismatch %u != %u",
-			__func__, *start, *end, keep, response_keep);
+			"Invalid Label chunk: %u - %u, keeps mismatch %u != %u",
+			*start, *end, keep, response_keep);
 	}
 	/* sanity */
 	if (*start > *end || *start < MPLS_LABEL_UNRESERVED_MIN
 	    || *end > MPLS_LABEL_UNRESERVED_MAX) {
-		zlog_err("%s: Invalid Label chunk: %u - %u", __func__, *start,
-			 *end);
+		zlog_err("Invalid Label chunk: %u - %u", *start, *end);
 		return -1;
 	}
 
 	if (zclient_debug)
-		zlog_debug("Label Chunk assign: %u - %u (%u) ", *start, *end,
+		zlog_debug("Label Chunk assign: %u - %u (%u)", *start, *end,
 			   response_keep);
 
 	return 0;
@@ -2260,7 +2256,7 @@ int lm_release_label_chunk(struct zclient *zclient, uint32_t start,
 	struct stream *s;
 
 	if (zclient_debug)
-		zlog_debug("Releasing Label Chunk");
+		zlog_debug("Releasing Label Chunk %u - %u", start, end);
 
 	if (zclient->sock < 0)
 		return -1;
@@ -2284,13 +2280,13 @@ int lm_release_label_chunk(struct zclient *zclient, uint32_t start,
 
 	ret = writen(zclient->sock, s->data, stream_get_endp(s));
 	if (ret < 0) {
-		zlog_err("%s: can't write to zclient->sock", __func__);
+		zlog_err("Can't write to zclient sock");
 		close(zclient->sock);
 		zclient->sock = -1;
 		return -1;
 	}
 	if (ret == 0) {
-		zlog_err("%s: zclient->sock connection closed", __func__);
+		zlog_err("Zclient sock connection closed");
 		close(zclient->sock);
 		zclient->sock = -1;
 		return -1;

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -82,8 +82,8 @@ static int relay_response_back(void)
 	ret = zclient_read_header(src, zclient->sock, &size, &marker, &version,
 				  &vrf_id, &resp_cmd);
 	if (ret < 0 && errno != EAGAIN) {
-		zlog_err("%s: Error reading Label Manager response: %s",
-			 __func__, strerror(errno));
+		zlog_err("Error reading Label Manager response: %s",
+			 strerror(errno));
 		return -1;
 	}
 	zlog_debug("Label Manager response received, %d bytes", size);
@@ -101,12 +101,13 @@ static int relay_response_back(void)
 	/* lookup the client to relay the msg to */
 	zserv = zebra_find_client(proto, instance);
 	if (!zserv) {
-		zlog_err("Error relaying LM response: can't find client %s, instance %u",
-				proto_str, instance);
+		zlog_err(
+			"Error relaying LM response: can't find client %s, instance %u",
+			proto_str, instance);
 		return -1;
 	}
 	zlog_debug("Found client to relay LM response to client %s instance %u",
-				proto_str, instance);
+		   proto_str, instance);
 
 	/* copy msg into output buffer */
 	dst = obuf;
@@ -116,11 +117,11 @@ static int relay_response_back(void)
 	ret = writen(zserv->sock, dst->data, stream_get_endp(dst));
 	if (ret <= 0) {
 		zlog_err("Error relaying LM response to %s instance %u: %s",
-				proto_str, instance, strerror(errno));
+			 proto_str, instance, strerror(errno));
 		return -1;
 	}
-	zlog_debug("Relayed LM response (%d bytes) to %s instance %u",
-				ret, proto_str, instance);
+	zlog_debug("Relayed LM response (%d bytes) to %s instance %u", ret,
+		   proto_str, instance);
 
 	return 0;
 }
@@ -173,7 +174,7 @@ static int reply_error(int cmd, struct zserv *zserv, vrf_id_t vrf_id)
  * @return 0 on success, -1 otherwise
  */
 int zread_relay_label_manager_request(int cmd, struct zserv *zserv,
-							struct stream *msg, vrf_id_t vrf_id)
+				      struct stream *msg, vrf_id_t vrf_id)
 {
 	struct stream *dst;
 	int ret = 0;
@@ -203,15 +204,15 @@ int zread_relay_label_manager_request(int cmd, struct zserv *zserv,
 
 	/* check & set client proto if unset */
 	if (zserv->proto && zserv->proto != proto) {
-		zlog_warn("Client proto(%u) != msg proto(%u)",
-				zserv->proto, proto);
+		zlog_warn("Client proto(%u) != msg proto(%u)", zserv->proto,
+			  proto);
 		return -1;
 	}
 
 	/* check & set client instance if unset */
 	if (zserv->instance && zserv->instance != instance) {
 		zlog_err("Client instance(%u) != msg instance(%u)",
-				zserv->instance, instance);
+			 zserv->instance, instance);
 		return -1;
 	}
 
@@ -233,12 +234,12 @@ int zread_relay_label_manager_request(int cmd, struct zserv *zserv,
 	ret = writen(zclient->sock, dst->data, stream_get_endp(dst));
 	if (ret <= 0) {
 		zlog_err("Error relaying LM request from %s instance %u: %s",
-				proto_str, instance, strerror(errno));
+			 proto_str, instance, strerror(errno));
 		reply_error(cmd, zserv, vrf_id);
 		return -1;
 	}
-	zlog_debug("Relayed LM request (%d bytes) from %s instance %u",
-				ret, proto_str, instance);
+	zlog_debug("Relayed LM request (%d bytes) from %s instance %u", ret,
+		   proto_str, instance);
 
 
 	/* Release label chunk has no response */

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -59,7 +59,7 @@ static void delete_label_chunk(void *val)
 	XFREE(MTYPE_LM_CHUNK, val);
 }
 
-static int relay_response_back(struct zserv *zserv)
+static int relay_response_back(void)
 {
 	int ret = 0;
 	struct stream *src, *dst;
@@ -68,12 +68,18 @@ static int relay_response_back(struct zserv *zserv)
 	uint8_t version;
 	vrf_id_t vrf_id;
 	uint16_t resp_cmd;
+	uint8_t proto;
+	const char *proto_str;
+	unsigned short instance;
+	struct zserv *zserv;
 
+	/* input buffer with msg from label manager */
 	src = zclient->ibuf;
 	dst = obuf;
 
 	stream_reset(src);
 
+	/* parse header */
 	ret = zclient_read_header(src, zclient->sock, &size, &marker, &version,
 				  &vrf_id, &resp_cmd);
 	if (ret < 0 && errno != EAGAIN) {
@@ -81,36 +87,53 @@ static int relay_response_back(struct zserv *zserv)
 			 __func__, strerror(errno));
 		return -1;
 	}
-	zlog_debug("%s: Label Manager response received, %d bytes", __func__,
-		   size);
+	zlog_debug("Label Manager response received, %d bytes", size);
 	if (size == 0)
 		return -1;
 
-	/* send response back */
-	stream_copy(dst, src);
-	ret = writen(zserv->sock, dst->data, stream_get_endp(dst));
-	if (ret <= 0) {
-		zlog_err("%s: Error sending Label Manager response back: %s",
-			 __func__, strerror(errno));
+	/* Get the 'proto' field of the message */
+	proto = stream_getc(src);
+
+	/* Get the 'instance' field of the message */
+	instance = stream_getw(src);
+
+	proto_str = zebra_route_string(proto);
+
+	/* lookup the client to relay the msg to */
+	zserv = zebra_find_client(proto, instance);
+	if (!zserv) {
+		zlog_err("Error sending LM response back: can't find client with proto %s, instance %u",
+				proto_str, instance);
 		return -1;
 	}
-	zlog_debug("%s: Label Manager response (%d bytes) sent back", __func__,
-		   ret);
+	zlog_debug("Found client to relay LM msg to: %s instance %u",
+				proto_str, instance);
+
+	/* copy msg into output buffer */
+	dst = obuf;
+	stream_copy(dst, src);
+
+	/* send response back */
+	ret = writen(zserv->sock, dst->data, stream_get_endp(dst));
+	if (ret <= 0) {
+		zlog_err("Error relaying Label Manager response to %s instance %u: %s",
+				proto_str, instance, strerror(errno));
+		return -1;
+	}
+	zlog_debug("Relayed Label Manager response (%d bytes) to %s instance %u",
+				ret, proto_str, instance);
 
 	return 0;
 }
 
 static int lm_zclient_read(struct thread *t)
 {
-	struct zserv *zserv;
 	int ret;
 
-	/* Get socket to zebra. */
-	zserv = THREAD_ARG(t);
 	zclient->t_read = NULL;
 
 	/* read response and send it back */
-	ret = relay_response_back(zserv);
+	ret = relay_response_back();
 
 	return ret;
 }
@@ -124,6 +147,10 @@ static int reply_error(int cmd, struct zserv *zserv, vrf_id_t vrf_id)
 
 	zclient_create_header(s, cmd, vrf_id);
 
+	/* proto */
+	stream_putc(s, zserv->proto);
+	/* instance */
+	stream_putw(s, zserv->instance);
 	/* result */
 	stream_putc(s, 1);
 
@@ -149,36 +176,71 @@ static int reply_error(int cmd, struct zserv *zserv, vrf_id_t vrf_id)
 int zread_relay_label_manager_request(int cmd, struct zserv *zserv,
 							struct stream *msg, vrf_id_t vrf_id)
 {
-	struct stream *src, *dst;
+	struct stream *dst;
 	int ret = 0;
+	uint8_t proto;
+	const char *proto_str;
+	unsigned short instance;
 
 	if (zclient->sock < 0) {
-		zlog_err(
-			"%s: Error relaying label chunk request: no zclient socket",
-			__func__);
+		zlog_err("Unable to relay label manager request: no socket");
 		reply_error(cmd, zserv, vrf_id);
 		return -1;
 	}
+
+	/* peek msg to get proto and instance id. This zebra, which acts as
+	 * a proxy needs to have such values for each client in order to
+	 * relay responses back to it.
+	 */
+
+	/* Get the 'proto' field of incoming msg */
+	proto = stream_getc(msg);
+
+	/* Get the 'instance' field of incoming msg */
+	instance = stream_getw(msg);
+
+	/* stringify proto */
+	proto_str = zebra_route_string(proto);
+
+	/* check & set client proto if unset */
+	if (zserv->proto && zserv->proto != proto) {
+		zlog_warn("Client proto(%u) != msg proto(%u)",
+				zserv->proto, proto);
+		return -1;
+	}
+
+	/* check & set client instance if unset */
+	if (zserv->instance && zserv->instance != instance) {
+		zlog_err("Client instance(%u) != msg instance(%u)",
+				zserv->instance, instance);
+		return -1;
+	}
+
+	/* recall proto and instance */
+	zserv->instance = instance;
+	zserv->proto = proto;
 
 	/* in case there's any incoming message enqueued, read and forward it */
 	while (ret == 0)
-		ret = relay_response_back(zserv);
+		ret = relay_response_back();
 
-	/* Send request to external label manager */
-	src = msg;
+	/* get the msg buffer used toward the 'master' Label Manager */
 	dst = zclient->obuf;
 
-	stream_copy(dst, src);
+	/* copy the message */
+	stream_copy(dst, msg);
 
+	/* Send request to external label manager */
 	ret = writen(zclient->sock, dst->data, stream_get_endp(dst));
 	if (ret <= 0) {
-		zlog_err("%s: Error relaying label chunk request: %s", __func__,
-			 strerror(errno));
+		zlog_err("Error relaying label manager request from %s instance %u: %s",
+				proto_str, instance, strerror(errno));
 		reply_error(cmd, zserv, vrf_id);
 		return -1;
 	}
-	zlog_debug("%s: Label chunk request relayed. %d bytes sent", __func__,
-		   ret);
+	zlog_debug("Relayed Label manager request (%d bytes) from %s instance %u",
+				ret, proto_str, instance);
+
 
 	/* Release label chunk has no response */
 	if (cmd == ZEBRA_RELEASE_LABEL_CHUNK)
@@ -186,7 +248,7 @@ int zread_relay_label_manager_request(int cmd, struct zserv *zserv,
 
 	/* make sure we listen to the response */
 	if (!zclient->t_read)
-		thread_add_read(zclient->master, lm_zclient_read, zserv,
+		thread_add_read(zclient->master, lm_zclient_read, NULL,
 				zclient->sock, &zclient->t_read);
 
 	return 0;

--- a/zebra/label_manager.h
+++ b/zebra/label_manager.h
@@ -64,7 +64,7 @@ struct label_manager {
 bool lm_is_external;
 
 int zread_relay_label_manager_request(int cmd, struct zserv *zserv,
-				      vrf_id_t vrf_id);
+					  struct stream *msg, vrf_id_t vrf_id);
 void label_manager_init(char *lm_zserv_path);
 struct label_manager_chunk *assign_label_chunk(uint8_t proto,
 					       unsigned short instance,

--- a/zebra/label_manager.h
+++ b/zebra/label_manager.h
@@ -64,7 +64,7 @@ struct label_manager {
 bool lm_is_external;
 
 int zread_relay_label_manager_request(int cmd, struct zserv *zserv,
-					  struct stream *msg, vrf_id_t vrf_id);
+				      struct stream *msg, vrf_id_t vrf_id);
 void label_manager_init(char *lm_zserv_path);
 struct label_manager_chunk *assign_label_chunk(uint8_t proto,
 					       unsigned short instance,

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -887,6 +887,10 @@ static int zsend_assign_label_chunk_response(struct zserv *client,
 	zclient_create_header(s, ZEBRA_GET_LABEL_CHUNK, vrf_id);
 
 	if (lmc) {
+		/* proto */
+		stream_putc(s, lmc->proto);
+		/* instance */
+		stream_putw(s, lmc->instance);
 		/* keep */
 		stream_putc(s, lmc->keep);
 		/* start and end labels */
@@ -911,6 +915,12 @@ static int zsend_label_manager_connect_response(struct zserv *client,
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, ZEBRA_LABEL_MANAGER_CONNECT, vrf_id);
+
+	/* proto */
+	stream_putc(s, client->proto);
+
+	/* instance */
+	stream_putw(s, client->instance);
 
 	/* result */
 	stream_putc(s, result);
@@ -2398,6 +2408,23 @@ static void zread_label_manager_connect(struct zserv *client,
 stream_failure:
 	return;
 }
+static int msg_client_id_mismatch(const char *op, struct zserv *client,
+				  uint8_t proto, unsigned int instance)
+{
+	if (proto != client->proto) {
+		zlog_err("%s: msg vs client proto mismatch, client=%u msg=%u",
+				op, client->proto, proto);
+		return 1;
+	}
+
+	if (instance != client->instance) {
+		zlog_err("%s: msg vs client instance mismatch, client=%u msg=%u",
+				op, client->instance, instance);
+		return 1;
+	}
+
+	return 0;
+}
 
 static void zread_get_label_chunk(struct zserv *client, struct stream *msg,
 				  vrf_id_t vrf_id)
@@ -2406,21 +2433,29 @@ static void zread_get_label_chunk(struct zserv *client, struct stream *msg,
 	uint8_t keep;
 	uint32_t size;
 	struct label_manager_chunk *lmc;
+	uint8_t proto;
+	unsigned short instance;
 
 	/* Get input stream.  */
 	s = msg;
 
 	/* Get data. */
+	STREAM_GETC(s, proto);
+	STREAM_GETW(s, instance);
 	STREAM_GETC(s, keep);
 	STREAM_GETL(s, size);
 
+	/* detect client vs message (proto,instance) mismatch */
+	if (msg_client_id_mismatch("Get-label-chunk", client, proto, instance))
+		return;
+
 	lmc = assign_label_chunk(client->proto, client->instance, keep, size);
 	if (!lmc)
-		zlog_err("%s: Unable to assign Label Chunk of size %u",
-			 __func__, size);
+		zlog_err("Unable to assign Label Chunk of size %u to %s instance %u",
+			 size, zebra_route_string(client->proto), client->instance);
 	else
-		zlog_debug("Assigned Label Chunk %u - %u to %u", lmc->start,
-			   lmc->end, keep);
+		zlog_debug("Assigned Label Chunk %u - %u to %s instance %u", lmc->start,
+			   lmc->end, zebra_route_string(client->proto), client->instance);
 	/* send response back */
 	zsend_assign_label_chunk_response(client, vrf_id, lmc);
 
@@ -2432,13 +2467,21 @@ static void zread_release_label_chunk(struct zserv *client, struct stream *msg)
 {
 	struct stream *s;
 	uint32_t start, end;
+	uint8_t proto;
+	unsigned short instance;
 
 	/* Get input stream.  */
 	s = msg;
 
 	/* Get data. */
+	STREAM_GETC(s, proto);
+	STREAM_GETW(s, instance);
 	STREAM_GETL(s, start);
 	STREAM_GETL(s, end);
+
+	/* detect client vs message (proto,instance) mismatch */
+	if (msg_client_id_mismatch("Release-label-chunk", client, proto, instance))
+		return;
 
 	release_label_chunk(client->proto, client->instance, start, end);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2454,7 +2454,7 @@ static void zread_label_manager_request(ZAPI_HANDLER_ARGS)
 	/* external label manager */
 	if (lm_is_external)
 		zread_relay_label_manager_request(hdr->command, client,
-						  zvrf_id(zvrf));
+						msg, zvrf_id(zvrf));
 	/* this is a label manager */
 	else {
 		if (hdr->command == ZEBRA_LABEL_MANAGER_CONNECT)

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2413,14 +2413,15 @@ static int msg_client_id_mismatch(const char *op, struct zserv *client,
 {
 	if (proto != client->proto) {
 		zlog_err("%s: msg vs client proto mismatch, client=%u msg=%u",
-				op, client->proto, proto);
+			 op, client->proto, proto);
 		/* TODO: fail when BGP sets proto and instance */
 		/* return 1; */
 	}
 
 	if (instance != client->instance) {
-		zlog_err("%s: msg vs client instance mismatch, client=%u msg=%u",
-				op, client->instance, instance);
+		zlog_err(
+			"%s: msg vs client instance mismatch, client=%u msg=%u",
+			op, client->instance, instance);
 		/* TODO: fail when BGP sets proto and instance */
 		/* return 1; */
 	}
@@ -2453,11 +2454,14 @@ static void zread_get_label_chunk(struct zserv *client, struct stream *msg,
 
 	lmc = assign_label_chunk(client->proto, client->instance, keep, size);
 	if (!lmc)
-		zlog_err("Unable to assign Label Chunk of size %u to %s instance %u",
-			 size, zebra_route_string(client->proto), client->instance);
+		zlog_err(
+			"Unable to assign Label Chunk of size %u to %s instance %u",
+			size, zebra_route_string(client->proto),
+			client->instance);
 	else
-		zlog_debug("Assigned Label Chunk %u - %u to %s instance %u", lmc->start,
-			   lmc->end, zebra_route_string(client->proto), client->instance);
+		zlog_debug("Assigned Label Chunk %u - %u to %s instance %u",
+			   lmc->start, lmc->end,
+			   zebra_route_string(client->proto), client->instance);
 	/* send response back */
 	zsend_assign_label_chunk_response(client, vrf_id, lmc);
 
@@ -2482,7 +2486,8 @@ static void zread_release_label_chunk(struct zserv *client, struct stream *msg)
 	STREAM_GETL(s, end);
 
 	/* detect client vs message (proto,instance) mismatch */
-	if (msg_client_id_mismatch("Release-label-chunk", client, proto, instance))
+	if (msg_client_id_mismatch("Release-label-chunk", client, proto,
+				   instance))
 		return;
 
 	release_label_chunk(client->proto, client->instance, start, end);
@@ -2498,8 +2503,8 @@ static void zread_label_manager_request(ZAPI_HANDLER_ARGS)
 
 	/* external label manager */
 	if (lm_is_external)
-		zread_relay_label_manager_request(hdr->command, client,
-						msg, zvrf_id(zvrf));
+		zread_relay_label_manager_request(hdr->command, client, msg,
+						  zvrf_id(zvrf));
 	/* this is a label manager */
 	else {
 		if (hdr->command == ZEBRA_LABEL_MANAGER_CONNECT)

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2414,13 +2414,15 @@ static int msg_client_id_mismatch(const char *op, struct zserv *client,
 	if (proto != client->proto) {
 		zlog_err("%s: msg vs client proto mismatch, client=%u msg=%u",
 				op, client->proto, proto);
-		return 1;
+		/* TODO: fail when BGP sets proto and instance */
+		/* return 1; */
 	}
 
 	if (instance != client->instance) {
 		zlog_err("%s: msg vs client instance mismatch, client=%u msg=%u",
 				op, client->instance, instance);
-		return 1;
+		/* TODO: fail when BGP sets proto and instance */
+		/* return 1; */
 	}
 
 	return 0;


### PR DESCRIPTION
The label manager proxy/relaying functionality was broken by a couple of fixes in a recent refactor.
The first commit (881999e64fcf1cf7bac65a74bcc4a6ed7cfdbbbe),  fixes it and leaves it as it was before.

The second and third commit fix a limitation of the proxy functionality of the label manager.
That implementation, relayed clients' messages to a remote label manager and the responses back. 
The relay of requests to an external label manager, was correct. However, the relay of responses from the label manager back to the client was not. When receiving a request from client A, the relay function  checked for pending responses from the label manager and relayed them ---no matter the client that triggered them --- to  client A. Therefore, if multiple clients send requests to a label manager thru the same proxy, responses may be returned to the incorrect client. To solve this:

1) the second commit includes the clients' (proto,instance) at the beginning of each zserv message.
2) the third commit uses the (proto,instance) to route the responses back to the requestors.

