### PR TITLE
Clean up some issues found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -232,7 +232,6 @@ else
    fi
 fi
 AM_CONDITIONAL([DEV_BUILD], [test "x$enable_dev_build" = "xyes"])
-AM_CONDITIONAL([SHARPD], [test "x$enable_dev_build" = "xyes"])
 
 dnl always want these CFLAGS
 AC_C_FLAG([-fno-omit-frame-pointer])
@@ -356,6 +355,8 @@ AC_ARG_ENABLE(pimd,
   AS_HELP_STRING([--disable-pimd], [do not build pimd]))
 AC_ARG_ENABLE(pbrd,
   AS_HELP_STRING([--disable-pbrd], [do not build pbrd]))
+AC_ARG_ENABLE(sharpd,
+  AS_HELP_STRING([--enable-sharpd], [do not build sharpd]))
 AC_ARG_ENABLE(bgp-announce,
   AS_HELP_STRING([--disable-bgp-announce,], [turn off BGP route announcement]))
 AC_ARG_ENABLE(bgp-vnc,
@@ -1380,6 +1381,7 @@ AM_CONDITIONAL(OSPF6D, test "${enable_ospf6d}" != "no")
 AM_CONDITIONAL(ISISD, test "${enable_isisd}" != "no")
 AM_CONDITIONAL(PIMD, test "${enable_pimd}" != "no")
 AM_CONDITIONAL(PBRD, test "${enable_pbrd}" != "no")
+AM_CONDITIONAL(SHARPD, test "${enable_sharpd}" = "yes")
 
 if test "${enable_bgp_announce}" = "no";then
   AC_DEFINE(DISABLE_BGP_ANNOUNCE,1,Disable BGP installation to zebra)

--- a/configure.ac
+++ b/configure.ac
@@ -354,6 +354,8 @@ AC_ARG_ENABLE(isisd,
   AS_HELP_STRING([--disable-isisd], [do not build isisd]))
 AC_ARG_ENABLE(pimd,
   AS_HELP_STRING([--disable-pimd], [do not build pimd]))
+AC_ARG_ENABLE(pbrd,
+  AS_HELP_STRING([--disable-pbrd], [do not build pbrd]))
 AC_ARG_ENABLE(bgp-announce,
   AS_HELP_STRING([--disable-bgp-announce,], [turn off BGP route announcement]))
 AC_ARG_ENABLE(bgp-vnc,

--- a/tools/etc/iproute2/rt_protos.d/frr.conf
+++ b/tools/etc/iproute2/rt_protos.d/frr.conf
@@ -9,3 +9,4 @@
 192  eigrp
 193  ldp
 194  sharp
+195  pbr

--- a/tools/frr
+++ b/tools/frr
@@ -552,16 +552,19 @@ case "$1" in
 	  # Additionally if a new protocol is added
 	  # we need to add it here as well as
 	  # in rt_netlink.h( follow the directions! )
-          ip route flush proto 186
-          ip route flush proto 188
           ip route flush proto 4
+          ip route flush proto 11
+          ip route flush proto 42
+          ip route flush proto 186
+          ip route flush proto 187
+          ip route flush proto 188
           ip route flush proto 189
           ip route flush proto 190
-          ip route flush proto 11
-          ip route flush proto 187
-          ip route flush proto 192
-          ip route flush proto 42
           ip route flush proto 191
+          ip route flush proto 192
+          ip route flush proto 193
+          ip route flush proto 194
+          ip route flush proto 195
        else
          [ -n "$dmn" ] && eval "${dmn/-/_}=0"
          start_watchfrr

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -98,7 +98,8 @@ static inline int is_selfroute(int proto)
 	    || (proto == RTPROT_ISIS) || (proto == RTPROT_RIPNG)
 	    || (proto == RTPROT_NHRP) || (proto == RTPROT_EIGRP)
 	    || (proto == RTPROT_LDP) || (proto == RTPROT_BABEL)
-	    || (proto == RTPROT_RIP) || (proto == RTPROT_SHARP)) {
+	    || (proto == RTPROT_RIP) || (proto == RTPROT_SHARP)
+	    || (proto == RTPROT_PBR)) {
 		return 1;
 	}
 
@@ -142,7 +143,18 @@ static inline int zebra2proto(int proto)
 	case ZEBRA_ROUTE_SHARP:
 		proto = RTPROT_SHARP;
 		break;
+	case ZEBRA_ROUTE_PBR:
+		proto = RTPROT_PBR;
+		break;
 	default:
+		/*
+		 * When a user adds a new protocol this will show up
+		 * to let them know to do something about it.  This
+		 * is intentionally a warn because we should see
+		 * this as part of development of a new protocol
+		 */
+		zlog_warn("%s: Please add this protocol(%d) to proper rt_netlink.c handling",
+			  __PRETTY_FUNCTION__, proto);
 		proto = RTPROT_ZEBRA;
 		break;
 	}
@@ -184,7 +196,22 @@ static inline int proto2zebra(int proto, int family)
 	case RTPROT_STATIC:
 		proto = ZEBRA_ROUTE_STATIC;
 		break;
+	case RTPROT_SHARP:
+		proto = ZEBRA_ROUTE_SHARP;
+		break;
+	case RTPROT_PBR:
+		proto = ZEBRA_ROUTE_PBR;
+		break;
 	default:
+		/*
+		 * When a user adds a new protocol this will show up
+		 * to let them know to do something about it.  This
+		 * is intentionally a warn because we should see
+		 * this as part of development of a new protocol
+		 */
+		zlog_warn("%s: Please add this protocol(%d) to proper rt_netlink.c handling",
+			  __PRETTY_FUNCTION__,
+			  proto);
 		proto = ZEBRA_ROUTE_KERNEL;
 		break;
 	}

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -52,6 +52,7 @@
 #define RTPROT_EIGRP       192
 #define RTPROT_LDP         193
 #define RTPROT_SHARP       194
+#define RTPROT_PBR         195
 
 void rt_netlink_init(void);
 


### PR DESCRIPTION
1) FRR was not properly handling sharp and pbr for route installation in a couple of different cases
2) Cleanup pbr so you can turn the build off for it if you wanted to.
3) Make sharpd build by, `--enable-sharpd=yes` as opposed to it being in the dev build.  People are starting to find useful use cases for it that are beyond development tools.  Allow them to use the tool.