### PR TITLE
*: change struct evpn_addr to include a union of all evpn route types

### DIFF
--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -227,16 +227,18 @@ extern int bgp_build_evpn_prefix(int evpn_type, uint32_t eth_tag,
 	dst->family = AF_EVPN;
 	p_evpn_p->route_type = evpn_type;
 	if (evpn_type == BGP_EVPN_IP_PREFIX_ROUTE) {
-		p_evpn_p->eth_tag = eth_tag;
-		p_evpn_p->ip_prefix_length = p2.prefixlen;
+		p_evpn_p->prefix_addr.eth_tag = eth_tag;
+		p_evpn_p->prefix_addr.ip_prefix_length = p2.prefixlen;
 		if (src->family == AF_INET) {
-			SET_IPADDR_V4(&p_evpn_p->ip);
-			memcpy(&p_evpn_p->ip.ipaddr_v4, &src->u.prefix4,
+			SET_IPADDR_V4(&p_evpn_p->prefix_addr.ip);
+			memcpy(&p_evpn_p->prefix_addr.ip.ipaddr_v4,
+			       &src->u.prefix4,
 			       sizeof(struct in_addr));
 			dst->prefixlen = (uint8_t)PREFIX_LEN_ROUTE_TYPE_5_IPV4;
 		} else {
-			SET_IPADDR_V6(&p_evpn_p->ip);
-			memcpy(&p_evpn_p->ip.ipaddr_v6, &src->u.prefix6,
+			SET_IPADDR_V6(&p_evpn_p->prefix_addr.ip);
+			memcpy(&p_evpn_p->prefix_addr.ip.ipaddr_v6,
+			       &src->u.prefix6,
 			       sizeof(struct in6_addr));
 			dst->prefixlen = (uint8_t)PREFIX_LEN_ROUTE_TYPE_5_IPV6;
 		}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4624,7 +4624,7 @@ static void bgp_static_update_safi(struct bgp *bgp, struct prefix *p,
 		if (bgp_static->encap_tunneltype == BGP_ENCAP_TYPE_VXLAN) {
 			struct bgp_encap_type_vxlan bet;
 			memset(&bet, 0, sizeof(struct bgp_encap_type_vxlan));
-			bet.vnid = p->u.prefix_evpn.eth_tag;
+			bet.vnid = p->u.prefix_evpn.prefix_addr.eth_tag;
 			bgp_encap_type_vxlan_to_tlv(&bet, &attr);
 		}
 		if (bgp_static->router_mac) {
@@ -5099,10 +5099,10 @@ int bgp_static_set_safi(afi_t afi, safi_t safi, struct vty *vty,
 				return CMD_WARNING_CONFIG_FAILED;
 			}
 			if ((gw_ip.family == AF_INET
-			     && IS_EVPN_PREFIX_IPADDR_V6(
+			     && is_evpn_prefix_ipaddr_v6(
 					(struct prefix_evpn *)&p))
 			    || (gw_ip.family == AF_INET6
-				&& IS_EVPN_PREFIX_IPADDR_V4(
+				&& is_evpn_prefix_ipaddr_v4(
 					   (struct prefix_evpn *)&p))) {
 				vty_out(vty,
 					"%% GatewayIp family differs with IP prefix\n");
@@ -7063,10 +7063,10 @@ void route_vty_out_overlay(struct vty *vty, struct prefix *p,
 		vty_out(vty, "%s", str);
 		XFREE(MTYPE_TMP, str);
 
-		if (IS_EVPN_PREFIX_IPADDR_V4((struct prefix_evpn *)p)) {
+		if (is_evpn_prefix_ipaddr_v4((struct prefix_evpn *)p)) {
 			vty_out(vty, "/%s",
 				inet_ntoa(attr->evpn_overlay.gw_ip.ipv4));
-		} else if (IS_EVPN_PREFIX_IPADDR_V6((struct prefix_evpn *)p)) {
+		} else if (is_evpn_prefix_ipaddr_v6((struct prefix_evpn *)p)) {
 			vty_out(vty, "/%s",
 				inet_ntop(AF_INET6,
 					  &(attr->evpn_overlay.gw_ip.ipv6), buf,
@@ -11253,14 +11253,15 @@ static void bgp_config_write_network_evpn(struct vty *vty, struct bgp *bgp,
 			prefix_rd2str(prd, rdbuf, sizeof(rdbuf));
 			if (p->u.prefix_evpn.route_type == 5) {
 				char local_buf[PREFIX_STRLEN];
-				uint8_t family = IS_EVPN_PREFIX_IPADDR_V4((
+				uint8_t family = is_evpn_prefix_ipaddr_v4((
 							 struct prefix_evpn *)p)
 							 ? AF_INET
 							 : AF_INET6;
-				inet_ntop(family, &p->u.prefix_evpn.ip.ip.addr,
+				inet_ntop(family,
+					  &p->u.prefix_evpn.prefix_addr.ip.ip.addr,
 					  local_buf, PREFIX_STRLEN);
 				sprintf(buf, "%s/%u", local_buf,
-					p->u.prefix_evpn.ip_prefix_length);
+					p->u.prefix_evpn.prefix_addr.ip_prefix_length);
 			} else {
 				prefix2str(p, buf, sizeof(buf));
 			}
@@ -11272,7 +11273,8 @@ static void bgp_config_write_network_evpn(struct vty *vty, struct bgp *bgp,
 					  sizeof(buf2));
 			vty_out(vty,
 				"  network %s rd %s ethtag %u label %u esi %s gwip %s routermac %s\n",
-				buf, rdbuf, p->u.prefix_evpn.eth_tag,
+				buf, rdbuf,
+				p->u.prefix_evpn.prefix_addr.eth_tag,
 				decode_label(&bgp_static->label), esi, buf2,
 				macrouter);
 

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -635,7 +635,7 @@ static route_map_result_t route_match_mac_address(void *rule,
 
 		p.family = AF_ETHERNET;
 		p.prefixlen = ETH_ALEN * 8;
-		p.u.prefix_eth = prefix->u.prefix_evpn.mac;
+		p.u.prefix_eth = prefix->u.prefix_evpn.macip_addr.mac;
 
 		return (access_list_apply(alist, &p) == FILTER_DENY
 				? RMAP_NOMATCH


### PR DESCRIPTION
EVPN prefix depends on the EVPN route type.
Currently, in FRR we have a prefix_evpn/evpn_addr which relates to a evpn prefix.
We need to convert this to encompass an union of various EVPN route-types.

This diff handles the necessary code changes to adopt the new struct evpn_addr.

Signed-off-by: Mitesh Kanjariya <mitesh@cumulusnetworks.com>