### PR TITLE
lib: allow hostname to begin with a letter or number

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1873,7 +1873,7 @@ DEFUN (config_hostname,
 {
 	struct cmd_token *word = argv[1];
 
-	if (!isalpha((int)word->arg[0])) {
+	if (!isalnum((int)word->arg[0])) {
 		vty_out(vty, "Please specify string starting with alphabet\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}


### PR DESCRIPTION
Customers have requested the ability to name their devices starting
with a number instead of a letter.  This fix changes the check for
hostname to allow either a letter or a number.

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>