### PR TITLE
doc: Explain ecmp building and startup for zebra

### DIFF
--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -176,6 +176,14 @@ customize the build to include or exclude specific features and dependencies.
    With this option, we provide a way to strip out these characters for APK dev
    package builds.
 
+.. option:: --enable-multipath=X
+
+   Compile FRR with up to X way ECMP supported.  This number can be from 0-999.
+   For backwards compatability with older configure options when setting X = 0,
+   we will build FRR with 64 way ECMP.  This is needed because there are
+   hardcoded arrays that FRR builds towards, so we need to know how big to
+   make these arrays at build time.
+
 You may specify any combination of the above options to the configure
 script. By default, the executables are placed in :file:`/usr/local/sbin`
 and the configuration files in :file:`/usr/local/etc`. The :file:`/usr/local/`

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -31,6 +31,13 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 
    When program terminates, retain routes added by zebra.
 
+.. option:: -e X, --ecmp X
+
+   Run zebra with a limited ecmp ability compared to what it is compiled to.
+   If you are running zebra on hardware limited functionality you can
+   force zebra to limit the maximum ecmp allowed to X.  This number
+   is bounded by what you compiled FRR with as the maximum number.
+
 .. program:: configure
 
 .. _interface-commands:


### PR DESCRIPTION
Explain the --enable-ecmp=X configure option as well as
modify the zebra user doc to explain the -e X option.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>