### PR TITLE
zebra: Fix crash on *BSD

### DIFF
--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1386,7 +1386,7 @@ static void routing_socket(struct zebra_ns *zns)
 		zlog_err("routing_socket: Can't raise privileges");
 
 	routing_sock =
-		ns_socket(AF_ROUTE, SOCK_RAW, 0, (ns_id_t)zns->ns->ns_id);
+		ns_socket(AF_ROUTE, SOCK_RAW, 0, zns->ns_id);
 
 	if (routing_sock < 0) {
 		if (zserv_privs.change(ZPRIVS_LOWER))


### PR DESCRIPTION
The zns->ns pointer is not created until we get a callback
from the kernel that a ns exists.  This should potentially
fix a crash in the *BSD code path.

Fixes: #2152
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>