### PR TITLE
bgpd: Handle multiple PREFIX_SID's at a time.

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -308,6 +308,9 @@ extern int bgp_mp_reach_parse(struct bgp_attr_parser_args *args,
 			      struct bgp_nlri *);
 extern int bgp_mp_unreach_parse(struct bgp_attr_parser_args *args,
 				struct bgp_nlri *);
+extern bgp_attr_parse_ret_t
+bgp_attr_prefix_sid(int32_t tlength, struct bgp_attr_parser_args *args,
+		    struct bgp_nlri *mp_update);
 
 extern struct bgp_attr_encap_subtlv *
 encap_tlv_dup(struct bgp_attr_encap_subtlv *orig);


### PR DESCRIPTION
Handle multiple PREFIX_SID's at the same time.  The draft clearly
states that multiple should be handled and we have a actual pcap
file that clearly has multiple PREFIX_SID's at the same time.

Fixes: #2153
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>