### PR TITLE
eigrpd: Correctly calculate EIGRP packet MTU

### DIFF
--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -630,7 +630,7 @@ static struct eigrp_packet *eigrp_hello_encode(struct eigrp_interface *ei,
 	uint16_t length = EIGRP_HEADER_LEN;
 
 	// allocate a new packet to be sent
-	ep = eigrp_packet_new(ei->ifp->mtu - sizeof(struct ip), NULL);
+	ep = eigrp_packet_new(EIGRP_PACKET_MTU(ei->ifp->mtu), NULL);
 
 	if (ep) {
 		// encode common header feilds

--- a/eigrpd/eigrp_hello.c
+++ b/eigrpd/eigrp_hello.c
@@ -630,7 +630,7 @@ static struct eigrp_packet *eigrp_hello_encode(struct eigrp_interface *ei,
 	uint16_t length = EIGRP_HEADER_LEN;
 
 	// allocate a new packet to be sent
-	ep = eigrp_packet_new(ei->ifp->mtu, NULL);
+	ep = eigrp_packet_new(ei->ifp->mtu - sizeof(struct ip), NULL);
 
 	if (ep) {
 		// encode common header feilds

--- a/eigrpd/eigrp_macros.h
+++ b/eigrpd/eigrp_macros.h
@@ -35,6 +35,8 @@
 
 //--------------------------------------------------------------------------
 
+#define EIGRP_PACKET_MTU(mtu) ((mtu) - (sizeof(struct ip)))
+
 /* Topology Macros */
 
 

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -51,6 +51,7 @@
 #include "eigrpd/eigrp_zebra.h"
 #include "eigrpd/eigrp_vty.h"
 #include "eigrpd/eigrp_dump.h"
+#include "eigrpd/eigrp_macros.h"
 #include "eigrpd/eigrp_network.h"
 #include "eigrpd/eigrp_topology.h"
 #include "eigrpd/eigrp_fsm.h"
@@ -1088,7 +1089,7 @@ struct eigrp_packet *eigrp_packet_duplicate(struct eigrp_packet *old,
 {
 	struct eigrp_packet *new;
 
-	new = eigrp_packet_new(nbr->ei->ifp->mtu - sizeof(struct ip), nbr);
+	new = eigrp_packet_new(EIGRP_PACKET_MTU(nbr->ei->ifp->mtu), nbr);
 	new->length = old->length;
 	new->retrans_counter = old->retrans_counter;
 	new->dst = old->dst;

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -1088,7 +1088,7 @@ struct eigrp_packet *eigrp_packet_duplicate(struct eigrp_packet *old,
 {
 	struct eigrp_packet *new;
 
-	new = eigrp_packet_new(nbr->ei->ifp->mtu, nbr);
+	new = eigrp_packet_new(nbr->ei->ifp->mtu - sizeof(struct ip), nbr);
 	new->length = old->length;
 	new->retrans_counter = old->retrans_counter;
 	new->dst = old->dst;

--- a/eigrpd/eigrp_query.c
+++ b/eigrpd/eigrp_query.c
@@ -167,6 +167,7 @@ void eigrp_send_query(struct eigrp_interface *ei)
 	struct eigrp_prefix_entry *pe;
 	bool has_tlv = false;
 	bool new_packet = true;
+	uint16_t eigrp_mtu = ei->ifp->mtu - sizeof(struct ip);
 
 	for (ALL_LIST_ELEMENTS(ei->eigrp->topology_changes_internalIPV4, node,
 			       nnode, pe)) {
@@ -174,7 +175,7 @@ void eigrp_send_query(struct eigrp_interface *ei)
 			continue;
 
 		if (new_packet) {
-			ep = eigrp_packet_new(ei->ifp->mtu, NULL);
+			ep = eigrp_packet_new(eigrp_mtu, NULL);
 
 			/* Prepare EIGRP INIT UPDATE header */
 			eigrp_packet_header_init(EIGRP_OPC_QUERY, ei->eigrp,
@@ -197,7 +198,7 @@ void eigrp_send_query(struct eigrp_interface *ei)
 				listnode_add(pe->rij, nbr);
 		}
 
-		if (length + EIGRP_TLV_MAX_IPV4_BYTE > (uint16_t)ei->ifp->mtu) {
+		if (length + EIGRP_TLV_MAX_IPV4_BYTE > eigrp_mtu) {
 			if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
 			    && ei->params.auth_keychain != NULL) {
 				eigrp_make_md5_digest(ei, ep->s,

--- a/eigrpd/eigrp_query.c
+++ b/eigrpd/eigrp_query.c
@@ -167,7 +167,7 @@ void eigrp_send_query(struct eigrp_interface *ei)
 	struct eigrp_prefix_entry *pe;
 	bool has_tlv = false;
 	bool new_packet = true;
-	uint16_t eigrp_mtu = ei->ifp->mtu - sizeof(struct ip);
+	uint16_t eigrp_mtu = EIGRP_PACKET_MTU(ei->ifp->mtu);
 
 	for (ALL_LIST_ELEMENTS(ei->eigrp->topology_changes_internalIPV4, node,
 			       nnode, pe)) {

--- a/eigrpd/eigrp_reply.c
+++ b/eigrpd/eigrp_reply.c
@@ -85,7 +85,7 @@ void eigrp_send_reply(struct eigrp_neighbor *nbr, struct eigrp_prefix_entry *pe)
 	 * End of filtering
 	 */
 
-	ep = eigrp_packet_new(ei->ifp->mtu, nbr);
+	ep = eigrp_packet_new(ei->ifp->mtu - sizeof(struct ip), nbr);
 
 	/* Prepare EIGRP INIT UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_REPLY, eigrp, ep->s, 0,

--- a/eigrpd/eigrp_reply.c
+++ b/eigrpd/eigrp_reply.c
@@ -85,7 +85,7 @@ void eigrp_send_reply(struct eigrp_neighbor *nbr, struct eigrp_prefix_entry *pe)
 	 * End of filtering
 	 */
 
-	ep = eigrp_packet_new(ei->ifp->mtu - sizeof(struct ip), nbr);
+	ep = eigrp_packet_new(EIGRP_PACKET_MTU(ei->ifp->mtu), nbr);
 
 	/* Prepare EIGRP INIT UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_REPLY, eigrp, ep->s, 0,

--- a/eigrpd/eigrp_siaquery.c
+++ b/eigrpd/eigrp_siaquery.c
@@ -119,7 +119,7 @@ void eigrp_send_siaquery(struct eigrp_neighbor *nbr,
 	struct eigrp_packet *ep;
 	uint16_t length = EIGRP_HEADER_LEN;
 
-	ep = eigrp_packet_new(nbr->ei->ifp->mtu, nbr);
+	ep = eigrp_packet_new(nbr->ei->ifp->mtu - sizeof(struct ip), nbr);
 
 	/* Prepare EIGRP INIT UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_SIAQUERY, nbr->ei->eigrp, ep->s, 0,

--- a/eigrpd/eigrp_siaquery.c
+++ b/eigrpd/eigrp_siaquery.c
@@ -119,7 +119,7 @@ void eigrp_send_siaquery(struct eigrp_neighbor *nbr,
 	struct eigrp_packet *ep;
 	uint16_t length = EIGRP_HEADER_LEN;
 
-	ep = eigrp_packet_new(nbr->ei->ifp->mtu - sizeof(struct ip), nbr);
+	ep = eigrp_packet_new(EIGRP_PACKET_MTU(nbr->ei->ifp->mtu), nbr);
 
 	/* Prepare EIGRP INIT UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_SIAQUERY, nbr->ei->eigrp, ep->s, 0,

--- a/eigrpd/eigrp_siareply.c
+++ b/eigrpd/eigrp_siareply.c
@@ -118,7 +118,7 @@ void eigrp_send_siareply(struct eigrp_neighbor *nbr,
 	struct eigrp_packet *ep;
 	uint16_t length = EIGRP_HEADER_LEN;
 
-	ep = eigrp_packet_new(nbr->ei->ifp->mtu, nbr);
+	ep = eigrp_packet_new(nbr->ei->ifp->mtu - sizeof(struct ip), nbr);
 
 	/* Prepare EIGRP INIT UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_SIAREPLY, nbr->ei->eigrp, ep->s, 0,

--- a/eigrpd/eigrp_siareply.c
+++ b/eigrpd/eigrp_siareply.c
@@ -118,7 +118,7 @@ void eigrp_send_siareply(struct eigrp_neighbor *nbr,
 	struct eigrp_packet *ep;
 	uint16_t length = EIGRP_HEADER_LEN;
 
-	ep = eigrp_packet_new(nbr->ei->ifp->mtu - sizeof(struct ip), nbr);
+	ep = eigrp_packet_new(EIGRP_PACKET_MTU(nbr->ei->ifp->mtu), nbr);
 
 	/* Prepare EIGRP INIT UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_SIAREPLY, nbr->ei->eigrp, ep->s, 0,

--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -420,7 +420,7 @@ void eigrp_update_send_init(struct eigrp_neighbor *nbr)
 	struct eigrp_packet *ep;
 	uint16_t length = EIGRP_HEADER_LEN;
 
-	ep = eigrp_packet_new(nbr->ei->ifp->mtu - sizeof(struct ip), nbr);
+	ep = eigrp_packet_new(EIGRP_PACKET_MTU(nbr->ei->ifp->mtu), nbr);
 
 	/* Prepare EIGRP INIT UPDATE header */
 	if (IS_DEBUG_EIGRP_PACKET(0, RECV))
@@ -533,7 +533,7 @@ void eigrp_update_send_EOT(struct eigrp_neighbor *nbr)
 	struct eigrp *eigrp = ei->eigrp;
 	struct prefix *dest_addr;
 	uint32_t seq_no = eigrp->sequence_number;
-	uint16_t eigrp_mtu = ei->ifp->mtu - sizeof(struct ip);
+	uint16_t eigrp_mtu = EIGRP_PACKET_MTU(ei->ifp->mtu);
 	struct route_node *rn;
 
 	ep = eigrp_packet_new(eigrp_mtu, nbr);
@@ -604,7 +604,7 @@ void eigrp_update_send(struct eigrp_interface *ei)
 	struct eigrp *eigrp = ei->eigrp;
 	struct prefix *dest_addr;
 	uint32_t seq_no = eigrp->sequence_number;
-	uint16_t eigrp_mtu = ei->ifp->mtu - sizeof(struct ip);
+	uint16_t eigrp_mtu = EIGRP_PACKET_MTU(ei->ifp->mtu);
 
 	if (ei->nbrs->count == 0)
 		return;
@@ -790,7 +790,7 @@ static void eigrp_update_send_GR_part(struct eigrp_neighbor *nbr)
 		}
 	}
 
-	ep = eigrp_packet_new(ei->ifp->mtu - sizeof(struct ip), nbr);
+	ep = eigrp_packet_new(EIGRP_PACKET_MTU(ei->ifp->mtu), nbr);
 
 	/* Prepare EIGRP Graceful restart UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_UPDATE, eigrp, ep->s, flags,

--- a/eigrpd/eigrp_update.c
+++ b/eigrpd/eigrp_update.c
@@ -420,7 +420,7 @@ void eigrp_update_send_init(struct eigrp_neighbor *nbr)
 	struct eigrp_packet *ep;
 	uint16_t length = EIGRP_HEADER_LEN;
 
-	ep = eigrp_packet_new(nbr->ei->ifp->mtu, nbr);
+	ep = eigrp_packet_new(nbr->ei->ifp->mtu - sizeof(struct ip), nbr);
 
 	/* Prepare EIGRP INIT UPDATE header */
 	if (IS_DEBUG_EIGRP_PACKET(0, RECV))
@@ -533,10 +533,10 @@ void eigrp_update_send_EOT(struct eigrp_neighbor *nbr)
 	struct eigrp *eigrp = ei->eigrp;
 	struct prefix *dest_addr;
 	uint32_t seq_no = eigrp->sequence_number;
-	uint16_t mtu = ei->ifp->mtu;
+	uint16_t eigrp_mtu = ei->ifp->mtu - sizeof(struct ip);
 	struct route_node *rn;
 
-	ep = eigrp_packet_new(mtu, nbr);
+	ep = eigrp_packet_new(eigrp_mtu, nbr);
 
 	/* Prepare EIGRP EOT UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_UPDATE, eigrp, ep->s, EIGRP_EOT_FLAG,
@@ -557,13 +557,13 @@ void eigrp_update_send_EOT(struct eigrp_neighbor *nbr)
 			if (eigrp_nbr_split_horizon_check(te, ei))
 				continue;
 
-			if ((length + EIGRP_TLV_MAX_IPV4_BYTE) > mtu) {
+			if ((length + EIGRP_TLV_MAX_IPV4_BYTE) > eigrp_mtu) {
 				eigrp_update_place_on_nbr_queue(nbr, ep, seq_no,
 								length);
 				seq_no++;
 
 				length = EIGRP_HEADER_LEN;
-				ep = eigrp_packet_new(mtu, nbr);
+				ep = eigrp_packet_new(eigrp_mtu, nbr);
 				eigrp_packet_header_init(
 					EIGRP_OPC_UPDATE, nbr->ei->eigrp, ep->s,
 					EIGRP_EOT_FLAG, seq_no,
@@ -604,13 +604,14 @@ void eigrp_update_send(struct eigrp_interface *ei)
 	struct eigrp *eigrp = ei->eigrp;
 	struct prefix *dest_addr;
 	uint32_t seq_no = eigrp->sequence_number;
+	uint16_t eigrp_mtu = ei->ifp->mtu - sizeof(struct ip);
 
 	if (ei->nbrs->count == 0)
 		return;
 
 	uint16_t length = EIGRP_HEADER_LEN;
 
-	ep = eigrp_packet_new(ei->ifp->mtu, NULL);
+	ep = eigrp_packet_new(eigrp_mtu, NULL);
 
 	/* Prepare EIGRP INIT UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_UPDATE, eigrp, ep->s, 0, seq_no, 0);
@@ -633,8 +634,7 @@ void eigrp_update_send(struct eigrp_interface *ei)
 		if (eigrp_nbr_split_horizon_check(ne, ei))
 			continue;
 
-		if ((length + EIGRP_TLV_MAX_IPV4_BYTE)
-		    > (uint16_t)ei->ifp->mtu) {
+		if ((length + EIGRP_TLV_MAX_IPV4_BYTE) > eigrp_mtu) {
 			if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
 			    && (ei->params.auth_keychain != NULL)) {
 				eigrp_make_md5_digest(ei, ep->s,
@@ -651,7 +651,7 @@ void eigrp_update_send(struct eigrp_interface *ei)
 			eigrp_update_send_to_all_nbrs(ei, ep);
 
 			length = EIGRP_HEADER_LEN;
-			ep = eigrp_packet_new(ei->ifp->mtu, NULL);
+			ep = eigrp_packet_new(eigrp_mtu, NULL);
 			eigrp_packet_header_init(EIGRP_OPC_UPDATE, eigrp, ep->s,
 						 0, seq_no, 0);
 			if ((ei->params.auth_type == EIGRP_AUTH_TYPE_MD5)
@@ -790,7 +790,7 @@ static void eigrp_update_send_GR_part(struct eigrp_neighbor *nbr)
 		}
 	}
 
-	ep = eigrp_packet_new(ei->ifp->mtu, nbr);
+	ep = eigrp_packet_new(ei->ifp->mtu - sizeof(struct ip), nbr);
 
 	/* Prepare EIGRP Graceful restart UPDATE header */
 	eigrp_packet_header_init(EIGRP_OPC_UPDATE, eigrp, ep->s, flags,


### PR DESCRIPTION
Someone forgot that EIGRP packets are encapsulated in IP.

This fixes (one of the many) bugs mentioned in #1348.

Before the patch with 1500 MTU I was getting error in sendmsg in eigrp_write. Packets being sent were 1519 bytes long (IP + EIGRP). After the patch, longest packets I observe are 1490 bytes long and are being sent without an error.