### PR TITLE
eigrpd: Consider only feasible successors as successors

### DIFF
--- a/eigrpd/eigrp_topology.c
+++ b/eigrpd/eigrp_topology.c
@@ -443,17 +443,24 @@ void eigrp_topology_update_node_flags(struct eigrp_prefix_entry *dest)
 	struct eigrp *eigrp = eigrp_lookup();
 
 	for (ALL_LIST_ELEMENTS_RO(dest->entries, node, entry)) {
-		if (((uint64_t)entry->distance
-		     <= (uint64_t)dest->distance * (uint64_t)eigrp->variance)
-		    && entry->distance != EIGRP_MAX_METRIC) // is successor
-		{
-			entry->flags |= EIGRP_NEXTHOP_ENTRY_SUCCESSOR_FLAG;
-			entry->flags &= ~EIGRP_NEXTHOP_ENTRY_FSUCCESSOR_FLAG;
-		} else if (entry->reported_distance
-			   < dest->fdistance) // is feasible successor
-		{
-			entry->flags |= EIGRP_NEXTHOP_ENTRY_FSUCCESSOR_FLAG;
-			entry->flags &= ~EIGRP_NEXTHOP_ENTRY_SUCCESSOR_FLAG;
+		if (entry->reported_distance < dest->fdistance) {
+			// is feasible successor, can be successor
+			if (((uint64_t)entry->distance
+			     <= (uint64_t)dest->distance
+					* (uint64_t)eigrp->variance)
+			    && entry->distance != EIGRP_MAX_METRIC) {
+				// is successor
+				entry->flags |=
+					EIGRP_NEXTHOP_ENTRY_SUCCESSOR_FLAG;
+				entry->flags &=
+					~EIGRP_NEXTHOP_ENTRY_FSUCCESSOR_FLAG;
+			} else {
+				// is feasible successor only
+				entry->flags |=
+					EIGRP_NEXTHOP_ENTRY_FSUCCESSOR_FLAG;
+				entry->flags &=
+					~EIGRP_NEXTHOP_ENTRY_SUCCESSOR_FLAG;
+			}
 		} else {
 			entry->flags &= ~EIGRP_NEXTHOP_ENTRY_FSUCCESSOR_FLAG;
 			entry->flags &= ~EIGRP_NEXTHOP_ENTRY_SUCCESSOR_FLAG;


### PR DESCRIPTION
Meeting the feasibility condition is required also for routes meeting the variance condition. 

The current code results in routing loops practically in any network when `variance > 1` is set.

Before:

```
r2> show ip eigrp topology

EIGRP Topology Table for AS(1)/ID(10.100.0.37)

Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply
       r - reply Status, s - sia Status

P  10.100.0.0/30, 2 successors, FD is 30720, serno: 0
       via 10.100.0.25 (30720/28160), eth1
       via 10.100.0.38 (35840/33280), eth2
P  10.100.0.4/30, 2 successors, FD is 33280, serno: 0
       via 10.100.0.25 (33280/30720), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.8/30, 1 successors, FD is 28160, serno: 0
       via Connected, eth3
P  10.100.0.12/30, 2 successors, FD is 30720, serno: 0
       via 10.100.0.38 (30720/28160), eth2
       via 10.100.0.25 (35840/33280), eth1
P  10.100.0.16/30, 2 successors, FD is 33280, serno: 0
       via 10.100.0.25 (33280/30720), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.20/30, 2 successors, FD is 30720, serno: 0
       via 10.100.0.25 (30720/28160), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.24/30, 1 successors, FD is 28160, serno: 0
       via Connected, eth1
P  10.100.0.28/30, 2 successors, FD is 30720, serno: 0
       via 10.100.0.25 (30720/28160), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.32/30, 2 successors, FD is 30720, serno: 0
       via 10.100.0.38 (30720/28160), eth2
       via 10.100.0.25 (33280/30720), eth1
P  10.100.0.36/30, 1 successors, FD is 28160, serno: 0
       via Connected, eth2
P  10.100.0.40/30, 2 successors, FD is 30720, serno: 0
       via 10.100.0.38 (30720/28160), eth2
       via 10.100.0.25 (33280/30720), eth1
```

After:

```
r2> show ip eigrp topology

EIGRP Topology Table for AS(1)/ID(10.100.0.37)

Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply
       r - reply Status, s - sia Status

P  10.100.0.0/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.25 (30720/28160), eth1
P  10.100.0.4/30, 2 successors, FD is 33280, serno: 0
       via 10.100.0.25 (33280/30720), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.8/30, 1 successors, FD is 28160, serno: 0
       via Connected, eth3
P  10.100.0.12/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.38 (30720/28160), eth2
P  10.100.0.16/30, 2 successors, FD is 33280, serno: 0
       via 10.100.0.25 (33280/30720), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.20/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.25 (30720/28160), eth1
P  10.100.0.24/30, 1 successors, FD is 28160, serno: 0
       via Connected, eth1
P  10.100.0.28/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.25 (30720/28160), eth1
P  10.100.0.32/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.38 (30720/28160), eth2
P  10.100.0.36/30, 1 successors, FD is 28160, serno: 0
       via Connected, eth2
P  10.100.0.40/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.38 (30720/28160), eth2

r2> show ip eigrp topology all-links

EIGRP Topology Table for AS(1)/ID(10.100.0.37)

Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply
       r - reply Status, s - sia Status

P  10.100.0.0/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.25 (30720/28160), eth1
       via 10.100.0.38 (35840/33280), eth2
P  10.100.0.4/30, 2 successors, FD is 33280, serno: 0
       via 10.100.0.25 (33280/30720), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.8/30, 1 successors, FD is 28160, serno: 0
       via Connected, eth3
P  10.100.0.12/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.38 (30720/28160), eth2
       via 10.100.0.25 (35840/33280), eth1
P  10.100.0.16/30, 2 successors, FD is 33280, serno: 0
       via 10.100.0.25 (33280/30720), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.20/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.25 (30720/28160), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.24/30, 1 successors, FD is 28160, serno: 0
       via Connected, eth1
P  10.100.0.28/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.25 (30720/28160), eth1
       via 10.100.0.38 (33280/30720), eth2
P  10.100.0.32/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.38 (30720/28160), eth2
       via 10.100.0.25 (33280/30720), eth1
P  10.100.0.36/30, 1 successors, FD is 28160, serno: 0
       via Connected, eth2
P  10.100.0.40/30, 1 successors, FD is 30720, serno: 0
       via 10.100.0.38 (30720/28160), eth2
       via 10.100.0.25 (33280/30720), eth1
```