### PR TITLE
pimd: show ip igmp statistics command

### DIFF
--- a/pimd/COMMANDS
+++ b/pimd/COMMANDS
@@ -24,6 +24,7 @@ verification commands:
        show ip igmp groups retransmissions	IGMP group retransmission
        show ip igmp sources			IGMP sources information
        show ip igmp sources retransmissions	IGMP source retransmission
+       show ip igmp statistics			IGMP statistics information
        show ip pim address			PIM interface address
        show ip pim assert			PIM interface assert
        show ip pim assert-internal		PIM interface internal assert state

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -25,6 +25,7 @@
 #include <zebra.h>
 #include "vty.h"
 #include "linklist.h"
+#include "pim_igmp_stats.h"
 
 /*
   The following sizes are likely to support
@@ -94,6 +95,8 @@ struct igmp_sock {
 
 	struct list *igmp_group_list; /* list of struct igmp_group */
 	struct hash *igmp_group_hash;
+
+	struct igmp_stats rx_stats;
 };
 
 struct igmp_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,

--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -671,6 +671,9 @@ int igmp_mtrace_recv_qry_req(struct igmp_sock *igmp, struct ip *ip_hdr,
 		return -1;
 	}
 
+	/* Collecting IGMP Rx stats */
+	igmp->rx_stats.mtrace_req++;
+
 	if (PIM_DEBUG_MTRACE)
 		mtrace_debug(pim_ifp, mtracep, igmp_msg_len);
 
@@ -880,6 +883,9 @@ int igmp_mtrace_recv_response(struct igmp_sock *igmp, struct ip *ip_hdr,
 	}
 
 	mtracep->checksum = checksum;
+
+	/* Collecting IGMP Rx stats */
+	igmp->rx_stats.mtrace_rsp++;
 
 	if (PIM_DEBUG_MTRACE)
 		mtrace_debug(pim_ifp, mtracep, igmp_msg_len);

--- a/pimd/pim_igmp_stats.c
+++ b/pimd/pim_igmp_stats.c
@@ -1,0 +1,42 @@
+/*
+ * PIM for FRRouting
+ * Copyright (C) 2018  Mladen Sablic
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "pim_igmp_stats.h"
+
+void igmp_stats_init(struct igmp_stats *stats)
+{
+	memset(stats, 0, sizeof(struct igmp_stats));
+}
+
+void igmp_stats_add(struct igmp_stats *a, struct igmp_stats *b)
+{
+	if (!a || !b)
+		return;
+
+	a->query_v1 += b->query_v1;
+	a->query_v2 += b->query_v2;
+	a->query_v3 += b->query_v3;
+	a->report_v1 += b->report_v1;
+	a->report_v2 += b->report_v2;
+	a->report_v3 += b->report_v3;
+	a->leave_v2 += b->leave_v2;
+	a->mtrace_rsp += b->mtrace_rsp;
+	a->mtrace_req += b->mtrace_req;
+	a->unsupported += b->unsupported;
+}

--- a/pimd/pim_igmp_stats.h
+++ b/pimd/pim_igmp_stats.h
@@ -1,0 +1,41 @@
+/*
+ * PIM for FRRouting
+ * Copyright (C) 2018  Mladen Sablic
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef PIM_IGMP_STATS_H
+#define PIM_IGMP_STATS_H
+
+#include <zebra.h>
+
+struct igmp_stats {
+	uint32_t	query_v1;
+	uint32_t	query_v2;
+	uint32_t	query_v3;
+	uint32_t	report_v1;
+	uint32_t	report_v2;
+	uint32_t	report_v3;
+	uint32_t	leave_v2;
+	uint32_t	mtrace_rsp;
+	uint32_t	mtrace_req;
+	uint32_t	unsupported;
+};
+
+void igmp_stats_init(struct igmp_stats *stats);
+void igmp_stats_add(struct igmp_stats *a, struct igmp_stats *b);
+
+#endif /* PIM_IGMP_STATS_H */

--- a/pimd/pim_igmpv2.c
+++ b/pimd/pim_igmpv2.c
@@ -121,6 +121,9 @@ int igmp_v2_recv_report(struct igmp_sock *igmp, struct in_addr from,
 		return -1;
 	}
 
+	/* Collecting IGMP Rx stats */
+	igmp->rx_stats.report_v2++;
+
 	memcpy(&group_addr, igmp_msg + 4, sizeof(struct in_addr));
 
 	if (PIM_DEBUG_IGMP_PACKETS) {
@@ -166,6 +169,9 @@ int igmp_v2_recv_leave(struct igmp_sock *igmp, struct in_addr from,
 			from_str, ifp->name, igmp_msg_len, IGMP_V12_MSG_SIZE);
 		return -1;
 	}
+
+	/* Collecting IGMP Rx stats */
+	igmp->rx_stats.leave_v2++;
 
 	memcpy(&group_addr, igmp_msg + 4, sizeof(struct in_addr));
 

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1900,6 +1900,9 @@ int igmp_v3_recv_report(struct igmp_sock *igmp, struct in_addr from,
 		return -1;
 	}
 
+	/* Collecting IGMP Rx stats */
+	igmp->rx_stats.report_v3++;
+
 	num_groups = ntohs(
 		*(uint16_t *)(igmp_msg + IGMP_V3_REPORT_NUMGROUPS_OFFSET));
 	if (num_groups < 1) {

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -20,6 +20,7 @@ pimd_libpim_a_SOURCES = \
 	pimd/pim_ifchannel.c \
 	pimd/pim_igmp.c \
 	pimd/pim_igmp_mtrace.c \
+	pimd/pim_igmp_stats.c \
 	pimd/pim_igmpv2.c \
 	pimd/pim_igmpv3.c \
 	pimd/pim_instance.c \
@@ -69,6 +70,7 @@ noinst_HEADERS += \
 	pimd/pim_igmp.h \
 	pimd/pim_igmp_join.h \
 	pimd/pim_igmp_mtrace.h \
+	pimd/pim_igmp_stats.h \
 	pimd/pim_igmpv2.h \
 	pimd/pim_igmpv3.h \
 	pimd/pim_instance.h \


### PR DESCRIPTION
Command showing IGMP Rx statistics, useful for analyzing IGMP
activity on interfaces.

Signed-off-by: Mladen Sablic <mladen.sablic@gmail.com>