### PR TITLE
ospf6d: add newline to show debugging cmd

### DIFF
--- a/ospf6d/ospf6d.c
+++ b/ospf6d/ospf6d.c
@@ -97,7 +97,7 @@ DEFUN_NOSH (show_debugging_ospf6,
 	    DEBUG_STR
 	    OSPF6_STR)
 {
-	vty_out(vty, "OSPF6 debugging status:");
+	vty_out(vty, "OSPF6 debugging status:\n");
 
 	config_write_ospf6_debug(vty);
 


### PR DESCRIPTION

Testing Done:
Before:
OSPF6 debugging status:debug ospf6 lsa inter-router examine  <-- **newline required**
debug ospf6 lsa as-external examine
debug ospf6 route memory
debug ospf6 border-routers

After:
OSPF6 debugging status:
debug ospf6 lsa inter-router examine
debug ospf6 lsa as-external examine
debug ospf6 route memory
debug ospf6 border-routers

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>