### PR TITLE
frr: remove stamp-h.in

### DIFF
--- a/stamp-h.in
+++ b/stamp-h.in
@@ -1,1 +1,0 @@
-timestamp


### PR DESCRIPTION
No idea when this stopped being used, but I don't see any references to
it in Makefile.am's or configure.ac which is where it's supposed to be
used. Project builds fine without it...

Apparently these are supposed to be used as part of recipes for `config.h` that always needs to be rebuilt but never changes, so a workaround was to echo into this file and use it in a target recipe.

Edit: nvm this does look kinda necessary

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>