### PR TITLE
BGP: Preclude race condition between listener thread and core during shutdown

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -179,7 +179,7 @@ static int bgp_process_reads(struct thread *thread)
 
 	peer = THREAD_ARG(thread);
 
-	if (peer->fd < 0)
+	if (peer->fd < 0 || bm->terminating)
 		return -1;
 
 	struct frr_pthread *fpt = frr_pthread_get(PTHREAD_IO);

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -143,6 +143,8 @@ void sighup(void)
 __attribute__((__noreturn__)) void sigint(void)
 {
 	zlog_notice("Terminating on signal");
+	assert(bm->terminating == false);
+	bm->terminating = true;	/* global flag that shutting down */
 
 	if (!retain_mode)
 		bgp_terminate();

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7559,6 +7559,7 @@ void bgp_master_init(struct thread_master *master)
 	bm->start_time = bgp_clock();
 	bm->t_rmap_update = NULL;
 	bm->rmap_update_timer = RMAP_DEFAULT_UPDATE_TIMER;
+	bm->terminating = false;
 
 	bgp_process_queue_init();
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -144,6 +144,7 @@ struct bgp_master {
 	/* dynamic mpls label allocation pool */
 	struct labelpool labelpool;
 
+	bool terminating;	/* global flag that sigint terminate seen */
 	QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(bgp_master)


### PR DESCRIPTION
addresses #2184 

There is a secondary issue that once #2174 is fixed (or perhaps just avoided) there is another crash.  
I suspect that this crash is not thread related, so would go into another PR -- will know once fix is identified.
