### PR TITLE
Two fixes to improve bgp connections

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -200,11 +200,8 @@ void zebra_add_rnh_client(struct rnh *rnh, struct zserv *client,
 			   zebra_route_string(client->proto),
 			   rnh_str(rnh, buf, sizeof(buf)), type);
 	}
-	if (!listnode_lookup(rnh->client_list, client)) {
+	if (!listnode_lookup(rnh->client_list, client))
 		listnode_add(rnh->client_list, client);
-		send_client(rnh, client, type,
-			    vrf_id); // Pending: check if its needed
-	}
 }
 
 void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client,


### PR DESCRIPTION
1) When a client protocol requested NHT from zebra for a address, we would always get 2 responses for the request.  The first response typically just included the address we are watching.  As such bgp was interpreting this 'I got the packet' as a this address had no reachability and it would intentionally upset connections that were for that address.  The second response actually contained the resolved nht information.  There is no need to send this bogus response back to the higher level protocol since we always immediately respond once we have processed the request.

2) BGP is receiving EAGAIN messages for a getsockopt call.  We were interpreting this as an actual connection error as opposed to actually scheduling a check in the future.  Write a bit of code to notice when we have a try again message from the kernel and try again instead of assuming there has been a problem with the connection.