### PR TITLE
debianpkg: improve VTYSH_PAGER environment check

### DIFF
--- a/debianpkg/backports/ubuntu14.04/debian/frr.postinst
+++ b/debianpkg/backports/ubuntu14.04/debian/frr.postinst
@@ -18,7 +18,7 @@ chgrp ${frrvtygid} /etc/frr/vtysh*
 chmod 644 /etc/frr/*
 
 ENVIRONMENTFILE=/etc/environment
-if ! grep --quiet VTYSH_PAGER=/bin/cat ${ENVIRONMENTFILE}; then
+if ! egrep --quiet '^VTYSH_PAGER=' ${ENVIRONMENTFILE}; then
     echo "VTYSH_PAGER=/bin/cat"  >> ${ENVIRONMENTFILE}
 fi
 ##################################################

--- a/debianpkg/frr.postinst
+++ b/debianpkg/frr.postinst
@@ -19,7 +19,7 @@ chgrp ${frrvtygid} /etc/frr/vtysh*
 chmod 644 /etc/frr/*
 
 ENVIRONMENTFILE=/etc/environment
-if ! grep --quiet VTYSH_PAGER=/bin/cat ${ENVIRONMENTFILE}; then
+if ! egrep --quiet '^VTYSH_PAGER=' ${ENVIRONMENTFILE}; then
     echo "VTYSH_PAGER=/bin/cat"  >> ${ENVIRONMENTFILE}
 fi
 ##################################################


### PR DESCRIPTION
The current post-installation scripts for all Debian packages execute
grep 'VTYSH_PAGER=/bin/cat' to check if the VTYSH_PAGER variable is
present within /etc/environment.

While presence of that environment variable should be checked, the
current implementation does not handle this line being a comment (and
therefor not active) or the user picking a different VTYSH_PAGER than
/bin/cat.

This commit ensures that the environment variable can be freely changed
by the user, while still guaranteeing that it is present in the file
without being a comment.

Fixes #1995 

Signed-off-by: Pascal Mathis <mail@pascalmathis.com>