### PR TITLE
lib: Ported 'no (enable) password' from stable/3.0

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -55,18 +55,23 @@ Basic Config Commands
 
    Set hostname of the router.
 
-.. index:: password PASSWORD
+.. index::
+   single: no password PASSWORD
+   single: password PASSWORD
 
-.. clicmd:: password PASSWORD
+.. clicmd:: [no] password PASSWORD
 
-   Set password for vty interface. If there is no password, a vty won't
-   accept connections.
+   Set password for vty interface. The ``no`` form of the command deletes the
+   password. If there is no password, a vty won't accept connections.
 
-.. index:: enable password PASSWORD
+.. index::
+   single: no enable password PASSWORD
+   single: enable password PASSWORD
 
-.. clicmd:: enable password PASSWORD
+.. clicmd:: [no] enable password PASSWORD
 
-   Set enable password.
+   Set enable password. The ``no`` form of the command deletes the enable
+   password.
 
 .. index::
    single: no log trap [LEVEL]

--- a/lib/command.c
+++ b/lib/command.c
@@ -1895,7 +1895,7 @@ DEFUN (config_no_hostname,
 DEFUN (config_password,
        password_cmd,
        "password [(8-8)] WORD",
-       "Assign the terminal connection password\n"
+       "Modify the terminal connection password\n"
        "Specifies a HIDDEN password will follow\n"
        "The password string\n")
 {
@@ -1930,6 +1930,36 @@ DEFUN (config_password,
 			XSTRDUP(MTYPE_HOST, zencrypt(argv[idx_8]->arg));
 	} else
 		host.password = XSTRDUP(MTYPE_HOST, argv[idx_8]->arg);
+
+	return CMD_SUCCESS;
+}
+
+/* VTY interface password delete. */
+DEFUN (no_config_password,
+       no_password_cmd,
+       "no password",
+       NO_STR
+       "Modify the terminal connection password\n")
+{
+	bool warned = false;
+
+	if (host.password) {
+		vty_out(vty,
+			"Please be aware that removing the password is a security risk and "
+			"you should think twice about this command\n");
+		warned = true;
+		XFREE(MTYPE_HOST, host.password);
+	}
+	host.password = NULL;
+
+	if (host.password_encrypt) {
+		if (!warned)
+			vty_out(vty,
+				"Please be aware that removing the password is a security risk "
+				"and you should think twice about this command\n");
+		XFREE(MTYPE_HOST, host.password_encrypt);
+	}
+	host.password_encrypt = NULL;
 
 	return CMD_SUCCESS;
 }
@@ -1995,12 +2025,24 @@ DEFUN (no_config_enable_password,
        "Modify enable password parameters\n"
        "Assign the privileged level password\n")
 {
-	if (host.enable)
+	bool warned = false;
+
+	if (host.enable) {
+		vty_out(vty,
+			"Please be aware that removing the password is a security risk and "
+			"you should think twice about this command\n");
+		warned = true;
 		XFREE(MTYPE_HOST, host.enable);
+	}
 	host.enable = NULL;
 
-	if (host.enable_encrypt)
+	if (host.enable_encrypt) {
+		if (!warned)
+			vty_out(vty,
+				"Please be aware that removing the password is a security risk "
+				"and you should think twice about this command\n");
 		XFREE(MTYPE_HOST, host.enable_encrypt);
+	}
 	host.enable_encrypt = NULL;
 
 	return CMD_SUCCESS;
@@ -2710,6 +2752,7 @@ void cmd_init(int terminal)
 
 	if (terminal > 0) {
 		install_element(CONFIG_NODE, &password_cmd);
+		install_element(CONFIG_NODE, &no_password_cmd);
 		install_element(CONFIG_NODE, &enable_password_cmd);
 		install_element(CONFIG_NODE, &no_enable_password_cmd);
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2361,9 +2361,16 @@ DEFUNSH(VTYSH_ALL, no_vtysh_service_password_encrypt,
 
 DEFUNSH(VTYSH_ALL, vtysh_config_password, vtysh_password_cmd,
 	"password [(8-8)] LINE",
-	"Assign the terminal connection password\n"
+	"Modify the terminal connection password\n"
 	"Specifies a HIDDEN password will follow\n"
 	"The password string\n")
+{
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_ALL, no_vtysh_config_password, no_vtysh_password_cmd,
+	"no password", NO_STR
+	"Modify the terminal connection password\n")
 {
 	return CMD_SUCCESS;
 }
@@ -3605,6 +3612,7 @@ void vtysh_init_vty(void)
 	install_element(CONFIG_NODE, &no_vtysh_service_password_encrypt_cmd);
 
 	install_element(CONFIG_NODE, &vtysh_password_cmd);
+	install_element(CONFIG_NODE, &no_vtysh_password_cmd);
 	install_element(CONFIG_NODE, &vtysh_enable_password_cmd);
 	install_element(CONFIG_NODE, &no_vtysh_enable_password_cmd);
 }


### PR DESCRIPTION
The pull request #1545 from @donaldsharp introduced the command 'no
password' to remove an existing terminal connection password.
Additionally, warnings have been added to both 'no password' and 'no
enable password' to make the user aware of any security implications.

It seems that this specific pull request was never merged against master
and got lost. This commit is a cherry-pick of d4961273cb with fixed
conflicts and updated documentation.

Thanks to @donaldsharp and @pogojotz for the original PR.

Signed-off-by: Pascal Mathis <mail@pascalmathis.com>