### PR TITLE
Pim cleanup when networking restarts under itself

### DIFF
--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -62,7 +62,16 @@ void pim_if_init(struct pim_instance *pim)
 
 void pim_if_terminate(struct pim_instance *pim)
 {
-	// Nothing to do at this moment
+	struct interface *ifp;
+
+	FOR_ALL_INTERFACES (pim->vrf, ifp) {
+		struct pim_interface *pim_ifp = ifp->info;
+
+		if (!pim_ifp)
+			continue;
+
+		pim_if_delete(ifp);
+	}
 	return;
 }
 

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -124,11 +124,6 @@ static void pim_ifchannel_find_new_children(struct pim_ifchannel *ch)
 	}
 }
 
-void pim_ifchannel_free(struct pim_ifchannel *ch)
-{
-	XFREE(MTYPE_PIM_IFCHANNEL, ch);
-}
-
 void pim_ifchannel_delete(struct pim_ifchannel *ch)
 {
 	struct pim_interface *pim_ifp;
@@ -198,7 +193,7 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 		zlog_debug("%s: ifchannel entry %s is deleted ",
 			   __PRETTY_FUNCTION__, ch->sg_str);
 
-	pim_ifchannel_free(ch);
+	XFREE(MTYPE_PIM_IFCHANNEL, ch);
 }
 
 void pim_ifchannel_delete_all(struct interface *ifp)

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -114,7 +114,6 @@ RB_HEAD(pim_ifchannel_rb, pim_ifchannel);
 RB_PROTOTYPE(pim_ifchannel_rb, pim_ifchannel, pim_ifp_rb,
 	     pim_ifchannel_compare);
 
-void pim_ifchannel_free(struct pim_ifchannel *ch);
 void pim_ifchannel_delete(struct pim_ifchannel *ch);
 void pim_ifchannel_delete_all(struct interface *ifp);
 void pim_ifchannel_membership_clear(struct interface *ifp);

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -35,13 +35,6 @@
 
 static void pim_instance_terminate(struct pim_instance *pim)
 {
-	/* Traverse and cleanup rpf_hash */
-	if (pim->rpf_hash) {
-		hash_clean(pim->rpf_hash, (void *)pim_rp_list_hash_clean);
-		hash_free(pim->rpf_hash);
-		pim->rpf_hash = NULL;
-	}
-
 	if (pim->ssm_info) {
 		pim_ssm_terminate(pim->ssm_info);
 		pim->ssm_info = NULL;
@@ -53,6 +46,13 @@ static void pim_instance_terminate(struct pim_instance *pim)
 	pim_rp_free(pim);
 
 	pim_upstream_terminate(pim);
+
+	/* Traverse and cleanup rpf_hash */
+	if (pim->rpf_hash) {
+		hash_clean(pim->rpf_hash, (void *)pim_rp_list_hash_clean);
+		hash_free(pim->rpf_hash);
+		pim->rpf_hash = NULL;
+	}
 
 	pim_oil_terminate(pim);
 

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1176,8 +1176,7 @@ static void pim_msdp_peer_free(struct pim_msdp_peer *mp)
 	 * Let's make sure we are not running when we delete
 	 * the underlying data structure
 	 */
-	pim_msdp_peer_cr_timer_setup(mp, false);
-	pim_msdp_peer_ka_timer_setup(mp, false);
+	pim_msdp_peer_stop_tcp_conn(mp, false);
 
 	if (mp->ibuf) {
 		stream_free(mp->ibuf);
@@ -1190,6 +1189,8 @@ static void pim_msdp_peer_free(struct pim_msdp_peer *mp)
 	if (mp->mesh_group_name) {
 		XFREE(MTYPE_PIM_MSDP_MG_NAME, mp->mesh_group_name);
 	}
+
+	mp->pim = NULL;
 	XFREE(MTYPE_PIM_MSDP_PEER, mp);
 }
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -140,12 +140,6 @@ static struct pim_upstream *pim_upstream_find_parent(struct pim_instance *pim,
 	return NULL;
 }
 
-void pim_upstream_free(struct pim_upstream *up)
-{
-	XFREE(MTYPE_PIM_UPSTREAM, up);
-	up = NULL;
-}
-
 static void upstream_channel_oil_detach(struct pim_upstream *up)
 {
 	if (up->channel_oil) {
@@ -209,11 +203,6 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 
 	list_delete_and_null(&up->ifchannels);
 
-	/*
-	  notice that listnode_delete() can't be moved
-	  into pim_upstream_free() because the later is
-	  called by list_delete_all_node()
-	*/
 	if (up->parent && up->parent->sources)
 		listnode_delete(up->parent->sources, up);
 	up->parent = NULL;
@@ -237,7 +226,7 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 	}
 	pim_delete_tracked_nexthop(pim, &nht_p, up, NULL);
 
-	pim_upstream_free(up);
+	XFREE(MTYPE_PIM_UPSTREAM, up);
 
 	return NULL;
 }
@@ -1545,8 +1534,15 @@ unsigned int pim_upstream_hash_key(void *arg)
 
 void pim_upstream_terminate(struct pim_instance *pim)
 {
-	if (pim->upstream_list)
+	struct listnode *node, *nnode;
+	struct pim_upstream *up;
+
+	if (pim->upstream_list) {
+		for (ALL_LIST_ELEMENTS(pim->upstream_list, node, nnode, up))
+			pim_upstream_del(pim, up, __PRETTY_FUNCTION__);
+
 		list_delete_and_null(&pim->upstream_list);
+	}
 
 	if (pim->upstream_hash)
 		hash_free(pim->upstream_hash);
@@ -1773,6 +1769,5 @@ void pim_upstream_init(struct pim_instance *pim)
 					      pim_upstream_equal, hash_name);
 
 	pim->upstream_list = list_new();
-	pim->upstream_list->del = (void (*)(void *))pim_upstream_free;
 	pim->upstream_list->cmp = pim_upstream_compare;
 }

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -137,7 +137,6 @@ struct pim_upstream {
 	int64_t state_transition; /* Record current state uptime */
 };
 
-void pim_upstream_free(struct pim_upstream *up);
 struct pim_upstream *pim_upstream_find(struct pim_instance *pim,
 				       struct prefix_sg *sg);
 struct pim_upstream *pim_upstream_find_or_add(struct prefix_sg *sg,

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -69,6 +69,7 @@ static int pim_zebra_if_add(int command, struct zclient *zclient,
 			    zebra_size_t length, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
+	struct pim_instance *pim;
 
 	/*
 	  zebra api adds/dels interfaces using the same call
@@ -78,6 +79,7 @@ static int pim_zebra_if_add(int command, struct zclient *zclient,
 	if (!ifp)
 		return 0;
 
+	pim = pim_get_pim_instance(vrf_id);
 	if (PIM_DEBUG_ZEBRA) {
 		zlog_debug(
 			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
@@ -86,8 +88,19 @@ static int pim_zebra_if_add(int command, struct zclient *zclient,
 			if_is_operative(ifp));
 	}
 
-	if (if_is_operative(ifp))
+	if (if_is_operative(ifp)) {
+		struct pim_interface *pim_ifp;
+
+		pim_ifp = ifp->info;
+		/*
+		 * If we have a pim_ifp already and this is an if_add
+		 * that means that we probably have a vrf move event
+		 * If that is the case, set the proper vrfness.
+		 */
+		if (pim_ifp)
+			pim_ifp->pim = pim;
 		pim_if_addr_add_all(ifp);
+	}
 
 	/*
 	 * If we are a vrf device that is up, open up the pim_socket for
@@ -145,6 +158,7 @@ static int pim_zebra_if_del(int command, struct zclient *zclient,
 static int pim_zebra_if_state_up(int command, struct zclient *zclient,
 				 zebra_size_t length, vrf_id_t vrf_id)
 {
+	struct pim_instance *pim;
 	struct interface *ifp;
 	uint32_t table_id;
 
@@ -164,7 +178,19 @@ static int pim_zebra_if_state_up(int command, struct zclient *zclient,
 			if_is_operative(ifp));
 	}
 
+	pim = pim_get_pim_instance(vrf_id);
 	if (if_is_operative(ifp)) {
+		struct pim_interface *pim_ifp;
+
+		pim_ifp = ifp->info;
+		/*
+		 * If we have a pim_ifp already and this is an if_add
+		 * that means that we probably have a vrf move event
+		 * If that is the case, set the proper vrfness.
+		 */
+		if (pim_ifp)
+			pim_ifp->pim = pim;
+
 		/*
 		  pim_if_addr_add_all() suffices for bringing up both IGMP and
 		  PIM
@@ -274,6 +300,7 @@ static int pim_zebra_if_address_add(int command, struct zclient *zclient,
 	struct connected *c;
 	struct prefix *p;
 	struct pim_interface *pim_ifp;
+	struct pim_instance *pim;
 
 	/*
 	  zebra api notifies address adds/dels events by using the same call
@@ -327,8 +354,12 @@ static int pim_zebra_if_address_add(int command, struct zclient *zclient,
 	}
 
 	pim_if_addr_add(c);
-	if (pim_ifp)
+	if (pim_ifp) {
+		pim = pim_get_pim_instance(vrf_id);
+		pim_ifp->pim = pim;
+
 		pim_rp_check_on_if_add(pim_ifp);
+	}
 
 	if (if_is_loopback(c->ifp)) {
 		struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);


### PR DESCRIPTION
This is a series of commits that allows pim to work without crashing after networking under FRR is restarted in some manner.