### PR TITLE
pbrd: encode null fwmark to be consistent with zebra decode rule

### DIFF
--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -479,6 +479,7 @@ static void pbr_encode_pbr_map_sequence(struct stream *s,
 	stream_putw(s, 0);  /* src port */
 	pbr_encode_pbr_map_sequence_prefix(s, pbrms->dst, family);
 	stream_putw(s, 0);  /* dst port */
+	stream_putl(s, 0);  /* fwmark */
 	if (pbrms->nhgrp_name)
 		stream_putl(s, pbr_nht_get_table(pbrms->nhgrp_name));
 	else if (pbrms->nhg)


### PR DESCRIPTION
A null 4-byte long fwmark is encoded in pbr rule.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>