### PR TITLE
lib: Improved warnings for 'no (enable) password'

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1961,10 +1961,7 @@ DEFUN (no_config_password,
 
 	if (host.password) {
 		if (!vty_shell_serv(vty)) {
-			vty_out(vty,
-				"Please be aware that removing the password is "
-				"a security risk and you should think twice "
-				"about this command\n");
+			vty_out(vty, NO_PASSWD_CMD_WARNING);
 			warned = true;
 		}
 		XFREE(MTYPE_HOST, host.password);
@@ -1973,10 +1970,7 @@ DEFUN (no_config_password,
 
 	if (host.password_encrypt) {
 		if (!warned && !vty_shell_serv(vty))
-			vty_out(vty,
-				"Please be aware that removing the password is "
-				"a security risk and you should think twice "
-				"about this command\n");
+			vty_out(vty, NO_PASSWD_CMD_WARNING);
 		XFREE(MTYPE_HOST, host.password_encrypt);
 	}
 	host.password_encrypt = NULL;
@@ -2049,10 +2043,7 @@ DEFUN (no_config_enable_password,
 
 	if (host.enable) {
 		if (!vty_shell_serv(vty)) {
-			vty_out(vty,
-				"Please be aware that removing the password is "
-				"a security risk and you should think twice "
-				"about this command\n");
+			vty_out(vty, NO_PASSWD_CMD_WARNING);
 			warned = true;
 		}
 		XFREE(MTYPE_HOST, host.enable);
@@ -2061,10 +2052,7 @@ DEFUN (no_config_enable_password,
 
 	if (host.enable_encrypt) {
 		if (!warned && !vty_shell_serv(vty))
-			vty_out(vty,
-				"Please be aware that removing the password is "
-				"a security risk and you should think twice "
-				"about this command\n");
+			vty_out(vty, NO_PASSWD_CMD_WARNING);
 		XFREE(MTYPE_HOST, host.enable_encrypt);
 	}
 	host.enable_encrypt = NULL;

--- a/lib/command.c
+++ b/lib/command.c
@@ -1960,19 +1960,23 @@ DEFUN (no_config_password,
 	bool warned = false;
 
 	if (host.password) {
-		vty_out(vty,
-			"Please be aware that removing the password is a security risk and "
-			"you should think twice about this command\n");
-		warned = true;
+		if (!vty_shell_serv(vty)) {
+			vty_out(vty,
+				"Please be aware that removing the password is "
+				"a security risk and you should think twice "
+				"about this command\n");
+			warned = true;
+		}
 		XFREE(MTYPE_HOST, host.password);
 	}
 	host.password = NULL;
 
 	if (host.password_encrypt) {
-		if (!warned)
+		if (!warned && !vty_shell_serv(vty))
 			vty_out(vty,
-				"Please be aware that removing the password is a security risk "
-				"and you should think twice about this command\n");
+				"Please be aware that removing the password is "
+				"a security risk and you should think twice "
+				"about this command\n");
 		XFREE(MTYPE_HOST, host.password_encrypt);
 	}
 	host.password_encrypt = NULL;
@@ -2044,19 +2048,23 @@ DEFUN (no_config_enable_password,
 	bool warned = false;
 
 	if (host.enable) {
-		vty_out(vty,
-			"Please be aware that removing the password is a security risk and "
-			"you should think twice about this command\n");
-		warned = true;
+		if (!vty_shell_serv(vty)) {
+			vty_out(vty,
+				"Please be aware that removing the password is "
+				"a security risk and you should think twice "
+				"about this command\n");
+			warned = true;
+		}
 		XFREE(MTYPE_HOST, host.enable);
 	}
 	host.enable = NULL;
 
 	if (host.enable_encrypt) {
-		if (!warned)
+		if (!warned && !vty_shell_serv(vty))
 			vty_out(vty,
-				"Please be aware that removing the password is a security risk "
-				"and you should think twice about this command\n");
+				"Please be aware that removing the password is "
+				"a security risk and you should think twice "
+				"about this command\n");
 		XFREE(MTYPE_HOST, host.enable_encrypt);
 	}
 	host.enable_encrypt = NULL;

--- a/lib/command.h
+++ b/lib/command.h
@@ -376,6 +376,10 @@ struct cmd_node {
 
 #define CONF_BACKUP_EXT ".sav"
 
+/* Command warnings. */
+#define NO_PASSWD_CMD_WARNING                                                  \
+	"Please be aware that removing the password is a security risk and you should think twice about this command.\n"
+
 /* IPv4 only machine should not accept IPv6 address for peer's IP
    address.  So we replace VTY command string like below. */
 #define NEIGHBOR_ADDR_STR  "Neighbor address\nIPv6 address\n"

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2372,6 +2372,10 @@ DEFUNSH(VTYSH_ALL, no_vtysh_config_password, no_vtysh_password_cmd,
 	"no password", NO_STR
 	"Modify the terminal connection password\n")
 {
+	vty_out(vty,
+		"Please be aware that removing the password is a security risk "
+		"and you should think twice about this command\n");
+
 	return CMD_SUCCESS;
 }
 
@@ -2390,6 +2394,10 @@ DEFUNSH(VTYSH_ALL, no_vtysh_config_enable_password,
 	"Modify enable password parameters\n"
 	"Assign the privileged level password\n")
 {
+	vty_out(vty,
+		"Please be aware that removing the password is a security risk "
+		"and you should think twice about this command\n");
+
 	return CMD_SUCCESS;
 }
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2372,9 +2372,7 @@ DEFUNSH(VTYSH_ALL, no_vtysh_config_password, no_vtysh_password_cmd,
 	"no password", NO_STR
 	"Modify the terminal connection password\n")
 {
-	vty_out(vty,
-		"Please be aware that removing the password is a security risk "
-		"and you should think twice about this command\n");
+	vty_out(vty, NO_PASSWD_CMD_WARNING);
 
 	return CMD_SUCCESS;
 }
@@ -2394,9 +2392,7 @@ DEFUNSH(VTYSH_ALL, no_vtysh_config_enable_password,
 	"Modify enable password parameters\n"
 	"Assign the privileged level password\n")
 {
-	vty_out(vty,
-		"Please be aware that removing the password is a security risk "
-		"and you should think twice about this command\n");
+	vty_out(vty, NO_PASSWD_CMD_WARNING);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
When the user executes one of the commands 'no password' or 'no enable
password', a warning message gets shown to inform the user of the
security implications.

While the current implementation works, a warning message gets printed
once for each daemon, which can lead to seeing the same message many
times. This does not affect functionality, but looks like an error to
the user as it can be seen within issue #1432.

This commit only prints the warning message inside lib when vtysh
dispatch is not being used. Additionally, the warning message was copied
into the vtysh command handlers, so that they get printed exactly once.

Fixes #1432 

Signed-off-by: Pascal Mathis <mail@pascalmathis.com>