### PR TITLE
doc: support VPATH builds [5.0]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1913,8 +1913,13 @@ AC_MSG_RESULT($ac_cv_htonl_works)
 AC_CONFIG_FILES([Makefile
 	  bgpd/Makefile
 	  vtysh/Makefile
-	  doc/Makefile tests/Makefile
-	  bgpd/rfp-example/rfptest/Makefile bgpd/rfp-example/librfp/Makefile
+	  doc/Makefile
+	  doc/user/Makefile
+	  doc/manpages/Makefile
+	  doc/developer/Makefile
+	  tests/Makefile
+	  bgpd/rfp-example/rfptest/Makefile
+	  bgpd/rfp-example/librfp/Makefile
 	  redhat/frr.spec
 	  debianpkg/Makefile
 	  debianpkg/changelog

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -14,7 +14,7 @@
 .NOTPARALLEL:
 
 SUBDIRS = manpages user
-AM_MAKEFLAGS = DESTDIR=${DESTDIR} infodir=${infodir} doczdir=${abs_srcdir}
+AM_MAKEFLAGS = DESTDIR=${DESTDIR} infodir=${infodir}
 
 MANPAGE_BUILDDIR = manpages/_build/man
 

--- a/doc/developer/.gitignore
+++ b/doc/developer/.gitignore
@@ -1,3 +1,3 @@
 /_templates
 /_build
-!/Makefile
+!/Makefile.in

--- a/doc/developer/Makefile
+++ b/doc/developer/Makefile
@@ -1,1 +1,0 @@
-include ../frr-sphinx.mk

--- a/doc/developer/Makefile.in
+++ b/doc/developer/Makefile.in
@@ -1,0 +1,8 @@
+# This is necessary to support VPATH builds.
+srcdir = @srcdir@
+VPATH = @srcdir@
+
+# This variable is used as the documentation source location in frr-sphinx.mk
+SOURCESDIR = @srcdir@
+
+include @srcdir@/../frr-sphinx.mk

--- a/doc/developer/conf.py
+++ b/doc/developer/conf.py
@@ -342,6 +342,14 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
+# contents of ../extra/frrlexer.py.
+# This is read here to support VPATH build. Since this section is execfile()'d
+# with the file location, we can safely use a relative path here to save the
+# contents of the lexer file for later use even if our relative path changes
+# due to VPATH.
+with open('../extra/frrlexer.py', 'rb') as lex:
+    frrlexerpy = lex.read()
+
 # custom extensions here
 def setup(app):
     # object type for FRR CLI commands, can be extended to document parent CLI
@@ -357,5 +365,5 @@ def setup(app):
     #
     # frrlexer = pygments.lexers.load_lexer_from_file('../extra/frrlexer.py', lexername="FRRLexer")
     custom_namespace = {}
-    exec(open('../extra/frrlexer.py', 'rb').read(), custom_namespace)
+    exec(frrlexerpy, custom_namespace)
     lexers['frr'] = custom_namespace['FRRLexer']()

--- a/doc/frr-sphinx.mk
+++ b/doc/frr-sphinx.mk
@@ -10,6 +10,11 @@ SPHINXBUILD   ?= sphinx-build
 PAPER         ?=
 BUILDDIR      = _build
 
+# This is a custom FRR variable just for this docs subdirectory used to support
+# VPATH builds. Makefiles which include this file should override it to point
+# to the correct sources path.
+SOURCESDIR    ?= .
+
 # User-friendly check for sphinx-build
 ifneq ($(MAKECMDGOALS), clean)
     ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -23,9 +28,9 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCESDIR)
 # the i18n builder cannot share the environment and doctrees with the others
-I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCESDIR)
 
 .PHONY: help
 help:

--- a/doc/manpages/.gitignore
+++ b/doc/manpages/.gitignore
@@ -1,3 +1,3 @@
 /_templates
 /_build
-!/Makefile
+!/Makefile.in

--- a/doc/manpages/Makefile.in
+++ b/doc/manpages/Makefile.in
@@ -1,4 +1,11 @@
-include ../frr-sphinx.mk
+# This is necessary to support VPATH builds.
+srcdir = @srcdir@
+VPATH = @srcdir@
+
+# This variable is used as the documentation source location in frr-sphinx.mk
+SOURCESDIR = @srcdir@
+
+include @srcdir@/../frr-sphinx.mk
 
 # -----------------------------------------------------------------------------
 # Automake requires that 3rd-party Makefiles recognize these targets.

--- a/doc/user/.gitignore
+++ b/doc/user/.gitignore
@@ -1,3 +1,3 @@
 /_templates
 /_build
-!/Makefile
+!/Makefile.in

--- a/doc/user/Makefile.in
+++ b/doc/user/Makefile.in
@@ -1,4 +1,11 @@
-include ../frr-sphinx.mk
+# This is necessary to support VPATH builds.
+srcdir = @srcdir@
+VPATH = @srcdir@
+
+# This variable is used as the documentation source location in frr-sphinx.mk
+SOURCESDIR = @srcdir@
+
+include @srcdir@/../frr-sphinx.mk
 
 # -----------------------------------------------------------------------------
 # Automake requires that 3rd-party Makefiles recognize these targets.

--- a/doc/user/conf.py
+++ b/doc/user/conf.py
@@ -342,6 +342,14 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
+# contents of ../extra/frrlexer.py.
+# This is read here to support VPATH build. Since this section is execfile()'d
+# with the file location, we can safely use a relative path here to save the
+# contents of the lexer file for later use even if our relative path changes
+# due to VPATH.
+with open('../extra/frrlexer.py', 'rb') as lex:
+    frrlexerpy = lex.read()
+
 # custom extensions here
 def setup(app):
     # object type for FRR CLI commands, can be extended to document parent CLI
@@ -357,5 +365,5 @@ def setup(app):
     #
     # frrlexer = pygments.lexers.load_lexer_from_file('../extra/frrlexer.py', lexername="FRRLexer")
     custom_namespace = {}
-    exec(open('../extra/frrlexer.py', 'rb').read(), custom_namespace)
+    exec(frrlexerpy, custom_namespace)
     lexers['frr'] = custom_namespace['FRRLexer']()


### PR DESCRIPTION
Cherry-pick of the same from master.

-------------

Documentation was not fully using Automake / Autoconf and therefore needs
modifications to support black magic VPATH builds.

* Convert Makefile's to Autoconf-controlled Makefile.in's
* Tweak loading of pygments lexer to handle runtime paths
* Update .gitignore's as necessary

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>