### PR TITLE
Fix compilation against rtrlib with ssh

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -25,6 +25,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+/* If rtrlib compiled with ssh support, don`t fail build */
+#define LIBSSH_LEGACY_0_4
+
 #include <zebra.h>
 #include <pthread.h>
 #include <time.h>


### PR DESCRIPTION
Without this macro, build would stop at

`
In file included from /usr/include/libssh/libssh.h:670:0,
                 from /usr/include/rtrlib/transport/ssh/ssh_transport.h:27,
                 from /usr/include/rtrlib/rtrlib.h:25,
                 from bgp_rpki.c:49:
/usr/include/libssh/legacy.h:45:32: error: conflicting types for ‘buffer_free’
 SSH_DEPRECATED LIBSSH_API void buffer_free(ssh_buffer buffer);
`
