### PR TITLE
bgpd: Improve JSON support for large communities

### DIFF
--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -512,7 +512,7 @@ static int lcommunity_regexp_match(struct lcommunity *com, regex_t *reg)
 	if (com == NULL || com->size == 0)
 		str = "";
 	else
-		str = lcommunity_str(com);
+		str = lcommunity_str(com, false);
 
 	/* Regular expression match.  */
 	if (regexec(reg, str, 0, NULL, 0) == 0)
@@ -986,13 +986,8 @@ int lcommunity_list_set(struct community_list_handler *ch, const char *name,
 	entry->any = (str ? 0 : 1);
 	entry->u.lcom = lcom;
 	entry->reg = regex;
-	if (lcom)
-		entry->config = lcommunity_lcom2str(
-			lcom, LCOMMUNITY_FORMAT_COMMUNITY_LIST);
-	else if (regex)
-		entry->config = XSTRDUP(MTYPE_COMMUNITY_LIST_CONFIG, str);
-	else
-		entry->config = NULL;
+	entry->config =
+		(regex ? XSTRDUP(MTYPE_COMMUNITY_LIST_CONFIG, str) : NULL);
 
 	/* Do not put duplicated community entry.  */
 	if (community_list_dup_check(list, entry))

--- a/bgpd/bgp_lcommunity.h
+++ b/bgpd/bgp_lcommunity.h
@@ -21,10 +21,7 @@
 #ifndef _QUAGGA_BGP_LCOMMUNITY_H
 #define _QUAGGA_BGP_LCOMMUNITY_H
 
-/* Extended communities attribute string format.  */
-#define LCOMMUNITY_FORMAT_ROUTE_MAP            0
-#define LCOMMUNITY_FORMAT_COMMUNITY_LIST       1
-#define LCOMMUNITY_FORMAT_DISPLAY              2
+#include "lib/json.h"
 
 /* Large Communities value is twelve octets long.  */
 #define LCOMMUNITY_SIZE                        12
@@ -39,6 +36,9 @@ struct lcommunity {
 
 	/* Large Communities value.  */
 	uint8_t *val;
+
+	/* Large Communities as a json object */
+	json_object *json;
 
 	/* Human readable format string.  */
 	char *str;
@@ -65,10 +65,9 @@ extern void lcommunity_unintern(struct lcommunity **);
 extern unsigned int lcommunity_hash_make(void *);
 extern struct hash *lcommunity_hash(void);
 extern struct lcommunity *lcommunity_str2com(const char *);
-extern char *lcommunity_lcom2str(struct lcommunity *, int);
 extern int lcommunity_match(const struct lcommunity *,
 			    const struct lcommunity *);
-extern char *lcommunity_str(struct lcommunity *);
+extern char *lcommunity_str(struct lcommunity *, bool make_json);
 extern int lcommunity_include(struct lcommunity *lcom, uint8_t *ptr);
 extern void lcommunity_del_val(struct lcommunity *lcom, uint8_t *ptr);
 #endif /* _QUAGGA_BGP_LCOMMUNITY_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7414,7 +7414,6 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 	json_object *json_cluster_list = NULL;
 	json_object *json_cluster_list_list = NULL;
 	json_object *json_ext_community = NULL;
-	json_object *json_lcommunity = NULL;
 	json_object *json_last_update = NULL;
 	json_object *json_pmsi = NULL;
 	json_object *json_nexthop_global = NULL;
@@ -8041,13 +8040,12 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 		/* Line 6 display Large community */
 		if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES)) {
 			if (json_paths) {
-				json_lcommunity = json_object_new_object();
-				json_object_string_add(json_lcommunity,
-						       "string",
-						       attr->lcommunity->str);
+				if (!attr->lcommunity->json)
+					lcommunity_str(attr->lcommunity, true);
+				json_object_lock(attr->lcommunity->json);
 				json_object_object_add(json_path,
 						       "largeCommunity",
-						       json_lcommunity);
+						       attr->lcommunity->json);
 			} else {
 				vty_out(vty, "      Large Community: %s\n",
 					attr->lcommunity->str);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10859,7 +10859,7 @@ static void lcommunity_show_all_iterator(struct hash_backet *backet,
 
 	lcom = (struct lcommunity *)backet->data;
 	vty_out(vty, "[%p] (%ld) %s\n", (void *)lcom, lcom->refcnt,
-		lcommunity_str(lcom));
+		lcommunity_str(lcom, false));
 }
 
 /* Show BGP's community internal data. */
@@ -13606,6 +13606,24 @@ DEFUN (no_ip_community_list_expanded_all,
 	return CMD_SUCCESS;
 }
 
+/* Return configuration string of community-list entry.  */
+static const char *community_list_config_str(struct community_entry *entry)
+{
+	const char *str;
+
+	if (entry->any)
+		str = "";
+	else {
+		if (entry->style == COMMUNITY_LIST_STANDARD)
+			str = community_str(entry->u.com, false);
+		else if (entry->style == LARGE_COMMUNITY_LIST_STANDARD)
+			str = lcommunity_str(entry->u.lcom, false);
+		else
+			str = entry->config;
+	}
+	return str;
+}
+
 static void community_list_show(struct vty *vty, struct community_list *list)
 {
 	struct community_entry *entry;
@@ -13631,9 +13649,7 @@ static void community_list_show(struct vty *vty, struct community_list *list)
 		else
 			vty_out(vty, "    %s %s\n",
 				community_direct_str(entry->direct),
-				entry->style == COMMUNITY_LIST_STANDARD
-					? community_str(entry->u.com, false)
-					: entry->config);
+				community_list_config_str(entry));
 	}
 }
 
@@ -13985,9 +14001,7 @@ static void lcommunity_list_show(struct vty *vty, struct community_list *list)
 		else
 			vty_out(vty, "    %s %s\n",
 				community_direct_str(entry->direct),
-				entry->style == EXTCOMMUNITY_LIST_STANDARD
-					? entry->u.ecom->str
-					: entry->config);
+				community_list_config_str(entry));
 	}
 }
 
@@ -14222,9 +14236,7 @@ static void extcommunity_list_show(struct vty *vty, struct community_list *list)
 		else
 			vty_out(vty, "    %s %s\n",
 				community_direct_str(entry->direct),
-				entry->style == EXTCOMMUNITY_LIST_STANDARD
-					? entry->u.ecom->str
-					: entry->config);
+				community_list_config_str(entry));
 	}
 }
 
@@ -14273,22 +14285,6 @@ DEFUN (show_ip_extcommunity_list_arg,
 	extcommunity_list_show(vty, list);
 
 	return CMD_SUCCESS;
-}
-
-/* Return configuration string of community-list entry.  */
-static const char *community_list_config_str(struct community_entry *entry)
-{
-	const char *str;
-
-	if (entry->any)
-		str = "";
-	else {
-		if (entry->style == COMMUNITY_LIST_STANDARD)
-			str = community_str(entry->u.com, false);
-		else
-			str = entry->config;
-	}
-	return str;
 }
 
 /* Display community-list and extcommunity-list configuration.  */


### PR DESCRIPTION
The current implementation of building JSON output is greatly different
for large communities compared to standard communities. This is mainly
noticeable by the missing 'list' attribute, which usually offers an
array of all communities present on a BGP route.

This commit adds the missing functionality of properly returning a
'list' attribute in JSON output and also tries a similar approach like
the standard communities are using to implement this feature.

Additionally, the 'format' specifier has been completely removed from
large communities string/JSON rendering, as the official RFC8092 specifies that
there is only one canonical representation:

> The canonical representation of BGP Large Communities is three
> separate unsigned integers in decimal notation in the following
> order: Global Administrator, Local Data 1, Local Data 2. Numbers
> MUST NOT contain leading zeros; a zero value MUST be represented with
> a single zero. Each number is separated from the next by a single
> colon. For example: 64496:4294967295:2, 64496:0:0.

As the 'format' specifier has not been used/checked and only one
canonical representation exists per today, there was no reason to keep
the 'format' parameter in the function signature.

Last but not least, the struct attribute 'community_entry.config' is no
longer being used for large communities and instead 'lcommunity_str' is
being called to maintain a similar approach to standard communities.

As a side effect, this also fixed a memory leak inside 'community_entry_free'
which did not free the allocated memory for the 'config' attribute when
dealing with a large community.

Fixes #2206 

Signed-off-by: Pascal Mathis <mail@pascalmathis.com>