### PR TITLE
bgpd: Improve route-map matching for INET(6) AF

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -338,9 +338,8 @@ static route_map_result_t route_match_ip_address(void *rule,
 						 void *object)
 {
 	struct access_list *alist;
-	/* struct prefix_ipv4 match; */
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		alist = access_list_lookup(AFI_IP, (char *)rule);
 		if (alist == NULL)
 			return RMAP_NOMATCH;
@@ -382,7 +381,7 @@ static route_map_result_t route_match_ip_next_hop(void *rule,
 	struct bgp_info *bgp_info;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		bgp_info = object;
 		p.family = AF_INET;
 		p.prefix = bgp_info->attr->nexthop;
@@ -430,7 +429,7 @@ static route_map_result_t route_match_ip_route_source(void *rule,
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		bgp_info = object;
 		peer = bgp_info->peer;
 
@@ -478,7 +477,7 @@ route_match_ip_address_prefix_list(void *rule, struct prefix *prefix,
 {
 	struct prefix_list *plist;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		plist = prefix_list_lookup(AFI_IP, (char *)rule);
 		if (plist == NULL)
 			return RMAP_NOMATCH;
@@ -515,7 +514,7 @@ route_match_ip_next_hop_prefix_list(void *rule, struct prefix *prefix,
 	struct bgp_info *bgp_info;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		bgp_info = object;
 		p.family = AF_INET;
 		p.prefix = bgp_info->attr->nexthop;
@@ -558,7 +557,7 @@ route_match_ip_route_source_prefix_list(void *rule, struct prefix *prefix,
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		bgp_info = object;
 		peer = bgp_info->peer;
 
@@ -2239,7 +2238,7 @@ static route_map_result_t route_match_ipv6_address(void *rule,
 {
 	struct access_list *alist;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET6) {
 		alist = access_list_lookup(AFI_IP6, (char *)rule);
 		if (alist == NULL)
 			return RMAP_NOMATCH;
@@ -2326,7 +2325,7 @@ route_match_ipv6_address_prefix_list(void *rule, struct prefix *prefix,
 {
 	struct prefix_list *plist;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET6) {
 		plist = prefix_list_lookup(AFI_IP6, (char *)rule);
 		if (plist == NULL)
 			return RMAP_NOMATCH;


### PR DESCRIPTION
While the current implementation does pay attention to the AF
(inet/inet6) when comparing the IPv4/v6 address against an address-list
/ prefix-list inside a route-map, the AF check is being done rather
late, which leads to CPU cycles being wasted due to unnecessary list
lookups / address matching.

This commit checks the address family of a prefix right inside the
`route_match_ip(v6)_` functions before looking up any address- and/or
prefix-list, which should improve performance.

Fixes #1439 

Signed-off-by: Pascal Mathis <mail@pascalmathis.com>