### PR TITLE
Allow modification to number of netlink messages to process

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -275,7 +275,9 @@ static int netlink_information_fetch(struct sockaddr_nl *snl,
 static int kernel_read(struct thread *thread)
 {
 	struct zebra_ns *zns = (struct zebra_ns *)THREAD_ARG(thread);
-	netlink_parse_info(netlink_information_fetch, &zns->netlink, zns, 5, 0);
+	netlink_parse_info(netlink_information_fetch,
+			   &zns->netlink, zns,
+			   zebrad.nl_packets_to_process, 0);
 	zns->t_netlink = NULL;
 	thread_add_read(zebrad.master, kernel_read, zns, zns->netlink.sock,
 			&zns->t_netlink);

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -57,7 +57,7 @@
 /* Zebra instance */
 struct zebra_t zebrad = {
 	.rtm_table_default = 0,
-	.packets_to_process = ZEBRA_ZAPI_PACKETS_TO_PROCESS,
+	.zapi_packets_to_process = ZEBRA_ZAPI_PACKETS_TO_PROCESS,
 };
 
 /* process id. */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3346,6 +3346,22 @@ DEFUN_HIDDEN (no_zebra_packet_process,
 	return CMD_SUCCESS;
 }
 
+DEFPY_HIDDEN (zebra_nl_packet_process,
+	      zebra_nl_packet_process_cmd,
+	      "[no]$no zebra nl-packets (1-10000)$packets",
+	      ZEBRA_STR
+	      "NL Protocol\n"
+	      "Number of packets to process before relinquishing thread\n")
+{
+	if (no)
+		zebrad.nl_packets_to_process = ZEBRA_NL_PACKETS_TO_PROCESS;
+	else
+		zebrad.nl_packets_to_process = packets;
+
+	return CMD_SUCCESS;
+}
+
+
 DEFUN_HIDDEN (zebra_workqueue_timer,
 	      zebra_workqueue_timer_cmd,
 	      "zebra work-queue (0-10000)",
@@ -3423,6 +3439,10 @@ static int config_write_protocol(struct vty *vty)
 	if (zebrad.zapi_packets_to_process != ZEBRA_ZAPI_PACKETS_TO_PROCESS)
 		vty_out(vty, "zebra zapi-packets %u\n",
 			zebrad.zapi_packets_to_process);
+
+	if (zebrad.nl_packets_to_process != ZEBRA_NL_PACKETS_TO_PROCESS)
+		vty_out(vty, "zebra nl-packets %u\n",
+			zebrad.nl_packets_to_process);
 
 	enum multicast_mode ipv4_multicast_mode = multicast_mode_ipv4_get();
 
@@ -3713,6 +3733,7 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &no_zebra_workqueue_timer_cmd);
 	install_element(CONFIG_NODE, &zebra_packet_process_cmd);
 	install_element(CONFIG_NODE, &no_zebra_packet_process_cmd);
+	install_element(CONFIG_NODE, &zebra_nl_packet_process_cmd);
 
 	install_element(VIEW_NODE, &show_vrf_cmd);
 	install_element(VIEW_NODE, &show_vrf_vni_cmd);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3328,7 +3328,7 @@ DEFUN_HIDDEN (zebra_packet_process,
 {
 	uint32_t packets = strtoul(argv[2]->arg, NULL, 10);
 
-	zebrad.packets_to_process = packets;
+	zebrad.zapi_packets_to_process = packets;
 
 	return CMD_SUCCESS;
 }
@@ -3341,7 +3341,7 @@ DEFUN_HIDDEN (no_zebra_packet_process,
 	      "Zapi Protocol\n"
 	      "Number of packets to process before relinquishing thread\n")
 {
-	zebrad.packets_to_process = ZEBRA_ZAPI_PACKETS_TO_PROCESS;
+	zebrad.zapi_packets_to_process = ZEBRA_ZAPI_PACKETS_TO_PROCESS;
 
 	return CMD_SUCCESS;
 }
@@ -3420,9 +3420,9 @@ static int config_write_protocol(struct vty *vty)
 	if (zebrad.ribq->spec.hold != ZEBRA_RIB_PROCESS_HOLD_TIME)
 		vty_out(vty, "zebra work-queue %u\n", zebrad.ribq->spec.hold);
 
-	if (zebrad.packets_to_process != ZEBRA_ZAPI_PACKETS_TO_PROCESS)
+	if (zebrad.zapi_packets_to_process != ZEBRA_ZAPI_PACKETS_TO_PROCESS)
 		vty_out(vty, "zebra zapi-packets %u\n",
-			zebrad.packets_to_process);
+			zebrad.zapi_packets_to_process);
 
 	enum multicast_mode ipv4_multicast_mode = multicast_mode_ipv4_get();
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -377,7 +377,7 @@ static int zserv_read(struct thread *thread)
 #if defined(HANDLE_ZAPI_FUZZING)
 	int packets = 1;
 #else
-	int packets = zebrad.packets_to_process;
+	int packets = zebrad.zapi_packets_to_process;
 #endif
 	/* Get thread data.  Reset reading thread because I'm running. */
 	sock = THREAD_FD(thread);
@@ -497,7 +497,7 @@ static int zserv_read(struct thread *thread)
 
 	if (IS_ZEBRA_DEBUG_PACKET)
 		zlog_debug("Read %d packets",
-			   zebrad.packets_to_process - packets);
+			   zebrad.zapi_packets_to_process - packets);
 
 	/* Schedule job to process those packets */
 	thread_add_event(zebrad.master, &zserv_process_messages, client, 0,

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -167,6 +167,9 @@ struct zebra_t {
 
 #define ZEBRA_ZAPI_PACKETS_TO_PROCESS 10
 	uint32_t zapi_packets_to_process;
+
+#define ZEBRA_NL_PACKETS_TO_PROCESS 5
+	uint32_t nl_packets_to_process;
 };
 extern struct zebra_t zebrad;
 extern unsigned int multipath_num;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -166,7 +166,7 @@ struct zebra_t {
 	struct work_queue *lsp_process_q;
 
 #define ZEBRA_ZAPI_PACKETS_TO_PROCESS 10
-	uint32_t packets_to_process;
+	uint32_t zapi_packets_to_process;
 };
 extern struct zebra_t zebrad;
 extern unsigned int multipath_num;


### PR DESCRIPTION
Allow the end user to modify via a hidden command the number of netlink messages to read at one time.