### PR TITLE
frr: fix sanitizer builds under Ubuntu 18.04

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,8 +190,8 @@ AC_ARG_ENABLE([address-sanitizer], AS_HELP_STRING([--enable-address-sanitizer], 
               [enabled AddressSanitizer support for detecting a wide variety of \
                memory allocation and deallocation errors]), \
               [AC_DEFINE(HAVE_ADDRESS_SANITIZER, 1, [enable AddressSanitizer])
-              CFLAGS="$CFLAGS -fsanitize=address"
-              CXXFLAGS="$CXXFLAGS -fsanitize=address"
+              CFLAGS="$CFLAGS -fsanitize=address -static-libasan"
+              CXXFLAGS="$CXXFLAGS -fsanitize=address -static-libasan"
               AC_TRY_COMPILE([],[const int i=0;],[AC_MSG_NOTICE([Address Sanitizer Enabled])],
                                                  [AC_MSG_ERROR([Address Sanitizer not available])])
               ])

--- a/tools/lsan-suppressions.txt
+++ b/tools/lsan-suppressions.txt
@@ -3,3 +3,4 @@ leak:PyObject_Malloc
 leak:PyObject_Realloc
 leak:PyList_Append
 leak:malloc
+leak:PyObject_GC_Resize


### PR DESCRIPTION
* Add suppression for new Python binding leak
* Instruct GCC to statically link libasan per clang docs, as some users
  are having problems dynamically linking on Ubuntu 18.04 and perhaps
  other platforms; not necessary for Clang as it already does the right
  thing

Revised version of #2220

Reviewed-by: Lou Berger <lberger@labn.net>
Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>