### PR TITLE
redhat: Make watchfrr the default

### DIFF
--- a/redhat/daemons
+++ b/redhat/daemons
@@ -34,7 +34,7 @@
 # When using "vtysh" such a config file is also needed. It should be owned by
 # group "frrvty" and set to ug=rw,o= though. Check /etc/pam.d/frr, too.
 #
-watchfrr_enable=no
+watchfrr_enable=yes
 watchfrr_options=("-b_" "-r/usr/lib/frr/frr_restart_%s" "-s/usr/lib/frr/frr_start_%s" "-k/usr/lib/frr/frr_stop_%s")
 #
 zebra=no

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -448,6 +448,12 @@ done
 #  Config files won't get replaced by default, so we do this ugly hack to fix it
 %__sed -i 's|/etc/init.d/|%{_sbindir}/|g' %{_sysconfdir}/daemons 2> /dev/null || true
 
+# With systemd, watchfrr is mandatory. Fix config to make sure it's enabled if
+# we install or upgrade to a frr built with systemd
+%if "%{initsystem}" == "systemd"
+    %__sed -i 's|watchfrr_enable=no|watchfrr_enable=yes|g' %{_sysconfdir}/daemons 2> /dev/null || true
+%endif
+
 /sbin/install-info %{_infodir}/frr.info.gz %{_infodir}/dir
 
 # Create dummy files if they don't exist so basic functions can be used.


### PR DESCRIPTION
With systemd being the default on more systems now, lets
configure watchfrr to start else systemd systems on
redhat will not stay up for more than 1 minute.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>