### PR TITLE
zebra: upon zclient breaking, flush PBR entries

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -51,6 +51,7 @@
 #include "zebra/label_manager.h"
 #include "zebra/zebra_netns_notify.h"
 #include "zebra/zebra_rnh.h"
+#include "zebra/zebra_pbr.h"
 
 #define ZEBRA_PTM_SUPPORT
 
@@ -342,6 +343,7 @@ int main(int argc, char **argv)
 	zebra_mpls_init();
 	zebra_mpls_vty_init();
 	zebra_pw_vty_init();
+	zebra_pbr_init();
 
 /* For debug purpose. */
 /* SET_FLAG (zebra_debug_event, ZEBRA_DEBUG_EVENT); */

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -320,11 +320,20 @@ static void zebra_pbr_cleanup_rules(struct hash_backet *b, void *data)
 	}
 }
 
-void zebra_pbr_client_close_cleanup(int sock)
+static int zebra_pbr_client_close_cleanup(struct zserv *client)
 {
+	int sock = client->sock;
 	struct zebra_ns *zns = zebra_ns_lookup(NS_DEFAULT);
 
+	if (!sock)
+		return 0;
 	hash_iterate(zns->rules_hash, zebra_pbr_cleanup_rules, &sock);
+	return 1;
+}
+
+void zebra_pbr_init(void)
+{
+	hook_register(zapi_client_close, zebra_pbr_client_close_cleanup);
 }
 
 static void *pbr_ipset_alloc_intern(void *arg)

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -182,8 +182,6 @@ extern void kernel_pbr_iptable_add_del_status(struct zebra_pbr_iptable *iptable,
  */
 extern int kernel_pbr_rule_del(struct zebra_pbr_rule *rule);
 
-extern void zebra_pbr_client_close_cleanup(int sock);
-
 extern void zebra_pbr_rules_free(void *arg);
 extern uint32_t zebra_pbr_rules_hash_key(void *arg);
 extern int zebra_pbr_rules_hash_equal(const void *arg1, const void *arg2);
@@ -205,4 +203,5 @@ extern void zebra_pbr_iptable_free(void *arg);
 extern uint32_t zebra_pbr_iptable_hash_key(void *arg);
 extern int zebra_pbr_iptable_hash_equal(const void *arg1, const void *arg2);
 
+extern void zebra_pbr_init(void);
 #endif /* _ZEBRA_PBR_H */


### PR DESCRIPTION
In case, the BGP or PBR daemon leaves, the PBR contexts created by this
daemon are flushed.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>