### PR TITLE
doc: move -r option docs to zebra only

### DIFF
--- a/doc/manpages/common-options.rst
+++ b/doc/manpages/common-options.rst
@@ -157,10 +157,3 @@ frr supports optional dynamically loadable modules, although these can only be l
 
 The list of loaded modules can be inspected at runtime with the show modules VTY command.
 
-ROUTES
-------
-
-.. option:: -r, --retain
-
-   When the program terminates, retain routes added by the daemon.
-

--- a/doc/manpages/zebra.rst
+++ b/doc/manpages/zebra.rst
@@ -42,6 +42,14 @@ OPTIONS available for the |DAEMON| command:
 
    Enable namespace VRF backend. By default, the VRF backend relies on VRF-lite support from the Linux kernel. This option permits discovering Linux named network namespaces and mapping it to FRR VRF contexts.
 
+ROUTES
+------
+
+.. option:: -r, --retain
+
+   When the program terminates, do not flush routes installed by zebra from the kernel.
+
+
 FILES
 =====
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -30,10 +30,6 @@ be specified (:ref:`common-invocation-options`).
    Set the bgp protocol's port number. When port number is 0, that means do not
    listen bgp port.
 
-.. option:: -r, --retain
-
-   When program terminates, retain BGP routes added by zebra.
-
 .. option:: -l, --listenon
 
    Specify a specific IP address for bgpd to listen on, rather than its

--- a/doc/user/eigrpd.rst
+++ b/doc/user/eigrpd.rst
@@ -60,10 +60,6 @@ Certain signals have special meanings to *eigrpd*.
 
 .. program:: eigrpd
 
-.. option:: -r, --retain
-
-   When the program terminates, retain routes added by *eigrpd*.
-
 .. _eigrp-configuration:
 
 EIGRP Configuration

--- a/doc/user/ripd.rst
+++ b/doc/user/ripd.rst
@@ -60,9 +60,6 @@ Certain signals have special meanings to *ripd*.
 *ripd* invocation options. Common options that can be specified
 (:ref:`common-invocation-options`).
 
-.. option:: -r, --retain
-
-   When the program terminates, retain routes added by *ripd*.
 
 .. _rip-netmask:
 

--- a/doc/user/setup.rst
+++ b/doc/user/setup.rst
@@ -50,7 +50,7 @@ This file has several parts. Here is an example:
    # Check /etc/pam.d/frr if you intend to use "vtysh"!
    #
    vtysh_enable=yes
-   zebra_options=" -r -s 90000000 --daemon -A 127.0.0.1"
+   zebra_options=" -s 90000000 --daemon -A 127.0.0.1"
    bgpd_options="   --daemon -A 127.0.0.1"
    ospfd_options="  --daemon -A 127.0.0.1"
    ospf6d_options=" --daemon -A ::1"
@@ -86,7 +86,7 @@ reasons touched on in the VTYSH documentation and should generally be enabled.
 
 ::
 
-   zebra_options=" -r -s 90000000 --daemon -A 127.0.0.1"
+   zebra_options=" -s 90000000 --daemon -A 127.0.0.1"
    bgpd_options="   --daemon -A 127.0.0.1"
    ...
 

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -29,7 +29,8 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 
 .. option:: -r, --retain
 
-   When program terminates, retain routes added by zebra.
+   When program terminates, do not flush routes installed by *zebra* from the
+   kernel.
 
 .. option:: -e X, --ecmp X
 


### PR DESCRIPTION
This should have gone with the `-r` removal commit.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>