### PR TITLE
zebra: netlink cleanups

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -557,10 +557,11 @@ static int netlink_bridge_interface(struct nlmsghdr *h, int len, ns_id_t ns_id,
 	return 0;
 }
 
-/* Called from interface_lookup_netlink().  This function is only used
-   during bootstrap. */
-static int netlink_interface(struct sockaddr_nl *snl, struct nlmsghdr *h,
-			     ns_id_t ns_id, int startup)
+/*
+ * Called from interface_lookup_netlink().  This function is only used
+ * during bootstrap.
+ */
+static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 {
 	int len;
 	struct ifinfomsg *ifi;
@@ -874,8 +875,7 @@ int kernel_address_delete_ipv6(struct interface *ifp, struct connected *ifc)
 	return netlink_address(RTM_DELADDR, AF_INET6, ifp, ifc);
 }
 
-int netlink_interface_addr(struct sockaddr_nl *snl, struct nlmsghdr *h,
-			   ns_id_t ns_id, int startup)
+int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 {
 	int len;
 	struct ifaddrmsg *ifa;
@@ -1078,8 +1078,7 @@ static void if_netlink_check_ifp_instance_consistency(uint16_t cmd,
 	 */
 }
 
-int netlink_link_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
-			ns_id_t ns_id, int startup)
+int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 {
 	int len;
 	struct ifinfomsg *ifi;

--- a/zebra/if_netlink.h
+++ b/zebra/if_netlink.h
@@ -23,10 +23,9 @@
 
 #ifdef HAVE_NETLINK
 
-extern int netlink_interface_addr(struct sockaddr_nl *snl, struct nlmsghdr *h,
-				  ns_id_t ns_id, int startup);
-extern int netlink_link_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
-			       ns_id_t ns_id, int startup);
+extern int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id,
+				  int startup);
+extern int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup);
 extern int interface_lookup_netlink(struct zebra_ns *zns);
 
 #endif /* HAVE_NETLINK */

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -128,8 +128,7 @@ extern uint32_t nl_rcvbufsize;
 
 extern struct zebra_privs_t zserv_privs;
 
-int netlink_talk_filter(struct sockaddr_nl *snl, struct nlmsghdr *h,
-			ns_id_t ns_id, int startup)
+int netlink_talk_filter(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 {
 	/*
 	 * This is an error condition that must be handled during
@@ -244,8 +243,7 @@ static int netlink_socket(struct nlsock *nl, unsigned long groups,
 	return ret;
 }
 
-static int netlink_information_fetch(struct sockaddr_nl *snl,
-				     struct nlmsghdr *h, ns_id_t ns_id,
+static int netlink_information_fetch(struct nlmsghdr *h, ns_id_t ns_id,
 				     int startup)
 {
 	/*
@@ -259,25 +257,25 @@ static int netlink_information_fetch(struct sockaddr_nl *snl,
 	 */
 	switch (h->nlmsg_type) {
 	case RTM_NEWROUTE:
-		return netlink_route_change(snl, h, ns_id, startup);
+		return netlink_route_change(h, ns_id, startup);
 	case RTM_DELROUTE:
-		return netlink_route_change(snl, h, ns_id, startup);
+		return netlink_route_change(h, ns_id, startup);
 	case RTM_NEWLINK:
-		return netlink_link_change(snl, h, ns_id, startup);
+		return netlink_link_change(h, ns_id, startup);
 	case RTM_DELLINK:
-		return netlink_link_change(snl, h, ns_id, startup);
+		return netlink_link_change(h, ns_id, startup);
 	case RTM_NEWADDR:
-		return netlink_interface_addr(snl, h, ns_id, startup);
+		return netlink_interface_addr(h, ns_id, startup);
 	case RTM_DELADDR:
-		return netlink_interface_addr(snl, h, ns_id, startup);
+		return netlink_interface_addr(h, ns_id, startup);
 	case RTM_NEWNEIGH:
-		return netlink_neigh_change(snl, h, ns_id);
+		return netlink_neigh_change(h, ns_id);
 	case RTM_DELNEIGH:
-		return netlink_neigh_change(snl, h, ns_id);
+		return netlink_neigh_change(h, ns_id);
 	case RTM_NEWRULE:
-		return netlink_rule_change(snl, h, ns_id, startup);
+		return netlink_rule_change(h, ns_id, startup);
 	case RTM_DELRULE:
-		return netlink_rule_change(snl, h, ns_id, startup);
+		return netlink_rule_change(h, ns_id, startup);
 	default:
 		/*
 		 * If we have received this message then
@@ -512,8 +510,7 @@ const char *nl_rttype_to_str(uint8_t rttype)
  * startup -> Are we reading in under startup conditions? passed to
  *            the filter.
  */
-int netlink_parse_info(int (*filter)(struct sockaddr_nl *, struct nlmsghdr *,
-				     ns_id_t, int),
+int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 		       struct nlsock *nl, struct zebra_ns *zns, int count,
 		       int startup)
 {
@@ -691,7 +688,7 @@ int netlink_parse_info(int (*filter)(struct sockaddr_nl *, struct nlmsghdr *,
 				continue;
 			}
 
-			error = (*filter)(&snl, h, zns->ns_id, startup);
+			error = (*filter)(h, zns->ns_id, startup);
 			if (error < 0) {
 				zlog_err("%s filter function error", nl->name);
 				ret = error;
@@ -725,8 +722,7 @@ int netlink_parse_info(int (*filter)(struct sockaddr_nl *, struct nlmsghdr *,
  * startup  -> Are we reading in under startup conditions
  *             This is passed through eventually to filter.
  */
-int netlink_talk(int (*filter)(struct sockaddr_nl *, struct nlmsghdr *, ns_id_t,
-			       int startup),
+int netlink_talk(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 		 struct nlmsghdr *n, struct nlsock *nl, struct zebra_ns *zns,
 		 int startup)
 {

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -131,8 +131,20 @@ extern struct zebra_privs_t zserv_privs;
 int netlink_talk_filter(struct sockaddr_nl *snl, struct nlmsghdr *h,
 			ns_id_t ns_id, int startup)
 {
-	zlog_warn("netlink_talk: ignoring message type 0x%04x NS %u",
-		  h->nlmsg_type, ns_id);
+	/*
+	 * This is an error condition that must be handled during
+	 * development.
+	 *
+	 * The netlink_talk_filter function is used for communication
+	 * down the netlink_cmd pipe and we are expecting
+	 * an ack being received.  So if we get here
+	 * then we did not receive the ack and instead
+	 * received some other message in an unexpected
+	 * way.
+	 */
+	zlog_err("%s: ignoring message type 0x%04x(%s) NS %u",
+		 __PRETTY_FUNCTION__, h->nlmsg_type,
+		 nl_msg_type_to_str(h->nlmsg_type), ns_id);
 	return 0;
 }
 
@@ -242,6 +254,15 @@ static int netlink_information_fetch(struct sockaddr_nl *snl,
 		return 0;
 	}
 
+	/*
+	 * When we handle new message types here
+	 * because we are starting to install them
+	 * then lets check the netlink_install_filter
+	 * and see if we should add the corresponding
+	 * allow through entry there.
+	 * Probably not needed to do but please
+	 * think about it.
+	 */
 	switch (h->nlmsg_type) {
 	case RTM_NEWROUTE:
 		return netlink_route_change(snl, h, ns_id, startup);
@@ -264,9 +285,16 @@ static int netlink_information_fetch(struct sockaddr_nl *snl,
 	case RTM_DELRULE:
 		return netlink_rule_change(snl, h, ns_id, startup);
 	default:
-		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug("Unknown netlink nlmsg_type %d vrf %u\n",
-				   h->nlmsg_type, ns_id);
+		/*
+		 * If we have received this message then
+		 * we have made a mistake during development
+		 * and we need to write some code to handle
+		 * this message type or not ask for
+		 * it to be sent up to us
+		 */
+		zlog_err("Unknown netlink nlmsg_type %s(%d) vrf %u\n",
+			 nl_msg_type_to_str(h->nlmsg_type), h->nlmsg_type,
+			 ns_id);
 		break;
 	}
 	return 0;
@@ -283,31 +311,69 @@ static int kernel_read(struct thread *thread)
 	return 0;
 }
 
-/* Filter out messages from self that occur on listener socket,
+/*
+ * Filter out messages from self that occur on listener socket,
  * caused by our actions on the command socket
+ *
+ * When we add new Netlink message types we probably
+ * do not need to add them here as that we are filtering
+ * on the routes we actually care to receive( which is rarer
+ * then the normal course of operations).  We are intentionally
+ * allowing some messages from ourselves through
+ * ( I'm looking at you Interface based netlink messages )
+ * so that we only had to write one way to handle incoming
+ * address add/delete changes.
  */
 static void netlink_install_filter(int sock, __u32 pid)
 {
+	/*
+	 * BPF_JUMP instructions and where you jump to are based upon
+	 * 0 as being the next statement.  So count from 0.  Writing
+	 * this down because every time I look at this I have to
+	 * re-remember it.
+	 */
 	struct sock_filter filter[] = {
-		/* 0: ldh [4]	          */
-		BPF_STMT(BPF_LD | BPF_ABS | BPF_H,
-			 offsetof(struct nlmsghdr, nlmsg_type)),
-		/* 1: jeq 0x18 jt 5 jf next  */
-		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, htons(RTM_NEWROUTE), 3, 0),
-		/* 2: jeq 0x19 jt 5 jf next  */
-		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, htons(RTM_DELROUTE), 2, 0),
-		/* 3: jeq 0x19 jt 5 jf next  */
-		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, htons(RTM_NEWNEIGH), 1, 0),
-		/* 4: jeq 0x19 jt 5 jf 8  */
-		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, htons(RTM_DELNEIGH), 0, 3),
-		/* 5: ldw [12]		  */
+		/*
+		 * Logic:
+		 *   if (nlmsg_pid == pid) {
+		 *       if (the incoming nlmsg_type ==
+		 *           RTM_NEWADDR | RTM_DELADDR)
+		 *           keep this message
+		 *       else
+		 *           skip this message
+		 *   } else
+		 *       keep this netlink message
+		 */
+		/*
+		 * 0: Load the nlmsg_pid into the BPF register
+		 */
 		BPF_STMT(BPF_LD | BPF_ABS | BPF_W,
 			 offsetof(struct nlmsghdr, nlmsg_pid)),
-		/* 6: jeq XX  jt 7 jf 8   */
-		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, htonl(pid), 0, 1),
-		/* 7: ret 0    (skip)     */
+		/*
+		 * 1: Compare to pid
+		 */
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, htonl(pid), 0, 4),
+		/*
+		 * 2: Load the nlmsg_type into BPF register
+		 */
+		BPF_STMT(BPF_LD | BPF_ABS | BPF_H,
+			 offsetof(struct nlmsghdr, nlmsg_type)),
+		/*
+		 * 3: Compare to RTM_NEWADDR
+		 */
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, htons(RTM_NEWADDR), 2, 0),
+		/*
+		 * 4: Compare to RTM_DELADDR
+		 */
+		BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, htons(RTM_DELADDR), 1, 0),
+		/*
+		 * 5: This is the end state of we want to skip the
+		 *    message
+		 */
 		BPF_STMT(BPF_RET | BPF_K, 0),
-		/* 8: ret 0xffff (keep)   */
+		/* 6: This is the end state of we want to keep
+		 *     the message
+		 */
 		BPF_STMT(BPF_RET | BPF_K, 0xffff),
 	};
 
@@ -619,23 +685,6 @@ int netlink_parse_info(int (*filter)(struct sockaddr_nl *, struct nlmsghdr *,
 					nl_msg_type_to_str(h->nlmsg_type),
 					h->nlmsg_type, h->nlmsg_len,
 					h->nlmsg_seq, h->nlmsg_pid);
-
-			/* skip unsolicited messages originating from command
-			 * socket
-			 * linux sets the originators port-id for {NEW|DEL}ADDR
-			 * messages,
-			 * so this has to be checked here. */
-			if (nl != &zns->netlink_cmd
-			    && h->nlmsg_pid == zns->netlink_cmd.snl.nl_pid
-			    && (h->nlmsg_type != RTM_NEWADDR
-				&& h->nlmsg_type != RTM_DELADDR)) {
-				if (IS_ZEBRA_DEBUG_KERNEL)
-					zlog_debug(
-						"netlink_parse_info: %s packet comes from %s",
-						zns->netlink_cmd.name,
-						nl->name);
-				continue;
-			}
 
 			error = (*filter)(&snl, h, zns->ns_id, startup);
 			if (error < 0) {

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -248,12 +248,6 @@ static int netlink_information_fetch(struct sockaddr_nl *snl,
 				     struct nlmsghdr *h, ns_id_t ns_id,
 				     int startup)
 {
-	/* JF: Ignore messages that aren't from the kernel */
-	if (snl->nl_pid != 0) {
-		zlog_err("Ignoring message from pid %u", snl->nl_pid);
-		return 0;
-	}
-
 	/*
 	 * When we handle new message types here
 	 * because we are starting to install them
@@ -685,6 +679,17 @@ int netlink_parse_info(int (*filter)(struct sockaddr_nl *, struct nlmsghdr *,
 					nl_msg_type_to_str(h->nlmsg_type),
 					h->nlmsg_type, h->nlmsg_len,
 					h->nlmsg_seq, h->nlmsg_pid);
+
+
+			/*
+			 * Ignore messages that maybe sent from
+			 * other actors besides the kernel
+			 */
+			if (snl.nl_pid != 0) {
+				zlog_err("Ignoring message from pid %u",
+					 snl.nl_pid);
+				continue;
+			}
 
 			error = (*filter)(&snl, h, zns->ns_id, startup);
 			if (error < 0) {

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -836,11 +836,24 @@ void kernel_init(struct zebra_ns *zns)
 {
 	unsigned long groups;
 
-	/* Initialize netlink sockets */
-	groups = RTMGRP_LINK | RTMGRP_IPV4_ROUTE | RTMGRP_IPV4_IFADDR
-		 | RTMGRP_IPV6_ROUTE | RTMGRP_IPV6_IFADDR | RTMGRP_IPV4_MROUTE
-		 | RTMGRP_NEIGH
-		 | RTNLGRP_IPV4_RULE | RTNLGRP_IPV6_RULE;
+	/*
+	 * Initialize netlink sockets
+	 *
+	 * If RTMGRP_XXX exists use that, but at some point
+	 * I think the kernel developers realized that
+	 * keeping track of all the different values would
+	 * lead to confusion, so we need to convert the
+	 * RTNLGRP_XXX to a bit position for ourself
+	 */
+	groups = RTMGRP_LINK                   |
+		RTMGRP_IPV4_ROUTE              |
+		RTMGRP_IPV4_IFADDR             |
+		RTMGRP_IPV6_ROUTE              |
+		RTMGRP_IPV6_IFADDR             |
+		RTMGRP_IPV4_MROUTE             |
+		RTMGRP_NEIGH                   |
+		(1 << (RTNLGRP_IPV4_RULE - 1)) |
+		(1 << (RTNLGRP_IPV6_RULE - 1));
 
 	snprintf(zns->netlink.name, sizeof(zns->netlink.name),
 		 "netlink-listen (NS %u)", zns->ns_id);

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -45,14 +45,11 @@ extern const char *nl_rtproto_to_str(uint8_t rtproto);
 extern const char *nl_family_to_str(uint8_t family);
 extern const char *nl_rttype_to_str(uint8_t rttype);
 
-extern int netlink_parse_info(int (*filter)(struct sockaddr_nl *,
-					    struct nlmsghdr *, ns_id_t, int),
+extern int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 			      struct nlsock *nl, struct zebra_ns *zns,
 			      int count, int startup);
-extern int netlink_talk_filter(struct sockaddr_nl *, struct nlmsghdr *, ns_id_t,
-			       int startup);
-extern int netlink_talk(int (*filter)(struct sockaddr_nl *, struct nlmsghdr *,
-				      ns_id_t, int startup),
+extern int netlink_talk_filter(struct nlmsghdr *h, ns_id_t ns, int startup);
+extern int netlink_talk(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 			struct nlmsghdr *n, struct nlsock *nl,
 			struct zebra_ns *zns, int startup);
 extern int netlink_request(struct nlsock *nl, struct nlmsghdr *n);

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -58,12 +58,10 @@ void rt_netlink_init(void);
 
 extern int netlink_mpls_multipath(int cmd, zebra_lsp_t *lsp);
 
-extern int netlink_route_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
-				ns_id_t ns_id, int startup);
+extern int netlink_route_change(struct nlmsghdr *h, ns_id_t ns_id, int startup);
 extern int netlink_route_read(struct zebra_ns *zns);
 
-extern int netlink_neigh_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
-				ns_id_t ns_id);
+extern int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id);
 extern int netlink_macfdb_read(struct zebra_ns *zns);
 extern int netlink_macfdb_read_for_bridge(struct zebra_ns *zns,
 					  struct interface *ifp,

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -166,8 +166,7 @@ void kernel_del_pbr_rule(struct zebra_pbr_rule *rule)
  * notification of interest. The expectation is that if this corresponds
  * to a PBR rule added by FRR, it will be readded.
  */
-int netlink_rule_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
-			ns_id_t ns_id, int startup)
+int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 {
 	struct zebra_ns *zns;
 	struct fib_rule_hdr *frh;

--- a/zebra/rule_netlink.h
+++ b/zebra/rule_netlink.h
@@ -29,8 +29,7 @@
 /*
  * Handle netlink notification informing a rule add or delete.
  */
-extern int netlink_rule_change(struct sockaddr_nl *snl, struct nlmsghdr *h,
-				ns_id_t ns_id, int startup);
+extern int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup);
 
 /*
  * Get to know existing PBR rules in the kernel - typically called at startup.


### PR DESCRIPTION
1) Make sure we ignore rules from ourselves
2) Remove the snl variable from being passed around.
