### PR TITLE
doc: update doc titles [5.0]

### DIFF
--- a/doc/developer/index.rst
+++ b/doc/developer/index.rst
@@ -1,5 +1,5 @@
-Welcome to FRR's documentation!
-===============================
+FRRouting Developer's Guide
+===========================
 
 .. toctree::
    :maxdepth: 2

--- a/doc/manpages/index.rst
+++ b/doc/manpages/index.rst
@@ -3,9 +3,6 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to FRR's documentation!
-===============================
-
 .. toctree::
    :maxdepth: 2
 

--- a/doc/user/index.rst
+++ b/doc/user/index.rst
@@ -1,5 +1,5 @@
-Welcome to FRR's documentation!
-===============================
+FRRouting User Guide
+====================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Titles for 5.0 docs and latest docs should be the same.

http://frrouting.readthedocs.io/en/latest/
https://frrouting.readthedocs.io/en/dev-5.0/

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>