### PR TITLE
Fix other static owners

### DIFF
--- a/tools/etc/iproute2/rt_protos.d/frr.conf
+++ b/tools/etc/iproute2/rt_protos.d/frr.conf
@@ -10,3 +10,4 @@
 193  ldp
 194  sharp
 195  pbr
+196  static

--- a/tools/frr
+++ b/tools/frr
@@ -565,6 +565,7 @@ case "$1" in
           ip route flush proto 193
           ip route flush proto 194
           ip route flush proto 195
+	  ip route flush proto 196
        else
          [ -n "$dmn" ] && eval "${dmn/-/_}=0"
          start_watchfrr

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -110,6 +110,7 @@ static const struct message rtproto_str[] = {
 	{RTPROT_ISIS, "IS-IS"},
 	{RTPROT_RIP, "RIP"},
 	{RTPROT_RIPNG, "RIPNG"},
+	{RTPROT_ZSTATIC, "static"},
 	{0}};
 
 static const struct message family_str[] = {{AF_INET, "ipv4"},

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -94,7 +94,7 @@ void rt_netlink_init(void)
 static inline int is_selfroute(int proto)
 {
 	if ((proto == RTPROT_BGP) || (proto == RTPROT_OSPF)
-	    || (proto == RTPROT_STATIC) || (proto == RTPROT_ZEBRA)
+	    || (proto == RTPROT_ZSTATIC) || (proto == RTPROT_ZEBRA)
 	    || (proto == RTPROT_ISIS) || (proto == RTPROT_RIPNG)
 	    || (proto == RTPROT_NHRP) || (proto == RTPROT_EIGRP)
 	    || (proto == RTPROT_LDP) || (proto == RTPROT_BABEL)
@@ -120,7 +120,7 @@ static inline int zebra2proto(int proto)
 		proto = RTPROT_OSPF;
 		break;
 	case ZEBRA_ROUTE_STATIC:
-		proto = RTPROT_STATIC;
+		proto = RTPROT_ZSTATIC;
 		break;
 	case ZEBRA_ROUTE_ISIS:
 		proto = RTPROT_ISIS;
@@ -194,6 +194,7 @@ static inline int proto2zebra(int proto, int family)
 		proto = ZEBRA_ROUTE_LDP;
 		break;
 	case RTPROT_STATIC:
+	case RTPROT_ZSTATIC:
 		proto = ZEBRA_ROUTE_STATIC;
 		break;
 	case RTPROT_SHARP:

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -310,8 +310,12 @@ static int netlink_route_change_read_unicast(struct sockaddr_nl *snl,
 		return 0;
 
 	if (!startup && is_selfroute(rtm->rtm_protocol)
-	    && h->nlmsg_type == RTM_NEWROUTE)
+	    && h->nlmsg_type == RTM_NEWROUTE) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("Route type: %d Received that we think we have originated, ignoring",
+				   rtm->rtm_protocol);
 		return 0;
+	}
 
 	/* We don't care about change notifications for the MPLS table. */
 	/* TODO: Revisit this. */

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -53,6 +53,7 @@
 #define RTPROT_LDP         193
 #define RTPROT_SHARP       194
 #define RTPROT_PBR         195
+#define RTPROT_ZSTATIC     196
 
 void rt_netlink_init(void);
 


### PR DESCRIPTION
The static route protocol value RTPROT_STATIC is commonly used by other daemons to install routes into the linux kernel.  This is causing repeated collisions and situations where FRR thinks it own a route and just ignores the netlink notification from the kernel about the route.  Modify the RTPROT_XXX value we are using for static routes to a different unused value to get rid of this collision.