### PR TITLE
*: add support for `|` actions

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -499,8 +499,6 @@ is no VTY password, one cannot connect to the VTY interface at all.
    Router#
 
 
-:kbd:`?` and the ``find`` command are very useful for looking up commands.
-
 .. _vty-modes:
 
 VTY Modes
@@ -636,4 +634,62 @@ insta-help, and VTY session management.
    You can use command line help by typing ``help`` at the beginning of the
    line.  Typing :kbd:`?` at any point in the line will show possible
    completions.
+
+.. index:: find COMMAND...
+.. clicmd:: find COMMAND...
+
+   This commmand performs a simple substring search across all defined commands
+   in all modes. As an example, suppose you're in enable mode and can't
+   remember where the command to turn OSPF segment routing on is:
+
+   ::
+
+      frr# find segment-routing on
+        (ospf)  segment-routing on
+
+   The CLI mode is displayed next to each command. In this example,
+   :clicmd:`segment-routing on` is under the `router ospf` mode.
+
+   Similarly, suppose you want a listing of all commands that contain "l2vpn":
+
+   ::
+
+      frr# find l2vpn
+        (view)  show [ip] bgp l2vpn evpn [json]
+        (view)  show [ip] bgp l2vpn evpn all <A.B.C.D|A.B.C.D/M> [json]
+        (view)  show [ip] bgp l2vpn evpn all neighbors A.B.C.D advertised-routes [json]
+        (view)  show [ip] bgp l2vpn evpn all neighbors A.B.C.D routes [json]
+        (view)  show [ip] bgp l2vpn evpn all overlay
+        ...
+
+Pipe Actions
+^^^^^^^^^^^^
+
+VTY supports optional modifiers at the end of commands that perform
+postprocessing on command output or modify the action of commands. These do not
+show up in the :kbd:`?` or :kbd:`TAB` suggestion lists.
+
+``... | include REGEX``
+   Filters the output of the preceding command, including only lines which
+   match the POSIX Extended Regular Expression ``REGEX``. Do not put the regex
+   in quotes.
+
+   Examples:
+
+   ::
+
+      frr# show ip bgp sum json | include remoteAs
+            "remoteAs":0,
+            "remoteAs":455,
+            "remoteAs":99,
+
+   ::
+
+      frr# show run | include neigh.*[0-9]{2}\.0\.[2-4]\.[0-9]*
+       neighbor 10.0.2.106 remote-as 99
+       neighbor 10.0.2.107 remote-as 99
+       neighbor 10.0.2.108 remote-as 99
+       neighbor 10.0.2.109 remote-as 99
+       neighbor 10.0.2.110 remote-as 99
+       neighbor 10.0.3.111 remote-as 111
 

--- a/lib/command.c
+++ b/lib/command.c
@@ -1226,10 +1226,9 @@ fail:
 
 static int handle_pipe_action_done(struct vty *vty, const char *cmd_exec)
 {
-	if (vty->filter) {
+	if (vty->filter)
 		vty_set_include(vty, NULL);
-		vty_out(vty, "\n");
-	}
+
 	return 0;
 }
 

--- a/lib/command.c
+++ b/lib/command.c
@@ -1202,8 +1202,8 @@ static int handle_pipe_action(struct vty *vty, const char *cmd_in,
 			vty_out(vty, "%% Bad regexp '%s'", regexp);
 			goto fail;
 		}
-		cmd_out = XSTRDUP(MTYPE_TMP, cmd_in);
-		*(strstr(cmd_in, "|")) = '\0';
+		*cmd_out = XSTRDUP(MTYPE_TMP, cmd_in);
+		*(strstr(*cmd_out, "|")) = '\0';
 	} else {
 		vty_out(vty, "%% Unknown action '%s'", token);
 		goto fail;

--- a/lib/command.c
+++ b/lib/command.c
@@ -290,7 +290,8 @@ vector cmd_make_strvec(const char *string)
 	for (unsigned int i = 0; i < vector_active(result); i++) {
 		if (strlen(vector_slot(result, i)) == 0) {
 			XFREE(MTYPE_TMP, vector_slot(result, i));
-			vector_unset(result, i);
+			vector_remove(result, i);
+			--i;
 		}
 	}
 	return result;

--- a/lib/command.c
+++ b/lib/command.c
@@ -290,10 +290,12 @@ vector cmd_make_strvec(const char *string)
 	for (unsigned int i = 0; i < vector_active(result); i++) {
 		if (strlen(vector_slot(result, i)) == 0) {
 			XFREE(MTYPE_TMP, vector_slot(result, i));
-			vector_remove(result, i);
-			--i;
+			vector_unset(result, i);
 		}
 	}
+
+	vector_compact(result);
+
 	return result;
 }
 

--- a/lib/command.c
+++ b/lib/command.c
@@ -285,7 +285,7 @@ vector cmd_make_strvec(const char *string)
 	if (*copy == '\0' || *copy == '!' || *copy == '#')
 		return NULL;
 
-	vector result = frrstr_split_vec(copy, " \n\r\t");
+	vector result = frrstr_split_vec(copy, "\n\r\t ");
 
 	for (unsigned int i = 0; i < vector_active(result); i++) {
 		if (strlen(vector_slot(result, i)) == 0) {
@@ -1163,15 +1163,15 @@ int cmd_execute_command_strict(vector vline, struct vty *vty,
  *    The result of any processing.
  */
 DECLARE_HOOK(cmd_execute,
-	     (struct vty * vty, const char *cmd_in, char **cmd_out),
+	     (struct vty *vty, const char *cmd_in, char **cmd_out),
 	     (vty, cmd_in, cmd_out));
-DEFINE_HOOK(cmd_execute, (struct vty * vty, const char *cmd_in, char **cmd_out),
+DEFINE_HOOK(cmd_execute, (struct vty *vty, const char *cmd_in, char **cmd_out),
 	    (vty, cmd_in, cmd_out));
 
 /* Hook executed after a CLI command. */
-DECLARE_KOOH(cmd_execute_done, (struct vty * vty, const char *cmd_exec),
+DECLARE_KOOH(cmd_execute_done, (struct vty *vty, const char *cmd_exec),
 	     (vty, cmd_exec));
-DEFINE_KOOH(cmd_execute_done, (struct vty * vty, const char *cmd_exec),
+DEFINE_KOOH(cmd_execute_done, (struct vty *vty, const char *cmd_exec),
 	    (vty, cmd_exec));
 
 /*
@@ -1198,6 +1198,7 @@ static int handle_pipe_action(struct vty *vty, const char *cmd_in,
 		/* the remaining text should be a regexp */
 		char *regexp = working;
 		bool succ = vty_set_include(vty, regexp);
+
 		if (!succ) {
 			vty_out(vty, "%% Bad regexp '%s'", regexp);
 			goto fail;

--- a/lib/command.h
+++ b/lib/command.h
@@ -416,6 +416,28 @@ extern int command_config_read_one_line(struct vty *vty,
 					int use_config_node);
 extern int config_from_file(struct vty *, FILE *, unsigned int *line_num);
 extern enum node_type node_parent(enum node_type);
+/*
+ * Execute command under the given vty context.
+ *
+ * vty
+ *    The vty context to execute under.
+ *
+ * cmd
+ *    The command string to execute.
+ *
+ * matched
+ *    If non-null and a match was found, the address of the matched command is
+ *    stored here. No action otherwise.
+ *
+ * vtysh
+ *    Whether or not this is being called from vtysh. If this is nonzero,
+ *    XXX: then what?
+ *
+ * Returns:
+ *    XXX: what does it return
+ */
+extern int cmd_execute(struct vty *vty, const char *cmd,
+		       const struct cmd_element **matched, int vtysh);
 extern int cmd_execute_command(vector, struct vty *,
 			       const struct cmd_element **, int);
 extern int cmd_execute_command_strict(vector, struct vty *,

--- a/lib/command.h
+++ b/lib/command.h
@@ -33,9 +33,6 @@
 DECLARE_MTYPE(HOST)
 DECLARE_MTYPE(COMPLETION)
 
-/* for test-commands.c */
-DECLARE_MTYPE(STRVEC)
-
 /* Host configuration variable */
 struct host {
 	/* Host name of this router. */

--- a/lib/frrstr.c
+++ b/lib/frrstr.c
@@ -40,6 +40,7 @@ void frrstr_split(const char *string, const char *delimiter, char ***result,
 	*argc = 0;
 
 	const char *tok = NULL;
+
 	while (copy) {
 		tok = strsep(&copy, delimiter);
 		(*result)[idx] = XSTRDUP(MTYPE_TMP, tok);
@@ -50,8 +51,6 @@ void frrstr_split(const char *string, const char *delimiter, char ***result,
 	}
 
 	XFREE(MTYPE_TMP, copystart);
-
-	return;
 }
 
 vector frrstr_split_vec(const char *string, const char *delimiter)
@@ -62,7 +61,9 @@ vector frrstr_split_vec(const char *string, const char *delimiter)
 	frrstr_split(string, delimiter, &result, &argc);
 
 	vector v = array_to_vector((void **)result, argc);
+
 	XFREE(MTYPE_TMP, result);
+
 	return v;
 }
 
@@ -85,6 +86,7 @@ char *frrstr_join(const char **parts, int argc, const char *join)
 
 	for (i = 0; i < argc; i++) {
 		size_t arglen = strlen(parts[i]);
+
 		memcpy(p, parts[i], arglen);
 		p += arglen;
 		if (i + 1 != argc) {
@@ -115,6 +117,7 @@ char *frrstr_join_vec(vector v, const char *join)
 void frrstr_filter_vec(vector v, regex_t *filter)
 {
 	regmatch_t ignored[1];
+
 	for (unsigned int i = 0; i < vector_active(v); i++) {
 		if (regexec(filter, vector_slot(v, i), 0, ignored, 0)) {
 			XFREE(MTYPE_TMP, vector_slot(v, i));
@@ -143,9 +146,12 @@ bool begins_with(const char *str, const char *prefix)
 {
 	if (!str || !prefix)
 		return 0;
+
 	size_t lenstr = strlen(str);
 	size_t lenprefix = strlen(prefix);
+
 	if (lenprefix > lenstr)
 		return 0;
+
 	return strncmp(str, prefix, lenprefix) == 0;
 }

--- a/lib/frrstr.c
+++ b/lib/frrstr.c
@@ -1,0 +1,141 @@
+/*
+ * FRR string processing utilities.
+ * Copyright (C) 2018  Cumulus Networks, Inc.
+ *                     Quentin Young
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <string.h>
+#include <ctype.h>
+#include <sys/types.h>
+#include <regex.h>
+
+#include "frrstr.h"
+#include "memory.h"
+#include "vector.h"
+
+void frrstr_split(const char *string, const char *delimiter, char ***result,
+		  int *argc)
+{
+	if (!string)
+		return;
+
+	unsigned int sz = 4, idx = 0;
+	char *copy, *copystart;
+	*result = XCALLOC(MTYPE_TMP, sizeof(char *) * sz);
+	copystart = copy = XSTRDUP(MTYPE_TMP, string);
+	*argc = 0;
+
+	const char *tok = NULL;
+	while (copy) {
+		tok = strsep(&copy, delimiter);
+		(*result)[idx] = XSTRDUP(MTYPE_TMP, tok);
+		if (++idx == sz)
+			*result = XREALLOC(MTYPE_TMP, *result,
+					   (sz *= 2) * sizeof(char *));
+		(*argc)++;
+	}
+
+	XFREE(MTYPE_TMP, copystart);
+
+	return;
+}
+
+vector frrstr_split_vec(const char *string, const char *delimiter)
+{
+	char **result;
+	int argc;
+
+	frrstr_split(string, delimiter, &result, &argc);
+
+	vector v = array_to_vector((void **)result, argc);
+	XFREE(MTYPE_TMP, result);
+	return v;
+}
+
+char *frrstr_join(const char **parts, int argc, const char *join)
+{
+	int i;
+	char *str;
+	char *p;
+	size_t len = 0;
+	size_t joinlen = join ? strlen(join) : 0;
+
+	for (i = 0; i < argc; i++)
+		len += strlen(parts[i]);
+	len += argc * joinlen + 1;
+
+	if (!len)
+		return NULL;
+
+	p = str = XMALLOC(MTYPE_TMP, len);
+
+	for (i = 0; i < argc; i++) {
+		size_t arglen = strlen(parts[i]);
+		memcpy(p, parts[i], arglen);
+		p += arglen;
+		if (i + 1 != argc) {
+			memcpy(p, join, joinlen);
+			p += joinlen;
+		}
+	}
+
+	*p = '\0';
+
+	return str;
+}
+
+char *frrstr_join_vec(vector v, const char *join)
+{
+	char **argv;
+	int argc;
+
+	vector_to_array(v, (void ***)&argv, &argc);
+
+	char *ret = frrstr_join((const char **)argv, argc, join);
+
+	XFREE(MTYPE_TMP, argv);
+
+	return ret;
+}
+
+void frrstr_filter_vec(vector v, regex_t *filter)
+{
+	regmatch_t ignored[1];
+	for (unsigned int i = 0; i < vector_active(v); i++) {
+		if (regexec(filter, vector_slot(v, i), 0, ignored, 0)) {
+			XFREE(MTYPE_TMP, vector_slot(v, i));
+			vector_unset(v, i);
+		}
+	}
+}
+
+void frrstr_strvec_free(vector v)
+{
+	unsigned int i;
+	char *cp;
+
+	if (!v)
+		return;
+
+	for (i = 0; i < vector_active(v); i++) {
+		cp = vector_slot(v, i);
+		XFREE(MTYPE_TMP, cp);
+	}
+
+	vector_free(v);
+}
+

--- a/lib/frrstr.c
+++ b/lib/frrstr.c
@@ -58,6 +58,9 @@ vector frrstr_split_vec(const char *string, const char *delimiter)
 	char **result;
 	int argc;
 
+	if (!string)
+		return NULL;
+
 	frrstr_split(string, delimiter, &result, &argc);
 
 	vector v = array_to_vector((void **)result, argc);
@@ -89,7 +92,7 @@ char *frrstr_join(const char **parts, int argc, const char *join)
 
 		memcpy(p, parts[i], arglen);
 		p += arglen;
-		if (i + 1 != argc) {
+		if (i + 1 != argc && join) {
 			memcpy(p, join, joinlen);
 			p += joinlen;
 		}

--- a/lib/frrstr.c
+++ b/lib/frrstr.c
@@ -139,3 +139,13 @@ void frrstr_strvec_free(vector v)
 	vector_free(v);
 }
 
+bool begins_with(const char *str, const char *prefix)
+{
+	if (!str || !prefix)
+		return 0;
+	size_t lenstr = strlen(str);
+	size_t lenprefix = strlen(prefix);
+	if (lenprefix > lenstr)
+		return 0;
+	return strncmp(str, prefix, lenprefix) == 0;
+}

--- a/lib/frrstr.h
+++ b/lib/frrstr.h
@@ -23,6 +23,7 @@
 
 #include <sys/types.h>
 #include <regex.h>
+#include <stdbool.h>
 
 #include "vector.h"
 
@@ -82,5 +83,18 @@ void frrstr_filter_vec(vector v, regex_t *filter);
  */
 void frrstr_strvec_free(vector v);
 
+/*
+ * Prefix match for string.
+ *
+ * str
+ *    string to check for prefix match
+ *
+ * prefix
+ *    prefix to look for
+ *
+ * Returns:
+ *   true str starts with prefix, false otherwise
+ */
+bool begins_with(const char *str, const char *prefix);
 
 #endif /* _FRRSTR_H_ */

--- a/lib/frrstr.h
+++ b/lib/frrstr.h
@@ -1,0 +1,86 @@
+/*
+ * FRR string processing utilities.
+ * Copyright (C) 2018  Cumulus Networks, Inc.
+ *                     Quentin Young
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _FRRSTR_H_
+#define _FRRSTR_H_
+
+#include <sys/types.h>
+#include <regex.h>
+
+#include "vector.h"
+
+/*
+ * Tokenizes a string, storing tokens in a vector. Whitespace is ignored.
+ * Delimiter characters are not included.
+ *
+ * string
+ *    The string to split
+ *
+ * delimiter
+ *    Delimiter string, as used in strsep()
+ *
+ * Returns:
+ *    The split string. Each token is allocated with MTYPE_TMP.
+ */
+void frrstr_split(const char *string, const char *delimiter, char ***result,
+		  int *argc);
+vector frrstr_split_vec(const char *string, const char *delimiter);
+
+/*
+ * Concatenate string array into a single string.
+ *
+ * argv
+ *    array of string pointers to concatenate
+ *
+ * argc
+ *    array length
+ *
+ * join
+ *    string to insert between each part, or NULL for nothing
+ *
+ * Returns:
+ *    the joined string, allocated with MTYPE_TMP
+ */
+char *frrstr_join(const char **parts, int argc, const char *join);
+char *frrstr_join_vec(vector v, const char *join);
+
+/*
+ * Filter string vector.
+ * Removes lines that do not contain a match for the provided regex.
+ *
+ * v
+ *    The vector to filter.
+ *
+ * filter
+ *    Regex to filter with.
+ */
+void frrstr_filter_vec(vector v, regex_t *filter);
+
+/*
+ * Free allocated string vector.
+ * Assumes each item is allocated with MTYPE_TMP.
+ *
+ * v
+ *    the vector to free
+ */
+void frrstr_strvec_free(vector v);
+
+
+#endif /* _FRRSTR_H_ */

--- a/lib/graph.c
+++ b/lib/graph.c
@@ -60,7 +60,7 @@ struct graph_node *graph_new_node(struct graph *graph, void *data,
 	return node;
 }
 
-static void vector_remove(vector v, unsigned int ix)
+static void graph_vector_remove(vector v, unsigned int ix)
 {
 	if (ix >= v->active)
 		return;
@@ -105,7 +105,7 @@ void graph_delete_node(struct graph *graph, struct graph_node *node)
 	// remove node from graph->nodes
 	for (unsigned int i = vector_active(graph->nodes); i--; /**/)
 		if (vector_slot(graph->nodes, i) == node) {
-			vector_remove(graph->nodes, i);
+			graph_vector_remove(graph->nodes, i);
 			break;
 		}
 
@@ -126,13 +126,13 @@ void graph_remove_edge(struct graph_node *from, struct graph_node *to)
 	// remove from from to->from
 	for (unsigned int i = vector_active(to->from); i--; /**/)
 		if (vector_slot(to->from, i) == from) {
-			vector_remove(to->from, i);
+			graph_vector_remove(to->from, i);
 			break;
 		}
 	// remove to from from->to
 	for (unsigned int i = vector_active(from->to); i--; /**/)
 		if (vector_slot(from->to, i) == to) {
-			vector_remove(from->to, i);
+			graph_vector_remove(from->to, i);
 			break;
 		}
 }

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -21,6 +21,7 @@ lib_libfrr_la_SOURCES = \
 	lib/ferr.c \
 	lib/filter.c \
 	lib/frr_pthread.c \
+	lib/frrstr.c \
 	lib/getopt.c \
 	lib/getopt1.c \
 	lib/grammar_sandbox.c \
@@ -105,6 +106,7 @@ pkginclude_HEADERS += \
 	lib/freebsd-queue.h \
 	lib/frr_pthread.h \
 	lib/frratomic.h \
+	lib/frrstr.h \
 	lib/getopt.h \
 	lib/graph.h \
 	lib/hash.h \

--- a/lib/vector.c
+++ b/lib/vector.c
@@ -164,6 +164,16 @@ void vector_remove(vector v, unsigned int ix)
 	v->index[v->active] = NULL;
 }
 
+void vector_compact(vector v)
+{
+	for (unsigned int i = 0; i < vector_active(v); ++i) {
+		if (vector_slot(v, i) == NULL) {
+			vector_remove(v, i);
+			--i;
+		}
+	}
+}
+
 void vector_unset_value(vector v, void *val)
 {
 	size_t i;

--- a/lib/vector.c
+++ b/lib/vector.c
@@ -192,6 +192,7 @@ void vector_to_array(vector v, void ***dest, int *argc)
 vector array_to_vector(void **src, int argc)
 {
 	vector v = vector_init(VECTOR_MIN_SIZE);
+
 	for (int i = 0; i < argc; i++)
 		vector_set_index(v, i, src[i]);
 	return v;

--- a/lib/vector.c
+++ b/lib/vector.c
@@ -153,6 +153,17 @@ void vector_unset(vector v, unsigned int i)
 	}
 }
 
+void vector_remove(vector v, unsigned int ix)
+{
+	if (ix >= v->active)
+		return;
+
+	int n = (--v->active) - ix;
+
+	memmove(&v->index[ix], &v->index[ix + 1], n * sizeof(void *));
+	v->index[v->active] = NULL;
+}
+
 void vector_unset_value(vector v, void *val)
 {
 	size_t i;

--- a/lib/vector.c
+++ b/lib/vector.c
@@ -181,3 +181,18 @@ unsigned int vector_count(vector v)
 
 	return count;
 }
+
+void vector_to_array(vector v, void ***dest, int *argc)
+{
+	*dest = XCALLOC(MTYPE_TMP, sizeof(void *) * v->active);
+	memcpy(*dest, v->index, sizeof(void *) * v->active);
+	*argc = v->active;
+}
+
+vector array_to_vector(void **src, int argc)
+{
+	vector v = vector_init(VECTOR_MIN_SIZE);
+	for (int i = 0; i < argc; i++)
+		vector_set_index(v, i, src[i]);
+	return v;
+}

--- a/lib/vector.h
+++ b/lib/vector.h
@@ -59,5 +59,6 @@ extern vector vector_copy(vector v);
 
 extern void *vector_lookup(vector, unsigned int);
 extern void *vector_lookup_ensure(vector, unsigned int);
-
+extern void vector_to_array(vector v, void ***dest, int *argc);
+extern vector array_to_vector(void **src, int argc);
 #endif /* _ZEBRA_VECTOR_H */

--- a/lib/vector.h
+++ b/lib/vector.h
@@ -53,6 +53,7 @@ extern int vector_set_index(vector v, unsigned int i, void *val);
 extern void vector_unset(vector v, unsigned int i);
 extern void vector_unset_value(vector v, void *val);
 extern void vector_remove(vector v, unsigned int ix);
+extern void vector_compact(vector v);
 
 extern unsigned int vector_count(vector v);
 extern void vector_free(vector v);

--- a/lib/vector.h
+++ b/lib/vector.h
@@ -52,6 +52,7 @@ extern int vector_set(vector v, void *val);
 extern int vector_set_index(vector v, unsigned int i, void *val);
 extern void vector_unset(vector v, unsigned int i);
 extern void vector_unset_value(vector v, void *val);
+extern void vector_remove(vector v, unsigned int ix);
 
 extern unsigned int vector_count(vector v);
 extern void vector_free(vector v);

--- a/lib/version.h.in
+++ b/lib/version.h.in
@@ -47,10 +47,10 @@
 #define FRR_CONFIG_ARGS "@CONFIG_ARGS@"
 
 #define FRR_DEFAULT_MOTD \
-	"\r\n" \
-	"Hello, this is " FRR_FULL_NAME " (version " FRR_VERSION ").\r\n" \
-	FRR_COPYRIGHT "\r\n" \
-	GIT_INFO "\r\n"
+	"\n" \
+	"Hello, this is " FRR_FULL_NAME " (version " FRR_VERSION ").\n" \
+	FRR_COPYRIGHT "\n" \
+	GIT_INFO "\n"
 
 pid_t pid_output (const char *);
 

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -186,6 +186,7 @@ int vty_out(struct vty *vty, const char *format, ...)
 	/* filter buffer */
 	if (vty->filter) {
 		vector lines = frrstr_split_vec(buf, "\n");
+
 		frrstr_filter_vec(lines, &vty->include);
 		if (buf[strlen(buf) - 1] == '\n' && vector_active(lines) > 0)
 			vector_set(lines, XSTRDUP(MTYPE_TMP, ""));

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -24,6 +24,7 @@
 #include <lib/version.h>
 #include <sys/types.h>
 #include <regex.h>
+#include <stdio.h>
 
 #include "linklist.h"
 #include "thread.h"
@@ -1647,6 +1648,7 @@ struct vty *vty_new()
 	struct vty *new = XCALLOC(MTYPE_VTY, sizeof(struct vty));
 
 	new->fd = new->wfd = -1;
+	new->of = stdout;
 	new->obuf = buffer_new(0); /* Use default buffer size. */
 	new->buf = XCALLOC(MTYPE_VTY, VTY_BUFSIZ);
 	new->error_buf = XCALLOC(MTYPE_VTY, VTY_BUFSIZ);

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -188,6 +188,7 @@ int vty_out(struct vty *vty, const char *format, ...)
 		vector lines = frrstr_split_vec(buf, "\n");
 
 		frrstr_filter_vec(lines, &vty->include);
+		vector_compact(lines);
 
 		/*
 		 * Consider the string "foo\n". If the regex is an empty string

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -21,6 +21,9 @@
 #ifndef _ZEBRA_VTY_H
 #define _ZEBRA_VTY_H
 
+#include <sys/types.h>
+#include <regex.h>
+
 #include "thread.h"
 #include "log.h"
 #include "sockunion.h"
@@ -46,6 +49,10 @@ struct vty {
 
 	/* Failure count */
 	int fail;
+
+	/* Output filer regex */
+	bool filter;
+	regex_t include;
 
 	/* Output buffer. */
 	struct buffer *obuf;
@@ -223,6 +230,7 @@ extern struct vty *vty_stdio(void (*atclose)(int isexit));
 extern int vty_out(struct vty *, const char *, ...) PRINTF_ATTRIBUTE(2, 3);
 extern void vty_frame(struct vty *, const char *, ...) PRINTF_ATTRIBUTE(2, 3);
 extern void vty_endframe(struct vty *, const char *);
+bool vty_set_include(struct vty *vty, const char *regexp);
 
 extern void vty_read_config(const char *, char *);
 extern void vty_time_print(struct vty *, int);

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -61,6 +61,9 @@ struct vty {
 	bool filter;
 	regex_t include;
 
+	/* Line buffer */
+	struct buffer *lbuf;
+
 	/* Output buffer. */
 	struct buffer *obuf;
 

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -41,6 +41,13 @@ struct vty {
 	/* output FD, to support stdin/stdout combination */
 	int wfd;
 
+	/* File output, used for VTYSH only */
+	FILE *of;
+	FILE *of_saved;
+
+	/* whether we are using pager or not */
+	bool is_paged;
+
 	/* Is this vty connect to file or not */
 	enum { VTY_TERM, VTY_FILE, VTY_SHELL, VTY_SHELL_SERV } type;
 

--- a/tests/lib/cli/test_commands.c
+++ b/tests/lib/cli/test_commands.c
@@ -130,7 +130,7 @@ static void test_load(void)
 			line[strlen(line) - 1] = '\0';
 		if (line[0] == '#')
 			continue;
-		vector_set(test_cmds, XSTRDUP(MTYPE_STRVEC, line));
+		vector_set(test_cmds, XSTRDUP(MTYPE_TMP, line));
 	}
 }
 
@@ -181,7 +181,7 @@ static void test_terminate(void)
 
 	vty_terminate();
 	for (i = 0; i < vector_active(test_cmds); i++)
-		XFREE(MTYPE_STRVEC, vector_slot(test_cmds, i));
+		XFREE(MTYPE_TMP, vector_slot(test_cmds, i));
 	vector_free(test_cmds);
 	cmd_terminate();
 }

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -70,6 +70,9 @@ static FILE *vty_open_pager(struct vty *vty)
 	if (vty->is_paged)
 		return vty->of;
 
+	if (!vtysh_pager_name)
+		return NULL;
+
 	vty->of_saved = vty->of;
 	vty->of = popen(vtysh_pager_name, "w");
 	if (vty->of == NULL) {

--- a/vtysh/vtysh.h
+++ b/vtysh/vtysh.h
@@ -90,7 +90,7 @@ int vtysh_write_config_integrated(void);
 
 void vtysh_config_parse_line(void *, const char *);
 
-void vtysh_config_dump(FILE *);
+void vtysh_config_dump(void);
 
 void vtysh_config_init(void);
 

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -342,7 +342,7 @@ void vtysh_config_parse_line(void *arg, const char *line)
 	 || (I) == MPLS_NODE)
 
 /* Display configuration to file pointer. */
-void vtysh_config_dump(FILE *fp)
+void vtysh_config_dump()
 {
 	struct listnode *node, *nnode;
 	struct listnode *mnode, *mnnode;
@@ -351,12 +351,10 @@ void vtysh_config_dump(FILE *fp)
 	char *line;
 	unsigned int i;
 
-	for (ALL_LIST_ELEMENTS(config_top, node, nnode, line)) {
-		fprintf(fp, "%s\n", line);
-		fflush(fp);
-	}
-	fprintf(fp, "!\n");
-	fflush(fp);
+	for (ALL_LIST_ELEMENTS(config_top, node, nnode, line))
+		vty_out(vty, "%s\n", line);
+
+	vty_out(vty, "!\n");
 
 	for (i = 0; i < vector_active(configvec); i++)
 		if ((master = vector_slot(configvec, i)) != NULL) {
@@ -373,23 +371,16 @@ void vtysh_config_dump(FILE *fp)
 				    && list_isempty(config->line))
 					continue;
 
-				fprintf(fp, "%s\n", config->name);
-				fflush(fp);
+				vty_out(vty, "%s\n", config->name);
 
 				for (ALL_LIST_ELEMENTS(config->line, mnode,
-						       mnnode, line)) {
-					fprintf(fp, "%s\n", line);
-					fflush(fp);
-				}
-				if (!NO_DELIMITER(i)) {
-					fprintf(fp, "!\n");
-					fflush(fp);
-				}
+						       mnnode, line))
+					vty_out(vty, "%s\n", line);
+				if (!NO_DELIMITER(i))
+					vty_out(vty, "!\n");
 			}
-			if (NO_DELIMITER(i)) {
-				fprintf(fp, "!\n");
-				fflush(fp);
-			}
+			if (NO_DELIMITER(i))
+				vty_out(vty, "!\n");
 		}
 
 	for (i = 0; i < vector_active(configvec); i++)

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -342,7 +342,7 @@ void vtysh_config_parse_line(void *arg, const char *line)
 	 || (I) == MPLS_NODE)
 
 /* Display configuration to file pointer. */
-void vtysh_config_dump()
+void vtysh_config_dump(void)
 {
 	struct listnode *node, *nnode;
 	struct listnode *mnode, *mnnode;


### PR DESCRIPTION
This set of changes adds infrastructure to implement CLI pre- and postprocessing code that can be triggered by appending a pipe (`|`) and the action name to the end of any command. This is done with a set of hooks called before and after a CLI command executes.

* Add `frrstr.[ch]` to `libfrr` to start consolidating our string processing stuff
* Add filter field to `struct vty` used in `vty_out()` to filter output
* Add better vtysh support to `vty_out()`
* Change vtysh to use `vty_out()` for non-error printouts in order to get output filtering
* Patch `output file` support into `struct vty` to handle the above
* Rewrite VTYSH pager implementation to support pipe actions
* Implement `| include` to filter output commands with a regex filter

------------

```
ubuntu-bionic# show run
...<snip>...
!
router bgp 100
 neighbor swp1 interface remote-as external
 neighbor swp1 capability extended-nexthop
 !
 address-family l2vpn evpn
  neighbor swp1 activate
  vni 20
   rd 2:2
   route-target import 2:2
   route-target export 2:2
  exit-vni
  vni 30
   rd 3:3
   route-target import 3:3
   route-target export 3:3
  exit-vni
  vni 10
   rd 1:1
   route-target import 2:2
   route-target export 3:3
  exit-vni
 exit-address-family
!
line vty
!
end
```
```
ubuntu-bionic# show run | include rou.*ex[a-z]*\s[0-9]:[0-9]
   route-target export 2:2
   route-target export 3:3
   route-target export 3:3

ubuntu-bionic#
```