### PR TITLE
bgpd: issue 2263: fix "no label vpn export auto"

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6311,6 +6311,10 @@ DEFPY (af_label_vpn_export,
 	if (argv_find(argv, argc, "no", &idx))
 		yes = 0;
 
+	/* If "no ...", squash trailing parameter */
+	if (!yes)
+		label_auto = NULL;
+
 	if (yes) {
 		if (!label_auto)
 			label = label_val; /* parser should force unsigned */


### PR DESCRIPTION
This command should unset the label (instead of wrongly setting to "auto")