### PR TITLE
*: Backport bugfixes and features into dev/5.0

### DIFF
--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -512,7 +512,7 @@ static int lcommunity_regexp_match(struct lcommunity *com, regex_t *reg)
 	if (com == NULL || com->size == 0)
 		str = "";
 	else
-		str = lcommunity_str(com);
+		str = lcommunity_str(com, false);
 
 	/* Regular expression match.  */
 	if (regexec(reg, str, 0, NULL, 0) == 0)
@@ -986,13 +986,8 @@ int lcommunity_list_set(struct community_list_handler *ch, const char *name,
 	entry->any = (str ? 0 : 1);
 	entry->u.lcom = lcom;
 	entry->reg = regex;
-	if (lcom)
-		entry->config = lcommunity_lcom2str(
-			lcom, LCOMMUNITY_FORMAT_COMMUNITY_LIST);
-	else if (regex)
-		entry->config = XSTRDUP(MTYPE_COMMUNITY_LIST_CONFIG, str);
-	else
-		entry->config = NULL;
+	entry->config =
+		(regex ? XSTRDUP(MTYPE_COMMUNITY_LIST_CONFIG, str) : NULL);
 
 	/* Do not put duplicated community entry.  */
 	if (community_list_dup_check(list, entry))

--- a/bgpd/bgp_lcommunity.h
+++ b/bgpd/bgp_lcommunity.h
@@ -21,10 +21,7 @@
 #ifndef _QUAGGA_BGP_LCOMMUNITY_H
 #define _QUAGGA_BGP_LCOMMUNITY_H
 
-/* Extended communities attribute string format.  */
-#define LCOMMUNITY_FORMAT_ROUTE_MAP            0
-#define LCOMMUNITY_FORMAT_COMMUNITY_LIST       1
-#define LCOMMUNITY_FORMAT_DISPLAY              2
+#include "lib/json.h"
 
 /* Large Communities value is twelve octets long.  */
 #define LCOMMUNITY_SIZE                        12
@@ -39,6 +36,9 @@ struct lcommunity {
 
 	/* Large Communities value.  */
 	uint8_t *val;
+
+	/* Large Communities as a json object */
+	json_object *json;
 
 	/* Human readable format string.  */
 	char *str;
@@ -65,10 +65,9 @@ extern void lcommunity_unintern(struct lcommunity **);
 extern unsigned int lcommunity_hash_make(void *);
 extern struct hash *lcommunity_hash(void);
 extern struct lcommunity *lcommunity_str2com(const char *);
-extern char *lcommunity_lcom2str(struct lcommunity *, int);
 extern int lcommunity_match(const struct lcommunity *,
 			    const struct lcommunity *);
-extern char *lcommunity_str(struct lcommunity *);
+extern char *lcommunity_str(struct lcommunity *, bool make_json);
 extern int lcommunity_include(struct lcommunity *lcom, uint8_t *ptr);
 extern void lcommunity_del_val(struct lcommunity *lcom, uint8_t *ptr);
 #endif /* _QUAGGA_BGP_LCOMMUNITY_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7383,7 +7383,6 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 	json_object *json_cluster_list = NULL;
 	json_object *json_cluster_list_list = NULL;
 	json_object *json_ext_community = NULL;
-	json_object *json_lcommunity = NULL;
 	json_object *json_last_update = NULL;
 	json_object *json_pmsi = NULL;
 	json_object *json_nexthop_global = NULL;
@@ -8010,13 +8009,12 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 		/* Line 6 display Large community */
 		if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES)) {
 			if (json_paths) {
-				json_lcommunity = json_object_new_object();
-				json_object_string_add(json_lcommunity,
-						       "string",
-						       attr->lcommunity->str);
+				if (!attr->lcommunity->json)
+					lcommunity_str(attr->lcommunity, true);
+				json_object_lock(attr->lcommunity->json);
 				json_object_object_add(json_path,
 						       "largeCommunity",
-						       json_lcommunity);
+						       attr->lcommunity->json);
 			} else {
 				vty_out(vty, "      Large Community: %s\n",
 					attr->lcommunity->str);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10334,8 +10334,10 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 							 afi, safi, rmap_name);
 
 				if (type == bgp_show_adj_route_filtered
-				    && ret != RMAP_DENY)
+				    && ret != RMAP_DENY) {
+					bgp_attr_undup(&attr, ain->attr);
 					continue;
+				}
 
 				if (type == bgp_show_adj_route_received
 				    && ret == RMAP_DENY)
@@ -10343,12 +10345,13 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 
 				route_vty_out_tmp(vty, &rn->p, &attr, safi,
 						  use_json, json_ar);
+				bgp_attr_undup(&attr, ain->attr);
 				output_count++;
 			}
 		} else if (type == bgp_show_adj_route_advertised) {
 			for (adj = rn->adj_out; adj; adj = adj->next)
 				SUBGRP_FOREACH_PEER (adj->subgroup, paf) {
-					if (paf->peer != peer)
+					if (paf->peer != peer || !adj->attr)
 						continue;
 
 					if (header1) {
@@ -10396,7 +10399,6 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 						}
 						header1 = 0;
 					}
-
 					if (header2) {
 						if (!use_json)
 							vty_out(vty,
@@ -10404,24 +10406,22 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 						header2 = 0;
 					}
 
-					if (adj->attr) {
-						bgp_attr_dup(&attr, adj->attr);
-						ret = bgp_output_modifier(
-							peer, &rn->p, &attr,
-							afi, safi, rmap_name);
-						if (ret != RMAP_DENY) {
-							route_vty_out_tmp(
-								vty, &rn->p,
-								&attr, safi,
-								use_json,
-								json_ar);
-							output_count++;
-						} else
-							filtered_count++;
+					bgp_attr_dup(&attr, adj->attr);
+					ret = bgp_output_modifier(
+						peer, &rn->p, &attr, afi, safi,
+						rmap_name);
 
-						bgp_attr_undup(&attr,
-							       adj->attr);
+					if (ret != RMAP_DENY) {
+						route_vty_out_tmp(vty, &rn->p,
+								  &attr, safi,
+								  use_json,
+								  json_ar);
+						output_count++;
+					} else {
+						filtered_count++;
 					}
+
+					bgp_attr_undup(&attr, adj->attr);
 				}
 		}
 	}

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -52,6 +52,12 @@ enum bgp_show_type {
 	bgp_show_type_detail,
 };
 
+enum bgp_show_adj_route_type {
+	bgp_show_adj_route_advertised,
+	bgp_show_adj_route_received,
+	bgp_show_adj_route_filtered,
+};
+
 
 #define BGP_SHOW_SCODE_HEADER                                                  \
 	"Status codes:  s suppressed, d damped, "                              \

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -338,9 +338,8 @@ static route_map_result_t route_match_ip_address(void *rule,
 						 void *object)
 {
 	struct access_list *alist;
-	/* struct prefix_ipv4 match; */
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		alist = access_list_lookup(AFI_IP, (char *)rule);
 		if (alist == NULL)
 			return RMAP_NOMATCH;
@@ -382,7 +381,7 @@ static route_map_result_t route_match_ip_next_hop(void *rule,
 	struct bgp_info *bgp_info;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		bgp_info = object;
 		p.family = AF_INET;
 		p.prefix = bgp_info->attr->nexthop;
@@ -430,7 +429,7 @@ static route_map_result_t route_match_ip_route_source(void *rule,
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		bgp_info = object;
 		peer = bgp_info->peer;
 
@@ -478,7 +477,7 @@ route_match_ip_address_prefix_list(void *rule, struct prefix *prefix,
 {
 	struct prefix_list *plist;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		plist = prefix_list_lookup(AFI_IP, (char *)rule);
 		if (plist == NULL)
 			return RMAP_NOMATCH;
@@ -515,7 +514,7 @@ route_match_ip_next_hop_prefix_list(void *rule, struct prefix *prefix,
 	struct bgp_info *bgp_info;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		bgp_info = object;
 		p.family = AF_INET;
 		p.prefix = bgp_info->attr->nexthop;
@@ -558,7 +557,7 @@ route_match_ip_route_source_prefix_list(void *rule, struct prefix *prefix,
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET) {
 		bgp_info = object;
 		peer = bgp_info->peer;
 
@@ -2239,7 +2238,7 @@ static route_map_result_t route_match_ipv6_address(void *rule,
 {
 	struct access_list *alist;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET6) {
 		alist = access_list_lookup(AFI_IP6, (char *)rule);
 		if (alist == NULL)
 			return RMAP_NOMATCH;
@@ -2326,7 +2325,7 @@ route_match_ipv6_address_prefix_list(void *rule, struct prefix *prefix,
 {
 	struct prefix_list *plist;
 
-	if (type == RMAP_BGP) {
+	if (type == RMAP_BGP && prefix->family == AF_INET6) {
 		plist = prefix_list_lookup(AFI_IP6, (char *)rule);
 		if (plist == NULL)
 			return RMAP_NOMATCH;

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10859,7 +10859,7 @@ static void lcommunity_show_all_iterator(struct hash_backet *backet,
 
 	lcom = (struct lcommunity *)backet->data;
 	vty_out(vty, "[%p] (%ld) %s\n", (void *)lcom, lcom->refcnt,
-		lcommunity_str(lcom));
+		lcommunity_str(lcom, false));
 }
 
 /* Show BGP's community internal data. */
@@ -13592,6 +13592,24 @@ DEFUN (no_ip_community_list_expanded_all,
 	return CMD_SUCCESS;
 }
 
+/* Return configuration string of community-list entry.  */
+static const char *community_list_config_str(struct community_entry *entry)
+{
+	const char *str;
+
+	if (entry->any)
+		str = "";
+	else {
+		if (entry->style == COMMUNITY_LIST_STANDARD)
+			str = community_str(entry->u.com, false);
+		else if (entry->style == LARGE_COMMUNITY_LIST_STANDARD)
+			str = lcommunity_str(entry->u.lcom, false);
+		else
+			str = entry->config;
+	}
+	return str;
+}
+
 static void community_list_show(struct vty *vty, struct community_list *list)
 {
 	struct community_entry *entry;
@@ -13617,9 +13635,7 @@ static void community_list_show(struct vty *vty, struct community_list *list)
 		else
 			vty_out(vty, "    %s %s\n",
 				community_direct_str(entry->direct),
-				entry->style == COMMUNITY_LIST_STANDARD
-					? community_str(entry->u.com, false)
-					: entry->config);
+				community_list_config_str(entry));
 	}
 }
 
@@ -13971,9 +13987,7 @@ static void lcommunity_list_show(struct vty *vty, struct community_list *list)
 		else
 			vty_out(vty, "    %s %s\n",
 				community_direct_str(entry->direct),
-				entry->style == EXTCOMMUNITY_LIST_STANDARD
-					? entry->u.ecom->str
-					: entry->config);
+				community_list_config_str(entry));
 	}
 }
 
@@ -14208,9 +14222,7 @@ static void extcommunity_list_show(struct vty *vty, struct community_list *list)
 		else
 			vty_out(vty, "    %s %s\n",
 				community_direct_str(entry->direct),
-				entry->style == EXTCOMMUNITY_LIST_STANDARD
-					? entry->u.ecom->str
-					: entry->config);
+				community_list_config_str(entry));
 	}
 }
 
@@ -14259,22 +14271,6 @@ DEFUN (show_ip_extcommunity_list_arg,
 	extcommunity_list_show(vty, list);
 
 	return CMD_SUCCESS;
-}
-
-/* Return configuration string of community-list entry.  */
-static const char *community_list_config_str(struct community_entry *entry)
-{
-	const char *str;
-
-	if (entry->any)
-		str = "";
-	else {
-		if (entry->style == COMMUNITY_LIST_STANDARD)
-			str = community_str(entry->u.com, false);
-		else
-			str = entry->config;
-	}
-	return str;
 }
 
 /* Display community-list and extcommunity-list configuration.  */

--- a/debianpkg/backports/ubuntu14.04/debian/frr.postinst
+++ b/debianpkg/backports/ubuntu14.04/debian/frr.postinst
@@ -18,7 +18,7 @@ chgrp ${frrvtygid} /etc/frr/vtysh*
 chmod 644 /etc/frr/*
 
 ENVIRONMENTFILE=/etc/environment
-if ! grep --quiet VTYSH_PAGER=/bin/cat ${ENVIRONMENTFILE}; then
+if ! egrep --quiet '^VTYSH_PAGER=' ${ENVIRONMENTFILE}; then
     echo "VTYSH_PAGER=/bin/cat"  >> ${ENVIRONMENTFILE}
 fi
 ##################################################

--- a/debianpkg/frr.postinst
+++ b/debianpkg/frr.postinst
@@ -19,7 +19,7 @@ chgrp ${frrvtygid} /etc/frr/vtysh*
 chmod 644 /etc/frr/*
 
 ENVIRONMENTFILE=/etc/environment
-if ! grep --quiet VTYSH_PAGER=/bin/cat ${ENVIRONMENTFILE}; then
+if ! egrep --quiet '^VTYSH_PAGER=' ${ENVIRONMENTFILE}; then
     echo "VTYSH_PAGER=/bin/cat"  >> ${ENVIRONMENTFILE}
 fi
 ##################################################

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -55,18 +55,23 @@ Basic Config Commands
 
    Set hostname of the router.
 
-.. index:: password PASSWORD
+.. index::
+   single: no password PASSWORD
+   single: password PASSWORD
 
-.. clicmd:: password PASSWORD
+.. clicmd:: [no] password PASSWORD
 
-   Set password for vty interface. If there is no password, a vty won't
-   accept connections.
+   Set password for vty interface. The ``no`` form of the command deletes the
+   password. If there is no password, a vty won't accept connections.
 
-.. index:: enable password PASSWORD
+.. index::
+   single: no enable password PASSWORD
+   single: enable password PASSWORD
 
-.. clicmd:: enable password PASSWORD
+.. clicmd:: [no] enable password PASSWORD
 
-   Set enable password.
+   Set enable password. The ``no`` form of the command deletes the enable
+   password.
 
 .. index::
    single: no log trap [LEVEL]

--- a/lib/command.c
+++ b/lib/command.c
@@ -1945,10 +1945,7 @@ DEFUN (no_config_password,
 
 	if (host.password) {
 		if (!vty_shell_serv(vty)) {
-			vty_out(vty,
-				"Please be aware that removing the password is "
-				"a security risk and you should think twice "
-				"about this command\n");
+			vty_out(vty, NO_PASSWD_CMD_WARNING);
 			warned = true;
 		}
 		XFREE(MTYPE_HOST, host.password);
@@ -1957,10 +1954,7 @@ DEFUN (no_config_password,
 
 	if (host.password_encrypt) {
 		if (!warned && !vty_shell_serv(vty))
-			vty_out(vty,
-				"Please be aware that removing the password is "
-				"a security risk and you should think twice "
-				"about this command\n");
+			vty_out(vty, NO_PASSWD_CMD_WARNING);
 		XFREE(MTYPE_HOST, host.password_encrypt);
 	}
 	host.password_encrypt = NULL;
@@ -2033,10 +2027,7 @@ DEFUN (no_config_enable_password,
 
 	if (host.enable) {
 		if (!vty_shell_serv(vty)) {
-			vty_out(vty,
-				"Please be aware that removing the password is "
-				"a security risk and you should think twice "
-				"about this command\n");
+			vty_out(vty, NO_PASSWD_CMD_WARNING);
 			warned = true;
 		}
 		XFREE(MTYPE_HOST, host.enable);
@@ -2045,10 +2036,7 @@ DEFUN (no_config_enable_password,
 
 	if (host.enable_encrypt) {
 		if (!warned && !vty_shell_serv(vty))
-			vty_out(vty,
-				"Please be aware that removing the password is "
-				"a security risk and you should think twice "
-				"about this command\n");
+			vty_out(vty, NO_PASSWD_CMD_WARNING);
 		XFREE(MTYPE_HOST, host.enable_encrypt);
 	}
 	host.enable_encrypt = NULL;

--- a/lib/command.c
+++ b/lib/command.c
@@ -1944,19 +1944,23 @@ DEFUN (no_config_password,
 	bool warned = false;
 
 	if (host.password) {
-		vty_out(vty,
-			"Please be aware that removing the password is a security risk and "
-			"you should think twice about this command\n");
-		warned = true;
+		if (!vty_shell_serv(vty)) {
+			vty_out(vty,
+				"Please be aware that removing the password is "
+				"a security risk and you should think twice "
+				"about this command\n");
+			warned = true;
+		}
 		XFREE(MTYPE_HOST, host.password);
 	}
 	host.password = NULL;
 
 	if (host.password_encrypt) {
-		if (!warned)
+		if (!warned && !vty_shell_serv(vty))
 			vty_out(vty,
-				"Please be aware that removing the password is a security risk "
-				"and you should think twice about this command\n");
+				"Please be aware that removing the password is "
+				"a security risk and you should think twice "
+				"about this command\n");
 		XFREE(MTYPE_HOST, host.password_encrypt);
 	}
 	host.password_encrypt = NULL;
@@ -2028,19 +2032,23 @@ DEFUN (no_config_enable_password,
 	bool warned = false;
 
 	if (host.enable) {
-		vty_out(vty,
-			"Please be aware that removing the password is a security risk and "
-			"you should think twice about this command\n");
-		warned = true;
+		if (!vty_shell_serv(vty)) {
+			vty_out(vty,
+				"Please be aware that removing the password is "
+				"a security risk and you should think twice "
+				"about this command\n");
+			warned = true;
+		}
 		XFREE(MTYPE_HOST, host.enable);
 	}
 	host.enable = NULL;
 
 	if (host.enable_encrypt) {
-		if (!warned)
+		if (!warned && !vty_shell_serv(vty))
 			vty_out(vty,
-				"Please be aware that removing the password is a security risk "
-				"and you should think twice about this command\n");
+				"Please be aware that removing the password is "
+				"a security risk and you should think twice "
+				"about this command\n");
 		XFREE(MTYPE_HOST, host.enable_encrypt);
 	}
 	host.enable_encrypt = NULL;

--- a/lib/command.c
+++ b/lib/command.c
@@ -1895,7 +1895,7 @@ DEFUN (config_no_hostname,
 DEFUN (config_password,
        password_cmd,
        "password [(8-8)] WORD",
-       "Assign the terminal connection password\n"
+       "Modify the terminal connection password\n"
        "Specifies a HIDDEN password will follow\n"
        "The password string\n")
 {
@@ -1930,6 +1930,36 @@ DEFUN (config_password,
 			XSTRDUP(MTYPE_HOST, zencrypt(argv[idx_8]->arg));
 	} else
 		host.password = XSTRDUP(MTYPE_HOST, argv[idx_8]->arg);
+
+	return CMD_SUCCESS;
+}
+
+/* VTY interface password delete. */
+DEFUN (no_config_password,
+       no_password_cmd,
+       "no password",
+       NO_STR
+       "Modify the terminal connection password\n")
+{
+	bool warned = false;
+
+	if (host.password) {
+		vty_out(vty,
+			"Please be aware that removing the password is a security risk and "
+			"you should think twice about this command\n");
+		warned = true;
+		XFREE(MTYPE_HOST, host.password);
+	}
+	host.password = NULL;
+
+	if (host.password_encrypt) {
+		if (!warned)
+			vty_out(vty,
+				"Please be aware that removing the password is a security risk "
+				"and you should think twice about this command\n");
+		XFREE(MTYPE_HOST, host.password_encrypt);
+	}
+	host.password_encrypt = NULL;
 
 	return CMD_SUCCESS;
 }
@@ -1995,12 +2025,24 @@ DEFUN (no_config_enable_password,
        "Modify enable password parameters\n"
        "Assign the privileged level password\n")
 {
-	if (host.enable)
+	bool warned = false;
+
+	if (host.enable) {
+		vty_out(vty,
+			"Please be aware that removing the password is a security risk and "
+			"you should think twice about this command\n");
+		warned = true;
 		XFREE(MTYPE_HOST, host.enable);
+	}
 	host.enable = NULL;
 
-	if (host.enable_encrypt)
+	if (host.enable_encrypt) {
+		if (!warned)
+			vty_out(vty,
+				"Please be aware that removing the password is a security risk "
+				"and you should think twice about this command\n");
 		XFREE(MTYPE_HOST, host.enable_encrypt);
+	}
 	host.enable_encrypt = NULL;
 
 	return CMD_SUCCESS;
@@ -2710,6 +2752,7 @@ void cmd_init(int terminal)
 
 	if (terminal > 0) {
 		install_element(CONFIG_NODE, &password_cmd);
+		install_element(CONFIG_NODE, &no_password_cmd);
 		install_element(CONFIG_NODE, &enable_password_cmd);
 		install_element(CONFIG_NODE, &no_enable_password_cmd);
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -376,6 +376,10 @@ struct cmd_node {
 
 #define CONF_BACKUP_EXT ".sav"
 
+/* Command warnings. */
+#define NO_PASSWD_CMD_WARNING                                                  \
+	"Please be aware that removing the password is a security risk and you should think twice about this command.\n"
+
 /* IPv4 only machine should not accept IPv6 address for peer's IP
    address.  So we replace VTY command string like below. */
 #define NEIGHBOR_ADDR_STR  "Neighbor address\nIPv6 address\n"

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2372,6 +2372,10 @@ DEFUNSH(VTYSH_ALL, no_vtysh_config_password, no_vtysh_password_cmd,
 	"no password", NO_STR
 	"Modify the terminal connection password\n")
 {
+	vty_out(vty,
+		"Please be aware that removing the password is a security risk "
+		"and you should think twice about this command\n");
+
 	return CMD_SUCCESS;
 }
 
@@ -2390,6 +2394,10 @@ DEFUNSH(VTYSH_ALL, no_vtysh_config_enable_password,
 	"Modify enable password parameters\n"
 	"Assign the privileged level password\n")
 {
+	vty_out(vty,
+		"Please be aware that removing the password is a security risk "
+		"and you should think twice about this command\n");
+
 	return CMD_SUCCESS;
 }
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2361,9 +2361,16 @@ DEFUNSH(VTYSH_ALL, no_vtysh_service_password_encrypt,
 
 DEFUNSH(VTYSH_ALL, vtysh_config_password, vtysh_password_cmd,
 	"password [(8-8)] LINE",
-	"Assign the terminal connection password\n"
+	"Modify the terminal connection password\n"
 	"Specifies a HIDDEN password will follow\n"
 	"The password string\n")
+{
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_ALL, no_vtysh_config_password, no_vtysh_password_cmd,
+	"no password", NO_STR
+	"Modify the terminal connection password\n")
 {
 	return CMD_SUCCESS;
 }
@@ -3605,6 +3612,7 @@ void vtysh_init_vty(void)
 	install_element(CONFIG_NODE, &no_vtysh_service_password_encrypt_cmd);
 
 	install_element(CONFIG_NODE, &vtysh_password_cmd);
+	install_element(CONFIG_NODE, &no_vtysh_password_cmd);
 	install_element(CONFIG_NODE, &vtysh_enable_password_cmd);
 	install_element(CONFIG_NODE, &no_vtysh_enable_password_cmd);
 }

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2372,9 +2372,7 @@ DEFUNSH(VTYSH_ALL, no_vtysh_config_password, no_vtysh_password_cmd,
 	"no password", NO_STR
 	"Modify the terminal connection password\n")
 {
-	vty_out(vty,
-		"Please be aware that removing the password is a security risk "
-		"and you should think twice about this command\n");
+	vty_out(vty, NO_PASSWD_CMD_WARNING);
 
 	return CMD_SUCCESS;
 }
@@ -2394,9 +2392,7 @@ DEFUNSH(VTYSH_ALL, no_vtysh_config_enable_password,
 	"Modify enable password parameters\n"
 	"Assign the privileged level password\n")
 {
-	vty_out(vty,
-		"Please be aware that removing the password is a security risk "
-		"and you should think twice about this command\n");
+	vty_out(vty, NO_PASSWD_CMD_WARNING);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
This list of cherry-picked commits backport various bugfixes and features into dev/5.0. All these commits were already merged into master in previously separate pull requests:

- **d27a91dc564d113ce38715c35b8514a6562aef57**: https://github.com/FRRouting/frr/pull/2207 (bgpd: fix and improve snmp peer lookups)
- **279dde85ba320ac7b724297dc906856749190ad8**: https://github.com/FRRouting/frr/pull/2208 (debianpkg: improve VTYSH_PAGER environment check)
- **620ef7d7095767f273d02e1807f5f71240ab76fa**: https://github.com/FRRouting/frr/pull/2212 (lib: Ported 'no (enable) password' from stable/3.0)
- **5e73768bfac4baae1b562976eeca91beb34c67f4** and **3c699296e08b533bce0067473636e5ad66143193**: https://github.com/FRRouting/frr/pull/2223 (lib: Improved warnings for 'no (enable) password')
- **64b6806d3b1a046a4a6897d1e071ba948c87d123**: https://github.com/FRRouting/frr/pull/2226 (bgpd: Improve JSON support for large communities)
- **7fbf0204d9f86a5fc48f88ab934fff0fa8741d15**: https://github.com/FRRouting/frr/pull/2231 (bgpd: Respect AFI/SAFI when hard-clearing a peer)
- **dd92d48d5672e6d70014488dbca29277f0829831**: https://github.com/FRRouting/frr/pull/2239 (bgpd: Improve route-map matching for INET(6) AF)
- **49a3410b7769e489ddb3a86c910227317393753d** and **acd8748094be69831012284d297879c398ae8859**: https://github.com/FRRouting/frr/pull/2248 (bgpd: Improve show commands for adjacent routes (advertised/received-routes))