### PR TITLE
bgpd: Do not set interfaces ifindex

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -241,7 +241,6 @@ static int bgp_interface_delete(int command, struct zclient *zclient,
 
 	bgp_update_interface_nbrs(bgp, ifp, NULL);
 
-	if_set_index(ifp, IFINDEX_INTERNAL);
 	return 0;
 }
 


### PR DESCRIPTION
When a interface is deleted we should not be setting
the interface's ifindex to IFINDEX_INTERNAL.  This is
causing issues when we get new messages from zebra
about what to do with this interface.

I believe this is a hold-over from the very first vrf
implementation and we were not properly handling
interface movements and were allowing the daemons to
keep some of the state when a call was received.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>