### PR TITLE
doc: name correct branch in Debian 9 build docs [4.0]

### DIFF
--- a/doc/Building_FRR_on_Debian9.md
+++ b/doc/Building_FRR_on_Debian9.md
@@ -30,7 +30,7 @@ an example.)
 
     git clone https://github.com/frrouting/frr.git frr
     cd frr
-    git checkout stable/3.0
+    git checkout stable/4.0
     ./bootstrap.sh
     ./configure \
         --enable-exampledir=/usr/share/doc/frr/examples/ \


### PR DESCRIPTION
Credits to TekunoKage (#2288) for finding and fixing. Based on the signing key for the commit I'm guessing he/she used the GitHub inline source editor and may not know how to sign off.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>