### PR TITLE
doc: inform the diff between config from zebra and outside

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -464,8 +464,9 @@ commands in relationship to VRF. Here is an extract of some of those commands:
 
    This command is available on configuration mode. By default, above command
    permits accessing the vrf configuration mode. This mode is available for
-   both VRFs. It is to be noted that *Zebra* does not create *Linux VRF*.
-   Provisioning this command is used to keep the configuration intact.
+   both VRFs. It is to be noted that *Zebra* does not create Linux VRF.
+   The network administrator can however decide to provision this command in
+   configuration file to provide more clarity about the intended configuration.
 
 .. index:: netns NAMESPACE
 .. clicmd:: netns NAMESPACE
@@ -474,8 +475,9 @@ commands in relationship to VRF. Here is an extract of some of those commands:
    when *Zebra* is run in :option:`-n` mode. This command reflects which *Linux
    network namespace* is to be mapped with *Zebra* VRF. It is to be noted that
    *Zebra* creates and detects added/suppressed VRFs from the Linux environment
-   (in fact, those managed with iproute2). Provisioning this command is used to
-   keep the configuration intact.
+   (in fact, those managed with iproute2). The network administrator can however
+   decide to provision this command in configuration file to provide more clarity
+   about the intended configuration.
 
 .. index:: ip route NETWORK NETMASK GATEWAY NEXTHOPVRF
 .. clicmd:: ip route NETWORK NETMASK GATEWAY NEXTHOPVRF

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -58,6 +58,26 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 
 .. _interface-commands:
 
+Configuration Addresses behaviour
+=================================
+
+At startup, *Zebra* will first discover the underlying networking objects
+from the operating system. This includes interfaces, addresses of
+interfaces, static routes, etc. Then, it will read the configuration
+file, including its own interface addresses, static routes, etc. All this
+information comprises the operational context from *Zebra*. But
+configuration context from *Zebra* will remain the same as the one from
+:file:`zebra.conf` config file. As an example, executing the following
+:clicmd:`show running-config` will reflect what was in :file:`zebra.conf`.
+In a similar way, networking objects that are configured outside of the
+*Zebra* like *iproute2* will not impact the configuration context from
+*Zebra*. This behaviour permits you to continue saving your own config
+file, and decide what is really to be pushed on the config file, and what
+is dependent on the underlying system.
+Note that inversely, from *Zebra*, you will not be able to delete networking
+objects that were previously configured outside of *Zebra*.
+
+
 Interface Commands
 ==================
 


### PR DESCRIPTION
To avoid some confusions, it is precised in the documentation that
the configuration not done from zebra will not be injected in the
configuration context. As consequence, the config file will not be
impacted by underlying network context. But also, this will not be
possible for *Zebra* to attempt to modify outside networking objects.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>