### PR TITLE
default VRF naming update

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -266,6 +266,12 @@ static int bgp_vrf_enable(struct vrf *vrf)
 
 	bgp = bgp_lookup_by_name(vrf->name);
 	if (bgp) {
+		if (bgp->name && strmatch(vrf->name, VRF_DEFAULT_NAME)) {
+			XFREE(MTYPE_BGP, bgp->name);
+			bgp->name = NULL;
+			XFREE(MTYPE_BGP, bgp->name_pretty);
+			bgp->name_pretty = XSTRDUP(MTYPE_BGP, "VRF default");
+		}
 		old_vrf_id = bgp->vrf_id;
 		/* We have instance configured, link to VRF and make it "up". */
 		bgp_vrf_link(bgp, vrf);

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -332,7 +332,8 @@ static int bgp_vrf_disable(struct vrf *vrf)
 
 static void bgp_vrf_init(void)
 {
-	vrf_init(bgp_vrf_new, bgp_vrf_enable, bgp_vrf_disable, bgp_vrf_delete);
+	vrf_init(bgp_vrf_new, bgp_vrf_enable, bgp_vrf_disable,
+		 bgp_vrf_delete, NULL);
 }
 
 static void bgp_vrf_terminate(void)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7735,10 +7735,8 @@ static void bgp_viewvrf_autocomplete(vector comps, struct cmd_token *token)
 	struct listnode *next;
 	struct bgp *bgp;
 
-	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		if (vrf->vrf_id != VRF_DEFAULT)
-			vector_set(comps, XSTRDUP(MTYPE_COMPLETION, vrf->name));
-	}
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
+		vector_set(comps, XSTRDUP(MTYPE_COMPLETION, vrf->name));
 
 	for (ALL_LIST_ELEMENTS_RO(bm->bgp, next, bgp)) {
 		if (bgp->inst_type != BGP_INSTANCE_TYPE_VIEW)

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -48,6 +48,13 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 
    .. seealso:: :ref:`zebra-vrf`
 
+.. option:: -o, --vrfdefaultname
+
+   When *Zebra* starts with this option, the default VRF name is changed to the
+   parameter.
+
+   .. seealso:: :ref:`zebra-vrf`
+
 .. option:: --v6-rr-semantics
 
    The linux kernel is receiving the ability to use the same route

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -355,6 +355,40 @@ commands in relationship to VRF. Here is an extract of some of those commands:
    will dump the routing table ``TABLENO`` of the *Linux network namespace*
    ``VRF``.
 
+By using the :option:`-n` option, the *Linux network namespace* will be mapped
+over the *Zebra* VRF. One nice feature that is possible by handling *Linux
+network namespace* is the ability to name default VRF. At startup, *Zebra*
+discovers the available *Linux network namespace* by parsing folder
+`/var/run/netns`. Each file stands for a *Linux network namespace*, but not all
+*Linux network namespaces* are available under that folder. This is the case for
+default VRF. It is possible to name the default VRF, by creating a file, by
+executing following commands.
+
+.. code-block:: shell
+
+   touch /var/run/netns/vrf0
+   mount --bind /proc/self/ns/net /var/run/netns/vrf0
+
+Above command illustrates what happens when the default VRF is visible under
+`var/run/netns/`. Here, the default VRF file is `vrf0`.
+At startup, FRR detects the presence of that file. It detects that the file
+statistics information matches the same file statistics information as
+`/proc/self/ns/net` ( through stat() function). As statistics information
+matches, then `vrf0` stands for the new default namespace name.
+Consequently, the VRF naming `Default` will be overriden by the new discovered
+namespace name `vrf0`.
+
+For those who don't use VRF backend with *Linux network namespace*, it is
+possible to statically configure and recompile FRR. It is possible to choose an
+alternate name for default VRF. Then, the default VRF naming will automatically
+be updated with the new name. To illustrate, if you want to recompile with
+`global` value, use the following command:
+
+.. code-block:: linux
+
+   ./configure --with-defaultvrfname=global
+
+More information about the option in :ref:`_frr-configuration`.
 
 .. _zebra-mpls:
 

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv, char **envp)
 	master = eigrp_om->master;
 
 	eigrp_error_init();
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 
 	/*EIGRPd init*/
 	eigrp_if_init();

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -192,7 +192,7 @@ int main(int argc, char **argv, char **envp)
 	 */
 	isis_error_init();
 	access_list_init();
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	prefix_list_init();
 	isis_init();
 	isis_circuit_init();

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -330,7 +330,7 @@ main(int argc, char *argv[])
 	master = frr_init();
 
 	vty_config_lockless();
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	access_list_init();
 	ldp_vty_init();
 	ldp_zebra_init(master);

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -447,10 +447,8 @@ static void vrf_autocomplete(vector comps, struct cmd_token *token)
 {
 	struct vrf *vrf = NULL;
 
-	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-		if (vrf->vrf_id != VRF_DEFAULT)
-			vector_set(comps, XSTRDUP(MTYPE_COMPLETION, vrf->name));
-	}
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
+		vector_set(comps, XSTRDUP(MTYPE_COMPLETION, vrf->name));
 }
 
 static const struct cmd_variable_handler vrf_var_handlers[] = {

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -466,7 +466,10 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 	      int ((*update)(struct vrf *)))
 {
 	struct vrf *default_vrf;
+	char *local_ptr =  (char *)VRF_DEFAULT_NAME;
 
+	if (local_ptr)
+		vrf_default_name = XSTRDUP(MTYPE_VRF, local_ptr);
 	/* initialise NS, in case VRF backend if NETNS */
 	ns_init();
 	if (debug_vrf)
@@ -480,12 +483,15 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 	vrf_master.vrf_update_name_hook = update;
 
 	/* The default VRF always exists. */
-	default_vrf = vrf_get(VRF_DEFAULT, VRF_DEFAULT_NAME);
+	default_vrf = vrf_get(VRF_DEFAULT, vrf_default_name);
 	if (!default_vrf) {
 		flog_err(LIB_ERR_VRF_START,
 			  "vrf_init: failed to create the default VRF!");
 		exit(1);
 	}
+	if (vrf_is_backend_netns())
+		strlcpy(default_vrf->data.l.netns_name,
+			vrf_default_name, NS_NAMSIZ);
 
 	/* Enable the default VRF. */
 	if (!vrf_enable(default_vrf)) {

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -473,10 +473,7 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 	      int ((*update)(struct vrf *)))
 {
 	struct vrf *default_vrf;
-	char *local_ptr =  (char *)VRF_DEFAULT_NAME;
 
-	if (local_ptr)
-		vrf_default_name = XSTRDUP(MTYPE_VRF, local_ptr);
 	/* initialise NS, in case VRF backend if NETNS */
 	ns_init();
 	if (debug_vrf)
@@ -490,7 +487,7 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 	vrf_master.vrf_update_name_hook = update;
 
 	/* The default VRF always exists. */
-	default_vrf = vrf_get(VRF_DEFAULT, vrf_default_name);
+	default_vrf = vrf_get(VRF_DEFAULT, VRF_DEFAULT_NAME);
 	if (!default_vrf) {
 		flog_err(LIB_ERR_VRF_START,
 			  "vrf_init: failed to create the default VRF!");
@@ -498,7 +495,7 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 	}
 	if (vrf_is_backend_netns())
 		strlcpy(default_vrf->data.l.netns_name,
-			vrf_default_name, NS_NAMSIZ);
+			VRF_DEFAULT_NAME, NS_NAMSIZ);
 
 	/* Enable the default VRF. */
 	if (!vrf_enable(default_vrf)) {

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -199,8 +199,10 @@ extern int vrf_bitmap_check(vrf_bitmap_t, vrf_id_t);
  * delete -> Called back when a vrf is being deleted from
  *           the system ( 2 and 3 ) above.
  */
-extern void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
-		     int (*disable)(struct vrf *), int (*delete)(struct vrf *));
+extern void vrf_init(int (*create)(struct vrf *vrf), int (*enable)(struct vrf *vrf),
+		     int (*disable)(struct vrf *vrf), int (*delete)(struct vrf *vrf),
+		     int ((*update)(struct vrf *vrf)));
+
 /*
  * Call vrf_terminate when the protocol is being shutdown
  */

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -41,8 +41,6 @@ enum { IFLA_VRF_UNSPEC, IFLA_VRF_TABLE, __IFLA_VRF_MAX };
 #define VRF_NAMSIZ      36
 #define NS_NAMSIZ       16
 
-#define VRF_DEFAULT_NAME    "Default-IP-Routing-Table"
-
 /*
  * The command strings
  */
@@ -235,6 +233,10 @@ extern int vrf_ioctl(vrf_id_t vrf_id, int d, unsigned long request, char *args);
 extern vrf_id_t vrf_get_default_id(void);
 /* The default VRF ID */
 #define VRF_DEFAULT vrf_get_default_id()
+
+extern void vrf_set_default_name(const char *default_name);
+extern const char *vrf_get_default_name(void);
+#define VRF_DEFAULT_NAME    vrf_get_default_name()
 
 /* VRF is mapped on netns or not ? */
 int vrf_is_mapped_on_netns(struct vrf *vrf);

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1366,6 +1366,9 @@ static void zclient_vrf_add(struct zclient *zclient, vrf_id_t vrf_id)
 	vrf = vrf_get(vrf_id, vrfname_tmp);
 	vrf->data.l.table_id = data.l.table_id;
 	memcpy(vrf->data.l.netns_name, data.l.netns_name, NS_NAMSIZ);
+	/* overwrite default vrf */
+	if (vrf_id == VRF_DEFAULT)
+		vrf_set_default_name(vrfname_tmp);
 	vrf_enable(vrf);
 }
 

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
 	/* Library inits. */
 	master = frr_init();
 	nhrp_error_init();
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	nhrp_interface_init();
 	resolver_init();
 

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -208,7 +208,7 @@ int main(int argc, char *argv[], char *envp[])
 	/* thread master */
 	master = frr_init();
 
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	access_list_init();
 	prefix_list_init();
 

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -145,6 +145,8 @@ static struct ospf *ospf_cmd_lookup_ospf(struct vty *vty,
 
 	if (argv_find(argv, argc, "vrf", &idx_vrf)) {
 		vrf_name = argv[idx_vrf + 1]->arg;
+		if (vrf_name == NULL || strmatch(vrf_name, VRF_DEFAULT_NAME))
+			vrf_name = NULL;
 		if (enable) {
 			/* Allocate VRF aware instance */
 			ospf = ospf_get(*instance, vrf_name);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -2149,7 +2149,7 @@ static int ospf_vrf_disable(struct vrf *vrf)
 void ospf_vrf_init(void)
 {
 	vrf_init(ospf_vrf_new, ospf_vrf_enable, ospf_vrf_disable,
-		 ospf_vrf_delete);
+		 ospf_vrf_delete, NULL);
 }
 
 void ospf_vrf_terminate(void)

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -234,12 +234,10 @@ static struct ospf *ospf_new(unsigned short instance, const char *name)
 	new->instance = instance;
 	new->router_id.s_addr = htonl(0);
 	new->router_id_static.s_addr = htonl(0);
-
-	if (name) {
+	if (name && !strmatch(name, VRF_DEFAULT_NAME)) {
 		new->vrf_id = VRF_UNKNOWN;
 		/* Freed in ospf_finish_final */
 		new->name = XSTRDUP(MTYPE_OSPF_TOP, name);
-		vrf = vrf_lookup_by_name(new->name);
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_debug(
 				"%s: Create new ospf instance with vrf_name %s vrf_id %u",
@@ -380,6 +378,9 @@ struct ospf *ospf_lookup_by_inst_name(unsigned short instance, const char *name)
 {
 	struct ospf *ospf = NULL;
 	struct listnode *node, *nnode;
+
+	if (name == NULL || strmatch(name, VRF_DEFAULT_NAME))
+		return ospf_lookup_by_vrf_id(VRF_DEFAULT);
 
 	for (ALL_LIST_ELEMENTS(om->ospf, node, nnode, ospf)) {
 		if ((ospf->instance == instance)
@@ -2078,6 +2079,10 @@ static int ospf_vrf_enable(struct vrf *vrf)
 
 	ospf = ospf_lookup_by_name(vrf->name);
 	if (ospf) {
+		if (ospf->name && strmatch(vrf->name, VRF_DEFAULT_NAME)) {
+			XFREE(MTYPE_OSPF_TOP, ospf->name);
+			ospf->name = NULL;
+		}
 		old_vrf_id = ospf->vrf_id;
 		/* We have instance configured, link to VRF and make it "up". */
 		ospf_vrf_link(ospf, vrf);

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -146,7 +146,7 @@ int main(int argc, char **argv, char **envp)
 
 	pbr_debug_init();
 
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	nexthop_group_init(pbr_nhgroup_add_cb,
 			   pbr_nhgroup_add_nexthop_cb,
 			   pbr_nhgroup_del_nexthop_cb,

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -196,7 +196,8 @@ static int pim_vrf_config_write(struct vty *vty)
 
 void pim_vrf_init(void)
 {
-	vrf_init(pim_vrf_new, pim_vrf_enable, pim_vrf_disable, pim_vrf_delete);
+	vrf_init(pim_vrf_new, pim_vrf_enable, pim_vrf_disable,
+		 pim_vrf_delete, NULL);
 
 	vrf_cmd_init(pim_vrf_config_write, &pimd_privs);
 }

--- a/ripd/rip_main.c
+++ b/ripd/rip_main.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv)
 	/* Library initialization. */
 	rip_error_init();
 	keychain_init();
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 
 	/* RIP related initialization. */
 	rip_init();

--- a/ripngd/ripng_main.c
+++ b/ripngd/ripng_main.c
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
 	master = frr_init();
 
 	/* Library inits. */
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 
 	/* RIPngd inits. */
 	ripng_init();

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -146,7 +146,7 @@ int main(int argc, char **argv, char **envp)
 
 	master = frr_init();
 
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 
 	access_list_init();
 	route_map_init();

--- a/staticd/static_vrf.c
+++ b/staticd/static_vrf.c
@@ -190,7 +190,7 @@ int static_vrf_has_config(struct static_vrf *svrf)
 void static_vrf_init(void)
 {
 	vrf_init(static_vrf_new, static_vrf_enable,
-		 static_vrf_disable, static_vrf_delete);
+		 static_vrf_disable, static_vrf_delete, NULL);
 
 	vrf_cmd_init(static_vrf_config_write, &static_privs);
 }

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -913,7 +913,7 @@ int main(void)
 	qobj_init();
 	master = thread_master_create(NULL);
 	bgp_master_init(master);
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 
 	bgp_pthreads_init();

--- a/tests/bgpd/test_mp_attr.c
+++ b/tests/bgpd/test_mp_attr.c
@@ -1079,7 +1079,7 @@ int main(void)
 	bgp_vty_init();
 	master = thread_master_create("test mp attr");
 	bgp_master_init(master);
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 	bgp_attr_init();
 

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -379,7 +379,7 @@ static int global_test_init(void)
 	master = thread_master_create(NULL);
 	zclient = zclient_new_notify(master, &zclient_options_default);
 	bgp_master_init(master);
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 
 	if (fileno(stdout) >= 0)

--- a/tests/bgpd/test_packet.c
+++ b/tests/bgpd/test_packet.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 	bgp_attr_init();
 	master = thread_master_create(NULL);
 	bgp_master_init(master);
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 
 	if (bgp_get(&bgp, &asn, NULL, BGP_INSTANCE_TYPE_DEFAULT))

--- a/tests/bgpd/test_peer_attr.c
+++ b/tests/bgpd/test_peer_attr.c
@@ -1387,7 +1387,7 @@ static void bgp_startup(void)
 	master = thread_master_create(NULL);
 	bgp_master_init(master);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
-	vrf_init(NULL, NULL, NULL, NULL);
+	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	bgp_init();
 	bgp_pthreads_run();
 }

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -99,6 +99,7 @@ struct option longopts[] = {
 	{"ecmp", required_argument, NULL, 'e'},
 	{"label_socket", no_argument, NULL, 'l'},
 	{"retain", no_argument, NULL, 'r'},
+	{"vrfdefaultname", required_argument, NULL, 'o'},
 #ifdef HAVE_NETLINK
 	{"vrfwnetns", no_argument, NULL, 'n'},
 	{"nl-bufsize", required_argument, NULL, 's'},
@@ -235,7 +236,7 @@ int main(int argc, char **argv)
 	frr_preinit(&zebra_di, argc, argv);
 
 	frr_opt_add(
-		"bakz:e:l:r"
+		"bakz:e:l:o:r"
 #ifdef HAVE_NETLINK
 		"s:n"
 #endif
@@ -254,6 +255,7 @@ int main(int argc, char **argv)
 		"  -l, --label_socket    Socket to external label manager\n"
 		"  -k, --keep_kernel     Don't delete old routes which were installed by zebra.\n"
 		"  -r, --retain          When program terminates, retain added route by zebra.\n"
+		"  -o, --vrfdefaultname  Set default VRF name.\n"
 #ifdef HAVE_NETLINK
 		"  -n, --vrfwnetns       Use NetNS as VRF backend\n"
 		"  -s, --nl-bufsize      Set netlink receive buffer size\n"
@@ -295,6 +297,9 @@ int main(int argc, char **argv)
 					MULTIPATH_NUM);
 				return 1;
 			}
+			break;
+		case 'o':
+			vrf_set_default_name(optarg);
 			break;
 		case 'z':
 			zserv_path = optarg;

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -282,6 +282,19 @@ static int zebra_vrf_delete(struct vrf *vrf)
 	return 0;
 }
 
+static int zebra_vrf_update(struct vrf *vrf)
+{
+	struct zebra_vrf *zvrf = vrf->info;
+
+	assert(zvrf);
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("VRF %s id %u, name updated", vrf->name,
+			   zvrf_id(zvrf));
+	zebra_vrf_add_update(zvrf);
+	return 0;
+}
+
+
 /* Return if this VRF has any FRR configuration or not.
  * IMPORTANT: This function needs to be updated when additional configuration
  * is added for a VRF.
@@ -491,7 +504,7 @@ static int vrf_config_write(struct vty *vty)
 void zebra_vrf_init(void)
 {
 	vrf_init(zebra_vrf_new, zebra_vrf_enable, zebra_vrf_disable,
-		 zebra_vrf_delete);
+		 zebra_vrf_delete, zebra_vrf_update);
 
 	vrf_cmd_init(vrf_config_write, &zserv_privs);
 }


### PR DESCRIPTION
This set of patches permits configuring VRF with extended naming convention.
in vrf backend with netns mode, it is possible to create netns using the same NSID (practically this  is the same netnamespace, but from the user point of view, there are several netns).
So, FRR recognizes those different names, that I call aliases.
