### PR TITLE
pimd: Fix nexthop determination when sending towards RP

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -657,10 +657,19 @@ int pim_parse_nexthop_update(int command, struct zclient *zclient,
 			nexthop = nexthop_from_zapi_nexthop(&nhr.nexthops[i]);
 			switch (nexthop->type) {
 			case NEXTHOP_TYPE_IPV4:
-			case NEXTHOP_TYPE_IFINDEX:
 			case NEXTHOP_TYPE_IPV4_IFINDEX:
 			case NEXTHOP_TYPE_IPV6:
 			case NEXTHOP_TYPE_BLACKHOLE:
+				break;
+			case NEXTHOP_TYPE_IFINDEX:
+				/*
+				 * Connected route (i.e. no nexthop), use
+				 * RPF address from nexthop cache (i.e.
+				 * destination) as PIM nexthop.
+				 */
+				nexthop->type = NEXTHOP_TYPE_IPV4;
+				nexthop->gate.ipv4 =
+					pnc->rpf.rpf_addr.u.prefix4;
 				break;
 			case NEXTHOP_TYPE_IPV6_IFINDEX:
 				ifp1 = if_lookup_by_index(nexthop->ifindex,


### PR DESCRIPTION
When sending a PIM join upwards on the RP-based tree, it may get dropped on
the last hop before the RP if the RP is reachable via a connected route
(i.e. there's no associated nexthop). pimd needs to put the nexthop IP
address into the PIM join payload and fails to do that if that route has a
nexthop of 0.0.0.0. Instead of using that (and complaining that it can't
send later), simply use the RP's address directly as the nexthop instead.

Fixes #2326.

Disclaimer: Works for me in a simple setup, but I'm not familiar enough with
the pimd source code to judge whether this is the correct fix or whether
there are more places that need fixing.

Signed-off-by: Martin Buck <mb-tmp-tvguho.pbz@gromit.dyndns.org>