### PR TITLE
ospfd: implement passive-interface function of cisco

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -716,7 +716,7 @@ void ospf_if_set_multicast(struct ospf_interface *oi)
 {
 	if ((oi->state > ISM_Loopback) && (oi->type != OSPF_IFTYPE_LOOPBACK)
 	    && (oi->type != OSPF_IFTYPE_VIRTUALLINK)
-	    && (OSPF_IF_PASSIVE_STATUS(oi) == OSPF_IF_ACTIVE)) {
+	    && (oi->passive_interface == OSPF_IF_ACTIVE)) {
 		/* The interface should belong to the OSPF-all-routers group. */
 		if (!OI_MEMBER_CHECK(oi, MEMBER_ALLROUTERS)
 		    && (ospf_if_add_allspfrouters(oi->ospf, oi->address,
@@ -746,7 +746,7 @@ void ospf_if_set_multicast(struct ospf_interface *oi)
 	if (((oi->type == OSPF_IFTYPE_BROADCAST)
 	     || (oi->type == OSPF_IFTYPE_POINTOPOINT))
 	    && ((oi->state == ISM_DR) || (oi->state == ISM_Backup))
-	    && (OSPF_IF_PASSIVE_STATUS(oi) == OSPF_IF_ACTIVE)) {
+	    && (oi->passive_interface == OSPF_IF_ACTIVE)) {
 		/* The interface should belong to the OSPF-designated-routers
 		 * group. */
 		if (!OI_MEMBER_CHECK(oi, MEMBER_DROUTERS)

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -187,6 +187,11 @@ struct ospf_interface {
 	struct prefix *address;      /* Interface prefix */
 	struct connected *connected; /* Pointer to connected */
 
+	/* This flag indicate if the network of a interface is passive/active
+	 * and it's more simple and clear than params
+	 */
+	uint8_t passive_interface;
+
 	/* Configured varables. */
 	struct ospf_if_params *params;
 

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2958,7 +2958,7 @@ int ospf_read(struct thread *thread)
 	   purposes and must remain very accurate in doing this. */
 
 	/* If incoming interface is passive one, ignore it. */
-	if (oi && OSPF_IF_PASSIVE_STATUS(oi) == OSPF_IF_PASSIVE) {
+	if (oi && oi->passive_interface == OSPF_IF_PASSIVE) {
 		char buf[3][INET_ADDRSTRLEN];
 
 		if (IS_DEBUG_OSPF_EVENT)
@@ -3565,7 +3565,7 @@ static void ospf_poll_send(struct ospf_nbr_nbma *nbr_nbma)
 	assert(oi);
 
 	/* If this is passive interface, do not send OSPF Hello. */
-	if (OSPF_IF_PASSIVE_STATUS(oi) == OSPF_IF_PASSIVE)
+	if (oi->passive_interface == OSPF_IF_PASSIVE)
 		return;
 
 	if (oi->type != OSPF_IFTYPE_NBMA)
@@ -3627,7 +3627,7 @@ int ospf_hello_reply_timer(struct thread *thread)
 void ospf_hello_send(struct ospf_interface *oi)
 {
 	/* If this is passive interface, do not send OSPF Hello. */
-	if (OSPF_IF_PASSIVE_STATUS(oi) == OSPF_IF_PASSIVE)
+	if (oi->passive_interface == OSPF_IF_PASSIVE)
 		return;
 
 	if (oi->type == OSPF_IFTYPE_NBMA) {

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -131,7 +131,10 @@ static int ospf_interface_add(int command, struct zclient *zclient,
 
 	ospf_if_recalculate_output_cost(ifp);
 
-	ospf_if_update(ospf, ifp);
+	if (ospf->passive_interface_default == OSPF_IF_PASSIVE)
+		ospf_passive_if_update(ospf, ifp);
+	else
+		ospf_if_update(ospf, ifp);
 
 	hook_call(ospf_if_update, ifp);
 

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1031,6 +1031,7 @@ static struct ospf_network *ospf_network_new(struct in_addr area_id)
 
 	new->area_id = area_id;
 	new->area_id_fmt = OSPF_AREA_ID_FMT_DOTTEDQUAD;
+	new->passive = OSPF_IF_ACTIVE;
 
 	return new;
 }
@@ -1043,7 +1044,7 @@ void ospf_network_free(struct ospf *ospf, struct ospf_network *network)
 }
 
 int ospf_network_set(struct ospf *ospf, struct prefix_ipv4 *p,
-		     struct in_addr area_id, int df)
+		     struct in_addr area_id, int df, uint8_t passive)
 {
 	struct ospf_network *network;
 	struct ospf_area *area;
@@ -1055,6 +1056,7 @@ int ospf_network_set(struct ospf *ospf, struct prefix_ipv4 *p,
 		route_unlock_node(rn);
 
 		if (IPV4_ADDR_SAME(&area_id, &network->area_id)) {
+			network->passive = passive;
 			return 1;
 		} else {
 			/* There is already same network statement. */
@@ -1063,6 +1065,7 @@ int ospf_network_set(struct ospf *ospf, struct prefix_ipv4 *p,
 	}
 
 	rn->info = network = ospf_network_new(area_id);
+	network->passive = passive;
 	network->area_id_fmt = df;
 	area = ospf_area_get(ospf, area_id);
 	ospf_area_display_format_set(ospf, area, df);

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -511,6 +511,7 @@ extern void ospf_finish(struct ospf *);
 extern void ospf_router_id_update(struct ospf *ospf);
 extern int ospf_network_set(struct ospf *, struct prefix_ipv4 *, struct in_addr,
 			    int);
+extern void ospf_network_free(struct ospf *ospf, struct ospf_network *network);
 extern int ospf_network_unset(struct ospf *, struct prefix_ipv4 *,
 			      struct in_addr);
 extern int ospf_area_display_format_set(struct ospf *, struct ospf_area *area,
@@ -543,6 +544,7 @@ extern int ospf_nbr_nbma_poll_interval_unset(struct ospf *, struct in_addr);
 extern void ospf_prefix_list_update(struct prefix_list *);
 extern void ospf_init(void);
 extern void ospf_if_update(struct ospf *, struct interface *);
+extern void ospf_passive_if_update(struct ospf *ospf, struct interface *ifp);
 extern void ospf_ls_upd_queue_empty(struct ospf_interface *);
 extern void ospf_terminate(void);
 extern void ospf_nbr_nbma_if_update(struct ospf *, struct ospf_interface *);

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -432,6 +432,7 @@ struct ospf_network {
 	/* Area ID. */
 	struct in_addr area_id;
 	int area_id_fmt;
+	uint8_t passive;
 };
 
 /* OSPF NBMA neighbor structure. */
@@ -510,7 +511,7 @@ extern struct ospf *ospf_lookup_by_vrf_id(vrf_id_t vrf_id);
 extern void ospf_finish(struct ospf *);
 extern void ospf_router_id_update(struct ospf *ospf);
 extern int ospf_network_set(struct ospf *, struct prefix_ipv4 *, struct in_addr,
-			    int);
+			    int, uint8_t passive);
 extern void ospf_network_free(struct ospf *ospf, struct ospf_network *network);
 extern int ospf_network_unset(struct ospf *, struct prefix_ipv4 *,
 			      struct in_addr);


### PR DESCRIPTION
"passive-interface default/interface [IPv4]" will automatic
add interface into ospf but not active it for adjacency and
futher action

"no passive-interface default/interface [IPv4]" will active
the passive interface for adjacency and futher