### PR TITLE
bgpd: do not save 'bgp default shutdown' to config

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7389,10 +7389,6 @@ int bgp_config_write(struct vty *vty)
 			vty_out(vty, " bgp default subgroup-pkt-queue-max %u\n",
 				bgp->default_subgroup_pkt_queue_max);
 
-		/* BGP default autoshutdown neighbors */
-		if (bgp->autoshutdown)
-			vty_out(vty, " bgp default shutdown\n");
-
 		/* BGP client-to-client reflection. */
 		if (bgp_flag_check(bgp, BGP_FLAG_NO_CLIENT_TO_CLIENT))
 			vty_out(vty, " no bgp client-to-client reflection\n");

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -633,8 +633,7 @@ Defining Peer
 BGP Peer commands
 -----------------
 
-In a `router bgp` clause there are neighbor specific configurations
-required.
+Various options for BGP peerings.
 
 .. index:: neighbor PEER shutdown
 .. clicmd:: neighbor PEER shutdown
@@ -643,9 +642,22 @@ required.
 .. clicmd:: no neighbor PEER shutdown
 
    Shutdown the peer. We can delete the neighbor's configuration by
-   ``no neighbor PEER remote-as ASN`` but all configuration of the neighbor
+   :clicmd:`no neighbor PEER remote-as ASN` but all configuration of the neighbor
    will be deleted. When you want to preserve the configuration, but want to
    drop the BGP peer, use this syntax.
+
+.. index:: bgp default shutdown
+.. clicmd:: bgp default shutdown
+
+.. index:: no bgp default shutdown
+.. clicmd:: no bgp default shutdown
+
+   When entered from VTYSH or a Telnet session, this option will cause all
+   peers configured after it to automatically placed in administrative
+   shutdown. To prevent unintended side effects after a daemon restart, this
+   option is not saved to the config when using :clicmd:`write file`. If placed
+   in the config file manually, each peer will need to be manually enabled
+   after every daemon restart.
 
 .. index:: neighbor PEER ebgp-multihop
 .. clicmd:: neighbor PEER ebgp-multihop
@@ -656,7 +668,6 @@ required.
 
 .. index:: neighbor PEER description ...
 .. clicmd:: neighbor PEER description ...
-
 
 .. index:: no neighbor PEER description ...
 .. clicmd:: no neighbor PEER description ...


### PR DESCRIPTION
Saving this option to the config caused all peers to remain in
administrative shutdown after a restart, which was not the desired
behavior. Instead make this knob ephemeral to the program lifetime and
do not save it.

Unless there are issues with this I will open a PR to cherry-pick against 5.0 as well.

Fixes #2286 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>