### PR TITLE
zebra: Fix memory leak on host prefix removal

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3111,8 +3111,10 @@ static void rb_delete_host(struct host_rb_tree_entry *hrbe, struct prefix *host)
 	memcpy(&lookup.p, host, sizeof(*host));
 
 	hle = RB_FIND(host_rb_tree_entry, hrbe, &lookup);
-	if (hle)
+	if (hle) {
 		RB_REMOVE(host_rb_tree_entry, hrbe, hle);
+		XFREE(MTYPE_HOST_PREFIX, hle);
+	}
 
 	return;
 }


### PR DESCRIPTION
When we have a host prefix, actually free the alloced memory
associated with it when we free it.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>