### PR TITLE
pimd: Fix ecmp_enable and ecmp_rebalance_enable

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4428,9 +4428,9 @@ static void pim_cmd_show_ip_multicast_helper(struct pim_instance *pim,
 	vty_out(vty, "\n");
 	vty_out(vty, "Upstream Join Timer: %d secs\n", qpim_t_periodic);
 	vty_out(vty, "Join/Prune Holdtime: %d secs\n", PIM_JP_HOLDTIME);
-	vty_out(vty, "PIM ECMP: %s\n", qpim_ecmp_enable ? "Enable" : "Disable");
+	vty_out(vty, "PIM ECMP: %s\n", pim->ecmp_enable ? "Enable" : "Disable");
 	vty_out(vty, "PIM ECMP Rebalance: %s\n",
-		qpim_ecmp_rebalance_enable ? "Enable" : "Disable");
+		pim->ecmp_rebalance_enable ? "Enable" : "Disable");
 
 	vty_out(vty, "\n");
 
@@ -5734,7 +5734,7 @@ DEFUN (ip_pim_ecmp,
        "Enable PIM ECMP \n")
 {
 	PIM_DECLVAR_CONTEXT(vrf, pim);
-	qpim_ecmp_enable = 1;
+	pim->ecmp_enable = true;
 
 	return CMD_SUCCESS;
 }
@@ -5748,7 +5748,7 @@ DEFUN (no_ip_pim_ecmp,
        "Disable PIM ECMP \n")
 {
 	PIM_DECLVAR_CONTEXT(vrf, pim);
-	qpim_ecmp_enable = 0;
+	pim->ecmp_enable = false;
 
 	return CMD_SUCCESS;
 }
@@ -5762,8 +5762,8 @@ DEFUN (ip_pim_ecmp_rebalance,
        "Enable PIM ECMP Rebalance\n")
 {
 	PIM_DECLVAR_CONTEXT(vrf, pim);
-	qpim_ecmp_enable = 1;
-	qpim_ecmp_rebalance_enable = 1;
+	pim->ecmp_enable = true;
+	pim->ecmp_rebalance_enable = true;
 
 	return CMD_SUCCESS;
 }
@@ -5778,7 +5778,7 @@ DEFUN (no_ip_pim_ecmp_rebalance,
        "Disable PIM ECMP Rebalance\n")
 {
 	PIM_DECLVAR_CONTEXT(vrf, pim);
-	qpim_ecmp_rebalance_enable = 0;
+	pim->ecmp_rebalance_enable = false;
 
 	return CMD_SUCCESS;
 }

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -77,6 +77,8 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	pim->keep_alive_time = PIM_KEEPALIVE_PERIOD;
 	pim->rp_keep_alive_time = PIM_RP_KEEPALIVE_PERIOD;
 
+	pim->ecmp_enable = false;
+	pim->ecmp_rebalance_enable = false;
 
 	pim->vrf_id = vrf->vrf_id;
 	pim->vrf = vrf;

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -95,6 +95,9 @@ struct pim_instance {
 	unsigned int keep_alive_time;
 	unsigned int rp_keep_alive_time;
 
+	bool ecmp_enable;
+	bool ecmp_rebalance_enable;
+
 	/* If we need to rescan all our upstreams */
 	struct thread *rpf_cache_refresher;
 	int64_t rpf_cache_refresh_requests;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -449,7 +449,7 @@ int pim_ecmp_nexthop_search(struct pim_instance *pim,
 		   metric is less than nexthop update.
 		 */
 
-		if (qpim_ecmp_rebalance_enable == 0) {
+		if (pim->ecmp_rebalance_enable == 0) {
 			uint8_t curr_route_valid = 0;
 			// Check if current nexthop is present in new updated
 			// Nexthop list.
@@ -499,7 +499,7 @@ int pim_ecmp_nexthop_search(struct pim_instance *pim,
 			}
 		}
 	}
-	if (qpim_ecmp_enable) {
+	if (pim->ecmp_enable) {
 		// PIM ECMP flag is enable then choose ECMP path.
 		hash_val = pim_compute_ecmp_hash(src, grp);
 		mod_val = hash_val % pnc->nexthop_num;
@@ -586,7 +586,7 @@ int pim_ecmp_nexthop_search(struct pim_instance *pim,
 					"%s: (%s,%s)(%s) selected nhop interface %s addr %s mod_val %u iter %d ecmp %d",
 					__PRETTY_FUNCTION__, buf2, buf3,
 					pim->vrf->name, ifp->name, buf, mod_val,
-					nh_iter, qpim_ecmp_enable);
+					nh_iter, pim->ecmp_enable);
 			}
 		}
 		nh_iter++;
@@ -808,7 +808,7 @@ int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 	}
 
 	// If PIM ECMP enable then choose ECMP path.
-	if (qpim_ecmp_enable) {
+	if (pim->ecmp_enable) {
 		hash_val = pim_compute_ecmp_hash(src, grp);
 		mod_val = hash_val % num_ifindex;
 		if (PIM_DEBUG_PIM_NHT_DETAIL)
@@ -942,7 +942,7 @@ int pim_ecmp_fib_lookup_if_vif_index(struct pim_instance *pim,
 	}
 
 	// If PIM ECMP enable then choose ECMP path.
-	if (qpim_ecmp_enable) {
+	if (pim->ecmp_enable) {
 		hash_val = pim_compute_ecmp_hash(src, grp);
 		mod_val = hash_val % num_ifindex;
 		if (PIM_DEBUG_PIM_NHT_DETAIL)

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -214,10 +214,10 @@ int pim_global_config_write_worker(struct pim_instance *pim, struct vty *vty)
 				spaces);
 		++writes;
 	}
-	if (qpim_ecmp_rebalance_enable) {
+	if (pim->ecmp_rebalance_enable) {
 		vty_out(vty, "%sip pim ecmp rebalance\n", spaces);
 		++writes;
-	} else if (qpim_ecmp_enable) {
+	} else if (pim->ecmp_enable) {
 		vty_out(vty, "%sip pim ecmp\n", spaces);
 		++writes;
 	}

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -53,8 +53,6 @@ int qpim_t_periodic =
 struct pim_assert_metric qpim_infinite_assert_metric;
 long qpim_rpf_cache_refresh_delay_msec = 50;
 int qpim_packet_process = PIM_DEFAULT_PACKET_PROCESS;
-uint8_t qpim_ecmp_enable = 0;
-uint8_t qpim_ecmp_rebalance_enable = 0;
 struct pim_instance *pimg = NULL;
 
 int32_t qpim_register_suppress_time = PIM_REGISTER_SUPPRESSION_TIME_DEFAULT;


### PR DESCRIPTION
These commands were being accepted in all vrf's and
affecting all vrf's behavior globally, since they were
global variables.

Modify the code to make these two commands work
on a per-vrf basis.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>