### PR TITLE
bgpd: Actually display labeled unicast routes received

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7979,7 +7979,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					    BGP_UPTIME_LEN, 0, NULL));
 
 			if (peer->status == Established)
-				if (peer->afc_recv[afi][pfx_rcd_safi])
+				if (peer->afc_recv[afi][safi])
 					vty_out(vty, " %12ld",
 						peer->pcount[afi]
 							    [pfx_rcd_safi]);


### PR DESCRIPTION
The labeled unicast and unicast tables have been combined
into the unicast table.  Additionally we have a restriction
where if you configure labeled unicast you cannot configure
unicast.  This created a bug with 'show bgp ipv4 labeled-unicast summ'
command where we were displaying NoNeg, because v4 has been intentionally
turned off.

Modify the code so that when we are looking up if we have negotiated
a capapbility we use the correct one, while still using the appropriate
table for prefix count.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>