### PR TITLE
pimd: Fix connected route nexthop fix from 66f5152f

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -667,7 +667,7 @@ int pim_parse_nexthop_update(int command, struct zclient *zclient,
 				 * RPF address from nexthop cache (i.e.
 				 * destination) as PIM nexthop.
 				 */
-				nexthop->type = NEXTHOP_TYPE_IPV4;
+				nexthop->type = NEXTHOP_TYPE_IPV4_IFINDEX;
 				nexthop->gate.ipv4 =
 					pnc->rpf.rpf_addr.u.prefix4;
 				break;

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -215,6 +215,8 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 				tab_size, addr_str, pim->vrf->name);
 			return num_ifindex;
 		}
+		nexthop_tab[num_ifindex].protocol_distance = distance;
+		nexthop_tab[num_ifindex].route_metric = metric;
 		switch (nexthop_type) {
 		case NEXTHOP_TYPE_IFINDEX:
 			nexthop_tab[num_ifindex].ifindex = stream_getl(s);
@@ -276,13 +278,19 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 			}
 			++num_ifindex;
 			break;
-		case NEXTHOP_TYPE_IPV6:
-		case NEXTHOP_TYPE_BLACKHOLE:
-			/* ignore */
-			continue;
+		default:
+			/* do nothing */
+			{
+				char addr_str[INET_ADDRSTRLEN];
+				pim_inet4_dump("<addr?>", addr, addr_str,
+					       sizeof(addr_str));
+				zlog_warn(
+					"%s: found non-ifindex nexthop type=%d for address %s(%s)",
+					__PRETTY_FUNCTION__, nexthop_type,
+					addr_str, pim->vrf->name);
+			}
+			break;
 		}
-		nexthop_tab[num_ifindex].protocol_distance = distance;
-		nexthop_tab[num_ifindex].route_metric = metric;
 	}
 
 	return num_ifindex;


### PR DESCRIPTION
Fix a couple of problems in my 1st fix for PIM nexthops reachable via a
connected route:

Use NEXTHOP_TYPE_IPV4_IFINDEX instead of NEXTHOP_TYPE_IPV4 since we add an
IPv4 address to an already known ifindex.

Assign nexthop_tab[num_ifindex].protocol_distance and .route_metric before
incrementing num_ifindex.

Revert the default: to individual switch case statement conversion in
zclient_read_nexthop() as requested by donaldsharp in #2347

Signed-off-by: Martin Buck <mb-tmp-tvguho.pbz@gromit.dyndns.org>