### PR TITLE
lib: fix sizeof expression (Coverity 1455482)

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -60,7 +60,7 @@ static struct list *masters;
 /* CLI start ---------------------------------------------------------------- */
 static unsigned int cpu_record_hash_key(struct cpu_thread_history *a)
 {
-	int size = sizeof(&a->func);
+	int size = sizeof(a->func);
 
 	return jhash(&a->func, size, 0);
 }


### PR DESCRIPTION
At first glance an evident correction (reviewing Coverity issues at [1])

[1] https://scan.coverity.com/projects/freerangerouting-frr