### PR TITLE
spf6d: fix use after free (Coverity 1221459)

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -349,8 +349,9 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 						ospf6_lsa_unlock(req);
 						on->last_ls_req = NULL;
 					}
-					ospf6_lsdb_remove(req,
-							  on->request_list);
+					if (req)
+						ospf6_lsdb_remove(req,
+							on->request_list);
 					ospf6_check_nbr_loading(on);
 					/* fall through */
 				}


### PR DESCRIPTION
At first glance an evident correction (reviewing Coverity issues at [1])

[1] https://scan.coverity.com/projects/freerangerouting-frr