### PR TITLE
vtysh: null dereference (Coverity 1469896)

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -548,8 +548,10 @@ static int vtysh_execute_func(const char *line, int pager)
 				line = "end";
 				vline = cmd_make_strvec(line);
 
-				if (vline == NULL && vty->is_paged) {
-					vty_close_pager(vty);
+
+				if (vline == NULL) {
+					if (vty->is_paged)
+						vty_close_pager(vty);
 					return CMD_SUCCESS;
 				}
 


### PR DESCRIPTION
I'm not sure it is the best possible correction, but unless I missed something, it should not harm  (reviewing today's Coverity error report email [1])

[1] https://scan.coverity.com/projects/freerangerouting-frr