### PR TITLE
lib: null dereference (Coverity 1469895)

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -120,9 +120,11 @@ bool vty_set_include(struct vty *vty, const char *regexp)
 	bool ret = true;
 	char errbuf[256];
 
-	if (!regexp && vty->filter) {
-		regfree(&vty->include);
-		vty->filter = false;
+	if (!regexp) {
+		if (vty->filter) {
+			regfree(&vty->include);
+			vty->filter = false;
+		}
 		return true;
 	}
 


### PR DESCRIPTION
At first glance an evident correction, but please check it with caution (reviewing today's Coverity error report email [1])

[1] https://scan.coverity.com/projects/freerangerouting-frr