### PR TITLE
*: disable all sanitizers for clippy build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,9 +3,8 @@
 AUTOMAKE_OPTIONS = subdir-objects 1.12
 include common.am
 
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/lib \
+AM_CPPFLAGS += -I$(top_srcdir) -I$(top_srcdir)/include -I$(top_srcdir)/lib \
 	      -I$(top_builddir) -I$(top_builddir)/include -I$(top_builddir)/lib
-AM_CFLAGS = $(WERROR)
 VERSION_TYPE := $(shell if echo $(VERSION) | grep -q '^[0-9\.]*$$'; then echo RELEASE ; else echo DEV ; fi)
 DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\" -DCONFDATE=$(CONFDATE) -DVERSION_TYPE_$(VERSION_TYPE)
 LIBCAP = @LIBCAP@

--- a/bgpd/Makefile.am
+++ b/bgpd/Makefile.am
@@ -61,12 +61,10 @@ BGP_VNC_RFP_HD=
 BGP_VNC_RFP_LD_FLAGS=
 endif
 
-AM_CPPFLAGS = -I.. -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_builddir)/lib \
+AM_CPPFLAGS += -I.. -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_builddir)/lib \
 	$(BGP_VNC_RFAPI_INC) $(BGP_VNC_RFP_INC)
 DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\"
 INSTALL_SDATA=@INSTALL@ -m 600
-
-AM_CFLAGS = $(WERROR)
 
 noinst_LIBRARIES = libbgp.a
 module_LTLIBRARIES =

--- a/common.am
+++ b/common.am
@@ -1,20 +1,21 @@
 #
 # Automake fragment intended to be shared by Makefile.am files in the
-# tree.
+# tree. When used, should be included at the very top of the file.
 #
+AM_CPPFLAGS = @ASAN_FLAGS@ @TSAN_FLAGS@ @MSAN_FLAGS@ @WERROR@
+AM_CFLAGS = @ASAN_FLAGS@ @TSAN_FLAGS@ @MSAN_FLAGS@ @WERROR@
 
 AM_V_CLIPPY = $(am__v_CLIPPY_$(V))
 am__v_CLIPPY_ = $(am__v_CLIPPY_$(AM_DEFAULT_VERBOSITY))
 am__v_CLIPPY_0 = @echo "  CLIPPY  " $@;
 am__v_CLIPPY_1 =
 
-CLIPPY_SUPPRESSIONS = LSAN_OPTIONS="suppressions=$(top_builddir)/tools/lsan-suppressions.txt"
 CLIPPY_DEPS = $(HOSTTOOLS)lib/clippy $(top_srcdir)/python/clidef.py
 
 SUFFIXES = _clippy.c .proto .pb-c.c .pb-c.h .pb.h
 .c_clippy.c:
 	@{ test -x $(top_builddir)/$(HOSTTOOLS)lib/clippy || $(MAKE) -C $(top_builddir)/$(HOSTTOOLS) lib/clippy; }
-	$(AM_V_CLIPPY) $(CLIPPY_SUPPRESSIONS) $(top_builddir)/$(HOSTTOOLS)lib/clippy $(top_srcdir)/python/clidef.py -o $@ $<
+	$(AM_V_CLIPPY) $(top_builddir)/$(HOSTTOOLS)lib/clippy $(top_srcdir)/python/clidef.py -o $@ $<
 
 ## automake's "ylwrap" is a great piece of GNU software... not. 
 .l.c:

--- a/configure.ac
+++ b/configure.ac
@@ -190,8 +190,8 @@ AC_ARG_ENABLE([address-sanitizer], AS_HELP_STRING([--enable-address-sanitizer], 
               [enabled AddressSanitizer support for detecting a wide variety of \
                memory allocation and deallocation errors]), \
               [AC_DEFINE(HAVE_ADDRESS_SANITIZER, 1, [enable AddressSanitizer])
-              CFLAGS="$CFLAGS -fsanitize=address"
-              CXXFLAGS="$CXXFLAGS -fsanitize=address"
+              ASAN_FLAGS="-fsanitize=address"
+              AC_SUBST([ASAN_FLAGS])
               LIBS="-ldl $LIBS"
               AC_TRY_COMPILE([],[const int i=0;],[AC_MSG_NOTICE([Address Sanitizer Enabled])],
                                                  [AC_MSG_ERROR([Address Sanitizer not available])])
@@ -201,8 +201,8 @@ dnl ThreadSanitizer support
 AC_ARG_ENABLE([thread-sanitizer], AS_HELP_STRING([--enable-thread-sanitizer], \
               [enabled ThreadSanitizer support for detecting data races]), \
               [AC_DEFINE(HAVE_THREAD_SANITIZER, 1, [enable ThreadSanitizer])
-              CFLAGS="$CFLAGS -fsanitize=thread"
-              CXXFLAGS="$CXXFLAGS -fsanitize=thread"
+              TSAN_FLAGS="-fsanitize=thread"
+              AC_SUBST([TSAN_FLAGS])
               LIBS="-ldl $LIBS"
               AC_TRY_COMPILE([],[const int i=0;],[AC_MSG_NOTICE([Thread Sanitizer Enabled])],
                                                  [AC_MSG_ERROR([Thread Sanitizer not available])])
@@ -212,8 +212,8 @@ dnl MemorySanitizer support
 AC_ARG_ENABLE([memory-sanitizer], AS_HELP_STRING([--enable-memory-sanitizer], \
               [enabled MemorySanitizer support for detecting uninitialized memory reads]), \
               [AC_DEFINE(HAVE_THREAD_SANITIZER, 1, [enable MemorySanitizer])
-              CFLAGS="$CFLAGS -fsanitize=memory -fPIE -pie"
-              CXXFLAGS="$CXXFLAGS -fsanitize=memory -fPIE -pie"
+              MSAN_FLAGS="-fsanitize=memory -fPIE -pie"
+              AC_SUBST([MSAN_FLAGS])
               LIBS="-ldl $LIBS"
               AC_TRY_COMPILE([],[const int i=0;],[AC_MSG_NOTICE([Memory Sanitizer Enabled])],
                                                  [AC_MSG_ERROR([Memory Sanitizer not available])])

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -2,7 +2,7 @@
 # libfrr
 #
 lib_LTLIBRARIES += lib/libfrr.la
-lib_libfrr_la_LDFLAGS = -version-info 0:0:0 
+lib_libfrr_la_LDFLAGS = -version-info 0:0:0
 lib_libfrr_la_LIBADD = @LIBCAP@
 
 lib_libfrr_la_SOURCES = \
@@ -235,8 +235,8 @@ lib_grammar_sandbox_SOURCES = \
 lib_grammar_sandbox_LDADD = \
 	lib/libfrr.la
 
-lib_clippy_CPPFLAGS = $(AM_CPPFLAGS) -D_GNU_SOURCE -DBUILDING_CLIPPY
-lib_clippy_CFLAGS = $(PYTHON_CFLAGS)
+lib_clippy_CPPFLAGS = $(AM_CPPFLAGS) -D_GNU_SOURCE -DBUILDING_CLIPPY -fno-sanitize=all
+lib_clippy_CFLAGS = $(PYTHON_CFLAGS) $(AM_CFLAGS) -fno-sanitize=all
 lib_clippy_LDADD = $(PYTHON_LIBS)
 lib_clippy_SOURCES = \
 	lib/clippy.c \

--- a/tools/lsan-suppressions.txt
+++ b/tools/lsan-suppressions.txt
@@ -1,6 +1,0 @@
-leak:clippy
-leak:PyObject_Malloc
-leak:PyObject_Realloc
-leak:PyList_Append
-leak:malloc
-leak:PyObject_GC_Resize

--- a/vtysh/Makefile.am
+++ b/vtysh/Makefile.am
@@ -1,5 +1,6 @@
 ## Process this file with Automake to create Makefile.in
 
+include ../common.am
 
 if ENABLE_BGP_VNC
 BGP_VNC_RFP_SRCDIR   = @top_srcdir@/@LIBRFP@
@@ -16,13 +17,11 @@ BGP_VNC_RFAPI_INCDIR =
 BGP_VNC_RFAPI_SRCDIR =
 BGP_VNC_RFAPI_SRC    =
 endif
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_builddir)/lib \
+AM_CPPFLAGS += -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_builddir)/lib \
 	$(BGP_VNC_RFAPI_INCDIR) $(BGP_VNC_RFP_INCDIR)
 DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\"
 
 LIBS = @LIBS@ @CURSES@ @LIBPAM@
-
-AM_CFLAGS = $(WERROR)
 
 bin_PROGRAMS = vtysh
 


### PR DESCRIPTION
* Move configure flag propagations out of user flags
* Use AC_SUBST to transfer flag values to Automake
* Set default AM_CFLAGS and AM_CPPFLAGS in common.am and change child
  Makefiles to modify these base variables
* Add flag override to turn off all sanitizers when building clippy
* Remove LSAN suppressions blacklist as it's no longer needed

Fixes #2258 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>