### PR TITLE
ospfd: logically dead code (Coverity 1399236)

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8176,9 +8176,6 @@ DEFUN (ospf_redistribute_instance_source,
 
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
 
-	if (!ospf)
-		return CMD_SUCCESS;
-
 	if ((source == ZEBRA_ROUTE_OSPF) && !ospf->instance) {
 		vty_out(vty,
 			"Instance redistribution in non-instanced OSPF not allowed\n");


### PR DESCRIPTION
An evident correction (FRR Coverity open issues [1])

[1] https://scan.coverity.com/projects/freerangerouting-frr