### PR TITLE
zebra: Out-of-bounds read (Coverity 1465495)

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3061,7 +3061,7 @@ void zserv_handle_commands(struct zserv *client, struct stream *msg)
 		return;
 	}
 
-	if (hdr.command > array_size(zserv_handlers)
+	if (hdr.command >= array_size(zserv_handlers)
 	    || zserv_handlers[hdr.command] == NULL)
 		zlog_info("Zebra received unknown command %d", hdr.command);
 	else


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1])

[1] https://scan.coverity.com/projects/freerangerouting-frr