### PR TITLE
tests: use BUILT_SOURCES in tests/Makefile.am for automake 1.16.1

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -102,8 +102,6 @@ lib/cli/test_commands_defun.c: ../vtysh/vtysh_cmd.c
 
 isisd/test_fuzz_isis_tlv_tests.h: $(top_srcdir)/tests/isisd/test_fuzz_isis_tlv_tests.h.gz
 	gzip -d < $(top_srcdir)/tests/isisd/test_fuzz_isis_tlv_tests.h.gz > "$@"
-isisd/isisd_test_fuzz_isis_tlv-test_fuzz_isis_tlv.$(OBJEXT): \
-	isisd/test_fuzz_isis_tlv_tests.h
 
 noinst_HEADERS = \
 	./helpers/c/prng.h \
@@ -146,6 +144,9 @@ bgpd_test_ecommunity_SOURCES = bgpd/test_ecommunity.c
 bgpd_test_mp_attr_SOURCES = bgpd/test_mp_attr.c
 bgpd_test_mpath_SOURCES = bgpd/test_mpath.c
 isisd_test_fuzz_isis_tlv_SOURCES = isisd/test_fuzz_isis_tlv.c
+nodist_isisd_test_fuzz_isis_tlv_SOURCES = isisd/test_fuzz_isis_tlv_tests.h
+BUILT_SOURCES=isisd/test_fuzz_isis_tlv_tests.h
+CLEANFILES=isisd/test_fuzz_isis_tlv_tests.h
 isisd_test_fuzz_isis_tlv_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_builddir)/tests/isisd
 isisd_test_isis_vertex_queue_SOURCES = isisd/test_isis_vertex_queue.c
 


### PR DESCRIPTION
When trying to run make check using automake 1.16.1, we get:

```
CC isisd/test_fuzz_isis_tlv-test_fuzz_isis_tlv.o
isisd/test_fuzz_isis_tlv.c:1:10: fatal error: test_fuzz_isis_tlv_tests.h: No such file or directory
^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Makefile:1096: recipe for target 'isisd/test_fuzz_isis_tlv-test_fuzz_isis_tlv.o' failed
make[1]: *** [isisd/test_fuzz_isis_tlv-test_fuzz_isis_tlv.o] Error 1
make[1]: Leaving directory '/src/frr-frr-5.0/tests'
Makefile:1220: recipe for target 'check-am' failed
make: *** [check-am] Error 2
```

From reading the automake docs, it looks like there may be a more
reliable way to express built files in the Makefile.am using BUILT_SOURCES.
Using this method, we seem to build fine now on 1.16.1 and this
has been tested on Ubuntu 18.04, CentOS 7 and Alpine edge (which uses
automake 1.16.1).

Issue: https://github.com/FRRouting/frr/issues/2403
Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>