### PR TITLE
lib: Out-of-bounds access (Coverity 1448806, 1448810)

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -584,8 +584,8 @@ int prefix_match(const struct prefix *n, const struct prefix *p)
 	}
 
 	/* Set both prefix's head pointer. */
-	np = (const uint8_t *)&n->u.prefix;
-	pp = (const uint8_t *)&p->u.prefix;
+	np = n->u.val;
+	pp = p->u.val;
 
 	offset = n->prefixlen / PNBBY;
 	shift = n->prefixlen % PNBBY;
@@ -609,8 +609,8 @@ int prefix_match_network_statement(const struct prefix *n,
 	const uint8_t *np, *pp;
 
 	/* Set both prefix's head pointer. */
-	np = (const uint8_t *)&n->u.prefix;
-	pp = (const uint8_t *)&p->u.prefix;
+	np = n->u.val;
+	pp = p->u.val;
 
 	offset = n->prefixlen / PNBBY;
 	shift = n->prefixlen % PNBBY;
@@ -742,8 +742,8 @@ int prefix_cmp(const struct prefix *p1, const struct prefix *p2)
 				return 1;
 		return 0;
 	}
-	pp1 = (const uint8_t *)&p1->u.prefix;
-	pp2 = (const uint8_t *)&p2->u.prefix;
+	pp1 = p1->u.val;
+	pp2 = p2->u.val;
 
 	if (p1->prefixlen != p2->prefixlen)
 		return 1;
@@ -774,8 +774,8 @@ int prefix_common_bits(const struct prefix *p1, const struct prefix *p2)
 	uint8_t xor ;
 
 	/* Set both prefix's head pointer. */
-	const uint8_t *pp1 = (const uint8_t *)&p1->u.prefix;
-	const uint8_t *pp2 = (const uint8_t *)&p2->u.prefix;
+	const uint8_t *pp1 = p1->u.val;
+	const uint8_t *pp2 = p2->u.val;
 
 	if (p1->family == AF_INET)
 		length = IPV4_MAX_BYTELEN;


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1])

[1] https://scan.coverity.com/projects/freerangerouting-frr