### PR TITLE
vtysh: fix config write

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2646,7 +2646,10 @@ int vtysh_write_config_integrated(void)
 		vtysh_client_config(&vtysh_client[i], line);
 
 	vtysh_config_write();
+	vty->of_saved = vty->of;
+	vty->of = fp;
 	vtysh_config_dump();
+	vty->of = vty->of_saved;
 
 	if (fchmod(fd, CONFIGFILE_MASK) != 0) {
 		printf("%% Warning: can't chmod configuration file %s: %s\n",


### PR DESCRIPTION
Changing vtysh to use vty_out() for everything broke writing to config
files.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>