### PR TITLE
debianpkg: Add additional lintian override for Ubuntu 18.04

### DIFF
--- a/debianpkg/frr.lintian-overrides
+++ b/debianpkg/frr.lintian-overrides
@@ -3,3 +3,4 @@ frr: non-dev-pkg-with-shlib-symlink usr/lib/libfrr.so.0.0.0 usr/lib/libfrr.so
 frr: non-dev-pkg-with-shlib-symlink usr/lib/libfrrfpm_pb.so.0.0.0 usr/lib/libfrrfpm_pb.so
 frr: package-name-doesnt-match-sonames libfrr0 libfrrfpm-pb0 libfrrospfapiclient0
 frr: systemd-service-file-refers-to-unusual-wantedby-target lib/systemd/system/frr.service network-online.target
+frr: shared-lib-without-dependency-information usr/lib/libfrrfpm_pb.so.0.0.0


### PR DESCRIPTION
Fixes recent new lintian warning seen on Ubuntu 18.04 builds
`W: frr: shared-lib-without-dependency-information usr/lib/libfrrfpm_pb.so.0.0.0`

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>