### PR TITLE
PBR table range configuration + misc cleanups

### DIFF
--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -33,7 +33,6 @@ Nexthop Groups
 Nexthop groups are a way to encapsulate ECMP information together.  It's a
 listing of ECMP nexthops used to forward packets for when a pbr-map is matched.
 
-.. index:: nexthop-group
 .. clicmd:: nexthop-group NAME
 
    Create a nexthop-group with an associated NAME.  This will put you into a
@@ -46,24 +45,38 @@ listing of ECMP nexthops used to forward packets for when a pbr-map is matched.
    are used to are allowed here.  The syntax was intentionally kept the same as
    creating nexthops as you would for static routes.
 
+.. clicmd:: [no] pbr table range (10000-4294966272) (10000-4294966272)
+
+   Set or unset the range used to assign numeric table ID's to new
+   nexthop-group tables. Existing tables will not be modified to fit in this
+   range, so it is recommended to configure this before adding nexthop groups.
+
+   .. seealso:: :ref:`pbr-details`
+
+Showing Nexthop Group Information
+---------------------------------
+
+.. clicmd:: show pbr nexthop-groups [NAME]
+
+   Display information on a PBR nexthop-group. If ``NAME`` is omitted, all
+   nexthop groups are shown.
+
 .. _pbr-maps:
 
 PBR Maps
 ========
 
-PBR maps are a way to group policies that we would like to apply
-to individual interfaces.  These policies when applied are matched
-against incoming packets.  If matched the nexthop-group or nexthop
-is used to forward the packets to the end destination
+PBR maps are a way to group policies that we would like to apply to individual
+interfaces. These policies when applied are matched against incoming packets.
+If matched the nexthop-group or nexthop is used to forward the packets to the
+end destination.
 
-.. index:: pbr-map
 .. clicmd:: pbr-map NAME seq (1-700)
 
    Create a pbr-map with NAME and sequence number specified.  This command puts
    you into a new submode for pbr-map specification.  To exit this mode type
    exit or end as per normal conventions for leaving a sub-mode.
 
-.. index:: match
 .. clicmd:: match src-ip PREFIX
 
    When a incoming packet matches the source prefix specified, take the packet

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -20,6 +20,8 @@
 #ifndef _PBR_H
 #define _PBR_H
 
+#define PBR_STR "Policy Based Routing\n"
+
 /*
  * A PBR filter
  *

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -20,6 +20,10 @@
 #ifndef _PBR_H
 #define _PBR_H
 
+#include <zebra.h>
+#include "stream.h"
+#include "prefix.h"
+
 #define PBR_STR "Policy Based Routing\n"
 
 /*

--- a/pbrd/pbr_nht.h
+++ b/pbrd/pbr_nht.h
@@ -56,9 +56,13 @@ extern void pbr_nht_write_table_range(struct vty *vty);
 extern void pbr_nht_set_tableid_range(uint32_t low, uint32_t high);
 
 /*
- * Get the next tableid to use for installation
+ * Get the next tableid to use for installation.
+ *
+ * peek
+ *    If set to true, retrieves the next ID without marking it used. The next
+ *    call will return the same ID.
  */
-extern uint32_t pbr_nht_get_next_tableid(void);
+extern uint32_t pbr_nht_get_next_tableid(bool peek);
 /*
  * Get the next rule number to use for installation
  */

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -26,7 +26,6 @@
 #include "nexthop.h"
 #include "nexthop_group.h"
 #include "log.h"
-#include "json.h"
 #include "debug.h"
 
 #include "pbrd/pbr_nht.h"
@@ -382,10 +381,9 @@ DEFPY (pbr_policy,
 
 DEFPY (show_pbr,
 	show_pbr_cmd,
-	"show pbr [json$json]",
+	"show pbr",
 	SHOW_STR
-	"Policy Based Routing\n"
-	JSON_STR)
+	"Policy Based Routing\n")
 {
 	pbr_nht_write_table_range(vty);
 	pbr_nht_write_rule_range(vty);
@@ -395,13 +393,12 @@ DEFPY (show_pbr,
 
 DEFPY (show_pbr_map,
 	show_pbr_map_cmd,
-	"show pbr map [NAME$name] [detail$detail] [json$json]",
+	"show pbr map [NAME$name] [detail$detail]",
 	SHOW_STR
 	"Policy Based Routing\n"
 	"PBR Map\n"
 	"PBR Map Name\n"
-	"Detailed information\n"
-	JSON_STR)
+	"Detailed information\n")
 {
 	struct pbr_map_sequence *pbrms;
 	struct pbr_map *pbrm;
@@ -477,12 +474,11 @@ DEFPY(show_pbr_nexthop_group,
 
 DEFPY (show_pbr_interface,
 	show_pbr_interface_cmd,
-	"show pbr interface [NAME$name] [json$json]",
+	"show pbr interface [NAME$name]",
 	SHOW_STR
 	"Policy Based Routing\n"
 	"PBR Interface\n"
-	"PBR Interface Name\n"
-	JSON_STR)
+	"PBR Interface Name\n")
 {
 	struct interface *ifp;
 	struct vrf *vrf;

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -97,12 +97,13 @@ DEFPY(pbr_set_table_range,
 {
 	/* upper bound is 2^32 - 2^10 */
 	int ret = CMD_WARNING;
+	const int minrange = 1000;
 
 	/* validate given bounds */
 	if (lb > ub)
 		vty_out(vty, "%% Lower bound must be less than upper bound\n");
-	else if (ub - lb < 10)
-		vty_out(vty, "%% Range breadth must be at least 10\n");
+	else if (ub - lb < minrange)
+		vty_out(vty, "%% Range breadth must be at least %d\n", minrange);
 	else {
 		ret = CMD_SUCCESS;
 		pbr_nht_set_tableid_range((uint32_t) lb, (uint32_t) ub);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -85,6 +85,33 @@ DEFUN_NOSH(no_pbr_map, no_pbr_map_cmd, "no pbr-map WORD [seq (1-700)]",
 	return CMD_SUCCESS;
 }
 
+DEFPY(pbr_set_table_range,
+      pbr_set_table_range_cmd,
+      "[no] pbr table range (10000-4294966272)$lb (10000-4294966272)$ub",
+      NO_STR
+      PBR_STR
+      "Set table ID range\n"
+      "Set table ID range\n"
+      "Lower bound for table ID range\n"
+      "Upper bound for table ID range\n")
+{
+	/* upper bound is 2^32 - 2^10 */
+	int ret = CMD_WARNING;
+
+	/* validate given bounds */
+	if (lb > ub)
+		vty_out(vty, "%% Lower bound must be less than upper bound\n");
+	else if (ub - lb < 10)
+		vty_out(vty, "%% Range breadth must be at least 10\n");
+	else {
+		ret = CMD_SUCCESS;
+		pbr_nht_set_tableid_range((uint32_t) lb, (uint32_t) ub);
+	}
+
+	return ret;
+}
+
+
 DEFPY(pbr_map_match_src, pbr_map_match_src_cmd,
 	"[no] match src-ip <A.B.C.D/M|X:X::X:X/M>$prefix",
 	NO_STR
@@ -489,7 +516,6 @@ DEFPY (show_pbr_interface,
 }
 
 /* PBR debugging CLI ------------------------------------------------------- */
-/* clang-format off */
 
 static struct cmd_node debug_node = {DEBUG_NODE, "", 1};
 
@@ -536,7 +562,6 @@ DEFUN_NOSH(show_debugging_pbr,
 	return CMD_SUCCESS;
 }
 
-/* clang-format on */
 /* ------------------------------------------------------------------------- */
 
 
@@ -634,6 +659,7 @@ void pbr_vty_init(void)
 
 	install_element(CONFIG_NODE, &pbr_map_cmd);
 	install_element(CONFIG_NODE, &no_pbr_map_cmd);
+	install_element(CONFIG_NODE, &pbr_set_table_range_cmd);
 	install_element(INTERFACE_NODE, &pbr_policy_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_src_cmd);
 	install_element(PBRMAP_NODE, &pbr_map_match_dst_cmd);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -27,6 +27,7 @@
 #include "nexthop_group.h"
 #include "log.h"
 #include "debug.h"
+#include "pbr.h"
 
 #include "pbrd/pbr_nht.h"
 #include "pbrd/pbr_map.h"

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -383,7 +383,7 @@ DEFPY (show_pbr,
 	show_pbr_cmd,
 	"show pbr",
 	SHOW_STR
-	"Policy Based Routing\n")
+	PBR_STR)
 {
 	pbr_nht_write_table_range(vty);
 	pbr_nht_write_rule_range(vty);
@@ -395,7 +395,7 @@ DEFPY (show_pbr_map,
 	show_pbr_map_cmd,
 	"show pbr map [NAME$name] [detail$detail]",
 	SHOW_STR
-	"Policy Based Routing\n"
+	PBR_STR
 	"PBR Map\n"
 	"PBR Map Name\n"
 	"Detailed information\n")
@@ -463,7 +463,7 @@ DEFPY(show_pbr_nexthop_group,
       show_pbr_nexthop_group_cmd,
       "show pbr nexthop-groups [WORD$word]",
       SHOW_STR
-      "Policy Based Routing\n"
+      PBR_STR
       "Nexthop Groups\n"
       "Optional Name of the nexthop group\n")
 {
@@ -476,7 +476,7 @@ DEFPY (show_pbr_interface,
 	show_pbr_interface_cmd,
 	"show pbr interface [NAME$name]",
 	SHOW_STR
-	"Policy Based Routing\n"
+	PBR_STR
 	"PBR Interface\n"
 	"PBR Interface Name\n")
 {
@@ -520,7 +520,7 @@ DEFPY(debug_pbr,
       "[no] debug pbr [{map$map|zebra$zebra|nht$nht|events$events}]",
       NO_STR
       DEBUG_STR
-      "Policy Based Routing\n"
+      PBR_STR
       "Policy maps\n"
       "PBRD <-> Zebra communications\n"
       "Nexthop tracking\n"
@@ -549,7 +549,7 @@ DEFUN_NOSH(show_debugging_pbr,
 	   "show debugging [pbr]",
 	   SHOW_STR
 	   DEBUG_STR
-	   "Policy Based Routing\n")
+	   PBR_STR)
 {
 	vty_out(vty, "PBR debugging status:\n");
 

--- a/pbrd/pbr_vty.h
+++ b/pbrd/pbr_vty.h
@@ -20,5 +20,7 @@
 #ifndef __PBR_VTY_H__
 #define __PBR_VTY_H__
 
+#define PBR_STR "Policy based routing\n"
+
 extern void pbr_vty_init(void);
 #endif

--- a/pbrd/pbr_vty.h
+++ b/pbrd/pbr_vty.h
@@ -20,7 +20,7 @@
 #ifndef __PBR_VTY_H__
 #define __PBR_VTY_H__
 
-#define PBR_STR "Policy based routing\n"
+#define PBR_STR "Policy Based Routing\n"
 
 extern void pbr_vty_init(void);
 #endif

--- a/pbrd/pbr_vty.h
+++ b/pbrd/pbr_vty.h
@@ -20,7 +20,5 @@
 #ifndef __PBR_VTY_H__
 #define __PBR_VTY_H__
 
-#define PBR_STR "Policy Based Routing\n"
-
 extern void pbr_vty_init(void);
 #endif


### PR DESCRIPTION
Adds the ability to configure the numeric used when automatically assigning table ID's to nexthop group tables, updates the docs to cover this new command (and a couple others) and removes the json options from a couple commands since these aren't implemented yet.