### PR TITLE
bgpd: null check (Coverity 1399270)

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -102,6 +102,7 @@ struct community_list_handler *bgp_clist;
 unsigned int multipath_num = MULTIPATH_NUM;
 
 static void bgp_if_finish(struct bgp *bgp);
+static void peer_drop_dynamic_neighbor(struct peer *peer);
 
 extern struct zclient *zclient;
 
@@ -3718,10 +3719,10 @@ struct peer *peer_lookup_dynamic_neighbor(struct bgp *bgp, union sockunion *su)
 	return peer;
 }
 
-void peer_drop_dynamic_neighbor(struct peer *peer)
+static void peer_drop_dynamic_neighbor(struct peer *peer)
 {
 	int dncount = -1;
-	if (peer->group && peer->group->bgp) {
+	if (peer->group->bgp) {
 		dncount = peer->group->bgp->dynamic_neighbors_count;
 		if (dncount)
 			peer->group->bgp->dynamic_neighbors_count = --dncount;
@@ -3730,7 +3731,6 @@ void peer_drop_dynamic_neighbor(struct peer *peer)
 		zlog_debug("%s dropped from group %s, count %d", peer->host,
 			   peer->group->name, dncount);
 }
-
 
 /* If peer is configured at least one address family return 1. */
 int peer_active(struct peer *peer)

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1462,7 +1462,6 @@ extern struct peer_group *peer_group_lookup_dynamic_neighbor(struct bgp *,
 							     struct prefix **);
 extern struct peer *peer_lookup_dynamic_neighbor(struct bgp *,
 						 union sockunion *);
-extern void peer_drop_dynamic_neighbor(struct peer *);
 
 /*
  * Peers are incredibly easy to memory leak


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1])

[1] https://scan.coverity.com/projects/freerangerouting-frr