### PR TITLE
bgpd: Fix possible use while uninited

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -603,9 +603,9 @@ static void show_vni_routes_hash(struct hash_backet *backet, void *arg)
 static void show_l3vni_entry(struct vty *vty, struct bgp *bgp,
 			     json_object *json)
 {
-	json_object *json_vni;
-	json_object *json_import_rtl;
-	json_object *json_export_rtl;
+	json_object *json_vni = NULL;
+	json_object *json_import_rtl = NULL;
+	json_object *json_export_rtl = NULL;
 	char buf1[10];
 	char buf2[INET6_ADDRSTRLEN];
 	char rt_buf[25];


### PR DESCRIPTION
Certain compilers are saying that it is possible
to use some json variables before they are initialized,
which could result in using weird data.  Fix to make
compiler happy even if this is never possible.

Fixes: #2423
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>