### PR TITLE
ospfd: buffer termination (Coverity 23089)

### DIFF
--- a/ospfd/ospf_vty.h
+++ b/ospfd/ospf_vty.h
@@ -53,6 +53,5 @@ extern void ospf_vty_init(void);
 extern void ospf_vty_show_init(void);
 extern void ospf_vty_clear_init(void);
 extern int str2area_id(const char *, struct in_addr *, int *);
-extern void area_id2str(char *, int, struct in_addr *, int);
 
 #endif /* _QUAGGA_OSPF_VTY_H */


### PR DESCRIPTION
Details:
- INET_ADDRSTRLEN is 16, for xxx.xxx.xxx\0, so 15 is now passed
 to the strncpy call instead of 16, ensuring ASCII-z output

Also, area_id2str() made static, as it is only used in ospfd/ospf_vty.c (applying criteria seen in PR 2424)

Signed-off-by: F. Aragon <paco@voltanet.io>