### PR TITLE
ospfd: dereference check (Clang scan-build)

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2582,7 +2582,8 @@ struct ospf_lsa *ospf_lsa_install(struct ospf *ospf, struct ospf_interface *oi,
 		lsdb = ospf->lsdb;
 		break;
 	default:
-		lsdb = lsa->area->lsdb;
+		if (lsa->area)
+			lsdb = lsa->area->lsdb;
 		break;
 	}
 


### PR DESCRIPTION
At first glance, an evident correction (Clang scan-build open issues [1])

http://www.pinkbelly.org/frr/