### PR TITLE
ospfd: null check (Coverity 1457300)

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9779,7 +9779,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 			}
 
 			/* bfd  print. */
-			if (params->bfd_info)
+			if (params && params->bfd_info)
 				ospf_bfd_write_config(vty, params);
 
 			/* MTU ignore print. */


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr