### PR TITLE
bgpd: Fix bgpd crash in evpn vni route-map apply

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1173,6 +1173,7 @@ static int bgp_input_modifier(struct peer *peer, struct prefix *p,
 
 	/* Route map apply. */
 	if (rmap) {
+		memset(&info, 0, sizeof(struct bgp_info));
 		/* Duplicate current value to new strucutre for modification. */
 		info.peer = peer;
 		info.attr = attr;
@@ -1225,6 +1226,7 @@ static int bgp_output_modifier(struct peer *peer, struct prefix *p,
 	if (rmap == NULL)
 		return RMAP_DENY;
 
+	memset(&info, 0, sizeof(struct bgp_info));
 	/* Route map apply. */
 	/* Duplicate current value to new strucutre for modification. */
 	info.peer = peer;
@@ -1682,6 +1684,7 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_info *ri,
 		struct bgp_info_extra dummy_info_extra;
 		struct attr dummy_attr;
 
+		memset(&info, 0, sizeof(struct bgp_info));
 		info.peer = peer;
 		info.attr = attr;
 
@@ -4363,6 +4366,8 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 	/* Apply route-map. */
 	if (bgp_static->rmap.name) {
 		struct attr attr_tmp = attr;
+
+		memset(&info, 0, sizeof(struct bgp_info));
 		info.peer = bgp->peer_self;
 		info.attr = &attr_tmp;
 
@@ -6082,6 +6087,7 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 
 		/* Apply route-map. */
 		if (red->rmap.name) {
+			memset(&info, 0, sizeof(struct bgp_info));
 			info.peer = bgp->peer_self;
 			info.attr = &attr_new;
 

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -676,6 +676,9 @@ static route_map_result_t route_match_vni(void *rule, struct prefix *prefix,
 		vni = *((vni_t *)rule);
 		bgp_info = (struct bgp_info *)object;
 
+		if (bgp_info->extra == NULL)
+			return RMAP_NOMATCH;
+
 		if (vni == label2vni(&bgp_info->extra->label[0]))
 			return RMAP_MATCH;
 	}


### PR DESCRIPTION
When evpn configured wiht route-map with vni which is not configured.
Upon receiving evpn routes (i.e Type-2, Type-3), route-map match 
will be triggered. Since there is no l2vni exists in db, some of the
member fields in bgp_info (i.e. dummy_info_extra) are passed uninitialized 
to evpn filter match cb. This results in inaccessible memory results in crash.

Fix is to memset the bgp_info prior to passing to evpn route apply filter cb.
In evpn vni filter cb, ensure to have NULL check for member filed of the bgp_info.

memset bgp_info at few places where it is passed to route_match.


Configure route-map with not configured l2vni.
Simulate to learn l2vpn type-2, 3 route.
Restart frr.service with below config
address-family l2vpn evpn
  neighbor fear route-map EVPN_VNI out

route-map EVPN_VNI deny 10
 match evpn vni 140010

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>