### PR TITLE
Lib delayed read

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -405,6 +405,13 @@ These options apply to all |PACKAGE_NAME| daemons.
 
    Print program version.
 
+.. option:: --log <stdout|syslog|file:/path/to/log/file>
+
+   When initializing the daemon, setup the log to go to either stdout,
+   syslog or to a file.  These values will be displayed as part of
+   a show run.  Additionally they can be overridden at runtime if
+   desired via the normal log commands.
+
 .. _loadable-module-support:
 
 Loadable Module Support

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -412,6 +412,11 @@ These options apply to all |PACKAGE_NAME| daemons.
    a show run.  Additionally they can be overridden at runtime if
    desired via the normal log commands.
 
+.. option:: --log-level <emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>
+
+   When initializing the daemon, allow the specification of a default
+   log level at startup from one of the specified levels.
+
 .. _loadable-module-support:
 
 Loadable Module Support

--- a/lib/command.c
+++ b/lib/command.c
@@ -2429,7 +2429,8 @@ static int set_log_file(struct vty *vty, const char *fname, int loglevel)
 		XFREE(MTYPE_TMP, p);
 
 	if (!ret) {
-		vty_out(vty, "can't open logfile %s\n", fname);
+		if (vty)
+			vty_out(vty, "can't open logfile %s\n", fname);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
@@ -2443,6 +2444,26 @@ static int set_log_file(struct vty *vty, const char *fname, int loglevel)
 		zlog_set_level(ZLOG_DEST_SYSLOG, ZLOG_DISABLED);
 #endif
 	return CMD_SUCCESS;
+}
+
+void command_setup_early_logging(const char *option)
+{
+	char *token;
+
+	if (strcmp(option, "stdout") == 0) {
+		zlog_set_level(ZLOG_DEST_STDOUT, zlog_default->default_lvl);
+		return;
+	}
+
+	if (strcmp(option, "syslog") == 0) {
+		zlog_set_level(ZLOG_DEST_SYSLOG, zlog_default->default_lvl);
+		return;
+	}
+
+	token = strstr(option, ":");
+	token++;
+
+	set_log_file(NULL, token, zlog_default->default_lvl);
 }
 
 DEFUN (config_log_file,

--- a/lib/command.c
+++ b/lib/command.c
@@ -2446,21 +2446,31 @@ static int set_log_file(struct vty *vty, const char *fname, int loglevel)
 	return CMD_SUCCESS;
 }
 
-void command_setup_early_logging(const char *option)
+void command_setup_early_logging(const char *dest, const char *level)
 {
 	char *token;
 
-	if (strcmp(option, "stdout") == 0) {
+	if (level) {
+		int nlevel = level_match(level);
+
+		if (nlevel != ZLOG_DISABLED)
+			zlog_default->default_lvl = nlevel;
+	}
+
+	if (!dest)
+		return;
+
+	if (strcmp(dest, "stdout") == 0) {
 		zlog_set_level(ZLOG_DEST_STDOUT, zlog_default->default_lvl);
 		return;
 	}
 
-	if (strcmp(option, "syslog") == 0) {
+	if (strcmp(dest, "syslog") == 0) {
 		zlog_set_level(ZLOG_DEST_SYSLOG, zlog_default->default_lvl);
 		return;
 	}
 
-	token = strstr(option, ":");
+	token = strstr(dest, ":");
 	token++;
 
 	set_log_file(NULL, token, zlog_default->default_lvl);

--- a/lib/command.h
+++ b/lib/command.h
@@ -479,5 +479,5 @@ extern void
 cmd_variable_handler_register(const struct cmd_variable_handler *cvh);
 extern char *cmd_variable_comp2str(vector comps, unsigned short cols);
 
-extern void command_setup_early_logging(const char *option);
+extern void command_setup_early_logging(const char *dest, const char *level);
 #endif /* _ZEBRA_COMMAND_H */

--- a/lib/command.h
+++ b/lib/command.h
@@ -479,4 +479,5 @@ extern void
 cmd_variable_handler_register(const struct cmd_variable_handler *cvh);
 extern char *cmd_variable_comp2str(vector comps, unsigned short cols);
 
+extern void command_setup_early_logging(const char *option);
 #endif /* _ZEBRA_COMMAND_H */

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -725,7 +725,12 @@ void frr_config_fork(void)
 {
 	hook_call(frr_late_init, master);
 
-	vty_read_config(di->config_file, config_default);
+	if (!vty_read_config(di->config_file, config_default) &&
+	    di->backup_config_file) {
+		zlog_info("Attempting to read backup config file: %s specified",
+			  di->backup_config_file);
+		vty_read_config(di->backup_config_file, config_default);
+	}
 
 	/* Don't start execution if we are in dry-run mode */
 	if (di->dryrun)

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -78,7 +78,8 @@ static void opt_extend(const struct optspec *os)
 
 #define OPTION_VTYSOCK   1000
 #define OPTION_MODULEDIR 1002
-#define OPTION_LOG 1003
+#define OPTION_LOG       1003
+#define OPTION_LOGLEVEL  1004
 
 static const struct option lo_always[] = {
 	{"help", no_argument, NULL, 'h'},
@@ -88,6 +89,7 @@ static const struct option lo_always[] = {
 	{"vty_socket", required_argument, NULL, OPTION_VTYSOCK},
 	{"moduledir", required_argument, NULL, OPTION_MODULEDIR},
 	{"log", required_argument, NULL, OPTION_LOG},
+	{"log-level", required_argument, NULL, OPTION_LOGLEVEL},
 	{NULL}};
 static const struct optspec os_always = {
 	"hvdM:",
@@ -97,7 +99,8 @@ static const struct optspec os_always = {
 	"  -M, --module       Load specified module\n"
 	"      --vty_socket   Override vty socket path\n"
 	"      --moduledir    Override modules directory\n"
-	"      --log          Set Logging to stdout, syslog, or file:<name>\n",
+	"      --log          Set Logging to stdout, syslog, or file:<name>\n"
+	"      --log-level    Set Logging Level to use, debug, info, warn, etc\n",
 	lo_always};
 
 
@@ -450,6 +453,9 @@ static int frr_opt(int opt)
 	case OPTION_LOG:
 		di->early_logging = optarg;
 		break;
+	case OPTION_LOGLEVEL:
+		di->early_loglevel = optarg;
+		break;
 	default:
 		return 1;
 	}
@@ -550,8 +556,7 @@ struct thread_master *frr_init(void)
 	openzlog(di->progname, di->logname, di->instance,
 		 LOG_CONS | LOG_NDELAY | LOG_PID, LOG_DAEMON);
 
-	if (di->early_logging)
-		command_setup_early_logging(di->early_logging);
+	command_setup_early_logging(di->early_logging, di->early_loglevel);
 
 	if (!frr_zclient_addr(&zclient_addr, &zclient_addr_len,
 			      frr_zclientpath)) {

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -78,6 +78,7 @@ static void opt_extend(const struct optspec *os)
 
 #define OPTION_VTYSOCK   1000
 #define OPTION_MODULEDIR 1002
+#define OPTION_LOG 1003
 
 static const struct option lo_always[] = {
 	{"help", no_argument, NULL, 'h'},
@@ -86,6 +87,7 @@ static const struct option lo_always[] = {
 	{"module", no_argument, NULL, 'M'},
 	{"vty_socket", required_argument, NULL, OPTION_VTYSOCK},
 	{"moduledir", required_argument, NULL, OPTION_MODULEDIR},
+	{"log", required_argument, NULL, OPTION_LOG},
 	{NULL}};
 static const struct optspec os_always = {
 	"hvdM:",
@@ -94,7 +96,8 @@ static const struct optspec os_always = {
 	"  -d, --daemon       Runs in daemon mode\n"
 	"  -M, --module       Load specified module\n"
 	"      --vty_socket   Override vty socket path\n"
-	"      --moduledir    Override modules directory\n",
+	"      --moduledir    Override modules directory\n"
+	"      --log          Set Logging to stdout, syslog, or file:<name>\n",
 	lo_always};
 
 
@@ -444,6 +447,9 @@ static int frr_opt(int opt)
 			return 1;
 		di->privs->group = optarg;
 		break;
+	case OPTION_LOG:
+		di->early_logging = optarg;
+		break;
 	default:
 		return 1;
 	}
@@ -543,6 +549,9 @@ struct thread_master *frr_init(void)
 
 	openzlog(di->progname, di->logname, di->instance,
 		 LOG_CONS | LOG_NDELAY | LOG_PID, LOG_DAEMON);
+
+	if (di->early_logging)
+		command_setup_early_logging(di->early_logging);
 #if defined(HAVE_CUMULUS)
 	zlog_set_level(ZLOG_DEST_SYSLOG, zlog_default->default_lvl);
 #endif

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -552,9 +552,6 @@ struct thread_master *frr_init(void)
 
 	if (di->early_logging)
 		command_setup_early_logging(di->early_logging);
-#if defined(HAVE_CUMULUS)
-	zlog_set_level(ZLOG_DEST_SYSLOG, zlog_default->default_lvl);
-#endif
 
 	if (!frr_zclient_addr(&zclient_addr, &zclient_addr_len,
 			      frr_zclientpath)) {

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -51,6 +51,7 @@ struct frr_daemon_info {
 	bool daemon_mode;
 	bool terminal;
 	const char *config_file;
+	const char *backup_config_file;
 	const char *pid_file;
 	const char *vty_path;
 	const char *module_path;

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -59,6 +59,7 @@ struct frr_daemon_info {
 	const char *module_path;
 	const char *pathspace;
 	const char *early_logging;
+	const char *early_loglevel;
 
 	const char *proghelp;
 	void (*printhelp)(FILE *target);

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -50,6 +50,8 @@ struct frr_daemon_info {
 	bool dryrun;
 	bool daemon_mode;
 	bool terminal;
+
+	struct thread *read_in;
 	const char *config_file;
 	const char *backup_config_file;
 	const char *pid_file;

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -58,6 +58,7 @@ struct frr_daemon_info {
 	const char *vty_path;
 	const char *module_path;
 	const char *pathspace;
+	const char *early_logging;
 
 	const char *proghelp;
 	void (*printhelp)(FILE *target);

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2462,12 +2462,13 @@ static FILE *vty_use_backup_config(const char *fullpath)
 }
 
 /* Read up configuration file from file_name. */
-void vty_read_config(const char *config_file, char *config_default_dir)
+bool vty_read_config(const char *config_file, char *config_default_dir)
 {
 	char cwd[MAXPATHLEN];
 	FILE *confp = NULL;
 	const char *fullpath;
 	char *tmp = NULL;
+	bool read_success = false;
 
 	/* If -f flag specified. */
 	if (config_file != NULL) {
@@ -2525,8 +2526,10 @@ void vty_read_config(const char *config_file, char *config_default_dir)
 
 		if (strstr(config_default_dir, "vtysh") == NULL) {
 			ret = stat(integrate_default, &conf_stat);
-			if (ret >= 0)
+			if (ret >= 0) {
+				read_success = true;
 				goto tmp_free_and_out;
+			}
 		}
 #endif /* VTYSH */
 		confp = fopen(config_default_dir, "r");
@@ -2550,6 +2553,7 @@ void vty_read_config(const char *config_file, char *config_default_dir)
 	}
 
 	vty_read_file(confp);
+	read_success = true;
 
 	fclose(confp);
 
@@ -2558,6 +2562,8 @@ void vty_read_config(const char *config_file, char *config_default_dir)
 tmp_free_and_out:
 	if (tmp)
 		XFREE(MTYPE_TMP, tmp);
+
+	return read_success;
 }
 
 /* Small utility function which output log to the VTY. */

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -242,7 +242,7 @@ extern void vty_frame(struct vty *, const char *, ...) PRINTF_ATTRIBUTE(2, 3);
 extern void vty_endframe(struct vty *, const char *);
 bool vty_set_include(struct vty *vty, const char *regexp);
 
-extern void vty_read_config(const char *, char *);
+extern bool vty_read_config(const char *, char *);
 extern void vty_time_print(struct vty *, int);
 extern void vty_serv_sock(const char *, unsigned short, const char *);
 extern void vty_close(struct vty *);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2415,10 +2415,11 @@ DEFUNSH(VTYSH_ALL, vtysh_log_syslog, vtysh_log_syslog_cmd,
 }
 
 DEFUNSH(VTYSH_ALL, no_vtysh_log_syslog, no_vtysh_log_syslog_cmd,
-	"no log syslog [LEVEL]", NO_STR
+	"no log syslog [<emergencies|alerts|critical|errors|warnings|notifications|informational|debugging>]",
+	NO_STR
 	"Logging control\n"
 	"Cancel logging to syslog\n"
-	"Logging level\n")
+	LOG_LEVEL_DESC)
 {
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
Add a few new features:

a) Allow the vty read in of the config file, have the ability to pass up whether or not it was able to read in the specified config file.  And if it was unable allow end daemons to specify a backup file for trying to read in( this will be used by staticd )

b) Modify the read in of config until after the event handling has already started.  This makes the config read in the same between integrated and non-integrated configs.

(b) above fixes some topotest errors that I am seeing:
```2018-06-14 14:39:52,526 ERROR: assert failed at "test_all_protocol_startup/test_error_messages_daemons": Daemons report errors to StdErr
assert 'r1 BGPd StdE...() failed\r\n' == ''
  - r1 BGPd StdErr Output:
  - 2018/06/14 14:39:47 warnings: BGP: sendmsg_nexthop: zclient_send_message() failed\r
  - 2018/06/14 14:39:47 warnings: BGP: sendmsg_nexthop: zclient_send_message() failed\r
FAILED                                                 [ 20%]
test_all_protocol_startup.py::test_converge_protocols ```

What is happening is that bgp is attempting to register the nexthops for specified peers and since we do not ahve a zclient connection they are lost.