### PR TITLE
bgpd: Fix crash when showing filtered routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1185,12 +1185,8 @@ static int bgp_input_modifier(struct peer *peer, struct prefix *p,
 
 		peer->rmap_type = 0;
 
-		if (ret == RMAP_DENYMATCH) {
-			/* Free newly generated AS path and community by
-			 * route-map. */
-			bgp_attr_flush(attr);
+		if (ret == RMAP_DENYMATCH)
 			return RMAP_DENY;
-		}
 	}
 	return RMAP_PERMIT;
 }


### PR DESCRIPTION
This commit fixes the issue mentioned in #2419, which is caused by a
double-free. The problem of the current implementation is that
*bgp_input_modifier* already frees the passed attributes under specific
circumstances, which can then lead to a double-free as *bgp_attr_undup*
does not check if the attributes are set to NULL.

As it is not transparent to the function caller if the attributes get
freed or not and the similar function *bgp_output_modifier* also does
not flush the passed attributes, the line has been removed altogether.

All callers of *bgp_input_modifier* already deal by themself with
freeing/flushing/unduping BGP attributes, so it is safe to remove.

Fixes #2419.