### PR TITLE
pimd: Untrusted val as argument (Coverity 1465491)

### DIFF
--- a/pimd/mtracebis.c
+++ b/pimd/mtracebis.c
@@ -296,6 +296,10 @@ static int recv_response(int fd, int *hops, struct igmp_mtrace *mtracer)
 
 	mtrace_len = ntohs(ip->ip_len) - ip->ip_hl * 4;
 
+	if ((char *)mtrace + mtrace_len
+	    > (char *)mtrace_buf + IP_AND_MTRACE_BUF_LEN)
+		return -1;
+
 	if (mtrace_len < (int)MTRACE_HDR_SIZE)
 		return -1;
 


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr