### PR TITLE
lib: uninitialized variable (Coverity 1469898)

### DIFF
--- a/lib/frrstr.c
+++ b/lib/frrstr.c
@@ -78,6 +78,9 @@ char *frrstr_join(const char **parts, int argc, const char *join)
 	size_t len = 0;
 	size_t joinlen = join ? strlen(join) : 0;
 
+	if (!argc)
+		return NULL;
+
 	for (i = 0; i < argc; i++)
 		len += strlen(parts[i]);
 	len += argc * joinlen + 1;


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr