### PR TITLE
zebra: string null termination (Coverity 1465494)

### DIFF
--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -212,6 +212,11 @@ static int zebra_ns_notify_read(struct thread *t)
 			continue;
 		if (event->mask & IN_DELETE)
 			return zebra_ns_delete(event->name);
+		if (&event->name[event->len] >= &buf[sizeof(buf)]) {
+			zlog_err("NS notify read: buffer underflow");
+			break;
+		}
+		event->name[event->len] = 0;
 		netnspath = ns_netns_pathname(NULL, event->name);
 		if (!netnspath)
 			continue;


### PR DESCRIPTION
Simple correction, but please review it carefully -I've checked inotify(7) man page- (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr