### PR TITLE
isisd: out-of-bounds access (Coverity 1399309)

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -357,14 +357,14 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 			for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_link, node,
 						  ip6)) {
 				prefix2str((struct prefix *)ip6, (char *)buf,
-					   BUFSIZ);
+					   sizeof(buf));
 				zlog_warn("  %s", buf);
 			}
 			zlog_warn(" -----");
 			for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_non_link, node,
 						  ip6)) {
 				prefix2str((struct prefix *)ip6, (char *)buf,
-					   BUFSIZ);
+					   sizeof(buf));
 				zlog_warn("  %s", buf);
 			}
 			zlog_warn("End of addresses");


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr