### PR TITLE
tests: fixup minor autotools nit

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -236,7 +236,7 @@ lib_grammar_sandbox_LDADD = \
 	lib/libfrr.la
 
 lib_clippy_CPPFLAGS = $(AM_CPPFLAGS) -D_GNU_SOURCE -DBUILDING_CLIPPY @SAN_CLIPPY_FLAGS@
-lib_clippy_CFLAGS = $(PYTHON_CFLAGS) $(AM_CFLAGS) @SAN_CLIPPY_FLAGS@
+lib_clippy_CFLAGS = $(PYTHON_CFLAGS) @SAN_CLIPPY_FLAGS@
 lib_clippy_LDADD = $(PYTHON_LIBS)
 lib_clippy_SOURCES = \
 	lib/clippy.c \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@ include ../common.am
 PYTHON ?= python
 
 AUTOMAKE_OPTIONS = subdir-objects
-AM_CPPFLAGS = \
+AM_CPPFLAGS += \
 	-I.. \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/lib \


### PR DESCRIPTION
Makes super strict builds fail due to a warning.

Fixes #2451 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>