### PR TITLE
zebra: Hide default vrf instance of l3vni cmd

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1829,6 +1829,7 @@ static void evpn_unconfigure_vrf_rd(struct bgp *bgp_vrf)
 
 	/* fall back to default RD */
 	bgp_evpn_derive_auto_rd_for_vrf(bgp_vrf);
+	UNSET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_RD_CFGD);
 
 	/* We have a new RD for VRF.
 	 * Advertise all type-5 routes again with the new RD

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2898,7 +2898,7 @@ DEFUN (show_vrf,
 	return CMD_SUCCESS;
 }
 
-DEFUN (default_vrf_vni_mapping,
+DEFUN_HIDDEN (default_vrf_vni_mapping,
        default_vrf_vni_mapping_cmd,
        "vni " CMD_VNI_RANGE "[prefix-routes-only]",
        "VNI corresponding to the DEFAULT VRF\n"
@@ -2928,7 +2928,7 @@ DEFUN (default_vrf_vni_mapping,
 	return CMD_SUCCESS;
 }
 
-DEFUN (no_default_vrf_vni_mapping,
+DEFUN_HIDDEN (no_default_vrf_vni_mapping,
        no_default_vrf_vni_mapping_cmd,
        "no vni " CMD_VNI_RANGE,
        NO_STR


### PR DESCRIPTION
1) Hide following l3vni config from DEFAULT_VRF instance until it is fully supported.

     S1(config)# vni 2222456 prefix-routes-only

2)  bgpd: fix default RD value in running-configuration 

    When bgp vrf is configured with non-default  RD value, config flag is set.
    Upon removing non-default RD value the flag was not reset,
    thus displayed default RD value in running-config.

    router bgp 5550 vrf vrf1
     rd 45.0.2.2:5 

    Unset the RD configuration flag under bgp_vrf instance.