### PR TITLE
Add 'show thread poll'

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -241,15 +241,21 @@ void hash_iterate(struct hash *hash, void (*func)(struct hash_backet *, void *),
 	unsigned int i;
 	struct hash_backet *hb;
 	struct hash_backet *hbnext;
+	uint32_t count = 0;
 
-	for (i = 0; i < hash->size; i++)
+	for (i = 0; i < hash->size; i++) {
 		for (hb = hash->index[i]; hb; hb = hbnext) {
 			/* get pointer to next hash backet here, in case (*func)
 			 * decides to delete hb by calling hash_release
 			 */
 			hbnext = hb->next;
 			(*func)(hb, arg);
+			count++;
+
 		}
+		if (count == hash->count)
+			return;
+	}
 }
 
 void hash_walk(struct hash *hash, int (*func)(struct hash_backet *, void *),
@@ -259,6 +265,7 @@ void hash_walk(struct hash *hash, int (*func)(struct hash_backet *, void *),
 	struct hash_backet *hb;
 	struct hash_backet *hbnext;
 	int ret = HASHWALK_CONTINUE;
+	uint32_t count = 0;
 
 	for (i = 0; i < hash->size; i++) {
 		for (hb = hash->index[i]; hb; hb = hbnext) {
@@ -269,7 +276,10 @@ void hash_walk(struct hash *hash, int (*func)(struct hash_backet *, void *),
 			ret = (*func)(hb, arg);
 			if (ret == HASHWALK_ABORT)
 				return;
+			count++;
 		}
+		if (count == hash->count)
+			return;
 	}
 }
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2136,6 +2136,29 @@ DEFUNSH(VTYSH_INTERFACE, vtysh_quit_interface, vtysh_quit_interface_cmd, "quit",
 	return vtysh_exit_interface(self, vty, argc, argv);
 }
 
+DEFUN (vtysh_show_poll,
+       vtysh_show_poll_cmd,
+       "show thread poll",
+       SHOW_STR
+       "Thread information\n"
+       "Thread Poll Information\n")
+{
+	unsigned int i;
+	int idx = 0;
+	int ret = CMD_SUCCESS;
+	char line[100];
+
+	snprintf(line, sizeof(line), "do show thread poll\n");
+	for (i = 0; i < array_size(vtysh_client); i++)
+		if (vtysh_client[i].fd >= 0) {
+			vty_out(vty, "Thread statistics for %s:\n",
+				vtysh_client[i].name);
+			ret = vtysh_client_execute(&vtysh_client[i], line);
+			vty_out(vty, "\n");
+		}
+	return ret;
+}
+
 DEFUN (vtysh_show_thread,
        vtysh_show_thread_cmd,
        "show thread cpu [FILTER]",
@@ -3720,6 +3743,7 @@ void vtysh_init_vty(void)
 	install_element(VIEW_NODE, &vtysh_show_work_queues_cmd);
 	install_element(VIEW_NODE, &vtysh_show_work_queues_daemon_cmd);
 	install_element(VIEW_NODE, &vtysh_show_thread_cmd);
+	install_element(VIEW_NODE, &vtysh_show_poll_cmd);
 
 	/* Logging */
 	install_element(VIEW_NODE, &vtysh_show_logging_cmd);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2144,7 +2144,6 @@ DEFUN (vtysh_show_poll,
        "Thread Poll Information\n")
 {
 	unsigned int i;
-	int idx = 0;
 	int ret = CMD_SUCCESS;
 	char line[100];
 


### PR DESCRIPTION
Add a new cli 'show thread poll', we are seeing some strange behavior with bgpd under heavy load, see #2472 add a bit of code to allow us to see poll information we are sending into the kernel.

Add a small optimization to hash walking to allow the iterators to cut out early if they detect that they are done.

I am certain I am going to have more followup commits to add some more debugging cli for threads but I wanted to get this one in there early, to let us see what is going on for people using this at scale, which might give us a clue of what is going on.