### PR TITLE
bgpd: null check (Coverity 1433544, 1433543, 1433542)

### DIFF
--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -471,7 +471,7 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_info *new_best,
 		zlog_debug(
 			"%s: starting mpath update, newbest %s num candidates %d old-mpath-count %d",
 			pfx_buf, new_best ? new_best->peer->host : "NONE",
-			listcount(mp_list), old_mpath_count);
+			mp_list ? listcount(mp_list) : 0, old_mpath_count);
 
 	/*
 	 * We perform an ordered walk through both lists in parallel.

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1733,7 +1733,8 @@ void rfapiPrintMatchingDescriptors(struct vty *vty, struct prefix *vn_prefix,
 int rfapiCliGetPrefixAddr(struct vty *vty, const char *str, struct prefix *p)
 {
 	if (!str2prefix(str, p)) {
-		vty_out(vty, "Malformed address \"%s\"%s", str, HVTYNL);
+		vty_out(vty, "Malformed address \"%s\"%s", str ? str : "null",
+			HVTYNL);
 		return CMD_WARNING;
 	}
 	switch (p->family) {

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1197,6 +1197,9 @@ int str2prefix(const char *str, struct prefix *p)
 {
 	int ret;
 
+	if (!str || !p)
+		return 0;
+
 	/* First we try to convert string to struct prefix_ipv4. */
 	ret = str2prefix_ipv4(str, (struct prefix_ipv4 *)p);
 	if (ret)


### PR DESCRIPTION
At first glance, an evident correction, but please check if the vty log is convenient or if it is required to be changed (FRR Coverity open issues [1]).

The fix on bgpd/bgp_mpath.c is because a Clang warning appeared after the CI (strange, probably because an Clang version upgrade (?))

[1] https://scan.coverity.com/projects/freerangerouting-frr