### PR TITLE
zebra: re-install static routes needed vrf when the vrf intf comes up

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -934,6 +934,12 @@ void if_up(struct interface *ifp)
 	/* Install connected routes to the kernel. */
 	if_install_connected(ifp);
 
+	/* Install any static routes using this vrf interface */
+	if (IS_ZEBRA_IF_VRF(ifp)) {
+		static_fixup_vrf_ids(zvrf);
+		static_config_install_delayed_routes(zvrf);
+	}
+
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 		zlog_debug("%u: IF %s up, scheduling RIB processing",
 			   ifp->vrf_id, ifp->name);


### PR DESCRIPTION
Problem reported that if the vrf device is taken down and then brought
back up, any static route referencing that vrf device was not
re-installed.  This fix runs back thru the static routes that
reference the vrf device coming up and re-install them.

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>