### PR TITLE
bgpd: vpn null check

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1335,6 +1335,9 @@ void vpn_leak_to_vrf_update_all(struct bgp *bgp_vrf, /* to */
 	struct bgp_node *prn;
 	safi_t safi = SAFI_MPLS_VPN;
 
+	if (!bgp_vpn)
+		return;
+
 	/*
 	 * Walk vpn table
 	 */


### PR DESCRIPTION
Can be reproduced with following vtysh sequence (an intentionaly wrong
sequence):

['configure terminal\n router bgp 255 vrf l3vrf-6\n',
 'configure terminal\n router bgp 255 vrf l3vrf-6\nbgp router-id 10.255.255.1\n',
 'configure terminal\n router bgp 255 vrf l3vrf-6\n address-family ipv4\nlabel vpn export 45000\n',
 'configure terminal\n router bgp 255 vrf l3vrf-6\n address-family ipv4\nrd vpn export 255:5\n',
 'configure terminal\n router bgp 255 vrf l3vrf-6\n address-family ipv4\nredistribute isis\n', 'configure terminal\n router bgp 255 vrf l3vrf-6\n address-family ipv4\nredistribute ospf\n', 'configure terminal\n router bgp 255 vrf l3vrf-6\n address-family ipv4\nredistribute connected\n', 'configure terminal\n router bgp 255 vrf l3vrf-6\n address-family ipv4\nimport vpn\n', 'configure terminal\n router bgp 255 vrf l3vrf-6\n address-family ipv4\nexport vpn\n', 'configure terminal\n router bgp 255 vrf l3vrf-6\n address-family ipv4\nrt vpn import 255:1\n', 'configure terminal\n router bgp 255 vrf l3vrf-6\n address-family ipv4\nrt vpn export 255:1\n'
]

Signed-off-by: F. Aragon <paco@voltanet.io>