### PR TITLE
ospfd, pimd: redundant memset (cppcheck)

### DIFF
--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -146,8 +146,6 @@ void ospf_nbr_state_message(struct ospf_neighbor *nbr, char *buf, size_t size)
 	else
 		state = ISM_DROther;
 
-	memset(buf, 0, size);
-
 	snprintf(buf, size, "%s/%s",
 		 lookup_msg(ospf_nsm_state_msg, nbr->state, NULL),
 		 lookup_msg(ospf_ism_state_msg, state, NULL));
@@ -254,8 +252,6 @@ static void ospf_packet_hello_dump(struct stream *s, uint16_t length)
 
 static char *ospf_dd_flags_dump(uint8_t flags, char *buf, size_t size)
 {
-	memset(buf, 0, size);
-
 	snprintf(buf, size, "%s|%s|%s", (flags & OSPF_DD_FLAG_I) ? "I" : "-",
 		 (flags & OSPF_DD_FLAG_M) ? "M" : "-",
 		 (flags & OSPF_DD_FLAG_MS) ? "MS" : "-");
@@ -265,8 +261,6 @@ static char *ospf_dd_flags_dump(uint8_t flags, char *buf, size_t size)
 
 static char *ospf_router_lsa_flags_dump(uint8_t flags, char *buf, size_t size)
 {
-	memset(buf, 0, size);
-
 	snprintf(buf, size, "%s|%s|%s",
 		 (flags & ROUTER_LSA_VIRTUAL) ? "V" : "-",
 		 (flags & ROUTER_LSA_EXTERNAL) ? "E" : "-",

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -40,7 +40,6 @@ char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size)
 	struct prefix_sg sg;
 	int i;
 
-	memset(buf, 0, size);
 	sg.src = c_oil->oil.mfcc_origin;
 	sg.grp = c_oil->oil.mfcc_mcastgrp;
 	sprintf(buf, "%s IIF: %d, OIFS: ", pim_str_sg_dump(&sg),


### PR DESCRIPTION
At first glance, an evident correction (Cppcheck 1.72)