### PR TITLE
babeld, eigrpd, ospfd: unsigned negative check (cppcheck, grouped)

### DIFF
--- a/babeld/message.c
+++ b/babeld/message.c
@@ -662,7 +662,7 @@ static int
 check_bucket(struct interface *ifp)
 {
     babel_interface_nfo *babel_ifp = babel_get_if_nfo(ifp);
-    if(babel_ifp->bucket <= 0) {
+    if(babel_ifp->bucket == 0) {
         int seconds = babel_now.tv_sec - babel_ifp->bucket_time;
         if(seconds > 0) {
             babel_ifp->bucket = MIN(BUCKET_TOKENS_MAX,

--- a/babeld/neighbour.c
+++ b/babeld/neighbour.c
@@ -120,7 +120,7 @@ update_neighbour(struct neighbour *neigh, int hello, int hello_interval)
     int rc = 0;
 
     if(hello < 0) {
-        if(neigh->hello_interval <= 0)
+        if(neigh->hello_interval == 0)
             return rc;
         missed_hellos =
             ((int)timeval_minus_msec(&babel_now, &neigh->hello_time) -

--- a/eigrpd/eigrp_snmp.c
+++ b/eigrpd/eigrp_snmp.c
@@ -573,7 +573,7 @@ static struct eigrp_neighbor *eigrpNbrLookup(struct variable *v, oid *name,
 		first = 0;
 		len = *length - v->namelen;
 
-		if (len <= 0)
+		if (len == 0)
 			first = 1;
 
 		if (len > IN_ADDR_SIZE)

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -1626,7 +1626,7 @@ static struct ospf_interface *ospfIfLookup(struct variable *v, oid *name,
 		len = *length - v->namelen;
 		if (len >= IN_ADDR_SIZE)
 			len = IN_ADDR_SIZE;
-		if (len <= 0)
+		if (len == 0)
 			ifaddr_next = 1;
 
 		oid2in_addr(name + v->namelen, len, ifaddr);
@@ -1990,7 +1990,7 @@ ospfVirtIfLookup(struct variable *v, oid *name, size_t *length,
 		first = 0;
 
 		len = *length - v->namelen;
-		if (len <= 0)
+		if (len == 0)
 			first = 1;
 		if (len > IN_ADDR_SIZE)
 			len = IN_ADDR_SIZE;
@@ -2176,7 +2176,7 @@ static struct ospf_neighbor *ospfNbrLookup(struct variable *v, oid *name,
 		first = 0;
 		len = *length - v->namelen;
 
-		if (len <= 0)
+		if (len == 0)
 			first = 1;
 
 		if (len > IN_ADDR_SIZE)


### PR DESCRIPTION
At first glance, an evident correction (Cppcheck 1.72)

I've grouped all errors of the same type.
