### PR TITLE
eigrpd, isisd, lib, ospfd: no effect (cppcheck)

### DIFF
--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -944,8 +944,6 @@ void eigrp_packet_free(struct eigrp_packet *ep)
 	THREAD_OFF(ep->t_retrans_timer);
 
 	XFREE(MTYPE_EIGRP_PACKET, ep);
-
-	ep = NULL;
 }
 
 /* EIGRP Header verification. */

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -288,7 +288,6 @@ void isis_adj_state_change(struct isis_adjacency *adj,
 		if (del)
 			isis_delete_adj(adj);
 
-		adj = NULL;
 	} else if (circuit->circ_type == CIRCUIT_T_P2P) {
 		del = false;
 		for (level = IS_LEVEL_1; level <= IS_LEVEL_2; level++) {
@@ -326,8 +325,6 @@ void isis_adj_state_change(struct isis_adjacency *adj,
 
 		if (del)
 			isis_delete_adj(adj);
-
-		adj = NULL;
 	}
 
 	return;

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -269,7 +269,6 @@ static int fpt_halt(struct frr_pthread *fpt, void **res)
 {
 	thread_add_event(fpt->master, &fpt_finish, fpt, 0, NULL);
 	pthread_join(fpt->thread, res);
-	fpt = NULL;
 
 	return 0;
 }

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -144,8 +144,6 @@ void ospf_packet_free(struct ospf_packet *op)
 		stream_free(op->s);
 
 	XFREE(MTYPE_OSPF_PACKET, op);
-
-	op = NULL;
 }
 
 struct ospf_fifo *ospf_fifo_new()


### PR DESCRIPTION
At first glance, an evident correction (Cppcheck 1.72)

Assignment of function parameter has no effect outside the function.
