### PR TITLE
bgpd isisd ldpd lib ospfd pimd: redundancy (infer, grouped)

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -174,7 +174,6 @@ static int bgp_process_reads(struct thread *thread)
 	bool more = true;		// whether we got more data
 	bool fatal = false;		// whether fatal error occurred
 	bool added_pkt = false;		// whether we pushed onto ->ibuf
-	bool header_valid = true;	// whether header is valid
 	/* clang-format on */
 
 	peer = THREAD_ARG(thread);
@@ -214,10 +213,8 @@ static int bgp_process_reads(struct thread *thread)
 		if (ringbuf_remain(ibw) < BGP_HEADER_SIZE)
 			break;
 
-		/* validate header */
-		header_valid = validate_header(peer);
-
-		if (!header_valid) {
+		/* check that header is valid */
+		if (!validate_header(peer)) {
 			fatal = true;
 			break;
 		}

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -438,7 +438,7 @@ int bgp_subgrp_multiaccess_check_v4(struct in_addr nexthop,
 	struct bgp_node *rn1, *rn2;
 	struct peer_af *paf;
 	struct prefix p, np;
-	struct bgp *bgp = NULL;
+	struct bgp *bgp;
 
 	np.family = AF_INET;
 	np.prefixlen = IPV4_MAX_BITLEN;
@@ -447,7 +447,7 @@ int bgp_subgrp_multiaccess_check_v4(struct in_addr nexthop,
 	p.family = AF_INET;
 	p.prefixlen = IPV4_MAX_BITLEN;
 
-	rn1 = rn2 = NULL;
+	rn2 = NULL;
 
 	bgp = SUBGRP_INST(subgrp);
 	rn1 = bgp_node_match(bgp->connected_table[AFI_IP], &np);

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -397,7 +397,7 @@ struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,
 	vec = &pkt->arr.entries[BGP_ATTR_VEC_NH];
 	if (CHECK_FLAG(vec->flags, BPKT_ATTRVEC_FLAGS_UPDATED)) {
 		uint8_t nhlen;
-		afi_t nhafi = AFI_MAX; /* NH AFI is based on nhlen! */
+		afi_t nhafi;
 		int route_map_sets_nh;
 		nhlen = stream_getc_from(s, vec->offset);
 		if (peer_cap_enhe(peer, paf->afi, paf->safi))

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -125,7 +125,7 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 
 					if (rd_header) {
 						uint16_t type;
-						struct rd_as rd_as;
+						struct rd_as rd_as = {0};
 						struct rd_ip rd_ip = {0};
 #if ENABLE_BGP_VNC
 						struct rd_vnc_eth rd_vnc_eth = {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11408,7 +11408,6 @@ DEFUN (show_ip_bgp_peer_groups,
        "Peer group name\n")
 {
 	char *vrf, *pg;
-	vrf = pg = NULL;
 	int idx = 0;
 
 	vrf = argv_find(argv, argc, "VIEWVRFNAME", &idx) ? argv[idx]->arg

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -884,7 +884,7 @@ static uint8_t print_subtlv_use_bw(struct sbuf *buf, int indent,
 static uint8_t print_unknown_tlv(struct sbuf *buf, int indent,
 				 struct subtlv_header *tlvh)
 {
-	int i, rtn = 1;
+	int i, rtn;
 	uint8_t *v = (uint8_t *)tlvh;
 
 	if (tlvh->length != 0) {

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -1373,7 +1373,7 @@ static int show_isis_database(struct vty *vty, const char *argv, int ui_level)
 	struct isis_area *area;
 	struct isis_lsp *lsp;
 	struct isis_dynhn *dynhn;
-	const char *pos = argv;
+	const char *pos;
 	uint8_t lspid[ISIS_SYS_ID_LEN + 2];
 	char sysid[255];
 	uint8_t number[3];

--- a/lib/imsg.c
+++ b/lib/imsg.c
@@ -77,7 +77,7 @@ ssize_t imsg_read(struct imsgbuf *ibuf)
 		char buf[CMSG_SPACE(sizeof(int) * 1)];
 	} cmsgbuf;
 	struct iovec iov;
-	ssize_t n = -1;
+	ssize_t n;
 	int fd;
 	struct imsg_fd *ifd;
 
@@ -110,7 +110,8 @@ again:
 		return (-1);
 	}
 
-	if ((n = recvmsg(ibuf->fd, &msg, 0)) == -1) {
+	n = recvmsg(ibuf->fd, &msg, 0);
+	if (n == -1) {
 		if (errno == EINTR)
 			goto again;
 		goto fail;

--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -457,8 +457,7 @@ int setsockopt_ifindex(int af, int sock, ifindex_t val)
  */
 static ifindex_t getsockopt_ipv4_ifindex(struct msghdr *msgh)
 {
-	/* XXX: initialize to zero?  (Always overwritten, so just cosmetic.) */
-	ifindex_t ifindex = -1;
+	ifindex_t ifindex;
 
 #if defined(IP_PKTINFO)
 	/* Linux pktinfo based ifindex retrieval */
@@ -466,7 +465,11 @@ static ifindex_t getsockopt_ipv4_ifindex(struct msghdr *msgh)
 
 	pktinfo = (struct in_pktinfo *)getsockopt_cmsg_data(msgh, IPPROTO_IP,
 							    IP_PKTINFO);
-	/* XXX Can pktinfo be NULL?  Clean up post 0.98. */
+
+	/* getsockopt_ifindex() will forward this, being 0 "not found" */
+	if (pktinfo == NULL)
+		return 0;
+
 	ifindex = pktinfo->ipi_ifindex;
 
 #elif defined(IP_RECVIF)

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -2412,8 +2412,8 @@ DEFUN (ospf_neighbor_poll_interval,
 	int idx_poll = 3;
 	int idx_pri = 5;
 	struct in_addr nbr_addr;
-	unsigned int priority = OSPF_NEIGHBOR_PRIORITY_DEFAULT;
-	unsigned int interval = OSPF_POLL_INTERVAL_DEFAULT;
+	unsigned int priority;
+	unsigned int interval;
 
 	if (!inet_aton(argv[idx_ipv4]->arg, &nbr_addr)) {
 		vty_out(vty, "Please specify Neighbor ID by A.B.C.D\n");
@@ -2422,8 +2422,8 @@ DEFUN (ospf_neighbor_poll_interval,
 
 	interval = strtoul(argv[idx_poll]->arg, NULL, 10);
 
-	if (argc > 4)
-		priority = strtoul(argv[idx_pri]->arg, NULL, 10);
+	priority = argc > 4 ? strtoul(argv[idx_pri]->arg, NULL, 10)
+			    : OSPF_NEIGHBOR_PRIORITY_DEFAULT;
 
 	ospf_nbr_nbma_set(ospf, nbr_addr);
 	ospf_nbr_nbma_poll_interval_set(ospf, nbr_addr, interval);

--- a/pimd/mtracebis.c
+++ b/pimd/mtracebis.c
@@ -336,7 +336,7 @@ static int wait_for_response(int fd, int *hops, struct igmp_mtrace *mtrace,
 {
 	fd_set readfds;
 	struct timeval timeout;
-	int ret = -1;
+	int ret;
 	long msec, rmsec, tmsec;
 
 	FD_ZERO(&readfds);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4504,8 +4504,8 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty, bool fill,
 	json_object *json_source = NULL;
 	json_object *json_oil = NULL;
 	json_object *json_ifp_out = NULL;
-	int found_oif = 0;
-	int first = 1;
+	int found_oif;
+	int first;
 	char grp_str[INET_ADDRSTRLEN];
 	char src_str[INET_ADDRSTRLEN];
 	char in_ifname[INTERFACE_NAMSIZ + 1];

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -521,7 +521,7 @@ int pim_msg_send(int fd, struct in_addr src, struct in_addr dst,
 	socklen_t tolen;
 	unsigned char buffer[10000];
 	unsigned char *msg_start;
-	uint8_t ttl = MAXTTL;
+	uint8_t ttl;
 	struct pim_msg_header *header;
 	struct ip *ip;
 


### PR DESCRIPTION
At first glance, evident corrections, using Infer v0.15.0 static code analyzer [1]. Corrections are related to redundant initializations, missing initializations, and a null check.

[1] https://github.com/facebook/infer
