### PR TITLE
ospf6d: fix use after free (2) (Coverity 1221459)

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -347,6 +347,7 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 							"Received is newer, remove requesting");
 					if (req == on->last_ls_req) {
 						ospf6_lsa_unlock(req);
+						req = NULL;
 						on->last_ls_req = NULL;
 					}
 					if (req)


### PR DESCRIPTION
Previous fix was incomplete (PR #2390), as calling ospf6_lsa_unlock() frees 'req' but
it does not put it to zero, so it was called ospf6_lsdb_remove() afterwards
even being 'req' already freed.

Please excuse the inconvenience.