### PR TITLE
lib: uninitialized variable (2) (Coverity 1469898)

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -261,8 +261,11 @@ void print_version(const char *progname)
 
 char *argv_concat(struct cmd_token **argv, int argc, int shift)
 {
-	int cnt = argc - shift;
-	const char *argstr[cnt];
+	int cnt = MAX(argc - shift, 0);
+	const char *argstr[cnt + 1];
+
+	if (!cnt)
+		return NULL;
 
 	for (int i = 0; i < cnt; i++)
 		argstr[i] = argv[i + shift]->arg;


### PR DESCRIPTION
Previous correction (2c2d5cb397c140c05ad81e8c79273bd3af13b595), PR #2459, was not enough,
so now it is ensured that the argument shift is not negative nor zero. Also, in addition to that, in order to avoid a Clang-6 warning, it is ensured non-zero allocation size for argstr[] ("const char *argstr[cnt + 1];")

Please excuse the inconvenience.