### PR TITLE
bgpd ospf6d: null check (Coverity 1221453 1461297)

### DIFF
--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -1426,7 +1426,8 @@ DEFUN (vnc_export_nvegroup,
 	if (rfg_new == NULL) {
 		rfg_new = bgp_rfapi_cfg_match_byname(bgp, argv[5]->arg,
 						     RFAPI_GROUP_CFG_VRF);
-		vnc_add_vrf_opener(bgp, rfg_new);
+		if (rfg_new)
+			vnc_add_vrf_opener(bgp, rfg_new);
 	}
 
 	if (rfg_new == NULL) {

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -677,6 +677,10 @@ void ospf6_spf_schedule(struct ospf6 *ospf6, unsigned int reason)
 {
 	unsigned long delay, elapsed, ht;
 
+	/* OSPF instance does not exist. */
+	if (ospf6 == NULL)
+		return;
+
 	ospf6_set_spf_reason(ospf6, reason);
 
 	if (IS_OSPF6_DEBUG_SPF(PROCESS) || IS_OSPF6_DEBUG_SPF(TIME)) {
@@ -685,10 +689,6 @@ void ospf6_spf_schedule(struct ospf6 *ospf6, unsigned int reason)
 		zlog_debug("SPF: calculation timer scheduled (reason %s)",
 			   rbuf);
 	}
-
-	/* OSPF instance does not exist. */
-	if (ospf6 == NULL)
-		return;
 
 	/* SPF calculation timer is already scheduled. */
 	if (ospf6->t_spf_calc) {


### PR DESCRIPTION
At first glance, evident corrections (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr