### PR TITLE
bgpd, lib: null check (Coverity 1436344, 1451361)

### DIFF
--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -1054,6 +1054,9 @@ int extcommunity_list_set(struct community_list_handler *ch, const char *name,
 	struct ecommunity *ecom = NULL;
 	regex_t *regex = NULL;
 
+	if (str == NULL)
+		return COMMUNITY_LIST_ERR_MALFORMED_VAL;
+
 	entry = NULL;
 
 	/* Get community list. */
@@ -1089,7 +1092,7 @@ int extcommunity_list_set(struct community_list_handler *ch, const char *name,
 	entry = community_entry_new();
 	entry->direct = direct;
 	entry->style = style;
-	entry->any = (str ? 0 : 1);
+	entry->any = 0;
 	if (ecom)
 		entry->config = ecommunity_ecom2str(
 			ecom, ECOMMUNITY_FORMAT_COMMUNITY_LIST, 0);

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -609,6 +609,7 @@ static struct list *disambiguate(struct list *first, struct list *second,
 				 vector vline, unsigned int n)
 {
 	// doesn't make sense for these to be inequal length
+	assert(first && second);
 	assert(first->count == second->count);
 	assert(first->count == vector_active(vline) - n + 1);
 


### PR DESCRIPTION
At first glance, evident corrections (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr