### PR TITLE
zebra: untrusted array index (Coverity 1470113)

### DIFF
--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -216,7 +216,6 @@ static int zebra_ns_notify_read(struct thread *t)
 			zlog_err("NS notify read: buffer underflow");
 			break;
 		}
-		event->name[event->len] = 0;
 		netnspath = ns_netns_pathname(NULL, event->name);
 		if (!netnspath)
 			continue;


### PR DESCRIPTION
This is a correction over 32ac96b2ba9693696d2f1156af1b80985d4e55bb (PR #2462), so
removing the forced string null termination doesn't involve a worse situation
than before (the underflow check should protect for the case of receiving
an incomplete buffer, which would be the cause of non-zero terminated string)
