### PR TITLE
Redhat fpm 3.0

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -302,6 +302,9 @@ rm -rf %{buildroot}/usr/share/info/dir
 # Remove debian init script if it was installed
 rm -f %{buildroot}%{_sbindir}/frr
 
+# kill bogus libtool files for modules
+rm -f %{buildroot}%{_libdir}/frr/modules/*.la
+
 # install /etc sources
 %if "%{initsystem}" == "systemd"
 mkdir -p %{buildroot}%{_unitdir}

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -532,6 +532,9 @@ rm -rf %{buildroot}
 %{_libdir}/lib*.so.0
 %attr(755,root,root) %{_libdir}/lib*.so.0.*
 %endif
+%if %{with_fpm}
+%attr(755,root,root) %{_libdir}/frr/modules/zebra_fpm.so
+%endif
 %{_bindir}/*
 %config(noreplace) /etc/frr/[!v]*.conf*
 %config(noreplace) %attr(750,%frr_user,%frr_user) /etc/frr/daemons


### PR DESCRIPTION
Fixed FPM build on CI uncovered an error for the RPM package with unpacked files.
This PR fixes 3.0 branch, so it passes the CI build again