### PR TITLE
ldpd, lib: null check (Coverity 1452287 and 20 alike)

### DIFF
--- a/ldpd/ldp_debug.c
+++ b/ldpd/ldp_debug.c
@@ -41,6 +41,9 @@ int
 ldp_vty_debug(struct vty *vty, const char *negate, const char *type_str,
     const char *dir_str, const char *all)
 {
+	if (type_str == NULL)
+		return (CMD_WARNING_CONFIG_FAILED);
+
 	if (strcmp(type_str, "discovery") == 0) {
 		if (dir_str == NULL)
 			return (CMD_WARNING_CONFIG_FAILED);

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -850,6 +850,11 @@ static int vty_prefix_list_install(struct vty *vty, afi_t afi, const char *name,
 	int lenum = 0;
 	int genum = 0;
 
+	if (name == NULL || prefix == NULL || typestr == NULL) {
+		vty_out(vty, "%% Missing prefix or type\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
 	/* Sequential number. */
 	if (seq)
 		seqnum = (int64_t)atol(seq);


### PR DESCRIPTION
At first glance, evident corrections, but please check vty messages -I put them with good intention, but maybe with not enough global knowledge- (FRR Coverity open issues [1]).

Coverity issues fixed with this commit:

1452287 1452291 1452307 1452310 1452317 1452321 1452327 1452330 1452331 1452336
1452337 1452340 1452352 1452354 1452358
(originated at ldpd/ldpd_vty_cmds_clippy.c)

1448388 1448390 1448392 1448397 1448404 1448408
(originated at lib/plist_clippy.c)

[1] https://scan.coverity.com/projects/freerangerouting-frr