### PR TITLE
eigrpd: null check (Coverity 1455334 and 4 alike)

### DIFF
--- a/eigrpd/eigrp_fsm.c
+++ b/eigrpd/eigrp_fsm.c
@@ -486,6 +486,7 @@ int eigrp_fsm_event_q_fcn(struct eigrp_fsm_action_message *msg)
 
 int eigrp_fsm_event_keep_state(struct eigrp_fsm_action_message *msg)
 {
+	struct eigrp *eigrp;
 	struct eigrp_prefix_entry *prefix = msg->prefix;
 	struct eigrp_nexthop_entry *ne = listnode_head(prefix->entries);
 
@@ -498,9 +499,10 @@ int eigrp_fsm_event_keep_state(struct eigrp_fsm_action_message *msg)
 			if (msg->packet_type == EIGRP_OPC_QUERY)
 				eigrp_send_reply(msg->adv_router, prefix);
 			prefix->req_action |= EIGRP_FSM_NEED_UPDATE;
-			listnode_add(
-				(eigrp_lookup())->topology_changes_internalIPV4,
-				prefix);
+			eigrp = eigrp_lookup();
+			assert(eigrp);
+			listnode_add(eigrp->topology_changes_internalIPV4,
+				     prefix);
 		}
 		eigrp_topology_update_node_flags(prefix);
 		eigrp_update_routing_table(prefix);

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -336,6 +336,9 @@ void eigrp_if_free(struct eigrp_interface *ei, int source)
 	struct eigrp_prefix_entry *pe;
 	struct eigrp *eigrp = eigrp_lookup();
 
+	if (!eigrp)
+		return;
+
 	if (source == INTERFACE_DOWN_BY_VTY) {
 		THREAD_OFF(ei->t_hello);
 		eigrp_hello_send(ei, EIGRP_HELLO_GRACEFUL_SHUTDOWN, NULL);

--- a/eigrpd/eigrp_topology.c
+++ b/eigrpd/eigrp_topology.c
@@ -182,6 +182,9 @@ void eigrp_prefix_entry_delete(struct route_table *table,
 	struct eigrp *eigrp = eigrp_lookup();
 	struct route_node *rn;
 
+	if (!eigrp)
+		return;
+
 	rn = route_node_lookup(table, pe->destination);
 	if (!rn)
 		return;
@@ -426,6 +429,9 @@ void eigrp_topology_update_all_node_flags(struct eigrp *eigrp)
 	struct eigrp_prefix_entry *pe;
 	struct route_node *rn;
 
+	if (!eigrp)
+		return;
+
 	for (rn = route_top(eigrp->topology_table); rn; rn = route_next(rn)) {
 		pe = rn->info;
 
@@ -471,10 +477,14 @@ void eigrp_topology_update_node_flags(struct eigrp_prefix_entry *dest)
 void eigrp_update_routing_table(struct eigrp_prefix_entry *prefix)
 {
 	struct eigrp *eigrp = eigrp_lookup();
-	struct list *successors =
-		eigrp_topology_get_successor_max(prefix, eigrp->max_paths);
+	struct list *successors;
 	struct listnode *node;
 	struct eigrp_nexthop_entry *entry;
+
+	if (!eigrp)
+		return;
+
+	successors = eigrp_topology_get_successor_max(prefix, eigrp->max_paths);
 
 	if (successors) {
 		eigrp_zebra_route_add(prefix->destination, successors);


### PR DESCRIPTION
At first glance, evident corrections, but please check if it could be more convenient to use an assert() instead of plain return (FRR Coverity open issues [1]).

Coverity issues fixed with this commit:

1455334 1455335 1455336 1455337
(returning after checking the null pointer)

1455339
(using an assert())

[1] https://scan.coverity.com/projects/freerangerouting-frr