### PR TITLE
Flowspec support other options

### DIFF
--- a/bgpd/bgp_flowspec.c
+++ b/bgpd/bgp_flowspec.c
@@ -59,7 +59,8 @@ static int bgp_fs_nlri_validate(uint8_t *nlri_content, uint32_t len)
 						   len - offset, NULL, &error);
 			break;
 		case FLOWSPEC_TCP_FLAGS:
-			ret = bgp_flowspec_tcpflags_decode(
+		case FLOWSPEC_FRAGMENT:
+			ret = bgp_flowspec_bitmask_decode(
 						   BGP_FLOWSPEC_VALIDATE_ONLY,
 						   nlri_content + offset,
 						   len - offset, NULL, &error);
@@ -67,12 +68,6 @@ static int bgp_fs_nlri_validate(uint8_t *nlri_content, uint32_t len)
 		case FLOWSPEC_PKT_LEN:
 		case FLOWSPEC_DSCP:
 			ret = bgp_flowspec_op_decode(
-						BGP_FLOWSPEC_VALIDATE_ONLY,
-						nlri_content + offset,
-						len - offset, NULL, &error);
-			break;
-		case FLOWSPEC_FRAGMENT:
-			ret = bgp_flowspec_fragment_type_decode(
 						BGP_FLOWSPEC_VALIDATE_ONLY,
 						nlri_content + offset,
 						len - offset, NULL, &error);

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -124,8 +124,9 @@ static bool bgp_flowspec_contains_prefix(struct prefix *pfs,
 						     len - offset,
 						     NULL, &error);
 			break;
+		case FLOWSPEC_FRAGMENT:
 		case FLOWSPEC_TCP_FLAGS:
-			ret = bgp_flowspec_tcpflags_decode(
+			ret = bgp_flowspec_bitmask_decode(
 						BGP_FLOWSPEC_VALIDATE_ONLY,
 						nlri_content+offset,
 						len - offset,
@@ -134,13 +135,6 @@ static bool bgp_flowspec_contains_prefix(struct prefix *pfs,
 		case FLOWSPEC_PKT_LEN:
 		case FLOWSPEC_DSCP:
 			ret = bgp_flowspec_op_decode(
-						BGP_FLOWSPEC_VALIDATE_ONLY,
-						nlri_content + offset,
-						len - offset, NULL,
-						&error);
-			break;
-		case FLOWSPEC_FRAGMENT:
-			ret = bgp_flowspec_fragment_type_decode(
 						BGP_FLOWSPEC_VALIDATE_ONLY,
 						nlri_content + offset,
 						len - offset, NULL,
@@ -312,14 +306,14 @@ int bgp_flowspec_op_decode(enum bgp_flowspec_util_nlri_t type,
 
 
 /*
- * handle the flowspec tcpflags field
+ * handle the flowspec tcpflags or fragment field
  * return number of bytes analysed
  * if there is an error, the passed error param is used to give error:
  * -1 if decoding error,
  * if result is a string, its assumed length
  *  is BGP_FLOWSPEC_STRING_DISPLAY_MAX
  */
-int bgp_flowspec_tcpflags_decode(enum bgp_flowspec_util_nlri_t type,
+int bgp_flowspec_bitmask_decode(enum bgp_flowspec_util_nlri_t type,
 				 uint8_t *nlri_ptr,
 				 uint32_t max_len,
 				 void *result, int *error)
@@ -417,92 +411,6 @@ int bgp_flowspec_tcpflags_decode(enum bgp_flowspec_util_nlri_t type,
 	/* use error parameter to count the number of entries */
 	if (*error == 0)
 		*error = loop;
-	return offset;
-}
-
-/*
- * handle the flowspec fragment type field
- * return error (returned values are invalid) or number of bytes analysed
- * -1 if error in decoding
- * >= 0 : number of bytes analysed (ok).
- */
-int bgp_flowspec_fragment_type_decode(enum bgp_flowspec_util_nlri_t type,
-				      uint8_t *nlri_ptr,
-				      uint32_t max_len,
-				      void *result, int *error)
-{
-	int op[8];
-	int len, value, value_size, loop = 0;
-	char *ptr = (char *)result; /* for return_string */
-	struct bgp_pbr_fragment_val *mval =
-		(struct bgp_pbr_fragment_val *)result;
-	uint32_t offset = 0;
-	int len_string = BGP_FLOWSPEC_STRING_DISPLAY_MAX;
-	int len_written;
-
-	*error = 0;
-	do {
-		hex2bin(&nlri_ptr[offset], op);
-		offset++;
-		len = 2 * op[2] + op[3];
-		value_size = 1 << len;
-		value = hexstr2num(&nlri_ptr[offset], value_size);
-		if (value != 1 && value != 2 && value != 4 && value != 8)
-			*error = -1;
-		offset += value_size;
-		/* TODO : as per RFC5574 : first Fragment bits are Reserved
-		 * does that mean that it is not possible
-		 * to handle multiple occurences ?
-		 * as of today, we only grab the first TCP fragment
-		 */
-		if (loop) {
-			*error = -2;
-			loop++;
-			continue;
-		}
-		switch (type) {
-		case BGP_FLOWSPEC_RETURN_STRING:
-			switch (value) {
-			case 1:
-				len_written = snprintf(ptr, len_string,
-						       "dont-fragment");
-				len_string -= len_written;
-				ptr += len_written;
-				break;
-			case 2:
-				len_written = snprintf(ptr, len_string,
-						      "is-fragment");
-				len_string -= len_written;
-				ptr += len_written;
-				break;
-			case 4:
-				len_written = snprintf(ptr, len_string,
-						       "first-fragment");
-				len_string -= len_written;
-				ptr += len_written;
-				break;
-			case 8:
-				len_written = snprintf(ptr, len_string,
-						       "last-fragment");
-				len_string -= len_written;
-				ptr += len_written;
-				break;
-			default:
-				{}
-			}
-			break;
-		case BGP_FLOWSPEC_CONVERT_TO_NON_OPAQUE:
-			mval->bitmask = (uint8_t)value;
-			break;
-		case BGP_FLOWSPEC_VALIDATE_ONLY:
-		default:
-			/* no action */
-			break;
-		}
-		loop++;
-	} while (op[0] == 0 && offset < max_len - 1);
-	if (offset > max_len)
-		*error = -1;
 	return offset;
 }
 
@@ -624,7 +532,7 @@ int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 							&error);
 			break;
 		case FLOWSPEC_TCP_FLAGS:
-			ret = bgp_flowspec_tcpflags_decode(
+			ret = bgp_flowspec_bitmask_decode(
 					BGP_FLOWSPEC_CONVERT_TO_NON_OPAQUE,
 					nlri_content + offset,
 					len - offset,
@@ -638,7 +546,7 @@ int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 			offset += ret;
 			break;
 		case FLOWSPEC_FRAGMENT:
-			ret = bgp_flowspec_fragment_type_decode(
+			ret = bgp_flowspec_bitmask_decode(
 					BGP_FLOWSPEC_CONVERT_TO_NON_OPAQUE,
 					nlri_content + offset,
 					len - offset, &bpem->fragment,
@@ -647,7 +555,7 @@ int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 				zlog_err("%s: flowspec_fragment_type_decode error %d",
 					 __func__, error);
 			else
-				bpem->match_bitmask |= FRAGMENT_PRESENT;
+				bpem->match_fragment_num = error;
 			offset += ret;
 			break;
 		default:

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -348,32 +348,33 @@ int bgp_flowspec_tcpflags_decode(enum bgp_flowspec_util_nlri_t type,
 		case BGP_FLOWSPEC_RETURN_STRING:
 			if (op[1] == 1 && loop != 0) {
 				len_written = snprintf(ptr, len_string,
-						       ", and ");
+						       ",&");
 				len_string -= len_written;
 				ptr += len_written;
 			} else if (op[1] == 0 && loop != 0) {
 				len_written = snprintf(ptr, len_string,
-						      ", or ");
-				len_string -= len_written;
-				ptr += len_written;
-			}
-			len_written = snprintf(ptr, len_string,
-					       "tcp flags is ");
-			len_string -= len_written;
-			ptr += len_written;
-			if (op[6] == 1) {
-				ptr += snprintf(ptr, len_string,
-					       "not ");
+						      ",|");
 				len_string -= len_written;
 				ptr += len_written;
 			}
 			if (op[7] == 1) {
-				ptr += snprintf(ptr, len_string,
-					       "exactly match ");
+				len_written = snprintf(ptr, len_string,
+					       "= ");
+				len_string -= len_written;
+				ptr += len_written;
+			} else {
+				len_written = snprintf(ptr, len_string,
+						       "∋ ");
 				len_string -= len_written;
 				ptr += len_written;
 			}
-			ptr += snprintf(ptr, len_string,
+			if (op[6] == 1) {
+				len_written = snprintf(ptr, len_string,
+					       "! ");
+				len_string -= len_written;
+				ptr += len_written;
+			}
+			len_written = snprintf(ptr, len_string,
 				       "%d", value);
 			len_string -= len_written;
 			ptr += len_written;

--- a/bgpd/bgp_flowspec_util.h
+++ b/bgpd/bgp_flowspec_util.h
@@ -41,15 +41,11 @@ extern int bgp_flowspec_ip_address(enum bgp_flowspec_util_nlri_t type,
 				   uint32_t max_len,
 				   void *result, int *error);
 
-extern int bgp_flowspec_tcpflags_decode(enum bgp_flowspec_util_nlri_t type,
+extern int bgp_flowspec_bitmask_decode(enum bgp_flowspec_util_nlri_t type,
 					uint8_t *nlri_ptr,
 					uint32_t max_len,
 					void *result, int *error);
 
-extern int bgp_flowspec_fragment_type_decode(enum bgp_flowspec_util_nlri_t type,
-					     uint8_t *nlri_ptr,
-					     uint32_t max_len,
-					     void *result, int *error);
 struct bgp_pbr_entry_main;
 extern int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 					 struct bgp_pbr_entry_main *bpem);

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -62,7 +62,7 @@ static const struct message bgp_flowspec_display_min[] = {
 	{FLOWSPEC_SRC_PORT, "srcp"},
 	{FLOWSPEC_ICMP_TYPE, "type"},
 	{FLOWSPEC_ICMP_CODE, "code"},
-	{FLOWSPEC_TCP_FLAGS, "flags"},
+	{FLOWSPEC_TCP_FLAGS, "tcp"},
 	{FLOWSPEC_PKT_LEN, "pktlen"},
 	{FLOWSPEC_DSCP, "dscp"},
 	{FLOWSPEC_FRAGMENT, "pktfrag"},

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -173,7 +173,7 @@ void bgp_fs_nlri_get_string(unsigned char *nlri_content, size_t len,
 			ptr += len_written;
 			break;
 		case FLOWSPEC_TCP_FLAGS:
-			ret = bgp_flowspec_tcpflags_decode(
+			ret = bgp_flowspec_bitmask_decode(
 					      type_util,
 					      nlri_content+offset,
 					      len - offset,
@@ -221,11 +221,11 @@ void bgp_fs_nlri_get_string(unsigned char *nlri_content, size_t len,
 			ptr += len_written;
 			break;
 		case FLOWSPEC_FRAGMENT:
-			ret = bgp_flowspec_fragment_type_decode(
-						type_util,
-						nlri_content + offset,
-						len - offset, local_string,
-						&error);
+			ret = bgp_flowspec_bitmask_decode(
+					      type_util,
+					      nlri_content+offset,
+					      len - offset,
+					      local_string, &error);
 			if (ret <= 0)
 				break;
 			if (json_path) {

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1071,10 +1071,11 @@ void bgp_pbr_print_policy_route(struct bgp_pbr_entry_main *api)
 		ptr += sprintf_bgp_pbr_match_val(ptr, &api->tcpflags[i],
 					 i > 0 ? NULL : "@tcpflags ");
 
-	if (api->match_bitmask & FRAGMENT_PRESENT) {
+	if (api->match_fragment_num)
 		INCREMENT_DISPLAY(ptr, nb_items);
-		ptr += sprintf(ptr, "@fragment %u", api->fragment.bitmask);
-	}
+	for (i = 0; i < api->match_fragment_num; i++)
+		ptr += sprintf_bgp_pbr_match_val(ptr, &api->fragment[i],
+					 i > 0 ? NULL : "@fragment ");
 	if (!nb_items)
 		ptr = return_string;
 	else

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -21,6 +21,7 @@
 #include "prefix.h"
 #include "zclient.h"
 #include "jhash.h"
+#include "pbr.h"
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_pbr.h"

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1393,7 +1393,7 @@ static void bgp_pbr_policyroute_add_to_zebra(struct bgp *bgp,
 	 * it will be suppressed subsequently
 	 */
 	/* ip rule add */
-	if (!bpa->installed) {
+	if (!bpa->installed && !bpa->install_in_progress) {
 		bgp_send_pbr_rule_action(bpa, true);
 		bgp_zebra_announce_default(bgp, nh,
 					   AFI_IP, bpa->table_id, true);

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -180,6 +180,19 @@ struct bgp_pbr_range_port {
 	uint16_t max_port;
 };
 
+static bool bgp_pbr_extract_enumerate(struct bgp_pbr_match_val list[],
+				      int num)
+{
+	int i = 0;
+
+	for (i = 0; i < num; i++) {
+		if (list[i].compare_operator !=
+		    OPERATOR_COMPARE_EQUAL_TO)
+			return false;
+	}
+	return true;
+}
+
 /* return true if extraction ok
  */
 static bool bgp_pbr_extract(struct bgp_pbr_match_val list[],
@@ -231,6 +244,8 @@ static bool bgp_pbr_extract(struct bgp_pbr_match_val list[],
 
 static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 {
+	bool enumerate_icmp = false;
+
 	/* because bgp pbr entry may contain unsupported
 	 * combinations, a message will be displayed here if
 	 * not supported.
@@ -240,7 +255,7 @@ static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 	 * - combination src/dst => drop
 	 * - combination srcport + @IP
 	 */
-	if (api->match_icmp_type_num || api->match_packet_length_num
+	if (api->match_packet_length_num
 	    || api->match_dscp_num || api->match_tcpflags_num) {
 		if (BGP_DEBUG(pbr, PBR)) {
 			bgp_pbr_print_policy_route(api);
@@ -259,6 +274,7 @@ static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 	}
 	if (api->match_protocol_num == 1 &&
 	    api->protocol[0].value != PROTOCOL_UDP &&
+	    api->protocol[0].value != PROTOCOL_ICMP &&
 	    api->protocol[0].value != PROTOCOL_TCP) {
 		if (BGP_DEBUG(pbr, PBR))
 			zlog_debug("BGP: match protocol operations:"
@@ -278,6 +294,32 @@ static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 				   "too complex. ignoring.");
 		return 0;
 	}
+	if (!bgp_pbr_extract(api->icmp_type, api->match_icmp_type_num, NULL)) {
+		if (!bgp_pbr_extract_enumerate(api->icmp_type,
+					       api->match_icmp_type_num)) {
+			if (BGP_DEBUG(pbr, PBR))
+				zlog_debug("BGP: match icmp type operations:"
+					   "too complex. ignoring.");
+			return 0;
+		}
+		enumerate_icmp = true;
+	}
+	if (!bgp_pbr_extract(api->icmp_code, api->match_icmp_code_num, NULL)) {
+		if (!bgp_pbr_extract_enumerate(api->icmp_code,
+					  api->match_icmp_code_num)) {
+			if (BGP_DEBUG(pbr, PBR))
+				zlog_debug("BGP: match icmp code operations:"
+					   "too complex. ignoring.");
+			return 0;
+		} else if (api->match_icmp_type_num > 1 &&
+			   enumerate_icmp == false) {
+			if (BGP_DEBUG(pbr, PBR))
+				zlog_debug("BGP: match icmp code is enumerate"
+					   ", and icmp type is not."
+					   " too complex. ignoring.");
+			return 0;
+		}
+	}
 	if (!bgp_pbr_extract(api->port, api->match_port_num, NULL)) {
 		if (BGP_DEBUG(pbr, PBR))
 			zlog_debug("BGP: match port operations:"
@@ -291,6 +333,14 @@ static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 	    api->match_port_num > 3) {
 		if (BGP_DEBUG(pbr, PBR))
 			zlog_debug("BGP: match multiple port operations:"
+				 " too complex. ignoring.");
+		return 0;
+	}
+	if ((api->match_src_port_num || api->match_dst_port_num
+	     || api->match_port_num) && (api->match_icmp_type_num
+					 || api->match_icmp_code_num)) {
+		if (BGP_DEBUG(pbr, PBR))
+			zlog_debug("BGP: match multiple port/imcp operations:"
 				 " too complex. ignoring.");
 		return 0;
 	}
@@ -984,7 +1034,7 @@ static void bgp_pbr_policyroute_remove_from_zebra(struct bgp *bgp,
 		prefix_copy(&temp2.dst, dst);
 	} else
 		temp2.dst.family = AF_INET;
-	if (src_port) {
+	if (src_port && src_port->min_port) {
 		temp.flags |= MATCH_PORT_SRC_SET;
 		temp2.src_port_min = src_port->min_port;
 		if (src_port->max_port) {
@@ -992,7 +1042,7 @@ static void bgp_pbr_policyroute_remove_from_zebra(struct bgp *bgp,
 			temp2.src_port_max = src_port->max_port;
 		}
 	}
-	if (dst_port) {
+	if (dst_port && dst_port->min_port) {
 		temp.flags |= MATCH_PORT_DST_SET;
 		temp2.dst_port_min = dst_port->min_port;
 		if (dst_port->max_port) {
@@ -1207,6 +1257,183 @@ static void bgp_pbr_policyroute_add_to_zebra(struct bgp *bgp,
 
 }
 
+static const struct message icmp_code_unreach_str[] = {
+	{ 9, "communication-prohibited-by-filtering"},
+	{ 10, "destination-host-prohibited"},
+	{ 7, "destination-host-unknown"},
+	{ 6, "destination-network-unknown"},
+	{ 4, "fragmentation-needed"},
+	{ 14, "host-precedence-violation"},
+	{ 0, "network-unreachable"},
+	{ 12, "network-unreachable-for-tos"},
+	{ 3, "port-unreachable"},
+	{ 8, "source-host-isolated"},
+	{ 5, "source-route-failed"},
+	{0}
+};
+
+static const struct message icmp_code_redirect_str[] = {
+	{ 1, "redirect-for-host"},
+	{ 0, "redirect-for-network"},
+	{ 3, "redirect-for-tos-and-host"},
+	{ 2, "redirect-for-tos-and-net"},
+	{0}
+};
+
+static const struct message icmp_code_exceed_str[] = {
+	{ 1, "ttl-eq-zero-during-reassembly"},
+	{ 0, "ttl-eq-zero-during-transit"},
+	{0}
+};
+
+static const struct message icmp_code_problem_str[] = {
+	{ 1, "required-option-missing"},
+	{ 2, "ip-header-bad"},
+	{0}
+};
+static void  bgp_pbr_enumerate_action_src_dst(struct bgp_pbr_match_val src[],
+				     int src_num,
+				     struct bgp_pbr_match_val dst[],
+				     int dst_num,
+				     struct prefix *src_address,
+				     struct prefix *dst_address,
+				     uint8_t proto,
+				     struct bgp *bgp,
+				     struct bgp_info *binfo,
+				     bool add,
+				     vrf_id_t vrf_id,
+				     struct nexthop *nh,
+				     float *rate)
+{
+	int i = 0, j;
+	struct bgp_pbr_range_port srcp, dstp;
+
+	if (proto != IPPROTO_ICMP)
+		return;
+	/* combinatory forced. ignore icmp type / code combinatory */
+	if (src_num == 1 && dst_num == 1) {
+		srcp.max_port = 0;
+		dstp.max_port = 0;
+		srcp.min_port = src[0].value;
+		dstp.min_port = dst[0].value;
+		if (add)
+			bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
+							 vrf_id, src_address,
+							 dst_address,
+							 nh, rate, proto,
+							 &srcp, &dstp);
+		else
+			bgp_pbr_policyroute_remove_from_zebra(
+							      bgp,
+							      binfo,
+							      vrf_id,
+							      src_address,
+							      dst_address,
+							      proto,
+							      &srcp, &dstp);
+		return;
+	}
+	/* parse icmp type and lookup appropriate icmp code
+	 * if no icmp code found, create as many entryes as
+	 * there are listed icmp codes for that icmp type
+	 */
+	for (i = 0; i < src_num; i++) {
+		const struct message *pnt;
+		const struct message *pnt_code = NULL;
+		static struct message nt = {0};
+		bool icmp_typecode_configured = false;
+
+		srcp.min_port = src[i].value;
+		srcp.max_port = 0;
+		dstp.max_port = 0;
+		if (src[i].value == 3)
+			pnt_code = icmp_code_unreach_str;
+		else if (src[i].value == 5)
+			pnt_code = icmp_code_redirect_str;
+		else if (src[i].value == 11)
+			pnt_code = icmp_code_exceed_str;
+		else if (src[i].value == 12)
+			pnt_code = icmp_code_problem_str;
+		switch (src[i].value) {
+		case 3:
+		case 5:
+		case 11:
+		case 12:
+			for (j = 0; j < dst_num; j++) {
+				for (pnt = pnt_code;
+				     pnt && memcmp(pnt, &nt, sizeof(struct message));
+				     pnt++) {
+					if (dst[i].value != pnt->key)
+						continue;
+					dstp.min_port = dst[i].value;
+					icmp_typecode_configured = true;
+					if (add)
+						bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
+										 vrf_id, src_address,
+										 dst_address,
+										 nh, rate, proto,
+										 &srcp, &dstp);
+					else
+						bgp_pbr_policyroute_remove_from_zebra(
+										      bgp,
+										      binfo,
+										      vrf_id,
+										      src_address,
+										      dst_address,
+										      proto,
+										      &srcp, &dstp);
+				}
+			}
+			/* create a list of ICMP type/code combinatories */
+			if (!icmp_typecode_configured) {
+				for (pnt = pnt_code;
+				     pnt && memcmp(pnt, &nt, sizeof(struct message));
+				     pnt++) {
+					dstp.min_port = pnt->key;
+					if (add)
+						bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
+										 vrf_id, src_address,
+										 dst_address,
+										 nh, rate, proto,
+										 &srcp, &dstp);
+					else
+						bgp_pbr_policyroute_remove_from_zebra(
+										      bgp,
+										      binfo,
+										      vrf_id,
+										      src_address,
+										      dst_address,
+										      proto,
+										      &srcp, &dstp);
+				}
+
+			}
+			break;
+		default:
+			/* icmp type is not one of the above
+			 * forge an entry only based on the icmp type
+			 */
+			dstp.min_port = 0;
+			if (add)
+				bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
+								 vrf_id, src_address,
+								 dst_address,
+								 nh, rate, proto,
+								 &srcp, &dstp);
+			else
+				bgp_pbr_policyroute_remove_from_zebra(
+								      bgp,
+								      binfo,
+								      vrf_id,
+								      src_address,
+								      dst_address,
+								      proto,
+								      &srcp, &dstp);
+			break;
+		}
+	}
+}
+
 static void bgp_pbr_handle_entry(struct bgp *bgp,
 				struct bgp_info *binfo,
 				struct bgp_pbr_entry_main *api,
@@ -1219,7 +1446,8 @@ static void bgp_pbr_handle_entry(struct bgp *bgp,
 	struct prefix *src = NULL, *dst = NULL;
 	uint8_t proto = 0;
 	struct bgp_pbr_range_port *srcp = NULL, *dstp = NULL;
-	struct bgp_pbr_range_port range;
+	struct bgp_pbr_range_port range, range_icmp_code;
+	bool enum_icmp = false;
 
 	memset(&nh, 0, sizeof(struct nexthop));
 	if (api->match_bitmask & PREFIX_SRC_PRESENT)
@@ -1251,10 +1479,48 @@ static void bgp_pbr_handle_entry(struct bgp *bgp,
 		dstp = &range;
 		srcp = NULL;
 	}
-	if (!add)
-		return bgp_pbr_policyroute_remove_from_zebra(bgp, binfo,
-					     api->vrf_id, src, dst,
-					     proto, srcp, dstp);
+	if (api->match_icmp_type_num >= 1) {
+		proto = IPPROTO_ICMP;
+		if (bgp_pbr_extract_enumerate(api->icmp_type,
+					      api->match_icmp_type_num))
+			enum_icmp = true;
+		else {
+			bgp_pbr_extract(api->icmp_type,
+					api->match_icmp_type_num,
+					&range);
+			srcp = &range;
+		}
+	}
+	if (api->match_icmp_code_num >= 1) {
+		proto = IPPROTO_ICMP;
+		if (bgp_pbr_extract_enumerate(api->icmp_code,
+					      api->match_icmp_code_num))
+			enum_icmp = true;
+		else {
+			bgp_pbr_extract(api->icmp_code,
+					api->match_icmp_code_num,
+					&range_icmp_code);
+			dstp = &range_icmp_code;
+		}
+	}
+
+	if (!add) {
+		if (enum_icmp) {
+			return bgp_pbr_enumerate_action_src_dst(api->icmp_type,
+						api->match_icmp_type_num,
+						api->icmp_code,
+						api->match_icmp_code_num,
+						src, dst, proto,
+						bgp, binfo, add,
+						api->vrf_id, NULL, NULL);
+		}
+		return bgp_pbr_policyroute_remove_from_zebra(bgp,
+							     binfo,
+							     api->vrf_id,
+							     src, dst,
+							     proto,
+							     srcp, dstp);
+	}
 	/* no action for add = true */
 	for (i = 0; i < api->action_num; i++) {
 		switch (api->actions[i].action) {
@@ -1263,10 +1529,19 @@ static void bgp_pbr_handle_entry(struct bgp *bgp,
 			if (api->actions[i].u.r.rate == 0) {
 				nh.vrf_id = api->vrf_id;
 				nh.type = NEXTHOP_TYPE_BLACKHOLE;
-				bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
-						    api->vrf_id, src, dst,
-						    &nh, &rate, proto,
-						    srcp, dstp);
+				if (enum_icmp)
+					bgp_pbr_enumerate_action_src_dst(api->icmp_type,
+									 api->match_icmp_type_num,
+									 api->icmp_code,
+									 api->match_icmp_code_num,
+									 src, dst, proto,
+									 bgp, binfo, add,
+									 api->vrf_id, &nh, &rate);
+				else
+					bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
+									 api->vrf_id, src, dst,
+									 &nh, &rate, proto,
+									 srcp, dstp);
 			} else {
 				/* update rate. can be reentrant */
 				rate = api->actions[i].u.r.rate;
@@ -1306,11 +1581,20 @@ static void bgp_pbr_handle_entry(struct bgp *bgp,
 			nh.gate.ipv4.s_addr =
 				api->actions[i].u.zr.redirect_ip_v4.s_addr;
 			nh.vrf_id = api->vrf_id;
-			bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
-							    api->vrf_id,
-							    src, dst,
-							    &nh, &rate, proto,
-							    srcp, dstp);
+			if (enum_icmp)
+				bgp_pbr_enumerate_action_src_dst(api->icmp_type,
+								 api->match_icmp_type_num,
+								 api->icmp_code,
+								 api->match_icmp_code_num,
+								 src, dst, proto,
+								 bgp, binfo, add,
+								 api->vrf_id, &nh, &rate);
+			else
+				bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
+								 api->vrf_id,
+								 src, dst,
+								 &nh, &rate, proto,
+								 srcp, dstp);
 			/* XXX combination with REDIRECT_VRF
 			 * + REDIRECT_NH_IP not done
 			 */
@@ -1319,7 +1603,16 @@ static void bgp_pbr_handle_entry(struct bgp *bgp,
 		case ACTION_REDIRECT:
 			nh.vrf_id = api->actions[i].u.redirect_vrf;
 			nh.type = NEXTHOP_TYPE_IPV4;
-			bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
+			if (enum_icmp)
+				bgp_pbr_enumerate_action_src_dst(api->icmp_type,
+								 api->match_icmp_type_num,
+								 api->icmp_code,
+								 api->match_icmp_code_num,
+								 src, dst, proto,
+								 bgp, binfo, add,
+								 api->vrf_id, &nh, &rate);
+			else
+				bgp_pbr_policyroute_add_to_zebra(bgp, binfo,
 							 api->vrf_id,
 							 src, dst,
 							 &nh, &rate, proto,

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -185,6 +185,7 @@ struct bgp_pbr_match {
 	uint16_t tcp_flags;
 	uint16_t tcp_mask_flags;
 	uint8_t dscp_value;
+	uint8_t fragment;
 
 	vrf_id_t vrf_id;
 

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -185,6 +185,9 @@ struct bgp_pbr_match {
 #define MATCH_PORT_DST_RANGE_SET	(1 << 5)
 	uint32_t flags;
 
+	uint16_t pkt_len_min;
+	uint16_t pkt_len_max;
+
 	vrf_id_t vrf_id;
 
 	/* unique identifier for ipset create transaction

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -178,12 +178,6 @@ struct bgp_pbr_match {
 	 */
 	uint32_t type;
 
-#define MATCH_IP_SRC_SET		(1 << 0)
-#define MATCH_IP_DST_SET		(1 << 1)
-#define MATCH_PORT_SRC_SET		(1 << 2)
-#define MATCH_PORT_DST_SET		(1 << 3)
-#define MATCH_PORT_SRC_RANGE_SET	(1 << 4)
-#define MATCH_PORT_DST_RANGE_SET	(1 << 5)
 	uint32_t flags;
 
 	uint16_t pkt_len_min;

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -184,6 +184,7 @@ struct bgp_pbr_match {
 	uint16_t pkt_len_max;
 	uint16_t tcp_flags;
 	uint16_t tcp_mask_flags;
+	uint8_t dscp_value;
 
 	vrf_id_t vrf_id;
 

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -125,6 +125,7 @@ struct bgp_pbr_entry_main {
 
 #define PROTOCOL_UDP 17
 #define PROTOCOL_TCP 6
+#define PROTOCOL_ICMP 1
 	struct bgp_pbr_match_val protocol[BGP_PBR_MATCH_VAL_MAX];
 	struct bgp_pbr_match_val src_port[BGP_PBR_MATCH_VAL_MAX];
 	struct bgp_pbr_match_val dst_port[BGP_PBR_MATCH_VAL_MAX];

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -107,7 +107,6 @@ struct bgp_pbr_entry_main {
 
 #define PREFIX_SRC_PRESENT (1 << 0)
 #define PREFIX_DST_PRESENT (1 << 1)
-#define FRAGMENT_PRESENT   (1 << 2)
 	uint8_t match_bitmask;
 
 	uint8_t match_src_port_num;
@@ -119,6 +118,7 @@ struct bgp_pbr_entry_main {
 	uint8_t match_packet_length_num;
 	uint8_t match_dscp_num;
 	uint8_t match_tcpflags_num;
+	uint8_t match_fragment_num;
 
 	struct prefix src_prefix;
 	struct prefix dst_prefix;
@@ -136,7 +136,7 @@ struct bgp_pbr_entry_main {
 	struct bgp_pbr_match_val dscp[BGP_PBR_MATCH_VAL_MAX];
 
 	struct bgp_pbr_match_val tcpflags[BGP_PBR_MATCH_VAL_MAX];
-	struct bgp_pbr_fragment_val fragment;
+	struct bgp_pbr_match_val fragment[BGP_PBR_MATCH_VAL_MAX];
 
 	uint16_t action_num;
 	struct bgp_pbr_entry_action actions[ACTIONS_MAX_NUM];

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -134,6 +134,7 @@ struct bgp_pbr_entry_main {
 	struct bgp_pbr_match_val icmp_code[BGP_PBR_MATCH_VAL_MAX];
 	struct bgp_pbr_match_val packet_length[BGP_PBR_MATCH_VAL_MAX];
 	struct bgp_pbr_match_val dscp[BGP_PBR_MATCH_VAL_MAX];
+
 	struct bgp_pbr_match_val tcpflags[BGP_PBR_MATCH_VAL_MAX];
 	struct bgp_pbr_fragment_val fragment;
 
@@ -187,6 +188,8 @@ struct bgp_pbr_match {
 
 	uint16_t pkt_len_min;
 	uint16_t pkt_len_max;
+	uint16_t tcp_flags;
+	uint16_t tcp_mask_flags;
 
 	vrf_id_t vrf_id;
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2221,6 +2221,8 @@ static void bgp_encode_pbr_iptable_match(struct stream *s,
 		   ZEBRA_IPSET_NAME_SIZE);
 	stream_putw(s, pbm->pkt_len_min);
 	stream_putw(s, pbm->pkt_len_max);
+	stream_putw(s, pbm->tcp_flags);
+	stream_putw(s, pbm->tcp_mask_flags);
 }
 
 /* BGP has established connection with Zebra. */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2224,6 +2224,7 @@ static void bgp_encode_pbr_iptable_match(struct stream *s,
 	stream_putw(s, pbm->tcp_flags);
 	stream_putw(s, pbm->tcp_mask_flags);
 	stream_putc(s, pbm->dscp_value);
+	stream_putc(s, pbm->fragment);
 }
 
 /* BGP has established connection with Zebra. */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2219,6 +2219,8 @@ static void bgp_encode_pbr_iptable_match(struct stream *s,
 	stream_putl(s, bpa->fwmark);
 	stream_put(s, pbm->ipset_name,
 		   ZEBRA_IPSET_NAME_SIZE);
+	stream_putw(s, pbm->pkt_len_min);
+	stream_putw(s, pbm->pkt_len_max);
 }
 
 /* BGP has established connection with Zebra. */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2223,6 +2223,7 @@ static void bgp_encode_pbr_iptable_match(struct stream *s,
 	stream_putw(s, pbm->pkt_len_max);
 	stream_putw(s, pbm->tcp_flags);
 	stream_putw(s, pbm->tcp_mask_flags);
+	stream_putc(s, pbm->dscp_value);
 }
 
 /* BGP has established connection with Zebra. */

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -114,6 +114,7 @@ struct pbr_rule {
 #define MATCH_PORT_DST_RANGE_SET	(1 << 5)
 #define MATCH_DSCP_SET			(1 << 6)
 #define MATCH_DSCP_INVERSE_SET		(1 << 7)
+#define MATCH_PKT_LEN_INVERSE_SET	(1 << 8)
 
 extern int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s,
 				struct pbr_rule *zrule);

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -103,6 +103,16 @@ struct pbr_rule {
 			      | TCP_HEADER_RST | TCP_HEADER_PSH \
 			      | TCP_HEADER_ACK | TCP_HEADER_URG)
 
+/* Pbr IPTable defines
+ * those are common flags shared between BGP and Zebra
+ */
+#define MATCH_IP_SRC_SET		(1 << 0)
+#define MATCH_IP_DST_SET		(1 << 1)
+#define MATCH_PORT_SRC_SET		(1 << 2)
+#define MATCH_PORT_DST_SET		(1 << 3)
+#define MATCH_PORT_SRC_RANGE_SET	(1 << 4)
+#define MATCH_PORT_DST_RANGE_SET	(1 << 5)
+
 extern int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s,
 				struct pbr_rule *zrule);
 

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -89,6 +89,20 @@ struct pbr_rule {
 	uint32_t ifindex;
 };
 
+/* TCP flags value shared
+ * those are values of byte 13 of TCP header
+ * as mentioned in rfc793
+ */
+#define TCP_HEADER_FIN (0x01)
+#define TCP_HEADER_SYN (0x02)
+#define TCP_HEADER_RST (0x04)
+#define TCP_HEADER_PSH (0x08)
+#define TCP_HEADER_ACK (0x10)
+#define TCP_HEADER_URG (0x20)
+#define TCP_HEADER_ALL_FLAGS (TCP_HEADER_FIN | TCP_HEADER_SYN \
+			      | TCP_HEADER_RST | TCP_HEADER_PSH \
+			      | TCP_HEADER_ACK | TCP_HEADER_URG)
+
 extern int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s,
 				struct pbr_rule *zrule);
 

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -116,6 +116,7 @@ struct pbr_rule {
 #define MATCH_DSCP_INVERSE_SET		(1 << 7)
 #define MATCH_PKT_LEN_INVERSE_SET	(1 << 8)
 #define MATCH_FRAGMENT_INVERSE_SET	(1 << 9)
+#define MATCH_ICMP_SET			(1 << 10)
 
 extern int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s,
 				struct pbr_rule *zrule);

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -112,6 +112,8 @@ struct pbr_rule {
 #define MATCH_PORT_DST_SET		(1 << 3)
 #define MATCH_PORT_SRC_RANGE_SET	(1 << 4)
 #define MATCH_PORT_DST_RANGE_SET	(1 << 5)
+#define MATCH_DSCP_SET			(1 << 6)
+#define MATCH_DSCP_INVERSE_SET		(1 << 7)
 
 extern int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s,
 				struct pbr_rule *zrule);

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -115,6 +115,7 @@ struct pbr_rule {
 #define MATCH_DSCP_SET			(1 << 6)
 #define MATCH_DSCP_INVERSE_SET		(1 << 7)
 #define MATCH_PKT_LEN_INVERSE_SET	(1 << 8)
+#define MATCH_FRAGMENT_INVERSE_SET	(1 << 9)
 
 extern int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s,
 				struct pbr_rule *zrule);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2943,6 +2943,7 @@ static inline void zread_iptable(ZAPI_HANDLER_ARGS)
 	STREAM_GETW(s, zpi.tcp_flags);
 	STREAM_GETW(s, zpi.tcp_mask_flags);
 	STREAM_GETC(s, zpi.dscp_value);
+	STREAM_GETC(s, zpi.fragment);
 	STREAM_GETL(s, zpi.nb_interface);
 	zebra_pbr_iptable_update_interfacelist(s, &zpi);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2896,9 +2896,9 @@ static inline void zread_ipset_entry(ZAPI_HANDLER_ARGS)
 
 		if (!is_default_prefix(&zpi.dst))
 			zpi.filter_bm |= PBR_FILTER_DST_IP;
-		if (zpi.dst_port_min != 0)
+		if (zpi.dst_port_min != 0 || zpi.proto == IPPROTO_ICMP)
 			zpi.filter_bm |= PBR_FILTER_DST_PORT;
-		if (zpi.src_port_min != 0)
+		if (zpi.src_port_min != 0 || zpi.proto == IPPROTO_ICMP)
 			zpi.filter_bm |= PBR_FILTER_SRC_PORT;
 		if (zpi.dst_port_max != 0)
 			zpi.filter_bm |= PBR_FILTER_DST_PORT_RANGE;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2938,6 +2938,8 @@ static inline void zread_iptable(ZAPI_HANDLER_ARGS)
 	STREAM_GETL(s, zpi.action);
 	STREAM_GETL(s, zpi.fwmark);
 	STREAM_GET(&zpi.ipset_name, s, ZEBRA_IPSET_NAME_SIZE);
+	STREAM_GETW(s, zpi.pkt_len_min);
+	STREAM_GETW(s, zpi.pkt_len_max);
 	STREAM_GETL(s, zpi.nb_interface);
 	zebra_pbr_iptable_update_interfacelist(s, &zpi);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2942,6 +2942,7 @@ static inline void zread_iptable(ZAPI_HANDLER_ARGS)
 	STREAM_GETW(s, zpi.pkt_len_max);
 	STREAM_GETW(s, zpi.tcp_flags);
 	STREAM_GETW(s, zpi.tcp_mask_flags);
+	STREAM_GETC(s, zpi.dscp_value);
 	STREAM_GETL(s, zpi.nb_interface);
 	zebra_pbr_iptable_update_interfacelist(s, &zpi);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2940,6 +2940,8 @@ static inline void zread_iptable(ZAPI_HANDLER_ARGS)
 	STREAM_GET(&zpi.ipset_name, s, ZEBRA_IPSET_NAME_SIZE);
 	STREAM_GETW(s, zpi.pkt_len_min);
 	STREAM_GETW(s, zpi.pkt_len_max);
+	STREAM_GETW(s, zpi.tcp_flags);
+	STREAM_GETW(s, zpi.tcp_mask_flags);
 	STREAM_GETL(s, zpi.nb_interface);
 	zebra_pbr_iptable_update_interfacelist(s, &zpi);
 

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -515,7 +515,7 @@ struct pbr_ipset_name_lookup {
 	char ipset_name[ZEBRA_IPSET_NAME_SIZE];
 };
 
-static const char *zebra_pbr_ipset_type2str(uint32_t type)
+const char *zebra_pbr_ipset_type2str(uint32_t type)
 {
 	return lookup_msg(ipset_type_msg, type,
 			  "Unrecognized IPset Type");

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -82,6 +82,17 @@ const struct message icmp_typecode_str[] = {
 	{0}
 };
 
+/* definitions */
+static const struct message tcp_value_str[] = {
+	{TCP_HEADER_FIN, "FIN"},
+	{TCP_HEADER_SYN, "SYN"},
+	{TCP_HEADER_RST, "RST"},
+	{TCP_HEADER_PSH, "PSH"},
+	{TCP_HEADER_ACK, "ACK"},
+	{TCP_HEADER_URG, "URG"},
+	{0}
+};
+
 /* static function declarations */
 DEFINE_HOOK(zebra_pbr_ipset_entry_wrap_script_get_stat, (struct zebra_ns *zns,
 				    struct zebra_pbr_ipset_entry *ipset,
@@ -362,6 +373,8 @@ uint32_t zebra_pbr_iptable_hash_key(void *arg)
 	key = jhash_1word(iptable->fwmark, key);
 	key = jhash_1word(iptable->pkt_len_min, key);
 	key = jhash_1word(iptable->pkt_len_max, key);
+	key = jhash_1word(iptable->tcp_flags, key);
+	key = jhash_1word(iptable->tcp_mask_flags, key);
 	return jhash_3words(iptable->filter_bm, iptable->type,
 			    iptable->unique, key);
 }
@@ -389,6 +402,10 @@ int zebra_pbr_iptable_hash_equal(const void *arg1, const void *arg2)
 	if (r1->pkt_len_min != r2->pkt_len_min)
 		return 0;
 	if (r1->pkt_len_max != r2->pkt_len_max)
+		return 0;
+	if (r1->tcp_flags != r2->tcp_flags)
+		return 0;
+	if (r1->tcp_mask_flags != r2->tcp_mask_flags)
 		return 0;
 	return 1;
 }
@@ -958,6 +975,26 @@ static int zebra_pbr_show_ipset_walkcb(struct hash_backet *backet, void *arg)
 	return HASHWALK_CONTINUE;
 }
 
+size_t zebra_pbr_tcpflags_snprintf(char *buffer, size_t len,
+				   uint16_t tcp_val)
+{
+	size_t len_written = 0;
+	static struct message nt = {0};
+	const struct message *pnt;
+	int incr = 0;
+
+	for (pnt = tcp_value_str;
+	     memcmp(pnt, &nt, sizeof(struct message)); pnt++)
+		if (pnt->key & tcp_val) {
+			len_written += snprintf(buffer + len_written,
+						len - len_written,
+						"%s%s", incr ?
+						",":"", pnt->str);
+			incr++;
+		}
+	return len_written;
+}
+
 /*
  */
 void zebra_pbr_show_ipset_list(struct vty *vty, char *ipsetname)
@@ -1030,6 +1067,19 @@ static int zebra_pbr_show_iptable_walkcb(struct hash_backet *backet, void *arg)
 			vty_out(vty, "\t pkt len [%u;%u]\n",
 				iptable->pkt_len_min,
 				iptable->pkt_len_max);
+	}
+	if (iptable->tcp_flags || iptable->tcp_mask_flags) {
+		char tcp_flag_str[64];
+		char tcp_flag_mask_str[64];
+
+		zebra_pbr_tcpflags_snprintf(tcp_flag_str,
+					    sizeof(tcp_flag_str),
+					    iptable->tcp_flags);
+		zebra_pbr_tcpflags_snprintf(tcp_flag_mask_str,
+					    sizeof(tcp_flag_mask_str),
+					    iptable->tcp_mask_flags);
+		vty_out(vty, "\t tcpflags [%s/%s]\n",
+			tcp_flag_str, tcp_flag_mask_str);
 	}
 	ret = hook_call(zebra_pbr_iptable_wrap_script_get_stat,
 			zns, iptable, &pkts, &bytes);

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -44,6 +44,44 @@ static const struct message ipset_type_msg[] = {
 	{0}
 };
 
+const struct message icmp_typecode_str[] = {
+	{ 0 << 8, "echo-reply"},
+	{ 0 << 8, "pong"},
+	{ 3 << 8, "network-unreachable"},
+	{ (3 << 8) + 1, "host-unreachable"},
+	{ (3 << 8) + 2, "protocol-unreachable"},
+	{ (3 << 8) + 3, "port-unreachable"},
+	{ (3 << 8) + 4, "fragmentation-needed"},
+	{ (3 << 8) + 5, "source-route-failed"},
+	{ (3 << 8) + 6, "network-unknown"},
+	{ (3 << 8) + 7, "host-unknown"},
+	{ (3 << 8) + 9, "network-prohibited"},
+	{ (3 << 8) + 10, "host-prohibited"},
+	{ (3 << 8) + 11, "TOS-network-unreachable"},
+	{ (3 << 8) + 12, "TOS-host-unreachable"},
+	{ (3 << 8) + 13, "communication-prohibited"},
+	{ (3 << 8) + 14, "host-precedence-violation"},
+	{ (3 << 8) + 15, "precedence-cutoff"},
+	{ 4 << 8, "source-quench"},
+	{ 5 << 8, "network-redirect"},
+	{ (5 << 8) +  1, "host-redirect"},
+	{ (5 << 8) +  2, "TOS-network-redirect"},
+	{ (5 << 8) +  3, "TOS-host-redirect"},
+	{ 8 << 8, "echo-request"},
+	{ 8 << 8, "ping"},
+	{ 9 << 8, "router-advertisement"},
+	{ 10 << 8, "router-solicitation"},
+	{ 11 << 8, "ttl-zero-during-transit"},
+	{ (11 << 8) + 1, "ttl-zero-during-reassembly"},
+	{ 12 << 8, "ip-header-bad"},
+	{ (12 << 8) + 1, "required-option-missing"},
+	{ 13 << 8, "timestamp-request"},
+	{ 14 << 8, "timestamp-reply"},
+	{ 17 << 8, "address-mask-request"},
+	{ 18 << 8, "address-mask-reply"},
+	{0}
+};
+
 /* static function declarations */
 DEFINE_HOOK(zebra_pbr_ipset_entry_wrap_script_get_stat, (struct zebra_ns *zns,
 				    struct zebra_pbr_ipset_entry *ipset,
@@ -773,6 +811,30 @@ static const char *zebra_pbr_prefix2str(union prefixconstptr pu,
 	return prefix2str(pu, str, size);
 }
 
+static void zebra_pbr_display_icmp(struct vty *vty,
+				   struct zebra_pbr_ipset_entry *zpie)
+{
+	char decoded_str[20];
+	uint16_t port;
+
+	/* range icmp type */
+	if (zpie->src_port_max || zpie->dst_port_max) {
+		vty_out(vty, ":icmp:[type <%d:%d>;code <%d:%d>",
+			zpie->src_port_min, zpie->src_port_max,
+			zpie->dst_port_min, zpie->dst_port_max);
+	} else {
+		port = ((zpie->src_port_min << 8) & 0xff00) +
+			(zpie->dst_port_min & 0xff);
+		memset(decoded_str, 0, sizeof(decoded_str));
+		sprintf(decoded_str, "%d/%d",
+			zpie->src_port_min,
+			zpie->dst_port_min);
+		vty_out(vty, ":icmp:%s",
+			lookup_msg(icmp_typecode_str,
+				   port, decoded_str));
+	}
+}
+
 static void zebra_pbr_display_port(struct vty *vty, uint32_t filter_bm,
 			    uint16_t port_min, uint16_t port_max,
 			    uint8_t proto)
@@ -816,7 +878,8 @@ static int zebra_pbr_show_ipset_entry_walkcb(struct hash_backet *backet,
 
 		zebra_pbr_prefix2str(&(zpie->src), buf, sizeof(buf));
 		vty_out(vty, "\tfrom %s", buf);
-		if (zpie->filter_bm & PBR_FILTER_SRC_PORT)
+		if (zpie->filter_bm & PBR_FILTER_SRC_PORT &&
+		    zpie->proto != IPPROTO_ICMP)
 			zebra_pbr_display_port(vty, zpie->filter_bm,
 					       zpie->src_port_min,
 					       zpie->src_port_max,
@@ -824,11 +887,14 @@ static int zebra_pbr_show_ipset_entry_walkcb(struct hash_backet *backet,
 		vty_out(vty, " to ");
 		zebra_pbr_prefix2str(&(zpie->dst), buf, sizeof(buf));
 		vty_out(vty, "%s", buf);
-		if (zpie->filter_bm & PBR_FILTER_DST_PORT)
+		if (zpie->filter_bm & PBR_FILTER_DST_PORT &&
+		    zpie->proto != IPPROTO_ICMP)
 			zebra_pbr_display_port(vty, zpie->filter_bm,
 					       zpie->dst_port_min,
 					       zpie->dst_port_max,
 					       zpie->proto);
+		if (zpie->proto == IPPROTO_ICMP)
+			zebra_pbr_display_icmp(vty, zpie);
 	} else if ((zpi->type == IPSET_NET) ||
 		   (zpi->type == IPSET_NET_PORT)) {
 		char buf[PREFIX_STRLEN];
@@ -837,7 +903,8 @@ static int zebra_pbr_show_ipset_entry_walkcb(struct hash_backet *backet,
 			zebra_pbr_prefix2str(&(zpie->src), buf, sizeof(buf));
 			vty_out(vty, "\tfrom %s", buf);
 		}
-		if (zpie->filter_bm & PBR_FILTER_SRC_PORT)
+		if (zpie->filter_bm & PBR_FILTER_SRC_PORT &&
+		    zpie->proto != IPPROTO_ICMP)
 			zebra_pbr_display_port(vty, zpie->filter_bm,
 					       zpie->src_port_min,
 					       zpie->src_port_max,
@@ -846,11 +913,14 @@ static int zebra_pbr_show_ipset_entry_walkcb(struct hash_backet *backet,
 			zebra_pbr_prefix2str(&(zpie->dst), buf, sizeof(buf));
 			vty_out(vty, "\tto %s", buf);
 		}
-		if (zpie->filter_bm & PBR_FILTER_DST_PORT)
+		if (zpie->filter_bm & PBR_FILTER_DST_PORT &&
+		    zpie->proto != IPPROTO_ICMP)
 			zebra_pbr_display_port(vty, zpie->filter_bm,
 					       zpie->dst_port_min,
 					       zpie->dst_port_max,
 					       zpie->proto);
+		if (zpie->proto == IPPROTO_ICMP)
+			zebra_pbr_display_icmp(vty, zpie);
 	}
 	vty_out(vty, " (%u)\n", zpie->unique);
 

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -1084,6 +1084,11 @@ static int zebra_pbr_show_iptable_walkcb(struct hash_backet *backet, void *arg)
 		vty_out(vty, "\t tcpflags [%s/%s]\n",
 			tcp_flag_str, tcp_flag_mask_str);
 	}
+	if (iptable->filter_bm & (MATCH_DSCP_SET | MATCH_DSCP_INVERSE_SET)) {
+		vty_out(vty, "\t dscp %s %d\n",
+			iptable->filter_bm & MATCH_DSCP_INVERSE_SET ?
+			"not" : "", iptable->dscp_value);
+	}
 	ret = hook_call(zebra_pbr_iptable_wrap_script_get_stat,
 			zns, iptable, &pkts, &bytes);
 	if (ret && pkts > 0)

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -375,6 +375,7 @@ uint32_t zebra_pbr_iptable_hash_key(void *arg)
 	key = jhash_1word(iptable->pkt_len_max, key);
 	key = jhash_1word(iptable->tcp_flags, key);
 	key = jhash_1word(iptable->tcp_mask_flags, key);
+	key = jhash_1word(iptable->dscp_value, key);
 	return jhash_3words(iptable->filter_bm, iptable->type,
 			    iptable->unique, key);
 }
@@ -406,6 +407,8 @@ int zebra_pbr_iptable_hash_equal(const void *arg1, const void *arg2)
 	if (r1->tcp_flags != r2->tcp_flags)
 		return 0;
 	if (r1->tcp_mask_flags != r2->tcp_mask_flags)
+		return 0;
+	if (r1->dscp_value != r2->dscp_value)
 		return 0;
 	return 1;
 }

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -138,6 +138,7 @@ struct zebra_pbr_iptable {
 	uint16_t tcp_flags;
 	uint16_t tcp_mask_flags;
 	uint8_t dscp_value;
+	uint8_t fragment;
 
 	uint32_t nb_interface;
 

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -138,6 +138,8 @@ struct zebra_pbr_iptable {
 	char ipset_name[ZEBRA_IPSET_NAME_SIZE];
 };
 
+extern const struct message icmp_typecode_str[];
+
 const char *zebra_pbr_ipset_type2str(uint32_t type);
 
 void zebra_pbr_add_rule(struct zebra_ns *zns, struct zebra_pbr_rule *rule);

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -138,6 +138,8 @@ struct zebra_pbr_iptable {
 	char ipset_name[ZEBRA_IPSET_NAME_SIZE];
 };
 
+const char *zebra_pbr_ipset_type2str(uint32_t type);
+
 void zebra_pbr_add_rule(struct zebra_ns *zns, struct zebra_pbr_rule *rule);
 void zebra_pbr_del_rule(struct zebra_ns *zns, struct zebra_pbr_rule *rule);
 void zebra_pbr_create_ipset(struct zebra_ns *zns,

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -133,6 +133,9 @@ struct zebra_pbr_iptable {
 
 	uint32_t action;
 
+	uint16_t pkt_len_min;
+	uint16_t pkt_len_max;
+
 	uint32_t nb_interface;
 
 	struct list *interface_name_list;

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -135,6 +135,8 @@ struct zebra_pbr_iptable {
 
 	uint16_t pkt_len_min;
 	uint16_t pkt_len_max;
+	uint16_t tcp_flags;
+	uint16_t tcp_mask_flags;
 
 	uint32_t nb_interface;
 
@@ -234,6 +236,8 @@ extern void zebra_pbr_show_ipset_list(struct vty *vty, char *ipsetname);
 extern void zebra_pbr_show_iptable(struct vty *vty);
 extern void zebra_pbr_iptable_update_interfacelist(struct stream *s,
 				   struct zebra_pbr_iptable *zpi);
+size_t zebra_pbr_tcpflags_snprintf(char *buffer, size_t len,
+				   uint16_t tcp_val);
 
 DECLARE_HOOK(zebra_pbr_ipset_entry_wrap_script_get_stat, (struct zebra_ns *zns,
 				    struct zebra_pbr_ipset_entry *ipset,

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -137,6 +137,7 @@ struct zebra_pbr_iptable {
 	uint16_t pkt_len_max;
 	uint16_t tcp_flags;
 	uint16_t tcp_mask_flags;
+	uint8_t dscp_value;
 
 	uint32_t nb_interface;
 

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -91,8 +91,10 @@ struct zebra_pbr_ipset_entry {
 	struct prefix src;
 	struct prefix dst;
 
+	/* udp/tcp src port or icmp type */
 	uint16_t src_port_min;
 	uint16_t src_port_max;
+	/* udp/tcp dst port or icmp code */
 	uint16_t dst_port_min;
 	uint16_t dst_port_max;
 


### PR DESCRIPTION
support for:
- ICMP values ( type and code)
- DSCP : enumerate or single value
- packet length : enumerate or single value or range
- fragment : enumerate
- tcp flags : enumerate or single value

the enumerate is a OR list.
that implies that there is a demultiplexer in BGP that creates as many pbr ipset and pbr iptable entries as needed.


