### PR TITLE
bgpd: null check (Coverity 23106)

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -1632,7 +1632,7 @@ struct aspath *aspath_reconcile_as4(struct aspath *aspath,
 	struct aspath *newpath = NULL, *mergedpath;
 	int hops, cpasns = 0;
 
-	if (!aspath)
+	if (!aspath || !as4path)
 		return NULL;
 
 	seg = aspath->segments;

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1513,6 +1513,9 @@ bgp_attr_munge_as4_attrs(struct peer *const peer, struct attr *const attr,
 	if (!ignore_as4_path
 	    && (attr->flag & (ATTR_FLAG_BIT(BGP_ATTR_AS4_PATH)))) {
 		newpath = aspath_reconcile_as4(attr->aspath, as4_path);
+		if (!newpath)
+			return BGP_ATTR_PARSE_ERROR;
+
 		aspath_unintern(&attr->aspath);
 		attr->aspath = aspath_intern(newpath);
 	}


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr