### PR TITLE
bgpd: dead code (Coverity 1399238)

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6564,14 +6564,8 @@ void route_vty_out(struct vty *vty, struct prefix *p, struct bgp_info *binfo,
 		} else {
 			char buf[BUFSIZ];
 
-			if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_EVPN))
-				snprintf(buf, sizeof(buf), "%s%s",
-					inet_ntoa(attr->mp_nexthop_global_in),
-					vrf_id_str);
-			else
-				snprintf(buf, sizeof(buf), "%s%s",
-					inet_ntoa(attr->nexthop),
-					vrf_id_str);
+			snprintf(buf, sizeof(buf), "%s%s",
+				inet_ntoa(attr->nexthop), vrf_id_str);
 			vty_out(vty, "%-16s", buf);
 		}
 	}


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr