### PR TITLE
lib: Fix privs when using HAVE_CAPABILITIES

### DIFF
--- a/lib/privs.c
+++ b/lib/privs.c
@@ -824,6 +824,19 @@ void zprivs_init(struct zebra_privs_t *zprivs)
 
 #ifdef HAVE_CAPABILITIES
 	zprivs_caps_init(zprivs);
+
+	/*
+	 * If we have initialized the system with no requested
+	 * capabilities, change will not have been set
+	 * to anything by zprivs_caps_init, As such
+	 * we should make sure that when we attempt
+	 * to raize privileges that we actually have
+	 * a do nothing function to call instead of a
+	 * crash :).
+	 */
+	if (!zprivs->change)
+		zprivs->change = zprivs_change_null;
+
 #else  /* !HAVE_CAPABILITIES */
 	/* we dont have caps. we'll need to maintain rid and saved uid
 	 * and change euid back to saved uid (who we presume has all neccessary

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -51,7 +51,6 @@ uint32_t installed_routes = 0;
 uint32_t removed_routes = 0;
 
 zebra_capabilities_t _caps_p[] = {
-	ZCAP_NET_RAW, ZCAP_BIND, ZCAP_NET_ADMIN,
 };
 
 struct zebra_privs_t sharp_privs = {


### PR DESCRIPTION
If your daemon does not need any special privileges
and you are compiling with HAVE_CAPABILIES, the
zprivs->change pointer will end up NULL due
to the way zprivs_caps_init.  So as a check
let's add a NULL check for zprivs->change
and set it to a function that will do nothing.

This change prevents a crash if you raise privileges
when your daemon needs no special privileges.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>