### PR TITLE
lib: null check (Coverity 1399277)

### DIFF
--- a/lib/sockunion.c
+++ b/lib/sockunion.c
@@ -46,6 +46,9 @@ int str2sockunion(const char *str, union sockunion *su)
 {
 	int ret;
 
+	if (str == NULL)
+		return -1;
+
 	memset(su, 0, sizeof(union sockunion));
 
 	ret = inet_pton(AF_INET, str, &su->sin.sin_addr);


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

From bgpd/bgp_vty.c to lib/sockunion.c (at str2sockunion())

[1] https://scan.coverity.com/projects/freerangerouting-frr