### PR TITLE
bgpd: null check (Coverity 1455380)

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1318,6 +1318,8 @@ void bgp_attr_add_gshut_community(struct attr *attr)
 	old = attr->community;
 	gshut = community_str2com("graceful-shutdown");
 
+	assert(gshut);
+
 	if (old) {
 		merge = community_merge(community_dup(old), gshut);
 


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr