### PR TITLE
Coverity 1399295 out of bounds read

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -799,11 +799,11 @@ static int rip_auth_simple_password(struct rte *rte, struct sockaddr_in *from,
 				    struct interface *ifp)
 {
 	struct rip_interface *ri;
-	char *auth_str = (char *)&rte->prefix;
+	char *auth_str = (char *)rte + offsetof(struct rte, prefix);
 	int i;
 
 	/* reject passwords with zeros in the middle of the string */
-	for (i = strlen(auth_str); i < 16; i++) {
+	for (i = strnlen(auth_str, 16); i < 16; i++) {
 		if (auth_str[i] != '\0')
 			return 0;
 	}


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

I thought about changing the loop for a simpler implementation, but I didn't add the additional because of not being sure of keeping the intended behavior, e.g.

```
        /* reject passwords with zeros in the middle of the string */
        for (i = 0; i < 16; i++) {
                if (auth_str[i] == '\0')
                        return 0;
        }
```

[1] https://scan.coverity.com/projects/freerangerouting-frr