### PR TITLE
Redistribution and some extra developer debug code

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -1109,6 +1109,10 @@ struct stream_fifo *stream_fifo_new(void)
 /* Add new stream to fifo. */
 void stream_fifo_push(struct stream_fifo *fifo, struct stream *s)
 {
+#if defined DEV_BUILD
+	size_t max, curmax;
+#endif
+
 	if (fifo->tail)
 		fifo->tail->next = s;
 	else
@@ -1116,8 +1120,15 @@ void stream_fifo_push(struct stream_fifo *fifo, struct stream *s)
 
 	fifo->tail = s;
 	fifo->tail->next = NULL;
-
+#if !defined DEV_BUILD
 	atomic_fetch_add_explicit(&fifo->count, 1, memory_order_release);
+#else
+	max = atomic_fetch_add_explicit(&fifo->count, 1, memory_order_release);
+	curmax = atomic_load_explicit(&fifo->max_count, memory_order_relaxed);
+	if (max > curmax)
+		atomic_store_explicit(&fifo->max_count, max,
+				      memory_order_relaxed);
+#endif
 }
 
 void stream_fifo_push_safe(struct stream_fifo *fifo, struct stream *s)

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -115,6 +115,9 @@ struct stream_fifo {
 
 	/* number of streams in this fifo */
 	_Atomic size_t count;
+#if defined DEV_BUILD
+	_Atomic size_t max_count;
+#endif
 
 	struct stream *head;
 	struct stream *tail;

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -737,8 +737,6 @@ static void pim_zebra_connected(struct zclient *zclient)
 
 void pim_zebra_init(void)
 {
-	int i;
-
 	/* Socket for receiving updates from Zebra daemon */
 	zclient = zclient_new_notify(master, &zclient_options_default);
 
@@ -754,31 +752,7 @@ void pim_zebra_init(void)
 
 	zclient_init(zclient, ZEBRA_ROUTE_PIM, 0, &pimd_privs);
 	if (PIM_DEBUG_PIM_TRACE) {
-		zlog_info("zclient_init cleared redistribution request");
-	}
-
-	/* Request all redistribution */
-	for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
-		if (i == zclient->redist_default)
-			continue;
-		vrf_bitmap_set(zclient->redist[AFI_IP][i], pimg->vrf_id);
-		;
-		if (PIM_DEBUG_PIM_TRACE) {
-			zlog_debug("%s: requesting redistribution for %s (%i)",
-				   __PRETTY_FUNCTION__, zebra_route_string(i),
-				   i);
-		}
-	}
-
-	/* Request default information */
-	zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_ADD, zclient,
-				     pimg->vrf_id);
-
-	if (PIM_DEBUG_PIM_TRACE) {
-		zlog_info("%s: requesting default information redistribution",
-			  __PRETTY_FUNCTION__);
-
-		zlog_notice("%s: zclient update socket initialized",
+		zlog_notice("%s: zclient socket initialized",
 			    __PRETTY_FUNCTION__);
 	}
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -521,12 +521,31 @@ int zsend_redistribute_route(int cmd, struct zserv *client, struct prefix *p,
 	struct zapi_nexthop *api_nh;
 	struct nexthop *nexthop;
 	int count = 0;
+	afi_t afi;
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = re->vrf_id;
 	api.type = re->type;
 	api.instance = re->instance;
 	api.flags = re->flags;
+
+	afi = family2afi(p->family);
+	switch (afi) {
+	case AFI_IP:
+		if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
+			client->redist_v4_add_cnt++;
+		else
+			client->redist_v4_del_cnt++;
+		break;
+	case AFI_IP6:
+		if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
+			client->redist_v6_add_cnt++;
+		else
+			client->redist_v6_del_cnt++;
+		break;
+	default:
+		break;
+	}
 
 	/* Prefix. */
 	api.prefix = *p;

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -939,6 +939,11 @@ static void zebra_show_client_detail(struct vty *vty, struct zserv *client)
 	vty_out(vty, "MAC-IP add notifications: %d\n", client->macipadd_cnt);
 	vty_out(vty, "MAC-IP delete notifications: %d\n", client->macipdel_cnt);
 
+#if defined DEV_BUILD
+	vty_out(vty, "Input Fifo: %zu:%zu Output Fifo: %zu:%zu\n",
+		client->ibuf_fifo->count, client->ibuf_fifo->max_count,
+		client->obuf_fifo->count, client->obuf_fifo->max_count);
+#endif
 	vty_out(vty, "\n");
 	return;
 }


### PR DESCRIPTION
1) We had lost track of redistribution events somewhere along the way.  Add it back
2) Pim was requesting redistribtution events and completely ignoring the message from zebra, so remove the request
3) Add a bit of code to allow developers to look at the fifo usage for zapi clients.