### PR TITLE
zebra: untrusted array index (2) (Coverity 1470113)

### DIFF
--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -212,7 +212,9 @@ static int zebra_ns_notify_read(struct thread *t)
 			continue;
 		if (event->mask & IN_DELETE)
 			return zebra_ns_delete(event->name);
-		if (&event->name[event->len] >= &buf[sizeof(buf)]) {
+
+		if (offsetof(struct inotify_event, name) + event->len
+		    >= sizeof(buf)) {
 			zlog_err("NS notify read: buffer underflow");
 			break;
 		}


### PR DESCRIPTION
This is a correction over 7f61ea7bd47bfd86a2c873870507281b1837dcdd (PR #2508) in order to avoid the TAINTED_SCALAR Coverity warning (ending in "Untrusted array index read"). This is equivalent to the previous fix, but avoiding pointer arithmetic with tainted variables.
