### PR TITLE
lib: null check (Coverity 1470150)

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -2471,6 +2471,9 @@ void command_setup_early_logging(const char *dest, const char *level)
 	}
 
 	token = strstr(dest, ":");
+	if (token == NULL)
+		return;
+
 	token++;
 
 	set_log_file(NULL, token, zlog_default->default_lvl);


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr