### PR TITLE
5.0: Don't open per vrf sockets when net.ipv4.tcp|udp_l3mdev_accept != 0

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -745,7 +745,7 @@ int bgp_socket(struct bgp *bgp, unsigned short port, const char *address)
 			close(sock);
 	}
 	freeaddrinfo(ainfo_save);
-	if (count == 0) {
+	if (count == 0 && bgp->inst_type != BGP_INSTANCE_TYPE_VRF) {
 		zlog_err(
 			"%s: no usable addresses please check other programs usage of specified port %d",
 			__func__, port);

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -287,6 +287,92 @@ or upper.
   utility.  It contains *ifconfig*, *route*, *netstat*, and other tools.
   `net-tools` may be found at http://www.tazenda.demon.co.uk/phil/net-tools/.
 
+
+Linux sysctl settings and kernel modules
+````````````````````````````````````````
+
+There are several kernel parameters that impact overall operation of FRR when
+using Linux as a router. Generally these parameters should be set in a
+sysctl related configuration file, e.g., :file:`/etc/sysctl.conf` on
+Ubuntu based systems and a new file
+:file:`/etc/sysctl.d/90-routing-sysctl.conf` on Centos based systems.
+Additional kernel modules are also needed to support MPLS forwarding.
+
+:makevar:`IPv4 and IPv6 forwarding`
+   The following are set to enable IP forwarding in the kernel:
+
+   .. code-block:: shell
+
+      net.ipv4.conf.all.forwarding=1
+      net.ipv6.conf.all.forwarding=1
+
+:makevar:`MPLS forwarding`
+   Basic MPLS kernel support was introduced 4.1, additional capability
+   was introduced in 4.3 and 4.5. For some general information on Linux
+   MPLS support see
+   https://www.netdevconf.org/1.1/proceedings/slides/prabhu-mpls-tutorial.pdf.
+   The following modules should be loaded to support MPLS forwarding,
+   and are generally added to a configuration file such as
+   :file:`/etc/modules-load.d/modules.conf`:
+
+   .. code-block:: shell
+
+      # Load MPLS Kernel Modules
+      mpls_router
+      mpls_iptunnel
+
+   The following is an example to enable MPLS forwarding in the kernel:
+
+   .. code-block:: shell
+
+      # Enable MPLS Label processing on all interfaces
+      net.mpls.conf.eth0.input=1
+      net.mpls.conf.eth1.input=1
+      net.mpls.conf.eth2.input=1
+      net.mpls.platform_labels=100000
+
+   Make sure to add a line equal to :file:`net.mpls.conf.<if>.input` for
+   each interface *'<if>'* used with MPLS and to set labels to an
+   appropriate value.
+
+:makevar:`VRF forwarding`
+   General information on Linux VRF support can be found in
+   https://www.kernel.org/doc/Documentation/networking/vrf.txt. Kernel
+   support for VRFs was introduced in 4.3 and improved upon through
+   4.13, which is the version most used in FRR testing (as of June
+   2018).  Additional background on using Linux VRFs and kernel specific
+   features can be found in
+   http://schd.ws/hosted_files/ossna2017/fe/vrf-tutorial-oss.pdf.
+
+   The following impacts how BGP TCP sockets are managed across VRFs:
+
+   .. code-block:: shell
+
+      net.ipv4.tcp_l3mdev_accept=0
+
+   With this setting a BGP TCP socket is opened per VRF.  This setting
+   ensures that other TCP services, such as SSH, provided for non-VRF
+   purposes are blocked from VRF associated Linux interfaces.
+
+   .. code-block:: shell
+
+      net.ipv4.tcp_l3mdev_accept=1
+
+   With this setting a single BGP TCP socket is shared across the
+   system.  This setting exposes any TCP service running on the system,
+   e.g., SSH, to all VRFs.  Generally this setting is not used in
+   environments where VRFs are used to support multiple administrative
+   groups.
+
+   **Important note** as of June 2018, Kernel versions 4.14-4.18 have a
+   known bug where VRF-specific TCP sockets are not properly handled. When
+   running these kernel versions, if unable to establish any VRF BGP
+   adjacencies, either downgrade to 4.13 or set
+   'net.ipv4.tcp_l3mdev_accept=1'. The fix for this issue is planned to be
+   included in future kernel versions so upgrading your kernel may also
+   address this issue.
+
+
 .. _build-the-software:
 
 Build the Software

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -121,10 +121,10 @@ int vrf_switch_to_netns(vrf_id_t vrf_id)
 
 	/* VRF is default VRF. silently ignore */
 	if (!vrf || vrf->vrf_id == VRF_DEFAULT)
-		return 0;
+		return 1;	/* 1 = default */
 	/* VRF has no NETNS backend. silently ignore */
 	if (vrf->data.l.netns_name[0] == '\0')
-		return 0;
+		return 2;	/* 2 = no netns */
 	name = ns_netns_pathname(NULL, vrf->data.l.netns_name);
 	if (debug_vrf)
 		zlog_debug("VRF_SWITCH: %s(%u)", name, vrf->vrf_id);
@@ -505,6 +505,35 @@ void vrf_terminate(void)
 	}
 }
 
+static int vrf_default_accepts_vrf(int type)
+{
+	const char *fname = NULL;
+	char buf[32] = {0x0};
+	int ret = 0;
+	FILE *fd = NULL;
+
+	/*
+	 * TCP & UDP services running in the default VRF context (ie., not bound
+	 * to any VRF device) can work across all VRF domains by enabling the
+	 * tcp_l3mdev_accept and udp_l3mdev_accept sysctl options:
+	 * sysctl -w net.ipv4.tcp_l3mdev_accept=1
+	 * sysctl -w net.ipv4.udp_l3mdev_accept=1
+	 */
+	if (type == SOCK_STREAM)
+		fname = "/proc/sys/net/ipv4/tcp_l3mdev_accept";
+	else if (type == SOCK_DGRAM)
+		fname = "/proc/sys/net/ipv4/udp_l3mdev_accept";
+	else
+		return ret;
+	fd = fopen(fname, "r");
+	if (fd == NULL)
+		return ret;
+	fgets(buf, 32, fd);
+	ret = atoi(buf);
+	fclose(fd);
+	return ret;
+}
+
 /* Create a socket for the VRF. */
 int vrf_socket(int domain, int type, int protocol, vrf_id_t vrf_id,
 	       char *interfacename)
@@ -515,6 +544,12 @@ int vrf_socket(int domain, int type, int protocol, vrf_id_t vrf_id,
 	if (ret < 0)
 		zlog_err("%s: Can't switch to VRF %u (%s)", __func__, vrf_id,
 			 safe_strerror(errno));
+	if (ret > 0 && interfacename && vrf_default_accepts_vrf(type)) {
+		zlog_err("VRF socket not used since net.ipv4.%s_l3mdev_accept != 0",
+			  (type == SOCK_STREAM ? "tcp" : "udp"));
+		errno = EEXIST; /* not sure if this is the best error... */
+		return -2;
+	}
 	ret = socket(domain, type, protocol);
 	save_errno = errno;
 	ret2 = vrf_switchback_to_initial();


### PR DESCRIPTION
5.0 version of #2475 

per vrf TCP and UPD sockets not needed when kernel is configured to allow default vrf to accept incoming vrf sockets. Setting net.ipv4.tcp_l3mdev_accept=1 is a work around to kernel bug discussed in #2460 . (Setting net.ipv4.tcp_l3mdev_accept=1 all the time is not acceptable in may environments as having vrf's being able reach the default instance is considered security hole in many VRF environments.)