### PR TITLE
ospfd: out-of-bounds access (Coverity 1399304 1399286)

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8166,6 +8166,11 @@ DEFUN (ospf_redistribute_instance_source,
 
 	source = proto_redistnum(AFI_IP, argv[idx_ospf_table]->text);
 
+	if (source < 0) {
+		vty_out(vty, "Unknown instance redistribution\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
 	instance = strtoul(argv[idx_number]->arg, NULL, 10);
 
 	if ((source == ZEBRA_ROUTE_OSPF) && !ospf->instance) {


### PR DESCRIPTION
At first glance, an evident correction, but please check the added vty message (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr