### PR TITLE
pimd: untrusted argument (2) (Coverity 1465491)

### DIFF
--- a/pimd/mtracebis.c
+++ b/pimd/mtracebis.c
@@ -303,6 +303,9 @@ static int recv_response(int fd, int *hops, struct igmp_mtrace *mtracer)
 	if (mtrace_len < (int)MTRACE_HDR_SIZE)
 		return -1;
 
+	if (mtrace_len > (int)MTRACE_BUF_LEN)
+		return -1;
+
 	sum = mtrace->checksum;
 	mtrace->checksum = 0;
 	if (sum != in_cksum(mtrace, mtrace_len)) {


### PR DESCRIPTION
Additional fix over 18e994a0437cfba9f4c09bd62293e13e49ea774b (PR #2457)

Previous correction was not enough for fixing the Coverity warning. Now we
ensure we don't overflow the output buffer (in previous commit we checked the reception buffer).

Signed-off-by: F. Aragon <paco@voltanet.io>