### PR TITLE
eigrpd ospfd: null check (Coverity 1458168 1455335)

### DIFF
--- a/eigrpd/eigrp_topology.c
+++ b/eigrpd/eigrp_topology.c
@@ -448,6 +448,8 @@ void eigrp_topology_update_node_flags(struct eigrp_prefix_entry *dest)
 	struct eigrp_nexthop_entry *entry;
 	struct eigrp *eigrp = eigrp_lookup();
 
+	assert(eigrp);
+
 	for (ALL_LIST_ELEMENTS_RO(dest->entries, node, entry)) {
 		if (entry->reported_distance < dest->fdistance) {
 			// is feasible successor, can be successor

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -243,13 +243,14 @@ static struct ospf *ospf_new(unsigned short instance, const char *name)
 			zlog_debug(
 				"%s: Create new ospf instance with vrf_name %s vrf_id %u",
 				__PRETTY_FUNCTION__, name, new->vrf_id);
-		if (vrf)
-			ospf_vrf_link(new, vrf);
 	} else {
 		new->vrf_id = VRF_DEFAULT;
 		vrf = vrf_lookup_by_id(VRF_DEFAULT);
-		ospf_vrf_link(new, vrf);
 	}
+
+	if (vrf)
+		ospf_vrf_link(new, vrf);
+
 	ospf_zebra_vrf_register(new);
 
 	new->abr_type = OSPF_ABR_DEFAULT;


### PR DESCRIPTION
At first glance, evident corrections (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr