### PR TITLE
lib: check return value (Coverity 1453456)

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -846,7 +846,9 @@ static int frr_daemon_ctl(struct thread *t)
 	switch (buf[0]) {
 	case 'S': /* SIGTSTP */
 		vty_stdio_suspend();
-		send(daemon_ctl_sock, "s", 1, 0);
+		if (send(daemon_ctl_sock, "s", 1, 0) < 0)
+			zlog_err("%s send(\"s\") error (SIGTSTP propagation)",
+				 (di && di->name ? di->name : ""));
 		break;
 	case 'R': /* SIGTCNT [implicit] */
 		vty_stdio_resume();


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr