### PR TITLE
pimd: return check (Coverity 1465490)

### DIFF
--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -817,7 +817,7 @@ int igmp_mtrace_recv_qry_req(struct igmp_sock *igmp, struct ip *ip_hdr,
 		 * Previous-hop router not known,
 		 * packet is sent to an appropriate multicast address
 		 */
-		inet_aton(MCAST_ALL_ROUTERS, &nh_addr);
+		(void)inet_aton(MCAST_ALL_ROUTERS, &nh_addr);
 	}
 
 	/* 6.2.2 8. If this router is the Rendez-vous Point */


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

Unless someone intentionally changes MCAST_ALL_ROUTERS ("224.0.0.2") with a wrong IP, this should never fail, so the fix is using "(void)" at the left of the function call, as an explicit way of indicating we discard the return value on purpose.

[1] https://scan.coverity.com/projects/freerangerouting-frr