### PR TITLE
lib ospfd: dead code (Coverity 1302503 1302502)

### DIFF
--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -52,6 +52,7 @@ struct list {
 };
 
 #define listnextnode(X) ((X) ? ((X)->next) : NULL)
+#define listnextnode_unchecked(X) ((X)->next)
 #define listhead(X) ((X) ? ((X)->head) : NULL)
 #define listtail(X) ((X) ? ((X)->tail) : NULL)
 #define listcount(X) ((X)->count)

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -582,7 +582,7 @@ static int ospf_ase_route_match_same(struct route_table *rt,
 
 	/* Check each path. */
 	for (n1 = listhead(or->paths), n2 = listhead(newor->paths); n1 && n2;
-	     n1 = listnextnode(n1), n2 = listnextnode(n2)) {
+	     n1 = listnextnode_unchecked(n1), n2 = listnextnode_unchecked(n2)) {
 		op = listgetdata(n1);
 		newop = listgetdata(n2);
 

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -170,8 +170,8 @@ int ospf_route_match_same(struct route_table *rt, struct prefix_ipv4 *prefix,
 			/* Check each path. */
 			for (n1 = listhead(or->paths),
 			    n2 = listhead(newor->paths);
-			     n1 && n2;
-			     n1 = listnextnode(n1), n2 = listnextnode(n2)) {
+			     n1 && n2; n1 = listnextnode_unchecked(n1),
+			    n2 = listnextnode_unchecked(n2)) {
 				op = listgetdata(n1);
 				newop = listgetdata(n2);
 


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

I've used clang-format-5.0 for formatting the for(). The style is not like before to the change, though. If you prefer the previous style I could change it, no problem.

[1] https://scan.coverity.com/projects/freerangerouting-frr