### PR TITLE
lib ospf6d: dead code (Coverity 1399231)

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -161,9 +161,10 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 	    && route->type != OSPF6_DEST_TYPE_RANGE
 	    && ((route->type != OSPF6_DEST_TYPE_ROUTER)
 		|| !CHECK_FLAG(route->path.router_bits, OSPF6_ROUTER_BIT_E))) {
-		if (is_debug)
-			zlog_debug(
-				"Route type is none of network, range nor ASBR, ignore");
+#if 0
+		zlog_debug(
+			"Route type is none of network, range nor ASBR, ignore");
+#endif
 		return 0;
 	}
 
@@ -177,16 +178,17 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 
 	/* do not generate if the path's area is the same as target area */
 	if (route->path.area_id == area->area_id) {
-		if (is_debug)
-			zlog_debug("The route is in the area itself, ignore");
+#if 0
+		zlog_debug("The route is in the area itself, ignore");
+#endif
 		return 0;
 	}
 
 	/* do not generate if the nexthops belongs to the target area */
 	if (ospf6_abr_nexthops_belong_to_area(route, area)) {
-		if (is_debug)
-			zlog_debug(
-				"The route's nexthop is in the same area, ignore");
+#if 0
+		zlog_debug("The route's nexthop is in the same area, ignore");
+#endif
 		return 0;
 	}
 


### PR DESCRIPTION
Dead code disabled, keeping the previous behavior.
