### PR TITLE
lib zebra: str-z check (2) (Coverity 1465494)

### DIFF
--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -218,6 +218,12 @@ static int zebra_ns_notify_read(struct thread *t)
 			zlog_err("NS notify read: buffer underflow");
 			break;
 		}
+
+		if (strnlen(event->name, event->len) == event->len) {
+			zlog_err("NS notify error: bad event name");
+			break;
+		}
+
 		netnspath = ns_netns_pathname(NULL, event->name);
 		if (!netnspath)
 			continue;


### PR DESCRIPTION
This is an additional correction after  45981fda0634f7277c27c2a55e30d7f3433ffa16 / PR #2462. I hope this fixes the Coverity warning (I've added an additional check for ensuring the string provided by the inotify read is zero-terminated).

[1] https://scan.coverity.com/projects/freerangerouting-frr