### PR TITLE
ospf6d: null check (Coverity 23024)

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -641,6 +641,11 @@ void ospf6_abr_originate_summary(struct ospf6_route *route)
 
 	if (route->type == OSPF6_DEST_TYPE_NETWORK) {
 		oa = ospf6_area_lookup(route->path.area_id, ospf6);
+		if (!oa) {
+			zlog_err("OSPFv6 area lookup failed");
+			return;
+		}
+
 		range = ospf6_route_lookup_bestmatch(&route->prefix,
 						     oa->range_table);
 		if (range) {


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr