### PR TITLE
lib: null check (2) (Coverity 1451361)

### DIFF
--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -608,12 +608,14 @@ static struct cmd_token *disambiguate_tokens(struct cmd_token *first,
 static struct list *disambiguate(struct list *first, struct list *second,
 				 vector vline, unsigned int n)
 {
+	assert(first != NULL);
+	assert(second != NULL);
 	// doesn't make sense for these to be inequal length
-	assert(first && second);
 	assert(first->count == second->count);
 	assert(first->count == vector_active(vline) - n + 1);
 
-	struct listnode *fnode = listhead(first), *snode = listhead(second);
+	struct listnode *fnode = listhead_unchecked(first),
+			*snode = listhead_unchecked(second);
 	struct cmd_token *ftok = listgetdata(fnode), *stok = listgetdata(snode),
 			 *best = NULL;
 

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -54,6 +54,7 @@ struct list {
 #define listnextnode(X) ((X) ? ((X)->next) : NULL)
 #define listnextnode_unchecked(X) ((X)->next)
 #define listhead(X) ((X) ? ((X)->head) : NULL)
+#define listhead_unchecked(X) ((X)->head)
 #define listtail(X) ((X) ? ((X)->tail) : NULL)
 #define listcount(X) ((X)->count)
 #define list_isempty(X) ((X)->head == NULL && (X)->tail == NULL)


### PR DESCRIPTION
Additional correction to fa3016309b33395c02cf10e7e198517c5b81e55a (PR #2507)
