### PR TITLE
lib: untrusted argument (Coverity 1448386)

### DIFF
--- a/lib/clippy.c
+++ b/lib/clippy.c
@@ -31,9 +31,11 @@
 #define pychar wchar_t
 static wchar_t *wconv(const char *s)
 {
-	size_t outlen = mbstowcs(NULL, s, 0);
+	size_t outlen = s ? mbstowcs(NULL, s, 0) : 0;
 	wchar_t *out = malloc((outlen + 1) * sizeof(wchar_t));
-	mbstowcs(out, s, outlen + 1);
+
+	if (outlen > 0)
+		mbstowcs(out, s, outlen);
 	out[outlen] = 0;
 	return out;
 }


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr