### PR TITLE
bgpd: return value (Coverity 1399203)

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -80,8 +80,9 @@ void bgp_capability_vty_out(struct vty *vty, struct peer *peer,
 			afi_t afi;
 			safi_t safi;
 
-			bgp_map_afi_safi_iana2int(ntohs(mpc.afi), mpc.safi,
-						  &afi, &safi);
+			(void)bgp_map_afi_safi_iana2int(ntohs(mpc.afi),
+							mpc.safi, &afi, &safi);
+
 			if (use_json) {
 				switch (afi) {
 				case AFI_IP:


### PR DESCRIPTION
The return value can be ignored because in case of error both the 'afi'
and 'safi' variables are set to the invalid values (AFI_MAX, SAFI_MAX),
and the invalid values are handled properly afterwards in the 'default'
blocks.

Signed-off-by: F. Aragon <paco@voltanet.io>