### PR TITLE
bgpd: copy-paste error (Coverity 1399202)

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7072,7 +7072,7 @@ static int bgp_clear_prefix(struct vty *vty, const char *view_name,
 				    != NULL) {
 					if (rm->p.prefixlen
 					    == match.prefixlen) {
-						SET_FLAG(rn->flags,
+						SET_FLAG(rm->flags,
 							 BGP_NODE_USER_CLEAR);
 						bgp_process(bgp, rm, afi, safi);
 					}


### PR DESCRIPTION
At first glance, an evident correction, but please review it carefully (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr