### PR TITLE
bgpd: dead code (Coverity 1399377)

### DIFF
--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -3021,9 +3021,9 @@ static int rfapiDeleteLocalPrefixesByRFD(struct rfapi_local_reg_delete_arg *cda,
 		 * match un, vn addresses of NVEs
 		 */
 		if (pUn && (rfapi_ip_addr_cmp(pUn, &rfd->un_addr)))
-			continue;
+			break;
 		if (pVn && (rfapi_ip_addr_cmp(pVn, &rfd->vn_addr)))
-			continue;
+			break;
 
 #if DEBUG_L2_EXTRA
 		vnc_zlog_debug_verbose("%s: un, vn match", __func__);


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

Replacing "continue" with "break" because the loop is a "while (0)"

[1] https://scan.coverity.com/projects/freerangerouting-frr