### PR TITLE
bgpd: null check (Coverity 1453455)

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2733,9 +2733,8 @@ int peer_group_bind(struct bgp *bgp, union sockunion *su, struct peer *peer,
 		if (peer->group) {
 			assert(group && peer->group == group);
 		} else {
-			struct listnode *pn;
-			pn = listnode_lookup(bgp->peer, peer);
-			list_delete_node(bgp->peer, pn);
+			listnode_delete(bgp->peer, peer);
+
 			peer->group = group;
 			listnode_add_sort(bgp->peer, peer);
 

--- a/lib/linklist.c
+++ b/lib/linklist.c
@@ -186,26 +186,10 @@ void listnode_move_to_tail(struct list *l, struct listnode *n)
 
 void listnode_delete(struct list *list, void *val)
 {
-	struct listnode *node;
+	struct listnode *node = listnode_lookup(list, val);
 
-	assert(list);
-	for (node = list->head; node; node = node->next) {
-		if (node->data == val) {
-			if (node->prev)
-				node->prev->next = node->next;
-			else
-				list->head = node->next;
-
-			if (node->next)
-				node->next->prev = node->prev;
-			else
-				list->tail = node->prev;
-
-			list->count--;
-			listnode_free(node);
-			return;
-		}
-	}
+	if (node)
+		list_delete_node(list, node);
 }
 
 void *listnode_head(struct list *list)


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr