### PR TITLE
isisd: return check (Coverity 1424370)

### DIFF
--- a/isisd/isis_pfpacket.c
+++ b/isisd/isis_pfpacket.c
@@ -309,9 +309,9 @@ int isis_recv_pdu_p2p(struct isis_circuit *circuit, uint8_t *ssnpa)
 	addr_len = sizeof(s_addr);
 
 	/* we can read directly to the stream */
-	stream_recvfrom(circuit->rcv_stream, circuit->fd,
-			circuit->interface->mtu, 0, (struct sockaddr *)&s_addr,
-			(socklen_t *)&addr_len);
+	(void)stream_recvfrom(
+		circuit->rcv_stream, circuit->fd, circuit->interface->mtu, 0,
+		(struct sockaddr *)&s_addr, (socklen_t *)&addr_len);
 
 	if (s_addr.sll_pkttype == PACKET_OUTGOING) {
 		/*  Read the packet into discard buff */


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

Added a (void) so Coverity understands we want to ignore the warning. Maybe you want to check if there is some case where it could be convenient to handle errors in that call? (I guess it makes sense to ignore the errors because the stream could hold data from previous calls)

[1] https://scan.coverity.com/projects/freerangerouting-frr