### PR TITLE
isisd: null check (Coverity 1424529)

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1052,6 +1052,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 					uint8_t subtlv_len;
 
 					if (IS_MPLS_TE(isisMplsTE)
+					    && circuit->interface != NULL
 					    && HAS_LINK_PARAMS(
 						       circuit->interface))
 						/* Update Local and Remote IP


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr