### PR TITLE
bgpd: Remove HAVE_CUMULUS from evpn commands

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4242,6 +4242,7 @@ void bgp_evpn_unconfigure_import_rt_for_vrf(struct bgp *bgp_vrf,
 	if (node_to_del)
 		list_delete_node(bgp_vrf->vrf_import_rtl, node_to_del);
 
+	assert(bgp_vrf->vrf_import_rtl);
 	/* fallback to auto import rt, if this was the last RT */
 	if (list_isempty(bgp_vrf->vrf_import_rtl)) {
 		UNSET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_IMPORT_RT_CFGD);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -52,7 +52,6 @@ struct vni_walk_ctx {
 	json_object *json;
 };
 
-#if defined(HAVE_CUMULUS)
 static void display_vrf_import_rt(struct vty *vty, struct vrf_irt_node *irt,
 				  json_object *json)
 {
@@ -980,7 +979,6 @@ static void show_vni_entry(struct hash_backet *backet, void *args[])
 		vty_out(vty, "\n");
 	}
 }
-#endif /* HAVE_CUMULUS */
 
 static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 				 enum bgp_show_type type, void *output_arg,
@@ -1635,8 +1633,6 @@ DEFUN(no_evpnrt5_network,
 		BGP_EVPN_IP_PREFIX_ROUTE, argv[idx_esi]->arg,
 		argv[idx_gwip]->arg, argv[idx_ethtag]->arg);
 }
-
-#if defined(HAVE_CUMULUS)
 
 static void evpn_import_rt_delete_auto(struct bgp *bgp, struct bgpevpn *vpn)
 {
@@ -2752,7 +2748,6 @@ static void evpn_unset_advertise_autort_rfc8365(struct bgp *bgp)
 	bgp->advertise_autort_rfc8365 = 0;
 	bgp_evpn_handle_autort_change(bgp);
 }
-#endif /* HAVE_CUMULUS */
 
 static void write_vni_config(struct vty *vty, struct bgpevpn *vpn)
 {
@@ -2799,7 +2794,6 @@ static void write_vni_config(struct vty *vty, struct bgpevpn *vpn)
 	}
 }
 
-#if defined(HAVE_CUMULUS)
 DEFUN (bgp_evpn_advertise_default_gw_vni,
        bgp_evpn_advertise_default_gw_vni_cmd,
        "advertise-default-gw",
@@ -3904,7 +3898,6 @@ DEFUN(show_bgp_l2vpn_evpn_import_rt,
 	return CMD_SUCCESS;
 }
 
-#if defined(HAVE_CUMULUS)
 DEFUN(test_adv_evpn_type4_route,
       test_adv_evpn_type4_route_cmd,
       "advertise es ESI",
@@ -4064,7 +4057,6 @@ ALIAS_HIDDEN(show_bgp_l2vpn_evpn_route_vni_all, show_bgp_evpn_route_vni_all_cmd,
 ALIAS_HIDDEN(show_bgp_l2vpn_evpn_import_rt, show_bgp_evpn_import_rt_cmd,
 	     "show bgp evpn import-rt",
 	     SHOW_STR BGP_STR EVPN_HELP_STR "Show import route target\n")
-#endif
 
 DEFUN_NOSH (bgp_evpn_vni,
             bgp_evpn_vni_cmd,
@@ -4841,7 +4833,6 @@ DEFUN (no_bgp_evpn_vni_rt_without_val,
 		evpn_unconfigure_export_rt(bgp, vpn, NULL);
 	return CMD_SUCCESS;
 }
-#endif
 
 static int vni_cmp(const void **a, const void **b)
 {
@@ -4961,7 +4952,6 @@ void bgp_ethernetvpn_init(void)
 	install_element(VIEW_NODE, &show_ip_bgp_l2vpn_evpn_all_overlay_cmd);
 	install_element(BGP_EVPN_NODE, &no_evpnrt5_network_cmd);
 	install_element(BGP_EVPN_NODE, &evpnrt5_network_cmd);
-#if defined(HAVE_CUMULUS)
 	install_element(BGP_EVPN_NODE, &bgp_evpn_advertise_all_vni_cmd);
 	install_element(BGP_EVPN_NODE, &no_bgp_evpn_advertise_all_vni_cmd);
 	install_element(BGP_EVPN_NODE, &bgp_evpn_advertise_autort_rfc8365_cmd);
@@ -5027,5 +5017,4 @@ void bgp_ethernetvpn_init(void)
 	install_element(BGP_EVPN_VNI_NODE, &bgp_evpn_advertise_vni_subnet_cmd);
 	install_element(BGP_EVPN_VNI_NODE,
 			&no_bgp_evpn_advertise_vni_subnet_cmd);
-#endif
 }

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3256,10 +3256,11 @@ DEFUN(show_bgp_l2vpn_evpn_es,
 {
 	int idx = 0;
 	uint8_t uj = 0;
-	esi_t esi = {0};
+	esi_t esi;
 	json_object *json = NULL;
 	struct bgp *bgp = NULL;
 
+	memset(&esi, 0, sizeof(esi));
 	uj = use_json(argc, argv);
 
 	bgp = bgp_get_default();
@@ -3541,10 +3542,11 @@ DEFUN(show_bgp_l2vpn_evpn_route_esi,
       JSON_STR)
 {
 	int uj = 0;
-	esi_t esi = {0};
+	esi_t esi;
 	struct bgp *bgp = NULL;
 	json_object *json = NULL;
 
+	memset(&esi, 0, sizeof(esi));
 	bgp = bgp_get_default();
 	if (!bgp)
 		return CMD_WARNING;

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -244,7 +244,7 @@ static void display_import_rt(struct vty *vty, struct irt_node *irt,
 	for (ALL_LIST_ELEMENTS(irt->vnis, node, nnode, tmp_vpn)) {
 		if (json)
 			json_object_array_add(
-				json_vnis, json_object_new_int64(tmp_vpn->vni));
+				json_vnis, json_object_new_int(tmp_vpn->vni));
 		else
 			vty_out(vty, "  %u\n", tmp_vpn->vni);
 	}

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1717,6 +1717,7 @@ static void evpn_unconfigure_import_rt(struct bgp *bgp, struct bgpevpn *vpn,
 			list_delete_node(vpn->import_rtl, node_to_del);
 	}
 
+	assert(vpn->import_rtl);
 	/* Reset to auto RT - this also rebuilds the RT to VNI mapping */
 	if (list_isempty(vpn->import_rtl)) {
 		UNSET_FLAG(vpn->flags, VNI_FLAG_IMPRT_CFGD);
@@ -1784,6 +1785,7 @@ static void evpn_unconfigure_export_rt(struct bgp *bgp, struct bgpevpn *vpn,
 			list_delete_node(vpn->export_rtl, node_to_del);
 	}
 
+	assert(vpn->export_rtl);
 	if (list_isempty(vpn->export_rtl)) {
 		UNSET_FLAG(vpn->flags, VNI_FLAG_EXPRT_CFGD);
 		bgp_evpn_derive_auto_rt_export(bgp, vpn);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8010,10 +8010,9 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 		if (binfo->extra && binfo->extra->damp_info)
 			bgp_damp_info_vty(vty, binfo, json_path);
 
-/* Remote Label */
+		/* Remote Label */
 		if (binfo->extra && bgp_is_valid_label(&binfo->extra->label[0])
-		    && safi != SAFI_EVPN)
-		{
+		    && safi != SAFI_EVPN) {
 			mpls_label_t label =
 				label_pton(&binfo->extra->label[0]);
 			if (json_paths)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6282,7 +6282,6 @@ static void route_vty_out_route(struct prefix *p, struct vty *vty,
 		prefix2str(p, buf, PREFIX_STRLEN);
 		len = vty_out(vty, "%s", buf);
 	} else if (p->family == AF_EVPN) {
-#if defined(HAVE_CUMULUS)
 		if (!json)
 			len = vty_out(
 				vty, "%s",
@@ -6290,10 +6289,6 @@ static void route_vty_out_route(struct prefix *p, struct vty *vty,
 						   BUFSIZ));
 		else
 			bgp_evpn_route2json((struct prefix_evpn *)p, json);
-#else
-		prefix2str(p, buf, PREFIX_STRLEN);
-		len = vty_out(vty, "%s", buf);
-#endif
 	} else if (p->family == AF_FLOWSPEC) {
 		route_vty_out_flowspec(vty, p, NULL,
 			       json ?
@@ -7301,9 +7296,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 {
 	char buf[INET6_ADDRSTRLEN];
 	char buf1[BUFSIZ];
-#if defined(HAVE_CUMULUS)
 	char buf2[EVPN_ROUTE_STRLEN];
-#endif
 	struct attr *attr;
 	int sockunion_vty_out(struct vty *, union sockunion *);
 	time_t tbuf;
@@ -7336,7 +7329,6 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 		json_nexthop_global = json_object_new_object();
 	}
 
-#if defined(HAVE_CUMULUS)
 	if (!json_paths && safi == SAFI_EVPN) {
 		char tag_buf[30];
 
@@ -7366,7 +7358,6 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 			}
 		}
 	}
-#endif
 
 	attr = binfo->attr;
 
@@ -8020,12 +8011,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 			bgp_damp_info_vty(vty, binfo, json_path);
 
 /* Remote Label */
-#if defined(HAVE_CUMULUS)
 		if (binfo->extra && bgp_is_valid_label(&binfo->extra->label[0])
 		    && safi != SAFI_EVPN)
-#else
-		if (binfo->extra && bgp_is_valid_label(&binfo->extra->label[0]))
-#endif
 		{
 			mpls_label_t label =
 				label_pton(&binfo->extra->label[0]);
@@ -8597,9 +8584,7 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 	struct listnode *node, *nnode;
 	char buf1[RD_ADDRSTRLEN];
 	char buf2[INET6_ADDRSTRLEN];
-#if defined(HAVE_CUMULUS)
 	char buf3[EVPN_ROUTE_STRLEN];
-#endif
 	char prefix_str[BUFSIZ];
 	int count = 0;
 	int best = 0;
@@ -8626,7 +8611,6 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 			json, "prefix",
 			prefix2str(p, prefix_str, sizeof(prefix_str)));
 	} else {
-#if defined(HAVE_CUMULUS)
 		if (safi == SAFI_EVPN)
 			vty_out(vty, "BGP routing table entry for %s%s%s\n",
 				prd ? prefix_rd2str(prd, buf1, sizeof(buf1))
@@ -8644,29 +8628,10 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 				inet_ntop(p->family, &p->u.prefix, buf2,
 					  INET6_ADDRSTRLEN),
 				p->prefixlen);
-#else
-		if (p->family == AF_ETHERNET)
-			prefix2str(p, buf2, INET6_ADDRSTRLEN);
-		else
-			inet_ntop(p->family, &p->u.prefix, buf2,
-				  INET6_ADDRSTRLEN);
-		vty_out(vty, "BGP routing table entry for %s%s%s/%d\n",
-			((safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP
-			  || safi == SAFI_EVPN)
-				 ? prefix_rd2str(prd, buf1, sizeof(buf1))
-				 : ""),
-			((safi == SAFI_MPLS_VPN) || (safi == SAFI_EVPN)) ? ":"
-									 : "",
-			buf2, p->prefixlen);
-#endif
 
 		if (has_valid_label)
 			vty_out(vty, "Local label: %d\n", label);
-#if defined(HAVE_CUMULUS)
 		if (bgp_labeled_safi(safi) && safi != SAFI_EVPN)
-#else
-		if (bgp_labeled_safi(safi))
-#endif
 			vty_out(vty, "not allocated\n");
 	}
 


### PR DESCRIPTION
In order to make EVPN behavior work without special casing
the code, bring the evpn commands under HAVE_CUMULUS into
the fold.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>