### PR TITLE
nhrpd: uninitialized variable (Clang scan)

### DIFF
--- a/nhrpd/vici.c
+++ b/nhrpd/vici.c
@@ -287,6 +287,7 @@ static void vici_recv_sa(struct vici_conn *vici, struct zbuf *msg, int event)
 	char buf[32];
 	struct handle_sa_ctx ctx = {
 		.event = event,
+		.msgctx.nsections = 0
 	};
 
 	vici_parse_message(vici, msg, parse_sa_message, &ctx.msgctx);


### PR DESCRIPTION
Fixes for:

Logic error | Assigned value is garbage or undefined | nhrpd/vici.c | vici_parse_message | 100 | 203 | [View Report](https://ci1.netdef.org/browse/FRR-FRRPULLREQ-4292/artifact/shared/static_analysis/report-0189ae.html#EndPath)
-- | -- | -- | -- | -- | -- | --
Logic error | Assigned value is garbage or undefined | nhrpd/vici.c | vici_parse_message | 105 | 192 | [View Report](https://ci1.netdef.org/browse/FRR-FRRPULLREQ-4292/artifact/shared/static_analysis/report-8bdc1d.html#EndPath)

