### PR TITLE
isisd zebra: dead code (Clang scan)

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -622,7 +622,7 @@ static const char *lsp_bits2string(uint8_t lsp_bits, char *buf, size_t buf_size)
 	pos += sprintf(pos, "%d/",
 		       ISIS_MASK_LSP_PARTITION_BIT(lsp_bits) ? 1 : 0);
 
-	pos += sprintf(pos, "%d", ISIS_MASK_LSP_OL_BIT(lsp_bits) ? 1 : 0);
+	sprintf(pos, "%d", ISIS_MASK_LSP_OL_BIT(lsp_bits) ? 1 : 0);
 
 	return buf;
 }

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -545,7 +545,6 @@ static void netlink_parse_extended_ack(struct nlmsghdr *h)
 
 		if (off > h->nlmsg_len) {
 			zlog_err("Invalid offset for NLMSGERR_ATTR_OFFS\n");
-			off = 0;
 		} else if (!(h->nlmsg_flags & NLM_F_CAPPED)) {
 			/*
 			 * Header of failed message


### PR DESCRIPTION
Fixes for:

Dead store | Dead assignment | zebra/kernel_netlink.c | netlink_parse_extended_ack | 548 | 1 | [View Report](https://ci1.netdef.org/browse/FRR-FRRPULLREQ-4292/artifact/shared/static_analysis/report-4df356.html#EndPath)
-- | -- | -- | -- | -- | -- | --
Dead store | Dead increment | isisd/isis_lsp.c | lsp_bits2string | 625 | 1 | [View Report](https://ci1.netdef.org/browse/FRR-FRRPULLREQ-4292/artifact/shared/static_analysis/report-747916.html#EndPath)

