### PR TITLE
bgpd isisd: null check (Clang scan)

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4243,7 +4243,7 @@ void bgp_evpn_unconfigure_import_rt_for_vrf(struct bgp *bgp_vrf,
 		list_delete_node(bgp_vrf->vrf_import_rtl, node_to_del);
 
 	/* fallback to auto import rt, if this was the last RT */
-	if (list_isempty(bgp_vrf->vrf_import_rtl)) {
+	if (bgp_vrf->vrf_import_rtl && list_isempty(bgp_vrf->vrf_import_rtl)) {
 		UNSET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_IMPORT_RT_CFGD);
 		evpn_auto_rt_import_add_for_vrf(bgp_vrf);
 	}

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1473,8 +1473,9 @@ static void isis_print_paths(struct vty *vty, struct isis_vertex_queue *queue,
 		vty_out(vty, "%-20s %-12s %-6u ",
 			vid2string(vertex, buff, sizeof(buff)),
 			vtype2string(vertex->type), vertex->d_N);
-		for (unsigned int i = 0; i < MAX(listcount(vertex->Adj_N),
-						 listcount(vertex->parents));
+		for (unsigned int i = 0;
+		     i < MAX(vertex->Adj_N ? listcount(vertex->Adj_N) : 0,
+			     vertex->parents ? listcount(vertex->parents) : 0);
 		     i++) {
 			if (anode) {
 				adj = listgetdata(anode);


### PR DESCRIPTION
Fixes for:


Logic error | Dereference of null pointer | bgpd/bgp_evpn.c | bgp_evpn_unconfigure_import_rt_for_vrf | 4246 | 4 | [View Report](https://ci1.netdef.org/browse/FRR-FRRPULLREQ-4292/artifact/shared/static_analysis/report-bd7e8f.html#EndPath)
-- | -- | -- | -- | -- | -- | --
Logic error | Dereference of null pointer | isisd/isis_spf.c | isis_print_paths | 1476 | 69 | [View Report](https://ci1.netdef.org/browse/FRR-FRRPULLREQ-4292/artifact/shared/static_analysis/report-a0ebed.html#EndPath)
Logic error | Dereference of null pointer | isisd/isis_spf.c | isis_print_paths | 1476 | 69 | [View Report](https://ci1.netdef.org/browse/FRR-FRRPULLREQ-4292/artifact/shared/static_analysis/report-56cdbc.html#EndPath)

The two last lines are repeated because there are two errors of the same type in the same line.
