### PR TITLE
bgpd: fix NULL dereference in vrf-vpn leak config if before default instance

### DIFF
--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -182,6 +182,10 @@ static inline void vpn_leak_prechange(vpn_policy_direction_t direction,
 				      afi_t afi, struct bgp *bgp_vpn,
 				      struct bgp *bgp_vrf)
 {
+	/* Detect when default bgp instance is not (yet) defined by config */
+	if (!bgp_vpn)
+		return;
+
 	if ((direction == BGP_VPN_POLICY_DIR_FROMVPN) &&
 		vpn_leak_from_vpn_active(bgp_vrf, afi, NULL)) {
 
@@ -198,6 +202,10 @@ static inline void vpn_leak_postchange(vpn_policy_direction_t direction,
 				       afi_t afi, struct bgp *bgp_vpn,
 				       struct bgp *bgp_vrf)
 {
+	/* Detect when default bgp instance is not (yet) defined by config */
+	if (!bgp_vpn)
+		return;
+
 	if (direction == BGP_VPN_POLICY_DIR_FROMVPN)
 		vpn_leak_to_vrf_update_all(bgp_vrf, bgp_vpn, afi);
 	if (direction == BGP_VPN_POLICY_DIR_TOVPN) {
@@ -215,5 +223,7 @@ static inline void vpn_leak_postchange(vpn_policy_direction_t direction,
 extern void vpn_policy_routemap_event(const char *rmap_name);
 
 extern vrf_id_t get_first_vrf_for_redirect_with_rt(struct ecommunity *eckey);
+
+extern void vpn_leak_postchange_all(void);
 
 #endif /* _QUAGGA_BGP_MPLSVPN_H */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -928,6 +928,14 @@ DEFUN_NOSH (router_bgp,
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 
+		/*
+		 * If we just instantiated the default instance, complete
+		 * any pending VRF-VPN leaking that was configured via
+		 * earlier "router bgp X vrf FOO" blocks.
+		 */
+		if (inst_type == BGP_INSTANCE_TYPE_DEFAULT)
+			vpn_leak_postchange_all();
+
 		/* Pending: handle when user tries to change a view to vrf n vv.
 		 */
 	}


### PR DESCRIPTION
[I'm particularly soliciting comments on my change in vpn_leak_to_vrf_update_all(). My position is that it is better to assert for programmer error instead of introducing subtle erroneous results which could be difficult to track down. However, I am open to persuasion otherwise. Hoping to get feedback from @pacovn but I don't seem to be able to loop him into this PR discussion via github.]

Issue 2473

VRF-VPN route-leaking configuration commands assumed existence of
default bgp instance. If a non-default vrf configuration occurred
before the default vrf configuration, it would result in a (NULL)
dereference to the non-existent default vrf.

This change 1) detects non-existence of default vrf and skips corresponding
RIB updating that normally occurs during configuration changes of the
route-leaking parameters; and 2) when the default bgp instance is defined,
runs the deferred RIB updating.

In vpn_leak_to_vrf_update_all(), replace early return if bgp_vpn is NULL
with assert, as the former would lead to subtly wrong RIB contents. The
underlying issue that led to commit 73aed5841a1fe31e8a1f251dfcf87e1f2b1f2463
should be fixed by the above changes.