### PR TITLE
zebra: duplicate nexthops for cross-vrf static routes on vrf bounce

### DIFF
--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -134,14 +134,6 @@ static int zebra_vrf_enable(struct vrf *vrf)
 		zvrf->import_check_table[afi] = table;
 	}
 
-	static_fixup_vrf_ids(zvrf);
-
-	/*
-	 * We may have static routes that are now possible to
-	 * insert into the appropriate tables
-	 */
-	static_config_install_delayed_routes(zvrf);
-
 	/* Kick off any VxLAN-EVPN processing. */
 	zebra_vxlan_vrf_enable(zvrf);
 


### PR DESCRIPTION
Problem created by the fix for cm-21306 (inactive cross-vrf static routes
when vrfs were bounced.)  Determined that in another case, that fix would
cause duplicate nexthops to appear in the table. Resolved the problem by
removing the vrf static route process from the zebra "add" process leaving
it in the zebra " if up" process as added in cm-21306 since that's the point
that the vrf device is now functional.

Ticket: CM-21429
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>