### PR TITLE
ospfd zebra: array overrun fixes (PVS-Studio)

### DIFF
--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -91,7 +91,7 @@ struct external_info *ospf_external_info_check(struct ospf *ospf,
 	p.prefix = lsa->data->id;
 	p.prefixlen = ip_masklen(al->mask);
 
-	for (type = 0; type <= ZEBRA_ROUTE_MAX; type++) {
+	for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
 		int redist_on = 0;
 
 		redist_on =

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -274,7 +274,7 @@ void zebra_redistribute_add(ZAPI_HANDLER_ARGS)
 			__func__, zebra_route_string(client->proto), afi,
 			zebra_route_string(type), zvrf_id(zvrf), instance);
 
-	if (afi == 0 || afi > AFI_MAX) {
+	if (afi == 0 || afi >= AFI_MAX) {
 		zlog_warn("%s: Specified afi %d does not exist",
 			  __PRETTY_FUNCTION__, afi);
 		return;
@@ -320,7 +320,7 @@ void zebra_redistribute_delete(ZAPI_HANDLER_ARGS)
 	STREAM_GETC(msg, type);
 	STREAM_GETW(msg, instance);
 
-	if (afi == 0 || afi > AFI_MAX) {
+	if (afi == 0 || afi >= AFI_MAX) {
 		zlog_warn("%s: Specified afi %d does not exist",
 			  __PRETTY_FUNCTION__, afi);
 		return;


### PR DESCRIPTION
At first glance, an evident correction (found using PVS-Studio trial version [1]).

[1] https://www.viva64.com/en/m/0036/#ID0EEEAE
