### PR TITLE
bgpd zebra: element overflow (PVS-Studio)

### DIFF
--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -57,7 +57,7 @@ int bgp_parse_fec_update(void)
 	memset(&p, 0, sizeof(struct prefix));
 	p.family = stream_getw(s);
 	p.prefixlen = stream_getc(s);
-	stream_get(&p.u.prefix, s, PSIZE(p.prefixlen));
+	stream_get(p.u.val, s, PSIZE(p.prefixlen));
 	label = stream_getl(s);
 
 	/* hack for the bgp instance & SAFI = have to send/receive it */

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -220,7 +220,7 @@ int bgp_nlri_parse_vpn(struct peer *peer, struct attr *attr,
 		p.prefixlen =
 			prefixlen
 			- VPN_PREFIXLEN_MIN_BYTES * 8; /* exclude label & RD */
-		memcpy(&p.u.prefix, pnt + VPN_PREFIXLEN_MIN_BYTES,
+		memcpy(p.u.val, pnt + VPN_PREFIXLEN_MIN_BYTES,
 		       psize - VPN_PREFIXLEN_MIN_BYTES);
 
 		if (attr) {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4237,7 +4237,7 @@ int bgp_nlri_parse_ip(struct peer *peer, struct attr *attr,
 		}
 
 		/* Fetch prefix from NLRI packet. */
-		memcpy(&p.u.prefix, pnt, psize);
+		memcpy(p.u.val, pnt, psize);
 
 		/* Check address. */
 		if (afi == AFI_IP && safi == SAFI_UNICAST) {

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -564,7 +564,7 @@ void connected_delete_ipv6(struct interface *ifp, struct in6_addr *address,
 	if (broad) {
 		memset(&d, 0, sizeof(struct prefix));
 		d.family = AF_INET6;
-		IPV6_ADDR_COPY(&d.u.prefix, broad);
+		IPV6_ADDR_COPY(&d.u.prefix6, broad);
 		d.prefixlen = prefixlen;
 		ifc = connected_check_ptp(ifp, &p, &d);
 	} else

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -518,7 +518,7 @@ static void rtadv_process_advert(uint8_t *msg, unsigned int len,
 
 	/* Create entry for neighbor if not known. */
 	p.family = AF_INET6;
-	IPV6_ADDR_COPY(&p.u.prefix, &addr->sin6_addr);
+	IPV6_ADDR_COPY(&p.u.prefix6, &addr->sin6_addr);
 	p.prefixlen = IPV6_MAX_PREFIXLEN;
 
 	if (!nbr_connected_check(ifp, &p))

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -448,7 +448,7 @@ void nbr_connected_add_ipv6(struct interface *ifp, struct in6_addr *address)
 	struct prefix p;
 
 	p.family = AF_INET6;
-	IPV6_ADDR_COPY(&p.u.prefix, address);
+	IPV6_ADDR_COPY(&p.u.prefix6, address);
 	p.prefixlen = IPV6_MAX_PREFIXLEN;
 
 	ifc = listnode_head(ifp->nbr_connected);
@@ -473,7 +473,7 @@ void nbr_connected_delete_ipv6(struct interface *ifp, struct in6_addr *address)
 	struct prefix p;
 
 	p.family = AF_INET6;
-	IPV6_ADDR_COPY(&p.u.prefix, address);
+	IPV6_ADDR_COPY(&p.u.prefix6, address);
 	p.prefixlen = IPV6_MAX_PREFIXLEN;
 
 	ifc = nbr_connected_check(ifp, &p);


### PR DESCRIPTION
The warning given by PVS-Studio is related to per-element overflow (there is
no real overflow, because of how elements are mapped in the union). This
same warning is typically reported by Coverity, too.
