### PR TITLE
nhrpd: uninitialized variable (Clang scan)

### DIFF
--- a/nhrpd/vici.c
+++ b/nhrpd/vici.c
@@ -306,7 +306,7 @@ static void vici_recv_message(struct vici_conn *vici, struct zbuf *msg)
 	uint32_t msglen;
 	uint8_t msgtype;
 	struct blob name;
-	struct vici_message_ctx ctx;
+	struct vici_message_ctx ctx = { .nsections = 0 };
 
 	msglen = zbuf_get_be32(msg);
 	msgtype = zbuf_get8(msg);


### PR DESCRIPTION
Fix over 0a939f4f24fa34fea688482fbf57fb16eaf2a081 (there was a case not
covered by previous fix)
