### PR TITLE
zebra: remove asserts on task nullity

### DIFF
--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -618,14 +618,6 @@ static int zserv_handle_client_close(struct thread *thread)
 {
 	struct zserv *client = THREAD_ARG(thread);
 
-	/*
-	 * Ensure these have been nulled. This does not equate to the
-	 * associated task(s) being scheduled or unscheduled on the client
-	 * pthread's threadmaster.
-	 */
-	assert(!client->t_read);
-	assert(!client->t_write);
-
 	/* synchronously stop thread */
 	frr_pthread_stop(client->pthread, NULL);
 


### PR DESCRIPTION
While ZAPI I/O threads make a best effort to kill any scheduled tasks on
their threadmasters, after death another pthread can continue to
schedule onto the threadmaster. This isn't a problem per se since the
tasks will never run, but it also means that asserting that it hasn't
happened is pointless.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>