### PR TITLE
bgpd: l3vni del to free ip prefix routes from vrf

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5216,7 +5216,7 @@ int bgp_evpn_local_l3vni_add(vni_t l3vni, vrf_id_t vrf_id, struct ethaddr *rmac,
 	struct bgpevpn *vpn = NULL;
 	as_t as = 0;
 
-	/* get the default instamce - required to get the AS number for VRF
+	/* get the default instance - required to get the AS number for VRF
 	 * auto-creatio
 	 */
 	bgp_def = bgp_get_default();
@@ -5319,11 +5319,12 @@ int bgp_evpn_local_l3vni_del(vni_t l3vni, vrf_id_t vrf_id)
 		return -1;
 	}
 
-	/* unimport remote routes from VRF, if it is AUTO vrf bgp_delete will
-	 * take care of uninstalling the routes from zebra
+	/* Remove remote routes from BGT VRF even if BGP_VRF_AUTO is configured,
+	 * bgp_delete would not remove/decrement bgp_info of the ip_prefix
+	 * routes. This will uninstalling the routes from zebra and decremnt the
+	 * bgp info count.
 	 */
-	if (!CHECK_FLAG(bgp_vrf->vrf_flags, BGP_VRF_AUTO))
-		uninstall_routes_for_vrf(bgp_vrf);
+	uninstall_routes_for_vrf(bgp_vrf);
 
 	/* delete/withdraw all type-5 routes */
 	delete_withdraw_vrf_routes(bgp_vrf);


### PR DESCRIPTION
In Symmetric routing case, L3VNI stores evpn MAC_IP routes as IP_PREFIX routes in associated bgp_vrf and fib.

When vxlan device for l3vni goes down, triggers l3vni delete in bgp.
As part l3vni delete, evpn ip prefix routes associated with the vni need to be withdrawn
from zebra as well bgpinfo needs to be freed.
bgp_delete does not free bgp_info associated to evpn ip prefix routes (link to bgp_vrf).
Call to uninstall_evpn_route_entry_in_vrf() properly cleanup bgp_info as well triggers appropriate updates.


Testing Done:
On DUT, bring up symmetric routing configuration, learn EVPN Type-2 and Type-3 Routes.
Type-2 MAC_IP routes will be stored as ip_prefix in vrf table during l3vni bring up.

Remove L3vni, deletes all ip_prefix routes from the zebra, kernel vrf route table and bgp_info is freed.

Check the show bgp memory stats for bgp_info post l3vni flap.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>