### PR TITLE
tests/isisd: bypass test_fuzz_isis_tlv when inet_ntop is broken

### DIFF
--- a/tests/isisd/test_fuzz_isis_tlv.py
+++ b/tests/isisd/test_fuzz_isis_tlv.py
@@ -2,10 +2,21 @@ import frrtest
 
 import pytest
 import platform
+import socket
 
-if platform.uname()[0] == 'SunOS':
+
+##
+# on musl, ntop compresses a single :0: -> :: which is against RFC
+##
+def inet_ntop_broken():
+    addr = '1:2:3:4:0:6:7:8'
+    return socket.inet_ntop(socket.AF_INET6,
+                            socket.inet_pton(socket.AF_INET6, addr)) != addr
+
+
+if platform.uname()[0] == 'SunOS' or inet_ntop_broken():
     class TestFuzzIsisTLV:
-        @pytest.mark.skipif(True, reason='Test unsupported on SunOS')
+        @pytest.mark.skipif(True, reason='Test unsupported')
         def test_exit_cleanly(self):
             pass
 else:


### PR DESCRIPTION
On Alpine Linux edge, musl does not seem to be RFC 5952 4.2.2
compliant (how to print a single :0: in the IPv6 address).  Let's
skip that test, as we get false negatives when running against
that version of musl.

Credit for the idea for the fix and how to fix it is due to
chris@opensourcerouting.org.

NB 5.0:

This cherry-pick from master will simplify frr packaging for alpine

Testing done:

make check on alpine linux passes now

Issue: https://github.com/FRRouting/frr/issues/2375
Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>