### PR TITLE
ldpd: buffer underflow, thread safety (PVS-Studio)

### DIFF
--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -691,7 +691,8 @@ void		 embedscope(struct sockaddr_in6 *);
 void		 recoverscope(struct sockaddr_in6 *);
 void		 addscope(struct sockaddr_in6 *, uint32_t);
 void		 clearscope(struct in6_addr *);
-struct sockaddr	*addr2sa(int af, union ldpd_addr *, uint16_t);
+void		 addr2sa(int af, const union ldpd_addr *, uint16_t,
+		    union sockunion *su);
 void		 sa2addr(struct sockaddr *, int *, union ldpd_addr *,
 		    in_port_t *);
 socklen_t	 sockaddr_len(struct sockaddr *);

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -70,7 +70,7 @@ int
 send_packet(int fd, int af, union ldpd_addr *dst, struct iface_af *ia,
     void *pkt, size_t len)
 {
-	struct sockaddr		*sa;
+	union sockunion su;
 
 	switch (af) {
 	case AF_INET:
@@ -97,10 +97,10 @@ send_packet(int fd, int af, union ldpd_addr *dst, struct iface_af *ia,
 		fatalx("send_packet: unknown af");
 	}
 
-	sa = addr2sa(af, dst, LDP_PORT);
-	if (sendto(fd, pkt, len, 0, sa, sockaddr_len(sa)) == -1) {
+	addr2sa(af, dst, LDP_PORT, &su);
+	if (sendto(fd, pkt, len, 0, &su.sa, sockaddr_len(&su.sa)) == -1) {
 		log_warn("%s: error sending packet to %s", __func__,
-		    log_sockaddr(sa));
+			 log_sockaddr(&su.sa));
 		return (-1);
 	}
 

--- a/ldpd/util.c
+++ b/ldpd/util.c
@@ -305,14 +305,13 @@ clearscope(struct in6_addr *in6)
 	}
 }
 
-struct sockaddr *
-addr2sa(int af, union ldpd_addr *addr, uint16_t port)
+void
+addr2sa(int af, const union ldpd_addr *addr, uint16_t port, union sockunion *su)
 {
-	static struct sockaddr_storage	 ss;
-	struct sockaddr_in		*sa_in = (struct sockaddr_in *)&ss;
-	struct sockaddr_in6		*sa_in6 = (struct sockaddr_in6 *)&ss;
+	struct sockaddr_in		*sa_in = &su->sin;
+	struct sockaddr_in6		*sa_in6 = &su->sin6;
 
-	memset(&ss, 0, sizeof(ss));
+	memset(su, 0, sizeof(*su));
 	switch (af) {
 	case AF_INET:
 		sa_in->sin_family = AF_INET;
@@ -333,8 +332,6 @@ addr2sa(int af, union ldpd_addr *addr, uint16_t port)
 	default:
 		fatalx("addr2sa: unknown af");
 	}
-
-	return ((struct sockaddr *)&ss);
 }
 
 void


### PR DESCRIPTION
This commit fixes two issues:
- memcpy() using containers of different sizes when using addr2sa(), mixing
  'struct sockaddr_storage' and 'union sockunion'.
- addr2sa() function not being thread safe (using a local static variable as
  container.

Signed-off-by: F. Aragon <paco@voltanet.io>