### PR TITLE
lib: add the pathname to get the realpath in case of failure

### DIFF
--- a/lib/netns_linux.c
+++ b/lib/netns_linux.c
@@ -435,10 +435,13 @@ char *ns_netns_pathname(struct vty *vty, const char *name)
 
 	if (!result) {
 		if (vty)
-			vty_out(vty, "Invalid pathname: %s\n",
+			vty_out(vty, "Invalid pathname for %s: %s\n",
+				pathname,
 				safe_strerror(errno));
 		else
-			zlog_warn("Invalid pathname: %s", safe_strerror(errno));
+			zlog_warn("Invalid pathname for %s: %s",
+				  pathname,
+				  safe_strerror(errno));
 		return NULL;
 	}
 	check_base = basename(pathname);


### PR DESCRIPTION
Sometimes, the file under /var/run/netns may not be authorised to be
read ( because it is not read permission for frr user, for instance).
so it is good to know what happened.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>