### PR TITLE
revert hash_walk/iterate optimizations

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -241,21 +241,15 @@ void hash_iterate(struct hash *hash, void (*func)(struct hash_backet *, void *),
 	unsigned int i;
 	struct hash_backet *hb;
 	struct hash_backet *hbnext;
-	uint32_t count = 0;
 
-	for (i = 0; i < hash->size; i++) {
+	for (i = 0; i < hash->size; i++)
 		for (hb = hash->index[i]; hb; hb = hbnext) {
 			/* get pointer to next hash backet here, in case (*func)
 			 * decides to delete hb by calling hash_release
 			 */
 			hbnext = hb->next;
 			(*func)(hb, arg);
-			count++;
-
 		}
-		if (count == hash->count)
-			return;
-	}
 }
 
 void hash_walk(struct hash *hash, int (*func)(struct hash_backet *, void *),
@@ -265,7 +259,6 @@ void hash_walk(struct hash *hash, int (*func)(struct hash_backet *, void *),
 	struct hash_backet *hb;
 	struct hash_backet *hbnext;
 	int ret = HASHWALK_CONTINUE;
-	uint32_t count = 0;
 
 	for (i = 0; i < hash->size; i++) {
 		for (hb = hash->index[i]; hb; hb = hbnext) {
@@ -276,10 +269,7 @@ void hash_walk(struct hash *hash, int (*func)(struct hash_backet *, void *),
 			ret = (*func)(hb, arg);
 			if (ret == HASHWALK_ABORT)
 				return;
-			count++;
 		}
-		if (count == hash->count)
-			return;
 	}
 }
 

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -232,7 +232,9 @@ extern void *hash_release(struct hash *hash, void *data);
  * Iterate over the elements in a hash table.
  *
  * It is safe to delete items passed to the iteration function from the hash
- * table during iteration.
+ * table during iteration.  Please note that adding entries to the hash
+ * during the walk will cause undefined behavior in that some new entries
+ * will be walked and some will not.  So do not do this.
  *
  * hash
  *    hash table to operate on
@@ -250,7 +252,9 @@ extern void hash_iterate(struct hash *hash,
  * Iterate over the elements in a hash table, stopping on condition.
  *
  * It is safe to delete items passed to the iteration function from the hash
- * table during iteration.
+ * table during iteration.  Please note that adding entries to the hash
+ * during the walk will cause undefined behavior in that some new entries
+ * will be walked and some will not.  So do not do this.
  *
  * hash
  *    hash table to operate on

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2144,6 +2144,7 @@ DEFUN (vtysh_show_poll,
        "Thread Poll Information\n")
 {
 	unsigned int i;
+	int idx = 0;
 	int ret = CMD_SUCCESS;
 	char line[100];
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2144,7 +2144,6 @@ DEFUN (vtysh_show_poll,
        "Thread Poll Information\n")
 {
 	unsigned int i;
-	int idx = 0;
 	int ret = CMD_SUCCESS;
 	char line[100];
 


### PR DESCRIPTION
Revert the hash_walk/iterate optimizations as that if the walk/iterate delete an item we will be left in a weird state.  Additionally if the user does something stupid like adding a new item it will cause this function to misbehave even worse.  Update documentation to tell people to not add items during a walk/iterate or you will have undefined behavior