### PR TITLE
Pim neighbor needed

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4252,7 +4252,7 @@ DEFUN (show_ip_pim_nexthop_lookup,
        "Source/RP address\n"
        "Multicast Group address\n")
 {
-	struct pim_nexthop_cache pnc;
+	struct pim_nexthop_cache *pnc = NULL;
 	struct prefix nht_p;
 	int result = 0;
 	struct in_addr src_addr, grp_addr;
@@ -4264,6 +4264,7 @@ DEFUN (show_ip_pim_nexthop_lookup,
 	char grp_str[PREFIX_STRLEN];
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
+	struct pim_rpf rpf;
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -4301,7 +4302,6 @@ DEFUN (show_ip_pim_nexthop_lookup,
 				      grp_addr))
 		return CMD_SUCCESS;
 
-	memset(&pnc, 0, sizeof(struct pim_nexthop_cache));
 	nht_p.family = AF_INET;
 	nht_p.prefixlen = IPV4_MAX_BITLEN;
 	nht_p.u.prefix4 = vif_source;
@@ -4310,8 +4310,14 @@ DEFUN (show_ip_pim_nexthop_lookup,
 	grp.u.prefix4 = grp_addr;
 	memset(&nexthop, 0, sizeof(nexthop));
 
-	if (pim_find_or_track_nexthop(vrf->info, &nht_p, NULL, NULL, &pnc))
-		result = pim_ecmp_nexthop_search(vrf->info, &pnc, &nexthop,
+	memset(&rpf, 0, sizeof(struct pim_rpf));
+	rpf.rpf_addr.family = AF_INET;
+	rpf.rpf_addr.prefixlen = IPV4_MAX_BITLEN;
+	rpf.rpf_addr.u.prefix4 = vif_source;
+
+	pnc = pim_nexthop_cache_find(vrf->info, &rpf);
+	if (pnc)
+		result = pim_ecmp_nexthop_search(vrf->info, pnc, &nexthop,
 						 &nht_p, &grp, 0);
 	else
 		result = pim_ecmp_nexthop_lookup(vrf->info, &nexthop,

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -203,6 +203,7 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	struct prefix nht_p;
 	struct pim_nexthop_cache pnc;
 	struct prefix src, grp;
+	bool neigh_needed = true;
 
 	saved.source_nexthop = rpf->source_nexthop;
 	saved.rpf_addr = rpf->rpf_addr;
@@ -226,23 +227,21 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	grp.prefixlen = IPV4_MAX_BITLEN;
 	grp.u.prefix4 = up->sg.grp;
 	memset(&pnc, 0, sizeof(struct pim_nexthop_cache));
+
+	if ((up->sg.src.s_addr == INADDR_ANY && I_am_RP(pim, up->sg.grp)) ||
+	    PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
+		neigh_needed = FALSE;
 	if (pim_find_or_track_nexthop(pim, &nht_p, up, NULL, &pnc)) {
 		if (pnc.nexthop_num) {
-			if (!pim_ecmp_nexthop_search(
-				    pim, &pnc, &up->rpf.source_nexthop, &src,
-				    &grp,
-				    !PIM_UPSTREAM_FLAG_TEST_FHR(up->flags)
-					    && !PIM_UPSTREAM_FLAG_TEST_SRC_IGMP(
-						       up->flags)))
+			if (!pim_ecmp_nexthop_search(pim, &pnc,
+						     &up->rpf.source_nexthop,
+						     &src, &grp, neigh_needed))
 				return PIM_RPF_FAILURE;
 		}
 	} else {
-		if (!pim_ecmp_nexthop_lookup(
-			    pim, &rpf->source_nexthop, up->upstream_addr, &src,
-			    &grp,
-			    !PIM_UPSTREAM_FLAG_TEST_FHR(up->flags)
-				    && !PIM_UPSTREAM_FLAG_TEST_SRC_IGMP(
-					       up->flags)))
+		if (!pim_ecmp_nexthop_lookup(pim, &rpf->source_nexthop,
+					     up->upstream_addr, &src,
+					     &grp, neigh_needed))
 			return PIM_RPF_FAILURE;
 	}
 


### PR DESCRIPTION
When figuring out what ecmp paths to use for RPF decisions, Try to be more specific about what RPF lookups need pim neighbors or not.  Additionally when figuring out a ecmp path, only allow selection over those ecmp paths that actually have a pim neighbor.