### PR TITLE
bgpd: Cleanup of bgp daemon code

### DIFF
--- a/bgpd/IMPLEMENTATION.txt
+++ b/bgpd/IMPLEMENTATION.txt
@@ -131,7 +131,6 @@ bgpd.h
   struct peer_group
   struct bgp_notify: (in-core representation of wire format?)
   struct bgp_nexthop: (v4 and v6 addresses, *ifp)
-  struct bgp_rd: router distinguisher: 8 octects
   struct bgp_filter: distribute, prefix, aslist, route_maps
   struct peer: neighbor structure (very rich/complex)
   struct bgp_nlri: reference to wire format

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -274,8 +274,7 @@ static void community_list_entry_add(struct community_list *list,
 
 /* Delete community-list entry from the list.  */
 static void community_list_entry_delete(struct community_list *list,
-					struct community_entry *entry,
-					int style)
+					struct community_entry *entry)
 {
 	if (entry->next)
 		entry->next->prev = entry->prev;
@@ -882,7 +881,7 @@ int community_list_unset(struct community_list_handler *ch, const char *name,
 	if (!entry)
 		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
 
-	community_list_entry_delete(list, entry, style);
+	community_list_entry_delete(list, entry);
 	route_map_notify_dependencies(name, RMAP_EVENT_CLIST_DELETED);
 
 	return 0;
@@ -1040,7 +1039,7 @@ int lcommunity_list_unset(struct community_list_handler *ch, const char *name,
 	if (!entry)
 		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
 
-	community_list_entry_delete(list, entry, style);
+	community_list_entry_delete(list, entry);
 
 	return 0;
 }
@@ -1056,8 +1055,6 @@ int extcommunity_list_set(struct community_list_handler *ch, const char *name,
 
 	if (str == NULL)
 		return COMMUNITY_LIST_ERR_MALFORMED_VAL;
-
-	entry = NULL;
 
 	/* Get community list. */
 	list = community_list_get(ch, name, EXTCOMMUNITY_LIST_MASTER);
@@ -1149,7 +1146,7 @@ int extcommunity_list_unset(struct community_list_handler *ch, const char *name,
 	if (!entry)
 		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
 
-	community_list_entry_delete(list, entry, style);
+	community_list_entry_delete(list, entry);
 	route_map_notify_dependencies(name, RMAP_EVENT_ECLIST_DELETED);
 
 	return 0;

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -65,7 +65,6 @@ void ecommunity_free(struct ecommunity **ecom)
 	if ((*ecom)->str)
 		XFREE(MTYPE_ECOMMUNITY_STR, (*ecom)->str);
 	XFREE(MTYPE_ECOMMUNITY, *ecom);
-	ecom = NULL;
 }
 
 static void ecommunity_hash_free(struct ecommunity *ecom)

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4639,7 +4639,6 @@ int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 	int addpath_encoded;
 	int psize = 0;
 	uint8_t rtype;
-	uint8_t rlen;
 	struct prefix p;
 
 	/* Start processing the NLRI - there may be multiple in the MP_REACH */
@@ -4673,7 +4672,7 @@ int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 			return -1;
 
 		rtype = *pnt++;
-		psize = rlen = *pnt++;
+		psize = *pnt++;
 
 		/* When packet overflow occur return immediately. */
 		if (pnt + psize > lim)

--- a/bgpd/bgp_flowspec.c
+++ b/bgpd/bgp_flowspec.c
@@ -91,7 +91,6 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 	afi_t afi;
 	safi_t safi;
 	int psize = 0;
-	uint8_t rlen;
 	struct prefix p;
 	int ret;
 	void *temp;
@@ -121,7 +120,7 @@ int bgp_nlri_parse_flowspec(struct peer *peer, struct attr *attr,
 		if (pnt + 1 > lim)
 			return -1;
 
-		psize = rlen = *pnt++;
+		psize = *pnt++;
 
 		/* When packet overflow occur return immediately. */
 		if (pnt + psize > lim) {

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -50,7 +50,6 @@ void lcommunity_free(struct lcommunity **lcom)
 	if ((*lcom)->str)
 		XFREE(MTYPE_LCOMMUNITY_STR, (*lcom)->str);
 	XFREE(MTYPE_LCOMMUNITY, *lcom);
-	lcom = NULL;
 }
 
 static void lcommunity_hash_free(struct lcommunity *lcom)

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -447,8 +447,6 @@ int bgp_subgrp_multiaccess_check_v4(struct in_addr nexthop,
 	p.family = AF_INET;
 	p.prefixlen = IPV4_MAX_BITLEN;
 
-	rn2 = NULL;
-
 	bgp = SUBGRP_INST(subgrp);
 	rn1 = bgp_node_match(bgp->connected_table[AFI_IP], &np);
 	if (!rn1)

--- a/bgpd/bgp_open.h
+++ b/bgpd/bgp_open.h
@@ -34,19 +34,10 @@ struct capability_mp_data {
 	uint8_t safi; /* iana_safi_t */
 };
 
-struct capability_as4 {
-	uint32_t as4;
-};
-
 struct graceful_restart_af {
 	afi_t afi;
 	safi_t safi;
 	uint8_t flag;
-};
-
-struct capability_gr {
-	uint16_t restart_flag_time;
-	struct graceful_restart_af gr[];
 };
 
 /* Capability Code */

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -348,7 +348,7 @@ static bool bgp_pbr_extract_enumerate(struct bgp_pbr_match_val list[],
 				      void *valmask, uint8_t type_entry)
 {
 	bool ret;
-	uint8_t unary_operator_val = unary_operator;
+	uint8_t unary_operator_val;
 	bool double_check = false;
 
 	if ((unary_operator & OPERATOR_UNARY_OR) &&

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -57,16 +57,12 @@ struct bgp_pbr_match_val {
 	uint16_t value;
 	uint8_t compare_operator;
 	uint8_t unary_operator;
-} bgp_pbr_value_t;
+};
 
 #define FRAGMENT_DONT  1
 #define FRAGMENT_IS    2
 #define FRAGMENT_FIRST 4
 #define FRAGMENT_LAST  8
-
-struct bgp_pbr_fragment_val {
-	uint8_t bitmask;
-};
 
 struct bgp_pbr_entry_action {
 	/* used to store enum bgp_pbr_action_enum enumerate */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2673,14 +2673,12 @@ static void bgp_rib_withdraw(struct bgp_node *rn, struct bgp_info *ri,
 			     struct peer *peer, afi_t afi, safi_t safi,
 			     struct prefix_rd *prd)
 {
-	int status = BGP_DAMP_NONE;
-
 	/* apply dampening, if result is suppressed, we'll be retaining
 	 * the bgp_info in the RIB for historical reference.
 	 */
 	if (CHECK_FLAG(peer->bgp->af_flags[afi][safi], BGP_CONFIG_DAMPENING)
 	    && peer->sort == BGP_PEER_EBGP)
-		if ((status = bgp_damp_withdraw(ri, rn, afi, safi, 0))
+		if ((bgp_damp_withdraw(ri, rn, afi, safi, 0))
 		    == BGP_DAMP_SUPPRESSED) {
 			bgp_aggregate_decrement(peer->bgp, &rn->p, ri, afi,
 						safi);

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -864,7 +864,7 @@ DEFPY (rpki_cache,
        "Preference of the cache server\n"
        "Preference value\n")
 {
-	int return_value = SUCCESS;
+	int return_value;
 
 	// use ssh connection
 	if (ssh_uname) {
@@ -873,6 +873,7 @@ DEFPY (rpki_cache,
 			add_ssh_cache(cache, sshport, ssh_uname, ssh_privkey,
 				      ssh_pubkey, server_pubkey, preference);
 #else
+		return_value = SUCCESS;
 		vty_out(vty,
 			"ssh sockets are not supported. "
 			"Please recompile rtrlib and frr with ssh support. "

--- a/bgpd/bgp_vnc_types.h
+++ b/bgpd/bgp_vnc_types.h
@@ -25,16 +25,5 @@ typedef enum {
 	BGP_VNC_SUBTLV_TYPE_RFPOPTION = 2, /* deprecated */
 } bgp_vnc_subtlv_types;
 
-/*
- * VNC Attribute subtlvs
- */
-struct bgp_vnc_subtlv_lifetime {
-	uint32_t lifetime;
-};
-
-struct bgp_vnc_subtlv_unaddr {
-	struct prefix un_address; /* IPv4 or IPv6; pfx length ignored */
-};
-
 #endif /* ENABLE_BGP_VNC */
 #endif /* _QUAGGA_BGP_VNC_TYPES_H */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3372,8 +3372,6 @@ DEFUN (neighbor_set_peer_group,
 	struct peer *peer;
 	struct peer_group *group;
 
-	peer = NULL;
-
 	ret = str2sockunion(argv[idx_peer]->arg, &su);
 	if (ret < 0) {
 		peer = peer_lookup_by_conf_if(bgp, argv[idx_peer]->arg);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1190,7 +1190,7 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 	mpls_label_t label;
 	int nh_othervrf = 0;
 	char buf_prefix[PREFIX_STRLEN];	/* filled in if we are debugging */
-	bool is_evpn = false;
+	bool is_evpn;
 	int nh_updated;
 
 	/* Don't try to install if we're not connected to Zebra or Zebra doesn't

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -888,129 +888,6 @@ static bool peergroup_filter_check(struct peer *peer, afi_t afi, safi_t safi,
 	}
 }
 
-/* Reset all address family specific configuration.  */
-static void peer_af_flag_reset(struct peer *peer, afi_t afi, safi_t safi)
-{
-	int i;
-	struct bgp_filter *filter;
-	char orf_name[BUFSIZ];
-
-	filter = &peer->filter[afi][safi];
-
-	/* Clear neighbor filter and route-map */
-	for (i = FILTER_IN; i < FILTER_MAX; i++) {
-		if (filter->dlist[i].name) {
-			XFREE(MTYPE_BGP_FILTER_NAME, filter->dlist[i].name);
-			filter->dlist[i].name = NULL;
-		}
-		if (filter->plist[i].name) {
-			XFREE(MTYPE_BGP_FILTER_NAME, filter->plist[i].name);
-			filter->plist[i].name = NULL;
-		}
-		if (filter->aslist[i].name) {
-			XFREE(MTYPE_BGP_FILTER_NAME, filter->aslist[i].name);
-			filter->aslist[i].name = NULL;
-		}
-	}
-	for (i = RMAP_IN; i < RMAP_MAX; i++) {
-		if (filter->map[i].name) {
-			XFREE(MTYPE_BGP_FILTER_NAME, filter->map[i].name);
-			filter->map[i].name = NULL;
-		}
-	}
-
-	/* Clear unsuppress map.  */
-	if (filter->usmap.name)
-		XFREE(MTYPE_BGP_FILTER_NAME, filter->usmap.name);
-	filter->usmap.name = NULL;
-	filter->usmap.map = NULL;
-
-	/* Clear neighbor's all address family flags.  */
-	peer->af_flags[afi][safi] = 0;
-
-	/* Clear neighbor's all address family sflags. */
-	peer->af_sflags[afi][safi] = 0;
-
-	/* Clear neighbor's all address family capabilities. */
-	peer->af_cap[afi][safi] = 0;
-
-	/* Clear ORF info */
-	peer->orf_plist[afi][safi] = NULL;
-	sprintf(orf_name, "%s.%d.%d", peer->host, afi, safi);
-	prefix_bgp_orf_remove_all(afi, orf_name);
-
-	/* Set default neighbor send-community.  */
-	if (!bgp_option_check(BGP_OPT_CONFIG_CISCO)) {
-		SET_FLAG(peer->af_flags[afi][safi], PEER_FLAG_SEND_COMMUNITY);
-		SET_FLAG(peer->af_flags[afi][safi],
-			 PEER_FLAG_SEND_EXT_COMMUNITY);
-		SET_FLAG(peer->af_flags[afi][safi],
-			 PEER_FLAG_SEND_LARGE_COMMUNITY);
-
-		SET_FLAG(peer->af_flags_invert[afi][safi],
-			 PEER_FLAG_SEND_COMMUNITY);
-		SET_FLAG(peer->af_flags_invert[afi][safi],
-			 PEER_FLAG_SEND_EXT_COMMUNITY);
-		SET_FLAG(peer->af_flags_invert[afi][safi],
-			 PEER_FLAG_SEND_LARGE_COMMUNITY);
-	}
-
-	/* Clear neighbor default_originate_rmap */
-	if (peer->default_rmap[afi][safi].name)
-		XFREE(MTYPE_ROUTE_MAP_NAME, peer->default_rmap[afi][safi].name);
-	peer->default_rmap[afi][safi].name = NULL;
-	peer->default_rmap[afi][safi].map = NULL;
-
-	/* Clear neighbor maximum-prefix */
-	peer->pmax[afi][safi] = 0;
-	peer->pmax_threshold[afi][safi] = MAXIMUM_PREFIX_THRESHOLD_DEFAULT;
-}
-
-/* peer global config reset */
-static void peer_global_config_reset(struct peer *peer)
-{
-	int saved_flags = 0;
-
-	peer->change_local_as = 0;
-	peer->ttl = (peer_sort(peer) == BGP_PEER_IBGP ? MAXTTL : 1);
-	if (peer->update_source) {
-		sockunion_free(peer->update_source);
-		peer->update_source = NULL;
-	}
-	if (peer->update_if) {
-		XFREE(MTYPE_PEER_UPDATE_SOURCE, peer->update_if);
-		peer->update_if = NULL;
-	}
-
-	if (peer_sort(peer) == BGP_PEER_IBGP)
-		peer->v_routeadv = BGP_DEFAULT_IBGP_ROUTEADV;
-	else
-		peer->v_routeadv = BGP_DEFAULT_EBGP_ROUTEADV;
-
-	/* These are per-peer specific flags and so we must preserve them */
-	saved_flags |= CHECK_FLAG(peer->flags, PEER_FLAG_IFPEER_V6ONLY);
-	saved_flags |= CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN);
-	peer->flags = 0;
-	SET_FLAG(peer->flags, saved_flags);
-
-	peer->holdtime = 0;
-	peer->keepalive = 0;
-	peer->connect = 0;
-	peer->v_connect = BGP_DEFAULT_CONNECT_RETRY;
-
-	/* Reset some other configs back to defaults. */
-	peer->v_start = BGP_INIT_START_TIMER;
-	peer->password = NULL;
-	peer->local_id = peer->bgp->router_id;
-	peer->v_holdtime = peer->bgp->default_holdtime;
-	peer->v_keepalive = peer->bgp->default_keepalive;
-
-	bfd_info_free(&(peer->bfd_info));
-
-	/* Set back the CONFIG_NODE flag. */
-	SET_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE);
-}
-
 /* Check peer's AS number and determines if this peer is IBGP or EBGP */
 static inline bgp_peer_sort_t peer_calc_sort(struct peer *peer)
 {
@@ -2821,61 +2698,6 @@ int peer_group_bind(struct bgp *bgp, union sockunion *su, struct peer *peer,
 	return 0;
 }
 
-int peer_group_unbind(struct bgp *bgp, struct peer *peer,
-		      struct peer_group *group)
-{
-	struct peer *other;
-	afi_t afi;
-	safi_t safi;
-
-	if (group != peer->group)
-		return BGP_ERR_PEER_GROUP_MISMATCH;
-
-	FOREACH_AFI_SAFI (afi, safi) {
-		if (peer->afc[afi][safi]) {
-			peer->afc[afi][safi] = 0;
-			peer_af_flag_reset(peer, afi, safi);
-
-			if (peer_af_delete(peer, afi, safi) != 0) {
-				zlog_err(
-					"couldn't delete af structure for peer %s",
-					peer->host);
-			}
-		}
-	}
-
-	assert(listnode_lookup(group->peer, peer));
-	peer_unlock(peer); /* peer group list reference */
-	listnode_delete(group->peer, peer);
-	peer->group = NULL;
-	other = peer->doppelganger;
-
-	if (group->conf->as) {
-		peer_delete(peer);
-		if (other && other->status != Deleted) {
-			if (other->group) {
-				peer_unlock(other);
-				listnode_delete(group->peer, other);
-			}
-			other->group = NULL;
-			peer_delete(other);
-		}
-		return 0;
-	}
-
-	bgp_bfd_deregister_peer(peer);
-	peer_global_config_reset(peer);
-
-	if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->status)) {
-		peer->last_reset = PEER_DOWN_RMAP_UNBIND;
-		bgp_notify_send(peer, BGP_NOTIFY_CEASE,
-				BGP_NOTIFY_CEASE_CONFIG_CHANGE);
-	} else
-		bgp_session_reset(peer);
-
-	return 0;
-}
-
 static int bgp_startup_timer_expire(struct thread *thread)
 {
 	struct bgp *bgp;
@@ -3825,9 +3647,6 @@ struct peer_flag_action {
 
 	/* Action when the flag is changed.  */
 	enum peer_change_type type;
-
-	/* Peer down cause */
-	uint8_t peer_down;
 };
 
 static const struct peer_flag_action peer_flag_action_list[] = {
@@ -7913,8 +7732,6 @@ static void bgp_if_finish(struct bgp *bgp)
 			bgp_connected_delete(bgp, c);
 	}
 }
-
-extern void bgp_snmp_init(void);
 
 static void bgp_viewvrf_autocomplete(vector comps, struct cmd_token *token)
 {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -590,13 +590,7 @@ struct bgp_nexthop {
 
 #define BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE 1
 
-/* BGP router distinguisher value.  */
-#define BGP_RD_SIZE                8
-
-struct bgp_rd {
-	uint8_t val[BGP_RD_SIZE];
-};
-
+/* Route map direction */
 #define RMAP_IN  0
 #define RMAP_OUT 1
 #define RMAP_MAX 2
@@ -1590,7 +1584,6 @@ extern int peer_afc_set(struct peer *, afi_t, safi_t, int);
 
 extern int peer_group_bind(struct bgp *, union sockunion *, struct peer *,
 			   struct peer_group *, as_t *);
-extern int peer_group_unbind(struct bgp *, struct peer *, struct peer_group *);
 
 extern int peer_flag_set(struct peer *, uint32_t);
 extern int peer_flag_unset(struct peer *, uint32_t);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -3197,8 +3197,8 @@ DEFUN (debug_rfapi_register_vn_un_l2o,
 	memset(optary, 0, sizeof(optary));
 	optary[opt_next].v.l2addr.logical_net_id =
 		strtoul(argv[14]->arg, NULL, 10);
-	if ((rc = rfapiStr2EthAddr(argv[12]->arg,
-				   &optary[opt_next].v.l2addr.macaddr))) {
+	if (rfapiStr2EthAddr(argv[12]->arg,
+			     &optary[opt_next].v.l2addr.macaddr)) {
 		vty_out(vty, "Bad mac address \"%s\"\n", argv[12]->arg);
 		return CMD_WARNING_CONFIG_FAILED;
 	}

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -2099,7 +2099,6 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 			nhp->vn_options = NULL;
 
 			XFREE(MTYPE_RFAPI_NEXTHOP, nhp);
-			nhp = NULL;
 		}
 	}
 

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -402,7 +402,6 @@ void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct route_node *rn,
 
 static void vnc_direct_bgp_vpn_enable_ce(struct bgp *bgp, afi_t afi)
 {
-	struct rfapi_cfg *hc;
 	struct route_node *rn;
 	struct bgp_info *ri;
 
@@ -411,7 +410,7 @@ static void vnc_direct_bgp_vpn_enable_ce(struct bgp *bgp, afi_t afi)
 	if (!bgp)
 		return;
 
-	if (!(hc = bgp->rfapi_cfg))
+	if (!(bgp->rfapi_cfg))
 		return;
 
 	if (!VNC_EXPORT_BGP_CE_ENABLED(bgp->rfapi_cfg)) {

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -557,7 +557,6 @@ static void vnc_import_bgp_add_route_mode_resolve_nve(
 	struct bgp_info *info)			/* unicast info */
 {
 	afi_t afi = family2afi(prefix->family);
-	struct rfapi_cfg *hc = NULL;
 
 	struct prefix pfx_unicast_nexthop = {0}; /* happy valgrind */
 
@@ -607,7 +606,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve(
 		return;
 	}
 
-	if (!(hc = bgp->rfapi_cfg)) {
+	if (!(bgp->rfapi_cfg)) {
 		vnc_zlog_debug_verbose("%s: bgp->rfapi_cfg is NULL, skipping",
 				       __func__);
 		return;
@@ -698,7 +697,7 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 	struct peer *peer = info->peer;
 	struct attr *attr = info->attr;
 	struct attr hattr;
-	struct rfapi_cfg *hc = NULL;
+	struct rfapi_cfg *hc = bgp->rfapi_cfg;
 	struct attr *iattr = NULL;
 
 	struct rfapi_ip_addr vnaddr;
@@ -723,7 +722,7 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 		return;
 	}
 
-	if (!(hc = bgp->rfapi_cfg)) {
+	if (!hc) {
 		vnc_zlog_debug_verbose("%s: bgp->rfapi_cfg is NULL, skipping",
 				       __func__);
 		return;
@@ -886,7 +885,6 @@ vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
 	struct peer *peer = info->peer;
 	struct attr *attr = info->attr;
 	struct attr hattr;
-	struct rfapi_cfg *hc = NULL;
 	struct attr *iattr = NULL;
 
 	struct rfapi_ip_addr vnaddr;
@@ -911,7 +909,7 @@ vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
 		return;
 	}
 
-	if (!(hc = bgp->rfapi_cfg)) {
+	if (!(bgp->rfapi_cfg)) {
 		vnc_zlog_debug_verbose("%s: bgp->rfapi_cfg is NULL, skipping",
 				       __func__);
 		return;


### PR DESCRIPTION
This commit removes various parts of the bgpd implementation code which are no longer used, e.g. unused functions, unused variable initialization, unused structs, unused parameters and so on.

The function `peer_group_unbind` inside bgpd.c and its sub-functions were the biggest chunk of code that I was able to remove, as it was added back in 2002 and never properly used. It seems like it was meant to support unbinding a peer from a peer-group (currently doing so removes the peer completely), but the implementation is unused, incomplete and outdated.

If anyone thinks that a specific part should be kept, please tell me so and I'll get the PR updated. This is a first rough shot at cleaning up bgpd, more fine-grained and time-consuming cleanups will follow.