### PR TITLE
pimd: Remove unnecessary alloc failures

### DIFF
--- a/pimd/pim_br.c
+++ b/pimd/pim_br.c
@@ -64,10 +64,6 @@ void pim_br_set_pmbr(struct prefix_sg *sg, struct in_addr br)
 
 	if (!pim_br) {
 		pim_br = XCALLOC(MTYPE_PIM_BR, sizeof(*pim_br));
-		if (!pim_br) {
-			zlog_err("PIM XCALLOC(%zu) failure", sizeof(*pim_br));
-			return;
-		}
 
 		pim_br->sg = *sg;
 
@@ -100,9 +96,4 @@ void pim_br_clear_pmbr(struct prefix_sg *sg)
 void pim_br_init(void)
 {
 	pim_br_list = list_new();
-	if (!pim_br_list) {
-		zlog_err("%s: Failure to create pim_br_list",
-			 __PRETTY_FUNCTION__);
-		return;
-	}
 }

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -520,12 +520,6 @@ struct pim_ifchannel *pim_ifchannel_add(struct interface *ifp,
 	pim_ifp = ifp->info;
 
 	ch = XCALLOC(MTYPE_PIM_IFCHANNEL, sizeof(*ch));
-	if (!ch) {
-		zlog_warn(
-			"%s: pim_ifchannel_new() failure for (S,G)=%s on interface %s",
-			__PRETTY_FUNCTION__, pim_str_sg_dump(sg), ifp->name);
-		return NULL;
-	}
 
 	ch->flags = 0;
 	if ((source_flags & PIM_ENCODE_RPT_BIT)

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -860,18 +860,8 @@ static struct igmp_sock *igmp_sock_new(int fd, struct in_addr ifaddr,
 	}
 
 	igmp = XCALLOC(MTYPE_PIM_IGMP_SOCKET, sizeof(*igmp));
-	if (!igmp) {
-		zlog_warn("%s %s: XCALLOC() failure", __FILE__,
-			  __PRETTY_FUNCTION__);
-		return 0;
-	}
 
 	igmp->igmp_group_list = list_new();
-	if (!igmp->igmp_group_list) {
-		zlog_err("%s %s: failure: igmp_group_list = list_new()",
-			 __FILE__, __PRETTY_FUNCTION__);
-		return 0;
-	}
 	igmp->igmp_group_list->del = (void (*)(void *))igmp_group_free;
 
 	snprintf(hash_name, 64, "IGMP %s hash", ifp->name);
@@ -1130,19 +1120,8 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 	*/
 
 	group = XCALLOC(MTYPE_PIM_IGMP_GROUP, sizeof(*group));
-	if (!group) {
-		zlog_warn("%s %s: XCALLOC() failure", __FILE__,
-			  __PRETTY_FUNCTION__);
-		return NULL; /* error, not found, could not create */
-	}
 
 	group->group_source_list = list_new();
-	if (!group->group_source_list) {
-		zlog_warn("%s %s: list_new() failure", __FILE__,
-			  __PRETTY_FUNCTION__);
-		XFREE(MTYPE_PIM_IGMP_GROUP, group); /* discard group */
-		return NULL; /* error, not found, could not initialize */
-	}
 	group->group_source_list->del = (void (*)(void *))igmp_source_free;
 
 	group->t_group_timer = NULL;

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -457,11 +457,6 @@ struct igmp_source *source_new(struct igmp_group *group,
 	}
 
 	src = XCALLOC(MTYPE_PIM_IGMP_GROUP_SOURCE, sizeof(*src));
-	if (!src) {
-		zlog_warn("%s %s: XCALLOC() failure", __FILE__,
-			  __PRETTY_FUNCTION__);
-		return 0; /* error, not found, could not create */
-	}
 
 	src->t_source_timer = NULL;
 	src->source_group = group; /* back pointer */

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -69,8 +69,6 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	char hash_name[64];
 
 	pim = XCALLOC(MTYPE_PIM_PIM_INSTANCE, sizeof(struct pim_instance));
-	if (!pim)
-		return NULL;
 
 	pim_if_init(pim);
 
@@ -102,12 +100,6 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	}
 
 	pim->static_routes = list_new();
-	if (!pim->static_routes) {
-		zlog_err("%s %s: failure: static_routes=list_new()", __FILE__,
-			 __PRETTY_FUNCTION__);
-		pim_instance_terminate(pim);
-		return NULL;
-	}
 	pim->static_routes->del = (void (*)(void *))pim_static_route_free;
 
 	pim->send_v6_secondary = 1;

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -329,7 +329,6 @@ void pim_jp_agg_single_upstream_send(struct pim_rpf *rpf,
 
 	if (first) {
 		groups = list_new();
-
 		jag.sources = list_new();
 
 		listnode_add(groups, &jag);

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -240,11 +240,6 @@ static struct pim_msdp_sa *pim_msdp_sa_new(struct pim_instance *pim,
 	struct pim_msdp_sa *sa;
 
 	sa = XCALLOC(MTYPE_PIM_MSDP_SA, sizeof(*sa));
-	if (!sa) {
-		zlog_err("%s: PIM XCALLOC(%zu) failure", __PRETTY_FUNCTION__,
-			 sizeof(*sa));
-		return NULL;
-	}
 
 	sa->pim = pim;
 	sa->sg = *sg;
@@ -1069,11 +1064,6 @@ static enum pim_msdp_err pim_msdp_peer_new(struct pim_instance *pim,
 	pim_msdp_enable(pim);
 
 	mp = XCALLOC(MTYPE_PIM_MSDP_PEER, sizeof(*mp));
-	if (!mp) {
-		zlog_err("%s: PIM XCALLOC(%zu) failure", __PRETTY_FUNCTION__,
-			 sizeof(*mp));
-		return PIM_MSDP_ERR_OOM;
-	}
 
 	mp->pim = pim;
 	mp->peer = peer_addr;
@@ -1277,11 +1267,6 @@ static struct pim_msdp_mg *pim_msdp_mg_new(const char *mesh_group_name)
 	struct pim_msdp_mg *mg;
 
 	mg = XCALLOC(MTYPE_PIM_MSDP_MG, sizeof(*mg));
-	if (!mg) {
-		zlog_err("%s: PIM XCALLOC(%zu) failure", __PRETTY_FUNCTION__,
-			 sizeof(*mg));
-		return NULL;
-	}
 
 	mg->mesh_group_name = XSTRDUP(MTYPE_PIM_MSDP_MG_NAME, mesh_group_name);
 	mg->mbr_list = list_new();
@@ -1395,13 +1380,6 @@ enum pim_msdp_err pim_msdp_mg_mbr_add(struct pim_instance *pim,
 	}
 
 	mbr = XCALLOC(MTYPE_PIM_MSDP_MG_MBR, sizeof(*mbr));
-	if (!mbr) {
-		zlog_err("%s: PIM XCALLOC(%zu) failure", __PRETTY_FUNCTION__,
-			 sizeof(*mbr));
-		/* if there are no references to the mg free it */
-		pim_msdp_mg_free(pim, mg);
-		return PIM_MSDP_ERR_OOM;
-	}
 	mbr->mbr_ip = mbr_ip;
 	listnode_add_sort(mg->mbr_list, mbr);
 

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -305,11 +305,6 @@ pim_neighbor_new(struct interface *ifp, struct in_addr source_addr,
 	zassert(pim_ifp);
 
 	neigh = XCALLOC(MTYPE_PIM_NEIGHBOR, sizeof(*neigh));
-	if (!neigh) {
-		zlog_err("%s: PIM XCALLOC(%zu) failure", __PRETTY_FUNCTION__,
-			 sizeof(*neigh));
-		return 0;
-	}
 
 	neigh->creation = pim_time_monotonic_sec();
 	neigh->source_addr = source_addr;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -92,10 +92,6 @@ static struct pim_nexthop_cache *pim_nexthop_cache_add(struct pim_instance *pim,
 
 	pnc = XCALLOC(MTYPE_PIM_NEXTHOP_CACHE,
 		      sizeof(struct pim_nexthop_cache));
-	if (!pnc) {
-		zlog_err("%s: NHT PIM XCALLOC failure ", __PRETTY_FUNCTION__);
-		return NULL;
-	}
 	pnc->rpf.rpf_addr.family = rpf_addr->rpf_addr.family;
 	pnc->rpf.rpf_addr.prefixlen = rpf_addr->rpf_addr.prefixlen;
 	pnc->rpf.rpf_addr.u.prefix4.s_addr =
@@ -140,14 +136,6 @@ int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
 	pnc = pim_nexthop_cache_find(pim, &rpf);
 	if (!pnc) {
 		pnc = pim_nexthop_cache_add(pim, &rpf);
-		if (!pnc) {
-			char rpf_str[PREFIX_STRLEN];
-			pim_addr_dump("<nht-pnc?>", addr, rpf_str,
-				      sizeof(rpf_str));
-			zlog_warn("%s: pnc node allocation failed. addr %s ",
-				  __PRETTY_FUNCTION__, rpf_str);
-			return 0;
-		}
 		pim_sendmsg_zebra_rnh(pim, zclient, pnc,
 				      ZEBRA_NEXTHOP_REGISTER);
 		if (PIM_DEBUG_PIM_NHT) {
@@ -168,7 +156,7 @@ int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
 	if (up != NULL)
 		hash_get(pnc->upstream_hash, up, hash_alloc_intern);
 
-	if (pnc && CHECK_FLAG(pnc->flags, PIM_NEXTHOP_VALID)) {
+	if (CHECK_FLAG(pnc->flags, PIM_NEXTHOP_VALID)) {
 		memcpy(out_pnc, pnc, sizeof(struct pim_nexthop_cache));
 		return 1;
 	}

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -107,11 +107,6 @@ void pim_oil_init(struct pim_instance *pim)
 						 pim_oil_equal, hash_name);
 
 	pim->channel_oil_list = list_new();
-	if (!pim->channel_oil_list) {
-		zlog_err("%s %s: failure: channel_oil_list=list_new()",
-			 __FILE__, __PRETTY_FUNCTION__);
-		return;
-	}
 	pim->channel_oil_list->del = (void (*)(void *))pim_channel_oil_free;
 	pim->channel_oil_list->cmp =
 		(int (*)(void *, void *))pim_channel_oil_compare;
@@ -182,10 +177,6 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 	}
 
 	c_oil = XCALLOC(MTYPE_PIM_CHANNEL_OIL, sizeof(*c_oil));
-	if (!c_oil) {
-		zlog_err("PIM XCALLOC(%zu) failure", sizeof(*c_oil));
-		return NULL;
-	}
 
 	c_oil->oil.mfcc_mcastgrp = sg->grp;
 	c_oil->oil.mfcc_origin = sg->src;

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -115,13 +115,6 @@ void pim_rp_init(struct pim_instance *pim)
 
 	rp_info = XCALLOC(MTYPE_PIM_RP, sizeof(*rp_info));
 
-	if (!rp_info) {
-		zlog_err("Unable to alloc rp_info");
-		route_table_finish(pim->rp_table);
-		list_delete_and_null(&pim->rp_list);
-		return;
-	}
-
 	if (!str2prefix("224.0.0.0/4", &rp_info->group)) {
 		zlog_err("Unable to convert 224.0.0.0/4 to prefix");
 		list_delete_and_null(&pim->rp_list);
@@ -365,8 +358,6 @@ int pim_rp_new(struct pim_instance *pim, const char *rp,
 	struct route_node *rn;
 
 	rp_info = XCALLOC(MTYPE_PIM_RP, sizeof(*rp_info));
-	if (!rp_info)
-		return PIM_MALLOC_FAIL;
 
 	if (group_range == NULL)
 		result = str2prefix("224.0.0.0/4", &rp_info->group);
@@ -534,12 +525,6 @@ int pim_rp_new(struct pim_instance *pim, const char *rp,
 
 	listnode_add_sort(pim->rp_list, rp_info);
 	rn = route_node_get(pim->rp_table, &rp_info->group);
-	if (!rn) {
-		char buf[PREFIX_STRLEN];
-		zlog_err("Failure to get route node for pim->rp_table: %s",
-			 prefix2str(&rp_info->group, buf, sizeof(buf)));
-		return PIM_MALLOC_FAIL;
-	}
 	rn->info = rp_info;
 
 	if (PIM_DEBUG_TRACE) {

--- a/pimd/pim_ssmpingd.c
+++ b/pimd/pim_ssmpingd.c
@@ -348,12 +348,6 @@ static struct ssmpingd_sock *ssmpingd_new(struct pim_instance *pim,
 
 	if (!pim->ssmpingd_list) {
 		pim->ssmpingd_list = list_new();
-		if (!pim->ssmpingd_list) {
-			zlog_err(
-				"%s %s: failure: qpim_ssmpingd_list=list_new()",
-				__FILE__, __PRETTY_FUNCTION__);
-			return 0;
-		}
 		pim->ssmpingd_list->del = (void (*)(void *))ssmpingd_free;
 	}
 
@@ -369,15 +363,6 @@ static struct ssmpingd_sock *ssmpingd_new(struct pim_instance *pim,
 	}
 
 	ss = XCALLOC(MTYPE_PIM_SSMPINGD, sizeof(*ss));
-	if (!ss) {
-		char source_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<src?>", source_addr, source_str,
-			       sizeof(source_str));
-		zlog_err("%s: XCALLOC(%zu) failure for ssmpingd source %s",
-			 __PRETTY_FUNCTION__, sizeof(*ss), source_str);
-		close(sock_fd);
-		return 0;
-	}
 
 	ss->pim = pim;
 	ss->sock_fd = sock_fd;

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -39,14 +39,7 @@ void pim_static_route_free(struct static_route *s_route)
 
 static struct static_route *static_route_alloc()
 {
-	struct static_route *s_route;
-
-	s_route = XCALLOC(MTYPE_PIM_STATIC_ROUTE, sizeof(*s_route));
-	if (!s_route) {
-		zlog_err("PIM XCALLOC(%zu) failure", sizeof(*s_route));
-		return 0;
-	}
-	return s_route;
+	return XCALLOC(MTYPE_PIM_STATIC_ROUTE, sizeof(struct static_route));
 }
 
 static struct static_route *static_route_new(unsigned int iif, unsigned int oif,
@@ -55,9 +48,6 @@ static struct static_route *static_route_new(unsigned int iif, unsigned int oif,
 {
 	struct static_route *s_route;
 	s_route = static_route_alloc();
-	if (!s_route) {
-		return 0;
-	}
 
 	s_route->group = group;
 	s_route->source = source;

--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -757,12 +757,6 @@ int pim_tlv_parse_addr_list(const char *ifname, struct in_addr src_addr,
 		 */
 		if (!*hello_option_addr_list) {
 			*hello_option_addr_list = list_new();
-			if (!*hello_option_addr_list) {
-				zlog_err(
-					"%s %s: failure: hello_option_addr_list=list_new()",
-					__FILE__, __PRETTY_FUNCTION__);
-				return -2;
-			}
 			(*hello_option_addr_list)->del =
 				(void (*)(void *))prefix_free;
 		}

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -603,11 +603,6 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 	struct pim_upstream *up;
 
 	up = XCALLOC(MTYPE_PIM_UPSTREAM, sizeof(*up));
-	if (!up) {
-		zlog_err("%s: PIM XCALLOC(%zu) failure", __PRETTY_FUNCTION__,
-			 sizeof(*up));
-		return NULL;
-	}
 
 	up->sg = *sg;
 	pim_str_sg_set(sg, up->sg_str);


### PR DESCRIPTION
Remove from pim unnecessary alloc failure testing
as that alloc failure will cause an assert.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>