### PR TITLE
libs: add ALL_NEXTHOPS_PTR iterator macro

### DIFF
--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -56,6 +56,11 @@ void copy_nexthops(struct nexthop **tnh, struct nexthop *nh,
 	(nhop);								\
 	(nhop) = nexthop_next(nhop)
 
+#define ALL_NEXTHOPS_PTR(head, nhop)					\
+	(nhop) = ((head)->nexthop);					\
+	(nhop);								\
+	(nhop) = nexthop_next(nhop)
+
 
 struct nexthop_hold {
 	char *nhvrf_name;


### PR DESCRIPTION
Because sometimes we have a pointer to a nexthop_group.

Signed-off-by: Mark Stapp <mjs@voltanet.io>