### PR TITLE
zebra, libs: use const prefix ptrs in apis

### DIFF
--- a/lib/srcdest_table.c
+++ b/lib/srcdest_table.c
@@ -127,7 +127,7 @@ route_table_delegate_t _srcdest_srcnode_delegate = {
 
 /* NB: read comments in code for refcounting before using! */
 static struct route_node *srcdest_srcnode_get(struct route_node *rn,
-					      struct prefix_ipv6 *src_p)
+					      const struct prefix_ipv6 *src_p)
 {
 	struct srcdest_rnode *srn;
 
@@ -158,11 +158,12 @@ static struct route_node *srcdest_srcnode_get(struct route_node *rn,
 		route_unlock_node(rn);
 	}
 
-	return route_node_get(srn->src_table, (struct prefix *)src_p);
+	return route_node_get(srn->src_table, (const struct prefix *)src_p);
 }
 
-static struct route_node *srcdest_srcnode_lookup(struct route_node *rn,
-						 struct prefix_ipv6 *src_p)
+static struct route_node *srcdest_srcnode_lookup(
+	struct route_node *rn,
+	const struct prefix_ipv6 *src_p)
 {
 	struct srcdest_rnode *srn;
 
@@ -180,7 +181,7 @@ static struct route_node *srcdest_srcnode_lookup(struct route_node *rn,
 	if (!srn->src_table)
 		return NULL;
 
-	return route_node_lookup(srn->src_table, (struct prefix *)src_p);
+	return route_node_lookup(srn->src_table, (const struct prefix *)src_p);
 }
 
 /* ----- exported functions ----- */
@@ -233,25 +234,25 @@ struct route_node *srcdest_route_next(struct route_node *rn)
 }
 
 struct route_node *srcdest_rnode_get(struct route_table *table,
-				     union prefixptr dst_pu,
-				     struct prefix_ipv6 *src_p)
+				     union prefixconstptr dst_pu,
+				     const struct prefix_ipv6 *src_p)
 {
-	struct prefix_ipv6 *dst_p = dst_pu.p6;
+	const struct prefix_ipv6 *dst_p = dst_pu.p6;
 	struct route_node *rn;
 
-	rn = route_node_get(table, (struct prefix *)dst_p);
+	rn = route_node_get(table, (const struct prefix *)dst_p);
 	return srcdest_srcnode_get(rn, src_p);
 }
 
 struct route_node *srcdest_rnode_lookup(struct route_table *table,
-					union prefixptr dst_pu,
-					struct prefix_ipv6 *src_p)
+					union prefixconstptr dst_pu,
+					const struct prefix_ipv6 *src_p)
 {
-	struct prefix_ipv6 *dst_p = dst_pu.p6;
+	const struct prefix_ipv6 *dst_p = dst_pu.p6;
 	struct route_node *rn;
 	struct route_node *srn;
 
-	rn = route_node_lookup_maynull(table, (struct prefix *)dst_p);
+	rn = route_node_lookup_maynull(table, (const struct prefix *)dst_p);
 	srn = srcdest_srcnode_lookup(rn, src_p);
 
 	if (rn != NULL && rn == srn && !rn->info) {
@@ -263,8 +264,8 @@ struct route_node *srcdest_rnode_lookup(struct route_table *table,
 	return srn;
 }
 
-void srcdest_rnode_prefixes(struct route_node *rn, struct prefix **p,
-			    struct prefix **src_p)
+void srcdest_rnode_prefixes(struct route_node *rn, const struct prefix **p,
+			    const struct prefix **src_p)
 {
 	if (rnode_is_srcnode(rn)) {
 		struct route_node *dst_rn = rn->table->info;
@@ -282,7 +283,7 @@ void srcdest_rnode_prefixes(struct route_node *rn, struct prefix **p,
 
 const char *srcdest_rnode2str(struct route_node *rn, char *str, int size)
 {
-	struct prefix *dst_p, *src_p;
+	const struct prefix *dst_p, *src_p;
 	char dst_buf[PREFIX_STRLEN], src_buf[PREFIX_STRLEN];
 
 	srcdest_rnode_prefixes(rn, &dst_p, &src_p);

--- a/lib/srcdest_table.h
+++ b/lib/srcdest_table.h
@@ -56,13 +56,14 @@ extern route_table_delegate_t _srcdest_srcnode_delegate;
 
 extern struct route_table *srcdest_table_init(void);
 extern struct route_node *srcdest_rnode_get(struct route_table *table,
-					    union prefixptr dst_pu,
-					    struct prefix_ipv6 *src_p);
+					    union prefixconstptr dst_pu,
+					    const struct prefix_ipv6 *src_p);
 extern struct route_node *srcdest_rnode_lookup(struct route_table *table,
-					       union prefixptr dst_pu,
-					       struct prefix_ipv6 *src_p);
-extern void srcdest_rnode_prefixes(struct route_node *rn, struct prefix **p,
-				   struct prefix **src_p);
+					       union prefixconstptr dst_pu,
+					       const struct prefix_ipv6 *src_p);
+extern void srcdest_rnode_prefixes(struct route_node *rn,
+				   const struct prefix **p,
+				   const struct prefix **src_p);
 extern const char *srcdest_rnode2str(struct route_node *rn, char *str,
 				     int size);
 extern struct route_node *srcdest_route_next(struct route_node *rn);

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -390,8 +390,8 @@ void netlink_parse_rtattr(struct rtattr **tb, int max, struct rtattr *rta,
 	}
 }
 
-int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type, void *data,
-	      unsigned int alen)
+int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type,
+	      const void *data, unsigned int alen)
 {
 	int len;
 	struct rtattr *rta;
@@ -415,8 +415,8 @@ int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type, void *data,
 	return 0;
 }
 
-int rta_addattr_l(struct rtattr *rta, unsigned int maxlen, int type, void *data,
-		  unsigned int alen)
+int rta_addattr_l(struct rtattr *rta, unsigned int maxlen, int type,
+		  const void *data, unsigned int alen)
 {
 	unsigned int len;
 	struct rtattr *subrta;

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -29,9 +29,9 @@
 extern void netlink_parse_rtattr(struct rtattr **tb, int max,
 				 struct rtattr *rta, int len);
 extern int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type,
-		     void *data, unsigned int alen);
+		     const void *data, unsigned int alen);
 extern int rta_addattr_l(struct rtattr *rta, unsigned int maxlen, int type,
-			 void *data, unsigned int alen);
+			 const void *data, unsigned int alen);
 extern int addattr16(struct nlmsghdr *n, unsigned int maxlen, int type,
 		     uint16_t data);
 extern int addattr32(struct nlmsghdr *n, unsigned int maxlen, int type,

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -113,7 +113,7 @@ static void zebra_redistribute(struct zserv *client, int type,
 
 	for (rn = route_top(table); rn; rn = srcdest_route_next(rn))
 		RNODE_FOREACH_RE (rn, newre) {
-			struct prefix *dst_p, *src_p;
+			const struct prefix *dst_p, *src_p;
 			char buf[PREFIX_STRLEN];
 
 			srcdest_rnode_prefixes(rn, &dst_p, &src_p);
@@ -147,7 +147,7 @@ static void zebra_redistribute(struct zserv *client, int type,
 
 /* Either advertise a route for redistribution to registered clients or */
 /* withdraw redistribution if add cannot be done for client */
-void redistribute_update(struct prefix *p, struct prefix *src_p,
+void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 			 struct route_entry *re, struct route_entry *prev_re)
 {
 	struct listnode *node, *nnode;
@@ -216,7 +216,7 @@ void redistribute_update(struct prefix *p, struct prefix *src_p,
 	}
 }
 
-void redistribute_delete(struct prefix *p, struct prefix *src_p,
+void redistribute_delete(const struct prefix *p, const struct prefix *src_p,
 			 struct route_entry *re)
 {
 	struct listnode *node, *nnode;

--- a/zebra/redistribute.h
+++ b/zebra/redistribute.h
@@ -36,9 +36,11 @@ extern void zebra_redistribute_default_add(ZAPI_HANDLER_ARGS);
 extern void zebra_redistribute_default_delete(ZAPI_HANDLER_ARGS);
 /* ----------------- */
 
-extern void redistribute_update(struct prefix *, struct prefix *,
+extern void redistribute_update(const struct prefix *p,
+				const struct prefix *src_p,
 				struct route_entry *, struct route_entry *);
-extern void redistribute_delete(struct prefix *, struct prefix *,
+extern void redistribute_delete(const struct prefix *p,
+				const struct prefix *src_p,
 				struct route_entry *);
 
 extern void zebra_interface_up_update(struct interface *);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -289,7 +289,7 @@ extern int rib_lookup_ipv4_route(struct prefix_ipv4 *p, union sockunion *qgate,
 
 extern int is_zebra_valid_kernel_table(uint32_t table_id);
 extern int is_zebra_main_routing_table(uint32_t table_id);
-extern int zebra_check_addr(struct prefix *p);
+extern int zebra_check_addr(const struct prefix *p);
 
 extern void rib_addnode(struct route_node *rn, struct route_entry *re,
 			int process);

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -67,8 +67,8 @@ enum dp_req_result {
  * a re-add.
  */
 extern enum dp_req_result kernel_route_rib(struct route_node *rn,
-					   struct prefix *p,
-					   struct prefix *src_p,
+					   const struct prefix *p,
+					   const struct prefix *src_p,
 					   struct route_entry *old,
 					   struct route_entry *new);
 
@@ -77,7 +77,8 @@ extern enum dp_req_result kernel_route_rib(struct route_node *rn,
  * so let's separate it out and allow the result to
  * be passed back up.
  */
-extern void kernel_route_rib_pass_fail(struct route_node *rn, struct prefix *p,
+extern void kernel_route_rib_pass_fail(struct route_node *rn,
+				       const struct prefix *p,
 				       struct route_entry *re,
 				       enum dp_results res);
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1287,8 +1287,8 @@ _netlink_mpls_build_multipath(const char *routedesc, zebra_nhlfe_t *nhlfe,
  * @param zvrf: The vrf we are in
  * @param tableid: The table we are working on
  */
-static void _netlink_route_debug(int cmd, struct prefix *p,
-				 int family, struct zebra_vrf *zvrf,
+static void _netlink_route_debug(int cmd, const struct prefix *p,
+				 int family, vrf_id_t vrfid,
 				 uint32_t tableid)
 {
 	if (IS_ZEBRA_DEBUG_KERNEL) {
@@ -1297,7 +1297,7 @@ static void _netlink_route_debug(int cmd, struct prefix *p,
 			"netlink_route_multipath(): %s %s vrf %u(%u)",
 			nl_msg_type_to_str(cmd),
 			prefix2str(p, buf, sizeof(buf)),
-			zvrf_id(zvrf), tableid);
+			vrfid, tableid);
 	}
 }
 
@@ -1340,8 +1340,9 @@ static int netlink_neigh_update(int cmd, int ifindex, uint32_t addr, char *lla,
 
 /* Routing table change via netlink interface. */
 /* Update flag indicates whether this is a "replace" or not. */
-static int netlink_route_multipath(int cmd, struct prefix *p,
-				   struct prefix *src_p, struct route_entry *re,
+static int netlink_route_multipath(int cmd, const struct prefix *p,
+				   const struct prefix *src_p,
+				   struct route_entry *re,
 				   int update)
 {
 	int bytelen;
@@ -1416,7 +1417,7 @@ static int netlink_route_multipath(int cmd, struct prefix *p,
 		addattr32(&req.n, sizeof req, RTA_TABLE, re->table);
 	}
 
-	_netlink_route_debug(cmd, p, family, zvrf, re->table);
+	_netlink_route_debug(cmd, p, family, zvrf_id(zvrf), re->table);
 
 	/*
 	 * If we are not updating the route and we have received
@@ -1699,8 +1700,8 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 }
 
 enum dp_req_result kernel_route_rib(struct route_node *rn,
-				    struct prefix *p,
-				    struct prefix *src_p,
+				    const struct prefix *p,
+				    const struct prefix *src_p,
 				    struct route_entry *old,
 				    struct route_entry *new)
 {

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -386,8 +386,8 @@ static int kernel_rtm(int cmd, struct prefix *p, struct route_entry *re)
 }
 
 enum dp_req_result kernel_route_rib(struct route_node *rn,
-				    struct prefix *p,
-				    struct prefix *src_p,
+				    const struct prefix *p,
+				    const struct prefix *src_p,
 				    struct route_entry *old,
 				    struct route_entry *new)
 {

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -56,7 +56,8 @@ extern void nbr_connected_delete_ipv6(struct interface *ifp,
 extern int zsend_interface_update(int cmd, struct zserv *client,
 				  struct interface *ifp);
 extern int zsend_redistribute_route(int cmd, struct zserv *zclient,
-				    struct prefix *p, struct prefix *src_p,
+				    const struct prefix *p,
+				    const struct prefix *src_p,
 				    struct route_entry *re);
 extern int zsend_router_id_update(struct zserv *zclient, struct prefix *p,
 				  vrf_id_t vrf_id);
@@ -65,7 +66,8 @@ extern int zsend_interface_vrf_update(struct zserv *zclient,
 extern int zsend_interface_link_params(struct zserv *zclient,
 				       struct interface *ifp);
 extern int zsend_pw_update(struct zserv *client, struct zebra_pw *pw);
-extern int zsend_route_notify_owner(struct route_entry *re, struct prefix *p,
+extern int zsend_route_notify_owner(struct route_entry *re,
+				    const struct prefix *p,
 				    enum zapi_route_notify_owner note);
 
 extern void zsend_rule_notify_owner(struct zebra_pbr_rule *rule,

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -156,7 +156,7 @@ int is_zebra_main_routing_table(uint32_t table_id)
 	return 0;
 }
 
-int zebra_check_addr(struct prefix *p)
+int zebra_check_addr(const struct prefix *p)
 {
 	if (p->family == AF_INET) {
 		uint32_t addr;
@@ -325,7 +325,7 @@ struct nexthop *route_entry_nexthop_blackhole_add(struct route_entry *re,
 	return nexthop;
 }
 
-static void nexthop_set_resolved(afi_t afi, struct nexthop *newhop,
+static void nexthop_set_resolved(afi_t afi, const struct nexthop *newhop,
 				 struct nexthop *nexthop)
 {
 	struct nexthop *resolved_hop;
@@ -843,7 +843,7 @@ static unsigned nexthop_active_check(struct route_node *rn,
 	route_map_result_t ret = RMAP_MATCH;
 	int family;
 	char buf[SRCDEST2STR_BUFFER];
-	struct prefix *p, *src_p;
+	const struct prefix *p, *src_p;
 	srcdest_rnode_prefixes(rn, &p, &src_p);
 
 	if (rn->p.family == AF_INET)
@@ -1012,7 +1012,7 @@ int zebra_rib_labeled_unicast(struct route_entry *re)
 	return 1;
 }
 
-void kernel_route_rib_pass_fail(struct route_node *rn, struct prefix *p,
+void kernel_route_rib_pass_fail(struct route_node *rn, const struct prefix *p,
 				struct route_entry *re,
 				enum dp_results res)
 {
@@ -1085,7 +1085,7 @@ void rib_install_kernel(struct route_node *rn, struct route_entry *re,
 {
 	struct nexthop *nexthop;
 	rib_table_info_t *info = srcdest_rnode_table_info(rn);
-	struct prefix *p, *src_p;
+	const struct prefix *p, *src_p;
 	struct zebra_vrf *zvrf = vrf_info_lookup(re->vrf_id);
 
 	srcdest_rnode_prefixes(rn, &p, &src_p);
@@ -1143,7 +1143,7 @@ void rib_uninstall_kernel(struct route_node *rn, struct route_entry *re)
 {
 	struct nexthop *nexthop;
 	rib_table_info_t *info = srcdest_rnode_table_info(rn);
-	struct prefix *p, *src_p;
+	const struct prefix *p, *src_p;
 	struct zebra_vrf *zvrf = vrf_info_lookup(re->vrf_id);
 
 	srcdest_rnode_prefixes(rn, &p, &src_p);
@@ -1194,7 +1194,8 @@ static void rib_uninstall(struct route_node *rn, struct route_entry *re)
 	}
 
 	if (CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED)) {
-		struct prefix *p, *src_p;
+		const struct prefix *p, *src_p;
+
 		srcdest_rnode_prefixes(rn, &p, &src_p);
 
 		redistribute_delete(p, src_p, re);
@@ -1536,7 +1537,8 @@ static void rib_process(struct route_node *rn)
 	char buf[SRCDEST2STR_BUFFER];
 	rib_dest_t *dest;
 	struct zebra_vrf *zvrf = NULL;
-	struct prefix *p, *src_p;
+	const struct prefix *p, *src_p;
+
 	srcdest_rnode_prefixes(rn, &p, &src_p);
 	vrf_id_t vrf_id = VRF_UNKNOWN;
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1337,7 +1337,8 @@ void zebra_route_map_write_delay_timer(struct vty *vty)
 }
 
 route_map_result_t zebra_route_map_check(int family, int rib_type,
-					 uint8_t instance, struct prefix *p,
+					 uint8_t instance,
+					 const struct prefix *p,
 					 struct nexthop *nexthop,
 					 vrf_id_t vrf_id, route_tag_t tag)
 {
@@ -1358,7 +1359,8 @@ route_map_result_t zebra_route_map_check(int family, int rib_type,
 		rmap = route_map_lookup_by_name(
 			proto_rm[family][ZEBRA_ROUTE_MAX]);
 	if (rmap) {
-		ret = route_map_apply(rmap, p, RMAP_ZEBRA, &nh_obj);
+		ret = route_map_apply(rmap, (struct prefix *)p,
+				      RMAP_ZEBRA, &nh_obj);
 	}
 
 	return (ret);

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -40,7 +40,7 @@ zebra_import_table_route_map_check(int family, int rib_type, uint8_t instance,
 				   const char *rmap_name);
 extern route_map_result_t
 zebra_route_map_check(int family, int rib_type, uint8_t instance,
-		      struct prefix *p, struct nexthop *nexthop,
+		      const struct prefix *p, struct nexthop *nexthop,
 		      vrf_id_t vrf_id, route_tag_t tag);
 extern route_map_result_t
 zebra_nht_route_map_check(int family, int client_proto, struct prefix *p,

--- a/zebra/zebra_static.c
+++ b/zebra/zebra_static.c
@@ -37,8 +37,9 @@
 #include "zebra/zebra_memory.h"
 
 /* Install static route into rib. */
-void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
-			  struct prefix_ipv6 *src_p, struct static_route *si)
+void static_install_route(afi_t afi, safi_t safi, const struct prefix *p,
+			  const struct prefix_ipv6 *src_p,
+			  struct static_route *si)
 {
 	struct route_entry *re;
 	struct route_node *rn;
@@ -292,8 +293,9 @@ static int static_nexthop_same(struct nexthop *nexthop, struct static_route *si)
 }
 
 /* Uninstall static route from RIB. */
-void static_uninstall_route(afi_t afi, safi_t safi, struct prefix *p,
-			    struct prefix_ipv6 *src_p, struct static_route *si)
+void static_uninstall_route(afi_t afi, safi_t safi, const struct prefix *p,
+			    const struct prefix_ipv6 *src_p,
+			    struct static_route *si)
 {
 	struct route_node *rn;
 	struct route_entry *re;
@@ -610,7 +612,7 @@ static void static_ifindex_update_af(struct interface *ifp, bool up, afi_t afi,
 	struct route_table *stable;
 	struct route_node *rn;
 	struct static_route *si;
-	struct prefix *p, *src_pp;
+	const struct prefix *p, *src_pp;
 	struct prefix_ipv6 *src_p;
 	struct vrf *vrf;
 

--- a/zebra/zebra_static.h
+++ b/zebra/zebra_static.h
@@ -82,11 +82,12 @@ struct static_route {
 	uint32_t table_id;
 };
 
-extern void static_install_route(afi_t afi, safi_t safi, struct prefix *p,
-				 struct prefix_ipv6 *src_p,
+extern void static_install_route(afi_t afi, safi_t safi, const struct prefix *p,
+				 const struct prefix_ipv6 *src_p,
 				 struct static_route *si);
-extern void static_uninstall_route(afi_t afi, safi_t safi, struct prefix *p,
-				   struct prefix_ipv6 *src_p,
+extern void static_uninstall_route(afi_t afi, safi_t safi,
+				   const struct prefix *p,
+				   const struct prefix_ipv6 *src_p,
 				   struct static_route *si);
 
 extern int static_add_route(afi_t, safi_t safi, uint8_t type, struct prefix *p,


### PR DESCRIPTION
Add 'const' to prefix args to several zebra route update, redistribution, and route owner notification apis. I encountered some of these issues while doing other work, and Donald S asked to have this presented as a standalone PR.

Signed-off-by: Mark Stapp <mjs@voltanet.io>