### PR TITLE
zebra: remove default vrf output for kernel vrf ipv6 blackhole default

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1198,7 +1198,8 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 				break;
 			}
 
-			if (re->vrf_id != nexthop->vrf_id) {
+			if ((re->vrf_id != nexthop->vrf_id)
+			     && !NEXTHOP_TYPE_BLACKHOLE) {
 				struct vrf *vrf =
 					vrf_lookup_by_id(nexthop->vrf_id);
 
@@ -1415,7 +1416,8 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 				break;
 			}
 
-			if (nexthop->vrf_id != re->vrf_id) {
+			if ((nexthop->vrf_id != re->vrf_id)
+			     && !NEXTHOP_TYPE_BLACKHOLE) {
 				struct vrf *vrf =
 					vrf_lookup_by_id(nexthop->vrf_id);
 
@@ -1569,7 +1571,8 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 			break;
 		}
 
-		if (nexthop->vrf_id != re->vrf_id) {
+		if ((nexthop->vrf_id != re->vrf_id)
+		     && !NEXTHOP_TYPE_BLACKHOLE) {
 			struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
 
 			if (vrf)

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1199,7 +1199,7 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 			}
 
 			if ((re->vrf_id != nexthop->vrf_id)
-			     && !NEXTHOP_TYPE_BLACKHOLE) {
+			     && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
 				struct vrf *vrf =
 					vrf_lookup_by_id(nexthop->vrf_id);
 
@@ -1417,7 +1417,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 			}
 
 			if ((nexthop->vrf_id != re->vrf_id)
-			     && !NEXTHOP_TYPE_BLACKHOLE) {
+			     && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
 				struct vrf *vrf =
 					vrf_lookup_by_id(nexthop->vrf_id);
 
@@ -1572,7 +1572,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		}
 
 		if ((nexthop->vrf_id != re->vrf_id)
-		     && !NEXTHOP_TYPE_BLACKHOLE) {
+		     && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
 			struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
 
 			if (vrf)


### PR DESCRIPTION
It was reported that "show ipv6 route vrf <vrfname>", "show ipv6 route
vrf <vrfname> ::/0 " or "show ipv6 route vrf <vrfname> json" all
displayed that the nexthop was in the default vrf.  This was because
the kernel netlink messages would supply the RTA_OIF of the loopback
interface for the kernel-created default route for the vrf, where ipv4
did not supply any RTA_OIF.  This fix suppresses the display if the
nexthop and route entry are in different vrfs and the nexthop is
NEXTHOP_TYPE_BLACKHOLE.

Ticket: CM-21722
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>