### PR TITLE
Use metric for default-originate with route-map if applied

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -690,6 +690,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 	aspath = attr.aspath;
 
 	attr.local_pref = bgp->default_local_pref;
+	attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
 
 	memset(&p, 0, sizeof(p));
 	p.family = afi2family(afi);
@@ -723,6 +724,8 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 				ret = route_map_apply(
 					peer->default_rmap[afi][safi].map,
 					&rn->p, RMAP_BGP, &info);
+
+				attr.med = info.attr->med;
 
 				/* The route map might have set attributes. If
 				 * we don't flush them


### PR DESCRIPTION
We are missing this functionality in [Hostinger](https://www.hostinger.com/)

spine:
```
router bgp 65031
 bgp router-id 10.0.0.1
 neighbor 10.0.0.2 remote-as 65032
 !
 address-family ipv4 unicast
  redistribute kernel
  neighbor 10.0.0.2 default-originate route-map default
 exit-address-family
!
route-map default permit 10
 set metric 200
!
```
leaf:
```
router bgp 65032
 bgp router-id 10.0.0.2
 neighbor 10.0.0.1 remote-as 65031
!

leaf1-debian-9# sh ip bgp 0.0.0.0
BGP routing table entry for 0.0.0.0/0
Paths: (1 available, best #1, table Default-IP-Routing-Table)
  Advertised to non peer-group peers:
  10.0.0.1
  65031
    10.0.0.1 from 10.0.0.1 (10.0.0.1)
      Origin IGP, metric 200, localpref 100, valid, external, best
      AddPath ID: RX 0, TX 88
      Last update: Tue Jul 17 16:53:53 2018
```