### PR TITLE
Fix zapi fuzzing

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -236,15 +236,15 @@ int main(int argc, char **argv)
 		"  -z, --socket          Set path of zebra socket\n"
 		"  -e, --ecmp            Specify ECMP to use.\n"
 		"  -l, --label_socket    Socket to external label manager\n"
-		"  -k, --keep_kernel     Don't delete old routes which installed by zebra.\n"
+		"  -k, --keep_kernel     Don't delete old routes which were installed by zebra.\n"
 		"  -r, --retain          When program terminates, retain added route by zebra.\n"
 #ifdef HAVE_NETLINK
-		"  -n, --vrfwnetns       Set VRF with NetNS\n"
+		"  -n, --vrfwnetns       Use NetNS as VRF backend\n"
 		"  -s, --nl-bufsize      Set netlink receive buffer size\n"
 		"      --v6-rr-semantics Use v6 RR semantics\n"
 #endif /* HAVE_NETLINK */
 #if defined(HANDLE_ZAPI_FUZZING)
-		"  -c <file>             Bypass normal startup use this file for tetsting of zapi"
+		"  -c <file>             Bypass normal startup and use this file for testing of zapi"
 #endif
 	);
 

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -349,13 +349,6 @@ int main(int argc, char **argv)
 /* For debug purpose. */
 /* SET_FLAG (zebra_debug_event, ZEBRA_DEBUG_EVENT); */
 
-#if defined(HANDLE_ZAPI_FUZZING)
-	if (fuzzing) {
-		zserv_read_file(fuzzing);
-		exit(0);
-	}
-#endif
-
 	/* Process the configuration file. Among other configuration
 	*  directives we can meet those installing static routes. Such
 	*  requests will not be executed immediately, but queued in
@@ -390,6 +383,14 @@ int main(int argc, char **argv)
 
 	/* RNH init */
 	zebra_rnh_init();
+
+#if defined(HANDLE_ZAPI_FUZZING)
+	if (fuzzing) {
+		zserv_read_file(fuzzing);
+		exit(0);
+	}
+#endif
+
 
 	frr_run(zebrad.master);
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -640,7 +640,7 @@ static int zserv_handle_client_close(struct thread *thread)
  * sock
  *    client's socket file descriptor
  */
-static void zserv_client_create(int sock)
+static struct zserv *zserv_client_create(int sock)
 {
 	struct zserv *client;
 	int i;
@@ -696,6 +696,8 @@ static void zserv_client_create(int sock)
 
 	/* start pthread */
 	frr_pthread_run(client->pthread, NULL);
+
+	return client;
 }
 
 /*
@@ -1025,20 +1027,10 @@ void zserv_read_file(char *input)
 	struct zserv *client = NULL;
 	struct thread t;
 
-	zserv_client_create(-1);
-
-	frr_pthread_stop(client->pthread, NULL);
-	frr_pthread_destroy(client->pthread);
-	client->pthread = NULL;
-
-	t.arg = client;
-
 	fd = open(input, O_RDONLY | O_NONBLOCK);
 	t.u.fd = fd;
 
-	zserv_read(&t);
-
-	close(fd);
+	zserv_client_create(fd);
 }
 #endif
 


### PR DESCRIPTION
Fixes the ability for Zebra to use a file as input for ZAPI for fuzzing purposes. This was broken with the introduction of ZAPI pthreads.