### PR TITLE
Document bgp well-known communities in PR2684

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8581,9 +8581,19 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 	int count = 0;
 	int best = 0;
 	int suppress = 0;
+	int accept_own = 0;
+	int route_filter_translated_v4 = 0;
+	int route_filter_v4 = 0;
+	int route_filter_translated_v6 = 0;
+	int route_filter_v6 = 0;
+	int llgr_stale = 0;
+	int no_llgr = 0;
+	int accept_own_nexthop = 0;
+	int blackhole = 0;
 	int no_export = 0;
 	int no_advertise = 0;
 	int local_as = 0;
+	int no_peer = 0;
 	int first = 1;
 	int has_valid_label = 0;
 	mpls_label_t label = 0;
@@ -8660,12 +8670,41 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 		} else
 			vty_out(vty, ", no best path");
 
-		if (no_advertise)
-			vty_out(vty, ", not advertised to any peer");
+		if (accept_own)
+			vty_out(vty,
+			", accept own local route exported and imported in different VRF");
+		else if (route_filter_translated_v4)
+			vty_out(vty,
+			", mark translated RTs for VPNv4 route filtering");
+		else if (route_filter_v4)
+			vty_out(vty,
+			", attach RT as-is for VPNv4 route filtering");
+		else if (route_filter_translated_v6)
+			vty_out(vty,
+			", mark translated RTs for VPNv6 route filtering");
+		else if (route_filter_v6)
+			vty_out(vty,
+			", attach RT as-is for VPNv6 route filtering");
+		else if (llgr_stale)
+			vty_out(vty,
+			", mark routes to be retained for a longer time. Requeres support for Long-lived BGP Graceful Restart");
+		else if (no_llgr)
+			vty_out(vty,
+			", mark routes to not be treated according to Long-lived BGP Graceful Restart operations");
+		else if (accept_own_nexthop)
+			vty_out(vty,
+			", accept local nexthop");
+		else if (blackhole)
+			vty_out(vty, ", inform peer to blackhole prefix");
 		else if (no_export)
 			vty_out(vty, ", not advertised to EBGP peer");
+		else if (no_advertise)
+			vty_out(vty, ", not advertised to any peer");
 		else if (local_as)
 			vty_out(vty, ", not advertised outside local AS");
+		else if (no_peer)
+			vty_out(vty,
+			", inform EBGP peer not to advertise to their EBGP peers");
 
 		if (suppress)
 			vty_out(vty,
@@ -9026,6 +9065,10 @@ DEFUN (show_ip_bgp,
            |prefix-list WORD\
            |filter-list WORD\
            |statistics\
+           |community <AA:NN|local-AS|no-advertise|no-export|graceful-shutdown\
+           no-peer|blackhole|llgr-stale|no-llgr|accept-own|accept-own-nexthop\
+           route-filter-v6|route-filter-v4|route-filter-translated-v6|\
+           route-filter-translated-v4> [exact-match]\
            |community-list <(1-500)|WORD> [exact-match]\
            |A.B.C.D/M longer-prefixes\
            |X:X::X:X/M longer-prefixes\
@@ -9045,6 +9088,23 @@ DEFUN (show_ip_bgp,
        "Display routes conforming to the filter-list\n"
        "Regular expression access list name\n"
        "BGP RIB advertisement statistics\n"
+       "Display routes matching the communities\n"
+       COMMUNITY_AANN_STR
+       "Do not send outside local AS (well-known community)\n"
+       "Do not advertise to any peer (well-known community)\n"
+       "Do not export to next AS (well-known community)\n"
+       "Graceful shutdown (well-known community)\n"
+       "Do not export to any peer (well-known community)\n"
+       "Inform EBGP peers to blackhole traffic to prefix (well-known community)\n"
+       "Staled Long-lived Graceful Restart VPN route (well-known community)\n"
+       "Removed because Long-lived Graceful Restart was not enabled for VPN route (well-known community)\n"
+       "Should accept local VPN route if exported and imported into different VRF (well-known community)\n"
+       "Should accept VPN route with local nexthop (well-known community)\n"
+       "RT VPNv6 route filtering (well-known community)\n"
+       "RT VPNv4 route filtering (well-known community)\n"
+       "RT translated VPNv6 route filtering (well-known community)\n"
+       "RT translated VPNv4 route filtering (well-known community)\n"
+       "Exact match of the communities\n"
        "Display routes matching the community-list\n"
        "community-list number\n"
        "community-list name\n"

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1011,6 +1011,75 @@ is 4 octet long. The following format is used to define the community value.
 ``internet``
    ``internet`` represents well-known communities value 0.
 
+``graceful-shutdown``
+   ``graceful-shutdown`` represents well-known communities value
+   ``GRACEFUL_SHUTDOWN`` ``0xFFFF0000`` ``65535:0``. :rfc:`8326` implements
+   the purpose Graceful BGP Session Shutdown to reduce the amount of
+   lost traffic when taking BGP sessions down for maintainance. The use
+   of the community needs to be supported from your peers side to
+   actually have any effect.
+
+``accept-own``
+   ``accept-own`` represents well-known communities value ``ACCEPT_OWN``
+   ``0xFFFF0001`` ``65535:1``. :rfc:`7611` implements a way to signal
+   to a router to accept routes with a local nexthop address. This
+   can be the case when doing policing and having traffic having a
+   nexthop located in another VRF but still local interface to the
+   router. It is recommended to read the RFC for full details.
+
+``route-filter-translated-v4``
+   ``route-filter-translated-v4`` represents well-known communities value
+   ``ROUTE_FILTER_TRANSLATED_v4`` ``0xFFFF0002`` ``65535:2``.
+
+``route-filter-v4``
+   ``route-filter-v4`` represents well-known communities value
+   ``ROUTE_FILTER_v4`` ``0xFFFF0003`` ``65535:3``.
+
+``route-filter-translated-v6``
+   ``route-filter-translated-v6`` represents well-known communities value
+   ``ROUTE_FILTER_TRANSLATED_v6`` ``0xFFFF0004`` ``65535:4``.
+
+``route-filter-v6``
+   ``route-filter-v6`` represents well-known communities value
+   ``ROUTE_FILTER_v6`` ``0xFFFF0005`` ``65535:5``.
+
+``llgr-stale``
+   ``llgr-stale`` represents well-known communities value ``LLGR_STALE``
+   ``0xFFFF0006`` ``65535:6``.
+   Assigned and intented only for use with routers supporting the
+   Long-lived Graceful Restart Capability  as described in
+   :rfc:`draft-uttaro-idr-bgp-persistence`.
+   Routers recieving routes with this community may (depending on
+   implementation) choose allow to reject or modify routes on the
+   presence or absence of this community.
+
+``no-llgr``
+   ``no-llgr`` represents well-known communities value ``NO_LLGR``
+   ``0xFFFF0007`` ``65535:7``.
+   Assigned and intented only for use with routers supporting the
+   Long-lived Graceful Restart Capability  as described in
+   :rfc:`draft-uttaro-idr-bgp-persistence`.
+   Routers recieving routes with this community may (depending on
+   implementation) choose allow to reject or modify routes on the
+   presence or absence of this community.
+
+``accept-own-nexthop``
+   ``accept-own-nexthop`` represents well-known communities value
+   ``accept-own-nexthop`` ``0xFFFF0008`` ``65535:8``.
+   :rfc:`draft-agrewal-idr-accept-own-nexthop` describes
+   how to tag and label VPN routes to be able to send traffic between VRFs
+   via an internal layer 2 domain on the same PE device. Refer to
+   :rfc:`draft-agrewal-idr-accept-own-nexthop` for full details.
+
+``blackhole``
+   ``blackhole`` represents well-known communities value ``BLACKHOLE``
+   ``0xFFFF029A`` ``65535:666``. :rfc:`7999` documents sending prefixes to
+   EBGP peers and upstream for the purpose of blackholing traffic.
+   Prefixes tagged with the this community should normally not be
+   re-advertised from neighbors of the originating network. It is
+   recommended upon receiving prefixes tagged with this community to
+   add ``NO_EXPORT`` and ``NO_ADVERTISE``.
+
 ``no-export``
    ``no-export`` represents well-known communities value ``NO_EXPORT``
    ``0xFFFFFF01``. All routes carry this value must not be advertised to
@@ -1029,6 +1098,11 @@ is 4 octet long. The following format is used to define the community value.
    external BGP peers. Even if the neighboring router is part of confederation,
    it is considered as external BGP peer, so the route will not be announced to
    the peer.
+
+``no-peer``
+   ``no-peer`` represents well-known communities value ``NOPEER``
+   ``0xFFFFFF04``  ``65535:65284``. :rfc:`3765` is used to communicate to
+   another network how the originating network want the prefix propagated.
 
 When the communities attribute is received duplicate community values in the
 attribute are ignored and value is sorted in numerical order.


### PR DESCRIPTION
Document bgp communities added with PR #2684.

Documentation for how-to use the introduced bgp well-known communities is done in route_vty_out_detail_header in bgpd/bgp_route.c

**Note:** Checks for this PR should fail until #2684 is merged into master