### PR TITLE
lib/compiler.h: Always define CPP_NOTICE

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -76,6 +76,7 @@
 
 #else
 #define CPP_WARN(text)
+#define CPP_NOTICE(text)
 #endif
 
 #endif /* _FRR_COMPILER_H */


### PR DESCRIPTION
On old compilers CPP_NOTICE should be a macro evaluating to an empty statement, instead of being undefined.