### PR TITLE
doc: add cmd line param section to modules.rst

### DIFF
--- a/doc/developer/modules.rst
+++ b/doc/developer/modules.rst
@@ -100,6 +100,15 @@ a function that removes all of a module's installed hooks.
 There's also the ``frr_module`` symbol in modules, pretty much a
 standard entry point for loadable modules.
 
+Command line parameters
+-----------------------
+
+Command line parameters can be passed directly to a module by appending a 
+colon to the module name when loading it, e.g. ``-M mymodule:myparameter``. 
+The text after the colon will be accessible in the module's code through 
+``THIS_MODULE->load_args``. For example, see how the format parameter is
+configured in the ``zfpm_init()`` function inside ``zebra_fpm.c``.
+
 Hooks
 -----
 


### PR DESCRIPTION
A chat with @rwestphal made me realize that it is possible to pass command-line parameters to FRR modules through THIS_MODULE->load_args; however this is not currently documented in modules.rst. I just added a few lines to document this feature.