### PR TITLE
zebra: Add code for fuzzing netlink

### DIFF
--- a/doc/developer/modules.rst
+++ b/doc/developer/modules.rst
@@ -100,6 +100,15 @@ a function that removes all of a module's installed hooks.
 There's also the ``frr_module`` symbol in modules, pretty much a
 standard entry point for loadable modules.
 
+Command line parameters
+-----------------------
+
+Command line parameters can be passed directly to a module by appending a 
+colon to the module name when loading it, e.g. ``-M mymodule:myparameter``. 
+The text after the colon will be accessible in the module's code through 
+``THIS_MODULE->load_args``. For example, see how the format parameter is
+configured in the ``zfpm_init()`` function inside ``zebra_fpm.c``.
+
 Hooks
 -----
 

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -20,6 +20,11 @@
 
 #include <zebra.h>
 
+#if defined(HANDLE_ZAPI_FUZZING)
+#include <stdio.h>
+#include <string.h>
+#endif
+
 #ifdef HAVE_NETLINK
 
 #include "linklist.h"
@@ -292,6 +297,97 @@ static int netlink_information_fetch(struct nlmsghdr *h, ns_id_t ns_id,
 	}
 	return 0;
 }
+
+#if defined(HANDLE_ZAPI_FUZZING)
+/* Using globals here to avoid adding function parameters */
+
+/* Keep distinct filenames for netlink fuzzy collection */
+static unsigned int netlink_file_counter = 1;
+
+/* File name to read fuzzed netlink from */
+static char netlink_fuzz_file[MAXPATHLEN] = "";
+
+/* Flag for whether to read from file or not */
+static int netlink_read = 0;
+
+/**
+ * netlink_set_read() - Sets the read flag
+ * @flag:      Flag value.
+ *
+ */
+void set_netlink_read(int flag)
+{
+	netlink_read = flag;
+}
+
+/**
+ * netlink_read_init() - Starts the message parser
+ * @fname:      Filename to read.
+ */
+void netlink_read_init(const char *fname)
+{
+	snprintf(netlink_fuzz_file, MAXPATHLEN, "%s", fname);
+	/* Creating this fake socket for testing purposes */
+	struct zebra_ns zns = {
+		.ns_id = 0,
+		.netlink_cmd = {.sock = -1,
+				.seq = -1,
+				.name = "fuzzer_command_channel"},
+		.netlink = {.sock = -1,
+			    .seq = -1,
+			    .name = "fuzzer_kernel_message"}
+	};
+	netlink_parse_info(netlink_information_fetch, &zns.netlink, &zns, 1, 0);
+}
+
+/**
+ * netlink_write_incoming() - Writes all data received from netlink to a file
+ * @buf:        Data from netlink.
+ * @size:       Size of data.
+ * @counter:    Counter for keeping filenames distinct.
+ */
+static void netlink_write_incoming(const char *buf, const unsigned int size,
+				   unsigned int counter)
+{
+	char fname[MAXPATHLEN];
+	FILE *f;
+
+	zserv_privs.change(ZPRIVS_RAISE);
+	snprintf(fname, MAXPATHLEN, "%s/%s_%u", DAEMON_VTY_DIR, "netlink",
+		 counter);
+	f = fopen(fname, "w");
+	if (f) {
+		fwrite(buf, 1, size, f);
+		fclose(f);
+	}
+	zserv_privs.change(ZPRIVS_LOWER);
+}
+
+/**
+ * netlink_read_file() - Reads netlink data from file
+ * @buf:        Netlink buffer being overwritten.
+ * @fname:      File name to read from.
+ *
+ * Return:      Size of file.
+ */
+static long netlink_read_file(char *buf, const char *fname)
+{
+	FILE *f;
+	long file_bytes = -1;
+	zserv_privs.change(ZPRIVS_RAISE);
+	f = fopen(fname, "r");
+	if (f) {
+		fseek(f, 0, SEEK_END);
+		file_bytes = ftell(f);
+		rewind(f);
+		fread(buf, file_bytes, 1, f);
+		fclose(f);
+	}
+	zserv_privs.change(ZPRIVS_LOWER);
+	return file_bytes;
+}
+
+#endif
 
 static int kernel_read(struct thread *thread)
 {
@@ -602,7 +698,18 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 		if (count && read_in >= count)
 			return 0;
 
+#if defined(HANDLE_ZAPI_FUZZING)
+		/* Check if reading and filename is set */
+		if (netlink_read && '\0' != netlink_fuzz_file[0]) {
+			zlog_debug("Reading netlink fuzz file");
+			status = netlink_read_file(buf, netlink_fuzz_file);
+			snl.nl_pid = 0;
+		} else {
+			status = recvmsg(nl->sock, &msg, 0);
+		}
+#else
 		status = recvmsg(nl->sock, &msg, 0);
+#endif
 		if (status < 0) {
 			if (errno == EINTR)
 				continue;
@@ -635,6 +742,14 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 				   __func__);
 			zlog_hexdump(buf, status);
 		}
+
+#if defined(HANDLE_ZAPI_FUZZING)
+		if (!netlink_read) {
+			zlog_debug("Writing incoming netlink message");
+			netlink_write_incoming(buf, status,
+					       netlink_file_counter++);
+		}
+#endif
 
 		read_in++;
 		for (h = (struct nlmsghdr *)buf;

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -45,6 +45,10 @@ extern const char *nl_rtproto_to_str(uint8_t rtproto);
 extern const char *nl_family_to_str(uint8_t family);
 extern const char *nl_rttype_to_str(uint8_t rttype);
 
+#if defined(HANDLE_ZAPI_FUZZING)
+extern void set_netlink_read(int flag);
+extern void netlink_read_init(const char *fname);
+#endif
 extern int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 			      struct nlsock *nl, struct zebra_ns *zns,
 			      int count, int startup);


### PR DESCRIPTION
This code allows you to fuzz the netlink listening socket
in zebra by --enable-fuzzing and passing the -w [FILE]
option when running zebra.

File collection is stored in /var/run/frr/netlink_*
where each number is just a counter to keep the
files distinct.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>