### PR TITLE
zebra: Add code for fuzzing netlink

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -436,6 +436,8 @@ AC_ARG_ENABLE(datacenter,
   AS_HELP_STRING([--enable-datacenter], [enable Compilation for Data Center Extensions]))
 AC_ARG_ENABLE(fuzzing,
   AS_HELP_STRING([--enable-fuzzing], [enable ability to fuzz various parts of FRR]))
+AC_ARG_ENABLE(netlink_fuzzing,
+  AS_HELP_STRING([--enable-netlink-fuzzing], [enable ability to fuzz netlink listening socket in zebra]))
 AC_ARG_ENABLE(rr-semantics,
   AS_HELP_STRING([--disable-rr-semantics], [disable the v6 Route Replace semantics]))
 AC_ARG_ENABLE([protobuf],
@@ -499,6 +501,10 @@ fi
 
 if test "${enable_fuzzing}" = "yes" ; then
   AC_DEFINE(HANDLE_ZAPI_FUZZING,,Compile extensions to use with a fuzzer)
+fi
+
+if test "${enable_netlink_fuzzing}" = "yes" ; then
+  AC_DEFINE(HANDLE_NETLINK_FUZZING,,Compile extensions to use with a fuzzer for netlink)
 fi
 
 if test "${enable_cumulus}" = "yes" ; then

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -308,7 +308,7 @@ static unsigned int netlink_file_counter = 1;
 static char netlink_fuzz_file[MAXPATHLEN] = "";
 
 /* Flag for whether to read from file or not */
-bool netlink_read = false;
+bool netlink_read;
 
 /**
  * netlink_read_init() - Starts the message parser

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -318,16 +318,9 @@ void netlink_read_init(const char *fname)
 {
 	snprintf(netlink_fuzz_file, MAXPATHLEN, "%s", fname);
 	/* Creating this fake socket for testing purposes */
-	struct zebra_ns zns = {
-		.ns_id = 0,
-		.netlink_cmd = {.sock = -1,
-				.seq = -1,
-				.name = "fuzzer_command_channel"},
-		.netlink = {.sock = -1,
-			    .seq = -1,
-			    .name = "fuzzer_kernel_message"}
-	};
-	netlink_parse_info(netlink_information_fetch, &zns.netlink, &zns, 1, 0);
+	struct zebra_ns *zns = zebra_ns_lookup(NS_DEFAULT);
+
+	netlink_parse_info(netlink_information_fetch, &zns->netlink, zns, 1, 0);
 }
 
 /**
@@ -371,7 +364,7 @@ static long netlink_read_file(char *buf, const char *fname)
 		fseek(f, 0, SEEK_END);
 		file_bytes = ftell(f);
 		rewind(f);
-		fread(buf, file_bytes, 1, f);
+		fread(buf, NL_RCV_PKT_BUF_SIZE, 1, f);
 		fclose(f);
 	}
 	zserv_privs.change(ZPRIVS_LOWER);

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -308,7 +308,7 @@ static unsigned int netlink_file_counter = 1;
 static char netlink_fuzz_file[MAXPATHLEN] = "";
 
 /* Flag for whether to read from file or not */
-static int netlink_read = 0;
+int netlink_read;
 
 /**
  * netlink_set_read() - Sets the read flag
@@ -374,6 +374,7 @@ static long netlink_read_file(char *buf, const char *fname)
 {
 	FILE *f;
 	long file_bytes = -1;
+
 	zserv_privs.change(ZPRIVS_RAISE);
 	f = fopen(fname, "r");
 	if (f) {

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -20,6 +20,11 @@
 
 #include <zebra.h>
 
+#if defined(HANDLE_ZAPI_FUZZING)
+#include <stdio.h>
+#include <string.h>
+#endif
+
 #ifdef HAVE_NETLINK
 
 #include "linklist.h"
@@ -292,6 +297,97 @@ static int netlink_information_fetch(struct nlmsghdr *h, ns_id_t ns_id,
 	}
 	return 0;
 }
+
+#if defined(HANDLE_ZAPI_FUZZING)
+/* Using globals here to avoid adding function parameters */
+
+/* Keep distinct filenames for netlink fuzzy collection */
+static unsigned int netlink_file_counter = 1;
+
+/* File name to read fuzzed netlink from */
+static char netlink_fuzz_file[MAXPATHLEN] = "";
+
+/* Flag for whether to read from file or not */
+static int netlink_read = 0;
+
+/**
+ * netlink_set_read() - Sets the read flag
+ * @flag:      Flag value.
+ *
+ */
+void set_netlink_read(int flag)
+{
+	netlink_read = flag;
+}
+
+/**
+ * netlink_read_init() - Starts the message parser
+ * @fname:      Filename to read.
+ */
+void netlink_read_init(const char *fname)
+{
+	snprintf(netlink_fuzz_file, MAXPATHLEN, "%s", fname);
+	/* Creating this fake socket for testing purposes */
+	struct zebra_ns zns = {
+		.ns_id = 0,
+		.netlink_cmd = {.sock = -1,
+				.seq = -1,
+				.name = "fuzzer_command_channel"},
+		.netlink = {.sock = -1,
+			    .seq = -1,
+			    .name = "fuzzer_kernel_message"}
+	};
+	netlink_parse_info(netlink_information_fetch, &zns.netlink, &zns, 1, 0);
+}
+
+/**
+ * netlink_write_incoming() - Writes all data received from netlink to a file
+ * @buf:        Data from netlink.
+ * @size:       Size of data.
+ * @counter:    Counter for keeping filenames distinct.
+ */
+static void netlink_write_incoming(const char *buf, const unsigned int size,
+				   unsigned int counter)
+{
+	char fname[MAXPATHLEN];
+	FILE *f;
+
+	zserv_privs.change(ZPRIVS_RAISE);
+	snprintf(fname, MAXPATHLEN, "%s/%s_%u", DAEMON_VTY_DIR, "netlink",
+		 counter);
+	f = fopen(fname, "w");
+	if (f) {
+		fwrite(buf, 1, size, f);
+		fclose(f);
+	}
+	zserv_privs.change(ZPRIVS_LOWER);
+}
+
+/**
+ * netlink_read_file() - Reads netlink data from file
+ * @buf:        Netlink buffer being overwritten.
+ * @fname:      File name to read from.
+ *
+ * Return:      Size of file.
+ */
+static long netlink_read_file(char *buf, const char *fname)
+{
+	FILE *f;
+	long file_bytes = -1;
+	zserv_privs.change(ZPRIVS_RAISE);
+	f = fopen(fname, "r");
+	if (f) {
+		fseek(f, 0, SEEK_END);
+		file_bytes = ftell(f);
+		rewind(f);
+		fread(buf, file_bytes, 1, f);
+		fclose(f);
+	}
+	zserv_privs.change(ZPRIVS_LOWER);
+	return file_bytes;
+}
+
+#endif
 
 static int kernel_read(struct thread *thread)
 {
@@ -602,7 +698,18 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 		if (count && read_in >= count)
 			return 0;
 
+#if defined(HANDLE_ZAPI_FUZZING)
+		/* Check if reading and filename is set */
+		if (netlink_read && '\0' != netlink_fuzz_file[0]) {
+			zlog_debug("Reading netlink fuzz file");
+			status = netlink_read_file(buf, netlink_fuzz_file);
+			snl.nl_pid = 0;
+		} else {
+			status = recvmsg(nl->sock, &msg, 0);
+		}
+#else
 		status = recvmsg(nl->sock, &msg, 0);
+#endif
 		if (status < 0) {
 			if (errno == EINTR)
 				continue;
@@ -635,6 +742,14 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 				   __func__);
 			zlog_hexdump(buf, status);
 		}
+
+#if defined(HANDLE_ZAPI_FUZZING)
+		if (!netlink_read) {
+			zlog_debug("Writing incoming netlink message");
+			netlink_write_incoming(buf, status,
+					       netlink_file_counter++);
+		}
+#endif
 
 		read_in++;
 		for (h = (struct nlmsghdr *)buf;

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -45,10 +45,10 @@ extern const char *nl_rtproto_to_str(uint8_t rtproto);
 extern const char *nl_family_to_str(uint8_t family);
 extern const char *nl_rttype_to_str(uint8_t rttype);
 
-#if defined(HANDLE_ZAPI_FUZZING)
-extern void set_netlink_read(int flag);
+#if defined(HANDLE_NETLINK_FUZZING)
+extern bool netlink_read;
 extern void netlink_read_init(const char *fname);
-#endif
+#endif /* HANDLE_NETLINK_FUZZING */
 extern int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 			      struct nlsock *nl, struct zebra_ns *zns,
 			      int count, int startup);

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -45,6 +45,10 @@ extern const char *nl_rtproto_to_str(uint8_t rtproto);
 extern const char *nl_family_to_str(uint8_t family);
 extern const char *nl_rttype_to_str(uint8_t rttype);
 
+#if defined(HANDLE_ZAPI_FUZZING)
+extern void set_netlink_read(int flag);
+extern void netlink_read_init(const char *fname);
+#endif
 extern int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 			      struct nlsock *nl, struct zebra_ns *zns,
 			      int count, int startup);

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -364,7 +364,6 @@ int main(int argc, char **argv)
 /* For debug purpose. */
 /* SET_FLAG (zebra_debug_event, ZEBRA_DEBUG_EVENT); */
 
-
 	/* Process the configuration file. Among other configuration
 	*  directives we can meet those installing static routes. Such
 	*  requests will not be executed immediately, but queued in


### PR DESCRIPTION
This code allows you to fuzz the netlink listening socket
in zebra by --enable-fuzzing and passing the -w [FILE]
option when running zebra.

File collection is stored in /var/run/frr/netlink_*
where each number is just a counter to keep the
files distinct.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>