### PR TITLE
zebra: Add address family filters

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -740,6 +740,16 @@ int netlink_route_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return 0;
 	}
 
+	if (!(rtm->rtm_family == AF_INET || rtm->rtm_family == AF_INET6
+	      || rtm->rtm_family == AF_ETHERNET || rtm->rtm_family == AF_EVPN
+	      || rtm->rtm_family == AF_UNSPEC
+	      || rtm->rtm_family == AF_FLOWSPEC)) {
+		zlog_warn(
+			"Invalid address family: %d recieved from kernel route change: %d",
+			rtm->rtm_family, h->nlmsg_type);
+		return 0;
+	}
+
 	/* Connected route. */
 	if (IS_ZEBRA_DEBUG_KERNEL)
 		zlog_debug("%s %s %s proto %s NS %u",
@@ -2386,6 +2396,12 @@ int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id)
 
 	if (ndm->ndm_family == AF_INET || ndm->ndm_family == AF_INET6)
 		return netlink_ipneigh_change(h, len, ns_id);
+	else {
+		zlog_warn(
+			"Invalid address family: %d recieved from kernel neighbor change: %d",
+			ndm->ndm_family, h->nlmsg_type);
+		return 0;
+	}
 
 	return 0;
 }

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -741,11 +741,10 @@ int netlink_route_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	}
 
 	if (!(rtm->rtm_family == AF_INET || rtm->rtm_family == AF_INET6
-	      || rtm->rtm_family == AF_ETHERNET || rtm->rtm_family == AF_EVPN
-	      || rtm->rtm_family == AF_UNSPEC
-	      || rtm->rtm_family == AF_FLOWSPEC)) {
+	      || rtm->rtm_family == AF_ETHERNET
+	      || rtm->rtm_family == AF_MPLS)) {
 		zlog_warn(
-			"Invalid address family: %d recieved from kernel route change: %d",
+			"Invalid address family: %d received from kernel route change: %d",
 			rtm->rtm_family, h->nlmsg_type);
 		return 0;
 	}
@@ -2398,7 +2397,7 @@ int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id)
 		return netlink_ipneigh_change(h, len, ns_id);
 	else {
 		zlog_warn(
-			"Invalid address family: %d recieved from kernel neighbor change: %d",
+			"Invalid address family: %d received from kernel neighbor change: %d",
 			ndm->ndm_family, h->nlmsg_type);
 		return 0;
 	}

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -204,8 +204,12 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	}
 
 	frh = NLMSG_DATA(h);
-	if (frh->family != AF_INET && frh->family != AF_INET6)
+	if (frh->family != AF_INET && frh->family != AF_INET6) {
+		zlog_warn(
+			"Invalid address family: %d received from kernel rule change: %d",
+			frh->family, h->nlmsg_type);
 		return 0;
+	}
 	if (frh->action != FR_ACT_TO_TBL)
 		return 0;
 


### PR DESCRIPTION
The zebra netlink socket was attempting to read netlink
messages with invalid address families in a couple areas.
Added filters and warn messages.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>