### PR TITLE
tests/isisd: fix warnings

### DIFF
--- a/tests/isisd/test_isis_vertex_queue.c
+++ b/tests/isisd/test_isis_vertex_queue.c
@@ -16,43 +16,42 @@ static size_t vertex_count;
 
 static void setup_test_vertices(void)
 {
-	struct prefix p = {
-		.family = AF_UNSPEC
+	union isis_N nid, nip = {
+		.prefix.family = AF_UNSPEC
 	};
-	uint8_t node_id[7];
 
 	vertices = XMALLOC(MTYPE_TMP, sizeof(*vertices) * 16);
 
-	p.family = AF_INET;
-	p.prefixlen = 24;
-	inet_pton(AF_INET, "192.168.1.0", &p.u.prefix4);
-	vertices[vertex_count] = isis_vertex_new(&p, VTYPE_IPREACH_TE);
+	nip.prefix.family = AF_INET;
+	nip.prefix.prefixlen = 24;
+	inet_pton(AF_INET, "192.168.1.0", &nip.prefix.u.prefix4);
+	vertices[vertex_count] = isis_vertex_new(&nip, VTYPE_IPREACH_TE);
 	vertices[vertex_count]->d_N = 20;
 	vertex_count++;
 
-	p.family = AF_INET;
-	p.prefixlen = 24;
-	inet_pton(AF_INET, "192.168.2.0", &p.u.prefix4);
-	vertices[vertex_count] = isis_vertex_new(&p, VTYPE_IPREACH_TE);
+	nip.prefix.family = AF_INET;
+	nip.prefix.prefixlen = 24;
+	inet_pton(AF_INET, "192.168.2.0", &nip.prefix.u.prefix4);
+	vertices[vertex_count] = isis_vertex_new(&nip, VTYPE_IPREACH_TE);
 	vertices[vertex_count]->d_N = 20;
 	vertex_count++;
 
-	memset(node_id, 0, sizeof(node_id));
-	node_id[6] = 1;
-	vertices[vertex_count] = isis_vertex_new(node_id, VTYPE_PSEUDO_TE_IS);
+	memset(nid.id, 0, sizeof(nid.id));
+	nid.id[6] = 1;
+	vertices[vertex_count] = isis_vertex_new(&nid, VTYPE_PSEUDO_TE_IS);
 	vertices[vertex_count]->d_N = 15;
 	vertex_count++;
 
-	memset(node_id, 0, sizeof(node_id));
-	node_id[5] = 2;
-	vertices[vertex_count] = isis_vertex_new(node_id, VTYPE_NONPSEUDO_TE_IS);
+	memset(nid.id, 0, sizeof(nid.id));
+	nid.id[5] = 2;
+	vertices[vertex_count] = isis_vertex_new(&nid, VTYPE_NONPSEUDO_TE_IS);
 	vertices[vertex_count]->d_N = 15;
 	vertex_count++;
 
-	p.family = AF_INET;
-	p.prefixlen = 24;
-	inet_pton(AF_INET, "192.168.3.0", &p.u.prefix4);
-	vertices[vertex_count] = isis_vertex_new(&p, VTYPE_IPREACH_TE);
+	nip.prefix.family = AF_INET;
+	nip.prefix.prefixlen = 24;
+	inet_pton(AF_INET, "192.168.3.0", &nip.prefix.u.prefix4);
+	vertices[vertex_count] = isis_vertex_new(&nip, VTYPE_IPREACH_TE);
 	vertices[vertex_count]->d_N = 20;
 	vertex_count++;
 };
@@ -76,23 +75,23 @@ static void test_ordered(void)
 	assert(isis_vertex_queue_count(&q) == vertex_count);
 
 	for (size_t i = 0; i < vertex_count; i++) {
-		assert(isis_find_vertex(&q, vertices[i]->N.id, vertices[i]->type) == vertices[i]);
+		assert(isis_find_vertex(&q, &vertices[i]->N, vertices[i]->type) == vertices[i]);
 	}
 
 	assert(isis_vertex_queue_pop(&q) == vertices[2]);
-	assert(isis_find_vertex(&q, vertices[2]->N.id, vertices[2]->type) == NULL);
+	assert(isis_find_vertex(&q, &vertices[2]->N, vertices[2]->type) == NULL);
 
 	assert(isis_vertex_queue_pop(&q) == vertices[3]);
-	assert(isis_find_vertex(&q, vertices[3]->N.id, vertices[3]->type) == NULL);
+	assert(isis_find_vertex(&q, &vertices[3]->N, vertices[3]->type) == NULL);
 
 	assert(isis_vertex_queue_pop(&q) == vertices[0]);
-	assert(isis_find_vertex(&q, vertices[0]->N.id, vertices[0]->type) == NULL);
+	assert(isis_find_vertex(&q, &vertices[0]->N, vertices[0]->type) == NULL);
 
 	assert(isis_vertex_queue_pop(&q) == vertices[1]);
-	assert(isis_find_vertex(&q, vertices[1]->N.id, vertices[1]->type) == NULL);
+	assert(isis_find_vertex(&q, &vertices[1]->N, vertices[1]->type) == NULL);
 
 	isis_vertex_queue_delete(&q, vertices[4]);
-	assert(isis_find_vertex(&q, vertices[4]->N.id, vertices[4]->type) == NULL);
+	assert(isis_find_vertex(&q, &vertices[4]->N, vertices[4]->type) == NULL);
 
 	assert(isis_vertex_queue_count(&q) == 0);
 	assert(isis_vertex_queue_pop(&q) == NULL);


### PR DESCRIPTION
Commit ae9c9aba changed isis_vertex_id_init() and isis_find_vertex()
parameters, so compiler reported warnings in the test (the actual data
passing through is the same because of the union used in the latest changes).
This commit fixes the warnings in the test.

Thanks to @mjstapp for discovering the issue :-)
