### PR TITLE
pimd: uninitialized memory access fix

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -430,6 +430,9 @@ int pim_ecmp_nexthop_search(struct pim_instance *pim,
 	if (!pnc || !pnc->nexthop_num || !nexthop)
 		return 0;
 
+	memset(&nbrs, 0, sizeof(nbrs));
+	memset(&ifps, 0, sizeof(ifps));
+
 	// Current Nexthop is VALID, check to stay on the current path.
 	if (nexthop->interface && nexthop->interface->info
 	    && nexthop->mrib_nexthop_addr.u.prefix4.s_addr
@@ -828,6 +831,9 @@ int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 				__PRETTY_FUNCTION__, addr_str, pim->vrf->name);
 		return 0;
 	}
+
+	memset(&nbrs, 0, sizeof(nbrs));
+	memset(&ifps, 0, sizeof(ifps));
 
 	/*
 	 * Look up all interfaces and neighbors,


### PR DESCRIPTION
Signed-off-by: F. Aragon <paco@voltanet.io>