### PR TITLE
zebra: remove unused var in zserv.c

### DIFF
--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1024,7 +1024,6 @@ DEFUN (show_zebra_client_summary,
 void zserv_read_file(char *input)
 {
 	int fd;
-	struct zserv *client = NULL;
 	struct thread t;
 
 	fd = open(input, O_RDONLY | O_NONBLOCK);


### PR DESCRIPTION
Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>