### PR TITLE
lib, ripnd: Isolate aggreagate pointer to using protocol

### DIFF
--- a/bgpd/Makefile.am
+++ b/bgpd/Makefile.am
@@ -41,6 +41,7 @@ BGP_VNC_RFAPI_HD=rfapi/bgp_rfapi_cfg.h \
 	rfapi/rfapi_monitor.h \
 	rfapi/rfapi_private.h \
 	rfapi/rfapi_rib.h \
+	rfapi/rfapi_table.h \
 	rfapi/rfapi_vty.h \
 	rfapi/vnc_debug.h \
 	rfapi/vnc_export_bgp.h \

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -28,6 +28,8 @@
 
 #include "lib/thread.h"
 
+#include "bgpd/rfapi/rfapi_table.h"
+
 /*
  * These are per-rt-import-list
  *
@@ -100,7 +102,7 @@ extern void rfapiImportTableRefDelByIt(struct bgp *bgp,
  * next less-specific node (i.e., this node's parent) at the end.
  */
 extern struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
-	struct route_node *rn, uint32_t lifetime, /* put into nexthop entries */
+	struct rfapi_node *rn, uint32_t lifetime, /* put into nexthop entries */
 	struct rfapi_ip_addr *exclude_vnaddr,     /* omit routes to same NVE */
 	struct route_table *rfd_rib_table,   /* preload this NVE rib table */
 	struct prefix *pfx_target_original); /* query target */
@@ -122,10 +124,10 @@ extern struct rfapi_next_hop_entry *rfapiEthRouteTable2NextHopList(
 extern int rfapiEcommunitiesIntersect(struct ecommunity *e1,
 				      struct ecommunity *e2);
 
-extern void rfapiCheckRefcount(struct route_node *rn, safi_t safi,
+extern void rfapiCheckRefcount(struct rfapi_node *rn, safi_t safi,
 			       int lockoffset);
 
-extern int rfapiHasNonRemovedRoutes(struct route_node *rn);
+extern int rfapiHasNonRemovedRoutes(struct rfapi_node *rn);
 
 extern int rfapiProcessDeferredClose(struct thread *t);
 
@@ -153,7 +155,7 @@ extern void rfapiBgpInfoFilteredImportVPN(
 	uint32_t *label);  /* part of bgp_info */
 
 extern struct rfapi_next_hop_entry *rfapiEthRouteNode2NextHopList(
-	struct route_node *rn, struct rfapi_ip_prefix *rprefix,
+	struct rfapi_node *rn, struct rfapi_ip_prefix *rprefix,
 	uint32_t lifetime,		      /* put into nexthop entries */
 	struct rfapi_ip_addr *exclude_vnaddr, /* omit routes to same NVE */
 	struct route_table *rib_route_table,  /* preload NVE rib table */

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -68,10 +68,10 @@ static void rfapiMonitorEthDetachImport(struct bgp *bgp,
 /*
  * Debug function, special case
  */
-void rfapiMonitorEthSlCheck(struct route_node *rn, const char *tag1,
+void rfapiMonitorEthSlCheck(struct rfapi_node *rn, const char *tag1,
 			    const char *tag2)
 {
-	struct route_node *rn_saved = NULL;
+	struct rfapi_node *rn_saved = NULL;
 	static struct skiplist *sl_saved = NULL;
 	struct skiplist *sl;
 
@@ -118,12 +118,13 @@ void rfapiMonitorDupCheck(struct bgp *bgp)
 	struct rfapi_descriptor *rfd;
 
 	for (ALL_LIST_ELEMENTS_RO(&bgp->rfapi->descriptors, hnode, rfd)) {
-		struct route_node *mrn;
+		struct rfapi_node *mrn;
 
 		if (!rfd->mon)
 			continue;
 
-		for (mrn = route_top(rfd->mon); mrn; mrn = route_next(mrn)) {
+		for (mrn = rfapi_route_top(rfd->mon); mrn;
+		     mrn = rfapi_route_next(mrn)) {
 			struct rfapi_monitor_vpn *m;
 			for (m = (struct rfapi_monitor_vpn *)(mrn->info); m;
 			     m = m->next)
@@ -132,12 +133,13 @@ void rfapiMonitorDupCheck(struct bgp *bgp)
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(&bgp->rfapi->descriptors, hnode, rfd)) {
-		struct route_node *mrn;
+		struct rfapi_node *mrn;
 
 		if (!rfd->mon)
 			continue;
 
-		for (mrn = route_top(rfd->mon); mrn; mrn = route_next(mrn)) {
+		for (mrn = rfapi_route_top(rfd->mon); mrn;
+		     mrn = rfapi_route_next(mrn)) {
 			struct rfapi_monitor_vpn *m;
 
 			for (m = (struct rfapi_monitor_vpn *)(mrn->info); m;
@@ -158,15 +160,17 @@ void rfapiMonitorCleanCheck(struct bgp *bgp)
 		assert(!rfd->import_table->vpn0_queries[AFI_IP]);
 		assert(!rfd->import_table->vpn0_queries[AFI_IP6]);
 
-		struct route_node *rn;
+		struct rfapi_node *rn;
 
-		for (rn = route_top(rfd->import_table->imported_vpn[AFI_IP]);
-		     rn; rn = route_next(rn)) {
+		for (rn = rfapi_route_top(
+			     rfd->import_table->imported_vpn[AFI_IP]);
+		     rn; rn = rfapi_route_next(rn)) {
 
 			assert(!RFAPI_MONITOR_VPN(rn));
 		}
-		for (rn = route_top(rfd->import_table->imported_vpn[AFI_IP6]);
-		     rn; rn = route_next(rn)) {
+		for (rn = rfapi_route_top(
+			     rfd->import_table->imported_vpn[AFI_IP6]);
+		     rn; rn = rfapi_route_next(rn)) {
 
 			assert(!RFAPI_MONITOR_VPN(rn));
 		}
@@ -180,7 +184,7 @@ void rfapiMonitorCheckAttachAllowed(void)
 	assert(!(bgp->rfapi_cfg->flags & BGP_VNC_CONFIG_CALLBACK_DISABLE));
 }
 
-void rfapiMonitorExtraFlush(safi_t safi, struct route_node *rn)
+void rfapiMonitorExtraFlush(safi_t safi, struct rfapi_node *rn)
 {
 	struct rfapi_it_extra *hie;
 	struct rfapi_monitor_vpn *v;
@@ -202,7 +206,7 @@ void rfapiMonitorExtraFlush(safi_t safi, struct route_node *rn)
 			e_next = e->next;
 			e->next = NULL;
 			XFREE(MTYPE_RFAPI_MONITOR_ENCAP, e);
-			route_unlock_node(rn);
+			rfapi_unlock_node(rn);
 		}
 		hie->u.encap.e = NULL;
 		break;
@@ -212,33 +216,33 @@ void rfapiMonitorExtraFlush(safi_t safi, struct route_node *rn)
 			v_next = v->next;
 			v->next = NULL;
 			XFREE(MTYPE_RFAPI_MONITOR, e);
-			route_unlock_node(rn);
+			rfapi_unlock_node(rn);
 		}
 		hie->u.vpn.v = NULL;
 		if (hie->u.vpn.e.source) {
 			while (!skiplist_delete_first(hie->u.vpn.e.source)) {
-				route_unlock_node(rn);
+				rfapi_unlock_node(rn);
 			}
 			skiplist_free(hie->u.vpn.e.source);
 			hie->u.vpn.e.source = NULL;
-			route_unlock_node(rn);
+			rfapi_unlock_node(rn);
 		}
 		if (hie->u.vpn.idx_rd) {
 			/* looping through bi->extra->vnc.import.rd is tbd */
 			while (!skiplist_delete_first(hie->u.vpn.idx_rd)) {
-				route_unlock_node(rn);
+				rfapi_unlock_node(rn);
 			}
 			skiplist_free(hie->u.vpn.idx_rd);
 			hie->u.vpn.idx_rd = NULL;
-			route_unlock_node(rn);
+			rfapi_unlock_node(rn);
 		}
 		if (hie->u.vpn.mon_eth) {
 			while (!skiplist_delete_first(hie->u.vpn.mon_eth)) {
-				route_unlock_node(rn);
+				rfapi_unlock_node(rn);
 			}
 			skiplist_free(hie->u.vpn.mon_eth);
 			hie->u.vpn.mon_eth = NULL;
-			route_unlock_node(rn);
+			rfapi_unlock_node(rn);
 		}
 		break;
 
@@ -247,13 +251,13 @@ void rfapiMonitorExtraFlush(safi_t safi, struct route_node *rn)
 	}
 	XFREE(MTYPE_RFAPI_IT_EXTRA, hie);
 	rn->aggregate = NULL;
-	route_unlock_node(rn);
+	rfapi_unlock_node(rn);
 }
 
 /*
  * If the child lists are empty, release the rfapi_it_extra struct
  */
-void rfapiMonitorExtraPrune(safi_t safi, struct route_node *rn)
+void rfapiMonitorExtraPrune(safi_t safi, struct rfapi_node *rn)
 {
 	struct rfapi_it_extra *hie;
 
@@ -279,28 +283,28 @@ void rfapiMonitorExtraPrune(safi_t safi, struct route_node *rn)
 				return;
 			skiplist_free(hie->u.vpn.mon_eth);
 			hie->u.vpn.mon_eth = NULL;
-			route_unlock_node(rn); /* uncount skiplist */
+			rfapi_unlock_node(rn); /* uncount skiplist */
 		}
 		if (hie->u.vpn.e.source) {
 			if (skiplist_count(hie->u.vpn.e.source))
 				return;
 			skiplist_free(hie->u.vpn.e.source);
 			hie->u.vpn.e.source = NULL;
-			route_unlock_node(rn);
+			rfapi_unlock_node(rn);
 		}
 		if (hie->u.vpn.idx_rd) {
 			if (skiplist_count(hie->u.vpn.idx_rd))
 				return;
 			skiplist_free(hie->u.vpn.idx_rd);
 			hie->u.vpn.idx_rd = NULL;
-			route_unlock_node(rn);
+			rfapi_unlock_node(rn);
 		}
 		if (hie->u.vpn.mon_eth) {
 			if (skiplist_count(hie->u.vpn.mon_eth))
 				return;
 			skiplist_free(hie->u.vpn.mon_eth);
 			hie->u.vpn.mon_eth = NULL;
-			route_unlock_node(rn);
+			rfapi_unlock_node(rn);
 		}
 		break;
 
@@ -309,17 +313,17 @@ void rfapiMonitorExtraPrune(safi_t safi, struct route_node *rn)
 	}
 	XFREE(MTYPE_RFAPI_IT_EXTRA, hie);
 	rn->aggregate = NULL;
-	route_unlock_node(rn);
+	rfapi_unlock_node(rn);
 }
 
 /*
  * returns locked node
  */
-struct route_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
+struct rfapi_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
 					     struct prefix *p)
 {
 	afi_t afi;
-	struct route_node *rn;
+	struct rfapi_node *rn;
 
 	if (RFAPI_0_PREFIX(p)) {
 		assert(1);
@@ -341,7 +345,8 @@ struct route_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
 	 * if a monitor is moved to another node, there must be
 	 * corresponding unlock/locks
 	 */
-	for (rn = route_node_match(rfd->import_table->imported_vpn[afi], p);
+	for (rn = rfapi_route_node_match(rfd->import_table->imported_vpn[afi],
+					 p);
 	     rn;) {
 
 		struct bgp_info *bi;
@@ -369,9 +374,9 @@ struct route_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
 		if (bi)
 			break;
 
-		route_unlock_node(rn);
-		if ((rn = rn->parent)) {
-			route_lock_node(rn);
+		rfapi_unlock_node(rn);
+		if ((rn = (struct rfapi_node *)rn->parent)) {
+			rfapi_unlock_node(rn);
 		}
 	}
 
@@ -383,8 +388,8 @@ struct route_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
 
 		/* creates default node if none exists, and increments ref count
 		 */
-		rn = route_node_get(rfd->import_table->imported_vpn[afi],
-				    &pfx_default);
+		rn = rfapi_route_node_get(rfd->import_table->imported_vpn[afi],
+					  &pfx_default);
 	}
 
 	return rn;
@@ -396,10 +401,10 @@ struct route_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
  * returned (for the benefit of caller which might like to use it
  * to generate an immediate query response).
  */
-static struct route_node *rfapiMonitorAttachImport(struct rfapi_descriptor *rfd,
+static struct rfapi_node *rfapiMonitorAttachImport(struct rfapi_descriptor *rfd,
 						   struct rfapi_monitor_vpn *m)
 {
-	struct route_node *rn;
+	struct rfapi_node *rn;
 
 	rfapiMonitorCheckAttachAllowed();
 
@@ -438,7 +443,7 @@ static struct route_node *rfapiMonitorAttachImport(struct rfapi_descriptor *rfd,
  */
 void rfapiMonitorAttachImportHd(struct rfapi_descriptor *rfd)
 {
-	struct route_node *mrn;
+	struct rfapi_node *mrn;
 
 	if (!rfd->mon) {
 		/*
@@ -447,7 +452,8 @@ void rfapiMonitorAttachImportHd(struct rfapi_descriptor *rfd)
 		return;
 	}
 
-	for (mrn = route_top(rfd->mon); mrn; mrn = route_next(mrn)) {
+	for (mrn = rfapi_route_top(rfd->mon); mrn;
+	     mrn = rfapi_route_next(mrn)) {
 
 		if (!mrn->info)
 			continue;
@@ -467,11 +473,11 @@ void rfapiMonitorAttachImportHd(struct rfapi_descriptor *rfd)
  * are disabled, this function will not perform a lookup, and the
  * caller will have to do its own lookup.
  */
-struct route_node *
+struct rfapi_node *
 rfapiMonitorAdd(struct bgp *bgp, struct rfapi_descriptor *rfd, struct prefix *p)
 {
 	struct rfapi_monitor_vpn *m;
-	struct route_node *rn;
+	struct rfapi_node *rn;
 
 	/*
 	 * Initialize nve's monitor list if needed
@@ -482,13 +488,13 @@ rfapiMonitorAdd(struct bgp *bgp, struct rfapi_descriptor *rfd, struct prefix *p)
 	if (!rfd->mon) {
 		rfd->mon = route_table_init();
 	}
-	rn = route_node_get(rfd->mon, p);
+	rn = rfapi_route_node_get(rfd->mon, p);
 	if (rn->info) {
 		/*
 		 * received this query before, no further action needed
 		 */
 		rfapiMonitorTimerRestart((struct rfapi_monitor_vpn *)rn->info);
-		route_unlock_node(rn);
+		rfapi_unlock_node(rn);
 		return NULL;
 	}
 
@@ -575,7 +581,7 @@ rfapiMonitorDetachImport(struct rfapi_monitor_vpn *m)
 						this->next;
 				}
 				RFAPI_CHECK_REFCOUNT(m->node, SAFI_MPLS_VPN, 1);
-				route_unlock_node(m->node);
+				rfapi_unlock_node(m->node);
 			}
 			m->node = NULL;
 		}
@@ -586,12 +592,12 @@ rfapiMonitorDetachImport(struct rfapi_monitor_vpn *m)
 
 void rfapiMonitorDetachImportHd(struct rfapi_descriptor *rfd)
 {
-	struct route_node *rn;
+	struct rfapi_node *rn;
 
 	if (!rfd->mon)
 		return;
 
-	for (rn = route_top(rfd->mon); rn; rn = route_next(rn)) {
+	for (rn = rfapi_route_top(rfd->mon); rn; rn = rfapi_route_next(rn)) {
 		if (rn->info) {
 			rfapiMonitorDetachImport(
 				(struct rfapi_monitor_vpn *)(rn->info));
@@ -602,11 +608,11 @@ void rfapiMonitorDetachImportHd(struct rfapi_descriptor *rfd)
 void rfapiMonitorDel(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		     struct prefix *p)
 {
-	struct route_node *rn;
+	struct rfapi_node *rn;
 	struct rfapi_monitor_vpn *m;
 
 	assert(rfd->mon);
-	rn = route_node_get(rfd->mon, p); /* locks node */
+	rn = rfapi_route_node_get(rfd->mon, p); /* locks node */
 	m = rn->info;
 
 	assert(m);
@@ -628,8 +634,8 @@ void rfapiMonitorDel(struct bgp *bgp, struct rfapi_descriptor *rfd,
 	 */
 	XFREE(MTYPE_RFAPI_MONITOR, m);
 	rn->info = NULL;
-	route_unlock_node(rn); /* undo original lock when created */
-	route_unlock_node(rn); /* undo lock in route_node_get */
+	rfapi_unlock_node(rn); /* undo original lock when created */
+	rfapi_unlock_node(rn); /* undo lock in rfapi_route_node_get */
 
 	--rfd->monitor_count;
 	--bgp->rfapi->monitor_count;
@@ -640,7 +646,7 @@ void rfapiMonitorDel(struct bgp *bgp, struct rfapi_descriptor *rfd,
  */
 int rfapiMonitorDelHd(struct rfapi_descriptor *rfd)
 {
-	struct route_node *rn;
+	struct rfapi_node *rn;
 	struct bgp *bgp;
 	int count = 0;
 
@@ -649,7 +655,8 @@ int rfapiMonitorDelHd(struct rfapi_descriptor *rfd)
 	bgp = bgp_get_default();
 
 	if (rfd->mon) {
-		for (rn = route_top(rfd->mon); rn; rn = route_next(rn)) {
+		for (rn = rfapi_route_top(rfd->mon); rn;
+		     rn = rfapi_route_next(rn)) {
 			struct rfapi_monitor_vpn *m;
 			if ((m = rn->info)) {
 				if (!(bgp->rfapi_cfg->flags
@@ -664,7 +671,7 @@ int rfapiMonitorDelHd(struct rfapi_descriptor *rfd)
 
 				XFREE(MTYPE_RFAPI_MONITOR, m);
 				rn->info = NULL;
-				route_unlock_node(rn); /* undo original lock
+				rfapi_unlock_node(rn); /* undo original lock
 							  when created */
 				++count;
 				--rfd->monitor_count;
@@ -788,7 +795,7 @@ static void rfapiMonitorTimerRestart(struct rfapi_monitor_vpn *m)
  */
 void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd, struct prefix *p)
 {
-	struct route_node *rn;
+	struct rfapi_node *rn;
 
 	if (AF_ETHERNET == p->family) {
 		struct rfapi_monitor_eth *mon_eth;
@@ -812,7 +819,8 @@ void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd, struct prefix *p)
 		}
 
 	} else {
-		for (rn = route_top(rfd->mon); rn; rn = route_next(rn)) {
+		for (rn = rfapi_route_top(rfd->mon); rn;
+		     rn = rfapi_route_next(rn)) {
 			struct rfapi_monitor_vpn *m;
 
 			if (!((m = rn->info)))
@@ -831,11 +839,11 @@ void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd, struct prefix *p)
  * rfapiRibUpdatePendingNode with this node and all corresponding NVEs.
  */
 void rfapiMonitorItNodeChanged(
-	struct rfapi_import_table *import_table, struct route_node *it_node,
+	struct rfapi_import_table *import_table, struct rfapi_node *it_node,
 	struct rfapi_monitor_vpn *monitor_list) /* for base it node, NULL=all */
 {
 	struct skiplist *nves_seen;
-	struct route_node *rn = it_node;
+	struct rfapi_node *rn = it_node;
 	struct bgp *bgp = bgp_get_default();
 	afi_t afi = family2afi(rn->p.family);
 #if DEBUG_L2_EXTRA
@@ -947,7 +955,7 @@ void rfapiMonitorItNodeChanged(
 						m->rfd->response_lifetime);
 				}
 			}
-			rn = rn->parent;
+			rn = (struct rfapi_node *)rn->parent;
 			if (rn)
 				m = RFAPI_MONITOR_VPN(rn);
 		} while (rn);
@@ -1023,8 +1031,8 @@ void rfapiMonitorItNodeChanged(
  * omit old node and its subtree
  */
 void rfapiMonitorMovedUp(struct rfapi_import_table *import_table,
-			 struct route_node *old_node,
-			 struct route_node *new_node,
+			 struct rfapi_node *old_node,
+			 struct rfapi_node *new_node,
 			 struct rfapi_monitor_vpn *monitor_list)
 {
 	struct bgp *bgp = bgp_get_default();
@@ -1125,7 +1133,7 @@ static int mon_eth_cmp(void *a, void *b)
 
 static void rfapiMonitorEthAttachImport(
 	struct rfapi_import_table *it,
-	struct route_node *rn,	 /* it node attach point if non-0 */
+	struct rfapi_node *rn,	 /* it node attach point if non-0 */
 	struct rfapi_monitor_eth *mon) /* monitor struct to attach */
 {
 	struct skiplist *sl;
@@ -1162,7 +1170,7 @@ static void rfapiMonitorEthAttachImport(
 	if (!sl) {
 		sl = RFAPI_MONITOR_ETH_W_ALLOC(rn) =
 			skiplist_new(0, NULL, NULL);
-		route_lock_node(rn); /* count skiplist mon_eth */
+		rfapi_unlock_node(rn); /* count skiplist mon_eth */
 	}
 
 #if DEBUG_L2_EXTRA
@@ -1175,7 +1183,7 @@ static void rfapiMonitorEthAttachImport(
 	assert(!rc);
 
 	/* count eth monitor */
-	route_lock_node(rn);
+	rfapi_unlock_node(rn);
 }
 
 /*
@@ -1202,7 +1210,7 @@ static void rfapiMonitorEthAttachImportHd(struct bgp *bgp,
 
 		struct rfapi_import_table *it;
 		struct prefix pfx_mac_buf;
-		struct route_node *rn;
+		struct rfapi_node *rn;
 
 		it = rfapiMacImportTableGet(bgp, mon->logical_net_id);
 		assert(it);
@@ -1212,7 +1220,8 @@ static void rfapiMonitorEthAttachImportHd(struct bgp *bgp,
 		pfx_mac_buf.prefixlen = 48;
 		pfx_mac_buf.u.prefix_eth = mon->macaddr;
 
-		rn = route_node_get(it->imported_vpn[AFI_L2VPN], &pfx_mac_buf);
+		rn = rfapi_route_node_get(it->imported_vpn[AFI_L2VPN],
+					  &pfx_mac_buf);
 		assert(rn);
 
 		(void)rfapiMonitorEthAttachImport(it, rn, mon);
@@ -1226,7 +1235,7 @@ static void rfapiMonitorEthDetachImport(
 	struct rfapi_import_table *it;
 	struct prefix pfx_mac_buf;
 	struct skiplist *sl;
-	struct route_node *rn;
+	struct rfapi_node *rn;
 	int rc;
 
 	it = rfapiMacImportTableGet(bgp, mon->logical_net_id);
@@ -1262,7 +1271,7 @@ static void rfapiMonitorEthDetachImport(
 	pfx_mac_buf.prefixlen = 48;
 	pfx_mac_buf.u.prefix_eth = mon->macaddr;
 
-	rn = route_node_get(it->imported_vpn[AFI_L2VPN], &pfx_mac_buf);
+	rn = rfapi_route_node_get(it->imported_vpn[AFI_L2VPN], &pfx_mac_buf);
 	assert(rn);
 
 #if DEBUG_L2_EXTRA
@@ -1288,10 +1297,10 @@ static void rfapiMonitorEthDetachImport(
 	assert(!rc);
 
 	/* uncount eth monitor */
-	route_unlock_node(rn);
+	rfapi_unlock_node(rn);
 }
 
-struct route_node *rfapiMonitorEthAdd(struct bgp *bgp,
+struct rfapi_node *rfapiMonitorEthAdd(struct bgp *bgp,
 				      struct rfapi_descriptor *rfd,
 				      struct ethaddr *macaddr,
 				      uint32_t logical_net_id)
@@ -1300,7 +1309,7 @@ struct route_node *rfapiMonitorEthAdd(struct bgp *bgp,
 	struct rfapi_monitor_eth mon_buf;
 	struct rfapi_monitor_eth *val;
 	struct rfapi_import_table *it;
-	struct route_node *rn = NULL;
+	struct rfapi_node *rn = NULL;
 	struct prefix pfx_mac_buf;
 
 	if (!rfd->mon_eth) {
@@ -1323,7 +1332,8 @@ struct route_node *rfapiMonitorEthAdd(struct bgp *bgp,
 	pfx_mac_buf.u.prefix_eth = *macaddr;
 
 	if (!RFAPI_0_ETHERADDR(macaddr)) {
-		rn = route_node_get(it->imported_vpn[AFI_L2VPN], &pfx_mac_buf);
+		rn = rfapi_route_node_get(it->imported_vpn[AFI_L2VPN],
+					  &pfx_mac_buf);
 		assert(rn);
 	}
 
@@ -1454,7 +1464,7 @@ void rfapiMonitorCallbacksOff(struct bgp *bgp)
 	struct rfapi_import_table *it;
 	afi_t afi;
 	struct route_table *rt;
-	struct route_node *rn;
+	struct rfapi_node *rn;
 	void *cursor;
 	int rc;
 	struct rfapi *h = bgp->rfapi;
@@ -1485,7 +1495,8 @@ void rfapiMonitorCallbacksOff(struct bgp *bgp)
 
 			rt = it->imported_vpn[afi];
 
-			for (rn = route_top(rt); rn; rn = route_next(rn)) {
+			for (rn = rfapi_route_top(rt); rn;
+			     rn = rfapi_route_next(rn)) {
 				m = RFAPI_MONITOR_VPN(rn);
 				if (RFAPI_MONITOR_VPN(rn))
 					RFAPI_MONITOR_VPN_W_ALLOC(rn) = NULL;
@@ -1494,7 +1505,7 @@ void rfapiMonitorCallbacksOff(struct bgp *bgp)
 					m->next =
 						NULL; /* gratuitous safeness */
 					m->node = NULL;
-					route_unlock_node(rn); /* uncount */
+					rfapi_unlock_node(rn); /* uncount */
 				}
 			}
 
@@ -1531,12 +1542,12 @@ void rfapiMonitorCallbacksOff(struct bgp *bgp)
 		 * Find non-0 monitors (i.e., actual addresses, not FTD
 		 * monitors)
 		 */
-		for (rn = route_top(rt); rn; rn = route_next(rn)) {
+		for (rn = rfapi_route_top(rt); rn; rn = rfapi_route_next(rn)) {
 			struct skiplist *sl;
 
 			sl = RFAPI_MONITOR_ETH(rn);
 			while (!skiplist_delete_first(sl)) {
-				route_unlock_node(rn); /* uncount monitor */
+				rfapi_unlock_node(rn); /* uncount monitor */
 			}
 		}
 

--- a/bgpd/rfapi/rfapi_monitor.h
+++ b/bgpd/rfapi/rfapi_monitor.h
@@ -33,7 +33,7 @@ struct rfapi_monitor_vpn {
 	struct rfapi_monitor_vpn *next; /* chain from struct route_node */
 	struct rfapi_descriptor *rfd;   /* which NVE requested the route */
 	struct prefix p;		/* constant: pfx in original request */
-	struct route_node *node;	/* node we're currently attached to */
+	struct rfapi_node *node;	/* node we're currently attached to */
 	uint32_t flags;
 #define RFAPI_MON_FLAG_NEEDCALLBACK	0x00000001      /* deferred callback */
 
@@ -44,9 +44,9 @@ struct rfapi_monitor_vpn {
 struct rfapi_monitor_encap {
 	struct rfapi_monitor_encap *next;
 	struct rfapi_monitor_encap *prev;
-	struct route_node *node; /* VPN node */
+	struct rfapi_node *node; /* VPN node */
 	struct bgp_info *bi;     /* VPN bi */
-	struct route_node *rn;   /* parent node */
+	struct rfapi_node *rn;   /* parent node */
 };
 
 struct rfapi_monitor_eth {
@@ -98,7 +98,7 @@ struct rfapi_it_extra {
 	((struct rfapi_it_extra                                                \
 		  *)((rn)->aggregate                                           \
 			     ? (rn)->aggregate                                 \
-			     : (route_lock_node(rn),                           \
+			     : (rfapi_lock_node(rn),                           \
 				(rn)->aggregate = XCALLOC(                     \
 					MTYPE_RFAPI_IT_EXTRA,                  \
 					sizeof(struct rfapi_it_extra)))))
@@ -138,14 +138,14 @@ extern void rfapiMonitorCleanCheck(struct bgp *bgp);
 
 extern void rfapiMonitorCheckAttachAllowed(void);
 
-extern void rfapiMonitorExtraFlush(safi_t safi, struct route_node *rn);
+extern void rfapiMonitorExtraFlush(safi_t safi, struct rfapi_node *rn);
 
-extern struct route_node *
+extern struct rfapi_node *
 rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd, struct prefix *p);
 
 extern void rfapiMonitorAttachImportHd(struct rfapi_descriptor *rfd);
 
-extern struct route_node *rfapiMonitorAdd(struct bgp *bgp,
+extern struct rfapi_node *rfapiMonitorAdd(struct bgp *bgp,
 					  struct rfapi_descriptor *rfd,
 					  struct prefix *p);
 
@@ -164,21 +164,21 @@ extern void rfapiMonitorResponseRemovalOff(struct bgp *bgp);
 
 extern void rfapiMonitorResponseRemovalOn(struct bgp *bgp);
 
-extern void rfapiMonitorExtraPrune(safi_t safi, struct route_node *rn);
+extern void rfapiMonitorExtraPrune(safi_t safi, struct rfapi_node *rn);
 
 extern void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd,
 				      struct prefix *p);
 
 extern void rfapiMonitorItNodeChanged(struct rfapi_import_table *import_table,
-				      struct route_node *it_node,
+				      struct rfapi_node *it_node,
 				      struct rfapi_monitor_vpn *monitor_list);
 
 extern void rfapiMonitorMovedUp(struct rfapi_import_table *import_table,
-				struct route_node *old_node,
-				struct route_node *new_node,
+				struct rfapi_node *old_node,
+				struct rfapi_node *new_node,
 				struct rfapi_monitor_vpn *monitor_list);
 
-extern struct route_node *rfapiMonitorEthAdd(struct bgp *bgp,
+extern struct rfapi_node *rfapiMonitorEthAdd(struct bgp *bgp,
 					     struct rfapi_descriptor *rfd,
 					     struct ethaddr *macaddr,
 					     uint32_t logical_net_id);

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -47,7 +47,7 @@ struct rfapi_advertised_prefixes {
 };
 
 struct rfapi_descriptor {
-	struct route_node *un_node; /* backref to un table */
+	struct rfapi_node *un_node; /* backref to un table */
 
 	struct rfapi_descriptor *next; /* next vn_addr */
 

--- a/bgpd/rfapi/rfapi_rib.h
+++ b/bgpd/rfapi/rfapi_rib.h
@@ -93,17 +93,17 @@ extern void rfapiRibFree(struct rfapi_descriptor *rfd);
 extern void rfapiRibUpdatePendingNode(struct bgp *bgp,
 				      struct rfapi_descriptor *rfd,
 				      struct rfapi_import_table *it,
-				      struct route_node *it_node,
+				      struct rfapi_node *it_node,
 				      uint32_t lifetime);
 
 extern void rfapiRibUpdatePendingNodeSubtree(struct bgp *bgp,
 					     struct rfapi_descriptor *rfd,
 					     struct rfapi_import_table *it,
-					     struct route_node *it_node,
-					     struct route_node *omit_subtree,
+					     struct rfapi_node *it_node,
+					     struct rfapi_node *omit_subtree,
 					     uint32_t lifetime);
 
-extern int rfapiRibPreloadBi(struct route_node *rfd_rib_node,
+extern int rfapiRibPreloadBi(struct rfapi_node *rfd_rib_node,
 			     struct prefix *pfx_vn, struct prefix *pfx_un,
 			     uint32_t lifetime, struct bgp_info *bi);
 
@@ -113,7 +113,7 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 
 extern void rfapiRibPendingDeleteRoute(struct bgp *bgp,
 				       struct rfapi_import_table *it, afi_t afi,
-				       struct route_node *it_node);
+				       struct rfapi_node *it_node);
 
 extern void rfapiRibShowResponsesSummary(void *stream);
 
@@ -124,7 +124,7 @@ extern void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 
 extern int rfapiRibFTDFilterRecentPrefix(
 	struct rfapi_descriptor *rfd,
-	struct route_node *it_rn,	    /* import table node */
+	struct rfapi_node *it_rn,	    /* import table node */
 	struct prefix *pfx_target_original); /* query target */
 
 extern void rfapiFreeRfapiUnOptionChain(struct rfapi_un_option *p);

--- a/bgpd/rfapi/rfapi_table.h
+++ b/bgpd/rfapi/rfapi_table.h
@@ -1,0 +1,77 @@
+/*
+ * rfapi-table Header
+ * Copyright (C) 2018 Cumulus Networks, Inc.
+ *               Donald Sharp
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef __RFAPI_TABLE_H__
+#define __RFAPI_TABLE_H__
+#include <table.h>
+
+struct rfapi_node {
+	/*
+	 * CAUTION
+	 *
+	 * These fields must be the very first fields in this structure.
+	 *
+	 * @see bgp_node_to_rnode
+	 * @see bgp_node_from_rnode
+	 */
+	ROUTE_NODE_FIELDS
+
+	void *aggregate;
+};
+
+
+static inline struct rfapi_node *rfapi_lock_node(struct rfapi_node *node)
+{
+	return (struct rfapi_node *)route_lock_node((struct route_node *)node);
+}
+
+static inline void rfapi_unlock_node(struct rfapi_node *node)
+{
+	route_unlock_node((struct route_node *)node);
+}
+
+static inline struct rfapi_node *rfapi_route_next(struct rfapi_node *node)
+{
+	return (struct rfapi_node *)route_next((struct route_node *)node);
+}
+
+static inline struct rfapi_node *rfapi_route_top(struct route_table *node)
+{
+	return (struct rfapi_node *)route_top(node);
+}
+
+static inline struct rfapi_node *rfapi_route_node_get(struct route_table *table,
+						      union prefixconstptr ptr)
+{
+	return (struct rfapi_node *)route_node_get(table, ptr);
+}
+
+static inline struct rfapi_node *
+rfapi_route_node_lookup(struct route_table *table, union prefixconstptr ptr)
+{
+	return (struct rfapi_node *)route_node_lookup(table, ptr);
+}
+
+static inline struct rfapi_node *
+rfapi_route_node_match(const struct route_table *table,
+		       union prefixconstptr ptr)
+{
+	return (struct rfapi_node *)route_node_match(table, ptr);
+}
+#endif

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -742,7 +742,7 @@ static void rfapiDebugPrintMonitorEncap(void *stream,
 	   m->bi, HVTYNL);
 }
 
-void rfapiShowItNode(void *stream, struct route_node *rn)
+void rfapiShowItNode(void *stream, struct rfapi_node *rn)
 {
 	struct bgp_info *bi;
 	char buf[BUFSIZ];
@@ -769,7 +769,7 @@ void rfapiShowItNode(void *stream, struct route_node *rn)
 void rfapiShowImportTable(void *stream, const char *label,
 			  struct route_table *rt, int isvpn)
 {
-	struct route_node *rn;
+	struct rfapi_node *rn;
 	char buf[BUFSIZ];
 
 	int (*fp)(void *, const char *, ...);
@@ -782,7 +782,7 @@ void rfapiShowImportTable(void *stream, const char *label,
 
 	fp(out, "Import Table [%s]%s", label, HVTYNL);
 
-	for (rn = route_top(rt); rn; rn = route_next(rn)) {
+	for (rn = rfapi_route_top(rt); rn; rn = rfapi_route_next(rn)) {
 		struct bgp_info *bi;
 
 		if (rn->p.family == AF_ETHERNET) {
@@ -851,7 +851,7 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 
 	for (ALL_LIST_ELEMENTS_RO(&h->descriptors, node, rfd)) {
 
-		struct route_node *rn;
+		struct rfapi_node *rn;
 		int printedquerier = 0;
 
 
@@ -868,8 +868,8 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 		 * IP Queries
 		 */
 		if (rfd->mon) {
-			for (rn = route_top(rfd->mon); rn;
-			     rn = route_next(rn)) {
+			for (rn = rfapi_route_top(rfd->mon); rn;
+			     rn = rfapi_route_next(rn)) {
 				struct rfapi_monitor_vpn *m;
 				char buf_remain[BUFSIZ];
 				char buf_pfx[BUFSIZ];
@@ -1012,7 +1012,7 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 }
 
 static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
-				 struct route_node *rn, struct bgp_info *bi)
+				 struct rfapi_node *rn, struct bgp_info *bi)
 {
 	int (*fp)(void *, const char *, ...);
 	struct vty *vty;
@@ -1218,13 +1218,13 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 
 	for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
 
-		struct route_node *rn;
+		struct rfapi_node *rn;
 
 		if (!it->imported_vpn[afi])
 			continue;
 
-		for (rn = route_top(it->imported_vpn[afi]); rn;
-		     rn = route_next(rn)) {
+		for (rn = rfapi_route_top(it->imported_vpn[afi]); rn;
+		     rn = rfapi_route_next(rn)) {
 
 			struct bgp_info *bi;
 			int count_only;

--- a/bgpd/rfapi/rfapi_vty.h
+++ b/bgpd/rfapi/rfapi_vty.h
@@ -124,7 +124,7 @@ extern char *rfapiMonitorVpn2Str(struct rfapi_monitor_vpn *m, char *buf,
 extern const char *rfapiRfapiIpPrefix2Str(struct rfapi_ip_prefix *p, char *buf,
 					  int bufsize);
 
-extern void rfapiShowItNode(void *stream, struct route_node *rn);
+extern void rfapiShowItNode(void *stream, struct rfapi_node *rn);
 
 extern char *rfapiEthAddr2Str(const struct ethaddr *ea, char *buf, int bufsize);
 

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -53,7 +53,7 @@
 
 static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 				       struct rfapi_nve_group_cfg *rfg,
-				       struct route_node *rn, struct attr *attr,
+				       struct rfapi_node *rn, struct attr *attr,
 				       afi_t afi,
 				       struct rfapi_descriptor *irfd);
 
@@ -171,7 +171,7 @@ static int getce(struct bgp *bgp, struct attr *attr, struct prefix *pfx_ce)
 }
 
 
-void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct route_node *rn,
+void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct rfapi_node *rn,
 				 struct bgp_info *bi)
 {
 	struct attr *attr = bi->attr;
@@ -325,7 +325,7 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct route_node *rn,
 /*
  * "Withdrawing a Route" export process
  */
-void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct route_node *rn,
+void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct rfapi_node *rn,
 				 struct bgp_info *bi)
 {
 	afi_t afi = family2afi(rn->p.family);
@@ -402,7 +402,7 @@ void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct route_node *rn,
 
 static void vnc_direct_bgp_vpn_enable_ce(struct bgp *bgp, afi_t afi)
 {
-	struct route_node *rn;
+	struct rfapi_node *rn;
 	struct bgp_info *ri;
 
 	vnc_zlog_debug_verbose("%s: entry, afi=%d", __func__, afi);
@@ -428,8 +428,8 @@ static void vnc_direct_bgp_vpn_enable_ce(struct bgp *bgp, afi_t afi)
 	/*
 	 * Go through entire ce import table and export to BGP unicast.
 	 */
-	for (rn = route_top(bgp->rfapi->it_ce->imported_vpn[afi]); rn;
-	     rn = route_next(rn)) {
+	for (rn = rfapi_route_top(bgp->rfapi->it_ce->imported_vpn[afi]); rn;
+	     rn = rfapi_route_next(rn)) {
 
 		if (!rn->info)
 			continue;
@@ -511,7 +511,7 @@ static void vnc_direct_bgp_vpn_disable_ce(struct bgp *bgp, afi_t afi)
  * Export methods that proxy nexthop BEGIN
  ***********************************************************************/
 
-static struct ecommunity *vnc_route_origin_ecom(struct route_node *rn)
+static struct ecommunity *vnc_route_origin_ecom(struct rfapi_node *rn)
 {
 	struct ecommunity *new;
 	struct bgp_info *bi;
@@ -584,7 +584,7 @@ static struct ecommunity *vnc_route_origin_ecom_single(struct in_addr *origin)
 static int
 encap_attr_export(struct attr *new, struct attr *orig,
 		  struct prefix *new_nexthop,
-		  struct route_node *rn) /* for VN addrs for ecom list */
+		  struct rfapi_node *rn) /* for VN addrs for ecom list */
 					 /* if rn is 0, use route's nexthop */
 {
 	struct prefix orig_nexthop;
@@ -690,7 +690,7 @@ encap_attr_export(struct attr *new, struct attr *orig,
  */
 void vnc_direct_bgp_add_prefix(struct bgp *bgp,
 			       struct rfapi_import_table *import_table,
-			       struct route_node *rn)
+			       struct rfapi_node *rn)
 {
 	struct attr attr = {0};
 	struct listnode *node, *nnode;
@@ -800,7 +800,7 @@ void vnc_direct_bgp_add_prefix(struct bgp *bgp,
  */
 void vnc_direct_bgp_del_prefix(struct bgp *bgp,
 			       struct rfapi_import_table *import_table,
-			       struct route_node *rn)
+			       struct rfapi_node *rn)
 {
 	struct listnode *node, *nnode;
 	struct rfapi_rfg_name *rfgn;
@@ -961,7 +961,7 @@ void vnc_direct_bgp_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 		if (rfgn->rfg == rfg) {
 
 			struct route_table *rt = NULL;
-			struct route_node *rn;
+			struct rfapi_node *rn;
 			struct attr attr = {0};
 			struct rfapi_import_table *import_table;
 
@@ -981,7 +981,8 @@ void vnc_direct_bgp_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 			/*
 			 * Walk the NVE-Group's VNC Import table
 			 */
-			for (rn = route_top(rt); rn; rn = route_next(rn)) {
+			for (rn = rfapi_route_top(rt); rn;
+			     rn = rfapi_route_next(rn)) {
 
 				if (rn->info) {
 
@@ -1105,7 +1106,7 @@ void vnc_direct_bgp_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 		if (rfg && rfgn->rfg == rfg) {
 
 			struct route_table *rt = NULL;
-			struct route_node *rn;
+			struct rfapi_node *rn;
 			struct rfapi_import_table *import_table;
 
 			import_table = rfg->rfapi_import_table;
@@ -1120,7 +1121,8 @@ void vnc_direct_bgp_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 			/*
 			 * Walk the NVE-Group's VNC Import table
 			 */
-			for (rn = route_top(rt); rn; rn = route_next(rn)) {
+			for (rn = rfapi_route_top(rt); rn;
+			     rn = rfapi_route_next(rn)) {
 
 				if (rn->info) {
 
@@ -1151,7 +1153,7 @@ void vnc_direct_bgp_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 
 static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 				       struct rfapi_nve_group_cfg *rfg,
-				       struct route_node *rn, struct attr *attr,
+				       struct rfapi_node *rn, struct attr *attr,
 				       afi_t afi, struct rfapi_descriptor *irfd)
 {
 	struct prefix nhp;
@@ -1272,7 +1274,7 @@ static void vnc_direct_bgp_add_group_afi(struct bgp *bgp,
 					 afi_t afi)
 {
 	struct route_table *rt = NULL;
-	struct route_node *rn;
+	struct rfapi_node *rn;
 	struct attr attr = {0};
 	struct rfapi_import_table *import_table;
 
@@ -1303,7 +1305,7 @@ static void vnc_direct_bgp_add_group_afi(struct bgp *bgp,
 	/*
 	 * Walk the NVE-Group's VNC Import table
 	 */
-	for (rn = route_top(rt); rn; rn = route_next(rn)) {
+	for (rn = rfapi_route_top(rt); rn; rn = rfapi_route_next(rn)) {
 
 		if (rn->info) {
 
@@ -1358,7 +1360,7 @@ void vnc_direct_bgp_add_group(struct bgp *bgp, struct rfapi_nve_group_cfg *rfg)
 
 static void vnc_direct_del_rn_group_rd(struct bgp *bgp,
 				       struct rfapi_nve_group_cfg *rfg,
-				       struct route_node *rn, afi_t afi,
+				       struct rfapi_node *rn, afi_t afi,
 				       struct rfapi_descriptor *irfd)
 {
 	if (irfd == NULL)
@@ -1381,7 +1383,7 @@ static void vnc_direct_bgp_del_group_afi(struct bgp *bgp,
 					 afi_t afi)
 {
 	struct route_table *rt = NULL;
-	struct route_node *rn;
+	struct rfapi_node *rn;
 	struct rfapi_import_table *import_table;
 
 	vnc_zlog_debug_verbose("%s: entry", __func__);
@@ -1404,7 +1406,7 @@ static void vnc_direct_bgp_del_group_afi(struct bgp *bgp,
 	/*
 	 * Walk the NVE-Group's VNC Import table
 	 */
-	for (rn = route_top(rt); rn; rn = route_next(rn))
+	for (rn = rfapi_route_top(rt); rn; rn = rfapi_route_next(rn))
 		if (rn->info) {
 			if (rfg->type == RFAPI_GROUP_CFG_VRF)
 				vnc_direct_del_rn_group_rd(bgp, rfg, rn, afi,
@@ -1470,9 +1472,9 @@ static void vnc_direct_bgp_unexport_table(afi_t afi, struct route_table *rt,
 {
 	if (nve_list) {
 
-		struct route_node *rn;
+		struct rfapi_node *rn;
 
-		for (rn = route_top(rt); rn; rn = route_next(rn)) {
+		for (rn = rfapi_route_top(rt); rn; rn = rfapi_route_next(rn)) {
 
 			if (rn->info) {
 

--- a/bgpd/rfapi/vnc_export_bgp_p.h
+++ b/bgpd/rfapi/vnc_export_bgp_p.h
@@ -29,19 +29,19 @@
 
 #include "rfapi_private.h"
 
-extern void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct route_node *rn,
+extern void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct rfapi_node *rn,
 					struct bgp_info *bi);
 
-extern void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct route_node *rn,
+extern void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct rfapi_node *rn,
 					struct bgp_info *bi);
 
 extern void vnc_direct_bgp_add_prefix(struct bgp *bgp,
 				      struct rfapi_import_table *import_table,
-				      struct route_node *rn);
+				      struct rfapi_node *rn);
 
 extern void vnc_direct_bgp_del_prefix(struct bgp *bgp,
 				      struct rfapi_import_table *import_table,
-				      struct route_node *rn);
+				      struct rfapi_node *rn);
 
 extern void vnc_direct_bgp_add_nve(struct bgp *bgp,
 				   struct rfapi_descriptor *rfd);

--- a/bgpd/rfapi/vnc_import_bgp_p.h
+++ b/bgpd/rfapi/vnc_import_bgp_p.h
@@ -29,12 +29,12 @@
 
 extern void vnc_import_bgp_exterior_add_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct route_node *rn_interior, /* VPN IT node */
+	struct rfapi_node *rn_interior, /* VPN IT node */
 	struct bgp_info *bi_interior);  /* VPN IT route */
 
 extern void vnc_import_bgp_exterior_del_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct route_node *rn_interior, /* VPN IT node */
+	struct rfapi_node *rn_interior, /* VPN IT node */
 	struct bgp_info *bi_interior);  /* VPN IT route */
 
 extern void

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -555,7 +555,7 @@ static void import_table_to_nve_list_zebra(struct bgp *bgp,
 
 static void vnc_zebra_add_del_prefix(struct bgp *bgp,
 				     struct rfapi_import_table *import_table,
-				     struct route_node *rn,
+				     struct rfapi_node *rn,
 				     int add) /* !0 = add, 0 = del */
 {
 	struct list *nves;
@@ -609,14 +609,14 @@ static void vnc_zebra_add_del_prefix(struct bgp *bgp,
 
 void vnc_zebra_add_prefix(struct bgp *bgp,
 			  struct rfapi_import_table *import_table,
-			  struct route_node *rn)
+			  struct rfapi_node *rn)
 {
 	vnc_zebra_add_del_prefix(bgp, import_table, rn, 1);
 }
 
 void vnc_zebra_del_prefix(struct bgp *bgp,
 			  struct rfapi_import_table *import_table,
-			  struct route_node *rn)
+			  struct rfapi_node *rn)
 {
 	vnc_zebra_add_del_prefix(bgp, import_table, rn, 0);
 }
@@ -676,7 +676,7 @@ static void vnc_zebra_add_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		if (rfgn->rfg == rfg) {
 
 			struct route_table *rt = NULL;
-			struct route_node *rn;
+			struct rfapi_node *rn;
 			struct rfapi_import_table *import_table;
 			import_table = rfg->rfapi_import_table;
 
@@ -689,7 +689,8 @@ static void vnc_zebra_add_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd,
 			/*
 			 * Walk the NVE-Group's VNC Import table
 			 */
-			for (rn = route_top(rt); rn; rn = route_next(rn)) {
+			for (rn = rfapi_route_top(rt); rn;
+			     rn = rfapi_route_next(rn)) {
 
 				if (rn->info) {
 
@@ -719,7 +720,7 @@ static void vnc_zebra_add_del_group_afi(struct bgp *bgp,
 					afi_t afi, int add)
 {
 	struct route_table *rt = NULL;
-	struct route_node *rn;
+	struct rfapi_node *rn;
 	struct rfapi_import_table *import_table;
 	uint8_t family = afi2family(afi);
 
@@ -769,7 +770,8 @@ static void vnc_zebra_add_del_group_afi(struct bgp *bgp,
 			/*
 			 * Walk the NVE-Group's VNC Import table
 			 */
-			for (rn = route_top(rt); rn; rn = route_next(rn)) {
+			for (rn = rfapi_route_top(rt); rn;
+			     rn = rfapi_route_next(rn)) {
 				if (rn->info) {
 					vnc_zebra_route_msg(&rn->p,
 							    nexthop_count,

--- a/bgpd/rfapi/vnc_zebra.h
+++ b/bgpd/rfapi/vnc_zebra.h
@@ -29,11 +29,11 @@
 
 extern void vnc_zebra_add_prefix(struct bgp *bgp,
 				 struct rfapi_import_table *import_table,
-				 struct route_node *rn);
+				 struct rfapi_node *rn);
 
 extern void vnc_zebra_del_prefix(struct bgp *bgp,
 				 struct rfapi_import_table *import_table,
-				 struct route_node *rn);
+				 struct rfapi_node *rn);
 
 extern void vnc_zebra_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd);
 

--- a/lib/table.h
+++ b/lib/table.h
@@ -125,10 +125,7 @@ struct route_table {
 	unsigned int table_rdonly(lock);                                       \
                                                                                \
 	/* Each node of route. */                                              \
-	void *info;                                                            \
-                                                                               \
-	/* Aggregation. */                                                     \
-	void *aggregate;
+	void *info;
 
 
 /* Each routing entry. */

--- a/ripngd/ripng_route.c
+++ b/ripngd/ripng_route.c
@@ -44,13 +44,13 @@ void ripng_aggregate_free(struct ripng_aggregate *aggregate)
 }
 
 /* Aggregate count increment check. */
-void ripng_aggregate_increment(struct route_node *child,
+void ripng_aggregate_increment(struct ripng_node *child,
 			       struct ripng_info *rinfo)
 {
-	struct route_node *np;
+	struct ripng_node *np;
 	struct ripng_aggregate *aggregate;
 
-	for (np = child; np; np = np->parent)
+	for (np = child; np; np = (struct ripng_node *)np->parent)
 		if ((aggregate = np->aggregate) != NULL) {
 			aggregate->count++;
 			rinfo->suppress++;
@@ -58,13 +58,13 @@ void ripng_aggregate_increment(struct route_node *child,
 }
 
 /* Aggregate count decrement check. */
-void ripng_aggregate_decrement(struct route_node *child,
+void ripng_aggregate_decrement(struct ripng_node *child,
 			       struct ripng_info *rinfo)
 {
-	struct route_node *np;
+	struct ripng_node *np;
 	struct ripng_aggregate *aggregate;
 
-	for (np = child; np; np = np->parent)
+	for (np = child; np; np = (struct ripng_node *)np->parent)
 		if ((aggregate = np->aggregate) != NULL) {
 			aggregate->count--;
 			rinfo->suppress--;
@@ -72,14 +72,14 @@ void ripng_aggregate_decrement(struct route_node *child,
 }
 
 /* Aggregate count decrement check for a list. */
-void ripng_aggregate_decrement_list(struct route_node *child, struct list *list)
+void ripng_aggregate_decrement_list(struct ripng_node *child, struct list *list)
 {
-	struct route_node *np;
+	struct ripng_node *np;
 	struct ripng_aggregate *aggregate;
 	struct ripng_info *rinfo = NULL;
 	struct listnode *node = NULL;
 
-	for (np = child; np; np = np->parent)
+	for (np = child; np; np = (struct ripng_node *)np->parent)
 		if ((aggregate = np->aggregate) != NULL)
 			aggregate->count -= listcount(list);
 
@@ -90,8 +90,8 @@ void ripng_aggregate_decrement_list(struct route_node *child, struct list *list)
 /* RIPng routes treatment. */
 int ripng_aggregate_add(struct prefix *p)
 {
-	struct route_node *top;
-	struct route_node *rp;
+	struct ripng_node *top;
+	struct ripng_node *rp;
 	struct ripng_info *rinfo;
 	struct ripng_aggregate *aggregate;
 	struct ripng_aggregate *sub;
@@ -99,7 +99,7 @@ int ripng_aggregate_add(struct prefix *p)
 	struct listnode *node = NULL;
 
 	/* Get top node for aggregation. */
-	top = route_node_get(ripng->table, p);
+	top = (struct ripng_node *)route_node_get(ripng->table, p);
 
 	/* Allocate new aggregate. */
 	aggregate = ripng_aggregate_new();
@@ -108,7 +108,8 @@ int ripng_aggregate_add(struct prefix *p)
 	top->aggregate = aggregate;
 
 	/* Suppress routes match to the aggregate. */
-	for (rp = route_lock_node(top); rp; rp = route_next_until(rp, top)) {
+	for (rp = ripng_lock_node(top); rp;
+	     rp = ripng_route_next_until(rp, top)) {
 		/* Suppress normal route. */
 		if ((list = rp->info) != NULL)
 			for (ALL_LIST_ELEMENTS_RO(list, node, rinfo)) {
@@ -128,8 +129,8 @@ int ripng_aggregate_add(struct prefix *p)
 /* Delete RIPng static route. */
 int ripng_aggregate_delete(struct prefix *p)
 {
-	struct route_node *top;
-	struct route_node *rp;
+	struct ripng_node *top;
+	struct ripng_node *rp;
 	struct ripng_info *rinfo;
 	struct ripng_aggregate *aggregate;
 	struct ripng_aggregate *sub;
@@ -137,13 +138,14 @@ int ripng_aggregate_delete(struct prefix *p)
 	struct listnode *node = NULL;
 
 	/* Get top node for aggregation. */
-	top = route_node_get(ripng->table, p);
+	top = (struct ripng_node *)route_node_get(ripng->table, p);
 
 	/* Allocate new aggregate. */
 	aggregate = top->aggregate;
 
 	/* Suppress routes match to the aggregate. */
-	for (rp = route_lock_node(top); rp; rp = route_next_until(rp, top)) {
+	for (rp = ripng_lock_node(top); rp;
+	     rp = ripng_route_next_until(rp, top)) {
 		/* Suppress normal route. */
 		if ((list = rp->info) != NULL)
 			for (ALL_LIST_ELEMENTS_RO(list, node, rinfo)) {
@@ -160,8 +162,8 @@ int ripng_aggregate_delete(struct prefix *p)
 	top->aggregate = NULL;
 	ripng_aggregate_free(aggregate);
 
-	route_unlock_node(top);
-	route_unlock_node(top);
+	ripng_unlock_node(top);
+	ripng_unlock_node(top);
 
 	return 0;
 }

--- a/ripngd/ripng_route.h
+++ b/ripngd/ripng_route.h
@@ -22,6 +22,68 @@
 #ifndef _ZEBRA_RIPNG_ROUTE_H
 #define _ZEBRA_RIPNG_ROUTE_H
 
+#include <table.h>
+
+struct ripng_node {
+	/*
+	 * CAUTION
+	 *
+	 * These fields must be the very first fields in this structure.
+	 *
+	 * @see bgp_node_to_rnode
+	 * @see bgp_node_from_rnode
+	 */
+	ROUTE_NODE_FIELDS
+
+	void *aggregate;
+};
+
+static inline void ripng_unlock_node(struct ripng_node *node)
+{
+	route_unlock_node((struct route_node *)node);
+}
+
+static inline struct ripng_node *ripng_lock_node(struct ripng_node *node)
+{
+	return (struct ripng_node *)route_lock_node((struct route_node *)node);
+}
+
+static inline struct ripng_node *ripng_route_next(struct ripng_node *node)
+{
+	return (struct ripng_node *)route_next((struct route_node *)node);
+}
+
+static inline struct ripng_node *ripng_route_top(struct route_table *node)
+{
+	return (struct ripng_node *)route_top(node);
+}
+
+static inline struct ripng_node *
+ripng_route_next_until(struct ripng_node *rn, const struct ripng_node *limit)
+{
+	return (struct ripng_node *)route_next_until(
+		(struct route_node *)rn, (const struct route_node *)limit);
+}
+
+static inline struct ripng_node *ripng_route_node_get(struct route_table *table,
+						      union prefixconstptr ptr)
+{
+	return (struct ripng_node *)route_node_get(table, ptr);
+}
+
+static inline struct ripng_node *
+ripng_route_node_lookup(struct route_table *table, union prefixconstptr ptr)
+{
+	return (struct ripng_node *)route_node_lookup(table, ptr);
+}
+
+static inline struct ripng_node *
+ripng_route_node_match(const struct route_table *table,
+		       union prefixconstptr ptr)
+{
+	return (struct ripng_node *)route_node_match(table, ptr);
+}
+
 struct ripng_aggregate {
 	/* Aggregate route count. */
 	unsigned int count;
@@ -42,11 +104,11 @@ struct ripng_aggregate {
 	uint16_t tag_out;
 };
 
-extern void ripng_aggregate_increment(struct route_node *rp,
+extern void ripng_aggregate_increment(struct ripng_node *rp,
 				      struct ripng_info *rinfo);
-extern void ripng_aggregate_decrement(struct route_node *rp,
+extern void ripng_aggregate_decrement(struct ripng_node *rp,
 				      struct ripng_info *rinfo);
-extern void ripng_aggregate_decrement_list(struct route_node *rp,
+extern void ripng_aggregate_decrement_list(struct ripng_node *rp,
 					   struct list *list);
 extern int ripng_aggregate_add(struct prefix *p);
 extern int ripng_aggregate_delete(struct prefix *p);

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -31,13 +31,14 @@
 #include "log.h"
 
 #include "ripngd/ripngd.h"
+#include "ripngd/ripng_route.h"
 #include "ripngd/ripng_debug.h"
 
 /* All information about zebra. */
 struct zclient *zclient = NULL;
 
 /* Send ECMP routes to zebra. */
-static void ripng_zebra_ipv6_send(struct route_node *rp, uint8_t cmd)
+static void ripng_zebra_ipv6_send(struct ripng_node *rp, uint8_t cmd)
 {
 	struct list *list = (struct list *)rp->info;
 	struct zapi_route api;
@@ -100,13 +101,13 @@ static void ripng_zebra_ipv6_send(struct route_node *rp, uint8_t cmd)
 }
 
 /* Add/update ECMP routes to zebra. */
-void ripng_zebra_ipv6_add(struct route_node *rp)
+void ripng_zebra_ipv6_add(struct ripng_node *rp)
 {
 	ripng_zebra_ipv6_send(rp, ZEBRA_ROUTE_ADD);
 }
 
 /* Delete ECMP routes from zebra. */
-void ripng_zebra_ipv6_delete(struct route_node *rp)
+void ripng_zebra_ipv6_delete(struct ripng_node *rp)
 {
 	ripng_zebra_ipv6_send(rp, ZEBRA_ROUTE_DELETE);
 }

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -198,7 +198,7 @@ struct ripng_info {
 	uint8_t metric_out;
 	uint16_t tag_out;
 
-	struct route_node *rp;
+	struct ripng_node *rp;
 };
 
 #ifdef notyet
@@ -377,8 +377,8 @@ extern void ripng_redistribute_withdraw(int type);
 extern void ripng_distribute_update_interface(struct interface *);
 extern void ripng_if_rmap_update_interface(struct interface *);
 
-extern void ripng_zebra_ipv6_add(struct route_node *);
-extern void ripng_zebra_ipv6_delete(struct route_node *);
+extern void ripng_zebra_ipv6_add(struct ripng_node *);
+extern void ripng_zebra_ipv6_delete(struct ripng_node *);
 
 extern void ripng_redistribute_clean(void);
 extern int ripng_redistribute_check(int);


### PR DESCRIPTION
The `void *aggregate` pointer in ROUTE_NODE_FIELDS is only used by ripngd.
As such every single route_node in the system is paying the cost
of keeping this pointer around and never using it.  Follow the table.h
design pattern in bgp_table.h and create a `struct ripng_node` pointer
that actually has this aggregate pointer and then provide ripng
specific struct route_node <-> struct ripng_node translator functions.

On a 64 bit system this should account for 8 bytes of data per route_node
which is not insignificant considering a full bgp feed in both bgp and
zebra, or evpn routes which make signficant usage of tables.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>