### PR TITLE
zebra: fix missing table identifier passed for ip route vrf commands

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -463,7 +463,7 @@ commands in relationship to VRF. Here is an extract of some of those commands:
 .. clicmd:: vrf VRF
 
    This command is available on configuration mode. By default, above command
-   permits accessing the vrf configuration mode. This mode is available for
+   permits accessing the VRF configuration mode. This mode is available for
    both VRFs. It is to be noted that *Zebra* does not create Linux VRF.
    The network administrator can however decide to provision this command in
    configuration file to provide more clarity about the intended configuration.
@@ -493,7 +493,10 @@ commands in relationship to VRF. Here is an extract of some of those commands:
 
    This command is based on configuration mode. There, for default VRF, this
    command is available for all modes. The ``TABLENO`` configured is one of the
-   tables from Default *Linux network namespace*.
+   tables from Default *Linux network namespace*. This command is also available
+   on vrf configuration mode, provided that *Zebra* is run with :option:`-n`
+   option. In that case, this command configures a network route in the given
+   ``TABLENO`` of the *Linux network namespace* of the relevant VRF.
 
 .. index:: show ip route vrf VRF
 .. clicmd:: show ip route vrf VRF

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1071,7 +1071,7 @@ DEFPY(ip_route_vrf,
 	return zebra_static_route_leak(
 		vty, zvrf, nh_zvrf, AFI_IP, SAFI_UNICAST, no, prefix, mask_str,
 		NULL, gate_str, ifname, flag, tag_str, distance_str, label,
-		NULL);
+		table_str);
 }
 
 /* New RIB.  Detailed information for IPv4 route. */


### PR DESCRIPTION
The parameter was missing in that vty command. Then it is being added.
Also some documentation is refreshed.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>