### PR TITLE
bgpd: changes for crash seen in BGP on "no rt vpn" bug Id 2667

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -189,7 +189,6 @@ static void bgp_info_extra_free(struct bgp_info_extra **extra)
 
 		if (bi->net)
 			bgp_unlock_node((struct bgp_node *)bi->net);
-		bi->net = NULL;
 		bgp_info_unlock(e->parent);
 		e->parent = NULL;
 	}


### PR DESCRIPTION
There is a default BGP VPN and BGP VRF instance in L3VPN configuration.
The routes are imported and exported between BGP VPN and BGP VRF.
Suppose there is one route in BGP VRF and exported to BGP VPN.
In BGP VPN there is bgp_info struct with bgp_info_extra struct has parent pointer pointing to the bgp_info of BGP VRF.
We take the lock for bgp_node and bgp_info of BGP VRF in the context of BGP VPN.
bgp_info has a back pointer to bgp_node via net.

Now when we have done "no rd vpn" in BGP VRF then in bgp_info_extra_free we have to free the parent resources.
In this context only unlocking is required. It should not set the BGP VRF (bgp_info->net) to NULL.

Signed-off-by: vishaldhingra vdhingra@vmware.com