### PR TITLE
pimd: RPT Prunes do not need to be figured for a *,G Prune

### DIFF
--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -114,7 +114,7 @@ size_t pim_msg_get_jp_group_size(struct list *sources)
 	size += sizeof(struct pim_encoded_source_ipv4) * sources->count;
 
 	js = listgetdata(listhead(sources));
-	if (js && js->up->sg.src.s_addr == INADDR_ANY) {
+	if (js && js->up->sg.src.s_addr == INADDR_ANY && js->is_join) {
 		struct pim_upstream *child, *up;
 		struct listnode *up_node;
 


### PR DESCRIPTION
Packet sending in PIM is a two step process.
1) Gather data size of next G to be packed into a packet.
2) Write data

After 1 we need to ensure that the next G to pack will actually
fit in a packet.  If it does not send what we've currently written
and start a new packet to send.

Because this was a 2 step process it is important to be consistent
in what you think you have packed -vs- what you think you should.

PIM has a bug where we were considering S,G RPT Prunes for a *,G
even when the *,G was being pruned.  This lead to a situation where
we were figuring a write size of more data then what we actually wrote
into a packet.  This would leave a 8 byte whole of 0's in the packet
due to the way we moved pointers around.

Fix the code so that we do not attempt to consider S,G rpt prunes
for a *,G prune when figuring out how much we should write in step 1.

Ticket: CM-21644
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>