### PR TITLE
Fix zebra shutdown crash

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -134,10 +134,17 @@ static void sigint(void)
 {
 	struct vrf *vrf;
 	struct zebra_vrf *zvrf;
+	struct listnode *ln;
+	struct frr_pthread *fpt;
 
 	zlog_notice("Terminating on signal");
 
 	frr_early_fini();
+
+	for (ALL_LIST_ELEMENTS_RO(zebrad.client_list, ln, fpt)) {
+		pthread_cancel(fpt->thread);
+		pthread_join(fpt->thread, NULL);
+	}
 
 	list_delete_all_node(zebrad.client_list);
 	zebra_ptm_finish();

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -1037,7 +1037,6 @@ void zserv_init(void)
 {
 	/* Client list init. */
 	zebrad.client_list = list_new();
-	zebrad.client_list->del = (void (*)(void *)) zserv_client_free;
 
 	/* Misc init. */
 	zebrad.sock = -1;


### PR DESCRIPTION
Hopefully fixes #2656 and friends.

Client list deletion function pointer was bound to a function that expected the owning pthread to be dead before it was called, but since the pthread was never killed, it deleted out the resources from under it.