### PR TITLE
bgpd: route detail output local pref display

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7737,13 +7737,6 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 			else
 				vty_out(vty, ", localpref %u",
 					attr->local_pref);
-		} else {
-			if (json_paths)
-				json_object_int_add(json_path, "localpref",
-						    bgp->default_local_pref);
-			else
-				vty_out(vty, ", localpref %u",
-					bgp->default_local_pref);
 		}
 
 		if (attr->weight != 0) {


### PR DESCRIPTION
Avoid displaying default configured local preference as part of bgp route's detail output.
Local preference is for iBGP learnt route's. The value could be default (100) or configured value (via routemap or local pref config cmd).
show bgp afi safi (brief output) does not display, if the local pref attribute is not set.
Similarly, show bgp afi safi detail route output should display
if the the attribute is set, and should not display configured value.
This way both output would be consistent.
The configured local preference can be seen via running-config.


Testing Done:

eBGP output:
show bgp ipv4 45.0.3.0/24
BGP routing table entry for 45.0.3.0/24
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  MSP1(uplink-1) MSP2(uplink-2)
  Local
    0.0.0.0 from 0.0.0.0 (27.0.0.9)
      Origin incomplete, metric 0, weight 32768, valid,sourced, bestpath-from-AS Local, best
      AddPath ID: RX 0, TX 7
      Last update: Thu Jul 26 02:10:02 2018

iBGP output:

show bgp ipv4 unicast 6.0.0.16/32
BGP routing table entry for 6.0.0.16/32
Paths: (1 available, best #1, table default)
  Not advertised to any peer
  Local
    6.0.0.16 (metric 20) from tor-12(6.0.0.16) (6.0.0.16)
      Origin incomplete, metric 0, localpref 100, valid, internal, bestpath-from-AS Local, best
      AddPath ID: RX 0, TX 13
      Last update: Thu Jul 26 05:26:18 2018

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>