### PR TITLE
Complement fs patch3

### DIFF
--- a/bgpd/bgp_flowspec.h
+++ b/bgpd/bgp_flowspec.h
@@ -50,4 +50,12 @@ extern void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 extern int bgp_fs_config_write_pbr(struct vty *vty, struct bgp *bgp,
 				   afi_t afi, safi_t safi);
 
+extern int bgp_flowspec_display_match_per_ip(afi_t afi,
+				struct bgp_table *rib,
+				struct prefix *match,
+				int prefix_check,
+				struct vty *vty,
+				uint8_t use_json,
+				json_object *json_paths);
+
 #endif /* _FRR_BGP_FLOWSPEC_H */

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -73,9 +73,9 @@ static int bgp_flowspec_call_non_opaque_decode(uint8_t *nlri_content, int len,
 	return ret;
 }
 
-static bool bgp_flowspec_contains_prefix(struct prefix *pfs,
-					 struct prefix *input,
-					 int prefix_check)
+bool bgp_flowspec_contains_prefix(struct prefix *pfs,
+				 struct prefix *input,
+				 int prefix_check)
 {
 	uint32_t offset = 0;
 	int type;
@@ -563,25 +563,4 @@ int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 		}
 	}
 	return error;
-}
-
-
-struct bgp_node *bgp_flowspec_get_match_per_ip(afi_t afi,
-					       struct bgp_table *rib,
-					       struct prefix *match,
-					       int prefix_check)
-{
-	struct bgp_node *rn;
-	struct prefix *prefix;
-
-	for (rn = bgp_table_top(rib); rn; rn = bgp_route_next(rn)) {
-		prefix = &rn->p;
-
-		if (prefix->family != AF_FLOWSPEC)
-			continue;
-
-		if (bgp_flowspec_contains_prefix(prefix, match, prefix_check))
-			return rn;
-	}
-	return NULL;
 }

--- a/bgpd/bgp_flowspec_util.h
+++ b/bgpd/bgp_flowspec_util.h
@@ -50,8 +50,8 @@ struct bgp_pbr_entry_main;
 extern int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 					 struct bgp_pbr_entry_main *bpem);
 
-extern struct bgp_node *bgp_flowspec_get_match_per_ip(afi_t afi,
-						      struct bgp_table *rib,
-						      struct prefix *match,
-						      int prefix_check);
+extern bool bgp_flowspec_contains_prefix(struct prefix *pfs,
+					 struct prefix *input,
+					 int prefix_check);
+
 #endif /* _FRR_BGP_FLOWSPEC_UTIL_H */

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -335,7 +335,7 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 			struct listnode *node;
 			struct bgp_pbr_match_entry *bpme;
 			struct bgp_pbr_match *bpm;
-			int unit = 0;
+			bool list_began = false;
 			struct list *list_bpm;
 
 			list_bpm = list_new();
@@ -347,17 +347,17 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 				if (listnode_lookup(list_bpm, bpm))
 					continue;
 				listnode_add(list_bpm, bpm);
-				if (unit == 0)
+				if (!list_began) {
 					vty_out(vty, " (");
-				else
+					list_began = true;
+				} else
 					vty_out(vty, ", ");
 				vty_out(vty, "%s", bpm->ipset_name);
-				unit++;
 			}
-			if (unit)
+			if (list_began)
 				vty_out(vty, ")");
 			vty_out(vty, "\n");
-			list_delete_all_node(list_bpm);
+			list_delete_and_null(&list_bpm);
 		} else
 			vty_out(vty, "\tnot installed in PBR\n");
 	}

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -542,6 +542,36 @@ DEFUN (bgp_fs_local_install_any,
 	return bgp_fs_local_install_interface(bgp, no, NULL);
 }
 
+extern int bgp_flowspec_display_match_per_ip(afi_t afi,
+			struct bgp_table *rib,
+			struct prefix *match,
+			int prefix_check,
+			struct vty *vty,
+			uint8_t use_json,
+			json_object *json_paths)
+{
+	struct bgp_node *rn;
+	struct prefix *prefix;
+	int display = 0;
+
+	for (rn = bgp_table_top(rib); rn; rn = bgp_route_next(rn)) {
+		prefix = &rn->p;
+
+		if (prefix->family != AF_FLOWSPEC)
+			continue;
+
+		if (bgp_flowspec_contains_prefix(prefix, match, prefix_check)) {
+			route_vty_out_flowspec(vty, &rn->p,
+					       rn->info, use_json ?
+					       NLRI_STRING_FORMAT_JSON :
+					       NLRI_STRING_FORMAT_LARGE,
+					       json_paths);
+			display++;
+		}
+	}
+	return display;
+}
+
 void bgp_flowspec_vty_init(void)
 {
 	install_element(ENABLE_NODE, &debug_bgp_flowspec_cmd);

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -460,8 +460,6 @@ int bgp_fs_config_write_pbr(struct vty *vty, struct bgp *bgp,
 	RB_FOREACH (pbr_if, bgp_pbr_interface_head, head) {
 		vty_out(vty, "  local-install %s\n", pbr_if->name);
 	}
-	if (!bgp_pbr_interface_any)
-		vty_out(vty, "  no local-install any\n");
 	return declare_node ? 1 : 0;
 }
 
@@ -529,19 +527,6 @@ DEFUN (bgp_fs_local_install_ifname,
 	return bgp_fs_local_install_interface(bgp, no, ifname);
 }
 
-DEFUN (bgp_fs_local_install_any,
-	bgp_fs_local_install_any_cmd,
-	"[no] local-install any",
-	NO_STR
-	"Apply local policy routing\n"
-	"Any Interface\n")
-{
-	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
-	const char *no = strmatch(argv[0]->text, (char *)"no") ? "no" : NULL;
-
-	return bgp_fs_local_install_interface(bgp, no, NULL);
-}
-
 extern int bgp_flowspec_display_match_per_ip(afi_t afi,
 			struct bgp_table *rib,
 			struct prefix *match,
@@ -578,6 +563,5 @@ void bgp_flowspec_vty_init(void)
 	install_element(CONFIG_NODE, &debug_bgp_flowspec_cmd);
 	install_element(ENABLE_NODE, &no_debug_bgp_flowspec_cmd);
 	install_element(CONFIG_NODE, &no_debug_bgp_flowspec_cmd);
-	install_element(BGP_FLOWSPECV4_NODE, &bgp_fs_local_install_any_cmd);
 	install_element(BGP_FLOWSPECV4_NODE, &bgp_fs_local_install_ifname_cmd);
 }

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1678,7 +1678,7 @@ static void bgp_pbr_dump_entry(struct bgp_pbr_filter *bpf, bool add)
 			 ? "!" : "",
 			 bpf->dscp->val);
 	}
-	zlog_info("BGP: %s FS PBR from %s to %s, %s %s",
+	zlog_debug("BGP: %s FS PBR from %s to %s, %s %s",
 		  add ? "adding" : "removing",
 		  bpf->src == NULL ? "<all>" :
 		  prefix2str(bpf->src, bufsrc, sizeof(bufsrc)),

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1285,7 +1285,13 @@ static int bgp_pbr_get_remaining_entry(struct hash_backet *backet, void *arg)
 	bpm_temp = bpme->backpointer;
 	if (bpm_temp->vrf_id != bpm->vrf_id ||
 	    bpm_temp->type != bpm->type ||
-	    bpm_temp->flags != bpm->flags)
+	    bpm_temp->flags != bpm->flags ||
+	    bpm_temp->tcp_flags != bpm->tcp_flags ||
+	    bpm_temp->tcp_mask_flags != bpm->tcp_mask_flags ||
+	    bpm_temp->pkt_len_min != bpm->pkt_len_min ||
+	    bpm_temp->pkt_len_max != bpm->pkt_len_max ||
+	    bpm_temp->dscp_value != bpm->dscp_value ||
+	    bpm_temp->fragment != bpm->fragment)
 		return HASHWALK_CONTINUE;
 
 	/* look for remaining bpme */

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1805,7 +1805,7 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 		       bgp_pbr_match_alloc_intern);
 
 	/* new, then self allocate ipset_name and unique */
-	if (bpm && bpm->unique == 0) {
+	if (bpm->unique == 0) {
 		bpm->unique = ++bgp_pbr_match_counter_unique;
 		/* 0 value is forbidden */
 		sprintf(bpm->ipset_name, "match%p", bpm);
@@ -1836,10 +1836,9 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 	temp2.src_port_max = src_port ? src_port->max_port : 0;
 	temp2.dst_port_max = dst_port ? dst_port->max_port : 0;
 	temp2.proto = bpf->protocol;
-	if (bpm)
-		bpme = hash_get(bpm->entry_hash, &temp2,
-				bgp_pbr_match_entry_alloc_intern);
-	if (bpme && bpme->unique == 0) {
+	bpme = hash_get(bpm->entry_hash, &temp2,
+			bgp_pbr_match_entry_alloc_intern);
+	if (bpme->unique == 0) {
 		bpme->unique = ++bgp_pbr_match_entry_counter_unique;
 		/* 0 value is forbidden */
 		bpme->backpointer = bpm;
@@ -1851,7 +1850,7 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 		bpme_found = true;
 
 	/* already installed */
-	if (bpme_found && bpme) {
+	if (bpme_found) {
 		struct bgp_info_extra *extra = bgp_info_extra_get(binfo);
 
 		if (extra && extra->bgp_fs_pbr &&

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -835,12 +835,12 @@ uint32_t bgp_pbr_match_hash_key(void *arg)
 
 	key = jhash_1word(pbm->vrf_id, 0x4312abde);
 	key = jhash_1word(pbm->flags, key);
-	key = jhash_1word(pbm->pkt_len_min, key);
-	key = jhash_1word(pbm->pkt_len_max, key);
-	key = jhash_1word(pbm->tcp_flags, key);
-	key = jhash_1word(pbm->tcp_mask_flags, key);
-	key = jhash_1word(pbm->dscp_value, key);
-	key = jhash_1word(pbm->fragment, key);
+	key = jhash(&pbm->pkt_len_min, 2, key);
+	key = jhash(&pbm->pkt_len_max, 2, key);
+	key = jhash(&pbm->tcp_flags, 2, key);
+	key = jhash(&pbm->tcp_mask_flags, 2, key);
+	key = jhash(&pbm->dscp_value, 1, key);
+	key = jhash(&pbm->fragment, 1, key);
 	return jhash_1word(pbm->type, key);
 }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8898,17 +8898,11 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 			bgp_unlock_node(rm);
 		}
 	} else if (safi == SAFI_FLOWSPEC) {
-		rn = bgp_flowspec_get_match_per_ip(afi, rib,
-						   &match, prefix_check);
-		if (rn != NULL) {
-			route_vty_out_flowspec(vty, &rn->p,
-					       rn->info, use_json ?
-					       NLRI_STRING_FORMAT_JSON :
-					       NLRI_STRING_FORMAT_LARGE,
-					       json_paths);
-			display++;
-			bgp_unlock_node(rn);
-		}
+		display = bgp_flowspec_display_match_per_ip(afi, rib,
+					   &match, prefix_check,
+					   vty,
+					   use_json,
+					   json_paths);
 	} else {
 		header = 1;
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -181,8 +181,7 @@ static void bgp_info_extra_free(struct bgp_info_extra **extra)
 		(*extra)->damp_info = NULL;
 
 		if ((*extra)->bgp_fs_pbr)
-			list_delete_all_node((*extra)->bgp_fs_pbr);
-		(*extra)->bgp_fs_pbr = NULL;
+			list_delete_and_null(&((*extra)->bgp_fs_pbr));
 
 		XFREE(MTYPE_BGP_ROUTE_EXTRA, *extra);
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -180,6 +180,10 @@ static void bgp_info_extra_free(struct bgp_info_extra **extra)
 
 		(*extra)->damp_info = NULL;
 
+		if ((*extra)->bgp_fs_pbr)
+			list_delete_all_node((*extra)->bgp_fs_pbr);
+		(*extra)->bgp_fs_pbr = NULL;
+
 		XFREE(MTYPE_BGP_ROUTE_EXTRA, *extra);
 
 		*extra = NULL;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -147,7 +147,7 @@ struct bgp_info_extra {
 	 */
 	struct prefix nexthop_orig;
 	/* presence of FS pbr entry */
-	void *bgp_fs_pbr;
+	struct list *bgp_fs_pbr;
 };
 
 struct bgp_info {

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2012,7 +2012,7 @@ static int ipset_notify_owner(int command, struct zclient *zclient,
 	bgp_pbim = bgp_pbr_match_ipset_lookup(vrf_id, unique);
 	if (!bgp_pbim) {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("%s: Fail to look BGP match ( %u %u)",
+			zlog_debug("%s: Fail to look BGP match ( %u, ID %u)",
 				   __PRETTY_FUNCTION__, note, unique);
 		return 0;
 	}
@@ -2062,7 +2062,7 @@ static int ipset_entry_notify_owner(int command, struct zclient *zclient,
 						     unique);
 	if (!bgp_pbime) {
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_debug("%s: Fail to look BGP match entry (%u %u)",
+			zlog_debug("%s: Fail to look BGP match entry (%u, ID %u)",
 				   __PRETTY_FUNCTION__, note, unique);
 		return 0;
 	}
@@ -2568,9 +2568,10 @@ void bgp_send_pbr_ipset_match(struct bgp_pbr_match *pbrim, bool install)
 	if (pbrim->install_in_progress)
 		return;
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("%s: name %s type %d %d",
+		zlog_debug("%s: name %s type %d %d, ID %u",
 			   __PRETTY_FUNCTION__,
-			   pbrim->ipset_name, pbrim->type, install);
+			   pbrim->ipset_name, pbrim->type,
+			   install, pbrim->unique);
 	s = zclient->obuf;
 	stream_reset(s);
 
@@ -2596,9 +2597,9 @@ void bgp_send_pbr_ipset_entry_match(struct bgp_pbr_match_entry *pbrime,
 	if (pbrime->install_in_progress)
 		return;
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("%s: name %s %d %d", __PRETTY_FUNCTION__,
+		zlog_debug("%s: name %s %d %d, ID %u", __PRETTY_FUNCTION__,
 			   pbrime->backpointer->ipset_name,
-			   pbrime->unique, install);
+			   pbrime->unique, install, pbrime->unique);
 	s = zclient->obuf;
 	stream_reset(s);
 
@@ -2663,9 +2664,10 @@ void bgp_send_pbr_iptable(struct bgp_pbr_action *pba,
 	if (pbm->install_iptable_in_progress)
 		return;
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("%s: name %s type %d mark %d %d",
+		zlog_debug("%s: name %s type %d mark %d %d, ID %u",
 			   __PRETTY_FUNCTION__, pbm->ipset_name,
-			   pbm->type, pba->fwmark, install);
+			   pbm->type, pba->fwmark, install,
+			   pbm->unique2);
 	s = zclient->obuf;
 	stream_reset(s);
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2088,7 +2088,9 @@ static int ipset_entry_notify_owner(int command, struct zclient *zclient,
 			/* link bgp_info to bpme */
 			bgp_info = (struct bgp_info *)bgp_pbime->bgp_info;
 			extra = bgp_info_extra_get(bgp_info);
-			extra->bgp_fs_pbr = (void *)bgp_pbime;
+			if (extra->bgp_fs_pbr == NULL)
+				extra->bgp_fs_pbr = list_new();
+			listnode_add(extra->bgp_fs_pbr, bgp_pbime);
 		}
 		break;
 	case ZAPI_IPSET_ENTRY_FAIL_REMOVE:

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -1069,6 +1069,15 @@ static void zebra_pbr_show_iptable_unit(struct zebra_pbr_iptable *iptable,
 	vty_out(vty, "IPtable %s action %s (%u)\n", iptable->ipset_name,
 		iptable->action == ZEBRA_IPTABLES_DROP ? "drop" : "redirect",
 		iptable->unique);
+	if (iptable->type == IPSET_NET_PORT ||
+	    iptable->type == IPSET_NET_PORT_NET) {
+		if (!(iptable->filter_bm & MATCH_ICMP_SET)) {
+			if (iptable->filter_bm & PBR_FILTER_DST_PORT)
+				vty_out(vty, "\t lookup dst port\n");
+			else if (iptable->filter_bm & PBR_FILTER_SRC_PORT)
+				vty_out(vty, "\t lookup src port\n");
+		}
+	}
 	if (iptable->pkt_len_min || iptable->pkt_len_max) {
 		if (!iptable->pkt_len_max)
 			vty_out(vty, "\t pkt len %u\n",

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -829,6 +829,7 @@ struct zebra_pbr_ipset_entry_unique_display {
 struct zebra_pbr_env_display {
 	struct zebra_ns *zns;
 	struct vty *vty;
+	char *name;
 };
 
 static const char *zebra_pbr_prefix2str(union prefixconstptr pu,
@@ -1034,6 +1035,7 @@ void zebra_pbr_show_ipset_list(struct vty *vty, char *ipsetname)
 	}
 	uniqueipset.zns = zns;
 	uniqueipset.vty = vty;
+	uniqueipset.name = NULL;
 	hash_walk(zns->ipset_hash, zebra_pbr_show_ipset_walkcb,
 		  &uniqueipset);
 }
@@ -1057,13 +1059,10 @@ static int zebra_pbr_rule_lookup_fwmark_walkcb(struct hash_backet *backet,
 	return HASHWALK_CONTINUE;
 }
 
-static int zebra_pbr_show_iptable_walkcb(struct hash_backet *backet, void *arg)
+static void zebra_pbr_show_iptable_unit(struct zebra_pbr_iptable *iptable,
+				       struct vty *vty,
+				       struct zebra_ns *zns)
 {
-	struct zebra_pbr_iptable *iptable =
-		(struct zebra_pbr_iptable *)backet->data;
-	struct zebra_pbr_env_display *env = (struct zebra_pbr_env_display *)arg;
-	struct vty *vty = env->vty;
-	struct zebra_ns *zns = env->zns;
 	int ret;
 	uint64_t pkts = 0, bytes = 0;
 
@@ -1126,17 +1125,34 @@ static int zebra_pbr_show_iptable_walkcb(struct hash_backet *backet, void *arg)
 				prfl.fwmark);
 		}
 	}
+}
+
+static int zebra_pbr_show_iptable_walkcb(struct hash_backet *backet, void *arg)
+{
+	struct zebra_pbr_iptable *iptable =
+		(struct zebra_pbr_iptable *)backet->data;
+	struct zebra_pbr_env_display *env = (struct zebra_pbr_env_display *)arg;
+	struct vty *vty = env->vty;
+	struct zebra_ns *zns = env->zns;
+	char *iptable_name = env->name;
+
+	if (!iptable_name)
+		zebra_pbr_show_iptable_unit(iptable, vty, zns);
+	else if (!strncmp(iptable_name,
+			  iptable->ipset_name,
+			  ZEBRA_IPSET_NAME_SIZE))
+		zebra_pbr_show_iptable_unit(iptable, vty, zns);
 	return HASHWALK_CONTINUE;
 }
 
-void zebra_pbr_show_iptable(struct vty *vty)
+void zebra_pbr_show_iptable(struct vty *vty, char *iptable_name)
 {
 	struct zebra_ns *zns = zebra_ns_lookup(NS_DEFAULT);
 	struct zebra_pbr_env_display env;
 
 	env.vty = vty;
 	env.zns = zns;
-
+	env.name = iptable_name;
 	hash_walk(zns->iptable_hash, zebra_pbr_show_iptable_walkcb,
 		  &env);
 }

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -235,7 +235,7 @@ extern int zebra_pbr_iptable_hash_equal(const void *arg1, const void *arg2);
 
 extern void zebra_pbr_init(void);
 extern void zebra_pbr_show_ipset_list(struct vty *vty, char *ipsetname);
-extern void zebra_pbr_show_iptable(struct vty *vty);
+extern void zebra_pbr_show_iptable(struct vty *vty, char *iptable);
 extern void zebra_pbr_iptable_update_interfacelist(struct stream *s,
 				   struct zebra_pbr_iptable *zpi);
 size_t zebra_pbr_tcpflags_snprintf(char *buffer, size_t len,

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -3304,12 +3304,20 @@ DEFUN (show_pbr_ipset,
 /* policy routing contexts */
 DEFUN (show_pbr_iptable,
        show_pbr_iptable_cmd,
-       "show pbr iptable",
+       "show pbr iptable [WORD]",
        SHOW_STR
        "Policy-Based Routing\n"
-       "IPtable Context information\n")
+       "IPtable Context information\n"
+       "IPtable Name information\n")
 {
-	zebra_pbr_show_iptable(vty);
+	int idx = 0;
+	int found = 0;
+
+	found = argv_find(argv, argc, "WORD", &idx);
+	if (!found)
+		zebra_pbr_show_iptable(vty, NULL);
+	else
+		zebra_pbr_show_iptable(vty, argv[idx]->arg);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
This is yet another bunch of fixes for flowspec.

- show ip route A.B.C.D can display more than one entry
- fix for filtering with two FS rules, but with only iptables flag different.   ( the previous fs entry was removed)
- jhash hash calculation changed for bgp bpm list
- add some more debug traces
