### PR TITLE
zebra: Check for netlink message next fault

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -638,7 +638,7 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 
 		read_in++;
 		for (h = (struct nlmsghdr *)buf;
-		     NLMSG_OK(h, (unsigned int)status);
+		     (status >= 0 && NLMSG_OK(h, (unsigned int)status));
 		     h = NLMSG_NEXT(h, status)) {
 			/* Finish of reading. */
 			if (h->nlmsg_type == NLMSG_DONE)


### PR DESCRIPTION
NLMSG_NEXT decrements the buffer length (status) by
the header msg length (nlmsg_len) everytime its called.
If nlmsg_len isn't accurate and set to be larger than
what it should represent, it will cause status to
decrement passed 0. This makes NLMSG_NEXT return a
pointer that references an inaccessible address.
When that is passed to NLMSG_OK, it segfaults.

Add a check to verify that there is still something to read
before we try to.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>