### PR TITLE
Fix zebra shutdown crash

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -134,10 +134,15 @@ static void sigint(void)
 {
 	struct vrf *vrf;
 	struct zebra_vrf *zvrf;
+	struct listnode *ln, *nn;
+	struct zserv *client;
 
 	zlog_notice("Terminating on signal");
 
 	frr_early_fini();
+
+	for (ALL_LIST_ELEMENTS(zebrad.client_list, ln, nn, client))
+		zserv_close_client(client);
 
 	list_delete_all_node(zebrad.client_list);
 	zebra_ptm_finish();

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -232,6 +232,18 @@ extern int zserv_send_message(struct zserv *client, struct stream *msg);
  */
 extern struct zserv *zserv_find_client(uint8_t proto, unsigned short instance);
 
+
+/*
+ * Close a client.
+ *
+ * Kills a client's thread, removes the client from the client list and cleans
+ * up its resources.
+ *
+ * client
+ *    the client to close
+ */
+extern void zserv_close_client(struct zserv *client);
+
 #if defined(HANDLE_ZAPI_FUZZING)
 extern void zserv_read_file(char *input);
 #endif


### PR DESCRIPTION
Hopefully fixes #2656 and friends.

* Stop client pthread datastructures getting deleted by the main thread without killing the thread
* Rename some functions and things to be less confusing
* Add some logging around client closure