### PR TITLE
bgpd: changes for crash seen in BGP on "no rt vpn" bug Id 2667

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -189,7 +189,6 @@ static void bgp_info_extra_free(struct bgp_info_extra **extra)
 
 		if (bi->net)
 			bgp_unlock_node((struct bgp_node *)bi->net);
-		bi->net = NULL;
 		bgp_info_unlock(e->parent);
 		e->parent = NULL;
 	}

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -580,6 +580,9 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 					route_entry_nexthop_ifindex_add(
 						re, index, nh_vrf_id);
 
+				if (rtnh->rtnh_len == 0)
+					break;
+
 				len -= NLMSG_ALIGN(rtnh->rtnh_len);
 				rtnh = RTNH_NEXT(rtnh);
 			}
@@ -699,6 +702,9 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 
 			oif[oif_count] = rtnh->rtnh_ifindex;
 			oif_count++;
+
+			if (rtnh->rtnh_len == 0)
+				break;
 
 			len -= NLMSG_ALIGN(rtnh->rtnh_len);
 			rtnh = RTNH_NEXT(rtnh);


### PR DESCRIPTION
There is a default BGP VPN and BGP VRF instance in L3VPN configuration.
The routes are imported and exported between BGP VPN and BGP VRF.
Suppose there is one route in BGP VRF and exported to BGP VPN.
In BGP VPN there is bgp_info struct with bgp_info_extra struct has parent pointer pointing to the bgp_info of BGP VRF.
We take the lock for bgp_node and bgp_info of BGP VRF in the context of BGP VPN.
bgp_info has a back pointer to bgp_node via net.

Now when we have done "no rd vpn" in BGP VRF then in bgp_info_extra_free we have to free the parent resources.
In this context only unlocking is required. It should not set the BGP VRF (bgp_info->net) to NULL.
After this "no rt vpn" leads to crash.

Signed-off-by: vishaldhingra vdhingra@vmware.com