### PR TITLE
Put back some removed Code

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -188,7 +188,7 @@ static void bgp_info_extra_free(struct bgp_info_extra **extra)
 		struct bgp_info *bi = (struct bgp_info *)e->parent;
 
 		if (bi->net)
-			bgp_unlock_node((struct bgp_node *)bi->net);
+			bi->net = bgp_unlock_node((struct bgp_node *)bi->net);
 		bgp_info_unlock(e->parent);
 		e->parent = NULL;
 	}

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -128,9 +128,9 @@ static inline struct bgp_node *bgp_node_parent_nolock(struct bgp_node *node)
 /*
  * bgp_unlock_node
  */
-static inline void bgp_unlock_node(struct bgp_node *node)
+static inline struct bgp_node *bgp_unlock_node(struct bgp_node *node)
 {
-	route_unlock_node(bgp_node_to_rnode(node));
+	return (struct bgp_node *)route_unlock_node(bgp_node_to_rnode(node));
 }
 
 /*

--- a/lib/table.h
+++ b/lib/table.h
@@ -233,13 +233,17 @@ static inline struct route_node *route_lock_node(struct route_node *node)
 }
 
 /* Unlock node. */
-static inline void route_unlock_node(struct route_node *node)
+static inline struct route_node *route_unlock_node(struct route_node *node)
 {
 	assert(node->lock > 0);
 	(*(unsigned *)&node->lock)--;
 
-	if (node->lock == 0)
+	if (node->lock == 0) {
 		route_node_delete(node);
+		return NULL;
+	}
+
+	return node;
 }
 
 /*


### PR DESCRIPTION
PR #2708 removed a parent->net pointer null'ing to prevent a crash when the parent still exists and we are removing the child.  The parent->net pointer NULL'ing was put into place for the reverse, for when the parent was removed and the child remained still( hadn't been processed).  So provide a bit of functionality to do the right thing with the pointer by setting the pointer to null or not based upon deletion.