### PR TITLE
bgpd: add keepalive thread name

### DIFF
--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -180,6 +180,12 @@ void *bgp_keepalives_start(void *arg)
 	pthread_cond_init(peerhash_cond, &attrs);
 	pthread_condattr_destroy(&attrs);
 
+#ifdef GNU_LINUX
+	pthread_setname_np(fpt->thread, "bgpd_ka");
+#elif defined(OPEN_BSD)
+	pthread_set_name_np(fpt->thread, "bgpd_ka");
+#endif
+
 	/* initialize peer hashtable */
 	peerhash = hash_create_size(2048, peer_hash_key, peer_hash_cmp, NULL);
 	pthread_mutex_lock(peerhash_mtx);


### PR DESCRIPTION
Call pthread setname to set thread name. 

Testing Done:

cat /proc/pid/task/tid/comm 

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>