### PR TITLE
zebra: display consistant mac count

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -244,6 +244,7 @@ static uint32_t num_valid_macs(zebra_vni_t *zvni)
 		for (hb = hash->index[i]; hb; hb = hb->next) {
 			mac = (zebra_mac_t *)hb->data;
 			if (CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE)
+			    || CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)
 			    || !CHECK_FLAG(mac->flags, ZEBRA_MAC_AUTO))
 				num_macs++;
 		}


### PR DESCRIPTION
show evpn mac vni all
show evpn mac vni x
does not display local svi and anycast mac into count.

Testing Done:

Before:

TOR1# show evpn mac vni 1008
Number of MACs (local and remote) known for this VNI: 4
MAC               Type   Intf/Remote VTEP      VLAN
44:38:39:00:6b:4c local  vlan1008              1008
00:02:00:00:00:04 local  hostbond5             1008
00:02:00:00:00:02 local  hostbond4             1008
00:00:5e:00:01:01 local  vlan1008-v0           1008
00:02:00:00:00:0c remote 27.0.0.15
00:02:00:00:00:0a remote 27.0.0.15
dell-s6000-07#

After:

TOR1# show evpn mac vni 1008
Number of MACs (local and remote) known for this VNI: 6
MAC               Type   Intf/Remote VTEP      VLAN
44:38:39:00:6b:4c local  vlan1008              1008
00:02:00:00:00:04 local  hostbond5             1008
00:02:00:00:00:02 local  hostbond4             1008
00:00:5e:00:01:01 local  vlan1008-v0           1008
00:02:00:00:00:0c remote 27.0.0.15
00:02:00:00:00:0a remote 27.0.0.15

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>