### PR TITLE
doc: fix syntax warnings in rpki.rst

### DIFF
--- a/doc/user/rpki.rst
+++ b/doc/user/rpki.rst
@@ -68,9 +68,10 @@ Enabling RPKI
    :ref:`configuring-rpki-rtr-cache-servers` for configuring a cache server.
 
 .. index:: daemons.conf
+.. clicmd:: daemons.conf
 
    When first installing FRR with RPKI support from the pre-packaged binaries.
-   Remember to append :option:`-M rpki` in the :file:`/etc/frr/daemons.conf`
+   Remember to append **-M rpki** in the :file:`/etc/frr/daemons.conf`
    file to ``bgpd_options``, like so::
 
       bgpd_options="   --daemon -A 127.0.0.1 -M rpki"


### PR DESCRIPTION
The rpki rst source had a couple of syntax issues - I'm no rst expert, so it'd be great if someone who _is_ could look at the way I addressed the warnings...

Signed-off-by: Mark Stapp <mjs@voltanet.io>