### PR TITLE
*: pthread set name abstraction

### DIFF
--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -180,11 +180,7 @@ void *bgp_keepalives_start(void *arg)
 	pthread_cond_init(peerhash_cond, &attrs);
 	pthread_condattr_destroy(&attrs);
 
-#ifdef GNU_LINUX
-	pthread_setname_np(fpt->thread, "bgpd_ka");
-#elif defined(OPEN_BSD)
-	pthread_set_name_np(fpt->thread, "bgpd_ka");
-#endif
+	frr_pthread_set_name(fpt, NULL, "bgpd_ka");
 
 	/* initialize peer hashtable */
 	peerhash = hash_create_size(2048, peer_hash_key, peer_hash_cmp, NULL);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7765,8 +7765,8 @@ static void bgp_pthreads_init()
 		.start = bgp_keepalives_start,
 		.stop = bgp_keepalives_stop,
 	};
-	frr_pthread_new(&io, "BGP I/O thread");
-	frr_pthread_new(&ka, "BGP Keepalives thread");
+	frr_pthread_new(&io, "BGP I/O thread", "bgpd_io");
+	frr_pthread_new(&ka, "BGP Keepalives thread", "bgpd_ka");
 }
 
 void bgp_pthreads_run()

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -28,6 +28,8 @@
 DECLARE_MTYPE(FRR_PTHREAD);
 DECLARE_MTYPE(PTHREAD_PRIM);
 
+#define OS_THREAD_NAMELEN 16
+
 struct frr_pthread;
 struct frr_pthread_attr;
 
@@ -89,6 +91,9 @@ struct frr_pthread {
 	 * Requires: mtx
 	 */
 	char *name;
+
+	/* Used in pthread_set_name max 16 characters */
+	char os_name[OS_THREAD_NAMELEN];
 };
 
 extern struct frr_pthread_attr frr_pthread_attr_default;
@@ -122,18 +127,23 @@ void frr_pthread_finish(void);
  *
  * @param attr - the thread attributes
  * @param name - Human-readable name
+ * @param os_name - 16 characters (including '\0') thread name to set in os,
  * @return the created frr_pthread upon success, or NULL upon failure
  */
 struct frr_pthread *frr_pthread_new(struct frr_pthread_attr *attr,
-				    const char *name);
+				    const char *name, const char *os_name);
 
 /*
  * Changes the name of the frr_pthread.
  *
  * @param fpt - the frr_pthread to operate on
  * @param name - Human-readable name
+ * @param os_name - 16 characters thread name , including the null
+ * terminator ('\0') to set in os.
+ * @return -  on success returns 0 otherwise nonzero error number.
  */
-void frr_pthread_set_name(struct frr_pthread *fpt, const char *name);
+int frr_pthread_set_name(struct frr_pthread *fpt, const char *name,
+			 const char *os_name);
 
 /*
  * Destroys an frr_pthread.

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -705,7 +705,8 @@ static struct zserv *zserv_client_create(int sock)
 		.stop = frr_pthread_attr_default.stop
 	};
 	client->pthread =
-		frr_pthread_new(&zclient_pthr_attrs, "Zebra API client thread");
+		frr_pthread_new(&zclient_pthr_attrs, "Zebra API client thread",
+				"zebra_apic");
 
 	zebra_vrf_update_all(client);
 


### PR DESCRIPTION
Testing Done:

 TOR#cat /proc/2670/task/2672/comm
 bgpd_ka

TOR# ps H -C bgpd -o 'pid tid cmd comm'
  PID   TID CMD                         COMMAND
  2670  2670 /usr/lib/frr/bgpd -M snmp - bgpd
  2670  2671 /usr/lib/frr/bgpd -M snmp - bgpd
  2670  2672 /usr/lib/frr/bgpd -M snmp - bgpd_ka

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>