### PR TITLE
bgpd: Make sure default-originate works without route-map as well

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -662,6 +662,7 @@ void subgroup_announce_route(struct update_subgroup *subgrp)
 void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 {
 	struct bgp *bgp;
+	struct attr attr;
 	struct bgp_info *info, init_info;
 	struct prefix p;
 	struct peer *from;
@@ -685,8 +686,23 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 	bgp = peer->bgp;
 	from = bgp->peer_self;
 
-	init_info.attr = NULL;
+	bgp_attr_default_set(&attr, BGP_ORIGIN_IGP);
+	attr.local_pref = bgp->default_local_pref;
+
+	if ((afi == AFI_IP6) || peer_cap_enhe(peer, afi, safi)) {
+		/* IPv6 global nexthop must be included.
+		 */
+		attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
+
+		/* If the peer is on shared nextwork and
+		 * we have link-local nexthop set it. */
+		if (peer->shared_network
+		    && !IN6_IS_ADDR_UNSPECIFIED(&peer->nexthop.v6_local))
+			attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
+	}
+	init_info.attr = &attr;
 	info = &init_info;
+	bgp_attr_intern(info->attr);
 
 	memset(&p, 0, sizeof(p));
 	p.family = afi2family(afi);
@@ -709,13 +725,9 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 
 				if ((afi == AFI_IP6)
 				    || peer_cap_enhe(peer, afi, safi)) {
-					/* IPv6 global nexthop must be included.
-					 */
 					tmp_info.attr->mp_nexthop_len =
 						BGP_ATTR_NHLEN_IPV6_GLOBAL;
 
-					/* If the peer is on shared nextwork and
-					 * we have link-local nexthop set it. */
 					if (peer->shared_network
 					    && !IN6_IS_ADDR_UNSPECIFIED(
 						       &peer->nexthop.v6_local))
@@ -728,6 +740,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 					&rn->p, RMAP_BGP, &tmp_info);
 
 				info = &tmp_info;
+				bgp_attr_intern(info->attr);
 
 				if (ret != RMAP_DENYMATCH)
 					break;
@@ -776,6 +789,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 				BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE);
 		}
 	}
+	aspath_unintern(&info->attr->aspath);
 }
 
 /*


### PR DESCRIPTION
fixes:
```
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: Received signal 11 at 1533016638 (si_addr 0x0, PC 0x55d717bf762c); aborting...
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: Backtrace for 13 stack frames:
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/local/lib/libfrr.so.0(zlog_backtrace_sigsafe+0x32) [0x7fc5fec1dd2c]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/local/lib/libfrr.so.0(zlog_signal+0x21b) [0x7fc5fec1e254]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/local/lib/libfrr.so.0(+0x4a819) [0x7fc5fec2e819]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /lib/x86_64-linux-gnu/libpthread.so.0(+0x110c0) [0x7fc5fde850c0]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/lib/frr/bgpd(bgp_attr_default_set+0x13) [0x55d717bf762c]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/lib/frr/bgpd(subgroup_default_originate+0x67) [0x55d717c42967]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/lib/frr/bgpd(subgroup_announce_table+0xa8) [0x55d717c42d69]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/lib/frr/bgpd(+0x92f64) [0x55d717c42f64]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/local/lib/libfrr.so.0(thread_call+0x46) [0x7fc5fec38871]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/local/lib/libfrr.so.0(frr_run+0x1b1) [0x7fc5fec1cd65]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/lib/frr/bgpd(main+0x219) [0x55d717be45cf]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1) [0x7fc5fdaf52e1]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: /usr/lib/frr/bgpd(_start+0x2a) [0x55d717be62fa]
Jul 31 05:57:18 spine1-debian-9 bgpd[4136]: read subgroup_coalesce_timer scheduled from bgp_updgrp_adv.c:826
Jul 31 05:57:18 spine1-debian-9 watchfrr[4146]: bgpd state -> down : read returned EOF
Jul 31 05:57:18 spine1-debian-9 watchfrr[4146]: bgpd state -> up : connect succeeded
Jul 31 05:57:18 spine1-debian-9 zebra[4129]: release_daemon_table_chunks: Released 0 table chunks
Jul 31 05:57:18 spine1-debian-9 zebra[4129]: release_daemon_label_chunks: Released 0 label chunks
Jul 31 05:57:18 spine1-debian-9 zebra[4129]: client 18 disconnected. 0 vnc routes removed from the rib
Jul 31 05:57:18 spine1-debian-9 watchfrr[4146]: bgpd state -> down : unexpected read error: Connection reset by peer
```

Related: https://github.com/FRRouting/frr/pull/2708


