### PR TITLE
lib and pim silliness

### DIFF
--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -120,7 +120,6 @@ extern vrf_id_t vrf_name_to_id(const char *);
 			} else {                                               \
 				vty_out(vty, "%% VRF %s not found\n", NAME);   \
 			}                                                      \
-			vty_out(vty, "%% VRF %s not found\n", NAME);           \
 			return CMD_WARNING;                                    \
 		}                                                              \
 		if (vrf->vrf_id == VRF_UNKNOWN) {                              \

--- a/pimd/pim_igmp_join.h
+++ b/pimd/pim_igmp_join.h
@@ -60,8 +60,6 @@ static int pim_igmp_join_source(int fd, ifindex_t ifindex,
 
 	return setsockopt(fd, SOL_IP, MCAST_JOIN_SOURCE_GROUP, &req,
 			  sizeof(req));
-
-	return 0;
 }
 
 #endif /* PIM_IGMP_JOIN_H */

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -38,7 +38,6 @@
 #include "pim_mroute.h"
 #include "pim_sock.h"
 #include "pim_str.h"
-#include "pim_igmp_join.h"
 
 /* GLOBAL VARS */
 
@@ -320,26 +319,6 @@ int pim_socket_join(int fd, struct in_addr group, struct in_addr ifaddr,
 	}
 
 	return ret;
-}
-
-int pim_socket_join_source(int fd, ifindex_t ifindex, struct in_addr group_addr,
-			   struct in_addr source_addr, const char *ifname)
-{
-	if (pim_igmp_join_source(fd, ifindex, group_addr, source_addr)) {
-		char group_str[INET_ADDRSTRLEN];
-		char source_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<grp?>", group_addr, group_str,
-			       sizeof(group_str));
-		pim_inet4_dump("<src?>", source_addr, source_str,
-			       sizeof(source_str));
-		zlog_warn(
-			"%s: setsockopt(fd=%d) failure for IGMP group %s source %s ifindex %d on interface %s: errno=%d: %s",
-			__PRETTY_FUNCTION__, fd, group_str, source_str, ifindex,
-			ifname, errno, safe_strerror(errno));
-		return -1;
-	}
-
-	return 0;
 }
 
 int pim_socket_recvfromto(int fd, uint8_t *buf, size_t len,

--- a/pimd/pim_sock.h
+++ b/pimd/pim_sock.h
@@ -42,8 +42,6 @@ int pim_socket_mcast(int protocol, struct in_addr ifaddr, struct interface *ifp,
 		     uint8_t loop);
 int pim_socket_join(int fd, struct in_addr group, struct in_addr ifaddr,
 		    ifindex_t ifindex);
-int pim_socket_join_source(int fd, ifindex_t ifindex, struct in_addr group_addr,
-			   struct in_addr source_addr, const char *ifname);
 int pim_socket_recvfromto(int fd, uint8_t *buf, size_t len,
 			  struct sockaddr_in *from, socklen_t *fromlen,
 			  struct sockaddr_in *to, socklen_t *tolen,


### PR DESCRIPTION
clean up some silliness in pim and lib

lib -> we are always displaying two lines on failure to find information on a specified vrf
pim-> Cleanup return statement and remove weird abstraction to call A -> B -> C, where B is effectively a 1 line function and B is only ever called by A