### PR TITLE
bgpd: Fix show ip bgp summary json command for dynamicPeers

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7914,9 +7914,11 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 		if (use_json) {
 			json_peer = json_object_new_object();
 
-			if (peer_dynamic_neighbor(peer))
+			if (peer_dynamic_neighbor(peer)) {
+				dn_count++;
 				json_object_boolean_true_add(json_peer,
 							     "dynamicPeer");
+			}
 
 			if (peer->hostname)
 				json_object_string_add(json_peer, "hostname",


### PR DESCRIPTION
The dn_count for dynamic Peers was not being updated when
using json output.

Signed-off-by: Dongling Duan <dlduan@amazon.com>
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>