### PR TITLE
bgpd: check existing l3vni for any l2vni creation

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4932,6 +4932,23 @@ void bgp_evpn_derive_auto_rd(struct bgp *bgp, struct bgpevpn *vpn)
 }
 
 /*
+ * Lookup L3-VNI
+ */
+bool bgp_evpn_lookup_l3vni_l2vni_table(vni_t vni)
+{
+	struct list *inst = bm->bgp;
+	struct listnode *node;
+	struct bgp *bgp_vrf;
+
+	for (ALL_LIST_ELEMENTS_RO(inst, node, bgp_vrf)) {
+		if (bgp_vrf->l3vni == vni)
+			return true;
+	}
+
+	return false;
+}
+
+/*
  * Lookup VNI.
  */
 struct bgpevpn *bgp_evpn_lookup_vni(struct bgp *bgp, vni_t vni)

--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -503,4 +503,5 @@ extern struct evpnes *bgp_evpn_lookup_es(struct bgp *bgp, esi_t *esi);
 extern struct evpnes *bgp_evpn_es_new(struct bgp *bgp, esi_t *esi,
 				      struct ipaddr *originator_ip);
 extern void bgp_evpn_es_free(struct bgp *bgp, struct evpnes *es);
+extern bool bgp_evpn_lookup_l3vni_l2vni_table(vni_t vni);
 #endif /* _BGP_EVPN_PRIVATE_H */

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1888,6 +1888,14 @@ static struct bgpevpn *evpn_create_update_vni(struct bgp *bgp, vni_t vni)
 
 	vpn = bgp_evpn_lookup_vni(bgp, vni);
 	if (!vpn) {
+		/* Check if this L2VNI is already configured as L3VNI */
+		if (bgp_evpn_lookup_l3vni_l2vni_table(vni)) {
+			flog_err(BGP_ERR_VNI,
+				 "%u: Failed to create L2VNI %u, it is configured as L3VNI",
+				 bgp->vrf_id, vni);
+			return NULL;
+		}
+
 		/* tenant vrf will be updated when we get local_vni_add from
 		 * zebra
 		 */


### PR DESCRIPTION
Scan all bgp vrf instances and respective L3VNI against the VNI which is being configured.

Testing Done:
Configure l3vni,
try to configure same vni as l2vni under router bgp, address-family
l2vpn evpn.
The configuration is rejected.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>