### PR TITLE
ripd: null check the key string

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -902,7 +902,7 @@ static int rip_auth_md5(struct rip_packet *packet, struct sockaddr_in *from,
 			return 0;
 
 		key = key_lookup_for_accept(keychain, md5->keyid);
-		if (key == NULL)
+		if (key == NULL || key->string == NULL)
 			return 0;
 
 		strncpy(auth_str, key->string, RIP_AUTH_MD5_SIZE);


### PR DESCRIPTION
This fix a crash of  null pointer.
when we don't add a key string or delete it,
the key is not null but key string is null,
so the code have to return.

Signed-off-by: lyq140 <34637052+lyq140@users.noreply.github.com>