### PR TITLE
lib: fix getsockopt_cmsg_data retrieval

### DIFF
--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -75,7 +75,7 @@ static void *getsockopt_cmsg_data(struct msghdr *msgh, int level, int type)
 
 	for (cmsg = ZCMSG_FIRSTHDR(msgh); cmsg != NULL;
 	     cmsg = CMSG_NXTHDR(msgh, cmsg))
-		if (cmsg->cmsg_level == level && cmsg->cmsg_type)
+		if (cmsg->cmsg_level == level && cmsg->cmsg_type == type)
 			return (ptr = CMSG_DATA(cmsg));
 
 	return NULL;


### PR DESCRIPTION
The `type` parameter was not being compared with `cmsg_type`, so the
result of this function was always a pointer to the first header
matching the level.

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>

---

As an additional note: this bug only affects users of `recvmsg` which expect to receive more than one `cmsg` header.