### PR TITLE
ripd: null check key

### DIFF
--- a/lib/keychain.c
+++ b/lib/keychain.c
@@ -172,7 +172,7 @@ struct key *key_match_for_accept(const struct keychain *keychain,
 		if (key->accept.start == 0
 		    || (key->accept.start <= now
 			&& (key->accept.end >= now || key->accept.end == -1)))
-			if (strncmp(key->string, auth_str, 16) == 0)
+			if (key->string && (strncmp(key->string, auth_str, 16) == 0))
 				return key;
 	}
 	return NULL;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -828,7 +828,7 @@ static int rip_auth_simple_password(struct rte *rte, struct sockaddr_in *from,
 		struct key *key;
 
 		keychain = keychain_lookup(ri->key_chain);
-		if (keychain == NULL)
+		if (keychain == NULL || keychain->key == NULL)
 			return 0;
 
 		key = key_match_for_accept(keychain, auth_str);


### PR DESCRIPTION
Fix ripd crash of null pointer.
when authenticate a rip packet,
the key pointer or the key string pointer may be null,
the code have to return then.

Signed-off-by: lyq140 <34637052+lyq140@users.noreply.github.com>