### PR TITLE
bgpd: Intentionally stop some timers on instance removal

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3120,6 +3120,9 @@ int bgp_delete(struct bgp *bgp)
 
 	assert(bgp);
 	THREAD_OFF(bgp->t_startup);
+	THREAD_OFF(bgp->t_maxmed_onstartup);
+	THREAD_OFF(bgp->t_update_delay);
+	THREAD_OFF(bgp->t_establish_wait);
 
 	if (BGP_DEBUG(zebra, ZEBRA)) {
 		if (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)


### PR DESCRIPTION
When a bgp instance is stopped, with a `no router bgp..`
make sure any timers associated with the instance are stopped
as well.

This issue was discovered when a customer issued a `no router bgp`
while a maxmed timer was operative.  The max-med timer used the
`struct bgp *` as the passed in value for the thread.  The
thread eventually popped after the cleanup and attempted to use
data off in lala land and crashed

Ticket: CM-21895
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>