### PR TITLE
tools/frr: make frr reload error message clearer on missing frr-reload.py

### DIFF
--- a/tools/frr
+++ b/tools/frr
@@ -574,7 +574,11 @@ case "$1" in
 
     reload)
        # Just apply the commands that have changed, no restart necessary
-       [ ! -x "$RELOAD_SCRIPT" ] && echo "frr-reload script not available" && exit 0
+       if [ ! -x "$RELOAD_SCRIPT" ]; then
+          echo "Please install frr-pythontools package. Required for reload"
+          exit 0
+       fi
+
        NEW_CONFIG_FILE="${2:-$C_PATH/frr.conf}"
        [ ! -r $NEW_CONFIG_FILE ] && echo "Unable to read new configuration file $NEW_CONFIG_FILE" && exit 1
        echo "Applying only incremental changes to running configuration from frr.conf"


### PR DESCRIPTION
Only frr-reload.py pulls in a python depenedency for frr, we can
reduce the size of the base frr package by a lot if we separate
out frr-pythontools.  When we do this, we get a somewhat cryptic
error message when frr-reload.py is missing on frr reload.

Here, we pull the error message from frr-reload script, which is
much clearer.

Testing done:

frr reload both with and without the frr-reload.py script, see
the frr-reload message when missing and it runs frr-reload.py when
not missing.

Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>