### PR TITLE
Topo mc crashy mc crasherson

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -782,6 +782,7 @@ struct thread *funcname_thread_add_read_write(int dir, struct thread_master *m,
 {
 	struct thread *thread = NULL;
 
+	assert(fd >= 0 && fd < m->fd_limit);
 	pthread_mutex_lock(&m->mtx);
 	{
 		if (t_ptr


### PR DESCRIPTION
1) Create assert for attempted write to a read/write poll fd out of range
2) Prevent zebra from causing the above assert.