### PR TITLE
zebra: don't close client socket from I/O pthread mc crasherson mc crashy crash bandicoot

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -782,6 +782,7 @@ struct thread *funcname_thread_add_read_write(int dir, struct thread_master *m,
 {
 	struct thread *thread = NULL;
 
+	assert(fd >= 0 && fd < m->fd_limit);
 	pthread_mutex_lock(&m->mtx);
 	{
 		if (t_ptr

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -576,6 +576,7 @@ static void zserv_client_free(struct zserv *client)
 		unsigned long nroutes;
 
 		close(client->sock);
+
 		nroutes = rib_score_proto(client->proto, client->instance);
 		zlog_notice(
 			"client %d disconnected. %lu %s routes removed from the rib",
@@ -620,12 +621,6 @@ void zserv_close_client(struct zserv *client)
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("Closing client '%s'",
 			   zebra_route_string(client->proto));
-
-	/* if file descriptor is still open, close it */
-	if (client->sock > 0) {
-		close(client->sock);
-		client->sock = -1;
-	}
 
 	thread_cancel_event(zebrad.master, client);
 	THREAD_OFF(client->t_cleanup);


### PR DESCRIPTION
The client socket value can only be modified by the main thread.
Modifying the client socket from within the client I/O pthread
introduces race conditions.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>