### PR TITLE
Fix bgp updates prefix debugging

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -338,6 +338,7 @@ struct cmd_node {
 #define UNDEBUG_STR "Disable debugging functions (see also 'debug')\n"
 #define ROUTER_STR "Enable a routing process\n"
 #define AS_STR "AS number\n"
+#define MAC_STR "MAC address\n"
 #define MBGP_STR "MBGP information\n"
 #define MATCH_STR "Match values from routing table\n"
 #define SET_STR "Set values in destination routing protocol\n"


### PR DESCRIPTION
* Fix prefix debugs not being printed in config
* Fix memory leaks in debug commands
* Use CLI tokens to properly sanitize input
* Remove unnecessary error handling code from debug commands
* Remove unnecessary parameters from conf print functions