### PR TITLE
Pim ordering

### DIFF
--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -313,21 +313,21 @@ int pim_interface_config_write(struct vty *vty)
 					++writes;
 				}
 
-				/* IF ip igmp query-interval */
-				if (pim_ifp->igmp_default_query_interval
-				    != IGMP_GENERAL_QUERY_INTERVAL) {
-					vty_out(vty,
-						" ip igmp query-interval %d\n",
-						pim_ifp->igmp_default_query_interval);
-					++writes;
-				}
-
 				/* IF ip igmp query-max-response-time */
 				if (pim_ifp->igmp_query_max_response_time_dsec
 				    != IGMP_QUERY_MAX_RESPONSE_TIME_DSEC) {
 					vty_out(vty,
 						" ip igmp query-max-response-time %d\n",
 						pim_ifp->igmp_query_max_response_time_dsec);
+					++writes;
+				}
+
+				/* IF ip igmp query-interval */
+				if (pim_ifp->igmp_default_query_interval
+				    != IGMP_GENERAL_QUERY_INTERVAL) {
+					vty_out(vty,
+						" ip igmp query-interval %d\n",
+						pim_ifp->igmp_default_query_interval);
 					++writes;
 				}
 

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -179,6 +179,9 @@ void vtysh_config_parse_line(void *arg, const char *line)
 					   strlen(" ip multicast boundary"))
 				   == 0) {
 				config_add_line_end(config->line, line);
+			} else if (strncmp(line, " ip igmp query-interval",
+					   strlen(" ip igmp query-interval")) == 0) {
+				config_add_line_end(config->line, line);
 			} else if (config->index == LINK_PARAMS_NODE
 				   && strncmp(line, "  exit-link-params",
 					      strlen("  exit"))


### PR DESCRIPTION
the `ip igmp query-interval` and `ip igmp query-max-response-time` commands needed to be reversed in show output to allow modified values of query-interval to be accepted when modifying query-max-response-time as well.