### PR TITLE
lib: Increase stream allocation speed.

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -100,16 +100,12 @@ struct stream *stream_new(size_t size)
 
 	assert(size > 0);
 
-	s = XCALLOC(MTYPE_STREAM, sizeof(struct stream));
+	s = XMALLOC(MTYPE_STREAM, sizeof(struct stream));
 
-	if (s == NULL)
-		return s;
+	s->data = XMALLOC(MTYPE_STREAM_DATA, size);
 
-	if ((s->data = XMALLOC(MTYPE_STREAM_DATA, size)) == NULL) {
-		XFREE(MTYPE_STREAM, s);
-		return NULL;
-	}
-
+	s->getp = s->endp = 0;
+	s->next = NULL;
 	s->size = size;
 	return s;
 }


### PR DESCRIPTION
Modify stream_new in this way:

1) ALLOC allocations do not fail, they cause a crash so remove
if tests for it.

2) Modify usage of XCALLOC to XMALLOC and then hand set all the
relevant data in the stream pointer.

With this modification stream allocation of 10000000 streams at
10k bytes each reduced from on average 1.43 seconds to 0.65 seconds.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>