### PR TITLE
bgpd: dead code (Coverity 1472230 1472231 1472238)

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2807,9 +2807,6 @@ DEFUN (bgp_evpn_advertise_default_gw_vni,
 	if (!bgp)
 		return CMD_WARNING;
 
-	if (!vpn)
-		return CMD_WARNING;
-
 	evpn_set_advertise_default_gw(bgp, vpn);
 
 	return CMD_SUCCESS;
@@ -2825,9 +2822,6 @@ DEFUN (no_bgp_evpn_advertise_default_vni_gw,
 	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
 
 	if (!bgp)
-		return CMD_WARNING;
-
-	if (!vpn)
 		return CMD_WARNING;
 
 	evpn_unset_advertise_default_gw(bgp, vpn);
@@ -2972,9 +2966,6 @@ DEFUN_HIDDEN (bgp_evpn_advertise_vni_subnet,
 	if (!bgp)
 		return CMD_WARNING;
 
-	if (!vpn)
-		return CMD_WARNING;
-
 	bgp_vrf = bgp_lookup_by_vrf_id(vpn->tenant_vrf_id);
 	if (!bgp_vrf)
 		return CMD_WARNING;
@@ -2993,9 +2984,6 @@ DEFUN_HIDDEN (no_bgp_evpn_advertise_vni_subnet,
 	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
 
 	if (!bgp)
-		return CMD_WARNING;
-
-	if (!vpn)
 		return CMD_WARNING;
 
 	evpn_unset_advertise_subnet(bgp, vpn);
@@ -4225,7 +4213,7 @@ DEFUN (bgp_evpn_vni_rd,
 	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
 	int ret;
 
-	if (!bgp || !vpn)
+	if (!bgp)
 		return CMD_WARNING;
 
 	if (bgp->vrf_id != VRF_DEFAULT) {
@@ -4261,7 +4249,7 @@ DEFUN (no_bgp_evpn_vni_rd,
 	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
 	int ret;
 
-	if (!bgp || !vpn)
+	if (!bgp)
 		return CMD_WARNING;
 
 	if (bgp->vrf_id != VRF_DEFAULT) {
@@ -4301,7 +4289,7 @@ DEFUN (no_bgp_evpn_vni_rd_without_val,
 	struct bgp *bgp = VTY_GET_CONTEXT(bgp);
 	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
 
-	if (!bgp || !vpn)
+	if (!bgp)
 		return CMD_WARNING;
 
 	if (bgp->vrf_id != VRF_DEFAULT) {
@@ -4630,7 +4618,7 @@ DEFUN (bgp_evpn_vni_rt,
 	int rt_type;
 	struct ecommunity *ecomadd = NULL;
 
-	if (!bgp || !vpn)
+	if (!bgp)
 		return CMD_WARNING;
 
 	if (bgp->vrf_id != VRF_DEFAULT) {
@@ -4698,7 +4686,7 @@ DEFUN (no_bgp_evpn_vni_rt,
 	int rt_type, found_ecomdel;
 	struct ecommunity *ecomdel = NULL;
 
-	if (!bgp || !vpn)
+	if (!bgp)
 		return CMD_WARNING;
 
 	if (bgp->vrf_id != VRF_DEFAULT) {
@@ -4797,7 +4785,7 @@ DEFUN (no_bgp_evpn_vni_rt_without_val,
 	VTY_DECLVAR_CONTEXT_SUB(bgpevpn, vpn);
 	int rt_type;
 
-	if (!bgp || !vpn)
+	if (!bgp)
 		return CMD_WARNING;
 
 	if (bgp->vrf_id != VRF_DEFAULT) {


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr