### PR TITLE
bgpd: null check (Coverity 1472237)

### DIFF
--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -144,9 +144,6 @@ void bgp_table_range_lookup(const struct bgp_table *table, struct prefix *p,
 	struct bgp_node *node = bgp_node_from_rnode(table->route_table->top);
 	struct bgp_node *matched = NULL;
 
-	if (node == NULL)
-		return;
-
 	while (node && node->p.prefixlen <= p->prefixlen
 	       && prefix_match(&node->p, p)) {
 		if (node->info && node->p.prefixlen == p->prefixlen) {
@@ -156,6 +153,9 @@ void bgp_table_range_lookup(const struct bgp_table *table, struct prefix *p,
 		node = bgp_node_from_rnode(node->link[prefix_bit(
 			&p->u.prefix, node->p.prefixlen)]);
 	}
+
+	if (node == NULL)
+		return;
 
 	if ((matched == NULL && node->p.prefixlen > maxlen) || !node->parent)
 		return;


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

IMO, @mroethke (1dacdd8b) should review this, just in case :-)

[1] https://scan.coverity.com/projects/freerangerouting-frr