### PR TITLE
zebra: socket fd check (Coverity 1472236)

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -1085,6 +1085,7 @@ void kernel_init(struct zebra_ns *zns)
 	if (nl_rcvbufsize)
 		netlink_recvbuf(&zns->netlink, nl_rcvbufsize);
 
+	assert(zns->netlink.sock >= 0);
 	netlink_install_filter(zns->netlink.sock,
 			       zns->netlink_cmd.snl.nl_pid);
 	zns->t_netlink = NULL;


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr