### PR TITLE
ospfd: dead code (Coverity 1472227)

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -1921,7 +1921,7 @@ struct ospf_lsa *ospf_translated_nssa_refresh(struct ospf *ospf,
 			zlog_debug(
 				"ospf_translated_nssa_refresh(): Could not install "
 				"translated LSA, Id %s",
-				type7 ? inet_ntoa(type7->data->id) : "(null)");
+				inet_ntoa(type7->data->id));
 		return NULL;
 	}
 


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr