### PR TITLE
Abstract `void *aggregate` pointer in `struct route_node`

### DIFF
--- a/bgpd/rfapi/bgp_rfapi_cfg.h
+++ b/bgpd/rfapi/bgp_rfapi_cfg.h
@@ -47,8 +47,8 @@ typedef enum {
 } rfapi_group_cfg_type_t;
 
 struct rfapi_nve_group_cfg {
-	struct route_node *vn_node; /* backref */
-	struct route_node *un_node; /* backref */
+	struct agg_node *vn_node; /* backref */
+	struct agg_node *un_node; /* backref */
 
 	rfapi_group_cfg_type_t type; /* NVE|VPN */
 	char *name;		     /* unique by type! */
@@ -135,8 +135,8 @@ struct rfapi_cfg {
 	struct list *l2_groups; /* rfapi_l2_group_cfg list */
 	/* three views into the same collection of rfapi_nve_group_cfg */
 	struct list *nve_groups_sequential;
-	struct route_table *nve_groups_vn[AFI_MAX];
-	struct route_table *nve_groups_un[AFI_MAX];
+	struct agg_table *nve_groups_vn[AFI_MAX];
+	struct agg_table *nve_groups_un[AFI_MAX];
 
 	/*
 	 * For Single VRF export to ordinary routing protocols. This is

--- a/bgpd/rfapi/rfapi_ap.c
+++ b/bgpd/rfapi/rfapi_ap.c
@@ -22,7 +22,7 @@
 
 #include "lib/zebra.h"
 #include "lib/prefix.h"
-#include "lib/table.h"
+#include "lib/agg_table.h"
 #include "lib/vty.h"
 #include "lib/memory.h"
 #include "lib/routemap.h"

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -27,7 +27,7 @@
 
 #include "lib/zebra.h"
 #include "lib/prefix.h"
-#include "lib/table.h"
+#include "lib/agg_table.h"
 #include "lib/vty.h"
 #include "lib/memory.h"
 #include "lib/log.h"
@@ -80,7 +80,7 @@
  */
 struct rfapi_withdraw {
 	struct rfapi_import_table *import_table;
-	struct route_node *node;
+	struct agg_node *node;
 	struct bgp_info *info;
 	safi_t safi; /* used only for bulk operations */
 	/*
@@ -88,8 +88,8 @@ struct rfapi_withdraw {
 	 * Normally when a timer expires, lockoffset should be 0. However, if
 	 * the timer expiration function is called directly (e.g.,
 	 * rfapiExpireVpnNow), the node could be locked by a preceding
-	 * route_top() or route_next() in a loop, so we need to pass this
-	 * value in.
+	 * agg_route_top() or agg_route_next() in a loop, so we need to pass
+	 * this value in.
 	 */
 	int lockoffset;
 };
@@ -140,8 +140,8 @@ void rfapiCheckRouteCount()
 	for (it = h->imports; it; it = it->next) {
 		for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
 
-			struct route_table *rt;
-			struct route_node *rn;
+			struct agg_table *rt;
+			struct agg_node *rn;
 
 			int holddown_count = 0;
 			int local_count = 0;
@@ -150,7 +150,8 @@ void rfapiCheckRouteCount()
 
 			rt = it->imported_vpn[afi];
 
-			for (rn = route_top(rt); rn; rn = route_next(rn)) {
+			for (rn = agg_route_top(rt); rn;
+			     rn = agg_route_next(rn)) {
 				struct bgp_info *bi;
 				struct bgp_info *next;
 
@@ -211,11 +212,11 @@ void rfapiCheckRouteCount()
  * Validate reference count for a node in an import table
  *
  * Normally lockoffset is 0 for nodes in quiescent state. However,
- * route_unlock_node will delete the node if it is called when
+ * agg_unlock_node will delete the node if it is called when
  * node->lock == 1, and we have to validate the refcount before
  * the node is deleted. In this case, we specify lockoffset 1.
  */
-void rfapiCheckRefcount(struct route_node *rn, safi_t safi, int lockoffset)
+void rfapiCheckRefcount(struct agg_node *rn, safi_t safi, int lockoffset)
 {
 	unsigned int count_bi = 0;
 	unsigned int count_monitor = 0;
@@ -613,8 +614,8 @@ struct rfapi_import_table *rfapiMacImportTableGet(struct bgp *bgp, uint32_t lni)
 		it->rt_import_list = enew;
 
 		for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
-			it->imported_vpn[afi] = route_table_init();
-			it->imported_encap[afi] = route_table_init();
+			it->imported_vpn[afi] = agg_table_init();
+			it->imported_encap[afi] = agg_table_init();
 		}
 
 		it->l2_logical_net_id = lni;
@@ -633,10 +634,10 @@ struct rfapi_import_table *rfapiMacImportTableGet(struct bgp *bgp, uint32_t lni)
  * Returns pointer to the list of moved monitors
  */
 static struct rfapi_monitor_vpn *
-rfapiMonitorMoveShorter(struct route_node *original_vpn_node, int lockoffset)
+rfapiMonitorMoveShorter(struct agg_node *original_vpn_node, int lockoffset)
 {
 	struct bgp_info *bi;
-	struct route_node *par;
+	struct agg_node *par;
 	struct rfapi_monitor_vpn *m;
 	struct rfapi_monitor_vpn *mlast;
 	struct rfapi_monitor_vpn *moved;
@@ -679,7 +680,8 @@ rfapiMonitorMoveShorter(struct route_node *original_vpn_node, int lockoffset)
 	 *    one route (even if it is only a withdrawn route) with a
 	 *    valid UN address. Call this node "Node P."
 	 */
-	for (par = original_vpn_node->parent; par; par = par->parent) {
+	for (par = agg_node_parent(original_vpn_node); par;
+	     par = agg_node_parent(par)) {
 		for (bi = par->info; bi; bi = bi->next) {
 			struct prefix pfx;
 			if (!rfapiGetUnAddrOfVpnBi(bi, &pfx)) {
@@ -699,14 +701,14 @@ rfapiMonitorMoveShorter(struct route_node *original_vpn_node, int lockoffset)
 	 */
 	if (!par) {
 		/* this isn't necessarily 0/0 */
-		par = route_top(original_vpn_node->table);
+		par = agg_route_table_top(original_vpn_node);
 
 		/*
 		 * If we got the top node but it wasn't 0/0,
 		 * ignore it
 		 */
 		if (par && par->p.prefixlen) {
-			route_unlock_node(par); /* maybe free */
+			agg_unlock_node(par); /* maybe free */
 			par = NULL;
 		}
 
@@ -725,7 +727,8 @@ rfapiMonitorMoveShorter(struct route_node *original_vpn_node, int lockoffset)
 		pfx_default.family = original_vpn_node->p.family;
 
 		/* creates default node if none exists */
-		par = route_node_get(original_vpn_node->table, &pfx_default);
+		par = agg_node_get(agg_get_table(original_vpn_node),
+				   &pfx_default);
 		++parent_already_refcounted;
 	}
 
@@ -764,18 +767,18 @@ rfapiMonitorMoveShorter(struct route_node *original_vpn_node, int lockoffset)
 	RFAPI_CHECK_REFCOUNT(par, SAFI_MPLS_VPN,
 			     parent_already_refcounted - movecount);
 	while (movecount > parent_already_refcounted) {
-		route_lock_node(par);
+		agg_lock_node(par);
 		++parent_already_refcounted;
 	}
 	while (movecount < parent_already_refcounted) {
 		/* unlikely, but code defensively */
-		route_unlock_node(par);
+		agg_unlock_node(par);
 		--parent_already_refcounted;
 	}
 	RFAPI_CHECK_REFCOUNT(original_vpn_node, SAFI_MPLS_VPN,
 			     movecount + lockoffset);
 	while (movecount--) {
-		route_unlock_node(original_vpn_node);
+		agg_unlock_node(original_vpn_node);
 	}
 
 #if DEBUG_MONITOR_MOVE_SHORTER
@@ -796,12 +799,12 @@ rfapiMonitorMoveShorter(struct route_node *original_vpn_node, int lockoffset)
  * Implement MONITOR_MOVE_LONGER(new_node) from
  * RFAPI-Import-Event-Handling.txt
  */
-static void rfapiMonitorMoveLonger(struct route_node *new_vpn_node)
+static void rfapiMonitorMoveLonger(struct agg_node *new_vpn_node)
 {
 	struct rfapi_monitor_vpn *monitor;
 	struct rfapi_monitor_vpn *mlast;
 	struct bgp_info *bi;
-	struct route_node *par;
+	struct agg_node *par;
 
 	RFAPI_CHECK_REFCOUNT(new_vpn_node, SAFI_MPLS_VPN, 0);
 
@@ -824,7 +827,8 @@ static void rfapiMonitorMoveLonger(struct route_node *new_vpn_node)
 	/*
 	 * Find first parent node that has monitors
 	 */
-	for (par = new_vpn_node->parent; par; par = par->parent) {
+	for (par = agg_node_parent(new_vpn_node); par;
+	     par = agg_node_parent(par)) {
 		if (RFAPI_MONITOR_VPN(par))
 			break;
 	}
@@ -860,14 +864,14 @@ static void rfapiMonitorMoveLonger(struct route_node *new_vpn_node)
 			RFAPI_MONITOR_VPN_W_ALLOC(new_vpn_node) = monitor;
 			monitor->node = new_vpn_node;
 
-			route_lock_node(new_vpn_node); /* incr refcount */
+			agg_lock_node(new_vpn_node); /* incr refcount */
 
 			monitor = mlast ? mlast->next : RFAPI_MONITOR_VPN(par);
 
 			RFAPI_CHECK_REFCOUNT(par, SAFI_MPLS_VPN, 1);
 			/* decr refcount after we're done with par as this might
 			 * free it */
-			route_unlock_node(par);
+			agg_unlock_node(par);
 
 			continue;
 		}
@@ -919,10 +923,10 @@ static void rfapiImportTableFlush(struct rfapi_import_table *it)
 
 	for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
 
-		struct route_node *rn;
+		struct agg_node *rn;
 
-		for (rn = route_top(it->imported_vpn[afi]); rn;
-		     rn = route_next(rn)) {
+		for (rn = agg_route_top(it->imported_vpn[afi]); rn;
+		     rn = agg_route_next(rn)) {
 			/*
 			 * Each route_node has:
 			 * aggregate: points to rfapi_it_extra with monitor
@@ -936,8 +940,8 @@ static void rfapiImportTableFlush(struct rfapi_import_table *it)
 			rfapiMonitorExtraFlush(SAFI_MPLS_VPN, rn);
 		}
 
-		for (rn = route_top(it->imported_encap[afi]); rn;
-		     rn = route_next(rn)) {
+		for (rn = agg_route_top(it->imported_encap[afi]); rn;
+		     rn = agg_route_next(rn)) {
 			/* free bgp_info and its children */
 			rfapiBgpInfoChainFree(rn->info);
 			rn->info = NULL;
@@ -945,8 +949,8 @@ static void rfapiImportTableFlush(struct rfapi_import_table *it)
 			rfapiMonitorExtraFlush(SAFI_ENCAP, rn);
 		}
 
-		route_table_finish(it->imported_vpn[afi]);
-		route_table_finish(it->imported_encap[afi]);
+		agg_table_finish(it->imported_vpn[afi]);
+		agg_table_finish(it->imported_encap[afi]);
 	}
 	if (it->monitor_exterior_orphans) {
 		skiplist_free(it->monitor_exterior_orphans);
@@ -1293,9 +1297,9 @@ int rfapi_extract_l2o(
 
 static struct rfapi_next_hop_entry *
 rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
-			    struct bgp_info *bi,   /* route to encode */
-			    uint32_t lifetime,     /* use this in nhe */
-			    struct route_node *rn) /* req for L2 eth addr */
+			    struct bgp_info *bi, /* route to encode */
+			    uint32_t lifetime,   /* use this in nhe */
+			    struct agg_node *rn) /* req for L2 eth addr */
 {
 	struct rfapi_next_hop_entry *new;
 	int have_vnc_tunnel_un = 0;
@@ -1481,7 +1485,7 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 	return new;
 }
 
-int rfapiHasNonRemovedRoutes(struct route_node *rn)
+int rfapiHasNonRemovedRoutes(struct agg_node *rn)
 {
 	struct bgp_info *bi;
 
@@ -1501,7 +1505,7 @@ int rfapiHasNonRemovedRoutes(struct route_node *rn)
 /*
  * DEBUG FUNCTION
  */
-void rfapiDumpNode(struct route_node *rn)
+void rfapiDumpNode(struct agg_node *rn)
 {
 	struct bgp_info *bi;
 
@@ -1527,14 +1531,14 @@ void rfapiDumpNode(struct route_node *rn)
 #endif
 
 static int rfapiNhlAddNodeRoutes(
-	struct route_node *rn,		      /* in */
+	struct agg_node *rn,		      /* in */
 	struct rfapi_ip_prefix *rprefix,      /* in */
 	uint32_t lifetime,		      /* in */
 	int removed,			      /* in */
 	struct rfapi_next_hop_entry **head,   /* in/out */
 	struct rfapi_next_hop_entry **tail,   /* in/out */
 	struct rfapi_ip_addr *exclude_vnaddr, /* omit routes to same NVE */
-	struct route_node *rfd_rib_node,      /* preload this NVE rib node */
+	struct agg_node *rfd_rib_node,	/* preload this NVE rib node */
 	struct prefix *pfx_target_original)   /* query target */
 {
 	struct bgp_info *bi;
@@ -1544,15 +1548,17 @@ static int rfapiNhlAddNodeRoutes(
 	int count = 0;
 	int is_l2 = (rn->p.family == AF_ETHERNET);
 
-	if (rfd_rib_node && rfd_rib_node->table && rfd_rib_node->table->info) {
+	if (rfd_rib_node) {
+		struct agg_table *atable = agg_get_table(rfd_rib_node);
 		struct rfapi_descriptor *rfd;
 
-		rfd = (struct rfapi_descriptor *)(rfd_rib_node->table->info);
+		if (atable) {
+			rfd = agg_get_table_info(atable);
 
-		if (rfapiRibFTDFilterRecentPrefix(
-			rfd, rn, pfx_target_original))
-
-			return 0;
+			if (rfapiRibFTDFilterRecentPrefix(rfd, rn,
+							  pfx_target_original))
+				return 0;
+		}
 	}
 
 	seen_nexthops =
@@ -1657,13 +1663,13 @@ static int rfapiNhlAddNodeRoutes(
  * matches (of course, we still travel down its child subtrees).
  */
 static int rfapiNhlAddSubtree(
-	struct route_node *rn,		      /* in */
+	struct agg_node *rn,		      /* in */
 	uint32_t lifetime,		      /* in */
 	struct rfapi_next_hop_entry **head,   /* in/out */
 	struct rfapi_next_hop_entry **tail,   /* in/out */
-	struct route_node *omit_node,	 /* in */
+	struct agg_node *omit_node,	   /* in */
 	struct rfapi_ip_addr *exclude_vnaddr, /* omit routes to same NVE */
-	struct route_table *rfd_rib_table,    /* preload here */
+	struct agg_table *rfd_rib_table,      /* preload here */
 	struct prefix *pfx_target_original)   /* query target */
 {
 	struct rfapi_ip_prefix rprefix;
@@ -1671,65 +1677,67 @@ static int rfapiNhlAddSubtree(
 
 	/* FIXME: need to find a better way here to work without sticking our
 	 * hands in node->link */
-	if (rn->l_left && rn->l_left != omit_node) {
-		if (rn->l_left->info) {
+	if (agg_node_left(rn) && agg_node_left(rn) != omit_node) {
+		if (agg_node_left(rn)->info) {
 			int count = 0;
-			struct route_node *rib_rn = NULL;
+			struct agg_node *rib_rn = NULL;
 
-			rfapiQprefix2Rprefix(&rn->l_left->p, &rprefix);
+			rfapiQprefix2Rprefix(&agg_node_left(rn)->p, &rprefix);
 			if (rfd_rib_table) {
-				rib_rn = route_node_get(rfd_rib_table,
-							&rn->l_left->p);
+				rib_rn = agg_node_get(rfd_rib_table,
+						      &agg_node_left(rn)->p);
 			}
 
 			count = rfapiNhlAddNodeRoutes(
-				rn->l_left, &rprefix, lifetime, 0, head, tail,
-				exclude_vnaddr, rib_rn, pfx_target_original);
+				agg_node_left(rn), &rprefix, lifetime, 0, head,
+				tail, exclude_vnaddr, rib_rn,
+				pfx_target_original);
 			if (!count) {
 				count = rfapiNhlAddNodeRoutes(
-					rn->l_left, &rprefix, lifetime, 1, head,
-					tail, exclude_vnaddr, rib_rn,
+					agg_node_left(rn), &rprefix, lifetime,
+					1, head, tail, exclude_vnaddr, rib_rn,
 					pfx_target_original);
 			}
 			rcount += count;
 			if (rib_rn)
-				route_unlock_node(rib_rn);
+				agg_unlock_node(rib_rn);
 		}
 	}
 
-	if (rn->l_right && rn->l_right != omit_node) {
-		if (rn->l_right->info) {
+	if (agg_node_right(rn) && agg_node_right(rn) != omit_node) {
+		if (agg_node_right(rn)->info) {
 			int count = 0;
-			struct route_node *rib_rn = NULL;
+			struct agg_node *rib_rn = NULL;
 
-			rfapiQprefix2Rprefix(&rn->l_right->p, &rprefix);
+			rfapiQprefix2Rprefix(&agg_node_right(rn)->p, &rprefix);
 			if (rfd_rib_table) {
-				rib_rn = route_node_get(rfd_rib_table,
-							&rn->l_right->p);
+				rib_rn = agg_node_get(rfd_rib_table,
+						      &agg_node_right(rn)->p);
 			}
 			count = rfapiNhlAddNodeRoutes(
-				rn->l_right, &rprefix, lifetime, 0, head, tail,
-				exclude_vnaddr, rib_rn, pfx_target_original);
+				agg_node_right(rn), &rprefix, lifetime, 0, head,
+				tail, exclude_vnaddr, rib_rn,
+				pfx_target_original);
 			if (!count) {
 				count = rfapiNhlAddNodeRoutes(
-					rn->l_right, &rprefix, lifetime, 1,
-					head, tail, exclude_vnaddr, rib_rn,
+					agg_node_right(rn), &rprefix, lifetime,
+					1, head, tail, exclude_vnaddr, rib_rn,
 					pfx_target_original);
 			}
 			rcount += count;
 			if (rib_rn)
-				route_unlock_node(rib_rn);
+				agg_unlock_node(rib_rn);
 		}
 	}
 
-	if (rn->l_left) {
+	if (agg_node_left(rn)) {
 		rcount += rfapiNhlAddSubtree(
-			rn->l_left, lifetime, head, tail, omit_node,
+			agg_node_left(rn), lifetime, head, tail, omit_node,
 			exclude_vnaddr, rfd_rib_table, pfx_target_original);
 	}
-	if (rn->l_right) {
+	if (agg_node_right(rn)) {
 		rcount += rfapiNhlAddSubtree(
-			rn->l_right, lifetime, head, tail, omit_node,
+			agg_node_right(rn), lifetime, head, tail, omit_node,
 			exclude_vnaddr, rfd_rib_table, pfx_target_original);
 	}
 
@@ -1748,17 +1756,17 @@ static int rfapiNhlAddSubtree(
  * next less-specific node (i.e., this node's parent) at the end.
  */
 struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
-	struct route_node *rn, uint32_t lifetime, /* put into nexthop entries */
-	struct rfapi_ip_addr *exclude_vnaddr,     /* omit routes to same NVE */
-	struct route_table *rfd_rib_table,	/* preload here */
-	struct prefix *pfx_target_original)       /* query target */
+	struct agg_node *rn, uint32_t lifetime, /* put into nexthop entries */
+	struct rfapi_ip_addr *exclude_vnaddr,   /* omit routes to same NVE */
+	struct agg_table *rfd_rib_table,	/* preload here */
+	struct prefix *pfx_target_original)     /* query target */
 {
 	struct rfapi_ip_prefix rprefix;
 	struct rfapi_next_hop_entry *answer = NULL;
 	struct rfapi_next_hop_entry *last = NULL;
-	struct route_node *parent;
+	struct agg_node *parent;
 	int count = 0;
-	struct route_node *rib_rn;
+	struct agg_node *rib_rn;
 
 #if DEBUG_RETURNED_NHL
 	{
@@ -1773,7 +1781,7 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 
 	rfapiQprefix2Rprefix(&rn->p, &rprefix);
 
-	rib_rn = rfd_rib_table ? route_node_get(rfd_rib_table, &rn->p) : NULL;
+	rib_rn = rfd_rib_table ? agg_node_get(rfd_rib_table, &rn->p) : NULL;
 
 	/*
 	 * Add non-withdrawn routes at this node
@@ -1795,7 +1803,7 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 		rfapiPrintNhl(NULL, answer);
 #endif
 		if (rib_rn)
-			route_unlock_node(rib_rn);
+			agg_unlock_node(rib_rn);
 		return answer;
 	}
 
@@ -1806,7 +1814,7 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 				      exclude_vnaddr, rib_rn,
 				      pfx_target_original);
 	if (rib_rn)
-		route_unlock_node(rib_rn);
+		agg_unlock_node(rib_rn);
 
 	// rfapiPrintNhl(NULL, answer);
 
@@ -1814,7 +1822,8 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 	 * walk up the tree until we find a node with non-deleted
 	 * routes, then add them
 	 */
-	for (parent = rn->parent; parent; parent = parent->parent) {
+	for (parent = agg_node_parent(rn); parent;
+	     parent = agg_node_parent(parent)) {
 		if (rfapiHasNonRemovedRoutes(parent)) {
 			break;
 		}
@@ -1824,9 +1833,8 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 	 * Add non-withdrawn routes from less-specific prefix
 	 */
 	if (parent) {
-		rib_rn = rfd_rib_table
-				 ? route_node_get(rfd_rib_table, &parent->p)
-				 : NULL;
+		rib_rn = rfd_rib_table ? agg_node_get(rfd_rib_table, &parent->p)
+				       : NULL;
 		rfapiQprefix2Rprefix(&parent->p, &rprefix);
 		count += rfapiNhlAddNodeRoutes(parent, &rprefix, lifetime, 0,
 					       &answer, &last, exclude_vnaddr,
@@ -1835,7 +1843,7 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 					    rn, exclude_vnaddr, rfd_rib_table,
 					    pfx_target_original);
 		if (rib_rn)
-			route_unlock_node(rib_rn);
+			agg_unlock_node(rib_rn);
 	} else {
 		/*
 		 * There is no parent with non-removed routes. Still need to
@@ -1861,19 +1869,18 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
  * Construct nexthop list of all routes in table
  */
 struct rfapi_next_hop_entry *rfapiRouteTable2NextHopList(
-	struct route_table *rt,
-	uint32_t lifetime,		      /* put into nexthop entries */
-	struct rfapi_ip_addr *exclude_vnaddr, /* omit routes to same NVE */
-	struct route_table *rfd_rib_table,    /* preload this NVE rib table */
-	struct prefix *pfx_target_original)   /* query target */
+	struct agg_table *rt, uint32_t lifetime, /* put into nexthop entries */
+	struct rfapi_ip_addr *exclude_vnaddr,    /* omit routes to same NVE */
+	struct agg_table *rfd_rib_table,    /* preload this NVE rib table */
+	struct prefix *pfx_target_original) /* query target */
 {
-	struct route_node *rn;
+	struct agg_node *rn;
 	struct rfapi_next_hop_entry *biglist = NULL;
 	struct rfapi_next_hop_entry *nhl;
 	struct rfapi_next_hop_entry *tail = NULL;
 	int count = 0;
 
-	for (rn = route_top(rt); rn; rn = route_next(rn)) {
+	for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
 
 		nhl = rfapiRouteNode2NextHopList(rn, lifetime, exclude_vnaddr,
 						 rfd_rib_table,
@@ -1898,18 +1905,18 @@ struct rfapi_next_hop_entry *rfapiRouteTable2NextHopList(
 }
 
 struct rfapi_next_hop_entry *rfapiEthRouteNode2NextHopList(
-	struct route_node *rn, struct rfapi_ip_prefix *rprefix,
+	struct agg_node *rn, struct rfapi_ip_prefix *rprefix,
 	uint32_t lifetime,		      /* put into nexthop entries */
 	struct rfapi_ip_addr *exclude_vnaddr, /* omit routes to same NVE */
-	struct route_table *rfd_rib_table,    /* preload NVE rib table */
+	struct agg_table *rfd_rib_table,      /* preload NVE rib table */
 	struct prefix *pfx_target_original)   /* query target */
 {
 	int count = 0;
 	struct rfapi_next_hop_entry *answer = NULL;
 	struct rfapi_next_hop_entry *last = NULL;
-	struct route_node *rib_rn;
+	struct agg_node *rib_rn;
 
-	rib_rn = rfd_rib_table ? route_node_get(rfd_rib_table, &rn->p) : NULL;
+	rib_rn = rfd_rib_table ? agg_node_get(rfd_rib_table, &rn->p) : NULL;
 
 	count = rfapiNhlAddNodeRoutes(rn, rprefix, lifetime, 0, &answer, &last,
 				      NULL, rib_rn, pfx_target_original);
@@ -1928,7 +1935,7 @@ struct rfapi_next_hop_entry *rfapiEthRouteNode2NextHopList(
 	}
 
 	if (rib_rn)
-		route_unlock_node(rib_rn);
+		agg_unlock_node(rib_rn);
 
 #if DEBUG_RETURNED_NHL
 	rfapiPrintNhl(NULL, answer);
@@ -1945,13 +1952,13 @@ struct rfapi_next_hop_entry *rfapiEthRouteTable2NextHopList(
 	uint32_t logical_net_id, struct rfapi_ip_prefix *rprefix,
 	uint32_t lifetime,		      /* put into nexthop entries */
 	struct rfapi_ip_addr *exclude_vnaddr, /* omit routes to same NVE */
-	struct route_table *rfd_rib_table,    /* preload NVE rib node */
+	struct agg_table *rfd_rib_table,      /* preload NVE rib node */
 	struct prefix *pfx_target_original)   /* query target */
 {
 	struct rfapi_import_table *it;
 	struct bgp *bgp = bgp_get_default();
-	struct route_table *rt;
-	struct route_node *rn;
+	struct agg_table *rt;
+	struct agg_node *rn;
 	struct rfapi_next_hop_entry *biglist = NULL;
 	struct rfapi_next_hop_entry *nhl;
 	struct rfapi_next_hop_entry *tail = NULL;
@@ -1961,7 +1968,7 @@ struct rfapi_next_hop_entry *rfapiEthRouteTable2NextHopList(
 	it = rfapiMacImportTableGet(bgp, logical_net_id);
 	rt = it->imported_vpn[AFI_L2VPN];
 
-	for (rn = route_top(rt); rn; rn = route_next(rn)) {
+	for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
 
 		nhl = rfapiEthRouteNode2NextHopList(
 			rn, rprefix, lifetime, exclude_vnaddr, rfd_rib_table,
@@ -1989,7 +1996,7 @@ struct rfapi_next_hop_entry *rfapiEthRouteTable2NextHopList(
  * Insert a new bi to the imported route table node,
  * keeping the list of BIs sorted best route first
  */
-static void rfapiBgpInfoAttachSorted(struct route_node *rn,
+static void rfapiBgpInfoAttachSorted(struct agg_node *rn,
 				     struct bgp_info *info_new, afi_t afi,
 				     safi_t safi)
 {
@@ -2031,7 +2038,7 @@ static void rfapiBgpInfoAttachSorted(struct route_node *rn,
 	bgp_attr_intern(info_new->attr);
 }
 
-static void rfapiBgpInfoDetach(struct route_node *rn, struct bgp_info *bi)
+static void rfapiBgpInfoDetach(struct agg_node *rn, struct bgp_info *bi)
 {
 	/*
 	 * Remove the route (doubly-linked)
@@ -2127,8 +2134,8 @@ static int rfapi_bi_peer_rd_aux_cmp(void *b1, void *b2)
 /*
  * Index on RD and Peer
  */
-static void rfapiItBiIndexAdd(struct route_node *rn, /* Import table VPN node */
-			      struct bgp_info *bi)   /* new BI */
+static void rfapiItBiIndexAdd(struct agg_node *rn, /* Import table VPN node */
+			      struct bgp_info *bi) /* new BI */
 {
 	struct skiplist *sl;
 
@@ -2153,15 +2160,15 @@ static void rfapiItBiIndexAdd(struct route_node *rn, /* Import table VPN node */
 			sl = skiplist_new(0, rfapi_bi_peer_rd_cmp, NULL);
 		}
 		RFAPI_IT_EXTRA_GET(rn)->u.vpn.idx_rd = sl;
-		route_lock_node(rn); /* for skiplist */
+		agg_lock_node(rn); /* for skiplist */
 	}
 	assert(!skiplist_insert(sl, (void *)bi, (void *)bi));
-	route_lock_node(rn); /* for skiplist entry */
+	agg_lock_node(rn); /* for skiplist entry */
 
 	/* NB: BIs in import tables are not refcounted */
 }
 
-static void rfapiItBiIndexDump(struct route_node *rn)
+static void rfapiItBiIndexDump(struct agg_node *rn)
 {
 	struct skiplist *sl;
 	void *cursor = NULL;
@@ -2192,7 +2199,7 @@ static void rfapiItBiIndexDump(struct route_node *rn)
 }
 
 static struct bgp_info *rfapiItBiIndexSearch(
-	struct route_node *rn, /* Import table VPN node */
+	struct agg_node *rn, /* Import table VPN node */
 	struct prefix_rd *prd, struct peer *peer,
 	struct prefix *aux_prefix) /* optional L3 addr for L2 ITs */
 {
@@ -2298,8 +2305,8 @@ static struct bgp_info *rfapiItBiIndexSearch(
 	return bi_result;
 }
 
-static void rfapiItBiIndexDel(struct route_node *rn, /* Import table VPN node */
-			      struct bgp_info *bi)   /* old BI */
+static void rfapiItBiIndexDel(struct agg_node *rn, /* Import table VPN node */
+			      struct bgp_info *bi) /* old BI */
 {
 	struct skiplist *sl;
 	int rc;
@@ -2322,7 +2329,7 @@ static void rfapiItBiIndexDel(struct route_node *rn, /* Import table VPN node */
 	}
 	assert(!rc);
 
-	route_unlock_node(rn); /* for skiplist entry */
+	agg_unlock_node(rn); /* for skiplist entry */
 
 	/* NB: BIs in import tables are not refcounted */
 }
@@ -2332,17 +2339,16 @@ static void rfapiItBiIndexDel(struct route_node *rn, /* Import table VPN node */
  * refers to it
  */
 static void rfapiMonitorEncapAdd(struct rfapi_import_table *import_table,
-				 struct prefix *p,	  /* VN address */
-				 struct route_node *vpn_rn, /* VPN node */
-				 struct bgp_info *vpn_bi)   /* VPN bi/route */
+				 struct prefix *p,	/* VN address */
+				 struct agg_node *vpn_rn, /* VPN node */
+				 struct bgp_info *vpn_bi) /* VPN bi/route */
 {
 	afi_t afi = family2afi(p->family);
-	struct route_node *rn;
+	struct agg_node *rn;
 	struct rfapi_monitor_encap *m;
 
 	assert(afi);
-	rn = route_node_get(import_table->imported_encap[afi],
-			    p); /* locks rn */
+	rn = agg_node_get(import_table->imported_encap[afi], p); /* locks rn */
 	assert(rn);
 
 	m = XCALLOC(MTYPE_RFAPI_MONITOR_ENCAP,
@@ -2399,7 +2405,7 @@ static void rfapiMonitorEncapDelete(struct bgp_info *vpn_bi)
 			 * freed */
 			rfapiMonitorExtraPrune(SAFI_ENCAP, hme->rn);
 
-			route_unlock_node(hme->rn); /* decr ref count */
+			agg_unlock_node(hme->rn); /* decr ref count */
 			XFREE(MTYPE_RFAPI_MONITOR_ENCAP, hme);
 			vpn_bi->extra->vnc.import.hme = NULL;
 		}
@@ -2533,7 +2539,7 @@ done:
 	}
 
 	RFAPI_CHECK_REFCOUNT(wcb->node, SAFI_MPLS_VPN, 1 + wcb->lockoffset);
-	route_unlock_node(wcb->node); /* decr ref count */
+	agg_unlock_node(wcb->node); /* decr ref count */
 	XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 	return 0;
 }
@@ -2660,7 +2666,7 @@ static void rfapiCopyUnEncap2VPN(struct bgp_info *encap_bi,
  */
 static int rfapiWithdrawEncapUpdateCachedUn(
 	struct rfapi_import_table *import_table, struct bgp_info *encap_bi,
-	struct route_node *vpn_rn, struct bgp_info *vpn_bi)
+	struct agg_node *vpn_rn, struct bgp_info *vpn_bi)
 {
 	if (!encap_bi) {
 
@@ -2762,7 +2768,7 @@ static int rfapiWithdrawTimerEncap(struct thread *t)
 	/*
 	 * for each VPN node referenced in the ENCAP monitors:
 	 */
-	struct route_node *rn;
+	struct agg_node *rn;
 	while (!skiplist_first(vpn_node_sl, (void **)&rn, NULL)) {
 		if (!wcb->node->info) {
 			struct rfapi_monitor_vpn *moved;
@@ -2783,7 +2789,7 @@ static int rfapiWithdrawTimerEncap(struct thread *t)
 
 done:
 	RFAPI_CHECK_REFCOUNT(wcb->node, SAFI_ENCAP, 1);
-	route_unlock_node(wcb->node); /* decr ref count */
+	agg_unlock_node(wcb->node); /* decr ref count */
 	XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 	skiplist_free(vpn_node_sl);
 	return 0;
@@ -2796,7 +2802,7 @@ done:
  */
 static void
 rfapiBiStartWithdrawTimer(struct rfapi_import_table *import_table,
-			  struct route_node *rn, struct bgp_info *bi, afi_t afi,
+			  struct agg_node *rn, struct bgp_info *bi, afi_t afi,
 			  safi_t safi,
 			  int (*timer_service_func)(struct thread *))
 {
@@ -2886,7 +2892,7 @@ typedef void(rfapi_bi_filtered_import_f)(struct rfapi_import_table *, int,
 
 
 static void rfapiExpireEncapNow(struct rfapi_import_table *it,
-				struct route_node *rn, struct bgp_info *bi)
+				struct agg_node *rn, struct bgp_info *bi)
 {
 	struct rfapi_withdraw *wcb;
 	struct thread t;
@@ -2939,8 +2945,8 @@ static void rfapiBgpInfoFilteredImportEncap(
 	uint8_t sub_type,  /* part of bgp_info */
 	uint32_t *label)   /* part of bgp_info */
 {
-	struct route_table *rt = NULL;
-	struct route_node *rn;
+	struct agg_table *rt = NULL;
+	struct agg_node *rn;
 	struct bgp_info *info_new;
 	struct bgp_info *bi;
 	struct bgp_info *next;
@@ -3034,10 +3040,10 @@ static void rfapiBgpInfoFilteredImportEncap(
 	}
 
 	/*
-	 * route_node_lookup returns a node only if there is at least
+	 * agg_node_lookup returns a node only if there is at least
 	 * one route attached.
 	 */
-	rn = route_node_lookup(rt, p);
+	rn = agg_node_lookup(rt, p);
 
 #if DEBUG_ENCAP_MONITOR
 	vnc_zlog_debug_verbose("%s: initial encap lookup(it=%p) rn=%p",
@@ -3047,7 +3053,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 	if (rn) {
 
 		RFAPI_CHECK_REFCOUNT(rn, SAFI_ENCAP, 1);
-		route_unlock_node(rn); /* undo lock in route_node_lookup */
+		agg_unlock_node(rn); /* undo lock in agg_node_lookup */
 
 
 		/*
@@ -3187,9 +3193,9 @@ static void rfapiBgpInfoFilteredImportEncap(
 
 	if (rn) {
 		if (!replacing)
-			route_lock_node(rn); /* incr ref count for new BI */
+			agg_lock_node(rn); /* incr ref count for new BI */
 	} else {
-		rn = route_node_get(rt, p);
+		rn = agg_node_get(rt, p);
 	}
 
 	vnc_zlog_debug_verbose(
@@ -3254,7 +3260,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 		struct rfapi_monitor_encap *m;
 		struct rfapi_monitor_encap *mnext;
 
-		struct route_node *referenced_vpn_prefix;
+		struct agg_node *referenced_vpn_prefix;
 
 		/*
 		 * Optimized approach: build radix tree on the fly to
@@ -3265,9 +3271,9 @@ static void rfapiBgpInfoFilteredImportEncap(
 		 * struct rfapi_monitor_encap, each of which refers to a
 		 * specific VPN node.
 		 */
-		struct route_table *referenced_vpn_table;
+		struct agg_table *referenced_vpn_table;
 
-		referenced_vpn_table = route_table_init();
+		referenced_vpn_table = agg_table_init();
 		assert(referenced_vpn_table);
 
 /*
@@ -3306,8 +3312,8 @@ static void rfapiBgpInfoFilteredImportEncap(
 			 * per prefix.
 			 */
 
-			referenced_vpn_prefix = route_node_get(
-				referenced_vpn_table, &m->node->p);
+			referenced_vpn_prefix =
+				agg_node_get(referenced_vpn_table, &m->node->p);
 			assert(referenced_vpn_prefix);
 			for (mnext = referenced_vpn_prefix->info; mnext;
 			     mnext = mnext->next) {
@@ -3320,7 +3326,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 				/*
 				 * already have an entry for this VPN node
 				 */
-				route_unlock_node(referenced_vpn_prefix);
+				agg_unlock_node(referenced_vpn_prefix);
 			} else {
 				mnext = XCALLOC(
 					MTYPE_RFAPI_MONITOR_ENCAP,
@@ -3335,16 +3341,18 @@ static void rfapiBgpInfoFilteredImportEncap(
 		/*
 		 * for each VPN node referenced in the ENCAP monitors:
 		 */
-		for (referenced_vpn_prefix = route_top(referenced_vpn_table);
-		     referenced_vpn_prefix; referenced_vpn_prefix = route_next(
-						    referenced_vpn_prefix)) {
+		for (referenced_vpn_prefix =
+			     agg_route_top(referenced_vpn_table);
+		     referenced_vpn_prefix;
+		     referenced_vpn_prefix =
+			     agg_route_next(referenced_vpn_prefix)) {
 
 			while ((m = referenced_vpn_prefix->info)) {
 
-				struct route_node *n;
+				struct agg_node *n;
 
 				rfapiMonitorMoveLonger(m->node);
-				for (n = m->node; n; n = n->parent) {
+				for (n = m->node; n; n = agg_node_parent(n)) {
 					// rfapiDoRouteCallback(import_table, n,
 					// NULL);
 				}
@@ -3352,18 +3360,18 @@ static void rfapiBgpInfoFilteredImportEncap(
 							  NULL);
 
 				referenced_vpn_prefix->info = m->next;
-				route_unlock_node(referenced_vpn_prefix);
+				agg_unlock_node(referenced_vpn_prefix);
 				XFREE(MTYPE_RFAPI_MONITOR_ENCAP, m);
 			}
 		}
-		route_table_finish(referenced_vpn_table);
+		agg_table_finish(referenced_vpn_table);
 	}
 
 	RFAPI_CHECK_REFCOUNT(rn, SAFI_ENCAP, 0);
 }
 
 static void rfapiExpireVpnNow(struct rfapi_import_table *it,
-			      struct route_node *rn, struct bgp_info *bi,
+			      struct agg_node *rn, struct bgp_info *bi,
 			      int lockoffset)
 {
 	struct rfapi_withdraw *wcb;
@@ -3398,9 +3406,9 @@ void rfapiBgpInfoFilteredImportVPN(
 	uint8_t sub_type,  /* part of bgp_info */
 	uint32_t *label)   /* part of bgp_info */
 {
-	struct route_table *rt = NULL;
-	struct route_node *rn;
-	struct route_node *n;
+	struct agg_table *rt = NULL;
+	struct agg_node *rn;
+	struct agg_node *n;
 	struct bgp_info *info_new;
 	struct bgp_info *bi;
 	struct bgp_info *next;
@@ -3408,7 +3416,7 @@ void rfapiBgpInfoFilteredImportVPN(
 	struct prefix vn_prefix;
 	struct prefix un_prefix;
 	int un_prefix_valid = 0;
-	struct route_node *ern;
+	struct agg_node *ern;
 	int replacing = 0;
 	int original_had_routes = 0;
 	struct prefix original_nexthop;
@@ -3494,17 +3502,17 @@ void rfapiBgpInfoFilteredImportVPN(
 	memset(&original_nexthop, 0, sizeof(original_nexthop));
 
 	/*
-	 * route_node_lookup returns a node only if there is at least
+	 * agg_node_lookup returns a node only if there is at least
 	 * one route attached.
 	 */
-	rn = route_node_lookup(rt, p);
+	rn = agg_node_lookup(rt, p);
 
 	vnc_zlog_debug_verbose("%s: rn=%p", __func__, rn);
 
 	if (rn) {
 
 		RFAPI_CHECK_REFCOUNT(rn, SAFI_MPLS_VPN, 1);
-		route_unlock_node(rn); /* undo lock in route_node_lookup */
+		agg_unlock_node(rn); /* undo lock in agg_node_lookup */
 
 		if (rn->info)
 			original_had_routes = 1;
@@ -3667,10 +3675,10 @@ void rfapiBgpInfoFilteredImportVPN(
 	/*
 	 * lookup un address in encap table
 	 */
-	ern = route_node_match(import_table->imported_encap[afi], &vn_prefix);
+	ern = agg_node_match(import_table->imported_encap[afi], &vn_prefix);
 	if (ern) {
 		rfapiCopyUnEncap2VPN(ern->info, info_new);
-		route_unlock_node(ern); /* undo lock in route_note_match */
+		agg_unlock_node(ern); /* undo lock in route_note_match */
 	} else {
 		char buf[PREFIX_STRLEN];
 
@@ -3683,13 +3691,13 @@ void rfapiBgpInfoFilteredImportVPN(
 
 	if (rn) {
 		if (!replacing)
-			route_lock_node(rn);
+			agg_lock_node(rn);
 	} else {
 		/*
 		 * No need to increment reference count, so only "get"
 		 * if the node is not there already
 		 */
-		rn = route_node_get(rt, p);
+		rn = agg_node_get(rt, p);
 	}
 
 	/*
@@ -3856,7 +3864,7 @@ void rfapiBgpInfoFilteredImportVPN(
 	}
 
 	if (!(bgp->rfapi_cfg->flags & BGP_VNC_CONFIG_CALLBACK_DISABLE)) {
-		for (n = rn; n; n = n->parent) {
+		for (n = rn; n; n = agg_node_parent(n)) {
 			// rfapiDoRouteCallback(import_table, n, NULL);
 		}
 		rfapiMonitorItNodeChanged(import_table, rn, NULL);
@@ -4108,9 +4116,9 @@ static void rfapiProcessPeerDownRt(struct peer *peer,
 				   struct rfapi_import_table *import_table,
 				   afi_t afi, safi_t safi)
 {
-	struct route_node *rn;
+	struct agg_node *rn;
 	struct bgp_info *bi;
-	struct route_table *rt;
+	struct agg_table *rt;
 	int (*timer_service_func)(struct thread *);
 
 	assert(afi == AFI_IP || afi == AFI_IP6);
@@ -4131,7 +4139,7 @@ static void rfapiProcessPeerDownRt(struct peer *peer,
 	}
 
 
-	for (rn = route_top(rt); rn; rn = route_next(rn)) {
+	for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
 		for (bi = rn->info; bi; bi = bi->next) {
 			if (bi->peer == peer) {
 
@@ -4274,7 +4282,7 @@ struct rfapi *bgp_rfapi_new(struct bgp *bgp)
 	h = (struct rfapi *)XCALLOC(MTYPE_RFAPI, sizeof(struct rfapi));
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
-		h->un[afi] = route_table_init();
+		h->un[afi] = agg_table_init();
 	}
 
 	/*
@@ -4282,10 +4290,10 @@ struct rfapi *bgp_rfapi_new(struct bgp *bgp)
 	 */
 	h->it_ce = XCALLOC(MTYPE_RFAPI_IMPORTTABLE,
 			   sizeof(struct rfapi_import_table));
-	h->it_ce->imported_vpn[AFI_IP] = route_table_init();
-	h->it_ce->imported_vpn[AFI_IP6] = route_table_init();
-	h->it_ce->imported_encap[AFI_IP] = route_table_init();
-	h->it_ce->imported_encap[AFI_IP6] = route_table_init();
+	h->it_ce->imported_vpn[AFI_IP] = agg_table_init();
+	h->it_ce->imported_vpn[AFI_IP6] = agg_table_init();
+	h->it_ce->imported_encap[AFI_IP] = agg_table_init();
+	h->it_ce->imported_encap[AFI_IP6] = agg_table_init();
 	rfapiBgpTableFilteredImport(bgp, h->it_ce, AFI_IP, SAFI_MPLS_VPN);
 	rfapiBgpTableFilteredImport(bgp, h->it_ce, AFI_IP6, SAFI_MPLS_VPN);
 
@@ -4317,10 +4325,10 @@ void bgp_rfapi_destroy(struct bgp *bgp, struct rfapi *h)
 		h->resolve_nve_nexthop = NULL;
 	}
 
-	route_table_finish(h->it_ce->imported_vpn[AFI_IP]);
-	route_table_finish(h->it_ce->imported_vpn[AFI_IP6]);
-	route_table_finish(h->it_ce->imported_encap[AFI_IP]);
-	route_table_finish(h->it_ce->imported_encap[AFI_IP6]);
+	agg_table_finish(h->it_ce->imported_vpn[AFI_IP]);
+	agg_table_finish(h->it_ce->imported_vpn[AFI_IP6]);
+	agg_table_finish(h->it_ce->imported_encap[AFI_IP]);
+	agg_table_finish(h->it_ce->imported_encap[AFI_IP6]);
 
 	if (h->import_mac) {
 		struct rfapi_import_table *it;
@@ -4346,7 +4354,7 @@ void bgp_rfapi_destroy(struct bgp *bgp, struct rfapi *h)
 		rfp_stop(h->rfp);
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
-		route_table_finish(h->un[afi]);
+		agg_table_finish(h->un[afi]);
 	}
 
 	XFREE(MTYPE_RFAPI_IMPORTTABLE, h->it_ce);
@@ -4394,8 +4402,8 @@ rfapiImportTableRefAdd(struct bgp *bgp, struct ecommunity *rt_import_list,
 		 */
 		for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
 
-			it->imported_vpn[afi] = route_table_init();
-			it->imported_encap[afi] = route_table_init();
+			it->imported_vpn[afi] = agg_table_init();
+			it->imported_encap[afi] = agg_table_init();
 
 			rfapiBgpTableFilteredImport(bgp, it, afi,
 						    SAFI_MPLS_VPN);
@@ -4452,8 +4460,8 @@ static void rfapiDeleteRemotePrefixesIt(
 
 	for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
 
-		struct route_table *rt;
-		struct route_node *rn;
+		struct agg_table *rt;
+		struct agg_node *rn;
 
 		if (p && (family2afi(p->family) != afi)) {
 			continue;
@@ -4466,7 +4474,7 @@ static void rfapiDeleteRemotePrefixesIt(
 		vnc_zlog_debug_verbose("%s: scanning rt for afi=%d", __func__,
 				       afi);
 
-		for (rn = route_top(rt); rn; rn = route_next(rn)) {
+		for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
 			struct bgp_info *bi;
 			struct bgp_info *next;
 

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -40,10 +40,10 @@ struct rfapi_import_table {
 	struct ecommunity *rt_import_list; /* copied from nve grp */
 	int refcount;			   /* nve grps and nves */
 	uint32_t l2_logical_net_id;	/* L2 only: EVPN Eth Seg Id */
-	struct route_table *imported_vpn[AFI_MAX];
+	struct agg_table *imported_vpn[AFI_MAX];
 	struct rfapi_monitor_vpn *vpn0_queries[AFI_MAX];
 	struct rfapi_monitor_eth *eth0_queries;
-	struct route_table *imported_encap[AFI_MAX];
+	struct agg_table *imported_encap[AFI_MAX];
 	struct skiplist *monitor_exterior_orphans;
 	int local_count[AFI_MAX];
 	int remote_count[AFI_MAX];
@@ -80,7 +80,7 @@ extern void rfapiCheckRouteCount(void);
 extern void rfapiPrintBi(void *stream, struct bgp_info *bi);
 
 extern void rfapiShowImportTable(void *stream, const char *label,
-				 struct route_table *rt, int isvpn);
+				 struct agg_table *rt, int isvpn);
 
 extern struct rfapi_import_table *
 rfapiImportTableRefAdd(struct bgp *bgp, struct ecommunity *rt_import_list,
@@ -100,32 +100,31 @@ extern void rfapiImportTableRefDelByIt(struct bgp *bgp,
  * next less-specific node (i.e., this node's parent) at the end.
  */
 extern struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
-	struct route_node *rn, uint32_t lifetime, /* put into nexthop entries */
-	struct rfapi_ip_addr *exclude_vnaddr,     /* omit routes to same NVE */
-	struct route_table *rfd_rib_table,   /* preload this NVE rib table */
-	struct prefix *pfx_target_original); /* query target */
+	struct agg_node *rn, uint32_t lifetime, /* put into nexthop entries */
+	struct rfapi_ip_addr *exclude_vnaddr,   /* omit routes to same NVE */
+	struct agg_table *rfd_rib_table,	/* preload this NVE rib table */
+	struct prefix *pfx_target_original);    /* query target */
 
 extern struct rfapi_next_hop_entry *rfapiRouteTable2NextHopList(
-	struct route_table *rt,
-	uint32_t lifetime,		      /* put into nexthop entries */
-	struct rfapi_ip_addr *exclude_vnaddr, /* omit routes to same NVE */
-	struct route_table *rfd_rib_table,    /* preload this NVE rib table */
-	struct prefix *pfx_target_original);  /* query target */
+	struct agg_table *rt, uint32_t lifetime, /* put into nexthop entries */
+	struct rfapi_ip_addr *exclude_vnaddr,    /* omit routes to same NVE */
+	struct agg_table *rfd_rib_table,     /* preload this NVE rib table */
+	struct prefix *pfx_target_original); /* query target */
 
 extern struct rfapi_next_hop_entry *rfapiEthRouteTable2NextHopList(
 	uint32_t logical_net_id, struct rfapi_ip_prefix *rprefix,
 	uint32_t lifetime,		      /* put into nexthop entries */
 	struct rfapi_ip_addr *exclude_vnaddr, /* omit routes to same NVE */
-	struct route_table *rib_route_table,  /* preload NVE rib node */
+	struct agg_table *rib_route_table,    /* preload NVE rib node */
 	struct prefix *pfx_target_original);  /* query target */
 
 extern int rfapiEcommunitiesIntersect(struct ecommunity *e1,
 				      struct ecommunity *e2);
 
-extern void rfapiCheckRefcount(struct route_node *rn, safi_t safi,
+extern void rfapiCheckRefcount(struct agg_node *rn, safi_t safi,
 			       int lockoffset);
 
-extern int rfapiHasNonRemovedRoutes(struct route_node *rn);
+extern int rfapiHasNonRemovedRoutes(struct agg_node *rn);
 
 extern int rfapiProcessDeferredClose(struct thread *t);
 
@@ -153,10 +152,10 @@ extern void rfapiBgpInfoFilteredImportVPN(
 	uint32_t *label);  /* part of bgp_info */
 
 extern struct rfapi_next_hop_entry *rfapiEthRouteNode2NextHopList(
-	struct route_node *rn, struct rfapi_ip_prefix *rprefix,
+	struct agg_node *rn, struct rfapi_ip_prefix *rprefix,
 	uint32_t lifetime,		      /* put into nexthop entries */
 	struct rfapi_ip_addr *exclude_vnaddr, /* omit routes to same NVE */
-	struct route_table *rib_route_table,  /* preload NVE rib table */
+	struct agg_table *rib_route_table,    /* preload NVE rib table */
 	struct prefix *pfx_target_original);  /* query target */
 
 extern struct rfapi_import_table *rfapiMacImportTableGetNoAlloc(struct bgp *bgp,

--- a/bgpd/rfapi/rfapi_monitor.h
+++ b/bgpd/rfapi/rfapi_monitor.h
@@ -30,10 +30,10 @@
  * to indicate which nves are interested in a prefix/target
  */
 struct rfapi_monitor_vpn {
-	struct rfapi_monitor_vpn *next; /* chain from struct route_node */
+	struct rfapi_monitor_vpn *next; /* chain from struct agg_node */
 	struct rfapi_descriptor *rfd;   /* which NVE requested the route */
 	struct prefix p;		/* constant: pfx in original request */
-	struct route_node *node;	/* node we're currently attached to */
+	struct agg_node *node;		/* node we're currently attached to */
 	uint32_t flags;
 #define RFAPI_MON_FLAG_NEEDCALLBACK	0x00000001      /* deferred callback */
 
@@ -44,9 +44,9 @@ struct rfapi_monitor_vpn {
 struct rfapi_monitor_encap {
 	struct rfapi_monitor_encap *next;
 	struct rfapi_monitor_encap *prev;
-	struct route_node *node; /* VPN node */
+	struct agg_node *node;   /* VPN node */
 	struct bgp_info *bi;     /* VPN bi */
-	struct route_node *rn;   /* parent node */
+	struct agg_node *rn;     /* parent node */
 };
 
 struct rfapi_monitor_eth {
@@ -98,7 +98,7 @@ struct rfapi_it_extra {
 	((struct rfapi_it_extra                                                \
 		  *)((rn)->aggregate                                           \
 			     ? (rn)->aggregate                                 \
-			     : (route_lock_node(rn),                           \
+			     : (agg_lock_node(rn),                             \
 				(rn)->aggregate = XCALLOC(                     \
 					MTYPE_RFAPI_IT_EXTRA,                  \
 					sizeof(struct rfapi_it_extra)))))
@@ -138,16 +138,16 @@ extern void rfapiMonitorCleanCheck(struct bgp *bgp);
 
 extern void rfapiMonitorCheckAttachAllowed(void);
 
-extern void rfapiMonitorExtraFlush(safi_t safi, struct route_node *rn);
+extern void rfapiMonitorExtraFlush(safi_t safi, struct agg_node *rn);
 
-extern struct route_node *
-rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd, struct prefix *p);
+extern struct agg_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
+						  struct prefix *p);
 
 extern void rfapiMonitorAttachImportHd(struct rfapi_descriptor *rfd);
 
-extern struct route_node *rfapiMonitorAdd(struct bgp *bgp,
-					  struct rfapi_descriptor *rfd,
-					  struct prefix *p);
+extern struct agg_node *rfapiMonitorAdd(struct bgp *bgp,
+					struct rfapi_descriptor *rfd,
+					struct prefix *p);
 
 extern void rfapiMonitorDetachImportHd(struct rfapi_descriptor *rfd);
 
@@ -164,24 +164,24 @@ extern void rfapiMonitorResponseRemovalOff(struct bgp *bgp);
 
 extern void rfapiMonitorResponseRemovalOn(struct bgp *bgp);
 
-extern void rfapiMonitorExtraPrune(safi_t safi, struct route_node *rn);
+extern void rfapiMonitorExtraPrune(safi_t safi, struct agg_node *rn);
 
 extern void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd,
 				      struct prefix *p);
 
 extern void rfapiMonitorItNodeChanged(struct rfapi_import_table *import_table,
-				      struct route_node *it_node,
+				      struct agg_node *it_node,
 				      struct rfapi_monitor_vpn *monitor_list);
 
 extern void rfapiMonitorMovedUp(struct rfapi_import_table *import_table,
-				struct route_node *old_node,
-				struct route_node *new_node,
+				struct agg_node *old_node,
+				struct agg_node *new_node,
 				struct rfapi_monitor_vpn *monitor_list);
 
-extern struct route_node *rfapiMonitorEthAdd(struct bgp *bgp,
-					     struct rfapi_descriptor *rfd,
-					     struct ethaddr *macaddr,
-					     uint32_t logical_net_id);
+extern struct agg_node *rfapiMonitorEthAdd(struct bgp *bgp,
+					   struct rfapi_descriptor *rfd,
+					   struct ethaddr *macaddr,
+					   uint32_t logical_net_id);
 
 extern void rfapiMonitorEthDel(struct bgp *bgp, struct rfapi_descriptor *rfd,
 			       struct ethaddr *macaddr,

--- a/bgpd/rfapi/rfapi_nve_addr.c
+++ b/bgpd/rfapi/rfapi_nve_addr.c
@@ -21,7 +21,7 @@
 
 #include "lib/zebra.h"
 #include "lib/prefix.h"
-#include "lib/table.h"
+#include "lib/agg_table.h"
 #include "lib/vty.h"
 #include "lib/memory.h"
 #include "lib/skiplist.h"

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -47,7 +47,7 @@ struct rfapi_advertised_prefixes {
 };
 
 struct rfapi_descriptor {
-	struct route_node *un_node; /* backref to un table */
+	struct agg_node *un_node; /* backref to un table */
 
 	struct rfapi_descriptor *next; /* next vn_addr */
 
@@ -76,7 +76,7 @@ struct rfapi_descriptor {
 	struct rfapi_import_table *import_table;
 
 	uint32_t monitor_count;
-	struct route_table *mon;  /* rfapi_monitors */
+	struct agg_table *mon;    /* rfapi_monitors */
 	struct skiplist *mon_eth; /* ethernet monitors */
 
 	/*
@@ -85,10 +85,10 @@ struct rfapi_descriptor {
 	 * rsp_times      last time we sent response containing pfx
 	 */
 	uint32_t rib_prefix_count; /* pfxes with routes */
-	struct route_table *rib[AFI_MAX];
-	struct route_table *rib_pending[AFI_MAX];
+	struct agg_table *rib[AFI_MAX];
+	struct agg_table *rib_pending[AFI_MAX];
 	struct work_queue *updated_responses_queue;
-	struct route_table *rsp_times[AFI_MAX];
+	struct agg_table *rsp_times[AFI_MAX];
 
 	uint32_t rsp_counter;	 /* dedup initial rsp */
 	time_t rsp_time;	      /* dedup initial rsp */
@@ -171,7 +171,7 @@ struct rfapi_global_stats {
  * check vn address to get exact match.
  */
 struct rfapi {
-	struct route_table *un[AFI_MAX];
+	struct agg_table *un[AFI_MAX];
 	struct rfapi_import_table *imports; /* IPv4, IPv6 */
 	struct list descriptors;	    /* debug & resolve-nve imports */
 
@@ -198,8 +198,8 @@ struct rfapi {
 	 * bgp unicast or zebra, we need to keep track of information
 	 * related to expiring the routes according to the VNC lifetime
 	 */
-	struct route_table *rt_export_bgp[AFI_MAX];
-	struct route_table *rt_export_zebra[AFI_MAX];
+	struct agg_table *rt_export_bgp[AFI_MAX];
+	struct agg_table *rt_export_zebra[AFI_MAX];
 
 	/*
 	 * For VNC->BGP unicast exports in CE mode, we need a

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -27,7 +27,7 @@
 
 #include "lib/zebra.h"
 #include "lib/prefix.h"
-#include "lib/table.h"
+#include "lib/agg_table.h"
 #include "lib/vty.h"
 #include "lib/memory.h"
 #include "lib/log.h"
@@ -150,10 +150,10 @@ void rfapiRibCheckCounts(
 
 		for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
 
-			struct route_node *rn;
+			struct agg_node *rn;
 
-			for (rn = route_top(rfd->rib[afi]); rn;
-			     rn = route_next(rn)) {
+			for (rn = agg_route_top(rfd->rib[afi]); rn;
+			     rn = agg_route_next(rn)) {
 
 				struct skiplist *sl = rn->info;
 				struct skiplist *dsl = rn->aggregate;
@@ -175,8 +175,8 @@ void rfapiRibCheckCounts(
 					++t_pfx_deleted;
 				}
 			}
-			for (rn = route_top(rfd->rib_pending[afi]); rn;
-			     rn = route_next(rn)) {
+			for (rn = agg_route_top(rfd->rib_pending[afi]); rn;
+			     rn = agg_route_next(rn)) {
 
 				struct list *l = rn->info; /* sorted by cost */
 				struct skiplist *sl = rn->aggregate;
@@ -286,7 +286,7 @@ struct rfapi_rib_tcb {
 	struct rfapi_descriptor *rfd;
 	struct skiplist *sl;
 	struct rfapi_info *ri;
-	struct route_node *rn;
+	struct agg_node *rn;
 	int flags;
 #define RFAPI_RIB_TCB_FLAG_DELETED	0x00000001
 };
@@ -325,7 +325,7 @@ static int rfapiRibExpireTimer(struct thread *t)
 			RFAPI_RIB_PREFIX_COUNT_DECR(tcb->rfd, bgp->rfapi);
 		}
 		skiplist_free(tcb->sl);
-		route_unlock_node(tcb->rn);
+		agg_unlock_node(tcb->rn);
 	}
 
 	XFREE(MTYPE_RFAPI_RECENT_DELETE, tcb);
@@ -335,10 +335,10 @@ static int rfapiRibExpireTimer(struct thread *t)
 	return 0;
 }
 
-static void
-rfapiRibStartTimer(struct rfapi_descriptor *rfd, struct rfapi_info *ri,
-		   struct route_node *rn, /* route node attached to */
-		   int deleted)
+static void rfapiRibStartTimer(struct rfapi_descriptor *rfd,
+			       struct rfapi_info *ri,
+			       struct agg_node *rn, /* route node attached to */
+			       int deleted)
 {
 	struct thread *t = ri->timer;
 	struct rfapi_rib_tcb *tcb = NULL;
@@ -486,12 +486,12 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 #endif
 
 	for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
-		struct route_node *pn;
-		struct route_node *rn;
+		struct agg_node *pn;
+		struct agg_node *rn;
 
 		if (rfd->rib_pending[afi]) {
-			for (pn = route_top(rfd->rib_pending[afi]); pn;
-			     pn = route_next(pn)) {
+			for (pn = agg_route_top(rfd->rib_pending[afi]); pn;
+			     pn = agg_route_next(pn)) {
 				if (pn->aggregate) {
 					/*
 					 * free references into the rfapi_info
@@ -502,7 +502,7 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 						(struct skiplist
 							 *)(pn->aggregate));
 					pn->aggregate = NULL;
-					route_unlock_node(
+					agg_unlock_node(
 						pn); /* skiplist deleted */
 				}
 				/*
@@ -516,13 +516,13 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 					}
 					pn->info = NULL;
 					/* linklist or 1 deleted */
-					route_unlock_node(pn);
+					agg_unlock_node(pn);
 				}
 			}
 		}
 		if (rfd->rib[afi]) {
-			for (rn = route_top(rfd->rib[afi]); rn;
-			     rn = route_next(rn)) {
+			for (rn = agg_route_top(rfd->rib[afi]); rn;
+			     rn = agg_route_next(rn)) {
 				if (rn->info) {
 
 					struct rfapi_info *ri;
@@ -541,7 +541,7 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 					skiplist_free(
 						(struct skiplist *)rn->info);
 					rn->info = NULL;
-					route_unlock_node(rn);
+					agg_unlock_node(rn);
 					RFAPI_RIB_PREFIX_COUNT_DECR(rfd,
 								    bgp->rfapi);
 				}
@@ -566,7 +566,7 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 							 *)(rn->aggregate));
 
 					rn->aggregate = NULL;
-					route_unlock_node(rn);
+					agg_unlock_node(rn);
 				}
 			}
 		}
@@ -601,15 +601,18 @@ void rfapiRibFree(struct rfapi_descriptor *rfd)
 	 * Free radix trees
 	 */
 	for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
-		route_table_finish(rfd->rib_pending[afi]);
+		if (rfd->rib_pending[afi])
+			agg_table_finish(rfd->rib_pending[afi]);
 		rfd->rib_pending[afi] = NULL;
 
-		route_table_finish(rfd->rib[afi]);
+		if (rfd->rib[afi])
+			agg_table_finish(rfd->rib[afi]);
 		rfd->rib[afi] = NULL;
 
-		/* NB route_table_finish frees only prefix nodes, not chained
+		/* NB agg_table_finish frees only prefix nodes, not chained
 		 * info */
-		route_table_finish(rfd->rsp_times[afi]);
+		if (rfd->rsp_times[afi])
+			agg_table_finish(rfd->rsp_times[afi]);
 		rfd->rib[afi] = NULL;
 	}
 }
@@ -730,7 +733,7 @@ static void rfapiRibBi2Ri(struct bgp_info *bi, struct rfapi_info *ri,
  *	!0	do not include route in response
  */
 int rfapiRibPreloadBi(
-	struct route_node *rfd_rib_node, /* NULL = don't preload or filter */
+	struct agg_node *rfd_rib_node, /* NULL = don't preload or filter */
 	struct prefix *pfx_vn, struct prefix *pfx_un, uint32_t lifetime,
 	struct bgp_info *bi)
 {
@@ -738,7 +741,7 @@ int rfapiRibPreloadBi(
 	struct skiplist *slRibPt = NULL;
 	struct rfapi_info *ori = NULL;
 	struct rfapi_rib_key rk;
-	struct route_node *trn;
+	struct agg_node *trn;
 	afi_t afi;
 
 	if (!rfd_rib_node)
@@ -746,7 +749,7 @@ int rfapiRibPreloadBi(
 
 	afi = family2afi(rfd_rib_node->p.family);
 
-	rfd = (struct rfapi_descriptor *)(rfd_rib_node->table->info);
+	rfd = agg_get_table_info(agg_get_table(rfd_rib_node));
 
 	memset((void *)&rk, 0, sizeof(rk));
 	rk.vn = *pfx_vn;
@@ -784,7 +787,7 @@ int rfapiRibPreloadBi(
 		if (!slRibPt) {
 			slRibPt = skiplist_new(0, rfapi_rib_key_cmp, NULL);
 			rfd_rib_node->info = slRibPt;
-			route_lock_node(rfd_rib_node);
+			agg_lock_node(rfd_rib_node);
 			RFAPI_RIB_PREFIX_COUNT_INCR(rfd, rfd->bgp->rfapi);
 		}
 		skiplist_insert(slRibPt, &ori->rk, ori);
@@ -802,11 +805,11 @@ int rfapiRibPreloadBi(
 	/*
 	 * Update last sent time for prefix
 	 */
-	trn = route_node_get(rfd->rsp_times[afi],
-			     &rfd_rib_node->p); /* locks trn */
+	trn = agg_node_get(rfd->rsp_times[afi],
+			   &rfd_rib_node->p); /* locks trn */
 	trn->info = (void *)(uintptr_t)bgp_clock();
 	if (trn->lock > 1)
-		route_unlock_node(trn);
+		agg_unlock_node(trn);
 
 	return 0;
 }
@@ -837,7 +840,7 @@ int rfapiRibPreloadBi(
  */
 static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 				 afi_t afi,
-				 struct route_node *pn, /* pending node */
+				 struct agg_node *pn, /* pending node */
 				 struct rfapi_next_hop_entry **head,
 				 struct rfapi_next_hop_entry **tail)
 {
@@ -845,7 +848,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 	struct listnode *nnode = NULL;
 	struct rfapi_info *ri = NULL;    /* happy valgrind */
 	struct rfapi_ip_prefix hp = {0}; /* pfx to put in NHE */
-	struct route_node *rn = NULL;
+	struct agg_node *rn = NULL;
 	struct skiplist *slRibPt = NULL; /* rib list */
 	struct skiplist *slPendPt = NULL;
 	struct list *lPendCost = NULL;
@@ -875,7 +878,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 	/*
 	 * Find corresponding RIB node
 	 */
-	rn = route_node_get(rfd->rib[afi], &pn->p); /* locks rn */
+	rn = agg_node_get(rfd->rib[afi], &pn->p); /* locks rn */
 
 	/*
 	 * RIB skiplist has key=rfapi_addr={vn,un}, val = rfapi_info,
@@ -945,30 +948,30 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 
 			skiplist_free(slRibPt);
 			rn->info = slRibPt = NULL;
-			route_unlock_node(rn);
+			agg_unlock_node(rn);
 
 			lPendCost = pn->info = NULL;
-			route_unlock_node(pn);
+			agg_unlock_node(pn);
 
 			goto callback;
 		}
 		if (slRibPt) {
 			skiplist_free(slRibPt);
 			rn->info = NULL;
-			route_unlock_node(rn);
+			agg_unlock_node(rn);
 		}
 
 		assert(!slPendPt);
 		if (slPendPt) { /* TBD I think we can toss this block */
 			skiplist_free(slPendPt);
 			pn->aggregate = NULL;
-			route_unlock_node(pn);
+			agg_unlock_node(pn);
 		}
 
 		pn->info = NULL;
-		route_unlock_node(pn);
+		agg_unlock_node(pn);
 
-		route_unlock_node(rn); /* route_node_get() */
+		agg_unlock_node(rn); /* agg_node_get() */
 
 		if (rib_node_started_nonempty) {
 			RFAPI_RIB_PREFIX_COUNT_DECR(rfd, bgp->rfapi);
@@ -1076,7 +1079,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 			if (skiplist_empty(slRibPt)) {
 				skiplist_free(slRibPt);
 				slRibPt = rn->info = NULL;
-				route_unlock_node(rn);
+				agg_unlock_node(rn);
 			}
 		}
 	}
@@ -1142,7 +1145,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 					slRibPt = skiplist_new(
 						0, rfapi_rib_key_cmp, NULL);
 					rn->info = slRibPt;
-					route_lock_node(rn);
+					agg_lock_node(rn);
 				}
 				skiplist_insert(slRibPt, &ori->rk, ori);
 
@@ -1192,7 +1195,7 @@ callback:
 		for (ALL_LIST_ELEMENTS(lPendCost, node, nnode, ri)) {
 
 			struct rfapi_next_hop_entry *new;
-			struct route_node *trn;
+			struct agg_node *trn;
 
 			new = XCALLOC(MTYPE_RFAPI_NEXTHOP,
 				      sizeof(struct rfapi_next_hop_entry));
@@ -1244,11 +1247,11 @@ callback:
 			/*
 			 * update this NVE's timestamp for this prefix
 			 */
-			trn = route_node_get(rfd->rsp_times[afi],
-					     &pn->p); /* locks trn */
+			trn = agg_node_get(rfd->rsp_times[afi],
+					   &pn->p); /* locks trn */
 			trn->info = (void *)(uintptr_t)bgp_clock();
 			if (trn->lock > 1)
-				route_unlock_node(trn);
+				agg_unlock_node(trn);
 
 			rfapiRfapiIpAddr2Str(&new->vn_address, buf, BUFSIZ);
 			rfapiRfapiIpAddr2Str(&new->un_address, buf2, BUFSIZ);
@@ -1347,7 +1350,7 @@ callback:
 						0, rfapi_rib_key_cmp,
 						(void (*)(void *))
 							rfapi_info_free);
-					route_lock_node(rn);
+					agg_lock_node(rn);
 				}
 				RFAPI_RIB_CHECK_COUNTS(0, delete_list->count);
 
@@ -1438,18 +1441,18 @@ callback:
 	RFAPI_RIB_CHECK_COUNTS(0, 0);
 
 	/*
-	 * Reset pending lists. The final route_unlock_node() will probably
+	 * Reset pending lists. The final agg_unlock_node() will probably
 	 * cause the pending node to be released.
 	 */
 	if (slPendPt) {
 		skiplist_free(slPendPt);
 		pn->aggregate = NULL;
-		route_unlock_node(pn);
+		agg_unlock_node(pn);
 	}
 	if (lPendCost) {
 		list_delete_and_null(&lPendCost);
 		pn->info = NULL;
-		route_unlock_node(pn);
+		agg_unlock_node(pn);
 	}
 	RFAPI_RIB_CHECK_COUNTS(0, 0);
 
@@ -1466,7 +1469,7 @@ callback:
 	if (sendingsomeroutes)
 		rfapiMonitorTimersRestart(rfd, &pn->p);
 
-	route_unlock_node(rn); /* route_node_get() */
+	agg_unlock_node(rn); /* agg_node_get() */
 
 	RFAPI_RIB_CHECK_COUNTS(1, 0);
 }
@@ -1484,7 +1487,7 @@ static void rib_do_callback_onepass(struct rfapi_descriptor *rfd, afi_t afi)
 	struct bgp *bgp = bgp_get_default();
 	struct rfapi_next_hop_entry *head = NULL;
 	struct rfapi_next_hop_entry *tail = NULL;
-	struct route_node *rn;
+	struct agg_node *rn;
 
 #if DEBUG_L2_EXTRA
 	vnc_zlog_debug_verbose("%s: rfd=%p, afi=%d", __func__, rfd, afi);
@@ -1495,7 +1498,8 @@ static void rib_do_callback_onepass(struct rfapi_descriptor *rfd, afi_t afi)
 
 	assert(bgp->rfapi);
 
-	for (rn = route_top(rfd->rib_pending[afi]); rn; rn = route_next(rn)) {
+	for (rn = agg_route_top(rfd->rib_pending[afi]); rn;
+	     rn = agg_route_next(rn)) {
 		process_pending_node(bgp, rfd, afi, rn, &head, &tail);
 	}
 
@@ -1585,11 +1589,11 @@ static void updated_responses_queue_init(struct rfapi_descriptor *rfd)
 void rfapiRibUpdatePendingNode(
 	struct bgp *bgp, struct rfapi_descriptor *rfd,
 	struct rfapi_import_table *it, /* needed for L2 */
-	struct route_node *it_node, uint32_t lifetime)
+	struct agg_node *it_node, uint32_t lifetime)
 {
 	struct prefix *prefix;
 	struct bgp_info *bi;
-	struct route_node *pn;
+	struct agg_node *pn;
 	afi_t afi;
 	uint32_t queued_flag;
 	int count = 0;
@@ -1609,7 +1613,7 @@ void rfapiRibUpdatePendingNode(
 	prefix2str(prefix, buf, sizeof(buf));
 	vnc_zlog_debug_verbose("%s: prefix=%s", __func__, buf);
 
-	pn = route_node_get(rfd->rib_pending[afi], prefix);
+	pn = agg_node_get(rfd->rib_pending[afi], prefix);
 	assert(pn);
 
 	vnc_zlog_debug_verbose("%s: pn->info=%p, pn->aggregate=%p", __func__,
@@ -1622,7 +1626,7 @@ void rfapiRibUpdatePendingNode(
 		 */
 		skiplist_free((struct skiplist *)(pn->aggregate));
 		pn->aggregate = NULL;
-		route_unlock_node(pn); /* skiplist deleted */
+		agg_unlock_node(pn); /* skiplist deleted */
 	}
 
 
@@ -1634,7 +1638,7 @@ void rfapiRibUpdatePendingNode(
 			list_delete_and_null((struct list **)(&pn->info));
 		}
 		pn->info = NULL;
-		route_unlock_node(pn); /* linklist or 1 deleted */
+		agg_unlock_node(pn); /* linklist or 1 deleted */
 	}
 
 	/*
@@ -1689,7 +1693,7 @@ void rfapiRibUpdatePendingNode(
 		if (!pn->aggregate) {
 			pn->aggregate =
 				skiplist_new(0, rfapi_rib_key_cmp, NULL);
-			route_lock_node(pn);
+			agg_lock_node(pn);
 		}
 
 		/*
@@ -1715,7 +1719,7 @@ void rfapiRibUpdatePendingNode(
 			pn->info = list_new();
 			((struct list *)(pn->info))->del =
 				(void (*)(void *))rfapi_info_free;
-			route_lock_node(pn);
+			agg_lock_node(pn);
 		}
 
 		listnode_add((struct list *)(pn->info), ri);
@@ -1730,10 +1734,10 @@ void rfapiRibUpdatePendingNode(
 		assert(!pn->aggregate);
 		pn->info = (void *)1; /* magic value means this node has no
 					 routes */
-		route_lock_node(pn);
+		agg_lock_node(pn);
 	}
 
-	route_unlock_node(pn); /* route_node_get */
+	agg_unlock_node(pn); /* agg_node_get */
 
 	queued_flag = RFAPI_QUEUED_FLAG(afi);
 
@@ -1757,25 +1761,30 @@ void rfapiRibUpdatePendingNode(
 
 void rfapiRibUpdatePendingNodeSubtree(
 	struct bgp *bgp, struct rfapi_descriptor *rfd,
-	struct rfapi_import_table *it, struct route_node *it_node,
-	struct route_node *omit_subtree, /* may be NULL */
+	struct rfapi_import_table *it, struct agg_node *it_node,
+	struct agg_node *omit_subtree, /* may be NULL */
 	uint32_t lifetime)
 {
 	/* FIXME: need to find a better way here to work without sticking our
 	 * hands in node->link */
-	if (it_node->l_left && (it_node->l_left != omit_subtree)) {
-		if (it_node->l_left->info)
-			rfapiRibUpdatePendingNode(bgp, rfd, it, it_node->l_left,
-						  lifetime);
-		rfapiRibUpdatePendingNodeSubtree(bgp, rfd, it, it_node->l_left,
+	if (agg_node_left(it_node)
+	    && (agg_node_left(it_node) != omit_subtree)) {
+		if (agg_node_left(it_node)->info)
+			rfapiRibUpdatePendingNode(
+				bgp, rfd, it, agg_node_left(it_node), lifetime);
+		rfapiRibUpdatePendingNodeSubtree(bgp, rfd, it,
+						 agg_node_left(it_node),
 						 omit_subtree, lifetime);
 	}
 
-	if (it_node->l_right && (it_node->l_right != omit_subtree)) {
-		if (it_node->l_right->info)
+	if (agg_node_right(it_node)
+	    && (agg_node_right(it_node) != omit_subtree)) {
+		if (agg_node_right(it_node)->info)
 			rfapiRibUpdatePendingNode(bgp, rfd, it,
-						  it_node->l_right, lifetime);
-		rfapiRibUpdatePendingNodeSubtree(bgp, rfd, it, it_node->l_right,
+						  agg_node_right(it_node),
+						  lifetime);
+		rfapiRibUpdatePendingNodeSubtree(bgp, rfd, it,
+						 agg_node_right(it_node),
 						 omit_subtree, lifetime);
 	}
 }
@@ -1788,13 +1797,13 @@ void rfapiRibUpdatePendingNodeSubtree(
  */
 int rfapiRibFTDFilterRecentPrefix(
 	struct rfapi_descriptor *rfd,
-	struct route_node *it_rn,	   /* import table node */
+	struct agg_node *it_rn,		    /* import table node */
 	struct prefix *pfx_target_original) /* query target */
 {
 	struct bgp *bgp = rfd->bgp;
 	afi_t afi = family2afi(it_rn->p.family);
 	time_t prefix_time;
-	struct route_node *trn;
+	struct agg_node *trn;
 
 	/*
 	 * Not in FTD mode, so allow prefix
@@ -1833,10 +1842,10 @@ int rfapiRibFTDFilterRecentPrefix(
 	/*
 	 * check this NVE's timestamp for this prefix
 	 */
-	trn = route_node_get(rfd->rsp_times[afi], &it_rn->p); /* locks trn */
+	trn = agg_node_get(rfd->rsp_times[afi], &it_rn->p); /* locks trn */
 	prefix_time = (time_t)trn->info;
 	if (trn->lock > 1)
-		route_unlock_node(trn);
+		agg_unlock_node(trn);
 
 #if DEBUG_FTD_FILTER_RECENT
 	vnc_zlog_debug_verbose("%s: last sent time %lu, last allowed time %lu",
@@ -1883,9 +1892,9 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		afi_t afi;
 		struct rfapi_info *ri;
 		int need_insert;
-		struct route_node *rn;
+		struct agg_node *rn;
 		int rib_node_started_nonempty = 0;
-		struct route_node *trn;
+		struct agg_node *trn;
 		int allowed = 0;
 
 		/* save in case we delete nhp */
@@ -1947,13 +1956,13 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		/*
 		 * Look up prefix in RIB
 		 */
-		rn = route_node_get(rfd->rib[afi], &pfx); /* locks rn */
+		rn = agg_node_get(rfd->rib[afi], &pfx); /* locks rn */
 
 		if (rn->info) {
 			rib_node_started_nonempty = 1;
 		} else {
 			rn->info = skiplist_new(0, rfapi_rib_key_cmp, NULL);
-			route_lock_node(rn);
+			agg_lock_node(rn);
 		}
 
 		/*
@@ -2063,15 +2072,15 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		rfapiRibStartTimer(rfd, ri, rn, 0);
 		RFAPI_RIB_CHECK_COUNTS(0, 0);
 
-		route_unlock_node(rn);
+		agg_unlock_node(rn);
 
 		/*
 		 * update this NVE's timestamp for this prefix
 		 */
-		trn = route_node_get(rfd->rsp_times[afi], &pfx); /* locks trn */
+		trn = agg_node_get(rfd->rsp_times[afi], &pfx); /* locks trn */
 		trn->info = (void *)(uintptr_t)bgp_clock();
 		if (trn->lock > 1)
-			route_unlock_node(trn);
+			agg_unlock_node(trn);
 
 		{
 			char str_pfx[PREFIX_STRLEN];
@@ -2108,7 +2117,7 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 }
 
 void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
-				afi_t afi, struct route_node *it_node)
+				afi_t afi, struct agg_node *it_node)
 {
 	struct rfapi_descriptor *rfd;
 	struct listnode *node;
@@ -2124,7 +2133,7 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 		 * identifies the rfd that owns it.
 		 */
 		struct rfapi_monitor_eth *m;
-		struct route_node *rn;
+		struct agg_node *rn;
 		struct skiplist *sl;
 		void *cursor;
 		int rc;
@@ -2154,12 +2163,12 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 				 * NVE, it's OK to send an update with the
 				 * delete
 				 */
-				if ((rn = route_node_lookup(m->rfd->rib[afi],
-							    &it_node->p))) {
+				if ((rn = agg_node_lookup(m->rfd->rib[afi],
+							  &it_node->p))) {
 					rfapiRibUpdatePendingNode(
 						bgp, m->rfd, it, it_node,
 						m->rfd->response_lifetime);
-					route_unlock_node(rn);
+					agg_unlock_node(rn);
 				}
 			}
 		}
@@ -2177,8 +2186,8 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 			 * this
 			 * NVE, it's OK to send an update with the delete
 			 */
-			if ((rn = route_node_lookup(m->rfd->rib[afi],
-						    &it_node->p))) {
+			if ((rn = agg_node_lookup(m->rfd->rib[afi],
+						  &it_node->p))) {
 				rfapiRibUpdatePendingNode(
 					bgp, m->rfd, it, it_node,
 					m->rfd->response_lifetime);
@@ -2192,7 +2201,7 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 		for (ALL_LIST_ELEMENTS_RO(&bgp->rfapi->descriptors, node,
 					  rfd)) {
 
-			struct route_node *rn;
+			struct agg_node *rn;
 
 			vnc_zlog_debug_verbose(
 				"%s: comparing rfd(%p)->import_table=%p to it=%p",
@@ -2209,12 +2218,12 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 			 * prefix
 			 * previously, we should send an updated response.
 			 */
-			if ((rn = route_node_lookup(rfd->rib[afi],
-						    &it_node->p))) {
+			if ((rn = agg_node_lookup(rfd->rib[afi],
+						  &it_node->p))) {
 				rfapiRibUpdatePendingNode(
 					bgp, rfd, it, it_node,
 					rfd->response_lifetime);
-				route_unlock_node(rn);
+				agg_unlock_node(rn);
 			}
 		}
 	}
@@ -2406,13 +2415,13 @@ void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 
 		for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
 
-			struct route_node *rn;
+			struct agg_node *rn;
 
 			if (!rfd->rib[afi])
 				continue;
 
-			for (rn = route_top(rfd->rib[afi]); rn;
-			     rn = route_next(rn)) {
+			for (rn = agg_route_top(rfd->rib[afi]); rn;
+			     rn = agg_route_next(rn)) {
 
 				struct skiplist *sl;
 				char str_pfx[PREFIX_STRLEN];

--- a/bgpd/rfapi/rfapi_rib.h
+++ b/bgpd/rfapi/rfapi_rib.h
@@ -93,17 +93,17 @@ extern void rfapiRibFree(struct rfapi_descriptor *rfd);
 extern void rfapiRibUpdatePendingNode(struct bgp *bgp,
 				      struct rfapi_descriptor *rfd,
 				      struct rfapi_import_table *it,
-				      struct route_node *it_node,
+				      struct agg_node *it_node,
 				      uint32_t lifetime);
 
 extern void rfapiRibUpdatePendingNodeSubtree(struct bgp *bgp,
 					     struct rfapi_descriptor *rfd,
 					     struct rfapi_import_table *it,
-					     struct route_node *it_node,
-					     struct route_node *omit_subtree,
+					     struct agg_node *it_node,
+					     struct agg_node *omit_subtree,
 					     uint32_t lifetime);
 
-extern int rfapiRibPreloadBi(struct route_node *rfd_rib_node,
+extern int rfapiRibPreloadBi(struct agg_node *rfd_rib_node,
 			     struct prefix *pfx_vn, struct prefix *pfx_un,
 			     uint32_t lifetime, struct bgp_info *bi);
 
@@ -113,7 +113,7 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 
 extern void rfapiRibPendingDeleteRoute(struct bgp *bgp,
 				       struct rfapi_import_table *it, afi_t afi,
-				       struct route_node *it_node);
+				       struct agg_node *it_node);
 
 extern void rfapiRibShowResponsesSummary(void *stream);
 
@@ -124,7 +124,7 @@ extern void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 
 extern int rfapiRibFTDFilterRecentPrefix(
 	struct rfapi_descriptor *rfd,
-	struct route_node *it_rn,	    /* import table node */
+	struct agg_node *it_rn,		     /* import table node */
 	struct prefix *pfx_target_original); /* query target */
 
 extern void rfapiFreeRfapiUnOptionChain(struct rfapi_un_option *p);

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -23,7 +23,7 @@
 
 #include "lib/zebra.h"
 #include "lib/prefix.h"
-#include "lib/table.h"
+#include "lib/agg_table.h"
 #include "lib/vty.h"
 #include "lib/memory.h"
 #include "lib/routemap.h"
@@ -742,7 +742,7 @@ static void rfapiDebugPrintMonitorEncap(void *stream,
 	   m->bi, HVTYNL);
 }
 
-void rfapiShowItNode(void *stream, struct route_node *rn)
+void rfapiShowItNode(void *stream, struct agg_node *rn)
 {
 	struct bgp_info *bi;
 	char buf[BUFSIZ];
@@ -766,10 +766,10 @@ void rfapiShowItNode(void *stream, struct route_node *rn)
 	/* doesn't show montors */
 }
 
-void rfapiShowImportTable(void *stream, const char *label,
-			  struct route_table *rt, int isvpn)
+void rfapiShowImportTable(void *stream, const char *label, struct agg_table *rt,
+			  int isvpn)
 {
-	struct route_node *rn;
+	struct agg_node *rn;
 	char buf[BUFSIZ];
 
 	int (*fp)(void *, const char *, ...);
@@ -782,7 +782,7 @@ void rfapiShowImportTable(void *stream, const char *label,
 
 	fp(out, "Import Table [%s]%s", label, HVTYNL);
 
-	for (rn = route_top(rt); rn; rn = route_next(rn)) {
+	for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
 		struct bgp_info *bi;
 
 		if (rn->p.family == AF_ETHERNET) {
@@ -851,7 +851,7 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 
 	for (ALL_LIST_ELEMENTS_RO(&h->descriptors, node, rfd)) {
 
-		struct route_node *rn;
+		struct agg_node *rn;
 		int printedquerier = 0;
 
 
@@ -868,8 +868,8 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 		 * IP Queries
 		 */
 		if (rfd->mon) {
-			for (rn = route_top(rfd->mon); rn;
-			     rn = route_next(rn)) {
+			for (rn = agg_route_top(rfd->mon); rn;
+			     rn = agg_route_next(rn)) {
 				struct rfapi_monitor_vpn *m;
 				char buf_remain[BUFSIZ];
 				char buf_pfx[BUFSIZ];
@@ -1012,7 +1012,7 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 }
 
 static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
-				 struct route_node *rn, struct bgp_info *bi)
+				 struct agg_node *rn, struct bgp_info *bi)
 {
 	int (*fp)(void *, const char *, ...);
 	struct vty *vty;
@@ -1218,13 +1218,13 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 
 	for (afi = AFI_IP; afi < AFI_MAX; ++afi) {
 
-		struct route_node *rn;
+		struct agg_node *rn;
 
 		if (!it->imported_vpn[afi])
 			continue;
 
-		for (rn = route_top(it->imported_vpn[afi]); rn;
-		     rn = route_next(rn)) {
+		for (rn = agg_route_top(it->imported_vpn[afi]); rn;
+		     rn = agg_route_next(rn)) {
 
 			struct bgp_info *bi;
 			int count_only;

--- a/bgpd/rfapi/rfapi_vty.h
+++ b/bgpd/rfapi/rfapi_vty.h
@@ -124,7 +124,7 @@ extern char *rfapiMonitorVpn2Str(struct rfapi_monitor_vpn *m, char *buf,
 extern const char *rfapiRfapiIpPrefix2Str(struct rfapi_ip_prefix *p, char *buf,
 					  int bufsize);
 
-extern void rfapiShowItNode(void *stream, struct route_node *rn);
+extern void rfapiShowItNode(void *stream, struct agg_node *rn);
 
 extern char *rfapiEthAddr2Str(const struct ethaddr *ea, char *buf, int bufsize);
 

--- a/bgpd/rfapi/vnc_export_bgp_p.h
+++ b/bgpd/rfapi/vnc_export_bgp_p.h
@@ -29,19 +29,19 @@
 
 #include "rfapi_private.h"
 
-extern void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct route_node *rn,
+extern void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
 					struct bgp_info *bi);
 
-extern void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct route_node *rn,
+extern void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
 					struct bgp_info *bi);
 
 extern void vnc_direct_bgp_add_prefix(struct bgp *bgp,
 				      struct rfapi_import_table *import_table,
-				      struct route_node *rn);
+				      struct agg_node *rn);
 
 extern void vnc_direct_bgp_del_prefix(struct bgp *bgp,
 				      struct rfapi_import_table *import_table,
-				      struct route_node *rn);
+				      struct agg_node *rn);
 
 extern void vnc_direct_bgp_add_nve(struct bgp *bgp,
 				   struct rfapi_descriptor *rfd);

--- a/bgpd/rfapi/vnc_export_table.h
+++ b/bgpd/rfapi/vnc_export_table.h
@@ -37,7 +37,7 @@ typedef enum vnc_export_type {
 
 struct vnc_export_info {
 	struct vnc_export_info *next;
-	struct route_node *node;
+	struct agg_node *node;
 	struct peer *peer;
 	uint8_t type;
 	uint8_t subtype;
@@ -45,11 +45,11 @@ struct vnc_export_info {
 	struct thread *timer;
 };
 
-extern struct route_node *vnc_etn_get(struct bgp *bgp, vnc_export_type_t type,
-				      struct prefix *p);
+extern struct agg_node *vnc_etn_get(struct bgp *bgp, vnc_export_type_t type,
+				    struct prefix *p);
 
-extern struct route_node *
-vnc_etn_lookup(struct bgp *bgp, vnc_export_type_t type, struct prefix *p);
+extern struct agg_node *vnc_etn_lookup(struct bgp *bgp, vnc_export_type_t type,
+				       struct prefix *p);
 
 extern struct vnc_export_info *vnc_eti_get(struct bgp *bgp,
 					   vnc_export_type_t etype,

--- a/bgpd/rfapi/vnc_import_bgp_p.h
+++ b/bgpd/rfapi/vnc_import_bgp_p.h
@@ -29,13 +29,13 @@
 
 extern void vnc_import_bgp_exterior_add_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct route_node *rn_interior, /* VPN IT node */
-	struct bgp_info *bi_interior);  /* VPN IT route */
+	struct agg_node *rn_interior,  /* VPN IT node */
+	struct bgp_info *bi_interior); /* VPN IT route */
 
 extern void vnc_import_bgp_exterior_del_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct route_node *rn_interior, /* VPN IT node */
-	struct bgp_info *bi_interior);  /* VPN IT route */
+	struct agg_node *rn_interior,  /* VPN IT node */
+	struct bgp_info *bi_interior); /* VPN IT route */
 
 extern void
 vnc_import_bgp_exterior_redist_enable_it(struct bgp *bgp, afi_t afi,

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -25,7 +25,7 @@
 
 #include "lib/zebra.h"
 #include "lib/prefix.h"
-#include "lib/table.h"
+#include "lib/agg_table.h"
 #include "lib/log.h"
 #include "lib/command.h"
 #include "lib/zclient.h"
@@ -556,7 +556,7 @@ static void import_table_to_nve_list_zebra(struct bgp *bgp,
 
 static void vnc_zebra_add_del_prefix(struct bgp *bgp,
 				     struct rfapi_import_table *import_table,
-				     struct route_node *rn,
+				     struct agg_node *rn,
 				     int add) /* !0 = add, 0 = del */
 {
 	struct list *nves;
@@ -611,14 +611,14 @@ static void vnc_zebra_add_del_prefix(struct bgp *bgp,
 
 void vnc_zebra_add_prefix(struct bgp *bgp,
 			  struct rfapi_import_table *import_table,
-			  struct route_node *rn)
+			  struct agg_node *rn)
 {
 	vnc_zebra_add_del_prefix(bgp, import_table, rn, 1);
 }
 
 void vnc_zebra_del_prefix(struct bgp *bgp,
 			  struct rfapi_import_table *import_table,
-			  struct route_node *rn)
+			  struct agg_node *rn)
 {
 	vnc_zebra_add_del_prefix(bgp, import_table, rn, 0);
 }
@@ -678,8 +678,8 @@ static void vnc_zebra_add_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		 */
 		if (rfgn->rfg == rfg) {
 
-			struct route_table *rt = NULL;
-			struct route_node *rn;
+			struct agg_table *rt = NULL;
+			struct agg_node *rn;
 			struct rfapi_import_table *import_table;
 			import_table = rfg->rfapi_import_table;
 
@@ -692,7 +692,8 @@ static void vnc_zebra_add_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd,
 			/*
 			 * Walk the NVE-Group's VNC Import table
 			 */
-			for (rn = route_top(rt); rn; rn = route_next(rn)) {
+			for (rn = agg_route_top(rt); rn;
+			     rn = agg_route_next(rn)) {
 
 				if (rn->info) {
 
@@ -721,8 +722,8 @@ static void vnc_zebra_add_del_group_afi(struct bgp *bgp,
 					struct rfapi_nve_group_cfg *rfg,
 					afi_t afi, int add)
 {
-	struct route_table *rt = NULL;
-	struct route_node *rn;
+	struct agg_table *rt = NULL;
+	struct agg_node *rn;
 	struct rfapi_import_table *import_table;
 	uint8_t family = afi2family(afi);
 
@@ -773,7 +774,8 @@ static void vnc_zebra_add_del_group_afi(struct bgp *bgp,
 			/*
 			 * Walk the NVE-Group's VNC Import table
 			 */
-			for (rn = route_top(rt); rn; rn = route_next(rn)) {
+			for (rn = agg_route_top(rt); rn;
+			     rn = agg_route_next(rn)) {
 				if (rn->info) {
 					vnc_zebra_route_msg(&rn->p,
 							    nexthop_count,

--- a/bgpd/rfapi/vnc_zebra.h
+++ b/bgpd/rfapi/vnc_zebra.h
@@ -29,11 +29,11 @@
 
 extern void vnc_zebra_add_prefix(struct bgp *bgp,
 				 struct rfapi_import_table *import_table,
-				 struct route_node *rn);
+				 struct agg_node *rn);
 
 extern void vnc_zebra_del_prefix(struct bgp *bgp,
 				 struct rfapi_import_table *import_table,
-				 struct route_node *rn);
+				 struct agg_node *rn);
 
 extern void vnc_zebra_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd);
 

--- a/bgpd/rfp-example/librfp/rfp_example.c
+++ b/bgpd/rfp-example/librfp/rfp_example.c
@@ -230,7 +230,7 @@ void *rfp_start(struct thread_master *master, struct rfapi_rfp_cfg **cfgp,
 
 	/* initilize struct rfapi_rfp_cfg, see rfapi.h */
 	global_rfi.rfapi_config.download_type =
-		RFAPI_RFP_DOWNLOAD_FULL; /* default=partial */
+		RFAPI_RFP_DOWNLOAD_PARTIAL; /* default=partial */
 	global_rfi.rfapi_config.ftd_advertisement_interval =
 		RFAPI_RFP_CFG_DEFAULT_FTD_ADVERTISEMENT_INTERVAL;
 	global_rfi.rfapi_config.holddown_factor =

--- a/lib/agg_table.c
+++ b/lib/agg_table.c
@@ -1,0 +1,59 @@
+/*
+ * Aggregate Route
+ * Copyright (C) 2018 Cumulus Networks, Inc.
+ *               Donald Sharp
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include "zebra.h"
+
+#include "agg_table.h"
+
+
+static struct route_node *agg_node_create(route_table_delegate_t *delegate,
+					  struct route_table *table)
+{
+	struct agg_node *node;
+
+	node = XCALLOC(MTYPE_TMP, sizeof(struct agg_node));
+
+	return agg_node_to_rnode(node);
+}
+
+static void agg_node_destroy(route_table_delegate_t *delegate,
+			     struct route_table *table, struct route_node *node)
+
+{
+	struct agg_node *anode = agg_node_from_rnode(node);
+
+	XFREE(MTYPE_TMP, anode);
+}
+
+route_table_delegate_t agg_table_delegate = {
+	.create_node = agg_node_create,
+	.destroy_node = agg_node_destroy,
+};
+
+struct agg_table *agg_table_init(void)
+{
+	struct agg_table *at;
+
+	at = XCALLOC(MTYPE_TMP, sizeof(struct agg_table));
+
+	at->route_table = route_table_init_with_delegate(&agg_table_delegate);
+	at->route_table->info = at;
+
+	return at;
+}

--- a/lib/agg_table.h
+++ b/lib/agg_table.h
@@ -1,0 +1,151 @@
+/*
+ * agg_table - Aggregate Table Header
+ * Copyright (C) 2018 Cumulus Networks, Inc.
+ *               Donald Sharp
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef __AGG_TABLE_H__
+#define __AGG_TABLE_H__
+
+#include "prefix.h"
+#include "table.h"
+
+struct agg_table {
+	struct route_table *route_table;
+
+	void *info;
+};
+
+struct agg_node {
+	/*
+	 * Caution these must be the very first fields
+	 * @see agg_node_to_rnode
+	 * @see agg_node_from_rnode
+	 */
+	ROUTE_NODE_FIELDS
+
+};
+
+static inline struct route_node *agg_node_to_rnode(struct agg_node *node)
+{
+	return (struct route_node *)node;
+}
+
+static inline struct agg_node *agg_node_from_rnode(struct route_node *node)
+{
+	return (struct agg_node *)node;
+}
+
+static inline struct agg_node *agg_lock_node(struct agg_node *node)
+{
+	return (struct agg_node *)route_lock_node(agg_node_to_rnode(node));
+}
+
+static inline void agg_unlock_node(struct agg_node *node)
+{
+	return route_unlock_node(agg_node_to_rnode(node));
+}
+
+static inline void agg_set_table_info(struct agg_table *atable, void *data)
+{
+	atable->info = data;
+}
+
+static inline void *agg_get_table_info(struct agg_table *atable)
+{
+	return atable->info;
+}
+
+static inline struct agg_node *agg_route_top(struct agg_table *table)
+{
+	return agg_node_from_rnode(route_top(table->route_table));
+}
+
+static inline struct agg_node *agg_route_next(struct agg_node *node)
+{
+	return agg_node_from_rnode(route_next(agg_node_to_rnode(node)));
+}
+
+static inline struct agg_node *agg_node_get(struct agg_table *table,
+					    struct prefix *p)
+{
+	return agg_node_from_rnode(route_node_get(table->route_table, p));
+}
+
+static inline struct agg_node *
+agg_node_lookup(const struct agg_table *const table, struct prefix *p)
+{
+	return agg_node_from_rnode(route_node_lookup(table->route_table, p));
+}
+
+static inline struct agg_node *agg_route_next_until(struct agg_node *node,
+						    struct agg_node *limit)
+{
+	struct route_node *rnode;
+
+	rnode = route_next_until(agg_node_to_rnode(node),
+				agg_node_to_rnode(limit));
+
+	return agg_node_from_rnode(rnode);
+}
+
+static inline struct agg_node *agg_node_match(struct agg_table *table,
+					      struct prefix *p)
+{
+	return agg_node_from_rnode(route_node_match(table->route_table, p));
+}
+
+static inline struct agg_node *agg_node_parent(struct agg_node *node)
+{
+	struct route_node *rn = agg_node_to_rnode(node);
+
+	return agg_node_from_rnode(rn->parent);
+}
+
+static inline struct agg_node *agg_node_left(struct agg_node *node)
+{
+	struct route_node *rn = agg_node_to_rnode(node);
+
+	return agg_node_from_rnode(rn->l_left);
+}
+
+static inline struct agg_node *agg_node_right(struct agg_node *node)
+{
+	struct route_node *rn = agg_node_to_rnode(node);
+
+	return agg_node_from_rnode(rn->l_right);
+}
+
+extern struct agg_table *agg_table_init(void);
+
+static inline void agg_table_finish(struct agg_table *atable)
+{
+	route_table_finish(atable->route_table);
+	atable->route_table = NULL;
+
+	XFREE(MTYPE_TMP, atable);
+}
+
+static inline struct agg_node *agg_route_table_top(struct agg_node *node)
+{
+	return (struct agg_node *)route_top(node->table);
+}
+
+static inline struct agg_table *agg_get_table(struct agg_node *node)
+{
+	return (struct agg_table *)node->table->info;
+}
+#endif

--- a/lib/agg_table.h
+++ b/lib/agg_table.h
@@ -37,6 +37,8 @@ struct agg_node {
 	 */
 	ROUTE_NODE_FIELDS
 
+	/* Aggregation. */
+	void *aggregate;
 };
 
 static inline struct route_node *agg_node_to_rnode(struct agg_node *node)

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -6,6 +6,7 @@ lib_libfrr_la_LDFLAGS = -version-info 0:0:0
 lib_libfrr_la_LIBADD = @LIBCAP@
 
 lib_libfrr_la_SOURCES = \
+	lib/agg_table.c \
 	lib/bfd.c \
 	lib/buffer.c \
 	lib/checksum.c \
@@ -89,6 +90,7 @@ lib/nexthop_group_clippy.c: $(CLIPPY_DEPS)
 lib/nexthop_group.lo: lib/nexthop_group_clippy.c
 
 pkginclude_HEADERS += \
+	lib/agg_table.h \
 	lib/bfd.h \
 	lib/bitfield.h \
 	lib/buffer.h \

--- a/lib/table.h
+++ b/lib/table.h
@@ -126,9 +126,6 @@ struct route_table {
                                                                                \
 	/* Each node of route. */                                              \
 	void *info;                                                            \
-                                                                               \
-	/* Aggregation. */                                                     \
-	void *aggregate;
 
 
 /* Each routing entry. */

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -31,7 +31,7 @@
 #include "stream.h"
 #include "zclient.h"
 #include "command.h"
-#include "table.h"
+#include "agg_table.h"
 #include "thread.h"
 #include "privs.h"
 #include "vrf.h"
@@ -159,14 +159,15 @@ static int ripng_if_ipv6_lladdress_check(struct interface *ifp)
 
 static int ripng_if_down(struct interface *ifp)
 {
-	struct route_node *rp;
+	struct agg_node *rp;
 	struct ripng_info *rinfo;
 	struct ripng_interface *ri;
 	struct list *list = NULL;
 	struct listnode *listnode = NULL, *nextnode = NULL;
 
 	if (ripng)
-		for (rp = route_top(ripng->table); rp; rp = route_next(rp))
+		for (rp = agg_route_top(ripng->table); rp;
+		     rp = agg_route_next(rp))
 			if ((list = rp->info) != NULL)
 				for (ALL_LIST_ELEMENTS(list, listnode, nextnode,
 						       rinfo))
@@ -479,7 +480,7 @@ int ripng_interface_address_delete(int command, struct zclient *zclient,
 vector ripng_enable_if;
 
 /* RIPng enable network table. */
-struct route_table *ripng_enable_network;
+struct agg_table *ripng_enable_network;
 
 /* Lookup RIPng enable network. */
 /* Check wether the interface has at least a connected prefix that
@@ -492,7 +493,7 @@ static int ripng_enable_network_lookup_if(struct interface *ifp)
 
 	for (ALL_LIST_ELEMENTS_RO(ifp->connected, node, connected)) {
 		struct prefix *p;
-		struct route_node *n;
+		struct agg_node *n;
 
 		p = connected->address;
 
@@ -501,10 +502,10 @@ static int ripng_enable_network_lookup_if(struct interface *ifp)
 			address.prefix = p->u.prefix6;
 			address.prefixlen = IPV6_MAX_BITLEN;
 
-			n = route_node_match(ripng_enable_network,
-					     (struct prefix *)&address);
+			n = agg_node_match(ripng_enable_network,
+					   (struct prefix *)&address);
 			if (n) {
-				route_unlock_node(n);
+				agg_unlock_node(n);
 				return 1;
 			}
 		}
@@ -521,7 +522,7 @@ static int ripng_enable_network_lookup2(struct connected *connected)
 	p = connected->address;
 
 	if (p->family == AF_INET6) {
-		struct route_node *node;
+		struct agg_node *node;
 
 		address.family = p->family;
 		address.prefix = p->u.prefix6;
@@ -529,11 +530,11 @@ static int ripng_enable_network_lookup2(struct connected *connected)
 
 		/* LPM on p->family, p->u.prefix6/IPV6_MAX_BITLEN within
 		 * ripng_enable_network */
-		node = route_node_match(ripng_enable_network,
-					(struct prefix *)&address);
+		node = agg_node_match(ripng_enable_network,
+				      (struct prefix *)&address);
 
 		if (node) {
-			route_unlock_node(node);
+			agg_unlock_node(node);
 			return 1;
 		}
 	}
@@ -544,12 +545,12 @@ static int ripng_enable_network_lookup2(struct connected *connected)
 /* Add RIPng enable network. */
 static int ripng_enable_network_add(struct prefix *p)
 {
-	struct route_node *node;
+	struct agg_node *node;
 
-	node = route_node_get(ripng_enable_network, p);
+	node = agg_node_get(ripng_enable_network, p);
 
 	if (node->info) {
-		route_unlock_node(node);
+		agg_unlock_node(node);
 		return -1;
 	} else
 		node->info = (void *)1;
@@ -563,17 +564,17 @@ static int ripng_enable_network_add(struct prefix *p)
 /* Delete RIPng enable network. */
 static int ripng_enable_network_delete(struct prefix *p)
 {
-	struct route_node *node;
+	struct agg_node *node;
 
-	node = route_node_lookup(ripng_enable_network, p);
+	node = agg_node_lookup(ripng_enable_network, p);
 	if (node) {
 		node->info = NULL;
 
 		/* Unlock info lock. */
-		route_unlock_node(node);
+		agg_unlock_node(node);
 
 		/* Unlock lookup lock. */
-		route_unlock_node(node);
+		agg_unlock_node(node);
 
 		return 1;
 	}
@@ -771,13 +772,14 @@ void ripng_clean_network()
 {
 	unsigned int i;
 	char *str;
-	struct route_node *rn;
+	struct agg_node *rn;
 
 	/* ripng_enable_network */
-	for (rn = route_top(ripng_enable_network); rn; rn = route_next(rn))
+	for (rn = agg_route_top(ripng_enable_network); rn;
+	     rn = agg_route_next(rn))
 		if (rn->info) {
 			rn->info = NULL;
-			route_unlock_node(rn);
+			agg_unlock_node(rn);
 		}
 
 	/* ripng_enable_if */
@@ -877,12 +879,12 @@ int ripng_network_write(struct vty *vty, int config_mode)
 {
 	unsigned int i;
 	const char *ifname;
-	struct route_node *node;
+	struct agg_node *node;
 	char buf[BUFSIZ];
 
 	/* Write enable network. */
-	for (node = route_top(ripng_enable_network); node;
-	     node = route_next(node))
+	for (node = agg_route_top(ripng_enable_network); node;
+	     node = agg_route_next(node))
 		if (node->info) {
 			struct prefix *p = &node->p;
 			vty_out(vty, "%s%s/%d\n",
@@ -1124,7 +1126,7 @@ void ripng_if_init()
 	hook_register_prio(if_del, 0, ripng_if_delete_hook);
 
 	/* RIPng enable network init. */
-	ripng_enable_network = route_table_init();
+	ripng_enable_network = agg_table_init();
 
 	/* RIPng enable interface init. */
 	ripng_enable_if = vector_init(1);

--- a/ripngd/ripng_route.h
+++ b/ripngd/ripng_route.h
@@ -42,11 +42,11 @@ struct ripng_aggregate {
 	uint16_t tag_out;
 };
 
-extern void ripng_aggregate_increment(struct route_node *rp,
+extern void ripng_aggregate_increment(struct agg_node *rp,
 				      struct ripng_info *rinfo);
-extern void ripng_aggregate_decrement(struct route_node *rp,
+extern void ripng_aggregate_decrement(struct agg_node *rp,
 				      struct ripng_info *rinfo);
-extern void ripng_aggregate_decrement_list(struct route_node *rp,
+extern void ripng_aggregate_decrement_list(struct agg_node *rp,
 					   struct list *list);
 extern int ripng_aggregate_add(struct prefix *p);
 extern int ripng_aggregate_delete(struct prefix *p);

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -23,7 +23,7 @@
 
 #include "command.h"
 #include "prefix.h"
-#include "table.h"
+#include "agg_table.h"
 #include "stream.h"
 #include "memory.h"
 #include "routemap.h"
@@ -37,7 +37,7 @@
 struct zclient *zclient = NULL;
 
 /* Send ECMP routes to zebra. */
-static void ripng_zebra_ipv6_send(struct route_node *rp, uint8_t cmd)
+static void ripng_zebra_ipv6_send(struct agg_node *rp, uint8_t cmd)
 {
 	struct list *list = (struct list *)rp->info;
 	struct zapi_route api;
@@ -100,13 +100,13 @@ static void ripng_zebra_ipv6_send(struct route_node *rp, uint8_t cmd)
 }
 
 /* Add/update ECMP routes to zebra. */
-void ripng_zebra_ipv6_add(struct route_node *rp)
+void ripng_zebra_ipv6_add(struct agg_node *rp)
 {
 	ripng_zebra_ipv6_send(rp, ZEBRA_ROUTE_ADD);
 }
 
 /* Delete ECMP routes from zebra. */
-void ripng_zebra_ipv6_delete(struct route_node *rp)
+void ripng_zebra_ipv6_delete(struct agg_node *rp)
 {
 	ripng_zebra_ipv6_send(rp, ZEBRA_ROUTE_DELETE);
 }

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -109,13 +109,13 @@ struct ripng {
 	struct stream *obuf;
 
 	/* RIPng routing information base. */
-	struct route_table *table;
+	struct agg_table *table;
 
 	/* RIPng only static route information. */
-	struct route_table *route;
+	struct agg_table *route;
 
 	/* RIPng aggregate route information. */
-	struct route_table *aggregate;
+	struct agg_table *aggregate;
 
 	/* RIPng threads. */
 	struct thread *t_read;
@@ -198,7 +198,7 @@ struct ripng_info {
 	uint8_t metric_out;
 	uint16_t tag_out;
 
-	struct route_node *rp;
+	struct agg_node *rp;
 };
 
 #ifdef notyet
@@ -377,8 +377,8 @@ extern void ripng_redistribute_withdraw(int type);
 extern void ripng_distribute_update_interface(struct interface *);
 extern void ripng_if_rmap_update_interface(struct interface *);
 
-extern void ripng_zebra_ipv6_add(struct route_node *);
-extern void ripng_zebra_ipv6_delete(struct route_node *);
+extern void ripng_zebra_ipv6_add(struct agg_node *node);
+extern void ripng_zebra_ipv6_delete(struct agg_node *node);
 
 extern void ripng_redistribute_clean(void);
 extern int ripng_redistribute_check(int);


### PR DESCRIPTION
The `struct route_node` data structure has a `void *aggregate` pointer that is being used by rfapi and ripngd.  For a full bgp feed, this is causing an extra 8 bytes per node over 1.2 million nodes in bgp and zebra alone.

Create a `struct agg_node` and a `struct agg_table` data structure that we can replace into rfapi and ripng, then work magic over those code bases to convert over to the new data structure.  Finally move the aggregate pointer in to the `struct agg_node` data structure.