### PR TITLE
bgpd: Display `::` if AFI is IPv6, `0.0.0.0` otherwise

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9560,7 +9560,7 @@ ravg_tally (unsigned long count, unsigned long oldavg, unsigned long newval)
   unsigned long newtot = (count-1) * oldavg + (newval * TALLY_SIGFIG);
   unsigned long res = (newtot * TALLY_SIGFIG) / count;
   unsigned long ret = newtot / count;
-  
+
   if ((res % TALLY_SIGFIG) > (TALLY_SIGFIG/2))
     return ret + 1;
   else
@@ -9654,7 +9654,7 @@ static int bgp_table_stats_walker(struct thread *t)
 				ts->counts[BGP_STATS_ASPATH_TOTHOPS] += hops;
 				ts->counts[BGP_STATS_ASPATH_TOTSIZE] += size;
 #if 0
-              ts->counts[BGP_STATS_ASPATH_AVGHOPS] 
+              ts->counts[BGP_STATS_ASPATH_AVGHOPS]
                 = ravg_tally (ts->counts[BGP_STATS_ASPATH_COUNT],
                               ts->counts[BGP_STATS_ASPATH_AVGHOPS],
                               hops);
@@ -10142,9 +10142,9 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 					       json_scode);
 			json_object_object_add(json, "bgpOriginCodes",
 					       json_ocode);
-			json_object_string_add(json,
-					       "bgpOriginatingDefaultNetwork",
-					       "0.0.0.0");
+			json_object_string_add(
+				json, "bgpOriginatingDefaultNetwork",
+				(afi == AFI_IP) ? "0.0.0.0/0" : "::/0");
 		} else {
 			vty_out(vty, "BGP table version is %" PRIu64
 				     ", local router ID is %s, vrf id ",
@@ -10158,7 +10158,8 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 			vty_out(vty, BGP_SHOW_NCODE_HEADER);
 			vty_out(vty, BGP_SHOW_OCODE_HEADER);
 
-			vty_out(vty, "Originating default network 0.0.0.0\n\n");
+			vty_out(vty, "Originating default network %s\n\n",
+				(afi == AFI_IP) ? "0.0.0.0/0" : "::/0");
 		}
 		header1 = 0;
 	}


### PR DESCRIPTION
spine:
```
!
frr version 5.0.1-MyOwnFRRVersion
frr defaults traditional
hostname spine1-debian-9
no ip forwarding
no ipv6 forwarding
service integrated-vtysh-config
username cumulus nopassword
!
router bgp 65031
 bgp router-id 10.0.0.1
 neighbor 2a02:4780::2 remote-as 65032
 !
 address-family ipv4 unicast
  neighbor 2a02:4780::2 default-originate
 exit-address-family
 !
 address-family ipv6 unicast
  redistribute kernel
  neighbor 2a02:4780::2 activate
  neighbor 2a02:4780::2 default-originate
 exit-address-family
!
line vty
!
end

spine1-debian-9# show ip bgp neighbors 2a02:4780::2 advertised-routes 
BGP table version is 0, local router ID is 10.0.0.1, vrf id 0
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

Originating default network 0.0.0.0

spine1-debian-9# show ip bgp ipv6 unicast neighbors 2a02:4780::2 advertised-routes 
BGP table version is 0, local router ID is 10.0.0.1, vrf id 0
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

Originating default network ::
```

leaf:
```
!
frr version 5.0.1-MyOwnFRRVersion
frr defaults traditional
hostname leaf1-debian-9
log syslog informational
no ip forwarding
no ipv6 forwarding
service integrated-vtysh-config
username cumulus nopassword
!
router bgp 65032
 bgp router-id 10.0.0.2
 neighbor 2a02:4780::1 remote-as 65031
 !
 address-family ipv6 unicast
  neighbor 2a02:4780::1 activate
 exit-address-family
!
line vty
!
end

leaf1-debian-9# show ip bgp ipv6 unicast ::
BGP routing table entry for ::/0
Paths: (1 available, best #1, table Default-IP-Routing-Table)
  Advertised to non peer-group peers:
  2a02:4780::1
  65031
    2a02:4780::1 from 2a02:4780::1 (10.0.0.1)
    (fe80::a00:27ff:feec:f490) (used)
      Origin IGP, localpref 100, valid, external, best
      AddPath ID: RX 0, TX 2
      Last update: Sat Aug  4 11:46:52 2018
```
Signed-off-by: Donatas Abraitis donatas.abraitis@gmail.com