### PR TITLE
lib: Add stream last pointer

### DIFF
--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -24,6 +24,7 @@
 #include "frr_pthread.h"
 #include "memory.h"
 #include "hash.h"
+#include "stream.h"
 
 DEFINE_MTYPE(LIB, FRR_PTHREAD, "FRR POSIX Thread");
 DEFINE_MTYPE(LIB, PTHREAD_PRIM, "POSIX synchronization primitives");
@@ -67,6 +68,7 @@ void frr_pthread_init()
 {
 	pthread_mutex_lock(&frr_pthread_hash_mtx);
 	{
+		stream_init_last();
 		frr_pthread_hash = hash_create(frr_pthread_hash_key,
 					       frr_pthread_hash_cmp, NULL);
 	}

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -247,6 +247,9 @@ extern void stream_reset(struct stream *);
 extern int stream_flush(struct stream *, int);
 extern int stream_empty(struct stream *); /* is the stream empty? */
 
+/* Cleanup stream internal data structures at end of program */
+extern void stream_init_last(void);
+
 /* deprecated */
 extern uint8_t *stream_pnt(struct stream *);
 


### PR DESCRIPTION
Add a `static struct stream *last` pointer to stream.c.

This code will store the last stream sent to stream_free,
if the size of the stream is bigger than the last pointer
switch it out for that one.

On stream_new call if last exists and the size constraint
is satisfied then pass back the last pointer, else create
a new one.

In testing of 10k stream size and 10000000 allocations/frees
we reduce time from .65 to .06 seconds.

I am making an assumption here that there are two types
of stream allocations:

1) Initial setup of size X and we hold onto this pointer
until the end of the program.  In this case we might
have a couple of suboptimal( oversized ) stream allocations
but I think this is ok considering that the largest stream
allocation I am aware of is 65k.

2) Temporary scratch pads for the passing of data between
processes( zapi comes to mind immediately ), in which
case the stream data structure is ephermeral and constantly
alloced/freed.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>