### PR TITLE
ripd: fix packet sending

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2101,6 +2101,9 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 		/* to be passed to auth functions later */
 		rip_auth_prepare_str_send(ri, key, auth_str,
 					  RIP_AUTH_SIMPLE_SIZE);
+        if (0 == strlen(auth_str)) {
+            return;
+        }
 	}
 
 	if (version == RIPv1) {

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2101,9 +2101,8 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 		/* to be passed to auth functions later */
 		rip_auth_prepare_str_send(ri, key, auth_str,
 					  RIP_AUTH_SIMPLE_SIZE);
-        if (0 == strlen(auth_str)) {
-            return;
-        }
+		if (strlen(auth_str) == 0)
+			return;
 	}
 
 	if (version == RIPv1) {


### PR DESCRIPTION
fix a bug when sending a rip packet.
in authenticate mode but without any string,
no packet should send.

Signed-off-by: lyq140 <34637052+lyq140@users.noreply.github.com>