### PR TITLE
doc: set origin

### DIFF
--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -277,6 +277,11 @@ Route Map Set Command
 
    Set the BGP-4+ link local IPv6 nexthop address.
 
+.. index:: set origin ORIGIN <egp|igp|incomplete>
+.. clicmd:: set origin ORIGIN <egp|igp|incomplete>
+
+   Set BGP route origin.
+
 .. _route-map-call-command:
 
 Route Map Call Command


### PR DESCRIPTION
Add description of set origin igp/egp/incomplete.

Feature was not documented as raised issue was raised on [list FROG](https://lists.frrouting.org/pipermail/frog/2018-August/000250.html) about it.