### PR TITLE
PIMD: Fix pim_mroute_del crash while killing pimd.

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -174,8 +174,11 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 	   ifchannel list is empty before deleting upstream_del
 	   ref count will take care of it.
 	*/
-	pim_upstream_del(pim_ifp->pim, ch->upstream, __PRETTY_FUNCTION__);
-	ch->upstream = NULL;
+
+        if (!(ch->upstream->flags & PIM_UPSTREAM_FLAG_DEL)) {
+	        pim_upstream_del(pim_ifp->pim, ch->upstream, __PRETTY_FUNCTION__);
+	        ch->upstream = NULL;
+        }
 
 	THREAD_OFF(ch->t_ifjoin_expiry_timer);
 	THREAD_OFF(ch->t_ifjoin_prune_pending_timer);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -172,6 +172,8 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 	if (up->ref_count >= 1)
 		return up;
 
+        up->flags |= PIM_UPSTREAM_FLAG_DEL;
+
 	THREAD_OFF(up->t_ka_timer);
 	THREAD_OFF(up->t_rs_timer);
 	THREAD_OFF(up->t_msdp_reg_timer);

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -37,6 +37,7 @@
 #define PIM_UPSTREAM_FLAG_MASK_SRC_MSDP                (1 << 6)
 #define PIM_UPSTREAM_FLAG_MASK_SEND_SG_RPT_PRUNE       (1 << 7)
 #define PIM_UPSTREAM_FLAG_MASK_SRC_LHR                 (1 << 8)
+#define PIM_UPSTREAM_FLAG_DEL                          (1 << 9)
 #define PIM_UPSTREAM_FLAG_ALL 0xFFFFFFFF
 
 #define PIM_UPSTREAM_FLAG_TEST_DR_JOIN_DESIRED(flags) ((flags) & PIM_UPSTREAM_FLAG_MASK_DR_JOIN_DESIRED)


### PR DESCRIPTION
When we kill pimd, pim_upstream_del() will be get called as part of cleaning process.
Delete mroute by calling pim_mroute_del() which in result initialize the up->channel_oil
to NULL after cleanup. Delete each ifchannel stored in the upstream ifchannel list one
by one. As part of pim_ifchannel_delete(), it will check if it is the last ifchannel,
then delete the corresponding upstream. So pim_upstream_del will be get called more than
once as part of pim_upstream_terminate() and pim_ ifchannel_delete(). Similarly pim_mroute_del()
will be again called and since there is no NULL check before accesing the data, crash is happening.

Fix:
Adding Null check in pim_mroute_del before accessing the data.
and using the FLAG "PIM_UPSTREAM_FLAG_DEL" which will check if the deletion of pim upstream is already
in progress then don’t call pim_upstream_del() from pim_ifchannel_delete().

Signed-off-by: Sarita Patra <saritap@vmware.com>