### PR TITLE
pimd: fix bogus uninitialized warning

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -352,7 +352,7 @@ int pim_ecmp_nexthop_search(struct pim_instance *pim,
 			    struct pim_nexthop *nexthop, struct prefix *src,
 			    struct prefix *grp, int neighbor_needed)
 {
-	struct pim_neighbor *nbrs[MULTIPATH_NUM], *nbr;
+	struct pim_neighbor *nbrs[MULTIPATH_NUM], *nbr = NULL;
 	struct interface *ifps[MULTIPATH_NUM];
 	struct nexthop *nh_node = NULL;
 	ifindex_t first_ifindex;


### PR DESCRIPTION
pimd/pim_nht.c: In function ‘pim_ecmp_nexthop_search’:
pimd/pim_nht.c:523:17: error: ‘nbr’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
    nexthop->nbr = nbr;

(on gcc 5.4.0; this is the only warning with that version.)

Signed-off-by: David Lamparter <equinox@diac24.net>