### PR TITLE
lib: track total memory per MTYPE if possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1811,15 +1811,58 @@ dnl order to check no alternative allocator
 dnl has been specified, which might not provide
 dnl mallinfo, e.g. such as Umem on Solaris.
 dnl -----------------------------------------
-AC_CHECK_HEADER([malloc.h],
- [AC_MSG_CHECKING(whether mallinfo is available)
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <malloc.h>]],
-                        [[struct mallinfo ac_x; ac_x = mallinfo ();]])],
-      [AC_MSG_RESULT(yes)
-       AC_DEFINE(HAVE_MALLINFO,,mallinfo)],
-       AC_MSG_RESULT(no)
-  )
- ], [], FRR_INCLUDES)
+AC_CHECK_HEADERS([malloc.h malloc/malloc.h],,, [FRR_INCLUDES])
+
+AC_MSG_CHECKING(whether mallinfo is available)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([FRR_INCLUDES [
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+#ifdef HAVE_MALLOC_MALLOC_H
+#include <malloc/malloc.h>
+#endif
+]], [[
+struct mallinfo ac_x; ac_x = mallinfo ();
+]])], [
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(HAVE_MALLINFO,,mallinfo)
+], [
+  AC_MSG_RESULT(no)
+])
+
+AC_MSG_CHECKING(whether malloc_usable_size is available)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([FRR_INCLUDES [
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+#ifdef HAVE_MALLOC_MALLOC_H
+#include <malloc/malloc.h>
+#endif
+]], [[
+size_t ac_x; ac_x = malloc_usable_size(NULL);
+]])], [
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(HAVE_MALLOC_USABLE_SIZE,,malloc_usable_size)
+], [
+  AC_MSG_RESULT(no)
+
+  AC_MSG_CHECKING(whether malloc_size is available)
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+#ifdef HAVE_MALLOC_MALLOC_H
+#include <malloc/malloc.h>
+#endif
+]], [[
+size_t ac_x; ac_x = malloc_size(NULL);
+]])], [
+    AC_MSG_RESULT(yes)
+    AC_DEFINE(HAVE_MALLOC_SIZE,,malloc_size)
+  ], [
+    AC_MSG_RESULT(no)
+  ])
+])
 
 dnl ------
 dnl ZeroMQ

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -320,6 +320,67 @@ Terminal Mode Commands
    Shows the current configuration of the logging system. This includes the
    status of all logging destinations.
 
+.. index:: show memory
+.. clicmd:: show memory
+
+   Show information on how much memory is used for which specific things in
+   |PACKAGE_NAME|.  Output may vary depending on system capabilities but will
+   generally look something like this:
+
+   ::
+
+      frr# show memory
+      System allocator statistics:
+        Total heap allocated:  1584 KiB
+        Holding block headers: 0 bytes
+        Used small blocks:     0 bytes
+        Used ordinary blocks:  1484 KiB
+        Free small blocks:     2096 bytes
+        Free ordinary blocks:  100 KiB
+        Ordinary blocks:       2
+        Small blocks:          60
+        Holding blocks:        0
+      (see system documentation for 'mallinfo' for meaning)
+      --- qmem libfrr ---
+      Buffer                        :          3      24                  72
+      Buffer data                   :          1    4120                4120
+      Host config                   :          3  (variably sized)        72
+      Command Tokens                :       3427      72              247160
+      Command Token Text            :       2555  (variably sized)     83720
+      Command Token Help            :       2555  (variably sized)     61720
+      Command Argument              :          2  (variably sized)        48
+      Command Argument Name         :        641  (variably sized)     15672
+      [...]
+      --- qmem Label Manager ---
+      --- qmem zebra ---
+      ZEBRA VRF                     :          1     912                 920
+      Route Entry                   :         11      80                 968
+      Static route                  :          1     192                 200
+      RIB destination               :          8      48                 448
+      RIB table info                :          4      16                  96
+      Nexthop tracking object       :          1     200                 200
+      Zebra Name Space              :          1     312                 312
+      --- qmem Table Manager ---
+
+   To understand system allocator statistics, refer to your system's
+   :manpage:`mallinfo(3)` man page.
+
+   Below these statistics, statistics on individual memory allocation types
+   in |PACKAGE_NAME| (so-called `MTYPEs`) is printed:
+
+   * the first column of numbers is the current count of allocations made for
+     the type (the number decreases when items are freed.)
+   * the second column is the size of each item.  This is only available if
+     allocations on a type are always made with the same size.
+   * the third column is the total amount of memory allocated for the
+     particular type, including padding applied by malloc.  This means that
+     the number may be larger than the first column multiplied by the second.
+     Overhead incurred by malloc's bookkeeping is not included in this, and
+     the column may be missing if system support is not available.
+
+   When executing this command from ``vtysh``, each of the daemons' memory
+   usage is printed sequentially.
+
 .. index:: logmsg LEVEL MESSAGE
 .. clicmd:: logmsg LEVEL MESSAGE
 

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -24,12 +24,20 @@
 
 #define array_size(ar) (sizeof(ar) / sizeof(ar[0]))
 
+#if defined(HAVE_MALLOC_SIZE) && !defined(HAVE_MALLOC_USABLE_SIZE)
+#define malloc_usable_size(x) malloc_size(x)
+#define HAVE_MALLOC_USABLE_SIZE
+#endif
+
 #define SIZE_VAR ~0UL
 struct memtype {
 	struct memtype *next, **ref;
 	const char *name;
 	_Atomic size_t n_alloc;
 	_Atomic size_t size;
+#ifdef HAVE_MALLOC_USABLE_SIZE
+	_Atomic size_t total;
+#endif
 };
 
 struct memgroup {

--- a/lib/memory_vty.c
+++ b/lib/memory_vty.c
@@ -21,9 +21,12 @@
 
 #include <zebra.h>
 /* malloc.h is generally obsolete, however GNU Libc mallinfo wants it. */
-#if (defined(GNU_LINUX) && defined(HAVE_MALLINFO))
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
-#endif /* HAVE_MALLINFO */
+#endif
+#ifdef HAVE_MALLOC_MALLOC_H
+#include <malloc/malloc.h>
+#endif
 #include <dlfcn.h>
 #include <link.h>
 

--- a/lib/memory_vty.c
+++ b/lib/memory_vty.c
@@ -79,12 +79,21 @@ static int qmem_walker(void *arg, struct memgroup *mg, struct memtype *mt)
 		if (mt->n_alloc != 0) {
 			char size[32];
 			snprintf(size, sizeof(size), "%6zu", mt->size);
-			vty_out(vty, "%-30s: %10zu  %s\n", mt->name,
+
+#ifdef HAVE_MALLOC_USABLE_SIZE
+#define TSTR " %9zu"
+#define TARG , mt->total
+#else
+#define TSTR ""
+#define TARG
+#endif
+			vty_out(vty, "%-30s: %10zu  %-16s"TSTR"\n", mt->name,
 				mt->n_alloc,
 				mt->size == 0 ? ""
 					      : mt->size == SIZE_VAR
 							? "(variably sized)"
-							: size);
+							: size
+				TARG);
 		}
 	}
 	return 0;

--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -4181,7 +4181,9 @@ sub process {
 				} elsif ($op eq ',') {
 					my $rtrim_before = 0;
 					my $space_after = 0;
-					if ($ctx =~ /Wx./) {
+					if ($line=~/\#\s*define/) {
+						# ignore , spacing in macros
+					} elsif ($ctx =~ /Wx./) {
 						if (ERROR("SPACING",
 							  "space prohibited before that '$op' $at\n" . $hereptr)) {
 							$line_fixed = 1;
@@ -4847,6 +4849,7 @@ sub process {
 			my $ctx = '';
 			my $has_flow_statement = 0;
 			my $has_arg_concat = 0;
+			my $complex = 0;
 			($dstat, $dcond, $ln, $cnt, $off) =
 				ctx_statement_block($linenr, $realcnt, 0);
 			$ctx = $dstat;
@@ -4865,6 +4868,7 @@ sub process {
 				$define_args = substr($define_args, 1, length($define_args) - 2);
 				$define_args =~ s/\s*//g;
 				@def_args = split(",", $define_args);
+				$complex = 1;
 			}
 
 			$dstat =~ s/$;//g;
@@ -4932,7 +4936,7 @@ sub process {
 				} elsif ($dstat =~ /;/) {
 					ERROR("MULTISTATEMENT_MACRO_USE_DO_WHILE",
 					      "Macros with multiple statements should be enclosed in a do - while loop\n" . "$herectx");
-				} else {
+				} elsif ($complex) {
 					ERROR("COMPLEX_MACRO",
 					      "Macros with complex values should be enclosed in parentheses\n" . "$herectx");
 				}


### PR DESCRIPTION
without this we don't get a good memory usage reading for "variably sized" MTYPEs.