### PR TITLE
lib: fix "-t" command line option

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2303,9 +2303,9 @@ void vty_close(struct vty *vty)
 	 * additionally, we'd need to replace these fds with /dev/null. */
 	if (vty->wfd > STDERR_FILENO && vty->wfd != vty->fd)
 		close(vty->wfd);
-	if (vty->fd > STDERR_FILENO) {
+	if (vty->fd > STDERR_FILENO)
 		close(vty->fd);
-	} else
+	if (vty->fd == STDIN_FILENO)
 		was_stdio = true;
 
 	if (vty->buf)


### PR DESCRIPTION
was_stdio was getting set for fd == -1 (config file read), thus
prematurely closing the stdio vty.

Signed-off-by: David Lamparter <equinox@diac24.net>