### PR TITLE
bgpd: print evpn nd ext community in route

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -739,6 +739,13 @@ char *ecommunity_ecom2str(struct ecommunity *ecom, int format, int filter)
 				else
 					len = sprintf(str_buf + str_pnt,
 						      "MM:%u", seqnum);
+			} else if (*pnt == ECOMMUNITY_EVPN_SUBTYPE_ND) {
+				uint8_t flags = *++pnt;
+
+				if (flags
+				    & ECOMMUNITY_EVPN_SUBTYPE_ND_ROUTER_FLAG)
+					len = sprintf(str_buf + str_pnt,
+						      "ND:Router Flag");
 			} else
 				unk_ecom = 1;
 		} else if (type == ECOMMUNITY_ENCODE_REDIRECT_IP_NH) {


### PR DESCRIPTION
Route [2]:[0]:[0]:[48]:[00:02:00:00:00:0e]:[128]:[2001:fee1::a] VNI 1000
   4435 5551
27.0.0.16 from MSP1(uplink-1) (27.0.0.9)
   Origin IGP, valid, external
   Extended Community: RT:5551:1000 ET:8 ND: Router
   Flag
   AddPath ID: RX 0, TX 1125
   Last update: Thu Aug  9 04:31:37 2018

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>