### PR TITLE
staticd: Fix null pointer access (coverity 1472311)

### DIFF
--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -119,7 +119,7 @@ static int interface_state_up(int command, struct zclient *zclient,
 
 	ifp = zebra_interface_if_lookup(zclient->ibuf);
 
-	if (if_is_vrf(ifp)) {
+	if (ifp && if_is_vrf(ifp)) {
 		struct static_vrf *svrf = static_vrf_lookup_by_id(vrf_id);
 
 		static_fixup_vrf_ids(svrf);


### PR DESCRIPTION
Aded a check to ensure that if_is_vrf() is not called on a NULL if pointer.
Incidentally this was causing PR #2805 to fail.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>