### PR TITLE
ospf6d: fix use after free on LSA

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -330,6 +330,8 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 						zlog_debug(
 							"Requesting the same, remove it, next neighbor");
 					if (req == on->last_ls_req) {
+						/* sanity check refcount */
+						assert(req->lock >= 2);
 						ospf6_lsa_unlock(req);
 						on->last_ls_req = NULL;
 					}


### PR DESCRIPTION
ospf6_lsdb_remove() handles deleting route nodes, we don't need to do it

Improved version of #2792 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>