### PR TITLE
Zebra does not properly track which route-maps are changed (#2493)

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -715,7 +715,7 @@ int zebra_import_table_config(struct vty *vty)
 	return write;
 }
 
-void zebra_import_table_rm_update()
+void zebra_import_table_rm_update(const char *rmap)
 {
 	afi_t afi;
 	int i;
@@ -730,9 +730,8 @@ void zebra_import_table_rm_update()
 				continue;
 
 			rmap_name = zebra_get_import_table_route_map(afi, i);
-			if (!rmap_name)
-				return;
-
+			if ((!rmap_name) || (strcmp(rmap_name, rmap) != 0))
+				continue;
 			table = zebra_vrf_other_route_table(afi, i,
 							    VRF_DEFAULT);
 			for (rn = route_top(table); rn; rn = route_next(rn)) {

--- a/zebra/redistribute.h
+++ b/zebra/redistribute.h
@@ -71,6 +71,5 @@ extern int is_zebra_import_table_enabled(afi_t, uint32_t table_id);
 
 extern int zebra_import_table_config(struct vty *);
 
-extern void zebra_import_table_rm_update(void);
-
+extern void zebra_import_table_rm_update(const char *rmap);
 #endif /* _ZEBRA_REDISTRIBUTE_H */

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -325,6 +325,8 @@ extern struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *p,
 					   vrf_id_t vrf_id);
 
 extern void rib_update(vrf_id_t vrf_id, rib_update_event_t event);
+extern void rib_update_table(struct route_table *table,
+			     rib_update_event_t event);
 extern void rib_sweep_route(void);
 extern void rib_sweep_table(struct route_table *table);
 extern void rib_close_table(struct route_table *table);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2637,8 +2637,7 @@ int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 }
 
 /* Schedule routes of a particular table (address-family) based on event. */
-static void rib_update_table(struct route_table *table,
-			     rib_update_event_t event)
+void rib_update_table(struct route_table *table, rib_update_event_t event)
 {
 	struct route_node *rn;
 	struct route_entry *re, *next;
@@ -2718,12 +2717,18 @@ void rib_update(vrf_id_t vrf_id, rib_update_event_t event)
 
 	/* Process routes of interested address-families. */
 	table = zebra_vrf_table(AFI_IP, SAFI_UNICAST, vrf_id);
-	if (table)
+	if (table) {
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s : AFI_IP event %d", __func__, event);
 		rib_update_table(table, event);
+	}
 
 	table = zebra_vrf_table(AFI_IP6, SAFI_UNICAST, vrf_id);
-	if (table)
+	if (table) {
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s : AFI_IP6 event %d", __func__, event);
 		rib_update_table(table, event);
+	}
 }
 
 /* Delete self installed routes after zebra is relaunched.  */


### PR DESCRIPTION
Check for the modified routemap in zebra_route_map_process_update_cb()
and call appropriate function for the changed routemap.
Added zebra_rib_table_rm_update() and zebra_nht_rm_update() for
RIB and NHT routemap processing.
Added code for "match ipv6 address prefix list" command