### PR TITLE
create privilege raising/lowering wrapper

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -543,13 +543,11 @@ int bgp_connect(struct peer *peer)
 		zlog_debug("Peer address not learnt: Returning from connect");
 		return 0;
 	}
-	if (bgpd_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
+	frr_elevate_privs(&bgpd_privs) {
 	/* Make socket for the peer. */
-	peer->fd = vrf_sockunion_socket(&peer->su, peer->bgp->vrf_id,
-					bgp_get_bound_name(peer));
-	if (bgpd_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+		peer->fd = vrf_sockunion_socket(&peer->su, peer->bgp->vrf_id,
+						bgp_get_bound_name(peer));
+	}
 	if (peer->fd < 0)
 		return -1;
 
@@ -568,14 +566,12 @@ int bgp_connect(struct peer *peer)
 			  peer->host, safe_strerror(errno));
 
 #ifdef IPTOS_PREC_INTERNETCONTROL
-	if (bgpd_privs.change(ZPRIVS_RAISE))
-		zlog_err("%s: could not raise privs", __func__);
-	if (sockunion_family(&peer->su) == AF_INET)
-		setsockopt_ipv4_tos(peer->fd, IPTOS_PREC_INTERNETCONTROL);
-	else if (sockunion_family(&peer->su) == AF_INET6)
-		setsockopt_ipv6_tclass(peer->fd, IPTOS_PREC_INTERNETCONTROL);
-	if (bgpd_privs.change(ZPRIVS_LOWER))
-		zlog_err("%s: could not lower privs", __func__);
+	frr_elevate_privs(&bgpd_privs) {
+		if (sockunion_family(&peer->su) == AF_INET)
+			setsockopt_ipv4_tos(peer->fd, IPTOS_PREC_INTERNETCONTROL);
+		else if (sockunion_family(&peer->su) == AF_INET6)
+			setsockopt_ipv6_tclass(peer->fd, IPTOS_PREC_INTERNETCONTROL);
+	}
 #endif
 
 	if (peer->password)
@@ -642,22 +638,20 @@ static int bgp_listener(int sock, struct sockaddr *sa, socklen_t salen,
 	sockopt_reuseaddr(sock);
 	sockopt_reuseport(sock);
 
-	if (bgpd_privs.change(ZPRIVS_RAISE))
-		zlog_err("%s: could not raise privs", __func__);
+	frr_elevate_privs(&bgpd_privs) {
 
 #ifdef IPTOS_PREC_INTERNETCONTROL
-	if (sa->sa_family == AF_INET)
-		setsockopt_ipv4_tos(sock, IPTOS_PREC_INTERNETCONTROL);
-	else if (sa->sa_family == AF_INET6)
-		setsockopt_ipv6_tclass(sock, IPTOS_PREC_INTERNETCONTROL);
+		if (sa->sa_family == AF_INET)
+			setsockopt_ipv4_tos(sock, IPTOS_PREC_INTERNETCONTROL);
+		else if (sa->sa_family == AF_INET6)
+			setsockopt_ipv6_tclass(sock, IPTOS_PREC_INTERNETCONTROL);
 #endif
 
-	sockopt_v6only(sa->sa_family, sock);
+		sockopt_v6only(sa->sa_family, sock);
 
-	ret = bind(sock, sa, salen);
-	en = errno;
-	if (bgpd_privs.change(ZPRIVS_LOWER))
-		zlog_err("%s: could not lower privs", __func__);
+		ret = bind(sock, sa, salen);
+		en = errno;
+	}
 
 	if (ret < 0) {
 		zlog_err("bind: %s", safe_strerror(en));
@@ -702,12 +696,10 @@ int bgp_socket(struct bgp *bgp, unsigned short port, const char *address)
 	snprintf(port_str, sizeof(port_str), "%d", port);
 	port_str[sizeof(port_str) - 1] = '\0';
 
-	if (bgpd_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	ret = vrf_getaddrinfo(address, port_str, &req, &ainfo_save,
-			      bgp->vrf_id);
-	if (bgpd_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	frr_elevate_privs(&bgpd_privs) {
+		ret = vrf_getaddrinfo(address, port_str, &req, &ainfo_save,
+				      bgp->vrf_id);
+	}
 	if (ret != 0) {
 		zlog_err("getaddrinfo: %s", gai_strerror(ret));
 		return -1;
@@ -720,14 +712,13 @@ int bgp_socket(struct bgp *bgp, unsigned short port, const char *address)
 		if (ainfo->ai_family != AF_INET && ainfo->ai_family != AF_INET6)
 			continue;
 
-		if (bgpd_privs.change(ZPRIVS_RAISE))
-			zlog_err("Can't raise privileges");
-		sock = vrf_socket(ainfo->ai_family, ainfo->ai_socktype,
-				  ainfo->ai_protocol, bgp->vrf_id,
-				  (bgp->inst_type == BGP_INSTANCE_TYPE_VRF ?
-				   bgp->name : NULL));
-		if (bgpd_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
+		frr_elevate_privs(&bgpd_privs) {
+			sock = vrf_socket(ainfo->ai_family,
+					  ainfo->ai_socktype,
+					  ainfo->ai_protocol, bgp->vrf_id,
+					  (bgp->inst_type == BGP_INSTANCE_TYPE_VRF ?
+					   bgp->name : NULL));
+		}
 		if (sock < 0) {
 			zlog_err("socket: %s", safe_strerror(errno));
 			continue;

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -555,9 +555,11 @@ int bgp_connect(struct peer *peer)
 #ifdef IPTOS_PREC_INTERNETCONTROL
 	frr_elevate_privs(&bgpd_privs) {
 		if (sockunion_family(&peer->su) == AF_INET)
-			setsockopt_ipv4_tos(peer->fd, IPTOS_PREC_INTERNETCONTROL);
+			setsockopt_ipv4_tos(peer->fd,
+					    IPTOS_PREC_INTERNETCONTROL);
 		else if (sockunion_family(&peer->su) == AF_INET6)
-			setsockopt_ipv6_tclass(peer->fd, IPTOS_PREC_INTERNETCONTROL);
+			setsockopt_ipv6_tclass(peer->fd,
+					       IPTOS_PREC_INTERNETCONTROL);
 	}
 #endif
 
@@ -631,7 +633,8 @@ static int bgp_listener(int sock, struct sockaddr *sa, socklen_t salen,
 		if (sa->sa_family == AF_INET)
 			setsockopt_ipv4_tos(sock, IPTOS_PREC_INTERNETCONTROL);
 		else if (sa->sa_family == AF_INET6)
-			setsockopt_ipv6_tclass(sock, IPTOS_PREC_INTERNETCONTROL);
+			setsockopt_ipv6_tclass(sock,
+					       IPTOS_PREC_INTERNETCONTROL);
 #endif
 
 		sockopt_v6only(sa->sa_family, sock);
@@ -703,8 +706,9 @@ int bgp_socket(struct bgp *bgp, unsigned short port, const char *address)
 			sock = vrf_socket(ainfo->ai_family,
 					  ainfo->ai_socktype,
 					  ainfo->ai_protocol, bgp->vrf_id,
-					  (bgp->inst_type == BGP_INSTANCE_TYPE_VRF ?
-					   bgp->name : NULL));
+					  (bgp->inst_type
+					   == BGP_INSTANCE_TYPE_VRF
+					   ? bgp->name : NULL));
 		}
 		if (sock < 0) {
 			zlog_err("socket: %s", safe_strerror(errno));

--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -125,9 +125,7 @@ void eigrp_adjust_sndbuflen(struct eigrp *eigrp, unsigned int buflen)
 	/* Check if any work has to be done at all. */
 	if (eigrp->maxsndbuflen >= buflen)
 		return;
-	if (eigrpd_privs.change(ZPRIVS_RAISE))
-		zlog_err("%s: could not raise privs, %s", __func__,
-			 safe_strerror(errno));
+	frr_elevate_privs(&eigrpd_privs) {
 
 	/* Now we try to set SO_SNDBUF to what our caller has requested
 	 * (the MTU of a newly added interface). However, if the OS has
@@ -136,18 +134,16 @@ void eigrp_adjust_sndbuflen(struct eigrp *eigrp, unsigned int buflen)
 	 * may allocate more buffer space, than requested, this isn't
 	 * a error.
 	 */
-	setsockopt_so_sendbuf(eigrp->fd, buflen);
-	newbuflen = getsockopt_so_sendbuf(eigrp->fd);
-	if (newbuflen < 0 || newbuflen < (int)buflen)
-		zlog_warn("%s: tried to set SO_SNDBUF to %u, but got %d",
-			  __func__, buflen, newbuflen);
-	if (newbuflen >= 0)
-		eigrp->maxsndbuflen = (unsigned int)newbuflen;
-	else
-		zlog_warn("%s: failed to get SO_SNDBUF", __func__);
-	if (eigrpd_privs.change(ZPRIVS_LOWER))
-		zlog_err("%s: could not lower privs, %s", __func__,
-			 safe_strerror(errno));
+		setsockopt_so_sendbuf(eigrp->fd, buflen);
+		newbuflen = getsockopt_so_sendbuf(eigrp->fd);
+		if (newbuflen < 0 || newbuflen < (int)buflen)
+			zlog_warn("%s: tried to set SO_SNDBUF to %u, but got %d",
+				  __func__, buflen, newbuflen);
+		if (newbuflen >= 0)
+			eigrp->maxsndbuflen = (unsigned int)newbuflen;
+		else
+			zlog_warn("%s: failed to get SO_SNDBUF", __func__);
+	}
 }
 
 int eigrp_if_ipmulticast(struct eigrp *top, struct prefix *p,

--- a/isisd/isis_bpf.c
+++ b/isisd/isis_bpf.c
@@ -191,7 +191,8 @@ int isis_sock_init(struct isis_circuit *circuit)
 		retval = open_bpf_dev(circuit);
 
 		if (retval != ISIS_OK) {
-			zlog_warn("%s: could not initialize the socket", __func__);
+			zlog_warn("%s: could not initialize the socket",
+				  __func__);
 			break;
 		}
 
@@ -203,8 +204,7 @@ int isis_sock_init(struct isis_circuit *circuit)
 			retval = ISIS_WARNING;
 			break;
 		}
-
-}
+	}
 
 	return retval;
 }

--- a/isisd/isis_bpf.c
+++ b/isisd/isis_bpf.c
@@ -186,30 +186,25 @@ int isis_sock_init(struct isis_circuit *circuit)
 {
 	int retval = ISIS_OK;
 
-	if (isisd_privs.change(ZPRIVS_RAISE))
-		zlog_err("%s: could not raise privs, %s", __func__,
-			 safe_strerror(errno));
+	frr_elevate_privs(&isisd_privs) {
 
-	retval = open_bpf_dev(circuit);
+		retval = open_bpf_dev(circuit);
 
-	if (retval != ISIS_OK) {
-		zlog_warn("%s: could not initialize the socket", __func__);
-		goto end;
-	}
+		if (retval != ISIS_OK) {
+			zlog_warn("%s: could not initialize the socket", __func__);
+			break;
+		}
 
-	if (if_is_broadcast(circuit->interface)) {
-		circuit->tx = isis_send_pdu_bcast;
-		circuit->rx = isis_recv_pdu_bcast;
-	} else {
-		zlog_warn("isis_sock_init(): unknown circuit type");
-		retval = ISIS_WARNING;
-		goto end;
-	}
+		if (if_is_broadcast(circuit->interface)) {
+			circuit->tx = isis_send_pdu_bcast;
+			circuit->rx = isis_recv_pdu_bcast;
+		} else {
+			zlog_warn("isis_sock_init(): unknown circuit type");
+			retval = ISIS_WARNING;
+			break;
+		}
 
-end:
-	if (isisd_privs.change(ZPRIVS_LOWER))
-		zlog_err("%s: could not lower privs, %s", __func__,
-			 safe_strerror(errno));
+}
 
 	return retval;
 }

--- a/isisd/isis_dlpi.c
+++ b/isisd/isis_dlpi.c
@@ -472,7 +472,8 @@ int isis_sock_init(struct isis_circuit *circuit)
 		retval = open_dlpi_dev(circuit);
 
 		if (retval != ISIS_OK) {
-			zlog_warn("%s: could not initialize the socket", __func__);
+			zlog_warn("%s: could not initialize the socket",
+				  __func__);
 			break;
 		}
 
@@ -484,8 +485,7 @@ int isis_sock_init(struct isis_circuit *circuit)
 			retval = ISIS_WARNING;
 			break;
 		}
-
-}
+	}
 
 	return retval;
 }

--- a/isisd/isis_pfpacket.c
+++ b/isisd/isis_pfpacket.c
@@ -189,7 +189,8 @@ int isis_sock_init(struct isis_circuit *circuit)
 		retval = open_packet_socket(circuit);
 
 		if (retval != ISIS_OK) {
-			zlog_warn("%s: could not initialize the socket", __func__);
+			zlog_warn("%s: could not initialize the socket",
+				  __func__);
 			break;
 		}
 
@@ -205,8 +206,7 @@ int isis_sock_init(struct isis_circuit *circuit)
 			retval = ISIS_WARNING;
 			break;
 		}
-
-}
+	}
 
 	return retval;
 }

--- a/isisd/isis_pfpacket.c
+++ b/isisd/isis_pfpacket.c
@@ -184,34 +184,29 @@ int isis_sock_init(struct isis_circuit *circuit)
 {
 	int retval = ISIS_OK;
 
-	if (isisd_privs.change(ZPRIVS_RAISE))
-		zlog_err("%s: could not raise privs, %s", __func__,
-			 safe_strerror(errno));
+	frr_elevate_privs(&isisd_privs) {
 
-	retval = open_packet_socket(circuit);
+		retval = open_packet_socket(circuit);
 
-	if (retval != ISIS_OK) {
-		zlog_warn("%s: could not initialize the socket", __func__);
-		goto end;
-	}
+		if (retval != ISIS_OK) {
+			zlog_warn("%s: could not initialize the socket", __func__);
+			break;
+		}
 
 	/* Assign Rx and Tx callbacks are based on real if type */
-	if (if_is_broadcast(circuit->interface)) {
-		circuit->tx = isis_send_pdu_bcast;
-		circuit->rx = isis_recv_pdu_bcast;
-	} else if (if_is_pointopoint(circuit->interface)) {
-		circuit->tx = isis_send_pdu_p2p;
-		circuit->rx = isis_recv_pdu_p2p;
-	} else {
-		zlog_warn("isis_sock_init(): unknown circuit type");
-		retval = ISIS_WARNING;
-		goto end;
-	}
+		if (if_is_broadcast(circuit->interface)) {
+			circuit->tx = isis_send_pdu_bcast;
+			circuit->rx = isis_recv_pdu_bcast;
+		} else if (if_is_pointopoint(circuit->interface)) {
+			circuit->tx = isis_send_pdu_p2p;
+			circuit->rx = isis_recv_pdu_p2p;
+		} else {
+			zlog_warn("isis_sock_init(): unknown circuit type");
+			retval = ISIS_WARNING;
+			break;
+		}
 
-end:
-	if (isisd_privs.change(ZPRIVS_LOWER))
-		zlog_err("%s: could not lower privs, %s", __func__,
-			 safe_strerror(errno));
+}
 
 	return retval;
 }

--- a/ldpd/socket.c
+++ b/ldpd/socket.c
@@ -262,17 +262,13 @@ int
 sock_set_bindany(int fd, int enable)
 {
 #ifdef HAVE_SO_BINDANY
-	if (ldpd_privs.change(ZPRIVS_RAISE))
-		log_warn("%s: could not raise privs", __func__);
-	if (setsockopt(fd, SOL_SOCKET, SO_BINDANY, &enable,
-	    sizeof(int)) < 0) {
-		if (ldpd_privs.change(ZPRIVS_LOWER))
-			log_warn("%s: could not lower privs", __func__);
-		log_warn("%s: error setting SO_BINDANY", __func__);
-		return (-1);
+	frr_elevate_privs(&ldpd_privs) {
+		if (setsockopt(fd, SOL_SOCKET, SO_BINDANY, &enable,
+			       sizeof(int)) < 0) {
+			log_warn("%s: error setting SO_BINDANY", __func__);
+			return (-1);
+		}
 	}
-	if (ldpd_privs.change(ZPRIVS_LOWER))
-		log_warn("%s: could not lower privs", __func__);
 	return (0);
 #elif defined(HAVE_IP_FREEBIND)
 	if (setsockopt(fd, IPPROTO_IP, IP_FREEBIND, &enable, sizeof(int)) < 0) {

--- a/lib/privs.h
+++ b/lib/privs.h
@@ -62,6 +62,7 @@ struct zebra_privs_t {
 	int (*change)(zebra_privs_ops_t); /* change privileges, 0 on success */
 	zebra_privs_current_t (*current_state)(
 		void); /* current privilege state */
+	const char *raised_in_funcname;
 };
 
 struct zprivs_ids_t {
@@ -80,5 +81,42 @@ extern void zprivs_init(struct zebra_privs_t *zprivs);
 extern void zprivs_terminate(struct zebra_privs_t *);
 /* query for runtime uid's and gid's, eg vty needs this */
 extern void zprivs_get_ids(struct zprivs_ids_t *);
+
+/*
+ * Wrapper around zprivs, to be used as:
+ *   frr_elevate_privs(&privs) {
+ *     ... code ...
+ *     if (error)
+ *       break;         -- break can be used to get out of the block
+ *     ... code ...
+ *   }
+ *
+ * The argument to frr_elevate_privs() can be NULL to leave privileges as-is
+ * (mostly useful for conditional privilege-raising, i.e.:)
+ *   frr_elevate_privs(cond ? &privs : NULL) {}
+ *
+ * NB: The code block is always executed, regardless of whether privileges
+ * could be raised or not, or whether NULL was given or not.  This is fully
+ * intentional;  the user may have configured some RBAC or similar that we
+ * are not aware of, but that allows our code to proceed without privileges.
+ *
+ * The point of this wrapper is to prevent accidental bugs where privileges
+ * are elevated but then not dropped.  This can happen when, for example, a
+ * "return", "goto" or "break" in the middle of the elevated-privilege code
+ * skips past the privilege dropping call.
+ *
+ * The macro below uses variable cleanup to drop privileges as soon as the
+ * code block is left in any way (and thus the _privs variable goes out of
+ * scope.)  _once is just a trick to run the loop exactly once.
+ */
+extern struct zebra_privs_t *_zprivs_raise(struct zebra_privs_t *privs,
+					   const char *funcname);
+extern void _zprivs_lower(struct zebra_privs_t **privs);
+
+#define frr_elevate_privs(privs) \
+	for (struct zebra_privs_t *_once = NULL, \
+			*_privs __attribute__((unused, cleanup(_zprivs_lower)))\
+				= _zprivs_raise(privs, __func__); \
+		_once == NULL; _once = (void *)1)
 
 #endif /* _ZEBRA_PRIVS_H */

--- a/lib/sockunion.c
+++ b/lib/sockunion.c
@@ -365,14 +365,10 @@ int sockopt_mark_default(int sock, int mark, struct zebra_privs_t *cap)
 #ifdef SO_MARK
 	int ret;
 
-	if (cap->change(ZPRIVS_RAISE))
-		zlog_err("routing_socket: Can't raise privileges");
-
-	ret = setsockopt(sock, SOL_SOCKET, SO_MARK, &mark, sizeof(mark));
-
-	if (cap->change(ZPRIVS_LOWER))
-		zlog_err("routing_socket: Can't lower privileges");
-
+	frr_elevate_privs(cap) {
+		ret = setsockopt(sock, SOL_SOCKET, SO_MARK, &mark,
+				 sizeof(mark));
+	}
 	return ret;
 #else
 	return 0;

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -758,16 +758,10 @@ DEFUN (vrf_netns,
 	if (!pathname)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	if (vrf_daemon_privs &&
-	    vrf_daemon_privs->change(ZPRIVS_RAISE))
-		zlog_err("%s: Can't raise privileges", __func__);
-
-	ret = vrf_netns_handler_create(vty, vrf, pathname,
-				       NS_UNKNOWN, NS_UNKNOWN);
-
-	if (vrf_daemon_privs &&
-	    vrf_daemon_privs->change(ZPRIVS_LOWER))
-		zlog_err("%s: Can't lower privileges", __func__);
+	frr_elevate_privs(vrf_daemon_privs) {
+		ret = vrf_netns_handler_create(vty, vrf, pathname,
+					       NS_UNKNOWN, NS_UNKNOWN);
+	}
 	return ret;
 }
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -212,9 +212,9 @@ int zclient_socket_connect(struct zclient *zclient)
 
 	set_cloexec(sock);
 
-	zclient->privs->change(ZPRIVS_RAISE);
-	setsockopt_so_sendbuf(sock, 1048576);
-	zclient->privs->change(ZPRIVS_LOWER);
+	frr_elevate_privs(zclient->privs) {
+		setsockopt_so_sendbuf(sock, 1048576);
+	}
 
 	/* Connect to zebra. */
 	ret = connect(sock, (struct sockaddr *)&zclient_addr, zclient_addr_len);

--- a/ospf6d/ospf6_network.c
+++ b/ospf6d/ospf6_network.c
@@ -75,18 +75,14 @@ static void ospf6_set_checksum(void)
 /* Make ospf6d's server socket. */
 int ospf6_serv_sock(void)
 {
-	if (ospf6d_privs.change(ZPRIVS_RAISE))
-		zlog_err("ospf6_serv_sock: could not raise privs");
+	frr_elevate_privs(&ospf6d_privs) {
 
-	ospf6_sock = socket(AF_INET6, SOCK_RAW, IPPROTO_OSPFIGP);
-	if (ospf6_sock < 0) {
-		zlog_warn("Network: can't create OSPF6 socket.");
-		if (ospf6d_privs.change(ZPRIVS_LOWER))
-			zlog_err("ospf_sock_init: could not lower privs");
-		return -1;
+		ospf6_sock = socket(AF_INET6, SOCK_RAW, IPPROTO_OSPFIGP);
+		if (ospf6_sock < 0) {
+			zlog_warn("Network: can't create OSPF6 socket.");
+			return -1;
+		}
 	}
-	if (ospf6d_privs.change(ZPRIVS_LOWER))
-		zlog_err("ospf_sock_init: could not lower privs");
 
 /* set socket options */
 #if 1

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -2087,25 +2087,17 @@ static int ospf_vrf_enable(struct vrf *vrf)
 				old_vrf_id);
 
 		if (old_vrf_id != ospf->vrf_id) {
-			if (ospfd_privs.change(ZPRIVS_RAISE)) {
-				zlog_err(
-					"ospf_sock_init: could not raise privs, %s",
-					safe_strerror(errno));
-			}
+			frr_elevate_privs(&ospfd_privs) {
+				/* stop zebra redist to us for old vrf */
+				zclient_send_dereg_requests(zclient,
+							    old_vrf_id);
 
-			/* stop zebra redist to us for old vrf */
-			zclient_send_dereg_requests(zclient, old_vrf_id);
+				ospf_set_redist_vrf_bitmaps(ospf);
 
-			ospf_set_redist_vrf_bitmaps(ospf);
+				/* start zebra redist to us for new vrf */
+				ospf_zebra_vrf_register(ospf);
 
-			/* start zebra redist to us for new vrf */
-			ospf_zebra_vrf_register(ospf);
-
-			ret = ospf_sock_init(ospf);
-			if (ospfd_privs.change(ZPRIVS_LOWER)) {
-				zlog_err(
-					"ospf_sock_init: could not lower privs, %s",
-					safe_strerror(errno));
+				ret = ospf_sock_init(ospf);
 			}
 			if (ret < 0 || ospf->fd <= 0)
 				return 0;

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -716,8 +716,8 @@ int pim_mroute_socket_enable(struct pim_instance *pim)
 
 #ifdef SO_BINDTODEVICE
 		if (pim->vrf->vrf_id != VRF_DEFAULT
-		    && setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, pim->vrf->name,
-				  strlen(pim->vrf->name))) {
+		    && setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
+				  pim->vrf->name, strlen(pim->vrf->name))) {
 			zlog_warn("Could not setsockopt SO_BINDTODEVICE: %s",
 				  safe_strerror(errno));
 			close(fd);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -55,27 +55,22 @@ static int pim_mroute_set(struct pim_instance *pim, int enable)
 	 * We need to create the VRF table for the pim mroute_socket
 	 */
 	if (pim->vrf_id != VRF_DEFAULT) {
-		if (pimd_privs.change(ZPRIVS_RAISE))
-			zlog_err(
-				"pim_mroute_socket_enable: could not raise privs, %s",
-				safe_strerror(errno));
+		frr_elevate_privs(&pimd_privs) {
 
-		opt = pim->vrf->data.l.table_id;
-		err = setsockopt(pim->mroute_socket, IPPROTO_IP, MRT_TABLE,
-				 &opt, opt_len);
-		if (err) {
-			zlog_warn(
-				"%s %s: failure: setsockopt(fd=%d,IPPROTO_IP, MRT_TABLE=%d): errno=%d: %s",
-				__FILE__, __PRETTY_FUNCTION__,
-				pim->mroute_socket, opt, errno,
-				safe_strerror(errno));
-			return -1;
+			opt = pim->vrf->data.l.table_id;
+			err = setsockopt(pim->mroute_socket, IPPROTO_IP,
+					 MRT_TABLE,
+					 &opt, opt_len);
+			if (err) {
+				zlog_warn(
+					  "%s %s: failure: setsockopt(fd=%d,IPPROTO_IP, MRT_TABLE=%d): errno=%d: %s",
+					  __FILE__, __PRETTY_FUNCTION__,
+					  pim->mroute_socket, opt, errno,
+					  safe_strerror(errno));
+				return -1;
+			}
+
 		}
-
-		if (pimd_privs.change(ZPRIVS_LOWER))
-			zlog_err(
-				"pim_mroute_socket_enable: could not lower privs, %s",
-				safe_strerror(errno));
 	}
 
 	opt = enable ? MRT_INIT : MRT_DONE;
@@ -708,32 +703,29 @@ int pim_mroute_socket_enable(struct pim_instance *pim)
 {
 	int fd;
 
-	if (pimd_privs.change(ZPRIVS_RAISE))
-		zlog_err("pim_mroute_socket_enable: could not raise privs, %s",
-			 safe_strerror(errno));
+	frr_elevate_privs(&pimd_privs) {
 
-	fd = socket(AF_INET, SOCK_RAW, IPPROTO_IGMP);
+		fd = socket(AF_INET, SOCK_RAW, IPPROTO_IGMP);
 
-	if (fd < 0) {
-		zlog_warn("Could not create mroute socket: errno=%d: %s", errno,
-			  safe_strerror(errno));
-		return -2;
-	}
+		if (fd < 0) {
+			zlog_warn("Could not create mroute socket: errno=%d: %s",
+				  errno,
+				  safe_strerror(errno));
+			return -2;
+		}
 
 #ifdef SO_BINDTODEVICE
-	if (pim->vrf->vrf_id != VRF_DEFAULT
-	    && setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, pim->vrf->name,
-			  strlen(pim->vrf->name))) {
-		zlog_warn("Could not setsockopt SO_BINDTODEVICE: %s",
-			  safe_strerror(errno));
-		close(fd);
-		return -3;
-	}
+		if (pim->vrf->vrf_id != VRF_DEFAULT
+		    && setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, pim->vrf->name,
+				  strlen(pim->vrf->name))) {
+			zlog_warn("Could not setsockopt SO_BINDTODEVICE: %s",
+				  safe_strerror(errno));
+			close(fd);
+			return -3;
+		}
 #endif
 
-	if (pimd_privs.change(ZPRIVS_LOWER))
-		zlog_err("pim_mroute_socket_enable: could not lower privs, %s",
-			 safe_strerror(errno));
+	}
 
 	pim->mroute_socket = fd;
 	if (pim_mroute_set(pim, 1)) {

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -167,17 +167,9 @@ int pim_msdp_sock_listen(struct pim_instance *pim)
 		}
 	}
 
-	if (pimd_privs.change(ZPRIVS_RAISE)) {
-		zlog_err("pim_msdp_socket: could not raise privs, %s",
-			 safe_strerror(errno));
-	}
-
-	/* bind to well known TCP port */
-	rc = bind(sock, (struct sockaddr *)&sin, socklen);
-
-	if (pimd_privs.change(ZPRIVS_LOWER)) {
-		zlog_err("pim_msdp_socket: could not lower privs, %s",
-			 safe_strerror(errno));
+	frr_elevate_privs(&pimd_privs) {
+		/* bind to well known TCP port */
+		rc = bind(sock, (struct sockaddr *)&sin, socklen);
 	}
 
 	if (rc < 0) {

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -45,15 +45,11 @@ int pim_socket_raw(int protocol)
 {
 	int fd;
 
-	if (pimd_privs.change(ZPRIVS_RAISE))
-		zlog_err("pim_sockek_raw: could not raise privs, %s",
-			 safe_strerror(errno));
+	frr_elevate_privs(&pimd_privs) {
 
-	fd = socket(AF_INET, SOCK_RAW, protocol);
+		fd = socket(AF_INET, SOCK_RAW, protocol);
 
-	if (pimd_privs.change(ZPRIVS_LOWER))
-		zlog_err("pim_socket_raw: could not lower privs, %s",
-			 safe_strerror(errno));
+	}
 
 	if (fd < 0) {
 		zlog_warn("Could not create raw socket: errno=%d: %s", errno,
@@ -68,17 +64,13 @@ void pim_socket_ip_hdr(int fd)
 {
 	const int on = 1;
 
-	if (pimd_privs.change(ZPRIVS_RAISE))
-		zlog_err("%s: could not raise privs, %s", __PRETTY_FUNCTION__,
-			 safe_strerror(errno));
+	frr_elevate_privs(&pimd_privs) {
 
-	if (setsockopt(fd, IPPROTO_IP, IP_HDRINCL, &on, sizeof(on)))
-		zlog_err("%s: Could not turn on IP_HDRINCL option: %s",
-			 __PRETTY_FUNCTION__, safe_strerror(errno));
+		if (setsockopt(fd, IPPROTO_IP, IP_HDRINCL, &on, sizeof(on)))
+			zlog_err("%s: Could not turn on IP_HDRINCL option: %s",
+				 __PRETTY_FUNCTION__, safe_strerror(errno));
 
-	if (pimd_privs.change(ZPRIVS_LOWER))
-		zlog_err("%s: could not lower privs, %s", __PRETTY_FUNCTION__,
-			 safe_strerror(errno));
+	}
 }
 
 /*
@@ -90,16 +82,12 @@ int pim_socket_bind(int fd, struct interface *ifp)
 	int ret = 0;
 #ifdef SO_BINDTODEVICE
 
-	if (pimd_privs.change(ZPRIVS_RAISE))
-		zlog_err("%s: could not raise privs, %s", __PRETTY_FUNCTION__,
-			 safe_strerror(errno));
+	frr_elevate_privs(&pimd_privs) {
 
-	ret = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, ifp->name,
-			 strlen(ifp->name));
+		ret = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, ifp->name,
+				 strlen(ifp->name));
 
-	if (pimd_privs.change(ZPRIVS_LOWER))
-		zlog_err("%s: could not lower privs, %s", __PRETTY_FUNCTION__,
-			 safe_strerror(errno));
+	}
 
 #endif
 	return ret;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1356,20 +1356,16 @@ static int rip_create_socket(void)
 
 	frr_elevate_privs(&ripd_privs) {
 		setsockopt_so_recvbuf(sock, RIP_UDP_RCV_BUF);
-		if ((ret = bind(sock, (struct sockaddr *)&addr, sizeof(addr))) < 0)
-
-		{
-			int save_errno = errno;
-
+		if ((ret = bind(sock, (struct sockaddr *)&addr, sizeof(addr)))
+		    < 0) {
 			zlog_err("%s: Can't bind socket %d to %s port %d: %s",
-				 __func__,
-				 sock, inet_ntoa(addr.sin_addr),
-				 (int)ntohs(addr.sin_port), safe_strerror(save_errno));
+				 __func__, sock, inet_ntoa(addr.sin_addr),
+				 (int)ntohs(addr.sin_port),
+				 safe_strerror(errno));
 
 			close(sock);
 			return ret;
 		}
-
 	}
 
 	return sock;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1354,26 +1354,23 @@ static int rip_create_socket(void)
 	setsockopt_ipv4_tos(sock, IPTOS_PREC_INTERNETCONTROL);
 #endif
 
-	if (ripd_privs.change(ZPRIVS_RAISE))
-		zlog_err("rip_create_socket: could not raise privs");
-	setsockopt_so_recvbuf(sock, RIP_UDP_RCV_BUF);
-	if ((ret = bind(sock, (struct sockaddr *)&addr, sizeof(addr))) < 0)
+	frr_elevate_privs(&ripd_privs) {
+		setsockopt_so_recvbuf(sock, RIP_UDP_RCV_BUF);
+		if ((ret = bind(sock, (struct sockaddr *)&addr, sizeof(addr))) < 0)
 
-	{
-		int save_errno = errno;
-		if (ripd_privs.change(ZPRIVS_LOWER))
-			zlog_err("rip_create_socket: could not lower privs");
+		{
+			int save_errno = errno;
 
-		zlog_err("%s: Can't bind socket %d to %s port %d: %s", __func__,
-			 sock, inet_ntoa(addr.sin_addr),
-			 (int)ntohs(addr.sin_port), safe_strerror(save_errno));
+			zlog_err("%s: Can't bind socket %d to %s port %d: %s",
+				 __func__,
+				 sock, inet_ntoa(addr.sin_addr),
+				 (int)ntohs(addr.sin_port), safe_strerror(save_errno));
 
-		close(sock);
-		return ret;
+			close(sock);
+			return ret;
+		}
+
 	}
-
-	if (ripd_privs.change(ZPRIVS_LOWER))
-		zlog_err("rip_create_socket: could not lower privs");
 
 	return sock;
 }

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -71,15 +71,14 @@ static int ripng_multicast_join(struct interface *ifp)
 		 * While this is bogus, privs are available and easy to use
 		 * for this call as a workaround.
 		 */
-		if (ripngd_privs.change(ZPRIVS_RAISE))
-			zlog_err("ripng_multicast_join: could not raise privs");
+		frr_elevate_privs(&ripngd_privs) {
 
-		ret = setsockopt(ripng->sock, IPPROTO_IPV6, IPV6_JOIN_GROUP,
-				 (char *)&mreq, sizeof(mreq));
-		save_errno = errno;
+			ret = setsockopt(ripng->sock, IPPROTO_IPV6,
+					 IPV6_JOIN_GROUP,
+					 (char *)&mreq, sizeof(mreq));
+			save_errno = errno;
 
-		if (ripngd_privs.change(ZPRIVS_LOWER))
-			zlog_err("ripng_multicast_join: could not lower privs");
+		}
 
 		if (ret < 0 && save_errno == EADDRINUSE) {
 			/*

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -124,18 +124,14 @@ static int ripng_make_socket(void)
 #endif /* SIN6_LEN */
 	ripaddr.sin6_port = htons(RIPNG_PORT_DEFAULT);
 
-	if (ripngd_privs.change(ZPRIVS_RAISE))
-		zlog_err("ripng_make_socket: could not raise privs");
+	frr_elevate_privs(&ripngd_privs) {
 
-	ret = bind(sock, (struct sockaddr *)&ripaddr, sizeof(ripaddr));
-	if (ret < 0) {
-		zlog_err("Can't bind ripng socket: %s.", safe_strerror(errno));
-		if (ripngd_privs.change(ZPRIVS_LOWER))
-			zlog_err("ripng_make_socket: could not lower privs");
-		goto error;
+		ret = bind(sock, (struct sockaddr *)&ripaddr, sizeof(ripaddr));
+		if (ret < 0) {
+			zlog_err("Can't bind ripng socket: %s.", safe_strerror(errno));
+			goto error;
+		}
 	}
-	if (ripngd_privs.change(ZPRIVS_LOWER))
-		zlog_err("ripng_make_socket: could not lower privs");
 	return sock;
 
 error:

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -125,10 +125,10 @@ static int ripng_make_socket(void)
 	ripaddr.sin6_port = htons(RIPNG_PORT_DEFAULT);
 
 	frr_elevate_privs(&ripngd_privs) {
-
 		ret = bind(sock, (struct sockaddr *)&ripaddr, sizeof(ripaddr));
 		if (ret < 0) {
-			zlog_err("Can't bind ripng socket: %s.", safe_strerror(errno));
+			zlog_err("Can't bind ripng socket: %s.",
+				 safe_strerror(errno));
 			goto error;
 		}
 	}

--- a/tests/lib/test_privs.c
+++ b/tests/lib/test_privs.c
@@ -113,10 +113,9 @@ int main(int argc, char **argv)
 	((test_privs.current_state() == ZPRIVS_RAISED) ? "Raised" : "Lowered")
 
 	printf("%s\n", PRIV_STATE());
-	test_privs.change(ZPRIVS_RAISE);
-
-	printf("%s\n", PRIV_STATE());
-	test_privs.change(ZPRIVS_LOWER);
+	frr_elevate_privs(&test_privs) {
+		printf("%s\n", PRIV_STATE());
+	}
 
 	printf("%s\n", PRIV_STATE());
 	zprivs_get_ids(&ids);
@@ -126,10 +125,9 @@ int main(int argc, char **argv)
 
 	/* but these should continue to work... */
 	printf("%s\n", PRIV_STATE());
-	test_privs.change(ZPRIVS_RAISE);
-
-	printf("%s\n", PRIV_STATE());
-	test_privs.change(ZPRIVS_LOWER);
+	frr_elevate_privs(&test_privs) {
+		printf("%s\n", PRIV_STATE());
+	}
 
 	printf("%s\n", PRIV_STATE());
 	zprivs_get_ids(&ids);

--- a/tools/zprivs.cocci
+++ b/tools/zprivs.cocci
@@ -1,0 +1,76 @@
+@@
+identifier change;
+identifier end;
+expression E, f, g;
+iterator name frr_elevate_privs;
+@@
+
+- if (E.change(ZPRIVS_RAISE))
+-   f;
++ frr_elevate_privs(&E) {
+  <+...
+-   goto end;
++   break;
+  ...+>
+- end:
+- if (E.change(ZPRIVS_LOWER))
+-   g;
++ }
+
+@@
+identifier change, errno, safe_strerror, exit;
+expression E, f1, f2, f3, ret, fn;
+iterator name frr_elevate_privs;
+@@
+
+  if (E.change(ZPRIVS_RAISE))
+    f1;
+  ...
+  if (...) {
+-   int save_errno = errno;
+    ...
+-   if (E.change(ZPRIVS_LOWER))
+-     f2;
+    ...
+-   safe_strerror(save_errno)
++   safe_strerror(errno)
+    ...
+    \( return ret; \| exit(ret); \)
+  }
+  ...
+  if (E.change(ZPRIVS_LOWER))
+    f3;
+
+@@
+identifier change;
+expression E, f1, f2, f3, ret;
+iterator name frr_elevate_privs;
+@@
+
+  if (E.change(ZPRIVS_RAISE))
+    f1;
+  ...
+  if (...) {
+    ...
+-   if (E.change(ZPRIVS_LOWER))
+-     f2;
+    ...
+    return ret;
+  }
+  ...
+  if (E.change(ZPRIVS_LOWER))
+    f3;
+
+@@
+identifier change;
+expression E, f, g;
+iterator name frr_elevate_privs;
+@@
+
+- if (E.change(ZPRIVS_RAISE))
+-   f;
++ frr_elevate_privs(&E) {
+  ...
+- if (E.change(ZPRIVS_LOWER))
+-   g;
++ }

--- a/zebra/if_ioctl_solaris.c
+++ b/zebra/if_ioctl_solaris.c
@@ -58,29 +58,24 @@ static int interface_list_ioctl(int af)
 	size_t needed, lastneeded = 0;
 	char *buf = NULL;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
+	frr_elevate_privs(&zserv_privs) {
 
-	sock = socket(af, SOCK_DGRAM, 0);
-	if (sock < 0) {
-		zlog_warn("Can't make %s socket stream: %s",
-			  (af == AF_INET ? "AF_INET" : "AF_INET6"),
-			  safe_strerror(errno));
+		sock = socket(af, SOCK_DGRAM, 0);
+		if (sock < 0) {
+			zlog_warn("Can't make %s socket stream: %s",
+				  (af == AF_INET ? "AF_INET" : "AF_INET6"),
+				  safe_strerror(errno));
 
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
-
-		return -1;
-	}
+			return -1;
+		}
 
 calculate_lifc_len: /* must hold privileges to enter here */
-	lifn.lifn_family = af;
-	lifn.lifn_flags = LIFC_NOXMIT; /* we want NOXMIT interfaces too */
-	ret = ioctl(sock, SIOCGLIFNUM, &lifn);
-	save_errno = errno;
+		lifn.lifn_family = af;
+		lifn.lifn_flags = LIFC_NOXMIT; /* we want NOXMIT interfaces too */
+		ret = ioctl(sock, SIOCGLIFNUM, &lifn);
+		save_errno = errno;
 
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	}
 
 	if (ret < 0) {
 		zlog_warn("interface_list_ioctl: SIOCGLIFNUM failed %s",

--- a/zebra/if_ioctl_solaris.c
+++ b/zebra/if_ioctl_solaris.c
@@ -59,19 +59,21 @@ static int interface_list_ioctl(int af)
 	char *buf = NULL;
 
 	frr_elevate_privs(&zserv_privs) {
-
 		sock = socket(af, SOCK_DGRAM, 0);
-		if (sock < 0) {
-			zlog_warn("Can't make %s socket stream: %s",
-				  (af == AF_INET ? "AF_INET" : "AF_INET6"),
-				  safe_strerror(errno));
+	}
 
-			return -1;
-		}
+	if (sock < 0) {
+		zlog_warn("Can't make %s socket stream: %s",
+			  (af == AF_INET ? "AF_INET" : "AF_INET6"),
+			  safe_strerror(errno));
+		return -1;
+	}
 
-calculate_lifc_len: /* must hold privileges to enter here */
+calculate_lifc_len:
+	frr_elevate_privs(&zserv_privs) {
 		lifn.lifn_family = af;
-		lifn.lifn_flags = LIFC_NOXMIT; /* we want NOXMIT interfaces too */
+		lifn.lifn_flags = LIFC_NOXMIT;
+		/* we want NOXMIT interfaces too */
 		ret = ioctl(sock, SIOCGLIFNUM, &lifn);
 		save_errno = errno;
 
@@ -108,26 +110,17 @@ calculate_lifc_len: /* must hold privileges to enter here */
 	lifconf.lifc_len = needed;
 	lifconf.lifc_buf = buf;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-
-	ret = ioctl(sock, SIOCGLIFCONF, &lifconf);
+	frr_elevate_privs(&zserv_privs) {
+		ret = ioctl(sock, SIOCGLIFCONF, &lifconf);
+	}
 
 	if (ret < 0) {
 		if (errno == EINVAL)
-			goto calculate_lifc_len; /* deliberately hold privileges
-						    */
+			goto calculate_lifc_len;
 
 		zlog_warn("SIOCGLIFCONF: %s", safe_strerror(errno));
-
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
-
 		goto end;
 	}
-
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 
 	/* Allocate interface. */
 	lifreq = lifconf.lifc_req;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -384,7 +384,8 @@ static int get_iflink_speed(struct interface *interface)
 			return 0;
 		}
 	/* Get the current link state for the interface */
-		rc = vrf_ioctl(interface->vrf_id, sd, SIOCETHTOOL, (char *)&ifdata);
+		rc = vrf_ioctl(interface->vrf_id, sd, SIOCETHTOOL,
+			       (char *)&ifdata);
 	}
 	if (rc < 0) {
 		if (IS_ZEBRA_DEBUG_KERNEL)

--- a/zebra/ioctl_solaris.c
+++ b/zebra/ioctl_solaris.c
@@ -57,24 +57,19 @@ int if_ioctl(unsigned long request, caddr_t buffer)
 	int ret;
 	int err;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
+	frr_elevate_privs(&zserv_privs) {
 
-	sock = socket(AF_INET, SOCK_DGRAM, 0);
-	if (sock < 0) {
-		int save_errno = errno;
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
-		zlog_err("Cannot create UDP socket: %s",
-			 safe_strerror(save_errno));
-		exit(1);
+		sock = socket(AF_INET, SOCK_DGRAM, 0);
+		if (sock < 0) {
+			zlog_err("Cannot create UDP socket: %s",
+				 safe_strerror(errno));
+			exit(1);
+		}
+
+		if ((ret = ioctl(sock, request, buffer)) < 0)
+			err = errno;
+
 	}
-
-	if ((ret = ioctl(sock, request, buffer)) < 0)
-		err = errno;
-
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 
 	close(sock);
 
@@ -92,24 +87,19 @@ int if_ioctl_ipv6(unsigned long request, caddr_t buffer)
 	int ret;
 	int err;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
+	frr_elevate_privs(&zserv_privs) {
 
-	sock = socket(AF_INET6, SOCK_DGRAM, 0);
-	if (sock < 0) {
-		int save_errno = errno;
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
-		zlog_err("Cannot create IPv6 datagram socket: %s",
-			 safe_strerror(save_errno));
-		exit(1);
+		sock = socket(AF_INET6, SOCK_DGRAM, 0);
+		if (sock < 0) {
+			zlog_err("Cannot create IPv6 datagram socket: %s",
+				 safe_strerror(errno));
+			exit(1);
+		}
+
+		if ((ret = ioctl(sock, request, buffer)) < 0)
+			err = errno;
+
 	}
-
-	if ((ret = ioctl(sock, request, buffer)) < 0)
-		err = errno;
-
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 
 	close(sock);
 

--- a/zebra/ipforward_proc.c
+++ b/zebra/ipforward_proc.c
@@ -76,24 +76,19 @@ int ipforward_on(void)
 {
 	FILE *fp;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges, %s", safe_strerror(errno));
+	frr_elevate_privs(&zserv_privs) {
 
-	fp = fopen(proc_ipv4_forwarding, "w");
+		fp = fopen(proc_ipv4_forwarding, "w");
 
-	if (fp == NULL) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges, %s",
-				 safe_strerror(errno));
-		return -1;
+		if (fp == NULL) {
+			return -1;
+		}
+
+		fprintf(fp, "1\n");
+
+		fclose(fp);
+
 	}
-
-	fprintf(fp, "1\n");
-
-	fclose(fp);
-
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges, %s", safe_strerror(errno));
 
 	return ipforward();
 }
@@ -102,24 +97,19 @@ int ipforward_off(void)
 {
 	FILE *fp;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges, %s", safe_strerror(errno));
+	frr_elevate_privs(&zserv_privs) {
 
-	fp = fopen(proc_ipv4_forwarding, "w");
+		fp = fopen(proc_ipv4_forwarding, "w");
 
-	if (fp == NULL) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges, %s",
-				 safe_strerror(errno));
-		return -1;
+		if (fp == NULL) {
+			return -1;
+		}
+
+		fprintf(fp, "0\n");
+
+		fclose(fp);
+
 	}
-
-	fprintf(fp, "0\n");
-
-	fclose(fp);
-
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges, %s", safe_strerror(errno));
 
 	return ipforward();
 }
@@ -153,24 +143,19 @@ int ipforward_ipv6_on(void)
 {
 	FILE *fp;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges, %s", safe_strerror(errno));
+	frr_elevate_privs(&zserv_privs) {
 
-	fp = fopen(proc_ipv6_forwarding, "w");
+		fp = fopen(proc_ipv6_forwarding, "w");
 
-	if (fp == NULL) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges, %s",
-				 safe_strerror(errno));
-		return -1;
+		if (fp == NULL) {
+			return -1;
+		}
+
+		fprintf(fp, "1\n");
+
+		fclose(fp);
+
 	}
-
-	fprintf(fp, "1\n");
-
-	fclose(fp);
-
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges, %s", safe_strerror(errno));
 
 	return ipforward_ipv6();
 }
@@ -180,24 +165,19 @@ int ipforward_ipv6_off(void)
 {
 	FILE *fp;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges, %s", safe_strerror(errno));
+	frr_elevate_privs(&zserv_privs) {
 
-	fp = fopen(proc_ipv6_forwarding, "w");
+		fp = fopen(proc_ipv6_forwarding, "w");
 
-	if (fp == NULL) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges, %s",
-				 safe_strerror(errno));
-		return -1;
+		if (fp == NULL) {
+			return -1;
+		}
+
+		fprintf(fp, "0\n");
+
+		fclose(fp);
+
 	}
-
-	fprintf(fp, "0\n");
-
-	fclose(fp);
-
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges, %s", safe_strerror(errno));
 
 	return ipforward_ipv6();
 }

--- a/zebra/ipforward_solaris.c
+++ b/zebra/ipforward_solaris.c
@@ -81,27 +81,21 @@ static int solaris_nd(const int cmd, const char *parameter, const int value)
 	strioctl.ic_len = ND_BUFFER_SIZE;
 	strioctl.ic_dp = nd_buf;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("solaris_nd: Can't raise privileges");
-	if ((fd = open(device, O_RDWR)) < 0) {
-		zlog_warn("failed to open device %s - %s", device,
-			  safe_strerror(errno));
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("solaris_nd: Can't lower privileges");
-		return -1;
-	}
-	if (ioctl(fd, I_STR, &strioctl) < 0) {
-		int save_errno = errno;
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("solaris_nd: Can't lower privileges");
+	frr_elevate_privs(&zserv_privs) {
+		if ((fd = open(device, O_RDWR)) < 0) {
+			zlog_warn("failed to open device %s - %s", device,
+				  safe_strerror(errno));
+			return -1;
+		}
+		if (ioctl(fd, I_STR, &strioctl) < 0) {
+			close(fd);
+			zlog_warn("ioctl I_STR failed on device %s - %s",
+				  device,
+				  safe_strerror(errno));
+			return -1;
+		}
 		close(fd);
-		zlog_warn("ioctl I_STR failed on device %s - %s", device,
-			  safe_strerror(save_errno));
-		return -1;
 	}
-	close(fd);
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("solaris_nd: Can't lower privileges");
 
 	if (cmd == ND_GET) {
 		errno = 0;

--- a/zebra/ipforward_sysctl.c
+++ b/zebra/ipforward_sysctl.c
@@ -108,7 +108,8 @@ int ipforward_ipv6_on(void)
 
 	len = sizeof ip6forwarding;
 	frr_elevate_privs(&zserv_privs) {
-		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len) < 0) {
+		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len)
+		    < 0) {
 			zlog_warn("can't get ip6forwarding value");
 			return -1;
 		}
@@ -123,7 +124,8 @@ int ipforward_ipv6_off(void)
 
 	len = sizeof ip6forwarding;
 	frr_elevate_privs(&zserv_privs) {
-		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len) < 0) {
+		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len)
+		    < 0) {
 			zlog_warn("can't get ip6forwarding value");
 			return -1;
 		}

--- a/zebra/ipforward_sysctl.c
+++ b/zebra/ipforward_sysctl.c
@@ -53,16 +53,12 @@ int ipforward_on(void)
 	int ipforwarding = 1;
 
 	len = sizeof ipforwarding;
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	if (sysctl(mib, MIB_SIZ, NULL, NULL, &ipforwarding, len) < 0) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
-		zlog_warn("Can't set ipforwarding on");
-		return -1;
+	frr_elevate_privs(&zserv_privs) {
+		if (sysctl(mib, MIB_SIZ, NULL, NULL, &ipforwarding, len) < 0) {
+			zlog_warn("Can't set ipforwarding on");
+			return -1;
+		}
 	}
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 	return ipforwarding;
 }
 
@@ -72,16 +68,12 @@ int ipforward_off(void)
 	int ipforwarding = 0;
 
 	len = sizeof ipforwarding;
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	if (sysctl(mib, MIB_SIZ, NULL, NULL, &ipforwarding, len) < 0) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
-		zlog_warn("Can't set ipforwarding on");
-		return -1;
+	frr_elevate_privs(&zserv_privs) {
+		if (sysctl(mib, MIB_SIZ, NULL, NULL, &ipforwarding, len) < 0) {
+			zlog_warn("Can't set ipforwarding on");
+			return -1;
+		}
 	}
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 	return ipforwarding;
 }
 
@@ -100,16 +92,12 @@ int ipforward_ipv6(void)
 	int ip6forwarding = 0;
 
 	len = sizeof ip6forwarding;
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	if (sysctl(mib_ipv6, MIB_SIZ, &ip6forwarding, &len, 0, 0) < 0) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
-		zlog_warn("can't get ip6forwarding value");
-		return -1;
+	frr_elevate_privs(&zserv_privs) {
+		if (sysctl(mib_ipv6, MIB_SIZ, &ip6forwarding, &len, 0, 0) < 0) {
+			zlog_warn("can't get ip6forwarding value");
+			return -1;
+		}
 	}
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 	return ip6forwarding;
 }
 
@@ -119,16 +107,12 @@ int ipforward_ipv6_on(void)
 	int ip6forwarding = 1;
 
 	len = sizeof ip6forwarding;
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len) < 0) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
-		zlog_warn("can't get ip6forwarding value");
-		return -1;
+	frr_elevate_privs(&zserv_privs) {
+		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len) < 0) {
+			zlog_warn("can't get ip6forwarding value");
+			return -1;
+		}
 	}
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 	return ip6forwarding;
 }
 
@@ -138,16 +122,12 @@ int ipforward_ipv6_off(void)
 	int ip6forwarding = 0;
 
 	len = sizeof ip6forwarding;
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len) < 0) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("Can't lower privileges");
-		zlog_warn("can't get ip6forwarding value");
-		return -1;
+	frr_elevate_privs(&zserv_privs) {
+		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len) < 0) {
+			zlog_warn("can't get ip6forwarding value");
+			return -1;
+		}
 	}
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 	return ip6forwarding;
 }
 

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -80,16 +80,12 @@ int irdp_sock_init(void)
 	int save_errno;
 	int sock;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("irdp_sock_init: could not raise privs, %s",
-			 safe_strerror(errno));
+	frr_elevate_privs(&zserv_privs) {
 
-	sock = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
-	save_errno = errno;
+		sock = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+		save_errno = errno;
 
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("irdp_sock_init: could not lower privs, %s",
-			 safe_strerror(errno));
+	}
 
 	if (sock < 0) {
 		zlog_warn("IRDP: can't create irdp socket %s",

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -202,33 +202,26 @@ static int netlink_socket(struct nlsock *nl, unsigned long groups,
 	struct sockaddr_nl snl;
 	int sock;
 	int namelen;
-	int save_errno;
 
-	if (zserv_privs.change(ZPRIVS_RAISE)) {
-		zlog_err("Can't raise privileges");
-		return -1;
+	frr_elevate_privs(&zserv_privs) {
+		sock = ns_socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE, ns_id);
+		if (sock < 0) {
+			zlog_err("Can't open %s socket: %s", nl->name,
+				 safe_strerror(errno));
+			return -1;
+		}
+
+		memset(&snl, 0, sizeof snl);
+		snl.nl_family = AF_NETLINK;
+		snl.nl_groups = groups;
+
+		/* Bind the socket to the netlink structure for anything. */
+		ret = bind(sock, (struct sockaddr *)&snl, sizeof snl);
 	}
-
-	sock = ns_socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE, ns_id);
-	if (sock < 0) {
-		zlog_err("Can't open %s socket: %s", nl->name,
-			 safe_strerror(errno));
-		return -1;
-	}
-
-	memset(&snl, 0, sizeof snl);
-	snl.nl_family = AF_NETLINK;
-	snl.nl_groups = groups;
-
-	/* Bind the socket to the netlink structure for anything. */
-	ret = bind(sock, (struct sockaddr *)&snl, sizeof snl);
-	save_errno = errno;
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 
 	if (ret < 0) {
 		zlog_err("Can't bind %s socket to group 0x%x: %s", nl->name,
-			 snl.nl_groups, safe_strerror(save_errno));
+			 snl.nl_groups, safe_strerror(errno));
 		close(sock);
 		return -1;
 	}
@@ -334,15 +327,15 @@ static void netlink_write_incoming(const char *buf, const unsigned int size,
 	char fname[MAXPATHLEN];
 	FILE *f;
 
-	zserv_privs.change(ZPRIVS_RAISE);
 	snprintf(fname, MAXPATHLEN, "%s/%s_%u", DAEMON_VTY_DIR, "netlink",
 		 counter);
-	f = fopen(fname, "w");
+	frr_elevate_privs(&zserv_privs) {
+		f = fopen(fname, "w");
+	}
 	if (f) {
 		fwrite(buf, 1, size, f);
 		fclose(f);
 	}
-	zserv_privs.change(ZPRIVS_LOWER);
 }
 
 /**
@@ -357,8 +350,9 @@ static long netlink_read_file(char *buf, const char *fname)
 	FILE *f;
 	long file_bytes = -1;
 
-	zserv_privs.change(ZPRIVS_RAISE);
-	f = fopen(fname, "r");
+	frr_elevate_privs(&zserv_privs) {
+		f = fopen(fname, "r");
+	}
 	if (f) {
 		fseek(f, 0, SEEK_END);
 		file_bytes = ftell(f);
@@ -366,7 +360,6 @@ static long netlink_read_file(char *buf, const char *fname)
 		fread(buf, NL_RCV_PKT_BUF_SIZE, 1, f);
 		fclose(f);
 	}
-	zserv_privs.change(ZPRIVS_LOWER);
 	return file_bytes;
 }
 
@@ -966,7 +959,6 @@ int netlink_request(struct nlsock *nl, struct nlmsghdr *n)
 {
 	int ret;
 	struct sockaddr_nl snl;
-	int save_errno;
 
 	/* Check netlink socket. */
 	if (nl->sock < 0) {
@@ -983,21 +975,14 @@ int netlink_request(struct nlsock *nl, struct nlmsghdr *n)
 	snl.nl_family = AF_NETLINK;
 
 	/* Raise capabilities and send message, then lower capabilities. */
-	if (zserv_privs.change(ZPRIVS_RAISE)) {
-		zlog_err("Can't raise privileges");
-		return -1;
+	frr_elevate_privs(&zserv_privs) {
+		ret = sendto(nl->sock, (void *)n, n->nlmsg_len, 0,
+			     (struct sockaddr *)&snl, sizeof snl);
 	}
-
-	ret = sendto(nl->sock, (void *)n, n->nlmsg_len, 0,
-		     (struct sockaddr *)&snl, sizeof snl);
-	save_errno = errno;
-
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
 
 	if (ret < 0) {
 		zlog_err("%s sendto failed: %s", nl->name,
-			 safe_strerror(save_errno));
+			 safe_strerror(errno));
 		return -1;
 	}
 

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -898,11 +898,11 @@ int netlink_talk(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 		 struct nlmsghdr *n, struct nlsock *nl, struct zebra_ns *zns,
 		 int startup)
 {
-	int status;
+	int status = 0;
 	struct sockaddr_nl snl;
 	struct iovec iov;
 	struct msghdr msg;
-	int save_errno;
+	int save_errno = 0;
 
 	memset(&snl, 0, sizeof snl);
 	memset(&iov, 0, sizeof iov);

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1382,15 +1382,11 @@ static int kernel_read(struct thread *thread)
 /* Make routing socket. */
 static void routing_socket(struct zebra_ns *zns)
 {
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("routing_socket: Can't raise privileges");
-
-	routing_sock =
-		ns_socket(AF_ROUTE, SOCK_RAW, 0, zns->ns_id);
+	frr_elevate_privs(&zserv_privs) {
+		routing_sock = ns_socket(AF_ROUTE, SOCK_RAW, 0, zns->ns_id);
+	}
 
 	if (routing_sock < 0) {
-		if (zserv_privs.change(ZPRIVS_LOWER))
-			zlog_err("routing_socket: Can't lower privileges");
 		zlog_warn("Can't init kernel routing socket");
 		return;
 	}
@@ -1401,9 +1397,6 @@ static void routing_socket(struct zebra_ns *zns)
 	 */
 	/*if (fcntl (routing_sock, F_SETFL, O_NONBLOCK) < 0)
 	  zlog_warn ("Can't set O_NONBLOCK to routing socket");*/
-
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("routing_socket: Can't lower privileges");
 
 	/* kernel_read needs rewrite. */
 	thread_add_read(zebrad.master, kernel_read, NULL, routing_sock, NULL);

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -400,17 +400,15 @@ enum dp_req_result kernel_route_rib(struct route_node *rn,
 		return DP_REQUEST_FAILURE;
 	}
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
+	frr_elevate_privs(&zserv_privs) {
 
-	if (old)
-		route |= kernel_rtm(RTM_DELETE, p, old);
+		if (old)
+			route |= kernel_rtm(RTM_DELETE, p, old);
 
-	if (new)
-		route |= kernel_rtm(RTM_ADD, p, new);
+		if (new)
+			route |= kernel_rtm(RTM_ADD, p, new);
 
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	}
 
 	if (new) {
 		kernel_route_rib_pass_fail(

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -624,7 +624,7 @@ static int rtadv_read(struct thread *thread)
 
 static int rtadv_make_socket(ns_id_t ns_id)
 {
-	int sock;
+	int sock = -1;
 	int ret = 0;
 	struct icmp6_filter filter;
 

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -628,15 +628,11 @@ static int rtadv_make_socket(ns_id_t ns_id)
 	int ret = 0;
 	struct icmp6_filter filter;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("rtadv_make_socket: could not raise privs, %s",
-			 safe_strerror(errno));
+	frr_elevate_privs(&zserv_privs) {
 
-	sock = ns_socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6, ns_id);
+		sock = ns_socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6, ns_id);
 
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("rtadv_make_socket: could not lower privs, %s",
-			 safe_strerror(errno));
+	}
 
 	if (sock < 0) {
 		return -1;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -3070,12 +3070,13 @@ static void zserv_write_incoming(struct stream *orig, uint16_t command)
 	copy = stream_dup(orig);
 	stream_set_getp(copy, 0);
 
-	zserv_privs.change(ZPRIVS_RAISE);
 	snprintf(fname, MAXPATHLEN, "%s/%u", DAEMON_VTY_DIR, command);
-	fd = open(fname, O_CREAT | O_WRONLY | O_EXCL, 0644);
+
+	frr_elevate_privs(&zserv_privs) {
+		fd = open(fname, O_CREAT | O_WRONLY | O_EXCL, 0644);
+	}
 	stream_flush(copy, fd);
 	close(fd);
-	zserv_privs.change(ZPRIVS_LOWER);
 	stream_free(copy);
 }
 #endif

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -116,11 +116,9 @@ static int kernel_send_rtmsg_v4(int action, mpls_label_t in_label,
 			hdr.rtm_mpls = MPLS_OP_SWAP;
 	}
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	ret = writev(kr_state.fd, iov, iovcnt);
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	frr_elevate_privs(&zserv_privs) {
+		ret = writev(kr_state.fd, iov, iovcnt);
+	}
 
 	if (ret == -1)
 		zlog_err("%s: %s", __func__, safe_strerror(errno));
@@ -224,11 +222,9 @@ static int kernel_send_rtmsg_v6(int action, mpls_label_t in_label,
 			hdr.rtm_mpls = MPLS_OP_SWAP;
 	}
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	ret = writev(kr_state.fd, iov, iovcnt);
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	frr_elevate_privs(&zserv_privs) {
+		ret = writev(kr_state.fd, iov, iovcnt);
+	}
 
 	if (ret == -1)
 		zlog_err("%s: %s", __func__, safe_strerror(errno));

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -75,11 +75,9 @@ static void zebra_ns_notify_create_context_from_entry_name(const char *name)
 	if (netnspath == NULL)
 		return;
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	ns_id = zebra_ns_id_get(netnspath);
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	frr_elevate_privs(&zserv_privs) {
+		ns_id = zebra_ns_id_get(netnspath);
+	}
 	if (ns_id == NS_UNKNOWN)
 		return;
 	ns_id_external = ns_map_nsid_with_external(ns_id, true);
@@ -96,12 +94,10 @@ static void zebra_ns_notify_create_context_from_entry_name(const char *name)
 		ns_map_nsid_with_external(ns_id, false);
 		return;
 	}
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	ret = vrf_netns_handler_create(NULL, vrf, netnspath,
-				       ns_id_external, ns_id);
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	frr_elevate_privs(&zserv_privs) {
+		ret = vrf_netns_handler_create(NULL, vrf, netnspath,
+					       ns_id_external, ns_id);
+	}
 	if (ret != CMD_SUCCESS) {
 		zlog_warn("NS notify : failed to create NS %s", netnspath);
 		ns_map_nsid_with_external(ns_id, false);
@@ -168,20 +164,16 @@ static int zebra_ns_ready_read(struct thread *t)
 	netnspath = zns_info->netnspath;
 	if (--zns_info->retries == 0)
 		stop_retry = 1;
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	err = ns_switch_to_netns(netnspath);
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	frr_elevate_privs(&zserv_privs) {
+		err = ns_switch_to_netns(netnspath);
+	}
 	if (err < 0)
 		return zebra_ns_continue_read(zns_info, stop_retry);
 
 	/* go back to default ns */
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	err = ns_switchback_to_initial();
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	frr_elevate_privs(&zserv_privs) {
+		err = ns_switchback_to_initial();
+	}
 	if (err < 0)
 		return zebra_ns_continue_read(zns_info, stop_retry);
 

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -314,11 +314,9 @@ int zebra_ns_init(void)
 
 	dzns = zebra_ns_alloc();
 
-	if (zserv_privs.change(ZPRIVS_RAISE))
-		zlog_err("Can't raise privileges");
-	ns_id = zebra_ns_id_get_default();
-	if (zserv_privs.change(ZPRIVS_LOWER))
-		zlog_err("Can't lower privileges");
+	frr_elevate_privs(&zserv_privs) {
+		ns_id = zebra_ns_id_get_default();
+	}
 	ns_id_external = ns_map_nsid_with_external(ns_id, true);
 	ns_init_management(ns_id_external, ns_id);
 


### PR DESCRIPTION
See comment in lib/zprivs.h.

```
/*
 * Wrapper around zprivs, to be used as:
 *   frr_elevate_privs(&privs) {
 *     ... code ...
 *     if (error)
 *       break;         -- break can be used to get out of the block
 *     ... code ...
 *   }
 *
 * The argument to frr_elevate_privs() can be NULL to leave privileges as-is
 * (mostly useful for conditional privilege-raising, i.e.:)
 *   frr_elevate_privs(cond ? &privs : NULL) {}
 *
 * NB: The code block is always executed, regardless of whether privileges
 * could be raised or not, or whether NULL was given or not.  This is fully
 * intentional;  the user may have configured some RBAC or similar that we
 * are not aware of, but that allows our code to proceed without privileges.
 *
 * The point of this wrapper is to prevent accidental bugs where privileges
 * are elevated but then not dropped.  This can happen when, for example, a
 * "return", "goto" or "break" in the middle of the elevated-privilege code
 * skips past the privilege dropping call.
 *
 * The macro below uses variable cleanup to drop privileges as soon as the
 * code block is left in any way (and thus the _privs variable goes out of
 * scope.)  _once is just a trick to run the loop exactly once.
 */
```