### PR TITLE
zebra: Add support for static encap mpls labels

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -472,9 +472,9 @@ void netlink_parse_rtattr(struct rtattr **tb, int max, struct rtattr *rta,
 
 /**
  * netlink_parse_rtattr_nested() - Parses a nested route attribute
- * @tb:		Pointer to array for storing rtattr in.
- * @max:	Max number to store.
- * @rta:	Pointer to rtattr to look for nested items in.
+ * @tb:         Pointer to array for storing rtattr in.
+ * @max:        Max number to store.
+ * @rta:        Pointer to rtattr to look for nested items in.
  */
 void netlink_parse_rtattr_nested(struct rtattr **tb, int max,
 				 struct rtattr *rta)

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -470,6 +470,18 @@ void netlink_parse_rtattr(struct rtattr **tb, int max, struct rtattr *rta,
 	}
 }
 
+/**
+ * netlink_parse_rtattr_nested() - Parses a nested route attribute
+ * @tb:		Pointer to array for storing rtattr in.
+ * @max:	Max number to store.
+ * @rta:	Pointer to rtattr to look for nested items in.
+ */
+void netlink_parse_rtattr_nested(struct rtattr **tb, int max,
+				 struct rtattr *rta)
+{
+	netlink_parse_rtattr(tb, max, RTA_DATA(rta), RTA_PAYLOAD(rta));
+}
+
 int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type,
 	      const void *data, unsigned int alen)
 {

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -28,6 +28,8 @@
 
 extern void netlink_parse_rtattr(struct rtattr **tb, int max,
 				 struct rtattr *rta, int len);
+extern void netlink_parse_rtattr_nested(struct rtattr **tb, int max,
+					struct rtattr *rta);
 extern int addattr_l(struct nlmsghdr *n, unsigned int maxlen, int type,
 		     const void *data, unsigned int alen);
 extern int rta_addattr_l(struct rtattr *rta, unsigned int maxlen, int type,

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -255,7 +255,8 @@ static vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
  */
 static int parse_encap_mpls(struct rtattr *tb, mpls_label_t *labels)
 {
-	struct rtattr *tb_encap[MPLS_IPTUNNEL_MAX + 1];
+	struct rtattr *tb_encap[MPLS_IPTUNNEL_MAX + 1] = {0};
+	mpls_lse_t *lses = NULL;
 	int num_labels = 0;
 	uint32_t ttl = 0;
 	uint32_t bos = 0;
@@ -263,10 +264,9 @@ static int parse_encap_mpls(struct rtattr *tb, mpls_label_t *labels)
 	mpls_label_t label = 0;
 
 	netlink_parse_rtattr_nested(tb_encap, MPLS_IPTUNNEL_MAX, tb);
-	while (!bos) {
-		mpls_lse_t lse =
-			*(mpls_label_t *)RTA_DATA(tb_encap[MPLS_IPTUNNEL_DST]);
-		mpls_lse_decode(lse, &label, &ttl, &exp, &bos);
+	lses = (mpls_lse_t *)RTA_DATA(tb_encap[MPLS_IPTUNNEL_DST]);
+	while (!bos && num_labels < MPLS_MAX_LABELS) {
+		mpls_lse_decode(lses[num_labels], &label, &ttl, &exp, &bos);
 		/* Encapped mpls messages come with a ttl associated with them
 		 * If there isn't one alread present in the label itself, we
 		 * re-encode it here with the one from the encap command.

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -248,10 +248,10 @@ static vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 
 /**
  * @parse_encap_mpls() - Parses encapsulated mpls attributes
- * @tb:		Pointer to rtattr to look for nested items in.
- * @labels	Pointer to store labels in.
+ * @tb:         Pointer to rtattr to look for nested items in.
+ * @labels:     Pointer to store labels in.
  *
- * Return:	Number of mpls labels found.
+ * Return:      Number of mpls labels found.
  */
 static int parse_encap_mpls(struct rtattr *tb, mpls_label_t *labels)
 {
@@ -271,11 +271,12 @@ static int parse_encap_mpls(struct rtattr *tb, mpls_label_t *labels)
 		 * If there isn't one alread present in the label itself, we
 		 * re-encode it here with the one from the encap command.
 		 */
-		if (!ttl && tb_encap[MPLS_IPTUNNEL_TTL])
+		if (!ttl && tb_encap[MPLS_IPTUNNEL_TTL]) {
 			ttl = *(uint32_t *)RTA_DATA(
 				tb_encap[MPLS_IPTUNNEL_TTL]);
-		mpls_lse_decode(mpls_lse_encode(label, ttl, exp, bos), &label,
-				&ttl, &exp, &bos);
+			mpls_lse_decode(mpls_lse_encode(label, ttl, exp, bos),
+					&label, &ttl, &exp, &bos);
+		}
 		labels[num_labels++] = label;
 	}
 	return num_labels;


### PR DESCRIPTION
We were ignoring mpls labels encapped with static routes.
Added support for single and multipath labels.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>