### PR TITLE
bgpd: issues with vrf imports when switchd or networking restarted

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -275,6 +275,10 @@ static int bgp_vrf_enable(struct vrf *vrf)
 		bgp_instance_up(bgp);
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP);
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP6);
+		vpn_leak_to_vrf_update_all(bgp, bgp_get_default(), AFI_IP);
+		vpn_leak_from_vrf_update_all(bgp, bgp_get_default(), AFI_IP);
+		vpn_leak_to_vrf_update_all(bgp, bgp_get_default(), AFI_IP6);
+		vpn_leak_from_vrf_update_all(bgp, bgp_get_default(), AFI_IP6);
 	}
 
 	return 0;
@@ -296,6 +300,10 @@ static int bgp_vrf_disable(struct vrf *vrf)
 
 		vpn_leak_zebra_vrf_label_withdraw(bgp, AFI_IP);
 		vpn_leak_zebra_vrf_label_withdraw(bgp, AFI_IP6);
+		vpn_leak_to_vrf_withdraw_all(bgp, AFI_IP);
+		vpn_leak_to_vrf_withdraw_all(bgp, AFI_IP6);
+		vpn_leak_from_vrf_withdraw_all(bgp_get_default(), bgp, AFI_IP);
+		vpn_leak_from_vrf_withdraw_all(bgp_get_default(), bgp, AFI_IP6);
 
 		old_vrf_id = bgp->vrf_id;
 		bgp_handle_socket(bgp, vrf, VRF_UNKNOWN, false);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -577,7 +577,7 @@ leak_update(
 			zlog_debug("%s: ->%s: %s Found route, changed attr",
 				   __func__, bgp->name_pretty, buf_prefix);
 
-		return NULL;
+		return bi;
 	}
 
 	new = info_make(ZEBRA_ROUTE_BGP, BGP_ROUTE_IMPORTED, 0,

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -151,6 +151,12 @@ static inline int vpn_leak_from_vpn_active(struct bgp *bgp_vrf, afi_t afi,
 		return 0;
 	}
 
+	if (bgp_vrf->vrf_id == VRF_UNKNOWN) {
+		if (pmsg)
+			*pmsg = "destination bgp instance vrf is VRF_UNKNOWN";
+		return 0;
+	}
+
 	/* Is vrf configured to import from vpn? */
 	if (!CHECK_FLAG(bgp_vrf->af_flags[afi][SAFI_UNICAST],
 			BGP_CONFIG_MPLSVPN_TO_VRF_IMPORT)


### PR DESCRIPTION
Problem reported that when systemctl restart networking or switchd
performed, not all imported prefixes were successfully restored.

Ticket: CM-21684
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
