### PR TITLE
bgpd: return value check (Coverity 1472310)

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -621,7 +621,7 @@ static int bgp_debug_parse_evpn_prefix(struct vty *vty, struct cmd_token **argv,
 		memset(&ip, 0, sizeof(struct ipaddr));
 
 		argv_find(argv, argc, "mac", &mac_idx);
-		prefix_str2mac(argv[mac_idx + 1]->arg, &mac);
+		(void)prefix_str2mac(argv[mac_idx + 1]->arg, &mac);
 
 		argv_find(argv, argc, "ip", &ip_idx);
 		str2ipaddr(argv[ip_idx + 1]->arg, &ip);


### PR DESCRIPTION
At first glance, evident corrections (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr