### PR TITLE
staticd: null check (Coverity 1472311)

### DIFF
--- a/staticd/static_nht.c
+++ b/staticd/static_nht.c
@@ -42,7 +42,7 @@ void static_nht_update(struct prefix *p, uint32_t nh_num,
 
 	vrf = vrf_lookup_by_id(vrf_id);
 
-	if (!vrf->info)
+	if (!vrf || !vrf->info)
 		return;
 
 	svrf = vrf->info;


### PR DESCRIPTION
At first glance, an evident correction (FRR Coverity open issues [1]).

[1] https://scan.coverity.com/projects/freerangerouting-frr