### PR TITLE
ospf6d: revert fix for Coverity 1221459

### DIFF
--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -347,7 +347,6 @@ void ospf6_flood_interface(struct ospf6_neighbor *from, struct ospf6_lsa *lsa,
 							"Received is newer, remove requesting");
 					if (req == on->last_ls_req) {
 						ospf6_lsa_unlock(req);
-						req = NULL;
 						on->last_ls_req = NULL;
 					}
 					if (req)


### PR DESCRIPTION
The correction in commit 7edb6aa (PR #2502) was wrong, as it is was not
taking in consideration the unlock counter. Thanks to @eqvinox for noticing
it.
