### PR TITLE
zebra: remove unguarded debugging leftovers

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2354,7 +2354,6 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 	/* Lookup route node.*/
 	rn = srcdest_rnode_get(table, p, src_p);
 
-	zlog_debug("Distance: %d", re->distance);
 	/*
 	 * If same type of route are installed, treat it as a implicit
 	 * withdraw.
@@ -2386,7 +2385,6 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 			break;
 	}
 
-	zlog_debug("same: %p distance: %d", same, same ? same->distance : -1);
 	/* If this route is kernel route, set FIB flag to the route. */
 	if (RIB_SYSTEM_ROUTE(re))
 		for (nexthop = re->ng.nexthop; nexthop; nexthop = nexthop->next)


### PR DESCRIPTION
These debug messages were committed by accident.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>