### PR TITLE
lib, ripngd, zebra: Remove pre-solaris 9 special cased code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1194,33 +1194,6 @@ case "$host_os" in
 esac
 AC_DEFINE_UNQUOTED(ISIS_METHOD, $ISIS_METHOD_MACRO, [ selected method for isis, == one of the constants ])
 
-dnl ------------------------------------
-dnl check for broken CMSG_FIRSTHDR macro
-dnl ------------------------------------
-AC_MSG_CHECKING(for broken CMSG_FIRSTHDR)
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#ifdef SUNOS_5
-#define _XPG4_2
-#define __EXTENSIONS__
-#endif
-#include <stdlib.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-
-main()
-{
-  struct msghdr msg;
-  char buf[4];
-
-  msg.msg_control = buf;
-  msg.msg_controllen = 0;
-
-  if (CMSG_FIRSTHDR(&msg) != NULL)
-    exit(0);
-  exit (1);
-}]])],[AC_MSG_RESULT(yes - using workaround) AC_DEFINE(HAVE_BROKEN_CMSG_FIRSTHDR,,Broken CMSG_FIRSTHDR)],
-[AC_MSG_RESULT(no)],[AC_MSG_RESULT(no)])
-
 dnl ---------------------------------------------------------------
 dnl figure out how to specify an interface in multicast sockets API
 dnl ---------------------------------------------------------------

--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -73,7 +73,7 @@ static void *getsockopt_cmsg_data(struct msghdr *msgh, int level, int type)
 	struct cmsghdr *cmsg;
 	void *ptr = NULL;
 
-	for (cmsg = ZCMSG_FIRSTHDR(msgh); cmsg != NULL;
+	for (cmsg = CMSG_FIRSTHDR(msgh); cmsg != NULL;
 	     cmsg = CMSG_NXTHDR(msgh, cmsg))
 		if (cmsg->cmsg_level == level && cmsg->cmsg_type == type)
 			return (ptr = CMSG_DATA(cmsg));

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -242,23 +242,6 @@ size_t strlcpy(char *__restrict dest,
 	       const char *__restrict src, size_t destsize);
 #endif
 
-#ifdef HAVE_BROKEN_CMSG_FIRSTHDR
-/* This bug is present in Solaris 8 and pre-patch Solaris 9 <sys/socket.h>;
-   please refer to http://bugzilla.quagga.net/show_bug.cgi?id=142 */
-
-/* Check that msg_controllen is large enough. */
-#define ZCMSG_FIRSTHDR(mhdr)                                                   \
-	(((size_t)((mhdr)->msg_controllen) >= sizeof(struct cmsghdr))          \
-		 ? CMSG_FIRSTHDR(mhdr)                                         \
-		 : (struct cmsghdr *)NULL)
-
-#warning "CMSG_FIRSTHDR is broken on this platform, using a workaround"
-
-#else  /* HAVE_BROKEN_CMSG_FIRSTHDR */
-#define ZCMSG_FIRSTHDR(M) CMSG_FIRSTHDR(M)
-#endif /* HAVE_BROKEN_CMSG_FIRSTHDR */
-
-
 /* GCC have printf type attribute check.  */
 #ifdef __GNUC__
 #define PRINTF_ATTRIBUTE(a,b) __attribute__ ((__format__ (__printf__, a, b)))

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -246,7 +246,7 @@ static int ripng_recv_packet(int sock, uint8_t *buf, int bufsize,
 	if (ret < 0)
 		return ret;
 
-	for (cmsgptr = ZCMSG_FIRSTHDR(&msg); cmsgptr != NULL;
+	for (cmsgptr = CMSG_FIRSTHDR(&msg); cmsgptr != NULL;
 	     cmsgptr = CMSG_NXTHDR(&msg, cmsgptr)) {
 		/* I want interface index which this packet comes from. */
 		if (cmsgptr->cmsg_level == IPPROTO_IPV6

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -123,7 +123,7 @@ static int rtadv_recv_packet(struct zebra_ns *zns, int sock, uint8_t *buf,
 	if (ret < 0)
 		return ret;
 
-	for (cmsgptr = ZCMSG_FIRSTHDR(&msg); cmsgptr != NULL;
+	for (cmsgptr = CMSG_FIRSTHDR(&msg); cmsgptr != NULL;
 	     cmsgptr = CMSG_NXTHDR(&msg, cmsgptr)) {
 		/* I want interface index which this packet comes from. */
 		if (cmsgptr->cmsg_level == IPPROTO_IPV6
@@ -362,7 +362,7 @@ static void rtadv_send_packet(int sock, struct interface *ifp)
 	iov.iov_base = buf;
 	iov.iov_len = len;
 
-	cmsgptr = ZCMSG_FIRSTHDR(&msg);
+	cmsgptr = CMSG_FIRSTHDR(&msg);
 	cmsgptr->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
 	cmsgptr->cmsg_level = IPPROTO_IPV6;
 	cmsgptr->cmsg_type = IPV6_PKTINFO;


### PR DESCRIPTION
The CMSG_FIRSTHDR was broken on solaris pre version 9.  Version 9
was released in May of 2002 and EOL'ed in 2014.  Version 8 EOL'ed
in 2012.  Remove special case code for a little used platform
that has not seen the light of day in a very long time.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>