### PR TITLE
Backet data

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3526,14 +3526,7 @@ static int delete_withdraw_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
  */
 static void update_router_id_vni(struct hash_backet *backet, struct bgp *bgp)
 {
-	struct bgpevpn *vpn;
-
-	vpn = (struct bgpevpn *)backet->data;
-
-	if (!vpn) {
-		zlog_warn("%s: VNI hash entry for VNI not found", __FUNCTION__);
-		return;
-	}
+	struct bgpevpn *vpn = (struct bgpevpn *)backet->data;
 
 	/* Skip VNIs with configured RD. */
 	if (is_rd_configured(vpn))
@@ -3551,14 +3544,7 @@ static void update_router_id_vni(struct hash_backet *backet, struct bgp *bgp)
  */
 static void withdraw_router_id_vni(struct hash_backet *backet, struct bgp *bgp)
 {
-	struct bgpevpn *vpn;
-
-	vpn = (struct bgpevpn *)backet->data;
-
-	if (!vpn) {
-		zlog_warn("%s: VNI hash entry for VNI not found", __FUNCTION__);
-		return;
-	}
+	struct bgpevpn *vpn = (struct bgpevpn *)backet->data;
 
 	/* Skip VNIs with configured RD. */
 	if (is_rd_configured(vpn))
@@ -3993,9 +3979,8 @@ static void cleanup_vni_on_disable(struct hash_backet *backet, struct bgp *bgp)
  */
 static void free_vni_entry(struct hash_backet *backet, struct bgp *bgp)
 {
-	struct bgpevpn *vpn;
+	struct bgpevpn *vpn = (struct bgpevpn *)backet->data;
 
-	vpn = (struct bgpevpn *)backet->data;
 	delete_all_vni_routes(bgp, vpn);
 	bgp_evpn_free(bgp, vpn);
 }
@@ -4066,11 +4051,6 @@ static void bgp_evpn_handle_export_rt_change_for_vrf(struct bgp *bgp_vrf)
 static void update_autort_vni(struct hash_backet *backet, struct bgp *bgp)
 {
 	struct bgpevpn *vpn = backet->data;
-
-	if (!vpn) {
-		zlog_warn("%s: VNI hash entry for VNI not found", __PRETTY_FUNCTION__);
-		return;
-	}
 
 	if (!is_import_rt_configured(vpn)) {
 		if (is_vni_live(vpn))
@@ -5221,13 +5201,12 @@ int bgp_evpn_local_macip_add(struct bgp *bgp, vni_t vni, struct ethaddr *mac,
 static void link_l2vni_hash_to_l3vni(struct hash_backet *backet,
 				     struct bgp *bgp_vrf)
 {
-	struct bgpevpn *vpn = NULL;
+	struct bgpevpn *vpn = (struct bgpevpn *)backet->data;
 	struct bgp *bgp_def = NULL;
 
 	bgp_def = bgp_get_default();
 	assert(bgp_def);
 
-	vpn = (struct bgpevpn *)backet->data;
 	if (vpn->tenant_vrf_id == bgp_vrf->vrf_id)
 		bgpevpn_link_to_l3vni(vpn);
 }

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -167,7 +167,9 @@ hash_create_size(unsigned int size, unsigned int (*hash_key)(void *),
  *    hash table to operate on
  *
  * data
- *    data to insert or retrieve
+ *    data to insert or retrieve - A hash backet will not be created if
+ *    the alloc_func returns a NULL pointer and nothing will be added to
+ *    the hash.  As such backet->data will always be non-NULL.
  *
  * alloc_func
  *    function to call if the item is not found in the hash table. This
@@ -236,6 +238,8 @@ extern void *hash_release(struct hash *hash, void *data);
  * during the walk will cause undefined behavior in that some new entries
  * will be walked and some will not.  So do not do this.
  *
+ * The backet passed to func will have a non-NULL data pointer.
+ *
  * hash
  *    hash table to operate on
  *
@@ -255,6 +259,8 @@ extern void hash_iterate(struct hash *hash,
  * table during iteration.  Please note that adding entries to the hash
  * during the walk will cause undefined behavior in that some new entries
  * will be walked and some will not.  So do not do this.
+ *
+ * The backet passed to func will have a non-NULL data pointer.
  *
  * hash
  *    hash table to operate on

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1545,7 +1545,7 @@ static void route_map_clear_reference(struct hash_backet *backet, void *arg)
 	struct route_map_dep *dep = (struct route_map_dep *)backet->data;
 	char *rmap_name;
 
-	if (dep && arg) {
+	if (arg) {
 		rmap_name =
 			(char *)hash_release(dep->dep_rmap_hash, (void *)arg);
 		if (rmap_name) {
@@ -1601,9 +1601,8 @@ static void route_map_print_dependency(struct hash_backet *backet, void *data)
 	char *rmap_name = (char *)backet->data;
 	char *dep_name = (char *)data;
 
-	if (rmap_name)
-		zlog_debug("%s: Dependency for %s: %s", __FUNCTION__, dep_name,
-			   rmap_name);
+	zlog_debug("%s: Dependency for %s: %s", __FUNCTION__, dep_name,
+		   rmap_name);
 }
 
 static int route_map_dep_update(struct hash *dephash, const char *dep_name,
@@ -1725,18 +1724,14 @@ static struct hash *route_map_get_dep_hash(route_map_event_t event)
 
 static void route_map_process_dependency(struct hash_backet *backet, void *data)
 {
-	char *rmap_name;
+	char *rmap_name = (char *)backet->data;
 	route_map_event_t type = (route_map_event_t)(ptrdiff_t)data;
 
-	rmap_name = (char *)backet->data;
-
-	if (rmap_name) {
-		if (rmap_debug)
-			zlog_debug("%s: Notifying %s of dependency",
-				   __FUNCTION__, rmap_name);
-		if (route_map_master.event_hook)
-			(*route_map_master.event_hook)(type, rmap_name);
-	}
+	if (rmap_debug)
+		zlog_debug("%s: Notifying %s of dependency",
+			   __FUNCTION__, rmap_name);
+	if (route_map_master.event_hook)
+		(*route_map_master.event_hook)(type, rmap_name);
 }
 
 void route_map_upd8_dependency(route_map_event_t type, const char *arg,

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -1524,10 +1524,6 @@ static void ospf_sr_nhlfe_update(struct hash_backet *backet, void *args)
 	struct sr_nhlfe old;
 	int rc;
 
-	/* Sanity Check */
-	if (srn == NULL)
-		return;
-
 	if (IS_DEBUG_OSPF_SR)
 		zlog_debug("  |-  Update Prefix for SR Node %s",
 			   inet_ntoa(srn->adv_router));

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2795,9 +2795,6 @@ static int pim_print_pnc_cache_walkcb(struct hash_backet *backet, void *arg)
 	ifindex_t first_ifindex;
 	struct interface *ifp = NULL;
 
-	if (!pnc)
-		return CMD_SUCCESS;
-
 	for (nh_node = pnc->nexthop; nh_node; nh_node = nh_node->next) {
 		first_ifindex = nh_node->ifindex;
 		ifp = if_lookup_by_index(first_ifindex, pim->vrf_id);

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2433,7 +2433,7 @@ void mpls_ldp_lsp_uninstall_all(struct hash_backet *backet, void *ctxt)
 	struct hash *lsp_table;
 
 	lsp = (zebra_lsp_t *)backet->data;
-	if (!lsp || !lsp->nhlfe_list)
+	if (!lsp->nhlfe_list)
 		return;
 
 	lsp_table = ctxt;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -280,8 +280,6 @@ static void zvni_find_neigh_addr_width(struct hash_backet *backet, void *ctxt)
 	int width;
 
 	n = (zebra_neigh_t *)backet->data;
-	if (!n)
-		return;
 
 	ipaddr2str(&n->ip, buf, sizeof(buf)), width = strlen(buf);
 	if (width > wctx->addr_width)
@@ -355,8 +353,6 @@ static void zvni_print_neigh_hash(struct hash_backet *backet, void *ctxt)
 	vty = wctx->vty;
 	json_vni = wctx->json;
 	n = (zebra_neigh_t *)backet->data;
-	if (!n)
-		return;
 
 	if (json_vni)
 		json_row = json_object_new_object();
@@ -435,11 +431,7 @@ static void zvni_print_neigh_hash_all_vni(struct hash_backet *backet,
 	json = (json_object *)args[1];
 
 	zvni = (zebra_vni_t *)backet->data;
-	if (!zvni) {
-		if (json)
-			vty_out(vty, "{}\n");
-		return;
-	}
+
 	num_neigh = hashcount(zvni->neigh_table);
 	if (json == NULL) {
 		vty_out(vty,
@@ -628,8 +620,6 @@ static void zvni_print_mac_hash(struct hash_backet *backet, void *ctxt)
 	vty = wctx->vty;
 	json_mac_hdr = wctx->json;
 	mac = (zebra_mac_t *)backet->data;
-	if (!mac)
-		return;
 
 	prefix_mac2str(&mac->macaddr, buf1, sizeof(buf1));
 
@@ -735,11 +725,6 @@ static void zvni_print_mac_hash_all_vni(struct hash_backet *backet, void *ctxt)
 	json = (struct json_object *)wctx->json;
 
 	zvni = (zebra_vni_t *)backet->data;
-	if (!zvni) {
-		if (json)
-			vty_out(vty, "{}\n");
-		return;
-	}
 	wctx->zvni = zvni;
 
 	/*We are iterating over a new VNI, set the count to 0*/
@@ -794,8 +779,6 @@ static void zl3vni_print_nh_hash(struct hash_backet *backet, void *ctx)
 	if (json_vni)
 		json_nh = json_object_new_object();
 	n = (zebra_neigh_t *)backet->data;
-	if (!n)
-		return;
 
 	if (!json_vni) {
 		vty_out(vty, "%-15s %-17s\n",
@@ -828,11 +811,6 @@ static void zl3vni_print_nh_hash_all_vni(struct hash_backet *backet,
 	json = (struct json_object *)args[1];
 
 	zl3vni = (zebra_l3vni_t *)backet->data;
-	if (!zl3vni) {
-		if (json)
-			vty_out(vty, "{}\n");
-		return;
-	}
 
 	num_nh = hashcount(zl3vni->nh_table);
 	if (!num_nh)
@@ -872,11 +850,6 @@ static void zl3vni_print_rmac_hash_all_vni(struct hash_backet *backet,
 	json = (struct json_object *)args[1];
 
 	zl3vni = (zebra_l3vni_t *)backet->data;
-	if (!zl3vni) {
-		if (json)
-			vty_out(vty, "{}\n");
-		return;
-	}
 
 	num_rmacs = hashcount(zl3vni->rmac_table);
 	if (!num_rmacs)
@@ -920,8 +893,6 @@ static void zl3vni_print_rmac_hash(struct hash_backet *backet, void *ctx)
 	if (json)
 		json_rmac = json_object_new_object();
 	zrmac = (zebra_mac_t *)backet->data;
-	if (!zrmac)
-		return;
 
 	if (!json) {
 		vty_out(vty, "%-17s %-21s\n",
@@ -1098,8 +1069,6 @@ static void zl3vni_print_hash(struct hash_backet *backet, void *ctx[])
 	json = (json_object *)ctx[1];
 
 	zl3vni = (zebra_l3vni_t *)backet->data;
-	if (!zl3vni)
-		return;
 
 	if (!json) {
 		vty_out(vty, "%-10u %-4s %-21s %-8lu %-8lu %-15s %-37s\n",
@@ -1147,8 +1116,6 @@ static void zvni_print_hash(struct hash_backet *backet, void *ctxt[])
 	json = ctxt[1];
 
 	zvni = (zebra_vni_t *)backet->data;
-	if (!zvni)
-		return;
 
 	zvtep = zvni->vteps;
 	while (zvtep) {
@@ -1653,8 +1620,6 @@ static void zvni_install_neigh_hash(struct hash_backet *backet, void *ctxt)
 	struct neigh_walk_ctx *wctx = ctxt;
 
 	n = (zebra_neigh_t *)backet->data;
-	if (!n)
-		return;
 
 	if (CHECK_FLAG(n->flags, ZEBRA_NEIGH_REMOTE))
 		zvni_neigh_install(wctx->zvni, n);
@@ -1919,8 +1884,6 @@ static void zvni_gw_macip_del_for_vni_hash(struct hash_backet *backet,
 
 	/* Add primary SVI MAC*/
 	zvni = (zebra_vni_t *)backet->data;
-	if (!zvni)
-		return;
 
 	ifp = zvni->vxlan_if;
 	if (!ifp)
@@ -1960,8 +1923,6 @@ static void zvni_gw_macip_add_for_vni_hash(struct hash_backet *backet,
 	struct interface *ifp = NULL;
 
 	zvni = (zebra_vni_t *)backet->data;
-	if (!zvni)
-		return;
 
 	ifp = zvni->vxlan_if;
 	if (!ifp)
@@ -2622,8 +2583,6 @@ static void zvni_install_mac_hash(struct hash_backet *backet, void *ctxt)
 	struct mac_walk_ctx *wctx = ctxt;
 
 	mac = (zebra_mac_t *)backet->data;
-	if (!mac)
-		return;
 
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE))
 		zvni_mac_install(wctx->zvni, mac);
@@ -3067,8 +3026,6 @@ static void zvni_cleanup_all(struct hash_backet *backet, void *arg)
 	struct zebra_vrf *zvrf = (struct zebra_vrf *)arg;
 
 	zvni = (zebra_vni_t *)backet->data;
-	if (!zvni)
-		return;
 
 	/* remove from l3-vni list */
 	if (zvrf->l3vni)
@@ -3093,8 +3050,6 @@ static void zl3vni_cleanup_all(struct hash_backet *backet, void *args)
 	zebra_l3vni_t *zl3vni = NULL;
 
 	zl3vni = (zebra_l3vni_t *)backet->data;
-	if (!zl3vni)
-		return;
 
 	zebra_vxlan_process_l3vni_oper_down(zl3vni);
 }


### PR DESCRIPTION
Cleanup some silly assumptions around backet->data

hash_get cannot create a backet with a non-NULL backet->data so note this in documentation and remove the assumption that data can be NULL