### PR TITLE
Fix memory leak pim nexthop creation

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -56,6 +56,8 @@ void pim_rp_list_hash_clean(void *data)
 	hash_clean(pnc->upstream_hash, NULL);
 	hash_free(pnc->upstream_hash);
 	pnc->upstream_hash = NULL;
+	if (pnc->nexthop)
+		nexthops_free(pnc->nexthop);
 
 	XFREE(MTYPE_PIM_NEXTHOP_CACHE, pnc);
 }


### PR DESCRIPTION
While terminating pim instance, the memory allocated for pim nexthop
should be released before deallocating the memory of pim nexthop cache(pnc).
This resolves the memory leak detected in pnc->nexthop creation.

Signed-off-by: Sarita Patra <saritap@vmware.com>