### PR TITLE
Fix pim_mroute_del crash while killing pimd

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -174,7 +174,16 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 	   ifchannel list is empty before deleting upstream_del
 	   ref count will take care of it.
 	*/
-	pim_upstream_del(pim_ifp->pim, ch->upstream, __PRETTY_FUNCTION__);
+	if (ch->upstream->ref_count > 0)
+		pim_upstream_del(pim_ifp->pim, ch->upstream,
+			__PRETTY_FUNCTION__);
+
+	else
+		zlog_warn("%s: Avoiding deletion of upstream with ref_count %d "
+			"from ifchannel(%s): %s", __PRETTY_FUNCTION__,
+			ch->upstream->ref_count, ch->interface->name,
+			ch->sg_str);
+
 	ch->upstream = NULL;
 
 	THREAD_OFF(ch->t_ifjoin_expiry_timer);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -167,6 +167,8 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 			up->ref_count, up->flags,
 			up->channel_oil->oil_ref_count);
 
+	 assert(up->ref_count > 0);
+
 	--up->ref_count;
 
 	if (up->ref_count >= 1)


### PR DESCRIPTION
When we kill pimd, pim_upstream_del() will be get called as part of cleaning process.
Delete mroute by calling pim_mroute_del() which in result initialize the up->channel_oil
to NULL after cleanup. Delete each ifchannel stored in the upstream ifchannel list one
by one. As part of pim_ifchannel_delete(), it will check if it is the last ifchannel,
then delete the corresponding upstream. So pim_upstream_del will be get called more than
once as part of pim_upstream_terminate() and pim_ ifchannel_delete(). Similarly pim_mroute_del()
will be again called and since there is no NULL check before accesing the data, crash is happening.

Fix:
Adding Null check in pim_mroute_del before accessing the data.
and using the FLAG "PIM_UPSTREAM_FLAG_DEL" which will check if the deletion of pim upstream is already
in progress then don’t call pim_upstream_del() from pim_ifchannel_delete().

Signed-off-by: Sarita Patra <saritap@vmware.com>