### PR TITLE
zebra: When using BFD ensure that zebra thinks ptm is disabled

### DIFF
--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -1559,7 +1559,7 @@ void zebra_ptm_if_init(struct zebra_if *zifp __attribute__((__unused__)))
 
 int zebra_ptm_get_enable_state(void)
 {
-	return 1;
+	return 0;
 }
 
 void zebra_ptm_show_status(struct vty *vty __attribute__((__unused__)),


### PR DESCRIPTION
In order for connected routes to be installed the if_is_operative
function is called.  This function checks the status of ptm
and decides to use ptm enabled/disabled on the interface.
The call to zebra_ptm_get_enable was returning true and causing
the interface subsystem to do the wrong thing.  Modify the
internal bfd case to when checking for ptm enabled to say it
is not enabled.

Tested-by: Mark Stapp <mjs@voltanet.io>
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>