### PR TITLE
configure.ac: emit a config  warning if sphinx-build is missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1322,6 +1322,7 @@ dnl disable doc check
 if test "${enable_doc}" = "no";then
   DOC=""
 else
+  AC_CHECK_PROGS([SPHINXBUILD], [sphinx-build sphinx-build3 sphinx-build2], [no])
   DOC="doc"
 fi
 
@@ -2075,3 +2076,8 @@ zebra protobuf enabled  : ${have_protobuf:-no}
 
 The above user and group must have read/write access to the state file
 directory and to the config files in the config file directory."
+
+if test "${enable_doc}" != "no";then
+  AS_IF([test "x$SPHINXBUILD" = xno],
+     AC_MSG_WARN(sphinx-build is missing but required to build documentation))
+fi


### PR DESCRIPTION
  If we don't have --disabled-doc and sphinx-build is not available
  warn the user that sphinx-build is needed to build documentation
  as shown in the last line of config summary example below

FRRouting configuration
------------------------------
FRR version             : 5.1-dev
host operating system   : linux-gnu
source code location    : .
compiler                : gcc -std=gnu11
compiler flags          :  -g -Os -fno-omit-frame-pointer -funwind-tables -Wall -Wextra -Wmissing-prototypes -Wmissing-declarations -Wpointer-arith -Wbad-function-cast -Wwrite-strings -Wno-unused-result -Wno-unused-parameter -Wno-missing-field-initializers -pthread
make                    : make
linker flags            :  -rdynamic -ldl -lm -lcrypt   -ljson-c -lrt  -lreadline  -ltermcap -lm
state file directory    : /var/run
config file directory   : /usr/local/etc
example directory       : /usr/local/etc
module directory        : /usr/local/lib/frr/modules
user to run as          : frr
group to run as         : frr
group for vty sockets   :
config file mask        : 0600
log file mask           : 0600
zebra protobuf enabled  : no

The above user and group must have read/write access to the state file
directory and to the config files in the config file directory.
configure: WARNING: sphinx-build is missing but required to build documentation

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>