### PR TITLE
snapcraft: Add RPKI to snap package

### DIFF
--- a/snapcraft/README.usage.md
+++ b/snapcraft/README.usage.md
@@ -31,7 +31,7 @@ Commands defined by this snap
 - `frr.readme`:
 	Returns this document `cat README_usage.md`
 - `frr.set`:
-	Allows to enable `FPM` module. See FPM section below
+	Allows to enable `FPM` and/or disable RPKIi module. See Module section below
 
 and for debugging defined at this time (May get removed later - do not 
 depend on them). These are mainly intended to debug the Snap
@@ -100,19 +100,30 @@ are named `eth0`, `eth1` and `eth2`, then the additional lines in
 These settings require either a reboot or a manual configuration with
 `sysctl` as well.
 
-FPM Module
+Modules
 ----------
-The `frr.set` allows to turn FPM module on or off.
+The `frr.set` allows to turn FPM module ond the RPKI module on or off.
 
     frr.set fpm {disable|protobuf|netlink}
     
-    Disables FPM or enables FPM with selected mode
+    Disables FPM or enables FPM with selected mode (default: disabled)
 
 By default, the FPM module is disabled, but installed with netlink and
 protobuf support. To enable the FPM module, use the `frr.set fpm protobuf`
 or `frr.set fpm netlink` command. The command will only enable the mode
 for the next restart of zebra. Please reboot or restart zebra after
 changing the mode to become effective.
+
+    frr.set rpki {enable|disable}
+   
+    Disables or enables BGP RPKI (default: enabled)
+
+By default, the RPKI module is enabled. To disable the RPKI module
+use the `frr.set rpki disable` command. The command will only enable
+the module after the next restart of the bgp daemon. Please reboot or 
+restart bgpd after changing the mode to become effective.
+(Normally, there is no need to disable the module as it has no effect
+if there are no RPKI configurations in BGP)
 
 FAQ
 ---

--- a/snapcraft/scripts/bgpd-service
+++ b/snapcraft/scripts/bgpd-service
@@ -5,9 +5,16 @@ set -e -x
 if ! [ -e $SNAP_DATA/bgpd.conf ]; then
     cp $SNAP/etc/frr/bgpd.conf.default $SNAP_DATA/bgpd.conf
 fi
+# If no RPKI option is specified, then we create a default
+# with RPKI enabled
+if ! [ -e $SNAP_DATA/rpki.conf ]; then
+    echo "-M rpki" > $SNAP_DATA/rpki.conf
+fi
+EXTRA_OPTIONS="`cat $SNAP_DATA/rpki.conf`"
 exec $SNAP/sbin/bgpd \
     -f $SNAP_DATA/bgpd.conf \
     --pid_file $SNAP_DATA/bgpd.pid \
     --socket $SNAP_DATA/zsock \
-    --vty_socket $SNAP_DATA
+    --vty_socket $SNAP_DATA \
+    --moduledir $SNAP/lib/frr/modules $EXTRA_OPTIONS
 

--- a/snapcraft/scripts/set-options
+++ b/snapcraft/scripts/set-options
@@ -28,11 +28,34 @@ case $1 in
                 ;;
         esac
         ;;
+    rpki)
+        case $2 in
+            disable)
+                echo "" > $SNAP_DATA/rpki.conf
+                echo "RPKI module disabled. Please restart FRR"
+                ;;
+            enable)
+                echo "-M rpki" > $SNAP_DATA/rpki.conf
+                echo "RPKI module enabled. Please restart FRR"
+                ;;
+            *)
+                echo "Usage:"
+                echo "    ${SNAP_NAME}.set rpki {disable|enable}"
+                echo ""
+                echo "    Disables BGP RPKI module or enables it (default: enabled)"
+                echo "    Mode will be saved for next restart of bgpd, but bgpd"
+                echo "    is not automatically restarted"
+                exit 1
+                ;;
+        esac
+        ;;
     *)
         echo "Usage:"
         echo "    ${SNAP_NAME}.set fpm {disable|protobuf|netlink}"
+        echo "    ${SNAP_NAME}.set rpki {disable|enable}"
         echo ""
-        echo "    Disables FPM or enables FPM with selected mode"
+        echo "    fpm: Disables FPM or enables FPM with selected mode"
+        echo "    rpki: Disables BGP RPKI or enables it (default: enabled)"
         exit 1
         ;;
 esac

--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -136,7 +136,7 @@ apps:
             - network-bind
             - network-control
     bgpd-debug:
-        command: sbin/bgpd -f $SNAP_DATA/bgpd.conf --pid_file $SNAP_DATA/bgpd.pid --socket $SNAP_DATA/zsock --vty_socket $SNAP_DATA
+        command: sbin/bgpd -f $SNAP_DATA/bgpd.conf --pid_file $SNAP_DATA/bgpd.pid --socket $SNAP_DATA/zsock --vty_socket $SNAP_DATA --moduledir $SNAP/lib/frr/modules `cat $SNAP_DATA/rpki.conf 2> /dev/null`
         plugs:
             - network
             - network-bind
@@ -221,8 +221,27 @@ apps:
             - network-control
 
 parts:
+    rtrlib:
+        build-packages:
+           - cmake
+           - make
+           - gcc
+           - libssh-dev
+        stage-packages:
+           - libssh-4
+        prime:
+           - lib/x86_64-linux-gnu/librtr.so*
+           - usr/lib/x86_64-linux-gnu/libssh.so*
+        source: https://github.com/rtrlib/rtrlib.git
+        source-type: git
+        source-tag: v0.5.0
+        plugin: cmake
+        configflags:
+           - -DCMAKE_BUILD_TYPE=Release
     frr: 
-        build-packages: 
+        after: [rtrlib]
+        build-packages:
+           - gcc
            - autoconf
            - automake
            - libtool
@@ -247,6 +266,7 @@ parts:
            - flex
            - python3-dev
            - protobuf-c-compiler
+           - python3-sphinx
         stage-packages:
            - coreutils
            - iproute2
@@ -276,6 +296,7 @@ parts:
             - --enable-ldpd
             - --enable-fpm
             - --enable-protobuf
+            - --enable-rpki
             - --enable-configfile-mask=0640
             - --enable-logfile-mask=0640 
             - --localstatedir=/var/run


### PR DESCRIPTION
Add rtrlib to snapcraft package and build snap package with RPKI enabled

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>