### PR TITLE
doc, debianpkg: Cleanup tcp-zebra configure options

### DIFF
--- a/debianpkg/backports/ubuntu12.04/debian/rules
+++ b/debianpkg/backports/ubuntu12.04/debian/rules
@@ -10,7 +10,6 @@
 WANT_LDP ?= 1
 WANT_PIM ?= 1
 WANT_OSPFAPI ?= 1
-WANT_TCP_ZEBRA ?= 0
 WANT_BGP_VNC ?= 1
 WANT_CUMULUS_MODE ?= 0
 WANT_MULTIPATH ?= 1
@@ -65,12 +64,6 @@ else
   USE_OSPFAPI=--enable-ospfapi=no
 endif
 
-ifeq ($(WANT_TCP_ZEBRA),1)
-  USE_TCP_ZEBRA=--enable-tcp-zebra
-else
-  USE_TCP_ZEBRA=--disable-tcp-zebra
-endif
-
 ifeq ($(WANT_BGP_VNC), 1)
   USE_BGP_VNC=--enable-bgp-vnc=yes
 else
@@ -123,7 +116,6 @@ override_dh_auto_configure:
 		$(USE_OSPFAPI) \
 		$(USE_MULTIPATH) \
 		$(USE_LDP) \
-		$(USE_TCP_ZEBRA) \
 		--enable-fpm \
 		$(USE_FRR_USER) $(USE_FRR_GROUP) \
 		$(USE_FRR_VTY_GROUP) \

--- a/debianpkg/backports/ubuntu14.04/debian/rules
+++ b/debianpkg/backports/ubuntu14.04/debian/rules
@@ -10,7 +10,6 @@
 WANT_LDP ?= 1
 WANT_PIM ?= 1
 WANT_OSPFAPI ?= 1
-WANT_TCP_ZEBRA ?= 0
 WANT_BGP_VNC ?= 1
 WANT_CUMULUS_MODE ?= 0
 WANT_MULTIPATH ?= 1
@@ -73,12 +72,6 @@ ifeq ($(WANT_OSPFAPI), 1)
   USE_OSPFAPI=--enable-ospfapi=yes
 else
   USE_OSPFAPI=--enable-ospfapi=no
-endif
-
-ifeq ($(WANT_TCP_ZEBRA),1)
-  USE_TCP_ZEBRA=--enable-tcp-zebra
-else
-  USE_TCP_ZEBRA=--disable-tcp-zebra
 endif
 
 ifeq ($(WANT_BGP_VNC), 1)
@@ -152,7 +145,6 @@ override_dh_auto_configure:
 		$(USE_OSPFAPI) \
 		$(USE_MULTIPATH) \
 		$(USE_LDP) \
-		$(USE_TCP_ZEBRA) \
 		--enable-fpm \
 		$(USE_FRR_USER) $(USE_FRR_GROUP) \
 		$(USE_FRR_VTY_GROUP) \

--- a/debianpkg/rules
+++ b/debianpkg/rules
@@ -10,7 +10,6 @@
 WANT_LDP ?= 1
 WANT_PIM ?= 1
 WANT_OSPFAPI ?= 1
-WANT_TCP_ZEBRA ?= 0
 WANT_BGP_VNC ?= 1
 WANT_CUMULUS_MODE ?= 0
 WANT_MULTIPATH ?= 1
@@ -73,12 +72,6 @@ ifeq ($(WANT_OSPFAPI), 1)
   USE_OSPFAPI=--enable-ospfapi=yes
 else
   USE_OSPFAPI=--enable-ospfapi=no
-endif
-
-ifeq ($(WANT_TCP_ZEBRA),1)
-  USE_TCP_ZEBRA=--enable-tcp-zebra
-else
-  USE_TCP_ZEBRA=--disable-tcp-zebra
 endif
 
 ifeq ($(WANT_BGP_VNC), 1)
@@ -152,7 +145,6 @@ override_dh_auto_configure:
 		$(USE_OSPFAPI) \
 		$(USE_MULTIPATH) \
 		$(USE_LDP) \
-		$(USE_TCP_ZEBRA) \
 		--enable-fpm \
 		$(USE_FRR_USER) $(USE_FRR_GROUP) \
 		$(USE_FRR_VTY_GROUP) \

--- a/doc/manpages/common-options.rst
+++ b/doc/manpages/common-options.rst
@@ -126,7 +126,7 @@ These following options control the daemon's VTY (interactive command line) inte
       staticd         2616
       bfdd            2617
 
-   Port 2607 is used for ospfd's Opaque LSA API, while port 2600 is used for the (insecure) TCP-ZEBRA interface.
+   Port 2607 is used for ospfd's Opaque LSA API.
 
 .. option:: --vty_socket vty-path
 


### PR DESCRIPTION
Since we removed --enable-tcp-zebra cleanup the last
remaining vestiges of that code from the system.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>