### PR TITLE
ospfd: Add ospf_lsa_new_and_data function and abstract away

### DIFF
--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -1425,19 +1425,7 @@ struct ospf_lsa *ospf_apiserver_opaque_lsa_new(struct ospf_area *area,
 	newlsa->length = htons(length);
 
 	/* Create OSPF LSA. */
-	if ((new = ospf_lsa_new()) == NULL) {
-		zlog_warn("ospf_apiserver_opaque_lsa_new: ospf_lsa_new() ?");
-		stream_free(s);
-		return NULL;
-	}
-
-	if ((new->data = ospf_lsa_data_new(length)) == NULL) {
-		zlog_warn(
-			"ospf_apiserver_opaque_lsa_new: ospf_lsa_data_new() ?");
-		ospf_lsa_unlock(&new);
-		stream_free(s);
-		return NULL;
-	}
+	new = ospf_lsa_new_and_data(length);
 
 	new->area = area;
 	new->oi = oi;

--- a/ospfd/ospf_ext.c
+++ b/ospfd/ospf_ext.c
@@ -977,20 +977,7 @@ static struct ospf_lsa *ospf_ext_pref_lsa_new(struct ospf_area *area,
 	lsah->length = htons(length);
 
 	/* Now, create an OSPF LSA instance. */
-	new = ospf_lsa_new();
-	if (new == NULL) {
-		zlog_warn("EXT (%s): ospf_lsa_new() error", __func__);
-		stream_free(s);
-		return NULL;
-	}
-	new->data = ospf_lsa_data_new(length);
-	if (new->data == NULL) {
-		zlog_warn("EXT (%s): ospf_lsa_data_new() error", __func__);
-		ospf_lsa_unlock(&new);
-		new = NULL;
-		stream_free(s);
-		return NULL;
-	}
+	new = ospf_lsa_new_and_data(length);
 
 	/* Segment Routing belongs only to default VRF */
 	new->vrf_id = VRF_DEFAULT;
@@ -1056,20 +1043,7 @@ static struct ospf_lsa *ospf_ext_link_lsa_new(struct ospf_area *area,
 	lsah->length = htons(length);
 
 	/* Now, create an OSPF LSA instance. */
-	new = ospf_lsa_new();
-	if (new == NULL) {
-		zlog_warn("EXT (%s): ospf_lsa_new() error", __func__);
-		stream_free(s);
-		return NULL;
-	}
-	new->data = ospf_lsa_data_new(length);
-	if (new->data == NULL) {
-		zlog_warn("EXT (%s): ospf_lsa_data_new() error", __func__);
-		ospf_lsa_unlock(&new);
-		new = NULL;
-		stream_free(s);
-		return NULL;
-	}
+	new = ospf_lsa_new_and_data(length);
 
 	/* Segment Routing belongs only to default VRF */
 	new->vrf_id = VRF_DEFAULT;

--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -810,8 +810,7 @@ struct ospf_lsa *ospf_ls_request_new(struct lsa_header *lsah)
 {
 	struct ospf_lsa *new;
 
-	new = ospf_lsa_new();
-	new->data = ospf_lsa_data_new(OSPF_LSA_HEADER_SIZE);
+	new = ospf_lsa_new_and_data(OSPF_LSA_HEADER_SIZE);
 	memcpy(new->data, lsah, OSPF_LSA_HEADER_SIZE);
 
 	return new;

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -167,6 +167,16 @@ struct ospf_lsa *ospf_lsa_new()
 	return new;
 }
 
+struct ospf_lsa *ospf_lsa_new_and_data(size_t size)
+{
+	struct ospf_lsa *new;
+
+	new = ospf_lsa_new();
+	new->data = ospf_lsa_data_new(size);
+
+	return new;
+}
+
 /* Duplicate OSPF LSA. */
 struct ospf_lsa *ospf_lsa_dup(struct ospf_lsa *lsa)
 {
@@ -781,17 +791,13 @@ static struct ospf_lsa *ospf_router_lsa_new(struct ospf_area *area)
 	lsah->length = htons(length);
 
 	/* Now, create OSPF LSA instance. */
-	if ((new = ospf_lsa_new()) == NULL) {
-		zlog_err("%s: Unable to create new lsa", __func__);
-		return NULL;
-	}
+	new = ospf_lsa_new_and_data(length);
 
 	new->area = area;
 	SET_FLAG(new->flags, OSPF_LSA_SELF | OSPF_LSA_SELF_CHECKED);
 	new->vrf_id = area->ospf->vrf_id;
 
 	/* Copy LSA data to store, discard stream. */
-	new->data = ospf_lsa_data_new(length);
 	memcpy(new->data, lsah, length);
 	stream_free(s);
 
@@ -997,17 +1003,13 @@ static struct ospf_lsa *ospf_network_lsa_new(struct ospf_interface *oi)
 	lsah->length = htons(length);
 
 	/* Create OSPF LSA instance. */
-	if ((new = ospf_lsa_new()) == NULL) {
-		zlog_err("%s: ospf_lsa_new returned NULL", __func__);
-		return NULL;
-	}
+	new = ospf_lsa_new_and_data(length);
 
 	new->area = oi->area;
 	SET_FLAG(new->flags, OSPF_LSA_SELF | OSPF_LSA_SELF_CHECKED);
 	new->vrf_id = oi->ospf->vrf_id;
 
 	/* Copy LSA to store. */
-	new->data = ospf_lsa_data_new(length);
 	memcpy(new->data, lsah, length);
 	stream_free(s);
 
@@ -1181,13 +1183,12 @@ static struct ospf_lsa *ospf_summary_lsa_new(struct ospf_area *area,
 	lsah->length = htons(length);
 
 	/* Create OSPF LSA instance. */
-	new = ospf_lsa_new();
+	new = ospf_lsa_new_and_data(length);
 	new->area = area;
 	SET_FLAG(new->flags, OSPF_LSA_SELF | OSPF_LSA_SELF_CHECKED);
 	new->vrf_id = area->ospf->vrf_id;
 
 	/* Copy LSA to store. */
-	new->data = ospf_lsa_data_new(length);
 	memcpy(new->data, lsah, length);
 	stream_free(s);
 
@@ -1323,13 +1324,12 @@ static struct ospf_lsa *ospf_summary_asbr_lsa_new(struct ospf_area *area,
 	lsah->length = htons(length);
 
 	/* Create OSPF LSA instance. */
-	new = ospf_lsa_new();
+	new = ospf_lsa_new_and_data(length);
 	new->area = area;
 	SET_FLAG(new->flags, OSPF_LSA_SELF | OSPF_LSA_SELF_CHECKED);
 	new->vrf_id = area->ospf->vrf_id;
 
 	/* Copy LSA to store. */
-	new->data = ospf_lsa_data_new(length);
 	memcpy(new->data, lsah, length);
 	stream_free(s);
 
@@ -1629,14 +1629,13 @@ static struct ospf_lsa *ospf_external_lsa_new(struct ospf *ospf,
 	lsah->length = htons(length);
 
 	/* Now, create OSPF LSA instance. */
-	new = ospf_lsa_new();
+	new = ospf_lsa_new_and_data(length);
 	new->area = NULL;
 	SET_FLAG(new->flags,
 		 OSPF_LSA_SELF | OSPF_LSA_APPROVED | OSPF_LSA_SELF_CHECKED);
 	new->vrf_id = ospf->vrf_id;
 
 	/* Copy LSA data to store, discard stream. */
-	new->data = ospf_lsa_data_new(length);
 	memcpy(new->data, lsah, length);
 	stream_free(s);
 

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -235,6 +235,7 @@ extern int ospf_check_nbr_status(struct ospf *);
 
 /* Prototype for LSA primitive. */
 extern struct ospf_lsa *ospf_lsa_new(void);
+extern struct ospf_lsa *ospf_lsa_new_and_data(size_t size);
 extern struct ospf_lsa *ospf_lsa_dup(struct ospf_lsa *);
 extern void ospf_lsa_free(struct ospf_lsa *);
 extern struct ospf_lsa *ospf_lsa_lock(struct ospf_lsa *);

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -1742,7 +1742,7 @@ static struct list *ospf_ls_upd_list_lsa(struct ospf_neighbor *nbr,
 		}
 
 		/* Create OSPF LSA instance. */
-		lsa = ospf_lsa_new();
+		lsa = ospf_lsa_new_and_data(length);
 
 		lsa->vrf_id = oi->ospf->vrf_id;
 		/* We may wish to put some error checking if type NSSA comes in
@@ -1761,7 +1761,6 @@ static struct list *ospf_ls_upd_list_lsa(struct ospf_neighbor *nbr,
 			break;
 		}
 
-		lsa->data = ospf_lsa_data_new(length);
 		memcpy(lsa->data, lsah, length);
 
 		if (IS_DEBUG_OSPF_EVENT)

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -775,18 +775,7 @@ static struct ospf_lsa *ospf_router_info_lsa_new()
 	lsah->length = htons(length);
 
 	/* Now, create an OSPF LSA instance. */
-	if ((new = ospf_lsa_new()) == NULL) {
-		zlog_warn("ospf_router_info_lsa_new: ospf_lsa_new() ?");
-		stream_free(s);
-		return NULL;
-	}
-	if ((new->data = ospf_lsa_data_new(length)) == NULL) {
-		zlog_warn("ospf_router_info_lsa_new: ospf_lsa_data_new() ?");
-		ospf_lsa_unlock(&new);
-		new = NULL;
-		stream_free(s);
-		return new;
-	}
+	new = ospf_lsa_new_and_data(length);
 
 	new->area = OspfRI.area; /* Area must be null if the Opaque type is AS
 				    scope, fulfill otherwise */

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1201,18 +1201,7 @@ static struct ospf_lsa *ospf_mpls_te_lsa_new(struct ospf *ospf,
 	lsah->length = htons(length);
 
 	/* Now, create an OSPF LSA instance. */
-	if ((new = ospf_lsa_new()) == NULL) {
-		zlog_warn("%s: ospf_lsa_new() ?", __func__);
-		stream_free(s);
-		return NULL;
-	}
-	if ((new->data = ospf_lsa_data_new(length)) == NULL) {
-		zlog_warn("%s: ospf_lsa_data_new() ?", __func__);
-		ospf_lsa_unlock(&new);
-		new = NULL;
-		stream_free(s);
-		return new;
-	}
+	new = ospf_lsa_new_and_data(length);
 
 	new->vrf_id = ospf->vrf_id;
 	if (area && area->ospf)


### PR DESCRIPTION
In all but one instance we were following this pattern
with ospf_lsa_new:

ospf_lsa_new()
ospf_lsa_data_new()

so let's create a ospf_lsa_new_and_data to abstract
this bit of fun and cleanup all the places where
it assumes these function calls can fail.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>