### PR TITLE
bgpd: avoid memory leak in bgp flowspec list, plus usage of bool

### DIFF
--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -335,7 +335,7 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 			struct listnode *node;
 			struct bgp_pbr_match_entry *bpme;
 			struct bgp_pbr_match *bpm;
-			int unit = 0;
+			bool list_began = false;
 			struct list *list_bpm;
 
 			list_bpm = list_new();
@@ -347,14 +347,14 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 				if (listnode_lookup(list_bpm, bpm))
 					continue;
 				listnode_add(list_bpm, bpm);
-				if (unit == 0)
+				if (!list_began) {
 					vty_out(vty, " (");
-				else
+					list_began = true;
+				} else
 					vty_out(vty, ", ");
 				vty_out(vty, "%s", bpm->ipset_name);
-				unit++;
 			}
-			if (unit)
+			if (list_began)
 				vty_out(vty, ")");
 			vty_out(vty, "\n");
 			list_delete_and_null(&list_bpm);

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1680,7 +1680,7 @@ static void bgp_pbr_dump_entry(struct bgp_pbr_filter *bpf, bool add)
 			 ? "!" : "",
 			 bpf->dscp->val);
 	}
-	zlog_info("BGP: %s FS PBR from %s to %s, %s %s",
+	zlog_debug("BGP: %s FS PBR from %s to %s, %s %s",
 		  add ? "adding" : "removing",
 		  bpf->src == NULL ? "<all>" :
 		  prefix2str(bpf->src, bufsrc, sizeof(bufsrc)),

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1807,7 +1807,7 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 		       bgp_pbr_match_alloc_intern);
 
 	/* new, then self allocate ipset_name and unique */
-	if (bpm && bpm->unique == 0) {
+	if (bpm->unique == 0) {
 		bpm->unique = ++bgp_pbr_match_counter_unique;
 		/* 0 value is forbidden */
 		sprintf(bpm->ipset_name, "match%p", bpm);
@@ -1838,10 +1838,9 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 	temp2.src_port_max = src_port ? src_port->max_port : 0;
 	temp2.dst_port_max = dst_port ? dst_port->max_port : 0;
 	temp2.proto = bpf->protocol;
-	if (bpm)
-		bpme = hash_get(bpm->entry_hash, &temp2,
-				bgp_pbr_match_entry_alloc_intern);
-	if (bpme && bpme->unique == 0) {
+	bpme = hash_get(bpm->entry_hash, &temp2,
+			bgp_pbr_match_entry_alloc_intern);
+	if (bpme->unique == 0) {
 		bpme->unique = ++bgp_pbr_match_entry_counter_unique;
 		/* 0 value is forbidden */
 		bpme->backpointer = bpm;
@@ -1853,7 +1852,7 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 		bpme_found = true;
 
 	/* already installed */
-	if (bpme_found && bpme) {
+	if (bpme_found) {
 		struct bgp_info_extra *extra = bgp_info_extra_get(binfo);
 
 		if (extra && extra->bgp_fs_pbr &&

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -198,8 +198,7 @@ static void bgp_info_extra_free(struct bgp_info_extra **extra)
 		bgp_unlock(e->bgp_orig);
 
 	if ((*extra)->bgp_fs_pbr)
-		list_delete_all_node((*extra)->bgp_fs_pbr);
-	(*extra)->bgp_fs_pbr = NULL;
+		list_delete_and_null(&((*extra)->bgp_fs_pbr));
 	XFREE(MTYPE_BGP_ROUTE_EXTRA, *extra);
 
 	*extra = NULL;


### PR DESCRIPTION
Avoid memory leak in bgp flowspec list.
Usage of bool parameter instead of int, to handle the number of entries
PBR.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>