### PR TITLE
lib: fix show error all

### DIFF
--- a/lib/ferr.c
+++ b/lib/ferr.c
@@ -146,7 +146,7 @@ void log_ref_display(struct vty *vty, uint32_t code, bool json)
 			char ubuf[256];
 
 			snprintf(pbuf, sizeof(pbuf), "\nError %"PRIu32" - %s",
-				 code, ref->title);
+				 ref->code, ref->title);
 			memset(ubuf, '=', strlen(pbuf));
 			ubuf[sizeof(ubuf) - 1] = '\0';
 


### PR DESCRIPTION
show error all was displaying 0 value for code, whereas real code value
was not displayed.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>