### PR TITLE
ospfd: Remove unused function

### DIFF
--- a/ospfclient/ospf_apiclient.c
+++ b/ospfclient/ospf_apiclient.c
@@ -46,6 +46,7 @@
 #include "ospfd/ospf_lsdb.h"
 #include "ospfd/ospf_neighbor.h"
 #include "ospfd/ospf_dump.h"
+#include "ospfd/ospf_route.h"
 #include "ospfd/ospf_zebra.h"
 #include "ospfd/ospf_api.h"
 

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -73,26 +73,6 @@ void ospf_external_route_remove(struct ospf *ospf, struct prefix_ipv4 *p)
 		  p->prefixlen);
 }
 
-/* Lookup external route. */
-struct ospf_route *ospf_external_route_lookup(struct ospf *ospf,
-					      struct prefix_ipv4 *p)
-{
-	struct route_node *rn;
-
-	rn = route_node_lookup(ospf->old_external_route, (struct prefix *)p);
-	if (rn) {
-		route_unlock_node(rn);
-		if (rn->info)
-			return rn->info;
-	}
-
-	zlog_warn("Route[%s/%d]: lookup, no such prefix", inet_ntoa(p->prefix),
-		  p->prefixlen);
-
-	return NULL;
-}
-
-
 /* Add an External info for AS-external-LSA. */
 struct external_info *ospf_external_info_new(uint8_t type,
 					     unsigned short instance)

--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -68,8 +68,6 @@ extern void ospf_external_info_delete(struct ospf *, uint8_t, unsigned short,
 extern struct external_info *ospf_external_info_lookup(struct ospf *, uint8_t,
 						       unsigned short,
 						       struct prefix_ipv4 *);
-extern struct ospf_route *ospf_external_route_lookup(struct ospf *,
-						     struct prefix_ipv4 *);
 extern void ospf_asbr_status_update(struct ospf *, uint8_t);
 
 extern void ospf_redistribute_withdraw(struct ospf *, uint8_t, unsigned short);

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -49,6 +49,7 @@
 #include "ospfd/ospf_lsdb.h"
 #include "ospfd/ospf_neighbor.h"
 #include "ospfd/ospf_dump.h"
+#include "ospfd/ospf_route.h"
 #include "ospfd/ospf_zebra.h"
 #include "ospfd/ospf_vty.h"
 #include "ospfd/ospf_bfd.h"

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -47,6 +47,7 @@
 #include "ospfd/ospf_flood.h"
 #include "ospfd/ospf_ism.h"
 #include "ospfd/ospf_dump.h"
+#include "ospfd/ospf_route.h"
 #include "ospfd/ospf_zebra.h"
 
 /* OSPF2-MIB. */

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -52,10 +52,10 @@
 #include "ospfd/ospf_spf.h"
 #include "ospfd/ospf_packet.h"
 #include "ospfd/ospf_dump.h"
+#include "ospfd/ospf_route.h"
 #include "ospfd/ospf_zebra.h"
 #include "ospfd/ospf_abr.h"
 #include "ospfd/ospf_flood.h"
-#include "ospfd/ospf_route.h"
 #include "ospfd/ospf_ase.h"
 
 


### PR DESCRIPTION
The ospf_external_route_lookup function was not
being used so let's just remove it.

Unfortunately the removal was not quite so simple as
that ospf_asbr.h was being used to generate a reference
for the `struct ospf_route` data structure, so we
need to fix up the compile by fixing up header
inclusions so that ospf_route.h is actually included

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>