### PR TITLE
build: wrap "fallthrough" attr

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -24,6 +24,9 @@
 #if __clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 5)
 #  define _RET_NONNULL    , returns_nonnull
 #endif
+#if __has_attribute(fallthrough)
+#  define _FALLTHROUGH __attribute__((fallthrough));
+#endif
 # define _CONSTRUCTOR(x)  constructor(x)
 #elif defined(__GNUC__)
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
@@ -33,6 +36,9 @@
 #  define _CONSTRUCTOR(x) constructor(x)
 #  define _DESTRUCTOR(x)  destructor(x)
 #  define _ALLOC_SIZE(x)  alloc_size(x)
+#endif
+#if __GNUC__ >= 7
+#  define _FALLTHROUGH __attribute__((fallthrough));
 #endif
 #endif
 
@@ -54,6 +60,9 @@
 #endif
 #ifndef _ALLOC_SIZE
 # define _ALLOC_SIZE(x)
+#endif
+#ifndef _FALLTHROUGH
+#define _FALLTHROUGH
 #endif
 
 /*

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -821,7 +821,7 @@ static void parse_test(struct peer *peer, struct test_segment *t, int type)
 	switch (type) {
 	case CAPABILITY:
 		len += 2; /* to cover the OPT-Param header */
-		__attribute__ ((fallthrough));
+		_FALLTHROUGH
 	case OPT_PARAM:
 		printf("len: %u\n", len);
 		/* peek_for_as4 wants getp at capibility*/


### PR DESCRIPTION
This generates a warning on gcc versions before 7.0.

Signed-off-by: David Lamparter <equinox@diac24.net>