### PR TITLE
bgpd: fix rpki exit command

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1210,10 +1210,10 @@ DEFUN_NOSH (rpki_exit,
 	    "exit",
 	    "Exit rpki configuration and restart rpki session\n")
 {
-	int ret = reset(false);
+	reset(false);
 
 	vty->node = CONFIG_NODE;
-	return ret == SUCCESS ? CMD_SUCCESS : CMD_WARNING;
+	return CMD_SUCCESS;
 }
 
 DEFUN_NOSH (rpki_quit,

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1435,24 +1435,6 @@ DEFUNSH(VTYSH_BGPD,
 	return CMD_SUCCESS;
 }
 
-DEFUNSH(VTYSH_BGPD,
-	rpki_exit,
-	rpki_exit_cmd,
-	"exit",
-	"Exit current mode and down to previous mode\n")
-{
-	vty->node = CONFIG_NODE;
-	return CMD_SUCCESS;
-}
-
-DEFUNSH(VTYSH_BGPD,
-	rpki_quit,
-	rpki_quit_cmd,
-	"quit",
-	"Exit current mode and down to previous mode\n")
-{
-	return rpki_exit(self, vty, argc, argv);
-}
 #endif
 
 DEFUNSH(VTYSH_BGPD, address_family_evpn, address_family_evpn_cmd,
@@ -1790,6 +1772,7 @@ static int vtysh_exit(struct vty *vty)
 	case VTY_NODE:
 	case KEYCHAIN_NODE:
 	case BFD_NODE:
+	case RPKI_NODE:
 		vtysh_execute("end");
 		vtysh_execute("configure terminal");
 		vty->node = CONFIG_NODE;
@@ -1883,7 +1866,23 @@ DEFUNSH(VTYSH_BGPD, exit_vnc_config, exit_vnc_config_cmd, "exit-vnc",
 	    || vty->node == BGP_VNC_L2_GROUP_NODE)
 		vty->node = BGP_NODE;
 	return CMD_SUCCESS;
+
 }
+
+#if defined(HAVE_RPKI)
+DEFUNSH(VTYSH_BGPD, rpki_exit, rpki_exit_cmd, "exit",
+	"Exit current mode and down to previous mode\n")
+{
+	vtysh_exit(vty);
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_BGPD, rpki_quit, rpki_quit_cmd, "quit",
+	"Exit current mode and down to previous mode\n")
+{
+	return rpki_exit(self, vty, argc, argv);
+}
+#endif /* HAVE_RPKI */
 
 DEFUNSH(VTYSH_PIMD|VTYSH_ZEBRA, exit_vrf_config, exit_vrf_config_cmd, "exit-vrf",
 	"Exit from VRF configuration mode\n")


### PR DESCRIPTION
If a command returns a nonzero exit status and VTYSH has a corresponding
command, VTYSH will skip executing its own version. If this happens in a
command that changes CLI nodes we get node desynchronization.

Fixes #2835 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>