### PR TITLE
To avoid running of the second instance of a FRR daemon, if it is alr…

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -129,7 +129,6 @@ static struct frr_daemon_info bgpd_di;
 void sighup(void)
 {
 	zlog_info("SIGHUP received");
-
 	/* Terminate all thread. */
 	bgp_terminate();
 	bgp_reset();
@@ -373,7 +372,11 @@ int main(int argc, char **argv)
 		"  -n, --no_kernel    Do not install route to kernel.\n"
 		"  -S, --skip_runas   Skip capabilities checks, and changing user and group IDs.\n"
 		"  -e, --ecmp         Specify ECMP to use.\n");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a BGPD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	/* Command line argument treatment. */
 	while (1) {
 		opt = frr_getopt(argc, argv, 0);

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -144,7 +144,11 @@ int main(int argc, char **argv, char **envp)
 {
 	frr_preinit(&eigrpd_di, argc, argv);
 	frr_opt_add("", longopts, "");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a EIGRPD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	while (1) {
 		int opt;
 

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -166,7 +166,11 @@ int main(int argc, char **argv, char **envp)
 
 	frr_preinit(&isisd_di, argc, argv);
 	frr_opt_add("", longopts, "");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a LDPD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	/* Command line argument treatment. */
 	while (1) {
 		opt = frr_getopt(argc, argv, NULL);

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -225,7 +225,11 @@ main(int argc, char *argv[])
 	frr_opt_add("LEn:", longopts,
 		"      --ctl_socket   Override ctl socket path\n"
 		"  -n, --instance     Instance id\n");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE ) {
+		zlog_err("There is already a LDPD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	while (1) {
 		int opt;
 

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -35,6 +35,12 @@
 #define FRR_NO_CFG_PID_DRY		(1 << 3)
 #define FRR_NO_ZCLIENT		(1 << 4)
 
+
+enum frr_ret {
+SUCCESS = 0,
+FAILURE = 1
+};
+
 struct frr_daemon_info {
 	unsigned flags;
 
@@ -101,7 +107,7 @@ extern struct thread_master *frr_init(void);
 
 DECLARE_HOOK(frr_late_init, (struct thread_master * tm), (tm))
 extern void frr_config_fork(void);
-
+extern int frr_guard_daemon(void);
 extern void frr_vty_serv(void);
 
 /* note: contains call to frr_vty_serv() */

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -124,9 +124,12 @@ int main(int argc, char **argv)
 {
 	frr_preinit(&nhrpd_di, argc, argv);
 	frr_opt_add("", longopts, "");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a NHRPD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	parse_arguments(argc, argv);
-
 	/* Library inits. */
 	master = frr_init();
 	nhrp_error_init();

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -179,7 +179,11 @@ int main(int argc, char *argv[], char *envp[])
 
 	frr_preinit(&ospf6d_di, argc, argv);
 	frr_opt_add("", longopts, "");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a OSPF6D Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	/* Command line argument treatment. */
 	while (1) {
 		opt = frr_getopt(argc, argv, NULL);

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -145,7 +145,11 @@ int main(int argc, char **argv)
 	frr_opt_add("n:a", longopts,
 		    "  -n, --instance     Set the instance id\n"
 		    "  -a, --apiserver    Enable OSPF apiserver\n");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a OSPFD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	while (1) {
 		int opt;
 

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -124,7 +124,11 @@ int main(int argc, char **argv, char **envp)
 {
 	frr_preinit(&pbrd_di, argc, argv);
 	frr_opt_add("", longopts, "");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a PBRD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	while (1) {
 		int opt;
 

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -85,7 +85,11 @@ int main(int argc, char **argv, char **envp)
 {
 	frr_preinit(&pimd_di, argc, argv);
 	frr_opt_add("", longopts, "");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a PIMD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	/* this while just reads the options */
 	while (1) {
 		int opt;

--- a/ripd/rip_main.c
+++ b/ripd/rip_main.c
@@ -138,7 +138,11 @@ int main(int argc, char **argv)
 	frr_preinit(&ripd_di, argc, argv);
 
 	frr_opt_add("" DEPRECATED_OPTIONS, longopts, "");
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a RIPD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	/* Command line option parse. */
 	while (1) {
 		int opt;

--- a/ripngd/ripng_main.c
+++ b/ripngd/ripng_main.c
@@ -138,7 +138,11 @@ int main(int argc, char **argv)
 	frr_preinit(&ripngd_di, argc, argv);
 
 	frr_opt_add("" DEPRECATED_OPTIONS, longopts, "");
-
+	/* Guard to prevent a second instance of this daemon */
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a RIPNGD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	while (1) {
 		int opt;
 

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -233,7 +233,11 @@ int main(int argc, char **argv)
 	logicalrouter_configure_backend(LOGICALROUTER_BACKEND_NETNS);
 
 	frr_preinit(&zebra_di, argc, argv);
-
+	/* Guard to prevent a second instance of this daemon*/
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a NHRPD Process running, hence not allowing a second instance");
+		exit(1);
+	}
 	frr_opt_add(
 		"bakz:e:l:r"
 #ifdef HAVE_NETLINK


### PR DESCRIPTION
To avoid running of the second instance of a FRR daemon, if it is already running.	
FRRouting#2680	

Solution :	
The following procedures would be performed :	
Verify if the pid file for each daemon is present or not. If the file is not present, that means the daemon is getting instantiated for the first time. So let it go ahead. If the file is present proceed to point ‘2’.	
Try fetching the properties of the pid file	
If it has RW lock, that means one instance of this the daemon is already running. So stop moving ahead and do exit() else let it go ahead.	
Please note all above procedure happen at the initial state of daemon’s instantiation, much before it starts any session with other process/allocates resources etc.. and this verification do not have any impact of any operations done later, if the verification succeeds.	

I had covered these daemons :	
Bgpd	
Eigrpd	
Isisd	
Ldpd	
Nhrpd	
Ospf6d	
Prbd	
Ospfd	
Ripd	
Ripngd	
Zebrad	
pimd	
Daemons that are not covered are :	
babled	
sharpd	
watchfrrd	
Test Cases run :-	
root@dev:/var/run/frr# ls -lrt *.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 zebra.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 bgpd.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 ripd.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 ripngd.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 ospfd.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 ospf6d.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 isisd.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 pimd.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 ldpd.pid	
-rw-r--r-- 1 root frr 6 Aug 8 02:04 nhrpd.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 eigrpd.pid	
-rw-r--r-- 1 frr frr 6 Aug 8 02:04 pbrd.pid	
-rw-r--r-- 1 root root 6 Aug 8 02:04 watchfrr.pid	
root@dev:/var/run/frr# lsof *.pid	
COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME	
zebra 13138 frr 11uW REG 0,16 6 241 zebra.pid	
bgpd 13145 frr 11uW REG 0,16 6 634 bgpd.pid	
ripd 13156 frr 7uW REG 0,16 6 636 ripd.pid	
ripngd 13164 frr 7uW REG 0,16 6 638 ripngd.pid	
ospfd 13172 frr 8uW REG 0,16 6 640 ospfd.pid	
ospf6d 13180 frr 8uW REG 0,16 6 642 ospf6d.pid	
isisd 13188 frr 7uW REG 0,16 6 645 isisd.pid	
pimd 13196 frr 8uW REG 0,16 6 667 pimd.pid	
ldpd 13207 frr 11uW REG 0,16 6 678 ldpd.pid	
nhrpd 13215 frr 10uW REG 0,16 6 681 nhrpd.pid	
eigrpd 13224 frr 7uW REG 0,16 6 683 eigrpd.pid	
pbrd 13232 frr 7uW REG 0,16 6 685 pbrd.pid	
watchfrr 13240 root 7uW REG 0,16 6 689 watchfrr.pid	
root@dev:/var/run/frr# ps -elf | grep frr	
Warning: /boot/System.map-4.4.36-nn3-server not parseable as a System.map	
0 T root 2068 2065 0 80 0 - 6280 - 01:49 pts/2 00:00:00 editor /root/frr/.git/COMMIT_EDITMSG	
5 S frr 13138 1 0 75 -5 - 275138 ffffff 02:04 ? 00:00:00 /usr/lib/frr/zebra -s 90000000 --daemon -A 127.0.0.1	
5 S frr 13145 1 0 75 -5 - 49529 ffffff 02:04 ? 00:00:00 /usr/lib/frr/bgpd --daemon -A 127.0.0.1	
5 S frr 13156 1 0 75 -5 - 11781 - 02:04 ? 00:00:00 /usr/lib/frr/ripd --daemon -A 127.0.0.1	
5 S frr 13164 1 0 75 -5 - 11744 - 02:04 ? 00:00:00 /usr/lib/frr/ripngd --daemon -A ::1	
5 S frr 13172 1 0 75 -5 - 12036 - 02:04 ? 00:00:00 /usr/lib/frr/ospfd --daemon -A 127.0.0.1	
5 S frr 13180 1 0 75 -5 - 11882 - 02:04 ? 00:00:00 /usr/lib/frr/ospf6d --daemon -A ::1	
5 S frr 13188 1 0 75 -5 - 11846 - 02:04 ? 00:00:00 /usr/lib/frr/isisd --daemon -A 127.0.0.1	
5 S frr 13196 1 0 75 -5 - 11959 - 02:04 ? 00:00:00 /usr/lib/frr/pimd --daemon -A 127.0.0.1	
4 S frr 13205 1 0 75 -5 - 11201 - 02:04 ? 00:00:00 /usr/lib/frr/ldpd -L	
4 S frr 13206 1 0 75 -5 - 11238 - 02:04 ? 00:00:00 /usr/lib/frr/ldpd -E	
5 S frr 13207 1 0 75 -5 - 11957 - 02:04 ? 00:00:00 /usr/lib/frr/ldpd --daemon -A 127.0.0.1	
5 S frr 13215 1 0 75 -5 - 12382 - 02:04 ? 00:00:00 /usr/lib/frr/nhrpd --daemon -A 127.0.0.1	
5 S frr 13224 1 0 75 -5 - 11783 - 02:04 ? 00:00:00 /usr/lib/frr/eigrpd --daemon -A 127.0.0.1	
5 S frr 13232 1 0 75 -5 - 11701 - 02:04 ? 00:00:00 /usr/lib/frr/pbrd --daemon -A 127.0.0.1	
5 S root 13240 1 0 75 -5 - 11041 - 02:04 ? 00:00:01 /usr/lib/frr/watchfrr -d -r /usr/sbin/servicebBfrrbBrestartbB%s -s /usr/sbin/servicebBfrrbBstartbB%s -k /usr/sbin/servicebBfrrbBstopbB%s -b bB zebra bgpd ripd ripngd ospfd ospf6d isisd pimd ldpd nhrpd eigrpd pbrd	
0 S root 13356 9819 0 80 0 - 3556 - 02:34 pts/0 00:00:00 grep --color=auto frr	
root@dev:/var/run/frr# cat ospfd.pid	
13172	
root@dev:/var/run/frr# cat ospf6d.pid	
13180	
root@dev:/var/run/frr#	
root@dev:/usr/lib/frr# ./ospfd	
2018/08/24 00:26:49 unknown: Process 22652 has a write lock on file /var/run/frr/ospfd.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:26:49 unknown: There is already a OSPFD Process running, hence not allowing a second instance	
root@dev:/usr/lib/frr# ./ospf6d 	
2018/08/24 00:27:11 unknown: Process 22660 has a write lock on file /var/run/frr/ospf6d.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:27:11 unknown: There is already a OSPF6D Process running, hence not allowing a second instance	
root@dev:/usr/lib/frr# ./zebra 	
2018/08/24 00:27:18 unknown: Process 22618 has a write lock on file /var/run/frr/zebra.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:27:18 unknown: There is already a ZEBRA Process running, hence not allowing a second instance	
root@dev:/usr/lib/frr# ./ripd	
2018/08/24 00:27:30 unknown: Process 22636 has a write lock on file /var/run/frr/ripd.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:27:30 unknown: There is already a RIPD Process running, hence not allowing a second instance	
root@dev:/usr/lib/frr# ./ripngd 	
2018/08/24 00:27:38 unknown: Process 22644 has a write lock on file /var/run/frr/ripngd.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:27:38 unknown: There is already a RIPNGD Process running, hence not allowing a second instance	
root@dev:/usr/lib/frr# ./nhrpd 	
2018/08/24 00:27:46 unknown: Process 22695 has a write lock on file /var/run/frr/nhrpd.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:27:46 unknown: There is already a NHRPD Process running, hence not allowing a second instance	
root@dev:/usr/lib/frr# ./ldpd 	
2018/08/24 00:27:52 unknown: Process 22687 has a write lock on file /var/run/frr/ldpd.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:27:52 unknown: There is already a LDPD Process running, hence not allowing a second instance	
root@dev:/usr/lib/frr# ./isisd 	
2018/08/24 00:28:01 unknown: Process 22668 has a write lock on file /var/run/frr/isisd.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:28:01 unknown: There is already a ISISD Process running, hence not allowing a second instance	
root@dev:/usr/lib/frr# ./eigrpd 	
2018/08/24 00:28:10 unknown: Process 22704 has a write lock on file /var/run/frr/eigrpd.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:28:10 unknown: There is already a EGRPD Process running, hence not allowing a second instance	
root@dev:/usr/lib/frr# ./bgpd 	
2018/08/24 00:28:20 unknown: Process 22625 has a write lock on file /var/run/frr/bgpd.pid already! Error :( No such file or directory) 	
	
2018/08/24 00:28:20 unknown: There is already a BGPD Process running, hence not allowing a second instance)	
