### PR TITLE
bgpd: Fix CONFDATE to 2019 for a couple of items.

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2019,7 +2019,7 @@ DEFUN (no_bgp_fast_external_failover,
 }
 
 /* "bgp enforce-first-as" configuration. */
-#if CONFDATE > 20180517
+#if CONFDATE > 20190517
 CPP_NOTICE("bgpd: remove deprecated '[no] bgp enforce-first-as' commands")
 #endif
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7345,7 +7345,7 @@ static void bgp_config_write_family(struct vty *vty, struct bgp *bgp, afi_t afi,
 }
 
 /* clang-format off */
-#if CONFDATE > 20180517
+#if CONFDATE > 20190517
 CPP_NOTICE("bgpd: remove 'bgp enforce-first-as' config migration from bgp_config_write")
 #endif
 /* clang-format on */


### PR DESCRIPTION
While perusing CONFDATE I noticed that we had a couple
CONFDATE 201805, which we were not picking up( for other
reasons and fixed in a different PR ).  But upon investigation
of these I noticed that the commits where in 201805, so these
CONFDATES should be in 2019

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>