### PR TITLE
ospfd: interface speed change during intf add

### DIFF
--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -288,6 +288,7 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 	struct prefix_ipv4 asbr, p;
 	struct route_node *rn;
 	struct ospf_route *new, * or ;
+	char buf1[INET_ADDRSTRLEN];
 	int ret;
 
 	assert(lsa);
@@ -304,10 +305,14 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 		return 0;
 	}
 
-	if (IS_DEBUG_OSPF(lsa, LSA))
+	if (IS_DEBUG_OSPF(lsa, LSA)) {
+		snprintf(buf1, INET_ADDRSTRLEN, "%s",
+			 inet_ntoa(al->header.adv_router));
 		zlog_debug(
-			"Route[External]: Calculate AS-external-LSA to %s/%d",
-			inet_ntoa(al->header.id), ip_masklen(al->mask));
+			"Route[External]: Calculate AS-external-LSA to %s/%d adv_router %s",
+			inet_ntoa(al->header.id), ip_masklen(al->mask), buf1);
+	}
+
 	/* (1) If the cost specified by the LSA is LSInfinity, or if the
 	       LSA's LS age is equal to MaxAge, then examine the next LSA. */
 	if ((metric = GET_METRIC(al->e[0].metric)) >= OSPF_LS_INFINITY) {
@@ -459,8 +464,9 @@ int ospf_ase_calculate_route(struct ospf *ospf, struct ospf_lsa *lsa)
 
 	if (!rn || (or = rn->info) == NULL) {
 		if (IS_DEBUG_OSPF(lsa, LSA))
-			zlog_debug("Route[External]: Adding a new route %s/%d",
-				   inet_ntoa(p.prefix), p.prefixlen);
+			zlog_debug("Route[External]: Adding a new route %s/%d with paths %u",
+				   inet_ntoa(p.prefix), p.prefixlen,
+				   listcount(asbr_route->paths));
 
 		ospf_route_add(ospf->new_external_route, &p, new, asbr_route);
 


### PR DESCRIPTION
The problem is seen where speed mismatch caused ECMP route
not being reflected with correct number paths (NHs).

During cold boot, some interface speed updated by zebra as
part of one shot timer and triggers interface add to clients.
In this case, ospf already have created interface (bond interface),
but speed was not updated, trigger to do interface speed change
as part of interface add, which will trigger all Router LSA to
use updated speed into cost calculation.

Testing Done:
Bring up CLOS config with Spine and leafs. Leaf have CLAG pair,
with same VRR ip address.
At spine one of the bond connecting to leaf node was having
higher speed than the paired device, With this fix, at spine (DUT)
bond interface speed is equal from all peer nodes.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>