### PR TITLE
lib: remove Linux 2.4 TCP-MD5 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -418,8 +418,6 @@ AC_ARG_ENABLE(rusage,
   AS_HELP_STRING([--disable-rusage], [disable using getrusage]))
 AC_ARG_ENABLE(gcc_ultra_verbose,
   AS_HELP_STRING([--enable-gcc-ultra-verbose], [enable ultra verbose GCC warnings]))
-AC_ARG_ENABLE(linux24_tcp_md5,
-  AS_HELP_STRING([--enable-linux24-tcp-md5], [enable support for old, Linux-2.4 RFC2385 patch]))
 AC_ARG_ENABLE(backtrace,
   AS_HELP_STRING([--disable-backtrace,], [disable crash backtraces (default autodetect)]))
 AC_ARG_ENABLE(time-check,
@@ -643,10 +641,6 @@ AM_CONDITIONAL([HAVE_PROTOBUF], [test "x$have_protobuf" = "xyes"])
 #
 # End of logic for protobuf support.
 #
-
-if test "${enable_linux24_tcp_md5}" = "yes"; then
-  AC_DEFINE(HAVE_TCP_MD5_LINUX24,,Old Linux 2.4 TCP MD5 Signature Patch)
-fi
 
 AC_MSG_CHECKING(if zebra should be configurable to send Route Advertisements)
 if test "${enable_rtadv}" != "no"; then

--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -580,31 +580,7 @@ int sockopt_tcp_rtt(int sock)
 
 int sockopt_tcp_signature(int sock, union sockunion *su, const char *password)
 {
-#if defined(HAVE_TCP_MD5_LINUX24) && defined(GNU_LINUX)
-/* Support for the old Linux 2.4 TCP-MD5 patch, taken from Hasso Tepper's
- * version of the Quagga patch (based on work by Rick Payne, and Bruce
- * Simpson)
- */
-#define TCP_MD5_AUTH 13
-#define TCP_MD5_AUTH_ADD 1
-#define TCP_MD5_AUTH_DEL 2
-	struct tcp_rfc2385_cmd {
-		uint8_t command;  /* Command - Add/Delete */
-		uint32_t address; /* IPV4 address associated */
-		uint8_t keylen;   /* MD5 Key len (do NOT assume 0 terminated
-				      ascii) */
-		void *key;	 /* MD5 Key */
-	} cmd;
-	struct in_addr *addr = &su->sin.sin_addr;
-
-	cmd.command = (password != NULL ? TCP_MD5_AUTH_ADD : TCP_MD5_AUTH_DEL);
-	cmd.address = addr->s_addr;
-	cmd.keylen = (password != NULL ? strlen(password) : 0);
-	cmd.key = password;
-
-	return setsockopt(sock, IPPROTO_TCP, TCP_MD5_AUTH, &cmd, sizeof cmd);
-
-#elif HAVE_DECL_TCP_MD5SIG
+#if HAVE_DECL_TCP_MD5SIG
 	int ret;
 #ifndef GNU_LINUX
 	/*


### PR DESCRIPTION
Linux 2.6.0 was released in December of 2003... I'm pretty sure we don't
need this Linux 2.4 support anymore.

Signed-off-by: David Lamparter <equinox@diac24.net>