### PR TITLE
watchfrr: fix global restart

### DIFF
--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -314,6 +314,9 @@ static int restart_kill(struct thread *t_kill)
 static struct restart_info *find_child(pid_t child)
 {
 	struct daemon *dmn;
+	if (gs.restart.pid == child)
+		return &gs.restart;
+
 	for (dmn = gs.daemons; dmn; dmn = dmn->next) {
 		if (dmn->restart.pid == child)
 			return &dmn->restart;


### PR DESCRIPTION
watchfrr needs to handle a SIGCHLD also when it calls a global restart
command. Before this patch, it would lead to the following behavior:

15:44:28: zebra state -> down : unexpected read error: Connection reset by peer
15:44:33: Forked background command [pid 6392]: /usr/sbin/frr.init watchrestart all
15:44:53: Warning: restart all child process 6392 still running after 20 seconds, sending signal 15
15:44:53: waitpid returned status for an unknown child process 6392
15:44:53: background (unknown) process 6392 terminated due to signal 15
15:45:13: Warning: restart all child process 6392 still running after 40 seconds, sending signal 9
15:45:33: Warning: restart all child process 6392 still running after 60 seconds, sending signal 9
15:45:53: Warning: restart all child process 6392 still running after 80 seconds, sending signal 9
15:46:13: Warning: restart all child process 6392 still running after 100 seconds, sending signal 9
15:46:33: Warning: restart all child process 6392 still running after 120 seconds, sending signal 9
15:46:53: Warning: restart all child process 6392 still running after 140 seconds, sending signal 9

This is obviously incorrect and can be fixed by comparing the pid to
the global restart object as well.

Signed-off-by: Christian Franke <chris@opensourcerouting.org>