### PR TITLE
zebra: when veth link is used across vrf, the link may not be good

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -259,6 +259,8 @@ static void netlink_determine_zebra_iftype(char *kind, zebra_iftype_t *zif_type)
 		*zif_type = ZEBRA_IF_VXLAN;
 	else if (strcmp(kind, "macvlan") == 0)
 		*zif_type = ZEBRA_IF_MACVLAN;
+	else if (strcmp(kind, "veth") == 0)
+		*zif_type = ZEBRA_IF_VETH;
 }
 
 #define parse_rtattr_nested(tb, max, rta)                                      \

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -675,7 +675,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		SET_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK);
 
 	/* Update link. */
-	zebra_if_update_link(ifp, link_ifindex);
+	zebra_if_update_link(ifp, link_ifindex, ns_id);
 
 	/* Hardware type and address. */
 	ifp->ll_type = netlink_to_zebra_link_type(ifi->ifi_type);
@@ -1262,7 +1262,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 					 ZEBRA_INTERFACE_VRF_LOOPBACK);
 
 			/* Update link. */
-			zebra_if_update_link(ifp, link_ifindex);
+			zebra_if_update_link(ifp, link_ifindex, ns_id);
 
 			netlink_interface_update_hw_addr(tb, ifp);
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1007,6 +1007,8 @@ void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,
 {
 	struct zebra_if *zif;
 
+	if (IS_ZEBRA_IF_VETH(ifp))
+		return;
 	zif = (struct zebra_if *)ifp->info;
 	zif->link_ifindex = link_ifindex;
 	zif->link = if_lookup_by_index_per_ns(zebra_ns_lookup(ns_id),
@@ -1092,6 +1094,10 @@ static const char *zebra_ziftype_2str(zebra_iftype_t zif_type)
 
 	case ZEBRA_IF_VRF:
 		return "VRF";
+		break;
+
+	case ZEBRA_IF_VETH:
+		return "VETH";
 		break;
 
 	default:

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1002,13 +1002,14 @@ void if_refresh(struct interface *ifp)
 	if_get_flags(ifp);
 }
 
-void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex)
+void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,
+			  ns_id_t ns_id)
 {
 	struct zebra_if *zif;
 
 	zif = (struct zebra_if *)ifp->info;
 	zif->link_ifindex = link_ifindex;
-	zif->link = if_lookup_by_index_per_ns(zebra_ns_lookup(NS_DEFAULT),
+	zif->link = if_lookup_by_index_per_ns(zebra_ns_lookup(ns_id),
 					      link_ifindex);
 }
 

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -344,7 +344,8 @@ extern int if_subnet_add(struct interface *, struct connected *);
 extern int if_subnet_delete(struct interface *, struct connected *);
 extern int ipv6_address_configured(struct interface *ifp);
 extern void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id);
-extern void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex);
+extern void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,
+				 ns_id_t ns_id);
 
 extern void vrf_add_update(struct vrf *vrfp);
 

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -191,6 +191,7 @@ typedef enum {
 	ZEBRA_IF_BRIDGE,    /* bridge device */
 	ZEBRA_IF_VLAN,      /* VLAN sub-interface */
 	ZEBRA_IF_MACVLAN,   /* MAC VLAN interface*/
+	ZEBRA_IF_VETH,      /* VETH interface*/
 } zebra_iftype_t;
 
 /* Zebra "slave" interface type */
@@ -312,7 +313,10 @@ static inline void zebra_if_set_ziftype(struct interface *ifp,
 #define IS_ZEBRA_IF_MACVLAN(ifp)                                               \
 	(((struct zebra_if *)(ifp->info))->zif_type == ZEBRA_IF_MACVLAN)
 
-#define IS_ZEBRA_IF_BRIDGE_SLAVE(ifp)                                          \
+#define IS_ZEBRA_IF_VETH(ifp)                                               \
+	(((struct zebra_if *)(ifp->info))->zif_type == ZEBRA_IF_VETH)
+
+#define IS_ZEBRA_IF_BRIDGE_SLAVE(ifp)					\
 	(((struct zebra_if *)(ifp->info))->zif_slave_type                      \
 	 == ZEBRA_IF_SLAVE_BRIDGE)
 


### PR DESCRIPTION
This function is changed so that the interface index is searched across
the correct namespace.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>