### PR TITLE
pimd: Add some more useful data to debug output

### DIFF
--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -332,8 +332,9 @@ static int pim_sock_read(struct thread *t)
 		if (!ifp || !ifp->info) {
 			if (PIM_DEBUG_PIM_PACKETS)
 				zlog_debug(
-					"%s: Received incoming pim packet on interface not yet configured for pim",
-					__PRETTY_FUNCTION__);
+					"%s: Received incoming pim packet on interface(%s:%d) not yet configured for pim",
+					__PRETTY_FUNCTION__,
+					ifp ? ifp->name : "Unknown", ifindex);
 			goto done;
 		}
 		int fail = pim_pim_packet(ifp, buf, len);


### PR DESCRIPTION
End user was seeing this debug but we are not giving
the user enough information to debug this on his own.
Add a tiny bit of extra information that could point
the user to solving the problem for themselves.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>