### PR TITLE
fix zebra crash when a vrf interface changes with netns implementation for vrf

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -387,31 +387,31 @@ struct interface *if_get_by_name(const char *name, vrf_id_t vrf_id, int vty)
 			return NULL;
 		}
 		return if_create(name, vrf_id);
-	} else {
-		ifp = if_lookup_by_name_all_vrf(name);
-		if (ifp) {
-			if (ifp->vrf_id == vrf_id)
-				return ifp;
-			/* Found a match on a different VRF. If the interface
-			 * command was entered in vty without a VRF (passed as
-			 * VRF_DEFAULT), accept the ifp we found. If a vrf was
-			 * entered and there is a mismatch, reject it if from
-			 * vty. If it came from the kernel or by way of zclient,
-			 * believe it and update the ifp accordingly.
-			 */
-			if (vty) {
-				if (vrf_id == VRF_DEFAULT)
-					return ifp;
-				return NULL;
-			}
-			/* If it came from the kernel or by way of zclient,
-			 * believe it and update the ifp accordingly.
-			 */
-			if_update_to_new_vrf(ifp, vrf_id);
-			return ifp;
-		}
-		return if_create(name, vrf_id);
 	}
+	/* vrf is based on vrf-lite */
+	ifp = if_lookup_by_name_all_vrf(name);
+	if (ifp) {
+		if (ifp->vrf_id == vrf_id)
+			return ifp;
+		/* Found a match on a different VRF. If the interface command
+		 * was entered in vty without a VRF (passed as VRF_DEFAULT),
+		 * accept the ifp we found. If a vrf was entered and there is a
+		 * mismatch, reject it if from vty. If it came from the kernel
+		 * or by way of zclient, believe it and update the ifp
+		 * accordingly.
+		 */
+		if (vty) {
+			if (vrf_id == VRF_DEFAULT)
+				return ifp;
+			return NULL;
+		}
+		/* If it came from the kernel or by way of zclient, believe it
+		 * and update the ifp accordingly.
+		 */
+		if_update_to_new_vrf(ifp, vrf_id);
+		return ifp;
+	}
+	return if_create(name, vrf_id);
 }
 
 void if_set_index(struct interface *ifp, ifindex_t ifindex)

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -493,18 +493,14 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 			  "vrf_init: failed to create the default VRF!");
 		exit(1);
 	}
-	if (vrf_is_backend_netns())
-		strlcpy(default_vrf->data.l.netns_name,
-			VRF_DEFAULT_NAME, NS_NAMSIZ);
-
 	if (vrf_is_backend_netns()) {
 		struct ns *ns;
 
 		strlcpy(default_vrf->data.l.netns_name,
 			VRF_DEFAULT_NAME, NS_NAMSIZ);
 		ns = ns_lookup(ns_get_default_id());
-		ns->vrf_ctxt = (void *)default_vrf;
-		default_vrf->ns_ctxt = (void *)ns;
+		ns->vrf_ctxt = default_vrf;
+		default_vrf->ns_ctxt = ns;
 	}
 
 	/* Enable the default VRF. */

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -497,6 +497,16 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 		strlcpy(default_vrf->data.l.netns_name,
 			VRF_DEFAULT_NAME, NS_NAMSIZ);
 
+	if (vrf_is_backend_netns()) {
+		struct ns *ns;
+
+		strlcpy(default_vrf->data.l.netns_name,
+			VRF_DEFAULT_NAME, NS_NAMSIZ);
+		ns = ns_lookup(ns_get_default_id());
+		ns->vrf_ctxt = (void *)default_vrf;
+		default_vrf->ns_ctxt = (void *)ns;
+	}
+
 	/* Enable the default VRF. */
 	if (!vrf_enable(default_vrf)) {
 		flog_err(LIB_ERR_VRF_START,
@@ -710,8 +720,6 @@ int vrf_netns_handler_create(struct vty *vty, struct vrf *vrf, char *pathname,
 int vrf_is_mapped_on_netns(struct vrf *vrf)
 {
 	if (!vrf || vrf->data.l.netns_name[0] == '\0')
-		return 0;
-	if (vrf->vrf_id == VRF_DEFAULT)
 		return 0;
 	return 1;
 }

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -733,7 +733,7 @@ void if_delete_update(struct interface *ifp)
 	 * occur with this implementation whereas it is not possible with
 	 * vrf-lite).
 	 */
-	if ((ifp->vrf_id) && !vrf_is_backend_netns())
+	if (ifp->vrf_id && !vrf_is_backend_netns())
 		if_handle_vrf_change(ifp, VRF_DEFAULT);
 
 	/* Reset some zebra interface params to default values. */

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -324,8 +324,6 @@ extern void zebra_if_init(void);
 extern struct interface *if_lookup_by_index_per_ns(struct zebra_ns *, uint32_t);
 extern struct interface *if_lookup_by_name_per_ns(struct zebra_ns *,
 						  const char *);
-extern struct interface *if_lookup_by_name_not_ns(ns_id_t ns_id,
-						  const char *ifname);
 extern struct interface *if_link_per_ns(struct zebra_ns *, struct interface *);
 extern const char *ifindex2ifname_per_ns(struct zebra_ns *, unsigned int);
 


### PR DESCRIPTION
When an interface is moved from vrfX to default vrf and then move back to the vrfX it is possible to have a crash of zebra.
This crash is due to a desynchronization of the interface belonging to the different vrfs at zebra level and at namespace level.
This case occurs with a specific reception of netlink messages.

To fix the issue old method to manage vrf change of an interface has been reverted and a new one is implemented. This method allows to have two interfaces with the same name in two different netns (that was not allow in the previous implementation) to avoid desynchronization issue and reduces the number of case where the vrf implementation is tested (i.e. the difference between netns and vrf-lite is smaller)

Behavior of vrf change for vrf-lite implementation is unchanged.