### PR TITLE
bgpd/ospfd: make bgp and ospf json response a bit more consistent

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -530,7 +530,7 @@ void bgp_bfd_peer_config_write(struct vty *vty, struct peer *peer, char *addr)
 /*
  * bgp_bfd_show_info - Show the peer BFD information.
  */
-void bgp_bfd_show_info(struct vty *vty, struct peer *peer, uint8_t use_json,
+void bgp_bfd_show_info(struct vty *vty, struct peer *peer, bool use_json,
 		       json_object *json_neigh)
 {
 	bfd_show_info(vty, (struct bfd_info *)peer->bfd_info,

--- a/bgpd/bgp_bfd.h
+++ b/bgpd/bgp_bfd.h
@@ -34,8 +34,8 @@ extern void bgp_bfd_deregister_peer(struct peer *peer);
 extern void bgp_bfd_peer_config_write(struct vty *vty, struct peer *peer,
 				      char *addr);
 
-extern void bgp_bfd_show_info(struct vty *vty, struct peer *peer,
-			      uint8_t use_json, json_object *json_neigh);
+extern void bgp_bfd_show_info(struct vty *vty, struct peer *peer, bool use_json,
+			      json_object *json_neigh);
 
 extern int bgp_bfd_is_peer_multihop(struct peer *peer);
 

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -523,7 +523,7 @@ void bgp_config_write_damp(struct vty *vty)
 }
 
 static const char *bgp_get_reuse_time(unsigned int penalty, char *buf,
-				      size_t len, uint8_t use_json,
+				      size_t len, bool use_json,
 				      json_object *json)
 {
 	time_t reuse_time = 0;
@@ -641,7 +641,7 @@ void bgp_damp_info_vty(struct vty *vty, struct bgp_info *binfo,
 }
 
 const char *bgp_damp_reuse_time_vty(struct vty *vty, struct bgp_info *binfo,
-				    char *timebuf, size_t len, uint8_t use_json,
+				    char *timebuf, size_t len, bool use_json,
 				    json_object *json)
 {
 	struct bgp_damp_info *bdi;

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -140,8 +140,10 @@ extern int bgp_damp_decay(time_t, int);
 extern void bgp_config_write_damp(struct vty *);
 extern void bgp_damp_info_vty(struct vty *, struct bgp_info *,
 			      json_object *json_path);
-extern const char *bgp_damp_reuse_time_vty(struct vty *, struct bgp_info *,
-					   char *, size_t, bool, json_object *);
+extern const char *bgp_damp_reuse_time_vty(struct vty *vty,
+					   struct bgp_info *binfo,
+					   char *timebuf, size_t len,
+					   bool use_json, json_object *json);
 extern int bgp_show_dampening_parameters(struct vty *vty, afi_t, safi_t);
 
 #endif /* _QUAGGA_BGP_DAMP_H */

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -141,8 +141,7 @@ extern void bgp_config_write_damp(struct vty *);
 extern void bgp_damp_info_vty(struct vty *, struct bgp_info *,
 			      json_object *json_path);
 extern const char *bgp_damp_reuse_time_vty(struct vty *, struct bgp_info *,
-					   char *, size_t, uint8_t,
-					   json_object *);
+					   char *, size_t, bool, json_object *);
 extern int bgp_show_dampening_parameters(struct vty *vty, afi_t, safi_t);
 
 #endif /* _QUAGGA_BGP_DAMP_H */

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -983,7 +983,7 @@ static void show_vni_entry(struct hash_backet *backet, void *args[])
 
 static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 				 enum bgp_show_type type, void *output_arg,
-				 int option, uint8_t use_json)
+				 int option, bool use_json)
 {
 	afi_t afi = AFI_L2VPN;
 	struct bgp *bgp;
@@ -1276,7 +1276,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_neighbor_routes,
 	union sockunion su;
 	struct peer *peer;
 	int ret;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	argv_find(argv, argc, "A.B.C.D", &idx_ipv4);
 
@@ -1336,7 +1336,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
 	union sockunion su;
 	struct peer *peer;
 	struct prefix_rd prd;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	argv_find(argv, argc, "ASN:NN_OR_IP-ADDRESS:NN", &idx_ext_community);
 	argv_find(argv, argc, "A.B.C.D", &idx_ipv4);
@@ -1409,7 +1409,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_all_neighbor_advertised_routes,
 	int ret;
 	struct peer *peer;
 	union sockunion su;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	argv_find(argv, argc, "A.B.C.D", &idx_ipv4);
 
@@ -1467,7 +1467,7 @@ DEFUN(show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes,
 	struct peer *peer;
 	struct prefix_rd prd;
 	union sockunion su;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	argv_find(argv, argc, "ASN:NN_OR_IP-ADDRESS:NN", &idx_ext_community);
 	argv_find(argv, argc, "A.B.C.D", &idx_ipv4);
@@ -3172,7 +3172,7 @@ DEFUN(show_bgp_l2vpn_evpn_vni,
 	struct bgp *bgp_def;
 	vni_t vni;
 	int idx = 0;
-	uint8_t uj = 0;
+	bool uj = false;
 	json_object *json = NULL;
 	uint32_t num_l2vnis = 0;
 	uint32_t num_l3vnis = 0;
@@ -3255,7 +3255,7 @@ DEFUN(show_bgp_l2vpn_evpn_es,
       JSON_STR)
 {
 	int idx = 0;
-	uint8_t uj = 0;
+	bool uj = false;
 	esi_t esi;
 	json_object *json = NULL;
 	struct bgp *bgp = NULL;
@@ -3312,7 +3312,7 @@ DEFUN(show_bgp_l2vpn_evpn_summary,
       JSON_STR)
 {
 	int idx_vrf = 0;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	char *vrf = NULL;
 
 	if (argv_find(argv, argc, "vrf", &idx_vrf))
@@ -3341,7 +3341,7 @@ DEFUN(show_bgp_l2vpn_evpn_route,
 	struct bgp *bgp;
 	int type_idx = 0;
 	int type = 0;
-	uint8_t uj = 0;
+	bool uj = false;
 	json_object *json = NULL;
 
 	uj = use_json(argc, argv);
@@ -3404,7 +3404,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd,
 	int type = 0;
 	int rd_idx = 0;
 	int type_idx = 0;
-	int uj = 0;
+	bool uj = false;
 	json_object *json = NULL;
 
 	bgp = bgp_get_default();
@@ -3477,7 +3477,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_rd_macip,
 	int rd_idx = 0;
 	int mac_idx = 0;
 	int ip_idx = 0;
-	int uj = 0;
+	bool uj = false;
 	json_object *json = NULL;
 
 	memset(&mac, 0, sizeof(struct ethaddr));
@@ -3541,7 +3541,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_esi,
       "ESI ID\n"
       JSON_STR)
 {
-	int uj = 0;
+	bool uj = false;
 	esi_t esi;
 	struct bgp *bgp = NULL;
 	json_object *json = NULL;
@@ -3597,7 +3597,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_vni, show_bgp_l2vpn_evpn_route_vni_cmd,
 	struct in_addr vtep_ip;
 	int type = 0;
 	int idx = 0;
-	int uj = 0;
+	bool uj = false;
 	json_object *json = NULL;
 
 	bgp = bgp_get_default();
@@ -3669,7 +3669,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_vni_macip,
 	struct ethaddr mac;
 	struct ipaddr ip;
 	int idx = 0;
-	int uj = 0;
+	bool uj = false;
 	json_object *json = NULL;
 
 	bgp = bgp_get_default();
@@ -3737,7 +3737,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_vni_multicast,
 	int ret;
 	struct in_addr orig_ip;
 	int idx = 0;
-	int uj = 0;
+	bool uj = false;
 	json_object *json = NULL;
 
 	bgp = bgp_get_default();
@@ -3793,7 +3793,7 @@ DEFUN(show_bgp_l2vpn_evpn_route_vni_all,
 	struct bgp *bgp;
 	struct in_addr vtep_ip;
 	int idx = 0;
-	int uj = 0;
+	bool uj = false;
 	json_object *json = NULL;
 
 	bgp = bgp_get_default();
@@ -3841,7 +3841,7 @@ DEFUN(show_bgp_l2vpn_evpn_vrf_import_rt,
       "Show vrf import route target\n"
       JSON_STR)
 {
-	uint8_t uj = 0;
+	bool uj = false;
 	struct bgp *bgp_def = NULL;
 	json_object *json = NULL;
 
@@ -3878,7 +3878,7 @@ DEFUN(show_bgp_l2vpn_evpn_import_rt,
       JSON_STR)
 {
 	struct bgp *bgp;
-	uint8_t uj = 0;
+	bool uj = false;
 	json_object *json = NULL;
 
 	bgp = bgp_get_default();
@@ -4359,7 +4359,7 @@ DEFUN (show_bgp_vrf_l3vni_info,
 	json_object *json_vnis = NULL;
 	json_object *json_export_rts = NULL;
 	json_object *json_import_rts = NULL;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (uj) {
 		json = json_object_new_object();

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1775,7 +1775,7 @@ DEFUN (no_vpnv6_network,
 
 int bgp_show_mpls_vpn(struct vty *vty, afi_t afi, struct prefix_rd *prd,
 		      enum bgp_show_type type, void *output_arg, int tags,
-		      uint8_t use_json)
+		      bool use_json)
 {
 	struct bgp *bgp;
 	struct bgp_table *table;
@@ -1953,7 +1953,7 @@ DEFUN (show_ip_bgp_vpn_all_neighbor_routes,
 	union sockunion su;
 	struct peer *peer;
 	int ret;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	afi_t afi;
 	int idx = 0;
 
@@ -2017,7 +2017,7 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_routes,
 	union sockunion su;
 	struct peer *peer;
 	struct prefix_rd prd;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	afi_t afi;
 	int idx = 0;
 
@@ -2095,7 +2095,7 @@ DEFUN (show_ip_bgp_vpn_all_neighbor_advertised_routes,
 	int ret;
 	struct peer *peer;
 	union sockunion su;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	afi_t afi;
 	int idx = 0;
 
@@ -2157,7 +2157,7 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_advertised_routes,
 	struct peer *peer;
 	struct prefix_rd prd;
 	union sockunion su;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	afi_t afi;
 	int idx = 0;
 

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -50,7 +50,7 @@ extern int argv_find_and_parse_vpnvx(struct cmd_token **argv, int argc,
 				     int *index, afi_t *afi);
 extern int bgp_show_mpls_vpn(struct vty *vty, afi_t afi, struct prefix_rd *prd,
 			     enum bgp_show_type type, void *output_arg,
-			     int tags, uint8_t use_json);
+			     int tags, bool use_json);
 
 extern void vpn_leak_from_vrf_update(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
 				     struct bgp_info *info_vrf);

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -52,8 +52,8 @@
    Next, if we send capability to the peer we want to set my capabilty
    inforation at each peer. */
 
-void bgp_capability_vty_out(struct vty *vty, struct peer *peer,
-			    uint8_t use_json, json_object *json_neigh)
+void bgp_capability_vty_out(struct vty *vty, struct peer *peer, bool use_json,
+			    json_object *json_neigh)
 {
 	char *pnt;
 	char *end;

--- a/bgpd/bgp_open.h
+++ b/bgpd/bgp_open.h
@@ -86,7 +86,7 @@ struct graceful_restart_af {
 
 extern int bgp_open_option_parse(struct peer *, uint8_t, int *);
 extern void bgp_open_capability(struct stream *, struct peer *);
-extern void bgp_capability_vty_out(struct vty *, struct peer *, uint8_t,
+extern void bgp_capability_vty_out(struct vty *, struct peer *, bool,
 				   json_object *);
 extern as_t peek_for_as4_capability(struct peer *, uint8_t);
 

--- a/bgpd/bgp_open.h
+++ b/bgpd/bgp_open.h
@@ -86,8 +86,8 @@ struct graceful_restart_af {
 
 extern int bgp_open_option_parse(struct peer *, uint8_t, int *);
 extern void bgp_open_capability(struct stream *, struct peer *);
-extern void bgp_capability_vty_out(struct vty *, struct peer *, bool,
-				   json_object *);
+extern void bgp_capability_vty_out(struct vty *vty, struct peer *peer,
+				   bool use_json, json_object *json_neigh);
 extern as_t peek_for_as4_capability(struct peer *, uint8_t);
 
 #endif /* _QUAGGA_BGP_OPEN_H */

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -435,8 +435,9 @@ extern void route_vty_out(struct vty *, struct prefix *, struct bgp_info *, int,
 			  safi_t, json_object *);
 extern void route_vty_out_tag(struct vty *, struct prefix *, struct bgp_info *,
 			      int, safi_t, json_object *);
-extern void route_vty_out_tmp(struct vty *, struct prefix *, struct attr *,
-			      safi_t, bool, json_object *);
+extern void route_vty_out_tmp(struct vty *vty, struct prefix *p,
+			      struct attr *attr, safi_t safi, bool use_json,
+			      json_object *json_ar);
 extern void route_vty_out_overlay(struct vty *vty, struct prefix *p,
 				  struct bgp_info *binfo, int display,
 				  json_object *json);

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -436,7 +436,7 @@ extern void route_vty_out(struct vty *, struct prefix *, struct bgp_info *, int,
 extern void route_vty_out_tag(struct vty *, struct prefix *, struct bgp_info *,
 			      int, safi_t, json_object *);
 extern void route_vty_out_tmp(struct vty *, struct prefix *, struct attr *,
-			      safi_t, uint8_t, json_object *);
+			      safi_t, bool, json_object *);
 extern void route_vty_out_overlay(struct vty *vty, struct prefix *p,
 				  struct bgp_info *binfo, int display,
 				  json_object *json);
@@ -484,5 +484,5 @@ extern void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 extern int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, safi_t safi,
 			     struct bgp_table *table, struct prefix_rd *prd,
 			     enum bgp_show_type type, void *output_arg,
-			     uint8_t use_json);
+			     bool use_json);
 #endif /* _QUAGGA_BGP_ROUTE_H */

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -32,7 +32,7 @@
 
 int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 		       struct prefix_rd *prd, afi_t afi, safi_t safi,
-		       uint8_t use_json)
+		       bool use_json)
 {
 	struct bgp *bgp;
 	struct bgp_table *table;

--- a/bgpd/bgp_vpn.h
+++ b/bgpd/bgp_vpn.h
@@ -25,6 +25,6 @@
 
 extern int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 			      struct prefix_rd *prd, afi_t afi, safi_t safi,
-			      uint8_t use_json);
+			      bool use_json);
 
 #endif /* _QUAGGA_BGP_VPN_H */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -301,7 +301,7 @@ int argv_find_and_parse_safi(struct cmd_token **argv, int argc, int *index,
 int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 					struct cmd_token **argv, int argc,
 					int *idx, afi_t *afi, safi_t *safi,
-					struct bgp **bgp)
+					struct bgp **bgp, bool use_json)
 {
 	char *vrf_name = NULL;
 
@@ -321,9 +321,11 @@ int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 		else {
 			*bgp = bgp_lookup_by_name(vrf_name);
 			if (!*bgp) {
-				vty_out(vty,
-					"View/Vrf specified is unknown: %s\n",
-					vrf_name);
+				use_json
+					? vty_out(vty, "{}\n")
+					: vty_out(vty,
+						  "View/Vrf specified is unknown: %s\n",
+						  vrf_name);
 				*idx = 0;
 				return 0;
 			}
@@ -331,7 +333,10 @@ int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 	} else {
 		*bgp = bgp_get_default();
 		if (!*bgp) {
-			vty_out(vty, "Unable to find default BGP instance\n");
+			use_json
+				? vty_out(vty, "{}\n")
+				: vty_out(vty,
+					  "Unable to find default BGP instance\n");
 			*idx = 0;
 			return 0;
 		}
@@ -7317,7 +7322,7 @@ DEFUN (show_bgp_vrfs,
 	struct list *inst = bm->bgp;
 	struct listnode *node;
 	struct bgp *bgp;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	json_object *json = NULL;
 	json_object *json_vrfs = NULL;
 	int count = 0;
@@ -7638,7 +7643,7 @@ static void bgp_show_bestpath_json(struct bgp *bgp, json_object *json)
 
 /* Show BGP peer's summary information. */
 static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
-			    uint8_t use_json, json_object *json)
+			    bool use_json, json_object *json)
 {
 	struct peer *peer;
 	struct listnode *node, *nnode;
@@ -8055,14 +8060,14 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 }
 
 static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
-				      int safi, uint8_t use_json,
+				      int safi, bool use_json,
 				      json_object *json)
 {
 	int is_first = 1;
 	int afi_wildcard = (afi == AFI_MAX);
 	int safi_wildcard = (safi == SAFI_MAX);
 	int is_wildcard = (afi_wildcard || safi_wildcard);
-	bool json_output = false;
+	bool nbr_output = false;
 
 	if (use_json && is_wildcard)
 		vty_out(vty, "{\n");
@@ -8073,7 +8078,7 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 			safi = 1; /* SAFI_UNICAST */
 		while (safi < SAFI_MAX) {
 			if (bgp_afi_safi_peer_exists(bgp, afi, safi)) {
-				json_output = true;
+				nbr_output = true;
 				if (is_wildcard) {
 					/*
 					 * So limit output to those afi/safi
@@ -8112,22 +8117,25 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 
 	if (use_json && is_wildcard)
 		vty_out(vty, "}\n");
-	else if (use_json && !json_output)
-		vty_out(vty, "{}\n");
+	else if (!nbr_output)
+		use_json ? vty_out(vty, "{}\n")
+			 : vty_out(vty, "%% No BGP neighbors found\n");
 }
 
 static void bgp_show_all_instances_summary_vty(struct vty *vty, afi_t afi,
-					       safi_t safi, uint8_t use_json)
+					       safi_t safi, bool use_json)
 {
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
 	json_object *json = NULL;
 	int is_first = 1;
+	bool nbr_output = false;
 
 	if (use_json)
 		vty_out(vty, "{\n");
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+		nbr_output = true;
 		if (use_json) {
 			json = json_object_new_object();
 
@@ -8151,10 +8159,12 @@ static void bgp_show_all_instances_summary_vty(struct vty *vty, afi_t afi,
 
 	if (use_json)
 		vty_out(vty, "}\n");
+	else if (!nbr_output)
+		vty_out(vty, "%% BGP instance not found\n");
 }
 
 int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
-			 safi_t safi, uint8_t use_json)
+			 safi_t safi, bool use_json)
 {
 	struct bgp *bgp;
 
@@ -8167,11 +8177,10 @@ int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
 			bgp = bgp_lookup_by_name(name);
 
 			if (!bgp) {
-				if (use_json)
-					vty_out(vty, "{}\n");
-				else
-					vty_out(vty,
-						"%% No such BGP instance exist\n");
+				use_json
+					? vty_out(vty, "{}\n")
+					: vty_out(vty,
+						  "%% BGP instance not found\n");
 				return CMD_WARNING;
 			}
 
@@ -8185,6 +8194,11 @@ int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
 
 	if (bgp)
 		bgp_show_summary_afi_safi(vty, bgp, afi, safi, use_json, NULL);
+	else {
+		use_json ? vty_out(vty, "{}\n")
+			 : vty_out(vty, "%% No such BGP instance exist\n");
+		return CMD_WARNING;
+	}
 
 	return CMD_SUCCESS;
 }
@@ -8220,7 +8234,7 @@ DEFUN (show_ip_bgp_summary,
 		argv_find_and_parse_safi(argv, argc, &idx, &safi);
 	}
 
-	int uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	return bgp_show_summary_vty(vty, vrf, afi, safi, uj);
 }
@@ -8302,7 +8316,7 @@ static void bgp_show_peer_afi_orf_cap(struct vty *vty, struct peer *p,
 				      afi_t afi, safi_t safi,
 				      uint16_t adv_smcap, uint16_t adv_rmcap,
 				      uint16_t rcv_smcap, uint16_t rcv_rmcap,
-				      uint8_t use_json, json_object *json_pref)
+				      bool use_json, json_object *json_pref)
 {
 	/* Send-Mode */
 	if (CHECK_FLAG(p->af_cap[afi][safi], adv_smcap)
@@ -8362,7 +8376,7 @@ static void bgp_show_peer_afi_orf_cap(struct vty *vty, struct peer *p,
 }
 
 static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
-			      safi_t safi, uint8_t use_json,
+			      safi_t safi, bool use_json,
 			      json_object *json_neigh)
 {
 	struct bgp_filter *filter;
@@ -8937,7 +8951,7 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 	}
 }
 
-static void bgp_show_peer(struct vty *vty, struct peer *p, uint8_t use_json,
+static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 			  json_object *json)
 {
 	struct bgp *bgp;
@@ -10684,12 +10698,13 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, uint8_t use_json,
 
 static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp,
 			     enum show_type type, union sockunion *su,
-			     const char *conf_if, uint8_t use_json,
+			     const char *conf_if, bool use_json,
 			     json_object *json)
 {
 	struct listnode *node, *nnode;
 	struct peer *peer;
 	int find = 0;
+	bool nbr_output = false;
 
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 		if (!CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
@@ -10698,6 +10713,7 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp,
 		switch (type) {
 		case show_all:
 			bgp_show_peer(vty, peer, use_json, json);
+			nbr_output = true;
 			break;
 		case show_peer:
 			if (conf_if) {
@@ -10727,6 +10743,9 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp,
 			vty_out(vty, "%% No such neighbor in this view/vrf\n");
 	}
 
+	if (type != show_peer && !nbr_output && !use_json)
+		vty_out(vty, "%% No BGP neighbors found \n");
+
 	if (use_json) {
 		vty_out(vty, "%s\n", json_object_to_json_string_ext(
 					     json, JSON_C_TO_STRING_PRETTY));
@@ -10741,18 +10760,20 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp,
 static void bgp_show_all_instances_neighbors_vty(struct vty *vty,
 						 enum show_type type,
 						 const char *ip_str,
-						 uint8_t use_json)
+						 bool use_json)
 {
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
 	union sockunion su;
 	json_object *json = NULL;
 	int ret, is_first = 1;
+	bool nbr_output = false;
 
 	if (use_json)
 		vty_out(vty, "{\n");
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
+		nbr_output = true;
 		if (use_json) {
 			if (!(json = json_object_new_object())) {
 				flog_err(
@@ -10805,11 +10826,13 @@ static void bgp_show_all_instances_neighbors_vty(struct vty *vty,
 
 	if (use_json)
 		vty_out(vty, "}\n");
+	else if (!nbr_output)
+		vty_out(vty, "%% BGP instance not found\n");
 }
 
 static int bgp_show_neighbor_vty(struct vty *vty, const char *name,
 				 enum show_type type, const char *ip_str,
-				 uint8_t use_json)
+				 bool use_json)
 {
 	int ret;
 	struct bgp *bgp;
@@ -10826,8 +10849,6 @@ static int bgp_show_neighbor_vty(struct vty *vty, const char *name,
 			if (!bgp) {
 				if (use_json) {
 					json = json_object_new_object();
-					json_object_boolean_true_add(
-						json, "bgpNoSuchInstance");
 					vty_out(vty, "%s\n",
 						json_object_to_json_string_ext(
 							json,
@@ -10835,7 +10856,7 @@ static int bgp_show_neighbor_vty(struct vty *vty, const char *name,
 					json_object_free(json);
 				} else
 					vty_out(vty,
-						"%% No such BGP instance exist\n");
+						"%% BGP instance not found\n");
 
 				return CMD_WARNING;
 			}
@@ -10859,6 +10880,9 @@ static int bgp_show_neighbor_vty(struct vty *vty, const char *name,
 					  json);
 		}
 		json_object_free(json);
+	} else {
+		use_json ? vty_out(vty, "{}\n")
+			 : vty_out(vty, "%% BGP instance not found\n");
 	}
 
 	return CMD_SUCCESS;
@@ -10884,7 +10908,7 @@ DEFUN (show_ip_bgp_neighbors,
 	char *sh_arg = NULL;
 	enum show_type sh_type;
 
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	int idx = 0;
 
@@ -10994,8 +11018,8 @@ DEFUN (show_ip_bgp_attr_info,
 	return CMD_SUCCESS;
 }
 
-static int bgp_show_route_leak_vty(struct vty *vty, const char *name,
-				   afi_t afi, safi_t safi, uint8_t use_json)
+static int bgp_show_route_leak_vty(struct vty *vty, const char *name, afi_t afi,
+				   safi_t safi, bool use_json)
 {
 	struct bgp *bgp;
 	struct listnode *node;
@@ -11011,16 +11035,9 @@ static int bgp_show_route_leak_vty(struct vty *vty, const char *name,
 
 		json = json_object_new_object();
 
-		/* Provide context for the block */
-		json_object_string_add(json, "vrf", name ? name : "default");
-		json_object_string_add(json, "afiSafi",
-					afi_safi_print(afi, safi));
-
 		bgp = name ? bgp_lookup_by_name(name) : bgp_get_default();
 
 		if (!bgp) {
-			json_object_boolean_true_add(json,
-						     "bgpNoSuchInstance");
 			vty_out(vty, "%s\n",
 				json_object_to_json_string_ext(
 					json,
@@ -11028,6 +11045,12 @@ static int bgp_show_route_leak_vty(struct vty *vty, const char *name,
 			json_object_free(json);
 
 			return CMD_WARNING;
+		} else {
+			/* Provide context for the block */
+			json_object_string_add(json, "vrf",
+					       name ? name : "default");
+			json_object_string_add(json, "afiSafi",
+					       afi_safi_print(afi, safi));
 		}
 
 		if (!CHECK_FLAG(bgp->af_flags[afi][safi],
@@ -11168,7 +11191,7 @@ DEFUN (show_ip_bgp_route_leak,
 	afi_t afi = AFI_MAX;
 	safi_t safi = SAFI_MAX;
 
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	int idx = 0;
 
 	/* show [ip] bgp */
@@ -11486,7 +11509,7 @@ static int bgp_show_peer_group_vty(struct vty *vty, const char *name,
 	bgp = name ? bgp_lookup_by_name(name) : bgp_get_default();
 
 	if (!bgp) {
-		vty_out(vty, "%% No such BGP instance exists\n");
+		vty_out(vty, "%% BGP instance not found\n");
 		return CMD_WARNING;
 	}
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -321,11 +321,11 @@ int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 		else {
 			*bgp = bgp_lookup_by_name(vrf_name);
 			if (!*bgp) {
-				vty_out(vty,
-					use_json
-						? "{}\n"
-						: "View/Vrf specified is unknown: %s\n",
-					vrf_name);
+				if (use_json)
+					vty_out(vty, "{}\n");
+				else
+					vty_out(vty, "View/Vrf %s is unknown\n",
+						vrf_name);
 				*idx = 0;
 				return 0;
 			}
@@ -333,10 +333,11 @@ int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 	} else {
 		*bgp = bgp_get_default();
 		if (!*bgp) {
-			vty_out(vty,
-				use_json
-					? "{}\n"
-					: "Unable to find default BGP instance\n");
+			if (use_json)
+				vty_out(vty, "{}\n");
+			else
+				vty_out(vty,
+					"Default BGP instance not found\n");
 			*idx = 0;
 			return 0;
 		}
@@ -8117,8 +8118,12 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 
 	if (use_json && is_wildcard)
 		vty_out(vty, "}\n");
-	else if (!nbr_output)
-		vty_out(vty, use_json ? "{}\n" : "%% No BGP neighbors found\n");
+	else if (!nbr_output) {
+		if (use_json)
+			vty_out(vty, "{}\n");
+		else
+			vty_out(vty, "%% No BGP neighbors found\n");
+	}
 }
 
 static void bgp_show_all_instances_summary_vty(struct vty *vty, afi_t afi,
@@ -8176,10 +8181,11 @@ int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
 			bgp = bgp_lookup_by_name(name);
 
 			if (!bgp) {
-				vty_out(vty,
-					use_json
-						? "{}\n"
-						: "%% BGP instance not found\n");
+				if (use_json)
+					vty_out(vty, "{}\n");
+				else
+					vty_out(vty,
+						"%% BGP instance not found\n");
 				return CMD_WARNING;
 			}
 
@@ -8194,8 +8200,10 @@ int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
 	if (bgp)
 		bgp_show_summary_afi_safi(vty, bgp, afi, safi, use_json, NULL);
 	else {
-		vty_out(vty,
-			use_json ? "{}\n" : "%% No such BGP instance exist\n");
+		if (use_json)
+			vty_out(vty, "{}\n");
+		else
+			vty_out(vty, "%% BGP instance not found\n");
 		return CMD_WARNING;
 	}
 
@@ -10879,8 +10887,12 @@ static int bgp_show_neighbor_vty(struct vty *vty, const char *name,
 					  json);
 		}
 		json_object_free(json);
-	} else
-		vty_out(vty, use_json ? "{}\n" : "%% BGP instance not found\n");
+	} else {
+		if (use_json)
+			vty_out(vty, "{}\n");
+		else
+			vty_out(vty, "%% BGP instance not found\n");
+	}
 
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -321,11 +321,11 @@ int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 		else {
 			*bgp = bgp_lookup_by_name(vrf_name);
 			if (!*bgp) {
-				use_json
-					? vty_out(vty, "{}\n")
-					: vty_out(vty,
-						  "View/Vrf specified is unknown: %s\n",
-						  vrf_name);
+				vty_out(vty,
+					use_json
+						? "{}\n"
+						: "View/Vrf specified is unknown: %s\n",
+					vrf_name);
 				*idx = 0;
 				return 0;
 			}
@@ -333,10 +333,10 @@ int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 	} else {
 		*bgp = bgp_get_default();
 		if (!*bgp) {
-			use_json
-				? vty_out(vty, "{}\n")
-				: vty_out(vty,
-					  "Unable to find default BGP instance\n");
+			vty_out(vty,
+				use_json
+					? "{}\n"
+					: "Unable to find default BGP instance\n");
 			*idx = 0;
 			return 0;
 		}
@@ -8118,8 +8118,7 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 	if (use_json && is_wildcard)
 		vty_out(vty, "}\n");
 	else if (!nbr_output)
-		use_json ? vty_out(vty, "{}\n")
-			 : vty_out(vty, "%% No BGP neighbors found\n");
+		vty_out(vty, use_json ? "{}\n" : "%% No BGP neighbors found\n");
 }
 
 static void bgp_show_all_instances_summary_vty(struct vty *vty, afi_t afi,
@@ -8177,10 +8176,10 @@ int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
 			bgp = bgp_lookup_by_name(name);
 
 			if (!bgp) {
-				use_json
-					? vty_out(vty, "{}\n")
-					: vty_out(vty,
-						  "%% BGP instance not found\n");
+				vty_out(vty,
+					use_json
+						? "{}\n"
+						: "%% BGP instance not found\n");
 				return CMD_WARNING;
 			}
 
@@ -8195,8 +8194,8 @@ int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
 	if (bgp)
 		bgp_show_summary_afi_safi(vty, bgp, afi, safi, use_json, NULL);
 	else {
-		use_json ? vty_out(vty, "{}\n")
-			 : vty_out(vty, "%% No such BGP instance exist\n");
+		vty_out(vty,
+			use_json ? "{}\n" : "%% No such BGP instance exist\n");
 		return CMD_WARNING;
 	}
 
@@ -10880,10 +10879,8 @@ static int bgp_show_neighbor_vty(struct vty *vty, const char *name,
 					  json);
 		}
 		json_object_free(json);
-	} else {
-		use_json ? vty_out(vty, "{}\n")
-			 : vty_out(vty, "%% BGP instance not found\n");
-	}
+	} else
+		vty_out(vty, use_json ? "{}\n" : "%% BGP instance not found\n");
 
 	return CMD_SUCCESS;
 }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10744,7 +10744,7 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp,
 	}
 
 	if (type != show_peer && !nbr_output && !use_json)
-		vty_out(vty, "%% No BGP neighbors found \n");
+		vty_out(vty, "%% No BGP neighbors found\n");
 
 	if (use_json) {
 		vty_out(vty, "%s\n", json_object_to_json_string_ext(
@@ -11045,13 +11045,12 @@ static int bgp_show_route_leak_vty(struct vty *vty, const char *name, afi_t afi,
 			json_object_free(json);
 
 			return CMD_WARNING;
-		} else {
-			/* Provide context for the block */
-			json_object_string_add(json, "vrf",
-					       name ? name : "default");
-			json_object_string_add(json, "afiSafi",
-					       afi_safi_print(afi, safi));
 		}
+
+		/* Provide context for the block */
+		json_object_string_add(json, "vrf", name ? name : "default");
+		json_object_string_add(json, "afiSafi",
+				       afi_safi_print(afi, safi));
 
 		if (!CHECK_FLAG(bgp->af_flags[afi][safi],
 				BGP_CONFIG_VRF_TO_VRF_IMPORT)) {

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -69,9 +69,10 @@ extern int argv_find_and_parse_safi(struct cmd_token **argv, int argc,
 extern int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 					       struct cmd_token **argv,
 					       int argc, int *idx, afi_t *afi,
-					       safi_t *safi, struct bgp **bgp);
+					       safi_t *safi, struct bgp **bgp,
+					       bool use_json);
 extern int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
-				safi_t safi, uint8_t use_json);
+				safi_t safi, bool use_json);
 extern void bgp_vpn_policy_config_write_afi(struct vty *vty, struct bgp *bgp,
 					    afi_t afi);
 #endif /* _QUAGGA_BGP_VTY_H */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6626,7 +6626,7 @@ int peer_clear_soft(struct peer *peer, afi_t afi, safi_t safi,
 }
 
 /* Display peer uptime.*/
-char *peer_uptime(time_t uptime2, char *buf, size_t len, uint8_t use_json,
+char *peer_uptime(time_t uptime2, char *buf, size_t len, bool use_json,
 		  json_object *json)
 {
 	time_t uptime1, epoch_tbuf;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1513,7 +1513,7 @@ extern struct peer *peer_create(union sockunion *, const char *, struct bgp *,
 				struct peer_group *);
 extern struct peer *peer_create_accept(struct bgp *);
 extern void peer_xfer_config(struct peer *dst, struct peer *src);
-extern char *peer_uptime(time_t, char *, size_t, uint8_t, json_object *);
+extern char *peer_uptime(time_t, char *, size_t, bool, json_object *);
 
 extern int bgp_config_write(struct vty *);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1513,7 +1513,8 @@ extern struct peer *peer_create(union sockunion *, const char *, struct bgp *,
 				struct peer_group *);
 extern struct peer *peer_create_accept(struct bgp *);
 extern void peer_xfer_config(struct peer *dst, struct peer *src);
-extern char *peer_uptime(time_t, char *, size_t, bool, json_object *);
+extern char *peer_uptime(time_t uptime2, char *buf, size_t len, bool use_json,
+			 json_object *json);
 
 extern int bgp_config_write(struct vty *);
 

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -342,7 +342,7 @@ static void bfd_last_update(time_t last_update, char *buf, size_t len)
  * bfd_show_param - Show the BFD parameter information.
  */
 void bfd_show_param(struct vty *vty, struct bfd_info *bfd_info, int bfd_tag,
-		    int extra_space, uint8_t use_json, json_object *json_obj)
+		    int extra_space, bool use_json, json_object *json_obj)
 {
 	json_object *json_bfd = NULL;
 
@@ -378,7 +378,7 @@ void bfd_show_param(struct vty *vty, struct bfd_info *bfd_info, int bfd_tag,
  * bfd_show_status - Show the BFD status information.
  */
 static void bfd_show_status(struct vty *vty, struct bfd_info *bfd_info,
-			    int bfd_tag, int extra_space, uint8_t use_json,
+			    int bfd_tag, int extra_space, bool use_json,
 			    json_object *json_bfd)
 {
 	char time_buf[32];
@@ -402,7 +402,7 @@ static void bfd_show_status(struct vty *vty, struct bfd_info *bfd_info,
  * bfd_show_info - Show the BFD information.
  */
 void bfd_show_info(struct vty *vty, struct bfd_info *bfd_info, int multihop,
-		   int extra_space, uint8_t use_json, json_object *json_obj)
+		   int extra_space, bool use_json, json_object *json_obj)
 {
 	json_object *json_bfd = NULL;
 

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -91,11 +91,11 @@ extern struct interface *bfd_get_peer_info(struct stream *s, struct prefix *dp,
 const char *bfd_get_status_str(int status);
 
 extern void bfd_show_param(struct vty *vty, struct bfd_info *bfd_info,
-			   int bfd_tag, int extra_space, uint8_t use_json,
+			   int bfd_tag, int extra_space, bool use_json,
 			   json_object *json_obj);
 
 extern void bfd_show_info(struct vty *vty, struct bfd_info *bfd_info,
-			  int multihop, int extra_space, uint8_t use_json,
+			  int multihop, int extra_space, bool use_json,
 			  json_object *json_obj);
 
 extern void bfd_client_sendmsg(struct zclient *zclient, int command);

--- a/lib/json.c
+++ b/lib/json.c
@@ -28,15 +28,15 @@
  * is the *last* keyword on the line no matter
  * what.
  */
-int use_json(const int argc, struct cmd_token *argv[])
+bool use_json(const int argc, struct cmd_token *argv[])
 {
 	if (argc == 0)
-		return 0;
+		return false;
 
 	if (argv[argc - 1]->arg && strmatch(argv[argc - 1]->text, "json"))
-		return 1;
+		return true;
 
-	return 0;
+	return false;
 }
 
 void json_object_string_add(struct json_object *obj, const char *key,

--- a/lib/json.h
+++ b/lib/json.h
@@ -52,7 +52,7 @@ extern int json_object_object_get_ex(struct json_object *obj, const char *key,
 
 #include "command.h"
 
-extern int use_json(const int argc, struct cmd_token *argv[]);
+extern bool use_json(const int argc, struct cmd_token *argv[]);
 extern void json_object_string_add(struct json_object *obj, const char *key,
 				   const char *s);
 extern void json_object_int_add(struct json_object *obj, const char *key,

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1900,7 +1900,7 @@ void prefix_bgp_orf_remove_all(afi_t afi, char *name)
 
 /* return prefix count */
 int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
-				uint8_t use_json)
+				bool use_json)
 {
 	struct prefix_list *plist;
 	struct prefix_list_entry *pentry;

--- a/lib/plist.h
+++ b/lib/plist.h
@@ -72,6 +72,7 @@ extern struct stream *prefix_bgp_orf_entry(struct stream *,
 					   uint8_t, uint8_t);
 extern int prefix_bgp_orf_set(char *, afi_t, struct orf_prefix *, int, int);
 extern void prefix_bgp_orf_remove_all(afi_t, char *);
-extern int prefix_bgp_show_prefix_list(struct vty *, afi_t, char *, bool);
+extern int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
+				       bool use_json);
 
 #endif /* _QUAGGA_PLIST_H */

--- a/lib/plist.h
+++ b/lib/plist.h
@@ -72,6 +72,6 @@ extern struct stream *prefix_bgp_orf_entry(struct stream *,
 					   uint8_t, uint8_t);
 extern int prefix_bgp_orf_set(char *, afi_t, struct orf_prefix *, int, int);
 extern void prefix_bgp_orf_remove_all(afi_t, char *);
-extern int prefix_bgp_show_prefix_list(struct vty *, afi_t, char *, uint8_t);
+extern int prefix_bgp_show_prefix_list(struct vty *, afi_t, char *, bool);
 
 #endif /* _QUAGGA_PLIST_H */

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -312,7 +312,7 @@ void ospf_bfd_write_config(struct vty *vty, struct ospf_if_params *params)
  * ospf_bfd_show_info - Show BFD info structure
  */
 void ospf_bfd_show_info(struct vty *vty, void *bfd_info, json_object *json_obj,
-			uint8_t use_json, int param_only)
+			bool use_json, int param_only)
 {
 	if (param_only)
 		bfd_show_param(vty, (struct bfd_info *)bfd_info, 1, 0, use_json,
@@ -326,7 +326,7 @@ void ospf_bfd_show_info(struct vty *vty, void *bfd_info, json_object *json_obj,
  * ospf_bfd_interface_show - Show the interface BFD configuration.
  */
 void ospf_bfd_interface_show(struct vty *vty, struct interface *ifp,
-			     json_object *json_interface_sub, uint8_t use_json)
+			     json_object *json_interface_sub, bool use_json)
 {
 	struct ospf_if_params *params;
 

--- a/ospfd/ospf_bfd.h
+++ b/ospfd/ospf_bfd.h
@@ -35,13 +35,13 @@ extern void ospf_bfd_trigger_event(struct ospf_neighbor *nbr, int old_state,
 
 extern void ospf_bfd_interface_show(struct vty *vty, struct interface *ifp,
 				    json_object *json_interface_sub,
-				    uint8_t use_json);
+				    bool use_json);
 
 extern void ospf_bfd_info_nbr_create(struct ospf_interface *oi,
 				     struct ospf_neighbor *nbr);
 
 extern void ospf_bfd_show_info(struct vty *vty, void *bfd_info,
-			       json_object *json_obj, uint8_t use_json,
+			       json_object *json_obj, bool use_json,
 			       int param_only);
 
 extern void ospf_bfd_info_free(void **bfd_info);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3263,6 +3263,7 @@ DEFUN (show_ip_ospf,
 	if (vrf_name) {
 		bool ospf_output = FALSE;
 		use_vrf = 1;
+
 		if (all_vrf) {
 			for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
 				if (!ospf->oi_running)
@@ -3288,7 +3289,7 @@ DEFUN (show_ip_ospf,
 						json, JSON_C_TO_STRING_PRETTY));
 				json_object_free(json);
 			} else
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 
 			return CMD_SUCCESS;
 		}
@@ -3302,7 +3303,7 @@ DEFUN (show_ip_ospf,
 						json, JSON_C_TO_STRING_PRETTY));
 				json_object_free(json);
 			} else
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 
 			return CMD_SUCCESS;
 		}
@@ -3965,7 +3966,7 @@ DEFUN (show_ip_ospf_interface,
 						json, JSON_C_TO_STRING_PRETTY));
 				json_object_free(json);
 			} else if (!ospf)
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 
 			return ret;
 		}
@@ -3977,7 +3978,7 @@ DEFUN (show_ip_ospf_interface,
 						json, JSON_C_TO_STRING_PRETTY));
 				json_object_free(json);
 			} else
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 
 			return CMD_SUCCESS;
 		}
@@ -3994,7 +3995,7 @@ DEFUN (show_ip_ospf_interface,
 						json, JSON_C_TO_STRING_PRETTY));
 				json_object_free(json);
 			} else
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 
 			return CMD_SUCCESS;
 		}
@@ -6339,6 +6340,7 @@ DEFUN (show_ip_ospf_database_max,
 	if (vrf_name) {
 		bool ospf_output = FALSE;
 		use_vrf = 1;
+
 		if (all_vrf) {
 			for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
 				if (!ospf->oi_running)
@@ -6354,7 +6356,7 @@ DEFUN (show_ip_ospf_database_max,
 		} else {
 			ospf = ospf_lookup_by_inst_name(inst, vrf_name);
 			if (ospf == NULL || !ospf->oi_running) {
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 				return CMD_SUCCESS;
 			}
 			ret = (show_ip_ospf_database_common(
@@ -6365,7 +6367,7 @@ DEFUN (show_ip_ospf_database_max,
 		/* Display default ospf (instance 0) info */
 		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
 		if (ospf == NULL || !ospf->oi_running) {
-			vty_out(vty, "%% OSPF instance not found \n");
+			vty_out(vty, "%% OSPF instance not found\n");
 			return CMD_SUCCESS;
 		}
 
@@ -6429,7 +6431,7 @@ DEFUN (show_ip_ospf_instance_database,
 		} else {
 			ospf = ospf_lookup_by_inst_name(inst, vrf_name);
 			if ((ospf == NULL) || !ospf->oi_running) {
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 				return CMD_SUCCESS;
 			}
 
@@ -6440,7 +6442,7 @@ DEFUN (show_ip_ospf_instance_database,
 		/* Display default ospf (instance 0) info */
 		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
 		if (ospf == NULL || !ospf->oi_running) {
-			vty_out(vty, "%% OSPF instance not found \n");
+			vty_out(vty, "%% OSPF instance not found\n");
 			return CMD_SUCCESS;
 		}
 
@@ -6473,7 +6475,7 @@ DEFUN (show_ip_ospf_instance_database_max,
 		return CMD_NOT_MY_INSTANCE;
 
 	if (!ospf->oi_running) {
-		vty_out(vty, "%% OSPF instance not found \n");
+		vty_out(vty, "%% OSPF instance not found\n");
 		return CMD_SUCCESS;
 	}
 
@@ -6565,7 +6567,7 @@ DEFUN (show_ip_ospf_instance_database_type_adv_router,
 		if (ospf == NULL)
 			return CMD_NOT_MY_INSTANCE;
 		if (!ospf->oi_running) {
-			vty_out(vty, "%% OSPF instance not found \n");
+			vty_out(vty, "%% OSPF instance not found\n");
 			return CMD_SUCCESS;
 		}
 
@@ -6578,6 +6580,7 @@ DEFUN (show_ip_ospf_instance_database_type_adv_router,
 	if (vrf_name) {
 		bool ospf_output = FALSE;
 		use_vrf = 1;
+
 		if (all_vrf) {
 			for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
 				if (!ospf->oi_running)
@@ -6592,7 +6595,7 @@ DEFUN (show_ip_ospf_instance_database_type_adv_router,
 		} else {
 			ospf = ospf_lookup_by_inst_name(inst, vrf_name);
 			if ((ospf == NULL) || !ospf->oi_running) {
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 				return CMD_SUCCESS;
 			}
 
@@ -6603,7 +6606,7 @@ DEFUN (show_ip_ospf_instance_database_type_adv_router,
 		/* Display default ospf (instance 0) info */
 		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
 		if (ospf == NULL || !ospf->oi_running) {
-			vty_out(vty, "%% OSPF instance not found \n");
+			vty_out(vty, "%% OSPF instance not found\n");
 			return CMD_SUCCESS;
 		}
 
@@ -9345,6 +9348,7 @@ DEFUN (show_ip_ospf_border_routers,
 	if (vrf_name) {
 		bool ospf_output = FALSE;
 		use_vrf = 1;
+
 		if (all_vrf) {
 			for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
 				if (!ospf->oi_running)
@@ -9356,11 +9360,11 @@ DEFUN (show_ip_ospf_border_routers,
 			}
 
 			if (!ospf_output)
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 		} else {
 			ospf = ospf_lookup_by_inst_name(inst, vrf_name);
 			if (ospf == NULL || !ospf->oi_running) {
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 				return CMD_SUCCESS;
 			}
 
@@ -9371,7 +9375,7 @@ DEFUN (show_ip_ospf_border_routers,
 		/* Display default ospf (instance 0) info */
 		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
 		if (ospf == NULL || !ospf->oi_running) {
-			vty_out(vty, "%% OSPF instance not found \n");
+			vty_out(vty, "%% OSPF instance not found\n");
 			return CMD_SUCCESS;
 		}
 
@@ -9487,6 +9491,7 @@ DEFUN (show_ip_ospf_route,
 	if (vrf_name) {
 		bool ospf_output = FALSE;
 		use_vrf = 1;
+
 		if (all_vrf) {
 			for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
 				if (!ospf->oi_running)
@@ -9514,7 +9519,7 @@ DEFUN (show_ip_ospf_route,
 						json, JSON_C_TO_STRING_PRETTY));
 				json_object_free(json);
 			} else
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 
 			return CMD_SUCCESS;
 		}
@@ -9528,7 +9533,7 @@ DEFUN (show_ip_ospf_route,
 						json, JSON_C_TO_STRING_PRETTY));
 				json_object_free(json);
 			} else
-				vty_out(vty, "%% OSPF instance not found \n");
+				vty_out(vty, "%% OSPF instance not found\n");
 
 			return CMD_SUCCESS;
 		}

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3262,6 +3262,7 @@ DEFUN (show_ip_ospf,
 	/* vrf input is provided could be all or specific vrf*/
 	if (vrf_name) {
 		bool ospf_output = FALSE;
+
 		use_vrf = 1;
 
 		if (all_vrf) {
@@ -6339,6 +6340,7 @@ DEFUN (show_ip_ospf_database_max,
 
 	if (vrf_name) {
 		bool ospf_output = FALSE;
+
 		use_vrf = 1;
 
 		if (all_vrf) {
@@ -6579,6 +6581,7 @@ DEFUN (show_ip_ospf_instance_database_type_adv_router,
 
 	if (vrf_name) {
 		bool ospf_output = FALSE;
+
 		use_vrf = 1;
 
 		if (all_vrf) {
@@ -9347,6 +9350,7 @@ DEFUN (show_ip_ospf_border_routers,
 
 	if (vrf_name) {
 		bool ospf_output = FALSE;
+
 		use_vrf = 1;
 
 		if (all_vrf) {
@@ -9490,6 +9494,7 @@ DEFUN (show_ip_ospf_route,
 	/* vrf input is provided could be all or specific vrf*/
 	if (vrf_name) {
 		bool ospf_output = FALSE;
+
 		use_vrf = 1;
 
 		if (all_vrf) {

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -64,7 +64,7 @@ void pim_bfd_write_config(struct vty *vty, struct interface *ifp)
  * pim_bfd_show_info - Show BFD info structure
  */
 void pim_bfd_show_info(struct vty *vty, void *bfd_info, json_object *json_obj,
-		       uint8_t use_json, int param_only)
+		       bool use_json, int param_only)
 {
 	if (param_only)
 		bfd_show_param(vty, (struct bfd_info *)bfd_info, 1, 0, use_json,

--- a/pimd/pim_bfd.h
+++ b/pimd/pim_bfd.h
@@ -28,7 +28,7 @@
 void pim_bfd_init(void);
 void pim_bfd_write_config(struct vty *vty, struct interface *ifp);
 void pim_bfd_show_info(struct vty *vty, void *bfd_info, json_object *json_obj,
-		       uint8_t use_json, int param_only);
+		       bool use_json, int param_only);
 void pim_bfd_if_param_set(struct interface *ifp, uint32_t min_rx,
 			  uint32_t min_tx, uint8_t detect_mult, int defaults);
 int pim_bfd_reg_dereg_all_nbr(struct interface *ifp, int command);

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3373,7 +3373,7 @@ DEFUN (show_ip_igmp_interface,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -3400,7 +3400,7 @@ DEFUN (show_ip_igmp_interface_vrf_all,
        JSON_STR)
 {
 	int idx = 2;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -3456,7 +3456,7 @@ DEFUN (show_ip_igmp_join_vrf_all,
        VRF_CMD_HELP_STR
        "IGMP static join information\n")
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -3490,7 +3490,7 @@ DEFUN (show_ip_igmp_groups,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -3510,7 +3510,7 @@ DEFUN (show_ip_igmp_groups_vrf_all,
        IGMP_GROUP_STR
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -3608,7 +3608,7 @@ DEFUN (show_ip_igmp_statistics,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -3715,7 +3715,7 @@ DEFUN (show_ip_pim_interface,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -3742,7 +3742,7 @@ DEFUN (show_ip_pim_interface_vrf_all,
        JSON_STR)
 {
 	int idx = 6;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -3781,7 +3781,7 @@ DEFUN (show_ip_pim_join,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -3801,7 +3801,7 @@ DEFUN (show_ip_pim_join_vrf_all,
        "PIM interface join information\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -3835,7 +3835,7 @@ DEFUN (show_ip_pim_local_membership,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -3859,7 +3859,7 @@ DEFUN (show_ip_pim_neighbor,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -3886,7 +3886,7 @@ DEFUN (show_ip_pim_neighbor_vrf_all,
        JSON_STR)
 {
 	int idx = 2;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -3949,7 +3949,7 @@ DEFUN (show_ip_pim_state,
 	const char *group = NULL;
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -3983,7 +3983,7 @@ DEFUN (show_ip_pim_state_vrf_all,
 	const char *src_or_group = NULL;
 	const char *group = NULL;
 	int idx = 2;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -4026,7 +4026,7 @@ DEFUN (show_ip_pim_upstream,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -4046,7 +4046,7 @@ DEFUN (show_ip_pim_upstream_vrf_all,
        "PIM upstream information\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -4078,7 +4078,7 @@ DEFUN (show_ip_pim_upstream_join_desired,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -4100,7 +4100,7 @@ DEFUN (show_ip_pim_upstream_rpf,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -4122,7 +4122,7 @@ DEFUN (show_ip_pim_rp,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -4142,7 +4142,7 @@ DEFUN (show_ip_pim_rp_vrf_all,
        "PIM RP information\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -4176,7 +4176,7 @@ DEFUN (show_ip_pim_rpf,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -4196,7 +4196,7 @@ DEFUN (show_ip_pim_rpf_vrf_all,
        "PIM cached source rpf information\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -4349,7 +4349,7 @@ DEFUN (show_ip_pim_interface_traffic,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -4473,7 +4473,7 @@ DEFUN (show_ip_multicast_vrf_all,
        VRF_CMD_HELP_STR
        "Multicast global information\n")
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -4830,7 +4830,7 @@ DEFUN (show_ip_mroute,
        "Fill in Assumed data\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	bool fill = false;
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
@@ -4855,7 +4855,7 @@ DEFUN (show_ip_mroute_vrf_all,
        "Fill in Assumed data\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	int idx = 4;
 	struct vrf *vrf;
 	bool first = true;
@@ -4963,7 +4963,7 @@ DEFUN (show_ip_mroute_count_vrf_all,
        VRF_CMD_HELP_STR
        "Route and packet count data\n")
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -5578,7 +5578,7 @@ DEFUN (show_ip_pim_ssm_range,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -5631,7 +5631,7 @@ DEFUN (show_ip_pim_group_type,
 {
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -7985,7 +7985,7 @@ DEFUN (show_ip_msdp_mesh_group,
        "MSDP mesh-group information\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
 
@@ -8007,7 +8007,7 @@ DEFUN (show_ip_msdp_mesh_group_vrf_all,
        "MSDP mesh-group information\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -8200,7 +8200,7 @@ DEFUN (show_ip_msdp_peer_detail,
        "peer ip address\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
 
@@ -8235,7 +8235,7 @@ DEFUN (show_ip_msdp_peer_detail_vrf_all,
        JSON_STR)
 {
 	int idx = 2;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -8441,7 +8441,7 @@ DEFUN (show_ip_msdp_sa_detail,
        "Detailed output\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
 
@@ -8464,7 +8464,7 @@ DEFUN (show_ip_msdp_sa_detail_vrf_all,
        "Detailed output\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 
@@ -8556,7 +8556,7 @@ DEFUN (show_ip_msdp_sa_sg,
        "group ip\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	int idx = 2;
 
@@ -8593,7 +8593,7 @@ DEFUN (show_ip_msdp_sa_sg_vrf_all,
        "group ip\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	struct vrf *vrf;
 	bool first = true;
 	int idx = 2;

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2698,7 +2698,7 @@ void zebra_mpls_lsp_schedule(struct zebra_vrf *zvrf)
  * (VTY command handler).
  */
 void zebra_mpls_print_lsp(struct vty *vty, struct zebra_vrf *zvrf,
-			  mpls_label_t label, uint8_t use_json)
+			  mpls_label_t label, bool use_json)
 {
 	struct hash *lsp_table;
 	zebra_lsp_t *lsp;
@@ -2729,7 +2729,7 @@ void zebra_mpls_print_lsp(struct vty *vty, struct zebra_vrf *zvrf,
  * Display MPLS label forwarding table (VTY command handler).
  */
 void zebra_mpls_print_lsp_table(struct vty *vty, struct zebra_vrf *zvrf,
-				uint8_t use_json)
+				bool use_json)
 {
 	char buf[BUFSIZ];
 	json_object *json = NULL;

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -349,13 +349,13 @@ void zebra_mpls_lsp_schedule(struct zebra_vrf *zvrf);
  * (VTY command handler).
  */
 void zebra_mpls_print_lsp(struct vty *vty, struct zebra_vrf *zvrf,
-			  mpls_label_t label, uint8_t use_json);
+			  mpls_label_t label, bool use_json);
 
 /*
  * Display MPLS label forwarding table (VTY command handler).
  */
 void zebra_mpls_print_lsp_table(struct vty *vty, struct zebra_vrf *zvrf,
-				uint8_t use_json);
+				bool use_json);
 
 /*
  * Display MPLS LSP configuration of all static LSPs (VTY command handler).

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -55,7 +55,7 @@
 extern int allow_delete;
 
 static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
-			    safi_t safi, bool use_fib, uint8_t use_json,
+			    safi_t safi, bool use_fib, bool use_json,
 			    route_tag_t tag,
 			    const struct prefix *longer_prefix_p,
 			    bool supernets_only, int type,
@@ -135,7 +135,7 @@ DEFUN (show_ip_rpf,
        "Display RPF information for multicast source\n"
        JSON_STR)
 {
-	int uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	return do_show_ip_route(vty, VRF_DEFAULT_NAME, AFI_IP, SAFI_MULTICAST,
 				false, uj, 0, NULL, false, 0, 0);
 }
@@ -760,8 +760,7 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 				 bool use_fib, route_tag_t tag,
 				 const struct prefix *longer_prefix_p,
 				 bool supernets_only, int type,
-				 unsigned short ospf_instance_id,
-				 uint8_t use_json)
+				 unsigned short ospf_instance_id, bool use_json)
 {
 	struct route_node *rn;
 	struct route_entry *re;
@@ -850,7 +849,7 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
 }
 
 static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
-			    safi_t safi, bool use_fib, uint8_t use_json,
+			    safi_t safi, bool use_fib, bool use_json,
 			    route_tag_t tag,
 			    const struct prefix *longer_prefix_p,
 			    bool supernets_only, int type,
@@ -1723,7 +1722,7 @@ DEFUN (show_vrf_vni,
 	struct zebra_vrf *zvrf;
 	json_object *json = NULL;
 	json_object *json_vrfs = NULL;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (uj) {
 		json = json_object_new_object();
@@ -1759,7 +1758,7 @@ DEFUN (show_evpn_global,
        "EVPN\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	zebra_vxlan_print_evpn(vty, uj);
 	return CMD_SUCCESS;
@@ -1774,7 +1773,7 @@ DEFUN (show_evpn_vni,
        JSON_STR)
 {
 	struct zebra_vrf *zvrf;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 	zebra_vxlan_print_vnis(vty, zvrf, uj);
@@ -1792,7 +1791,7 @@ DEFUN (show_evpn_vni_vni,
 {
 	struct zebra_vrf *zvrf;
 	vni_t vni;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	vni = strtoul(argv[3]->arg, NULL, 10);
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
@@ -1814,7 +1813,7 @@ DEFUN (show_evpn_rmac_vni_mac,
 {
 	vni_t l3vni = 0;
 	struct ethaddr mac;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	l3vni = strtoul(argv[4]->arg, NULL, 10);
 	if (!prefix_str2mac(argv[6]->arg, &mac)) {
@@ -1836,7 +1835,7 @@ DEFUN (show_evpn_rmac_vni,
        JSON_STR)
 {
 	vni_t l3vni = 0;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	l3vni = strtoul(argv[4]->arg, NULL, 10);
 	zebra_vxlan_print_rmacs_l3vni(vty, l3vni, uj);
@@ -1854,7 +1853,7 @@ DEFUN (show_evpn_rmac_vni_all,
        "All VNIs\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	zebra_vxlan_print_rmacs_all_l3vni(vty, uj);
 
@@ -1875,7 +1874,7 @@ DEFUN (show_evpn_nh_vni_ip,
 {
 	vni_t l3vni;
 	struct ipaddr ip;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	l3vni = strtoul(argv[4]->arg, NULL, 10);
 	if (str2ipaddr(argv[6]->arg, &ip) != 0) {
@@ -1899,7 +1898,7 @@ DEFUN (show_evpn_nh_vni,
        JSON_STR)
 {
 	vni_t l3vni;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	l3vni = strtoul(argv[4]->arg, NULL, 10);
 	zebra_vxlan_print_nh_l3vni(vty, l3vni, uj);
@@ -1917,7 +1916,7 @@ DEFUN (show_evpn_nh_vni_all,
        "All VNIs\n"
        JSON_STR)
 {
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	zebra_vxlan_print_nh_all_l3vni(vty, uj);
 
@@ -1936,7 +1935,7 @@ DEFUN (show_evpn_mac_vni,
 {
 	struct zebra_vrf *zvrf;
 	vni_t vni;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	vni = strtoul(argv[4]->arg, NULL, 10);
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
@@ -1955,7 +1954,7 @@ DEFUN (show_evpn_mac_vni_all,
        JSON_STR)
 {
 	struct zebra_vrf *zvrf;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 	zebra_vxlan_print_macs_all_vni(vty, zvrf, uj);
@@ -1976,7 +1975,7 @@ DEFUN (show_evpn_mac_vni_all_vtep,
 {
 	struct zebra_vrf *zvrf;
 	struct in_addr vtep_ip;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	if (!inet_aton(argv[6]->arg, &vtep_ip)) {
 		if (!uj)
@@ -2030,7 +2029,7 @@ DEFUN (show_evpn_mac_vni_vtep,
 	struct zebra_vrf *zvrf;
 	vni_t vni;
 	struct in_addr vtep_ip;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	vni = strtoul(argv[4]->arg, NULL, 10);
 	if (!inet_aton(argv[6]->arg, &vtep_ip)) {
@@ -2056,7 +2055,7 @@ DEFUN (show_evpn_neigh_vni,
 {
 	struct zebra_vrf *zvrf;
 	vni_t vni;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	vni = strtoul(argv[4]->arg, NULL, 10);
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
@@ -2075,7 +2074,7 @@ DEFUN (show_evpn_neigh_vni_all,
        JSON_STR)
 {
 	struct zebra_vrf *zvrf;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 	zebra_vxlan_print_neigh_all_vni(vty, zvrf, uj);
@@ -2097,7 +2096,7 @@ DEFUN (show_evpn_neigh_vni_neigh,
 	struct zebra_vrf *zvrf;
 	vni_t vni;
 	struct ipaddr ip;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	vni = strtoul(argv[4]->arg, NULL, 10);
 	if (str2ipaddr(argv[6]->arg, &ip) != 0) {
@@ -2125,7 +2124,7 @@ DEFUN (show_evpn_neigh_vni_vtep,
 	struct zebra_vrf *zvrf;
 	vni_t vni;
 	struct in_addr vtep_ip;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	vni = strtoul(argv[4]->arg, NULL, 10);
 	if (!inet_aton(argv[6]->arg, &vtep_ip)) {

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4057,8 +4057,7 @@ void zebra_vxlan_evpn_vrf_route_del(vrf_id_t vrf_id,
 }
 
 void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,
-					   struct ethaddr *rmac,
-					   uint8_t use_json)
+					   struct ethaddr *rmac, bool use_json)
 {
 	zebra_l3vni_t *zl3vni = NULL;
 	zebra_mac_t *zrmac = NULL;
@@ -4102,8 +4101,7 @@ void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,
 	}
 }
 
-void zebra_vxlan_print_rmacs_l3vni(struct vty *vty, vni_t l3vni,
-				   uint8_t use_json)
+void zebra_vxlan_print_rmacs_l3vni(struct vty *vty, vni_t l3vni, bool use_json)
 {
 	zebra_l3vni_t *zl3vni;
 	uint32_t num_rmacs;
@@ -4147,7 +4145,7 @@ void zebra_vxlan_print_rmacs_l3vni(struct vty *vty, vni_t l3vni,
 	}
 }
 
-void zebra_vxlan_print_rmacs_all_l3vni(struct vty *vty, uint8_t use_json)
+void zebra_vxlan_print_rmacs_all_l3vni(struct vty *vty, bool use_json)
 {
 	struct zebra_ns *zns = NULL;
 	json_object *json = NULL;
@@ -4184,7 +4182,7 @@ void zebra_vxlan_print_rmacs_all_l3vni(struct vty *vty, uint8_t use_json)
 }
 
 void zebra_vxlan_print_specific_nh_l3vni(struct vty *vty, vni_t l3vni,
-					 struct ipaddr *ip, uint8_t use_json)
+					 struct ipaddr *ip, bool use_json)
 {
 	zebra_l3vni_t *zl3vni = NULL;
 	zebra_neigh_t *n = NULL;
@@ -4228,7 +4226,7 @@ void zebra_vxlan_print_specific_nh_l3vni(struct vty *vty, vni_t l3vni,
 	}
 }
 
-void zebra_vxlan_print_nh_l3vni(struct vty *vty, vni_t l3vni, uint8_t use_json)
+void zebra_vxlan_print_nh_l3vni(struct vty *vty, vni_t l3vni, bool use_json)
 {
 	uint32_t num_nh;
 	struct nh_walk_ctx wctx;
@@ -4272,7 +4270,7 @@ void zebra_vxlan_print_nh_l3vni(struct vty *vty, vni_t l3vni, uint8_t use_json)
 	}
 }
 
-void zebra_vxlan_print_nh_all_l3vni(struct vty *vty, uint8_t use_json)
+void zebra_vxlan_print_nh_all_l3vni(struct vty *vty, bool use_json)
 {
 	struct zebra_ns *zns = NULL;
 	json_object *json = NULL;
@@ -4309,7 +4307,7 @@ void zebra_vxlan_print_nh_all_l3vni(struct vty *vty, uint8_t use_json)
 /*
  * Display L3 VNI information (VTY command handler).
  */
-void zebra_vxlan_print_l3vni(struct vty *vty, vni_t vni, uint8_t use_json)
+void zebra_vxlan_print_l3vni(struct vty *vty, vni_t vni, bool use_json)
 {
 	void *args[2];
 	json_object *json = NULL;
@@ -4382,7 +4380,7 @@ void zebra_vxlan_print_vrf_vni(struct vty *vty, struct zebra_vrf *zvrf,
  * Display Neighbors for a VNI (VTY command handler).
  */
 void zebra_vxlan_print_neigh_vni(struct vty *vty, struct zebra_vrf *zvrf,
-				 vni_t vni, uint8_t use_json)
+				 vni_t vni, bool use_json)
 {
 	zebra_vni_t *zvni;
 	uint32_t num_neigh;
@@ -4438,7 +4436,7 @@ void zebra_vxlan_print_neigh_vni(struct vty *vty, struct zebra_vrf *zvrf,
  * Display neighbors across all VNIs (VTY command handler).
  */
 void zebra_vxlan_print_neigh_all_vni(struct vty *vty, struct zebra_vrf *zvrf,
-				     uint8_t use_json)
+				     bool use_json)
 {
 	json_object *json = NULL;
 	void *args[2];
@@ -4467,7 +4465,7 @@ void zebra_vxlan_print_neigh_all_vni(struct vty *vty, struct zebra_vrf *zvrf,
  */
 void zebra_vxlan_print_specific_neigh_vni(struct vty *vty,
 					  struct zebra_vrf *zvrf, vni_t vni,
-					  struct ipaddr *ip, uint8_t use_json)
+					  struct ipaddr *ip, bool use_json)
 {
 	zebra_vni_t *zvni;
 	zebra_neigh_t *n;
@@ -4509,7 +4507,7 @@ void zebra_vxlan_print_specific_neigh_vni(struct vty *vty,
  */
 void zebra_vxlan_print_neigh_vni_vtep(struct vty *vty, struct zebra_vrf *zvrf,
 				      vni_t vni, struct in_addr vtep_ip,
-				      uint8_t use_json)
+				      bool use_json)
 {
 	zebra_vni_t *zvni;
 	uint32_t num_neigh;
@@ -4551,7 +4549,7 @@ void zebra_vxlan_print_neigh_vni_vtep(struct vty *vty, struct zebra_vrf *zvrf,
  * Display MACs for a VNI (VTY command handler).
  */
 void zebra_vxlan_print_macs_vni(struct vty *vty, struct zebra_vrf *zvrf,
-				vni_t vni, uint8_t use_json)
+				vni_t vni, bool use_json)
 {
 	zebra_vni_t *zvni;
 	uint32_t num_macs;
@@ -4606,7 +4604,7 @@ void zebra_vxlan_print_macs_vni(struct vty *vty, struct zebra_vrf *zvrf,
  * Display MACs for all VNIs (VTY command handler).
  */
 void zebra_vxlan_print_macs_all_vni(struct vty *vty, struct zebra_vrf *zvrf,
-				    uint8_t use_json)
+				    bool use_json)
 {
 	struct mac_walk_ctx wctx;
 	json_object *json = NULL;
@@ -4636,8 +4634,7 @@ void zebra_vxlan_print_macs_all_vni(struct vty *vty, struct zebra_vrf *zvrf,
  */
 void zebra_vxlan_print_macs_all_vni_vtep(struct vty *vty,
 					 struct zebra_vrf *zvrf,
-					 struct in_addr vtep_ip,
-					 uint8_t use_json)
+					 struct in_addr vtep_ip, bool use_json)
 {
 	struct mac_walk_ctx wctx;
 	json_object *json = NULL;
@@ -4693,7 +4690,7 @@ void zebra_vxlan_print_specific_mac_vni(struct vty *vty, struct zebra_vrf *zvrf,
  */
 void zebra_vxlan_print_macs_vni_vtep(struct vty *vty, struct zebra_vrf *zvrf,
 				     vni_t vni, struct in_addr vtep_ip,
-				     uint8_t use_json)
+				     bool use_json)
 {
 	zebra_vni_t *zvni;
 	uint32_t num_macs;
@@ -4743,7 +4740,7 @@ void zebra_vxlan_print_macs_vni_vtep(struct vty *vty, struct zebra_vrf *zvrf,
  * Display VNI information (VTY command handler).
  */
 void zebra_vxlan_print_vni(struct vty *vty, struct zebra_vrf *zvrf, vni_t vni,
-			   uint8_t use_json)
+			   bool use_json)
 {
 	json_object *json = NULL;
 	void *args[2];
@@ -4831,7 +4828,7 @@ void zebra_vxlan_print_evpn(struct vty *vty, uint8_t uj)
  * Display VNI hash table (VTY command handler).
  */
 void zebra_vxlan_print_vnis(struct vty *vty, struct zebra_vrf *zvrf,
-			    uint8_t use_json)
+			    bool use_json)
 {
 	json_object *json = NULL;
 	struct zebra_ns *zns = NULL;

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -68,53 +68,51 @@ extern int zebra_vxlan_vrf_enable(struct zebra_vrf *zvrf);
 extern int zebra_vxlan_vrf_disable(struct zebra_vrf *zvrf);
 extern int zebra_vxlan_vrf_delete(struct zebra_vrf *zvrf);
 extern void zebra_vxlan_print_specific_nh_l3vni(struct vty *vty, vni_t l3vni,
-						struct ipaddr *ip, uint8_t uj);
+						struct ipaddr *ip, bool uj);
 extern void zebra_vxlan_print_evpn(struct vty *vty, uint8_t uj);
 extern void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,
 						  struct ethaddr *rmac,
-						  uint8_t use_json);
+						  bool use_json);
 extern void zebra_vxlan_print_macs_vni(struct vty *vty, struct zebra_vrf *zvrf,
-				       vni_t vni, uint8_t use_json);
+				       vni_t vni, bool use_json);
 extern void zebra_vxlan_print_macs_all_vni(struct vty *vty,
 					   struct zebra_vrf *zvrf,
-					   uint8_t use_json);
+					   bool use_json);
 extern void zebra_vxlan_print_macs_all_vni_vtep(struct vty *vty,
 						struct zebra_vrf *zvrf,
 						struct in_addr vtep_ip,
-						uint8_t use_json);
+						bool use_json);
 extern void zebra_vxlan_print_specific_mac_vni(struct vty *vty,
 					       struct zebra_vrf *zvrf,
 					       vni_t vni, struct ethaddr *mac);
 extern void zebra_vxlan_print_macs_vni_vtep(struct vty *vty,
 					    struct zebra_vrf *zvrf, vni_t vni,
 					    struct in_addr vtep_ip,
-					    uint8_t use_json);
+					    bool use_json);
 extern void zebra_vxlan_print_neigh_vni(struct vty *vty, struct zebra_vrf *zvrf,
-					vni_t vni, uint8_t use_json);
+					vni_t vni, bool use_json);
 extern void zebra_vxlan_print_neigh_all_vni(struct vty *vty,
 					    struct zebra_vrf *zvrf,
-					    uint8_t use_json);
+					    bool use_json);
 extern void zebra_vxlan_print_specific_neigh_vni(struct vty *vty,
 						 struct zebra_vrf *zvrf,
 						 vni_t vni, struct ipaddr *ip,
-						 uint8_t use_json);
+						 bool use_json);
 extern void zebra_vxlan_print_neigh_vni_vtep(struct vty *vty,
 					     struct zebra_vrf *zvrf, vni_t vni,
 					     struct in_addr vtep_ip,
-					     uint8_t use_json);
+					     bool use_json);
 extern void zebra_vxlan_print_vni(struct vty *vty, struct zebra_vrf *zvrf,
-				  vni_t vni, uint8_t use_json);
+				  vni_t vni, bool use_json);
 extern void zebra_vxlan_print_vnis(struct vty *vty, struct zebra_vrf *zvrf,
-				   uint8_t use_json);
+				   bool use_json);
 extern void zebra_vxlan_print_rmacs_l3vni(struct vty *vty, vni_t vni,
-					  uint8_t use_json);
-extern void zebra_vxlan_print_rmacs_all_l3vni(struct vty *vty,
-					      uint8_t use_json);
+					  bool use_json);
+extern void zebra_vxlan_print_rmacs_all_l3vni(struct vty *vty, bool use_json);
 extern void zebra_vxlan_print_nh_l3vni(struct vty *vty, vni_t vni,
-				       uint8_t use_json);
-extern void zebra_vxlan_print_nh_all_l3vni(struct vty *vty, uint8_t use_json);
-extern void zebra_vxlan_print_l3vni(struct vty *vty, vni_t vni,
-				    uint8_t use_json);
+				       bool use_json);
+extern void zebra_vxlan_print_nh_all_l3vni(struct vty *vty, bool use_json);
+extern void zebra_vxlan_print_l3vni(struct vty *vty, vni_t vni, bool use_json);
 extern void zebra_vxlan_print_vrf_vni(struct vty *vty, struct zebra_vrf *zvrf,
 				      json_object *json_vrfs);
 extern int zebra_vxlan_add_del_gw_macip(struct interface *ifp, struct prefix *p,


### PR DESCRIPTION
Problem reported that some bgp and ospf json commands did not return
any json output at all if the bgp/ospf instance did not exist.
Additionally, some bgp and ospf json commands did not return any json
output if the instance existed but no neighbors were defined.  This
fix makes these commands more consistent in returning empty braces for
json output and issue a message if not using json output.  Additionally,
made the flag "use_json" a bool to make it consistent since previously,
it had been defined as an int, char, u_char, and bool at various places.

Ticket: CM-21040
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>