### PR TITLE
lib: Ensure FRR has appropriate error messages for when it detects being run a second time (#2680)

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -262,12 +262,41 @@ bool frr_zclient_addr(struct sockaddr_storage *sa, socklen_t *sa_len,
 
 static struct frr_daemon_info *di = NULL;
 
+int frr_guard_daemon(void)
+{
+	int fd;
+	struct flock lock;
+
+	const char *path = pidfile_default;
+	fd = open(path, O_RDWR);
+	if (fd != -1) {
+		memset(&lock, 0, sizeof(lock));
+		set_cloexec(fd);
+		lock.l_type = F_WRLCK;
+		lock.l_whence = SEEK_SET;
+		if (fcntl(fd, F_GETLK, &lock) < 0) {
+			zlog_err("Could not do F_GETLK pid_file %s (%s), exiting",
+				path, safe_strerror(errno));
+			close(fd);
+			return FAILURE;
+		} else if (lock.l_type == F_WRLCK) {
+			zlog_err("Process %d has a write lock on file %s already! Error :( %s)",
+				lock.l_pid, path, safe_strerror(errno));
+			close(fd);
+			return FAILURE;
+		}
+		close(fd);
+	}
+	return SUCCESS;
+}
+
 void frr_preinit(struct frr_daemon_info *daemon, int argc, char **argv)
 {
 	di = daemon;
 
 	/* basename(), opencoded. */
 	char *p = strrchr(argv[0], '/');
+
 	di->progname = p ? p + 1 : argv[0];
 
 	umask(0027);
@@ -588,6 +617,12 @@ struct thread_master *frr_init(void)
 	}
 
 	zprivs_init(di->privs);
+
+	/* Guard to prevent a second instance of this daemon */
+	if (frr_guard_daemon() == FAILURE) {
+		zlog_err("There is already a similar Process running,hence not allowing a second instance.");
+		exit(1);
+	}
 
 	master = thread_master_create(NULL);
 	signal_init(master, di->n_signals, di->signals);

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -35,6 +35,11 @@
 #define FRR_NO_CFG_PID_DRY		(1 << 3)
 #define FRR_NO_ZCLIENT		(1 << 4)
 
+enum frr_ret {
+	SUCCESS = 0,
+	FAILURE = 1
+};
+
 struct frr_daemon_info {
 	unsigned flags;
 
@@ -91,6 +96,7 @@ struct frr_daemon_info {
 			  .version = FRR_VERSION, )                            \
 /* end */
 
+extern int frr_guard_daemon(void);
 extern void frr_preinit(struct frr_daemon_info *daemon, int argc, char **argv);
 extern void frr_opt_add(const char *optstr, const struct option *longopts,
 			const char *helpstr);


### PR DESCRIPTION

Solution :
The following procedures would be performed :
1. Verify if the pid file for each daemon is present or not. If the file is not present, that means the
   daemon is getting instantiated for the first time. So let it go ahead.
   If the file is present proceed to point ‘2’.
2. Try fetching the properties of the pid file
3. If it has RW lock, that means one instance of this the daemon is already running.
   So stop moving ahead and do exit() else let it go ahead. Please note all above procedure happen at
   the initial state of daemon’s instantiation, much before it starts any session with other
   process/allocates resources etc.. and this verification do not have any impact of any
   operations done later, if the verification succeeds.

Signed-off-by: bisdhdh <sadhub@vmware.com>