### PR TITLE
plist: Add safety check to avoid going over 4294967295 for prefix-list

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -396,7 +396,7 @@ static int64_t prefix_new_seq_get(struct prefix_list *plist)
 
 	newseq = ((maxseq / 5) * 5) + 5;
 
-	return newseq;
+	return (newseq > UINT_MAX) ? UINT_MAX : newseq;
 }
 
 /* Return prefix list entry which has same seq number. */


### PR DESCRIPTION
This will overwrite the latest rule with seq 4294967295 if no sequence is provided.

```
spine1-debian-9(config)# do sh ip prefix-list labas
ZEBRA: ip prefix-list labas: 2 entries
   seq 4294967294 permit 1.1.1.1/32
   seq 4294967295 permit 1.1.1.3/32
BGP: ip prefix-list labas: 2 entries
   seq 4294967294 permit 1.1.1.1/32
   seq 4294967295 permit 1.1.1.3/32

spine1-debian-9(config)# ip prefix-list labas permit 100.100.100.0/24

spine1-debian-9(config)# do sh ip prefix-list labas
ZEBRA: ip prefix-list labas: 2 entries
   seq 4294967294 permit 1.1.1.1/32
   seq 4294967295 permit 100.100.100.0/24
BGP: ip prefix-list labas: 2 entries
   seq 4294967294 permit 1.1.1.1/32
   seq 4294967295 permit 100.100.100.0/24
```

I think it's much better than confusing the end user with 4294967295 as the maximum value, which cannot be deleted if stepped over this limit.