### PR TITLE
tools: missing staticd reference in daemons file

### DIFF
--- a/tools/etc/frr/daemons
+++ b/tools/etc/frr/daemons
@@ -35,4 +35,5 @@ eigrpd=no
 babeld=no
 sharpd=no
 pbrd=no
+staticd=no
 bfdd=no


### PR DESCRIPTION
Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>