### PR TITLE
zebra: filter zebra messages (label manager)

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -76,6 +76,7 @@
 
 #else
 #define CPP_WARN(text)
+#define CPP_NOTICE(text)
 #endif
 
 #endif /* _FRR_COMPILER_H */


### PR DESCRIPTION
This change makes the zebra acting as label manager proxy not to relay non-LM messages to clients that a zebra acting in non-proxy mode may send to it. Also, the existing code does not schedule a rcv in case of relay_response_back returns -1. This patch re-schedules reads on the socket even in case such a function returns -1 by calling thread_add_read().

Edit: added a commit for fixing the build for older compilers (backport from master, where it was already solved)