### PR TITLE
zebra: filter zebra messages (label manager)

### DIFF
--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -86,7 +86,23 @@ static int relay_response_back(void)
 			 strerror(errno));
 		return -1;
 	}
-	zlog_debug("Label Manager response received, %d bytes", size);
+
+	/* do not relay a msg that has nothing to do with LM */
+	switch (resp_cmd)
+	{
+		case ZEBRA_LABEL_MANAGER_CONNECT:
+		case ZEBRA_LABEL_MANAGER_CONNECT_ASYNC:	/* should not be seen */
+		case ZEBRA_GET_LABEL_CHUNK:
+		case ZEBRA_RELEASE_LABEL_CHUNK:			break;
+		default:
+			zlog_debug("Not relaying '%s' response (size %d) from LM",
+					zserv_command_string(resp_cmd), size);
+			return -1;
+	}
+
+	zlog_debug("Received '%s' response (size %d) from LM",
+			zserv_command_string(resp_cmd), size);
+
 	if (size == 0)
 		return -1;
 
@@ -135,6 +151,11 @@ static int lm_zclient_read(struct thread *t)
 	/* read response and send it back */
 	ret = relay_response_back();
 
+	/* on error, schedule another read */
+	if ( ret == -1 )
+		if (!zclient->t_read)
+			thread_add_read(zclient->master, lm_zclient_read, NULL,
+					zclient->sock, &zclient->t_read);
 	return ret;
 }
 


### PR DESCRIPTION
(made a new PR, because I used a wrong user, and because of that it didn't get the updates, please excuse the inconvenience -I've fixed the style issues-)

This change makes the zebra acting as label manager proxy not to relay non-LM
messages to clients that a zebra acting in non-proxy mode may send to it. Also,
the existing code does not schedule a rcv in case of relay_response_back
returns -1. This patch re-schedules reads on the socket even in case such a
function returns -1 by calling thread_add_read().

Signed-off-by: F. Aragon <paco@voltanet.io>