### PR TITLE
bgpd, ospfd, pimd, zebra: Convert more use_json locations to bool

### DIFF
--- a/bgpd/bgp_flowspec.h
+++ b/bgpd/bgp_flowspec.h
@@ -34,9 +34,8 @@ extern void bgp_flowspec_vty_init(void);
 
 extern int bgp_show_table_flowspec(struct vty *vty, struct bgp *bgp, afi_t afi,
 				   struct bgp_table *table,
-				   enum bgp_show_type type,
-				   void *output_arg, uint8_t use_json,
-				   int is_last,
+				   enum bgp_show_type type, void *output_arg,
+				   bool use_json, int is_last,
 				   unsigned long *output_cum,
 				   unsigned long *total_cum);
 
@@ -50,12 +49,10 @@ extern void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 extern int bgp_fs_config_write_pbr(struct vty *vty, struct bgp *bgp,
 				   afi_t afi, safi_t safi);
 
-extern int bgp_flowspec_display_match_per_ip(afi_t afi,
-				struct bgp_table *rib,
-				struct prefix *match,
-				int prefix_check,
-				struct vty *vty,
-				uint8_t use_json,
-				json_object *json_paths);
+extern int bgp_flowspec_display_match_per_ip(afi_t afi, struct bgp_table *rib,
+					     struct prefix *match,
+					     int prefix_check, struct vty *vty,
+					     bool use_json,
+					     json_object *json_paths);
 
 #endif /* _FRR_BGP_FLOWSPEC_H */

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -365,9 +365,8 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 
 int bgp_show_table_flowspec(struct vty *vty, struct bgp *bgp, afi_t afi,
 			    struct bgp_table *table, enum bgp_show_type type,
-			    void *output_arg, uint8_t use_json,
-			    int is_last, unsigned long *output_cum,
-			    unsigned long *total_cum)
+			    void *output_arg, bool use_json, int is_last,
+			    unsigned long *output_cum, unsigned long *total_cum)
 {
 	struct bgp_info *ri;
 	struct bgp_node *rn;
@@ -527,13 +526,11 @@ DEFUN (bgp_fs_local_install_ifname,
 	return bgp_fs_local_install_interface(bgp, no, ifname);
 }
 
-extern int bgp_flowspec_display_match_per_ip(afi_t afi,
-			struct bgp_table *rib,
-			struct prefix *match,
-			int prefix_check,
-			struct vty *vty,
-			uint8_t use_json,
-			json_object *json_paths)
+extern int bgp_flowspec_display_match_per_ip(afi_t afi, struct bgp_table *rib,
+					     struct prefix *match,
+					     int prefix_check, struct vty *vty,
+					     bool use_json,
+					     json_object *json_paths)
 {
 	struct bgp_node *rn;
 	struct prefix *prefix;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8911,7 +8911,7 @@ static int bgp_show_route(struct vty *vty, struct bgp *bgp, const char *ip_str,
 
 static int bgp_show_lcommunity(struct vty *vty, struct bgp *bgp, int argc,
 			       struct cmd_token **argv, afi_t afi, safi_t safi,
-			       uint8_t uj)
+			       bool uj)
 {
 	struct lcommunity *lcom;
 	struct buffer *b;
@@ -8948,7 +8948,7 @@ static int bgp_show_lcommunity(struct vty *vty, struct bgp *bgp, int argc,
 
 static int bgp_show_lcommunity_list(struct vty *vty, struct bgp *bgp,
 				    const char *lcom, afi_t afi, safi_t safi,
-				    uint8_t uj)
+				    bool uj)
 {
 	struct community_list *list;
 

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -2311,7 +2311,7 @@ DEFUN (show_ip_opsf_srdb,
 	int idx = 0;
 	struct in_addr rid;
 	struct sr_node *srn;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 	json_object *json = NULL, *json_node_array = NULL;
 
 	if (!OspfSR.enabled) {

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -432,7 +432,7 @@ static void pim_show_membership_helper(struct vty *vty,
 	json_object_object_add(json_iface, ch_grp_str, json_row);
 }
 static void pim_show_membership(struct pim_instance *pim, struct vty *vty,
-				uint8_t uj)
+				bool uj)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_ifchannel *ch;
@@ -549,7 +549,7 @@ static void pim_print_ifp_flags(struct vty *vty, struct interface *ifp,
 }
 
 static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
-				 uint8_t uj)
+				 bool uj)
 {
 	struct interface *ifp;
 	time_t now;
@@ -634,7 +634,7 @@ static void igmp_show_interfaces(struct pim_instance *pim, struct vty *vty,
 
 static void igmp_show_interfaces_single(struct pim_instance *pim,
 					struct vty *vty, const char *ifname,
-					uint8_t uj)
+					bool uj)
 {
 	struct igmp_sock *igmp;
 	struct interface *ifp;
@@ -894,7 +894,7 @@ static void igmp_show_interface_join(struct pim_instance *pim, struct vty *vty)
 
 static void pim_show_interfaces_single(struct pim_instance *pim,
 				       struct vty *vty, const char *ifname,
-				       uint8_t uj)
+				       bool uj)
 {
 	struct in_addr ifaddr;
 	struct interface *ifp;
@@ -1295,7 +1295,7 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 }
 
 static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
-				 const char *ifname, uint8_t uj)
+				 const char *ifname, bool uj)
 {
 	struct interface *ifp;
 	struct igmp_stats rx_stats;
@@ -1365,7 +1365,7 @@ static void igmp_show_statistics(struct pim_instance *pim, struct vty *vty,
 }
 
 static void pim_show_interfaces(struct pim_instance *pim, struct vty *vty,
-				uint8_t uj)
+				bool uj)
 {
 	struct interface *ifp;
 	struct listnode *upnode;
@@ -1458,7 +1458,7 @@ static void pim_show_interfaces(struct pim_instance *pim, struct vty *vty,
 }
 
 static void pim_show_interface_traffic(struct pim_instance *pim,
-				       struct vty *vty, uint8_t uj)
+				       struct vty *vty, bool uj)
 {
 	struct interface *ifp = NULL;
 	struct pim_interface *pim_ifp = NULL;
@@ -1538,7 +1538,7 @@ static void pim_show_interface_traffic(struct pim_instance *pim,
 
 static void pim_show_interface_traffic_single(struct pim_instance *pim,
 					      struct vty *vty,
-					      const char *ifname, uint8_t uj)
+					      const char *ifname, bool uj)
 {
 	struct interface *ifp = NULL;
 	struct pim_interface *pim_ifp = NULL;
@@ -1627,7 +1627,7 @@ static void pim_show_interface_traffic_single(struct pim_instance *pim,
 
 static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 				 struct pim_ifchannel *ch, json_object *json,
-				 time_t now, uint8_t uj)
+				 time_t now, bool uj)
 {
 	char ch_src_str[INET_ADDRSTRLEN];
 	char ch_grp_str[INET_ADDRSTRLEN];
@@ -1690,7 +1690,7 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 	}
 }
 
-static void pim_show_join(struct pim_instance *pim, struct vty *vty, uint8_t uj)
+static void pim_show_join(struct pim_instance *pim, struct vty *vty, bool uj)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_ifchannel *ch;
@@ -1724,7 +1724,7 @@ static void pim_show_join(struct pim_instance *pim, struct vty *vty, uint8_t uj)
 }
 
 static void pim_show_neighbors_single(struct pim_instance *pim, struct vty *vty,
-				      const char *neighbor, uint8_t uj)
+				      const char *neighbor, bool uj)
 {
 	struct listnode *neighnode;
 	struct interface *ifp;
@@ -1933,8 +1933,7 @@ static void pim_show_neighbors_single(struct pim_instance *pim, struct vty *vty,
 }
 
 static void pim_show_state(struct pim_instance *pim, struct vty *vty,
-			   const char *src_or_group, const char *group,
-			   uint8_t uj)
+			   const char *src_or_group, const char *group, bool uj)
 {
 	struct channel_oil *c_oil;
 	struct listnode *node;
@@ -2135,7 +2134,7 @@ static void pim_show_state(struct pim_instance *pim, struct vty *vty,
 }
 
 static void pim_show_neighbors(struct pim_instance *pim, struct vty *vty,
-			       uint8_t uj)
+			       bool uj)
 {
 	struct listnode *neighnode;
 	struct interface *ifp;
@@ -2331,7 +2330,7 @@ static const char *pim_reg_state2brief_str(enum pim_reg_state reg_state,
 }
 
 static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
-			      uint8_t uj)
+			      bool uj)
 {
 	struct listnode *upnode;
 	struct pim_upstream *up;
@@ -2476,7 +2475,7 @@ static void pim_show_join_desired_helper(struct pim_instance *pim,
 					 struct vty *vty,
 					 struct pim_interface *pim_ifp,
 					 struct pim_ifchannel *ch,
-					 json_object *json, uint8_t uj)
+					 json_object *json, bool uj)
 {
 	struct pim_upstream *up = ch->upstream;
 	json_object *json_group = NULL;
@@ -2532,7 +2531,7 @@ static void pim_show_join_desired_helper(struct pim_instance *pim,
 }
 
 static void pim_show_join_desired(struct pim_instance *pim, struct vty *vty,
-				  uint8_t uj)
+				  bool uj)
 {
 	struct pim_interface *pim_ifp;
 	struct pim_ifchannel *ch;
@@ -2568,7 +2567,7 @@ static void pim_show_join_desired(struct pim_instance *pim, struct vty *vty,
 }
 
 static void pim_show_upstream_rpf(struct pim_instance *pim, struct vty *vty,
-				  uint8_t uj)
+				  bool uj)
 {
 	struct listnode *upnode;
 	struct pim_upstream *up;
@@ -2701,7 +2700,7 @@ static void show_scan_oil_stats(struct pim_instance *pim, struct vty *vty,
 		uptime_mroute_del, (long long)pim->mroute_del_events);
 }
 
-static void pim_show_rpf(struct pim_instance *pim, struct vty *vty, uint8_t uj)
+static void pim_show_rpf(struct pim_instance *pim, struct vty *vty, bool uj)
 {
 	struct listnode *up_node;
 	struct pim_upstream *up;
@@ -2821,8 +2820,7 @@ static void pim_show_nexthop(struct pim_instance *pim, struct vty *vty)
 	hash_walk(pim->rpf_hash, pim_print_pnc_cache_walkcb, &cwd);
 }
 
-static void igmp_show_groups(struct pim_instance *pim, struct vty *vty,
-			     uint8_t uj)
+static void igmp_show_groups(struct pim_instance *pim, struct vty *vty, bool uj)
 {
 	struct interface *ifp;
 	time_t now;
@@ -4496,7 +4494,7 @@ DEFUN (show_ip_multicast_vrf_all,
 }
 
 static void show_mroute(struct pim_instance *pim, struct vty *vty, bool fill,
-			uint8_t uj)
+			bool uj)
 {
 	struct listnode *node;
 	struct channel_oil *c_oil;
@@ -5549,7 +5547,7 @@ DEFUN (no_ip_pim_ssm_prefix_list_name,
 }
 
 static void ip_pim_ssm_show_group_range(struct pim_instance *pim,
-					struct vty *vty, uint8_t uj)
+					struct vty *vty, bool uj)
 {
 	struct pim_ssm *ssm = pim->ssm_info;
 	const char *range_str =
@@ -5589,7 +5587,7 @@ DEFUN (show_ip_pim_ssm_range,
 }
 
 static void ip_pim_ssm_show_group_type(struct pim_instance *pim,
-				       struct vty *vty, uint8_t uj,
+				       struct vty *vty, bool uj,
 				       const char *group)
 {
 	struct in_addr group_addr;
@@ -7908,7 +7906,7 @@ static void print_empty_json_obj(struct vty *vty)
 }
 
 static void ip_msdp_show_mesh_group(struct pim_instance *pim, struct vty *vty,
-				    uint8_t uj)
+				    bool uj)
 {
 	struct listnode *mbrnode;
 	struct pim_msdp_mg_mbr *mbr;
@@ -8030,7 +8028,7 @@ DEFUN (show_ip_msdp_mesh_group_vrf_all,
 }
 
 static void ip_msdp_show_peers(struct pim_instance *pim, struct vty *vty,
-			       uint8_t uj)
+			       bool uj)
 {
 	struct listnode *mpnode;
 	struct pim_msdp_peer *mp;
@@ -8084,7 +8082,7 @@ static void ip_msdp_show_peers(struct pim_instance *pim, struct vty *vty,
 }
 
 static void ip_msdp_show_peers_detail(struct pim_instance *pim, struct vty *vty,
-				      const char *peer, uint8_t uj)
+				      const char *peer, bool uj)
 {
 	struct listnode *mpnode;
 	struct pim_msdp_peer *mp;
@@ -8262,8 +8260,7 @@ DEFUN (show_ip_msdp_peer_detail_vrf_all,
 	return CMD_SUCCESS;
 }
 
-static void ip_msdp_show_sa(struct pim_instance *pim, struct vty *vty,
-			    uint8_t uj)
+static void ip_msdp_show_sa(struct pim_instance *pim, struct vty *vty, bool uj)
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
@@ -8340,7 +8337,7 @@ static void ip_msdp_show_sa(struct pim_instance *pim, struct vty *vty,
 static void ip_msdp_show_sa_entry_detail(struct pim_msdp_sa *sa,
 					 const char *src_str,
 					 const char *grp_str, struct vty *vty,
-					 uint8_t uj, json_object *json)
+					 bool uj, json_object *json)
 {
 	char rp_str[INET_ADDRSTRLEN];
 	char peer_str[INET_ADDRSTRLEN];
@@ -8404,7 +8401,7 @@ static void ip_msdp_show_sa_entry_detail(struct pim_msdp_sa *sa,
 }
 
 static void ip_msdp_show_sa_detail(struct pim_instance *pim, struct vty *vty,
-				   uint8_t uj)
+				   bool uj)
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
@@ -8487,7 +8484,7 @@ DEFUN (show_ip_msdp_sa_detail_vrf_all,
 }
 
 static void ip_msdp_show_sa_addr(struct pim_instance *pim, struct vty *vty,
-				 const char *addr, uint8_t uj)
+				 const char *addr, bool uj)
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;
@@ -8516,7 +8513,7 @@ static void ip_msdp_show_sa_addr(struct pim_instance *pim, struct vty *vty,
 }
 
 static void ip_msdp_show_sa_sg(struct pim_instance *pim, struct vty *vty,
-			       const char *src, const char *grp, uint8_t uj)
+			       const char *src, const char *grp, bool uj)
 {
 	struct listnode *sanode;
 	struct pim_msdp_sa *sa;

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -951,8 +951,7 @@ int pim_rp_check_is_my_ip_address(struct pim_instance *pim,
 	return 0;
 }
 
-void pim_rp_show_information(struct pim_instance *pim, struct vty *vty,
-			     uint8_t uj)
+void pim_rp_show_information(struct pim_instance *pim, struct vty *vty, bool uj)
 {
 	struct rp_info *rp_info;
 	struct rp_info *prev_rp_info = NULL;

--- a/pimd/pim_rp.h
+++ b/pimd/pim_rp.h
@@ -68,7 +68,7 @@ struct pim_rpf *pim_rp_g(struct pim_instance *pim, struct in_addr group);
 #define RP(P, G)       pim_rp_g ((P), (G))
 
 void pim_rp_show_information(struct pim_instance *pim, struct vty *vty,
-			     uint8_t uj);
+			     bool uj);
 void pim_resolve_rp_nh(struct pim_instance *pim);
 int pim_rp_list_cmp(void *v1, void *v2);
 #endif

--- a/zebra/zebra_mpls_vty.c
+++ b/zebra/zebra_mpls_vty.c
@@ -339,7 +339,7 @@ DEFUN (show_mpls_table,
        JSON_STR)
 {
 	struct zebra_vrf *zvrf;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 	zebra_mpls_print_lsp_table(vty, zvrf, uj);
@@ -357,7 +357,7 @@ DEFUN (show_mpls_table_lsp,
 {
 	uint32_t label;
 	struct zebra_vrf *zvrf;
-	uint8_t uj = use_json(argc, argv);
+	bool uj = use_json(argc, argv);
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 	label = atoi(argv[3]->arg);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4779,7 +4779,7 @@ void zebra_vxlan_print_vni(struct vty *vty, struct zebra_vrf *zvrf, vni_t vni,
 }
 
 /* Display all global details for EVPN */
-void zebra_vxlan_print_evpn(struct vty *vty, uint8_t uj)
+void zebra_vxlan_print_evpn(struct vty *vty, bool uj)
 {
 	int num_l2vnis = 0;
 	int num_l3vnis = 0;

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -69,7 +69,7 @@ extern int zebra_vxlan_vrf_disable(struct zebra_vrf *zvrf);
 extern int zebra_vxlan_vrf_delete(struct zebra_vrf *zvrf);
 extern void zebra_vxlan_print_specific_nh_l3vni(struct vty *vty, vni_t l3vni,
 						struct ipaddr *ip, bool uj);
-extern void zebra_vxlan_print_evpn(struct vty *vty, uint8_t uj);
+extern void zebra_vxlan_print_evpn(struct vty *vty, bool uj);
 extern void zebra_vxlan_print_specific_rmac_l3vni(struct vty *vty, vni_t l3vni,
 						  struct ethaddr *rmac,
 						  bool use_json);

--- a/zebra/zebra_vxlan_null.c
+++ b/zebra/zebra_vxlan_null.c
@@ -83,7 +83,7 @@ void zebra_vxlan_print_vnis(struct vty *vty, struct zebra_vrf *zvrf)
 {
 }
 
-void zebra_vxlan_print_evpn(struct vty *vty, uint8_t uj)
+void zebra_vxlan_print_evpn(struct vty *vty, bool uj)
 {
 }
 


### PR DESCRIPTION
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>

### Summary
Change additional locations with use_json (or uj, referring to use_json) to bool from other types.

### Components
bgpd, ospfd, pimd, zebra

