### PR TITLE
osfpd: Install default route after second try instantly

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -8201,6 +8201,8 @@ DEFUN (no_ospf_redistribute_source,
 		return CMD_SUCCESS;
 
 	ospf_routemap_unset(red);
+	ospf_redist_del(ospf, source, 0);
+
 	return ospf_redistribute_unset(ospf, source, 0);
 }
 
@@ -8315,6 +8317,8 @@ DEFUN (no_ospf_redistribute_instance_source,
 		return CMD_SUCCESS;
 
 	ospf_routemap_unset(red);
+	ospf_redist_del(ospf, source, instance);
+
 	return ospf_redistribute_unset(ospf, source, instance);
 }
 
@@ -8447,6 +8451,8 @@ DEFUN (no_ospf_default_information_originate,
 		return CMD_SUCCESS;
 
 	ospf_routemap_unset(red);
+	ospf_redist_del(ospf, DEFAULT_ROUTE, 0);
+
 	return ospf_redistribute_default_unset(ospf);
 }
 

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -744,8 +744,6 @@ int ospf_redistribute_unset(struct ospf *ospf, int type,
 		zlog_debug("Redistribute[%s][%d] vrf id %u: Stop",
 			   ospf_redist_string(type), instance, ospf->vrf_id);
 
-	ospf_redist_del(ospf, type, instance);
-
 	/* Remove the routes from OSPF table. */
 	ospf_redistribute_withdraw(ospf, type, instance);
 
@@ -759,30 +757,17 @@ int ospf_redistribute_unset(struct ospf *ospf, int type,
 int ospf_redistribute_default_set(struct ospf *ospf, int originate, int mtype,
 				  int mvalue)
 {
-	struct ospf_redist *red;
-
 	ospf->default_originate = originate;
-
-	red = ospf_redist_add(ospf, DEFAULT_ROUTE, 0);
-	red->dmetric.type = mtype;
-	red->dmetric.value = mvalue;
 
 	ospf_external_add(ospf, DEFAULT_ROUTE, 0);
 
-	if (ospf_is_type_redistributed(ospf, DEFAULT_ROUTE, 0)) {
-		/* if ospf->default_originate changes value, is calling
-		   ospf_external_lsa_refresh_default sufficient to implement
-		   the change? */
-		ospf_external_lsa_refresh_default(ospf);
-
+	if (ospf_is_type_redistributed(ospf, DEFAULT_ROUTE, 0))
 		if (IS_DEBUG_OSPF(zebra, ZEBRA_REDISTRIBUTE))
 			zlog_debug(
 				"Redistribute[%s]: Refresh  Type[%d], Metric[%d]",
 				ospf_redist_string(DEFAULT_ROUTE),
 				metric_type(ospf, DEFAULT_ROUTE, 0),
 				metric_value(ospf, DEFAULT_ROUTE, 0));
-		return CMD_SUCCESS;
-	}
 
 	zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_ADD, zclient,
 				     ospf->vrf_id);
@@ -791,6 +776,8 @@ int ospf_redistribute_default_set(struct ospf *ospf, int originate, int mtype,
 		zlog_debug("Redistribute[DEFAULT]: Start  Type[%d], Metric[%d]",
 			   metric_type(ospf, DEFAULT_ROUTE, 0),
 			   metric_value(ospf, DEFAULT_ROUTE, 0));
+
+	ospf_external_lsa_refresh_default(ospf);
 
 	if (ospf->router_id.s_addr == 0)
 		ospf->external_origin |= (1 << DEFAULT_ROUTE);
@@ -809,7 +796,6 @@ int ospf_redistribute_default_unset(struct ospf *ospf)
 		return CMD_SUCCESS;
 
 	ospf->default_originate = DEFAULT_ORIGINATE_NONE;
-	ospf_redist_del(ospf, DEFAULT_ROUTE, 0);
 
 	zclient_redistribute_default(ZEBRA_REDISTRIBUTE_DEFAULT_DELETE, zclient,
 				     ospf->vrf_id);


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis donatas.abraitis@gmail.com

### Summary
This gives no `0.0.0.0`/`::/0` installed. 
```
spine1-debian-9(config-router)# no default-information originate
spine1-debian-9(config-router)# default-information originate always
```

Need to double `default-information originate always` to install the route.

This is because `ospf_is_type_redistributed()` expects `default_information` while it's set in `zclient_redistribute_default()` only after the `ospf_is_type_redistributed()`.

### Related Issue
https://github.com/FRRouting/frr/issues/721

### Components
ospfd

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
