### PR TITLE
zebra: Fix RB-Tree storage comparison function for v6

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -207,6 +207,9 @@ static int host_rb_entry_compare(const struct host_rb_entry *hle1,
 			return 1;
 
 		return 0;
+	} else if (hle1->p.family == AF_INET6) {
+		return memcmp(&hle1->p.u.prefix6, &hle2->p.u.prefix6,
+			      IPV6_MAX_BYTELEN);
 	} else {
 		zlog_warn("%s: Unexpected family type: %d", __PRETTY_FUNCTION__,
 			  hle1->p.family);


### PR DESCRIPTION
The RB-Tree used to store rmac information was not properly
handling the v6 address family.  Modify the code to allow
this handling.

Cleans up this error message:

zebra[2231]: host_rb_entry_compare: Unexpected family type: 10

That is being seen, This fixes some connectivity issues being seen.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
