### PR TITLE
lib: Add missing smux.h to `make distrib` results

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -152,6 +152,7 @@ pkginclude_HEADERS += \
 	lib/sha256.h \
 	lib/sigevent.h \
 	lib/skiplist.h \
+	lib/smux.h \
 	lib/sockopt.h \
 	lib/sockunion.h \
 	lib/spf_backoff.h \


### PR DESCRIPTION
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

