### PR TITLE
lib: Ensure FRR detects running of the second instance of a FRR daemo…

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -262,12 +262,39 @@ bool frr_zclient_addr(struct sockaddr_storage *sa, socklen_t *sa_len,
 
 static struct frr_daemon_info *di = NULL;
 
+static void frr_guard_daemon(void)
+{
+	int fd;
+	struct flock lock;
+
+	const char *path = di->pid_file;
+	fd = open(path, O_RDWR);
+	if (fd != -1) {
+		memset(&lock, 0, sizeof(lock));
+		lock.l_type = F_WRLCK;
+		lock.l_whence = SEEK_SET;
+		if (fcntl(fd, F_GETLK, &lock) < 0) {
+			flog_err_sys(LIB_ERR_SYSTEM_CALL,
+				"Could not do F_GETLK pid_file %s (%s), exiting",
+				path, safe_strerror(errno));
+			exit(1);
+		} else if (lock.l_type == F_WRLCK) {
+			flog_err_sys(LIB_ERR_SYSTEM_CALL,
+				"Process %d has a write lock on file %s already! Error : ( %s)",
+				lock.l_pid, path, safe_strerror(errno));
+			exit(1);
+		}
+		close(fd);
+	}
+}
+
 void frr_preinit(struct frr_daemon_info *daemon, int argc, char **argv)
 {
 	di = daemon;
 
 	/* basename(), opencoded. */
 	char *p = strrchr(argv[0], '/');
+
 	di->progname = p ? p + 1 : argv[0];
 
 	umask(0027);
@@ -588,6 +615,9 @@ struct thread_master *frr_init(void)
 	}
 
 	zprivs_init(di->privs);
+
+	/* Guard to prevent a second instance of this daemon */
+	frr_guard_daemon();
 
 	master = thread_master_create(NULL);
 	signal_init(master, di->n_signals, di->signals);


### PR DESCRIPTION
…n, doesnot allow it to run.

Solution :
The following procedures would be performed :

1. Verify if the pid file for each daemon is present or not. If the file is not present, that means the
   daemon is getting instantiated for the first time. So let it go ahead.
   If the file is present proceed to point ‘2’.

2. Try fetching the properties of the pid file.

3. If it has RW lock, that means one instance of this the daemon is already running.
   So stop moving ahead and do exit() else let it go ahead. Please note all above procedure happen at
   the initial state of daemon’s instantiation, much before it starts any session with other
   process/allocates resources etc.. and this verification do not have any impact of any
   operations done later, if the verification succeeds.

Signed-off-by: bisdhdh sadhub@vmware.com

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
