### PR TITLE
pimd: create a new command "ip pim" configuring pim sm

### DIFF
--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -267,7 +267,7 @@ int pim_interface_config_write(struct vty *vty)
 				struct pim_interface *pim_ifp = ifp->info;
 
 				if (PIM_IF_TEST_PIM(pim_ifp->options)) {
-					vty_out(vty, " ip pim sm\n");
+					vty_out(vty, " ip pim\n");
 					++writes;
 				}
 


### PR DESCRIPTION
A new command "ip pim" is created to configure pim sm on an
interface, which replaces the existing commands "ip pim sm"
and "ip pim ssm" and make "ip pim sm" and "ip pim ssm" as
hidden commands. The command "ip multicast-routing" is removed
since it is already enabled on FRR by default.

Signed-off-by: Sarita Patra saritap@vmware.com

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
