### PR TITLE
bgpd: Prevent possible crash when parsing v6 attributes

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1707,8 +1707,14 @@ int bgp_mp_reach_parse(struct bgp_attr_parser_args *args,
 			stream_getl(s); /* RD low */
 		}
 		stream_get(&attr->mp_nexthop_global, s, IPV6_MAX_BYTELEN);
-		if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_global))
+		if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_global)) {
+			if (!peer->nexthop.ifp) {
+				zlog_warn("%s: interface not set appropriately to handle some attributes",
+					  peer->host);
+				return BGP_ATTR_PARSE_WITHDRAW;
+			}
 			attr->nh_ifindex = peer->nexthop.ifp->ifindex;
+		}
 		break;
 	case BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL:
 	case BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL:
@@ -1718,8 +1724,14 @@ int bgp_mp_reach_parse(struct bgp_attr_parser_args *args,
 			stream_getl(s); /* RD low */
 		}
 		stream_get(&attr->mp_nexthop_global, s, IPV6_MAX_BYTELEN);
-		if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_global))
+		if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_global)) {
+			if (!peer->nexthop.ifp) {
+				zlog_warn("%s: interface not set appropriately to handle some attributes",
+					  peer->host);
+				return BGP_ATTR_PARSE_WITHDRAW;
+			}
 			attr->nh_ifindex = peer->nexthop.ifp->ifindex;
+		}
 		if (attr->mp_nexthop_len
 		    == BGP_ATTR_NHLEN_VPNV6_GLOBAL_AND_LL) {
 			stream_getl(s); /* RD high */
@@ -1742,6 +1754,11 @@ int bgp_mp_reach_parse(struct bgp_attr_parser_args *args,
 						  INET6_ADDRSTRLEN));
 
 			attr->mp_nexthop_len = IPV6_MAX_BYTELEN;
+		}
+		if (!peer->nexthop.ifp) {
+			zlog_warn("%s: Interface not set appropriately to handle this some attributes",
+				  peer->host);
+			return BGP_ATTR_PARSE_WITHDRAW;
 		}
 		attr->nh_lla_ifindex = peer->nexthop.ifp->ifindex;
 		break;

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -36,6 +36,7 @@
 #include "filter.h"
 #include "ns.h"
 #include "lib_errors.h"
+#include "nexthop.h"
 
 #include "bgpd/bgpd.h"
 #include "bgpd/bgp_open.h"
@@ -44,6 +45,7 @@
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_errors.h"
 #include "bgpd/bgp_network.h"
+#include "bgpd/bgp_zebra.h"
 
 extern struct zebra_privs_t bgpd_privs;
 
@@ -617,15 +619,12 @@ int bgp_getsockname(struct peer *peer)
 	if (!peer->su_remote)
 		return -1;
 
-	if (bgp_nexthop_set(peer->su_local, peer->su_remote, &peer->nexthop,
-			    peer)) {
-#if defined(HAVE_CUMULUS)
-		flog_err(
-			BGP_ERR_NH_UPD,
-			"%s: nexthop_set failed, resetting connection - intf %p",
-			peer->host, peer->nexthop.ifp);
+	if (!bgp_zebra_nexthop_set(peer->su_local, peer->su_remote,
+				   &peer->nexthop, peer)) {
+		flog_err(BGP_ERR_NH_UPD,
+			 "%s: nexthop_set failed, resetting connection - intf %p",
+			 peer->host, peer->nexthop.ifp);
 		return -1;
-#endif
 	}
 	return 0;
 }

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -73,6 +73,9 @@ extern int bgp_zebra_advertise_all_vni(struct bgp *, int);
 
 extern int bgp_zebra_num_connects(void);
 
+extern bool bgp_zebra_nexthop_set(union sockunion *, union sockunion *,
+				  struct bgp_nexthop *, struct peer *);
+
 struct bgp_pbr_action;
 struct bgp_pbr_match;
 struct bgp_pbr_match_entry;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1470,8 +1470,6 @@ extern void bgp_terminate(void);
 extern void bgp_reset(void);
 extern time_t bgp_clock(void);
 extern void bgp_zclient_reset(void);
-extern int bgp_nexthop_set(union sockunion *, union sockunion *,
-			   struct bgp_nexthop *, struct peer *);
 extern struct bgp *bgp_get_default(void);
 extern struct bgp *bgp_lookup(as_t, const char *);
 extern struct bgp *bgp_lookup_by_name(const char *);


### PR DESCRIPTION
The peer->nexthop.ifp pointer must be set when parsing the
some attributes in bgp_mp_reach_parse, notice this
and fail gracefully.

Also add some verbiage to log when we fail to properly setup
the peer->nexthop.ifp pointer.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
