### PR TITLE
Mac compiling cleanups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -313,6 +313,13 @@ AX_PTHREAD([
   AC_MSG_FAILURE([This FRR version needs pthreads])
 ])
 
+AC_SEARCH_LIBS([pthread_condattr_setclock], [],
+		[frr_cv_pthread_condattr_setclock=yes],
+		[frr_cv_pthread_condattr_setclock=no])
+if test "$frr_cv_pthread_condattr_setclock" = yes; then
+  AC_DEFINE(HAVE_PTHREAD_CONDATTR_SETCLOCK, 1, [Have pthread.h pthread_condattr_setclock])
+fi
+
 dnl --------------
 dnl Check programs
 dnl --------------

--- a/configure.ac
+++ b/configure.ac
@@ -1056,6 +1056,10 @@ dnl	 [TODO] on Linux, and in [TODO] on Solaris.
          if test $ac_cv_lib_readline_rl_completion_matches = no; then
            AC_DEFINE(rl_completion_matches,completion_matches,Old readline)
 	 fi
+	 AC_SEARCH_LIBS([append_history], [readline], [frr_cv_append_history=yes], [frr_cv_append_history=no])
+	 if test "$frr_cv_append_history" = yes; then
+	   AC_DEFINE(HAVE_APPEND_HISTORY, 1, [Have history.h append_history])
+	 fi
 	 ;;
 esac
 AC_SUBST(LIBREADLINE)

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -234,4 +234,8 @@ void frr_pthread_yield(void);
  */
 uint32_t frr_pthread_get_id(void);
 
+#ifndef HAVE_PTHREAD_CONDATTR_SETCLOCK
+#define pthread_condattr_setclock(A, B)
+#endif
+
 #endif /* _FRR_PTHREAD_H */

--- a/lib/memory_vty.c
+++ b/lib/memory_vty.c
@@ -28,7 +28,9 @@
 #include <malloc/malloc.h>
 #endif
 #include <dlfcn.h>
+#ifdef HAVE_LINK_H
 #include <link.h>
+#endif
 
 #include "log.h"
 #include "memory.h"

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1112,7 +1112,7 @@ static char *command_generator(const char *text, int state)
 	return NULL;
 }
 
-static char **new_completion(char *text, int start, int end)
+static char **new_completion(const char *text, int start, int end)
 {
 	char **matches;
 
@@ -3386,8 +3386,7 @@ void vtysh_readline_init(void)
 	rl_initialize();
 	rl_bind_key('?', (rl_command_func_t *)vtysh_rl_describe);
 	rl_completion_entry_function = vtysh_completion_entry_function;
-	rl_attempted_completion_function =
-		(rl_completion_func_t *)new_completion;
+	rl_attempted_completion_function = new_completion;
 }
 
 char *vtysh_prompt(void)

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -30,6 +30,16 @@
 #include <readline/readline.h>
 #include <readline/history.h>
 
+/*
+ * The append_history function only appears in newer versions
+ * of the readline library it appears like.  Since we don't
+ * need this just silently ignore the code on these
+ * ancient platforms.
+ */
+#if !defined HAVE_APPEND_HISTORY
+#define append_history(A, B)
+#endif
+
 #include <lib/version.h>
 #include "getopt.h"
 #include "command.h"


### PR DESCRIPTION
Provide some code fixups to allow us to get a few steps closer to compiling on a mac.  Mainly autoconf autodetection and silently doing nothing on the mac platform for a couple of the esoteric pieces we were using.  I do not think any of the lost functionality is major at this point in time.