### PR TITLE
doc: Update RPM building instructions

### DIFF
--- a/redhat/README.rpm_build.md
+++ b/redhat/README.rpm_build.md
@@ -3,16 +3,15 @@ Building your own FRRouting RPM
 (Tested on CentOS 6, CentOS 7 and Fedora 24.)
 
 1. On CentOS 6 (which doesn't provide a bison/automake/autoconf of a recent enough version):
-    - Check out ../doc/Building_FRR_on_CentOS6.md for details on installing
+    - Check out ../doc/developer/building-frr-for-centos6.rst for details on installing
     a bison/automake/autoconf to support frr building.
 
     Newer automake/autoconf/bison is only needed to build the rpm and is
     **not** needed to install the binary rpm package
 
-2. Install the build packages as documented in doc/Building_on_xxxxx.md 
-   and the following additional packages:
+2. Install the build packages as documented in doc/developer/building-frr-for-xxxxx.rst and the following additional packages:
 
-        yum install rpm-build net-snmp-devel pam-devel
+        yum install rpm-build net-snmp-devel pam-devel libcap-devel
 
     Additionally, on systems with systemd (CentOS 7, Fedora)
 


### PR DESCRIPTION
### Summary
The RPM building instruction was referring to old paths in the repo and did not mention installing libcap-devel required in frr.spec

### Components
doc
