### PR TITLE
bgpd: Try to notice when configuration changes during startup

### DIFF
--- a/bgpd/bgp_errors.c
+++ b/bgpd/bgp_errors.c
@@ -463,6 +463,12 @@ static struct log_ref ferr_bgp_err[] = {
 		.suggestion = "Gather log files from the router and open an issue, Restart FRR"
 	},
 	{
+		.code = EC_BGP_DOPPELGANGER_CONFIG,
+		.title = "BGP has detected a configuration overwrite during peer collision resolution",
+		.description = "As part of BGP startup, the peer and ourselves can start connections to each other at the same time. During this process BGP received additional configuration, but it was only applied to one of the two nascent connections. Depending on the result of collision detection and resolution this configuration might be lost.  To remedy this, after performing collision detection and resolution the peer session has been reset in order to apply the new configuration.",
+		.suggestion = "Gather data and open a Issue so that this developmental escape can be fixed, the peer should have been reset",
+	},
+	{
 		.code = END_FERR,
 	}
 };

--- a/bgpd/bgp_errors.h
+++ b/bgpd/bgp_errors.h
@@ -99,6 +99,7 @@ enum bgp_log_refs {
 	EC_BGP_CAPABILITY_VENDOR,
 	EC_BGP_CAPABILITY_UNKNOWN,
 	EC_BGP_INVALID_NEXTHOP_LENGTH,
+	EC_BGP_DOPPELGANGER_CONFIG,
 };
 
 extern void bgp_error_init(void);

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -125,6 +125,20 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	if (!peer || !CHECK_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE))
 		return from_peer;
 
+	/*
+	 * Let's check that we are not going to loose known configuration
+	 * state based upon doppelganger rules.
+	 */
+	FOREACH_AFI_SAFI (afi, safi) {
+		if (from_peer->afc[afi][safi] != peer->afc[afi][safi]) {
+			flog_err(
+				EC_BGP_DOPPELGANGER_CONFIG,
+				"from_peer->afc[%d][%d] is not the same as what we are overwriting",
+				afi, safi);
+			return NULL;
+		}
+	}
+
 	if (bgp_debug_neighbor_events(peer))
 		zlog_debug("%s: peer transfer %p fd %d -> %p fd %d)",
 			   from_peer->host, from_peer, from_peer->fd, peer,


### PR DESCRIPTION
During peer startup there exists the possibility that both
locally and remote peers try to start communication at the
same time.  In addition it is possible for local configuration
to change at the same time this is going on.  When this happens
try to notice that the remote peer may be in opensent or openconfirm
and if so we need to restart the connection from both sides.

Additionally try to write a bit of extra code in peer_xfer_conn
to notice when this happens and to emit a error message to
the end user about this happening so that it can be cleaned up.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
