### PR TITLE
bgpd: Using no bgp fast-external-failover prevents vrf intf moves

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -287,6 +287,7 @@ static int bgp_interface_down(int command, struct zclient *zclient,
 	struct nbr_connected *nc;
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
+	struct peer *peer;
 
 	bgp = bgp_lookup_by_vrf_id(vrf_id);
 	if (!bgp)
@@ -307,11 +308,7 @@ static int bgp_interface_down(int command, struct zclient *zclient,
 		bgp_nbr_connected_delete(bgp, nc, 1);
 
 	/* Fast external-failover */
-	{
-		struct peer *peer;
-
-		if (CHECK_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER))
-			return 0;
+	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER)) {
 
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 #if defined(HAVE_CUMULUS)
@@ -474,6 +471,7 @@ static int bgp_interface_vrf_update(int command, struct zclient *zclient,
 	struct nbr_connected *nc;
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
+	struct peer *peer;
 
 	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrf_id,
 					      &new_vrf_id);
@@ -495,12 +493,7 @@ static int bgp_interface_vrf_update(int command, struct zclient *zclient,
 		bgp_nbr_connected_delete(bgp, nc, 1);
 
 	/* Fast external-failover */
-	{
-		struct peer *peer;
-
-		if (CHECK_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER))
-			return 0;
-
+	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER)) {
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 			if ((peer->ttl != 1) && (peer->gtsm_hops != 1))
 				continue;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -845,6 +845,14 @@ Configuring Peers
    specified number of hops away will be allowed to become neighbors. This
    command is mutually exclusive with *ebgp-multihop*.
 
+.. index:: [no] bgp fast-external-failover
+.. clicmd:: [no] bgp fast-external-failover
+
+   This command causes bgp to not take down ebgp peers immediately
+   when a link flaps.  `bgp fast-external-failover` is the default
+   and will not be displayed as part of a `show run`.  The no form
+   of the command turns off this ability.
+
 .. _bgp-peer-filtering:
 
 Peer Filtering


### PR DESCRIPTION
When using `no bgp fast-external-failover` and a interface moves
from one vrf into another we would not fully process the change.
Fix this code path.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>