### PR TITLE
bgp_node abstraction

### DIFF
--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -360,4 +360,16 @@ static inline void bgp_connected_set_node_info(struct bgp_node *node,
 	node->info = bc;
 }
 
+static inline struct bgp_nexthop_cache *
+bgp_nexthop_get_node_info(struct bgp_node *node)
+{
+	return node->info;
+}
+
+static inline void bgp_nexthop_set_node_info(struct bgp_node *node,
+					     struct bgp_nexthop_cache *bnc)
+{
+	node->info = bnc;
+}
+
 #endif /* _QUAGGA_BGP_TABLE_H */

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -313,4 +313,17 @@ static inline uint64_t bgp_table_version(struct bgp_table *table)
 void bgp_table_range_lookup(const struct bgp_table *table, struct prefix *p,
 			    uint8_t maxlen, struct list *matches);
 
+
+static inline struct bgp_aggregate *
+bgp_aggregate_get_node_info(struct bgp_node *node)
+{
+	return node->info;
+}
+
+static inline void bgp_aggregate_set_node_info(struct bgp_node *node,
+					       struct bgp_aggregate *aggregate)
+{
+	node->info = aggregate;
+}
+
 #endif /* _QUAGGA_BGP_TABLE_H */

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -326,4 +326,15 @@ static inline void bgp_aggregate_set_node_info(struct bgp_node *node,
 	node->info = aggregate;
 }
 
+static inline struct bgp_distance *bgp_distance_get_node(struct bgp_node *node)
+{
+	return node->info;
+}
+
+static inline void bgp_distance_set_node(struct bgp_node *node,
+					 struct bgp_distance *distance)
+{
+	node->info = distance;
+}
+
 #endif /* _QUAGGA_BGP_TABLE_H */

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -347,4 +347,17 @@ static inline void bgp_static_set_node_info(struct bgp_node *node,
 {
 	node->info = bgp_static;
 }
+
+static inline struct bgp_connected_ref *
+bgp_connected_get_node_info(struct bgp_node *node)
+{
+	return node->info;
+}
+
+static inline void bgp_connected_set_node_info(struct bgp_node *node,
+					       struct bgp_connected_ref *bc)
+{
+	node->info = bc;
+}
+
 #endif /* _QUAGGA_BGP_TABLE_H */

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -331,10 +331,20 @@ static inline struct bgp_distance *bgp_distance_get_node(struct bgp_node *node)
 	return node->info;
 }
 
-static inline void bgp_distance_set_node(struct bgp_node *node,
-					 struct bgp_distance *distance)
+static inline void bgp_distance_set_node_info(struct bgp_node *node,
+					      struct bgp_distance *distance)
 {
 	node->info = distance;
 }
 
+static inline struct bgp_static *bgp_static_get_node_info(struct bgp_node *node)
+{
+	return node->info;
+}
+
+static inline void bgp_static_set_node_info(struct bgp_node *node,
+					    struct bgp_static *bgp_static)
+{
+	node->info = bgp_static;
+}
 #endif /* _QUAGGA_BGP_TABLE_H */


### PR DESCRIPTION
Start the work to abstract out the usage of `struct bgp_node` into a `struct route_node`.  These commits provide insert/retrieval functions for some common data types that are stored on a `struct bgp_node`.  This will become useful in the future when we swap out `struct bgp_node`.