### PR TITLE
bgpd: type fix

### DIFF
--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -177,7 +177,7 @@ int bgp_damp_withdraw(struct bgp_info *binfo, struct bgp_node *rn, afi_t afi,
 {
 	time_t t_now;
 	struct bgp_damp_info *bdi = NULL;
-	double last_penalty = 0;
+	unsigned int last_penalty = 0;
 
 	t_now = bgp_clock();
 


### PR DESCRIPTION
### Summary

For tracking the last state of the penalty (struct bgp_damp_info) a 'double'
type was used instead of using the 'unsigned int' being used in the structure.

Detected using ./configure CFLAGS=-Wfloat-equal CC=clang

### Components

bgpd
