### PR TITLE
bgpd isisd zebra: misuse of comma operator

### DIFF
--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -2004,7 +2004,8 @@ register_add(struct vty *vty, struct cmd_token *carg_prefix,
 					"Missing parameter for local-next-hop\n");
 				return CMD_WARNING_CONFIG_FAILED;
 			}
-			++argv, --argc;
+			++argv;
+			--argc;
 			arg_lnh = argv[0]->arg;
 		}
 		if (strmatch(argv[0]->text, "local-cost")) {
@@ -2018,7 +2019,8 @@ register_add(struct vty *vty, struct cmd_token *carg_prefix,
 					"Missing parameter for local-cost\n");
 				return CMD_WARNING_CONFIG_FAILED;
 			}
-			++argv, --argc;
+			++argv;
+			--argc;
 			arg_lnh_cost = argv[0]->arg;
 		}
 	}

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -897,16 +897,16 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 			vty_out(vty, "    IP Prefix(es):\n");
 			for (ALL_LIST_ELEMENTS_RO(circuit->ip_addrs, node,
 						  ip_addr)) {
-				prefix2str(ip_addr, buf, sizeof(buf)),
-					vty_out(vty, "      %s\n", buf);
+				prefix2str(ip_addr, buf, sizeof(buf));
+				vty_out(vty, "      %s\n", buf);
 			}
 		}
 		if (circuit->ipv6_link && listcount(circuit->ipv6_link) > 0) {
 			vty_out(vty, "    IPv6 Link-Locals:\n");
 			for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_link, node,
 						  ip_addr)) {
-				prefix2str(ip_addr, (char *)buf, BUFSIZ),
-					vty_out(vty, "      %s\n", buf);
+				prefix2str(ip_addr, (char *)buf, BUFSIZ);
+				vty_out(vty, "      %s\n", buf);
 			}
 		}
 		if (circuit->ipv6_non_link
@@ -914,8 +914,8 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 			vty_out(vty, "    IPv6 Prefixes:\n");
 			for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_non_link, node,
 						  ip_addr)) {
-				prefix2str(ip_addr, (char *)buf, BUFSIZ),
-					vty_out(vty, "      %s\n", buf);
+				prefix2str(ip_addr, (char *)buf, BUFSIZ);
+				vty_out(vty, "      %s\n", buf);
 			}
 		}
 

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -275,8 +275,7 @@ int zebra_ns_disable(ns_id_t ns_id, void **info)
 
 	hash_clean(zns->rules_hash, zebra_pbr_rules_free);
 	hash_free(zns->rules_hash);
-	hash_clean(zns->ipset_entry_hash,
-		   zebra_pbr_ipset_entry_free),
+	hash_clean(zns->ipset_entry_hash, zebra_pbr_ipset_entry_free);
 	hash_clean(zns->ipset_hash, zebra_pbr_ipset_free);
 	hash_free(zns->ipset_hash);
 	hash_free(zns->ipset_entry_hash);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -285,7 +285,8 @@ static void zvni_find_neigh_addr_width(struct hash_backet *backet, void *ctxt)
 
 	n = (zebra_neigh_t *)backet->data;
 
-	ipaddr2str(&n->ip, buf, sizeof(buf)), width = strlen(buf);
+	ipaddr2str(&n->ip, buf, sizeof(buf));
+	width = strlen(buf);
 	if (width > wctx->addr_width)
 		wctx->addr_width = width;
 


### PR DESCRIPTION
### Summary

Misuse of comma operator. Detected using ./configure CFLAGS=-Wcomma CC=clang

### Components

bgpd isisd zebra
