### PR TITLE
`struct bgp_info` to `struct bgp_path`

### DIFF
--- a/bgpd/IMPLEMENTATION.txt
+++ b/bgpd/IMPLEMENTATION.txt
@@ -104,8 +104,8 @@ bgp_route.[hc]:
       looking for data in hash table, and putting there if missing, refcnt
       using pointer to existing data
     many validity checks
-    get new struct bgp_info (10 words/40 bytes)
-    call bgp_info_add with rn and bgp_info
+    get new struct bgp_path_info
+    call bgp_path_info_add with rn and bgp_path_info
     call bgp_process
 
 bgp_routemap.c
@@ -149,7 +149,7 @@ bgpd.c
 Question: How much memory does quagga's bgpd use as a function of
 state received from peers?
 
-It seems that a struct bgp_info is kept for each prefix.  The "struct
+It seems that a struct bgp_path_info is kept for each prefix.  The "struct
 attr *" is interned, and variables within that are interned.  So, 40
 bytes are kept per received prefix, plus interned shared values.  This
 could be 36 if 'int suppress' where changed to a u_char and moved to

--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -91,8 +91,8 @@ struct bgp_advertise *bgp_advertise_new(void)
 void bgp_advertise_free(struct bgp_advertise *adv)
 {
 	if (adv->binfo)
-		bgp_info_unlock(
-			adv->binfo); /* bgp_advertise bgp_info reference */
+		bgp_path_info_unlock(
+			adv->binfo); /* bgp_advertise bgp_path_info reference */
 	XFREE(MTYPE_BGP_ADVERTISE, adv);
 }
 

--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -90,9 +90,9 @@ struct bgp_advertise *bgp_advertise_new(void)
 
 void bgp_advertise_free(struct bgp_advertise *adv)
 {
-	if (adv->binfo)
-		bgp_path_info_unlock(
-			adv->binfo); /* bgp_advertise bgp_path_info reference */
+	if (adv->pathi)
+		/* bgp_advertise bgp_path_info reference */
+		bgp_path_info_unlock(adv->pathi);
 	XFREE(MTYPE_BGP_ADVERTISE, adv);
 }
 

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -62,7 +62,7 @@ struct bgp_advertise {
 	struct bgp_advertise_attr *baa;
 
 	/* BGP info.  */
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *pathi;
 };
 
 /* BGP adjacency out.  */

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -113,7 +113,7 @@ struct bgp_synchronize {
 };
 
 /* BGP adjacency linked list.  */
-#define BGP_INFO_ADD(N, A, TYPE)                                               \
+#define BGP_PATH_INFO_ADD(N, A, TYPE)                                          \
 	do {                                                                   \
 		(A)->prev = NULL;                                              \
 		(A)->next = (N)->TYPE;                                         \
@@ -122,7 +122,7 @@ struct bgp_synchronize {
 		(N)->TYPE = (A);                                               \
 	} while (0)
 
-#define BGP_INFO_DEL(N, A, TYPE)                                               \
+#define BGP_PATH_INFO_DEL(N, A, TYPE)                                          \
 	do {                                                                   \
 		if ((A)->next)                                                 \
 			(A)->next->prev = (A)->prev;                           \
@@ -132,10 +132,10 @@ struct bgp_synchronize {
 			(N)->TYPE = (A)->next;                                 \
 	} while (0)
 
-#define BGP_ADJ_IN_ADD(N,A)    BGP_INFO_ADD(N,A,adj_in)
-#define BGP_ADJ_IN_DEL(N,A)    BGP_INFO_DEL(N,A,adj_in)
-#define BGP_ADJ_OUT_ADD(N,A)   BGP_INFO_ADD(N,A,adj_out)
-#define BGP_ADJ_OUT_DEL(N,A)   BGP_INFO_DEL(N,A,adj_out)
+#define BGP_ADJ_IN_ADD(N, A) BGP_PATH_INFO_ADD(N, A, adj_in)
+#define BGP_ADJ_IN_DEL(N, A) BGP_PATH_INFO_DEL(N, A, adj_in)
+#define BGP_ADJ_OUT_ADD(N, A) BGP_PATH_INFO_ADD(N, A, adj_out)
+#define BGP_ADJ_OUT_DEL(N, A) BGP_PATH_INFO_DEL(N, A, adj_out)
 
 #define BGP_ADV_FIFO_ADD(F, N)                                                 \
 	do {                                                                   \

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -62,7 +62,7 @@ struct bgp_advertise {
 	struct bgp_advertise_attr *baa;
 
 	/* BGP info.  */
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 };
 
 /* BGP adjacency out.  */

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -172,8 +172,8 @@ static int bgp_reuse_timer(struct thread *t)
 }
 
 /* A route becomes unreachable (RFC2439 Section 4.8.2).  */
-int bgp_damp_withdraw(struct bgp_info *binfo, struct bgp_node *rn, afi_t afi,
-		      safi_t safi, int attr_change)
+int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
+		      afi_t afi, safi_t safi, int attr_change)
 {
 	time_t t_now;
 	struct bgp_damp_info *bdi = NULL;
@@ -252,7 +252,7 @@ int bgp_damp_withdraw(struct bgp_info *binfo, struct bgp_node *rn, afi_t afi,
 	return BGP_DAMP_USED;
 }
 
-int bgp_damp_update(struct bgp_info *binfo, struct bgp_node *rn, afi_t afi,
+int bgp_damp_update(struct bgp_path_info *binfo, struct bgp_node *rn, afi_t afi,
 		    safi_t safi)
 {
 	time_t t_now;
@@ -290,7 +290,7 @@ int bgp_damp_update(struct bgp_info *binfo, struct bgp_node *rn, afi_t afi,
 }
 
 /* Remove dampening information and history route.  */
-int bgp_damp_scan(struct bgp_info *binfo, afi_t afi, safi_t safi)
+int bgp_damp_scan(struct bgp_path_info *binfo, afi_t afi, safi_t safi)
 {
 	time_t t_now, t_diff;
 	struct bgp_damp_info *bdi;
@@ -334,7 +334,7 @@ int bgp_damp_scan(struct bgp_info *binfo, afi_t afi, safi_t safi)
 
 void bgp_damp_info_free(struct bgp_damp_info *bdi, int withdraw)
 {
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 
 	if (!bdi)
 		return;
@@ -588,7 +588,7 @@ static const char *bgp_get_reuse_time(unsigned int penalty, char *buf,
 	return buf;
 }
 
-void bgp_damp_info_vty(struct vty *vty, struct bgp_info *binfo,
+void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *binfo,
 		       json_object *json_path)
 {
 	struct bgp_damp_info *bdi;
@@ -640,8 +640,9 @@ void bgp_damp_info_vty(struct vty *vty, struct bgp_info *binfo,
 	}
 }
 
-const char *bgp_damp_reuse_time_vty(struct vty *vty, struct bgp_info *binfo,
-				    char *timebuf, size_t len, bool use_json,
+const char *bgp_damp_reuse_time_vty(struct vty *vty,
+				    struct bgp_path_info *binfo, char *timebuf,
+				    size_t len, bool use_json,
 				    json_object *json)
 {
 	struct bgp_damp_info *bdi;

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -145,13 +145,13 @@ static int bgp_reuse_timer(struct thread *t)
 		/* if (figure-of-merit < reuse).  */
 		if (bdi->penalty < damp->reuse_limit) {
 			/* Reuse the route.  */
-			bgp_info_unset_flag(bdi->rn, bdi->binfo,
-					    BGP_PATH_DAMPED);
+			bgp_path_info_unset_flag(bdi->rn, bdi->binfo,
+						 BGP_PATH_DAMPED);
 			bdi->suppress_time = 0;
 
 			if (bdi->lastrecord == BGP_RECORD_UPDATE) {
-				bgp_info_unset_flag(bdi->rn, bdi->binfo,
-						    BGP_PATH_HISTORY);
+				bgp_path_info_unset_flag(bdi->rn, bdi->binfo,
+							 BGP_PATH_HISTORY);
 				bgp_aggregate_increment(bgp, &bdi->rn->p,
 							bdi->binfo, bdi->afi,
 							bdi->safi);
@@ -205,7 +205,7 @@ int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
 		bdi->index = -1;
 		bdi->afi = afi;
 		bdi->safi = safi;
-		(bgp_info_extra_get(binfo))->damp_info = bdi;
+		(bgp_path_info_extra_get(binfo))->damp_info = bdi;
 		BGP_DAMP_LIST_ADD(damp, bdi);
 	} else {
 		last_penalty = bdi->penalty;
@@ -228,7 +228,7 @@ int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
 	bdi->t_updated = t_now;
 
 	/* Make this route as historical status.  */
-	bgp_info_set_flag(rn, binfo, BGP_PATH_HISTORY);
+	bgp_path_info_set_flag(rn, binfo, BGP_PATH_HISTORY);
 
 	/* Remove the route from a reuse list if it is on one.  */
 	if (CHECK_FLAG(bdi->binfo->flags, BGP_PATH_DAMPED)) {
@@ -243,7 +243,7 @@ int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
 	/* If not suppressed before, do annonunce this withdraw and
 	   insert into reuse_list.  */
 	if (bdi->penalty >= damp->suppress_value) {
-		bgp_info_set_flag(rn, binfo, BGP_PATH_DAMPED);
+		bgp_path_info_set_flag(rn, binfo, BGP_PATH_DAMPED);
 		bdi->suppress_time = t_now;
 		BGP_DAMP_LIST_DEL(damp, bdi);
 		bgp_reuse_list_add(bdi);
@@ -263,7 +263,7 @@ int bgp_damp_update(struct bgp_path_info *binfo, struct bgp_node *rn, afi_t afi,
 		return BGP_DAMP_USED;
 
 	t_now = bgp_clock();
-	bgp_info_unset_flag(rn, binfo, BGP_PATH_HISTORY);
+	bgp_path_info_unset_flag(rn, binfo, BGP_PATH_HISTORY);
 
 	bdi->lastrecord = BGP_RECORD_UPDATE;
 	bdi->penalty = bgp_damp_decay(t_now - bdi->t_updated, bdi->penalty);
@@ -273,7 +273,7 @@ int bgp_damp_update(struct bgp_path_info *binfo, struct bgp_node *rn, afi_t afi,
 		status = BGP_DAMP_USED;
 	else if (CHECK_FLAG(bdi->binfo->flags, BGP_PATH_DAMPED)
 		 && (bdi->penalty < damp->reuse_limit)) {
-		bgp_info_unset_flag(rn, binfo, BGP_PATH_DAMPED);
+		bgp_path_info_unset_flag(rn, binfo, BGP_PATH_DAMPED);
 		bgp_reuse_list_delete(bdi);
 		BGP_DAMP_LIST_ADD(damp, bdi);
 		bdi->suppress_time = 0;
@@ -304,7 +304,8 @@ int bgp_damp_scan(struct bgp_path_info *binfo, afi_t afi, safi_t safi)
 		t_diff = t_now - bdi->suppress_time;
 
 		if (t_diff >= damp->max_suppress_time) {
-			bgp_info_unset_flag(bdi->rn, binfo, BGP_PATH_DAMPED);
+			bgp_path_info_unset_flag(bdi->rn, binfo,
+						 BGP_PATH_DAMPED);
 			bgp_reuse_list_delete(bdi);
 			BGP_DAMP_LIST_ADD(damp, bdi);
 			bdi->penalty = damp->reuse_limit;
@@ -347,10 +348,11 @@ void bgp_damp_info_free(struct bgp_damp_info *bdi, int withdraw)
 	else
 		BGP_DAMP_LIST_DEL(damp, bdi);
 
-	bgp_info_unset_flag(bdi->rn, binfo, BGP_PATH_HISTORY | BGP_PATH_DAMPED);
+	bgp_path_info_unset_flag(bdi->rn, binfo,
+				 BGP_PATH_HISTORY | BGP_PATH_DAMPED);
 
 	if (bdi->lastrecord == BGP_RECORD_WITHDRAW && withdraw)
-		bgp_info_delete(bdi->rn, binfo);
+		bgp_path_info_delete(bdi->rn, binfo);
 
 	XFREE(MTYPE_BGP_DAMP_INFO, bdi);
 }

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -128,7 +128,7 @@ static int bgp_reuse_timer(struct thread *t)
 
 	/* 3. if ( the saved list head pointer is non-empty ) */
 	for (; bdi; bdi = next) {
-		struct bgp *bgp = bdi->binfo->peer->bgp;
+		struct bgp *bgp = bdi->path->peer->bgp;
 
 		next = bdi->next;
 
@@ -145,15 +145,15 @@ static int bgp_reuse_timer(struct thread *t)
 		/* if (figure-of-merit < reuse).  */
 		if (bdi->penalty < damp->reuse_limit) {
 			/* Reuse the route.  */
-			bgp_path_info_unset_flag(bdi->rn, bdi->binfo,
+			bgp_path_info_unset_flag(bdi->rn, bdi->path,
 						 BGP_PATH_DAMPED);
 			bdi->suppress_time = 0;
 
 			if (bdi->lastrecord == BGP_RECORD_UPDATE) {
-				bgp_path_info_unset_flag(bdi->rn, bdi->binfo,
+				bgp_path_info_unset_flag(bdi->rn, bdi->path,
 							 BGP_PATH_HISTORY);
 				bgp_aggregate_increment(bgp, &bdi->rn->p,
-							bdi->binfo, bdi->afi,
+							bdi->path, bdi->afi,
 							bdi->safi);
 				bgp_process(bgp, bdi->rn, bdi->afi, bdi->safi);
 			}
@@ -172,7 +172,7 @@ static int bgp_reuse_timer(struct thread *t)
 }
 
 /* A route becomes unreachable (RFC2439 Section 4.8.2).  */
-int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
+int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_node *rn,
 		      afi_t afi, safi_t safi, int attr_change)
 {
 	time_t t_now;
@@ -182,8 +182,8 @@ int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
 	t_now = bgp_clock();
 
 	/* Processing Unreachable Messages.  */
-	if (binfo->extra)
-		bdi = binfo->extra->damp_info;
+	if (path->extra)
+		bdi = path->extra->damp_info;
 
 	if (bdi == NULL) {
 		/* If there is no previous stability history. */
@@ -195,7 +195,7 @@ int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
 
 		bdi = XCALLOC(MTYPE_BGP_DAMP_INFO,
 			      sizeof(struct bgp_damp_info));
-		bdi->binfo = binfo;
+		bdi->path = path;
 		bdi->rn = rn;
 		bdi->penalty =
 			(attr_change ? DEFAULT_PENALTY / 2 : DEFAULT_PENALTY);
@@ -205,7 +205,7 @@ int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
 		bdi->index = -1;
 		bdi->afi = afi;
 		bdi->safi = safi;
-		(bgp_path_info_extra_get(binfo))->damp_info = bdi;
+		(bgp_path_info_extra_get(path))->damp_info = bdi;
 		BGP_DAMP_LIST_ADD(damp, bdi);
 	} else {
 		last_penalty = bdi->penalty;
@@ -222,16 +222,16 @@ int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
 		bdi->flap++;
 	}
 
-	assert((rn == bdi->rn) && (binfo == bdi->binfo));
+	assert((rn == bdi->rn) && (path == bdi->path));
 
 	bdi->lastrecord = BGP_RECORD_WITHDRAW;
 	bdi->t_updated = t_now;
 
 	/* Make this route as historical status.  */
-	bgp_path_info_set_flag(rn, binfo, BGP_PATH_HISTORY);
+	bgp_path_info_set_flag(rn, path, BGP_PATH_HISTORY);
 
 	/* Remove the route from a reuse list if it is on one.  */
-	if (CHECK_FLAG(bdi->binfo->flags, BGP_PATH_DAMPED)) {
+	if (CHECK_FLAG(bdi->path->flags, BGP_PATH_DAMPED)) {
 		/* If decay rate isn't equal to 0, reinsert brn. */
 		if (bdi->penalty != last_penalty && bdi->index >= 0) {
 			bgp_reuse_list_delete(bdi);
@@ -243,7 +243,7 @@ int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
 	/* If not suppressed before, do annonunce this withdraw and
 	   insert into reuse_list.  */
 	if (bdi->penalty >= damp->suppress_value) {
-		bgp_path_info_set_flag(rn, binfo, BGP_PATH_DAMPED);
+		bgp_path_info_set_flag(rn, path, BGP_PATH_DAMPED);
 		bdi->suppress_time = t_now;
 		BGP_DAMP_LIST_DEL(damp, bdi);
 		bgp_reuse_list_add(bdi);
@@ -252,28 +252,28 @@ int bgp_damp_withdraw(struct bgp_path_info *binfo, struct bgp_node *rn,
 	return BGP_DAMP_USED;
 }
 
-int bgp_damp_update(struct bgp_path_info *binfo, struct bgp_node *rn, afi_t afi,
+int bgp_damp_update(struct bgp_path_info *path, struct bgp_node *rn, afi_t afi,
 		    safi_t safi)
 {
 	time_t t_now;
 	struct bgp_damp_info *bdi;
 	int status;
 
-	if (!binfo->extra || !((bdi = binfo->extra->damp_info)))
+	if (!path->extra || !((bdi = path->extra->damp_info)))
 		return BGP_DAMP_USED;
 
 	t_now = bgp_clock();
-	bgp_path_info_unset_flag(rn, binfo, BGP_PATH_HISTORY);
+	bgp_path_info_unset_flag(rn, path, BGP_PATH_HISTORY);
 
 	bdi->lastrecord = BGP_RECORD_UPDATE;
 	bdi->penalty = bgp_damp_decay(t_now - bdi->t_updated, bdi->penalty);
 
-	if (!CHECK_FLAG(bdi->binfo->flags, BGP_PATH_DAMPED)
+	if (!CHECK_FLAG(bdi->path->flags, BGP_PATH_DAMPED)
 	    && (bdi->penalty < damp->suppress_value))
 		status = BGP_DAMP_USED;
-	else if (CHECK_FLAG(bdi->binfo->flags, BGP_PATH_DAMPED)
+	else if (CHECK_FLAG(bdi->path->flags, BGP_PATH_DAMPED)
 		 && (bdi->penalty < damp->reuse_limit)) {
-		bgp_path_info_unset_flag(rn, binfo, BGP_PATH_DAMPED);
+		bgp_path_info_unset_flag(rn, path, BGP_PATH_DAMPED);
 		bgp_reuse_list_delete(bdi);
 		BGP_DAMP_LIST_ADD(damp, bdi);
 		bdi->suppress_time = 0;
@@ -290,21 +290,21 @@ int bgp_damp_update(struct bgp_path_info *binfo, struct bgp_node *rn, afi_t afi,
 }
 
 /* Remove dampening information and history route.  */
-int bgp_damp_scan(struct bgp_path_info *binfo, afi_t afi, safi_t safi)
+int bgp_damp_scan(struct bgp_path_info *path, afi_t afi, safi_t safi)
 {
 	time_t t_now, t_diff;
 	struct bgp_damp_info *bdi;
 
-	assert(binfo->extra && binfo->extra->damp_info);
+	assert(path->extra && path->extra->damp_info);
 
 	t_now = bgp_clock();
-	bdi = binfo->extra->damp_info;
+	bdi = path->extra->damp_info;
 
-	if (CHECK_FLAG(binfo->flags, BGP_PATH_DAMPED)) {
+	if (CHECK_FLAG(path->flags, BGP_PATH_DAMPED)) {
 		t_diff = t_now - bdi->suppress_time;
 
 		if (t_diff >= damp->max_suppress_time) {
-			bgp_path_info_unset_flag(bdi->rn, binfo,
+			bgp_path_info_unset_flag(bdi->rn, path,
 						 BGP_PATH_DAMPED);
 			bgp_reuse_list_delete(bdi);
 			BGP_DAMP_LIST_ADD(damp, bdi);
@@ -312,7 +312,7 @@ int bgp_damp_scan(struct bgp_path_info *binfo, afi_t afi, safi_t safi)
 			bdi->suppress_time = 0;
 			bdi->t_updated = t_now;
 
-			/* Need to announce UPDATE once this binfo is usable
+			/* Need to announce UPDATE once this path is usable
 			 * again. */
 			if (bdi->lastrecord == BGP_RECORD_UPDATE)
 				return 1;
@@ -324,7 +324,7 @@ int bgp_damp_scan(struct bgp_path_info *binfo, afi_t afi, safi_t safi)
 		bdi->penalty = bgp_damp_decay(t_diff, bdi->penalty);
 
 		if (bdi->penalty <= damp->reuse_limit / 2.0) {
-			/* release the bdi, bdi->binfo. */
+			/* release the bdi, bdi->path. */
 			bgp_damp_info_free(bdi, 1);
 			return 0;
 		} else
@@ -335,24 +335,24 @@ int bgp_damp_scan(struct bgp_path_info *binfo, afi_t afi, safi_t safi)
 
 void bgp_damp_info_free(struct bgp_damp_info *bdi, int withdraw)
 {
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 
 	if (!bdi)
 		return;
 
-	binfo = bdi->binfo;
-	binfo->extra->damp_info = NULL;
+	path = bdi->path;
+	path->extra->damp_info = NULL;
 
-	if (CHECK_FLAG(binfo->flags, BGP_PATH_DAMPED))
+	if (CHECK_FLAG(path->flags, BGP_PATH_DAMPED))
 		bgp_reuse_list_delete(bdi);
 	else
 		BGP_DAMP_LIST_DEL(damp, bdi);
 
-	bgp_path_info_unset_flag(bdi->rn, binfo,
+	bgp_path_info_unset_flag(bdi->rn, path,
 				 BGP_PATH_HISTORY | BGP_PATH_DAMPED);
 
 	if (bdi->lastrecord == BGP_RECORD_WITHDRAW && withdraw)
-		bgp_path_info_delete(bdi->rn, binfo);
+		bgp_path_info_delete(bdi->rn, path);
 
 	XFREE(MTYPE_BGP_DAMP_INFO, bdi);
 }
@@ -590,7 +590,7 @@ static const char *bgp_get_reuse_time(unsigned int penalty, char *buf,
 	return buf;
 }
 
-void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *binfo,
+void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *path,
 		       json_object *json_path)
 {
 	struct bgp_damp_info *bdi;
@@ -598,11 +598,11 @@ void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *binfo,
 	char timebuf[BGP_UPTIME_LEN];
 	int penalty;
 
-	if (!binfo->extra)
+	if (!path->extra)
 		return;
 
 	/* BGP dampening information.  */
-	bdi = binfo->extra->damp_info;
+	bdi = path->extra->damp_info;
 
 	/* If dampening is not enabled or there is no dampening information,
 	   return immediately.  */
@@ -620,8 +620,8 @@ void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *binfo,
 		peer_uptime(bdi->start_time, timebuf, BGP_UPTIME_LEN, 1,
 			    json_path);
 
-		if (CHECK_FLAG(binfo->flags, BGP_PATH_DAMPED)
-		    && !CHECK_FLAG(binfo->flags, BGP_PATH_HISTORY))
+		if (CHECK_FLAG(path->flags, BGP_PATH_DAMPED)
+		    && !CHECK_FLAG(path->flags, BGP_PATH_HISTORY))
 			bgp_get_reuse_time(penalty, timebuf, BGP_UPTIME_LEN, 1,
 					   json_path);
 	} else {
@@ -631,8 +631,8 @@ void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *binfo,
 			peer_uptime(bdi->start_time, timebuf, BGP_UPTIME_LEN, 0,
 				    json_path));
 
-		if (CHECK_FLAG(binfo->flags, BGP_PATH_DAMPED)
-		    && !CHECK_FLAG(binfo->flags, BGP_PATH_HISTORY))
+		if (CHECK_FLAG(path->flags, BGP_PATH_DAMPED)
+		    && !CHECK_FLAG(path->flags, BGP_PATH_HISTORY))
 			vty_out(vty, ", reuse in %s",
 				bgp_get_reuse_time(penalty, timebuf,
 						   BGP_UPTIME_LEN, 0,
@@ -642,20 +642,19 @@ void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *binfo,
 	}
 }
 
-const char *bgp_damp_reuse_time_vty(struct vty *vty,
-				    struct bgp_path_info *binfo, char *timebuf,
-				    size_t len, bool use_json,
+const char *bgp_damp_reuse_time_vty(struct vty *vty, struct bgp_path_info *path,
+				    char *timebuf, size_t len, bool use_json,
 				    json_object *json)
 {
 	struct bgp_damp_info *bdi;
 	time_t t_now, t_diff;
 	int penalty;
 
-	if (!binfo->extra)
+	if (!path->extra)
 		return NULL;
 
 	/* BGP dampening information.  */
-	bdi = binfo->extra->damp_info;
+	bdi = path->extra->damp_info;
 
 	/* If dampening is not enabled or there is no dampening information,
 	   return immediately.  */

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -44,7 +44,7 @@ struct bgp_damp_info {
 	time_t suppress_time;
 
 	/* Back reference to bgp_info. */
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 
 	/* Back reference to bgp_node. */
 	struct bgp_node *rn;
@@ -130,18 +130,19 @@ struct bgp_damp_config {
 extern int bgp_damp_enable(struct bgp *, afi_t, safi_t, time_t, unsigned int,
 			   unsigned int, time_t);
 extern int bgp_damp_disable(struct bgp *, afi_t, safi_t);
-extern int bgp_damp_withdraw(struct bgp_info *, struct bgp_node *, afi_t,
-			     safi_t, int);
-extern int bgp_damp_update(struct bgp_info *, struct bgp_node *, afi_t, safi_t);
-extern int bgp_damp_scan(struct bgp_info *, afi_t, safi_t);
-extern void bgp_damp_info_free(struct bgp_damp_info *, int);
+extern int bgp_damp_withdraw(struct bgp_path_info *path, struct bgp_node *rn,
+			     afi_t afi, safi_t safi, int attr_change);
+extern int bgp_damp_update(struct bgp_path_info *path, struct bgp_node *rn,
+			   afi_t afi, safi_t saff);
+extern int bgp_damp_scan(struct bgp_path_info *path, afi_t afi, safi_t safi);
+extern void bgp_damp_info_free(struct bgp_damp_info *path, int withdraw);
 extern void bgp_damp_info_clean(void);
 extern int bgp_damp_decay(time_t, int);
 extern void bgp_config_write_damp(struct vty *);
-extern void bgp_damp_info_vty(struct vty *, struct bgp_info *,
+extern void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *path,
 			      json_object *json_path);
 extern const char *bgp_damp_reuse_time_vty(struct vty *vty,
-					   struct bgp_info *binfo,
+					   struct bgp_path_info *binfo,
 					   char *timebuf, size_t len,
 					   bool use_json, json_object *json);
 extern int bgp_show_dampening_parameters(struct vty *vty, afi_t, safi_t);

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -43,7 +43,7 @@ struct bgp_damp_info {
 	/* Time of route start to be suppressed.  */
 	time_t suppress_time;
 
-	/* Back reference to bgp_info. */
+	/* Back reference to bgp_path_info. */
 	struct bgp_path_info *binfo;
 
 	/* Back reference to bgp_node. */

--- a/bgpd/bgp_damp.h
+++ b/bgpd/bgp_damp.h
@@ -44,7 +44,7 @@ struct bgp_damp_info {
 	time_t suppress_time;
 
 	/* Back reference to bgp_path_info. */
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 
 	/* Back reference to bgp_node. */
 	struct bgp_node *rn;
@@ -142,7 +142,7 @@ extern void bgp_config_write_damp(struct vty *);
 extern void bgp_damp_info_vty(struct vty *vty, struct bgp_path_info *path,
 			      json_object *json_path);
 extern const char *bgp_damp_reuse_time_vty(struct vty *vty,
-					   struct bgp_path_info *binfo,
+					   struct bgp_path_info *path,
 					   char *timebuf, size_t len,
 					   bool use_json, json_object *json);
 extern int bgp_show_dampening_parameters(struct vty *vty, afi_t, safi_t);

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -299,9 +299,9 @@ static void bgp_dump_routes_index_table(struct bgp *bgp)
 }
 
 
-static struct bgp_info *bgp_dump_route_node_record(int afi, struct bgp_node *rn,
-						   struct bgp_info *info,
-						   unsigned int seq)
+static struct bgp_path_info *
+bgp_dump_route_node_record(int afi, struct bgp_node *rn,
+			   struct bgp_path_info *info, unsigned int seq)
 {
 	struct stream *obuf;
 	size_t sizep;
@@ -387,7 +387,7 @@ static struct bgp_info *bgp_dump_route_node_record(int afi, struct bgp_node *rn,
 static unsigned int bgp_dump_routes_func(int afi, int first_run,
 					 unsigned int seq)
 {
-	struct bgp_info *info;
+	struct bgp_path_info *info;
 	struct bgp_node *rn;
 	struct bgp *bgp;
 	struct bgp_table *table;

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -301,7 +301,7 @@ static void bgp_dump_routes_index_table(struct bgp *bgp)
 
 static struct bgp_path_info *
 bgp_dump_route_node_record(int afi, struct bgp_node *rn,
-			   struct bgp_path_info *info, unsigned int seq)
+			   struct bgp_path_info *path, unsigned int seq)
 {
 	struct stream *obuf;
 	size_t sizep;
@@ -349,18 +349,18 @@ bgp_dump_route_node_record(int afi, struct bgp_node *rn,
 	stream_putw(obuf, 0);
 
 	endp = stream_get_endp(obuf);
-	for (; info; info = info->next) {
+	for (; path; path = path->next) {
 		size_t cur_endp;
 
 		/* Peer index */
-		stream_putw(obuf, info->peer->table_dump_index);
+		stream_putw(obuf, path->peer->table_dump_index);
 
 		/* Originated */
-		stream_putl(obuf, time(NULL) - (bgp_clock() - info->uptime));
+		stream_putl(obuf, time(NULL) - (bgp_clock() - path->uptime));
 
 		/* Dump attribute. */
 		/* Skip prefix & AFI/SAFI for MP_NLRI */
-		bgp_dump_routes_attr(obuf, info->attr, &rn->p);
+		bgp_dump_routes_attr(obuf, path->attr, &rn->p);
 
 		cur_endp = stream_get_endp(obuf);
 		if (cur_endp > BGP_MAX_PACKET_SIZE + BGP_DUMP_MSG_HEADER
@@ -379,7 +379,7 @@ bgp_dump_route_node_record(int afi, struct bgp_node *rn,
 	bgp_dump_set_size(obuf, MSG_TABLE_DUMP_V2);
 	fwrite(STREAM_DATA(obuf), stream_get_endp(obuf), 1, bgp_dump_routes.fp);
 
-	return info;
+	return path;
 }
 
 
@@ -387,7 +387,7 @@ bgp_dump_route_node_record(int afi, struct bgp_node *rn,
 static unsigned int bgp_dump_routes_func(int afi, int first_run,
 					 unsigned int seq)
 {
-	struct bgp_path_info *info;
+	struct bgp_path_info *path;
 	struct bgp_node *rn;
 	struct bgp *bgp;
 	struct bgp_table *table;
@@ -410,9 +410,9 @@ static unsigned int bgp_dump_routes_func(int afi, int first_run,
 	table = bgp->rib[afi][SAFI_UNICAST];
 
 	for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
-		info = rn->info;
-		while (info) {
-			info = bgp_dump_route_node_record(afi, rn, info, seq);
+		path = rn->info;
+		while (path) {
+			path = bgp_dump_route_node_record(afi, rn, path, seq);
 			seq++;
 		}
 	}

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -76,9 +76,9 @@ static inline int advertise_type5_routes(struct bgp *bgp_vrf,
 }
 
 /* Flag if the route's parent is a EVPN route. */
-static inline int is_route_parent_evpn(struct bgp_info *ri)
+static inline int is_route_parent_evpn(struct bgp_path_info *ri)
 {
-	struct bgp_info *parent_ri;
+	struct bgp_path_info *parent_ri;
 	struct bgp_table *table;
 	struct bgp_node *rn;
 
@@ -89,7 +89,7 @@ static inline int is_route_parent_evpn(struct bgp_info *ri)
 		return 0;
 
 	/* See if the parent is of family L2VPN/EVPN */
-	parent_ri = (struct bgp_info *)ri->extra->parent;
+	parent_ri = (struct bgp_path_info *)ri->extra->parent;
 	rn = parent_ri->net;
 	if (!rn)
 		return 0;
@@ -124,9 +124,9 @@ extern void bgp_evpn_encode_prefix(struct stream *s, struct prefix *p,
 extern int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 			       struct bgp_nlri *packet, int withdraw);
 extern int bgp_evpn_import_route(struct bgp *bgp, afi_t afi, safi_t safi,
-				 struct prefix *p, struct bgp_info *ri);
+				 struct prefix *p, struct bgp_path_info *ri);
 extern int bgp_evpn_unimport_route(struct bgp *bgp, afi_t afi, safi_t safi,
-				   struct prefix *p, struct bgp_info *ri);
+				   struct prefix *p, struct bgp_path_info *ri);
 extern int bgp_filter_evpn_routes_upon_martian_nh_change(struct bgp *bgp);
 extern int bgp_evpn_local_macip_del(struct bgp *bgp, vni_t vni,
 				    struct ethaddr *mac, struct ipaddr *ip);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -536,7 +536,7 @@ static void show_esi_routes(struct bgp *bgp,
 {
 	int header = 1;
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	uint32_t prefix_cnt, path_cnt;
 	uint64_t tbl_ver;
 
@@ -616,7 +616,7 @@ static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn, int type,
 			    json_object *json)
 {
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	struct bgp_table *table;
 	int header = 1;
 	uint64_t tbl_ver;
@@ -990,7 +990,7 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 	struct bgp_table *table;
 	struct bgp_node *rn;
 	struct bgp_node *rm;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	int rd_header;
 	int header = 1;
 
@@ -2017,7 +2017,7 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 	struct bgpevpn *vpn;
 	struct prefix_evpn p;
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	uint32_t path_cnt = 0;
 	afi_t afi;
 	safi_t safi;
@@ -2086,7 +2086,7 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 	struct bgpevpn *vpn;
 	struct prefix_evpn p;
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	uint32_t path_cnt = 0;
 	afi_t afi;
 	safi_t safi;
@@ -2196,7 +2196,7 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 {
 	struct prefix_evpn p;
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	afi_t afi;
 	safi_t safi;
 	uint32_t path_cnt = 0;
@@ -2262,7 +2262,7 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 	struct bgp_node *rd_rn;
 	struct bgp_table *table;
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	int rd_header = 1;
 	afi_t afi;
 	safi_t safi;
@@ -2383,7 +2383,7 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 	struct bgp_node *rd_rn;
 	struct bgp_table *table;
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	int header = 1;
 	int rd_header;
 	afi_t afi;

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -536,7 +536,7 @@ static void show_esi_routes(struct bgp *bgp,
 {
 	int header = 1;
 	struct bgp_node *rn;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	uint32_t prefix_cnt, path_cnt;
 	uint64_t tbl_ver;
 
@@ -573,13 +573,13 @@ static void show_esi_routes(struct bgp *bgp,
 		/* For EVPN, the prefix is displayed for each path (to fit in
 		 * with code that already exists).
 		 */
-		for (ri = rn->info; ri; ri = ri->next) {
+		for (pi = rn->info; pi; pi = pi->next) {
 			json_object *json_path = NULL;
 
 			if (json)
 				json_path = json_object_new_array();
 
-			route_vty_out(vty, &rn->p, ri, 0, SAFI_EVPN, json_path);
+			route_vty_out(vty, &rn->p, pi, 0, SAFI_EVPN, json_path);
 
 			if (json)
 				json_object_array_add(json_paths, json_path);
@@ -616,7 +616,7 @@ static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn, int type,
 			    json_object *json)
 {
 	struct bgp_node *rn;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	struct bgp_table *table;
 	int header = 1;
 	uint64_t tbl_ver;
@@ -660,18 +660,18 @@ static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn, int type,
 		/* For EVPN, the prefix is displayed for each path (to fit in
 		 * with code that already exists).
 		 */
-		for (ri = rn->info; ri; ri = ri->next) {
+		for (pi = rn->info; pi; pi = pi->next) {
 			json_object *json_path = NULL;
 
 			if (vtep_ip.s_addr
 			    && !IPV4_ADDR_SAME(&(vtep_ip),
-					       &(ri->attr->nexthop)))
+					       &(pi->attr->nexthop)))
 				continue;
 
 			if (json)
 				json_path = json_object_new_array();
 
-			route_vty_out(vty, &rn->p, ri, 0, SAFI_EVPN, json_path);
+			route_vty_out(vty, &rn->p, pi, 0, SAFI_EVPN, json_path);
 
 			if (json)
 				json_object_array_add(json_paths, json_path);
@@ -990,7 +990,7 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 	struct bgp_table *table;
 	struct bgp_node *rn;
 	struct bgp_node *rm;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	int rd_header;
 	int header = 1;
 
@@ -1046,14 +1046,14 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 		tbl_ver = table->version;
 
 		for (rm = bgp_table_top(table); rm; rm = bgp_route_next(rm))
-			for (ri = rm->info; ri; ri = ri->next) {
+			for (pi = rm->info; pi; pi = pi->next) {
 				total_count++;
 				if (type == bgp_show_type_neighbor) {
 					union sockunion *su = output_arg;
 
-					if (ri->peer->su_remote == NULL
+					if (pi->peer->su_remote == NULL
 					    || !sockunion_same(
-						       ri->peer->su_remote, su))
+						       pi->peer->su_remote, su))
 						continue;
 				}
 				if (header == 0) {
@@ -1162,14 +1162,14 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 				else
 					json_array = NULL;
 				if (option == SHOW_DISPLAY_TAGS)
-					route_vty_out_tag(vty, &rm->p, ri, 0,
+					route_vty_out_tag(vty, &rm->p, pi, 0,
 							  SAFI_EVPN,
 							  json_array);
 				else if (option == SHOW_DISPLAY_OVERLAY)
-					route_vty_out_overlay(vty, &rm->p, ri,
+					route_vty_out_overlay(vty, &rm->p, pi,
 							      0, json_array);
 				else
-					route_vty_out(vty, &rm->p, ri, 0,
+					route_vty_out(vty, &rm->p, pi, 0,
 						      SAFI_EVPN, json_array);
 				output_count++;
 			}
@@ -2017,7 +2017,7 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 	struct bgpevpn *vpn;
 	struct prefix_evpn p;
 	struct bgp_node *rn;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	uint32_t path_cnt = 0;
 	afi_t afi;
 	safi_t safi;
@@ -2049,13 +2049,13 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 	route_vty_out_detail_header(vty, bgp, rn, NULL, afi, safi, json);
 
 	/* Display each path for this prefix. */
-	for (ri = rn->info; ri; ri = ri->next) {
+	for (pi = rn->info; pi; pi = pi->next) {
 		json_object *json_path = NULL;
 
 		if (json)
 			json_path = json_object_new_array();
 
-		route_vty_out_detail(vty, bgp, &rn->p, ri, afi, safi,
+		route_vty_out_detail(vty, bgp, &rn->p, pi, afi, safi,
 				     json_path);
 
 		if (json)
@@ -2086,7 +2086,7 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 	struct bgpevpn *vpn;
 	struct prefix_evpn p;
 	struct bgp_node *rn;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	uint32_t path_cnt = 0;
 	afi_t afi;
 	safi_t safi;
@@ -2119,13 +2119,13 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 	route_vty_out_detail_header(vty, bgp, rn, NULL, afi, safi, json);
 
 	/* Display each path for this prefix. */
-	for (ri = rn->info; ri; ri = ri->next) {
+	for (pi = rn->info; pi; pi = pi->next) {
 		json_object *json_path = NULL;
 
 		if (json)
 			json_path = json_object_new_array();
 
-		route_vty_out_detail(vty, bgp, &rn->p, ri, afi, safi,
+		route_vty_out_detail(vty, bgp, &rn->p, pi, afi, safi,
 				     json_path);
 
 		if (json)
@@ -2196,7 +2196,7 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 {
 	struct prefix_evpn p;
 	struct bgp_node *rn;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	afi_t afi;
 	safi_t safi;
 	uint32_t path_cnt = 0;
@@ -2226,13 +2226,13 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 		json_paths = json_object_new_array();
 
 	/* Display each path for this prefix. */
-	for (ri = rn->info; ri; ri = ri->next) {
+	for (pi = rn->info; pi; pi = pi->next) {
 		json_object *json_path = NULL;
 
 		if (json)
 			json_path = json_object_new_array();
 
-		route_vty_out_detail(vty, bgp, &rn->p, ri, afi, safi,
+		route_vty_out_detail(vty, bgp, &rn->p, pi, afi, safi,
 				     json_path);
 
 		if (json)
@@ -2262,7 +2262,7 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 	struct bgp_node *rd_rn;
 	struct bgp_table *table;
 	struct bgp_node *rn;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	int rd_header = 1;
 	afi_t afi;
 	safi_t safi;
@@ -2330,13 +2330,13 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 			json_paths = json_object_new_array();
 
 		/* Display each path for this prefix. */
-		for (ri = rn->info; ri; ri = ri->next) {
+		for (pi = rn->info; pi; pi = pi->next) {
 			json_object *json_path = NULL;
 
 			if (json)
 				json_path = json_object_new_array();
 
-			route_vty_out_detail(vty, bgp, &rn->p, ri, afi, safi,
+			route_vty_out_detail(vty, bgp, &rn->p, pi, afi, safi,
 					     json_path);
 
 			if (json)
@@ -2383,7 +2383,7 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 	struct bgp_node *rd_rn;
 	struct bgp_table *table;
 	struct bgp_node *rn;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	int header = 1;
 	int rd_header;
 	afi_t afi;
@@ -2467,7 +2467,7 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 			 * fit in
 			 * with code that already exists).
 			 */
-			for (ri = rn->info; ri; ri = ri->next) {
+			for (pi = rn->info; pi; pi = pi->next) {
 				json_object *json_path = NULL;
 				path_cnt++;
 				add_prefix_to_json = 1;
@@ -2476,7 +2476,7 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 				if (json)
 					json_path = json_object_new_array();
 
-				route_vty_out(vty, &rn->p, ri, 0, SAFI_EVPN,
+				route_vty_out(vty, &rn->p, pi, 0, SAFI_EVPN,
 					      json_path);
 
 				if (json)

--- a/bgpd/bgp_flowspec.h
+++ b/bgpd/bgp_flowspec.h
@@ -44,8 +44,8 @@ extern void bgp_fs_nlri_get_string(unsigned char *nlri_content, size_t len,
 				   json_object *json_path);
 
 extern void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
-				   struct bgp_info *binfo,
-				   int display, json_object *json_paths);
+				   struct bgp_path_info *binfo, int display,
+				   json_object *json_paths);
 extern int bgp_fs_config_write_pbr(struct vty *vty, struct bgp *bgp,
 				   afi_t afi, safi_t safi);
 

--- a/bgpd/bgp_flowspec.h
+++ b/bgpd/bgp_flowspec.h
@@ -44,7 +44,7 @@ extern void bgp_fs_nlri_get_string(unsigned char *nlri_content, size_t len,
 				   json_object *json_path);
 
 extern void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
-				   struct bgp_path_info *binfo, int display,
+				   struct bgp_path_info *path, int display,
 				   json_object *json_paths);
 extern int bgp_fs_config_write_pbr(struct vty *vty, struct bgp *bgp,
 				   afi_t afi, safi_t safi);

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -329,7 +329,8 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 			json_object_array_add(json_paths, json_time_path);
 	}
 	if (display == NLRI_STRING_FORMAT_LARGE) {
-		struct bgp_path_info_extra *extra = bgp_info_extra_get(binfo);
+		struct bgp_path_info_extra *extra =
+			bgp_path_info_extra_get(binfo);
 
 		if (extra->bgp_fs_pbr) {
 			struct listnode *node;

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -253,8 +253,8 @@ void bgp_fs_nlri_get_string(unsigned char *nlri_content, size_t len,
 }
 
 void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
-			    struct bgp_info *binfo,
-			    int display, json_object *json_paths)
+			    struct bgp_path_info *binfo, int display,
+			    json_object *json_paths)
 {
 	struct attr *attr;
 	char return_string[BGP_FLOWSPEC_STRING_DISPLAY_MAX];
@@ -329,7 +329,7 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 			json_object_array_add(json_paths, json_time_path);
 	}
 	if (display == NLRI_STRING_FORMAT_LARGE) {
-		struct bgp_info_extra *extra = bgp_info_extra_get(binfo);
+		struct bgp_path_info_extra *extra = bgp_info_extra_get(binfo);
 
 		if (extra->bgp_fs_pbr) {
 			struct listnode *node;
@@ -368,7 +368,7 @@ int bgp_show_table_flowspec(struct vty *vty, struct bgp *bgp, afi_t afi,
 			    void *output_arg, bool use_json, int is_last,
 			    unsigned long *output_cum, unsigned long *total_cum)
 {
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	struct bgp_node *rn;
 	unsigned long total_count = 0;
 	json_object *json_paths = NULL;

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -369,7 +369,7 @@ int bgp_show_table_flowspec(struct vty *vty, struct bgp *bgp, afi_t afi,
 			    void *output_arg, bool use_json, int is_last,
 			    unsigned long *output_cum, unsigned long *total_cum)
 {
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	struct bgp_node *rn;
 	unsigned long total_count = 0;
 	json_object *json_paths = NULL;
@@ -385,12 +385,10 @@ int bgp_show_table_flowspec(struct vty *vty, struct bgp *bgp, afi_t afi,
 			json_paths = json_object_new_array();
 			display = NLRI_STRING_FORMAT_JSON;
 		}
-		for (ri = rn->info; ri; ri = ri->next) {
+		for (pi = rn->info; pi; pi = pi->next) {
 			total_count++;
-			route_vty_out_flowspec(vty, &rn->p,
-					       ri, display,
+			route_vty_out_flowspec(vty, &rn->p, pi, display,
 					       json_paths);
-
 		}
 		if (use_json) {
 			vty_out(vty, "%s\n",

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -253,7 +253,7 @@ void bgp_fs_nlri_get_string(unsigned char *nlri_content, size_t len,
 }
 
 void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
-			    struct bgp_path_info *binfo, int display,
+			    struct bgp_path_info *path, int display,
 			    json_object *json_paths)
 {
 	struct attr *attr;
@@ -274,9 +274,9 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 			else
 				json_nlri_path = json_paths;
 		}
-		if (display == NLRI_STRING_FORMAT_LARGE && binfo)
+		if (display == NLRI_STRING_FORMAT_LARGE && path)
 			vty_out(vty, "BGP flowspec entry: (flags 0x%x)\n",
-				binfo->flags);
+				path->flags);
 		bgp_fs_nlri_get_string((unsigned char *)
 				       p->u.prefix_flowspec.ptr,
 				       p->u.prefix_flowspec.prefixlen,
@@ -292,11 +292,11 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 		else if (json_paths && display == NLRI_STRING_FORMAT_JSON)
 			json_object_array_add(json_paths, json_nlri_path);
 	}
-	if (!binfo)
+	if (!path)
 		return;
-	if (binfo->attr && binfo->attr->ecommunity) {
+	if (path->attr && path->attr->ecommunity) {
 		/* Print attribute */
-		attr = binfo->attr;
+		attr = path->attr;
 		s = ecommunity_ecom2str(attr->ecommunity,
 					ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 		if (!s)
@@ -318,7 +318,7 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 			vty_out(vty, "\tNH %-16s\n", inet_ntoa(attr->nexthop));
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
-	peer_uptime(binfo->uptime, timebuf, BGP_UPTIME_LEN, 0, NULL);
+	peer_uptime(path->uptime, timebuf, BGP_UPTIME_LEN, 0, NULL);
 	if (display == NLRI_STRING_FORMAT_LARGE) {
 		vty_out(vty, "\treceived for %8s\n", timebuf);
 	} else if (json_paths) {
@@ -330,7 +330,7 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 	}
 	if (display == NLRI_STRING_FORMAT_LARGE) {
 		struct bgp_path_info_extra *extra =
-			bgp_path_info_extra_get(binfo);
+			bgp_path_info_extra_get(path);
 
 		if (extra->bgp_fs_pbr) {
 			struct listnode *node;

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -94,7 +94,7 @@ int bgp_parse_fec_update(void)
 	return 1;
 }
 
-mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_info *ri,
+mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_path_info *ri,
 			   struct peer *to, afi_t afi, safi_t safi)
 {
 	struct peer *from;
@@ -120,7 +120,8 @@ mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_info *ri,
 	return rn->local_label;
 }
 
-void bgp_reg_dereg_for_label(struct bgp_node *rn, struct bgp_info *ri, int reg)
+void bgp_reg_dereg_for_label(struct bgp_node *rn, struct bgp_path_info *ri,
+			     int reg)
 {
 	struct stream *s;
 	struct prefix *p;

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -94,18 +94,18 @@ int bgp_parse_fec_update(void)
 	return 1;
 }
 
-mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_path_info *ri,
+mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_path_info *pi,
 			   struct peer *to, afi_t afi, safi_t safi)
 {
 	struct peer *from;
 	mpls_label_t remote_label;
 	int reflect;
 
-	if (!rn || !ri || !to)
+	if (!rn || !pi || !to)
 		return MPLS_INVALID_LABEL;
 
-	remote_label = ri->extra ? ri->extra->label[0] : MPLS_INVALID_LABEL;
-	from = ri->peer;
+	remote_label = pi->extra ? pi->extra->label[0] : MPLS_INVALID_LABEL;
+	from = pi->peer;
 	reflect =
 		((from->sort == BGP_PEER_IBGP) && (to->sort == BGP_PEER_IBGP));
 
@@ -120,7 +120,7 @@ mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_path_info *ri,
 	return rn->local_label;
 }
 
-void bgp_reg_dereg_for_label(struct bgp_node *rn, struct bgp_path_info *ri,
+void bgp_reg_dereg_for_label(struct bgp_node *rn, struct bgp_path_info *pi,
 			     int reg)
 {
 	struct stream *s;
@@ -143,11 +143,11 @@ void bgp_reg_dereg_for_label(struct bgp_node *rn, struct bgp_path_info *ri,
 	stream_putw(s, PREFIX_FAMILY(p));
 	stream_put_prefix(s, p);
 	if (reg) {
-		assert(ri);
-		if (ri->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_PREFIX_SID)) {
-			if (ri->attr->label_index != BGP_INVALID_LABEL_INDEX) {
+		assert(pi);
+		if (pi->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_PREFIX_SID)) {
+			if (pi->attr->label_index != BGP_INVALID_LABEL_INDEX) {
 				flags |= ZEBRA_FEC_REGISTER_LABEL_INDEX;
-				stream_putl(s, ri->attr->label_index);
+				stream_putl(s, pi->attr->label_index);
 			}
 		}
 		SET_FLAG(rn->flags, BGP_NODE_REGISTERED_FOR_LABEL);

--- a/bgpd/bgp_label.h
+++ b/bgpd/bgp_label.h
@@ -27,13 +27,13 @@
 #define BGP_PREVENT_VRF_2_VRF_LEAK 0xFFFFFFFE
 
 struct bgp_node;
-struct bgp_info;
+struct bgp_path_info;
 struct peer;
 
-extern void bgp_reg_dereg_for_label(struct bgp_node *rn, struct bgp_info *ri,
-				    int reg);
+extern void bgp_reg_dereg_for_label(struct bgp_node *rn,
+				    struct bgp_path_info *ri, int reg);
 extern int bgp_parse_fec_update(void);
-extern mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_info *ri,
+extern mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_path_info *ri,
 				  struct peer *to, afi_t afi, safi_t safi);
 
 extern int bgp_nlri_parse_label(struct peer *peer, struct attr *attr,
@@ -85,7 +85,7 @@ static inline void bgp_unset_valid_label(mpls_label_t *label)
 }
 
 static inline void bgp_register_for_label(struct bgp_node *rn,
-					  struct bgp_info *ri)
+					  struct bgp_path_info *ri)
 {
 	bgp_reg_dereg_for_label(rn, ri, 1);
 }

--- a/bgpd/bgp_label.h
+++ b/bgpd/bgp_label.h
@@ -31,9 +31,9 @@ struct bgp_path_info;
 struct peer;
 
 extern void bgp_reg_dereg_for_label(struct bgp_node *rn,
-				    struct bgp_path_info *ri, int reg);
+				    struct bgp_path_info *pi, int reg);
 extern int bgp_parse_fec_update(void);
-extern mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_path_info *ri,
+extern mpls_label_t bgp_adv_label(struct bgp_node *rn, struct bgp_path_info *pi,
 				  struct peer *to, afi_t afi, safi_t safi);
 
 extern int bgp_nlri_parse_label(struct peer *peer, struct attr *attr,
@@ -85,9 +85,9 @@ static inline void bgp_unset_valid_label(mpls_label_t *label)
 }
 
 static inline void bgp_register_for_label(struct bgp_node *rn,
-					  struct bgp_path_info *ri)
+					  struct bgp_path_info *pi)
 {
-	bgp_reg_dereg_for_label(rn, ri, 1);
+	bgp_reg_dereg_for_label(rn, pi, 1);
 }
 
 static inline void bgp_unregister_for_label(struct bgp_node *rn)

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -113,13 +113,14 @@ static int bgp_interface_same(struct interface *ifp1, struct interface *ifp2)
 
 
 /*
- * bgp_info_nexthop_cmp
+ * bgp_path_info_nexthop_cmp
  *
  * Compare the nexthops of two paths. Return value is less than, equal to,
  * or greater than zero if bi1 is respectively less than, equal to,
  * or greater than bi2.
  */
-int bgp_info_nexthop_cmp(struct bgp_path_info *bi1, struct bgp_path_info *bi2)
+int bgp_path_info_nexthop_cmp(struct bgp_path_info *bi1,
+			      struct bgp_path_info *bi2)
 {
 	int compare;
 	struct in6_addr addr1, addr2;
@@ -182,7 +183,7 @@ int bgp_info_nexthop_cmp(struct bgp_path_info *bi1, struct bgp_path_info *bi2)
 }
 
 /*
- * bgp_info_mpath_cmp
+ * bgp_path_info_mpath_cmp
  *
  * This function determines our multipath list ordering. By ordering
  * the list we can deterministically select which paths are included
@@ -193,7 +194,7 @@ int bgp_info_nexthop_cmp(struct bgp_path_info *bi1, struct bgp_path_info *bi2)
  * The order of paths is determined first by received nexthop, and then
  * by peer address if the nexthops are the same.
  */
-static int bgp_info_mpath_cmp(void *val1, void *val2)
+static int bgp_path_info_mpath_cmp(void *val1, void *val2)
 {
 	struct bgp_path_info *bi1, *bi2;
 	int compare;
@@ -201,7 +202,7 @@ static int bgp_info_mpath_cmp(void *val1, void *val2)
 	bi1 = val1;
 	bi2 = val2;
 
-	compare = bgp_info_nexthop_cmp(bi1, bi2);
+	compare = bgp_path_info_nexthop_cmp(bi1, bi2);
 
 	if (!compare) {
 		if (!bi1->peer->su_remote && !bi2->peer->su_remote)
@@ -228,7 +229,7 @@ void bgp_mp_list_init(struct list *mp_list)
 {
 	assert(mp_list);
 	memset(mp_list, 0, sizeof(struct list));
-	mp_list->cmp = bgp_info_mpath_cmp;
+	mp_list->cmp = bgp_path_info_mpath_cmp;
 }
 
 /*
@@ -254,11 +255,11 @@ void bgp_mp_list_add(struct list *mp_list, struct bgp_path_info *mpinfo)
 }
 
 /*
- * bgp_info_mpath_new
+ * bgp_path_info_mpath_new
  *
- * Allocate and zero memory for a new bgp_info_mpath element
+ * Allocate and zero memory for a new bgp_path_info_mpath element
  */
-static struct bgp_path_info_mpath *bgp_info_mpath_new(void)
+static struct bgp_path_info_mpath *bgp_path_info_mpath_new(void)
 {
 	struct bgp_path_info_mpath *new_mpath;
 	new_mpath = XCALLOC(MTYPE_BGP_MPATH_INFO,
@@ -267,11 +268,11 @@ static struct bgp_path_info_mpath *bgp_info_mpath_new(void)
 }
 
 /*
- * bgp_info_mpath_free
+ * bgp_path_info_mpath_free
  *
- * Release resources for a bgp_info_mpath element and zero out pointer
+ * Release resources for a bgp_path_info_mpath element and zero out pointer
  */
-void bgp_info_mpath_free(struct bgp_path_info_mpath **mpath)
+void bgp_path_info_mpath_free(struct bgp_path_info_mpath **mpath)
 {
 	if (mpath && *mpath) {
 		if ((*mpath)->mp_attr)
@@ -282,17 +283,17 @@ void bgp_info_mpath_free(struct bgp_path_info_mpath **mpath)
 }
 
 /*
- * bgp_info_mpath_get
+ * bgp_path_info_mpath_get
  *
- * Fetch the mpath element for the given bgp_info. Used for
+ * Fetch the mpath element for the given bgp_path_info. Used for
  * doing lazy allocation.
  */
 static struct bgp_path_info_mpath *
-bgp_info_mpath_get(struct bgp_path_info *binfo)
+bgp_path_info_mpath_get(struct bgp_path_info *binfo)
 {
 	struct bgp_path_info_mpath *mpath;
 	if (!binfo->mpath) {
-		mpath = bgp_info_mpath_new();
+		mpath = bgp_path_info_mpath_new();
 		if (!mpath)
 			return NULL;
 		binfo->mpath = mpath;
@@ -302,18 +303,18 @@ bgp_info_mpath_get(struct bgp_path_info *binfo)
 }
 
 /*
- * bgp_info_mpath_enqueue
+ * bgp_path_info_mpath_enqueue
  *
  * Enqueue a path onto the multipath list given the previous multipath
  * list entry
  */
-static void bgp_info_mpath_enqueue(struct bgp_path_info *prev_info,
-				   struct bgp_path_info *binfo)
+static void bgp_path_info_mpath_enqueue(struct bgp_path_info *prev_info,
+					struct bgp_path_info *binfo)
 {
 	struct bgp_path_info_mpath *prev, *mpath;
 
-	prev = bgp_info_mpath_get(prev_info);
-	mpath = bgp_info_mpath_get(binfo);
+	prev = bgp_path_info_mpath_get(prev_info);
+	mpath = bgp_path_info_mpath_get(binfo);
 	if (!prev || !mpath)
 		return;
 
@@ -327,11 +328,11 @@ static void bgp_info_mpath_enqueue(struct bgp_path_info *prev_info,
 }
 
 /*
- * bgp_info_mpath_dequeue
+ * bgp_path_info_mpath_dequeue
  *
  * Remove a path from the multipath list
  */
-void bgp_info_mpath_dequeue(struct bgp_path_info *binfo)
+void bgp_path_info_mpath_dequeue(struct bgp_path_info *binfo)
 {
 	struct bgp_path_info_mpath *mpath = binfo->mpath;
 	if (!mpath)
@@ -345,11 +346,11 @@ void bgp_info_mpath_dequeue(struct bgp_path_info *binfo)
 }
 
 /*
- * bgp_info_mpath_next
+ * bgp_path_info_mpath_next
  *
- * Given a bgp_info, return the next multipath entry
+ * Given a bgp_path_info, return the next multipath entry
  */
-struct bgp_path_info *bgp_info_mpath_next(struct bgp_path_info *binfo)
+struct bgp_path_info *bgp_path_info_mpath_next(struct bgp_path_info *binfo)
 {
 	if (!binfo->mpath || !binfo->mpath->mp_next)
 		return NULL;
@@ -357,21 +358,21 @@ struct bgp_path_info *bgp_info_mpath_next(struct bgp_path_info *binfo)
 }
 
 /*
- * bgp_info_mpath_first
+ * bgp_path_info_mpath_first
  *
- * Given bestpath bgp_info, return the first multipath entry.
+ * Given bestpath bgp_path_info, return the first multipath entry.
  */
-struct bgp_path_info *bgp_info_mpath_first(struct bgp_path_info *binfo)
+struct bgp_path_info *bgp_path_info_mpath_first(struct bgp_path_info *binfo)
 {
-	return bgp_info_mpath_next(binfo);
+	return bgp_path_info_mpath_next(binfo);
 }
 
 /*
- * bgp_info_mpath_count
+ * bgp_path_info_mpath_count
  *
- * Given the bestpath bgp_info, return the number of multipath entries
+ * Given the bestpath bgp_path_info, return the number of multipath entries
  */
-uint32_t bgp_info_mpath_count(struct bgp_path_info *binfo)
+uint32_t bgp_path_info_mpath_count(struct bgp_path_info *binfo)
 {
 	if (!binfo->mpath)
 		return 0;
@@ -379,29 +380,29 @@ uint32_t bgp_info_mpath_count(struct bgp_path_info *binfo)
 }
 
 /*
- * bgp_info_mpath_count_set
+ * bgp_path_info_mpath_count_set
  *
  * Sets the count of multipaths into bestpath's mpath element
  */
-static void bgp_info_mpath_count_set(struct bgp_path_info *binfo,
-				     uint32_t count)
+static void bgp_path_info_mpath_count_set(struct bgp_path_info *binfo,
+					  uint32_t count)
 {
 	struct bgp_path_info_mpath *mpath;
 	if (!count && !binfo->mpath)
 		return;
-	mpath = bgp_info_mpath_get(binfo);
+	mpath = bgp_path_info_mpath_get(binfo);
 	if (!mpath)
 		return;
 	mpath->mp_count = count;
 }
 
 /*
- * bgp_info_mpath_attr
+ * bgp_path_info_mpath_attr
  *
- * Given bestpath bgp_info, return aggregated attribute set used
+ * Given bestpath bgp_path_info, return aggregated attribute set used
  * for advertising the multipath route
  */
-struct attr *bgp_info_mpath_attr(struct bgp_path_info *binfo)
+struct attr *bgp_path_info_mpath_attr(struct bgp_path_info *binfo)
 {
 	if (!binfo->mpath)
 		return NULL;
@@ -409,31 +410,33 @@ struct attr *bgp_info_mpath_attr(struct bgp_path_info *binfo)
 }
 
 /*
- * bgp_info_mpath_attr_set
+ * bgp_path_info_mpath_attr_set
  *
  * Sets the aggregated attribute into bestpath's mpath element
  */
-static void bgp_info_mpath_attr_set(struct bgp_path_info *binfo,
-				    struct attr *attr)
+static void bgp_path_info_mpath_attr_set(struct bgp_path_info *binfo,
+					 struct attr *attr)
 {
 	struct bgp_path_info_mpath *mpath;
 	if (!attr && !binfo->mpath)
 		return;
-	mpath = bgp_info_mpath_get(binfo);
+	mpath = bgp_path_info_mpath_get(binfo);
 	if (!mpath)
 		return;
 	mpath->mp_attr = attr;
 }
 
 /*
- * bgp_info_mpath_update
+ * bgp_path_info_mpath_update
  *
  * Compare and sync up the multipath list with the mp_list generated by
  * bgp_best_selection
  */
-void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_path_info *new_best,
-			   struct bgp_path_info *old_best, struct list *mp_list,
-			   struct bgp_maxpaths_cfg *mpath_cfg)
+void bgp_path_info_mpath_update(struct bgp_node *rn,
+				struct bgp_path_info *new_best,
+				struct bgp_path_info *old_best,
+				struct list *mp_list,
+				struct bgp_maxpaths_cfg *mpath_cfg)
 {
 	uint16_t maxpaths, mpath_count, old_mpath_count;
 	struct listnode *mp_node, *mp_next_node;
@@ -457,17 +460,17 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_path_info *new_best,
 	if (new_best) {
 		mpath_count++;
 		if (new_best != old_best)
-			bgp_info_mpath_dequeue(new_best);
+			bgp_path_info_mpath_dequeue(new_best);
 		maxpaths = (new_best->peer->sort == BGP_PEER_IBGP)
 				   ? mpath_cfg->maxpaths_ibgp
 				   : mpath_cfg->maxpaths_ebgp;
 	}
 
 	if (old_best) {
-		cur_mpath = bgp_info_mpath_first(old_best);
-		old_mpath_count = bgp_info_mpath_count(old_best);
-		bgp_info_mpath_count_set(old_best, 0);
-		bgp_info_mpath_dequeue(old_best);
+		cur_mpath = bgp_path_info_mpath_first(old_best);
+		old_mpath_count = bgp_path_info_mpath_count(old_best);
+		bgp_path_info_mpath_count_set(old_best, 0);
+		bgp_path_info_mpath_dequeue(old_best);
 	}
 
 	if (debug)
@@ -499,7 +502,8 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_path_info *new_best,
 			break;
 
 		mp_next_node = mp_node ? listnextnode(mp_node) : NULL;
-		next_mpath = cur_mpath ? bgp_info_mpath_next(cur_mpath) : NULL;
+		next_mpath =
+			cur_mpath ? bgp_path_info_mpath_next(cur_mpath) : NULL;
 		tmp_info = mp_node ? listgetdata(mp_node) : NULL;
 
 		if (debug)
@@ -515,14 +519,16 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_path_info *new_best,
 		 */
 		if (mp_node && (listgetdata(mp_node) == cur_mpath)) {
 			list_delete_node(mp_list, mp_node);
-			bgp_info_mpath_dequeue(cur_mpath);
+			bgp_path_info_mpath_dequeue(cur_mpath);
 			if ((mpath_count < maxpaths)
-			    && bgp_info_nexthop_cmp(prev_mpath, cur_mpath)) {
-				bgp_info_mpath_enqueue(prev_mpath, cur_mpath);
+			    && bgp_path_info_nexthop_cmp(prev_mpath,
+							 cur_mpath)) {
+				bgp_path_info_mpath_enqueue(prev_mpath,
+							    cur_mpath);
 				prev_mpath = cur_mpath;
 				mpath_count++;
 				if (debug) {
-					bgp_info_path_with_addpath_rx_str(
+					bgp_path_info_path_with_addpath_rx_str(
 						cur_mpath, path_buf);
 					zlog_debug(
 						"%s: %s is still multipath, cur count %d",
@@ -531,7 +537,7 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_path_info *new_best,
 			} else {
 				mpath_changed = 1;
 				if (debug) {
-					bgp_info_path_with_addpath_rx_str(
+					bgp_path_info_path_with_addpath_rx_str(
 						cur_mpath, path_buf);
 					zlog_debug(
 						"%s: remove mpath %s nexthop %s, cur count %d",
@@ -551,7 +557,8 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_path_info *new_best,
 
 		if (cur_mpath
 		    && (!mp_node
-			|| (bgp_info_mpath_cmp(cur_mpath, listgetdata(mp_node))
+			|| (bgp_path_info_mpath_cmp(cur_mpath,
+						    listgetdata(mp_node))
 			    < 0))) {
 			/*
 			 * If here, we have an old multipath and either the
@@ -560,11 +567,11 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_path_info *new_best,
 			 * multipath, so we need to purge this path from the
 			 * multipath list
 			 */
-			bgp_info_mpath_dequeue(cur_mpath);
+			bgp_path_info_mpath_dequeue(cur_mpath);
 			mpath_changed = 1;
 			if (debug) {
-				bgp_info_path_with_addpath_rx_str(cur_mpath,
-								  path_buf);
+				bgp_path_info_path_with_addpath_rx_str(
+					cur_mpath, path_buf);
 				zlog_debug(
 					"%s: remove mpath %s nexthop %s, cur count %d",
 					pfx_buf, path_buf,
@@ -598,17 +605,19 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_path_info *new_best,
 			assert(new_mpath);
 			assert(prev_mpath);
 			if ((mpath_count < maxpaths) && (new_mpath != new_best)
-			    && bgp_info_nexthop_cmp(prev_mpath, new_mpath)) {
+			    && bgp_path_info_nexthop_cmp(prev_mpath,
+							 new_mpath)) {
 				if (new_mpath == next_mpath)
-					bgp_info_mpath_next(new_mpath);
-				bgp_info_mpath_dequeue(new_mpath);
+					bgp_path_info_mpath_next(new_mpath);
+				bgp_path_info_mpath_dequeue(new_mpath);
 
-				bgp_info_mpath_enqueue(prev_mpath, new_mpath);
+				bgp_path_info_mpath_enqueue(prev_mpath,
+							    new_mpath);
 				prev_mpath = new_mpath;
 				mpath_changed = 1;
 				mpath_count++;
 				if (debug) {
-					bgp_info_path_with_addpath_rx_str(
+					bgp_path_info_path_with_addpath_rx_str(
 						new_mpath, path_buf);
 					zlog_debug(
 						"%s: add mpath %s nexthop %s, cur count %d",
@@ -632,9 +641,9 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_path_info *new_best,
 				pfx_buf, mpath_count,
 				mpath_changed ? "YES" : "NO");
 
-		bgp_info_mpath_count_set(new_best, mpath_count - 1);
+		bgp_path_info_mpath_count_set(new_best, mpath_count - 1);
 		if (mpath_changed
-		    || (bgp_info_mpath_count(new_best) != old_mpath_count))
+		    || (bgp_path_info_mpath_count(new_best) != old_mpath_count))
 			SET_FLAG(new_best->flags, BGP_PATH_MULTIPATH_CHG);
 	}
 }
@@ -652,19 +661,19 @@ void bgp_mp_dmed_deselect(struct bgp_path_info *dmed_best)
 	if (!dmed_best)
 		return;
 
-	for (mpinfo = bgp_info_mpath_first(dmed_best); mpinfo;
+	for (mpinfo = bgp_path_info_mpath_first(dmed_best); mpinfo;
 	     mpinfo = mpnext) {
-		mpnext = bgp_info_mpath_next(mpinfo);
-		bgp_info_mpath_dequeue(mpinfo);
+		mpnext = bgp_path_info_mpath_next(mpinfo);
+		bgp_path_info_mpath_dequeue(mpinfo);
 	}
 
-	bgp_info_mpath_count_set(dmed_best, 0);
+	bgp_path_info_mpath_count_set(dmed_best, 0);
 	UNSET_FLAG(dmed_best->flags, BGP_PATH_MULTIPATH_CHG);
-	assert(bgp_info_mpath_first(dmed_best) == 0);
+	assert(bgp_path_info_mpath_first(dmed_best) == 0);
 }
 
 /*
- * bgp_info_mpath_aggregate_update
+ * bgp_path_info_mpath_aggregate_update
  *
  * Set the multipath aggregate attribute. We need to see if the
  * aggregate has changed and then set the ATTR_CHANGED flag on the
@@ -675,8 +684,8 @@ void bgp_mp_dmed_deselect(struct bgp_path_info *dmed_best)
  * is no change in multipath selection and no attribute change in
  * any multipath.
  */
-void bgp_info_mpath_aggregate_update(struct bgp_path_info *new_best,
-				     struct bgp_path_info *old_best)
+void bgp_path_info_mpath_aggregate_update(struct bgp_path_info *new_best,
+					  struct bgp_path_info *old_best)
 {
 	struct bgp_path_info *mpinfo;
 	struct aspath *aspath;
@@ -689,18 +698,18 @@ void bgp_info_mpath_aggregate_update(struct bgp_path_info *new_best,
 	struct attr attr = {0};
 
 	if (old_best && (old_best != new_best)
-	    && (old_attr = bgp_info_mpath_attr(old_best))) {
+	    && (old_attr = bgp_path_info_mpath_attr(old_best))) {
 		bgp_attr_unintern(&old_attr);
-		bgp_info_mpath_attr_set(old_best, NULL);
+		bgp_path_info_mpath_attr_set(old_best, NULL);
 	}
 
 	if (!new_best)
 		return;
 
-	if (!bgp_info_mpath_count(new_best)) {
-		if ((new_attr = bgp_info_mpath_attr(new_best))) {
+	if (!bgp_path_info_mpath_count(new_best)) {
+		if ((new_attr = bgp_path_info_mpath_attr(new_best))) {
 			bgp_attr_unintern(&new_attr);
-			bgp_info_mpath_attr_set(new_best, NULL);
+			bgp_path_info_mpath_attr_set(new_best, NULL);
 			SET_FLAG(new_best->flags, BGP_PATH_ATTR_CHANGED);
 		}
 		return;
@@ -721,8 +730,8 @@ void bgp_info_mpath_aggregate_update(struct bgp_path_info *new_best,
 		lcomm = (attr.lcommunity) ? lcommunity_dup(attr.lcommunity)
 					  : NULL;
 
-		for (mpinfo = bgp_info_mpath_first(new_best); mpinfo;
-		     mpinfo = bgp_info_mpath_next(mpinfo)) {
+		for (mpinfo = bgp_path_info_mpath_first(new_best); mpinfo;
+		     mpinfo = bgp_path_info_mpath_next(mpinfo)) {
 			asmerge =
 				aspath_aggregate(aspath, mpinfo->attr->aspath);
 			aspath_free(aspath);
@@ -792,10 +801,10 @@ void bgp_info_mpath_aggregate_update(struct bgp_path_info *new_best,
 
 	new_attr = bgp_attr_intern(&attr);
 
-	if (new_attr != bgp_info_mpath_attr(new_best)) {
-		if ((old_attr = bgp_info_mpath_attr(new_best)))
+	if (new_attr != bgp_path_info_mpath_attr(new_best)) {
+		if ((old_attr = bgp_path_info_mpath_attr(new_best)))
 			bgp_attr_unintern(&old_attr);
-		bgp_info_mpath_attr_set(new_best, new_attr);
+		bgp_path_info_mpath_attr_set(new_best, new_attr);
 		SET_FLAG(new_best->flags, BGP_PATH_ATTR_CHANGED);
 	} else
 		bgp_attr_unintern(&new_attr);

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -116,43 +116,44 @@ static int bgp_interface_same(struct interface *ifp1, struct interface *ifp2)
  * bgp_path_info_nexthop_cmp
  *
  * Compare the nexthops of two paths. Return value is less than, equal to,
- * or greater than zero if bi1 is respectively less than, equal to,
- * or greater than bi2.
+ * or greater than zero if bpi1 is respectively less than, equal to,
+ * or greater than bpi2.
  */
-int bgp_path_info_nexthop_cmp(struct bgp_path_info *bi1,
-			      struct bgp_path_info *bi2)
+int bgp_path_info_nexthop_cmp(struct bgp_path_info *bpi1,
+			      struct bgp_path_info *bpi2)
 {
 	int compare;
 	struct in6_addr addr1, addr2;
 
-	compare = IPV4_ADDR_CMP(&bi1->attr->nexthop, &bi2->attr->nexthop);
+	compare = IPV4_ADDR_CMP(&bpi1->attr->nexthop, &bpi2->attr->nexthop);
 	if (!compare) {
-		if (bi1->attr->mp_nexthop_len == bi2->attr->mp_nexthop_len) {
-			switch (bi1->attr->mp_nexthop_len) {
+		if (bpi1->attr->mp_nexthop_len == bpi2->attr->mp_nexthop_len) {
+			switch (bpi1->attr->mp_nexthop_len) {
 			case BGP_ATTR_NHLEN_IPV4:
 			case BGP_ATTR_NHLEN_VPNV4:
 				compare = IPV4_ADDR_CMP(
-					&bi1->attr->mp_nexthop_global_in,
-					&bi2->attr->mp_nexthop_global_in);
+					&bpi1->attr->mp_nexthop_global_in,
+					&bpi2->attr->mp_nexthop_global_in);
 				break;
 			case BGP_ATTR_NHLEN_IPV6_GLOBAL:
 			case BGP_ATTR_NHLEN_VPNV6_GLOBAL:
 				compare = IPV6_ADDR_CMP(
-					&bi1->attr->mp_nexthop_global,
-					&bi2->attr->mp_nexthop_global);
+					&bpi1->attr->mp_nexthop_global,
+					&bpi2->attr->mp_nexthop_global);
 				break;
 			case BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL:
-				addr1 = (bi1->attr->mp_nexthop_prefer_global)
-						? bi1->attr->mp_nexthop_global
-						: bi1->attr->mp_nexthop_local;
-				addr2 = (bi2->attr->mp_nexthop_prefer_global)
-						? bi2->attr->mp_nexthop_global
-						: bi2->attr->mp_nexthop_local;
+				addr1 = (bpi1->attr->mp_nexthop_prefer_global)
+						? bpi1->attr->mp_nexthop_global
+						: bpi1->attr->mp_nexthop_local;
+				addr2 = (bpi2->attr->mp_nexthop_prefer_global)
+						? bpi2->attr->mp_nexthop_global
+						: bpi2->attr->mp_nexthop_local;
 
-				if (!bi1->attr->mp_nexthop_prefer_global
-				    && !bi2->attr->mp_nexthop_prefer_global)
+				if (!bpi1->attr->mp_nexthop_prefer_global
+				    && !bpi2->attr->mp_nexthop_prefer_global)
 					compare = !bgp_interface_same(
-						bi1->peer->ifp, bi2->peer->ifp);
+						bpi1->peer->ifp,
+						bpi2->peer->ifp);
 
 				if (!compare)
 					compare = IPV6_ADDR_CMP(&addr1, &addr2);
@@ -164,14 +165,15 @@ int bgp_path_info_nexthop_cmp(struct bgp_path_info *bi1,
 		 * link-local
 		 * nexthops but another IPv6 peer only sends you global
 		 */
-		else if (bi1->attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV6_GLOBAL
-			 || bi1->attr->mp_nexthop_len
+		else if (bpi1->attr->mp_nexthop_len
+				 == BGP_ATTR_NHLEN_IPV6_GLOBAL
+			 || bpi1->attr->mp_nexthop_len
 				    == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL) {
-			compare = IPV6_ADDR_CMP(&bi1->attr->mp_nexthop_global,
-						&bi2->attr->mp_nexthop_global);
+			compare = IPV6_ADDR_CMP(&bpi1->attr->mp_nexthop_global,
+						&bpi2->attr->mp_nexthop_global);
 			if (!compare) {
-				if (bi1->attr->mp_nexthop_len
-				    < bi2->attr->mp_nexthop_len)
+				if (bpi1->attr->mp_nexthop_len
+				    < bpi2->attr->mp_nexthop_len)
 					compare = -1;
 				else
 					compare = 1;
@@ -196,24 +198,24 @@ int bgp_path_info_nexthop_cmp(struct bgp_path_info *bi1,
  */
 static int bgp_path_info_mpath_cmp(void *val1, void *val2)
 {
-	struct bgp_path_info *bi1, *bi2;
+	struct bgp_path_info *bpi1, *bpi2;
 	int compare;
 
-	bi1 = val1;
-	bi2 = val2;
+	bpi1 = val1;
+	bpi2 = val2;
 
-	compare = bgp_path_info_nexthop_cmp(bi1, bi2);
+	compare = bgp_path_info_nexthop_cmp(bpi1, bpi2);
 
 	if (!compare) {
-		if (!bi1->peer->su_remote && !bi2->peer->su_remote)
+		if (!bpi1->peer->su_remote && !bpi2->peer->su_remote)
 			compare = 0;
-		else if (!bi1->peer->su_remote)
+		else if (!bpi1->peer->su_remote)
 			compare = 1;
-		else if (!bi2->peer->su_remote)
+		else if (!bpi2->peer->su_remote)
 			compare = -1;
 		else
-			compare = sockunion_cmp(bi1->peer->su_remote,
-						bi2->peer->su_remote);
+			compare = sockunion_cmp(bpi1->peer->su_remote,
+						bpi2->peer->su_remote);
 	}
 
 	return compare;

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -322,7 +322,7 @@ static void bgp_info_mpath_enqueue(struct bgp_info *prev_info,
 		prev->mp_next->mp_prev = mpath;
 	prev->mp_next = mpath;
 
-	SET_FLAG(binfo->flags, BGP_INFO_MULTIPATH);
+	SET_FLAG(binfo->flags, BGP_PATH_MULTIPATH);
 }
 
 /*
@@ -340,7 +340,7 @@ void bgp_info_mpath_dequeue(struct bgp_info *binfo)
 	if (mpath->mp_next)
 		mpath->mp_next->mp_prev = mpath->mp_prev;
 	mpath->mp_next = mpath->mp_prev = NULL;
-	UNSET_FLAG(binfo->flags, BGP_INFO_MULTIPATH);
+	UNSET_FLAG(binfo->flags, BGP_PATH_MULTIPATH);
 }
 
 /*
@@ -632,14 +632,14 @@ void bgp_info_mpath_update(struct bgp_node *rn, struct bgp_info *new_best,
 		bgp_info_mpath_count_set(new_best, mpath_count - 1);
 		if (mpath_changed
 		    || (bgp_info_mpath_count(new_best) != old_mpath_count))
-			SET_FLAG(new_best->flags, BGP_INFO_MULTIPATH_CHG);
+			SET_FLAG(new_best->flags, BGP_PATH_MULTIPATH_CHG);
 	}
 }
 
 /*
  * bgp_mp_dmed_deselect
  *
- * Clean up multipath information for BGP_INFO_DMED_SELECTED path that
+ * Clean up multipath information for BGP_PATH_DMED_SELECTED path that
  * is not selected as best path
  */
 void bgp_mp_dmed_deselect(struct bgp_info *dmed_best)
@@ -656,7 +656,7 @@ void bgp_mp_dmed_deselect(struct bgp_info *dmed_best)
 	}
 
 	bgp_info_mpath_count_set(dmed_best, 0);
-	UNSET_FLAG(dmed_best->flags, BGP_INFO_MULTIPATH_CHG);
+	UNSET_FLAG(dmed_best->flags, BGP_PATH_MULTIPATH_CHG);
 	assert(bgp_info_mpath_first(dmed_best) == 0);
 }
 
@@ -698,7 +698,7 @@ void bgp_info_mpath_aggregate_update(struct bgp_info *new_best,
 		if ((new_attr = bgp_info_mpath_attr(new_best))) {
 			bgp_attr_unintern(&new_attr);
 			bgp_info_mpath_attr_set(new_best, NULL);
-			SET_FLAG(new_best->flags, BGP_INFO_ATTR_CHANGED);
+			SET_FLAG(new_best->flags, BGP_PATH_ATTR_CHANGED);
 		}
 		return;
 	}
@@ -793,7 +793,7 @@ void bgp_info_mpath_aggregate_update(struct bgp_info *new_best,
 		if ((old_attr = bgp_info_mpath_attr(new_best)))
 			bgp_attr_unintern(&old_attr);
 		bgp_info_mpath_attr_set(new_best, new_attr);
-		SET_FLAG(new_best->flags, BGP_INFO_ATTR_CHANGED);
+		SET_FLAG(new_best->flags, BGP_PATH_ATTR_CHANGED);
 	} else
 		bgp_attr_unintern(&new_attr);
 }

--- a/bgpd/bgp_mpath.h
+++ b/bgpd/bgp_mpath.h
@@ -22,7 +22,7 @@
 #ifndef _QUAGGA_BGP_MPATH_H
 #define _QUAGGA_BGP_MPATH_H
 
-/* Supplemental information linked to bgp_info for keeping track of
+/* Supplemental information linked to bgp_path_info for keeping track of
  * multipath selections, lazily allocated to save memory
  */
 struct bgp_path_info_mpath {
@@ -32,7 +32,7 @@ struct bgp_path_info_mpath {
 	/* Points to the previous multipath or NULL on bestpath */
 	struct bgp_path_info_mpath *mp_prev;
 
-	/* Points to bgp_info associated with this multipath info */
+	/* Points to bgp_path_info associated with this multipath info */
 	struct bgp_path_info *mp_info;
 
 	/* When attached to best path, the number of selected multipaths */
@@ -50,30 +50,33 @@ extern int bgp_maximum_paths_unset(struct bgp *, afi_t, safi_t, int);
 /* Functions used by bgp_best_selection to record current
  * multipath selections
  */
-extern int bgp_info_nexthop_cmp(struct bgp_path_info *bi1,
-				struct bgp_path_info *bi2);
+extern int bgp_path_info_nexthop_cmp(struct bgp_path_info *bi1,
+				     struct bgp_path_info *bi2);
 extern void bgp_mp_list_init(struct list *);
 extern void bgp_mp_list_clear(struct list *);
 extern void bgp_mp_list_add(struct list *mp_list, struct bgp_path_info *mpinfo);
 extern void bgp_mp_dmed_deselect(struct bgp_path_info *dmed_best);
-extern void bgp_info_mpath_update(struct bgp_node *rn,
-				  struct bgp_path_info *new_best,
-				  struct bgp_path_info *old_best,
-				  struct list *mp_list,
-				  struct bgp_maxpaths_cfg *mpath_cfg);
-extern void bgp_info_mpath_aggregate_update(struct bgp_path_info *new_best,
-					    struct bgp_path_info *old_best);
+extern void bgp_path_info_mpath_update(struct bgp_node *rn,
+				       struct bgp_path_info *new_best,
+				       struct bgp_path_info *old_best,
+				       struct list *mp_list,
+				       struct bgp_maxpaths_cfg *mpath_cfg);
+extern void
+bgp_path_info_mpath_aggregate_update(struct bgp_path_info *new_best,
+				     struct bgp_path_info *old_best);
 
-/* Unlink and free multipath information associated with a bgp_info */
-extern void bgp_info_mpath_dequeue(struct bgp_path_info *path);
-extern void bgp_info_mpath_free(struct bgp_path_info_mpath **mpath);
+/* Unlink and free multipath information associated with a bgp_path_info */
+extern void bgp_path_info_mpath_dequeue(struct bgp_path_info *path);
+extern void bgp_path_info_mpath_free(struct bgp_path_info_mpath **mpath);
 
 /* Walk list of multipaths associated with a best path */
-extern struct bgp_path_info *bgp_info_mpath_first(struct bgp_path_info *);
-extern struct bgp_path_info *bgp_info_mpath_next(struct bgp_path_info *);
+extern struct bgp_path_info *
+bgp_path_info_mpath_first(struct bgp_path_info *path);
+extern struct bgp_path_info *
+bgp_path_info_mpath_next(struct bgp_path_info *path);
 
 /* Accessors for multipath information */
-extern uint32_t bgp_info_mpath_count(struct bgp_path_info *path);
-extern struct attr *bgp_info_mpath_attr(struct bgp_path_info *path);
+extern uint32_t bgp_path_info_mpath_count(struct bgp_path_info *path);
+extern struct attr *bgp_path_info_mpath_attr(struct bgp_path_info *path);
 
 #endif /* _QUAGGA_BGP_MPATH_H */

--- a/bgpd/bgp_mpath.h
+++ b/bgpd/bgp_mpath.h
@@ -50,8 +50,8 @@ extern int bgp_maximum_paths_unset(struct bgp *, afi_t, safi_t, int);
 /* Functions used by bgp_best_selection to record current
  * multipath selections
  */
-extern int bgp_path_info_nexthop_cmp(struct bgp_path_info *bi1,
-				     struct bgp_path_info *bi2);
+extern int bgp_path_info_nexthop_cmp(struct bgp_path_info *bpi1,
+				     struct bgp_path_info *bpi2);
 extern void bgp_mp_list_init(struct list *);
 extern void bgp_mp_list_clear(struct list *);
 extern void bgp_mp_list_add(struct list *mp_list, struct bgp_path_info *mpinfo);

--- a/bgpd/bgp_mpath.h
+++ b/bgpd/bgp_mpath.h
@@ -25,15 +25,15 @@
 /* Supplemental information linked to bgp_info for keeping track of
  * multipath selections, lazily allocated to save memory
  */
-struct bgp_info_mpath {
+struct bgp_path_info_mpath {
 	/* Points to the first multipath (on bestpath) or the next multipath */
-	struct bgp_info_mpath *mp_next;
+	struct bgp_path_info_mpath *mp_next;
 
 	/* Points to the previous multipath or NULL on bestpath */
-	struct bgp_info_mpath *mp_prev;
+	struct bgp_path_info_mpath *mp_prev;
 
 	/* Points to bgp_info associated with this multipath info */
-	struct bgp_info *mp_info;
+	struct bgp_path_info *mp_info;
 
 	/* When attached to best path, the number of selected multipaths */
 	uint32_t mp_count;
@@ -50,27 +50,30 @@ extern int bgp_maximum_paths_unset(struct bgp *, afi_t, safi_t, int);
 /* Functions used by bgp_best_selection to record current
  * multipath selections
  */
-extern int bgp_info_nexthop_cmp(struct bgp_info *bi1, struct bgp_info *bi2);
+extern int bgp_info_nexthop_cmp(struct bgp_path_info *bi1,
+				struct bgp_path_info *bi2);
 extern void bgp_mp_list_init(struct list *);
 extern void bgp_mp_list_clear(struct list *);
-extern void bgp_mp_list_add(struct list *, struct bgp_info *);
-extern void bgp_mp_dmed_deselect(struct bgp_info *);
-extern void bgp_info_mpath_update(struct bgp_node *, struct bgp_info *,
-				  struct bgp_info *, struct list *,
-				  struct bgp_maxpaths_cfg *);
-extern void bgp_info_mpath_aggregate_update(struct bgp_info *,
-					    struct bgp_info *);
+extern void bgp_mp_list_add(struct list *mp_list, struct bgp_path_info *mpinfo);
+extern void bgp_mp_dmed_deselect(struct bgp_path_info *dmed_best);
+extern void bgp_info_mpath_update(struct bgp_node *rn,
+				  struct bgp_path_info *new_best,
+				  struct bgp_path_info *old_best,
+				  struct list *mp_list,
+				  struct bgp_maxpaths_cfg *mpath_cfg);
+extern void bgp_info_mpath_aggregate_update(struct bgp_path_info *new_best,
+					    struct bgp_path_info *old_best);
 
 /* Unlink and free multipath information associated with a bgp_info */
-extern void bgp_info_mpath_dequeue(struct bgp_info *);
-extern void bgp_info_mpath_free(struct bgp_info_mpath **);
+extern void bgp_info_mpath_dequeue(struct bgp_path_info *path);
+extern void bgp_info_mpath_free(struct bgp_path_info_mpath **mpath);
 
 /* Walk list of multipaths associated with a best path */
-extern struct bgp_info *bgp_info_mpath_first(struct bgp_info *);
-extern struct bgp_info *bgp_info_mpath_next(struct bgp_info *);
+extern struct bgp_path_info *bgp_info_mpath_first(struct bgp_path_info *);
+extern struct bgp_path_info *bgp_info_mpath_next(struct bgp_path_info *);
 
 /* Accessors for multipath information */
-extern uint32_t bgp_info_mpath_count(struct bgp_info *);
-extern struct attr *bgp_info_mpath_attr(struct bgp_info *);
+extern uint32_t bgp_info_mpath_count(struct bgp_path_info *path);
+extern struct attr *bgp_info_mpath_attr(struct bgp_path_info *path);
 
 #endif /* _QUAGGA_BGP_MPATH_H */

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -516,9 +516,8 @@ leak_update(
 	if (bi) {
 		bool labelssame = labels_same(bi, label, num_labels);
 
-		if (attrhash_cmp(bi->attr, new_attr)
-		    && labelssame
-		    && !CHECK_FLAG(bi->flags, BGP_INFO_REMOVED)) {
+		if (attrhash_cmp(bi->attr, new_attr) && labelssame
+		    && !CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
 
 			bgp_attr_unintern(&new_attr);
 			if (debug)
@@ -530,10 +529,10 @@ leak_update(
 		}
 
 		/* attr is changed */
-		bgp_info_set_flag(bn, bi, BGP_INFO_ATTR_CHANGED);
+		bgp_info_set_flag(bn, bi, BGP_PATH_ATTR_CHANGED);
 
 		/* Rewrite BGP route information. */
-		if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+		if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 			bgp_info_restore(bn, bi);
 		else
 			bgp_aggregate_decrement(bgp, p, bi, afi, safi);
@@ -548,7 +547,7 @@ leak_update(
 			setlabels(bi, label, num_labels);
 
 		if (nexthop_self_flag)
-			bgp_info_set_flag(bn, bi, BGP_INFO_ANNC_NH_SELF);
+			bgp_info_set_flag(bn, bi, BGP_PATH_ANNC_NH_SELF);
 
 		struct bgp *bgp_nexthop = bgp;
 		int nh_valid;
@@ -574,7 +573,7 @@ leak_update(
 				bgp_nexthop->name_pretty);
 
 		if (nh_valid)
-			bgp_info_set_flag(bn, bi, BGP_INFO_VALID);
+			bgp_info_set_flag(bn, bi, BGP_PATH_VALID);
 
 		/* Process change. */
 		bgp_aggregate_increment(bgp, p, bi, afi, safi);
@@ -592,7 +591,7 @@ leak_update(
 		bgp->peer_self, new_attr, bn);
 
 	if (nexthop_self_flag)
-		bgp_info_set_flag(bn, new, BGP_INFO_ANNC_NH_SELF);
+		bgp_info_set_flag(bn, new, BGP_PATH_ANNC_NH_SELF);
 
 	bgp_info_extra_get(new);
 
@@ -635,7 +634,7 @@ leak_update(
 			__func__, (nh_valid ? "" : "not "),
 			bgp_nexthop->name_pretty);
 	if (nh_valid)
-		bgp_info_set_flag(bn, new, BGP_INFO_VALID);
+		bgp_info_set_flag(bn, new, BGP_PATH_VALID);
 
 	bgp_aggregate_increment(bgp, p, new, afi, safi);
 	bgp_info_add(bn, new);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -441,7 +441,7 @@ static void setlabels(struct bgp_path_info *bi,
 		return;
 	}
 
-	struct bgp_path_info_extra *extra = bgp_info_extra_get(bi);
+	struct bgp_path_info_extra *extra = bgp_path_info_extra_get(bi);
 	uint32_t i;
 
 	for (i = 0; i < num_labels; ++i) {
@@ -454,7 +454,7 @@ static void setlabels(struct bgp_path_info *bi,
 }
 
 /*
- * returns pointer to new bgp_info upon success
+ * returns pointer to new bgp_path_info upon success
  */
 static struct bgp_path_info *
 leak_update(struct bgp *bgp, /* destination bgp instance */
@@ -521,11 +521,11 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 		}
 
 		/* attr is changed */
-		bgp_info_set_flag(bn, bi, BGP_PATH_ATTR_CHANGED);
+		bgp_path_info_set_flag(bn, bi, BGP_PATH_ATTR_CHANGED);
 
 		/* Rewrite BGP route information. */
 		if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
-			bgp_info_restore(bn, bi);
+			bgp_path_info_restore(bn, bi);
 		else
 			bgp_aggregate_decrement(bgp, p, bi, afi, safi);
 		bgp_attr_unintern(&bi->attr);
@@ -539,7 +539,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 			setlabels(bi, label, num_labels);
 
 		if (nexthop_self_flag)
-			bgp_info_set_flag(bn, bi, BGP_PATH_ANNC_NH_SELF);
+			bgp_path_info_set_flag(bn, bi, BGP_PATH_ANNC_NH_SELF);
 
 		struct bgp *bgp_nexthop = bgp;
 		int nh_valid;
@@ -565,7 +565,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 				bgp_nexthop->name_pretty);
 
 		if (nh_valid)
-			bgp_info_set_flag(bn, bi, BGP_PATH_VALID);
+			bgp_path_info_set_flag(bn, bi, BGP_PATH_VALID);
 
 		/* Process change. */
 		bgp_aggregate_increment(bgp, p, bi, afi, safi);
@@ -583,14 +583,14 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 		bgp->peer_self, new_attr, bn);
 
 	if (nexthop_self_flag)
-		bgp_info_set_flag(bn, new, BGP_PATH_ANNC_NH_SELF);
+		bgp_path_info_set_flag(bn, new, BGP_PATH_ANNC_NH_SELF);
 
-	bgp_info_extra_get(new);
+	bgp_path_info_extra_get(new);
 
 	if (num_labels)
 		setlabels(new, label, num_labels);
 
-	new->extra->parent = bgp_info_lock(parent);
+	new->extra->parent = bgp_path_info_lock(parent);
 	bgp_lock_node((struct bgp_node *)((struct bgp_path_info *)parent)->net);
 	if (bgp_orig)
 		new->extra->bgp_orig = bgp_lock(bgp_orig);
@@ -626,10 +626,10 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 			__func__, (nh_valid ? "" : "not "),
 			bgp_nexthop->name_pretty);
 	if (nh_valid)
-		bgp_info_set_flag(bn, new, BGP_PATH_VALID);
+		bgp_path_info_set_flag(bn, new, BGP_PATH_VALID);
 
 	bgp_aggregate_increment(bgp, p, new, afi, safi);
-	bgp_info_add(bn, new);
+	bgp_path_info_add(bn, new);
 
 	bgp_unlock_node(bn);
 	bgp_process(bgp, bn, afi, safi);
@@ -935,7 +935,7 @@ void vpn_leak_from_vrf_withdraw(struct bgp *bgp_vpn,		/* to */
 		vpn_leak_to_vrf_withdraw(bgp_vpn, bi);
 
 		bgp_aggregate_decrement(bgp_vpn, p, bi, afi, safi);
-		bgp_info_delete(bn, bi);
+		bgp_path_info_delete(bn, bi);
 		bgp_process(bgp_vpn, bn, afi, safi);
 	}
 	bgp_unlock_node(bn);
@@ -992,7 +992,7 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn, /* to */
 							   __func__);
 					bgp_aggregate_decrement(bgp_vpn, &bn->p,
 								bi, afi, safi);
-					bgp_info_delete(bn, bi);
+					bgp_path_info_delete(bn, bi);
 					bgp_process(bgp_vpn, bn, afi, safi);
 				}
 			}
@@ -1312,7 +1312,7 @@ void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,	    /* from */
 			if (debug)
 				zlog_debug("%s: deleting bi %p", __func__, bi);
 			bgp_aggregate_decrement(bgp, p, bi, afi, safi);
-			bgp_info_delete(bn, bi);
+			bgp_path_info_delete(bn, bi);
 			bgp_process(bgp, bn, afi, safi);
 		}
 		bgp_unlock_node(bn);
@@ -1341,7 +1341,7 @@ void vpn_leak_to_vrf_withdraw_all(struct bgp *bgp_vrf, /* to */
 				/* delete route */
 				bgp_aggregate_decrement(bgp_vrf, &bn->p, bi,
 							afi, safi);
-				bgp_info_delete(bn, bi);
+				bgp_path_info_delete(bn, bi);
 				bgp_process(bgp_vrf, bn, afi, safi);
 			}
 		}

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -402,23 +402,23 @@ static int ecom_intersect(struct ecommunity *e1, struct ecommunity *e2)
 	return 0;
 }
 
-static bool labels_same(struct bgp_path_info *bi, mpls_label_t *label,
+static bool labels_same(struct bgp_path_info *bpi, mpls_label_t *label,
 			uint32_t n)
 {
 	uint32_t i;
 
-	if (!bi->extra) {
+	if (!bpi->extra) {
 		if (!n)
 			return true;
 		else
 			return false;
 	}
 
-	if (n != bi->extra->num_labels)
+	if (n != bpi->extra->num_labels)
 		return false;
 
 	for (i = 0; i < n; ++i) {
-		if (label[i] != bi->extra->label[i])
+		if (label[i] != bpi->extra->label[i])
 			return false;
 	}
 	return true;
@@ -427,7 +427,7 @@ static bool labels_same(struct bgp_path_info *bi, mpls_label_t *label,
 /*
  * make encoded route labels match specified encoded label set
  */
-static void setlabels(struct bgp_path_info *bi,
+static void setlabels(struct bgp_path_info *bpi,
 		      mpls_label_t *label, /* array of labels */
 		      uint32_t num_labels)
 {
@@ -436,12 +436,12 @@ static void setlabels(struct bgp_path_info *bi,
 	assert(num_labels <= BGP_MAX_LABELS);
 
 	if (!num_labels) {
-		if (bi->extra)
-			bi->extra->num_labels = 0;
+		if (bpi->extra)
+			bpi->extra->num_labels = 0;
 		return;
 	}
 
-	struct bgp_path_info_extra *extra = bgp_path_info_extra_get(bi);
+	struct bgp_path_info_extra *extra = bgp_path_info_extra_get(bpi);
 	uint32_t i;
 
 	for (i = 0; i < num_labels; ++i) {
@@ -459,22 +459,22 @@ static void setlabels(struct bgp_path_info *bi,
 static struct bgp_path_info *
 leak_update(struct bgp *bgp, /* destination bgp instance */
 	    struct bgp_node *bn, struct attr *new_attr, /* already interned */
-	    afi_t afi, safi_t safi, struct bgp_path_info *source_bi,
+	    afi_t afi, safi_t safi, struct bgp_path_info *source_bpi,
 	    mpls_label_t *label, uint32_t num_labels, void *parent,
 	    struct bgp *bgp_orig, struct prefix *nexthop_orig,
 	    int nexthop_self_flag, int debug)
 {
 	struct prefix *p = &bn->p;
-	struct bgp_path_info *bi;
-	struct bgp_path_info *bi_ultimate;
+	struct bgp_path_info *bpi;
+	struct bgp_path_info *bpi_ultimate;
 	struct bgp_path_info *new;
 	char buf_prefix[PREFIX_STRLEN];
 
 	if (debug) {
 		prefix2str(&bn->p, buf_prefix, sizeof(buf_prefix));
 		zlog_debug("%s: entry: leak-to=%s, p=%s, type=%d, sub_type=%d",
-			__func__, bgp->name_pretty, buf_prefix,
-			source_bi->type, source_bi->sub_type);
+			   __func__, bgp->name_pretty, buf_prefix,
+			   source_bpi->type, source_bpi->sub_type);
 	}
 
 	/*
@@ -486,30 +486,30 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	 * should have nexthop tracking, we must find the ultimate
 	 * parent so we can check its sub_type.
 	 *
-	 * As of now, source_bi may at most be a second-generation route
+	 * As of now, source_bpi may at most be a second-generation route
 	 * (only one hop back to ultimate parent for vrf-vpn-vrf scheme).
 	 * Using a loop here supports more complex intra-bgp import-export
 	 * schemes that could be implemented in the future.
 	 *
 	 */
-	for (bi_ultimate = source_bi;
-		bi_ultimate->extra && bi_ultimate->extra->parent;
-		bi_ultimate = bi_ultimate->extra->parent)
-			;
+	for (bpi_ultimate = source_bpi;
+	     bpi_ultimate->extra && bpi_ultimate->extra->parent;
+	     bpi_ultimate = bpi_ultimate->extra->parent)
+		;
 
 	/*
 	 * match parent
 	 */
-	for (bi = bn->info; bi; bi = bi->next) {
-		if (bi->extra && bi->extra->parent == parent)
+	for (bpi = bn->info; bpi; bpi = bpi->next) {
+		if (bpi->extra && bpi->extra->parent == parent)
 			break;
 	}
 
-	if (bi) {
-		bool labelssame = labels_same(bi, label, num_labels);
+	if (bpi) {
+		bool labelssame = labels_same(bpi, label, num_labels);
 
-		if (attrhash_cmp(bi->attr, new_attr) && labelssame
-		    && !CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
+		if (attrhash_cmp(bpi->attr, new_attr) && labelssame
+		    && !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
 
 			bgp_attr_unintern(&new_attr);
 			if (debug)
@@ -521,43 +521,42 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 		}
 
 		/* attr is changed */
-		bgp_path_info_set_flag(bn, bi, BGP_PATH_ATTR_CHANGED);
+		bgp_path_info_set_flag(bn, bpi, BGP_PATH_ATTR_CHANGED);
 
 		/* Rewrite BGP route information. */
-		if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
-			bgp_path_info_restore(bn, bi);
+		if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED))
+			bgp_path_info_restore(bn, bpi);
 		else
-			bgp_aggregate_decrement(bgp, p, bi, afi, safi);
-		bgp_attr_unintern(&bi->attr);
-		bi->attr = new_attr;
-		bi->uptime = bgp_clock();
+			bgp_aggregate_decrement(bgp, p, bpi, afi, safi);
+		bgp_attr_unintern(&bpi->attr);
+		bpi->attr = new_attr;
+		bpi->uptime = bgp_clock();
 
 		/*
 		 * rewrite labels
 		 */
 		if (!labelssame)
-			setlabels(bi, label, num_labels);
+			setlabels(bpi, label, num_labels);
 
 		if (nexthop_self_flag)
-			bgp_path_info_set_flag(bn, bi, BGP_PATH_ANNC_NH_SELF);
+			bgp_path_info_set_flag(bn, bpi, BGP_PATH_ANNC_NH_SELF);
 
 		struct bgp *bgp_nexthop = bgp;
 		int nh_valid;
 
-		if (bi->extra && bi->extra->bgp_orig)
-			bgp_nexthop = bi->extra->bgp_orig;
+		if (bpi->extra && bpi->extra->bgp_orig)
+			bgp_nexthop = bpi->extra->bgp_orig;
 
 		/* No nexthop tracking for redistributed routes */
-		if (bi_ultimate->sub_type == BGP_ROUTE_REDISTRIBUTE)
+		if (bpi_ultimate->sub_type == BGP_ROUTE_REDISTRIBUTE)
 			nh_valid = 1;
 		else
 			/*
 			 * TBD do we need to do anything about the
 			 * 'connected' parameter?
 			 */
-			nh_valid = bgp_find_or_add_nexthop(
-						bgp, bgp_nexthop,
-						afi, bi, NULL, 0);
+			nh_valid = bgp_find_or_add_nexthop(bgp, bgp_nexthop,
+							   afi, bpi, NULL, 0);
 
 		if (debug)
 			zlog_debug("%s: nexthop is %svalid (in vrf %s)",
@@ -565,10 +564,10 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 				bgp_nexthop->name_pretty);
 
 		if (nh_valid)
-			bgp_path_info_set_flag(bn, bi, BGP_PATH_VALID);
+			bgp_path_info_set_flag(bn, bpi, BGP_PATH_VALID);
 
 		/* Process change. */
-		bgp_aggregate_increment(bgp, p, bi, afi, safi);
+		bgp_aggregate_increment(bgp, p, bpi, afi, safi);
 		bgp_process(bgp, bn, afi, safi);
 		bgp_unlock_node(bn);
 
@@ -576,7 +575,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 			zlog_debug("%s: ->%s: %s Found route, changed attr",
 				   __func__, bgp->name_pretty, buf_prefix);
 
-		return bi;
+		return bpi;
 	}
 
 	new = info_make(ZEBRA_ROUTE_BGP, BGP_ROUTE_IMPORTED, 0,
@@ -611,7 +610,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	 * their originating protocols will do the tracking and
 	 * withdraw those routes if the nexthops become unreachable
 	 */
-	if (bi_ultimate->sub_type == BGP_ROUTE_REDISTRIBUTE)
+	if (bpi_ultimate->sub_type == BGP_ROUTE_REDISTRIBUTE)
 		nh_valid = 1;
 	else
 		/*
@@ -644,10 +643,10 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 /* cf vnc_import_bgp_add_route_mode_nvegroup() and add_vnc_route() */
 void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 			      struct bgp *bgp_vrf,	    /* from */
-			      struct bgp_path_info *info_vrf) /* route */
+			      struct bgp_path_info *path_vrf) /* route */
 {
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF);
-	struct prefix *p = &info_vrf->net->p;
+	struct prefix *p = &path_vrf->net->p;
 	afi_t afi = family2afi(p->family);
 	struct attr static_attr = {0};
 	struct attr *new_attr = NULL;
@@ -661,12 +660,12 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 	if (debug)
 		zlog_debug("%s: from vrf %s", __func__, bgp_vrf->name_pretty);
 
-	if (debug && info_vrf->attr->ecommunity) {
-		char *s = ecommunity_ecom2str(info_vrf->attr->ecommunity,
+	if (debug && path_vrf->attr->ecommunity) {
+		char *s = ecommunity_ecom2str(path_vrf->attr->ecommunity,
 					      ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 
-		zlog_debug("%s: %s info_vrf->type=%d, EC{%s}", __func__,
-			   bgp_vrf->name, info_vrf->type, s);
+		zlog_debug("%s: %s path_vrf->type=%d, EC{%s}", __func__,
+			   bgp_vrf->name, path_vrf->type, s);
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
 
@@ -680,7 +679,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 	}
 
 	/* loop check - should not be an imported route. */
-	if (info_vrf->extra && info_vrf->extra->bgp_orig)
+	if (path_vrf->extra && path_vrf->extra->bgp_orig)
 		return;
 
 
@@ -691,7 +690,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 		return;
 	}
 
-	bgp_attr_dup(&static_attr, info_vrf->attr); /* shallow copy */
+	bgp_attr_dup(&static_attr, path_vrf->attr); /* shallow copy */
 
 	/*
 	 * route map handling
@@ -809,8 +808,8 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 			 * IPv4 nexthops as the attr has been copied
 			 * otherwise.
 			 */
-			if (afi == AFI_IP &&
-			    !BGP_ATTR_NEXTHOP_AFI_IP6(info_vrf->attr)) {
+			if (afi == AFI_IP
+			    && !BGP_ATTR_NEXTHOP_AFI_IP6(path_vrf->attr)) {
 				static_attr.mp_nexthop_global_in.s_addr =
 					static_attr.nexthop.s_addr;
 				static_attr.mp_nexthop_len = 4;
@@ -852,8 +851,8 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 
 	struct bgp_path_info *new_info;
 
-	new_info = leak_update(bgp_vpn, bn, new_attr, afi, safi, info_vrf,
-			       &label, 1, info_vrf, bgp_vrf, NULL,
+	new_info = leak_update(bgp_vpn, bn, new_attr, afi, safi, path_vrf,
+			       &label, 1, path_vrf, bgp_vrf, NULL,
 			       nexthop_self_flag, debug);
 
 	/*
@@ -871,13 +870,13 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 
 void vpn_leak_from_vrf_withdraw(struct bgp *bgp_vpn,		/* to */
 				struct bgp *bgp_vrf,		/* from */
-				struct bgp_path_info *info_vrf) /* route */
+				struct bgp_path_info *path_vrf) /* route */
 {
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF);
-	struct prefix *p = &info_vrf->net->p;
+	struct prefix *p = &path_vrf->net->p;
 	afi_t afi = family2afi(p->family);
 	safi_t safi = SAFI_MPLS_VPN;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct bgp_node *bn;
 	const char *debugmsg;
 	char buf_prefix[PREFIX_STRLEN];
@@ -887,16 +886,16 @@ void vpn_leak_from_vrf_withdraw(struct bgp *bgp_vpn,		/* to */
 		zlog_debug(
 			"%s: entry: leak-from=%s, p=%s, type=%d, sub_type=%d",
 			__func__, bgp_vrf->name_pretty, buf_prefix,
-			info_vrf->type, info_vrf->sub_type);
+			path_vrf->type, path_vrf->sub_type);
 	}
 
-	if (info_vrf->sub_type != BGP_ROUTE_NORMAL
-	    && info_vrf->sub_type != BGP_ROUTE_STATIC
-	    && info_vrf->sub_type != BGP_ROUTE_REDISTRIBUTE) {
+	if (path_vrf->sub_type != BGP_ROUTE_NORMAL
+	    && path_vrf->sub_type != BGP_ROUTE_STATIC
+	    && path_vrf->sub_type != BGP_ROUTE_REDISTRIBUTE) {
 
 		if (debug)
 			zlog_debug("%s: wrong sub_type %d", __func__,
-				   info_vrf->sub_type);
+				   path_vrf->sub_type);
 		return;
 	}
 	if (!bgp_vpn)
@@ -915,27 +914,27 @@ void vpn_leak_from_vrf_withdraw(struct bgp *bgp_vpn,		/* to */
 	}
 
 	if (debug)
-		zlog_debug("%s: withdrawing (info_vrf=%p)", __func__, info_vrf);
+		zlog_debug("%s: withdrawing (path_vrf=%p)", __func__, path_vrf);
 
 	bn = bgp_afi_node_get(bgp_vpn->rib[afi][safi], afi, safi, p,
 			      &(bgp_vrf->vpn_policy[afi].tovpn_rd));
 
 	/*
 	 * vrf -> vpn
-	 * match original bi imported from
+	 * match original bpi imported from
 	 */
-	for (bi = (bn ? bn->info : NULL); bi; bi = bi->next) {
-		if (bi->extra && bi->extra->parent == info_vrf) {
+	for (bpi = (bn ? bn->info : NULL); bpi; bpi = bpi->next) {
+		if (bpi->extra && bpi->extra->parent == path_vrf) {
 			break;
 		}
 	}
 
-	if (bi) {
+	if (bpi) {
 		/* withdraw from looped vrfs as well */
-		vpn_leak_to_vrf_withdraw(bgp_vpn, bi);
+		vpn_leak_to_vrf_withdraw(bgp_vpn, bpi);
 
-		bgp_aggregate_decrement(bgp_vpn, p, bi, afi, safi);
-		bgp_path_info_delete(bn, bi);
+		bgp_aggregate_decrement(bgp_vpn, p, bpi, afi, safi);
+		bgp_path_info_delete(bn, bpi);
 		bgp_process(bgp_vpn, bn, afi, safi);
 	}
 	bgp_unlock_node(bn);
@@ -950,14 +949,14 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn, /* to */
 	safi_t safi = SAFI_MPLS_VPN;
 
 	/*
-	 * Walk vpn table, delete bi with bgp_orig == bgp_vrf
+	 * Walk vpn table, delete bpi with bgp_orig == bgp_vrf
 	 */
 	for (prn = bgp_table_top(bgp_vpn->rib[afi][safi]); prn;
 	     prn = bgp_route_next(prn)) {
 
 		struct bgp_table *table;
 		struct bgp_node *bn;
-		struct bgp_path_info *bi;
+		struct bgp_path_info *bpi;
 
 		/* This is the per-RD table of prefixes */
 		table = prn->info;
@@ -975,24 +974,24 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn, /* to */
 					prefix2str(&bn->p, buf, sizeof(buf)));
 			}
 
-			for (bi = bn->info; bi; bi = bi->next) {
+			for (bpi = bn->info; bpi; bpi = bpi->next) {
 				if (debug)
 					zlog_debug("%s: type %d, sub_type %d",
-						   __func__, bi->type,
-						   bi->sub_type);
-				if (bi->sub_type != BGP_ROUTE_IMPORTED)
+						   __func__, bpi->type,
+						   bpi->sub_type);
+				if (bpi->sub_type != BGP_ROUTE_IMPORTED)
 					continue;
-				if (!bi->extra)
+				if (!bpi->extra)
 					continue;
-				if ((struct bgp *)bi->extra->bgp_orig
+				if ((struct bgp *)bpi->extra->bgp_orig
 				    == bgp_vrf) {
 					/* delete route */
 					if (debug)
 						zlog_debug("%s: deleting it\n",
 							   __func__);
 					bgp_aggregate_decrement(bgp_vpn, &bn->p,
-								bi, afi, safi);
-					bgp_path_info_delete(bn, bi);
+								bpi, afi, safi);
+					bgp_path_info_delete(bn, bpi);
 					bgp_process(bgp_vpn, bn, afi, safi);
 				}
 			}
@@ -1005,7 +1004,7 @@ void vpn_leak_from_vrf_update_all(struct bgp *bgp_vpn, /* to */
 				  afi_t afi)
 {
 	struct bgp_node *bn;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF);
 
 	if (debug)
@@ -1018,12 +1017,12 @@ void vpn_leak_from_vrf_update_all(struct bgp *bgp_vpn, /* to */
 		if (debug)
 			zlog_debug("%s: node=%p", __func__, bn);
 
-		for (bi = bn->info; bi; bi = bi->next) {
+		for (bpi = bn->info; bpi; bpi = bpi->next) {
 			if (debug)
 				zlog_debug(
 					"%s: calling vpn_leak_from_vrf_update",
 					__func__);
-			vpn_leak_from_vrf_update(bgp_vpn, bgp_vrf, bi);
+			vpn_leak_from_vrf_update(bgp_vpn, bgp_vrf, bpi);
 		}
 	}
 }
@@ -1031,9 +1030,9 @@ void vpn_leak_from_vrf_update_all(struct bgp *bgp_vpn, /* to */
 static void
 vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 			      struct bgp *bgp_vpn,	    /* from */
-			      struct bgp_path_info *info_vpn) /* route */
+			      struct bgp_path_info *path_vpn) /* route */
 {
-	struct prefix *p = &info_vpn->net->p;
+	struct prefix *p = &path_vpn->net->p;
 	afi_t afi = family2afi(p->family);
 
 	struct attr static_attr = {0};
@@ -1045,7 +1044,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 	mpls_label_t *pLabels = NULL;
 	uint32_t num_labels = 0;
 	int nexthop_self_flag = 1;
-	struct bgp_path_info *bi_ultimate = NULL;
+	struct bgp_path_info *bpi_ultimate = NULL;
 	int origin_local = 0;
 	struct bgp *src_vrf;
 
@@ -1060,7 +1059,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 	/* Check for intersection of route targets */
 	if (!ecom_intersect(
 		    bgp_vrf->vpn_policy[afi].rtlist[BGP_VPN_POLICY_DIR_FROMVPN],
-		    info_vpn->attr->ecommunity)) {
+		    path_vpn->attr->ecommunity)) {
 
 		return;
 	}
@@ -1069,7 +1068,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 		zlog_debug("%s: updating to vrf %s", __func__,
 				bgp_vrf->name_pretty);
 
-	bgp_attr_dup(&static_attr, info_vpn->attr); /* shallow copy */
+	bgp_attr_dup(&static_attr, path_vpn->attr); /* shallow copy */
 
 	/*
 	 * Nexthop: stash and clear
@@ -1078,7 +1077,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 	 * Stash it for later label resolution by vrf ingress path and then
 	 * overwrite with 0, i.e., "me", for the sake of vrf advertisement.
 	 */
-	uint8_t nhfamily = NEXTHOP_FAMILY(info_vpn->attr->mp_nexthop_len);
+	uint8_t nhfamily = NEXTHOP_FAMILY(path_vpn->attr->mp_nexthop_len);
 
 	memset(&nexthop_orig, 0, sizeof(nexthop_orig));
 	nexthop_orig.family = nhfamily;
@@ -1086,7 +1085,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 	switch (nhfamily) {
 	case AF_INET:
 		/* save */
-		nexthop_orig.u.prefix4 = info_vpn->attr->mp_nexthop_global_in;
+		nexthop_orig.u.prefix4 = path_vpn->attr->mp_nexthop_global_in;
 		nexthop_orig.prefixlen = 32;
 
 		if (CHECK_FLAG(bgp_vrf->af_flags[afi][safi],
@@ -1095,15 +1094,15 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 				nexthop_orig.u.prefix4.s_addr;
 
 			static_attr.mp_nexthop_global_in =
-				info_vpn->attr->mp_nexthop_global_in;
+				path_vpn->attr->mp_nexthop_global_in;
 			static_attr.mp_nexthop_len =
-				info_vpn->attr->mp_nexthop_len;
+				path_vpn->attr->mp_nexthop_len;
 		}
 		static_attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
 		break;
 	case AF_INET6:
 		/* save */
-		nexthop_orig.u.prefix6 = info_vpn->attr->mp_nexthop_global;
+		nexthop_orig.u.prefix6 = path_vpn->attr->mp_nexthop_global;
 		nexthop_orig.prefixlen = 128;
 
 		if (CHECK_FLAG(bgp_vrf->af_flags[afi][safi],
@@ -1165,30 +1164,30 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 	if (!CHECK_FLAG(bgp_vrf->af_flags[afi][safi],
 			BGP_CONFIG_VRF_TO_VRF_IMPORT)) {
 		/* work back to original route */
-		for (bi_ultimate = info_vpn;
-		     bi_ultimate->extra && bi_ultimate->extra->parent;
-		     bi_ultimate = bi_ultimate->extra->parent)
+		for (bpi_ultimate = path_vpn;
+		     bpi_ultimate->extra && bpi_ultimate->extra->parent;
+		     bpi_ultimate = bpi_ultimate->extra->parent)
 			;
 
 		/*
 		 * if original route was unicast,
 		 * then it did not arrive over vpn
 		 */
-		if (bi_ultimate->net) {
+		if (bpi_ultimate->net) {
 			struct bgp_table *table;
 
-			table = bgp_node_table(bi_ultimate->net);
+			table = bgp_node_table(bpi_ultimate->net);
 			if (table && (table->safi == SAFI_UNICAST))
 				origin_local = 1;
 		}
 
 		/* copy labels */
-		if (!origin_local &&
-		    info_vpn->extra && info_vpn->extra->num_labels) {
-			num_labels = info_vpn->extra->num_labels;
+		if (!origin_local && path_vpn->extra
+		    && path_vpn->extra->num_labels) {
+			num_labels = path_vpn->extra->num_labels;
 			if (num_labels > BGP_MAX_LABELS)
 				num_labels = BGP_MAX_LABELS;
-			pLabels = info_vpn->extra->label;
+			pLabels = path_vpn->extra->label;
 		}
 	}
 
@@ -1203,19 +1202,18 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 	 * For VRF-2-VRF route-leaking,
 	 * the source will be the originating VRF.
 	 */
-	if (info_vpn->extra && info_vpn->extra->bgp_orig)
-		src_vrf = info_vpn->extra->bgp_orig;
+	if (path_vpn->extra && path_vpn->extra->bgp_orig)
+		src_vrf = path_vpn->extra->bgp_orig;
 	else
 		src_vrf = bgp_vpn;
 
-	leak_update(bgp_vrf, bn, new_attr, afi, safi, info_vpn,
-		pLabels, num_labels,
-		info_vpn, /* parent */
-		src_vrf, &nexthop_orig, nexthop_self_flag, debug);
+	leak_update(bgp_vrf, bn, new_attr, afi, safi, path_vpn, pLabels,
+		    num_labels, path_vpn, /* parent */
+		    src_vrf, &nexthop_orig, nexthop_self_flag, debug);
 }
 
 void vpn_leak_to_vrf_update(struct bgp *bgp_vpn,	    /* from */
-			    struct bgp_path_info *info_vpn) /* route */
+			    struct bgp_path_info *path_vpn) /* route */
 {
 	struct listnode *mnode, *mnnode;
 	struct bgp *bgp;
@@ -1223,20 +1221,20 @@ void vpn_leak_to_vrf_update(struct bgp *bgp_vpn,	    /* from */
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_TO_VRF);
 
 	if (debug)
-		zlog_debug("%s: start (info_vpn=%p)", __func__, info_vpn);
+		zlog_debug("%s: start (path_vpn=%p)", __func__, path_vpn);
 
 	/* Loop over VRFs */
 	for (ALL_LIST_ELEMENTS(bm->bgp, mnode, mnnode, bgp)) {
 
-		if (!info_vpn->extra
-		    || info_vpn->extra->bgp_orig != bgp) { /* no loop */
-			vpn_leak_to_vrf_update_onevrf(bgp, bgp_vpn, info_vpn);
+		if (!path_vpn->extra
+		    || path_vpn->extra->bgp_orig != bgp) { /* no loop */
+			vpn_leak_to_vrf_update_onevrf(bgp, bgp_vpn, path_vpn);
 		}
 	}
 }
 
 void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,	    /* from */
-			      struct bgp_path_info *info_vpn) /* route */
+			      struct bgp_path_info *path_vpn) /* route */
 {
 	struct prefix *p;
 	afi_t afi;
@@ -1244,38 +1242,38 @@ void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,	    /* from */
 	struct bgp *bgp;
 	struct listnode *mnode, *mnnode;
 	struct bgp_node *bn;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	const char *debugmsg;
 	char buf_prefix[PREFIX_STRLEN];
 
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_TO_VRF);
 
 	if (debug) {
-		prefix2str(&info_vpn->net->p, buf_prefix, sizeof(buf_prefix));
-		zlog_debug("%s: entry: p=%s, type=%d, sub_type=%d",
-			__func__, buf_prefix,
-			info_vpn->type, info_vpn->sub_type);
+		prefix2str(&path_vpn->net->p, buf_prefix, sizeof(buf_prefix));
+		zlog_debug("%s: entry: p=%s, type=%d, sub_type=%d", __func__,
+			   buf_prefix, path_vpn->type, path_vpn->sub_type);
 	}
 
 	if (debug)
-		zlog_debug("%s: start (info_vpn=%p)", __func__, info_vpn);
+		zlog_debug("%s: start (path_vpn=%p)", __func__, path_vpn);
 
-	if (!info_vpn->net) {
+	if (!path_vpn->net) {
 #if ENABLE_BGP_VNC
-		/* BGP_ROUTE_RFP routes do not have info_vpn->net set (yet) */
-		if (info_vpn->type == ZEBRA_ROUTE_BGP &&
-			info_vpn->sub_type == BGP_ROUTE_RFP) {
+		/* BGP_ROUTE_RFP routes do not have path_vpn->net set (yet) */
+		if (path_vpn->type == ZEBRA_ROUTE_BGP
+		    && path_vpn->sub_type == BGP_ROUTE_RFP) {
 
 			return;
 		}
 #endif
 		if (debug)
-			zlog_debug("%s: info_vpn->net unexpectedly NULL, no prefix, bailing",
+			zlog_debug(
+				"%s: path_vpn->net unexpectedly NULL, no prefix, bailing",
 				__func__);
 		return;
 	}
 
-	p = &info_vpn->net->p;
+	p = &path_vpn->net->p;
 	afi = family2afi(p->family);
 
 	/* Loop over VRFs */
@@ -1290,7 +1288,7 @@ void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,	    /* from */
 		/* Check for intersection of route targets */
 		if (!ecom_intersect(bgp->vpn_policy[afi]
 					    .rtlist[BGP_VPN_POLICY_DIR_FROMVPN],
-				    info_vpn->attr->ecommunity)) {
+				    path_vpn->attr->ecommunity)) {
 
 			continue;
 		}
@@ -1300,19 +1298,20 @@ void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,	    /* from */
 				   bgp->name_pretty);
 
 		bn = bgp_afi_node_get(bgp->rib[afi][safi], afi, safi, p, NULL);
-		for (bi = (bn ? bn->info : NULL); bi; bi = bi->next) {
-			if (bi->extra
-			    && (struct bgp_path_info *)bi->extra->parent
-				       == info_vpn) {
+		for (bpi = (bn ? bn->info : NULL); bpi; bpi = bpi->next) {
+			if (bpi->extra
+			    && (struct bgp_path_info *)bpi->extra->parent
+				       == path_vpn) {
 				break;
 			}
 		}
 
-		if (bi) {
+		if (bpi) {
 			if (debug)
-				zlog_debug("%s: deleting bi %p", __func__, bi);
-			bgp_aggregate_decrement(bgp, p, bi, afi, safi);
-			bgp_path_info_delete(bn, bi);
+				zlog_debug("%s: deleting bpi %p", __func__,
+					   bpi);
+			bgp_aggregate_decrement(bgp, p, bpi, afi, safi);
+			bgp_path_info_delete(bn, bpi);
 			bgp_process(bgp, bn, afi, safi);
 		}
 		bgp_unlock_node(bn);
@@ -1323,25 +1322,25 @@ void vpn_leak_to_vrf_withdraw_all(struct bgp *bgp_vrf, /* to */
 				  afi_t afi)
 {
 	struct bgp_node *bn;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	safi_t safi = SAFI_UNICAST;
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_TO_VRF);
 
 	if (debug)
 		zlog_debug("%s: entry", __func__);
 	/*
-	 * Walk vrf table, delete bi with bgp_orig in a different vrf
+	 * Walk vrf table, delete bpi with bgp_orig in a different vrf
 	 */
 	for (bn = bgp_table_top(bgp_vrf->rib[afi][safi]); bn;
 	     bn = bgp_route_next(bn)) {
 
-		for (bi = bn->info; bi; bi = bi->next) {
-			if (bi->extra && bi->extra->bgp_orig != bgp_vrf) {
+		for (bpi = bn->info; bpi; bpi = bpi->next) {
+			if (bpi->extra && bpi->extra->bgp_orig != bgp_vrf) {
 
 				/* delete route */
-				bgp_aggregate_decrement(bgp_vrf, &bn->p, bi,
+				bgp_aggregate_decrement(bgp_vrf, &bn->p, bpi,
 							afi, safi);
-				bgp_path_info_delete(bn, bi);
+				bgp_path_info_delete(bn, bpi);
 				bgp_process(bgp_vrf, bn, afi, safi);
 			}
 		}
@@ -1366,7 +1365,7 @@ void vpn_leak_to_vrf_update_all(struct bgp *bgp_vrf, /* to */
 
 		struct bgp_table *table;
 		struct bgp_node *bn;
-		struct bgp_path_info *bi;
+		struct bgp_path_info *bpi;
 
 		memset(&prd, 0, sizeof(prd));
 		prd.family = AF_UNSPEC;
@@ -1381,13 +1380,14 @@ void vpn_leak_to_vrf_update_all(struct bgp *bgp_vrf, /* to */
 
 		for (bn = bgp_table_top(table); bn; bn = bgp_route_next(bn)) {
 
-			for (bi = bn->info; bi; bi = bi->next) {
+			for (bpi = bn->info; bpi; bpi = bpi->next) {
 
-				if (bi->extra && bi->extra->bgp_orig == bgp_vrf)
+				if (bpi->extra
+				    && bpi->extra->bgp_orig == bgp_vrf)
 					continue;
 
 				vpn_leak_to_vrf_update_onevrf(bgp_vrf, bgp_vpn,
-							      bi);
+							      bpi);
 			}
 		}
 	}

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -53,10 +53,10 @@ extern int bgp_show_mpls_vpn(struct vty *vty, afi_t afi, struct prefix_rd *prd,
 			     int tags, bool use_json);
 
 extern void vpn_leak_from_vrf_update(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
-				     struct bgp_info *info_vrf);
+				     struct bgp_path_info *info_vrf);
 
 extern void vpn_leak_from_vrf_withdraw(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
-				       struct bgp_info *info_vrf);
+				       struct bgp_path_info *info_vrf);
 
 extern void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn,
 					   struct bgp *bgp_vrf, afi_t afi);
@@ -70,10 +70,10 @@ extern void vpn_leak_to_vrf_update_all(struct bgp *bgp_vrf, struct bgp *bgp_vpn,
 				       afi_t afi);
 
 extern void vpn_leak_to_vrf_update(struct bgp *bgp_vpn,
-				   struct bgp_info *info_vpn);
+				   struct bgp_path_info *info_vpn);
 
 extern void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,
-				     struct bgp_info *info_vpn);
+				     struct bgp_path_info *info_vpn);
 
 extern void vpn_leak_zebra_vrf_label_update(struct bgp *bgp, afi_t afi);
 extern void vpn_leak_zebra_vrf_label_withdraw(struct bgp *bgp, afi_t afi);

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -53,10 +53,10 @@ extern int bgp_show_mpls_vpn(struct vty *vty, afi_t afi, struct prefix_rd *prd,
 			     int tags, bool use_json);
 
 extern void vpn_leak_from_vrf_update(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
-				     struct bgp_path_info *info_vrf);
+				     struct bgp_path_info *path_vrf);
 
 extern void vpn_leak_from_vrf_withdraw(struct bgp *bgp_vpn, struct bgp *bgp_vrf,
-				       struct bgp_path_info *info_vrf);
+				       struct bgp_path_info *path_vrf);
 
 extern void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn,
 					   struct bgp *bgp_vrf, afi_t afi);
@@ -70,10 +70,10 @@ extern void vpn_leak_to_vrf_update_all(struct bgp *bgp_vrf, struct bgp *bgp_vpn,
 				       afi_t afi);
 
 extern void vpn_leak_to_vrf_update(struct bgp *bgp_vpn,
-				   struct bgp_path_info *info_vpn);
+				   struct bgp_path_info *path_vpn);
 
 extern void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,
-				     struct bgp_path_info *info_vpn);
+				     struct bgp_path_info *path_vpn);
 
 extern void vpn_leak_zebra_vrf_label_update(struct bgp *bgp, afi_t afi);
 extern void vpn_leak_zebra_vrf_label_withdraw(struct bgp *bgp, afi_t afi);

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -63,7 +63,7 @@ struct bgp_nexthop_cache {
 
 	struct bgp_node *node;
 	void *nht_info; /* In BGP, peer session */
-	LIST_HEAD(path_list, bgp_info) paths;
+	LIST_HEAD(path_list, bgp_path_info) paths;
 	unsigned int path_count;
 	struct bgp *bgp;
 };
@@ -74,8 +74,6 @@ struct tip_addr {
 	int refcnt;
 };
 
-extern int bgp_nexthop_lookup(afi_t, struct peer *peer, struct bgp_info *,
-			      int *, int *);
 extern void bgp_connected_add(struct bgp *bgp, struct connected *c);
 extern void bgp_connected_delete(struct bgp *bgp, struct connected *c);
 extern int bgp_subgrp_multiaccess_check_v4(struct in_addr nexthop,

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -256,7 +256,7 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 		path_nh_map(ri, bnc, 1); /* updates NHT ri list reference */
 
 		if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_VALID) && bnc->metric)
-			(bgp_info_extra_get(ri))->igpmetric = bnc->metric;
+			(bgp_path_info_extra_get(ri))->igpmetric = bnc->metric;
 		else if (ri->extra)
 			ri->extra->igpmetric = 0;
 	} else if (peer)
@@ -745,9 +745,11 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 			if (CHECK_FLAG(path->flags, BGP_PATH_VALID)) {
 				bgp_aggregate_decrement(bgp_path, &rn->p,
 							path, afi, safi);
-				bgp_info_unset_flag(rn, path, BGP_PATH_VALID);
+				bgp_path_info_unset_flag(rn, path,
+							 BGP_PATH_VALID);
 			} else {
-				bgp_info_set_flag(rn, path, BGP_PATH_VALID);
+				bgp_path_info_set_flag(rn, path,
+						       BGP_PATH_VALID);
 				bgp_aggregate_increment(bgp_path, &rn->p,
 							path, afi, safi);
 			}
@@ -756,7 +758,8 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 		/* Copy the metric to the path. Will be used for bestpath
 		 * computation */
 		if (bgp_isvalid_nexthop(bnc) && bnc->metric)
-			(bgp_info_extra_get(path))->igpmetric = bnc->metric;
+			(bgp_path_info_extra_get(path))->igpmetric =
+				bnc->metric;
 		else if (path->extra)
 			path->extra->igpmetric = 0;
 

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -50,9 +50,9 @@ static void register_zebra_rnh(struct bgp_nexthop_cache *bnc,
 static void unregister_zebra_rnh(struct bgp_nexthop_cache *bnc,
 				 int is_bgp_static_route);
 static void evaluate_paths(struct bgp_nexthop_cache *bnc);
-static int make_prefix(int afi, struct bgp_info *ri, struct prefix *p);
-static void path_nh_map(struct bgp_info *path, struct bgp_nexthop_cache *bnc,
-			int keep);
+static int make_prefix(int afi, struct bgp_path_info *ri, struct prefix *p);
+static void path_nh_map(struct bgp_path_info *path,
+			struct bgp_nexthop_cache *bnc, int keep);
 
 static int bgp_isvalid_nexthop(struct bgp_nexthop_cache *bnc)
 {
@@ -66,7 +66,7 @@ static int bgp_isvalid_labeled_nexthop(struct bgp_nexthop_cache *bnc)
 		|| (bnc && CHECK_FLAG(bnc->flags, BGP_NEXTHOP_LABELED_VALID)));
 }
 
-int bgp_find_nexthop(struct bgp_info *path, int connected)
+int bgp_find_nexthop(struct bgp_path_info *path, int connected)
 {
 	struct bgp_nexthop_cache *bnc = path->nexthop;
 
@@ -104,7 +104,7 @@ static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 	}
 }
 
-void bgp_unlink_nexthop(struct bgp_info *path)
+void bgp_unlink_nexthop(struct bgp_path_info *path)
 {
 	struct bgp_nexthop_cache *bnc = path->nexthop;
 
@@ -143,7 +143,7 @@ void bgp_unlink_nexthop_by_peer(struct peer *peer)
  * we need both the bgp_route and bgp_nexthop pointers.
  */
 int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
-			    afi_t afi, struct bgp_info *ri,
+			    afi_t afi, struct bgp_path_info *ri,
 			    struct peer *peer, int connected)
 {
 	struct bgp_node *rn;
@@ -527,7 +527,7 @@ void bgp_cleanup_nexthops(struct bgp *bgp)
  * make_prefix - make a prefix structure from the path (essentially
  * path's node.
  */
-static int make_prefix(int afi, struct bgp_info *ri, struct prefix *p)
+static int make_prefix(int afi, struct bgp_path_info *ri, struct prefix *p)
 {
 
 	int is_bgp_static = ((ri->type == ZEBRA_ROUTE_BGP)
@@ -673,7 +673,7 @@ static void unregister_zebra_rnh(struct bgp_nexthop_cache *bnc,
 static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 {
 	struct bgp_node *rn;
-	struct bgp_info *path;
+	struct bgp_path_info *path;
 	int afi;
 	struct peer *peer = (struct peer *)bnc->nht_info;
 	struct bgp_table *table;
@@ -786,8 +786,8 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
  *   make - if set, make the association. if unset, just break the existing
  *          association.
  */
-static void path_nh_map(struct bgp_info *path, struct bgp_nexthop_cache *bnc,
-			int make)
+static void path_nh_map(struct bgp_path_info *path,
+			struct bgp_nexthop_cache *bnc, int make)
 {
 	if (path->nexthop) {
 		LIST_REMOVE(path, nh_thread);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -740,14 +740,14 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 				(bnc_is_valid_nexthop ? "" : "not "));
 		}
 
-		if ((CHECK_FLAG(path->flags, BGP_INFO_VALID) ? 1 : 0)
+		if ((CHECK_FLAG(path->flags, BGP_PATH_VALID) ? 1 : 0)
 		    != bnc_is_valid_nexthop) {
-			if (CHECK_FLAG(path->flags, BGP_INFO_VALID)) {
+			if (CHECK_FLAG(path->flags, BGP_PATH_VALID)) {
 				bgp_aggregate_decrement(bgp_path, &rn->p,
 							path, afi, safi);
-				bgp_info_unset_flag(rn, path, BGP_INFO_VALID);
+				bgp_info_unset_flag(rn, path, BGP_PATH_VALID);
 			} else {
-				bgp_info_set_flag(rn, path, BGP_INFO_VALID);
+				bgp_info_set_flag(rn, path, BGP_PATH_VALID);
 				bgp_aggregate_increment(bgp_path, &rn->p,
 							path, afi, safi);
 			}
@@ -762,7 +762,7 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 
 		if (CHECK_FLAG(bnc->change_flags, BGP_NEXTHOP_METRIC_CHANGED)
 		    || CHECK_FLAG(bnc->change_flags, BGP_NEXTHOP_CHANGED))
-			SET_FLAG(path->flags, BGP_INFO_IGP_CHANGED);
+			SET_FLAG(path->flags, BGP_PATH_IGP_CHANGED);
 
 		bgp_process(bgp_path, rn, afi, safi);
 	}

--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -32,7 +32,7 @@ extern void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id);
  *   p - path for which the nexthop object is being looked up
  *   connected - True if NH MUST be a connected route
  */
-extern int bgp_find_nexthop(struct bgp_info *p, int connected);
+extern int bgp_find_nexthop(struct bgp_path_info *p, int connected);
 
 /**
  * bgp_find_or_add_nexthop() - lookup the nexthop cache table for the bnc
@@ -47,16 +47,17 @@ extern int bgp_find_nexthop(struct bgp_info *p, int connected);
  *   connected - True if NH MUST be a connected route
  */
 extern int bgp_find_or_add_nexthop(struct bgp *bgp_route,
-			struct bgp *bgp_nexthop, afi_t a, struct bgp_info *p,
-			struct peer *peer, int connected);
+				   struct bgp *bgp_nexthop, afi_t a,
+				   struct bgp_path_info *p, struct peer *peer,
+				   int connected);
 
 /**
  * bgp_unlink_nexthop() - Unlink the nexthop object from the path structure.
  * ARGUMENTS:
  *   p - path structure.
  */
-extern void bgp_unlink_nexthop(struct bgp_info *p);
-void bgp_unlink_nexthop_by_peer(struct peer *);
+extern void bgp_unlink_nexthop(struct bgp_path_info *p);
+void bgp_unlink_nexthop_by_peer(struct peer *peer);
 
 /**
  * bgp_delete_connected_nexthop() - Reset the 'peer' pointer for a connected

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -627,7 +627,7 @@ static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 
 /* return -1 if build or validation failed */
 static int bgp_pbr_build_and_validate_entry(struct prefix *p,
-					    struct bgp_path_info *info,
+					    struct bgp_path_info *path,
 					    struct bgp_pbr_entry_main *api)
 {
 	int ret;
@@ -645,8 +645,8 @@ static int bgp_pbr_build_and_validate_entry(struct prefix *p,
 	if (ret < 0)
 		return -1;
 	/* extract actiosn from flowspec ecom list */
-	if (info && info->attr && info->attr->ecommunity) {
-		ecom = info->attr->ecommunity;
+	if (path && path->attr && path->attr->ecommunity) {
+		ecom = path->attr->ecommunity;
 		for (i = 0; i < ecom->size; i++) {
 			ecom_eval = (struct ecommunity_val *)
 				(ecom->val + (i * ECOMMUNITY_SIZE));
@@ -690,7 +690,7 @@ static int bgp_pbr_build_and_validate_entry(struct prefix *p,
 				    (char)ECOMMUNITY_REDIRECT_IP_NH)) {
 				api_action->action = ACTION_REDIRECT_IP;
 				api_action->u.zr.redirect_ip_v4.s_addr =
-					info->attr->nexthop.s_addr;
+					path->attr->nexthop.s_addr;
 				api_action->u.zr.duplicate = ecom_eval->val[7];
 			} else {
 				if (ecom_eval->val[0] !=

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1227,9 +1227,9 @@ static void bgp_pbr_flush_entry(struct bgp *bgp, struct bgp_pbr_action *bpa,
 			struct bgp_path_info *bgp_info;
 			struct bgp_path_info_extra *extra;
 
-			/* unlink bgp_info to bpme */
+			/* unlink bgp_path_info to bpme */
 			bgp_info = (struct bgp_path_info *)bpme->bgp_info;
-			extra = bgp_info_extra_get(bgp_info);
+			extra = bgp_path_info_extra_get(bgp_info);
 			if (extra->bgp_fs_pbr)
 				listnode_delete(extra->bgp_fs_pbr, bpme);
 			bpme->bgp_info = NULL;
@@ -1850,7 +1850,8 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 
 	/* already installed */
 	if (bpme_found) {
-		struct bgp_path_info_extra *extra = bgp_info_extra_get(binfo);
+		struct bgp_path_info_extra *extra =
+			bgp_path_info_extra_get(binfo);
 
 		if (extra && extra->bgp_fs_pbr &&
 		    listnode_lookup(extra->bgp_fs_pbr, bpme)) {

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -227,7 +227,7 @@ struct bgp_pbr_or_filter {
 };
 
 static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
-						  struct bgp_info *binfo,
+						  struct bgp_path_info *binfo,
 						  struct bgp_pbr_filter *bpf,
 						  struct nexthop *nh,
 						  float *rate);
@@ -627,7 +627,7 @@ static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 
 /* return -1 if build or validation failed */
 static int bgp_pbr_build_and_validate_entry(struct prefix *p,
-					    struct bgp_info *info,
+					    struct bgp_path_info *info,
 					    struct bgp_pbr_entry_main *api)
 {
 	int ret;
@@ -1224,11 +1224,11 @@ static void bgp_pbr_flush_entry(struct bgp *bgp, struct bgp_pbr_action *bpa,
 		bpme->installed = false;
 		bpme->backpointer = NULL;
 		if (bpme->bgp_info) {
-			struct bgp_info *bgp_info;
-			struct bgp_info_extra *extra;
+			struct bgp_path_info *bgp_info;
+			struct bgp_path_info_extra *extra;
 
 			/* unlink bgp_info to bpme */
-			bgp_info = (struct bgp_info *)bpme->bgp_info;
+			bgp_info = (struct bgp_path_info *)bpme->bgp_info;
 			extra = bgp_info_extra_get(bgp_info);
 			if (extra->bgp_fs_pbr)
 				listnode_delete(extra->bgp_fs_pbr, bpme);
@@ -1304,9 +1304,10 @@ static int bgp_pbr_get_remaining_entry(struct hash_backet *backet, void *arg)
 	return HASHWALK_ABORT;
 }
 
-static void bgp_pbr_policyroute_remove_from_zebra_unit(struct bgp *bgp,
-				struct bgp_info *binfo,
-				struct bgp_pbr_filter *bpf)
+static void
+bgp_pbr_policyroute_remove_from_zebra_unit(struct bgp *bgp,
+					   struct bgp_path_info *binfo,
+					   struct bgp_pbr_filter *bpf)
 {
 	struct bgp_pbr_match temp;
 	struct bgp_pbr_match_entry temp2;
@@ -1438,13 +1439,10 @@ static uint8_t bgp_pbr_next_type_entry(uint8_t type_entry)
 	return 0;
 }
 
-static void  bgp_pbr_icmp_action(struct bgp *bgp,
-				 struct bgp_info *binfo,
-				 struct bgp_pbr_filter *bpf,
-				 struct bgp_pbr_or_filter *bpof,
-				 bool add,
-				 struct nexthop *nh,
-				 float *rate)
+static void bgp_pbr_icmp_action(struct bgp *bgp, struct bgp_path_info *binfo,
+				struct bgp_pbr_filter *bpf,
+				struct bgp_pbr_or_filter *bpof, bool add,
+				struct nexthop *nh, float *rate)
 {
 	struct bgp_pbr_range_port srcp, dstp;
 	struct bgp_pbr_val_mask *icmp_type, *icmp_code;
@@ -1507,11 +1505,10 @@ static void  bgp_pbr_icmp_action(struct bgp *bgp,
 	}
 }
 
-static void bgp_pbr_policyroute_remove_from_zebra_recursive(struct bgp *bgp,
-			struct bgp_info *binfo,
-			struct bgp_pbr_filter *bpf,
-			struct bgp_pbr_or_filter *bpof,
-			uint8_t type_entry)
+static void bgp_pbr_policyroute_remove_from_zebra_recursive(
+	struct bgp *bgp, struct bgp_path_info *binfo,
+	struct bgp_pbr_filter *bpf, struct bgp_pbr_or_filter *bpof,
+	uint8_t type_entry)
 {
 	struct listnode *node, *nnode;
 	struct bgp_pbr_val_mask *valmask;
@@ -1554,10 +1551,9 @@ static void bgp_pbr_policyroute_remove_from_zebra_recursive(struct bgp *bgp,
 	}
 }
 
-static void bgp_pbr_policyroute_remove_from_zebra(struct bgp *bgp,
-				struct bgp_info *binfo,
-				struct bgp_pbr_filter *bpf,
-				struct bgp_pbr_or_filter *bpof)
+static void bgp_pbr_policyroute_remove_from_zebra(
+	struct bgp *bgp, struct bgp_path_info *binfo,
+	struct bgp_pbr_filter *bpf, struct bgp_pbr_or_filter *bpof)
 {
 	if (!bpof)
 		return bgp_pbr_policyroute_remove_from_zebra_unit(bgp,
@@ -1692,10 +1688,10 @@ static void bgp_pbr_dump_entry(struct bgp_pbr_filter *bpf, bool add)
 }
 
 static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
-				     struct bgp_info *binfo,
-				     struct bgp_pbr_filter *bpf,
-				     struct nexthop *nh,
-				     float *rate)
+						  struct bgp_path_info *binfo,
+						  struct bgp_pbr_filter *bpf,
+						  struct nexthop *nh,
+						  float *rate)
 {
 	struct bgp_pbr_match temp;
 	struct bgp_pbr_match_entry temp2;
@@ -1854,7 +1850,7 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 
 	/* already installed */
 	if (bpme_found) {
-		struct bgp_info_extra *extra = bgp_info_extra_get(binfo);
+		struct bgp_path_info_extra *extra = bgp_info_extra_get(binfo);
 
 		if (extra && extra->bgp_fs_pbr &&
 		    listnode_lookup(extra->bgp_fs_pbr, bpme)) {
@@ -1911,13 +1907,10 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 
 }
 
-static void bgp_pbr_policyroute_add_to_zebra_recursive(struct bgp *bgp,
-			struct bgp_info *binfo,
-			struct bgp_pbr_filter *bpf,
-			struct bgp_pbr_or_filter *bpof,
-			struct nexthop *nh,
-			float *rate,
-			uint8_t type_entry)
+static void bgp_pbr_policyroute_add_to_zebra_recursive(
+	struct bgp *bgp, struct bgp_path_info *binfo,
+	struct bgp_pbr_filter *bpf, struct bgp_pbr_or_filter *bpof,
+	struct nexthop *nh, float *rate, uint8_t type_entry)
 {
 	struct listnode *node, *nnode;
 	struct bgp_pbr_val_mask *valmask;
@@ -1961,11 +1954,10 @@ static void bgp_pbr_policyroute_add_to_zebra_recursive(struct bgp *bgp,
 }
 
 static void bgp_pbr_policyroute_add_to_zebra(struct bgp *bgp,
-				     struct bgp_info *binfo,
-				     struct bgp_pbr_filter *bpf,
-				     struct bgp_pbr_or_filter *bpof,
-				     struct nexthop *nh,
-				     float *rate)
+					     struct bgp_path_info *binfo,
+					     struct bgp_pbr_filter *bpf,
+					     struct bgp_pbr_or_filter *bpof,
+					     struct nexthop *nh, float *rate)
 {
 	if (!bpof)
 		return bgp_pbr_policyroute_add_to_zebra_unit(bgp, binfo,
@@ -2012,10 +2004,8 @@ static void bgp_pbr_policyroute_add_to_zebra(struct bgp *bgp,
 		list_delete_all_node(bpof->icmp_code);
 }
 
-static void bgp_pbr_handle_entry(struct bgp *bgp,
-				struct bgp_info *binfo,
-				struct bgp_pbr_entry_main *api,
-				bool add)
+static void bgp_pbr_handle_entry(struct bgp *bgp, struct bgp_path_info *binfo,
+				 struct bgp_pbr_entry_main *api, bool add)
 {
 	struct nexthop nh;
 	int i = 0;
@@ -2236,8 +2226,8 @@ static void bgp_pbr_handle_entry(struct bgp *bgp,
 }
 
 void bgp_pbr_update_entry(struct bgp *bgp, struct prefix *p,
-			 struct bgp_info *info, afi_t afi, safi_t safi,
-			 bool nlri_update)
+			  struct bgp_path_info *info, afi_t afi, safi_t safi,
+			  bool nlri_update)
 {
 	struct bgp_pbr_entry_main api;
 

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -279,11 +279,10 @@ extern int bgp_pbr_match_hash_equal(const void *arg1,
 void bgp_pbr_print_policy_route(struct bgp_pbr_entry_main *api);
 
 struct bgp_node;
-struct bgp_info;
+struct bgp_path_info;
 extern void bgp_pbr_update_entry(struct bgp *bgp, struct prefix *p,
-				 struct bgp_info *new_select,
-				afi_t afi, safi_t safi,
-				bool nlri_update);
+				 struct bgp_path_info *new_select, afi_t afi,
+				 safi_t safi, bool nlri_update);
 
 /* bgp pbr utilities */
 extern struct bgp_pbr_interface *pbr_interface_lookup(const char *name);

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -219,7 +219,7 @@ struct bgp_pbr_match_entry {
 	uint16_t dst_port_max;
 	uint8_t proto;
 
-	void *bgp_info;
+	void *path;
 
 	bool installed;
 	bool install_in_progress;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8849,11 +8849,11 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 				}
 				display++;
 
-				if (pathtype == BGP_PATH_ALL
-				    || (pathtype == BGP_PATH_BESTPATH
+				if (pathtype == BGP_PATH_SHOW_ALL
+				    || (pathtype == BGP_PATH_SHOW_BESTPATH
 					&& CHECK_FLAG(ri->flags,
 						      BGP_INFO_SELECTED))
-				    || (pathtype == BGP_PATH_MULTIPATH
+				    || (pathtype == BGP_PATH_SHOW_MULTIPATH
 					&& (CHECK_FLAG(ri->flags,
 						       BGP_INFO_MULTIPATH)
 					    || CHECK_FLAG(ri->flags,
@@ -8886,12 +8886,14 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 					}
 					display++;
 
-					if (pathtype == BGP_PATH_ALL
-					    || (pathtype == BGP_PATH_BESTPATH
+					if (pathtype == BGP_PATH_SHOW_ALL
+					    || (pathtype
+							== BGP_PATH_SHOW_BESTPATH
 						&& CHECK_FLAG(
 							   ri->flags,
 							   BGP_INFO_SELECTED))
-					    || (pathtype == BGP_PATH_MULTIPATH
+					    || (pathtype
+							== BGP_PATH_SHOW_MULTIPATH
 						&& (CHECK_FLAG(
 							    ri->flags,
 							    BGP_INFO_MULTIPATH)
@@ -9344,11 +9346,11 @@ DEFUN (show_ip_bgp_route,
 
 	/* [<bestpath|multipath>] */
 	if (argv_find(argv, argc, "bestpath", &idx))
-		path_type = BGP_PATH_BESTPATH;
+		path_type = BGP_PATH_SHOW_BESTPATH;
 	else if (argv_find(argv, argc, "multipath", &idx))
-		path_type = BGP_PATH_MULTIPATH;
+		path_type = BGP_PATH_SHOW_MULTIPATH;
 	else
-		path_type = BGP_PATH_ALL;
+		path_type = BGP_PATH_SHOW_ALL;
 
 	return bgp_show_route(vty, bgp, prefix, afi, safi, NULL, prefix_check,
 			      path_type, uj);
@@ -10115,7 +10117,7 @@ DEFUN (show_ip_bgp_vpn_all_route_prefix,
 	}
 
 	return bgp_show_route(vty, bgp, network, AFI_IP, SAFI_MPLS_VPN, NULL, 0,
-			      BGP_PATH_ALL, use_json(argc, argv));
+			      BGP_PATH_SHOW_ALL, use_json(argc, argv));
 }
 #endif /* KEEP_OLD_VPN_COMMANDS */
 
@@ -10144,7 +10146,7 @@ DEFUN (show_ip_bgp_l2vpn_evpn_all_route_prefix,
 		return CMD_WARNING;
 	}
 	return bgp_show_route(vty, NULL, network, AFI_L2VPN, SAFI_EVPN, NULL, 0,
-			      BGP_PATH_ALL, use_json(argc, argv));
+			      BGP_PATH_SHOW_ALL, use_json(argc, argv));
 }
 
 static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
@@ -10757,7 +10759,7 @@ DEFUN (show_bgp_afi_vpn_rd_route,
 	}
 
 	return bgp_show_route(vty, NULL, argv[6]->arg, afi, SAFI_MPLS_VPN, &prd,
-			      0, BGP_PATH_ALL, use_json(argc, argv));
+			      0, BGP_PATH_SHOW_ALL, use_json(argc, argv));
 }
 
 static struct bgp_distance *bgp_distance_new(void)

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -318,7 +318,11 @@ struct bgp_static {
 /* path PREFIX (addpath rxid NUMBER) */
 #define PATH_ADDPATH_STR_BUFFER PREFIX2STR_BUFFER + 32
 
-enum bgp_path_type { BGP_PATH_ALL, BGP_PATH_BESTPATH, BGP_PATH_MULTIPATH };
+enum bgp_path_type {
+	BGP_PATH_SHOW_ALL,
+	BGP_PATH_SHOW_BESTPATH,
+	BGP_PATH_SHOW_MULTIPATH
+};
 
 static inline void bgp_bump_version(struct bgp_node *node)
 {

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -185,21 +185,21 @@ struct bgp_info {
 
 	/* BGP information status.  */
 	uint16_t flags;
-#define BGP_INFO_IGP_CHANGED    (1 << 0)
-#define BGP_INFO_DAMPED         (1 << 1)
-#define BGP_INFO_HISTORY        (1 << 2)
-#define BGP_INFO_SELECTED       (1 << 3)
-#define BGP_INFO_VALID          (1 << 4)
-#define BGP_INFO_ATTR_CHANGED   (1 << 5)
-#define BGP_INFO_DMED_CHECK     (1 << 6)
-#define BGP_INFO_DMED_SELECTED  (1 << 7)
-#define BGP_INFO_STALE          (1 << 8)
-#define BGP_INFO_REMOVED        (1 << 9)
-#define BGP_INFO_COUNTED	(1 << 10)
-#define BGP_INFO_MULTIPATH      (1 << 11)
-#define BGP_INFO_MULTIPATH_CHG  (1 << 12)
-#define BGP_INFO_RIB_ATTR_CHG   (1 << 13)
-#define BGP_INFO_ANNC_NH_SELF   (1 << 14)
+#define BGP_PATH_IGP_CHANGED (1 << 0)
+#define BGP_PATH_DAMPED (1 << 1)
+#define BGP_PATH_HISTORY (1 << 2)
+#define BGP_PATH_SELECTED (1 << 3)
+#define BGP_PATH_VALID (1 << 4)
+#define BGP_PATH_ATTR_CHANGED (1 << 5)
+#define BGP_PATH_DMED_CHECK (1 << 6)
+#define BGP_PATH_DMED_SELECTED (1 << 7)
+#define BGP_PATH_STALE (1 << 8)
+#define BGP_PATH_REMOVED (1 << 9)
+#define BGP_PATH_COUNTED (1 << 10)
+#define BGP_PATH_MULTIPATH (1 << 11)
+#define BGP_PATH_MULTIPATH_CHG (1 << 12)
+#define BGP_PATH_RIB_ATTR_CHG (1 << 13)
+#define BGP_PATH_ANNC_NH_SELF (1 << 14)
 
 	/* BGP route type.  This can be static, RIP, OSPF, BGP etc.  */
 	uint8_t type;
@@ -277,20 +277,20 @@ struct bgp_static {
 #define BGP_ATTR_NEXTHOP_AFI_IP6(attr)                                         \
 	(!CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP))             \
 	 && ((attr)->mp_nexthop_len == 16 || (attr)->mp_nexthop_len == 32))
-#define BGP_INFO_COUNTABLE(BI)                                                 \
-	(!CHECK_FLAG((BI)->flags, BGP_INFO_HISTORY)                            \
-	 && !CHECK_FLAG((BI)->flags, BGP_INFO_REMOVED))
+#define BGP_PATH_COUNTABLE(BI)                                                 \
+	(!CHECK_FLAG((BI)->flags, BGP_PATH_HISTORY)                            \
+	 && !CHECK_FLAG((BI)->flags, BGP_PATH_REMOVED))
 
 /* Flags which indicate a route is unuseable in some form */
-#define BGP_INFO_UNUSEABLE                                                     \
-	(BGP_INFO_HISTORY | BGP_INFO_DAMPED | BGP_INFO_REMOVED)
+#define BGP_PATH_UNUSEABLE                                                     \
+	(BGP_PATH_HISTORY | BGP_PATH_DAMPED | BGP_PATH_REMOVED)
 /* Macro to check BGP information is alive or not.  Sadly,
  * not equivalent to just checking previous, because of the
  * sense of the additional VALID flag.
  */
-#define BGP_INFO_HOLDDOWN(BI)                                                  \
-	(!CHECK_FLAG((BI)->flags, BGP_INFO_VALID)                              \
-	 || CHECK_FLAG((BI)->flags, BGP_INFO_UNUSEABLE))
+#define BGP_PATH_HOLDDOWN(BI)                                                  \
+	(!CHECK_FLAG((BI)->flags, BGP_PATH_VALID)                              \
+	 || CHECK_FLAG((BI)->flags, BGP_PATH_UNUSEABLE))
 
 #define DISTRIBUTE_IN_NAME(F)   ((F)->dlist[FILTER_IN].name)
 #define DISTRIBUTE_IN(F)        ((F)->dlist[FILTER_IN].alist)

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -358,19 +358,19 @@ extern void bgp_clear_stale_route(struct peer *, afi_t, safi_t);
 extern struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
 					 safi_t safi, struct prefix *p,
 					 struct prefix_rd *prd);
-extern struct bgp_path_info *bgp_info_lock(struct bgp_path_info *path);
-extern struct bgp_path_info *bgp_info_unlock(struct bgp_path_info *path);
-extern void bgp_info_add(struct bgp_node *rn, struct bgp_path_info *ri);
-extern void bgp_info_reap(struct bgp_node *rn, struct bgp_path_info *ri);
-extern void bgp_info_delete(struct bgp_node *rn, struct bgp_path_info *ri);
+extern struct bgp_path_info *bgp_path_info_lock(struct bgp_path_info *path);
+extern struct bgp_path_info *bgp_path_info_unlock(struct bgp_path_info *path);
+extern void bgp_path_info_add(struct bgp_node *rn, struct bgp_path_info *ri);
+extern void bgp_path_info_reap(struct bgp_node *rn, struct bgp_path_info *ri);
+extern void bgp_path_info_delete(struct bgp_node *rn, struct bgp_path_info *ri);
 extern struct bgp_path_info_extra *
-bgp_info_extra_get(struct bgp_path_info *path);
-extern void bgp_info_set_flag(struct bgp_node *rn, struct bgp_path_info *path,
-			      uint32_t flag);
-extern void bgp_info_unset_flag(struct bgp_node *rn, struct bgp_path_info *path,
-				uint32_t flag);
-extern void bgp_info_path_with_addpath_rx_str(struct bgp_path_info *ri,
-					      char *buf);
+bgp_path_info_extra_get(struct bgp_path_info *path);
+extern void bgp_path_info_set_flag(struct bgp_node *rn,
+				   struct bgp_path_info *path, uint32_t flag);
+extern void bgp_path_info_unset_flag(struct bgp_node *rn,
+				     struct bgp_path_info *path, uint32_t flag);
+extern void bgp_path_info_path_with_addpath_rx_str(struct bgp_path_info *ri,
+						   char *buf);
 
 extern int bgp_nlri_parse_ip(struct peer *, struct attr *, struct bgp_nlri *);
 
@@ -472,12 +472,14 @@ extern void bgp_process_queues_drain_immediate(void);
 extern struct bgp_node *bgp_afi_node_lookup(struct bgp_table *table, afi_t afi,
 					    safi_t safi, struct prefix *p,
 					    struct prefix_rd *prd);
-extern struct bgp_path_info *bgp_info_new(void);
-extern void bgp_info_restore(struct bgp_node *rn, struct bgp_path_info *path);
+extern struct bgp_path_info *bgp_path_info_new(void);
+extern void bgp_path_info_restore(struct bgp_node *rn,
+				  struct bgp_path_info *path);
 
-extern int bgp_info_cmp_compatible(struct bgp *bgp, struct bgp_path_info *new,
-				   struct bgp_path_info *exist, char *pfx_buf,
-				   afi_t afi, safi_t safi);
+extern int bgp_path_info_cmp_compatible(struct bgp *bgp,
+					struct bgp_path_info *new,
+					struct bgp_path_info *exist,
+					char *pfx_buf, afi_t afi, safi_t safi);
 extern void bgp_attr_add_gshut_community(struct attr *attr);
 
 extern void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -339,7 +339,7 @@ static inline int bgp_fibupd_safi(safi_t safi)
 }
 
 /* Prototypes. */
-extern void bgp_rib_remove(struct bgp_node *rn, struct bgp_path_info *ri,
+extern void bgp_rib_remove(struct bgp_node *rn, struct bgp_path_info *pi,
 			   struct peer *peer, afi_t afi, safi_t safi);
 extern void bgp_process_queue_init(void);
 extern void bgp_route_init(void);
@@ -360,16 +360,16 @@ extern struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
 					 struct prefix_rd *prd);
 extern struct bgp_path_info *bgp_path_info_lock(struct bgp_path_info *path);
 extern struct bgp_path_info *bgp_path_info_unlock(struct bgp_path_info *path);
-extern void bgp_path_info_add(struct bgp_node *rn, struct bgp_path_info *ri);
-extern void bgp_path_info_reap(struct bgp_node *rn, struct bgp_path_info *ri);
-extern void bgp_path_info_delete(struct bgp_node *rn, struct bgp_path_info *ri);
+extern void bgp_path_info_add(struct bgp_node *rn, struct bgp_path_info *pi);
+extern void bgp_path_info_reap(struct bgp_node *rn, struct bgp_path_info *pi);
+extern void bgp_path_info_delete(struct bgp_node *rn, struct bgp_path_info *pi);
 extern struct bgp_path_info_extra *
 bgp_path_info_extra_get(struct bgp_path_info *path);
 extern void bgp_path_info_set_flag(struct bgp_node *rn,
 				   struct bgp_path_info *path, uint32_t flag);
 extern void bgp_path_info_unset_flag(struct bgp_node *rn,
 				     struct bgp_path_info *path, uint32_t flag);
-extern void bgp_path_info_path_with_addpath_rx_str(struct bgp_path_info *ri,
+extern void bgp_path_info_path_with_addpath_rx_str(struct bgp_path_info *pi,
 						   char *buf);
 
 extern int bgp_nlri_parse_ip(struct peer *, struct attr *, struct bgp_nlri *);
@@ -461,7 +461,7 @@ extern int subgroup_process_announce_selected(struct update_subgroup *subgrp,
 					      uint32_t addpath_tx_id);
 
 extern int subgroup_announce_check(struct bgp_node *rn,
-				   struct bgp_path_info *ri,
+				   struct bgp_path_info *pi,
 				   struct update_subgroup *subgrp,
 				   struct prefix *p, struct attr *attr);
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -452,7 +452,7 @@ extern void route_vty_out_tmp(struct vty *vty, struct prefix *p,
 			      struct attr *attr, safi_t safi, bool use_json,
 			      json_object *json_ar);
 extern void route_vty_out_overlay(struct vty *vty, struct prefix *p,
-				  struct bgp_path_info *binfo, int display,
+				  struct bgp_path_info *path, int display,
 				  json_object *json);
 
 extern int subgroup_process_announce_selected(struct update_subgroup *subgrp,
@@ -495,7 +495,7 @@ extern void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 					struct prefix_rd *prd, afi_t afi,
 					safi_t safi, json_object *json);
 extern void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
-				 struct prefix *p, struct bgp_path_info *binfo,
+				 struct prefix *p, struct bgp_path_info *path,
 				 afi_t afi, safi_t safi,
 				 json_object *json_paths);
 extern int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, safi_t safi,

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -477,13 +477,13 @@ static route_map_result_t route_match_ip_next_hop(void *rule,
 						  void *object)
 {
 	struct access_list *alist;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct prefix_ipv4 p;
 
 	if (type == RMAP_BGP && prefix->family == AF_INET) {
-		bgp_info = object;
+		path = object;
 		p.family = AF_INET;
-		p.prefix = bgp_info->attr->nexthop;
+		p.prefix = path->attr->nexthop;
 		p.prefixlen = IPV4_MAX_BITLEN;
 
 		alist = access_list_lookup(AFI_IP, (char *)rule);
@@ -524,13 +524,13 @@ static route_map_result_t route_match_ip_route_source(void *rule,
 						      void *object)
 {
 	struct access_list *alist;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
 	if (type == RMAP_BGP && pfx->family == AF_INET) {
-		bgp_info = object;
-		peer = bgp_info->peer;
+		path = object;
+		peer = path->peer;
 
 		if (!peer || sockunion_family(&peer->su) != AF_INET)
 			return RMAP_NOMATCH;
@@ -610,13 +610,13 @@ route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
 				    route_map_object_t type, void *object)
 {
 	struct prefix_list *plist;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct prefix_ipv4 p;
 
 	if (type == RMAP_BGP && prefix->family == AF_INET) {
-		bgp_info = object;
+		path = object;
 		p.family = AF_INET;
-		p.prefix = bgp_info->attr->nexthop;
+		p.prefix = path->attr->nexthop;
 		p.prefixlen = IPV4_MAX_BITLEN;
 
 		plist = prefix_list_lookup(AFI_IP, (char *)rule);
@@ -651,19 +651,19 @@ static route_map_result_t
 route_match_ip_next_hop_type(void *rule, const struct prefix *prefix,
 			     route_map_object_t type, void *object)
 {
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP && prefix->family == AF_INET) {
-		bgp_info = (struct bgp_path_info *)object;
-		if (!bgp_info || !bgp_info->attr)
+		path = (struct bgp_path_info *)object;
+		if (!path || !path->attr)
 			return RMAP_DENYMATCH;
 
 		/* If nexthop interface's index can't be resolved and nexthop is
 		   set to any address then mark it as type `blackhole`.
 		   This logic works for matching kernel/static routes like:
 		   `ip route add blackhole 10.0.0.1`. */
-		if (bgp_info->attr->nexthop.s_addr == INADDR_ANY
-		    && !bgp_info->attr->nh_ifindex)
+		if (path->attr->nexthop.s_addr == INADDR_ANY
+		    && !path->attr->nh_ifindex)
 			return RMAP_MATCH;
 	}
 	return RMAP_NOMATCH;
@@ -692,13 +692,13 @@ route_match_ip_route_source_prefix_list(void *rule,
 					route_map_object_t type, void *object)
 {
 	struct prefix_list *plist;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
 	if (type == RMAP_BGP && prefix->family == AF_INET) {
-		bgp_info = object;
-		peer = bgp_info->peer;
+		path = object;
+		peer = path->peer;
 
 		if (!peer || sockunion_family(&peer->su) != AF_INET)
 			return RMAP_NOMATCH;
@@ -810,16 +810,16 @@ static route_map_result_t route_match_vni(void *rule,
 					  route_map_object_t type, void *object)
 {
 	vni_t vni = 0;
-	struct bgp_path_info *bgp_info = NULL;
+	struct bgp_path_info *path = NULL;
 
 	if (type == RMAP_BGP) {
 		vni = *((vni_t *)rule);
-		bgp_info = (struct bgp_path_info *)object;
+		path = (struct bgp_path_info *)object;
 
-		if (bgp_info->extra == NULL)
+		if (path->extra == NULL)
 			return RMAP_NOMATCH;
 
-		if (vni == label2vni(&bgp_info->extra->label[0]))
+		if (vni == label2vni(&path->extra->label[0]))
 			return RMAP_MATCH;
 	}
 
@@ -914,13 +914,13 @@ static route_map_result_t route_match_local_pref(void *rule,
 						 void *object)
 {
 	uint32_t *local_pref;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		local_pref = rule;
-		bgp_info = object;
+		path = object;
 
-		if (bgp_info->attr->local_pref == *local_pref)
+		if (path->attr->local_pref == *local_pref)
 			return RMAP_MATCH;
 		else
 			return RMAP_NOMATCH;
@@ -974,12 +974,12 @@ static route_map_result_t route_match_metric(void *rule,
 					     void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		rv = rule;
-		bgp_info = object;
-		return route_value_match(rv, bgp_info->attr->med);
+		path = object;
+		return route_value_match(rv, path->attr->med);
 	}
 	return RMAP_NOMATCH;
 }
@@ -999,17 +999,17 @@ static route_map_result_t route_match_aspath(void *rule,
 {
 
 	struct as_list *as_list;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		as_list = as_list_lookup((char *)rule);
 		if (as_list == NULL)
 			return RMAP_NOMATCH;
 
-		bgp_info = object;
+		path = object;
 
 		/* Perform match. */
-		return ((as_list_apply(as_list, bgp_info->attr->aspath)
+		return ((as_list_apply(as_list, path->attr->aspath)
 			 == AS_FILTER_DENY)
 				? RMAP_NOMATCH
 				: RMAP_MATCH);
@@ -1047,11 +1047,11 @@ static route_map_result_t route_match_community(void *rule,
 						void *object)
 {
 	struct community_list *list;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct rmap_community *rcom;
 
 	if (type == RMAP_BGP) {
-		bgp_info = object;
+		path = object;
 		rcom = rule;
 
 		list = community_list_lookup(bgp_clist, rcom->name,
@@ -1060,12 +1060,11 @@ static route_map_result_t route_match_community(void *rule,
 			return RMAP_NOMATCH;
 
 		if (rcom->exact) {
-			if (community_list_exact_match(
-				    bgp_info->attr->community, list))
+			if (community_list_exact_match(path->attr->community,
+						       list))
 				return RMAP_MATCH;
 		} else {
-			if (community_list_match(bgp_info->attr->community,
-						 list))
+			if (community_list_match(path->attr->community, list))
 				return RMAP_MATCH;
 		}
 	}
@@ -1115,11 +1114,11 @@ static route_map_result_t route_match_lcommunity(void *rule,
 						 void *object)
 {
 	struct community_list *list;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct rmap_community *rcom;
 
 	if (type == RMAP_BGP) {
-		bgp_info = object;
+		path = object;
 		rcom = rule;
 
 		list = community_list_lookup(bgp_clist, rcom->name,
@@ -1127,7 +1126,7 @@ static route_map_result_t route_match_lcommunity(void *rule,
 		if (!list)
 			return RMAP_NOMATCH;
 
-		if (lcommunity_list_match(bgp_info->attr->lcommunity, list))
+		if (lcommunity_list_match(path->attr->lcommunity, list))
 			return RMAP_MATCH;
 	}
 	return RMAP_NOMATCH;
@@ -1176,17 +1175,17 @@ static route_map_result_t route_match_ecommunity(void *rule,
 						 void *object)
 {
 	struct community_list *list;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
-		bgp_info = object;
+		path = object;
 
 		list = community_list_lookup(bgp_clist, (char *)rule,
 					     EXTCOMMUNITY_LIST_MASTER);
 		if (!list)
 			return RMAP_NOMATCH;
 
-		if (ecommunity_list_match(bgp_info->attr->ecommunity, list))
+		if (ecommunity_list_match(path->attr->ecommunity, list))
 			return RMAP_MATCH;
 	}
 	return RMAP_NOMATCH;
@@ -1219,13 +1218,13 @@ static route_map_result_t route_match_origin(void *rule,
 					     void *object)
 {
 	uint8_t *origin;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		origin = rule;
-		bgp_info = object;
+		path = object;
 
-		if (bgp_info->attr->origin == *origin)
+		if (path->attr->origin == *origin)
 			return RMAP_MATCH;
 	}
 
@@ -1368,14 +1367,13 @@ static route_map_result_t route_match_tag(void *rule,
 					  route_map_object_t type, void *object)
 {
 	route_tag_t *tag;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		tag = rule;
-		bgp_info = object;
+		path = object;
 
-		return ((bgp_info->attr->tag == *tag) ? RMAP_MATCH
-						      : RMAP_NOMATCH);
+		return ((path->attr->tag == *tag) ? RMAP_MATCH : RMAP_NOMATCH);
 	}
 
 	return RMAP_NOMATCH;
@@ -1402,15 +1400,15 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 					       void *object)
 {
 	struct rmap_ip_nexthop_set *rins = rule;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct peer *peer;
 
 	if (type == RMAP_BGP) {
-		bgp_info = object;
-		peer = bgp_info->peer;
+		path = object;
+		peer = path->peer;
 
 		if (rins->unchanged) {
-			SET_FLAG(bgp_info->attr->rmap_change_flags,
+			SET_FLAG(path->attr->rmap_change_flags,
 				 BATTR_RMAP_NEXTHOP_UNCHANGED);
 		} else if (rins->peer_address) {
 			if ((CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
@@ -1418,9 +1416,9 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 					   PEER_RMAP_TYPE_IMPORT))
 			    && peer->su_remote
 			    && sockunion_family(peer->su_remote) == AF_INET) {
-				bgp_info->attr->nexthop.s_addr =
+				path->attr->nexthop.s_addr =
 					sockunion2ip(peer->su_remote);
-				bgp_info->attr->flag |=
+				path->attr->flag |=
 					ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
 			} else if (CHECK_FLAG(peer->rmap_type,
 					      PEER_RMAP_TYPE_OUT)) {
@@ -1430,20 +1428,19 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 				 * needs to be done.
 				 * Also, clear the value.
 				 */
-				SET_FLAG(bgp_info->attr->rmap_change_flags,
+				SET_FLAG(path->attr->rmap_change_flags,
 					 BATTR_RMAP_NEXTHOP_PEER_ADDRESS);
-				bgp_info->attr->nexthop.s_addr = 0;
+				path->attr->nexthop.s_addr = 0;
 			}
 		} else {
 			/* Set next hop value. */
-			bgp_info->attr->flag |=
-				ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
-			bgp_info->attr->nexthop = *rins->address;
-			SET_FLAG(bgp_info->attr->rmap_change_flags,
+			path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
+			path->attr->nexthop = *rins->address;
+			SET_FLAG(path->attr->rmap_change_flags,
 				 BATTR_RMAP_IPV4_NHOP_CHANGED);
 			/* case for MP-BGP : MPLS VPN */
-			bgp_info->attr->mp_nexthop_global_in = *rins->address;
-			bgp_info->attr->mp_nexthop_len = sizeof(*rins->address);
+			path->attr->mp_nexthop_global_in = *rins->address;
+			path->attr->mp_nexthop_len = sizeof(*rins->address);
 		}
 	}
 
@@ -1510,21 +1507,21 @@ static route_map_result_t route_set_local_pref(void *rule,
 					       void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	uint32_t locpref = 0;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
 		rv = rule;
-		bgp_info = object;
+		path = object;
 
 		/* Set local preference value. */
-		if (bgp_info->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF))
-			locpref = bgp_info->attr->local_pref;
+		if (path->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF))
+			locpref = path->attr->local_pref;
 
-		bgp_info->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF);
-		bgp_info->attr->local_pref =
-			route_value_adjust(rv, locpref, bgp_info->peer);
+		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF);
+		path->attr->local_pref =
+			route_value_adjust(rv, locpref, path->peer);
 	}
 
 	return RMAP_OKAY;
@@ -1545,16 +1542,15 @@ static route_map_result_t route_set_weight(void *rule,
 					   void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
 		rv = rule;
-		bgp_info = object;
+		path = object;
 
 		/* Set weight value. */
-		bgp_info->attr->weight =
-			route_value_adjust(rv, 0, bgp_info->peer);
+		path->attr->weight = route_value_adjust(rv, 0, path->peer);
 	}
 
 	return RMAP_OKAY;
@@ -1574,21 +1570,19 @@ static route_map_result_t route_set_metric(void *rule,
 					   void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	uint32_t med = 0;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
 		rv = rule;
-		bgp_info = object;
+		path = object;
 
-		if (bgp_info->attr->flag
-		    & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC))
-			med = bgp_info->attr->med;
+		if (path->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC))
+			med = path->attr->med;
 
-		bgp_info->attr->med =
-			route_value_adjust(rv, med, bgp_info->peer);
-		bgp_info->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
+		path->attr->med = route_value_adjust(rv, med, path->peer);
+		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC);
 	}
 	return RMAP_OKAY;
 }
@@ -1608,15 +1602,15 @@ static route_map_result_t route_set_aspath_prepend(void *rule,
 {
 	struct aspath *aspath;
 	struct aspath *new;
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
-		binfo = object;
+		path = object;
 
-		if (binfo->attr->aspath->refcnt)
-			new = aspath_dup(binfo->attr->aspath);
+		if (path->attr->aspath->refcnt)
+			new = aspath_dup(path->attr->aspath);
 		else
-			new = binfo->attr->aspath;
+			new = path->attr->aspath;
 
 		if ((uintptr_t)rule > 10) {
 			aspath = rule;
@@ -1624,11 +1618,11 @@ static route_map_result_t route_set_aspath_prepend(void *rule,
 		} else {
 			as_t as = aspath_leftmost(new);
 			if (!as)
-				as = binfo->peer->as;
+				as = path->peer->as;
 			new = aspath_add_seq_n(new, as, (uintptr_t)rule);
 		}
 
-		binfo->attr->aspath = new;
+		path->attr->aspath = new;
 	}
 
 	return RMAP_OKAY;
@@ -1670,16 +1664,16 @@ static route_map_result_t route_set_aspath_exclude(void *rule,
 						   void *object)
 {
 	struct aspath *new_path, *exclude_path;
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		exclude_path = rule;
-		binfo = object;
-		if (binfo->attr->aspath->refcnt)
-			new_path = aspath_dup(binfo->attr->aspath);
+		path = object;
+		if (path->attr->aspath->refcnt)
+			new_path = aspath_dup(path->attr->aspath);
 		else
-			new_path = binfo->attr->aspath;
-		binfo->attr->aspath =
+			new_path = path->attr->aspath;
+		path->attr->aspath =
 			aspath_filter_exclude(new_path, exclude_path);
 	}
 	return RMAP_OKAY;
@@ -1705,7 +1699,7 @@ static route_map_result_t route_set_community(void *rule,
 					      void *object)
 {
 	struct rmap_com_set *rcs;
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 	struct attr *attr;
 	struct community *new = NULL;
 	struct community *old;
@@ -1713,8 +1707,8 @@ static route_map_result_t route_set_community(void *rule,
 
 	if (type == RMAP_BGP) {
 		rcs = rule;
-		binfo = object;
-		attr = binfo->attr;
+		path = object;
+		attr = path->attr;
 		old = attr->community;
 
 		/* "none" case.  */
@@ -1821,7 +1815,7 @@ static route_map_result_t route_set_lcommunity(void *rule,
 					       void *object)
 {
 	struct rmap_lcom_set *rcs;
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 	struct attr *attr;
 	struct lcommunity *new = NULL;
 	struct lcommunity *old;
@@ -1829,8 +1823,8 @@ static route_map_result_t route_set_lcommunity(void *rule,
 
 	if (type == RMAP_BGP) {
 		rcs = rule;
-		binfo = object;
-		attr = binfo->attr;
+		path = object;
+		attr = path->attr;
 		old = attr->lcommunity;
 
 		/* "none" case.  */
@@ -1937,16 +1931,16 @@ static route_map_result_t route_set_lcommunity_delete(void *rule,
 	struct lcommunity *merge;
 	struct lcommunity *new;
 	struct lcommunity *old;
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		if (!rule)
 			return RMAP_OKAY;
 
-		binfo = object;
+		path = object;
 		list = community_list_lookup(bgp_clist, rule,
 					     LARGE_COMMUNITY_LIST_MASTER);
-		old = binfo->attr->lcommunity;
+		old = path->attr->lcommunity;
 
 		if (list && old) {
 			merge = lcommunity_list_match_delete(
@@ -1963,13 +1957,13 @@ static route_map_result_t route_set_lcommunity_delete(void *rule,
 				lcommunity_free(&old);
 
 			if (new->size == 0) {
-				binfo->attr->lcommunity = NULL;
-				binfo->attr->flag &= ~ATTR_FLAG_BIT(
+				path->attr->lcommunity = NULL;
+				path->attr->flag &= ~ATTR_FLAG_BIT(
 					BGP_ATTR_LARGE_COMMUNITIES);
 				lcommunity_free(&new);
 			} else {
-				binfo->attr->lcommunity = new;
-				binfo->attr->flag |= ATTR_FLAG_BIT(
+				path->attr->lcommunity = new;
+				path->attr->flag |= ATTR_FLAG_BIT(
 					BGP_ATTR_LARGE_COMMUNITIES);
 			}
 		}
@@ -2022,16 +2016,16 @@ static route_map_result_t route_set_community_delete(
 	struct community *merge;
 	struct community *new;
 	struct community *old;
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		if (!rule)
 			return RMAP_OKAY;
 
-		binfo = object;
+		path = object;
 		list = community_list_lookup(bgp_clist, rule,
 					     COMMUNITY_LIST_MASTER);
-		old = binfo->attr->community;
+		old = path->attr->community;
 
 		if (list && old) {
 			merge = community_list_match_delete(community_dup(old),
@@ -2048,13 +2042,13 @@ static route_map_result_t route_set_community_delete(
 				community_free(old);
 
 			if (new->size == 0) {
-				binfo->attr->community = NULL;
-				binfo->attr->flag &=
+				path->attr->community = NULL;
+				path->attr->flag &=
 					~ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
 				community_free(new);
 			} else {
-				binfo->attr->community = new;
-				binfo->attr->flag |=
+				path->attr->community = new;
+				path->attr->flag |=
 					ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
 			}
 		}
@@ -2104,17 +2098,17 @@ static route_map_result_t route_set_ecommunity(void *rule,
 	struct ecommunity *ecom;
 	struct ecommunity *new_ecom;
 	struct ecommunity *old_ecom;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		ecom = rule;
-		bgp_info = object;
+		path = object;
 
 		if (!ecom)
 			return RMAP_OKAY;
 
 		/* We assume additive for Extended Community. */
-		old_ecom = bgp_info->attr->ecommunity;
+		old_ecom = path->attr->ecommunity;
 
 		if (old_ecom) {
 			new_ecom = ecommunity_merge(ecommunity_dup(old_ecom),
@@ -2130,9 +2124,9 @@ static route_map_result_t route_set_ecommunity(void *rule,
 			new_ecom = ecommunity_dup(ecom);
 
 		/* will be intern()'d or attr_flush()'d by bgp_update_main() */
-		bgp_info->attr->ecommunity = new_ecom;
+		path->attr->ecommunity = new_ecom;
 
-		bgp_info->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES);
+		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES);
 	}
 	return RMAP_OKAY;
 }
@@ -2190,13 +2184,13 @@ static route_map_result_t route_set_origin(void *rule,
 					   void *object)
 {
 	uint8_t *origin;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		origin = rule;
-		bgp_info = object;
+		path = object;
 
-		bgp_info->attr->origin = *origin;
+		path->attr->origin = *origin;
 	}
 
 	return RMAP_OKAY;
@@ -2239,12 +2233,11 @@ static route_map_result_t route_set_atomic_aggregate(void *rule,
 						     route_map_object_t type,
 						     void *object)
 {
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
-		bgp_info = object;
-		bgp_info->attr->flag |=
-			ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE);
+		path = object;
+		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_ATOMIC_AGGREGATE);
 	}
 
 	return RMAP_OKAY;
@@ -2279,16 +2272,16 @@ static route_map_result_t route_set_aggregator_as(void *rule,
 						  route_map_object_t type,
 						  void *object)
 {
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct aggregator *aggregator;
 
 	if (type == RMAP_BGP) {
-		bgp_info = object;
+		path = object;
 		aggregator = rule;
 
-		bgp_info->attr->aggregator_as = aggregator->as;
-		bgp_info->attr->aggregator_addr = aggregator->address;
-		bgp_info->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
+		path->attr->aggregator_as = aggregator->as;
+		path->attr->aggregator_addr = aggregator->address;
+		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
 	}
 
 	return RMAP_OKAY;
@@ -2333,14 +2326,14 @@ static route_map_result_t route_set_tag(void *rule,
 					route_map_object_t type, void *object)
 {
 	route_tag_t *tag;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		tag = rule;
-		bgp_info = object;
+		path = object;
 
 		/* Set tag value */
-		bgp_info->attr->tag = *tag;
+		path->attr->tag = *tag;
 	}
 
 	return RMAP_OKAY;
@@ -2359,20 +2352,19 @@ static route_map_result_t route_set_label_index(void *rule,
 						void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	uint32_t label_index;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
 		rv = rule;
-		bgp_info = object;
+		path = object;
 
 		/* Set label-index value. */
 		label_index = rv->value;
 		if (label_index) {
-			bgp_info->attr->label_index = label_index;
-			bgp_info->attr->flag |=
-				ATTR_FLAG_BIT(BGP_ATTR_PREFIX_SID);
+			path->attr->label_index = label_index;
+			path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_PREFIX_SID);
 		}
 	}
 
@@ -2429,17 +2421,17 @@ static route_map_result_t route_match_ipv6_next_hop(void *rule,
 						    void *object)
 {
 	struct in6_addr *addr = rule;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
-		bgp_info = object;
+		path = object;
 
-		if (IPV6_ADDR_SAME(&bgp_info->attr->mp_nexthop_global, addr))
+		if (IPV6_ADDR_SAME(&path->attr->mp_nexthop_global, addr))
 			return RMAP_MATCH;
 
-		if (bgp_info->attr->mp_nexthop_len
+		if (path->attr->mp_nexthop_len
 			    == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL
-		    && IPV6_ADDR_SAME(&bgp_info->attr->mp_nexthop_local, rule))
+		    && IPV6_ADDR_SAME(&path->attr->mp_nexthop_local, rule))
 			return RMAP_MATCH;
 
 		return RMAP_NOMATCH;
@@ -2514,16 +2506,16 @@ static route_map_result_t
 route_match_ipv6_next_hop_type(void *rule, const struct prefix *prefix,
 			      route_map_object_t type, void *object)
 {
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct in6_addr *addr = rule;
 
 	if (type == RMAP_BGP && prefix->family == AF_INET6) {
-		bgp_info = (struct bgp_path_info *)object;
-		if (!bgp_info || !bgp_info->attr)
+		path = (struct bgp_path_info *)object;
+		if (!path || !path->attr)
 			return RMAP_DENYMATCH;
 
-		if (IPV6_ADDR_SAME(&bgp_info->attr->mp_nexthop_global, addr)
-		    && !bgp_info->attr->nh_ifindex)
+		if (IPV6_ADDR_SAME(&path->attr->mp_nexthop_global, addr)
+		    && !path->attr->nh_ifindex)
 			return RMAP_MATCH;
 	}
 	return RMAP_NOMATCH;
@@ -2564,22 +2556,21 @@ static route_map_result_t route_set_ipv6_nexthop_global(void *rule,
 							void *object)
 {
 	struct in6_addr *address;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
 		address = rule;
-		bgp_info = object;
+		path = object;
 
 		/* Set next hop value. */
-		bgp_info->attr->mp_nexthop_global = *address;
+		path->attr->mp_nexthop_global = *address;
 
 		/* Set nexthop length. */
-		if (bgp_info->attr->mp_nexthop_len == 0)
-			bgp_info->attr->mp_nexthop_len =
-				BGP_ATTR_NHLEN_IPV6_GLOBAL;
+		if (path->attr->mp_nexthop_len == 0)
+			path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
 
-		SET_FLAG(bgp_info->attr->rmap_change_flags,
+		SET_FLAG(path->attr->rmap_change_flags,
 			 BATTR_RMAP_IPV6_GLOBAL_NHOP_CHANGED);
 	}
 
@@ -2622,25 +2613,25 @@ static route_map_result_t
 route_set_ipv6_nexthop_prefer_global(void *rule, const struct prefix *prefix,
 				     route_map_object_t type, void *object)
 {
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct peer *peer;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
-		bgp_info = object;
-		peer = bgp_info->peer;
+		path = object;
+		peer = path->peer;
 
 		if ((CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
 		     || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IMPORT))
 		    && peer->su_remote
 		    && sockunion_family(peer->su_remote) == AF_INET6) {
 			/* Set next hop preference to global */
-			bgp_info->attr->mp_nexthop_prefer_global = TRUE;
-			SET_FLAG(bgp_info->attr->rmap_change_flags,
+			path->attr->mp_nexthop_prefer_global = TRUE;
+			SET_FLAG(path->attr->rmap_change_flags,
 				 BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED);
 		} else {
-			bgp_info->attr->mp_nexthop_prefer_global = FALSE;
-			SET_FLAG(bgp_info->attr->rmap_change_flags,
+			path->attr->mp_nexthop_prefer_global = FALSE;
+			SET_FLAG(path->attr->rmap_change_flags,
 				 BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED);
 		}
 	}
@@ -2678,23 +2669,23 @@ static route_map_result_t route_set_ipv6_nexthop_local(void *rule,
 						       void *object)
 {
 	struct in6_addr *address;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
 		address = rule;
-		bgp_info = object;
+		path = object;
 
 		/* Set next hop value. */
-		bgp_info->attr->mp_nexthop_local = *address;
+		path->attr->mp_nexthop_local = *address;
 
 		/* Set nexthop length. */
-		if (bgp_info->attr->mp_nexthop_len
+		if (path->attr->mp_nexthop_len
 		    != BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
-			bgp_info->attr->mp_nexthop_len =
+			path->attr->mp_nexthop_len =
 				BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
 
-		SET_FLAG(bgp_info->attr->rmap_change_flags,
+		SET_FLAG(path->attr->rmap_change_flags,
 			 BATTR_RMAP_IPV6_LL_NHOP_CHANGED);
 	}
 
@@ -2741,13 +2732,13 @@ static route_map_result_t route_set_ipv6_nexthop_peer(void *rule,
 						      void *object)
 {
 	struct in6_addr peer_address;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 	struct peer *peer;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
-		bgp_info = object;
-		peer = bgp_info->peer;
+		path = object;
+		peer = path->peer;
 
 		if ((CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
 		     || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IMPORT))
@@ -2756,14 +2747,13 @@ static route_map_result_t route_set_ipv6_nexthop_peer(void *rule,
 			peer_address = peer->su_remote->sin6.sin6_addr;
 			/* Set next hop value and length in attribute. */
 			if (IN6_IS_ADDR_LINKLOCAL(&peer_address)) {
-				bgp_info->attr->mp_nexthop_local = peer_address;
-				if (bgp_info->attr->mp_nexthop_len != 32)
-					bgp_info->attr->mp_nexthop_len = 32;
+				path->attr->mp_nexthop_local = peer_address;
+				if (path->attr->mp_nexthop_len != 32)
+					path->attr->mp_nexthop_len = 32;
 			} else {
-				bgp_info->attr->mp_nexthop_global =
-					peer_address;
-				if (bgp_info->attr->mp_nexthop_len == 0)
-					bgp_info->attr->mp_nexthop_len = 16;
+				path->attr->mp_nexthop_global = peer_address;
+				if (path->attr->mp_nexthop_len == 0)
+					path->attr->mp_nexthop_len = 16;
 			}
 
 		} else if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_OUT)) {
@@ -2776,12 +2766,12 @@ static route_map_result_t route_set_ipv6_nexthop_peer(void *rule,
 			 * nexthops, whether we send one or both is determined
 			 * elsewhere.
 			 */
-			SET_FLAG(bgp_info->attr->rmap_change_flags,
+			SET_FLAG(path->attr->rmap_change_flags,
 				 BATTR_RMAP_NEXTHOP_PEER_ADDRESS);
 			/* clear next hop value. */
-			memset(&(bgp_info->attr->mp_nexthop_global), 0,
+			memset(&(path->attr->mp_nexthop_global), 0,
 			       sizeof(struct in6_addr));
-			memset(&(bgp_info->attr->mp_nexthop_local), 0,
+			memset(&(path->attr->mp_nexthop_local), 0,
 			       sizeof(struct in6_addr));
 		}
 	}
@@ -2820,16 +2810,16 @@ static route_map_result_t route_set_vpnv4_nexthop(void *rule,
 						  void *object)
 {
 	struct in_addr *address;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
 		address = rule;
-		bgp_info = object;
+		path = object;
 
 		/* Set next hop value. */
-		bgp_info->attr->mp_nexthop_global_in = *address;
-		bgp_info->attr->mp_nexthop_len = 4;
+		path->attr->mp_nexthop_global_in = *address;
+		path->attr->mp_nexthop_len = 4;
 	}
 
 	return RMAP_OKAY;
@@ -2860,17 +2850,17 @@ static route_map_result_t route_set_vpnv6_nexthop(void *rule,
 						  void *object)
 {
 	struct in6_addr *address;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
 		address = rule;
-		bgp_info = object;
+		path = object;
 
 		/* Set next hop value. */
-		memcpy(&bgp_info->attr->mp_nexthop_global, address,
+		memcpy(&path->attr->mp_nexthop_global, address,
 		       sizeof(struct in6_addr));
-		bgp_info->attr->mp_nexthop_len = BGP_ATTR_NHLEN_VPNV6_GLOBAL;
+		path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_VPNV6_GLOBAL;
 	}
 
 	return RMAP_OKAY;
@@ -2916,14 +2906,14 @@ static route_map_result_t route_set_originator_id(void *rule,
 						  void *object)
 {
 	struct in_addr *address;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
 		address = rule;
-		bgp_info = object;
+		path = object;
 
-		bgp_info->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID);
-		bgp_info->attr->originator_id = *address;
+		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID);
+		path->attr->originator_id = *address;
 	}
 
 	return RMAP_OKAY;

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -233,7 +233,7 @@ struct bgp_match_peer_compiled {
 /* 'match peer (A.B.C.D|X:X::X:X|WORD)' */
 
 /* Compares the peer specified in the 'match peer' clause with the peer
-    received in bgp_info->peer. If it is the same, or if the peer structure
+    received in bgp_path_info->peer. If it is the same, or if the peer structure
     received is a peer_group containing it, returns RMAP_MATCH. */
 static route_map_result_t route_match_peer(void *rule,
 					   const struct prefix *prefix,
@@ -354,7 +354,7 @@ static route_map_result_t route_match_command(void *rule,
 
 	zlog_debug("Set up prefix table");
 	/*
-	 * Setup the bgp_info information
+	 * Setup the bgp_path_info information
 	 */
 	lua_newtable(L);
 	lua_pushinteger(L, info->attr->med);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -251,7 +251,7 @@ static route_map_result_t route_match_peer(void *rule,
 	if (type == RMAP_BGP) {
 		pc = rule;
 		su = &pc->su;
-		peer = ((struct bgp_info *)object)->peer;
+		peer = ((struct bgp_path_info *)object)->peer;
 
 		if (pc->interface) {
 			if (!peer->conf_if)
@@ -341,7 +341,7 @@ static route_map_result_t route_match_command(void *rule,
 	u_int32_t locpref = 0;
 	u_int32_t newlocpref = 0;
 	enum lua_rm_status lrm_status;
-	struct bgp_info *info = (struct bgp_info *)object;
+	struct bgp_path_info *info = (struct bgp_path_info *)object;
 	lua_State *L = lua_initialize("/etc/frr/lua.scr");
 
 	if (L == NULL)
@@ -477,7 +477,7 @@ static route_map_result_t route_match_ip_next_hop(void *rule,
 						  void *object)
 {
 	struct access_list *alist;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct prefix_ipv4 p;
 
 	if (type == RMAP_BGP && prefix->family == AF_INET) {
@@ -524,7 +524,7 @@ static route_map_result_t route_match_ip_route_source(void *rule,
 						      void *object)
 {
 	struct access_list *alist;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
@@ -610,7 +610,7 @@ route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
 				    route_map_object_t type, void *object)
 {
 	struct prefix_list *plist;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct prefix_ipv4 p;
 
 	if (type == RMAP_BGP && prefix->family == AF_INET) {
@@ -651,10 +651,10 @@ static route_map_result_t
 route_match_ip_next_hop_type(void *rule, const struct prefix *prefix,
 			     route_map_object_t type, void *object)
 {
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP && prefix->family == AF_INET) {
-		bgp_info = (struct bgp_info *)object;
+		bgp_info = (struct bgp_path_info *)object;
 		if (!bgp_info || !bgp_info->attr)
 			return RMAP_DENYMATCH;
 
@@ -692,7 +692,7 @@ route_match_ip_route_source_prefix_list(void *rule,
 					route_map_object_t type, void *object)
 {
 	struct prefix_list *plist;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct peer *peer;
 	struct prefix_ipv4 p;
 
@@ -810,11 +810,11 @@ static route_map_result_t route_match_vni(void *rule,
 					  route_map_object_t type, void *object)
 {
 	vni_t vni = 0;
-	struct bgp_info *bgp_info = NULL;
+	struct bgp_path_info *bgp_info = NULL;
 
 	if (type == RMAP_BGP) {
 		vni = *((vni_t *)rule);
-		bgp_info = (struct bgp_info *)object;
+		bgp_info = (struct bgp_path_info *)object;
 
 		if (bgp_info->extra == NULL)
 			return RMAP_NOMATCH;
@@ -914,7 +914,7 @@ static route_map_result_t route_match_local_pref(void *rule,
 						 void *object)
 {
 	uint32_t *local_pref;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		local_pref = rule;
@@ -974,7 +974,7 @@ static route_map_result_t route_match_metric(void *rule,
 					     void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		rv = rule;
@@ -999,7 +999,7 @@ static route_map_result_t route_match_aspath(void *rule,
 {
 
 	struct as_list *as_list;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		as_list = as_list_lookup((char *)rule);
@@ -1047,7 +1047,7 @@ static route_map_result_t route_match_community(void *rule,
 						void *object)
 {
 	struct community_list *list;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct rmap_community *rcom;
 
 	if (type == RMAP_BGP) {
@@ -1115,7 +1115,7 @@ static route_map_result_t route_match_lcommunity(void *rule,
 						 void *object)
 {
 	struct community_list *list;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct rmap_community *rcom;
 
 	if (type == RMAP_BGP) {
@@ -1176,7 +1176,7 @@ static route_map_result_t route_match_ecommunity(void *rule,
 						 void *object)
 {
 	struct community_list *list;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		bgp_info = object;
@@ -1219,7 +1219,7 @@ static route_map_result_t route_match_origin(void *rule,
 					     void *object)
 {
 	uint8_t *origin;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		origin = rule;
@@ -1322,7 +1322,7 @@ static route_map_result_t route_match_interface(void *rule,
 						void *object)
 {
 	struct interface *ifp;
-	struct bgp_info *info;
+	struct bgp_path_info *info;
 
 	if (type == RMAP_BGP) {
 		info = object;
@@ -1368,7 +1368,7 @@ static route_map_result_t route_match_tag(void *rule,
 					  route_map_object_t type, void *object)
 {
 	route_tag_t *tag;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		tag = rule;
@@ -1402,7 +1402,7 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 					       void *object)
 {
 	struct rmap_ip_nexthop_set *rins = rule;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct peer *peer;
 
 	if (type == RMAP_BGP) {
@@ -1510,7 +1510,7 @@ static route_map_result_t route_set_local_pref(void *rule,
 					       void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	uint32_t locpref = 0;
 
 	if (type == RMAP_BGP) {
@@ -1545,7 +1545,7 @@ static route_map_result_t route_set_weight(void *rule,
 					   void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
@@ -1574,7 +1574,7 @@ static route_map_result_t route_set_metric(void *rule,
 					   void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	uint32_t med = 0;
 
 	if (type == RMAP_BGP) {
@@ -1608,7 +1608,7 @@ static route_map_result_t route_set_aspath_prepend(void *rule,
 {
 	struct aspath *aspath;
 	struct aspath *new;
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 
 	if (type == RMAP_BGP) {
 		binfo = object;
@@ -1670,7 +1670,7 @@ static route_map_result_t route_set_aspath_exclude(void *rule,
 						   void *object)
 {
 	struct aspath *new_path, *exclude_path;
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 
 	if (type == RMAP_BGP) {
 		exclude_path = rule;
@@ -1705,7 +1705,7 @@ static route_map_result_t route_set_community(void *rule,
 					      void *object)
 {
 	struct rmap_com_set *rcs;
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 	struct attr *attr;
 	struct community *new = NULL;
 	struct community *old;
@@ -1821,7 +1821,7 @@ static route_map_result_t route_set_lcommunity(void *rule,
 					       void *object)
 {
 	struct rmap_lcom_set *rcs;
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 	struct attr *attr;
 	struct lcommunity *new = NULL;
 	struct lcommunity *old;
@@ -1937,7 +1937,7 @@ static route_map_result_t route_set_lcommunity_delete(void *rule,
 	struct lcommunity *merge;
 	struct lcommunity *new;
 	struct lcommunity *old;
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 
 	if (type == RMAP_BGP) {
 		if (!rule)
@@ -2022,7 +2022,7 @@ static route_map_result_t route_set_community_delete(
 	struct community *merge;
 	struct community *new;
 	struct community *old;
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 
 	if (type == RMAP_BGP) {
 		if (!rule)
@@ -2104,7 +2104,7 @@ static route_map_result_t route_set_ecommunity(void *rule,
 	struct ecommunity *ecom;
 	struct ecommunity *new_ecom;
 	struct ecommunity *old_ecom;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		ecom = rule;
@@ -2190,7 +2190,7 @@ static route_map_result_t route_set_origin(void *rule,
 					   void *object)
 {
 	uint8_t *origin;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		origin = rule;
@@ -2239,7 +2239,7 @@ static route_map_result_t route_set_atomic_aggregate(void *rule,
 						     route_map_object_t type,
 						     void *object)
 {
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		bgp_info = object;
@@ -2279,7 +2279,7 @@ static route_map_result_t route_set_aggregator_as(void *rule,
 						  route_map_object_t type,
 						  void *object)
 {
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct aggregator *aggregator;
 
 	if (type == RMAP_BGP) {
@@ -2327,13 +2327,13 @@ struct route_map_rule_cmd route_set_aggregator_as_cmd = {
 	route_set_aggregator_as_compile, route_set_aggregator_as_free,
 };
 
-/* Set tag to object. object must be pointer to struct bgp_info */
+/* Set tag to object. object must be pointer to struct bgp_path_info */
 static route_map_result_t route_set_tag(void *rule,
 					const struct prefix *prefix,
 					route_map_object_t type, void *object)
 {
 	route_tag_t *tag;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		tag = rule;
@@ -2352,14 +2352,14 @@ static struct route_map_rule_cmd route_set_tag_cmd = {
 	route_map_rule_tag_free,
 };
 
-/* Set label-index to object. object must be pointer to struct bgp_info */
+/* Set label-index to object. object must be pointer to struct bgp_path_info */
 static route_map_result_t route_set_label_index(void *rule,
 						const struct prefix *prefix,
 						route_map_object_t type,
 						void *object)
 {
 	struct rmap_value *rv;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	uint32_t label_index;
 
 	if (type == RMAP_BGP) {
@@ -2429,7 +2429,7 @@ static route_map_result_t route_match_ipv6_next_hop(void *rule,
 						    void *object)
 {
 	struct in6_addr *addr = rule;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		bgp_info = object;
@@ -2514,11 +2514,11 @@ static route_map_result_t
 route_match_ipv6_next_hop_type(void *rule, const struct prefix *prefix,
 			      route_map_object_t type, void *object)
 {
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct in6_addr *addr = rule;
 
 	if (type == RMAP_BGP && prefix->family == AF_INET6) {
-		bgp_info = (struct bgp_info *)object;
+		bgp_info = (struct bgp_path_info *)object;
 		if (!bgp_info || !bgp_info->attr)
 			return RMAP_DENYMATCH;
 
@@ -2564,7 +2564,7 @@ static route_map_result_t route_set_ipv6_nexthop_global(void *rule,
 							void *object)
 {
 	struct in6_addr *address;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
@@ -2622,7 +2622,7 @@ static route_map_result_t
 route_set_ipv6_nexthop_prefer_global(void *rule, const struct prefix *prefix,
 				     route_map_object_t type, void *object)
 {
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct peer *peer;
 
 	if (type == RMAP_BGP) {
@@ -2678,7 +2678,7 @@ static route_map_result_t route_set_ipv6_nexthop_local(void *rule,
 						       void *object)
 {
 	struct in6_addr *address;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
@@ -2741,7 +2741,7 @@ static route_map_result_t route_set_ipv6_nexthop_peer(void *rule,
 						      void *object)
 {
 	struct in6_addr peer_address;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 	struct peer *peer;
 
 	if (type == RMAP_BGP) {
@@ -2820,7 +2820,7 @@ static route_map_result_t route_set_vpnv4_nexthop(void *rule,
 						  void *object)
 {
 	struct in_addr *address;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
@@ -2860,7 +2860,7 @@ static route_map_result_t route_set_vpnv6_nexthop(void *rule,
 						  void *object)
 {
 	struct in6_addr *address;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		/* Fetch routemap's rule information. */
@@ -2916,7 +2916,7 @@ static route_map_result_t route_set_originator_id(void *rule,
 						  void *object)
 {
 	struct in_addr *address;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		address = rule;

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -217,12 +217,12 @@ static route_map_result_t route_match(void *rule, const struct prefix *prefix,
 				      route_map_object_t type, void *object)
 {
 	int *rpki_status = rule;
-	struct bgp_path_info *bgp_info;
+	struct bgp_path_info *path;
 
 	if (type == RMAP_BGP) {
-		bgp_info = object;
+		path = object;
 
-		if (rpki_validate_prefix(bgp_info->peer, bgp_info->attr, prefix)
+		if (rpki_validate_prefix(path->peer, path->attr, prefix)
 		    == *rpki_status) {
 			return RMAP_MATCH;
 		}
@@ -418,13 +418,13 @@ static void revalidate_bgp_node(struct bgp_node *bgp_node, afi_t afi,
 
 	for (ain = bgp_node->adj_in; ain; ain = ain->next) {
 		int ret;
-		struct bgp_path_info *bgp_info = bgp_node->info;
+		struct bgp_path_info *path = bgp_node->info;
 		mpls_label_t *label = NULL;
 		uint32_t num_labels = 0;
 
-		if (bgp_info && bgp_info->extra) {
-			label = bgp_info->extra->label;
-			num_labels = bgp_info->extra->num_labels;
+		if (path && path->extra) {
+			label = path->extra->label;
+			num_labels = path->extra->num_labels;
 		}
 		ret = bgp_update(ain->peer, &bgp_node->p, ain->addpath_rx_id,
 				 ain->attr, afi, safi, ZEBRA_ROUTE_BGP,

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -217,7 +217,7 @@ static route_map_result_t route_match(void *rule, const struct prefix *prefix,
 				      route_map_object_t type, void *object)
 {
 	int *rpki_status = rule;
-	struct bgp_info *bgp_info;
+	struct bgp_path_info *bgp_info;
 
 	if (type == RMAP_BGP) {
 		bgp_info = object;
@@ -418,7 +418,7 @@ static void revalidate_bgp_node(struct bgp_node *bgp_node, afi_t afi,
 
 	for (ain = bgp_node->adj_in; ain; ain = ain->next) {
 		int ret;
-		struct bgp_info *bgp_info = bgp_node->info;
+		struct bgp_path_info *bgp_info = bgp_node->info;
 		mpls_label_t *label = NULL;
 		uint32_t num_labels = 0;
 

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -674,14 +674,15 @@ static uint8_t *bgpRcvdPathAttrTable(struct variable *v, oid name[],
 	return NULL;
 }
 
-static struct bgp_info *bgp4PathAttrLookup(struct variable *v, oid name[],
-					   size_t *length, struct bgp *bgp,
-					   struct prefix_ipv4 *addr, int exact)
+static struct bgp_path_info *bgp4PathAttrLookup(struct variable *v, oid name[],
+						size_t *length, struct bgp *bgp,
+						struct prefix_ipv4 *addr,
+						int exact)
 {
 	oid *offset;
 	int offsetlen;
-	struct bgp_info *binfo;
-	struct bgp_info *min;
+	struct bgp_path_info *binfo;
+	struct bgp_path_info *min;
 	struct bgp_node *rn;
 	union sockunion su;
 	unsigned int len;
@@ -812,7 +813,7 @@ static uint8_t *bgp4PathAttrTable(struct variable *v, oid name[],
 				  WriteMethod **write_method)
 {
 	struct bgp *bgp;
-	struct bgp_info *binfo;
+	struct bgp_path_info *binfo;
 	struct prefix_ipv4 addr;
 
 	bgp = bgp_get_default();

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -681,7 +681,7 @@ static struct bgp_path_info *bgp4PathAttrLookup(struct variable *v, oid name[],
 {
 	oid *offset;
 	int offsetlen;
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 	struct bgp_path_info *min;
 	struct bgp_node *rn;
 	union sockunion su;
@@ -715,9 +715,9 @@ static struct bgp_path_info *bgp4PathAttrLookup(struct variable *v, oid name[],
 		if (rn) {
 			bgp_unlock_node(rn);
 
-			for (binfo = rn->info; binfo; binfo = binfo->next)
-				if (sockunion_same(&binfo->peer->su, &su))
-					return binfo;
+			for (path = rn->info; path; path = path->next)
+				if (sockunion_same(&path->peer->su, &su))
+					return path;
 		}
 	} else {
 		offset = name + v->namelen;
@@ -762,22 +762,22 @@ static struct bgp_path_info *bgp4PathAttrLookup(struct variable *v, oid name[],
 		do {
 			min = NULL;
 
-			for (binfo = rn->info; binfo; binfo = binfo->next) {
-				if (binfo->peer->su.sin.sin_family == AF_INET
+			for (path = rn->info; path; path = path->next) {
+				if (path->peer->su.sin.sin_family == AF_INET
 				    && ntohl(paddr.s_addr)
-					       < ntohl(binfo->peer->su.sin
+					       < ntohl(path->peer->su.sin
 							       .sin_addr
 							       .s_addr)) {
 					if (min) {
-						if (ntohl(binfo->peer->su.sin
+						if (ntohl(path->peer->su.sin
 								  .sin_addr
 								  .s_addr)
 						    < ntohl(min->peer->su.sin
 								    .sin_addr
 								    .s_addr))
-							min = binfo;
+							min = path;
 					} else
-						min = binfo;
+						min = path;
 				}
 			}
 
@@ -813,7 +813,7 @@ static uint8_t *bgp4PathAttrTable(struct variable *v, oid name[],
 				  WriteMethod **write_method)
 {
 	struct bgp *bgp;
-	struct bgp_path_info *binfo;
+	struct bgp_path_info *path;
 	struct prefix_ipv4 addr;
 
 	bgp = bgp_get_default();
@@ -825,13 +825,13 @@ static uint8_t *bgp4PathAttrTable(struct variable *v, oid name[],
 		return NULL;
 	memset(&addr, 0, sizeof(struct prefix_ipv4));
 
-	binfo = bgp4PathAttrLookup(v, name, length, bgp, &addr, exact);
-	if (!binfo)
+	path = bgp4PathAttrLookup(v, name, length, bgp, &addr, exact);
+	if (!path)
 		return NULL;
 
 	switch (v->magic) {
 	case BGP4PATHATTRPEER: /* 1 */
-		return SNMP_IPADDRESS(binfo->peer->su.sin.sin_addr);
+		return SNMP_IPADDRESS(path->peer->su.sin.sin_addr);
 		break;
 	case BGP4PATHATTRIPADDRPREFIXLEN: /* 2 */
 		return SNMP_INTEGER(addr.prefixlen);
@@ -840,28 +840,28 @@ static uint8_t *bgp4PathAttrTable(struct variable *v, oid name[],
 		return SNMP_IPADDRESS(addr.prefix);
 		break;
 	case BGP4PATHATTRORIGIN: /* 4 */
-		return SNMP_INTEGER(binfo->attr->origin);
+		return SNMP_INTEGER(path->attr->origin);
 		break;
 	case BGP4PATHATTRASPATHSEGMENT: /* 5 */
-		return aspath_snmp_pathseg(binfo->attr->aspath, var_len);
+		return aspath_snmp_pathseg(path->attr->aspath, var_len);
 		break;
 	case BGP4PATHATTRNEXTHOP: /* 6 */
-		return SNMP_IPADDRESS(binfo->attr->nexthop);
+		return SNMP_IPADDRESS(path->attr->nexthop);
 		break;
 	case BGP4PATHATTRMULTIEXITDISC: /* 7 */
-		return SNMP_INTEGER(binfo->attr->med);
+		return SNMP_INTEGER(path->attr->med);
 		break;
 	case BGP4PATHATTRLOCALPREF: /* 8 */
-		return SNMP_INTEGER(binfo->attr->local_pref);
+		return SNMP_INTEGER(path->attr->local_pref);
 		break;
 	case BGP4PATHATTRATOMICAGGREGATE: /* 9 */
 		return SNMP_INTEGER(1);
 		break;
 	case BGP4PATHATTRAGGREGATORAS: /* 10 */
-		return SNMP_INTEGER(binfo->attr->aggregator_as);
+		return SNMP_INTEGER(path->attr->aggregator_as);
 		break;
 	case BGP4PATHATTRAGGREGATORADDR: /* 11 */
-		return SNMP_IPADDRESS(binfo->attr->aggregator_addr);
+		return SNMP_IPADDRESS(path->attr->aggregator_addr);
 		break;
 	case BGP4PATHATTRCALCLOCALPREF: /* 12 */
 		return SNMP_INTEGER(-1);
@@ -869,7 +869,7 @@ static uint8_t *bgp4PathAttrTable(struct variable *v, oid name[],
 	case BGP4PATHATTRBEST: /* 13 */
 #define BGP4_PathAttrBest_false 1
 #define BGP4_PathAttrBest_true  2
-		if (CHECK_FLAG(binfo->flags, BGP_INFO_SELECTED))
+		if (CHECK_FLAG(path->flags, BGP_INFO_SELECTED))
 			return SNMP_INTEGER(BGP4_PathAttrBest_true);
 		else
 			return SNMP_INTEGER(BGP4_PathAttrBest_false);

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -104,7 +104,7 @@ struct bgp_table *bgp_table_init(struct bgp *bgp, afi_t afi, safi_t safi)
 	route_table_set_info(rt->route_table, rt);
 
 	/*
-	 * pointer to bgp instance allows working back from bgp_info to bgp
+	 * pointer to bgp instance allows working back from bgp_path_info to bgp
 	 */
 	rt->bgp = bgp;
 

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1904,7 +1904,7 @@ int bgp_addpath_encode_tx(struct peer *peer, afi_t afi, safi_t safi)
  * configured addpath-tx knob
  */
 int bgp_addpath_tx_path(struct peer *peer, afi_t afi, safi_t safi,
-			struct bgp_info *ri)
+			struct bgp_path_info *ri)
 {
 	if (CHECK_FLAG(peer->af_flags[afi][safi],
 		       PEER_FLAG_ADDPATH_TX_ALL_PATHS))

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1912,7 +1912,7 @@ int bgp_addpath_tx_path(struct peer *peer, afi_t afi, safi_t safi,
 
 	if (CHECK_FLAG(peer->af_flags[afi][safi],
 		       PEER_FLAG_ADDPATH_TX_BESTPATH_PER_AS)
-	    && CHECK_FLAG(ri->flags, BGP_INFO_DMED_SELECTED))
+	    && CHECK_FLAG(ri->flags, BGP_PATH_DMED_SELECTED))
 		return 1;
 
 	return 0;

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1904,7 +1904,7 @@ int bgp_addpath_encode_tx(struct peer *peer, afi_t afi, safi_t safi)
  * configured addpath-tx knob
  */
 int bgp_addpath_tx_path(struct peer *peer, afi_t afi, safi_t safi,
-			struct bgp_path_info *ri)
+			struct bgp_path_info *pi)
 {
 	if (CHECK_FLAG(peer->af_flags[afi][safi],
 		       PEER_FLAG_ADDPATH_TX_ALL_PATHS))
@@ -1912,7 +1912,7 @@ int bgp_addpath_tx_path(struct peer *peer, afi_t afi, safi_t safi,
 
 	if (CHECK_FLAG(peer->af_flags[afi][safi],
 		       PEER_FLAG_ADDPATH_TX_BESTPATH_PER_AS)
-	    && CHECK_FLAG(ri->flags, BGP_PATH_DMED_SELECTED))
+	    && CHECK_FLAG(pi->flags, BGP_PATH_DMED_SELECTED))
 		return 1;
 
 	return 0;

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -293,7 +293,7 @@ typedef int (*updgrp_walkcb)(struct update_group *updgrp, void *ctx);
 struct updwalk_context {
 	struct vty *vty;
 	struct bgp_node *rn;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	uint64_t updgrp_id;
 	uint64_t subgrp_id;
 	bgp_policy_type_e policy_type;
@@ -442,7 +442,7 @@ extern void subgroup_announce_all(struct update_subgroup *subgrp);
 extern void subgroup_default_originate(struct update_subgroup *subgrp,
 				       int withdraw);
 extern void group_announce_route(struct bgp *bgp, afi_t afi, safi_t safi,
-				 struct bgp_node *rn, struct bgp_path_info *ri);
+				 struct bgp_node *rn, struct bgp_path_info *pi);
 extern void subgroup_clear_table(struct update_subgroup *subgrp);
 extern void update_group_announce(struct bgp *bgp);
 extern void update_group_announce_rrclients(struct bgp *bgp);
@@ -470,7 +470,7 @@ extern int update_group_clear_update_dbg(struct update_group *updgrp,
 extern void update_bgp_group_free(struct bgp *bgp);
 extern int bgp_addpath_encode_tx(struct peer *peer, afi_t afi, safi_t safi);
 extern int bgp_addpath_tx_path(struct peer *peer, afi_t afi, safi_t safi,
-			       struct bgp_path_info *ri);
+			       struct bgp_path_info *pi);
 
 /*
  * Inline functions

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -293,7 +293,7 @@ typedef int (*updgrp_walkcb)(struct update_group *updgrp, void *ctx);
 struct updwalk_context {
 	struct vty *vty;
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	uint64_t updgrp_id;
 	uint64_t subgrp_id;
 	bgp_policy_type_e policy_type;
@@ -442,7 +442,7 @@ extern void subgroup_announce_all(struct update_subgroup *subgrp);
 extern void subgroup_default_originate(struct update_subgroup *subgrp,
 				       int withdraw);
 extern void group_announce_route(struct bgp *bgp, afi_t afi, safi_t safi,
-				 struct bgp_node *rn, struct bgp_info *ri);
+				 struct bgp_node *rn, struct bgp_path_info *ri);
 extern void subgroup_clear_table(struct update_subgroup *subgrp);
 extern void update_group_announce(struct bgp *bgp);
 extern void update_group_announce_rrclients(struct bgp *bgp);
@@ -455,7 +455,8 @@ extern void bgp_adj_out_remove_subgroup(struct bgp_node *rn,
 					struct update_subgroup *subgrp);
 extern void bgp_adj_out_set_subgroup(struct bgp_node *rn,
 				     struct update_subgroup *subgrp,
-				     struct attr *attr, struct bgp_info *binfo);
+				     struct attr *attr,
+				     struct bgp_path_info *binfo);
 extern void bgp_adj_out_unset_subgroup(struct bgp_node *rn,
 				       struct update_subgroup *subgrp,
 				       char withdraw, uint32_t addpath_tx_id);
@@ -469,7 +470,7 @@ extern int update_group_clear_update_dbg(struct update_group *updgrp,
 extern void update_bgp_group_free(struct bgp *bgp);
 extern int bgp_addpath_encode_tx(struct peer *peer, afi_t afi, safi_t safi);
 extern int bgp_addpath_tx_path(struct peer *peer, afi_t afi, safi_t safi,
-			       struct bgp_info *ri);
+			       struct bgp_path_info *ri);
 
 /*
  * Inline functions

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -456,7 +456,7 @@ extern void bgp_adj_out_remove_subgroup(struct bgp_node *rn,
 extern void bgp_adj_out_set_subgroup(struct bgp_node *rn,
 				     struct update_subgroup *subgrp,
 				     struct attr *attr,
-				     struct bgp_path_info *binfo);
+				     struct bgp_path_info *path);
 extern void bgp_adj_out_unset_subgroup(struct bgp_node *rn,
 				       struct update_subgroup *subgrp,
 				       char withdraw, uint32_t addpath_tx_id);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -594,7 +594,7 @@ void subgroup_announce_table(struct update_subgroup *subgrp,
 	for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn))
 		for (ri = rn->info; ri; ri = ri->next)
 
-			if (CHECK_FLAG(ri->flags, BGP_INFO_SELECTED)
+			if (CHECK_FLAG(ri->flags, BGP_PATH_SELECTED)
 			    || (addpath_capable
 				&& bgp_addpath_tx_path(peer, afi, safi, ri))) {
 				if (subgroup_announce_check(rn, ri, subgrp,

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -101,7 +101,7 @@ static int group_announce_route_walkcb(struct update_group *updgrp, void *arg)
 {
 	struct updwalk_context *ctx = arg;
 	struct update_subgroup *subgrp;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	afi_t afi;
 	safi_t safi;
 	struct peer *peer;
@@ -429,7 +429,7 @@ bgp_advertise_clean_subgroup(struct update_subgroup *subgrp,
 
 void bgp_adj_out_set_subgroup(struct bgp_node *rn,
 			      struct update_subgroup *subgrp, struct attr *attr,
-			      struct bgp_info *binfo)
+			      struct bgp_path_info *binfo)
 {
 	struct bgp_adj_out *adj = NULL;
 	struct bgp_advertise *adv;
@@ -453,7 +453,8 @@ void bgp_adj_out_set_subgroup(struct bgp_node *rn,
 	adv = adj->adv;
 	adv->rn = rn;
 	assert(adv->binfo == NULL);
-	adv->binfo = bgp_info_lock(binfo); /* bgp_info adj_out reference */
+	/* bgp_path_info adj_out reference */
+	adv->binfo = bgp_info_lock(binfo);
 
 	if (attr)
 		adv->baa = bgp_advertise_intern(subgrp->hash, attr);
@@ -568,7 +569,7 @@ void subgroup_announce_table(struct update_subgroup *subgrp,
 			     struct bgp_table *table)
 {
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	struct attr attr;
 	struct peer *peer;
 	afi_t afi;
@@ -663,11 +664,11 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 {
 	struct bgp *bgp;
 	struct attr attr;
-	struct bgp_info *info, init_info, tmp_info;
+	struct bgp_path_info *info, init_info, tmp_info;
 	struct prefix p;
 	struct peer *from;
 	struct bgp_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 	struct peer *peer;
 	int ret = RMAP_DENYMATCH;
 	afi_t afi;
@@ -830,7 +831,7 @@ void subgroup_announce_all(struct update_subgroup *subgrp)
  * input route.
  */
 void group_announce_route(struct bgp *bgp, afi_t afi, safi_t safi,
-			  struct bgp_node *rn, struct bgp_info *ri)
+			  struct bgp_node *rn, struct bgp_path_info *ri)
 {
 	struct updwalk_context ctx;
 	ctx.ri = ri;

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -454,7 +454,7 @@ void bgp_adj_out_set_subgroup(struct bgp_node *rn,
 	adv->rn = rn;
 	assert(adv->binfo == NULL);
 	/* bgp_path_info adj_out reference */
-	adv->binfo = bgp_info_lock(binfo);
+	adv->binfo = bgp_path_info_lock(binfo);
 
 	if (attr)
 		adv->baa = bgp_advertise_intern(subgrp->hash, attr);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -429,7 +429,7 @@ bgp_advertise_clean_subgroup(struct update_subgroup *subgrp,
 
 void bgp_adj_out_set_subgroup(struct bgp_node *rn,
 			      struct update_subgroup *subgrp, struct attr *attr,
-			      struct bgp_path_info *binfo)
+			      struct bgp_path_info *path)
 {
 	struct bgp_adj_out *adj = NULL;
 	struct bgp_advertise *adv;
@@ -438,10 +438,10 @@ void bgp_adj_out_set_subgroup(struct bgp_node *rn,
 		return;
 
 	/* Look for adjacency information. */
-	adj = adj_lookup(rn, subgrp, binfo->addpath_tx_id);
+	adj = adj_lookup(rn, subgrp, path->addpath_tx_id);
 
 	if (!adj) {
-		adj = bgp_adj_out_alloc(subgrp, rn, binfo->addpath_tx_id);
+		adj = bgp_adj_out_alloc(subgrp, rn, path->addpath_tx_id);
 		if (!adj)
 			return;
 	}
@@ -452,9 +452,9 @@ void bgp_adj_out_set_subgroup(struct bgp_node *rn,
 
 	adv = adj->adv;
 	adv->rn = rn;
-	assert(adv->binfo == NULL);
+	assert(adv->pathi == NULL);
 	/* bgp_path_info adj_out reference */
-	adv->binfo = bgp_path_info_lock(binfo);
+	adv->pathi = bgp_path_info_lock(path);
 
 	if (attr)
 		adv->baa = bgp_advertise_intern(subgrp->hash, attr);

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -101,7 +101,7 @@ static int group_announce_route_walkcb(struct update_group *updgrp, void *arg)
 {
 	struct updwalk_context *ctx = arg;
 	struct update_subgroup *subgrp;
-	struct bgp_path_info *ri;
+	struct bgp_path_info *pi;
 	afi_t afi;
 	safi_t safi;
 	struct peer *peer;
@@ -140,15 +140,15 @@ static int group_announce_route_walkcb(struct update_group *updgrp, void *arg)
 					adj_next = adj->next;
 
 					if (adj->subgroup == subgrp) {
-						for (ri = ctx->rn->info; ri;
-						     ri = ri->next) {
-							if (ri->addpath_tx_id
+						for (pi = ctx->rn->info; pi;
+						     pi = pi->next) {
+							if (pi->addpath_tx_id
 							    == adj->addpath_tx_id) {
 								break;
 							}
 						}
 
-						if (!ri) {
+						if (!pi) {
 							subgroup_process_announce_selected(
 								subgrp, NULL,
 								ctx->rn,
@@ -157,32 +157,32 @@ static int group_announce_route_walkcb(struct update_group *updgrp, void *arg)
 					}
 				}
 
-				for (ri = ctx->rn->info; ri; ri = ri->next) {
+				for (pi = ctx->rn->info; pi; pi = pi->next) {
 					/* Skip the bestpath for now */
-					if (ri == ctx->ri)
+					if (pi == ctx->pi)
 						continue;
 
 					subgroup_process_announce_selected(
-						subgrp, ri, ctx->rn,
-						ri->addpath_tx_id);
+						subgrp, pi, ctx->rn,
+						pi->addpath_tx_id);
 				}
 
 				/* Process the bestpath last so the "show [ip]
 				 * bgp neighbor x.x.x.x advertised"
 				 * output shows the attributes from the bestpath
 				 */
-				if (ctx->ri)
+				if (ctx->pi)
 					subgroup_process_announce_selected(
-						subgrp, ctx->ri, ctx->rn,
-						ctx->ri->addpath_tx_id);
+						subgrp, ctx->pi, ctx->rn,
+						ctx->pi->addpath_tx_id);
 			}
 
 			/* An update-group that does not use addpath */
 			else {
-				if (ctx->ri) {
+				if (ctx->pi) {
 					subgroup_process_announce_selected(
-						subgrp, ctx->ri, ctx->rn,
-						ctx->ri->addpath_tx_id);
+						subgrp, ctx->pi, ctx->rn,
+						ctx->pi->addpath_tx_id);
 				} else {
 					/* Find the addpath_tx_id of the path we
 					 * had advertised and
@@ -831,10 +831,10 @@ void subgroup_announce_all(struct update_subgroup *subgrp)
  * input route.
  */
 void group_announce_route(struct bgp *bgp, afi_t afi, safi_t safi,
-			  struct bgp_node *rn, struct bgp_path_info *ri)
+			  struct bgp_node *rn, struct bgp_path_info *pi)
 {
 	struct updwalk_context ctx;
-	ctx.ri = ri;
+	ctx.pi = pi;
 	ctx.rn = rn;
 	update_group_af_walk(bgp, afi, safi, group_announce_route_walkcb, &ctx);
 }

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -687,7 +687,7 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 	struct bgp_adj_out *adj;
 	struct bgp_advertise *adv;
 	struct bgp_node *rn = NULL;
-	struct bgp_info *binfo = NULL;
+	struct bgp_path_info *binfo = NULL;
 	bgp_size_t total_attr_len = 0;
 	unsigned long attrlen_pos = 0;
 	size_t mpattrlen_pos = 0;

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -687,7 +687,7 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 	struct bgp_adj_out *adj;
 	struct bgp_advertise *adv;
 	struct bgp_node *rn = NULL;
-	struct bgp_path_info *binfo = NULL;
+	struct bgp_path_info *path = NULL;
 	bgp_size_t total_attr_len = 0;
 	unsigned long attrlen_pos = 0;
 	size_t mpattrlen_pos = 0;
@@ -731,7 +731,7 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 		rn = adv->rn;
 		adj = adv->adj;
 		addpath_tx_id = adj->addpath_tx_id;
-		binfo = adv->binfo;
+		path = adv->pathi;
 
 		space_remaining = STREAM_CONCAT_REMAIN(s, snlri, STREAM_SIZE(s))
 				  - BGP_MAX_PACKET_SIZE_OVERFLOW;
@@ -747,8 +747,8 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 		if (stream_empty(s)) {
 			struct peer *from = NULL;
 
-			if (binfo)
-				from = binfo->peer;
+			if (path)
+				from = path->peer;
 
 			/* 1: Write the BGP message header - 16 bytes marker, 2
 			 * bytes length,
@@ -821,13 +821,13 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 				prd = (struct prefix_rd *)&rn->prn->p;
 
 			if (safi == SAFI_LABELED_UNICAST) {
-				label = bgp_adv_label(rn, binfo, peer, afi,
+				label = bgp_adv_label(rn, path, peer, afi,
 						      safi);
 				label_pnt = &label;
 				num_labels = 1;
-			} else if (binfo && binfo->extra) {
-				label_pnt = &binfo->extra->label[0];
-				num_labels = binfo->extra->num_labels;
+			} else if (path && path->extra) {
+				label_pnt = &path->extra->label[0];
+				num_labels = path->extra->num_labels;
 			}
 
 			if (stream_empty(snlri))

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7524,12 +7524,13 @@ DEFUN (show_bgp_memory,
 	count = mtype_stats_alloc(MTYPE_BGP_ROUTE);
 	vty_out(vty, "%ld BGP routes, using %s of memory\n", count,
 		mtype_memstr(memstrbuf, sizeof(memstrbuf),
-			     count * sizeof(struct bgp_info)));
+			     count * sizeof(struct bgp_path_info)));
 	if ((count = mtype_stats_alloc(MTYPE_BGP_ROUTE_EXTRA)))
 		vty_out(vty, "%ld BGP route ancillaries, using %s of memory\n",
 			count,
-			mtype_memstr(memstrbuf, sizeof(memstrbuf),
-				     count * sizeof(struct bgp_info_extra)));
+			mtype_memstr(
+				memstrbuf, sizeof(memstrbuf),
+				count * sizeof(struct bgp_path_info_extra)));
 
 	if ((count = mtype_stats_alloc(MTYPE_BGP_STATIC)))
 		vty_out(vty, "%ld Static routes, using %s of memory\n", count,

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -925,8 +925,8 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 	return true;
 }
 
-static struct in6_addr *bgp_info_to_ipv6_nexthop(struct bgp_path_info *info,
-						 ifindex_t *ifindex)
+static struct in6_addr *
+bgp_path_info_to_ipv6_nexthop(struct bgp_path_info *info, ifindex_t *ifindex)
 {
 	struct in6_addr *nexthop = NULL;
 
@@ -994,7 +994,7 @@ static int bgp_table_map_apply(struct route_map *map, struct prefix *p,
 			ifindex_t ifindex;
 			struct in6_addr *nexthop;
 
-			nexthop = bgp_info_to_ipv6_nexthop(info, &ifindex);
+			nexthop = bgp_path_info_to_ipv6_nexthop(info, &ifindex);
 			zlog_debug(
 				"Zebra rmap deny: IPv6 route %s/%d nexthop %s",
 				inet_ntop(AF_INET6, &p->u.prefix6, buf[0],
@@ -1265,7 +1265,7 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 
 	/* Metric is currently based on the best-path only */
 	metric = info->attr->med;
-	for (mpinfo = info; mpinfo; mpinfo = bgp_info_mpath_next(mpinfo)) {
+	for (mpinfo = info; mpinfo; mpinfo = bgp_path_info_mpath_next(mpinfo)) {
 		if (valid_nh_count >= multipath_num)
 			break;
 
@@ -1355,8 +1355,8 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 					tag = mpinfo_cp->attr->tag;
 				}
 			}
-			nexthop = bgp_info_to_ipv6_nexthop(mpinfo_cp,
-							   &ifindex);
+			nexthop = bgp_path_info_to_ipv6_nexthop(mpinfo_cp,
+								&ifindex);
 			nh_updated = update_ipv6nh_for_route_install(
 					nh_othervrf, nexthop, ifindex,
 					mpinfo, info, is_evpn, api_nh);
@@ -1702,8 +1702,8 @@ int bgp_redistribute_metric_set(struct bgp *bgp, struct bgp_redist *red,
 				ri->attr = bgp_attr_intern(&new_attr);
 				bgp_attr_unintern(&old_attr);
 
-				bgp_info_set_flag(rn, ri,
-						  BGP_PATH_ATTR_CHANGED);
+				bgp_path_info_set_flag(rn, ri,
+						       BGP_PATH_ATTR_CHANGED);
 				bgp_process(bgp, rn, afi, SAFI_UNICAST);
 			}
 		}
@@ -2090,7 +2090,7 @@ static int ipset_entry_notify_owner(int command, struct zclient *zclient,
 				   __PRETTY_FUNCTION__);
 		/* link bgp_info to bpme */
 		bgp_info = (struct bgp_path_info *)bgp_pbime->bgp_info;
-		extra = bgp_info_extra_get(bgp_info);
+		extra = bgp_path_info_extra_get(bgp_info);
 		if (extra->bgp_fs_pbr == NULL)
 			extra->bgp_fs_pbr = list_new();
 		listnode_add(extra->bgp_fs_pbr, bgp_pbime);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1480,7 +1480,7 @@ void bgp_zebra_announce_table(struct bgp *bgp, afi_t afi, safi_t safi)
 
 	for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn))
 		for (ri = rn->info; ri; ri = ri->next)
-			if (CHECK_FLAG(ri->flags, BGP_INFO_SELECTED) &&
+			if (CHECK_FLAG(ri->flags, BGP_PATH_SELECTED) &&
 
 			    (ri->type == ZEBRA_ROUTE_BGP
 			     && (ri->sub_type == BGP_ROUTE_NORMAL
@@ -1704,7 +1704,7 @@ int bgp_redistribute_metric_set(struct bgp *bgp, struct bgp_redist *red,
 				bgp_attr_unintern(&old_attr);
 
 				bgp_info_set_flag(rn, ri,
-						  BGP_INFO_ATTR_CHANGED);
+						  BGP_PATH_ATTR_CHANGED);
 				bgp_process(bgp, rn, afi, SAFI_UNICAST);
 			}
 		}

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2080,7 +2080,7 @@ static int ipset_entry_notify_owner(int command, struct zclient *zclient,
 		break;
 	case ZAPI_IPSET_ENTRY_INSTALLED:
 		{
-		struct bgp_path_info *bgp_info;
+		struct bgp_path_info *path;
 		struct bgp_path_info_extra *extra;
 
 		bgp_pbime->installed = true;
@@ -2088,9 +2088,9 @@ static int ipset_entry_notify_owner(int command, struct zclient *zclient,
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("%s: Received IPSET_ENTRY_INSTALLED",
 				   __PRETTY_FUNCTION__);
-		/* link bgp_info to bpme */
-		bgp_info = (struct bgp_path_info *)bgp_pbime->bgp_info;
-		extra = bgp_path_info_extra_get(bgp_info);
+		/* link bgp_path_info to bpme */
+		path = (struct bgp_path_info *)bgp_pbime->path;
+		extra = bgp_path_info_extra_get(path);
 		if (extra->bgp_fs_pbr == NULL)
 			extra->bgp_fs_pbr = list_new();
 		listnode_add(extra->bgp_fs_pbr, bgp_pbime);

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -36,11 +36,12 @@ extern void bgp_config_write_maxpaths(struct vty *, struct bgp *, afi_t,
 				      safi_t);
 extern void bgp_config_write_redistribute(struct vty *, struct bgp *, afi_t,
 					  safi_t);
-extern void bgp_zebra_announce(struct bgp_node *, struct prefix *,
-			       struct bgp_info *, struct bgp *, afi_t, safi_t);
+extern void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
+			       struct bgp_path_info *path, struct bgp *bgp,
+			       afi_t afi, safi_t safi);
 extern void bgp_zebra_announce_table(struct bgp *, afi_t, safi_t);
-extern void bgp_zebra_withdraw(struct prefix *, struct bgp_info *,
-			       struct bgp *, safi_t);
+extern void bgp_zebra_withdraw(struct prefix *p, struct bgp_path_info *path,
+			       struct bgp *bgp, safi_t safi);
 
 extern void bgp_zebra_initiate_radv(struct bgp *bgp, struct peer *peer);
 extern void bgp_zebra_terminate_radv(struct bgp *bgp, struct peer *peer);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -483,9 +483,8 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 		/*
 		 * Delete local_nexthops list
 		 */
-		if (bpi->extra && bpi->extra->vnc.export.local_nexthops) {
+		if (bpi->extra && bpi->extra->vnc.export.local_nexthops)
 			list_delete(&bpi->extra->vnc.export.local_nexthops);
-		}
 
 		bgp_aggregate_decrement(bgp, p, bpi, afi, safi);
 		bgp_path_info_delete(bn, bpi);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -488,7 +488,7 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 		}
 
 		bgp_aggregate_decrement(bgp, p, bi, afi, safi);
-		bgp_info_delete(bn, bi);
+		bgp_path_info_delete(bn, bi);
 		bgp_process(bgp, bn, afi, safi);
 	} else {
 		vnc_zlog_debug_verbose(
@@ -1010,7 +1010,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 			goto done;
 		} else {
 			/* The attribute is changed. */
-			bgp_info_set_flag(bn, bi, BGP_PATH_ATTR_CHANGED);
+			bgp_path_info_set_flag(bn, bi, BGP_PATH_ATTR_CHANGED);
 
 			if (safi == SAFI_MPLS_VPN) {
 				struct bgp_node *prn = NULL;
@@ -1029,7 +1029,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 
 			/* Rewrite BGP route information. */
 			if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
-				bgp_info_restore(bn, bi);
+				bgp_path_info_restore(bn, bi);
 			else
 				bgp_aggregate_decrement(bgp, p, bi, afi, safi);
 			bgp_attr_unintern(&bi->attr);
@@ -1066,7 +1066,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	}
 
 
-	new = bgp_info_new();
+	new = bgp_path_info_new();
 	new->type = type;
 	new->sub_type = sub_type;
 	new->peer = rfd->peer;
@@ -1075,7 +1075,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	new->uptime = bgp_clock();
 
 	/* save backref to rfapi handle */
-	assert(bgp_info_extra_get(new));
+	assert(bgp_path_info_extra_get(new));
 	new->extra->vnc.export.rfapi_handle = (void *)rfd;
 	encode_label(label_val, &new->extra->label[0]);
 
@@ -1087,7 +1087,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	}
 
 	bgp_aggregate_increment(bgp, p, new, afi, safi);
-	bgp_info_add(bn, new);
+	bgp_path_info_add(bn, new);
 
 	if (safi == SAFI_MPLS_VPN) {
 		struct bgp_node *prn = NULL;

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -361,7 +361,7 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 {
 	afi_t afi; /* of the VN address */
 	struct bgp_node *bn;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	char buf[PREFIX_STRLEN];
 	char buf2[RD_ADDRSTRLEN];
 	struct prefix_rd prd0;
@@ -384,21 +384,22 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 		__func__, peer, buf, prefix_rd2str(prd, buf2, sizeof(buf2)),
 		afi, safi, bn, (bn ? bn->info : NULL));
 
-	for (bi = (bn ? bn->info : NULL); bi; bi = bi->next) {
+	for (bpi = (bn ? bn->info : NULL); bpi; bpi = bpi->next) {
 
 		vnc_zlog_debug_verbose(
-			"%s: trying bi=%p, bi->peer=%p, bi->type=%d, bi->sub_type=%d, bi->extra->vnc.export.rfapi_handle=%p, local_pref=%u",
-			__func__, bi, bi->peer, bi->type, bi->sub_type,
-			(bi->extra ? bi->extra->vnc.export.rfapi_handle : NULL),
-			((bi->attr
-			  && CHECK_FLAG(bi->attr->flag,
+			"%s: trying bpi=%p, bpi->peer=%p, bpi->type=%d, bpi->sub_type=%d, bpi->extra->vnc.export.rfapi_handle=%p, local_pref=%u",
+			__func__, bpi, bpi->peer, bpi->type, bpi->sub_type,
+			(bpi->extra ? bpi->extra->vnc.export.rfapi_handle
+				    : NULL),
+			((bpi->attr
+			  && CHECK_FLAG(bpi->attr->flag,
 					ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)))
-				 ? bi->attr->local_pref
+				 ? bpi->attr->local_pref
 				 : 0));
 
-		if (bi->peer == peer && bi->type == type
-		    && bi->sub_type == sub_type && bi->extra
-		    && bi->extra->vnc.export.rfapi_handle == (void *)rfd) {
+		if (bpi->peer == peer && bpi->type == type
+		    && bpi->sub_type == sub_type && bpi->extra
+		    && bpi->extra->vnc.export.rfapi_handle == (void *)rfd) {
 
 			vnc_zlog_debug_verbose("%s: matched it", __func__);
 
@@ -412,8 +413,8 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 		 * route. Leave the route itself in place.
 		 * TBD add return code reporting of success/failure
 		 */
-		if (!bi || !bi->extra
-		    || !bi->extra->vnc.export.local_nexthops) {
+		if (!bpi || !bpi->extra
+		    || !bpi->extra->vnc.export.local_nexthops) {
 			/*
 			 * no local nexthops
 			 */
@@ -429,7 +430,7 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 		struct listnode *node;
 		struct rfapi_nexthop *pLnh = NULL;
 
-		for (ALL_LIST_ELEMENTS_RO(bi->extra->vnc.export.local_nexthops,
+		for (ALL_LIST_ELEMENTS_RO(bpi->extra->vnc.export.local_nexthops,
 					  node, pLnh)) {
 
 			if (prefix_same(&pLnh->addr, &lnh->addr)) {
@@ -438,7 +439,7 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 		}
 
 		if (pLnh) {
-			listnode_delete(bi->extra->vnc.export.local_nexthops,
+			listnode_delete(bpi->extra->vnc.export.local_nexthops,
 					pLnh);
 
 			/* silly rabbit, listnode_delete doesn't invoke
@@ -458,7 +459,7 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 	 */
 	rfapiProcessWithdraw(peer, rfd, p, prd, NULL, afi, safi, type, kill);
 
-	if (bi) {
+	if (bpi) {
 		prefix2str(p, buf, sizeof(buf));
 		vnc_zlog_debug_verbose(
 			"%s: Found route (safi=%d) to delete at prefix %s",
@@ -474,7 +475,7 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 				table = (struct bgp_table *)(prn->info);
 
 				vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
-					bgp, prd, table, p, bi);
+					bgp, prd, table, p, bpi);
 			}
 			bgp_unlock_node(prn);
 		}
@@ -482,13 +483,12 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 		/*
 		 * Delete local_nexthops list
 		 */
-		if (bi->extra && bi->extra->vnc.export.local_nexthops) {
-			list_delete(
-				&bi->extra->vnc.export.local_nexthops);
+		if (bpi->extra && bpi->extra->vnc.export.local_nexthops) {
+			list_delete(&bpi->extra->vnc.export.local_nexthops);
 		}
 
-		bgp_aggregate_decrement(bgp, p, bi, afi, safi);
-		bgp_path_info_delete(bn, bi);
+		bgp_aggregate_decrement(bgp, p, bpi, afi, safi);
+		bgp_path_info_delete(bn, bpi);
 		bgp_process(bgp, bn, afi, safi);
 	} else {
 		vnc_zlog_debug_verbose(
@@ -576,7 +576,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 {
 	afi_t afi; /* of the VN address */
 	struct bgp_path_info *new;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct bgp_node *bn;
 
 	struct attr attr = {0};
@@ -946,29 +946,29 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	 *      ecommunity: POINTS TO interned/refcounted dynamic 2-part AS attr
 	 *  aspath: POINTS TO interned/refcounted hashed block
 	 */
-	for (bi = bn->info; bi; bi = bi->next) {
+	for (bpi = bn->info; bpi; bpi = bpi->next) {
 		/* probably only need to check
-		 * bi->extra->vnc.export.rfapi_handle */
-		if (bi->peer == rfd->peer && bi->type == type
-		    && bi->sub_type == sub_type && bi->extra
-		    && bi->extra->vnc.export.rfapi_handle == (void *)rfd) {
+		 * bpi->extra->vnc.export.rfapi_handle */
+		if (bpi->peer == rfd->peer && bpi->type == type
+		    && bpi->sub_type == sub_type && bpi->extra
+		    && bpi->extra->vnc.export.rfapi_handle == (void *)rfd) {
 
 			break;
 		}
 	}
 
-	if (bi) {
+	if (bpi) {
 
 		/*
 		 * Adding new local_nexthop, which does not by itself change
 		 * what is advertised via BGP
 		 */
 		if (lnh) {
-			if (!bi->extra->vnc.export.local_nexthops) {
+			if (!bpi->extra->vnc.export.local_nexthops) {
 				/* TBD make arrangements to free when needed */
-				bi->extra->vnc.export.local_nexthops =
+				bpi->extra->vnc.export.local_nexthops =
 					list_new();
-				bi->extra->vnc.export.local_nexthops->del =
+				bpi->extra->vnc.export.local_nexthops->del =
 					rfapi_nexthop_free;
 			}
 
@@ -979,8 +979,8 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 			struct rfapi_nexthop *pLnh = NULL;
 
 			for (ALL_LIST_ELEMENTS_RO(
-				     bi->extra->vnc.export.local_nexthops, node,
-				     pLnh)) {
+				     bpi->extra->vnc.export.local_nexthops,
+				     node, pLnh)) {
 
 				if (prefix_same(&pLnh->addr, &lnh->addr)) {
 					break;
@@ -993,13 +993,13 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 			if (!pLnh) {
 				pLnh = rfapi_nexthop_new(lnh);
 				listnode_add(
-					bi->extra->vnc.export.local_nexthops,
+					bpi->extra->vnc.export.local_nexthops,
 					pLnh);
 			}
 		}
 
-		if (attrhash_cmp(bi->attr, new_attr)
-		    && !CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
+		if (attrhash_cmp(bpi->attr, new_attr)
+		    && !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
 			bgp_attr_unintern(&new_attr);
 			bgp_unlock_node(bn);
 
@@ -1010,7 +1010,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 			goto done;
 		} else {
 			/* The attribute is changed. */
-			bgp_path_info_set_flag(bn, bi, BGP_PATH_ATTR_CHANGED);
+			bgp_path_info_set_flag(bn, bpi, BGP_PATH_ATTR_CHANGED);
 
 			if (safi == SAFI_MPLS_VPN) {
 				struct bgp_node *prn = NULL;
@@ -1022,19 +1022,19 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 					table = (struct bgp_table *)(prn->info);
 
 					vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
-						bgp, prd, table, p, bi);
+						bgp, prd, table, p, bpi);
 				}
 				bgp_unlock_node(prn);
 			}
 
 			/* Rewrite BGP route information. */
-			if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
-				bgp_path_info_restore(bn, bi);
+			if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED))
+				bgp_path_info_restore(bn, bpi);
 			else
-				bgp_aggregate_decrement(bgp, p, bi, afi, safi);
-			bgp_attr_unintern(&bi->attr);
-			bi->attr = new_attr;
-			bi->uptime = bgp_clock();
+				bgp_aggregate_decrement(bgp, p, bpi, afi, safi);
+			bgp_attr_unintern(&bpi->attr);
+			bpi->attr = new_attr;
+			bpi->uptime = bgp_clock();
 
 
 			if (safi == SAFI_MPLS_VPN) {
@@ -1047,13 +1047,13 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 					table = (struct bgp_table *)(prn->info);
 
 					vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
-						bgp, prd, table, p, bi);
+						bgp, prd, table, p, bpi);
 				}
 				bgp_unlock_node(prn);
 			}
 
 			/* Process change. */
-			bgp_aggregate_increment(bgp, p, bi, afi, safi);
+			bgp_aggregate_increment(bgp, p, bpi, afi, safi);
 			bgp_process(bgp, bn, afi, safi);
 			bgp_unlock_node(bn);
 
@@ -3690,7 +3690,7 @@ static void rfapi_print_exported(struct bgp *bgp)
 {
 	struct bgp_node *rdn;
 	struct bgp_node *rn;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 
 	if (!bgp)
 		return;
@@ -3705,8 +3705,8 @@ static void rfapi_print_exported(struct bgp *bgp)
 			if (!rn->info)
 				continue;
 			fprintf(stderr, "%s: rn=%p\n", __func__, rn);
-			for (bi = rn->info; bi; bi = bi->next) {
-				rfapiPrintBi((void *)2, bi); /* 2 => stderr */
+			for (bpi = rn->info; bpi; bpi = bpi->next) {
+				rfapiPrintBi((void *)2, bpi); /* 2 => stderr */
 			}
 		}
 	}
@@ -3720,8 +3720,8 @@ static void rfapi_print_exported(struct bgp *bgp)
 			if (!rn->info)
 				continue;
 			fprintf(stderr, "%s: rn=%p\n", __func__, rn);
-			for (bi = rn->info; bi; bi = bi->next) {
-				rfapiPrintBi((void *)2, bi); /* 2 => stderr */
+			for (bpi = rn->info; bpi; bpi = bpi->next) {
+				rfapiPrintBi((void *)2, bpi); /* 2 => stderr */
 			}
 		}
 	}

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -361,7 +361,7 @@ void del_vnc_route(struct rfapi_descriptor *rfd,
 {
 	afi_t afi; /* of the VN address */
 	struct bgp_node *bn;
-	struct bgp_info *bi;
+	struct bgp_path_info *bi;
 	char buf[PREFIX_STRLEN];
 	char buf2[RD_ADDRSTRLEN];
 	struct prefix_rd prd0;
@@ -575,8 +575,8 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 		   int flags)
 {
 	afi_t afi; /* of the VN address */
-	struct bgp_info *new;
-	struct bgp_info *bi;
+	struct bgp_path_info *new;
+	struct bgp_path_info *bi;
 	struct bgp_node *bn;
 
 	struct attr attr = {0};
@@ -3690,7 +3690,7 @@ static void rfapi_print_exported(struct bgp *bgp)
 {
 	struct bgp_node *rdn;
 	struct bgp_node *rn;
-	struct bgp_info *bi;
+	struct bgp_path_info *bi;
 
 	if (!bgp)
 		return;

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -999,7 +999,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 		}
 
 		if (attrhash_cmp(bi->attr, new_attr)
-		    && !CHECK_FLAG(bi->flags, BGP_INFO_REMOVED)) {
+		    && !CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
 			bgp_attr_unintern(&new_attr);
 			bgp_unlock_node(bn);
 
@@ -1010,7 +1010,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 			goto done;
 		} else {
 			/* The attribute is changed. */
-			bgp_info_set_flag(bn, bi, BGP_INFO_ATTR_CHANGED);
+			bgp_info_set_flag(bn, bi, BGP_PATH_ATTR_CHANGED);
 
 			if (safi == SAFI_MPLS_VPN) {
 				struct bgp_node *prn = NULL;
@@ -1028,7 +1028,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 			}
 
 			/* Rewrite BGP route information. */
-			if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+			if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 				bgp_info_restore(bn, bi);
 			else
 				bgp_aggregate_decrement(bgp, p, bi, afi, safi);
@@ -1070,7 +1070,7 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 	new->type = type;
 	new->sub_type = sub_type;
 	new->peer = rfd->peer;
-	SET_FLAG(new->flags, BGP_INFO_VALID);
+	SET_FLAG(new->flags, BGP_PATH_VALID);
 	new->attr = new_attr;
 	new->uptime = bgp_clock();
 

--- a/bgpd/rfapi/rfapi_backend.h
+++ b/bgpd/rfapi/rfapi_backend.h
@@ -57,7 +57,7 @@ extern void vnc_zebra_withdraw(struct prefix *p,
 
 
 extern void rfapi_vty_out_vncinfo(struct vty *vty, struct prefix *p,
-				  struct bgp_path_info *bi, safi_t safi);
+				  struct bgp_path_info *bpi, safi_t safi);
 
 
 extern void vnc_direct_bgp_vpn_enable(struct bgp *bgp, afi_t afi);

--- a/bgpd/rfapi/rfapi_backend.h
+++ b/bgpd/rfapi/rfapi_backend.h
@@ -48,14 +48,16 @@ extern void rfapiProcessWithdraw(struct peer *peer, void *rfd, struct prefix *p,
 
 extern void rfapiProcessPeerDown(struct peer *peer);
 
-extern void vnc_zebra_announce(struct prefix *p, struct bgp_info *new_select,
+extern void vnc_zebra_announce(struct prefix *p,
+			       struct bgp_path_info *new_select,
 			       struct bgp *bgp);
 
-extern void vnc_zebra_withdraw(struct prefix *p, struct bgp_info *old_select);
+extern void vnc_zebra_withdraw(struct prefix *p,
+			       struct bgp_path_info *old_select);
 
 
 extern void rfapi_vty_out_vncinfo(struct vty *vty, struct prefix *p,
-				  struct bgp_info *bi, safi_t safi);
+				  struct bgp_path_info *bi, safi_t safi);
 
 
 extern void vnc_direct_bgp_vpn_enable(struct bgp *bgp, afi_t afi);

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -150,22 +150,22 @@ void rfapiCheckRouteCount()
 
 			for (rn = agg_route_top(rt); rn;
 			     rn = agg_route_next(rn)) {
-				struct bgp_path_info *bi;
+				struct bgp_path_info *bpi;
 				struct bgp_path_info *next;
 
-				for (bi = rn->info; bi; bi = next) {
-					next = bi->next;
+				for (bpi = rn->info; bpi; bpi = next) {
+					next = bpi->next;
 
-					if (CHECK_FLAG(bi->flags,
+					if (CHECK_FLAG(bpi->flags,
 						       BGP_PATH_REMOVED)) {
 						++holddown_count;
 
 					} else {
-						if (RFAPI_LOCAL_BI(bi)) {
+						if (RFAPI_LOCAL_BI(bpi)) {
 							++local_count;
 						} else {
 							if (RFAPI_DIRECT_IMPORT_BI(
-								    bi)) {
+								    bpi)) {
 								++imported_count;
 							} else {
 								++remote_count;
@@ -216,14 +216,14 @@ void rfapiCheckRouteCount()
  */
 void rfapiCheckRefcount(struct agg_node *rn, safi_t safi, int lockoffset)
 {
-	unsigned int count_bi = 0;
+	unsigned int count_bpi = 0;
 	unsigned int count_monitor = 0;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct rfapi_monitor_encap *hme;
 	struct rfapi_monitor_vpn *hmv;
 
-	for (bi = rn->info; bi; bi = bi->next)
-		++count_bi;
+	for (bpi = rn->info; bpi; bpi = bpi->next)
+		++count_bpi;
 
 
 	if (rn->aggregate) {
@@ -265,10 +265,10 @@ void rfapiCheckRefcount(struct agg_node *rn, safi_t safi, int lockoffset)
 		}
 	}
 
-	if (count_bi + count_monitor + lockoffset != rn->lock) {
+	if (count_bpi + count_monitor + lockoffset != rn->lock) {
 		vnc_zlog_debug_verbose(
-			"%s: count_bi=%d, count_monitor=%d, lockoffset=%d, rn->lock=%d",
-			__func__, count_bi, count_monitor, lockoffset,
+			"%s: count_bpi=%d, count_monitor=%d, lockoffset=%d, rn->lock=%d",
+			__func__, count_bpi, count_monitor, lockoffset,
 			rn->lock);
 		assert(0);
 	}
@@ -457,28 +457,28 @@ int rfapiGetVncTunnelUnAddr(struct attr *attr, struct prefix *p)
 /*
  * Get UN address wherever it might be
  */
-int rfapiGetUnAddrOfVpnBi(struct bgp_path_info *bi, struct prefix *p)
+int rfapiGetUnAddrOfVpnBi(struct bgp_path_info *bpi, struct prefix *p)
 {
 	/* If it's in this route's VNC attribute, we're done */
-	if (!rfapiGetVncTunnelUnAddr(bi->attr, p))
+	if (!rfapiGetVncTunnelUnAddr(bpi->attr, p))
 		return 0;
 	/*
 	 * Otherwise, see if it's cached from a corresponding ENCAP SAFI
 	 * advertisement
 	 */
-	if (bi->extra) {
-		switch (bi->extra->vnc.import.un_family) {
+	if (bpi->extra) {
+		switch (bpi->extra->vnc.import.un_family) {
 		case AF_INET:
 			if (p) {
-				p->family = bi->extra->vnc.import.un_family;
-				p->u.prefix4 = bi->extra->vnc.import.un.addr4;
+				p->family = bpi->extra->vnc.import.un_family;
+				p->u.prefix4 = bpi->extra->vnc.import.un.addr4;
 				p->prefixlen = 32;
 			}
 			return 0;
 		case AF_INET6:
 			if (p) {
-				p->family = bi->extra->vnc.import.un_family;
-				p->u.prefix6 = bi->extra->vnc.import.un.addr6;
+				p->family = bpi->extra->vnc.import.un_family;
+				p->u.prefix6 = bpi->extra->vnc.import.un.addr6;
 				p->prefixlen = 128;
 			}
 			return 0;
@@ -487,7 +487,7 @@ int rfapiGetUnAddrOfVpnBi(struct bgp_path_info *bi, struct prefix *p)
 				p->family = 0;
 #if DEBUG_ENCAP_MONITOR
 			vnc_zlog_debug_verbose(
-				"%s: bi->extra->vnc.import.un_family is 0, no UN addr",
+				"%s: bpi->extra->vnc.import.un_family is 0, no UN addr",
 				__func__);
 #endif
 			break;
@@ -635,7 +635,7 @@ struct rfapi_import_table *rfapiMacImportTableGet(struct bgp *bgp, uint32_t lni)
 static struct rfapi_monitor_vpn *
 rfapiMonitorMoveShorter(struct agg_node *original_vpn_node, int lockoffset)
 {
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct agg_node *par;
 	struct rfapi_monitor_vpn *m;
 	struct rfapi_monitor_vpn *mlast;
@@ -656,14 +656,14 @@ rfapiMonitorMoveShorter(struct agg_node *original_vpn_node, int lockoffset)
 #endif
 
 	/*
-	 * 1. If there is at least one bi (either regular route or
+	 * 1. If there is at least one bpi (either regular route or
 	 *    route marked as withdrawn, with a pending timer) at
 	 *    original_node with a valid UN address, we're done. Return.
 	 */
-	for (bi = original_vpn_node->info; bi; bi = bi->next) {
+	for (bpi = original_vpn_node->info; bpi; bpi = bpi->next) {
 		struct prefix pfx;
 
-		if (!rfapiGetUnAddrOfVpnBi(bi, &pfx)) {
+		if (!rfapiGetUnAddrOfVpnBi(bpi, &pfx)) {
 #if DEBUG_MONITOR_MOVE_SHORTER
 			vnc_zlog_debug_verbose(
 				"%s: have valid UN at original node, no change",
@@ -681,13 +681,13 @@ rfapiMonitorMoveShorter(struct agg_node *original_vpn_node, int lockoffset)
 	 */
 	for (par = agg_node_parent(original_vpn_node); par;
 	     par = agg_node_parent(par)) {
-		for (bi = par->info; bi; bi = bi->next) {
+		for (bpi = par->info; bpi; bpi = bpi->next) {
 			struct prefix pfx;
-			if (!rfapiGetUnAddrOfVpnBi(bi, &pfx)) {
+			if (!rfapiGetUnAddrOfVpnBi(bpi, &pfx)) {
 				break;
 			}
 		}
-		if (bi)
+		if (bpi)
 			break;
 	}
 
@@ -802,7 +802,7 @@ static void rfapiMonitorMoveLonger(struct agg_node *new_vpn_node)
 {
 	struct rfapi_monitor_vpn *monitor;
 	struct rfapi_monitor_vpn *mlast;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct agg_node *par;
 
 	RFAPI_CHECK_REFCOUNT(new_vpn_node, SAFI_MPLS_VPN, 0);
@@ -810,13 +810,13 @@ static void rfapiMonitorMoveLonger(struct agg_node *new_vpn_node)
 	/*
 	 * Make sure we have at least one valid route at the new node
 	 */
-	for (bi = new_vpn_node->info; bi; bi = bi->next) {
+	for (bpi = new_vpn_node->info; bpi; bpi = bpi->next) {
 		struct prefix pfx;
-		if (!rfapiGetUnAddrOfVpnBi(bi, &pfx))
+		if (!rfapiGetUnAddrOfVpnBi(bpi, &pfx))
 			break;
 	}
 
-	if (!bi) {
+	if (!bpi) {
 		vnc_zlog_debug_verbose(
 			"%s: no valid routes at node %p, so not attempting moves",
 			__func__, new_vpn_node);
@@ -882,31 +882,31 @@ static void rfapiMonitorMoveLonger(struct agg_node *new_vpn_node)
 }
 
 
-static void rfapiBgpInfoChainFree(struct bgp_path_info *bi)
+static void rfapiBgpInfoChainFree(struct bgp_path_info *bpi)
 {
 	struct bgp_path_info *next;
 
-	while (bi) {
+	while (bpi) {
 
 		/*
-		 * If there is a timer waiting to delete this bi, cancel
+		 * If there is a timer waiting to delete this bpi, cancel
 		 * the timer and delete immediately
 		 */
-		if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)
-		    && bi->extra->vnc.import.timer) {
+		if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)
+		    && bpi->extra->vnc.import.timer) {
 
 			struct thread *t =
-				(struct thread *)bi->extra->vnc.import.timer;
+				(struct thread *)bpi->extra->vnc.import.timer;
 			struct rfapi_withdraw *wcb = t->arg;
 
 			XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 			thread_cancel(t);
 		}
 
-		next = bi->next;
-		bi->next = NULL;
-		rfapiBgpInfoFree(bi);
-		bi = next;
+		next = bpi->next;
+		bpi->next = NULL;
+		rfapiBgpInfoFree(bpi);
+		bpi = next;
 	}
 }
 
@@ -1101,28 +1101,28 @@ int rfapiEcommunityGetEthernetTag(struct ecommunity *ecom, uint16_t *tag_id)
 	return ENOENT;
 }
 
-static int rfapiVpnBiNhEqualsPt(struct bgp_path_info *bi,
+static int rfapiVpnBiNhEqualsPt(struct bgp_path_info *bpi,
 				struct rfapi_ip_addr *hpt)
 {
 	uint8_t family;
 
-	if (!hpt || !bi)
+	if (!hpt || !bpi)
 		return 0;
 
-	family = BGP_MP_NEXTHOP_FAMILY(bi->attr->mp_nexthop_len);
+	family = BGP_MP_NEXTHOP_FAMILY(bpi->attr->mp_nexthop_len);
 
 	if (hpt->addr_family != family)
 		return 0;
 
 	switch (family) {
 	case AF_INET:
-		if (bi->attr->mp_nexthop_global_in.s_addr
+		if (bpi->attr->mp_nexthop_global_in.s_addr
 		    != hpt->addr.v4.s_addr)
 			return 0;
 		break;
 
 	case AF_INET6:
-		if (IPV6_ADDR_CMP(&bi->attr->mp_nexthop_global, &hpt->addr.v6))
+		if (IPV6_ADDR_CMP(&bpi->attr->mp_nexthop_global, &hpt->addr.v6))
 			return 0;
 		break;
 
@@ -1138,37 +1138,37 @@ static int rfapiVpnBiNhEqualsPt(struct bgp_path_info *bi,
 /*
  * Compare 2 VPN BIs. Return true if they have the same VN and UN addresses
  */
-static int rfapiVpnBiSamePtUn(struct bgp_path_info *bi1,
-			      struct bgp_path_info *bi2)
+static int rfapiVpnBiSamePtUn(struct bgp_path_info *bpi1,
+			      struct bgp_path_info *bpi2)
 {
 	struct prefix pfx_un1;
 	struct prefix pfx_un2;
 
-	if (!bi1 || !bi2)
+	if (!bpi1 || !bpi2)
 		return 0;
 
-	if (!bi1->attr || !bi2->attr)
+	if (!bpi1->attr || !bpi2->attr)
 		return 0;
 
 	/*
 	 * VN address comparisons
 	 */
 
-	if (BGP_MP_NEXTHOP_FAMILY(bi1->attr->mp_nexthop_len)
-	    != BGP_MP_NEXTHOP_FAMILY(bi2->attr->mp_nexthop_len)) {
+	if (BGP_MP_NEXTHOP_FAMILY(bpi1->attr->mp_nexthop_len)
+	    != BGP_MP_NEXTHOP_FAMILY(bpi2->attr->mp_nexthop_len)) {
 		return 0;
 	}
 
-	switch (BGP_MP_NEXTHOP_FAMILY(bi1->attr->mp_nexthop_len)) {
+	switch (BGP_MP_NEXTHOP_FAMILY(bpi1->attr->mp_nexthop_len)) {
 	case AF_INET:
-		if (bi1->attr->mp_nexthop_global_in.s_addr
-		    != bi2->attr->mp_nexthop_global_in.s_addr)
+		if (bpi1->attr->mp_nexthop_global_in.s_addr
+		    != bpi2->attr->mp_nexthop_global_in.s_addr)
 			return 0;
 		break;
 
 	case AF_INET6:
-		if (IPV6_ADDR_CMP(&bi1->attr->mp_nexthop_global,
-				  &bi2->attr->mp_nexthop_global))
+		if (IPV6_ADDR_CMP(&bpi1->attr->mp_nexthop_global,
+				  &bpi2->attr->mp_nexthop_global))
 			return 0;
 		break;
 
@@ -1180,17 +1180,17 @@ static int rfapiVpnBiSamePtUn(struct bgp_path_info *bi1,
 	/*
 	 * UN address comparisons
 	 */
-	if (rfapiGetVncTunnelUnAddr(bi1->attr, &pfx_un1)) {
-		if (bi1->extra) {
-			pfx_un1.family = bi1->extra->vnc.import.un_family;
-			switch (bi1->extra->vnc.import.un_family) {
+	if (rfapiGetVncTunnelUnAddr(bpi1->attr, &pfx_un1)) {
+		if (bpi1->extra) {
+			pfx_un1.family = bpi1->extra->vnc.import.un_family;
+			switch (bpi1->extra->vnc.import.un_family) {
 			case AF_INET:
 				pfx_un1.u.prefix4 =
-					bi1->extra->vnc.import.un.addr4;
+					bpi1->extra->vnc.import.un.addr4;
 				break;
 			case AF_INET6:
 				pfx_un1.u.prefix6 =
-					bi1->extra->vnc.import.un.addr6;
+					bpi1->extra->vnc.import.un.addr6;
 				break;
 			default:
 				pfx_un1.family = 0;
@@ -1199,17 +1199,17 @@ static int rfapiVpnBiSamePtUn(struct bgp_path_info *bi1,
 		}
 	}
 
-	if (rfapiGetVncTunnelUnAddr(bi2->attr, &pfx_un2)) {
-		if (bi2->extra) {
-			pfx_un2.family = bi2->extra->vnc.import.un_family;
-			switch (bi2->extra->vnc.import.un_family) {
+	if (rfapiGetVncTunnelUnAddr(bpi2->attr, &pfx_un2)) {
+		if (bpi2->extra) {
+			pfx_un2.family = bpi2->extra->vnc.import.un_family;
+			switch (bpi2->extra->vnc.import.un_family) {
 			case AF_INET:
 				pfx_un2.u.prefix4 =
-					bi2->extra->vnc.import.un.addr4;
+					bpi2->extra->vnc.import.un.addr4;
 				break;
 			case AF_INET6:
 				pfx_un2.u.prefix6 =
-					bi2->extra->vnc.import.un.addr6;
+					bpi2->extra->vnc.import.un.addr6;
 				break;
 			default:
 				pfx_un2.family = 0;
@@ -1298,15 +1298,15 @@ int rfapi_extract_l2o(
 
 static struct rfapi_next_hop_entry *
 rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
-			    struct bgp_path_info *bi, /* route to encode */
-			    uint32_t lifetime,	/* use this in nhe */
-			    struct agg_node *rn)      /* req for L2 eth addr */
+			    struct bgp_path_info *bpi, /* route to encode */
+			    uint32_t lifetime,	 /* use this in nhe */
+			    struct agg_node *rn)       /* req for L2 eth addr */
 {
 	struct rfapi_next_hop_entry *new;
 	int have_vnc_tunnel_un = 0;
 
 #if DEBUG_ENCAP_MONITOR
-	vnc_zlog_debug_verbose("%s: entry, bi %p, rn %p", __func__, bi, rn);
+	vnc_zlog_debug_verbose("%s: entry, bpi %p, rn %p", __func__, bpi, rn);
 #endif
 
 	new = XCALLOC(MTYPE_RFAPI_NEXTHOP, sizeof(struct rfapi_next_hop_entry));
@@ -1314,8 +1314,8 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 
 	new->prefix = *rprefix;
 
-	if (bi->extra
-	    && decode_rd_type(bi->extra->vnc.import.rd.val)
+	if (bpi->extra
+	    && decode_rd_type(bpi->extra->vnc.import.rd.val)
 		       == RD_TYPE_VNC_ETH) {
 		/* ethernet */
 
@@ -1330,19 +1330,19 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 		memcpy(&vo->v.l2addr.macaddr, &rn->p.u.prefix_eth.octet,
 		       ETH_ALEN);
 		/* only low 3 bytes of this are significant */
-		if (bi->attr) {
+		if (bpi->attr) {
 			(void)rfapiEcommunityGetLNI(
-				bi->attr->ecommunity,
+				bpi->attr->ecommunity,
 				&vo->v.l2addr.logical_net_id);
 			(void)rfapiEcommunityGetEthernetTag(
-				bi->attr->ecommunity, &vo->v.l2addr.tag_id);
+				bpi->attr->ecommunity, &vo->v.l2addr.tag_id);
 		}
 
 		/* local_nve_id comes from lower byte of RD type */
-		vo->v.l2addr.local_nve_id = bi->extra->vnc.import.rd.val[1];
+		vo->v.l2addr.local_nve_id = bpi->extra->vnc.import.rd.val[1];
 
 		/* label comes from MP_REACH_NLRI label */
-		vo->v.l2addr.label = decode_label(&bi->extra->label[0]);
+		vo->v.l2addr.label = decode_label(&bpi->extra->label[0]);
 
 		new->vn_options = vo;
 
@@ -1350,38 +1350,38 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 		 * If there is an auxiliary prefix (i.e., host IP address),
 		 * use it as the nexthop prefix instead of the query prefix
 		 */
-		if (bi->extra->vnc.import.aux_prefix.family) {
-			rfapiQprefix2Rprefix(&bi->extra->vnc.import.aux_prefix,
+		if (bpi->extra->vnc.import.aux_prefix.family) {
+			rfapiQprefix2Rprefix(&bpi->extra->vnc.import.aux_prefix,
 					     &new->prefix);
 		}
 	}
 
-	if (bi->attr) {
+	if (bpi->attr) {
 		bgp_encap_types tun_type;
-		new->prefix.cost = rfapiRfpCost(bi->attr);
+		new->prefix.cost = rfapiRfpCost(bpi->attr);
 
 		struct bgp_attr_encap_subtlv *pEncap;
 
-		switch (BGP_MP_NEXTHOP_FAMILY(bi->attr->mp_nexthop_len)) {
+		switch (BGP_MP_NEXTHOP_FAMILY(bpi->attr->mp_nexthop_len)) {
 		case AF_INET:
 			new->vn_address.addr_family = AF_INET;
 			new->vn_address.addr.v4 =
-				bi->attr->mp_nexthop_global_in;
+				bpi->attr->mp_nexthop_global_in;
 			break;
 
 		case AF_INET6:
 			new->vn_address.addr_family = AF_INET6;
-			new->vn_address.addr.v6 = bi->attr->mp_nexthop_global;
+			new->vn_address.addr.v6 = bpi->attr->mp_nexthop_global;
 			break;
 
 		default:
 			zlog_warn("%s: invalid vpn nexthop length: %d",
-				  __func__, bi->attr->mp_nexthop_len);
+				  __func__, bpi->attr->mp_nexthop_len);
 			rfapi_free_next_hop_list(new);
 			return NULL;
 		}
 
-		for (pEncap = bi->attr->vnc_subtlvs; pEncap;
+		for (pEncap = bpi->attr->vnc_subtlvs; pEncap;
 		     pEncap = pEncap->next) {
 			switch (pEncap->type) {
 			case BGP_VNC_SUBTLV_TYPE_LIFETIME:
@@ -1397,18 +1397,18 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 			}
 		}
 
-		rfapiGetTunnelType(bi->attr, &tun_type);
+		rfapiGetTunnelType(bpi->attr, &tun_type);
 		if (tun_type == BGP_ENCAP_TYPE_MPLS) {
 			struct prefix p;
 			/* MPLS carries UN address in next hop */
-			rfapiNexthop2Prefix(bi->attr, &p);
+			rfapiNexthop2Prefix(bpi->attr, &p);
 			if (p.family != 0) {
 				rfapiQprefix2Raddr(&p, &new->un_address);
 				have_vnc_tunnel_un = 1;
 			}
 		}
 
-		for (pEncap = bi->attr->encap_subtlvs; pEncap;
+		for (pEncap = bpi->attr->encap_subtlvs; pEncap;
 		     pEncap = pEncap->next) {
 			switch (pEncap->type) {
 			case BGP_ENCAP_SUBTLV_TYPE_REMOTE_ENDPOINT:
@@ -1433,8 +1433,8 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 
 				default:
 					zlog_warn(
-						"%s: invalid tunnel subtlv UN addr length (%d) for bi %p",
-						__func__, pEncap->length, bi);
+						"%s: invalid tunnel subtlv UN addr length (%d) for bpi %p",
+						__func__, pEncap->length, bpi);
 				}
 				break;
 
@@ -1448,33 +1448,33 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 			}
 		}
 
-		new->un_options = rfapi_encap_tlv_to_un_option(bi->attr);
+		new->un_options = rfapi_encap_tlv_to_un_option(bpi->attr);
 
 #if DEBUG_ENCAP_MONITOR
 		vnc_zlog_debug_verbose("%s: line %d: have_vnc_tunnel_un=%d",
 				       __func__, __LINE__, have_vnc_tunnel_un);
 #endif
 
-		if (!have_vnc_tunnel_un && bi->extra) {
+		if (!have_vnc_tunnel_un && bpi->extra) {
 			/*
 			 * use cached UN address from ENCAP route
 			 */
 			new->un_address.addr_family =
-				bi->extra->vnc.import.un_family;
+				bpi->extra->vnc.import.un_family;
 			switch (new->un_address.addr_family) {
 			case AF_INET:
 				new->un_address.addr.v4 =
-					bi->extra->vnc.import.un.addr4;
+					bpi->extra->vnc.import.un.addr4;
 				break;
 			case AF_INET6:
 				new->un_address.addr.v6 =
-					bi->extra->vnc.import.un.addr6;
+					bpi->extra->vnc.import.un.addr6;
 				break;
 			default:
 				zlog_warn(
-					"%s: invalid UN addr family (%d) for bi %p",
+					"%s: invalid UN addr family (%d) for bpi %p",
 					__func__, new->un_address.addr_family,
-					bi);
+					bpi);
 				rfapi_free_next_hop_list(new);
 				return NULL;
 				break;
@@ -1488,13 +1488,13 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 
 int rfapiHasNonRemovedRoutes(struct agg_node *rn)
 {
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 
-	for (bi = rn->info; bi; bi = bi->next) {
+	for (bpi = rn->info; bpi; bpi = bpi->next) {
 		struct prefix pfx;
 
-		if (!CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)
-		    && (bi->extra && !rfapiGetUnAddrOfVpnBi(bi, &pfx))) {
+		if (!CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)
+		    && (bpi->extra && !rfapiGetUnAddrOfVpnBi(bpi, &pfx))) {
 
 			return 1;
 		}
@@ -1508,16 +1508,16 @@ int rfapiHasNonRemovedRoutes(struct agg_node *rn)
  */
 void rfapiDumpNode(struct agg_node *rn)
 {
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 
 	vnc_zlog_debug_verbose("%s: rn=%p", __func__, rn);
-	for (bi = rn->info; bi; bi = bi->next) {
+	for (bpi = rn->info; bpi; bpi = bpi->next) {
 		struct prefix pfx;
-		int ctrc = rfapiGetUnAddrOfVpnBi(bi, &pfx);
+		int ctrc = rfapiGetUnAddrOfVpnBi(bpi, &pfx);
 		int nr;
 
-		if (!CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)
-		    && (bi->extra && !ctrc)) {
+		if (!CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)
+		    && (bpi->extra && !ctrc)) {
 
 			nr = 1;
 		} else {
@@ -1525,8 +1525,8 @@ void rfapiDumpNode(struct agg_node *rn)
 		}
 
 		vnc_zlog_debug_verbose(
-			"  bi=%p, nr=%d, flags=0x%x, extra=%p, ctrc=%d", bi, nr,
-			bi->flags, bi->extra, ctrc);
+			"  bpi=%p, nr=%d, flags=0x%x, extra=%p, ctrc=%d", bpi,
+			nr, bpi->flags, bpi->extra, ctrc);
 	}
 }
 #endif
@@ -1542,7 +1542,7 @@ static int rfapiNhlAddNodeRoutes(
 	struct agg_node *rfd_rib_node,	/* preload this NVE rib node */
 	struct prefix *pfx_target_original)   /* query target */
 {
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct rfapi_next_hop_entry *new;
 	struct prefix pfx_un;
 	struct skiplist *seen_nexthops;
@@ -1565,12 +1565,12 @@ static int rfapiNhlAddNodeRoutes(
 	seen_nexthops =
 		skiplist_new(0, vnc_prefix_cmp, (void (*)(void *))prefix_free);
 
-	for (bi = rn->info; bi; bi = bi->next) {
+	for (bpi = rn->info; bpi; bpi = bpi->next) {
 
 		struct prefix pfx_vn;
 		struct prefix *newpfx;
 
-		if (removed && !CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
+		if (removed && !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
 #if DEBUG_RETURNED_NHL
 			vnc_zlog_debug_verbose(
 				"%s: want holddown, this route not holddown, skip",
@@ -1578,18 +1578,18 @@ static int rfapiNhlAddNodeRoutes(
 #endif
 			continue;
 		}
-		if (!removed && CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
+		if (!removed && CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
 			continue;
 		}
 
-		if (!bi->extra) {
+		if (!bpi->extra) {
 			continue;
 		}
 
 		/*
 		 * Check for excluded VN address
 		 */
-		if (rfapiVpnBiNhEqualsPt(bi, exclude_vnaddr))
+		if (rfapiVpnBiNhEqualsPt(bpi, exclude_vnaddr))
 			continue;
 
 		/*
@@ -1598,9 +1598,9 @@ static int rfapiNhlAddNodeRoutes(
 		if (is_l2) {
 			/* L2 routes: semantic nexthop in aux_prefix; VN addr
 			 * ain't it */
-			pfx_vn = bi->extra->vnc.import.aux_prefix;
+			pfx_vn = bpi->extra->vnc.import.aux_prefix;
 		} else {
-			rfapiNexthop2Prefix(bi->attr, &pfx_vn);
+			rfapiNexthop2Prefix(bpi->attr, &pfx_vn);
 		}
 		if (!skiplist_search(seen_nexthops, &pfx_vn, NULL)) {
 #if DEBUG_RETURNED_NHL
@@ -1614,10 +1614,10 @@ static int rfapiNhlAddNodeRoutes(
 			continue;
 		}
 
-		if (rfapiGetUnAddrOfVpnBi(bi, &pfx_un)) {
+		if (rfapiGetUnAddrOfVpnBi(bpi, &pfx_un)) {
 #if DEBUG_ENCAP_MONITOR
 			vnc_zlog_debug_verbose(
-				"%s: failed to get UN address of this VPN bi",
+				"%s: failed to get UN address of this VPN bpi",
 				__func__);
 #endif
 			continue;
@@ -1627,10 +1627,10 @@ static int rfapiNhlAddNodeRoutes(
 		*newpfx = pfx_vn;
 		skiplist_insert(seen_nexthops, newpfx, newpfx);
 
-		new = rfapiRouteInfo2NextHopEntry(rprefix, bi, lifetime, rn);
+		new = rfapiRouteInfo2NextHopEntry(rprefix, bpi, lifetime, rn);
 		if (new) {
 			if (rfapiRibPreloadBi(rfd_rib_node, &pfx_vn, &pfx_un,
-					      lifetime, bi)) {
+					      lifetime, bpi)) {
 				/* duplicate filtered by RIB */
 				rfapi_free_next_hop_list(new);
 				new = NULL;
@@ -1994,8 +1994,8 @@ struct rfapi_next_hop_entry *rfapiEthRouteTable2NextHopList(
 }
 
 /*
- * Insert a new bi to the imported route table node,
- * keeping the list of BIs sorted best route first
+ * Insert a new bpi to the imported route table node,
+ * keeping the list of BPIs sorted best route first
  */
 static void rfapiBgpInfoAttachSorted(struct agg_node *rn,
 				     struct bgp_path_info *info_new, afi_t afi,
@@ -2040,18 +2040,18 @@ static void rfapiBgpInfoAttachSorted(struct agg_node *rn,
 	bgp_attr_intern(info_new->attr);
 }
 
-static void rfapiBgpInfoDetach(struct agg_node *rn, struct bgp_path_info *bi)
+static void rfapiBgpInfoDetach(struct agg_node *rn, struct bgp_path_info *bpi)
 {
 	/*
 	 * Remove the route (doubly-linked)
 	 */
-	//  bgp_attr_unintern (&bi->attr);
-	if (bi->next)
-		bi->next->prev = bi->prev;
-	if (bi->prev)
-		bi->prev->next = bi->next;
+	//  bgp_attr_unintern (&bpi->attr);
+	if (bpi->next)
+		bpi->next->prev = bpi->prev;
+	if (bpi->prev)
+		bpi->prev->next = bpi->next;
 	else
-		rn->info = bi->next;
+		rn->info = bpi->next;
 }
 
 /*
@@ -2059,48 +2059,48 @@ static void rfapiBgpInfoDetach(struct agg_node *rn, struct bgp_path_info *bi)
  */
 static int rfapi_bi_peer_rd_cmp(void *b1, void *b2)
 {
-	struct bgp_path_info *bi1 = b1;
-	struct bgp_path_info *bi2 = b2;
+	struct bgp_path_info *bpi1 = b1;
+	struct bgp_path_info *bpi2 = b2;
 
 	/*
 	 * Compare peers
 	 */
-	if (bi1->peer < bi2->peer)
+	if (bpi1->peer < bpi2->peer)
 		return -1;
-	if (bi1->peer > bi2->peer)
+	if (bpi1->peer > bpi2->peer)
 		return 1;
 
 	/*
 	 * compare RDs
 	 */
-	return vnc_prefix_cmp((struct prefix *)&bi1->extra->vnc.import.rd,
-			      (struct prefix *)&bi2->extra->vnc.import.rd);
+	return vnc_prefix_cmp((struct prefix *)&bpi1->extra->vnc.import.rd,
+			      (struct prefix *)&bpi2->extra->vnc.import.rd);
 }
 
 /*
  * For L2-indexed import tables
- * The BIs in these tables should ALWAYS have an aux_prefix set because
+ * The BPIs in these tables should ALWAYS have an aux_prefix set because
  * they arrive via IPv4 or IPv6 advertisements.
  */
 static int rfapi_bi_peer_rd_aux_cmp(void *b1, void *b2)
 {
-	struct bgp_path_info *bi1 = b1;
-	struct bgp_path_info *bi2 = b2;
+	struct bgp_path_info *bpi1 = b1;
+	struct bgp_path_info *bpi2 = b2;
 	int rc;
 
 	/*
 	 * Compare peers
 	 */
-	if (bi1->peer < bi2->peer)
+	if (bpi1->peer < bpi2->peer)
 		return -1;
-	if (bi1->peer > bi2->peer)
+	if (bpi1->peer > bpi2->peer)
 		return 1;
 
 	/*
 	 * compare RDs
 	 */
-	rc = vnc_prefix_cmp((struct prefix *)&bi1->extra->vnc.import.rd,
-			    (struct prefix *)&bi2->extra->vnc.import.rd);
+	rc = vnc_prefix_cmp((struct prefix *)&bpi1->extra->vnc.import.rd,
+			    (struct prefix *)&bpi2->extra->vnc.import.rd);
 	if (rc) {
 		return rc;
 	}
@@ -2111,16 +2111,16 @@ static int rfapi_bi_peer_rd_aux_cmp(void *b1, void *b2)
 	 *
 	 * Use presence of aux_prefix with AF=ethernet and prefixlen=1
 	 * as magic value to signify explicit wildcarding of the aux_prefix.
-	 * This magic value will not appear in bona fide bi entries in
-	 * the import table, but is allowed in the "fake" bi used to
+	 * This magic value will not appear in bona fide bpi entries in
+	 * the import table, but is allowed in the "fake" bpi used to
 	 * probe the table when searching. (We have to test both b1 and b2
 	 * because there is no guarantee of the order the test key and
 	 * the real key will be passed)
 	 */
-	if ((bi1->extra->vnc.import.aux_prefix.family == AF_ETHERNET
-	     && (bi1->extra->vnc.import.aux_prefix.prefixlen == 1))
-	    || (bi2->extra->vnc.import.aux_prefix.family == AF_ETHERNET
-		&& (bi2->extra->vnc.import.aux_prefix.prefixlen == 1))) {
+	if ((bpi1->extra->vnc.import.aux_prefix.family == AF_ETHERNET
+	     && (bpi1->extra->vnc.import.aux_prefix.prefixlen == 1))
+	    || (bpi2->extra->vnc.import.aux_prefix.family == AF_ETHERNET
+		&& (bpi2->extra->vnc.import.aux_prefix.prefixlen == 1))) {
 
 		/*
 		 * wildcard aux address specified
@@ -2128,8 +2128,8 @@ static int rfapi_bi_peer_rd_aux_cmp(void *b1, void *b2)
 		return 0;
 	}
 
-	return vnc_prefix_cmp(&bi1->extra->vnc.import.aux_prefix,
-			      &bi2->extra->vnc.import.aux_prefix);
+	return vnc_prefix_cmp(&bpi1->extra->vnc.import.aux_prefix,
+			      &bpi2->extra->vnc.import.aux_prefix);
 }
 
 
@@ -2137,20 +2137,20 @@ static int rfapi_bi_peer_rd_aux_cmp(void *b1, void *b2)
  * Index on RD and Peer
  */
 static void rfapiItBiIndexAdd(struct agg_node *rn, /* Import table VPN node */
-			      struct bgp_path_info *bi) /* new BI */
+			      struct bgp_path_info *bpi) /* new BPI */
 {
 	struct skiplist *sl;
 
 	assert(rn);
-	assert(bi);
-	assert(bi->extra);
+	assert(bpi);
+	assert(bpi->extra);
 
 	{
 		char buf[RD_ADDRSTRLEN];
 
-		vnc_zlog_debug_verbose("%s: bi %p, peer %p, rd %s", __func__,
-				       bi, bi->peer,
-				       prefix_rd2str(&bi->extra->vnc.import.rd,
+		vnc_zlog_debug_verbose("%s: bpi %p, peer %p, rd %s", __func__,
+				       bpi, bpi->peer,
+				       prefix_rd2str(&bpi->extra->vnc.import.rd,
 						     buf, sizeof(buf)));
 	}
 
@@ -2164,10 +2164,10 @@ static void rfapiItBiIndexAdd(struct agg_node *rn, /* Import table VPN node */
 		RFAPI_IT_EXTRA_GET(rn)->u.vpn.idx_rd = sl;
 		agg_lock_node(rn); /* for skiplist */
 	}
-	assert(!skiplist_insert(sl, (void *)bi, (void *)bi));
+	assert(!skiplist_insert(sl, (void *)bpi, (void *)bpi));
 	agg_lock_node(rn); /* for skiplist entry */
 
-	/* NB: BIs in import tables are not refcounted */
+	/* NB: BPIs in import tables are not refcounted */
 }
 
 static void rfapiItBiIndexDump(struct agg_node *rn)
@@ -2195,7 +2195,7 @@ static void rfapiItBiIndexDump(struct agg_node *rn)
 		} else
 			strncpy(buf_aux_pfx, "(none)", PREFIX_STRLEN);
 
-		vnc_zlog_debug_verbose("bi %p, peer %p, rd %s, aux_prefix %s",
+		vnc_zlog_debug_verbose("bpi %p, peer %p, rd %s, aux_prefix %s",
 				       k, k->peer, buf, buf_aux_pfx);
 	}
 }
@@ -2207,9 +2207,9 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 {
 	struct skiplist *sl;
 	int rc;
-	struct bgp_path_info bi_fake;
-	struct bgp_path_info_extra bi_extra;
-	struct bgp_path_info *bi_result;
+	struct bgp_path_info bpi_fake;
+	struct bgp_path_info_extra bpi_extra;
+	struct bgp_path_info *bpi_result;
 
 	sl = RFAPI_RDINDEX(rn);
 	if (!sl)
@@ -2240,22 +2240,22 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 		vnc_zlog_debug_verbose("%s: short list algorithm", __func__);
 #endif
 		/* if short list, linear search might be faster */
-		for (bi_result = rn->info; bi_result;
-		     bi_result = bi_result->next) {
+		for (bpi_result = rn->info; bpi_result;
+		     bpi_result = bpi_result->next) {
 #if DEBUG_BI_SEARCH
 			{
 				char buf[RD_ADDRSTRLEN];
 
 				vnc_zlog_debug_verbose(
-					"%s: bi has prd=%s, peer=%p", __func__,
-					prefix_rd2str(&bi_result->extra->vnc
+					"%s: bpi has prd=%s, peer=%p", __func__,
+					prefix_rd2str(&bpi_result->extra->vnc
 							       .import.rd,
 						      buf, sizeof(buf)),
-					bi_result->peer);
+					bpi_result->peer);
 			}
 #endif
-			if (peer == bi_result->peer
-			    && !prefix_cmp((struct prefix *)&bi_result->extra
+			if (peer == bpi_result->peer
+			    && !prefix_cmp((struct prefix *)&bpi_result->extra
 						   ->vnc.import.rd,
 					   (struct prefix *)prd)) {
 
@@ -2265,9 +2265,10 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 					__func__);
 #endif
 				if (!aux_prefix
-				    || !prefix_cmp(aux_prefix,
-						   &bi_result->extra->vnc.import
-							    .aux_prefix)) {
+				    || !prefix_cmp(
+					       aux_prefix,
+					       &bpi_result->extra->vnc.import
+							.aux_prefix)) {
 
 #if DEBUG_BI_SEARCH
 					vnc_zlog_debug_verbose("%s: match",
@@ -2277,21 +2278,21 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 				}
 			}
 		}
-		return bi_result;
+		return bpi_result;
 	}
 
-	bi_fake.peer = peer;
-	bi_fake.extra = &bi_extra;
-	bi_fake.extra->vnc.import.rd = *(struct prefix_rd *)prd;
+	bpi_fake.peer = peer;
+	bpi_fake.extra = &bpi_extra;
+	bpi_fake.extra->vnc.import.rd = *(struct prefix_rd *)prd;
 	if (aux_prefix) {
-		bi_fake.extra->vnc.import.aux_prefix = *aux_prefix;
+		bpi_fake.extra->vnc.import.aux_prefix = *aux_prefix;
 	} else {
 		/* wildcard */
-		bi_fake.extra->vnc.import.aux_prefix.family = AF_ETHERNET;
-		bi_fake.extra->vnc.import.aux_prefix.prefixlen = 1;
+		bpi_fake.extra->vnc.import.aux_prefix.family = AF_ETHERNET;
+		bpi_fake.extra->vnc.import.aux_prefix.prefixlen = 1;
 	}
 
-	rc = skiplist_search(sl, (void *)&bi_fake, (void *)&bi_result);
+	rc = skiplist_search(sl, (void *)&bpi_fake, (void *)&bpi_result);
 
 	if (rc) {
 #if DEBUG_BI_SEARCH
@@ -2301,14 +2302,14 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 	}
 
 #if DEBUG_BI_SEARCH
-	vnc_zlog_debug_verbose("%s: matched bi=%p", __func__, bi_result);
+	vnc_zlog_debug_verbose("%s: matched bpi=%p", __func__, bpi_result);
 #endif
 
-	return bi_result;
+	return bpi_result;
 }
 
 static void rfapiItBiIndexDel(struct agg_node *rn, /* Import table VPN node */
-			      struct bgp_path_info *bi) /* old BI */
+			      struct bgp_path_info *bpi) /* old BPI */
 {
 	struct skiplist *sl;
 	int rc;
@@ -2316,16 +2317,16 @@ static void rfapiItBiIndexDel(struct agg_node *rn, /* Import table VPN node */
 	{
 		char buf[RD_ADDRSTRLEN];
 
-		vnc_zlog_debug_verbose("%s: bi %p, peer %p, rd %s", __func__,
-				       bi, bi->peer,
-				       prefix_rd2str(&bi->extra->vnc.import.rd,
+		vnc_zlog_debug_verbose("%s: bpi %p, peer %p, rd %s", __func__,
+				       bpi, bpi->peer,
+				       prefix_rd2str(&bpi->extra->vnc.import.rd,
 						     buf, sizeof(buf)));
 	}
 
 	sl = RFAPI_RDINDEX(rn);
 	assert(sl);
 
-	rc = skiplist_delete(sl, (void *)(bi), (void *)bi);
+	rc = skiplist_delete(sl, (void *)(bpi), (void *)bpi);
 	if (rc) {
 		rfapiItBiIndexDump(rn);
 	}
@@ -2333,7 +2334,7 @@ static void rfapiItBiIndexDel(struct agg_node *rn, /* Import table VPN node */
 
 	agg_unlock_node(rn); /* for skiplist entry */
 
-	/* NB: BIs in import tables are not refcounted */
+	/* NB: BPIs in import tables are not refcounted */
 }
 
 /*
@@ -2342,9 +2343,9 @@ static void rfapiItBiIndexDel(struct agg_node *rn, /* Import table VPN node */
  */
 static void
 rfapiMonitorEncapAdd(struct rfapi_import_table *import_table,
-		     struct prefix *p,		   /* VN address */
-		     struct agg_node *vpn_rn,      /* VPN node */
-		     struct bgp_path_info *vpn_bi) /* VPN bi/route */
+		     struct prefix *p,		    /* VN address */
+		     struct agg_node *vpn_rn,       /* VPN node */
+		     struct bgp_path_info *vpn_bpi) /* VPN bpi/route */
 {
 	afi_t afi = family2afi(p->family);
 	struct agg_node *rn;
@@ -2359,7 +2360,7 @@ rfapiMonitorEncapAdd(struct rfapi_import_table *import_table,
 	assert(m);
 
 	m->node = vpn_rn;
-	m->bi = vpn_bi;
+	m->bpi = vpn_bpi;
 	m->rn = rn;
 
 	/* insert to encap node's list */
@@ -2369,24 +2370,25 @@ rfapiMonitorEncapAdd(struct rfapi_import_table *import_table,
 	RFAPI_MONITOR_ENCAP_W_ALLOC(rn) = m;
 
 	/* for easy lookup when deleting vpn route */
-	vpn_bi->extra->vnc.import.hme = m;
+	vpn_bpi->extra->vnc.import.hme = m;
 
 	vnc_zlog_debug_verbose(
-		"%s: it=%p, vpn_bi=%p, afi=%d, encap rn=%p, setting vpn_bi->extra->vnc.import.hme=%p",
-		__func__, import_table, vpn_bi, afi, rn, m);
+		"%s: it=%p, vpn_bpi=%p, afi=%d, encap rn=%p, setting vpn_bpi->extra->vnc.import.hme=%p",
+		__func__, import_table, vpn_bpi, afi, rn, m);
 
 	RFAPI_CHECK_REFCOUNT(rn, SAFI_ENCAP, 0);
-	bgp_attr_intern(vpn_bi->attr);
+	bgp_attr_intern(vpn_bpi->attr);
 }
 
-static void rfapiMonitorEncapDelete(struct bgp_path_info *vpn_bi)
+static void rfapiMonitorEncapDelete(struct bgp_path_info *vpn_bpi)
 {
 	/*
 	 * Remove encap monitor
 	 */
-	vnc_zlog_debug_verbose("%s: vpn_bi=%p", __func__, vpn_bi);
-	if (vpn_bi->extra) {
-		struct rfapi_monitor_encap *hme = vpn_bi->extra->vnc.import.hme;
+	vnc_zlog_debug_verbose("%s: vpn_bpi=%p", __func__, vpn_bpi);
+	if (vpn_bpi->extra) {
+		struct rfapi_monitor_encap *hme =
+			vpn_bpi->extra->vnc.import.hme;
 
 		if (hme) {
 
@@ -2410,7 +2412,7 @@ static void rfapiMonitorEncapDelete(struct bgp_path_info *vpn_bi)
 
 			agg_unlock_node(hme->rn); /* decr ref count */
 			XFREE(MTYPE_RFAPI_MONITOR_ENCAP, hme);
-			vpn_bi->extra->vnc.import.hme = NULL;
+			vpn_bpi->extra->vnc.import.hme = NULL;
 		}
 	}
 }
@@ -2422,16 +2424,16 @@ static void rfapiMonitorEncapDelete(struct bgp_path_info *vpn_bi)
 static int rfapiWithdrawTimerVPN(struct thread *t)
 {
 	struct rfapi_withdraw *wcb = t->arg;
-	struct bgp_path_info *bi = wcb->info;
+	struct bgp_path_info *bpi = wcb->info;
 	struct bgp *bgp = bgp_get_default();
 
 	struct rfapi_monitor_vpn *moved;
 	afi_t afi;
 
 	assert(wcb->node);
-	assert(bi);
+	assert(bpi);
 	assert(wcb->import_table);
-	assert(bi->extra);
+	assert(bpi->extra);
 
 	RFAPI_CHECK_REFCOUNT(wcb->node, SAFI_MPLS_VPN, wcb->lockoffset);
 
@@ -2439,7 +2441,7 @@ static int rfapiWithdrawTimerVPN(struct thread *t)
 		char buf[BUFSIZ];
 
 		vnc_zlog_debug_verbose(
-			"%s: removing bi %p at prefix %s/%d", __func__, bi,
+			"%s: removing bpi %p at prefix %s/%d", __func__, bpi,
 			rfapi_ntop(wcb->node->p.family, &wcb->node->p.u.prefix,
 				   buf, BUFSIZ),
 			wcb->node->p.prefixlen);
@@ -2448,17 +2450,17 @@ static int rfapiWithdrawTimerVPN(struct thread *t)
 	/*
 	 * Remove the route (doubly-linked)
 	 */
-	if (CHECK_FLAG(bi->flags, BGP_PATH_VALID)
-	    && VALID_INTERIOR_TYPE(bi->type))
+	if (CHECK_FLAG(bpi->flags, BGP_PATH_VALID)
+	    && VALID_INTERIOR_TYPE(bpi->type))
 		RFAPI_MONITOR_EXTERIOR(wcb->node)->valid_interior_count--;
 
 	afi = family2afi(wcb->node->p.family);
 	wcb->import_table->holddown_count[afi] -= 1; /* keep count consistent */
-	rfapiItBiIndexDel(wcb->node, bi);
-	rfapiBgpInfoDetach(wcb->node, bi); /* with removed bi */
+	rfapiItBiIndexDel(wcb->node, bpi);
+	rfapiBgpInfoDetach(wcb->node, bpi); /* with removed bpi */
 
 	vnc_import_bgp_exterior_del_route_interior(bgp, wcb->import_table,
-						   wcb->node, bi);
+						   wcb->node, bpi);
 
 
 	/*
@@ -2470,7 +2472,7 @@ static int rfapiWithdrawTimerVPN(struct thread *t)
 	      & BGP_VNC_CONFIG_RESPONSE_REMOVAL_DISABLE)) {
 
 		int has_valid_duplicate = 0;
-		struct bgp_path_info *bii;
+		struct bgp_path_info *bpii;
 
 		/*
 		 * First check if there are any OTHER routes at this node
@@ -2478,8 +2480,8 @@ static int rfapiWithdrawTimerVPN(struct thread *t)
 		 * there are (e.g., from other peers), then the route isn't
 		 * really gone, so skip sending a response removal message.
 		 */
-		for (bii = wcb->node->info; bii; bii = bii->next) {
-			if (rfapiVpnBiSamePtUn(bi, bii)) {
+		for (bpii = wcb->node->info; bpii; bpii = bpii->next) {
+			if (rfapiVpnBiSamePtUn(bpi, bpii)) {
 				has_valid_duplicate = 1;
 				break;
 			}
@@ -2494,7 +2496,7 @@ static int rfapiWithdrawTimerVPN(struct thread *t)
 		}
 	}
 
-	rfapiMonitorEncapDelete(bi);
+	rfapiMonitorEncapDelete(bpi);
 
 	/*
 	 * If there are no VPN monitors at this VPN Node A,
@@ -2519,9 +2521,9 @@ static int rfapiWithdrawTimerVPN(struct thread *t)
 
 done:
 	/*
-	 * Free VPN bi
+	 * Free VPN bpi
 	 */
-	rfapiBgpInfoFree(bi);
+	rfapiBgpInfoFree(bpi);
 	wcb->info = NULL;
 
 	/*
@@ -2618,48 +2620,48 @@ static int rfapiAttrNexthopAddrDifferent(struct prefix *p1, struct prefix *p2)
 	return 1;
 }
 
-static void rfapiCopyUnEncap2VPN(struct bgp_path_info *encap_bi,
-				 struct bgp_path_info *vpn_bi)
+static void rfapiCopyUnEncap2VPN(struct bgp_path_info *encap_bpi,
+				 struct bgp_path_info *vpn_bpi)
 {
-	if (!encap_bi->attr) {
-		zlog_warn("%s: no encap bi attr/extra, can't copy UN address",
+	if (!encap_bpi->attr) {
+		zlog_warn("%s: no encap bpi attr/extra, can't copy UN address",
 			  __func__);
 		return;
 	}
 
-	if (!vpn_bi || !vpn_bi->extra) {
-		zlog_warn("%s: no vpn  bi attr/extra, can't copy UN address",
+	if (!vpn_bpi || !vpn_bpi->extra) {
+		zlog_warn("%s: no vpn  bpi attr/extra, can't copy UN address",
 			  __func__);
 		return;
 	}
 
-	switch (BGP_MP_NEXTHOP_FAMILY(encap_bi->attr->mp_nexthop_len)) {
+	switch (BGP_MP_NEXTHOP_FAMILY(encap_bpi->attr->mp_nexthop_len)) {
 	case AF_INET:
 
 		/*
 		 * instrumentation to debug segfault of 091127
 		 */
-		vnc_zlog_debug_verbose("%s: vpn_bi=%p", __func__, vpn_bi);
-		if (vpn_bi) {
-			vnc_zlog_debug_verbose("%s: vpn_bi->extra=%p", __func__,
-					       vpn_bi->extra);
+		vnc_zlog_debug_verbose("%s: vpn_bpi=%p", __func__, vpn_bpi);
+		if (vpn_bpi) {
+			vnc_zlog_debug_verbose("%s: vpn_bpi->extra=%p",
+					       __func__, vpn_bpi->extra);
 		}
 
-		vpn_bi->extra->vnc.import.un_family = AF_INET;
-		vpn_bi->extra->vnc.import.un.addr4 =
-			encap_bi->attr->mp_nexthop_global_in;
+		vpn_bpi->extra->vnc.import.un_family = AF_INET;
+		vpn_bpi->extra->vnc.import.un.addr4 =
+			encap_bpi->attr->mp_nexthop_global_in;
 		break;
 
 	case AF_INET6:
-		vpn_bi->extra->vnc.import.un_family = AF_INET6;
-		vpn_bi->extra->vnc.import.un.addr6 =
-			encap_bi->attr->mp_nexthop_global;
+		vpn_bpi->extra->vnc.import.un_family = AF_INET6;
+		vpn_bpi->extra->vnc.import.un.addr6 =
+			encap_bpi->attr->mp_nexthop_global;
 		break;
 
 	default:
 		zlog_warn("%s: invalid encap nexthop length: %d", __func__,
-			  encap_bi->attr->mp_nexthop_len);
-		vpn_bi->extra->vnc.import.un_family = 0;
+			  encap_bpi->attr->mp_nexthop_len);
+		vpn_bpi->extra->vnc.import.un_family = 0;
 		break;
 	}
 }
@@ -2667,55 +2669,57 @@ static void rfapiCopyUnEncap2VPN(struct bgp_path_info *encap_bi,
 /*
  * returns 0 on success, nonzero on error
  */
-static int rfapiWithdrawEncapUpdateCachedUn(
-	struct rfapi_import_table *import_table, struct bgp_path_info *encap_bi,
-	struct agg_node *vpn_rn, struct bgp_path_info *vpn_bi)
+static int
+rfapiWithdrawEncapUpdateCachedUn(struct rfapi_import_table *import_table,
+				 struct bgp_path_info *encap_bpi,
+				 struct agg_node *vpn_rn,
+				 struct bgp_path_info *vpn_bpi)
 {
-	if (!encap_bi) {
+	if (!encap_bpi) {
 
 		/*
 		 * clear cached UN address
 		 */
-		if (!vpn_bi || !vpn_bi->extra) {
+		if (!vpn_bpi || !vpn_bpi->extra) {
 			zlog_warn(
-				"%s: missing VPN bi/extra, can't clear UN addr",
+				"%s: missing VPN bpi/extra, can't clear UN addr",
 				__func__);
 			return 1;
 		}
-		vpn_bi->extra->vnc.import.un_family = 0;
-		memset(&vpn_bi->extra->vnc.import.un, 0,
-		       sizeof(vpn_bi->extra->vnc.import.un));
-		if (CHECK_FLAG(vpn_bi->flags, BGP_PATH_VALID)) {
-			if (rfapiGetVncTunnelUnAddr(vpn_bi->attr, NULL)) {
-				UNSET_FLAG(vpn_bi->flags, BGP_PATH_VALID);
-				if (VALID_INTERIOR_TYPE(vpn_bi->type))
+		vpn_bpi->extra->vnc.import.un_family = 0;
+		memset(&vpn_bpi->extra->vnc.import.un, 0,
+		       sizeof(vpn_bpi->extra->vnc.import.un));
+		if (CHECK_FLAG(vpn_bpi->flags, BGP_PATH_VALID)) {
+			if (rfapiGetVncTunnelUnAddr(vpn_bpi->attr, NULL)) {
+				UNSET_FLAG(vpn_bpi->flags, BGP_PATH_VALID);
+				if (VALID_INTERIOR_TYPE(vpn_bpi->type))
 					RFAPI_MONITOR_EXTERIOR(vpn_rn)
 						->valid_interior_count--;
 				/* signal interior route withdrawal to
 				 * import-exterior */
 				vnc_import_bgp_exterior_del_route_interior(
 					bgp_get_default(), import_table, vpn_rn,
-					vpn_bi);
+					vpn_bpi);
 			}
 		}
 
 	} else {
-		if (!vpn_bi) {
-			zlog_warn("%s: missing VPN bi, can't clear UN addr",
+		if (!vpn_bpi) {
+			zlog_warn("%s: missing VPN bpi, can't clear UN addr",
 				  __func__);
 			return 1;
 		}
-		rfapiCopyUnEncap2VPN(encap_bi, vpn_bi);
-		if (!CHECK_FLAG(vpn_bi->flags, BGP_PATH_VALID)) {
-			SET_FLAG(vpn_bi->flags, BGP_PATH_VALID);
-			if (VALID_INTERIOR_TYPE(vpn_bi->type))
+		rfapiCopyUnEncap2VPN(encap_bpi, vpn_bpi);
+		if (!CHECK_FLAG(vpn_bpi->flags, BGP_PATH_VALID)) {
+			SET_FLAG(vpn_bpi->flags, BGP_PATH_VALID);
+			if (VALID_INTERIOR_TYPE(vpn_bpi->type))
 				RFAPI_MONITOR_EXTERIOR(vpn_rn)
 					->valid_interior_count++;
 			/* signal interior route withdrawal to import-exterior
 			 */
 			vnc_import_bgp_exterior_add_route_interior(
 				bgp_get_default(), import_table, vpn_rn,
-				vpn_bi);
+				vpn_bpi);
 		}
 	}
 	return 0;
@@ -2724,25 +2728,25 @@ static int rfapiWithdrawEncapUpdateCachedUn(
 static int rfapiWithdrawTimerEncap(struct thread *t)
 {
 	struct rfapi_withdraw *wcb = t->arg;
-	struct bgp_path_info *bi = wcb->info;
+	struct bgp_path_info *bpi = wcb->info;
 	int was_first_route = 0;
 	struct rfapi_monitor_encap *em;
 	struct skiplist *vpn_node_sl = skiplist_new(0, NULL, NULL);
 
 	assert(wcb->node);
-	assert(bi);
+	assert(bpi);
 	assert(wcb->import_table);
 
 	RFAPI_CHECK_REFCOUNT(wcb->node, SAFI_ENCAP, 0);
 
-	if (wcb->node->info == bi)
+	if (wcb->node->info == bpi)
 		was_first_route = 1;
 
 	/*
-	 * Remove the route/bi and free it
+	 * Remove the route/bpi and free it
 	 */
-	rfapiBgpInfoDetach(wcb->node, bi);
-	rfapiBgpInfoFree(bi);
+	rfapiBgpInfoDetach(wcb->node, bpi);
+	rfapiBgpInfoFree(bpi);
 
 	if (!was_first_route)
 		goto done;
@@ -2750,13 +2754,13 @@ static int rfapiWithdrawTimerEncap(struct thread *t)
 	for (em = RFAPI_MONITOR_ENCAP(wcb->node); em; em = em->next) {
 
 		/*
-		 * Update monitoring VPN BIs with new encap info at the
-		 * head of the encap bi chain (which could be NULL after
-		 * removing the expiring bi above)
+		 * Update monitoring VPN BPIs with new encap info at the
+		 * head of the encap bpi chain (which could be NULL after
+		 * removing the expiring bpi above)
 		 */
 		if (rfapiWithdrawEncapUpdateCachedUn(wcb->import_table,
 						     wcb->node->info, em->node,
-						     em->bi))
+						     em->bpi))
 			continue;
 
 		/*
@@ -2805,14 +2809,14 @@ done:
  */
 static void
 rfapiBiStartWithdrawTimer(struct rfapi_import_table *import_table,
-			  struct agg_node *rn, struct bgp_path_info *bi,
+			  struct agg_node *rn, struct bgp_path_info *bpi,
 			  afi_t afi, safi_t safi,
 			  int (*timer_service_func)(struct thread *))
 {
 	uint32_t lifetime;
 	struct rfapi_withdraw *wcb;
 
-	if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
+	if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
 		/*
 		 * Already on the path to being withdrawn,
 		 * should already have a timer set up to
@@ -2823,13 +2827,13 @@ rfapiBiStartWithdrawTimer(struct rfapi_import_table *import_table,
 		return;
 	}
 
-	rfapiGetVncLifetime(bi->attr, &lifetime);
+	rfapiGetVncLifetime(bpi->attr, &lifetime);
 	vnc_zlog_debug_verbose("%s: VNC lifetime is %u", __func__, lifetime);
 
 	/*
 	 * withdrawn routes get to hang around for a while
 	 */
-	SET_FLAG(bi->flags, BGP_PATH_REMOVED);
+	SET_FLAG(bpi->flags, BGP_PATH_REMOVED);
 
 	/* set timer to remove the route later */
 	lifetime = rfapiGetHolddownFromLifetime(lifetime);
@@ -2842,24 +2846,24 @@ rfapiBiStartWithdrawTimer(struct rfapi_import_table *import_table,
 	wcb = XCALLOC(MTYPE_RFAPI_WITHDRAW, sizeof(struct rfapi_withdraw));
 	assert(wcb);
 	wcb->node = rn;
-	wcb->info = bi;
+	wcb->info = bpi;
 	wcb->import_table = import_table;
-	bgp_attr_intern(bi->attr);
+	bgp_attr_intern(bpi->attr);
 
 	if (VNC_DEBUG(VERBOSE)) {
 		vnc_zlog_debug_verbose(
-			"%s: wcb values: node=%p, info=%p, import_table=%p (bi follows)",
+			"%s: wcb values: node=%p, info=%p, import_table=%p (bpi follows)",
 			__func__, wcb->node, wcb->info, wcb->import_table);
-		rfapiPrintBi(NULL, bi);
+		rfapiPrintBi(NULL, bpi);
 	}
 
 
-	assert(bi->extra);
+	assert(bpi->extra);
 	if (lifetime > UINT32_MAX / 1001) {
 		/* sub-optimal case, but will probably never happen */
-		bi->extra->vnc.import.timer = NULL;
+		bpi->extra->vnc.import.timer = NULL;
 		thread_add_timer(bm->master, timer_service_func, wcb, lifetime,
-				 &bi->extra->vnc.import.timer);
+				 &bpi->extra->vnc.import.timer);
 	} else {
 		static uint32_t jitter;
 		uint32_t lifetime_msec;
@@ -2873,16 +2877,16 @@ rfapiBiStartWithdrawTimer(struct rfapi_import_table *import_table,
 
 		lifetime_msec = (lifetime * 1000) + jitter;
 
-		bi->extra->vnc.import.timer = NULL;
+		bpi->extra->vnc.import.timer = NULL;
 		thread_add_timer_msec(bm->master, timer_service_func, wcb,
 				      lifetime_msec,
-				      &bi->extra->vnc.import.timer);
+				      &bpi->extra->vnc.import.timer);
 	}
 
 	/* re-sort route list (BGP_PATH_REMOVED routes are last) */
 	if (((struct bgp_path_info *)rn->info)->next) {
-		rfapiBgpInfoDetach(rn, bi);
-		rfapiBgpInfoAttachSorted(rn, bi, afi, safi);
+		rfapiBgpInfoDetach(rn, bpi);
+		rfapiBgpInfoAttachSorted(rn, bpi, afi, safi);
 	}
 }
 
@@ -2895,7 +2899,7 @@ typedef void(rfapi_bi_filtered_import_f)(struct rfapi_import_table *, int,
 
 
 static void rfapiExpireEncapNow(struct rfapi_import_table *it,
-				struct agg_node *rn, struct bgp_path_info *bi)
+				struct agg_node *rn, struct bgp_path_info *bpi)
 {
 	struct rfapi_withdraw *wcb;
 	struct thread t;
@@ -2904,7 +2908,7 @@ static void rfapiExpireEncapNow(struct rfapi_import_table *it,
 	 * pretend we're an expiring timer
 	 */
 	wcb = XCALLOC(MTYPE_RFAPI_WITHDRAW, sizeof(struct rfapi_withdraw));
-	wcb->info = bi;
+	wcb->info = bpi;
 	wcb->node = rn;
 	wcb->import_table = it;
 	memset(&t, 0, sizeof(t));
@@ -2951,12 +2955,12 @@ static void rfapiBgpInfoFilteredImportEncap(
 	struct agg_table *rt = NULL;
 	struct agg_node *rn;
 	struct bgp_path_info *info_new;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct bgp_path_info *next;
 	char buf[BUFSIZ];
 
-	struct prefix p_firstbi_old;
-	struct prefix p_firstbi_new;
+	struct prefix p_firstbpi_old;
+	struct prefix p_firstbpi_new;
 	int replacing = 0;
 	const char *action_str = NULL;
 	struct prefix un_prefix;
@@ -2983,8 +2987,8 @@ static void rfapiBgpInfoFilteredImportEncap(
 		"%s: entry: %s: prefix %s/%d", __func__, action_str,
 		inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ), p->prefixlen);
 
-	memset(&p_firstbi_old, 0, sizeof(p_firstbi_old));
-	memset(&p_firstbi_new, 0, sizeof(p_firstbi_new));
+	memset(&p_firstbpi_old, 0, sizeof(p_firstbpi_old));
+	memset(&p_firstbpi_new, 0, sizeof(p_firstbpi_new));
 
 	if (action == FIF_ACTION_UPDATE) {
 		/*
@@ -3060,37 +3064,37 @@ static void rfapiBgpInfoFilteredImportEncap(
 
 
 		/*
-		 * capture nexthop of first bi
+		 * capture nexthop of first bpi
 		 */
 		if (rn->info) {
 			rfapiNexthop2Prefix(
 				((struct bgp_path_info *)(rn->info))->attr,
-				&p_firstbi_old);
+				&p_firstbpi_old);
 		}
 
-		for (bi = rn->info; bi; bi = bi->next) {
+		for (bpi = rn->info; bpi; bpi = bpi->next) {
 
 			/*
 			 * Does this bgp_path_info refer to the same route
 			 * as we are trying to add?
 			 */
-			vnc_zlog_debug_verbose("%s: comparing BI %p", __func__,
-					       bi);
+			vnc_zlog_debug_verbose("%s: comparing BPI %p", __func__,
+					       bpi);
 
 
 			/*
 			 * Compare RDs
 			 *
-			 * RD of import table bi is in bi->extra->vnc.import.rd
-			 * RD of info_orig is in prd
+			 * RD of import table bpi is in
+			 * bpi->extra->vnc.import.rd RD of info_orig is in prd
 			 */
-			if (!bi->extra) {
-				vnc_zlog_debug_verbose("%s: no bi->extra",
+			if (!bpi->extra) {
+				vnc_zlog_debug_verbose("%s: no bpi->extra",
 						       __func__);
 				continue;
 			}
 			if (prefix_cmp(
-				    (struct prefix *)&bi->extra->vnc.import.rd,
+				    (struct prefix *)&bpi->extra->vnc.import.rd,
 				    (struct prefix *)prd)) {
 
 				vnc_zlog_debug_verbose("%s: prd does not match",
@@ -3101,16 +3105,16 @@ static void rfapiBgpInfoFilteredImportEncap(
 			/*
 			 * Compare peers
 			 */
-			if (bi->peer != peer) {
+			if (bpi->peer != peer) {
 				vnc_zlog_debug_verbose(
 					"%s: peer does not match", __func__);
 				continue;
 			}
 
-			vnc_zlog_debug_verbose("%s: found matching bi",
+			vnc_zlog_debug_verbose("%s: found matching bpi",
 					       __func__);
 
-			/* Same route. Delete this bi, replace with new one */
+			/* Same route. Delete this bpi, replace with new one */
 
 			if (action == FIF_ACTION_WITHDRAW) {
 
@@ -3122,7 +3126,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 					rn->p.prefixlen);
 
 				rfapiBiStartWithdrawTimer(
-					import_table, rn, bi, afi, SAFI_ENCAP,
+					import_table, rn, bpi, afi, SAFI_ENCAP,
 					rfapiWithdrawTimerEncap);
 
 			} else {
@@ -3141,11 +3145,11 @@ static void rfapiBgpInfoFilteredImportEncap(
 				 * a previous withdraw, we must cancel its
 				 * timer.
 				 */
-				if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)
-				    && bi->extra->vnc.import.timer) {
+				if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)
+				    && bpi->extra->vnc.import.timer) {
 
 					struct thread *t =
-						(struct thread *)bi->extra->vnc
+						(struct thread *)bpi->extra->vnc
 							.import.timer;
 					struct rfapi_withdraw *wcb = t->arg;
 
@@ -3154,13 +3158,13 @@ static void rfapiBgpInfoFilteredImportEncap(
 				}
 
 				if (action == FIF_ACTION_UPDATE) {
-					rfapiBgpInfoDetach(rn, bi);
-					rfapiBgpInfoFree(bi);
+					rfapiBgpInfoDetach(rn, bpi);
+					rfapiBgpInfoFree(bpi);
 					replacing = 1;
 				} else {
 					/*
 					 * Kill: do export stuff when removing
-					 * bi
+					 * bpi
 					 */
 					struct rfapi_withdraw *wcb;
 					struct thread t;
@@ -3171,7 +3175,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 					wcb = XCALLOC(
 						MTYPE_RFAPI_WITHDRAW,
 						sizeof(struct rfapi_withdraw));
-					wcb->info = bi;
+					wcb->info = bpi;
 					wcb->node = rn;
 					wcb->import_table = import_table;
 					memset(&t, 0, sizeof(t));
@@ -3196,7 +3200,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 
 	if (rn) {
 		if (!replacing)
-			agg_lock_node(rn); /* incr ref count for new BI */
+			agg_lock_node(rn); /* incr ref count for new BPI */
 	} else {
 		rn = agg_node_get(rt, p);
 	}
@@ -3212,13 +3216,13 @@ static void rfapiBgpInfoFilteredImportEncap(
 	 * Delete holddown routes from same NVE. See details in
 	 * rfapiBgpInfoFilteredImportVPN()
 	 */
-	for (bi = info_new->next; bi; bi = next) {
+	for (bpi = info_new->next; bpi; bpi = next) {
 
 		struct prefix pfx_un;
 		int un_match = 0;
 
-		next = bi->next;
-		if (!CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
+		next = bpi->next;
+		if (!CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED))
 			continue;
 
 		/*
@@ -3226,7 +3230,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 		 * of the route node)
 		 */
 
-		if (!rfapiGetNexthop(bi->attr, &pfx_un)
+		if (!rfapiGetNexthop(bpi->attr, &pfx_un)
 		    && prefix_same(&pfx_un, &un_prefix)) {
 
 			un_match = 1;
@@ -3236,21 +3240,21 @@ static void rfapiBgpInfoFilteredImportEncap(
 			continue;
 
 		vnc_zlog_debug_verbose(
-			"%s: removing holddown bi matching NVE of new route",
+			"%s: removing holddown bpi matching NVE of new route",
 			__func__);
-		if (bi->extra->vnc.import.timer) {
+		if (bpi->extra->vnc.import.timer) {
 			struct thread *t =
-				(struct thread *)bi->extra->vnc.import.timer;
+				(struct thread *)bpi->extra->vnc.import.timer;
 			struct rfapi_withdraw *wcb = t->arg;
 
 			XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 			thread_cancel(t);
 		}
-		rfapiExpireEncapNow(import_table, rn, bi);
+		rfapiExpireEncapNow(import_table, rn, bpi);
 	}
 
 	rfapiNexthop2Prefix(((struct bgp_path_info *)(rn->info))->attr,
-			    &p_firstbi_new);
+			    &p_firstbpi_new);
 
 	/*
 	 * If the nexthop address of the selected Encap route (i.e.,
@@ -3258,7 +3262,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 	 * routes that refer to this Encap route and possibly force
 	 * rfapi callbacks.
 	 */
-	if (rfapiAttrNexthopAddrDifferent(&p_firstbi_old, &p_firstbi_new)) {
+	if (rfapiAttrNexthopAddrDifferent(&p_firstbpi_old, &p_firstbpi_new)) {
 
 		struct rfapi_monitor_encap *m;
 		struct rfapi_monitor_encap *mnext;
@@ -3289,19 +3293,19 @@ static void rfapiBgpInfoFilteredImportEncap(
 		for (m = RFAPI_MONITOR_ENCAP(rn); m; m = m->next) {
 
 			/*
-			 * For each referenced bi/route, copy the ENCAP route's
+			 * For each referenced bpi/route, copy the ENCAP route's
 			 * nexthop to the VPN route's cached UN address field
 			 * and set
 			 * the address family of the cached UN address field.
 			 */
-			rfapiCopyUnEncap2VPN(info_new, m->bi);
-			if (!CHECK_FLAG(m->bi->flags, BGP_PATH_VALID)) {
-				SET_FLAG(m->bi->flags, BGP_PATH_VALID);
-				if (VALID_INTERIOR_TYPE(m->bi->type))
+			rfapiCopyUnEncap2VPN(info_new, m->bpi);
+			if (!CHECK_FLAG(m->bpi->flags, BGP_PATH_VALID)) {
+				SET_FLAG(m->bpi->flags, BGP_PATH_VALID);
+				if (VALID_INTERIOR_TYPE(m->bpi->type))
 					RFAPI_MONITOR_EXTERIOR(m->node)
 						->valid_interior_count++;
 				vnc_import_bgp_exterior_add_route_interior(
-					bgp, import_table, m->node, m->bi);
+					bgp, import_table, m->node, m->bpi);
 			}
 
 			/*
@@ -3374,7 +3378,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 }
 
 static void rfapiExpireVpnNow(struct rfapi_import_table *it,
-			      struct agg_node *rn, struct bgp_path_info *bi,
+			      struct agg_node *rn, struct bgp_path_info *bpi,
 			      int lockoffset)
 {
 	struct rfapi_withdraw *wcb;
@@ -3384,7 +3388,7 @@ static void rfapiExpireVpnNow(struct rfapi_import_table *it,
 	 * pretend we're an expiring timer
 	 */
 	wcb = XCALLOC(MTYPE_RFAPI_WITHDRAW, sizeof(struct rfapi_withdraw));
-	wcb->info = bi;
+	wcb->info = bpi;
 	wcb->node = rn;
 	wcb->import_table = it;
 	wcb->lockoffset = lockoffset;
@@ -3413,7 +3417,7 @@ void rfapiBgpInfoFilteredImportVPN(
 	struct agg_node *rn;
 	struct agg_node *n;
 	struct bgp_path_info *info_new;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct bgp_path_info *next;
 	char buf[BUFSIZ];
 	struct prefix vn_prefix;
@@ -3529,25 +3533,25 @@ void rfapiBgpInfoFilteredImportVPN(
 		/*
 		 * Look for same route (will have same RD and peer)
 		 */
-		bi = rfapiItBiIndexSearch(rn, prd, peer, aux_prefix);
+		bpi = rfapiItBiIndexSearch(rn, prd, peer, aux_prefix);
 
-		if (bi) {
+		if (bpi) {
 
 			/*
 			 * This was an old test when we iterated over the
-			 * BIs linearly. Since we're now looking up with
+			 * BPIs linearly. Since we're now looking up with
 			 * RD and peer, comparing types should not be
 			 * needed. Changed to assertion.
 			 *
 			 * Compare types. Doing so prevents a RFP-originated
 			 * route from matching an imported route, for example.
 			 */
-			if (VNC_DEBUG(VERBOSE) && bi->type != type)
+			if (VNC_DEBUG(VERBOSE) && bpi->type != type)
 				/* should be handled by RDs, but warn for now */
-				zlog_warn("%s: type mismatch! (bi=%d, arg=%d)",
-					  __func__, bi->type, type);
+				zlog_warn("%s: type mismatch! (bpi=%d, arg=%d)",
+					  __func__, bpi->type, type);
 
-			vnc_zlog_debug_verbose("%s: found matching bi",
+			vnc_zlog_debug_verbose("%s: found matching bpi",
 					       __func__);
 
 			/*
@@ -3555,15 +3559,15 @@ void rfapiBgpInfoFilteredImportVPN(
 			 * holddown
 			 */
 			if (import_table == bgp->rfapi->it_ce) {
-				vnc_direct_bgp_del_route_ce(bgp, rn, bi);
+				vnc_direct_bgp_del_route_ce(bgp, rn, bpi);
 				if (action == FIF_ACTION_WITHDRAW)
 					action = FIF_ACTION_KILL;
 			}
 
 			if (action == FIF_ACTION_WITHDRAW) {
 
-				int washolddown =
-					CHECK_FLAG(bi->flags, BGP_PATH_REMOVED);
+				int washolddown = CHECK_FLAG(bpi->flags,
+							     BGP_PATH_REMOVED);
 
 				vnc_zlog_debug_verbose(
 					"%s: withdrawing at prefix %s/%d%s",
@@ -3578,12 +3582,12 @@ void rfapiBgpInfoFilteredImportVPN(
 				VNC_ITRCCK;
 				if (!washolddown) {
 					rfapiBiStartWithdrawTimer(
-						import_table, rn, bi, afi,
+						import_table, rn, bpi, afi,
 						SAFI_MPLS_VPN,
 						rfapiWithdrawTimerVPN);
 
 					RFAPI_UPDATE_ITABLE_COUNT(
-						bi, import_table, afi, -1);
+						bpi, import_table, afi, -1);
 					import_table->holddown_count[afi] += 1;
 				}
 				VNC_ITRCCK;
@@ -3604,11 +3608,11 @@ void rfapiBgpInfoFilteredImportVPN(
 				 * a previous withdraw, we must cancel its
 				 * timer.
 				 */
-				if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)
-				    && bi->extra->vnc.import.timer) {
+				if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)
+				    && bpi->extra->vnc.import.timer) {
 
 					struct thread *t =
-						(struct thread *)bi->extra->vnc
+						(struct thread *)bpi->extra->vnc
 							.import.timer;
 					struct rfapi_withdraw *wcb = t->arg;
 
@@ -3617,15 +3621,15 @@ void rfapiBgpInfoFilteredImportVPN(
 
 					import_table->holddown_count[afi] -= 1;
 					RFAPI_UPDATE_ITABLE_COUNT(
-						bi, import_table, afi, 1);
+						bpi, import_table, afi, 1);
 				}
 				/*
 				 * decrement remote count (if route is remote)
 				 * because
 				 * we are going to remove it below
 				 */
-				RFAPI_UPDATE_ITABLE_COUNT(bi, import_table, afi,
-							  -1);
+				RFAPI_UPDATE_ITABLE_COUNT(bpi, import_table,
+							  afi, -1);
 				if (action == FIF_ACTION_UPDATE) {
 					replacing = 1;
 
@@ -3633,31 +3637,31 @@ void rfapiBgpInfoFilteredImportVPN(
 					 * make copy of original nexthop so we
 					 * can see if it changed
 					 */
-					rfapiGetNexthop(bi->attr,
+					rfapiGetNexthop(bpi->attr,
 							&original_nexthop);
 
 					/*
-					 * remove bi without doing any export
+					 * remove bpi without doing any export
 					 * processing
 					 */
-					if (CHECK_FLAG(bi->flags,
+					if (CHECK_FLAG(bpi->flags,
 						       BGP_PATH_VALID)
-					    && VALID_INTERIOR_TYPE(bi->type))
+					    && VALID_INTERIOR_TYPE(bpi->type))
 						RFAPI_MONITOR_EXTERIOR(rn)
 							->valid_interior_count--;
-					rfapiItBiIndexDel(rn, bi);
-					rfapiBgpInfoDetach(rn, bi);
-					rfapiMonitorEncapDelete(bi);
+					rfapiItBiIndexDel(rn, bpi);
+					rfapiBgpInfoDetach(rn, bpi);
+					rfapiMonitorEncapDelete(bpi);
 					vnc_import_bgp_exterior_del_route_interior(
-						bgp, import_table, rn, bi);
-					rfapiBgpInfoFree(bi);
+						bgp, import_table, rn, bpi);
+					rfapiBgpInfoFree(bpi);
 				} else {
 					/* Kill */
 					/*
-					 * remove bi and do export processing
+					 * remove bpi and do export processing
 					 */
 					import_table->holddown_count[afi] += 1;
-					rfapiExpireVpnNow(import_table, rn, bi,
+					rfapiExpireVpnNow(import_table, rn, bpi,
 							  0);
 				}
 			}
@@ -3705,16 +3709,17 @@ void rfapiBgpInfoFilteredImportVPN(
 
 	/*
 	 * For ethernet routes, if there is an accompanying IP address,
-	 * save it in the bi
+	 * save it in the bpi
 	 */
 	if ((AFI_L2VPN == afi) && aux_prefix) {
 
-		vnc_zlog_debug_verbose("%s: setting BI's aux_prefix", __func__);
+		vnc_zlog_debug_verbose("%s: setting BPI's aux_prefix",
+				       __func__);
 		info_new->extra->vnc.import.aux_prefix = *aux_prefix;
 	}
 
 	vnc_zlog_debug_verbose(
-		"%s: inserting bi %p at prefix %s/%d #%d", __func__, info_new,
+		"%s: inserting bpi %p at prefix %s/%d #%d", __func__, info_new,
 		rfapi_ntop(rn->p.family, &rn->p.u.prefix, buf, BUFSIZ),
 		rn->p.prefixlen, rn->lock);
 
@@ -3784,40 +3789,40 @@ void rfapiBgpInfoFilteredImportVPN(
 	 * by the fresh route).
 	 */
 	/*
-	 * We know that the new bi will have been inserted before any routes
+	 * We know that the new bpi will have been inserted before any routes
 	 * in holddown, so we can skip any that came before it
 	 */
-	for (bi = info_new->next; bi; bi = next) {
+	for (bpi = info_new->next; bpi; bpi = next) {
 
 		struct prefix pfx_vn;
 		struct prefix pfx_un;
 		int un_match = 0;
 		int remote_peer_match = 0;
 
-		next = bi->next;
+		next = bpi->next;
 
 		/*
 		 * Must be holddown
 		 */
-		if (!CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
+		if (!CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED))
 			continue;
 
 		/*
 		 * Must match VN address (nexthop of VPN route)
 		 */
-		if (rfapiGetNexthop(bi->attr, &pfx_vn))
+		if (rfapiGetNexthop(bpi->attr, &pfx_vn))
 			continue;
 		if (!prefix_same(&pfx_vn, &vn_prefix))
 			continue;
 
 		if (un_prefix_valid && /* new route UN addr */
-		    !rfapiGetUnAddrOfVpnBi(bi, &pfx_un)
+		    !rfapiGetUnAddrOfVpnBi(bpi, &pfx_un)
 		    &&					/* old route UN addr */
 		    prefix_same(&pfx_un, &un_prefix)) { /* compare */
 			un_match = 1;
 		}
-		if (!RFAPI_LOCAL_BI(bi) && !RFAPI_LOCAL_BI(info_new)
-		    && sockunion_same(&bi->peer->su, &info_new->peer->su)) {
+		if (!RFAPI_LOCAL_BI(bpi) && !RFAPI_LOCAL_BI(info_new)
+		    && sockunion_same(&bpi->peer->su, &info_new->peer->su)) {
 			/* old & new are both remote, same peer */
 			remote_peer_match = 1;
 		}
@@ -3826,17 +3831,17 @@ void rfapiBgpInfoFilteredImportVPN(
 			continue;
 
 		vnc_zlog_debug_verbose(
-			"%s: removing holddown bi matching NVE of new route",
+			"%s: removing holddown bpi matching NVE of new route",
 			__func__);
-		if (bi->extra->vnc.import.timer) {
+		if (bpi->extra->vnc.import.timer) {
 			struct thread *t =
-				(struct thread *)bi->extra->vnc.import.timer;
+				(struct thread *)bpi->extra->vnc.import.timer;
 			struct rfapi_withdraw *wcb = t->arg;
 
 			XFREE(MTYPE_RFAPI_WITHDRAW, wcb);
 			thread_cancel(t);
 		}
-		rfapiExpireVpnNow(import_table, rn, bi, 0);
+		rfapiExpireVpnNow(import_table, rn, bpi, 0);
 	}
 
 	if (!original_had_routes) {
@@ -4093,22 +4098,22 @@ void rfapiProcessWithdraw(struct peer *peer, void *rfd, struct prefix *p,
  * routes expiring at the same time due to peer drop.
  */
 /*
- * 1. Visit all BIs in all ENCAP import tables.
+ * 1. Visit all BPIs in all ENCAP import tables.
  *
- *    a. If a bi's peer is the failed peer, remove the bi.
- *	  b. If the removed ENCAP bi was first in the list of
- *       BIs at this ENCAP node, loop over all monitors
+ *    a. If a bpi's peer is the failed peer, remove the bpi.
+ *	  b. If the removed ENCAP bpi was first in the list of
+ *       BPIs at this ENCAP node, loop over all monitors
  *       at this node:
  *
  *       (1) for each ENCAP monitor, loop over all its
  *           VPN node monitors and set their RFAPI_MON_FLAG_NEEDCALLBACK
  *           flags.
  *
- * 2. Visit all BIs in all VPN import tables.
- *    a. If a bi's peer is the failed peer, remove the bi.
+ * 2. Visit all BPIs in all VPN import tables.
+ *    a. If a bpi's peer is the failed peer, remove the bpi.
  *    b. loop over all the VPN node monitors and set their
  *       RFAPI_MON_FLAG_NEEDCALLBACK flags
- *    c. If there are no BIs left at this VPN node,
+ *    c. If there are no BPIs left at this VPN node,
  *
  */
 
@@ -4119,7 +4124,7 @@ static void rfapiProcessPeerDownRt(struct peer *peer,
 				   afi_t afi, safi_t safi)
 {
 	struct agg_node *rn;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct agg_table *rt;
 	int (*timer_service_func)(struct thread *);
 
@@ -4142,20 +4147,20 @@ static void rfapiProcessPeerDownRt(struct peer *peer,
 
 
 	for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
-		for (bi = rn->info; bi; bi = bi->next) {
-			if (bi->peer == peer) {
+		for (bpi = rn->info; bpi; bpi = bpi->next) {
+			if (bpi->peer == peer) {
 
-				if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
+				if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
 					/* already in holddown, skip */
 					continue;
 				}
 
 				if (safi == SAFI_MPLS_VPN) {
 					RFAPI_UPDATE_ITABLE_COUNT(
-						bi, import_table, afi, -1);
+						bpi, import_table, afi, -1);
 					import_table->holddown_count[afi] += 1;
 				}
-				rfapiBiStartWithdrawTimer(import_table, rn, bi,
+				rfapiBiStartWithdrawTimer(import_table, rn, bpi,
 							  afi, safi,
 							  timer_service_func);
 			}
@@ -4187,11 +4192,11 @@ void rfapiProcessPeerDown(struct peer *peer)
 		return;
 
 	/*
-	 * 1. Visit all BIs in all ENCAP import tables.
-	 *    Start withdraw timer on the BIs that match peer.
+	 * 1. Visit all BPIs in all ENCAP import tables.
+	 *    Start withdraw timer on the BPIs that match peer.
 	 *
-	 * 2. Visit All BIs in all VPN import tables.
-	 *    Start withdraw timer on the BIs that match peer.
+	 * 2. Visit All BPIs in all VPN import tables.
+	 *    Start withdraw timer on the BPIs that match peer.
 	 */
 
 	bgp = bgp_get_default(); /* assume 1 instance for now */
@@ -4243,27 +4248,27 @@ static void rfapiBgpTableFilteredImport(struct bgp *bgp,
 			for (rn2 = bgp_table_top(rn1->info); rn2;
 			     rn2 = bgp_route_next(rn2)) {
 
-				struct bgp_path_info *bi;
+				struct bgp_path_info *bpi;
 
-				for (bi = rn2->info; bi; bi = bi->next) {
+				for (bpi = rn2->info; bpi; bpi = bpi->next) {
 					uint32_t label = 0;
 
-					if (CHECK_FLAG(bi->flags,
+					if (CHECK_FLAG(bpi->flags,
 						       BGP_PATH_REMOVED))
 						continue;
 
-					if (bi->extra)
+					if (bpi->extra)
 						label = decode_label(
-							&bi->extra->label[0]);
+							&bpi->extra->label[0]);
 					(*rfapiBgpInfoFilteredImportFunction(
 						safi))(
 						it, /* which import table */
-						FIF_ACTION_UPDATE, bi->peer,
+						FIF_ACTION_UPDATE, bpi->peer,
 						NULL, &rn2->p, /* prefix */
 						NULL, afi,
 						(struct prefix_rd *)&rn1->p,
-						bi->attr, bi->type,
-						bi->sub_type, &label);
+						bpi->attr, bpi->type,
+						bpi->sub_type, &label);
 				}
 			}
 		}
@@ -4477,7 +4482,7 @@ static void rfapiDeleteRemotePrefixesIt(
 				       afi);
 
 		for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
-			struct bgp_path_info *bi;
+			struct bgp_path_info *bpi;
 			struct bgp_path_info *next;
 
 			if (VNC_DEBUG(IMPORT_DEL_REMOTE)) {
@@ -4504,8 +4509,8 @@ static void rfapiDeleteRemotePrefixesIt(
 			/* TBD is this valid for afi == AFI_L2VPN? */
 			RFAPI_CHECK_REFCOUNT(rn, SAFI_MPLS_VPN, 1);
 
-			for (bi = rn->info; bi; bi = next) {
-				next = bi->next;
+			for (bpi = rn->info; bpi; bpi = next) {
+				next = bpi->next;
 
 				struct prefix qpt;
 				struct prefix qct;
@@ -4513,11 +4518,11 @@ static void rfapiDeleteRemotePrefixesIt(
 				int qct_valid = 0;
 				int is_active = 0;
 
-				vnc_zlog_debug_verbose("%s: examining bi %p",
-						       __func__, bi);
+				vnc_zlog_debug_verbose("%s: examining bpi %p",
+						       __func__, bpi);
 
-				if (bi->attr) {
-					if (!rfapiGetNexthop(bi->attr, &qpt))
+				if (bpi->attr) {
+					if (!rfapiGetNexthop(bpi->attr, &qpt))
 						qpt_valid = 1;
 				}
 				if (vn) {
@@ -4532,7 +4537,7 @@ static void rfapiDeleteRemotePrefixesIt(
 					}
 				}
 
-				if (!rfapiGetUnAddrOfVpnBi(bi, &qct))
+				if (!rfapiGetUnAddrOfVpnBi(bpi, &qct))
 					qct_valid = 1;
 
 				if (un) {
@@ -4549,7 +4554,7 @@ static void rfapiDeleteRemotePrefixesIt(
 
 
 				/*
-				 * Blow bi away
+				 * Blow bpi away
 				 */
 				/*
 				 * If this route is waiting to be deleted
@@ -4557,13 +4562,13 @@ static void rfapiDeleteRemotePrefixesIt(
 				 * a previous withdraw, we must cancel its
 				 * timer.
 				 */
-				if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
+				if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
 					if (!delete_holddown)
 						continue;
-					if (bi->extra->vnc.import.timer) {
+					if (bpi->extra->vnc.import.timer) {
 
 						struct thread *t =
-							(struct thread *)bi
+							(struct thread *)bpi
 								->extra->vnc
 								.import.timer;
 						struct rfapi_withdraw *wcb =
@@ -4573,7 +4578,7 @@ static void rfapiDeleteRemotePrefixesIt(
 							->holddown_count[afi] -=
 							1;
 						RFAPI_UPDATE_ITABLE_COUNT(
-							bi, wcb->import_table,
+							bpi, wcb->import_table,
 							afi, 1);
 						XFREE(MTYPE_RFAPI_WITHDRAW,
 						      wcb);
@@ -4586,8 +4591,8 @@ static void rfapiDeleteRemotePrefixesIt(
 				}
 
 				vnc_zlog_debug_verbose(
-					"%s: deleting bi %p (qct_valid=%d, qpt_valid=%d, delete_holddown=%d, delete_active=%d)",
-					__func__, bi, qct_valid, qpt_valid,
+					"%s: deleting bpi %p (qct_valid=%d, qpt_valid=%d, delete_holddown=%d, delete_active=%d)",
+					__func__, bpi, qct_valid, qpt_valid,
 					delete_holddown, delete_active);
 
 
@@ -4633,11 +4638,11 @@ static void rfapiDeleteRemotePrefixesIt(
 				}
 
 				vnc_direct_bgp_rh_del_route(bgp, afi, &rn->p,
-							    bi->peer);
+							    bpi->peer);
 
-				RFAPI_UPDATE_ITABLE_COUNT(bi, it, afi, -1);
+				RFAPI_UPDATE_ITABLE_COUNT(bpi, it, afi, -1);
 				it->holddown_count[afi] += 1;
-				rfapiExpireVpnNow(it, rn, bi, 1);
+				rfapiExpireVpnNow(it, rn, bpi, 1);
 
 				vnc_zlog_debug_verbose(
 					"%s: incrementing count (is_active=%d)",

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -509,14 +509,14 @@ static struct bgp_path_info *rfapiBgpInfoCreate(struct attr *attr,
 {
 	struct bgp_path_info *new;
 
-	new = bgp_info_new();
+	new = bgp_path_info_new();
 	assert(new);
 
 	if (attr) {
 		if (!new->attr)
 			new->attr = bgp_attr_intern(attr);
 	}
-	bgp_info_extra_get(new);
+	bgp_path_info_extra_get(new);
 	if (prd) {
 		new->extra->vnc.import.rd = *prd;
 		rfapi_time(&new->extra->vnc.import.create_time);
@@ -2021,8 +2021,8 @@ static void rfapiBgpInfoAttachSorted(struct agg_node *rn,
 		if (!bgp
 		    || (!CHECK_FLAG(info_new->flags, BGP_PATH_REMOVED)
 			&& CHECK_FLAG(next->flags, BGP_PATH_REMOVED))
-		    || bgp_info_cmp_compatible(bgp, info_new, next, pfx_buf,
-					       afi, safi)
+		    || bgp_path_info_cmp_compatible(bgp, info_new, next,
+						    pfx_buf, afi, safi)
 			       == -1) { /* -1 if 1st is better */
 			break;
 		}

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -499,7 +499,7 @@ int rfapiGetUnAddrOfVpnBi(struct bgp_path_info *bi, struct prefix *p)
 
 
 /*
- * Make a new bgp_info from gathered parameters
+ * Make a new bgp_path_info from gathered parameters
  */
 static struct bgp_path_info *rfapiBgpInfoCreate(struct attr *attr,
 						struct peer *peer, void *rfd,
@@ -532,7 +532,7 @@ static struct bgp_path_info *rfapiBgpInfoCreate(struct attr *attr,
 }
 
 /*
- * Frees bgp_info as used in import tables (parts are not
+ * Frees bgp_path_info as used in import tables (parts are not
  * allocated exactly the way they are in the main RIBs)
  */
 static void rfapiBgpInfoFree(struct bgp_path_info *goner)
@@ -930,9 +930,9 @@ static void rfapiImportTableFlush(struct rfapi_import_table *it)
 			 * Each route_node has:
 			 * aggregate: points to rfapi_it_extra with monitor
 			 * chain(s)
-			 * info: points to chain of bgp_info
+			 * info: points to chain of bgp_path_info
 			 */
-			/* free bgp_info and its children */
+			/* free bgp_path_info and its children */
 			rfapiBgpInfoChainFree(rn->info);
 			rn->info = NULL;
 
@@ -941,7 +941,7 @@ static void rfapiImportTableFlush(struct rfapi_import_table *it)
 
 		for (rn = agg_route_top(it->imported_encap[afi]); rn;
 		     rn = agg_route_next(rn)) {
-			/* free bgp_info and its children */
+			/* free bgp_path_info and its children */
 			rfapiBgpInfoChainFree(rn->info);
 			rn->info = NULL;
 
@@ -2934,7 +2934,7 @@ static int rfapiGetNexthop(struct attr *attr, struct prefix *prefix)
 }
 
 /*
- * import a bgp_info if its route target list intersects with the
+ * import a bgp_path_info if its route target list intersects with the
  * import table's route target list
  */
 static void rfapiBgpInfoFilteredImportEncap(
@@ -2943,10 +2943,10 @@ static void rfapiBgpInfoFilteredImportEncap(
 	struct prefix *p,
 	struct prefix *aux_prefix, /* Unused for encap routes */
 	afi_t afi, struct prefix_rd *prd,
-	struct attr *attr, /* part of bgp_info */
-	uint8_t type,      /* part of bgp_info */
-	uint8_t sub_type,  /* part of bgp_info */
-	uint32_t *label)   /* part of bgp_info */
+	struct attr *attr, /* part of bgp_path_info */
+	uint8_t type,      /* part of bgp_path_info */
+	uint8_t sub_type,  /* part of bgp_path_info */
+	uint32_t *label)   /* part of bgp_path_info */
 {
 	struct agg_table *rt = NULL;
 	struct agg_node *rn;
@@ -3071,7 +3071,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 		for (bi = rn->info; bi; bi = bi->next) {
 
 			/*
-			 * Does this bgp_info refer to the same route
+			 * Does this bgp_path_info refer to the same route
 			 * as we are trying to add?
 			 */
 			vnc_zlog_debug_verbose("%s: comparing BI %p", __func__,
@@ -3395,7 +3395,7 @@ static void rfapiExpireVpnNow(struct rfapi_import_table *it,
 
 
 /*
- * import a bgp_info if its route target list intersects with the
+ * import a bgp_path_info if its route target list intersects with the
  * import table's route target list
  */
 void rfapiBgpInfoFilteredImportVPN(
@@ -3404,10 +3404,10 @@ void rfapiBgpInfoFilteredImportVPN(
 	struct prefix *p,
 	struct prefix *aux_prefix, /* AFI_L2VPN: optional IP */
 	afi_t afi, struct prefix_rd *prd,
-	struct attr *attr, /* part of bgp_info */
-	uint8_t type,      /* part of bgp_info */
-	uint8_t sub_type,  /* part of bgp_info */
-	uint32_t *label)   /* part of bgp_info */
+	struct attr *attr, /* part of bgp_path_info */
+	uint8_t type,      /* part of bgp_path_info */
+	uint8_t sub_type,  /* part of bgp_path_info */
+	uint32_t *label)   /* part of bgp_path_info */
 {
 	struct agg_table *rt = NULL;
 	struct agg_node *rn;
@@ -3882,10 +3882,10 @@ static void rfapiBgpInfoFilteredImportBadSafi(
 	struct prefix *p,
 	struct prefix *aux_prefix, /* AFI_L2VPN: optional IP */
 	afi_t afi, struct prefix_rd *prd,
-	struct attr *attr, /* part of bgp_info */
-	uint8_t type,      /* part of bgp_info */
-	uint8_t sub_type,  /* part of bgp_info */
-	uint32_t *label)   /* part of bgp_info */
+	struct attr *attr, /* part of bgp_path_info */
+	uint8_t type,      /* part of bgp_path_info */
+	uint8_t sub_type,  /* part of bgp_path_info */
+	uint32_t *label)   /* part of bgp_path_info */
 {
 	vnc_zlog_debug_verbose("%s: Error, bad safi", __func__);
 }

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -77,7 +77,7 @@ extern void rfapiCheckRouteCount(void);
 /*
  * Print BI in an Import Table
  */
-extern void rfapiPrintBi(void *stream, struct bgp_info *bi);
+extern void rfapiPrintBi(void *stream, struct bgp_path_info *bi);
 
 extern void rfapiShowImportTable(void *stream, const char *label,
 				 struct agg_table *rt, int isvpn);
@@ -128,7 +128,7 @@ extern int rfapiHasNonRemovedRoutes(struct agg_node *rn);
 
 extern int rfapiProcessDeferredClose(struct thread *t);
 
-extern int rfapiGetUnAddrOfVpnBi(struct bgp_info *bi, struct prefix *p);
+extern int rfapiGetUnAddrOfVpnBi(struct bgp_path_info *bi, struct prefix *p);
 
 extern void rfapiNexthop2Prefix(struct attr *attr, struct prefix *p);
 
@@ -146,10 +146,10 @@ extern void rfapiBgpInfoFilteredImportVPN(
 	struct prefix *p,
 	struct prefix *aux_prefix, /* AFI_ETHER: optional IP */
 	afi_t afi, struct prefix_rd *prd,
-	struct attr *attr, /* part of bgp_info */
-	uint8_t type,      /* part of bgp_info */
-	uint8_t sub_type,  /* part of bgp_info */
-	uint32_t *label);  /* part of bgp_info */
+	struct attr *attr, /* part of bgp_path_info */
+	uint8_t type,      /* part of bgp_path_info */
+	uint8_t sub_type,  /* part of bgp_path_info */
+	uint32_t *label);  /* part of bgp_path_info */
 
 extern struct rfapi_next_hop_entry *rfapiEthRouteNode2NextHopList(
 	struct agg_node *rn, struct rfapi_ip_prefix *rprefix,

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -31,7 +31,7 @@
 /*
  * These are per-rt-import-list
  *
- * routes are not segregated by RD - the RD is stored in bgp_info_extra
+ * routes are not segregated by RD - the RD is stored in bgp_path_info_extra
  * and is needed to determine if two prefixes are the same.
  */
 struct rfapi_import_table {
@@ -94,7 +94,7 @@ extern void rfapiImportTableRefDelByIt(struct bgp *bgp,
  * Construct an rfapi nexthop list based on the routes attached to
  * the specified node.
  *
- * If there are any routes that do NOT have BGP_INFO_REMOVED set,
+ * If there are any routes that do NOT have BGP_PATH_REMOVED set,
  * return those only. If there are ONLY routes with BGP_INFO_REMOVED,
  * then return those, and also include all the non-removed routes from the
  * next less-specific node (i.e., this node's parent) at the end.

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -51,18 +51,18 @@ struct rfapi_import_table {
 	int imported_count[AFI_MAX];
 };
 
-#define RFAPI_LOCAL_BI(bi)                                                     \
-	(((bi)->type == ZEBRA_ROUTE_BGP) && ((bi)->sub_type == BGP_ROUTE_RFP))
+#define RFAPI_LOCAL_BI(bpi)                                                    \
+	(((bpi)->type == ZEBRA_ROUTE_BGP) && ((bpi)->sub_type == BGP_ROUTE_RFP))
 
-#define RFAPI_DIRECT_IMPORT_BI(bi)                                             \
-	(((bi)->type == ZEBRA_ROUTE_BGP_DIRECT)                                \
-	 || ((bi)->type == ZEBRA_ROUTE_BGP_DIRECT_EXT))
+#define RFAPI_DIRECT_IMPORT_BI(bpi)                                            \
+	(((bpi)->type == ZEBRA_ROUTE_BGP_DIRECT)                               \
+	 || ((bpi)->type == ZEBRA_ROUTE_BGP_DIRECT_EXT))
 
-#define RFAPI_UPDATE_ITABLE_COUNT(bi, itable, afi, cnt)                        \
-	if (RFAPI_LOCAL_BI(bi)) {                                              \
+#define RFAPI_UPDATE_ITABLE_COUNT(bpi, itable, afi, cnt)                       \
+	if (RFAPI_LOCAL_BI(bpi)) {                                             \
 		(itable)->local_count[(afi)] += (cnt);                         \
 	} else {                                                               \
-		if (RFAPI_DIRECT_IMPORT_BI(bi))                                \
+		if (RFAPI_DIRECT_IMPORT_BI(bpi))                               \
 			(itable)->imported_count[(afi)] += (cnt);              \
 		else                                                           \
 			(itable)->remote_count[(afi)] += (cnt);                \
@@ -75,9 +75,9 @@ extern void rfapiDebugBacktrace(void);
 extern void rfapiCheckRouteCount(void);
 
 /*
- * Print BI in an Import Table
+ * Print BPI in an Import Table
  */
-extern void rfapiPrintBi(void *stream, struct bgp_path_info *bi);
+extern void rfapiPrintBi(void *stream, struct bgp_path_info *bpi);
 
 extern void rfapiShowImportTable(void *stream, const char *label,
 				 struct agg_table *rt, int isvpn);
@@ -128,7 +128,7 @@ extern int rfapiHasNonRemovedRoutes(struct agg_node *rn);
 
 extern int rfapiProcessDeferredClose(struct thread *t);
 
-extern int rfapiGetUnAddrOfVpnBi(struct bgp_path_info *bi, struct prefix *p);
+extern int rfapiGetUnAddrOfVpnBi(struct bgp_path_info *bpi, struct prefix *p);
 
 extern void rfapiNexthop2Prefix(struct attr *attr, struct prefix *p);
 

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -226,7 +226,7 @@ void rfapiMonitorExtraFlush(safi_t safi, struct agg_node *rn)
 			agg_unlock_node(rn);
 		}
 		if (hie->u.vpn.idx_rd) {
-			/* looping through bi->extra->vnc.import.rd is tbd */
+			/* looping through bpi->extra->vnc.import.rd is tbd */
 			while (!skiplist_delete_first(hie->u.vpn.idx_rd)) {
 				agg_unlock_node(rn);
 			}
@@ -346,16 +346,16 @@ struct agg_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
 	for (rn = agg_node_match(rfd->import_table->imported_vpn[afi], p);
 	     rn;) {
 
-		struct bgp_path_info *bi;
+		struct bgp_path_info *bpi;
 		struct prefix pfx_dummy;
 
 		/* TBD update this code to use new valid_interior_count */
-		for (bi = rn->info; bi; bi = bi->next) {
+		for (bpi = rn->info; bpi; bpi = bpi->next) {
 			/*
 			 * If there is a cached ENCAP UN address, it's a usable
 			 * VPN route
 			 */
-			if (bi->extra && bi->extra->vnc.import.un_family) {
+			if (bpi->extra && bpi->extra->vnc.import.un_family) {
 				break;
 			}
 
@@ -364,11 +364,11 @@ struct agg_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
 			 * address,
 			 * it's a usable VPN route.
 			 */
-			if (!rfapiGetVncTunnelUnAddr(bi->attr, &pfx_dummy)) {
+			if (!rfapiGetVncTunnelUnAddr(bpi->attr, &pfx_dummy)) {
 				break;
 			}
 		}
-		if (bi)
+		if (bpi)
 			break;
 
 		agg_unlock_node(rn);

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -346,7 +346,7 @@ struct agg_node *rfapiMonitorGetAttachNode(struct rfapi_descriptor *rfd,
 	for (rn = agg_node_match(rfd->import_table->imported_vpn[afi], p);
 	     rn;) {
 
-		struct bgp_info *bi;
+		struct bgp_path_info *bi;
 		struct prefix pfx_dummy;
 
 		/* TBD update this code to use new valid_interior_count */

--- a/bgpd/rfapi/rfapi_monitor.h
+++ b/bgpd/rfapi/rfapi_monitor.h
@@ -45,7 +45,7 @@ struct rfapi_monitor_encap {
 	struct rfapi_monitor_encap *next;
 	struct rfapi_monitor_encap *prev;
 	struct agg_node *node;   /* VPN node */
-	struct bgp_path_info *bi; /* VPN bi */
+	struct bgp_path_info *bpi; /* VPN bpi */
 	struct agg_node *rn;     /* parent node */
 };
 
@@ -83,7 +83,7 @@ struct rfapi_it_extra {
 				 * Encap TLV */
 				int valid_interior_count;
 
-				/* unicast exterior routes, key=bi,
+				/* unicast exterior routes, key=bpi,
 				 * val=allocated prefix */
 				struct skiplist *source;
 			} e;

--- a/bgpd/rfapi/rfapi_monitor.h
+++ b/bgpd/rfapi/rfapi_monitor.h
@@ -45,7 +45,7 @@ struct rfapi_monitor_encap {
 	struct rfapi_monitor_encap *next;
 	struct rfapi_monitor_encap *prev;
 	struct agg_node *node;   /* VPN node */
-	struct bgp_info *bi;     /* VPN bi */
+	struct bgp_path_info *bi; /* VPN bi */
 	struct agg_node *rn;     /* parent node */
 };
 

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -212,7 +212,7 @@ struct rfapi {
 
 	/*
 	 * when importing bgp-direct routes in resolve-nve mode,
-	 * this list maps unicast route nexthops to their bgp_infos
+	 * this list maps unicast route nexthops to their bgp_path_infos
 	 * in the unicast table
 	 */
 	struct skiplist *resolve_nve_nexthop;

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -616,9 +616,9 @@ void rfapiRibFree(struct rfapi_descriptor *rfd)
 }
 
 /*
- * Copies struct bgp_info to struct rfapi_info, except for rk fields and un
+ * Copies struct bgp_path_info to struct rfapi_info, except for rk fields and un
  */
-static void rfapiRibBi2Ri(struct bgp_info *bi, struct rfapi_info *ri,
+static void rfapiRibBi2Ri(struct bgp_path_info *bi, struct rfapi_info *ri,
 			  uint32_t lifetime)
 {
 	struct bgp_attr_encap_subtlv *pEncap;
@@ -733,7 +733,7 @@ static void rfapiRibBi2Ri(struct bgp_info *bi, struct rfapi_info *ri,
 int rfapiRibPreloadBi(
 	struct agg_node *rfd_rib_node, /* NULL = don't preload or filter */
 	struct prefix *pfx_vn, struct prefix *pfx_un, uint32_t lifetime,
-	struct bgp_info *bi)
+	struct bgp_path_info *bi)
 {
 	struct rfapi_descriptor *rfd;
 	struct skiplist *slRibPt = NULL;
@@ -1590,7 +1590,7 @@ void rfapiRibUpdatePendingNode(
 	struct agg_node *it_node, uint32_t lifetime)
 {
 	struct prefix *prefix;
-	struct bgp_info *bi;
+	struct bgp_path_info *bi;
 	struct agg_node *pn;
 	afi_t afi;
 	uint32_t queued_flag;

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -618,16 +618,16 @@ void rfapiRibFree(struct rfapi_descriptor *rfd)
 /*
  * Copies struct bgp_path_info to struct rfapi_info, except for rk fields and un
  */
-static void rfapiRibBi2Ri(struct bgp_path_info *bi, struct rfapi_info *ri,
+static void rfapiRibBi2Ri(struct bgp_path_info *bpi, struct rfapi_info *ri,
 			  uint32_t lifetime)
 {
 	struct bgp_attr_encap_subtlv *pEncap;
 
-	ri->cost = rfapiRfpCost(bi->attr);
+	ri->cost = rfapiRfpCost(bpi->attr);
 	ri->lifetime = lifetime;
 
 	/* This loop based on rfapiRouteInfo2NextHopEntry() */
-	for (pEncap = bi->attr->vnc_subtlvs; pEncap; pEncap = pEncap->next) {
+	for (pEncap = bpi->attr->vnc_subtlvs; pEncap; pEncap = pEncap->next) {
 		struct bgp_tea_options *hop;
 
 		switch (pEncap->type) {
@@ -665,13 +665,13 @@ static void rfapiRibBi2Ri(struct bgp_path_info *bi, struct rfapi_info *ri,
 	}
 
 	rfapi_un_options_free(ri->un_options); /* maybe free old version */
-	ri->un_options = rfapi_encap_tlv_to_un_option(bi->attr);
+	ri->un_options = rfapi_encap_tlv_to_un_option(bpi->attr);
 
 	/*
 	 * VN options
 	 */
-	if (bi->extra
-	    && decode_rd_type(bi->extra->vnc.import.rd.val)
+	if (bpi->extra
+	    && decode_rd_type(bpi->extra->vnc.import.rd.val)
 		       == RD_TYPE_VNC_ETH) {
 		/* ethernet route */
 
@@ -683,21 +683,21 @@ static void rfapiRibBi2Ri(struct bgp_path_info *bi, struct rfapi_info *ri,
 
 		vo->type = RFAPI_VN_OPTION_TYPE_L2ADDR;
 
-		/* copy from RD already stored in bi, so we don't need it_node
+		/* copy from RD already stored in bpi, so we don't need it_node
 		 */
-		memcpy(&vo->v.l2addr.macaddr, bi->extra->vnc.import.rd.val + 2,
+		memcpy(&vo->v.l2addr.macaddr, bpi->extra->vnc.import.rd.val + 2,
 		       ETH_ALEN);
 
-		(void)rfapiEcommunityGetLNI(bi->attr->ecommunity,
+		(void)rfapiEcommunityGetLNI(bpi->attr->ecommunity,
 					    &vo->v.l2addr.logical_net_id);
-		(void)rfapiEcommunityGetEthernetTag(bi->attr->ecommunity,
+		(void)rfapiEcommunityGetEthernetTag(bpi->attr->ecommunity,
 						    &vo->v.l2addr.tag_id);
 
 		/* local_nve_id comes from RD */
-		vo->v.l2addr.local_nve_id = bi->extra->vnc.import.rd.val[1];
+		vo->v.l2addr.local_nve_id = bpi->extra->vnc.import.rd.val[1];
 
 		/* label comes from MP_REACH_NLRI label */
-		vo->v.l2addr.label = decode_label(&bi->extra->label[0]);
+		vo->v.l2addr.label = decode_label(&bpi->extra->label[0]);
 
 		rfapi_vn_options_free(
 			ri->vn_options); /* maybe free old version */
@@ -707,8 +707,8 @@ static void rfapiRibBi2Ri(struct bgp_path_info *bi, struct rfapi_info *ri,
 	/*
 	 * If there is an auxiliary IP address (L2 can have it), copy it
 	 */
-	if (bi->extra && bi->extra->vnc.import.aux_prefix.family) {
-		ri->rk.aux_prefix = bi->extra->vnc.import.aux_prefix;
+	if (bpi->extra && bpi->extra->vnc.import.aux_prefix.family) {
+		ri->rk.aux_prefix = bpi->extra->vnc.import.aux_prefix;
 	}
 }
 
@@ -733,7 +733,7 @@ static void rfapiRibBi2Ri(struct bgp_path_info *bi, struct rfapi_info *ri,
 int rfapiRibPreloadBi(
 	struct agg_node *rfd_rib_node, /* NULL = don't preload or filter */
 	struct prefix *pfx_vn, struct prefix *pfx_un, uint32_t lifetime,
-	struct bgp_path_info *bi)
+	struct bgp_path_info *bpi)
 {
 	struct rfapi_descriptor *rfd;
 	struct skiplist *slRibPt = NULL;
@@ -751,13 +751,13 @@ int rfapiRibPreloadBi(
 
 	memset((void *)&rk, 0, sizeof(rk));
 	rk.vn = *pfx_vn;
-	rk.rd = bi->extra->vnc.import.rd;
+	rk.rd = bpi->extra->vnc.import.rd;
 
 	/*
 	 * If there is an auxiliary IP address (L2 can have it), copy it
 	 */
-	if (bi->extra->vnc.import.aux_prefix.family) {
-		rk.aux_prefix = bi->extra->vnc.import.aux_prefix;
+	if (bpi->extra->vnc.import.aux_prefix.family) {
+		rk.aux_prefix = bpi->extra->vnc.import.aux_prefix;
 	}
 
 	/*
@@ -774,13 +774,13 @@ int rfapiRibPreloadBi(
 
 		/* found: update contents of existing route in RIB */
 		ori->un = *pfx_un;
-		rfapiRibBi2Ri(bi, ori, lifetime);
+		rfapiRibBi2Ri(bpi, ori, lifetime);
 	} else {
 		/* not found: add new route to RIB */
 		ori = rfapi_info_new();
 		ori->rk = rk;
 		ori->un = *pfx_un;
-		rfapiRibBi2Ri(bi, ori, lifetime);
+		rfapiRibBi2Ri(bpi, ori, lifetime);
 
 		if (!slRibPt) {
 			slRibPt = skiplist_new(0, rfapi_rib_key_cmp, NULL);
@@ -1590,7 +1590,7 @@ void rfapiRibUpdatePendingNode(
 	struct agg_node *it_node, uint32_t lifetime)
 {
 	struct prefix *prefix;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	struct agg_node *pn;
 	afi_t afi;
 	uint32_t queued_flag;
@@ -1640,25 +1640,25 @@ void rfapiRibUpdatePendingNode(
 	}
 
 	/*
-	 * The BIs in the import table are already sorted by cost
+	 * The BPIs in the import table are already sorted by cost
 	 */
-	for (bi = it_node->info; bi; bi = bi->next) {
+	for (bpi = it_node->info; bpi; bpi = bpi->next) {
 
 		struct rfapi_info *ri;
 		struct prefix pfx_nh;
 
-		if (!bi->attr) {
+		if (!bpi->attr) {
 			/* shouldn't happen */
 			/* TBD increment error stats counter */
 			continue;
 		}
-		if (!bi->extra) {
+		if (!bpi->extra) {
 			/* shouldn't happen */
 			/* TBD increment error stats counter */
 			continue;
 		}
 
-		rfapiNexthop2Prefix(bi->attr, &pfx_nh);
+		rfapiNexthop2Prefix(bpi->attr, &pfx_nh);
 
 		/*
 		 * Omit route if nexthop is self
@@ -1675,15 +1675,15 @@ void rfapiRibUpdatePendingNode(
 
 		ri = rfapi_info_new();
 		ri->rk.vn = pfx_nh;
-		ri->rk.rd = bi->extra->vnc.import.rd;
+		ri->rk.rd = bpi->extra->vnc.import.rd;
 		/*
 		 * If there is an auxiliary IP address (L2 can have it), copy it
 		 */
-		if (bi->extra->vnc.import.aux_prefix.family) {
-			ri->rk.aux_prefix = bi->extra->vnc.import.aux_prefix;
+		if (bpi->extra->vnc.import.aux_prefix.family) {
+			ri->rk.aux_prefix = bpi->extra->vnc.import.aux_prefix;
 		}
 
-		if (rfapiGetUnAddrOfVpnBi(bi, &ri->un)) {
+		if (rfapiGetUnAddrOfVpnBi(bpi, &ri->un)) {
 			rfapi_info_free(ri);
 			continue;
 		}
@@ -1711,7 +1711,7 @@ void rfapiRibUpdatePendingNode(
 			continue;
 		}
 
-		rfapiRibBi2Ri(bi, ri, lifetime);
+		rfapiRibBi2Ri(bpi, ri, lifetime);
 
 		if (!pn->info) {
 			pn->info = list_new();

--- a/bgpd/rfapi/rfapi_rib.h
+++ b/bgpd/rfapi/rfapi_rib.h
@@ -105,7 +105,7 @@ extern void rfapiRibUpdatePendingNodeSubtree(struct bgp *bgp,
 
 extern int rfapiRibPreloadBi(struct agg_node *rfd_rib_node,
 			     struct prefix *pfx_vn, struct prefix *pfx_un,
-			     uint32_t lifetime, struct bgp_info *bi);
+			     uint32_t lifetime, struct bgp_path_info *bi);
 
 extern struct rfapi_next_hop_entry *
 rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,

--- a/bgpd/rfapi/rfapi_rib.h
+++ b/bgpd/rfapi/rfapi_rib.h
@@ -105,7 +105,7 @@ extern void rfapiRibUpdatePendingNodeSubtree(struct bgp *bgp,
 
 extern int rfapiRibPreloadBi(struct agg_node *rfd_rib_node,
 			     struct prefix *pfx_vn, struct prefix *pfx_un,
-			     uint32_t lifetime, struct bgp_path_info *bi);
+			     uint32_t lifetime, struct bgp_path_info *bpi);
 
 extern struct rfapi_next_hop_entry *
 rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -506,7 +506,7 @@ void rfapiPrintBi(void *stream, struct bgp_info *bi)
 	if (!bi)
 		return;
 
-	if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED) && bi->extra
+	if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED) && bi->extra
 	    && bi->extra->vnc.import.timer) {
 		struct thread *t = (struct thread *)bi->extra->vnc.import.timer;
 		r = snprintf(p, REMAIN, " [%4lu] ",
@@ -619,7 +619,7 @@ void rfapiPrintBi(void *stream, struct bgp_info *bi)
 	r = snprintf(p, REMAIN, " p@%p", bi->peer);
 	INCP;
 
-	if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED)) {
+	if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
 		r = snprintf(p, REMAIN, " HD=yes");
 		INCP;
 	} else {
@@ -1113,7 +1113,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 		fp(out, "%-10s ", buf_lifetime);
 	}
 
-	if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED) && bi->extra
+	if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED) && bi->extra
 	    && bi->extra->vnc.import.timer) {
 
 		uint32_t remaining;
@@ -1247,11 +1247,11 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 				}
 
 				if (show_expiring
-				    && !CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+				    && !CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 					continue;
 
 				if (!show_expiring
-				    && CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+				    && CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 					continue;
 
 				if (bi->type == ZEBRA_ROUTE_BGP_DIRECT
@@ -1543,7 +1543,7 @@ void rfapiPrintAdvertisedInfo(struct vty *vty, struct rfapi_descriptor *rfd,
 	struct prefix_rd *prd;
 
 	/*
-	 * Find the bgp_info in the RIB corresponding to this
+	 * Find the bgp_path in the RIB corresponding to this
 	 * prefix and rfd
 	 */
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -394,7 +394,7 @@ int rfapiStream2Vty(void *stream,			   /* input */
 
 /* called from bgpd/bgp_vty.c'route_vty_out() */
 void rfapi_vty_out_vncinfo(struct vty *vty, struct prefix *p,
-			   struct bgp_path_info *bi, safi_t safi)
+			   struct bgp_path_info *bpi, safi_t safi)
 {
 	char *s;
 	uint32_t lifetime;
@@ -410,7 +410,7 @@ void rfapi_vty_out_vncinfo(struct vty *vty, struct prefix *p,
 	if (safi == SAFI_MPLS_VPN) {
 		struct prefix pfx_un;
 
-		if (!rfapiGetVncTunnelUnAddr(bi->attr, &pfx_un)) {
+		if (!rfapiGetVncTunnelUnAddr(bpi->attr, &pfx_un)) {
 			char buf[BUFSIZ];
 			vty_out(vty, "UN=%s",
 				inet_ntop(pfx_un.family, pfx_un.u.val, buf,
@@ -418,27 +418,27 @@ void rfapi_vty_out_vncinfo(struct vty *vty, struct prefix *p,
 		}
 	}
 
-	if (bi->attr && bi->attr->ecommunity) {
-		s = ecommunity_ecom2str(bi->attr->ecommunity,
+	if (bpi->attr && bpi->attr->ecommunity) {
+		s = ecommunity_ecom2str(bpi->attr->ecommunity,
 					ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 		vty_out(vty, " EC{%s}", s);
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
 
-	if (bi->extra != NULL) {
-		if (bi->extra->label[0] == BGP_PREVENT_VRF_2_VRF_LEAK)
+	if (bpi->extra != NULL) {
+		if (bpi->extra->label[0] == BGP_PREVENT_VRF_2_VRF_LEAK)
 			vty_out(vty, " label=VRF2VRF");
 		else
 			vty_out(vty, " label=%u",
-				decode_label(&bi->extra->label[0]));
+				decode_label(&bpi->extra->label[0]));
 	}
 
-	if (!rfapiGetVncLifetime(bi->attr, &lifetime)) {
+	if (!rfapiGetVncLifetime(bpi->attr, &lifetime)) {
 		vty_out(vty, " life=%d", lifetime);
 	}
 
-	vty_out(vty, " type=%s, subtype=%d", zebra_route_string(bi->type),
-		bi->sub_type);
+	vty_out(vty, " type=%s, subtype=%d", zebra_route_string(bpi->type),
+		bpi->sub_type);
 
 	vty_out(vty, "%s", HVTYNL);
 }
@@ -477,9 +477,9 @@ void rfapiPrintAttrPtrs(void *stream, struct attr *attr)
 }
 
 /*
- * Print BI in an Import Table
+ * Print BPI in an Import Table
  */
-void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
+void rfapiPrintBi(void *stream, struct bgp_path_info *bpi)
 {
 	char buf[BUFSIZ];
 	char *s;
@@ -503,12 +503,13 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 	if (rfapiStream2Vty(stream, &fp, &vty, &out, &vty_newline) == 0)
 		return;
 
-	if (!bi)
+	if (!bpi)
 		return;
 
-	if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED) && bi->extra
-	    && bi->extra->vnc.import.timer) {
-		struct thread *t = (struct thread *)bi->extra->vnc.import.timer;
+	if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED) && bpi->extra
+	    && bpi->extra->vnc.import.timer) {
+		struct thread *t =
+			(struct thread *)bpi->extra->vnc.import.timer;
 		r = snprintf(p, REMAIN, " [%4lu] ",
 			     thread_timer_remain_second(t));
 		INCP;
@@ -518,14 +519,14 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		INCP;
 	}
 
-	if (bi->extra) {
+	if (bpi->extra) {
 		/* TBD This valid only for SAFI_MPLS_VPN, but not for encap */
-		if (decode_rd_type(bi->extra->vnc.import.rd.val)
+		if (decode_rd_type(bpi->extra->vnc.import.rd.val)
 		    == RD_TYPE_VNC_ETH) {
 			has_macaddr = 1;
-			memcpy(macaddr.octet, bi->extra->vnc.import.rd.val + 2,
+			memcpy(macaddr.octet, bpi->extra->vnc.import.rd.val + 2,
 			       6);
-			l2hid = bi->extra->vnc.import.rd.val[1];
+			l2hid = bpi->extra->vnc.import.rd.val[1];
 		}
 	}
 
@@ -537,24 +538,24 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 	 *          RFP option sizes (they are opaque values)
 	 *          extended communities (RTs)
 	 */
-	if (bi->attr) {
+	if (bpi->attr) {
 		uint32_t lifetime;
 		int printed_1st_gol = 0;
 		struct bgp_attr_encap_subtlv *pEncap;
 		struct prefix pfx_un;
-		int af = BGP_MP_NEXTHOP_FAMILY(bi->attr->mp_nexthop_len);
+		int af = BGP_MP_NEXTHOP_FAMILY(bpi->attr->mp_nexthop_len);
 
 		/* Nexthop */
 		if (af == AF_INET) {
 			r = snprintf(p, REMAIN, "%s",
 				     inet_ntop(AF_INET,
-					       &bi->attr->mp_nexthop_global_in,
+					       &bpi->attr->mp_nexthop_global_in,
 					       buf, BUFSIZ));
 			INCP;
 		} else if (af == AF_INET6) {
 			r = snprintf(p, REMAIN, "%s",
 				     inet_ntop(AF_INET6,
-					       &bi->attr->mp_nexthop_global,
+					       &bpi->attr->mp_nexthop_global,
 					       buf, BUFSIZ));
 			INCP;
 		} else {
@@ -565,7 +566,7 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		/*
 		 * VNC tunnel subtlv, if present, contains UN address
 		 */
-		if (!rfapiGetVncTunnelUnAddr(bi->attr, &pfx_un)) {
+		if (!rfapiGetVncTunnelUnAddr(bpi->attr, &pfx_un)) {
 			r = snprintf(p, REMAIN, " un=%s",
 				     inet_ntop(pfx_un.family, pfx_un.u.val, buf,
 					       BUFSIZ));
@@ -573,7 +574,7 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		}
 
 		/* Lifetime */
-		if (rfapiGetVncLifetime(bi->attr, &lifetime)) {
+		if (rfapiGetVncLifetime(bpi->attr, &lifetime)) {
 			r = snprintf(p, REMAIN, " nolife");
 			INCP;
 		} else {
@@ -585,7 +586,7 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		}
 
 		/* RFP option lengths */
-		for (pEncap = bi->attr->vnc_subtlvs; pEncap;
+		for (pEncap = bpi->attr->vnc_subtlvs; pEncap;
 		     pEncap = pEncap->next) {
 
 			if (pEncap->type == BGP_VNC_SUBTLV_TYPE_RFPOPTION) {
@@ -604,8 +605,8 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		}
 
 		/* RT list */
-		if (bi->attr->ecommunity) {
-			s = ecommunity_ecom2str(bi->attr->ecommunity,
+		if (bpi->attr->ecommunity) {
+			s = ecommunity_ecom2str(bpi->attr->ecommunity,
 						ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 			r = snprintf(p, REMAIN, " %s", s);
 			INCP;
@@ -613,13 +614,13 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		}
 	}
 
-	r = snprintf(p, REMAIN, " bi@%p", bi);
+	r = snprintf(p, REMAIN, " bpi@%p", bpi);
 	INCP;
 
-	r = snprintf(p, REMAIN, " p@%p", bi->peer);
+	r = snprintf(p, REMAIN, " p@%p", bpi->peer);
 	INCP;
 
-	if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED)) {
+	if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
 		r = snprintf(p, REMAIN, " HD=yes");
 		INCP;
 	} else {
@@ -627,15 +628,16 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		INCP;
 	}
 
-	if (bi->attr) {
+	if (bpi->attr) {
 
-		if (bi->attr->weight) {
-			r = snprintf(p, REMAIN, " W=%d", bi->attr->weight);
+		if (bpi->attr->weight) {
+			r = snprintf(p, REMAIN, " W=%d", bpi->attr->weight);
 			INCP;
 		}
 
-		if (bi->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) {
-			r = snprintf(p, REMAIN, " LP=%d", bi->attr->local_pref);
+		if (bpi->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)) {
+			r = snprintf(p, REMAIN, " LP=%d",
+				     bpi->attr->local_pref);
 			INCP;
 		} else {
 			r = snprintf(p, REMAIN, " LP=unset");
@@ -643,8 +645,8 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		}
 	}
 
-	r = snprintf(p, REMAIN, " %c:%u", zebra_route_char(bi->type),
-		     bi->sub_type);
+	r = snprintf(p, REMAIN, " %c:%u", zebra_route_char(bpi->type),
+		     bpi->sub_type);
 	INCP;
 
 	fp(out, "%s%s", line, HVTYNL);
@@ -656,7 +658,7 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		   HVTYNL);
 	}
 
-	if (!rfapiGetL2o(bi->attr, &l2o_buf)) {
+	if (!rfapiGetL2o(bpi->attr, &l2o_buf)) {
 		fp(out,
 		   "        L2O ETH=%02x:%02x:%02x:%02x:%02x:%02x LBL=%d LNI=%d LHI=%hhu%s",
 		   l2o_buf.macaddr.octet[0], l2o_buf.macaddr.octet[1],
@@ -665,12 +667,12 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 		   l2o_buf.label, l2o_buf.logical_net_id, l2o_buf.local_nve_id,
 		   HVTYNL);
 	}
-	if (bi->extra && bi->extra->vnc.import.aux_prefix.family) {
+	if (bpi->extra && bpi->extra->vnc.import.aux_prefix.family) {
 		const char *sp;
 
-		sp = rfapi_ntop(bi->extra->vnc.import.aux_prefix.family,
-				&bi->extra->vnc.import.aux_prefix.u.prefix, buf,
-				BUFSIZ);
+		sp = rfapi_ntop(bpi->extra->vnc.import.aux_prefix.family,
+				&bpi->extra->vnc.import.aux_prefix.u.prefix,
+				buf, BUFSIZ);
 		buf[BUFSIZ - 1] = 0;
 		if (sp) {
 			fp(out, "        IP: %s%s", sp, HVTYNL);
@@ -678,7 +680,7 @@ void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 	}
 	{
 		struct rfapi_un_option *uo =
-			rfapi_encap_tlv_to_un_option(bi->attr);
+			rfapi_encap_tlv_to_un_option(bpi->attr);
 		if (uo) {
 			rfapi_print_tunneltype_option(stream, 8, &uo->v.tunnel);
 			rfapi_un_options_free(uo);
@@ -734,13 +736,13 @@ static void rfapiDebugPrintMonitorEncap(void *stream,
 	if (rfapiStream2Vty(stream, &fp, &vty, &out, &vty_newline) == 0)
 		return;
 
-	fp(out, "    Mon m=%p, next=%p, node=%p, bi=%p%s", m, m->next, m->node,
-	   m->bi, HVTYNL);
+	fp(out, "    Mon m=%p, next=%p, node=%p, bpi=%p%s", m, m->next, m->node,
+	   m->bpi, HVTYNL);
 }
 
 void rfapiShowItNode(void *stream, struct agg_node *rn)
 {
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	char buf[BUFSIZ];
 
 	int (*fp)(void *, const char *, ...);
@@ -755,8 +757,8 @@ void rfapiShowItNode(void *stream, struct agg_node *rn)
 	   rfapi_ntop(rn->p.family, &rn->p.u.prefix, buf, BUFSIZ),
 	   rn->p.prefixlen, rn, rn->lock, HVTYNL);
 
-	for (bi = rn->info; bi; bi = bi->next) {
-		rfapiPrintBi(stream, bi);
+	for (bpi = rn->info; bpi; bpi = bpi->next) {
+		rfapiPrintBi(stream, bpi);
 	}
 
 	/* doesn't show montors */
@@ -779,7 +781,7 @@ void rfapiShowImportTable(void *stream, const char *label, struct agg_table *rt,
 	fp(out, "Import Table [%s]%s", label, HVTYNL);
 
 	for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
-		struct bgp_path_info *bi;
+		struct bgp_path_info *bpi;
 
 		if (rn->p.family == AF_ETHERNET) {
 			rfapiEthAddr2Str(&rn->p.u.prefix_eth, buf, BUFSIZ);
@@ -791,8 +793,8 @@ void rfapiShowImportTable(void *stream, const char *label, struct agg_table *rt,
 		   rn->lock - 1, /* account for loop iterator locking */
 		   HVTYNL);
 
-		for (bi = rn->info; bi; bi = bi->next) {
-			rfapiPrintBi(stream, bi);
+		for (bpi = rn->info; bpi; bpi = bpi->next) {
+			rfapiPrintBi(stream, bpi);
 		}
 
 		if (isvpn) {
@@ -1008,7 +1010,7 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 }
 
 static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
-				 struct agg_node *rn, struct bgp_path_info *bi)
+				 struct agg_node *rn, struct bgp_path_info *bpi)
 {
 	int (*fp)(void *, const char *, ...);
 	struct vty *vty;
@@ -1047,26 +1049,26 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 	 * UN addr
 	 */
 	buf_un[0] = 0;
-	if (!rfapiGetUnAddrOfVpnBi(bi, &pfx_un)) {
+	if (!rfapiGetUnAddrOfVpnBi(bpi, &pfx_un)) {
 		snprintf(buf_un, BUFSIZ, "%s",
 			 inet_ntop(pfx_un.family, &pfx_un.u.prefix, buf_ntop,
 				   BUFSIZ));
 	}
 
-	rfapiGetTunnelType(bi->attr, &tun_type);
+	rfapiGetTunnelType(bpi->attr, &tun_type);
 	/*
 	 * VN addr
 	 */
 	buf_vn[0] = 0;
-	rfapiNexthop2Prefix(bi->attr, &pfx_vn);
+	rfapiNexthop2Prefix(bpi->attr, &pfx_vn);
 	if (tun_type == BGP_ENCAP_TYPE_MPLS) {
 		/* MPLS carries un in nrli next hop (same as vn for IP tunnels)
 		 */
 		snprintf(buf_un, BUFSIZ, "%s",
 			 inet_ntop(pfx_vn.family, &pfx_vn.u.prefix, buf_ntop,
 				   BUFSIZ));
-		if (bi->extra) {
-			uint32_t l = decode_label(&bi->extra->label[0]);
+		if (bpi->extra) {
+			uint32_t l = decode_label(&bpi->extra->label[0]);
 			snprintf(buf_vn, BUFSIZ, "Label: %d", l);
 		} else /* should never happen */
 		{
@@ -1085,10 +1087,10 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 	 * See rfapi_import.c'rfapiRouteInfo2NextHopEntry() for conversion
 	 * back to cost.
 	 */
-	if (bi->attr) {
+	if (bpi->attr) {
 		uint32_t local_pref;
-		if (bi->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF))
-			local_pref = bi->attr->local_pref;
+		if (bpi->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF))
+			local_pref = bpi->attr->local_pref;
 		else
 			local_pref = 0;
 		cost = (local_pref > 255) ? 0 : 255 - local_pref;
@@ -1103,7 +1105,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 
 	/* Lifetime */
 	/* NB rfapiGetVncLifetime sets infinite value when returning !0 */
-	if (rfapiGetVncLifetime(bi->attr, &lifetime)
+	if (rfapiGetVncLifetime(bpi->attr, &lifetime)
 	    || (lifetime == RFAPI_INFINITE_LIFETIME)) {
 
 		fp(out, "%-10s ", "infinite");
@@ -1113,14 +1115,15 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 		fp(out, "%-10s ", buf_lifetime);
 	}
 
-	if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED) && bi->extra
-	    && bi->extra->vnc.import.timer) {
+	if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED) && bpi->extra
+	    && bpi->extra->vnc.import.timer) {
 
 		uint32_t remaining;
 		time_t age;
 		char buf_age[BUFSIZ];
 
-		struct thread *t = (struct thread *)bi->extra->vnc.import.timer;
+		struct thread *t =
+			(struct thread *)bpi->extra->vnc.import.timer;
 		remaining = thread_timer_remain_second(t);
 
 #if RFAPI_REGISTRATIONS_REPORT_AGE
@@ -1140,12 +1143,12 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 
 		fp(out, "%-10s ", buf_age);
 
-	} else if (RFAPI_LOCAL_BI(bi)) {
+	} else if (RFAPI_LOCAL_BI(bpi)) {
 
 		char buf_age[BUFSIZ];
 
-		if (bi->extra && bi->extra->vnc.import.create_time) {
-			rfapiFormatAge(bi->extra->vnc.import.create_time,
+		if (bpi->extra && bpi->extra->vnc.import.create_time) {
+			rfapiFormatAge(bpi->extra->vnc.import.create_time,
 				       buf_age, BUFSIZ);
 		} else {
 			buf_age[0] = '?';
@@ -1161,12 +1164,12 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 		 * print that on the next line
 		 */
 
-		if (bi->extra && bi->extra->vnc.import.aux_prefix.family) {
+		if (bpi->extra && bpi->extra->vnc.import.aux_prefix.family) {
 			const char *sp;
 
 			sp = rfapi_ntop(
-				bi->extra->vnc.import.aux_prefix.family,
-				&bi->extra->vnc.import.aux_prefix.u.prefix,
+				bpi->extra->vnc.import.aux_prefix.family,
+				&bpi->extra->vnc.import.aux_prefix.u.prefix,
 				buf_ntop, BUFSIZ);
 			buf_ntop[BUFSIZ - 1] = 0;
 
@@ -1177,8 +1180,8 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 			}
 		}
 	}
-	if (tun_type != BGP_ENCAP_TYPE_MPLS && bi->extra) {
-		uint32_t l = decode_label(&bi->extra->label[0]);
+	if (tun_type != BGP_ENCAP_TYPE_MPLS && bpi->extra) {
+		uint32_t l = decode_label(&bpi->extra->label[0]);
 		if (!MPLS_LABEL_IS_NULL(l)) {
 			fp(out, "  Label: %d", l);
 			if (nlines == 1)
@@ -1222,7 +1225,7 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 		for (rn = agg_route_top(it->imported_vpn[afi]); rn;
 		     rn = agg_route_next(rn)) {
 
-			struct bgp_path_info *bi;
+			struct bgp_path_info *bpi;
 			int count_only;
 
 			/* allow for wider or more narrow mask from user */
@@ -1232,30 +1235,32 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 			else
 				count_only = 0;
 
-			for (bi = rn->info; bi; bi = bi->next) {
+			for (bpi = rn->info; bpi; bpi = bpi->next) {
 
-				if (!show_local && RFAPI_LOCAL_BI(bi)) {
+				if (!show_local && RFAPI_LOCAL_BI(bpi)) {
 
 					/* local route from RFP */
 					continue;
 				}
 
-				if (!show_remote && !RFAPI_LOCAL_BI(bi)) {
+				if (!show_remote && !RFAPI_LOCAL_BI(bpi)) {
 
 					/* remote route */
 					continue;
 				}
 
 				if (show_expiring
-				    && !CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
+				    && !CHECK_FLAG(bpi->flags,
+						   BGP_PATH_REMOVED))
 					continue;
 
 				if (!show_expiring
-				    && CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
+				    && CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED))
 					continue;
 
-				if (bi->type == ZEBRA_ROUTE_BGP_DIRECT
-				    || bi->type == ZEBRA_ROUTE_BGP_DIRECT_EXT) {
+				if (bpi->type == ZEBRA_ROUTE_BGP_DIRECT
+				    || bpi->type
+					       == ZEBRA_ROUTE_BGP_DIRECT_EXT) {
 					if (!show_imported)
 						continue;
 				} else {
@@ -1277,7 +1282,7 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 							type = "Holddown";
 						} else {
 							if (RFAPI_LOCAL_BI(
-								    bi)) {
+								    bpi)) {
 								type = "Local";
 							} else {
 								type = "Remote";
@@ -1327,7 +1332,7 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 					   "Lifetime", agetype, HVTYNL);
 				}
 				printed += rfapiPrintRemoteRegBi(bgp, stream,
-								 rn, bi);
+								 rn, bpi);
 			}
 		}
 	}
@@ -1535,7 +1540,7 @@ void rfapiPrintAdvertisedInfo(struct vty *vty, struct rfapi_descriptor *rfd,
 {
 	afi_t afi; /* of the VN address */
 	struct bgp_node *bn;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 	uint8_t type = ZEBRA_ROUTE_BGP;
 	struct bgp *bgp;
 	int printed = 0;
@@ -1565,12 +1570,12 @@ void rfapiPrintAdvertisedInfo(struct vty *vty, struct rfapi_descriptor *rfd,
 
 	vty_out(vty, "  bn=%p%s", bn, HVTYNL);
 
-	for (bi = bn->info; bi; bi = bi->next) {
-		if (bi->peer == rfd->peer && bi->type == type
-		    && bi->sub_type == BGP_ROUTE_RFP && bi->extra
-		    && bi->extra->vnc.export.rfapi_handle == (void *)rfd) {
+	for (bpi = bn->info; bpi; bpi = bpi->next) {
+		if (bpi->peer == rfd->peer && bpi->type == type
+		    && bpi->sub_type == BGP_ROUTE_RFP && bpi->extra
+		    && bpi->extra->vnc.export.rfapi_handle == (void *)rfd) {
 
-			rfapiPrintBi(vty, bi);
+			rfapiPrintBi(vty, bpi);
 			printed = 1;
 		}
 	}

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -394,7 +394,7 @@ int rfapiStream2Vty(void *stream,			   /* input */
 
 /* called from bgpd/bgp_vty.c'route_vty_out() */
 void rfapi_vty_out_vncinfo(struct vty *vty, struct prefix *p,
-			   struct bgp_info *bi, safi_t safi)
+			   struct bgp_path_info *bi, safi_t safi)
 {
 	char *s;
 	uint32_t lifetime;
@@ -479,7 +479,7 @@ void rfapiPrintAttrPtrs(void *stream, struct attr *attr)
 /*
  * Print BI in an Import Table
  */
-void rfapiPrintBi(void *stream, struct bgp_info *bi)
+void rfapiPrintBi(void *stream, struct bgp_path_info *bi)
 {
 	char buf[BUFSIZ];
 	char *s;
@@ -740,7 +740,7 @@ static void rfapiDebugPrintMonitorEncap(void *stream,
 
 void rfapiShowItNode(void *stream, struct agg_node *rn)
 {
-	struct bgp_info *bi;
+	struct bgp_path_info *bi;
 	char buf[BUFSIZ];
 
 	int (*fp)(void *, const char *, ...);
@@ -779,7 +779,7 @@ void rfapiShowImportTable(void *stream, const char *label, struct agg_table *rt,
 	fp(out, "Import Table [%s]%s", label, HVTYNL);
 
 	for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
-		struct bgp_info *bi;
+		struct bgp_path_info *bi;
 
 		if (rn->p.family == AF_ETHERNET) {
 			rfapiEthAddr2Str(&rn->p.u.prefix_eth, buf, BUFSIZ);
@@ -1008,7 +1008,7 @@ int rfapiShowVncQueries(void *stream, struct prefix *pfx_match)
 }
 
 static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
-				 struct agg_node *rn, struct bgp_info *bi)
+				 struct agg_node *rn, struct bgp_path_info *bi)
 {
 	int (*fp)(void *, const char *, ...);
 	struct vty *vty;
@@ -1126,7 +1126,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 #if RFAPI_REGISTRATIONS_REPORT_AGE
 		/*
 		 * Calculate when the timer started. Doing so here saves
-		 * us a timestamp field in "struct bgp_info".
+		 * us a timestamp field in "struct bgp_path_info".
 		 *
 		 * See rfapi_import.c'rfapiBiStartWithdrawTimer() for the
 		 * original calculation.
@@ -1222,7 +1222,7 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 		for (rn = agg_route_top(it->imported_vpn[afi]); rn;
 		     rn = agg_route_next(rn)) {
 
-			struct bgp_info *bi;
+			struct bgp_path_info *bi;
 			int count_only;
 
 			/* allow for wider or more narrow mask from user */
@@ -1535,7 +1535,7 @@ void rfapiPrintAdvertisedInfo(struct vty *vty, struct rfapi_descriptor *rfd,
 {
 	afi_t afi; /* of the VN address */
 	struct bgp_node *bn;
-	struct bgp_info *bi;
+	struct bgp_path_info *bi;
 	uint8_t type = ZEBRA_ROUTE_BGP;
 	struct bgp *bgp;
 	int printed = 0;

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -173,14 +173,14 @@ static int getce(struct bgp *bgp, struct attr *attr, struct prefix *pfx_ce)
 
 
 void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
-				 struct bgp_info *bi)
+				 struct bgp_path_info *bi)
 {
 	struct attr *attr = bi->attr;
 	struct peer *peer = bi->peer;
 	struct prefix *prefix = &rn->p;
 	afi_t afi = family2afi(prefix->family);
 	struct bgp_node *urn;
-	struct bgp_info *ubi;
+	struct bgp_path_info *ubi;
 	struct attr hattr;
 	struct attr *iattr;
 	struct prefix ce_nexthop;
@@ -282,7 +282,7 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
 	 */
 	encap_attr_export_ce(&hattr, attr, &ce_nexthop);
 	if (bgp->rfapi_cfg->routemap_export_bgp) {
-		struct bgp_info info;
+		struct bgp_path_info info;
 		route_map_result_t ret;
 
 		memset(&info, 0, sizeof(info));
@@ -328,10 +328,10 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
  * "Withdrawing a Route" export process
  */
 void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
-				 struct bgp_info *bi)
+				 struct bgp_path_info *bi)
 {
 	afi_t afi = family2afi(rn->p.family);
-	struct bgp_info *vbi;
+	struct bgp_path_info *vbi;
 	struct prefix ce_nexthop;
 
 	if (!afi) {
@@ -405,7 +405,7 @@ void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
 static void vnc_direct_bgp_vpn_enable_ce(struct bgp *bgp, afi_t afi)
 {
 	struct agg_node *rn;
-	struct bgp_info *ri;
+	struct bgp_path_info *ri;
 
 	vnc_zlog_debug_verbose("%s: entry, afi=%d", __func__, afi);
 
@@ -480,8 +480,8 @@ static void vnc_direct_bgp_vpn_disable_ce(struct bgp *bgp, afi_t afi)
 	for (rn = bgp_table_top(bgp->rib[afi][SAFI_UNICAST]); rn;
 	     rn = bgp_route_next(rn)) {
 
-		struct bgp_info *ri;
-		struct bgp_info *next;
+		struct bgp_path_info *ri;
+		struct bgp_path_info *next;
 
 		for (ri = rn->info, next = NULL; ri; ri = next) {
 
@@ -516,7 +516,7 @@ static void vnc_direct_bgp_vpn_disable_ce(struct bgp *bgp, afi_t afi)
 static struct ecommunity *vnc_route_origin_ecom(struct agg_node *rn)
 {
 	struct ecommunity *new;
-	struct bgp_info *bi;
+	struct bgp_path_info *bi;
 
 	if (!rn->info)
 		return NULL;
@@ -996,7 +996,7 @@ void vnc_direct_bgp_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 					struct rfapi_descriptor *irfd = rfd;
 					struct attr hattr;
 					struct attr *iattr;
-					struct bgp_info info;
+					struct bgp_path_info info;
 
 					if (rfapiRaddr2Qprefix(&irfd->vn_addr,
 							       &nhp))
@@ -1165,7 +1165,7 @@ static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 				       afi_t afi, struct rfapi_descriptor *irfd)
 {
 	struct prefix nhp;
-	struct bgp_info info;
+	struct bgp_path_info info;
 	struct attr hattr;
 	struct attr *iattr;
 
@@ -1684,7 +1684,7 @@ void vnc_direct_bgp_rh_add_route(struct bgp *bgp, afi_t afi,
 	if (encap_attr_export(&hattr, attr, NULL, NULL))
 		return;
 	if (hc->routemap_export_bgp) {
-		struct bgp_info info;
+		struct bgp_path_info info;
 		route_map_result_t ret;
 
 		memset(&info, 0, sizeof(info));
@@ -1839,7 +1839,7 @@ void vnc_direct_bgp_rh_vpn_enable(struct bgp *bgp, afi_t afi)
 
 		struct bgp_table *table;
 		struct bgp_node *rn;
-		struct bgp_info *ri;
+		struct bgp_path_info *ri;
 
 		memset(&prd, 0, sizeof(prd));
 		prd.family = AF_UNSPEC;
@@ -1910,7 +1910,7 @@ void vnc_direct_bgp_rh_vpn_enable(struct bgp *bgp, afi_t afi)
 					}
 
 					if (hc->routemap_export_bgp) {
-						struct bgp_info info;
+						struct bgp_path_info info;
 						route_map_result_t ret;
 
 						memset(&info, 0, sizeof(info));
@@ -2001,8 +2001,8 @@ void vnc_direct_bgp_rh_vpn_disable(struct bgp *bgp, afi_t afi)
 	for (rn = bgp_table_top(bgp->rib[afi][SAFI_UNICAST]); rn;
 	     rn = bgp_route_next(rn)) {
 
-		struct bgp_info *ri;
-		struct bgp_info *next;
+		struct bgp_path_info *ri;
+		struct bgp_path_info *next;
 
 		for (ri = rn->info, next = NULL; ri; ri = next) {
 

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -259,7 +259,7 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
 	for (ubi = urn->info; ubi; ubi = ubi->next) {
 		struct prefix unicast_nexthop;
 
-		if (CHECK_FLAG(ubi->flags, BGP_INFO_REMOVED))
+		if (CHECK_FLAG(ubi->flags, BGP_PATH_REMOVED))
 			continue;
 
 		rfapiUnicastNexthop2Prefix(afi, ubi->attr, &unicast_nexthop);

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -173,14 +173,14 @@ static int getce(struct bgp *bgp, struct attr *attr, struct prefix *pfx_ce)
 
 
 void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
-				 struct bgp_path_info *bi)
+				 struct bgp_path_info *bpi)
 {
-	struct attr *attr = bi->attr;
-	struct peer *peer = bi->peer;
+	struct attr *attr = bpi->attr;
+	struct peer *peer = bpi->peer;
 	struct prefix *prefix = &rn->p;
 	afi_t afi = family2afi(prefix->family);
 	struct bgp_node *urn;
-	struct bgp_path_info *ubi;
+	struct bgp_path_info *ubpi;
 	struct attr hattr;
 	struct attr *iattr;
 	struct prefix ce_nexthop;
@@ -193,10 +193,10 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
 		return;
 	}
 
-	if ((bi->type != ZEBRA_ROUTE_BGP)
-	    || (bi->sub_type != BGP_ROUTE_NORMAL
-		&& bi->sub_type != BGP_ROUTE_RFP
-		&& bi->sub_type != BGP_ROUTE_STATIC)) {
+	if ((bpi->type != ZEBRA_ROUTE_BGP)
+	    || (bpi->sub_type != BGP_ROUTE_NORMAL
+		&& bpi->sub_type != BGP_ROUTE_RFP
+		&& bpi->sub_type != BGP_ROUTE_STATIC)) {
 
 		vnc_zlog_debug_verbose(
 			"%s: wrong route type/sub_type for export, skipping",
@@ -256,17 +256,17 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
 	 */
 	urn = bgp_afi_node_get(bgp->rib[afi][SAFI_UNICAST], afi, SAFI_UNICAST,
 			       prefix, NULL);
-	for (ubi = urn->info; ubi; ubi = ubi->next) {
+	for (ubpi = urn->info; ubpi; ubpi = ubpi->next) {
 		struct prefix unicast_nexthop;
 
-		if (CHECK_FLAG(ubi->flags, BGP_PATH_REMOVED))
+		if (CHECK_FLAG(ubpi->flags, BGP_PATH_REMOVED))
 			continue;
 
-		rfapiUnicastNexthop2Prefix(afi, ubi->attr, &unicast_nexthop);
+		rfapiUnicastNexthop2Prefix(afi, ubpi->attr, &unicast_nexthop);
 
-		if (ubi->type == ZEBRA_ROUTE_VNC_DIRECT
-		    && ubi->sub_type == BGP_ROUTE_REDISTRIBUTE
-		    && ubi->peer == peer
+		if (ubpi->type == ZEBRA_ROUTE_VNC_DIRECT
+		    && ubpi->sub_type == BGP_ROUTE_REDISTRIBUTE
+		    && ubpi->peer == peer
 		    && prefix_same(&unicast_nexthop, &ce_nexthop)) {
 
 			vnc_zlog_debug_verbose(
@@ -328,10 +328,10 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
  * "Withdrawing a Route" export process
  */
 void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
-				 struct bgp_path_info *bi)
+				 struct bgp_path_info *bpi)
 {
 	afi_t afi = family2afi(rn->p.family);
-	struct bgp_path_info *vbi;
+	struct bgp_path_info *vbpi;
 	struct prefix ce_nexthop;
 
 	if (!afi) {
@@ -364,7 +364,7 @@ void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
 	 * This works only for IPv4 because IPv6 addresses are too big
 	 * to fit in an extended community
 	 */
-	if (getce(bgp, bi->attr, &ce_nexthop)) {
+	if (getce(bgp, bpi->attr, &ce_nexthop)) {
 		vnc_zlog_debug_verbose("%s: EC has no encoded CE, skipping",
 				       __func__);
 		return;
@@ -376,13 +376,13 @@ void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
 	 * route from the unicast RIB
 	 */
 
-	for (vbi = rn->info; vbi; vbi = vbi->next) {
+	for (vbpi = rn->info; vbpi; vbpi = vbpi->next) {
 		struct prefix ce;
-		if (bi == vbi)
+		if (bpi == vbpi)
 			continue;
-		if (bi->peer != vbi->peer)
+		if (bpi->peer != vbpi->peer)
 			continue;
-		if (getce(bgp, vbi->attr, &ce))
+		if (getce(bgp, vbpi->attr, &ce))
 			continue;
 		if (prefix_same(&ce, &ce_nexthop)) {
 			vnc_zlog_debug_verbose(
@@ -395,8 +395,8 @@ void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
 	/*
 	 * withdraw the route
 	 */
-	bgp_withdraw(bi->peer, &rn->p, 0, /* addpath_id */
-		     NULL,		  /* attr, ignored */
+	bgp_withdraw(bpi->peer, &rn->p, 0, /* addpath_id */
+		     NULL,		   /* attr, ignored */
 		     afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT,
 		     BGP_ROUTE_REDISTRIBUTE, NULL, /* RD not used for unicast */
 		     NULL, 0, NULL); /* tag not used for unicast */
@@ -516,24 +516,24 @@ static void vnc_direct_bgp_vpn_disable_ce(struct bgp *bgp, afi_t afi)
 static struct ecommunity *vnc_route_origin_ecom(struct agg_node *rn)
 {
 	struct ecommunity *new;
-	struct bgp_path_info *bi;
+	struct bgp_path_info *bpi;
 
 	if (!rn->info)
 		return NULL;
 
 	new = ecommunity_new();
 
-	for (bi = rn->info; bi; bi = bi->next) {
+	for (bpi = rn->info; bpi; bpi = bpi->next) {
 
 		struct ecommunity_val roec;
 
-		switch (BGP_MP_NEXTHOP_FAMILY(bi->attr->mp_nexthop_len)) {
+		switch (BGP_MP_NEXTHOP_FAMILY(bpi->attr->mp_nexthop_len)) {
 		case AF_INET:
 			memset(&roec, 0, sizeof(roec));
 			roec.val[0] = 0x01;
 			roec.val[1] = 0x03;
 			memcpy(roec.val + 2,
-			       &bi->attr->mp_nexthop_global_in.s_addr, 4);
+			       &bpi->attr->mp_nexthop_global_in.s_addr, 4);
 			roec.val[6] = 0;
 			roec.val[7] = 0;
 			ecommunity_add_val(new, &roec);
@@ -1629,7 +1629,7 @@ void vnc_direct_bgp_vpn_disable(struct bgp *bgp, afi_t afi)
 
 /*
  * "Adding a Route" export process
- * TBD do we need to check bi->type and bi->sub_type here, or does
+ * TBD do we need to check bpi->type and bpi->sub_type here, or does
  * caller do it?
  */
 void vnc_direct_bgp_rh_add_route(struct bgp *bgp, afi_t afi,
@@ -1753,7 +1753,7 @@ static int vncExportWithdrawTimer(struct thread *t)
 
 /*
  * "Withdrawing a Route" export process
- * TBD do we need to check bi->type and bi->sub_type here, or does
+ * TBD do we need to check bpi->type and bpi->sub_type here, or does
  * caller do it?
  */
 void vnc_direct_bgp_rh_del_route(struct bgp *bgp, afi_t afi,

--- a/bgpd/rfapi/vnc_export_bgp_p.h
+++ b/bgpd/rfapi/vnc_export_bgp_p.h
@@ -30,10 +30,10 @@
 #include "rfapi_private.h"
 
 extern void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
-					struct bgp_info *bi);
+					struct bgp_path_info *bi);
 
 extern void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
-					struct bgp_info *bi);
+					struct bgp_path_info *bi);
 
 extern void vnc_direct_bgp_add_prefix(struct bgp *bgp,
 				      struct rfapi_import_table *import_table,

--- a/bgpd/rfapi/vnc_export_bgp_p.h
+++ b/bgpd/rfapi/vnc_export_bgp_p.h
@@ -30,10 +30,10 @@
 #include "rfapi_private.h"
 
 extern void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
-					struct bgp_path_info *bi);
+					struct bgp_path_info *bpi);
 
 extern void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
-					struct bgp_path_info *bi);
+					struct bgp_path_info *bpi);
 
 extern void vnc_direct_bgp_add_prefix(struct bgp *bgp,
 				      struct rfapi_import_table *import_table,

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -452,7 +452,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve_one_bi(
 
 		return;
 	}
-	if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+	if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 		return;
 
 	vncHDResolveNve.peer = bi->peer;
@@ -1253,7 +1253,7 @@ static void vnc_import_bgp_del_route_mode_resolve_nve_one_bi(
 
 		return;
 	}
-	if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+	if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 		return;
 
 	vncHDResolveNve.peer = bi->peer;
@@ -1658,9 +1658,9 @@ static int is_usable_interior_route(struct bgp_info *bi_interior)
 #endif
 		return 0;
 	}
-	if (!CHECK_FLAG(bi_interior->flags, BGP_INFO_VALID)) {
+	if (!CHECK_FLAG(bi_interior->flags, BGP_PATH_VALID)) {
 #if DEBUG_IS_USABLE_INTERIOR
-		vnc_zlog_debug_verbose("%s: NO: BGP_INFO_VALID not set",
+		vnc_zlog_debug_verbose("%s: NO: BGP_PATH_VALID not set",
 				       __func__);
 #endif
 		return 0;
@@ -2772,7 +2772,7 @@ void vnc_import_bgp_redist_enable(struct bgp *bgp, afi_t afi)
 
 		for (bi = rn->info; bi; bi = bi->next) {
 
-			if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+			if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 				continue;
 
 			vnc_import_bgp_add_route(bgp, &rn->p, bi);
@@ -2812,7 +2812,7 @@ void vnc_import_bgp_exterior_redist_enable(struct bgp *bgp, afi_t afi)
 
 		for (bi = rn->info; bi; bi = bi->next) {
 
-			if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+			if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 				continue;
 
 			vnc_import_bgp_exterior_add_route(bgp_exterior, &rn->p,
@@ -2857,7 +2857,7 @@ void vnc_import_bgp_exterior_redist_enable_it(
 
 		for (bi = rn->info; bi; bi = bi->next) {
 
-			if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+			if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 				continue;
 
 			vnc_import_bgp_exterior_add_route_it(
@@ -2989,7 +2989,7 @@ void vnc_import_bgp_exterior_redist_disable(struct bgp *bgp, afi_t afi)
 
 			for (bi = rn->info; bi; bi = bi->next) {
 
-				if (CHECK_FLAG(bi->flags, BGP_INFO_REMOVED))
+				if (CHECK_FLAG(bi->flags, BGP_PATH_REMOVED))
 					continue;
 
 				vnc_import_bgp_exterior_del_route(bgp_exterior,

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -122,7 +122,7 @@ static int is_host_prefix(struct prefix *p)
 struct prefix_bag {
 	struct prefix hpfx;   /* ce address = unicast nexthop */
 	struct prefix upfx;   /* unicast prefix */
-	struct bgp_info *ubi; /* unicast route */
+	struct bgp_path_info *ubi; /* unicast route */
 };
 
 static const uint8_t maskbit[] = {0x00, 0x80, 0xc0, 0xe0, 0xf0,
@@ -300,7 +300,7 @@ static void vnc_rhnck(char *tag)
 static int process_unicast_route(struct bgp *bgp,		 /* in */
 				 afi_t afi,			 /* in */
 				 struct prefix *prefix,		 /* in */
-				 struct bgp_info *info,		 /* in */
+				 struct bgp_path_info *info,     /* in */
 				 struct ecommunity **ecom,       /* OUT */
 				 struct prefix *unicast_nexthop) /* OUT */
 {
@@ -359,7 +359,7 @@ static int process_unicast_route(struct bgp *bgp,		 /* in */
 	bgp_attr_dup(&hattr, attr); /* hattr becomes a ghost attr */
 
 	if (rmap) {
-		struct bgp_info info;
+		struct bgp_path_info info;
 		route_map_result_t ret;
 
 		memset(&info, 0, sizeof(info));
@@ -422,8 +422,8 @@ static int process_unicast_route(struct bgp *bgp,		 /* in */
 
 
 static void vnc_import_bgp_add_route_mode_resolve_nve_one_bi(
-	struct bgp *bgp, afi_t afi, struct bgp_info *bi, /* VPN bi */
-	struct prefix_rd *prd,				 /* RD */
+	struct bgp *bgp, afi_t afi, struct bgp_path_info *bi, /* VPN bi */
+	struct prefix_rd *prd,				      /* RD */
 	struct prefix *prefix,   /* unicast route prefix */
 	uint32_t *local_pref,    /* NULL = no local_pref */
 	uint32_t *med,		 /* NULL = no med */
@@ -521,7 +521,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve_one_rd(
 	struct prefix *ubi_nexthop) /* unicast nexthop */
 {
 	struct bgp_node *bn;
-	struct bgp_info *bi;
+	struct bgp_path_info *bi;
 
 	if (!table_rd)
 		return;
@@ -542,7 +542,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve_one_rd(
 		return;
 	}
 
-	/* Iterate over bgp_info items at this node */
+	/* Iterate over bgp_path_info items at this node */
 	for (bi = bn->info; bi; bi = bi->next) {
 
 		vnc_import_bgp_add_route_mode_resolve_nve_one_bi(
@@ -555,7 +555,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve_one_rd(
 
 static void vnc_import_bgp_add_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix *prefix, /* unicast prefix */
-	struct bgp_info *info)			/* unicast info */
+	struct bgp_path_info *info)		/* unicast info */
 {
 	afi_t afi = family2afi(prefix->family);
 
@@ -693,7 +693,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve(
 
 static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 						struct prefix *prefix,
-						struct bgp_info *info)
+						struct bgp_path_info *info)
 {
 	afi_t afi = family2afi(prefix->family);
 	struct peer *peer = info->peer;
@@ -808,7 +808,7 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 	bgp_attr_dup(&hattr, attr); /* hattr becomes a ghost attr */
 
 	if (rmap) {
-		struct bgp_info info;
+		struct bgp_path_info info;
 		route_map_result_t ret;
 
 		memset(&info, 0, sizeof(info));
@@ -881,7 +881,7 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 
 static void
 vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
-				       struct bgp_info *info,
+				       struct bgp_path_info *info,
 				       struct rfapi_nve_group_cfg *rfg)
 {
 	afi_t afi = family2afi(prefix->family);
@@ -1010,7 +1010,7 @@ vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
 	bgp_attr_dup(&hattr, attr); /* hattr becomes a ghost attr */
 
 	if (rmap) {
-		struct bgp_info binfo;
+		struct bgp_path_info binfo;
 		route_map_result_t ret;
 
 		memset(&binfo, 0, sizeof(binfo));
@@ -1085,7 +1085,7 @@ vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
 
 static void vnc_import_bgp_del_route_mode_plain(struct bgp *bgp,
 						struct prefix *prefix,
-						struct bgp_info *info)
+						struct bgp_path_info *info)
 {
 	struct prefix_rd prd;
 	afi_t afi = family2afi(prefix->family);
@@ -1158,7 +1158,7 @@ static void vnc_import_bgp_del_route_mode_plain(struct bgp *bgp,
 
 static void vnc_import_bgp_del_route_mode_nvegroup(struct bgp *bgp,
 						   struct prefix *prefix,
-						   struct bgp_info *info)
+						   struct bgp_path_info *info)
 {
 	struct prefix_rd prd;
 	afi_t afi = family2afi(prefix->family);
@@ -1238,8 +1238,8 @@ static void vnc_import_bgp_del_route_mode_nvegroup(struct bgp *bgp,
 }
 
 static void vnc_import_bgp_del_route_mode_resolve_nve_one_bi(
-	struct bgp *bgp, afi_t afi, struct bgp_info *bi, /* VPN bi */
-	struct prefix_rd *prd,				 /* RD */
+	struct bgp *bgp, afi_t afi, struct bgp_path_info *bi, /* VPN bi */
+	struct prefix_rd *prd,				      /* RD */
 	struct prefix *prefix) /* unicast route prefix */
 {
 	struct prefix un;
@@ -1278,7 +1278,7 @@ static void vnc_import_bgp_del_route_mode_resolve_nve_one_rd(
 	struct prefix *ubi_nexthop) /* unicast bi's nexthop */
 {
 	struct bgp_node *bn;
-	struct bgp_info *bi;
+	struct bgp_path_info *bi;
 
 	if (!table_rd)
 		return;
@@ -1299,7 +1299,7 @@ static void vnc_import_bgp_del_route_mode_resolve_nve_one_rd(
 		return;
 	}
 
-	/* Iterate over bgp_info items at this node */
+	/* Iterate over bgp_path_info items at this node */
 	for (bi = bn->info; bi; bi = bi->next) {
 
 		vnc_import_bgp_del_route_mode_resolve_nve_one_bi(
@@ -1311,10 +1311,10 @@ static void vnc_import_bgp_del_route_mode_resolve_nve_one_rd(
 	bgp_unlock_node(bn);
 }
 
-static void vnc_import_bgp_del_route_mode_resolve_nve(struct bgp *bgp,
-						      afi_t afi,
-						      struct prefix *prefix,
-						      struct bgp_info *info)
+static void
+vnc_import_bgp_del_route_mode_resolve_nve(struct bgp *bgp, afi_t afi,
+					  struct prefix *prefix,
+					  struct bgp_path_info *info)
 {
 	struct ecommunity *ecom = NULL;
 	struct prefix pfx_unicast_nexthop = {0}; /* happy valgrind */
@@ -1398,7 +1398,7 @@ void vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
 	struct prefix *prefix,			/* VPN prefix */
-	struct bgp_info *bi)			/* new VPN host route */
+	struct bgp_path_info *bi)		/* new VPN host route */
 {
 	afi_t afi = family2afi(prefix->family);
 	struct skiplist *sl = NULL;
@@ -1538,7 +1538,7 @@ void vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
 	struct prefix *prefix,			/* VPN prefix */
-	struct bgp_info *bi)			/* old VPN host route */
+	struct bgp_path_info *bi)		/* old VPN host route */
 {
 	afi_t afi = family2afi(prefix->family);
 	struct skiplist *sl = NULL;
@@ -1648,7 +1648,7 @@ void vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
 
 #define DEBUG_IS_USABLE_INTERIOR 1
 
-static int is_usable_interior_route(struct bgp_info *bi_interior)
+static int is_usable_interior_route(struct bgp_path_info *bi_interior)
 {
 	if (!VALID_INTERIOR_TYPE(bi_interior->type)) {
 #if DEBUG_IS_USABLE_INTERIOR
@@ -1680,7 +1680,7 @@ static int is_usable_interior_route(struct bgp_info *bi_interior)
 static void vnc_import_bgp_exterior_add_route_it(
 	struct bgp *bgp,		    /* exterior instance, we hope */
 	struct prefix *prefix,		    /* unicast prefix */
-	struct bgp_info *info,		    /* unicast info */
+	struct bgp_path_info *info,	 /* unicast info */
 	struct rfapi_import_table *it_only) /* NULL, or limit to this IT */
 {
 	struct rfapi *h;
@@ -1740,7 +1740,7 @@ static void vnc_import_bgp_exterior_add_route_it(
 		struct agg_table *table;
 		struct agg_node *rn;
 		struct agg_node *par;
-		struct bgp_info *bi_interior;
+		struct bgp_path_info *bi_interior;
 		int have_usable_route;
 
 		vnc_zlog_debug_verbose("%s: doing it %p", __func__, it);
@@ -1854,9 +1854,9 @@ static void vnc_import_bgp_exterior_add_route_it(
 }
 
 void vnc_import_bgp_exterior_add_route(
-	struct bgp *bgp,       /* exterior instance, we hope */
-	struct prefix *prefix, /* unicast prefix */
-	struct bgp_info *info) /* unicast info */
+	struct bgp *bgp,	    /* exterior instance, we hope */
+	struct prefix *prefix,      /* unicast prefix */
+	struct bgp_path_info *info) /* unicast info */
 {
 	vnc_import_bgp_exterior_add_route_it(bgp, prefix, info, NULL);
 }
@@ -1872,7 +1872,7 @@ void vnc_import_bgp_exterior_add_route(
  */
 void vnc_import_bgp_exterior_del_route(
 	struct bgp *bgp, struct prefix *prefix, /* unicast prefix */
-	struct bgp_info *info)			/* unicast info */
+	struct bgp_path_info *info)		/* unicast info */
 {
 	struct rfapi *h;
 	struct rfapi_cfg *hc;
@@ -1931,7 +1931,7 @@ void vnc_import_bgp_exterior_del_route(
 		struct agg_table *table;
 		struct agg_node *rn;
 		struct agg_node *par;
-		struct bgp_info *bi_interior;
+		struct bgp_path_info *bi_interior;
 		int have_usable_route;
 
 		table = it->imported_vpn[afi];
@@ -2038,12 +2038,12 @@ void vnc_import_bgp_exterior_del_route(
  */
 void vnc_import_bgp_exterior_add_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct agg_node *rn_interior, /* VPN IT node */
-	struct bgp_info *bi_interior) /* VPN IT route */
+	struct agg_node *rn_interior,      /* VPN IT node */
+	struct bgp_path_info *bi_interior) /* VPN IT route */
 {
 	afi_t afi = family2afi(rn_interior->p.family);
 	struct agg_node *par;
-	struct bgp_info *bi_exterior;
+	struct bgp_path_info *bi_exterior;
 	struct prefix *pfx_exterior; /* exterior pfx */
 	void *cursor;
 	int rc;
@@ -2194,7 +2194,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 
 			if (prefix_match(&rn_interior->p, &pfx_nexthop)) {
 
-				struct bgp_info *bi;
+				struct bgp_path_info *bi;
 				struct prefix_rd *prd;
 				struct attr new_attr;
 				uint32_t label = 0;
@@ -2420,12 +2420,12 @@ void vnc_import_bgp_exterior_add_route_interior(
  */
 void vnc_import_bgp_exterior_del_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct agg_node *rn_interior, /* VPN IT node */
-	struct bgp_info *bi_interior) /* VPN IT route */
+	struct agg_node *rn_interior,      /* VPN IT node */
+	struct bgp_path_info *bi_interior) /* VPN IT route */
 {
 	afi_t afi = family2afi(rn_interior->p.family);
 	struct agg_node *par;
-	struct bgp_info *bi_exterior;
+	struct bgp_path_info *bi_exterior;
 	struct prefix *pfx_exterior; /* exterior pfx */
 	void *cursor;
 	int rc;
@@ -2532,7 +2532,7 @@ void vnc_import_bgp_exterior_del_route_interior(
 
 		if (par) {
 
-			struct bgp_info *bi;
+			struct bgp_path_info *bi;
 
 			/*
 			 * Add monitor to parent node
@@ -2612,7 +2612,7 @@ void vnc_import_bgp_exterior_del_route_interior(
  ***********************************************************************/
 
 void vnc_import_bgp_add_route(struct bgp *bgp, struct prefix *prefix,
-			      struct bgp_info *info)
+			      struct bgp_path_info *info)
 {
 	afi_t afi = family2afi(prefix->family);
 
@@ -2681,7 +2681,7 @@ void vnc_import_bgp_add_route(struct bgp *bgp, struct prefix *prefix,
  * "Withdrawing a Route" import process
  */
 void vnc_import_bgp_del_route(struct bgp *bgp, struct prefix *prefix,
-			      struct bgp_info *info) /* unicast info */
+			      struct bgp_path_info *info) /* unicast info */
 {
 	afi_t afi = family2afi(prefix->family);
 
@@ -2768,7 +2768,7 @@ void vnc_import_bgp_redist_enable(struct bgp *bgp, afi_t afi)
 	for (rn = bgp_table_top(bgp->rib[afi][SAFI_UNICAST]); rn;
 	     rn = bgp_route_next(rn)) {
 
-		struct bgp_info *bi;
+		struct bgp_path_info *bi;
 
 		for (bi = rn->info; bi; bi = bi->next) {
 
@@ -2808,7 +2808,7 @@ void vnc_import_bgp_exterior_redist_enable(struct bgp *bgp, afi_t afi)
 	for (rn = bgp_table_top(bgp_exterior->rib[afi][SAFI_UNICAST]); rn;
 	     rn = bgp_route_next(rn)) {
 
-		struct bgp_info *bi;
+		struct bgp_path_info *bi;
 
 		for (bi = rn->info; bi; bi = bi->next) {
 
@@ -2853,7 +2853,7 @@ void vnc_import_bgp_exterior_redist_enable_it(
 	for (rn = bgp_table_top(bgp_exterior->rib[afi][SAFI_UNICAST]); rn;
 	     rn = bgp_route_next(rn)) {
 
-		struct bgp_info *bi;
+		struct bgp_path_info *bi;
 
 		for (bi = rn->info; bi; bi = bi->next) {
 
@@ -2896,8 +2896,8 @@ void vnc_import_bgp_redist_disable(struct bgp *bgp, afi_t afi)
 			for (rn2 = bgp_table_top(rn1->info); rn2;
 			     rn2 = bgp_route_next(rn2)) {
 
-				struct bgp_info *bi;
-				struct bgp_info *nextbi;
+				struct bgp_path_info *bi;
+				struct bgp_path_info *nextbi;
 
 				for (bi = rn2->info; bi; bi = nextbi) {
 
@@ -2944,7 +2944,7 @@ void vnc_import_bgp_redist_disable(struct bgp *bgp, afi_t afi)
 	/* Clear RHN list */
 	if (bgp->rfapi->resolve_nve_nexthop) {
 		struct prefix_bag *pb;
-		struct bgp_info *info;
+		struct bgp_path_info *info;
 		while (!skiplist_first(bgp->rfapi->resolve_nve_nexthop, NULL,
 				       (void *)&pb)) {
 			info = pb->ubi;
@@ -2985,7 +2985,7 @@ void vnc_import_bgp_exterior_redist_disable(struct bgp *bgp, afi_t afi)
 		for (rn = bgp_table_top(bgp_exterior->rib[afi][SAFI_UNICAST]);
 		     rn; rn = bgp_route_next(rn)) {
 
-			struct bgp_info *bi;
+			struct bgp_path_info *bi;
 
 			for (bi = rn->info; bi; bi = bi->next) {
 

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -660,7 +660,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve(
 	pb->ubi = info;
 	pb->upfx = *prefix;
 
-	bgp_info_lock(info); /* skiplist refers to it */
+	bgp_path_info_lock(info); /* skiplist refers to it */
 	skiplist_insert(bgp->rfapi->resolve_nve_nexthop, &pb->hpfx, pb);
 
 	/*
@@ -1354,7 +1354,7 @@ vnc_import_bgp_del_route_mode_resolve_nve(struct bgp *bgp, afi_t afi,
 	while (!rc) {
 		if (pb->ubi == info) {
 			skiplist_delete(sl, &pfx_unicast_nexthop, pb);
-			bgp_info_unlock(info);
+			bgp_path_info_unlock(info);
 			break;
 		}
 		rc = skiplist_next_value(sl, &pfx_unicast_nexthop, (void *)&pb,
@@ -1829,7 +1829,7 @@ static void vnc_import_bgp_exterior_add_route_it(
 					    RFAPI_MONITOR_EXTERIOR(rn)->source,
 					    info, pfx_mon)) {
 
-					bgp_info_lock(info);
+					bgp_path_info_lock(info);
 				}
 			}
 			par = agg_node_parent(rn);
@@ -1847,7 +1847,7 @@ static void vnc_import_bgp_exterior_add_route_it(
 			if (!skiplist_insert(it->monitor_exterior_orphans, info,
 					     pfx_mon)) {
 
-				bgp_info_lock(info);
+				bgp_path_info_lock(info);
 			}
 		}
 	}
@@ -1986,7 +1986,8 @@ void vnc_import_bgp_exterior_del_route(
 								    ->source,
 							    info, NULL)) {
 
-							bgp_info_unlock(info);
+							bgp_path_info_unlock(
+								info);
 							agg_unlock_node(
 								rn); /* sl entry
 								      */
@@ -2023,7 +2024,7 @@ void vnc_import_bgp_exterior_del_route(
 			if (!skiplist_delete(it->monitor_exterior_orphans, info,
 					     NULL)) {
 
-				bgp_info_unlock(info);
+				bgp_path_info_unlock(info);
 			}
 		}
 	}
@@ -2949,7 +2950,7 @@ void vnc_import_bgp_redist_disable(struct bgp *bgp, afi_t afi)
 				       (void *)&pb)) {
 			info = pb->ubi;
 			skiplist_delete_first(bgp->rfapi->resolve_nve_nexthop);
-			bgp_info_unlock(info);
+			bgp_path_info_unlock(info);
 		}
 	}
 

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -1010,13 +1010,13 @@ vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
 	bgp_attr_dup(&hattr, attr); /* hattr becomes a ghost attr */
 
 	if (rmap) {
-		struct bgp_path_info binfo;
+		struct bgp_path_info path;
 		route_map_result_t ret;
 
-		memset(&binfo, 0, sizeof(binfo));
-		binfo.peer = peer;
-		binfo.attr = &hattr;
-		ret = route_map_apply(rmap, prefix, RMAP_BGP, &binfo);
+		memset(&path, 0, sizeof(path));
+		path.peer = peer;
+		path.attr = &hattr;
+		ret = route_map_apply(rmap, prefix, RMAP_BGP, &path);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			vnc_zlog_debug_verbose(

--- a/bgpd/rfapi/vnc_import_bgp.h
+++ b/bgpd/rfapi/vnc_import_bgp.h
@@ -62,12 +62,12 @@ extern void vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
 	struct prefix *prefix,			/* VPN prefix */
-	struct bgp_path_info *bi);		/* new VPN host route */
+	struct bgp_path_info *bpi);		/* new VPN host route */
 
 extern void vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
 	struct prefix *prefix,			/* VPN prefix */
-	struct bgp_path_info *bi);		/* old VPN host route */
+	struct bgp_path_info *bpi);		/* old VPN host route */
 
 #endif /* _QUAGGA_RFAPI_VNC_IMPORT_BGP_H_ */

--- a/bgpd/rfapi/vnc_import_bgp.h
+++ b/bgpd/rfapi/vnc_import_bgp.h
@@ -35,10 +35,10 @@ extern uint32_t calc_local_pref(struct attr *attr, struct peer *peer);
 extern int vnc_prefix_cmp(void *pfx1, void *pfx2);
 
 extern void vnc_import_bgp_add_route(struct bgp *bgp, struct prefix *prefix,
-				     struct bgp_info *info);
+				     struct bgp_path_info *info);
 
 extern void vnc_import_bgp_del_route(struct bgp *bgp, struct prefix *prefix,
-				     struct bgp_info *info);
+				     struct bgp_path_info *info);
 
 extern void vnc_import_bgp_redist_enable(struct bgp *bgp, afi_t afi);
 
@@ -50,25 +50,24 @@ extern void vnc_import_bgp_exterior_redist_disable(struct bgp *bgp, afi_t afi);
 
 
 extern void vnc_import_bgp_exterior_add_route(
-	struct bgp *bgp,	/* exterior instance, we hope */
-	struct prefix *prefix,  /* unicast prefix */
-	struct bgp_info *info); /* unicast info */
+	struct bgp *bgp,	     /* exterior instance, we hope */
+	struct prefix *prefix,       /* unicast prefix */
+	struct bgp_path_info *info); /* unicast info */
 
-extern void
-vnc_import_bgp_exterior_del_route(struct bgp *bgp,
-				  struct prefix *prefix,  /* unicast prefix */
-				  struct bgp_info *info); /* unicast info */
+extern void vnc_import_bgp_exterior_del_route(
+	struct bgp *bgp, struct prefix *prefix, /* unicast prefix */
+	struct bgp_path_info *info);		/* unicast info */
 
 extern void vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
 	struct prefix *prefix,			/* VPN prefix */
-	struct bgp_info *bi);			/* new VPN host route */
+	struct bgp_path_info *bi);		/* new VPN host route */
 
 extern void vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
 	struct prefix *prefix,			/* VPN prefix */
-	struct bgp_info *bi);			/* old VPN host route */
+	struct bgp_path_info *bi);		/* old VPN host route */
 
 #endif /* _QUAGGA_RFAPI_VNC_IMPORT_BGP_H_ */

--- a/bgpd/rfapi/vnc_import_bgp_p.h
+++ b/bgpd/rfapi/vnc_import_bgp_p.h
@@ -29,13 +29,13 @@
 
 extern void vnc_import_bgp_exterior_add_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct agg_node *rn_interior,       /* VPN IT node */
-	struct bgp_path_info *bi_interior); /* VPN IT route */
+	struct agg_node *rn_interior,	/* VPN IT node */
+	struct bgp_path_info *bpi_interior); /* VPN IT route */
 
 extern void vnc_import_bgp_exterior_del_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct agg_node *rn_interior,       /* VPN IT node */
-	struct bgp_path_info *bi_interior); /* VPN IT route */
+	struct agg_node *rn_interior,	/* VPN IT node */
+	struct bgp_path_info *bpi_interior); /* VPN IT route */
 
 extern void
 vnc_import_bgp_exterior_redist_enable_it(struct bgp *bgp, afi_t afi,

--- a/bgpd/rfapi/vnc_import_bgp_p.h
+++ b/bgpd/rfapi/vnc_import_bgp_p.h
@@ -29,13 +29,13 @@
 
 extern void vnc_import_bgp_exterior_add_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct agg_node *rn_interior,  /* VPN IT node */
-	struct bgp_info *bi_interior); /* VPN IT route */
+	struct agg_node *rn_interior,       /* VPN IT node */
+	struct bgp_path_info *bi_interior); /* VPN IT route */
 
 extern void vnc_import_bgp_exterior_del_route_interior(
 	struct bgp *bgp, struct rfapi_import_table *it,
-	struct agg_node *rn_interior,  /* VPN IT node */
-	struct bgp_info *bi_interior); /* VPN IT route */
+	struct agg_node *rn_interior,       /* VPN IT node */
+	struct bgp_path_info *bi_interior); /* VPN IT route */
 
 extern void
 vnc_import_bgp_exterior_redist_enable_it(struct bgp *bgp, afi_t afi,

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -316,7 +316,7 @@ static void vnc_redistribute_withdraw(struct bgp *bgp, afi_t afi, uint8_t type)
 
 		for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
 
-			struct bgp_info *ri;
+			struct bgp_path_info *ri;
 
 			for (ri = rn->info; ri; ri = ri->next) {
 				if (ri->type

--- a/doc/developer/next-hop-tracking.rst
+++ b/doc/developer/next-hop-tracking.rst
@@ -241,7 +241,7 @@ Legend:
     /\   struct bgp_node: a BGP destination/route/prefix
     \/
 
-    [ ]  struct bgp_info: a BGP path (e.g. route received from a peer)
+    [ ]  struct bgp_path_info: a BGP path (e.g. route received from a peer)
 
      _
     (_)  struct bgp_nexthop_cache: a BGP nexthop

--- a/gdb/lib.txt
+++ b/gdb/lib.txt
@@ -16,7 +16,7 @@
 # ...
 # (gdb) cont
 # Breakpoint 3, bgp_write_packet (peer=0x7fa885199080) at bgp_packet.c:614
-# 614                     if (CHECK_FLAG (adv->binfo->peer->cap,PEER_CAP_RESTART_RCV)
+# 614                     if (CHECK_FLAG (adv->path->peer->cap,PEER_CAP_RESTART_RCV)
 # (gdb) dump_prefix4  &adv->rn->p
 # IPv4:10.1.1.0/24
 # (gdb) dump_prefix  &adv->rn->p

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -317,7 +317,8 @@ static int run_bgp_path_info_mpath_update(testcase_t *t)
 	bgp_mp_list_add(&mp_list, &test_mp_list_info[1]);
 	new_best = &test_mp_list_info[3];
 	old_best = NULL;
-	bgp_path_info_mpath_update(&test_rn, new_best, old_best, &mp_list, &mp_cfg);
+	bgp_path_info_mpath_update(&test_rn, new_best, old_best, &mp_list,
+				   &mp_cfg);
 	bgp_mp_list_clear(&mp_list);
 	EXPECT_TRUE(bgp_path_info_mpath_count(new_best) == 2, test_result);
 	mpath = bgp_path_info_mpath_first(new_best);
@@ -331,7 +332,8 @@ static int run_bgp_path_info_mpath_update(testcase_t *t)
 	bgp_mp_list_add(&mp_list, &test_mp_list_info[1]);
 	new_best = &test_mp_list_info[0];
 	old_best = &test_mp_list_info[3];
-	bgp_path_info_mpath_update(&test_rn, new_best, old_best, &mp_list, &mp_cfg);
+	bgp_path_info_mpath_update(&test_rn, new_best, old_best, &mp_list,
+				   &mp_cfg);
 	bgp_mp_list_clear(&mp_list);
 	EXPECT_TRUE(bgp_path_info_mpath_count(new_best) == 1, test_result);
 	mpath = bgp_path_info_mpath_first(new_best);

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -207,7 +207,7 @@ struct peer test_mp_list_peer[] = {
 };
 int test_mp_list_peer_count = sizeof(test_mp_list_peer) / sizeof(struct peer);
 struct attr test_mp_list_attr[4];
-struct bgp_info test_mp_list_info[] = {
+struct bgp_path_info test_mp_list_info[] = {
 	{.peer = &test_mp_list_peer[0], .attr = &test_mp_list_attr[0]},
 	{.peer = &test_mp_list_peer[1], .attr = &test_mp_list_attr[1]},
 	{.peer = &test_mp_list_peer[2], .attr = &test_mp_list_attr[1]},
@@ -215,7 +215,7 @@ struct bgp_info test_mp_list_info[] = {
 	{.peer = &test_mp_list_peer[4], .attr = &test_mp_list_attr[3]},
 };
 int test_mp_list_info_count =
-	sizeof(test_mp_list_info) / sizeof(struct bgp_info);
+	sizeof(test_mp_list_info) / sizeof(struct bgp_path_info);
 
 static int setup_bgp_mp_list(testcase_t *t)
 {
@@ -247,7 +247,7 @@ static int run_bgp_mp_list(testcase_t *t)
 {
 	struct list mp_list;
 	struct listnode *mp_node;
-	struct bgp_info *info;
+	struct bgp_path_info *info;
 	int i;
 	int test_result = TEST_PASSED;
 	bgp_mp_list_init(&mp_list);
@@ -289,24 +289,24 @@ testcase_t test_bgp_mp_list = {
 };
 
 /*=========================================================
- * Testcase for bgp_info_mpath_update
+ * Testcase for bgp_path_info_mpath_update
  */
 
 struct bgp_node test_rn;
 
-static int setup_bgp_info_mpath_update(testcase_t *t)
+static int setup_bgp_path_info_mpath_update(testcase_t *t)
 {
 	int i;
 	str2prefix("42.1.1.0/24", &test_rn.p);
 	setup_bgp_mp_list(t);
 	for (i = 0; i < test_mp_list_info_count; i++)
-		bgp_info_add(&test_rn, &test_mp_list_info[i]);
+		bgp_path_info_add(&test_rn, &test_mp_list_info[i]);
 	return 0;
 }
 
-static int run_bgp_info_mpath_update(testcase_t *t)
+static int run_bgp_path_info_mpath_update(testcase_t *t)
 {
-	struct bgp_info *new_best, *old_best, *mpath;
+	struct bgp_path_info *new_best, *old_best, *mpath;
 	struct list mp_list;
 	struct bgp_maxpaths_cfg mp_cfg = {3, 3};
 	int test_result = TEST_PASSED;
@@ -317,13 +317,13 @@ static int run_bgp_info_mpath_update(testcase_t *t)
 	bgp_mp_list_add(&mp_list, &test_mp_list_info[1]);
 	new_best = &test_mp_list_info[3];
 	old_best = NULL;
-	bgp_info_mpath_update(&test_rn, new_best, old_best, &mp_list, &mp_cfg);
+	bgp_path_info_mpath_update(&test_rn, new_best, old_best, &mp_list, &mp_cfg);
 	bgp_mp_list_clear(&mp_list);
-	EXPECT_TRUE(bgp_info_mpath_count(new_best) == 2, test_result);
-	mpath = bgp_info_mpath_first(new_best);
+	EXPECT_TRUE(bgp_path_info_mpath_count(new_best) == 2, test_result);
+	mpath = bgp_path_info_mpath_first(new_best);
 	EXPECT_TRUE(mpath == &test_mp_list_info[0], test_result);
 	EXPECT_TRUE(CHECK_FLAG(mpath->flags, BGP_PATH_MULTIPATH), test_result);
-	mpath = bgp_info_mpath_next(mpath);
+	mpath = bgp_path_info_mpath_next(mpath);
 	EXPECT_TRUE(mpath == &test_mp_list_info[1], test_result);
 	EXPECT_TRUE(CHECK_FLAG(mpath->flags, BGP_PATH_MULTIPATH), test_result);
 
@@ -331,10 +331,10 @@ static int run_bgp_info_mpath_update(testcase_t *t)
 	bgp_mp_list_add(&mp_list, &test_mp_list_info[1]);
 	new_best = &test_mp_list_info[0];
 	old_best = &test_mp_list_info[3];
-	bgp_info_mpath_update(&test_rn, new_best, old_best, &mp_list, &mp_cfg);
+	bgp_path_info_mpath_update(&test_rn, new_best, old_best, &mp_list, &mp_cfg);
 	bgp_mp_list_clear(&mp_list);
-	EXPECT_TRUE(bgp_info_mpath_count(new_best) == 1, test_result);
-	mpath = bgp_info_mpath_first(new_best);
+	EXPECT_TRUE(bgp_path_info_mpath_count(new_best) == 1, test_result);
+	mpath = bgp_path_info_mpath_first(new_best);
 	EXPECT_TRUE(mpath == &test_mp_list_info[1], test_result);
 	EXPECT_TRUE(CHECK_FLAG(mpath->flags, BGP_PATH_MULTIPATH), test_result);
 	EXPECT_TRUE(!CHECK_FLAG(test_mp_list_info[0].flags, BGP_PATH_MULTIPATH),
@@ -343,7 +343,7 @@ static int run_bgp_info_mpath_update(testcase_t *t)
 	return test_result;
 }
 
-static int cleanup_bgp_info_mpath_update(testcase_t *t)
+static int cleanup_bgp_path_info_mpath_update(testcase_t *t)
 {
 	int i;
 
@@ -353,11 +353,11 @@ static int cleanup_bgp_info_mpath_update(testcase_t *t)
 	return 0;
 }
 
-testcase_t test_bgp_info_mpath_update = {
-	.desc = "Test bgp_info_mpath_update",
-	.setup = setup_bgp_info_mpath_update,
-	.run = run_bgp_info_mpath_update,
-	.cleanup = cleanup_bgp_info_mpath_update,
+testcase_t test_bgp_path_info_mpath_update = {
+	.desc = "Test bgp_path_info_mpath_update",
+	.setup = setup_bgp_path_info_mpath_update,
+	.run = run_bgp_path_info_mpath_update,
+	.cleanup = cleanup_bgp_path_info_mpath_update,
 };
 
 /*=========================================================
@@ -365,7 +365,7 @@ testcase_t test_bgp_info_mpath_update = {
  */
 testcase_t *all_tests[] = {
 	&test_bgp_cfg_maximum_paths, &test_bgp_mp_list,
-	&test_bgp_info_mpath_update,
+	&test_bgp_path_info_mpath_update,
 };
 
 int all_tests_count = (sizeof(all_tests) / sizeof(testcase_t *));

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -322,10 +322,10 @@ static int run_bgp_info_mpath_update(testcase_t *t)
 	EXPECT_TRUE(bgp_info_mpath_count(new_best) == 2, test_result);
 	mpath = bgp_info_mpath_first(new_best);
 	EXPECT_TRUE(mpath == &test_mp_list_info[0], test_result);
-	EXPECT_TRUE(CHECK_FLAG(mpath->flags, BGP_INFO_MULTIPATH), test_result);
+	EXPECT_TRUE(CHECK_FLAG(mpath->flags, BGP_PATH_MULTIPATH), test_result);
 	mpath = bgp_info_mpath_next(mpath);
 	EXPECT_TRUE(mpath == &test_mp_list_info[1], test_result);
-	EXPECT_TRUE(CHECK_FLAG(mpath->flags, BGP_INFO_MULTIPATH), test_result);
+	EXPECT_TRUE(CHECK_FLAG(mpath->flags, BGP_PATH_MULTIPATH), test_result);
 
 	bgp_mp_list_add(&mp_list, &test_mp_list_info[0]);
 	bgp_mp_list_add(&mp_list, &test_mp_list_info[1]);
@@ -336,8 +336,8 @@ static int run_bgp_info_mpath_update(testcase_t *t)
 	EXPECT_TRUE(bgp_info_mpath_count(new_best) == 1, test_result);
 	mpath = bgp_info_mpath_first(new_best);
 	EXPECT_TRUE(mpath == &test_mp_list_info[1], test_result);
-	EXPECT_TRUE(CHECK_FLAG(mpath->flags, BGP_INFO_MULTIPATH), test_result);
-	EXPECT_TRUE(!CHECK_FLAG(test_mp_list_info[0].flags, BGP_INFO_MULTIPATH),
+	EXPECT_TRUE(CHECK_FLAG(mpath->flags, BGP_PATH_MULTIPATH), test_result);
+	EXPECT_TRUE(!CHECK_FLAG(test_mp_list_info[0].flags, BGP_PATH_MULTIPATH),
 		    test_result);
 
 	return test_result;

--- a/tests/bgpd/test_mpath.py
+++ b/tests/bgpd/test_mpath.py
@@ -5,5 +5,5 @@ class TestMpath(frrtest.TestMultiOut):
 
 TestMpath.okfail("bgp maximum-paths config")
 TestMpath.okfail("bgp_mp_list")
-TestMpath.okfail("bgp_info_mpath_update")
+TestMpath.okfail("bgp_path_info_mpath_update")
 


### PR DESCRIPTION
Convert `struct bgp_info` to `struct bgp_path` and also cleanup all the associated variable names