### PR TITLE
staticd: Allow table_id to be a distinguisher for installation

### DIFF
--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -385,6 +385,9 @@ extern void static_zebra_route_add(struct route_node *rn,
 		if (si->distance != si_changed->distance)
 			continue;
 
+		if (si->table_id != si_changed->table_id)
+			continue;
+
 		api_nh->vrf_id = si->nh_vrf_id;
 		switch (si->type) {
 		case STATIC_IFNAME:


### PR DESCRIPTION
The table_id should be a discriminator in the installation of
static routes into zebra from staticd.  Add this to allow the end
user to do something like this:

ip route 4.5.6.7/32 192.168.209.44
ip route 4.5.6.7/32 192.168.209.44 table 3000
ip route 4.5.6.7/32 192.168.209.45 table 3000

robot# show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route

K>* 0.0.0.0/0 [0/101] via 192.168.201.1, enp0s3, 00:01:40
S>* 4.3.2.1/32 [1/0] via 192.168.210.4, enp0s10, 00:01:35
S>* 4.3.2.2/32 [1/0] via 192.168.209.4, enp0s9, 00:01:35
S>* 4.5.6.0/26 [1/0] via 192.168.210.4, enp0s10, 00:01:35
S>* 4.5.6.7/32 [1/0] via 192.168.209.44, enp0s9, 00:01:35
C>* 192.168.201.0/24 is directly connected, enp0s3, 00:01:40
C>* 192.168.208.0/24 is directly connected, enp0s8, 00:01:40
C>* 192.168.209.0/24 is directly connected, enp0s9, 00:01:40
C>* 192.168.210.0/24 is directly connected, enp0s10, 00:01:40
robot# show ip route table 3000
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route

S>* 4.5.6.7/32 [1/0] via 192.168.209.44, enp0s9, 00:00:55
  *                  via 192.168.209.45, enp0s9, 00:00:55
robot#

Fixes: #2954
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

