### PR TITLE
Kernel is a mernel

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -901,8 +901,8 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (ifa->ifa_family != AF_INET && ifa->ifa_family != AF_INET6) {
 		flog_warn(
 			EC_ZEBRA_UNKNOWN_FAMILY,
-			"Invalid address family: %u received from kernel interface addr change: %u",
-			ifa->ifa_family, h->nlmsg_type);
+			"Invalid address family: %u received from kernel interface addr change: %s",
+			ifa->ifa_family, nl_msg_type_to_str(h->nlmsg_type));
 		return 0;
 	}
 
@@ -1006,8 +1006,9 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (ifa->ifa_family == AF_INET) {
 		if (ifa->ifa_prefixlen > IPV4_MAX_BITLEN) {
 			zlog_err(
-				"Invalid prefix length: %u received from kernel interface addr change: %u",
-				ifa->ifa_prefixlen, h->nlmsg_type);
+				"Invalid prefix length: %u received from kernel interface addr change: %s",
+				ifa->ifa_prefixlen,
+				nl_msg_type_to_str(h->nlmsg_type));
 			return -1;
 		}
 		if (h->nlmsg_type == RTM_NEWADDR)
@@ -1022,8 +1023,9 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (ifa->ifa_family == AF_INET6) {
 		if (ifa->ifa_prefixlen > IPV6_MAX_BITLEN) {
 			zlog_err(
-				"Invalid prefix length: %u received from kernel interface addr change: %u",
-				ifa->ifa_prefixlen, h->nlmsg_type);
+				"Invalid prefix length: %u received from kernel interface addr change: %s",
+				ifa->ifa_prefixlen,
+				nl_msg_type_to_str(h->nlmsg_type));
 			return -1;
 		}
 		if (h->nlmsg_type == RTM_NEWADDR) {
@@ -1073,8 +1075,8 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	/* assume if not default zns, then new VRF */
 	if (!(h->nlmsg_type == RTM_NEWLINK || h->nlmsg_type == RTM_DELLINK)) {
 		/* If this is not link add/delete message so print warning. */
-		zlog_debug("netlink_link_change: wrong kernel message %d",
-			   h->nlmsg_type);
+		zlog_debug("netlink_link_change: wrong kernel message %s",
+			   nl_msg_type_to_str(h->nlmsg_type));
 		return 0;
 	}
 
@@ -1082,8 +1084,8 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	      || ifi->ifi_family == AF_INET6)) {
 		flog_warn(
 			EC_ZEBRA_UNKNOWN_FAMILY,
-			"Invalid address family: %u received from kernel link change: %u",
-			ifi->ifi_family, h->nlmsg_type);
+			"Invalid address family: %u received from kernel link change: %s",
+			ifi->ifi_family, nl_msg_type_to_str(h->nlmsg_type));
 		return 0;
 	}
 

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -641,8 +641,9 @@ static void netlink_parse_extended_ack(struct nlmsghdr *h)
 			 * but noticing it for later.
 			 */
 			err_nlh = &err->msg;
-			zlog_debug("%s: Received %d extended Ack",
-				   __PRETTY_FUNCTION__, err_nlh->nlmsg_type);
+			zlog_debug("%s: Received %s extended Ack",
+				   __PRETTY_FUNCTION__,
+				   nl_msg_type_to_str(err_nlh->nlmsg_type));
 		}
 	}
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -833,7 +833,9 @@ int netlink_route_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return 0;
 	}
 
-	if (!(rtm->rtm_family == AF_INET || rtm->rtm_family == AF_INET6)) {
+	if (!(rtm->rtm_family == AF_INET ||
+	      rtm->rtm_family == AF_INET6 ||
+	      rtm->rtm_family == RTNL_FAMILY_IPMR )) {
 		flog_warn(
 			EC_ZEBRA_UNKNOWN_FAMILY,
 			"Invalid address family: %u received from kernel route change: %s",

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -828,15 +828,16 @@ int netlink_route_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 	if (!(h->nlmsg_type == RTM_NEWROUTE || h->nlmsg_type == RTM_DELROUTE)) {
 		/* If this is not route add/delete message print warning. */
-		zlog_debug("Kernel message: %d NS %u\n", h->nlmsg_type, ns_id);
+		zlog_debug("Kernel message: %s NS %u\n",
+			   nl_msg_type_to_str(h->nlmsg_type), ns_id);
 		return 0;
 	}
 
 	if (!(rtm->rtm_family == AF_INET || rtm->rtm_family == AF_INET6)) {
 		flog_warn(
 			EC_ZEBRA_UNKNOWN_FAMILY,
-			"Invalid address family: %u received from kernel route change: %u",
-			rtm->rtm_family, h->nlmsg_type);
+			"Invalid address family: %u received from kernel route change: %s",
+			rtm->rtm_family, nl_msg_type_to_str(h->nlmsg_type));
 		return 0;
 	}
 
@@ -2487,8 +2488,8 @@ int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id)
 	else {
 		flog_warn(
 			EC_ZEBRA_UNKNOWN_FAMILY,
-			"Invalid address family: %u received from kernel neighbor change: %u",
-			ndm->ndm_family, h->nlmsg_type);
+			"Invalid address family: %u received from kernel neighbor change: %s",
+			ndm->ndm_family, nl_msg_type_to_str(h->nlmsg_type));
 		return 0;
 	}
 


### PR DESCRIPTION
Poking around today I noticed that a newer linux kernel than I've used in a long time was sending up data to zebra about mroutes coming in.  The correct thing to do here is to notice the pim mroute and do nothing with it( at this time ) as that there is insufficient information to even do anything with this data!  So notice the data in a manner that won't cause the error messages to the log.  The correct place to do this is via the pim kernel socket.

Additionally find some places in the code where we were printing out netlink message type #'s and print out a useful string instead.

