### PR TITLE
bgpd: Update message received by router is sent back to originator

### DIFF
--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -63,6 +63,9 @@ struct bgp_advertise {
 
 	/* BGP info.  */
 	struct bgp_info *binfo;
+
+	/* Advertising peer */
+	struct peer *peer;
 };
 
 /* BGP adjacency out.  */

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -455,7 +455,8 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 			 * packet with appropriate attributes from peer
 			 * and advance peer */
 			s = bpacket_reformat_for_peer(next_pkt, paf);
-			bgp_packet_add(peer, s);
+			if (s)
+				bgp_packet_add(peer, s);
 			bpacket_queue_advance_peer(paf);
 		}
 	} while (s && (++generated < wpq));

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -445,7 +445,8 @@ extern void route_vty_out_overlay(struct vty *vty, struct prefix *p,
 extern int subgroup_process_announce_selected(struct update_subgroup *subgrp,
 					      struct bgp_info *selected,
 					      struct bgp_node *rn,
-					      uint32_t addpath_tx_id);
+					      uint32_t addpath_tx_id,
+					      struct peer *from);
 
 extern int subgroup_announce_check(struct bgp_node *rn, struct bgp_info *ri,
 				   struct update_subgroup *subgrp,

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -88,6 +88,10 @@ typedef struct {
 #define BPKT_ATTRVEC_FLAGS_RMAP_IPV4_NH_CHANGED   (1 << 4)
 #define BPKT_ATTRVEC_FLAGS_RMAP_IPV6_GNH_CHANGED  (1 << 5)
 #define BPKT_ATTRVEC_FLAGS_RMAP_IPV6_LNH_CHANGED  (1 << 6)
+#define BPKT_ATTRVEC_FLAGS_ADDED_NUM_ROUTES	(1 << 7)
+
+#define BPKT_TYPE_UPDATE   1
+#define BPKT_TYPE_WITHDRAW 2
 
 typedef struct bpacket_attr_vec_arr {
 	bpacket_attr_vec entries[BGP_ATTR_VEC_MAX];
@@ -104,6 +108,7 @@ struct bpacket {
 	bpacket_attr_vec_arr arr;
 
 	unsigned int ver;
+	uint8_t type;
 };
 
 struct bpacket_queue {
@@ -303,7 +308,7 @@ struct updwalk_context {
 	updgrp_walkcb cb;
 	void *context;
 	uint8_t flags;
-
+	struct peer *peer;
 #define UPDWALK_FLAGS_ADVQUEUE   (1 << 0)
 #define UPDWALK_FLAGS_ADVERTISED (1 << 1)
 };
@@ -442,7 +447,8 @@ extern void subgroup_announce_all(struct update_subgroup *subgrp);
 extern void subgroup_default_originate(struct update_subgroup *subgrp,
 				       int withdraw);
 extern void group_announce_route(struct bgp *bgp, afi_t afi, safi_t safi,
-				 struct bgp_node *rn, struct bgp_info *ri);
+				 struct bgp_node *rn, struct bgp_info *ri,
+				 struct bgp_info *old_ri);
 extern void subgroup_clear_table(struct update_subgroup *subgrp);
 extern void update_group_announce(struct bgp *bgp);
 extern void update_group_announce_rrclients(struct bgp *bgp);
@@ -457,8 +463,9 @@ extern void bgp_adj_out_set_subgroup(struct bgp_node *rn,
 				     struct update_subgroup *subgrp,
 				     struct attr *attr, struct bgp_info *binfo);
 extern void bgp_adj_out_unset_subgroup(struct bgp_node *rn,
-				       struct update_subgroup *subgrp,
-				       char withdraw, uint32_t addpath_tx_id);
+					struct update_subgroup *subgrp,
+					char withdraw, uint32_t addpath_tx_id,
+					struct peer *peer);
 void subgroup_announce_table(struct update_subgroup *subgrp,
 			     struct bgp_table *table);
 extern void subgroup_trigger_write(struct update_subgroup *subgrp);


### PR DESCRIPTION
* The issue is that when processing bgp advertisements in
  subgroup_update_packet() and subgroup_withdraw_packet() the peer from
  which route is learnt is not known and update msg is sent to all
  peers in the update group
* The command neighbor <addr> solo" configures single peer in the
  update group which can help resolve the issue but it will not scale
  for large number of peers
* The code changes encode peer information in the buffer allocate in
  subgroup_update_packet() and subgroup_withdraw_packet(). The peer information
  is used to determine if the route to be advertised to a peer is already learnt
  from the same peer router. This is removed in bpacket_reformat_for_peer() when
  sending packet to peer router

Signed-off-by: kssoman <somanks@vmware.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
