### PR TITLE
pimd: Actually create vif's in non-integrated config

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5694,7 +5694,8 @@ static int pim_cmd_igmp_start(struct vty *vty, struct interface *ifp)
 	pim_ifp = ifp->info;
 
 	if (!pim_ifp) {
-		pim_ifp = pim_if_new(ifp, 1 /* igmp=true */, 0 /* pim=false */);
+		pim_ifp = pim_if_new(ifp, 1 /* igmp=true */, 0 /* pim=false */,
+				     false);
 		if (!pim_ifp) {
 			vty_out(vty, "Could not enable IGMP on interface %s\n",
 				ifp->name);
@@ -6305,7 +6306,8 @@ static int pim_cmd_interface_add(struct interface *ifp)
 	struct pim_interface *pim_ifp = ifp->info;
 
 	if (!pim_ifp) {
-		pim_ifp = pim_if_new(ifp, 0 /* igmp=false */, 1 /* pim=true */);
+		pim_ifp = pim_if_new(ifp, 0 /* igmp=false */, 1 /* pim=true */,
+				     false);
 		if (!pim_ifp) {
 			return 0;
 		}

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -154,7 +154,8 @@ struct pim_interface {
 void pim_if_init(struct pim_instance *pim);
 void pim_if_terminate(struct pim_instance *pim);
 
-struct pim_interface *pim_if_new(struct interface *ifp, int igmp, int pim);
+struct pim_interface *pim_if_new(struct interface *ifp, int igmp, int pim,
+				 bool ispimreg);
 void pim_if_delete(struct interface *ifp);
 void pim_if_addr_add(struct connected *ifc);
 void pim_if_addr_del(struct connected *ifc, int force_prim_as_any);
@@ -163,7 +164,7 @@ void pim_if_addr_del_all(struct interface *ifp);
 void pim_if_addr_del_all_igmp(struct interface *ifp);
 void pim_if_addr_del_all_pim(struct interface *ifp);
 
-int pim_if_add_vif(struct interface *ifp);
+int pim_if_add_vif(struct interface *ifp, bool ispimreg);
 int pim_if_del_vif(struct interface *ifp);
 void pim_if_add_vif_all(struct pim_instance *pim);
 void pim_if_del_vif_all(struct pim_instance *pim);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -99,7 +99,7 @@ static int pim_zebra_if_add(int command, struct zclient *zclient,
 		struct pim_interface *pim_ifp;
 
 		if (!ifp->info) {
-			pim_ifp = pim_if_new(ifp, 0, 0);
+			pim_ifp = pim_if_new(ifp, 0, 0, false);
 			ifp->info = pim_ifp;
 		}
 


### PR DESCRIPTION
The startup of a non-integrated config was not properly
allowing for startup to create the vif when we have
not learned about the interface we are trying to configure
at this point in time.  Actually notice when we are
trying to create a pimreg device or not to properly
notice when to attempt to create the vif or not.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
