### PR TITLE
zebra: Send correct default vrf tableid for MROUTE stats

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1667,6 +1667,7 @@ skip:
 
 int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 {
+	uint32_t actual_table;
 	int suc = 0;
 	struct mcast_route_data *mr = (struct mcast_route_data *)in;
 	struct {
@@ -1693,7 +1694,23 @@ int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
 	addattr_l(&req.n, sizeof(req), RTA_OIF, &mroute->ifindex, 4);
 	addattr_l(&req.n, sizeof(req), RTA_SRC, &mroute->sg.src.s_addr, 4);
 	addattr_l(&req.n, sizeof(req), RTA_DST, &mroute->sg.grp.s_addr, 4);
-	addattr_l(&req.n, sizeof(req), RTA_TABLE, &zvrf->table_id, 4);
+	/*
+	 * What?
+	 *
+	 * So during the namespace cleanup we started storing
+	 * the zvrf table_id for the default table as RT_TABLE_MAIN
+	 * which is what the normal routing table for ip routing is.
+	 * This change caused this to break our lookups of sg data
+	 * because prior to this change the zvrf->table_id was 0
+	 * and when the pim multicast kernel code saw a 0,
+	 * it was auto-translated to RT_TABLE_DEFAULT.  But since
+	 * we are now passing in RT_TABLE_MAIN there is no auto-translation
+	 * and the kernel goes screw you and the delicious cookies you
+	 * are trying to give me.  So now we have this little hack.
+	 */
+	actual_table = (zvrf->table_id == RT_TABLE_MAIN) ? RT_TABLE_DEFAULT :
+		zvrf->table_id;
+	addattr_l(&req.n, sizeof(req), RTA_TABLE, &actual_table, 4);
 
 	suc = netlink_talk(netlink_route_change_read_multicast, &req.n,
 			   &zns->netlink_cmd, zns, 0);


### PR DESCRIPTION
So the linux kernel uses the RT_TABLE_MAIN for the table
id used for ip routing.  The multicast routing tables use
RT_TABLE_DEFAULT.  We changed the internal code of zebra_vrf
a few months back to use RT_TABLE_MAIN as the tableid to
use.  This caused the pim sg stats to stop working because
of the kernel bug where it uses a different table
for ip routing and ip multicast.

Put a bit of a special case in to do the right thing.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
