### PR TITLE
isisd: null check (Coverity 1473285)

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1905,7 +1905,7 @@ int lsp_tick(struct thread *thread)
 							 dnode);
 				}
 
-				if (fabricd_init_c) {
+				if (fabricd_init_c && lsp) {
 					fabricd_sync_incomplete |=
 						ISIS_CHECK_FLAG(lsp->SSNflags,
 								fabricd_init_c);


### PR DESCRIPTION
### Summary

Null pointer check. Coverity issue 1473285.

### Components

isisd
