### PR TITLE
bgpd: null check (Coverity 1472965 1472966)

### DIFF
--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1882,14 +1882,14 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 	}
 
 	/* ipset create */
-	if (bpm && !bpm->installed)
+	if (!bpm->installed)
 		bgp_send_pbr_ipset_match(bpm, true);
 	/* ipset add */
-	if (bpme && !bpme->installed)
+	if (!bpme->installed)
 		bgp_send_pbr_ipset_entry_match(bpme, true);
 
 	/* iptables */
-	if (bpm && !bpm->installed_in_iptable)
+	if (!bpm->installed_in_iptable)
 		bgp_send_pbr_iptable(bpa, bpm, true);
 
 	/* A previous entry may already exist


### PR DESCRIPTION
### Summary

There were checks for null pointer after being dereferenced. Checks have been removed (we've discussed the no need of adding assert()'s because of similar code not requiring them). Coverity issues: 1472965, 1472966.

### Components

bgpd
