### PR TITLE
tools: null check (Coverity 1399484)

### DIFF
--- a/tools/permutations.c
+++ b/tools/permutations.c
@@ -39,7 +39,8 @@ int main(int argc, char *argv[])
 		fprintf(stdout, USAGE "\n");
 		exit(EXIT_SUCCESS);
 	}
-	struct cmd_element *cmd = calloc(1, sizeof(struct cmd_element));
+	struct cmd_element *cmd = XCALLOC(MTYPE_TMP,
+					  sizeof(struct cmd_element));
 	cmd->string = strdup(argv[1]);
 
 	struct graph *graph = graph_new();


### PR DESCRIPTION
### Summary

Fixed using XCALLOC(MTYPE_TMP, ...) instead of calloc(...) because of the error handling (XCALLOC checks + log + abort through memory_oom()). It comes from Coverity issue 1399484.

### Components

tools
