### PR TITLE
zebra: redeclaration fix (SA)

### DIFF
--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -187,7 +187,6 @@ extern enum dp_req_result kernel_del_pbr_rule(struct zebra_pbr_rule *rule);
  */
 extern void kernel_read_pbr_rules(struct zebra_ns *zns);
 
-enum dp_results;
 /*
  * Handle success or failure of rule (un)install in the kernel.
  */


### PR DESCRIPTION
### Summary

Unnecesary redeclaration of already-defined enum 'dp_results' removed.

Can be detected via static analysis with e.g.

	./configure CFLAGS=-Wgnu-redeclared-enum CC=clang

### Related Issue

zebra