### PR TITLE
lib: redundant parentheses (SA)

### DIFF
--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -201,7 +201,7 @@ extern int vrf_bitmap_check(vrf_bitmap_t, vrf_id_t);
  */
 extern void vrf_init(int (*create)(struct vrf *vrf), int (*enable)(struct vrf *vrf),
 		     int (*disable)(struct vrf *vrf), int (*delete)(struct vrf *vrf),
-		     int ((*update)(struct vrf *vrf)));
+		     int (*update)(struct vrf *vrf));
 
 /*
  * Call vrf_terminate when the protocol is being shutdown


### PR DESCRIPTION
### Summary

Redundant parentheses surrounding declarator removed.

Can be detected via static analysis with e.g.

	./configure CFLAGS=-Wredundant-parens CC=clang

### Components

lib
