### PR TITLE
watchfrr: Modify some stderr messages to zlog_warn

### DIFF
--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -1217,12 +1217,13 @@ int main(int argc, char **argv)
 		}
 	}
 	if (!gs.daemons) {
-		fputs("Must specify one or more daemons to monitor.\n", stderr);
+		flog_err(EC_WATCHFRR_UNEXPECTED_DAEMONS,
+			  "Must specify one or more daemons to monitor.");
 		frr_help_exit(1);
 	}
 	if (!watch_only && !gs.special) {
-		fprintf(stderr, "\"%s\" daemon must be in daemon list\n",
-			special);
+		flog_err(EC_WATCHFRR_UNEXPECTED_DAEMONS,
+			  "\"%s\" daemon must be in daemon lists", special);
 		frr_help_exit(1);
 	}
 

--- a/watchfrr/watchfrr_errors.c
+++ b/watchfrr/watchfrr_errors.c
@@ -32,6 +32,12 @@ static struct log_ref ferr_watchfrr_err[] = {
 		.suggestion = "Ensure that FRR is still running and if not please open an Issue"
 	},
 	{
+		.code = EC_WATCHFRR_UNEXPECTED_DAEMONS,
+		.title = "WATCHFRR wrong daemons to watch",
+		.description = "As part of WATCHFRR startup you must specify 1 or more daemons to monitor",
+		.suggestion = "Update your startup scripts to include zebra and any other daemon you would like to monitor",
+	},
+	{
 		.code = END_FERR,
 	}
 };

--- a/watchfrr/watchfrr_errors.h
+++ b/watchfrr/watchfrr_errors.h
@@ -25,6 +25,7 @@
 
 enum watchfrr_log_refs {
 	EC_WATCHFRR_CONNECTION = WATCHFRR_FERR_START,
+	EC_WATCHFRR_UNEXPECTED_DAEMONS,
 };
 
 extern void watchfrr_error_init(void);


### PR DESCRIPTION
The stderr output is not being displayed as part of watchfrr invocation
in system startup.  Specifically if the user has not properly sent
1 or more daemons to monitor.  If the end-user is using tools/frr
this stderr is dropped( and systemd appears to drop stderr too? )

Modify the two stderr calls in this situation and use the zlog system.
Now I can clearly see an error message that tells me what has gone wrong.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

