### PR TITLE
Pim fixes

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1187,8 +1187,9 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 			vty_out(vty, "Designated Router\n");
 			vty_out(vty, "-----------------\n");
 			vty_out(vty, "Address   : %s\n", dr_str);
-			vty_out(vty, "Priority  : %d\n",
-				pim_ifp->pim_dr_priority);
+			vty_out(vty, "Priority  : %d(%d)\n",
+				pim_ifp->pim_dr_priority,
+				pim_ifp->pim_dr_num_nondrpri_neighbors);
 			vty_out(vty, "Uptime    : %s\n", dr_uptime);
 			vty_out(vty, "Elections : %d\n",
 				pim_ifp->pim_dr_election_count);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -1044,9 +1044,14 @@ void igmp_source_forward_start(struct pim_instance *pim,
 		return;
 	}
 
-	if (!(PIM_I_am_DR(pim_oif)))
+	if (!(PIM_I_am_DR(pim_oif))) {
+		if (PIM_DEBUG_IGMP_TRACE)
+			zlog_debug("%s: %s was received on %s interface but we are not DR for that interface",
+				   __PRETTY_FUNCTION__,
+				   pim_str_sg_dump(&sg),
+				   group->group_igmp_sock->interface->name);
 		return;
-
+	}
 	/*
 	  Feed IGMPv3-gathered local membership information into PIM
 	  per-interface (S,G) state.


### PR DESCRIPTION
1) Add some extra output to `show ip pim int X detail` to give us a bit of a hint when drpriority is being used on an interface
2) Add some extra debug to allow us to figure out why state was not created when we do not create it due to not being the DR.
3) Blackhole traffic when we are not DR for new stream received