### PR TITLE
Bgp nexthop address

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -169,6 +169,28 @@ void bgp_tip_del(struct bgp *bgp, struct in_addr *tip)
 	}
 }
 
+/* BGP own address structure */
+struct bgp_addr {
+	struct in_addr addr;
+	int refcnt;
+};
+
+static void show_address_entry(struct hash_backet *backet, void *args)
+{
+	struct vty *vty = (struct vty *)args;
+	struct bgp_addr *addr = (struct bgp_addr *)backet->data;
+
+	vty_out(vty, "addr: %s, count: %d\n", inet_ntoa(addr->addr),
+		addr->refcnt);
+}
+
+void bgp_nexthop_show_address_hash(struct vty *vty, struct bgp *bgp)
+{
+	hash_iterate(bgp->address_hash,
+		     (void (*)(struct hash_backet *, void *))show_address_entry,
+		     vty);
+}
+
 static void *bgp_address_hash_alloc(void *p)
 {
 	const struct in_addr *val = (const struct in_addr *)p;

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -68,12 +68,6 @@ struct bgp_nexthop_cache {
 	struct bgp *bgp;
 };
 
-/* BGP own address structure */
-struct bgp_addr {
-	struct in_addr addr;
-	int refcnt;
-};
-
 /* Own tunnel-ip address structure */
 struct tip_addr {
 	struct in_addr addr;
@@ -103,4 +97,5 @@ extern void bgp_tip_del(struct bgp *bgp, struct in_addr *tip);
 extern void bgp_tip_hash_init(struct bgp *bgp);
 extern void bgp_tip_hash_destroy(struct bgp *bgp);
 
+extern void bgp_nexthop_show_address_hash(struct vty *vty, struct bgp *bgp);
 #endif /* _QUAGGA_BGP_NEXTHOP_H */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7451,14 +7451,6 @@ DEFUN (show_bgp_vrfs,
 	return CMD_SUCCESS;
 }
 
-static void show_address_entry(struct hash_backet *backet, void *args)
-{
-	struct vty *vty = (struct vty *)args;
-	struct bgp_addr *addr = (struct bgp_addr *)backet->data;
-
-	vty_out(vty, "addr: %s, count: %d\n", inet_ntoa(addr->addr),
-		addr->refcnt);
-}
 
 static void show_tip_entry(struct hash_backet *backet, void *args)
 {
@@ -7472,9 +7464,7 @@ static void show_tip_entry(struct hash_backet *backet, void *args)
 static void bgp_show_martian_nexthops(struct vty *vty, struct bgp *bgp)
 {
 	vty_out(vty, "self nexthop database:\n");
-	hash_iterate(bgp->address_hash,
-		     (void (*)(struct hash_backet *, void *))show_address_entry,
-		     vty);
+	bgp_nexthop_show_address_hash(vty, bgp);
 
 	vty_out(vty, "Tunnel-ip database:\n");
 	hash_iterate(bgp->tip_hash,


### PR DESCRIPTION
The martian addresses that we were tracking in bgp were being stored just by the address w/ a ref count.  There exists call paths where we would get a call back multiple times to add but one time to delete( I'm looking at you bonds).  Modify the martian address code to still just hash on the address but to keep a list of interfaces that act as the ref count.  Also just keep the name of the interface and update the output to display actual list of interfaces we think we are tracking.  This might tell us when the figmentary poop hits the real fan.