### PR TITLE
lib: Allow useful display of default vrf name

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -656,7 +656,8 @@ DEFUN_NOSH (interface,
 	int idx_ifname = 1;
 	int idx_vrf = 3;
 	const char *ifname = argv[idx_ifname]->arg;
-	const char *vrfname = (argc > 2) ? argv[idx_vrf]->arg : NULL;
+	const char *vrfname =
+		(argc > 2) ? argv[idx_vrf]->arg : VRF_DEFAULT_NAME;
 
 	struct interface *ifp;
 	vrf_id_t vrf_id = VRF_DEFAULT;
@@ -681,7 +682,8 @@ DEFUN_NOSH (interface,
 #endif /* SUNOS_5 */
 
 	if (!ifp) {
-		vty_out(vty, "%% interface %s not in %s\n", ifname, vrfname);
+		vty_out(vty, "%% interface %s not in %s vrf\n", ifname,
+			vrfname);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 	VTY_PUSH_CONTEXT(INTERFACE_NODE, ifp);


### PR DESCRIPTION
When entering a interface name and you fat-finger it
actually display some useful information about the vrf
we are in.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
