### PR TITLE
eigrpd: Fix eigrp crash on shut of a interface

### DIFF
--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -183,9 +183,7 @@ int eigrp_if_up(struct eigrp_interface *ei)
 
 	struct prefix dest_addr;
 
-	dest_addr.family = AF_INET;
-	dest_addr.u.prefix4 = ei->connected->address->u.prefix4;
-	dest_addr.prefixlen = ei->connected->address->prefixlen;
+	dest_addr = *ei->address;
 	apply_mask(&dest_addr);
 	pe = eigrp_topology_table_lookup_ipv4(eigrp->topology_table,
 					      &dest_addr);
@@ -344,7 +342,7 @@ void eigrp_if_free(struct eigrp_interface *ei, int source)
 		eigrp_hello_send(ei, EIGRP_HELLO_GRACEFUL_SHUTDOWN, NULL);
 	}
 
-	dest_addr = *ei->connected->address;
+	dest_addr = *ei->address;
 	apply_mask(&dest_addr);
 	pe = eigrp_topology_table_lookup_ipv4(eigrp->topology_table,
 					      &dest_addr);

--- a/eigrpd/eigrp_structs.h
+++ b/eigrpd/eigrp_structs.h
@@ -178,7 +178,6 @@ struct eigrp_interface {
 	uint8_t type;
 
 	struct prefix *address;      /* Interface prefix */
-	struct connected *connected; /* Pointer to connected */
 
 	/* Neighbor information. */
 	struct list *nbrs; /* EIGRP Neighbor List */


### PR DESCRIPTION
The eigrp interface structure was storing a pointer to the
connected interface structure and on shutdown of an interface
this would cause zebra to call eigrp back with a shutdown of
that interface, as part of that operation the connected interface
structure is being deleted, but eigrp was keeping a pointer to
the connected structure.  At the same time we were keeping the address
of the connected structure and this is all we need, so keep a copy
of that data and use that instead.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
