### PR TITLE
Pid cleanup

### DIFF
--- a/lib/pid_output.c
+++ b/lib/pid_output.c
@@ -60,7 +60,7 @@ pid_t pid_output(const char *path)
 
 		if (fcntl(fd, F_SETLK, &lock) < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
-				     "Could not lock pid_file %s (%s), exiting",
+				     "Could not lock pid_file %s (%s), exiting.  Please ensure that the daemon is not already running",
 				     path, safe_strerror(errno));
 			exit(1);
 		}


### PR DESCRIPTION
Revert the guard file because it does nothing for the 'normal case' and add the extra bit of code to the error message to clue the user in as to what is going wrong.