### PR TITLE
pimd: Why was pim including zebra headers?

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -19,8 +19,6 @@
 
 #include <zebra.h>
 
-#include "zebra/rib.h"
-
 #include "log.h"
 #include "zclient.h"
 #include "memory.h"

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -19,8 +19,6 @@
 
 #include <zebra.h>
 
-#include "zebra/rib.h"
-
 #include "if.h"
 #include "log.h"
 #include "prefix.h"

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -18,7 +18,6 @@
  */
 
 #include <zebra.h>
-#include "zebra/rib.h"
 
 #include "log.h"
 #include "prefix.h"


### PR DESCRIPTION
Remove the inclusion of zebra headers from pim.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

