### PR TITLE
eigrpd: Fix memory leaks and remove dead/unused functions

### DIFF
--- a/eigrpd/eigrp_topology.h
+++ b/eigrpd/eigrp_topology.h
@@ -38,7 +38,6 @@ extern void eigrp_topology_init(struct route_table *table);
 extern struct eigrp_prefix_entry *eigrp_prefix_entry_new(void);
 extern struct eigrp_nexthop_entry *eigrp_nexthop_entry_new(void);
 extern void eigrp_topology_free(struct route_table *table);
-extern void eigrp_topology_cleanup(struct route_table *table);
 extern void eigrp_prefix_entry_add(struct route_table *table,
 				   struct eigrp_prefix_entry *pe);
 extern void eigrp_nexthop_entry_add(struct eigrp_prefix_entry *,
@@ -48,7 +47,6 @@ extern void eigrp_prefix_entry_delete(struct route_table *table,
 extern void eigrp_nexthop_entry_delete(struct eigrp_prefix_entry *,
 				       struct eigrp_nexthop_entry *);
 extern void eigrp_topology_delete_all(struct route_table *table);
-extern unsigned int eigrp_topology_table_isempty(struct list *);
 extern struct eigrp_prefix_entry *
 eigrp_topology_table_lookup_ipv4(struct route_table *table, struct prefix *p);
 extern struct list *eigrp_topology_get_successor(struct eigrp_prefix_entry *);

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -62,9 +62,7 @@ static struct eigrp_master eigrp_master;
 
 struct eigrp_master *eigrp_om;
 
-static void eigrp_delete(struct eigrp *);
 static struct eigrp *eigrp_new(const char *);
-static void eigrp_add(struct eigrp *);
 
 extern struct zclient *zclient;
 extern struct in_addr router_id_zebra;
@@ -203,16 +201,6 @@ static struct eigrp *eigrp_new(const char *AS)
 	return eigrp;
 }
 
-static void eigrp_add(struct eigrp *eigrp)
-{
-	listnode_add(eigrp_om->eigrp, eigrp);
-}
-
-static void eigrp_delete(struct eigrp *eigrp)
-{
-	listnode_delete(eigrp_om->eigrp, eigrp);
-}
-
 struct eigrp *eigrp_get(const char *AS)
 {
 	struct eigrp *eigrp;
@@ -220,7 +208,7 @@ struct eigrp *eigrp_get(const char *AS)
 	eigrp = eigrp_lookup();
 	if (eigrp == NULL) {
 		eigrp = eigrp_new(AS);
-		eigrp_add(eigrp);
+		listnode_add(eigrp_om->eigrp, eigrp);
 	}
 
 	return eigrp;
@@ -281,7 +269,6 @@ void eigrp_finish_final(struct eigrp *eigrp)
 	list_delete_and_null(&eigrp->eiflist);
 	list_delete_and_null(&eigrp->oi_write_q);
 
-	eigrp_topology_cleanup(eigrp->topology_table);
 	eigrp_topology_free(eigrp->topology_table);
 
 	eigrp_nbr_delete(eigrp->neighbor_self);
@@ -289,8 +276,9 @@ void eigrp_finish_final(struct eigrp *eigrp)
 	list_delete_and_null(&eigrp->topology_changes_externalIPV4);
 	list_delete_and_null(&eigrp->topology_changes_internalIPV4);
 
-	eigrp_delete(eigrp);
+	listnode_delete(eigrp_om->eigrp, eigrp);
 
+	stream_free(eigrp->ibuf);
 	XFREE(MTYPE_EIGRP_TOP, eigrp);
 }
 


### PR DESCRIPTION
During shutdown we were not properly cleaning up some memory
as reported by valgrind.  Additionally during cleanup operations
I noticed that there were some dead/unused functions remove/reduce.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
