### PR TITLE
bgpd: Fix for large AS paths which are split into segments (6.0 branch)

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -899,7 +899,7 @@ size_t aspath_put(struct stream *s, struct aspath *as, int use32bit)
 			while ((seg->length - written) > AS_SEGMENT_MAX) {
 				assegment_header_put(s, seg->type,
 						     AS_SEGMENT_MAX);
-				assegment_data_put(s, seg->as, AS_SEGMENT_MAX,
+				assegment_data_put(s, (seg->as + written), AS_SEGMENT_MAX,
 						   use32bit);
 				written += AS_SEGMENT_MAX;
 				bytes += ASSEGMENT_SIZE(AS_SEGMENT_MAX,


### PR DESCRIPTION
Same as PR #2992 for 6.0 branch

Summary

Fix for large AS paths as provided by a 3rd party "with a large number of as path, wrong as paths were written"
Components

bgpd

Signed-off-by: Martin Winter mwinter@opensourcerouting.org