### PR TITLE
bgpd, lib, zebra: Wrapper get/set of table->info pointer

### DIFF
--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -101,7 +101,7 @@ struct bgp_table *bgp_table_init(struct bgp *bgp, afi_t afi, safi_t safi)
 	/*
 	 * Set up back pointer to bgp_table.
 	 */
-	rt->route_table->info = rt;
+	route_table_set_info(rt->route_table, rt);
 
 	/*
 	 * pointer to bgp instance allows working back from bgp_info to bgp

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -112,7 +112,7 @@ static inline struct route_node *bgp_node_to_rnode(struct bgp_node *node)
  */
 static inline struct bgp_table *bgp_node_table(struct bgp_node *node)
 {
-	return bgp_node_to_rnode(node)->table->info;
+	return route_table_get_info(bgp_node_to_rnode(node)->table);
 }
 
 /*

--- a/lib/agg_table.c
+++ b/lib/agg_table.c
@@ -53,7 +53,7 @@ struct agg_table *agg_table_init(void)
 	at = XCALLOC(MTYPE_TMP, sizeof(struct agg_table));
 
 	at->route_table = route_table_init_with_delegate(&agg_table_delegate);
-	at->route_table->info = at;
+	route_table_set_info(at->route_table, at);
 
 	return at;
 }

--- a/lib/agg_table.h
+++ b/lib/agg_table.h
@@ -148,6 +148,6 @@ static inline struct agg_node *agg_route_table_top(struct agg_node *node)
 
 static inline struct agg_table *agg_get_table(struct agg_node *node)
 {
-	return (struct agg_table *)node->table->info;
+	return (struct agg_table *)route_table_get_info(node->table);
 }
 #endif

--- a/lib/srcdest_table.c
+++ b/lib/srcdest_table.c
@@ -103,7 +103,7 @@ static void srcdest_srcnode_destroy(route_table_delegate_t *delegate,
 
 	XFREE(MTYPE_ROUTE_SRC_NODE, rn);
 
-	srn = table->info;
+	srn = route_table_get_info(table);
 	if (srn->src_table && route_table_count(srn->src_table) == 0) {
 		/* deleting the route_table from inside destroy_node is ONLY
 		 * permitted IF table->count is 0!  see lib/table.c
@@ -140,7 +140,7 @@ static struct route_node *srcdest_srcnode_get(struct route_node *rn,
 		 * here */
 		srn->src_table = route_table_init_with_delegate(
 			&_srcdest_srcnode_delegate);
-		srn->src_table->info = srn;
+		route_table_set_info(srn->src_table, srn);
 
 		/* there is no route_unlock_node on the original rn here.
 		 * The reference is kept for the src_table. */
@@ -220,7 +220,7 @@ struct route_node *srcdest_route_next(struct route_node *rn)
 	}
 
 	/* This part handles the case of iterating source nodes. */
-	parent = route_lock_node(rn->table->info);
+	parent = route_lock_node(route_table_get_info(rn->table));
 	next = route_next(rn);
 
 	if (next) {
@@ -268,7 +268,7 @@ void srcdest_rnode_prefixes(struct route_node *rn, const struct prefix **p,
 			    const struct prefix **src_p)
 {
 	if (rnode_is_srcnode(rn)) {
-		struct route_node *dst_rn = rn->table->info;
+		struct route_node *dst_rn = route_table_get_info(rn->table);
 		if (p)
 			*p = &dst_rn->p;
 		if (src_p)

--- a/lib/srcdest_table.h
+++ b/lib/srcdest_table.h
@@ -84,7 +84,7 @@ static inline int rnode_is_srcnode(struct route_node *rn)
 static inline struct route_table *srcdest_rnode_table(struct route_node *rn)
 {
 	if (rnode_is_srcnode(rn)) {
-		struct route_node *dst_rn = rn->table->info;
+		struct route_node *dst_rn = route_table_get_info(rn->table);
 		return dst_rn->table;
 	} else {
 		return rn->table;
@@ -92,7 +92,7 @@ static inline struct route_table *srcdest_rnode_table(struct route_node *rn)
 }
 static inline void *srcdest_rnode_table_info(struct route_node *rn)
 {
-	return srcdest_rnode_table(rn)->info;
+	return route_table_get_info(srcdest_rnode_table(rn));
 }
 
 #endif /* _ZEBRA_SRC_DEST_TABLE_H */

--- a/lib/table.h
+++ b/lib/table.h
@@ -179,6 +179,16 @@ route_table_init_with_delegate(route_table_delegate_t *delegate);
 
 extern route_table_delegate_t *route_table_get_default_delegate(void);
 
+static inline void *route_table_get_info(struct route_table *table)
+{
+	return table->info;
+}
+
+static inline void route_table_set_info(struct route_table *table, void *d)
+{
+	table->info = d;
+}
+
 extern void route_table_finish(struct route_table *table);
 extern struct route_node *route_top(struct route_table *table);
 extern struct route_node *route_next(struct route_node *node);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -355,7 +355,7 @@ extern uint8_t route_distance(int type);
  */
 static inline rib_table_info_t *rib_table_info(struct route_table *table)
 {
-	return (rib_table_info_t *)table->info;
+	return (rib_table_info_t *)route_table_get_info(table);
 }
 
 /*

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -249,7 +249,7 @@ struct route_table *zebra_ns_get_table(struct zebra_ns *zns,
 	info->zvrf = zvrf;
 	info->afi = afi;
 	info->safi = SAFI_UNICAST;
-	znst->table->info = info;
+	route_table_set_info(znst->table, info);
 	znst->table->cleanup = zebra_rtable_node_cleanup;
 
 	RB_INSERT(zebra_ns_table_head, &zns->ns_tables, znst);
@@ -262,7 +262,7 @@ static void zebra_ns_free_table(struct zebra_ns_table *znst)
 
 	rib_close_table(znst->table);
 
-	table_info = znst->table->info;
+	table_info = route_table_get_info(znst->table);
 	route_table_finish(znst->table);
 	XFREE(MTYPE_RIB_TABLE_INFO, table_info);
 	XFREE(MTYPE_ZEBRA_NS, znst);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2955,7 +2955,7 @@ void rib_close_table(struct route_table *table)
 	if (!table)
 		return;
 
-	info = table->info;
+	info = route_table_get_info(table);
 
 	for (rn = route_top(table); rn; rn = srcdest_route_next(rn)) {
 		dest = rib_dest_from_rnode(rn);

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -205,7 +205,7 @@ static int zebra_vrf_disable(struct vrf *vrf)
 
 		for (safi = SAFI_UNICAST; safi <= SAFI_MULTICAST; safi++) {
 			table = zvrf->table[afi][safi];
-			table_info = table->info;
+			table_info = route_table_get_info(table);
 			route_table_finish(table);
 			XFREE(MTYPE_RIB_TABLE_INFO, table_info);
 			zvrf->table[afi][safi] = NULL;
@@ -261,7 +261,7 @@ static int zebra_vrf_delete(struct vrf *vrf)
 		for (safi = SAFI_UNICAST; safi <= SAFI_MULTICAST; safi++) {
 			table = zvrf->table[afi][safi];
 			if (table) {
-				table_info = table->info;
+				table_info = route_table_get_info(table);
 				route_table_finish(table);
 				XFREE(MTYPE_RIB_TABLE_INFO, table_info);
 			}
@@ -384,7 +384,7 @@ static void zebra_vrf_table_create(struct zebra_vrf *zvrf, afi_t afi,
 	info->zvrf = zvrf;
 	info->afi = afi;
 	info->safi = safi;
-	table->info = info;
+	route_table_set_info(table, info);
 }
 
 /* Allocate new zebra VRF. */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1358,7 +1358,7 @@ static void vty_show_ip_route_summary(struct vty *vty,
 		}
 
 	vty_out(vty, "%-20s %-20s %s  (vrf %s)\n", "Route Source", "Routes",
-		"FIB", zvrf_name(((rib_table_info_t *)table->info)->zvrf));
+		"FIB", zvrf_name(((rib_table_info_t *)route_table_get_info(table))->zvrf));
 
 	for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
 		if ((rib_cnt[i] > 0) || (i == ZEBRA_ROUTE_BGP
@@ -1434,7 +1434,7 @@ static void vty_show_ip_route_summary_prefix(struct vty *vty,
 
 	vty_out(vty, "%-20s %-20s %s  (vrf %s)\n", "Route Source",
 		"Prefix Routes", "FIB",
-		zvrf_name(((rib_table_info_t *)table->info)->zvrf));
+		zvrf_name(((rib_table_info_t *)route_table_get_info(table))->zvrf));
 
 	for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
 		if (rib_cnt[i] > 0) {


### PR DESCRIPTION
Wrapper the get/set of the table->info pointer so that
people are not directly accessing this data.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

