### PR TITLE
pimd: Fix several address sanitizer issues

### DIFF
--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -44,9 +44,9 @@ static void pim_instance_terminate(struct pim_instance *pim)
 	if (pim->static_routes)
 		list_delete_and_null(&pim->static_routes);
 
-	pim_rp_free(pim);
-
 	pim_upstream_terminate(pim);
+
+	pim_rp_free(pim);
 
 	/* Traverse and cleanup rpf_hash */
 	if (pim->rpf_hash) {

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1534,12 +1534,13 @@ unsigned int pim_upstream_hash_key(void *arg)
 
 void pim_upstream_terminate(struct pim_instance *pim)
 {
-	struct listnode *node, *nnode;
 	struct pim_upstream *up;
 
 	if (pim->upstream_list) {
-		for (ALL_LIST_ELEMENTS(pim->upstream_list, node, nnode, up))
+		while (pim->upstream_list->count) {
+			up = listnode_head(pim->upstream_list);
 			pim_upstream_del(pim, up, __PRETTY_FUNCTION__);
+		}
 
 		list_delete_and_null(&pim->upstream_list);
 	}


### PR DESCRIPTION
This commit fixes two issues during pim shutdown.

1) The rp_info structure was being freed before the
outgoing notifications that depended on it's information
was sent out as part of shutdown.

2) The pim->upstream_list shutdown involved iterating
over the list via ALL_LIST_ELEMENTS.  This typically
is enough but pim will auto delete child nodes as well
as itself when it goes away and they depend on it.  As such
the node and nnode could possibly already have been freed.
So change the way we look at all the data in the upstream_list

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
