### PR TITLE
ospfd: remove unnecessary housekeeping code when using linked lists

### DIFF
--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -438,10 +438,6 @@ void ospf_delete_opaque_functab(uint8_t lsa_type, uint8_t opaque_type)
 				/* Dequeue listnode entry from the list. */
 				listnode_delete(funclist, functab);
 
-				/* Avoid misjudgement in the next lookup. */
-				if (listcount(funclist) == 0)
-					funclist->head = funclist->tail = NULL;
-
 				XFREE(MTYPE_OSPF_OPAQUE_FUNCTAB, functab);
 				break;
 			}
@@ -2121,10 +2117,6 @@ void ospf_opaque_lsa_flush_schedule(struct ospf_lsa *lsa0)
 
 	/* Dequeue listnode entry from the list. */
 	listnode_delete(oipt->id_list, oipi);
-
-	/* Avoid misjudgement in the next lookup. */
-	if (listcount(oipt->id_list) == 0)
-		oipt->id_list->head = oipt->id_list->tail = NULL;
 
 	/* Disassociate internal control information with the given lsa. */
 	free_opaque_info_per_id((void *)oipi);

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -380,10 +380,6 @@ static void unset_pce_domain(uint16_t type, uint32_t domain,
 	if (found) {
 		listnode_delete(pce->pce_domain, old);
 
-		/* Avoid misjudgement in the next lookup. */
-		if (listcount(pce->pce_domain) == 0)
-			pce->pce_domain->head = pce->pce_domain->tail = NULL;
-
 		/* Finally free the old domain */
 		XFREE(MTYPE_OSPF_PCE_PARAMS, old);
 	}
@@ -429,11 +425,6 @@ static void unset_pce_neighbor(uint16_t type, uint32_t domain,
 	/* if found remove it */
 	if (found) {
 		listnode_delete(pce->pce_neighbor, old);
-
-		/* Avoid misjudgement in the next lookup. */
-		if (listcount(pce->pce_neighbor) == 0)
-			pce->pce_neighbor->head = pce->pce_neighbor->tail =
-				NULL;
 
 		/* Finally free the old domain */
 		XFREE(MTYPE_OSPF_PCE_PARAMS, old);

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -897,10 +897,6 @@ static int ospf_mpls_te_del_if(struct interface *ifp)
 		/* Dequeue listnode entry from the list. */
 		listnode_delete(iflist, lp);
 
-		/* Avoid misjudgement in the next lookup. */
-		if (listcount(iflist) == 0)
-			iflist->head = iflist->tail = NULL;
-
 		XFREE(MTYPE_OSPF_MPLS_TE, lp);
 	}
 


### PR DESCRIPTION
The head and tail pointers of linked lists should never be modified
manually, the linked list API guarantees that these pointers are always
valid and up-to-date.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>

### Summary
Found this by accident while reviewing another PR...

### Components
[ospfd]