### PR TITLE
ospfd: handling of OSPF_AREA_RANGE_ADVERTISE flag

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -441,6 +441,7 @@ DEFUN (area_range,
 			SET_FLAG(range->flag, OSPF6_ROUTE_DO_NOT_ADVERTISE);
 		} else if (strmatch(argv[idx_type]->text, "advertise")) {
 			UNSET_FLAG(range->flag, OSPF6_ROUTE_DO_NOT_ADVERTISE);
+			cost = range->path.u.cost_config;
 		} else {
 			cost = strtoul(argv[5]->arg, NULL, 10);
 			UNSET_FLAG(range->flag, OSPF6_ROUTE_DO_NOT_ADVERTISE);

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -196,6 +196,8 @@ int ospf_area_range_set(struct ospf *ospf, struct in_addr area_id,
 
 	range = ospf_area_range_lookup(area, p);
 	if (range != NULL) {
+		if (!CHECK_FLAG(advertise, OSPF_AREA_RANGE_ADVERTISE))
+			range->cost_config = OSPF_AREA_RANGE_COST_UNSPEC;
 		if ((CHECK_FLAG(range->flags, OSPF_AREA_RANGE_ADVERTISE)
 		     && !CHECK_FLAG(advertise, OSPF_AREA_RANGE_ADVERTISE))
 		    || (!CHECK_FLAG(range->flags, OSPF_AREA_RANGE_ADVERTISE)
@@ -209,8 +211,10 @@ int ospf_area_range_set(struct ospf *ospf, struct in_addr area_id,
 
 	if (CHECK_FLAG(advertise, OSPF_AREA_RANGE_ADVERTISE))
 		SET_FLAG(range->flags, OSPF_AREA_RANGE_ADVERTISE);
-	else
+	else {
 		UNSET_FLAG(range->flags, OSPF_AREA_RANGE_ADVERTISE);
+		range->cost_config = OSPF_AREA_RANGE_COST_UNSPEC;
+	}
 
 	return 1;
 }

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -750,6 +750,7 @@ DEFUN (ospf_area_range_not_advertise,
 	ospf_area_range_set(ospf, area_id, &p, 0);
 	ospf_area_display_format_set(ospf, ospf_area_get(ospf, area_id),
 				     format);
+	ospf_area_range_substitute_unset(ospf, area_id, &p);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
Issue: # https://github.com/FRRouting/frr/issues/1836

Issue 1: if the router ospf current configuration is "area 0.0.0.2
range 1.0.0.0/24 cost 23" and user try to configure "area 0.0.0.2
range 1.0.0.0/24 not-advertise", the existing o/p is "area 0.0.0.2
range 1.0.0.0/24 cost 23 not-advertise". The keywords "not-advertise"
& "cost" are multually exclusive, so they should not come together.
The vice versa way configuration is working fine.

Fix: When ospf area range "not-advertise", the cost should be initialized
to OSPF_AREA_RANGE_COST_UNSPEC.

Issue 2: if the router ospf current configuration "area 0.0.0.2 range
1.0.0.0/24 substitute 2.0.0.0/24" and user try to configure "area 0.0.0.2
range 1.0.0.0/24 not-advertise" the existing o/p is "area 0.0.0.2 range
1.0.0.0/24 not-advertise substitute 2.0.0.0/24". The keywords
"not-advertise" & "substiture" are multually exclusive, so they should
not come together. The vice versa way configuration is working fine.

Fix: When ospf area range "not-advertise" is configured,
ospf_area_range_substitute_unset() should be get called.

Issue 3: if the router ospf6 current configuration is "area 0.0.0.2
range 2001::/64 cost 23" and user try to configure "area 0.0.0.2 range
2001::/64 advertise", the existing o/p is area 0.0.0.2 range 2001::/64.
The keyword "cost 23" disappears.

Fix: When ospf area range "advertise" is configured and the range is not
NULL, the cost should not be modified.

Signed-off-by: Sarita Patra <saritap@vmware.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
