### PR TITLE
bfdd: fix memory leak and echo-mode start

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -157,7 +157,8 @@ void ptm_bfd_echo_stop(struct bfd_session *bfd, int polling)
 void ptm_bfd_echo_start(struct bfd_session *bfd)
 {
 	bfd->echo_detect_TO = (bfd->remote_detect_mult * bfd->echo_xmt_TO);
-	ptm_bfd_echo_xmt_TO(bfd);
+	if (bfd->echo_detect_TO > 0)
+		ptm_bfd_echo_xmt_TO(bfd);
 
 	bfd->polling = 1;
 	bfd->new_timers.desired_min_tx = bfd->up_min_tx;
@@ -324,7 +325,8 @@ int bfd_echo_xmt_cb(struct thread *t)
 {
 	struct bfd_session *bs = THREAD_ARG(t);
 
-	ptm_bfd_echo_xmt_TO(bs);
+	if (bs->echo_xmt_TO > 0)
+		ptm_bfd_echo_xmt_TO(bs);
 
 	return 0;
 }

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -197,7 +197,8 @@ static int ptm_bfd_process_echo_pkt(int s)
 	bfd->echo_detect_TO = bfd->remote_detect_mult * bfd->echo_xmt_TO;
 
 	/* Update echo receive timeout. */
-	bfd_echo_recvtimer_update(bfd);
+	if (bfd->echo_detect_TO > 0)
+		bfd_echo_recvtimer_update(bfd);
 
 	return 0;
 }

--- a/bfdd/event.c
+++ b/bfdd/event.c
@@ -39,6 +39,9 @@ void bfd_recvtimer_update(struct bfd_session *bs)
 {
 	struct timeval tv = {.tv_sec = 0, .tv_usec = bs->detect_TO};
 
+	/* Remove previous schedule if any. */
+	bfd_recvtimer_delete(bs);
+
 	/* Don't add event if peer is deactivated. */
 	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 		return;
@@ -47,9 +50,6 @@ void bfd_recvtimer_update(struct bfd_session *bs)
 #ifdef BFD_EVENT_DEBUG
 	log_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec, tv.tv_usec);
 #endif /* BFD_EVENT_DEBUG */
-
-	/* Remove previous schedule if any. */
-	bfd_recvtimer_delete(bs);
 
 	thread_add_timer_tv(master, bfd_recvtimer_cb, bs, &tv,
 			    &bs->recvtimer_ev);
@@ -59,6 +59,9 @@ void bfd_echo_recvtimer_update(struct bfd_session *bs)
 {
 	struct timeval tv = {.tv_sec = 0, .tv_usec = bs->echo_detect_TO};
 
+	/* Remove previous schedule if any. */
+	bfd_echo_recvtimer_delete(bs);
+
 	/* Don't add event if peer is deactivated. */
 	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 		return;
@@ -67,9 +70,6 @@ void bfd_echo_recvtimer_update(struct bfd_session *bs)
 #ifdef BFD_EVENT_DEBUG
 	log_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec, tv.tv_usec);
 #endif /* BFD_EVENT_DEBUG */
-
-	/* Remove previous schedule if any. */
-	bfd_echo_recvtimer_delete(bs);
 
 	thread_add_timer_tv(master, bfd_echo_recvtimer_cb, bs, &tv,
 			    &bs->echo_recvtimer_ev);
@@ -79,6 +79,9 @@ void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 {
 	struct timeval tv = {.tv_sec = 0, .tv_usec = jitter};
 
+	/* Remove previous schedule if any. */
+	bfd_xmttimer_delete(bs);
+
 	/* Don't add event if peer is deactivated. */
 	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 		return;
@@ -87,9 +90,6 @@ void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 #ifdef BFD_EVENT_DEBUG
 	log_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec, tv.tv_usec);
 #endif /* BFD_EVENT_DEBUG */
-
-	/* Remove previous schedule if any. */
-	bfd_xmttimer_delete(bs);
 
 	thread_add_timer_tv(master, bfd_xmt_cb, bs, &tv, &bs->xmttimer_ev);
 }
@@ -98,6 +98,9 @@ void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 {
 	struct timeval tv = {.tv_sec = 0, .tv_usec = jitter};
 
+	/* Remove previous schedule if any. */
+	bfd_echo_xmttimer_delete(bs);
+
 	/* Don't add event if peer is deactivated. */
 	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 		return;
@@ -106,9 +109,6 @@ void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 #ifdef BFD_EVENT_DEBUG
 	log_debug("%s: sec = %ld, usec = %ld", __func__, tv.tv_sec, tv.tv_usec);
 #endif /* BFD_EVENT_DEBUG */
-
-	/* Remove previous schedule if any. */
-	bfd_echo_xmttimer_delete(bs);
 
 	thread_add_timer_tv(master, bfd_echo_xmt_cb, bs, &tv,
 			    &bs->echo_xmttimer_ev);

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -58,6 +58,7 @@ pthread_key_t thread_current;
 pthread_mutex_t masters_mtx = PTHREAD_MUTEX_INITIALIZER;
 static struct list *masters;
 
+static void thread_free(struct thread_master *master, struct thread *thread);
 
 /* CLI start ---------------------------------------------------------------- */
 static unsigned int cpu_record_hash_key(struct cpu_thread_history *a)
@@ -538,6 +539,8 @@ static struct thread *thread_trim_head(struct thread_list *list)
 /* Move thread to unuse list. */
 static void thread_add_unuse(struct thread_master *m, struct thread *thread)
 {
+	pthread_mutex_t mtxc = thread->mtx;
+
 	assert(m != NULL && thread != NULL);
 	assert(thread->next == NULL);
 	assert(thread->prev == NULL);
@@ -546,10 +549,15 @@ static void thread_add_unuse(struct thread_master *m, struct thread *thread)
 	memset(thread, 0, sizeof(struct thread));
 	thread->type = THREAD_UNUSED;
 
-	if (m->unuse.count < THREAD_UNUSED_DEPTH)
+	/* Restore the thread mutex context. */
+	thread->mtx = mtxc;
+
+	if (m->unuse.count < THREAD_UNUSED_DEPTH) {
 		thread_list_add(&m->unuse, thread);
-	else
-		XFREE(MTYPE_THREAD, thread);
+		return;
+	}
+
+	thread_free(m, thread);
 }
 
 /* Free all unused thread. */
@@ -560,9 +568,8 @@ static void thread_list_free(struct thread_master *m, struct thread_list *list)
 
 	for (t = list->head; t; t = next) {
 		next = t->next;
-		XFREE(MTYPE_THREAD, t);
+		thread_free(m, t);
 		list->count--;
-		m->alloc--;
 	}
 }
 
@@ -576,8 +583,7 @@ static void thread_array_free(struct thread_master *m,
 		t = thread_array[index];
 		if (t) {
 			thread_array[index] = NULL;
-			XFREE(MTYPE_THREAD, t);
-			m->alloc--;
+			thread_free(m, t);
 		}
 	}
 	XFREE(MTYPE_THREAD_POLL, thread_array);
@@ -588,9 +594,8 @@ static void thread_queue_free(struct thread_master *m, struct pqueue *queue)
 	int i;
 
 	for (i = 0; i < queue->size; i++)
-		XFREE(MTYPE_THREAD, queue->array[i]);
+		thread_free(m, queue->array[i]);
 
-	m->alloc -= queue->size;
 	pqueue_delete(queue);
 }
 
@@ -608,8 +613,7 @@ void thread_master_free_unused(struct thread_master *m)
 	{
 		struct thread *t;
 		while ((t = thread_trim_head(&m->unuse)) != NULL) {
-			pthread_mutex_destroy(&t->mtx);
-			XFREE(MTYPE_THREAD, t);
+			thread_free(m, t);
 		}
 	}
 	pthread_mutex_unlock(&m->mtx);
@@ -726,6 +730,17 @@ static struct thread *thread_get(struct thread_master *m, uint8_t type,
 	thread->schedfrom_line = fromln;
 
 	return thread;
+}
+
+static void thread_free(struct thread_master *master, struct thread *thread)
+{
+	/* Update statistics. */
+	assert(master->alloc > 0);
+	master->alloc--;
+
+	/* Free allocated resources. */
+	pthread_mutex_destroy(&thread->mtx);
+	XFREE(MTYPE_THREAD, thread);
 }
 
 static int fd_poll(struct thread_master *m, struct pollfd *pfds, nfds_t pfdsize,

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -1648,25 +1648,27 @@ void funcname_thread_execute(struct thread_master *m,
 			     int (*func)(struct thread *), void *arg, int val,
 			     debugargdef)
 {
-	struct cpu_thread_history tmp;
-	struct thread dummy;
+	struct thread *thread;
 
-	memset(&dummy, 0, sizeof(struct thread));
+	/* Get or allocate new thread to execute. */
+	pthread_mutex_lock(&m->mtx);
+	{
+		thread = thread_get(m, THREAD_EVENT, func, arg, debugargpass);
 
-	pthread_mutex_init(&dummy.mtx, NULL);
-	dummy.type = THREAD_EVENT;
-	dummy.add_type = THREAD_EXECUTE;
-	dummy.master = NULL;
-	dummy.arg = arg;
-	dummy.u.val = val;
+		/* Set its event value. */
+		pthread_mutex_lock(&thread->mtx);
+		{
+			thread->add_type = THREAD_EXECUTE;
+			thread->u.val = val;
+			thread->ref = &thread;
+		}
+		pthread_mutex_unlock(&thread->mtx);
+	}
+	pthread_mutex_unlock(&m->mtx);
 
-	tmp.func = dummy.func = func;
-	tmp.funcname = dummy.funcname = funcname;
-	dummy.hist = hash_get(m->cpu_record, &tmp,
-			      (void *(*)(void *))cpu_record_hash_alloc);
+	/* Execute thread doing all accounting. */
+	thread_call(thread);
 
-	dummy.schedfrom = schedfrom;
-	dummy.schedfrom_line = fromln;
-
-	thread_call(&dummy);
+	/* Give back or free thread. */
+	thread_add_unuse(m, thread);
 }


### PR DESCRIPTION
### Summary

This PR fixes a memory leak I found when running `bfdd` with valgrind/address sanitizer in Linux. To fix the memory leak I simplified the single thread cancellation code to avoid making memory allocations (see commit `lib: fix a memory leak on single thread cancel` message for more information).

It also fixes a echo packet burst when initiating `echo-mode` with a peer that just connected (`echo-interval` starts with value `0` so we must check if the neighbor permits echo packets).


### Components

`bfdd` and `lib/thread`.
