### PR TITLE
build: add --enable-static-bin option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ AM_CPPFLAGS = \
 	-I$(top_builddir) -I$(top_builddir)/include -I$(top_builddir)/lib
 AM_LDFLAGS = \
 	-export-dynamic \
+	$(AC_LDFLAGS) \
 	$(SAN_FLAGS) \
 	# end
 DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\" -DCONFDATE=$(CONFDATE)
@@ -154,6 +155,7 @@ EXTRA_DIST += \
 	aclocal.m4 \
 	README.md \
 	m4/README.txt \
+	m4/libtool-whole-archive.patch \
 	\
 	python/clidef.py \
 	python/clippy/__init__.py \

--- a/configure.ac
+++ b/configure.ac
@@ -310,7 +310,18 @@ AC_CHECK_TOOL(AR, ar)
 dnl -------
 dnl libtool
 dnl -------
+AC_ARG_ENABLE(static-bin,
+  AS_HELP_STRING([--enable-static-bin], [link binaries statically]))
 LT_INIT
+_LT_CONFIG_LIBTOOL([
+  patch -N -i "${srcdir}/m4/libtool-whole-archive.patch" libtool >&AS_MESSAGE_LOG_FD || \
+    AC_MSG_WARN([Could not patch libtool for static linking support.  Loading modules into a statically linked daemon will fail.])
+])
+if test "$enable_static_bin" = "yes"; then
+  AC_LDFLAGS="-static"
+fi
+AC_SUBST(AC_LDFLAGS)
+AM_CONDITIONAL([STATIC_BIN], [test "x$enable_static_bin" = "xyes"])
 
 dnl ----------------------
 dnl Packages configuration

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -207,6 +207,17 @@ noinst_HEADERS += \
 	lib/plist_int.h \
 	#end
 
+# General note about module and module helper library (libfrrsnmp, libfrrzmq)
+# linking:  If we're linking libfrr statically into daemons, we *must* remove
+# libfrr from modules because modules will always link it in dynamically and
+# thus 2 copies of libfrr will be loaded... hilarity ensues.
+#
+# Not linking libfrr into modules should generally work fine because the
+# executable refers to libfrr either way and the dynamic linker should make
+# libfrr available to modules.  If some OS platform has a dynamic linker that
+# doesn't do that, libfrr needs to be readded to modules, but _only_ _if_
+# it's not linked into daemons statically.
+
 #
 # SNMP support
 #
@@ -216,7 +227,7 @@ endif
 
 lib_libfrrsnmp_la_CFLAGS = $(WERROR) $(SNMP_CFLAGS) -std=gnu99
 lib_libfrrsnmp_la_LDFLAGS = -version-info 0:0:0
-lib_libfrrsnmp_la_LIBADD = lib/libfrr.la $(SNMP_LIBS)
+lib_libfrrsnmp_la_LIBADD = $(SNMP_LIBS)
 lib_libfrrsnmp_la_SOURCES = \
 	lib/agentx.c \
 	lib/snmp.c \
@@ -232,7 +243,7 @@ endif
 
 lib_libfrrzmq_la_CFLAGS = $(WERROR) $(ZEROMQ_CFLAGS)
 lib_libfrrzmq_la_LDFLAGS = -version-info 0:0:0
-lib_libfrrzmq_la_LIBADD = lib/libfrr.la $(ZEROMQ_LIBS)
+lib_libfrrzmq_la_LIBADD = $(ZEROMQ_LIBS)
 lib_libfrrzmq_la_SOURCES = \
 	lib/frr_zmq.c \
 	#end

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,4 +1,5 @@
 *.m4
+!*.patch
 
 !ax_compare_version.m4
 !ax_prog_perl_modules.m4

--- a/m4/libtool-whole-archive.patch
+++ b/m4/libtool-whole-archive.patch
@@ -1,0 +1,18 @@
+--- /usr/share/libtool/build-aux/ltmain.sh	2017-08-01 07:13:09.611041402 +0200
++++ ltmain.sh	2018-08-31 17:32:15.381903718 +0200
+@@ -8439,8 +8439,13 @@
+ 	  # shared platforms.
+ 	  if test unsupported != "$hardcode_direct"; then
+ 	    test -n "$old_library" && linklib=$old_library
+-	    compile_deplibs="$dir/$linklib $compile_deplibs"
+-	    finalize_deplibs="$dir/$linklib $finalize_deplibs"
++	    if test yes,yes = "$export_dynamic,$with_gnu_ld"; then
++	      compile_deplibs="-Wl,--no-whole-archive $dir/$linklib -Wl,--whole-archive $compile_deplibs"
++	      finalize_deplibs="-Wl,--no-whole-archive $dir/$linklib -Wl,--whole-archive $finalize_deplibs"
++	    else
++	      compile_deplibs="$dir/$linklib $compile_deplibs"
++	      finalize_deplibs="$dir/$linklib $finalize_deplibs"
++	    fi
+ 	  else
+ 	    compile_deplibs="-l$name -L$dir $compile_deplibs"
+ 	    finalize_deplibs="-l$name -L$dir $finalize_deplibs"

--- a/ospfclient/subdir.am
+++ b/ospfclient/subdir.am
@@ -23,9 +23,21 @@ endif
 
 ospfclient_ospfclient_LDADD = \
 	ospfclient/libfrrospfapiclient.la \
-	lib/libfrr.la \
 	@LIBCAP@ \
 	# end
+
+if STATIC_BIN
+# libfrr is linked in through libfrrospfapiclient.  If we list it here too,
+# it gets linked twice and we get a ton of symbol collisions.
+
+else # !STATIC_BIN
+# For most systems we don't need this, except Debian, who patch their linker
+# to disallow transitive references *while* *als* not patching their libtool
+# to work appropriately.  RedHat has the same linker behaviour, but things
+# work as expected since they also patch libtool.
+ospfclient_ospfclient_LDADD += lib/libfrr.la
+endif
+
 ospfclient_ospfclient_SOURCES = \
 	ospfclient/ospfclient.c \
 	# end

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -1799,7 +1799,7 @@ static int config_write_debug(struct vty *vty)
 }
 
 /* Initialize debug commands. */
-void debug_init()
+void ospf_debug_init(void)
 {
 	install_node(&debug_node, config_write_debug);
 

--- a/ospfd/ospf_dump.h
+++ b/ospfd/ospf_dump.h
@@ -140,7 +140,7 @@ extern const char *ospf_timer_dump(struct thread *, char *, size_t);
 extern const char *ospf_timeval_dump(struct timeval *, char *, size_t);
 extern void ospf_ip_header_dump(struct ip *);
 extern void ospf_packet_dump(struct stream *);
-extern void debug_init(void);
+extern void ospf_debug_init(void);
 
 /* Appropriate buffer size to use with ospf_timer_dump and ospf_timeval_dump: */
 #define OSPF_TIME_DUMP_SIZE	16

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
 	master = om->master;
 
 	/* Library inits. */
-	debug_init();
+	ospf_debug_init();
 	ospf_vrf_init();
 
 	access_list_init();


### PR DESCRIPTION
This option can be used to get statically linked binaries.

Note: libfrr.la is removed from modules' library dependency list.  This
is intentional and explained in a comment in lib/subdir.am.

Signed-off-by: David Lamparter <equinox@diac24.net>