### PR TITLE
lib: Trigger callbacks to re-evaluate route-map clauses when "call" CLI is executed

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1739,8 +1739,19 @@ void route_map_upd8_dependency(route_map_event_t type, const char *arg,
 {
 	struct hash *upd8_hash = NULL;
 
-	if ((upd8_hash = route_map_get_dep_hash(type)))
+	if ((upd8_hash = route_map_get_dep_hash(type))) {
 		route_map_dep_update(upd8_hash, arg, rmap_name, type);
+
+		if (type == RMAP_EVENT_CALL_ADDED) {
+			/* Execute hook. */
+			if (route_map_master.add_hook)
+				(*route_map_master.add_hook)(rmap_name);
+		} else if (type == RMAP_EVENT_CALL_DELETED) {
+			/* Execute hook. */
+			if (route_map_master.delete_hook)
+				(*route_map_master.delete_hook)(rmap_name);
+		}
+	}
 }
 
 void route_map_notify_dependencies(const char *affected_name,


### PR DESCRIPTION
### Summary
When the "call" CLI is executed from within a route-map that is already in use,
there is a need to get the route-map clients to re-evaluate the clauses defined
by both the parent route-map, as well as the child route-map.
The existing callbacks, add_hook() and delete_hook() can be used by the lib to
inform the clients when the "call" is configured and unconfigured.

### Related Issue
[3049](https://github.com/FRRouting/frr/issues/3049)

### Components
lib

Signed-off-by: NaveenThanikachalam <nthanikachal@vmware.com>