### PR TITLE
bgpd: Match routes by type under route-maps

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -111,6 +111,20 @@ struct route_map_match_set_hooks {
 						const char *arg,
 						route_map_event_t type);
 
+	/* match ip next hop type */
+	int (*match_ip_next_hop_type)(struct vty *vty,
+					     struct route_map_index *index,
+					     const char *command,
+					     const char *arg,
+					     route_map_event_t type);
+
+	/* no match ip next hop type */
+	int (*no_match_ip_next_hop_type)(struct vty *vty,
+						struct route_map_index *index,
+						const char *command,
+						const char *arg,
+						route_map_event_t type);
+
 	/* match ipv6 address */
 	int (*match_ipv6_address)(struct vty *vty,
 				  struct route_map_index *index,
@@ -137,6 +151,19 @@ struct route_map_match_set_hooks {
 						 const char *command,
 						 const char *arg,
 						 route_map_event_t type);
+
+	/* match ipv6 next-hop type */
+	int (*match_ipv6_next_hop_type)(struct vty *vty,
+					      struct route_map_index *index,
+					      const char *command,
+					      const char *arg,
+					      route_map_event_t type);
+
+	/* no match ipv6next-hop type */
+	int (*no_match_ipv6_next_hop_type)(struct vty *vty,
+					   struct route_map_index *index,
+					   const char *command, const char *arg,
+					   route_map_event_t type);
 
 	/* match metric */
 	int (*match_metric)(struct vty *vty, struct route_map_index *index,
@@ -275,6 +302,22 @@ void route_map_no_match_ip_next_hop_prefix_list_hook(int (*func)(
 	rmap_match_set_hook.no_match_ip_next_hop_prefix_list = func;
 }
 
+/* match ip next hop type */
+void route_map_match_ip_next_hop_type_hook(int (*func)(
+	struct vty *vty, struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type))
+{
+	rmap_match_set_hook.match_ip_next_hop_type = func;
+}
+
+/* no match ip next hop type */
+void route_map_no_match_ip_next_hop_type_hook(int (*func)(
+	struct vty *vty, struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type))
+{
+	rmap_match_set_hook.no_match_ip_next_hop_type = func;
+}
+
 /* match ipv6 address */
 void route_map_match_ipv6_address_hook(int (*func)(
 	struct vty *vty, struct route_map_index *index, const char *command,
@@ -306,6 +349,22 @@ void route_map_no_match_ipv6_address_prefix_list_hook(int (*func)(
 	const char *arg, route_map_event_t type))
 {
 	rmap_match_set_hook.no_match_ipv6_address_prefix_list = func;
+}
+
+/* match ipv6 next-hop type */
+void route_map_match_ipv6_next_hop_type_hook(int (*func)(
+	struct vty *vty, struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type))
+{
+	rmap_match_set_hook.match_ipv6_next_hop_type = func;
+}
+
+/* no match ipv6 next-hop type */
+void route_map_no_match_ipv6_next_hop_type_hook(int (*func)(
+	struct vty *vty, struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type))
+{
+	rmap_match_set_hook.no_match_ipv6_next_hop_type = func;
 }
 
 /* match metric */
@@ -2028,6 +2087,45 @@ DEFUN (no_match_ip_next_hop_prefix_list,
 	return CMD_SUCCESS;
 }
 
+DEFUN(match_ip_next_hop_type, match_ip_next_hop_type_cmd,
+      "match ip next-hop type <blackhole>",
+      MATCH_STR IP_STR
+      "Match next-hop address of route\n"
+      "Match entries by type\n"
+      "Blackhole\n")
+{
+	int idx_word = 4;
+	VTY_DECLVAR_CONTEXT(route_map_index, index);
+
+	if (rmap_match_set_hook.match_ip_next_hop_type)
+		return rmap_match_set_hook.match_ip_next_hop_type(
+			vty, index, "ip next-hop type", argv[idx_word]->arg,
+			RMAP_EVENT_MATCH_ADDED);
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_match_ip_next_hop_type, no_match_ip_next_hop_type_cmd,
+      "no match ip next-hop type [<blackhole>]",
+      NO_STR MATCH_STR IP_STR
+      "Match next-hop address of route\n"
+      "Match entries by type\n"
+      "Blackhole\n")
+{
+	int idx_word = 5;
+	VTY_DECLVAR_CONTEXT(route_map_index, index);
+
+	if (rmap_match_set_hook.no_match_ip_next_hop) {
+		if (argc <= idx_word)
+			return rmap_match_set_hook.no_match_ip_next_hop(
+				vty, index, "ip next-hop type", NULL,
+				RMAP_EVENT_MATCH_DELETED);
+		return rmap_match_set_hook.no_match_ip_next_hop(
+			vty, index, "ip next-hop type", argv[idx_word]->arg,
+			RMAP_EVENT_MATCH_DELETED);
+	}
+	return CMD_SUCCESS;
+}
+
 
 DEFUN (match_ipv6_address,
        match_ipv6_address_cmd,
@@ -2106,6 +2204,39 @@ DEFUN (no_match_ipv6_address_prefix_list,
 	return CMD_SUCCESS;
 }
 
+DEFUN(match_ipv6_next_hop_type, match_ipv6_next_hop_type_cmd,
+      "match ipv6 next-hop type <blackhole>",
+      MATCH_STR IPV6_STR
+      "Match address of route\n"
+      "Match entries by type\n"
+      "Blackhole\n")
+{
+	int idx_word = 4;
+	VTY_DECLVAR_CONTEXT(route_map_index, index);
+
+	if (rmap_match_set_hook.match_ipv6_next_hop_type)
+		return rmap_match_set_hook.match_ipv6_next_hop_type(
+			vty, index, "ipv6 next-hop type", argv[idx_word]->arg,
+			RMAP_EVENT_MATCH_ADDED);
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_match_ipv6_next_hop_type, no_match_ipv6_next_hop_type_cmd,
+      "no match ipv6 next-hop type [<blackhole>]",
+      NO_STR MATCH_STR IPV6_STR
+      "Match address of route\n"
+      "Match entries by type\n"
+      "Blackhole\n")
+{
+	int idx_word = 5;
+	VTY_DECLVAR_CONTEXT(route_map_index, index);
+
+	if (rmap_match_set_hook.no_match_ipv6_next_hop_type)
+		return rmap_match_set_hook.no_match_ipv6_next_hop_type(
+			vty, index, "ipv6 next-hop type", argv[idx_word]->arg,
+			RMAP_EVENT_MATCH_DELETED);
+	return CMD_SUCCESS;
+}
 
 DEFUN (match_metric,
        match_metric_cmd,
@@ -2873,11 +3004,17 @@ void route_map_init(void)
 	install_element(RMAP_NODE, &match_ip_next_hop_prefix_list_cmd);
 	install_element(RMAP_NODE, &no_match_ip_next_hop_prefix_list_cmd);
 
+	install_element(RMAP_NODE, &match_ip_next_hop_type_cmd);
+	install_element(RMAP_NODE, &no_match_ip_next_hop_type_cmd);
+
 	install_element(RMAP_NODE, &match_ipv6_address_cmd);
 	install_element(RMAP_NODE, &no_match_ipv6_address_cmd);
 
 	install_element(RMAP_NODE, &match_ipv6_address_prefix_list_cmd);
 	install_element(RMAP_NODE, &no_match_ipv6_address_prefix_list_cmd);
+
+	install_element(RMAP_NODE, &match_ipv6_next_hop_type_cmd);
+	install_element(RMAP_NODE, &no_match_ipv6_next_hop_type_cmd);
 
 	install_element(RMAP_NODE, &match_metric_cmd);
 	install_element(RMAP_NODE, &no_match_metric_cmd);

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -283,6 +283,14 @@ extern void route_map_match_ip_next_hop_prefix_list_hook(int (*func)(
 extern void route_map_no_match_ip_next_hop_prefix_list_hook(int (*func)(
 	struct vty *vty, struct route_map_index *index, const char *command,
 	const char *arg, route_map_event_t type));
+/* match ip next hop type */
+extern void route_map_match_ip_next_hop_type_hook(int (*func)(
+	struct vty *vty, struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type));
+/* no match ip next hop type */
+extern void route_map_no_match_ip_next_hop_type_hook(int (*func)(
+	struct vty *vty, struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type));
 /* match ipv6 address */
 extern void route_map_match_ipv6_address_hook(int (*func)(
 	struct vty *vty, struct route_map_index *index, const char *command,
@@ -297,6 +305,14 @@ extern void route_map_match_ipv6_address_prefix_list_hook(int (*func)(
 	const char *arg, route_map_event_t type));
 /* no match ipv6 address prefix list */
 extern void route_map_no_match_ipv6_address_prefix_list_hook(int (*func)(
+	struct vty *vty, struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type));
+/* match ipv6 next-hop type */
+extern void route_map_match_ipv6_next_hop_type_hook(int (*func)(
+	struct vty *vty, struct route_map_index *index, const char *command,
+	const char *arg, route_map_event_t type));
+/* no match ipv6 next-hop type */
+extern void route_map_no_match_ipv6_next_hop_type_hook(int (*func)(
 	struct vty *vty, struct route_map_index *index, const char *command,
 	const char *arg, route_map_event_t type));
 /* match metric */


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

### Summary
spine:

```username cumulus nopassword
!
ip route 4.4.4.4/32 blackhole
ip route 5.5.5.5/32 eth5
ipv6 route 2a02::/48 eth5
ipv6 route 2a02:4780:123::/48 blackhole
ipv6 route 2a02:4780:f00d::/48 eth1
!
router bgp 65032
 neighbor 10.0.0.2 remote-as 123
 neighbor 192.168.0.1 remote-as 65031
 neighbor 192.168.1.1 remote-as 65033
 neighbor 192.168.2.1 remote-as 65034
 neighbor 192.168.3.1 remote-as 65035
 neighbor 2a02:4780:abc::2 remote-as 123
 !
 address-family ipv4 unicast
  redistribute kernel
  redistribute static
  neighbor 10.0.0.2 route-map bh out
 exit-address-family
 !
 address-family ipv6 unicast
  redistribute kernel
  redistribute static
  neighbor 2a02:4780:abc::2 activate
  neighbor 2a02:4780:abc::2 route-map bh6 out
 exit-address-family
!
route-map bh permit 10
 match ip next-hop type blackhole
 set metric 1000
!
route-map bh permit 20
!
route-map bh6 permit 10
 match ipv6 next-hop type blackhole
 set metric 1000
!
route-map bh6 permit 20
!
line vty
!
```

leaf:

```
leaf1-debian-9# sh ip bgp 
BGP table version is 356, local router ID is 10.0.2.15, vrf id 0
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*  4.4.4.4/32       10.0.0.1              1000             0 65032 ?
*>                  10.0.0.1                 0             0 65032 ?
*  5.5.5.5/32       10.0.0.1                 0             0 65032 ?
*>                  10.0.0.1                 0             0 65032 ?
*  100.0.0.0/24     10.0.0.1                               0 65032 65031 ?
*>                  10.0.0.1                               0 65032 65031 ?
*  200.0.0.0        10.0.0.1                               0 65032 65031 ?
*>                  10.0.0.1                               0 65032 65031 ?
*  250.0.0.0/24     10.0.0.1                               0 65032 65031 ?
*>                  10.0.0.1                               0 65032 65031 ?

leaf1-debian-9# sh ip bgp ipv6 unicast 
BGP table version is 31, local router ID is 10.0.2.15, vrf id 0
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*> 2a02::/48        fe80::a00:27ff:feec:67f6
                                             0             0 65032 ?
*> 2a02:4780:123::/48
                    fe80::a00:27ff:feec:67f6
                                          1000             0 65032 ?
*> 2a02:4780:f00d::/48
                    fe80::a00:27ff:feec:67f6
                                             0             0 65032 ?
```

### Related Issue
https://github.com/FRRouting/frr/issues/1388

### Components
[bgpd]