### PR TITLE
bgpd: enable aggregation in evpn

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2428,6 +2428,8 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 		ri->uptime = bgp_clock();
 	}
 
+	bgp_aggregate_increment(bgp_vrf, &rn->p, ri, afi, safi);
+
 	/* Perform route selection and update zebra, if required. */
 	bgp_process(bgp_vrf, rn, afi, safi);
 
@@ -2599,6 +2601,8 @@ static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 
 	/* Mark entry for deletion */
 	bgp_info_delete(rn, ri);
+
+	bgp_aggregate_decrement(bgp_vrf, &rn->p, ri, afi, safi);
 
 	/* Perform route selection and update zebra, if required. */
 	bgp_process(bgp_vrf, rn, afi, safi);

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2599,10 +2599,10 @@ static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 	if (!ri)
 		return 0;
 
+	bgp_aggregate_decrement(bgp_vrf, &rn->p, ri, afi, safi);
+
 	/* Mark entry for deletion */
 	bgp_info_delete(rn, ri);
-
-	bgp_aggregate_decrement(bgp_vrf, &rn->p, ri, afi, safi);
 
 	/* Perform route selection and update zebra, if required. */
 	bgp_process(bgp_vrf, rn, afi, safi);


### PR DESCRIPTION
Ticket: CM-20585
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>

### Summary
Problem encountered where using the aggregate-address command in an
evpn environment did not work properly.  Depending on the order of
actions, the aggregate may not be created or removed when either the
commands were issued or routes come and go.

### Components
bgpd