### PR TITLE
doc: Use `mv -f` in Makefile

### DIFF
--- a/doc/subdir.am
+++ b/doc/subdir.am
@@ -56,7 +56,7 @@ doc/%/_build/man/man.stamp: doc/%/_build/.doctrees/environment.pickle
 		$(MKDIR_P) "$${subdoc}/_build/man"; touch $@.tmp; \
 		$(SPHINXBUILD) -a -q -b man -d "$${subdoc}/_build/.doctrees" \
 			$(ALLSPHINXOPTS) "$(top_srcdir)/$${subdoc}" "$${subdoc}/_build/man" && \
-			mv $@.tmp $@ \
+			mv -f $@.tmp $@ \
 	)
 
 #


### PR DESCRIPTION
Sphinx always runs, even in the `make install` stage. When `make install`
is run as root and then another `make` is run by a nonprivileged user,
some versions of `mv` prompt like this:

    mv: replace 'doc/manpages/_build/man/man.stamp',
                 overriding mode 0644 (rw-r--r--)?

Add `-f` to `mv` to avoid this. As `-f` is part of Posix, this should be
portable enough.