### PR TITLE
lib: RB-tree copy-paste error (Coverity 1446184)

### DIFF
--- a/lib/openbsd-tree.c
+++ b/lib/openbsd-tree.c
@@ -345,7 +345,7 @@ rbe_remove(const struct rb_type *t, struct rbt_tree *rbt, struct rb_entry *rbe)
 			else
 				RBE_RIGHT(tmp) = rbe;
 
-			rbe_if_augment(t, parent);
+			rbe_if_augment(t, tmp);
 		} else
 			RBH_ROOT(rbt) = rbe;
 


### PR DESCRIPTION
### Summary

Overview:

Coverity points a copy-paste error in the Red-Black tree implementation. The
RB tree code is based on the OpenBSD implementation, so at first glance, it
is a strong point for thinking twice before touching anything.

Details:

The code is an augmented RB tree implementation [1], which adds to RB trees
the possibility of using a callback on every node update for updating per-node
associated metainformation. The bug is clear once checking other places where
the callback is called.

Impact:

- FRR: no impact, because the "augmented" capability is not being used.
- OpenBSD [2]: it seems there is no impact, at least in the 'src' repository.

Additional observations:

- If the "augmented" capability is not used, the code could run faster (at
  every operation on a node the callback is checked for not being NULL). May
  be branch prediction could be enough for those extra operations being
  negligible on most processors in use.

[1] http://kaba.hilvi.org/pastel-1.3.0/pastel/sys/redblacktree.htm
[2] GH mirror: https://github.com/openbsd/src/blob/master/sys/kern/subr_tree.c

### Components

lib
