### PR TITLE
Add a script for building a Debian package in one step.

### DIFF
--- a/doc/developer/packaging-debian.rst
+++ b/doc/developer/packaging-debian.rst
@@ -130,6 +130,13 @@ If all worked correctly, then you should end up with the Debian packages under
 with the sources (``frr_*.orig.tar.gz``, ``frr_*.debian.tar.xz`` and
 ``frr_*.dsc``)
 
+The build procedure can also be executed automatically using the ``tools/build-debian-package.sh``
+script. For example:
+
+.. code-block:: shell
+
+   EXTRA_VERSION="-myversion" WANT_SNMP=1 WANT_CUMULUS_MODE=1 tools/build-debian-package.sh
+
 .. _deb-backports:
 
 Debian Backports

--- a/tools/build-debian-package.sh
+++ b/tools/build-debian-package.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Written by Daniil Baturin, 2018
+# This file is public domain
+
+git diff-index --quiet HEAD || echo "Warning: git working directory is not clean!"
+
+# Set the defaults
+if [ "$EXTRA_VERSION" = "" ]; then
+    EXTRA_VERSION="-MyDebPkgVersion"
+fi
+
+if [ "$WANT_SNMP" = "" ]; then
+    WANT_SNMP=0
+fi
+
+if [ "$WANT_CUMULUS_MODE" = "" ]; then
+    WANT_CUMULUS_MODE=0
+fi
+
+echo "Preparing the build"
+./bootstrap.sh
+./configure --with-pkg-extra-version=$EXTRA_VERSION
+make dist
+
+echo "Preparing Debian source package"
+mv debianpkg debian
+make -f debian/rules backports
+
+echo "Unpacking the source to frrpkg/"
+mkdir frrpkg
+cd frrpkg
+tar xf ../frr_*.orig.tar.gz
+cd frr*
+. /etc/os-release
+tar xf ../../frr_*${ID}${VERSION_ID}*.debian.tar.xz
+
+echo "Building the Debian package"
+debuild --no-lintian --set-envvar=WANT_SNMP=$WANT_SNMP --set-envvar=WANT_CUMULUS_MODE=$WANT_CUMULUS_MODE -b -uc -us
+

--- a/tools/subdir.am
+++ b/tools/subdir.am
@@ -26,4 +26,5 @@ EXTRA_DIST += \
 	tools/rrlookup.pl \
 	tools/zc.pl \
 	tools/zebra.el \
+	tools/build-debian-package.sh \
 	# end


### PR DESCRIPTION
### Summary
Add a script for building a Debian package in one step.
While the build procedure is documented, it's quite lengthy and can be annoying to execute. A one step method should make it easier to install test development versions of FRR on Debian-based systems.