### PR TITLE
lib: print version information in libfrr.so

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -741,6 +741,20 @@ if test "x$with_pkg_git_version" = "xyes"; then
 fi
 AM_CONDITIONAL([GIT_VERSION], [test "x$with_pkg_git_version" = "xyes"])
 
+AC_CHECK_TOOL([OBJCOPY], [objcopy], [:])
+AC_CACHE_CHECK([for .interp value to use], [frr_cv_interp], [
+  frr_cv_interp=""
+  AC_LINK_IFELSE([AC_LANG_SOURCE([[int main() { return 0; }]])], [
+    if $OBJCOPY -j.interp -Obinary conftest conftest.interp; then
+      frr_cv_interp="`xargs -0 echo < conftest.interp`"
+    fi
+    test -f conftest.interp && rm conftest.interp
+  ])
+])
+if test -n "$frr_cv_interp"; then
+  AC_DEFINE_UNQUOTED(INTERP, ["$frr_cv_interp"], [.interp value])
+fi
+
 dnl ------------------------------------
 dnl Check C keywords and standard  types
 dnl ------------------------------------

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -973,3 +973,25 @@ void frr_fini(void)
 		fclose(fp);
 	}
 }
+
+#ifdef INTERP
+static const char interp[]
+	__attribute__((section(".interp"), used)) = INTERP;
+#endif
+/*
+ * executable entry point for libfrr.so
+ *
+ * note that libc initialization is skipped for this so the set of functions
+ * that can be called is rather limited
+ */
+extern void _libfrr_version(void)
+	__attribute__((visibility("hidden"), noreturn));
+void _libfrr_version(void)
+{
+	const char banner[] =
+		FRR_FULL_NAME " " FRR_VERSION ".\n"
+		FRR_COPYRIGHT GIT_INFO "\n"
+		"configured with:\n    " FRR_CONFIG_ARGS "\n";
+	write(1, banner, sizeof(banner) - 1);
+	_exit(0);
+}

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -2,7 +2,7 @@
 # libfrr
 #
 lib_LTLIBRARIES += lib/libfrr.la
-lib_libfrr_la_LDFLAGS = -version-info 0:0:0
+lib_libfrr_la_LDFLAGS = -version-info 0:0:0 -Xlinker -e_libfrr_version
 lib_libfrr_la_LIBADD = @LIBCAP@
 
 lib_libfrr_la_SOURCES = \


### PR DESCRIPTION
This makes libfrr.so executable to print its version info.  This is
useful if you need to check your libfrr.so matches your daemons.