### PR TITLE
ospf6d: dead code (Coverity 1399231)

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -171,8 +171,9 @@ int ospf6_abr_originate_summary_to_area(struct ospf6_route *route,
 	/* AS External routes are never considered */
 	if (route->path.type == OSPF6_PATH_TYPE_EXTERNAL1
 	    || route->path.type == OSPF6_PATH_TYPE_EXTERNAL2) {
-		if (is_debug)
-			zlog_debug("Path type is external, skip");
+#if 0
+		zlog_debug("Path type is external, skip");
+#endif
 		return 0;
 	}
 


### PR DESCRIPTION
### Summary

The dead code has been disabled with '#if 0', in a similar way to other disabled logs in the same function.

### Components

ospf6d
