### PR TITLE
isisd: null check (Coverity 1424529)

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1050,6 +1050,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 						uint8_t subtlv_len;
 
 						if (IS_MPLS_TE(isisMplsTE)
+						    && circuit->interface
 						    && HAS_LINK_PARAMS(
 							       circuit->interface))
 							subtlv_len = add_te_subtlvs(


### PR DESCRIPTION
### Summary

Null check for covering Coverity issue # 1424529. Done in a similar way to other checks like that in the same function.

### Components

isisd