### PR TITLE
lib: Include compiler.h as early as is possible in the build

### DIFF
--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -379,6 +379,12 @@ struct in_pktinfo {
  */
 #define ZEBRA_HEADER_MARKER              254
 
+/*
+ * The compiler.h header is used for anyone using the CPP_NOTICE
+ * since this is universally needed, let's add it to zebra.h
+ */
+#include "compiler.h"
+
 /* Zebra route's types are defined in route_types.h */
 #include "route_types.h"
 


### PR DESCRIPTION
The compiler.h header provides us with some useful macro's
that we are using in the system.  We do not know exactly
where the CPP_NOTICE and CPP_WARN macros are used but
they can move around.  Place this header early in the
build then.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

