### PR TITLE
doc: correct route map match for prefix lists

### DIFF
--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -105,10 +105,10 @@ Route Map Match Command
 
    Matches the specified `access_list`
 
-.. index:: match ip address PREFIX-LIST
-.. clicmd:: match ip address PREFIX-LIST
+.. index:: match ip address prefix-list PREFIX_LIST
+.. clicmd:: match ip address prefix-list PREFIX_LIST
 
-   Matches the specified `prefix-list`
+   Matches the specified `PREFIX_LIST`
 
 .. index:: match ip address prefix-len 0-32
 .. clicmd:: match ip address prefix-len 0-32
@@ -120,10 +120,10 @@ Route Map Match Command
 
    Matches the specified `access_list`
 
-.. index:: match ipv6 address PREFIX-LIST
-.. clicmd:: match ipv6 address PREFIX-LIST
+.. index:: match ipv6 address prefix-list PREFIX_LIST
+.. clicmd:: match ipv6 address prefix-list PREFIX_LIST
 
-   Matches the specified `prefix-list`
+   Matches the specified `PREFIX_LIST`
 
 .. index:: match ipv6 address prefix-len 0-128
 .. clicmd:: match ipv6 address prefix-len 0-128


### PR DESCRIPTION
### Summary
This corrects the route map documentation to add the missing "prefix-list"
keyword, which is necessary when matching against a prefix list (as opposed to
an access list).

Additionally, change hyphens for underscores in the variables the user is
supposed to substitute in those commands, to prevent any confusion with the
"prefix-list" keyword itself, and also to make it more consistent with the
other documented commands (which are already using underscores).

### Related Issue
N/A

### Components
doc

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
