### PR TITLE
Feature: BFD for IS-IS

### DIFF
--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -114,6 +114,7 @@ void isis_delete_adj(void *adj);
 void isis_adj_process_threeway(struct isis_adjacency *adj,
 			       struct isis_threeway_adj *tw_adj,
 			       enum isis_adj_usage adj_usage);
+DECLARE_HOOK(isis_adj_state_change_hook, (struct isis_adjacency *adj), (adj))
 void isis_adj_state_change(struct isis_adjacency *adj,
 			   enum isis_adj_state state, const char *reason);
 void isis_adj_print(struct isis_adjacency *adj);

--- a/isisd/isis_adjacency.h
+++ b/isisd/isis_adjacency.h
@@ -68,6 +68,8 @@ struct isis_dis_record {
 	time_t last_dis_change; /* timestamp for last dis change */
 };
 
+struct bfd_session;
+
 struct isis_adjacency {
 	uint8_t snpa[ETH_ALEN];		    /* NeighbourSNPAAddress */
 	uint8_t sysid[ISIS_SYS_ID_LEN];     /* neighbourSystemIdentifier */
@@ -100,6 +102,7 @@ struct isis_adjacency {
 	struct isis_circuit *circuit; /* back pointer */
 	uint16_t *mt_set;      /* Topologies this adjacency is valid for */
 	unsigned int mt_count; /* Number of entries in mt_set */
+	struct bfd_session *bfd_session;
 };
 
 struct isis_threeway_adj;

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -70,6 +70,18 @@ static int isis_bfd_nbr_replay(int command, struct zclient *zclient,
 			       zebra_size_t length, vrf_id_t vrf_id)
 {
 	bfd_client_sendmsg(zclient, ZEBRA_BFD_CLIENT_REGISTER);
+
+	struct listnode *anode;
+	struct isis_area *area;
+
+	for (ALL_LIST_ELEMENTS_RO(isis->area_list, anode, area)) {
+		struct listnode *cnode;
+		struct isis_circuit *circuit;
+
+		for (ALL_LIST_ELEMENTS_RO(area->circuit_list, cnode, circuit))
+			isis_bfd_circuit_cmd(circuit, ZEBRA_BFD_DEST_UPDATE);
+	}
+
 	return 0;
 }
 

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -330,14 +330,7 @@ static int bfd_circuit_write_settings(struct isis_circuit *circuit,
 	if (!bfd_info)
 		return 0;
 
-#if HAVE_BFDD == 0
-	if (CHECK_FLAG(bfd_info->flags, BFD_FLAG_PARAM_CFG)) {
-		vty_out(vty, " %s bfd %" PRIu8 " %" PRIu32 " %" PRIu32 "\n",
-			PROTO_NAME, bfd_info->detect_mult,
-			bfd_info->required_min_rx, bfd_info->desired_min_tx);
-	} else
-#endif
-		vty_out(vty, " %s bfd\n", PROTO_NAME);
+	vty_out(vty, " %s bfd\n", PROTO_NAME);
 	return 1;
 }
 

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -1,0 +1,60 @@
+/*
+ * IS-IS Rout(e)ing protocol - BFD support
+ *
+ * Copyright (C) 2018 Christian Franke
+ *
+ * This file is part of FreeRangeRouting (FRR)
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include <zebra.h>
+
+#include "zclient.h"
+#include "bfd.h"
+
+#include "isisd/isis_bfd.h"
+#include "isisd/isis_zebra.h"
+
+static int isis_bfd_interface_dest_update(int command, struct zclient *zclient,
+					  zebra_size_t length, vrf_id_t vrf_id)
+{
+	return 0;
+}
+
+static int isis_bfd_nbr_replay(int command, struct zclient *zclient,
+			       zebra_size_t length, vrf_id_t vrf_id)
+{
+	bfd_client_sendmsg(zclient, ZEBRA_BFD_CLIENT_REGISTER);
+	return 0;
+}
+
+static void (*orig_zebra_connected)(struct zclient *);
+static void isis_bfd_zebra_connected(struct zclient *zclient)
+{
+	if (orig_zebra_connected)
+		orig_zebra_connected(zclient);
+
+	bfd_client_sendmsg(zclient, ZEBRA_BFD_CLIENT_REGISTER);
+}
+
+void isis_bfd_init(void)
+{
+	bfd_gbl_init();
+
+	orig_zebra_connected = zclient->zebra_connected;
+	zclient->zebra_connected = isis_bfd_zebra_connected;
+	zclient->interface_bfd_dest_update = isis_bfd_interface_dest_update;
+	zclient->bfd_dest_replay = isis_bfd_nbr_replay;
+}

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -71,8 +71,8 @@ static void bfd_adj_event(struct isis_adjacency *adj, struct prefix *dst,
 		return;
 
 	int old_status = adj->bfd_session->status;
-	adj->bfd_session->status = new_status;
 
+	adj->bfd_session->status = new_status;
 	if (old_status == new_status)
 		return;
 
@@ -108,6 +108,7 @@ static int isis_bfd_interface_dest_update(int command, struct zclient *zclient,
 
 	if (isis->debugs & DEBUG_BFD) {
 		char dst_buf[INET6_ADDRSTRLEN];
+
 		inet_ntop(AF_INET, &dst_ip.u.prefix4,
 			  dst_buf, sizeof(dst_buf));
 
@@ -116,6 +117,7 @@ static int isis_bfd_interface_dest_update(int command, struct zclient *zclient,
 	}
 
 	struct isis_circuit *circuit = circuit_scan_by_ifp(ifp);
+
 	if (!circuit)
 		return 0;
 
@@ -236,6 +238,7 @@ static void bfd_handle_adj_up(struct isis_adjacency *adj, int command)
 		goto out;
 
 	struct list *local_ips = fabricd_ip_addrs(adj->circuit);
+
 	if (!local_ips)
 		goto out;
 
@@ -296,6 +299,7 @@ void isis_bfd_circuit_cmd(struct isis_circuit *circuit, int command)
 
 			struct listnode *node;
 			struct isis_adjacency *adj;
+
 			for (ALL_LIST_ELEMENTS_RO(adjdb, node, adj))
 				bfd_adj_cmd(adj, command);
 		}

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -26,6 +26,11 @@
 
 #include "isisd/isis_bfd.h"
 #include "isisd/isis_zebra.h"
+#include "isisd/isis_common.h"
+#include "isisd/isis_constants.h"
+#include "isisd/isis_adjacency.h"
+#include "isisd/isis_circuit.h"
+#include "isisd/fabricd.h"
 
 static int isis_bfd_interface_dest_update(int command, struct zclient *zclient,
 					  zebra_size_t length, vrf_id_t vrf_id)
@@ -47,6 +52,24 @@ static void isis_bfd_zebra_connected(struct zclient *zclient)
 		orig_zebra_connected(zclient);
 
 	bfd_client_sendmsg(zclient, ZEBRA_BFD_CLIENT_REGISTER);
+}
+
+void isis_bfd_circuit_cmd(struct isis_circuit *circuit, int command)
+{
+	return;
+}
+
+void isis_bfd_circuit_param_set(struct isis_circuit *circuit,
+				uint32_t min_rx, uint32_t min_tx,
+				uint32_t detect_mult, int defaults)
+{
+	int command = 0;
+
+	bfd_set_param(&circuit->bfd_info, min_rx,
+		      min_tx, detect_mult, defaults, &command);
+
+	if (command)
+		isis_bfd_circuit_cmd(circuit, command);
 }
 
 void isis_bfd_init(void)

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -1,19 +1,16 @@
 /*
  * IS-IS Rout(e)ing protocol - BFD support
- *
  * Copyright (C) 2018 Christian Franke
  *
- * This file is part of FreeRangeRouting (FRR)
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; see the file COPYING; if not, write to the Free Software

--- a/isisd/isis_bfd.h
+++ b/isisd/isis_bfd.h
@@ -22,6 +22,12 @@
 #ifndef ISIS_BFD_H
 #define ISIS_BFD_H
 
+struct isis_circuit;
+
+void isis_bfd_circuit_cmd(struct isis_circuit *circuit, int command);
+void isis_bfd_circuit_param_set(struct isis_circuit *circuit,
+				uint32_t min_rx, uint32_t min_tx,
+				uint32_t detect_mult, int defaults);
 void isis_bfd_init(void);
 
 #endif

--- a/isisd/isis_bfd.h
+++ b/isisd/isis_bfd.h
@@ -1,0 +1,28 @@
+/*
+ * IS-IS Rout(e)ing protocol - BFD support
+ *
+ * Copyright (C) 2018 Christian Franke
+ *
+ * This file is part of FreeRangeRouting (FRR)
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef ISIS_BFD_H
+#define ISIS_BFD_H
+
+void isis_bfd_init(void);
+
+#endif
+

--- a/isisd/isis_bfd.h
+++ b/isisd/isis_bfd.h
@@ -1,19 +1,16 @@
 /*
  * IS-IS Rout(e)ing protocol - BFD support
- *
  * Copyright (C) 2018 Christian Franke
  *
- * This file is part of FreeRangeRouting (FRR)
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- * FRR is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2, or (at your option) any
- * later version.
- *
- * FRR is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; see the file COPYING; if not, write to the Free Software

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -924,6 +924,10 @@ void isis_circuit_print_vty(struct isis_circuit *circuit, struct vty *vty,
 	return;
 }
 
+DEFINE_HOOK(isis_circuit_config_write,
+	    (struct isis_circuit *circuit, struct vty *vty),
+	    (circuit, vty))
+
 int isis_interface_config_write(struct vty *vty)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
@@ -1138,7 +1142,7 @@ int isis_interface_config_write(struct vty *vty)
 					circuit->passwd.passwd);
 				write++;
 			}
-			write += circuit_write_mt_settings(circuit, vty);
+			write += hook_call(isis_circuit_config_write, circuit, vty);
 		}
 		vty_endframe(vty, "!\n");
 	}

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1142,7 +1142,8 @@ int isis_interface_config_write(struct vty *vty)
 					circuit->passwd.passwd);
 				write++;
 			}
-			write += hook_call(isis_circuit_config_write, circuit, vty);
+			write += hook_call(isis_circuit_config_write,
+					   circuit, vty);
 		}
 		vty_endframe(vty, "!\n");
 	}

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -193,4 +193,8 @@ ferr_r isis_circuit_passwd_hmac_md5_set(struct isis_circuit *circuit,
 int isis_circuit_mt_enabled_set(struct isis_circuit *circuit, uint16_t mtid,
 				bool enabled);
 
+DECLARE_HOOK(isis_circuit_config_write,
+	    (struct isis_circuit *circuit, struct vty *vty),
+	    (circuit, vty))
+
 #endif /* _ZEBRA_ISIS_CIRCUIT_H */

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -65,6 +65,8 @@ struct isis_p2p_info {
 	struct thread *t_send_p2p_hello; /* send P2P IIHs in this thread  */
 };
 
+struct bfd_info;
+
 struct isis_circuit {
 	int state;
 	uint8_t circuit_id;	  /* l1/l2 bcast CircuitID */
@@ -127,6 +129,7 @@ struct isis_circuit {
 #define ISIS_CIRCUIT_FLAPPED_AFTER_SPF 0x01
 	uint8_t flags;
 	bool disable_threeway_adj;
+	struct bfd_info *bfd_info;
 	/*
 	 * Counters as in 10589--11.2.5.9
 	 */

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -216,25 +216,6 @@ void isis_circuit_is_type_set(struct isis_circuit *circuit, int newtype)
  *
  * ***********************************************************************/
 
-void isis_event_adjacency_state_change(struct isis_adjacency *adj, int newstate)
-{
-	/* adjacency state change event.
-	 * - the only proto-type was supported */
-
-	/* invalid arguments */
-	if (!adj || !adj->circuit || !adj->circuit->area)
-		return;
-
-	if (isis->debugs & DEBUG_EVENTS)
-		zlog_debug("ISIS-Evt (%s) Adjacency State change",
-			   adj->circuit->area->area_tag);
-
-	/* LSP generation again */
-	lsp_regenerate_schedule(adj->circuit->area, IS_LEVEL_1 | IS_LEVEL_2, 0);
-
-	return;
-}
-
 /* events supporting code */
 
 int isis_event_dis_status_change(struct thread *thread)

--- a/isisd/isis_events.h
+++ b/isisd/isis_events.h
@@ -31,9 +31,6 @@ void isis_event_circuit_type_change(struct isis_circuit *circuit, int newtype);
 /*
  * Events related to adjacencies
  */
-void isis_event_adjacency_state_change(struct isis_adjacency *adj,
-				       int newstate);
-
 int isis_event_dis_status_change(struct thread *thread);
 
 /*

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1997,3 +1997,15 @@ void lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit)
 		fabricd_lsp_flood(lsp);
 	}
 }
+
+static int lsp_handle_adj_state_change(struct isis_adjacency *adj)
+{
+	lsp_regenerate_schedule(adj->circuit->area, IS_LEVEL_1 | IS_LEVEL_2, 0);
+	return 0;
+}
+
+void lsp_init(void)
+{
+	hook_register(isis_adj_state_change_hook,
+		      lsp_handle_adj_state_change);
+}

--- a/isisd/isis_lsp.h
+++ b/isisd/isis_lsp.h
@@ -101,5 +101,6 @@ int lsp_print_all(struct vty *vty, dict_t *lspdb, char detail, char dynhost);
 /* sets SRMflags for all active circuits of an lsp */
 void lsp_set_all_srmflags(struct isis_lsp *lsp, bool set);
 void lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit);
+void lsp_init(void);
 
 #endif /* ISIS_LSP */

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -56,6 +56,7 @@
 #include "isisd/isis_errors.h"
 #include "isisd/isis_vty_common.h"
 #include "isisd/isis_bfd.h"
+#include "isisd/isis_lsp.h"
 
 /* Default configuration file name */
 #define ISISD_DEFAULT_CONFIG "isisd.conf"
@@ -214,6 +215,7 @@ int main(int argc, char **argv, char **envp)
 	isis_redist_init();
 	isis_route_map_init();
 	isis_mpls_te_init();
+	lsp_init();
 
 	/* create the global 'isis' instance */
 	isis_new(1);

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -57,6 +57,7 @@
 #include "isisd/isis_vty_common.h"
 #include "isisd/isis_bfd.h"
 #include "isisd/isis_lsp.h"
+#include "isisd/isis_mt.h"
 
 /* Default configuration file name */
 #define ISISD_DEFAULT_CONFIG "isisd.conf"
@@ -216,6 +217,7 @@ int main(int argc, char **argv, char **envp)
 	isis_route_map_init();
 	isis_mpls_te_init();
 	lsp_init();
+	mt_init();
 
 	/* create the global 'isis' instance */
 	isis_new(1);

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -55,6 +55,7 @@
 #include "isisd/isis_te.h"
 #include "isisd/isis_errors.h"
 #include "isisd/isis_vty_common.h"
+#include "isisd/isis_bfd.h"
 
 /* Default configuration file name */
 #define ISISD_DEFAULT_CONFIG "isisd.conf"
@@ -218,6 +219,7 @@ int main(int argc, char **argv, char **envp)
 	isis_new(1);
 
 	isis_zebra_init(master);
+	isis_bfd_init();
 
 	frr_config_fork();
 	frr_run(master);

--- a/isisd/isis_mt.c
+++ b/isisd/isis_mt.c
@@ -302,7 +302,7 @@ circuit_get_mt_setting(struct isis_circuit *circuit, uint16_t mtid)
 	return setting;
 }
 
-int circuit_write_mt_settings(struct isis_circuit *circuit, struct vty *vty)
+static int circuit_write_mt_settings(struct isis_circuit *circuit, struct vty *vty)
 {
 	int written = 0;
 	struct listnode *node;
@@ -550,4 +550,10 @@ void tlvs_add_mt_p2p(struct isis_tlvs *tlvs, struct isis_circuit *circuit,
 
 	tlvs_add_mt_set(circuit->area, tlvs, adj->mt_count, adj->mt_set, id,
 			metric, subtlvs, subtlv_len);
+}
+
+void mt_init(void)
+{
+	hook_register(isis_circuit_config_write,
+		      circuit_write_mt_settings);
 }

--- a/isisd/isis_mt.c
+++ b/isisd/isis_mt.c
@@ -302,7 +302,8 @@ circuit_get_mt_setting(struct isis_circuit *circuit, uint16_t mtid)
 	return setting;
 }
 
-static int circuit_write_mt_settings(struct isis_circuit *circuit, struct vty *vty)
+static int circuit_write_mt_settings(struct isis_circuit *circuit,
+				     struct vty *vty)
 {
 	int written = 0;
 	struct listnode *node;

--- a/isisd/isis_mt.h
+++ b/isisd/isis_mt.h
@@ -109,7 +109,6 @@ void circuit_mt_init(struct isis_circuit *circuit);
 void circuit_mt_finish(struct isis_circuit *circuit);
 struct isis_circuit_mt_setting *
 circuit_get_mt_setting(struct isis_circuit *circuit, uint16_t mtid);
-int circuit_write_mt_settings(struct isis_circuit *circuit, struct vty *vty);
 struct isis_circuit_mt_setting **
 circuit_mt_settings(struct isis_circuit *circuit, unsigned int *mt_count);
 bool tlvs_to_adj_mt_set(struct isis_tlvs *tlvs, bool v4_usable, bool v6_usable,
@@ -122,4 +121,5 @@ void tlvs_add_mt_bcast(struct isis_tlvs *tlvs, struct isis_circuit *circuit,
 void tlvs_add_mt_p2p(struct isis_tlvs *tlvs, struct isis_circuit *circuit,
 		     uint8_t *id, uint32_t metric, uint8_t *subtlvs,
 		     uint8_t subtlv_len);
+void mt_init(void);
 #endif

--- a/isisd/isis_vty_common.c
+++ b/isisd/isis_vty_common.c
@@ -521,53 +521,12 @@ DEFUN (isis_bfd,
 	return CMD_SUCCESS;
 }
 
-#if HAVE_BFDD > 0
-DEFUN_HIDDEN (
-#else
-DEFUN (
-#endif
-       isis_bfd_param,
-       isis_bfd_param_cmd,
-       PROTO_NAME " bfd (2-255) (50-60000) (50-60000)",
-       PROTO_HELP
-       "Enable BFD support\n"
-       "Detect Multiplier\n"
-       "Required min receive interval\n"
-       "Desired min transmit interval\n")
-{
-	struct isis_circuit *circuit = isis_circuit_lookup(vty);
-	if (!circuit)
-		return CMD_ERR_NO_MATCH;
-
-	uint32_t rx_val;
-	uint32_t tx_val;
-	uint8_t dm_val;
-	int ret;
-
-	if ((ret = bfd_validate_param(vty, argv[2]->arg, argv[3]->arg,
-				      argv[4]->arg, &dm_val, &rx_val,
-				      &tx_val)) != CMD_SUCCESS)
-		return ret;
-
-	isis_bfd_circuit_param_set(circuit, rx_val, tx_val, dm_val, false);
-	return CMD_SUCCESS;
-}
-
 DEFUN (no_isis_bfd,
        no_isis_bfd_cmd,
-#if HAVE_BFDD > 0
        "no " PROTO_NAME " bfd",
-#else
-       "no " PROTO_NAME " bfd [(2-255) (50-60000) (50-60000)]",
-#endif
        NO_STR
        PROTO_HELP
        "Disables BFD support\n"
-#if HAVE_BFDD == 0
-       "Detect Multiplier\n"
-       "Required min receive interval\n"
-       "Desired min transmit interval\n"
-#endif
 )
 {
 	struct isis_circuit *circuit = isis_circuit_lookup(vty);
@@ -1015,7 +974,6 @@ void isis_vty_init(void)
 	install_element(INTERFACE_NODE, &no_circuit_topology_cmd);
 
 	install_element(INTERFACE_NODE, &isis_bfd_cmd);
-	install_element(INTERFACE_NODE, &isis_bfd_param_cmd);
 	install_element(INTERFACE_NODE, &no_isis_bfd_cmd);
 
 	install_element(ROUTER_NODE, &set_overload_bit_cmd);

--- a/isisd/isis_vty_common.c
+++ b/isisd/isis_vty_common.c
@@ -507,6 +507,7 @@ DEFUN (isis_bfd,
        "Enable BFD support\n")
 {
 	struct isis_circuit *circuit = isis_circuit_lookup(vty);
+
 	if (!circuit)
 		return CMD_ERR_NO_MATCH;
 
@@ -530,6 +531,7 @@ DEFUN (no_isis_bfd,
 )
 {
 	struct isis_circuit *circuit = isis_circuit_lookup(vty);
+
 	if (!circuit)
 		return CMD_ERR_NO_MATCH;
 

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -27,6 +27,8 @@ extern struct zclient *zclient;
 void isis_zebra_init(struct thread_master *);
 void isis_zebra_stop(void);
 
+struct isis_route_info;
+
 void isis_zebra_route_update(struct prefix *prefix,
 			     struct prefix_ipv6 *src_p,
 			     struct isis_route_info *route_info);

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -746,6 +746,8 @@ void print_debug(struct vty *vty, int flags, int onoff)
 		vty_out(vty, "IS-IS LSP scheduling debugging is %s\n", onoffs);
 	if (flags & DEBUG_FABRICD_FLOODING)
 		vty_out(vty, "OpenFabric Flooding debugging is %s\n", onoffs);
+	if (flags & DEBUG_BFD)
+		vty_out(vty, "IS-IS BFD debugging is %s\n", onoffs);
 }
 
 DEFUN_NOSH (show_debugging,
@@ -829,6 +831,10 @@ static int config_write_debug(struct vty *vty)
 	}
 	if (flags & DEBUG_FABRICD_FLOODING) {
 		vty_out(vty, "debug " PROTO_NAME " flooding\n");
+		write++;
+	}
+	if (flags & DEBUG_BFD) {
+		vty_out(vty, "debug " PROTO_NAME " bfd\n");
 		write++;
 	}
 	write += spf_backoff_write_config(vty);
@@ -1210,6 +1216,33 @@ DEFUN (no_debug_isis_lsp_sched,
 {
 	isis->debugs &= ~DEBUG_LSP_SCHED;
 	print_debug(vty, DEBUG_LSP_SCHED, 0);
+
+	return CMD_SUCCESS;
+}
+
+DEFUN (debug_isis_bfd,
+       debug_isis_bfd_cmd,
+       "debug " PROTO_NAME " bfd",
+       DEBUG_STR
+       PROTO_HELP
+       PROTO_NAME " interaction with BFD\n")
+{
+	isis->debugs |= DEBUG_BFD;
+	print_debug(vty, DEBUG_BFD, 1);
+
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_debug_isis_bfd,
+       no_debug_isis_bfd_cmd,
+       "no debug " PROTO_NAME " bfd",
+       NO_STR
+       UNDEBUG_STR
+       PROTO_HELP
+       PROTO_NAME " interaction with BFD\n")
+{
+	isis->debugs &= ~DEBUG_BFD;
+	print_debug(vty, DEBUG_BFD, 0);
 
 	return CMD_SUCCESS;
 }
@@ -2215,6 +2248,8 @@ void isis_init()
 	install_element(ENABLE_NODE, &no_debug_isis_lsp_gen_cmd);
 	install_element(ENABLE_NODE, &debug_isis_lsp_sched_cmd);
 	install_element(ENABLE_NODE, &no_debug_isis_lsp_sched_cmd);
+	install_element(ENABLE_NODE, &debug_isis_bfd_cmd);
+	install_element(ENABLE_NODE, &no_debug_isis_bfd_cmd);
 
 	install_element(CONFIG_NODE, &debug_isis_adj_cmd);
 	install_element(CONFIG_NODE, &no_debug_isis_adj_cmd);
@@ -2244,6 +2279,8 @@ void isis_init()
 	install_element(CONFIG_NODE, &no_debug_isis_lsp_gen_cmd);
 	install_element(CONFIG_NODE, &debug_isis_lsp_sched_cmd);
 	install_element(CONFIG_NODE, &no_debug_isis_lsp_sched_cmd);
+	install_element(CONFIG_NODE, &debug_isis_bfd_cmd);
+	install_element(CONFIG_NODE, &no_debug_isis_bfd_cmd);
 
 	install_element(CONFIG_NODE, &router_isis_cmd);
 	install_element(CONFIG_NODE, &no_router_isis_cmd);

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -211,6 +211,7 @@ extern struct thread_master *master;
 #define DEBUG_LSP_GEN                    (1<<13)
 #define DEBUG_LSP_SCHED                  (1<<14)
 #define DEBUG_FABRICD_FLOODING           (1<<15)
+#define DEBUG_BFD                        (1<<16)
 
 #define lsp_debug(...)                                                         \
 	do {                                                                   \

--- a/isisd/subdir.am
+++ b/isisd/subdir.am
@@ -27,6 +27,7 @@ endif
 noinst_HEADERS += \
 	isisd/dict.h \
 	isisd/isis_adjacency.h \
+	isisd/isis_bfd.h \
 	isisd/isis_circuit.h \
 	isisd/isis_common.h \
 	isisd/isis_constants.h \
@@ -60,6 +61,7 @@ noinst_HEADERS += \
 LIBISIS_SOURCES = \
 	isisd/dict.c \
 	isisd/isis_adjacency.c \
+	isisd/isis_bfd.c \
 	isisd/isis_circuit.c \
 	isisd/isis_csm.c \
 	isisd/isis_dr.c \

--- a/zebra/zebra_ptm.h
+++ b/zebra/zebra_ptm.h
@@ -59,6 +59,13 @@ struct zebra_ptm_cb {
 #define ZEBRA_IF_PTM_ENABLE_ON     1
 #define ZEBRA_IF_PTM_ENABLE_UNSPEC 2
 
+#define IS_BFD_ENABLED_PROTOCOL(protocol) ( \
+	(protocol) == ZEBRA_ROUTE_BGP || \
+	(protocol) == ZEBRA_ROUTE_OSPF || \
+	(protocol) == ZEBRA_ROUTE_OSPF6 || \
+	(protocol) == ZEBRA_ROUTE_PIM \
+)
+
 void zebra_ptm_init(void);
 void zebra_ptm_finish(void);
 int zebra_ptm_connect(struct thread *t);

--- a/zebra/zebra_ptm.h
+++ b/zebra/zebra_ptm.h
@@ -63,7 +63,9 @@ struct zebra_ptm_cb {
 	(protocol) == ZEBRA_ROUTE_BGP || \
 	(protocol) == ZEBRA_ROUTE_OSPF || \
 	(protocol) == ZEBRA_ROUTE_OSPF6 || \
-	(protocol) == ZEBRA_ROUTE_PIM \
+	(protocol) == ZEBRA_ROUTE_ISIS || \
+	(protocol) == ZEBRA_ROUTE_PIM || \
+	(protocol) == ZEBRA_ROUTE_OPENFABRIC \
 )
 
 void zebra_ptm_init(void);

--- a/zebra/zebra_ptm_redistribute.c
+++ b/zebra/zebra_ptm_redistribute.c
@@ -24,6 +24,7 @@
 #include "stream.h"
 #include "zebra/zserv.h"
 #include "zebra/zapi_msg.h"
+#include "zebra/zebra_ptm.h"
 #include "zebra/zebra_ptm_redistribute.h"
 #include "zebra/zebra_memory.h"
 
@@ -76,11 +77,7 @@ void zebra_interface_bfd_update(struct interface *ifp, struct prefix *dp,
 	struct zserv *client;
 
 	for (ALL_LIST_ELEMENTS(zebrad.client_list, node, nnode, client)) {
-		/* Supporting for OSPF, BGP and PIM */
-		if (client->proto != ZEBRA_ROUTE_OSPF
-		    && client->proto != ZEBRA_ROUTE_BGP
-		    && client->proto != ZEBRA_ROUTE_OSPF6
-		    && client->proto != ZEBRA_ROUTE_PIM)
+		if (!IS_BFD_ENABLED_PROTOCOL(client->proto))
 			continue;
 
 		/* Notify to the protocol daemons. */
@@ -110,11 +107,7 @@ void zebra_bfd_peer_replay_req(void)
 	struct zserv *client;
 
 	for (ALL_LIST_ELEMENTS(zebrad.client_list, node, nnode, client)) {
-		/* Supporting for BGP */
-		if ((client->proto != ZEBRA_ROUTE_BGP)
-		    && (client->proto != ZEBRA_ROUTE_OSPF)
-		    && (client->proto != ZEBRA_ROUTE_OSPF6)
-		    && (client->proto != ZEBRA_ROUTE_PIM))
+		if (!IS_BFD_ENABLED_PROTOCOL(client->proto))
 			continue;
 
 		/* Notify to the protocol daemons. */


### PR DESCRIPTION
Add BFD suport to IS-IS.

For all configured neighbors, this will setup BFD sessions via IPv4 and monitor their state.
Whenever a session transistions from up to down, the associated IS-IS adjacency will be torn down as soon as the notification from BFD is received.