### PR TITLE
zebra : VRF aware route map in zebra

### DIFF
--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -95,6 +95,10 @@ zebra_zebra_SOURCES = \
 zebra/zebra_vty_clippy.c: $(CLIPPY_DEPS)
 zebra/zebra_vty.$(OBJEXT): zebra/zebra_vty_clippy.c
 
+
+zebra/zebra_routemap_clippy.c: $(CLIPPY_DEPS)
+zebra/zebra_routemap.$(OBJEXT): zebra/zebra_routemap_clippy.c
+
 noinst_HEADERS += \
 	zebra/connected.h \
 	zebra/debug.h \

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1090,8 +1090,7 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 		zebra_add_rnh_client(rnh, client, type, zvrf_id(zvrf));
 		/* Anything not AF_INET/INET6 has been filtered out above */
 		if (!exist)
-			zebra_evaluate_rnh(zvrf_id(zvrf), p.family, 1, type,
-					   &p);
+			zebra_evaluate_rnh(zvrf, p.family, 1, type, &p);
 	}
 
 stream_failure:

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1901,14 +1901,12 @@ static void meta_queue_process_complete(struct work_queue *dummy)
 			continue;
 
 		zvrf->flags &= ~ZEBRA_VRF_RIB_SCHEDULED;
-		zebra_evaluate_rnh(zvrf_id(zvrf), AF_INET, 0, RNH_NEXTHOP_TYPE,
+		zebra_evaluate_rnh(zvrf, AF_INET, 0, RNH_NEXTHOP_TYPE, NULL);
+		zebra_evaluate_rnh(zvrf, AF_INET, 0, RNH_IMPORT_CHECK_TYPE,
 				   NULL);
-		zebra_evaluate_rnh(zvrf_id(zvrf), AF_INET, 0,
-				   RNH_IMPORT_CHECK_TYPE, NULL);
-		zebra_evaluate_rnh(zvrf_id(zvrf), AF_INET6, 0, RNH_NEXTHOP_TYPE,
+		zebra_evaluate_rnh(zvrf, AF_INET6, 0, RNH_NEXTHOP_TYPE, NULL);
+		zebra_evaluate_rnh(zvrf, AF_INET6, 0, RNH_IMPORT_CHECK_TYPE,
 				   NULL);
-		zebra_evaluate_rnh(zvrf_id(zvrf), AF_INET6, 0,
-				   RNH_IMPORT_CHECK_TYPE, NULL);
 	}
 
 	/* Schedule LSPs for processing, if needed. */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -886,6 +886,8 @@ static unsigned nexthop_active_check(struct route_node *rn,
 	int family;
 	char buf[SRCDEST2STR_BUFFER];
 	const struct prefix *p, *src_p;
+	struct zebra_vrf *zvrf;
+
 	srcdest_rnode_prefixes(rn, &p, &src_p);
 
 	if (rn->p.family == AF_INET)
@@ -949,7 +951,8 @@ static unsigned nexthop_active_check(struct route_node *rn,
 	}
 
 	/* XXX: What exactly do those checks do? Do we support
-	 * e.g. IPv4 routes with IPv6 nexthops or vice versa? */
+	 * e.g. IPv4 routes with IPv6 nexthops or vice versa?
+	 */
 	if (RIB_SYSTEM_ROUTE(re) || (family == AFI_IP && p->family != AF_INET)
 	    || (family == AFI_IP6 && p->family != AF_INET6))
 		return CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
@@ -969,9 +972,16 @@ static unsigned nexthop_active_check(struct route_node *rn,
 
 	memset(&nexthop->rmap_src.ipv6, 0, sizeof(union g_addr));
 
+	zvrf = zebra_vrf_lookup_by_id(nexthop->vrf_id);
+	if (!zvrf) {
+		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+			zlog_debug("\t%s: zvrf is NULL", __PRETTY_FUNCTION__);
+		return CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+	}
+
 	/* It'll get set if required inside */
-	ret = zebra_route_map_check(family, re->type, re->instance, p, nexthop,
-				    nexthop->vrf_id, re->tag);
+	ret = zebra_route_map_check(family, re->type, re->instance, p,
+				    nexthop, zvrf, re->tag);
 	if (ret == RMAP_DENYMATCH) {
 		if (IS_ZEBRA_DEBUG_RIB) {
 			srcdest_rnode2str(rn, buf, sizeof(buf));
@@ -1002,6 +1012,7 @@ static int nexthop_active_update(struct route_node *rn, struct route_entry *re,
 	union g_addr prev_src;
 	unsigned int prev_active, new_active, old_num_nh;
 	ifindex_t prev_index;
+
 	old_num_nh = re->nexthop_active_num;
 
 	re->nexthop_active_num = 0;

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -302,8 +302,10 @@ static int zebra_rnh_apply_nht_rmap(int family, struct route_node *prn,
 	if (prn && re) {
 		for (nexthop = re->ng.nexthop; nexthop;
 		     nexthop = nexthop->next) {
-			ret = zebra_nht_route_map_check(rmap_family, proto,
-							&prn->p, re, nexthop);
+			struct zebra_vrf *zvrf =
+				zebra_vrf_lookup_by_id(nexthop->vrf_id);
+			ret = zebra_nht_route_map_check(
+				rmap_family, proto, &prn->p, zvrf, re, nexthop);
 			if (ret != RMAP_DENYMATCH) {
 				SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 				at_least_one++; /* at least one valid NH */

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -260,13 +260,18 @@ void zebra_register_rnh_pseudowire(vrf_id_t vrf_id, struct zebra_pw *pw)
 	struct prefix nh;
 	struct rnh *rnh;
 	bool exists;
+	struct zebra_vrf *zvrf;
+
+	zvrf = vrf_info_lookup(vrf_id);
+	if (!zvrf)
+		return;
 
 	addr2hostprefix(pw->af, &pw->nexthop, &nh);
 	rnh = zebra_add_rnh(&nh, vrf_id, RNH_NEXTHOP_TYPE, &exists);
 	if (rnh && !listnode_lookup(rnh->zebra_pseudowire_list, pw)) {
 		listnode_add(rnh->zebra_pseudowire_list, pw);
 		pw->rnh = rnh;
-		zebra_evaluate_rnh(vrf_id, pw->af, 1, RNH_NEXTHOP_TYPE, &nh);
+		zebra_evaluate_rnh(zvrf, pw->af, 1, RNH_NEXTHOP_TYPE, &nh);
 	}
 }
 
@@ -289,7 +294,8 @@ void zebra_deregister_rnh_pseudowire(vrf_id_t vrf_id, struct zebra_pw *pw)
 /* Apply the NHT route-map for a client to the route (and nexthops)
  * resolving a NH.
  */
-static int zebra_rnh_apply_nht_rmap(int family, struct route_node *prn,
+static int zebra_rnh_apply_nht_rmap(int family, struct zebra_vrf *zvrf,
+				    struct route_node *prn,
 				    struct route_entry *re, int proto)
 {
 	int at_least_one = 0;
@@ -302,8 +308,6 @@ static int zebra_rnh_apply_nht_rmap(int family, struct route_node *prn,
 	if (prn && re) {
 		for (nexthop = re->ng.nexthop; nexthop;
 		     nexthop = nexthop->next) {
-			struct zebra_vrf *zvrf =
-				zebra_vrf_lookup_by_id(nexthop->vrf_id);
 			ret = zebra_nht_route_map_check(
 				rmap_family, proto, &prn->p, zvrf, re, nexthop);
 			if (ret != RMAP_DENYMATCH) {
@@ -322,7 +326,7 @@ static int zebra_rnh_apply_nht_rmap(int family, struct route_node *prn,
  * for BGP route for import.
  */
 static struct route_entry *
-zebra_rnh_resolve_import_entry(vrf_id_t vrfid, int family,
+zebra_rnh_resolve_import_entry(struct zebra_vrf *zvrf, int family,
 			       struct route_node *nrn, struct rnh *rnh,
 			       struct route_node **prn)
 {
@@ -332,7 +336,7 @@ zebra_rnh_resolve_import_entry(vrf_id_t vrfid, int family,
 
 	*prn = NULL;
 
-	route_table = zebra_vrf_table(family2afi(family), SAFI_UNICAST, vrfid);
+	route_table = zvrf->table[family2afi(family)][SAFI_UNICAST];
 	if (!route_table) // unexpected
 		return NULL;
 
@@ -404,11 +408,9 @@ static void zebra_rnh_eval_import_check_entry(vrf_id_t vrfid, int family,
 /*
  * Notify clients registered for this nexthop about a change.
  */
-static void zebra_rnh_notify_protocol_clients(vrf_id_t vrfid, int family,
-					      struct route_node *nrn,
-					      struct rnh *rnh,
-					      struct route_node *prn,
-					      struct route_entry *re)
+static void zebra_rnh_notify_protocol_clients(
+	struct zebra_vrf *zvrf, int family, struct route_node *nrn,
+	struct rnh *rnh, struct route_node *prn, struct route_entry *re)
 {
 	struct listnode *node;
 	struct zserv *client;
@@ -420,11 +422,11 @@ static void zebra_rnh_notify_protocol_clients(vrf_id_t vrfid, int family,
 		prefix2str(&nrn->p, bufn, INET6_ADDRSTRLEN);
 		if (prn && re) {
 			prefix2str(&prn->p, bufp, INET6_ADDRSTRLEN);
-			zlog_debug("%u:%s: NH resolved over route %s", vrfid,
-				   bufn, bufp);
+			zlog_debug("%u:%s: NH resolved over route %s",
+				   zvrf->vrf->vrf_id, bufn, bufp);
 		} else
-			zlog_debug("%u:%s: NH has become unresolved", vrfid,
-				   bufn);
+			zlog_debug("%u:%s: NH has become unresolved",
+				   zvrf->vrf->vrf_id, bufn);
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(rnh->client_list, node, client)) {
@@ -434,7 +436,7 @@ static void zebra_rnh_notify_protocol_clients(vrf_id_t vrfid, int family,
 			 * nexthop to see if it is filtered or not.
 			 */
 			num_resolving_nh = zebra_rnh_apply_nht_rmap(
-				family, prn, re, client->proto);
+				family, zvrf, prn, re, client->proto);
 			if (num_resolving_nh)
 				rnh->filtered[client->proto] = 0;
 			else
@@ -443,7 +445,7 @@ static void zebra_rnh_notify_protocol_clients(vrf_id_t vrfid, int family,
 			if (IS_ZEBRA_DEBUG_NHT)
 				zlog_debug(
 					"%u:%s: Notifying client %s about NH %s",
-					vrfid, bufn,
+					zvrf->vrf->vrf_id, bufn,
 					zebra_route_string(client->proto),
 					num_resolving_nh
 						? ""
@@ -453,11 +455,11 @@ static void zebra_rnh_notify_protocol_clients(vrf_id_t vrfid, int family,
 			if (IS_ZEBRA_DEBUG_NHT)
 				zlog_debug(
 					"%u:%s: Notifying client %s about NH (unreachable)",
-					vrfid, bufn,
+					zvrf->vrf->vrf_id, bufn,
 					zebra_route_string(client->proto));
 		}
 
-		send_client(rnh, client, RNH_NEXTHOP_TYPE, vrfid);
+		send_client(rnh, client, RNH_NEXTHOP_TYPE, zvrf->vrf->vrf_id);
 	}
 }
 
@@ -521,7 +523,7 @@ static void zebra_rnh_process_pbr_tables(int family,
  * nexthop.
  */
 static struct route_entry *
-zebra_rnh_resolve_nexthop_entry(vrf_id_t vrfid, int family,
+zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, int family,
 				struct route_node *nrn, struct rnh *rnh,
 				struct route_node **prn)
 {
@@ -531,7 +533,7 @@ zebra_rnh_resolve_nexthop_entry(vrf_id_t vrfid, int family,
 
 	*prn = NULL;
 
-	route_table = zebra_vrf_table(family2afi(family), SAFI_UNICAST, vrfid);
+	route_table = zvrf->table[family2afi(family)][SAFI_UNICAST];
 	if (!route_table)
 		return NULL;
 
@@ -608,8 +610,8 @@ static void zebra_rnh_process_pseudowires(vrf_id_t vrfid, struct rnh *rnh)
  * take appropriate action; this involves notifying any clients and/or
  * scheduling dependent static routes for processing.
  */
-static void zebra_rnh_eval_nexthop_entry(vrf_id_t vrfid, int family, int force,
-					 struct route_node *nrn,
+static void zebra_rnh_eval_nexthop_entry(struct zebra_vrf *zvrf, int family,
+					 int force, struct route_node *nrn,
 					 struct rnh *rnh,
 					 struct route_node *prn,
 					 struct route_entry *re)
@@ -638,20 +640,20 @@ static void zebra_rnh_eval_nexthop_entry(vrf_id_t vrfid, int family, int force,
 		 * rnh->state.
 		 */
 		/* Notify registered protocol clients. */
-		zebra_rnh_notify_protocol_clients(vrfid, family, nrn, rnh, prn,
+		zebra_rnh_notify_protocol_clients(zvrf, family, nrn, rnh, prn,
 						  rnh->state);
 
-		zebra_rnh_process_pbr_tables(family, nrn, rnh, prn,
-					     rnh->state);
+		zebra_rnh_process_pbr_tables(family, nrn, rnh, prn, rnh->state);
 
 		/* Process pseudowires attached to this nexthop */
-		zebra_rnh_process_pseudowires(vrfid, rnh);
+		zebra_rnh_process_pseudowires(zvrf->vrf->vrf_id, rnh);
 	}
 }
 
 /* Evaluate one tracked entry */
-static void zebra_rnh_evaluate_entry(vrf_id_t vrfid, int family, int force,
-				     rnh_type_t type, struct route_node *nrn)
+static void zebra_rnh_evaluate_entry(struct zebra_vrf *zvrf, int family,
+				     int force, rnh_type_t type,
+				     struct route_node *nrn)
 {
 	struct rnh *rnh;
 	struct route_entry *re;
@@ -660,18 +662,18 @@ static void zebra_rnh_evaluate_entry(vrf_id_t vrfid, int family, int force,
 
 	if (IS_ZEBRA_DEBUG_NHT) {
 		prefix2str(&nrn->p, bufn, INET6_ADDRSTRLEN);
-		zlog_debug("%u:%s: Evaluate RNH, type %d %s", vrfid, bufn, type,
-			   force ? "(force)" : "");
+		zlog_debug("%u:%s: Evaluate RNH, type %d %s", zvrf->vrf->vrf_id,
+			   bufn, type, force ? "(force)" : "");
 	}
 
 	rnh = nrn->info;
 
 	/* Identify route entry (RE) resolving this tracked entry. */
 	if (type == RNH_IMPORT_CHECK_TYPE)
-		re = zebra_rnh_resolve_import_entry(vrfid, family, nrn, rnh,
+		re = zebra_rnh_resolve_import_entry(zvrf, family, nrn, rnh,
 						    &prn);
 	else
-		re = zebra_rnh_resolve_nexthop_entry(vrfid, family, nrn, rnh,
+		re = zebra_rnh_resolve_nexthop_entry(zvrf, family, nrn, rnh,
 						     &prn);
 
 	/* If the entry cannot be resolved and that is also the existing state,
@@ -682,11 +684,11 @@ static void zebra_rnh_evaluate_entry(vrf_id_t vrfid, int family, int force,
 
 	/* Process based on type of entry. */
 	if (type == RNH_IMPORT_CHECK_TYPE)
-		zebra_rnh_eval_import_check_entry(vrfid, family, force, nrn,
-						  rnh, re);
+		zebra_rnh_eval_import_check_entry(zvrf->vrf->vrf_id, family,
+						  force, nrn, rnh, re);
 	else
-		zebra_rnh_eval_nexthop_entry(vrfid, family, force, nrn, rnh,
-					     prn, re);
+		zebra_rnh_eval_nexthop_entry(zvrf, family, force, nrn, rnh, prn,
+					     re);
 }
 
 /*
@@ -698,7 +700,7 @@ static void zebra_rnh_evaluate_entry(vrf_id_t vrfid, int family, int force,
  * we can have a situation where one re entry
  * covers multiple nexthops we are interested in.
  */
-static void zebra_rnh_clear_nhc_flag(vrf_id_t vrfid, int family,
+static void zebra_rnh_clear_nhc_flag(struct zebra_vrf *zvrf, int family,
 				     rnh_type_t type, struct route_node *nrn)
 {
 	struct rnh *rnh;
@@ -709,10 +711,10 @@ static void zebra_rnh_clear_nhc_flag(vrf_id_t vrfid, int family,
 
 	/* Identify route entry (RIB) resolving this tracked entry. */
 	if (type == RNH_IMPORT_CHECK_TYPE)
-		re = zebra_rnh_resolve_import_entry(vrfid, family, nrn, rnh,
+		re = zebra_rnh_resolve_import_entry(zvrf, family, nrn, rnh,
 						    &prn);
 	else
-		re = zebra_rnh_resolve_nexthop_entry(vrfid, family, nrn, rnh,
+		re = zebra_rnh_resolve_nexthop_entry(zvrf, family, nrn, rnh,
 						     &prn);
 
 	if (re) {
@@ -724,13 +726,13 @@ static void zebra_rnh_clear_nhc_flag(vrf_id_t vrfid, int family,
 /* Evaluate all tracked entries (nexthops or routes for import into BGP)
  * of a particular VRF and address-family or a specific prefix.
  */
-void zebra_evaluate_rnh(vrf_id_t vrfid, int family, int force, rnh_type_t type,
-			struct prefix *p)
+void zebra_evaluate_rnh(struct zebra_vrf *zvrf, int family, int force,
+			rnh_type_t type, struct prefix *p)
 {
 	struct route_table *rnh_table;
 	struct route_node *nrn;
 
-	rnh_table = get_rnh_table(vrfid, family, type);
+	rnh_table = get_rnh_table(zvrf->vrf->vrf_id, family, type);
 	if (!rnh_table) // unexpected
 		return;
 
@@ -738,7 +740,7 @@ void zebra_evaluate_rnh(vrf_id_t vrfid, int family, int force, rnh_type_t type,
 		/* Evaluating a specific entry, make sure it exists. */
 		nrn = route_node_lookup(rnh_table, p);
 		if (nrn && nrn->info)
-			zebra_rnh_evaluate_entry(vrfid, family, force, type,
+			zebra_rnh_evaluate_entry(zvrf, family, force, type,
 						 nrn);
 
 		if (nrn)
@@ -748,14 +750,14 @@ void zebra_evaluate_rnh(vrf_id_t vrfid, int family, int force, rnh_type_t type,
 		nrn = route_top(rnh_table);
 		while (nrn) {
 			if (nrn->info)
-				zebra_rnh_evaluate_entry(vrfid, family, force,
+				zebra_rnh_evaluate_entry(zvrf, family, force,
 							 type, nrn);
 			nrn = route_next(nrn); /* this will also unlock nrn */
 		}
 		nrn = route_top(rnh_table);
 		while (nrn) {
 			if (nrn->info)
-				zebra_rnh_clear_nhc_flag(vrfid, family, type,
+				zebra_rnh_clear_nhc_flag(zvrf, family, type,
 							 nrn);
 			nrn = route_next(nrn); /* this will also unlock nrn */
 		}

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -79,7 +79,7 @@ extern void zebra_register_rnh_pseudowire(vrf_id_t, struct zebra_pw *);
 extern void zebra_deregister_rnh_pseudowire(vrf_id_t, struct zebra_pw *);
 extern void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client,
 				    rnh_type_t type);
-extern void zebra_evaluate_rnh(vrf_id_t vrfid, int family, int force,
+extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, int family, int force,
 			       rnh_type_t type, struct prefix *p);
 extern void zebra_print_rnh_table(vrf_id_t vrfid, int family, struct vty *vty,
 				  rnh_type_t);

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -713,8 +713,13 @@ DEFUN (ip_protocol_nht_rmap,
 		XFREE(MTYPE_ROUTE_MAP_NAME, nht_rm[AFI_IP][i]);
 	}
 
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+	if (!zvrf)
+		return CMD_WARNING;
+
 	nht_rm[AFI_IP][i] = XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap);
-	zebra_evaluate_rnh(0, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(zvrf, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
 
 	return CMD_SUCCESS;
 }
@@ -745,10 +750,15 @@ DEFUN (no_ip_protocol_nht_rmap,
 	if (!nht_rm[AFI_IP][i])
 		return CMD_SUCCESS;
 
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+	if (!zvrf)
+		return CMD_WARNING;
+
 	if (!rmap || strcmp(rmap, nht_rm[AFI_IP][i]) == 0) {
 		XFREE(MTYPE_ROUTE_MAP_NAME, nht_rm[AFI_IP][i]);
 		nht_rm[AFI_IP][i] = NULL;
-		zebra_evaluate_rnh(0, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
+		zebra_evaluate_rnh(zvrf, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
 	}
 	return CMD_SUCCESS;
 }
@@ -801,10 +811,16 @@ DEFUN (ipv6_protocol_nht_rmap,
 		vty_out(vty, "invalid protocol name \"%s\"\n", proto);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+	if (!zvrf)
+		return CMD_WARNING;
+
 	if (nht_rm[AFI_IP6][i])
 		XFREE(MTYPE_ROUTE_MAP_NAME, nht_rm[AFI_IP6][i]);
 	nht_rm[AFI_IP6][i] = XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap);
-	zebra_evaluate_rnh(0, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(zvrf, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
 
 	return CMD_SUCCESS;
 }
@@ -841,8 +857,12 @@ DEFUN (no_ipv6_protocol_nht_rmap,
 		XFREE(MTYPE_ROUTE_MAP_NAME, nht_rm[AFI_IP6][i]);
 		nht_rm[AFI_IP6][i] = NULL;
 	}
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
 
-	zebra_evaluate_rnh(0, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
+	if (!zvrf)
+		return CMD_WARNING;
+
+	zebra_evaluate_rnh(zvrf, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
 
 	return CMD_SUCCESS;
 }
@@ -1411,8 +1431,7 @@ static void zebra_nht_rm_update(const char *rmap)
 						afi_ip = 1;
 
 						zebra_evaluate_rnh(
-							zvrf->vrf->vrf_id,
-							AF_INET, 1,
+							zvrf, AF_INET, 1,
 							RNH_NEXTHOP_TYPE, NULL);
 					}
 				}
@@ -1438,8 +1457,7 @@ static void zebra_nht_rm_update(const char *rmap)
 						afi_ipv6 = 1;
 
 						zebra_evaluate_rnh(
-							zvrf->vrf->vrf_id,
-							AF_INET, 1,
+							zvrf, AF_INET, 1,
 							RNH_NEXTHOP_TYPE, NULL);
 					}
 				}

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -25,7 +25,8 @@
 #include "lib/routemap.h"
 
 extern void zebra_route_map_init(void);
-extern void zebra_routemap_config_write_protocol(struct vty *vty);
+extern void zebra_routemap_config_write_protocol(struct vty *vty,
+						 struct zebra_vrf *vrf);
 extern char *zebra_get_import_table_route_map(afi_t afi, uint32_t table);
 extern void zebra_add_import_table_route_map(afi_t afi, const char *rmap_name,
 					     uint32_t table);
@@ -36,9 +37,8 @@ extern void zebra_route_map_write_delay_timer(struct vty *);
 extern route_map_result_t
 zebra_import_table_route_map_check(int family, int rib_type, uint8_t instance,
 				   const struct prefix *p,
-				   struct nexthop *nexthop,
-				   vrf_id_t vrf_id, route_tag_t tag,
-				   const char *rmap_name);
+				   struct nexthop *nexthop, vrf_id_t vrf_id,
+				   route_tag_t tag, const char *rmap_name);
 extern route_map_result_t
 zebra_route_map_check(int family, int rib_type, uint8_t instance,
 		      const struct prefix *p, struct nexthop *nexthop,

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -42,10 +42,10 @@ zebra_import_table_route_map_check(int family, int rib_type, uint8_t instance,
 extern route_map_result_t
 zebra_route_map_check(int family, int rib_type, uint8_t instance,
 		      const struct prefix *p, struct nexthop *nexthop,
-		      vrf_id_t vrf_id, route_tag_t tag);
+		      struct zebra_vrf *zvrf, route_tag_t tag);
 extern route_map_result_t
 zebra_nht_route_map_check(int family, int client_proto, const struct prefix *p,
-			  struct route_entry *, struct nexthop *nexthop);
-
+			  struct zebra_vrf *zvrf, struct route_entry *,
+			  struct nexthop *nexthop);
 
 #endif

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -39,6 +39,7 @@
 #include "zebra/zebra_mpls.h"
 #include "zebra/zebra_vxlan.h"
 #include "zebra/zebra_netns_notify.h"
+#include "zebra/zebra_routemap.h"
 
 extern struct zebra_t zebrad;
 
@@ -481,7 +482,6 @@ static int vrf_config_write(struct vty *vty)
 		if (zvrf_id(zvrf) == VRF_DEFAULT) {
 			if (zvrf->l3vni)
 				vty_out(vty, "vni %u\n", zvrf->l3vni);
-			vty_out(vty, "!\n");
 		} else {
 			vty_frame(vty, "vrf %s\n", zvrf_name(zvrf));
 			if (zvrf->l3vni)
@@ -491,11 +491,14 @@ static int vrf_config_write(struct vty *vty)
 						? " prefix-routes-only"
 						: "");
 			zebra_ns_config_write(vty, (struct ns *)vrf->ns_ctxt);
-
 		}
+
+		zebra_routemap_config_write_protocol(vty, zvrf);
 
 		if (zvrf_id(zvrf) != VRF_DEFAULT)
 			vty_endframe(vty, " exit-vrf\n!\n");
+		else
+			vty_out(vty, "!\n");
 	}
 	return 0;
 }

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -32,6 +32,11 @@ typedef struct mpls_srgb_t_ {
 	uint32_t end_label;
 } mpls_srgb_t;
 
+struct zebra_rmap {
+	char *name;
+	struct route_map *map;
+};
+
 /* Routing table instance.  */
 struct zebra_vrf {
 	/* Back pointer */
@@ -92,6 +97,9 @@ struct zebra_vrf {
 	struct zebra_pw_head pseudowires;
 	struct zebra_static_pw_head static_pseudowires;
 
+	struct zebra_rmap proto_rm[AFI_MAX][ZEBRA_ROUTE_MAX + 1];
+	struct zebra_rmap nht_rm[AFI_MAX][ZEBRA_ROUTE_MAX + 1];
+
 	/* MPLS processing flags */
 	uint16_t mpls_flags;
 #define MPLS_FLAG_SCHEDULE_LSPS    (1 << 0)
@@ -122,6 +130,10 @@ struct zebra_vrf {
 	uint64_t lsp_installs;
 	uint64_t lsp_removals;
 };
+#define PROTO_RM_NAME(zvrf, afi, rtype) zvrf->proto_rm[afi][rtype].name
+#define NHT_RM_NAME(zvrf, afi, rtype) zvrf->nht_rm[afi][rtype].name
+#define PROTO_RM_MAP(zvrf, afi, rtype) zvrf->proto_rm[afi][rtype].map
+#define NHT_RM_MAP(zvrf, afi, rtype) zvrf->nht_rm[afi][rtype].map
 
 static inline vrf_id_t zvrf_id(struct zebra_vrf *zvrf)
 {

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -135,6 +135,13 @@ struct zebra_vrf {
 #define PROTO_RM_MAP(zvrf, afi, rtype) zvrf->proto_rm[afi][rtype].map
 #define NHT_RM_MAP(zvrf, afi, rtype) zvrf->nht_rm[afi][rtype].map
 
+/*
+ * special macro to allow us to get the correct zebra_vrf
+ */
+#define ZEBRA_DECLVAR_CONTEXT(A, B)                                            \
+	struct vrf *A = VTY_GET_CONTEXT(vrf);                                  \
+	struct zebra_vrf *B = (A) ? A->info : vrf_info_lookup(VRF_DEFAULT)
+
 static inline vrf_id_t zvrf_id(struct zebra_vrf *zvrf)
 {
 	if (!zvrf || !zvrf->vrf)

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1030,8 +1030,13 @@ DEFUN (ip_nht_default_route,
 	if (zebra_rnh_ip_default_route)
 		return CMD_SUCCESS;
 
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+	if (!zvrf)
+		return CMD_WARNING;
+
 	zebra_rnh_ip_default_route = 1;
-	zebra_evaluate_rnh(VRF_DEFAULT, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(zvrf, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
 	return CMD_SUCCESS;
 }
 
@@ -1046,8 +1051,13 @@ DEFUN (no_ip_nht_default_route,
 	if (!zebra_rnh_ip_default_route)
 		return CMD_SUCCESS;
 
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+	if (!zvrf)
+		return CMD_WARNING;
+
 	zebra_rnh_ip_default_route = 0;
-	zebra_evaluate_rnh(VRF_DEFAULT, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(zvrf, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
 	return CMD_SUCCESS;
 }
 
@@ -1061,8 +1071,13 @@ DEFUN (ipv6_nht_default_route,
 	if (zebra_rnh_ipv6_default_route)
 		return CMD_SUCCESS;
 
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+	if (!zvrf)
+		return CMD_WARNING;
+
 	zebra_rnh_ipv6_default_route = 1;
-	zebra_evaluate_rnh(VRF_DEFAULT, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(zvrf, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
 	return CMD_SUCCESS;
 }
 
@@ -1077,8 +1092,13 @@ DEFUN (no_ipv6_nht_default_route,
 	if (!zebra_rnh_ipv6_default_route)
 		return CMD_SUCCESS;
 
+	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+	if (!zvrf)
+		return CMD_WARNING;
+
 	zebra_rnh_ipv6_default_route = 0;
-	zebra_evaluate_rnh(VRF_DEFAULT, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
+	zebra_evaluate_rnh(zvrf, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
 	return CMD_SUCCESS;
 }
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2374,9 +2374,6 @@ static int config_write_protocol(struct vty *vty)
 								      == MCAST_MIX_DISTANCE
 							      ? "lower-distance"
 							      : "longer-prefix");
-
-	zebra_routemap_config_write_protocol(vty);
-
 	return 1;
 }
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -67,13 +67,6 @@ static void vty_show_ip_route_summary(struct vty *vty,
 static void vty_show_ip_route_summary_prefix(struct vty *vty,
 					     struct route_table *table);
 
-/*
- * special macro to allow us to get the correct zebra_vrf
- */
-#define ZEBRA_DECLVAR_CONTEXT(A, B)                                            \
-	struct vrf *A = VTY_GET_CONTEXT(vrf);                                  \
-	struct zebra_vrf *B = (vrf) ? vrf->info : NULL;
-
 /* VNI range as per RFC 7432 */
 #define CMD_VNI_RANGE "(1-16777215)"
 
@@ -1027,15 +1020,16 @@ DEFUN (ip_nht_default_route,
        "Filter Next Hop tracking route resolution\n"
        "Resolve via default route\n")
 {
-	if (zebra_rnh_ip_default_route)
-		return CMD_SUCCESS;
-
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
 
+	if (zebra_rnh_ip_default_route)
+		return CMD_SUCCESS;
+
 	zebra_rnh_ip_default_route = 1;
+
 	zebra_evaluate_rnh(zvrf, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
 	return CMD_SUCCESS;
 }
@@ -1048,13 +1042,13 @@ DEFUN (no_ip_nht_default_route,
        "Filter Next Hop tracking route resolution\n"
        "Resolve via default route\n")
 {
-	if (!zebra_rnh_ip_default_route)
-		return CMD_SUCCESS;
-
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
+
+	if (!zebra_rnh_ip_default_route)
+		return CMD_SUCCESS;
 
 	zebra_rnh_ip_default_route = 0;
 	zebra_evaluate_rnh(zvrf, AF_INET, 1, RNH_NEXTHOP_TYPE, NULL);
@@ -1068,13 +1062,13 @@ DEFUN (ipv6_nht_default_route,
        "Filter Next Hop tracking route resolution\n"
        "Resolve via default route\n")
 {
-	if (zebra_rnh_ipv6_default_route)
-		return CMD_SUCCESS;
-
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
+
+	if (zebra_rnh_ipv6_default_route)
+		return CMD_SUCCESS;
 
 	zebra_rnh_ipv6_default_route = 1;
 	zebra_evaluate_rnh(zvrf, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
@@ -1089,13 +1083,14 @@ DEFUN (no_ipv6_nht_default_route,
        "Filter Next Hop tracking route resolution\n"
        "Resolve via default route\n")
 {
-	if (!zebra_rnh_ipv6_default_route)
-		return CMD_SUCCESS;
 
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+	ZEBRA_DECLVAR_CONTEXT(vrf, zvrf);
 
 	if (!zvrf)
 		return CMD_WARNING;
+
+	if (!zebra_rnh_ipv6_default_route)
+		return CMD_SUCCESS;
 
 	zebra_rnh_ipv6_default_route = 0;
 	zebra_evaluate_rnh(zvrf, AF_INET6, 1, RNH_NEXTHOP_TYPE, NULL);
@@ -2669,6 +2664,10 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &no_ip_nht_default_route_cmd);
 	install_element(CONFIG_NODE, &ipv6_nht_default_route_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_nht_default_route_cmd);
+	install_element(VRF_NODE, &ip_nht_default_route_cmd);
+	install_element(VRF_NODE, &no_ip_nht_default_route_cmd);
+	install_element(VRF_NODE, &ipv6_nht_default_route_cmd);
+	install_element(VRF_NODE, &no_ipv6_nht_default_route_cmd);
 	install_element(VIEW_NODE, &show_ipv6_mroute_cmd);
 
 	/* Commands for VRF */


### PR DESCRIPTION
### Summary
There are three types of route maps available in ZEBRA

IP Protocol : It is per address family and per protocol
use case To make the routes policy based from protocol to FIB, i.e zebra allow/disallow routes from protocol to FIB. It is from ZEBRA to FIB.
ip nht : It is per address family and per protocol
use case If next hop trigger (UP/Down) comes from kernel then Zebra send the policy based updates to protocol clients, i.e if next hop goes down then zebra sends the updates to protocols based on route maps. It is from Zebra to Protocols
ip tables : It is per address family and max kernel tables.
use case It is used to import the routes from a particular table to default vrf table
Now 1st and 2nd route maps are not per VRF based, currently we are passing default VRF for further handling.
3rd Route map is already VRF aware, so there will be no change in that

### Related Issue
https://github.com/FRRouting/frr/issues/2802

### Components
zebra

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
