### PR TITLE
ospfd: default route got flushed after lsa refresh timer.

### DIFF
--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -91,7 +91,7 @@ struct external_info *ospf_external_info_check(struct ospf *ospf,
 	p.prefix = lsa->data->id;
 	p.prefixlen = ip_masklen(al->mask);
 
-	for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
+	for (type = 0; type <= ZEBRA_ROUTE_MAX; type++) {
 		int redist_on = 0;
 
 		redist_on =


### PR DESCRIPTION
### Summary
While originating a default route from ospf, ZEBRA_ROUTE_MAX(default_route) is used to update the external info list and other ospf specific lists. 
Upon lsa refresh timer expiry  , it is not being validated against default_route (type = ZEBRA_ROUTE_MAX) while processing this event.
So it is  fail to get the external info which makes it to trigger flush for this route from lsdb.
Added an appropriate fix to make it validate for default route as well.

Signed-off-by: rgirada <rgirada@vmware.com>

### Related Issue
[3014](https://github.com/FRRouting/frr/issues/3124)
### Components
ospfd

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html