### PR TITLE
bgp route ip leak using route-map

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -221,6 +221,7 @@ struct attr {
 #define BATTR_RMAP_IPV6_GLOBAL_NHOP_CHANGED (1 << 4)
 #define BATTR_RMAP_IPV6_LL_NHOP_CHANGED (1 << 5)
 #define BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED (1 << 6)
+#define BATTR_RMAP_VRF_NHOP_CHANGED (1 << 7)
 
 /* Router Reflector related structure. */
 struct cluster_list {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -172,6 +172,7 @@ static struct bgp_info_extra *bgp_info_extra_new(void)
 	new->label[0] = MPLS_INVALID_LABEL;
 	new->num_labels = 0;
 	new->vrf_id = VRF_UNKNOWN;
+	new->vrf_id_local = FALSE;
 	return new;
 }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -176,7 +176,7 @@ static struct bgp_info_extra *bgp_info_extra_new(void)
 	return new;
 }
 
-static void bgp_info_extra_free(struct bgp_info_extra **extra)
+void bgp_info_extra_free(struct bgp_info_extra **extra)
 {
 	struct bgp_info_extra *e;
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -139,7 +139,10 @@ struct bgp_info_extra {
 	 * Set to NULL if route is not imported from another bgp instance.
 	 */
 	struct bgp *bgp_orig;
-
+	/* set to VRF_UNKNOWN by default
+	 * this value will be overriden if route-map overrides vrf_id value
+	 */
+	vrf_id_t vrf_id;
 	/*
 	 * Nexthop in context of original bgp instance. Needed
 	 * for label resolution of core mpls routes exported to a vrf.

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -143,6 +143,7 @@ struct bgp_info_extra {
 	 * this value will be overriden if route-map overrides vrf_id value
 	 */
 	vrf_id_t vrf_id;
+	bool vrf_id_local;
 	/*
 	 * Nexthop in context of original bgp instance. Needed
 	 * for label resolution of core mpls routes exported to a vrf.

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -364,6 +364,7 @@ extern void bgp_info_add(struct bgp_node *rn, struct bgp_info *ri);
 extern void bgp_info_reap(struct bgp_node *rn, struct bgp_info *ri);
 extern void bgp_info_delete(struct bgp_node *rn, struct bgp_info *ri);
 extern struct bgp_info_extra *bgp_info_extra_get(struct bgp_info *);
+extern void bgp_info_extra_free(struct bgp_info_extra **extra);
 extern void bgp_info_set_flag(struct bgp_node *, struct bgp_info *, uint32_t);
 extern void bgp_info_unset_flag(struct bgp_node *, struct bgp_info *, uint32_t);
 extern void bgp_info_path_with_addpath_rx_str(struct bgp_info *ri, char *buf);


### PR DESCRIPTION
This pull request extends the route-map facilities by having the possibility to transform a route leak into a simple "static route with nexthop on the same vrf".
This commit is related to route-map extensions, and shows how it applies to BGP VPNv4.

