### PR TITLE
bgpd: Incorrect sent prefix count for a split subgroup

### DIFF
--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -1182,6 +1182,8 @@ static void update_subgroup_copy_adj_out(struct update_subgroup *source,
 		aout_copy->attr =
 			aout->attr ? bgp_attr_intern(aout->attr) : NULL;
 	}
+
+	dest->scount = source->scount;
 }
 
 /*


### PR DESCRIPTION
When a subgroup splits to form a new subgroup because of policy changes
for a peer, new subgroup copies adj out(state about advertised routes)
from the parent subgroup. At the same time, it should also copy
scount(advertised prefix count) to the new subgroup for the count to be
in sync with the adj_out for the subgroup.

Signed-off-by: Ameya Dharkar <adharkar@vmware.org>

### Summary
Issue seen:
I had 2 BGP peers peer1 and peer2 in the same subgroup which advertised 2 prefixes. When I added a route map for peer1 to deny advertisement of the 2 prefixes, I observed that the scount(advertised prefix count) of the new subgroup of peer1 was -2 instead of 0.
Reason for this incorrect count is; when the new subgroup is formed for peer1, it cloned adj out (advertised prefixes) from the parent subgroup and then applied the route map to withdraw the prefixes. Thus, initial scount of 0 became -2 after the route map was applied.
Thus, when a new subgroup is split from another subgroup, it should copy the scount along with the adj-out from the parent subgroup.

### Related Issue


### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html