### PR TITLE
Bgp mem issue with martian address interface strings

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -47,6 +47,8 @@
 #include "zebra/rib.h"
 #include "zebra/zserv.h" /* For ZEBRA_SERV_PATH. */
 
+DEFINE_MTYPE_STATIC(BGPD, MARTIAN_STRING, "BGP Martian Address Intf String");
+
 char *bnc_str(struct bgp_nexthop_cache *bnc, char *buf, int size)
 {
 	prefix2str(&(bnc->node->p), buf, size);
@@ -205,7 +207,7 @@ static void bgp_address_hash_string_del(void *val)
 {
 	char *data = val;
 
-	XFREE(MTYPE_TMP, data);
+	XFREE(MTYPE_MARTIAN_STRING, data);
 }
 
 static void *bgp_address_hash_alloc(void *p)
@@ -278,7 +280,7 @@ static void bgp_address_add(struct bgp *bgp, struct connected *ifc,
 			break;
 	}
 	if (!node) {
-		name = XSTRDUP(MTYPE_TMP, ifc->ifp->name);
+		name = XSTRDUP(MTYPE_MARTIAN_STRING, ifc->ifp->name);
 		listnode_add(addr->ifp_name_list, name);
 	}
 }

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -305,8 +305,10 @@ static void bgp_address_del(struct bgp *bgp, struct connected *ifc,
 			break;
 	}
 
-	if (node)
+	if (node) {
 		list_delete_node(addr->ifp_name_list, node);
+		XFREE(MTYPE_MARTIAN_STRING, name);
+	}
 
 	if (addr->ifp_name_list->count == 0) {
 		hash_release(bgp->address_hash, addr);


### PR DESCRIPTION
Clean up a memory leak and stop using MTYPE_TMP