### PR TITLE
doc: fix warning of doc compilation with bgp draft

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1171,7 +1171,7 @@ is 4 octet long. The following format is used to define the community value.
    ``0xFFFF0006`` ``65535:6``.
    Assigned and intented only for use with routers supporting the
    Long-lived Graceful Restart Capability  as described in
-   :rfc:`draft-uttaro-idr-bgp-persistence`.
+   [Draft-IETF-uttaro-idr-bgp-persistence]_.
    Routers recieving routes with this community may (depending on
    implementation) choose allow to reject or modify routes on the
    presence or absence of this community.
@@ -1181,7 +1181,7 @@ is 4 octet long. The following format is used to define the community value.
    ``0xFFFF0007`` ``65535:7``.
    Assigned and intented only for use with routers supporting the
    Long-lived Graceful Restart Capability  as described in
-   :rfc:`draft-uttaro-idr-bgp-persistence`.
+   [Draft-IETF-uttaro-idr-bgp-persistence]_.
    Routers recieving routes with this community may (depending on
    implementation) choose allow to reject or modify routes on the
    presence or absence of this community.
@@ -1189,10 +1189,10 @@ is 4 octet long. The following format is used to define the community value.
 ``accept-own-nexthop``
    ``accept-own-nexthop`` represents well-known communities value
    ``accept-own-nexthop`` ``0xFFFF0008`` ``65535:8``.
-   :rfc:`draft-agrewal-idr-accept-own-nexthop` describes
+   [Draft-IETF-agrewal-idr-accept-own-nexthop]_ describes
    how to tag and label VPN routes to be able to send traffic between VRFs
    via an internal layer 2 domain on the same PE device. Refer to
-   :rfc:`draft-agrewal-idr-accept-own-nexthop` for full details.
+   [Draft-IETF-agrewal-idr-accept-own-nexthop]_ for full details.
 
 ``blackhole``
    ``blackhole`` represents well-known communities value ``BLACKHOLE``
@@ -1229,6 +1229,9 @@ is 4 octet long. The following format is used to define the community value.
 
 When the communities attribute is received duplicate community values in the
 attribute are ignored and value is sorted in numerical order.
+
+.. [Draft-IETF-uttaro-idr-bgp-persistence] <https://tools.ietf.org/id/draft-uttaro-idr-bgp-persistence-04.txt>
+.. [Draft-IETF-agrewal-idr-accept-own-nexthop] <https://tools.ietf.org/id/draft-agrewal-idr-accept-own-nexthop-00.txt>
 
 .. _bgp-community-lists:
 


### PR DESCRIPTION
Some draft ietf are not handle by :rfc: keyword. A workaround is
proposed, like it has been done for flowspec.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
