### PR TITLE
lib, vtysh: Allow notification across multiple lines of failure

### DIFF
--- a/lib/command.h
+++ b/lib/command.h
@@ -419,7 +419,7 @@ extern char **cmd_complete_command(vector, struct vty *, int *status);
 extern const char *cmd_prompt(enum node_type);
 extern int command_config_read_one_line(struct vty *vty,
 					const struct cmd_element **,
-					int use_config_node);
+					uint32_t line_num, int use_config_node);
 extern int config_from_file(struct vty *, FILE *, unsigned int *line_num);
 extern enum node_type node_parent(enum node_type);
 /*

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -33,6 +33,11 @@
 #define VTY_BUFSIZ 4096
 #define VTY_MAXHIST 20
 
+struct vty_error {
+	char error_buf[VTY_BUFSIZ];
+	uint32_t line_num;
+};
+
 /* VTY struct. */
 struct vty {
 	/* File descripter of this vty. */
@@ -71,7 +76,7 @@ struct vty {
 	char *buf;
 
 	/* Command input error buffer */
-	char *error_buf;
+	struct list *error;
 
 	/* Command cursor point */
 	int cp;

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -856,7 +856,7 @@ int vtysh_config_from_file(struct vty *vty, FILE *fp)
 	while (fgets(vty->buf, VTY_BUFSIZ, fp)) {
 		lineno++;
 
-		ret = command_config_read_one_line(vty, &cmd, 1);
+		ret = command_config_read_one_line(vty, &cmd, lineno, 1);
 
 		switch (ret) {
 		case CMD_WARNING:


### PR DESCRIPTION
When reading in config files and we have failures on multiple
lines actually note the actual failure lines and return them.
This fixes an issue where we stopped counting errors after
the first one and we got missleading line numbers that
did not correspond to the actual problem.

This is fixed:
sharpd@donna ~/frr> sudo /usr/lib/frr/pimd --log=stdout -A 127.0.0.1 -f /etc/frr/pimd.conf
2018/10/11 09:41:01 PIM: VRF Created: default(0)
2018/10/11 09:41:01 PIM: pim_vrf_enable: for default
2018/10/11 09:41:01 PIM: zclient_lookup_sched_now: zclient lookup immediate connection scheduled
2018/10/11 09:41:01 PIM: zclient_lookup_new: zclient lookup socket initialized
2018/10/11 09:41:01 PIM: pimd 6.1-dev starting: vty@2611
2018/10/11 09:41:01 PIM: [EC 100663304] ERROR: No such command on config line 2: inteface lo
2018/10/11 09:41:01 PIM: [EC 100663304] ERROR: No such command on config line 3: ip igmp
2018/10/11 09:41:01 PIM: [EC 100663304] ERROR: No such command on config line 4: ip igmp join 224.1.1.1 13.13.13.2
^C2018/10/11 09:45:09 PIM: Terminating on signal SIGINT
2018/10/11 09:45:09 PIM: VRF Deletion: default(0)

Fixes: #3161
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
