### PR TITLE
bgpd: allow vrf validity and bgp vrf import/export, when zebra is off

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -375,6 +375,7 @@ int main(int argc, char **argv)
 	int bgp_port = BGP_PORT_DEFAULT;
 	char *bgp_address = NULL;
 	int no_fib_flag = 0;
+	int no_zebra_flag = 0;
 	int skip_runas = 0;
 	int instance = 0;
 
@@ -384,6 +385,7 @@ int main(int argc, char **argv)
 		"  -p, --bgp_port     Set BGP listen port number (0 means do not listen).\n"
 		"  -l, --listenon     Listen on specified address (implies -n)\n"
 		"  -n, --no_kernel    Do not install route to kernel.\n"
+		"  -Z, --no_zebra     Do not communicate with Zebra.\n"
 		"  -S, --skip_runas   Skip capabilities checks, and changing user and group IDs.\n"
 		"  -e, --ecmp         Specify ECMP to use.\n"
 		"  -I, --int_num      Set instance number (label-manager)\n");
@@ -430,6 +432,9 @@ int main(int argc, char **argv)
 		case 'n':
 			no_fib_flag = 1;
 			break;
+		case 'Z':
+			no_zebra_flag = 1;
+			break;
 		case 'S':
 			skip_runas = 1;
 			break;
@@ -453,9 +458,10 @@ int main(int argc, char **argv)
 	if (bgp_port == 0)
 		bgp_option_set(BGP_OPT_NO_LISTEN);
 	bm->address = bgp_address;
-	if (no_fib_flag)
+	if (no_fib_flag || no_zebra_flag)
 		bgp_option_set(BGP_OPT_NO_FIB);
-
+	if (no_zebra_flag)
+		bgp_option_set(BGP_OPT_NO_ZEBRA);
 	bgp_error_init();
 	/* Initializations. */
 	bgp_vrf_init();

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -708,7 +708,9 @@ int bgp_socket(struct bgp *bgp, unsigned short port, const char *address)
 			     gai_strerror(ret));
 		return -1;
 	}
-
+	if (bgp_option_check(BGP_OPT_NO_ZEBRA) &&
+	    bgp->vrf_id != VRF_DEFAULT)
+		return -1;
 	count = 0;
 	for (ainfo = ainfo_save; ainfo; ainfo = ainfo->ai_next) {
 		int sock;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -171,6 +171,7 @@ int bgp_option_set(int flag)
 	case BGP_OPT_MULTIPLE_INSTANCE:
 	case BGP_OPT_CONFIG_CISCO:
 	case BGP_OPT_NO_LISTEN:
+	case BGP_OPT_NO_ZEBRA:
 		SET_FLAG(bm->options, flag);
 		break;
 	default:
@@ -186,6 +187,7 @@ int bgp_option_unset(int flag)
 		if (listcount(bm->bgp) > 1)
 			return BGP_ERR_MULTIPLE_INSTANCE_USED;
 	/* Fall through.  */
+	case BGP_OPT_NO_ZEBRA:
 	case BGP_OPT_NO_FIB:
 	case BGP_OPT_CONFIG_CISCO:
 		UNSET_FLAG(bm->options, flag);
@@ -3095,6 +3097,8 @@ int bgp_get(struct bgp **bgp_val, as_t *as, const char *name,
 	}
 
 	bgp = bgp_create(as, name, inst_type);
+	if (bgp_option_check(BGP_OPT_NO_ZEBRA) && name)
+		bgp->vrf_id = vrf_generate_id();
 	bgp_router_id_set(bgp, &bgp->router_id_zebra);
 	bgp_address_init(bgp);
 	bgp_tip_hash_init(bgp);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -131,6 +131,7 @@ struct bgp_master {
 #define BGP_OPT_MULTIPLE_INSTANCE        (1 << 1)
 #define BGP_OPT_CONFIG_CISCO             (1 << 2)
 #define BGP_OPT_NO_LISTEN                (1 << 3)
+#define BGP_OPT_NO_ZEBRA                 (1 << 4)
 
 	uint64_t updgrp_idspace;
 	uint64_t subgrp_idspace;

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -1022,3 +1022,10 @@ int vrf_sockunion_socket(const union sockunion *su, vrf_id_t vrf_id,
 	}
 	return ret;
 }
+
+vrf_id_t vrf_generate_id(void)
+{
+	static int vrf_id_local;
+
+	return ++vrf_id_local;
+}

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -293,5 +293,6 @@ extern int vrf_netns_handler_create(struct vty *vty, struct vrf *vrf,
 extern void vrf_disable(struct vrf *vrf);
 extern int vrf_enable(struct vrf *vrf);
 extern void vrf_delete(struct vrf *vrf);
+extern vrf_id_t vrf_generate_id(void);
 
 #endif /*_ZEBRA_VRF_H*/


### PR DESCRIPTION
if zebra is not started, then vrf identifiers are not available. This
prevents import/exportation to be available. This commit permits having
import/export available, even when zebra is not started.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>

