### PR TITLE
ospf6d: fix ospf6 crash in inp lsa processing

### DIFF
--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -1729,7 +1729,7 @@ void ospf6_intra_prefix_lsa_add(struct ospf6_lsa *lsa)
 		listnode_add_sort(route->paths, path);
 
 		old = ospf6_route_lookup(&route->prefix, oa->route_table);
-		if (old && (ospf6_route_cmp(route, old) == 0)) {
+		if (old) {
 			if (IS_OSPF6_DEBUG_EXAMIN(INTRA_PREFIX)) {
 				prefix2str(&route->prefix, buf, sizeof(buf));
 				zlog_debug("%s Update route: %s old cost %u new cost %u paths %u nh %u",


### PR DESCRIPTION
Use ospf6_prefix_same for comparing two exact same prefix to determine ECMP for a route.
ospf6_route_cmp expects two different prefix rather being exactly same.

Prefixlen is 126 but instead of containing network address it contains host address. This results during route add, route node radix match but address did not match. Instead of using route_cmp api which strictly expects different network address, calling ospf6_route_same api which will do the job for checking ecmp path during storing new or updating existing route. 

 (gdb) p old->prefix
$1 = {family = 10 '\n', prefixlen = 126,
p route->prefix
$2 = {family = 10 '\n', prefixlen = 126
(gdb) p /x old->prefix.u.prefix6.__in6_u.__u6_addr8
$8 = {0x20, 0x1, 0x19, 0xf0, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x6c, 0x3d, 0x26, **0x24**} 
(gdb) p /x route->prefix.u.prefix6.__in6_u.__u6_addr8
$9 = {0x20, 0x1, 0x19, 0xf0, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x6c, 0x3d, 0x26, **0x26**}

Testing Done:
performed ECMP of intra network prefix route via
sending same route via different available
ospf6 paths.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>


This will address Issue 3146

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
