### PR TITLE
bgpd: BGP JSON new fields

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6301,6 +6301,7 @@ static void route_vty_out_route(struct prefix *p, struct vty *vty,
 {
 	int len = 0;
 	char buf[BUFSIZ];
+	char buf2[BUFSIZ];
 
 	if (p->family == AF_INET) {
 		if (!json) {
@@ -6314,6 +6315,8 @@ static void route_vty_out_route(struct prefix *p, struct vty *vty,
 							 &p->u.prefix, buf,
 							 BUFSIZ));
 			json_object_int_add(json, "prefixLen", p->prefixlen);
+			prefix2str(p, buf2, PREFIX_STRLEN);
+			json_object_string_add(json, "network", buf2);
 		}
 	} else if (p->family == AF_ETHERNET) {
 		prefix2str(p, buf, PREFIX_STRLEN);
@@ -6337,6 +6340,15 @@ static void route_vty_out_route(struct prefix *p, struct vty *vty,
 				vty, "%s/%d",
 				inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ),
 				p->prefixlen);
+		else {
+			json_object_string_add(json, "prefix",
+						inet_ntop(p->family,
+							&p->u.prefix, buf,
+							BUFSIZ));
+			json_object_int_add(json, "prefixLen", p->prefixlen);
+			prefix2str(p, buf2, PREFIX_STRLEN);
+			json_object_string_add(json, "network", buf2);
+		}
 	}
 
 	if (!json) {
@@ -6795,6 +6807,7 @@ void route_vty_out_tmp(struct vty *vty, struct prefix *p, struct attr *attr,
 	json_object *json_status = NULL;
 	json_object *json_net = NULL;
 	char buff[BUFSIZ];
+	char buf2[BUFSIZ];
 	/* Route status display. */
 	if (use_json) {
 		json_status = json_object_new_object();
@@ -6806,11 +6819,14 @@ void route_vty_out_tmp(struct vty *vty, struct prefix *p, struct attr *attr,
 	}
 
 	/* print prefix and mask */
-	if (use_json)
+	if (use_json) {
 		json_object_string_add(
 			json_net, "addrPrefix",
 			inet_ntop(p->family, &p->u.prefix, buff, BUFSIZ));
-	else
+		json_object_int_add(json_net, "prefixLen", p->prefixlen);
+		prefix2str(p, buf2, PREFIX_STRLEN);
+		json_object_string_add(json_net, "network", buf2);
+	} else
 		route_vty_out_route(p, vty, NULL);
 
 	/* Print attribute */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7682,6 +7682,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 	int pfx_rcd_safi;
 	json_object *json_peer = NULL;
 	json_object *json_peers = NULL;
+	struct peer_af *paf;
 
 	/* labeled-unicast routes are installed in the unicast table so in order
 	 * to
@@ -7976,6 +7977,11 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				    use_json, json_peer);
 			json_object_int_add(json_peer, "prefixReceivedCount",
 					    peer->pcount[afi][pfx_rcd_safi]);
+			paf = peer_af_find(peer, afi, pfx_rcd_safi);
+			if (paf && PAF_SUBGRP(paf))
+				json_object_int_add(json_peer,
+						"pfxSnt",
+						(PAF_SUBGRP(paf))->scount);
 
 			if (CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN))
 				json_object_string_add(json_peer, "state",
@@ -8689,6 +8695,9 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 		/* Receive prefix count */
 		json_object_int_add(json_addr, "acceptedPrefixCounter",
 				    p->pcount[afi][safi]);
+		if (paf && PAF_SUBGRP(paf))
+			json_object_int_add(json_addr, "sentPrefixCounter",
+						(PAF_SUBGRP(paf))->scount);
 
 		/* Maximum prefix */
 		if (CHECK_FLAG(p->af_flags[afi][safi], PEER_FLAG_MAX_PREFIX)) {


### PR DESCRIPTION
1. "show bgp ipv4 json"
  - Added "network" field which displays a prefix in 'prefix/prefixlen' format.

2. "show bgp ipv6 json"
  - Added "network" field which displays a prefix in 'prefix/prefixlen' format.
  - JSON does not have "prefix", "prefixLen" fields which are present in IPv4
    command. Added these fields as they are useful.

3. "show bgp ipv4/ipv6 neighbor <neighbor_addr> advertised-routes json"
  - Added "network" field.

4. "show bgp ipv4/ipv6 summary json"
  - Added "pfxSnt" for peers. This count is obtained from corresponding
    update_subgroup.

5. "show bgp neighbor json"
  - Added "sentPrefixCounter"

Signed-off-by: Ameya Dharkar <adharkar@vmware.org>

### Summary
As discussions for BGP JSON pull request https://github.com/FRRouting/frr/pull/3139 are going on for renaming certain JSON fields, I opened this new PR for the changes to add new useful fields only(not the fields that were renamed).

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html