### PR TITLE
Feature: IS-IS triggered hello

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -215,21 +215,24 @@ void isis_adj_process_threeway(struct isis_adjacency *adj,
 		}
 	}
 
+	if (adj->threeway_state != next_tw_state) {
+		send_hello_sched(adj->circuit, 0, TRIGGERED_IIH_DELAY);
+	}
+
 	adj->threeway_state = next_tw_state;
 }
 
 void isis_adj_state_change(struct isis_adjacency *adj,
 			   enum isis_adj_state new_state, const char *reason)
 {
-	int old_state;
-	int level;
-	struct isis_circuit *circuit;
+	enum isis_adj_state old_state = adj->adj_state;
+	struct isis_circuit *circuit = adj->circuit;
 	bool del;
 
-	old_state = adj->adj_state;
 	adj->adj_state = new_state;
-
-	circuit = adj->circuit;
+	if (new_state != old_state) {
+		send_hello_sched(circuit, adj->level, TRIGGERED_IIH_DELAY);
+	}
 
 	if (isis->debugs & DEBUG_ADJ_PACKETS) {
 		zlog_debug("ISIS-Adj (%s): Adjacency state change %d->%d: %s",
@@ -257,7 +260,7 @@ void isis_adj_state_change(struct isis_adjacency *adj,
 
 	if (circuit->circ_type == CIRCUIT_T_BROADCAST) {
 		del = false;
-		for (level = IS_LEVEL_1; level <= IS_LEVEL_2; level++) {
+		for (int level = IS_LEVEL_1; level <= IS_LEVEL_2; level++) {
 			if ((adj->level & level) == 0)
 				continue;
 			if (new_state == ISIS_ADJ_UP) {
@@ -298,15 +301,12 @@ void isis_adj_state_change(struct isis_adjacency *adj,
 
 	} else if (circuit->circ_type == CIRCUIT_T_P2P) {
 		del = false;
-		for (level = IS_LEVEL_1; level <= IS_LEVEL_2; level++) {
+		for (int level = IS_LEVEL_1; level <= IS_LEVEL_2; level++) {
 			if ((adj->level & level) == 0)
 				continue;
 			if (new_state == ISIS_ADJ_UP) {
 				circuit->upadjcount[level - 1]++;
 				hook_call(isis_adj_state_change_hook, adj);
-
-				if (adj->sys_type == ISIS_SYSTYPE_UNKNOWN)
-					send_hello(circuit, level);
 
 				/* update counter & timers for debugging
 				 * purposes */
@@ -337,8 +337,6 @@ void isis_adj_state_change(struct isis_adjacency *adj,
 		if (del)
 			isis_delete_adj(adj);
 	}
-
-	return;
 }
 
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -619,9 +619,7 @@ int isis_circuit_up(struct isis_circuit *circuit)
 			if (!(circuit->is_type & level))
 				continue;
 
-			thread_add_event(master, send_hello_cb,
-					 &circuit->level_arg[level - 1], 0,
-					 &circuit->u.bc.t_send_lan_hello[level - 1]);
+			send_hello_sched(circuit, level, TRIGGERED_IIH_DELAY);
 			circuit->u.bc.lan_neighs[level - 1] = list_new();
 
 			thread_add_timer(master, isis_run_dr,
@@ -637,9 +635,7 @@ int isis_circuit_up(struct isis_circuit *circuit)
 		 * for a ptp IF
 		 */
 		circuit->u.p2p.neighbor = NULL;
-		thread_add_event(master, send_hello_cb,
-				 &circuit->level_arg[0], 0,
-				 &circuit->u.p2p.t_send_p2p_hello);
+		send_hello_sched(circuit, 0, TRIGGERED_IIH_DELAY);
 	}
 
 	/* initializing PSNP timers */

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -89,6 +89,8 @@ struct isis_circuit *isis_circuit_new()
 		circuit->priority[i] = DEFAULT_PRIORITY;
 		circuit->metric[i] = DEFAULT_CIRCUIT_METRIC;
 		circuit->te_metric[i] = DEFAULT_CIRCUIT_METRIC;
+		circuit->level_arg[i].level = i + 1;
+		circuit->level_arg[i].circuit = circuit;
 	}
 
 	circuit->mtc = mpls_te_circuit_new();

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -67,6 +67,11 @@ struct isis_p2p_info {
 
 struct bfd_info;
 
+struct isis_circuit_arg {
+	int level;
+	struct isis_circuit *circuit;
+};
+
 struct isis_circuit {
 	int state;
 	uint8_t circuit_id;	  /* l1/l2 bcast CircuitID */
@@ -83,6 +88,7 @@ struct isis_circuit {
 	struct thread *t_send_psnp[2];
 	struct thread *t_send_lsp;
 	struct isis_tx_queue *tx_queue;
+	struct isis_circuit_arg level_arg[2]; /* used as argument for threads */
 
 	/* there is no real point in two streams, just for programming kicker */
 	int (*rx)(struct isis_circuit *circuit, uint8_t *ssnpa);

--- a/isisd/isis_constants.h
+++ b/isisd/isis_constants.h
@@ -75,6 +75,8 @@
 
 #define MIN_LSP_RETRANS_INTERVAL      5 /* Seconds */
 
+#define TRIGGERED_IIH_DELAY           50	/* msec */
+
 #define MIN_CSNP_INTERVAL             1
 #define MAX_CSNP_INTERVAL             600
 #define DEFAULT_CSNP_INTERVAL         10

--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -62,35 +62,28 @@ const char *isis_disflag2string(int disflag)
 	return NULL; /* not reached */
 }
 
-int isis_run_dr_l1(struct thread *thread)
+int isis_run_dr(struct thread *thread)
 {
-	struct isis_circuit *circuit;
+	struct isis_circuit_arg *arg = THREAD_ARG(thread);
 
-	circuit = THREAD_ARG(thread);
+	assert(arg);
+
+	struct isis_circuit *circuit = arg->circuit;
+	int level = arg->level;
+
 	assert(circuit);
 
-	if (circuit->u.bc.run_dr_elect[0])
-		zlog_warn("isis_run_dr(): run_dr_elect already set for l1");
+	if (circuit->circ_type != CIRCUIT_T_BROADCAST) {
+		zlog_warn("%s: scheduled for non broadcast circuit from %s:%d",
+			  __func__, thread->schedfrom, thread->schedfrom_line);
+		return ISIS_WARNING;
+	}
 
-	circuit->u.bc.t_run_dr[0] = NULL;
-	circuit->u.bc.run_dr_elect[0] = 1;
+	if (circuit->u.bc.run_dr_elect[level - 1])
+		zlog_warn("isis_run_dr(): run_dr_elect already set for l%d", level);
 
-	return ISIS_OK;
-}
-
-int isis_run_dr_l2(struct thread *thread)
-{
-	struct isis_circuit *circuit;
-
-	circuit = THREAD_ARG(thread);
-	assert(circuit);
-
-	if (circuit->u.bc.run_dr_elect[1])
-		zlog_warn("isis_run_dr(): run_dr_elect already set for l2");
-
-
-	circuit->u.bc.t_run_dr[1] = NULL;
-	circuit->u.bc.run_dr_elect[1] = 1;
+	circuit->u.bc.t_run_dr[level - 1] = NULL;
+	circuit->u.bc.run_dr_elect[level - 1] = 1;
 
 	return ISIS_OK;
 }
@@ -241,12 +234,6 @@ int isis_dr_resign(struct isis_circuit *circuit, int level)
 	if (level == 1) {
 		memset(circuit->u.bc.l1_desig_is, 0, ISIS_SYS_ID_LEN + 1);
 
-		THREAD_TIMER_OFF(circuit->t_send_csnp[0]);
-
-		thread_add_timer(master, isis_run_dr_l1, circuit,
-				 2 * circuit->hello_interval[0],
-				 &circuit->u.bc.t_run_dr[0]);
-
 		thread_add_timer(master, send_l1_psnp, circuit,
 				 isis_jitter(circuit->psnp_interval[level - 1],
 					     PSNP_JITTER),
@@ -254,17 +241,19 @@ int isis_dr_resign(struct isis_circuit *circuit, int level)
 	} else {
 		memset(circuit->u.bc.l2_desig_is, 0, ISIS_SYS_ID_LEN + 1);
 
-		THREAD_TIMER_OFF(circuit->t_send_csnp[1]);
-
-		thread_add_timer(master, isis_run_dr_l2, circuit,
-				 2 * circuit->hello_interval[1],
-				 &circuit->u.bc.t_run_dr[1]);
-
 		thread_add_timer(master, send_l2_psnp, circuit,
 				 isis_jitter(circuit->psnp_interval[level - 1],
 					     PSNP_JITTER),
 				 &circuit->t_send_psnp[1]);
 	}
+
+	THREAD_TIMER_OFF(circuit->t_send_csnp[level - 1]);
+
+	thread_add_timer(master, isis_run_dr,
+			 &circuit->level_arg[level - 1],
+			 2 * circuit->hello_interval[level - 1],
+			 &circuit->u.bc.t_run_dr[level - 1]);
+
 
 	thread_add_event(master, isis_event_dis_status_change, circuit, 0,
 			 NULL);
@@ -281,14 +270,10 @@ int isis_dr_commence(struct isis_circuit *circuit, int level)
 
 	/* Lets keep a pause in DR election */
 	circuit->u.bc.run_dr_elect[level - 1] = 0;
-	if (level == 1)
-		thread_add_timer(master, isis_run_dr_l1, circuit,
-				 2 * circuit->hello_interval[0],
-				 &circuit->u.bc.t_run_dr[0]);
-	else
-		thread_add_timer(master, isis_run_dr_l2, circuit,
-				 2 * circuit->hello_interval[1],
-				 &circuit->u.bc.t_run_dr[1]);
+	thread_add_timer(master, isis_run_dr,
+			 &circuit->level_arg[level - 1],
+			 2 * circuit->hello_interval[level - 1],
+			 &circuit->u.bc.t_run_dr[level - 1]);
 	circuit->u.bc.is_dr[level - 1] = 1;
 
 	if (level == 1) {
@@ -306,11 +291,6 @@ int isis_dr_commence(struct isis_circuit *circuit, int level)
 		/*    if (circuit->t_send_l1_psnp)
 		   thread_cancel (circuit->t_send_l1_psnp); */
 		lsp_generate_pseudo(circuit, 1);
-
-		THREAD_TIMER_OFF(circuit->u.bc.t_run_dr[0]);
-		thread_add_timer(master, isis_run_dr_l1, circuit,
-				 2 * circuit->hello_interval[0],
-				 &circuit->u.bc.t_run_dr[0]);
 
 		thread_add_timer(master, send_l1_csnp, circuit,
 				 isis_jitter(circuit->csnp_interval[level - 1],
@@ -332,11 +312,6 @@ int isis_dr_commence(struct isis_circuit *circuit, int level)
 		/*    if (circuit->t_send_l1_psnp)
 		   thread_cancel (circuit->t_send_l1_psnp); */
 		lsp_generate_pseudo(circuit, 2);
-
-		THREAD_TIMER_OFF(circuit->u.bc.t_run_dr[1]);
-		thread_add_timer(master, isis_run_dr_l2, circuit,
-				 2 * circuit->hello_interval[1],
-				 &circuit->u.bc.t_run_dr[1]);
 
 		thread_add_timer(master, send_l2_csnp, circuit,
 				 isis_jitter(circuit->csnp_interval[level - 1],

--- a/isisd/isis_dr.c
+++ b/isisd/isis_dr.c
@@ -270,10 +270,6 @@ int isis_dr_commence(struct isis_circuit *circuit, int level)
 
 	/* Lets keep a pause in DR election */
 	circuit->u.bc.run_dr_elect[level - 1] = 0;
-	thread_add_timer(master, isis_run_dr,
-			 &circuit->level_arg[level - 1],
-			 2 * circuit->hello_interval[level - 1],
-			 &circuit->u.bc.t_run_dr[level - 1]);
 	circuit->u.bc.is_dr[level - 1] = 1;
 
 	if (level == 1) {
@@ -319,6 +315,10 @@ int isis_dr_commence(struct isis_circuit *circuit, int level)
 				 &circuit->t_send_csnp[1]);
 	}
 
+	thread_add_timer(master, isis_run_dr,
+			 &circuit->level_arg[level - 1],
+			 2 * circuit->hello_interval[level - 1],
+			 &circuit->u.bc.t_run_dr[level - 1]);
 	thread_add_event(master, isis_event_dis_status_change, circuit, 0,
 			 NULL);
 

--- a/isisd/isis_dr.h
+++ b/isisd/isis_dr.h
@@ -24,8 +24,7 @@
 #ifndef _ZEBRA_ISIS_DR_H
 #define _ZEBRA_ISIS_DR_H
 
-int isis_run_dr_l1(struct thread *thread);
-int isis_run_dr_l2(struct thread *thread);
+int isis_run_dr(struct thread *thread);
 int isis_dr_elect(struct isis_circuit *circuit, int level);
 int isis_dr_resign(struct isis_circuit *circuit, int level);
 int isis_dr_commence(struct isis_circuit *circuit, int level);

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -77,47 +77,34 @@ void isis_event_circuit_state_change(struct isis_circuit *circuit,
 
 static void circuit_commence_level(struct isis_circuit *circuit, int level)
 {
-	if (level == 1) {
-		if (!circuit->is_passive)
+	if (!circuit->is_passive) {
+		if (level == 1) {
 			thread_add_timer(master, send_l1_psnp, circuit,
 					 isis_jitter(circuit->psnp_interval[0],
 						     PSNP_JITTER),
 					 &circuit->t_send_psnp[0]);
-
-		if (circuit->circ_type == CIRCUIT_T_BROADCAST) {
-			thread_add_timer(master, isis_run_dr_l1, circuit,
-					 2 * circuit->hello_interval[0],
-					 &circuit->u.bc.t_run_dr[0]);
-
-			thread_add_timer(master, send_lan_l1_hello, circuit,
-					 isis_jitter(circuit->hello_interval[0],
-						     IIH_JITTER),
-					 &circuit->u.bc.t_send_lan_hello[0]);
-
-			circuit->u.bc.lan_neighs[0] = list_new();
-		}
-	} else {
-		if (!circuit->is_passive)
+		} else {
 			thread_add_timer(master, send_l2_psnp, circuit,
 					 isis_jitter(circuit->psnp_interval[1],
 						     PSNP_JITTER),
 					 &circuit->t_send_psnp[1]);
-
-		if (circuit->circ_type == CIRCUIT_T_BROADCAST) {
-			thread_add_timer(master, isis_run_dr_l2, circuit,
-					 2 * circuit->hello_interval[1],
-					 &circuit->u.bc.t_run_dr[1]);
-
-			thread_add_timer(master, send_lan_l2_hello, circuit,
-					 isis_jitter(circuit->hello_interval[1],
-						     IIH_JITTER),
-					 &circuit->u.bc.t_send_lan_hello[1]);
-
-			circuit->u.bc.lan_neighs[1] = list_new();
 		}
 	}
 
-	return;
+	if (circuit->circ_type == CIRCUIT_T_BROADCAST) {
+		thread_add_timer(master, isis_run_dr,
+				 &circuit->level_arg[level - 1],
+				 2 * circuit->hello_interval[level - 1],
+				 &circuit->u.bc.t_run_dr[level - 1]);
+
+		thread_add_timer(master, send_hello_cb,
+				 &circuit->level_arg[level - 1],
+				 isis_jitter(circuit->hello_interval[level - 1],
+					     IIH_JITTER),
+				 &circuit->u.bc.t_send_lan_hello[level - 1]);
+
+		circuit->u.bc.lan_neighs[level - 1] = list_new();
+	}
 }
 
 static void circuit_resign_level(struct isis_circuit *circuit, int level)

--- a/isisd/isis_events.c
+++ b/isisd/isis_events.c
@@ -97,12 +97,7 @@ static void circuit_commence_level(struct isis_circuit *circuit, int level)
 				 2 * circuit->hello_interval[level - 1],
 				 &circuit->u.bc.t_run_dr[level - 1]);
 
-		thread_add_timer(master, send_hello_cb,
-				 &circuit->level_arg[level - 1],
-				 isis_jitter(circuit->hello_interval[level - 1],
-					     IIH_JITTER),
-				 &circuit->u.bc.t_send_lan_hello[level - 1]);
-
+		send_hello_sched(circuit, level, TRIGGERED_IIH_DELAY);
 		circuit->u.bc.lan_neighs[level - 1] = list_new();
 	}
 }

--- a/isisd/isis_pdu.h
+++ b/isisd/isis_pdu.h
@@ -208,7 +208,7 @@ int isis_receive(struct thread *thread);
 /*
  * Sending functions
  */
-int send_hello_cb(struct thread *thread);
+void send_hello_sched(struct isis_circuit *circuit, int level, long delay);
 int send_csnp(struct isis_circuit *circuit, int level);
 int send_l1_csnp(struct thread *thread);
 int send_l2_csnp(struct thread *thread);

--- a/isisd/isis_pdu.h
+++ b/isisd/isis_pdu.h
@@ -208,9 +208,7 @@ int isis_receive(struct thread *thread);
 /*
  * Sending functions
  */
-int send_lan_l1_hello(struct thread *thread);
-int send_lan_l2_hello(struct thread *thread);
-int send_p2p_hello(struct thread *thread);
+int send_hello_cb(struct thread *thread);
 int send_csnp(struct isis_circuit *circuit, int level);
 int send_l1_csnp(struct thread *thread);
 int send_l2_csnp(struct thread *thread);

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -655,18 +655,24 @@ void thread_master_free(struct thread_master *m)
 	XFREE(MTYPE_THREAD_MASTER, m);
 }
 
-/* Return remain time in second. */
-unsigned long thread_timer_remain_second(struct thread *thread)
+/* Return remain time in miliseconds. */
+unsigned long thread_timer_remain_msec(struct thread *thread)
 {
 	int64_t remain;
 
 	pthread_mutex_lock(&thread->mtx);
 	{
-		remain = monotime_until(&thread->u.sands, NULL) / 1000000LL;
+		remain = monotime_until(&thread->u.sands, NULL) / 1000LL;
 	}
 	pthread_mutex_unlock(&thread->mtx);
 
 	return remain < 0 ? 0 : remain;
+}
+
+/* Return remain time in seconds. */
+unsigned long thread_timer_remain_second(struct thread *thread)
+{
+	return thread_timer_remain_msec(thread) / 1000LL;
 }
 
 #define debugargdef  const char *funcname, const char *schedfrom, int fromln

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -217,6 +217,7 @@ extern struct thread *thread_fetch(struct thread_master *, struct thread *);
 extern void thread_call(struct thread *);
 extern unsigned long thread_timer_remain_second(struct thread *);
 extern struct timeval thread_timer_remain(struct thread *);
+extern unsigned long thread_timer_remain_msec(struct thread *);
 extern int thread_should_yield(struct thread *);
 /* set yield time for thread */
 extern void thread_set_yield_time(struct thread *, unsigned long);

--- a/tests/topotests/isis-topo1/r1/isisd.conf
+++ b/tests/topotests/isis-topo1/r1/isisd.conf
@@ -1,4 +1,7 @@
 hostname r1
+debug isis adj-packets
+debug isis events
+debug isis update-packets
 interface r1-eth0
  ip router isis 1
  ipv6 router isis 1

--- a/tests/topotests/isis-topo1/r2/isisd.conf
+++ b/tests/topotests/isis-topo1/r2/isisd.conf
@@ -1,4 +1,7 @@
 hostname r2
+debug isis adj-packets
+debug isis events
+debug isis update-packets
 interface r2-eth0
  ip router isis 1
  ipv6 router isis 1

--- a/tests/topotests/isis-topo1/r3/isisd.conf
+++ b/tests/topotests/isis-topo1/r3/isisd.conf
@@ -1,4 +1,7 @@
 hostname r3
+debug isis adj-packets
+debug isis events
+debug isis update-packets
 interface r3-eth0
  ip router isis 1
  ipv6 router isis 1

--- a/tests/topotests/isis-topo1/r4/isisd.conf
+++ b/tests/topotests/isis-topo1/r4/isisd.conf
@@ -1,4 +1,7 @@
 hostname r4
+debug isis adj-packets
+debug isis events
+debug isis update-packets
 interface r4-eth0
  ip router isis 1
  ipv6 router isis 1

--- a/tests/topotests/isis-topo1/r5/isisd.conf
+++ b/tests/topotests/isis-topo1/r5/isisd.conf
@@ -1,4 +1,7 @@
 hostname r5
+debug isis adj-packets
+debug isis events
+debug isis update-packets
 interface r5-eth0
  ip router isis 1
  ipv6 router isis 1

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -60,6 +60,9 @@ class json_cmp_result(object):
         "Returns True if there were errors, otherwise False."
         return len(self.errors) > 0
 
+    def __str__(self):
+        return '\n'.join(self.errors)
+
 def get_test_logdir(node=None, init=False):
     """
     Return the current test log directory based on PYTEST_CURRENT_TEST


### PR DESCRIPTION
`isisd` would only send hellos after each hello interval (modulo jitter). When running with a high hello interval, this leads to significant time until adjancencies are established. For example, with three-way handshake enabled and an IIH of 60 seconds, it can take up to three minutes for IS-IS to declare an adjacency up.

This is addressed by triggering transmission of hellos whenever an adjacency state change is observed. While in line with the spec, this leads to almost immediate (sub second) adjacency establishment after the first transmitted/received packet.