### PR TITLE
Bgp route ip leak 

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -221,6 +221,7 @@ struct attr {
 #define BATTR_RMAP_IPV6_GLOBAL_NHOP_CHANGED (1 << 4)
 #define BATTR_RMAP_IPV6_LL_NHOP_CHANGED (1 << 5)
 #define BATTR_RMAP_IPV6_PREFER_GLOBAL_CHANGED (1 << 6)
+#define BATTR_RMAP_VRF_NHOP_CHANGED (1 << 7)
 
 /* Router Reflector related structure. */
 struct cluster_list {

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -597,7 +597,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	if (num_labels)
 		setlabels(new, label, num_labels);
 	new->extra->vrf_id = nh_info->vrf_id;
-	new->extra->vrf_id_local = nh_info->vrf_local;
+	new->extra->vrf_local = nh_info->vrf_local;
 
 	new->extra->parent = bgp_path_info_lock(parent);
 	bgp_lock_node((struct bgp_node *)((struct bgp_path_info *)parent)->net);
@@ -614,7 +614,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 
 	if (new->extra->vrf_id != VRF_UNKNOWN)
 		bgp_nexthop = bgp_lookup_by_vrf_id(new->extra->vrf_id);
-	else if (!new->extra->vrf_id_local &&
+	else if (!new->extra->vrf_local &&
 		 new->extra->bgp_orig)
 		bgp_nexthop = new->extra->bgp_orig;
 	/*
@@ -1152,7 +1152,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 				      p, RMAP_BGP, &info);
 		if (RMAP_DENYMATCH != ret && bextra) {
 			nh_info.vrf_id = bextra->vrf_id;
-			nh_info.vrf_local = bextra->vrf_id_local;
+			nh_info.vrf_local = bextra->vrf_local;
 		}
 		if (bextra)
 			bgp_path_info_extra_free(&bextra);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -453,6 +453,12 @@ static void setlabels(struct bgp_path_info *bpi,
 	extra->num_labels = num_labels;
 }
 
+struct bgp_mpls_leak_nh_info {
+	int nexthop_self_flag;
+	vrf_id_t vrf_id;
+	bool vrf_local;
+};
+
 /*
  * returns pointer to new bgp_path_info upon success
  */
@@ -462,7 +468,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	    afi_t afi, safi_t safi, struct bgp_path_info *source_bpi,
 	    mpls_label_t *label, uint32_t num_labels, void *parent,
 	    struct bgp *bgp_orig, struct prefix *nexthop_orig,
-	    int nexthop_self_flag, int debug)
+	    struct bgp_mpls_leak_nh_info *nh_info, int debug)
 {
 	struct prefix *p = &bn->p;
 	struct bgp_path_info *bpi;
@@ -538,15 +544,17 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 		if (!labelssame)
 			setlabels(bpi, label, num_labels);
 
-		if (nexthop_self_flag)
+		if (nh_info->nexthop_self_flag)
 			bgp_path_info_set_flag(bn, bpi, BGP_PATH_ANNC_NH_SELF);
 
 		struct bgp *bgp_nexthop = bgp;
 		int nh_valid;
 
-		if (bpi->extra && bpi->extra->bgp_orig)
+		if (nh_info->vrf_id != VRF_UNKNOWN)
+			bgp_nexthop = bgp_lookup_by_vrf_id(nh_info->vrf_id);
+		else if (!nh_info->vrf_local &&
+			 bpi->extra && bpi->extra->bgp_orig)
 			bgp_nexthop = bpi->extra->bgp_orig;
-
 		/* No nexthop tracking for redistributed routes */
 		if (bpi_ultimate->sub_type == BGP_ROUTE_REDISTRIBUTE)
 			nh_valid = 1;
@@ -581,13 +589,15 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	new = info_make(ZEBRA_ROUTE_BGP, BGP_ROUTE_IMPORTED, 0,
 		bgp->peer_self, new_attr, bn);
 
-	if (nexthop_self_flag)
+	if (nh_info->nexthop_self_flag)
 		bgp_path_info_set_flag(bn, new, BGP_PATH_ANNC_NH_SELF);
 
 	bgp_path_info_extra_get(new);
 
 	if (num_labels)
 		setlabels(new, label, num_labels);
+	new->extra->vrf_id = nh_info->vrf_id;
+	new->extra->vrf_id_local = nh_info->vrf_local;
 
 	new->extra->parent = bgp_path_info_lock(parent);
 	bgp_lock_node((struct bgp_node *)((struct bgp_path_info *)parent)->net);
@@ -602,9 +612,11 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	struct bgp *bgp_nexthop = bgp;
 	int nh_valid;
 
-	if (new->extra->bgp_orig)
+	if (new->extra->vrf_id != VRF_UNKNOWN)
+		bgp_nexthop = bgp_lookup_by_vrf_id(new->extra->vrf_id);
+	else if (!new->extra->vrf_id_local &&
+		 new->extra->bgp_orig)
 		bgp_nexthop = new->extra->bgp_orig;
-
 	/*
 	 * No nexthop tracking for redistributed routes because
 	 * their originating protocols will do the tracking and
@@ -655,7 +667,11 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 	mpls_label_t label;
 	struct bgp_node *bn;
 	const char *debugmsg;
-	int nexthop_self_flag = 0;
+	struct bgp_mpls_leak_nh_info nh_info;
+
+	nh_info.vrf_id = VRF_UNKNOWN;
+	nh_info.vrf_local = FALSE;
+	nh_info.nexthop_self_flag = 1;
 
 	if (debug)
 		zlog_debug("%s: from vrf %s", __func__, bgp_vrf->name_pretty);
@@ -817,7 +833,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 					ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
 			}
 		}
-		nexthop_self_flag = 1;
+		nh_info.nexthop_self_flag = 1;
 	}
 
 	label_val = bgp_vrf->vpn_policy[afi].tovpn_label;
@@ -853,7 +869,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 
 	new_info = leak_update(bgp_vpn, bn, new_attr, afi, safi, path_vrf,
 			       &label, 1, path_vrf, bgp_vrf, NULL,
-			       nexthop_self_flag, debug);
+			       &nh_info, debug);
 
 	/*
 	 * Routes actually installed in the vpn RIB must also be
@@ -1043,13 +1059,16 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 	struct prefix nexthop_orig;
 	mpls_label_t *pLabels = NULL;
 	uint32_t num_labels = 0;
-	int nexthop_self_flag = 1;
 	struct bgp_path_info *bpi_ultimate = NULL;
 	int origin_local = 0;
 	struct bgp *src_vrf;
+	struct bgp_mpls_leak_nh_info nh_info;
 
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_TO_VRF);
 
+	nh_info.vrf_id = VRF_UNKNOWN;
+	nh_info.vrf_local = FALSE;
+	nh_info.nexthop_self_flag = 1;
 	if (!vpn_leak_from_vpn_active(bgp_vrf, afi, &debugmsg)) {
 		if (debug)
 			zlog_debug("%s: skipping: %s", __func__, debugmsg);
@@ -1119,14 +1138,25 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 	if (bgp_vrf->vpn_policy[afi].rmap[BGP_VPN_POLICY_DIR_FROMVPN]) {
 		struct bgp_path_info info;
 		route_map_result_t ret;
+		struct bgp_path_info_extra *bextra = NULL;
 
 		memset(&info, 0, sizeof(info));
 		info.peer = bgp_vrf->peer_self;
 		info.attr = &static_attr;
+		if (path_vpn->extra && path_vpn->extra->parent) {
+			bextra = bgp_path_info_extra_get(&info);
+			bextra->parent = path_vpn->extra->parent;
+		}
 		ret = route_map_apply(bgp_vrf->vpn_policy[afi]
 					      .rmap[BGP_VPN_POLICY_DIR_FROMVPN],
 				      p, RMAP_BGP, &info);
-		if (RMAP_DENYMATCH == ret) {
+		if (RMAP_DENYMATCH != ret && bextra) {
+			nh_info.vrf_id = bextra->vrf_id;
+			nh_info.vrf_local = bextra->vrf_id_local;
+		}
+		if (bextra)
+			bgp_path_info_extra_free(&bextra);
+		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&static_attr); /* free any added parts */
 			if (debug)
 				zlog_debug(
@@ -1142,7 +1172,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 		 */
 		if (!CHECK_FLAG(static_attr.rmap_change_flags,
 						BATTR_RMAP_NEXTHOP_UNCHANGED))
-			nexthop_self_flag = 0;
+			nh_info.nexthop_self_flag = 0;
 	}
 
 	new_attr = bgp_attr_intern(&static_attr);
@@ -1210,7 +1240,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 
 	leak_update(bgp_vrf, bn, new_attr, afi, safi, path_vpn, pLabels,
 		    num_labels, path_vpn, /* parent */
-		    src_vrf, &nexthop_orig, nexthop_self_flag, debug);
+		    src_vrf, &nexthop_orig, &nh_info, debug);
 }
 
 void vpn_leak_to_vrf_update(struct bgp *bgp_vpn,	    /* from */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -174,6 +174,7 @@ static struct bgp_path_info_extra *bgp_path_info_extra_new(void)
 	new->label[0] = MPLS_INVALID_LABEL;
 	new->num_labels = 0;
 	new->vrf_id = VRF_UNKNOWN;
+	new->vrf_id_local = FALSE;
 	return new;
 }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -174,7 +174,7 @@ static struct bgp_path_info_extra *bgp_path_info_extra_new(void)
 	new->label[0] = MPLS_INVALID_LABEL;
 	new->num_labels = 0;
 	new->vrf_id = VRF_UNKNOWN;
-	new->vrf_id_local = FALSE;
+	new->vrf_local = FALSE;
 	return new;
 }
 
@@ -3295,7 +3295,7 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 			struct bgp *bgp_nexthop = bgp;
 
 			if (pi->extra) {
-				if (pi->extra->vrf_id_local)
+				if (pi->extra->vrf_local)
 					bgp_nexthop = bgp;
 				else if (pi->extra->vrf_id != VRF_UNKNOWN)
 					bgp_nexthop = bgp_lookup_by_vrf_id(
@@ -6609,7 +6609,7 @@ void route_vty_out(struct vty *vty, struct prefix *p,
 	 * If vrf id of nexthop is different from that of prefix,
 	 * set up printable string to append
 	 */
-	if (path->extra && !path->extra->vrf_id_local
+	if (path->extra && !path->extra->vrf_local
 	    && (path->extra->bgp_orig ||
 		(path->extra->vrf_id != VRF_UNKNOWN &&
 		 path->peer && path->peer->bgp

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -144,7 +144,7 @@ struct bgp_path_info_extra {
 	 * this value will be overriden if route-map overrides vrf_id value
 	 */
 	vrf_id_t vrf_id;
-	bool vrf_id_local;
+	bool vrf_local;
 	/*
 	 * Nexthop in context of original bgp instance. Needed
 	 * for label resolution of core mpls routes exported to a vrf.

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -144,6 +144,7 @@ struct bgp_path_info_extra {
 	 * this value will be overriden if route-map overrides vrf_id value
 	 */
 	vrf_id_t vrf_id;
+	bool vrf_id_local;
 	/*
 	 * Nexthop in context of original bgp instance. Needed
 	 * for label resolution of core mpls routes exported to a vrf.

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -140,7 +140,10 @@ struct bgp_path_info_extra {
 	 * Set to NULL if route is not imported from another bgp instance.
 	 */
 	struct bgp *bgp_orig;
-
+	/* set to VRF_UNKNOWN by default
+	 * this value will be overriden if route-map overrides vrf_id value
+	 */
+	vrf_id_t vrf_id;
 	/*
 	 * Nexthop in context of original bgp instance. Needed
 	 * for label resolution of core mpls routes exported to a vrf.

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -371,6 +371,7 @@ extern void bgp_path_info_reap(struct bgp_node *rn, struct bgp_path_info *pi);
 extern void bgp_path_info_delete(struct bgp_node *rn, struct bgp_path_info *pi);
 extern struct bgp_path_info_extra *
 bgp_path_info_extra_get(struct bgp_path_info *path);
+extern void bgp_path_info_extra_free(struct bgp_path_info_extra **extra);
 extern void bgp_path_info_set_flag(struct bgp_node *rn,
 				   struct bgp_path_info *path, uint32_t flag);
 extern void bgp_path_info_unset_flag(struct bgp_node *rn,

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -100,6 +100,7 @@ o Cisco route-map
       ip default        :  (This will not be implemented by bgpd)
       ip next-hop       :  Done
       nexthop-vrf       :  Done
+      nexthop-vrf-local :  Done
       ip precedence     :  (This will not be implemented by bgpd)
       ip tos            :  (This will not be implemented by bgpd)
       level             :  (This will not be implemented by bgpd)
@@ -1459,6 +1460,7 @@ struct rmap_ip_nexthop_set {
 	int peer_address;
 	int unchanged;
 	char *name;
+	bool vrf_local;
 };
 
 static route_map_result_t route_set_ip_nexthop(void *rule,
@@ -1505,6 +1507,10 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 			vrf_name_to_id(rins->name);
 		SET_FLAG(path->attr->rmap_change_flags,
 			 BATTR_RMAP_VRF_NHOP_CHANGED);
+	} else if (rins->vrf_local) {
+		bgp_path_info_extra_get(path)->vrf_id_local = TRUE;
+		SET_FLAG(path->attr->rmap_change_flags,
+			 BATTR_RMAP_VRF_NHOP_CHANGED);
 	} else {
 		/* Set next hop value. */
 		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
@@ -1517,6 +1523,18 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 	}
 
 	return RMAP_OKAY;
+}
+
+static void *route_set_nexthop_vrf_local_compile(const char *arg_unused)
+{
+	struct rmap_ip_nexthop_set *rins;
+
+	rins = XCALLOC(MTYPE_ROUTE_MAP_COMPILED,
+		       sizeof(struct rmap_ip_nexthop_set));
+
+	rins->vrf_local = TRUE;
+
+	return rins;
 }
 
 static void *route_set_nexthop_vrf_compile(const char *arg)
@@ -1578,7 +1596,7 @@ static void route_set_ip_nexthop_free(void *rule)
 		XFREE(MTYPE_ROUTE_MAP_COMPILED, rins->name);
 	if (rins->address)
 		XFREE(MTYPE_ROUTE_MAP_COMPILED, rins->address);
-
+	rins->vrf_local = 0;
 	XFREE(MTYPE_ROUTE_MAP_COMPILED, rins);
 }
 
@@ -1589,6 +1607,11 @@ struct route_map_rule_cmd route_set_ip_nexthop_cmd = {
 
 struct route_map_rule_cmd route_set_nexthop_vrf_cmd = {
 	"nexthop-vrf", route_set_ip_nexthop, route_set_nexthop_vrf_compile,
+	route_set_ip_nexthop_free};
+
+struct route_map_rule_cmd route_set_nexthop_vrf_local_cmd = {
+	"nexthop-vrf-local", route_set_ip_nexthop,
+	route_set_nexthop_vrf_local_compile,
 	route_set_ip_nexthop_free};
 
 /* `set local-preference LOCAL_PREF' */
@@ -3982,6 +4005,27 @@ DEFUN (set_nexthop_vrf,
 			       "nexthop-vrf", vrfname);
 }
 
+DEFUN (unset_nexthop_vrf_local,
+       unset_nexthop_vrf_local_cmd,
+       "no set nexthop-vrf-local",
+       NO_STR
+       SET_STR
+       "Next-hop VRF is local\n")
+{
+	return generic_set_delete(vty, VTY_GET_CONTEXT(route_map_index),
+				  "nexthop-vrf-local", NULL);
+}
+
+DEFUN (set_nexthop_vrf_local,
+       set_nexthop_vrf_local_cmd,
+       "set nexthop-vrf-local",
+       SET_STR
+       "Next-hop VRF is local\n")
+{
+	return generic_set_add(vty, VTY_GET_CONTEXT(route_map_index),
+			       "nexthop-vrf-local", NULL);
+}
+
 DEFUN (set_ip_nexthop_peer,
        set_ip_nexthop_peer_cmd,
        "[no] set ip next-hop peer-address",
@@ -5029,6 +5073,7 @@ void bgp_route_map_init(void)
 
 	route_map_install_set(&route_set_ip_nexthop_cmd);
 	route_map_install_set(&route_set_nexthop_vrf_cmd);
+	route_map_install_set(&route_set_nexthop_vrf_local_cmd);
 	route_map_install_set(&route_set_local_pref_cmd);
 	route_map_install_set(&route_set_weight_cmd);
 	route_map_install_set(&route_set_label_index_cmd);
@@ -5083,6 +5128,8 @@ void bgp_route_map_init(void)
 	install_element(RMAP_NODE, &match_nexthop_vrf_cmd);
 	install_element(RMAP_NODE, &unmatch_nexthop_vrf_cmd);
 
+	install_element(RMAP_NODE, &set_nexthop_vrf_local_cmd);
+	install_element(RMAP_NODE, &unset_nexthop_vrf_local_cmd);
 	install_element(RMAP_NODE, &set_nexthop_vrf_cmd);
 	install_element(RMAP_NODE, &unset_nexthop_vrf_cmd);
 	install_element(RMAP_NODE, &set_ip_nexthop_peer_cmd);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -98,6 +98,7 @@ o Cisco route-map
       interface         :  (This will not be implemented by bgpd)
       ip default        :  (This will not be implemented by bgpd)
       ip next-hop       :  Done
+      nexthop-vrf       :  Done
       ip precedence     :  (This will not be implemented by bgpd)
       ip tos            :  (This will not be implemented by bgpd)
       level             :  (This will not be implemented by bgpd)
@@ -1392,6 +1393,7 @@ struct rmap_ip_nexthop_set {
 	struct in_addr *address;
 	int peer_address;
 	int unchanged;
+	char *name;
 };
 
 static route_map_result_t route_set_ip_nexthop(void *rule,
@@ -1433,6 +1435,11 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 				 BATTR_RMAP_NEXTHOP_PEER_ADDRESS);
 			path->attr->nexthop.s_addr = 0;
 		}
+	} else if (rins->name) {
+		bgp_path_info_extra_get(path)->vrf_id =
+			vrf_name_to_id(rins->name);
+		SET_FLAG(path->attr->rmap_change_flags,
+			 BATTR_RMAP_VRF_NHOP_CHANGED);
 	} else {
 		/* Set next hop value. */
 		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
@@ -1445,6 +1452,21 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 	}
 
 	return RMAP_OKAY;
+}
+
+static void *route_set_nexthop_vrf_compile(const char *arg)
+{
+	struct rmap_ip_nexthop_set *rins;
+	char *vrfname;
+
+	vrfname = XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, arg);
+
+	rins = XCALLOC(MTYPE_ROUTE_MAP_COMPILED,
+		       sizeof(struct rmap_ip_nexthop_set));
+
+	rins->name = vrfname;
+
+	return rins;
 }
 
 /* Route map `ip nexthop' compile function.  Given string is converted
@@ -1487,6 +1509,8 @@ static void route_set_ip_nexthop_free(void *rule)
 {
 	struct rmap_ip_nexthop_set *rins = rule;
 
+	if (rins->name)
+		XFREE(MTYPE_ROUTE_MAP_COMPILED, rins->name);
 	if (rins->address)
 		XFREE(MTYPE_ROUTE_MAP_COMPILED, rins->address);
 
@@ -1496,6 +1520,10 @@ static void route_set_ip_nexthop_free(void *rule)
 /* Route map commands for ip nexthop set. */
 struct route_map_rule_cmd route_set_ip_nexthop_cmd = {
 	"ip next-hop", route_set_ip_nexthop, route_set_ip_nexthop_compile,
+	route_set_ip_nexthop_free};
+
+struct route_map_rule_cmd route_set_nexthop_vrf_cmd = {
+	"nexthop-vrf", route_set_ip_nexthop, route_set_nexthop_vrf_compile,
 	route_set_ip_nexthop_free};
 
 /* `set local-preference LOCAL_PREF' */
@@ -3860,6 +3888,35 @@ DEFUN (no_match_origin,
 				      RMAP_EVENT_MATCH_DELETED);
 }
 
+DEFUN (unset_nexthop_vrf,
+       unset_nexthop_vrf_cmd,
+       "no set nexthop-vrf NAME",
+       NO_STR
+       SET_STR
+       "Next-hop VRF\n"
+       "VRF name\n")
+{
+	char vrfname[VRF_NAMSIZ];
+
+	snprintf(vrfname, VRF_NAMSIZ, "%s", argv[3]->arg);
+	return generic_set_delete(vty, VTY_GET_CONTEXT(route_map_index),
+				  "nexthop-vrf", vrfname);
+}
+
+DEFUN (set_nexthop_vrf,
+       set_nexthop_vrf_cmd,
+       "set nexthop-vrf NAME",
+       SET_STR
+       "Next-hop VRF\n"
+       "VRF name\n")
+{
+	char vrfname[VRF_NAMSIZ];
+
+	snprintf(vrfname, VRF_NAMSIZ, "%s", argv[2]->arg);
+	return generic_set_add(vty, VTY_GET_CONTEXT(route_map_index),
+			       "nexthop-vrf", vrfname);
+}
+
 DEFUN (set_ip_nexthop_peer,
        set_ip_nexthop_peer_cmd,
        "[no] set ip next-hop peer-address",
@@ -4905,6 +4962,7 @@ void bgp_route_map_init(void)
 	route_map_install_match(&route_match_evpn_default_route_cmd);
 
 	route_map_install_set(&route_set_ip_nexthop_cmd);
+	route_map_install_set(&route_set_nexthop_vrf_cmd);
 	route_map_install_set(&route_set_local_pref_cmd);
 	route_map_install_set(&route_set_weight_cmd);
 	route_map_install_set(&route_set_label_index_cmd);
@@ -4957,6 +5015,8 @@ void bgp_route_map_init(void)
 	install_element(RMAP_NODE, &match_probability_cmd);
 	install_element(RMAP_NODE, &no_match_probability_cmd);
 
+	install_element(RMAP_NODE, &set_nexthop_vrf_cmd);
+	install_element(RMAP_NODE, &unset_nexthop_vrf_cmd);
 	install_element(RMAP_NODE, &set_ip_nexthop_peer_cmd);
 	install_element(RMAP_NODE, &set_ip_nexthop_unchanged_cmd);
 	install_element(RMAP_NODE, &set_local_pref_cmd);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1508,7 +1508,7 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 		SET_FLAG(path->attr->rmap_change_flags,
 			 BATTR_RMAP_VRF_NHOP_CHANGED);
 	} else if (rins->vrf_local) {
-		bgp_path_info_extra_get(path)->vrf_id_local = TRUE;
+		bgp_path_info_extra_get(path)->vrf_local = TRUE;
 		SET_FLAG(path->attr->rmap_change_flags,
 			 BATTR_RMAP_VRF_NHOP_CHANGED);
 	} else {

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -74,6 +74,7 @@ o Cisco route-map
        interface        :  Done
        ip address       :  Done
        ip next-hop      :  Done
+       nexthop-vrf      :  Done
        ip route-source  :  Done
        ip prefix-list   :  Done
        ipv6 address     :  Done
@@ -498,6 +499,64 @@ static route_map_result_t route_match_ip_next_hop(void *rule,
 	return RMAP_NOMATCH;
 }
 
+/* Match function return 1 if match is success else return zero. */
+static route_map_result_t route_match_next_hop_vrf(void *rule,
+						  const struct prefix *prefix,
+						  route_map_object_t type,
+						  void *object)
+{
+	struct bgp_path_info *path;
+	struct bgp_path_info *path_ultimate;
+	vrf_id_t vrf_id;
+
+	if (type == RMAP_BGP) {
+		path = object;
+		vrf_id = vrf_name_to_id((char *)rule);
+		if (vrf_id == VRF_UNKNOWN)
+			return RMAP_NOMATCH;
+		/* search for bgp_info ultimate of bgp_info */
+		for (path_ultimate = path;
+		     path_ultimate->extra && path_ultimate->extra->parent;
+		     path_ultimate = path_ultimate->extra->parent)
+			;
+		if (path_ultimate->peer->bgp &&
+		    path_ultimate->peer->bgp->vrf_id == vrf_id)
+			return RMAP_MATCH;
+	}
+	return RMAP_NOMATCH;
+}
+
+DEFUN (unmatch_nexthop_vrf,
+       unmatch_nexthop_vrf_cmd,
+       "no match nexthop-vrf NAME",
+       NO_STR
+       MATCH_STR
+       "Next-hop VRF\n"
+       "VRF name\n")
+{
+	char vrfname[VRF_NAMSIZ];
+
+	snprintf(vrfname, VRF_NAMSIZ, "%s", argv[3]->arg);
+	return generic_match_delete(vty, VTY_GET_CONTEXT(route_map_index),
+				    "nexthop-vrf",
+				    vrfname, RMAP_EVENT_MATCH_DELETED);
+}
+
+DEFUN (match_nexthop_vrf,
+       match_nexthop_vrf_cmd,
+       "match nexthop-vrf NAME",
+       MATCH_STR
+       "Next-hop VRF\n"
+       "VRF name\n")
+{
+	char vrfname[VRF_NAMSIZ];
+
+	snprintf(vrfname, VRF_NAMSIZ, "%s", argv[2]->arg);
+	return generic_match_add(vty, VTY_GET_CONTEXT(route_map_index),
+				 "nexthop-vrf",
+				 vrfname, RMAP_EVENT_MATCH_ADDED);
+}
+
 /* Route map `ip next-hop' match statement. `arg' is
    access-list name. */
 static void *route_match_ip_next_hop_compile(const char *arg)
@@ -514,6 +573,12 @@ static void route_match_ip_next_hop_free(void *rule)
 /* Route map commands for ip next-hop matching. */
 struct route_map_rule_cmd route_match_ip_next_hop_cmd = {
 	"ip next-hop", route_match_ip_next_hop, route_match_ip_next_hop_compile,
+	route_match_ip_next_hop_free};
+
+/* Route map commands for nexthop-vrf matching. */
+struct route_map_rule_cmd route_match_next_hop_vrf_cmd = {
+	"nexthop-vrf", route_match_next_hop_vrf,
+	route_match_ip_next_hop_compile,
 	route_match_ip_next_hop_free};
 
 /* `match ip route-source ACCESS-LIST' */
@@ -4941,6 +5006,7 @@ void bgp_route_map_init(void)
 #endif
 	route_map_install_match(&route_match_ip_address_cmd);
 	route_map_install_match(&route_match_ip_next_hop_cmd);
+	route_map_install_match(&route_match_next_hop_vrf_cmd);
 	route_map_install_match(&route_match_ip_route_source_cmd);
 	route_map_install_match(&route_match_ip_address_prefix_list_cmd);
 	route_map_install_match(&route_match_ip_next_hop_prefix_list_cmd);
@@ -5014,6 +5080,8 @@ void bgp_route_map_init(void)
 	install_element(RMAP_NODE, &no_match_origin_cmd);
 	install_element(RMAP_NODE, &match_probability_cmd);
 	install_element(RMAP_NODE, &no_match_probability_cmd);
+	install_element(RMAP_NODE, &match_nexthop_vrf_cmd);
+	install_element(RMAP_NODE, &unmatch_nexthop_vrf_cmd);
 
 	install_element(RMAP_NODE, &set_nexthop_vrf_cmd);
 	install_element(RMAP_NODE, &unset_nexthop_vrf_cmd);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1226,7 +1226,7 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 	/*
 	 * vrf leaking support (will have only one nexthop)
 	 */
-	if (info->extra && info->extra->vrf_id_local)
+	if (info->extra && info->extra->vrf_local)
 		nh_othervrf = 0;
 	else if (info->extra && info->extra->vrf_id != VRF_UNKNOWN) {
 		if (info->extra->vrf_id != bgp->vrf_id)

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1226,9 +1226,15 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 	/*
 	 * vrf leaking support (will have only one nexthop)
 	 */
-	if (info->extra && info->extra->bgp_orig)
+	if (info->extra && info->extra->vrf_id_local)
+		nh_othervrf = 0;
+	else if (info->extra && info->extra->vrf_id != VRF_UNKNOWN) {
+		if (info->extra->vrf_id != bgp->vrf_id)
+			nh_othervrf = 0;
+		else
+			nh_othervrf = 1;
+	} else if (info->extra && info->extra->bgp_orig)
 		nh_othervrf = 1;
-
 	/* Make Zebra API structure. */
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = bgp->vrf_id;
@@ -1287,8 +1293,13 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 			continue;
 
 		api_nh = &api.nexthops[valid_nh_count];
-		api_nh->vrf_id = nh_othervrf ? info->extra->bgp_orig->vrf_id
-					     : bgp->vrf_id;
+		if (nh_othervrf) {
+			if (info->extra->vrf_id != VRF_UNKNOWN)
+				api_nh->vrf_id = info->extra->vrf_id;
+			else if (info->extra->bgp_orig->vrf_id)
+				api_nh->vrf_id = info->extra->bgp_orig->vrf_id;
+		} else
+			api_nh->vrf_id = bgp->vrf_id;
 		if (nh_family == AF_INET) {
 			if (bgp_debug_zebra(&api.prefix)) {
 				if (mpinfo->extra) {

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1890,6 +1890,41 @@ address-family:
    Disables automatic leaking from vrf VRFNAME to the current VRF using
    the VPN RIB as intermediary.
 
+Leaking with Netns Based VRF
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When BGP routes may be leaked in a separate VRF,  the validation process in
+BGP checks that the nexthop entry is reachable in the remote VRF. If reachable,
+then the entry is injected in to the *zebra* RIB. There, a selection process
+may elect the entry.
+The validation and selection process is conditionated by the kind of VRF backend.
+Currently, only the *Linux VRF* implementation is able to handle VRF route leaks.
+However, if the VRF backend is based on Linux network namespaces, it is possible
+to use route-maps that change the nexthop targeted VRF.
+
+Instead of keeping the targeted VRF and nexthop provided by the origin route, the
+topology assumes there are some virtual ethernet link topology between network namespaces.
+Those virtual ethernet links are IP-based. A route-map is applied to imported entries.
+Targeted nexthop VRF is matched and replaced by local VRF. As the virtual ethernet link
+are IP based, the targeted nexthop is replaced by the IP from the virtual ethernet interface
+that is owned by the targeted VRF.
+
+Following command helps on how to match imported vrf entries, under route-map config node.
+
+.. index:: match nexthop-vrf VRFNAME
+.. clicmd:: match nexthop-vrf VRFNAME
+
+Following command helps on how to change targeted nexthop vrf and nexthop ip, under route-map
+config node.
+
+.. index:: set nexthop-vrf VRFNAME
+.. clicmd:: set nexthop-vrf VRFNAME
+
+.. index:: set ip nexthop VRFNAME
+.. clicmd:: set ip nexthop VRFNAME
+
+.. index:: set nexthop-vrf-local
+.. clicmd:: set nexthop-vrf-local
 
 .. _bgp-cisco-compatibility:
 

--- a/tests/topotests/bgp_l3vpn_leakip/bgp-vrf-leakip-topo.dot
+++ b/tests/topotests/bgp_l3vpn_leakip/bgp-vrf-leakip-topo.dot
@@ -1,0 +1,76 @@
+## Color coding:
+#########################
+##  Main FRR: #f08080  red
+##  Switches: #d0e0d0  gray
+##  RIP:      #19e3d9  Cyan
+##  RIPng:    #fcb314  dark yellow
+##  OSPFv2:   #32b835  Green
+##  OSPFv3:   #19e3d9  Cyan
+##  ISIS IPv4 #fcb314  dark yellow
+##  ISIS IPv6 #9a81ec  purple
+##  BGP IPv4  #eee3d3  beige
+##  BGP IPv6  #fdff00  yellow
+##### Colors (see http://www.color-hex.com/)
+
+graph bgp_vrf_netns_eBGP_topo1 {
+	label="bgp vrf netns topo1 - eBGP with different AS numbers";
+    labelloc="t";
+
+	# Routers
+	r1-vrf-cust1 [
+		label="r1\nrtr-id 1.1.1.1/32",
+		shape=doubleoctagon,
+		fillcolor="#f08080",
+		style=filled,
+	];
+
+        r1-vrf-cust2 [
+		label="r1\nrtr-id 2.2.2.2/32",
+		shape=doubleoctagon,
+		fillcolor="#f08080",
+		style=filled,
+	];
+
+	# 1 Switch for BGP Peers
+	s1 [
+		label="s1\n1.1.1.0/24",
+		shape=oval,
+		fillcolor="#d0e0d0",
+		style=filled,
+	];
+
+        # 1 Switch for BGP Peers
+	s2 [
+		label="s1\n2.2.2.0/24",
+		shape=oval,
+		fillcolor="#d0e0d0",
+		style=filled,
+	];
+
+	# 1 ExaBGP Peers AS 100
+	peer1 [
+		label="eBGP peer1\nAS100\nrtr-id 1.1.1.2/32",
+		shape=rectangle,
+		fillcolor="#eee3d3",
+		style=filled,
+	];
+
+	# 1 ExaBGP Peers AS 100
+	peer1 [
+		label="eBGP peer2\nAS100\nrtr-id 2.2.2.3/32",
+		shape=rectangle,
+		fillcolor="#eee3d3",
+		style=filled,
+	];
+
+        # Connections
+	r1-vrf-cust1 -- s1 [label="eth0\n.1"];
+	r1-vrf-cust2 -- s2 [label="eth1\n.1"];
+
+	peer1 -- s1 [label="eth0\n.101"];
+	peer2 -- s2 [label="eth1\n.101"];
+
+	# Arrange network to make cleaner diagram
+	{ rank=same peer1 } -- s1 -- { rank=same r1-vrf-cust1 } [style=invis]
+	{ rank=same peer2 } -- s2 -- { rank=same r1-vrf-cust2 } [style=invis]
+}

--- a/tests/topotests/bgp_l3vpn_leakip/exabgp.env
+++ b/tests/topotests/bgp_l3vpn_leakip/exabgp.env
@@ -1,0 +1,54 @@
+
+[exabgp.api]
+encoder = text
+highres = false
+respawn = false
+socket = ''
+
+[exabgp.bgp]
+openwait = 60
+
+[exabgp.cache]
+attributes = true
+nexthops = true
+
+[exabgp.daemon]
+daemonize = true
+pid = '/var/run/exabgp/exabgp.pid'
+user = 'exabgp'
+##daemonize = false
+
+[exabgp.log]
+all = false
+configuration = true
+daemon = true
+destination = '/var/log/exabgp.log'
+enable = true
+level = INFO
+message = false
+network = true
+packets = false
+parser = false
+processes = true
+reactor = true
+rib = false
+routes = false
+short = false
+timers = false
+
+[exabgp.pdb]
+enable = false
+
+[exabgp.profile]
+enable = false
+file = ''
+
+[exabgp.reactor]
+speed = 1.0
+
+[exabgp.tcp]
+acl = false
+bind = ''
+delay = 0
+once = false
+port = 179

--- a/tests/topotests/bgp_l3vpn_leakip/peer1/exa-receive.py
+++ b/tests/topotests/bgp_l3vpn_leakip/peer1/exa-receive.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+"""
+exa-receive.py: Save received routes form ExaBGP into file
+"""
+
+from sys import stdin,argv
+from datetime import datetime
+
+# 1st arg is peer number
+peer = int(argv[1])
+
+# When the parent dies we are seeing continual newlines, so we only access so many before stopping
+counter = 0
+
+routesavefile = open('/tmp/peer%s-received.log' % peer, 'w')
+
+while True:
+    try:
+        line = stdin.readline()
+        timestamp = datetime.now().strftime('%Y%m%d_%H:%M:%S - ')
+        routesavefile.write(timestamp + line)
+        routesavefile.flush()
+
+        if line == "":
+            counter += 1
+            if counter > 100:
+                break
+            continue
+
+        counter = 0
+    except KeyboardInterrupt:
+        pass
+    except IOError:
+        # most likely a signal during readline
+        pass
+
+routesavefile.close()

--- a/tests/topotests/bgp_l3vpn_leakip/peer1/exa-send.py
+++ b/tests/topotests/bgp_l3vpn_leakip/peer1/exa-send.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+"""
+exa-send.py: Send a few testroutes with ExaBGP
+"""
+
+from sys import stdout,argv
+from time import sleep
+
+sleep(5)
+
+# 1st arg is peer number
+# 2nd arg is number of routes to send
+peer = int(argv[1])
+numRoutes = int(argv[2])
+asnum = 100
+
+# Announce numRoutes equal routes per PE - different neighbor AS
+for i in range(0, numRoutes):
+    stdout.write('announce route 10.101.%s.0/24 next-hop 1.1.1.2\n' % (i ))
+    stdout.flush()
+
+#Loop endlessly to allow ExaBGP to continue running
+while True:
+    sleep(1)
+

--- a/tests/topotests/bgp_l3vpn_leakip/peer1/exabgp.cfg
+++ b/tests/topotests/bgp_l3vpn_leakip/peer1/exabgp.cfg
@@ -1,0 +1,21 @@
+group controller {
+
+    process announce-routes {
+        run "/etc/exabgp/exa-send.py 1 10";
+    }
+
+    process receive-routes {
+        run "/etc/exabgp/exa-receive.py 1";
+        receive-routes;
+        encoder text;
+    }
+
+    neighbor 1.1.1.1 {
+        router-id 1.1.1.2;
+        local-address 1.1.1.2;
+        local-as 100;
+        peer-as 100;
+        graceful-restart;
+    }
+
+}

--- a/tests/topotests/bgp_l3vpn_leakip/peer2/exa-receive.py
+++ b/tests/topotests/bgp_l3vpn_leakip/peer2/exa-receive.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+"""
+exa-receive.py: Save received routes form ExaBGP into file
+"""
+
+from sys import stdin,argv
+from datetime import datetime
+
+# 1st arg is peer number
+peer = int(argv[1])
+
+# When the parent dies we are seeing continual newlines, so we only access so many before stopping
+counter = 0
+
+routesavefile = open('/tmp/peer%s-received.log' % peer, 'w')
+
+while True:
+    try:
+        line = stdin.readline()
+        timestamp = datetime.now().strftime('%Y%m%d_%H:%M:%S - ')
+        routesavefile.write(timestamp + line)
+        routesavefile.flush()
+
+        if line == "":
+            counter += 1
+            if counter > 100:
+                break
+            continue
+
+        counter = 0
+    except KeyboardInterrupt:
+        pass
+    except IOError:
+        # most likely a signal during readline
+        pass
+
+routesavefile.close()

--- a/tests/topotests/bgp_l3vpn_leakip/peer2/exa-send.py
+++ b/tests/topotests/bgp_l3vpn_leakip/peer2/exa-send.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+"""
+exa-send.py: Send a few testroutes with ExaBGP
+"""
+
+from sys import stdout,argv
+from time import sleep
+
+sleep(5)
+
+# 1st arg is peer number
+# 2nd arg is number of routes to send
+peer = int(argv[1])
+numRoutes = int(argv[2])
+asnum = 100
+
+# Announce numRoutes equal routes per PE - different neighbor AS
+for i in range(0, numRoutes):
+    stdout.write('announce route 10.201.%s.0/24 next-hop 2.2.2.3\n' % (i ))
+    stdout.flush()
+
+#Loop endlessly to allow ExaBGP to continue running
+while True:
+    sleep(1)
+

--- a/tests/topotests/bgp_l3vpn_leakip/peer2/exabgp.cfg
+++ b/tests/topotests/bgp_l3vpn_leakip/peer2/exabgp.cfg
@@ -1,0 +1,21 @@
+group controller {
+
+    process announce-routes {
+        run "/etc/exabgp/exa-send.py 1 10";
+    }
+
+    process receive-routes {
+        run "/etc/exabgp/exa-receive.py 1";
+        receive-routes;
+        encoder text;
+    }
+
+    neighbor 2.2.2.2 {
+        router-id 2.2.2.3;
+        local-address 2.2.2.3;
+        local-as 100;
+        peer-as 100;
+        graceful-restart;
+    }
+
+}

--- a/tests/topotests/bgp_l3vpn_leakip/r1/bgpd.conf
+++ b/tests/topotests/bgp_l3vpn_leakip/r1/bgpd.conf
@@ -1,0 +1,39 @@
+!
+router bgp 100
+ bgp router-id 3.3.3.3
+exit
+router bgp 100 vrf r1-cust1
+ bgp router-id 1.1.1.1
+ neighbor 1.1.1.2 remote-as 100
+ address-family ipv4 unicast
+  route-map vpn import vr2tovr1
+  rd vpn export 1:55
+  rt vpn import 2:55 1:55
+  rt vpn export 1:55
+  import vpn
+  export vpn
+exit-address-family
+exit
+router bgp 100 vrf r1-cust2
+ bgp router-id 2.2.2.2
+ neighbor 2.2.2.3 remote-as 100
+ address-family ipv4 unicast
+  route-map vpn import vr1tovr2
+  rd vpn export 2:55
+  rt vpn import 2:55 1:55
+  rt vpn export 2:55
+  export vpn
+  import vpn
+ exit-address-family
+exit
+route-map vr2tovr1 permit 1
+ match nexthop-vrf r1-cust2
+ set ip next-hop 169.254.128.2
+ set nexthop-vrf local
+exit
+route-map vr1tovr2 permit 1
+ match nexthop-vrf r1-cust1
+ set ip next-hop 169.254.128.1
+ set nexthop-vrf local
+exit
+

--- a/tests/topotests/bgp_l3vpn_leakip/r1/summary_peer1.txt
+++ b/tests/topotests/bgp_l3vpn_leakip/r1/summary_peer1.txt
@@ -1,0 +1,18 @@
+
+{
+"ipv4Unicast":{
+  "routerId":"1.1.1.1",
+  "as":100,
+  "vrfName":"r1-cust1",
+  "peerCount":1,
+  "peers":{
+    "1.1.1.2":{
+      "outq":0,
+      "inq":0,
+      "prefixReceivedCount":10,
+      "state":"Established"
+    }
+  },
+  "totalPeers":1
+}
+}

--- a/tests/topotests/bgp_l3vpn_leakip/r1/summary_peer2.txt
+++ b/tests/topotests/bgp_l3vpn_leakip/r1/summary_peer2.txt
@@ -1,0 +1,18 @@
+
+{
+"ipv4Unicast":{
+  "routerId":"2.2.2.2",
+  "as":100,
+  "vrfName":"r1-cust2",
+  "peerCount":1,
+  "peers":{
+    "2.2.2.3":{
+      "outq":0,
+      "inq":0,
+      "prefixReceivedCount":10,
+      "state":"Established"
+    }
+  },
+  "totalPeers":1
+}
+}

--- a/tests/topotests/bgp_l3vpn_leakip/r1/zebra.conf
+++ b/tests/topotests/bgp_l3vpn_leakip/r1/zebra.conf
@@ -1,0 +1,16 @@
+!
+interface r1-eth0 vrf r1-cust1
+ ip address 1.1.1.1/24
+!
+interface r1-eth1 vrf r1-cust2
+ ip address 2.2.2.2/24
+!
+interface r1-cust1 vrf r1-cust1
+ ip address 169.254.128.1/24
+!
+interface r1-cust2 vrf r1-cust2
+ ip address 169.254.128.2/24
+!
+line vty
+!
+debug vrf

--- a/tests/topotests/bgp_l3vpn_leakip/test_bgp_vrf_leakip_topo.py
+++ b/tests/topotests/bgp_l3vpn_leakip/test_bgp_vrf_leakip_topo.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_vrf_ipleak_topo.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2018 by 6WIND
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+test_bgp_vrf_ipleak_topo.py: Test BGP topology with EBGP on NETNS VRF
+"""
+
+import json
+import os
+import sys
+import functools
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+# Required to instantiate the topology builder class.
+from mininet.topo import Topo
+
+total_ebgp_peers = 1
+CustomizeVrfWithNetns = True
+
+#####################################################
+##
+##   Network Topology Definition
+##
+#####################################################
+
+class BGPVRFIPLEAKTopo(Topo):
+    "BGP BGP VRF Leak Topology 1"
+
+    def build(self, **_opts):
+        tgen = get_topogen(self)
+
+        # Setup Routers
+        tgen.add_router('r1')
+
+        # Setup Switches
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+
+        # Add eBGP ExaBGP neighbors
+        peer_ip = '1.1.1.2'
+        peer_route = 'via 1.1.1.2'
+        peer = tgen.add_exabgp_peer('peer1',
+                                    ip=peer_ip, defaultRoute=peer_route)
+        switch.add_link(peer)
+
+        switch = tgen.add_switch('s2')
+        switch.add_link(tgen.gears['r1'])
+
+        peer_ip = '2.2.2.3'
+        peer_route = 'via 2.2.2.3'
+        peer = tgen.add_exabgp_peer('peer2',
+                                    ip=peer_ip, defaultRoute=peer_route)
+        switch.add_link(peer)
+
+#####################################################
+##
+##   Tests starting
+##
+#####################################################
+
+def setup_module(module):
+    tgen = Topogen(BGPVRFIPLEAKTopo, module.__name__)
+    tgen.start_topology()
+
+    # Get r1 reference
+    router = tgen.gears['r1']
+
+    # check for zebra capability
+    if CustomizeVrfWithNetns == True:
+        if router.check_capability(
+                TopoRouter.RD_ZEBRA,
+                '--vrfwnetns'
+                ) == False:
+            return  pytest.skip('Skipping BGP VRF NETNS Test. VRF NETNS backend not available on FRR')
+        if os.system('ip netns list') != 0:
+            return  pytest.skip('Skipping BGP VRF NETNS Test. NETNS not available on System')
+    # retrieve VRF backend kind
+    if CustomizeVrfWithNetns == True:
+        logger.info('Testing with VRF Namespace support')
+
+    # sanity check - del previous vrf if any
+    cmds = ['ip netns del {0}-cust1',
+            'ip netns del {0}-cust2']
+    for cmd in cmds:
+        cmd = cmd.format('r1')
+        logger.info('cmd: '+cmd);
+        router.run(cmd.format('r1'))
+
+    # create r1-cust1 and r1-cust2
+    cmds = ['ip netns add {0}-cust1',
+            'ip link set dev {0}-eth0 netns {0}-cust1',
+            'ip netns exec {0}-cust1 ifconfig {0}-eth0 up',
+            'ip netns exec {0}-cust1 ip li set dev lo up',
+            'ip netns add {0}-cust2',
+            'ip link set dev {0}-eth1 netns {0}-cust2',
+            'ip netns exec {0}-cust2 ifconfig {0}-eth1 up',
+            'ip netns exec {0}-cust2 ip li set dev lo up']
+    for cmd in cmds:
+        cmd = cmd.format('r1')
+        logger.info('cmd: '+cmd);
+        output = router.run(cmd.format('r1'))
+        if output != None and len(output) > 0:
+            logger.info('Aborting due to unexpected output: cmd="{}" output=\n{}'.format(cmd, output))
+            return pytest.skip('Skipping BGP VRF NETNS Test. Unexpected output to command: '+cmd)
+
+    # create virtual ethernet interface across rx
+    cmds = ['ip link add r1-cust1 type veth peer name r1-cust2',
+            'ip link set r1-cust1 netns r1-cust1',
+            'ip link set r1-cust2 netns r1-cust2',
+            'ip netns exec r1-cust1 ip link set dev r1-cust1 up',
+            'ip netns exec r1-cust2 ip link set dev r1-cust2 up']
+    for cmd in cmds:
+        cmd = cmd.format('r1')
+        logger.info('cmd: '+cmd);
+        output = router.run(cmd.format('r1'))
+        if output != None and len(output) > 0:
+            logger.info('Aborting due to unexpected output: cmd="{}" output=\n{}'.format(cmd, output))
+            return pytest.skip('Skipping BGP VRF NETNS Test. Unexpected output to command: '+cmd)
+
+    #run daemons
+    router.load_config(
+        TopoRouter.RD_ZEBRA,
+        os.path.join(CWD, '{}/zebra.conf'.format('r1')),
+        '--vrfwnetns'
+    )
+
+    router.load_config(
+        TopoRouter.RD_BGP,
+        os.path.join(CWD, '{}/bgpd.conf'.format('r1'))
+    )
+
+    logger.info('Launching BGP and ZEBRA')
+    # BGP and ZEBRA start without underlying VRF
+    router.start()
+    # Starting Hosts and init ExaBGP on each of them
+    logger.info('starting exaBGP on peer1')
+    peer_list = tgen.exabgp_peers()
+    for pname, peer in peer_list.iteritems():
+        peer_dir = os.path.join(CWD, pname)
+        env_file = os.path.join(CWD, 'exabgp.env')
+        logger.info('Running ExaBGP peer')
+        peer.start(peer_dir, env_file)
+        logger.info(pname)
+
+def teardown_module(module):
+    tgen = get_topogen()
+    # move back r1-eth0 to default VRF
+    # delete VRF r1-cust1
+    cmds = ['ip netns exec {0}-cust1 ip link set {0}-eth0 netns 1',
+            'ip netns delete {0}-cust1']
+    for cmd in cmds:
+        tgen.net['r1'].cmd(cmd.format('r1'))
+
+    tgen.stop_topology()
+
+def test_bgp_vrf_ipleak_learn():
+    "Test daemon learnt VRF context"
+    tgen = get_topogen()
+
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Expected result
+    output = tgen.gears['r1'].vtysh_cmd("show vrf", isjson=False)
+    logger.info('output is: {}'.format(output))
+
+    output = tgen.gears['r1'].vtysh_cmd("show bgp vrfs", isjson=False)
+    logger.info('output is: {}'.format(output))
+
+
+def test_bgp_convergence():
+    "Test for BGP topology convergence"
+    tgen = get_topogen()
+
+    # uncomment if you want to troubleshoot
+    # tgen.mininet_cli()
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    logger.info('waiting for bgp convergence')
+
+    # Expected result
+    router = tgen.gears['r1']
+    reffile = os.path.join(CWD, 'r1/summary_peer1.txt')
+
+    expected = json.loads(open(reffile).read())
+
+    test_func = functools.partial(topotest.router_json_cmp,
+        router, 'show bgp vrf r1-cust1 summary json', expected)
+    _, res = topotest.run_and_expect(test_func, None, count=10, wait=0.5)
+    assertmsg = 'BGP router network for peer 1 did not converge'
+    assert res is None, assertmsg
+
+    router = tgen.gears['r1']
+    reffile = os.path.join(CWD, 'r1/summary_peer2.txt')
+
+    expected = json.loads(open(reffile).read())
+
+    test_func = functools.partial(topotest.router_json_cmp,
+        router, 'show bgp vrf r1-cust2 summary json', expected)
+    _, res = topotest.run_and_expect(test_func, None, count=90, wait=0.5)
+    assertmsg = 'BGP router network for peer 2 did not converge'
+
+    assert res is None, assertmsg
+
+def test_bgp_vrf_ipleak():
+    tgen = get_topogen()
+
+    # tgen.mininet_cli()
+    # Skip if previous fatal error condition is raised
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    expect = {
+        'routerId': '1.1.1.1',
+        'routes': {
+        },
+    }
+
+    list_values = {'0','1','2','3','4','5','6','7','8','9'}
+    donna = tgen.gears['r1'].vtysh_cmd("show bgp vrf r1-cust1 ipv4 json", isjson=True)
+
+    routes = donna['routes']
+    for i in list_values:
+        routeid = routes['10.201.{}.0/24'.format(i)]
+        assert routeid is not None, "route 10.201.{}.0/24 not found".format(i)
+        nexthopid = routeid[0]['nexthops']
+        assert nexthopid is not None, "nexthop for 10.201.{}.0/24 not found".format(i)
+        nh = nexthopid[0]['ip']
+        assert nh == "169.254.128.2", "nexthop {} not expected".format(nh)
+
+    donna = tgen.gears['r1'].vtysh_cmd("show bgp vrf r1-cust2 ipv4 json", isjson=True)
+
+    routes = donna['routes']
+    for i in list_values:
+        routeid = routes['10.101.{}.0/24'.format(i)]
+        assert routeid is not None, "route 10.101.{}.0/24 not found".format(i)
+        nexthopid = routeid[0]['nexthops']
+        assert nexthopid is not None, "nexthop for 10.101.{}.0/24 not found".format(i)
+        nh = nexthopid[0]['ip']
+        assert nh == "169.254.128.1", "nexthop {} not expected".format(nh)
+    
+    donna = tgen.gears['r1'].vtysh_cmd("show ip route vrf r1-cust1 json", isjson=True)
+    for i in list_values:
+        routeid = donna['10.201.{}.0/24'.format(i)]
+        assert routeid is not None, "route 10.201.{}.0/24 not found".format(i)
+        nexthopid = routeid[0]['nexthops']
+        assert nexthopid is not None, "nexthop for 10.201.{}.0/24 not found".format(i)
+        fib = nexthopid[0]['fib']
+        nh = nexthopid[0]['ip']
+        assert fib == True, "nexthop {} not added to FIB".format(nh)
+
+    donna = tgen.gears['r1'].vtysh_cmd("show ip route vrf r1-cust2 json", isjson=True)
+    for i in list_values:
+        routeid = donna['10.101.{}.0/24'.format(i)]
+        assert routeid is not None, "route 10.101.{}.0/24 not found".format(i)
+        nexthopid = routeid[0]['nexthops']
+        fib = nexthopid[0]['fib']
+        nh = nexthopid[0]['ip']
+        assert fib == True, "nexthop {} not added to FIB".format(nh)
+
+
+if __name__ == '__main__':
+
+    args = ["-s"] + sys.argv[1:]
+    ret = pytest.main(args)
+
+    sys.exit(ret)

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -8866,6 +8866,11 @@ void zebra_vxlan_close_tables(struct zebra_vrf *zvrf)
 /* init the l3vni table */
 void zebra_vxlan_ns_init(struct zebra_ns *zns)
 {
+	static int inited;
+
+	if (inited)
+		return;
+	inited++;
 	zrouter.l3vni_table = hash_create(l3vni_hash_keymake, l3vni_hash_cmp,
 					  "Zebra VRF L3 VNI table");
 }
@@ -8873,6 +8878,11 @@ void zebra_vxlan_ns_init(struct zebra_ns *zns)
 /* free l3vni table */
 void zebra_vxlan_ns_disable(struct zebra_ns *zns)
 {
+	static int deleted;
+
+	if (deleted)
+		return;
+	deleted++;
 	hash_free(zrouter.l3vni_table);
 }
 


### PR DESCRIPTION
This pull request extends the route-map facilities by having the possibility to transform a route leak into a simple "static route with nexthop on the same vrf".
This commit is related to route-map extensions, and shows how it applies to BGP VPNv4.