### PR TITLE
bgpd: fix IPv6 next-hop field name for routes in JSON

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6851,7 +6851,7 @@ void route_vty_out_tmp(struct vty *vty, struct prefix *p, struct attr *attr,
 				char buf[BUFSIZ];
 
 				json_object_string_add(
-					json_net, "netHopGloabal",
+					json_net, "nextHopGlobal",
 					inet_ntop(AF_INET6,
 						  &attr->mp_nexthop_global, buf,
 						  BUFSIZ));


### PR DESCRIPTION
### Summary
Fix IPv6 next-hop field name for routes in JSON.

This may break existing clients but the original name contains two
errors.

Before:

```
    "2a0a:faaa:f00:0:f:0:b9cc:7684":{
      "addrPrefix":"2a0a:faaa:f00:0:f:0:b9cc:7684",
      "netHopGloabal":"::",
      "localPref":100,
      "weight":0,
      "asPath":"",
      "bgpOriginCode":"i",
      "appliedStatusSymbols":{
        "*":true,
        ">":true
      }
    }
```

After:

```
    "2a0a:faaa:f00:0:f:0:b9cc:7684":{
      "addrPrefix":"2a0a:faaa:f00:0:f:0:b9cc:7684",
      "nextHopGlobal":"::",
      "localPref":100,
      "weight":0,
      "asPath":"",
      "bgpOriginCode":"i",
      "appliedStatusSymbols":{
        "*":true,
        ">":true
      }
    }
```

### Components
bgpd