### PR TITLE
lib: convert prefixlen to 16-bit integer

### DIFF
--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -267,13 +267,13 @@ extern int bgp_build_evpn_prefix(int evpn_type, uint32_t eth_tag,
 			memcpy(&p_evpn_p->prefix_addr.ip.ipaddr_v4,
 			       &src->u.prefix4,
 			       sizeof(struct in_addr));
-			dst->prefixlen = (uint8_t)PREFIX_LEN_ROUTE_TYPE_5_IPV4;
+			dst->prefixlen = (uint16_t)PREFIX_LEN_ROUTE_TYPE_5_IPV4;
 		} else {
 			SET_IPADDR_V6(&p_evpn_p->prefix_addr.ip);
 			memcpy(&p_evpn_p->prefix_addr.ip.ipaddr_v6,
 			       &src->u.prefix6,
 			       sizeof(struct in6_addr));
-			dst->prefixlen = (uint8_t)PREFIX_LEN_ROUTE_TYPE_5_IPV6;
+			dst->prefixlen = (uint16_t)PREFIX_LEN_ROUTE_TYPE_5_IPV6;
 		}
 	} else
 		return -1;

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -971,6 +971,10 @@ uint8_t ip_masklen(struct in_addr netmask)
 {
 	uint32_t tmp = ~ntohl(netmask.s_addr);
 
+	/*
+	 * clz: count leading zeroes. sadly, the behaviour of this builtin is
+	 * undefined for a 0 argument, even though most CPUs give 32
+	 */
 	return tmp ? __builtin_clz(tmp) : 32;
 }
 

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -451,7 +451,7 @@ int is_zero_mac(struct ethaddr *mac)
 	return 1;
 }
 
-unsigned int prefix_bit(const uint8_t *prefix, const uint8_t prefixlen)
+unsigned int prefix_bit(const uint8_t *prefix, const uint16_t prefixlen)
 {
 	unsigned int offset = prefixlen / 8;
 	unsigned int shift = 7 - (prefixlen % 8);
@@ -459,7 +459,7 @@ unsigned int prefix_bit(const uint8_t *prefix, const uint8_t prefixlen)
 	return (prefix[offset] >> shift) & 1;
 }
 
-unsigned int prefix6_bit(const struct in6_addr *prefix, const uint8_t prefixlen)
+unsigned int prefix6_bit(const struct in6_addr *prefix, const uint16_t prefixlen)
 {
 	return prefix_bit((const uint8_t *)&prefix->s6_addr, prefixlen);
 }
@@ -966,18 +966,12 @@ void masklen2ip(const int masklen, struct in_addr *netmask)
 }
 
 /* Convert IP address's netmask into integer. We assume netmask is
-   sequential one. Argument netmask should be network byte order. */
+ * sequential one. Argument netmask should be network byte order. */
 uint8_t ip_masklen(struct in_addr netmask)
 {
 	uint32_t tmp = ~ntohl(netmask.s_addr);
-	if (tmp)
-		/* clz: count leading zeroes. sadly, the behaviour of this
-		 * builtin
-		 * is undefined for a 0 argument, even though most CPUs give 32
-		 */
-		return __builtin_clz(tmp);
-	else
-		return 32;
+
+	return tmp ? __builtin_clz(tmp) : 32;
 }
 
 /* Apply mask to IPv4 prefix (network byte order). */

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -151,7 +151,7 @@ struct flowspec_prefix {
 /* FRR generic prefix structure. */
 struct prefix {
 	uint8_t family;
-	uint8_t prefixlen;
+	uint16_t prefixlen;
 	union {
 		uint8_t prefix;
 		struct in_addr prefix4;
@@ -171,20 +171,20 @@ struct prefix {
 /* IPv4 prefix structure. */
 struct prefix_ipv4 {
 	uint8_t family;
-	uint8_t prefixlen;
+	uint16_t prefixlen;
 	struct in_addr prefix __attribute__((aligned(8)));
 };
 
 /* IPv6 prefix structure. */
 struct prefix_ipv6 {
 	uint8_t family;
-	uint8_t prefixlen;
+	uint16_t prefixlen;
 	struct in6_addr prefix __attribute__((aligned(8)));
 };
 
 struct prefix_ls {
 	uint8_t family;
-	uint8_t prefixlen;
+	uint16_t prefixlen;
 	struct in_addr id __attribute__((aligned(8)));
 	struct in_addr adv_router;
 };
@@ -192,21 +192,21 @@ struct prefix_ls {
 /* Prefix for routing distinguisher. */
 struct prefix_rd {
 	uint8_t family;
-	uint8_t prefixlen;
+	uint16_t prefixlen;
 	uint8_t val[8] __attribute__((aligned(8)));
 };
 
 /* Prefix for ethernet. */
 struct prefix_eth {
 	uint8_t family;
-	uint8_t prefixlen;
+	uint16_t prefixlen;
 	struct ethaddr eth_addr __attribute__((aligned(8))); /* AF_ETHERNET */
 };
 
 /* EVPN prefix structure. */
 struct prefix_evpn {
 	uint8_t family;
-	uint8_t prefixlen;
+	uint16_t prefixlen;
 	struct evpn_addr prefix __attribute__((aligned(8)));
 };
 
@@ -252,20 +252,20 @@ static inline int is_evpn_prefix_ipaddr_v6(const struct prefix_evpn *evp)
 /* Prefix for a generic pointer */
 struct prefix_ptr {
 	uint8_t family;
-	uint8_t prefixlen;
+	uint16_t prefixlen;
 	uintptr_t prefix __attribute__((aligned(8)));
 };
 
 /* Prefix for a Flowspec entry */
 struct prefix_fs {
 	uint8_t family;
-	uint8_t prefixlen; /* unused */
+	uint16_t prefixlen; /* unused */
 	struct flowspec_prefix  prefix __attribute__((aligned(8)));
 };
 
 struct prefix_sg {
 	uint8_t family;
-	uint8_t prefixlen;
+	uint16_t prefixlen;
 	struct in_addr src __attribute__((aligned(8)));
 	struct in_addr grp;
 };
@@ -296,15 +296,17 @@ union prefixconstptr {
 #endif /* INET_ADDRSTRLEN */
 
 #ifndef INET6_ADDRSTRLEN
+/* dead:beef:dead:beef:dead:beef:dead:beef + \0 */
 #define INET6_ADDRSTRLEN 46
 #endif /* INET6_ADDRSTRLEN */
 
 #ifndef INET6_BUFSIZ
-#define INET6_BUFSIZ 51
+#define INET6_BUFSIZ 53
 #endif /* INET6_BUFSIZ */
 
 /* Maximum prefix string length (IPv6) */
-#define PREFIX_STRLEN 51
+/* dead:beef:dead:beef:dead:beef:dead:beef:255.255.255.255 + / + 65535 + \0 */
+#define PREFIX_STRLEN 53
 
 /* Max bit/byte length of IPv4 address. */
 #define IPV4_MAX_BYTELEN    4
@@ -367,9 +369,9 @@ extern const char *safi2str(safi_t safi);
 extern const char *afi2str(afi_t afi);
 
 /* Check bit of the prefix. */
-extern unsigned int prefix_bit(const uint8_t *prefix, const uint8_t prefixlen);
+extern unsigned int prefix_bit(const uint8_t *prefix, const uint16_t prefixlen);
 extern unsigned int prefix6_bit(const struct in6_addr *prefix,
-				const uint8_t prefixlen);
+				const uint16_t prefixlen);
 
 extern struct prefix *prefix_new(void);
 extern void prefix_free(struct prefix *);

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -304,9 +304,8 @@ union prefixconstptr {
 #define INET6_BUFSIZ 53
 #endif /* INET6_BUFSIZ */
 
-/* Maximum prefix string length (IPv6) */
-/* dead:beef:dead:beef:dead:beef:dead:beef:255.255.255.255 + / + 65535 + \0 */
-#define PREFIX_STRLEN 53
+/* Maximum string length of the result of prefix2str */
+#define PREFIX_STRLEN 80
 
 /* Max bit/byte length of IPv4 address. */
 #define IPV4_MAX_BYTELEN    4

--- a/lib/table.c
+++ b/lib/table.c
@@ -283,7 +283,7 @@ struct route_node *route_node_get(struct route_table *const table,
 	struct route_node *node;
 	struct route_node *match;
 	struct route_node *inserted;
-	uint8_t prefixlen = p->prefixlen;
+	uint16_t prefixlen = p->prefixlen;
 	const uint8_t *prefix = &p->u.prefix;
 
 	apply_mask((struct prefix *)p);

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -275,7 +275,7 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 
 /* Add connected IPv4 route to the interface. */
 void connected_add_ipv4(struct interface *ifp, int flags, struct in_addr *addr,
-			uint8_t prefixlen, struct in_addr *broad,
+			uint16_t prefixlen, struct in_addr *broad,
 			const char *label)
 {
 	struct prefix_ipv4 *p;
@@ -473,7 +473,7 @@ static void connected_delete_helper(struct connected *ifc, struct prefix *p)
 
 /* Delete connected IPv4 route to the interface. */
 void connected_delete_ipv4(struct interface *ifp, int flags,
-			   struct in_addr *addr, uint8_t prefixlen,
+			   struct in_addr *addr, uint16_t prefixlen,
 			   struct in_addr *broad)
 {
 	struct prefix p, d;
@@ -499,7 +499,7 @@ void connected_delete_ipv4(struct interface *ifp, int flags,
 
 /* Add connected IPv6 route to the interface. */
 void connected_add_ipv6(struct interface *ifp, int flags, struct in6_addr *addr,
-			struct in6_addr *broad, uint8_t prefixlen,
+			struct in6_addr *broad, uint16_t prefixlen,
 			const char *label)
 {
 	struct prefix_ipv6 *p;
@@ -556,7 +556,7 @@ void connected_add_ipv6(struct interface *ifp, int flags, struct in6_addr *addr,
 }
 
 void connected_delete_ipv6(struct interface *ifp, struct in6_addr *address,
-			   struct in6_addr *broad, uint8_t prefixlen)
+			   struct in6_addr *broad, uint16_t prefixlen)
 {
 	struct prefix p, d;
 	struct connected *ifc;

--- a/zebra/connected.h
+++ b/zebra/connected.h
@@ -35,11 +35,11 @@ extern struct connected *connected_check_ptp(struct interface *ifp,
 					     union prefixconstptr d);
 
 extern void connected_add_ipv4(struct interface *ifp, int flags,
-			       struct in_addr *addr, uint8_t prefixlen,
+			       struct in_addr *addr, uint16_t prefixlen,
 			       struct in_addr *broad, const char *label);
 
 extern void connected_delete_ipv4(struct interface *ifp, int flags,
-				  struct in_addr *addr, uint8_t prefixlen,
+				  struct in_addr *addr, uint16_t prefixlen,
 				  struct in_addr *broad);
 
 extern void connected_delete_ipv4_unnumbered(struct connected *ifc);
@@ -49,10 +49,10 @@ extern void connected_down(struct interface *ifp, struct connected *ifc);
 
 extern void connected_add_ipv6(struct interface *ifp, int flags,
 			       struct in6_addr *address, struct in6_addr *broad,
-			       uint8_t prefixlen, const char *label);
+			       uint16_t prefixlen, const char *label);
 extern void connected_delete_ipv6(struct interface *ifp,
 				  struct in6_addr *address,
-				  struct in6_addr *broad, uint8_t prefixlen);
+				  struct in6_addr *broad, uint16_t prefixlen);
 
 extern int connected_is_unnumbered(struct interface *);
 


### PR DESCRIPTION
### Summary
In some cases an 8 bit integer is not large enough to store the prefix length; enlarge it to 16 bits.

### Components
lib