### PR TITLE
staticd: add ability to create onlink static route

### DIFF
--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -64,8 +64,8 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 		     const char *ifname, enum static_blackhole_type bh_type,
 		     route_tag_t tag, uint8_t distance, struct static_vrf *svrf,
 		     struct static_vrf *nh_svrf,
-		     struct static_nh_label *snh_label,
-		     uint32_t table_id)
+		     struct static_nh_label *snh_label, uint32_t table_id,
+		     bool onlink)
 {
 	struct route_node *rn;
 	struct static_route *si;
@@ -104,7 +104,7 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 			    && (table_id == si->table_id)
 			    && !memcmp(&si->snh_label, snh_label,
 				       sizeof(struct static_nh_label))
-			    && si->bh_type == bh_type) {
+			    && si->bh_type == bh_type && si->onlink == onlink) {
 				route_unlock_node(rn);
 				return 0;
 			}
@@ -129,6 +129,7 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 	si->nh_vrf_id = nh_svrf->vrf->vrf_id;
 	strcpy(si->nh_vrfname, nh_svrf->vrf->name);
 	si->table_id = table_id;
+	si->onlink = onlink;
 
 	if (ifname)
 		strlcpy(si->ifname, ifname, sizeof(si->ifname));

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -79,6 +79,13 @@ struct static_route {
 	struct static_nh_label snh_label;
 
 	uint32_t table_id;
+
+	/*
+	 * Whether to pretend the nexthop is directly attached to the specified
+	 * link. Only meaningful when both a gateway address and interface name
+	 * are specified.
+	 */
+	bool onlink;
 };
 
 extern bool mpls_enabled;
@@ -94,7 +101,7 @@ extern int static_add_route(afi_t afi, safi_t safi, uint8_t type,
 			    uint8_t distance, struct static_vrf *svrf,
 			    struct static_vrf *nh_svrf,
 			    struct static_nh_label *snh_label,
-			    uint32_t table_id);
+			    uint32_t table_id, bool onlink);
 
 extern int static_delete_route(afi_t afi, safi_t safi, uint8_t type,
 			       struct prefix *p, struct prefix_ipv6 *src_p,

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -364,6 +364,8 @@ extern void static_zebra_route_add(struct route_node *rn,
 		memcpy(&api.src_prefix, src_pp, sizeof(api.src_prefix));
 	}
 	SET_FLAG(api.flags, ZEBRA_FLAG_RR_USE_DISTANCE);
+	if (si_changed->onlink)
+		SET_FLAG(api.flags, ZEBRA_FLAG_ONLINK);
 	SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
 	if (si_changed->distance) {
 		SET_FLAG(api.message, ZAPI_MESSAGE_DISTANCE);


### PR DESCRIPTION
### Summary
Static route commands were lacking the ability to specify that a new static route should be marked `onlink`.

### Components
staticd

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>