### PR TITLE
zebra: Add some missing breadcrumbs

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -601,9 +601,20 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 					__PRETTY_FUNCTION__);
 			return resolved;
 		} else {
+			if (IS_ZEBRA_DEBUG_RIB_DETAILED) {
+				zlog_debug("\t%s: Route Type %s has not turned on recursion",
+					   __PRETTY_FUNCTION__,
+					   zebra_route_string(re->type));
+				if (re->type == ZEBRA_ROUTE_BGP &&
+				    !CHECK_FLAG(re->flags, ZEBRA_FLAG_IBGP))
+					zlog_debug("\tEBGP: see \"disable-ebgp-connected-route-check\" or \"disable-connected-check\"");
+			}
 			return 0;
 		}
 	}
+	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+		zlog_debug("\t%s: Nexthop did not lookup in table",
+			   __PRETTY_FUNCTION__);
 	return 0;
 }
 


### PR DESCRIPTION
During a debugging session last night I discovered that I was
still having some `fun` figuring out why zebra was not making
a route's nexthop active.  After some debugging I figured out
that I was missing some states that we could end up in that
didn't have debug information about what happened in nexthop_active.

Add the missing breadcrumbs for nexthop resolution.  In addition
add a bit of code to notice the ebgp state without recursion turned
on and to let the user know about it.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
