### PR TITLE
bgpd: Select default routing table when importing VRF routes into global

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6749,13 +6749,12 @@ ALIAS(af_import_vrf_route_map, af_no_import_vrf_route_map_cmd,
       "Vrf routes being filtered\n"
       "Specify route map\n")
 
-DEFPY (bgp_imexport_vrf,
-       bgp_imexport_vrf_cmd,
-       "[no] import vrf NAME$import_name",
-       NO_STR
-       "Import routes from another VRF\n"
-       "VRF to import from\n"
-       "The name of the VRF\n")
+DEFPY(bgp_imexport_vrf, bgp_imexport_vrf_cmd,
+      "[no] import vrf VIEWVRFNAME$import_name",
+      NO_STR
+      "Import routes from another VRF\n"
+      "VRF to import from\n"
+      "The name of the VRF\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	struct listnode *node;


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

### Summary
I just encountered the problem unless asked in Slack/read the source when importing global routes into arbitrary VRF. It's much easier when you have an option to choose instantly the default instead of eyeballing what's the name of it (default, Default-IP-Routing-Table)

### Components
bgpd