### PR TITLE
Rmap crash

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1403,45 +1403,42 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 	struct bgp_path_info *path;
 	struct peer *peer;
 
-	if (type == RMAP_BGP) {
-		path = object;
-		peer = path->peer;
+	if (type != RMAP_BGP)
+		return RMAP_OKAY;
 
-		if (rins->unchanged) {
-			SET_FLAG(path->attr->rmap_change_flags,
-				 BATTR_RMAP_NEXTHOP_UNCHANGED);
-		} else if (rins->peer_address) {
-			if ((CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
-			     || CHECK_FLAG(peer->rmap_type,
-					   PEER_RMAP_TYPE_IMPORT))
-			    && peer->su_remote
-			    && sockunion_family(peer->su_remote) == AF_INET) {
-				path->attr->nexthop.s_addr =
-					sockunion2ip(peer->su_remote);
-				path->attr->flag |=
-					ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
-			} else if (CHECK_FLAG(peer->rmap_type,
-					      PEER_RMAP_TYPE_OUT)) {
-				/* The next hop value will be set as part of
-				 * packet rewrite.
-				 * Set the flags here to indicate that rewrite
-				 * needs to be done.
-				 * Also, clear the value.
-				 */
-				SET_FLAG(path->attr->rmap_change_flags,
-					 BATTR_RMAP_NEXTHOP_PEER_ADDRESS);
-				path->attr->nexthop.s_addr = 0;
-			}
-		} else {
-			/* Set next hop value. */
+	path = object;
+	peer = path->peer;
+
+	if (rins->unchanged) {
+		SET_FLAG(path->attr->rmap_change_flags,
+			 BATTR_RMAP_NEXTHOP_UNCHANGED);
+	} else if (rins->peer_address) {
+		if ((CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IN)
+		     || CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_IMPORT))
+		    && peer->su_remote
+		    && sockunion_family(peer->su_remote) == AF_INET) {
+			path->attr->nexthop.s_addr =
+				sockunion2ip(peer->su_remote);
 			path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
-			path->attr->nexthop = *rins->address;
+		} else if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_OUT)) {
+			/* The next hop value will be set as part of
+			 * packet rewrite.  Set the flags here to indicate
+			 * that rewrite needs to be done.
+			 * Also, clear the value.
+			 */
 			SET_FLAG(path->attr->rmap_change_flags,
-				 BATTR_RMAP_IPV4_NHOP_CHANGED);
-			/* case for MP-BGP : MPLS VPN */
-			path->attr->mp_nexthop_global_in = *rins->address;
-			path->attr->mp_nexthop_len = sizeof(*rins->address);
+				 BATTR_RMAP_NEXTHOP_PEER_ADDRESS);
+			path->attr->nexthop.s_addr = 0;
 		}
+	} else {
+		/* Set next hop value. */
+		path->attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
+		path->attr->nexthop = *rins->address;
+		SET_FLAG(path->attr->rmap_change_flags,
+			 BATTR_RMAP_IPV4_NHOP_CHANGED);
+		/* case for MP-BGP : MPLS VPN */
+		path->attr->mp_nexthop_global_in = *rins->address;
+		path->attr->mp_nexthop_len = sizeof(*rins->address);
 	}
 
 	return RMAP_OKAY;

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1406,6 +1406,9 @@ static route_map_result_t route_set_ip_nexthop(void *rule,
 	if (type != RMAP_BGP)
 		return RMAP_OKAY;
 
+	if (prefix->family == AF_INET6)
+		return RMAP_OKAY;
+
 	path = object;
 	peer = path->peer;
 


### PR DESCRIPTION
Using a route-map with a `set ip next-hop A.B.C.D` and matching on a v6 route in bgp will crash the system.  This fixes it.