### PR TITLE
6.0: bfdd: fix multi hop hash lookup

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1092,7 +1092,7 @@ struct bfd_session *bfd_mhop_lookup(struct bfd_mhop_key mhop)
 
 	_mhop_key(&bs, &mhop);
 
-	return hash_lookup(bfd_shop_hash, &bs);
+	return hash_lookup(bfd_mhop_hash, &bs);
 }
 
 struct bfd_vrf *bfd_vrf_lookup(int vrf_id)


### PR DESCRIPTION
### Summary

Use the proper multi hop hash for matching multi hop peers.

Spotted by Dmitrii Turlupov (@ak503).

---

This is a back port to the 6.0 version.


### Related Issue

https://github.com/FRRouting/frr/issues/3169


### Related PR

https://github.com/FRRouting/frr/pull/3172


### Components

`bfdd`.