### PR TITLE
ospfd: fix router-info commands

### DIFF
--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -1419,7 +1419,7 @@ DEFUN (router_info,
 
 	uint8_t scope;
 
-	if (OspfRI.enabled)
+	if (OspfRI.enabled && OspfRI.registered)
 		return CMD_SUCCESS;
 
 	/* Check and get Area value if present */


### PR DESCRIPTION
### Summary
The Segment-routing on command sets OspfRI.enable to true, but not register router-info functions such as show, originate and refresh.
Because of that, router-info not working when segment-routing enabled.

Signed-off-by: Kunio AKASHI <akashi004@gmail.com>

### Components
ospfd