### PR TITLE
bgpd:Fixing the signature of community_free function

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -849,7 +849,7 @@ void bgp_attr_undup(struct attr *new, struct attr *old)
 		aspath_free(new->aspath);
 
 	if (new->community != old->community)
-		community_free(new->community);
+		community_free(&new->community);
 
 	if (new->ecommunity != old->ecommunity)
 		ecommunity_free(&new->ecommunity);
@@ -887,11 +887,8 @@ void bgp_attr_flush(struct attr *attr)
 		aspath_free(attr->aspath);
 		attr->aspath = NULL;
 	}
-	if (attr->community && !attr->community->refcnt) {
-		community_free(attr->community);
-		attr->community = NULL;
-	}
-
+	if (attr->community && !attr->community->refcnt)
+		community_free(&attr->community);
 	if (attr->ecommunity && !attr->ecommunity->refcnt)
 		ecommunity_free(&attr->ecommunity);
 	if (attr->lcommunity && !attr->lcommunity->refcnt)

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -65,7 +65,7 @@ static void community_entry_free(struct community_entry *entry)
 	switch (entry->style) {
 	case COMMUNITY_LIST_STANDARD:
 		if (entry->u.com)
-			community_free(entry->u.com);
+			community_free(&entry->u.com);
 		break;
 	case LARGE_COMMUNITY_LIST_STANDARD:
 		if (entry->u.lcom)
@@ -903,7 +903,7 @@ int community_list_unset(struct community_list_handler *ch, const char *name,
 
 	if (com) {
 		entry = community_list_entry_lookup(list, com, direct);
-		community_free(com);
+		community_free(&com);
 	} else
 		entry = community_list_entry_lookup(list, str, direct);
 

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -39,19 +39,19 @@ static struct community *community_new(void)
 }
 
 /* Free communities value.  */
-void community_free(struct community *com)
+void community_free(struct community **com)
 {
-	if (com->val)
-		XFREE(MTYPE_COMMUNITY_VAL, com->val);
-	if (com->str)
-		XFREE(MTYPE_COMMUNITY_STR, com->str);
+	if ((*com)->val)
+		XFREE(MTYPE_COMMUNITY_VAL, (*com)->val);
+	if ((*com)->str)
+		XFREE(MTYPE_COMMUNITY_STR, (*com)->str);
 
-	if (com->json) {
-		json_object_free(com->json);
-		com->json = NULL;
+	if ((*com)->json) {
+		json_object_free((*com)->json);
+		(*com)->json = NULL;
 	}
 
-	XFREE(MTYPE_COMMUNITY, com);
+	XFREE(MTYPE_COMMUNITY, (*com));
 }
 
 /* Add one community value to the community. */
@@ -498,7 +498,7 @@ struct community *community_intern(struct community *com)
 	/* Arguemnt com is allocated temporary.  So when it is not used in
 	   hash, it should be freed.  */
 	if (find != com)
-		community_free(com);
+		community_free(&com);
 
 	/* Increment refrence counter.  */
 	find->refcnt++;
@@ -524,8 +524,7 @@ void community_unintern(struct community **com)
 		ret = (struct community *)hash_release(comhash, *com);
 		assert(ret != NULL);
 
-		community_free(*com);
-		*com = NULL;
+		community_free(com);
 	}
 }
 
@@ -874,13 +873,13 @@ struct community *community_str2com(const char *str)
 			break;
 		case community_token_unknown:
 			if (com)
-				community_free(com);
+				community_free(&com);
 			return NULL;
 		}
 	} while (str);
 
 	com_sort = community_uniq_sort(com);
-	community_free(com);
+	community_free(&com);
 
 	return com_sort;
 }

--- a/bgpd/bgp_community.h
+++ b/bgpd/bgp_community.h
@@ -68,7 +68,7 @@ struct community {
 /* Prototypes of communities attribute functions.  */
 extern void community_init(void);
 extern void community_finish(void);
-extern void community_free(struct community *);
+extern void community_free(struct community **comm);
 extern struct community *community_uniq_sort(struct community *);
 extern struct community *community_parse(uint32_t *, unsigned short);
 extern struct community *community_intern(struct community *);

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -749,7 +749,7 @@ void bgp_path_info_mpath_aggregate_update(struct bgp_path_info *new_best,
 						mpinfo->attr->community);
 					community =
 						community_uniq_sort(commerge);
-					community_free(commerge);
+					community_free(&commerge);
 				} else
 					community = community_dup(
 						mpinfo->attr->community);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1345,15 +1345,15 @@ void bgp_attr_add_gshut_community(struct attr *attr)
 		merge = community_merge(community_dup(old), gshut);
 
 		if (old->refcnt == 0)
-			community_free(old);
+			community_free(&old);
 
 		new = community_uniq_sort(merge);
-		community_free(merge);
+		community_free(&merge);
 	} else {
 		new = community_dup(gshut);
 	}
 
-	community_free(gshut);
+	community_free(&gshut);
 	attr->community = new;
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
 
@@ -5549,7 +5549,7 @@ static void bgp_aggregate_install(struct bgp *bgp, afi_t afi, safi_t safi,
 			if (aspath)
 				aspath_free(aspath);
 			if (community)
-				community_free(community);
+				community_free(&community);
 			if (ecommunity)
 				ecommunity_free(&ecommunity);
 			if (lcommunity)
@@ -5696,7 +5696,7 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 						community, pi->attr->community);
 					community =
 						community_uniq_sort(commerge);
-					community_free(commerge);
+					community_free(&commerge);
 				} else
 					community = community_dup(
 						pi->attr->community);
@@ -5758,7 +5758,7 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 						pinew->attr->community);
 					community =
 						community_uniq_sort(commerge);
-					community_free(commerge);
+					community_free(&commerge);
 				} else
 					community = community_dup(
 						pinew->attr->community);
@@ -5800,7 +5800,7 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 		if (aspath)
 			aspath_free(aspath);
 		if (community)
-			community_free(community);
+			community_free(&community);
 		if (ecommunity)
 			ecommunity_free(&ecommunity);
 		if (lcommunity)
@@ -9607,7 +9607,7 @@ static int bgp_show_community(struct vty *vty, struct bgp *bgp,
 		       (exact ? bgp_show_type_community_exact
 			      : bgp_show_type_community),
 		       com, use_json);
-	community_free(com);
+	community_free(&com);
 
 	return ret;
 }

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1717,7 +1717,7 @@ static route_map_result_t route_set_community(void *rule,
 			attr->community = NULL;
 			/* See the longer comment down below. */
 			if (old && old->refcnt == 0)
-				community_free(old);
+				community_free(&old);
 			return RMAP_OKAY;
 		}
 
@@ -1726,7 +1726,7 @@ static route_map_result_t route_set_community(void *rule,
 			merge = community_merge(community_dup(old), rcs->com);
 
 			new = community_uniq_sort(merge);
-			community_free(merge);
+			community_free(&merge);
 		} else
 			new = community_dup(rcs->com);
 
@@ -1736,7 +1736,7 @@ static route_map_result_t route_set_community(void *rule,
 		 * Really need to cleanup attribute caching sometime.
 		 */
 		if (old && old->refcnt == 0)
-			community_free(old);
+			community_free(&old);
 
 		/* will be interned by caller if required */
 		attr->community = new;
@@ -1790,7 +1790,7 @@ static void route_set_community_free(void *rule)
 	struct rmap_com_set *rcs = rule;
 
 	if (rcs->com)
-		community_free(rcs->com);
+		community_free(&rcs->com);
 	XFREE(MTYPE_ROUTE_MAP_COMPILED, rcs);
 }
 
@@ -2031,7 +2031,7 @@ static route_map_result_t route_set_community_delete(
 			merge = community_list_match_delete(community_dup(old),
 							    list);
 			new = community_uniq_sort(merge);
-			community_free(merge);
+			community_free(&merge);
 
 			/* HACK: if the old community is not intern'd,
 			 * we should free it here, or all reference to it may be
@@ -2039,13 +2039,13 @@ static route_map_result_t route_set_community_delete(
 			 * Really need to cleanup attribute caching sometime.
 			 */
 			if (old->refcnt == 0)
-				community_free(old);
+				community_free(&old);
 
 			if (new->size == 0) {
 				path->attr->community = NULL;
 				path->attr->flag &=
 					~ATTR_FLAG_BIT(BGP_ATTR_COMMUNITIES);
-				community_free(new);
+				community_free(&new);
 			} else {
 				path->attr->community = new;
 				path->attr->flag |=
@@ -4171,7 +4171,7 @@ DEFUN (set_community,
 		ret = generic_set_add(vty, VTY_GET_CONTEXT(route_map_index),
 				      "community", str);
 
-	community_free(com);
+	community_free(&com);
 
 	return ret;
 }


### PR DESCRIPTION
community_free, lcommunity_free and ecommunity_free are similar type of functions. Most of the places, these three are called together. The signature of community_free is different from other two functions. Modified the community_free API signature to align with other two functions to avoid any confusion. There is no functionality impact with this and this is just to avoid any confusion.

Testing: manual testing and show commands
Signed-off-by: Sri Mohana Singamsetty msingamsetty@vmware.com

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
