### PR TITLE
bgp: Revert default originate changes to allow set

### DIFF
--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -663,7 +663,9 @@ void subgroup_announce_route(struct update_subgroup *subgrp)
 void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 {
 	struct bgp *bgp;
-	struct bgp_path_info *info, init_info, tmp_info;
+	struct attr attr;
+	struct aspath *aspath;
+	struct bgp_path_info tmp_info;
 	struct prefix p;
 	struct peer *from;
 	struct bgp_node *rn;
@@ -686,48 +688,47 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 	bgp = peer->bgp;
 	from = bgp->peer_self;
 
-	init_info.attr = NULL;
-	info = &init_info;
+	bgp_attr_default_set(&attr, BGP_ORIGIN_IGP);
+	aspath = attr.aspath;
+
+	attr.local_pref = bgp->default_local_pref;
 
 	memset(&p, 0, sizeof(p));
 	p.family = afi2family(afi);
 	p.prefixlen = 0;
+
+	if ((afi == AFI_IP6) || peer_cap_enhe(peer, afi, safi)) {
+		/* IPv6 global nexthop must be included. */
+		attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
+
+		/* If the peer is on shared nextwork and we have link-local
+		   nexthop set it. */
+		if (peer->shared_network
+		    && !IN6_IS_ADDR_UNSPECIFIED(&peer->nexthop.v6_local))
+			attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
+	}
 
 	if (peer->default_rmap[afi][safi].name) {
 		SET_FLAG(bgp->peer_self->rmap_type, PEER_RMAP_TYPE_DEFAULT);
 		for (rn = bgp_table_top(bgp->rib[afi][safi]); rn;
 		     rn = bgp_route_next(rn)) {
 			for (ri = rn->info; ri; ri = ri->next) {
+				struct attr dummy_attr;
+
+				/* Provide dummy so the route-map can't modify
+				 * the attributes */
+				bgp_attr_dup(&dummy_attr, ri->attr);
 				tmp_info.peer = ri->peer;
-				tmp_info.attr = ri->attr;
-
-				/* Reset attributes every time to avoid \
-				 * unexpected as-path prepends */
-				bgp_attr_default_set(tmp_info.attr,
-						     BGP_ORIGIN_IGP);
-
-				if ((afi == AFI_IP6)
-				    || peer_cap_enhe(peer, afi, safi)) {
-					/* IPv6 global nexthop must be included.
-					 */
-					tmp_info.attr->mp_nexthop_len =
-						BGP_ATTR_NHLEN_IPV6_GLOBAL;
-
-					/* If the peer is on shared nextwork and
-					 * we have link-local nexthop set it. */
-					if (peer->shared_network
-					    && !IN6_IS_ADDR_UNSPECIFIED(
-						       &peer->nexthop.v6_local))
-						tmp_info.attr->mp_nexthop_len =
-							BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
-				}
+				tmp_info.attr = &dummy_attr;
 
 				ret = route_map_apply(
 					peer->default_rmap[afi][safi].map,
 					&rn->p, RMAP_BGP, &tmp_info);
 
-				info = &tmp_info;
-
+				/* The route map might have set attributes. If
+				 * we don't flush them
+				 * here, they will be leaked. */
+				bgp_attr_flush(&dummy_attr);
 				if (ret != RMAP_DENYMATCH)
 					break;
 			}
@@ -749,13 +750,12 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 				SUBGRP_STATUS_DEFAULT_ORIGINATE)) {
 
 			if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
-				bgp_attr_add_gshut_community(info->attr);
+				bgp_attr_add_gshut_community(&attr);
 			}
 
 			SET_FLAG(subgrp->sflags,
 				 SUBGRP_STATUS_DEFAULT_ORIGINATE);
-			subgroup_default_update_packet(subgrp, info->attr,
-						       from);
+			subgroup_default_update_packet(subgrp, &attr, from);
 
 			/* The 'neighbor x.x.x.x default-originate' default will
 			 * act as an
@@ -775,6 +775,8 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 				BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE);
 		}
 	}
+
+	aspath_unintern(&aspath);
 }
 
 /*

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -1123,6 +1123,8 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
 			snprintf(tx_id_buf, sizeof(tx_id_buf),
 				 " with addpath ID %u",
 				 BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE);
+		else
+			tx_id_buf[0] = '\0';
 
 		zlog_debug("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s%s %s",
 			   (SUBGRP_UPDGRP(subgrp))->id, subgrp->id,


### PR DESCRIPTION
The changes to allow for the default originate command to allow set operations in the route-map were inherently wrong and breaking correct bgp behavior:

1) They were changing the attributes of routes that should not be changed( routes besides the default originated route )
2) They were not properly setting the local pref( at the very least ) if we had no set operations.

We need to apply the route-map against all the routes in the table to see if we should originate the default route, but we do not currently have a methodology to apply the set against only the default routes data.

So let's revert these 2 code changes back to original code.

Additionally fix some debug code to properly output data when we are debugging