### PR TITLE
Feature: IS-IS improve lsp scheduling

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1388,7 +1388,9 @@ static int lsp_l2_refresh(struct thread *thread)
 	return lsp_regenerate(area, IS_LEVEL_2);
 }
 
-int lsp_regenerate_schedule(struct isis_area *area, int level, int all_pseudo)
+int _lsp_regenerate_schedule(struct isis_area *area, int level,
+			     int all_pseudo, const char *func,
+			     const char *file, int line)
 {
 	struct isis_lsp *lsp;
 	uint8_t id[ISIS_SYS_ID_LEN + 2];
@@ -1402,9 +1404,11 @@ int lsp_regenerate_schedule(struct isis_area *area, int level, int all_pseudo)
 		return ISIS_ERROR;
 
 	sched_debug(
-		"ISIS (%s): Scheduling regeneration of %s LSPs, %sincluding PSNs",
+		"ISIS (%s): Scheduling regeneration of %s LSPs, %sincluding PSNs"
+		" Caller: %s %s:%d",
 		area->area_tag, circuit_t2string(level),
-		all_pseudo ? "" : "not ");
+		all_pseudo ? "" : "not ",
+		func, file, line);
 
 	memcpy(id, isis->sysid, ISIS_SYS_ID_LEN);
 	LSP_PSEUDO_ID(id) = LSP_FRAGMENT(id) = 0;

--- a/isisd/isis_lsp.h
+++ b/isisd/isis_lsp.h
@@ -54,7 +54,12 @@ void lsp_db_destroy(dict_t *lspdb);
 int lsp_tick(struct thread *thread);
 
 int lsp_generate(struct isis_area *area, int level);
-int lsp_regenerate_schedule(struct isis_area *area, int level, int all_pseudo);
+#define lsp_regenerate_schedule(area, level, all_pseudo) \
+	_lsp_regenerate_schedule((area), (level), (all_pseudo), \
+				 __func__, __FILE__, __LINE__)
+int _lsp_regenerate_schedule(struct isis_area *area, int level,
+			     int all_pseudo, const char *func,
+				     const char *file, int line);
 int lsp_generate_pseudo(struct isis_circuit *circuit, int level);
 int lsp_regenerate_schedule_pseudo(struct isis_circuit *circuit, int level);
 

--- a/isisd/isis_lsp.h
+++ b/isisd/isis_lsp.h
@@ -55,11 +55,11 @@ int lsp_tick(struct thread *thread);
 
 int lsp_generate(struct isis_area *area, int level);
 #define lsp_regenerate_schedule(area, level, all_pseudo) \
-	_lsp_regenerate_schedule((area), (level), (all_pseudo), \
+	_lsp_regenerate_schedule((area), (level), (all_pseudo), true, \
 				 __func__, __FILE__, __LINE__)
 int _lsp_regenerate_schedule(struct isis_area *area, int level,
-			     int all_pseudo, const char *func,
-				     const char *file, int line);
+			     int all_pseudo, bool postpone,
+			     const char *func, const char *file, int line);
 int lsp_generate_pseudo(struct isis_circuit *circuit, int level);
 int lsp_regenerate_schedule_pseudo(struct isis_circuit *circuit, int level);
 

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1248,7 +1248,8 @@ static struct isis_spf_run *isis_run_spf_arg(struct isis_area *area, int level)
 	return run;
 }
 
-int isis_spf_schedule(struct isis_area *area, int level)
+int _isis_spf_schedule(struct isis_area *area, int level,
+		       const char *func, const char *file, int line)
 {
 	struct isis_spftree *spftree = area->spftree[SPFTREE_IPV4][level - 1];
 	time_t now = monotime(NULL);
@@ -1257,10 +1258,12 @@ int isis_spf_schedule(struct isis_area *area, int level)
 	assert(diff >= 0);
 	assert(area->is_type & level);
 
-	if (isis->debugs & DEBUG_SPF_EVENTS)
+	if (isis->debugs & DEBUG_SPF_EVENTS) {
 		zlog_debug(
-			"ISIS-Spf (%s) L%d SPF schedule called, lastrun %d sec ago",
-			area->area_tag, level, diff);
+			"ISIS-Spf (%s) L%d SPF schedule called, lastrun %d sec ago"
+			" Caller: %s %s:%d",
+			area->area_tag, level, diff, func, file, line);
+	}
 
 	if (area->spf_delay_ietf[level - 1]) {
 		/* Need to call schedule function also if spf delay is running

--- a/isisd/isis_spf.h
+++ b/isisd/isis_spf.h
@@ -34,7 +34,11 @@ void isis_spftree_del(struct isis_spftree *spftree);
 void spftree_area_init(struct isis_area *area);
 void spftree_area_del(struct isis_area *area);
 void spftree_area_adj_del(struct isis_area *area, struct isis_adjacency *adj);
-int isis_spf_schedule(struct isis_area *area, int level);
+#define isis_spf_schedule(area, level) \
+	_isis_spf_schedule((area), (level), __func__, \
+			   __FILE__, __LINE__)
+int _isis_spf_schedule(struct isis_area *area, int level,
+		       const char *func, const char *file, int line);
 void isis_spf_cmds_init(void);
 void isis_spf_print(struct isis_spftree *spftree, struct vty *vty);
 struct isis_spftree *isis_run_hopcount_spf(struct isis_area *area,

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -160,6 +160,13 @@ struct isis_area *isis_area_create(const char *area_tag)
 
 	if (fabricd)
 		area->fabricd = fabricd_new(area);
+
+	area->lsp_refresh_arg[0].area = area;
+	area->lsp_refresh_arg[0].level = IS_LEVEL_1;
+	area->lsp_refresh_arg[1].area = area;
+	area->lsp_refresh_arg[1].level = IS_LEVEL_2;
+
+
 	QOBJ_REG(area, isis_area);
 
 	return area;

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -90,6 +90,11 @@ enum spf_tree_id {
 	SPFTREE_COUNT
 };
 
+struct lsp_refresh_arg {
+	struct isis_area *area;
+	int level;
+};
+
 struct isis_area {
 	struct isis *isis;			       /* back pointer */
 	dict_t *lspdb[ISIS_LEVELS];		       /* link-state dbs */
@@ -159,6 +164,8 @@ struct isis_area {
 							    SPF algo
 							    parameters*/
 	struct thread *spf_timer[ISIS_LEVELS];
+
+	struct lsp_refresh_arg lsp_refresh_arg[ISIS_LEVELS];
 
 	QOBJ_FIELDS
 };

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -105,6 +105,7 @@ struct isis_area {
 	struct flags flags;
 	struct thread *t_tick; /* LSP walker */
 	struct thread *t_lsp_refresh[ISIS_LEVELS];
+	struct timeval last_lsp_refresh_event[ISIS_LEVELS];
 	/* t_lsp_refresh is used in two ways:
 	 * a) regular refresh of LSPs
 	 * b) (possibly throttled) updates to LSPs


### PR DESCRIPTION
IS-IS uses a holdoff timer for LSP generation to reduce overall load in the network.
For quick convergence, we need to ensure that related events make it into a single LSP update, otherwise they will be delayed by the holdoff timer.

