### PR TITLE
build: carry --with-pkg-extra-version into tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /config.status
 /config.guess
 /config.sub
+/config.version
 /ltmain.sh
 /stamp-h
 /stamp-h[0-9]*

--- a/Makefile.am
+++ b/Makefile.am
@@ -161,6 +161,7 @@ EXTRA_DIST += \
 	README.md \
 	m4/README.txt \
 	m4/libtool-whole-archive.patch \
+	config.version \
 	\
 	python/clidef.py \
 	python/clippy/__init__.py \

--- a/config.version.in
+++ b/config.version.in
@@ -1,0 +1,4 @@
+# this file is used to carry --with-pkg-extra-version into tarballs
+EXTRAVERSION="@EXTRAVERSION@"
+# for easy access by scripts before ./configure is run
+DIST_PACKAGE_VERSION="@PACKAGE_VERSION@"

--- a/configure.ac
+++ b/configure.ac
@@ -352,9 +352,19 @@ test -f conftest.a && rm conftest.a
 dnl ----------------------
 dnl Packages configuration
 dnl ----------------------
+if test -f config.version; then
+  . ./config.version
+elif test -f "${srcdir}/config.version"; then
+  . "${srcdir}/config.version"
+fi
 AC_ARG_WITH(pkg-extra-version,
-	AS_HELP_STRING([--with-pkg-extra-version=VER], [add extra version field, for packagers/distributions]),
-	[EXTRAVERSION=$withval],)
+  AS_HELP_STRING([--with-pkg-extra-version=VER], [add extra version field, for packagers/distributions]), [
+  if test "$withval" = "no"; then
+    EXTRAVERSION=
+  else
+    EXTRAVERSION=$withval
+  fi
+], [])
 AC_ARG_WITH(pkg-git-version,
 	AS_HELP_STRING([--with-pkg-git-version], [add git information to MOTD and build version string]),
 	[ test "x$withval" != "xno" && with_pkg_git_version="yes" ])
@@ -768,6 +778,7 @@ if test "x${EXTRAVERSION}" != "x" ; then
   AC_SUBST(PACKAGE_EXTRAVERSION, ["${EXTRAVERSION}"])
   PACKAGE_STRING="${PACKAGE_STRING}${EXTRAVERSION}"
 fi
+AC_SUBST(EXTRAVERSION)
 
 if test "x$with_pkg_git_version" = "xyes"; then
 	if test -d "${srcdir}/.git"; then
@@ -2059,6 +2070,7 @@ AC_MSG_RESULT($ac_cv_htonl_works)
 AC_CONFIG_FILES([Makefile],[sed -e 's/^#AUTODERP# //' -i Makefile])
 
 AC_CONFIG_FILES([
+	  config.version
 	  redhat/frr.spec
 	  solaris/Makefile
 	  debianpkg/changelog


### PR DESCRIPTION
If we use "./configure --with-pkg-extra-version=... && make dist", we
probably want the dist tarball to remember the extra version it was
configured with.

Use --without-pkg-extra-version to kill the tag.