### PR TITLE
lib: If command was successful don't store the command as an error

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1323,7 +1323,9 @@ int command_config_read_one_line(struct vty *vty,
 		}
 	}
 
-	if (ret != CMD_SUCCESS && ret != CMD_WARNING) {
+	if (ret != CMD_SUCCESS &&
+	    ret != CMD_WARNING &&
+	    ret != CMD_SUCCESS_DAEMON) {
 		struct vty_error *ve = XCALLOC(MTYPE_TMP, sizeof(*ve));
 
 		memcpy(ve->error_buf, vty->buf, VTY_BUFSIZ);


### PR DESCRIPTION
The CMD_SUCCESS_DAEMON case should be excluded from storing the command line
that we think failed.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
