### PR TITLE
ospfd: do not remove area structure, while vls are configured

### DIFF
--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -920,6 +920,23 @@ static void ospf_vl_if_delete(struct ospf_vl_data *vl_data)
 	vlink_count--;
 }
 
+/* for a defined area, count the number of configured vl
+ */
+int ospf_vl_count(struct ospf *ospf, struct ospf_area *area)
+{
+	int count = 0;
+	struct ospf_vl_data *vl_data;
+	struct listnode *node;
+
+	for (ALL_LIST_ELEMENTS_RO(ospf->vlinks, node, vl_data)) {
+		if (area
+		    && !IPV4_ADDR_SAME(&vl_data->vl_area_id, &area->area_id))
+			continue;
+		count++;
+	}
+	return count;
+}
+
 /* Look up vl_data for given peer, optionally qualified to be in the
  * specified area. NULL area returns first found..
  */

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -300,6 +300,7 @@ extern struct ospf_vl_data *ospf_vl_data_new(struct ospf_area *,
 					     struct in_addr);
 extern struct ospf_vl_data *ospf_vl_lookup(struct ospf *, struct ospf_area *,
 					   struct in_addr);
+extern int ospf_vl_count(struct ospf *ospf, struct ospf_area *area);
 extern void ospf_vl_data_free(struct ospf_vl_data *);
 extern void ospf_vl_add(struct ospf *, struct ospf_vl_data *);
 extern void ospf_vl_delete(struct ospf *, struct ospf_vl_data *);

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -890,6 +890,7 @@ void ospf_area_check_free(struct ospf *ospf, struct in_addr area_id)
 
 	area = ospf_area_lookup_by_area_id(ospf, area_id);
 	if (area && listcount(area->oiflist) == 0 && area->ranges->top == NULL
+	    && !ospf_vl_count(ospf, area)
 	    && area->shortcut_configured == OSPF_SHORTCUT_DEFAULT
 	    && area->external_routing == OSPF_AREA_DEFAULT
 	    && area->no_summary == 0 && area->default_cost == 1


### PR DESCRIPTION
when adding/removing virtual links per interface, sometimes, the ospf
virtual link can not be removed, whereas the associated area is already
removed. Do not remove the area while a virtual link is yet configured.
https://github.com/FRRouting/frr/issues/3238
Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
