### PR TITLE
Distribute vrf aware

### DIFF
--- a/babeld/babel_filter.c
+++ b/babeld/babel_filter.c
@@ -39,10 +39,11 @@ babel_filter(int output, const unsigned char *prefix, unsigned short plen,
     struct interface *ifp = if_lookup_by_index(ifindex, VRF_DEFAULT);
     babel_interface_nfo *babel_ifp = ifp ? babel_get_if_nfo(ifp) : NULL;
     struct prefix p;
-    struct distribute *dist;
+    struct distribute *dist = NULL;
     struct access_list *alist;
     struct prefix_list *plist;
     int distribute;
+    struct babel *babel;
 
     p.family = v4mapped(prefix) ? AF_INET : AF_INET6;
     p.prefixlen = v4mapped(prefix) ? plen - 96 : plen;
@@ -81,7 +82,9 @@ babel_filter(int output, const unsigned char *prefix, unsigned short plen,
     }
 
     /* All interface filter check. */
-    dist = distribute_lookup (NULL);
+    babel = babel_lookup();
+    if (babel)
+        dist = distribute_lookup (babel->distribute_ctx, NULL);
     if (dist) {
         if (dist->list[distribute]) {
             alist = access_list_lookup (p.family, dist->list[distribute]);

--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -1248,11 +1248,16 @@ DEFUN (show_babel_parameters,
        "Babel information\n"
        "Configuration information\n")
 {
+    struct babel *babel_ctx;
+
     vty_out (vty, "    -- Babel running configuration --\n");
     show_babel_main_configuration(vty);
-    vty_out (vty, "    -- distribution lists --\n");
-    config_show_distribute(vty);
 
+    babel_ctx = babel_lookup();
+    if (babel_ctx) {
+        vty_out (vty, "    -- distribution lists --\n");
+        config_show_distribute(vty, babel_ctx->distribute_ctx);
+    }
     return CMD_SUCCESS;
 }
 

--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -53,7 +53,8 @@ static int babel_read_protocol (struct thread *thread);
 static int babel_main_loop(struct thread *thread);
 static void babel_set_timer(struct timeval *timeout);
 static void babel_fill_with_next_timeout(struct timeval *tv);
-
+static void
+babel_distribute_update (struct distribute_ctx *ctx, struct distribute *dist);
 
 /* Informations relative to the babel running daemon. */
 static struct babel *babel_routing_process = NULL;
@@ -123,7 +124,7 @@ babel_config_write (struct vty *vty)
         }
     }
 
-    lines += config_write_distribute (vty);
+    lines += config_write_distribute (vty, babel_routing_process->distribute_ctx);
 
     return lines;
 }
@@ -154,8 +155,12 @@ babel_create_routing_process (void)
     thread_add_read(master, &babel_read_protocol, NULL, protocol_socket, &babel_routing_process->t_read);
     /* wait a little: zebra will announce interfaces, addresses, routes... */
     thread_add_timer_msec(master, babel_init_routing_process, NULL, 200L, &babel_routing_process->t_update);
-    return 0;
 
+    /* Distribute list install. */
+    babel_routing_process->distribute_ctx = distribute_list_ctx_create (vrf_lookup_by_id(VRF_DEFAULT));
+    distribute_list_add_hook (babel_routing_process->distribute_ctx, babel_distribute_update);
+    distribute_list_delete_hook (babel_routing_process->distribute_ctx, babel_distribute_update);
+    return 0;
 fail:
     XFREE(MTYPE_BABEL, babel_routing_process);
     babel_routing_process = NULL;
@@ -315,6 +320,7 @@ babel_clean_routing_process()
         thread_cancel(babel_routing_process->t_update);
     }
 
+    distribute_list_delete(&babel_routing_process->distribute_ctx);
     XFREE(MTYPE_BABEL, babel_routing_process);
     babel_routing_process = NULL;
 }
@@ -539,7 +545,7 @@ resize_receive_buffer(int size)
 }
 
 static void
-babel_distribute_update (struct distribute *dist)
+babel_distribute_update (struct distribute_ctx *ctx, struct distribute *dist)
 {
     struct interface *ifp;
     babel_interface_nfo *babel_ifp;
@@ -574,11 +580,12 @@ babel_distribute_update (struct distribute *dist)
 static void
 babel_distribute_update_interface (struct interface *ifp)
 {
-    struct distribute *dist;
+    struct distribute *dist = NULL;
 
-    dist = distribute_lookup (ifp->name);
+    if (babel_routing_process)
+        dist = distribute_lookup(babel_routing_process->distribute_ctx, ifp->name);
     if (dist)
-        babel_distribute_update (dist);
+        babel_distribute_update (babel_routing_process->distribute_ctx, dist);
 }
 
 /* Update all interface's distribute list. */
@@ -736,9 +743,7 @@ babeld_quagga_init(void)
     prefix_list_delete_hook (babel_distribute_update_all);
 
     /* Distribute list install. */
-    distribute_list_init (BABEL_NODE);
-    distribute_list_add_hook (babel_distribute_update);
-    distribute_list_delete_hook (babel_distribute_update);
+    distribute_list_init(BABEL_NODE);
 }
 
 /* Stubs to adapt Babel's filtering calls to Quagga's infrastructure. */
@@ -767,3 +772,7 @@ redistribute_filter(const unsigned char *prefix, unsigned short plen,
     return 0;
 }
 
+struct babel *babel_lookup(void)
+{
+    return babel_routing_process;
+}

--- a/babeld/babeld.h
+++ b/babeld/babeld.h
@@ -111,6 +111,8 @@ struct babel
     /* Babel threads. */
     struct thread *t_read;    /* on Babel protocol's socket */
     struct thread *t_update;  /* timers */
+    /* distribute_ctx */
+    struct distribute_ctx *distribute_ctx;
 };
 
 extern struct zebra_privs_t babeld_privs;
@@ -125,6 +127,6 @@ extern int redistribute_filter(const unsigned char *prefix, unsigned short plen,
                                unsigned int ifindex, int proto);
 extern int resize_receive_buffer(int size);
 extern void schedule_neighbours_check(int msecs, int override);
-
+extern struct babel *babel_lookup(void);
 
 #endif /* BABEL_BABELD_H */

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -62,7 +62,8 @@
 /*
  * Distribute-list update functions.
  */
-void eigrp_distribute_update(struct distribute *dist)
+void eigrp_distribute_update(struct distribute_ctx *ctx,
+			     struct distribute *dist)
 {
 	struct interface *ifp;
 	struct eigrp_interface *ei = NULL;
@@ -285,10 +286,15 @@ void eigrp_distribute_update(struct distribute *dist)
 void eigrp_distribute_update_interface(struct interface *ifp)
 {
 	struct distribute *dist;
+	struct eigrp *eigrp;
 
-	dist = distribute_lookup(ifp->name);
+	eigrp = eigrp_lookup();
+	if (!eigrp)
+		return;
+	dist = distribute_lookup(eigrp->distribute_ctx, ifp->name);
 	if (dist)
-		eigrp_distribute_update(dist);
+		eigrp_distribute_update(eigrp->distribute_ctx,
+					dist);
 }
 
 /* Update all interface's distribute list.

--- a/eigrpd/eigrp_filter.h
+++ b/eigrpd/eigrp_filter.h
@@ -33,7 +33,8 @@
 #ifndef EIGRPD_EIGRP_FILTER_H_
 #define EIGRPD_EIGRP_FILTER_H_
 
-extern void eigrp_distribute_update(struct distribute *);
+extern void eigrp_distribute_update(struct distribute_ctx *ctx,
+				    struct distribute *dist);
 extern void eigrp_distribute_update_interface(struct interface *);
 extern void eigrp_distribute_update_all(struct prefix_list *);
 extern void eigrp_distribute_update_all_wrapper(struct access_list *);

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -217,8 +217,6 @@ int main(int argc, char **argv, char **envp)
 
 	/* Distribute list install. */
 	distribute_list_init(EIGRP_NODE);
-	distribute_list_add_hook(eigrp_distribute_update);
-	distribute_list_delete_hook(eigrp_distribute_update);
 
 	frr_config_fork();
 	frr_run(master);

--- a/eigrpd/eigrp_structs.h
+++ b/eigrpd/eigrp_structs.h
@@ -131,6 +131,9 @@ struct eigrp {
 		uint32_t metric;
 	} route_map[ZEBRA_ROUTE_MAX];
 
+	/* distribute_ctx */
+	struct distribute_ctx *distribute_ctx;
+
 	QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(eigrp)

--- a/eigrpd/eigrp_vty.c
+++ b/eigrpd/eigrp_vty.c
@@ -174,7 +174,7 @@ static int config_write_eigrp_distribute(struct vty *vty, struct eigrp *eigrp)
 	int write = 0;
 
 	/* Distribute configuration. */
-	write += config_write_distribute(vty);
+	write += config_write_distribute(vty, eigrp->distribute_ctx);
 
 	return write;
 }

--- a/lib/distribute.h
+++ b/lib/distribute.h
@@ -45,14 +45,36 @@ struct distribute {
 	char *prefix[DISTRIBUTE_MAX];
 };
 
+struct distribute_ctx {
+	/* Hash of distribute list. */
+	struct hash *disthash;
+
+	/* Hook functions. */
+	void (*distribute_add_hook)(struct distribute_ctx *ctx,
+				    struct distribute *dist);
+	void (*distribute_delete_hook)(struct distribute_ctx *ctx,
+				       struct distribute *dist);
+
+	/* vrf information */
+	struct vrf *vrf;
+};
+
 /* Prototypes for distribute-list. */
-extern void distribute_list_init(int);
-extern void distribute_list_reset(void);
-extern void distribute_list_add_hook(void (*)(struct distribute *));
-extern void distribute_list_delete_hook(void (*)(struct distribute *));
-extern struct distribute *distribute_lookup(const char *);
-extern int config_write_distribute(struct vty *);
-extern int config_show_distribute(struct vty *);
+extern void distribute_list_init(int node);
+extern struct distribute_ctx *distribute_list_ctx_create(struct vrf *vrf);
+extern void distribute_list_delete(struct distribute_ctx **ctx);
+extern void distribute_list_add_hook(struct distribute_ctx *ctx,
+				     void (*)(struct distribute_ctx *ctx,
+					      struct distribute *));
+extern void distribute_list_delete_hook(struct distribute_ctx *ctx,
+					void (*)(struct distribute_ctx *ctx,
+						 struct distribute *));
+extern struct distribute *distribute_lookup(struct distribute_ctx *ctx,
+					    const char *ifname);
+extern int config_write_distribute(struct vty *vty,
+				   struct distribute_ctx *ctx);
+extern int config_show_distribute(struct vty *vty,
+				  struct distribute_ctx *ctx);
 
 extern enum filter_type distribute_apply_in(struct interface *,
 					    struct prefix *);

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -330,6 +330,8 @@ vrf_id_t vrf_name_to_id(const char *name)
 	vrf_id_t vrf_id = VRF_DEFAULT; // Pending: need a way to return invalid
 				       // id/ routine not used.
 
+	if (!name)
+		return vrf_id;
 	vrf = vrf_lookup_by_name(name);
 	if (vrf)
 		vrf_id = vrf->vrf_id;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -68,6 +68,9 @@ static void rip_output_process(struct connected *, struct sockaddr_in *, int,
 static int rip_triggered_update(struct thread *);
 static int rip_update_jitter(unsigned long);
 
+static void rip_distribute_update(struct distribute_ctx *ctx,
+				  struct distribute *dist);
+
 /* RIP output routes type. */
 enum { rip_all_route, rip_changed_route };
 
@@ -328,7 +331,7 @@ static int rip_filter(int rip_distribute, struct prefix_ipv4 *p,
 	}
 
 	/* All interface filter check. */
-	dist = distribute_lookup(NULL);
+	dist = distribute_lookup(rip->distribute_ctx, NULL);
 	if (dist) {
 		if (dist->list[distribute]) {
 			alist = access_list_lookup(AFI_IP,
@@ -2702,7 +2705,13 @@ int rip_create(int socket)
 	/* Create read and timer thread. */
 	rip_event(RIP_READ, rip->sock);
 	rip_event(RIP_UPDATE_EVENT, 1);
-
+	/* Distribute list install. */
+	rip->distribute_ctx = distribute_list_ctx_create(
+					 vrf_lookup_by_id(VRF_DEFAULT));
+	distribute_list_add_hook(rip->distribute_ctx,
+				 rip_distribute_update);
+	distribute_list_delete_hook(rip->distribute_ctx,
+				    rip_distribute_update);
 	return 0;
 }
 
@@ -3121,7 +3130,7 @@ DEFUN (show_ip_rip_status,
 	vty_out(vty, " garbage collect after %u seconds\n", rip->garbage_time);
 
 	/* Filtering status show. */
-	config_show_distribute(vty);
+	config_show_distribute(vty, rip->distribute_ctx);
 
 	/* Default metric information. */
 	vty_out(vty, "  Default redistribution metric is %u\n",
@@ -3215,7 +3224,8 @@ static int config_write_rip(struct vty *vty)
 		nb_cli_show_dnode_cmds(vty, dnode, false);
 
 		/* Distribute configuration. */
-		write += config_write_distribute(vty);
+		write += config_write_distribute(vty,
+						 rip->distribute_ctx);
 
 		/* Interface routemap configuration */
 		write += config_write_if_rmap(vty);
@@ -3227,7 +3237,8 @@ static int config_write_rip(struct vty *vty)
 static struct cmd_node rip_node = {RIP_NODE, "%s(config-router)# ", 1};
 
 /* Distribute-list update functions. */
-static void rip_distribute_update(struct distribute *dist)
+static void rip_distribute_update(struct distribute_ctx *ctx,
+				  struct distribute *dist)
 {
 	struct interface *ifp;
 	struct rip_interface *ri;
@@ -3288,9 +3299,11 @@ void rip_distribute_update_interface(struct interface *ifp)
 {
 	struct distribute *dist;
 
-	dist = distribute_lookup(ifp->name);
+	if (!rip)
+		return;
+	dist = distribute_lookup(rip->distribute_ctx, ifp->name);
 	if (dist)
-		rip_distribute_update(dist);
+		rip_distribute_update(rip->distribute_ctx, dist);
 }
 
 /* Update all interface's distribute list. */
@@ -3367,6 +3380,7 @@ void rip_clean(void)
 		route_table_finish(rip->table);
 		route_table_finish(rip->neighbor);
 
+		distribute_list_delete(&rip->distribute_ctx);
 		XFREE(MTYPE_RIP, rip);
 		rip = NULL;
 	}
@@ -3390,7 +3404,6 @@ static void rip_if_rmap_update(struct if_rmap *if_rmap)
 		return;
 
 	ri = ifp->info;
-
 	if (if_rmap->routemap[IF_RMAP_IN]) {
 		rmap = route_map_lookup_by_name(if_rmap->routemap[IF_RMAP_IN]);
 		if (rmap)
@@ -3472,8 +3485,6 @@ void rip_init(void)
 
 	/* Distribute list install. */
 	distribute_list_init(RIP_NODE);
-	distribute_list_add_hook(rip_distribute_update);
-	distribute_list_delete_hook(rip_distribute_update);
 
 	/* Route-map */
 	rip_route_map_init();

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -23,6 +23,7 @@
 
 #include "hook.h"
 #include "nexthop.h"
+#include "distribute.h"
 #include "rip_memory.h"
 
 /* RIP version number. */
@@ -150,6 +151,9 @@ struct rip {
 		bool metric_config;
 		uint8_t metric;
 	} route_map[ZEBRA_ROUTE_MAX];
+
+	/* For distribute-list container */
+	struct distribute_ctx *distribute_ctx;
 };
 
 /* RIP routing table entry which belong to rip_packet. */

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -24,6 +24,7 @@
 
 #include <zclient.h>
 #include <vty.h>
+#include <distribute.h>
 
 #include "ripng_memory.h"
 
@@ -128,6 +129,9 @@ struct ripng {
 		bool metric_config;
 		uint8_t metric;
 	} route_map[ZEBRA_ROUTE_MAX];
+
+	/* For distribute-list container */
+	struct distribute_ctx *distribute_ctx;
 };
 
 /* Routing table entry. */


### PR DESCRIPTION
This issue is preparing some work so that distribute list is indexed by vrf_id and by interface name.
A new API will be made available to daemons, so that daemons can give the vrf_id used.

this is the method proposed to make distribute list compliant with multiple vrf instances of daemons.
