### PR TITLE
Link-detect documentation

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -186,6 +186,8 @@ Standard Commands
    Enable/disable link-detect on platforms which support this. Currently only
    Linux and Solaris, and only where network interface drivers support
    reporting link-state via the ``IFF_RUNNING`` flag.
+   
+   In FRR, link-detect is on by default.
 
 .. _link-parameters-commands:
 


### PR DESCRIPTION
As a quagga user, I didn't realise link-detect is on by default.

### Summary
Just improved the documentation.  As a Quagga user I kept thinking link detect wasn't enabled.

### Related Issue
[fill here if applicable]

### Components
doc


Signed-off-by: Tim Bray <tim@kooky.org>

