### PR TITLE
zebra: only uninstall once, when closing rib table

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3246,8 +3246,10 @@ void rib_close_table(struct route_table *table)
 			if (info->safi == SAFI_UNICAST)
 				hook_call(rib_update, rn, NULL);
 
-			if (!RIB_SYSTEM_ROUTE(dest->selected_fib))
+			if (!RIB_SYSTEM_ROUTE(dest->selected_fib)) {
 				rib_uninstall_kernel(rn, dest->selected_fib);
+				dest->selected_fib = NULL;
+			}
 		}
 	}
 }


### PR DESCRIPTION
When the rib code is informed that a table is closing/
going away, only try once to uninstall associated routes from
the fib/dataplane. The close path can be called multiple times
in some cases - zebra shutdown, e.g.

Signed-off-by: Mark Stapp <mjs@voltanet.io>

### Related issue
3620

### Components
zebra
