### PR TITLE
Fixes/libyang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1595,6 +1595,12 @@ dnl ---------------
 PKG_CHECK_MODULES(libyang, [libyang >= 0.16.7], , [
   AC_MSG_ERROR([libyang (>= 0.16.7) was not found on your system.])
 ])
+AC_CHECK_MEMBER([struct lyd_node.priv], [], [
+  AC_MSG_ERROR([m4_normalize([
+    libyang needs to be compiled with ENABLE_LYD_PRIV=ON.
+    See http://docs.frrouting.org/projects/dev-guide/en/latest/building-libyang.html for details.])
+  ])
+], [[#include <libyang/libyang.h>]])
 
 dnl ---------------
 dnl configuration rollbacks

--- a/doc/developer/subdir.am
+++ b/doc/developer/subdir.am
@@ -23,6 +23,7 @@ dev_RSTFILES = \
 	doc/developer/building-frr-for-ubuntu1404.rst \
 	doc/developer/building-frr-for-ubuntu1604.rst \
 	doc/developer/building-frr-for-ubuntu1804.rst \
+	doc/developer/building-libyang.rst \
 	doc/developer/building.rst \
 	doc/developer/cli.rst \
 	doc/developer/conf.py \


### PR DESCRIPTION
### Summary

libyang needs to be built with the `priv` field enabled in `struct lyd_node`. We should check for this in autoconf instead of later having a weird error at compile time.