### PR TITLE
lib, zebra: Encode nexthop vrf in nht updates

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1217,6 +1217,7 @@ bool zapi_nexthop_update_decode(struct stream *s, struct zapi_route *nhr)
 	STREAM_GETC(s, nhr->nexthop_num);
 
 	for (i = 0; i < nhr->nexthop_num; i++) {
+		STREAM_GETL(s, nhr->nexthops[i].vrf_id);
 		STREAM_GETC(s, nhr->nexthops[i].type);
 		switch (nhr->nexthops[i].type) {
 		case NEXTHOP_TYPE_IPV4:

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -202,10 +202,12 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 	}
 
 	for (i = 0; i < nexthop_num; ++i) {
+		vrf_id_t nexthop_vrf_id;
 		enum nexthop_types_t nexthop_type;
 		struct pim_neighbor *nbr;
 		struct prefix p;
 
+		nexthop_vrf_id = stream_getl(s);
 		nexthop_type = stream_getc(s);
 		if (num_ifindex >= tab_size) {
 			char addr_str[INET_ADDRSTRLEN];
@@ -219,6 +221,7 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 		}
 		nexthop_tab[num_ifindex].protocol_distance = distance;
 		nexthop_tab[num_ifindex].route_metric = metric;
+		nexthop_tab[num_ifindex].vrf_id = nexthop_vrf_id;
 		switch (nexthop_type) {
 		case NEXTHOP_TYPE_IFINDEX:
 			nexthop_tab[num_ifindex].ifindex = stream_getl(s);
@@ -265,12 +268,12 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 					if_lookup_by_index(
 						nexthop_tab[num_ifindex]
 							.ifindex,
-						vrf_id),
+						nexthop_vrf_id),
 					&p);
 			else
 				nbr = pim_neighbor_find_if(if_lookup_by_index(
 					nexthop_tab[num_ifindex].ifindex,
-					vrf_id));
+					nexthop_vrf_id));
 			if (nbr) {
 				nexthop_tab[num_ifindex].nexthop_addr.family =
 					AF_INET;

--- a/pimd/pim_zlookup.h
+++ b/pimd/pim_zlookup.h
@@ -27,6 +27,7 @@
 #define PIM_NEXTHOP_LOOKUP_MAX (3) /* max. recursive route lookup */
 
 struct pim_zlookup_nexthop {
+	vrf_id_t vrf_id;
 	struct prefix nexthop_addr;
 	ifindex_t ifindex;
 	uint32_t route_metric;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -118,6 +118,7 @@ static void zserv_encode_vrf(struct stream *s, struct zebra_vrf *zvrf)
 
 static int zserv_encode_nexthop(struct stream *s, struct nexthop *nexthop)
 {
+	stream_putl(s, nexthop->vrf_id);
 	stream_putc(s, nexthop->type);
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IPV4:

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -913,6 +913,7 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 		stream_putc(s, 0);
 		for (nh = re->ng.nexthop; nh; nh = nh->next)
 			if (rnh_nexthop_valid(nh)) {
+				stream_putl(s, nh->vrf_id);
 				stream_putc(s, nh->type);
 				switch (nh->type) {
 				case NEXTHOP_TYPE_IPV4:


### PR DESCRIPTION
The nexthop vrf was not being encoded in nht updates.
Add it in.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
