### PR TITLE
*: Replace zclient_new with zclient_new_notify

### DIFF
--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -237,7 +237,7 @@ babel_zebra_connected (struct zclient *zclient)
 
 void babelz_zebra_init(void)
 {
-    zclient = zclient_new_notify(master, &zclient_options_default);
+    zclient = zclient_new(master, &zclient_options_default);
     zclient_init(zclient, ZEBRA_ROUTE_BABEL, 0, &babeld_privs);
 
     zclient->zebra_connected = babel_zebra_connected;

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -566,7 +566,7 @@ static void bfdd_zebra_connected(struct zclient *zc)
 
 void bfdd_zclient_init(struct zebra_privs_t *bfdd_priv)
 {
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	assert(zclient != NULL);
 	zclient_init(zclient, ZEBRA_ROUTE_BFD, 0, bfdd_priv);
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2574,7 +2574,7 @@ void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 	zclient_num_connects = 0;
 
 	/* Set default values. */
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
 	zclient->zebra_connected = bgp_zebra_connected;
 	zclient->router_id_update = bgp_router_id_update;

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -913,7 +913,7 @@ extern struct zebra_privs_t bgpd_privs;
 void vnc_zebra_init(struct thread_master *master)
 {
 	/* Set default values. */
-	zclient_vnc = zclient_new_notify(master, &zclient_options_default);
+	zclient_vnc = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient_vnc, ZEBRA_ROUTE_VNC, 0, &bgpd_privs);
 
 	zclient_vnc->redistribute_route_add = vnc_zebra_read_route;

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -116,7 +116,7 @@ void eigrp_zebra_init(void)
 {
 	struct zclient_options opt = {.receive_notify = false};
 
-	zclient = zclient_new_notify(master, &opt);
+	zclient = zclient_new(master, &opt);
 
 	zclient_init(zclient, ZEBRA_ROUTE_EIGRP, 0, &eigrpd_privs);
 	zclient->zebra_connected = eigrp_zebra_connected;

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -413,7 +413,7 @@ static void isis_zebra_connected(struct zclient *zclient)
 
 void isis_zebra_init(struct thread_master *master)
 {
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, PROTO_TYPE, 0, &isisd_privs);
 	zclient->zebra_connected = isis_zebra_connected;
 	zclient->router_id_update = isis_router_id_update_zebra;

--- a/ldpd/lde.c
+++ b/ldpd/lde.c
@@ -1627,7 +1627,7 @@ lde_address_list_free(struct lde_nbr *ln)
 static void zclient_sync_init(unsigned short instance)
 {
 	/* Initialize special zclient for synchronous message exchanges. */
-	zclient_sync = zclient_new_notify(master, &zclient_options_default);
+	zclient_sync = zclient_new(master, &zclient_options_default);
 	zclient_sync->sock = -1;
 	zclient_sync->redist_default = ZEBRA_ROUTE_LDP;
 	zclient_sync->instance = instance;

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -533,7 +533,7 @@ void
 ldp_zebra_init(struct thread_master *master)
 {
 	/* Set default values. */
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, ZEBRA_ROUTE_LDP, 0, &ldpd_privs);
 
 	/* set callbacks */

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -58,8 +58,8 @@ int zclient_debug = 0;
 struct zclient_options zclient_options_default = {.receive_notify = false};
 
 /* Allocate zclient structure. */
-struct zclient *zclient_new_notify(struct thread_master *master,
-				   struct zclient_options *opt)
+struct zclient *zclient_new(struct thread_master *master,
+			    struct zclient_options *opt)
 {
 	struct zclient *zclient;
 	zclient = XCALLOC(MTYPE_ZCLIENT, sizeof(struct zclient));
@@ -199,7 +199,7 @@ void zclient_reset(struct zclient *zclient)
  * @param zclient a pointer to zclient structure
  * @return socket fd just to make sure that connection established
  * @see zclient_init
- * @see zclient_new_notify
+ * @see zclient_new
  */
 int zclient_socket_connect(struct zclient *zclient)
 {

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -422,23 +422,10 @@ struct zclient_options {
 	bool receive_notify;
 };
 
-/* Prototypes of zebra client service functions. */
-extern struct zclient *zclient_new(struct thread_master *);
-
-/* clang-format off */
-#if CONFDATE > 20181101
-CPP_NOTICE("zclient_new_notify can take over or zclient_new now");
-#endif
-/* clang-format on */
-
 extern struct zclient_options zclient_options_default;
 
-extern struct zclient *zclient_new_notify(struct thread_master *m,
-					  struct zclient_options *opt);
-
-#define zclient_new(A)                                                         \
-	zclient_new_notify((A), &zclient_options_default);                     \
-	CPP_WARN("Please transition to using zclient_new_notify");
+extern struct zclient *zclient_new(struct thread_master *m,
+				   struct zclient_options *opt);
 
 extern void zclient_init(struct zclient *, int, unsigned short,
 			 struct zebra_privs_t *privs);

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -344,7 +344,7 @@ void nhrp_zebra_init(void)
 	zebra_rib[AFI_IP] = route_table_init();
 	zebra_rib[AFI_IP6] = route_table_init();
 
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	zclient->zebra_connected = nhrp_zebra_connected;
 	zclient->interface_add = nhrp_interface_add;
 	zclient->interface_delete = nhrp_interface_delete;

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -586,7 +586,7 @@ static void ospf6_zebra_connected(struct zclient *zclient)
 void ospf6_zebra_init(struct thread_master *master)
 {
 	/* Allocate zebra structure. */
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, ZEBRA_ROUTE_OSPF6, 0, &ospf6d_privs);
 	zclient->zebra_connected = ospf6_zebra_connected;
 	zclient->router_id_update = ospf6_router_id_update_zebra;

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1577,7 +1577,7 @@ static void ospf_zebra_connected(struct zclient *zclient)
 void ospf_zebra_init(struct thread_master *master, unsigned short instance)
 {
 	/* Allocate zebra structure. */
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, ZEBRA_ROUTE_OSPF, instance, &ospfd_privs);
 	zclient->zebra_connected = ospf_zebra_connected;
 	zclient->router_id_update = ospf_router_id_update_zebra;

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -391,7 +391,7 @@ void pbr_zebra_init(void)
 {
 	struct zclient_options opt = { .receive_notify = true };
 
-	zclient = zclient_new_notify(master, &opt);
+	zclient = zclient_new(master, &opt);
 
 	zclient_init(zclient, ZEBRA_ROUTE_PBR, 0, &pbr_privs);
 	zclient->zebra_connected = zebra_connected;

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -746,7 +746,7 @@ static void pim_zebra_connected(struct zclient *zclient)
 void pim_zebra_init(void)
 {
 	/* Socket for receiving updates from Zebra daemon */
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 
 	zclient->zebra_connected = pim_zebra_connected;
 	zclient->router_id_update = pim_router_id_update_zebra;

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -120,7 +120,7 @@ void zclient_lookup_free(void)
 
 void zclient_lookup_new(void)
 {
-	zlookup = zclient_new_notify(master, &zclient_options_default);
+	zlookup = zclient_new(master, &zclient_options_default);
 	if (!zlookup) {
 		flog_err(EC_LIB_ZAPI_SOCKET, "%s: zclient_new() failure",
 			 __PRETTY_FUNCTION__);

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -211,7 +211,7 @@ static void rip_zebra_connected(struct zclient *zclient)
 void rip_zclient_init(struct thread_master *master)
 {
 	/* Set default value to the zebra client structure. */
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, ZEBRA_ROUTE_RIP, 0, &ripd_privs);
 	zclient->zebra_connected = rip_zebra_connected;
 	zclient->interface_add = rip_interface_add;

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -414,7 +414,7 @@ static void ripng_zebra_connected(struct zclient *zclient)
 void zebra_init(struct thread_master *master)
 {
 	/* Allocate zebra structure. */
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, ZEBRA_ROUTE_RIPNG, 0, &ripngd_privs);
 
 	zclient->zebra_connected = ripng_zebra_connected;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -281,7 +281,7 @@ void sharp_zebra_init(void)
 {
 	struct zclient_options opt = {.receive_notify = true};
 
-	zclient = zclient_new_notify(master, &opt);
+	zclient = zclient_new(master, &opt);
 
 	zclient_init(zclient, ZEBRA_ROUTE_SHARP, 0, &sharp_privs);
 	zclient->zebra_connected = zebra_connected;

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -465,7 +465,7 @@ void static_zebra_init(void)
 {
 	struct zclient_options opt = { .receive_notify = true };
 
-	zclient = zclient_new_notify(master, &opt);
+	zclient = zclient_new(master, &opt);
 
 	zclient_init(zclient, ZEBRA_ROUTE_STATIC, 0, &static_privs);
 	zclient->zebra_capabilities = static_zebra_capabilities;

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -379,7 +379,7 @@ static int global_test_init(void)
 {
 	qobj_init();
 	master = thread_master_create(NULL);
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	bgp_master_init(master);
 	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);

--- a/tests/test_lblmgr.c
+++ b/tests/test_lblmgr.c
@@ -119,7 +119,7 @@ void init_zclient(struct thread_master *master, char *lm_zserv_path)
 {
 	frr_zclient_addr(&zclient_addr, &zclient_addr_len, lm_zserv_path);
 
-	zclient = zclient_new_notify(master, &zclient_options_default);
+	zclient = zclient_new(master, &zclient_options_default);
 	/* zclient_init(zclient, ZEBRA_LABEL_MANAGER, 0); */
 	zclient->sock = -1;
 	zclient->redist_default = ZEBRA_ROUTE_LDP;

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -318,7 +318,7 @@ static void lm_zclient_init(char *lm_zserv_path)
 				 lm_zserv_path);
 
 	/* Set default values. */
-	zclient = zclient_new_notify(zebrad.master, &zclient_options_default);
+	zclient = zclient_new(zebrad.master, &zclient_options_default);
 	zclient->privs = &zserv_privs;
 	zclient->sock = -1;
 	zclient->t_connect = NULL;


### PR DESCRIPTION
It's been a year since we added the new optional parameters
to instantiation.  Let's switch over to the new name.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

