### PR TITLE
doc: update libyang build instructions

### DIFF
--- a/doc/developer/building-libyang.rst
+++ b/doc/developer/building-libyang.rst
@@ -40,23 +40,3 @@ When building libyang on CentOS 6, it's also necessary to pass the
 Note: please check the `libyang build requirements
 <https://github.com/CESNET/libyang/blob/master/README.md#build-requirements>`_
 first.
-
-Libyang uses loadable libraries an YANG modules.  It supports
-environment variables to allow overriding the load paths for each of
-these. With FRR, this override currently must be done at the time of
-running FRR's configure command using new options. The new options are:
-
-.. code-block:: shell
-
-   --with-yangmodelsdir=DIR
-                          yang models directory (${datarootdir}/yang)
-   --with-libyang-pluginsdir=DIR
-                          yangmodule plugins directory
-                          (${libdir}/frr/libyang_plugins)
-
-an example which uses the compile directory is:
-
-.. code-block:: shell
-
-   ./configure --with-libyang-pluginsdir="`pwd`/yang/libyang_plugins/.libs" \
-          --with-yangmodelsdir="`pwd`/yang"

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -255,6 +255,24 @@ options to the configuration script.
    Configure zebra to use `dir` for local state files, such as pid files and
    unix sockets.
 
+.. option:: --with-yangmodelsdir <dir>
+
+   Look for YANG modules in `dir` [`prefix`/share/yang]. Note that the FRR
+   YANG modules will be installed here.
+
+.. option:: --with-libyang-pluginsdir <dir>
+
+   Look for libyang plugins in `dir` [`prefix`/lib/frr/libyang_plugins].
+   Note that the FRR libyang plugins will be installed here.
+
+When it's desired to run FRR without installing it in the system, it's possible
+to configure it as follows to look for YANG modules and libyang plugins in the
+compile directory:
+.. code-block:: shell
+
+   ./configure --with-libyang-pluginsdir="`pwd`/yang/libyang_plugins/.libs" \
+               --with-yangmodelsdir="`pwd`/yang"
+
 .. _least-privilege-support:
 
 Least-Privilege Support


### PR DESCRIPTION
### Summary
The --with-yangmodelsdir and --with-libyang-pluginsdir build-time options
pertain to FRR so they shouldn't be placed along with the libyang build
instructions. Move these instructions to where they belong to avoid
confusion.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>

### Related Issue
#3273

### Components
doc
