### PR TITLE
zebra: Carry onlink if set from resolving nexthop

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -358,8 +358,6 @@ static void nexthop_set_resolved(afi_t afi, const struct nexthop *newhop,
 		if (newhop->ifindex) {
 			resolved_hop->type = NEXTHOP_TYPE_IPV4_IFINDEX;
 			resolved_hop->ifindex = newhop->ifindex;
-			if (newhop->flags & NEXTHOP_FLAG_ONLINK)
-				resolved_hop->flags |= NEXTHOP_FLAG_ONLINK;
 		}
 		break;
 	case NEXTHOP_TYPE_IPV6:
@@ -397,6 +395,9 @@ static void nexthop_set_resolved(afi_t afi, const struct nexthop *newhop,
 		resolved_hop->bh_type = nexthop->bh_type;
 		break;
 	}
+
+	if (newhop->flags & NEXTHOP_FLAG_ONLINK)
+		resolved_hop->flags |= NEXTHOP_FLAG_ONLINK;
 
 	/* Copy labels of the resolved route */
 	if (newhop->nh_label)


### PR DESCRIPTION
When resolving a nexthop, carry the onlink flag if it
is set to the new nexthop.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

