### PR TITLE
ospfd: permit reconfiguring network after area suppressed

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -245,8 +245,11 @@ DEFUN_NOSH (router_ospf,
 						return ret;
 					}
 				}
-				ospf_interface_area_set(ospf, ifp);
-				ospf->if_ospf_cli_count++;
+				if (!ospf_interface_area_is_already_set(ospf,
+									ifp)) {
+					ospf_interface_area_set(ospf, ifp);
+					ospf->if_ospf_cli_count++;
+				}
 			}
 		}
 

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1149,6 +1149,32 @@ void ospf_interface_area_unset(struct ospf *ospf, struct interface *ifp)
 	update_redistributed(ospf, 0); /* interfaces possibly removed */
 }
 
+bool ospf_interface_area_is_already_set(struct ospf *ospf,
+					struct interface *ifp)
+{
+	struct route_node *rn_oi;
+
+	if (!ospf)
+		return false; /* Ospf not ready yet */
+
+	/* Find interfaces that may need to be removed. */
+	for (rn_oi = route_top(IF_OIFS(ifp)); rn_oi;
+	     rn_oi = route_next(rn_oi)) {
+		struct ospf_interface *oi = rn_oi->info;
+
+		if (oi == NULL)
+			continue;
+
+		if (oi->type == OSPF_IFTYPE_VIRTUALLINK)
+			continue;
+		/* at least one route covered by interface
+		 * that implies already done
+		 */
+		return true;
+	}
+	return false;
+}
+
 /* Check whether interface matches given network
  * returns: 1, true. 0, false
  */

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -561,6 +561,8 @@ extern void ospf_area_del_if(struct ospf_area *, struct ospf_interface *);
 
 extern void ospf_interface_area_set(struct ospf *, struct interface *);
 extern void ospf_interface_area_unset(struct ospf *, struct interface *);
+extern bool ospf_interface_area_is_already_set(struct ospf *ospf,
+					       struct interface *ifp);
 
 extern void ospf_route_map_init(void);
 


### PR DESCRIPTION
avoid counting twice the number of areas configured, when entering back
to router ospf config node.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
