### PR TITLE
bfdd: fix BGP unnumbered peer setup

### DIFF
--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -381,6 +381,21 @@ static int _ptm_msg_read(struct stream *msg, int command,
 		if (bpc->bpc_has_localif) {
 			STREAM_GET(bpc->bpc_localif, msg, ifnamelen);
 			bpc->bpc_localif[ifnamelen] = 0;
+
+			/*
+			 * IPv6 link-local addresses must use scope id,
+			 * otherwise the session lookup will always fail
+			 * and we'll have multiple sessions showing up.
+			 *
+			 * This problem only happens with single hop
+			 * since it is not possible to have link-local
+			 * address for multi hop sessions.
+			 */
+			if (bpc->bpc_ipv4 == false
+			    && IN6_IS_ADDR_LINKLOCAL(
+				       &bpc->bpc_peer.sa_sin6.sin6_addr))
+				bpc->bpc_peer.sa_sin6.sin6_scope_id =
+					ptm_bfd_fetch_ifindex(bpc->bpc_localif);
 		}
 	}
 


### PR DESCRIPTION
### Summary

The session key uses the scope id to figure out which interface we are
using with that link-local address, so if we don't set it when
registering a session we'll end up with multiple IPv6 sessions.

This bug was spotted by Sandro Bolliger.

(cherry picked from commit de61f256d68bc792a3823193fa8a49fdcaf77d3c)

This bug was first fixed in FRR 6.


### Related PR

https://github.com/FRRouting/frr/pull/3282


### Components

`bfdd`