### PR TITLE
isisd: Remove unused debug flags

### DIFF
--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -87,12 +87,6 @@ static int isis_zebra_if_add(int command, struct zclient *zclient,
 
 	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
 
-	if (isis->debugs & DEBUG_ZEBRA)
-		zlog_debug(
-			"Zebra I/F add: %s index %d flags %ld metric %d mtu %d",
-			ifp->name, ifp->ifindex, (long)ifp->flags, ifp->metric,
-			ifp->mtu);
-
 	if (if_is_operative(ifp))
 		isis_csm_state_change(IF_UP_FROM_Z, circuit_scan_by_ifp(ifp),
 				      ifp);
@@ -115,12 +109,6 @@ static int isis_zebra_if_del(int command, struct zclient *zclient,
 	if (if_is_operative(ifp))
 		zlog_warn("Zebra: got delete of %s, but interface is still up",
 			  ifp->name);
-
-	if (isis->debugs & DEBUG_ZEBRA)
-		zlog_debug(
-			"Zebra I/F delete: %s index %d flags %ld metric %d mtu %d",
-			ifp->name, ifp->ifindex, (long)ifp->flags, ifp->metric,
-			ifp->mtu);
 
 	isis_csm_state_change(IF_DOWN_FROM_Z, circuit_scan_by_ifp(ifp), ifp);
 

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -720,24 +720,11 @@ void print_debug(struct vty *vty, int flags, int onoff)
 		vty_out(vty,
 			"IS-IS Adjacency related packets debugging is %s\n",
 			onoffs);
-	if (flags & DEBUG_CHECKSUM_ERRORS)
-		vty_out(vty, "IS-IS checksum errors debugging is %s\n", onoffs);
-	if (flags & DEBUG_LOCAL_UPDATES)
-		vty_out(vty, "IS-IS local updates debugging is %s\n", onoffs);
-	if (flags & DEBUG_PROTOCOL_ERRORS)
-		vty_out(vty, "IS-IS protocol errors debugging is %s\n", onoffs);
 	if (flags & DEBUG_SNP_PACKETS)
 		vty_out(vty, "IS-IS CSNP/PSNP packets debugging is %s\n",
 			onoffs);
 	if (flags & DEBUG_SPF_EVENTS)
 		vty_out(vty, "IS-IS SPF events debugging is %s\n", onoffs);
-	if (flags & DEBUG_SPF_STATS)
-		vty_out(vty,
-			"IS-IS SPF Timing and Statistics Data debugging is %s\n",
-			onoffs);
-	if (flags & DEBUG_SPF_TRIGGERS)
-		vty_out(vty, "IS-IS SPF triggering events debugging is %s\n",
-			onoffs);
 	if (flags & DEBUG_UPDATE_PACKETS)
 		vty_out(vty, "IS-IS Update related packet debugging is %s\n",
 			onoffs);
@@ -784,32 +771,12 @@ static int config_write_debug(struct vty *vty)
 		vty_out(vty, "debug " PROTO_NAME " adj-packets\n");
 		write++;
 	}
-	if (flags & DEBUG_CHECKSUM_ERRORS) {
-		vty_out(vty, "debug " PROTO_NAME " checksum-errors\n");
-		write++;
-	}
-	if (flags & DEBUG_LOCAL_UPDATES) {
-		vty_out(vty, "debug " PROTO_NAME " local-updates\n");
-		write++;
-	}
-	if (flags & DEBUG_PROTOCOL_ERRORS) {
-		vty_out(vty, "debug " PROTO_NAME " protocol-errors\n");
-		write++;
-	}
 	if (flags & DEBUG_SNP_PACKETS) {
 		vty_out(vty, "debug " PROTO_NAME " snp-packets\n");
 		write++;
 	}
 	if (flags & DEBUG_SPF_EVENTS) {
 		vty_out(vty, "debug " PROTO_NAME " spf-events\n");
-		write++;
-	}
-	if (flags & DEBUG_SPF_STATS) {
-		vty_out(vty, "debug " PROTO_NAME " spf-statistics\n");
-		write++;
-	}
-	if (flags & DEBUG_SPF_TRIGGERS) {
-		vty_out(vty, "debug " PROTO_NAME " spf-triggers\n");
 		write++;
 	}
 	if (flags & DEBUG_UPDATE_PACKETS) {
@@ -872,87 +839,6 @@ DEFUN (no_debug_isis_adj,
 {
 	isis->debugs &= ~DEBUG_ADJ_PACKETS;
 	print_debug(vty, DEBUG_ADJ_PACKETS, 0);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (debug_isis_csum,
-       debug_isis_csum_cmd,
-       "debug " PROTO_NAME " checksum-errors",
-       DEBUG_STR
-       PROTO_HELP
-       "IS-IS LSP checksum errors\n")
-{
-	isis->debugs |= DEBUG_CHECKSUM_ERRORS;
-	print_debug(vty, DEBUG_CHECKSUM_ERRORS, 1);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_isis_csum,
-       no_debug_isis_csum_cmd,
-       "no debug " PROTO_NAME " checksum-errors",
-       NO_STR
-       UNDEBUG_STR
-       PROTO_HELP
-       "IS-IS LSP checksum errors\n")
-{
-	isis->debugs &= ~DEBUG_CHECKSUM_ERRORS;
-	print_debug(vty, DEBUG_CHECKSUM_ERRORS, 0);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (debug_isis_lupd,
-       debug_isis_lupd_cmd,
-       "debug " PROTO_NAME " local-updates",
-       DEBUG_STR
-       PROTO_HELP
-       "IS-IS local update packets\n")
-{
-	isis->debugs |= DEBUG_LOCAL_UPDATES;
-	print_debug(vty, DEBUG_LOCAL_UPDATES, 1);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_isis_lupd,
-       no_debug_isis_lupd_cmd,
-       "no debug " PROTO_NAME " local-updates",
-       NO_STR
-       UNDEBUG_STR
-       PROTO_HELP
-       "IS-IS local update packets\n")
-{
-	isis->debugs &= ~DEBUG_LOCAL_UPDATES;
-	print_debug(vty, DEBUG_LOCAL_UPDATES, 0);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (debug_isis_err,
-       debug_isis_err_cmd,
-       "debug " PROTO_NAME " protocol-errors",
-       DEBUG_STR
-       PROTO_HELP
-       "IS-IS LSP protocol errors\n")
-{
-	isis->debugs |= DEBUG_PROTOCOL_ERRORS;
-	print_debug(vty, DEBUG_PROTOCOL_ERRORS, 1);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_isis_err,
-       no_debug_isis_err_cmd,
-       "no debug " PROTO_NAME " protocol-errors",
-       NO_STR
-       UNDEBUG_STR
-       PROTO_HELP
-       "IS-IS LSP protocol errors\n")
-{
-	isis->debugs &= ~DEBUG_PROTOCOL_ERRORS;
-	print_debug(vty, DEBUG_PROTOCOL_ERRORS, 0);
 
 	return CMD_SUCCESS;
 }
@@ -1034,60 +920,6 @@ DEFUN (no_debug_isis_spfevents,
 {
 	isis->debugs &= ~DEBUG_SPF_EVENTS;
 	print_debug(vty, DEBUG_SPF_EVENTS, 0);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (debug_isis_spfstats,
-       debug_isis_spfstats_cmd,
-       "debug " PROTO_NAME " spf-statistics ",
-       DEBUG_STR
-       PROTO_HELP
-       "IS-IS SPF Timing and Statistic Data\n")
-{
-	isis->debugs |= DEBUG_SPF_STATS;
-	print_debug(vty, DEBUG_SPF_STATS, 1);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_isis_spfstats,
-       no_debug_isis_spfstats_cmd,
-       "no debug " PROTO_NAME " spf-statistics",
-       NO_STR
-       UNDEBUG_STR
-       PROTO_HELP
-       "IS-IS SPF Timing and Statistic Data\n")
-{
-	isis->debugs &= ~DEBUG_SPF_STATS;
-	print_debug(vty, DEBUG_SPF_STATS, 0);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (debug_isis_spftrigg,
-       debug_isis_spftrigg_cmd,
-       "debug " PROTO_NAME " spf-triggers",
-       DEBUG_STR
-       PROTO_HELP
-       "IS-IS SPF triggering events\n")
-{
-	isis->debugs |= DEBUG_SPF_TRIGGERS;
-	print_debug(vty, DEBUG_SPF_TRIGGERS, 1);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_debug_isis_spftrigg,
-       no_debug_isis_spftrigg_cmd,
-       "no debug " PROTO_NAME " spf-triggers",
-       NO_STR
-       UNDEBUG_STR
-       PROTO_HELP
-       "IS-IS SPF triggering events\n")
-{
-	isis->debugs &= ~DEBUG_SPF_TRIGGERS;
-	print_debug(vty, DEBUG_SPF_TRIGGERS, 0);
 
 	return CMD_SUCCESS;
 }
@@ -2229,22 +2061,12 @@ void isis_init()
 
 	install_element(ENABLE_NODE, &debug_isis_adj_cmd);
 	install_element(ENABLE_NODE, &no_debug_isis_adj_cmd);
-	install_element(ENABLE_NODE, &debug_isis_csum_cmd);
-	install_element(ENABLE_NODE, &no_debug_isis_csum_cmd);
-	install_element(ENABLE_NODE, &debug_isis_lupd_cmd);
-	install_element(ENABLE_NODE, &no_debug_isis_lupd_cmd);
-	install_element(ENABLE_NODE, &debug_isis_err_cmd);
-	install_element(ENABLE_NODE, &no_debug_isis_err_cmd);
 	install_element(ENABLE_NODE, &debug_isis_snp_cmd);
 	install_element(ENABLE_NODE, &no_debug_isis_snp_cmd);
 	install_element(ENABLE_NODE, &debug_isis_upd_cmd);
 	install_element(ENABLE_NODE, &no_debug_isis_upd_cmd);
 	install_element(ENABLE_NODE, &debug_isis_spfevents_cmd);
 	install_element(ENABLE_NODE, &no_debug_isis_spfevents_cmd);
-	install_element(ENABLE_NODE, &debug_isis_spfstats_cmd);
-	install_element(ENABLE_NODE, &no_debug_isis_spfstats_cmd);
-	install_element(ENABLE_NODE, &debug_isis_spftrigg_cmd);
-	install_element(ENABLE_NODE, &no_debug_isis_spftrigg_cmd);
 	install_element(ENABLE_NODE, &debug_isis_rtevents_cmd);
 	install_element(ENABLE_NODE, &no_debug_isis_rtevents_cmd);
 	install_element(ENABLE_NODE, &debug_isis_events_cmd);
@@ -2260,22 +2082,12 @@ void isis_init()
 
 	install_element(CONFIG_NODE, &debug_isis_adj_cmd);
 	install_element(CONFIG_NODE, &no_debug_isis_adj_cmd);
-	install_element(CONFIG_NODE, &debug_isis_csum_cmd);
-	install_element(CONFIG_NODE, &no_debug_isis_csum_cmd);
-	install_element(CONFIG_NODE, &debug_isis_lupd_cmd);
-	install_element(CONFIG_NODE, &no_debug_isis_lupd_cmd);
-	install_element(CONFIG_NODE, &debug_isis_err_cmd);
-	install_element(CONFIG_NODE, &no_debug_isis_err_cmd);
 	install_element(CONFIG_NODE, &debug_isis_snp_cmd);
 	install_element(CONFIG_NODE, &no_debug_isis_snp_cmd);
 	install_element(CONFIG_NODE, &debug_isis_upd_cmd);
 	install_element(CONFIG_NODE, &no_debug_isis_upd_cmd);
 	install_element(CONFIG_NODE, &debug_isis_spfevents_cmd);
 	install_element(CONFIG_NODE, &no_debug_isis_spfevents_cmd);
-	install_element(CONFIG_NODE, &debug_isis_spfstats_cmd);
-	install_element(CONFIG_NODE, &no_debug_isis_spfstats_cmd);
-	install_element(CONFIG_NODE, &debug_isis_spftrigg_cmd);
-	install_element(CONFIG_NODE, &no_debug_isis_spftrigg_cmd);
 	install_element(CONFIG_NODE, &debug_isis_rtevents_cmd);
 	install_element(CONFIG_NODE, &no_debug_isis_rtevents_cmd);
 	install_element(CONFIG_NODE, &debug_isis_events_cmd);

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -204,22 +204,16 @@ int isis_area_passwd_hmac_md5_set(struct isis_area *area, int level,
 extern struct thread_master *master;
 
 #define DEBUG_ADJ_PACKETS                (1<<0)
-#define DEBUG_CHECKSUM_ERRORS            (1<<1)
-#define DEBUG_LOCAL_UPDATES              (1<<2)
-#define DEBUG_PROTOCOL_ERRORS            (1<<3)
-#define DEBUG_SNP_PACKETS                (1<<4)
-#define DEBUG_UPDATE_PACKETS             (1<<5)
-#define DEBUG_SPF_EVENTS                 (1<<6)
-#define DEBUG_SPF_STATS                  (1<<7)
-#define DEBUG_SPF_TRIGGERS               (1<<8)
-#define DEBUG_RTE_EVENTS                 (1<<9)
-#define DEBUG_EVENTS                     (1<<10)
-#define DEBUG_ZEBRA                      (1<<11)
-#define DEBUG_PACKET_DUMP                (1<<12)
-#define DEBUG_LSP_GEN                    (1<<13)
-#define DEBUG_LSP_SCHED                  (1<<14)
-#define DEBUG_FABRICD_FLOODING           (1<<15)
-#define DEBUG_BFD                        (1<<16)
+#define DEBUG_SNP_PACKETS                (1<<1)
+#define DEBUG_UPDATE_PACKETS             (1<<2)
+#define DEBUG_SPF_EVENTS                 (1<<3)
+#define DEBUG_RTE_EVENTS                 (1<<4)
+#define DEBUG_EVENTS                     (1<<5)
+#define DEBUG_PACKET_DUMP                (1<<6)
+#define DEBUG_LSP_GEN                    (1<<7)
+#define DEBUG_LSP_SCHED                  (1<<8)
+#define DEBUG_FABRICD_FLOODING           (1<<9)
+#define DEBUG_BFD                        (1<<10)
 
 #define lsp_debug(...)                                                         \
 	do {                                                                   \
@@ -233,7 +227,7 @@ extern struct thread_master *master;
 			zlog_debug(__VA_ARGS__);                               \
 	} while (0)
 
-#define DEBUG_TE                         (1<<13)
+#define DEBUG_TE                         DEBUG_LSP_GEN
 
 #define IS_DEBUG_ISIS(x)                 (isis->debugs & x)
 


### PR DESCRIPTION
It turns out `isisd` defined quite a few debug flags which did not guard any debugs.

As this is quite confusing for the user, remove those flags.

(`DEBUG_ZEBRA` is somewhat special: It guarded two debugs, however there was no command to turn it on.)