### PR TITLE
fabricd: never flood back through the incoming interface

### DIFF
--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1999,13 +1999,13 @@ void lsp_set_all_srmflags(struct isis_lsp *lsp, bool set)
 
 void lsp_flood(struct isis_lsp *lsp, struct isis_circuit *circuit)
 {
-	if (!fabricd) {
+	if (!fabricd)
 		lsp_set_all_srmflags(lsp, true);
-		if (circuit)
-			isis_tx_queue_del(circuit->tx_queue, lsp);
-	} else {
+	else
 		fabricd_lsp_flood(lsp);
-	}
+
+	if (circuit)
+		isis_tx_queue_del(circuit->tx_queue, lsp);
 }
 
 static int lsp_handle_adj_state_change(struct isis_adjacency *adj)


### PR DESCRIPTION
The OpenFabric flooding restrictions should be applied on top of those from IS-IS, not instead of. Therefore, always remove the receiving interface when reflooding a received update.