### PR TITLE
Fix IS-IS CSNP handling

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -12,6 +12,7 @@
 /bgpd/test_peer_attr
 /isisd/test_fuzz_isis_tlv
 /isisd/test_fuzz_isis_tlv_tests.h
+/isisd/test_isis_lspdb
 /isisd/test_isis_vertex_queue
 /lib/cli/test_cli
 /lib/cli/test_cli_clippy.c

--- a/tests/isisd/test_isis_lspdb.c
+++ b/tests/isisd/test_isis_lspdb.c
@@ -1,0 +1,87 @@
+#include <zebra.h>
+
+#include "isisd/isis_lsp.c"
+
+struct thread_master *master;
+
+int isis_sock_init(struct isis_circuit *circuit);
+int isis_sock_init(struct isis_circuit *circuit)
+{
+	return 0;
+}
+
+struct zebra_privs_t isisd_privs;
+
+static void test_lsp_build_list_nonzero_ht(void)
+{
+	uint8_t lsp_id1[8]    = {
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00
+	};
+	uint8_t lsp_id_end[8] = {
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x5f, 0x00
+	};
+	uint8_t lsp_id2[8]    = {
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00
+	};
+
+	struct isis_area *area = calloc(sizeof(*area), 1);
+
+	area->lsp_mtu = 1500;
+
+	dict_t *lspdb = lsp_db_init();
+
+	struct isis_lsp *lsp1 = lsp_new(area, lsp_id1, 6000, 0, 0, 0, NULL,
+					ISIS_LEVEL2);
+
+	lsp_insert(lsp1, lspdb);
+
+	struct isis_lsp *lsp2 = lsp_new(area, lsp_id2, 6000, 0, 0, 0, NULL,
+					ISIS_LEVEL2);
+
+	lsp_insert(lsp2, lspdb);
+
+	struct list *list = list_new();
+
+	lsp_build_list_nonzero_ht(lsp_id1, lsp_id_end, list, lspdb);
+	assert(list->count == 1);
+	assert(listgetdata(listhead(list)) == lsp1);
+	list_delete_all_node(list);
+
+	lsp_id_end[5] = 0x03;
+	lsp_id_end[6] = 0x00;
+
+	lsp_build_list_nonzero_ht(lsp_id1, lsp_id_end, list, lspdb);
+	assert(list->count == 2);
+	assert(listgetdata(listhead(list)) == lsp1);
+	assert(listgetdata(listtail(list)) == lsp2);
+	list_delete_all_node(list);
+
+	memcpy(lsp_id1, lsp_id2, sizeof(lsp_id1));
+
+	lsp_build_list_nonzero_ht(lsp_id1, lsp_id_end, list, lspdb);
+	assert(list->count == 1);
+	assert(listgetdata(listhead(list)) == lsp2);
+	list_delete_all_node(list);
+
+	lsp_id1[5] = 0x03;
+	lsp_id_end[5] = 0x04;
+
+	lsp_build_list_nonzero_ht(lsp_id1, lsp_id_end, list, lspdb);
+	assert(list->count == 0);
+	list_delete_all_node(list);
+
+	lsp_id1[5] = 0x00;
+
+	lsp_build_list_nonzero_ht(lsp_id1, lsp_id_end, list, lspdb);
+	assert(list->count == 2);
+	assert(listgetdata(listhead(list)) == lsp1);
+	assert(listgetdata(listtail(list)) == lsp2);
+	list_delete_all_node(list);
+}
+
+int main(int argc, char **argv)
+{
+	isis = calloc(sizeof(*isis), 1);
+	test_lsp_build_list_nonzero_ht();
+	return 0;
+}

--- a/tests/isisd/test_isis_lspdb.py
+++ b/tests/isisd/test_isis_lspdb.py
@@ -1,0 +1,6 @@
+import frrtest
+
+class TestIsisLSPDB(frrtest.TestMultiOut):
+    program = './test_isis_lspdb'
+
+TestIsisLSPDB.exit_cleanly()

--- a/tests/subdir.am
+++ b/tests/subdir.am
@@ -24,6 +24,7 @@ TESTS_ISISD =
 else
 TESTS_ISISD = \
 	tests/isisd/test_fuzz_isis_tlv \
+	tests/isisd/test_isis_lspdb \
 	tests/isisd/test_isis_vertex_queue \
 	# end
 endif
@@ -155,6 +156,10 @@ tests_isisd_test_fuzz_isis_tlv_CPPFLAGS = $(TESTS_CPPFLAGS) -I$(top_builddir)/te
 tests_isisd_test_fuzz_isis_tlv_LDADD = $(ISISD_TEST_LDADD)
 tests_isisd_test_fuzz_isis_tlv_SOURCES = tests/isisd/test_fuzz_isis_tlv.c
 nodist_tests_isisd_test_fuzz_isis_tlv_SOURCES = tests/isisd/test_fuzz_isis_tlv_tests.h
+tests_isisd_test_isis_lspdb_CFLAGS = $(TESTS_CFLAGS)
+tests_isisd_test_isis_lspdb_CPPFLAGS = $(TESTS_CPPFLAGS)
+tests_isisd_test_isis_lspdb_LDADD = $(ISISD_TEST_LDADD)
+tests_isisd_test_isis_lspdb_SOURCES = tests/isisd/test_isis_lspdb.c
 tests_isisd_test_isis_vertex_queue_CFLAGS = $(TESTS_CFLAGS)
 tests_isisd_test_isis_vertex_queue_CPPFLAGS = $(TESTS_CPPFLAGS)
 tests_isisd_test_isis_vertex_queue_LDADD = $(ISISD_TEST_LDADD)
@@ -267,6 +272,7 @@ EXTRA_DIST += \
 	tests/helpers/python/frrtest.py \
 	tests/isisd/test_fuzz_isis_tlv.py \
 	tests/isisd/test_fuzz_isis_tlv_tests.h.gz \
+	tests/isisd/test_isis_lspdb.py \
 	tests/isisd/test_isis_vertex_queue.py \
 	tests/lib/cli/test_commands.in \
 	tests/lib/cli/test_commands.py \


### PR DESCRIPTION
### Summary

The code for handling CSNPs needs to build a list of LSPs in the local LSPDB which are in a specified interval. The function for this was behaving incorrectly if the specified interval contained only a single LSP.

Fix this and simplify the code.