### PR TITLE
zebra: Let zebra know about bond and blond slave intf types

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1150,6 +1150,15 @@ static const char *zebra_ziftype_2str(zebra_iftype_t zif_type)
 		return "VETH";
 		break;
 
+	case ZEBRA_IF_BOND:
+		return "bond";
+
+	case ZEBRA_IF_BOND_SLAVE:
+		return "bond_slave";
+
+	case ZEBRA_IF_MACVLAN:
+		return "macvlan";
+
 	default:
 		return "Unknown";
 		break;
@@ -1277,6 +1286,15 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 		if (br_slave->bridge_ifindex != IFINDEX_INTERNAL)
 			vty_out(vty, "  Master (bridge) ifindex %u\n",
 				br_slave->bridge_ifindex);
+	}
+
+	if (IS_ZEBRA_IF_BOND_SLAVE(ifp)) {
+		struct zebra_l2info_bondslave *bond_slave;
+
+		bond_slave = &zebra_if->bondslave_info;
+		if (bond_slave->bond_ifindex != IFINDEX_INTERNAL)
+			vty_out(vty, "  Master (bond) ifindex %u\n",
+				bond_slave->bond_ifindex);
 	}
 
 	if (zebra_if->link_ifindex != IFINDEX_INTERNAL) {

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -1,3 +1,4 @@
+
 /* Interface function header.
  * Copyright (C) 1999 Kunihiro Ishiguro
  *
@@ -192,6 +193,8 @@ typedef enum {
 	ZEBRA_IF_VLAN,      /* VLAN sub-interface */
 	ZEBRA_IF_MACVLAN,   /* MAC VLAN interface*/
 	ZEBRA_IF_VETH,      /* VETH interface*/
+	ZEBRA_IF_BOND,	    /* Bond */
+	ZEBRA_IF_BOND_SLAVE,	    /* Bond */
 } zebra_iftype_t;
 
 /* Zebra "slave" interface type */
@@ -199,6 +202,7 @@ typedef enum {
 	ZEBRA_IF_SLAVE_NONE,   /* Not a slave */
 	ZEBRA_IF_SLAVE_VRF,    /* Member of a VRF */
 	ZEBRA_IF_SLAVE_BRIDGE, /* Member of a bridge */
+	ZEBRA_IF_SLAVE_BOND,   /* Bond member */
 	ZEBRA_IF_SLAVE_OTHER,  /* Something else - e.g., bond slave */
 } zebra_slave_iftype_t;
 
@@ -268,6 +272,8 @@ struct zebra_if {
 	 */
 	struct zebra_l2info_brslave brslave_info;
 
+	struct zebra_l2info_bondslave bondslave_info;
+
 	/* Link fields - for sub-interfaces. */
 	ifindex_t link_ifindex;
 	struct interface *link;
@@ -323,6 +329,10 @@ static inline void zebra_if_set_ziftype(struct interface *ifp,
 
 #define IS_ZEBRA_IF_VRF_SLAVE(ifp)                                             \
 	(((struct zebra_if *)(ifp->info))->zif_slave_type == ZEBRA_IF_SLAVE_VRF)
+
+#define IS_ZEBRA_IF_BOND_SLAVE(ifp)					\
+	(((struct zebra_if *)(ifp->info))->zif_slave_type                      \
+	 == ZEBRA_IF_SLAVE_BOND)
 
 extern void zebra_if_init(void);
 

--- a/zebra/zebra_l2.h
+++ b/zebra/zebra_l2.h
@@ -52,6 +52,11 @@ struct zebra_l2info_vxlan {
 	vlanid_t access_vlan;   /* Access VLAN - for VLAN-aware bridge. */
 };
 
+struct zebra_l2info_bondslave {
+	ifindex_t bond_ifindex;    /* Bridge Master */
+	struct interface *bond_if; /* Pointer to master */
+};
+
 union zebra_l2if_info {
 	struct zebra_l2info_bridge br;
 	struct zebra_l2info_vlan vl;
@@ -70,6 +75,10 @@ union zebra_l2if_info {
 extern void zebra_l2_map_slave_to_bridge(struct zebra_l2info_brslave *br_slave);
 extern void
 zebra_l2_unmap_slave_from_bridge(struct zebra_l2info_brslave *br_slave);
+extern void
+zebra_l2_map_slave_to_bond(struct zebra_l2info_bondslave *bond_slave);
+extern void
+zebra_l2_unmap_slave_from_bond(struct zebra_l2info_bondslave *bond_slave);
 extern void zebra_l2_bridge_add_update(struct interface *ifp,
 				       struct zebra_l2info_bridge *bridge_info,
 				       int add);
@@ -85,4 +94,6 @@ extern void zebra_l2_vxlanif_del(struct interface *ifp);
 extern void zebra_l2if_update_bridge_slave(struct interface *ifp,
 					   ifindex_t bridge_ifindex);
 
+extern void zebra_l2if_update_bond_slave(struct interface *ifp,
+					 ifindex_t bond_ifindex);
 #endif /* _ZEBRA_L2_H */


### PR DESCRIPTION
The interface type can be a bond or a bond slave, add some
code to note this and to display it as part of a show interface
command.

Signed-off-by: Dinesh Dutt <didutt@gmail.com>
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

