### PR TITLE
bgpd: fix bgp path info for mplsvpn leaked routes

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -578,7 +578,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 		return bpi;
 	}
 
-	new = info_make(ZEBRA_ROUTE_BGP, BGP_ROUTE_IMPORTED, 0,
+	new = info_make(bpi_ultimate->type, bpi_ultimate->sub_type, 0,
 		bgp->peer_self, new_attr, bn);
 
 	if (nexthop_self_flag)


### PR DESCRIPTION
### Summary
MPLS VPN leaked routes were not being installed because the bgp_path_info sub_type for the leaked routes was statically (and incorrectly) set to BGP_ROUTE_IMPORTED in bgp_mplsvpn.c:leak_update() instead of using the route's real bgp_path_info. This was leading to Zebra's rnh module not being able to evaluate the route correctly. Now the rnh module sees mplsvpn routes as imported and treats them accordingly.

### Related Issue
This is the fix for #2724 which was reproduced by myself and confirmed as fixed with the patch applied.

### Components
[bgpd]