### PR TITLE
ospf6d: add missing vty commands to ospf6 area command

### DIFF
--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -567,9 +567,10 @@ void ospf6_area_config_write(struct vty *vty)
 
 DEFUN (area_filter_list,
        area_filter_list_cmd,
-       "area A.B.C.D filter-list prefix WORD <in|out>",
+       "area <A.B.C.D|(0-4294967295)> filter-list prefix WORD <in|out>",
        "OSPF6 area parameters\n"
        "OSPF6 area ID in IP address format\n"
+       "OSPF6 area ID as a decimal value\n"
        "Filter networks between OSPF6 areas\n"
        "Filter prefixes between OSPF6 areas\n"
        "Name of an IPv6 prefix-list\n"
@@ -605,10 +606,11 @@ DEFUN (area_filter_list,
 
 DEFUN (no_area_filter_list,
        no_area_filter_list_cmd,
-       "no area A.B.C.D filter-list prefix WORD <in|out>",
+       "no area <A.B.C.D|(0-4294967295)> filter-list prefix WORD <in|out>",
        NO_STR
        "OSPF6 area parameters\n"
        "OSPF6 area ID in IP address format\n"
+       "OSPF6 area ID as a decimal value\n"
        "Filter networks between OSPF6 areas\n"
        "Filter prefixes between OSPF6 areas\n"
        "Name of an IPv6 prefix-list\n"
@@ -662,9 +664,10 @@ void ospf6_area_plist_update(struct prefix_list *plist, int add)
 
 DEFUN (area_import_list,
        area_import_list_cmd,
-       "area A.B.C.D import-list NAME",
+       "area <A.B.C.D|(0-4294967295)> import-list NAME",
        "OSPF6 area parameters\n"
        "OSPF6 area ID in IP address format\n"
+       "OSPF6 area ID as a decimal value\n"
        "Set the filter for networks from other areas announced to the specified one\n"
        "Name of the acess-list\n")
 {
@@ -690,10 +693,11 @@ DEFUN (area_import_list,
 
 DEFUN (no_area_import_list,
        no_area_import_list_cmd,
-       "no area A.B.C.D import-list NAME",
+       "no area <A.B.C.D|(0-4294967295)> import-list NAME",
        NO_STR
        "OSPF6 area parameters\n"
        "OSPF6 area ID in IP address format\n"
+       "OSPF6 area ID as a decimal value\n"
        "Unset the filter for networks announced to other areas\n"
        "Name of the access-list\n")
 {
@@ -715,9 +719,10 @@ DEFUN (no_area_import_list,
 
 DEFUN (area_export_list,
        area_export_list_cmd,
-       "area A.B.C.D export-list NAME",
+       "area <A.B.C.D|(0-4294967295)> export-list NAME",
        "OSPF6 area parameters\n"
        "OSPF6 area ID in IP address format\n"
+       "OSPF6 area ID as a decimal value\n"
        "Set the filter for networks announced to other areas\n"
        "Name of the acess-list\n")
 {
@@ -743,10 +748,11 @@ DEFUN (area_export_list,
 
 DEFUN (no_area_export_list,
        no_area_export_list_cmd,
-       "no area A.B.C.D export-list NAME",
+       "no area <A.B.C.D|(0-4294967295)> export-list NAME",
        NO_STR
        "OSPF6 area parameters\n"
        "OSPF6 area ID in IP address format\n"
+       "OSPF6 area ID as a decimal value\n"
        "Unset the filter for networks announced to other areas\n"
        "Name of the access-list\n")
 {


### PR DESCRIPTION
it was not possible to configure per area identifier under decimal
format some ospf6 area options. this is the case of filter list, or
export-list.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
