### PR TITLE
doc: strip trailing whitespace

### DIFF
--- a/doc/developer/building-frr-for-ubuntu1804.rst
+++ b/doc/developer/building-frr-for-ubuntu1804.rst
@@ -115,7 +115,7 @@ Create empty FRR configuration files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Although not strictly necessary, it's good practice to create empty
-configuration files _before_ starting FRR. This assures that the permissions 
+configuration files _before_ starting FRR. This assures that the permissions
 are correct. If the files are not already present, FRR will create them.
 
 It's also important to consider _which_ files to create. FRR supports writing

--- a/doc/developer/modules.rst
+++ b/doc/developer/modules.rst
@@ -103,9 +103,9 @@ standard entry point for loadable modules.
 Command line parameters
 -----------------------
 
-Command line parameters can be passed directly to a module by appending a 
-colon to the module name when loading it, e.g. ``-M mymodule:myparameter``. 
-The text after the colon will be accessible in the module's code through 
+Command line parameters can be passed directly to a module by appending a
+colon to the module name when loading it, e.g. ``-M mymodule:myparameter``.
+The text after the colon will be accessible in the module's code through
 ``THIS_MODULE->load_args``. For example, see how the format parameter is
 configured in the ``zfpm_init()`` function inside ``zebra_fpm.c``.
 

--- a/doc/developer/next-hop-tracking.rst
+++ b/doc/developer/next-hop-tracking.rst
@@ -269,7 +269,7 @@ RNH table::
     O   O
        / \
       O   O
-   
+
    struct rnh
    {
      uint8_t flags;

--- a/doc/developer/process-architecture.rst
+++ b/doc/developer/process-architecture.rst
@@ -118,7 +118,7 @@ The following diagram illustrates a simplified version of this infrastructure.
 .. todo: replace these with SVG
 .. figure:: ../figures/threadmaster-single.png
    :align: center
-   
+
    Lifecycle of a program using a single threadmaster.
 
 The series of "task" boxes represents the current ready task queue. The various
@@ -183,7 +183,7 @@ running their own ``threadmaster``-based event loop.
 .. todo: replace these with SVG
 .. figure:: ../figures/threadmaster-multiple.png
    :align: center
-   
+
    Lifecycle of a program using multiple pthreads, each running their own
    ``threadmaster``
 

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -385,7 +385,7 @@ Additional kernel modules are also needed to support MPLS forwarding.
    appropriate value.
 
 :makevar:`VRF forwarding`
-   General information on Linux VRF support can be found in 
+   General information on Linux VRF support can be found in
    https://www.kernel.org/doc/Documentation/networking/vrf.txt. Kernel
    support for VRFs was introduced in 4.3 and improved upon through
    4.13, which is the version most used in FRR testing (as of June
@@ -421,7 +421,7 @@ Additional kernel modules are also needed to support MPLS forwarding.
    included in future kernel versions so upgrading your kernel may also
    address this issue.
 
-   
+
 Building
 ^^^^^^^^
 

--- a/doc/user/static.rst
+++ b/doc/user/static.rst
@@ -9,7 +9,7 @@ of static routes.
 
 .. _starting-static:
 
-Starting STATIC 
+Starting STATIC
 ===============
 
 Default configuration file for *staticd* is :file:`staticd.conf`.  The typical
@@ -45,11 +45,11 @@ a static prefix and gateway.
    initial form of the command.  GATEWAY is gateway for the prefix it currently
    must match the v4 or v6 route type specified at the start of the command.
    GATEWAY can also be treated as an interface name. If the interface name
-   is ``null0`` then zebra installs a blackhole route.  TABLENO 
+   is ``null0`` then zebra installs a blackhole route.  TABLENO
    is an optional parameter for namespaces that allows you to create the
    route in a specified table associated with the vrf namespace. table will
    be rejected if you are not using namespace based vrfs.  ``nexthop-vrf``
-   allows you to create a leaked route with a nexthop in the specified VRFNAME 
+   allows you to create a leaked route with a nexthop in the specified VRFNAME
    vrf VRFNAME allows you to create the route in a specified vrf.
    ``nexthop-vrf`` cannot be currently used with namespace based vrfs
    currently as well.

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -186,7 +186,7 @@ Standard Commands
    Enable/disable link-detect on platforms which support this. Currently only
    Linux and Solaris, and only where network interface drivers support
    reporting link-state via the ``IFF_RUNNING`` flag.
-   
+
    In FRR, link-detect is on by default.
 
 .. _link-parameters-commands:


### PR DESCRIPTION
Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>

### Summary
Just a quick sed to strip trailing whitespace I noticed whilst browsing our docs