### PR TITLE
Doc dev fixes

### DIFF
--- a/doc/developer/building-frr-for-centos6.rst
+++ b/doc/developer/building-frr-for-centos6.rst
@@ -244,7 +244,7 @@ Load the modifed sysctl's on the system:
 Add init.d startup files
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block::
+.. code-block:: shell
 
    sudo install -p -m 755 redhat/frr.init /etc/init.d/frr
    sudo chkconfig --add frr
@@ -252,13 +252,13 @@ Add init.d startup files
 Enable FRR daemon at startup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block::
+.. code-block:: shell
 
    sudo chkconfig frr on
 
 Start FRR manually (or reboot)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block::
+.. code-block:: shell
 
    sudo /etc/init.d/frr start

--- a/doc/developer/conf.py
+++ b/doc/developer/conf.py
@@ -131,7 +131,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'building-libyang.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/doc/developer/maintainer-release-build.rst
+++ b/doc/developer/maintainer-release-build.rst
@@ -1,5 +1,5 @@
-Release Build Procedure for FRR maintainers
-=========================================================
+Release Build Procedure for FRR Maintainers
+===========================================
 
 1. Rename branch (if needed)
 

--- a/doc/developer/packaging-debian.rst
+++ b/doc/developer/packaging-debian.rst
@@ -1,5 +1,5 @@
-Debian
-======
+Packaging Debian
+================
 
 (Tested on Ubuntu 12.04, 14.04, 16.04, 17.10, 18.04, Debian 8 and 9)
 

--- a/doc/developer/packaging.rst
+++ b/doc/developer/packaging.rst
@@ -5,4 +5,5 @@ Packaging
 .. toctree::
    :maxdepth: 2
 
+   maintainer-release-build
    packaging-debian


### PR DESCRIPTION
### Summary
Fixes a few issues I noticed when building docs.
1. libyang doc needs to be ignored as a top level source
2. Maintainer build doc needs to be included in a toctree in order to show up in build docs.
3. `.. code-block::` directive needs a type specifier.

### Components
doc