### PR TITLE
lib: remove agentx already enabled warning

### DIFF
--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -188,9 +188,8 @@ DEFUN (agentx_enable,
 		events = list_new();
 		agentx_events_update();
 		agentx_enabled = 1;
-		return CMD_SUCCESS;
 	}
-	vty_out(vty, "SNMP AgentX already enabled\n");
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
### Summary
This duplicates itself N times since it's not wrappered in a vtysh
command. In lieu of doing that, just remove the message, it's not really
necessary.

### Related Issue
Fixes #3284

### Components
lib