### PR TITLE
zebra: Fix netlink installation of recursive ecmp routes

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1711,6 +1711,8 @@ static int netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 						setsrc = 1;
 					}
 				}
+
+				continue;
 			}
 
 			if ((cmd == RTM_NEWROUTE


### PR DESCRIPTION
Recursive multipath nexthop installation in zebra was broken by the initial async dataplane commit - we were trying to install an extra, invalid nexthop. Re-added the missing 'continue' statement, preventing that extra nexthop from being added to the netlink message.
