### PR TITLE
Remove vestigial secondary

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -140,16 +140,6 @@ Standard Commands
    behind the other end of the link (or even on the link in Point-to-Multipoint
    setups), though generally /32s are used.
 
-.. index:: ip address ADDRESS/PREFIX secondary
-
-.. clicmd:: ip address ADDRESS/PREFIX secondary
-.. index:: no ip address ADDRESS/PREFIX secondary
-
-.. clicmd:: no ip address ADDRESS/PREFIX secondary
-
-   Set the secondary flag for this address. This causes ospfd to not treat the
-   address as a distinct subnet.
-
 .. index:: description DESCRIPTION ...
 
 .. clicmd:: description DESCRIPTION ...

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2767,7 +2767,7 @@ DEFUN (no_ip_address_label,
 
 static int ipv6_address_install(struct vty *vty, struct interface *ifp,
 				const char *addr_str, const char *peer_str,
-				const char *label, int secondary)
+				const char *label)
 {
 	struct zebra_if *if_data;
 	struct prefix_ipv6 cp;
@@ -2797,10 +2797,6 @@ static int ipv6_address_install(struct vty *vty, struct interface *ifp,
 		p = prefix_ipv6_new();
 		*p = cp;
 		ifc->address = (struct prefix *)p;
-
-		/* Secondary. */
-		if (secondary)
-			SET_FLAG(ifc->flags, ZEBRA_IFA_SECONDARY);
 
 		/* Label. */
 		if (label)
@@ -2857,7 +2853,7 @@ int ipv6_address_configured(struct interface *ifp)
 
 static int ipv6_address_uninstall(struct vty *vty, struct interface *ifp,
 				  const char *addr_str, const char *peer_str,
-				  const char *label, int secondry)
+				  const char *label)
 {
 	struct prefix_ipv6 cp;
 	struct connected *ifc;
@@ -2915,7 +2911,7 @@ DEFUN (ipv6_address,
 	int idx_ipv6_prefixlen = 2;
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	return ipv6_address_install(vty, ifp, argv[idx_ipv6_prefixlen]->arg,
-				    NULL, NULL, 0);
+				    NULL, NULL);
 }
 
 DEFUN (no_ipv6_address,
@@ -2929,7 +2925,7 @@ DEFUN (no_ipv6_address,
 	int idx_ipv6_prefixlen = 3;
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	return ipv6_address_uninstall(vty, ifp, argv[idx_ipv6_prefixlen]->arg,
-				      NULL, NULL, 0);
+				      NULL, NULL);
 }
 
 static int link_params_config_write(struct vty *vty, struct interface *ifp)

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -248,7 +248,7 @@ int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
  *      RTM_IFANNOUNCE or AF_NETLINK sockets is available), or when
  *      an interface is marked IFF_UP (i.e., an RTM_IFINFO message is
  *      received)
- *    - for the vty commands "ip address A.B.C.D/M [<secondary>|<label LINE>]"
+ *    - for the vty commands "ip address A.B.C.D/M [<label LINE>]"
  *      and "no bandwidth <1-10000000>", "ipv6 address X:X::X:X/M"
  *    - when an RTM_NEWADDR message is received from the kernel,
  *
@@ -269,7 +269,7 @@ int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
  *             |
  *         vty commands:
  *     "no ip address A.B.C.D/M [label LINE]"
- *     "no ip address A.B.C.D/M secondary"
+ *     "no ip address A.B.C.D/M"
  *     ["no ipv6 address X:X::X:X/M"]
  *
  */


### PR DESCRIPTION
### Summary
Secondary address options on cli commands haven't existed for 1.4 decades, remove this leftover crap

### Related Issue
Fixes #3292 

### Components
doc, zebra