### PR TITLE
zebra: fix zebra router memleaks

### DIFF
--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -96,6 +96,7 @@ struct route_table *zebra_router_get_table(struct zebra_vrf *zvrf,
 	zrt = XCALLOC(MTYPE_ZEBRA_NS, sizeof(*zrt));
 	zrt->tableid = tableid;
 	zrt->afi = afi;
+	zrt->safi = safi;
 	zrt->ns_id = zvrf->zns->ns_id;
 	zrt->table =
 		(afi == AFI_IP6) ? srcdest_table_init() : route_table_init();

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -380,6 +380,7 @@ static void zebra_vrf_table_create(struct zebra_vrf *zvrf, afi_t afi,
 	table->cleanup = zebra_rtable_node_cleanup;
 	zvrf->table[afi][safi] = table;
 
+	XFREE(MTYPE_RIB_TABLE_INFO, table->info);
 	info = XCALLOC(MTYPE_RIB_TABLE_INFO, sizeof(*info));
 	info->zvrf = zvrf;
 	info->afi = afi;


### PR DESCRIPTION
### Summary
Fixes two memory leaks.

* Correctly set safi to prevent duplicate allocations
* Free previously allocated table->info before overwriting it

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>

### Related Issue
Fixes #3268 

### Components
zebra