### PR TITLE
nexthop tracking extension for vrf

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -619,12 +619,16 @@ static void bgp_show_nexthops(struct vty *vty, struct bgp *bgp, int detail,
 					       node, next, bnc)) {
 				if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_VALID)) {
 					vty_out(vty,
-						" %s valid [IGP metric %d], #paths %d\n",
+						" %s valid [IGP metric %d], #paths %d",
 						inet_ntop(rn->p.family,
 							  &rn->p.u.prefix, buf,
 							  sizeof(buf)),
 						bnc->metric, bnc->path_count);
-
+					if (bnc->bgp != bnc->bgp_route)
+						vty_out(vty, " (from vrf %s)",
+						    vrf_id_to_name(
+						       bnc->bgp_route->vrf_id));
+					vty_out(vty, "\n");
 					if (!detail)
 						continue;
 

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -79,20 +79,22 @@ static void bgp_nexthop_cache_reset(struct bgp_table *table)
 {
 	struct bgp_node *rn;
 	struct bgp_nexthop_cache *bnc;
+	struct listnode *node, *next;
 
 	for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
-		bnc = bgp_node_get_bgp_nexthop_info(rn);
-		if (!bnc)
+		if (!rn->info)
 			continue;
+		for (ALL_LIST_ELEMENTS((struct list *)rn->info,
+				       node, next, bnc)) {
+			while (!LIST_EMPTY(&(bnc->paths))) {
+				struct bgp_path_info *path =
+					LIST_FIRST(&(bnc->paths));
 
-		while (!LIST_EMPTY(&(bnc->paths))) {
-			struct bgp_path_info *path = LIST_FIRST(&(bnc->paths));
-
-			path_nh_map(path, bnc, false);
+				path_nh_map(path, bnc, false);
+			}
+			bnc_free(bnc);
 		}
-
-		bnc_free(bnc);
-		bgp_node_set_bgp_nexthop_info(rn, NULL);
+		list_delete((struct list **)&rn->info);
 		bgp_unlock_node(rn);
 	}
 }
@@ -609,38 +611,40 @@ static void bgp_show_nexthops(struct vty *vty, struct bgp *bgp, int detail,
 			continue;
 		for (rn = bgp_table_top(table[afi]); rn;
 		     rn = bgp_route_next(rn)) {
-			bnc = bgp_node_get_bgp_nexthop_info(rn);
-			if (!bnc)
+			struct listnode *node, *next;
+
+			if (!rn->info)
 				continue;
+			for (ALL_LIST_ELEMENTS((struct list *)rn->info,
+					       node, next, bnc)) {
+				if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_VALID)) {
+					vty_out(vty,
+						" %s valid [IGP metric %d], #paths %d\n",
+						inet_ntop(rn->p.family,
+							  &rn->p.u.prefix, buf,
+							  sizeof(buf)),
+						bnc->metric, bnc->path_count);
 
-			if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_VALID)) {
-				vty_out(vty,
-					" %s valid [IGP metric %d], #paths %d\n",
-					inet_ntop(rn->p.family,
-						  &rn->p.u.prefix, buf,
-						  sizeof(buf)),
-					bnc->metric, bnc->path_count);
+					if (!detail)
+						continue;
 
-				if (!detail)
-					continue;
+					bgp_show_nexthops_detail(vty, bgp, bnc);
 
-				bgp_show_nexthops_detail(vty, bgp, bnc);
-
-			} else {
-				vty_out(vty, " %s invalid\n",
-					inet_ntop(rn->p.family,
-						  &rn->p.u.prefix, buf,
-						  sizeof(buf)));
-				if (CHECK_FLAG(bnc->flags,
-					       BGP_NEXTHOP_CONNECTED))
-					vty_out(vty, "  Must be Connected\n");
-				if (!CHECK_FLAG(bnc->flags,
-						BGP_NEXTHOP_REGISTERED))
-					vty_out(vty, "  Is not Registered\n");
+				} else {
+					vty_out(vty, " %s invalid\n",
+						inet_ntop(rn->p.family,
+							  &rn->p.u.prefix, buf,
+							  sizeof(buf)));
+					if (CHECK_FLAG(bnc->flags,
+						       BGP_NEXTHOP_CONNECTED))
+						vty_out(vty,
+							"  Must be Connected\n");
+				}
+				tbuf = time(NULL)
+				       - (bgp_clock() - bnc->last_update);
+				vty_out(vty, "  Last update: %s", ctime(&tbuf));
+				vty_out(vty, "\n");
 			}
-			tbuf = time(NULL) - (bgp_clock() - bnc->last_update);
-			vty_out(vty, "  Last update: %s", ctime(&tbuf));
-			vty_out(vty, "\n");
 		}
 	}
 }

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -66,6 +66,7 @@ struct bgp_nexthop_cache {
 	LIST_HEAD(path_list, bgp_path_info) paths;
 	unsigned int path_count;
 	struct bgp *bgp;
+	struct bgp *bgp_route; /* originator of the request */
 };
 
 /* Own tunnel-ip address structure */

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -64,6 +64,23 @@ static int bgp_isvalid_labeled_nexthop(struct bgp_nexthop_cache *bnc)
 		|| (bnc && CHECK_FLAG(bnc->flags, BGP_NEXTHOP_LABELED_VALID)));
 }
 
+static struct bgp_nexthop_cache *bgp_lookup_bnc_per_route(struct list *route,
+							  vrf_id_t vrfid_route)
+{
+	struct listnode *node, *next;
+	struct bgp_nexthop_cache *bnc;
+
+	if (!route)
+		return NULL;
+	for (ALL_LIST_ELEMENTS(route, node, next, bnc)) {
+		if (!bnc->bgp_route)
+			continue;
+		if (bnc->bgp_route->vrf_id == vrfid_route)
+			return (bnc);
+	}
+	return NULL;
+}
+
 int bgp_find_nexthop(struct bgp_path_info *path, int connected)
 {
 	struct bgp_nexthop_cache *bnc = path->nexthop;
@@ -88,6 +105,8 @@ int bgp_find_nexthop(struct bgp_path_info *path, int connected)
 static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 {
 	if (LIST_EMPTY(&(bnc->paths)) && !bnc->nht_info) {
+		struct bgp_node *rn = bnc->node;
+
 		if (BGP_DEBUG(nht, NHT)) {
 			char buf[PREFIX2STR_BUFFER];
 			zlog_debug("bgp_unlink_nexthop: freeing bnc %s",
@@ -95,9 +114,9 @@ static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 		}
 		unregister_zebra_rnh(bnc,
 				     CHECK_FLAG(bnc->flags, BGP_STATIC_ROUTE));
-		bgp_node_set_bgp_nexthop_info(bnc->node, NULL);
-		bgp_unlock_node(bnc->node);
-		bnc->node = NULL;
+		listnode_delete(rn->info, bnc);
+		if (list_isempty((struct list *)rn->info))
+			list_delete((struct list **)&rn->info);
 		bnc_free(bnc);
 	}
 }
@@ -105,13 +124,16 @@ static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 void bgp_unlink_nexthop(struct bgp_path_info *path)
 {
 	struct bgp_nexthop_cache *bnc = path->nexthop;
+	struct bgp_node *rn;
 
 	if (!bnc)
 		return;
-
+	rn = bnc->node;
 	path_nh_map(path, NULL, false);
 
 	bgp_unlink_nexthop_check(bnc);
+	if (rn->info && list_isempty((struct list *)rn->info))
+		list_delete((struct list **)&rn->info);
 }
 
 void bgp_unlink_nexthop_by_peer(struct peer *peer)
@@ -119,6 +141,8 @@ void bgp_unlink_nexthop_by_peer(struct peer *peer)
 	struct prefix p;
 	struct bgp_node *rn;
 	struct bgp_nexthop_cache *bnc;
+	struct listnode *node, *next;
+
 	afi_t afi = family2afi(peer->su.sa.sa_family);
 
 	if (!sockunion2hostprefix(&peer->su, &p))
@@ -130,10 +154,13 @@ void bgp_unlink_nexthop_by_peer(struct peer *peer)
 	if (!bnc)
 		return;
 
-	/* cleanup the peer reference */
-	bnc->nht_info = NULL;
-
-	bgp_unlink_nexthop_check(bnc);
+	for (ALL_LIST_ELEMENTS((struct list *)rn->info, node, next, bnc)) {
+		/* cleanup the peer reference */
+		bnc->nht_info = NULL;
+		bgp_unlink_nexthop_check(bnc);
+	}
+	if (rn->info && list_isempty((struct list *)rn->info))
+		list_delete((struct list **)&rn->info);
 }
 
 /*
@@ -145,7 +172,7 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 			    struct peer *peer, int connected)
 {
 	struct bgp_node *rn;
-	struct bgp_nexthop_cache *bnc;
+	struct bgp_nexthop_cache *bnc = NULL;
 	struct prefix p;
 	int is_bgp_static_route = 0;
 
@@ -183,12 +210,17 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 	else
 		rn = bgp_node_get(bgp_nexthop->nexthop_cache_table[afi], &p);
 
-	bnc = bgp_node_get_bgp_nexthop_info(rn);
-	if (!bnc) {
+	if (rn->info)
+		bnc = bgp_lookup_bnc_per_route(rn->info, bgp_route->vrf_id);
+	if (!rn->info || !bnc) {
 		bnc = bnc_new();
-		bgp_node_set_bgp_nexthop_info(rn, bnc);
+		if (!rn->info)
+			rn->info = list_new();
+		listnode_add((struct list *)rn->info, bnc);
+
 		bnc->node = rn;
 		bnc->bgp = bgp_nexthop;
+		bnc->bgp_route = bgp_route;
 		bgp_lock_node(rn);
 		if (BGP_DEBUG(nht, NHT)) {
 			char buf[PREFIX2STR_BUFFER];
@@ -277,6 +309,7 @@ void bgp_delete_connected_nexthop(afi_t afi, struct peer *peer)
 	struct bgp_node *rn;
 	struct bgp_nexthop_cache *bnc;
 	struct prefix p;
+	struct listnode *node, *next;
 
 	if (!peer)
 		return;
@@ -293,41 +326,40 @@ void bgp_delete_connected_nexthop(afi_t afi, struct peer *peer)
 		return;
 	}
 
-	bnc = bgp_node_get_bgp_nexthop_info(rn);
-	if (!bnc) {
+	if (!rn->info || !listcount((struct list *)rn->info)) {
 		if (BGP_DEBUG(nht, NHT))
 			zlog_debug("Cannot find connected NHT node for peer %s on route_node as expected",
 				   peer->host);
 		bgp_unlock_node(rn);
 		return;
 	}
+
+	for (ALL_LIST_ELEMENTS((struct list *)rn->info, node, next, bnc)) {
+		if (bnc->nht_info != peer) {
+			if (BGP_DEBUG(nht, NHT))
+				zlog_debug(
+					   "Connected NHT %p node for peer %s points to %p",
+					   bnc, peer->host, bnc->nht_info);
+			continue;
+		}
+		bnc->nht_info = NULL;
+
+		if (LIST_EMPTY(&(bnc->paths))) {
+			if (BGP_DEBUG(nht, NHT))
+				zlog_debug("Freeing connected NHT node %p for peer %s",
+					   bnc, peer->host);
+			unregister_zebra_rnh(bnc, 0);
+			listnode_delete(bnc->node->info, bnc);
+			bnc_free(bnc);
+		}
+	}
 	bgp_unlock_node(rn);
-
-	if (bnc->nht_info != peer) {
-		if (BGP_DEBUG(nht, NHT))
-			zlog_debug(
-				"Connected NHT %p node for peer %s points to %p",
-				bnc, peer->host, bnc->nht_info);
-		return;
-	}
-
-	bnc->nht_info = NULL;
-
-	if (LIST_EMPTY(&(bnc->paths))) {
-		if (BGP_DEBUG(nht, NHT))
-			zlog_debug("Freeing connected NHT node %p for peer %s",
-				   bnc, peer->host);
-		unregister_zebra_rnh(bnc, 0);
-		bgp_node_set_bgp_nexthop_info(bnc->node, NULL);
-		bgp_unlock_node(bnc->node);
-		bnc_free(bnc);
-	}
 }
 
 void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 {
 	struct bgp_node *rn = NULL;
-	struct bgp_nexthop_cache *bnc;
+	struct bgp_nexthop_cache *bnc = NULL;
 	struct nexthop *nexthop;
 	struct nexthop *oldnh;
 	struct nexthop *nhlist_head = NULL;
@@ -361,7 +393,9 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 			bgp->import_check_table[family2afi(nhr.prefix.family)],
 			&nhr.prefix);
 
-	if (!rn) {
+	if (rn && rn->info)
+		bnc = bgp_lookup_bnc_per_route(rn->info, nhr.vrf_id_route);
+	if (!rn || !rn->info || !bnc) {
 		if (BGP_DEBUG(nht, NHT)) {
 			char buf[PREFIX2STR_BUFFER];
 			prefix2str(&nhr.prefix, buf, sizeof(buf));
@@ -371,20 +405,8 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 		return;
 	}
 
-	bnc = bgp_node_get_bgp_nexthop_info(rn);
-	if (!bnc) {
-		if (BGP_DEBUG(nht, NHT)) {
-			char buf[PREFIX2STR_BUFFER];
-
-			prefix2str(&nhr.prefix, buf, sizeof(buf));
-			zlog_debug("parse nexthop update(%s): bnc node info not found",
-				   buf);
-		}
-		bgp_unlock_node(rn);
-		return;
-	}
-
 	bgp_unlock_node(rn);
+
 	bnc->last_update = bgp_clock();
 	bnc->change_flags = 0;
 
@@ -616,7 +638,7 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 	}
 
 	ret = zclient_send_rnh(zclient, command, p, exact_match,
-			       bnc->bgp->vrf_id, bnc->bgp->vrf_id);
+			       bnc->bgp->vrf_id, bnc->bgp_route->vrf_id);
 	/* TBD: handle the failure */
 	if (ret < 0)
 		flog_warn(EC_BGP_ZEBRA_SEND,

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -616,7 +616,7 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 	}
 
 	ret = zclient_send_rnh(zclient, command, p, exact_match,
-			       bnc->bgp->vrf_id);
+			       bnc->bgp->vrf_id, bnc->bgp->vrf_id);
 	/* TBD: handle the failure */
 	if (ret < 0)
 		flog_warn(EC_BGP_ZEBRA_SEND,

--- a/doc/developer/next-hop-tracking.rst
+++ b/doc/developer/next-hop-tracking.rst
@@ -76,10 +76,19 @@ Overview of changes
 The changes are in both BGP and Zebra modules.  The short summary is
 the following:
 
+- Nexthop information is indexed per (VRF nexthop prefix, VRF prefix,
+  AF) tuple. The reason is that it permits for a defined VRF prefix
+  to know which path to use when crossing vrf route leak, to reach its
+  nexthop. Actually, when vrf backend is not Linux vrf-lite, the
+  nexthop information is calculated from the prefix vrf table.
+
 - Zebra implements a registration mechanism by which clients can
   register for next hop notification. Consequently, it maintains a
-  separate table, per (VRF, AF) pair, of next hops and interested
-  client-list per next hop.
+  separate table, per (VRF nexthop prefix, VRF prefix, AF) tuple,
+  of next hops and interested client-list per next hop.
+
+- BGP implements separate table, per (VRF nexthop prefix, VRF prefix,
+  AF) tuple, of next hops.
 
 - When the main routing table changes in Zebra, it evaluates the next
   hop table: for each next hop, it checks if the route table
@@ -193,6 +202,8 @@ encoded in the following way:
     .      Nexthop prefix                                           .
     .                                                               .
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    . VRF ID from prefix  |
+    +-+-+-+-+-+-+-+-+-+-+-+
     .                                                               .
     .                                                               .
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -201,6 +212,8 @@ encoded in the following way:
     .      Nexthop prefix                                           .
     .                                                               .
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    . VRF ID from prefix  |
+    +-+-+-+-+-+-+-+-+-+-+-+
 
 
 ``ZEBRA_NEXTHOP_UPDATE`` message is encoded as follows:
@@ -215,7 +228,7 @@ encoded in the following way:
     .      Nexthop prefix getting resolved                          .
     .                                                               .
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |        metric                                                 |
+    | VRF ID from prefix  | type, instance, metric, distance        |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |  #nexthops    |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -649,7 +649,7 @@ static int zclient_connect(struct thread *t)
 }
 
 int zclient_send_rnh(struct zclient *zclient, int command, struct prefix *p,
-		     bool exact_match, vrf_id_t vrf_id)
+		     bool exact_match, vrf_id_t vrf_id, vrf_id_t vrf_id_route)
 {
 	struct stream *s;
 
@@ -670,6 +670,7 @@ int zclient_send_rnh(struct zclient *zclient, int command, struct prefix *p,
 	default:
 		break;
 	}
+	stream_putl(s, vrf_id_route);
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	return zclient_send_message(zclient);
@@ -1209,7 +1210,7 @@ bool zapi_nexthop_update_decode(struct stream *s, struct zapi_route *nhr)
 	default:
 		break;
 	}
-
+	STREAM_GETL(s, nhr->vrf_id_route);
 	STREAM_GETC(s, nhr->type);
 	STREAM_GETW(s, nhr->instance);
 	STREAM_GETC(s, nhr->distance);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -349,6 +349,8 @@ struct zapi_route {
 	vrf_id_t vrf_id;
 
 	uint32_t tableid;
+
+	vrf_id_t vrf_id_route;
 };
 
 struct zapi_pw {
@@ -583,7 +585,7 @@ extern void zebra_read_pw_status_update(int command, struct zclient *zclient,
 extern int zclient_route_send(uint8_t, struct zclient *, struct zapi_route *);
 extern int zclient_send_rnh(struct zclient *zclient, int command,
 			    struct prefix *p, bool exact_match,
-			    vrf_id_t vrf_id);
+			    vrf_id_t vrf_id, vrf_id_t vrf_id_route);
 extern int zapi_route_encode(uint8_t, struct stream *, struct zapi_route *);
 extern int zapi_route_decode(struct stream *, struct zapi_route *);
 bool zapi_route_notify_decode(struct stream *s, struct prefix *p,

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -437,7 +437,8 @@ void pbr_send_rnh(struct nexthop *nhop, bool reg)
 	}
 
 	if (zclient_send_rnh(zclient, command, &p,
-			     false, nhop->vrf_id) < 0) {
+			     false, nhop->vrf_id,
+			     nhop->vrf_id) < 0) {
 		zlog_warn("%s: Failure to send nexthop to zebra",
 			  __PRETTY_FUNCTION__);
 	}

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -51,7 +51,8 @@ void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zclient,
 	int ret;
 
 	p = &(pnc->rpf.rpf_addr);
-	ret = zclient_send_rnh(zclient, command, p, false, pim->vrf_id);
+	ret = zclient_send_rnh(zclient, command, p, false,
+			       pim->vrf_id, pim->vrf_id);
 	if (ret < 0)
 		zlog_warn("sendmsg_nexthop: zclient_send_message() failed");
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -341,7 +341,8 @@ void static_zebra_nht_register(struct static_route *si, bool reg)
 		static_nht_hash_free(nhtd);
 	}
 
-	if (zclient_send_rnh(zclient, cmd, &p, false, si->nh_vrf_id) < 0)
+	if (zclient_send_rnh(zclient, cmd, &p, false, si->nh_vrf_id,
+			     si->vrf_id) < 0)
 		zlog_warn("%s: Failure to send nexthop to zebra",
 			  __PRETTY_FUNCTION__);
 }

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1087,7 +1087,8 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 		STREAM_GETL(s, vrf_id_route);
 		l += 4;
 
-		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), type, &exist);
+		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), type,
+				    &exist, vrf_id_route);
 		if (!rnh)
 			return;
 
@@ -1176,7 +1177,7 @@ static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
 		STREAM_GETL(s, vrf_id_route);
 		l += 4;
 
-		rnh = zebra_lookup_rnh(&p, zvrf_id(zvrf), type);
+		rnh = zebra_lookup_rnh(&p, zvrf_id(zvrf), type, vrf_id_route);
 		if (rnh) {
 			client->nh_dereg_time = monotime(NULL);
 			zebra_remove_rnh_client(rnh, client, type);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1039,6 +1039,7 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 	uint8_t flags = 0;
 	uint16_t type = cmd2type[hdr->command];
 	bool exist;
+	vrf_id_t vrf_id_route;
 
 	if (IS_ZEBRA_DEBUG_NHT)
 		zlog_debug(
@@ -1083,6 +1084,9 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 				p.family);
 			return;
 		}
+		STREAM_GETL(s, vrf_id_route);
+		l += 4;
+
 		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), type, &exist);
 		if (!rnh)
 			return;
@@ -1122,6 +1126,7 @@ static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
 	struct prefix p;
 	unsigned short l = 0;
 	uint16_t type = cmd2type[hdr->command];
+	vrf_id_t vrf_id_route;
 
 	if (IS_ZEBRA_DEBUG_NHT)
 		zlog_debug(
@@ -1168,6 +1173,9 @@ static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
 				p.family);
 			return;
 		}
+		STREAM_GETL(s, vrf_id_route);
+		l += 4;
+
 		rnh = zebra_lookup_rnh(&p, zvrf_id(zvrf), type);
 		if (rnh) {
 			client->nh_dereg_time = monotime(NULL);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -905,6 +905,7 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 			 __FUNCTION__, rn->p.family);
 		break;
 	}
+	stream_putl(s, rnh->vrf_id_route);
 	if (re) {
 		stream_putc(s, re->type);
 		stream_putw(s, re->instance);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -67,7 +67,7 @@ static void copy_state(struct rnh *rnh, struct route_entry *re,
 static int compare_state(struct route_entry *r1, struct route_entry *r2);
 static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 		       vrf_id_t vrf_id);
-static void print_rnh(struct route_node *rn, struct vty *vty);
+static void print_rnh(struct rnh *rnh, struct vty *vty);
 static int zebra_client_cleanup_rnh(struct zserv *client);
 
 int zebra_rnh_ip_default_route = 0;
@@ -104,8 +104,22 @@ char *rnh_str(struct rnh *rnh, char *buf, int size)
 	return buf;
 }
 
+static struct rnh *zebra_lookup_rnh_per_route(struct list *route,
+					      vrf_id_t vrfid_route)
+{
+	struct listnode *node, *next;
+	struct rnh *rnh;
+
+	if (!route)
+		return NULL;
+	for (ALL_LIST_ELEMENTS(route, node, next, rnh))
+		if (rnh->vrf_id_route == vrfid_route)
+			return (rnh);
+	return NULL;
+}
+
 struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid, rnh_type_t type,
-			  bool *exists)
+			  bool *exists, vrf_id_t vrfid_route)
 {
 	struct route_table *table;
 	struct route_node *rn;
@@ -131,27 +145,35 @@ struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid, rnh_type_t type,
 
 	/* Lookup (or add) route node.*/
 	rn = route_node_get(table, p);
-
-	if (!rn->info) {
+	/* Look if the list */
+	if (rn->info)
+		rnh  = zebra_lookup_rnh_per_route((struct list *)rn->info,
+						  vrfid_route);
+	if (!rn->info || !rnh) {
 		rnh = XCALLOC(MTYPE_RNH, sizeof(struct rnh));
 		rnh->client_list = list_new();
 		rnh->vrf_id = vrfid;
+		rnh->vrf_id_route = vrfid_route;
 		rnh->zebra_pseudowire_list = list_new();
 		route_lock_node(rn);
-		rn->info = rnh;
+		if (!rn->info)
+			rn->info = list_new();
+		listnode_add(rn->info, rnh);
 		rnh->node = rn;
 		*exists = false;
 	} else
 		*exists = true;
 
 	route_unlock_node(rn);
-	return (rn->info);
+	return (rnh);
 }
 
-struct rnh *zebra_lookup_rnh(struct prefix *p, vrf_id_t vrfid, rnh_type_t type)
+struct rnh *zebra_lookup_rnh(struct prefix *p, vrf_id_t vrfid,
+			     rnh_type_t type, vrf_id_t vrfid_route)
 {
 	struct route_table *table;
 	struct route_node *rn;
+	struct rnh *rnh;
 
 	table = get_rnh_table(vrfid, PREFIX_FAMILY(p), type);
 	if (!table)
@@ -166,7 +188,10 @@ struct rnh *zebra_lookup_rnh(struct prefix *p, vrf_id_t vrfid, rnh_type_t type)
 		return NULL;
 
 	route_unlock_node(rn);
-	return (rn->info);
+
+	rnh = zebra_lookup_rnh_per_route((struct list *)rn->info,
+					 vrfid_route);
+	return rnh;
 }
 
 void zebra_free_rnh(struct rnh *rnh)
@@ -182,18 +207,23 @@ void zebra_delete_rnh(struct rnh *rnh, rnh_type_t type)
 {
 	struct route_node *rn;
 
-	if (!rnh || (rnh->flags & ZEBRA_NHT_DELETED) || !(rn = rnh->node))
+	if (!rnh || (rnh->flags & ZEBRA_NHT_DELETED))
 		return;
 
+	rn = rnh->node;
+	if (!rn)
+		return;
 	if (IS_ZEBRA_DEBUG_NHT) {
 		char buf[PREFIX2STR_BUFFER];
 		zlog_debug("%u: Del RNH %s type %d", rnh->vrf_id,
 			   rnh_str(rnh, buf, sizeof(buf)), type);
 	}
-
+	listnode_delete(rn->info, rnh);
 	zebra_free_rnh(rnh);
-	rn->info = NULL;
-	route_unlock_node(rn);
+	if (list_isempty((struct list *)rn->info)) {
+		list_delete((struct list **)&rn->info);
+		route_unlock_node(rn);
+	}
 }
 
 /*
@@ -272,7 +302,7 @@ void zebra_register_rnh_pseudowire(vrf_id_t vrf_id, struct zebra_pw *pw)
 		return;
 
 	addr2hostprefix(pw->af, &pw->nexthop, &nh);
-	rnh = zebra_add_rnh(&nh, vrf_id, RNH_NEXTHOP_TYPE, &exists);
+	rnh = zebra_add_rnh(&nh, vrf_id, RNH_NEXTHOP_TYPE, &exists, vrf_id);
 	if (rnh && !listnode_lookup(rnh->zebra_pseudowire_list, pw)) {
 		listnode_add(rnh->zebra_pseudowire_list, pw);
 		pw->rnh = rnh;
@@ -678,28 +708,28 @@ static void zebra_rnh_eval_nexthop_entry(struct zebra_vrf *zvrf, int family,
 /* Evaluate one tracked entry */
 static void zebra_rnh_evaluate_entry(struct zebra_vrf *zvrf, int family,
 				     int force, rnh_type_t type,
-				     struct route_node *nrn)
+				     struct rnh *rnh)
 {
-	struct rnh *rnh;
 	struct route_entry *re;
 	struct route_node *prn;
 	char bufn[INET6_ADDRSTRLEN];
 
 	if (IS_ZEBRA_DEBUG_NHT) {
-		prefix2str(&nrn->p, bufn, INET6_ADDRSTRLEN);
+		prefix2str(&rnh->node->p, bufn, INET6_ADDRSTRLEN);
 		zlog_debug("%u:%s: Evaluate RNH, type %d %s", zvrf->vrf->vrf_id,
-			   bufn, type, force ? "(force)" : "");
+			   bufn, type,
+			   force ? "(force)" : "");
 	}
-
-	rnh = nrn->info;
 
 	/* Identify route entry (RE) resolving this tracked entry. */
 	if (type == RNH_IMPORT_CHECK_TYPE)
-		re = zebra_rnh_resolve_import_entry(zvrf, family, nrn, rnh,
-						    &prn);
+		re = zebra_rnh_resolve_import_entry(zvrf, family,
+						    rnh->node,
+						    rnh, &prn);
 	else
-		re = zebra_rnh_resolve_nexthop_entry(zvrf, family, nrn, rnh,
-						     &prn);
+		re = zebra_rnh_resolve_nexthop_entry(zvrf, family,
+						     rnh->node,
+						     rnh, &prn);
 
 	/* If the entry cannot be resolved and that is also the existing state,
 	 * there is nothing further to do.
@@ -710,10 +740,10 @@ static void zebra_rnh_evaluate_entry(struct zebra_vrf *zvrf, int family,
 	/* Process based on type of entry. */
 	if (type == RNH_IMPORT_CHECK_TYPE)
 		zebra_rnh_eval_import_check_entry(zvrf->vrf->vrf_id, family,
-						  force, nrn, rnh, re);
+						  force, rnh->node, rnh, re);
 	else
-		zebra_rnh_eval_nexthop_entry(zvrf, family, force, nrn, rnh, prn,
-					     re);
+		zebra_rnh_eval_nexthop_entry(zvrf, family, force, rnh->node,
+					     rnh, prn, re);
 }
 
 /*
@@ -726,20 +756,19 @@ static void zebra_rnh_evaluate_entry(struct zebra_vrf *zvrf, int family,
  * covers multiple nexthops we are interested in.
  */
 static void zebra_rnh_clear_nhc_flag(struct zebra_vrf *zvrf, int family,
-				     rnh_type_t type, struct route_node *nrn)
+				     rnh_type_t type, struct rnh *rnh)
 {
-	struct rnh *rnh;
 	struct route_entry *re;
 	struct route_node *prn;
 
-	rnh = nrn->info;
-
 	/* Identify route entry (RIB) resolving this tracked entry. */
 	if (type == RNH_IMPORT_CHECK_TYPE)
-		re = zebra_rnh_resolve_import_entry(zvrf, family, nrn, rnh,
+		re = zebra_rnh_resolve_import_entry(zvrf, family,
+						    rnh->node, rnh,
 						    &prn);
 	else
-		re = zebra_rnh_resolve_nexthop_entry(zvrf, family, nrn, rnh,
+		re = zebra_rnh_resolve_nexthop_entry(zvrf, family,
+						     rnh->node, rnh,
 						     &prn);
 
 	if (re) {
@@ -764,26 +793,44 @@ void zebra_evaluate_rnh(struct zebra_vrf *zvrf, int family, int force,
 	if (p) {
 		/* Evaluating a specific entry, make sure it exists. */
 		nrn = route_node_lookup(rnh_table, p);
-		if (nrn && nrn->info)
-			zebra_rnh_evaluate_entry(zvrf, family, force, type,
-						 nrn);
+		if (nrn && nrn->info) {
+			struct listnode *node, *next;
+			struct rnh *rnh;
 
+			for (ALL_LIST_ELEMENTS((struct list *)nrn->info,
+					       node, next, rnh))
+				zebra_rnh_evaluate_entry(zvrf, family,
+							 force, type, rnh);
+		}
 		if (nrn)
 			route_unlock_node(nrn);
 	} else {
 		/* Evaluate entire table. */
 		nrn = route_top(rnh_table);
 		while (nrn) {
-			if (nrn->info)
-				zebra_rnh_evaluate_entry(zvrf, family, force,
-							 type, nrn);
+			if (nrn->info) {
+				struct listnode *node, *next;
+				struct rnh *rnh;
+
+				for (ALL_LIST_ELEMENTS((struct list *)nrn->info,
+						       node, next, rnh))
+					zebra_rnh_evaluate_entry(zvrf, family,
+								 force, type,
+								 rnh);
+			}
 			nrn = route_next(nrn); /* this will also unlock nrn */
 		}
 		nrn = route_top(rnh_table);
 		while (nrn) {
-			if (nrn->info)
-				zebra_rnh_clear_nhc_flag(zvrf, family, type,
-							 nrn);
+			if (nrn->info) {
+				struct listnode *node, *next;
+				struct rnh *rnh;
+
+				for (ALL_LIST_ELEMENTS((struct list *)nrn->info,
+						       node, next, rnh))
+					zebra_rnh_clear_nhc_flag(zvrf, family,
+								 type, rnh);
+			}
 			nrn = route_next(nrn); /* this will also unlock nrn */
 		}
 	}
@@ -801,9 +848,18 @@ void zebra_print_rnh_table(vrf_id_t vrfid, int af, struct vty *vty,
 		return;
 	}
 
-	for (rn = route_top(table); rn; rn = route_next(rn))
-		if (rn->info)
-			print_rnh(rn, vty);
+	for (rn = route_top(table); rn; rn = route_next(rn)) {
+		struct listnode *node, *next;
+		struct rnh *rnh;
+
+		if (!rn->info)
+			continue;
+
+		for (ALL_LIST_ELEMENTS((struct list *)
+				       rn->info,
+				       node, next, rnh))
+			print_rnh(rnh, vty);
+	}
 }
 
 /**
@@ -998,15 +1054,14 @@ static void print_nh(struct nexthop *nexthop, struct vty *vty)
 	vty_out(vty, "\n");
 }
 
-static void print_rnh(struct route_node *rn, struct vty *vty)
+static void print_rnh(struct rnh *rnh, struct vty *vty)
 {
-	struct rnh *rnh;
 	struct nexthop *nexthop;
 	struct listnode *node;
 	struct zserv *client;
 	char buf[BUFSIZ];
+	struct route_node *rn = rnh->node;
 
-	rnh = rn->info;
 	vty_out(vty, "%s%s\n",
 		inet_ntop(rn->p.family, &rn->p.u.prefix, buf, BUFSIZ),
 		CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED) ? "(Connected)"
@@ -1038,7 +1093,6 @@ static int zebra_cleanup_rnh_client(vrf_id_t vrf_id, int family,
 {
 	struct route_table *ntable;
 	struct route_node *nrn;
-	struct rnh *rnh;
 
 	if (IS_ZEBRA_DEBUG_NHT)
 		zlog_debug("%u: Client %s RNH cleanup for family %d type %d",
@@ -1052,11 +1106,14 @@ static int zebra_cleanup_rnh_client(vrf_id_t vrf_id, int family,
 	}
 
 	for (nrn = route_top(ntable); nrn; nrn = route_next(nrn)) {
+		struct listnode *node, *next;
+		struct rnh *rnh;
+
 		if (!nrn->info)
 			continue;
-
-		rnh = nrn->info;
-		zebra_remove_rnh_client(rnh, client, type);
+		for (ALL_LIST_ELEMENTS((struct list *)nrn->info,
+				       node, next, rnh))
+			zebra_remove_rnh_client(rnh, client, type);
 	}
 	return 1;
 }

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1062,13 +1062,18 @@ static void print_rnh(struct rnh *rnh, struct vty *vty)
 	char buf[BUFSIZ];
 	struct route_node *rn = rnh->node;
 
-	vty_out(vty, "%s%s\n",
+	vty_out(vty, "%s%s",
 		inet_ntop(rn->p.family, &rn->p.u.prefix, buf, BUFSIZ),
 		CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED) ? "(Connected)"
 							    : "");
+	if (rnh->vrf_id != rnh->vrf_id_route)
+		vty_out(vty, " from vrf %s",
+			vrf_id_to_name(rnh->vrf_id_route));
+	vty_out(vty, "\n");
 	if (rnh->state) {
-		vty_out(vty, " resolved via %s\n",
+		vty_out(vty, " resolved via %s",
 			zebra_route_string(rnh->state->type));
+		vty_out(vty, "\n");
 		for (nexthop = rnh->state->ng.nexthop; nexthop;
 		     nexthop = nexthop->next)
 			print_nh(nexthop, vty);

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -35,6 +35,7 @@ struct rnh {
 
 	/* VRF identifier. */
 	vrf_id_t vrf_id;
+	vrf_id_t vrf_id_route;
 
 	struct route_entry *state;
 	struct prefix resolved_route;
@@ -68,9 +69,10 @@ static inline int rnh_resolve_via_default(int family)
 }
 
 extern struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid,
-				 rnh_type_t type, bool *exists);
+				 rnh_type_t type, bool *exists,
+				 vrf_id_t vrfid_route);
 extern struct rnh *zebra_lookup_rnh(struct prefix *p, vrf_id_t vrfid,
-				    rnh_type_t type);
+				    rnh_type_t type, vrf_id_t vrfid_route);
 extern void zebra_free_rnh(struct rnh *rnh);
 extern void zebra_delete_rnh(struct rnh *rnh, rnh_type_t type);
 extern void zebra_add_rnh_client(struct rnh *rnh, struct zserv *client,

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -360,8 +360,15 @@ void zebra_rtable_node_cleanup(struct route_table *table,
 static void zebra_rnhtable_node_cleanup(struct route_table *table,
 					struct route_node *node)
 {
+	struct listnode *nn, *next;
+	struct rnh *rnh;
+
+	for (ALL_LIST_ELEMENTS((struct list *)node->info,
+			       nn, next, rnh))
+		if (rnh)
+			zebra_free_rnh(rnh);
 	if (node->info)
-		zebra_free_rnh(node->info);
+		list_delete((struct list **)&node->info);
 }
 
 /*


### PR DESCRIPTION
This series of commit permit to handle nexthop tracking for a defined nexthop in a defined vrf, from an other defined vrf. this may create a list of requests indexed by nexthop, but also source vrf and destination vrf.

Because the way to cross vrfs is not the same if the vrf is vrf-lite or netns based, then the minimum that nexthop tracking should do in the case vrf backend is netns, it would be to try to find a route for that nexthop in the local vrf.
   
