### PR TITLE
ospfd: remove call to if_lookup_all_vrf

### DIFF
--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -2530,8 +2530,8 @@ DEFUN (show_ip_ospf_mpls_te_link,
        "Interface name\n")
 {
 	struct vrf *vrf;
-	int idx_interface = 5;
-	struct interface *ifp;
+	int idx_interface = 0;
+	struct interface *ifp = NULL;
 	struct listnode *node;
 	char *vrf_name = NULL;
 	bool all_vrf;
@@ -2543,7 +2543,7 @@ DEFUN (show_ip_ospf_mpls_te_link,
 		vrf_name = argv[idx_vrf + 1]->arg;
 		all_vrf = strmatch(vrf_name, "all");
 	}
-
+	argv_find(argv, argc, "INTERFACE", &idx_interface);
 	/* vrf input is provided could be all or specific vrf*/
 	if (vrf_name) {
 		if (all_vrf) {
@@ -2557,32 +2557,31 @@ DEFUN (show_ip_ospf_mpls_te_link,
 			return CMD_SUCCESS;
 		}
 		ospf = ospf_lookup_by_inst_name(inst, vrf_name);
-		if (ospf == NULL || !ospf->oi_running)
+	} else
+		ospf = ospf_lookup_by_vrf_id(VRF_DEFAULT);
+	if (ospf == NULL || !ospf->oi_running)
+		return CMD_SUCCESS;
+
+	vrf = vrf_lookup_by_id(ospf->vrf_id);
+	if (!vrf)
+		return CMD_SUCCESS;
+	if (idx_interface) {
+		ifp = if_lookup_by_name(
+					argv[idx_interface]->arg,
+					ospf->vrf_id);
+		if (ifp == NULL) {
+			vty_out(vty, "No such interface name in vrf %s\n",
+				vrf->name);
 			return CMD_SUCCESS;
-		vrf = vrf_lookup_by_id(ospf->vrf_id);
+		}
+	}
+	if (!ifp) {
 		FOR_ALL_INTERFACES (vrf, ifp)
 			show_mpls_te_link_sub(vty, ifp);
 		return CMD_SUCCESS;
 	}
-	/* Show All Interfaces. */
-	if (argc == 5) {
-		for (ALL_LIST_ELEMENTS_RO(om->ospf, node, ospf)) {
-			if (!ospf->oi_running)
-				continue;
-			vrf = vrf_lookup_by_id(ospf->vrf_id);
-			FOR_ALL_INTERFACES (vrf, ifp)
-				show_mpls_te_link_sub(vty, ifp);
-		}
-	}
-	/* Interface name is specified. */
-	else {
-		ifp = if_lookup_by_name_all_vrf(argv[idx_interface]->arg);
-		if (ifp == NULL)
-			vty_out(vty, "No such interface name\n");
-		else
-			show_mpls_te_link_sub(vty, ifp);
-	}
 
+	show_mpls_te_link_sub(vty, ifp);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
so as to isolate ospf contexts separately for each vrf, the interface
used is cornered to the passed vrf context.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]

Always remember to follow proper coding style etc. as
described in the FRRouting Dev Guide.
http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html
