### PR TITLE
zebra: Add "show evpn vni detail" command

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1782,7 +1782,7 @@ DEFUN (show_evpn_vni,
        "show evpn vni [json]",
        SHOW_STR
        "EVPN\n"
-       "VxLAN information\n"
+       "VxLAN Network Identifier\n"
        JSON_STR)
 {
 	struct zebra_vrf *zvrf;
@@ -1790,6 +1790,22 @@ DEFUN (show_evpn_vni,
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 	zebra_vxlan_print_vnis(vty, zvrf, uj);
+	return CMD_SUCCESS;
+}
+
+DEFUN (show_evpn_vni_detail, show_evpn_vni_detail_cmd,
+       "show evpn vni detail [json]",
+       SHOW_STR
+       "EVPN\n"
+       "VxLAN Network Identifier\n"
+       "Detailed Information On Each VNI\n"
+       JSON_STR)
+{
+	struct zebra_vrf *zvrf;
+	bool uj = use_json(argc, argv);
+
+	zvrf = vrf_info_lookup(VRF_DEFAULT);
+	zebra_vxlan_print_vnis_detail(vty, zvrf, uj);
 	return CMD_SUCCESS;
 }
 
@@ -2743,6 +2759,7 @@ void zebra_vty_init(void)
 
 	install_element(VIEW_NODE, &show_evpn_global_cmd);
 	install_element(VIEW_NODE, &show_evpn_vni_cmd);
+	install_element(VIEW_NODE, &show_evpn_vni_detail_cmd);
 	install_element(VIEW_NODE, &show_evpn_vni_vni_cmd);
 	install_element(VIEW_NODE, &show_evpn_rmac_vni_mac_cmd);
 	install_element(VIEW_NODE, &show_evpn_rmac_vni_cmd);

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -117,6 +117,9 @@ extern void zebra_vxlan_print_vni(struct vty *vty, struct zebra_vrf *zvrf,
 				  vni_t vni, bool use_json);
 extern void zebra_vxlan_print_vnis(struct vty *vty, struct zebra_vrf *zvrf,
 				   bool use_json);
+extern void zebra_vxlan_print_vnis_detail(struct vty *vty,
+					  struct zebra_vrf *zvrf,
+					  bool use_json);
 extern void zebra_vxlan_print_rmacs_l3vni(struct vty *vty, vni_t vni,
 					  bool use_json);
 extern void zebra_vxlan_print_rmacs_all_l3vni(struct vty *vty, bool use_json);


### PR DESCRIPTION
Change helps display detailed output for all possible VNIs without
specifying VNI. It helps in troubleshooting - a single command can
be fired to capture detailed info on all VNIs.

Ticket: CM-22831
Signed-off-by: Nitin Soni <nsoni@cumulusnetworks.com>
Reviewed-by: CCR-8013

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[zebra]
