### PR TITLE
bgpd: fix resource leak (Coverity 1475489)

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -709,8 +709,10 @@ int bgp_socket(struct bgp *bgp, unsigned short port, const char *address)
 		return -1;
 	}
 	if (bgp_option_check(BGP_OPT_NO_ZEBRA) &&
-	    bgp->vrf_id != VRF_DEFAULT)
+	    bgp->vrf_id != VRF_DEFAULT) {
+		freeaddrinfo(ainfo_save);
 		return -1;
+	}
 	count = 0;
 	for (ainfo = ainfo_save; ainfo; ainfo = ainfo->ai_next) {
 		int sock;


### PR DESCRIPTION
### Summary

Resource leak pointed by Coverity 1475489: return on error before freeing a *getaddrinfo() allocation.

### Components

bgpd
