### PR TITLE
bgpd: fix small error in community-list patch

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -14140,6 +14140,7 @@ DEFUN (no_community_list_expanded_all,
 		zlog_warn("Deprecated option: 'no ip community-list <(1-99)|(100-500)|standard|expanded> <deny|permit> AA:NN' being used");
 	}
 
+	idx = 0;
 	argv_find(argv, argc, "permit", &idx);
 	argv_find(argv, argc, "deny", &idx);
 


### PR DESCRIPTION
Couldn't delete an expanded community-list by name alone, this should've been in #3344 