### PR TITLE
zebra: improve identification of loopback interfaces in the router-id code

### DIFF
--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -132,8 +132,7 @@ void router_id_add_address(struct connected *ifc)
 
 	router_id_get(&before, zvrf_id(zvrf));
 
-	if (!strncmp(ifc->ifp->name, "lo", 2)
-	    || !strncmp(ifc->ifp->name, "dummy", 5))
+	if (if_is_loopback(ifc->ifp))
 		l = zvrf->rid_lo_sorted_list;
 	else
 		l = zvrf->rid_all_sorted_list;
@@ -165,8 +164,7 @@ void router_id_del_address(struct connected *ifc)
 
 	router_id_get(&before, zvrf_id(zvrf));
 
-	if (!strncmp(ifc->ifp->name, "lo", 2)
-	    || !strncmp(ifc->ifp->name, "dummy", 5))
+	if (if_is_loopback(ifc->ifp))
 		l = zvrf->rid_lo_sorted_list;
 	else
 		l = zvrf->rid_all_sorted_list;


### PR DESCRIPTION
### Summary
The `if_is_loopback()` function is the right abstraction for identifying
loopback interfaces. There should be no reason for not using it in the
router-id code.

This fixes some problems with my netgen topologies.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>

### Components
[zebra]