### PR TITLE
True atomics

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1004,7 +1004,7 @@ struct peer {
 	struct thread *t_process_packet;
 
 	/* Thread flags. */
-	_Atomic uint16_t thread_flags;
+	_Atomic uint32_t thread_flags;
 #define PEER_THREAD_WRITES_ON         (1 << 0)
 #define PEER_THREAD_READS_ON          (1 << 1)
 #define PEER_THREAD_KEEPALIVES_ON     (1 << 2)

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -125,7 +125,7 @@ struct cpu_thread_history {
 		_Atomic unsigned long total, max;
 	} real;
 	struct time_stats cpu;
-	_Atomic uint8_t types;
+	_Atomic uint32_t types;
 	const char *funcname;
 };
 

--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -6367,6 +6367,13 @@ sub process {
 			ERROR("NONSTANDARD_INTEGRAL_TYPES",
 			      "Please, no nonstandard integer types in new code.\n" . $herecurr)
 		}
+
+# check for usage of non-32 bit atomics
+		if ($line =~ /_Atomic [u]?int(?!32)[0-9]+_t/) {
+			WARN("NON_32BIT_ATOMIC",
+			     "Please, only use 32 bit atomics.\n" . $herecurr);
+		}
+
 	}
 
 	# If we have no input at all, then there is nothing to report on

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -135,8 +135,8 @@ struct zebra_dplane_provider {
 
 	dplane_provider_fini_fp dp_fini;
 
-	_Atomic uint64_t dp_in_counter;
-	_Atomic uint64_t dp_error_counter;
+	_Atomic uint32_t dp_in_counter;
+	_Atomic uint32_t dp_error_counter;
 
 	/* Embedded list linkage */
 	TAILQ_ENTRY(zebra_dplane_provider) dp_q_providers;
@@ -171,10 +171,10 @@ static struct zebra_dplane_globals {
 	/* Limit number of pending, unprocessed updates */
 	_Atomic uint32_t dg_max_queued_updates;
 
-	_Atomic uint64_t dg_routes_in;
+	_Atomic uint32_t dg_routes_in;
 	_Atomic uint32_t dg_routes_queued;
 	_Atomic uint32_t dg_routes_queued_max;
-	_Atomic uint64_t dg_route_errors;
+	_Atomic uint32_t dg_route_errors;
 
 	/* Event-delivery context 'master' for the dplane */
 	struct thread_master *dg_master;

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -875,7 +875,7 @@ static void zebra_show_client_detail(struct vty *vty, struct zserv *client)
 	char cbuf[ZEBRA_TIME_BUF], rbuf[ZEBRA_TIME_BUF];
 	char wbuf[ZEBRA_TIME_BUF], nhbuf[ZEBRA_TIME_BUF], mbuf[ZEBRA_TIME_BUF];
 	time_t connect_time, last_read_time, last_write_time;
-	uint16_t last_read_cmd, last_write_cmd;
+	uint32_t last_read_cmd, last_write_cmd;
 
 	vty_out(vty, "Client: %s", zebra_route_string(client->proto));
 	if (client->instance)

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -157,9 +157,9 @@ struct zserv {
 	/* monotime of last message sent */
 	_Atomic uint32_t last_write_time;
 	/* command code of last message read */
-	_Atomic uint16_t last_read_cmd;
+	_Atomic uint32_t last_read_cmd;
 	/* command code of last message written */
-	_Atomic uint16_t last_write_cmd;
+	_Atomic uint32_t last_write_cmd;
 };
 
 #define ZAPI_HANDLER_ARGS                                                      \


### PR DESCRIPTION
### Summary
Convert all atomics to 32-bit. We cannot use 64-bit atomics on 32-bit platforms without invoking compiler compatibility routines, which must be explicitly linked for with `-latomic`. Since we currently don't have a real need for bigger or smaller atomics let's just use the ones that we know work.

Also adds a checkpatch warning for non-32 bit atomics.

### Components
tools, bgpd, zebra, lib