### PR TITLE
bgpd: null check (Coverity 1475469)

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -866,6 +866,8 @@ void bgp_nht_register_enhe_capability_interfaces(struct peer *peer)
 	if (p.family != AF_INET6)
 		return;
 	rn = bgp_node_lookup(bgp->nexthop_cache_table[AFI_IP6], &p);
+	if (!rn)
+		return;
 
 	bnc = bgp_nexthop_get_node_info(rn);
 	if (!bnc)


### PR DESCRIPTION
### Summary

Null check of 'rn' returned by bgp_node_lookup() because it could be deferenced afterwards into bgp_nexthop_get_node_info(). Coverage analysis into Coverity # 1475469.

### Components

bgpd
