### PR TITLE
bgpd isisd lib: fix return on void functions

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3495,8 +3495,8 @@ void bgp_packet_mpunreach_prefix(struct stream *s, struct prefix *p, afi_t afi,
 		num_labels = 1;
 	}
 
-	return bgp_packet_mpattr_prefix(s, afi, safi, p, prd, label, num_labels,
-					addpath_encode, addpath_tx_id, attr);
+	bgp_packet_mpattr_prefix(s, afi, safi, p, prd, label, num_labels,
+				 addpath_encode, addpath_tx_id, attr);
 }
 
 void bgp_packet_mpunreach_end(struct stream *s, size_t attrlen_pnt)

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1508,9 +1508,10 @@ static void bgp_pbr_policyroute_remove_from_zebra_recursive(
 	struct list *orig_list;
 	struct bgp_pbr_val_mask **target_val;
 
-	if (type_entry == 0)
-		return bgp_pbr_policyroute_remove_from_zebra_unit(bgp, path,
-								  bpf);
+	if (type_entry == 0) {
+		bgp_pbr_policyroute_remove_from_zebra_unit(bgp, path, bpf);
+		return;
+	}
 	next_type_entry = bgp_pbr_next_type_entry(type_entry);
 	if (type_entry == FLOWSPEC_TCP_FLAGS && bpof->tcpflags) {
 		orig_list = bpof->tcpflags;
@@ -1530,8 +1531,9 @@ static void bgp_pbr_policyroute_remove_from_zebra_recursive(
 		bgp_pbr_icmp_action(bgp, path, bpf, bpof, false, NULL, NULL);
 		return;
 	} else {
-		return bgp_pbr_policyroute_remove_from_zebra_recursive(
+		bgp_pbr_policyroute_remove_from_zebra_recursive(
 			bgp, path, bpf, bpof, next_type_entry);
+		return;
 	}
 	for (ALL_LIST_ELEMENTS(orig_list, node, nnode, valmask)) {
 		*target_val = valmask;
@@ -1544,9 +1546,10 @@ static void bgp_pbr_policyroute_remove_from_zebra(
 	struct bgp *bgp, struct bgp_path_info *path, struct bgp_pbr_filter *bpf,
 	struct bgp_pbr_or_filter *bpof)
 {
-	if (!bpof)
-		return bgp_pbr_policyroute_remove_from_zebra_unit(bgp, path,
-								  bpf);
+	if (!bpof) {
+		bgp_pbr_policyroute_remove_from_zebra_unit(bgp, path, bpf);
+		return;
+	}
 	if (bpof->tcpflags)
 		bgp_pbr_policyroute_remove_from_zebra_recursive(
 			bgp, path, bpf, bpof, FLOWSPEC_TCP_FLAGS);
@@ -1903,9 +1906,10 @@ static void bgp_pbr_policyroute_add_to_zebra_recursive(
 	struct list *orig_list;
 	struct bgp_pbr_val_mask **target_val;
 
-	if (type_entry == 0)
-		return bgp_pbr_policyroute_add_to_zebra_unit(bgp, path, bpf, nh,
-							     rate);
+	if (type_entry == 0) {
+		bgp_pbr_policyroute_add_to_zebra_unit(bgp, path, bpf, nh, rate);
+		return;
+	}
 	next_type_entry = bgp_pbr_next_type_entry(type_entry);
 	if (type_entry == FLOWSPEC_TCP_FLAGS && bpof->tcpflags) {
 		orig_list = bpof->tcpflags;
@@ -1925,8 +1929,9 @@ static void bgp_pbr_policyroute_add_to_zebra_recursive(
 		bgp_pbr_icmp_action(bgp, path, bpf, bpof, true, nh, rate);
 		return;
 	} else {
-		return bgp_pbr_policyroute_add_to_zebra_recursive(
+		bgp_pbr_policyroute_add_to_zebra_recursive(
 			bgp, path, bpf, bpof, nh, rate, next_type_entry);
+		return;
 	}
 	for (ALL_LIST_ELEMENTS(orig_list, node, nnode, valmask)) {
 		*target_val = valmask;
@@ -1941,9 +1946,10 @@ static void bgp_pbr_policyroute_add_to_zebra(struct bgp *bgp,
 					     struct bgp_pbr_or_filter *bpof,
 					     struct nexthop *nh, float *rate)
 {
-	if (!bpof)
-		return bgp_pbr_policyroute_add_to_zebra_unit(bgp, path, bpf, nh,
-							     rate);
+	if (!bpof) {
+		bgp_pbr_policyroute_add_to_zebra_unit(bgp, path, bpf, nh, rate);
+		return;
+	}
 	if (bpof->tcpflags)
 		bgp_pbr_policyroute_add_to_zebra_recursive(
 			bgp, path, bpf, bpof, nh, rate, FLOWSPEC_TCP_FLAGS);
@@ -2112,9 +2118,10 @@ static void bgp_pbr_handle_entry(struct bgp *bgp, struct bgp_path_info *path,
 	bpf.protocol = proto;
 	bpf.src_port = srcp;
 	bpf.dst_port = dstp;
-	if (!add)
-		return bgp_pbr_policyroute_remove_from_zebra(bgp, path, &bpf,
-							     &bpof);
+	if (!add) {
+		bgp_pbr_policyroute_remove_from_zebra(bgp, path, &bpf, &bpof);
+		return;
+	}
 	/* no action for add = true */
 	for (i = 0; i < api->action_num; i++) {
 		switch (api->actions[i].action) {

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1217,9 +1217,10 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 	if (bgp_debug_zebra(p))
 		prefix2str(p, buf_prefix, sizeof(buf_prefix));
 
-	if (safi == SAFI_FLOWSPEC)
-		return bgp_pbr_update_entry(bgp, &rn->p,
-					    info, afi, safi, true);
+	if (safi == SAFI_FLOWSPEC) {
+		bgp_pbr_update_entry(bgp, &rn->p, info, afi, safi, true);
+		return;
+	}
 
 	/*
 	 * vrf leaking support (will have only one nexthop)
@@ -1505,8 +1506,8 @@ void bgp_zebra_withdraw(struct prefix *p, struct bgp_path_info *info,
 
 	if (safi == SAFI_FLOWSPEC) {
 		peer = info->peer;
-		return bgp_pbr_update_entry(peer->bgp, p,
-					    info, AFI_IP, safi, false);
+		bgp_pbr_update_entry(peer->bgp, p, info, AFI_IP, safi, false);
+		return;
 	}
 
 	memset(&api, 0, sizeof(api));
@@ -2501,19 +2502,19 @@ static void bgp_zebra_process_local_ip_prefix(int cmd, struct zclient *zclient,
 	if (cmd == ZEBRA_IP_PREFIX_ROUTE_ADD) {
 
 		if (p.family == AF_INET)
-			return bgp_evpn_advertise_type5_route(
-				bgp_vrf, &p, NULL, AFI_IP, SAFI_UNICAST);
+			bgp_evpn_advertise_type5_route(bgp_vrf, &p, NULL,
+						       AFI_IP, SAFI_UNICAST);
 		else
-			return bgp_evpn_advertise_type5_route(
-				bgp_vrf, &p, NULL, AFI_IP6, SAFI_UNICAST);
+			bgp_evpn_advertise_type5_route(bgp_vrf, &p, NULL,
+						       AFI_IP6, SAFI_UNICAST);
 
 	} else {
 		if (p.family == AF_INET)
-			return bgp_evpn_withdraw_type5_route(
-				bgp_vrf, &p, AFI_IP, SAFI_UNICAST);
+			bgp_evpn_withdraw_type5_route(bgp_vrf, &p, AFI_IP,
+						      SAFI_UNICAST);
 		else
-			return bgp_evpn_withdraw_type5_route(
-				bgp_vrf, &p, AFI_IP6, SAFI_UNICAST);
+			bgp_evpn_withdraw_type5_route(bgp_vrf, &p, AFI_IP6,
+						      SAFI_UNICAST);
 	}
 }
 

--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -492,7 +492,7 @@ static void _isis_route_verify_table(struct isis_area *area,
 
 void isis_route_verify_table(struct isis_area *area, struct route_table *table)
 {
-	return _isis_route_verify_table(area, table, NULL);
+	_isis_route_verify_table(area, table, NULL);
 }
 
 /* Function to validate route tables for L1L2 areas. In this case we can't use

--- a/lib/agg_table.h
+++ b/lib/agg_table.h
@@ -58,7 +58,7 @@ static inline struct agg_node *agg_lock_node(struct agg_node *node)
 
 static inline void agg_unlock_node(struct agg_node *node)
 {
-	return route_unlock_node(agg_node_to_rnode(node));
+	route_unlock_node(agg_node_to_rnode(node));
 }
 
 static inline void agg_set_table_info(struct agg_table *atable, void *data)

--- a/lib/openbsd-tree.h
+++ b/lib/openbsd-tree.h
@@ -475,25 +475,25 @@ int _rb_check(const struct rb_type *, void *, unsigned long);
 	__attribute__((__unused__)) static inline void _name##_RB_SET_LEFT(    \
 		struct _type *elm, struct _type *left)                         \
 	{                                                                      \
-		return _rb_set_left(_name##_RB_TYPE, elm, left);               \
+		_rb_set_left(_name##_RB_TYPE, elm, left);                      \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline void _name##_RB_SET_RIGHT(   \
 		struct _type *elm, struct _type *right)                        \
 	{                                                                      \
-		return _rb_set_right(_name##_RB_TYPE, elm, right);             \
+		_rb_set_right(_name##_RB_TYPE, elm, right);                    \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline void _name##_RB_SET_PARENT(  \
 		struct _type *elm, struct _type *parent)                       \
 	{                                                                      \
-		return _rb_set_parent(_name##_RB_TYPE, elm, parent);           \
+		_rb_set_parent(_name##_RB_TYPE, elm, parent);                  \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline void _name##_RB_POISON(      \
 		struct _type *elm, unsigned long poison)                       \
 	{                                                                      \
-		return _rb_poison(_name##_RB_TYPE, elm, poison);               \
+		_rb_poison(_name##_RB_TYPE, elm, poison);                      \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline int _name##_RB_CHECK(        \


### PR DESCRIPTION
### Summary

ISO C forbids ‘return’ with expression, in function returning void.

### Components

bgpd, isisd, lib
