### PR TITLE
IS-IS: Bugfix ipv6 only

### DIFF
--- a/isisd/isis_mt.c
+++ b/isisd/isis_mt.c
@@ -398,7 +398,7 @@ bool tlvs_to_adj_mt_set(struct isis_tlvs *tlvs, bool v4_usable, bool v6_usable,
 		    && !tlvs->mt_router_info_empty) {
 			/* Other end does not have MT enabled */
 			if (mt_settings[i]->mtid == ISIS_MT_IPV4_UNICAST
-			    && v4_usable)
+			    && (v4_usable || v6_usable))
 				adj_mt_set(adj, intersect_count++,
 					   ISIS_MT_IPV4_UNICAST);
 		} else {

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -3408,7 +3408,7 @@ static void tlvs_protocols_supported_to_adj(struct isis_tlvs *tlvs,
 		reduced.nlpids[0] = NLPID_IP;
 	} else if (ipv6_supported) {
 		reduced.count = 1;
-		reduced.nlpids[1] = NLPID_IPV6;
+		reduced.nlpids[0] = NLPID_IPV6;
 	} else {
 		reduced.count = 0;
 	}


### PR DESCRIPTION
### Summary

Fixes: #3336 

There were two issues leading to IPv6 only links not being considered when running in non-MT mode.