### PR TITLE
bgpd: Fixed bgp daemon crash when a L2VNI is unconfigured

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1696,10 +1696,10 @@ static void evpn_unconfigure_import_rt(struct bgp *bgp, struct bgpevpn *vpn,
 
 	/* Delete all import RTs */
 	if (ecomdel == NULL) {
-		for (ALL_LIST_ELEMENTS(vpn->import_rtl, node, nnode, ecom))
+		for (ALL_LIST_ELEMENTS(vpn->import_rtl, node, nnode, ecom)) {
 			ecommunity_free(&ecom);
-
-		list_delete_all_node(vpn->import_rtl);
+			list_delete_node(vpn->import_rtl, node);
+		}
 	}
 
 	/* Delete a specific import RT */
@@ -1764,10 +1764,10 @@ static void evpn_unconfigure_export_rt(struct bgp *bgp, struct bgpevpn *vpn,
 	/* Delete all export RTs */
 	if (ecomdel == NULL) {
 		/* Reset to default and process all routes. */
-		for (ALL_LIST_ELEMENTS(vpn->export_rtl, node, nnode, ecom))
+		for (ALL_LIST_ELEMENTS(vpn->export_rtl, node, nnode, ecom)) {
 			ecommunity_free(&ecom);
-
-		list_delete_all_node(vpn->export_rtl);
+			list_delete_node(vpn->export_rtl, node);
+		}
 	}
 
 	/* Delete a specific export RT */


### PR DESCRIPTION
A L2VNI has been configured with export and import route target.
When a VNI is unconfigured it deletes all of its import and export
route-targets. There is a export route-target link list and import
route-target linked list per VNI. There are two loops in the deletion code.
In the 1st loop the route-target was deleted and freed, but list node
was not deleted and also the data of the node wasn't reset.
The second loop tries to delete and free an RT which was already freed
crashing the bgp daemon.

Signed-off-by: karamalla@vmware.com

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]
