### PR TITLE
bgpd: BGP daemon crashed when a L2VNI is unconfigured

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1696,10 +1696,10 @@ static void evpn_unconfigure_import_rt(struct bgp *bgp, struct bgpevpn *vpn,
 
 	/* Delete all import RTs */
 	if (ecomdel == NULL) {
-		for (ALL_LIST_ELEMENTS(vpn->import_rtl, node, nnode, ecom))
+		for (ALL_LIST_ELEMENTS(vpn->import_rtl, node, nnode, ecom)) {
 			ecommunity_free(&ecom);
-
-		list_delete_all_node(vpn->import_rtl);
+			list_delete_node(vpn->import_rtl, node);
+		}
 	}
 
 	/* Delete a specific import RT */
@@ -1764,10 +1764,10 @@ static void evpn_unconfigure_export_rt(struct bgp *bgp, struct bgpevpn *vpn,
 	/* Delete all export RTs */
 	if (ecomdel == NULL) {
 		/* Reset to default and process all routes. */
-		for (ALL_LIST_ELEMENTS(vpn->export_rtl, node, nnode, ecom))
+		for (ALL_LIST_ELEMENTS(vpn->export_rtl, node, nnode, ecom)) {
 			ecommunity_free(&ecom);
-
-		list_delete_all_node(vpn->export_rtl);
+			list_delete_node(vpn->export_rtl, node);
+		}
 	}
 
 	/* Delete a specific export RT */


### PR DESCRIPTION
When a VNI is unconfigured it deletes all of its import and export
route-targets.  There is a export route-target link list and import
route-target linked list.  There are redudant loops in  the
route-target deletion code.  In the first iteration it deleted the
route-target and freed the RT node, but not list node.
In the 2nd iteration it tries to free the RT node again, resulting in
 the double free of RT node.

Signed-off-by: "Kishore Aramalla karamalla@vmware.com"

### Related Issue
https://github.com/FRRouting/frr/issues/3333

### Components
bgpd,
