### PR TITLE
isisd lib ospfd pbrd python: fix empty init

### DIFF
--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -747,7 +747,7 @@ static int process_lsp(uint8_t pdu_type, struct isis_circuit *circuit,
 				       stream_get_endp(circuit->rcv_stream));
 	}
 
-	struct isis_lsp_hdr hdr = {};
+	struct isis_lsp_hdr hdr = {0};
 
 	hdr.pdu_len = stream_getw(circuit->rcv_stream);
 	hdr.rem_lifetime = stream_getw(circuit->rcv_stream);
@@ -1119,8 +1119,8 @@ static int process_snp(uint8_t pdu_type, struct isis_circuit *circuit,
 	stream_get(rem_sys_id, circuit->rcv_stream, ISIS_SYS_ID_LEN);
 	stream_forward_getp(circuit->rcv_stream, 1); /* Circuit ID - unused */
 
-	uint8_t start_lsp_id[ISIS_SYS_ID_LEN + 2] = {};
-	uint8_t stop_lsp_id[ISIS_SYS_ID_LEN + 2] = {};
+	uint8_t start_lsp_id[ISIS_SYS_ID_LEN + 2] = {0};
+	uint8_t stop_lsp_id[ISIS_SYS_ID_LEN + 2] = {0};
 
 	if (is_csnp) {
 		stream_get(start_lsp_id, circuit->rcv_stream,

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -171,8 +171,7 @@ static int unpack_item_prefix_sid(uint16_t mtid, uint8_t len, struct stream *s,
 				  struct sbuf *log, void *dest, int indent)
 {
 	struct isis_subtlvs *subtlvs = dest;
-	struct isis_prefix_sid sid = {
-	};
+	struct isis_prefix_sid sid = {0};
 
 	sbuf_push(log, indent, "Unpacking SR Prefix-SID...\n");
 
@@ -2052,7 +2051,7 @@ static int unpack_tlv_purge_originator(enum isis_tlv_context context,
 				       void *dest, int indent)
 {
 	struct isis_tlvs *tlvs = dest;
-	struct isis_purge_originator poi = {};
+	struct isis_purge_originator poi = {0};
 
 	sbuf_push(log, indent, "Unpacking Purge Originator Identification TLV...\n");
 	if (tlv_len < 7) {
@@ -3131,7 +3130,7 @@ static const struct tlv_ops *tlv_table[ISIS_CONTEXT_MAX][ISIS_TLV_MAX] = {
 		[ISIS_TLV_IPV6_REACH] = &tlv_ipv6_reach_ops,
 		[ISIS_TLV_MT_IPV6_REACH] = &tlv_ipv6_reach_ops,
 	},
-	[ISIS_CONTEXT_SUBTLV_NE_REACH] = {},
+	[ISIS_CONTEXT_SUBTLV_NE_REACH] = {0},
 	[ISIS_CONTEXT_SUBTLV_IP_REACH] = {
 		[ISIS_SUBTLV_PREFIX_SID] = &tlv_prefix_sid_ops,
 	},
@@ -3397,7 +3396,7 @@ static void tlvs_protocols_supported_to_adj(struct isis_tlvs *tlvs,
 			ipv6_supported = true;
 	}
 
-	struct nlpids reduced = {};
+	struct nlpids reduced = {0};
 
 	if (ipv4_supported && ipv6_supported) {
 		reduced.count = 2;

--- a/lib/command_py.c
+++ b/lib/command_py.c
@@ -92,7 +92,7 @@ static PyMemberDef members_graph_node[] = {
 	member(deprecated, T_BOOL),  member(hidden, T_BOOL),
 	member(text, T_STRING),      member(desc, T_STRING),
 	member(min, T_LONGLONG),     member(max, T_LONGLONG),
-	member(varname, T_STRING),   {},
+	member(varname, T_STRING),   {0},
 };
 #undef member
 
@@ -137,7 +137,7 @@ static PyObject *graph_node_join(PyObject *self, PyObject *args)
 static PyMethodDef methods_graph_node[] = {
 	{"next", graph_node_next, METH_NOARGS, "outbound graph edge list"},
 	{"join", graph_node_join, METH_NOARGS, "outbound join node"},
-	{}};
+	{0}};
 
 static void graph_node_wrap_free(void *arg)
 {
@@ -228,7 +228,7 @@ static PyObject *graph_to_pyobj(struct wrap_graph *wgraph,
 	}
 static PyMemberDef members_graph[] = {
 	member(definition, T_STRING),
-	{},
+	{0},
 };
 #undef member
 
@@ -242,7 +242,7 @@ static PyObject *graph_first(PyObject *self, PyObject *args)
 
 static PyMethodDef methods_graph[] = {
 	{"first", graph_first, METH_NOARGS, "first graph node"},
-	{}};
+	{0}};
 
 static PyObject *graph_parse(PyTypeObject *type, PyObject *args,
 			     PyObject *kwds);

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -655,7 +655,7 @@ static int ospf_write(struct thread *thread)
 	int pkt_count = 0;
 
 #ifdef GNU_LINUX
-	unsigned char cmsgbuf[64] = {};
+	unsigned char cmsgbuf[64] = {0};
 	struct cmsghdr *cm = (struct cmsghdr *)cmsgbuf;
 	struct in_pktinfo *pi;
 #endif

--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -232,9 +232,9 @@ void pbr_nhgroup_add_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 				const struct nexthop *nhop)
 {
 	char debugstr[256];
-	struct pbr_nexthop_group_cache pnhgc_find = {};
+	struct pbr_nexthop_group_cache pnhgc_find = {0};
 	struct pbr_nexthop_group_cache *pnhgc;
-	struct pbr_nexthop_cache pnhc_find = {};
+	struct pbr_nexthop_cache pnhc_find = {0};
 	struct pbr_nexthop_cache *pnhc;
 
 	if (!pbr_nht_get_next_tableid(true)) {
@@ -270,9 +270,9 @@ void pbr_nhgroup_del_nexthop_cb(const struct nexthop_group_cmd *nhgc,
 				const struct nexthop *nhop)
 {
 	char debugstr[256];
-	struct pbr_nexthop_group_cache pnhgc_find = {};
+	struct pbr_nexthop_group_cache pnhgc_find = {0};
 	struct pbr_nexthop_group_cache *pnhgc;
-	struct pbr_nexthop_cache pnhc_find = {};
+	struct pbr_nexthop_cache pnhc_find = {0};
 	struct pbr_nexthop_cache *pnhc;
 	enum nexthop_types_t nh_afi = nhop->type;
 

--- a/python/clidef.py
+++ b/python/clidef.py
@@ -67,19 +67,19 @@ class PrefixBase(RenderHandler):
     deref = '&'
 class Prefix4Handler(PrefixBase):
     argtype = 'const struct prefix_ipv4 *'
-    decl = Template('struct prefix_ipv4 $varname = { };')
+    decl = Template('struct prefix_ipv4 $varname = {0};')
     code = Template('_fail = !str2prefix_ipv4(argv[_i]->arg, &$varname);')
 class Prefix6Handler(PrefixBase):
     argtype = 'const struct prefix_ipv6 *'
-    decl = Template('struct prefix_ipv6 $varname = { };')
+    decl = Template('struct prefix_ipv6 $varname = {0};')
     code = Template('_fail = !str2prefix_ipv6(argv[_i]->arg, &$varname);')
 class PrefixEthHandler(PrefixBase):
     argtype = 'struct prefix_eth *'
-    decl = Template('struct prefix_eth $varname = { };')
+    decl = Template('struct prefix_eth $varname = {0};')
     code = Template('_fail = !str2prefix_eth(argv[_i]->arg, &$varname);')
 class PrefixGenHandler(PrefixBase):
     argtype = 'const struct prefix *'
-    decl = Template('struct prefix $varname = { };')
+    decl = Template('struct prefix $varname = {0};')
     code = Template('_fail = !str2prefix(argv[_i]->arg, &$varname);')
 
 # same for IP addresses.  result is union sockunion.
@@ -96,7 +96,7 @@ class IP4Handler(IPBase):
     code = Template('_fail = !inet_aton(argv[_i]->arg, &$varname);')
 class IP6Handler(IPBase):
     argtype = 'struct in6_addr'
-    decl = Template('struct in6_addr $varname = {};')
+    decl = Template('struct in6_addr $varname = {0};')
     code = Template('_fail = !inet_pton(AF_INET6, argv[_i]->arg, &$varname);')
 class IPGenHandler(IPBase):
     argtype = 'const union sockunion *'


### PR DESCRIPTION
### Summary

ISO C forbids empty initializer braces. Empty initializers have been replaced with {0}

### Components

isisd lib ospfd pbrd python
