### PR TITLE
Default vrf initialization

### DIFF
--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -236,7 +236,7 @@ extern vrf_id_t vrf_get_default_id(void);
 /* The default VRF ID */
 #define VRF_DEFAULT vrf_get_default_id()
 
-extern void vrf_set_default_name(const char *default_name);
+extern void vrf_set_default_name(const char *default_name, bool force);
 extern const char *vrf_get_default_name(void);
 #define VRF_DEFAULT_NAME    vrf_get_default_name()
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1370,7 +1370,7 @@ static void zclient_vrf_add(struct zclient *zclient, vrf_id_t vrf_id)
 	memcpy(vrf->data.l.netns_name, data.l.netns_name, NS_NAMSIZ);
 	/* overwrite default vrf */
 	if (vrf_id == VRF_DEFAULT)
-		vrf_set_default_name(vrfname_tmp);
+		vrf_set_default_name(vrfname_tmp, false);
 	vrf_enable(vrf);
 }
 

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -336,7 +336,7 @@ int main(int argc, char **argv)
 			}
 			break;
 		case 'o':
-			vrf_set_default_name(optarg);
+			vrf_set_default_name(optarg, true);
 			break;
 		case 'z':
 			zserv_path = optarg;

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -256,6 +256,7 @@ int main(int argc, char **argv)
 {
 	// int batch_mode = 0;
 	char *zserv_path = NULL;
+	char *vrf_default_name_configured = NULL;
 	/* Socket to external label manager */
 	char *lblmgr_path = NULL;
 	struct sockaddr_storage dummy;
@@ -336,7 +337,7 @@ int main(int argc, char **argv)
 			}
 			break;
 		case 'o':
-			vrf_set_default_name(optarg, true);
+			vrf_default_name_configured = optarg;
 			break;
 		case 'z':
 			zserv_path = optarg;
@@ -402,7 +403,9 @@ int main(int argc, char **argv)
 	 * Initialize NS( and implicitly the VRF module), and make kernel
 	 * routing socket. */
 	zebra_ns_init();
-
+	if (vrf_default_name_configured)
+		vrf_set_default_name(vrf_default_name_configured,
+				     true);
 	zebra_vty_init();
 	access_list_init();
 	prefix_list_init();

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -219,7 +219,7 @@ static int zebra_ns_ready_read(struct thread *t)
 		zlog_warn(
 			  "NS notify : NS %s is default VRF."
 			  " Updating VRF Name", basename(netnspath));
-		vrf_set_default_name(basename(netnspath));
+		vrf_set_default_name(basename(netnspath), false);
 		return zebra_ns_continue_read(zns_info, 1);
 	}
 
@@ -314,7 +314,7 @@ void zebra_ns_notify_parse(void)
 			zlog_warn(
 				  "NS notify : NS %s is default VRF."
 				  " Updating VRF Name", dent->d_name);
-			vrf_set_default_name(dent->d_name);
+			vrf_set_default_name(dent->d_name, false);
 			continue;
 		}
 		zebra_ns_notify_create_context_from_entry_name(dent->d_name);


### PR DESCRIPTION
This fix permits an user that uses vrf with netns backend.
if there is a default netns mapped under /var/run/netns, then forcing -o is useless : 
- first of all, the option is passed too early ( vrf context not initialised)
- secondly, if the netns folder appears subsequently, the -o option is overwritten

those 2 commits help for fixing this.
