### PR TITLE
bgpd: bgp pbr ignores bgp fs entries with 0.0.0.0 ips written.

### DIFF
--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -449,8 +449,17 @@ int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 				flog_err(EC_BGP_FLOWSPEC_PACKET,
 					 "%s: flowspec_ip_address error %d",
 					 __func__, error);
-			else
-				bpem->match_bitmask |= bitmask;
+			else {
+				/* if src or dst address is 0.0.0.0,
+				 * ignore that rule
+				 */
+				if (prefix->family == AF_INET
+				    && prefix->u.prefix4.s_addr == 0)
+					memset(prefix, 0,
+					       sizeof(struct prefix));
+				else
+					bpem->match_bitmask |= bitmask;
+			}
 			offset += ret;
 			break;
 		case FLOWSPEC_IP_PROTOCOL:


### PR DESCRIPTION
when converting bgp fs entries to bgp pbr entries, the fields of the
flowspec are analysed. In the case src ip or dst ip is set to 0.0.0.0,
that field is ignored, thus preventing from injecting a rule that can
not be injected into the pbr. ( because with ipset tools, you can not
create a rule with 0.0.0.0 inside). This can be done by avoiding mentioning
the field in the bitmask structure used to convert data to pbr entries.

PR=61620
Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
Acked-by: Emmanuel Vize <emmanuel.vize@6wind.com>
