### PR TITLE
lib: do not convert ip prefixes without '.' or ':'

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -853,7 +853,7 @@ int str2prefix_ipv4(const char *str, struct prefix_ipv4 *p)
 	/* String doesn't contail slash. */
 	if (pnt == NULL) {
 		/* Convert string to prefix. */
-		ret = inet_aton(str, &p->prefix);
+		ret = inet_pton(AF_INET, str, &p->prefix);
 		if (ret == 0)
 			return 0;
 


### PR DESCRIPTION
There are cases where the passed parameter for a vty command is either
an interface name or an ip address. Because the interface name can be a
number, and because the user may want to use a number to define an IP (
for instance 'ping 0' is valid from shell purpose), there is a choice
that needs to be done at frr level. either from the application point of
view, the interface name will be priorized, or each number will be
considered as an ip address. In that commit, the choice is to let prefix
API ignore the prefixes IPv4 or IPv6 as simple integers.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
