### PR TITLE
bgpd: add new draft for redirect ip for flowspec

### DIFF
--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -688,9 +688,23 @@ char *ecommunity_ecom2str(struct ecommunity *ecom, int format, int filter)
 			/* Low-order octet of type. */
 			sub_type = *pnt++;
 			if (sub_type != ECOMMUNITY_ROUTE_TARGET
-			    && sub_type != ECOMMUNITY_SITE_ORIGIN)
-				unk_ecom = 1;
-			else
+			    && sub_type != ECOMMUNITY_SITE_ORIGIN) {
+				if (sub_type ==
+				    ECOMMUNITY_FLOWSPEC_REDIRECT_IPV4 &&
+				    type == ECOMMUNITY_ENCODE_IP) {
+					struct in_addr *ipv4 =
+						(struct in_addr *)pnt;
+					char ipv4str[INET_ADDRSTRLEN];
+
+					inet_ntop(AF_INET, ipv4,
+						  ipv4str,
+						  INET_ADDRSTRLEN);
+					len = sprintf(str_buf + str_pnt,
+						      "NH:%s:%d",
+						      ipv4str, pnt[5]);
+				} else
+					unk_ecom = 1;
+			} else
 				len = ecommunity_rt_soo_str(str_buf + str_pnt,
 							    pnt, type, sub_type,
 							    format);

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -41,6 +41,10 @@
 #define ECOMMUNITY_REDIRECT_VRF             0x08
 #define ECOMMUNITY_TRAFFIC_MARKING          0x09
 #define ECOMMUNITY_REDIRECT_IP_NH           0x00
+/* from IANA: bgp-extended-communities/bgp-extended-communities.xhtml
+ * 0x0c Flow-spec Redirect to IPv4 - draft-ietf-idr-flowspec-redirect
+ */
+#define ECOMMUNITY_FLOWSPEC_REDIRECT_IPV4   0x0c
 
 /* Low-order octet of the Extended Communities type field for EVPN types */
 #define ECOMMUNITY_EVPN_SUBTYPE_MACMOBILITY  0x00

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -315,7 +315,8 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 		}
 		if (attr->nexthop.s_addr != 0 &&
 		    display == NLRI_STRING_FORMAT_LARGE)
-			vty_out(vty, "\tNH %-16s\n", inet_ntoa(attr->nexthop));
+			vty_out(vty, "\tNLRI NH %-16s\n",
+				inet_ntoa(attr->nexthop));
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
 	peer_uptime(path->uptime, timebuf, BGP_UPTIME_LEN, 0, NULL);


### PR DESCRIPTION
when converting bgp fs entries to bgp pbr entries, the fields of the
flowspec are analysed. In the case src ip or dst ip is set to 0.0.0.0,
that field is ignored, thus preventing from injecting a rule that can
not be injected into the pbr. ( because with ipset tools, you can not
create a rule with 0.0.0.0 inside). This can be done by avoiding mentioning
the field in the bitmask structure used to convert data to pbr entries.

PR=61620
Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
Acked-by: Emmanuel Vize <emmanuel.vize@6wind.com>
