### PR TITLE
bgpd: The default IP route not advertised with configured RD

### DIFF
--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -484,6 +484,9 @@ static inline int is_es_local(struct evpnes *es)
 	return CHECK_FLAG(es->flags, EVPNES_LOCAL) ? 1 : 0;
 }
 
+extern void bgp_evpn_install_uninstall_default_route(struct bgp *bgp_vrf,
+						     afi_t afi, safi_t safi,
+						     bool add);
 extern void evpn_rt_delete_auto(struct bgp *, vni_t, struct list *);
 extern void bgp_evpn_configure_export_rt_for_vrf(struct bgp *bgp_vrf,
 						 struct ecommunity *ecomadd);


### PR DESCRIPTION
When "default-originate ipv4" is configured, a type-5 route is installed in
the local node and advertised to the peer with auto-rd.

When the above was followed by configuring an RD in IP VRF, Type-5 are
generated for only the non-default routes.

Fixed this issue by withdrawing the default route with auto-rd and advertising
 the route with confiured RD.

Signed-off-by: Kishore Aramalla karamalla@vmware.com

https://github.com/FRRouting/frr/issues/3360