### PR TITLE
libs,bgpd: remove deprecated stream lib macros

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -295,7 +295,7 @@ static uint16_t bgp_write(struct peer *peer)
 		int writenum;
 		do {
 			writenum = stream_get_endp(s) - stream_get_getp(s);
-			num = write(peer->fd, STREAM_PNT(s), writenum);
+			num = write(peer->fd, stream_pnt(s), writenum);
 
 			if (num < 0) {
 				if (!ERRNO_IO_RETRY(errno)) {

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -133,13 +133,6 @@ struct stream_fifo {
 
 #define STREAM_CONCAT_REMAIN(S1, S2, size) ((size) - (S1)->endp - (S2)->endp)
 
-/* deprecated macros - do not use in new code */
-#if CONFDATE > 20181128
-CPP_NOTICE("lib: time to remove deprecated stream.h macros")
-#endif
-#define STREAM_PNT(S)   stream_pnt((S))
-#define STREAM_REMAIN(S) STREAM_WRITEABLE((S))
-
 /* this macro is deprecated, but not slated for removal anytime soon */
 #define STREAM_DATA(S)  ((S)->data)
 


### PR DESCRIPTION
A couple of deprecated lib/stream macros have aged out; remove them, and replace the one remaining use.

### Components
libs, bgpd
