### PR TITLE
lib: prefix compare able to compare prefixes with family not known

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -705,6 +705,9 @@ int prefix_same(const struct prefix *p1, const struct prefix *p2)
 				    p2->u.prefix_flowspec.prefixlen))
 				return 1;
 		}
+		if (!memcmp(p1, p2,
+			    sizeof(struct prefix)))
+			return 1;
 	}
 	return 0;
 }


### PR DESCRIPTION
prefix comparison can be a byte to byte comparison, if the prefix family
to compare is not known.
This can happen when using those utilities function on the zapi layer.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
