### PR TITLE
pbrd sharpd: return check fixes (Coverity 1475198 1475199)

### DIFF
--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -361,7 +361,10 @@ static int pbr_zebra_nexthop_update(int command, struct zclient *zclient,
 	char buf[PREFIX2STR_BUFFER];
 	uint32_t i;
 
-	zapi_nexthop_update_decode(zclient->ibuf, &nhr);
+	if (!zapi_nexthop_update_decode(zclient->ibuf, &nhr)) {
+		zlog_warn("Failure to decode Nexthop update message");
+		return 0;
+	}
 
 	if (DEBUG_MODE_CHECK(&pbr_dbg_zebra, DEBUG_MODE_ALL)) {
 

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -223,7 +223,9 @@ void sharp_zebra_nexthop_watch(struct prefix *p, bool watch)
 	if (!watch)
 		command = ZEBRA_NEXTHOP_UNREGISTER;
 
-	zclient_send_rnh(zclient, command, p, true, VRF_DEFAULT);
+	if (zclient_send_rnh(zclient, command, p, true, VRF_DEFAULT) < 0)
+		zlog_warn("%s: Failure to send nexthop to zebra",
+			  __PRETTY_FUNCTION__);
 }
 
 static int sharp_nexthop_update(int command, struct zclient *zclient,


### PR DESCRIPTION
### Summary

sharpd: return check (Coverity 1475198): not checked, using (void) for indicating we're aware.

pbrd: return check (Coverity 1475199): in other places where zapi_nexthop_update_decode() was called the return is checked. In order to avoid behavior, a debug log has been added for nexthop decode error.

### Components

pbrd sharpd
