### PR TITLE
bgpd: partially revert e23b9ef6d271223d29c7f91a10d98aa6dcd252b3

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -578,7 +578,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 		return bpi;
 	}
 
-	new = info_make(bpi_ultimate->type, bpi_ultimate->sub_type, 0,
+	new = info_make(bpi_ultimate->type, BGP_ROUTE_IMPORTED, 0,
 		bgp->peer_self, new_attr, bn);
 
 	if (nexthop_self_flag)


### PR DESCRIPTION
partially revert e23b9ef6d271223d29c7f91a10d98aa6dcd252b3
      previous change was to fix rnh module in Zebra for leaked routes
      this reverts that fix, so probably reintroduces the problem.

bgpd 
