### PR TITLE
6.x: bfdd: fix multihop on FreeBSD

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -761,6 +761,9 @@ static ssize_t bfd_recv_ipv4(int sd, bool is_mhop, char *port, size_t portlen,
 
 			local->sa_sin.sin_family = AF_INET;
 			local->sa_sin.sin_addr = pi->ipi_addr;
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+			local->sa_sin.sin_len = sizeof(local->sa_sin);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 			fetch_portname_from_ifindex(pi->ipi_ifindex, port,
 						    portlen);
 			break;
@@ -787,6 +790,9 @@ static ssize_t bfd_recv_ipv4(int sd, bool is_mhop, char *port, size_t portlen,
 			memcpy(&ia, CMSG_DATA(cm), sizeof(ia));
 			local->sa_sin.sin_family = AF_INET;
 			local->sa_sin.sin_addr = ia;
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+			local->sa_sin.sin_len = sizeof(local->sa_sin);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 			break;
 		}
 #endif /* BFD_BSD */
@@ -867,8 +873,11 @@ ssize_t bfd_recv_ipv6(int sd, bool is_mhop, char *port, size_t portlen,
 		} else if (cm->cmsg_type == IPV6_PKTINFO) {
 			pi6 = (struct in6_pktinfo *)CMSG_DATA(cm);
 			if (pi6) {
-				local->sa_sin.sin_family = AF_INET6;
+				local->sa_sin6.sin6_family = AF_INET6;
 				local->sa_sin6.sin6_addr = pi6->ipi6_addr;
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+				local->sa_sin6.sin6_len = sizeof(local->sa_sin6);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 				fetch_portname_from_ifindex(pi6->ipi6_ifindex,
 							    port, portlen);
 				ifindex = pi6->ipi6_ifindex;


### PR DESCRIPTION
### Summary

Some systems have a extra `struct sockaddr*` field (`_len`) which must
be filled in order for the peer lookup to work.


### Related Issue

#3382


## Related PR

#3403 


### Components

`bfdd`