### PR TITLE
Revert "tests/topotests: Change docker build context"

### DIFF
--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -70,7 +70,7 @@ RUN echo "" >> /etc/security/limits.conf; \
     echo "root hard core unlimited" >> /etc/security/limits.conf
 
 # Copy run scripts to facilitate users wanting to run the tests
-COPY tests/topotests/docker/inner /opt/topotests
+COPY docker/inner /opt/topotests
 
 WORKDIR /root/topotests
 ENV PATH "$PATH:/opt/topotests"

--- a/tests/topotests/docker/build.sh
+++ b/tests/topotests/docker/build.sh
@@ -22,10 +22,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cd "$(dirname "$0")"/../../..
+cd "$(dirname "$0")"/..
 
 exec docker build --pull \
 		  --compress \
 		  -t frrouting/frr:topotests-latest \
-		  -f tests/topotests/Dockerfile \
 		  .


### PR DESCRIPTION
This reverts commit 659782730bffea2d21e2fa22550db3166017061e.

Apparently, the build context is inferred from the Dockerfile path.
Yay for sensible documentation. :/

See https://hub.docker.com/r/frrouting/frr/builds/bpovrdlitjyuu7jecdnzgca/ for the failing build.

One doesn't get much logs there, but I assume it's due to the docker context being `tests/topotests` and not our repository root.

Signed-off-by: Christian Franke <chris@opensourcerouting.org>