### PR TITLE
zebra: dup addr detect clear cmd non-zero return

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2313,6 +2313,7 @@ DEFPY (clear_evpn_dup_addr,
 	vni_t vni = 0;
 	struct ipaddr host_ip = {.ipa_type = IPADDR_NONE };
 	struct ethaddr mac_addr;
+	int ret = CMD_SUCCESS;
 
 	zvrf = vrf_info_lookup(VRF_DEFAULT);
 	if (vni_val) {
@@ -2320,9 +2321,10 @@ DEFPY (clear_evpn_dup_addr,
 
 		if (mac_val) {
 			prefix_str2mac(mac_val, &mac_addr);
-			zebra_vxlan_clear_dup_detect_vni_mac(vty, zvrf, vni,
-							&mac_addr);
-		} else if (ip) {
+			ret = zebra_vxlan_clear_dup_detect_vni_mac(vty, zvrf,
+								   vni,
+								   &mac_addr);
+	        } else if (ip) {
 			if (sockunion_family(ip) == AF_INET) {
 				host_ip.ipa_type = IPADDR_V4;
 				host_ip.ipaddr_v4.s_addr = sockunion2ip(ip);
@@ -2331,16 +2333,17 @@ DEFPY (clear_evpn_dup_addr,
 				memcpy(&host_ip.ipaddr_v6, &ip->sin6.sin6_addr,
 				       sizeof(struct in6_addr));
 			}
-			zebra_vxlan_clear_dup_detect_vni_ip(vty, zvrf, vni,
-							    &host_ip);
+			ret = zebra_vxlan_clear_dup_detect_vni_ip(vty, zvrf,
+								  vni,
+								  &host_ip);
 		} else
-			zebra_vxlan_clear_dup_detect_vni(vty, zvrf, vni);
+			ret = zebra_vxlan_clear_dup_detect_vni(vty, zvrf, vni);
 
 	} else {
-		zebra_vxlan_clear_dup_detect_vni_all(vty, zvrf);
+		ret = zebra_vxlan_clear_dup_detect_vni_all(vty, zvrf);
 	}
 
-	return CMD_SUCCESS;
+	return ret;
 }
 
 /* Static ip route configuration write function. */

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -185,17 +185,17 @@ extern void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id,
 extern void zebra_vxlan_evpn_vrf_route_del(vrf_id_t vrf_id,
 					   struct ipaddr *vtep_ip,
 					   struct prefix *host_prefix);
-extern void zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
-						 struct zebra_vrf *zvrf,
-						 vni_t vni,
-						 struct ethaddr *macaddr);
-extern void zebra_vxlan_clear_dup_detect_vni_ip(struct vty *vty,
+extern int zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
 						struct zebra_vrf *zvrf,
-						vni_t vni, struct ipaddr *ip);
-extern void zebra_vxlan_clear_dup_detect_vni_all(struct vty *vty,
-						 struct zebra_vrf *zvrf);
-extern void zebra_vxlan_clear_dup_detect_vni(struct vty *vty,
-					     struct zebra_vrf *zvrf,
-					     vni_t vni);
+						vni_t vni,
+						struct ethaddr *macaddr);
+extern int zebra_vxlan_clear_dup_detect_vni_ip(struct vty *vty,
+					       struct zebra_vrf *zvrf,
+					       vni_t vni, struct ipaddr *ip);
+extern int zebra_vxlan_clear_dup_detect_vni_all(struct vty *vty,
+						struct zebra_vrf *zvrf);
+extern int zebra_vxlan_clear_dup_detect_vni(struct vty *vty,
+					    struct zebra_vrf *zvrf,
+					    vni_t vni);
 
 #endif /* _ZEBRA_VXLAN_H */


### PR DESCRIPTION


### Summary
EVPN Clear duplicate address vni  command needs to return non-zero value
in case of command is not successful.

Testing Done:
run clear command and check upon failure return code is non-zero.

root@TORS1:~# vtysh -c "clear evpn dup-addr vni 1000 ip 45.0.1.26"
% Requested IP's associated MAC 00:01:02:03:04:05 is still in duplicate
% state
root@TORS1:~# echo $?
1

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>

### Related Issue
[fill here if applicable]

### Components
zebra
