### PR TITLE
bgpd: reuse bgp_path_info_extra_free() routing in rfapi

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -176,7 +176,7 @@ static struct bgp_path_info_extra *bgp_path_info_extra_new(void)
 	return new;
 }
 
-static void bgp_path_info_extra_free(struct bgp_path_info_extra **extra)
+void bgp_path_info_extra_free(struct bgp_path_info_extra **extra)
 {
 	struct bgp_path_info_extra *e;
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -362,6 +362,7 @@ extern struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
 extern struct bgp_path_info *bgp_path_info_lock(struct bgp_path_info *path);
 extern struct bgp_path_info *bgp_path_info_unlock(struct bgp_path_info *path);
 extern void bgp_path_info_add(struct bgp_node *rn, struct bgp_path_info *pi);
+extern void bgp_path_info_extra_free(struct bgp_path_info_extra **extra);
 extern void bgp_path_info_reap(struct bgp_node *rn, struct bgp_path_info *pi);
 extern void bgp_path_info_delete(struct bgp_node *rn, struct bgp_path_info *pi);
 extern struct bgp_path_info_extra *

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -550,11 +550,8 @@ static void rfapiBgpInfoFree(struct bgp_path_info *goner)
 	if (goner->attr) {
 		bgp_attr_unintern(&goner->attr);
 	}
-	if (goner->extra) {
-		assert(!goner->extra->damp_info); /* Not used in import tbls */
-		XFREE(MTYPE_BGP_ROUTE_EXTRA, goner->extra);
-		goner->extra = NULL;
-	}
+	if (goner->extra)
+		bgp_path_info_extra_free(&goner->extra);
 	XFREE(MTYPE_BGP_ROUTE, goner);
 }
 


### PR DESCRIPTION
rfapi code should use bgp_path_info_extra_free() routine.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
