### PR TITLE
bgpd: delay destruction of label pool

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -235,6 +235,9 @@ static __attribute__((__noreturn__)) void bgp_exit(int status)
 
 	bf_free(bm->rd_idspace);
 	list_delete(&bm->bgp);
+
+	bgp_lp_finish();
+
 	memset(bm, 0, sizeof(*bm));
 
 	frr_fini();

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7963,5 +7963,4 @@ void bgp_terminate(void)
 	if (bm->t_rmap_update)
 		BGP_TIMER_OFF(bm->t_rmap_update);
 
-	bgp_lp_finish();
 }


### PR DESCRIPTION
label pool finalisation must be delayed after route deletion on bgp.
otherwise a crash will happen, while labels will be released.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
