### PR TITLE
zebra: `show ip route A.B.C.D json` would only show last route entry

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -732,15 +732,14 @@ static void vty_show_ip_route_detail_json(struct vty *vty,
 	char buf[BUFSIZ];
 
 	json = json_object_new_object();
+	json_prefix = json_object_new_array();
 
 	RNODE_FOREACH_RE (rn, re) {
-		json_prefix = json_object_new_array();
 		vty_show_ip_route(vty, rn, re, json_prefix);
-		prefix2str(&rn->p, buf, sizeof buf);
-		json_object_object_add(json, buf, json_prefix);
-		json_prefix = NULL;
 	}
 
+	prefix2str(&rn->p, buf, sizeof(buf));
+	json_object_object_add(json, buf, json_prefix);
 	vty_out(vty, "%s\n", json_object_to_json_string_ext(
 					     json, JSON_C_TO_STRING_PRETTY));
 	json_object_free(json);


### PR DESCRIPTION
The `show ip route A.B.C.D json` command was only displaying
the last route entry looked at and we would drop the data
associated with other route entries.  This fixes the issue:

robot# show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route

K>* 0.0.0.0/0 [0/100] via 192.168.201.1, enp3s0, 00:13:31
C>* 4.50.50.50/32 is directly connected, lo, 00:13:31
D   10.0.0.1/32 [150/0] via 192.168.201.1, enp3s0, 00:09:46
S>* 10.0.0.1/32 [1/0] via 192.168.201.1, enp3s0, 00:10:04
C>* 192.168.201.0/24 is directly connected, enp3s0, 00:13:31
robot# show ip route 10.0.0.1 json
{
  "10.0.0.1\/32":[
    {
      "prefix":"10.0.0.1\/32",
      "protocol":"sharp",
      "distance":150,
      "metric":0,
      "internalStatus":0,
      "internalFlags":1,
      "uptime":"00:09:50",
      "nexthops":[
        {
          "flags":1,
          "ip":"192.168.201.1",
          "afi":"ipv4",
          "interfaceIndex":2,
          "interfaceName":"enp3s0",
          "active":true
        }
      ]
    },
    {
      "prefix":"10.0.0.1\/32",
      "protocol":"static",
      "selected":true,
      "distance":1,
      "metric":0,
      "internalStatus":0,
      "internalFlags":2064,
      "uptime":"00:10:08",
      "nexthops":[
        {
          "flags":3,
          "fib":true,
          "ip":"192.168.201.1",
          "afi":"ipv4",
          "interfaceIndex":2,
          "interfaceName":"enp3s0",
          "active":true
        }
      ]
    }
  ]
}
robot#

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>