### PR TITLE
zebra: avoid initialising more than one the l3vni hash structure

### DIFF
--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -76,7 +76,6 @@ static int zebra_ns_new(struct ns *ns)
 
 	/* Do any needed per-NS data structure allocation. */
 	zns->if_table = route_table_init();
-	zebra_vxlan_ns_init(zns);
 
 	return 0;
 }
@@ -142,7 +141,6 @@ int zebra_ns_enable(ns_id_t ns_id, void **info)
 static int zebra_ns_disable_internal(struct zebra_ns *zns, bool complete)
 {
 	route_table_finish(zns->if_table);
-	zebra_vxlan_ns_disable(zns);
 #if defined(HAVE_RTADV)
 	rtadv_terminate(zns);
 #endif
@@ -201,7 +199,6 @@ int zebra_ns_init(void)
 
 	/* Do any needed per-NS data structure allocation. */
 	dzns->if_table = route_table_init();
-	zebra_vxlan_ns_init(dzns);
 
 	/* Register zebra VRF callbacks, create and activate default VRF. */
 	zebra_vrf_init();

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -24,6 +24,7 @@
 #include "zebra_router.h"
 #include "zebra_memory.h"
 #include "zebra_pbr.h"
+#include "zebra_vxlan.h"
 
 struct zebra_router zrouter;
 
@@ -157,6 +158,7 @@ void zebra_router_terminate(void)
 		zebra_router_free_table(zrt);
 	}
 
+	zebra_vxlan_disable();
 	hash_clean(zrouter.rules_hash, zebra_pbr_rules_free);
 	hash_free(zrouter.rules_hash);
 
@@ -170,8 +172,7 @@ void zebra_router_terminate(void)
 
 void zebra_router_init(void)
 {
-	zrouter.l3vni_table = NULL;
-
+	zebra_vxlan_init();
 	zrouter.rules_hash = hash_create_size(8, zebra_pbr_rules_hash_key,
 					      zebra_pbr_rules_hash_equal,
 					      "Rules Hash");

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -8864,14 +8864,14 @@ void zebra_vxlan_close_tables(struct zebra_vrf *zvrf)
 }
 
 /* init the l3vni table */
-void zebra_vxlan_ns_init(struct zebra_ns *zns)
+void zebra_vxlan_init(void)
 {
 	zrouter.l3vni_table = hash_create(l3vni_hash_keymake, l3vni_hash_cmp,
 					  "Zebra VRF L3 VNI table");
 }
 
 /* free l3vni table */
-void zebra_vxlan_ns_disable(struct zebra_ns *zns)
+void zebra_vxlan_disable(void)
 {
 	hash_free(zrouter.l3vni_table);
 }

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -183,8 +183,8 @@ extern int zebra_vxlan_process_vrf_vni_cmd(struct zebra_vrf *zvrf, vni_t vni,
 extern void zebra_vxlan_init_tables(struct zebra_vrf *zvrf);
 extern void zebra_vxlan_close_tables(struct zebra_vrf *);
 extern void zebra_vxlan_cleanup_tables(struct zebra_vrf *);
-extern void zebra_vxlan_ns_init(struct zebra_ns *zns);
-extern void zebra_vxlan_ns_disable(struct zebra_ns *zns);
+extern void zebra_vxlan_init(void);
+extern void zebra_vxlan_disable(void);
 extern void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id,
 					   struct ethaddr *rmac,
 					   struct ipaddr *ip,


### PR DESCRIPTION
actually, when running zebra with netns parameter, because the function
is reentrant, there are risks that zrouter.l3vni_table is overwritten,
thus leading to loss of memory because some pointers would be lost.
The l3vni_hash object is inited only once.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
