### PR TITLE
ospfd: default route got flushed after lsa refresh timer.

### DIFF
--- a/ospfd/ospf_flood.c
+++ b/ospfd/ospf_flood.c
@@ -91,7 +91,7 @@ struct external_info *ospf_external_info_check(struct ospf *ospf,
 	p.prefix = lsa->data->id;
 	p.prefixlen = ip_masklen(al->mask);
 
-	for (type = 0; type < ZEBRA_ROUTE_MAX; type++) {
+	for (type = 0; type <= ZEBRA_ROUTE_MAX; type++) {
 		int redist_on = 0;
 
 		redist_on =


### PR DESCRIPTION
Default route type is not considered while  processing  lsa
refresh timer  expiry   which intern makes it flushed from lsdb.

Signed-off-by: rgirada <rgirada@vmware.com>

