### PR TITLE
tests/topotests: Also search sbin for modprobe

### DIFF
--- a/tests/topotests/docker/frr-topotests.sh
+++ b/tests/topotests/docker/frr-topotests.sh
@@ -80,6 +80,8 @@ fi
 # them from the host however, they can be used just fine.
 #
 
+export PATH="$PATH:/sbin:/usr/sbin:/usr/local/sbin"
+
 for module in mpls-router mpls-iptunnel; do
 	if modprobe -n $module 2> /dev/null; then
 		:


### PR DESCRIPTION
We call `modprobe -n` to check if mpls modules are available to be
loaded. We do this as normal user, to only ask for root permissions
if we are actually loading the module.

This breaks if `modprobe` is in `/sbin` and normal users don't have
sbin in path.

So add `/sbin` to the search path to work around this.

Signed-off-by: Christian Franke <chris@opensourcerouting.org>