### PR TITLE
tests/topotests: Use copied tests in Docker

### DIFF
--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -72,7 +72,6 @@ RUN echo "" >> /etc/security/limits.conf; \
 # Copy run scripts to facilitate users wanting to run the tests
 COPY docker/inner /opt/topotests
 
-WORKDIR /root/topotests
 ENV PATH "$PATH:/opt/topotests"
 
 RUN echo "cat /opt/topotests/motd.txt" >> /root/.profile && \

--- a/tests/topotests/docker/frr-topotests.sh
+++ b/tests/topotests/docker/frr-topotests.sh
@@ -133,7 +133,6 @@ fi
 set -- --rm -i \
 	-v "$TOPOTEST_LOGS:/tmp" \
 	-v "$TOPOTEST_FRR:/root/host-frr:ro" \
-	-v "$TOPOTEST_FRR/tests/topotests:/root/topotests:ro" \
 	-v "$TOPOTEST_BUILDCACHE:/root/persist" \
 	-e "TOPOTEST_CLEAN=$TOPOTEST_CLEAN" \
 	-e "TOPOTEST_VERBOSE=$TOPOTEST_VERBOSE" \

--- a/tests/topotests/docker/inner/entrypoint.sh
+++ b/tests/topotests/docker/inner/entrypoint.sh
@@ -34,6 +34,8 @@ set -e
 "${CDIR}/compile_frr.sh"
 "${CDIR}/openvswitch.sh"
 
+cd "${FRR_BUILD_DIR}/tests/topotests"
+
 log_info "Setting permissions on /tmp so we can generate logs"
 chmod 1777 /tmp
 
@@ -42,7 +44,6 @@ if [ $# -eq 0 ] || ([[ "$1" != /* ]] && [[ "$1" != ./* ]]); then
 	export TOPOTESTS_CHECK_STDERR=Yes
 	set -- pytest \
 		--junitxml /tmp/topotests.xml \
-		-o cache_dir=/tmp \
 		"$@"
 fi
 


### PR DESCRIPTION
If we mount the tests into the container from the host, we also
mount any `*.pyc` files with them, which will lead to issues
as the mount is done read-only to avoid any changes to the host.

Since the tests are now integrated and we already create a writeable
copy of the FRR tree, just use the tests from the FRR tree to avoid
this issue.

Signed-off-by: Christian Franke <chris@opensourcerouting.org>