### PR TITLE
bgpd: don't show default value in configuration

### DIFF
--- a/bgpd/rfp-example/librfp/rfp_example.c
+++ b/bgpd/rfp-example/librfp/rfp_example.c
@@ -255,8 +255,8 @@ static int rfp_cfg_write_cb(struct vty *vty, void *rfp_start_val)
 			rfi->rfapi_config.holddown_factor);
 		write++;
 	}
-	if (rfi->rfapi_config.download_type != RFAPI_RFP_DOWNLOAD_FULL) {
-		vty_out(vty, " rfp full-table-download off\n");
+	if (rfi->rfapi_config.download_type == RFAPI_RFP_DOWNLOAD_FULL) {
+		vty_out(vty, " rfp full-table-download on\n");
 		write++;
 	}
 	return write;


### PR DESCRIPTION
### Summary

Don't show the configuration line `rfp full-table-download off` by
default as it is not the default value, instead only show
`rfp full-table-download on` (the non-default value) when it is
configured.

This standardizes this knob to the FRR default behavior.

You can find more evidence of this through the code:
https://github.com/FRRouting/frr/blob/master/bgpd/rfapi/bgp_rfapi_cfg.c#L4582

```c
	vty_out(vty, "%-39s %-19s %s\n", "RFP Full table download:",
		(hc->rfp_cfg.download_type == RFAPI_RFP_DOWNLOAD_FULL ? "On"
								      : "Off"),
		(hc->rfp_cfg.download_type == RFAPI_RFP_DOWNLOAD_PARTIAL
			 ? "(default)"
: ""));
```

And here:
https://github.com/FRRouting/frr/blob/master/bgpd/rfapi/rfapi.h#L315

```c
	/* partial or full table download */
	rfapi_rfp_download_type download_type; /* default=partial */
```

Another thing that I've noticed is that, even though this line shows up in `show running-config`, there are no commands available to configure/unconfigure it. It is also annoying to have it showing up in the configuration when you can't copy & paste it!

This is my normal `configure` line:

```sh
./configure \
	--disable-doc \
	--enable-sharpd \
	--enable-fpm \
	--enable-multipath=64 \
	--prefix=/usr/local \
	--localstatedir=/var/run/frr \
	--sysconfdir=/usr/local/etc/frr \
	--enable-pkgsrcrcdir=/usr/pkg/share/examples/rc.d \
	--enable-configfile-mask=0640 \
	--enable-logfile-mask=0640 \
	--enable-user=frr \
	--enable-group=frr \
	--enable-vty-group=frrvty \
	--enable-dev-build \
	--with-pkg-git-version
```


### Components

`bgpd`