### PR TITLE
lib: add support for confirmed commits

### DIFF
--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -653,7 +653,7 @@ struct thread_master *frr_init(void)
 	lib_error_init();
 
 	yang_init();
-	nb_init(di->yang_modules, di->n_yang_modules);
+	nb_init(master, di->yang_modules, di->n_yang_modules);
 
 	return master;
 }

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -1539,7 +1539,8 @@ static void nb_load_callbacks(const struct frr_yang_module_info *module)
 	}
 }
 
-void nb_init(const struct frr_yang_module_info *modules[], size_t nmodules)
+void nb_init(struct thread_master *tm,
+	     const struct frr_yang_module_info *modules[], size_t nmodules)
 {
 	unsigned int errors = 0;
 
@@ -1574,7 +1575,7 @@ void nb_init(const struct frr_yang_module_info *modules[], size_t nmodules)
 	running_config = nb_config_new(NULL);
 
 	/* Initialize the northbound CLI. */
-	nb_cli_init();
+	nb_cli_init(tm);
 }
 
 void nb_terminate(void)

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -20,6 +20,7 @@
 #ifndef _FRR_NORTHBOUND_H_
 #define _FRR_NORTHBOUND_H_
 
+#include "thread.h"
 #include "hook.h"
 #include "linklist.h"
 #include "openbsd-tree.h"
@@ -825,7 +826,7 @@ extern const char *nb_client_name(enum nb_client client);
  * nmodules
  *    Size of the modules array.
  */
-extern void nb_init(const struct frr_yang_module_info *modules[],
+extern void nb_init(struct thread_master *tm, const struct frr_yang_module_info *modules[],
 		    size_t nmodules);
 
 /*

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -105,8 +105,10 @@ extern void nb_cli_show_dnode_cmds(struct vty *vty, struct lyd_node *dnode,
 				   bool show_defaults);
 
 /* Prototypes of internal functions. */
+extern void nb_cli_confirmed_commit_clean(struct vty *vty);
+extern int nb_cli_confirmed_commit_rollback(struct vty *vty);
 extern void nb_cli_install_default(int node);
-extern void nb_cli_init(void);
+extern void nb_cli_init(struct thread_master *tm);
 extern void nb_cli_terminate(void);
 
 #endif /* _FRR_NORTHBOUND_CLI_H_ */

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2714,6 +2714,14 @@ int vty_config_enter(struct vty *vty, bool private_config, bool exclusive)
 
 void vty_config_exit(struct vty *vty)
 {
+	/* Check if there's a pending confirmed commit. */
+	if (vty->t_confirmed_commit_timeout) {
+		vty_out(vty,
+			"WARNING: exiting with a pending confirmed commit. Rolling back to previous configuration.\n\n");
+		nb_cli_confirmed_commit_rollback(vty);
+		nb_cli_confirmed_commit_clean(vty);
+	}
+
 	vty_config_exclusive_unlock(vty);
 
 	if (vty->candidate_config) {

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -126,6 +126,10 @@ struct vty {
 	/* Base candidate configuration. */
 	struct nb_config *candidate_config_base;
 
+	/* Confirmed-commit timeout and rollback configuration. */
+	struct thread *t_confirmed_commit_timeout;
+	struct nb_config *confirmed_commit_rollback;
+
 	/* qobj object ID (replacement for "index") */
 	uint64_t qobj_index;
 

--- a/tests/bgpd/test_peer_attr.c
+++ b/tests/bgpd/test_peer_attr.c
@@ -1384,10 +1384,10 @@ static void bgp_startup(void)
 		 LOG_DAEMON);
 	zprivs_preinit(&bgpd_privs);
 	zprivs_init(&bgpd_privs);
-	yang_init();
-	nb_init(NULL, 0);
 
 	master = thread_master_create(NULL);
+	yang_init();
+	nb_init(master, NULL, 0);
 	bgp_master_init(master);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 	vrf_init(NULL, NULL, NULL, NULL, NULL);

--- a/tests/helpers/c/main.c
+++ b/tests/helpers/c/main.c
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
 	vty_init(master);
 	memory_init();
 	yang_init();
-	nb_init(NULL, 0);
+	nb_init(master, NULL, 0);
 
 	/* OSPF vty inits. */
 	test_vty_init();

--- a/tests/lib/cli/common_cli.c
+++ b/tests/lib/cli/common_cli.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 	vty_init(master);
 	memory_init();
 	yang_init();
-	nb_init(NULL, 0);
+	nb_init(master, NULL, 0);
 
 	test_init(argc, argv);
 

--- a/tests/lib/cli/test_commands.c
+++ b/tests/lib/cli/test_commands.c
@@ -143,7 +143,7 @@ static void test_init(void)
 
 	cmd_init(1);
 	yang_init();
-	nb_init(NULL, 0);
+	nb_init(master, NULL, 0);
 
 	install_node(&bgp_node, NULL);
 	install_node(&rip_node, NULL);

--- a/tests/lib/northbound/test_oper_data.c
+++ b/tests/lib/northbound/test_oper_data.c
@@ -449,7 +449,7 @@ int main(int argc, char **argv)
 	vty_init(master);
 	memory_init();
 	yang_init();
-	nb_init(modules, array_size(modules));
+	nb_init(master, modules, array_size(modules));
 
 	/* Create artificial data. */
 	create_data(num_vrfs, num_interfaces, num_routes);


### PR DESCRIPTION
### Summary
Confirmed commits allow the user to request an automatic rollback to
the previous configuration if the commit operation is not confirmed
within a number of minutes. This is particularly useful when the user
is accessing the CLI through the network (e.g. using SSH) and any
configuration change might cause an unexpected loss of connectivity
between the user and the managed device (e.g. misconfiguration of a
routing protocol). By using a confirmed commit, the user can rest
assured the connectivity will be restored after the given timeout
expires, avoiding the need to access the router physically to fix
the problem.

When "commit confirmed TIMEOUT" is used, a new "commit" command is
expected to confirm the previous commit before the given timeout
expires. If "commit confirmed TIMEOUT" is used while there's already
a confirmed-commit in progress, the confirmed-commit timeout is
reset to the new value.

In the current implementation, if other users perform commits while
there's a confirmed-commit in progress, all commits are rolled back
when the confirmed-commit timeout expires. It's recommended to use
the "configure exclusive" configuration mode to prevent unexpected
outcomes when using confirmed commits.

When an user exits from the configuration mode while there's a
confirmed-commit in progress, the commit is automatically rolled
back and the user is notified about it. In the future we might
want to prompt the user if he or she really wants to exit from the
configuration mode when there's a pending confirmed commit.

Needless to say, confirmed commit only work for configuration
commands converted to the new northbound model. vtysh support will
be implemented at a later time.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>

### Components
[lib, tests]
