### PR TITLE
lib: implement the "show" command

### DIFF
--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -754,6 +754,30 @@ DEFPY (show_config_candidate,
 	return CMD_SUCCESS;
 }
 
+DEFPY (show_config_candidate_section,
+       show_config_candidate_section_cmd,
+       "show",
+       SHOW_STR)
+{
+	struct lyd_node *dnode;
+
+	/* Top-level configuration node, display everything. */
+	if (vty->xpath_index == 0)
+		return nb_cli_show_config(vty, vty->candidate_config,
+					  NB_CFG_FMT_CMDS, NULL, false);
+
+	/* Display only the current section of the candidate configuration. */
+	dnode = yang_dnode_get(vty->candidate_config->dnode, VTY_CURR_XPATH);
+	if (!dnode)
+		/* Shouldn't happen. */
+		return CMD_WARNING;
+
+	nb_cli_show_dnode_cmds(vty, dnode, 0);
+	vty_out(vty, "!\n");
+
+	return CMD_SUCCESS;
+}
+
 DEFPY (show_config_compare,
        show_config_compare_cmd,
        "show configuration compare\
@@ -1468,6 +1492,8 @@ static struct cmd_node nb_debug_node = {NORTHBOUND_DEBUG_NODE, "", 1};
 
 void nb_cli_install_default(int node)
 {
+	install_element(node, &show_config_candidate_section_cmd);
+
 	if (frr_get_cli_mode() != FRR_CLI_TRANSACTIONAL)
 		return;
 


### PR DESCRIPTION
### Summary
The "show" command will be available in the configuration mode and
all configuration subnodes. It's used to display the section of
the candidate configuration being edited, instead of displaying
the entire candidate configuration like when "show configuration
candidate" is used. The goal is to add more convenience when editing
huge configurations.

When the transactional CLI mode is not used, the candidate
configuration and the running configuration are identical, hence in
this case we can say that the "show" command displays the section
of the running configuration being edited.

Example:
```
ripd(config)# show
Configuration:
!
frr version 6.1-dev
frr defaults traditional
!
interface eth0
 ip rip split-horizon poisoned-reverse
 ip rip authentication mode md5
 ip rip authentication string supersecret
!
interface eth1
 ip rip receive version 1
 ip rip send version 1
!
router rip
 allow-ecmp
 route 10.0.1.0/24
 route 10.0.2.0/24
!
end
ripd(config)#
ripd(config)#
ripd(config)# interface eth0
ripd(config-if)# show
!
interface eth0
 ip rip split-horizon poisoned-reverse
 ip rip authentication mode md5
 ip rip authentication string supersecret
!
ripd(config-if)# exit
ripd(config)#
ripd(config)#
ripd(config)# router rip
ripd(config-router)# show
!
router rip
 allow-ecmp
 route 10.0.1.0/24
 route 10.0.2.0/24
!
ripd(config-router)#
```

The "show" command only works for daemons converted to the new
northbound model. vtysh support will be implemented at a later
time as it will require some level of coordination between vtysh
and the FRR daemons.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>

### Related Issue
Fixes #3148.

### Components
[lib]
