### PR TITLE
bgpd: Convert adj_out to a RB tree

### DIFF
--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -154,7 +154,7 @@ int bgp_adj_out_lookup(struct peer *peer, struct bgp_node *rn,
 	safi_t safi;
 	int addpath_capable;
 
-	for (adj = rn->adj_out; adj; adj = adj->next)
+	RB_FOREACH (adj, bgp_adj_out_rb, &rn->adj_out)
 		SUBGRP_FOREACH_PEER (adj->subgroup, paf)
 			if (paf->peer == peer) {
 				afi = SUBGRP_AFI(adj->subgroup);

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -67,9 +67,8 @@ struct bgp_advertise {
 
 /* BGP adjacency out.  */
 struct bgp_adj_out {
-	/* Lined list pointer.  */
-	struct bgp_adj_out *next;
-	struct bgp_adj_out *prev;
+	/* RB Tree of adjacency entries */
+	RB_ENTRY(bgp_adj_out) adj_entry;
 
 	/* Advertised subgroup.  */
 	struct update_subgroup *subgroup;
@@ -88,6 +87,10 @@ struct bgp_adj_out {
 	/* Advertisement information.  */
 	struct bgp_advertise *adv;
 };
+
+RB_HEAD(bgp_adj_out_rb, bgp_adj_out);
+RB_PROTOTYPE(bgp_adj_out_rb, bgp_adj_out, adj_entry,
+	     bgp_adj_out_compare);
 
 /* BGP adjacency in. */
 struct bgp_adj_in {
@@ -134,8 +137,6 @@ struct bgp_synchronize {
 
 #define BGP_ADJ_IN_ADD(N, A) BGP_PATH_INFO_ADD(N, A, adj_in)
 #define BGP_ADJ_IN_DEL(N, A) BGP_PATH_INFO_DEL(N, A, adj_in)
-#define BGP_ADJ_OUT_ADD(N, A) BGP_PATH_INFO_ADD(N, A, adj_out)
-#define BGP_ADJ_OUT_DEL(N, A) BGP_PATH_INFO_DEL(N, A, adj_out)
 
 #define BGP_ADV_FIFO_ADD(F, N)                                                 \
 	do {                                                                   \

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10560,7 +10560,7 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 				output_count++;
 			}
 		} else if (type == bgp_show_adj_route_advertised) {
-			for (adj = rn->adj_out; adj; adj = adj->next)
+			RB_FOREACH (adj, bgp_adj_out_rb, &rn->adj_out)
 				SUBGRP_FOREACH_PEER (adj->subgroup, paf) {
 					if (paf->peer != peer || !adj->attr)
 						continue;

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -67,6 +67,8 @@ static struct route_node *bgp_node_create(route_table_delegate_t *delegate,
 {
 	struct bgp_node *node;
 	node = XCALLOC(MTYPE_BGP_NODE, sizeof(struct bgp_node));
+
+	RB_INIT(bgp_adj_out_rb, &node->adj_out);
 	return bgp_node_to_rnode(node);
 }
 

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -26,6 +26,7 @@
 #include "queue.h"
 #include "linklist.h"
 #include "bgpd.h"
+#include "bgp_advertise.h"
 
 struct bgp_table {
 	/* table belongs to this instance */
@@ -52,7 +53,7 @@ struct bgp_node {
 	 */
 	ROUTE_NODE_FIELDS
 
-	struct bgp_adj_out *adj_out;
+	struct bgp_adj_out_rb adj_out;
 
 	struct bgp_adj_in *adj_in;
 


### PR DESCRIPTION
The adj_out data structure is a linked list of adjacencies
1 per update group.  In a large scale env where we are
not using peer groups, this list lookup starts to become
rather costly.  Convert to a better data structure for this.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

