### PR TITLE
[6.0] build reproducibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_SUBST(PACKAGE_URL)
 PACKAGE_FULLNAME="FRRouting"
 AC_SUBST(PACKAGE_FULLNAME)
 
-CONFIG_ARGS="$ac_configure_args"
+CONFIG_ARGS="`echo $ac_configure_args | sed -e \"s% '[[A-Z]]*FLAGS=[[^']]\+'%%g\"`"
 AC_SUBST(CONFIG_ARGS)
 
 AC_CONFIG_SRCDIR(lib/zebra.h)

--- a/tests/lib/cli/common_cli.c
+++ b/tests/lib/cli/common_cli.c
@@ -78,6 +78,7 @@ int main(int argc, char **argv)
 	/* Library inits. */
 	cmd_init(1);
 	cmd_hostname_set("test");
+	cmd_domainname_set("test.domain");
 
 	vty_init(master);
 	memory_init();

--- a/tests/lib/cli/test_cli.refout.in
+++ b/tests/lib/cli/test_cli.refout.in
@@ -311,6 +311,7 @@ frr version @PACKAGE_VERSION@
 frr defaults @DFLT_NAME@
 !
 hostname test
+domainname test.domain
 !
 !
 line vty
@@ -326,6 +327,7 @@ frr version @PACKAGE_VERSION@
 frr defaults @DFLT_NAME@
 !
 hostname foohost
+domainname test.domain
 !
 !
 line vty


### PR DESCRIPTION
Just a few lines of easy fixes.  With this, build is 100% reproducible, i.e. if you use the same set of build dependencies (compiler, etc.) you get the exact same binary again if you build with the same options (but maybe on a different host as a different user in a different directory.)