### PR TITLE
bgpd: re-add spelling error in JSON output

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -9722,7 +9722,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 								json_object_string_add(
 									json_nxt,
 									print_store,
-									"received");
+									"recieved"); /* misspelled for compatibility */
 							}
 						}
 						json_object_object_add(


### PR DESCRIPTION
I bulk-fixed "recieved" as a misspelling in 0437e10... but didn't notice
there was a JSON value among these.