### PR TITLE
bgpd: Back out rest of e23b9ef6d2

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -578,7 +578,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 		return bpi;
 	}
 
-	new = info_make(bpi_ultimate->type, BGP_ROUTE_IMPORTED, 0,
+	new = info_make(ZEBRA_ROUTE_BGP, BGP_ROUTE_IMPORTED, 0,
 		bgp->peer_self, new_attr, bn);
 
 	if (nexthop_self_flag)


### PR DESCRIPTION
Fully revert the rest of the e23b9ef6d2 commit as that it was breaking
route leaking between vrf's.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

