### PR TITLE
tests/topotests: Pull docker image from registry

### DIFF
--- a/tests/topotests/docker/README.md
+++ b/tests/topotests/docker/README.md
@@ -10,19 +10,15 @@ Your current user needs to have access to the Docker daemon. Alternatively
 you can run these commands as root.
 
 ```console
-make topotests-build
 make topotests
 ```
 
-The first command will build a docker image with all the dependencies needed
-to run the topotests.
-
-The second command will spawn an instance of this image, compile FRR inside
+This command will pull the most recent topotests image from dockerhub, compile FRR inside
 of it, and run the topotests.
 
 ## Advanced Usage
 
-Internally, the topotests make target uses a shell script to spawn the docker
+Internally, the topotests make target uses a shell script to pull the image and spawn the docker
 container.
 
 There are several environment variables which can be used to modify the behavior
@@ -54,4 +50,23 @@ And to compile FRR but drop into a shell instead of running pytest:
 
 ```console
 ./tests/topotests/docker/frr-topotests.sh /bin/bash
+```
+
+## Development
+
+The docker image just includes all the components to run the topotests, but not the topotests
+themselves. So if you just want to write tests and don't want to make changes to the environment
+provided by the docker image. You don't need to build your own docker image if you do not want to.
+
+When developing new tests, there is one caveat though: The startup script of the container will
+run a `git-clean` on its copy of the FRR tree to avoid any pollution of the container with build
+artefacts from the host. This will also result in your newly written tests being unavailable in the
+container unless at least added to the index with `git-add`.
+
+If you do want to test changes to the docker image, you can locally build the image and run the tests
+without pulling from the registry using the following commands:
+
+```console
+make topotests-build
+TOPOTEST_PULL=0 make topotests
 ```

--- a/tests/topotests/docker/frr-topotests.sh
+++ b/tests/topotests/docker/frr-topotests.sh
@@ -61,6 +61,9 @@ if [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
 	TOPOTEST_OPTIONS        These options are appended to the docker-run
 	                        command for starting the tests.
 
+	TOPOTEST_PULL           If set to 0, don't try to pull the most recent
+	                        version of the docker image from dockerhub.
+
 	TOPOTEST_SANITIZER      Controls whether to use the address sanitizer.
 	                        Enabled by default, set to 0 to disable.
 
@@ -130,6 +133,10 @@ if [ -z "$TOPOTEST_BUILDCACHE" ]; then
 	TOPOTEST_BUILDCACHE=topotest-buildcache
 	docker volume inspect "${TOPOTEST_BUILDCACHE}" &> /dev/null \
 		|| docker volume create "${TOPOTEST_BUILDCACHE}"
+fi
+
+if [ "${TOPOTEST_PULL:-1}" = "1" ]; then
+	docker pull frrouting/frr:topotests-latest
 fi
 
 set -- --rm -i \


### PR DESCRIPTION
We have set up automated builds for the topotest images at dockerhub.
Therefore, people don't need to perform a local build to run the
topotests on docker, but can use the image built by dockerhub.

As there is not much benefit in building locally, but the disadvantage
of weird errors if using an outdated image, change the topotests target
to always pull the most recent image from dockerhub.

Add an environment variable to disable this, e.g. for local development.

Signed-off-by: Christian Franke <chris@opensourcerouting.org>