### PR TITLE
Allow Class E addresses throughout FRR

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1286,7 +1286,7 @@ static bgp_attr_parse_ret_t bgp_attr_nexthop(struct bgp_attr_parser_args *args)
 	nexthop_n = stream_get_ipv4(peer->curr);
 	nexthop_h = ntohl(nexthop_n);
 	if ((IPV4_NET0(nexthop_h) || IPV4_NET127(nexthop_h)
-	     || IPV4_CLASS_DE(nexthop_h))
+	     || IPV4_CLASS_D(nexthop_h) || IPV4_BROADCAST(nexthop_h))
 	    && !BGP_DEBUG(
 		       allow_martians,
 		       ALLOW_MARTIANS)) /* loopbacks may be used in testing */

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1149,7 +1149,8 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	}
 
 	/* remote router-id check. */
-	if (remote_id.s_addr == 0 || IPV4_CLASS_DE(ntohl(remote_id.s_addr))
+	if (remote_id.s_addr == 0 || IPV4_CLASS_D(ntohl(remote_id.s_addr))
+	    || IPV4_BROADCAST(remote_id.s_addr)
 	    || ntohl(peer->local_id.s_addr) == ntohl(remote_id.s_addr)) {
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s bad OPEN, wrong router identifier %s",

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2867,7 +2867,8 @@ static int bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 	/* If NEXT_HOP is present, validate it. */
 	if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP)) {
 		if (attr->nexthop.s_addr == 0
-		    || IPV4_CLASS_DE(ntohl(attr->nexthop.s_addr))
+		    || IPV4_CLASS_D(ntohl(attr->nexthop.s_addr))
+		    || IPV4_BROADCAST(attr->nexthop.s_addr)
 		    || bgp_nexthop_self(bgp, attr->nexthop))
 			return 1;
 	}
@@ -2882,7 +2883,9 @@ static int bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 		case BGP_ATTR_NHLEN_IPV4:
 		case BGP_ATTR_NHLEN_VPNV4:
 			ret = (attr->mp_nexthop_global_in.s_addr == 0
-			       || IPV4_CLASS_DE(ntohl(
+			       || IPV4_BROADCAST(
+					  attr->mp_nexthop_global_in.s_addr)
+			       || IPV4_CLASS_D(ntohl(
 					  attr->mp_nexthop_global_in.s_addr))
 			       || bgp_nexthop_self(bgp,
 						   attr->mp_nexthop_global_in));

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -329,7 +329,8 @@ static inline void ipv4_addr_copy(struct in_addr *dst,
 #define IPV4_NET0(a) ((((uint32_t)(a)) & 0xff000000) == 0x00000000)
 #define IPV4_NET127(a) ((((uint32_t)(a)) & 0xff000000) == 0x7f000000)
 #define IPV4_LINKLOCAL(a) ((((uint32_t)(a)) & 0xffff0000) == 0xa9fe0000)
-#define IPV4_CLASS_DE(a) ((((uint32_t)(a)) & 0xe0000000) == 0xe0000000)
+#define IPV4_CLASS_D(a) ((((uint32_t)(a)) & 0xf0000000) == 0xe0000000)
+#define IPV4_BROADCAST(a) (((uint32_t)(a)) == 0xffffffff)
 #define IPV4_MC_LINKLOCAL(a) ((((uint32_t)(a)) & 0xffffff00) == 0xe0000000)
 
 /* Max bit/byte length of IPv6 address. */
@@ -465,7 +466,8 @@ static inline int ipv4_martian(struct in_addr *addr)
 {
 	in_addr_t ip = ntohl(addr->s_addr);
 
-	if (IPV4_NET0(ip) || IPV4_NET127(ip) || IPV4_CLASS_DE(ip)) {
+	if (IPV4_NET0(ip) || IPV4_NET127(ip) || IPV4_CLASS_D(ip)
+	    || IPV4_BROADCAST(ip)) {
 		return 1;
 	}
 	return 0;

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -2357,9 +2357,10 @@ DEFUN (set_ip_nexthop,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 	if (su.sin.sin_addr.s_addr == 0
-	    || IPV4_CLASS_DE(ntohl(su.sin.sin_addr.s_addr))) {
+	    || IPV4_BROADCAST(su.sin.sin_addr.s_addr)
+	    || IPV4_CLASS_D(ntohl(su.sin.sin_addr.s_addr))) {
 		vty_out(vty,
-			"%% nexthop address cannot be 0.0.0.0, multicast or reserved\n");
+			"%% nexthop address cannot be 0.0.0.0, or multicast\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 

--- a/pimd/mtracebis.c
+++ b/pimd/mtracebis.c
@@ -456,7 +456,8 @@ int main(int argc, char *const argv[])
 	if (argc == 3) {
 		if (inet_pton(AF_INET, argv[2], &mc_group) != 1)
 			not_group = true;
-		if (!not_group && !IPV4_CLASS_DE(ntohl(mc_group.s_addr)))
+		if (!not_group && !(IPV4_CLASS_D(ntohl(mc_group.s_addr))
+					|| IPV4_BROADCAST(mc_group.s_addr)))
 			not_group = true;
 	}
 


### PR DESCRIPTION
There is no reason to conflate the multicast and class e address
spaces within FRR.

### Summary
It turns out that class-e addresses (240.0.0.0/4) are surprisingly usable - fully assignable and statically routable in freebsd, osx, ios, linux, and android. 

With a very small set of patches all the routing daemons can be made to work also.

We are hoping to do a public test of public routability of 255.0.0.0/8 next year after setting up a larger testbed than the 4 testbeds we have so far, and after approaching iana and the ietf. 

### Related Issue

There's a document in progress, and all the other (extremely tiny!) patches we've need to make to the linux and other routing daemons is now up at: http://www.taht.net/classe/

### Components

This touches everywhere broadcast, multicast and class e were conflated in frr. Public bogon lists are the only other problem we've seen to date, however the pim related changes should be looked at closely.
