### PR TITLE
zebra: make incoming zserv message-processing a singleton event

### DIFF
--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -73,6 +73,9 @@ struct zserv {
 	struct thread *t_read;
 	struct thread *t_write;
 
+	/* Event for message processing, for the main pthread */
+	struct thread *t_process;
+
 	/* Threads for the main pthread */
 	struct thread *t_cleanup;
 


### PR DESCRIPTION
Stop creating individual, one-time events as each batch of
incoming zserv/zapi messages is processed: use a singleton
event so that the incoming message activity is more fair if
the zebra main pthread has other events to run. With the async
dataplane, this gives us more chance to keep the queue towards
the dataplane busy when there is a burst of incoming zserv/zapi
message activity.

### Components
zebra
