### PR TITLE
lib: Fix string size issue with clang

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -1071,7 +1071,7 @@ static int nb_oper_data_iter_list(const struct nb_node *nb_node,
 	/* Iterate over all list entries. */
 	do {
 		struct yang_list_keys list_keys;
-		char xpath[XPATH_MAXLEN];
+		char xpath[XPATH_MAXLEN * 2];
 		int ret;
 
 		/* Obtain list entry. */


### PR DESCRIPTION
Newer versions of clang are failing on xpath length
not being sufficiently sized to hold all possible data
that could be thrown at it.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

