### PR TITLE
bgpd: Cleanup non-normal compiled code path

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -418,7 +418,8 @@ static void revalidate_bgp_node(struct bgp_node *bgp_node, afi_t afi,
 
 	for (ain = bgp_node->adj_in; ain; ain = ain->next) {
 		int ret;
-		struct bgp_path_info *path = bgp_info_from_node(bgp_node);
+		struct bgp_path_info *path =
+			bgp_node_get_bgp_path_info(bgp_node);
 		mpls_label_t *label = NULL;
 		uint32_t num_labels = 0;
 

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -715,7 +715,7 @@ static struct bgp_path_info *bgp4PathAttrLookup(struct variable *v, oid name[],
 		if (rn) {
 			bgp_unlock_node(rn);
 
-			for (path = bgp_info_from_node(rn); path;
+			for (path = bgp_node_get_bgp_path_info(rn); path;
 			     path = path->next)
 				if (sockunion_same(&path->peer->su, &su))
 					return path;
@@ -763,7 +763,7 @@ static struct bgp_path_info *bgp4PathAttrLookup(struct variable *v, oid name[],
 		do {
 			min = NULL;
 
-			for (path = bgp_info_from_node(rn); path;
+			for (path = bgp_node_get_bgp_path_info(rn); path;
 			     path = path->next) {
 				if (path->peer->su.sin.sin_family == AF_INET
 				    && ntohl(paddr.s_addr)


### PR DESCRIPTION
Looks like we missed some code in a non-normal compiled
code path for the bgp_path_info conversion.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
