### PR TITLE
[master] kill empty libfrrfpm_pb

### DIFF
--- a/fpm/subdir.am
+++ b/fpm/subdir.am
@@ -1,5 +1,7 @@
 if FPM
+if HAVE_PROTOBUF
 lib_LTLIBRARIES += fpm/libfrrfpm_pb.la
+endif
 endif
 
 fpm_libfrrfpm_pb_la_LDFLAGS = -version-info 0:0:0
@@ -10,11 +12,9 @@ fpm_libfrrfpm_pb_la_SOURCES = \
 	fpm/fpm_pb.c \
 	# end
 
-if HAVE_PROTOBUF
 nodist_fpm_libfrrfpm_pb_la_SOURCES = \
 	fpm/fpm.pb-c.c \
 	# end
-endif
 
 CLEANFILES += \
 	fpm/fpm.pb-c.c \


### PR DESCRIPTION
We were building and installing an _empty_ library (i.e. it literally
didn't contain anything.)

(master version of #3479 )