### PR TITLE
tools: stop frr-reload.py from trying to delete the vrf context

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -974,8 +974,8 @@ def compare_context_objects(newconf, running):
                 delete_bgpd = True
                 lines_to_del.append((running_ctx_keys, None))
 
-            # We cannot do 'no interface' in FRR, and so deal with it
-            elif running_ctx_keys[0].startswith('interface'):
+            # We cannot do 'no interface' or 'no vrf' in FRR, and so deal with it
+            elif running_ctx_keys[0].startswith('interface') or running_ctx_keys[0].startswith('vrf'):
                 for line in running_ctx.lines:
                     lines_to_del.append((running_ctx_keys, line))
 


### PR DESCRIPTION
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>

### Summary
Problem seen when removing last config item under the vrf context,
where frr-reload.py tries instead to delete the vrf context itself.
Since that is not permitted on an active vrf, the command errors
out and nothing is deleted.

### Components
tools - frr-reload.py