### PR TITLE
Bsd topo abstract1

### DIFF
--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -908,7 +908,7 @@ class TopoExaBGP(TopoHost):
 
 # Disable linter branch warning. It is expected to have these here.
 # pylint: disable=R0912
-def diagnose_env():
+def diagnose_env_linux():
     """
     Run diagnostics in the running environment. Returns `True` when everything
     is ok, otherwise `False`.
@@ -1066,3 +1066,14 @@ def diagnose_env():
     logger.removeHandler(fhandler)
 
     return ret
+
+def diagnose_env_freebsd():
+    return True
+
+def diagnose_env():
+    if sys.platform.startswith("linux"):
+        return diagnose_env_linux()
+    elif sys.platform.startswith("freebsd"):
+        return diagnose_env_freebsd()
+
+    return False

--- a/tests/topotests/lib/topotest.py
+++ b/tests/topotests/lib/topotest.py
@@ -336,7 +336,7 @@ def normalize_text(text):
 
     return text
 
-def module_present(module, load=True):
+def module_present_linux(module, load):
     """
     Returns whether `module` is present.
 
@@ -351,6 +351,15 @@ def module_present(module, load=True):
         return False
     else:
         return True
+
+def module_present_freebsd(module, load):
+    return True
+
+def module_present(module, load=True):
+    if sys.platform.startswith("linux"):
+        module_present_linux(module, load)
+    elif sys.platform.startswith("freebsd"):
+        module_present_freebsd(module, load)
 
 def version_cmp(v1, v2):
     """


### PR DESCRIPTION
We need to get the topotests running on other platforms besides linux.  Start some of the abstraction in the topotests itself.  

This doesn't get us `working` on freebsd, just clser.  This effort is not my main focus and I need to intermix it in with other work I am doing.