### PR TITLE
bgpd: Fix confederation identifier unsigned display

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7557,7 +7557,7 @@ int bgp_config_write(struct vty *vty)
 
 		/* Confederation identifier*/
 		if (CHECK_FLAG(bgp->config, BGP_CONFIG_CONFEDERATION))
-			vty_out(vty, " bgp confederation identifier %i\n",
+			vty_out(vty, " bgp confederation identifier %u\n",
 				bgp->confed_id);
 
 		/* Confederation peer */


### PR DESCRIPTION
The confederation identifier is a `as_t` type which is a
uint32_t underneath the covers.  Display it using a %u

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

