### PR TITLE
zebra: Allow ns delete to happen after under/over flow checks

### DIFF
--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -252,8 +252,6 @@ static int zebra_ns_notify_read(struct thread *t)
 
 		if (!(event->mask & (IN_CREATE | IN_DELETE)))
 			continue;
-		if (event->mask & IN_DELETE)
-			return zebra_ns_delete(event->name);
 
 		if (offsetof(struct inotify_event, name) + event->len
 		    >= sizeof(buf)) {
@@ -267,6 +265,9 @@ static int zebra_ns_notify_read(struct thread *t)
 				 "NS notify error: bad event name");
 			break;
 		}
+
+		if (event->mask & IN_DELETE)
+			return zebra_ns_delete(event->name);
 
 		netnspath = ns_netns_pathname(NULL, event->name);
 		if (!netnspath)


### PR DESCRIPTION
Allow the ns deletion event to happen *after* the data validity
checks.

Please note this probably still leaves a weird hole if we receive
multiple namespace events ( as the for loop implies ).  We will
stop handling anything after a namespace deletion notification.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

