### PR TITLE
ripd, ripngd: fix memleaks when deleting routing instance

### DIFF
--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3364,8 +3364,8 @@ void rip_clean(void)
 			if (rip->route_map[i].name)
 				free(rip->route_map[i].name);
 
-		XFREE(MTYPE_ROUTE_TABLE, rip->table);
-		XFREE(MTYPE_ROUTE_TABLE, rip->neighbor);
+		route_table_finish(rip->table);
+		route_table_finish(rip->neighbor);
 
 		XFREE(MTYPE_RIP, rip);
 		rip = NULL;

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2445,7 +2445,7 @@ void ripng_clean()
 			if (ripng->route_map[i].name)
 				free(ripng->route_map[i].name);
 
-		XFREE(MTYPE_ROUTE_TABLE, ripng->table);
+		agg_table_finish(ripng->table);
 
 		stream_free(ripng->ibuf);
 		stream_free(ripng->obuf);


### PR DESCRIPTION
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>