### PR TITLE
[6.0] ripngd: fix route redistribution with route-maps

### DIFF
--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -330,7 +330,7 @@ DEFUN (ripng_redistribute_type_routemap,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	ripng_redistribute_routemap_set(type, argv[idx_word]->text);
+	ripng_redistribute_routemap_set(type, argv[idx_word]->arg);
 	zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP6, type, 0,
 			     VRF_DEFAULT);
 	return CMD_SUCCESS;
@@ -361,7 +361,7 @@ DEFUN (ripng_redistribute_type_metric_routemap,
 	}
 
 	ripng_redistribute_metric_set(type, metric);
-	ripng_redistribute_routemap_set(type, argv[idx_word]->text);
+	ripng_redistribute_routemap_set(type, argv[idx_word]->arg);
 	zclient_redistribute(ZEBRA_REDISTRIBUTE_ADD, zclient, AFI_IP6, type, 0,
 			     VRF_DEFAULT);
 	return CMD_SUCCESS;


### PR DESCRIPTION
This fix isn't necessary on master since ripngd is now using only
DEFPY for configuration commands after the northbound conversion.

Reported-by: Christoffer Hansen <netravnen@gmail.com>
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>
