### PR TITLE
bgpd: nexthop vrf name set to default vrf

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7863,7 +7863,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 				if (path->extra->bgp_orig->inst_type
 				    == BGP_INSTANCE_TYPE_DEFAULT)
 
-					vn = "Default";
+					vn = VRF_DEFAULT_NAME;
 				else
 					vn = path->extra->bgp_orig->name;
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6581,7 +6581,7 @@ void route_vty_out(struct vty *vty, struct prefix *p,
 		CHECK_FLAG(path->flags, BGP_PATH_ANNC_NH_SELF) ? true : false;
 	bool nexthop_othervrf = false;
 	vrf_id_t nexthop_vrfid = VRF_DEFAULT;
-	const char *nexthop_vrfname = "Default";
+	const char *nexthop_vrfname = VRF_DEFAULT_NAME;
 
 	if (json_paths)
 		json_path = json_object_new_object();

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -8395,7 +8395,7 @@ int zebra_vxlan_if_add(struct interface *ifp)
 				"Add L2-VNI %u VRF %s intf %s(%u) VLAN %u local IP %s master %u",
 				vni,
 				vlan_if ? vrf_id_to_name(vlan_if->vrf_id)
-					: "Default",
+					: VRF_DEFAULT_NAME,
 				ifp->name, ifp->ifindex, vxl->access_vlan,
 				inet_ntoa(vxl->vtep_ip),
 				zif->brslave_info.bridge_ifindex);


### PR DESCRIPTION
if default vrf is not Default, then nexthop vrf name returned may be
"Default", which is not the correct name of default vrf. change it
accordingly.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>

