### PR TITLE
BSD route socket refactoring/cleanup

### DIFF
--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -183,6 +183,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 		    !CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 			continue;
 
+		smplsp = NULL;
 		gate = false;
 		char gate_buf[INET_ADDRSTRLEN] = "NULL";
 

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -126,7 +126,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 	struct nexthop *nexthop;
 	int nexthop_num = 0;
 	ifindex_t ifindex = 0;
-	int gate = 0;
+	bool gate = false;
 	int error;
 	char prefix_buf[PREFIX_STRLEN];
 	enum blackhole_type bh_type = BLACKHOLE_UNSPEC;
@@ -183,7 +183,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 		    !CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 			continue;
 
-		gate = 0;
+		gate = false;
 		char gate_buf[INET_ADDRSTRLEN] = "NULL";
 
 		switch (nexthop->type) {
@@ -192,7 +192,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 			sin_gate.sin.sin_addr = nexthop->gate.ipv4;
 			sin_gate.sin.sin_family = AF_INET;
 			ifindex = nexthop->ifindex;
-			gate = 1;
+			gate = true;
 			break;
 		case NEXTHOP_TYPE_IPV6:
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
@@ -214,7 +214,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 					ifindex);
 #endif /* KAME */
 
-			gate = 1;
+			gate = true;
 			break;
 		case NEXTHOP_TYPE_IFINDEX:
 			ifindex = nexthop->ifindex;
@@ -226,7 +226,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 				struct in_addr loopback;
 				loopback.s_addr = htonl(INADDR_LOOPBACK);
 				sin_gate.sin.sin_addr = loopback;
-				gate = 1;
+				gate = true;
 			}
 				break;
 			case AFI_IP6:

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -204,10 +204,10 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 #ifdef KAME
 
 #define SET_IN6_LINKLOCAL_IFINDEX(a, i)                                        \
-        do {                                                                   \
-                (a).s6_addr[2] = ((i) >> 8) & 0xff;                            \
-                (a).s6_addr[3] = (i)&0xff;                                     \
-        } while (0)
+	do {                                                                   \
+		(a).s6_addr[2] = ((i) >> 8) & 0xff;                            \
+		(a).s6_addr[3] = (i)&0xff;                                     \
+	} while (0)
 
 			if (IN6_IS_ADDR_LINKLOCAL(&sin_gate.sin6.sin6_addr))
 				SET_IN6_LINKLOCAL_IFINDEX(

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -118,7 +118,6 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 		      const struct nexthop_group *ng, uint32_t metric)
 
 {
-	union sockunion *mask = NULL;
 	union sockunion sin_dest, sin_mask, sin_gate;
 #ifdef __OpenBSD__
 	struct sockaddr_mpls smpls;
@@ -237,32 +236,20 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 
 		switch (p->family) {
 		case AF_INET:
-			if (gate && p->prefixlen == 32)
-				mask = NULL;
-			else {
-				masklen2ip(p->prefixlen,
-					   &sin_mask.sin.sin_addr);
-				sin_mask.sin.sin_family = AF_INET;
+			masklen2ip(p->prefixlen, &sin_mask.sin.sin_addr);
+			sin_mask.sin.sin_family = AF_INET;
 #ifdef HAVE_STRUCT_SOCKADDR_IN_SIN_LEN
-				sin_mask.sin.sin_len = sin_masklen(
-					sin_mask.sin.sin_addr);
+			sin_mask.sin.sin_len = sin_masklen(
+				sin_mask.sin.sin_addr);
 #endif /* HAVE_STRUCT_SOCKADDR_IN_SIN_LEN */
-				mask = &sin_mask;
-			}
 			break;
 		case AF_INET6:
-			if (gate && p->prefixlen == 128)
-				mask = NULL;
-			else {
-				masklen2ip6(p->prefixlen,
-					    &sin_mask.sin6.sin6_addr);
-				sin_mask.sin6.sin6_family = AF_INET6;
+			masklen2ip6(p->prefixlen, &sin_mask.sin6.sin6_addr);
+			sin_mask.sin6.sin6_family = AF_INET6;
 #ifdef SIN6_LEN
-				sin_mask.sin6.sin6_len = sin6_masklen(
-					sin_mask.sin6.sin6_addr);
+			sin_mask.sin6.sin6_len = sin6_masklen(
+				sin_mask.sin6.sin6_addr);
 #endif /* SIN6_LEN */
-				mask = &sin_mask;
-			}
 			break;
 		}
 
@@ -272,7 +259,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 			continue;
 		smplsp = (union sockunion *)&smpls;
 #endif
-		error = rtm_write(cmd, &sin_dest, mask,
+		error = rtm_write(cmd, &sin_dest, &sin_mask,
 				  gate ? &sin_gate : NULL, smplsp,
 				  ifindex, bh_type, metric);
 

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -89,6 +89,30 @@ static int kernel_rtm_add_labels(struct mpls_label_stack *nh_label,
 }
 #endif
 
+#ifdef SIN6_LEN
+/* Calculate sin6_len value for netmask socket value. */
+static int sin6_masklen(struct in6_addr mask)
+{
+	struct sockaddr_in6 sin6;
+	char *p, *lim;
+	int len;
+
+	if (IN6_IS_ADDR_UNSPECIFIED(&mask))
+		return sizeof(long);
+
+	sin6.sin6_addr = mask;
+	len = sizeof(struct sockaddr_in6);
+
+	lim = (char *)&sin6.sin6_addr;
+	p = lim + sizeof(sin6.sin6_addr);
+
+	while (*--p == 0 && p >= lim)
+		len--;
+
+	return len;
+}
+#endif /* SIN6_LEN */
+
 /* Interface between zebra message and rtm message. */
 static int kernel_rtm_ipv4(int cmd, const struct prefix *p,
 			   const struct nexthop_group *ng, uint32_t metric)
@@ -252,30 +276,6 @@ static int kernel_rtm_ipv4(int cmd, const struct prefix *p,
 
 	return 0; /*XXX*/
 }
-
-#ifdef SIN6_LEN
-/* Calculate sin6_len value for netmask socket value. */
-static int sin6_masklen(struct in6_addr mask)
-{
-	struct sockaddr_in6 sin6;
-	char *p, *lim;
-	int len;
-
-	if (IN6_IS_ADDR_UNSPECIFIED(&mask))
-		return sizeof(long);
-
-	sin6.sin6_addr = mask;
-	len = sizeof(struct sockaddr_in6);
-
-	lim = (char *)&sin6.sin6_addr;
-	p = lim + sizeof(sin6.sin6_addr);
-
-	while (*--p == 0 && p >= lim)
-		len--;
-
-	return len;
-}
-#endif /* SIN6_LEN */
 
 /* Interface between zebra message and rtm message. */
 static int kernel_rtm_ipv6(int cmd, const struct prefix *p,


### PR DESCRIPTION
Provide a consolidated route installation for *bsd into the kernel.  Long term goal is to allow v4 routes w/ v6 nexthops
Janelle# show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route

K>* 0.0.0.0/0 [0/0] via 10.50.12.1, em0, 00:13:13
B>* 10.50.11.0/24 [20/0] via fe80::a00:27ff:fe28:3b50, em1, 00:13:09
C>* 10.50.12.0/24 is directly connected, em0, 00:13:13
B>* 10.232.0.16/32 [20/0] via fe80::a00:27ff:fe28:3b50, em1, 00:13:09
B>* 192.168.209.0/24 [20/0] via fe80::a00:27ff:fe28:3b50, em1, 00:13:09
B>* 192.168.230.0/24 [20/0] via fe80::a00:27ff:fe28:3b50, em1, 00:13:09
B>* 192.168.231.0/24 [20/0] via fe80::a00:27ff:fe28:3b50, em1, 00:13:09
Janelle# harpd@Janelle ~/frr> netstat -rn
Routing tables

Internet:
Destination        Gateway            Flags     Netif Expire
default            10.50.12.1         UGS         em0
10.50.11.0/24      fe80::a00:27ff:fe28:3b50%em1 UG1      em1
10.50.12.0/24      link#1             U           em0
10.50.12.121       link#1             UHS         lo0
10.232.0.16        fe80::a00:27ff:fe28:3b50%em1 UGH1      em1
127.0.0.1          link#4             UH          lo0
192.168.209.0/24   fe80::a00:27ff:fe28:3b50%em1 UG1      em1
192.168.230.0/24   fe80::a00:27ff:fe28:3b50%em1 UG1      em1
192.168.231.0/24   fe80::a00:27ff:fe28:3b50%em1 UG1      em1

