### PR TITLE
bgpd: fix json double free when showing neighbors

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10918,7 +10918,6 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp,
 	if (use_json) {
 		vty_out(vty, "%s\n", json_object_to_json_string_ext(
 					     json, JSON_C_TO_STRING_PRETTY));
-		json_object_free(json);
 	} else {
 		vty_out(vty, "\n");
 	}
@@ -10993,8 +10992,10 @@ static void bgp_show_all_instances_neighbors_vty(struct vty *vty,
 		}
 	}
 
-	if (use_json)
+	if (use_json) {
 		vty_out(vty, "}\n");
+		json_object_free(json);
+	}
 	else if (!nbr_output)
 		vty_out(vty, "%% BGP instance not found\n");
 }


### PR DESCRIPTION
### Summary
Fixes a double free when showing json for `show ip bgp neigh json`. Right now this tends only to crash on FreeBSD since it has a newer version of json-c that contains an assert on a refcount.

### Related Issue
Fixes #3365 

### Components
bgpd