### PR TITLE
 zebra: EVPN dup addr detect fix freeze/unfreeze action 

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -6381,7 +6381,8 @@ int zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
 		 * to BGP. Similarly remote macip update, neigh needs to be
 		 * installed locally.
 		 */
-		if (nbr->dad_count) {
+		if (zvrf->dad_freeze &&
+		    CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_DUPLICATE)) {
 			if (CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_LOCAL))
 				ZEBRA_NEIGH_SET_INACTIVE(nbr);
 			else if (CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_REMOTE))
@@ -6400,6 +6401,10 @@ int zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
 	mac->detect_start_time.tv_usec = 0;
 	mac->dad_dup_detect_time = 0;
 	THREAD_OFF(mac->dad_mac_auto_recovery_timer);
+
+	/* warn-only action return */
+	if (!zvrf->dad_freeze)
+		return CMD_SUCCESS;
 
 	/* Local: Notify Peer VTEPs, Remote: Install the entry */
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)) {


### PR DESCRIPTION
### Summary
[fill here]
Below are cases where EVPN duplicate detection
Freeze and Unfreeze required fixes:

Auto recovery needs to check neighbor's duplicate flag
to take action, as neigh could be marked duplicate
via inherited from MAC where IP detection count could be 0.

MAC duplicate detection needs to set flag to true
if freeze action is configured.

Local MAC add update should not send update to bgp
if MAC is in frozen state.

Remote MAC-IP update should not process neigh update if MAC
is detected as duplicate during remote update.

Clear dup-addr detection command: 
For neigh check duplicate flag as it can be inherited from duplicate
detected MAC (count could be 0).

### Related Issue
[fill here if applicable]

### Components
zebra
