### PR TITLE
bgpd: Set bgp default nexthop value of IPv6

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -793,6 +793,7 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 						      peer->bgp->vrf_id);
 	}
 	if (local->sa.sa_family == AF_INET6) {
+		memcpy(&nexthop->v6_global, &local->sin6.sin6_addr, IPV6_MAX_BYTELEN);
 		if (IN6_IS_ADDR_LINKLOCAL(&local->sin6.sin6_addr)) {
 			if (peer->conf_if || peer->ifname)
 				ifp = if_lookup_by_name(peer->conf_if


### PR DESCRIPTION
Set the bgp default nexthop value of IPv6 to the local ipv6 addr of the
tcp connection like IPv4. Fixed the problem of route with empty nexthop
advertised to the peer when zebra is not running.

* bgp_zebra.c: (bgp_zebra_nexthop_set) Set IPv6 bgp default nexthop value.

Signed-off-by: faicker.mo <faicker.mo@ucloud.cn>

