### PR TITLE
zebra: include lib/queue.h in zebra dataplane

### DIFF
--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -24,7 +24,7 @@
 #include "lib/prefix.h"
 #include "lib/nexthop.h"
 #include "lib/nexthop_group.h"
-#include "lib/openbsd-queue.h"
+#include "lib/queue.h"
 #include "zebra/zebra_ns.h"
 #include "zebra/rib.h"
 #include "zebra/zserv.h"


### PR DESCRIPTION
Fix a place where the queue lib wrapper (lib/queue.h) wasn't being used in the zebra dataplane - I was including one of the specific queue headers directly.