### PR TITLE
zebra: reduce rib workqueue retry timeout

### DIFF
--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -187,7 +187,7 @@ struct zebra_t {
 
 /* rib work queue */
 #define ZEBRA_RIB_PROCESS_HOLD_TIME 10
-#define ZEBRA_RIB_PROCESS_RETRY_TIME 5
+#define ZEBRA_RIB_PROCESS_RETRY_TIME 1
 	struct work_queue *ribq;
 	struct meta_queue *mq;
 


### PR DESCRIPTION
Reduce the zebra rib workqueue retry timeout, used when the queue towards the zebra dataplane has reached its limit. Lowering the value was reported to improve update throughput on some platforms.

### Components
zebra