### PR TITLE
doc: exclude snmptrap.rst from build

### DIFF
--- a/doc/user/conf.py
+++ b/doc/user/conf.py
@@ -132,7 +132,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build', 'rpki.rst', 'routeserver.rst',
-                    'ospf_fundamentals.rst', 'flowspec.rst']
+                    'ospf_fundamentals.rst', 'flowspec.rst', 'snmptrap.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
This is doc is `.. include::`d in snmp.rst and needs to be ignored as
part of the main toctree build. This patch squashes a Sphinx build
warning.

### Components
doc
