### PR TITLE
libd: Implemented a cli "show route-map-unused" to track all unused rou…

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3260,6 +3260,8 @@ DEFUN (bgp_evpn_advertise_type5,
 		if (bgp_vrf->adv_cmd_rmap[afi][safi].name) {
 			XFREE(MTYPE_ROUTE_MAP_NAME,
 			      bgp_vrf->adv_cmd_rmap[afi][safi].name);
+			route_map_counter_decrement(
+					bgp_vrf->adv_cmd_rmap[afi][safi].map);
 			bgp_vrf->adv_cmd_rmap[afi][safi].name = NULL;
 			bgp_vrf->adv_cmd_rmap[afi][safi].map = NULL;
 		}
@@ -3271,6 +3273,8 @@ DEFUN (bgp_evpn_advertise_type5,
 			XSTRDUP(MTYPE_ROUTE_MAP_NAME, argv[idx_rmap + 1]->arg);
 		bgp_vrf->adv_cmd_rmap[afi][safi].map =
 			route_map_lookup_by_name(argv[idx_rmap + 1]->arg);
+		route_map_counter_increment(
+				bgp_vrf->adv_cmd_rmap[afi][safi].map);
 	}
 
 	/* advertise type-5 routes */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4417,6 +4417,8 @@ static void bgp_static_free(struct bgp_static *bgp_static)
 {
 	if (bgp_static->rmap.name)
 		XFREE(MTYPE_ROUTE_MAP_NAME, bgp_static->rmap.name);
+	route_map_counter_decrement(bgp_static->rmap.map);
+
 	if (bgp_static->eth_s_id)
 		XFREE(MTYPE_ATTR, bgp_static->eth_s_id);
 	XFREE(MTYPE_BGP_STATIC, bgp_static);
@@ -4981,14 +4983,20 @@ static int bgp_static_set(struct vty *vty, const char *negate,
 				if (bgp_static->rmap.name)
 					XFREE(MTYPE_ROUTE_MAP_NAME,
 					      bgp_static->rmap.name);
+				route_map_counter_decrement(
+					bgp_static->rmap.map);
 				bgp_static->rmap.name =
 					XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap);
 				bgp_static->rmap.map =
 					route_map_lookup_by_name(rmap);
+				route_map_counter_increment(
+					bgp_static->rmap.map);
 			} else {
 				if (bgp_static->rmap.name)
 					XFREE(MTYPE_ROUTE_MAP_NAME,
 					      bgp_static->rmap.name);
+				route_map_counter_decrement(
+					bgp_static->rmap.map);
 				bgp_static->rmap.name = NULL;
 				bgp_static->rmap.map = NULL;
 				bgp_static->valid = 0;
@@ -5007,10 +5015,14 @@ static int bgp_static_set(struct vty *vty, const char *negate,
 				if (bgp_static->rmap.name)
 					XFREE(MTYPE_ROUTE_MAP_NAME,
 					      bgp_static->rmap.name);
+				route_map_counter_decrement(
+					bgp_static->rmap.map);
 				bgp_static->rmap.name =
 					XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap);
 				bgp_static->rmap.map =
 					route_map_lookup_by_name(rmap);
+				route_map_counter_increment(
+					bgp_static->rmap.map);
 			}
 			bgp_node_set_bgp_static_info(rn, bgp_static);
 		}
@@ -5289,10 +5301,12 @@ int bgp_static_set_safi(afi_t afi, safi_t safi, struct vty *vty,
 			if (bgp_static->rmap.name)
 				XFREE(MTYPE_ROUTE_MAP_NAME,
 				      bgp_static->rmap.name);
+			route_map_counter_decrement(bgp_static->rmap.map);
 			bgp_static->rmap.name =
 				XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap_str);
 			bgp_static->rmap.map =
 				route_map_lookup_by_name(rmap_str);
+			route_map_counter_increment(bgp_static->rmap.map);
 		}
 
 		if (safi == SAFI_EVPN) {
@@ -5395,11 +5409,14 @@ static int bgp_table_map_set(struct vty *vty, afi_t afi, safi_t safi,
 	if (rmap_name) {
 		if (rmap->name)
 			XFREE(MTYPE_ROUTE_MAP_NAME, rmap->name);
+		route_map_counter_decrement(rmap->map);
 		rmap->name = XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap_name);
 		rmap->map = route_map_lookup_by_name(rmap_name);
+		route_map_counter_increment(rmap->map);
 	} else {
 		if (rmap->name)
 			XFREE(MTYPE_ROUTE_MAP_NAME, rmap->name);
+		route_map_counter_decrement(rmap->map);
 		rmap->name = NULL;
 		rmap->map = NULL;
 	}
@@ -5419,6 +5436,7 @@ static int bgp_table_map_unset(struct vty *vty, afi_t afi, safi_t safi,
 	rmap = &bgp->table_map[afi][safi];
 	if (rmap->name)
 		XFREE(MTYPE_ROUTE_MAP_NAME, rmap->name);
+	route_map_counter_decrement(rmap->map);
 	rmap->name = NULL;
 	rmap->map = NULL;
 

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3250,6 +3250,15 @@ static void bgp_route_map_process_update(struct bgp *bgp, const char *rmap_name,
 		if (bgp->table_map[afi][safi].name
 		    && (strcmp(rmap_name, bgp->table_map[afi][safi].name)
 			== 0)) {
+
+			/* bgp->table_map[afi][safi].map  is NULL.
+			 * i.e Route map creation event.
+			 * So update applied_counter.
+			 * If it is not NULL, i.e It may be routemap updation or
+			 * deletion. so no need to update the counter.
+			 */
+			if (!bgp->table_map[afi][safi].map)
+				route_map_counter_increment(map);
 			bgp->table_map[afi][safi].map = map;
 
 			if (BGP_DEBUG(zebra, ZEBRA))
@@ -3271,6 +3280,9 @@ static void bgp_route_map_process_update(struct bgp *bgp, const char *rmap_name,
 			if (!bgp_static->rmap.name
 			    || (strcmp(rmap_name, bgp_static->rmap.name) != 0))
 				continue;
+
+			if (!bgp_static->rmap.map)
+				route_map_counter_increment(map);
 
 			bgp_static->rmap.map = map;
 
@@ -3302,6 +3314,9 @@ static void bgp_route_map_process_update(struct bgp *bgp, const char *rmap_name,
 				if (!red->rmap.name
 				    || (strcmp(rmap_name, red->rmap.name) != 0))
 					continue;
+
+				if (!red->rmap.map)
+					route_map_counter_increment(map);
 
 				red->rmap.map = map;
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1683,8 +1683,13 @@ int bgp_redistribute_rmap_set(struct bgp_redist *red, const char *name,
 
 	if (red->rmap.name)
 		XFREE(MTYPE_ROUTE_MAP_NAME, red->rmap.name);
+	/* Decrement the count for existing routemap and
+	 * increment the count for new route map.
+	 */
+	route_map_counter_decrement(red->rmap.map);
 	red->rmap.name = XSTRDUP(MTYPE_ROUTE_MAP_NAME, name);
 	red->rmap.map = route_map;
+	route_map_counter_increment(red->rmap.map);
 
 	return 1;
 }
@@ -1792,6 +1797,7 @@ int bgp_redistribute_unset(struct bgp *bgp, afi_t afi, int type,
 	/* Unset route-map. */
 	if (red->rmap.name)
 		XFREE(MTYPE_ROUTE_MAP_NAME, red->rmap.name);
+	route_map_counter_decrement(red->rmap.map);
 	red->rmap.name = NULL;
 	red->rmap.map = NULL;
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4594,15 +4594,18 @@ int peer_default_originate_set(struct peer *peer, afi_t afi, safi_t safi,
 				XFREE(MTYPE_ROUTE_MAP_NAME,
 				      peer->default_rmap[afi][safi].name);
 
+			route_map_counter_decrement(peer->default_rmap[afi][safi].map);
 			peer->default_rmap[afi][safi].name =
 				XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap);
 			peer->default_rmap[afi][safi].map = route_map;
+			route_map_counter_increment(route_map);
 		}
 	} else if (!rmap) {
 		if (peer->default_rmap[afi][safi].name)
 			XFREE(MTYPE_ROUTE_MAP_NAME,
 			      peer->default_rmap[afi][safi].name);
 
+		route_map_counter_decrement(peer->default_rmap[afi][safi].map);
 		peer->default_rmap[afi][safi].name = NULL;
 		peer->default_rmap[afi][safi].map = NULL;
 	}
@@ -4637,10 +4640,12 @@ int peer_default_originate_set(struct peer *peer, afi_t afi, safi_t safi,
 			if (member->default_rmap[afi][safi].name)
 				XFREE(MTYPE_ROUTE_MAP_NAME,
 				      member->default_rmap[afi][safi].name);
-
+			route_map_counter_decrement(
+					member->default_rmap[afi][safi].map);
 			member->default_rmap[afi][safi].name =
 				XSTRDUP(MTYPE_ROUTE_MAP_NAME, rmap);
 			member->default_rmap[afi][safi].map = route_map;
+			route_map_counter_increment(route_map);
 		}
 
 		/* Update peer route announcements. */
@@ -4677,6 +4682,7 @@ int peer_default_originate_unset(struct peer *peer, afi_t afi, safi_t safi)
 		if (peer->default_rmap[afi][safi].name)
 			XFREE(MTYPE_ROUTE_MAP_NAME,
 			      peer->default_rmap[afi][safi].name);
+		route_map_counter_decrement(peer->default_rmap[afi][safi].map);
 		peer->default_rmap[afi][safi].name = NULL;
 		peer->default_rmap[afi][safi].map = NULL;
 	}
@@ -4710,6 +4716,7 @@ int peer_default_originate_unset(struct peer *peer, afi_t afi, safi_t safi)
 		if (peer->default_rmap[afi][safi].name)
 			XFREE(MTYPE_ROUTE_MAP_NAME,
 			      peer->default_rmap[afi][safi].name);
+		route_map_counter_decrement(peer->default_rmap[afi][safi].map);
 		peer->default_rmap[afi][safi].name = NULL;
 		peer->default_rmap[afi][safi].map = NULL;
 
@@ -6118,8 +6125,10 @@ int peer_route_map_set(struct peer *peer, afi_t afi, safi_t safi, int direct,
 	filter = &peer->filter[afi][safi];
 	if (filter->map[direct].name)
 		XFREE(MTYPE_BGP_FILTER_NAME, filter->map[direct].name);
+	route_map_counter_decrement(filter->map[direct].map);
 	filter->map[direct].name = XSTRDUP(MTYPE_BGP_FILTER_NAME, name);
 	filter->map[direct].map = route_map;
+	route_map_counter_increment(route_map);
 
 	/* Check if handling a regular peer. */
 	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
@@ -6147,8 +6156,10 @@ int peer_route_map_set(struct peer *peer, afi_t afi, safi_t safi, int direct,
 		filter = &member->filter[afi][safi];
 		if (filter->map[direct].name)
 			XFREE(MTYPE_BGP_FILTER_NAME, filter->map[direct].name);
+		route_map_counter_decrement(filter->map[direct].map);
 		filter->map[direct].name = XSTRDUP(MTYPE_BGP_FILTER_NAME, name);
 		filter->map[direct].map = route_map;
+		route_map_counter_increment(route_map);
 
 		/* Process peer route updates. */
 		peer_on_policy_change(member, afi, safi,
@@ -6182,6 +6193,7 @@ int peer_route_map_unset(struct peer *peer, afi_t afi, safi_t safi, int direct)
 		filter = &peer->filter[afi][safi];
 		if (filter->map[direct].name)
 			XFREE(MTYPE_BGP_FILTER_NAME, filter->map[direct].name);
+		route_map_counter_decrement(filter->map[direct].map);
 		filter->map[direct].name = NULL;
 		filter->map[direct].map = NULL;
 	}
@@ -6210,6 +6222,7 @@ int peer_route_map_unset(struct peer *peer, afi_t afi, safi_t safi, int direct)
 		filter = &member->filter[afi][safi];
 		if (filter->map[direct].name)
 			XFREE(MTYPE_BGP_FILTER_NAME, filter->map[direct].name);
+		route_map_counter_decrement(filter->map[direct].map);
 		filter->map[direct].name = NULL;
 		filter->map[direct].map = NULL;
 
@@ -6233,8 +6246,10 @@ int peer_unsuppress_map_set(struct peer *peer, afi_t afi, safi_t safi,
 	filter = &peer->filter[afi][safi];
 	if (filter->usmap.name)
 		XFREE(MTYPE_BGP_FILTER_NAME, filter->usmap.name);
+	route_map_counter_decrement(filter->usmap.map);
 	filter->usmap.name = XSTRDUP(MTYPE_BGP_FILTER_NAME, name);
 	filter->usmap.map = route_map;
+	route_map_counter_increment(route_map);
 
 	/* Check if handling a regular peer. */
 	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
@@ -6261,8 +6276,10 @@ int peer_unsuppress_map_set(struct peer *peer, afi_t afi, safi_t safi,
 		filter = &member->filter[afi][safi];
 		if (filter->usmap.name)
 			XFREE(MTYPE_BGP_FILTER_NAME, filter->usmap.name);
+		route_map_counter_decrement(filter->usmap.map);
 		filter->usmap.name = XSTRDUP(MTYPE_BGP_FILTER_NAME, name);
 		filter->usmap.map = route_map;
+		route_map_counter_increment(route_map);
 
 		/* Process peer route updates. */
 		peer_on_policy_change(member, afi, safi, 1);
@@ -6293,6 +6310,7 @@ int peer_unsuppress_map_unset(struct peer *peer, afi_t afi, safi_t safi)
 		filter = &peer->filter[afi][safi];
 		if (filter->usmap.name)
 			XFREE(MTYPE_BGP_FILTER_NAME, filter->usmap.name);
+		route_map_counter_decrement(filter->usmap.map);
 		filter->usmap.name = NULL;
 		filter->usmap.map = NULL;
 	}
@@ -6320,6 +6338,7 @@ int peer_unsuppress_map_unset(struct peer *peer, afi_t afi, safi_t safi)
 		filter = &member->filter[afi][safi];
 		if (filter->usmap.name)
 			XFREE(MTYPE_BGP_FILTER_NAME, filter->usmap.name);
+		route_map_counter_decrement(filter->usmap.map);
 		filter->usmap.name = NULL;
 		filter->usmap.map = NULL;
 

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -1164,9 +1164,16 @@ DEFUN (vnc_redist_bgpdirect_routemap,
 
 	if (hc->routemap_redist_name[route_type])
 		free(hc->routemap_redist_name[route_type]);
+
+	/* If the old route map config overwrite with new
+	 * route map config , old routemap counter have to be
+	 * reduced.
+	 */
+	route_map_counter_decrement(hc->routemap_redist[route_type]);
 	hc->routemap_redist_name[route_type] = strdup(argv[4]->arg);
 	hc->routemap_redist[route_type] =
 		route_map_lookup_by_name(argv[4]->arg);
+	route_map_counter_increment(hc->routemap_redist[route_type]);
 
 	vnc_redistribute_postchange(bgp);
 
@@ -1210,6 +1217,8 @@ DEFUN (vnc_nve_group_redist_bgpdirect_no_prefixlist,
 
 	if (rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi])
 		free(rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi]);
+	route_map_counter_decrement(
+		rfg->plist_redist[ZEBRA_ROUTE_BGP_DIRECT][afi]);
 	rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi] = NULL;
 	rfg->plist_redist[ZEBRA_ROUTE_BGP_DIRECT][afi] = NULL;
 
@@ -1285,6 +1294,8 @@ DEFUN (vnc_nve_group_redist_bgpdirect_no_routemap,
 
 	if (rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT])
 		free(rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT]);
+	route_map_counter_decrement(
+		rfg->routemap_redist[ZEBRA_ROUTE_BGP_DIRECT]);
 	rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT] = NULL;
 	rfg->routemap_redist[ZEBRA_ROUTE_BGP_DIRECT] = NULL;
 
@@ -1316,10 +1327,14 @@ DEFUN (vnc_nve_group_redist_bgpdirect_routemap,
 
 	if (rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT])
 		free(rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT]);
+	route_map_counter_decrement(
+		rfg->routemap_redist[ZEBRA_ROUTE_BGP_DIRECT]);
 	rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT] =
 		strdup(argv[3]->arg);
 	rfg->routemap_redist[ZEBRA_ROUTE_BGP_DIRECT] =
 		route_map_lookup_by_name(argv[3]->arg);
+	route_map_counter_increment(
+		rfg->routemap_redist[ZEBRA_ROUTE_BGP_DIRECT]);
 
 	vnc_redistribute_postchange(bgp);
 
@@ -1741,6 +1756,7 @@ DEFUN (vnc_nve_group_export_no_routemap,
 				    rfg->routemap_export_bgp_name))) {
 			if (rfg->routemap_export_bgp_name)
 				free(rfg->routemap_export_bgp_name);
+			route_map_counter_decrement(rfg->routemap_export_bgp);
 			rfg->routemap_export_bgp_name = NULL;
 			rfg->routemap_export_bgp = NULL;
 
@@ -1754,6 +1770,7 @@ DEFUN (vnc_nve_group_export_no_routemap,
 				    rfg->routemap_export_zebra_name))) {
 			if (rfg->routemap_export_zebra_name)
 				free(rfg->routemap_export_zebra_name);
+			route_map_counter_decrement(rfg->routemap_export_zebra);
 			rfg->routemap_export_zebra_name = NULL;
 			rfg->routemap_export_zebra = NULL;
 
@@ -1800,17 +1817,21 @@ DEFUN (vnc_nve_group_export_routemap,
 	if (is_bgp) {
 		if (rfg->routemap_export_bgp_name)
 			free(rfg->routemap_export_bgp_name);
+		route_map_counter_decrement(rfg->routemap_export_bgp);
 		rfg->routemap_export_bgp_name = strdup(argv[idx]->arg);
 		rfg->routemap_export_bgp =
 			route_map_lookup_by_name(argv[idx]->arg);
+		route_map_counter_increment(rfg->routemap_export_bgp);
 		vnc_direct_bgp_reexport_group_afi(bgp, rfg, AFI_IP);
 		vnc_direct_bgp_reexport_group_afi(bgp, rfg, AFI_IP6);
 	} else {
 		if (rfg->routemap_export_zebra_name)
 			free(rfg->routemap_export_zebra_name);
+		route_map_counter_decrement(rfg->routemap_export_zebra);
 		rfg->routemap_export_zebra_name = strdup(argv[idx]->arg);
 		rfg->routemap_export_zebra =
 			route_map_lookup_by_name(argv[idx]->arg);
+		route_map_counter_increment(rfg->routemap_export_zebra);
 		vnc_zebra_reexport_group_afi(bgp, rfg, AFI_IP);
 		vnc_zebra_reexport_group_afi(bgp, rfg, AFI_IP6);
 	}
@@ -1937,6 +1958,7 @@ DEFUN (vnc_nve_export_no_routemap,
 		    || (argc <= 5)) {
 
 			free(hc->routemap_export_bgp_name);
+			route_map_counter_decrement(hc->routemap_export_bgp);
 			hc->routemap_export_bgp_name = NULL;
 			hc->routemap_export_bgp = NULL;
 			vnc_direct_bgp_reexport(bgp, AFI_IP);
@@ -1948,6 +1970,7 @@ DEFUN (vnc_nve_export_no_routemap,
 		    || (argc <= 5)) {
 
 			free(hc->routemap_export_zebra_name);
+			route_map_counter_decrement(hc->routemap_export_zebra);
 			hc->routemap_export_zebra_name = NULL;
 			hc->routemap_export_zebra = NULL;
 			/* TBD vnc_zebra_rh_reexport(bgp, AFI_IP); */
@@ -1975,17 +1998,21 @@ DEFUN (vnc_nve_export_routemap,
 	if (argv[2]->arg[0] == 'b') {
 		if (hc->routemap_export_bgp_name)
 			free(hc->routemap_export_bgp_name);
+		route_map_counter_decrement(hc->routemap_export_bgp);
 		hc->routemap_export_bgp_name = strdup(argv[4]->arg);
 		hc->routemap_export_bgp =
 			route_map_lookup_by_name(argv[4]->arg);
+		route_map_counter_increment(hc->routemap_export_bgp);
 		vnc_direct_bgp_reexport(bgp, AFI_IP);
 		vnc_direct_bgp_reexport(bgp, AFI_IP6);
 	} else {
 		if (hc->routemap_export_zebra_name)
 			free(hc->routemap_export_zebra_name);
+		route_map_counter_decrement(hc->routemap_export_zebra);
 		hc->routemap_export_zebra_name = strdup(argv[4]->arg);
 		hc->routemap_export_zebra =
 			route_map_lookup_by_name(argv[4]->arg);
+		route_map_counter_increment(hc->routemap_export_zebra);
 		/* TBD vnc_zebra_rh_reexport(bgp, AFI_IP); */
 		/* TBD vnc_zebra_rh_reexport(bgp, AFI_IP6); */
 	}
@@ -2083,6 +2110,7 @@ void vnc_routemap_update(struct bgp *bgp, const char *unused)
 	struct rfapi_nve_group_cfg *rfg;
 	struct rfapi_cfg *hc;
 	int i;
+	struct route_map *old = NULL;
 
 	vnc_zlog_debug_verbose("%s(arg=%s)", __func__, unused);
 
@@ -2104,18 +2132,36 @@ void vnc_routemap_update(struct bgp *bgp, const char *unused)
 				  rfg)) {
 
 		if (rfg->routemap_export_bgp_name) {
+			old = rfg->routemap_export_bgp;
 			rfg->routemap_export_bgp = route_map_lookup_by_name(
 				rfg->routemap_export_bgp_name);
+			/* old is NULL. i.e Route map creation event.
+			 * So update applied_counter.
+			 * If Old is not NULL, i.e It may be routemap
+			 * updation or deletion.
+			 * So no need to update the counter.
+			 */
+			if (!old)
+				route_map_counter_increment(
+					rfg->routemap_export_bgp);
 		}
 		if (rfg->routemap_export_zebra_name) {
+			old = rfg->routemap_export_bgp;
 			rfg->routemap_export_bgp = route_map_lookup_by_name(
 				rfg->routemap_export_zebra_name);
+			if (!old)
+				route_map_counter_increment(
+					rfg->routemap_export_bgp);
 		}
 		for (i = 0; i < ZEBRA_ROUTE_MAX; ++i) {
 			if (rfg->routemap_redist_name[i]) {
+				old = rfg->routemap_redist[i];
 				rfg->routemap_redist[i] =
 					route_map_lookup_by_name(
 						rfg->routemap_redist_name[i]);
+				if (!old)
+					route_map_counter_increment(
+						rfg->routemap_redist[i]);
 			}
 		}
 
@@ -2128,17 +2174,27 @@ void vnc_routemap_update(struct bgp *bgp, const char *unused)
 	 * RH config, too
 	 */
 	if (hc->routemap_export_bgp_name) {
+		old = hc->routemap_export_bgp;
 		hc->routemap_export_bgp =
 			route_map_lookup_by_name(hc->routemap_export_bgp_name);
+		if (!old)
+			route_map_counter_increment(hc->routemap_export_bgp);
 	}
 	if (hc->routemap_export_zebra_name) {
+		old  = hc->routemap_export_bgp;
 		hc->routemap_export_bgp = route_map_lookup_by_name(
 			hc->routemap_export_zebra_name);
+		if (!old)
+			route_map_counter_increment(hc->routemap_export_bgp);
 	}
 	for (i = 0; i < ZEBRA_ROUTE_MAX; ++i) {
 		if (hc->routemap_redist_name[i]) {
+			old = hc->routemap_redist[i];
 			hc->routemap_redist[i] = route_map_lookup_by_name(
 				hc->routemap_redist_name[i]);
+			if (!old)
+				route_map_counter_increment(
+					hc->routemap_redist[i]);
 		}
 	}
 

--- a/isisd/isis_redist.c
+++ b/isisd/isis_redist.c
@@ -338,12 +338,14 @@ static void isis_redist_routemap_set(struct isis_redist *redist,
 {
 	if (redist->map_name) {
 		XFREE(MTYPE_ISIS, redist->map_name);
+		route_map_counter_decrement(redist->map);
 		redist->map = NULL;
 	}
 
 	if (routemap && strlen(routemap)) {
 		redist->map_name = XSTRDUP(MTYPE_ISIS, routemap);
 		redist->map = route_map_lookup_by_name(routemap);
+		route_map_counter_increment(redist->map);
 	}
 }
 

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1007,6 +1007,34 @@ static int vty_show_route_map(struct vty *vty, const char *name)
 	return CMD_SUCCESS;
 }
 
+/* Unused route map details */
+static int vty_show_unused_route_map(struct vty *vty)
+{
+	struct list *maplist = list_new();
+	struct listnode *ln;
+	struct route_map *map;
+
+	for (map = route_map_master.head; map; map = map->next) {
+		/* If use_count is zero, No protocol is using this routemap.
+		 * so adding to the list.
+		 */
+		if (!map->use_count)
+			listnode_add(maplist, map);
+	}
+
+	if (maplist->count > 0) {
+		vty_out(vty, "\n%s:\n", frr_protonameinst);
+		list_sort(maplist, sort_route_map);
+
+		for (ALL_LIST_ELEMENTS_RO(maplist, ln, map))
+			vty_show_route_map_entry(vty, map);
+	} else {
+		vty_out(vty, "\n%s: None\n", frr_protonameinst);
+	}
+
+	list_delete(&maplist);
+	return CMD_SUCCESS;
+}
 
 /* New route map allocation. Please note route map's name must be
    specified. */
@@ -2759,6 +2787,15 @@ DEFUN (rmap_show_name,
 	return vty_show_route_map(vty, name);
 }
 
+DEFUN (rmap_show_unused,
+       rmap_show_unused_cmd,
+       "show route-map-unused",
+       SHOW_STR
+       "unused route-map information\n")
+{
+	return vty_show_unused_route_map(vty);
+}
+
 DEFUN (rmap_call,
        rmap_call_cmd,
        "call WORD",
@@ -2949,6 +2986,23 @@ static void rmap_autocomplete(vector comps, struct cmd_token *token)
 		vector_set(comps, XSTRDUP(MTYPE_COMPLETION, map->name));
 }
 
+/* Increment the use_count counter while attaching the route map */
+void route_map_counter_increment(struct route_map *map)
+{
+	if (map)
+		map->use_count++;
+}
+
+/* Decrement the use_count counter while detaching the route map. */
+void route_map_counter_decrement(struct route_map *map)
+{
+	if (map) {
+		if (map->use_count <= 0)
+			return;
+		map->use_count--;
+	}
+}
+
 static const struct cmd_variable_handler rmap_var_handlers[] = {
 	{/* "route-map WORD" */
 	 .varname = "route_map",
@@ -3006,6 +3060,7 @@ void route_map_init(void)
 
 	/* Install show command */
 	install_element(ENABLE_NODE, &rmap_show_name_cmd);
+	install_element(ENABLE_NODE, &rmap_show_unused_cmd);
 
 	install_element(RMAP_NODE, &match_interface_cmd);
 	install_element(RMAP_NODE, &no_match_interface_cmd);

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -169,6 +169,9 @@ struct route_map {
 	/* How many times have we applied this route-map */
 	uint64_t applied;
 
+	/* Counter to track active usage of this route-map */
+	uint16_t use_count;
+
 	QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(route_map)
@@ -378,5 +381,11 @@ extern void route_map_no_set_tag_hook(int (*func)(struct vty *vty,
 
 extern void *route_map_rule_tag_compile(const char *arg);
 extern void route_map_rule_tag_free(void *rule);
+
+/* Increment the route-map used counter */
+extern void route_map_counter_increment(struct route_map *map);
+
+/* Decrement the route-map used counter */
+extern void route_map_counter_decrement(struct route_map *map);
 
 #endif /* _ZEBRA_ROUTEMAP_H */

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -856,16 +856,22 @@ void ospf6_asbr_lsentry_remove(struct ospf6_route *asbr_entry)
 
 static void ospf6_asbr_routemap_set(int type, const char *mapname)
 {
-	if (ospf6->rmap[type].name)
+	if (ospf6->rmap[type].name) {
+		route_map_counter_decrement(ospf6->rmap[type].map);
 		free(ospf6->rmap[type].name);
+	}
 	ospf6->rmap[type].name = strdup(mapname);
 	ospf6->rmap[type].map = route_map_lookup_by_name(mapname);
+	route_map_counter_increment(ospf6->rmap[type].map);
 }
 
 static void ospf6_asbr_routemap_unset(int type)
 {
 	if (ospf6->rmap[type].name)
 		free(ospf6->rmap[type].name);
+
+	route_map_counter_decrement(ospf6->rmap[type].map);
+
 	ospf6->rmap[type].name = NULL;
 	ospf6->rmap[type].map = NULL;
 }
@@ -939,6 +945,10 @@ static void ospf6_asbr_routemap_update(const char *mapname)
 						"%s: route-map %s update, reset redist %s",
 						__PRETTY_FUNCTION__, mapname,
 						ZROUTE_NAME(type));
+
+				route_map_counter_increment(
+					ospf6->rmap[type].map);
+
 				ospf6_asbr_distribute_list_update(type);
 			}
 		} else

--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -70,11 +70,19 @@ static void ospf_route_map_update(const char *name)
 					/* Keep old route-map. */
 					struct route_map *old = ROUTEMAP(red);
 
-					/* Update route-map. */
-					ROUTEMAP(red) =
-						route_map_lookup_by_name(
-							ROUTEMAP_NAME(red));
+					if (!old) {
+						/* Route-map creation */
+						/* Update route-map. */
+						ROUTEMAP(red) =
+							route_map_lookup_by_name(
+								ROUTEMAP_NAME(red));
 
+							route_map_counter_increment(
+								ROUTEMAP(red));
+					} else {
+						/* Route-map deletion */
+						ROUTEMAP(red) = NULL;
+					}
 					/* No update for this distribute type.
 					 */
 					if (old == NULL

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -983,17 +983,22 @@ int ospf_redistribute_check(struct ospf *ospf, struct external_info *ei,
 /* OSPF route-map set for redistribution */
 void ospf_routemap_set(struct ospf_redist *red, const char *name)
 {
-	if (ROUTEMAP_NAME(red))
+	if (ROUTEMAP_NAME(red)) {
+		route_map_counter_decrement(ROUTEMAP(red));
 		free(ROUTEMAP_NAME(red));
+	}
 
 	ROUTEMAP_NAME(red) = strdup(name);
 	ROUTEMAP(red) = route_map_lookup_by_name(name);
+	route_map_counter_increment(ROUTEMAP(red));
 }
 
 void ospf_routemap_unset(struct ospf_redist *red)
 {
-	if (ROUTEMAP_NAME(red))
+	if (ROUTEMAP_NAME(red)) {
+		route_map_counter_decrement(ROUTEMAP(red));
 		free(ROUTEMAP_NAME(red));
+	}
 
 	ROUTEMAP_NAME(red) = NULL;
 	ROUTEMAP(red) = NULL;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3438,10 +3438,13 @@ static void rip_routemap_update_redistribute(void)
 
 	if (rip) {
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
-			if (rip->route_map[i].name)
+			if (rip->route_map[i].name) {
 				rip->route_map[i].map =
 					route_map_lookup_by_name(
 						rip->route_map[i].name);
+				route_map_counter_increment(
+					rip->route_map[i].map);
+			}
 		}
 	}
 }

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2522,10 +2522,13 @@ static void ripng_routemap_update_redistribute(void)
 
 	if (ripng) {
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
-			if (ripng->route_map[i].name)
+			if (ripng->route_map[i].name) {
 				ripng->route_map[i].map =
 					route_map_lookup_by_name(
 						ripng->route_map[i].name);
+				route_map_counter_increment(
+					ripng->route_map[i].map);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Summary
Made the following changes.
1.Defined two apis in routemap-lib, one for increment and another for
  decrement the applied counter.
2.Added a  new configuration “show route-map-unused” to track all unused
  routemaps.
3.called the corresponding route map update api when a route map attached
  or detached from any redistribution list.

Applied these changes  to all corresponding the  daemons where ever these route maps are being used.

### Related Issue
[3090](https://github.com/FRRouting/frr/issues/3090)

### Components
[bgpd, libd, ospfd, zebrad, isisd, ospf6d, ripd, ripngd]

Signed-off-by: RajeshGirada <rgirada@vmware.com>