### PR TITLE
zebra: start the netns notification mechanism after ns initialisation

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -407,10 +407,7 @@ int main(int argc, char **argv)
 	/*
 	 * Initialize NS( and implicitly the VRF module), and make kernel
 	 * routing socket. */
-	zebra_ns_init();
-	if (vrf_default_name_configured)
-		vrf_set_default_name(vrf_default_name_configured,
-				     true);
+	zebra_ns_init((const char *)vrf_default_name_configured);
 	zebra_vty_init();
 	access_list_init();
 	prefix_list_init();

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -215,6 +215,12 @@ static int zebra_ns_ready_read(struct thread *t)
 	if (err < 0)
 		return zebra_ns_continue_read(zns_info, stop_retry);
 
+	/* check default name is not already set */
+	if (strmatch(VRF_DEFAULT_NAME, basename(netnspath))) {
+		zlog_warn("NS notify : NS %s is already default VRF."
+			  "Cancel VRF Creation", basename(netnspath));
+		return zebra_ns_continue_read(zns_info, 1);
+	}
 	if (zebra_ns_notify_is_default_netns(basename(netnspath))) {
 		zlog_warn(
 			  "NS notify : NS %s is default VRF."
@@ -309,6 +315,12 @@ void zebra_ns_notify_parse(void)
 		if (S_ISDIR(st.st_mode)) {
 			zlog_debug("NS parsing init: %s is not a NS",
 				   dent->d_name);
+			continue;
+		}
+		/* check default name is not already set */
+		if (strmatch(VRF_DEFAULT_NAME, basename(dent->d_name))) {
+			zlog_warn("NS notify : NS %s is already default VRF."
+				  "Cancel VRF Creation", dent->d_name);
 			continue;
 		}
 		if (zebra_ns_notify_is_default_netns(dent->d_name)) {

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -183,7 +183,7 @@ int zebra_ns_final_shutdown(struct ns *ns)
 	return 0;
 }
 
-int zebra_ns_init(void)
+int zebra_ns_init(const char *optional_default_name)
 {
 	ns_id_t ns_id;
 	ns_id_t ns_id_external;
@@ -206,6 +206,10 @@ int zebra_ns_init(void)
 
 	/* Default NS is activated */
 	zebra_ns_enable(ns_id_external, (void **)&dzns);
+
+	if (optional_default_name)
+		vrf_set_default_name(optional_default_name,
+				     true);
 
 	if (vrf_is_backend_netns()) {
 		ns_add_hook(NS_NEW_HOOK, zebra_ns_new);

--- a/zebra/zebra_ns.h
+++ b/zebra/zebra_ns.h
@@ -60,7 +60,7 @@ struct zebra_ns {
 
 struct zebra_ns *zebra_ns_lookup(ns_id_t ns_id);
 
-int zebra_ns_init(void);
+int zebra_ns_init(const char *optional_default_name);
 int zebra_ns_enable(ns_id_t ns_id, void **info);
 int zebra_ns_disabled(struct ns *ns);
 int zebra_ns_early_shutdown(struct ns *ns);


### PR DESCRIPTION
when zebra is run, by using vrf netns backend mode, then the parser
detector of netns is run before forcing the default vrf to a possible
value. In that case, there is a possibility that the forced '-o' option
will create a second vrf with same name, whereas this option should be
there to uniquely have a default vrf with a value.
To make things consistent, the forced value will be priorised. Then, the
notifier will attempt to create vrf contexts. The expectation is that
the creation will fail, due to an already present vrf with same name.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>

