### PR TITLE
ldpd: *BSD fixes

### DIFF
--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -139,6 +139,16 @@ ldpe(void)
 void
 ldpe_init(struct ldpd_init *init)
 {
+#ifdef __OpenBSD__
+	/* This socket must be open before dropping privileges. */
+	global.pfkeysock = pfkey_init();
+	if (sysdep.no_pfkey == 0) {
+		pfkey_ev = NULL;
+		thread_add_read(master, ldpe_dispatch_pfkey, NULL, global.pfkeysock,
+				&pfkey_ev);
+	}
+#endif
+
 	/* drop privileges */
 	ldpe_privs.user = init->user;
 	ldpe_privs.group = init->group;
@@ -159,14 +169,6 @@ ldpe_init(struct ldpd_init *init)
 		fatal("inet_pton");
 	if (inet_pton(AF_INET6, AllRouters_v6, &global.mcast_addr_v6) != 1)
 		fatal("inet_pton");
-#ifdef __OpenBSD__
-	global.pfkeysock = pfkey_init();
-	if (sysdep.no_pfkey == 0) {
-		pfkey_ev = NULL;
-		thread_add_read(master, ldpe_dispatch_pfkey, NULL, global.pfkeysock,
-				&pfkey_ev);
-	}
-#endif
 
 	/* mark sockets as closed */
 	global.ipv4.ldp_disc_socket = -1;

--- a/ldpd/socket.c
+++ b/ldpd/socket.c
@@ -268,9 +268,18 @@ sock_set_bindany(int fd, int enable)
 		return (-1);
 	}
 	return (0);
+#elif defined(IP_BINDANY)
+	frr_elevate_privs(&ldpd_privs) {
+		if (setsockopt(fd, IPPROTO_IP, IP_BINDANY, &enable, sizeof(int))
+		    < 0) {
+			log_warn("%s: error setting IP_BINDANY", __func__);
+			return (-1);
+		}
+	}
 #else
-	log_warnx("%s: missing SO_BINDANY and IP_FREEBIND, unable to bind "
-	    "to a nonlocal IP address", __func__);
+	log_warnx(
+		"%s: missing SO_BINDANY, IP_FREEBIND and IP_BINDANY, unable to bind to a nonlocal IP address",
+		__func__);
 	return (-1);
 #endif /* HAVE_SO_BINDANY */
 }

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -139,7 +139,9 @@ const struct message rtm_type_str[] = {{RTM_ADD, "RTM_ADD"},
 				       {RTM_LOSING, "RTM_LOSING"},
 				       {RTM_REDIRECT, "RTM_REDIRECT"},
 				       {RTM_MISS, "RTM_MISS"},
+#ifdef RTM_LOCK
 				       {RTM_LOCK, "RTM_LOCK"},
+#endif /* RTM_LOCK */
 #ifdef OLDADD
 				       {RTM_OLDADD, "RTM_OLDADD"},
 #endif /* RTM_OLDADD */


### PR DESCRIPTION
### Summary

This PR is a collection of fixes I've made while trying to run `ldpd` on FreeBSD/OpenBSD following the official instructions.

Changes:
  * Make FreeBSD at least start the socket to connect to `ldpd` neighbors, even though it doesn't support any MPLS route installation;
  * Fix OpenBSD compilation: version 6.4 doesn't have the define `RTM_LOCK` anymore ( https://marc.info/?l=openbsd-tech&m=153018811429193&w=2 ).
  * Fix `ldpd` PF key socket start on OpenBSD: it must be open before the privilege drop.

### Components
`zebra`, `ldpd`