### PR TITLE
bgpd: Modify End of Rib notification to INFO

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1612,6 +1612,8 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 		}
 
 		if (afi && peer->afc[afi][safi]) {
+			struct vrf *vrf = vrf_lookup_by_id(peer->bgp->vrf_id);
+
 			/* End-of-RIB received */
 			if (!CHECK_FLAG(peer->af_sflags[afi][safi],
 					PEER_STATUS_EOR_RECEIVED)) {
@@ -1624,11 +1626,9 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			if (peer->nsf[afi][safi])
 				bgp_clear_stale_route(peer, afi, safi);
 
-			if (bgp_debug_neighbor_events(peer)) {
-				zlog_debug("rcvd End-of-RIB for %s from %s",
-					   afi_safi_print(afi, safi),
-					   peer->host);
-			}
+			zlog_info("%%NOTIFICATION: rcvd End-of-RIB for %s from %s in vrf %s",
+				  afi_safi_print(afi, safi), peer->host,
+				  vrf ? vrf->name : VRF_DEFAULT_NAME);
 		}
 	}
 


### PR DESCRIPTION
The End of Rib notification in BGP is useful to know no matter
the circumstances.  So change this from a debug message to
an info and cleanup the message a bit and add vrf we are in.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

