### PR TITLE
bgp Community list speedup

### DIFF
--- a/bgpd/bgp_clist.h
+++ b/bgpd/bgp_clist.h
@@ -100,6 +100,7 @@ struct community_list_list {
 struct community_list_master {
 	struct community_list_list num;
 	struct community_list_list str;
+	struct hash *hash;
 };
 
 /* Community-list handler.  community_list_init() returns this

--- a/bgpd/bgp_clist.h
+++ b/bgpd/bgp_clist.h
@@ -21,6 +21,8 @@
 #ifndef _QUAGGA_BGP_CLIST_H
 #define _QUAGGA_BGP_CLIST_H
 
+#include "jhash.h"
+
 /* Master Community-list. */
 #define COMMUNITY_LIST_MASTER          0
 #define EXTCOMMUNITY_LIST_MASTER       1
@@ -46,6 +48,9 @@
 struct community_list {
 	/* Name of the community-list.  */
 	char *name;
+
+	/* Stored hash value of name, to further speed up hash operations */
+	uint32_t name_hash;
 
 	/* String or number.  */
 	int sort;
@@ -152,7 +157,8 @@ extern struct community_list_master *
 community_list_master_lookup(struct community_list_handler *, int);
 
 extern struct community_list *
-community_list_lookup(struct community_list_handler *, const char *, int);
+community_list_lookup(struct community_list_handler *c, const char *name,
+		      uint32_t name_hash, int master);
 
 extern int community_list_match(struct community *, struct community_list *);
 extern int ecommunity_list_match(struct ecommunity *, struct community_list *);
@@ -164,4 +170,10 @@ extern struct community *community_list_match_delete(struct community *,
 extern struct lcommunity *
 lcommunity_list_match_delete(struct lcommunity *lcom,
 			     struct community_list *list);
+
+static inline uint32_t bgp_clist_hash_key(char *name)
+{
+	return jhash(name, sizeof(name), 0xdeadbeaf);
+}
+
 #endif /* _QUAGGA_BGP_CLIST_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9266,7 +9266,7 @@ static int bgp_show_lcommunity_list(struct vty *vty, struct bgp *bgp,
 {
 	struct community_list *list;
 
-	list = community_list_lookup(bgp_clist, lcom,
+	list = community_list_lookup(bgp_clist, lcom, 0,
 				     LARGE_COMMUNITY_LIST_MASTER);
 	if (list == NULL) {
 		vty_out(vty, "%% %s is not a valid large-community-list name\n",
@@ -9787,7 +9787,7 @@ static int bgp_show_community_list(struct vty *vty, struct bgp *bgp,
 {
 	struct community_list *list;
 
-	list = community_list_lookup(bgp_clist, com, COMMUNITY_LIST_MASTER);
+	list = community_list_lookup(bgp_clist, com, 0, COMMUNITY_LIST_MASTER);
 	if (list == NULL) {
 		vty_out(vty, "%% %s is not a valid community-list name\n", com);
 		return CMD_WARNING;

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1037,6 +1037,7 @@ struct route_map_rule_cmd route_match_aspath_cmd = {
 /* `match community COMMUNIY' */
 struct rmap_community {
 	char *name;
+	uint32_t name_hash;
 	int exact;
 };
 
@@ -1055,6 +1056,7 @@ static route_map_result_t route_match_community(void *rule,
 		rcom = rule;
 
 		list = community_list_lookup(bgp_clist, rcom->name,
+					     rcom->name_hash,
 					     COMMUNITY_LIST_MASTER);
 		if (!list)
 			return RMAP_NOMATCH;
@@ -1090,6 +1092,8 @@ static void *route_match_community_compile(const char *arg)
 		rcom->name = XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, arg);
 		rcom->exact = 0;
 	}
+
+	rcom->name_hash = bgp_clist_hash_key(rcom->name);
 	return rcom;
 }
 
@@ -1121,6 +1125,7 @@ static route_map_result_t route_match_lcommunity(void *rule,
 		path = object;
 
 		list = community_list_lookup(bgp_clist, rcom->name,
+					     rcom->name_hash,
 					     LARGE_COMMUNITY_LIST_MASTER);
 		if (!list)
 			return RMAP_NOMATCH;
@@ -1149,6 +1154,8 @@ static void *route_match_lcommunity_compile(const char *arg)
 		rcom->name = XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, arg);
 		rcom->exact = 0;
 	}
+
+	rcom->name_hash = bgp_clist_hash_key(rcom->name);
 	return rcom;
 }
 
@@ -1181,6 +1188,7 @@ static route_map_result_t route_match_ecommunity(void *rule,
 		path = object;
 
 		list = community_list_lookup(bgp_clist, rcom->name,
+					     rcom->name_hash,
 					     EXTCOMMUNITY_LIST_MASTER);
 		if (!list)
 			return RMAP_NOMATCH;
@@ -1198,6 +1206,7 @@ static void *route_match_ecommunity_compile(const char *arg)
 
 	rcom = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(struct rmap_community));
 	rcom->name = XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, arg);
+	rcom->name_hash = bgp_clist_hash_key(rcom->name);
 
 	return rcom;
 }
@@ -1948,6 +1957,7 @@ static route_map_result_t route_set_lcommunity_delete(void *rule,
 
 		path = object;
 		list = community_list_lookup(bgp_clist, rcom->name,
+					     rcom->name_hash,
 					     LARGE_COMMUNITY_LIST_MASTER);
 		old = path->attr->lcommunity;
 
@@ -2000,6 +2010,7 @@ static void *route_set_lcommunity_delete_compile(const char *arg)
 		str = NULL;
 
 	rcom->name = str;
+	rcom->name_hash = bgp_clist_hash_key(rcom->name);
 	return rcom;
 }
 
@@ -2041,6 +2052,7 @@ static route_map_result_t route_set_community_delete(
 
 		path = object;
 		list = community_list_lookup(bgp_clist, rcom->name,
+					     rcom->name_hash,
 					     COMMUNITY_LIST_MASTER);
 		old = path->attr->community;
 
@@ -2093,6 +2105,7 @@ static void *route_set_community_delete_compile(const char *arg)
 		str = NULL;
 
 	rcom->name = str;
+	rcom->name_hash = bgp_clist_hash_key(rcom->name);
 	return rcom;
 }
 

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1048,7 +1048,7 @@ static route_map_result_t route_match_community(void *rule,
 {
 	struct community_list *list;
 	struct bgp_path_info *path;
-	struct rmap_community *rcom;
+	struct rmap_community *rcom = rule;
 
 	if (type == RMAP_BGP) {
 		path = object;
@@ -1115,11 +1115,10 @@ static route_map_result_t route_match_lcommunity(void *rule,
 {
 	struct community_list *list;
 	struct bgp_path_info *path;
-	struct rmap_community *rcom;
+	struct rmap_community *rcom = rule;
 
 	if (type == RMAP_BGP) {
 		path = object;
-		rcom = rule;
 
 		list = community_list_lookup(bgp_clist, rcom->name,
 					     LARGE_COMMUNITY_LIST_MASTER);
@@ -1176,11 +1175,12 @@ static route_map_result_t route_match_ecommunity(void *rule,
 {
 	struct community_list *list;
 	struct bgp_path_info *path;
+	struct rmap_community *rcom = rule;
 
 	if (type == RMAP_BGP) {
 		path = object;
 
-		list = community_list_lookup(bgp_clist, (char *)rule,
+		list = community_list_lookup(bgp_clist, rcom->name,
 					     EXTCOMMUNITY_LIST_MASTER);
 		if (!list)
 			return RMAP_NOMATCH;
@@ -1194,13 +1194,21 @@ static route_map_result_t route_match_ecommunity(void *rule,
 /* Compile function for extcommunity match. */
 static void *route_match_ecommunity_compile(const char *arg)
 {
-	return XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, arg);
+	struct rmap_community *rcom;
+
+	rcom = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(struct rmap_community));
+	rcom->name = XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, arg);
+
+	return rcom;
 }
 
 /* Compile function for extcommunity match. */
 static void route_match_ecommunity_free(void *rule)
 {
-	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
+	struct rmap_community *rcom = rule;
+
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rcom->name);
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rcom);
 }
 
 /* Route map commands for community matching. */
@@ -1932,13 +1940,14 @@ static route_map_result_t route_set_lcommunity_delete(void *rule,
 	struct lcommunity *new;
 	struct lcommunity *old;
 	struct bgp_path_info *path;
+	struct rmap_community *rcom = rule;
 
 	if (type == RMAP_BGP) {
-		if (!rule)
+		if (!rcom)
 			return RMAP_OKAY;
 
 		path = object;
-		list = community_list_lookup(bgp_clist, rule,
+		list = community_list_lookup(bgp_clist, rcom->name,
 					     LARGE_COMMUNITY_LIST_MASTER);
 		old = path->attr->lcommunity;
 
@@ -1975,9 +1984,12 @@ static route_map_result_t route_set_lcommunity_delete(void *rule,
 /* Compile function for set lcommunity. */
 static void *route_set_lcommunity_delete_compile(const char *arg)
 {
+	struct rmap_community *rcom;
 	char *p;
 	char *str;
 	int len;
+
+	rcom = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(struct rmap_community));
 
 	p = strchr(arg, ' ');
 	if (p) {
@@ -1987,13 +1999,17 @@ static void *route_set_lcommunity_delete_compile(const char *arg)
 	} else
 		str = NULL;
 
-	return str;
+	rcom->name = str;
+	return rcom;
 }
 
 /* Free function for set lcommunity. */
 static void route_set_lcommunity_delete_free(void *rule)
 {
-	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
+	struct rmap_community *rcom = rule;
+
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rcom->name);
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rcom);
 }
 
 /* Set lcommunity rule structure. */
@@ -2017,13 +2033,14 @@ static route_map_result_t route_set_community_delete(
 	struct community *new;
 	struct community *old;
 	struct bgp_path_info *path;
+	struct rmap_community *rcom = rule;
 
 	if (type == RMAP_BGP) {
-		if (!rule)
+		if (!rcom)
 			return RMAP_OKAY;
 
 		path = object;
-		list = community_list_lookup(bgp_clist, rule,
+		list = community_list_lookup(bgp_clist, rcom->name,
 					     COMMUNITY_LIST_MASTER);
 		old = path->attr->community;
 
@@ -2060,9 +2077,12 @@ static route_map_result_t route_set_community_delete(
 /* Compile function for set community. */
 static void *route_set_community_delete_compile(const char *arg)
 {
+	struct rmap_community *rcom;
 	char *p;
 	char *str;
 	int len;
+
+	rcom = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(struct rmap_community));
 
 	p = strchr(arg, ' ');
 	if (p) {
@@ -2072,13 +2092,17 @@ static void *route_set_community_delete_compile(const char *arg)
 	} else
 		str = NULL;
 
-	return str;
+	rcom->name = str;
+	return rcom;
 }
 
 /* Free function for set community. */
 static void route_set_community_delete_free(void *rule)
 {
-	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
+	struct rmap_community *rcom = rule;
+
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rcom->name);
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rcom);
 }
 
 /* Set community rule structure. */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -14309,7 +14309,7 @@ DEFUN (show_community_list_arg,
 		vty_out(vty, "'show bgp community-list <(1-500)|WORD>'\n");
 		zlog_warn("Deprecated option: 'ip show community-list <(1-500)|WORD>' being used");
 	}
-	list = community_list_lookup(bgp_clist, argv[idx_comm_list]->arg,
+	list = community_list_lookup(bgp_clist, argv[idx_comm_list]->arg, 0,
 				     COMMUNITY_LIST_MASTER);
 	if (!list) {
 		vty_out(vty, "%% Can't find community-list\n");
@@ -14834,7 +14834,7 @@ DEFUN (show_lcommunity_list_arg,
 		zlog_warn("Deprecated option: 'ip show large-community-list <(1-500)|WORD>' being used");
 	}
 
-	list = community_list_lookup(bgp_clist, argv[3]->arg,
+	list = community_list_lookup(bgp_clist, argv[3]->arg, 0,
 				     LARGE_COMMUNITY_LIST_MASTER);
 	if (!list) {
 		vty_out(vty, "%% Can't find extcommunity-list\n");
@@ -15235,7 +15235,7 @@ DEFUN (show_extcommunity_list_arg,
 		vty_out(vty, "'show bgp extcommunity-list <(1-500)|WORD>'\n");
 		zlog_warn("Deprecated option: 'ip show extcommunity-list <(1-500)|WORD>' being used");
 	}
-	list = community_list_lookup(bgp_clist, argv[idx_comm_list]->arg,
+	list = community_list_lookup(bgp_clist, argv[idx_comm_list]->arg, 0,
 				     EXTCOMMUNITY_LIST_MASTER);
 	if (!list) {
 		vty_out(vty, "%% Can't find extcommunity-list\n");


### PR DESCRIPTION
BGP maintains the community list data structure as a linked list of data.  This data structure is optimized for display purposes not for run-time application of route-maps that use the community list.  Modify the clist code to have a hash for O(1) lookup of the data, Additionally modify this hash addition to have knowledge of it's hash value computed so we can further increase.

In my testbed, I have a bgp process that receives 14 full bgp feeds( a real feed of data ) and each neighbor has a routemap in and out that both have community/ecommunity/lcommunity matching in them.  Without my changes, convergence took ~2:45 wall clock and bgp cpu usage was ~151.71 seconds.  After these changes I am seeing convergence in ~55 seconds and around 40 seconds of bgp cpu time.  BGP cpu time is as reported by `show thread cpu`.  Convergence time is measured by the EOR notification from a peer.