### PR TITLE
zebra: remove duplicated code

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -784,7 +784,8 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 
 				if (h->nlmsg_len
 				    < NLMSG_LENGTH(sizeof(struct nlmsgerr))) {
-					zlog_err("%s error: message truncated",
+					flog_err(EC_ZEBRA_NETLINK_LENGTH_ERROR,
+						 "%s error: message truncated",
 						 nl->name);
 					return -1;
 				}

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -820,14 +820,6 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 					continue;
 				}
 
-				if (h->nlmsg_len
-				    < NLMSG_LENGTH(sizeof(struct nlmsgerr))) {
-					flog_err(EC_ZEBRA_NETLINK_LENGTH_ERROR,
-						 "%s error: message truncated",
-						 nl->name);
-					return -1;
-				}
-
 				/* Deal with errors that occur because of races
 				 * in link handling */
 				if (zns->is_cmd


### PR DESCRIPTION
### Summary

Remove duplicated code at the netlink error message handling code. The error message length check is already being done before that part.

(check out line 785 of the same file)


### Components

`zebra`