### PR TITLE
staticd: Do not ready prefix for printing till it's decoded

### DIFF
--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -154,10 +154,10 @@ static int route_notify_owner(int command, struct zclient *zclient,
 	uint32_t table_id;
 	char buf[PREFIX_STRLEN];
 
-	prefix2str(&p, buf, sizeof(buf));
-
 	if (!zapi_route_notify_decode(zclient->ibuf, &p, &table_id, &note))
 		return -1;
+
+	prefix2str(&p, buf, sizeof(buf));
 
 	switch (note) {
 	case ZAPI_ROUTE_FAIL_INSTALL:


### PR DESCRIPTION
The static daemon is setting up the prefix for printing
before it is decoded when we get notified about our
route.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
