### PR TITLE
bgpd: evpn command to restrict to default vrf

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2883,6 +2883,12 @@ DEFUN (bgp_evpn_advertise_default_gw,
 	if (!bgp)
 		return CMD_WARNING;
 
+	if (bgp->vrf_id != VRF_DEFAULT) {
+		vty_out(vty,
+			"This command is only supported under Default VRF\n");
+		return CMD_WARNING;
+	}
+
 	evpn_set_advertise_default_gw(bgp, NULL);
 
 	return CMD_SUCCESS;
@@ -2898,6 +2904,12 @@ DEFUN (no_bgp_evpn_advertise_default_gw,
 
 	if (!bgp)
 		return CMD_WARNING;
+
+	if (bgp->vrf_id != VRF_DEFAULT) {
+		vty_out(vty,
+			"This command is only supported under Default VRF\n");
+		return CMD_WARNING;
+	}
 
 	evpn_unset_advertise_default_gw(bgp, NULL);
 
@@ -3011,6 +3023,12 @@ DEFPY (dup_addr_detection,
 	if (!bgp_vrf)
 		return CMD_WARNING;
 
+	if (bgp_vrf->vrf_id != VRF_DEFAULT) {
+		vty_out(vty,
+			"This command is only supported under Default VRF\n");
+		return CMD_WARNING;
+	}
+
 	bgp_vrf->evpn_info->dup_addr_detect = true;
 
 	if (time_val)
@@ -3036,6 +3054,12 @@ DEFPY (dup_addr_detection_auto_recovery,
 
 	if (!bgp_vrf)
 		return CMD_WARNING;
+
+	if (bgp_vrf->vrf_id != VRF_DEFAULT) {
+		vty_out(vty,
+			"This command is only supported under Default VRF\n");
+		return CMD_WARNING;
+	}
 
 	bgp_vrf->evpn_info->dup_addr_detect = true;
 	bgp_vrf->evpn_info->dad_freeze = true;
@@ -3065,6 +3089,12 @@ DEFPY (no_dup_addr_detection,
 
 	if (!bgp_vrf)
 		return CMD_WARNING;
+
+	if (bgp_vrf->vrf_id != VRF_DEFAULT) {
+		vty_out(vty,
+			"This command is only supported under Default VRF\n");
+		return CMD_WARNING;
+	}
 
 	if (argc == 2) {
 		if (!bgp_vrf->evpn_info->dup_addr_detect)


### PR DESCRIPTION
### Summary

Certain EVPN configuartions should only be applied
under DEFAULT VRF bgpd instance.

reject the cli for non default bgp instance

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>

### Related Issue
Need to block inapplicable options under bgp vrf af l2vpn evpn

### Components
[bgpd]
