### PR TITLE
bgpd: use the wording vrf instead of table

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8974,12 +8974,14 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 		vty_out(vty, "Paths: (%d available", count);
 		if (best) {
 			vty_out(vty, ", best #%d", best);
-			if (safi == SAFI_UNICAST)
-				vty_out(vty, ", table %s",
-					(bgp->inst_type
-					 == BGP_INSTANCE_TYPE_DEFAULT)
-						? VRF_DEFAULT_NAME
-						: bgp->name);
+			if (safi == SAFI_UNICAST) {
+				if (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)
+					vty_out(vty, ", table %s",
+						VRF_DEFAULT_NAME);
+				else
+					vty_out(vty, ", vrf %s",
+						bgp->name);
+			}
 		} else
 			vty_out(vty, ", no best path");
 


### PR DESCRIPTION
in bgp, even if the main vrf implementation relies on tables, the fact
is some vrf implementation rely on network namespaces, and then the
table used is the default table from the network namespace. Use the
wording vrf instead of table.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
