### PR TITLE
lib: fix segfault on freebsd when using vsnprintf() incorrectly

### DIFF
--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -79,8 +79,7 @@ void nb_cli_enqueue_change(struct vty *vty, const char *xpath,
 int nb_cli_apply_changes(struct vty *vty, const char *xpath_base_fmt, ...)
 {
 	struct nb_config *candidate_transitory;
-	char xpath_base[XPATH_MAXLEN];
-	va_list ap;
+	char xpath_base[XPATH_MAXLEN] = {};
 	bool error = false;
 	int ret;
 
@@ -94,9 +93,13 @@ int nb_cli_apply_changes(struct vty *vty, const char *xpath_base_fmt, ...)
 	candidate_transitory = nb_config_dup(vty->candidate_config);
 
 	/* Parse the base XPath format string. */
-	va_start(ap, xpath_base_fmt);
-	vsnprintf(xpath_base, sizeof(xpath_base), xpath_base_fmt, ap);
-	va_end(ap);
+	if (xpath_base_fmt) {
+		va_list ap;
+
+		va_start(ap, xpath_base_fmt);
+		vsnprintf(xpath_base, sizeof(xpath_base), xpath_base_fmt, ap);
+		va_end(ap);
+	}
 
 	/* Edit candidate configuration. */
 	for (size_t i = 0; i < vty->num_cfg_changes; i++) {

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -60,7 +60,7 @@ extern void nb_cli_enqueue_change(struct vty *vty, const char *xpath,
  *
  * xpath_base_fmt
  *    Prepend the given XPath (absolute or relative) to all enqueued
- *    configuration changes.
+ *    configuration changes. This is an optional parameter.
  *
  * Returns:
  *    CMD_SUCCESS on success, CMD_WARNING_CONFIG_FAILED otherwise.


### PR DESCRIPTION
FreeBSD's libc segfaults when vsnprintf() is called with a null
format string. Add a null check before calling vsnprintf() to
resolve this problem.

Fixes #3537

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>