### PR TITLE
zebra: fix vrf netns broken

### DIFF
--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -73,6 +73,7 @@ static int zebra_ns_new(struct ns *ns)
 	zns = zebra_ns_alloc();
 	ns->info = zns;
 	zns->ns = ns;
+	zns->ns_id = ns->ns_id;
 
 	/* Do any needed per-NS data structure allocation. */
 	zns->if_table = route_table_init();


### PR DESCRIPTION
this commit partially reverts a comit named:
"zebra: fix zebra router memleaks"
More investigation should be needed to understand why this patch is
fixing the netns case.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
