### PR TITLE
Route Table Handling and shows

### DIFF
--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -126,6 +126,25 @@ unsigned long zebra_router_score_proto(uint8_t proto, unsigned short instance)
 	return cnt;
 }
 
+void zebra_router_show_table_summary(struct vty *vty)
+{
+	struct zebra_router_table *zrt;
+
+	vty_out(vty,
+		"VRF             NS ID    VRF ID     AFI            SAFI    Table      Count\n");
+	vty_out(vty,
+		"---------------------------------------------------------------------------\n");
+	RB_FOREACH (zrt, zebra_router_table_head, &zrouter.tables) {
+		rib_table_info_t *info = route_table_get_info(zrt->table);
+
+		vty_out(vty, "%-16s%5d %9d %7s %15s %8d %10lu\n", info->zvrf->vrf->name,
+			zrt->ns_id, info->zvrf->vrf->vrf_id,
+			afi2str(zrt->afi), safi2str(zrt->safi),
+			zrt->tableid,
+			zrt->table->count);
+	}
+}
+
 void zebra_router_sweep_route(void)
 {
 	struct zebra_router_table *zrt;

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -105,7 +105,7 @@ struct route_table *zebra_router_get_table(struct zebra_vrf *zvrf,
 	info = XCALLOC(MTYPE_RIB_TABLE_INFO, sizeof(*info));
 	info->zvrf = zvrf;
 	info->afi = afi;
-	info->safi = SAFI_UNICAST;
+	info->safi = safi;
 	route_table_set_info(zrt->table, info);
 	zrt->table->cleanup = zebra_rtable_node_cleanup;
 

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -81,4 +81,6 @@ extern int zebra_router_config_write(struct vty *vty);
 extern unsigned long zebra_router_score_proto(uint8_t proto,
 					      unsigned short instance);
 extern void zebra_router_sweep_route(void);
+
+extern void zebra_router_show_table_summary(struct vty *vty);
 #endif

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -370,22 +370,10 @@ static void zebra_rnhtable_node_cleanup(struct route_table *table,
 static void zebra_vrf_table_create(struct zebra_vrf *zvrf, afi_t afi,
 				   safi_t safi)
 {
-	rib_table_info_t *info;
-	struct route_table *table;
-
 	assert(!zvrf->table[afi][safi]);
 
-	table = zebra_router_get_table(zvrf, zvrf->table_id, afi, safi);
-
-	table->cleanup = zebra_rtable_node_cleanup;
-	zvrf->table[afi][safi] = table;
-
-	XFREE(MTYPE_RIB_TABLE_INFO, table->info);
-	info = XCALLOC(MTYPE_RIB_TABLE_INFO, sizeof(*info));
-	info->zvrf = zvrf;
-	info->afi = afi;
-	info->safi = safi;
-	route_table_set_info(table, info);
+	zvrf->table[afi][safi] =
+		zebra_router_get_table(zvrf, zvrf->table_id, afi, safi);
 }
 
 /* Allocate new zebra VRF. */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2857,6 +2857,20 @@ DEFUN (no_zebra_dplane_queue_limit,
 	return CMD_SUCCESS;
 }
 
+DEFUN (zebra_show_routing_tables_summary,
+       zebra_show_routing_tables_summary_cmd,
+       "show zebra router table summary",
+       SHOW_STR
+       ZEBRA_STR
+       "The Zebra Router Information\n"
+       "Table Information about this Zebra Router\n"
+       "Summary Information\n")
+{
+	zebra_router_show_table_summary(vty);
+
+	return CMD_SUCCESS;
+}
+
 /* Table configuration write function. */
 static int config_write_table(struct vty *vty)
 {
@@ -3000,4 +3014,6 @@ void zebra_vty_init(void)
 	install_element(VIEW_NODE, &show_dataplane_providers_cmd);
 	install_element(CONFIG_NODE, &zebra_dplane_queue_limit_cmd);
 	install_element(CONFIG_NODE, &no_zebra_dplane_queue_limit_cmd);
+
+	install_element(VIEW_NODE, &zebra_show_routing_tables_summary_cmd);
 }


### PR DESCRIPTION
Three things:
1) Create a `show zebra router table summary` command that dumps the zebra state of route table information.
2) Fix staticd to actually install the mroute we created
3) Fix table creation a little bit in that we were creating a info pointer, throwing it away and then recreating it.