### PR TITLE
isisd: fix point-to-point network type config

### DIFF
--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -1982,11 +1982,10 @@ static int lib_interface_isis_network_type_modify(enum nb_event event,
 		circuit = yang_dnode_get_entry(dnode, false);
 		if (!circuit)
 			break;
-		if (circuit->circ_type == CIRCUIT_T_LOOPBACK
-		    || circuit->circ_type == CIRCUIT_T_UNKNOWN) {
+		if (circuit->circ_type == CIRCUIT_T_LOOPBACK) {
 			flog_warn(
 				EC_LIB_NB_CB_CONFIG_VALIDATE,
-				"Cannot change network type on unknown or loopback interface");
+				"Cannot change network type on loopback interface");
 			return NB_ERR_VALIDATION;
 		}
 		if (net_type == CIRCUIT_T_BROADCAST


### PR DESCRIPTION
### Summary
`isis network point-to-point` was being rejected from the configuration
file as it was being processed before the reception of the zebra
interface-up notification. This meant that the `circ_type` was set
at `CIRCUIT_T_UNKNOWN`, which led the northbound callback to fail. This
check was removed as it was not really necessary; when the zebra
notification is received, the correct circuit type will be enforced,
but now the point-to-point config will be saved and correctly applied
when zebra recognizes the interface as a broadcast one.

### Related Issue
N/A (see isisd slack channel)

### Components
isisd