### PR TITLE
bgpd: don't use BGP_ATTR_VNC(255) unless ENABLE_BGP_VNC_ATTR is defined

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -78,7 +78,7 @@ static const struct message attr_str[] = {
 	{BGP_ATTR_AS_PATHLIMIT, "AS_PATHLIMIT"},
 	{BGP_ATTR_PMSI_TUNNEL, "PMSI_TUNNEL_ATTRIBUTE"},
 	{BGP_ATTR_ENCAP, "ENCAP"},
-#if ENABLE_BGP_VNC
+#if ENABLE_BGP_VNC_ATTR
 	{BGP_ATTR_VNC, "VNC"},
 #endif
 	{BGP_ATTR_LARGE_COMMUNITIES, "LARGE_COMMUNITY"},
@@ -2593,7 +2593,7 @@ bgp_attr_parse_ret_t bgp_attr_parse(struct peer *peer, struct attr *attr,
 		case BGP_ATTR_EXT_COMMUNITIES:
 			ret = bgp_attr_ext_communities(&attr_args);
 			break;
-#if ENABLE_BGP_VNC
+#if ENABLE_BGP_VNC_ATTR
 		case BGP_ATTR_VNC:
 #endif
 		case BGP_ATTR_ENCAP:
@@ -2946,7 +2946,7 @@ static void bgp_packet_mpattr_tea(struct bgp *bgp, struct peer *peer,
 		attrhdrlen = 1 + 1;   /* subTLV T + L */
 		break;
 
-#if ENABLE_BGP_VNC
+#if ENABLE_BGP_VNC_ATTR
 	case BGP_ATTR_VNC:
 		attrname = "VNC";
 		subtlvs = attr->vnc_subtlvs;
@@ -3433,7 +3433,7 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 		/* Tunnel Encap attribute */
 		bgp_packet_mpattr_tea(bgp, peer, s, attr, BGP_ATTR_ENCAP);
 
-#if ENABLE_BGP_VNC
+#if ENABLE_BGP_VNC_ATTR
 		/* VNC attribute */
 		bgp_packet_mpattr_tea(bgp, peer, s, attr, BGP_ATTR_VNC);
 #endif

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1280,7 +1280,7 @@ struct bgp_nlri {
 #define BGP_ATTR_ENCAP                          23
 #define BGP_ATTR_LARGE_COMMUNITIES              32
 #define BGP_ATTR_PREFIX_SID                     40
-#if ENABLE_BGP_VNC
+#if ENABLE_BGP_VNC_ATTR
 #define BGP_ATTR_VNC                           255
 #endif
 

--- a/tests/topotests/bgp_rfapi_basic_sanity/r1/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r1/bgpd.conf
@@ -20,7 +20,7 @@ router bgp 5226
      neighbor 2.2.2.2 activate
    exit-address-family
 !
- rfp holddown-factor 100
+ rfp holddown-factor 0
 !
  vnc defaults
   rd auto:vn:123

--- a/tests/topotests/bgp_rfapi_basic_sanity/r3/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r3/bgpd.conf
@@ -18,7 +18,7 @@ router bgp 5226
      neighbor 2.2.2.2 activate
    exit-address-family
 !
- rfp holddown-factor 100
+ rfp holddown-factor 0
 !
  vnc defaults
   rd auto:vn:123

--- a/tests/topotests/bgp_rfapi_basic_sanity/r4/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity/r4/bgpd.conf
@@ -19,7 +19,7 @@ router bgp 5226
      neighbor 2.2.2.2 activate
    exit-address-family
 !
- rfp holddown-factor 100
+ rfp holddown-factor 0
 !
  vnc defaults
   rd auto:vn:123

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r1/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r1/bgpd.conf
@@ -20,7 +20,7 @@ router bgp 5226
      neighbor 2.2.2.2 activate
    exit-address-family
 !
- rfp holddown-factor 100
+ rfp holddown-factor 0
  rfp full-table-download off
 !
  vnc defaults

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r3/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r3/bgpd.conf
@@ -18,7 +18,7 @@ router bgp 5226
      neighbor 2.2.2.2 activate
    exit-address-family
 !
- rfp holddown-factor 100
+ rfp holddown-factor 0
  rfp full-table-download off
 !
  vnc defaults

--- a/tests/topotests/bgp_rfapi_basic_sanity_config2/r4/bgpd.conf
+++ b/tests/topotests/bgp_rfapi_basic_sanity_config2/r4/bgpd.conf
@@ -19,7 +19,7 @@ router bgp 5226
      neighbor 2.2.2.2 activate
    exit-address-family
 !
- rfp holddown-factor 100
+ rfp holddown-factor 0
  rfp full-table-download off
 !
  vnc defaults


### PR DESCRIPTION

### Summary
Add ENABLE_BGP_VNC_ATTR check to use of BGP_ATTR_VNC(255) , off by default.

### Components
bgpd