### PR TITLE
zebra: update local ns_id field

### DIFF
--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -93,6 +93,7 @@ static int zebra_ns_new(struct ns *ns)
 	zns = zebra_ns_alloc();
 	ns->info = zns;
 	zns->ns = ns;
+	zns->ns_id = ns->ns_id;
 
 	/* Do any needed per-NS data structure allocation. */
 	zns->if_table = route_table_init();


### PR DESCRIPTION
ns_id field must be synced with ns_id from netns service.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
