### PR TITLE
lib: Convert RUSAGE_SELF to RUSAGE_THREAD where we can

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -1572,8 +1572,13 @@ void thread_set_yield_time(struct thread *thread, unsigned long yield_time)
 
 void thread_getrusage(RUSAGE_T *r)
 {
+#if defined RUSAGE_THREAD
+#define FRR_RUSAGE RUSAGE_THREAD
+#else
+#define FRR_RUSAGE RUSAGE_SELF
+#endif
 	monotime(&r->real);
-	getrusage(RUSAGE_SELF, &(r->cpu));
+	getrusage(FRR_RUSAGE, &(r->cpu));
 }
 
 /*


### PR DESCRIPTION
When using getrusage, we have multiple choices about what
to call for data gathering about this particular thread of execution.

RUSAGE_SELF -> This means gather all cpu run time for all pthreads associated
with this process.

RUSAGE_THREAD -> This means gather all cpu run time for this particular
pthread.

Clearly with data gathering for slow thread as well as `show thread cpu`
it would be preferable to gather only data about the current running
pthread.  This probably was the original behavior of using RUSAGE_SELF
when we didn't have multiple pthreads.  So it didn't matter so much.

Prior to this change, 10 iterations of 1 million routes install/remove
from zebra would give us this cpu time for the dataplane pthread:

Showing statistics for pthread Zebra dplane thread
--------------------------------------------------
                      CPU (user+system): Real (wall-clock):
Active   Runtime(ms)   Invoked Avg uSec Max uSecs Avg uSec Max uSecs  Type  Thread
    0     280902.149    326541      860   2609982      550   2468910    E  dplane_thread_loop

After this change we are seeing this:

Showing statistics for pthread Zebra dplane thread
--------------------------------------------------
                      CPU (user+system): Real (wall-clock):
Active   Runtime(ms)   Invoked Avg uSec Max uSecs Avg uSec Max uSecs  Type  Thread
    0      58045.560    334944      173    277226      539   2502268    E  dplane_thread_loop

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
