### PR TITLE
FRR pthread setnames

### DIFF
--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -181,7 +181,11 @@ void *bgp_keepalives_start(void *arg)
 	pthread_cond_init(peerhash_cond, &attrs);
 	pthread_condattr_destroy(&attrs);
 
-	frr_pthread_set_name(fpt, NULL, "bgpd_ka");
+	/*
+	 * We are not using normal FRR pthread mechanics and are
+	 * not using fpt_run
+	 */
+	frr_pthread_set_name(fpt);
 
 	/* initialize peer hashtable */
 	peerhash = hash_create_size(2048, peer_hash_key, peer_hash_cmp, NULL);

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -84,6 +84,8 @@ struct frr_pthread *frr_pthread_new(struct frr_pthread_attr *attr,
 	fpt->name = XSTRDUP(MTYPE_FRR_PTHREAD, name);
 	if (os_name)
 		snprintf(fpt->os_name, OS_THREAD_NAMELEN, "%s", os_name);
+	else
+		snprintf(fpt->os_name, OS_THREAD_NAMELEN, "%s", name);
 	/* initialize startup synchronization primitives */
 	fpt->running_cond_mtx = XCALLOC(
 		MTYPE_PTHREAD_PRIM, sizeof(pthread_mutex_t));

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -117,36 +117,19 @@ void frr_pthread_destroy(struct frr_pthread *fpt)
 	XFREE(MTYPE_FRR_PTHREAD, fpt);
 }
 
-int frr_pthread_set_name(struct frr_pthread *fpt, const char *name,
-			 const char *os_name)
+int frr_pthread_set_name(struct frr_pthread *fpt)
 {
 	int ret = 0;
 
-	if (name) {
-		pthread_mutex_lock(&fpt->mtx);
-		{
-			if (fpt->name)
-				XFREE(MTYPE_FRR_PTHREAD, fpt->name);
-			fpt->name = XSTRDUP(MTYPE_FRR_PTHREAD, name);
-		}
-		pthread_mutex_unlock(&fpt->mtx);
-		thread_master_set_name(fpt->master, name);
-	}
-
-	if (os_name) {
-		pthread_mutex_lock(&fpt->mtx);
-		snprintf(fpt->os_name, OS_THREAD_NAMELEN, "%s", os_name);
-		pthread_mutex_unlock(&fpt->mtx);
 #ifdef HAVE_PTHREAD_SETNAME_NP
 # ifdef GNU_LINUX
-		ret = pthread_setname_np(fpt->thread, fpt->os_name);
+	ret = pthread_setname_np(fpt->thread, fpt->os_name);
 # else /* NetBSD */
-		ret = pthread_setname_np(fpt->thread, fpt->os_name, NULL);
+	ret = pthread_setname_np(fpt->thread, fpt->os_name, NULL);
 # endif
 #elif defined(HAVE_PTHREAD_SET_NAME_NP)
-		pthread_set_name_np(fpt->thread, fpt->os_name);
+	pthread_set_name_np(fpt->thread, fpt->os_name);
 #endif
-	}
 
 	return ret;
 }
@@ -275,15 +258,7 @@ static void *fpt_run(void *arg)
 
 	fpt->master->handle_signals = false;
 
-#ifdef HAVE_PTHREAD_SETNAME_NP
-# ifdef GNU_LINUX
-	pthread_setname_np(fpt->thread, fpt->os_name);
-# else /* NetBSD */
-	pthread_setname_np(fpt->thread, fpt->os_name, NULL);
-# endif
-#elif defined(HAVE_PTHREAD_SET_NAME_NP)
-	pthread_set_name_np(fpt->thread, fpt->os_name);
-#endif
+	frr_pthread_set_name(fpt);
 
 	frr_pthread_notify_running(fpt);
 

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -275,8 +275,15 @@ static void *fpt_run(void *arg)
 
 	fpt->master->handle_signals = false;
 
-	if (fpt->os_name[0])
-		frr_pthread_set_name(fpt, NULL, fpt->os_name);
+#ifdef HAVE_PTHREAD_SETNAME_NP
+# ifdef GNU_LINUX
+	pthread_setname_np(fpt->thread, fpt->os_name);
+# else /* NetBSD */
+	pthread_setname_np(fpt->thread, fpt->os_name, NULL);
+# endif
+#elif defined(HAVE_PTHREAD_SET_NAME_NP)
+	pthread_set_name_np(fpt->thread, fpt->os_name);
+#endif
 
 	frr_pthread_notify_running(fpt);
 

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -133,16 +133,13 @@ struct frr_pthread *frr_pthread_new(struct frr_pthread_attr *attr,
 				    const char *name, const char *os_name);
 
 /*
- * Changes the name of the frr_pthread.
+ * Changes the name of the frr_pthread as reported by the operating
+ * system.
  *
  * @param fpt - the frr_pthread to operate on
- * @param name - Human-readable name
- * @param os_name - 16 characters thread name , including the null
- * terminator ('\0') to set in os.
  * @return -  on success returns 0 otherwise nonzero error number.
  */
-int frr_pthread_set_name(struct frr_pthread *fpt, const char *name,
-			 const char *os_name);
+int frr_pthread_set_name(struct frr_pthread *fpt);
 
 /*
  * Destroys an frr_pthread.


### PR DESCRIPTION
A couple various bugs were preventing proper display of the pthread names when we set the os name for them:

Before:
sharpd@robot ~/frr1> ps -L -p 10834
  PID   LWP TTY          TIME CMD
16895 16895 ?        00:01:39 bgpd
16895 16896 ?        00:00:54 
16895 16897 ?        00:00:07 bgpd_ka

sharpd@robot ~/frr2> ps -L -p 4023
      PID   LWP TTY          TIME CMD
    25643 25643 ?        00:00:00 zebra
    25643 25644 ?        00:00:00 
    25643 25684 ?        00:00:00 
  
After:
   sharpd@donna ~/frr1> ps -L -p 1752
      PID   LWP TTY          TIME CMD
     1752  1752 ?        00:00:00 bgpd
     1752  1753 ?        00:00:00 bgpd_io
     1752  1754 ?        00:00:00 bgpd_ka
   sharpd@donna ~/frr2> ps -L -p 25643
      PID   LWP TTY          TIME CMD
    25643 25643 ?        00:00:00 zebra
    25643 25644 ?        00:00:00 Zebra dplane
    25643 25684 ?        00:00:00 zebra_apic
    sharpd@donna ~/frr2>
