### PR TITLE
bgpd: flowspec redirect IP info is retrieved into nh tracking

### DIFF
--- a/bgpd/bgp_flowspec_util.h
+++ b/bgpd/bgp_flowspec_util.h
@@ -54,4 +54,8 @@ extern bool bgp_flowspec_contains_prefix(struct prefix *pfs,
 					 struct prefix *input,
 					 int prefix_check);
 
+extern int bgp_flowspec_get_first_nh(struct bgp *bgp,
+				     struct bgp_path_info *pi,
+				     struct prefix *nh);
+
 #endif /* _FRR_BGP_FLOWSPEC_UTIL_H */

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -42,6 +42,7 @@
 #include "bgpd/bgp_nht.h"
 #include "bgpd/bgp_fsm.h"
 #include "bgpd/bgp_zebra.h"
+#include "bgpd/bgp_flowspec_util.h"
 
 extern struct zclient *zclient;
 
@@ -533,7 +534,15 @@ static int make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p)
 			     && (pi->sub_type == BGP_ROUTE_STATIC))
 				    ? 1
 				    : 0;
+	struct bgp_node *net = pi->net;
+	struct prefix *p_orig = &net->p;
 
+	if (p_orig->family == AF_FLOWSPEC) {
+		if (!pi->peer)
+			return -1;
+		return bgp_flowspec_get_first_nh(pi->peer->bgp,
+						 pi, p);
+	}
 	memset(p, 0, sizeof(struct prefix));
 	switch (afi) {
 	case AFI_IP:

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -626,7 +626,7 @@ static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 }
 
 /* return -1 if build or validation failed */
-static int bgp_pbr_build_and_validate_entry(struct prefix *p,
+int bgp_pbr_build_and_validate_entry(struct prefix *p,
 					    struct bgp_path_info *path,
 					    struct bgp_pbr_entry_main *api)
 {

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -290,4 +290,7 @@ extern void bgp_pbr_reset(struct bgp *bgp, afi_t afi);
 extern struct bgp_pbr_interface *bgp_pbr_interface_lookup(const char *name,
 				   struct bgp_pbr_interface_head *head);
 
+extern int bgp_pbr_build_and_validate_entry(struct prefix *p,
+					    struct bgp_path_info *path,
+					    struct bgp_pbr_entry_main *api);
 #endif /* __BGP_PBR_H__ */


### PR DESCRIPTION
redirect IP nh of flowspec entry is retrieved so that the nexthop
IP information is injected into the nexthop tracking, and is associated
to the bgp_path structure. This permits validating or unvalidating the
bgp_path for injection in zebra or not.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
