### PR TITLE
zebra: handle multiple events for netns deletion event

### DIFF
--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -266,9 +266,10 @@ static int zebra_ns_notify_read(struct thread *t)
 			break;
 		}
 
-		if (event->mask & IN_DELETE)
-			return zebra_ns_delete(event->name);
-
+		if (event->mask & IN_DELETE) {
+			zebra_ns_delete(event->name);
+			continue;
+		}
 		netnspath = ns_netns_pathname(NULL, event->name);
 		if (!netnspath)
 			continue;


### PR DESCRIPTION
When handling events from /var/run/netns folder, if several netns are
removed at the same time, only the first one is deleted in the frr. Fix
this behaviour by applying continue in the loop.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
