### PR TITLE
sharpd: Clean up vtysh warning about insufficient doc string

### DIFF
--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -196,8 +196,9 @@ DEFPY (remove_routes,
        "Sharp Routing Protocol\n"
        "Remove some routes\n"
        "Routes to remove\n"
-       "Starting spot\n"
-       "Routes to uniinstall\n"
+       "v4 Starting spot\n"
+       "v6 Starting spot\n"
+       "Routes to uninstall\n"
        "instance to use\n"
        "Value of instance\n")
 {


### PR DESCRIPTION
Not sure why this wasn't caught by our CI system.  I thought it
would.  My screw up this should have been right from the start.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com.

