### PR TITLE
zebra: Fix uninitialized value warning in dplane code

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -995,7 +995,7 @@ int dplane_provider_register(const char *name,
 			     struct zebra_dplane_provider **prov_p)
 {
 	int ret = 0;
-	struct zebra_dplane_provider *p, *last;
+	struct zebra_dplane_provider *p = NULL, *last;
 
 	/* Validate */
 	if (fp == NULL) {


### PR DESCRIPTION
Fix a gcc-8 warning (at least) about a possible uninitialized value in the zebra_dplane code.

This was reported with gcc-8, and without --enable-dev-build in the configure options.

### Components
zebra