### PR TITLE
bfdd: Fix timer print-out function

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -770,10 +770,10 @@ void integer2timestr(uint64_t time, char *buf, size_t buflen)
 	int rv;
 
 #define MINUTES (60)
-#define HOURS (24 * MINUTES)
-#define DAYS (30 * HOURS)
-#define MONTHS (12 * DAYS)
-#define YEARS (MONTHS)
+#define HOURS (60 * MINUTES)
+#define DAYS (24 * HOURS)
+#define MONTHS (30 * DAYS)
+#define YEARS (12 * MONTHS)
 	if (time >= YEARS) {
 		year = time / YEARS;
 		time -= year * YEARS;


### PR DESCRIPTION
The timer2str function thought 24 minutes was an hour and had a
couple of other issues that needed to be corrected.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

