### PR TITLE
ospfd: remove default originate max aged lsa

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2249,6 +2249,22 @@ void ospf_external_lsa_refresh_default(struct ospf *ospf)
 	}
 }
 
+void ospf_default_originate_lsa_update(struct ospf *ospf)
+{
+	struct prefix_ipv4 p;
+	struct ospf_lsa *lsa;
+
+	p.family = AF_INET;
+	p.prefixlen = 0;
+	p.prefix.s_addr = 0;
+
+	lsa = ospf_external_info_find_lsa(ospf, &p);
+	if (lsa && IS_LSA_MAXAGE(lsa)) {
+		ospf_discard_from_db(ospf, lsa->lsdb, lsa);
+		ospf_lsdb_delete(lsa->lsdb, lsa);
+	}
+}
+
 void ospf_external_lsa_refresh_type(struct ospf *ospf, uint8_t type,
 				    unsigned short instance, int force)
 {

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -296,6 +296,7 @@ extern int ospf_lsa_maxage_walker(struct thread *);
 extern struct ospf_lsa *ospf_lsa_refresh(struct ospf *, struct ospf_lsa *);
 
 extern void ospf_external_lsa_refresh_default(struct ospf *);
+extern void ospf_default_originate_lsa_update(struct ospf *ospf);
 
 extern void ospf_external_lsa_refresh_type(struct ospf *, uint8_t,
 					   unsigned short, int);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -869,6 +869,9 @@ int ospf_redistribute_default_unset(struct ospf *ospf)
 
 	ospf_asbr_status_update(ospf, --ospf->redistribute);
 
+	/* clean up maxage default originate external lsa */
+	ospf_default_originate_lsa_update(ospf);
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
### Summary
default-information originate does not work
if config is removed and re-added.

Testing Done:
Validate default-information originate config
removed and re-added, check ospf lsa database, and peer
route cache entry for default route.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>

### Related Issue
[fill here if applicable]

### Components
ospfd
