### PR TITLE
libs, daemons: changes to permit c++ compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,7 +147,7 @@ dnl - specifically, options to control warnings
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_DEFUN([AC_C_FLAG], [{
-    m4_pushdef([cachename],[m4_translit([frr_cv_$1],[ =-],[___])])
+    m4_pushdef([cachename],[m4_translit([frr_cv_$1],[ =-+],[____])])
     AC_CACHE_CHECK([[whether $CC supports $1]], cachename, [
 	AC_LANG_PUSH([C])
 	ac_c_flag_save="$CFLAGS"
@@ -260,6 +260,9 @@ else
 fi
 AC_C_FLAG([-Wno-unused-parameter])
 AC_C_FLAG([-Wno-missing-field-initializers])
+
+AC_C_FLAG([-Wc++-compat], [], [CXX_COMPAT_CFLAGS="-Wc++-compat"])
+AC_SUBST([CXX_COMPAT_CFLAGS])
 
 dnl ICC emits a broken warning for const char *x = a ? "b" : "c";
 dnl for some reason the string consts get 'promoted' to char *,

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -89,7 +89,7 @@ DEFPY(no_router_isis, no_router_isis_cmd, "no router isis WORD$tag",
 		return CMD_ERR_NOTHING_TODO;
 	}
 
-	nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 	area = isis_area_lookup(tag);
 	if (area && area->circuit_list && listcount(area->circuit_list)) {
 		for (ALL_LIST_ELEMENTS(area->circuit_list, node, nnode,
@@ -103,7 +103,7 @@ DEFPY(no_router_isis, no_router_isis_cmd, "no router isis WORD$tag",
 				temp_xpath, XPATH_MAXLEN,
 				"/frr-interface:lib/interface[name='%s'][vrf='%s']/frr-isisd:isis",
 				circuit->interface->name, vrf_name);
-			nb_cli_enqueue_change(vty, temp_xpath, NB_OP_DELETE,
+			nb_cli_enqueue_change(vty, temp_xpath, NB_OP_DESTROY,
 					      NULL);
 		}
 	}
@@ -289,7 +289,7 @@ DEFPY(no_ip_router_isis, no_ip_router_isis_cmd,
 		    && !yang_dnode_get_bool(dnode,
 					    "./frr-isisd:isis/ipv4-routing"))
 			nb_cli_enqueue_change(vty, "./frr-isisd:isis",
-					      NB_OP_DELETE, NULL);
+					      NB_OP_DESTROY, NULL);
 		else
 			nb_cli_enqueue_change(vty,
 					      "./frr-isisd:isis/ipv6-routing",
@@ -299,7 +299,7 @@ DEFPY(no_ip_router_isis, no_ip_router_isis_cmd,
 		    && !yang_dnode_get_bool(dnode,
 					    "./frr-isisd:isis/ipv6-routing"))
 			nb_cli_enqueue_change(vty, "./frr-isisd:isis",
-					      NB_OP_DELETE, NULL);
+					      NB_OP_DESTROY, NULL);
 		else
 			nb_cli_enqueue_change(vty,
 					      "./frr-isisd:isis/ipv4-routing",
@@ -336,7 +336,7 @@ DEFPY(net, net_cmd, "[no] net WORD",
       "XX.XXXX. ... .XXX.XX  Network entity title (NET)\n")
 {
 	nb_cli_enqueue_change(vty, "./area-address",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, net);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, net);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -589,7 +589,7 @@ DEFPY(no_area_passwd, no_area_passwd_cmd,
       "Configure the authentication password for an area\n"
       "Set the authentication password for a routing domain\n")
 {
-	nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, "./%s", cmd);
 }
@@ -892,7 +892,7 @@ DEFPY(no_spf_delay_ietf, no_spf_delay_ietf_cmd,
       "Maximum duration needed to learn all the events related to a single failure\n"
       "Maximum duration needed to learn all the events related to a single failure (in milliseconds)\n")
 {
-	nb_cli_enqueue_change(vty, "./spf/ietf-backoff-delay", NB_OP_DELETE,
+	nb_cli_enqueue_change(vty, "./spf/ietf-backoff-delay", NB_OP_DESTROY,
 			      NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -947,7 +947,7 @@ DEFPY(no_isis_mpls_te_on, no_isis_mpls_te_on_cmd, "no mpls-te [on]",
       "Disable the MPLS-TE functionality\n"
       "Enable the MPLS-TE functionality\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-isisd:isis/mpls-te", NB_OP_DELETE,
+	nb_cli_enqueue_change(vty, "/frr-isisd:isis/mpls-te", NB_OP_DESTROY,
 			      NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -1014,16 +1014,16 @@ DEFPY(isis_default_originate, isis_default_originate_cmd,
       "Pointer to route-map entries\n")
 {
 	if (no)
-		nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 	else {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./always", NB_OP_MODIFY,
 				      always ? "true" : "false");
 		nb_cli_enqueue_change(vty, "./route-map",
-				      rmap ? NB_OP_MODIFY : NB_OP_DELETE,
+				      rmap ? NB_OP_MODIFY : NB_OP_DESTROY,
 				      rmap ? rmap : NULL);
 		nb_cli_enqueue_change(vty, "./metric",
-				      metric ? NB_OP_MODIFY : NB_OP_DELETE,
+				      metric ? NB_OP_MODIFY : NB_OP_DESTROY,
 				      metric ? metric_str : NULL);
 		if (strmatch(ip, "ipv6") && !always) {
 			vty_out(vty,
@@ -1094,14 +1094,14 @@ DEFPY(isis_redistribute, isis_redistribute_cmd,
       "Pointer to route-map entries\n")
 {
 	if (no)
-		nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 	else {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./route-map",
-				      route_map ? NB_OP_MODIFY : NB_OP_DELETE,
+				      route_map ? NB_OP_MODIFY : NB_OP_DESTROY,
 				      route_map ? route_map : NULL);
 		nb_cli_enqueue_change(vty, "./metric",
-				      metric ? NB_OP_MODIFY : NB_OP_DELETE,
+				      metric ? NB_OP_MODIFY : NB_OP_DESTROY,
 				      metric ? metric_str : NULL);
 	}
 
@@ -1182,7 +1182,7 @@ DEFPY(isis_topology, isis_topology_cmd,
 			 topology);
 
 	if (no)
-		nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 	else {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./overload", NB_OP_MODIFY,
@@ -1297,7 +1297,7 @@ DEFPY(no_isis_passwd, no_isis_passwd_cmd, "no isis password [<md5|clear> WORD]",
       "Cleartext password\n"
       "Circuit password\n")
 {
-	nb_cli_enqueue_change(vty, "./frr-isisd:isis/password", NB_OP_DELETE,
+	nb_cli_enqueue_change(vty, "./frr-isisd:isis/password", NB_OP_DESTROY,
 			      NULL);
 
 	return nb_cli_apply_changes(vty, NULL);

--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -72,7 +72,7 @@ static int isis_instance_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int isis_instance_delete(enum nb_event event,
+static int isis_instance_destroy(enum nb_event event,
 				const struct lyd_node *dnode)
 {
 	const char *area_tag;
@@ -193,7 +193,7 @@ static int isis_instance_area_address_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int isis_instance_area_address_delete(enum nb_event event,
+static int isis_instance_area_address_destroy(enum nb_event event,
 					     const struct lyd_node *dnode)
 {
 	struct area_addr addr, *addrp = NULL;
@@ -536,7 +536,7 @@ isis_instance_spf_ietf_backoff_delay_create(enum nb_event event,
 }
 
 static int
-isis_instance_spf_ietf_backoff_delay_delete(enum nb_event event,
+isis_instance_spf_ietf_backoff_delay_destroy(enum nb_event event,
 					    const struct lyd_node *dnode)
 {
 	struct isis_area *area;
@@ -676,7 +676,7 @@ static int isis_instance_area_password_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int isis_instance_area_password_delete(enum nb_event event,
+static int isis_instance_area_password_destroy(enum nb_event event,
 					      const struct lyd_node *dnode)
 {
 	struct isis_area *area;
@@ -755,7 +755,7 @@ static int isis_instance_domain_password_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int isis_instance_domain_password_delete(enum nb_event event,
+static int isis_instance_domain_password_destroy(enum nb_event event,
 						const struct lyd_node *dnode)
 {
 	struct isis_area *area;
@@ -851,7 +851,7 @@ static int isis_instance_default_information_originate_ipv4_create(
 	return NB_OK;
 }
 
-static int isis_instance_default_information_originate_ipv4_delete(
+static int isis_instance_default_information_originate_ipv4_destroy(
 	enum nb_event event, const struct lyd_node *dnode)
 {
 	struct isis_area *area;
@@ -889,7 +889,7 @@ static int isis_instance_default_information_originate_ipv4_route_map_modify(
 	return NB_OK;
 }
 
-static int isis_instance_default_information_originate_ipv4_route_map_delete(
+static int isis_instance_default_information_originate_ipv4_route_map_destroy(
 	enum nb_event event, const struct lyd_node *dnode)
 {
 	/* It's all done by default_info_origin_apply_finish */
@@ -907,7 +907,7 @@ static int isis_instance_default_information_originate_ipv4_metric_modify(
 	return NB_OK;
 }
 
-static int isis_instance_default_information_originate_ipv4_metric_delete(
+static int isis_instance_default_information_originate_ipv4_metric_destroy(
 	enum nb_event event, const struct lyd_node *dnode)
 {
 	/* It's all done by default_info_origin_apply_finish */
@@ -925,7 +925,7 @@ static int isis_instance_default_information_originate_ipv6_create(
 	return NB_OK;
 }
 
-static int isis_instance_default_information_originate_ipv6_delete(
+static int isis_instance_default_information_originate_ipv6_destroy(
 	enum nb_event event, const struct lyd_node *dnode)
 {
 	struct isis_area *area;
@@ -963,7 +963,7 @@ static int isis_instance_default_information_originate_ipv6_route_map_modify(
 	return NB_OK;
 }
 
-static int isis_instance_default_information_originate_ipv6_route_map_delete(
+static int isis_instance_default_information_originate_ipv6_route_map_destroy(
 	enum nb_event event, const struct lyd_node *dnode)
 {
 	/* It's all done by default_info_origin_apply_finish */
@@ -981,7 +981,7 @@ static int isis_instance_default_information_originate_ipv6_metric_modify(
 	return NB_OK;
 }
 
-static int isis_instance_default_information_originate_ipv6_metric_delete(
+static int isis_instance_default_information_originate_ipv6_metric_destroy(
 	enum nb_event event, const struct lyd_node *dnode)
 {
 	/* It's all done by default_info_origin_apply_finish */
@@ -1029,7 +1029,7 @@ static int isis_instance_redistribute_ipv4_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int isis_instance_redistribute_ipv4_delete(enum nb_event event,
+static int isis_instance_redistribute_ipv4_destroy(enum nb_event event,
 						  const struct lyd_node *dnode)
 {
 	struct isis_area *area;
@@ -1059,7 +1059,7 @@ isis_instance_redistribute_ipv4_route_map_modify(enum nb_event event,
 }
 
 static int
-isis_instance_redistribute_ipv4_route_map_delete(enum nb_event event,
+isis_instance_redistribute_ipv4_route_map_destroy(enum nb_event event,
 						 const struct lyd_node *dnode)
 {
 	/* It's all done by redistribute_apply_finish */
@@ -1079,7 +1079,7 @@ isis_instance_redistribute_ipv4_metric_modify(enum nb_event event,
 }
 
 static int
-isis_instance_redistribute_ipv4_metric_delete(enum nb_event event,
+isis_instance_redistribute_ipv4_metric_destroy(enum nb_event event,
 					      const struct lyd_node *dnode)
 {
 	/* It's all done by redistribute_apply_finish */
@@ -1097,7 +1097,7 @@ static int isis_instance_redistribute_ipv6_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int isis_instance_redistribute_ipv6_delete(enum nb_event event,
+static int isis_instance_redistribute_ipv6_destroy(enum nb_event event,
 						  const struct lyd_node *dnode)
 {
 	struct isis_area *area;
@@ -1127,7 +1127,7 @@ isis_instance_redistribute_ipv6_route_map_modify(enum nb_event event,
 }
 
 static int
-isis_instance_redistribute_ipv6_route_map_delete(enum nb_event event,
+isis_instance_redistribute_ipv6_route_map_destroy(enum nb_event event,
 						 const struct lyd_node *dnode)
 {
 	/* It's all done by redistribute_apply_finish */
@@ -1147,7 +1147,7 @@ isis_instance_redistribute_ipv6_metric_modify(enum nb_event event,
 }
 
 static int
-isis_instance_redistribute_ipv6_metric_delete(enum nb_event event,
+isis_instance_redistribute_ipv6_metric_destroy(enum nb_event event,
 					      const struct lyd_node *dnode)
 {
 	/* It's all done by redistribute_apply_finish */
@@ -1217,7 +1217,7 @@ isis_instance_multi_topology_ipv4_multicast_create(enum nb_event event,
 }
 
 static int
-isis_instance_multi_topology_ipv4_multicast_delete(enum nb_event event,
+isis_instance_multi_topology_ipv4_multicast_destroy(enum nb_event event,
 						   const struct lyd_node *dnode)
 {
 	return isis_multi_topology_common(event, dnode, "ipv4-multicast",
@@ -1245,7 +1245,7 @@ static int isis_instance_multi_topology_ipv4_management_create(
 	return isis_multi_topology_common(event, dnode, "ipv4-mgmt", true);
 }
 
-static int isis_instance_multi_topology_ipv4_management_delete(
+static int isis_instance_multi_topology_ipv4_management_destroy(
 	enum nb_event event, const struct lyd_node *dnode)
 {
 	return isis_multi_topology_common(event, dnode, "ipv4-mgmt", false);
@@ -1273,7 +1273,7 @@ isis_instance_multi_topology_ipv6_unicast_create(enum nb_event event,
 }
 
 static int
-isis_instance_multi_topology_ipv6_unicast_delete(enum nb_event event,
+isis_instance_multi_topology_ipv6_unicast_destroy(enum nb_event event,
 						 const struct lyd_node *dnode)
 {
 	return isis_multi_topology_common(event, dnode, "ipv6-unicast", false);
@@ -1302,7 +1302,7 @@ isis_instance_multi_topology_ipv6_multicast_create(enum nb_event event,
 }
 
 static int
-isis_instance_multi_topology_ipv6_multicast_delete(enum nb_event event,
+isis_instance_multi_topology_ipv6_multicast_destroy(enum nb_event event,
 						   const struct lyd_node *dnode)
 {
 	return isis_multi_topology_common(event, dnode, "ipv6-multicast",
@@ -1330,7 +1330,7 @@ static int isis_instance_multi_topology_ipv6_management_create(
 	return isis_multi_topology_common(event, dnode, "ipv6-mgmt", true);
 }
 
-static int isis_instance_multi_topology_ipv6_management_delete(
+static int isis_instance_multi_topology_ipv6_management_destroy(
 	enum nb_event event, const struct lyd_node *dnode)
 {
 	return isis_multi_topology_common(event, dnode, "ipv6-mgmt", false);
@@ -1358,7 +1358,7 @@ isis_instance_multi_topology_ipv6_dstsrc_create(enum nb_event event,
 }
 
 static int
-isis_instance_multi_topology_ipv6_dstsrc_delete(enum nb_event event,
+isis_instance_multi_topology_ipv6_dstsrc_destroy(enum nb_event event,
 						const struct lyd_node *dnode)
 {
 	return isis_multi_topology_common(event, dnode, "ipv6-dstsrc", false);
@@ -1436,7 +1436,7 @@ static int isis_mpls_te_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int isis_mpls_te_delete(enum nb_event event,
+static int isis_mpls_te_destroy(enum nb_event event,
 			       const struct lyd_node *dnode)
 {
 	struct listnode *node;
@@ -1494,7 +1494,7 @@ static int isis_mpls_te_router_address_modify(enum nb_event event,
 	return NB_OK;
 }
 
-static int isis_mpls_te_router_address_delete(enum nb_event event,
+static int isis_mpls_te_router_address_destroy(enum nb_event event,
 					      const struct lyd_node *dnode)
 {
 	struct listnode *node;
@@ -1555,7 +1555,7 @@ static int lib_interface_isis_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int lib_interface_isis_delete(enum nb_event event,
+static int lib_interface_isis_destroy(enum nb_event event,
 				     const struct lyd_node *dnode)
 {
 	struct isis_circuit *circuit;
@@ -2062,7 +2062,7 @@ static int lib_interface_isis_password_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int lib_interface_isis_password_delete(enum nb_event event,
+static int lib_interface_isis_password_destroy(enum nb_event event,
 					      const struct lyd_node *dnode)
 {
 	struct isis_circuit *circuit;
@@ -2749,7 +2749,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance",
 			.cbs.create = isis_instance_create,
-			.cbs.destroy = isis_instance_delete,
+			.cbs.destroy = isis_instance_destroy,
 			.cbs.cli_show = cli_show_router_isis,
 			.priority = NB_DFLT_PRIORITY - 1,
 		},
@@ -2761,7 +2761,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/area-address",
 			.cbs.create = isis_instance_area_address_create,
-			.cbs.destroy = isis_instance_area_address_delete,
+			.cbs.destroy = isis_instance_area_address_destroy,
 			.cbs.cli_show = cli_show_isis_area_address,
 		},
 		{
@@ -2833,7 +2833,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/ietf-backoff-delay",
 			.cbs.create = isis_instance_spf_ietf_backoff_delay_create,
-			.cbs.destroy = isis_instance_spf_ietf_backoff_delay_delete,
+			.cbs.destroy = isis_instance_spf_ietf_backoff_delay_destroy,
 			.cbs.apply_finish = ietf_backoff_delay_apply_finish,
 			.cbs.cli_show = cli_show_isis_spf_ietf_backoff,
 		},
@@ -2872,7 +2872,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/area-password",
 			.cbs.create = isis_instance_area_password_create,
-			.cbs.destroy = isis_instance_area_password_delete,
+			.cbs.destroy = isis_instance_area_password_destroy,
 			.cbs.apply_finish = area_password_apply_finish,
 			.cbs.cli_show = cli_show_isis_area_pwd,
 		},
@@ -2891,7 +2891,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/domain-password",
 			.cbs.create = isis_instance_domain_password_create,
-			.cbs.destroy = isis_instance_domain_password_delete,
+			.cbs.destroy = isis_instance_domain_password_destroy,
 			.cbs.apply_finish = domain_password_apply_finish,
 			.cbs.cli_show = cli_show_isis_domain_pwd,
 		},
@@ -2910,7 +2910,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4",
 			.cbs.create = isis_instance_default_information_originate_ipv4_create,
-			.cbs.destroy = isis_instance_default_information_originate_ipv4_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv4_destroy,
 			.cbs.apply_finish = default_info_origin_ipv4_apply_finish,
 			.cbs.cli_show = cli_show_isis_def_origin_ipv4,
 		},
@@ -2921,17 +2921,17 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4/route-map",
 			.cbs.modify = isis_instance_default_information_originate_ipv4_route_map_modify,
-			.cbs.destroy = isis_instance_default_information_originate_ipv4_route_map_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv4_route_map_destroy,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4/metric",
 			.cbs.modify = isis_instance_default_information_originate_ipv4_metric_modify,
-			.cbs.destroy = isis_instance_default_information_originate_ipv4_metric_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv4_metric_destroy,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6",
 			.cbs.create = isis_instance_default_information_originate_ipv6_create,
-			.cbs.destroy = isis_instance_default_information_originate_ipv6_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv6_destroy,
 			.cbs.apply_finish = default_info_origin_ipv6_apply_finish,
 			.cbs.cli_show = cli_show_isis_def_origin_ipv6,
 		},
@@ -2942,51 +2942,51 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6/route-map",
 			.cbs.modify = isis_instance_default_information_originate_ipv6_route_map_modify,
-			.cbs.destroy = isis_instance_default_information_originate_ipv6_route_map_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv6_route_map_destroy,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6/metric",
 			.cbs.modify = isis_instance_default_information_originate_ipv6_metric_modify,
-			.cbs.destroy = isis_instance_default_information_originate_ipv6_metric_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv6_metric_destroy,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4",
 			.cbs.create = isis_instance_redistribute_ipv4_create,
-			.cbs.destroy = isis_instance_redistribute_ipv4_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv4_destroy,
 			.cbs.apply_finish = redistribute_ipv4_apply_finish,
 			.cbs.cli_show = cli_show_isis_redistribute_ipv4,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4/route-map",
 			.cbs.modify = isis_instance_redistribute_ipv4_route_map_modify,
-			.cbs.destroy = isis_instance_redistribute_ipv4_route_map_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv4_route_map_destroy,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4/metric",
 			.cbs.modify = isis_instance_redistribute_ipv4_metric_modify,
-			.cbs.destroy = isis_instance_redistribute_ipv4_metric_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv4_metric_destroy,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6",
 			.cbs.create = isis_instance_redistribute_ipv6_create,
-			.cbs.destroy = isis_instance_redistribute_ipv6_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv6_destroy,
 			.cbs.apply_finish = redistribute_ipv6_apply_finish,
 			.cbs.cli_show = cli_show_isis_redistribute_ipv6,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6/route-map",
 			.cbs.modify = isis_instance_redistribute_ipv6_route_map_modify,
-			.cbs.destroy = isis_instance_redistribute_ipv6_route_map_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv6_route_map_destroy,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6/metric",
 			.cbs.modify = isis_instance_redistribute_ipv6_metric_modify,
-			.cbs.destroy = isis_instance_redistribute_ipv6_metric_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv6_metric_destroy,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv4-multicast",
 			.cbs.create = isis_instance_multi_topology_ipv4_multicast_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv4_multicast_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv4_multicast_destroy,
 			.cbs.cli_show = cli_show_isis_mt_ipv4_multicast,
 		},
 		{
@@ -2996,7 +2996,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv4-management",
 			.cbs.create = isis_instance_multi_topology_ipv4_management_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv4_management_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv4_management_destroy,
 			.cbs.cli_show = cli_show_isis_mt_ipv4_mgmt,
 		},
 		{
@@ -3006,7 +3006,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-unicast",
 			.cbs.create = isis_instance_multi_topology_ipv6_unicast_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv6_unicast_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv6_unicast_destroy,
 			.cbs.cli_show = cli_show_isis_mt_ipv6_unicast,
 		},
 		{
@@ -3016,7 +3016,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-multicast",
 			.cbs.create = isis_instance_multi_topology_ipv6_multicast_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv6_multicast_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv6_multicast_destroy,
 			.cbs.cli_show = cli_show_isis_mt_ipv6_multicast,
 		},
 		{
@@ -3026,7 +3026,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-management",
 			.cbs.create = isis_instance_multi_topology_ipv6_management_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv6_management_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv6_management_destroy,
 			.cbs.cli_show = cli_show_isis_mt_ipv6_mgmt,
 		},
 		{
@@ -3036,7 +3036,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-dstsrc",
 			.cbs.create = isis_instance_multi_topology_ipv6_dstsrc_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv6_dstsrc_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv6_dstsrc_destroy,
 			.cbs.cli_show = cli_show_isis_mt_ipv6_dstsrc,
 		},
 		{
@@ -3051,19 +3051,19 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/mpls-te",
 			.cbs.create = isis_mpls_te_create,
-			.cbs.destroy = isis_mpls_te_delete,
+			.cbs.destroy = isis_mpls_te_destroy,
 			.cbs.cli_show = cli_show_isis_mpls_te,
 		},
 		{
 			.xpath = "/frr-isisd:isis/mpls-te/router-address",
 			.cbs.modify = isis_mpls_te_router_address_modify,
-			.cbs.destroy = isis_mpls_te_router_address_delete,
+			.cbs.destroy = isis_mpls_te_router_address_destroy,
 			.cbs.cli_show = cli_show_isis_mpls_te_router_addr,
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis",
 			.cbs.create = lib_interface_isis_create,
-			.cbs.destroy = lib_interface_isis_delete,
+			.cbs.destroy = lib_interface_isis_destroy,
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/area-tag",
@@ -3174,7 +3174,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/password",
 			.cbs.create = lib_interface_isis_password_create,
-			.cbs.destroy = lib_interface_isis_password_delete,
+			.cbs.destroy = lib_interface_isis_password_destroy,
 			.cbs.cli_show = cli_show_ip_isis_password,
 		},
 		{

--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -2749,7 +2749,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance",
 			.cbs.create = isis_instance_create,
-			.cbs.delete = isis_instance_delete,
+			.cbs.destroy = isis_instance_delete,
 			.cbs.cli_show = cli_show_router_isis,
 			.priority = NB_DFLT_PRIORITY - 1,
 		},
@@ -2761,7 +2761,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/area-address",
 			.cbs.create = isis_instance_area_address_create,
-			.cbs.delete = isis_instance_area_address_delete,
+			.cbs.destroy = isis_instance_area_address_delete,
 			.cbs.cli_show = cli_show_isis_area_address,
 		},
 		{
@@ -2833,7 +2833,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/ietf-backoff-delay",
 			.cbs.create = isis_instance_spf_ietf_backoff_delay_create,
-			.cbs.delete = isis_instance_spf_ietf_backoff_delay_delete,
+			.cbs.destroy = isis_instance_spf_ietf_backoff_delay_delete,
 			.cbs.apply_finish = ietf_backoff_delay_apply_finish,
 			.cbs.cli_show = cli_show_isis_spf_ietf_backoff,
 		},
@@ -2872,7 +2872,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/area-password",
 			.cbs.create = isis_instance_area_password_create,
-			.cbs.delete = isis_instance_area_password_delete,
+			.cbs.destroy = isis_instance_area_password_delete,
 			.cbs.apply_finish = area_password_apply_finish,
 			.cbs.cli_show = cli_show_isis_area_pwd,
 		},
@@ -2891,7 +2891,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/domain-password",
 			.cbs.create = isis_instance_domain_password_create,
-			.cbs.delete = isis_instance_domain_password_delete,
+			.cbs.destroy = isis_instance_domain_password_delete,
 			.cbs.apply_finish = domain_password_apply_finish,
 			.cbs.cli_show = cli_show_isis_domain_pwd,
 		},
@@ -2910,7 +2910,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4",
 			.cbs.create = isis_instance_default_information_originate_ipv4_create,
-			.cbs.delete = isis_instance_default_information_originate_ipv4_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv4_delete,
 			.cbs.apply_finish = default_info_origin_ipv4_apply_finish,
 			.cbs.cli_show = cli_show_isis_def_origin_ipv4,
 		},
@@ -2921,17 +2921,17 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4/route-map",
 			.cbs.modify = isis_instance_default_information_originate_ipv4_route_map_modify,
-			.cbs.delete = isis_instance_default_information_originate_ipv4_route_map_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv4_route_map_delete,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4/metric",
 			.cbs.modify = isis_instance_default_information_originate_ipv4_metric_modify,
-			.cbs.delete = isis_instance_default_information_originate_ipv4_metric_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv4_metric_delete,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6",
 			.cbs.create = isis_instance_default_information_originate_ipv6_create,
-			.cbs.delete = isis_instance_default_information_originate_ipv6_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv6_delete,
 			.cbs.apply_finish = default_info_origin_ipv6_apply_finish,
 			.cbs.cli_show = cli_show_isis_def_origin_ipv6,
 		},
@@ -2942,51 +2942,51 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6/route-map",
 			.cbs.modify = isis_instance_default_information_originate_ipv6_route_map_modify,
-			.cbs.delete = isis_instance_default_information_originate_ipv6_route_map_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv6_route_map_delete,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6/metric",
 			.cbs.modify = isis_instance_default_information_originate_ipv6_metric_modify,
-			.cbs.delete = isis_instance_default_information_originate_ipv6_metric_delete,
+			.cbs.destroy = isis_instance_default_information_originate_ipv6_metric_delete,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4",
 			.cbs.create = isis_instance_redistribute_ipv4_create,
-			.cbs.delete = isis_instance_redistribute_ipv4_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv4_delete,
 			.cbs.apply_finish = redistribute_ipv4_apply_finish,
 			.cbs.cli_show = cli_show_isis_redistribute_ipv4,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4/route-map",
 			.cbs.modify = isis_instance_redistribute_ipv4_route_map_modify,
-			.cbs.delete = isis_instance_redistribute_ipv4_route_map_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv4_route_map_delete,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4/metric",
 			.cbs.modify = isis_instance_redistribute_ipv4_metric_modify,
-			.cbs.delete = isis_instance_redistribute_ipv4_metric_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv4_metric_delete,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6",
 			.cbs.create = isis_instance_redistribute_ipv6_create,
-			.cbs.delete = isis_instance_redistribute_ipv6_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv6_delete,
 			.cbs.apply_finish = redistribute_ipv6_apply_finish,
 			.cbs.cli_show = cli_show_isis_redistribute_ipv6,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6/route-map",
 			.cbs.modify = isis_instance_redistribute_ipv6_route_map_modify,
-			.cbs.delete = isis_instance_redistribute_ipv6_route_map_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv6_route_map_delete,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6/metric",
 			.cbs.modify = isis_instance_redistribute_ipv6_metric_modify,
-			.cbs.delete = isis_instance_redistribute_ipv6_metric_delete,
+			.cbs.destroy = isis_instance_redistribute_ipv6_metric_delete,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv4-multicast",
 			.cbs.create = isis_instance_multi_topology_ipv4_multicast_create,
-			.cbs.delete = isis_instance_multi_topology_ipv4_multicast_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv4_multicast_delete,
 			.cbs.cli_show = cli_show_isis_mt_ipv4_multicast,
 		},
 		{
@@ -2996,7 +2996,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv4-management",
 			.cbs.create = isis_instance_multi_topology_ipv4_management_create,
-			.cbs.delete = isis_instance_multi_topology_ipv4_management_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv4_management_delete,
 			.cbs.cli_show = cli_show_isis_mt_ipv4_mgmt,
 		},
 		{
@@ -3006,7 +3006,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-unicast",
 			.cbs.create = isis_instance_multi_topology_ipv6_unicast_create,
-			.cbs.delete = isis_instance_multi_topology_ipv6_unicast_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv6_unicast_delete,
 			.cbs.cli_show = cli_show_isis_mt_ipv6_unicast,
 		},
 		{
@@ -3016,7 +3016,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-multicast",
 			.cbs.create = isis_instance_multi_topology_ipv6_multicast_create,
-			.cbs.delete = isis_instance_multi_topology_ipv6_multicast_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv6_multicast_delete,
 			.cbs.cli_show = cli_show_isis_mt_ipv6_multicast,
 		},
 		{
@@ -3026,7 +3026,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-management",
 			.cbs.create = isis_instance_multi_topology_ipv6_management_create,
-			.cbs.delete = isis_instance_multi_topology_ipv6_management_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv6_management_delete,
 			.cbs.cli_show = cli_show_isis_mt_ipv6_mgmt,
 		},
 		{
@@ -3036,7 +3036,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-dstsrc",
 			.cbs.create = isis_instance_multi_topology_ipv6_dstsrc_create,
-			.cbs.delete = isis_instance_multi_topology_ipv6_dstsrc_delete,
+			.cbs.destroy = isis_instance_multi_topology_ipv6_dstsrc_delete,
 			.cbs.cli_show = cli_show_isis_mt_ipv6_dstsrc,
 		},
 		{
@@ -3051,19 +3051,19 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-isisd:isis/mpls-te",
 			.cbs.create = isis_mpls_te_create,
-			.cbs.delete = isis_mpls_te_delete,
+			.cbs.destroy = isis_mpls_te_delete,
 			.cbs.cli_show = cli_show_isis_mpls_te,
 		},
 		{
 			.xpath = "/frr-isisd:isis/mpls-te/router-address",
 			.cbs.modify = isis_mpls_te_router_address_modify,
-			.cbs.delete = isis_mpls_te_router_address_delete,
+			.cbs.destroy = isis_mpls_te_router_address_delete,
 			.cbs.cli_show = cli_show_isis_mpls_te_router_addr,
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis",
 			.cbs.create = lib_interface_isis_create,
-			.cbs.delete = lib_interface_isis_delete,
+			.cbs.destroy = lib_interface_isis_delete,
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/area-tag",
@@ -3174,7 +3174,7 @@ const struct frr_yang_module_info frr_isisd_info = {
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/password",
 			.cbs.create = lib_interface_isis_password_create,
-			.cbs.delete = lib_interface_isis_password_delete,
+			.cbs.destroy = lib_interface_isis_password_delete,
 			.cbs.cli_show = cli_show_ip_isis_password,
 		},
 		{

--- a/lib/agg_table.h
+++ b/lib/agg_table.h
@@ -23,6 +23,10 @@
 #include "prefix.h"
 #include "table.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct agg_table {
 	struct route_table *route_table;
 
@@ -150,4 +154,9 @@ static inline struct agg_table *agg_get_table(struct agg_node *node)
 {
 	return (struct agg_table *)route_table_get_info(node->table);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -26,6 +26,10 @@
 #include "lib/json.h"
 #include "lib/zclient.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define BFD_DEF_MIN_RX 300
 #define BFD_MIN_MIN_RX 50
 #define BFD_MAX_MIN_RX 60000
@@ -103,5 +107,9 @@ extern void bfd_client_sendmsg(struct zclient *zclient, int command);
 extern void bfd_gbl_init(void);
 
 extern void bfd_gbl_exit(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_BFD_H */

--- a/lib/bitfield.h
+++ b/lib/bitfield.h
@@ -44,6 +44,10 @@
 #include <string.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef unsigned int word_t;
 #define WORD_MAX 0xFFFFFFFF
 #define WORD_SIZE (sizeof(word_t) * 8)
@@ -152,5 +156,9 @@ typedef unsigned int word_t;
 			free((v).data);                                        \
 		}                                                              \
 	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/buffer.h
+++ b/lib/buffer.h
@@ -22,6 +22,10 @@
 #ifndef _ZEBRA_BUFFER_H
 #define _ZEBRA_BUFFER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Create a new buffer.  Memory will be allocated in chunks of the given
    size.  If the argument is 0, the library will supply a reasonable
    default size suitable for buffering socket I/O. */
@@ -98,5 +102,9 @@ extern buffer_status_t buffer_flush_all(struct buffer *, int fd);
 */
 extern buffer_status_t buffer_flush_window(struct buffer *, int fd, int width,
 					   int height, int erase, int no_more);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_BUFFER_H */

--- a/lib/checksum.h
+++ b/lib/checksum.h
@@ -1,4 +1,12 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int in_cksum(void *, int);
 #define FLETCHER_CHECKSUM_VALIDATE 0xffff
 extern uint16_t fletcher_checksum(uint8_t *, const size_t len,
 				  const uint16_t offset);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/clippy.h
+++ b/lib/clippy.h
@@ -22,7 +22,15 @@
 
 #include <Python.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern PyObject *clippy_parse(PyObject *self, PyObject *args);
 extern PyMODINIT_FUNC command_py_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_CLIPPY_H */

--- a/lib/command.c
+++ b/lib/command.c
@@ -1009,7 +1009,7 @@ enum node_type node_parent(enum node_type node)
 }
 
 /* Execute command by argument vline vector. */
-static int cmd_execute_command_real(vector vline, enum filter_type filter,
+static int cmd_execute_command_real(vector vline, enum cmd_filter_type filter,
 				    struct vty *vty,
 				    const struct cmd_element **cmd)
 {

--- a/lib/command.h
+++ b/lib/command.h
@@ -30,6 +30,10 @@
 #include "hash.h"
 #include "command_graph.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MTYPE(HOST)
 DECLARE_MTYPE(COMPLETION)
 
@@ -488,4 +492,9 @@ cmd_variable_handler_register(const struct cmd_variable_handler *cvh);
 extern char *cmd_variable_comp2str(vector comps, unsigned short cols);
 
 extern void command_setup_early_logging(const char *dest, const char *level);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _ZEBRA_COMMAND_H */

--- a/lib/command_graph.h
+++ b/lib/command_graph.h
@@ -32,6 +32,10 @@
 #include "vector.h"
 #include "graph.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MTYPE(CMD_ARG)
 
 struct vty;
@@ -132,5 +136,9 @@ extern void cmd_graph_node_print_cb(struct graph_node *gn, struct buffer *buf);
  *    String allocated with MTYPE_TMP representing this graph
  */
 char *cmd_graph_dump_dot(struct graph *cmdgraph);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_COMMAND_GRAPH_H */

--- a/lib/command_graph.h
+++ b/lib/command_graph.h
@@ -118,7 +118,7 @@ extern void cmd_token_varname_set(struct cmd_token *token, const char *varname);
 
 extern void cmd_graph_parse(struct graph *graph, struct cmd_element *cmd);
 extern void cmd_graph_names(struct graph *graph);
-extern void cmd_graph_merge(struct graph *old, struct graph *new,
+extern void cmd_graph_merge(struct graph *old, struct graph *n,
 			    int direction);
 /*
  * Print callback for DOT dumping.

--- a/lib/command_match.h
+++ b/lib/command_match.h
@@ -35,7 +35,7 @@ extern "C" {
 /* These definitions exist in command.c in the current engine but should be
  * relocated here in the new engine
  */
-enum filter_type { FILTER_RELAXED, FILTER_STRICT };
+enum cmd_filter_type { FILTER_RELAXED, FILTER_STRICT };
 
 /* matcher result value */
 enum matcher_rv {

--- a/lib/command_match.h
+++ b/lib/command_match.h
@@ -28,6 +28,10 @@
 #include "linklist.h"
 #include "command.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* These definitions exist in command.c in the current engine but should be
  * relocated here in the new engine
  */
@@ -97,5 +101,9 @@ enum matcher_rv command_match(struct graph *cmdgraph, vector vline,
  */
 enum matcher_rv command_complete(struct graph *cmdgraph, vector vline,
 				 struct list **completions);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_COMMAND_MATCH_H */

--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -17,6 +17,10 @@
 #ifndef _FRR_COMPILER_H
 #define _FRR_COMPILER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* function attributes, use like
  *   void prototype(void) __attribute__((_CONSTRUCTOR(100)));
  */
@@ -86,6 +90,10 @@
 #else
 #define CPP_WARN(text)
 #define CPP_NOTICE(text)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* _FRR_COMPILER_H */

--- a/lib/csv.h
+++ b/lib/csv.h
@@ -70,6 +70,10 @@
 #include <stdarg.h>
 #include <sys/queue.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct _csv_field_t_ csv_field_t;
 typedef struct _csv_record_t_ csv_record_t;
 typedef struct _csv_t_ csv_t;
@@ -184,5 +188,9 @@ void csv_clone_record(csv_t *csv, csv_record_t *in_rec, csv_record_t **out_rec);
  * Return number of records
  */
 int csv_num_records(csv_t *csv);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/db.h
+++ b/lib/db.h
@@ -38,6 +38,10 @@
 
 #include <sqlite3.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int db_init(const char *path_fmt, ...);
 extern int db_close(void);
 extern int db_bindf(struct sqlite3_stmt *ss, const char *fmt, ...);
@@ -47,6 +51,10 @@ extern int db_run(struct sqlite3_stmt *ss);
 extern int db_loadf(struct sqlite3_stmt *ss, const char *fmt, ...);
 extern void db_finalize(struct sqlite3_stmt **ss);
 extern int db_execute(const char *stmt_fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HAVE_SQLITE3 */
 #endif /* _FRR_DB_H_ */

--- a/lib/debug.h
+++ b/lib/debug.h
@@ -24,6 +24,10 @@
 #include "command.h"
 #include "frratomic.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Debugging modes.
  *
@@ -230,5 +234,9 @@ struct debug_callbacks {
  * MT-Safe
  */
 void debug_init(const struct debug_callbacks *cb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRRDEBUG_H */

--- a/lib/debug.h
+++ b/lib/debug.h
@@ -76,7 +76,7 @@
  *    Human-readable description of this debugging record.
  */
 struct debug {
-	_Atomic uint32_t flags;
+	atomic_uint_fast32_t flags;
 	const char *desc;
 };
 

--- a/lib/distribute.h
+++ b/lib/distribute.h
@@ -25,6 +25,10 @@
 #include "if.h"
 #include "filter.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Disctirubte list types. */
 enum distribute_type {
 	DISTRIBUTE_V4_IN,
@@ -80,5 +84,9 @@ extern enum filter_type distribute_apply_in(struct interface *,
 					    struct prefix *);
 extern enum filter_type distribute_apply_out(struct interface *,
 					     struct prefix *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_DISTRIBUTE_H */

--- a/lib/event_counter.h
+++ b/lib/event_counter.h
@@ -43,6 +43,10 @@
 #ifndef _ZEBRA_EVENT_COUNTER_H
 #define _ZEBRA_EVENT_COUNTER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct event_counter {
 	unsigned long long count;
 	time_t last;
@@ -50,5 +54,9 @@ struct event_counter {
 
 void event_counter_inc(struct event_counter *counter);
 const char *event_counter_format(const struct event_counter *counter);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/ferr.h
+++ b/lib/ferr.h
@@ -27,6 +27,10 @@
 
 #include "vty.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* return type when this error indication stuff is used.
  *
  * guaranteed to have boolean evaluation to "false" when OK, "true" when error
@@ -252,5 +256,9 @@ DEFUN("bla")
 }
 
 #endif /* THIS_IS_AN_EXAMPLE */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FERR_H */

--- a/lib/fifo.h
+++ b/lib/fifo.h
@@ -20,6 +20,10 @@
 #ifndef __LIB_FIFO_H__
 #define __LIB_FIFO_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* FIFO -- first in first out structure and macros.  */
 struct fifo {
 	struct fifo *next;
@@ -54,5 +58,9 @@ struct fifo {
 #define FIFO_EMPTY(F) (((struct fifo *)(F))->next == (struct fifo *)(F))
 
 #define FIFO_TOP(F) (FIFO_EMPTY(F) ? NULL : ((struct fifo *)(F))->next)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __LIB_FIFO_H__ */

--- a/lib/filter.h
+++ b/lib/filter.h
@@ -24,6 +24,10 @@
 
 #include "if.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Maximum ACL name length */
 #define ACL_NAMSIZ                128
 
@@ -61,5 +65,9 @@ extern void access_list_delete_hook(void (*func)(struct access_list *));
 extern struct access_list *access_list_lookup(afi_t, const char *);
 extern enum filter_type access_list_apply(struct access_list *access,
 					  const void *object);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_FILTER_H */

--- a/lib/freebsd-queue.h
+++ b/lib/freebsd-queue.h
@@ -33,6 +33,10 @@
 #ifndef _SYS_QUEUE_H_
 #define	_SYS_QUEUE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This file defines four types of data structures: singly-linked lists,
  * singly-linked tail queues, lists and tail queues.
@@ -674,5 +678,9 @@ struct qm_trace {
 		else                                                           \
 			(head2)->tqh_last = &(head2)->tqh_first;               \
 	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_SYS_QUEUE_H_ */

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -73,7 +73,7 @@ struct frr_pthread {
 	 */
 	pthread_cond_t *running_cond;
 	pthread_mutex_t *running_cond_mtx;
-	_Atomic bool running;
+	atomic_bool running;
 
 	/*
 	 * Fake thread-specific storage. No constraints on usage. Helpful when

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -25,6 +25,10 @@
 #include "memory.h"
 #include "thread.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MTYPE(FRR_PTHREAD);
 DECLARE_MTYPE(PTHREAD_PRIM);
 
@@ -209,6 +213,10 @@ void frr_pthread_stop_all(void);
 
 #ifndef HAVE_PTHREAD_CONDATTR_SETCLOCK
 #define pthread_condattr_setclock(A, B)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* _FRR_PTHREAD_H */

--- a/lib/frr_zmq.h
+++ b/lib/frr_zmq.h
@@ -23,6 +23,10 @@
 #include "thread.h"
 #include <zmq.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* linking/packaging note:  this is a separate library that needs to be
  * linked into any daemon/library/module that wishes to use its
  * functionality.  The purpose of this is to encapsulate the libzmq
@@ -123,5 +127,9 @@ extern void frrzmq_thread_cancel(struct frrzmq_cb **cb, struct cb_core *core);
  */
 extern void frrzmq_check_events(struct frrzmq_cb **cbp, struct cb_core *core,
 				int event);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRRZMQ_H */

--- a/lib/frratomic.h
+++ b/lib/frratomic.h
@@ -26,7 +26,23 @@
 #endif
 
 /* ISO C11 */
-#ifdef HAVE_STDATOMIC_H
+#ifdef __cplusplus
+#include <stdint.h>
+#include <atomic>
+using std::atomic_int;
+using std::memory_order;
+using std::memory_order_relaxed;
+using std::memory_order_acquire;
+using std::memory_order_release;
+using std::memory_order_acq_rel;
+using std::memory_order_consume;
+using std::memory_order_seq_cst;
+
+typedef std::atomic<bool>		atomic_bool;
+typedef std::atomic<size_t>		atomic_size_t;
+typedef std::atomic<uint_fast32_t>	atomic_uint_fast32_t;
+
+#elif defined(HAVE_STDATOMIC_H)
 #include <stdatomic.h>
 
 /* These are available in gcc, but not in stdatomic */
@@ -39,6 +55,7 @@
 #elif defined(HAVE___ATOMIC)
 
 #define _Atomic volatile
+#define _ATOMIC_WANT_TYPEDEFS
 
 #define memory_order_relaxed __ATOMIC_RELAXED
 #define memory_order_consume __ATOMIC_CONSUME
@@ -74,6 +91,7 @@
 #elif defined(HAVE___SYNC)
 
 #define _Atomic volatile
+#define _ATOMIC_WANT_TYPEDEFS
 
 #define memory_order_relaxed 0
 #define memory_order_consume 0
@@ -196,6 +214,17 @@
 
 #else /* !HAVE___ATOMIC && !HAVE_STDATOMIC_H */
 #error no atomic functions...
+#endif
+
+#ifdef _ATOMIC_WANT_TYPEDEFS
+#undef _ATOMIC_WANT_TYPEDEFS
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef _Atomic bool		atomic_bool;
+typedef _Atomic size_t		atomic_size_t;
+typedef _Atomic uint_fast32_t	atomic_uint_fast32_t;
 #endif
 
 #endif /* _FRRATOMIC_H */

--- a/lib/frrstr.h
+++ b/lib/frrstr.h
@@ -27,6 +27,10 @@
 
 #include "vector.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Tokenizes a string, storing tokens in a vector. Whitespace is ignored.
  * Delimiter characters are not included.
@@ -107,5 +111,9 @@ bool begins_with(const char *str, const char *prefix);
  *    1 str only contains digit characters, 0 otherwise
  */
 int all_digit(const char *str);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRRSTR_H_ */

--- a/lib/graph.h
+++ b/lib/graph.h
@@ -28,6 +28,10 @@
 #include "vector.h"
 #include "buffer.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct graph {
 	vector nodes;
 };
@@ -164,4 +168,9 @@ char *graph_dump_dot(struct graph *graph, struct graph_node *start,
 		     void (*pcb)(struct graph_node *, struct buffer *buf));
 
 #endif /* BUILDING_CLIPPY */
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _ZEBRA_COMMAND_GRAPH_H */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -54,9 +54,9 @@ struct hash_backet {
 
 struct hashstats {
 	/* number of empty hash buckets */
-	_Atomic uint_fast32_t empty;
+	atomic_uint_fast32_t empty;
 	/* sum of squares of bucket length */
-	_Atomic uint_fast32_t ssq;
+	atomic_uint_fast32_t ssq;
 };
 
 struct hash {

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -24,6 +24,10 @@
 #include "memory.h"
 #include "frratomic.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MTYPE(HASH)
 DECLARE_MTYPE(HASH_BACKET)
 
@@ -324,5 +328,9 @@ extern unsigned int string_hash_make(const char *);
  * Install CLI commands for viewing global hash table statistics.
  */
 extern void hash_cmd_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_HASH_H */

--- a/lib/hook.h
+++ b/lib/hook.h
@@ -22,6 +22,10 @@
 #include "module.h"
 #include "memory.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* type-safe subscribable hook points
  *
  * where "type-safe" applies to the function pointers used for subscriptions
@@ -218,5 +222,9 @@ extern void _hook_unregister(struct hook *hook, void *funcptr, void *arg,
 	DEFINE_HOOK_INT(hookname, arglist, passlist, false)
 #define DEFINE_KOOH(hookname, arglist, passlist)                               \
 	DEFINE_HOOK_INT(hookname, arglist, passlist, true)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_HOOK_H */

--- a/lib/id_alloc.h
+++ b/lib/id_alloc.h
@@ -24,6 +24,10 @@
 #include <limits.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define IDALLOC_INVALID 0
 
 #define IDALLOC_DIR_BITS     8
@@ -86,5 +90,9 @@ uint32_t idalloc_allocate_prefer_pool(struct id_alloc *alloc,
 uint32_t idalloc_reserve(struct id_alloc *alloc, uint32_t id);
 struct id_alloc *idalloc_new(const char *name);
 void idalloc_destroy(struct id_alloc *alloc);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/if.c
+++ b/lib/if.c
@@ -1379,13 +1379,13 @@ const struct frr_yang_module_info frr_interface_info = {
 		{
 			.xpath = "/frr-interface:lib/interface",
 			.cbs.create = lib_interface_create,
-			.cbs.delete = lib_interface_delete,
+			.cbs.destroy = lib_interface_delete,
 			.cbs.cli_show = cli_show_interface,
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/description",
 			.cbs.modify = lib_interface_description_modify,
-			.cbs.delete = lib_interface_description_delete,
+			.cbs.destroy = lib_interface_description_delete,
 			.cbs.cli_show = cli_show_interface_desc,
 		},
 		{

--- a/lib/if.c
+++ b/lib/if.c
@@ -1160,7 +1160,7 @@ DEFPY (no_interface,
 	if (!vrfname)
 		vrfname = VRF_DEFAULT_NAME;
 
-	nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+	nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(
 		vty, "/frr-interface:lib/interface[name='%s'][vrf='%s']",
@@ -1207,7 +1207,7 @@ DEFPY  (no_interface_desc,
 	NO_STR
 	"Interface specific description\n")
 {
-	nb_cli_enqueue_change(vty, "./description", NB_OP_DELETE, NULL);
+	nb_cli_enqueue_change(vty, "./description", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }

--- a/lib/if.h
+++ b/lib/if.h
@@ -290,9 +290,9 @@ struct interface {
 };
 
 RB_HEAD(if_name_head, interface);
-RB_PROTOTYPE(if_name_head, interface, name_entry, if_cmp_func);
+RB_PROTOTYPE(if_name_head, interface, name_entry, if_cmp_func)
 RB_HEAD(if_index_head, interface);
-RB_PROTOTYPE(if_index_head, interface, index_entry, if_cmp_func);
+RB_PROTOTYPE(if_index_head, interface, index_entry, if_cmp_func)
 DECLARE_QOBJ_TYPE(interface)
 
 #define IFNAME_RB_INSERT(vrf, ifp)                                             \

--- a/lib/if.h
+++ b/lib/if.h
@@ -27,6 +27,10 @@
 #include "qobj.h"
 #include "hook.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MTYPE(IF)
 DECLARE_MTYPE(CONNECTED_LABEL)
 
@@ -544,5 +548,9 @@ void if_link_params_free(struct interface *);
 /* Northbound. */
 extern void if_cmd_init(void);
 extern const struct frr_yang_module_info frr_interface_info;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_IF_H */

--- a/lib/if_rmap.h
+++ b/lib/if_rmap.h
@@ -21,6 +21,10 @@
 #ifndef _ZEBRA_IF_RMAP_H
 #define _ZEBRA_IF_RMAP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum if_rmap_type { IF_RMAP_IN, IF_RMAP_OUT, IF_RMAP_MAX };
 
 struct if_rmap {
@@ -36,5 +40,9 @@ extern void if_rmap_hook_add(void (*)(struct if_rmap *));
 extern void if_rmap_hook_delete(void (*)(struct if_rmap *));
 extern struct if_rmap *if_rmap_lookup(const char *);
 extern int config_write_if_rmap(struct vty *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_IF_RMAP_H */

--- a/lib/imsg.h
+++ b/lib/imsg.h
@@ -21,6 +21,10 @@
 #ifndef _IMSG_H_
 #define _IMSG_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define IBUF_READ_SIZE		65535
 #define IMSG_HEADER_SIZE	sizeof(struct imsg_hdr)
 #define MAX_IMSGSIZE		16384
@@ -107,5 +111,9 @@ void imsg_close(struct imsgbuf *, struct ibuf *);
 void imsg_free(struct imsg *);
 int imsg_flush(struct imsgbuf *);
 void imsg_clear(struct imsgbuf *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -25,6 +25,10 @@
 
 #include <zebra.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Generic IP address - union of IPv4 and IPv6 address.
  */
@@ -111,5 +115,9 @@ static inline void ipv4_mapped_ipv6_to_ipv4(struct in6_addr *in6,
 	memset(in, 0, sizeof(struct in_addr));
 	memcpy(in, (char *)in6 + 12, sizeof(struct in_addr));
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __IPADDR_H__ */

--- a/lib/jhash.h
+++ b/lib/jhash.h
@@ -20,6 +20,10 @@
 #ifndef _QUAGGA_JHASH_H
 #define _QUAGGA_JHASH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The most generic version, hashes an arbitrary sequence
  * of bytes.  No alignment or length assumptions are made about
  * the input key.
@@ -41,5 +45,9 @@ extern uint32_t jhash_3words(uint32_t a, uint32_t b, uint32_t c,
 			     uint32_t initval);
 extern uint32_t jhash_2words(uint32_t a, uint32_t b, uint32_t initval);
 extern uint32_t jhash_1word(uint32_t a, uint32_t initval);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _QUAGGA_JHASH_H */

--- a/lib/json.h
+++ b/lib/json.h
@@ -21,6 +21,10 @@
 #ifndef _QUAGGA_JSON_H
 #define _QUAGGA_JSON_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(HAVE_JSON_C_JSON_H)
 #include <json-c/json.h>
 
@@ -79,6 +83,10 @@ extern void json_object_free(struct json_object *obj);
   * Don't escape forward slashes.
   */
 #define JSON_C_TO_STRING_NOSLASHESCAPE (1<<4)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* _QUAGGA_JSON_H */

--- a/lib/keychain.h
+++ b/lib/keychain.h
@@ -23,6 +23,10 @@
 
 #include "qobj.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct keychain {
 	char *name;
 
@@ -56,5 +60,9 @@ extern struct keychain *keychain_lookup(const char *);
 extern struct key *key_lookup_for_accept(const struct keychain *, uint32_t);
 extern struct key *key_match_for_accept(const struct keychain *, const char *);
 extern struct key *key_lookup_for_send(const struct keychain *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_KEYCHAIN_H */

--- a/lib/lib_errors.h
+++ b/lib/lib_errors.h
@@ -23,6 +23,10 @@
 
 #include "lib/ferr.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum lib_log_refs {
 	EC_LIB_PRIVILEGES = LIB_FERR_START,
 	EC_LIB_VRF_START,
@@ -81,5 +85,9 @@ enum lib_log_refs {
 };
 
 extern void lib_error_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -30,6 +30,10 @@
 #include "hook.h"
 #include "northbound.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The following options disable specific command line options that
  * are not applicable for a particular daemon.
  */
@@ -151,5 +155,9 @@ extern char frr_protoname[];
 extern char frr_protonameinst[];
 
 extern bool debug_memstats_at_exit;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_FRR_H */

--- a/lib/libospf.h
+++ b/lib/libospf.h
@@ -22,6 +22,10 @@
 #ifndef _LIBOSPFD_H
 #define _LIBOSPFD_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* IP precedence. */
 #ifndef IPTOS_PREC_INTERNETCONTROL
 #define IPTOS_PREC_INTERNETCONTROL	0xC0
@@ -93,5 +97,9 @@
 
 #define OSPF_LSA_MAXAGE_CHECK_INTERVAL		30
 #define OSPF_LSA_MAXAGE_REMOVE_DELAY_DEFAULT	60
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _LIBOSPFD_H */

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -295,7 +295,8 @@ extern void list_add_list(struct list *list, struct list *add);
 #define ALL_LIST_ELEMENTS(list, node, nextnode, data)                          \
 	(node) = listhead(list), ((data) = NULL);                              \
 	(node) != NULL                                                         \
-		&& ((data) = listgetdata(node), (nextnode) = node->next, 1);   \
+		&& ((data) = static_cast(data, listgetdata(node)),             \
+		    (nextnode) = node->next, 1);                               \
 	(node) = (nextnode), ((data) = NULL)
 
 /* read-only list iteration macro.
@@ -306,7 +307,7 @@ extern void list_add_list(struct list *list, struct list *add);
  */
 #define ALL_LIST_ELEMENTS_RO(list, node, data)                                 \
 	(node) = listhead(list), ((data) = NULL);                              \
-	(node) != NULL && ((data) = listgetdata(node), 1);                     \
+	(node) != NULL && ((data) = static_cast(data, listgetdata(node)), 1);  \
 	(node) = listnextnode(node), ((data) = NULL)
 
 /* these *do not* cleanup list nodes and referenced data, as the functions

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -21,6 +21,10 @@
 #ifndef _ZEBRA_LINKLIST_H
 #define _ZEBRA_LINKLIST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* listnodes must always contain data to be valid. Adding an empty node
  * to a list is invalid
  */
@@ -335,5 +339,9 @@ extern void list_add_list(struct list *list, struct list *add);
 			(L)->tail = (N)->prev;                                 \
 		(L)->count--;                                                  \
 	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_LINKLIST_H */

--- a/lib/log.h
+++ b/lib/log.h
@@ -29,6 +29,10 @@
 #include <stdarg.h>
 #include "lib/hook.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Hook for external logging function */
 DECLARE_HOOK(zebra_ext_log, (int priority, const char *format, va_list args),
 	     (priority, format, args));
@@ -195,5 +199,9 @@ struct timestamp_control {
 	"Local use\n"                                                          \
 	"Local use\n"                                                          \
 	"Local use\n"
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_LOG_H */

--- a/lib/log.h
+++ b/lib/log.h
@@ -93,11 +93,11 @@ extern void zlog_debug(const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
 
 /* For logs which have error codes associated with them */
 #define flog_err(ferr_id, format, ...)                                        \
-	zlog_err("[EC %"PRIu32"] " format, ferr_id, ##__VA_ARGS__)
+	zlog_err("[EC %" PRIu32 "] " format, ferr_id, ##__VA_ARGS__)
 #define flog_err_sys(ferr_id, format, ...)                                     \
 	flog_err(ferr_id, format, ##__VA_ARGS__)
 #define flog_warn(ferr_id, format, ...)                                        \
-	zlog_warn("[EC %"PRIu32"] " format, ferr_id, ##__VA_ARGS__)
+	zlog_warn("[EC %" PRIu32 "] " format, ferr_id, ##__VA_ARGS__)
 
 
 extern void zlog_thread_info(int log_level);

--- a/lib/log_int.h
+++ b/lib/log_int.h
@@ -24,6 +24,10 @@
 
 #include "log.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct zlog {
 	const char *ident; /* daemon name (first arg to openlog) */
 	const char *protoname;
@@ -48,5 +52,9 @@ extern const char *zlog_priority[];
 /* Generic function for zlog. */
 extern void vzlog(int priority, const char *format, va_list args);
 extern void zlog(int priority, const char *format, ...) PRINTF_ATTRIBUTE(2, 3);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_LOG_PRIVATE_H */

--- a/lib/logicalrouter.h
+++ b/lib/logicalrouter.h
@@ -20,6 +20,10 @@
 #ifndef _ZEBRA_LOGICAL_ROUTER_H
 #define _ZEBRA_LOGICAL_ROUTER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Logical Router Backend defines */
 #define LOGICALROUTER_BACKEND_OFF   0
 #define LOGICALROUTER_BACKEND_NETNS 1
@@ -37,5 +41,9 @@ extern void logicalrouter_terminate(void);
  * one can think of having exclusivity only per NETNS
  */
 extern void logicalrouter_configure_backend(int backend_netns);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*_ZEBRA_LOGICAL_ROUTER_H*/

--- a/lib/lua.h
+++ b/lib/lua.h
@@ -29,6 +29,10 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * These functions are helper functions that
  * try to glom some of the lua_XXX functionality
@@ -75,5 +79,10 @@ enum lua_rm_status lua_run_rm_rule(lua_State *L, const char *rule);
  */
 const char *get_string(lua_State *L, const char *key);
 int get_integer(lua_State *L, const char *key);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 #endif

--- a/lib/md5.h
+++ b/lib/md5.h
@@ -38,6 +38,10 @@
 #ifndef _LIBZEBRA_MD5_H_
 #define _LIBZEBRA_MD5_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MD5_BUFLEN	64
 
 typedef struct {
@@ -81,5 +85,9 @@ extern void md5_result(uint8_t *, md5_ctxt *);
 /* From RFC 2104 */
 void hmac_md5(unsigned char *text, int text_len, unsigned char *key,
 	      int key_len, uint8_t *digest);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ! _LIBZEBRA_MD5_H_*/

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -33,12 +33,12 @@
 struct memtype {
 	struct memtype *next, **ref;
 	const char *name;
-	_Atomic size_t n_alloc;
-	_Atomic size_t n_max;
-	_Atomic size_t size;
+	atomic_size_t n_alloc;
+	atomic_size_t n_max;
+	atomic_size_t size;
 #ifdef HAVE_MALLOC_USABLE_SIZE
-	_Atomic size_t total;
-	_Atomic size_t max_size;
+	atomic_size_t total;
+	atomic_size_t max_size;
 #endif
 };
 

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -22,6 +22,10 @@
 #include <frratomic.h>
 #include "compiler.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define array_size(ar) (sizeof(ar) / sizeof(ar[0]))
 
 #if defined(HAVE_MALLOC_SIZE) && !defined(HAVE_MALLOC_USABLE_SIZE)
@@ -175,5 +179,9 @@ extern int log_memstats(FILE *fp, const char *);
 #define log_memstats_stderr(prefix) log_memstats(stderr, prefix)
 
 extern void memory_oom(size_t size, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _QUAGGA_MEMORY_H */

--- a/lib/memory_vty.h
+++ b/lib/memory_vty.h
@@ -23,9 +23,18 @@
 
 #include "memory.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void memory_init(void);
 
 /* Human friendly string for given byte count */
 #define MTYPE_MEMSTR_LEN 20
 extern const char *mtype_memstr(char *, size_t, unsigned long);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _ZEBRA_MEMORY_VTY_H */

--- a/lib/mlag.h
+++ b/lib/mlag.h
@@ -22,6 +22,10 @@
 #ifndef __MLAG_H__
 #define __MLAG_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum mlag_role {
 	MLAG_ROLE_NONE,
 	MLAG_ROLE_PRIMARY,
@@ -29,4 +33,9 @@ enum mlag_role {
 };
 
 extern char *mlag_role2str(enum mlag_role role, char *buf, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/lib/module.h
+++ b/lib/module.h
@@ -20,6 +20,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if !defined(__GNUC__)
 #error module code needs GCC visibility extensions
 #elif __GNUC__ < 4
@@ -93,6 +97,10 @@ extern struct frrmod_runtime *frrmod_load(const char *spec, const char *dir,
 #if 0
 /* not implemented yet */
 extern void frrmod_unload(struct frrmod_runtime *module);
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* _FRR_MODULE_H */

--- a/lib/module.h
+++ b/lib/module.h
@@ -82,9 +82,10 @@ extern union _frrmod_runtime_u _frrmod_this_module;
 
 #define FRR_COREMOD_SETUP(...)                                                 \
 	static const struct frrmod_info _frrmod_info = {__VA_ARGS__};          \
-	DSO_LOCAL union _frrmod_runtime_u _frrmod_this_module = {              \
-		.r.info = &_frrmod_info,                                       \
-	};
+	DSO_LOCAL union _frrmod_runtime_u _frrmod_this_module = {{             \
+		NULL,                                                          \
+		&_frrmod_info,                                                 \
+	}};
 #define FRR_MODULE_SETUP(...)                                                  \
 	FRR_COREMOD_SETUP(__VA_ARGS__)                                         \
 	DSO_SELF struct frrmod_runtime *frr_module = &_frrmod_this_module.r;

--- a/lib/monotime.h
+++ b/lib/monotime.h
@@ -21,6 +21,10 @@
 #include <time.h>
 #include <sys/time.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef TIMESPEC_TO_TIMEVAL
 /* should be in sys/time.h on BSD & Linux libcs */
 #define TIMESPEC_TO_TIMEVAL(tv, ts)                                            \
@@ -90,5 +94,9 @@ static inline char *time_to_string(time_t ts)
 
 	return ctime(&tbuf);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_MONOTIME_H */

--- a/lib/mpls.h
+++ b/lib/mpls.h
@@ -25,6 +25,10 @@
 #include <zebra.h>
 #include <arpa/inet.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef MPLS_LABEL_MAX
 #undef MPLS_LABEL_MAX
 #endif
@@ -208,5 +212,9 @@ int mpls_str2label(const char *label_str, uint8_t *num_labels,
  */
 char *mpls_label2str(uint8_t num_labels, mpls_label_t *labels, char *buf,
 		     int len, int pretty);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/network.h
+++ b/lib/network.h
@@ -22,6 +22,10 @@
 #ifndef _ZEBRA_NETWORK_H
 #define _ZEBRA_NETWORK_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Both readn and writen are deprecated and will be removed.  They are not
    suitable for use with non-blocking file descriptors.
  */
@@ -40,5 +44,9 @@ extern int set_cloexec(int fd);
 
 extern float htonf(float);
 extern float ntohf(float);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_NETWORK_H */

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -26,6 +26,10 @@
 #include "prefix.h"
 #include "mpls.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Maximum next hop string length - gateway + ifindex */
 #define NEXTHOP_STRLEN (INET6_ADDRSTRLEN + 30)
 
@@ -146,4 +150,9 @@ extern int nexthop_same_firsthop(struct nexthop *next1, struct nexthop *next2);
 extern const char *nexthop2str(const struct nexthop *nexthop, char *str, int size);
 extern struct nexthop *nexthop_next(struct nexthop *nexthop);
 extern unsigned int nexthop_level(struct nexthop *nexthop);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /*_LIB_NEXTHOP_H */

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -23,6 +23,10 @@
 
 #include <vty.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * What is a nexthop group?
  *
@@ -110,4 +114,9 @@ extern struct nexthop *nexthop_exists(struct nexthop_group *nhg,
 extern struct nexthop_group_cmd *nhgc_find(const char *name);
 
 extern void nexthop_group_write_nexthop(struct vty *vty, struct nexthop *nh);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -92,12 +92,12 @@ DECLARE_QOBJ_TYPE(nexthop_group_cmd)
  * code
  */
 void nexthop_group_init(
-	void (*new)(const char *name),
+	void (*create)(const char *name),
 	void (*add_nexthop)(const struct nexthop_group_cmd *nhgc,
 			    const struct nexthop *nhop),
 	void (*del_nexthop)(const struct nexthop_group_cmd *nhgc,
 			    const struct nexthop *nhop),
-	void (*delete)(const char *name));
+	void (*destroy)(const char *name));
 
 void nexthop_group_enable_vrf(struct vrf *vrf);
 void nexthop_group_disable_vrf(struct vrf *vrf);

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -184,7 +184,7 @@ static unsigned int nb_node_validate_cbs(const struct nb_node *nb_node)
 				     !!nb_node->cbs.create, false);
 	error += nb_node_validate_cb(nb_node, NB_OP_MODIFY,
 				     !!nb_node->cbs.modify, false);
-	error += nb_node_validate_cb(nb_node, NB_OP_DELETE,
+	error += nb_node_validate_cb(nb_node, NB_OP_DESTROY,
 				     !!nb_node->cbs.destroy, false);
 	error += nb_node_validate_cb(nb_node, NB_OP_MOVE, !!nb_node->cbs.move,
 				     false);
@@ -417,7 +417,7 @@ static void nb_config_diff(const struct nb_config *config1,
 			break;
 		case LYD_DIFF_DELETED:
 			dnode = diff->first[i];
-			operation = NB_OP_DELETE;
+			operation = NB_OP_DESTROY;
 			break;
 		case LYD_DIFF_CHANGED:
 			dnode = diff->second[i];
@@ -485,7 +485,7 @@ int nb_candidate_edit(struct nb_config *candidate,
 			lyd_validate(&dnode, LYD_OPT_CONFIG, ly_native_ctx);
 		}
 		break;
-	case NB_OP_DELETE:
+	case NB_OP_DESTROY:
 		dnode = yang_dnode_get(candidate->dnode, xpath_edit);
 		if (!dnode)
 			/*
@@ -741,7 +741,7 @@ static int nb_configuration_callback(const enum nb_event event,
 	case NB_OP_MODIFY:
 		ret = (*nb_node->cbs.modify)(event, dnode, resource);
 		break;
-	case NB_OP_DELETE:
+	case NB_OP_DESTROY:
 		ret = (*nb_node->cbs.destroy)(event, dnode);
 		break;
 	case NB_OP_MOVE:
@@ -912,7 +912,7 @@ static void nb_transaction_apply_finish(struct nb_transaction *transaction)
 		 * (the 'apply_finish' callbacks from the node ancestors should
 		 * be called though).
 		 */
-		if (change->cb.operation == NB_OP_DELETE) {
+		if (change->cb.operation == NB_OP_DESTROY) {
 			char xpath[XPATH_MAXLEN];
 
 			dnode = dnode->parent;
@@ -1359,7 +1359,7 @@ bool nb_operation_is_valid(enum nb_operation operation,
 			return false;
 		}
 		return true;
-	case NB_OP_DELETE:
+	case NB_OP_DESTROY:
 		if (!CHECK_FLAG(snode->flags, LYS_CONFIG_W))
 			return false;
 
@@ -1511,8 +1511,8 @@ const char *nb_operation_name(enum nb_operation operation)
 		return "create";
 	case NB_OP_MODIFY:
 		return "modify";
-	case NB_OP_DELETE:
-		return "delete";
+	case NB_OP_DESTROY:
+		return "destroy";
 	case NB_OP_MOVE:
 		return "move";
 	case NB_OP_APPLY_FINISH:

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -185,7 +185,7 @@ static unsigned int nb_node_validate_cbs(const struct nb_node *nb_node)
 	error += nb_node_validate_cb(nb_node, NB_OP_MODIFY,
 				     !!nb_node->cbs.modify, false);
 	error += nb_node_validate_cb(nb_node, NB_OP_DELETE,
-				     !!nb_node->cbs.delete, false);
+				     !!nb_node->cbs.destroy, false);
 	error += nb_node_validate_cb(nb_node, NB_OP_MOVE, !!nb_node->cbs.move,
 				     false);
 	error += nb_node_validate_cb(nb_node, NB_OP_APPLY_FINISH,
@@ -742,7 +742,7 @@ static int nb_configuration_callback(const enum nb_event event,
 		ret = (*nb_node->cbs.modify)(event, dnode, resource);
 		break;
 	case NB_OP_DELETE:
-		ret = (*nb_node->cbs.delete)(event, dnode);
+		ret = (*nb_node->cbs.destroy)(event, dnode);
 		break;
 	case NB_OP_MOVE:
 		ret = (*nb_node->cbs.move)(event, dnode);

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -168,7 +168,7 @@ struct nb_callbacks {
 	 *    - NB_ERR_INCONSISTENCY when an inconsistency was detected.
 	 *    - NB_ERR for other errors.
 	 */
-	int (*delete)(enum nb_event event, const struct lyd_node *dnode);
+	int (*destroy)(enum nb_event event, const struct lyd_node *dnode);
 
 	/*
 	 * Configuration callback.

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -27,6 +27,10 @@
 #include "yang.h"
 #include "yang_translator.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Forward declaration(s). */
 struct vty;
 
@@ -838,5 +842,9 @@ extern void nb_init(struct thread_master *tm, const struct frr_yang_module_info 
  * is exiting.
  */
 extern void nb_terminate(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_NORTHBOUND_H_ */

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -65,7 +65,7 @@ enum nb_event {
 enum nb_operation {
 	NB_OP_CREATE,
 	NB_OP_MODIFY,
-	NB_OP_DELETE,
+	NB_OP_DESTROY,
 	NB_OP_MOVE,
 	NB_OP_APPLY_FINISH,
 	NB_OP_GET_ELEM,

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -22,6 +22,10 @@
 
 #include "northbound.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Possible formats in which a configuration can be displayed. */
 enum nb_cfg_format {
 	NB_CFG_FMT_CMDS = 0,
@@ -110,5 +114,9 @@ extern int nb_cli_confirmed_commit_rollback(struct vty *vty);
 extern void nb_cli_install_default(int node);
 extern void nb_cli_init(struct thread_master *tm);
 extern void nb_cli_terminate(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_NORTHBOUND_CLI_H_ */

--- a/lib/northbound_confd.c
+++ b/lib/northbound_confd.c
@@ -228,7 +228,7 @@ frr_confd_cdb_diff_iter(confd_hkeypath_t *kp, enum cdb_iter_op cdb_op,
 		nb_op = NB_OP_CREATE;
 		break;
 	case MOP_DELETED:
-		nb_op = NB_OP_DELETE;
+		nb_op = NB_OP_DESTROY;
 		break;
 	case MOP_VALUE_SET:
 		if (nb_operation_is_valid(NB_OP_MODIFY, nb_node->snode))

--- a/lib/northbound_db.h
+++ b/lib/northbound_db.h
@@ -22,6 +22,10 @@
 
 #include "northbound.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Initialize the northbound database.
  *
@@ -100,5 +104,9 @@ extern int nb_db_transactions_iterate(
 	void (*func)(void *arg, int transaction_id, const char *client_name,
 		     const char *date, const char *comment),
 	void *arg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_NORTHBOUND_DB_H_ */

--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -202,10 +202,10 @@ static int frr_sr_process_change(struct nb_config *candidate,
 		 * notified about the removal of all of its leafs, even the ones
 		 * that are non-optional. We need to ignore these notifications.
 		 */
-		if (!nb_operation_is_valid(NB_OP_DELETE, nb_node->snode))
+		if (!nb_operation_is_valid(NB_OP_DESTROY, nb_node->snode))
 			return NB_OK;
 
-		nb_op = NB_OP_DELETE;
+		nb_op = NB_OP_DESTROY;
 		break;
 	case SR_OP_MOVED:
 		nb_op = NB_OP_MOVE;

--- a/lib/ns.h
+++ b/lib/ns.h
@@ -26,6 +26,10 @@
 #include "linklist.h"
 #include "vty.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef uint32_t ns_id_t;
 
 /* the default NS ID */
@@ -173,5 +177,9 @@ extern struct ns *ns_lookup_name(const char *name);
 extern int ns_enable(struct ns *ns, void (*func)(ns_id_t, void *));
 extern struct ns *ns_get_created(struct ns *ns, char *name, ns_id_t ns_id);
 extern void ns_disable(struct ns *ns);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*_ZEBRA_NS_H*/

--- a/lib/openbsd-queue.h
+++ b/lib/openbsd-queue.h
@@ -35,6 +35,10 @@
 #ifndef _SYS_QUEUE_H_
 #define	_SYS_QUEUE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This file defines five types of data structures: singly-linked lists,
  * lists, simple queues, tail queues and XOR simple queues.
@@ -571,5 +575,9 @@
 			TAILQ_INIT((head2));                                   \
 		}                                                              \
 	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_SYS_QUEUE_H_ */

--- a/lib/openbsd-tree.h
+++ b/lib/openbsd-tree.h
@@ -27,6 +27,10 @@
 #ifndef _SYS_TREE_H_
 #define	_SYS_TREE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This file defines data structures for different types of trees:
  * splay trees and red-black trees.
@@ -566,5 +570,9 @@ int _rb_check(const struct rb_type *, void *, unsigned long);
 #define RB_FOREACH_REVERSE_SAFE(_e, _name, _head, _n)                          \
 	for ((_e) = RB_MAX(_name, (_head));                                    \
 	     (_e) != NULL && ((_n) = RB_PREV(_name, (_e)), 1); (_e) = (_n))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _SYS_TREE_H_ */

--- a/lib/openbsd-tree.h
+++ b/lib/openbsd-tree.h
@@ -397,31 +397,36 @@ int _rb_check(const struct rb_type *, void *, unsigned long);
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_INSERT(struct _name *head, struct _type *elm)      \
 	{                                                                      \
-		return _rb_insert(_name##_RB_TYPE, &head->rbh_root, elm);      \
+		return (struct _type *)_rb_insert(                             \
+			_name##_RB_TYPE, &head->rbh_root, elm);                \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_REMOVE(struct _name *head, struct _type *elm)      \
 	{                                                                      \
-		return _rb_remove(_name##_RB_TYPE, &head->rbh_root, elm);      \
+		return (struct _type *)_rb_remove(                             \
+			_name##_RB_TYPE, &head->rbh_root, elm);                \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_FIND(struct _name *head, const struct _type *key)  \
 	{                                                                      \
-		return _rb_find(_name##_RB_TYPE, &head->rbh_root, key);        \
+		return (struct _type *)_rb_find(                               \
+			_name##_RB_TYPE, &head->rbh_root, key);                \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_NFIND(struct _name *head, const struct _type *key) \
 	{                                                                      \
-		return _rb_nfind(_name##_RB_TYPE, &head->rbh_root, key);       \
+		return (struct _type *)_rb_nfind(                              \
+			_name##_RB_TYPE, &head->rbh_root, key);                \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_ROOT(struct _name *head)                           \
 	{                                                                      \
-		return _rb_root(_name##_RB_TYPE, &head->rbh_root);             \
+		return (struct _type *)_rb_root(                               \
+			_name##_RB_TYPE, &head->rbh_root);                     \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline int _name##_RB_EMPTY(        \
@@ -433,43 +438,45 @@ int _rb_check(const struct rb_type *, void *, unsigned long);
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_MIN(struct _name *head)                            \
 	{                                                                      \
-		return _rb_min(_name##_RB_TYPE, &head->rbh_root);              \
+		return (struct _type *)_rb_min(                                \
+			_name##_RB_TYPE, &head->rbh_root);                     \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_MAX(struct _name *head)                            \
 	{                                                                      \
-		return _rb_max(_name##_RB_TYPE, &head->rbh_root);              \
+		return (struct _type *)_rb_max(                                \
+			_name##_RB_TYPE, &head->rbh_root);                     \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_NEXT(struct _type *elm)                            \
 	{                                                                      \
-		return _rb_next(_name##_RB_TYPE, elm);                         \
+		return (struct _type *)_rb_next(_name##_RB_TYPE, elm);         \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_PREV(struct _type *elm)                            \
 	{                                                                      \
-		return _rb_prev(_name##_RB_TYPE, elm);                         \
+		return (struct _type *)_rb_prev(_name##_RB_TYPE, elm);         \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_LEFT(struct _type *elm)                            \
 	{                                                                      \
-		return _rb_left(_name##_RB_TYPE, elm);                         \
+		return (struct _type *)_rb_left(_name##_RB_TYPE, elm);         \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_RIGHT(struct _type *elm)                           \
 	{                                                                      \
-		return _rb_right(_name##_RB_TYPE, elm);                        \
+		return (struct _type *)_rb_right(_name##_RB_TYPE, elm);        \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_PARENT(struct _type *elm)                          \
 	{                                                                      \
-		return _rb_parent(_name##_RB_TYPE, elm);                       \
+		return (struct _type *)_rb_parent(_name##_RB_TYPE, elm);       \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline void _name##_RB_SET_LEFT(    \

--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -24,6 +24,10 @@
 #include "stream.h"
 #include "prefix.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PBR_STR "Policy Based Routing\n"
 
 /*
@@ -120,5 +124,9 @@ struct pbr_rule {
 
 extern int zapi_pbr_rule_encode(uint8_t cmd, struct stream *s,
 				struct pbr_rule *zrule);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _PBR_H */

--- a/lib/plist.h
+++ b/lib/plist.h
@@ -27,6 +27,10 @@
 #include "stream.h"
 #include "vty.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum prefix_list_type {
 	PREFIX_DENY,
 	PREFIX_PERMIT,
@@ -74,5 +78,9 @@ extern int prefix_bgp_orf_set(char *, afi_t, struct orf_prefix *, int, int);
 extern void prefix_bgp_orf_remove_all(afi_t, char *);
 extern int prefix_bgp_show_prefix_list(struct vty *vty, afi_t afi, char *name,
 				       bool use_json);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _QUAGGA_PLIST_H */

--- a/lib/plist_int.h
+++ b/lib/plist_int.h
@@ -22,6 +22,10 @@
 #ifndef _QUAGGA_PLIST_INT_H
 #define _QUAGGA_PLIST_INT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum prefix_name_type { PREFIX_TYPE_STRING, PREFIX_TYPE_NUMBER };
 
 struct pltrie_table;
@@ -67,5 +71,9 @@ struct prefix_list_entry {
 	/* up the chain for best match search */
 	struct prefix_list_entry *next_best;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _QUAGGA_PLIST_INT_H */

--- a/lib/pqueue.h
+++ b/lib/pqueue.h
@@ -21,6 +21,10 @@
 #ifndef _ZEBRA_PQUEUE_H
 #define _ZEBRA_PQUEUE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct pqueue {
 	void **array;
 	int array_size;
@@ -42,5 +46,9 @@ extern void pqueue_remove(void *data, struct pqueue *queue);
 
 extern void trickle_down(int index, struct pqueue *queue);
 extern void trickle_up(int index, struct pqueue *queue);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_PQUEUE_H */

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -35,6 +35,10 @@
 #include "ipaddr.h"
 #include "compiler.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef ETH_ALEN
 #define ETH_ALEN 6
 #endif
@@ -506,4 +510,9 @@ static inline int is_host_route(struct prefix *p)
 		return (p->prefixlen == IPV6_MAX_BITLEN);
 	return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _ZEBRA_PREFIX_H */

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -276,20 +276,29 @@ struct prefix_sg {
  * side, which strips type safety since the cast will accept any pointer
  * type.)
  */
+#ifndef __cplusplus
+#define prefixtype(uname, typename, fieldname) \
+	typename *fieldname;
+#else
+#define prefixtype(uname, typename, fieldname) \
+	typename *fieldname; \
+	uname(typename *x) { this->fieldname = x; }
+#endif
+
 union prefixptr {
-	struct prefix *p;
-	struct prefix_ipv4 *p4;
-	struct prefix_ipv6 *p6;
-	struct prefix_evpn *evp;
-	const struct prefix_fs *fs;
+	prefixtype(prefixptr, struct prefix,      p)
+	prefixtype(prefixptr, struct prefix_ipv4, p4)
+	prefixtype(prefixptr, struct prefix_ipv6, p6)
+	prefixtype(prefixptr, struct prefix_evpn, evp)
+	prefixtype(prefixptr, struct prefix_fs,   fs)
 } __attribute__((transparent_union));
 
 union prefixconstptr {
-	const struct prefix *p;
-	const struct prefix_ipv4 *p4;
-	const struct prefix_ipv6 *p6;
-	const struct prefix_evpn *evp;
-	const struct prefix_fs *fs;
+	prefixtype(prefixconstptr, const struct prefix,      p)
+	prefixtype(prefixconstptr, const struct prefix_ipv4, p4)
+	prefixtype(prefixconstptr, const struct prefix_ipv6, p6)
+	prefixtype(prefixconstptr, const struct prefix_evpn, evp)
+	prefixtype(prefixconstptr, const struct prefix_fs,   fs)
 } __attribute__((transparent_union));
 
 #ifndef INET_ADDRSTRLEN

--- a/lib/privs.h
+++ b/lib/privs.h
@@ -23,6 +23,10 @@
 #ifndef _ZEBRA_PRIVS_H
 #define _ZEBRA_PRIVS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* list of zebra capabilities */
 typedef enum {
 	ZCAP_SETID,
@@ -119,5 +123,9 @@ extern void _zprivs_lower(struct zebra_privs_t **privs);
 					  (unused, cleanup(_zprivs_lower))) =  \
 					  _zprivs_raise(privs, __func__);      \
 	     _once == NULL; _once = (void *)1)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_PRIVS_H */

--- a/lib/ptm_lib.h
+++ b/lib/ptm_lib.h
@@ -20,6 +20,10 @@
 #ifndef __PTM_LIB_H__
 #define __PTM_LIB_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PTMLIB_MSG_SZ           1024
 #define PTMLIB_MSG_HDR_LEN      37
 #define PTMLIB_MSG_VERSION      2
@@ -64,5 +68,9 @@ int ptm_lib_init_msg(ptm_lib_handle_t *, int, int, void *, void **);
 int ptm_lib_append_msg(ptm_lib_handle_t *, void *, const char *, const char *);
 int ptm_lib_complete_msg(ptm_lib_handle_t *, void *, char *, int *);
 int ptm_lib_cleanup_msg(ptm_lib_handle_t *, void *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/pw.h
+++ b/lib/pw.h
@@ -48,9 +48,6 @@ union pw_protocol_fields {
 		uint32_t pwid;
 		char vpn_name[L2VPN_NAME_LEN];
 	} ldp;
-	struct {
-		/* TODO */
-	} bgp;
 };
 
 #ifdef __cplusplus

--- a/lib/pw.h
+++ b/lib/pw.h
@@ -20,6 +20,10 @@
 #ifndef _FRR_PW_H
 #define _FRR_PW_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* L2VPN name length. */
 #define L2VPN_NAME_LEN		32
 
@@ -48,5 +52,9 @@ union pw_protocol_fields {
 		/* TODO */
 	} bgp;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_PW_H */

--- a/lib/qobj.h
+++ b/lib/qobj.h
@@ -21,6 +21,10 @@
 #include <stdlib.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* reserve a specific amount of bytes for a struct, which can grow up to
  * that size (or be dummy'd out if not needed)
  *
@@ -132,5 +136,9 @@ void *qobj_get_typed(uint64_t id, struct qobj_nodetype *type);
 
 void qobj_init(void);
 void qobj_finish(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _QOBJ_H */

--- a/lib/qobj.h
+++ b/lib/qobj.h
@@ -28,11 +28,17 @@
  * this is intentional to prevent the struct from growing beyond the allocated
  * space.
  */
+#ifndef __cplusplus
 #define RESERVED_SPACE_STRUCT(name, fieldname, size)                           \
 	struct {                                                               \
 		struct name fieldname;                                         \
 		char padding##fieldname[size - sizeof(struct name)];           \
 	};
+#else
+#define RESERVED_SPACE_STRUCT(name, fieldname, size)                           \
+	struct name fieldname;                                                 \
+	char padding##fieldname[size - sizeof(struct name)];
+#endif
 
 /* don't need struct definitions for these here.  code actually using
  * these needs to define the struct *before* including this header.

--- a/lib/queue.h
+++ b/lib/queue.h
@@ -19,6 +19,10 @@
 #ifndef _FRR_QUEUE_H
 #define _FRR_QUEUE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(__OpenBSD__) && !defined(STAILQ_HEAD)
 #include "openbsd-queue.h"
 
@@ -83,6 +87,10 @@
 			(head)->tqh_last = &TAILQ_FIRST(head);                 \
 		TAILQ_FIRST(head) = TAILQ_NEXT((_elm), field);                 \
 	}; _elm; })
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* _FRR_QUEUE_H */

--- a/lib/ringbuf.h
+++ b/lib/ringbuf.h
@@ -25,6 +25,10 @@
 
 #include "memory.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ringbuf {
 	size_t size;
 	ssize_t start;
@@ -121,5 +125,9 @@ void ringbuf_reset(struct ringbuf *buf);
  * @param buf
  */
 void ringbuf_wipe(struct ringbuf *buf);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_RINGBUF_H_ */

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -26,6 +26,10 @@
 #include "qobj.h"
 #include "vty.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MTYPE(ROUTE_MAP_NAME)
 DECLARE_MTYPE(ROUTE_MAP_RULE)
 DECLARE_MTYPE(ROUTE_MAP_COMPILED)
@@ -387,5 +391,9 @@ extern void route_map_counter_increment(struct route_map *map);
 
 /* Decrement the route-map used counter */
 extern void route_map_counter_decrement(struct route_map *map);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_ROUTEMAP_H */

--- a/lib/sbuf.h
+++ b/lib/sbuf.h
@@ -23,6 +23,10 @@
 #ifndef SBUF_H
 #define SBUF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * sbuf provides a simple string buffer. One application where this comes
  * in handy is the parsing of binary data: If there is an error in the parsing
@@ -75,5 +79,9 @@ void sbuf_free(struct sbuf *buf);
 #include "lib/log.h"
 void sbuf_push(struct sbuf *buf, int indent, const char *format, ...)
 	PRINTF_ATTRIBUTE(3, 4);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/sha256.h
+++ b/lib/sha256.h
@@ -29,6 +29,10 @@
 #ifndef _SHA256_H_
 #define _SHA256_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct SHA256Context {
 	uint32_t state[8];
 	uint32_t count[2];
@@ -54,5 +58,9 @@ void HMAC__SHA256_Final(unsigned char[32], HMAC_SHA256_CTX *);
  */
 void PBKDF2_SHA256(const uint8_t *, size_t, const uint8_t *, size_t, uint64_t,
 		   uint8_t *, size_t);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_SHA256_H_ */

--- a/lib/sigevent.h
+++ b/lib/sigevent.h
@@ -25,6 +25,10 @@
 
 #include <thread.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define QUAGGA_SIGNAL_TIMER_INTERVAL 2L
 
 struct quagga_signal_t {
@@ -46,5 +50,9 @@ extern void signal_init(struct thread_master *m, int sigc,
 
 /* check whether there are signals to handle, process any found */
 extern int quagga_sigevent_process(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _QUAGGA_SIGNAL_H */

--- a/lib/skiplist.h
+++ b/lib/skiplist.h
@@ -31,6 +31,10 @@
 #ifndef _ZEBRA_SKIPLIST_H
 #define _ZEBRA_SKIPLIST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SKIPLIST_0TIMER_DEBUG 1
 
 /*
@@ -121,5 +125,9 @@ extern unsigned int skiplist_count(register struct skiplist *l); /* in */
 extern void skiplist_debug(struct vty *vty, struct skiplist *l);
 
 extern void skiplist_test(struct vty *vty);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_SKIPLIST_H */

--- a/lib/smux.h
+++ b/lib/smux.h
@@ -26,6 +26,10 @@
 
 #include "thread.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Structures here are mostly compatible with UCD SNMP 4.1.1 */
 #define MATCH_FAILED     (-1)
 #define MATCH_SUCCEEDED  0
@@ -102,5 +106,9 @@ extern int oid_compare(const oid *, int, const oid *, int);
 extern void oid2in_addr(oid[], int, struct in_addr *);
 extern void *oid_copy(void *, const void *, size_t);
 extern void oid_copy_addr(oid[], struct in_addr *, int);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_SNMP_H */

--- a/lib/sockopt.h
+++ b/lib/sockopt.h
@@ -23,6 +23,10 @@
 
 #include "sockunion.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void setsockopt_so_recvbuf(int sock, int size);
 extern void setsockopt_so_sendbuf(const int sock, int size);
 extern int getsockopt_so_sendbuf(const int sock);
@@ -98,4 +102,9 @@ extern void sockopt_iphdrincl_swab_systoh(struct ip *iph);
 extern int sockopt_tcp_rtt(int);
 extern int sockopt_tcp_signature(int sock, union sockunion *su,
 				 const char *password);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /*_ZEBRA_SOCKOPT_H */

--- a/lib/sockunion.h
+++ b/lib/sockunion.h
@@ -28,6 +28,10 @@
 #include <netmpls/mpls.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 union sockunion {
 	struct sockaddr sa;
 	struct sockaddr_in sin;
@@ -98,5 +102,9 @@ extern union sockunion *sockunion_getpeername(int);
 extern union sockunion *sockunion_dup(const union sockunion *);
 extern void sockunion_free(union sockunion *);
 extern void sockunion_init(union sockunion *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_SOCKUNION_H */

--- a/lib/spf_backoff.h
+++ b/lib/spf_backoff.h
@@ -26,6 +26,10 @@
 #ifndef _ZEBRA_SPF_BACKOFF_H
 #define _ZEBRA_SPF_BACKOFF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct spf_backoff;
 struct thread_master;
 struct vty;
@@ -57,5 +61,9 @@ long spf_backoff_short_delay(struct spf_backoff *backoff);
 long spf_backoff_long_delay(struct spf_backoff *backoff);
 long spf_backoff_holddown(struct spf_backoff *backoff);
 long spf_backoff_timetolearn(struct spf_backoff *backoff);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/srcdest_table.h
+++ b/lib/srcdest_table.h
@@ -84,7 +84,8 @@ static inline int rnode_is_srcnode(struct route_node *rn)
 static inline struct route_table *srcdest_rnode_table(struct route_node *rn)
 {
 	if (rnode_is_srcnode(rn)) {
-		struct route_node *dst_rn = route_table_get_info(rn->table);
+		struct route_node *dst_rn =
+			(struct route_node *)route_table_get_info(rn->table);
 		return dst_rn->table;
 	} else {
 		return rn->table;

--- a/lib/srcdest_table.h
+++ b/lib/srcdest_table.h
@@ -46,6 +46,10 @@
 #include "prefix.h"
 #include "table.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SRCDEST2STR_BUFFER (2*PREFIX2STR_BUFFER + sizeof(" from "))
 
 /* extended route node for IPv6 srcdest routing */
@@ -95,5 +99,9 @@ static inline void *srcdest_rnode_table_info(struct route_node *rn)
 {
 	return route_table_get_info(srcdest_rnode_table(rn));
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_SRC_DEST_TABLE_H */

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -28,6 +28,10 @@
 #include "mpls.h"
 #include "prefix.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * A stream is an arbitrary buffer, whose contents generally are assumed to
  * be in network order.
@@ -403,5 +407,9 @@ static inline uint8_t *ptr_get_be32(uint8_t *ptr, uint32_t *out)
 		if (!stream_get2((P), (STR), (SIZE)))                          \
 			goto stream_failure;                                   \
 	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_STREAM_H */

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -115,9 +115,9 @@ struct stream_fifo {
 	pthread_mutex_t mtx;
 
 	/* number of streams in this fifo */
-	_Atomic size_t count;
+	atomic_size_t count;
 #if defined DEV_BUILD
-	_Atomic size_t max_count;
+	atomic_size_t max_count;
 #endif
 
 	struct stream *head;

--- a/lib/systemd.h
+++ b/lib/systemd.h
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Wrapper functions to systemd calls.
  *
@@ -37,3 +41,7 @@ void systemd_send_stopping(void);
  *                process?
  */
 void systemd_send_started(struct thread_master *master, int the_process);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/table.h
+++ b/lib/table.h
@@ -25,6 +25,11 @@
 #include "memory.h"
 #include "hash.h"
 #include "prefix.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MTYPE(ROUTE_TABLE)
 DECLARE_MTYPE(ROUTE_NODE)
 
@@ -317,5 +322,9 @@ static inline int route_table_iter_started(route_table_iter_t *iter)
 {
 	return iter->state != RT_ITER_STATE_INIT;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_TABLE_H */

--- a/lib/table.h
+++ b/lib/table.h
@@ -275,15 +275,12 @@ static inline struct route_node *route_table_iter_next(route_table_iter_t *iter)
 		break;
 
 	case RT_ITER_STATE_PAUSED:
-	{
-		union prefixconstptr cp = {.p = &iter->pause_prefix};
 
 		/*
 		 * Start with the node following pause_prefix.
 		 */
-		node = route_table_get_next(iter->table, cp);
-	}
-	break;
+		node = route_table_get_next(iter->table, &iter->pause_prefix);
+		break;
 
 	case RT_ITER_STATE_DONE:
 		return NULL;

--- a/lib/table.h
+++ b/lib/table.h
@@ -275,12 +275,15 @@ static inline struct route_node *route_table_iter_next(route_table_iter_t *iter)
 		break;
 
 	case RT_ITER_STATE_PAUSED:
+	{
+		union prefixconstptr cp = {.p = &iter->pause_prefix};
 
 		/*
 		 * Start with the node following pause_prefix.
 		 */
-		node = route_table_get_next(iter->table, &iter->pause_prefix);
-		break;
+		node = route_table_get_next(iter->table, cp);
+	}
+	break;
 
 	case RT_ITER_STATE_DONE:
 		return NULL;

--- a/lib/termtable.h
+++ b/lib/termtable.h
@@ -22,6 +22,10 @@
 
 #include <zebra.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum ttable_align {
 	LEFT,
 	RIGHT,
@@ -293,5 +297,9 @@ void ttable_rowseps(struct ttable *tt, unsigned int row,
  * @return table in text form
  */
 char *ttable_dump(struct ttable *tt, const char *newline);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _TERMTABLE_H */

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -93,7 +93,8 @@ static void cpu_record_hash_free(void *a)
 static void vty_out_cpu_thread_history(struct vty *vty,
 				       struct cpu_thread_history *a)
 {
-	vty_out(vty, "%5d %10lu.%03lu %9u %8lu %9lu %8lu %9lu", a->total_active,
+	vty_out(vty, "%5"PRIdFAST32" %10lu.%03lu %9"PRIuFAST32
+		" %8lu %9lu %8lu %9lu", a->total_active,
 		a->cpu.total / 1000, a->cpu.total % 1000, a->total_calls,
 		a->cpu.total / a->total_calls, a->cpu.max,
 		a->real.total / a->total_calls, a->real.max);

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -119,13 +119,13 @@ struct thread {
 
 struct cpu_thread_history {
 	int (*func)(struct thread *);
-	_Atomic unsigned int total_calls;
-	_Atomic unsigned int total_active;
+	atomic_uint_fast32_t total_calls;
+	atomic_uint_fast32_t total_active;
 	struct time_stats {
-		_Atomic unsigned long total, max;
+		atomic_size_t total, max;
 	} real;
 	struct time_stats cpu;
-	_Atomic uint32_t types;
+	atomic_uint_fast32_t types;
 	const char *funcname;
 };
 

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -27,6 +27,10 @@
 #include "monotime.h"
 #include "frratomic.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct rusage_t {
 	struct rusage cpu;
 	struct timeval real;
@@ -232,5 +236,9 @@ extern unsigned long thread_consumed_time(RUSAGE_T *after, RUSAGE_T *before,
 
 /* only for use in logging functions! */
 extern pthread_key_t thread_current;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_THREAD_H */

--- a/lib/vector.h
+++ b/lib/vector.h
@@ -24,6 +24,10 @@
 
 #include "memory.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* struct for vector */
 struct _vector {
 	unsigned int active;  /* number of active slots */
@@ -63,4 +67,9 @@ extern void *vector_lookup(vector, unsigned int);
 extern void *vector_lookup_ensure(vector, unsigned int);
 extern void vector_to_array(vector v, void ***dest, int *argc);
 extern vector array_to_vector(void **src, int argc);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _ZEBRA_VECTOR_H */

--- a/lib/vlan.h
+++ b/lib/vlan.h
@@ -22,8 +22,16 @@
 #ifndef __VLAN_H__
 #define __VLAN_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* VLAN Identifier */
 typedef uint16_t vlanid_t;
 #define VLANID_MAX 4095
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __VLAN_H__ */

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -471,7 +471,7 @@ static const struct cmd_variable_handler vrf_var_handlers[] = {
 
 /* Initialize VRF module. */
 void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
-	      int (*disable)(struct vrf *), int (*delete)(struct vrf *),
+	      int (*disable)(struct vrf *), int (*destroy)(struct vrf *),
 	      int ((*update)(struct vrf *)))
 {
 	struct vrf *default_vrf;
@@ -485,7 +485,7 @@ void vrf_init(int (*create)(struct vrf *), int (*enable)(struct vrf *),
 	vrf_master.vrf_new_hook = create;
 	vrf_master.vrf_enable_hook = enable;
 	vrf_master.vrf_disable_hook = disable;
-	vrf_master.vrf_delete_hook = delete;
+	vrf_master.vrf_delete_hook = destroy;
 	vrf_master.vrf_update_name_hook = update;
 
 	/* The default VRF always exists. */

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -200,7 +200,7 @@ extern int vrf_bitmap_check(vrf_bitmap_t, vrf_id_t);
  *           the system ( 2 and 3 ) above.
  */
 extern void vrf_init(int (*create)(struct vrf *vrf), int (*enable)(struct vrf *vrf),
-		     int (*disable)(struct vrf *vrf), int (*delete)(struct vrf *vrf),
+		     int (*disable)(struct vrf *vrf), int (*destroy)(struct vrf *vrf),
 		     int (*update)(struct vrf *vrf));
 
 /*

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -28,6 +28,10 @@
 #include "vty.h"
 #include "ns.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The default VRF ID */
 #define VRF_UNKNOWN UINT32_MAX
 
@@ -291,5 +295,9 @@ extern void vrf_disable(struct vrf *vrf);
 extern int vrf_enable(struct vrf *vrf);
 extern void vrf_delete(struct vrf *vrf);
 extern vrf_id_t vrf_generate_id(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*_ZEBRA_VRF_H*/

--- a/lib/vrf_int.h
+++ b/lib/vrf_int.h
@@ -25,6 +25,10 @@
 
 #include "vrf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * These functions should only be called by:
  * zebra/if_netlink.c -> The interface from OS into Zebra
@@ -51,5 +55,9 @@ extern int vrf_enable(struct vrf *);
  * from interested parties
  */
 extern void vrf_delete(struct vrf *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -31,6 +31,10 @@
 #include "compiler.h"
 #include "northbound.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define VTY_BUFSIZ 4096
 #define VTY_MAXHIST 20
 #define VTY_MAXDEPTH 8
@@ -332,5 +336,9 @@ extern void vty_stdio_close(void);
 /* Send a fixed-size message to all vty terminal monitors; this should be
    an async-signal-safe function. */
 extern void vty_log_fixed(char *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_VTY_H */

--- a/lib/vxlan.h
+++ b/lib/vxlan.h
@@ -22,6 +22,10 @@
 #ifndef __VXLAN_H__
 #define __VXLAN_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* VxLAN Network Identifier - 24-bit (RFC 7348) */
 typedef uint32_t vni_t;
 #define VNI_MAX 16777215 /* (2^24 - 1) */
@@ -35,4 +39,9 @@ enum vxlan_flood_control {
 	VXLAN_FLOOD_HEAD_END_REPL = 0,
 	VXLAN_FLOOD_DISABLED,
 };
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __VXLAN_H__ */

--- a/lib/wheel.h
+++ b/lib/wheel.h
@@ -20,6 +20,10 @@
 #ifndef __WHEEL_H__
 #define __WHEEL_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct timer_wheel {
 	char *name;
 	struct thread_master *master;
@@ -114,5 +118,9 @@ int wheel_add_item(struct timer_wheel *wheel, void *item);
  * possibly change next time pop.
  */
 int wheel_remove_item(struct timer_wheel *wheel, void *item);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/workqueue.h
+++ b/lib/workqueue.h
@@ -25,6 +25,11 @@
 
 #include "memory.h"
 #include "queue.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MTYPE(WORK_QUEUE)
 
 /* Hold time for the initial schedule of a queue run, in  millisec */
@@ -175,5 +180,9 @@ bool work_queue_is_scheduled(struct work_queue *);
 extern int work_queue_run(struct thread *);
 
 extern void workqueue_cmd_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _QUAGGA_WORK_QUEUE_H */

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -29,6 +29,10 @@
 
 #include "yang_wrappers.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MTYPE(YANG_MODULE)
 DECLARE_MTYPE(YANG_DATA)
 
@@ -520,5 +524,9 @@ extern void yang_init(void);
  * is exiting.
  */
 extern void yang_terminate(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_YANG_H_ */

--- a/lib/yang_translator.h
+++ b/lib/yang_translator.h
@@ -20,6 +20,10 @@
 #ifndef _FRR_YANG_TRANSLATOR_H_
 #define _FRR_YANG_TRANSLATOR_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define YANG_TRANSLATE_TO_NATIVE 0
 #define YANG_TRANSLATE_FROM_NATIVE 1
 #define YANG_TRANSLATE_MAX 2
@@ -140,5 +144,9 @@ extern void yang_translator_init(void);
  * when the daemon is exiting.
  */
 extern void yang_translator_terminate(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _FRR_YANG_TRANSLATOR_H_ */

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -232,6 +232,15 @@ typedef unsigned char uint8_t;
 
 #include "zassert.h"
 
+/*
+ * Add explicit static cast only when using a C++ compiler.
+ */
+#ifdef __cplusplus
+#define static_cast(l, r) static_cast<decltype(l)>((r))
+#else
+#define static_cast(l, r) (r)
+#endif
+
 #ifndef HAVE_STRLCAT
 size_t strlcat(char *__restrict dest,
 	       const char *__restrict src, size_t destsize);

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -62,7 +62,7 @@ DEFPY (no_router_rip,
        "Enable a routing process\n"
        "Routing Information Protocol (RIP)\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-ripd:ripd/instance", NB_OP_DELETE,
+	nb_cli_enqueue_change(vty, "/frr-ripd:ripd/instance", NB_OP_DESTROY,
 			      NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -213,9 +213,9 @@ DEFPY (rip_distance_source,
 		nb_cli_enqueue_change(vty, "./distance", NB_OP_MODIFY,
 				      distance_str);
 		nb_cli_enqueue_change(vty, "./access-list",
-				      acl ? NB_OP_MODIFY : NB_OP_DELETE, acl);
+				      acl ? NB_OP_MODIFY : NB_OP_DESTROY, acl);
 	} else
-		nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, "./distance/source[prefix='%s']",
 				    prefix_str);
@@ -244,7 +244,7 @@ DEFPY (rip_neighbor,
        "Neighbor address\n")
 {
 	nb_cli_enqueue_change(vty, "./explicit-neighbor",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, neighbor_str);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, neighbor_str);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -266,7 +266,7 @@ DEFPY (rip_network_prefix,
        "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n")
 {
 	nb_cli_enqueue_change(vty, "./network",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, network_str);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, network_str);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -288,7 +288,7 @@ DEFPY (rip_network_if,
        "Interface name\n")
 {
 	nb_cli_enqueue_change(vty, "./interface",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, network);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, network);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -319,7 +319,7 @@ DEFPY (rip_offset_list,
 		nb_cli_enqueue_change(vty, "./metric", NB_OP_MODIFY,
 				      metric_str);
 	} else
-		nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(
 		vty, "./offset-list[interface='%s'][direction='%s']",
@@ -379,9 +379,9 @@ DEFPY (rip_passive_interface,
        "Interface name\n")
 {
 	nb_cli_enqueue_change(vty, "./passive-interface",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, ifname);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, ifname);
 	nb_cli_enqueue_change(vty, "./non-passive-interface",
-			      no ? NB_OP_CREATE : NB_OP_DELETE, ifname);
+			      no ? NB_OP_CREATE : NB_OP_DESTROY, ifname);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -417,13 +417,13 @@ DEFPY (rip_redistribute,
 	if (!no) {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./route-map",
-				      route_map ? NB_OP_MODIFY : NB_OP_DELETE,
+				      route_map ? NB_OP_MODIFY : NB_OP_DESTROY,
 				      route_map);
 		nb_cli_enqueue_change(vty, "./metric",
-				      metric_str ? NB_OP_MODIFY : NB_OP_DELETE,
+				      metric_str ? NB_OP_MODIFY : NB_OP_DESTROY,
 				      metric_str);
 	} else
-		nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, "./redistribute[protocol='%s']",
 				    protocol);
@@ -454,7 +454,7 @@ DEFPY (rip_route,
        "IP prefix <network>/<length>\n")
 {
 	nb_cli_enqueue_change(vty, "./static-route",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, route_str);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, route_str);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -942,7 +942,7 @@ DEFPY (no_ip_rip_authentication_key_chain,
        "Authentication key-chain\n"
        "name of key-chain\n")
 {
-	nb_cli_enqueue_change(vty, "./authentication-key-chain", NB_OP_DELETE,
+	nb_cli_enqueue_change(vty, "./authentication-key-chain", NB_OP_DESTROY,
 			      NULL);
 
 	return nb_cli_apply_changes(vty, "./frr-ripd:rip");

--- a/ripd/rip_northbound.c
+++ b/ripd/rip_northbound.c
@@ -1305,7 +1305,7 @@ const struct frr_yang_module_info frr_ripd_info = {
 		{
 			.xpath = "/frr-ripd:ripd/instance",
 			.cbs.create = ripd_instance_create,
-			.cbs.delete = ripd_instance_delete,
+			.cbs.destroy = ripd_instance_delete,
 			.cbs.cli_show = cli_show_router_rip,
 		},
 		{
@@ -1331,7 +1331,7 @@ const struct frr_yang_module_info frr_ripd_info = {
 		{
 			.xpath = "/frr-ripd:ripd/instance/distance/source",
 			.cbs.create = ripd_instance_distance_source_create,
-			.cbs.delete = ripd_instance_distance_source_delete,
+			.cbs.destroy = ripd_instance_distance_source_delete,
 			.cbs.cli_show = cli_show_rip_distance_source,
 		},
 		{
@@ -1341,30 +1341,30 @@ const struct frr_yang_module_info frr_ripd_info = {
 		{
 			.xpath = "/frr-ripd:ripd/instance/distance/source/access-list",
 			.cbs.modify = ripd_instance_distance_source_access_list_modify,
-			.cbs.delete = ripd_instance_distance_source_access_list_delete,
+			.cbs.destroy = ripd_instance_distance_source_access_list_delete,
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/explicit-neighbor",
 			.cbs.create = ripd_instance_explicit_neighbor_create,
-			.cbs.delete = ripd_instance_explicit_neighbor_delete,
+			.cbs.destroy = ripd_instance_explicit_neighbor_delete,
 			.cbs.cli_show = cli_show_rip_neighbor,
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/network",
 			.cbs.create = ripd_instance_network_create,
-			.cbs.delete = ripd_instance_network_delete,
+			.cbs.destroy = ripd_instance_network_delete,
 			.cbs.cli_show = cli_show_rip_network_prefix,
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/interface",
 			.cbs.create = ripd_instance_interface_create,
-			.cbs.delete = ripd_instance_interface_delete,
+			.cbs.destroy = ripd_instance_interface_delete,
 			.cbs.cli_show = cli_show_rip_network_interface,
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/offset-list",
 			.cbs.create = ripd_instance_offset_list_create,
-			.cbs.delete = ripd_instance_offset_list_delete,
+			.cbs.destroy = ripd_instance_offset_list_delete,
 			.cbs.cli_show = cli_show_rip_offset_list,
 		},
 		{
@@ -1383,36 +1383,36 @@ const struct frr_yang_module_info frr_ripd_info = {
 		{
 			.xpath = "/frr-ripd:ripd/instance/passive-interface",
 			.cbs.create = ripd_instance_passive_interface_create,
-			.cbs.delete = ripd_instance_passive_interface_delete,
+			.cbs.destroy = ripd_instance_passive_interface_delete,
 			.cbs.cli_show = cli_show_rip_passive_interface,
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/non-passive-interface",
 			.cbs.create = ripd_instance_non_passive_interface_create,
-			.cbs.delete = ripd_instance_non_passive_interface_delete,
+			.cbs.destroy = ripd_instance_non_passive_interface_delete,
 			.cbs.cli_show = cli_show_rip_non_passive_interface,
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/redistribute",
 			.cbs.create = ripd_instance_redistribute_create,
-			.cbs.delete = ripd_instance_redistribute_delete,
+			.cbs.destroy = ripd_instance_redistribute_delete,
 			.cbs.apply_finish = ripd_instance_redistribute_apply_finish,
 			.cbs.cli_show = cli_show_rip_redistribute,
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/redistribute/route-map",
 			.cbs.modify = ripd_instance_redistribute_route_map_modify,
-			.cbs.delete = ripd_instance_redistribute_route_map_delete,
+			.cbs.destroy = ripd_instance_redistribute_route_map_delete,
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/redistribute/metric",
 			.cbs.modify = ripd_instance_redistribute_metric_modify,
-			.cbs.delete = ripd_instance_redistribute_metric_delete,
+			.cbs.destroy = ripd_instance_redistribute_metric_delete,
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/static-route",
 			.cbs.create = ripd_instance_static_route_create,
-			.cbs.delete = ripd_instance_static_route_delete,
+			.cbs.destroy = ripd_instance_static_route_delete,
 			.cbs.cli_show = cli_show_rip_route,
 		},
 		{
@@ -1475,18 +1475,18 @@ const struct frr_yang_module_info frr_ripd_info = {
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/authentication-scheme/md5-auth-length",
 			.cbs.modify = lib_interface_rip_authentication_scheme_md5_auth_length_modify,
-			.cbs.delete = lib_interface_rip_authentication_scheme_md5_auth_length_delete,
+			.cbs.destroy = lib_interface_rip_authentication_scheme_md5_auth_length_delete,
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/authentication-password",
 			.cbs.modify = lib_interface_rip_authentication_password_modify,
-			.cbs.delete = lib_interface_rip_authentication_password_delete,
+			.cbs.destroy = lib_interface_rip_authentication_password_delete,
 			.cbs.cli_show = cli_show_ip_rip_authentication_string,
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/authentication-key-chain",
 			.cbs.modify = lib_interface_rip_authentication_key_chain_modify,
-			.cbs.delete = lib_interface_rip_authentication_key_chain_delete,
+			.cbs.destroy = lib_interface_rip_authentication_key_chain_delete,
 			.cbs.cli_show = cli_show_ip_rip_authentication_key_chain,
 		},
 		{

--- a/ripngd/ripng_cli.c
+++ b/ripngd/ripng_cli.c
@@ -62,7 +62,7 @@ DEFPY (no_router_ripng,
        "Enable a routing process\n"
        "Make RIPng instance command\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-ripngd:ripngd/instance", NB_OP_DELETE,
+	nb_cli_enqueue_change(vty, "/frr-ripngd:ripngd/instance", NB_OP_DESTROY,
 			      NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -170,7 +170,7 @@ DEFPY (ripng_network_prefix,
        "IPv6 network\n")
 {
 	nb_cli_enqueue_change(vty, "./network",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, network_str);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, network_str);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -192,7 +192,7 @@ DEFPY (ripng_network_if,
        "Interface name\n")
 {
 	nb_cli_enqueue_change(vty, "./interface",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, network);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, network);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -223,7 +223,7 @@ DEFPY (ripng_offset_list,
 		nb_cli_enqueue_change(vty, "./metric", NB_OP_MODIFY,
 				      metric_str);
 	} else
-		nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(
 		vty, "./offset-list[interface='%s'][direction='%s']",
@@ -257,7 +257,7 @@ DEFPY (ripng_passive_interface,
        "Interface name\n")
 {
 	nb_cli_enqueue_change(vty, "./passive-interface",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, ifname);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, ifname);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -286,13 +286,13 @@ DEFPY (ripng_redistribute,
 	if (!no) {
 		nb_cli_enqueue_change(vty, ".", NB_OP_CREATE, NULL);
 		nb_cli_enqueue_change(vty, "./route-map",
-				      route_map ? NB_OP_MODIFY : NB_OP_DELETE,
+				      route_map ? NB_OP_MODIFY : NB_OP_DESTROY,
 				      route_map);
 		nb_cli_enqueue_change(vty, "./metric",
-				      metric_str ? NB_OP_MODIFY : NB_OP_DELETE,
+				      metric_str ? NB_OP_MODIFY : NB_OP_DESTROY,
 				      metric_str);
 	} else
-		nb_cli_enqueue_change(vty, ".", NB_OP_DELETE, NULL);
+		nb_cli_enqueue_change(vty, ".", NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, "./redistribute[protocol='%s']",
 				    protocol);
@@ -323,7 +323,7 @@ DEFPY (ripng_route,
        "Set static RIPng route announcement\n")
 {
 	nb_cli_enqueue_change(vty, "./static-route",
-			      no ? NB_OP_DELETE : NB_OP_CREATE, route_str);
+			      no ? NB_OP_DESTROY : NB_OP_CREATE, route_str);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -345,7 +345,7 @@ DEFPY (ripng_aggregate_address,
        "Aggregate network\n")
 {
 	nb_cli_enqueue_change(vty, "./aggregate-address",
-			      no ? NB_OP_DELETE : NB_OP_CREATE,
+			      no ? NB_OP_DESTROY : NB_OP_CREATE,
 			      aggregate_address_str);
 
 	return nb_cli_apply_changes(vty, NULL);

--- a/ripngd/ripng_northbound.c
+++ b/ripngd/ripng_northbound.c
@@ -845,7 +845,7 @@ const struct frr_yang_module_info frr_ripngd_info = {
 		{
 			.xpath = "/frr-ripngd:ripngd/instance",
 			.cbs.create = ripngd_instance_create,
-			.cbs.delete = ripngd_instance_delete,
+			.cbs.destroy = ripngd_instance_delete,
 			.cbs.cli_show = cli_show_router_ripng,
 		},
 		{
@@ -866,19 +866,19 @@ const struct frr_yang_module_info frr_ripngd_info = {
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/network",
 			.cbs.create = ripngd_instance_network_create,
-			.cbs.delete = ripngd_instance_network_delete,
+			.cbs.destroy = ripngd_instance_network_delete,
 			.cbs.cli_show = cli_show_ripng_network_prefix,
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/interface",
 			.cbs.create = ripngd_instance_interface_create,
-			.cbs.delete = ripngd_instance_interface_delete,
+			.cbs.destroy = ripngd_instance_interface_delete,
 			.cbs.cli_show = cli_show_ripng_network_interface,
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/offset-list",
 			.cbs.create = ripngd_instance_offset_list_create,
-			.cbs.delete = ripngd_instance_offset_list_delete,
+			.cbs.destroy = ripngd_instance_offset_list_delete,
 			.cbs.cli_show = cli_show_ripng_offset_list,
 		},
 		{
@@ -892,36 +892,36 @@ const struct frr_yang_module_info frr_ripngd_info = {
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/passive-interface",
 			.cbs.create = ripngd_instance_passive_interface_create,
-			.cbs.delete = ripngd_instance_passive_interface_delete,
+			.cbs.destroy = ripngd_instance_passive_interface_delete,
 			.cbs.cli_show = cli_show_ripng_passive_interface,
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/redistribute",
 			.cbs.create = ripngd_instance_redistribute_create,
-			.cbs.delete = ripngd_instance_redistribute_delete,
+			.cbs.destroy = ripngd_instance_redistribute_delete,
 			.cbs.apply_finish = ripngd_instance_redistribute_apply_finish,
 			.cbs.cli_show = cli_show_ripng_redistribute,
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/redistribute/route-map",
 			.cbs.modify = ripngd_instance_redistribute_route_map_modify,
-			.cbs.delete = ripngd_instance_redistribute_route_map_delete,
+			.cbs.destroy = ripngd_instance_redistribute_route_map_delete,
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/redistribute/metric",
 			.cbs.modify = ripngd_instance_redistribute_metric_modify,
-			.cbs.delete = ripngd_instance_redistribute_metric_delete,
+			.cbs.destroy = ripngd_instance_redistribute_metric_delete,
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/static-route",
 			.cbs.create = ripngd_instance_static_route_create,
-			.cbs.delete = ripngd_instance_static_route_delete,
+			.cbs.destroy = ripngd_instance_static_route_delete,
 			.cbs.cli_show = cli_show_ripng_route,
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/aggregate-address",
 			.cbs.create = ripngd_instance_aggregate_address_create,
-			.cbs.delete = ripngd_instance_aggregate_address_delete,
+			.cbs.destroy = ripngd_instance_aggregate_address_delete,
 			.cbs.cli_show = cli_show_ripng_aggregate_address,
 		},
 		{

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -19,6 +19,7 @@
 /lib/cli/test_commands
 /lib/cli/test_commands_defun.c
 /lib/northbound/test_oper_data
+/lib/cxxcompat
 /lib/test_buffer
 /lib/test_checksum
 /lib/test_graph

--- a/tests/lib/cxxcompat.c
+++ b/tests/lib/cxxcompat.c
@@ -1,0 +1,113 @@
+/*
+ * C++ compatibility compile-time smoketest
+ * Copyright (C) 2019  David Lamparter for NetDEF, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "lib/zebra.h"
+
+#include "lib/agg_table.h"
+#include "lib/bfd.h"
+#include "lib/bitfield.h"
+#include "lib/buffer.h"
+#include "lib/checksum.h"
+#include "lib/command.h"
+#include "lib/command_graph.h"
+#include "lib/command_match.h"
+#include "lib/compiler.h"
+#include "lib/csv.h"
+#include "lib/debug.h"
+#include "lib/distribute.h"
+#include "lib/event_counter.h"
+#include "lib/ferr.h"
+#include "lib/fifo.h"
+#include "lib/filter.h"
+#include "lib/frr_pthread.h"
+#include "lib/frratomic.h"
+#include "lib/frrstr.h"
+#include "lib/getopt.h"
+#include "lib/graph.h"
+#include "lib/hash.h"
+#include "lib/hook.h"
+#include "lib/id_alloc.h"
+#include "lib/if.h"
+#include "lib/if_rmap.h"
+#include "lib/imsg.h"
+#include "lib/ipaddr.h"
+#include "lib/jhash.h"
+#include "lib/json.h"
+#include "lib/keychain.h"
+#include "lib/lib_errors.h"
+#include "lib/libfrr.h"
+#include "lib/libospf.h"
+#include "lib/linklist.h"
+#include "lib/log.h"
+#include "lib/logicalrouter.h"
+#include "lib/md5.h"
+#include "lib/memory.h"
+#include "lib/memory_vty.h"
+#include "lib/mlag.h"
+#include "lib/module.h"
+#include "lib/monotime.h"
+#include "lib/mpls.h"
+#include "lib/network.h"
+#include "lib/nexthop.h"
+#include "lib/nexthop_group.h"
+#include "lib/northbound.h"
+#include "lib/northbound_cli.h"
+#include "lib/northbound_db.h"
+#include "lib/ns.h"
+#include "lib/openbsd-tree.h"
+#include "lib/pbr.h"
+#include "lib/plist.h"
+#include "lib/pqueue.h"
+#include "lib/prefix.h"
+#include "lib/privs.h"
+#include "lib/ptm_lib.h"
+#include "lib/pw.h"
+#include "lib/qobj.h"
+#include "lib/queue.h"
+#include "lib/ringbuf.h"
+#include "lib/routemap.h"
+#include "lib/sbuf.h"
+#include "lib/sha256.h"
+#include "lib/sigevent.h"
+#include "lib/skiplist.h"
+#include "lib/sockopt.h"
+#include "lib/sockunion.h"
+#include "lib/spf_backoff.h"
+#include "lib/srcdest_table.h"
+#include "lib/stream.h"
+#include "lib/table.h"
+#include "lib/termtable.h"
+#include "lib/thread.h"
+#include "lib/vector.h"
+#include "lib/vlan.h"
+#include "lib/vrf.h"
+#include "lib/vty.h"
+#include "lib/vxlan.h"
+#include "lib/wheel.h"
+/* #include "lib/workqueue.h"		-- macro problem with STAILQ_LAST */
+#include "lib/yang.h"
+#include "lib/yang_translator.h"
+#include "lib/yang_wrappers.h"
+#include "lib/zassert.h"
+#include "lib/zclient.h"
+
+int main(int argc, char **argv)
+{
+	return 0;
+}

--- a/tests/subdir.am
+++ b/tests/subdir.am
@@ -46,6 +46,7 @@ tests/ospf6d/tests_ospf6d_test_lsdb-test_lsdb.$(OBJEXT): tests/ospf6d/test_lsdb_
 tests/ospf6d/test_lsdb-test_lsdb.$(OBJEXT): tests/ospf6d/test_lsdb_clippy.c
 
 check_PROGRAMS = \
+	tests/lib/cxxcompat \
 	tests/lib/test_buffer \
 	tests/lib/test_checksum \
 	tests/lib/test_heavy_thread \
@@ -170,6 +171,10 @@ tests_isisd_test_isis_vertex_queue_CPPFLAGS = $(TESTS_CPPFLAGS)
 tests_isisd_test_isis_vertex_queue_LDADD = $(ISISD_TEST_LDADD)
 tests_isisd_test_isis_vertex_queue_SOURCES = tests/isisd/test_isis_vertex_queue.c
 
+tests_lib_cxxcompat_CFLAGS = $(TESTS_CFLAGS) $(CXX_COMPAT_CFLAGS) $(WERROR)
+tests_lib_cxxcompat_CPPFLAGS = $(TESTS_CPPFLAGS)
+tests_lib_cxxcompat_SOURCES = tests/lib/cxxcompat.c
+tests_lib_cxxcompat_LDADD = $(ALL_TESTS_LDADD)
 tests_lib_cli_test_cli_CFLAGS = $(TESTS_CFLAGS)
 tests_lib_cli_test_cli_CPPFLAGS = $(TESTS_CPPFLAGS)
 tests_lib_cli_test_cli_LDADD = $(ALL_TESTS_LDADD)

--- a/tools/gen_northbound_callbacks.c
+++ b/tools/gen_northbound_callbacks.c
@@ -54,7 +54,7 @@ static struct nb_callback_info {
 			"enum nb_event event, const struct lyd_node *dnode, union nb_resource *resource",
 	},
 	{
-		.operation = NB_OP_DELETE,
+		.operation = NB_OP_DESTROY,
 		.return_type = "int ",
 		.return_value = "NB_OK",
 		.arguments =


### PR DESCRIPTION
Some misc changes to resolve some c++ compilation errors. The goal is only to permit an external module - a plugin, for example - to see frr headers, not to support or encourage contributions in c++. With these changes, and the '-fpermissive' flag, at least gcc can build an .so from a .cpp that includes some frr headers.

### Components
libs, ripd, ripngd, isisd