### PR TITLE
Vrf route leak support for netns based vrfs

### DIFF
--- a/bgpd/bgp_labelpool.h
+++ b/bgpd/bgp_labelpool.h
@@ -28,8 +28,9 @@
 /*
  * Types used in bgp_lp_get for debug tracking; add more as needed
  */
-#define LP_TYPE_VRF	0x00000001
-#define LP_TYPE_BGP_LU	0x00000002
+#define LP_TYPE_VRF		0x00000001
+#define LP_TYPE_BGP_LU		0x00000002
+#define LP_TYPE_VRF_VETH	0x00000003
 
 struct labelpool {
 	struct skiplist		*ledger;	/* all requests */

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -78,6 +78,9 @@ extern void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,
 extern void vpn_leak_zebra_vrf_label_update(struct bgp *bgp, afi_t afi);
 extern void vpn_leak_zebra_vrf_label_withdraw(struct bgp *bgp, afi_t afi);
 extern int vpn_leak_label_callback(mpls_label_t label, void *lblid, bool alloc);
+extern int bgp_vpn_leak_mpls_callback(mpls_label_t label,
+				      void *labelid,
+				      bool allocated);
 extern void vrf_import_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp,
 				afi_t afi, safi_t safi);
 void vrf_unimport_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp,

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -79,20 +79,22 @@ static void bgp_nexthop_cache_reset(struct bgp_table *table)
 {
 	struct bgp_node *rn;
 	struct bgp_nexthop_cache *bnc;
+	struct listnode *node, *next;
 
 	for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
-		bnc = bgp_node_get_bgp_nexthop_info(rn);
-		if (!bnc)
+		if (!rn->info)
 			continue;
+		for (ALL_LIST_ELEMENTS((struct list *)rn->info, node, next,
+				       bnc)) {
+			while (!LIST_EMPTY(&(bnc->paths))) {
+				struct bgp_info *path =
+					LIST_FIRST(&(bnc->paths));
 
-		while (!LIST_EMPTY(&(bnc->paths))) {
-			struct bgp_path_info *path = LIST_FIRST(&(bnc->paths));
-
-			path_nh_map(path, bnc, false);
+				path_nh_map(path, bnc, false);
+			}
+			bnc_free(bnc);
 		}
-
-		bnc_free(bnc);
-		bgp_node_set_bgp_nexthop_info(rn, NULL);
+		list_delete((struct list **)&rn->info);
 		bgp_unlock_node(rn);
 	}
 }
@@ -609,34 +611,39 @@ static void bgp_show_nexthops(struct vty *vty, struct bgp *bgp, int detail,
 			continue;
 		for (rn = bgp_table_top(table[afi]); rn;
 		     rn = bgp_route_next(rn)) {
-			bnc = bgp_node_get_bgp_nexthop_info(rn);
-			if (!bnc)
+			struct listnode *node, *next;
+
+			if (!rn->info)
 				continue;
+			for (ALL_LIST_ELEMENTS((struct list *)rn->info,
+					       node, next, bnc)) {
+				if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_VALID)) {
+					vty_out(vty,
+						" %s valid [IGP metric %d], #paths %d\n",
+						inet_ntop(rn->p.family,
+							  &rn->p.u.prefix, buf,
+							  sizeof(buf)),
+						bnc->metric, bnc->path_count);
 
-			if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_VALID)) {
-				vty_out(vty,
-					" %s valid [IGP metric %d], #paths %d\n",
-					inet_ntop(rn->p.family,
-						  &rn->p.u.prefix, buf,
-						  sizeof(buf)),
-					bnc->metric, bnc->path_count);
+					if (!detail)
+						continue;
 
-				if (!detail)
-					continue;
+					bgp_show_nexthops_detail(vty, bgp, bnc);
 
-				bgp_show_nexthops_detail(vty, bgp, bnc);
-
-			} else {
-				vty_out(vty, " %s invalid\n",
-					inet_ntop(rn->p.family,
-						  &rn->p.u.prefix, buf,
-						  sizeof(buf)));
-				if (CHECK_FLAG(bnc->flags,
-					       BGP_NEXTHOP_CONNECTED))
-					vty_out(vty, "  Must be Connected\n");
-				if (!CHECK_FLAG(bnc->flags,
-						BGP_NEXTHOP_REGISTERED))
-					vty_out(vty, "  Is not Registered\n");
+				} else {
+					vty_out(vty, " %s invalid\n",
+						inet_ntop(rn->p.family,
+							  &rn->p.u.prefix, buf,
+							  sizeof(buf)));
+					if (CHECK_FLAG(bnc->flags,
+						       BGP_NEXTHOP_CONNECTED))
+						vty_out(vty,
+							"  Must be Connected\n");
+				}
+				tbuf = time(NULL)
+				       - (bgp_clock() - bnc->last_update);
+				vty_out(vty, "  Last update: %s", ctime(&tbuf));
+				vty_out(vty, "\n");
 			}
 			tbuf = time(NULL) - (bgp_clock() - bnc->last_update);
 			vty_out(vty, "  Last update: %s", ctime(&tbuf));

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -54,6 +54,7 @@ struct bgp_nexthop_cache {
 #define BGP_STATIC_ROUTE              (1 << 4)
 #define BGP_STATIC_ROUTE_EXACT_MATCH  (1 << 5)
 #define BGP_NEXTHOP_LABELED_VALID     (1 << 6)
+#define BGP_NEXTHOP_RECURSION_IFACE   (1 << 7)
 
 	uint16_t change_flags;
 

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -66,6 +66,7 @@ struct bgp_nexthop_cache {
 	LIST_HEAD(path_list, bgp_path_info) paths;
 	unsigned int path_count;
 	struct bgp *bgp;
+	struct bgp *bgp_route; /* originator of the request */
 };
 
 /* Own tunnel-ip address structure */

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -68,6 +68,24 @@ struct bgp_nexthop_cache {
 	unsigned int path_count;
 	struct bgp *bgp;
 	struct bgp *bgp_route; /* originator of the request */
+	struct list *leak_mpls; /* label values for vrf route leak to that NH */
+};
+
+/* list of additional mpls entries
+ * needed for crossing vrfs
+ */
+struct bgp_leak_mpls {
+	mpls_label_t label_origin;
+	mpls_label_t label_new;
+	struct bgp_nexthop_cache *bnc;
+	/* allocation has been done
+	 * work is in progress
+	 */
+#define BGP_LEAK_MPLS_ALLOC_WIP 1
+	uint16_t flags;
+	uint16_t refcnt;
+	mpls_label_t label_out;
+	struct prefix nhop; /* used to store gateway */
 };
 
 /* Own tunnel-ip address structure */

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -625,7 +625,7 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 	}
 
 	ret = zclient_send_rnh(zclient, command, p, exact_match,
-			       bnc->bgp->vrf_id);
+			       bnc->bgp->vrf_id, bnc->bgp->vrf_id);
 	/* TBD: handle the failure */
 	if (ret < 0)
 		flog_warn(EC_BGP_ZEBRA_SEND,

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -37,6 +37,8 @@
 #include "bgpd/bgp_route.h"
 #include "bgpd/bgp_attr.h"
 #include "bgpd/bgp_nexthop.h"
+#include "bgpd/bgp_label.h"
+#include "bgpd/bgp_mplsvpn.h"
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_errors.h"
 #include "bgpd/bgp_nht.h"
@@ -50,8 +52,10 @@ static void register_zebra_rnh(struct bgp_nexthop_cache *bnc,
 			       int is_bgp_static_route);
 static void unregister_zebra_rnh(struct bgp_nexthop_cache *bnc,
 				 int is_bgp_static_route);
-static void evaluate_paths(struct bgp_nexthop_cache *bnc);
 static int make_prefix(int afi, struct bgp_path_info *pi, struct prefix *p);
+
+DEFINE_MTYPE_STATIC(BGPD, BGP_NEXTHOP_LEAK_LABEL,
+		    "Bgp Nexthop Label used for VRF route leak");
 
 static int bgp_isvalid_nexthop(struct bgp_nexthop_cache *bnc)
 {
@@ -63,6 +67,92 @@ static int bgp_isvalid_labeled_nexthop(struct bgp_nexthop_cache *bnc)
 {
 	return (bgp_zebra_num_connects() == 0
 		|| (bnc && CHECK_FLAG(bnc->flags, BGP_NEXTHOP_LABELED_VALID)));
+}
+
+static struct bgp_leak_mpls *bgp_nht_lookup_leak_mpls(
+						struct bgp_nexthop_cache *bnc,
+						struct bgp_path_info_extra *extra,
+						bool create)
+{
+	struct listnode *node, *next;
+	struct bgp_leak_mpls *blm;
+
+	if (!bnc || !bnc->leak_mpls ||
+	    !extra || extra->num_labels != 1)
+		return NULL;
+	for (ALL_LIST_ELEMENTS(bnc->leak_mpls, node, next, blm))
+		if (blm->label_origin == extra->label[0])
+			return blm;
+	if (!create)
+		return NULL;
+	blm = XCALLOC(MTYPE_BGP_NEXTHOP_LEAK_LABEL,
+		      sizeof(struct bgp_leak_mpls));
+	blm->label_origin = extra->label[0];
+	blm->bnc = bnc;
+	listnode_add(bnc->leak_mpls, blm);
+	return blm;
+}
+
+static int bgp_nht_handle_label(struct bgp_leak_mpls *blm,
+				struct bgp_path_info *path)
+{
+	int bnc_is_valid_nexthop = 1;
+
+	if (blm->label_new == 0) {
+		bnc_is_valid_nexthop = 0;
+		if (!(blm->flags &
+		      BGP_LEAK_MPLS_ALLOC_WIP)) {
+			blm->flags |=
+				BGP_LEAK_MPLS_ALLOC_WIP;
+			bgp_lp_get(LP_TYPE_VRF_VETH, blm,
+				   bgp_vpn_leak_mpls_callback);
+		}
+	} else {
+		if (!bgp_is_valid_label(&path->extra->label_route_leak) ||
+		    decode_label(&path->extra->label_route_leak)
+		    != blm->label_new) {
+			blm->refcnt++;
+			/* insert new mpls value */
+			encode_label(blm->label_new,
+				     &path->extra->label_route_leak);
+			bgp_set_valid_label(&path->extra->label_route_leak);
+		}
+	}
+	return bnc_is_valid_nexthop;
+}
+
+
+static void bgp_nht_leak_mpls_detach(struct bgp_path_info_extra *extra,
+				     struct bgp_nexthop_cache *bnc)
+{
+	struct bgp_leak_mpls *blm;
+
+	if (!bnc)
+		return;
+
+	blm = bgp_nht_lookup_leak_mpls(bnc, extra, 0);
+	/* suppress additional mpls entry */
+	if (!blm)
+		return;
+	if (blm->label_new &&
+	    bgp_is_valid_label(&extra->label_route_leak) &&
+	    decode_label(&extra->label_route_leak) == blm->label_new) {
+		blm->refcnt--;
+		extra->label_route_leak = 0;
+		if (!blm->refcnt) {
+			/* flush MPLS LSP entry */
+			bgp_zebra_send_mpls_label(ZEBRA_MPLS_LABELS_DELETE,
+						  blm->label_new,
+						  blm->label_out,
+						  &blm->nhop);
+			/* flush allocated label */
+			bgp_lp_release(LP_TYPE_VRF_VETH, blm, blm->label_new);
+			/* flush blm */
+			listnode_delete(bnc->leak_mpls, blm);
+			XFREE(MTYPE_BGP_NEXTHOP_LEAK_LABEL, blm);
+			blm = NULL;
+		}
+	}
 }
 
 static struct bgp_nexthop_cache *bgp_lookup_bnc_per_route(struct list *route,
@@ -222,6 +312,7 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 		bnc->node = rn;
 		bnc->bgp = bgp_nexthop;
 		bnc->bgp_route = bgp_route;
+		bnc->leak_mpls = list_new();
 		bgp_lock_node(rn);
 		if (BGP_DEBUG(nht, NHT)) {
 			char buf[PREFIX2STR_BUFFER];
@@ -294,6 +385,26 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 	} else if (peer)
 		bnc->nht_info = (void *)peer; /* NHT peer reference */
 
+	if (pi && (bnc->flags & BGP_NEXTHOP_RECURSION_IFACE) &&
+	    CHECK_FLAG(bnc->flags, BGP_NEXTHOP_VALID) &&
+	    CHECK_FLAG(bnc->flags, BGP_NEXTHOP_LABELED_VALID)) {
+		struct bgp_leak_mpls *blm;
+
+		blm = bgp_nht_lookup_leak_mpls(bnc, pi->extra, 1);
+		if (blm->label_new == 0) {
+			if (!(blm->flags & BGP_LEAK_MPLS_ALLOC_WIP)) {
+				blm->flags |= BGP_LEAK_MPLS_ALLOC_WIP;
+				bgp_lp_get(LP_TYPE_VRF_VETH, blm,
+					   bgp_vpn_leak_mpls_callback);
+				bnc->flags &= ~BGP_NEXTHOP_VALID;
+			}
+		} else {
+			/* insert new mpls value */
+			encode_label(blm->label_new,
+				     &pi->extra->label_route_leak);
+			bgp_set_valid_label(&pi->extra->label_route_leak);
+		}
+	}
 	/*
 	 * We are cheating here.  Views have no associated underlying
 	 * ability to detect nexthops.  So when we have a view
@@ -723,7 +834,7 @@ static void unregister_zebra_rnh(struct bgp_nexthop_cache *bnc,
  * RETURNS:
  *   void.
  */
-static void evaluate_paths(struct bgp_nexthop_cache *bnc)
+void evaluate_paths(struct bgp_nexthop_cache *bnc)
 {
 	struct bgp_node *rn;
 	struct bgp_path_info *path;
@@ -779,6 +890,23 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 
 			bnc_is_valid_nexthop =
 				bgp_isvalid_labeled_nexthop(bnc) ? 1 : 0;
+			if (!bnc->nexthop_num &&
+			    (bnc->change_flags & BGP_NEXTHOP_CHANGED)) {
+				bgp_nht_leak_mpls_detach(path->extra, bnc);
+				bnc_is_valid_nexthop = 0;
+			} else if ((bnc->flags & BGP_NEXTHOP_RECURSION_IFACE)
+				   && bnc->nexthop_num)
+				bnc_is_valid_nexthop = 1;
+			if ((bnc->flags & BGP_NEXTHOP_RECURSION_IFACE) &&
+			    bnc_is_valid_nexthop && bnc->nexthop_num) {
+				struct bgp_leak_mpls *blm;
+
+				blm = bgp_nht_lookup_leak_mpls(bnc,
+							       path->extra,
+							       1);
+				bnc_is_valid_nexthop =
+					bgp_nht_handle_label(blm, path);
+			}
 		} else {
 			bnc_is_valid_nexthop =
 				bgp_isvalid_nexthop(bnc) ? 1 : 0;
@@ -847,6 +975,7 @@ void path_nh_map(struct bgp_path_info *path, struct bgp_nexthop_cache *bnc,
 {
 	if (path->nexthop) {
 		LIST_REMOVE(path, nh_thread);
+		bgp_nht_leak_mpls_detach(path->extra, path->nexthop);
 		path->nexthop->path_count--;
 		path->nexthop = NULL;
 	}

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -65,6 +65,23 @@ static int bgp_isvalid_labeled_nexthop(struct bgp_nexthop_cache *bnc)
 		|| (bnc && CHECK_FLAG(bnc->flags, BGP_NEXTHOP_LABELED_VALID)));
 }
 
+static struct bgp_nexthop_cache *bgp_lookup_bnc_per_route(struct list *route,
+							  vrf_id_t vrfid_route)
+{
+	struct listnode *node, *next;
+	struct bgp_nexthop_cache *bnc;
+
+	if (!route)
+		return NULL;
+	for (ALL_LIST_ELEMENTS(route, node, next, bnc)) {
+		if (!bnc->bgp_route)
+			continue;
+		if (bnc->bgp_route->vrf_id == vrfid_route)
+			return (bnc);
+	}
+	return NULL;
+}
+
 int bgp_find_nexthop(struct bgp_path_info *path, int connected)
 {
 	struct bgp_nexthop_cache *bnc = path->nexthop;
@@ -89,6 +106,8 @@ int bgp_find_nexthop(struct bgp_path_info *path, int connected)
 static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 {
 	if (LIST_EMPTY(&(bnc->paths)) && !bnc->nht_info) {
+		struct bgp_node *rn = bnc->node;
+
 		if (BGP_DEBUG(nht, NHT)) {
 			char buf[PREFIX2STR_BUFFER];
 			zlog_debug("bgp_unlink_nexthop: freeing bnc %s",
@@ -96,9 +115,10 @@ static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 		}
 		unregister_zebra_rnh(bnc,
 				     CHECK_FLAG(bnc->flags, BGP_STATIC_ROUTE));
-		bgp_node_set_bgp_nexthop_info(bnc->node, NULL);
-		bgp_unlock_node(bnc->node);
-		bnc->node = NULL;
+		listnode_delete(rn->info, bnc);
+		if (list_isempty((struct list *)rn->info))
+			list_delete((struct list **)&rn->info);
+		bgp_unlock_node(rn);
 		bnc_free(bnc);
 	}
 }
@@ -106,13 +126,16 @@ static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 void bgp_unlink_nexthop(struct bgp_path_info *path)
 {
 	struct bgp_nexthop_cache *bnc = path->nexthop;
+	struct bgp_node *rn;
 
 	if (!bnc)
 		return;
-
+	rn = bnc->node;
 	path_nh_map(path, NULL, false);
 
 	bgp_unlink_nexthop_check(bnc);
+	if (rn->info && list_isempty((struct list *)rn->info))
+		list_delete((struct list **)&rn->info);
 }
 
 void bgp_unlink_nexthop_by_peer(struct peer *peer)
@@ -120,6 +143,8 @@ void bgp_unlink_nexthop_by_peer(struct peer *peer)
 	struct prefix p;
 	struct bgp_node *rn;
 	struct bgp_nexthop_cache *bnc;
+	struct listnode *node, *next;
+
 	afi_t afi = family2afi(peer->su.sa.sa_family);
 
 	if (!sockunion2hostprefix(&peer->su, &p))
@@ -131,10 +156,13 @@ void bgp_unlink_nexthop_by_peer(struct peer *peer)
 	if (!bnc)
 		return;
 
-	/* cleanup the peer reference */
-	bnc->nht_info = NULL;
-
-	bgp_unlink_nexthop_check(bnc);
+	for (ALL_LIST_ELEMENTS((struct list *)rn->info, node, next, bnc)) {
+		/* cleanup the peer reference */
+		bnc->nht_info = NULL;
+		bgp_unlink_nexthop_check(bnc);
+	}
+	if (rn->info && list_isempty((struct list *)rn->info))
+		list_delete((struct list **)&rn->info);
 }
 
 /*
@@ -146,7 +174,7 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 			    struct peer *peer, int connected)
 {
 	struct bgp_node *rn;
-	struct bgp_nexthop_cache *bnc;
+	struct bgp_nexthop_cache *bnc = NULL;
 	struct prefix p;
 	int is_bgp_static_route = 0;
 
@@ -184,12 +212,16 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 	else
 		rn = bgp_node_get(bgp_nexthop->nexthop_cache_table[afi], &p);
 
-	bnc = bgp_node_get_bgp_nexthop_info(rn);
-	if (!bnc) {
+	if (rn->info)
+		bnc = bgp_lookup_bnc_per_route(rn->info, bgp_route->vrf_id);
+	if (!rn->info || !bnc) {
 		bnc = bnc_new();
-		bgp_node_set_bgp_nexthop_info(rn, bnc);
+		if (!rn->info)
+			rn->info = list_new();
+		listnode_add((struct list *)rn->info, bnc);
 		bnc->node = rn;
 		bnc->bgp = bgp_nexthop;
+		bnc->bgp_route = bgp_route;
 		bgp_lock_node(rn);
 		if (BGP_DEBUG(nht, NHT)) {
 			char buf[PREFIX2STR_BUFFER];
@@ -278,6 +310,7 @@ void bgp_delete_connected_nexthop(afi_t afi, struct peer *peer)
 	struct bgp_node *rn;
 	struct bgp_nexthop_cache *bnc;
 	struct prefix p;
+	struct listnode *node, *next;
 
 	if (!peer)
 		return;
@@ -294,41 +327,32 @@ void bgp_delete_connected_nexthop(afi_t afi, struct peer *peer)
 		return;
 	}
 
-	bnc = bgp_node_get_bgp_nexthop_info(rn);
-	if (!bnc) {
-		if (BGP_DEBUG(nht, NHT))
-			zlog_debug("Cannot find connected NHT node for peer %s on route_node as expected",
-				   peer->host);
-		bgp_unlock_node(rn);
-		return;
+	for (ALL_LIST_ELEMENTS((struct list *)rn->info, node, next, bnc)) {
+		if (bnc->nht_info != peer) {
+			if (BGP_DEBUG(nht, NHT))
+				zlog_debug(
+					   "Connected NHT %p node for peer %s points to %p",
+					   bnc, peer->host, bnc->nht_info);
+			continue;
+		}
+		bnc->nht_info = NULL;
+
+		if (LIST_EMPTY(&(bnc->paths))) {
+			if (BGP_DEBUG(nht, NHT))
+				zlog_debug("Freeing connected NHT node %p for peer %s",
+					   bnc, peer->host);
+			unregister_zebra_rnh(bnc, 0);
+			listnode_delete(bnc->node->info, bnc);
+			bnc_free(bnc);
+		}
 	}
 	bgp_unlock_node(rn);
-
-	if (bnc->nht_info != peer) {
-		if (BGP_DEBUG(nht, NHT))
-			zlog_debug(
-				"Connected NHT %p node for peer %s points to %p",
-				bnc, peer->host, bnc->nht_info);
-		return;
-	}
-
-	bnc->nht_info = NULL;
-
-	if (LIST_EMPTY(&(bnc->paths))) {
-		if (BGP_DEBUG(nht, NHT))
-			zlog_debug("Freeing connected NHT node %p for peer %s",
-				   bnc, peer->host);
-		unregister_zebra_rnh(bnc, 0);
-		bgp_node_set_bgp_nexthop_info(bnc->node, NULL);
-		bgp_unlock_node(bnc->node);
-		bnc_free(bnc);
-	}
 }
 
 void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 {
 	struct bgp_node *rn = NULL;
-	struct bgp_nexthop_cache *bnc;
+	struct bgp_nexthop_cache *bnc = NULL;
 	struct nexthop *nexthop;
 	struct nexthop *oldnh;
 	struct nexthop *nhlist_head = NULL;
@@ -362,7 +386,9 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 			bgp->import_check_table[family2afi(nhr.prefix.family)],
 			&nhr.prefix);
 
-	if (!rn) {
+	if (rn->info)
+		bnc = bgp_lookup_bnc_per_route(rn->info, nhr.vrf_id_route);
+	if (!rn || !rn->info || !bnc) {
 		if (BGP_DEBUG(nht, NHT)) {
 			char buf[PREFIX2STR_BUFFER];
 			prefix2str(&nhr.prefix, buf, sizeof(buf));
@@ -372,20 +398,8 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 		return;
 	}
 
-	bnc = bgp_node_get_bgp_nexthop_info(rn);
-	if (!bnc) {
-		if (BGP_DEBUG(nht, NHT)) {
-			char buf[PREFIX2STR_BUFFER];
-
-			prefix2str(&nhr.prefix, buf, sizeof(buf));
-			zlog_debug("parse nexthop update(%s): bnc node info not found",
-				   buf);
-		}
-		bgp_unlock_node(rn);
-		return;
-	}
-
 	bgp_unlock_node(rn);
+
 	bnc->last_update = bgp_clock();
 	bnc->change_flags = 0;
 
@@ -625,7 +639,7 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 	}
 
 	ret = zclient_send_rnh(zclient, command, p, exact_match,
-			       bnc->bgp->vrf_id, bnc->bgp->vrf_id);
+			       bnc->bgp->vrf_id, bnc->bgp_route->vrf_id);
 	/* TBD: handle the failure */
 	if (ret < 0)
 		flog_warn(EC_BGP_ZEBRA_SEND,

--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -97,4 +97,5 @@ extern void bgp_nht_register_nexthops(struct bgp *bgp);
  */
 extern void bgp_nht_register_enhe_capability_interfaces(struct peer *peer);
 
+extern void evaluate_paths(struct bgp_nexthop_cache *bnc);
 #endif /* _BGP_NHT_H */

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -90,6 +90,7 @@ struct bgp_path_info_extra {
 	/* MPLS label(s) - VNI(s) for EVPN-VxLAN  */
 	mpls_label_t label[BGP_MAX_LABELS];
 	uint32_t num_labels;
+	mpls_label_t label_route_leak; /* for crossing some VRFs */
 
 #if ENABLE_BGP_VNC
 	union {

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1425,7 +1425,7 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 	if (bgp_debug_zebra(p)) {
 		char prefix_buf[PREFIX_STRLEN];
 		char nh_buf[INET6_ADDRSTRLEN];
-		char label_buf[20];
+		char label_buf[40];
 		int i;
 
 		prefix2str(&api.prefix, prefix_buf, sizeof(prefix_buf));
@@ -1449,9 +1449,14 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 
 			label_buf[0] = '\0';
 			if (has_valid_label
-			    && !CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE))
-				sprintf(label_buf, "label %u",
-					api_nh->labels[0]);
+			    && !CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE)) {
+				char *ptr = label_buf;
+
+				ptr += sprintf(ptr, "label %u",
+					       api_nh->labels[0]);
+				if (api_nh->label_num == 2)
+					sprintf(ptr, ", %u", api_nh->labels[1]);
+			}
 			zlog_debug("  nhop [%d]: %s if %u VRF %u %s",
 				   i + 1, nh_buf, api_nh->ifindex,
 				   api_nh->vrf_id, label_buf);

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -36,6 +36,9 @@ extern void bgp_config_write_maxpaths(struct vty *, struct bgp *, afi_t,
 				      safi_t);
 extern void bgp_config_write_redistribute(struct vty *, struct bgp *, afi_t,
 					  safi_t);
+extern void bgp_zebra_send_mpls_label(int cmd, mpls_label_t in_label,
+				      mpls_label_t out_label,
+				      struct prefix *gateway);
 extern void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 			       struct bgp_path_info *path, struct bgp *bgp,
 			       afi_t afi, safi_t safi);

--- a/doc/developer/bgpd.rst
+++ b/doc/developer/bgpd.rst
@@ -8,4 +8,5 @@ BGPD
    :maxdepth: 2
 
    next-hop-tracking
+   vrf-netns-route-leak
    bgp-typecodes

--- a/doc/developer/next-hop-tracking.rst
+++ b/doc/developer/next-hop-tracking.rst
@@ -105,6 +105,13 @@ the following:
   corresponding destination. This may result in re-announcing those
   destinations to peers.
 
+- In case a VRF route leak is requested to be resolved, the next hop
+  notification contains an additional in the resolved field of the
+  nexthop structure filled in. That field contains a nexthop interface
+  index structure containing the interface index to use, when crossing
+  vrf. In BGP case, upon presence of that interface index, the flag
+  `BGP_NEXTHOP_RECURSION_IFACE` is appended to the nexthop flags.
+
 Design
 ------
 

--- a/doc/developer/next-hop-tracking.rst
+++ b/doc/developer/next-hop-tracking.rst
@@ -76,10 +76,19 @@ Overview of changes
 The changes are in both BGP and Zebra modules.  The short summary is
 the following:
 
+- Nexthop information is indexed per (nexthop VRF, prefix VRF,
+  AF) tuple. The reason is that it permits for a defined prefix VRF
+  to know which path to use when crossing vrf route leak, to reach its
+  nexthop. Actually, when vrf backend is not Linux vrf-lite, the
+  nexthop information is calculated from the prefix vrf table.
+
 - Zebra implements a registration mechanism by which clients can
   register for next hop notification. Consequently, it maintains a
-  separate table, per (VRF, AF) pair, of next hops and interested
-  client-list per next hop.
+  separate table, per (VRF nexthop prefix, VRF prefix, AF) tuple,
+  of next hops and interested client-list per next hop.
+
+- BGP implements separate table, per (VRF nexthop prefix, VRF prefix,
+  AF) tuple, of next hops.
 
 - When the main routing table changes in Zebra, it evaluates the next
   hop table: for each next hop, it checks if the route table
@@ -193,6 +202,8 @@ encoded in the following way:
     .      Nexthop prefix                                           .
     .                                                               .
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    . VRF ID from prefix  |
+    +-+-+-+-+-+-+-+-+-+-+-+
     .                                                               .
     .                                                               .
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -201,6 +212,8 @@ encoded in the following way:
     .      Nexthop prefix                                           .
     .                                                               .
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    . VRF ID from prefix  |
+    +-+-+-+-+-+-+-+-+-+-+-+
 
 
 ``ZEBRA_NEXTHOP_UPDATE`` message is encoded as follows:
@@ -215,7 +228,7 @@ encoded in the following way:
     .      Nexthop prefix getting resolved                          .
     .                                                               .
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |        metric                                                 |
+    | VRF ID from prefix  | type, instance, metric, distance        |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |  #nexthops    |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

--- a/doc/developer/vrf-netns-route-leak.rst
+++ b/doc/developer/vrf-netns-route-leak.rst
@@ -1,0 +1,215 @@
+VRF netns route leak
+====================
+
+VRF netns route leak is a feature allowing to cross VRF boundaries when VRF
+has a netns backend. This can be done by using veth pairs configured between
+VRFs. It is currenty only used with BGP L3-VPN in two situations : leaking
+from a BGP-VPN to a local VRF (and vice-versa) or when leaking between local
+VRF. Basically, the former will rely on MPLS labels. Both will use veth pair
+as nexthop route entry to reach remote VRF/VPN.
+
+Veth pair configuration
+-----------------------
+
+Actually, crossing VRF can be done by using virtual ethernet interfaces.
+On linux, it is possible to do so, by creating veth pair of devices.
+
+Below example illustrates how a veth pair device can be configured and used
+to leak between two VRFs.
+
+::
+
+   ip link add vrf1 type veth peer name vrf2
+   ip link set dev vrf1 arp off
+   ip link set dev vrf2 arp off
+   ip link set dev vrf1 address 00:80:ed:01:01:01
+   ip link set dev vrf2 address 00:80:ed:01:01:01
+   ip link set vrf1 netns vrf2
+   ip link set vrf2 netns vrf1
+   ip netns exec vrf1 ip link set dev vrf2 up
+   ip netns exec vrf2 ip link set dev vrf1 up
+
+To work in an IP-less mode, we *must* have
+
+- ARP disabled,
+- Same mac address configured on both sides.
+
+Consequently, it is possible to configure a connected route to that
+interface, and send some traffic across that interface. Linux kernel permits a
+packet to be transmitted with equal source and destination mac address.
+
+::
+
+   ip netns exec vrf1 ip route add 2.2.2.0/24 dev vrf2
+   ip netns exec vrf2 ip route add 1.1.1.0/24 dev vrf1
+
+   # ip netns exec vrf1 ip route show
+   2.2.2.0/24 dev vrf2 scope link
+
+   # ip netns exec vrf2 ip route show
+   1.1.1.0/24 dev vrf2 scope link
+
+   # ip netns exec vrf1 ping 2.2.2.2 -I 1.1.1.1
+   # ip netns exec vrf2 ping 1.1.1.1 -I 2.2.2.2
+
+Once the veth infrastrucure is set, the route leak requires very little
+configuration : no extra adress, and a simple route through an interface.
+This solution does not alter the isolation property of netns based VRFs, as
+the leak infrastrucuture (veth pairs) needs to be explicitely set up : to
+keep a VRF fully isolated, just don't build veth pair pointing to another VRF.
+
+The drawback of that solution is that it may require a lot of veth pairs :
+one per VRF-pair where leaking is desired.
+
+FRR veth pair configuration
+---------------------------
+
+Similarly to what has been done for vrf-lite cases, there is a strong
+relationship between veth names and VRF names. In order to leak from a VRF
+named "vrf-a" to a  a VRF named "vrf-b", FRR will explicitely search in
+"vrf-a" a veth interface named with the target VRF, i.e. "vrf-b"; same naming
+convention applies for the return traffic.
+
+Configurable naming convention for veth pairs, and/or automatic creation of
+such pairs by FRR has been envisionned but not yet implemented.
+
+This implies that X-vrf veth provisionning must be done prior to FRR being
+started, or at least before any X-vrf route is computed by FRR. The presence
+of those veth pair will be considered as enough by the frrouting process to
+decide whether or not it is possible to do vrf route leak.
+
+.. note::
+
+   The user has to ensure that the veth pairs are well named and configured.
+   It is worth to be noted that the veth framework will fail in case mac address
+   of veth pairs are not the same, or the IFF_NOARP flag is not present, or the
+   operational status of veth pairs is not up. Not setting it may be well handled
+   by Zebra daemon (mainly thanks to nexthop tracking), but in some cases, may
+   lead to some inconsistencies (this is the case when incoming MPLS traffic from
+   VPN has to cross the boundaries to reach a VRF. For that, it is recommended to
+   have the veth pair well configured before restarting FRR).
+
+BGP route leaking resolution
+----------------------------
+
+The following kind of leaking route entries are handled.
+
+- connected routes, generally redistributed via BGP.
+  those are imported route entries on a separate VRF.
+- nexthop route entries. Those are route entries learnt by remote VPN (through MPLS VPN
+  protocol), or remote BGP ( through imported entries from a BGP PE on a VRF).
+
+As remind, whatever the service used, leaking from a BGP-VPN to a local VRF (and
+vice-versa) or when leaking between local VRF, the two services will result in handling
+the two kinds of above routes. The two leak services will both use the vpn to export
+entries to, and import entries from. The only difference will result in the path used,
+if the `nexthop origin` is in a local vrf, or in the VPN.
+
+The checks for first kind of route will rely on API `vrf_route_leak_possible()`.
+Actually, as the route imported is connected, no need to check that the route is
+reachable in the target VRF. This API just returns the feasability of crossing the
+vrf borders by giving two parameters : the origin vrf, and the target VRF. An interface
+index is returned, giving the interface to use by the origin VRF to reach the target VRF.
+
+The checks for the second kind of routes relies on nexthop tracking module.
+Like for vrf-lite case, the nexthop is submitted to Zebra route nexthop tracking module.
+Once the nexthop resolved in the target VRF, if the vrf backend is netns based VRFs, then
+an addition checking is done against the veth pair framework. An interface index is then
+obtained by Zebra route nexthop tracking; that interface index is the interface to use by
+the origin VRF to reach the target VRF and the associated nexthop.
+
+Once BGP checked the validity of the BGP route entry, if an interface index is available,
+BGP will use it to ask Zebra to insert an extra nexthop rule, so as to redirect the route
+through the correct veth interface. A specific function will create an extra nexthop entry
+: `bgp_zebra_handle_nexthop_vrf()`. Upon detection of a route leak, the route entry to be
+passed to ZEBRA will contain `ZEBRA_FLAG_CROSS_VRF_IFACE` flag. The flag explanation is given
+below.
+
+BGP MPLS route leaking resolution
+---------------------------------
+
+When importing a route entry from VPN, an MPLS label is associated to the
+nexthop of the route. This is to perfom MPLS encapsulation, and needs to be
+part of the route entry that has to be injected in the FIB.
+
+A VPN route needs also an extra MPLS encaspulation to occur, with the label
+used by the MPLS backbone. This is handled thanks to a "recursive" route, each
+level carrying it own label.
+
+Let's see it on an exemple, let's say for a VPN route `5.1.0.0/24` needing to
+be installed in VRF "vrf1", and needing the double MPLS encapsulation with
+labels 101 (for VPN), and 17 (for MPLS backbone), and compare the outputs for
+both vrf-lite and netns backends.
+
+With vrf-lite backend this will appear as follow :
+
+::
+
+   # show ip route vrf vrf1
+   ...
+   B>  5.1.0.0/24 [200/98] via 1.1.1.1(vrf default) (recursive), label 101, 00:00:05
+   *                       via 10.0.2.2, r4-eth0(vrf default), label 17, 00:00:05
+
+Thanks to vrf-lite lack of isolation at vrf level, both MPLS encaspulation can
+occur at the same time (more precisely operation will be done in vrf1).
+
+With netns backend, a FIB route in vrf1 can not refer to interface of another
+VRF, so it has to be done with an extra hop, hence splitting the final route in
+two parts. The first one is going though the X-vrf infrastrucutre, with the
+double MPLS encpasulation set ; at this level, because of possible conflicts
+the outer MPLS label can not be the one used by (and learnt from) MPLS backbone.
+It must be locally assigned, and then processed in the default vrf, where a
+swap operation will take place, finally setting the proper label needed by MPLS
+backbone. In other words, all is as if MPLS backbone was extended with an
+extra node in the default vrf.
+
+::
+
+   # show ip route vrf vrf1
+   ...
+   B>* 5.1.0.0/24 [200/98] is directly connected, vrf0, label 85/101, 00:00:01
+                                via 1.1.1.1(vrf vrf0) (recursive), label 101, 00:00:01
+     *                          via 10.0.2.2, r4-eth0(vrf vrf0), label 17, 00:00:01
+   ...
+   # show mpls table
+   Inbound                            Outbound
+     Label     Type          Nexthop     Label
+   --------  -------  ---------------  --------
+      85      BGP           10.0.2.2        17
+
+The following operations are then performed for each vpn entry:
+
+- in vrf1, the VPN label (101), and the internal label (85) are added
+- in vrf0, the internal label (85) is replaced by the MPLS backbone label (17)
+
+Note that as we're operating  at backbone level or equivalent, there are not
+as many internal label as there are MPLS vpn lsp : we need one per tuple
+(nexthop, target label).
+The MPLS swap entry is created once the nexthop entry is considered as valid by
+BGP nexthop management, thanks to the callback `bgp_vpn_leak_mpls_callback()`.
+
+Zebra route leaking handling
+----------------------------
+
+BGP RIB injection in ZEBRA will contain an extra nexthop entry that contains
+the interface index of the veth interface to use.
+
+Then one flag will be appended to the route entry:
+`ZEBRA_FLAG_CROSS_VRF_IFACE`. That flag will be used to determine that at least one nexthop
+is a rule to cross a VRF by using an interface. For instance, each line in the below route
+entry stands for a nexthop entry in the zapi message sent by BGP to ZEBRA. The first entry will
+be identified as the entry that will replace the two next ones.
+
+::
+
+   # show ip route vrf vrf1
+   ...
+   B>* 5.1.0.0/24 [200/98] is directly connected, vrf0, label 85/101, 00:00:01
+                                via 1.1.1.1(vrf vrf0) (recursive), label 101, 00:00:01
+     *                          via 10.0.2.2, r4-eth0(vrf vrf0), label 17, 00:00:01
+
+Adding to this, one other flag will be used in the last 2 nexthop entries:
+
+`NEXTHOP_FLAG_INFO_ONLY`. That flag will be used by ZEBRA. It will be applied to the two last
+nexthop entries. This will inform ZEBRA to not install the entries in the system. This
+information is kept, since it illustrates the relationship between Zebra entry and BGP entry.

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -72,6 +72,21 @@ int nexthop_same_no_recurse(const struct nexthop *next1,
 	return 1;
 }
 
+/* check if nexthops recurse information is same
+ * the recurse part is taken into account
+ */
+int nexthop_same_recurse(const struct nexthop *next1,
+			 const struct nexthop *next2)
+{
+	if (!next1->resolved && !next2->resolved)
+		return 1;
+	if (next1->resolved && !next2->resolved)
+		return 0;
+	if (next2->resolved && !next1->resolved)
+		return 0;
+	return 1;
+}
+
 int nexthop_same_firsthop(struct nexthop *next1, struct nexthop *next2)
 {
 	int type1 = NEXTHOP_FIRSTHOPTYPE(next1->type);

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -140,6 +140,8 @@ extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
 extern const char *nexthop_type_to_str(enum nexthop_types_t nh_type);
 extern int nexthop_same_no_recurse(const struct nexthop *next1,
 				   const struct nexthop *next2);
+extern int nexthop_same_recurse(const struct nexthop *next1,
+				const struct nexthop *next2);
 extern int nexthop_labels_match(struct nexthop *nh1, struct nexthop *nh2);
 extern int nexthop_same_firsthop(struct nexthop *next1, struct nexthop *next2);
 

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -71,7 +71,7 @@ struct nexthop {
 
 	enum nexthop_types_t type;
 
-	uint8_t flags;
+	uint16_t flags;
 #define NEXTHOP_FLAG_ACTIVE     (1 << 0) /* This nexthop is alive. */
 #define NEXTHOP_FLAG_FIB        (1 << 1) /* FIB nexthop. */
 #define NEXTHOP_FLAG_RECURSIVE  (1 << 2) /* Recursive nexthop. */
@@ -80,6 +80,7 @@ struct nexthop {
 #define NEXTHOP_FLAG_FILTERED   (1 << 5) /* rmap filtered, used by static only */
 #define NEXTHOP_FLAG_DUPLICATE  (1 << 6) /* nexthop duplicates another active one */
 #define NEXTHOP_FLAG_EVPN_RVTEP (1 << 7) /* EVPN remote vtep nexthop */
+#define NEXTHOP_FLAG_INFO_ONLY  (1 << 8) /* nexthop display only value */
 #define NEXTHOP_IS_ACTIVE(flags)                                               \
 	(CHECK_FLAG(flags, NEXTHOP_FLAG_ACTIVE)                                \
 	 && !CHECK_FLAG(flags, NEXTHOP_FLAG_DUPLICATE))

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -848,6 +848,24 @@ int vrf_route_leak_possible(vrf_id_t vrf_id_orig,
 	return ret;
 }
 
+/* checks if an interface possibly can be used for crossing vrfs
+ * if vrf backend is netns based vrf
+ * return:
+ * - ROUTE_LEAK_VRF_LITE_POSSIBLE
+ *    if vrf route leak is possible, because it is vrf lite
+ * - ROUTE_LEAK_VRF_NETNS_POSSIBLE
+ *    if vrf is netns based and virtual ethernet is available and up
+ * - ROUTE_LEAK_VRF_NETNS_MAYBE
+ *    if interfaces for veth are present, but status of interface is not up
+ * - ROUTE_LEAK_VRF_NOT_POSSIBLE on other cases
+ */
+int vrf_route_leak_interface_possible(vrf_id_t vrf_id_orig,
+				      struct interface *ifp)
+{
+	return vrf_route_leak_internal_possible(vrf_id_orig, VRF_UNKNOWN,
+				       ifp, NULL);
+}
+
 int vrf_is_mapped_on_netns(struct vrf *vrf)
 {
 	if (!vrf || vrf->data.l.netns_name[0] == '\0')

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -716,6 +716,138 @@ int vrf_netns_handler_create(struct vty *vty, struct vrf *vrf, char *pathname,
 	return CMD_SUCCESS;
 }
 
+/* validates that vrf route leak is possible across vrfs
+ * params:
+ *  vrf_id_orig : should always be valid
+ *  vrf_id_target : may be not set
+ *  ifp : local interface from vrf_id_orig
+ *  ifindex : interface index pointer to return
+ *          it is ifindex of local interface of vrf
+ * return:
+ * - ROUTE_LEAK_VRF_LITE_POSSIBLE
+ *    if vrf route leak is possible, because it is vrf lite
+ * - ROUTE_LEAK_VRF_NETNS_POSSIBLE
+ *    if vrf is netns based and virtual ethernet is available and up
+ * - ROUTE_LEAK_VRF_NETNS_MAYBE
+ *    if interfaces for veth are present, but status of interface is not up
+ * - ROUTE_LEAK_VRF_NOT_POSSIBLE on other cases
+ */
+static int vrf_route_leak_internal_possible(vrf_id_t vrf_id_orig,
+					    vrf_id_t vrf_id_target,
+					    struct interface *ifp,
+					    ifindex_t *ifindex)
+{
+	struct interface *ifp_orig, *ifp_target;
+	struct vrf *vrf_orig = NULL, *vrf_target = NULL;
+
+	if (vrf_id_orig == VRF_UNKNOWN)
+		return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+	if (vrf_id_target == vrf_id_orig)
+		return ROUTE_LEAK_ROUTING_POSSIBLE;
+	vrf_orig = vrf_lookup_by_id(vrf_id_orig);
+	if (!vrf_orig)
+		return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+	/* if not netns, then vrf lite, then natively supported */
+	if (!vrf_is_mapped_on_netns(vrf_orig))
+		return ROUTE_LEAK_VRF_LITE_POSSIBLE;
+
+	/* passed interface is used in veth to cross vrf borders
+	 * look for vrf name
+	 */
+	if (vrf_id_target == VRF_UNKNOWN) {
+		if (!ifp)
+			return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+		vrf_target = vrf_lookup_by_name(ifp->name);
+
+		if (!vrf_target)
+			return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+		/* look for interface in target vrf
+		 * with name is local vrf_orig name
+		 */
+		if (vrf_orig == vrf_target)
+			return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+		ifp_target = if_lookup_by_name(vrf_orig->name,
+					       vrf_target->vrf_id);
+		if (!ifp_target)
+			return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+		/* no need to search for ifp_orig, since ifp_orig
+		 * and ifp should be the same
+		 */
+		ifp_orig = ifp;
+	} else {
+		vrf_target = vrf_lookup_by_id(vrf_id_target);
+		if (!vrf_target)
+			return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+
+		/* on netns based vrf, solution consists in having interface
+		 * name matching target vrf name
+		 * example: communication between vrf0 and vrf1
+		 * to reach vrf1, interface vrf1 must exist in vrf vrf0
+		 */
+		ifp_orig = if_lookup_by_name(vrf_target->name, vrf_id_orig);
+		if (!ifp_orig)
+			return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+		ifp_target = if_lookup_by_name(vrf_orig->name, vrf_id_target);
+		/* because remote may not be present, this doesn ot mean that the
+		 * user will not provision it
+		 */
+		if (!ifp_target)
+			return ROUTE_LEAK_VRF_NETNS_MAYBE;
+	}
+	if (!(ifp_target->flags & IFF_NOARP) ||
+	    !(ifp_orig->flags & IFF_NOARP))
+		return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+	if (ifp_target->hw_addr_len != ifp_orig->hw_addr_len)
+		return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+	if (memcmp(ifp_target->hw_addr, ifp_orig->hw_addr,
+		   INTERFACE_HWADDR_MAX))
+		return ROUTE_LEAK_VRF_NOT_POSSIBLE;
+	/* return interface index of the interface to use
+	 * in case a route leak must be established to reach vrf_target
+	 */
+	if (ifindex)
+		*ifindex = ifp_orig->ifindex;
+	/* check that links are up on both sides
+	 * if not, the presence of interfaces is just enough
+	 * to assume this will be possible in an other
+	 * operational context
+	 */
+	if (!if_is_up(ifp_orig) || !if_is_up(ifp_target))
+		return ROUTE_LEAK_VRF_NETNS_MAYBE;
+	/* having interface name is not enough. one should check:
+	 * - that mac addresses are the same
+	 * - that interfaces are veth based
+	 */
+	return ROUTE_LEAK_VRF_NETNS_POSSIBLE;
+}
+
+/* validates that vrf route leak is possible across vrfs
+ * params:
+ *  vrf_id_orig : should always be valid
+ *  vrf_id_target : may be not set
+ *  ifp : local interface from vrf_id_orig
+ *  ifindex : interface index pointer to return
+ *          it is ifindex of local interface of vrf
+ * return:
+ * - ROUTE_LEAK_VRF_LITE_POSSIBLE
+ *    if vrf route leak is possible, because it is vrf lite
+ * - ROUTE_LEAK_VRF_NETNS_POSSIBLE
+ *    if vrf is netns based and virtual ethernet is available and up
+ * - ROUTE_LEAK_VRF_NOT_POSSIBLE on other cases
+ */
+int vrf_route_leak_possible(vrf_id_t vrf_id_orig,
+			    vrf_id_t vrf_id_target,
+			    ifindex_t *ifindex)
+{
+	int ret;
+
+	ret = vrf_route_leak_internal_possible(vrf_id_orig, vrf_id_target,
+					       NULL, ifindex);
+	if (ret == ROUTE_LEAK_VRF_NETNS_MAYBE)
+		ret = ROUTE_LEAK_VRF_NOT_POSSIBLE;
+	return ret;
+}
+
 int vrf_is_mapped_on_netns(struct vrf *vrf)
 {
 	if (!vrf || vrf->data.l.netns_name[0] == '\0')

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -250,6 +250,8 @@ int vrf_is_mapped_on_netns(struct vrf *vrf);
 int vrf_route_leak_possible(vrf_id_t vrf_id_orig,
 			    vrf_id_t vrf_id_target,
 			    ifindex_t *ifindex);
+int vrf_route_leak_interface_possible(vrf_id_t vrf_id_orig,
+				      struct interface *ifp);
 
 /* VRF switch from NETNS */
 extern int vrf_switch_to_netns(vrf_id_t vrf_id);

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -242,6 +242,14 @@ extern const char *vrf_get_default_name(void);
 
 /* VRF is mapped on netns or not ? */
 int vrf_is_mapped_on_netns(struct vrf *vrf);
+#define ROUTE_LEAK_VRF_NOT_POSSIBLE	0
+#define ROUTE_LEAK_VRF_LITE_POSSIBLE	1
+#define ROUTE_LEAK_VRF_NETNS_POSSIBLE	2
+#define ROUTE_LEAK_ROUTING_POSSIBLE	3
+#define ROUTE_LEAK_VRF_NETNS_MAYBE	4
+int vrf_route_leak_possible(vrf_id_t vrf_id_orig,
+			    vrf_id_t vrf_id_target,
+			    ifindex_t *ifindex);
 
 /* VRF switch from NETNS */
 extern int vrf_switch_to_netns(vrf_id_t vrf_id);

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -656,7 +656,7 @@ static int zclient_connect(struct thread *t)
 }
 
 int zclient_send_rnh(struct zclient *zclient, int command, struct prefix *p,
-		     bool exact_match, vrf_id_t vrf_id)
+		     bool exact_match, vrf_id_t vrf_id, vrf_id_t vrf_id_route)
 {
 	struct stream *s;
 
@@ -677,6 +677,7 @@ int zclient_send_rnh(struct zclient *zclient, int command, struct prefix *p,
 	default:
 		break;
 	}
+	stream_putl(s, vrf_id_route);
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	return zclient_send_message(zclient);
@@ -1216,7 +1217,7 @@ bool zapi_nexthop_update_decode(struct stream *s, struct zapi_route *nhr)
 	default:
 		break;
 	}
-
+	STREAM_GETL(s, nhr->vrf_id_route);
 	STREAM_GETC(s, nhr->type);
 	STREAM_GETW(s, nhr->instance);
 	STREAM_GETC(s, nhr->distance);

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1257,6 +1257,7 @@ bool zapi_nexthop_update_decode(struct stream *s, struct zapi_route *nhr)
 			STREAM_GET(&nhr->nexthops[i].labels[0], s,
 				   nhr->nexthops[i].label_num
 					   * sizeof(mpls_label_t));
+		STREAM_GETL(s, nhr->nexthops[i].recursive_iface_ifindex);
 	}
 
 	return true;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1196,6 +1196,17 @@ struct nexthop *nexthop_from_zapi_nexthop(struct zapi_nexthop *znh)
 				   znh->labels);
 	}
 
+	/*
+	 * This function appends a resolved entry
+	 */
+	if (znh->recursive_iface_ifindex) {
+		struct nexthop *resolved_n = nexthop_new();
+
+		resolved_n->ifindex = znh->recursive_iface_ifindex;
+		resolved_n->type = NEXTHOP_TYPE_IFINDEX;
+		resolved_n->rparent = n;
+		n->resolved = resolved_n;
+	}
 	return n;
 }
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -356,6 +356,9 @@ struct zapi_route {
 	vrf_id_t vrf_id;
 
 	uint32_t tableid;
+
+	/* for vrf route leak */
+	vrf_id_t vrf_id_route;
 };
 
 struct zapi_pw {
@@ -593,7 +596,7 @@ extern void zebra_read_pw_status_update(int command, struct zclient *zclient,
 extern int zclient_route_send(uint8_t, struct zclient *, struct zapi_route *);
 extern int zclient_send_rnh(struct zclient *zclient, int command,
 			    struct prefix *p, bool exact_match,
-			    vrf_id_t vrf_id);
+			    vrf_id_t vrf_id, vrf_id_t vrf_id_route);
 extern int zapi_route_encode(uint8_t, struct stream *, struct zapi_route *);
 extern int zapi_route_decode(struct stream *, struct zapi_route *);
 bool zapi_route_notify_decode(struct stream *s, struct prefix *p,

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -316,6 +316,8 @@ struct zapi_nexthop {
 	mpls_label_t labels[MPLS_MAX_LABELS];
 
 	struct ethaddr rmac;
+
+	ifindex_t recursive_iface_ifindex;
 };
 
 /*

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -451,6 +451,12 @@ extern const char *zserv_command_string(unsigned int command);
  * kernel install flag for it should be turned on
  */
 #define ZEBRA_FLAG_ONLINK             0x80
+/*
+ * This flag tells Zebra that the passed down route is a vrf route
+ * leak route through interface. Today, this applies to
+ * netns based vrfs, to avoid injecting in kernel all routes
+ */
+#define ZEBRA_FLAG_CROSS_VRF_IFACE    0x100
 
 #ifndef INADDR_LOOPBACK
 #define	INADDR_LOOPBACK	0x7f000001	/* Internet address 127.0.0.1.  */

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -437,7 +437,8 @@ void pbr_send_rnh(struct nexthop *nhop, bool reg)
 	}
 
 	if (zclient_send_rnh(zclient, command, &p,
-			     false, nhop->vrf_id) < 0) {
+			     false, nhop->vrf_id,
+			     nhop->vrf_id) < 0) {
 		zlog_warn("%s: Failure to send nexthop to zebra",
 			  __PRETTY_FUNCTION__);
 	}

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -51,7 +51,8 @@ void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zclient,
 	int ret;
 
 	p = &(pnc->rpf.rpf_addr);
-	ret = zclient_send_rnh(zclient, command, p, false, pim->vrf_id);
+	ret = zclient_send_rnh(zclient, command, p, false,
+			       pim->vrf_id, pim->vrf_id);
 	if (ret < 0)
 		zlog_warn("sendmsg_nexthop: zclient_send_message() failed");
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -341,7 +341,8 @@ void static_zebra_nht_register(struct static_route *si, bool reg)
 		static_nht_hash_free(nhtd);
 	}
 
-	if (zclient_send_rnh(zclient, cmd, &p, false, si->nh_vrf_id) < 0)
+	if (zclient_send_rnh(zclient, cmd, &p, false,
+			     si->nh_vrf_id, si->vrf_id) < 0)
 		zlog_warn("%s: Failure to send nexthop to zebra",
 			  __PRETTY_FUNCTION__);
 }

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -956,6 +956,7 @@ void if_up(struct interface *ifp)
 		if (link_if)
 			zebra_vxlan_svi_up(ifp, link_if);
 	}
+	zebra_vrf_route_leak_interface_updated(zvrf, ifp);
 }
 
 /* Interface goes down.  We have to manage different behavior of based
@@ -1003,6 +1004,8 @@ void if_down(struct interface *ifp)
 
 	/* Delete all neighbor addresses learnt through IPv6 RA */
 	if_down_del_nbr_connected(ifp);
+
+	zebra_vrf_route_leak_interface_updated(zvrf, ifp);
 }
 
 void if_refresh(struct interface *ifp)

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1575,6 +1575,8 @@ static int netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 	 */
 	nexthop_num = 0;
 	for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx), nexthop)) {
+		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_INFO_ONLY))
+			continue;
 		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 			continue;
 		if (cmd == RTM_NEWROUTE && !NEXTHOP_IS_ACTIVE(nexthop->flags))
@@ -1587,6 +1589,9 @@ static int netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 	if (nexthop_num == 1) {
 		nexthop_num = 0;
 		for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx), nexthop)) {
+			if (CHECK_FLAG(nexthop->flags,
+				       NEXTHOP_FLAG_INFO_ONLY))
+				continue;
 			/*
 			 * So we want to cover 2 types of blackhole
 			 * routes here:
@@ -1676,6 +1681,10 @@ static int netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 
 		nexthop_num = 0;
 		for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx), nexthop)) {
+			if (CHECK_FLAG(nexthop->flags,
+				       NEXTHOP_FLAG_INFO_ONLY))
+				continue;
+
 			if (CHECK_FLAG(nexthop->flags,
 				       NEXTHOP_FLAG_RECURSIVE)) {
 				/* This only works for IPv4 now */

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -179,6 +179,8 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 		/*
 		 * We only want to use the actual good nexthops
 		 */
+		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_INFO_ONLY))
+			continue;
 		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE) ||
 		    !CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 			continue;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1088,7 +1088,8 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 		STREAM_GETL(s, vrf_id_route);
 		l += 4;
 
-		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), type, &exist);
+		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), type, &exist,
+				    vrf_id_route);
 		if (!rnh)
 			return;
 
@@ -1177,7 +1178,7 @@ static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
 		STREAM_GETL(s, vrf_id_route);
 		l += 4;
 
-		rnh = zebra_lookup_rnh(&p, zvrf_id(zvrf), type);
+		rnh = zebra_lookup_rnh(&p, zvrf_id(zvrf), type, vrf_id_route);
 		if (rnh) {
 			client->nh_dereg_time = monotime(NULL);
 			zebra_remove_rnh_client(rnh, client, type);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1040,6 +1040,7 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 	uint8_t flags = 0;
 	uint16_t type = cmd2type[hdr->command];
 	bool exist;
+	vrf_id_t vrf_id_route;
 
 	if (IS_ZEBRA_DEBUG_NHT)
 		zlog_debug(
@@ -1084,6 +1085,9 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 				p.family);
 			return;
 		}
+		STREAM_GETL(s, vrf_id_route);
+		l += 4;
+
 		rnh = zebra_add_rnh(&p, zvrf_id(zvrf), type, &exist);
 		if (!rnh)
 			return;
@@ -1123,6 +1127,7 @@ static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
 	struct prefix p;
 	unsigned short l = 0;
 	uint16_t type = cmd2type[hdr->command];
+	vrf_id_t vrf_id_route;
 
 	if (IS_ZEBRA_DEBUG_NHT)
 		zlog_debug(
@@ -1169,6 +1174,9 @@ static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
 				p.family);
 			return;
 		}
+		STREAM_GETL(s, vrf_id_route);
+		l += 4;
+
 		rnh = zebra_lookup_rnh(&p, zvrf_id(zvrf), type);
 		if (rnh) {
 			client->nh_dereg_time = monotime(NULL);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1516,7 +1516,6 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 			}
 			/* MPLS labels for BGP-LU or Segment Routing */
 			if (CHECK_FLAG(api.message, ZAPI_MESSAGE_LABEL)
-			    && api_nh->type != NEXTHOP_TYPE_IFINDEX
 			    && api_nh->type != NEXTHOP_TYPE_BLACKHOLE) {
 				enum lsp_types_t label_type;
 

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1070,9 +1070,16 @@ void rib_install_kernel(struct route_node *rn, struct route_entry *re,
 				if (prev == nexthop)
 					break;
 				if (nexthop_same_firsthop(nexthop, prev)) {
-					SET_FLAG(nexthop->flags,
-						 NEXTHOP_FLAG_DUPLICATE);
-					break;
+					if (!nexthop->nh_label && !prev->nh_label) {
+						SET_FLAG(nexthop->flags,
+							 NEXTHOP_FLAG_DUPLICATE);
+						break;
+					}
+					if (nexthop_labels_match(nexthop, prev)) {
+						SET_FLAG(nexthop->flags,
+							 NEXTHOP_FLAG_DUPLICATE);
+						break;
+					}
 				}
 			}
 		}

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -905,6 +905,7 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 			 __FUNCTION__, rn->p.family);
 		break;
 	}
+	stream_putl(s, rnh->vrf_id_route);
 	if (re) {
 		stream_putc(s, re->type);
 		stream_putw(s, re->instance);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1055,13 +1055,22 @@ static void print_rnh(struct rnh *rnh, struct vty *vty)
 	char buf[BUFSIZ];
 	struct route_node *rn = rnh->node;
 
-	vty_out(vty, "%s%s\n",
+	vty_out(vty, "%s%s",
 		inet_ntop(rn->p.family, &rn->p.u.prefix, buf, BUFSIZ),
 		CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED) ? "(Connected)"
 							    : "");
+	if (rnh->vrf_id != rnh->vrf_id_route)
+		vty_out(vty, " from vrf %s",
+			vrf_id_to_name(rnh->vrf_id_route));
+	vty_out(vty, "\n");
 	if (rnh->state) {
-		vty_out(vty, " resolved via %s\n",
+		vty_out(vty, " resolved via %s",
 			zebra_route_string(rnh->state->type));
+		if (rnh->xvrf_ifindex)
+			vty_out(vty, " (recursive, using %s)",
+				ifindex2ifname(rnh->xvrf_ifindex,
+					       rnh->vrf_id_route));
+		vty_out(vty, "\n");
 		for (nexthop = rnh->state->ng.nexthop; nexthop;
 		     nexthop = nexthop->next)
 			print_nh(nexthop, vty);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -996,6 +996,12 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 								* sizeof(mpls_label_t));
 				} else
 					stream_putc(s, 0);
+				if (CHECK_FLAG(nh->flags,
+					       NEXTHOP_FLAG_RECURSIVE)
+				    && nh->resolved && nh->resolved->ifindex) {
+					stream_putl(s, nh->resolved->ifindex);
+				} else
+					stream_putl(s, 0);
 				num++;
 			}
 		stream_putc_at(s, nump, num);

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -50,6 +50,12 @@ struct rnh {
 	 * if this has been filtered for the client
 	 */
 	int filtered[ZEBRA_ROUTE_MAX];
+
+	/* interface index of veth
+	 * used in vrf route leak case
+	 * with netns backend vrfs
+	 */
+	ifindex_t xvrf_ifindex;
 };
 
 typedef enum { RNH_NEXTHOP_TYPE, RNH_IMPORT_CHECK_TYPE } rnh_type_t;

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -35,6 +35,7 @@ struct rnh {
 
 	/* VRF identifier. */
 	vrf_id_t vrf_id;
+	vrf_id_t vrf_id_route;
 
 	struct route_entry *state;
 	struct prefix resolved_route;
@@ -68,9 +69,10 @@ static inline int rnh_resolve_via_default(int family)
 }
 
 extern struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid,
-				 rnh_type_t type, bool *exists);
+				 rnh_type_t type, bool *exists,
+				 vrf_id_t vrfid_route);
 extern struct rnh *zebra_lookup_rnh(struct prefix *p, vrf_id_t vrfid,
-				    rnh_type_t type);
+				    rnh_type_t type, vrf_id_t vrfid_route);
 extern void zebra_free_rnh(struct rnh *rnh);
 extern void zebra_add_rnh_client(struct rnh *rnh, struct zserv *client,
 				 rnh_type_t type, vrf_id_t vrfid);

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -360,8 +360,15 @@ void zebra_rtable_node_cleanup(struct route_table *table,
 static void zebra_rnhtable_node_cleanup(struct route_table *table,
 					struct route_node *node)
 {
+	struct listnode *nn, *next;
+	struct rnh *rnh;
+
+	for (ALL_LIST_ELEMENTS((struct list *)node->info,
+			       nn, next, rnh))
+		if (rnh)
+			zebra_free_rnh(rnh);
 	if (node->info)
-		zebra_free_rnh(node->info);
+		list_delete((struct list **)&node->info);
 }
 
 /*

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -196,7 +196,9 @@ extern struct route_table *
 zebra_vrf_other_route_table(afi_t afi, uint32_t table_id, vrf_id_t vrf_id);
 extern int zebra_vrf_has_config(struct zebra_vrf *zvrf);
 extern void zebra_vrf_init(void);
-
+/* call nexthop tracking if needed */
+extern void zebra_vrf_route_leak_interface_updated(struct zebra_vrf *zvrf,
+						   struct interface *ifp);
 extern void zebra_rtable_node_cleanup(struct route_table *table,
 				      struct route_node *node);
 #endif /* ZEBRA_VRF_H */


### PR DESCRIPTION
This is the first version of netns based vrf route leak support:
use case : BGP L3VPN with and without MPLS.

this pr relies on a veth pair framework that must be created before.
an example is illustrated below.
   ip link add vrf1 type veth peer name vrf2
   ip link set dev vrf1 arp off
   ip link set dev vrf2 arp off
   ip link set dev vrf1 address 00:80:ed:01:01:01
   ip link set dev vrf2 address 00:80:ed:01:01:01
   ip link set vrf1 netns vrf2
   ip link set vrf2 netns vrf1

some documentation is available for understanding, as well as commit logs.

what is not yet handled is the creation of the veth pair framework, since this may be problematic for the user if there is a fault in the configuration. 
I expect however that frr way of working with that framework will be configurable ( meaning the framework will be created from outside).
 
