### PR TITLE
ldpd: fix missing return value in bindany

### DIFF
--- a/ldpd/socket.c
+++ b/ldpd/socket.c
@@ -276,6 +276,7 @@ sock_set_bindany(int fd, int enable)
 			return (-1);
 		}
 	}
+	return (0);
 #else
 	log_warnx(
 		"%s: missing SO_BINDANY, IP_FREEBIND and IP_BINDANY, unable to bind to a nonlocal IP address",


### PR DESCRIPTION
One of the socket utilities was missing a return value in one of its ifdef'd paths; that was producing a compiler warning.

### Components
ldpd