### PR TITLE
bgpd: Use string length not sizeof the array

### DIFF
--- a/bgpd/bgp_clist.h
+++ b/bgpd/bgp_clist.h
@@ -173,7 +173,7 @@ lcommunity_list_match_delete(struct lcommunity *lcom,
 
 static inline uint32_t bgp_clist_hash_key(char *name)
 {
-	return jhash(name, sizeof(name), 0xdeadbeaf);
+	return jhash(name, strlen(name), 0xdeadbeaf);
 }
 
 #endif /* _QUAGGA_BGP_CLIST_H */


### PR DESCRIPTION
strlen is the same as sizeof when the memory is dynamically allocated
but it is not the same when the memory being looked at is an array.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
