### PR TITLE
[6.0] ospfd: fix no virtual-link cmd

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -1199,14 +1199,17 @@ DEFUN (no_ospf_area_vlink,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	vl_data = ospf_vl_lookup(ospf, area, vl_config.vl_peer);
+	if (!vl_data) {
+		vty_out(vty, "Virtual link does not exist\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
 	if (argc <= 5) {
 		/* Basic VLink no command */
 		/* Thats all folks! - BUGS B. strikes again!!!*/
-		if ((vl_data = ospf_vl_lookup(ospf, area, vl_config.vl_peer)))
-			ospf_vl_delete(ospf, vl_data);
-
+		ospf_vl_delete(ospf, vl_data);
 		ospf_area_check_free(ospf, vl_config.area_id);
-
 		return CMD_SUCCESS;
 	}
 


### PR DESCRIPTION
fix a minor bug in ospfd virtual link command
Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>

### Summary
the `no area x.x.x.x virtual-link y.y.y.y` command was not checking
correctly in all cases whether the virtual link existed. This caused
bugs in some corner cases, e.g. when two virtual links were created,
one of them was deleted, and the second one was reset with the optional
authentication parameter - this would instead create a new virtual link with
the area in decimal format.

### Related Issue
N/A

### Components
ospfd
