### PR TITLE
Correct Zebra debug kernel message

### DIFF
--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -738,9 +738,8 @@ static void ifam_read_mesg(struct ifa_msghdr *ifm, union sockunion *addr,
 	if (IS_ZEBRA_DEBUG_KERNEL) {
 		int family = sockunion_family(addr);
 		switch (family) {
-		case AF_INET:
-		case AF_INET6: {
-			char buf[4][INET6_ADDRSTRLEN];
+		case AF_INET: {
+			char buf[4][INET_ADDRSTRLEN];
 			zlog_debug(
 				"%s: ifindex %d, ifname %s, ifam_addrs 0x%x, "
 				"ifam_flags 0x%x, addr %s/%d broad %s dst %s "
@@ -756,6 +755,25 @@ static void ifam_read_mesg(struct ifa_msghdr *ifm, union sockunion *addr,
 				inet_ntop(family, &dst.sin.sin_addr, buf[2],
 					  sizeof(buf[2])),
 				inet_ntop(family, &gateway.sin.sin_addr, buf[3],
+					  sizeof(buf[3])));
+		} break;
+		case AF_INET6: {
+			char buf[4][INET6_ADDRSTRLEN];
+			zlog_debug(
+				"%s: ifindex %d, ifname %s, ifam_addrs 0x%x, "
+				"ifam_flags 0x%x, addr %s/%d broad %s dst %s "
+				"gateway %s",
+				__func__, ifm->ifam_index,
+				(ifnlen ? ifname : "(nil)"), ifm->ifam_addrs,
+				ifm->ifam_flags,
+				inet_ntop(family, &addr->sin6.sin6_addr, buf[0],
+					  sizeof(buf[0])),
+				ip6_masklen(mask->sin6.sin6_addr),
+				inet_ntop(family, &brd->sin6.sin6_addr, buf[1],
+					  sizeof(buf[1])),
+				inet_ntop(family, &dst.sin6.sin6_addr, buf[2],
+					  sizeof(buf[2])),
+				inet_ntop(family, &gateway.sin6.sin6_addr, buf[3],
 					  sizeof(buf[3])));
 		} break;
 		default:


### PR DESCRIPTION
### Summary
Debug kernel message for ipv6 in ifam_read_mesg is wrong.

### Components
[zebra]