### PR TITLE
python: make DEFPY provide the text token of fixed parameters

### DIFF
--- a/python/clidef.py
+++ b/python/clidef.py
@@ -41,7 +41,7 @@ class RenderHandler(object):
 class StringHandler(RenderHandler):
     argtype = 'const char *'
     decl = Template('const char *$varname = NULL;')
-    code = Template('$varname = argv[_i]->arg;')
+    code = Template('$varname = (argv[_i]->type == WORD_TKN) ? argv[_i]->text : argv[_i]->arg;')
     drop_str = True
     canfail = False
 


### PR DESCRIPTION
In the CLI code, each cmd_token has both a "text" field, containing
the full token text (e.g. "unicast"), and an "arg" field,
containing the original text entered by the user (which might be
an abbreviation, like "uni" instead of "unicast").

To avoid the need to handle abbreviations, the recommended pattern
for DEFUN commands is to use the "text" value of fixed parameters
and the "arg" value of everything else.

Using DEFPY, however, the CLI parameters are automagically turned
into C variables which are initialized under the hood (so that
they're conveniently ready for use). The problem is that this
initialization was always using the "arg" value of the parameters,
which was leading to problems like these:

  debian# show ipv6 route isi
  Unknown route type
  debian#
  debian# conf t
  debian(config)# router isis 1
  debian(config-router)# redistribute ipv4 st level-1
  % Configuration failed.

  Invalid value "st" in "protocol" element.
  YANG path: /frr-isisd:isis/instance[area-tag='1']/redistribute/ipv4[protocol='st']/protocol

To fix these problems (and probably others too), make DEFPY commands
auto-detect the type of the input parameters and use either the
"arg" or "text" value from the cmd_tokens accordingly.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>