### PR TITLE
7.0: zebra: fix a few problems with routing socket

### DIFF
--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -909,7 +909,7 @@ static int rtm_read_mesg(struct rt_msghdr *rtm, union sockunion *dest,
 			pnt += rta_get(pnt, gate, sizeof(*gate));
 			break;
 		case RTA_NETMASK:
-			pnt += rta_get(pnt, mask, sizeof(*mask));
+			pnt += rta_getattr(pnt, mask, sizeof(*mask));
 			break;
 		case RTA_IFP:
 			pnt += rta_getsdlname(pnt, ifname, ifnlen);

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -273,7 +273,7 @@ size_t _rta_get(caddr_t sap, void *destp, size_t destlen, bool checkaf)
 		if (sa->sa_family == AF_LINK) {
 			sdl = (struct sockaddr_dl *)sa;
 			if (sdl->sdl_index == 0 || sdl->sdl_nlen == 0)
-				copylen = sizeof(*sdl) - sizeof(sdl->sdl_data);
+				copylen = destlen;
 		}
 
 		if (copylen > destlen) {

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -236,6 +236,7 @@ size_t _rta_get(caddr_t sap, void *destp, size_t destlen, bool checkaf);
 size_t rta_get(caddr_t sap, void *dest, size_t destlen);
 size_t rta_getattr(caddr_t sap, void *destp, size_t destlen);
 size_t rta_getsdlname(caddr_t sap, void *dest, short *destlen);
+const char *rtatostr(unsigned int flags, char *buf, size_t buflen);
 
 /* Supported address family check. */
 static inline int af_check(int family)
@@ -327,6 +328,85 @@ size_t rta_getsdlname(caddr_t sap, void *destp, short *destlen)
 		*destlen = 0;
 
 	return tlen;
+}
+
+const char *rtatostr(unsigned int flags, char *buf, size_t buflen)
+{
+	const char *flagstr, *bufstart;
+	int bit, wlen;
+	char ustr[32];
+
+	/* Hold the pointer to the buffer beginning. */
+	bufstart = buf;
+
+	for (bit = 1; bit; bit <<= 1) {
+		if ((flags & bit) == 0)
+			continue;
+
+		switch (bit) {
+		case RTA_DST:
+			flagstr = "DST";
+			break;
+		case RTA_GATEWAY:
+			flagstr = "GATEWAY";
+			break;
+		case RTA_NETMASK:
+			flagstr = "NETMASK";
+			break;
+#ifdef RTA_GENMASK
+		case RTA_GENMASK:
+			flagstr = "GENMASK";
+			break;
+#endif /* RTA_GENMASK */
+		case RTA_IFP:
+			flagstr = "IFP";
+			break;
+		case RTA_IFA:
+			flagstr = "IFA";
+			break;
+#ifdef RTA_AUTHOR
+		case RTA_AUTHOR:
+			flagstr = "AUTHOR";
+			break;
+#endif /* RTA_AUTHOR */
+		case RTA_BRD:
+			flagstr = "BRD";
+			break;
+#ifdef RTA_SRC
+		case RTA_SRC:
+			flagstr = "SRC";
+			break;
+#endif /* RTA_SRC */
+#ifdef RTA_SRCMASK
+		case RTA_SRCMASK:
+			flagstr = "SRCMASK";
+			break;
+#endif /* RTA_SRCMASK */
+#ifdef RTA_LABEL
+		case RTA_LABEL:
+			flagstr = "LABEL";
+			break;
+#endif /* RTA_LABEL */
+
+		default:
+			snprintf(ustr, sizeof(ustr), "0x%x", bit);
+			flagstr = ustr;
+			break;
+		}
+
+		wlen = snprintf(buf, buflen, "%s,", flagstr);
+		buf += wlen;
+		buflen -= wlen;
+	}
+
+	/* Check for empty buffer. */
+	if (bufstart != buf)
+		buf--;
+
+	/* Remove the last comma. */
+	*buf = 0;
+
+	return bufstart;
 }
 
 /* Dump routing table flag for debug purpose. */
@@ -443,6 +523,7 @@ int ifm_read(struct if_msghdr *ifm)
 	short ifnlen = 0;
 	int maskbit;
 	caddr_t cp;
+	char fbuf[64];
 
 	/* terminate ifname at head (for strnlen) and tail (for safety) */
 	ifname[IFNAMSIZ - 1] = '\0';
@@ -488,8 +569,9 @@ int ifm_read(struct if_msghdr *ifm)
 	}
 
 	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug("%s: sdl ifname %s", __func__,
-			   (ifnlen ? ifname : "(nil)"));
+		zlog_debug("%s: sdl ifname %s addrs {%s}", __func__,
+			   (ifnlen ? ifname : "(nil)"),
+			   rtatostr(ifm->ifm_addrs, fbuf, sizeof(fbuf)));
 
 	/*
 	 * Look up on ifindex first, because ifindices are the primary handle
@@ -687,6 +769,7 @@ static void ifam_read_mesg(struct ifa_msghdr *ifm, union sockunion *addr,
 	union sockunion dst;
 	union sockunion gateway;
 	int maskbit;
+	char fbuf[64];
 
 	pnt = (caddr_t)(ifm + 1);
 	end = ((caddr_t)ifm) + ifm->ifam_msglen;
@@ -745,11 +828,12 @@ static void ifam_read_mesg(struct ifa_msghdr *ifm, union sockunion *addr,
 					? ip_masklen(mask->sin.sin_addr)
 					: ip6_masklen(mask->sin6.sin6_addr);
 			zlog_debug(
-				"%s: ifindex %d, ifname %s, ifam_addrs 0x%x, "
+				"%s: ifindex %d, ifname %s, ifam_addrs {%s}, "
 				"ifam_flags 0x%x, addr %s/%d broad %s dst %s "
 				"gateway %s",
 				__func__, ifm->ifam_index,
-				(ifnlen ? ifname : "(nil)"), ifm->ifam_addrs,
+				(ifnlen ? ifname : "(nil)"),
+				rtatostr(ifm->ifam_addrs, fbuf, sizeof(fbuf)),
 				ifm->ifam_flags,
 				sockunion2str(addr, buf[0], sizeof(buf[0])),
 				masklen,
@@ -759,10 +843,11 @@ static void ifam_read_mesg(struct ifa_msghdr *ifm, union sockunion *addr,
 					      sizeof(buf[2])));
 		} break;
 		default:
-			zlog_debug("%s: ifindex %d, ifname %s, ifam_addrs 0x%x",
+			zlog_debug("%s: ifindex %d, ifname %s, ifam_addrs {%s}",
 				   __func__, ifm->ifam_index,
 				   (ifnlen ? ifname : "(nil)"),
-				   ifm->ifam_addrs);
+				   rtatostr(ifm->ifam_addrs, fbuf,
+					    sizeof(fbuf)));
 			break;
 		}
 	}
@@ -950,6 +1035,7 @@ void rtm_read(struct rt_msghdr *rtm)
 	struct prefix p;
 	ifindex_t ifindex = 0;
 	afi_t afi;
+	char fbuf[64];
 
 	zebra_flags = 0;
 
@@ -959,9 +1045,10 @@ void rtm_read(struct rt_msghdr *rtm)
 	if (!(flags & RTF_DONE))
 		return;
 	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug("%s: got rtm of type %d (%s)", __func__,
+		zlog_debug("%s: got rtm of type %d (%s) addrs {%s}", __func__,
 			   rtm->rtm_type,
-			   lookup_msg(rtm_type_str, rtm->rtm_type, NULL));
+			   lookup_msg(rtm_type_str, rtm->rtm_type, NULL),
+			   rtatostr(rtm->rtm_addrs, fbuf, sizeof(fbuf)));
 
 #ifdef RTF_CLONED /*bsdi, netbsd 1.6*/
 	if (flags & RTF_CLONED)
@@ -1207,12 +1294,14 @@ int rtm_write(int message, union sockunion *dest, union sockunion *mask,
 /* For debug purpose. */
 static void rtmsg_debug(struct rt_msghdr *rtm)
 {
+	char fbuf[64];
+
 	zlog_debug("Kernel: Len: %d Type: %s", rtm->rtm_msglen,
 		   lookup_msg(rtm_type_str, rtm->rtm_type, NULL));
 	rtm_flag_dump(rtm->rtm_flags);
 	zlog_debug("Kernel: message seq %d", rtm->rtm_seq);
-	zlog_debug("Kernel: pid %lld, rtm_addrs 0x%x", (long long)rtm->rtm_pid,
-		   rtm->rtm_addrs);
+	zlog_debug("Kernel: pid %lld, rtm_addrs {%s}", (long long)rtm->rtm_pid,
+		   rtatostr(rtm->rtm_addrs, fbuf, sizeof(fbuf)));
 }
 
 /* This is pretty gross, better suggestions welcome -- mhandler */

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -44,30 +44,6 @@
 
 extern struct zebra_privs_t zserv_privs;
 
-#ifdef HAVE_STRUCT_SOCKADDR_IN_SIN_LEN
-/* Adjust netmask socket length. Return value is a adjusted sin_len
-   value. */
-static int sin_masklen(struct in_addr mask)
-{
-	char *p, *lim;
-	int len;
-	struct sockaddr_in sin;
-
-	if (mask.s_addr == 0)
-		return sizeof(long);
-
-	sin.sin_addr = mask;
-	len = sizeof(struct sockaddr_in);
-
-	lim = (char *)&sin.sin_addr;
-	p = lim + sizeof(sin.sin_addr);
-
-	while (*--p == 0 && p >= lim)
-		len--;
-	return len;
-}
-#endif /* HAVE_STRUCT_SOCKADDR_IN_SIN_LEN */
-
 #ifdef __OpenBSD__
 static int kernel_rtm_add_labels(struct mpls_label_stack *nh_label,
 				 struct sockaddr_mpls *smpls)
@@ -88,30 +64,6 @@ static int kernel_rtm_add_labels(struct mpls_label_stack *nh_label,
 	return 0;
 }
 #endif
-
-#ifdef SIN6_LEN
-/* Calculate sin6_len value for netmask socket value. */
-static int sin6_masklen(struct in6_addr mask)
-{
-	struct sockaddr_in6 sin6;
-	char *p, *lim;
-	int len;
-
-	if (IN6_IS_ADDR_UNSPECIFIED(&mask))
-		return sizeof(long);
-
-	sin6.sin6_addr = mask;
-	len = sizeof(struct sockaddr_in6);
-
-	lim = (char *)&sin6.sin6_addr;
-	p = lim + sizeof(sin6.sin6_addr);
-
-	while (*--p == 0 && p >= lim)
-		len--;
-
-	return len;
-}
-#endif /* SIN6_LEN */
 
 /* Interface between zebra message and rtm message. */
 static int kernel_rtm(int cmd, const struct prefix *p,

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -154,23 +154,21 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 	switch (p->family) {
 	case AF_INET:
 		sin_dest.sin.sin_family = AF_INET;
-#ifdef HAVE_STRUCT_SOCKADDR_IN_SIN_LEN
-		sin_dest.sin.sin_len = sizeof(sin_dest);
-		sin_gate.sin.sin_len = sizeof(sin_gate);
-#endif /* HAVE_STRUCT_SOCKADDR_IN_SIN_LEN */
 		sin_dest.sin.sin_addr = p->u.prefix4;
 		sin_gate.sin.sin_family = AF_INET;
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+		sin_dest.sin.sin_len = sizeof(struct sockaddr_in);
+		sin_gate.sin.sin_len = sizeof(struct sockaddr_in);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 		break;
 	case AF_INET6:
 		sin_dest.sin6.sin6_family = AF_INET6;
-#ifdef SIN6_LEN
-		sin_dest.sin6.sin6_len = sizeof(sin_dest);
-#endif /* SIN6_LEN */
 		sin_dest.sin6.sin6_addr = p->u.prefix6;
 		sin_gate.sin6.sin6_family = AF_INET6;
-#ifdef HAVE_STRUCT_SOCKADDR_IN_SIN_LEN
-		sin_gate.sin6.sin6_len = sizeof(sin_gate);
-#endif /* HAVE_STRUCT_SOCKADDR_IN_SIN_LEN */
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+		sin_dest.sin6.sin6_len = sizeof(struct sockaddr_in6);
+		sin_gate.sin6.sin6_len = sizeof(struct sockaddr_in6);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 		break;
 	}
 
@@ -192,6 +190,9 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 		case NEXTHOP_TYPE_IPV4_IFINDEX:
 			sin_gate.sin.sin_addr = nexthop->gate.ipv4;
 			sin_gate.sin.sin_family = AF_INET;
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+			sin_gate.sin.sin_len = sizeof(struct sockaddr_in);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 			ifindex = nexthop->ifindex;
 			gate = true;
 			break;
@@ -199,6 +200,9 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
 			sin_gate.sin6.sin6_addr = nexthop->gate.ipv6;
 			sin_gate.sin6.sin6_family = AF_INET6;
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+			sin_gate.sin6.sin6_len = sizeof(struct sockaddr_in6);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 			ifindex = nexthop->ifindex;
 /* Under kame set interface index to link local address */
 #ifdef KAME
@@ -227,6 +231,10 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 				struct in_addr loopback;
 				loopback.s_addr = htonl(INADDR_LOOPBACK);
 				sin_gate.sin.sin_addr = loopback;
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+				sin_gate.sin.sin_len =
+					sizeof(struct sockaddr_in);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 				gate = true;
 			}
 				break;
@@ -239,18 +247,16 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 		case AF_INET:
 			masklen2ip(p->prefixlen, &sin_mask.sin.sin_addr);
 			sin_mask.sin.sin_family = AF_INET;
-#ifdef HAVE_STRUCT_SOCKADDR_IN_SIN_LEN
-			sin_mask.sin.sin_len = sin_masklen(
-				sin_mask.sin.sin_addr);
-#endif /* HAVE_STRUCT_SOCKADDR_IN_SIN_LEN */
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+			sin_mask.sin.sin_len = sizeof(struct sockaddr_in);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 			break;
 		case AF_INET6:
 			masklen2ip6(p->prefixlen, &sin_mask.sin6.sin6_addr);
 			sin_mask.sin6.sin6_family = AF_INET6;
-#ifdef SIN6_LEN
-			sin_mask.sin6.sin6_len = sin6_masklen(
-				sin_mask.sin6.sin6_addr);
-#endif /* SIN6_LEN */
+#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
+			sin_mask.sin6.sin6_len = sizeof(struct sockaddr_in6);
+#endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 			break;
 		}
 

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -80,6 +80,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 	ifindex_t ifindex = 0;
 	bool gate = false;
 	int error;
+	char gate_buf[INET6_BUFSIZ];
 	char prefix_buf[PREFIX_STRLEN];
 	enum blackhole_type bh_type = BLACKHOLE_UNSPEC;
 
@@ -135,7 +136,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 
 		smplsp = NULL;
 		gate = false;
-		char gate_buf[INET_ADDRSTRLEN] = "NULL";
+		snprintf(gate_buf, sizeof(gate_buf), "NULL");
 
 		switch (nexthop->type) {
 		case NEXTHOP_TYPE_IPV4:
@@ -224,13 +225,29 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 
 		if (IS_ZEBRA_DEBUG_KERNEL) {
 			if (!gate) {
-				zlog_debug("%s: %s: attention! gate not found for re",
-					   __func__, prefix_buf);
-			} else
-				inet_ntop(p->family == AFI_IP ? AF_INET
-					  : AF_INET6,
-					  &sin_gate.sin.sin_addr,
-					  gate_buf, INET_ADDRSTRLEN);
+				zlog_debug(
+					"%s: %s: attention! gate not found for re",
+					__func__, prefix_buf);
+			} else {
+				switch (p->family) {
+				case AFI_IP:
+					inet_ntop(AF_INET,
+						  &sin_gate.sin.sin_addr,
+						  gate_buf, sizeof(gate_buf));
+					break;
+
+				case AFI_IP6:
+					inet_ntop(AF_INET6,
+						  &sin_gate.sin6.sin6_addr,
+						  gate_buf, sizeof(gate_buf));
+					break;
+
+				default:
+					snprintf(gate_buf, sizeof(gate_buf),
+						 "(invalid-af)");
+					break;
+				}
+			}
 		}
 		switch (error) {
 			/* We only flag nexthops as being in FIB if

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -83,7 +83,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 	char prefix_buf[PREFIX_STRLEN];
 	enum blackhole_type bh_type = BLACKHOLE_UNSPEC;
 
-	if (IS_ZEBRA_DEBUG_RIB)
+	if (IS_ZEBRA_DEBUG_RIB || IS_ZEBRA_DEBUG_KERNEL)
 		prefix2str(p, prefix_buf, sizeof(prefix_buf));
 
 	/*
@@ -259,12 +259,11 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 
 			/* Note any unexpected status returns */
 		default:
-			flog_err(EC_LIB_SYSTEM_CALL,
-				 "%s: %s: rtm_write() unexpectedly returned %d for command %s",
-				 __func__,
-				 prefix2str(p, prefix_buf,
-					    sizeof(prefix_buf)),
-				 error, lookup_msg(rtm_type_str, cmd, NULL));
+			flog_err(
+				EC_LIB_SYSTEM_CALL,
+				"%s: %s: rtm_write() unexpectedly returned %d for command %s",
+				__func__, prefix_buf, error,
+				lookup_msg(rtm_type_str, cmd, NULL));
 			break;
 		}
 	} /* for (ALL_NEXTHOPS(...))*/
@@ -272,9 +271,9 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 	/* If there was no useful nexthop, then complain. */
 	if (nexthop_num == 0) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug("%s: No useful nexthops were found in RIB prefix %s",
-				   __func__, prefix2str(p, prefix_buf,
-							sizeof(prefix_buf)));
+			zlog_debug(
+				"%s: No useful nexthops were found in RIB prefix %s",
+				__func__, prefix_buf);
 		return 1;
 	}
 


### PR DESCRIPTION
### Summary

@mwinter-osr found a few problems running `dev/7.0` on FreeBSD and this PR attempts to fix them.

  * IPv6 interface addresses weren't being properly announced in `zebra` because of the netmask handling;
  * The routing socket code debug messages were not handling IPv6 properly;

This PR adds code to fix the above mentioned issues and improve on the routing socket debug messages.


### Related Issue

#3538


### Components

`zebra`
