### PR TITLE
zebra: Add code to track sequence number from zebra_router

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -24,6 +24,7 @@
 #include "lib/memory.h"
 #include "lib/queue.h"
 #include "lib/zebra.h"
+#include "zebra/zebra_router.h"
 #include "zebra/zebra_memory.h"
 #include "zebra/zserv.h"
 #include "zebra/zebra_dplane.h"
@@ -863,7 +864,7 @@ static int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx,
 	/* Trying out the sequence number idea, so we can try to detect
 	 * when a result is stale.
 	 */
-	re->dplane_sequence++;
+	re->dplane_sequence = zebra_router_get_next_sequence();
 	ctx->zd_seq = re->dplane_sequence;
 
 	ret = AOK;
@@ -1012,7 +1013,8 @@ dplane_route_update_internal(struct route_node *rn,
 		    old_re && (old_re != re)) {
 			ctx->zd_is_update = true;
 
-			old_re->dplane_sequence++;
+			old_re->dplane_sequence =
+				zebra_router_get_next_sequence();
 			ctx->zd_old_seq = old_re->dplane_sequence;
 
 			ctx->u.rinfo.zd_old_tag = old_re->tag;

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -21,6 +21,9 @@
  */
 #include "zebra.h"
 
+#include <pthread.h>
+#include "lib/frratomic.h"
+
 #include "zebra_router.h"
 #include "zebra_memory.h"
 #include "zebra_pbr.h"
@@ -169,6 +172,13 @@ static void zebra_router_free_table(struct zebra_router_table *zrt)
 	XFREE(MTYPE_ZEBRA_NS, zrt);
 }
 
+uint32_t zebra_router_get_next_sequence(void)
+{
+	return 1
+	       + atomic_fetch_add_explicit(&zrouter.sequence_num, 1,
+					   memory_order_relaxed);
+}
+
 void zebra_router_terminate(void)
 {
 	struct zebra_router_table *zrt, *tmp;
@@ -194,6 +204,8 @@ void zebra_router_terminate(void)
 
 void zebra_router_init(void)
 {
+	zrouter.sequence_num = 0;
+
 	zebra_vxlan_init();
 	zebra_mlag_init();
 

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -62,6 +62,9 @@ struct zebra_router {
 #if defined(HAVE_RTADV)
 	struct rtadv rtadv;
 #endif /* HAVE_RTADV */
+
+	/* A sequence number used for tracking routes */
+	_Atomic uint32_t sequence_num;
 };
 
 extern struct zebra_router zrouter;
@@ -83,4 +86,6 @@ extern unsigned long zebra_router_score_proto(uint8_t proto,
 extern void zebra_router_sweep_route(void);
 
 extern void zebra_router_show_table_summary(struct vty *vty);
+
+extern uint32_t zebra_router_get_next_sequence(void);
 #endif


### PR DESCRIPTION
The sequence number used should be unique and increase by 1
for netlink commands.  This will allow the code to match
up batched commands to actual requests, so that we can signal
the failure correctly back.

So start the movement and tracking of sequence numbers as
an atomic uint32_t in zebra_router.  Modify the dataplane
code to start tracking contexts from this value.

In future commits we will move more of the sequencing
data into using this value.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
