### PR TITLE
topotests: Modify bgp convergence to be more than 120 seconds

### DIFF
--- a/tests/topotests/bfd-topo1/test_bfd_topo1.py
+++ b/tests/topotests/bfd-topo1/test_bfd_topo1.py
@@ -138,7 +138,7 @@ def test_bgp_convergence():
         expected = json.loads(open(ref_file).read())
         test_func = partial(topotest.router_json_cmp,
                             router, 'show ip bgp summary json', expected)
-        _, res = topotest.run_and_expect(test_func, None, count=20, wait=0.5)
+        _, res = topotest.run_and_expect(test_func, None, count=125, wait=1.0)
         assertmsg = '{}: bgp did not converge'.format(router.name)
         assert res is None, assertmsg
 


### PR DESCRIPTION
Waiting 10 seconds for bgp convergence makes no sense, especially
if the test system is under load and a node is started up before
the node it is connecting to is up. We should wait for the full
default of 120 seconds, plus a little time to ensure nothing is
screwed up too much.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

