### PR TITLE
Treewide: use ANSI function definitions

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -1262,7 +1262,7 @@ DEFUN (show_babel_parameters,
 }
 
 void
-babel_if_init ()
+babel_if_init(void)
 {
     /* initialize interface list */
     hook_register_prio(if_add, 0, babel_if_new_hook);

--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -307,7 +307,7 @@ babel_initial_noise(void)
 
 /* Delete all the added babel routes, make babeld only speak to zebra. */
 static void
-babel_clean_routing_process()
+babel_clean_routing_process(void)
 {
     flush_all_routes();
     babel_interface_close_all();

--- a/babeld/message.c
+++ b/babeld/message.c
@@ -1430,7 +1430,7 @@ send_wildcard_retraction(struct interface *ifp)
 }
 
 void
-update_myseqno()
+update_myseqno(void)
 {
     myseqno = seqno_plus(myseqno, 1);
 }

--- a/babeld/neighbour.c
+++ b/babeld/neighbour.c
@@ -234,7 +234,7 @@ neighbour_txcost(struct neighbour *neigh)
 }
 
 unsigned
-check_neighbours()
+check_neighbours(void)
 {
     struct neighbour *neigh;
     int changed, rc;

--- a/babeld/resend.c
+++ b/babeld/resend.c
@@ -238,7 +238,7 @@ satisfy_request(const unsigned char *prefix, unsigned char plen,
 }
 
 void
-expire_resend()
+expire_resend(void)
 {
     struct resend *current, *previous;
     int recompute = 0;
@@ -267,7 +267,7 @@ expire_resend()
 }
 
 void
-recompute_resend_time()
+recompute_resend_time(void)
 {
     struct resend *request;
     struct timeval resend = {0, 0};
@@ -286,7 +286,7 @@ recompute_resend_time()
 }
 
 void
-do_resend()
+do_resend(void)
 {
     struct resend *resend;
 

--- a/babeld/route.c
+++ b/babeld/route.c
@@ -248,7 +248,7 @@ flush_route(struct babel_route *route)
 }
 
 void
-flush_all_routes()
+flush_all_routes(void)
 {
     int i;
 

--- a/babeld/source.c
+++ b/babeld/source.c
@@ -135,7 +135,7 @@ update_source(struct source *src,
 }
 
 void
-expire_sources()
+expire_sources(void)
 {
     struct source *src;
 

--- a/babeld/util.c
+++ b/babeld/util.c
@@ -441,7 +441,7 @@ uchar_to_in6addr(struct in6_addr *dest, const unsigned char *src)
 }
 
 int
-daemonise()
+daemonise(void)
 {
     int rc;
 

--- a/babeld/xroute.c
+++ b/babeld/xroute.c
@@ -169,7 +169,7 @@ add_xroute(unsigned char prefix[16], unsigned char plen,
 
 /* Returns an overestimate of the number of xroutes. */
 int
-xroutes_estimate()
+xroutes_estimate(void)
 {
     return numxroutes;
 }

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -288,7 +288,7 @@ void bgp_keepalives_off(struct peer *peer)
 	pthread_mutex_unlock(peerhash_mtx);
 }
 
-void bgp_keepalives_wake()
+void bgp_keepalives_wake(void)
 {
 	pthread_mutex_lock(peerhash_mtx);
 	{

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -65,7 +65,7 @@
 /********************
  * PUBLIC FUNCTIONS
  ********************/
-struct bpacket *bpacket_alloc()
+struct bpacket *bpacket_alloc(void)
 {
 	struct bpacket *pkt;
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7839,7 +7839,7 @@ static const struct cmd_variable_handler bgp_viewvrf_var_handlers[] = {
 struct frr_pthread *bgp_pth_io;
 struct frr_pthread *bgp_pth_ka;
 
-static void bgp_pthreads_init()
+static void bgp_pthreads_init(void)
 {
 	assert(!bgp_pth_io);
 	assert(!bgp_pth_ka);
@@ -7858,7 +7858,7 @@ static void bgp_pthreads_init()
 	bgp_pth_ka = frr_pthread_new(&ka, "BGP Keepalives thread", "bgpd_ka");
 }
 
-void bgp_pthreads_run()
+void bgp_pthreads_run(void)
 {
 	frr_pthread_run(bgp_pth_io, NULL);
 	frr_pthread_run(bgp_pth_ka, NULL);
@@ -7868,7 +7868,7 @@ void bgp_pthreads_run()
 	frr_pthread_wait_running(bgp_pth_ka);
 }
 
-void bgp_pthreads_finish()
+void bgp_pthreads_finish(void)
 {
 	frr_pthread_stop_all();
 	frr_pthread_finish();

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -575,7 +575,7 @@ static struct rfapi_l2_group_cfg *rfapi_l2_group_lookup_byname(struct bgp *bgp,
 	return NULL;
 }
 
-static struct rfapi_l2_group_cfg *rfapi_l2_group_new()
+static struct rfapi_l2_group_cfg *rfapi_l2_group_new(void)
 {
 	struct rfapi_l2_group_cfg *rfg;
 
@@ -1396,7 +1396,7 @@ DEFUN (vnc_export_mode,
 	return CMD_SUCCESS;
 }
 
-static struct rfapi_rfg_name *rfgn_new()
+static struct rfapi_rfg_name *rfgn_new(void)
 {
 	return XCALLOC(MTYPE_RFAPI_RFG_NAME, sizeof(struct rfapi_rfg_name));
 }

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -123,7 +123,7 @@ void rfapiDebugBacktrace(void)
  * Count remote routes and compare with actively-maintained values.
  * Abort if they disagree.
  */
-void rfapiCheckRouteCount()
+void rfapiCheckRouteCount(void)
 {
 	struct bgp *bgp = bgp_get_default();
 	struct rfapi *h;

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -222,7 +222,7 @@ void rfapiRibCheckCounts(
 	assert(t_ri_active + t_ri_deleted + t_ri_pend + offset == alloc_count);
 }
 
-static struct rfapi_info *rfapi_info_new()
+static struct rfapi_info *rfapi_info_new(void)
 {
 	return XCALLOC(MTYPE_RFAPI_INFO, sizeof(struct rfapi_info));
 }

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -4964,7 +4964,7 @@ DEFUN (clear_vrf_all,
 	return vnc_clear_vrf(vty, NULL, arg_vrf, NULL, NULL);
 }
 
-void rfapi_vty_init()
+void rfapi_vty_init(void)
 {
 	install_element(ENABLE_NODE, &add_vnc_prefix_cost_life_lnh_cmd);
 	install_element(ENABLE_NODE, &add_vnc_prefix_life_cost_lnh_cmd);

--- a/bgpd/rfp-example/librfp/rfp_example.c
+++ b/bgpd/rfp-example/librfp/rfp_example.c
@@ -107,7 +107,7 @@ DEFUN (rfp_full_table_download,
 	return CMD_SUCCESS;
 }
 
-static void rfp_vty_install()
+static void rfp_vty_install(void)
 {
 	static int installed = 0;
 	if (installed) /* do this only once */

--- a/bgpd/rfp-example/rfptest/rfptest.c
+++ b/bgpd/rfp-example/rfptest/rfptest.c
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "rfptest.h"
-int main()
+int main(void)
 {
 	printf("Your test code goes here.\n");
 	exit(1);

--- a/eigrpd/eigrp_dump.c
+++ b/eigrpd/eigrp_dump.c
@@ -605,7 +605,7 @@ static struct cmd_node eigrp_debug_node = {
 };
 
 /* Initialize debug commands. */
-void eigrp_debug_init()
+void eigrp_debug_init(void)
 {
 	install_node(&eigrp_debug_node, config_write_debug);
 

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -122,7 +122,7 @@ int eigrp_if_delete_hook(struct interface *ifp)
 
 struct list *eigrp_iflist;
 
-void eigrp_if_init()
+void eigrp_if_init(void)
 {
 	/* Initialize Zebra interface data structure. */
 	// hook_register_prio(if_add, 0, eigrp_if_new);

--- a/eigrpd/eigrp_packet.c
+++ b/eigrpd/eigrp_packet.c
@@ -1101,7 +1101,7 @@ struct eigrp_packet *eigrp_packet_duplicate(struct eigrp_packet *old,
 	return new;
 }
 
-static struct TLV_IPv4_Internal_type *eigrp_IPv4_InternalTLV_new()
+static struct TLV_IPv4_Internal_type *eigrp_IPv4_InternalTLV_new(void)
 {
 	struct TLV_IPv4_Internal_type *new;
 
@@ -1327,7 +1327,7 @@ uint16_t eigrp_add_authTLV_SHA256_to_stream(struct stream *s,
 	return 0;
 }
 
-struct TLV_MD5_Authentication_Type *eigrp_authTLV_MD5_new()
+struct TLV_MD5_Authentication_Type *eigrp_authTLV_MD5_new(void)
 {
 	struct TLV_MD5_Authentication_Type *new;
 
@@ -1342,7 +1342,7 @@ void eigrp_authTLV_MD5_free(struct TLV_MD5_Authentication_Type *authTLV)
 	XFREE(MTYPE_EIGRP_AUTH_TLV, authTLV);
 }
 
-struct TLV_SHA256_Authentication_Type *eigrp_authTLV_SHA256_new()
+struct TLV_SHA256_Authentication_Type *eigrp_authTLV_SHA256_new(void)
 {
 	struct TLV_SHA256_Authentication_Type *new;
 
@@ -1363,7 +1363,7 @@ void eigrp_IPv4_InternalTLV_free(
 	XFREE(MTYPE_EIGRP_IPV4_INT_TLV, IPv4_InternalTLV);
 }
 
-struct TLV_Sequence_Type *eigrp_SequenceTLV_new()
+struct TLV_Sequence_Type *eigrp_SequenceTLV_new(void)
 {
 	struct TLV_Sequence_Type *new;
 

--- a/eigrpd/eigrp_topology.c
+++ b/eigrpd/eigrp_topology.c
@@ -61,7 +61,7 @@ static int eigrp_nexthop_entry_cmp(struct eigrp_nexthop_entry *,
  * del - assigned function executed before deleting topology node by list
  * function
  */
-struct route_table *eigrp_topology_new()
+struct route_table *eigrp_topology_new(void)
 {
 	return route_table_init();
 }
@@ -70,7 +70,7 @@ struct route_table *eigrp_topology_new()
  * Returns new created toplogy node
  * cmp - assigned function for comparing topology entry
  */
-struct eigrp_prefix_entry *eigrp_prefix_entry_new()
+struct eigrp_prefix_entry *eigrp_prefix_entry_new(void)
 {
 	struct eigrp_prefix_entry *new;
 	new = XCALLOC(MTYPE_EIGRP_PREFIX_ENTRY,
@@ -102,7 +102,7 @@ static int eigrp_nexthop_entry_cmp(struct eigrp_nexthop_entry *entry1,
  * Returns new topology entry
  */
 
-struct eigrp_nexthop_entry *eigrp_nexthop_entry_new()
+struct eigrp_nexthop_entry *eigrp_nexthop_entry_new(void)
 {
 	struct eigrp_nexthop_entry *new;
 

--- a/eigrpd/eigrpd.c
+++ b/eigrpd/eigrpd.c
@@ -122,7 +122,7 @@ void eigrp_router_id_update(struct eigrp *eigrp)
 	}
 }
 
-void eigrp_master_init()
+void eigrp_master_init(void)
 {
 	struct timeval tv;
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -69,7 +69,7 @@ int isis_interface_config_write(struct vty *);
 int isis_if_new_hook(struct interface *);
 int isis_if_delete_hook(struct interface *);
 
-struct isis_circuit *isis_circuit_new()
+struct isis_circuit *isis_circuit_new(void)
 {
 	struct isis_circuit *circuit;
 	int i;
@@ -1393,7 +1393,7 @@ int isis_if_delete_hook(struct interface *ifp)
 	return 0;
 }
 
-void isis_circuit_init()
+void isis_circuit_init(void)
 {
 	/* Initialize Zebra interface data structure */
 	hook_register_prio(if_add, 0, isis_if_new_hook);

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1471,7 +1471,7 @@ DEFUN (show_isis_topology,
 	return CMD_SUCCESS;
 }
 
-void isis_spf_cmds_init()
+void isis_spf_cmds_init(void)
 {
 	install_element(VIEW_NODE, &show_isis_topology_cmd);
 }

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -68,7 +68,7 @@ const char *mode2text[] = {"Disable", "Area", "AS", "Emulate"};
  *------------------------------------------------------------------------*/
 
 /* Create new MPLS TE Circuit context */
-struct mpls_te_circuit *mpls_te_circuit_new()
+struct mpls_te_circuit *mpls_te_circuit_new(void)
 {
 	struct mpls_te_circuit *mtc;
 

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -2161,7 +2161,7 @@ int isis_config_write(struct vty *vty)
 
 struct cmd_node router_node = {ROUTER_NODE, "%s(config-router)# ", 1};
 
-void isis_init()
+void isis_init(void)
 {
 	/* Install IS-IS top node */
 	install_node(&router_node, isis_config_write);

--- a/lib/command.c
+++ b/lib/command.c
@@ -2883,7 +2883,7 @@ void cmd_init(int terminal)
 #endif
 }
 
-void cmd_terminate()
+void cmd_terminate(void)
 {
 	struct cmd_node *cmd_node;
 

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -2212,14 +2212,14 @@ static void access_list_init_ipv6(void)
 	install_element(CONFIG_NODE, &no_ipv6_access_list_remark_comment_cmd);
 }
 
-void access_list_init()
+void access_list_init(void)
 {
 	access_list_init_ipv4();
 	access_list_init_ipv6();
 	access_list_init_mac();
 }
 
-void access_list_reset()
+void access_list_reset(void)
 {
 	access_list_reset_ipv4();
 	access_list_reset_ipv6();

--- a/lib/frr_pthread.c
+++ b/lib/frr_pthread.c
@@ -47,7 +47,7 @@ static struct list *frr_pthread_list;
 
 /* ------------------------------------------------------------------------ */
 
-void frr_pthread_init()
+void frr_pthread_init(void)
 {
 	pthread_mutex_lock(&frr_pthread_list_mtx);
 	{
@@ -57,7 +57,7 @@ void frr_pthread_init()
 	pthread_mutex_unlock(&frr_pthread_list_mtx);
 }
 
-void frr_pthread_finish()
+void frr_pthread_finish(void)
 {
 	pthread_mutex_lock(&frr_pthread_list_mtx);
 	{
@@ -178,7 +178,7 @@ int frr_pthread_stop(struct frr_pthread *fpt, void **result)
 	return ret;
 }
 
-void frr_pthread_stop_all()
+void frr_pthread_stop_all(void)
 {
 	pthread_mutex_lock(&frr_pthread_list_mtx);
 	{

--- a/lib/graph.c
+++ b/lib/graph.c
@@ -27,7 +27,7 @@
 
 DEFINE_MTYPE_STATIC(LIB, GRAPH, "Graph")
 DEFINE_MTYPE_STATIC(LIB, GRAPH_NODE, "Graph Node")
-struct graph *graph_new()
+struct graph *graph_new(void)
 {
 	struct graph *graph = XCALLOC(MTYPE_GRAPH, sizeof(struct graph));
 	graph->nodes = vector_init(VECTOR_MIN_SIZE);

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -445,7 +445,7 @@ DEFUN_NOSH(show_hash_stats,
 	return CMD_SUCCESS;
 }
 
-void hash_cmd_init()
+void hash_cmd_init(void)
 {
 	install_element(ENABLE_NODE, &show_hash_stats_cmd);
 }

--- a/lib/if_rmap.c
+++ b/lib/if_rmap.c
@@ -287,7 +287,7 @@ int config_write_if_rmap(struct vty *vty)
 	return write;
 }
 
-void if_rmap_reset()
+void if_rmap_reset(void)
 {
 	hash_clean(ifrmaphash, (void (*)(void *))if_rmap_free);
 }

--- a/lib/keychain.c
+++ b/lib/keychain.c
@@ -1040,7 +1040,7 @@ static int keychain_config_write(struct vty *vty)
 	return 0;
 }
 
-void keychain_init()
+void keychain_init(void)
 {
 	keychain_list = list_new();
 

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -375,13 +375,8 @@ static void md5_calc(const uint8_t *b64, md5_ctxt *ctxt)
 }
 
 /* From RFC 2104 */
-void hmac_md5(text, text_len, key, key_len,
-	      digest) unsigned char *text; /* pointer to data stream */
-int text_len;				   /* length of data stream */
-unsigned char *key;			   /* pointer to authentication key */
-int key_len;				   /* length of authentication key */
-uint8_t *digest;			   /* caller digest to be filled in */
-
+void hmac_md5(unsigned char *text, int text_len, unsigned char *key,
+	      int key_len, uint8_t *digest)
 {
 	MD5_CTX context;
 	unsigned char k_ipad[65]; /* inner padding -

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -2111,7 +2111,7 @@ static void prefix_list_init_ipv6(void)
 	install_element(ENABLE_NODE, &clear_ipv6_prefix_list_cmd);
 }
 
-void prefix_list_init()
+void prefix_list_init(void)
 {
 	cmd_variable_handler_register(plist_var_handlers);
 
@@ -2119,7 +2119,7 @@ void prefix_list_init()
 	prefix_list_init_ipv6();
 }
 
-void prefix_list_reset()
+void prefix_list_reset(void)
 {
 	prefix_list_reset_afi(AFI_IP, 0);
 	prefix_list_reset_afi(AFI_IP6, 0);

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -820,7 +820,7 @@ const char *prefix_family_str(const struct prefix *p)
 }
 
 /* Allocate new prefix_ipv4 structure. */
-struct prefix_ipv4 *prefix_ipv4_new()
+struct prefix_ipv4 *prefix_ipv4_new(void)
 {
 	struct prefix_ipv4 *p;
 
@@ -1359,7 +1359,7 @@ const char *prefix2str(union prefixconstptr pu, char *str, int size)
 	return str;
 }
 
-struct prefix *prefix_new()
+struct prefix *prefix_new(void)
 {
 	struct prefix *p;
 

--- a/lib/skiplist.c
+++ b/lib/skiplist.c
@@ -88,7 +88,7 @@ static struct skiplist *skiplist_last_created; /* debugging hack */
 #endif
 
 
-static int randomLevel()
+static int randomLevel(void)
 {
 	register int level = 0;
 	register int b;

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -400,7 +400,7 @@ static void cancelreq_del(void *cr)
 }
 
 /* initializer, only ever called once */
-static void initializer()
+static void initializer(void)
 {
 	pthread_key_create(&thread_current, NULL);
 }

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -1605,7 +1605,7 @@ static int vty_flush(struct thread *thread)
 }
 
 /* Allocate new vty struct. */
-struct vty *vty_new()
+struct vty *vty_new(void)
 {
 	struct vty *new = XCALLOC(MTYPE_VTY, sizeof(struct vty));
 
@@ -3035,7 +3035,7 @@ struct cmd_node vty_node = {
 };
 
 /* Reset all VTY status. */
-void vty_reset()
+void vty_reset(void)
 {
 	unsigned int i;
 	struct vty *vty;
@@ -3100,7 +3100,7 @@ static void vty_save_cwd(void)
 	strcpy(vty_cwd, cwd);
 }
 
-char *vty_get_cwd()
+char *vty_get_cwd(void)
 {
 	return vty_cwd;
 }
@@ -3115,7 +3115,7 @@ int vty_shell_serv(struct vty *vty)
 	return vty->type == VTY_SHELL_SERV ? 1 : 0;
 }
 
-void vty_init_vtysh()
+void vty_init_vtysh(void)
 {
 	vtyvec = vector_init(VECTOR_MIN_SIZE);
 }

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1897,7 +1897,7 @@ int config_write_ospf6_debug_asbr(struct vty *vty)
 	return 0;
 }
 
-void install_element_ospf6_debug_asbr()
+void install_element_ospf6_debug_asbr(void)
 {
 	install_element(ENABLE_NODE, &debug_ospf6_asbr_cmd);
 	install_element(ENABLE_NODE, &no_debug_ospf6_asbr_cmd);

--- a/ospfd/ospf_api.c
+++ b/ospfd/ospf_api.c
@@ -300,7 +300,7 @@ uint32_t msg_get_seq(struct msg *msg)
  * -----------------------------------------------------------
  */
 
-struct msg_fifo *msg_fifo_new()
+struct msg_fifo *msg_fifo_new(void)
 {
 	return XCALLOC(MTYPE_OSPF_API_FIFO, sizeof(struct msg_fifo));
 }

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1182,7 +1182,7 @@ int ospf_vls_in_area(struct ospf_area *area)
 }
 
 
-struct crypt_key *ospf_crypt_key_new()
+struct crypt_key *ospf_crypt_key_new(void)
 {
 	return XCALLOC(MTYPE_OSPF_CRYPT_KEY, sizeof(struct crypt_key));
 }
@@ -1230,7 +1230,7 @@ uint8_t ospf_default_iftype(struct interface *ifp)
 		return OSPF_IFTYPE_BROADCAST;
 }
 
-void ospf_if_init()
+void ospf_if_init(void)
 {
 	/* Initialize Zebra interface data structure. */
 	hook_register_prio(if_add, 0, ospf_if_new_hook);

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -150,7 +150,7 @@ int ospf_lsa_checksum_valid(struct lsa_header *lsa)
 
 
 /* Create OSPF LSA. */
-struct ospf_lsa *ospf_lsa_new()
+struct ospf_lsa *ospf_lsa_new(void)
 {
 	struct ospf_lsa *new;
 

--- a/ospfd/ospf_lsdb.c
+++ b/ospfd/ospf_lsdb.c
@@ -31,7 +31,7 @@
 #include "ospfd/ospf_lsa.h"
 #include "ospfd/ospf_lsdb.h"
 
-struct ospf_lsdb *ospf_lsdb_new()
+struct ospf_lsdb *ospf_lsdb_new(void)
 {
 	struct ospf_lsdb *new;
 

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -148,7 +148,7 @@ void ospf_packet_free(struct ospf_packet *op)
 	XFREE(MTYPE_OSPF_PACKET, op);
 }
 
-struct ospf_fifo *ospf_fifo_new()
+struct ospf_fifo *ospf_fifo_new(void)
 {
 	struct ospf_fifo *new;
 

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -146,7 +146,7 @@ static int ospf_router_info_register(uint8_t scope)
 	return rc;
 }
 
-static int ospf_router_info_unregister()
+static int ospf_router_info_unregister(void)
 {
 
 	if ((OspfRI.scope != OSPF_OPAQUE_AS_LSA)

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -39,7 +39,7 @@
 #include "ospfd/ospf_zebra.h"
 #include "ospfd/ospf_dump.h"
 
-struct ospf_route *ospf_route_new()
+struct ospf_route *ospf_route_new(void)
 {
 	struct ospf_route *new;
 
@@ -51,7 +51,7 @@ struct ospf_route *ospf_route_new()
 	return new;
 }
 
-void ospf_route_free(struct ospf_route * or)
+void ospf_route_free(struct ospf_route *or)
 {
 	if (or->paths)
 		list_delete(& or->paths);
@@ -59,7 +59,7 @@ void ospf_route_free(struct ospf_route * or)
 	XFREE(MTYPE_OSPF_ROUTE, or);
 }
 
-struct ospf_path *ospf_path_new()
+struct ospf_path *ospf_path_new(void)
 {
 	struct ospf_path *new;
 

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -150,7 +150,7 @@ static int ospf_mpls_te_register(enum inter_as_mode mode)
 	return rc;
 }
 
-static int ospf_mpls_te_unregister()
+static int ospf_mpls_te_unregister(void)
 {
 	uint8_t scope;
 

--- a/pimd/pim_signals.c
+++ b/pimd/pim_signals.c
@@ -33,26 +33,26 @@
  * Signal handlers
  */
 
-static void pim_sighup()
+static void pim_sighup(void)
 {
 	zlog_info("SIGHUP received, ignoring");
 }
 
-static void pim_sigint()
+static void pim_sigint(void)
 {
 	zlog_notice("Terminating on signal SIGINT");
 	pim_terminate();
 	exit(1);
 }
 
-static void pim_sigterm()
+static void pim_sigterm(void)
 {
 	zlog_notice("Terminating on signal SIGTERM");
 	pim_terminate();
 	exit(1);
 }
 
-static void pim_sigusr1()
+static void pim_sigusr1(void)
 {
 	zlog_rotate();
 }

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -37,7 +37,7 @@ void pim_static_route_free(struct static_route *s_route)
 	XFREE(MTYPE_PIM_STATIC_ROUTE, s_route);
 }
 
-static struct static_route *static_route_alloc()
+static struct static_route *static_route_alloc(void)
 {
 	return XCALLOC(MTYPE_PIM_STATIC_ROUTE, sizeof(struct static_route));
 }

--- a/pimd/pim_time.c
+++ b/pimd/pim_time.c
@@ -47,7 +47,7 @@ static int gettime_monotonic(struct timeval *tv)
   pim_time_monotonic_sec():
   number of seconds since some unspecified starting point
 */
-int64_t pim_time_monotonic_sec()
+int64_t pim_time_monotonic_sec(void)
 {
 	struct timeval now_tv;
 
@@ -65,7 +65,7 @@ int64_t pim_time_monotonic_sec()
   pim_time_monotonic_dsec():
   number of deciseconds since some unspecified starting point
 */
-int64_t pim_time_monotonic_dsec()
+int64_t pim_time_monotonic_dsec(void)
 {
 	struct timeval now_tv;
 	int64_t now_dsec;

--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -67,7 +67,7 @@ void pim_prefix_list_update(struct prefix_list *plist)
 	}
 }
 
-static void pim_free()
+static void pim_free(void)
 {
 	pim_route_map_terminate();
 
@@ -123,7 +123,7 @@ void pim_init(void)
 	pim_cmd_init();
 }
 
-void pim_terminate()
+void pim_terminate(void)
 {
 	struct zclient *zclient;
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -563,7 +563,7 @@ int rip_if_down(struct interface *ifp)
 }
 
 /* Needed for stop RIP process. */
-void rip_if_down_all()
+void rip_if_down_all(void)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	struct interface *ifp;
@@ -964,7 +964,7 @@ void rip_enable_apply(struct interface *ifp)
 }
 
 /* Apply network configuration to all interface. */
-void rip_enable_apply_all()
+void rip_enable_apply_all(void)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	struct interface *ifp;
@@ -1029,7 +1029,7 @@ int rip_neighbor_delete(struct prefix_ipv4 *p)
 }
 
 /* Clear all network and neighbor configuration. */
-void rip_clean_network()
+void rip_clean_network(void)
 {
 	unsigned int i;
 	char *str;

--- a/ripd/rip_offset.c
+++ b/ripd/rip_offset.c
@@ -152,14 +152,14 @@ static int offset_list_cmp(struct rip_offset_list *o1,
 	return strcmp(o1->ifname, o2->ifname);
 }
 
-void rip_offset_init()
+void rip_offset_init(void)
 {
 	rip_offset_list_master = list_new();
 	rip_offset_list_master->cmp = (int (*)(void *, void *))offset_list_cmp;
 	rip_offset_list_master->del = (void (*)(void *))offset_list_del;
 }
 
-void rip_offset_clean()
+void rip_offset_clean(void)
 {
 	list_delete(&rip_offset_list_master);
 

--- a/ripd/rip_routemap.c
+++ b/ripd/rip_routemap.c
@@ -518,7 +518,7 @@ static struct route_map_rule_cmd route_set_tag_cmd = {
 #define SET_STR "Set values in destination routing protocol\n"
 
 /* Route-map init */
-void rip_route_map_init()
+void rip_route_map_init(void)
 {
 	route_map_init();
 

--- a/ripngd/ripng_debug.c
+++ b/ripngd/ripng_debug.c
@@ -207,7 +207,7 @@ static int config_write_debug(struct vty *vty)
 	return write;
 }
 
-void ripng_debug_init()
+void ripng_debug_init(void)
 {
 	ripng_debug_event = 0;
 	ripng_debug_packet = 0;

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -739,7 +739,7 @@ static void ripng_enable_apply_all(void)
 }
 
 /* Clear all network and neighbor configuration */
-void ripng_clean_network()
+void ripng_clean_network(void)
 {
 	unsigned int i;
 	char *str;
@@ -930,7 +930,7 @@ static struct cmd_node interface_node = {
 };
 
 /* Initialization of interface. */
-void ripng_if_init()
+void ripng_if_init(void)
 {
 	/* Interface initialize. */
 	hook_register_prio(if_add, 0, ripng_if_new_hook);

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -183,7 +183,7 @@ static int ripng_peer_list_cmp(struct ripng_peer *p1, struct ripng_peer *p2)
 	return memcmp(&p1->addr, &p2->addr, sizeof(struct in6_addr));
 }
 
-void ripng_peer_init()
+void ripng_peer_init(void)
 {
 	peer_list = list_new();
 	peer_list->cmp = (int (*)(void *, void *))ripng_peer_list_cmp;

--- a/ripngd/ripng_routemap.c
+++ b/ripngd/ripng_routemap.c
@@ -337,7 +337,7 @@ static struct route_map_rule_cmd route_set_tag_cmd = {
 #define MATCH_STR "Match values from routing table\n"
 #define SET_STR "Set values in destination routing protocol\n"
 
-void ripng_route_map_init()
+void ripng_route_map_init(void)
 {
 	route_map_init();
 

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -161,7 +161,7 @@ int ripng_redistribute_check(int type)
 	return vrf_bitmap_check(zclient->redist[AFI_IP6][type], VRF_DEFAULT);
 }
 
-void ripng_redistribute_clean()
+void ripng_redistribute_clean(void)
 {
 	for (int i = 0; i < ZEBRA_ROUTE_MAX; i++) {
 		if (!vrf_bitmap_check(zclient->redist[AFI_IP6][i], VRF_DEFAULT))

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -76,7 +76,7 @@ int ripng_route_rte(struct ripng_info *rinfo)
 }
 
 /* Allocate new ripng information. */
-struct ripng_info *ripng_info_new()
+struct ripng_info *ripng_info_new(void)
 {
 	struct ripng_info *new;
 
@@ -2401,7 +2401,7 @@ static void ripng_distribute_update_all_wrapper(struct access_list *notused)
 }
 
 /* delete all the added ripng routes. */
-void ripng_clean()
+void ripng_clean(void)
 {
 	int i;
 	struct agg_node *rp;
@@ -2542,7 +2542,7 @@ static void ripng_routemap_update(const char *unused)
 }
 
 /* Initialize ripng structure and set commands. */
-void ripng_init()
+void ripng_init(void)
 {
 	/* Install RIPNG_NODE. */
 	install_node(&cmd_ripng_node, ripng_config_write);

--- a/tests/bgpd/test_aspath.c
+++ b/tests/bgpd/test_aspath.c
@@ -1074,7 +1074,7 @@ static int validate(struct aspath *as, const struct test_spec *sp)
 	return fails;
 }
 
-static void empty_get_test()
+static void empty_get_test(void)
 {
 	struct aspath *as = aspath_empty_get();
 	struct test_spec sp = {"", "", 0, 0, 0, 0, 0, 0};
@@ -1219,7 +1219,7 @@ static void aggregate_test(struct tests *t)
 }
 
 /* cmp_left tests  */
-static void cmp_test()
+static void cmp_test(void)
 {
 	unsigned int i;
 #define CMP_TESTS_MAX (sizeof(left_compare) / sizeof(struct compare_tests))

--- a/tests/helpers/c/main.c
+++ b/tests/helpers/c/main.c
@@ -26,7 +26,7 @@
 #include "memory.h"
 #include "memory_vty.h"
 
-extern void test_init();
+extern void test_init(void);
 
 struct thread_master *master;
 
@@ -56,12 +56,12 @@ static int test_timer(struct thread *thread)
 	return 0;
 }
 
-static void test_timer_init()
+static void test_timer_init(void)
 {
 	thread_add_timer(master, test_timer, &timer_count, 10, NULL);
 }
 
-static void test_vty_init()
+static void test_vty_init(void)
 {
 	install_element(VIEW_NODE, &daemon_exit_cmd);
 }

--- a/tests/lib/test_heavy.c
+++ b/tests/lib/test_heavy.c
@@ -92,12 +92,12 @@ DEFUN (clear_foo,
 	return CMD_SUCCESS;
 }
 
-static void slow_vty_init()
+static void slow_vty_init(void)
 {
 	install_element(VIEW_NODE, &clear_foo_cmd);
 }
 
-void test_init()
+void test_init(void)
 {
 	slow_vty_init();
 }

--- a/tests/lib/test_heavy_thread.c
+++ b/tests/lib/test_heavy_thread.c
@@ -122,7 +122,7 @@ DEFUN (clear_foo,
 	return CMD_SUCCESS;
 }
 
-void test_init()
+void test_init(void)
 {
 	install_element(VIEW_NODE, &clear_foo_cmd);
 }

--- a/tests/lib/test_heavy_wq.c
+++ b/tests/lib/test_heavy_wq.c
@@ -139,7 +139,7 @@ DEFUN (clear_foo,
 	return CMD_SUCCESS;
 }
 
-static int heavy_wq_init()
+static int heavy_wq_init(void)
 {
 	heavy_wq = work_queue_new(master, "heavy_work_queue");
 
@@ -152,7 +152,7 @@ static int heavy_wq_init()
 	return 0;
 }
 
-void test_init()
+void test_init(void)
 {
 	install_element(VIEW_NODE, &clear_foo_cmd);
 	heavy_wq_init();

--- a/tests/lib/test_table.c
+++ b/tests/lib/test_table.c
@@ -402,7 +402,7 @@ static void verify_prefix_iter_cmp(const char *p1, const char *p2,
  *
  * Tests comparision of prefixes according to order of iteration.
  */
-static void test_prefix_iter_cmp()
+static void test_prefix_iter_cmp(void)
 {
 	printf("\n\nTesting route_table_prefix_iter_cmp()\n");
 

--- a/tools/start-stop-daemon.c
+++ b/tools/start-stop-daemon.c
@@ -280,7 +280,7 @@ static void add_namespace(const char *path)
 #endif
 
 #ifdef HAVE_LXC
-static void set_namespaces()
+static void set_namespaces(void)
 {
 	struct namespace *namespace;
 	int fd;
@@ -294,7 +294,7 @@ static void set_namespaces()
 	}
 }
 #else
-static void set_namespaces()
+static void set_namespaces(void)
 {
 	if (!LIST_EMPTY(&namespace_head))
 		fatal("LCX namespaces not supported");

--- a/vtysh/extract.pl.in
+++ b/vtysh/extract.pl.in
@@ -248,8 +248,7 @@ foreach (sort keys %live) {
 
 # Output install_element
 print <<EOF;
-void
-vtysh_init_cmd ()
+void vtysh_init_cmd(void)
 {
 EOF
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3464,7 +3464,7 @@ static const struct cmd_variable_handler vtysh_var_handler[] = {
 	 .completions = vtysh_autocomplete},
 	{.completions = NULL}};
 
-void vtysh_uninit()
+void vtysh_uninit(void)
 {
 	if (vty->of != stdout)
 		fclose(vty->of);

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -516,7 +516,7 @@ int vtysh_read_config(const char *config_default_dir)
  * be edited by hand. So, we handle only "write terminal" case here and
  * integrate vtysh specific conf with conf from daemons.
  */
-void vtysh_config_write()
+void vtysh_config_write(void)
 {
 	char line[81];
 
@@ -539,7 +539,7 @@ void vtysh_config_write()
 	user_config_write();
 }
 
-void vtysh_config_init()
+void vtysh_config_init(void)
 {
 	config_top = list_new();
 	config_top->del = (void (*)(void *))line_del;

--- a/vtysh/vtysh_user.c
+++ b/vtysh/vtysh_user.c
@@ -122,7 +122,7 @@ static struct vtysh_user *user_lookup(const char *name)
 	return NULL;
 }
 
-void user_config_write()
+void user_config_write(void)
 {
 	struct listnode *node, *nnode;
 	struct vtysh_user *user;

--- a/zebra/irdp_interface.c
+++ b/zebra/irdp_interface.c
@@ -706,7 +706,7 @@ DEFUN (ip_irdp_debug_disable,
 	return CMD_SUCCESS;
 }
 
-void irdp_if_init()
+void irdp_if_init(void)
 {
 	hook_register(zebra_if_config_wr, irdp_config_write);
 	hook_register(if_del, irdp_if_delete);

--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -480,7 +480,7 @@ int release_label_chunk(uint8_t proto, unsigned short instance, uint32_t start,
 }
 
 
-void label_manager_close()
+void label_manager_close(void)
 {
 	list_delete(&lbl_mgr.lc_list);
 	stream_free(obuf);

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1831,7 +1831,7 @@ void zebra_routemap_config_write_protocol(struct vty *vty,
 			zebra_rmap_update_timer);
 }
 
-void zebra_route_map_init()
+void zebra_route_map_init(void)
 {
 	install_element(CONFIG_NODE, &ip_protocol_cmd);
 	install_element(CONFIG_NODE, &no_ip_protocol_cmd);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -163,7 +163,7 @@ static zebra_vni_t *zvni_add(vni_t vni);
 static int zvni_del(zebra_vni_t *zvni);
 static int zvni_send_add_to_client(zebra_vni_t *zvni);
 static int zvni_send_del_to_client(vni_t vni);
-static void zvni_build_hash_table();
+static void zvni_build_hash_table(void);
 static int zvni_vtep_match(struct in_addr *vtep_ip, zebra_vtep_t *zvtep);
 static zebra_vtep_t *zvni_vtep_find(zebra_vni_t *zvni, struct in_addr *vtep_ip);
 static zebra_vtep_t *zvni_vtep_add(zebra_vni_t *zvni, struct in_addr *vtep_ip);
@@ -3841,7 +3841,7 @@ static int zvni_send_del_to_client(vni_t vni)
  * Build the VNI hash table by going over the VxLAN interfaces. This
  * is called when EVPN (advertise-all-vni) is enabled.
  */
-static void zvni_build_hash_table()
+static void zvni_build_hash_table(void)
 {
 	struct zebra_ns *zns;
 	struct route_node *rn;

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -37,7 +37,7 @@
 
 /* Is EVPN enabled? */
 #define EVPN_ENABLED(zvrf)  (zvrf)->advertise_all_vni
-static inline int is_evpn_enabled()
+static inline int is_evpn_enabled(void)
 {
 	struct zebra_vrf *zvrf = NULL;
 	zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
@@ -45,7 +45,7 @@ static inline int is_evpn_enabled()
 }
 
 static inline int
-is_vxlan_flooding_head_end()
+is_vxlan_flooding_head_end(void)
 {
 	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
 


### PR DESCRIPTION
Fix a few warnings found with -Wold-style-definitions and -Wstrict-prototypes.

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>

