### PR TITLE
bgpd: route-map fails to filter type-5 routes

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3325,12 +3325,18 @@ static void bgp_route_map_process_update(struct bgp *bgp, const char *rmap_name,
 			       != 0)
 			continue;
 
+		/* Make sure the route-map is populated here if not already done */
+		bgp->adv_cmd_rmap[afi][safi].map = map;
+
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug(
 				"Processing route_map %s update on advertise type5 route command",
 				rmap_name);
-		bgp_evpn_withdraw_type5_routes(bgp, afi, safi);
-		bgp_evpn_advertise_type5_routes(bgp, afi, safi);
+
+		if (route_update) {
+			bgp_evpn_withdraw_type5_routes(bgp, afi, safi);
+			bgp_evpn_advertise_type5_routes(bgp, afi, safi);
+		}
 	}
 }
 


### PR DESCRIPTION
Route-map filtering is based on the value of
"bgp->adv_cmd_rmap[afi][safi].map". For example, we advertise routes in
bgp_evpn_advertise_type5_routes() based on the value of
"bgp->adv_cmd_rmap[afi][safi].map". This variable gets populated in vty
handler bgp_evpn_advertise_type5. This variable will not get populated
if we have not yet applied the route-map configuration. The fix is to
correctly populate "bgp->adv_cmd_rmap[afi][safi].map" in
bgp_route_map_process_update() if it has not been populated before.

Ticket: CM-23263
Signed-off-by: Nitin Soni <nsoni@cumulusnetworks.com>
Reviewed-by: CCR-8163

### Summary
[This is an issue with the order of sequence of configuration. If route-map is not yet present as part of the configuration, it will not be applied to the type 5 routes. ]

### Related Issue
[fill here if applicable]

### Components
[bgpd]
`config for my setup today

leaf01

router bgp 65101 vrf BLUE
 neighbor 10.2.2.102 remote-as external
 !
 address-family ipv4 unicast
  network 10.2.2.0/24
  aggregate-address 10.2.0.0/16 summary-only
 exit-address-family
 !
 address-family l2vpn evpn
  advertise ipv4 unicast
 exit-address-family
!
ip prefix-list NET-AGG seq 5 permit 10.2.0.0/16
!
route-map AGG-ONLY permit 10
 match ip address prefix-list NET-AGG
!
line vty
!
end
without the patch,
leaf01 originate the routes

root@leaf01:~# net show bgp evpn route type prefix
BGP table version is 2, local router ID is 10.255.255.11
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-2 prefix: [2]:[ESI]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[ESI]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 10.2.2.2:2
*> [5]:[0]:[0]:[16]:[10.2.0.0]
                    192.168.1.12                       32768 i
*> [5]:[0]:[0]:[24]:[10.2.2.0]
                    192.168.1.12             0         32768 i

Displayed 2 prefixes (2 paths) (of requested type)
remote vtep learns agg + specific routes

root@leaf03:~# net show bgp evpn route type prefix
BGP table version is 2, local router ID is 10.255.255.13
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-2 prefix: [2]:[ESI]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[ESI]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 10.2.2.2:2
*  [5]:[0]:[0]:[16]:[10.2.0.0]
                    192.168.1.12                           0 65202 65101 i
*> [5]:[0]:[0]:[16]:[10.2.0.0]
                    192.168.1.12                           0 65201 65101 i
*  [5]:[0]:[0]:[24]:[10.2.2.0]
                    192.168.1.12                           0 65202 65101 i
*> [5]:[0]:[0]:[24]:[10.2.2.0]
                    192.168.1.12                           0 65201 65101 i

Displayed 2 prefixes (4 paths) (of requested type)
with the patch installed,
leaf01 originates the agg route

root@leaf01:~# net show bgp evpn route type prefix
BGP table version is 4, local router ID is 10.255.255.11
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-2 prefix: [2]:[ESI]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[ESI]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 10.2.2.2:2
*> [5]:[0]:[0]:[16]:[10.2.0.0]
                    192.168.1.12                       32768 i

Displayed 1 prefixes (1 paths) (of requested type)
remote vtep only learns agg route

root@leaf03:~# net show bgp evpn route type prefix
BGP table version is 4, local router ID is 10.255.255.13
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-2 prefix: [2]:[ESI]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[ESI]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 10.2.2.2:2
*  [5]:[0]:[0]:[16]:[10.2.0.0]
                    192.168.1.12                           0 65202 65101 i
*> [5]:[0]:[0]:[16]:[10.2.0.0]
                    192.168.1.12                           0 65201 65101 i

Displayed 1 prefixes (2 paths) (of requested type)`