### PR TITLE
[6.0] fix "log file" + "log syslog"

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -2542,8 +2542,6 @@ DEFUN (config_log_syslog,
 {
 	int idx_log_levels = 2;
 
-	disable_log_file();
-
 	if (argc == 3) {
 		int level;
 		if ((level = level_match(argv[idx_log_levels]->arg))


### PR DESCRIPTION
FRR log targets are independent, so "log syslog" must not disable
"log file" output.

Fixes: #3551
Fixes: 0204baa87630b210c71d9ae0e2569cff0fb0539b
Signed-off-by: David Lamparter <equinox@diac24.net>