### PR TITLE
lib: add hooks for external logging function

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -29,6 +29,7 @@
 #include "memory.h"
 #include "command.h"
 #include "lib_errors.h"
+#include "lib/hook.h"
 
 #ifndef SUNOS_5
 #include <sys/un.h>
@@ -45,6 +46,10 @@
 #endif
 
 DEFINE_MTYPE_STATIC(LIB, ZLOG, "Logging")
+
+/* hook for external logging */
+DEFINE_HOOK(zebra_ext_log, (int priority, const char *format, va_list args),
+	    (priority, format, args));
 
 static int logfile_fd = -1; /* Used in signal handler. */
 
@@ -212,6 +217,9 @@ void vzlog(int priority, const char *format, va_list args)
 	struct timestamp_control tsctl;
 	tsctl.already_rendered = 0;
 	struct zlog *zl = zlog_default;
+
+	/* call external hook */
+	hook_call(zebra_ext_log, priority, format, args);
 
 	/* When zlog_default is also NULL, use stderr for logging. */
 	if (zl == NULL) {

--- a/lib/log.h
+++ b/lib/log.h
@@ -26,6 +26,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdarg.h>
+#include "lib/hook.h"
+
+/* Hook for external logging function */
+DECLARE_HOOK(zebra_ext_log, (int priority, const char *format, va_list args),
+	     (priority, format, args));
 
 /* Here is some guidance on logging levels to use:
  *


### PR DESCRIPTION
Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>

### Summary
Add a hook which is called when logging through the zlog_xxx functions.
This is useful for example when additional log processing needs to be done,
or in case the logs need to be translated to a different format, or transported
elsewhere.

The downside of using hooks is that, since there is no way (afaik) to check if someone
has registered a callback, we might be doing a an additional `va_copy` and `va_end`
even when it is unnecessary to do so. For comparison, a bulkier, alternative implementation 
that doesn't use hooks and doesn't present this problem can be found here:
https://github.com/manuhalo/frr/commit/b3a0304830fa541a39de0104f7176f634ba8022d

### Related Issue
N/A

### Components
lib
