### PR TITLE
zebra: EVPN fix duplicate address detection remote macip add case

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -556,6 +556,7 @@ static void zebra_vxlan_dup_addr_detect_for_neigh(struct zebra_vrf *zvrf,
 
 		if (zvrf->dad_freeze)
 			*is_dup_detect = true;
+
 		/* warn-only action, neigh will be installed.
 		 * freeze action, it wil not be installed.
 		 */
@@ -5140,11 +5141,15 @@ static void process_remote_macip_add(vni_t vni,
 		 * RFC-7432: A PE/VTEP that detects a MAC mobility
 		 * event via local learning starts an M-second timer.
 		 *
-		 * VTEP-IP or seq. change along is not considered
+		 * VTEP-IP or seq. change alone is not considered
 		 * for dup. detection.
+		 *
+		 * MAC is already marked duplicate set dad, then
+		 * is_dup_detect will be set to not install the entry.
 		 */
-		if ((!CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE)) &&
-		    mac->dad_count)
+		if ((!CHECK_FLAG(mac->flags, ZEBRA_MAC_REMOTE) &&
+		    mac->dad_count) ||
+		    CHECK_FLAG(mac->flags, ZEBRA_MAC_DUPLICATE))
 			do_dad = true;
 
 		/* Remove local MAC from BGP. */


### PR DESCRIPTION

### Summary
A MACIP is detected as duplicate and after that the host continue to move behind
different VTEPs results in local VTEP receiving remote mobility events.
In remote_macip_add, ensure to trigger dad if MAC is marked as duplicate.
In case of freeze action enabled, is_dup_detect will be set to avoids installing
frozen MAC into kernel.

Testing Done:
Configured detection action freeze with detection count as 7 at DUT and >7 at remote VTEP, 
trigger MAC-IP mobility between VTEPs.
Once tdetection count reached, MAC detected as duplicate, post detection 
move the host to remote. The local VTEP receives remote macip add
and entry is not installed into kernel with fix.

root@VTEP1:~# net show evpn mac vni 1002 mac aa:aa:aa:aa:aa:aa
MAC: aa:aa:aa:aa:aa:aa
Remote VTEP: 27.0.0.16
Local Seq: 7 Remote Seq: 8
Duplicate, detected at Fri Jan 25 05:03:29 2019
Neighbors:
11.11.11.11 Inactive

Kernel entry still points to LOCAL
root@VTEP1:~# bridge fdb show | grep aa:aa:aa
aa:aa:aa:aa:aa:aa dev hostbond3 vlan 1002 master VxLanA-1

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>


### Related Issue
[fill here if applicable]

### Components
zebra
