### PR TITLE
zebra: reinstate bgp evpn remote route on local evpn route delete

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -7024,6 +7024,7 @@ int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
 	zebra_vni_t *zvni = NULL;
 	zebra_mac_t *zmac = NULL;
 	zebra_l3vni_t *zl3vni = NULL;
+	struct zebra_vrf *zvrf;
 
 	/* check if this is a remote neigh entry corresponding to remote
 	 * next-hop
@@ -7076,9 +7077,23 @@ int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
 		return 0;
 	}
 
+	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
+	if (!zvrf) {
+		zlog_debug("%s: VNI %u vrf lookup failed.",
+				   __PRETTY_FUNCTION__, zvni->vni);
+		return -1;
+	}
+
+	/* In case of feeze action, if local neigh is in duplicate state,
+	 * Mark the Neigh as inactive before sending delete request to BGPd,
+	 * If BGPd has remote entry, it will re-install
+	 */
+	if (zvrf->dad_freeze &&
+	    CHECK_FLAG(n->flags, ZEBRA_NEIGH_DUPLICATE))
+	    ZEBRA_NEIGH_SET_INACTIVE(n);
+
 	/* Remove neighbor from BGP. */
-	zvni_neigh_send_del_to_client(zvni->vni, &n->ip, &n->emac,
-			0, n->state);
+	zvni_neigh_send_del_to_client(zvni->vni, &n->ip, &n->emac, 0, n->state);
 
 	/* Delete this neighbor entry. */
 	zvni_neigh_del(zvni, n);


### PR DESCRIPTION
### Summary
Neigh detected duplicate detected during local update, upon receiving kernel neigh delete, set neigh inactive flag so BGPd can install remote route entry if present.

Only if freeze action enabled, local duplicate detected entry will not be present in BGPd thus marking neigh inactive is safe. BGPd will simply attempt install remote entry if present.

Testing Done:
Validated MAC-IP pair, trigger mobility of between two VTEPs,
upon local freeze perform neigh delete which triggers BGP
to install remote type-2 route into kernel.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]
