### PR TITLE
7.0: ospf6d: fix multicast join race on FreeBSD

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -381,9 +381,9 @@ void ospf6_interface_state_update(struct interface *ifp)
 	if (if_is_operative(ifp)
 	    && (ospf6_interface_get_linklocal_address(oi->interface)
 		|| if_is_loopback(oi->interface)))
-		thread_add_event(master, interface_up, oi, 0, NULL);
+		thread_execute(master, interface_up, oi, 0);
 	else
-		thread_add_event(master, interface_down, oi, 0, NULL);
+		thread_execute(master, interface_down, oi, 0);
 
 	return;
 }
@@ -1791,8 +1791,8 @@ DEFUN (ipv6_ospf6_network,
 	}
 
 	/* Reset the interface */
-	thread_add_event(master, interface_down, oi, 0, NULL);
-	thread_add_event(master, interface_up, oi, 0, NULL);
+	thread_execute(master, interface_down, oi, 0);
+	thread_execute(master, interface_up, oi, 0);
 
 	return CMD_SUCCESS;
 }
@@ -1825,8 +1825,8 @@ DEFUN (no_ipv6_ospf6_network,
 	oi->type = type;
 
 	/* Reset the interface */
-	thread_add_event(master, interface_down, oi, 0, NULL);
-	thread_add_event(master, interface_up, oi, 0, NULL);
+	thread_execute(master, interface_down, oi, 0);
+	thread_execute(master, interface_up, oi, 0);
 
 	return CMD_SUCCESS;
 }
@@ -1969,8 +1969,8 @@ static void ospf6_interface_clear(struct vty *vty, struct interface *ifp)
 		zlog_debug("Interface %s: clear by reset", ifp->name);
 
 	/* Reset the interface */
-	thread_add_event(master, interface_down, oi, 0, NULL);
-	thread_add_event(master, interface_up, oi, 0, NULL);
+	thread_execute(master, interface_down, oi, 0);
+	thread_execute(master, interface_up, oi, 0);
 }
 
 /* Clear interface */

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -80,6 +80,7 @@ struct ospf6_interface {
 
 	/* Interface socket setting trial counter, resets on success */
 	uint8_t sso_try_cnt;
+	struct thread *thread_sso;
 
 	/* OSPF6 Interface flag */
 	char flag;


### PR DESCRIPTION
### Summary

This is another bug @mwinter-osr found while testing FRR `dev/7.0` on FreeBSD (see related issue). The bug seems to affect FreeBSD 12.0 with any FRR version and only happens when batching commands.

This PR fixes a multicast join group race on FreeBSD by turning the events processing more predictable and delaying the `setsockopt` join system call. With the changes, the multicast group join will only happen once we've processed all events and will not happen if we remove the configuration abruptly (see the related issue).

Backport from `master`.


### Related Issue

#3639


## Related PR

#3680


### Components

`ospf6d`