### PR TITLE
zebra: async dataplane for pseudowires

### DIFF
--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -32,7 +32,7 @@
 #include "zebra/zebra_dplane.h"
 
 /*
- * Update or delete a route or LSP from the kernel,
+ * Update or delete a route, LSP, or pseudowire from the kernel,
  * using info from a dataplane context.
  */
 extern enum zebra_dplane_result kernel_route_update(
@@ -40,6 +40,8 @@ extern enum zebra_dplane_result kernel_route_update(
 
 extern enum zebra_dplane_result kernel_lsp_update(
 	struct zebra_dplane_ctx *ctx);
+
+enum zebra_dplane_result kernel_pw_update(struct zebra_dplane_ctx *ctx);
 
 extern int kernel_address_add_ipv4(struct interface *, struct connected *);
 extern int kernel_address_delete_ipv4(struct interface *, struct connected *);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -1058,6 +1058,7 @@ static int dplane_ctx_pw_init(struct zebra_dplane_ctx *ctx,
 
 	/* This name appears to be c-string, so we use string copy. */
 	strlcpy(ctx->u.pw.ifname, pw->ifname, sizeof(ctx->u.pw.ifname));
+	ctx->zd_vrf_id = pw->vrf_id;
 	ctx->u.pw.ifindex = pw->ifindex;
 	ctx->u.pw.type = pw->type;
 	ctx->u.pw.af = pw->af;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -1702,6 +1702,32 @@ kernel_dplane_lsp_update(struct zebra_dplane_ctx *ctx)
 }
 
 /*
+ * Handler for kernel pseudowire updates
+ */
+static enum zebra_dplane_result
+kernel_dplane_pw_update(struct zebra_dplane_ctx *ctx)
+{
+	enum zebra_dplane_result res;
+
+	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL)
+		zlog_debug("Dplane pw %s: op %s af %d loc: %u rem: %u",
+			   dplane_ctx_get_pw_ifname(ctx),
+			   dplane_op2str(ctx->zd_op),
+			   dplane_ctx_get_pw_af(ctx),
+			   dplane_ctx_get_pw_local_label(ctx),
+			   dplane_ctx_get_pw_remote_label(ctx));
+
+	res = kernel_pw_update(ctx);
+
+	if (res != ZEBRA_DPLANE_REQUEST_SUCCESS)
+		atomic_fetch_add_explicit(
+			&zdplane_info.dg_pw_errors, 1,
+			memory_order_relaxed);
+
+	return res;
+}
+
+/*
  * Handler for kernel route updates
  */
 static enum zebra_dplane_result
@@ -1765,6 +1791,11 @@ static int kernel_dplane_process_func(struct zebra_dplane_provider *prov)
 		case DPLANE_OP_LSP_UPDATE:
 		case DPLANE_OP_LSP_DELETE:
 			res = kernel_dplane_lsp_update(ctx);
+			break;
+
+		case DPLANE_OP_PW_INSTALL:
+		case DPLANE_OP_PW_UNINSTALL:
+			res = kernel_dplane_pw_update(ctx);
 			break;
 
 		default:

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -102,6 +102,23 @@ struct dplane_route_info {
 };
 
 /*
+ * Pseudowire info for the dataplane
+ */
+struct dplane_pw_info {
+	char ifname[IF_NAMESIZE];
+	ifindex_t ifindex;
+	int type;
+	int af;
+	int status;
+	uint32_t flags;
+	union g_addr nexthop;
+	mpls_label_t local_label;
+	mpls_label_t remote_label;
+
+	union pw_protocol_fields fields;
+};
+
+/*
  * The context block used to exchange info about route updates across
  * the boundary between the zebra main context (and pthread) and the
  * dataplane layer (and pthread).
@@ -136,6 +153,7 @@ struct zebra_dplane_ctx {
 	union {
 		struct dplane_route_info rinfo;
 		zebra_lsp_t lsp;
+		struct dplane_pw_info pw;
 	} u;
 
 	/* Namespace info, used especially for netlink kernel communication */
@@ -733,6 +751,71 @@ uint32_t dplane_ctx_get_lsp_num_ecmp(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.lsp.num_ecmp;
+}
+
+const char *dplane_ctx_get_pw_ifname(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.pw.ifname;
+}
+
+mpls_label_t dplane_ctx_get_pw_local_label(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.pw.local_label;
+}
+
+mpls_label_t dplane_ctx_get_pw_remote_label(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.pw.remote_label;
+}
+
+int dplane_ctx_get_pw_type(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.pw.type;
+}
+
+int dplane_ctx_get_pw_af(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.pw.af;
+}
+
+uint32_t dplane_ctx_get_pw_flags(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.pw.flags;
+}
+
+int dplane_ctx_get_pw_status(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.pw.status;
+}
+
+const union g_addr *dplane_ctx_get_pw_nexthop(
+	const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return &(ctx->u.pw.nexthop);
+}
+
+const union pw_protocol_fields *dplane_ctx_get_pw_proto(
+	const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return &(ctx->u.pw.fields);
 }
 
 /*

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -105,7 +105,11 @@ enum dplane_op_e {
 	/* LSP update */
 	DPLANE_OP_LSP_INSTALL,
 	DPLANE_OP_LSP_UPDATE,
-	DPLANE_OP_LSP_DELETE
+	DPLANE_OP_LSP_DELETE,
+
+	/* Pseudowire update */
+	DPLANE_OP_PW_INSTALL,
+	DPLANE_OP_PW_UNINSTALL,
 };
 
 /*
@@ -244,6 +248,12 @@ enum zebra_dplane_result dplane_route_delete(struct route_node *rn,
 enum zebra_dplane_result dplane_lsp_add(zebra_lsp_t *lsp);
 enum zebra_dplane_result dplane_lsp_update(zebra_lsp_t *lsp);
 enum zebra_dplane_result dplane_lsp_delete(zebra_lsp_t *lsp);
+
+/*
+ * Enqueue pseudowire operations for the dataplane.
+ */
+enum zebra_dplane_result dplane_pw_install(struct zebra_pw *pw);
+enum zebra_dplane_result dplane_pw_uninstall(struct zebra_pw *pw);
 
 /* Retrieve the limit on the number of pending, unprocessed updates. */
 uint32_t dplane_get_in_queue_limit(void);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -203,6 +203,19 @@ zebra_nhlfe_t *dplane_ctx_get_nhlfe(struct zebra_dplane_ctx *ctx);
 zebra_nhlfe_t *dplane_ctx_get_best_nhlfe(struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_lsp_num_ecmp(const struct zebra_dplane_ctx *ctx);
 
+/* Accessors for pseudowire information */
+const char *dplane_ctx_get_pw_ifname(const struct zebra_dplane_ctx *ctx);
+mpls_label_t dplane_ctx_get_pw_local_label(const struct zebra_dplane_ctx *ctx);
+mpls_label_t dplane_ctx_get_pw_remote_label(const struct zebra_dplane_ctx *ctx);
+int dplane_ctx_get_pw_type(const struct zebra_dplane_ctx *ctx);
+int dplane_ctx_get_pw_af(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_pw_flags(const struct zebra_dplane_ctx *ctx);
+int dplane_ctx_get_pw_status(const struct zebra_dplane_ctx *ctx);
+const union g_addr *dplane_ctx_get_pw_nexthop(
+	const struct zebra_dplane_ctx *ctx);
+const union pw_protocol_fields *dplane_ctx_get_pw_proto(
+	const struct zebra_dplane_ctx *ctx);
+
 /* Namespace info - esp. for netlink communication */
 const struct zebra_dplane_info *dplane_ctx_get_ns(
 	const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_mpls_netlink.c
+++ b/zebra/zebra_mpls_netlink.c
@@ -61,6 +61,16 @@ done:
 		ZEBRA_DPLANE_REQUEST_SUCCESS : ZEBRA_DPLANE_REQUEST_FAILURE);
 }
 
+/*
+ * Pseudowire update api - not supported by netlink as of 12/18,
+ * but note that the default has been to report 'success' for pw updates
+ * on unsupported platforms.
+ */
+enum zebra_dplane_result kernel_pw_update(struct zebra_dplane_ctx *ctx)
+{
+	return ZEBRA_DPLANE_REQUEST_SUCCESS;
+}
+
 int mpls_kernel_init(void)
 {
 	struct stat st;

--- a/zebra/zebra_mpls_null.c
+++ b/zebra/zebra_mpls_null.c
@@ -29,6 +29,15 @@ int mpls_kernel_init(void)
 	return -1;
 };
 
+/*
+ * Pseudowire update api - note that the default has been
+ * to report 'success' for pw updates on unsupported platforms.
+ */
+enum zebra_dplane_result kernel_pw_update(struct zebra_dplane_ctx *ctx)
+{
+	return ZEBRA_DPLANE_REQUEST_SUCCESS;
+}
+
 enum zebra_dplane_result kernel_lsp_update(struct zebra_dplane_ctx *ctx)
 {
 	return ZEBRA_DPLANE_REQUEST_FAILURE;

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -98,9 +98,10 @@ void zebra_pw_del(struct zebra_vrf *zvrf, struct zebra_pw *pw)
 	zebra_deregister_rnh_pseudowire(pw->vrf_id, pw);
 
 	/* uninstall */
-	if (pw->status == PW_STATUS_UP)
+	if (pw->status == PW_STATUS_UP) {
 		hook_call(pw_uninstall, pw);
-	else if (pw->install_retry_timer)
+		dplane_pw_uninstall(pw);
+	} else if (pw->install_retry_timer)
 		THREAD_TIMER_OFF(pw->install_retry_timer);
 
 	/* unlink and release memory */
@@ -171,7 +172,8 @@ static void zebra_pw_install(struct zebra_pw *pw)
 			   pw->vrf_id, pw->ifname,
 			   zebra_route_string(pw->protocol));
 
-	if (hook_call(pw_install, pw)) {
+	hook_call(pw_install, pw);
+	if (dplane_pw_install(pw) == ZEBRA_DPLANE_REQUEST_FAILURE) {
 		zebra_pw_install_failure(pw);
 		return;
 	}
@@ -192,6 +194,7 @@ static void zebra_pw_uninstall(struct zebra_pw *pw)
 
 	/* ignore any possible error */
 	hook_call(pw_uninstall, pw);
+	dplane_pw_uninstall(pw);
 
 	if (zebra_pw_enabled(pw))
 		zebra_pw_update_status(pw, PW_STATUS_DOWN);

--- a/zebra/zebra_pw.h
+++ b/zebra/zebra_pw.h
@@ -62,8 +62,8 @@ RB_PROTOTYPE(zebra_static_pw_head, zebra_pw, static_pw_entry, zebra_pw_compare);
 DECLARE_HOOK(pw_install, (struct zebra_pw * pw), (pw))
 DECLARE_HOOK(pw_uninstall, (struct zebra_pw * pw), (pw))
 
-struct zebra_pw *zebra_pw_add(struct zebra_vrf *, const char *, uint8_t,
-			      struct zserv *);
+struct zebra_pw *zebra_pw_add(struct zebra_vrf *zvrf, const char *ifname,
+			      uint8_t protocol, struct zserv *client);
 void zebra_pw_del(struct zebra_vrf *, struct zebra_pw *);
 void zebra_pw_change(struct zebra_pw *, ifindex_t, int, int, union g_addr *,
 		     uint32_t, uint32_t, uint8_t, union pw_protocol_fields *);


### PR DESCRIPTION
Migrate pseudowire programming to the async dataplane, following the pattern of routes and LSPs.

### Components
zebra