### PR TITLE
lib: protect termtable from bad fmt string

### DIFF
--- a/lib/termtable.c
+++ b/lib/termtable.c
@@ -163,7 +163,7 @@ static struct ttable_cell *ttable_insert_row_va(struct ttable *tt, int i,
 
 	orig = res;
 
-	while (res) {
+	while (res && col < tt->ncols) {
 		section = strsep(&res, "|");
 		row[col].text = XSTRDUP(MTYPE_TTABLE, section);
 		row[col].style = tt->style.cell;


### PR DESCRIPTION
Termtable can write out-of-bounds if given a format string with too many
column separators.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>