### PR TITLE
bgpd: detach vrf labels allocated, when removing bgp instance

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3252,6 +3252,10 @@ int bgp_delete(struct bgp *bgp)
 	/* unmap from RT list */
 	bgp_evpn_vrf_delete(bgp);
 
+	/* unmap bgp vrf label */
+	vpn_leak_zebra_vrf_label_withdraw(bgp, AFI_IP);
+	vpn_leak_zebra_vrf_label_withdraw(bgp, AFI_IP6);
+
 	/* Stop timers. */
 	if (bgp->t_rmap_def_originate_eval) {
 		BGP_TIMER_OFF(bgp->t_rmap_def_originate_eval);


### PR DESCRIPTION
bgp instance is disabling the label allocated to reach vrf entity.
previously, only vrf disabling was removing the label. now, when bgp
leaves, bgp instance also frees the label used.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
