### PR TITLE
bgpd: fix valgrind flagged errors

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -368,6 +368,8 @@ int bgp_dump_attr(struct attr *attr, char *buf, size_t size)
 	if (!attr)
 		return 0;
 
+	buf[0] = '\0';
+
 	if (CHECK_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP)))
 		snprintf(buf, size, "nexthop %s", inet_ntoa(attr->nexthop));
 

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5279,7 +5279,7 @@ int bgp_filter_evpn_routes_upon_martian_nh_change(struct bgp *bgp)
 
 				if (bgp_nexthop_self(bgp, pi->attr->nexthop)) {
 
-					char attr_str[BUFSIZ];
+					char attr_str[BUFSIZ] = {0};
 					char pbuf[PREFIX_STRLEN];
 
 					bgp_dump_attr(pi->attr, attr_str,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3245,9 +3245,11 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 		/* Update MPLS label */
 		if (has_valid_label) {
 			extra = bgp_path_info_extra_get(pi);
-			memcpy(&extra->label, label,
-			       num_labels * sizeof(mpls_label_t));
-			extra->num_labels = num_labels;
+			if (extra->label != label) {
+				memcpy(&extra->label, label,
+						num_labels * sizeof(mpls_label_t));
+				extra->num_labels = num_labels;
+			}
 			if (!(afi == AFI_L2VPN && safi == SAFI_EVPN))
 				bgp_set_valid_label(&extra->label[0]);
 		}
@@ -3416,8 +3418,10 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 	/* Update MPLS label */
 	if (has_valid_label) {
 		extra = bgp_path_info_extra_get(new);
-		memcpy(&extra->label, label, num_labels * sizeof(mpls_label_t));
-		extra->num_labels = num_labels;
+		if (extra->label != label) {
+			memcpy(&extra->label, label, num_labels * sizeof(mpls_label_t));
+			extra->num_labels = num_labels;
+		}
 		if (!(afi == AFI_L2VPN && safi == SAFI_EVPN))
 			bgp_set_valid_label(&extra->label[0]);
 	}


### PR DESCRIPTION
Executed some evpn related tests with valgrind and saw some errors
related to uninitialized memory and overlapping memcpy. This commit
fixes those.

Ticket: CM-21218
Signed-off-by: Nitin Soni <nsoni@cumulusnetworks.com>
Reviewed-by: CCR-8249

### Summary
[Here are the Valgrind errors - 

I am a bit concerned about fix for the 2nd one. The error is dumped because source and destination pointers are the same. Fix is just to suppress that error. If src and dst pointers will be same, fix will avoid memcpy. Need input on this.

44 ==1269== Conditional jump or move depends on uninitialised value(s) 
45 ==1269== at 0x4E83FA8: prefix2str (prefix.c:1081) 
46 ==1269== by 0x170554: bgp_zebra_announce.part.15 (bgp_zebra.c:1124) 
47 ==1269== by 0x15DDC1: bgp_process_main_one (bgp_route.c:2377) 
48 ==1269== by 0x15DDC1: bgp_process_wq (bgp_route.c:2450) 
49 ==1269== by 0x4EA06A7: work_queue_run (workqueue.c:282) 
50 ==1269== by 0x4E9939F: thread_call (thread.c:1552) 
51 ==1269== by 0x4E74DC7: frr_run (libfrr.c:920) 
52 ==1269== by 0x133A68: main (bgp_main.c:443) 

399 ==1269== Source and destination overlap in memcpy(0xc3e59e0, 0xc3e59e0, 4) 
400 ==1269== at 0x4C2D75D: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so) 
401 ==1269== by 0x16102D: memcpy (string3.h:51) 
402 ==1269== by 0x16102D: bgp_update (bgp_route.c:3184) 
403 ==1269== by 0x1C59DC: bgp_process_mac_rescan_table (bgp_mac.c:171) 
404 ==1269== by 0x1C59DC: bgp_mac_rescan_evpn_table (bgp_mac.c:215) 
405 ==1269== by 0x1C59DC: bgp_mac_rescan_all_evpn_tables (bgp_mac.c:229) 
406 ==1269== by 0x1C5DE2: bgp_mac_add_mac_entry (bgp_mac.c:292) 
407 ==1269== by 0x16F83F: bgp_interface_up (bgp_zebra.c:273) 
408 ==1269== by 0x4EA1693: zclient_read (zclient.c:2357) 
409 ==1269== by 0x4E9939F: thread_call (thread.c:1552) 
410 ==1269== by 0x4E74DC7: frr_run (libfrr.c:920) 
411 ==1269== by 0x133A68: main (bgp_main.c:443)
]

### Related Issue
[fill here if applicable]

### Components
[bgpd]
