### PR TITLE
ospfd: address CVE-2017-3224

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2098,10 +2098,22 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 
 		if (current == NULL
 		    || (ret = ospf_lsa_more_recent(current, lsa)) < 0) {
+			/* CVE-2017-3224 */
+			if (current && (lsa->data->ls_seqnum ==
+					htonl(OSPF_MAX_SEQUENCE_NUMBER)
+					&& !IS_LSA_MAXAGE(lsa))) {
+				zlog_debug(
+					"Link State Update[%s]: has Max Seq but not MaxAge. Dropping it",
+					dump_lsa_key(lsa));
+
+				DISCARD_LSA(lsa, 4);
+				continue;
+			}
+
 			/* Actual flooding procedure. */
 			if (ospf_flood(oi->ospf, nbr, current, lsa)
 			    < 0) /* Trap NSSA later. */
-				DISCARD_LSA(lsa, 4);
+				DISCARD_LSA(lsa, 5);
 			continue;
 		}
 
@@ -2158,7 +2170,7 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 							oi->ls_ack,
 							ospf_lsa_lock(lsa));
 
-				DISCARD_LSA(lsa, 5);
+				DISCARD_LSA(lsa, 6);
 			} else
 			/* Acknowledge the receipt of the LSA by sending a
 			   Link State Acknowledgment packet back out the
@@ -2166,7 +2178,7 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 			   interface. */
 			{
 				ospf_ls_ack_send(nbr, lsa);
-				DISCARD_LSA(lsa, 6);
+				DISCARD_LSA(lsa, 7);
 			}
 		}
 
@@ -2183,7 +2195,7 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 			if (IS_LSA_MAXAGE(current)
 			    && current->data->ls_seqnum
 				       == htonl(OSPF_MAX_SEQUENCE_NUMBER)) {
-				DISCARD_LSA(lsa, 7);
+				DISCARD_LSA(lsa, 8);
 			}
 			/* Otherwise, as long as the database copy has not been
 			   sent in a
@@ -2206,7 +2218,7 @@ static void ospf_ls_upd(struct ospf *ospf, struct ip *iph,
 					ospf_ls_upd_send_lsa(
 						nbr, current,
 						OSPF_SEND_PACKET_DIRECT);
-				DISCARD_LSA(lsa, 8);
+				DISCARD_LSA(lsa, 9);
 			}
 		}
 	}


### PR DESCRIPTION

### Summary
Based on the vulnerability mentioned in 793496 an attacker can craft an
LSA with MaxSequence number wtih invalid links and not set age to MAX_AGE
so the lsa would not be flush from the database.

To address the issue, check incoming LSA is MaxSeq but Age is not set
to MAX_AGE 3600, discard the LSA from processing it.
Based on  RFC-2328 , When a LSA update sequence reaches MaxSequence
number, it should be prematurely aged out from the database with age set
to MAX_AGE (3600).

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>

### Related Issue
[fill here if applicable]

### Components
ospfd
