### PR TITLE
tests: disable LSAN for make check

### DIFF
--- a/tests/subdir.am
+++ b/tests/subdir.am
@@ -3,6 +3,7 @@
 #
 
 PYTHON ?= python
+export ASAN_OPTIONS=detect_leaks=0
 
 if BGPD
 TESTS_BGPD = \


### PR DESCRIPTION
This allows us to run tests with ASAN and only see memory errors.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>