### PR TITLE
zebra: Move dataplane context into netlink_talk_info

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -932,13 +932,15 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
  *
  * filter   -> The filter to read final results from kernel
  * nlmsghdr -> The data to send to the kernel
- * dp_info -> The dataplane and netlink socket information
+ * dp_info  -> The dataplane and netlink socket information
+ * ctx      -> The dataplane ctx
  * startup  -> Are we reading in under startup conditions
  *             This is passed through eventually to filter.
  */
 int netlink_talk_info(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 		      struct nlmsghdr *n,
-		      const struct zebra_dplane_info *dp_info, int startup)
+		      const struct zebra_dplane_info *dp_info,
+		      struct zebra_dplane_ctx *ctx, int startup)
 {
 	int status = 0;
 	struct sockaddr_nl snl;
@@ -1013,7 +1015,7 @@ int netlink_talk(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 	/* Capture info in intermediate info struct */
 	zebra_dplane_info_from_zns(&dp_info, zns, (nl == &(zns->netlink_cmd)));
 
-	return netlink_talk_info(filter, n, &dp_info, startup);
+	return netlink_talk_info(filter, n, &dp_info, NULL, startup);
 }
 
 /* Issue request message to kernel via netlink socket. GET messages

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -62,8 +62,8 @@ extern int netlink_talk(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 /* Version with 'info' struct only */
 int netlink_talk_info(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 		      struct nlmsghdr *n,
-		      const struct zebra_dplane_info *dp_info, int startup);
-
+		      const struct zebra_dplane_info *dp_info,
+		      struct zebra_dplane_ctx *ctx, int startup);
 extern int netlink_request(struct nlsock *nl, struct nlmsghdr *n);
 
 #endif /* HAVE_NETLINK */

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1774,7 +1774,7 @@ skip:
 
 	/* Talk to netlink socket. */
 	return netlink_talk_info(netlink_talk_filter, &req.n,
-				 dplane_ctx_get_ns(ctx), 0);
+				 dplane_ctx_get_ns(ctx), ctx, 0);
 }
 
 int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *in)
@@ -2910,6 +2910,6 @@ int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 
 	/* Talk to netlink socket. */
 	return netlink_talk_info(netlink_talk_filter, &req.n,
-				 dplane_ctx_get_ns(ctx), 0);
+				 dplane_ctx_get_ns(ctx), ctx, 0);
 }
 #endif /* HAVE_NETLINK */


### PR DESCRIPTION
### Summary
Move dataplane context lower into the callstack so that we can access it with
batching later on.

### Components
zebra
