### PR TITLE
[7.0] tools: fix systemd dependency graph

### DIFF
--- a/redhat/frr.service
+++ b/redhat/frr.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=FRRouting (FRR)
-After=syslog.target networking.service
+Wants=network.target
+After=network-pre.target systemd-sysctl.service
+Before=network.target
 OnFailure=heartbeat-failed@%n.service
 
 [Service]
@@ -19,5 +21,4 @@ ExecStop=/usr/lib/frr/frr stop
 ExecReload=/usr/lib/frr/frr reload
 
 [Install]
-WantedBy=network-online.target
-
+WantedBy=multi-user.target

--- a/tools/frr.service
+++ b/tools/frr.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=FRRouting
 Documentation=https://frrouting.readthedocs.io/en/latest/setup.html
-After=networking.service
+Wants=network.target
+After=network-pre.target systemd-sysctl.service
+Before=network.target
 OnFailure=heartbeat-failed@%n.service
 
 [Service]
@@ -20,4 +22,4 @@ ExecStop=/usr/lib/frr/frrinit.sh stop
 ExecReload=/usr/lib/frr/frrinit.sh reload
 
 [Install]
-WantedBy=network-online.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Currently our systemd dependencies look something like this (example
from vanilla Debian 9):
```
$ systemctl list-dependencies frr
frr.service
● ├─system.slice
● └─sysinit.target
  ...
```
```
$ systemctl list-dependencies --reverse frr
frr.service
● └─network-online.target
●   └─apt-daily.service
```
Note that `sysinit.target` does not depend on any network* service or
target.

In other words, unless there is a service that requires
`network-online.target`, even if FRR is enabled it will not be started.
Therefore network-online.target is the wrong unit to have in `WantedBy=`,
as it is not always started.

This patch updates our service file so that it is properly started by
the system when enabled, delayed until networking is up, and if possible
delayed until after `NetworkManager`, `systemd-networkd` or any other
networking configuration manager has finished performing its tasks -
i.e. after `network-online.target`.

After these changes our new dependency graph looks like this:
```
$ systemctl list-dependencies frr
frr.service
● ├─system.slice
● ├─network-online.target
● │ └─networking.service
● ├─network.target
● └─sysinit.target
  ...
```
```
$ systemctl list-dependencies --reverse frr
frr.service
● └─multi-user.target
●   └─graphical.target
```
This way, FRR will be started by multi-user.target (just like most
applications), but delayed until after networking has been configured.