### PR TITLE
Revert "redhat: don't Requires initscript on systemd based distros"

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -171,6 +171,7 @@ BuildRequires:  python27-sphinx
 BuildRequires:  python-devel >= 2.7
 BuildRequires:  python-sphinx
 %endif
+Requires:       initscripts
 %if %{with_pam}
 BuildRequires:  pam-devel
 %endif
@@ -188,7 +189,6 @@ Requires(post):     chkconfig
 Requires(preun):    chkconfig
 # Initscripts > 5.60 is required for IPv6 support
 Requires(pre):      initscripts >= 5.60
-Requires:           initscripts
 %endif
 Provides:           routingdaemon = %{version}-%{release}
 Obsoletes:          gated mrt zebra frr-sysvinit


### PR DESCRIPTION
Frr.init (installed as /usr/lib/frr/frr and called by frr.service) requires initscripts in order to source several functions from /etc/init.d/functions.