### PR TITLE
bgpd: fix case where only have vrfs and l3mdev=1

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
@@ -172,7 +172,7 @@ def ltemplatePreRouterStartHook():
             'ip ru add oif {0}-cust1 table 10',
             'ip ru add iif {0}-cust1 table 10',
             'ip link set dev {0}-cust1 up',
-            'sysctl -w net.ipv4.udp_l3mdev_accept={}'.format(l3mdev_accept)]
+            'sysctl -w net.ipv4.tcp_l3mdev_accept={}'.format(l3mdev_accept)]
     for rtr in rtrs:
         router = tgen.gears[rtr]
         for cmd in cmds:
@@ -202,7 +202,7 @@ def ltemplatePreRouterStartHook():
             'ip ru add oif {0}-cust2 table 20',
             'ip ru add iif {0}-cust2 table 20',
             'ip link set dev {0}-cust2 up',
-            'sysctl -w net.ipv4.udp_l3mdev_accept={}'.format(l3mdev_accept)]
+            'sysctl -w net.ipv4.tcp_l3mdev_accept={}'.format(l3mdev_accept)]
     for rtr in rtrs:
         for cmd in cmds:
             cc.doCmd(tgen, rtr, cmd.format(rtr))

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
@@ -141,7 +141,10 @@ class ThisTestTopo(Topo):
         switch[1].add_link(tgen.gears['r2'], nodeif='r2-eth2')
         switch[1].add_link(tgen.gears['r3'], nodeif='r3-eth1')
 
+l3mdev_accept = 0
+
 def ltemplatePreRouterStartHook():
+    global l3mdev_accept
     cc = ltemplateRtrCmd()
     krel = platform.release()
     tgen = get_topogen()

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/check_linux_vrf.py
@@ -1,11 +1,12 @@
 from lutil import luCommand
-
-rtrs = ['r1', 'r3', 'r4', 'ce1', 'ce2', 'ce3', 'ce4']
-for rtr in rtrs:
+from customize import l3mdev_accept
+l3mdev_rtrs = ['r1', 'r3', 'r4', 'ce4']
+for rtr in l3mdev_rtrs:
     luCommand(rtr,'sysctl net.ipv4.tcp_l3mdev_accept',' = \d*','none','')
     found = luLast()
-    luCommand(rtr,'ss -aep',':bgp','pass','IPv4:bgp, l3mdev%s' % found.group(0))
-    luCommand(rtr,'ss -aep',':.:bgp','pass','IPv6:bgp')
+    luCommand(rtr,'ss -naep',':179','pass','IPv4:bgp, l3mdev{}'.format(found.group(0)))
+    luCommand(rtr,'ss -naep',':.*:179','pass','IPv6:bgp')
+    luCommand(rtr,'sysctl net.ipv4.tcp_l3mdev_accept',' = {}'.format(l3mdev_accept),'pass','l3mdev matches expected (real/expected{}/{})'.format(found.group(0),l3mdev_accept))
 
 rtrs = ['r1', 'r3', 'r4']
 for rtr in rtrs:


### PR DESCRIPTION
### Summary
in case where l3mdev=1, code needed core instance for *incoming* bgpd sockets

code changed to open socket in default instance, try to bind to port.
1st will succeed, others will fail and be closed.

### Components
topotest:  bgp_l3vpn_to_bgp_vrf: fix setting of TCP l3mdev 
   Fix setting of TCP l3mdev (was setting UDP)
   also add test to see that it is set as expected
