### PR TITLE
Send information

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -414,9 +414,6 @@ void zclient_send_reg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 	/* We need router-id information. */
 	zebra_message_send(zclient, ZEBRA_ROUTER_ID_ADD, vrf_id);
 
-	/* We need interface information. */
-	zebra_message_send(zclient, ZEBRA_INTERFACE_ADD, vrf_id);
-
 	/* Set unwanted redistribute route. */
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)
 		vrf_bitmap_set(zclient->redist[afi][zclient->redist_default],
@@ -480,9 +477,6 @@ void zclient_send_dereg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 
 	/* We need router-id information. */
 	zebra_message_send(zclient, ZEBRA_ROUTER_ID_DELETE, vrf_id);
-
-	/* We need interface information. */
-	zebra_message_send(zclient, ZEBRA_INTERFACE_DELETE, vrf_id);
 
 	/* Set unwanted redistribute route. */
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)
@@ -595,6 +589,8 @@ int zclient_start(struct zclient *zclient)
 	zclient_event(ZCLIENT_READ, zclient);
 
 	zebra_hello_send(zclient);
+
+	zebra_message_send(zclient, ZEBRA_INTERFACE_ADD, VRF_DEFAULT);
 
 	/* Inform the successful connection. */
 	if (zclient->zebra_connected)

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -406,12 +406,11 @@ void zebra_interface_up_update(struct interface *ifp)
 
 	if (ifp->ptm_status || !ifp->ptm_enable) {
 		for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode,
-				       client))
-			if (vrf_bitmap_check(client->ifinfo, ifp->vrf_id)) {
-				zsend_interface_update(ZEBRA_INTERFACE_UP,
-						       client, ifp);
-				zsend_interface_link_params(client, ifp);
-			}
+				       client)) {
+			zsend_interface_update(ZEBRA_INTERFACE_UP,
+					       client, ifp);
+			zsend_interface_link_params(client, ifp);
+		}
 	}
 }
 
@@ -440,12 +439,11 @@ void zebra_interface_add_update(struct interface *ifp)
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADD %s(%u)", ifp->name,
 			   ifp->vrf_id);
 
-	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client))
-		if (vrf_bitmap_check(client->ifinfo, ifp->vrf_id)) {
-			client->ifadd_cnt++;
-			zsend_interface_add(client, ifp);
-			zsend_interface_link_params(client, ifp);
-		}
+	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
+		client->ifadd_cnt++;
+		zsend_interface_add(client, ifp);
+		zsend_interface_link_params(client, ifp);
+	}
 }
 
 void zebra_interface_delete_update(struct interface *ifp)
@@ -814,6 +812,5 @@ void zebra_interface_parameters_update(struct interface *ifp)
 			   ifp->name, ifp->vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client))
-		if (vrf_bitmap_check(client->ifinfo, ifp->vrf_id))
-			zsend_interface_link_params(client, ifp);
+		zsend_interface_link_params(client, ifp);
 }

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -209,12 +209,6 @@ int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	/* Check this client need interface information. */
-	if (!vrf_bitmap_check(client->ifinfo, ifp->vrf_id)) {
-		stream_free(s);
-		return 0;
-	}
-
 	if (!ifp->link_params) {
 		stream_free(s);
 		return 0;
@@ -1317,9 +1311,6 @@ static void zread_interface_add(ZAPI_HANDLER_ARGS)
 	struct vrf *vrf;
 	struct interface *ifp;
 
-	/* Interface information is needed. */
-	vrf_bitmap_set(client->ifinfo, zvrf_id(zvrf));
-
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
 		FOR_ALL_INTERFACES (vrf, ifp) {
 			/* Skip pseudo interface. */
@@ -1336,7 +1327,6 @@ static void zread_interface_add(ZAPI_HANDLER_ARGS)
 /* Unregister zebra server interface information. */
 static void zread_interface_delete(ZAPI_HANDLER_ARGS)
 {
-	vrf_bitmap_unset(client->ifinfo, zvrf_id(zvrf));
 }
 
 void zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
@@ -1731,7 +1721,6 @@ static void zread_vrf_unregister(ZAPI_HANDLER_ARGS)
 			vrf_bitmap_unset(client->redist[afi][i], zvrf_id(zvrf));
 		vrf_bitmap_unset(client->redist_default[afi], zvrf_id(zvrf));
 	}
-	vrf_bitmap_unset(client->ifinfo, zvrf_id(zvrf));
 	vrf_bitmap_unset(client->ridinfo, zvrf_id(zvrf));
 }
 

--- a/zebra/zebra_ptm_redistribute.c
+++ b/zebra/zebra_ptm_redistribute.c
@@ -36,10 +36,6 @@ static int zsend_interface_bfd_update(int cmd, struct zserv *client,
 	int blen;
 	struct stream *s;
 
-	/* Check this client need interface information. */
-	if (!vrf_bitmap_check(client->ifinfo, ifp->vrf_id))
-		return 0;
-
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, vrf_id);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -626,7 +626,6 @@ static void zserv_client_free(struct zserv *client)
 
 		vrf_bitmap_free(client->redist_default[afi]);
 	}
-	vrf_bitmap_free(client->ifinfo);
 	vrf_bitmap_free(client->ridinfo);
 
 	XFREE(MTYPE_TMP, client);
@@ -710,7 +709,6 @@ static struct zserv *zserv_client_create(int sock)
 			client->redist[afi][i] = vrf_bitmap_init();
 		client->redist_default[afi] = vrf_bitmap_init();
 	}
-	client->ifinfo = vrf_bitmap_init();
 	client->ridinfo = vrf_bitmap_init();
 
 	/* by default, it's not a synchronous client */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -89,9 +89,6 @@ struct zserv {
 	/* Redistribute default route flag. */
 	vrf_bitmap_t redist_default[AFI_MAX];
 
-	/* Interface information. */
-	vrf_bitmap_t ifinfo;
-
 	/* Router-id information. */
 	vrf_bitmap_t ridinfo;
 


### PR DESCRIPTION
Remove restrictions on what clients receive from zebra about interface state.
Have clients ask for interface information on startup after the hello is sent.