### PR TITLE
bfdd: protocol refactory

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -418,10 +418,9 @@ static void _bfd_session_update(struct bfd_session *bs,
 			goto skip_echo;
 
 		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
-		ptm_bfd_echo_start(bs);
 
 		/* Activate/update echo receive timeout timer. */
-		bfd_echo_recvtimer_update(bs);
+		bs_echo_timer_handler(bs);
 	} else {
 		/* Check if echo mode is already disabled. */
 		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -495,10 +495,6 @@ skip_echo:
 		/* Enable all timers. */
 		bfd_recvtimer_update(bs);
 		bfd_xmttimer_update(bs, bs->xmt_TO);
-		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO)) {
-			bfd_echo_recvtimer_update(bs);
-			bfd_echo_xmttimer_update(bs, bs->echo_xmt_TO);
-		}
 	}
 }
 

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -36,7 +36,7 @@ DEFINE_QOBJ_TYPE(bfd_session);
 /*
  * Prototypes
  */
-struct bfd_session *bs_peer_waiting_find(struct bfd_peer_cfg *);
+static struct bfd_session *bs_peer_waiting_find(struct bfd_peer_cfg *bpc);
 
 static uint32_t ptm_bfd_gen_ID(void);
 static void ptm_bfd_echo_xmt_TO(struct bfd_session *bfd);
@@ -47,11 +47,16 @@ static struct bfd_session *bfd_find_disc(struct sockaddr_any *sa,
 static int bfd_session_update(struct bfd_session *bs, struct bfd_peer_cfg *bpc);
 static const char *get_diag_str(int diag);
 
+static void bs_admin_down_handler(struct bfd_session *bs, int nstate);
+static void bs_down_handler(struct bfd_session *bs, int nstate);
+static void bs_init_handler(struct bfd_session *bs, int nstate);
+static void bs_up_handler(struct bfd_session *bs, int nstate);
+
 
 /*
  * Functions
  */
-struct bfd_session *bs_peer_waiting_find(struct bfd_peer_cfg *bpc)
+static struct bfd_session *bs_peer_waiting_find(struct bfd_peer_cfg *bpc)
 {
 	struct bfd_session_observer *bso;
 	struct bfd_session *bs = NULL;
@@ -826,13 +831,9 @@ void bfd_set_polling(struct bfd_session *bs)
  * transition mechanism. `<state>` is the current session state and
  * the parameter `nstate` is the peer new state.
  */
-void bs_admin_down_handler(struct bfd_session *bs, int nstate);
-void bs_down_handler(struct bfd_session *bs, int nstate);
-void bs_init_handler(struct bfd_session *bs, int nstate);
-void bs_up_handler(struct bfd_session *bs, int nstate);
-
-void bs_admin_down_handler(struct bfd_session *bs __attribute__((__unused__)),
-			   int nstate __attribute__((__unused__)))
+static void bs_admin_down_handler(struct bfd_session *bs
+				  __attribute__((__unused__)),
+				  int nstate __attribute__((__unused__)))
 {
 	/*
 	 * We are administratively down, there is no state machine
@@ -840,7 +841,7 @@ void bs_admin_down_handler(struct bfd_session *bs __attribute__((__unused__)),
 	 */
 }
 
-void bs_down_handler(struct bfd_session *bs, int nstate)
+static void bs_down_handler(struct bfd_session *bs, int nstate)
 {
 	switch (nstate) {
 	case PTM_BFD_ADM_DOWN:
@@ -874,7 +875,7 @@ void bs_down_handler(struct bfd_session *bs, int nstate)
 	}
 }
 
-void bs_init_handler(struct bfd_session *bs, int nstate)
+static void bs_init_handler(struct bfd_session *bs, int nstate)
 {
 	switch (nstate) {
 	case PTM_BFD_ADM_DOWN:
@@ -901,7 +902,7 @@ void bs_init_handler(struct bfd_session *bs, int nstate)
 	}
 }
 
-void bs_up_handler(struct bfd_session *bs, int nstate)
+static void bs_up_handler(struct bfd_session *bs, int nstate)
 {
 	switch (nstate) {
 	case PTM_BFD_ADM_DOWN:

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -100,9 +100,18 @@ struct bfd_session *bs_peer_find(struct bfd_peer_cfg *bpc)
 
 static uint32_t ptm_bfd_gen_ID(void)
 {
-	static uint32_t sessionID = 1;
+	uint32_t session_id;
 
-	return (sessionID++);
+	/*
+	 * RFC 5880, Section 6.8.1. recommends that we should generate
+	 * random session identification numbers.
+	 */
+	do {
+		session_id = ((random() << 16) & 0xFFFF0000)
+			     | (random() & 0x0000FFFF);
+	} while (session_id == 0 || bfd_id_lookup(session_id) != NULL);
+
+	return session_id;
 }
 
 void ptm_bfd_start_xmt_timer(struct bfd_session *bfd, bool is_echo)

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -279,16 +279,6 @@ struct bfd_state_str_list {
 	int type;
 };
 
-struct bfd_vrf {
-	int vrf_id;
-	char name[MAXNAMELEN + 1];
-} bfd_vrf;
-
-struct bfd_iface {
-	int vrf_id;
-	char ifname[MAXNAMELEN + 1];
-} bfd_iface;
-
 
 /* States defined per 4.1 */
 #define PTM_BFD_ADM_DOWN 0

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -176,13 +176,13 @@ enum bfd_session_flags {
 /* BFD session hash keys */
 struct bfd_shop_key {
 	struct sockaddr_any peer;
-	char port_name[MAXNAMELEN + 1];
+	ifindex_t ifindex;
 };
 
 struct bfd_mhop_key {
 	struct sockaddr_any peer;
 	struct sockaddr_any local;
-	char vrf_name[MAXNAMELEN + 1];
+	vrf_id_t vrfid;
 };
 
 struct bfd_session_stats {
@@ -238,6 +238,7 @@ struct bfd_session {
 	struct sockaddr_any local_address;
 	struct sockaddr_any local_ip;
 	struct interface *ifp;
+	struct vrf *vrf;
 	uint8_t local_mac[ETHERNET_ADDRESS_LENGTH];
 	uint8_t peer_mac[ETHERNET_ADDRESS_LENGTH];
 
@@ -516,10 +517,9 @@ void ptm_bfd_echo_stop(struct bfd_session *bfd);
 void ptm_bfd_echo_start(struct bfd_session *bfd);
 void ptm_bfd_xmt_TO(struct bfd_session *bfd, int fbit);
 void ptm_bfd_start_xmt_timer(struct bfd_session *bfd, bool is_echo);
-struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp, char *port_name,
-				      struct sockaddr_any *peer,
-				      struct sockaddr_any *local,
-				      char *vrf_name, bool is_mhop);
+struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *, struct sockaddr_any *,
+				      struct sockaddr_any *, ifindex_t,
+				      vrf_id_t, bool);
 
 struct bfd_session *bs_peer_find(struct bfd_peer_cfg *bpc);
 int bfd_session_update_label(struct bfd_session *bs, const char *nlabel);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -214,8 +214,7 @@ struct bfd_session {
 
 	/* Timers */
 	struct bfd_timers timers;
-	struct bfd_timers new_timers;
-	uint32_t up_min_tx;
+	struct bfd_timers cur_timers;
 	uint64_t detect_TO;
 	struct thread *echo_recvtimer_ev;
 	struct thread *recvtimer_ev;

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -513,7 +513,7 @@ struct bfd_session *ptm_bfd_sess_new(struct bfd_peer_cfg *bpc);
 int ptm_bfd_ses_del(struct bfd_peer_cfg *bpc);
 void ptm_bfd_ses_dn(struct bfd_session *bfd, uint8_t diag);
 void ptm_bfd_ses_up(struct bfd_session *bfd);
-void ptm_bfd_echo_stop(struct bfd_session *bfd, int polling);
+void ptm_bfd_echo_stop(struct bfd_session *bfd);
 void ptm_bfd_echo_start(struct bfd_session *bfd);
 void ptm_bfd_xmt_TO(struct bfd_session *bfd, int fbit);
 void ptm_bfd_start_xmt_timer(struct bfd_session *bfd, bool is_echo);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -525,6 +525,7 @@ struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp, char *port_name,
 struct bfd_session *bs_peer_find(struct bfd_peer_cfg *bpc);
 int bfd_session_update_label(struct bfd_session *bs, const char *nlabel);
 void bfd_set_polling(struct bfd_session *bs);
+void bs_state_handler(struct bfd_session *, int);
 const char *satostr(struct sockaddr_any *sa);
 const char *diag2str(uint8_t diag);
 int strtosa(const char *addr, struct sockaddr_any *sa);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -465,8 +465,8 @@ int bp_udp_shop(void);
 int bp_udp_mhop(void);
 int bp_udp6_shop(void);
 int bp_udp6_mhop(void);
-int bp_peer_socket(const struct bfd_session *);
-int bp_peer_socketv6(const struct bfd_session *);
+int bp_peer_socket(const struct bfd_session *bs);
+int bp_peer_socketv6(const struct bfd_session *bs);
 int bp_echo_socket(void);
 int bp_echov6_socket(void);
 
@@ -504,8 +504,8 @@ void bfd_echo_xmttimer_assign(struct bfd_session *bs, bfd_ev_cb cb);
  *
  * BFD protocol specific code.
  */
-int bfd_session_enable(struct bfd_session *);
-void bfd_session_disable(struct bfd_session *);
+int bfd_session_enable(struct bfd_session *bs);
+void bfd_session_disable(struct bfd_session *bs);
 struct bfd_session *ptm_bfd_sess_new(struct bfd_peer_cfg *bpc);
 int ptm_bfd_ses_del(struct bfd_peer_cfg *bpc);
 void ptm_bfd_ses_dn(struct bfd_session *bfd, uint8_t diag);
@@ -514,16 +514,18 @@ void ptm_bfd_echo_stop(struct bfd_session *bfd);
 void ptm_bfd_echo_start(struct bfd_session *bfd);
 void ptm_bfd_xmt_TO(struct bfd_session *bfd, int fbit);
 void ptm_bfd_start_xmt_timer(struct bfd_session *bfd, bool is_echo);
-struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *, struct sockaddr_any *,
-				      struct sockaddr_any *, ifindex_t,
-				      vrf_id_t, bool);
+struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp,
+				      struct sockaddr_any *peer,
+				      struct sockaddr_any *local,
+				      ifindex_t ifindex, vrf_id_t vrfid,
+				      bool is_mhop);
 
 struct bfd_session *bs_peer_find(struct bfd_peer_cfg *bpc);
 int bfd_session_update_label(struct bfd_session *bs, const char *nlabel);
 void bfd_set_polling(struct bfd_session *bs);
-void bs_state_handler(struct bfd_session *, int);
-void bs_echo_timer_handler(struct bfd_session *);
-void bs_final_handler(struct bfd_session *);
+void bs_state_handler(struct bfd_session *bs, int nstate);
+void bs_echo_timer_handler(struct bfd_session *bs);
+void bs_final_handler(struct bfd_session *bs);
 void bs_set_slow_timers(struct bfd_session *bs);
 const char *satostr(struct sockaddr_any *sa);
 const char *diag2str(uint8_t diag);
@@ -531,8 +533,8 @@ int strtosa(const char *addr, struct sockaddr_any *sa);
 void integer2timestr(uint64_t time, char *buf, size_t buflen);
 const char *bs_to_string(struct bfd_session *bs);
 
-int bs_observer_add(struct bfd_session *);
-void bs_observer_del(struct bfd_session_observer *);
+int bs_observer_add(struct bfd_session *bs);
+void bs_observer_del(struct bfd_session_observer *bso);
 
 /* BFD hash data structures interface */
 void bfd_initialize(void);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -527,6 +527,7 @@ void bfd_set_polling(struct bfd_session *bs);
 void bs_state_handler(struct bfd_session *, int);
 void bs_echo_timer_handler(struct bfd_session *);
 void bs_final_handler(struct bfd_session *);
+void bs_set_slow_timers(struct bfd_session *bs);
 const char *satostr(struct sockaddr_any *sa);
 const char *diag2str(uint8_t diag);
 int strtosa(const char *addr, struct sockaddr_any *sa);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -526,6 +526,8 @@ struct bfd_session *bs_peer_find(struct bfd_peer_cfg *bpc);
 int bfd_session_update_label(struct bfd_session *bs, const char *nlabel);
 void bfd_set_polling(struct bfd_session *bs);
 void bs_state_handler(struct bfd_session *, int);
+void bs_echo_timer_handler(struct bfd_session *);
+void bs_final_handler(struct bfd_session *);
 const char *satostr(struct sockaddr_any *sa);
 const char *diag2str(uint8_t diag);
 int strtosa(const char *addr, struct sockaddr_any *sa);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -35,8 +35,6 @@
 
 #include "bfdctl.h"
 
-#define ETHERNET_ADDRESS_LENGTH 6
-
 #ifdef BFD_DEBUG
 #define BFDD_JSON_CONV_OPTIONS (JSON_C_TO_STRING_PRETTY)
 #else
@@ -242,8 +240,6 @@ struct bfd_session {
 	struct vrf *vrf;
 	char ifname[MAXNAMELEN];
 	char vrfname[MAXNAMELEN];
-	uint8_t local_mac[ETHERNET_ADDRESS_LENGTH];
-	uint8_t peer_mac[ETHERNET_ADDRESS_LENGTH];
 
 	/* BFD session flags */
 	enum bfd_session_flags flags;
@@ -301,15 +297,12 @@ TAILQ_HEAD(obslist, bfd_session_observer);
 
 /* Various constants */
 /* Retrieved from ptm_timer.h from Cumulus PTM sources. */
-#define MSEC_PER_SEC 1000L
-#define NSEC_PER_MSEC 1000000L
-
 #define BFD_DEF_DEMAND 0
 #define BFD_DEFDETECTMULT 3
-#define BFD_DEFDESIREDMINTX (300 * MSEC_PER_SEC)
-#define BFD_DEFREQUIREDMINRX (300 * MSEC_PER_SEC)
-#define BFD_DEF_REQ_MIN_ECHO (50 * MSEC_PER_SEC)
-#define BFD_DEF_SLOWTX (1000 * MSEC_PER_SEC)
+#define BFD_DEFDESIREDMINTX (300 * 1000) /* microseconds. */
+#define BFD_DEFREQUIREDMINRX (300 * 1000) /* microseconds. */
+#define BFD_DEF_REQ_MIN_ECHO (50 * 1000) /* microseconds. */
+#define BFD_DEF_SLOWTX (1000 * 1000) /* microseconds. */
 #define BFD_DEF_MHOP_TTL 5
 #define BFD_PKT_LEN 24 /* Length of control packet */
 #define BFD_TTL_VAL 255
@@ -323,8 +316,6 @@ TAILQ_HEAD(obslist, bfd_session_observer);
 #define BFD_DEFDESTPORT 3784
 #define BFD_DEF_ECHO_PORT 3785
 #define BFD_DEF_MHOP_DEST_PORT 4784
-#define BFD_CMD_STRING_LEN (MAXNAMELEN + 50)
-#define BFD_BUFFER_LEN (BFD_CMD_STRING_LEN + MAXNAMELEN + 1)
 
 /*
  * control.c

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -306,7 +306,7 @@ struct bfd_iface {
 #define BFD_DEFDESIREDMINTX (300 * MSEC_PER_SEC)
 #define BFD_DEFREQUIREDMINRX (300 * MSEC_PER_SEC)
 #define BFD_DEF_REQ_MIN_ECHO (50 * MSEC_PER_SEC)
-#define BFD_DEF_SLOWTX (2000 * MSEC_PER_SEC)
+#define BFD_DEF_SLOWTX (1000 * MSEC_PER_SEC)
 #define BFD_DEF_MHOP_TTL 5
 #define BFD_PKT_LEN 24 /* Length of control packet */
 #define BFD_TTL_VAL 255

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -505,7 +505,7 @@ int bfd_recv_cb(struct thread *t)
 	struct bfd_pkt *cp;
 	bool is_mhop;
 	ssize_t mlen = 0;
-	uint8_t ttl;
+	uint8_t ttl = 0;
 	vrf_id_t vrfid = VRF_DEFAULT;
 	ifindex_t ifindex = IFINDEX_INTERNAL;
 	struct sockaddr_any local, peer;

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -656,8 +656,13 @@ int bfd_recv_cb(struct thread *t)
 	 *
 	 * RFC 5880, Section 6.5.
 	 */
-	if (BFD_GETPBIT(cp->flags))
+	if (BFD_GETPBIT(cp->flags)) {
+		/* We are finalizing a poll negotiation. */
+		bs_final_handler(bfd);
+
+		/* Send the control packet with the final bit immediately. */
 		ptm_bfd_snd(bfd, 1);
+	}
 
 	return 0;
 }

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -617,7 +617,7 @@ int bfd_recv_cb(struct thread *t)
 	if ((bfd->discrs.remote_discr != 0)
 	    && (bfd->discrs.remote_discr != ntohl(cp->discrs.my_discr)))
 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
-			 "remote discriminator mismatch (expected %d, got %d)",
+			 "remote discriminator mismatch (expected %u, got %u)",
 			 bfd->discrs.remote_discr, ntohl(cp->discrs.my_discr));
 
 	bfd->discrs.remote_discr = ntohl(cp->discrs.my_discr);

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -213,8 +213,16 @@ void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 	cp.flags = 0;
 	BFD_SETSTATE(cp.flags, bfd->ses_state);
 	BFD_SETDEMANDBIT(cp.flags, BFD_DEF_DEMAND);
-	BFD_SETPBIT(cp.flags, bfd->polling);
+
+	/*
+	 * Polling and Final can't be set at the same time.
+	 *
+	 * RFC 5880, Section 6.5.
+	 */
 	BFD_SETFBIT(cp.flags, fbit);
+	if (fbit == 0)
+		BFD_SETPBIT(cp.flags, bfd->polling);
+
 	cp.detect_mult = bfd->detect_mult;
 	cp.len = BFD_PKT_LEN;
 	cp.discrs.my_discr = htonl(bfd->discrs.my_discr);

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -668,29 +668,8 @@ int bfd_recv_cb(struct thread *t)
 	/* Save remote diagnostics before state switch. */
 	bfd->remote_diag = cp->diag & BFD_DIAGMASK;
 
-	/* State switch from section 6.8.6 */
-	if (BFD_GETSTATE(cp->flags) == PTM_BFD_ADM_DOWN) {
-		if (bfd->ses_state != PTM_BFD_DOWN)
-			ptm_bfd_ses_dn(bfd, BD_NEIGHBOR_DOWN);
-	} else {
-		switch (bfd->ses_state) {
-		case (PTM_BFD_DOWN):
-			if (BFD_GETSTATE(cp->flags) == PTM_BFD_INIT)
-				ptm_bfd_ses_up(bfd);
-			else if (BFD_GETSTATE(cp->flags) == PTM_BFD_DOWN)
-				bfd->ses_state = PTM_BFD_INIT;
-			break;
-		case (PTM_BFD_INIT):
-			if (BFD_GETSTATE(cp->flags) == PTM_BFD_INIT
-			    || BFD_GETSTATE(cp->flags) == PTM_BFD_UP)
-				ptm_bfd_ses_up(bfd);
-			break;
-		case (PTM_BFD_UP):
-			if (BFD_GETSTATE(cp->flags) == PTM_BFD_DOWN)
-				ptm_bfd_ses_dn(bfd, BD_NEIGHBOR_DOWN);
-			break;
-		}
-	}
+	/* State switch from section 6.2. */
+	bs_state_handler(bfd, BFD_GETSTATE(cp->flags));
 
 	/*
 	 * Handle echo packet status:

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -229,12 +229,20 @@ void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 	cp.discrs.remote_discr = htonl(bfd->discrs.remote_discr);
 	if (bfd->polling) {
 		cp.timers.desired_min_tx =
-			htonl(bfd->new_timers.desired_min_tx);
+			htonl(bfd->timers.desired_min_tx);
 		cp.timers.required_min_rx =
-			htonl(bfd->new_timers.required_min_rx);
+			htonl(bfd->timers.required_min_rx);
 	} else {
-		cp.timers.desired_min_tx = htonl(bfd->timers.desired_min_tx);
-		cp.timers.required_min_rx = htonl(bfd->timers.required_min_rx);
+		/*
+		 * We can only announce current setting on poll, this
+		 * avoids timing mismatch with our peer and give it
+		 * the oportunity to learn. See `bs_final_handler` for
+		 * more information.
+		 */
+		cp.timers.desired_min_tx =
+			htonl(bfd->cur_timers.desired_min_tx);
+		cp.timers.required_min_rx =
+			htonl(bfd->cur_timers.required_min_rx);
 	}
 	cp.timers.required_min_echo = htonl(bfd->timers.required_min_echo);
 

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -32,6 +32,7 @@ DEFINE_MTYPE(BFDD, BFDD_TMP, "short-lived temporary memory");
 DEFINE_MTYPE(BFDD, BFDD_CONFIG, "long-lived configuration memory");
 DEFINE_MTYPE(BFDD, BFDD_LABEL, "long-lived label memory");
 DEFINE_MTYPE(BFDD, BFDD_CONTROL, "long-lived control socket memory");
+DEFINE_MTYPE(BFDD, BFDD_SESSION_OBSERVER, "Session observer");
 DEFINE_MTYPE(BFDD, BFDD_NOTIFICATION, "short-lived control notification data");
 
 /* Master of threads. */
@@ -153,6 +154,7 @@ struct bfd_state_str_list state_list[] = {
 static void bg_init(void)
 {
 	TAILQ_INIT(&bglobal.bg_bcslist);
+	TAILQ_INIT(&bglobal.bg_obslist);
 
 	bglobal.bg_shop = bp_udp_shop();
 	bglobal.bg_mhop = bp_udp_mhop();

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -369,16 +369,16 @@ static void _display_peer_header(struct vty *vty, struct bfd_session *bs)
 		vty_out(vty, "\tpeer %s", satostr(&bs->mhop.peer));
 		vty_out(vty, " multihop");
 		vty_out(vty, " local-address %s", satostr(&bs->mhop.local));
-		if (bs->mhop.vrf_name[0])
-			vty_out(vty, " vrf %s", bs->mhop.vrf_name);
+		if (bs->mhop.vrfid != VRF_DEFAULT)
+			vty_out(vty, " vrf %s", bs->vrf->name);
 		vty_out(vty, "\n");
 	} else {
 		vty_out(vty, "\tpeer %s", satostr(&bs->shop.peer));
 		if (bs->local_address.sa_sin.sin_family != AF_UNSPEC)
 			vty_out(vty, " local-address %s",
 				satostr(&bs->local_address));
-		if (bs->shop.port_name[0])
-			vty_out(vty, " interface %s", bs->shop.port_name);
+		if (bs->shop.ifindex != IFINDEX_INTERNAL)
+			vty_out(vty, " interface %s", bs->ifp->name);
 		vty_out(vty, "\n");
 	}
 
@@ -454,17 +454,16 @@ static struct json_object *_peer_json_header(struct bfd_session *bs)
 		json_object_boolean_true_add(jo, "multihop");
 		json_object_string_add(jo, "peer", satostr(&bs->mhop.peer));
 		json_object_string_add(jo, "local", satostr(&bs->mhop.local));
-		if (bs->mhop.vrf_name[0])
-			json_object_string_add(jo, "vrf", bs->mhop.vrf_name);
+		if (bs->mhop.vrfid != VRF_DEFAULT)
+			json_object_string_add(jo, "vrf", bs->vrf->name);
 	} else {
 		json_object_boolean_false_add(jo, "multihop");
 		json_object_string_add(jo, "peer", satostr(&bs->shop.peer));
 		if (bs->local_address.sa_sin.sin_family != AF_UNSPEC)
 			json_object_string_add(jo, "local",
 					       satostr(&bs->local_address));
-		if (bs->shop.port_name[0])
-			json_object_string_add(jo, "interface",
-					       bs->shop.port_name);
+		if (bs->shop.ifindex != IFINDEX_INTERNAL)
+			json_object_string_add(jo, "interface", bs->ifp->name);
 	}
 
 	if (bs->pl)
@@ -920,16 +919,16 @@ static void _bfdd_peer_write_config(struct hash_backet *hb, void *arg)
 		vty_out(vty, " peer %s", satostr(&bs->mhop.peer));
 		vty_out(vty, " multihop");
 		vty_out(vty, " local-address %s", satostr(&bs->mhop.local));
-		if (bs->mhop.vrf_name[0])
-			vty_out(vty, " vrf %s", bs->mhop.vrf_name);
+		if (bs->mhop.vrfid != VRF_DEFAULT)
+			vty_out(vty, " vrf %s", bs->vrf->name);
 		vty_out(vty, "\n");
 	} else {
 		vty_out(vty, " peer %s", satostr(&bs->shop.peer));
 		if (bs->local_address.sa_sin.sin_family != AF_UNSPEC)
 			vty_out(vty, " local-address %s",
 				satostr(&bs->local_address));
-		if (bs->shop.port_name[0])
-			vty_out(vty, " interface %s", bs->shop.port_name);
+		if (bs->shop.ifindex != IFINDEX_INTERNAL)
+			vty_out(vty, " interface %s", bs->ifp->name);
 		vty_out(vty, "\n");
 	}
 

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -200,10 +200,10 @@ DEFPY(bfd_peer_txinterval, bfd_peer_txinterval_cmd,
 	struct bfd_session *bs;
 
 	bs = VTY_GET_CONTEXT(bfd_session);
-	if (bs->up_min_tx == (uint32_t)(interval * 1000))
+	if (bs->timers.desired_min_tx == (uint32_t)(interval * 1000))
 		return CMD_SUCCESS;
 
-	bs->up_min_tx = interval * 1000;
+	bs->timers.desired_min_tx = interval * 1000;
 	bfd_set_polling(bs);
 
 	return CMD_SUCCESS;
@@ -430,20 +430,10 @@ static void _display_peer(struct vty *vty, struct bfd_session *bs)
 	vty_out(vty, "\t\tLocal timers:\n");
 	vty_out(vty, "\t\t\tReceive interval: %" PRIu32 "ms\n",
 		bs->timers.required_min_rx / 1000);
-	vty_out(vty, "\t\t\tTransmission interval: %" PRIu32 "ms",
+	vty_out(vty, "\t\t\tTransmission interval: %" PRIu32 "ms\n",
 		bs->timers.desired_min_tx / 1000);
-	if (bs->up_min_tx != bs->timers.desired_min_tx)
-		vty_out(vty, " (configured %" PRIu32 "ms)\n",
-			bs->up_min_tx / 1000);
-	else
-		vty_out(vty, "\n");
-
-	vty_out(vty, "\t\t\tEcho transmission interval: ");
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
-		vty_out(vty, "%" PRIu32 "ms\n",
-			bs->timers.required_min_echo / 1000);
-	else
-		vty_out(vty, "disabled\n");
+	vty_out(vty, "\t\t\tEcho transmission interval: %" PRIu32 "ms\n",
+		bs->timers.required_min_echo / 1000);
 
 	vty_out(vty, "\t\tRemote timers:\n");
 	vty_out(vty, "\t\t\tReceive interval: %" PRIu32 "ms\n",
@@ -948,9 +938,9 @@ static void _bfdd_peer_write_config(struct hash_backet *hb, void *arg)
 	if (bs->timers.required_min_rx != (BPC_DEF_RECEIVEINTERVAL * 1000))
 		vty_out(vty, "  receive-interval %" PRIu32 "\n",
 			bs->timers.required_min_rx / 1000);
-	if (bs->up_min_tx != (BPC_DEF_TRANSMITINTERVAL * 1000))
+	if (bs->timers.desired_min_tx != (BPC_DEF_TRANSMITINTERVAL * 1000))
 		vty_out(vty, "  transmit-interval %" PRIu32 "\n",
-			bs->up_min_tx / 1000);
+			bs->timers.desired_min_tx / 1000);
 	if (bs->timers.required_min_echo != (BPC_DEF_ECHOINTERVAL * 1000))
 		vty_out(vty, "  echo-interval %" PRIu32 "\n",
 			bs->timers.required_min_echo / 1000);

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -283,7 +283,7 @@ DEFPY(bfd_peer_echo, bfd_peer_echo_cmd, "[no] echo-mode",
 			return CMD_SUCCESS;
 
 		BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
-		ptm_bfd_echo_stop(bs, 0);
+		ptm_bfd_echo_stop(bs);
 	} else {
 		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
 			return CMD_SUCCESS;

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -131,6 +131,10 @@ DEFUN_NOSH(
 		vty_out(vty, "%% VRF is not mixable with interface\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
+	if (vrfname && !mhop) {
+		vty_out(vty, "%% VRF only applies with multihop.\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
 	strtosa(peer, &psa);
 	if (local) {

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -293,9 +293,8 @@ DEFPY(bfd_peer_echo, bfd_peer_echo_cmd, "[no] echo-mode",
 
 		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
 		/* Apply setting immediately. */
-		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN)) {
+		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
 			bs_echo_timer_handler(bs);
-		}
 	}
 
 	return CMD_SUCCESS;

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -291,8 +291,7 @@ DEFPY(bfd_peer_echo, bfd_peer_echo_cmd, "[no] echo-mode",
 		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
 		/* Apply setting immediately. */
 		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN)) {
-			ptm_bfd_echo_start(bs);
-			bfd_echo_recvtimer_update(bs);
+			bs_echo_timer_handler(bs);
 		}
 	}
 

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -171,7 +171,6 @@ DEFPY(bfd_peer_detectmultiplier, bfd_peer_detectmultiplier_cmd,
 		return CMD_SUCCESS;
 
 	bs->detect_mult = multiplier;
-	bfd_set_polling(bs);
 
 	return CMD_SUCCESS;
 }
@@ -222,7 +221,6 @@ DEFPY(bfd_peer_echointerval, bfd_peer_echointerval_cmd,
 		return CMD_SUCCESS;
 
 	bs->timers.required_min_echo = interval * 1000;
-	bfd_set_polling(bs);
 
 	return CMD_SUCCESS;
 }

--- a/bfdd/config.c
+++ b/bfdd/config.c
@@ -321,9 +321,9 @@ static int parse_peer_label_config(struct json_object *jo,
 		}
 	} else {
 		bpc->bpc_peer = pl->pl_bs->shop.peer;
-		if (pl->pl_bs->shop.ifindex != IFINDEX_INTERNAL) {
+		if (pl->pl_bs->ifname[0]) {
 			bpc->bpc_has_localif = true;
-			strlcpy(bpc->bpc_localif, pl->pl_bs->ifp->name,
+			strlcpy(bpc->bpc_localif, pl->pl_bs->ifname,
 				sizeof(bpc->bpc_localif));
 		}
 	}
@@ -531,8 +531,8 @@ static int json_object_add_peer(struct json_object *jo, struct bfd_session *bs)
 				       satostr(&bs->mhop.peer));
 		json_object_string_add(jo, "local-address",
 				       satostr(&bs->mhop.local));
-		if (bs->mhop.vrfid != VRF_DEFAULT)
-			json_object_string_add(jo, "vrf-name", bs->vrf->name);
+		if (bs->vrfname[0])
+			json_object_string_add(jo, "vrf-name", bs->vrfname);
 	} else {
 		json_object_boolean_false_add(jo, "multihop");
 		json_object_string_add(jo, "peer-address",
@@ -540,9 +540,9 @@ static int json_object_add_peer(struct json_object *jo, struct bfd_session *bs)
 		if (bs->local_address.sa_sin.sin_family != AF_UNSPEC)
 			json_object_string_add(jo, "local-address",
 					       satostr(&bs->local_address));
-		if (bs->shop.ifindex != IFINDEX_INTERNAL)
+		if (bs->ifname[0])
 			json_object_string_add(jo, "local-interface",
-					       bs->ifp->name);
+					       bs->ifname);
 	}
 
 	if (bs->pl)

--- a/bfdd/config.c
+++ b/bfdd/config.c
@@ -314,16 +314,16 @@ static int parse_peer_label_config(struct json_object *jo,
 	if (bpc->bpc_mhop) {
 		bpc->bpc_peer = pl->pl_bs->mhop.peer;
 		bpc->bpc_local = pl->pl_bs->mhop.local;
-		if (pl->pl_bs->mhop.vrf_name[0]) {
+		if (pl->pl_bs->mhop.vrfid != VRF_DEFAULT) {
 			bpc->bpc_has_vrfname = true;
-			strlcpy(bpc->bpc_vrfname, pl->pl_bs->mhop.vrf_name,
+			strlcpy(bpc->bpc_vrfname, pl->pl_bs->vrf->name,
 				sizeof(bpc->bpc_vrfname));
 		}
 	} else {
 		bpc->bpc_peer = pl->pl_bs->shop.peer;
-		if (pl->pl_bs->shop.port_name[0]) {
+		if (pl->pl_bs->shop.ifindex != IFINDEX_INTERNAL) {
 			bpc->bpc_has_localif = true;
-			strlcpy(bpc->bpc_localif, pl->pl_bs->shop.port_name,
+			strlcpy(bpc->bpc_localif, pl->pl_bs->ifp->name,
 				sizeof(bpc->bpc_localif));
 		}
 	}
@@ -531,9 +531,8 @@ static int json_object_add_peer(struct json_object *jo, struct bfd_session *bs)
 				       satostr(&bs->mhop.peer));
 		json_object_string_add(jo, "local-address",
 				       satostr(&bs->mhop.local));
-		if (strlen(bs->mhop.vrf_name) > 0)
-			json_object_string_add(jo, "vrf-name",
-					       bs->mhop.vrf_name);
+		if (bs->mhop.vrfid != VRF_DEFAULT)
+			json_object_string_add(jo, "vrf-name", bs->vrf->name);
 	} else {
 		json_object_boolean_false_add(jo, "multihop");
 		json_object_string_add(jo, "peer-address",
@@ -541,9 +540,9 @@ static int json_object_add_peer(struct json_object *jo, struct bfd_session *bs)
 		if (bs->local_address.sa_sin.sin_family != AF_UNSPEC)
 			json_object_string_add(jo, "local-address",
 					       satostr(&bs->local_address));
-		if (strlen(bs->shop.port_name) > 0)
+		if (bs->shop.ifindex != IFINDEX_INTERNAL)
 			json_object_string_add(jo, "local-interface",
-					       bs->shop.port_name);
+					       bs->ifp->name);
 	}
 
 	if (bs->pl)

--- a/bfdd/config.c
+++ b/bfdd/config.c
@@ -471,7 +471,8 @@ char *config_notify_config(const char *op, struct bfd_session *bs)
 	json_object_int_add(resp, "detect-multiplier", bs->detect_mult);
 	json_object_int_add(resp, "receive-interval",
 			    bs->timers.required_min_rx / 1000);
-	json_object_int_add(resp, "transmit-interval", bs->up_min_tx / 1000);
+	json_object_int_add(resp, "transmit-interval",
+			    bs->timers.desired_min_tx / 1000);
 	json_object_int_add(resp, "echo-interval",
 			    bs->timers.required_min_echo / 1000);
 

--- a/bfdd/event.c
+++ b/bfdd/event.c
@@ -43,7 +43,8 @@ void bfd_recvtimer_update(struct bfd_session *bs)
 	bfd_recvtimer_delete(bs);
 
 	/* Don't add event if peer is deactivated. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
+	    bs->sock == -1)
 		return;
 
 	tv_normalize(&tv);
@@ -63,7 +64,8 @@ void bfd_echo_recvtimer_update(struct bfd_session *bs)
 	bfd_echo_recvtimer_delete(bs);
 
 	/* Don't add event if peer is deactivated. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
+	    bs->sock == -1)
 		return;
 
 	tv_normalize(&tv);
@@ -83,7 +85,8 @@ void bfd_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 	bfd_xmttimer_delete(bs);
 
 	/* Don't add event if peer is deactivated. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
+	    bs->sock == -1)
 		return;
 
 	tv_normalize(&tv);
@@ -102,7 +105,8 @@ void bfd_echo_xmttimer_update(struct bfd_session *bs, uint64_t jitter)
 	bfd_echo_xmttimer_delete(bs);
 
 	/* Don't add event if peer is deactivated. */
-	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN) ||
+	    bs->sock == -1)
 		return;
 
 	tv_normalize(&tv);

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -597,23 +597,78 @@ static void bfdd_zebra_connected(struct zclient *zc)
 	zclient_send_message(zclient);
 }
 
-static int bfdd_interface_update(int cmd, struct zclient *zc, uint16_t len,
+static void bfdd_sessions_enable_interface(struct interface *ifp)
+{
+	struct bfd_session_observer *bso;
+	struct bfd_session *bs;
+
+	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
+		if (bso->bso_isinterface == false)
+			continue;
+
+		/* Interface name mismatch. */
+		bs = bso->bso_bs;
+		if (strcmp(ifp->name, bs->ifname))
+			continue;
+		/* Skip enabled sessions. */
+		if (bs->sock != -1)
+			continue;
+
+		/* Try to enable it. */
+		bfd_session_enable(bs);
+	}
+}
+
+static void bfdd_sessions_disable_interface(struct interface *ifp)
+{
+	struct bfd_session_observer *bso;
+	struct bfd_session *bs;
+
+	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
+		if (bso->bso_isinterface == false)
+			continue;
+
+		/* Interface name mismatch. */
+		bs = bso->bso_bs;
+		if (strcmp(ifp->name, bs->ifname))
+			continue;
+		/* Skip disabled sessions. */
+		if (bs->sock == -1)
+			continue;
+
+		/* Try to enable it. */
+		bfd_session_disable(bs);
+
+		TAILQ_INSERT_HEAD(&bglobal.bg_obslist, bso, bso_entry);
+	}
+}
+
+static int bfdd_interface_update(int cmd, struct zclient *zc,
+				 uint16_t len __attribute__((__unused__)),
 				 vrf_id_t vrfid)
 {
+	struct interface *ifp;
+
 	/*
 	 * `zebra_interface_add_read` will handle the interface creation
 	 * on `lib/if.c`. We'll use that data structure instead of
 	 * rolling our own.
 	 */
 	if (cmd == ZEBRA_INTERFACE_ADD) {
-		zebra_interface_add_read(zc->ibuf, vrfid);
+		ifp = zebra_interface_add_read(zc->ibuf, vrfid);
+		if (ifp == NULL)
+			return 0;
+
+		bfdd_sessions_enable_interface(ifp);
 		return 0;
 	}
 
 	/* Update interface information. */
-	zebra_interface_state_read(zc->ibuf, vrfid);
+	ifp = zebra_interface_state_read(zc->ibuf, vrfid);
+	if (ifp == NULL)
+		return 0;
 
-	/* TODO: stop all sessions using this interface. */
+	bfdd_sessions_disable_interface(ifp);
 
 	return 0;
 }


### PR DESCRIPTION
### Summary

This PR contains a `bfdd` code refactory to fix bugs and make the protocol more RFC 5880 friendly.

 Highlights:

  * Move more control code out of `bfd_packet.c`;
  * Don't do a poll sequence for echo interval changes;
  * Don't ever send a BFD control packet with poll and final bit set together;
  * Centralize timer handling code into a single place;
  * Slow down control packets on connection setup (down -> init -> before up);
  * Slow down control packets on connection loss;
  * Generate random identifiers instead of using sequential numbers;
  * Fix `bfdd` start up with configuration containing interfaces (it broke when `bfdd` started using zebra to learn about interfaces);
  * Other small misc fixes;


### Components

`bfdd`