### PR TITLE
bgpd: Address performance issues in BGP route aggregation.

### DIFF
--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -22,6 +22,7 @@
 #define _QUAGGA_BGP_ASPATH_H
 
 #include "lib/json.h"
+#include "bgpd/bgp_route.h"
 
 /* AS path segment type.  */
 #define AS_SET                       1
@@ -129,5 +130,11 @@ extern unsigned int aspath_has_as4(struct aspath *);
 
 /* For SNMP BGP4PATHATTRASPATHSEGMENT, might be useful for debug */
 extern uint8_t *aspath_snmp_pathseg(struct aspath *, size_t *);
+
+extern void bgp_compute_aggregate_aspath(struct bgp_aggregate *aggregate,
+					 struct aspath *aspath);
+extern void bgp_remove_aspath_from_aggregate(struct bgp_aggregate *aggregate,
+					     struct aspath *aspath);
+extern void bgp_aggr_aspath_remove(void *arg);
 
 #endif /* _QUAGGA_BGP_ASPATH_H */

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -910,3 +910,112 @@ void community_finish(void)
 	hash_free(comhash);
 	comhash = NULL;
 }
+
+static struct community *bgp_aggr_community_lookup(
+						struct bgp_aggregate *aggregate,
+						struct community *community)
+{
+	return hash_lookup(aggregate->community_hash, community);
+}
+
+static void *bgp_aggr_communty_hash_alloc(void *p)
+{
+	struct community *ref = (struct community *)p;
+	struct community *community = NULL;
+
+	community = community_dup(ref);
+	return community;
+}
+
+static void bgp_aggr_community_prepare(struct hash_backet *hb, void *arg)
+{
+	struct community *commerge = NULL;
+	struct community *hb_community = hb->data;
+	struct community **aggr_community = arg;
+
+	if (*aggr_community) {
+		commerge = community_merge(*aggr_community, hb_community);
+		*aggr_community = community_uniq_sort(commerge);
+		community_free(&commerge);
+	} else
+		*aggr_community = community_dup(hb_community);
+}
+
+void bgp_aggr_community_remove(void *arg)
+{
+	struct community *community = arg;
+
+	community_free(&community);
+}
+
+void bgp_compute_aggregate_community(struct bgp_aggregate *aggregate,
+				     struct community *community)
+{
+	struct community *aggr_community = NULL;
+
+	if ((aggregate == NULL) || (community == NULL))
+		return;
+
+	/* Create hash if not already created.
+	 */
+	if (aggregate->community_hash == NULL)
+		aggregate->community_hash = hash_create(
+			(unsigned int (*)(void *))community_hash_make,
+			(bool (*)(const void *, const void *))community_cmp,
+			"BGP Aggregator community hash");
+
+	aggr_community = bgp_aggr_community_lookup(aggregate, community);
+	if (aggr_community == NULL) {
+		/* Insert community into hash.
+		 */
+		aggr_community = hash_get(aggregate->community_hash, community,
+					  bgp_aggr_communty_hash_alloc);
+
+		/* Re-compute aggregate's community.
+		 */
+		if (aggregate->community)
+			community_free(&aggregate->community);
+
+		hash_iterate(aggregate->community_hash,
+			     bgp_aggr_community_prepare,
+			     &aggregate->community);
+	}
+
+	/* Increment refernce counter.
+	 */
+	aggr_community->refcnt++;
+}
+
+void bgp_remove_community_from_aggregate(struct bgp_aggregate *aggregate,
+					 struct community *community)
+{
+	struct community *aggr_community = NULL;
+	struct community *ret_comm = NULL;
+
+	if ((aggregate == NULL) || (community == NULL))
+		return;
+
+	if (aggregate->community_hash == NULL)
+		return;
+
+	/* Look-up the community in the hash.
+	 */
+	aggr_community = bgp_aggr_community_lookup(aggregate, community);
+	if (aggr_community) {
+		aggr_community->refcnt--;
+
+		if (aggr_community->refcnt == 0) {
+			ret_comm = hash_release(aggregate->community_hash,
+						aggr_community);
+			community_free(&ret_comm);
+
+			community_free(&aggregate->community);
+
+			/* Compute aggregate's community.
+			 */
+			hash_iterate(aggregate->community_hash,
+				     bgp_aggr_community_prepare,
+				     &aggregate->community);
+		}
+	}
+}

--- a/bgpd/bgp_community.h
+++ b/bgpd/bgp_community.h
@@ -22,6 +22,7 @@
 #define _QUAGGA_BGP_COMMUNITY_H
 
 #include "lib/json.h"
+#include "bgpd/bgp_route.h"
 
 /* Communities attribute.  */
 struct community {
@@ -89,5 +90,10 @@ extern void community_del_val(struct community *, uint32_t *);
 extern unsigned long community_count(void);
 extern struct hash *community_hash(void);
 extern uint32_t community_val_get(struct community *com, int i);
+extern void bgp_compute_aggregate_community(struct bgp_aggregate *aggregate,
+					    struct community *community);
+extern void bgp_remove_community_from_aggregate(struct bgp_aggregate *aggregate,
+						struct community *community);
+extern void bgp_aggr_community_remove(void *arg);
 
 #endif /* _QUAGGA_BGP_COMMUNITY_H */

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1026,3 +1026,112 @@ int ecommunity_fill_pbr_action(struct ecommunity_val *ecom_eval,
 		return -1;
 	return 0;
 }
+
+static struct ecommunity *bgp_aggr_ecommunity_lookup(
+						struct bgp_aggregate *aggregate,
+						struct ecommunity *ecommunity)
+{
+	return hash_lookup(aggregate->ecommunity_hash, ecommunity);
+}
+
+static void *bgp_aggr_ecommunty_hash_alloc(void *p)
+{
+	struct ecommunity *ref = (struct ecommunity *)p;
+	struct ecommunity *ecommunity = NULL;
+
+	ecommunity = ecommunity_dup(ref);
+	return ecommunity;
+}
+
+static void bgp_aggr_ecommunity_prepare(struct hash_backet *hb, void *arg)
+{
+	struct ecommunity *ecommerge = NULL;
+	struct ecommunity *hb_ecommunity = hb->data;
+	struct ecommunity **aggr_ecommunity = arg;
+
+	if (*aggr_ecommunity) {
+		ecommerge = ecommunity_merge(*aggr_ecommunity, hb_ecommunity);
+		*aggr_ecommunity = ecommunity_uniq_sort(ecommerge);
+		ecommunity_free(&ecommerge);
+	} else
+		*aggr_ecommunity = ecommunity_dup(hb_ecommunity);
+}
+
+void bgp_aggr_ecommunity_remove(void *arg)
+{
+	struct ecommunity *ecommunity = arg;
+
+	ecommunity_free(&ecommunity);
+}
+
+void bgp_compute_aggregate_ecommunity(struct bgp_aggregate *aggregate,
+				      struct ecommunity *ecommunity)
+{
+	struct ecommunity *aggr_ecommunity = NULL;
+
+	if ((aggregate == NULL) || (ecommunity == NULL))
+		return;
+
+	/* Create hash if not already created.
+	 */
+	if (aggregate->ecommunity_hash == NULL)
+		aggregate->ecommunity_hash = hash_create(
+					ecommunity_hash_make, ecommunity_cmp,
+					"BGP Aggregator ecommunity hash");
+
+	aggr_ecommunity = bgp_aggr_ecommunity_lookup(aggregate, ecommunity);
+	if (aggr_ecommunity == NULL) {
+		/* Insert ecommunity into hash.
+		 */
+		aggr_ecommunity = hash_get(aggregate->ecommunity_hash,
+					   ecommunity,
+					   bgp_aggr_ecommunty_hash_alloc);
+
+		/* Re-compute aggregate's ecommunity.
+		 */
+		if (aggregate->ecommunity)
+			ecommunity_free(&aggregate->ecommunity);
+
+		hash_iterate(aggregate->ecommunity_hash,
+			     bgp_aggr_ecommunity_prepare,
+			     &aggregate->ecommunity);
+	}
+
+	/* Increment refernce counter.
+	 */
+	aggr_ecommunity->refcnt++;
+}
+
+void bgp_remove_ecommunity_from_aggregate(struct bgp_aggregate *aggregate,
+					  struct ecommunity *ecommunity)
+{
+	struct ecommunity *aggr_ecommunity = NULL;
+	struct ecommunity *ret_ecomm = NULL;
+
+	if ((aggregate == NULL) || (ecommunity == NULL))
+		return;
+
+	if (aggregate->ecommunity_hash == NULL)
+		return;
+
+	/* Look-up the ecommunity in the hash.
+	 */
+	aggr_ecommunity = bgp_aggr_ecommunity_lookup(aggregate, ecommunity);
+	if (aggr_ecommunity) {
+		aggr_ecommunity->refcnt--;
+
+		if (aggr_ecommunity->refcnt == 0) {
+			ret_ecomm = hash_release(aggregate->ecommunity_hash,
+						 aggr_ecommunity);
+			ecommunity_free(&ret_ecomm);
+
+			ecommunity_free(&aggregate->ecommunity);
+
+			/* Compute aggregate's ecommunity.
+			 */
+			hash_iterate(aggregate->ecommunity_hash,
+				     bgp_aggr_ecommunity_prepare,
+				     &aggregate->ecommunity);
+		}
+	}
+}

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -21,6 +21,8 @@
 #ifndef _QUAGGA_BGP_ECOMMUNITY_H
 #define _QUAGGA_BGP_ECOMMUNITY_H
 
+#include "bgpd/bgp_route.h"
+
 /* High-order octet of the Extended Communities type field.  */
 #define ECOMMUNITY_ENCODE_AS                0x00
 #define ECOMMUNITY_ENCODE_IP                0x01
@@ -183,5 +185,13 @@ extern int ecommunity_del_val(struct ecommunity *ecom,
 struct bgp_pbr_entry_action;
 extern int ecommunity_fill_pbr_action(struct ecommunity_val *ecom_eval,
 			       struct bgp_pbr_entry_action *api);
+
+extern void bgp_compute_aggregate_ecommunity(
+					struct bgp_aggregate *aggregate,
+					struct ecommunity *ecommunity);
+extern void bgp_remove_ecommunity_from_aggregate(
+					struct bgp_aggregate *aggregate,
+					struct ecommunity *ecommunity);
+extern void bgp_aggr_ecommunity_remove(void *arg);
 
 #endif /* _QUAGGA_BGP_ECOMMUNITY_H */

--- a/bgpd/bgp_lcommunity.h
+++ b/bgpd/bgp_lcommunity.h
@@ -22,6 +22,7 @@
 #define _QUAGGA_BGP_LCOMMUNITY_H
 
 #include "lib/json.h"
+#include "bgpd/bgp_route.h"
 
 /* Large Communities value is twelve octets long.  */
 #define LCOMMUNITY_SIZE                        12
@@ -70,4 +71,13 @@ extern int lcommunity_match(const struct lcommunity *,
 extern char *lcommunity_str(struct lcommunity *, bool make_json);
 extern int lcommunity_include(struct lcommunity *lcom, uint8_t *ptr);
 extern void lcommunity_del_val(struct lcommunity *lcom, uint8_t *ptr);
+
+extern void bgp_compute_aggregate_lcommunity(
+					struct bgp_aggregate *aggregate,
+					struct lcommunity *lcommunity);
+extern void bgp_remove_lcommunity_from_aggregate(
+					struct bgp_aggregate *aggregate,
+					struct lcommunity *lcommunity);
+extern void bgp_aggr_lcommunity_remove(void *arg);
+
 #endif /* _QUAGGA_BGP_LCOMMUNITY_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5513,33 +5513,6 @@ DEFPY(ipv6_bgp_network,
 		label_index ? (uint32_t)label_index : BGP_INVALID_LABEL_INDEX);
 }
 
-/* Aggreagete address:
-
-  advertise-map  Set condition to advertise attribute
-  as-set         Generate AS set path information
-  attribute-map  Set attributes of aggregate
-  route-map      Set parameters of aggregate
-  summary-only   Filter more specific routes from updates
-  suppress-map   Conditionally filter more specific routes from updates
-  <cr>
- */
-struct bgp_aggregate {
-	/* Summary-only flag. */
-	uint8_t summary_only;
-
-	/* AS set generation. */
-	uint8_t as_set;
-
-	/* Route-map for aggregated route. */
-	struct route_map *map;
-
-	/* Suppress-count. */
-	unsigned long count;
-
-	/* SAFI configuration. */
-	safi_t safi;
-};
-
 static struct bgp_aggregate *bgp_aggregate_new(void)
 {
 	return XCALLOC(MTYPE_BGP_AGGREGATE, sizeof(struct bgp_aggregate));

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -272,6 +272,71 @@ struct bgp_static {
 	struct prefix gatewayIp;
 };
 
+/* Aggreagete address:
+ *
+ *  advertise-map  Set condition to advertise attribute
+ *  as-set         Generate AS set path information
+ *  attribute-map  Set attributes of aggregate
+ *  route-map      Set parameters of aggregate
+ *  summary-only   Filter more specific routes from updates
+ *  suppress-map   Conditionally filter more specific routes from updates
+ *  <cr>
+ */
+struct bgp_aggregate {
+	/* Summary-only flag. */
+	uint8_t summary_only;
+
+	/* AS set generation. */
+	uint8_t as_set;
+
+	/* Route-map for aggregated route. */
+	struct route_map *map;
+
+	/* Suppress-count. */
+	unsigned long count;
+
+	/* Count of routes of origin type incomplete under this aggregate. */
+	unsigned long incomplete_origin_count;
+
+	/* Count of routes of origin type egp under this aggregate. */
+	unsigned long egp_origin_count;
+
+	/* Hash containing the communities of all the
+	 * routes under this aggregate.
+	 */
+	struct hash *community_hash;
+
+	/* Hash containing the extended communities of all the
+	 * routes under this aggregate.
+	 */
+	struct hash *ecommunity_hash;
+
+	/* Hash containing the large communities of all the
+	 * routes under this aggregate.
+	 */
+	struct hash *lcommunity_hash;
+
+	/* Hash containing the AS-Path of all the
+	 * routes under this aggregate.
+	 */
+	struct hash *aspath_hash;
+
+	/* Aggregate route's community. */
+	struct community *community;
+
+	/* Aggregate route's extended community. */
+	struct ecommunity *ecommunity;
+
+	/* Aggregate route's large community. */
+	struct lcommunity *lcommunity;
+
+	/* Aggregate route's as-path. */
+	struct aspath *aspath;
+
+	/* SAFI configuration. */
+	safi_t safi;
+};
+
 #define BGP_NEXTHOP_AFI_FROM_NHLEN(nhlen)                                      \
 	((nhlen) < IPV4_MAX_BYTELEN                                            \
 		 ? 0                                                           \


### PR DESCRIPTION
### Summary
In the presence of an aggregate-address, the time taken to aggregate
and advertise about 100K-1M routes by BGPD is quite large as compared
to advertising the same number of routes in the absence of the
aggregate-address.
The code that causes the bottleneck has been written generically to
handle the below two cases:
a) When a new aggregate-address is configured.
b) When new routes, that can be aggregated under an existing
aggregate-address, are received.
This change optimizes the code that handles case-(b).

**This PDF elaborates the RCA for this issue.**
[nthanikachal-PerformanceIssuesinBGPRouteAggregation-RCA-040219-2322-32.pdf](https://github.com/FRRouting/frr/files/2836663/nthanikachal-PerformanceIssuesinBGPRouteAggregation-RCA-040219-2322-32.pdf)

**This PDF explains the fix for this issue.**
[nthanikachal-PerformanceIssuesinBGPRouteAggregation-Fix-040219-2324-34.pdf](https://github.com/FRRouting/frr/files/2836665/nthanikachal-PerformanceIssuesinBGPRouteAggregation-Fix-040219-2324-34.pdf)

**This PDF provides the test-data and the impact of the fix.**
[nthanikachal-PerformanceIssuesinBGPRouteAggregation-TestDataandResults-040219-2324-36.pdf](https://github.com/FRRouting/frr/files/2836667/nthanikachal-PerformanceIssuesinBGPRouteAggregation-TestDataandResults-040219-2324-36.pdf)

### Related Issue
[2990](https://github.com/FRRouting/frr/issues/2990)

### Components
bgpd

Signed-off-by: NaveenThanikachalam <nthanikachal@vmware.com>