### PR TITLE
Ospf missing interface handling

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1402,7 +1402,6 @@ static int lib_interface_create(enum nb_event event,
 		if (vrf->vrf_id == VRF_UNKNOWN) {
 			zlog_warn("%s: VRF %s is not active", __func__,
 				  vrf->name);
-			return NB_ERR_VALIDATION;
 		}
 
 		if (!vrf_is_backend_configured())
@@ -1428,7 +1427,7 @@ static int lib_interface_create(enum nb_event event,
 #ifdef SUNOS_5
 		ifp = if_sunwzebra_get(ifname, vrf->vrf_id);
 #else
-		ifp = if_get_by_name(ifname, vrf->vrf_id);
+		ifp = if_get_by_name_vrf(ifname, vrf);
 #endif /* SUNOS_5 */
 		yang_dnode_set_entry(dnode, ifp);
 		break;

--- a/lib/if.c
+++ b/lib/if.c
@@ -258,11 +258,8 @@ void if_delete_retain(struct interface *ifp)
 }
 
 /* Delete and free interface structure. */
-void if_delete(struct interface *ifp)
+static void if_delete_vrf(struct interface *ifp, struct vrf *vrf)
 {
-	struct vrf *vrf;
-
-	vrf = vrf_lookup_by_id(ifp->vrf_id);
 	assert(vrf);
 
 	IFNAME_RB_REMOVE(vrf, ifp);
@@ -280,6 +277,15 @@ void if_delete(struct interface *ifp)
 		XFREE(MTYPE_TMP, ifp->desc);
 
 	XFREE(MTYPE_IF, ifp);
+}
+
+/* Delete and free interface structure. */
+void if_delete(struct interface *ifp)
+{
+	struct vrf *vrf;
+
+	vrf = vrf_lookup_by_id(ifp->vrf_id);
+	if_delete_vrf(ifp, vrf);
 }
 
 /* Interface existance check by index. */
@@ -1054,7 +1060,7 @@ void if_terminate(struct vrf *vrf)
 			ifp->node->info = NULL;
 			route_unlock_node(ifp->node);
 		}
-		if_delete(ifp);
+		if_delete_vrf(ifp, vrf);
 	}
 }
 

--- a/lib/if.c
+++ b/lib/if.c
@@ -455,10 +455,10 @@ struct interface *if_get_by_name_vrf(const char *name, struct vrf *vrf)
 		return NULL;
 	switch (vrf_get_backend()) {
 	case VRF_BACKEND_NETNS:
-		ifp = if_lookup_by_name(name, vrf_id);
+		ifp = if_lookup_by_name_vrf(name, vrf);
 		if (ifp)
 			return ifp;
-		return if_create(name, vrf_id);
+		return if_create_vrf(name, vrf);
 	case VRF_BACKEND_VRF_LITE:
 		ifp = if_lookup_by_name_all_vrf(name);
 		if (ifp) {

--- a/lib/if.h
+++ b/lib/if.h
@@ -27,6 +27,8 @@
 #include "qobj.h"
 #include "hook.h"
 
+struct vrf;
+
 DECLARE_MTYPE(IF)
 DECLARE_MTYPE(CONNECTED_LABEL)
 
@@ -470,6 +472,8 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
  * else think before you use VRF_UNKNOWN
  */
 extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
+extern void if_update_to_new_vrf_vrf(struct interface *ifp,
+				     struct vrf *vrf);
 extern struct interface *if_create(const char *name, vrf_id_t vrf_id);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
 extern struct interface *if_lookup_exact_address(void *matchaddr, int family,
@@ -483,7 +487,11 @@ extern struct interface *if_lookup_prefix(struct prefix *prefix,
    by a '\0' character: */
 extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
 extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
+extern struct interface *if_lookup_by_name_vrf(const char *ifname,
+					       struct vrf *vrf);
 extern struct interface *if_get_by_name(const char *ifname, vrf_id_t vrf_id);
+extern struct interface *if_get_by_name_vrf(const char *name,
+					    struct vrf *vrf);
 extern void if_set_index(struct interface *ifp, ifindex_t ifindex);
 
 /* Delete the interface, but do not free the structure, and leave it in the

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -56,6 +56,7 @@ struct vrf_id_head vrfs_by_id = RB_INITIALIZER(&vrfs_by_id);
 struct vrf_name_head vrfs_by_name = RB_INITIALIZER(&vrfs_by_name);
 
 static int vrf_backend;
+static int vrf_backend_configured;
 static struct zebra_privs_t *vrf_daemon_privs;
 static char vrf_default_name[VRF_NAMSIZ] = VRF_DEFAULT_NAME_INTERNAL;
 
@@ -606,6 +607,11 @@ int vrf_socket(int domain, int type, int protocol, vrf_id_t vrf_id,
 	return ret;
 }
 
+int vrf_is_backend_configured(void)
+{
+	return vrf_backend_configured;
+}
+
 int vrf_is_backend_netns(void)
 {
 	return (vrf_backend == VRF_BACKEND_NETNS);
@@ -619,6 +625,7 @@ int vrf_get_backend(void)
 void vrf_configure_backend(int vrf_backend_netns)
 {
 	vrf_backend = vrf_backend_netns;
+	vrf_backend_configured = 1;
 }
 
 int vrf_handler_create(struct vty *vty, const char *vrfname,

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -268,6 +268,7 @@ extern void vrf_install_commands(void);
 extern void vrf_configure_backend(int vrf_backend_netns);
 extern int vrf_get_backend(void);
 extern int vrf_is_backend_netns(void);
+extern int vrf_is_backend_configured(void);
 
 
 /* API to create a VRF. either from vty

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1435,13 +1435,18 @@ struct interface *zebra_interface_add_read(struct stream *s, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
 	char ifname_tmp[INTERFACE_NAMSIZ];
+	struct vrf *vrf;
 
+	vrf = vrf_lookup_by_id(vrf_id);
 	/* Read interface name. */
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* Lookup/create interface by name. */
-	ifp = if_get_by_name(ifname_tmp, vrf_id);
 
+	ifp = if_get_by_name_vrf(ifname_tmp, vrf);
+	if (ifp->vrf_id == VRF_UNKNOWN &&
+	    vrf->vrf_id != VRF_UNKNOWN)
+		ifp->vrf_id = vrf_id;
 	zebra_interface_if_set_value(s, ifp);
 
 	return ifp;


### PR DESCRIPTION
the changes are yet experimental.
it contains some changes.

- the creation of unidentified vrfs and interfaces.
this is for being able to store configuration from daemons relying on interface contexts
the creation of unidentified lasts not only at startup, but 
this is a change in the way frr works. 
so before going further I would like some discussion about that.
For instance, should we limit it at startup.

- as consequence, if today yang prevents from configuring over uninitialised vrfs, this should be possible from now on.

- the second point is about the backend knowledge.
actually, the capabilities exchanges may not be available at configuration loading.
so when looking at an interface, we may have to play with that status.
I would like to have a accurate search of interfaces, while vrf backend is not yet initialised.


the set of changes is not optimised ( functionsare duplicated).
this is a wip, actually.

but you will understand that I would appreciate a primary feedback if it may be acceptable.

I feel that it will simplify many changes in the future, about how to handle configuration that should be applied later.