### PR TITLE
Sharp cleanups and new cli

### DIFF
--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -75,3 +75,9 @@ keyword. At present, no sharp commands will be preserved in the config.
 
    Instruct zebra to monitor and notify sharp when the specified nexthop is
    changed. The notification from zebra is written into the debug log.
+
+.. index:: sharp data nexthop
+.. clicmd:: sharp data nexthop
+
+   Allow end user to dump associated data with the nexthop tracking that
+   may have been turned on.

--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -56,6 +56,14 @@ keyword. At present, no sharp commands will be preserved in the config.
    log and when all routes have been successfully deleted the debug log will be
    updated with this information as well.
 
+.. index:: sharp data route
+.. clicmd:: sharp data route
+
+   Allow end user doing route install and deletion to get timing information
+   from the vty or vtysh instead of having to read the log file.  This command
+   is informational only and you should look at sharp_vty.c for explanation
+   of the output as that it may change.
+
 .. index:: sharp label
 .. clicmd:: sharp label <ipv4|ipv6> vrf NAME label (0-1000000)
 

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -35,7 +35,6 @@ struct memgroup **mg_insert = &mg_first;
 
 DEFINE_MGROUP(LIB, "libfrr")
 DEFINE_MTYPE(LIB, TMP, "Temporary memory")
-DEFINE_MTYPE(LIB, PREFIX_FLOWSPEC, "Prefix Flowspec")
 
 static inline void mt_count_alloc(struct memtype *mt, size_t size, void *ptr)
 {

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -137,7 +137,6 @@ struct memgroup {
 
 DECLARE_MGROUP(LIB)
 DECLARE_MTYPE(TMP)
-DECLARE_MTYPE(PREFIX_FLOWSPEC)
 
 
 extern void *qmalloc(struct memtype *mt, size_t size)

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -30,6 +30,7 @@
 #include "lib_errors.h"
 
 DEFINE_MTYPE_STATIC(LIB, PREFIX, "Prefix")
+DEFINE_MTYPE_STATIC(LIB, PREFIX_FLOWSPEC, "Prefix Flowspec")
 
 /* Maskbit. */
 static const uint8_t maskbit[] = {0x00, 0x80, 0xc0, 0xe0, 0xf0,

--- a/sharpd/sharp_globals.h
+++ b/sharpd/sharp_globals.h
@@ -42,6 +42,7 @@ struct sharp_routes {
 };
 
 struct sharp_global {
+	/* Global data about route install/deletions */
 	struct sharp_routes r;
 };
 

--- a/sharpd/sharp_globals.h
+++ b/sharpd/sharp_globals.h
@@ -1,0 +1,28 @@
+/*
+ * SHARP - code to track globals
+ * Copyright (C) 2019 Cumulus Networks, Inc.
+ *               Donald Sharp
+ *
+ * This file is part of FRR.
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef __SHARP_GLOBAL_H__
+#define __SHARP_GLOBAL_H__
+
+struct sharp_global {
+};
+
+#endif

--- a/sharpd/sharp_globals.h
+++ b/sharpd/sharp_globals.h
@@ -22,7 +22,28 @@
 #ifndef __SHARP_GLOBAL_H__
 #define __SHARP_GLOBAL_H__
 
-struct sharp_global {
+struct sharp_routes {
+	/* The original prefix for route installation */
+	struct prefix orig_prefix;
+
+	/* The nexthop group we are using for installation */
+	struct nexthop nhop;
+	struct nexthop_group nhop_group;
+
+	uint32_t total_routes;
+	uint32_t installed_routes;
+	uint32_t removed_routes;
+	int32_t repeat;
+
+	uint8_t inst;
+
+	struct timeval t_start;
+	struct timeval t_end;
 };
 
+struct sharp_global {
+	struct sharp_routes r;
+};
+
+extern struct sharp_global sg;
 #endif

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -46,6 +46,7 @@
 
 #include "sharp_zebra.h"
 #include "sharp_vty.h"
+#include "sharp_globals.h"
 
 uint32_t total_routes = 0;
 uint32_t installed_routes = 0;
@@ -125,7 +126,12 @@ FRR_DAEMON_INFO(sharpd, SHARP, .vty_port = SHARP_VTY_PORT,
 		.privs = &sharp_privs, .yang_modules = sharpd_yang_modules,
 		.n_yang_modules = array_size(sharpd_yang_modules), )
 
-extern void sharp_vty_init(void);
+struct sharp_global sg;
+
+static void sharp_global_init(void)
+{
+	memset(&sg, 0, sizeof(sg));
+}
 
 int main(int argc, char **argv, char **envp)
 {
@@ -150,6 +156,8 @@ int main(int argc, char **argv, char **envp)
 	}
 
 	master = frr_init();
+
+	sharp_global_init();
 
 	nexthop_group_init(NULL, NULL, NULL, NULL);
 	vrf_init(NULL, NULL, NULL, NULL, NULL);

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -48,10 +48,6 @@
 #include "sharp_vty.h"
 #include "sharp_globals.h"
 
-uint32_t total_routes = 0;
-uint32_t installed_routes = 0;
-uint32_t removed_routes = 0;
-
 zebra_capabilities_t _caps_p[] = {
 };
 

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -48,6 +48,8 @@
 #include "sharp_vty.h"
 #include "sharp_globals.h"
 
+DEFINE_MGROUP(SHARPD, "sharpd")
+
 zebra_capabilities_t _caps_p[] = {
 };
 
@@ -127,6 +129,7 @@ struct sharp_global sg;
 static void sharp_global_init(void)
 {
 	memset(&sg, 0, sizeof(sg));
+	sg.nhs = list_new();
 }
 
 int main(int argc, char **argv, char **envp)

--- a/sharpd/sharp_nht.c
+++ b/sharpd/sharp_nht.c
@@ -1,0 +1,67 @@
+/*
+ * SHARP - code to track nexthops
+ * Copyright (C) Cumulus Networks, Inc.
+ *               Donald Sharp
+ *
+ * This file is part of FRR.
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include <zebra.h>
+
+#include "memory.h"
+#include "nexthop.h"
+#include "nexthop_group.h"
+#include "vty.h"
+
+#include "sharp_nht.h"
+#include "sharp_globals.h"
+
+DEFINE_MTYPE_STATIC(SHARPD, NH_TRACKER, "Nexthop Tracker")
+
+struct sharp_nh_tracker *sharp_nh_tracker_get(struct prefix *p)
+{
+	struct listnode *node;
+	struct sharp_nh_tracker *nht;
+
+	for (ALL_LIST_ELEMENTS_RO(sg.nhs, node, nht)) {
+		if (prefix_same(&nht->p, p))
+			break;
+	}
+
+	if (nht)
+		return nht;
+
+	nht = XCALLOC(MTYPE_NH_TRACKER, sizeof(*nht));
+	prefix_copy(&nht->p, p);
+
+	listnode_add(sg.nhs, nht);
+	return nht;
+}
+
+void sharp_nh_tracker_dump(struct vty *vty)
+{
+	struct listnode *node;
+	struct sharp_nh_tracker *nht;
+
+	for (ALL_LIST_ELEMENTS_RO(sg.nhs, node, nht)) {
+		char buf[PREFIX_STRLEN];
+
+		vty_out(vty, "%s: Nexthops: %u Updates: %u\n",
+			prefix2str(&nht->p, buf, sizeof(buf)),
+			nht->nhop_num,
+			nht->updates);
+	}
+}

--- a/sharpd/sharp_nht.h
+++ b/sharpd/sharp_nht.h
@@ -1,6 +1,6 @@
 /*
- * SHARP - code to track globals
- * Copyright (C) 2019 Cumulus Networks, Inc.
+ * SHARP - code to track nexthops
+ * Copyright (C) Cumulus Networks, Inc.
  *               Donald Sharp
  *
  * This file is part of FRR.
@@ -19,37 +19,20 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#ifndef __SHARP_GLOBAL_H__
-#define __SHARP_GLOBAL_H__
+#ifndef __SHARP_NHT_H__
+#define __SHARP_NHT_H__
 
-DECLARE_MGROUP(SHARPD)
+struct sharp_nh_tracker {
+	/* What are we watching */
+	struct prefix p;
 
-struct sharp_routes {
-	/* The original prefix for route installation */
-	struct prefix orig_prefix;
+	/* Number of valid nexthops */
+	uint32_t nhop_num;
 
-	/* The nexthop group we are using for installation */
-	struct nexthop nhop;
-	struct nexthop_group nhop_group;
-
-	uint32_t total_routes;
-	uint32_t installed_routes;
-	uint32_t removed_routes;
-	int32_t repeat;
-
-	uint8_t inst;
-
-	struct timeval t_start;
-	struct timeval t_end;
+	uint32_t updates;
 };
 
-struct sharp_global {
-	/* Global data about route install/deletions */
-	struct sharp_routes r;
+extern struct sharp_nh_tracker *sharp_nh_tracker_get(struct prefix *p);
 
-	/* The list of nexthops that we are watching and data about them */
-	struct list *nhs;
-};
-
-extern struct sharp_global sg;
+extern void sharp_nh_tracker_dump(struct vty *vty);
 #endif

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -79,6 +79,27 @@ DEFPY(watch_nexthop_v4, watch_nexthop_v4_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY (install_routes_data_dump,
+       install_routes_data_dump_cmd,
+       "sharp data route",
+       "Sharp routing Protocol\n"
+       "Data about what is going on\n"
+       "Route Install/Removal Information\n")
+{
+	char buf[PREFIX_STRLEN];
+	struct timeval r;
+
+	timersub(&sg.r.t_end, &sg.r.t_start, &r);
+	vty_out(vty, "Prefix: %s Total: %u %u %u Time: %ld.%ld\n",
+		prefix2str(&sg.r.orig_prefix, buf, sizeof(buf)),
+		sg.r.total_routes,
+		sg.r.installed_routes,
+		sg.r.removed_routes,
+		r.tv_sec, r.tv_usec);
+
+	return CMD_SUCCESS;
+}
+
 DEFPY (install_routes,
        install_routes_cmd,
        "sharp install routes <A.B.C.D$start4|X:X::X:X$start6> <nexthop <A.B.C.D$nexthop4|X:X::X:X$nexthop6>|nexthop-group NAME$nexthop_group> (1-1000000)$routes [instance (0-255)$instance] [repeat (2-1000)$rpt]",
@@ -235,6 +256,7 @@ DEFUN_NOSH (show_debugging_sharpd,
 
 void sharp_vty_init(void)
 {
+	install_element(ENABLE_NODE, &install_routes_data_dump_cmd);
 	install_element(ENABLE_NODE, &install_routes_cmd);
 	install_element(ENABLE_NODE, &remove_routes_cmd);
 	install_element(ENABLE_NODE, &vrf_label_cmd);

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -32,6 +32,7 @@
 
 #include "sharpd/sharp_globals.h"
 #include "sharpd/sharp_zebra.h"
+#include "sharpd/sharp_nht.h"
 #include "sharpd/sharp_vty.h"
 #ifndef VTYSH_EXTRACT_PL
 #include "sharpd/sharp_vty_clippy.c"
@@ -53,6 +54,7 @@ DEFPY(watch_nexthop_v6, watch_nexthop_v6_cmd,
 	memcpy(&p.u.prefix6, &nhop, 16);
 	p.family = AF_INET6;
 
+	sharp_nh_tracker_get(&p);
 	sharp_zebra_nexthop_watch(&p, true, !!connected);
 
 	return CMD_SUCCESS;
@@ -74,7 +76,20 @@ DEFPY(watch_nexthop_v4, watch_nexthop_v4_cmd,
 	p.u.prefix4 = nhop;
 	p.family = AF_INET;
 
+	sharp_nh_tracker_get(&p);
 	sharp_zebra_nexthop_watch(&p, true, !!connected);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(sharp_nht_data_dump,
+      sharp_nht_data_dump_cmd,
+      "sharp data nexthop",
+      "Sharp routing Protocol\n"
+      "Nexthop information\n"
+      "Data Dump\n")
+{
+	sharp_nh_tracker_dump(vty);
 
 	return CMD_SUCCESS;
 }
@@ -260,6 +275,7 @@ void sharp_vty_init(void)
 	install_element(ENABLE_NODE, &install_routes_cmd);
 	install_element(ENABLE_NODE, &remove_routes_cmd);
 	install_element(ENABLE_NODE, &vrf_label_cmd);
+	install_element(ENABLE_NODE, &sharp_nht_data_dump_cmd);
 	install_element(ENABLE_NODE, &watch_nexthop_v6_cmd);
 	install_element(ENABLE_NODE, &watch_nexthop_v4_cmd);
 

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -49,11 +49,12 @@ uint32_t rts;
 int32_t repeat;
 
 DEFPY(watch_nexthop_v6, watch_nexthop_v6_cmd,
-      "sharp watch nexthop X:X::X:X$nhop",
+      "sharp watch nexthop X:X::X:X$nhop [connected$connected]",
       "Sharp routing Protocol\n"
       "Watch for changes\n"
       "Watch for nexthop changes\n"
-      "The v6 nexthop to signal for watching\n")
+      "The v6 nexthop to signal for watching\n"
+      "Should the route be connected\n")
 {
 	struct prefix p;
 
@@ -63,17 +64,18 @@ DEFPY(watch_nexthop_v6, watch_nexthop_v6_cmd,
 	memcpy(&p.u.prefix6, &nhop, 16);
 	p.family = AF_INET6;
 
-	sharp_zebra_nexthop_watch(&p, true);
+	sharp_zebra_nexthop_watch(&p, true, !!connected);
 
 	return CMD_SUCCESS;
 }
 
 DEFPY(watch_nexthop_v4, watch_nexthop_v4_cmd,
-      "sharp watch nexthop A.B.C.D$nhop",
+      "sharp watch nexthop A.B.C.D$nhop [connected$connected]",
       "Sharp routing Protocol\n"
       "Watch for changes\n"
       "Watch for nexthop changes\n"
-      "The v4 nexthop to signal for watching\n")
+      "The v4 nexthop to signal for watching\n"
+      "Should the route be connected\n")
 {
 	struct prefix p;
 
@@ -83,7 +85,7 @@ DEFPY(watch_nexthop_v4, watch_nexthop_v4_cmd,
 	p.u.prefix4 = nhop;
 	p.family = AF_INET;
 
-	sharp_zebra_nexthop_watch(&p, true);
+	sharp_zebra_nexthop_watch(&p, true, !!connected);
 
 	return CMD_SUCCESS;
 }

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -328,14 +328,14 @@ void route_delete(struct prefix *p, uint8_t instance)
 	return;
 }
 
-void sharp_zebra_nexthop_watch(struct prefix *p, bool watch)
+void sharp_zebra_nexthop_watch(struct prefix *p, bool watch, bool connected)
 {
 	int command = ZEBRA_NEXTHOP_REGISTER;
 
 	if (!watch)
 		command = ZEBRA_NEXTHOP_UNREGISTER;
 
-	if (zclient_send_rnh(zclient, command, p, true, VRF_DEFAULT) < 0)
+	if (zclient_send_rnh(zclient, command, p, connected, VRF_DEFAULT) < 0)
 		zlog_warn("%s: Failure to send nexthop to zebra",
 			  __PRETTY_FUNCTION__);
 }

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -37,6 +37,7 @@
 #include "nexthop_group.h"
 
 #include "sharp_globals.h"
+#include "sharp_nht.h"
 #include "sharp_zebra.h"
 
 /* Zebra structure to hold current status. */
@@ -334,6 +335,7 @@ void sharp_zebra_nexthop_watch(struct prefix *p, bool watch, bool connected)
 static int sharp_nexthop_update(int command, struct zclient *zclient,
 				zebra_size_t length, vrf_id_t vrf_id)
 {
+	struct sharp_nh_tracker *nht;
 	struct zapi_route nhr;
 	char buf[PREFIX_STRLEN];
 	int i;
@@ -346,6 +348,11 @@ static int sharp_nexthop_update(int command, struct zclient *zclient,
 
 	zlog_debug("Received update for %s",
 		   prefix2str(&nhr.prefix, buf, sizeof(buf)));
+
+	nht = sharp_nh_tracker_get(&nhr.prefix);
+	nht->nhop_num = nhr.nexthop_num;
+	nht->updates++;
+
 	for (i = 0; i < nhr.nexthop_num; i++) {
 		struct zapi_nexthop *znh = &nhr.nexthops[i];
 

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -28,7 +28,8 @@ extern void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label);
 extern void route_add(struct prefix *p, uint8_t instance,
 		      struct nexthop_group *nhg);
 extern void route_delete(struct prefix *p, uint8_t instance);
-extern void sharp_zebra_nexthop_watch(struct prefix *p, bool watch);
+extern void sharp_zebra_nexthop_watch(struct prefix *p, bool watch,
+				      bool connected);
 
 extern void sharp_install_routes_helper(struct prefix *p, uint8_t instance,
 					 struct nexthop_group *nhg,

--- a/sharpd/subdir.am
+++ b/sharpd/subdir.am
@@ -11,11 +11,13 @@ man8 += $(MANBUILD)/sharpd.8
 endif
 
 sharpd_libsharp_a_SOURCES = \
+	sharpd/sharp_nht.c \
 	sharpd/sharp_zebra.c \
 	sharpd/sharp_vty.c \
 	# end
 
 noinst_HEADERS += \
+	sharpd/sharp_nht.h \
 	sharpd/sharp_vty.h \
 	sharpd/sharp_globals.h \
 	sharpd/sharp_zebra.h \

--- a/sharpd/subdir.am
+++ b/sharpd/subdir.am
@@ -17,6 +17,7 @@ sharpd_libsharp_a_SOURCES = \
 
 noinst_HEADERS += \
 	sharpd/sharp_vty.h \
+	sharpd/sharp_globals.h \
 	sharpd/sharp_zebra.h \
 	# end
 


### PR DESCRIPTION
1) Cleanup global data to an improved structure
2) Add 2 new data dump commands 'sharp data [nexthop|route]` that will dump some data for use during new topotests coming down the pike.
3) Cleanup a weirdly placed memory type in memory.c