### PR TITLE
[6.0] bgpd: 'show bgp [ipv4|ipv6] neighbors' displays all address family neighbors

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -97,6 +97,9 @@ enum bgp_af_index {
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)                               \
 		for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++)
 
+#define FOREACH_SAFI(safi)                                            \
+	for (safi = SAFI_UNICAST; safi < SAFI_MAX; safi++)
+
 /* BGP master for system wide configurations and variables.  */
 struct bgp_master {
 	/* BGP instance list.  */


### PR DESCRIPTION
### Summary
Display only ipv4 neighbors when 'show bgp ipv4 neighbors' command is issued.
Display only ipv6 neighbors when 'show bgp ipv6 neighbors' command is issued.
Take the address family of the peer address into account, while displaying the neighbors.

Signed-off-by: Kiran Kella <kiran.kella@broadcom.com>

### Related Issue
https://github.com/FRRouting/frr/pull/3916  -> stable/7.0 branch
https://github.com/FRRouting/frr/pull/3860  -> master branch

### Components
[bgpd]
