### PR TITLE
pimd: fix for finding un-numbered interface

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -877,6 +877,20 @@ struct connected *connected_add_by_prefix(struct interface *ifp,
 	return ifc;
 }
 
+int if_is_unnumbered(struct interface *ifp)
+{
+	struct connected *connected;
+	struct listnode *node;
+
+	for (ALL_LIST_ELEMENTS_RO(ifp->connected, node, connected)) {
+		if (CHECK_FLAG(connected->conf, ZEBRA_IFC_REAL)
+		    && connected->address->family == AF_INET)
+			return CHECK_FLAG(connected->flags,
+					ZEBRA_IFA_UNNUMBERED);
+	}
+	return 0;
+}
+
 #if 0  /* this route_table of struct connected's is unused                     \
 	* however, it would be good to use a route_table rather than           \
 	* a list..                                                             \

--- a/lib/if.h
+++ b/lib/if.h
@@ -540,7 +540,7 @@ extern struct connected *connected_lookup_prefix_exact(struct interface *,
 extern struct nbr_connected *nbr_connected_new(void);
 extern void nbr_connected_free(struct nbr_connected *);
 struct nbr_connected *nbr_connected_check(struct interface *, struct prefix *);
-
+int if_is_unnumbered(struct interface *);
 /* link parameters */
 struct if_link_params *if_link_params_get(struct interface *);
 void if_link_params_free(struct interface *);

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -582,17 +582,3 @@ void connected_delete_ipv6(struct interface *ifp, struct in6_addr *address,
 
 	connected_delete_helper(ifc, &p);
 }
-
-int connected_is_unnumbered(struct interface *ifp)
-{
-	struct connected *connected;
-	struct listnode *node;
-
-	for (ALL_LIST_ELEMENTS_RO(ifp->connected, node, connected)) {
-		if (CHECK_FLAG(connected->conf, ZEBRA_IFC_REAL)
-		    && connected->address->family == AF_INET)
-			return CHECK_FLAG(connected->flags,
-					  ZEBRA_IFA_UNNUMBERED);
-	}
-	return 0;
-}

--- a/zebra/connected.h
+++ b/zebra/connected.h
@@ -56,6 +56,4 @@ extern void connected_delete_ipv6(struct interface *ifp,
 				  struct in6_addr *address,
 				  struct in6_addr *broad, uint16_t prefixlen);
 
-extern int connected_is_unnumbered(struct interface *);
-
 #endif /*_ZEBRA_CONNECTED_H */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -276,7 +276,7 @@ struct nexthop *route_entry_nexthop_ipv4_ifindex_add(struct route_entry *re,
 	/*Pending: need to think if null ifp here is ok during bootup?
 	  There was a crash because ifp here was coming to be NULL */
 	if (ifp)
-		if (connected_is_unnumbered(ifp)
+		if (if_is_unnumbered(ifp)
 		    || CHECK_FLAG(re->flags, ZEBRA_FLAG_EVPN_ROUTE)) {
 			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK);
 		}
@@ -470,7 +470,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 					nexthop->vrf_id);
 			return 0;
 		}
-		if (connected_is_unnumbered(ifp)) {
+		if (if_is_unnumbered(ifp)) {
 			if (if_is_operative(ifp))
 				return 1;
 			else {


### PR DESCRIPTION
Issue: when user shut down a pim interface, then "show ip pim interface"
shows the loop-back interface address.

Root-Casue: When we shut down a pim interface, zebra sends "interface_down"
and "interface_address_delete" messages to pimd.
1. pim_zebra_if_state_down() calls pim_if_addr_del with the flag
force_prim_as_any = true, which sets the primary address to INADDR_ANY.
Ideally It should not force the address to INADDR_ANY, but we are keeping
the existing-behaviour.(Keeping in mind we should not break anything).

2. pim_zebra_if_address_del() calls pim_if_addr_del() with the flag
force_prim_as_any = false. The function detect_primary_address_change()
will thick it is a un-numbered interface and change the primary address
to loopback address. The logic to find un-numbered is not correct.

Solution: We modified the logic to find a un-numbered interface,
which is copied from zebra/connected.c

Signed-off-by: Sarita Patra <saritap@vmware.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]
