### PR TITLE
pimd: Don't dispaly pim join information if state is NOINFO

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1644,6 +1644,15 @@ static void pim_show_join_helper(struct vty *vty, struct pim_interface *pim_ifp,
 	char expire[10];
 	char prune[10];
 
+	/* The below check is added in order to avoid printing the pim join
+	 * entry if it is in NOINFO state.
+	 *
+	 * NOINFO state maintained when the pim join entry gets created because
+	 * of IGMP report received.
+	 */
+	if (ch->ifjoin_state == PIM_IFJOIN_NOINFO)
+		return;
+
 	ifaddr = pim_ifp->primary_address;
 
 	pim_inet4_dump("<ch_src?>", ch->sg.src, ch_src_str, sizeof(ch_src_str));


### PR DESCRIPTION
Issue: The cli command "show ip pim join" in the LHR displays the
(*, G) entry as NOINFO and the join timer is not started. This is
mis-leading to the user, since "show ip pim state" commands shows
joined towards the RP and join timer is running.

Root Cause: In LHR, when we receive a IGMP report, a PIM join gets
created and state manintained as NOINFO. The state switches
from NOINFO to JOINED only when it receives PIM join. So in LHR,
pim join state shows NOINFO always.

Fix: If the state is NOINFO (that means pim join created because of
IGMP report received), don't display this information.

Signed-off-by: Sarita Patra <saritap@vmware.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]
