### PR TITLE
pimd: reject inconsistent address/mask "ip pim rp command"

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5142,6 +5142,12 @@ static int pim_rp_cmd_worker(struct pim_instance *pim, struct vty *vty,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	if (result == PIM_GROUP_BAD_ADDR_MASK_COMBO) {
+		vty_out(vty, "%% Inconsistent address and mask: %s\n",
+			group);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
 	return CMD_SUCCESS;
 }
 

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -345,6 +345,7 @@ int pim_rp_new(struct pim_instance *pim, const char *rp,
 	struct rp_info *tmp_rp_info;
 	char buffer[BUFSIZ];
 	struct prefix nht_p;
+	struct prefix temp;
 	struct pim_nexthop_cache pnc;
 	struct route_node *rn;
 
@@ -352,8 +353,17 @@ int pim_rp_new(struct pim_instance *pim, const char *rp,
 
 	if (group_range == NULL)
 		result = str2prefix("224.0.0.0/4", &rp_info->group);
-	else
+	else {
 		result = str2prefix(group_range, &rp_info->group);
+		if (result) {
+			prefix_copy(&temp, &rp_info->group);
+			apply_mask(&temp);
+			if (!prefix_same(&rp_info->group, &temp)) {
+				XFREE(MTYPE_PIM_RP, rp_info);
+				return PIM_GROUP_BAD_ADDR_MASK_COMBO;
+			}
+		}
+	}
 
 	if (!result) {
 		XFREE(MTYPE_PIM_RP, rp_info);

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -116,16 +116,17 @@
 /* Remember 32 bits!!! */
 
 /* PIM error codes */
-#define PIM_SUCCESS                0
-#define PIM_GROUP_BAD_ADDRESS     -2
-#define PIM_GROUP_OVERLAP         -3
-#define PIM_GROUP_PFXLIST_OVERLAP -4
-#define PIM_RP_BAD_ADDRESS        -5
-#define PIM_RP_NO_PATH            -6
-#define PIM_RP_NOT_FOUND          -7
-#define PIM_RP_PFXLIST_IN_USE     -8
-#define PIM_IFACE_NOT_FOUND       -9
-#define PIM_UPDATE_SOURCE_DUP     -10
+#define PIM_SUCCESS                      0
+#define PIM_GROUP_BAD_ADDRESS           -2
+#define PIM_GROUP_OVERLAP               -3
+#define PIM_GROUP_PFXLIST_OVERLAP       -4
+#define PIM_RP_BAD_ADDRESS              -5
+#define PIM_RP_NO_PATH                  -6
+#define PIM_RP_NOT_FOUND                -7
+#define PIM_RP_PFXLIST_IN_USE           -8
+#define PIM_IFACE_NOT_FOUND             -9
+#define PIM_UPDATE_SOURCE_DUP           -10
+#define PIM_GROUP_BAD_ADDR_MASK_COMBO   -11
 
 const char *const PIM_ALL_SYSTEMS;
 const char *const PIM_ALL_ROUTERS;


### PR DESCRIPTION
Issue: Configure "ip pim rp x.x.x.x 225.0.0.0/4".
Show running config shows "ip pim rp x.x.x.x 224.0.0.0/4"
This is mis-leading.

Root-cause: Internally 225.0.0.0/4 is getting converted to
224.0.0.0/4 group mask, since the prefix length is 4.

Fix: Restrict the user to configure inconsistent group address
mask by throughing a cli error "Inconsistent address and mask".

Signed-off-by: Sarita Patra <saritap@vmware.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]
