### PR TITLE
pimd: Don't refersh the oif_creation timer if S,G already present

### DIFF
--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -392,8 +392,10 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	if (channel_oil->oif_flags[pim_ifp->mroute_vif_index]
 	    & PIM_OIF_FLAG_PROTO_ANY) {
 
-		channel_oil->oif_creation[pim_ifp->mroute_vif_index] =
-			pim_time_monotonic_sec();
+		/* Updating time here is not required as this time has to
+		 * indicate when the interface is added
+		 */
+
 		channel_oil->oif_flags[pim_ifp->mroute_vif_index] |= proto_mask;
 		/* Check the OIF really exists before returning, and only log
 		   warning otherwise */


### PR DESCRIPTION
Issue: Shut the RP interface in the router RP. LHR will get to know
RP becomes not-reachable, so it send a prune towards the RP. On
receiving the prune, RP clear the (*, G) entry, but (S, G) should
not get removed if present.
Now no-shut the RP interface in the router RP. LHR will send a (*, G)
join towards the RP. On receiving join FRR create the (*, G) entry.
Along with this, it also add the interface(join received) in the OIL
of (S, G) and also refresh the (S, G) timer.

Fix: Dont refresh the timer for S, G or (*, G), if the flag for the
channel OIL is PIM_OIF_FLAG_PROTO_ANY.

Signed-off-by: Sarita Patra <saritap@vmware.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]
