### PR TITLE
bgpd: do not allocate lists on fs entries of bgp entries.

### DIFF
--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -332,14 +332,12 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 	if (display == NLRI_STRING_FORMAT_LARGE) {
 		struct bgp_path_info_extra *extra =
 			bgp_path_info_extra_get(path);
+		bool list_began = false;
 
-		if (listcount(extra->bgp_fs_pbr) ||
-		    listcount(extra->bgp_fs_iprule)) {
+		if (extra->bgp_fs_pbr && listcount(extra->bgp_fs_pbr)) {
 			struct listnode *node;
 			struct bgp_pbr_match_entry *bpme;
-			struct bgp_pbr_rule *bpr;
 			struct bgp_pbr_match *bpm;
-			bool list_began = false;
 			struct list *list_bpm;
 
 			list_bpm = list_new();
@@ -357,6 +355,14 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 					vty_out(vty, ", ");
 				vty_out(vty, "%s", bpm->ipset_name);
 			}
+			list_delete(&list_bpm);
+		}
+		if (extra->bgp_fs_iprule && listcount(extra->bgp_fs_iprule)) {
+			struct listnode *node;
+			struct bgp_pbr_rule *bpr;
+
+			if (!list_began)
+				vty_out(vty, "\tinstalled in PBR");
 			for (ALL_LIST_ELEMENTS_RO(extra->bgp_fs_iprule,
 						  node, bpr)) {
 				if (!bpr->action)
@@ -373,8 +379,8 @@ void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
 			if (list_began)
 				vty_out(vty, ")");
 			vty_out(vty, "\n");
-			list_delete(&list_bpm);
-		} else
+		}
+		if (!list_began)
 			vty_out(vty, "\tnot installed in PBR\n");
 	}
 }

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -2067,9 +2067,9 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 			struct bgp_path_info_extra *extra =
 				bgp_path_info_extra_get(path);
 
-			if (extra && extra->bgp_fs_iprule &&
-			    listnode_lookup(extra->bgp_fs_iprule,
-						     bpr)) {
+			if (extra &&
+			    listnode_lookup_nocheck(extra->bgp_fs_iprule,
+						    bpr)) {
 				if (BGP_DEBUG(pbr, PBR_ERROR))
 					zlog_err("%s: entry %p/%p already "
 						 "installed in bgp pbr iprule",
@@ -2216,8 +2216,8 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 		struct bgp_path_info_extra *extra =
 			bgp_path_info_extra_get(path);
 
-		if (extra && extra->bgp_fs_pbr &&
-		    listnode_lookup(extra->bgp_fs_pbr, bpme)) {
+		if (extra &&
+		    listnode_lookup_nocheck(extra->bgp_fs_pbr, bpme)) {
 			if (BGP_DEBUG(pbr, PBR_ERROR))
 				zlog_err(
 					"%s: entry %p/%p already installed in bgp pbr",

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1421,7 +1421,8 @@ static void bgp_pbr_flush_iprule(struct bgp *bgp, struct bgp_pbr_action *bpa,
 			/* unlink path to bpme */
 			path = (struct bgp_path_info *)bpr->path;
 			extra = bgp_path_info_extra_get(path);
-			listnode_delete(extra->bgp_fs_iprule, bpr);
+			if (extra->bgp_fs_iprule)
+				listnode_delete(extra->bgp_fs_iprule, bpr);
 			bpr->path = NULL;
 		}
 	}
@@ -1458,7 +1459,8 @@ static void bgp_pbr_flush_entry(struct bgp *bgp, struct bgp_pbr_action *bpa,
 			/* unlink path to bpme */
 			path = (struct bgp_path_info *)bpme->path;
 			extra = bgp_path_info_extra_get(path);
-			listnode_delete(extra->bgp_fs_pbr, bpme);
+			if (extra->bgp_fs_pbr)
+				listnode_delete(extra->bgp_fs_pbr, bpme);
 			bpme->path = NULL;
 		}
 	}
@@ -2065,7 +2067,8 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 			struct bgp_path_info_extra *extra =
 				bgp_path_info_extra_get(path);
 
-			if (extra && listnode_lookup(extra->bgp_fs_iprule,
+			if (extra && extra->bgp_fs_iprule &&
+			    listnode_lookup(extra->bgp_fs_iprule,
 						     bpr)) {
 				if (BGP_DEBUG(pbr, PBR_ERROR))
 					zlog_err("%s: entry %p/%p already "
@@ -2213,7 +2216,8 @@ static void bgp_pbr_policyroute_add_to_zebra_unit(struct bgp *bgp,
 		struct bgp_path_info_extra *extra =
 			bgp_path_info_extra_get(path);
 
-		if (extra && listnode_lookup(extra->bgp_fs_pbr, bpme)) {
+		if (extra && extra->bgp_fs_pbr &&
+		    listnode_lookup(extra->bgp_fs_pbr, bpme)) {
 			if (BGP_DEBUG(pbr, PBR_ERROR))
 				zlog_err(
 					"%s: entry %p/%p already installed in bgp pbr",

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -175,8 +175,8 @@ static struct bgp_path_info_extra *bgp_path_info_extra_new(void)
 		      sizeof(struct bgp_path_info_extra));
 	new->label[0] = MPLS_INVALID_LABEL;
 	new->num_labels = 0;
-	new->bgp_fs_pbr = list_new();
-	new->bgp_fs_iprule = list_new();
+	new->bgp_fs_pbr = NULL;
+	new->bgp_fs_iprule = NULL;
 	return new;
 }
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2156,9 +2156,8 @@ static int rule_notify_owner(int command, struct zclient *zclient,
 			/* link bgp_info to bgp_pbr */
 			path = (struct bgp_path_info *)bgp_pbr->path;
 			extra = bgp_path_info_extra_get(path);
-			if (!extra->bgp_fs_iprule)
-				extra->bgp_fs_iprule = list_new();
-			listnode_add(extra->bgp_fs_iprule, bgp_pbr);
+			listnode_add_force(&extra->bgp_fs_iprule,
+					   bgp_pbr);
 		}
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("%s: Received RULE_INSTALLED",
@@ -2266,9 +2265,7 @@ static int ipset_entry_notify_owner(int command, struct zclient *zclient,
 		/* link bgp_path_info to bpme */
 		path = (struct bgp_path_info *)bgp_pbime->path;
 		extra = bgp_path_info_extra_get(path);
-		if (!extra->bgp_fs_pbr)
-			extra->bgp_fs_pbr = list_new();
-		listnode_add(extra->bgp_fs_pbr, bgp_pbime);
+		listnode_add_force(&extra->bgp_fs_pbr, bgp_pbime);
 		}
 		break;
 	case ZAPI_IPSET_ENTRY_FAIL_REMOVE:

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2156,6 +2156,8 @@ static int rule_notify_owner(int command, struct zclient *zclient,
 			/* link bgp_info to bgp_pbr */
 			path = (struct bgp_path_info *)bgp_pbr->path;
 			extra = bgp_path_info_extra_get(path);
+			if (!extra->bgp_fs_iprule)
+				extra->bgp_fs_iprule = list_new();
 			listnode_add(extra->bgp_fs_iprule, bgp_pbr);
 		}
 		if (BGP_DEBUG(zebra, ZEBRA))
@@ -2264,6 +2266,8 @@ static int ipset_entry_notify_owner(int command, struct zclient *zclient,
 		/* link bgp_path_info to bpme */
 		path = (struct bgp_path_info *)bgp_pbime->path;
 		extra = bgp_path_info_extra_get(path);
+		if (!extra->bgp_fs_pbr)
+			extra->bgp_fs_pbr = list_new();
 		listnode_add(extra->bgp_fs_pbr, bgp_pbime);
 		}
 		break;

--- a/lib/linklist.c
+++ b/lib/linklist.c
@@ -259,6 +259,13 @@ struct listnode *listnode_lookup(struct list *list, void *data)
 	return NULL;
 }
 
+struct listnode *listnode_lookup_nocheck(struct list *list, void *data)
+{
+	if (!list)
+		return NULL;
+	return listnode_lookup(list, data);
+}
+
 void list_delete_node(struct list *list, struct listnode *node)
 {
 	if (node->prev)

--- a/lib/linklist.c
+++ b/lib/linklist.c
@@ -325,3 +325,10 @@ void list_sort(struct list *list, int (*cmp)(const void **, const void **))
 
 	XFREE(MTYPE_TMP, items);
 }
+
+void listnode_add_force(struct list **list, void *val)
+{
+	if (*list == NULL)
+		*list = list_new();
+	return listnode_add(*list, val);
+}

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -341,6 +341,8 @@ extern void list_add_list(struct list *list, struct list *add);
 		(L)->count--;                                                  \
 	} while (0)
 
+extern struct listnode *listnode_lookup_nocheck(struct list *list, void *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -343,6 +343,8 @@ extern void list_add_list(struct list *list, struct list *add);
 
 extern struct listnode *listnode_lookup_nocheck(struct list *list, void *data);
 
+extern void listnode_add_force(struct list **list, void *val);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
bgp entries in bgp_extra_path structure will be allocated as lists, only
when needed, that is to say when bgp fs entries will be received and
installed on the underlying system.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
