### PR TITLE
Lot's of Zebra changes

### DIFF
--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -362,6 +362,10 @@ static int isis_zebra_read(int command, struct zclient *zclient,
 	if (zapi_route_decode(zclient->ibuf, &api) < 0)
 		return -1;
 
+	if (api.prefix.family == AF_INET6
+	    && IN6_IS_ADDR_LINKLOCAL(&api.prefix.u.prefix6))
+		return 0;
+
 	/*
 	 * Avoid advertising a false default reachability. (A default
 	 * route installed by IS-IS gets redistributed from zebra back

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -226,6 +226,9 @@ static int ospf6_zebra_read_route(int command, struct zclient *zclient,
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_SRCPFX))
 		return 0;
 
+	if (IN6_IS_ADDR_LINKLOCAL(&api.prefix.u.prefix6))
+		return 0;
+
 	ifindex = api.nexthops[0].ifindex;
 	nexthop = &api.nexthops[0].gate.ipv6;
 

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -126,6 +126,9 @@ static int ripng_zebra_read_route(int command, struct zclient *zclient,
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_SRCPFX))
 		return 0;
 
+	if (IN6_IS_ADDR_LINKLOCAL(&api.prefix.u.prefix6))
+		return 0;
+
 	nexthop = api.nexthops[0].gate.ipv6;
 	ifindex = api.nexthops[0].ifindex;
 

--- a/tests/topotests/ldp-vpls-topo1/r1/zebra.conf
+++ b/tests/topotests/ldp-vpls-topo1/r1/zebra.conf
@@ -2,10 +2,12 @@ log file zebra.log
 !
 hostname r1
 !
-debug zebra rib
+debug zebra kernel
+debug zebra rib detailed
+debug zebra dplane detailed
 debug zebra nht
 debug zebra pseudowires
-debug zebra packet
+debug zebra mpls
 !
 interface lo
  ip address 1.1.1.1/32

--- a/tests/topotests/ldp-vpls-topo1/r2/zebra.conf
+++ b/tests/topotests/ldp-vpls-topo1/r2/zebra.conf
@@ -2,10 +2,11 @@ log file zebra.log
 !
 hostname r2
 !
-debug zebra rib
+debug zebra rib detailed
+debug zebra dplane detailed
+debug zebra kernel
 debug zebra nht
 debug zebra pseudowires
-debug zebra packet
 !
 interface lo
  ip address 2.2.2.2/32

--- a/tests/topotests/ldp-vpls-topo1/r3/zebra.conf
+++ b/tests/topotests/ldp-vpls-topo1/r3/zebra.conf
@@ -2,10 +2,11 @@ log file zebra.log
 !
 hostname r3
 !
-debug zebra rib
+debug zebra rib detailed
+debug zebra dplane detailed
+debug zebra kernel
 debug zebra nht
 debug zebra pseudowires
-debug zebra packet
 !
 interface lo
  ip address 3.3.3.3/32

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -272,7 +272,7 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 				ifp->vrf_id, ifp->name,
 				prefix2str(&p, buf, sizeof(buf)));
 		}
-		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id));
+		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id), &p);
 	}
 }
 
@@ -437,7 +437,7 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 				ifp->vrf_id, ifp->name,
 				prefix2str(&p, buf, sizeof(buf)));
 		}
-		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id));
+		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id), &p);
 	}
 }
 
@@ -471,7 +471,7 @@ static void connected_delete_helper(struct connected *ifc, struct prefix *p)
 				ifp->vrf_id, ifp->name,
 				prefix2str(p, buf, sizeof(buf)));
 		}
-		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id));
+		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id), p);
 	}
 }
 

--- a/zebra/debug.h
+++ b/zebra/debug.h
@@ -44,7 +44,9 @@ extern "C" {
 #define ZEBRA_DEBUG_RIB_DETAILED   0x02
 
 #define ZEBRA_DEBUG_FPM     0x01
-#define ZEBRA_DEBUG_NHT     0x01
+
+#define ZEBRA_DEBUG_NHT 0x01
+#define ZEBRA_DEBUG_NHT_DETAILED 0x02
 
 #define ZEBRA_DEBUG_MPLS    0x01
 
@@ -76,7 +78,10 @@ extern "C" {
 #define IS_ZEBRA_DEBUG_RIB_DETAILED  (zebra_debug_rib & ZEBRA_DEBUG_RIB_DETAILED)
 
 #define IS_ZEBRA_DEBUG_FPM (zebra_debug_fpm & ZEBRA_DEBUG_FPM)
+
 #define IS_ZEBRA_DEBUG_NHT  (zebra_debug_nht & ZEBRA_DEBUG_NHT)
+#define IS_ZEBRA_DEBUG_NHT_DETAILED (zebra_debug_nht & ZEBRA_DEBUG_NHT_DETAILED)
+
 #define IS_ZEBRA_DEBUG_MPLS  (zebra_debug_mpls & ZEBRA_DEBUG_MPLS)
 #define IS_ZEBRA_DEBUG_VXLAN (zebra_debug_vxlan & ZEBRA_DEBUG_VXLAN)
 #define IS_ZEBRA_DEBUG_PW  (zebra_debug_pw & ZEBRA_DEBUG_PW)

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -153,7 +153,9 @@ static void sigint(void)
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, ln, nn, client))
 		zserv_close_client(client);
 
+	zserv_close();
 	list_delete_all_node(zrouter.client_list);
+
 	zebra_ptm_finish();
 
 	if (retain_mode)

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -181,6 +181,8 @@ typedef struct rib_dest_t_ {
  */
 #define RIB_DEST_UPDATE_FPM    (1 << (ZEBRA_MAX_QINDEX + 2))
 
+#define RIB_DEST_UPDATE_LSPS   (1 << (ZEBRA_MAX_QINDEX + 3))
+
 /*
  * Macro to iterate over each route for a destination (prefix).
  */

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -145,6 +145,15 @@ typedef struct rib_dest_t_ {
 	uint32_t flags;
 
 	/*
+	 * The list of nht prefixes that have ended up
+	 * depending on this route node.
+	 * After route processing is returned from
+	 * the data plane we will run evaluate_rnh
+	 * on these prefixes.
+	 */
+	struct list *nht;
+
+	/*
 	 * Linkage to put dest on the FPM processing queue.
 	 */
 	TAILQ_ENTRY(rib_dest_t_) fpm_q_entries;
@@ -358,6 +367,8 @@ extern int rib_gc_dest(struct route_node *rn);
 extern struct route_table *rib_tables_iter_next(rib_tables_iter_t *iter);
 
 extern uint8_t route_distance(int type);
+
+extern void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq);
 
 /*
  * Inline functions.

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -431,6 +431,11 @@ static inline struct zebra_vrf *rib_dest_vrf(rib_dest_t *dest)
 }
 
 /*
+ * Create the rib_dest_t and attach it to the specified node
+ */
+extern rib_dest_t *zebra_rib_create_dest(struct route_node *rn);
+
+/*
  * rib_tables_iter_init
  */
 static inline void rib_tables_iter_init(rib_tables_iter_t *iter)

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -35,6 +35,9 @@
 extern "C" {
 #endif
 
+#define RSYSTEM_ROUTE(type)						\
+	((type) == ZEBRA_ROUTE_KERNEL || (type) == ZEBRA_ROUTE_CONNECT)
+
 /*
  * Update or delete a route, LSP, or pseudowire from the kernel,
  * using info from a dataplane context.

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1836,7 +1836,9 @@ enum zebra_dplane_result kernel_route_update(struct zebra_dplane_ctx *ctx)
 			 * of the route delete.  If that happens yeah we're
 			 * screwed.
 			 */
-			(void)netlink_route_multipath(RTM_DELROUTE, ctx);
+			if (!RSYSTEM_ROUTE(dplane_ctx_get_old_type(ctx)))
+				(void)netlink_route_multipath(RTM_DELROUTE,
+							      ctx);
 			cmd = RTM_NEWROUTE;
 		}
 
@@ -1844,7 +1846,10 @@ enum zebra_dplane_result kernel_route_update(struct zebra_dplane_ctx *ctx)
 		return ZEBRA_DPLANE_REQUEST_FAILURE;
 	}
 
-	ret = netlink_route_multipath(cmd, ctx);
+	if (!RSYSTEM_ROUTE(dplane_ctx_get_type(ctx)))
+		ret = netlink_route_multipath(cmd, ctx);
+	else
+		ret = 0;
 	if ((cmd == RTM_NEWROUTE) && (ret == 0)) {
 		/* Update installed nexthops to signal which have been
 		 * installed.

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1232,7 +1232,7 @@ void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq)
 	struct rnh *rnh;
 
 	/*
-	 * We are storing the rnh's associated with
+	 * We are storing the rnh's associated withb
 	 * the tracked nexthop as a list of the rn's.
 	 * Unresolved rnh's are placed at the top
 	 * of the tree list.( 0.0.0.0/0 for v4 and 0::0/0 for v6 )
@@ -1241,6 +1241,13 @@ void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq)
 	 * would match a more specific route
 	 */
 	while (rn) {
+		if (IS_ZEBRA_DEBUG_NHT_DETAILED) {
+			char buf[PREFIX_STRLEN];
+
+			zlog_debug("%s: %s Being examined for Nexthop Tracking",
+				   __PRETTY_FUNCTION__,
+				   srcdest_rnode2str(rn, buf, sizeof(buf)));
+		}
 		if (!dest) {
 			rn = rn->parent;
 			if (rn)
@@ -1258,13 +1265,13 @@ void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq)
 				zebra_vrf_lookup_by_id(rnh->vrf_id);
 			struct prefix *p = &rnh->node->p;
 
-			if (IS_ZEBRA_DEBUG_NHT) {
+			if (IS_ZEBRA_DEBUG_NHT_DETAILED) {
 				char buf1[PREFIX_STRLEN];
 				char buf2[PREFIX_STRLEN];
 
 				zlog_debug("%u:%s has Nexthop(%s) depending on it, evaluating %u:%u",
 					   zvrf->vrf->vrf_id,
-					   prefix2str(&rn->p, buf1,
+					   srcdest_rnode2str(rn, buf1,
 						      sizeof(buf1)),
 					   prefix2str(p, buf2, sizeof(buf2)),
 					   seq, rnh->seqno);
@@ -1282,8 +1289,12 @@ void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq)
 			 * we were originally as such we know that
 			 * that sequence number is ok to respect.
 			 */
-			if (rnh->seqno == seq)
+			if (rnh->seqno == seq) {
+				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
+					zlog_debug(
+						"\tNode processed and moved already");
 				continue;
+			}
 
 			rnh->seqno = seq;
 			zebra_evaluate_rnh(zvrf, family2afi(p->family), 0,

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1932,7 +1932,7 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 					   dplane_ctx_get_vrf(ctx),
 					   dest_str, old_re);
 		} else
-			UNSET_FLAG(re->status, ROUTE_ENTRY_QUEUED);
+			UNSET_FLAG(old_re->status, ROUTE_ENTRY_QUEUED);
 	}
 
 	switch (op) {

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1205,6 +1205,16 @@ static int rib_can_delete_dest(rib_dest_t *dest)
 	}
 
 	/*
+	 * Unresolved rnh's are stored on the default route's list
+	 *
+	 * dest->rnode can also be the source prefix node in an
+	 * ipv6 sourcedest table.  Fortunately the prefix of a
+	 * source prefix node can never be the default prefix.
+	 */
+	if (is_default_prefix(&dest->rnode->p))
+		return 0;
+
+	/*
 	 * Don't delete the dest if we have to update the FPM about this
 	 * prefix.
 	 */

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2010,9 +2010,10 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 			zsend_route_notify_owner_ctx(ctx, ZAPI_ROUTE_INSTALLED);
 
 		} else {
-			if (re)
+			if (re) {
 				SET_FLAG(re->status, ROUTE_ENTRY_FAILED);
-			if (old_re)
+				UNSET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+			} if (old_re)
 				SET_FLAG(old_re->status, ROUTE_ENTRY_FAILED);
 			if (re)
 				zsend_route_notify_owner(re, dest_pfx,

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2314,6 +2314,18 @@ static void rib_queue_init(void)
 	return;
 }
 
+rib_dest_t *zebra_rib_create_dest(struct route_node *rn)
+{
+	rib_dest_t *dest;
+
+	dest = XCALLOC(MTYPE_RIB_DEST, sizeof(rib_dest_t));
+	route_lock_node(rn); /* rn route table reference */
+	rn->info = dest;
+	dest->rnode = rn;
+
+	return dest;
+}
+
 /* RIB updates are processed via a queue of pointers to route_nodes.
  *
  * The queue length is bounded by the maximal size of the routing table,
@@ -2366,10 +2378,7 @@ static void rib_link(struct route_node *rn, struct route_entry *re, int process)
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 			rnode_debug(rn, re->vrf_id, "rn %p adding dest", rn);
 
-		dest = XCALLOC(MTYPE_RIB_DEST, sizeof(rib_dest_t));
-		route_lock_node(rn); /* rn route table reference */
-		rn->info = dest;
-		dest->rnode = rn;
+		dest = zebra_rib_create_dest(rn);
 	}
 
 	head = dest->routes;

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1175,10 +1175,7 @@ static void rib_uninstall(struct route_node *rn, struct route_entry *re)
 		if (zebra_rib_labeled_unicast(re))
 			zebra_mpls_lsp_uninstall(info->zvrf, rn, re);
 
-		if (!RIB_SYSTEM_ROUTE(re))
-			rib_uninstall_kernel(rn, re);
-		else
-			UNSET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+		rib_uninstall_kernel(rn, re);
 
 		dest->selected_fib = NULL;
 
@@ -1258,8 +1255,6 @@ int rib_gc_dest(struct route_node *rn)
 static void rib_process_add_fib(struct zebra_vrf *zvrf, struct route_node *rn,
 				struct route_entry *new)
 {
-	rib_dest_t *dest = rib_dest_from_rnode(rn);
-
 	hook_call(rib_update, rn, "new route selected");
 
 	/* Update real nexthop. This may actually determine if nexthop is active
@@ -1281,10 +1276,7 @@ static void rib_process_add_fib(struct zebra_vrf *zvrf, struct route_node *rn,
 	if (zebra_rib_labeled_unicast(new))
 		zebra_mpls_lsp_install(zvrf, rn, new);
 
-	if (!RIB_SYSTEM_ROUTE(new))
-		rib_install_kernel(rn, new, NULL);
-	else
-		dest->selected_fib = new;
+	rib_install_kernel(rn, new, NULL);
 
 	UNSET_FLAG(new->status, ROUTE_ENTRY_CHANGED);
 }
@@ -1292,7 +1284,6 @@ static void rib_process_add_fib(struct zebra_vrf *zvrf, struct route_node *rn,
 static void rib_process_del_fib(struct zebra_vrf *zvrf, struct route_node *rn,
 				struct route_entry *old)
 {
-	rib_dest_t *dest = rib_dest_from_rnode(rn);
 	hook_call(rib_update, rn, "removing existing route");
 
 	/* Uninstall from kernel. */
@@ -1308,20 +1299,7 @@ static void rib_process_del_fib(struct zebra_vrf *zvrf, struct route_node *rn,
 	if (zebra_rib_labeled_unicast(old))
 		zebra_mpls_lsp_uninstall(zvrf, rn, old);
 
-	if (!RIB_SYSTEM_ROUTE(old))
-		rib_uninstall_kernel(rn, old);
-	else {
-		UNSET_FLAG(old->status, ROUTE_ENTRY_INSTALLED);
-		/*
-		 * We are setting this to NULL here
-		 * because that is what we traditionally
-		 * have been doing.  I am not positive
-		 * that this is the right thing to do
-		 * but let's leave the code alone
-		 * for the RIB_SYSTEM_ROUTE case
-		 */
-		dest->selected_fib = NULL;
-	}
+	rib_uninstall_kernel(rn, old);
 
 	/* Update nexthop for route, reset changed flag. */
 	/* Note: this code also handles the Linux case when an interface goes
@@ -1340,9 +1318,7 @@ static void rib_process_update_fib(struct zebra_vrf *zvrf,
 				   struct route_entry *old,
 				   struct route_entry *new)
 {
-	struct nexthop *nexthop = NULL;
 	int nh_active = 0;
-	rib_dest_t *dest = rib_dest_from_rnode(rn);
 
 	/*
 	 * We have to install or update if a new route has been selected or
@@ -1384,48 +1360,15 @@ static void rib_process_update_fib(struct zebra_vrf *zvrf,
 			if (zebra_rib_labeled_unicast(old))
 				zebra_mpls_lsp_uninstall(zvrf, rn, old);
 
-			/* Non-system route should be installed. */
-			if (!RIB_SYSTEM_ROUTE(new)) {
-				/* If labeled-unicast route, install transit
-				 * LSP. */
-				if (zebra_rib_labeled_unicast(new))
-					zebra_mpls_lsp_install(zvrf, rn, new);
+			/*
+			 * Non-system route should be installed.
+			 * If labeled-unicast route, install transit
+			 * LSP.
+			 */
+			if (zebra_rib_labeled_unicast(new))
+				zebra_mpls_lsp_install(zvrf, rn, new);
 
-				rib_install_kernel(rn, new, old);
-			} else {
-				UNSET_FLAG(new->status, ROUTE_ENTRY_INSTALLED);
-				/*
-				 * We do not need to install the
-				 * selected route because it
-				 * is already isntalled by
-				 * the system( ie not us )
-				 * so just mark it as winning
-				 * we do need to ensure that
-				 * if we uninstall a route
-				 * from ourselves we don't
-				 * over write this pointer
-				 */
-				dest->selected_fib = new;
-			}
-			/* If install succeeded or system route, cleanup flags
-			 * for prior route. */
-			if (new != old) {
-				if (RIB_SYSTEM_ROUTE(new)) {
-					if (!RIB_SYSTEM_ROUTE(old))
-						rib_uninstall_kernel(rn, old);
-					else
-						UNSET_FLAG(
-							old->status,
-							ROUTE_ENTRY_INSTALLED);
-				} else {
-					UNSET_FLAG(old->status,
-						   ROUTE_ENTRY_INSTALLED);
-					for (nexthop = old->ng.nexthop; nexthop;
-					     nexthop = nexthop->next)
-						UNSET_FLAG(nexthop->flags,
-							   NEXTHOP_FLAG_FIB);
-				}
-			}
+			rib_install_kernel(rn, new, old);
 		}
 
 		/*
@@ -1455,25 +1398,18 @@ static void rib_process_update_fib(struct zebra_vrf *zvrf,
 			if (zebra_rib_labeled_unicast(old))
 				zebra_mpls_lsp_uninstall(zvrf, rn, old);
 
-			if (!RIB_SYSTEM_ROUTE(old))
-				rib_uninstall_kernel(rn, old);
-			else {
-				UNSET_FLAG(old->status, ROUTE_ENTRY_INSTALLED);
-				dest->selected_fib = NULL;
-			}
+			rib_uninstall_kernel(rn, old);
 		}
 	} else {
 		/*
 		 * Same route selected; check if in the FIB and if not,
-		 * re-install. This
-		 * is housekeeping code to deal with race conditions in kernel
-		 * with linux
-		 * netlink reporting interface up before IPv4 or IPv6 protocol
-		 * is ready
+		 * re-install. This is housekeeping code to deal with
+		 * race conditions in kernel with linux netlink reporting
+		 * interface up before IPv4 or IPv6 protocol is ready
 		 * to add routes.
 		 */
-		if (!RIB_SYSTEM_ROUTE(new)
-		    && !CHECK_FLAG(new->status, ROUTE_ENTRY_INSTALLED))
+		if (!CHECK_FLAG(new->status, ROUTE_ENTRY_INSTALLED) ||
+		    RIB_SYSTEM_ROUTE(new))
 			rib_install_kernel(rn, new, NULL);
 	}
 
@@ -1725,17 +1661,8 @@ static void rib_process(struct route_node *rn)
 			UNSET_FLAG(new_selected->status, ROUTE_ENTRY_CHANGED);
 		}
 
-		if (new_selected) {
+		if (new_selected)
 			SET_FLAG(new_selected->flags, ZEBRA_FLAG_SELECTED);
-
-			/* Special case: new route is system route, so
-			 * dataplane update will not be done - ensure we
-			 * redistribute the route.
-			 */
-			if (RIB_SYSTEM_ROUTE(new_selected))
-				redistribute_update(p, src_p, new_selected,
-						    old_selected);
-		}
 
 		if (old_selected) {
 			if (!new_selected)
@@ -1819,6 +1746,30 @@ static bool rib_route_match_ctx(const struct route_entry *re,
 done:
 
 	return (result);
+}
+
+static void zebra_rib_fixup_system(struct route_node *rn)
+{
+	struct route_entry *re;
+
+	RNODE_FOREACH_RE(rn, re) {
+		struct nexthop *nhop;
+
+		if (!RIB_SYSTEM_ROUTE(re))
+			continue;
+
+		if (CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED))
+			continue;
+
+		SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+
+		for (ALL_NEXTHOPS(re->ng, nhop)) {
+			if (CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_RECURSIVE))
+				continue;
+
+			SET_FLAG(nhop->flags, NEXTHOP_FLAG_FIB);
+		}
+	}
 }
 
 /*
@@ -1987,6 +1938,17 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 						   NEXTHOP_FLAG_FIB);
 			}
 
+			/*
+			 * System routes are weird in that they
+			 * allow multiple to be installed that match
+			 * to the same prefix, so after we get the
+			 * result we need to clean them up so that
+			 * we can actually use them.
+			 */
+			if ((re && RIB_SYSTEM_ROUTE(re)) ||
+			    (old_re && RIB_SYSTEM_ROUTE(old_re)))
+				zebra_rib_fixup_system(rn);
+
 			if (zvrf) {
 				zvrf->installs++;
 				/* Set flag for nexthop tracking processing */
@@ -2053,6 +2015,17 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 				  prefix2str(dest_pfx,
 					     dest_str, sizeof(dest_str)));
 		}
+
+		/*
+		 * System routes are weird in that they
+		 * allow multiple to be installed that match
+		 * to the same prefix, so after we get the
+		 * result we need to clean them up so that
+		 * we can actually use them.
+		 */
+		if ((re && RIB_SYSTEM_ROUTE(re)) ||
+		    (old_re && RIB_SYSTEM_ROUTE(old_re)))
+			zebra_rib_fixup_system(rn);
 		break;
 	default:
 		break;
@@ -2655,7 +2628,7 @@ void rib_lookup_and_pushup(struct prefix_ipv4 *p, vrf_id_t vrf_id)
 	 * revalidation
 	 * of the rest of the RE.
 	 */
-	if (dest->selected_fib && !RIB_SYSTEM_ROUTE(dest->selected_fib)) {
+	if (dest->selected_fib) {
 		changed = 1;
 		if (IS_ZEBRA_DEBUG_RIB) {
 			char buf[PREFIX_STRLEN];
@@ -2677,7 +2650,6 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 	struct route_table *table;
 	struct route_node *rn;
 	struct route_entry *same = NULL;
-	struct nexthop *nexthop;
 	int ret = 0;
 
 	if (!re)
@@ -2739,13 +2711,6 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 		 */
 		if (same->type != ZEBRA_ROUTE_CONNECT)
 			break;
-	}
-
-	/* If this route is kernel route, set FIB flag to the route. */
-	if (RIB_SYSTEM_ROUTE(re)) {
-		SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
-		for (nexthop = re->ng.nexthop; nexthop; nexthop = nexthop->next)
-			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB);
 	}
 
 	/* Link new re to node.*/
@@ -3223,10 +3188,8 @@ void rib_close_table(struct route_table *table)
 			if (info->safi == SAFI_UNICAST)
 				hook_call(rib_update, rn, NULL);
 
-			if (!RIB_SYSTEM_ROUTE(dest->selected_fib)) {
-				rib_uninstall_kernel(rn, dest->selected_fib);
-				dest->selected_fib = NULL;
-			}
+			rib_uninstall_kernel(rn, dest->selected_fib);
+			dest->selected_fib = NULL;
 		}
 	}
 }

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -632,7 +632,7 @@ static void zebra_rnh_eval_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 	 * the resolving route has some change (e.g., metric), there is a state
 	 * change.
 	 */
-	if (!prefix_same(&rnh->resolved_route, &prn->p)) {
+	if (!prefix_same(&rnh->resolved_route, prn ? NULL : &prn->p)) {
 		if (prn)
 			prefix_copy(&rnh->resolved_route, &prn->p);
 		else

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -101,12 +101,13 @@ struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid, rnh_type_t type,
 	struct route_node *rn;
 	struct rnh *rnh = NULL;
 	char buf[PREFIX2STR_BUFFER];
+	afi_t afi = family2afi(p->family);
 
 	if (IS_ZEBRA_DEBUG_NHT) {
 		prefix2str(p, buf, sizeof(buf));
 		zlog_debug("%u: Add RNH %s type %d", vrfid, buf, type);
 	}
-	table = get_rnh_table(vrfid, family2afi(PREFIX_FAMILY(p)), type);
+	table = get_rnh_table(vrfid, afi, type);
 	if (!table) {
 		prefix2str(p, buf, sizeof(buf));
 		flog_warn(EC_ZEBRA_RNH_NO_TABLE,
@@ -127,6 +128,7 @@ struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid, rnh_type_t type,
 		rnh->client_list = list_new();
 		rnh->vrf_id = vrfid;
 		rnh->type = type;
+		rnh->afi = afi;
 		rnh->zebra_pseudowire_list = list_new();
 		route_lock_node(rn);
 		rn->info = rnh;

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -126,6 +126,7 @@ struct rnh *zebra_add_rnh(struct prefix *p, vrf_id_t vrfid, rnh_type_t type,
 		rnh = XCALLOC(MTYPE_RNH, sizeof(struct rnh));
 		rnh->client_list = list_new();
 		rnh->vrf_id = vrfid;
+		rnh->type = type;
 		rnh->zebra_pseudowire_list = list_new();
 		route_lock_node(rn);
 		rn->info = rnh;

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -495,6 +495,7 @@ static void zebra_rnh_eval_import_check_entry(struct zebra_vrf *zvrf, afi_t afi,
 
 	if (compare_state(re, rnh->state)) {
 		copy_state(rnh, re, nrn);
+		state_changed = 1;
 	}
 
 	if (state_changed || force) {

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -29,6 +29,8 @@
 extern "C" {
 #endif
 
+typedef enum { RNH_NEXTHOP_TYPE, RNH_IMPORT_CHECK_TYPE } rnh_type_t;
+
 /* Nexthop structure. */
 struct rnh {
 	uint8_t flags;
@@ -39,6 +41,8 @@ struct rnh {
 
 	/* VRF identifier. */
 	vrf_id_t vrf_id;
+
+	rnh_type_t type;
 
 	struct route_entry *state;
 	struct prefix resolved_route;
@@ -54,8 +58,6 @@ struct rnh {
 	 */
 	int filtered[ZEBRA_ROUTE_MAX];
 };
-
-typedef enum { RNH_NEXTHOP_TYPE, RNH_IMPORT_CHECK_TYPE } rnh_type_t;
 
 extern int zebra_rnh_ip_default_route;
 extern int zebra_rnh_ipv6_default_route;

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -46,6 +46,8 @@ struct rnh {
 
 	rnh_type_t type;
 
+	uint32_t seqno;
+
 	struct route_entry *state;
 	struct prefix resolved_route;
 	struct list *client_list;

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -42,6 +42,8 @@ struct rnh {
 	/* VRF identifier. */
 	vrf_id_t vrf_id;
 
+	afi_t afi;
+
 	rnh_type_t type;
 
 	struct route_entry *state;

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -164,8 +164,6 @@ static void zebra_router_free_table(struct zebra_router_table *zrt)
 {
 	void *table_info;
 
-	rib_close_table(zrt->table);
-
 	table_info = route_table_get_info(zrt->table);
 	route_table_finish(zrt->table);
 	RB_REMOVE(zebra_router_table_head, &zrouter.tables, zrt);

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -354,7 +354,12 @@ void zebra_rtable_node_cleanup(struct route_table *table,
 		rib_unlink(node, re);
 	}
 
-	XFREE(MTYPE_RIB_DEST, node->info);
+	if (node->info) {
+		rib_dest_t *dest = node->info;
+
+		list_delete(&dest->nht);
+		XFREE(MTYPE_RIB_DEST, node->info);
+	}
 }
 
 static void zebra_rnhtable_node_cleanup(struct route_table *table,

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -370,10 +370,19 @@ static void zebra_rnhtable_node_cleanup(struct route_table *table,
 static void zebra_vrf_table_create(struct zebra_vrf *zvrf, afi_t afi,
 				   safi_t safi)
 {
+	struct route_node *rn;
+	struct prefix p;
+
 	assert(!zvrf->table[afi][safi]);
 
 	zvrf->table[afi][safi] =
 		zebra_router_get_table(zvrf, zvrf->table_id, afi, safi);
+
+	memset(&p, 0, sizeof(p));
+	p.family = afi2family(afi);
+
+	rn = srcdest_rnode_get(zvrf->table[afi][safi], &p, NULL);
+	zebra_rib_create_dest(rn);
 }
 
 /* Allocate new zebra VRF. */

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -773,6 +773,18 @@ static int zserv_accept(struct thread *thread)
 	return 0;
 }
 
+void zserv_close(void)
+{
+	/*
+	 * On shutdown, let's close the socket down
+	 * so that long running processes of killing the
+	 * routing table doesn't leave us in a bad
+	 * state where a client tries to reconnect
+	 */
+	close(zsock);
+	zsock = -1;
+}
+
 void zserv_start(char *path)
 {
 	int ret;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -184,6 +184,13 @@ extern unsigned int multipath_num;
 extern void zserv_init(void);
 
 /*
+ * Stop the Zebra API server.
+ *
+ * closes the socket
+ */
+extern void zserv_close(void);
+
+/*
  * Start Zebra API server.
  *
  * Allocates resources, creates the server socket and begins listening on the


### PR DESCRIPTION
Lot's of different changes:
a) Some bug fixes in how routes were handled from when we receive data back from the data plane
b) Structural changes to nexthop tracking in zebra to allow us to know how to lookup what is needed from the rnh itself.
c) Modify rnh tracking to have the rib table we are looking up against to track the rnh off of the rib_dest_t.  If a rnh is not currently tracked it is stored on the default route.
d) Add some additional debugging code to nht to allow us to figure out waht is going on.
e) Modify lsp processing to be based upon the route node instead of the zvrf.