### PR TITLE
bgpd: Remove unused bgp_debug_count function

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -2123,67 +2123,6 @@ DEFUN_NOSH (show_debugging_bgp,
 	return CMD_SUCCESS;
 }
 
-/* return count of number of debug flags set */
-int bgp_debug_count(void)
-{
-	int ret = 0;
-	if (BGP_DEBUG(as4, AS4))
-		ret++;
-
-	if (BGP_DEBUG(as4, AS4_SEGMENT))
-		ret++;
-
-	if (BGP_DEBUG(bestpath, BESTPATH))
-		ret++;
-
-	if (BGP_DEBUG(keepalive, KEEPALIVE))
-		ret++;
-
-	if (BGP_DEBUG(neighbor_events, NEIGHBOR_EVENTS))
-		ret++;
-
-	if (BGP_DEBUG(nht, NHT))
-		ret++;
-
-	if (BGP_DEBUG(update_groups, UPDATE_GROUPS))
-		ret++;
-
-	if (BGP_DEBUG(update, UPDATE_PREFIX))
-		ret++;
-
-	if (BGP_DEBUG(update, UPDATE_IN))
-		ret++;
-
-	if (BGP_DEBUG(update, UPDATE_OUT))
-		ret++;
-
-	if (BGP_DEBUG(zebra, ZEBRA))
-		ret++;
-
-	if (BGP_DEBUG(allow_martians, ALLOW_MARTIANS))
-		ret++;
-
-	if (BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF))
-		ret++;
-	if (BGP_DEBUG(vpn, VPN_LEAK_TO_VRF))
-		ret++;
-	if (BGP_DEBUG(vpn, VPN_LEAK_RMAP_EVENT))
-		ret++;
-	if (BGP_DEBUG(vpn, VPN_LEAK_LABEL))
-		ret++;
-	if (BGP_DEBUG(flowspec, FLOWSPEC))
-		ret++;
-	if (BGP_DEBUG(labelpool, LABELPOOL))
-		ret++;
-
-	if (BGP_DEBUG(pbr, PBR))
-		ret++;
-	if (BGP_DEBUG(pbr, PBR_ERROR))
-		ret++;
-
-	return ret;
-}
-
 static int bgp_config_write_debug(struct vty *vty)
 {
 	int write = 0;

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -168,7 +168,6 @@ extern int bgp_debug_update(struct peer *peer, struct prefix *p,
 extern int bgp_debug_bestpath(struct prefix *p);
 extern int bgp_debug_zebra(struct prefix *p);
 
-extern int bgp_debug_count(void);
 extern const char *bgp_debug_rdpfxpath2str(afi_t, safi_t, struct prefix_rd *,
 					   union prefixconstptr, mpls_label_t *,
 					   uint32_t, int, uint32_t, char *,


### PR DESCRIPTION
This function was not used anywhere, remove it from the system.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
