### PR TITLE
zebra: Update zserv debug messages to give a bit more useful info

### DIFF
--- a/tests/topotests/ospf-topo1-vrf/r1/zebra.conf
+++ b/tests/topotests/ospf-topo1-vrf/r1/zebra.conf
@@ -1,3 +1,7 @@
+debug zebra kernel
+debug zebra dplane detail
+debug zebra rib
+debug zebra event
 !
 hostname r1
 password zebra

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -405,8 +405,10 @@ static int zserv_read(struct thread *thread)
 		}
 
 		/* Debug packet information. */
-		if (IS_ZEBRA_DEBUG_EVENT)
-			zlog_debug("zebra message comes from socket [%d]",
+		if (IS_ZEBRA_DEBUG_PACKET)
+			zlog_debug("zebra message[%s:%u:%u] comes from socket [%d]",
+				   zserv_command_string(hdr.command),
+				   hdr.vrf_id, hdr.length,
 				   sock);
 
 		if (IS_ZEBRA_DEBUG_PACKET && IS_ZEBRA_DEBUG_RECV)
@@ -442,7 +444,8 @@ static int zserv_read(struct thread *thread)
 	}
 
 	if (IS_ZEBRA_DEBUG_PACKET)
-		zlog_debug("Read %d packets", p2p_orig - p2p);
+		zlog_debug("Read %d packets from client: %s", p2p_orig - p2p,
+			   zebra_route_string(client->proto));
 
 	/* Reschedule ourselves */
 	zserv_client_event(client, ZSERV_CLIENT_READ);


### PR DESCRIPTION
When we schedule a packet for future handling, list the packet
type so that we can see what we are getting with debugs.

Also note which client and how many packets we received from that
client.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

