### PR TITLE
Ospf missing interface handling 2

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -241,7 +241,7 @@ babel_enable_if_add (const char *ifname)
 
     vector_set (babel_enable_if, strdup (ifname));
 
-    ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+    ifp = if_lookup_by_name(ifname, vrf_lookup_by_id(VRF_DEFAULT));
     if (ifp != NULL)
         interface_recalculate(ifp);
 
@@ -264,7 +264,7 @@ babel_enable_if_delete (const char *ifname)
     free (str);
     vector_unset (babel_enable_if, babel_enable_if_index);
 
-    ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+    ifp = if_lookup_by_name(ifname, vrf_lookup_by_id(VRF_DEFAULT));
     if (ifp != NULL)
         interface_reset(ifp);
 
@@ -907,7 +907,8 @@ DEFUN (show_babel_interface,
       show_babel_interface_sub (vty, ifp);
     return CMD_SUCCESS;
   }
-  if ((ifp = if_lookup_by_name (argv[3]->arg, VRF_DEFAULT)) == NULL)
+  if ((ifp = if_lookup_by_name (argv[3]->arg,
+				vrf_lookup_by_id(VRF_DEFAULT))) == NULL)
   {
     vty_out (vty, "No such interface name\n");
     return CMD_WARNING;
@@ -949,7 +950,8 @@ DEFUN (show_babel_neighbour,
         }
         return CMD_SUCCESS;
     }
-    if ((ifp = if_lookup_by_name (argv[3]->arg, VRF_DEFAULT)) == NULL)
+    if ((ifp = if_lookup_by_name (argv[3]->arg,
+				  vrf_lookup_by_id(VRF_DEFAULT))) == NULL)
     {
         vty_out (vty, "No such interface name\n");
         return CMD_WARNING;

--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -555,7 +555,7 @@ babel_distribute_update (struct distribute_ctx *ctx, struct distribute *dist)
     if (! dist->ifname)
         return;
 
-    ifp = if_lookup_by_name (dist->ifname, VRF_DEFAULT);
+    ifp = if_lookup_by_name (dist->ifname, vrf_lookup_by_id(VRF_DEFAULT));
     if (ifp == NULL)
         return;
 

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -139,7 +139,7 @@ int bfd_session_enable(struct bfd_session *bs)
 
 	if (bs->key.ifname[0]) {
 		if (vrf)
-			ifp = if_lookup_by_name(bs->key.ifname, vrf->vrf_id);
+			ifp = if_lookup_by_name(bs->key.ifname, vrf);
 		else
 			ifp = if_lookup_by_name_all_vrf(bs->key.ifname);
 		if (ifp == NULL) {
@@ -148,7 +148,7 @@ int bfd_session_enable(struct bfd_session *bs)
 			return 0;
 		}
 		if (bs->key.ifname[0] && !vrf) {
-			vrf = vrf_lookup_by_id(ifp->vrf_id);
+			vrf = ifp->vrf;
 			if (vrf == NULL) {
 				log_error(
 					  "session-enable: specified VRF doesn't exists.");

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -572,7 +572,10 @@ static void bfdd_sessions_enable_interface(struct interface *ifp)
 {
 	struct bfd_session_observer *bso;
 	struct bfd_session *bs;
-	struct vrf *vrf;
+	struct vrf *vrf = ifp->vrf;
+
+	if (!vrf)
+		return;
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
 		bs = bso->bso_bs;
@@ -580,9 +583,6 @@ static void bfdd_sessions_enable_interface(struct interface *ifp)
 			continue;
 		/* Interface name mismatch. */
 		if (strcmp(ifp->name, bs->key.ifname))
-			continue;
-		vrf = vrf_lookup_by_id(ifp->vrf_id);
-		if (!vrf)
 			continue;
 		if (bs->key.vrfname[0] &&
 		    strcmp(vrf->name, bs->key.vrfname))

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -698,13 +698,14 @@ static int bfdd_interface_update(ZAPI_CALLBACK_ARGS)
 static int bfdd_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
+	struct vrf *nvrf;
 	vrf_id_t nvrfid;
 
 	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrf_id, &nvrfid);
 	if (ifp == NULL)
 		return 0;
-
-	if_update_to_new_vrf(ifp, nvrfid);
+	nvrf = vrf_lookup_by_id(nvrfid);
+	if_update_to_new_vrf(ifp, nvrf);
 
 	return 0;
 }

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -310,7 +310,8 @@ static int bgp_get_instance_for_inc_conn(int sock, struct bgp **bgp_inst)
 		if (bgp->inst_type == BGP_INSTANCE_TYPE_VIEW)
 			continue;
 
-		ifp = if_lookup_by_name(name, bgp->vrf_id);
+		ifp = if_lookup_by_name(name,
+					vrf_lookup_by_id(bgp->vrf_id));
 		if (ifp) {
 			*bgp_inst = bgp;
 			return 0;
@@ -570,7 +571,8 @@ static int bgp_update_source(struct peer *peer)
 
 	/* Source is specified with interface name.  */
 	if (peer->update_if) {
-		ifp = if_lookup_by_name(peer->update_if, peer->bgp->vrf_id);
+		ifp = if_lookup_by_name(peer->update_if,
+					vrf_lookup_by_id(peer->bgp->vrf_id));
 		if (!ifp)
 			return -1;
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -802,7 +802,7 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 								 peer->bgp->vrf_id));
 		} else if (peer->update_if)
 			ifp = if_lookup_by_name(peer->update_if,
-						vrf_lookup_by_id(peer->bgp->vrf_id));
+					vrf_lookup_by_id(peer->bgp->vrf_id));
 		else
 			ifp = if_lookup_by_ipv6_exact(&local->sin6.sin6_addr,
 						      local->sin6.sin6_scope_id,

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -787,7 +787,7 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 		nexthop->v4 = local->sin.sin_addr;
 		if (peer->update_if)
 			ifp = if_lookup_by_name(peer->update_if,
-						peer->bgp->vrf_id);
+						vrf_lookup_by_id(peer->bgp->vrf_id));
 		else
 			ifp = if_lookup_by_ipv4_exact(&local->sin.sin_addr,
 						      peer->bgp->vrf_id);
@@ -798,10 +798,11 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 				ifp = if_lookup_by_name(peer->conf_if
 								? peer->conf_if
 								: peer->ifname,
-							peer->bgp->vrf_id);
+							vrf_lookup_by_id(
+								 peer->bgp->vrf_id));
 		} else if (peer->update_if)
 			ifp = if_lookup_by_name(peer->update_if,
-						peer->bgp->vrf_id);
+						vrf_lookup_by_id(peer->bgp->vrf_id));
 		else
 			ifp = if_lookup_by_ipv6_exact(&local->sin6.sin6_addr,
 						      local->sin6.sin6_scope_id,
@@ -2882,7 +2883,8 @@ static void bgp_encode_pbr_interface_list(struct bgp *bgp, struct stream *s)
 	head = &(bgp_pbr_cfg->ifaces_by_name_ipv4);
 
 	RB_FOREACH (pbr_if, bgp_pbr_interface_head, head) {
-		ifp = if_lookup_by_name(pbr_if->name, bgp->vrf_id);
+		ifp = if_lookup_by_name(pbr_if->name,
+					vrf_lookup_by_id(bgp->vrf_id));
 		if (ifp)
 			stream_putl(s, ifp->ifindex);
 	}
@@ -2900,7 +2902,8 @@ static int bgp_pbr_get_ifnumber(struct bgp *bgp)
 	head = &(bgp_pbr_cfg->ifaces_by_name_ipv4);
 
 	RB_FOREACH (pbr_if, bgp_pbr_interface_head, head) {
-		if (if_lookup_by_name(pbr_if->name, bgp->vrf_id))
+		if (if_lookup_by_name(pbr_if->name,
+				      vrf_lookup_by_id(bgp->vrf_id)))
 			cnt++;
 	}
 	return cnt;

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -503,7 +503,7 @@ static int bgp_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 		}
 	}
 
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, vrf_lookup_by_id(new_vrf_id));
 
 	bgp = bgp_lookup_by_vrf_id(new_vrf_id);
 	if (!bgp)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1436,7 +1436,8 @@ void bgp_peer_conf_if_to_su_update(struct peer *peer)
 	hash_release(peer->bgp->peerhash, peer);
 
 	prev_family = peer->su.sa.sa_family;
-	if ((ifp = if_lookup_by_name(peer->conf_if, peer->bgp->vrf_id))) {
+	if ((ifp = if_lookup_by_name(peer->conf_if,
+				     vrf_lookup_by_id(peer->bgp->vrf_id)))) {
 		peer->ifp = ifp;
 		/* If BGP unnumbered is not "v6only", we first see if we can
 		 * derive the

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -174,7 +174,8 @@ void eigrp_distribute_update(struct distribute_ctx *ctx,
 		return;
 	}
 
-	ifp = if_lookup_by_name(dist->ifname, VRF_DEFAULT);
+	ifp = if_lookup_by_name(dist->ifname,
+				vrf_lookup_by_id(VRF_DEFAULT));
 	if (ifp == NULL)
 		return;
 

--- a/eigrpd/eigrp_routemap.c
+++ b/eigrpd/eigrp_routemap.c
@@ -62,7 +62,7 @@ void eigrp_if_rmap_update(struct if_rmap *if_rmap)
 	struct route_map *rmap;
 	struct eigrp *e;
 
-	ifp = if_lookup_by_name(if_rmap->ifname);
+	ifp = if_lookup_by_name(if_rmap->ifname, vrf_lookup_by_id(VRF_DEFAULT));
 	if (ifp == NULL)
 		return;
 

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -336,7 +336,8 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, VRF_DEFAULT);
+	return if_lookup_by_name(ifname_tmp,
+				 vrf_lookup_by_id(VRF_DEFAULT));
 }
 
 void eigrp_zebra_route_add(struct prefix *p, struct list *successors,

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -97,8 +97,7 @@ DEFPY(no_router_isis, no_router_isis_cmd, "no router isis WORD$tag",
 			/* add callbacks to delete each of the circuits listed
 			 */
 			const char *vrf_name =
-				vrf_lookup_by_id(circuit->interface->vrf_id)
-					->name;
+				circuit->interface->vrf->name;
 			snprintf(
 				temp_xpath, XPATH_MAXLEN,
 				"/frr-interface:lib/interface[name='%s'][vrf='%s']/frr-isisd:isis",

--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -1597,7 +1597,7 @@ static int lib_interface_isis_area_tag_modify(enum nb_event event,
 		vrfname = yang_dnode_get_string(dnode->parent->parent, "./vrf");
 		vrf = vrf_lookup_by_name(vrfname);
 		assert(vrf);
-		ifp = if_lookup_by_name(ifname, vrf->vrf_id);
+		ifp = if_lookup_by_name(ifname, vrf);
 		if (!ifp)
 			return NB_OK;
 		circuit = circuit_lookup_by_ifp(ifp, isis->init_circ_list);
@@ -1635,7 +1635,7 @@ static int lib_interface_isis_circuit_type_modify(enum nb_event event,
 		vrfname = yang_dnode_get_string(dnode->parent->parent, "./vrf");
 		vrf = vrf_lookup_by_name(vrfname);
 		assert(vrf);
-		ifp = if_lookup_by_name(ifname, vrf->vrf_id);
+		ifp = if_lookup_by_name(ifname, vrf);
 		if (!ifp)
 			break;
 		circuit = circuit_lookup_by_ifp(ifp, isis->init_circ_list);

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1175,7 +1175,8 @@ DEFUN (show_isis_mpls_te_interface,
 		}
 	} else {
 		/* Interface name is specified. */
-		ifp = if_lookup_by_name(argv[idx_interface]->arg, VRF_DEFAULT);
+		ifp = if_lookup_by_name(argv[idx_interface]->arg,
+					vrf_lookup_by_id(VRF_DEFAULT));
 		if (ifp == NULL)
 			vty_out(vty, "No such interface name\n");
 		else {

--- a/lib/if.c
+++ b/lib/if.c
@@ -177,6 +177,8 @@ void if_update_to_new_vrf(struct interface *ifp, vrf_id_t vrf_id)
 	if (ifp->ifindex != IFINDEX_INTERNAL)
 		IFINDEX_RB_INSERT(vrf, ifp);
 
+	if (!old_vrf->name)
+		return;
 	/*
 	 * HACK: Change the interface VRF in the running configuration directly,
 	 * bypassing the northbound layer. This is necessary to avoid deleting

--- a/lib/if.c
+++ b/lib/if.c
@@ -132,9 +132,8 @@ static int if_cmp_index_func(const struct interface *ifp1,
 }
 
 /* Create new interface structure. */
-struct interface *if_create(const char *name, vrf_id_t vrf_id)
+struct interface *if_create(const char *name, struct vrf *vrf)
 {
-	struct vrf *vrf = vrf_get(vrf_id, NULL);
 	struct interface *ifp;
 
 	ifp = XCALLOC(MTYPE_IF, sizeof(struct interface));
@@ -142,7 +141,7 @@ struct interface *if_create(const char *name, vrf_id_t vrf_id)
 
 	assert(name);
 	strlcpy(ifp->name, name, sizeof(ifp->name));
-	ifp->vrf_id = vrf_id;
+	ifp->vrf_id = vrf->vrf_id;
 	IFNAME_RB_INSERT(vrf, ifp);
 	ifp->connected = list_new();
 	ifp->connected->del = (void (*)(void *))connected_free;
@@ -429,7 +428,7 @@ struct interface *if_get_by_name(const char *name, struct vrf *vrf)
 		ifp = if_lookup_by_name(name, vrf->vrf_id);
 		if (ifp)
 			return ifp;
-		return if_create(name, vrf->vrf_id);
+		return if_create(name, vrf);
 	case VRF_BACKEND_VRF_LITE:
 		ifp = if_lookup_by_name_all_vrf(name);
 		if (ifp) {
@@ -441,7 +440,7 @@ struct interface *if_get_by_name(const char *name, struct vrf *vrf)
 			if_update_to_new_vrf(ifp, vrf->vrf_id);
 			return ifp;
 		}
-		return if_create(name, vrf->vrf_id);
+		return if_create(name, vrf);
 	}
 
 	return NULL;

--- a/lib/if.c
+++ b/lib/if.c
@@ -1139,7 +1139,7 @@ DEFPY_NOSH (interface,
 	 * interface is found, then a new one should be created on the default
 	 * VRF.
 	 */
-	VRF_GET_INSTANCE(vrf, vrfname, false);
+	VRF_GET_INSTANCE(vrf, vrfname, false, true);
 	/*
 	 * within vrf context, vrf_id may be unknown
 	 * this happens on daemons relying on zebra

--- a/lib/if.c
+++ b/lib/if.c
@@ -419,29 +419,29 @@ size_t if_lookup_by_hwaddr(const uint8_t *hw_addr, size_t addrsz,
 
 /* Get interface by name if given name interface doesn't exist create
    one. */
-struct interface *if_get_by_name(const char *name, vrf_id_t vrf_id)
+struct interface *if_get_by_name(const char *name, struct vrf *vrf)
 {
 	struct interface *ifp;
 
 	switch (vrf_get_backend()) {
 	case VRF_BACKEND_UNKNOWN:
 	case VRF_BACKEND_NETNS:
-		ifp = if_lookup_by_name(name, vrf_id);
+		ifp = if_lookup_by_name(name, vrf->vrf_id);
 		if (ifp)
 			return ifp;
-		return if_create(name, vrf_id);
+		return if_create(name, vrf->vrf_id);
 	case VRF_BACKEND_VRF_LITE:
 		ifp = if_lookup_by_name_all_vrf(name);
 		if (ifp) {
-			if (ifp->vrf_id == vrf_id)
+			if (ifp->vrf_id == vrf->vrf_id)
 				return ifp;
 			/* If it came from the kernel or by way of zclient,
 			 * believe it and update the ifp accordingly.
 			 */
-			if_update_to_new_vrf(ifp, vrf_id);
+			if_update_to_new_vrf(ifp, vrf->vrf_id);
 			return ifp;
 		}
-		return if_create(name, vrf_id);
+		return if_create(name, vrf->vrf_id);
 	}
 
 	return NULL;
@@ -631,12 +631,12 @@ void if_dump_all(void)
  *     if not:
  *     - no idea, just get the name in its entirety.
  */
-static struct interface *if_sunwzebra_get(const char *name, vrf_id_t vrf_id)
+static struct interface *if_sunwzebra_get(const char *name, struct vrf *vrf)
 {
 	struct interface *ifp;
 	char *cp;
 
-	if ((ifp = if_lookup_by_name(name, vrf_id)) != NULL)
+	if ((ifp = if_lookup_by_name(name, vrf->vrf_id)) != NULL)
 		return ifp;
 
 	/* hunt the primary interface name... */
@@ -644,7 +644,7 @@ static struct interface *if_sunwzebra_get(const char *name, vrf_id_t vrf_id)
 	if (cp)
 		*cp = '\0';
 
-	return if_get_by_name(name, vrf_id);
+	return if_get_by_name(name, vrf);
 }
 #endif /* SUNOS_5 */
 
@@ -1343,9 +1343,9 @@ static int lib_interface_create(enum nb_event event,
 		vrf = vrf_lookup_by_name(vrfname);
 		assert(vrf);
 #ifdef SUNOS_5
-		ifp = if_sunwzebra_get(ifname, vrf->vrf_id);
+		ifp = if_sunwzebra_get(ifname, vrf);
 #else
-		ifp = if_get_by_name(ifname, vrf->vrf_id);
+		ifp = if_get_by_name(ifname, vrf);
 #endif /* SUNOS_5 */
 		nb_running_set_entry(dnode, ifp);
 		break;

--- a/lib/if.c
+++ b/lib/if.c
@@ -264,16 +264,16 @@ const char *ifindex2ifname(ifindex_t ifindex, vrf_id_t vrf_id)
 ifindex_t ifname2ifindex(const char *name, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
-	return ((ifp = if_lookup_by_name(name, vrf_id)) != NULL)
+	return ((ifp = if_lookup_by_name(name, vrf)) != NULL)
 		       ? ifp->ifindex
 		       : IFINDEX_INTERNAL;
 }
 
 /* Interface existance check by interface name. */
-struct interface *if_lookup_by_name(const char *name, vrf_id_t vrf_id)
+struct interface *if_lookup_by_name(const char *name, struct vrf *vrf)
 {
-	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 	struct interface if_tmp;
 
 	if (!vrf || !name
@@ -293,7 +293,7 @@ struct interface *if_lookup_by_name_all_vrf(const char *name)
 		return NULL;
 
 	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
-		ifp = if_lookup_by_name(name, vrf->vrf_id);
+		ifp = if_lookup_by_name(name, vrf);
 		if (ifp)
 			return ifp;
 	}
@@ -425,7 +425,7 @@ struct interface *if_get_by_name(const char *name, struct vrf *vrf)
 	switch (vrf_get_backend()) {
 	case VRF_BACKEND_UNKNOWN:
 	case VRF_BACKEND_NETNS:
-		ifp = if_lookup_by_name(name, vrf->vrf_id);
+		ifp = if_lookup_by_name(name, vrf);
 		if (ifp)
 			return ifp;
 		return if_create(name, vrf);
@@ -635,7 +635,7 @@ static struct interface *if_sunwzebra_get(const char *name, struct vrf *vrf)
 	struct interface *ifp;
 	char *cp;
 
-	if ((ifp = if_lookup_by_name(name, vrf->vrf_id)) != NULL)
+	if ((ifp = if_lookup_by_name(name, vrf)) != NULL)
 		return ifp;
 
 	/* hunt the primary interface name... */
@@ -1128,6 +1128,7 @@ DEFPY_NOSH (interface,
 	vrf_id_t vrf_id;
 	struct interface *ifp;
 	int ret;
+	struct vrf *vrf;
 
 	if (!vrfname)
 		vrfname = VRF_DEFAULT_NAME;
@@ -1142,8 +1143,6 @@ DEFPY_NOSH (interface,
 	VRF_GET_ID(vrf_id, vrfname, false);
 	ifp = if_lookup_by_name_all_vrf(ifname);
 	if (ifp && ifp->vrf_id != vrf_id) {
-		struct vrf *vrf;
-
 		/*
 		 * Special case 1: a VRF name was specified, but the found
 		 * interface is associated to different VRF. Reject the command.
@@ -1161,9 +1160,9 @@ DEFPY_NOSH (interface,
 		 */
 		vrf = vrf_lookup_by_id(ifp->vrf_id);
 		assert(vrf);
-		vrf_id = ifp->vrf_id;
 		vrfname = vrf->name;
-	}
+	} else
+		vrf = vrf_lookup_by_id(vrf_id);
 
 	snprintf(xpath_list, sizeof(xpath_list),
 		 "/frr-interface:lib/interface[name='%s'][vrf='%s']", ifname,
@@ -1180,7 +1179,7 @@ DEFPY_NOSH (interface,
 		 * all interface-level commands are converted to the new
 		 * northbound model.
 		 */
-		ifp = if_lookup_by_name(ifname, vrf_id);
+		ifp = if_lookup_by_name(ifname, vrf);
 		if (ifp)
 			VTY_PUSH_CONTEXT(INTERFACE_NODE, ifp);
 	}

--- a/lib/if.c
+++ b/lib/if.c
@@ -157,11 +157,18 @@ struct interface *if_create(const char *name, struct vrf *vrf)
 	return ifp;
 }
 
-/* Create new interface structure. */
-void if_update_to_new_vrf(struct interface *ifp, vrf_id_t vrf_id)
+/* Create new interface structure.
+ * vrf must be created outside of this routing
+ */
+void if_update_to_new_vrf(struct interface *ifp, struct vrf *vrf)
 {
-	struct vrf *old_vrf, *vrf;
+	struct vrf *old_vrf;
 
+	if (!vrf) {
+		flog_err(EC_LIB_INTERFACE, "interface %s. Unknown VRF",
+			 ifp->name);
+		return;
+	}
 	/* remove interface from old master vrf list */
 	old_vrf = vrf_lookup_by_id(ifp->vrf_id);
 	if (old_vrf) {
@@ -170,8 +177,7 @@ void if_update_to_new_vrf(struct interface *ifp, vrf_id_t vrf_id)
 			IFINDEX_RB_REMOVE(old_vrf, ifp);
 	}
 
-	ifp->vrf_id = vrf_id;
-	vrf = vrf_get(ifp->vrf_id, NULL);
+	ifp->vrf_id = vrf->vrf_id;
 
 	IFNAME_RB_INSERT(vrf, ifp);
 	if (ifp->ifindex != IFINDEX_INTERNAL)
@@ -439,7 +445,7 @@ struct interface *if_get_by_name(const char *name, struct vrf *vrf)
 			/* If it came from the kernel or by way of zclient,
 			 * believe it and update the ifp accordingly.
 			 */
-			if_update_to_new_vrf(ifp, vrf->vrf_id);
+			if_update_to_new_vrf(ifp, vrf);
 			return ifp;
 		}
 		return if_create(name, vrf);

--- a/lib/if.c
+++ b/lib/if.c
@@ -1125,8 +1125,7 @@ DEFPY_NOSH (interface,
        VRF_CMD_HELP_STR)
 {
 	char xpath_list[XPATH_MAXLEN];
-	vrf_id_t vrf_id;
-	struct interface *ifp;
+	struct interface *ifp = NULL;
 	int ret;
 	struct vrf *vrf;
 
@@ -1140,14 +1139,24 @@ DEFPY_NOSH (interface,
 	 * interface is found, then a new one should be created on the default
 	 * VRF.
 	 */
-	VRF_GET_ID(vrf_id, vrfname, false);
-	ifp = if_lookup_by_name_all_vrf(ifname);
-	if (ifp && ifp->vrf_id != vrf_id) {
+	VRF_GET_INSTANCE(vrf, vrfname, false);
+	/*
+	 * within vrf context, vrf_id may be unknown
+	 * this happens on daemons relying on zebra
+	 * on this specific case, interface creation may
+	 * be forced
+	 */
+	if (vrf && (vrf->vrf_id == VRF_UNKNOWN ||
+		    vrf_get_backend() == VRF_BACKEND_UNKNOWN))
+		ifp = if_lookup_by_name(ifname, vrf);
+	else
+		ifp = if_lookup_by_name_all_vrf(ifname);
+	if (ifp && ifp->vrf_id != vrf->vrf_id) {
 		/*
 		 * Special case 1: a VRF name was specified, but the found
 		 * interface is associated to different VRF. Reject the command.
 		 */
-		if (vrf_id != VRF_DEFAULT) {
+		if (vrf->vrf_id != VRF_DEFAULT) {
 			vty_out(vty, "%% interface %s not in %s vrf\n", ifname,
 				vrfname);
 			return CMD_WARNING_CONFIG_FAILED;
@@ -1161,8 +1170,7 @@ DEFPY_NOSH (interface,
 		vrf = vrf_lookup_by_id(ifp->vrf_id);
 		assert(vrf);
 		vrfname = vrf->name;
-	} else
-		vrf = vrf_lookup_by_id(vrf_id);
+	}
 
 	snprintf(xpath_list, sizeof(xpath_list),
 		 "/frr-interface:lib/interface[name='%s'][vrf='%s']", ifname,
@@ -1301,7 +1309,7 @@ static int lib_interface_create(enum nb_event event,
 	const char *ifname;
 	const char *vrfname;
 	struct vrf *vrf;
-	struct interface *ifp;
+	struct interface *ifp = NULL;
 
 	ifname = yang_dnode_get_string(dnode, "./name");
 	vrfname = yang_dnode_get_string(dnode, "./vrf");
@@ -1314,11 +1322,9 @@ static int lib_interface_create(enum nb_event event,
 				  vrfname);
 			return NB_ERR_VALIDATION;
 		}
-		if (vrf->vrf_id == VRF_UNKNOWN) {
-			zlog_warn("%s: VRF %s is not active", __func__,
-				  vrf->name);
-			return NB_ERR_VALIDATION;
-		}
+		if (vrf->vrf_id == VRF_UNKNOWN)
+			zlog_warn("%s: VRF %s is not active. Using interface however.",
+				  __func__, vrf->name);
 
 		/* if VRF is netns or not yet known - init for instance
 		 * then assumption is that passed config is exact

--- a/lib/if.h
+++ b/lib/if.h
@@ -494,7 +494,7 @@ size_t if_lookup_by_hwaddr(const uint8_t *hw_addr, size_t addrsz,
 /* These 3 functions are to be used when the ifname argument is terminated
    by a '\0' character: */
 extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
-extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
+extern struct interface *if_lookup_by_name(const char *ifname, struct vrf *vrf);
 extern struct interface *if_get_by_name(const char *ifname, struct vrf *vrf);
 extern void if_set_index(struct interface *ifp, ifindex_t ifindex);
 

--- a/lib/if.h
+++ b/lib/if.h
@@ -294,7 +294,7 @@ struct interface {
 #endif /* HAVE_NET_RT_IFLIST */
 
 	struct route_node *node;
-	vrf_id_t vrf_id;
+	struct vrf *vrf;
 
 	QOBJ_FIELDS
 };
@@ -305,33 +305,37 @@ RB_HEAD(if_index_head, interface);
 RB_PROTOTYPE(if_index_head, interface, index_entry, if_cmp_func)
 DECLARE_QOBJ_TYPE(interface)
 
-#define IFNAME_RB_INSERT(vrf, ifp)                                             \
-	if (RB_INSERT(if_name_head, &vrf->ifaces_by_name, (ifp)))              \
+#define IFNAME_RB_INSERT(_vrf, _ifp)                                           \
+	if (RB_INSERT(if_name_head, &(_vrf)->ifaces_by_name, (_ifp)))	       \
 		flog_err(EC_LIB_INTERFACE,                                     \
 			 "%s(%s): corruption detected -- interface with this " \
 			 "name exists already in VRF %u!",                     \
-			 __func__, (ifp)->name, (ifp)->vrf_id);
+			 __func__, (_ifp)->name, (_ifp)->vrf ?                 \
+			 (_ifp)->vrf->vrf_id : VRF_UNKNOWN);
 
-#define IFNAME_RB_REMOVE(vrf, ifp)                                             \
-	if (RB_REMOVE(if_name_head, &vrf->ifaces_by_name, (ifp)) == NULL)      \
+#define IFNAME_RB_REMOVE(_vrf, _ifp)                                           \
+	if (RB_REMOVE(if_name_head, &(_vrf)->ifaces_by_name, (_ifp)) == NULL)  \
 		flog_err(EC_LIB_INTERFACE,                                     \
 			 "%s(%s): corruption detected -- interface with this " \
 			 "name doesn't exist in VRF %u!",                      \
-			 __func__, (ifp)->name, (ifp)->vrf_id);
+			 __func__, (_ifp)->name, (_ifp)->vrf ?                 \
+			 (_ifp)->vrf->vrf_id : VRF_UNKNOWN);
 
-#define IFINDEX_RB_INSERT(vrf, ifp)                                            \
-	if (RB_INSERT(if_index_head, &vrf->ifaces_by_index, (ifp)))            \
+#define IFINDEX_RB_INSERT(_vrf, _ifp)                                          \
+	if (RB_INSERT(if_index_head, &(_vrf)->ifaces_by_index, (_ifp)))        \
 		flog_err(EC_LIB_INTERFACE,                                     \
 			 "%s(%u): corruption detected -- interface with this " \
 			 "ifindex exists already in VRF %u!",                  \
-			 __func__, (ifp)->ifindex, (ifp)->vrf_id);
+			 __func__, (_ifp)->ifindex, (_ifp)->vrf ?              \
+			 (_ifp)->vrf->vrf_id : VRF_UNKNOWN);
 
-#define IFINDEX_RB_REMOVE(vrf, ifp)                                            \
-	if (RB_REMOVE(if_index_head, &vrf->ifaces_by_index, (ifp)) == NULL)    \
+#define IFINDEX_RB_REMOVE(_vrf, _ifp)                                          \
+	if (RB_REMOVE(if_index_head, &(_vrf)->ifaces_by_index, (_ifp)) == NULL)\
 		flog_err(EC_LIB_INTERFACE,                                     \
 			 "%s(%u): corruption detected -- interface with this " \
 			 "ifindex doesn't exist in VRF %u!",                   \
-			 __func__, (ifp)->ifindex, (ifp)->vrf_id);
+			 __func__, (_ifp)->ifindex, (_ifp)->vrf ?              \
+			 (_ifp)->vrf->vrf_id : VRF_UNKNOWN);
 
 #define FOR_ALL_INTERFACES(vrf, ifp)                                           \
 	if (vrf)                                                               \

--- a/lib/if.h
+++ b/lib/if.h
@@ -34,6 +34,8 @@ extern "C" {
 DECLARE_MTYPE(IF)
 DECLARE_MTYPE(CONNECTED_LABEL)
 
+struct vrf;
+
 /* Interface link-layer type, if known. Derived from:
  *
  * net/if_arp.h on various platforms - Linux especially.
@@ -493,7 +495,7 @@ size_t if_lookup_by_hwaddr(const uint8_t *hw_addr, size_t addrsz,
    by a '\0' character: */
 extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
 extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
-extern struct interface *if_get_by_name(const char *ifname, vrf_id_t vrf_id);
+extern struct interface *if_get_by_name(const char *ifname, struct vrf *vrf);
 extern void if_set_index(struct interface *ifp, ifindex_t ifindex);
 
 /* Delete the interface, but do not free the structure, and leave it in the

--- a/lib/if.h
+++ b/lib/if.h
@@ -479,7 +479,7 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
  * This is useful for vrf route-leaking.  So more than anything
  * else think before you use VRF_UNKNOWN
  */
-extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
+extern void if_update_to_new_vrf(struct interface *, struct vrf *vrf);
 extern struct interface *if_create(const char *name, struct vrf *vrf);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
 extern struct interface *if_lookup_exact_address(void *matchaddr, int family,

--- a/lib/if.h
+++ b/lib/if.h
@@ -480,7 +480,7 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
  * else think before you use VRF_UNKNOWN
  */
 extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
-extern struct interface *if_create(const char *name, vrf_id_t vrf_id);
+extern struct interface *if_create(const char *name, struct vrf *vrf);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
 extern struct interface *if_lookup_exact_address(void *matchaddr, int family,
 						 vrf_id_t vrf_id);

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -923,14 +923,15 @@ int vrf_bind(vrf_id_t vrf_id, int fd, const char *name)
 {
 	int ret = 0;
 	struct interface *ifp;
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
-	if (fd < 0 || name == NULL)
+	if (fd < 0 || name == NULL || !vrf)
 		return fd;
 	/* the device should exist
 	 * otherwise we should return
 	 * case ifname = vrf in netns mode => return
 	 */
-	ifp = if_lookup_by_name(name, vrf_id);
+	ifp = if_lookup_by_name(name, vrf);
 	if (!ifp)
 		return fd;
 #ifdef SO_BINDTODEVICE
@@ -1016,4 +1017,14 @@ vrf_id_t vrf_generate_id(void)
 	static int vrf_id_local;
 
 	return ++vrf_id_local;
+}
+
+vrf_id_t vrf_to_id(struct vrf *vrf)
+{
+	return vrf ? vrf->vrf_id : VRF_UNKNOWN;
+}
+
+const char *vrf_to_name(struct vrf *vrf)
+{
+	return vrf ? vrf->name : "NIL";
 }

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -114,6 +114,30 @@ extern struct vrf *vrf_get(vrf_id_t, const char *);
 extern const char *vrf_id_to_name(vrf_id_t vrf_id);
 extern vrf_id_t vrf_name_to_id(const char *);
 
+/* vrf context is searched and created
+ */
+#define VRF_GET_INSTANCE(V, NAME, USE_JSON)                                    \
+	do {								       \
+		struct vrf *_vrf;                                              \
+									       \
+		if (!(_vrf = vrf_lookup_by_name(NAME))) {                      \
+			if (USE_JSON) {                                        \
+				vty_out(vty, "{}\n");                          \
+			} else {                                               \
+				vty_out(vty, "%% VRF %s not found\n", NAME);   \
+			}                                                      \
+			return CMD_WARNING;                                    \
+		}                                                              \
+		if (_vrf->vrf_id == VRF_UNKNOWN) {                             \
+			if (USE_JSON) {                                        \
+				vty_out(vty, "{}\n");                          \
+			} else {                                               \
+				vty_out(vty, "%% VRF %s not active\n", NAME);  \
+			}                                                      \
+		}                                                              \
+		(V) = _vrf;						       \
+	} while (0)
+
 #define VRF_GET_ID(V, NAME, USE_JSON)                                          \
 	do {                                                                   \
 		struct vrf *_vrf;                                              \

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -116,17 +116,21 @@ extern vrf_id_t vrf_name_to_id(const char *);
 
 /* vrf context is searched and created
  */
-#define VRF_GET_INSTANCE(V, NAME, USE_JSON)                                    \
+#define VRF_GET_INSTANCE(V, NAME, USE_JSON, FORCE_CREATION)		       \
 	do {								       \
 		struct vrf *_vrf;                                              \
 									       \
 		if (!(_vrf = vrf_lookup_by_name(NAME))) {                      \
-			if (USE_JSON) {                                        \
-				vty_out(vty, "{}\n");                          \
-			} else {                                               \
-				vty_out(vty, "%% VRF %s not found\n", NAME);   \
+			if (!FORCE_CREATION) {   			       \
+				if (USE_JSON) {				       \
+					vty_out(vty, "{}\n");                  \
+				} else {                                       \
+					vty_out(vty, "%% VRF %s not found\n",  \
+						NAME);			       \
+				}                                              \
+				return CMD_WARNING;                            \
 			}                                                      \
-			return CMD_WARNING;                                    \
+			_vrf = vrf_get(VRF_UNKNOWN, NAME);                     \
 		}                                                              \
 		if (_vrf->vrf_id == VRF_UNKNOWN) {                             \
 			if (USE_JSON) {                                        \

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -113,6 +113,8 @@ extern struct vrf *vrf_lookup_by_name(const char *);
 extern struct vrf *vrf_get(vrf_id_t, const char *);
 extern const char *vrf_id_to_name(vrf_id_t vrf_id);
 extern vrf_id_t vrf_name_to_id(const char *);
+extern vrf_id_t vrf_to_id(struct vrf *vrf);
+extern const char *vrf_to_name(struct vrf *vrf);
 
 /* vrf context is searched and created
  */

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1469,6 +1469,11 @@ struct interface *zebra_interface_add_read(struct stream *s, vrf_id_t vrf_id)
 	/* Lookup/create interface by name. */
 	ifp = if_get_by_name(ifname_tmp, vrf);
 
+	/* update vrf_id of interface */
+	if (ifp->vrf->vrf_id == VRF_UNKNOWN &&
+	    vrf->vrf_id != VRF_UNKNOWN)
+		ifp->vrf = vrf;
+
 	zebra_interface_if_set_value(s, ifp);
 
 	return ifp;
@@ -2844,11 +2849,12 @@ void zclient_interface_set_master(struct zclient *client,
 	s = client->obuf;
 	stream_reset(s);
 
-	zclient_create_header(s, ZEBRA_INTERFACE_SET_MASTER, master->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_SET_MASTER,
+			      vrf_to_id(master->vrf));
 
-	stream_putl(s, master->vrf_id);
+	stream_putl(s, vrf_to_id(master->vrf));
 	stream_putl(s, master->ifindex);
-	stream_putl(s, slave->vrf_id);
+	stream_putl(s, vrf_to_id(slave->vrf));
 	stream_putl(s, slave->ifindex);
 
 	stream_putw_at(s, 0, stream_get_endp(s));

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1461,12 +1461,13 @@ struct interface *zebra_interface_add_read(struct stream *s, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
 	char ifname_tmp[INTERFACE_NAMSIZ];
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
 	/* Read interface name. */
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* Lookup/create interface by name. */
-	ifp = if_get_by_name(ifname_tmp, vrf_id);
+	ifp = if_get_by_name(ifname_tmp, vrf);
 
 	zebra_interface_if_set_value(s, ifp);
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1490,7 +1490,8 @@ struct interface *zebra_interface_state_read(struct stream *s, vrf_id_t vrf_id)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* Lookup this by interface index. */
-	ifp = if_lookup_by_name(ifname_tmp, vrf_id);
+	ifp = if_lookup_by_name(ifname_tmp,
+				vrf_lookup_by_id(vrf_id));
 	if (ifp == NULL) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
 			 "INTERFACE_STATE: Cannot find IF %s in VRF %d",
@@ -1550,7 +1551,8 @@ struct interface *zebra_interface_link_params_read(struct stream *s,
 
 	ifindex = stream_getl(s);
 
-	struct interface *ifp = if_lookup_by_index(ifindex, vrf_id);
+	struct interface *ifp = if_lookup_by_index(ifindex,
+						   vrf_id);
 
 	if (ifp == NULL) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
@@ -1846,7 +1848,8 @@ struct interface *zebra_interface_vrf_update_read(struct stream *s,
 	stream_get(ifname, s, INTERFACE_NAMSIZ);
 
 	/* Lookup interface. */
-	ifp = if_lookup_by_name(ifname, vrf_id);
+	ifp = if_lookup_by_name(ifname,
+				vrf_lookup_by_id(vrf_id));
 	if (ifp == NULL) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
 			 "INTERFACE_VRF_UPDATE: Cannot find IF %s in VRF %d",

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -126,7 +126,8 @@ static void nhrp_interface_update_nbma(struct interface *ifp)
 	sockunion_family(&nbma) = AF_UNSPEC;
 
 	if (nifp->source)
-		nbmaifp = if_lookup_by_name(nifp->source, VRF_DEFAULT);
+		nbmaifp = if_lookup_by_name(nifp->source,
+					    vrf_lookup_by_id(VRF_DEFAULT));
 
 	switch (ifp->ll_type) {
 	case ZEBRA_LLT_IPGRE: {

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1404,7 +1404,8 @@ ospf6_routemap_rule_match_interface(void *rule, const struct prefix *prefix,
 
 	if (type == RMAP_OSPF6) {
 		ei = ((struct ospf6_route *)object)->route_option;
-		ifp = if_lookup_by_name((char *)rule, VRF_DEFAULT);
+		ifp = if_lookup_by_name((char *)rule,
+					vrf_lookup_by_id(VRF_DEFAULT));
 
 		if (ifp != NULL && ei->ifindex == ifp->ifindex)
 			return RMAP_MATCH;

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -996,7 +996,8 @@ DEFUN (show_ipv6_ospf6_interface,
 	struct interface *ifp;
 
 	if (argc == 5) {
-		ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+		ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+					vrf_lookup_by_id(VRF_DEFAULT));
 		if (ifp == NULL) {
 			vty_out(vty, "No such Interface: %s\n",
 				argv[idx_ifname]->arg);
@@ -1081,7 +1082,8 @@ DEFUN (show_ipv6_ospf6_interface_traffic,
 
 	if (argv_find(argv, argc, "IFNAME", &idx_ifname)) {
 		intf_name = argv[idx_ifname]->arg;
-		ifp = if_lookup_by_name(intf_name, VRF_DEFAULT);
+		ifp = if_lookup_by_name(intf_name,
+					vrf_lookup_by_id(VRF_DEFAULT));
 		if (ifp == NULL) {
 			vty_out(vty, "No such Interface: %s\n", intf_name);
 			return CMD_WARNING;
@@ -1125,7 +1127,8 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
 	struct interface *ifp;
 	struct ospf6_interface *oi;
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+				vrf_lookup_by_id(VRF_DEFAULT));
 	if (ifp == NULL) {
 		vty_out(vty, "No such Interface: %s\n", argv[idx_ifname]->arg);
 		return CMD_WARNING;
@@ -2026,7 +2029,7 @@ DEFUN (clear_ipv6_ospf6_interface,
 	} else /* Interface name is specified. */
 	{
 		if ((ifp = if_lookup_by_name(argv[idx_ifname]->arg,
-					     VRF_DEFAULT))
+					     vrf_lookup_by_id(VRF_DEFAULT)))
 		    == NULL) {
 			vty_out(vty, "No such Interface: %s\n",
 				argv[idx_ifname]->arg);

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -715,7 +715,8 @@ DEFUN (no_ospf6_interface_area,
 	struct interface *ifp;
 	uint32_t area_id;
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+				vrf_lookup_by_id(VRF_DEFAULT));
 	if (ifp == NULL) {
 		vty_out(vty, "No such interface %s\n", argv[idx_ifname]->arg);
 		return CMD_SUCCESS;

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -654,9 +654,10 @@ DEFUN (ospf6_interface_area,
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 	uint32_t area_id;
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	/* find/create ospf6 interface */
-	ifp = if_get_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+	ifp = if_get_by_name(argv[idx_ifname]->arg, vrf);
 	oi = (struct ospf6_interface *)ifp->info;
 	if (oi == NULL)
 		oi = ospf6_interface_create(ifp);

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -838,6 +838,7 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 	struct in_addr area_id;
 	struct connected *co;
 	struct prefix_ipv4 *p;
+	struct vrf *vrf;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("ospf_vl_new(): Start");
@@ -855,7 +856,8 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 			ospf->vrf_id);
 
 	snprintf(ifname, sizeof(ifname), "VLINK%u", vlink_count);
-	vi = if_create(ifname, ospf->vrf_id);
+	vrf = vrf_lookup_by_id(ospf->vrf_id);
+	vi = if_create(ifname, vrf);
 	/*
 	 * if_create sets ZEBRA_INTERFACE_LINKDETECTION
 	 * virtual links don't need this.

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -349,8 +349,8 @@ void ospf_if_free(struct ospf_interface *oi)
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("%s: ospf interface %s vrf %s id %u deleted",
 			   __PRETTY_FUNCTION__, oi->ifp->name,
-			   ospf_vrf_id_to_name(oi->ifp->vrf_id),
-			   oi->ifp->vrf_id);
+			   vrf_to_name(oi->ifp->vrf),
+			   vrf_to_id(oi->ifp->vrf));
 
 	ospf_delete_from_if(oi->ifp, oi);
 

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -2569,7 +2569,7 @@ DEFUN (show_ip_ospf_mpls_te_link,
 	if (idx_interface) {
 		ifp = if_lookup_by_name(
 					argv[idx_interface]->arg,
-					ospf->vrf_id);
+					vrf_lookup_by_id(ospf->vrf_id));
 		if (ifp == NULL) {
 			vty_out(vty, "No such interface name in vrf %s\n",
 				vrf->name);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -457,13 +457,14 @@ DEFUN (ospf_passive_interface,
 	int ret;
 	struct ospf_if_params *params;
 	struct route_node *rn;
+	struct vrf *vrf = vrf_lookup_by_id(ospf->vrf_id);
 
 	if (strmatch(argv[1]->text, "default")) {
 		ospf_passive_interface_default(ospf, OSPF_IF_PASSIVE);
 		return CMD_SUCCESS;
 	}
 	if (ospf->vrf_id != VRF_UNKNOWN)
-		ifp = if_get_by_name(argv[1]->arg, ospf->vrf_id);
+		ifp = if_get_by_name(argv[1]->arg, vrf);
 
 	if (ifp == NULL) {
 		vty_out(vty, "interface %s not found.\n", (char *)argv[1]->arg);
@@ -529,6 +530,7 @@ DEFUN (no_ospf_passive_interface,
 	struct ospf_if_params *params;
 	int ret;
 	struct route_node *rn;
+	struct vrf *vrf = vrf_lookup_by_id(ospf->vrf_id);
 
 	if (strmatch(argv[2]->text, "default")) {
 		ospf_passive_interface_default(ospf, OSPF_IF_ACTIVE);
@@ -536,7 +538,7 @@ DEFUN (no_ospf_passive_interface,
 	}
 
 	if (ospf->vrf_id != VRF_UNKNOWN)
-		ifp = if_get_by_name(argv[2]->arg, ospf->vrf_id);
+		ifp = if_get_by_name(argv[2]->arg, vrf);
 
 	if (ifp == NULL) {
 		vty_out(vty, "interface %s not found.\n", (char *)argv[2]->arg);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3741,7 +3741,8 @@ static int show_ip_ospf_interface_common(struct vty *vty, struct ospf *ospf,
 					       json_interface);
 	} else {
 		/* Interface name is specified. */
-		ifp = if_lookup_by_name(intf_name, ospf->vrf_id);
+		ifp = if_lookup_by_name(intf_name,
+					vrf_lookup_by_id(ospf->vrf_id));
 		if (ifp == NULL) {
 			if (use_json)
 				json_object_boolean_true_add(json_vrf,
@@ -3881,7 +3882,8 @@ static int show_ip_ospf_interface_traffic_common(
 		}
 	} else {
 		/* Interface name is specified. */
-		ifp = if_lookup_by_name(intf_name, ospf->vrf_id);
+		ifp = if_lookup_by_name(intf_name,
+					vrf_lookup_by_id(ospf->vrf_id));
 		if (ifp != NULL) {
 			struct route_node *rn;
 			struct ospf_interface *oi;
@@ -4691,7 +4693,8 @@ static int show_ip_ospf_neighbor_int_common(struct vty *vty, struct ospf *ospf,
 
 	ospf_show_vrf_name(ospf, vty, json, use_vrf);
 
-	ifp = if_lookup_by_name(argv[arg_base]->arg, ospf->vrf_id);
+	ifp = if_lookup_by_name(argv[arg_base]->arg,
+				vrf_lookup_by_id(ospf->vrf_id));
 	if (!ifp) {
 		if (use_json)
 			json_object_boolean_true_add(json, "noSuchIface");
@@ -4759,7 +4762,8 @@ DEFUN (show_ip_ospf_neighbor_int,
 
 	argv_find(argv, argc, "IFNAME", &idx_ifname);
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+				vrf_lookup_by_id(vrf_id));
 	if (!ifp)
 		return ret;
 
@@ -5576,7 +5580,8 @@ static int show_ip_ospf_neighbor_int_detail_common(struct vty *vty,
 			vty_out(vty, "\nOSPF Instance: %d\n\n", ospf->instance);
 	}
 
-	ifp = if_lookup_by_name(argv[arg_base]->arg, ospf->vrf_id);
+	ifp = if_lookup_by_name(argv[arg_base]->arg,
+				vrf_lookup_by_id(ospf->vrf_id));
 	if (!ifp) {
 		if (!use_json)
 			vty_out(vty, "No such interface.\n");
@@ -10684,7 +10689,8 @@ DEFUN (clear_ip_ospf_interface,
 		}
 	} else {
 		/* Interface name is specified. */
-		ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
+		ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+					vrf_lookup_by_id(vrf_id));
 		if (ifp == NULL)
 			vty_out(vty, "No such interface name\n");
 		else

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -7279,7 +7279,7 @@ static int ospf_vty_dead_interval_set(struct vty *vty, const char *interval_str,
 	if (nbr_str) {
 		struct ospf *ospf = NULL;
 
-		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+		ospf = ospf_lookup_by_vrf(ifp->vrf);
 		if (ospf) {
 			oi = ospf_if_lookup_by_local_addr(ospf, ifp, addr);
 			if (oi)
@@ -7396,7 +7396,7 @@ DEFUN (no_ip_ospf_dead_interval,
 	if (argc == 1) {
 		struct ospf *ospf = NULL;
 
-		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+		ospf = ospf_lookup_by_vrf(ifp->vrf);
 		if (ospf) {
 			oi = ospf_if_lookup_by_local_addr(ospf, ifp, addr);
 			if (oi)
@@ -7995,8 +7995,8 @@ DEFUN (ip_ospf_area,
 	argv_find(argv, argc, "area", &idx);
 	areaid = argv[idx + 1]->arg;
 
-	if (ifp->vrf_id && !instance)
-		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+	if (ifp->vrf && ifp->vrf->vrf_id && !instance)
+		ospf = ospf_lookup_by_vrf(ifp->vrf);
 	else
 		ospf = ospf_lookup_instance(instance);
 
@@ -8093,8 +8093,8 @@ DEFUN (no_ip_ospf_area,
 	if (argv_find(argv, argc, "(1-65535)", &idx))
 		instance = strtol(argv[idx]->arg, NULL, 10);
 
-	if (ifp->vrf_id && !instance)
-		ospf = ospf_lookup_by_vrf_id(ifp->vrf_id);
+	if (ifp->vrf && ifp->vrf->vrf_id && !instance)
+		ospf = ospf_lookup_by_vrf(ifp->vrf);
 	else
 		ospf = ospf_lookup_instance(instance);
 
@@ -9720,7 +9720,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 			continue;
 
 		vty_frame(vty, "!\n");
-		if (ifp->vrf_id == VRF_DEFAULT)
+		if (ifp->vrf->vrf_id == VRF_DEFAULT)
 			vty_frame(vty, "interface %s\n", ifp->name);
 		else
 			vty_frame(vty, "interface %s vrf %s\n", ifp->name,

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -175,7 +175,8 @@ static struct interface *zebra_interface_if_lookup(struct stream *s,
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, vrf_id);
+	return if_lookup_by_name(ifname_tmp,
+				 vrf_lookup_by_id(vrf_id));
 }
 
 static int ospf_interface_state_up(ZAPI_CALLBACK_ARGS)

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -110,8 +110,8 @@ static int ospf_interface_add(ZAPI_CALLBACK_ARGS)
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
 		zlog_debug(
 			"Zebra: interface add %s vrf %s[%u] index %d flags %llx metric %d mtu %d speed %u",
-			ifp->name, ospf_vrf_id_to_name(ifp->vrf_id),
-			ifp->vrf_id, ifp->ifindex,
+			ifp->name, vrf_to_name(ifp->vrf),
+			vrf_to_id(ifp->vrf), ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu,
 			ifp->speed);
 
@@ -152,8 +152,8 @@ static int ospf_interface_delete(ZAPI_CALLBACK_ARGS)
 	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
 		zlog_debug(
 			"Zebra: interface delete %s vrf %s[%u] index %d flags %llx metric %d mtu %d",
-			ifp->name, ospf_vrf_id_to_name(ifp->vrf_id),
-			ifp->vrf_id, ifp->ifindex,
+			ifp->name, vrf_to_name(ifp->vrf),
+			vrf_to_id(ifp->vrf), ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
 
 	hook_call(ospf_if_delete, ifp);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -366,7 +366,7 @@ static int ospf_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 			ospf_vrf_id_to_name(new_vrf_id), new_vrf_id);
 
 	/*if_update(ifp, ifp->name, strlen(ifp->name), new_vrf_id);*/
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, vrf_lookup_by_id(new_vrf_id));
 
 	return 0;
 }

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -452,6 +452,11 @@ struct ospf *ospf_lookup_by_vrf_id(vrf_id_t vrf_id)
 	vrf = vrf_lookup_by_id(vrf_id);
 	if (!vrf)
 		return NULL;
+	return ospf_lookup_by_vrf(vrf);
+}
+
+struct ospf *ospf_lookup_by_vrf(struct vrf *vrf)
+{
 	return (vrf->info) ? (struct ospf *)vrf->info : NULL;
 }
 
@@ -1347,8 +1352,8 @@ void ospf_if_update(struct ospf *ospf, struct interface *ifp)
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug(
-			"%s: interface %s ifp->vrf_id %u ospf vrf %s vrf_id %u router_id %s",
-			__PRETTY_FUNCTION__, ifp->name, ifp->vrf_id,
+			"%s: interface %s ifp->vrf->vrf_id %u ospf vrf %s vrf_id %u router_id %s",
+			__PRETTY_FUNCTION__, ifp->name, vrf_to_id(ifp->vrf),
 			ospf_vrf_id_to_name(ospf->vrf_id), ospf->vrf_id,
 			inet_ntoa(ospf->router_id));
 

--- a/ospfd/ospfd.h
+++ b/ospfd/ospfd.h
@@ -507,6 +507,7 @@ extern struct ospf *ospf_get_instance(unsigned short);
 extern struct ospf *ospf_lookup_by_inst_name(unsigned short instance,
 					     const char *name);
 extern struct ospf *ospf_lookup_by_vrf_id(vrf_id_t vrf_id);
+extern struct ospf *ospf_lookup_by_vrf(struct vrf *vrf);
 extern void ospf_finish(struct ospf *);
 extern void ospf_router_id_update(struct ospf *ospf);
 extern int ospf_network_set(struct ospf *, struct prefix_ipv4 *, struct in_addr,

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7655,7 +7655,7 @@ DEFUN (interface_ip_mroute,
 	pim = pim_ifp->pim;
 
 	oifname = argv[idx_interface]->arg;
-	oif = if_lookup_by_name(oifname, pim->vrf_id);
+	oif = if_lookup_by_name(oifname, pim->vrf);
 	if (!oif) {
 		vty_out(vty, "No such interface name %s\n", oifname);
 		return CMD_WARNING;
@@ -7706,7 +7706,7 @@ DEFUN (interface_ip_mroute_source,
 	pim = pim_ifp->pim;
 
 	oifname = argv[idx_interface]->arg;
-	oif = if_lookup_by_name(oifname, pim->vrf_id);
+	oif = if_lookup_by_name(oifname, pim->vrf);
 	if (!oif) {
 		vty_out(vty, "No such interface name %s\n", oifname);
 		return CMD_WARNING;
@@ -7761,7 +7761,7 @@ DEFUN (interface_no_ip_mroute,
 	pim = pim_ifp->pim;
 
 	oifname = argv[idx_interface]->arg;
-	oif = if_lookup_by_name(oifname, pim->vrf_id);
+	oif = if_lookup_by_name(oifname, pim->vrf);
 	if (!oif) {
 		vty_out(vty, "No such interface name %s\n", oifname);
 		return CMD_WARNING;
@@ -7813,7 +7813,7 @@ DEFUN (interface_no_ip_mroute_source,
 	pim = pim_ifp->pim;
 
 	oifname = argv[idx_interface]->arg;
-	oif = if_lookup_by_name(oifname, pim->vrf_id);
+	oif = if_lookup_by_name(oifname, pim->vrf);
 	if (!oif) {
 		vty_out(vty, "No such interface name %s\n", oifname);
 		return CMD_WARNING;
@@ -10127,7 +10127,7 @@ DEFUN_HIDDEN (ip_pim_mlag,
 
 	idx = 3;
 	peerlink = argv[idx]->arg;
-	ifp = if_lookup_by_name(peerlink, VRF_DEFAULT);
+	ifp = if_lookup_by_name(peerlink, vrf_lookup_by_id(VRF_DEFAULT));
 	if (!ifp) {
 		vty_out(vty, "No such interface name %s\n", peerlink);
 		return CMD_WARNING;

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -895,9 +895,9 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 		struct interface *lo_ifp;
 		// DBS - Come back and check here
 		if (ifp->vrf_id == VRF_DEFAULT)
-			lo_ifp = if_lookup_by_name("lo", vrf->vrf_id);
+			lo_ifp = if_lookup_by_name("lo", vrf);
 		else
-			lo_ifp = if_lookup_by_name(vrf->name, vrf->vrf_id);
+			lo_ifp = if_lookup_by_name(vrf->name, vrf);
 
 		if (lo_ifp)
 			return pim_find_primary_addr(lo_ifp);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1480,7 +1480,7 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 			snprintf(pimreg_name, sizeof(pimreg_name), "pimreg%u",
 				 pim->vrf->data.l.table_id);
 
-		pim->regiface = if_create(pimreg_name, pim->vrf_id);
+		pim->regiface = if_create(pimreg_name, pim->vrf);
 		pim->regiface->ifindex = PIM_OIF_PIM_REGISTER_VIF;
 
 		pim_if_new(pim->regiface, false, false, true,

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -120,7 +120,7 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 	pim_ifp = XCALLOC(MTYPE_PIM_INTERFACE, sizeof(*pim_ifp));
 
 	pim_ifp->options = 0;
-	pim_ifp->pim = pim_get_pim_instance(ifp->vrf_id);
+	pim_ifp->pim = pim_get_pim_instance(vrf_to_id(ifp->vrf));
 	pim_ifp->mroute_vif_index = -1;
 
 	pim_ifp->igmp_version = IGMP_DEFAULT_VERSION;
@@ -781,7 +781,7 @@ void pim_if_addr_del_all(struct interface *ifp)
 	struct connected *ifc;
 	struct listnode *node;
 	struct listnode *nextnode;
-	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+	struct vrf *vrf = ifp->vrf;
 	struct pim_instance *pim;
 
 	if (!vrf)
@@ -853,7 +853,7 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 	int v4_addrs = 0;
 	int v6_addrs = 0;
 	struct pim_interface *pim_ifp = ifp->info;
-	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+	struct vrf *vrf = ifp->vrf;
 
 	if (!vrf)
 		return addr;
@@ -894,7 +894,7 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 	if (!v4_addrs && v6_addrs && !if_is_loopback(ifp)) {
 		struct interface *lo_ifp;
 		// DBS - Come back and check here
-		if (ifp->vrf_id == VRF_DEFAULT)
+		if (!ifp->vrf || ifp->vrf->vrf_id == VRF_DEFAULT)
 			lo_ifp = if_lookup_by_name("lo", vrf);
 		else
 			lo_ifp = if_lookup_by_name(vrf->name, vrf);

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -158,7 +158,7 @@ int pim_msdp_sock_listen(struct pim_instance *pim)
 
 	if (pim->vrf_id != VRF_DEFAULT) {
 		struct interface *ifp =
-			if_lookup_by_name(pim->vrf->name, pim->vrf_id);
+			if_lookup_by_name(pim->vrf->name, pim->vrf);
 		if (!ifp) {
 			flog_err(EC_LIB_INTERFACE,
 				 "%s: Unable to lookup vrf interface: %s",
@@ -239,7 +239,7 @@ int pim_msdp_sock_connect(struct pim_msdp_peer *mp)
 
 	if (mp->pim->vrf_id != VRF_DEFAULT) {
 		struct interface *ifp =
-			if_lookup_by_name(mp->pim->vrf->name, mp->pim->vrf_id);
+			if_lookup_by_name(mp->pim->vrf->name, mp->pim->vrf);
 		if (!ifp) {
 			flog_err(EC_LIB_INTERFACE,
 				 "%s: Unable to lookup vrf interface: %s",

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -92,7 +92,7 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 		return -4;
 	}
 #endif
-	if (iif->vrf_id != oif->vrf_id) {
+	if (iif->vrf != oif->vrf) {
 		return -3;
 	}
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -214,7 +214,7 @@ static int pim_zebra_if_state_up(ZAPI_CALLBACK_ARGS)
 
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 			if ((table_id == vrf->data.l.table_id)
-			    && (ifp->vrf_id != vrf->vrf_id)) {
+			    && (ifp->vrf != vrf)) {
 				struct interface *master = if_lookup_by_name(
 							     vrf->name, vrf);
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -211,11 +211,12 @@ static int pim_zebra_if_state_up(ZAPI_CALLBACK_ARGS)
 	 */
 	if (sscanf(ifp->name, "pimreg%" SCNu32, &table_id) == 1) {
 		struct vrf *vrf;
+
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 			if ((table_id == vrf->data.l.table_id)
 			    && (ifp->vrf_id != vrf->vrf_id)) {
 				struct interface *master = if_lookup_by_name(
-					vrf->name, vrf->vrf_id);
+							     vrf->name, vrf);
 
 				if (!master) {
 					zlog_debug(

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -291,7 +291,7 @@ static int pim_zebra_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 			   __PRETTY_FUNCTION__,
 			   ifp->name, vrf_id, new_vrf_id);
 
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, vrf_lookup_by_id(new_vrf_id));
 
 	return 0;
 }

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -468,17 +468,20 @@ int rip_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	vrf_id_t new_vrf_id;
+	struct vrf *new_vrf;
 
 	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrf_id,
 					      &new_vrf_id);
 	if (!ifp)
 		return 0;
 
+	new_vrf = vrf_lookup_by_id(new_vrf_id);
+
 	if (IS_RIP_DEBUG_ZEBRA)
 		zlog_debug("interface %s VRF change vrf_id %u new vrf id %u",
 			   ifp->name, vrf_id, new_vrf_id);
 
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, new_vrf);
 	rip_interface_sync(ifp);
 
 	return 0;

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -364,7 +364,7 @@ int rip_interface_down(ZAPI_CALLBACK_ARGS)
 	if (IS_RIP_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface %s vrf %u index %d flags %llx metric %d mtu %d is down",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			ifp->name, ifp->vrf->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
 
 	return 0;
@@ -385,7 +385,7 @@ int rip_interface_up(ZAPI_CALLBACK_ARGS)
 	if (IS_RIP_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface %s vrf %u index %d flags %#llx metric %d mtu %d is up",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			ifp->name, ifp->vrf->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
 
 	rip_interface_sync(ifp);
@@ -413,7 +413,7 @@ int rip_interface_add(ZAPI_CALLBACK_ARGS)
 	if (IS_RIP_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface add %s vrf %u index %d flags %#llx metric %d mtu %d",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			ifp->name, ifp->vrf->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
 
 	/* Check if this interface is RIP enabled or not.*/
@@ -453,7 +453,7 @@ int rip_interface_delete(ZAPI_CALLBACK_ARGS)
 
 	zlog_info(
 		"interface delete %s vrf %u index %d flags %#llx metric %d mtu %d",
-		ifp->name, ifp->vrf_id, ifp->ifindex,
+		ifp->name, ifp->vrf->vrf_id, ifp->ifindex,
 		(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
 
 	/* To support pseudo interface do not free interface structure.  */
@@ -482,6 +482,7 @@ int rip_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 			   ifp->name, vrf_id, new_vrf_id);
 
 	if_update_to_new_vrf(ifp, new_vrf);
+
 	rip_interface_sync(ifp);
 
 	return 0;
@@ -1226,7 +1227,7 @@ void rip_interface_sync(struct interface *ifp)
 {
 	struct vrf *vrf;
 
-	vrf = vrf_lookup_by_id(ifp->vrf_id);
+	vrf = ifp->vrf;
 	if (vrf) {
 		struct rip_interface *ri;
 

--- a/ripd/rip_routemap.c
+++ b/ripd/rip_routemap.c
@@ -106,7 +106,8 @@ static route_map_result_t route_match_interface(void *rule,
 
 	if (type == RMAP_RIP) {
 		ifname = rule;
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifname,
+					vrf_lookup_by_id(VRF_DEFAULT));
 
 		if (!ifp)
 			return RMAP_NOMATCH;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3299,7 +3299,7 @@ static void rip_distribute_update(struct distribute_ctx *ctx,
 	if (!ctx->vrf || !dist->ifname)
 		return;
 
-	ifp = if_lookup_by_name(dist->ifname, ctx->vrf->vrf_id);
+	ifp = if_lookup_by_name(dist->ifname, ctx->vrf);
 	if (ifp == NULL)
 		return;
 
@@ -3418,7 +3418,7 @@ static void rip_if_rmap_update(struct if_rmap_ctx *ctx,
 	if (ctx->name)
 		vrf = vrf_lookup_by_name(ctx->name);
 	if (vrf)
-		ifp = if_lookup_by_name(if_rmap->ifname, vrf->vrf_id);
+		ifp = if_lookup_by_name(if_rmap->ifname, vrf);
 	if (ifp == NULL)
 		return;
 

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3451,6 +3451,8 @@ void rip_if_rmap_update_interface(struct interface *ifp)
 
 	if (!rip)
 		return;
+	if (ifp->vrf && ifp->vrf->vrf_id == VRF_UNKNOWN)
+		return;
 	ctx = rip->if_rmap_ctx;
 	if (!ctx)
 		return;

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -314,17 +314,20 @@ int ripng_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	vrf_id_t new_vrf_id;
+	struct vrf *new_vrf;
 
 	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrf_id,
 					      &new_vrf_id);
 	if (!ifp)
 		return 0;
 
+	new_vrf = vrf_lookup_by_id(new_vrf_id);
+
 	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug("interface %s VRF change vrf_id %u new vrf id %u",
 			   ifp->name, vrf_id, new_vrf_id);
 
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, new_vrf);
 	ripng_interface_sync(ifp);
 
 	return 0;

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -210,7 +210,7 @@ int ripng_interface_up(ZAPI_CALLBACK_ARGS)
 	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface up %s vrf %u index %d flags %llx metric %d mtu %d",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			ifp->name, ifp->vrf->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
 
 	ripng_interface_sync(ifp);
@@ -247,7 +247,7 @@ int ripng_interface_down(ZAPI_CALLBACK_ARGS)
 	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface down %s vrf %u index %d flags %#llx metric %d mtu %d",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			ifp->name, ifp->vrf->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
 
 	return 0;
@@ -264,7 +264,7 @@ int ripng_interface_add(ZAPI_CALLBACK_ARGS)
 	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug(
 			"RIPng interface add %s vrf %u index %d flags %#llx metric %d mtu %d",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			ifp->name, ifp->vrf->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
 
 	/* Check is this interface is RIP enabled or not.*/
@@ -299,7 +299,7 @@ int ripng_interface_delete(ZAPI_CALLBACK_ARGS)
 
 	zlog_info(
 		"interface delete %s vrf %u index %d flags %#llx metric %d mtu %d",
-		ifp->name, ifp->vrf_id, ifp->ifindex,
+		ifp->name, ifp->vrf->vrf_id, ifp->ifindex,
 		(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
 
 	/* To support pseudo interface do not free interface structure.  */
@@ -328,6 +328,7 @@ int ripng_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 			   ifp->name, vrf_id, new_vrf_id);
 
 	if_update_to_new_vrf(ifp, new_vrf);
+
 	ripng_interface_sync(ifp);
 
 	return 0;
@@ -932,7 +933,7 @@ void ripng_interface_sync(struct interface *ifp)
 {
 	struct vrf *vrf;
 
-	vrf = vrf_lookup_by_id(ifp->vrf_id);
+	vrf = ifp->vrf;
 	if (vrf) {
 		struct ripng_interface *ri;
 

--- a/ripngd/ripng_routemap.c
+++ b/ripngd/ripng_routemap.c
@@ -97,7 +97,8 @@ static route_map_result_t route_match_interface(void *rule,
 
 	if (type == RMAP_RIPNG) {
 		ifname = rule;
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifname,
+					vrf_lookup_by_id(VRF_DEFAULT));
 
 		if (!ifp)
 			return RMAP_NOMATCH;

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2454,7 +2454,7 @@ static void ripng_distribute_update(struct distribute_ctx *ctx,
 	if (!ctx->vrf || !dist->ifname)
 		return;
 
-	ifp = if_lookup_by_name(dist->ifname, ctx->vrf->vrf_id);
+	ifp = if_lookup_by_name(dist->ifname, ctx->vrf);
 	if (ifp == NULL)
 		return;
 
@@ -2571,7 +2571,7 @@ static void ripng_if_rmap_update(struct if_rmap_ctx *ctx,
 	if (ctx->name)
 		vrf = vrf_lookup_by_name(ctx->name);
 	if (vrf)
-		ifp = if_lookup_by_name(if_rmap->ifname, vrf->vrf_id);
+		ifp = if_lookup_by_name(if_rmap->ifname, vrf);
 	if (ifp == NULL)
 		return;
 

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2603,6 +2603,8 @@ void ripng_if_rmap_update_interface(struct interface *ifp)
 	struct if_rmap *if_rmap;
 	struct if_rmap_ctx *ctx;
 
+	if (ifp->vrf && ifp->vrf->vrf_id == VRF_UNKNOWN)
+		return;
 	if (!ripng)
 		return;
 	ctx = ripng->if_rmap_ctx;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -46,7 +46,7 @@ struct zclient *zclient = NULL;
 /* For registering threads. */
 extern struct thread_master *master;
 
-static struct interface *zebra_interface_if_lookup(struct stream *s)
+static struct interface *zebra_interface_if_lookup(struct stream *s, vrf_id_t vrf_id)
 {
 	char ifname_tmp[INTERFACE_NAMSIZ];
 
@@ -54,7 +54,8 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, VRF_DEFAULT);
+	return if_lookup_by_name(ifname_tmp,
+				 vrf_lookup_by_id(vrf_id));
 }
 
 /* Inteface addition message from zebra. */
@@ -112,7 +113,7 @@ static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 static int interface_state_up(ZAPI_CALLBACK_ARGS)
 {
 
-	zebra_interface_if_lookup(zclient->ibuf);
+	zebra_interface_if_lookup(zclient->ibuf, vrf_id);
 
 	return 0;
 }

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -187,7 +187,7 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 	else {
 		struct interface *ifp;
 
-		ifp = if_lookup_by_name(ifname, nh_svrf->vrf->vrf_id);
+		ifp = if_lookup_by_name(ifname, nh_svrf->vrf);
 		if (ifp && ifp->ifindex != IFINDEX_INTERNAL) {
 			si->ifindex = ifp->ifindex;
 			static_install_route(rn, si, safi);
@@ -331,8 +331,7 @@ static void static_fixup_vrf(struct static_vrf *svrf,
 			si->nh_vrf_id = svrf->vrf->vrf_id;
 			si->nh_registered = false;
 			if (si->ifindex) {
-				ifp = if_lookup_by_name(si->ifname,
-							si->nh_vrf_id);
+				ifp = if_lookup_by_name(si->ifname, svrf->vrf);
 				if (ifp)
 					si->ifindex = ifp->ifindex;
 				else
@@ -367,7 +366,8 @@ static void static_enable_vrf(struct static_vrf *svrf,
 			si->vrf_id = vrf->vrf_id;
 			if (si->ifindex) {
 				ifp = if_lookup_by_name(si->ifname,
-							si->nh_vrf_id);
+							vrf_lookup_by_id(
+							 si->nh_vrf_id));
 				if (ifp)
 					si->ifindex = ifp->ifindex;
 				else

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -516,7 +516,7 @@ static void static_fixup_intf_nh(struct route_table *stable,
 
 	for (rn = route_top(stable); rn; rn = route_next(rn)) {
 		for (si = rn->info; si; si = si->next) {
-			if (si->nh_vrf_id != ifp->vrf_id)
+			if (si->nh_vrf_id != vrf_to_id(ifp->vrf))
 				continue;
 
 			if (si->ifindex != ifp->ifindex)
@@ -542,7 +542,7 @@ void static_install_intf_nh(struct interface *ifp)
 		struct static_vrf *svrf = vrf->info;
 
 		/* Not needed if same vrf since happens naturally */
-		if (vrf->vrf_id == ifp->vrf_id)
+		if (vrf == ifp->vrf)
 			continue;
 
 		/* Install any static routes configured for this interface. */

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -47,7 +47,7 @@
 struct zclient *zclient;
 static struct hash *static_nht_hash;
 
-static struct interface *zebra_interface_if_lookup(struct stream *s)
+static struct interface *zebra_interface_if_lookup(struct stream *s, vrf_id_t vrf_id)
 {
 	char ifname_tmp[INTERFACE_NAMSIZ];
 
@@ -55,7 +55,8 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, VRF_DEFAULT);
+	return if_lookup_by_name(ifname_tmp,
+				 vrf_lookup_by_id(vrf_id));
 }
 
 /* Inteface addition message from zebra. */
@@ -115,7 +116,7 @@ static int interface_state_up(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
-	ifp = zebra_interface_if_lookup(zclient->ibuf);
+	ifp = zebra_interface_if_lookup(zclient->ibuf, vrf_id);
 
 	if (ifp) {
 		if (if_is_vrf(ifp)) {

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -207,16 +207,16 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 	struct nexthop nh = {
 		.type = NEXTHOP_TYPE_IFINDEX,
 		.ifindex = ifp->ifindex,
-		.vrf_id = ifp->vrf_id,
+		.vrf_id = vrf_to_id(ifp->vrf),
 	};
 	struct zebra_vrf *zvrf;
 	uint32_t metric;
 
-	zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	zvrf = zebra_vrf_lookup_by_id(ifp->vrf->vrf_id);
 	if (!zvrf) {
 		flog_err(EC_ZEBRA_VRF_NOT_FOUND,
 			 "%s: Received Up for interface but no associated zvrf: %d",
-			 __PRETTY_FUNCTION__, ifp->vrf_id);
+			 __PRETTY_FUNCTION__, ifp->vrf->vrf_id);
 		return;
 	}
 	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_REAL))
@@ -265,7 +265,7 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 
 		zlog_debug(
 			"%u: IF %s address %s add/up, scheduling RIB processing",
-			ifp->vrf_id, ifp->name,
+			vrf_to_id(ifp->vrf), ifp->name,
 			prefix2str(&p, buf, sizeof(buf)));
 	}
 	rib_update(zvrf->vrf->vrf_id, RIB_UPDATE_IF_CHANGE);
@@ -383,15 +383,15 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 	struct nexthop nh = {
 		.type = NEXTHOP_TYPE_IFINDEX,
 		.ifindex = ifp->ifindex,
-		.vrf_id = ifp->vrf_id,
+		.vrf_id = vrf_to_id(ifp->vrf),
 	};
 	struct zebra_vrf *zvrf;
 
-	zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	zvrf = zebra_vrf_lookup_by_id(ifp->vrf->vrf_id);
 	if (!zvrf) {
 		flog_err(EC_ZEBRA_VRF_NOT_FOUND,
 			 "%s: Received Up for interface but no associated zvrf: %d",
-			 __PRETTY_FUNCTION__, ifp->vrf_id);
+			 __PRETTY_FUNCTION__, ifp->vrf->vrf_id);
 		return;
 	}
 
@@ -473,22 +473,22 @@ static void connected_delete_helper(struct connected *ifc, struct prefix *p)
 
 		zlog_debug(
 			"%u: IF %s IP %s address del, scheduling RIB processing",
-			ifp->vrf_id, ifp->name,
+			vrf_to_id(ifp->vrf), ifp->name,
 			prefix2str(p, buf, sizeof(buf)));
 	}
-	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
+	rib_update(vrf_to_id(ifp->vrf), RIB_UPDATE_IF_CHANGE);
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
-	if (ifp->vrf_id == VRF_DEFAULT) {
+	if (vrf_to_id(ifp->vrf) == VRF_DEFAULT) {
 		if (IS_ZEBRA_DEBUG_MPLS) {
 			char buf[PREFIX_STRLEN];
 
 			zlog_debug(
 				"%u: IF %s IP %s address delete, scheduling MPLS processing",
-				ifp->vrf_id, ifp->name,
+				vrf_to_id(ifp->vrf), ifp->name,
 				prefix2str(p, buf, sizeof(buf)));
 		}
-		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id), p);
+		mpls_mark_lsps_for_processing(zvrf_info_lookup(ifp->vrf), p);
 	}
 }
 

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -54,6 +54,7 @@ static int interface_list_ioctl(void)
 	struct interface *ifp;
 	int n;
 	int lastlen;
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	/* Normally SIOCGIFCONF works with AF_INET socket. */
 	sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -110,7 +111,7 @@ static int interface_list_ioctl(void)
 		unsigned int size;
 
 		ifreq = (struct ifreq *)((caddr_t)ifconf.ifc_req + n);
-		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT);
+		ifp = if_get_by_name(ifreq->ifr_name, vrf);
 		if_add_update(ifp);
 		size = ifreq->ifr_addr.sa_len;
 		if (size < sizeof(ifreq->ifr_addr))
@@ -120,7 +121,7 @@ static int interface_list_ioctl(void)
 	}
 #else
 	for (n = 0; n < ifconf.ifc_len; n += sizeof(struct ifreq)) {
-		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT);
+		ifp = if_get_by_name(ifreq->ifr_name, vrf);
 		if_add_update(ifp);
 		ifreq++;
 	}

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -196,7 +196,8 @@ static int if_getaddrs(void)
 			continue;
 		}
 
-		ifp = if_lookup_by_name(ifap->ifa_name, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifap->ifa_name,
+					vrf_lookup_by_id(VRF_DEFAULT));
 		if (ifp == NULL) {
 			flog_err(EC_LIB_INTERFACE,
 				 "if_getaddrs(): Can't lookup interface %s\n",

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -152,7 +152,8 @@ static int if_get_hwaddr(struct interface *ifp)
 	ifreq.ifr_addr.sa_family = AF_INET;
 
 	/* Fetch Hardware address if available. */
-	ret = vrf_if_ioctl(SIOCGIFHWADDR, (caddr_t)&ifreq, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCGIFHWADDR, (caddr_t)&ifreq,
+			   vrf_to_id(ifp->vrf));
 	if (ret < 0)
 		ifp->hw_addr_len = 0;
 	else {

--- a/zebra/if_ioctl_solaris.c
+++ b/zebra/if_ioctl_solaris.c
@@ -59,6 +59,7 @@ static int interface_list_ioctl(int af)
 	int n;
 	size_t needed, lastneeded = 0;
 	char *buf = NULL;
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	frr_elevate_privs(&zserv_privs) {
 		sock = socket(af, SOCK_DGRAM, 0);
@@ -156,7 +157,7 @@ calculate_lifc_len:
 		       && (*(lifreq->lifr_name + normallen) != ':'))
 			normallen++;
 
-		ifp = if_get_by_name(lifreq->lifr_name, VRF_DEFAULT);
+		ifp = if_get_by_name(lifreq->lifr_name, vrf);
 
 		if (lifreq->lifr_addr.ss_family == AF_INET)
 			ifp->flags |= IFF_IPV4;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1233,7 +1233,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			} else {
 				/* pre-configured interface, learnt now */
 				if (ifp->vrf_id != vrf_id)
-					if_update_to_new_vrf(ifp, vrf_id);
+					if_update_to_new_vrf(ifp, vrf);
 			}
 
 			/* Update interface information. */

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -665,6 +665,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		    && !vrf_is_backend_netns()) {
 			zif_slave_type = ZEBRA_IF_SLAVE_VRF;
 			vrf_id = *(uint32_t *)RTA_DATA(tb[IFLA_MASTER]);
+			/* vrf can be needed before vrf netlink discovery */
+			vrf_get(vrf_id, NULL);
 		} else if (slave_kind && (strcmp(slave_kind, "bridge") == 0)) {
 			zif_slave_type = ZEBRA_IF_SLAVE_BRIDGE;
 			bridge_ifindex =
@@ -677,9 +679,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	}
 	if (vrf_is_backend_netns())
 		vrf_id = (vrf_id_t)ns_id;
-
 	vrf = vrf_lookup_by_id(vrf_id);
-
 	/* If linking to another interface, note it. */
 	if (tb[IFLA_LINK])
 		link_ifindex = *(ifindex_t *)RTA_DATA(tb[IFLA_LINK]);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1589,17 +1589,15 @@ DEFPY(show_interface, show_interface_cmd,
       VRF_CMD_HELP_STR
       "Interface status and configuration summary\n")
 {
-	struct vrf *vrf;
+	struct vrf *vrf = NULL;
 	struct interface *ifp;
-	vrf_id_t vrf_id = VRF_DEFAULT;
 
 	interface_update_stats();
 
 	if (name)
-		VRF_GET_ID(vrf_id, name, false);
+		VRF_GET_INSTANCE(vrf, name, false);
 
 	/* All interface print. */
-	vrf = vrf_lookup_by_id(vrf_id);
 	if (brief) {
 		ifs_dump_brief_vty(vty, vrf);
 	} else {
@@ -1646,15 +1644,14 @@ DEFUN (show_interface_name_vrf,
 	int idx_ifname = 2;
 	int idx_name = 4;
 	struct interface *ifp;
-	vrf_id_t vrf_id;
+	struct vrf *vrf;
 
 	interface_update_stats();
 
-	VRF_GET_ID(vrf_id, argv[idx_name]->arg, false);
+	VRF_GET_INSTANCE(vrf, argv[idx_name]->arg, false);
 
 	/* Specified interface print. */
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg,
-				vrf_lookup_by_id(vrf_id));
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf);
 	if (ifp == NULL) {
 		vty_out(vty, "%% Can't find interface %s\n",
 			argv[idx_ifname]->arg);
@@ -1701,9 +1698,8 @@ DEFUN (show_interface_name_vrf_all,
 }
 
 
-static void if_show_description(struct vty *vty, vrf_id_t vrf_id)
+static void if_show_description(struct vty *vty, struct vrf *vrf)
 {
-	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 	struct interface *ifp;
 
 	vty_out(vty, "Interface       Status  Protocol  Description\n");
@@ -1757,12 +1753,14 @@ DEFUN (show_interface_desc,
        "Interface description\n"
        VRF_CMD_HELP_STR)
 {
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	struct vrf *vrf;
 
 	if (argc > 3)
-		VRF_GET_ID(vrf_id, argv[4]->arg, false);
+		VRF_GET_INSTANCE(vrf, argv[4]->arg, false);
+	else
+		vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
-	if_show_description(vty, vrf_id);
+	if_show_description(vty, vrf);
 
 	return CMD_SUCCESS;
 }
@@ -1781,7 +1779,7 @@ DEFUN (show_interface_desc_vrf_all,
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
 		if (!RB_EMPTY(if_name_head, &vrf->ifaces_by_name)) {
 			vty_out(vty, "\n\tVRF %u\n\n", vrf->vrf_id);
-			if_show_description(vty, vrf->vrf_id);
+			if_show_description(vty, vrf);
 		}
 
 	return CMD_SUCCESS;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1595,7 +1595,7 @@ DEFPY(show_interface, show_interface_cmd,
 	interface_update_stats();
 
 	if (name)
-		VRF_GET_INSTANCE(vrf, name, false);
+		VRF_GET_INSTANCE(vrf, name, false, false);
 
 	/* All interface print. */
 	if (brief) {
@@ -1648,7 +1648,7 @@ DEFUN (show_interface_name_vrf,
 
 	interface_update_stats();
 
-	VRF_GET_INSTANCE(vrf, argv[idx_name]->arg, false);
+	VRF_GET_INSTANCE(vrf, argv[idx_name]->arg, false, false);
 
 	/* Specified interface print. */
 	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf);
@@ -1756,7 +1756,7 @@ DEFUN (show_interface_desc,
 	struct vrf *vrf;
 
 	if (argc > 3)
-		VRF_GET_INSTANCE(vrf, argv[4]->arg, false);
+		VRF_GET_INSTANCE(vrf, argv[4]->arg, false, false);
 	else
 		vrf = vrf_lookup_by_id(VRF_DEFAULT);
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1653,7 +1653,8 @@ DEFUN (show_interface_name_vrf,
 	VRF_GET_ID(vrf_id, argv[idx_name]->arg, false);
 
 	/* Specified interface print. */
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+				vrf_lookup_by_id(vrf_id));
 	if (ifp == NULL) {
 		vty_out(vty, "%% Can't find interface %s\n",
 			argv[idx_ifname]->arg);
@@ -1683,7 +1684,7 @@ DEFUN (show_interface_name_vrf_all,
 	/* All interface print. */
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 		/* Specified interface print. */
-		ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf->vrf_id);
+		ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf);
 		if (ifp) {
 			if_dump_vty(vty, ifp);
 			found++;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -768,6 +768,7 @@ void if_delete_update(struct interface *ifp)
 void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
 {
 	vrf_id_t old_vrf_id;
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
 	old_vrf_id = ifp->vrf_id;
 
@@ -785,7 +786,7 @@ void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
 	zebra_interface_vrf_update_del(ifp, vrf_id);
 
 	/* update VRF */
-	if_update_to_new_vrf(ifp, vrf_id);
+	if_update_to_new_vrf(ifp, vrf);
 
 	/* Send out notification on interface VRF change. */
 	/* This is to issue an ADD, if needed. */

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -530,7 +530,7 @@ void if_add_update(struct interface *ifp)
 {
 	struct zebra_if *if_data;
 	struct zebra_ns *zns;
-	struct zebra_vrf *zvrf = vrf_info_lookup(ifp->vrf_id);
+	struct zebra_vrf *zvrf = zvrf_info_lookup(ifp->vrf);
 
 	/* case interface populate before vrf enabled */
 	if (zvrf->zns)
@@ -558,7 +558,8 @@ void if_add_update(struct interface *ifp)
 				zlog_debug(
 					"interface %s vrf %u index %d is shutdown. "
 					"Won't wake it up.",
-					ifp->name, ifp->vrf_id, ifp->ifindex);
+					ifp->name, vrf_to_id(ifp->vrf),
+					ifp->ifindex);
 			return;
 		}
 
@@ -567,12 +568,13 @@ void if_add_update(struct interface *ifp)
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
 				"interface %s vrf %u index %d becomes active.",
-				ifp->name, ifp->vrf_id, ifp->ifindex);
+				ifp->name, vrf_to_id(ifp->vrf), ifp->ifindex);
 
 	} else {
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug("interface %s vrf %u index %d is added.",
-				   ifp->name, ifp->vrf_id, ifp->ifindex);
+				   ifp->name, vrf_to_id(ifp->vrf),
+				   ifp->ifindex);
 	}
 }
 
@@ -714,7 +716,7 @@ void if_delete_update(struct interface *ifp)
 		flog_err(
 			EC_LIB_INTERFACE,
 			"interface %s vrf %u index %d is still up while being deleted.",
-			ifp->name, ifp->vrf_id, ifp->ifindex);
+			ifp->name, vrf_to_id(ifp->vrf), ifp->ifindex);
 		return;
 	}
 
@@ -726,7 +728,7 @@ void if_delete_update(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_KERNEL)
 		zlog_debug("interface %s vrf %u index %d is now inactive.",
-			   ifp->name, ifp->vrf_id, ifp->ifindex);
+			   ifp->name, vrf_to_id(ifp->vrf), ifp->ifindex);
 
 	/* Delete connected routes from the kernel. */
 	if_delete_connected(ifp);
@@ -750,7 +752,7 @@ void if_delete_update(struct interface *ifp)
 	 * occur with this implementation whereas it is not possible with
 	 * vrf-lite).
 	 */
-	if (ifp->vrf_id && !vrf_is_backend_netns())
+	if (ifp->vrf->vrf_id && !vrf_is_backend_netns())
 		if_handle_vrf_change(ifp, VRF_DEFAULT);
 
 	/* Reset some zebra interface params to default values. */
@@ -770,7 +772,7 @@ void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
 	vrf_id_t old_vrf_id;
 	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
-	old_vrf_id = ifp->vrf_id;
+	old_vrf_id = vrf_to_id(ifp->vrf);
 
 	/* Uninstall connected routes. */
 	if_uninstall_connected(ifp);
@@ -801,9 +803,9 @@ void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
 	 */
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 		zlog_debug("%u: IF %s VRF change, scheduling RIB processing",
-			   ifp->vrf_id, ifp->name);
+			   vrf_to_id(ifp->vrf), ifp->name);
 	rib_update(old_vrf_id, RIB_UPDATE_IF_CHANGE);
-	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
+	rib_update(vrf_to_id(ifp->vrf), RIB_UPDATE_IF_CHANGE);
 }
 
 static void ipv6_ll_address_to_mac(struct in6_addr *address, uint8_t *mac)
@@ -821,7 +823,7 @@ void if_nbr_mac_to_ipv4ll_neigh_update(struct interface *ifp,
 				       struct in6_addr *address,
 				       int add)
 {
-	struct zebra_vrf *zvrf = vrf_info_lookup(ifp->vrf_id);
+	struct zebra_vrf *zvrf = zvrf_info_lookup(ifp->vrf);
 	struct zebra_if *zif = ifp->info;
 	char buf[16] = "169.254.0.1";
 	struct in_addr ipv4_ll;
@@ -917,7 +919,7 @@ void if_up(struct interface *ifp)
 {
 	struct zebra_if *zif;
 	struct interface *link_if;
-	struct zebra_vrf *zvrf = vrf_info_lookup(ifp->vrf_id);
+	struct zebra_vrf *zvrf = zvrf_info_lookup(ifp->vrf);
 
 	zif = ifp->info;
 	zif->up_count++;
@@ -948,8 +950,8 @@ void if_up(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 		zlog_debug("%u: IF %s up, scheduling RIB processing",
-			   ifp->vrf_id, ifp->name);
-	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
+			   vrf_to_id(ifp->vrf), ifp->name);
+	rib_update(vrf_to_id(ifp->vrf), RIB_UPDATE_IF_CHANGE);
 
 	/* Handle interface up for specific types for EVPN. Non-VxLAN interfaces
 	 * are checked to see if (remote) neighbor entries need to be installed
@@ -974,7 +976,7 @@ void if_down(struct interface *ifp)
 {
 	struct zebra_if *zif;
 	struct interface *link_if;
-	struct zebra_vrf *zvrf = vrf_info_lookup(ifp->vrf_id);
+	struct zebra_vrf *zvrf = zvrf_info_lookup(ifp->vrf);
 
 	zif = ifp->info;
 	zif->down_count++;
@@ -1006,8 +1008,8 @@ void if_down(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 		zlog_debug("%u: IF %s down, scheduling RIB processing",
-			   ifp->vrf_id, ifp->name);
-	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
+			   vrf_to_id(ifp->vrf), ifp->name);
+	rib_update(vrf_to_id(ifp->vrf), RIB_UPDATE_IF_CHANGE);
 
 	if_nbr_ipv6ll_to_ipv4ll_neigh_del_all(ifp);
 
@@ -1308,7 +1310,7 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 
 	zebra_ptm_show_status(vty, ifp);
 
-	vrf = vrf_lookup_by_id(ifp->vrf_id);
+	vrf = ifp->vrf;
 	vty_out(vty, "  vrf: %s\n", vrf->name);
 
 	if (ifp->desc)
@@ -3134,9 +3136,9 @@ static int if_config_write(struct vty *vty)
 			struct vrf *vrf;
 
 			if_data = ifp->info;
-			vrf = vrf_lookup_by_id(ifp->vrf_id);
+			vrf = ifp->vrf;
 
-			if (ifp->vrf_id == VRF_DEFAULT)
+			if (vrf->vrf_id == VRF_DEFAULT)
 				vty_frame(vty, "interface %s\n", ifp->name);
 			else
 				vty_frame(vty, "interface %s vrf %s\n",

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -142,7 +142,8 @@ void if_get_metric(struct interface *ifp)
 
 	ifreq_set_name(&ifreq, ifp);
 
-	if (vrf_if_ioctl(SIOCGIFMETRIC, (caddr_t)&ifreq, ifp->vrf_id) < 0)
+	if (vrf_if_ioctl(SIOCGIFMETRIC, (caddr_t)&ifreq,
+			 vrf_to_id(ifp->vrf)) < 0)
 		return;
 	ifp->metric = ifreq.ifr_metric;
 	if (ifp->metric == 0)
@@ -160,7 +161,8 @@ void if_get_mtu(struct interface *ifp)
 	ifreq_set_name(&ifreq, ifp);
 
 #if defined(SIOCGIFMTU)
-	if (vrf_if_ioctl(SIOCGIFMTU, (caddr_t)&ifreq, ifp->vrf_id) < 0) {
+	if (vrf_if_ioctl(SIOCGIFMTU, (caddr_t)&ifreq,
+			 vrf_to_id(ifp->vrf)) < 0) {
 		zlog_info("Can't lookup mtu by ioctl(SIOCGIFMTU)");
 		ifp->mtu6 = ifp->mtu = -1;
 		return;
@@ -427,7 +429,7 @@ void if_get_flags(struct interface *ifp)
 
 	ifreq_set_name(&ifreq, ifp);
 
-	ret = vrf_if_ioctl(SIOCGIFFLAGS, (caddr_t)&ifreq, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCGIFFLAGS, (caddr_t)&ifreq, vrf_to_id(ifp->vrf));
 	if (ret < 0) {
 		flog_err_sys(EC_LIB_SYSTEM_CALL,
 			     "vrf_if_ioctl(SIOCGIFFLAGS) failed: %s",
@@ -477,7 +479,7 @@ int if_set_flags(struct interface *ifp, uint64_t flags)
 	ifreq.ifr_flags = ifp->flags;
 	ifreq.ifr_flags |= flags;
 
-	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, vrf_to_id(ifp->vrf));
 
 	if (ret < 0) {
 		zlog_info("can't set interface flags");
@@ -498,7 +500,7 @@ int if_unset_flags(struct interface *ifp, uint64_t flags)
 	ifreq.ifr_flags = ifp->flags;
 	ifreq.ifr_flags &= ~flags;
 
-	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, ifp->vrf_id);
+	ret = vrf_if_ioctl(SIOCSIFFLAGS, (caddr_t)&ifreq, vrf_to_id(ifp->vrf));
 
 	if (ret < 0) {
 		zlog_info("can't unset interface flags");

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -435,6 +435,7 @@ static void rtm_flag_dump(int flag)
 static int ifan_read(struct if_announcemsghdr *ifan)
 {
 	struct interface *ifp;
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	ifp = if_lookup_by_index(ifan->ifan_index, VRF_DEFAULT);
 
@@ -450,7 +451,7 @@ static int ifan_read(struct if_announcemsghdr *ifan)
 				__func__, ifan->ifan_index, ifan->ifan_name);
 
 		/* Create Interface */
-		ifp = if_get_by_name(ifan->ifan_name, VRF_DEFAULT);
+		ifp = if_get_by_name(ifan->ifan_name, vrf);
 		if_set_index(ifp, ifan->ifan_index);
 
 		if_get_metric(ifp);

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -616,7 +616,7 @@ int ifm_read(struct if_msghdr *ifm)
 	 * be filled in.
 	 */
 	if ((ifp == NULL) && ifnlen)
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifname, vrf);
 
 	/*
 	 * If ifp still does not exist or has an invalid index

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -530,6 +530,7 @@ int ifm_read(struct if_msghdr *ifm)
 	int maskbit;
 	caddr_t cp;
 	char fbuf[64];
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	/* terminate ifname at head (for strnlen) and tail (for safety) */
 	ifname[IFNAMSIZ - 1] = '\0';
@@ -644,7 +645,7 @@ int ifm_read(struct if_msghdr *ifm)
 		if (ifp == NULL) {
 			/* Interface that zebra was not previously aware of, so
 			 * create. */
-			ifp = if_create(ifname, VRF_DEFAULT);
+			ifp = if_create(ifname, vrf);
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug("%s: creating ifp for ifindex %d",
 					   __func__, ifm->ifm_index);

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -402,7 +402,7 @@ void zebra_interface_up_update(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_UP %s(%u)",
-			   ifp->name, ifp->vrf_id);
+			   ifp->name, vrf_to_id(ifp->vrf));
 
 	if (ifp->ptm_status || !ifp->ptm_enable) {
 		for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode,
@@ -422,7 +422,7 @@ void zebra_interface_down_update(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_DOWN %s(%u)",
-			   ifp->name, ifp->vrf_id);
+			   ifp->name, vrf_to_id(ifp->vrf));
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		zsend_interface_update(ZEBRA_INTERFACE_DOWN, client, ifp);
@@ -437,7 +437,7 @@ void zebra_interface_add_update(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADD %s(%u)", ifp->name,
-			   ifp->vrf_id);
+			   vrf_to_id(ifp->vrf));
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		client->ifadd_cnt++;
@@ -453,7 +453,7 @@ void zebra_interface_delete_update(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_DELETE %s(%u)",
-			   ifp->name, ifp->vrf_id);
+			   ifp->name, vrf_to_id(ifp->vrf));
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		client->ifdel_cnt++;
@@ -475,7 +475,7 @@ void zebra_interface_address_add_update(struct interface *ifp,
 		p = ifc->address;
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADDRESS_ADD %s on %s(%u)",
 			   prefix2str(p, buf, sizeof(buf)), ifp->name,
-			   ifp->vrf_id);
+			   vrf_to_id(ifp->vrf));
 	}
 
 	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_REAL))
@@ -509,7 +509,7 @@ void zebra_interface_address_delete_update(struct interface *ifp,
 		p = ifc->address;
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADDRESS_DELETE %s on %s(%u)",
 			   prefix2str(p, buf, sizeof(buf)),
-			   ifp->name, ifp->vrf_id);
+			   ifp->name, vrf_to_id(ifp->vrf));
 	}
 
 	zebra_vxlan_add_del_gw_macip(ifp, ifc->address, 0);
@@ -535,7 +535,7 @@ void zebra_interface_vrf_update_del(struct interface *ifp, vrf_id_t new_vrf_id)
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug(
 			"MESSAGE: ZEBRA_INTERFACE_VRF_UPDATE/DEL %s VRF Id %u -> %u",
-			ifp->name, ifp->vrf_id, new_vrf_id);
+			ifp->name, vrf_to_id(ifp->vrf), new_vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Need to delete if the client is not interested in the new
@@ -558,7 +558,7 @@ void zebra_interface_vrf_update_add(struct interface *ifp, vrf_id_t old_vrf_id)
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug(
 			"MESSAGE: ZEBRA_INTERFACE_VRF_UPDATE/ADD %s VRF Id %u -> %u",
-			ifp->name, old_vrf_id, ifp->vrf_id);
+			ifp->name, old_vrf_id, vrf_to_id(ifp->vrf));
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Need to add if the client is interested in the new VRF. */
@@ -816,7 +816,7 @@ void zebra_interface_parameters_update(struct interface *ifp)
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug("MESSAGE: ZEBRA_INTERFACE_LINK_PARAMS %s(%u)",
-			   ifp->name, ifp->vrf_id);
+			   ifp->name, vrf_to_id(ifp->vrf));
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client))
 		zsend_interface_link_params(client, ifp);

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -122,7 +122,7 @@ void router_id_add_address(struct connected *ifc)
 	struct prefix before;
 	struct prefix after;
 	struct zserv *client;
-	struct zebra_vrf *zvrf = vrf_info_get(ifc->ifp->vrf_id);
+	struct zebra_vrf *zvrf = vrf_info_get(vrf_to_id(ifc->ifp->vrf));
 
 	if (router_id_bad_address(ifc))
 		return;
@@ -154,7 +154,7 @@ void router_id_del_address(struct connected *ifc)
 	struct prefix before;
 	struct listnode *node;
 	struct zserv *client;
-	struct zebra_vrf *zvrf = vrf_info_get(ifc->ifp->vrf_id);
+	struct zebra_vrf *zvrf = vrf_info_get(vrf_to_id(ifc->ifp->vrf));
 
 	if (router_id_bad_address(ifc))
 		return;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -545,7 +545,7 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 						zebra_ns_lookup(ns_id),
 						index);
 				if (ifp)
-					nh_vrf_id = ifp->vrf_id;
+					nh_vrf_id = vrf_to_id(ifp->vrf);
 			}
 			nh.vrf_id = nh_vrf_id;
 
@@ -605,7 +605,7 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 							zebra_ns_lookup(ns_id),
 							index);
 					if (ifp)
-						nh_vrf_id = ifp->vrf_id;
+						nh_vrf_id = vrf_to_id(ifp->vrf);
 					else {
 						flog_warn(
 							EC_ZEBRA_UNKNOWN_INTERFACE,
@@ -1889,7 +1889,7 @@ static int netlink_vxlan_flood_list_update(struct interface *ifp,
 		char buf[256];
 	} req;
 	uint8_t dst_mac[6] = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	struct zebra_vrf *zvrf = zvrf_info_lookup(ifp->vrf);
 
 	zns = zvrf->zns;
 	memset(&req, 0, sizeof(req));
@@ -2287,7 +2287,7 @@ static int netlink_macfdb_update(struct interface *ifp, vlanid_t vid,
 	int vid_present = 0;
 	char vid_buf[20];
 	char dst_buf[30];
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	struct zebra_vrf *zvrf = zvrf_info_lookup(ifp->vrf);
 
 	zns = zvrf->zns;
 	zif = ifp->info;
@@ -2631,7 +2631,7 @@ int netlink_neigh_read_specific_ip(struct ipaddr *ip,
 {
 	int ret = 0;
 	struct zebra_ns *zns;
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(vlan_if->vrf_id);
+	struct zebra_vrf *zvrf = zvrf_info_lookup(vlan_if->vrf);
 	char buf[INET6_ADDRSTRLEN];
 	struct zebra_dplane_info dp_info;
 
@@ -2644,7 +2644,7 @@ int netlink_neigh_read_specific_ip(struct ipaddr *ip,
 			   __PRETTY_FUNCTION__, vlan_if->name,
 			   vlan_if->ifindex,
 			   ipaddr2str(ip, buf, sizeof(buf)),
-			   vlan_if->vrf_id);
+			   vrf_to_id(vlan_if->vrf));
 
 	ret = netlink_request_specific_neigh_in_vlan(zns, RTM_GETNEIGH, ip,
 					    vlan_if->ifindex);
@@ -2709,7 +2709,7 @@ static int netlink_neigh_update2(struct interface *ifp, struct ipaddr *ip,
 	struct zebra_ns *zns;
 	char buf[INET6_ADDRSTRLEN];
 	char buf2[ETHER_ADDR_STRLEN];
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	struct zebra_vrf *zvrf =  zvrf_info_lookup(ifp->vrf);
 
 	zns = zvrf->zns;
 	memset(&req, 0, sizeof(req));

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -532,7 +532,7 @@ static int rtadv_timer(struct thread *thread)
 
 static void rtadv_process_solicit(struct interface *ifp)
 {
-	struct zebra_vrf *zvrf = vrf_info_lookup(ifp->vrf_id);
+	struct zebra_vrf *zvrf = zvrf_info_lookup(ifp->vrf);
 
 	assert(zvrf);
 	rtadv_send_packet(rtadv_get_socket(zvrf), ifp);
@@ -882,7 +882,7 @@ static void ipv6_nd_suppress_ra_set(struct interface *ifp,
 	struct zebra_vrf *zvrf;
 
 	zif = ifp->info;
-	zvrf = vrf_info_lookup(ifp->vrf_id);
+	zvrf = zvrf_info_lookup(ifp->vrf);
 
 	if (status == RA_SUPPRESS) {
 		/* RA is currently enabled */
@@ -955,11 +955,11 @@ static void zebra_interface_radv_set(ZAPI_HANDLER_ARGS, int enable)
 			  zebra_route_string(client->proto));
 		return;
 	}
-	if (ifp->vrf_id != zvrf_id(zvrf)) {
+	if (ifp->vrf != zvrf->vrf) {
 		zlog_debug(
 			"%u: IF %u RA %s client %s - VRF mismatch, IF VRF %u",
 			zvrf_id(zvrf), ifindex, enable ? "enable" : "disable",
-			zebra_route_string(client->proto), ifp->vrf_id);
+			zebra_route_string(client->proto), vrf_to_id(ifp->vrf));
 		return;
 	}
 
@@ -1056,7 +1056,7 @@ DEFUN (ipv6_nd_ra_interval_msec,
 	struct zebra_if *zif = ifp->info;
 	struct zebra_vrf *zvrf;
 
-	zvrf = vrf_info_lookup(ifp->vrf_id);
+	zvrf = zvrf_info_lookup(ifp->vrf);
 
 	interval = strtoul(argv[idx_number]->arg, NULL, 10);
 	if ((zif->rtadv.AdvDefaultLifetime != -1
@@ -1094,7 +1094,7 @@ DEFUN (ipv6_nd_ra_interval,
 	struct zebra_if *zif = ifp->info;
 	struct zebra_vrf *zvrf;
 
-	zvrf = vrf_info_lookup(ifp->vrf_id);
+	zvrf = zvrf_info_lookup(ifp->vrf);
 
 	interval = strtoul(argv[idx_number]->arg, NULL, 10);
 	if ((zif->rtadv.AdvDefaultLifetime != -1
@@ -1133,7 +1133,7 @@ DEFUN (no_ipv6_nd_ra_interval,
 	struct zebra_if *zif = ifp->info;
 	struct zebra_vrf *zvrf = NULL;
 
-	zvrf = vrf_info_lookup(ifp->vrf_id);
+	zvrf = zvrf_info_lookup(ifp->vrf);
 
 	if (zif->rtadv.MaxRtrAdvInterval % 1000)
 		zvrf->rtadv.adv_msec_if_count--;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -165,7 +165,7 @@ int zsend_interface_add(struct zserv *client, struct interface *ifp)
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, ZEBRA_INTERFACE_ADD, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_ADD, vrf_to_id(ifp->vrf));
 	zserv_encode_interface(s, ifp);
 
 	client->ifadd_cnt++;
@@ -177,7 +177,7 @@ int zsend_interface_delete(struct zserv *client, struct interface *ifp)
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, ZEBRA_INTERFACE_DELETE, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_DELETE, vrf_to_id(ifp->vrf));
 	zserv_encode_interface(s, ifp);
 
 	client->ifdel_cnt++;
@@ -217,7 +217,8 @@ int zsend_interface_link_params(struct zserv *client, struct interface *ifp)
 		return 0;
 	}
 
-	zclient_create_header(s, ZEBRA_INTERFACE_LINK_PARAMS, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_LINK_PARAMS,
+			      vrf_to_id(ifp->vrf));
 
 	/* Add Interface Index */
 	stream_putl(s, ifp->ifindex);
@@ -279,7 +280,7 @@ int zsend_interface_address(int cmd, struct zserv *client,
 	struct prefix *p;
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, cmd, ifp->vrf_id);
+	zclient_create_header(s, cmd, vrf_to_id(ifp->vrf));
 	stream_putl(s, ifp->ifindex);
 
 	/* Interface address flag. */
@@ -321,7 +322,7 @@ static int zsend_interface_nbr_address(int cmd, struct zserv *client,
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 	struct prefix *p;
 
-	zclient_create_header(s, cmd, ifp->vrf_id);
+	zclient_create_header(s, cmd, vrf_to_id(ifp->vrf));
 	stream_putl(s, ifp->ifindex);
 
 	/* Prefix information. */
@@ -429,7 +430,8 @@ int zsend_interface_vrf_update(struct zserv *client, struct interface *ifp,
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, ZEBRA_INTERFACE_VRF_UPDATE, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_VRF_UPDATE,
+			      vrf_to_id(ifp->vrf));
 
 	/* Fill in the name of the interface and its new VRF (id) */
 	stream_put(s, ifp->name, INTERFACE_NAMSIZ);
@@ -504,7 +506,7 @@ int zsend_interface_update(int cmd, struct zserv *client, struct interface *ifp)
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, cmd, ifp->vrf_id);
+	zclient_create_header(s, cmd, vrf_to_id(ifp->vrf));
 	zserv_encode_interface(s, ifp);
 
 	if (cmd == ZEBRA_INTERFACE_UP)

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2207,9 +2207,9 @@ static void zread_vrf_label(ZAPI_HANDLER_ARGS)
 	STREAM_GETC(s, ltype);
 
 	if (zvrf->vrf->vrf_id != VRF_DEFAULT)
-		ifp = if_lookup_by_name(zvrf->vrf->name, zvrf->vrf->vrf_id);
+		ifp = if_lookup_by_name(zvrf->vrf->name, zvrf->vrf);
 	else
-		ifp = if_lookup_by_name("lo", VRF_DEFAULT);
+		ifp = if_lookup_by_name("lo", vrf_lookup_by_id(VRF_DEFAULT));
 
 	if (!ifp) {
 		zlog_debug("Unable to find specified Interface for %s",

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -1916,7 +1916,7 @@ enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
 		struct prefix_ipv4 *p;
 
 		p = (struct prefix_ipv4 *)ifc->address;
-		rib_lookup_and_pushup(p, ifp->vrf_id);
+		rib_lookup_and_pushup(p, ifp->vrf->vrf_id);
 	}
 #endif
 
@@ -1947,7 +1947,7 @@ static enum zebra_dplane_result intf_addr_update_internal(
 		prefix2str(ifc->address, addr_str, sizeof(addr_str));
 
 		zlog_debug("init intf ctx %s: idx %d, addr %u:%s",
-			   dplane_op2str(op), ifp->ifindex, ifp->vrf_id,
+			   dplane_op2str(op), ifp->ifindex, ifp->vrf->vrf_id,
 			   addr_str);
 	}
 
@@ -1955,9 +1955,9 @@ static enum zebra_dplane_result intf_addr_update_internal(
 
 	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
-	ctx->zd_vrf_id = ifp->vrf_id;
+	ctx->zd_vrf_id = ifp->vrf->vrf_id;
 
-	zns = zebra_ns_lookup(ifp->vrf_id);
+	zns = zebra_ns_lookup(ifp->vrf->vrf_id);
 	dplane_ctx_ns_init(ctx, zns, false);
 
 	/* Init the interface-addr-specific area */

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -522,7 +522,7 @@ static int zebra_ptm_handle_bfd_msg(void *arg, void *in_ctxt,
 	}
 
 	if (!strcmp(ZEBRA_PTM_INVALID_VRF, vrf_str) && ifp) {
-		vrf_id = ifp->vrf_id;
+		vrf_id = vrf_to_id(ifp->vrf);
 	} else {
 		vrf_id = vrf_name_to_id(vrf_str);
 	}

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -193,6 +193,15 @@ static inline vrf_id_t zvrf_id(struct zebra_vrf *zvrf)
 	return zvrf->vrf->vrf_id;
 }
 
+static inline struct zebra_vrf *zvrf_info_lookup(struct vrf *vrf)
+{
+	struct zebra_vrf *zvrf = NULL;
+
+	if (vrf)
+		zvrf = (struct zebra_vrf *)vrf->info;
+	return zvrf;
+}
+
 static inline const char *zvrf_ns_name(struct zebra_vrf *zvrf)
 {
 	if (!zvrf->vrf || !zvrf->vrf->ns_ctxt)

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -970,10 +970,9 @@ DEFPY (show_route_table_vrf,
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
 	struct zebra_vrf *zvrf;
 	struct route_table *t;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	vrf_id_t vrf_id;
 
-	if (vrf_name)
-		VRF_GET_ID(vrf_id, vrf_name, !!json);
+	VRF_GET_ID(vrf_id, vrf_name, !!json);
 	zvrf = zebra_vrf_lookup_by_id(vrf_id);
 
 	t = zebra_router_find_table(zvrf, table, afi, SAFI_UNICAST);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2353,7 +2353,7 @@ static void zvni_process_neigh_on_local_mac_change(zebra_vni_t *zvni,
 	struct zebra_vrf *zvrf = NULL;
 	char buf[ETHER_ADDR_STRLEN];
 
-	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
+	zvrf = zvrf_info_lookup(zvni->vxlan_if->vrf);
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug("Processing neighbors on local MAC %s %s, VNI %u",
@@ -2612,7 +2612,7 @@ struct interface *zebra_get_vrr_intf_for_svi(struct interface *ifp)
 	struct interface *tmp_if = NULL;
 	struct zebra_if *zif = NULL;
 
-	zvrf = vrf_info_lookup(ifp->vrf_id);
+	zvrf = zvrf_info_lookup(ifp->vrf);
 	assert(zvrf);
 
 	FOR_ALL_INTERFACES (zvrf->vrf, tmp_if) {
@@ -2716,10 +2716,10 @@ static int zvni_advertise_subnet(zebra_vni_t *zvni, struct interface *ifp,
 
 		apply_mask(&p);
 		if (advertise)
-			ip_prefix_send_to_client(ifp->vrf_id, &p,
+			ip_prefix_send_to_client(vrf_to_id(ifp->vrf), &p,
 						 ZEBRA_IP_PREFIX_ROUTE_ADD);
 		else
-			ip_prefix_send_to_client(ifp->vrf_id, &p,
+			ip_prefix_send_to_client(vrf_to_id(ifp->vrf), &p,
 						 ZEBRA_IP_PREFIX_ROUTE_DEL);
 	}
 	return 0;
@@ -2838,7 +2838,7 @@ static int zvni_gw_macip_del(struct interface *ifp, zebra_vni_t *zvni,
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug(
 			"%u:SVI %s(%u) VNI %u, sending GW MAC %s IP %s del to BGP",
-			ifp->vrf_id, ifp->name, ifp->ifindex, zvni->vni,
+			vrf_to_id(ifp->vrf), ifp->name, ifp->ifindex, zvni->vni,
 			prefix_mac2str(&(n->emac), buf1, sizeof(buf1)),
 			ipaddr2str(ip, buf2, sizeof(buf2)));
 
@@ -3025,11 +3025,11 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 		}
 	}
 
-	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
+	zvrf = zvrf_info_lookup(zvni->vxlan_if->vrf);
 	if (!zvrf) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("\tUnable to find vrf for: %d",
-				   zvni->vxlan_if->vrf_id);
+			zlog_debug("\tUnable to find vrf for: %s",
+				   zvni->vxlan_if->vrf->name);
 		return -1;
 	}
 
@@ -4086,8 +4086,9 @@ static void zvni_build_hash_table(void)
 			vlan_if = zvni_map_to_svi(vxl->access_vlan,
 						  zif->brslave_info.br_if);
 			if (vlan_if) {
-				zvni->vrf_id = vlan_if->vrf_id;
-				zl3vni = zl3vni_from_vrf(vlan_if->vrf_id);
+				zvni->vrf_id = vrf_to_id(vlan_if->vrf);
+				zl3vni = zl3vni_from_vrf(
+						vrf_to_id(vlan_if->vrf));
 				if (zl3vni)
 					listnode_add_sort(zl3vni->l2vnis, zvni);
 			}
@@ -5240,7 +5241,7 @@ static void process_remote_macip_add(vni_t vni,
 		return;
 	}
 
-	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
+	zvrf = zvrf_info_lookup(zvni->vxlan_if->vrf);
 	if (!zvrf)
 		return;
 
@@ -5568,7 +5569,7 @@ static void process_remote_macip_del(vni_t vni,
 	if (!mac && !n)
 		return;
 
-	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
+	zvrf = zvrf_info_lookup(zvni->vxlan_if->vrf);
 
 	/* Ignore the delete if this mac is a gateway mac-ip */
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)
@@ -7255,7 +7256,7 @@ int zebra_vxlan_handle_kernel_neigh_del(struct interface *ifp,
 		return 0;
 	}
 
-	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
+	zvrf = zvrf_info_lookup(zvni->vxlan_if->vrf);
 	if (!zvrf) {
 		zlog_debug("%s: VNI %u vrf lookup failed.",
 				   __PRETTY_FUNCTION__, zvni->vni);
@@ -7678,11 +7679,11 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 		return -1;
 	}
 
-	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
+	zvrf = zvrf_info_lookup(zvni->vxlan_if->vrf);
 	if (!zvrf) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("\tNo Vrf found for vrf_id: %d",
-				   zvni->vxlan_if->vrf_id);
+			zlog_debug("\tNo Vrf found for vrf_id: %s",
+				   zvni->vxlan_if->vrf->name);
 		return -1;
 	}
 
@@ -8214,10 +8215,10 @@ int zebra_vxlan_svi_up(struct interface *ifp, struct interface *link_if)
 			zlog_debug(
 				"SVI %s(%u) VNI %u VRF %s is UP, installing neighbors",
 				ifp->name, ifp->ifindex, zvni->vni,
-				vrf_id_to_name(ifp->vrf_id));
+				vrf_to_name(ifp->vrf));
 
 		/* update the vrf information for l2-vni and inform bgp */
-		zvni->vrf_id = ifp->vrf_id;
+		zvni->vrf_id = vrf_to_id(ifp->vrf);
 		zvni_send_add_to_client(zvni);
 
 		/* Install any remote neighbors for this VNI. */
@@ -8343,8 +8344,8 @@ int zebra_vxlan_if_up(struct interface *ifp)
 		vlan_if = zvni_map_to_svi(vxl->access_vlan,
 					  zif->brslave_info.br_if);
 		if (vlan_if) {
-			zvni->vrf_id = vlan_if->vrf_id;
-			zl3vni = zl3vni_from_vrf(vlan_if->vrf_id);
+			zvni->vrf_id = vrf_to_id(vlan_if->vrf);
+			zl3vni = zl3vni_from_vrf(vrf_to_id(vlan_if->vrf));
 			if (zl3vni)
 				listnode_add_sort(zl3vni->l2vnis, zvni);
 		}
@@ -8672,8 +8673,8 @@ int zebra_vxlan_if_add(struct interface *ifp)
 		vlan_if = zvni_map_to_svi(vxl->access_vlan,
 					  zif->brslave_info.br_if);
 		if (vlan_if) {
-			zvni->vrf_id = vlan_if->vrf_id;
-			zl3vni = zl3vni_from_vrf(vlan_if->vrf_id);
+			zvni->vrf_id = vrf_to_id(vlan_if->vrf);
+			zl3vni = zl3vni_from_vrf(vrf_to_id(vlan_if->vrf));
 			if (zl3vni)
 				listnode_add_sort(zl3vni->l2vnis, zvni);
 		}
@@ -8690,7 +8691,7 @@ int zebra_vxlan_if_add(struct interface *ifp)
 			zlog_debug(
 				"Add L2-VNI %u VRF %s intf %s(%u) VLAN %u local IP %s mcast_grp %s master %u",
 				vni,
-				vlan_if ? vrf_id_to_name(vlan_if->vrf_id)
+				vlan_if ? vrf_to_name(vlan_if->vrf)
 					: VRF_DEFAULT_NAME,
 				ifp->name, ifp->ifindex, vxl->access_vlan,
 				addr_buf1, addr_buf2,


### PR DESCRIPTION
this pr replaces:
https://github.com/FRRouting/frr/pull/3747

the interface structure replaces old vrf_id attribute with vrf pointer.

this is done in order to be able to solve https://github.com/FRRouting/frr/issues/3741
