### PR TITLE
pbrd: add support for interface nexthops

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -192,7 +192,7 @@ static int nhgl_cmp(struct nexthop_hold *nh1, struct nexthop_hold *nh2)
 {
 	int ret;
 
-	ret = sockunion_cmp(&nh1->addr, &nh2->addr);
+	ret = sockunion_cmp(nh1->addr, nh2->addr);
 	if (ret)
 		return ret;
 
@@ -210,6 +210,8 @@ static void nhgl_delete(struct nexthop_hold *nh)
 
 	if (nh->nhvrf_name)
 		XFREE(MTYPE_TMP, nh->nhvrf_name);
+
+	sockunion_free(nh->addr);
 
 	XFREE(MTYPE_TMP, nh);
 }
@@ -295,7 +297,7 @@ static void nexthop_group_save_nhop(struct nexthop_group_cmd *nhgc,
 	if (intf)
 		nh->intf = XSTRDUP(MTYPE_TMP, intf);
 
-	nh->addr = *addr;
+	nh->addr = sockunion_dup(addr);
 
 	listnode_add_sort(nhgc->nhg_list, nh);
 }
@@ -310,7 +312,7 @@ static void nexthop_group_unsave_nhop(struct nexthop_group_cmd *nhgc,
 
 	for (ALL_LIST_ELEMENTS_RO(nhgc->nhg_list, node, nh)) {
 		if (nhgc_cmp_helper(nhvrf_name, nh->nhvrf_name) == 0 &&
-		    sockunion_cmp(addr, &nh->addr) == 0 &&
+		    sockunion_cmp(addr, nh->addr) == 0 &&
 		    nhgc_cmp_helper(intf, nh->intf) == 0)
 			break;
 	}
@@ -478,7 +480,7 @@ static void nexthop_group_write_nexthop_internal(struct vty *vty,
 
 	vty_out(vty, "nexthop ");
 
-	vty_out(vty, "%s", sockunion2str(&nh->addr, buf, sizeof(buf)));
+	vty_out(vty, "%s", sockunion2str(nh->addr, buf, sizeof(buf)));
 
 	if (nh->intf)
 		vty_out(vty, " %s", nh->intf);
@@ -522,7 +524,7 @@ void nexthop_group_enable_vrf(struct vrf *vrf)
 			struct nexthop nhop;
 			struct nexthop *nh;
 
-			if (!nexthop_group_parse_nexthop(&nhop, &nhh->addr,
+			if (!nexthop_group_parse_nexthop(&nhop, nhh->addr,
 							 nhh->intf,
 							 nhh->nhvrf_name))
 				continue;
@@ -558,7 +560,7 @@ void nexthop_group_disable_vrf(struct vrf *vrf)
 			struct nexthop nhop;
 			struct nexthop *nh;
 
-			if (!nexthop_group_parse_nexthop(&nhop, &nhh->addr,
+			if (!nexthop_group_parse_nexthop(&nhop, nhh->addr,
 							 nhh->intf,
 							 nhh->nhvrf_name))
 				continue;
@@ -596,7 +598,7 @@ void nexthop_group_interface_state_change(struct interface *ifp,
 				struct nexthop nhop;
 
 				if (!nexthop_group_parse_nexthop(
-					    &nhop, &nhh->addr, nhh->intf,
+					    &nhop, nhh->addr, nhh->intf,
 					    nhh->nhvrf_name))
 					continue;
 

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -520,7 +520,7 @@ static int nexthop_group_write(struct vty *vty)
 		vty_out(vty, "nexthop-group %s\n", nhgc->name);
 
 		for (ALL_LIST_ELEMENTS_RO(nhgc->nhg_list, node, nh)) {
-			vty_out(vty, "  ");
+			vty_out(vty, " ");
 			nexthop_group_write_nexthop_internal(vty, nh);
 		}
 

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -188,11 +188,25 @@ static int nhgc_cmp_helper(const char *a, const char *b)
 	return strcmp(a, b);
 }
 
+static int nhgc_addr_cmp_helper(const union sockunion *a, const union sockunion *b)
+{
+	if (!a && !b)
+		return 0;
+
+	if (a && !b)
+		return -1;
+
+	if (!a && b)
+		return 1;
+
+	return sockunion_cmp(a, b);
+}
+
 static int nhgl_cmp(struct nexthop_hold *nh1, struct nexthop_hold *nh2)
 {
 	int ret;
 
-	ret = sockunion_cmp(nh1->addr, nh2->addr);
+	ret = nhgc_addr_cmp_helper(nh1->addr, nh2->addr);
 	if (ret)
 		return ret;
 
@@ -211,7 +225,8 @@ static void nhgl_delete(struct nexthop_hold *nh)
 	if (nh->nhvrf_name)
 		XFREE(MTYPE_TMP, nh->nhvrf_name);
 
-	sockunion_free(nh->addr);
+	if (nh->addr)
+		sockunion_free(nh->addr);
 
 	XFREE(MTYPE_TMP, nh);
 }
@@ -296,8 +311,8 @@ static void nexthop_group_save_nhop(struct nexthop_group_cmd *nhgc,
 		nh->nhvrf_name = XSTRDUP(MTYPE_TMP, nhvrf_name);
 	if (intf)
 		nh->intf = XSTRDUP(MTYPE_TMP, intf);
-
-	nh->addr = sockunion_dup(addr);
+	if (addr)
+		nh->addr = sockunion_dup(addr);
 
 	listnode_add_sort(nhgc->nhg_list, nh);
 }
@@ -312,7 +327,7 @@ static void nexthop_group_unsave_nhop(struct nexthop_group_cmd *nhgc,
 
 	for (ALL_LIST_ELEMENTS_RO(nhgc->nhg_list, node, nh)) {
 		if (nhgc_cmp_helper(nhvrf_name, nh->nhvrf_name) == 0 &&
-		    sockunion_cmp(addr, nh->addr) == 0 &&
+		    nhgc_addr_cmp_helper(addr, nh->addr) == 0 &&
 		    nhgc_cmp_helper(intf, nh->intf) == 0)
 			break;
 	}
@@ -345,35 +360,44 @@ static bool nexthop_group_parse_nexthop(struct nexthop *nhop,
 
 	nhop->vrf_id = vrf->vrf_id;
 
-	if (addr->sa.sa_family == AF_INET) {
-		nhop->gate.ipv4.s_addr = addr->sin.sin_addr.s_addr;
-		if (intf) {
-			nhop->type = NEXTHOP_TYPE_IPV4_IFINDEX;
-			nhop->ifindex = ifname2ifindex(intf, vrf->vrf_id);
-			if (nhop->ifindex == IFINDEX_INTERNAL)
-				return false;
-		} else
-			nhop->type = NEXTHOP_TYPE_IPV4;
-	} else {
-		memcpy(&nhop->gate.ipv6, &addr->sin6.sin6_addr, 16);
-		if (intf) {
-			nhop->type = NEXTHOP_TYPE_IPV6_IFINDEX;
-			nhop->ifindex = ifname2ifindex(intf, vrf->vrf_id);
-			if (nhop->ifindex == IFINDEX_INTERNAL)
-				return false;
-		} else
-			nhop->type = NEXTHOP_TYPE_IPV6;
+	if (intf) {
+		nhop->ifindex = ifname2ifindex(intf, vrf->vrf_id);
+		if (nhop->ifindex == IFINDEX_INTERNAL)
+			return false;
 	}
+
+	if (addr) {
+		if (addr->sa.sa_family == AF_INET) {
+			nhop->gate.ipv4.s_addr = addr->sin.sin_addr.s_addr;
+			if (intf)
+				nhop->type = NEXTHOP_TYPE_IPV4_IFINDEX;
+			else
+				nhop->type = NEXTHOP_TYPE_IPV4;
+		} else {
+			nhop->gate.ipv6 = addr->sin6.sin6_addr;
+			if (intf)
+				nhop->type = NEXTHOP_TYPE_IPV6_IFINDEX;
+			else
+				nhop->type = NEXTHOP_TYPE_IPV6;
+		}
+	} else
+		nhop->type = NEXTHOP_TYPE_IFINDEX;
 
 	return true;
 }
 
 DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
-      "[no] nexthop <A.B.C.D|X:X::X:X>$addr [INTERFACE]$intf [nexthop-vrf NAME$name]",
+      "[no] nexthop\
+        <\
+	  <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
+	  |INTERFACE$intf\
+	>\
+	[nexthop-vrf NAME$name]",
       NO_STR
       "Specify one of the nexthops in this ECMP group\n"
       "v4 Address\n"
       "v6 Address\n"
+      "Interface to use\n"
       "Interface to use\n"
       "If the nexthop is in a different vrf tell us\n"
       "The nexthop-vrf Name\n")
@@ -382,13 +406,6 @@ DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
 	struct nexthop nhop;
 	struct nexthop *nh;
 	bool legal;
-
-	/*
-	 * This is impossible to happen as that the cli parser refuses
-	 * to let you get here without an addr, but the SA system
-	 * does not understand this intricacy
-	 */
-	assert(addr);
 
 	legal = nexthop_group_parse_nexthop(&nhop, addr, intf, name);
 
@@ -478,9 +495,10 @@ static void nexthop_group_write_nexthop_internal(struct vty *vty,
 {
 	char buf[100];
 
-	vty_out(vty, "nexthop ");
+	vty_out(vty, "nexthop");
 
-	vty_out(vty, "%s", sockunion2str(nh->addr, buf, sizeof(buf)));
+	if (nh->addr)
+		vty_out(vty, " %s", sockunion2str(nh->addr, buf, sizeof(buf)));
 
 	if (nh->intf)
 		vty_out(vty, " %s", nh->intf);

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -322,13 +322,7 @@ static void nexthop_group_unsave_nhop(struct nexthop_group_cmd *nhgc,
 		return;
 
 	list_delete_node(nhgc->nhg_list, node);
-
-	if (nh->nhvrf_name)
-		XFREE(MTYPE_TMP, nh->nhvrf_name);
-	if (nh->intf)
-		XFREE(MTYPE_TMP, nh->intf);
-
-	XFREE(MTYPE_TMP, nh);
+	nhgl_delete(nh);
 }
 
 static bool nexthop_group_parse_nexthop(struct nexthop *nhop,

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -68,7 +68,7 @@ void copy_nexthops(struct nexthop **tnh, struct nexthop *nh,
 
 struct nexthop_hold {
 	char *nhvrf_name;
-	union sockunion addr;
+	union sockunion *addr;
 	char *intf;
 };
 

--- a/pbrd/pbr_nht.h
+++ b/pbrd/pbr_nht.h
@@ -117,5 +117,10 @@ extern void pbr_nht_show_nexthop_group(struct vty *vty, const char *name);
  */
 extern void pbr_nht_nexthop_update(struct zapi_route *nhr);
 
+/*
+ * When we get a callback from zebra about an interface status update.
+ */
+extern void pbr_nht_nexthop_interface_update(struct interface *ifp);
+
 extern void pbr_nht_init(void);
 #endif

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -612,18 +612,18 @@ static int pbr_vty_map_config_write_sequence(struct vty *vty,
 	vty_out(vty, "pbr-map %s seq %u\n", pbrm->name, pbrms->seqno);
 
 	if (pbrms->src)
-		vty_out(vty, "  match src-ip %s\n",
+		vty_out(vty, " match src-ip %s\n",
 			prefix2str(pbrms->src, buff, sizeof(buff)));
 
 	if (pbrms->dst)
-		vty_out(vty, "  match dst-ip %s\n",
+		vty_out(vty, " match dst-ip %s\n",
 			prefix2str(pbrms->dst, buff, sizeof(buff)));
 
 	if (pbrms->nhgrp_name)
-		vty_out(vty, "  set nexthop-group %s\n", pbrms->nhgrp_name);
+		vty_out(vty, " set nexthop-group %s\n", pbrms->nhgrp_name);
 
 	if (pbrms->nhg) {
-		vty_out(vty, "  set ");
+		vty_out(vty, " set ");
 		nexthop_group_write_nexthop(vty, pbrms->nhg->nexthop);
 	}
 

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -221,12 +221,18 @@ DEFPY(pbr_map_nexthop_group, pbr_map_nexthop_group_cmd,
 }
 
 DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
-      "[no] set nexthop <A.B.C.D|X:X::X:X>$addr [INTERFACE]$intf [nexthop-vrf NAME$name]",
+      "[no] set nexthop\
+        <\
+	  <A.B.C.D|X:X::X:X>$addr [INTERFACE$intf]\
+	  |INTERFACE$intf\
+	>\
+        [nexthop-vrf NAME$name]",
       NO_STR
       "Set for the PBR-MAP\n"
       "Specify one of the nexthops in this map\n"
       "v4 Address\n"
       "v6 Address\n"
+      "Interface to use\n"
       "Interface to use\n"
       "If the nexthop is in a different vrf tell us\n"
       "The nexthop-vrf Name\n")
@@ -255,44 +261,38 @@ DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
 	memset(&nhop, 0, sizeof(nhop));
 	nhop.vrf_id = vrf->vrf_id;
 
-	/*
-	 * Make SA happy.  CLIPPY is not going to give us a NULL
-	 * addr.
-	 */
-	assert(addr);
-	if (addr->sa.sa_family == AF_INET) {
-		nhop.gate.ipv4.s_addr = addr->sin.sin_addr.s_addr;
-		if (intf) {
-			nhop.type = NEXTHOP_TYPE_IPV4_IFINDEX;
-			nhop.ifindex = ifname2ifindex(intf, vrf->vrf_id);
-			if (nhop.ifindex == IFINDEX_INTERNAL) {
-				vty_out(vty,
-					"Specified Intf %s does not exist in vrf: %s\n",
-					intf, vrf->name);
-				return CMD_WARNING_CONFIG_FAILED;
-			}
-		} else
-			nhop.type = NEXTHOP_TYPE_IPV4;
-	} else {
-		memcpy(&nhop.gate.ipv6, &addr->sin6.sin6_addr, 16);
-		if (intf) {
-			nhop.type = NEXTHOP_TYPE_IPV6_IFINDEX;
-			nhop.ifindex = ifname2ifindex(intf, vrf->vrf_id);
-			if (nhop.ifindex == IFINDEX_INTERNAL) {
-				vty_out(vty,
-					"Specified Intf %s does not exist in vrf: %s\n",
-					intf, vrf->name);
-				return CMD_WARNING_CONFIG_FAILED;
-			}
-		} else {
-			if (IN6_IS_ADDR_LINKLOCAL(&nhop.gate.ipv6)) {
-				vty_out(vty,
-					"Specified a v6 LL with no interface, rejecting\n");
-				return CMD_WARNING_CONFIG_FAILED;
-			}
-			nhop.type = NEXTHOP_TYPE_IPV6;
+	if (intf) {
+		nhop.ifindex = ifname2ifindex(intf, vrf->vrf_id);
+		if (nhop.ifindex == IFINDEX_INTERNAL) {
+			vty_out(vty,
+				"Specified Intf %s does not exist in vrf: %s\n",
+				intf, vrf->name);
+			return CMD_WARNING_CONFIG_FAILED;
 		}
 	}
+
+	if (addr) {
+		if (addr->sa.sa_family == AF_INET) {
+			nhop.gate.ipv4.s_addr = addr->sin.sin_addr.s_addr;
+			if (intf)
+				nhop.type = NEXTHOP_TYPE_IPV4_IFINDEX;
+			else
+				nhop.type = NEXTHOP_TYPE_IPV4;
+		} else {
+			nhop.gate.ipv6 = addr->sin6.sin6_addr;
+			if (intf)
+				nhop.type = NEXTHOP_TYPE_IPV6_IFINDEX;
+			else {
+				if (IN6_IS_ADDR_LINKLOCAL(&nhop.gate.ipv6)) {
+					vty_out(vty,
+						"Specified a v6 LL with no interface, rejecting\n");
+					return CMD_WARNING_CONFIG_FAILED;
+				}
+				nhop.type = NEXTHOP_TYPE_IPV6;
+			}
+		}
+	} else
+		nhop.type = NEXTHOP_TYPE_IFINDEX;
 
 	if (pbrms->nhg)
 		nh = nexthop_exists(pbrms->nhg, &nhop);
@@ -333,6 +333,14 @@ DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
 
 		pbr_nht_add_individual_nexthop(pbrms);
 		pbr_map_check(pbrms);
+	}
+
+	if (nhop.type == NEXTHOP_TYPE_IFINDEX) {
+		struct interface *ifp;
+
+		ifp = if_lookup_by_index(nhop.ifindex, nhop.vrf_id);
+		if (ifp)
+			pbr_nht_nexthop_interface_update(ifp);
 	}
 
 	return CMD_SUCCESS;

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -75,6 +75,8 @@ static int interface_add(int command, struct zclient *zclient,
 	if (!ifp->info)
 		pbr_if_new(ifp);
 
+	pbr_nht_nexthop_interface_update(ifp);
+
 	return 0;
 }
 
@@ -144,6 +146,8 @@ static int interface_state_up(int command, struct zclient *zclient,
 	DEBUGD(&pbr_dbg_zebra,
 	       "%s: %s is up", __PRETTY_FUNCTION__, ifp->name);
 
+	pbr_nht_nexthop_interface_update(ifp);
+
 	return 0;
 }
 
@@ -156,6 +160,8 @@ static int interface_state_down(int command, struct zclient *zclient,
 
 	DEBUGD(&pbr_dbg_zebra,
 	       "%s: %s is down", __PRETTY_FUNCTION__, ifp->name);
+
+	pbr_nht_nexthop_interface_update(ifp);
 
 	return 0;
 }


### PR DESCRIPTION
Small changes to support nexthops of type `NEXTHOP_TYPE_IFINDEX` in pbrd. This should be useful to route packets to different p2p tunnels (without IP addresses) depending on PBR policies.

@donaldsharp please review carefully as I might have missed something :)