### PR TITLE
topotests: Add code to ensure routes are as expected

### DIFF
--- a/tests/topotests/all-protocol-startup/r1/ipv4_routes.ref
+++ b/tests/topotests/all-protocol-startup/r1/ipv4_routes.ref
@@ -1,0 +1,12 @@
+C>* 192.168.0.0/24 is directly connected, r1-eth0, XX:XX:XX
+C>* 192.168.1.0/26 is directly connected, r1-eth1, XX:XX:XX
+C>* 192.168.2.0/26 is directly connected, r1-eth2, XX:XX:XX
+C>* 192.168.3.0/26 is directly connected, r1-eth3, XX:XX:XX
+C>* 192.168.4.0/26 is directly connected, r1-eth4, XX:XX:XX
+C>* 192.168.5.0/26 is directly connected, r1-eth5, XX:XX:XX
+C>* 192.168.6.0/26 is directly connected, r1-eth6, XX:XX:XX
+C>* 192.168.7.0/26 is directly connected, r1-eth7, XX:XX:XX
+C>* 192.168.8.0/26 is directly connected, r1-eth8, XX:XX:XX
+C>* 192.168.9.0/26 is directly connected, r1-eth9, XX:XX:XX
+O   192.168.0.0/24 [110/10] is directly connected, r1-eth0, XX:XX:XX
+O   192.168.3.0/26 [110/10] is directly connected, r1-eth3, XX:XX:XX

--- a/tests/topotests/all-protocol-startup/r1/ipv6_routes.ref
+++ b/tests/topotests/all-protocol-startup/r1/ipv6_routes.ref
@@ -1,0 +1,22 @@
+C>* fc00:0:0:1::/64 is directly connected, r1-eth1, XX:XX:XX
+C>* fc00:0:0:2::/64 is directly connected, r1-eth2, XX:XX:XX
+C>* fc00:0:0:3::/64 is directly connected, r1-eth3, XX:XX:XX
+C>* fc00:0:0:4::/64 is directly connected, r1-eth4, XX:XX:XX
+C>* fc00:0:0:5::/64 is directly connected, r1-eth5, XX:XX:XX
+C>* fc00:0:0:6::/64 is directly connected, r1-eth6, XX:XX:XX
+C>* fc00:0:0:7::/64 is directly connected, r1-eth7, XX:XX:XX
+C>* fc00:0:0:8::/64 is directly connected, r1-eth8, XX:XX:XX
+C>* fc00:0:0:9::/64 is directly connected, r1-eth9, XX:XX:XX
+C>* fc00::/64 is directly connected, r1-eth0, XX:XX:XX
+C>* fe80::/64 is directly connected, lo, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth0, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth1, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth2, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth3, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth4, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth5, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth6, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth7, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth8, XX:XX:XX
+C * fe80::/64 is directly connected, r1-eth9, XX:XX:XX
+O   fc00:0:0:4::/64 [110/10] is directly connected, r1-eth4, XX:XX:XX


### PR DESCRIPTION
This code just ensures that v4 and v6 routes are as expected
in the rib.  While this test addition is not that complicated it would
have caught some issues while I was attempting to handle the
switchover to a different style of rib processing.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

