### PR TITLE
tests: Remove some inconsistent local labels in check in test_ldp_vpls_topo1

### DIFF
--- a/tests/topotests/ldp-vpls-topo1/r1/show_ldp_binding.ref
+++ b/tests/topotests/ldp-vpls-topo1/r1/show_ldp_binding.ref
@@ -20,7 +20,6 @@
       "addressFamily":"ipv4",
       "prefix":"2.2.2.2/32",
       "neighborId":"2.2.2.2",
-      "localLabel":"17",
       "remoteLabel":"imp-null",
       "inUse":1
     },
@@ -28,7 +27,6 @@
       "addressFamily":"ipv4",
       "prefix":"2.2.2.2/32",
       "neighborId":"3.3.3.3",
-      "localLabel":"17",
       "remoteLabel":"17",
       "inUse":0
     },
@@ -36,7 +34,6 @@
       "addressFamily":"ipv4",
       "prefix":"3.3.3.3/32",
       "neighborId":"2.2.2.2",
-      "localLabel":"18",
       "remoteLabel":"18",
       "inUse":0
     },
@@ -44,7 +41,6 @@
       "addressFamily":"ipv4",
       "prefix":"3.3.3.3/32",
       "neighborId":"3.3.3.3",
-      "localLabel":"18",
       "remoteLabel":"imp-null",
       "inUse":1
     }

--- a/tests/topotests/ldp-vpls-topo1/r2/show_ldp_binding.ref
+++ b/tests/topotests/ldp-vpls-topo1/r2/show_ldp_binding.ref
@@ -4,7 +4,6 @@
       "addressFamily":"ipv4",
       "prefix":"1.1.1.1/32",
       "neighborId":"1.1.1.1",
-      "localLabel":"17",
       "remoteLabel":"imp-null",
       "inUse":1
     },
@@ -12,7 +11,6 @@
       "addressFamily":"ipv4",
       "prefix":"1.1.1.1/32",
       "neighborId":"3.3.3.3",
-      "localLabel":"17",
       "remoteLabel":"16",
       "inUse":0
     },
@@ -36,7 +34,6 @@
       "addressFamily":"ipv4",
       "prefix":"3.3.3.3/32",
       "neighborId":"1.1.1.1",
-      "localLabel":"18",
       "remoteLabel":"18",
       "inUse":0
     },
@@ -44,7 +41,6 @@
       "addressFamily":"ipv4",
       "prefix":"3.3.3.3/32",
       "neighborId":"3.3.3.3",
-      "localLabel":"18",
       "remoteLabel":"imp-null",
       "inUse":1
     }

--- a/tests/topotests/ldp-vpls-topo1/r3/show_ldp_binding.ref
+++ b/tests/topotests/ldp-vpls-topo1/r3/show_ldp_binding.ref
@@ -20,7 +20,6 @@
       "addressFamily":"ipv4",
       "prefix":"2.2.2.2/32",
       "neighborId":"1.1.1.1",
-      "localLabel":"17",
       "remoteLabel":"17",
       "inUse":0
     },
@@ -28,7 +27,6 @@
       "addressFamily":"ipv4",
       "prefix":"2.2.2.2/32",
       "neighborId":"2.2.2.2",
-      "localLabel":"17",
       "remoteLabel":"imp-null",
       "inUse":1
     },


### PR DESCRIPTION
### Summary
Fixes https://github.com/FRRouting/frr/issues/3718.
Remove inconsistent labels from check in test_ldp_vpls_topo1

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>