### PR TITLE
Backport Revert "redhat: don't Requires initscript on systemd based distros"

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -170,6 +170,7 @@ BuildRequires:  python27-sphinx
 BuildRequires:  python-devel >= 2.7
 BuildRequires:  python-sphinx
 %endif
+Requires:       initscripts
 %if %{with_pam}
 BuildRequires:  pam-devel
 %endif
@@ -187,7 +188,6 @@ Requires(post):     chkconfig
 Requires(preun):    chkconfig
 # Initscripts > 5.60 is required for IPv6 support
 Requires(pre):      initscripts >= 5.60
-Requires:           initscripts
 %endif
 Provides:           routingdaemon = %{version}-%{release}
 Obsoletes:          gated mrt zebra frr-sysvinit


### PR DESCRIPTION
Backport of #3719

Signed-off-by: Liam McBirnie <liam.mcbirnie@boeing.com>