### PR TITLE
zebra: async interface address programming

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -436,13 +436,13 @@ void if_set_index(struct interface *ifp, ifindex_t ifindex)
 }
 
 /* Does interface up ? */
-int if_is_up(struct interface *ifp)
+int if_is_up(const struct interface *ifp)
 {
 	return ifp->flags & IFF_UP;
 }
 
 /* Is interface running? */
-int if_is_running(struct interface *ifp)
+int if_is_running(const struct interface *ifp)
 {
 	return ifp->flags & IFF_RUNNING;
 }
@@ -450,7 +450,7 @@ int if_is_running(struct interface *ifp)
 /* Is the interface operative, eg. either UP & RUNNING
    or UP & !ZEBRA_INTERFACE_LINK_DETECTION and
    if ptm checking is enabled, then ptm check has passed */
-int if_is_operative(struct interface *ifp)
+int if_is_operative(const struct interface *ifp)
 {
 	return ((ifp->flags & IFF_UP)
 		&& (((ifp->flags & IFF_RUNNING)
@@ -461,7 +461,7 @@ int if_is_operative(struct interface *ifp)
 
 /* Is the interface operative, eg. either UP & RUNNING
    or UP & !ZEBRA_INTERFACE_LINK_DETECTION, without PTM check */
-int if_is_no_ptm_operative(struct interface *ifp)
+int if_is_no_ptm_operative(const struct interface *ifp)
 {
 	return ((ifp->flags & IFF_UP)
 		&& ((ifp->flags & IFF_RUNNING)
@@ -470,7 +470,7 @@ int if_is_no_ptm_operative(struct interface *ifp)
 }
 
 /* Is this loopback interface ? */
-int if_is_loopback(struct interface *ifp)
+int if_is_loopback(const struct interface *ifp)
 {
 	/* XXX: Do this better, eg what if IFF_WHATEVER means X on platform M
 	 * but Y on platform N?
@@ -479,12 +479,12 @@ int if_is_loopback(struct interface *ifp)
 }
 
 /* Check interface is VRF */
-int if_is_vrf(struct interface *ifp)
+int if_is_vrf(const struct interface *ifp)
 {
 	return CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_VRF_LOOPBACK);
 }
 
-bool if_is_loopback_or_vrf(struct interface *ifp)
+bool if_is_loopback_or_vrf(const struct interface *ifp)
 {
 	if (if_is_loopback(ifp) || if_is_vrf(ifp))
 		return true;
@@ -493,19 +493,19 @@ bool if_is_loopback_or_vrf(struct interface *ifp)
 }
 
 /* Does this interface support broadcast ? */
-int if_is_broadcast(struct interface *ifp)
+int if_is_broadcast(const struct interface *ifp)
 {
 	return ifp->flags & IFF_BROADCAST;
 }
 
 /* Does this interface support broadcast ? */
-int if_is_pointopoint(struct interface *ifp)
+int if_is_pointopoint(const struct interface *ifp)
 {
 	return ifp->flags & IFF_POINTOPOINT;
 }
 
 /* Does this interface support multicast ? */
-int if_is_multicast(struct interface *ifp)
+int if_is_multicast(const struct interface *ifp)
 {
 	return ifp->flags & IFF_MULTICAST;
 }

--- a/lib/if.h
+++ b/lib/if.h
@@ -499,16 +499,16 @@ extern void if_delete_retain(struct interface *);
    deletes it from the interface list and frees the structure. */
 extern void if_delete(struct interface *);
 
-extern int if_is_up(struct interface *);
-extern int if_is_running(struct interface *);
-extern int if_is_operative(struct interface *);
-extern int if_is_no_ptm_operative(struct interface *);
-extern int if_is_loopback(struct interface *);
-extern int if_is_vrf(struct interface *ifp);
-extern bool if_is_loopback_or_vrf(struct interface *ifp);
-extern int if_is_broadcast(struct interface *);
-extern int if_is_pointopoint(struct interface *);
-extern int if_is_multicast(struct interface *);
+extern int if_is_up(const struct interface *ifp);
+extern int if_is_running(const struct interface *ifp);
+extern int if_is_operative(const struct interface *ifp);
+extern int if_is_no_ptm_operative(const struct interface *ifp);
+extern int if_is_loopback(const struct interface *ifp);
+extern int if_is_vrf(const struct interface *ifp);
+extern bool if_is_loopback_or_vrf(const struct interface *ifp);
+extern int if_is_broadcast(const struct interface *ifp);
+extern int if_is_pointopoint(const struct interface *ifp);
+extern int if_is_multicast(const struct interface *ifp);
 struct vrf;
 extern void if_terminate(struct vrf *vrf);
 extern void if_dump_all(void);

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -894,6 +894,69 @@ static int netlink_address(int cmd, int family, struct interface *ifp,
 			    0);
 }
 
+/* Interface address modification. */
+static int netlink_address_ctx(const struct zebra_dplane_ctx *ctx)
+{
+	int bytelen;
+	const struct prefix *p;
+	int cmd;
+	const char *label;
+
+	struct {
+		struct nlmsghdr n;
+		struct ifaddrmsg ifa;
+		char buf[NL_PKT_BUF_SIZE];
+	} req;
+
+	p = dplane_ctx_get_intf_addr(ctx);
+	memset(&req, 0, sizeof(req) - NL_PKT_BUF_SIZE);
+
+	bytelen = (p->family == AF_INET ? 4 : 16);
+
+	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifaddrmsg));
+	req.n.nlmsg_flags = NLM_F_REQUEST;
+
+	if (dplane_ctx_get_op(ctx) == DPLANE_OP_ADDR_INSTALL)
+		cmd = RTM_NEWADDR;
+	else
+		cmd = RTM_DELADDR;
+
+	req.n.nlmsg_type = cmd;
+	req.ifa.ifa_family = p->family;
+
+	req.ifa.ifa_index = dplane_ctx_get_ifindex(ctx);
+
+	addattr_l(&req.n, sizeof(req), IFA_LOCAL, &p->u.prefix, bytelen);
+
+	if (p->family == AF_INET) {
+		if (dplane_ctx_intf_is_connected(ctx)) {
+			p = dplane_ctx_get_intf_dest(ctx);
+			addattr_l(&req.n, sizeof(req), IFA_ADDRESS,
+				  &p->u.prefix, bytelen);
+		} else if (cmd == RTM_NEWADDR &&
+			   dplane_ctx_intf_has_dest(ctx)) {
+			p = dplane_ctx_get_intf_dest(ctx);
+			addattr_l(&req.n, sizeof(req), IFA_BROADCAST,
+				  &p->u.prefix, bytelen);
+		}
+	}
+
+	/* p is now either address or destination/bcast addr */
+	req.ifa.ifa_prefixlen = p->prefixlen;
+
+	if (dplane_ctx_intf_is_secondary(ctx))
+		SET_FLAG(req.ifa.ifa_flags, IFA_F_SECONDARY);
+
+	if (dplane_ctx_intf_has_label(ctx)) {
+		label = dplane_ctx_get_intf_label(ctx);
+		addattr_l(&req.n, sizeof(req), IFA_LABEL, label,
+			  strlen(label) + 1);
+	}
+
+	return netlink_talk_info(netlink_talk_filter, &req.n,
+				 dplane_ctx_get_ns(ctx), 0);
+}
+
 int kernel_address_add_ipv4(struct interface *ifp, struct connected *ifc)
 {
 	return netlink_address(RTM_NEWADDR, AF_INET, ifp, ifc);
@@ -912,6 +975,12 @@ int kernel_address_add_ipv6(struct interface *ifp, struct connected *ifc)
 int kernel_address_delete_ipv6(struct interface *ifp, struct connected *ifc)
 {
 	return netlink_address(RTM_DELADDR, AF_INET6, ifp, ifc);
+}
+
+enum zebra_dplane_result kernel_address_update_ctx(struct zebra_dplane_ctx *ctx)
+{
+	return (netlink_address_ctx(ctx) == 0 ?
+		ZEBRA_DPLANE_REQUEST_SUCCESS : ZEBRA_DPLANE_REQUEST_FAILURE);
 }
 
 int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -442,6 +442,7 @@ static void if_addr_wakeup(struct interface *ifp)
 	struct connected *ifc;
 	struct prefix *p;
 	int ret;
+	enum zebra_dplane_result dplane_res;
 
 	for (ALL_LIST_ELEMENTS(ifp->connected, node, nnode, ifc)) {
 		p = ifc->address;
@@ -479,12 +480,13 @@ static void if_addr_wakeup(struct interface *ifp)
 					if_refresh(ifp);
 				}
 
-				ret = if_set_prefix(ifp, ifc);
-				if (ret < 0) {
+				dplane_res = dplane_intf_addr_set(ifp, ifc);
+				if (dplane_res ==
+				    ZEBRA_DPLANE_REQUEST_FAILURE) {
 					flog_err_sys(
 						EC_ZEBRA_IFACE_ADDR_ADD_FAILED,
 						"Can't set interface's address: %s",
-						safe_strerror(errno));
+						dplane_res2str(dplane_res));
 					continue;
 				}
 
@@ -2626,6 +2628,7 @@ static int ip_address_install(struct vty *vty, struct interface *ifp,
 	struct connected *ifc;
 	struct prefix_ipv4 *p;
 	int ret;
+	enum zebra_dplane_result dplane_res;
 
 	if_data = ifp->info;
 
@@ -2699,10 +2702,10 @@ static int ip_address_install(struct vty *vty, struct interface *ifp,
 			if_refresh(ifp);
 		}
 
-		ret = if_set_prefix(ifp, ifc);
-		if (ret < 0) {
+		dplane_res = dplane_intf_addr_set(ifp, ifc);
+		if (dplane_res == ZEBRA_DPLANE_REQUEST_FAILURE) {
 			vty_out(vty, "%% Can't set interface IP address: %s.\n",
-				safe_strerror(errno));
+				dplane_res2str(dplane_res));
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 
@@ -2723,6 +2726,7 @@ static int ip_address_uninstall(struct vty *vty, struct interface *ifp,
 	struct prefix_ipv4 lp, pp;
 	struct connected *ifc;
 	int ret;
+	enum zebra_dplane_result dplane_res;
 
 	/* Convert to prefix structure. */
 	ret = str2prefix_ipv4(addr_str, &lp);
@@ -2767,10 +2771,10 @@ static int ip_address_uninstall(struct vty *vty, struct interface *ifp,
 	}
 
 	/* This is real route. */
-	ret = if_unset_prefix(ifp, ifc);
-	if (ret < 0) {
+	dplane_res = dplane_intf_addr_unset(ifp, ifc);
+	if (dplane_res == ZEBRA_DPLANE_REQUEST_FAILURE) {
 		vty_out(vty, "%% Can't unset interface IP address: %s.\n",
-			safe_strerror(errno));
+			dplane_res2str(dplane_res));
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 	UNSET_FLAG(ifc->conf, ZEBRA_IFC_QUEUED);

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -180,6 +180,20 @@ void if_get_mtu(struct interface *ifp)
 #endif
 }
 
+/*
+ * TODO -- stub handler for interface address programming via the zebra dplane,
+ *         for non-netlink platforms.
+ */
+#ifndef HAVE_NETLINK
+
+enum zebra_dplane_result kernel_address_update_ctx(
+	struct zebra_dplane_ctx *ctx)
+{
+	return -1;
+}
+
+#endif	/* !HAVE_NETLINK */
+
 #ifdef HAVE_NETLINK
 /* Interface address setting via netlink interface. */
 int if_set_prefix(struct interface *ifp, struct connected *ifc)

--- a/zebra/ioctl.h
+++ b/zebra/ioctl.h
@@ -35,14 +35,8 @@ extern int if_set_flags(struct interface *, uint64_t);
 extern int if_unset_flags(struct interface *, uint64_t);
 extern void if_get_flags(struct interface *);
 
-extern int if_set_prefix(struct interface *, struct connected *);
-extern int if_unset_prefix(struct interface *, struct connected *);
-
 extern void if_get_metric(struct interface *);
 extern void if_get_mtu(struct interface *);
-
-extern int if_prefix_add_ipv6(struct interface *, struct connected *);
-extern int if_prefix_delete_ipv6(struct interface *, struct connected *);
 
 #ifdef SOLARIS_IPV6
 extern int if_ioctl_ipv6(unsigned long, caddr_t);

--- a/zebra/ioctl_solaris.c
+++ b/zebra/ioctl_solaris.c
@@ -38,8 +38,15 @@
 #include "zebra/interface.h"
 #include "zebra/ioctl_solaris.h"
 #include "zebra/zebra_errors.h"
+#include "zebra/debug.h"
 
 extern struct zebra_privs_t zserv_privs;
+
+/* Prototypes */
+static int if_set_prefix_ctx(const struct zebra_dplane_ctx *ctx);
+static int if_unset_prefix_ctx(const struct zebra_dplane_ctx *ctx);
+static int if_set_prefix6_ctx(const struct zebra_dplane_ctx *ctx);
+static int if_unset_prefix6_ctx(const struct zebra_dplane_ctx *ctx);
 
 /* clear and set interface name string */
 void lifreq_set_name(struct lifreq *lifreq, const char *ifname)
@@ -184,30 +191,51 @@ void if_get_mtu(struct interface *ifp)
 }
 
 /*
- * Stub for new dataplane interface-address modification path.
+ *
  */
-enum zebra_dplane_result kernel_address_update_ctx(struct zebra_dplane_ctx *ctx)
+enum zebra_dplane_result kernel_address_update_ctx(
+	struct zebra_dplane_ctx *ctx)
 {
-	return ZEBRA_DPLANE_REQUEST_FAILURE;
+	int ret = -1;
+	const struct prefix *p;
+
+	p = dplane_ctx_get_intf_addr(ctx);
+
+	if (dplane_ctx_get_op(ctx) == DPLANE_OP_ADDR_INSTALL) {
+		if (p->family == AF_INET)
+			ret = if_set_prefix_ctx(ctx);
+		else
+			ret = if_set_prefix6_ctx(ctx);
+	} else if (dplane_ctx_get_op(ctx) == DPLANE_OP_ADDR_UNINSTALL) {
+		if (p->family == AF_INET)
+			ret = if_unset_prefix_ctx(ctx);
+		else
+			ret = if_unset_prefix6_ctx(ctx);
+	} else {
+		if (IS_ZEBRA_DEBUG_DPLANE)
+			zlog_debug("Invalid op in interface-addr install");
+	}
+
+	return (ret == 0 ?
+		ZEBRA_DPLANE_REQUEST_SUCCESS : ZEBRA_DPLANE_REQUEST_FAILURE);
 }
 
 /* Set up interface's address, netmask (and broadcast? ).
    Solaris uses ifname:number semantics to set IP address aliases. */
-int if_set_prefix(struct interface *ifp, struct connected *ifc)
+static int if_set_prefix_ctx(const struct zebra_dplane_ctx *ctx)
 {
 	int ret;
 	struct ifreq ifreq;
-	struct sockaddr_in addr;
-	struct sockaddr_in broad;
-	struct sockaddr_in mask;
+	struct sockaddr_in addr, broad, mask;
 	struct prefix_ipv4 ifaddr;
 	struct prefix_ipv4 *p;
 
-	p = (struct prefix_ipv4 *)ifc->address;
+	p = (struct prefix_ipv4 *)dplane_ctx_get_intf_addr(ctx);
 
 	ifaddr = *p;
 
-	strlcpy(ifreq.ifr_name, ifp->name, sizeof(ifreq.ifr_name));
+	strlcpy(ifreq.ifr_name, dplane_ctx_get_ifname(ctx),
+		sizeof(ifreq.ifr_name));
 
 	addr.sin_addr = p->prefix;
 	addr.sin_family = p->family;
@@ -221,7 +249,7 @@ int if_set_prefix(struct interface *ifp, struct connected *ifc)
 	/* We need mask for make broadcast addr. */
 	masklen2ip(p->prefixlen, &mask.sin_addr);
 
-	if (if_is_broadcast(ifp)) {
+	if (dplane_ctx_intf_is_broadcast(ctx)) {
 		apply_mask_ipv4(&ifaddr);
 		addr.sin_addr = ifaddr.prefix;
 
@@ -249,16 +277,17 @@ int if_set_prefix(struct interface *ifp, struct connected *ifc)
 
 /* Set up interface's address, netmask (and broadcast).
    Solaris uses ifname:number semantics to set IP address aliases. */
-int if_unset_prefix(struct interface *ifp, struct connected *ifc)
+static int if_unset_prefix_ctx(const struct zebra_dplane_ctx *ctx)
 {
 	int ret;
 	struct ifreq ifreq;
 	struct sockaddr_in addr;
 	struct prefix_ipv4 *p;
 
-	p = (struct prefix_ipv4 *)ifc->address;
+	p = (struct prefix_ipv4 *)dplane_ctx_get_intf_addr(ctx);
 
-	strlcpy(ifreq.ifr_name, ifp->name, sizeof(ifreq.ifr_name));
+	strncpy(ifreq.ifr_name, dplane_ctx_get_ifname(ctx),
+		sizeof(ifreq.ifr_name));
 
 	memset(&addr, 0, sizeof(struct sockaddr_in));
 	addr.sin_family = p->family;
@@ -385,24 +414,26 @@ int if_unset_flags(struct interface *ifp, uint64_t flags)
 }
 
 /* Interface's address add/delete functions. */
-int if_prefix_add_ipv6(struct interface *ifp, struct connected *ifc)
+static int if_set_prefix6_ctx(const struct zebra_dplane_ctx *ctx)
 {
 	char addrbuf[PREFIX_STRLEN];
 
+	prefix2str(dplane_ctx_get_intf_addr(ctx), addrbuf, sizeof(addrbuf));
+
 	flog_warn(EC_LIB_DEVELOPMENT, "Can't set %s on interface %s",
-		  prefix2str(ifc->address, addrbuf, sizeof(addrbuf)),
-		  ifp->name);
+		  addrbuf, dplane_ctx_get_ifname(ctx));
 
 	return 0;
 }
 
-int if_prefix_delete_ipv6(struct interface *ifp, struct connected *ifc)
+static int if_unset_prefix6_ctx(const struct zebra_dplane_ctx *ctx)
 {
 	char addrbuf[PREFIX_STRLEN];
 
+	prefix2str(dplane_ctx_get_intf_addr(ctx), addrbuf, sizeof(addrbuf));
+
 	flog_warn(EC_LIB_DEVELOPMENT, "Can't delete %s on interface %s",
-		  prefix2str(ifc->address, addrbuf, sizeof(addrbuf)),
-		  ifp->name);
+		  addrbuf, dplane_ctx_get_ifname(ctx));
 
 	return 0;
 }

--- a/zebra/ioctl_solaris.c
+++ b/zebra/ioctl_solaris.c
@@ -183,6 +183,14 @@ void if_get_mtu(struct interface *ifp)
 		zebra_interface_up_update(ifp);
 }
 
+/*
+ * Stub for new dataplane interface-address modification path.
+ */
+enum zebra_dplane_result kernel_address_update_ctx(struct zebra_dplane_ctx *ctx)
+{
+	return ZEBRA_DPLANE_REQUEST_FAILURE;
+}
+
 /* Set up interface's address, netmask (and broadcast? ).
    Solaris uses ifname:number semantics to set IP address aliases. */
 int if_set_prefix(struct interface *ifp, struct connected *ifc)

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -50,11 +50,6 @@ extern enum zebra_dplane_result kernel_lsp_update(
 
 enum zebra_dplane_result kernel_pw_update(struct zebra_dplane_ctx *ctx);
 
-extern int kernel_address_add_ipv4(struct interface *, struct connected *);
-extern int kernel_address_delete_ipv4(struct interface *, struct connected *);
-extern int kernel_address_add_ipv6(struct interface *, struct connected *);
-extern int kernel_address_delete_ipv6(struct interface *, struct connected *);
-
 enum zebra_dplane_result kernel_address_update_ctx(
 	struct zebra_dplane_ctx *ctx);
 

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -54,6 +54,10 @@ extern int kernel_address_add_ipv4(struct interface *, struct connected *);
 extern int kernel_address_delete_ipv4(struct interface *, struct connected *);
 extern int kernel_address_add_ipv6(struct interface *, struct connected *);
 extern int kernel_address_delete_ipv6(struct interface *, struct connected *);
+
+enum zebra_dplane_result kernel_address_update_ctx(
+	struct zebra_dplane_ctx *ctx);
+
 extern int kernel_neigh_update(int cmd, int ifindex, uint32_t addr, char *lla,
 			       int llalen, ns_id_t ns_id);
 extern int kernel_interface_set_master(struct interface *master,

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -122,6 +122,32 @@ struct dplane_pw_info {
 };
 
 /*
+ * Interface/prefix info for the dataplane
+ */
+struct dplane_intf_info {
+
+	char ifname[INTERFACE_NAMSIZ];
+	ifindex_t ifindex;
+
+	uint32_t metric;
+	uint32_t flags;
+
+#define DPLANE_INTF_CONNECTED   (1 << 0) /* Connected peer, p2p */
+#define DPLANE_INTF_SECONDARY   (1 << 1)
+#define DPLANE_INTF_HAS_DEST    (1 << 2)
+#define DPLANE_INTF_HAS_LABEL   (1 << 3)
+
+	/* Interface address/prefix */
+	struct prefix prefix;
+
+	/* Dest address, for p2p, or broadcast prefix */
+	struct prefix dest_prefix;
+
+	char *label;
+	char label_buf[32];
+};
+
+/*
  * The context block used to exchange info about route updates across
  * the boundary between the zebra main context (and pthread) and the
  * dataplane layer (and pthread).
@@ -152,11 +178,12 @@ struct zebra_dplane_ctx {
 	vrf_id_t zd_vrf_id;
 	uint32_t zd_table_id;
 
-	/* Support info for either route or LSP update */
+	/* Support info for different kinds of updates */
 	union {
 		struct dplane_route_info rinfo;
 		zebra_lsp_t lsp;
 		struct dplane_pw_info pw;
+		struct dplane_intf_info intf;
 	} u;
 
 	/* Namespace info, used especially for netlink kernel communication */
@@ -409,6 +436,8 @@ static void dplane_ctx_free(struct zebra_dplane_ctx **pctx)
 		}
 		break;
 
+	case DPLANE_OP_ADDR_INSTALL:
+	case DPLANE_OP_ADDR_UNINSTALL:
 	case DPLANE_OP_NONE:
 		break;
 	}
@@ -549,6 +578,14 @@ const char *dplane_op2str(enum dplane_op_e op)
 	case DPLANE_OP_SYS_ROUTE_DELETE:
 		ret = "SYS_ROUTE_DEL";
 		break;
+
+	case DPLANE_OP_ADDR_INSTALL:
+		ret = "ADDR_INSTALL";
+		break;
+	case DPLANE_OP_ADDR_UNINSTALL:
+		ret = "ADDR_UNINSTALL";
+		break;
+
 	}
 
 	return ret;
@@ -866,6 +903,83 @@ dplane_ctx_get_pw_nhg(const struct zebra_dplane_ctx *ctx)
 	DPLANE_CTX_VALID(ctx);
 
 	return &(ctx->u.pw.nhg);
+}
+
+/* Accessors for interface information */
+const char *dplane_ctx_get_ifname(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.ifname;
+}
+
+ifindex_t dplane_ctx_get_ifindex(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.ifindex;
+}
+
+uint32_t dplane_ctx_get_intf_metric(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.metric;
+}
+
+/* Is interface addr p2p? */
+bool dplane_ctx_intf_is_connected(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return (ctx->u.intf.flags & DPLANE_INTF_CONNECTED);
+}
+
+bool dplane_ctx_intf_is_secondary(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return (ctx->u.intf.flags & DPLANE_INTF_SECONDARY);
+}
+
+const struct prefix *dplane_ctx_get_intf_addr(
+	const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return &(ctx->u.intf.prefix);
+}
+
+bool dplane_ctx_intf_has_dest(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return (ctx->u.intf.flags & DPLANE_INTF_HAS_DEST);
+}
+
+const struct prefix *dplane_ctx_get_intf_dest(
+	const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	if (ctx->u.intf.flags & DPLANE_INTF_HAS_DEST)
+		return &(ctx->u.intf.dest_prefix);
+	else
+		return NULL;
+}
+
+bool dplane_ctx_intf_has_label(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return (ctx->u.intf.flags & DPLANE_INTF_HAS_LABEL);
+}
+
+const char *dplane_ctx_get_intf_label(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+
+	return ctx->u.intf.label;
 }
 
 /*
@@ -1491,6 +1605,24 @@ done:
 	}
 
 	return result;
+}
+
+/*
+ * Enqueue interface address add for the dataplane.
+ */
+enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
+					      const struct connected *ifc)
+{
+	return ZEBRA_DPLANE_REQUEST_FAILURE;
+}
+
+/*
+ * Enqueue interface address remove/uninstall for the dataplane.
+ */
+enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
+						const struct connected *ifc)
+{
+	return ZEBRA_DPLANE_REQUEST_FAILURE;
 }
 
 /*

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -118,6 +118,10 @@ enum dplane_op_e {
 	/* System route notification */
 	DPLANE_OP_SYS_ROUTE_ADD,
 	DPLANE_OP_SYS_ROUTE_DELETE,
+
+	/* Interface address update */
+	DPLANE_OP_ADDR_INSTALL,
+	DPLANE_OP_ADDR_UNINSTALL,
 };
 
 /* Enable system route notifications */
@@ -234,6 +238,21 @@ const union pw_protocol_fields *dplane_ctx_get_pw_proto(
 const struct nexthop_group *dplane_ctx_get_pw_nhg(
 	const struct zebra_dplane_ctx *ctx);
 
+/* Accessors for interface information */
+const char *dplane_ctx_get_ifname(const struct zebra_dplane_ctx *ctx);
+ifindex_t dplane_ctx_get_ifindex(const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_get_intf_metric(const struct zebra_dplane_ctx *ctx);
+/* Is interface addr p2p? */
+bool dplane_ctx_intf_is_connected(const struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_intf_is_secondary(const struct zebra_dplane_ctx *ctx);
+const struct prefix *dplane_ctx_get_intf_addr(
+	const struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_intf_has_dest(const struct zebra_dplane_ctx *ctx);
+const struct prefix *dplane_ctx_get_intf_dest(
+	const struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_intf_has_label(const struct zebra_dplane_ctx *ctx);
+const char *dplane_ctx_get_intf_label(const struct zebra_dplane_ctx *ctx);
+
 /* Namespace info - esp. for netlink communication */
 const struct zebra_dplane_info *dplane_ctx_get_ns(
 	const struct zebra_dplane_ctx *ctx);
@@ -274,6 +293,15 @@ enum zebra_dplane_result dplane_lsp_delete(zebra_lsp_t *lsp);
  */
 enum zebra_dplane_result dplane_pw_install(struct zebra_pw *pw);
 enum zebra_dplane_result dplane_pw_uninstall(struct zebra_pw *pw);
+
+/*
+ * Enqueue interface address changes for the dataplane.
+ */
+enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
+					      const struct connected *ifc);
+enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
+						const struct connected *ifc);
+
 
 /* Retrieve the limit on the number of pending, unprocessed updates. */
 uint32_t dplane_get_in_queue_limit(void);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -245,6 +245,7 @@ uint32_t dplane_ctx_get_intf_metric(const struct zebra_dplane_ctx *ctx);
 /* Is interface addr p2p? */
 bool dplane_ctx_intf_is_connected(const struct zebra_dplane_ctx *ctx);
 bool dplane_ctx_intf_is_secondary(const struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_intf_is_broadcast(const struct zebra_dplane_ctx *ctx);
 const struct prefix *dplane_ctx_get_intf_addr(
 	const struct zebra_dplane_ctx *ctx);
 bool dplane_ctx_intf_has_dest(const struct zebra_dplane_ctx *ctx);


### PR DESCRIPTION
Move interface address programming to the async dataplane. This mainly consists of extending the existing dataplane context to hold interface information, and converting the various OS code paths to use the context structs instead of zebra's own interface data structs.

### Components
Zebra, libs
