### PR TITLE
zebra: Deletion of a lsp is not a failure event

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -1800,9 +1800,10 @@ void zebra_mpls_lsp_dplane_result(struct zebra_dplane_ctx *ctx)
 		break;
 
 	case DPLANE_OP_LSP_DELETE:
-		flog_warn(EC_ZEBRA_LSP_DELETE_FAILURE,
-			  "LSP Deletion Failure: in-label %u",
-			  dplane_ctx_get_in_label(ctx));
+		if (status != ZEBRA_DPLANE_REQUEST_SUCCESS)
+			flog_warn(EC_ZEBRA_LSP_DELETE_FAILURE,
+				  "LSP Deletion Failure: in-label %u",
+				  dplane_ctx_get_in_label(ctx));
 		break;
 
 	default:


### PR DESCRIPTION
FRR is reporting that a lsp deletion event as a failure
in the log messsages.  This will lead to confusion and
lots of fun debugging.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
