### PR TITLE
Show debugging for bfd

### DIFF
--- a/bfdd/Makefile
+++ b/bfdd/Makefile
@@ -1,0 +1,10 @@
+all: ALWAYS
+	@$(MAKE) -s -C .. bfdd/bfdd
+%: ALWAYS
+	@$(MAKE) -s -C .. bfdd/$@
+
+Makefile:
+	#nothing
+ALWAYS:
+.PHONY: ALWAYS makefiles
+.SUFFIXES:

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -968,6 +968,18 @@ static void _bfdd_peer_write_config(struct hash_backet *hb, void *arg)
 	vty_out(vty, " !\n");
 }
 
+DEFUN_NOSH(show_debugging_bfd,
+	   show_debugging_bfd_cmd,
+	   "show debugging [bfd]",
+	   SHOW_STR
+	   DEBUG_STR
+	   "BFD daemon\n")
+{
+	vty_out(vty, "BFD debugging status:\n");
+
+	return CMD_SUCCESS;
+}
+
 static int bfdd_peer_write_config(struct vty *vty)
 {
 	bfd_id_iterate(_bfdd_peer_write_config, vty);
@@ -993,6 +1005,7 @@ void bfdd_vty_init(void)
 	install_element(ENABLE_NODE, &bfd_show_peers_cmd);
 	install_element(ENABLE_NODE, &bfd_show_peer_cmd);
 	install_element(CONFIG_NODE, &bfd_enter_cmd);
+	install_element(ENABLE_NODE, &show_debugging_bfd_cmd);
 
 	/* Install BFD node and commands. */
 	install_node(&bfd_node, bfdd_write_config);


### PR DESCRIPTION
`show debugging` from the vtysh was returning `command incomplete` when I had bfdd running.  I just added a shell function that does not do anything at this point in time.