### PR TITLE
build: fix automake fart under MSAN

### DIFF
--- a/bgpd/subdir.am
+++ b/bgpd/subdir.am
@@ -191,12 +191,15 @@ noinst_HEADERS += \
 bgpd_bgpd_SOURCES = bgpd/bgp_main.c
 bgpd_bgp_btoa_SOURCES = bgpd/bgp_btoa.c
 
+bgpd_bgpd_CFLAGS = $(AM_CFLAGS)
+bgpd_bgp_btoa_CFLAGS = $(AM_CFLAGS)
+
 if ENABLE_BGP_VNC
 bgpd_bgpd_SOURCES += bgpd/rfapi/rfapi_descriptor_rfp_utils.c
-bgpd_bgpd_CFLAGS = $(AM_CFLAGS) -Irfapi -I@top_srcdir@/$(RFPINC)
+bgpd_bgpd_CFLAGS += -Irfapi -I@top_srcdir@/$(RFPINC)
 
 bgpd_bgp_btoa_SOURCES += bgpd/rfapi/rfapi_descriptor_rfp_utils.c
-bgpd_bgp_btoa_CFLAGS = $(AM_CFLAGS) -Irfapi -I@top_srcdir@/$(RFPINC)
+bgpd_bgp_btoa_CFLAGS += -Irfapi -I@top_srcdir@/$(RFPINC)
 endif
 
 # RFPLDADD is set in bgpd/rfp-example/librfp/subdir.am


### PR DESCRIPTION
Automake wasn't using the correct compiler flags when building BGP binaries under MSAN with VNC disabled because it sucks

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>