### PR TITLE
[6.0] vtysh: Don't attempt to reconnect the non-instanced ospf process

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -576,7 +576,7 @@ static int vtysh_execute_func(const char *line, int pager)
 				    && (cmd->daemon == vtysh_client[i].flag)) {
 					for (vc = &vtysh_client[i]; vc;
 					     vc = vc->next)
-						if (vc->fd < 0)
+						if (vc->fd == VTYSH_WAS_ACTIVE)
 							vtysh_reconnect(vc);
 				}
 				if (vtysh_client[i].fd < 0


### PR DESCRIPTION
When running ospf instances we should not attempt to reconnect
the default ospf instance on running a command.

This commit should be targeted enough because in the case
of normal operation we connect to everything we should
and only set the VTYSH_WAS_ACTIVE flag for those we
truly have lost connection too.

Before:

donna.cumulusnetworks.com# config t
donna.cumulusnetworks.com(config)# router ospf 100
Warning: connecting to ospfd...failed!
donna.cumulusnetworks.com(config-router)#

After:
donna.cumulusnetworks.com# conf t
donna.cumulusnetworks.com(config)# router ospf 100
donna.cumulusnetworks.com(config-router)# end
donna.cumulusnetworks.com#

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]
