### PR TITLE
bgpd: Establish BGP session only if zebra is connected

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1442,7 +1442,7 @@ int bgp_start(struct peer *peer)
 	if (!bgp_find_or_add_nexthop(peer->bgp, peer->bgp,
 				     family2afi(peer->su.sa.sa_family), NULL,
 				     peer, connected)) {
-		if (bgp_zebra_num_connects()) {
+		if (!bgp_zebra_num_connects()) {
 			if (bgp_debug_neighbor_events(peer))
 				zlog_debug("%s [FSM] Waiting for NHT",
 					   peer->host);


### PR DESCRIPTION
Here we have a race condition and do not transition to Connect state from Active anymore. Both peers stand in Active state and never gets connected.

I might be wrong of course. 

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

BEFORE:
![issue3697-master](https://user-images.githubusercontent.com/3352707/52884277-2f3dec00-3176-11e9-860c-a23341c87fcc.gif)

AFTER:
![issue3697](https://user-images.githubusercontent.com/3352707/52884156-d5d5bd00-3175-11e9-96d1-a0b10f424546.gif)


### Related Issue
https://github.com/FRRouting/frr/issues/3697

### Components
bgpd