### PR TITLE
[6.0] bgpd: Incorrect number of peers count in "show bgp ipv6 summary" output

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7838,7 +7838,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					json, "ribMemory",
 					ents * sizeof(struct bgp_node));
 
-				ents = listcount(bgp->peer);
+				ents = bgp->af_peer_count[afi][safi];
 				json_object_int_add(json, "peerCount", ents);
 				json_object_int_add(json, "peerMemory",
 						    ents * sizeof(struct peer));
@@ -7878,7 +7878,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 								   bgp_node)));
 
 				/* Peer related usage */
-				ents = listcount(bgp->peer);
+				ents = bgp->af_peer_count[afi][safi];
 				vty_out(vty, "Peers %ld, using %s of memory\n",
 					ents,
 					mtype_memstr(

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -671,6 +671,7 @@ struct peer_af *peer_af_create(struct peer *peer, afi_t afi, safi_t safi)
 {
 	struct peer_af *af;
 	int afid;
+	struct bgp *bgp;
 
 	if (!peer)
 		return NULL;
@@ -679,6 +680,7 @@ struct peer_af *peer_af_create(struct peer *peer, afi_t afi, safi_t safi)
 	if (afid >= BGP_AF_MAX)
 		return NULL;
 
+	bgp = peer->bgp;
 	assert(peer->peer_af_array[afid] == NULL);
 
 	/* Allocate new peer af */
@@ -689,6 +691,7 @@ struct peer_af *peer_af_create(struct peer *peer, afi_t afi, safi_t safi)
 	af->safi = safi;
 	af->afid = afid;
 	af->peer = peer;
+	bgp->af_peer_count[afi][safi]++;
 
 	return af;
 }
@@ -711,6 +714,7 @@ int peer_af_delete(struct peer *peer, afi_t afi, safi_t safi)
 {
 	struct peer_af *af;
 	int afid;
+	struct bgp *bgp;
 
 	if (!peer)
 		return -1;
@@ -723,6 +727,7 @@ int peer_af_delete(struct peer *peer, afi_t afi, safi_t safi)
 	if (!af)
 		return -1;
 
+	bgp = peer->bgp;
 	bgp_stop_announce_route_timer(af);
 
 	if (PAF_SUBGRP(af)) {
@@ -733,6 +738,9 @@ int peer_af_delete(struct peer *peer, afi_t afi, safi_t safi)
 	}
 
 	update_subgroup_remove_peer(af->subgroup, af);
+
+	if (bgp->af_peer_count[afi][safi])
+		bgp->af_peer_count[afi][safi]--;
 
 	peer->peer_af_array[afid] = NULL;
 	XFREE(MTYPE_BGP_PEER_AF, af);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -370,6 +370,9 @@ struct bgp {
 #define BGP_CONFIG_VRF_TO_VRF_EXPORT			(1 << 8)
 #define BGP_DEFAULT_NAME		"default"
 
+	/* BGP per AF peer count */
+	uint32_t af_peer_count[AFI_MAX][SAFI_MAX];
+
 	/* Route table for next-hop lookup cache. */
 	struct bgp_table *nexthop_cache_table[AFI_MAX];
 


### PR DESCRIPTION
### Summary
The "show bgp ipv6 summary" output displays incorrect number of peers count.

sonic# show bgp ipv6 summary

IPv6 Unicast Summary:
BGP router identifier 10.1.0.1, local AS number 65100 vrf-id 0
BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 5, using 103 KiB of memory
Peer groups 1, using 64 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
2003::1         4      65099       0       0        0    0    0    never       Active
2088::1         4      65100       0       0        0    0    0    never       Active
3021::2         4      65100       0       0        0    0    0    never       Active

Total number of neighbors 3
sonic#
In the above output, the peers count displays as 5 but the actual peer count is 3, i.e.. 3 neighbors are activated in ipv6 unicast address family.
Displayed peer count (5) is the number of the neighbors activated in a BGP instance.

Fix : Now the peers count displays the number of neighbors activated per afi/safi.
After Fix:
sonic# show bgp ipv6 summary 

IPv6 Unicast Summary:
BGP router identifier 10.1.0.1, local AS number 65100 vrf-id 0
BGP table version 0                                           
RIB entries 0, using 0 bytes of memory                        
Peers 3, using 62 KiB of memory                               
Peer groups 1, using 64 bytes of memory                       

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
2003::1         4      65099       0       0        0    0    0    never       Active
2088::1         4      65100       0       0        0    0    0    never       Active
3021::2         4      65100       0       0        0    0    0    never       Active

Total number of neighbors 3
sonic# 

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>

### Related Issue
https://github.com/FRRouting/frr/pull/3917 -> stable/7.0 branch
https://github.com/FRRouting/frr/pull/3920 -> master branch

### Components
[bgpd]
