### PR TITLE
snapcraft: Disable libyang CACHE for snap package (Temp workaround)

### DIFF
--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -266,6 +266,7 @@ parts:
         configflags:
            - -DCMAKE_INSTALL_PREFIX:PATH=/usr
            - -DENABLE_LYD_PRIV=ON
+           - -DENABLE_CACHE=OFF
            - -DCMAKE_BUILD_TYPE:String="Release"
     frr: 
         after: [rtrlib,libyang]


### PR DESCRIPTION
There seems to be a bug in latest libyang running when running in
a snap container which causes a failure of the cache logic. Disable
CACHE for now as it's not yet needed. Will be re-enabled in a later
release

Workaround for Issue https://github.com/FRRouting/frr/issues/3813

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>
