### PR TITLE
libs: remove deprecated workqueue api

### DIFF
--- a/lib/workqueue.c
+++ b/lib/workqueue.c
@@ -99,7 +99,10 @@ struct work_queue *work_queue_new(struct thread_master *m,
 	return new;
 }
 
-void work_queue_free_original(struct work_queue *wq)
+/*
+ * Internal helper api; used to be public.
+ */
+static void work_queue_free_original(struct work_queue *wq)
 {
 	if (wq->thread != NULL)
 		thread_cancel(wq->thread);

--- a/lib/workqueue.h
+++ b/lib/workqueue.h
@@ -159,19 +159,10 @@ extern struct work_queue *work_queue_new(struct thread_master *, const char *);
  * The usage of work_queue_free is being transitioned to pass
  * in the double pointer to remove use after free's.
  */
-#if CONFDATE > 20190205
-CPP_NOTICE("work_queue_free without double pointer is deprecated, please fixup")
-#endif
-extern void work_queue_free_and_null(struct work_queue **);
-extern void work_queue_free_original(struct work_queue *);
-#define work_queue_free(X)                                                     \
-	do {                                                                   \
-		work_queue_free_original((X));                                 \
-		CPP_WARN("Please use work_queue_free_and_null");               \
-	} while (0)
+extern void work_queue_free_and_null(struct work_queue **wqp);
 
 /* Add the supplied data as an item onto the workqueue */
-extern void work_queue_add(struct work_queue *, void *);
+extern void work_queue_add(struct work_queue *wq, void *item);
 
 /* plug the queue, ie prevent it from being drained / processed */
 extern void work_queue_plug(struct work_queue *wq);


### PR DESCRIPTION
Remove deprecated api from workqueue module.

Signed-off-by: Mark Stapp <mjs@voltanet.io>
