### PR TITLE
build: fix linking to libconfd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1659,6 +1659,8 @@ if test "$enable_confd" != "" -a "$enable_confd" != "no"; then
    fi
    CONFD_CFLAGS="-I${enable_confd}/include -L${enable_confd}/lib"
    AC_SUBST([CONFD_CFLAGS])
+   CONFD_LIBS="-lconfd"
+   AC_SUBST([CONFD_LIBS])
    AC_DEFINE([HAVE_CONFD], [1], [Enable confd integration])
 fi
 AM_CONDITIONAL([CONFD], [test "x$enable_confd" != "x"])


### PR DESCRIPTION
Commit fdbd8086b1e1 removed the explicit -lconfd flag from
lib_confd_la_LIBADD in favor of using the CONFD_LIBS variable. The
problem, however, is that ConfD doesn't use pkg-config nor anything
similar, so CONFD_LIBS is not created automatically by autotools.

Fix this problem by manually assigning -lconfd to the CONFD_LIBS
variable in the configure script.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>