### PR TITLE
[6.0] tools: fix new init script wrt. multi-instance

### DIFF
--- a/tools/frrcommon.sh.in
+++ b/tools/frrcommon.sh.in
@@ -67,9 +67,9 @@ vtysh_b () {
 daemon_inst() {
 	# note this sets global variables ($dmninst, $daemon, $inst)
 	dmninst="$1"
-	daemon="${dmninst%:*}"
+	daemon="${dmninst%-*}"
 	inst=""
-	[ "$daemon" != "$dmninst" ] && inst="${dmninst#*:}"
+	[ "$daemon" != "$dmninst" ] && inst="${dmninst#*-}"
 }
 
 daemon_list() {
@@ -92,9 +92,12 @@ daemon_list() {
 			enabled="$enabled $daemon"
 			if [ -n "$inst" ]; then
 				debug "$daemon multi-instance $inst"
+				oldifs="${IFS}"
+				IFS="${IFS},"
 				for i in $inst; do
-					enabled="$enabled $daemon:$inst"
+					enabled="$enabled $daemon-$i"
 				done
+				IFS="${oldifs}"
 			fi
 		else
 			debug "$daemon disabled"
@@ -119,7 +122,7 @@ daemon_prep() {
 	inst="$2"
 	[ "$daemon" = "watchfrr" ] && return 0
 	[ -x "$D_PATH/$daemon" ] || {
-		log_failure_msg "cannot start $daemon${inst:+ (instance $inst)}: daemon binary not installed\n"
+		log_failure_msg "cannot start $daemon${inst:+ (instance $inst)}: daemon binary not installed"
 		return 1
 	}
 	[ -r "$C_PATH/frr.conf" ] && return 0
@@ -279,7 +282,7 @@ load_old_config() {
 }
 
 [ -r "$C_PATH/daemons" ] || {
-	log_failure_msg "cannot run $@: $C_PATH/daemons does not exist\n"
+	log_failure_msg "cannot run $@: $C_PATH/daemons does not exist"
 	exit 1
 }
 . "$C_PATH/daemons"


### PR DESCRIPTION
TBH when I looked at watchfrr I didn't see any MI support and hence
assumed this just didn't work to begin with.  However, it actually does
(transparently to watchfrr, by just using "ospfd-1" as daemon name.)

So, fix this up and make it work again.

(Also remove 2 extraneous \n in messages.)

[This does need a 7.0/master version; I've stacked it on my list with the 7.0 Debian PR.]
