### PR TITLE
Revert "redhat: don't Requires initscript on systemd based distros"

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -171,6 +171,7 @@ BuildRequires:  python27-sphinx
 BuildRequires:  python-devel >= 2.7
 BuildRequires:  python-sphinx
 %endif
+Requires:       initscripts
 %if %{with_pam}
 BuildRequires:  pam-devel
 %endif
@@ -188,7 +189,6 @@ Requires(post):     chkconfig
 Requires(preun):    chkconfig
 # Initscripts > 5.60 is required for IPv6 support
 Requires(pre):      initscripts >= 5.60
-Requires:           initscripts
 %endif
 Provides:           routingdaemon = %{version}-%{release}
 Obsoletes:          gated mrt zebra frr-sysvinit


### PR DESCRIPTION
This reverts commit ec59a1559cce612d04131639653eddf65d69e868.

Frr.init (called by frr.service) requires functions provided by
/etc/init.d/functions (part of the initscripts package).

Signed-off-by: Liam McBirnie <liam.mcbirnie@boeing.com>
