### PR TITLE
build: update doc link for libyang warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1598,7 +1598,7 @@ PKG_CHECK_MODULES(libyang, [libyang >= 0.16.7], , [
 AC_CHECK_MEMBER([struct lyd_node.priv], [], [
   AC_MSG_ERROR([m4_normalize([
     libyang needs to be compiled with ENABLE_LYD_PRIV=ON.
-    See http://docs.frrouting.org/projects/dev-guide/en/latest/building-libyang.html for details.])
+    Instructions for this are included in the build documentation for your platform at http://docs.frrouting.org/projects/dev-guide/en/latest/building.html])
   ])
 ], [[#include <libyang/libyang.h>]])
 


### PR DESCRIPTION
Doc link points to nonexistent document