### PR TITLE
 enable vrf creation from all daemon instances

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -243,7 +243,7 @@ babel_enable_if_add (const char *ifname)
 
     vector_set (babel_enable_if, strdup (ifname));
 
-    ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+    ifp = if_lookup_by_name(ifname, vrf_lookup_by_id(VRF_DEFAULT));
     if (ifp != NULL)
         interface_recalculate(ifp);
 
@@ -266,7 +266,7 @@ babel_enable_if_delete (const char *ifname)
     free (str);
     vector_unset (babel_enable_if, babel_enable_if_index);
 
-    ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+    ifp = if_lookup_by_name(ifname, vrf_lookup_by_id(VRF_DEFAULT));
     if (ifp != NULL)
         interface_reset(ifp);
 
@@ -909,7 +909,8 @@ DEFUN (show_babel_interface,
       show_babel_interface_sub (vty, ifp);
     return CMD_SUCCESS;
   }
-  if ((ifp = if_lookup_by_name (argv[3]->arg, VRF_DEFAULT)) == NULL)
+  if ((ifp = if_lookup_by_name (argv[3]->arg,
+				vrf_lookup_by_id(VRF_DEFAULT))) == NULL)
   {
     vty_out (vty, "No such interface name\n");
     return CMD_WARNING;
@@ -951,7 +952,8 @@ DEFUN (show_babel_neighbour,
         }
         return CMD_SUCCESS;
     }
-    if ((ifp = if_lookup_by_name (argv[3]->arg, VRF_DEFAULT)) == NULL)
+    if ((ifp = if_lookup_by_name (argv[3]->arg,
+				  vrf_lookup_by_id(VRF_DEFAULT))) == NULL)
     {
         vty_out (vty, "No such interface name\n");
         return CMD_WARNING;

--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -555,7 +555,7 @@ babel_distribute_update (struct distribute_ctx *ctx, struct distribute *dist)
     if (! dist->ifname)
         return;
 
-    ifp = if_lookup_by_name (dist->ifname, VRF_DEFAULT);
+    ifp = if_lookup_by_name (dist->ifname, vrf_lookup_by_id(VRF_DEFAULT));
     if (ifp == NULL)
         return;
 

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -625,13 +625,14 @@ static int bfdd_interface_vrf_update(int command __attribute__((__unused__)),
 				     vrf_id_t vrfid)
 {
 	struct interface *ifp;
+	struct vrf *nvrf;
 	vrf_id_t nvrfid;
 
 	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrfid, &nvrfid);
 	if (ifp == NULL)
 		return 0;
-
-	if_update_to_new_vrf(ifp, nvrfid);
+	nvrf = vrf_lookup_by_id(nvrfid);
+	if_update_to_new_vrf(ifp, nvrf);
 
 	return 0;
 }

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -310,7 +310,8 @@ static int bgp_get_instance_for_inc_conn(int sock, struct bgp **bgp_inst)
 		if (bgp->inst_type == BGP_INSTANCE_TYPE_VIEW)
 			continue;
 
-		ifp = if_lookup_by_name(name, bgp->vrf_id);
+		ifp = if_lookup_by_name(name,
+					vrf_lookup_by_id(bgp->vrf_id));
 		if (ifp) {
 			*bgp_inst = bgp;
 			return 0;
@@ -570,7 +571,8 @@ static int bgp_update_source(struct peer *peer)
 
 	/* Source is specified with interface name.  */
 	if (peer->update_if) {
-		ifp = if_lookup_by_name(peer->update_if, peer->bgp->vrf_id);
+		ifp = if_lookup_by_name(peer->update_if,
+					vrf_lookup_by_id(peer->bgp->vrf_id));
 		if (!ifp)
 			return -1;
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -802,7 +802,7 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 		nexthop->v4 = local->sin.sin_addr;
 		if (peer->update_if)
 			ifp = if_lookup_by_name(peer->update_if,
-						peer->bgp->vrf_id);
+						vrf_lookup_by_id(peer->bgp->vrf_id));
 		else
 			ifp = if_lookup_by_ipv4_exact(&local->sin.sin_addr,
 						      peer->bgp->vrf_id);
@@ -813,10 +813,11 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
 				ifp = if_lookup_by_name(peer->conf_if
 								? peer->conf_if
 								: peer->ifname,
-							peer->bgp->vrf_id);
+							vrf_lookup_by_id(
+								 peer->bgp->vrf_id));
 		} else if (peer->update_if)
 			ifp = if_lookup_by_name(peer->update_if,
-						peer->bgp->vrf_id);
+						vrf_lookup_by_id(peer->bgp->vrf_id));
 		else
 			ifp = if_lookup_by_ipv6_exact(&local->sin6.sin6_addr,
 						      local->sin6.sin6_scope_id,
@@ -2895,7 +2896,8 @@ static void bgp_encode_pbr_interface_list(struct bgp *bgp, struct stream *s)
 	head = &(bgp_pbr_cfg->ifaces_by_name_ipv4);
 
 	RB_FOREACH (pbr_if, bgp_pbr_interface_head, head) {
-		ifp = if_lookup_by_name(pbr_if->name, bgp->vrf_id);
+		ifp = if_lookup_by_name(pbr_if->name,
+					vrf_lookup_by_id(bgp->vrf_id));
 		if (ifp)
 			stream_putl(s, ifp->ifindex);
 	}
@@ -2913,7 +2915,8 @@ static int bgp_pbr_get_ifnumber(struct bgp *bgp)
 	head = &(bgp_pbr_cfg->ifaces_by_name_ipv4);
 
 	RB_FOREACH (pbr_if, bgp_pbr_interface_head, head) {
-		if (if_lookup_by_name(pbr_if->name, bgp->vrf_id))
+		if (if_lookup_by_name(pbr_if->name,
+				      vrf_lookup_by_id(bgp->vrf_id)))
 			cnt++;
 	}
 	return cnt;

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -517,7 +517,7 @@ static int bgp_interface_vrf_update(int command, struct zclient *zclient,
 		}
 	}
 
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, vrf_lookup_by_id(new_vrf_id));
 
 	bgp = bgp_lookup_by_vrf_id(new_vrf_id);
 	if (!bgp)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1445,7 +1445,8 @@ void bgp_peer_conf_if_to_su_update(struct peer *peer)
 	hash_release(peer->bgp->peerhash, peer);
 
 	prev_family = peer->su.sa.sa_family;
-	if ((ifp = if_lookup_by_name(peer->conf_if, peer->bgp->vrf_id))) {
+	if ((ifp = if_lookup_by_name(peer->conf_if,
+				     vrf_lookup_by_id(peer->bgp->vrf_id)))) {
 		peer->ifp = ifp;
 		/* If BGP unnumbered is not "v6only", we first see if we can
 		 * derive the

--- a/eigrpd/eigrp_filter.c
+++ b/eigrpd/eigrp_filter.c
@@ -174,7 +174,8 @@ void eigrp_distribute_update(struct distribute_ctx *ctx,
 		return;
 	}
 
-	ifp = if_lookup_by_name(dist->ifname, VRF_DEFAULT);
+	ifp = if_lookup_by_name(dist->ifname,
+				vrf_lookup_by_id(VRF_DEFAULT));
 	if (ifp == NULL)
 		return;
 

--- a/eigrpd/eigrp_routemap.c
+++ b/eigrpd/eigrp_routemap.c
@@ -62,7 +62,7 @@ void eigrp_if_rmap_update(struct if_rmap *if_rmap)
 	struct route_map *rmap;
 	struct eigrp *e;
 
-	ifp = if_lookup_by_name(if_rmap->ifname);
+	ifp = if_lookup_by_name(if_rmap->ifname, vrf_lookup_by_id(VRF_DEFAULT));
 	if (ifp == NULL)
 		return;
 

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -351,7 +351,8 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, VRF_DEFAULT);
+	return if_lookup_by_name(ifname_tmp,
+				 vrf_lookup_by_id(VRF_DEFAULT));
 }
 
 void eigrp_zebra_route_add(struct prefix *p, struct list *successors,

--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -1574,7 +1574,7 @@ static int lib_interface_isis_area_tag_modify(enum nb_event event,
 		vrfname = yang_dnode_get_string(dnode->parent->parent, "./vrf");
 		vrf = vrf_lookup_by_name(vrfname);
 		assert(vrf);
-		ifp = if_lookup_by_name(ifname, vrf->vrf_id);
+		ifp = if_lookup_by_name(ifname, vrf);
 		if (!ifp)
 			return NB_OK;
 		circuit = circuit_lookup_by_ifp(ifp, isis->init_circ_list);
@@ -1612,7 +1612,7 @@ static int lib_interface_isis_circuit_type_modify(enum nb_event event,
 		vrfname = yang_dnode_get_string(dnode->parent->parent, "./vrf");
 		vrf = vrf_lookup_by_name(vrfname);
 		assert(vrf);
-		ifp = if_lookup_by_name(ifname, vrf->vrf_id);
+		ifp = if_lookup_by_name(ifname, vrf);
 		if (!ifp)
 			break;
 		circuit = circuit_lookup_by_ifp(ifp, isis->init_circ_list);

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -1199,7 +1199,7 @@ DEFUN (show_isis_mpls_te_interface,
 	/* Interface name is specified. */
 	else {
 		if ((ifp = if_lookup_by_name(argv[idx_interface]->arg,
-					     VRF_DEFAULT))
+					     vrf_lookup_by_id(VRF_DEFAULT)))
 		    == NULL)
 			vty_out(vty, "No such interface name\n");
 		else

--- a/lib/if.c
+++ b/lib/if.c
@@ -177,6 +177,8 @@ void if_update_to_new_vrf(struct interface *ifp, vrf_id_t vrf_id)
 	if (ifp->ifindex != IFINDEX_INTERNAL)
 		IFINDEX_RB_INSERT(vrf, ifp);
 
+	if (!old_vrf->name)
+		return;
 	/*
 	 * HACK: Change the interface VRF in the running configuration directly,
 	 * bypassing the northbound layer. This is necessary to avoid deleting

--- a/lib/if.c
+++ b/lib/if.c
@@ -132,9 +132,8 @@ static int if_cmp_index_func(const struct interface *ifp1,
 }
 
 /* Create new interface structure. */
-struct interface *if_create(const char *name, vrf_id_t vrf_id)
+struct interface *if_create(const char *name, struct vrf *vrf)
 {
-	struct vrf *vrf = vrf_get(vrf_id, NULL);
 	struct interface *ifp;
 
 	ifp = XCALLOC(MTYPE_IF, sizeof(struct interface));
@@ -142,7 +141,7 @@ struct interface *if_create(const char *name, vrf_id_t vrf_id)
 
 	assert(name);
 	strlcpy(ifp->name, name, sizeof(ifp->name));
-	ifp->vrf_id = vrf_id;
+	ifp->vrf_id = vrf->vrf_id;
 	IFNAME_RB_INSERT(vrf, ifp);
 	ifp->connected = list_new();
 	ifp->connected->del = (void (*)(void *))connected_free;
@@ -398,7 +397,7 @@ struct interface *if_get_by_name(const char *name, struct vrf *vrf)
 		ifp = if_lookup_by_name(name, vrf->vrf_id);
 		if (ifp)
 			return ifp;
-		return if_create(name, vrf->vrf_id);
+		return if_create(name, vrf);
 	case VRF_BACKEND_VRF_LITE:
 		ifp = if_lookup_by_name_all_vrf(name);
 		if (ifp) {
@@ -410,7 +409,7 @@ struct interface *if_get_by_name(const char *name, struct vrf *vrf)
 			if_update_to_new_vrf(ifp, vrf->vrf_id);
 			return ifp;
 		}
-		return if_create(name, vrf->vrf_id);
+		return if_create(name, vrf);
 	}
 
 	return NULL;

--- a/lib/if.c
+++ b/lib/if.c
@@ -1095,7 +1095,7 @@ DEFPY_NOSH (interface,
 	 * interface is found, then a new one should be created on the default
 	 * VRF.
 	 */
-	VRF_GET_INSTANCE(vrf, vrfname, false);
+	VRF_GET_INSTANCE(vrf, vrfname, false, true);
 	/*
 	 * within vrf context, vrf_id may be unknown
 	 * this happens on daemons relying on zebra

--- a/lib/if.h
+++ b/lib/if.h
@@ -475,7 +475,7 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
  * This is useful for vrf route-leaking.  So more than anything
  * else think before you use VRF_UNKNOWN
  */
-extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
+extern void if_update_to_new_vrf(struct interface *, struct vrf *vrf);
 extern struct interface *if_create(const char *name, struct vrf *vrf);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
 extern struct interface *if_lookup_exact_address(void *matchaddr, int family,

--- a/lib/if.h
+++ b/lib/if.h
@@ -488,7 +488,7 @@ extern struct interface *if_lookup_prefix(struct prefix *prefix,
 /* These 3 functions are to be used when the ifname argument is terminated
    by a '\0' character: */
 extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
-extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
+extern struct interface *if_lookup_by_name(const char *ifname, struct vrf *vrf);
 extern struct interface *if_get_by_name(const char *ifname, struct vrf *vrf);
 extern void if_set_index(struct interface *ifp, ifindex_t ifindex);
 

--- a/lib/if.h
+++ b/lib/if.h
@@ -34,6 +34,8 @@ extern "C" {
 DECLARE_MTYPE(IF)
 DECLARE_MTYPE(CONNECTED_LABEL)
 
+struct vrf;
+
 /* Interface link-layer type, if known. Derived from:
  *
  * net/if_arp.h on various platforms - Linux especially.
@@ -487,7 +489,7 @@ extern struct interface *if_lookup_prefix(struct prefix *prefix,
    by a '\0' character: */
 extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
 extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
-extern struct interface *if_get_by_name(const char *ifname, vrf_id_t vrf_id);
+extern struct interface *if_get_by_name(const char *ifname, struct vrf *vrf);
 extern void if_set_index(struct interface *ifp, ifindex_t ifindex);
 
 /* Delete the interface, but do not free the structure, and leave it in the

--- a/lib/if.h
+++ b/lib/if.h
@@ -476,7 +476,7 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
  * else think before you use VRF_UNKNOWN
  */
 extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
-extern struct interface *if_create(const char *name, vrf_id_t vrf_id);
+extern struct interface *if_create(const char *name, struct vrf *vrf);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
 extern struct interface *if_lookup_exact_address(void *matchaddr, int family,
 						 vrf_id_t vrf_id);

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -114,6 +114,30 @@ extern struct vrf *vrf_get(vrf_id_t, const char *);
 extern const char *vrf_id_to_name(vrf_id_t vrf_id);
 extern vrf_id_t vrf_name_to_id(const char *);
 
+/* vrf context is searched and created
+ */
+#define VRF_GET_INSTANCE(V, NAME, USE_JSON)                                    \
+	do {								       \
+		struct vrf *_vrf;                                              \
+									       \
+		if (!(_vrf = vrf_lookup_by_name(NAME))) {                      \
+			if (USE_JSON) {                                        \
+				vty_out(vty, "{}\n");                          \
+			} else {                                               \
+				vty_out(vty, "%% VRF %s not found\n", NAME);   \
+			}                                                      \
+			return CMD_WARNING;                                    \
+		}                                                              \
+		if (_vrf->vrf_id == VRF_UNKNOWN) {                             \
+			if (USE_JSON) {                                        \
+				vty_out(vty, "{}\n");                          \
+			} else {                                               \
+				vty_out(vty, "%% VRF %s not active\n", NAME);  \
+			}                                                      \
+		}                                                              \
+		(V) = _vrf;						       \
+	} while (0)
+
 #define VRF_GET_ID(V, NAME, USE_JSON)                                          \
 	do {                                                                   \
 		struct vrf *_vrf;                                              \

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -116,17 +116,21 @@ extern vrf_id_t vrf_name_to_id(const char *);
 
 /* vrf context is searched and created
  */
-#define VRF_GET_INSTANCE(V, NAME, USE_JSON)                                    \
+#define VRF_GET_INSTANCE(V, NAME, USE_JSON, FORCE_CREATION)		       \
 	do {								       \
 		struct vrf *_vrf;                                              \
 									       \
 		if (!(_vrf = vrf_lookup_by_name(NAME))) {                      \
-			if (USE_JSON) {                                        \
-				vty_out(vty, "{}\n");                          \
-			} else {                                               \
-				vty_out(vty, "%% VRF %s not found\n", NAME);   \
+			if (!FORCE_CREATION) {   			       \
+				if (USE_JSON) {				       \
+					vty_out(vty, "{}\n");                  \
+				} else {                                       \
+					vty_out(vty, "%% VRF %s not found\n",  \
+						NAME);			       \
+				}                                              \
+				return CMD_WARNING;                            \
 			}                                                      \
-			return CMD_WARNING;                                    \
+			_vrf = vrf_get(VRF_UNKNOWN, NAME);                     \
 		}                                                              \
 		if (_vrf->vrf_id == VRF_UNKNOWN) {                             \
 			if (USE_JSON) {                                        \

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1466,7 +1466,8 @@ struct interface *zebra_interface_state_read(struct stream *s, vrf_id_t vrf_id)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* Lookup this by interface index. */
-	ifp = if_lookup_by_name(ifname_tmp, vrf_id);
+	ifp = if_lookup_by_name(ifname_tmp,
+				vrf_lookup_by_id(vrf_id));
 	if (ifp == NULL) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
 			 "INTERFACE_STATE: Cannot find IF %s in VRF %d",
@@ -1526,7 +1527,8 @@ struct interface *zebra_interface_link_params_read(struct stream *s,
 
 	ifindex = stream_getl(s);
 
-	struct interface *ifp = if_lookup_by_index(ifindex, vrf_id);
+	struct interface *ifp = if_lookup_by_index(ifindex,
+						   vrf_id);
 
 	if (ifp == NULL) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
@@ -1821,7 +1823,8 @@ struct interface *zebra_interface_vrf_update_read(struct stream *s,
 	stream_get(ifname, s, INTERFACE_NAMSIZ);
 
 	/* Lookup interface. */
-	ifp = if_lookup_by_name(ifname, vrf_id);
+	ifp = if_lookup_by_name(ifname,
+				vrf_lookup_by_id(vrf_id));
 	if (ifp == NULL) {
 		flog_err(EC_LIB_ZAPI_ENCODE,
 			 "INTERFACE_VRF_UPDATE: Cannot find IF %s in VRF %d",

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1437,12 +1437,13 @@ struct interface *zebra_interface_add_read(struct stream *s, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
 	char ifname_tmp[INTERFACE_NAMSIZ];
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
 	/* Read interface name. */
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* Lookup/create interface by name. */
-	ifp = if_get_by_name(ifname_tmp, vrf_id);
+	ifp = if_get_by_name(ifname_tmp, vrf);
 
 	zebra_interface_if_set_value(s, ifp);
 

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -126,7 +126,8 @@ static void nhrp_interface_update_nbma(struct interface *ifp)
 	sockunion_family(&nbma) = AF_UNSPEC;
 
 	if (nifp->source)
-		nbmaifp = if_lookup_by_name(nifp->source, VRF_DEFAULT);
+		nbmaifp = if_lookup_by_name(nifp->source,
+					    vrf_lookup_by_id(VRF_DEFAULT));
 
 	switch (ifp->ll_type) {
 	case ZEBRA_LLT_IPGRE: {

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1404,7 +1404,8 @@ ospf6_routemap_rule_match_interface(void *rule, const struct prefix *prefix,
 
 	if (type == RMAP_OSPF6) {
 		ei = ((struct ospf6_route *)object)->route_option;
-		ifp = if_lookup_by_name((char *)rule, VRF_DEFAULT);
+		ifp = if_lookup_by_name((char *)rule,
+					vrf_lookup_by_id(VRF_DEFAULT));
 
 		if (ifp != NULL && ei->ifindex == ifp->ifindex)
 			return RMAP_MATCH;

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -996,7 +996,8 @@ DEFUN (show_ipv6_ospf6_interface,
 	struct interface *ifp;
 
 	if (argc == 5) {
-		ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+		ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+					vrf_lookup_by_id(VRF_DEFAULT));
 		if (ifp == NULL) {
 			vty_out(vty, "No such Interface: %s\n",
 				argv[idx_ifname]->arg);
@@ -1081,7 +1082,8 @@ DEFUN (show_ipv6_ospf6_interface_traffic,
 
 	if (argv_find(argv, argc, "IFNAME", &idx_ifname)) {
 		intf_name = argv[idx_ifname]->arg;
-		ifp = if_lookup_by_name(intf_name, VRF_DEFAULT);
+		ifp = if_lookup_by_name(intf_name,
+					vrf_lookup_by_id(VRF_DEFAULT));
 		if (ifp == NULL) {
 			vty_out(vty, "No such Interface: %s\n", intf_name);
 			return CMD_WARNING;
@@ -1125,7 +1127,8 @@ DEFUN (show_ipv6_ospf6_interface_ifname_prefix,
 	struct interface *ifp;
 	struct ospf6_interface *oi;
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+				vrf_lookup_by_id(VRF_DEFAULT));
 	if (ifp == NULL) {
 		vty_out(vty, "No such Interface: %s\n", argv[idx_ifname]->arg);
 		return CMD_WARNING;
@@ -2026,7 +2029,7 @@ DEFUN (clear_ipv6_ospf6_interface,
 	} else /* Interface name is specified. */
 	{
 		if ((ifp = if_lookup_by_name(argv[idx_ifname]->arg,
-					     VRF_DEFAULT))
+					     vrf_lookup_by_id(VRF_DEFAULT)))
 		    == NULL) {
 			vty_out(vty, "No such Interface: %s\n",
 				argv[idx_ifname]->arg);

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -715,7 +715,8 @@ DEFUN (no_ospf6_interface_area,
 	struct interface *ifp;
 	uint32_t area_id;
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+				vrf_lookup_by_id(VRF_DEFAULT));
 	if (ifp == NULL) {
 		vty_out(vty, "No such interface %s\n", argv[idx_ifname]->arg);
 		return CMD_SUCCESS;

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -654,9 +654,10 @@ DEFUN (ospf6_interface_area,
 	struct ospf6_interface *oi;
 	struct interface *ifp;
 	uint32_t area_id;
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	/* find/create ospf6 interface */
-	ifp = if_get_by_name(argv[idx_ifname]->arg, VRF_DEFAULT);
+	ifp = if_get_by_name(argv[idx_ifname]->arg, vrf);
 	oi = (struct ospf6_interface *)ifp->info;
 	if (oi == NULL)
 		oi = ospf6_interface_create(ifp);

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -838,6 +838,7 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 	struct in_addr area_id;
 	struct connected *co;
 	struct prefix_ipv4 *p;
+	struct vrf *vrf;
 
 	if (IS_DEBUG_OSPF_EVENT)
 		zlog_debug("ospf_vl_new(): Start");
@@ -855,7 +856,8 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 			ospf->vrf_id);
 
 	snprintf(ifname, sizeof(ifname), "VLINK%u", vlink_count);
-	vi = if_create(ifname, ospf->vrf_id);
+	vrf = vrf_lookup_by_id(ospf->vrf_id);
+	vi = if_create(ifname, vrf);
 	/*
 	 * if_create sets ZEBRA_INTERFACE_LINKDETECTION
 	 * virtual links don't need this.

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -2568,7 +2568,7 @@ DEFUN (show_ip_ospf_mpls_te_link,
 	if (idx_interface) {
 		ifp = if_lookup_by_name(
 					argv[idx_interface]->arg,
-					ospf->vrf_id);
+					vrf_lookup_by_id(ospf->vrf_id));
 		if (ifp == NULL) {
 			vty_out(vty, "No such interface name in vrf %s\n",
 				vrf->name);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -457,13 +457,14 @@ DEFUN (ospf_passive_interface,
 	int ret;
 	struct ospf_if_params *params;
 	struct route_node *rn;
+	struct vrf *vrf = vrf_lookup_by_id(ospf->vrf_id);
 
 	if (strmatch(argv[1]->text, "default")) {
 		ospf_passive_interface_default(ospf, OSPF_IF_PASSIVE);
 		return CMD_SUCCESS;
 	}
 	if (ospf->vrf_id != VRF_UNKNOWN)
-		ifp = if_get_by_name(argv[1]->arg, ospf->vrf_id);
+		ifp = if_get_by_name(argv[1]->arg, vrf);
 
 	if (ifp == NULL) {
 		vty_out(vty, "interface %s not found.\n", (char *)argv[1]->arg);
@@ -529,6 +530,7 @@ DEFUN (no_ospf_passive_interface,
 	struct ospf_if_params *params;
 	int ret;
 	struct route_node *rn;
+	struct vrf *vrf = vrf_lookup_by_id(ospf->vrf_id);
 
 	if (strmatch(argv[2]->text, "default")) {
 		ospf_passive_interface_default(ospf, OSPF_IF_ACTIVE);
@@ -536,7 +538,7 @@ DEFUN (no_ospf_passive_interface,
 	}
 
 	if (ospf->vrf_id != VRF_UNKNOWN)
-		ifp = if_get_by_name(argv[2]->arg, ospf->vrf_id);
+		ifp = if_get_by_name(argv[2]->arg, vrf);
 
 	if (ifp == NULL) {
 		vty_out(vty, "interface %s not found.\n", (char *)argv[2]->arg);

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3741,7 +3741,8 @@ static int show_ip_ospf_interface_common(struct vty *vty, struct ospf *ospf,
 					       json_interface);
 	} else {
 		/* Interface name is specified. */
-		ifp = if_lookup_by_name(intf_name, ospf->vrf_id);
+		ifp = if_lookup_by_name(intf_name,
+					vrf_lookup_by_id(ospf->vrf_id));
 		if (ifp == NULL) {
 			if (use_json)
 				json_object_boolean_true_add(json_vrf,
@@ -3881,7 +3882,8 @@ static int show_ip_ospf_interface_traffic_common(
 		}
 	} else {
 		/* Interface name is specified. */
-		ifp = if_lookup_by_name(intf_name, ospf->vrf_id);
+		ifp = if_lookup_by_name(intf_name,
+					vrf_lookup_by_id(ospf->vrf_id));
 		if (ifp != NULL) {
 			struct route_node *rn;
 			struct ospf_interface *oi;
@@ -4691,7 +4693,8 @@ static int show_ip_ospf_neighbor_int_common(struct vty *vty, struct ospf *ospf,
 
 	ospf_show_vrf_name(ospf, vty, json, use_vrf);
 
-	ifp = if_lookup_by_name(argv[arg_base]->arg, ospf->vrf_id);
+	ifp = if_lookup_by_name(argv[arg_base]->arg,
+				vrf_lookup_by_id(ospf->vrf_id));
 	if (!ifp) {
 		if (use_json)
 			json_object_boolean_true_add(json, "noSuchIface");
@@ -4759,7 +4762,8 @@ DEFUN (show_ip_ospf_neighbor_int,
 
 	argv_find(argv, argc, "IFNAME", &idx_ifname);
 
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+				vrf_lookup_by_id(vrf_id));
 	if (!ifp)
 		return ret;
 
@@ -5576,7 +5580,8 @@ static int show_ip_ospf_neighbor_int_detail_common(struct vty *vty,
 			vty_out(vty, "\nOSPF Instance: %d\n\n", ospf->instance);
 	}
 
-	ifp = if_lookup_by_name(argv[arg_base]->arg, ospf->vrf_id);
+	ifp = if_lookup_by_name(argv[arg_base]->arg,
+				vrf_lookup_by_id(ospf->vrf_id));
 	if (!ifp) {
 		if (!use_json)
 			vty_out(vty, "No such interface.\n");
@@ -10684,7 +10689,8 @@ DEFUN (clear_ip_ospf_interface,
 		}
 	} else {
 		/* Interface name is specified. */
-		ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
+		ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+					vrf_lookup_by_id(vrf_id));
 		if (ifp == NULL)
 			vty_out(vty, "No such interface name\n");
 		else

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -178,7 +178,8 @@ static struct interface *zebra_interface_if_lookup(struct stream *s,
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, vrf_id);
+	return if_lookup_by_name(ifname_tmp,
+				 vrf_lookup_by_id(vrf_id));
 }
 
 static int ospf_interface_state_up(int command, struct zclient *zclient,

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -375,7 +375,7 @@ static int ospf_interface_vrf_update(int command, struct zclient *zclient,
 			ospf_vrf_id_to_name(new_vrf_id), new_vrf_id);
 
 	/*if_update(ifp, ifp->name, strlen(ifp->name), new_vrf_id);*/
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, vrf_lookup_by_id(new_vrf_id));
 
 	return 0;
 }

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6670,7 +6670,7 @@ DEFUN (interface_ip_mroute,
 	pim = pim_ifp->pim;
 
 	oifname = argv[idx_interface]->arg;
-	oif = if_lookup_by_name(oifname, pim->vrf_id);
+	oif = if_lookup_by_name(oifname, pim->vrf);
 	if (!oif) {
 		vty_out(vty, "No such interface name %s\n", oifname);
 		return CMD_WARNING;
@@ -6721,7 +6721,7 @@ DEFUN (interface_ip_mroute_source,
 	pim = pim_ifp->pim;
 
 	oifname = argv[idx_interface]->arg;
-	oif = if_lookup_by_name(oifname, pim->vrf_id);
+	oif = if_lookup_by_name(oifname, pim->vrf);
 	if (!oif) {
 		vty_out(vty, "No such interface name %s\n", oifname);
 		return CMD_WARNING;
@@ -6776,7 +6776,7 @@ DEFUN (interface_no_ip_mroute,
 	pim = pim_ifp->pim;
 
 	oifname = argv[idx_interface]->arg;
-	oif = if_lookup_by_name(oifname, pim->vrf_id);
+	oif = if_lookup_by_name(oifname, pim->vrf);
 	if (!oif) {
 		vty_out(vty, "No such interface name %s\n", oifname);
 		return CMD_WARNING;
@@ -6828,7 +6828,7 @@ DEFUN (interface_no_ip_mroute_source,
 	pim = pim_ifp->pim;
 
 	oifname = argv[idx_interface]->arg;
-	oif = if_lookup_by_name(oifname, pim->vrf_id);
+	oif = if_lookup_by_name(oifname, pim->vrf);
 	if (!oif) {
 		vty_out(vty, "No such interface name %s\n", oifname);
 		return CMD_WARNING;

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1466,7 +1466,7 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 			snprintf(pimreg_name, sizeof(pimreg_name), "pimreg%u",
 				 pim->vrf->data.l.table_id);
 
-		pim->regiface = if_create(pimreg_name, pim->vrf_id);
+		pim->regiface = if_create(pimreg_name, pim->vrf);
 		pim->regiface->ifindex = PIM_OIF_PIM_REGISTER_VIF;
 
 		pim_if_new(pim->regiface, false, false, true);

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -888,9 +888,9 @@ struct in_addr pim_find_primary_addr(struct interface *ifp)
 		struct interface *lo_ifp;
 		// DBS - Come back and check here
 		if (ifp->vrf_id == VRF_DEFAULT)
-			lo_ifp = if_lookup_by_name("lo", vrf->vrf_id);
+			lo_ifp = if_lookup_by_name("lo", vrf);
 		else
-			lo_ifp = if_lookup_by_name(vrf->name, vrf->vrf_id);
+			lo_ifp = if_lookup_by_name(vrf->name, vrf);
 
 		if (lo_ifp)
 			return pim_find_primary_addr(lo_ifp);

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -158,7 +158,7 @@ int pim_msdp_sock_listen(struct pim_instance *pim)
 
 	if (pim->vrf_id != VRF_DEFAULT) {
 		struct interface *ifp =
-			if_lookup_by_name(pim->vrf->name, pim->vrf_id);
+			if_lookup_by_name(pim->vrf->name, pim->vrf);
 		if (!ifp) {
 			flog_err(EC_LIB_INTERFACE,
 				 "%s: Unable to lookup vrf interface: %s",
@@ -239,7 +239,7 @@ int pim_msdp_sock_connect(struct pim_msdp_peer *mp)
 
 	if (mp->pim->vrf_id != VRF_DEFAULT) {
 		struct interface *ifp =
-			if_lookup_by_name(mp->pim->vrf->name, mp->pim->vrf_id);
+			if_lookup_by_name(mp->pim->vrf->name, mp->pim->vrf);
 		if (!ifp) {
 			flog_err(EC_LIB_INTERFACE,
 				 "%s: Unable to lookup vrf interface: %s",

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -286,7 +286,7 @@ static int pim_zebra_interface_vrf_update(int command, struct zclient *zclient,
 			   __PRETTY_FUNCTION__,
 			   ifp->name, vrf_id, new_vrf_id);
 
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, vrf_lookup_by_id(new_vrf_id));
 
 	return 0;
 }

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -204,11 +204,12 @@ static int pim_zebra_if_state_up(int command, struct zclient *zclient,
 	 */
 	if (sscanf(ifp->name, "pimreg%" SCNu32, &table_id) == 1) {
 		struct vrf *vrf;
+
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 			if ((table_id == vrf->data.l.table_id)
 			    && (ifp->vrf_id != vrf->vrf_id)) {
 				struct interface *master = if_lookup_by_name(
-					vrf->name, vrf->vrf_id);
+							     vrf->name, vrf);
 
 				if (!master) {
 					zlog_debug(

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -473,17 +473,20 @@ int rip_interface_vrf_update(int command, struct zclient *zclient,
 {
 	struct interface *ifp;
 	vrf_id_t new_vrf_id;
+	struct vrf *new_vrf;
 
 	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrf_id,
 					      &new_vrf_id);
 	if (!ifp)
 		return 0;
 
+	new_vrf = vrf_lookup_by_id(new_vrf_id);
+
 	if (IS_RIP_DEBUG_ZEBRA)
 		zlog_debug("interface %s VRF change vrf_id %u new vrf id %u",
 			   ifp->name, vrf_id, new_vrf_id);
 
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, new_vrf);
 	rip_interface_sync(ifp);
 
 	return 0;

--- a/ripd/rip_routemap.c
+++ b/ripd/rip_routemap.c
@@ -106,7 +106,8 @@ static route_map_result_t route_match_interface(void *rule,
 
 	if (type == RMAP_RIP) {
 		ifname = rule;
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifname,
+					vrf_lookup_by_id(VRF_DEFAULT));
 
 		if (!ifp)
 			return RMAP_NOMATCH;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3299,7 +3299,7 @@ static void rip_distribute_update(struct distribute_ctx *ctx,
 	if (!ctx->vrf || !dist->ifname)
 		return;
 
-	ifp = if_lookup_by_name(dist->ifname, ctx->vrf->vrf_id);
+	ifp = if_lookup_by_name(dist->ifname, ctx->vrf);
 	if (ifp == NULL)
 		return;
 
@@ -3418,7 +3418,7 @@ static void rip_if_rmap_update(struct if_rmap_ctx *ctx,
 	if (ctx->name)
 		vrf = vrf_lookup_by_name(ctx->name);
 	if (vrf)
-		ifp = if_lookup_by_name(if_rmap->ifname, vrf->vrf_id);
+		ifp = if_lookup_by_name(if_rmap->ifname, vrf);
 	if (ifp == NULL)
 		return;
 

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -318,17 +318,20 @@ int ripng_interface_vrf_update(int command, struct zclient *zclient,
 {
 	struct interface *ifp;
 	vrf_id_t new_vrf_id;
+	struct vrf *new_vrf;
 
 	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrf_id,
 					      &new_vrf_id);
 	if (!ifp)
 		return 0;
 
+	new_vrf = vrf_lookup_by_id(new_vrf_id);
+
 	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug("interface %s VRF change vrf_id %u new vrf id %u",
 			   ifp->name, vrf_id, new_vrf_id);
 
-	if_update_to_new_vrf(ifp, new_vrf_id);
+	if_update_to_new_vrf(ifp, new_vrf);
 	ripng_interface_sync(ifp);
 
 	return 0;

--- a/ripngd/ripng_routemap.c
+++ b/ripngd/ripng_routemap.c
@@ -97,7 +97,8 @@ static route_map_result_t route_match_interface(void *rule,
 
 	if (type == RMAP_RIPNG) {
 		ifname = rule;
-		ifp = if_lookup_by_name(ifname, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifname,
+					vrf_lookup_by_id(VRF_DEFAULT));
 
 		if (!ifp)
 			return RMAP_NOMATCH;

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2454,7 +2454,7 @@ static void ripng_distribute_update(struct distribute_ctx *ctx,
 	if (!ctx->vrf || !dist->ifname)
 		return;
 
-	ifp = if_lookup_by_name(dist->ifname, ctx->vrf->vrf_id);
+	ifp = if_lookup_by_name(dist->ifname, ctx->vrf);
 	if (ifp == NULL)
 		return;
 
@@ -2571,7 +2571,7 @@ static void ripng_if_rmap_update(struct if_rmap_ctx *ctx,
 	if (ctx->name)
 		vrf = vrf_lookup_by_name(ctx->name);
 	if (vrf)
-		ifp = if_lookup_by_name(if_rmap->ifname, vrf->vrf_id);
+		ifp = if_lookup_by_name(if_rmap->ifname, vrf);
 	if (ifp == NULL)
 		return;
 

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -46,7 +46,7 @@ struct zclient *zclient = NULL;
 /* For registering threads. */
 extern struct thread_master *master;
 
-static struct interface *zebra_interface_if_lookup(struct stream *s)
+static struct interface *zebra_interface_if_lookup(struct stream *s, vrf_id_t vrf_id)
 {
 	char ifname_tmp[INTERFACE_NAMSIZ];
 
@@ -54,7 +54,8 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, VRF_DEFAULT);
+	return if_lookup_by_name(ifname_tmp,
+				 vrf_lookup_by_id(vrf_id));
 }
 
 /* Inteface addition message from zebra. */
@@ -117,7 +118,7 @@ static int interface_state_up(int command, struct zclient *zclient,
 			      zebra_size_t length, vrf_id_t vrf_id)
 {
 
-	zebra_interface_if_lookup(zclient->ibuf);
+	zebra_interface_if_lookup(zclient->ibuf, vrf_id);
 
 	return 0;
 }

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -187,7 +187,7 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 	else {
 		struct interface *ifp;
 
-		ifp = if_lookup_by_name(ifname, nh_svrf->vrf->vrf_id);
+		ifp = if_lookup_by_name(ifname, nh_svrf->vrf);
 		if (ifp && ifp->ifindex != IFINDEX_INTERNAL) {
 			si->ifindex = ifp->ifindex;
 			static_install_route(rn, si, safi);
@@ -331,8 +331,7 @@ static void static_fixup_vrf(struct static_vrf *svrf,
 			si->nh_vrf_id = svrf->vrf->vrf_id;
 			si->nh_registered = false;
 			if (si->ifindex) {
-				ifp = if_lookup_by_name(si->ifname,
-							si->nh_vrf_id);
+				ifp = if_lookup_by_name(si->ifname, svrf->vrf);
 				if (ifp)
 					si->ifindex = ifp->ifindex;
 				else
@@ -367,7 +366,8 @@ static void static_enable_vrf(struct static_vrf *svrf,
 			si->vrf_id = vrf->vrf_id;
 			if (si->ifindex) {
 				ifp = if_lookup_by_name(si->ifname,
-							si->nh_vrf_id);
+							vrf_lookup_by_id(
+							 si->nh_vrf_id));
 				if (ifp)
 					si->ifindex = ifp->ifindex;
 				else

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -47,7 +47,7 @@
 struct zclient *zclient;
 static struct hash *static_nht_hash;
 
-static struct interface *zebra_interface_if_lookup(struct stream *s)
+static struct interface *zebra_interface_if_lookup(struct stream *s, vrf_id_t vrf_id)
 {
 	char ifname_tmp[INTERFACE_NAMSIZ];
 
@@ -55,7 +55,8 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
 
 	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, VRF_DEFAULT);
+	return if_lookup_by_name(ifname_tmp,
+				 vrf_lookup_by_id(vrf_id));
 }
 
 /* Inteface addition message from zebra. */
@@ -120,7 +121,7 @@ static int interface_state_up(int command, struct zclient *zclient,
 {
 	struct interface *ifp;
 
-	ifp = zebra_interface_if_lookup(zclient->ibuf);
+	ifp = zebra_interface_if_lookup(zclient->ibuf, vrf_id);
 
 	if (ifp) {
 		if (if_is_vrf(ifp)) {

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -54,6 +54,7 @@ static int interface_list_ioctl(void)
 	struct interface *ifp;
 	int n;
 	int lastlen;
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	/* Normally SIOCGIFCONF works with AF_INET socket. */
 	sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -110,7 +111,7 @@ static int interface_list_ioctl(void)
 		unsigned int size;
 
 		ifreq = (struct ifreq *)((caddr_t)ifconf.ifc_req + n);
-		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT);
+		ifp = if_get_by_name(ifreq->ifr_name, vrf);
 		if_add_update(ifp);
 		size = ifreq->ifr_addr.sa_len;
 		if (size < sizeof(ifreq->ifr_addr))
@@ -120,7 +121,7 @@ static int interface_list_ioctl(void)
 	}
 #else
 	for (n = 0; n < ifconf.ifc_len; n += sizeof(struct ifreq)) {
-		ifp = if_get_by_name(ifreq->ifr_name, VRF_DEFAULT);
+		ifp = if_get_by_name(ifreq->ifr_name, vrf);
 		if_add_update(ifp);
 		ifreq++;
 	}

--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -196,7 +196,8 @@ static int if_getaddrs(void)
 			continue;
 		}
 
-		ifp = if_lookup_by_name(ifap->ifa_name, VRF_DEFAULT);
+		ifp = if_lookup_by_name(ifap->ifa_name,
+					vrf_lookup_by_id(VRF_DEFAULT));
 		if (ifp == NULL) {
 			flog_err(EC_LIB_INTERFACE,
 				 "if_getaddrs(): Can't lookup interface %s\n",

--- a/zebra/if_ioctl_solaris.c
+++ b/zebra/if_ioctl_solaris.c
@@ -59,6 +59,7 @@ static int interface_list_ioctl(int af)
 	int n;
 	size_t needed, lastneeded = 0;
 	char *buf = NULL;
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	frr_elevate_privs(&zserv_privs) {
 		sock = socket(af, SOCK_DGRAM, 0);
@@ -156,7 +157,7 @@ calculate_lifc_len:
 		       && (*(lifreq->lifr_name + normallen) != ':'))
 			normallen++;
 
-		ifp = if_get_by_name(lifreq->lifr_name, VRF_DEFAULT);
+		ifp = if_get_by_name(lifreq->lifr_name, vrf);
 
 		if (lifreq->lifr_addr.ss_family == AF_INET)
 			ifp->flags |= IFF_IPV4;

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -593,6 +593,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	ifindex_t link_ifindex = IFINDEX_INTERNAL;
 	ifindex_t bond_ifindex = IFINDEX_INTERNAL;
 	struct zebra_if *zif;
+	struct vrf *vrf;
 
 	zns = zebra_ns_lookup(ns_id);
 	ifi = NLMSG_DATA(h);
@@ -672,12 +673,14 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (vrf_is_backend_netns())
 		vrf_id = (vrf_id_t)ns_id;
 
+	vrf = vrf_lookup_by_id(vrf_id);
+
 	/* If linking to another interface, note it. */
 	if (tb[IFLA_LINK])
 		link_ifindex = *(ifindex_t *)RTA_DATA(tb[IFLA_LINK]);
 
 	/* Add interface. */
-	ifp = if_get_by_name(name, vrf_id);
+	ifp = if_get_by_name(name, vrf);
 	set_ifindex(ifp, ifi->ifi_index, zns);
 	ifp->flags = ifi->ifi_flags & 0x0000fffff;
 	ifp->mtu6 = ifp->mtu = *(uint32_t *)RTA_DATA(tb[IFLA_MTU]);
@@ -1113,7 +1116,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	ifindex_t bond_ifindex = IFINDEX_INTERNAL;
 	ifindex_t link_ifindex = IFINDEX_INTERNAL;
 	uint8_t old_hw_addr[INTERFACE_HWADDR_MAX];
-
+	struct vrf *vrf;
 
 	zns = zebra_ns_lookup(ns_id);
 	ifi = NLMSG_DATA(h);
@@ -1220,6 +1223,9 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		}
 		if (vrf_is_backend_netns())
 			vrf_id = (vrf_id_t)ns_id;
+
+		vrf = vrf_lookup_by_id(vrf_id);
+
 		if (ifp == NULL
 		    || !CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
 			/* Add interface notification from kernel */
@@ -1233,7 +1239,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 			if (ifp == NULL) {
 				/* unknown interface */
-				ifp = if_get_by_name(name, vrf_id);
+				ifp = if_get_by_name(name, vrf);
 			} else {
 				/* pre-configured interface, learnt now */
 				if (ifp->vrf_id != vrf_id)

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1243,7 +1243,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			} else {
 				/* pre-configured interface, learnt now */
 				if (ifp->vrf_id != vrf_id)
-					if_update_to_new_vrf(ifp, vrf_id);
+					if_update_to_new_vrf(ifp, vrf);
 			}
 
 			/* Update interface information. */

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -660,6 +660,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		    && !vrf_is_backend_netns()) {
 			zif_slave_type = ZEBRA_IF_SLAVE_VRF;
 			vrf_id = *(uint32_t *)RTA_DATA(tb[IFLA_MASTER]);
+			/* vrf can be needed before vrf netlink discovery */
+			vrf_get(vrf_id, NULL);
 		} else if (slave_kind && (strcmp(slave_kind, "bridge") == 0)) {
 			zif_slave_type = ZEBRA_IF_SLAVE_BRIDGE;
 			bridge_ifindex =
@@ -672,9 +674,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	}
 	if (vrf_is_backend_netns())
 		vrf_id = (vrf_id_t)ns_id;
-
 	vrf = vrf_lookup_by_id(vrf_id);
-
 	/* If linking to another interface, note it. */
 	if (tb[IFLA_LINK])
 		link_ifindex = *(ifindex_t *)RTA_DATA(tb[IFLA_LINK]);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1577,7 +1577,7 @@ DEFPY(show_interface, show_interface_cmd,
 	interface_update_stats();
 
 	if (name)
-		VRF_GET_INSTANCE(vrf, name, false);
+		VRF_GET_INSTANCE(vrf, name, false, false);
 
 	/* All interface print. */
 	if (brief) {
@@ -1630,7 +1630,7 @@ DEFUN (show_interface_name_vrf,
 
 	interface_update_stats();
 
-	VRF_GET_INSTANCE(vrf, argv[idx_name]->arg, false);
+	VRF_GET_INSTANCE(vrf, argv[idx_name]->arg, false, false);
 
 	/* Specified interface print. */
 	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf);
@@ -1723,7 +1723,7 @@ DEFUN (show_interface_desc,
 	struct vrf *vrf;
 
 	if (argc > 3)
-		VRF_GET_INSTANCE(vrf, argv[4]->arg, false);
+		VRF_GET_INSTANCE(vrf, argv[4]->arg, false, false);
 	else
 		vrf = vrf_lookup_by_id(VRF_DEFAULT);
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -763,6 +763,7 @@ void if_delete_update(struct interface *ifp)
 void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
 {
 	vrf_id_t old_vrf_id;
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
 	old_vrf_id = ifp->vrf_id;
 
@@ -780,7 +781,7 @@ void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
 	zebra_interface_vrf_update_del(ifp, vrf_id);
 
 	/* update VRF */
-	if_update_to_new_vrf(ifp, vrf_id);
+	if_update_to_new_vrf(ifp, vrf);
 
 	/* Send out notification on interface VRF change. */
 	/* This is to issue an ADD, if needed. */

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1635,7 +1635,8 @@ DEFUN (show_interface_name_vrf,
 	VRF_GET_ID(vrf_id, argv[idx_name]->arg, false);
 
 	/* Specified interface print. */
-	ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf_id);
+	ifp = if_lookup_by_name(argv[idx_ifname]->arg,
+				vrf_lookup_by_id(vrf_id));
 	if (ifp == NULL) {
 		vty_out(vty, "%% Can't find interface %s\n",
 			argv[idx_ifname]->arg);
@@ -1665,7 +1666,7 @@ DEFUN (show_interface_name_vrf_all,
 	/* All interface print. */
 	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
 		/* Specified interface print. */
-		ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf->vrf_id);
+		ifp = if_lookup_by_name(argv[idx_ifname]->arg, vrf);
 		if (ifp) {
 			if_dump_vty(vty, ifp);
 			found++;

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -434,6 +434,7 @@ static void rtm_flag_dump(int flag)
 static int ifan_read(struct if_announcemsghdr *ifan)
 {
 	struct interface *ifp;
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	ifp = if_lookup_by_index(ifan->ifan_index, VRF_DEFAULT);
 
@@ -449,7 +450,7 @@ static int ifan_read(struct if_announcemsghdr *ifan)
 				__func__, ifan->ifan_index, ifan->ifan_name);
 
 		/* Create Interface */
-		ifp = if_get_by_name(ifan->ifan_name, VRF_DEFAULT);
+		ifp = if_get_by_name(ifan->ifan_name, vrf);
 		if_set_index(ifp, ifan->ifan_index);
 
 		if_get_metric(ifp);

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -529,6 +529,7 @@ int ifm_read(struct if_msghdr *ifm)
 	int maskbit;
 	caddr_t cp;
 	char fbuf[64];
+	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 
 	/* terminate ifname at head (for strnlen) and tail (for safety) */
 	ifname[IFNAMSIZ - 1] = '\0';
@@ -643,7 +644,7 @@ int ifm_read(struct if_msghdr *ifm)
 		if (ifp == NULL) {
 			/* Interface that zebra was not previously aware of, so
 			 * create. */
-			ifp = if_create(ifname, VRF_DEFAULT);
+			ifp = if_create(ifname, vrf);
 			if (IS_ZEBRA_DEBUG_KERNEL)
 				zlog_debug("%s: creating ifp for ifindex %d",
 					   __func__, ifm->ifm_index);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2171,9 +2171,9 @@ static void zread_vrf_label(ZAPI_HANDLER_ARGS)
 	STREAM_GETC(s, ltype);
 
 	if (zvrf->vrf->vrf_id != VRF_DEFAULT)
-		ifp = if_lookup_by_name(zvrf->vrf->name, zvrf->vrf->vrf_id);
+		ifp = if_lookup_by_name(zvrf->vrf->name, zvrf->vrf);
 	else
-		ifp = if_lookup_by_name("lo", VRF_DEFAULT);
+		ifp = if_lookup_by_name("lo", vrf_lookup_by_id(VRF_DEFAULT));
 
 	if (!ifp) {
 		zlog_debug("Unable to find specified Interface for %s",

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -941,10 +941,9 @@ DEFPY (show_route_table_vrf,
 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
 	struct zebra_vrf *zvrf;
 	struct route_table *t;
-	vrf_id_t vrf_id = VRF_DEFAULT;
+	vrf_id_t vrf_id;
 
-	if (vrf_name)
-		VRF_GET_ID(vrf_id, vrf_name, !!json);
+	VRF_GET_ID(vrf_id, vrf_name, !!json);
 	zvrf = zebra_vrf_lookup_by_id(vrf_id);
 
 	t = zebra_router_find_table(zvrf, table, afi, SAFI_UNICAST);


### PR DESCRIPTION
    in order to benefit from interface creation at startup relying on vrf
    that are not yet known, the vrf creation must be made possible. For
    that:
    - the vrf command is authorised, so as to be able to create vrf
    this is true for each daemon vty, but also from vtysh
    that command must be made possible on all daemons. the reason is that
    from vtysh, if vrf command is refused by at least one daemon, then that
    means the vrf creation will not work, and then it will not be possible
    to access subsequently interface <> vrf <> later.
    - if vrf creation must be made possible from each daemon, the
      running-config should be written. there are two cases:
      o case where vrf is used, and interfaces will be used within the
      configuration. this is true for bgp, ospf. for that it may be
      necessary to have the vrf configuration saved. then a generic write
      function is done that can be used by every daemon that needs to use
      vrf interface configuration.
      o case where vrf is not used. there is no need to save vrf
      configuration in the config. For instance, eigrp or isis, or ldp do
      not need to have that saved in config. a local routine will
      ignore the vrf to display in the configuration.
- also the yang validation is relaxed against vrf with vrf_id set to unknown
