### PR TITLE
FRR: Python script to generate support bundle for FRR

### DIFF
--- a/tools/etc/frr/support_bundle_commands.conf
+++ b/tools/etc/frr/support_bundle_commands.conf
@@ -1,0 +1,83 @@
+# FRR Support Bundle Command List
+# Do Not modify the lines that start with
+# PROC_NAME, CMD_LIST_START and CMD_LIST_END
+# Add the new command for each process between
+# CMD_LIST_START and CMD_LIST_END lines
+
+# BGP Support Bundle Command List
+PROC_NAME:bgp
+CMD_LIST_START
+show bgp summary
+show ip bgp
+show ip bgp neighbors
+show ip bgp summary
+show ip bgp statistics
+
+show ip bgp update-groups advertise-queue
+show ip bgp update-groups advertised-routes
+show ip bgp update-groups packet-queue
+show ip bgp update-groups statistics
+show ip bgp peer-group
+show ip bgp memory
+
+show bgp ipv6
+show bgp ipv6 neighbors
+show bgp ipv6 summary
+show bgp ipv6 update-groups advertise-queue
+show bgp ipv6 update-groups advertised-routes
+show bgp ipv6 update-groups packet-queue
+show bgp ipv6 update-groups statistics
+show ip bgp statistics
+
+show bgp evpn route
+CMD_LIST_END
+
+# Zebra Support Bundle Command List
+PROC_NAME:zebra
+CMD_LIST_START
+show zebra
+show zebra client summary
+show ip route
+
+show route-map
+show memory
+show interface
+show vrf
+show error all
+show work-queues
+show running-config
+show thread cpu
+show thread poll
+show daemons
+show version
+CMD_LIST_END
+
+# OSPF Support Bundle Command List
+# PROC_NAME:ospf
+# CMD_LIST_START
+# CMD_LIST_END
+
+# RIP Support Bundle Command List
+# PROC_NAME:rip
+# CMD_LIST_START
+# CMD_LIST_END
+
+# ISIS Support Bundle Command List
+# PROC_NAME:isis
+# CMD_LIST_START
+# CMD_LIST_END
+
+# BFD Support Bundle Command List
+# PROC_NAME:bfd
+# CMD_LIST_START
+# CMD_LIST_END
+
+# STATIC Support Bundle Command List
+# PROC_NAME:static
+# CMD_LIST_START
+# CMD_LIST_END
+
+# PIM Support Bundle Command List
+# PROC_NAME:pim
+# CMD_LIST_START
+# CMD_LIST_END

--- a/tools/generate_support_bundle.py
+++ b/tools/generate_support_bundle.py
@@ -1,0 +1,110 @@
+########################################################
+### Python Script to generate the FRR support bundle ###
+########################################################
+import os
+import subprocess
+import datetime
+
+TOOLS_DIR="tools/"
+ETC_DIR="/etc/frr/"
+LOG_DIR="/var/log/frr/"
+SUCCESS = 1
+FAIL = 0
+
+inputFile = ETC_DIR + "support_bundle_commands.conf"
+
+# Open support bundle configuration file
+def openConfFile(i_file):
+  try:
+    with open(i_file) as supportBundleConfFile:
+      lines = filter(None, (line.rstrip() for line in supportBundleConfFile))
+    return lines
+  except IOError:
+    return ([])
+
+# Create the output file name
+def createOutputFile(procName):
+  fileName = procName + "_support_bundle.log"
+  oldFile = LOG_DIR + fileName
+  cpFileCmd = "cp " + oldFile + " " + oldFile + ".prev"
+  rmFileCmd = "rm -rf " + oldFile
+  print "Making backup of " + oldFile
+  os.system(cpFileCmd)
+  print "Removing " + oldFile
+  os.system(rmFileCmd)
+  return fileName
+
+# Open the output file for this process
+def openOutputFile(fileName):
+  crt_file_cmd = LOG_DIR + fileName
+  print crt_file_cmd
+  try:
+    outputFile = open(crt_file_cmd, "w")
+    return outputFile
+  except IOError:
+    return ()
+
+# Close the output file for this process
+def closeOutputFile(file):
+  try:
+    file.close()
+    return SUCCESS
+  except IOError:
+    return FAIL
+
+# Execute the command over vtysh and store in the
+# output file
+def executeCommand(cmd, outputFile):
+  cmd_exec_str = "vtysh -c \"" + cmd + "\" "
+  try:
+    cmd_output = subprocess.check_output(cmd_exec_str, shell=True)
+    try:
+      dateTime = datetime.datetime.now()
+      outputFile.write(">>[" + str(dateTime) + "]" + cmd + "\n")
+      outputFile.write(cmd_output)
+      outputFile.write("########################################################\n")
+      outputFile.write('\n')
+    except:
+      print "Writing to ouptut file Failed"
+  except subprocess.CalledProcessError as e:
+    dateTime = datetime.datetime.now()
+    outputFile.write(">>[" + str(dateTime) + "]" + cmd + "\n")
+    outputFile.write(e.output)
+    outputFile.write("########################################################\n")
+    outputFile.write('\n')
+    print "Error:" + e.output
+
+
+# Process the support bundle configuration file
+# and call appropriate functions
+def processConfFile(lines):
+  for line in lines:
+    if line[0][0] == '#':
+      continue
+    cmd_line = line.split(':')
+    if cmd_line[0] == "PROC_NAME":
+      outputFileName = createOutputFile(cmd_line[1])
+      if outputFileName:
+        print outputFileName, "created for", cmd_line[1]
+    elif cmd_line[0] == "CMD_LIST_START":
+      outputFile = openOutputFile(outputFileName)
+      if outputFile:
+        print outputFileName, "opened"
+      else:
+        print outputFileName, "open failed"
+	return FAIL
+    elif cmd_line[0] == "CMD_LIST_END":
+      if closeOutputFile(outputFile):
+        print outputFileName, "closed"
+      else:
+        print outputFileName, "close failed"
+    else:
+      print "Execute:" , cmd_line[0]
+      executeCommand(cmd_line[0], outputFile)
+      
+# Main Function
+lines = openConfFile(inputFile)
+if not lines:
+  print "File support_bundle_commands.conf not present in /etc/frr/ directory"
+else:
+  processConfFile(lines)


### PR DESCRIPTION
This has a python script that helps in collecting various CLI show command outputs in an automated way.

This commit has two files.

1.Text Configuration file: support_bundle_commands.conf - This file has list of CLI show commands to be executed. This file will be in tools/etc/frr/ directory. On executing command "sudo install -m 644 tools/etc/frr/ support_bundle_commands.conf /etc/frr/support_bundle_commands.conf", as part of FRR installation, this file will be copied into /etc/frr directory.

2.Python script file: generate_support_bundle.py - This file has the python code that has the below functionality.
  * It reads the support_bundle_commands.conf file. For each process present in the conf file, it creates a support_bundle file. For example, it creates bgp_support_bundle.log file for BGP and zebra_support_bundle.log file for Zebra. These files will be created in /var/log/frr/ directory. This is where regular FRR log files are also stored currently.
  * The script reads the CLI command specified between CLI_START and CLI_END key words for each process. It will execute the commands one by one.
  * For each such command, the script also appends the current time stamp at which the CLI command is executed.
  * In case of successful execution of the CLI command, it will copy the CLI output into the above support bundle file.
  * In case of CLI command failure, it will capture the error thrown and the error is also written into the same file.
  * A small snippet of the output file is as below.

  >>[2019-01-02 13:55:23.318987]show bgp summary

  IPv4 Unicast Summary:
  BGP router identifier 203.0.113.1, local AS number 65000 vrf-id 0
  BGP table version 4
  RIB entries 7, using 1176 bytes of memory
  Peers 1, using 21 KiB of memory
  Peer groups 1, using 64 bytes of memory

  Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
  203.0.113.2     4      65001      34      34        0    0    0 00:29:47            2

  Total number of neighbors 1
  >>[2019-01-02 13:55:23.619953]show ip bgp

  BGP table version is 4, local router ID is 203.0.113.1, vrf id 0
  Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                 i internal, r RIB-failure, S Stale, R Removed

Signed-off-by: Sri Mohana Singamsetty <msingamsetty@vmware.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]
