### PR TITLE
zebra: unlock route-node in dplane results handler

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1879,6 +1879,8 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 		goto done;
 	}
 
+	route_unlock_node(rn);
+
 	srcdest_rnode_prefixes(rn, &dest_pfx, &src_pfx);
 
 	op = dplane_ctx_get_op(ctx);


### PR DESCRIPTION
We look up a route-node when processing async dataplane results, but we don't unlock/unref it. We need to do that.

### Components
zebra