### PR TITLE
[7.0] zebra: unlock route-node when processing dplane results

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1860,6 +1860,8 @@ static void rib_process_after(struct zebra_dplane_ctx *ctx)
 		goto done;
 	}
 
+	route_unlock_node(rn);
+
 	srcdest_rnode_prefixes(rn, &dest_pfx, &src_pfx);
 
 	op = dplane_ctx_get_op(ctx);


### PR DESCRIPTION
Unlock the route-node datastruct we access while processing
results from the async dataplane. [7.0 version]

### Components
zebra