### PR TITLE
zebra: Prevent crash in dad auto recovery

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -9162,16 +9162,16 @@ static int zebra_vxlan_dad_ip_auto_recovery_exp(struct thread *t)
 	nbr = THREAD_ARG(t);
 
 	/* since this is asynchronous we need sanity checks*/
-	nbr = zvni_neigh_lookup(zvni, &nbr->ip);
-	if (!nbr)
+	zvrf = vrf_info_lookup(nbr->zvni->vrf_id);
+	if (!zvrf)
 		return 0;
 
 	zvni = zvni_lookup(nbr->zvni->vni);
 	if (!zvni)
 		return 0;
 
-	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
-	if (!zvrf)
+	nbr = zvni_neigh_lookup(zvni, &nbr->ip);
+	if (!nbr)
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
@@ -9212,16 +9212,16 @@ static int zebra_vxlan_dad_mac_auto_recovery_exp(struct thread *t)
 	mac = THREAD_ARG(t);
 
 	/* since this is asynchronous we need sanity checks*/
-	mac = zvni_mac_lookup(zvni, &mac->macaddr);
-	if (!mac)
+	zvrf = vrf_info_lookup(mac->zvni->vrf_id);
+	if (!zvrf)
 		return 0;
 
 	zvni = zvni_lookup(mac->zvni->vni);
 	if (!zvni)
 		return 0;
 
-	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
-	if (!zvrf)
+	mac = zvni_mac_lookup(zvni, &mac->macaddr);
+	if (!mac)
 		return 0;
 
 	if (IS_ZEBRA_DEBUG_VXLAN)


### PR DESCRIPTION
Commit: 6005fe55bce1c9cd54f4f7773fc2b0e15a99008f
Introduced a crash with zebra looking up either the
nbr structure or the mac structure.  This is because
the zvni used is NULL and we eventually call a hash_lookup
call that would cause a NULL dereference.  Partially
revert this commit to original behavior.

Problems found via clang Static Analyzer.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

