### PR TITLE
zebra: Fix possible use of NULL re

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1938,8 +1938,10 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 				zlog_debug("%u:%s Stale dplane result for old_re %p",
 					   dplane_ctx_get_vrf(ctx),
 					   dest_str, old_re);
-		} else
-			UNSET_FLAG(re->status, ROUTE_ENTRY_QUEUED);
+		} else {
+			if (re)
+				UNSET_FLAG(re->status, ROUTE_ENTRY_QUEUED);
+		}
 	}
 
 	switch (op) {


### PR DESCRIPTION
There exists a path in rib_process_result that we can use
a re that has not been actually set from it's initial NULL
value.  Just add a quick NULL test before using it.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
