### PR TITLE
ospfd: fix link MTU warning style

### DIFF
--- a/ospfd/ospf_errors.c
+++ b/ospfd/ospf_errors.c
@@ -172,11 +172,8 @@ static struct log_ref ferr_ospf_err[] = {
 	{
 		.code = EC_OSPF_LARGE_HELLO,
 		.title = "OSPF Encountered a Large Hello",
-		.description = "OSPF attempted to send a Hello larger than MTU "
-					   "but did not",
-		.suggestion = "Too many neighbors configured on a single interface."
-					  " Suggestion is to decrease the number of neighbors on"
-					  " a single interface/subnet"
+		.description = "OSPF attempted to send a Hello larger than MTU but did not",
+		.suggestion = "Too many neighbors configured on a single interface. Suggestion is to decrease the number of neighbors on a single interface/subnet"
 	},
 	{
 		.code = END_FERR,

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -3326,8 +3326,7 @@ static int ospf_make_hello(struct ospf_interface *oi, struct stream *s)
 								> ospf_packet_max(oi)) {
 								flog_err(
 									EC_OSPF_LARGE_HELLO,
-									"Oversized Hello packet!"
-									" Larger than MTU. Not sending it out");
+									"Oversized Hello packet! Larger than MTU. Not sending it out");
 								return 0;
 							}
 


### PR DESCRIPTION
Kernel style dictates that we do not break log messages across lines.