### PR TITLE
zebra: replace strncpy with strlcpy

### DIFF
--- a/zebra/if_ioctl.c
+++ b/zebra/if_ioctl.c
@@ -147,7 +147,7 @@ static int if_get_hwaddr(struct interface *ifp)
 	struct ifreq ifreq;
 	int i;
 
-	strncpy(ifreq.ifr_name, ifp->name, IFNAMSIZ);
+	strlcpy(ifreq.ifr_name, ifp->name, sizeof(ifreq.ifr_name));
 	ifreq.ifr_addr.sa_family = AF_INET;
 
 	/* Fetch Hardware address if available. */

--- a/zebra/if_ioctl_solaris.c
+++ b/zebra/if_ioctl_solaris.c
@@ -247,7 +247,8 @@ static int if_get_addr(struct interface *ifp, struct sockaddr *addr,
 	 * We need to use the logical interface name / label, if we've been
 	 * given one, in order to get the right address
 	 */
-	strncpy(lifreq.lifr_name, (label ? label : ifp->name), IFNAMSIZ);
+	strlcpy(lifreq.lifr_name, (label ? label : ifp->name),
+		sizeof(lifreq.lifr_name));
 
 	/* Interface's address. */
 	memcpy(&lifreq.lifr_addr, addr, ADDRLEN(addr));

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -213,7 +213,7 @@ int if_set_prefix(struct interface *ifp, struct connected *ifc)
 	rib_lookup_and_pushup(p, ifp->vrf_id);
 
 	memset(&addreq, 0, sizeof addreq);
-	strncpy((char *)&addreq.ifra_name, ifp->name, sizeof addreq.ifra_name);
+	strlcpy(addreq.ifra_name, ifp->name, sizeof(addreq.ifra_name));
 
 	memset(&addr, 0, sizeof(struct sockaddr_in));
 	addr.sin_addr = p->prefix;
@@ -267,7 +267,7 @@ int if_unset_prefix(struct interface *ifp, struct connected *ifc)
 	p = (struct prefix_ipv4 *)ifc->address;
 
 	memset(&addreq, 0, sizeof addreq);
-	strncpy((char *)&addreq.ifra_name, ifp->name, sizeof addreq.ifra_name);
+	strlcpy(addreq.ifra_name, ifp->name, sizeof(addreq.ifra_name));
 
 	memset(&addr, 0, sizeof(struct sockaddr_in));
 	addr.sin_addr = p->prefix;
@@ -412,7 +412,7 @@ void if_get_flags(struct interface *ifp)
 
 	if (CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_LINKDETECTION)) {
 		(void)memset(&ifmr, 0, sizeof(ifmr));
-		strncpy(ifmr.ifm_name, ifp->name, IFNAMSIZ);
+		strlcpy(ifmr.ifm_name, ifp->name, sizeof(ifmr.ifm_name));
 
 		/* Seems not all interfaces implement this ioctl */
 		if (if_ioctl(SIOCGIFMEDIA, (caddr_t)&ifmr) == -1 &&
@@ -514,7 +514,7 @@ int if_prefix_add_ipv6(struct interface *ifp, struct connected *ifc)
 	p = (struct prefix_ipv6 *)ifc->address;
 
 	memset(&addreq, 0, sizeof addreq);
-	strncpy((char *)&addreq.ifra_name, ifp->name, sizeof addreq.ifra_name);
+	strlcpy(addreq.ifra_name, ifp->name, sizeof(addreq.ifra_name));
 
 	memset(&addr, 0, sizeof(struct sockaddr_in6));
 	addr.sin6_addr = p->prefix;
@@ -557,7 +557,7 @@ int if_prefix_delete_ipv6(struct interface *ifp, struct connected *ifc)
 	p = (struct prefix_ipv6 *)ifc->address;
 
 	memset(&addreq, 0, sizeof addreq);
-	strncpy((char *)&addreq.ifra_name, ifp->name, sizeof addreq.ifra_name);
+	strlcpy(addreq.ifra_name, ifp->name, sizeof(addreq.ifra_name));
 
 	memset(&addr, 0, sizeof(struct sockaddr_in6));
 	addr.sin6_addr = p->prefix;

--- a/zebra/ioctl_solaris.c
+++ b/zebra/ioctl_solaris.c
@@ -44,7 +44,7 @@ extern struct zebra_privs_t zserv_privs;
 /* clear and set interface name string */
 void lifreq_set_name(struct lifreq *lifreq, const char *ifname)
 {
-	strncpy(lifreq->lifr_name, ifname, IFNAMSIZ);
+	strlcpy(lifreq->lifr_name, ifname, sizeof(lifreq->lifr_name));
 }
 
 int vrf_if_ioctl(unsigned long request, caddr_t buffer, vrf_id_t vrf_id)
@@ -199,7 +199,7 @@ int if_set_prefix(struct interface *ifp, struct connected *ifc)
 
 	ifaddr = *p;
 
-	strncpy(ifreq.ifr_name, ifp->name, IFNAMSIZ);
+	strlcpy(ifreq.ifr_name, ifp->name, sizeof(ifreq.ifr_name));
 
 	addr.sin_addr = p->prefix;
 	addr.sin_family = p->family;
@@ -250,7 +250,7 @@ int if_unset_prefix(struct interface *ifp, struct connected *ifc)
 
 	p = (struct prefix_ipv4 *)ifc->address;
 
-	strncpy(ifreq.ifr_name, ifp->name, IFNAMSIZ);
+	strlcpy(ifreq.ifr_name, ifp->name, sizeof(ifreq.ifr_name));
 
 	memset(&addr, 0, sizeof(struct sockaddr_in));
 	addr.sin_family = p->family;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -767,8 +767,7 @@ static void zvni_print_neigh(zebra_neigh_t *n, void *ctxt, json_object *json)
 						n->detect_start_time.tv_sec);
 				char tmp_buf[30];
 
-				memset(tmp_buf, 0, 30);
-				strncpy(tmp_buf, buf, strlen(buf) - 1);
+				strlcpy(tmp_buf, buf, sizeof(tmp_buf));
 				vty_out(vty,
 					" Duplicate detection started at %s, detection count %u\n",
 					tmp_buf, n->dad_count);
@@ -1148,7 +1147,7 @@ static void zvni_print_mac(zebra_mac_t *mac, void *ctxt, json_object *json)
 	struct vty *vty;
 	zebra_neigh_t *n = NULL;
 	struct listnode *node = NULL;
-	char buf1[20];
+	char buf1[ETHER_ADDR_STRLEN];
 	char buf2[INET6_ADDRSTRLEN];
 	struct zebra_vrf *zvrf;
 	struct timeval detect_start_time = {0, 0};
@@ -1289,8 +1288,7 @@ static void zvni_print_mac(zebra_mac_t *mac, void *ctxt, json_object *json)
 						mac->detect_start_time.tv_sec);
 				char tmp_buf[30];
 
-				memset(tmp_buf, 0, 30);
-				strncpy(tmp_buf, buf, strlen(buf) - 1);
+				strlcpy(tmp_buf, buf, sizeof(tmp_buf));
 				vty_out(vty,
 					" Duplicate detection started at %s, detection count %u\n",
 					tmp_buf, mac->dad_count);
@@ -1323,7 +1321,7 @@ static void zvni_print_mac_hash(struct hash_backet *backet, void *ctxt)
 	struct vty *vty;
 	json_object *json_mac_hdr = NULL, *json_mac = NULL;
 	zebra_mac_t *mac;
-	char buf1[20];
+	char buf1[ETHER_ADDR_STRLEN];
 	struct mac_walk_ctx *wctx = ctxt;
 
 	vty = wctx->vty;
@@ -1445,7 +1443,7 @@ static void zvni_print_mac_hash_detail(struct hash_backet *backet, void *ctxt)
 	json_object *json_mac_hdr = NULL;
 	zebra_mac_t *mac;
 	struct mac_walk_ctx *wctx = ctxt;
-	char buf1[20];
+	char buf1[ETHER_ADDR_STRLEN];
 
 	vty = wctx->vty;
 	json_mac_hdr = wctx->json;


### PR DESCRIPTION
* Use strlcpy
* Use the correct buffer sizes for Ethernet address strings
