### PR TITLE
[7.0] ospfd: Allow pre-existing vrf's to work

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -234,8 +234,12 @@ static struct ospf *ospf_new(unsigned short instance, const char *name)
 	new->instance = instance;
 	new->router_id.s_addr = htonl(0);
 	new->router_id_static.s_addr = htonl(0);
-	if (name && !strmatch(name, VRF_DEFAULT_NAME)) {
-		new->vrf_id = VRF_UNKNOWN;
+	if (name) {
+		vrf = vrf_lookup_by_name(name);
+		if (vrf)
+			new->vrf_id = vrf->vrf_id;
+		else
+			new->vrf_id = VRF_UNKNOWN;
 		/* Freed in ospf_finish_final */
 		new->name = XSTRDUP(MTYPE_OSPF_TOP, name);
 		if (IS_DEBUG_OSPF_EVENT)


### PR DESCRIPTION
When creating a ospf vrf based instance allow it to work
if the vrf has been created *before* we create the ospf
instance.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

