### PR TITLE
bgpd: Add peer action for PEER_FLAG_IFPEER_V6ONLY flag

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3811,6 +3811,7 @@ static const struct peer_flag_action peer_flag_action_list[] = {
 	{PEER_FLAG_DISABLE_CONNECTED_CHECK, 0, peer_change_reset},
 	{PEER_FLAG_CAPABILITY_ENHE, 0, peer_change_reset},
 	{PEER_FLAG_ENFORCE_FIRST_AS, 0, peer_change_reset_in},
+	{PEER_FLAG_IFPEER_V6ONLY, 0, peer_change_reset},
 	{PEER_FLAG_ROUTEADV, 0, peer_change_none},
 	{PEER_FLAG_TIMER, 0, peer_change_none},
 	{PEER_FLAG_TIMER_CONNECT, 0, peer_change_none},


### PR DESCRIPTION
Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

### Summary
peer_flag_modify() will always return BGP_ERR_INVALID_FLAG because
the action was not defined for PEER_FLAG_IFPEER_V6ONLY flag.

```
global PEER_FLAG_IFPEER_V6ONLY = 16384;
global BGP_ERR_INVALID_FLAG = -2;

probe process("/usr/lib/frr/bgpd").statement("peer_flag_modify@/root/frr/bgpd/bgpd.c:3975")
{
    if ($flag == PEER_FLAG_IFPEER_V6ONLY && $action->type == 0)
        printf("action not found for the flag PEER_FLAG_IFPEER_V6ONLY\n");
}

probe process("/usr/lib/frr/bgpd").function("peer_flag_modify").return
{
    if ($return == BGP_ERR_INVALID_FLAG)
        printf("return BGP_ERR_INVALID_FLAG\n");
}
```
produces:
action not found for the flag PEER_FLAG_IFPEER_V6ONLY
return BGP_ERR_INVALID_FLAG

$ vtysh -c 'conf t' -c 'router bgp 20' -c 'neighbor eth1 interface v6only remote-as external'

### Related Issue
Closes https://github.com/FRRouting/frr/issues/3721

### Components
bgpd
