### PR TITLE
tools: fix blackhole static changes in frr-reload.py

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -300,13 +300,11 @@ class Config(object):
 
         '''
           More fixups in user specification and what running config shows.
-          "null0" in routes must be replaced by Null0, and "blackhole" must
-          be replaced by Null0 as well.
+          "null0" in routes must be replaced by Null0.
         '''
         if (key[0].startswith('ip route') or key[0].startswith('ipv6 route') and
-                'null0' in key[0] or 'blackhole' in key[0]):
+                'null0' in key[0]):
             key[0] = re.sub(r'\s+null0(\s*$)', ' Null0', key[0])
-            key[0] = re.sub(r'\s+blackhole(\s*$)', ' Null0', key[0])
 
         if lines:
             if tuple(key) not in self.contexts:


### PR DESCRIPTION
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>

### Summary
Problem caused when automated tools are used to create "ip route 1.1.1.0/24
blackhole" because frr-reload.py changed the line to Null0 instead
of blackhole.  If the automated tool tries to delete it using the same format as
entered, the commit fails since it doesn't match the syntax.

### Components
tools: frr-reload.py