### PR TITLE
tools: keep exit-vrf to change context correctly between vrfs

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -435,11 +435,22 @@ end
                 self.save_contexts(ctx_keys, current_context_lines)
                 new_ctx = True
 
-            elif line in ["end", "exit-vrf"]:
+            elif line == "end":
                 self.save_contexts(ctx_keys, current_context_lines)
                 log.debug('LINE %-50s: exiting old context, %-50s', line, ctx_keys)
 
                 # Start a new context
+                new_ctx = True
+                main_ctx_key = []
+                ctx_keys = []
+                current_context_lines = []
+
+            elif line == "exit-vrf":
+                self.save_contexts(ctx_keys, current_context_lines)
+                current_context_lines.append(line)
+                log.debug('LINE %-50s: append to current_context_lines, %-50s', line, ctx_keys)
+
+                #Start a new context
                 new_ctx = True
                 main_ctx_key = []
                 ctx_keys = []


### PR DESCRIPTION
Signed-off-by: Don Slice <dslice@cumulusnetwork.com>

### Summary
Discovered in testing that if a static route in the default table
was entered immediately after a vrf static block, the static route
intended for the default table was put in the vrf instead.  This
fix retains the "exit-vrf" statement which causes the following
static routes to appear in the default table correctly.

### Components
tools: frr-reload.py