### PR TITLE
Remove strncpy

### DIFF
--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -2190,7 +2190,7 @@ static void rfapiItBiIndexDump(struct agg_node *rn)
 			prefix2str(&k->extra->vnc.import.aux_prefix,
 				   buf_aux_pfx, sizeof(buf_aux_pfx));
 		} else
-			strncpy(buf_aux_pfx, "(none)", PREFIX_STRLEN);
+			strlcpy(buf_aux_pfx, "(none)", sizeof(buf_aux_pfx));
 
 		vnc_zlog_debug_verbose("bpi %p, peer %p, rd %s, aux_prefix %s",
 				       k, k->peer, buf, buf_aux_pfx);
@@ -2221,7 +2221,7 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 			prefix2str(aux_prefix, buf_aux_pfx,
 				   sizeof(buf_aux_pfx));
 		} else
-			strncpy(buf_aux_pfx, "(nil)", sizeof(buf_aux_pfx));
+			strlcpy(buf_aux_pfx, "(nil)", sizeof(buf_aux_pfx));
 
 		vnc_zlog_debug_verbose("%s want prd=%s, peer=%p, aux_prefix=%s",
 				       __func__,

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1305,8 +1305,8 @@ ferr_r isis_circuit_passwd_unset(struct isis_circuit *circuit)
 	return ferr_ok();
 }
 
-static int isis_circuit_passwd_set(struct isis_circuit *circuit,
-				   uint8_t passwd_type, const char *passwd)
+ferr_r isis_circuit_passwd_set(struct isis_circuit *circuit,
+			       uint8_t passwd_type, const char *passwd)
 {
 	int len;
 
@@ -1319,7 +1319,8 @@ static int isis_circuit_passwd_set(struct isis_circuit *circuit,
 			"circuit password too long (max 254 chars)");
 
 	circuit->passwd.len = len;
-	strncpy((char *)circuit->passwd.passwd, passwd, 255);
+	strlcpy((char *)circuit->passwd.passwd, passwd,
+		sizeof(circuit->passwd.passwd));
 	circuit->passwd.type = passwd_type;
 	return ferr_ok();
 }

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -190,6 +190,8 @@ ferr_r isis_circuit_metric_set(struct isis_circuit *circuit, int level,
 			       int metric);
 
 ferr_r isis_circuit_passwd_unset(struct isis_circuit *circuit);
+ferr_r isis_circuit_passwd_set(struct isis_circuit *circuit,
+			       uint8_t passwd_type, const char *passwd);
 ferr_r isis_circuit_passwd_cleartext_set(struct isis_circuit *circuit,
 					 const char *passwd);
 ferr_r isis_circuit_passwd_hmac_md5_set(struct isis_circuit *circuit,

--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -2092,8 +2092,8 @@ lib_interface_isis_password_password_modify(enum nb_event event,
 
 	password = yang_dnode_get_string(dnode, NULL);
 	circuit = yang_dnode_get_entry(dnode, true);
-	circuit->passwd.len = strlen(password);
-	strncpy((char *)circuit->passwd.passwd, password, 255);
+
+	isis_circuit_passwd_set(circuit, circuit->passwd.type, password);
 
 	return NB_OK;
 }

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -1363,7 +1363,7 @@ struct isis_lsp *lsp_for_arg(const char *argv, dict_t *lspdb)
 	 * xxxx.xxxx.xxxx
 	 */
 	if (argv)
-		strncpy(sysid, argv, 254);
+		strlcpy(sysid, argv, sizeof(sysid));
 	if (argv && strlen(argv) > 3) {
 		pos = argv + strlen(argv) - 3;
 		if (strncmp(pos, "-", 1) == 0) {
@@ -1639,7 +1639,8 @@ static int isis_area_passwd_set(struct isis_area *area, int level,
 			return -1;
 
 		modified.len = len;
-		strncpy((char *)modified.passwd, passwd, 255);
+		strlcpy((char *)modified.passwd, passwd,
+			sizeof(modified.passwd));
 		modified.type = passwd_type;
 		modified.snp_auth = snp_auth;
 	}

--- a/lib/event_counter.c
+++ b/lib/event_counter.c
@@ -62,7 +62,7 @@ const char *event_counter_format(const struct event_counter *counter)
 	    || strftime(timebuf, sizeof(timebuf), "%a, %d %b %Y %T %z",
 			last_change)
 		       == 0) {
-		strncpy(timebuf, "???", sizeof(timebuf));
+		strlcpy(timebuf, "???", sizeof(timebuf));
 	}
 
 	snprintf(rv, sizeof(rv), "%5llu  last: %s", counter->count,

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -866,7 +866,7 @@ int str2prefix_ipv4(const char *str, struct prefix_ipv4 *p)
 		return ret;
 	} else {
 		cp = XMALLOC(MTYPE_TMP, (pnt - str) + 1);
-		strncpy(cp, str, pnt - str);
+		memcpy(cp, str, pnt - str);
 		*(cp + (pnt - str)) = '\0';
 		ret = inet_aton(cp, &p->prefix);
 		XFREE(MTYPE_TMP, cp);
@@ -913,7 +913,7 @@ int str2prefix_eth(const char *str, struct prefix_eth *p)
 		}
 
 		cp = XMALLOC(MTYPE_TMP, (pnt - str) + 1);
-		strncpy(cp, str, pnt - str);
+		memcpy(cp, str, pnt - str);
 		*(cp + (pnt - str)) = '\0';
 
 		str_addr = cp;
@@ -1030,7 +1030,7 @@ int str2prefix_ipv6(const char *str, struct prefix_ipv6 *p)
 		int plen;
 
 		cp = XMALLOC(MTYPE_TMP, (pnt - str) + 1);
-		strncpy(cp, str, pnt - str);
+		memcpy(cp, str, pnt - str);
 		*(cp + (pnt - str)) = '\0';
 		ret = inet_pton(AF_INET6, cp, &p->prefix);
 		XFREE(MTYPE_TMP, cp);

--- a/lib/yang_translator.c
+++ b/lib/yang_translator.c
@@ -511,7 +511,7 @@ static void str_replace(char *o_string, const char *s_string,
 	if (!ch)
 		return;
 
-	strncpy(buffer, o_string, ch - o_string);
+	memcpy(buffer, o_string, ch - o_string);
 	buffer[ch - o_string] = 0;
 
 	sprintf(buffer + (ch - o_string), "%s%s", r_string,

--- a/nhrpd/linux.c
+++ b/nhrpd/linux.c
@@ -110,7 +110,7 @@ static int linux_configure_arp(const char *iface, int on)
 {
 	struct ifreq ifr;
 
-	strncpy(ifr.ifr_name, iface, IFNAMSIZ - 1);
+	strlcpy(ifr.ifr_name, iface, sizeof(ifr.ifr_name));
 	if (ioctl(nhrp_socket_fd, SIOCGIFFLAGS, &ifr))
 		return -1;
 

--- a/nhrpd/vici.c
+++ b/nhrpd/vici.c
@@ -550,7 +550,7 @@ int sock_open_unix(const char *path)
 
 	memset(&addr, 0, sizeof(struct sockaddr_un));
 	addr.sun_family = AF_UNIX;
-	strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+	strlcpy(addr.sun_path, path, sizeof(addr.sun_path));
 
 	ret = connect(fd, (struct sockaddr *)&addr,
 		      sizeof(addr.sun_family) + strlen(addr.sun_path));

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -538,8 +538,7 @@ static void ospf_header_dump(struct ospf_header *ospfh)
 	case OSPF_AUTH_NULL:
 		break;
 	case OSPF_AUTH_SIMPLE:
-		memset(buf, 0, 9);
-		strncpy(buf, (char *)ospfh->u.auth_data, 8);
+		strlcpy(buf, (char *)ospfh->u.auth_data, sizeof(buf));
 		zlog_debug("  Simple Password %s", buf);
 		break;
 	case OSPF_AUTH_CRYPTOGRAPHIC:

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -954,8 +954,9 @@ static int ospf_vl_set_security(struct ospf_vl_data *vl_data,
 	if (vl_config->auth_key) {
 		memset(IF_DEF_PARAMS(ifp)->auth_simple, 0,
 		       OSPF_AUTH_SIMPLE_SIZE + 1);
-		strncpy((char *)IF_DEF_PARAMS(ifp)->auth_simple,
-			vl_config->auth_key, OSPF_AUTH_SIMPLE_SIZE);
+		strlcpy((char *)IF_DEF_PARAMS(ifp)->auth_simple,
+			vl_config->auth_key,
+			sizeof(IF_DEF_PARAMS(ifp)->auth_simple));
 	} else if (vl_config->md5_key) {
 		if (ospf_crypt_key_lookup(IF_DEF_PARAMS(ifp)->auth_crypt,
 					  vl_config->crypto_key_id)
@@ -967,8 +968,8 @@ static int ospf_vl_set_security(struct ospf_vl_data *vl_data,
 		ck = ospf_crypt_key_new();
 		ck->key_id = vl_config->crypto_key_id;
 		memset(ck->auth_key, 0, OSPF_AUTH_MD5_SIZE + 1);
-		strncpy((char *)ck->auth_key, vl_config->md5_key,
-			OSPF_AUTH_MD5_SIZE);
+		strlcpy((char *)ck->auth_key, vl_config->md5_key,
+			sizeof(ck->auth_key));
 
 		ospf_crypt_key_add(IF_DEF_PARAMS(ifp)->auth_crypt, ck);
 	} else if (vl_config->crypto_key_id != 0) {
@@ -1147,14 +1148,12 @@ DEFUN (ospf_area_vlink,
 		if (vl_config.crypto_key_id < 0)
 			return CMD_WARNING_CONFIG_FAILED;
 
-		memset(md5_key, 0, OSPF_AUTH_MD5_SIZE + 1);
-		strncpy(md5_key, argv[idx + 3]->arg, OSPF_AUTH_MD5_SIZE);
+		strlcpy(md5_key, argv[idx + 3]->arg, sizeof(md5_key));
 		vl_config.md5_key = md5_key;
 	}
 
 	if (argv_find(argv, argc, "authentication-key", &idx)) {
-		memset(auth_key, 0, OSPF_AUTH_SIMPLE_SIZE + 1);
-		strncpy(auth_key, argv[idx + 1]->arg, OSPF_AUTH_SIMPLE_SIZE);
+		strlcpy(auth_key, argv[idx + 1]->arg, sizeof(auth_key));
 		vl_config.auth_key = auth_key;
 	}
 
@@ -6895,9 +6894,8 @@ DEFUN (ip_ospf_authentication_key,
 		ospf_if_update_params(ifp, addr);
 	}
 
-	memset(params->auth_simple, 0, OSPF_AUTH_SIMPLE_SIZE + 1);
-	strncpy((char *)params->auth_simple, argv[3]->arg,
-		OSPF_AUTH_SIMPLE_SIZE);
+	strlcpy((char *)params->auth_simple, argv[3]->arg,
+		sizeof(params->auth_simple));
 	SET_IF_PARAM(params, auth_simple);
 
 	return CMD_SUCCESS;
@@ -7006,8 +7004,7 @@ DEFUN (ip_ospf_message_digest_key,
 
 	ck = ospf_crypt_key_new();
 	ck->key_id = (uint8_t)key_id;
-	memset(ck->auth_key, 0, OSPF_AUTH_MD5_SIZE + 1);
-	strncpy((char *)ck->auth_key, cryptkey, OSPF_AUTH_MD5_SIZE);
+	strlcpy((char *)ck->auth_key, cryptkey, sizeof(ck->auth_key));
 
 	ospf_crypt_key_add(params->auth_crypt, ck);
 	SET_IF_PARAM(params, auth_crypt);

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -189,8 +189,8 @@ void pim_register_send(const uint8_t *buf, int buf_size, struct in_addr src,
 
 	if (PIM_DEBUG_PIM_REG) {
 		char rp_str[INET_ADDRSTRLEN];
-		strncpy(rp_str, inet_ntoa(rpg->rpf_addr.u.prefix4),
-			INET_ADDRSTRLEN - 1);
+		strlcpy(rp_str, inet_ntoa(rpg->rpf_addr.u.prefix4),
+			sizeof(rp_str));
 		zlog_debug("%s: Sending %s %sRegister Packet to %s on %s",
 			   __PRETTY_FUNCTION__, up->sg_str,
 			   null_register ? "NULL " : "", rp_str, ifp->name);

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -851,7 +851,7 @@ static int rip_auth_md5(struct rip_packet *packet, struct sockaddr_in *from,
 	MD5_CTX ctx;
 	uint8_t digest[RIP_AUTH_MD5_SIZE];
 	uint16_t packet_len;
-	char auth_str[RIP_AUTH_MD5_SIZE];
+	char auth_str[RIP_AUTH_MD5_SIZE] = {};
 
 	if (IS_RIP_DEBUG_EVENT)
 		zlog_debug("RIPv2 MD5 authentication from %s",
@@ -895,8 +895,6 @@ static int rip_auth_md5(struct rip_packet *packet, struct sockaddr_in *from,
 	/* retrieve authentication data */
 	md5data = (struct rip_md5_data *)(((uint8_t *)packet) + packet_len);
 
-	memset(auth_str, 0, RIP_AUTH_MD5_SIZE);
-
 	if (ri->key_chain) {
 		keychain = keychain_lookup(ri->key_chain);
 		if (keychain == NULL)
@@ -906,9 +904,9 @@ static int rip_auth_md5(struct rip_packet *packet, struct sockaddr_in *from,
 		if (key == NULL || key->string == NULL)
 			return 0;
 
-		strncpy(auth_str, key->string, RIP_AUTH_MD5_SIZE);
+		strlcpy(auth_str, key->string, sizeof(auth_str));
 	} else if (ri->auth_str)
-		strncpy(auth_str, ri->auth_str, RIP_AUTH_MD5_SIZE);
+		strlcpy(auth_str, ri->auth_str, sizeof(auth_str));
 
 	if (auth_str[0] == 0)
 		return 0;
@@ -941,9 +939,9 @@ static void rip_auth_prepare_str_send(struct rip_interface *ri, struct key *key,
 
 	memset(auth_str, 0, len);
 	if (key && key->string)
-		strncpy(auth_str, key->string, len);
+		strlcpy(auth_str, key->string, len);
 	else if (ri->auth_str)
-		strncpy(auth_str, ri->auth_str, len);
+		strlcpy(auth_str, ri->auth_str, len);
 
 	return;
 }
@@ -1389,13 +1387,12 @@ static int rip_send_packet(uint8_t *buf, int size, struct sockaddr_in *to,
 	if (IS_RIP_DEBUG_PACKET) {
 #define ADDRESS_SIZE 20
 		char dst[ADDRESS_SIZE];
-		dst[ADDRESS_SIZE - 1] = '\0';
 
 		if (to) {
-			strncpy(dst, inet_ntoa(to->sin_addr), ADDRESS_SIZE - 1);
+			strlcpy(dst, inet_ntoa(to->sin_addr), sizeof(dst));
 		} else {
 			sin.sin_addr.s_addr = htonl(INADDR_RIP_GROUP);
-			strncpy(dst, inet_ntoa(sin.sin_addr), ADDRESS_SIZE - 1);
+			strlcpy(dst, inet_ntoa(sin.sin_addr), sizeof(dst));
 		}
 #undef ADDRESS_SIZE
 		zlog_debug("rip_send_packet %s > %s (%s)",
@@ -2100,8 +2097,7 @@ void rip_output_process(struct connected *ifc, struct sockaddr_in *to,
 				key = key_lookup_for_send(keychain);
 		}
 		/* to be passed to auth functions later */
-		rip_auth_prepare_str_send(ri, key, auth_str,
-					  RIP_AUTH_SIMPLE_SIZE);
+		rip_auth_prepare_str_send(ri, key, auth_str, sizeof(auth_str));
 		if (strlen(auth_str) == 0)
 			return;
 	}


### PR DESCRIPTION
- Replace `strncpy` with `strlcpy` where the intended result is a null terminated string
- Replace `strncpy` with `memcpy` where the intended result is an N-byte copy
- Leave `strncpy` as-is where the intended result is a maximum N-byte copy that may or may not be null terminated