### PR TITLE
Refine install of EVPN-based routes to remove some special handling

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5396,7 +5396,8 @@ static void link_l2vni_hash_to_l3vni(struct hash_bucket *bucket,
 }
 
 int bgp_evpn_local_l3vni_add(vni_t l3vni, vrf_id_t vrf_id, struct ethaddr *rmac,
-			     struct in_addr originator_ip, int filter)
+			     struct in_addr originator_ip, int filter,
+			     ifindex_t svi_ifindex)
 {
 	struct bgp *bgp_vrf = NULL; /* bgp VRF instance */
 	struct bgp *bgp_def = NULL; /* default bgp instance */
@@ -5444,14 +5445,11 @@ int bgp_evpn_local_l3vni_add(vni_t l3vni, vrf_id_t vrf_id, struct ethaddr *rmac,
 		SET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_AUTO);
 	}
 
-	/* associate with l3vni */
+	/* associate the vrf with l3vni and related parameters */
 	bgp_vrf->l3vni = l3vni;
-
-	/* set the router mac - to be used in mac-ip routes for this vrf */
 	memcpy(&bgp_vrf->rmac, rmac, sizeof(struct ethaddr));
-
-	/* set the originator ip */
 	bgp_vrf->originator_ip = originator_ip;
+	bgp_vrf->l3vni_svi_ifindex = svi_ifindex;
 
 	/* set the right filter - are we using l3vni only for prefix routes? */
 	if (filter)

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -136,7 +136,8 @@ extern int bgp_evpn_local_macip_add(struct bgp *bgp, vni_t vni,
 				    uint8_t flags, uint32_t seq);
 extern int bgp_evpn_local_l3vni_add(vni_t vni, vrf_id_t vrf_id,
 				    struct ethaddr *rmac,
-				    struct in_addr originator_ip, int filter);
+				    struct in_addr originator_ip, int filter,
+				    ifindex_t svi_ifindex);
 extern int bgp_evpn_local_l3vni_del(vni_t vni, vrf_id_t vrf_id);
 extern int bgp_evpn_local_vni_del(struct bgp *bgp, vni_t vni);
 extern int bgp_evpn_local_vni_add(struct bgp *bgp, vni_t vni,

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1126,6 +1126,7 @@ static int update_ipv4nh_for_route_install(int nh_othervrf,
 	 */
 	if (is_evpn) {
 		api_nh->type = NEXTHOP_TYPE_IPV4_IFINDEX;
+		api_nh->onlink = true;
 		api_nh->ifindex = nh_bgp->l3vni_svi_ifindex;
 	} else if (nh_othervrf &&
 		 api_nh->gate.ipv4.s_addr == INADDR_ANY) {
@@ -1151,6 +1152,7 @@ update_ipv6nh_for_route_install(int nh_othervrf, struct bgp *nh_bgp,
 
 	if (is_evpn) {
 		api_nh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
+		api_nh->onlink = true;
 		api_nh->ifindex = nh_bgp->l3vni_svi_ifindex;
 	} else if (nh_othervrf) {
 		if (IN6_IS_ADDR_UNSPECIFIED(nexthop)) {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -517,6 +517,9 @@ struct bgp {
 	/* originator ip - to be used as NH for type-5 routes */
 	struct in_addr originator_ip;
 
+	/* SVI associated with the L3-VNI corresponding to this vrf */
+	ifindex_t l3vni_svi_ifindex;
+
 	/* vrf flags */
 	uint32_t vrf_flags;
 #define BGP_VRF_AUTO                        (1 << 0)

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -83,7 +83,6 @@ struct nexthop {
 #define NEXTHOP_FLAG_MATCHED    (1 << 4) /* Already matched vs a nexthop */
 #define NEXTHOP_FLAG_FILTERED   (1 << 5) /* rmap filtered, used by static only */
 #define NEXTHOP_FLAG_DUPLICATE  (1 << 6) /* nexthop duplicates another active one */
-#define NEXTHOP_FLAG_EVPN_RVTEP (1 << 7) /* EVPN remote vtep nexthop */
 #define NEXTHOP_IS_ACTIVE(flags)                                               \
 	(CHECK_FLAG(flags, NEXTHOP_FLAG_ACTIVE)                                \
 	 && !CHECK_FLAG(flags, NEXTHOP_FLAG_DUPLICATE))

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1432,12 +1432,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 		case NEXTHOP_TYPE_IPV4_IFINDEX:
 
 			memset(&vtep_ip, 0, sizeof(struct ipaddr));
-			if (CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE)) {
-				ifindex = get_l3vni_svi_ifindex(vrf_id);
-			} else {
-				ifindex = api_nh->ifindex;
-			}
-
+			ifindex = api_nh->ifindex;
 			if (IS_ZEBRA_DEBUG_RECV) {
 				char nhbuf[INET6_ADDRSTRLEN] = {0};
 
@@ -1473,12 +1468,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 			break;
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
 			memset(&vtep_ip, 0, sizeof(struct ipaddr));
-			if (CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE)) {
-				ifindex = get_l3vni_svi_ifindex(vrf_id);
-			} else {
-				ifindex = api_nh->ifindex;
-			}
-
+			ifindex = api_nh->ifindex;
 			nexthop = route_entry_nexthop_ipv6_ifindex_add(
 				re, &api_nh->gate.ipv6, ifindex,
 				api_nh->vrf_id);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1447,12 +1447,10 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 				re, &api_nh->gate.ipv4, NULL, ifindex,
 				api_nh->vrf_id);
 
-			/* if this an EVPN route entry,
-			 * program the nh as neigh
+			/* Special handling for IPv4 routes sourced from EVPN:
+			 * the nexthop and associated MAC need to be installed.
 			 */
 			if (CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE)) {
-				SET_FLAG(nexthop->flags,
-					 NEXTHOP_FLAG_EVPN_RVTEP);
 				vtep_ip.ipa_type = IPADDR_V4;
 				memcpy(&(vtep_ip.ipaddr_v4),
 				       &(api_nh->gate.ipv4),
@@ -1473,12 +1471,10 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 				re, &api_nh->gate.ipv6, ifindex,
 				api_nh->vrf_id);
 
-			/* if this an EVPN route entry,
-			 * program the nh as neigh
+			/* Special handling for IPv6 routes sourced from EVPN:
+			 * the nexthop and associated MAC need to be installed.
 			 */
 			if (CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE)) {
-				SET_FLAG(nexthop->flags,
-					 NEXTHOP_FLAG_EVPN_RVTEP);
 				vtep_ip.ipa_type = IPADDR_V6;
 				memcpy(&vtep_ip.ipaddr_v6, &(api_nh->gate.ipv6),
 				       sizeof(struct in6_addr));

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -4875,6 +4875,7 @@ static int zl3vni_send_add_to_client(zebra_l3vni_t *zl3vni)
 	stream_put(s, &rmac, sizeof(struct ethaddr));
 	stream_put_in_addr(s, &zl3vni->local_vtep_ip);
 	stream_put(s, &zl3vni->filter, sizeof(int));
+	stream_putl(s, zl3vni->svi_if->ifindex);
 
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));


### PR DESCRIPTION
### Summary
The next hop of an IPv4 or IPv6 route that is based on an EVPN has to be installed on the interface that is associated with the "L3" VNI - the VNI that maps to the tenant's VRF. Instead of having this derived by zebra in a special way, this set of patches passes some additional information from zebra to BGP and has BGP use it and set other existing flags when installing such routes.

### Related Issue
[fill here if applicable]

### Components
bgpd, zebra, lib
