### PR TITLE
bgpd: [6.0] Add peer action for PEER_FLAG_IFPEER_V6ONLY flag

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3660,6 +3660,7 @@ static const struct peer_flag_action peer_flag_action_list[] = {
 	{PEER_FLAG_DISABLE_CONNECTED_CHECK, 0, peer_change_reset},
 	{PEER_FLAG_CAPABILITY_ENHE, 0, peer_change_reset},
 	{PEER_FLAG_ENFORCE_FIRST_AS, 0, peer_change_reset_in},
+	{PEER_FLAG_IFPEER_V6ONLY, 0, peer_change_reset},
 	{PEER_FLAG_ROUTEADV, 0, peer_change_none},
 	{PEER_FLAG_TIMER, 0, peer_change_none},
 	{PEER_FLAG_TIMER_CONNECT, 0, peer_change_none},


### PR DESCRIPTION
backport from https://github.com/FRRouting/frr/pull/3868/commits/afad5cedf1be827238b376e63b0b93bb555c928e

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>