### PR TITLE
ospfd: Cleanup ospf->redist and ospf->external on shutdown

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -633,8 +633,10 @@ static void ospf_finish_final(struct ospf *ospf)
 		if (!red_list)
 			continue;
 
-		for (ALL_LIST_ELEMENTS(red_list, node, nnode, red))
+		for (ALL_LIST_ELEMENTS(red_list, node, nnode, red)) {
 			ospf_redistribute_unset(ospf, i, red->instance);
+			ospf_redist_del(ospf, i, red->instance);
+		}
 	}
 	ospf_redistribute_default_unset(ospf);
 
@@ -781,6 +783,8 @@ static void ospf_finish_final(struct ospf *ospf)
 					rn->info = NULL;
 					route_unlock_node(rn);
 				}
+
+			ospf_external_del(ospf, i, ext->instance);
 		}
 	}
 


### PR DESCRIPTION
These two data types were written to handle redistribute
and external data types.  On shutdown cleanup the memory
allocated to these if we are doing redistribution.

This was found using valgrind.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
