### PR TITLE
zebra Rnh vrf down stuff

### DIFF
--- a/sharpd/sharp_globals.h
+++ b/sharpd/sharp_globals.h
@@ -38,6 +38,7 @@ struct sharp_routes {
 	int32_t repeat;
 
 	uint8_t inst;
+	vrf_id_t vrf_id;
 
 	struct timeval t_start;
 	struct timeval t_end;

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -63,7 +63,8 @@ DEFPY(watch_nexthop_v6, watch_nexthop_v6_cmd,
 	p.family = AF_INET6;
 
 	sharp_nh_tracker_get(&p);
-	sharp_zebra_nexthop_watch(&p, type_import, true, !!connected);
+	sharp_zebra_nexthop_watch(&p, VRF_DEFAULT, type_import,
+				  true, !!connected);
 
 	return CMD_SUCCESS;
 }
@@ -92,7 +93,8 @@ DEFPY(watch_nexthop_v4, watch_nexthop_v4_cmd,
 	p.family = AF_INET;
 
 	sharp_nh_tracker_get(&p);
-	sharp_zebra_nexthop_watch(&p, type_import, true, !!connected);
+	sharp_zebra_nexthop_watch(&p, VRF_DEFAULT, type_import,
+				  true, !!connected);
 
 	return CMD_SUCCESS;
 }

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -195,12 +195,15 @@ DEFPY (install_routes,
 			sg.r.nhop.type = NEXTHOP_TYPE_IPV6;
 		}
 
+		sg.r.nhop.vrf_id = VRF_DEFAULT;
 		sg.r.nhop_group.nexthop = &sg.r.nhop;
 	}
 
 	sg.r.inst = instance;
+	sg.r.vrf_id = VRF_DEFAULT;
 	rts = routes;
-	sharp_install_routes_helper(&prefix, sg.r.inst, &sg.r.nhop_group, rts);
+	sharp_install_routes_helper(&prefix, sg.r.vrf_id,
+				    sg.r.inst, &sg.r.nhop_group, rts);
 
 	return CMD_SUCCESS;
 }
@@ -266,8 +269,10 @@ DEFPY (remove_routes,
 	}
 
 	sg.r.inst = instance;
+	sg.r.vrf_id = VRF_DEFAULT;
 	rts = routes;
-	sharp_remove_routes_helper(&prefix, sg.r.inst, rts);
+	sharp_remove_routes_helper(&prefix, sg.r.vrf_id,
+				   sg.r.inst, rts);
 
 	return CMD_SUCCESS;
 }

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -323,7 +323,7 @@ void route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance)
 	return;
 }
 
-void sharp_zebra_nexthop_watch(struct prefix *p, bool import,
+void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id, bool import,
 			       bool watch, bool connected)
 {
 	int command;
@@ -340,7 +340,7 @@ void sharp_zebra_nexthop_watch(struct prefix *p, bool import,
 			command = ZEBRA_IMPORT_ROUTE_UNREGISTER;
 	}
 
-	if (zclient_send_rnh(zclient, command, p, connected, VRF_DEFAULT) < 0)
+	if (zclient_send_rnh(zclient, command, p, connected, vrf_id) < 0)
 		zlog_warn("%s: Failure to send nexthop to zebra",
 			  __PRETTY_FUNCTION__);
 }

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -28,8 +28,8 @@ extern void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label);
 extern void route_add(struct prefix *p, vrf_id_t, uint8_t instance,
 		      struct nexthop_group *nhg);
 extern void route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance);
-extern void sharp_zebra_nexthop_watch(struct prefix *p, bool import,
-				      bool watch, bool connected);
+extern void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id,
+				      bool import, bool watch, bool connected);
 
 extern void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 					uint8_t instance,

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -25,15 +25,16 @@
 extern void sharp_zebra_init(void);
 
 extern void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label);
-extern void route_add(struct prefix *p, uint8_t instance,
+extern void route_add(struct prefix *p, vrf_id_t, uint8_t instance,
 		      struct nexthop_group *nhg);
-extern void route_delete(struct prefix *p, uint8_t instance);
+extern void route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance);
 extern void sharp_zebra_nexthop_watch(struct prefix *p, bool import,
 				      bool watch, bool connected);
 
-extern void sharp_install_routes_helper(struct prefix *p, uint8_t instance,
-					 struct nexthop_group *nhg,
-					 uint32_t routes);
-extern void sharp_remove_routes_helper(struct prefix *p, uint8_t instance,
-				       uint32_t routes);
+extern void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
+					uint8_t instance,
+					struct nexthop_group *nhg,
+					uint32_t routes);
+extern void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id,
+				       uint8_t instance, uint32_t routes);
 #endif

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -168,8 +168,29 @@ static void zebra_router_free_table(struct zebra_router_table *zrt)
 
 	table_info = route_table_get_info(zrt->table);
 	route_table_finish(zrt->table);
+	RB_REMOVE(zebra_router_table_head, &zrouter.tables, zrt);
+
 	XFREE(MTYPE_RIB_TABLE_INFO, table_info);
 	XFREE(MTYPE_ZEBRA_NS, zrt);
+}
+
+void zebra_router_release_table(struct zebra_vrf *zvrf, uint32_t tableid,
+				afi_t afi, safi_t safi)
+{
+	struct zebra_router_table finder;
+	struct zebra_router_table *zrt;
+
+	memset(&finder, 0, sizeof(finder));
+	finder.afi = afi;
+	finder.safi = safi;
+	finder.tableid = tableid;
+	finder.ns_id = zvrf->zns->ns_id;
+	zrt = RB_FIND(zebra_router_table_head, &zrouter.tables, &finder);
+
+	if (!zrt)
+		return;
+
+	zebra_router_free_table(zrt);
 }
 
 uint32_t zebra_router_get_next_sequence(void)

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -117,6 +117,8 @@ extern struct route_table *zebra_router_find_table(struct zebra_vrf *zvrf,
 extern struct route_table *zebra_router_get_table(struct zebra_vrf *zvrf,
 						  uint32_t tableid, afi_t afi,
 						  safi_t safi);
+extern void zebra_router_release_table(struct zebra_vrf *zvrf, uint32_t tableid,
+				       afi_t afi, safi_t safi);
 
 extern int zebra_router_config_write(struct vty *vty);
 


### PR DESCRIPTION
When deleting a vrf and then adding it back in we were not properly cleaning up the routing tables associated with that vrf and we were leaving dangling pointers.  This cleans that up.

Also add some code to the sharp daemon to have the ability to operate inside of a vrf.