### PR TITLE
Leaking of EVPN-based IPv4 and IPv6 routes between VRFs

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2508,6 +2508,9 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 	/* Perform route selection and update zebra, if required. */
 	bgp_process(bgp_vrf, rn, afi, safi);
 
+	/* Process for route leaking. */
+	vpn_leak_from_vrf_update(bgp_get_default(), bgp_vrf, pi);
+
 	return ret;
 }
 
@@ -2672,6 +2675,9 @@ static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 
 	if (!pi)
 		return 0;
+
+	/* Process for route leaking. */
+	vpn_leak_from_vrf_withdraw(bgp_get_default(), bgp_vrf, pi);
 
 	bgp_aggregate_decrement(bgp_vrf, &rn->p, pi, afi, safi);
 

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -101,6 +101,12 @@ static inline int is_route_parent_evpn(struct bgp_path_info *ri)
 	return 0;
 }
 
+/* Flag if the route path's family is EVPN. */
+static inline bool is_pi_family_evpn(struct bgp_path_info *pi)
+{
+	return is_pi_family_matching(pi, AFI_L2VPN, SAFI_EVPN);
+}
+
 extern void bgp_evpn_advertise_type5_route(struct bgp *bgp_vrf,
 					   struct prefix *p,
 					   struct attr *src_attr, afi_t afi,

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -88,8 +88,13 @@ static inline int is_route_parent_evpn(struct bgp_path_info *ri)
 	    !ri->extra->parent)
 		return 0;
 
-	/* See if the parent is of family L2VPN/EVPN */
-	parent_ri = (struct bgp_path_info *)ri->extra->parent;
+	/* Determine parent recursively */
+	for (parent_ri = ri->extra->parent;
+	     parent_ri->extra && parent_ri->extra->parent;
+	     parent_ri = parent_ri->extra->parent)
+		;
+
+	/* See if of family L2VPN/EVPN */
 	rn = parent_ri->net;
 	if (!rn)
 		return 0;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -901,15 +901,6 @@ void vpn_leak_from_vrf_withdraw(struct bgp *bgp_vpn,		/* to */
 			path_vrf->type, path_vrf->sub_type);
 	}
 
-	if (path_vrf->sub_type != BGP_ROUTE_NORMAL
-	    && path_vrf->sub_type != BGP_ROUTE_STATIC
-	    && path_vrf->sub_type != BGP_ROUTE_REDISTRIBUTE) {
-
-		if (debug)
-			zlog_debug("%s: wrong sub_type %d", __func__,
-				   path_vrf->sub_type);
-		return;
-	}
 	if (!bgp_vpn)
 		return;
 

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -683,10 +683,9 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 		return;
 	}
 
-	/* loop check - should not be an imported route. */
-	if (path_vrf->extra && path_vrf->extra->bgp_orig)
+	/* Is this route exportable into the VPN table? */
+	if (!is_route_injectable_into_vpn(path_vrf))
 		return;
-
 
 	if (!vpn_leak_to_vpn_active(bgp_vrf, afi, &debugmsg)) {
 		if (debug)
@@ -911,6 +910,10 @@ void vpn_leak_from_vrf_withdraw(struct bgp *bgp_vpn,		/* to */
 			zlog_debug("%s: can't get afi of prefix", __func__);
 		return;
 	}
+
+	/* Is this route exportable into the VPN table? */
+	if (!is_route_injectable_into_vpn(path_vrf))
+		return;
 
 	if (!vpn_leak_to_vpn_active(bgp_vrf, afi, &debugmsg)) {
 		if (debug)

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1355,7 +1355,10 @@ void vpn_leak_to_vrf_withdraw_all(struct bgp *bgp_vrf, /* to */
 
 		for (bpi = bgp_node_get_bgp_path_info(bn); bpi;
 		     bpi = bpi->next) {
-			if (bpi->extra && bpi->extra->bgp_orig != bgp_vrf) {
+			if (bpi->extra
+			    && bpi->extra->bgp_orig != bgp_vrf
+			    && bpi->extra->parent
+			    && is_pi_family_vpn(bpi->extra->parent)) {
 
 				/* delete route */
 				bgp_aggregate_decrement(bgp_vrf, &bn->p, bpi,

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -226,6 +226,32 @@ static inline void vpn_leak_postchange(vpn_policy_direction_t direction,
 	}
 }
 
+/* Flag if the route is injectable into VPN. This would be either a
+ * non-imported route or a non-VPN imported route.
+ */
+static inline bool is_route_injectable_into_vpn(struct bgp_path_info *pi)
+{
+	struct bgp_path_info *parent_pi;
+	struct bgp_table *table;
+	struct bgp_node *rn;
+
+	if (pi->sub_type != BGP_ROUTE_IMPORTED ||
+	    !pi->extra ||
+	    !pi->extra->parent)
+		return true;
+
+	parent_pi = (struct bgp_path_info *)pi->extra->parent;
+	rn = parent_pi->net;
+	if (!rn)
+		return true;
+	table = bgp_node_table(rn);
+	if (table &&
+	    (table->afi == AFI_IP || table->afi == AFI_IP6) &&
+	    table->safi == SAFI_MPLS_VPN)
+		return false;
+	return true;
+}
+
 extern void vpn_policy_routemap_event(const char *rmap_name);
 
 extern vrf_id_t get_first_vrf_for_redirect_with_rt(struct ecommunity *eckey);

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -252,6 +252,13 @@ static inline bool is_route_injectable_into_vpn(struct bgp_path_info *pi)
 	return true;
 }
 
+/* Flag if the route path's family is VPN. */
+static inline bool is_pi_family_vpn(struct bgp_path_info *pi)
+{
+	return (is_pi_family_matching(pi, AFI_IP, SAFI_MPLS_VPN) ||
+		is_pi_family_matching(pi, AFI_IP6, SAFI_MPLS_VPN));
+}
+
 extern void vpn_policy_routemap_event(const char *rmap_name);
 
 extern vrf_id_t get_first_vrf_for_redirect_with_rt(struct ecommunity *eckey);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2476,8 +2476,9 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 
 	/* advertise/withdraw type-5 routes */
 	if ((afi == AFI_IP || afi == AFI_IP6) && (safi == SAFI_UNICAST)) {
-		if (advertise_type5_routes(bgp, afi) && new_select &&
-		    (!new_select->extra || !new_select->extra->parent)) {
+		if (advertise_type5_routes(bgp, afi) &&
+		    new_select &&
+		    is_route_injectable_into_evpn(new_select)) {
 
 			/* apply the route-map */
 			if (bgp->adv_cmd_rmap[afi][safi].map) {
@@ -2500,8 +2501,9 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 							       afi, safi);
 
 			}
-		} else if (advertise_type5_routes(bgp, afi) && old_select &&
-			 (!old_select->extra || !old_select->extra->parent))
+		} else if (advertise_type5_routes(bgp, afi) &&
+			   old_select &&
+			   is_route_injectable_into_evpn(old_select))
 			bgp_evpn_withdraw_type5_route(bgp, &rn->p, afi, safi);
 	}
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -341,6 +341,24 @@ static inline int bgp_fibupd_safi(safi_t safi)
 	return 0;
 }
 
+/* Flag if the route path's family matches params. */
+static inline bool is_pi_family_matching(struct bgp_path_info *pi,
+					 afi_t afi, safi_t safi)
+{
+	struct bgp_table *table;
+	struct bgp_node *rn;
+
+	rn = pi->net;
+	if (!rn)
+		return false;
+	table = bgp_node_table(rn);
+	if (table &&
+	    table->afi == afi &&
+	    table->safi == safi)
+		return true;
+	return false;
+}
+
 /* Prototypes. */
 extern void bgp_rib_remove(struct bgp_node *rn, struct bgp_path_info *pi,
 			   struct peer *peer, afi_t afi, safi_t safi);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1463,8 +1463,8 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 				       &(api_nh->gate.ipv4),
 				       sizeof(struct in_addr));
 				zebra_vxlan_evpn_vrf_route_add(
-					vrf_id, &api_nh->rmac, &vtep_ip,
-					&api.prefix);
+					api_nh->vrf_id, &api_nh->rmac,
+					&vtep_ip, &api.prefix);
 			}
 			break;
 		case NEXTHOP_TYPE_IPV6:
@@ -1493,8 +1493,8 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 				memcpy(&vtep_ip.ipaddr_v6, &(api_nh->gate.ipv6),
 				       sizeof(struct in6_addr));
 				zebra_vxlan_evpn_vrf_route_add(
-					vrf_id, &api_nh->rmac, &vtep_ip,
-					&api.prefix);
+					api_nh->vrf_id, &api_nh->rmac,
+					&vtep_ip, &api.prefix);
 			}
 			break;
 		case NEXTHOP_TYPE_BLACKHOLE:


### PR DESCRIPTION
### Summary
This set of commits implements dynamic route leaking of EVPN-based routes between VRFs. EVPN-based routes refers to IPv4 or IPv6 unicast routes in a BGP instance which are sourced/imported from an EVPN type-2 or type-5 route. Dynamic route leaking refers to the capability of FRR to leak these routes between BGP instances as they come and go, based on the operator merely enabling the leaking between the VRFs.

The approach followed is fully based on the existing route leaking capability that deals with leaking of regular (i.e., learnt or redistributed) IPv4 or IPv6 unicast routes between BGP instances. Specifically, the EVPN-based IP routes also get exported from the BGP instance routing table to the IP-VPN routing table in the default BGP instance and then imported by other relevant BGP instances. Special handling is needed for EVPN-based routes with respect to loop checking, next hop handling, passing along the proper info when installing into the zebra instance RIB, re-announcing the route back into EVPN etc. and these are implemented with these commits.

### Related Issue
[fill here if applicable]

### Components
bgpd, zebra
