### PR TITLE
zebra: include nexthop info when installing pseudowires

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -927,7 +927,7 @@ static void _netlink_route_nl_add_gateway_info(uint8_t route_family,
 					       uint8_t gw_family,
 					       struct nlmsghdr *nlmsg,
 					       size_t req_size, int bytelen,
-					       struct nexthop *nexthop)
+					       const struct nexthop *nexthop)
 {
 	if (route_family == AF_MPLS) {
 		struct gw_family_t gw_fam;
@@ -954,7 +954,7 @@ static void _netlink_route_rta_add_gateway_info(uint8_t route_family,
 						struct rtattr *rta,
 						struct rtnexthop *rtnh,
 						size_t req_size, int bytelen,
-						struct nexthop *nexthop)
+						const struct nexthop *nexthop)
 {
 	if (route_family == AF_MPLS) {
 		struct gw_family_t gw_fam;
@@ -990,7 +990,7 @@ static void _netlink_route_rta_add_gateway_info(uint8_t route_family,
  * @param req_size: The size allocated for the message.
  */
 static void _netlink_route_build_singlepath(const char *routedesc, int bytelen,
-					    struct nexthop *nexthop,
+					    const struct nexthop *nexthop,
 					    struct nlmsghdr *nlmsg,
 					    struct rtmsg *rtmsg,
 					    size_t req_size, int cmd)
@@ -1009,7 +1009,7 @@ static void _netlink_route_build_singlepath(const char *routedesc, int bytelen,
 	label_buf[0] = '\0';
 
 	assert(nexthop);
-	for (struct nexthop *nh = nexthop; nh; nh = nh->rparent) {
+	for (const struct nexthop *nh = nexthop; nh; nh = nh->rparent) {
 		char label_buf1[20];
 
 		nh_label = nh->nh_label;
@@ -1175,11 +1175,11 @@ static void _netlink_route_build_singlepath(const char *routedesc, int bytelen,
  *             the prefsrc should be stored.
  */
 static void _netlink_route_build_multipath(const char *routedesc, int bytelen,
-					   struct nexthop *nexthop,
+					   const struct nexthop *nexthop,
 					   struct rtattr *rta,
 					   struct rtnexthop *rtnh,
 					   struct rtmsg *rtmsg,
-					   union g_addr **src)
+					   const union g_addr **src)
 {
 	struct mpls_label_stack *nh_label;
 	mpls_lse_t out_lse[MPLS_MAX_LABELS];
@@ -1200,7 +1200,7 @@ static void _netlink_route_build_multipath(const char *routedesc, int bytelen,
 	label_buf[0] = '\0';
 
 	assert(nexthop);
-	for (struct nexthop *nh = nexthop; nh; nh = nh->rparent) {
+	for (const struct nexthop *nh = nexthop; nh; nh = nh->rparent) {
 		char label_buf1[20];
 
 		nh_label = nh->nh_label;
@@ -1342,7 +1342,7 @@ static void _netlink_route_build_multipath(const char *routedesc, int bytelen,
 }
 
 static inline void _netlink_mpls_build_singlepath(const char *routedesc,
-						  zebra_nhlfe_t *nhlfe,
+						  const zebra_nhlfe_t *nhlfe,
 						  struct nlmsghdr *nlmsg,
 						  struct rtmsg *rtmsg,
 						  size_t req_size, int cmd)
@@ -1358,9 +1358,9 @@ static inline void _netlink_mpls_build_singlepath(const char *routedesc,
 
 
 static inline void
-_netlink_mpls_build_multipath(const char *routedesc, zebra_nhlfe_t *nhlfe,
+_netlink_mpls_build_multipath(const char *routedesc, const zebra_nhlfe_t *nhlfe,
 			      struct rtattr *rta, struct rtnexthop *rtnh,
-			      struct rtmsg *rtmsg, union g_addr **src)
+			      struct rtmsg *rtmsg, const union g_addr **src)
 {
 	int bytelen;
 	uint8_t family;
@@ -1655,7 +1655,7 @@ static int netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 		char buf[NL_PKT_BUF_SIZE];
 		struct rtattr *rta = (void *)buf;
 		struct rtnexthop *rtnh;
-		union g_addr *src1 = NULL;
+		const union g_addr *src1 = NULL;
 
 		rta->rta_type = RTA_MULTIPATH;
 		rta->rta_len = RTA_LENGTH(0);
@@ -2744,7 +2744,7 @@ int kernel_upd_neigh(struct interface *ifp, struct ipaddr *ip,
 int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 {
 	mpls_lse_t lse;
-	zebra_nhlfe_t *nhlfe;
+	const zebra_nhlfe_t *nhlfe;
 	struct nexthop *nexthop = NULL;
 	unsigned int nexthop_num;
 	const char *routedesc;
@@ -2847,7 +2847,7 @@ int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 		char buf[NL_PKT_BUF_SIZE];
 		struct rtattr *rta = (void *)buf;
 		struct rtnexthop *rtnh;
-		union g_addr *src1 = NULL;
+		const union g_addr *src1 = NULL;
 
 		rta->rta_type = RTA_MULTIPATH;
 		rta->rta_len = RTA_LENGTH(0);

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -756,14 +756,15 @@ uint32_t dplane_ctx_get_lsp_flags(const struct zebra_dplane_ctx *ctx)
 	return ctx->u.lsp.flags;
 }
 
-zebra_nhlfe_t *dplane_ctx_get_nhlfe(struct zebra_dplane_ctx *ctx)
+const zebra_nhlfe_t *dplane_ctx_get_nhlfe(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
 
 	return ctx->u.lsp.nhlfe_list;
 }
 
-zebra_nhlfe_t *dplane_ctx_get_best_nhlfe(struct zebra_dplane_ctx *ctx)
+const zebra_nhlfe_t *
+dplane_ctx_get_best_nhlfe(const struct zebra_dplane_ctx *ctx)
 {
 	DPLANE_CTX_VALID(ctx);
 

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -219,6 +219,8 @@ const union g_addr *dplane_ctx_get_pw_dest(
 	const struct zebra_dplane_ctx *ctx);
 const union pw_protocol_fields *dplane_ctx_get_pw_proto(
 	const struct zebra_dplane_ctx *ctx);
+const struct nexthop_group *dplane_ctx_get_pw_nhg(
+	const struct zebra_dplane_ctx *ctx);
 
 /* Namespace info - esp. for netlink communication */
 const struct zebra_dplane_info *dplane_ctx_get_ns(

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -203,8 +203,9 @@ const struct nexthop_group *dplane_ctx_get_old_ng(
 mpls_label_t dplane_ctx_get_in_label(const struct zebra_dplane_ctx *ctx);
 uint8_t dplane_ctx_get_addr_family(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_lsp_flags(const struct zebra_dplane_ctx *ctx);
-zebra_nhlfe_t *dplane_ctx_get_nhlfe(struct zebra_dplane_ctx *ctx);
-zebra_nhlfe_t *dplane_ctx_get_best_nhlfe(struct zebra_dplane_ctx *ctx);
+const zebra_nhlfe_t *dplane_ctx_get_nhlfe(const struct zebra_dplane_ctx *ctx);
+const zebra_nhlfe_t *dplane_ctx_get_best_nhlfe(
+	const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_lsp_num_ecmp(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for pseudowire information */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -215,7 +215,7 @@ int dplane_ctx_get_pw_type(const struct zebra_dplane_ctx *ctx);
 int dplane_ctx_get_pw_af(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_pw_flags(const struct zebra_dplane_ctx *ctx);
 int dplane_ctx_get_pw_status(const struct zebra_dplane_ctx *ctx);
-const union g_addr *dplane_ctx_get_pw_nexthop(
+const union g_addr *dplane_ctx_get_pw_dest(
 	const struct zebra_dplane_ctx *ctx);
 const union pw_protocol_fields *dplane_ctx_get_pw_proto(
 	const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -342,7 +342,7 @@ static enum zebra_dplane_result kmpw_install(struct zebra_dplane_ctx *ctx)
 
 	/* pseudowire nexthop */
 	memset(&ss, 0, sizeof(ss));
-	gaddr = dplane_ctx_get_pw_nexthop(ctx);
+	gaddr = dplane_ctx_get_pw_dest(ctx);
 	switch (dplane_ctx_get_pw_af(ctx)) {
 	case AF_INET:
 		sa_in->sin_family = AF_INET;

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -43,7 +43,7 @@ struct {
 } kr_state;
 
 static int kernel_send_rtmsg_v4(int action, mpls_label_t in_label,
-				zebra_nhlfe_t *nhlfe)
+				const zebra_nhlfe_t *nhlfe)
 {
 	struct iovec iov[5];
 	struct rt_msghdr hdr;
@@ -135,7 +135,7 @@ static int kernel_send_rtmsg_v4(int action, mpls_label_t in_label,
 #endif
 
 static int kernel_send_rtmsg_v6(int action, mpls_label_t in_label,
-				zebra_nhlfe_t *nhlfe)
+				const zebra_nhlfe_t *nhlfe)
 {
 	struct iovec iov[5];
 	struct rt_msghdr hdr;
@@ -238,7 +238,7 @@ static int kernel_send_rtmsg_v6(int action, mpls_label_t in_label,
 
 static int kernel_lsp_cmd(struct zebra_dplane_ctx *ctx)
 {
-	zebra_nhlfe_t *nhlfe;
+	const zebra_nhlfe_t *nhlfe;
 	struct nexthop *nexthop = NULL;
 	unsigned int nexthop_num = 0;
 	int action;


### PR DESCRIPTION
In the zebra dataplane, include nexthop info when programming pseudowires. Some dataplanes might like to have that info.

### Components
zebra
