### PR TITLE
bgpd: validate the nexthop of VPN routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3563,7 +3563,8 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 	}
 	/* Nexthop reachability check. */
 	if ((afi == AFI_IP || afi == AFI_IP6)
-	    && (safi == SAFI_UNICAST || safi == SAFI_LABELED_UNICAST)) {
+	    && (safi == SAFI_UNICAST || safi == SAFI_LABELED_UNICAST
+		|| safi == SAFI_MPLS_VPN)) {
 		if (peer->sort == BGP_PEER_EBGP && peer->ttl == 1
 		    && !CHECK_FLAG(peer->flags,
 				   PEER_FLAG_DISABLE_CONNECTED_CHECK)


### PR DESCRIPTION
We shouldn't mark a VPN route as valid unless we have an LSP to its
BGP nexthop. This is necessary to ensure that VPN-labeled packets
can reach the remote PE, otherwise traffic blackholing can occur
(e.g. when BGP converges before LDP).

This is in line with RFC 4364, which says the following (section
4.3.2):
  "(...) In using BGP-distributed MPLS labels in this manner,
  we presuppose that an MPLS packet carrying such a label can
  be tunneled from the router that installs the corresponding
  BGP-distributed route to the router that is the BGP next hop
  of that route. This requires either that a label switched path
  exist between those two routers or else that some other tunneling
  technology (e.g., [MPLS-in-IP-GRE]) can be used between them".

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>