### PR TITLE
zebra: When installing a new route always use REPLACE

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1477,10 +1477,9 @@ static int netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
 	req.n.nlmsg_flags = NLM_F_CREATE | NLM_F_REQUEST;
 
-	if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_UPDATE) {
-		if ((p->family == AF_INET) || v6_rr_semantics)
-			req.n.nlmsg_flags |= NLM_F_REPLACE;
-	}
+	if ((cmd == RTM_NEWROUTE) &&
+	    ((p->family == AF_INET) || v6_rr_semantics))
+		req.n.nlmsg_flags |= NLM_F_REPLACE;
 
 	req.n.nlmsg_type = cmd;
 


### PR DESCRIPTION
When we install a new route into the kernel always use
REPLACE.  Else if the route is already there it can
be translated into an append with the flags we are
using.

This is especially true for the way we handle pbr
routes as that we are re-installing the same route
entry from pbr at the moment.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
