### PR TITLE
bgpd: Remove private AS numbers if local-as is defined

### DIFF
--- a/tests/topotests/bgp_local_as_private_remove/r1/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r1/bgpd.conf
@@ -1,0 +1,6 @@
+router bgp 65000
+  neighbor 192.168.255.2 remote-as 1000
+  neighbor 192.168.255.2 local-as 500
+  address-family ipv4 unicast
+    neighbor 192.168.255.2 remove-private-AS
+    redistribute connected

--- a/tests/topotests/bgp_local_as_private_remove/r1/zebra.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r1/zebra.conf
@@ -1,0 +1,9 @@
+!
+interface lo
+ ip address 172.16.255.254/32
+!
+interface r1-eth0
+ ip address 192.168.255.1/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_local_as_private_remove/r2/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r2/bgpd.conf
@@ -1,0 +1,2 @@
+router bgp 1000
+  neighbor 192.168.255.1 remote-as 500

--- a/tests/topotests/bgp_local_as_private_remove/r2/zebra.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r2/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r2-eth0
+ ip address 192.168.255.2/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_local_as_private_remove/r3/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r3/bgpd.conf
@@ -1,0 +1,6 @@
+router bgp 3000
+  neighbor 192.168.255.2 remote-as 1000
+  neighbor 192.168.255.2 local-as 500
+  address-family ipv4 unicast
+    neighbor 192.168.255.2 remove-private-AS
+    redistribute connected

--- a/tests/topotests/bgp_local_as_private_remove/r3/zebra.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r3/zebra.conf
@@ -1,0 +1,9 @@
+!
+interface lo
+ ip address 172.16.255.254/32
+!
+interface r3-eth0
+ ip address 192.168.255.1/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_local_as_private_remove/r4/bgpd.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r4/bgpd.conf
@@ -1,0 +1,2 @@
+router bgp 1000
+  neighbor 192.168.255.1 remote-as 500

--- a/tests/topotests/bgp_local_as_private_remove/r4/zebra.conf
+++ b/tests/topotests/bgp_local_as_private_remove/r4/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r4-eth0
+ ip address 192.168.255.2/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_local_as_private_remove/test_bgp_local_as_private_remove.py
+++ b/tests/topotests/bgp_local_as_private_remove/test_bgp_local_as_private_remove.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+#
+# bgp_local_as_private_remove.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2019 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+bgp_local_as_private_remove.py:
+Test if primary AS number is not removed in cases when `local-as`
+used together with `remove-private-AS`.
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+class TemplateTopo(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        for routern in range(1, 5):
+            tgen.add_router('r{}'.format(routern))
+
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
+
+        switch = tgen.add_switch('s2')
+        switch.add_link(tgen.gears['r3'])
+        switch.add_link(tgen.gears['r4'])
+
+def setup_module(mod):
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA,
+            os.path.join(CWD, '{}/zebra.conf'.format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP,
+            os.path.join(CWD, '{}/bgpd.conf'.format(rname))
+        )
+
+    tgen.start_router()
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_bgp_remove_private_as():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _bgp_converge(router):
+        while True:
+            output = json.loads(tgen.gears[router].vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
+            if output['192.168.255.1']['bgpState'] == 'Established':
+                time.sleep(1)
+                return True
+
+    def _bgp_as_path(router):
+        output = json.loads(tgen.gears[router].vtysh_cmd("show ip bgp 172.16.255.254/32 json"))
+        if output['prefix'] == '172.16.255.254/32':
+            return output['paths'][0]['aspath']['segments'][0]['list']
+
+    if _bgp_converge('r2'):
+        assert len(_bgp_as_path('r2')) == 1
+        assert 65000 not in _bgp_as_path('r2')
+
+    if _bgp_converge('r4'):
+        assert len(_bgp_as_path('r4')) == 2
+        assert 3000 in _bgp_as_path('r4')
+
+if __name__ == '__main__':
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
When using remove-private-AS together with local-as
aspath_remove_private_asns() is called before bgp_packet_attribute().

In this case, private AS will always appear in front of change_local_as.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

### Related Issue
Closes https://github.com/FRRouting/frr/issues/3891

### Components
bgpd
