### PR TITLE
ripd: fix removal of configured passive interfaces

### DIFF
--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -378,10 +378,19 @@ DEFPY (rip_passive_interface,
        "Suppress routing updates on an interface\n"
        "Interface name\n")
 {
-	nb_cli_enqueue_change(vty, "./passive-interface",
-			      no ? NB_OP_DESTROY : NB_OP_CREATE, ifname);
-	nb_cli_enqueue_change(vty, "./non-passive-interface",
-			      no ? NB_OP_CREATE : NB_OP_DESTROY, ifname);
+	bool passive_default =
+		yang_dnode_get_bool(vty->candidate_config->dnode, "%s%s",
+				    VTY_CURR_XPATH, "/passive-default");
+
+	if (passive_default) {
+		nb_cli_enqueue_change(vty, "./non-passive-interface",
+				      no ? NB_OP_CREATE : NB_OP_DESTROY,
+				      ifname);
+	} else {
+		nb_cli_enqueue_change(vty, "./passive-interface",
+				      no ? NB_OP_DESTROY : NB_OP_CREATE,
+				      ifname);
+	}
 
 	return nb_cli_apply_changes(vty, NULL);
 }


### PR DESCRIPTION
### Summary
libyang-0.16-rc3 fixed a bug [1] in which data would be auto-deleted
when it shouldn't. The problem is that the "no passive-interface"
command was relying on that wrong behavior, so the command was
affected when the libyang bug was fixed. Adapt the command to do
the right thing in order to get rid of the problem (regardless of
the libyang version being used).

"passive-interface default" still has problems though, but that
will be addressed separetely in the future.

[1] https://github.com/CESNET/libyang/commit/8af82206908

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>

### Related Issue
Fixes #3870.

### Components
ripd
