### PR TITLE
pimd: Ensure DR election happens when both sides change prio

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6353,8 +6353,8 @@ DEFUN (interface_ip_pim_drprio,
 	pim_ifp->pim_dr_priority = strtol(argv[idx_number]->arg, NULL, 10);
 
 	if (old_dr_prio != pim_ifp->pim_dr_priority) {
-		if (pim_if_dr_election(ifp))
-			pim_hello_restart_now(ifp);
+		pim_if_dr_election(ifp);
+		pim_hello_restart_now(ifp);
 	}
 
 	return CMD_SUCCESS;
@@ -6379,8 +6379,8 @@ DEFUN (interface_no_ip_pim_drprio,
 
 	if (pim_ifp->pim_dr_priority != PIM_DEFAULT_DR_PRIORITY) {
 		pim_ifp->pim_dr_priority = PIM_DEFAULT_DR_PRIORITY;
-		if (pim_if_dr_election(ifp))
-			pim_hello_restart_now(ifp);
+		pim_if_dr_election(ifp);
+		pim_hello_restart_now(ifp);
 	}
 
 	return CMD_SUCCESS;


### PR DESCRIPTION
Suppose we have 2 routers A and B.  Both Router A and B have
the same priority of 1000.  Router A is the elected DR.
Now suppose B lowers his priority to 1.  He still looses the
DR election and we are not sending a hello with the new priority.
Immediately after this A's priority is also lowered to 1, it
looses the election and sends the hello.  B receives this hello
and elects A as the DR( since it has the better ip address)
At this point A believes B is the DR, and B believes A is the
DR until such time that the normal hello from B is sent to A,
which if timed correctly can be a significant amount of time).

This code just causes a hello to be sent if the priority is
changed.  Now both sides will be able to converge quickly

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

