### PR TITLE
zebra: Treat ifaces withouth IPv4 as unnumbered

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -594,5 +594,5 @@ int connected_is_unnumbered(struct interface *ifp)
 			return CHECK_FLAG(connected->flags,
 					  ZEBRA_IFA_UNNUMBERED);
 	}
-	return 0;
+	return 1;
 }


### PR DESCRIPTION
The current definition of an unnumberd interface as an interface with a
/32 IPv4 is too restrictive, especially for EVPN symmetric routing since
commit 2b83602 "*: Explicitly mark nexthop of EVPN-sourced routes as
onlink".

It removes the bypass check wether the nexthop is an EVPN VTEP, and
relies on the SVI to be unnumberd to bypass the gateway lookup. While
this works great if the SVI has an IP, it might not, and the test falls
flat and EVPN type 5 routes are not installed into the RIB.

Sample interface setup, where vxlan-blue is the L3VNI and br-blue the
SVI:

              +----------+
              |          |
              | vrf-blue |
              |          |
              +---+--+---+
                  |  |
          +-------+  +-----------+
          |                      |
     +----+----+       +---------+---------+
     |         |       |        br1        |
     | br-blue |       |    10.0.0.1/24    |
     |         |       +-+-------+-------+-+
     +----+----+         |       |       |
          |              |       |       |
    +-----+------+ +-----+--+ +--+---+ +-+----+
    |            | |        | |      | |      |
    | vxlan-blue | | vxlan1 | | eth1 | | eth2 |
    |            | |        | |      | |      |
    +------------+ +--------+ +------+ +------+

For inter-VNI routing, the SVI has no reason to have an IP, but it still
needs type-5 routes from remote VTEPs.

This commit expands the definition of an unnumberd interface to an
interface having a /32 IPv4 or no IPv4 at all.

### Components
zebra
