### PR TITLE
Ecmp up in my business

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -765,7 +765,7 @@ AC_DEFINE_UNQUOTED([CONFIGFILE_MASK], [${enable_configfile_mask}], [Mask for con
 enable_logfile_mask=${enable_logfile_mask:-0600}
 AC_DEFINE_UNQUOTED([LOGFILE_MASK], [${enable_logfile_mask}], [Mask for log files])
 
-MPATH_NUM=1
+MPATH_NUM=16
 
 case "${enable_multipath}" in
   0)

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -275,7 +275,8 @@ options from the list below.
    For backwards compatability with older configure options when setting X = 0,
    we will build FRR with 64 way ECMP.  This is needed because there are
    hardcoded arrays that FRR builds towards, so we need to know how big to
-   make these arrays at build time.
+   make these arrays at build time.  Additionally if this parameter is
+   not passed in FRR will default to 16 ECMP.
 
 .. option:: --enable-shell-access
 


### PR DESCRIPTION
Update the configuration of FRR to always assume 16 way ecmp.  This is a change in behavior for people who compile FRR, those who actually want 1 will need to specify it by hand now.