### PR TITLE
ospfd: When converting to ms divide by 1000

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3490,7 +3490,7 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 					    oi->output_cost);
 			json_object_int_add(
 				json_interface_sub, "transmitDelayMsecs",
-				1000 / OSPF_IF_PARAM(oi, transmit_delay));
+				OSPF_IF_PARAM(oi, transmit_delay) / 1000);
 			json_object_string_add(json_interface_sub, "state",
 					       lookup_msg(ospf_ism_state_msg,
 							  oi->state, NULL));
@@ -3594,20 +3594,20 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 			if (OSPF_IF_PARAM(oi, fast_hello) == 0)
 				json_object_int_add(
 					json_interface_sub, "timerMsecs",
-					1000 / OSPF_IF_PARAM(oi, v_hello));
+					OSPF_IF_PARAM(oi, v_hello) / 1000);
 			else
 				json_object_int_add(
 					json_interface_sub, "timerMsecs",
-					1000 / OSPF_IF_PARAM(oi, fast_hello));
+					OSPF_IF_PARAM(oi, fast_hello) / 1000);
 			json_object_int_add(json_interface_sub,
 					    "timerDeadMsecs",
-					    1000 / OSPF_IF_PARAM(oi, v_wait));
+					    OSPF_IF_PARAM(oi, v_wait) / 1000);
 			json_object_int_add(json_interface_sub,
 					    "timerWaitMsecs",
-					    1000 / OSPF_IF_PARAM(oi, v_wait));
+					    OSPF_IF_PARAM(oi, v_wait) / 1000);
 			json_object_int_add(
 				json_interface_sub, "timerRetransmit",
-				1000 / OSPF_IF_PARAM(oi, retransmit_interval));
+				OSPF_IF_PARAM(oi, retransmit_interval) / 1000);
 		} else {
 			vty_out(vty, "  Timer intervals configured,");
 			vty_out(vty, " Hello ");


### PR DESCRIPTION
When converting to miliseconds divide by 1000 not
the other way around.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
