### PR TITLE
ospfd: Rename timers to something a bit better

### DIFF
--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -3615,11 +3615,11 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 		if (use_json) {
 			if (OSPF_IF_PARAM(oi, fast_hello) == 0)
 				json_object_int_add(
-					json_interface_sub, "timerMsecs",
+					json_interface_sub, "timerHelloMsecs",
 					OSPF_IF_PARAM(oi, v_hello) / 1000);
 			else
 				json_object_int_add(
-					json_interface_sub, "timerMsecs",
+					json_interface_sub, "timerHelloMsecs",
 					OSPF_IF_PARAM(oi, fast_hello) / 1000);
 			json_object_int_add(json_interface_sub,
 					    "timerDeadMsecs",
@@ -3628,7 +3628,7 @@ static void show_ip_ospf_interface_sub(struct vty *vty, struct ospf *ospf,
 					    "timerWaitMsecs",
 					    OSPF_IF_PARAM(oi, v_wait) / 1000);
 			json_object_int_add(
-				json_interface_sub, "timerRetransmit",
+				json_interface_sub, "timerRetransmitMsecs",
 				OSPF_IF_PARAM(oi, retransmit_interval) / 1000);
 		} else {
 			vty_out(vty, "  Timer intervals configured,");


### PR DESCRIPTION
The json entry names were not very useful and given that they
were being calculated incorrectly, no-one could have been using
them.  Update the names to be more descriptive.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

