### PR TITLE
zebra: Set ZEBRA_IFA_PEER whenever we have a broadcast address

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1018,11 +1018,12 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	    && memcmp(RTA_DATA(tb[IFA_ADDRESS]), RTA_DATA(tb[IFA_LOCAL]),
 		      RTA_PAYLOAD(tb[IFA_ADDRESS]))) {
 		broad = RTA_DATA(tb[IFA_ADDRESS]);
-		SET_FLAG(flags, ZEBRA_IFA_PEER);
 	} else
 		/* seeking a broadcast address */
 		broad = (tb[IFA_BROADCAST] ? RTA_DATA(tb[IFA_BROADCAST])
 					   : NULL);
+	if (broad)
+		SET_FLAG(flags, ZEBRA_IFA_PEER);
 
 	/* addr is primary key, SOL if we don't have one */
 	if (addr == NULL) {


### PR DESCRIPTION
Under linux there exists a code path where we were not setting
the ZEBRA_IFA_PEER if we have a broadcast address from the
kernel.  Modify the code to read in the broadcast and set
the flag as appropriate.

Fixes: #3053 
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
