### PR TITLE
Bgpd redist connected vrf

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -281,9 +281,9 @@ static int bgp_vrf_enable(struct vrf *vrf)
 		bgp_vrf_link(bgp, vrf);
 
 		bgp_handle_socket(bgp, vrf, old_vrf_id, true);
-		/* Update any redistribute vrf bitmaps if the vrf_id changed */
+		/* Update any redistribution if vrf_id changed */
 		if (old_vrf_id != bgp->vrf_id)
-			bgp_update_redist_vrf_bitmaps(bgp, old_vrf_id);
+			bgp_redistribute_redo(bgp);
 		bgp_instance_up(bgp);
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP);
 		vpn_leak_zebra_vrf_label_update(bgp, AFI_IP6);
@@ -330,9 +330,9 @@ static int bgp_vrf_disable(struct vrf *vrf)
 		/* We have instance configured, unlink from VRF and make it
 		 * "down". */
 		bgp_vrf_unlink(bgp, vrf);
-		/* Update any redistribute vrf bitmaps if the vrf_id changed */
+		/* Delete any redistribute vrf bitmaps if the vrf_id changed */
 		if (old_vrf_id != bgp->vrf_id)
-			bgp_update_redist_vrf_bitmaps(bgp, old_vrf_id);
+			bgp_unset_redist_vrf_bitmaps(bgp, old_vrf_id);
 		bgp_instance_down(bgp);
 	}
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2055,29 +2055,6 @@ DEFUN (no_bgp_graceful_restart_preserve_fw,
 	return CMD_SUCCESS;
 }
 
-static void bgp_redistribute_redo(struct bgp *bgp)
-{
-	afi_t afi;
-	int i;
-	struct list *red_list;
-	struct listnode *node;
-	struct bgp_redist *red;
-
-	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
-		for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
-
-			red_list = bgp->redist[afi][i];
-			if (!red_list)
-				continue;
-
-			for (ALL_LIST_ELEMENTS_RO(red_list, node, red)) {
-				bgp_redistribute_resend(bgp, afi, i,
-							red->instance);
-			}
-		}
-	}
-}
-
 /* "bgp graceful-shutdown" configuration */
 DEFUN (bgp_graceful_shutdown,
        bgp_graceful_shutdown_cmd,

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1820,6 +1820,29 @@ int bgp_redistribute_unset(struct bgp *bgp, afi_t afi, int type,
 	return CMD_SUCCESS;
 }
 
+void bgp_redistribute_redo(struct bgp *bgp)
+{
+	afi_t afi;
+	int i;
+	struct list *red_list;
+	struct listnode *node;
+	struct bgp_redist *red;
+
+	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
+		for (i = 0; i < ZEBRA_ROUTE_MAX; i++) {
+
+			red_list = bgp->redist[afi][i];
+			if (!red_list)
+				continue;
+
+			for (ALL_LIST_ELEMENTS_RO(red_list, node, red)) {
+				bgp_redistribute_resend(bgp, afi, i,
+							red->instance);
+			}
+		}
+	}
+}
+
 /* Update redistribute vrf bitmap during triggers like
    restart networking or delete/add VRFs */
 void bgp_update_redist_vrf_bitmaps(struct bgp *bgp, vrf_id_t old_vrf_id)

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1829,9 +1829,8 @@ void bgp_update_redist_vrf_bitmaps(struct bgp *bgp, vrf_id_t old_vrf_id)
 
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
-			if ((old_vrf_id == VRF_UNKNOWN)
-			    || vrf_bitmap_check(zclient->redist[afi][i],
-						old_vrf_id)) {
+			if (vrf_bitmap_check(zclient->redist[afi][i],
+					     old_vrf_id)) {
 				vrf_bitmap_unset(zclient->redist[afi][i],
 						 old_vrf_id);
 				vrf_bitmap_set(zclient->redist[afi][i],

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1843,9 +1843,9 @@ void bgp_redistribute_redo(struct bgp *bgp)
 	}
 }
 
-/* Update redistribute vrf bitmap during triggers like
-   restart networking or delete/add VRFs */
-void bgp_update_redist_vrf_bitmaps(struct bgp *bgp, vrf_id_t old_vrf_id)
+/* Unset redistribute vrf bitmap during triggers like
+   restart networking or delete VRFs */
+void bgp_unset_redist_vrf_bitmaps(struct bgp *bgp, vrf_id_t old_vrf_id)
 {
 	int i;
 	afi_t afi;
@@ -1853,12 +1853,9 @@ void bgp_update_redist_vrf_bitmaps(struct bgp *bgp, vrf_id_t old_vrf_id)
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)
 		for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
 			if (vrf_bitmap_check(zclient->redist[afi][i],
-					     old_vrf_id)) {
+					     old_vrf_id))
 				vrf_bitmap_unset(zclient->redist[afi][i],
 						 old_vrf_id);
-				vrf_bitmap_set(zclient->redist[afi][i],
-					       bgp->vrf_id);
-			}
 	return;
 }
 

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -49,6 +49,7 @@ extern void bgp_zebra_terminate_radv(struct bgp *bgp, struct peer *peer);
 extern void bgp_zebra_instance_register(struct bgp *);
 extern void bgp_zebra_instance_deregister(struct bgp *);
 
+extern void bgp_redistribute_redo(struct bgp *bgp);
 extern struct bgp_redist *bgp_redist_lookup(struct bgp *, afi_t, uint8_t,
 					    unsigned short);
 extern struct bgp_redist *bgp_redist_add(struct bgp *, afi_t, uint8_t,

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1904,7 +1904,7 @@ static inline void bgp_vrf_unlink(struct bgp *bgp, struct vrf *vrf)
 	bgp->vrf_id = VRF_UNKNOWN;
 }
 
-extern void bgp_update_redist_vrf_bitmaps(struct bgp *, vrf_id_t);
+extern void bgp_unset_redist_vrf_bitmaps(struct bgp *, vrf_id_t);
 
 /* For benefit of rfapi */
 extern struct peer *peer_new(struct bgp *bgp);


### PR DESCRIPTION
### Summary
Found that previous fix (PR1620) for this issue caused collateral damage and
reverted that fix.  This fix clears the vrf_bitmaps when the vrf is
disabled/deleted and then re-applies the redist config when the vrf
is re-enabled.

### Related Issue
PR1620

### Components
bgpd