### PR TITLE
*: remove trailing newlines from zlog messages

### DIFF
--- a/bgpd/bgp_addpath.c
+++ b/bgpd/bgp_addpath.c
@@ -384,7 +384,7 @@ void bgp_addpath_set_peer_type(struct peer *peer, afi_t afi, safi_t safi,
 		}
 	}
 
-	zlog_info("Resetting peer %s%s due to change in addpath config\n",
+	zlog_info("Resetting peer %s%s due to change in addpath config",
 		  CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP) ? "group " : "",
 		  peer->host);
 

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -995,7 +995,7 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn, /* to */
 				    == bgp_vrf) {
 					/* delete route */
 					if (debug)
-						zlog_debug("%s: deleting it\n",
+						zlog_debug("%s: deleting it",
 							   __func__);
 					bgp_aggregate_decrement(bgp_vpn, &bn->p,
 								bpi, afi, safi);

--- a/eigrpd/eigrp_fsm.c
+++ b/eigrpd/eigrp_fsm.c
@@ -314,7 +314,7 @@ eigrp_get_fsm_event(struct eigrp_fsm_action_message *msg)
 			if (prefix->rij->count)
 				return EIGRP_FSM_KEEP_STATE;
 
-			zlog_info("All reply received\n");
+			zlog_info("All reply received");
 			if (head->reported_distance < prefix->fdistance) {
 				return EIGRP_FSM_EVENT_LR_FCS;
 			}
@@ -344,7 +344,7 @@ eigrp_get_fsm_event(struct eigrp_fsm_action_message *msg)
 			} else if (prefix->rij->count) {
 				return EIGRP_FSM_KEEP_STATE;
 			} else {
-				zlog_info("All reply received\n");
+				zlog_info("All reply received");
 				return EIGRP_FSM_EVENT_LR;
 			}
 		} else if (msg->packet_type == EIGRP_OPC_UPDATE
@@ -366,7 +366,7 @@ eigrp_get_fsm_event(struct eigrp_fsm_action_message *msg)
 			if (prefix->rij->count) {
 				return EIGRP_FSM_KEEP_STATE;
 			} else {
-				zlog_info("All reply received\n");
+				zlog_info("All reply received");
 				if (head->reported_distance
 				    < prefix->fdistance) {
 					return EIGRP_FSM_EVENT_LR_FCS;
@@ -390,7 +390,7 @@ eigrp_get_fsm_event(struct eigrp_fsm_action_message *msg)
 			} else if (prefix->rij->count) {
 				return EIGRP_FSM_KEEP_STATE;
 			} else {
-				zlog_info("All reply received\n");
+				zlog_info("All reply received");
 				return EIGRP_FSM_EVENT_LR;
 			}
 		} else if (msg->packet_type == EIGRP_OPC_UPDATE

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -131,7 +131,7 @@ static int process_p2p_hello(struct iih_info *iih)
 	if (tw_adj) {
 		if (tw_adj->state > ISIS_THREEWAY_DOWN) {
 			if (isis->debugs & DEBUG_ADJ_PACKETS) {
-				zlog_debug("ISIS-Adj (%s): Rcvd P2P IIH from (%s) with invalid three-way state: %d\n",
+				zlog_debug("ISIS-Adj (%s): Rcvd P2P IIH from (%s) with invalid three-way state: %d",
 					   iih->circuit->area->area_tag,
 					   iih->circuit->interface->name,
 					   tw_adj->state);
@@ -144,7 +144,7 @@ static int process_p2p_hello(struct iih_info *iih)
 			|| tw_adj->neighbor_circuit_id != (uint32_t) iih->circuit->idx)) {
 
 			if (isis->debugs & DEBUG_ADJ_PACKETS) {
-				zlog_debug("ISIS-Adj (%s): Rcvd P2P IIH from (%s) which lists IS/Circuit different from us as neighbor.\n",
+				zlog_debug("ISIS-Adj (%s): Rcvd P2P IIH from (%s) which lists IS/Circuit different from us as neighbor.",
 					   iih->circuit->area->area_tag,
 					   iih->circuit->interface->name);
 			}
@@ -1523,7 +1523,7 @@ static int process_snp(uint8_t pdu_type, struct isis_circuit *circuit,
 	}
 
 	if (fabricd_initial_sync_is_complete(circuit->area) && resync_needed)
-		zlog_warn("OpenFabric: Needed to resync LSPDB using CSNP!\n");
+		zlog_warn("OpenFabric: Needed to resync LSPDB using CSNP!");
 
 	retval = ISIS_OK;
 out:

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -662,7 +662,7 @@ int vrf_netns_handler_create(struct vty *vty, struct vrf *vrf, char *pathname,
 				"VRF %u is already configured with VRF %s\n",
 				vrf->vrf_id, vrf->name);
 		else
-			zlog_info("VRF %u is already configured with VRF %s\n",
+			zlog_info("VRF %u is already configured with VRF %s",
 				  vrf->vrf_id, vrf->name);
 		return CMD_WARNING_CONFIG_FAILED;
 	}

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2504,7 +2504,7 @@ static int zclient_read(struct thread *thread)
 	length -= ZEBRA_HEADER_SIZE;
 
 	if (zclient_debug)
-		zlog_debug("zclient 0x%p command 0x%x VRF %u\n",
+		zlog_debug("zclient 0x%p command 0x%x VRF %u",
 			   (void *)zclient, command, vrf_id);
 
 	switch (command) {
@@ -2574,14 +2574,14 @@ static int zclient_read(struct thread *thread)
 		break;
 	case ZEBRA_NEXTHOP_UPDATE:
 		if (zclient_debug)
-			zlog_debug("zclient rcvd nexthop update\n");
+			zlog_debug("zclient rcvd nexthop update");
 		if (zclient->nexthop_update)
 			(*zclient->nexthop_update)(command, zclient, length,
 						   vrf_id);
 		break;
 	case ZEBRA_IMPORT_CHECK_UPDATE:
 		if (zclient_debug)
-			zlog_debug("zclient rcvd import check update\n");
+			zlog_debug("zclient rcvd import check update");
 		if (zclient->import_check_update)
 			(*zclient->import_check_update)(command, zclient,
 							length, vrf_id);
@@ -2608,7 +2608,7 @@ static int zclient_read(struct thread *thread)
 		break;
 	case ZEBRA_FEC_UPDATE:
 		if (zclient_debug)
-			zlog_debug("zclient rcvd fec update\n");
+			zlog_debug("zclient rcvd fec update");
 		if (zclient->fec_update)
 			(*zclient->fec_update)(command, zclient, length);
 		break;

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -138,11 +138,11 @@ static void ospf6_area_stub_update(struct ospf6_area *area)
 
 	if (IS_AREA_STUB(area)) {
 		if (IS_OSPF6_DEBUG_ORIGINATE(ROUTER))
-			zlog_debug("Stubbing out area for if %s\n", area->name);
+			zlog_debug("Stubbing out area for if %s", area->name);
 		OSPF6_OPT_CLEAR(area->options, OSPF6_OPT_E);
 	} else if (IS_AREA_ENABLED(area)) {
 		if (IS_OSPF6_DEBUG_ORIGINATE(ROUTER))
-			zlog_debug("Normal area for if %s\n", area->name);
+			zlog_debug("Normal area for if %s", area->name);
 		OSPF6_OPT_SET(area->options, OSPF6_OPT_E);
 		ospf6_asbr_send_externals_to_area(area);
 	}
@@ -450,7 +450,7 @@ DEFUN (area_range,
 
 	range->path.u.cost_config = cost;
 
-	zlog_debug("%s: for prefix %s, flag = %x\n", __func__,
+	zlog_debug("%s: for prefix %s, flag = %x", __func__,
 		   argv[idx_ipv6_prefixlen]->arg, range->flag);
 	if (range->rnode == NULL) {
 		ospf6_route_add(range, oa->range_table);

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1006,7 +1006,7 @@ void ospf6_asbr_send_externals_to_area(struct ospf6_area *oa)
 
 	for (ALL_LSDB(oa->ospf6->lsdb, lsa)) {
 		if (ntohs(lsa->header->type) == OSPF6_LSTYPE_AS_EXTERNAL) {
-			zlog_debug("%s: Flooding AS-External LSA %s\n",
+			zlog_debug("%s: Flooding AS-External LSA %s",
 				   __func__, lsa->name);
 			ospf6_flood_area(NULL, lsa, oa);
 		}

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -475,7 +475,7 @@ void ospf6_spf_calculation(uint32_t router_id,
 	lsa = ospf6_create_single_router_lsa(oa, oa->lsdb_self, router_id);
 	if (lsa == NULL) {
 		if (IS_OSPF6_DEBUG_SPF(PROCESS))
-			zlog_debug("%s: No router LSA for area %s\n", __func__,
+			zlog_debug("%s: No router LSA for area %s", __func__,
 				   oa->name);
 		return;
 	}

--- a/ospfd/ospf_api.c
+++ b/ospfd/ospf_api.c
@@ -74,12 +74,12 @@ void api_opaque_lsa_print(struct lsa_header *data)
 	olsa = (struct opaque_lsa *)data;
 
 	opaquelen = ntohs(data->length) - OSPF_LSA_HEADER_SIZE;
-	zlog_debug("apiserver_lsa_print: opaquelen=%d\n", opaquelen);
+	zlog_debug("apiserver_lsa_print: opaquelen=%d", opaquelen);
 
 	for (i = 0; i < opaquelen; i++) {
 		zlog_debug("0x%x ", olsa->mydata[i]);
 	}
-	zlog_debug("\n");
+	zlog_debug(" ");
 }
 
 /* -----------------------------------------------------------
@@ -242,7 +242,7 @@ const char *ospf_api_errname(int errcode)
 void msg_print(struct msg *msg)
 {
 	if (!msg) {
-		zlog_debug("msg_print msg=NULL!\n");
+		zlog_debug("msg_print msg=NULL!");
 		return;
 	}
 

--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -2024,7 +2024,7 @@ int ospf_apiserver_del_if(struct interface *ifp)
 
 	/* zlog_warn for debugging */
 	zlog_warn("ospf_apiserver_del_if");
-	zlog_warn("ifp name=%s status=%d index=%d\n", ifp->name, ifp->status,
+	zlog_warn("ifp name=%s status=%d index=%d", ifp->name, ifp->status,
 		  ifp->ifindex);
 
 	oi = ospf_apiserver_if_lookup_by_ifp(ifp);
@@ -2110,7 +2110,7 @@ void ospf_apiserver_show_info(struct vty *vty, struct ospf_lsa *lsa)
 		for (i = 0; i < opaquelen; i++) {
 			zlog_debug("0x%x ", olsa->data[i]);
 		}
-		zlog_debug("\n");
+		zlog_debug("");
 	}
 	return;
 }

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -1372,14 +1372,14 @@ static uint16_t show_vty_sr_algorithm(struct vty *vty, struct tlv_header *tlvh)
 	}
 
 	else {
-		zlog_debug("  Segment Routing Algorithm TLV:\n");
+		zlog_debug("  Segment Routing Algorithm TLV:");
 		for (i = 0; i < ntohs(algo->header.length); i++)
 			switch (algo->value[i]) {
 			case 0:
-				zlog_debug("    Algorithm %d: SPF\n", i);
+				zlog_debug("    Algorithm %d: SPF", i);
 				break;
 			case 1:
-				zlog_debug("    Algorithm %d: Strict SPF\n", i);
+				zlog_debug("    Algorithm %d: Strict SPF", i);
 				break;
 			default:
 				zlog_debug(

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -901,7 +901,7 @@ static struct ospf_lsa *lsdb_lookup_next(struct ospf_area *area, uint8_t *type,
 	/* Sanity check, if LSA type unknwon
 	   merley skip any LSA */
 	if ((i < OSPF_MIN_LSA) || (i >= OSPF_MAX_LSA)) {
-		zlog_debug("Strange request with LSA type %d\n", i);
+		zlog_debug("Strange request with LSA type %d", i);
 		return NULL;
 	}
 

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1140,13 +1140,13 @@ ospf_rtrs_print (struct route_table *rtrs)
               if (path->nexthop.s_addr == 0)
                 {
                   if (IS_DEBUG_OSPF_EVENT)
-                    zlog_debug ("   directly attached to %s\r\n",
+                    zlog_debug ("   directly attached to %s\r",
 				ifindex2ifname (path->ifindex), VRF_DEFAULT);
                 }
               else
                 {
                   if (IS_DEBUG_OSPF_EVENT)
-                    zlog_debug ("   via %s, %s\r\n",
+                    zlog_debug ("   via %s, %s\r",
 				inet_ntoa (path->nexthop),
 				ifindex2ifname (path->ifindex), VRF_DEFAULT);
                 }

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -1600,7 +1600,7 @@ static int ospf_sr_update_schedule(struct thread *t)
 	monotime(&stop_time);
 
 	if (IS_DEBUG_OSPF_SR)
-		zlog_debug("SR (%s): SPF Processing Time(usecs): %lld\n",
+		zlog_debug("SR (%s): SPF Processing Time(usecs): %lld",
 			   __func__,
 			   (stop_time.tv_sec - start_time.tv_sec) * 1000000LL
 				   + (stop_time.tv_usec - start_time.tv_usec));

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -97,7 +97,7 @@ void pim_register_stop_send(struct interface *ifp, struct prefix_sg *sg,
 	pinfo = (struct pim_interface *)ifp->info;
 	if (!pinfo) {
 		if (PIM_DEBUG_PIM_TRACE)
-			zlog_debug("%s: No pinfo!\n", __PRETTY_FUNCTION__);
+			zlog_debug("%s: No pinfo!", __PRETTY_FUNCTION__);
 		return;
 	}
 	if (pim_msg_send(pinfo->pim_sock_fd, src, originator, buffer,

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -90,7 +90,7 @@ static int ripng_multicast_join(struct interface *ifp)
 			 * group on
 			 * an interface that has just gone down.
 			 */
-			zlog_warn("ripng join on %s EADDRINUSE (ignoring)\n",
+			zlog_warn("ripng join on %s EADDRINUSE (ignoring)",
 				  ifp->name);
 			return 0; /* not an error */
 		}
@@ -124,7 +124,7 @@ static int ripng_multicast_leave(struct interface *ifp)
 		ret = setsockopt(ripng->sock, IPPROTO_IPV6, IPV6_LEAVE_GROUP,
 				 (char *)&mreq, sizeof(mreq));
 		if (ret < 0)
-			zlog_warn("can't setsockopt IPV6_LEAVE_GROUP: %s\n",
+			zlog_warn("can't setsockopt IPV6_LEAVE_GROUP: %s",
 				  safe_strerror(errno));
 
 		if (IS_RIPNG_DEBUG_EVENT)

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -241,7 +241,7 @@ int irdp_send_thread(struct thread *t_advert)
 		timer = MAX_INITIAL_ADVERT_INTERVAL;
 
 	if (irdp->flags & IF_DEBUG_MISC)
-		zlog_debug("IRDP: New timer for %s set to %u\n", ifp->name,
+		zlog_debug("IRDP: New timer for %s set to %u", ifp->name,
 			   timer);
 
 	irdp->t_advertise = NULL;

--- a/zebra/irdp_packet.c
+++ b/zebra/irdp_packet.c
@@ -166,7 +166,7 @@ static void parse_irdp_packet(char *p, int len, struct interface *ifp)
 	case ICMP_ROUTERSOLICIT:
 
 		if (irdp->flags & IF_DEBUG_MESSAGES)
-			zlog_debug("IRDP: RX Solicit on %s from %s\n",
+			zlog_debug("IRDP: RX Solicit on %s from %s",
 				   ifp->name, inet_ntoa(src));
 
 		process_solicit(ifp);
@@ -253,7 +253,7 @@ int irdp_read_raw(struct thread *r)
 	if (!(irdp->flags & IF_ACTIVE)) {
 
 		if (irdp->flags & IF_DEBUG_MISC)
-			zlog_debug("IRDP: RX ICMP for disabled interface %s\n",
+			zlog_debug("IRDP: RX ICMP for disabled interface %s",
 				   ifp->name);
 		return 0;
 	}

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -652,7 +652,7 @@ static void netlink_parse_extended_ack(struct nlmsghdr *h)
 		off = *(uint32_t *)RTA_DATA(tb[NLMSGERR_ATTR_OFFS]);
 
 		if (off > h->nlmsg_len) {
-			zlog_err("Invalid offset for NLMSGERR_ATTR_OFFS\n");
+			zlog_err("Invalid offset for NLMSGERR_ATTR_OFFS");
 		} else if (!(h->nlmsg_flags & NLM_F_CAPPED)) {
 			/*
 			 * Header of failed message

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -622,7 +622,7 @@ int ifm_read(struct if_msghdr *ifm)
 		 * RTA_IFP) is required.
 		 */
 		if (!ifnlen) {
-			zlog_debug("Interface index %d (new) missing ifname\n",
+			zlog_debug("Interface index %d (new) missing ifname",
 				   ifm->ifm_index);
 			return -1;
 		}

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -835,7 +835,7 @@ int netlink_route_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 	if (!(h->nlmsg_type == RTM_NEWROUTE || h->nlmsg_type == RTM_DELROUTE)) {
 		/* If this is not route add/delete message print warning. */
-		zlog_debug("Kernel message: %s NS %u\n",
+		zlog_debug("Kernel message: %s NS %u",
 			   nl_msg_type_to_str(h->nlmsg_type), ns_id);
 		return 0;
 	}

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -328,7 +328,7 @@ DEFUN (zebra_ptm_enable_if,
 	if (!old_ptm_enable && ptm_cb.ptm_enable) {
 		if (!if_is_operative(ifp) && send_linkdown) {
 			if (IS_ZEBRA_DEBUG_EVENT)
-				zlog_debug("%s: Bringing down interface %s\n",
+				zlog_debug("%s: Bringing down interface %s",
 					   __func__, ifp->name);
 			if_down(ifp);
 		}
@@ -354,7 +354,7 @@ DEFUN (no_zebra_ptm_enable_if,
 		ifp->ptm_enable = ZEBRA_IF_PTM_ENABLE_OFF;
 		if (if_is_no_ptm_operative(ifp) && send_linkup) {
 			if (IS_ZEBRA_DEBUG_EVENT)
-				zlog_debug("%s: Bringing up interface %s\n",
+				zlog_debug("%s: Bringing up interface %s",
 					   __func__, ifp->name);
 			if_up(ifp);
 		}

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -383,7 +383,7 @@ static void zebra_rnh_eval_import_check_entry(vrf_id_t vrfid, afi_t afi,
 	if (state_changed || force) {
 		if (IS_ZEBRA_DEBUG_NHT) {
 			prefix2str(&nrn->p, bufn, INET6_ADDRSTRLEN);
-			zlog_debug("%u:%s: Route import check %s %s\n", vrfid,
+			zlog_debug("%u:%s: Route import check %s %s", vrfid,
 				   bufn, rnh->state ? "passed" : "failed",
 				   state_changed ? "(state changed)" : "");
 		}
@@ -775,7 +775,7 @@ void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
 
 	table = get_rnh_table(vrfid, afi, type);
 	if (!table) {
-		zlog_debug("print_rnhs: rnh table not found\n");
+		zlog_debug("print_rnhs: rnh table not found");
 		return;
 	}
 
@@ -1025,7 +1025,7 @@ static int zebra_cleanup_rnh_client(vrf_id_t vrf_id, afi_t afi,
 
 	ntable = get_rnh_table(vrf_id, afi, type);
 	if (!ntable) {
-		zlog_debug("cleanup_rnh_client: rnh table not found\n");
+		zlog_debug("cleanup_rnh_client: rnh table not found");
 		return -1;
 	}
 


### PR DESCRIPTION
Zlog puts its own newlines on, and doing this makes logs look nasty.