### PR TITLE
zebra: Allow json output to give a bit more data

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -365,6 +365,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 	json_object *json_labels = NULL;
 	time_t uptime;
 	struct tm *tm;
+	rib_dest_t *dest = rib_dest_from_rnode(rn);
 
 	uptime = time(NULL);
 	uptime -= re->uptime;
@@ -388,6 +389,10 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 
 		if (CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED))
 			json_object_boolean_true_add(json_route, "selected");
+
+		if (dest->selected_fib == re)
+			json_object_boolean_true_add(json_route,
+						     "destSelected");
 
 		if (re->type != ZEBRA_ROUTE_CONNECT) {
 			json_object_int_add(json_route, "distance",


### PR DESCRIPTION
<This is a Double commit of a PR in master>

The dest->selected_fib should be reported in json output
so that we can debug subtle conditions a bit better in the
future.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

