### PR TITLE
pimd: Display drpriority as a unsigned int

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1191,7 +1191,7 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 			vty_out(vty, "Designated Router\n");
 			vty_out(vty, "-----------------\n");
 			vty_out(vty, "Address   : %s\n", dr_str);
-			vty_out(vty, "Priority  : %d(%d)\n",
+			vty_out(vty, "Priority  : %u(%d)\n",
 				pim_ifp->pim_dr_priority,
 				pim_ifp->pim_dr_num_nondrpri_neighbors);
 			vty_out(vty, "Uptime    : %s\n", dr_uptime);


### PR DESCRIPTION
There existed output code that used %d for a uint32_t
switch to a %u.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

