### PR TITLE
bfdd: Prevent uninited use of data

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1187,7 +1187,8 @@ int bs_observer_add(struct bfd_session *bs)
 {
 	struct bfd_session_observer *bso;
 
-	bso = XMALLOC(MTYPE_BFDD_SESSION_OBSERVER, sizeof(*bso));
+	bso = XCALLOC(MTYPE_BFDD_SESSION_OBSERVER, sizeof(*bso));
+	bso->bso_isaddress = false;
 	bso->bso_bs = bs;
 	bso->bso_isinterface = !BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH);
 	if (bso->bso_isinterface)


### PR DESCRIPTION
Running valgrind w/ bfdd and shut/no shuting interfaces
can result in this valgrind issue:

==20279== Conditional jump or move depends on uninitialised value(s)
==20279==    at 0x115848: bfdd_sessions_enable_address (ptm_adapter.c:644)
==20279==    by 0x115848: bfdd_interface_address_update (ptm_adapter.c:674)
==20279==    by 0x48D8CAB: zclient_read (zclient.c:2698)
==20279==    by 0x48CCEE3: thread_call (thread.c:1603)
==20279==    by 0x48A84EF: frr_run (libfrr.c:1011)
==20279==    by 0x10DAC3: main (bfdd.c:236)
==20279==

When creating the bso data structure set the bso_isaddress to false
as a default value.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

### Summary
[fill here]

### Related Issue
[fill here if applicable]

### Components
[bgpd, build, doc, ripd, ospfd, eigrpd, isisd, etc. etc.]
