### PR TITLE
ospfd: remove empty debug

### DIFF
--- a/ospfd/ospf_apiserver.c
+++ b/ospfd/ospf_apiserver.c
@@ -2110,7 +2110,6 @@ void ospf_apiserver_show_info(struct vty *vty, struct ospf_lsa *lsa)
 		for (i = 0; i < opaquelen; i++) {
 			zlog_debug("0x%x ", olsa->data[i]);
 		}
-		zlog_debug("");
 	}
 	return;
 }


### PR DESCRIPTION
The recent commit that removed newlines from log strings left an empty string behind in ospfd. Remove that empty debug line - it generates a compile warning.

### Components
ospfd