### PR TITLE
tests: point topotests docker img to new location

### DIFF
--- a/tests/topotests/docker/build.sh
+++ b/tests/topotests/docker/build.sh
@@ -26,5 +26,5 @@ cd "$(dirname "$0")"/..
 
 exec docker build --pull \
 		  --compress \
-		  -t frrouting/frr:topotests-latest \
+		  -t frrouting/topotests:latest \
 		  .

--- a/tests/topotests/docker/frr-topotests.sh
+++ b/tests/topotests/docker/frr-topotests.sh
@@ -136,7 +136,7 @@ if [ -z "$TOPOTEST_BUILDCACHE" ]; then
 fi
 
 if [ "${TOPOTEST_PULL:-1}" = "1" ]; then
-	docker pull frrouting/frr:topotests-latest
+	docker pull frrouting/topotests:latest
 fi
 
 set -- --rm -i \
@@ -149,7 +149,7 @@ set -- --rm -i \
 	-e "TOPOTEST_SANITIZER=$TOPOTEST_SANITIZER" \
 	--privileged \
 	$TOPOTEST_OPTIONS \
-	frrouting/frr:topotests-latest "$@"
+	frrouting/topotests:latest "$@"
 
 if [ -t 0 ]; then
 	set -- -t "$@"


### PR DESCRIPTION
The topotests docker image has moved from frrouting/frr to
frrouting/topotests. Update accordingly.

Once this is merged I will change `frrouting/frr` to be a Debian or Alpine based end-user FRR image.