### PR TITLE
bfdd: two small fixes

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1231,7 +1231,7 @@ void bs_to_bpc(struct bfd_session *bs, struct bfd_peer_cfg *bpc)
 
 		if (memcmp(&bs->key.local, &zero_addr, sizeof(bs->key.local))) {
 			bpc->bpc_local.sa_sin.sin_family = AF_INET6;
-			memcpy(&bpc->bpc_local.sa_sin.sin_addr, &bs->key.peer,
+			memcpy(&bpc->bpc_local.sa_sin.sin_addr, &bs->key.local,
 			       sizeof(bpc->bpc_local.sa_sin.sin_addr));
 		}
 		break;
@@ -1242,7 +1242,7 @@ void bs_to_bpc(struct bfd_session *bs, struct bfd_peer_cfg *bpc)
 		       sizeof(bpc->bpc_peer.sa_sin6.sin6_addr));
 
 		bpc->bpc_local.sa_sin6.sin6_family = AF_INET6;
-		memcpy(&bpc->bpc_local.sa_sin6.sin6_addr, &bs->key.peer,
+		memcpy(&bpc->bpc_local.sa_sin6.sin6_addr, &bs->key.local,
 		       sizeof(bpc->bpc_local.sa_sin6.sin6_addr));
 		break;
 	}

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -141,6 +141,7 @@ void ptm_bfd_echo_snd(struct bfd_session *bfd)
 	if (BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_IPV6)) {
 		sd = bglobal.bg_echov6;
 		memset(&sin6, 0, sizeof(sin6));
+		sin6.sin6_family = AF_INET6;
 		memcpy(&sin6.sin6_addr, &bfd->key.peer, sizeof(sin6.sin6_addr));
 		if (bfd->ifp && IN6_IS_ADDR_LINKLOCAL(&sin6.sin6_addr))
 			sin6.sin6_scope_id = bfd->ifp->ifindex;
@@ -155,6 +156,7 @@ void ptm_bfd_echo_snd(struct bfd_session *bfd)
 	} else {
 		sd = bglobal.bg_echo;
 		memset(&sin6, 0, sizeof(sin6));
+		sin.sin_family = AF_INET;
 		memcpy(&sin.sin_addr, &bfd->key.peer, sizeof(sin.sin_addr));
 		sin.sin_port = htons(BFD_DEF_ECHO_PORT);
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN


### PR DESCRIPTION
### Summary

This PR wants to solve two problems:

  * JSON API failing to locate labels / setting sessions with local-address;

    Problem spotted by @eqvinox on code review after PR merge (thanks!).

  * ARM8 `echo-mode` which broke `bfd-topo1`;

    Missing family type on sockaddr structure. Spotted by @mwinter-osr on #3966 .


### Related Issue

#3966 


### Components

`bfdd`