### PR TITLE
bgpd: l3vni add-del handle non-defualt rd

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5041,6 +5041,9 @@ void bgp_evpn_derive_auto_rt_export(struct bgp *bgp, struct bgpevpn *vpn)
  */
 void bgp_evpn_derive_auto_rd_for_vrf(struct bgp *bgp)
 {
+	if (is_vrf_rd_configured(bgp))
+		return;
+
 	form_auto_rd(bgp->router_id, bgp->vrf_rd_id, &bgp->vrf_prd);
 }
 

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -5212,7 +5212,7 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 		vty_out(vty, "  default-originate ipv6\n");
 
 	if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_RD_CFGD))
-		vty_out(vty, "   rd %s\n",
+		vty_out(vty, "  rd %s\n",
 			prefix_rd2str(&bgp->vrf_prd, buf1, sizeof(buf1)));
 
 	/* import route-target */


### PR DESCRIPTION


### Summary
During L3VNI add, non-default RD value is not replayed correctly. 
Instead of picking non-default value it picks up auto RD value
which is derived based on router-id.

Indentation issue: Remove additional space from L3VNI running config output.


Testing Done:

Bring up evpn configuration with L3vni up with non-default
RD value, perform peerlink flap, l3vni flap which removes
all VNIS and readds with RD and RT values.
The configured RD and RTs are replayed.

Post L3VNI flap
router bgp 5546 vrf vrf2
 !
 address-family l2vpn evpn
  rd 45.0.66.2:6
  route-target import 20001:1
  route-target export 20001:1
 exit-address-family

TORC11# show bgp l2vpn evpn vni 4002
VNI: 4002 (known to the kernel)
  Type: L3
  Tenant VRF: vrf2
  RD: 45.0.66.2:6
  Originator IP: 36.0.0.11
  Advertise-gw-macip : n/a
  Import Route Target:
    20001:1
  Export Route Target:
    20001:1

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>

### Related Issue
[fill here if applicable]

### Components
[bgpd]
