### PR TITLE
zebra: copy-paste error (Coverity 1479148)

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1932,7 +1932,7 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 					   dplane_ctx_get_vrf(ctx),
 					   dest_str, old_re);
 		} else
-			UNSET_FLAG(re->status, ROUTE_ENTRY_QUEUED);
+			UNSET_FLAG(old_re->status, ROUTE_ENTRY_QUEUED);
 	}
 
 	switch (op) {


### PR DESCRIPTION
### Summary

Copy-paste error found by Coverity (issue 1479148).

### Components

zebra
