### PR TITLE
tools: add zebra to daemons file

### DIFF
--- a/tools/etc/frr/daemons
+++ b/tools/etc/frr/daemons
@@ -12,8 +12,10 @@
 # When using "vtysh" such a config file is also needed. It should be owned by
 # group "frrvty" and set to ug=rw,o= though. Check /etc/pam.d/frr, too.
 #
-# The watchfrr and zebra daemons are always started.
+# Watchfrr is always started. Zebra is started by default; if you do not want
+# this, set zebra=no.
 #
+zebra=yes
 bgpd=no
 ospfd=no
 ospf6d=no


### PR DESCRIPTION
Comment indicates that Zebra is always started but, at least on Fedora
28, this is not true. It needs to be explicitly enabled.

Note that it *is* explicitly enabled in `redhat/daemons`, but we want to combine these files and there's no harm in explicitly enabling Zebra on any platform.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>