### PR TITLE
bgpd: add command to lookup prefixes in the rpki table

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1203,8 +1203,9 @@ DEFPY (show_rpki_prefix,
 
 	struct lrtr_ip_addr addr;
 	char addr_str[INET6_ADDRSTRLEN];
-	memset(addr_str, 0, sizeof(addr_str));
 	size_t addr_len = strchr(prefix_str, '/') - prefix_str;
+
+	memset(addr_str, 0, sizeof(addr_str));
 	memcpy(addr_str, prefix_str, addr_len);
 
 	if (lrtr_ip_str_to_addr(addr_str, &addr) != 0) {
@@ -1226,6 +1227,7 @@ DEFPY (show_rpki_prefix,
 	vty_out(vty, "%-40s %s  %s\n", "Prefix", "Prefix Length", "Origin-AS");
 	for (size_t i = 0; i < match_count; ++i) {
 		const struct pfx_record *record = &matches[i];
+
 		if (record->max_len >= prefix->prefixlen
 		    && ((asn != 0 && asn == record->asn) || asn == 0)) {
 			print_record(&matches[i], vty);

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -125,7 +125,7 @@ static struct rtr_socket *create_rtr_socket(struct tr_socket *tr_socket);
 static struct cache *find_cache(const uint8_t preference);
 static int add_tcp_cache(const char *host, const char *port,
 			 const uint8_t preference);
-static void print_record(const struct pfx_record *record, void *data);
+static void print_record(const struct pfx_record *record, struct vty *vty);
 static int is_synchronized(void);
 static int is_running(void);
 static void route_match_free(void *rule);
@@ -271,17 +271,23 @@ static struct cache *find_cache(const uint8_t preference)
 	return NULL;
 }
 
-static void print_record(const struct pfx_record *record, void *data)
+static void print_record(const struct pfx_record *record, struct vty *vty)
 {
 	char ip[INET6_ADDRSTRLEN];
+
+	lrtr_ip_addr_to_str(&record->prefix, ip, sizeof(ip));
+	vty_out(vty, "%-40s   %3u - %3u   %10u\n", ip, record->min_len,
+		record->max_len, record->asn);
+}
+
+static void print_record_cb(const struct pfx_record *record, void *data)
+{
 	struct rpki_for_each_record_arg *arg = data;
 	struct vty *vty = arg->vty;
 
 	(*arg->prefix_amount)++;
 
-	lrtr_ip_addr_to_str(&record->prefix, ip, sizeof(ip));
-	vty_out(vty, "%-40s   %3u - %3u   %10u\n", ip, record->min_len,
-		record->max_len, record->asn);
+	print_record(record, vty);
 }
 
 static struct rtr_mgr_group *get_groups(void)
@@ -663,10 +669,10 @@ static void print_prefix_table(struct vty *vty)
 	vty_out(vty, "%-40s %s  %s\n", "Prefix", "Prefix Length", "Origin-AS");
 
 	arg.prefix_amount = &number_of_ipv4_prefixes;
-	pfx_table_for_each_ipv4_record(pfx_table, print_record, &arg);
+	pfx_table_for_each_ipv4_record(pfx_table, print_record_cb, &arg);
 
 	arg.prefix_amount = &number_of_ipv6_prefixes;
-	pfx_table_for_each_ipv6_record(pfx_table, print_record, &arg);
+	pfx_table_for_each_ipv6_record(pfx_table, print_record_cb, &arg);
 
 	vty_out(vty, "Number of IPv4 Prefixes: %u\n", number_of_ipv4_prefixes);
 	vty_out(vty, "Number of IPv6 Prefixes: %u\n", number_of_ipv6_prefixes);
@@ -1179,6 +1185,56 @@ DEFUN (show_rpki_prefix_table,
 	return CMD_SUCCESS;
 }
 
+DEFPY (show_rpki_prefix,
+       show_rpki_prefix_cmd,
+       "show rpki prefix <A.B.C.D/M|X:X::X:X/M> [(1-4294967295)$asn]",
+       SHOW_STR
+       RPKI_OUTPUT_STRING
+       "Lookup IP prefix and optionally ASN in prefix table\n"
+       "IPv4 prefix\n"
+       "IPv6 prefix\n"
+       "AS Number\n")
+{
+
+	if (!is_synchronized()) {
+		vty_out(vty, "No Conection to RPKI cache server.\n");
+		return CMD_WARNING;
+	}
+
+	struct lrtr_ip_addr addr;
+	char addr_str[INET6_ADDRSTRLEN];
+	memset(addr_str, 0, sizeof(addr_str));
+	size_t addr_len = strchr(prefix_str, '/') - prefix_str;
+	memcpy(addr_str, prefix_str, addr_len);
+
+	if (lrtr_ip_str_to_addr(addr_str, &addr) != 0) {
+		vty_out(vty, "Invalid IP prefix\n");
+		return CMD_WARNING;
+	}
+
+	struct pfx_record *matches = NULL;
+	unsigned int match_count = 0;
+	enum pfxv_state result;
+
+	if (pfx_table_validate_r(rtr_config->pfx_table, &matches, &match_count,
+				 asn, &addr, prefix->prefixlen, &result)
+	    != PFX_SUCCESS) {
+		vty_out(vty, "Prefix lookup failed");
+		return CMD_WARNING;
+	}
+
+	vty_out(vty, "%-40s %s  %s\n", "Prefix", "Prefix Length", "Origin-AS");
+	for (size_t i = 0; i < match_count; ++i) {
+		const struct pfx_record *record = &matches[i];
+		if (record->max_len >= prefix->prefixlen
+		    && ((asn != 0 && asn == record->asn) || asn == 0)) {
+			print_record(&matches[i], vty);
+		}
+	}
+
+	return CMD_SUCCESS;
+}
+
 DEFUN (show_rpki_cache_server,
        show_rpki_cache_server_cmd,
        "show rpki cache-server",
@@ -1450,6 +1506,7 @@ static void install_cli_commands(void)
 	install_element(ENABLE_NODE, &show_rpki_prefix_table_cmd);
 	install_element(ENABLE_NODE, &show_rpki_cache_connection_cmd);
 	install_element(ENABLE_NODE, &show_rpki_cache_server_cmd);
+	install_element(ENABLE_NODE, &show_rpki_prefix_cmd);
 
 	/* Install debug commands */
 	install_element(CONFIG_NODE, &debug_rpki_cmd);


### PR DESCRIPTION
### Summary
Add command to lookup prefixes in the rpki table optionally with 

### Components
[bgpd]

I'm wondering if this should be backported, as it is quite useful and has a low risk of breaking anything, as it only touches code related to functions that are easily verified.