### PR TITLE
zebra: add extern C guards to headers

### DIFF
--- a/zebra/connected.h
+++ b/zebra/connected.h
@@ -28,6 +28,10 @@
 #include "lib/if.h"
 #include "lib/prefix.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern struct connected *connected_check(struct interface *ifp,
 					 union prefixconstptr p);
 extern struct connected *connected_check_ptp(struct interface *ifp,
@@ -58,4 +62,7 @@ extern void connected_delete_ipv6(struct interface *ifp,
 
 extern int connected_is_unnumbered(struct interface *);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /*_ZEBRA_CONNECTED_H */

--- a/zebra/debug.h
+++ b/zebra/debug.h
@@ -24,6 +24,10 @@
 
 #include "lib/vty.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Debug flags. */
 #define ZEBRA_DEBUG_EVENT   0x01
 
@@ -98,5 +102,9 @@ extern unsigned long zebra_debug_mlag;
 extern void zebra_debug_init(void);
 
 DECLARE_HOOK(zebra_debug_show_debugging, (struct vty *vty), (vty));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_DEBUG_H */

--- a/zebra/if_netlink.h
+++ b/zebra/if_netlink.h
@@ -23,10 +23,18 @@
 
 #ifdef HAVE_NETLINK
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id,
 				  int startup);
 extern int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup);
 extern int interface_lookup_netlink(struct zebra_ns *zns);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HAVE_NETLINK */
 

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -28,6 +28,10 @@
 
 #include "zebra/zebra_l2.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* For interface multicast configuration. */
 #define IF_ZEBRA_MULTICAST_UNSPEC 0
 #define IF_ZEBRA_MULTICAST_ON     1
@@ -431,5 +435,9 @@ extern int interface_list_proc(void);
 #ifdef HAVE_PROC_NET_IF_INET6
 extern int ifaddr_proc_ipv6(void);
 #endif /* HAVE_PROC_NET_IF_INET6 */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_INTERFACE_H */

--- a/zebra/ioctl.h
+++ b/zebra/ioctl.h
@@ -22,6 +22,10 @@
 #ifndef _ZEBRA_IOCTL_H
 #define _ZEBRA_IOCTL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Prototypes. */
 extern void ifreq_set_name(struct ifreq *, struct interface *);
 extern int if_ioctl(unsigned long, caddr_t);
@@ -52,5 +56,9 @@ extern struct connected *if_lookup_linklocal(struct interface *);
 #define AF_IOCTL(af, request, buffer)  if_ioctl(request, buffer)
 
 #endif /* SOLARIS_IPV6 */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_IOCTL_H */

--- a/zebra/ioctl_solaris.h
+++ b/zebra/ioctl_solaris.h
@@ -22,7 +22,15 @@
 #ifndef _ZEBRA_IF_IOCTL_SOLARIS_H
 #define _ZEBRA_IF_IOCTL_SOLARIS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void lifreq_set_name(struct lifreq *, const char *);
 int if_get_flags_direct(const char *, uint64_t *, unsigned int af);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_IF_IOCTL_SOLARIS_H */

--- a/zebra/ipforward.h
+++ b/zebra/ipforward.h
@@ -21,6 +21,10 @@
 #ifndef _ZEBRA_IPFORWARD_H
 #define _ZEBRA_IPFORWARD_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int ipforward(void);
 extern int ipforward_on(void);
 extern int ipforward_off(void);
@@ -28,5 +32,9 @@ extern int ipforward_off(void);
 extern int ipforward_ipv6(void);
 extern int ipforward_ipv6_on(void);
 extern int ipforward_ipv6_off(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_IPFORWARD_H */

--- a/zebra/irdp.h
+++ b/zebra/irdp.h
@@ -28,6 +28,10 @@
 
 #include "lib/vty.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define TRUE 1
 #define FALSE 0
 
@@ -150,5 +154,8 @@ extern int irdp_read_raw(struct thread *r);
 extern void send_packet(struct interface *ifp, struct stream *s, uint32_t dst,
 			struct prefix *p, uint32_t ttl);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _IRDP_H */

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -21,6 +21,10 @@
 #ifndef _ZEBRA_KERNEL_NETLINK_H
 #define _ZEBRA_KERNEL_NETLINK_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef HAVE_NETLINK
 
 #define NL_RCV_PKT_BUF_SIZE     32768
@@ -67,5 +71,9 @@ int netlink_talk_info(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 extern int netlink_request(struct nlsock *nl, struct nlmsghdr *n);
 
 #endif /* HAVE_NETLINK */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_KERNEL_NETLINK_H */

--- a/zebra/kernel_socket.h
+++ b/zebra/kernel_socket.h
@@ -22,6 +22,10 @@
 #ifndef __ZEBRA_KERNEL_SOCKET_H
 #define __ZEBRA_KERNEL_SOCKET_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Error codes of zebra. */
 #define ZEBRA_ERR_NOERROR                0
 #define ZEBRA_ERR_RTEXIST               -1
@@ -37,5 +41,9 @@ extern int rtm_write(int, union sockunion *, union sockunion *,
 		     union sockunion *, union sockunion *, unsigned int,
 		     enum blackhole_type, int);
 extern const struct message rtm_type_str[];
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ZEBRA_KERNEL_SOCKET_H */

--- a/zebra/label_manager.h
+++ b/zebra/label_manager.h
@@ -31,6 +31,10 @@
 
 #include "zebra/zserv.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NO_PROTO 0
 
 /*
@@ -73,5 +77,9 @@ int release_label_chunk(uint8_t proto, unsigned short instance, uint32_t start,
 			uint32_t end);
 int release_daemon_label_chunks(struct zserv *client);
 void label_manager_close(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _LABEL_MANAGER_H */

--- a/zebra/redistribute.h
+++ b/zebra/redistribute.h
@@ -29,6 +29,10 @@
 #include "zebra/zserv.h"
 #include "zebra/rib.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ZAPI command handlers */
 extern void zebra_redistribute_add(ZAPI_HANDLER_ARGS);
 extern void zebra_redistribute_delete(ZAPI_HANDLER_ARGS);
@@ -73,4 +77,9 @@ extern int is_zebra_import_table_enabled(afi_t, uint32_t table_id);
 extern int zebra_import_table_config(struct vty *);
 
 extern void zebra_import_table_rm_update(const char *rmap);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _ZEBRA_REDISTRIBUTE_H */

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -35,6 +35,10 @@
 #include "mpls.h"
 #include "srcdest_table.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DISTANCE_INFINITY  255
 #define ZEBRA_KERNEL_TABLE_MAX 252 /* support for no more than this rt tables */
 
@@ -464,4 +468,9 @@ extern void zebra_vty_init(void);
 extern pid_t pid;
 
 extern bool v6_rr_semantics;
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /*_ZEBRA_RIB_H */

--- a/zebra/router-id.h
+++ b/zebra/router-id.h
@@ -30,11 +30,19 @@
 #include "zclient.h"
 #include "if.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void router_id_add_address(struct connected *);
 extern void router_id_del_address(struct connected *);
 extern void router_id_init(struct zebra_vrf *);
 extern void router_id_cmd_init(void);
 extern void router_id_write(struct vty *);
 extern void router_id_get(struct prefix *, vrf_id_t);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -31,6 +31,10 @@
 #include "zebra/zebra_mpls.h"
 #include "zebra/zebra_dplane.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Update or delete a route, LSP, or pseudowire from the kernel,
  * using info from a dataplane context.
@@ -90,5 +94,9 @@ extern void neigh_read_for_vlan(struct zebra_ns *zns, struct interface *ifp);
 extern void neigh_read_specific_ip(struct ipaddr *ip,
 				   struct interface *vlan_if);
 extern void route_read(struct zebra_ns *zns);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_RT_H */

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -26,6 +26,10 @@
 #include "zebra/zebra_mpls.h"
 #include "zebra/zebra_dplane.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NL_DEFAULT_ROUTE_METRIC 20
 
 /*
@@ -78,6 +82,10 @@ extern int netlink_macfdb_read_specific_mac(struct zebra_ns *zns,
 					    struct ethaddr *mac, uint16_t vid);
 extern int netlink_neigh_read_specific_ip(struct ipaddr *ip,
 					  struct interface *vlan_if);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HAVE_NETLINK */
 

--- a/zebra/rtadv.h
+++ b/zebra/rtadv.h
@@ -25,6 +25,10 @@
 #include "vty.h"
 #include "zebra/interface.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* NB: RTADV is defined in zebra/interface.h above */
 #if defined(HAVE_RTADV)
 
@@ -137,5 +141,8 @@ extern void rtadv_cmd_init(void);
 extern void zebra_interface_radv_disable(ZAPI_HANDLER_ARGS);
 extern void zebra_interface_radv_enable(ZAPI_HANDLER_ARGS);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_RTADV_H */

--- a/zebra/rule_netlink.h
+++ b/zebra/rule_netlink.h
@@ -26,6 +26,10 @@
 
 #ifdef HAVE_NETLINK
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Handle netlink notification informing a rule add or delete.
  */
@@ -35,6 +39,10 @@ extern int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup);
  * Get to know existing PBR rules in the kernel - typically called at startup.
  */
 extern int netlink_rules_read(struct zebra_ns *zns);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HAVE_NETLINK */
 

--- a/zebra/table_manager.h
+++ b/zebra/table_manager.h
@@ -27,6 +27,10 @@
 
 #include "zebra/zserv.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Table chunk struct
  * Client daemon which the chunk belongs to can be identified by either
@@ -62,5 +66,9 @@ int release_table_chunk(uint8_t proto, uint16_t instance, uint32_t start,
 			uint32_t end);
 int release_daemon_table_chunks(struct zserv *client);
 void table_manager_disable(ns_id_t ns_id);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _TABLE_MANAGER_H */

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -30,6 +30,10 @@
 #include "zebra/zebra_pbr.h"
 #include "zebra/zebra_errors.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This is called to process inbound ZAPI messages.
  *
@@ -86,3 +90,7 @@ extern void zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 				   const unsigned int nexthop_num);
 
 extern void zsend_capabilities_all_clients(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -30,6 +30,10 @@
 #include "zebra/zserv.h"
 #include "zebra/zebra_mpls.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Key netlink info from zebra ns */
 struct zebra_dplane_info {
 	ns_id_t ns_id;
@@ -393,5 +397,9 @@ void zebra_dplane_start(void);
 void zebra_dplane_pre_finish(void);
 void zebra_dplane_finish(void);
 void zebra_dplane_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif	/* _ZEBRA_DPLANE_H */

--- a/zebra/zebra_errors.h
+++ b/zebra/zebra_errors.h
@@ -23,6 +23,10 @@
 
 #include "lib/ferr.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum zebra_log_refs {
 	EC_ZEBRA_LM_RESPONSE = ZEBRA_FERR_START,
 	EC_ZEBRA_LM_NO_SUCH_CLIENT,
@@ -125,5 +129,9 @@ enum zebra_log_refs {
 };
 
 void zebra_error_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __EC_ZEBRAORS_H__ */

--- a/zebra/zebra_fpm_private.h
+++ b/zebra/zebra_fpm_private.h
@@ -26,6 +26,10 @@
 
 #include "zebra/debug.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
 
 #define zfpm_debug(...)                                                        \
@@ -61,4 +65,9 @@ extern int zfpm_protobuf_encode_route(rib_dest_t *dest, struct route_entry *re,
 				      uint8_t *in_buf, size_t in_buf_len);
 
 extern struct route_entry *zfpm_route_for_update(rib_dest_t *dest);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _ZEBRA_FPM_PRIVATE_H */

--- a/zebra/zebra_l2.h
+++ b/zebra/zebra_l2.h
@@ -29,6 +29,10 @@
 #include "vlan.h"
 #include "vxlan.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* zebra L2 interface information - bridge slave (linkage to bridge) */
 struct zebra_l2info_brslave {
 	ifindex_t bridge_ifindex; /* Bridge Master */
@@ -96,4 +100,9 @@ extern void zebra_l2if_update_bridge_slave(struct interface *ifp,
 
 extern void zebra_l2if_update_bond_slave(struct interface *ifp,
 					 ifindex_t bond_ifindex);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _ZEBRA_L2_H */

--- a/zebra/zebra_memory.h
+++ b/zebra/zebra_memory.h
@@ -24,6 +24,10 @@
 
 #include "memory.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DECLARE_MGROUP(ZEBRA)
 DECLARE_MTYPE(RTADV_PREFIX)
 DECLARE_MTYPE(ZEBRA_NS)
@@ -36,5 +40,9 @@ DECLARE_MTYPE(RIB_TABLE_INFO)
 DECLARE_MTYPE(RNH)
 DECLARE_MTYPE(DP_CTX)
 DECLARE_MTYPE(DP_PROV)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _QUAGGA_ZEBRA_MEMORY_H */

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -24,8 +24,17 @@
 
 #include "mlag.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void zebra_mlag_init(void);
 void zebra_mlag_terminate(void);
 
 enum mlag_role zebra_mlag_get_role(void);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -34,6 +34,9 @@
 #include "zebra/zserv.h"
 #include "zebra/zebra_vrf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Definitions and macros. */
 
@@ -533,5 +536,9 @@ static inline int mpls_should_lsps_be_processed(struct zebra_vrf *zvrf)
 
 /* Global variables. */
 extern int mpls_enabled;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*_ZEBRA_MPLS_H */

--- a/zebra/zebra_mroute.h
+++ b/zebra/zebra_mroute.h
@@ -24,6 +24,10 @@
 
 #include "zebra/zserv.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct mcast_route_data {
 	struct prefix_sg sg;
 	unsigned int ifindex;
@@ -31,5 +35,9 @@ struct mcast_route_data {
 };
 
 void zebra_ipmr_route_stats(ZAPI_HANDLER_ARGS);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/zebra/zebra_netns_id.h
+++ b/zebra/zebra_netns_id.h
@@ -20,7 +20,15 @@
 #include "zebra.h"
 #include "ns.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern ns_id_t zebra_ns_id_get(const char *netnspath);
 extern ns_id_t zebra_ns_id_get_default(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ZEBRA_NS_ID_H__ */

--- a/zebra/zebra_netns_notify.h
+++ b/zebra/zebra_netns_notify.h
@@ -20,10 +20,18 @@
 #ifndef _NETNS_NOTIFY_H
 #define _NETNS_NOTIFY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void zebra_ns_notify_init(void);
 extern void zebra_ns_notify_parse(void);
 extern void zebra_ns_notify_close(void);
 
 extern struct zebra_privs_t zserv_privs;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NETNS_NOTIFY_H */

--- a/zebra/zebra_ns.h
+++ b/zebra/zebra_ns.h
@@ -28,6 +28,10 @@
 #include "zebra/rib.h"
 #include "zebra/zebra_vrf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef HAVE_NETLINK
 /* Socket interface to kernel */
 struct nlsock {
@@ -67,5 +71,9 @@ int zebra_ns_early_shutdown(struct ns *ns);
 int zebra_ns_final_shutdown(struct ns *ns);
 
 int zebra_ns_config_write(struct vty *vty, struct ns *ns);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -32,6 +32,10 @@
 #include "rt.h"
 #include "pbr.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct zebra_pbr_rule {
 	int sock;
 
@@ -251,5 +255,9 @@ DECLARE_HOOK(zebra_pbr_ipset_entry_update,
 	     (int cmd, struct zebra_pbr_ipset_entry *ipset), (cmd, ipset));
 DECLARE_HOOK(zebra_pbr_ipset_update,
 	     (int cmd, struct zebra_pbr_ipset *ipset), (cmd, ipset));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_PBR_H */

--- a/zebra/zebra_ptm.h
+++ b/zebra/zebra_ptm.h
@@ -31,6 +31,10 @@ extern const char ZEBRA_PTM_SOCK_NAME[];
 #include "zebra/zserv.h"
 #include "zebra/interface.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Zebra ptm context block */
 struct zebra_ptm_cb {
 	int ptm_sock; /* ptm file descriptor. */
@@ -87,4 +91,9 @@ void zebra_ptm_if_init(struct zebra_if *zebra_ifp);
 void zebra_ptm_if_set_ptm_state(struct interface *ifp,
 				struct zebra_if *zebra_ifp);
 void zebra_ptm_if_write(struct vty *vty, struct zebra_if *zebra_ifp);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/zebra/zebra_ptm_redistribute.h
+++ b/zebra/zebra_ptm_redistribute.h
@@ -21,7 +21,17 @@
 
 #ifndef _ZEBRA_PTM_REDISTRIBUTE_H
 #define _ZEBRA_PTM_REDISTRIBUTE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void zebra_interface_bfd_update(struct interface *, struct prefix *,
 				       struct prefix *, int, vrf_id_t);
 extern void zebra_bfd_peer_replay_req(void);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* _ZEBRA_PTM_REDISTRIBUTE_H */

--- a/zebra/zebra_pw.h
+++ b/zebra/zebra_pw.h
@@ -29,6 +29,10 @@
 
 #include "zebra/zebra_vrf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PW_INSTALL_RETRY_INTERVAL	30
 
 struct zebra_pw {
@@ -73,5 +77,9 @@ void zebra_pw_install_failure(struct zebra_pw *);
 void zebra_pw_init(struct zebra_vrf *);
 void zebra_pw_exit(struct zebra_vrf *);
 void zebra_pw_vty_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEBRA_PW_H_ */

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -25,6 +25,10 @@
 #include "prefix.h"
 #include "vty.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Nexthop structure. */
 struct rnh {
 	uint8_t flags;
@@ -83,4 +87,9 @@ extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
 				  rnh_type_t);
 extern char *rnh_str(struct rnh *rnh, char *buf, int size);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /*_ZEBRA_RNH_H */

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -24,6 +24,10 @@
 
 #include "lib/routemap.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void zebra_route_map_init(void);
 extern void zebra_routemap_config_write_protocol(struct vty *vty,
 						 struct zebra_vrf *vrf);
@@ -47,5 +51,9 @@ extern route_map_result_t
 zebra_nht_route_map_check(afi_t afi, int client_proto, const struct prefix *p,
 			  struct zebra_vrf *zvrf, struct route_entry *,
 			  struct nexthop *nexthop);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -26,6 +26,10 @@
 
 #include "zebra/zebra_ns.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This header file contains the idea of a router and as such
  * owns data that is associated with a router from zebra's
@@ -129,4 +133,9 @@ extern void zebra_router_sweep_route(void);
 extern void zebra_router_show_table_summary(struct vty *vty);
 
 extern uint32_t zebra_router_get_next_sequence(void);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -28,6 +28,10 @@
 #include <zebra/zebra_pw.h>
 #include <lib/vxlan.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* MPLS (Segment Routing) global block */
 typedef struct mpls_srgb_t_ {
 	uint32_t start_label;
@@ -203,4 +207,9 @@ extern void zebra_vrf_init(void);
 
 extern void zebra_rtable_node_cleanup(struct route_table *table,
 				      struct route_node *node);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* ZEBRA_VRF_H */

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -35,6 +35,10 @@
 #include "zebra/zebra_vrf.h"
 #include "zebra/zserv.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Is EVPN enabled? */
 #define EVPN_ENABLED(zvrf)  (zvrf)->advertise_all_vni
 static inline int is_evpn_enabled(void)
@@ -205,5 +209,9 @@ extern int zebra_vxlan_clear_dup_detect_vni_all(struct vty *vty,
 extern int zebra_vxlan_clear_dup_detect_vni(struct vty *vty,
 					    struct zebra_vrf *zvrf,
 					    vni_t vni);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_VXLAN_H */

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -26,11 +26,13 @@
 
 #include <zebra.h>
 
-#include <zebra.h>
-
 #include "if.h"
 #include "linklist.h"
 #include "zebra_vxlan.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define ERR_STR_SZ 256
 
@@ -420,5 +422,9 @@ struct nh_walk_ctx {
 	struct vty *vty;
 	struct json_object *json;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_VXLAN_PRIVATE_H */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -40,6 +40,10 @@
 #include "zebra/zebra_vrf.h"  /* for zebra_vrf */
 /* clang-format on */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Default port information. */
 #define ZEBRA_VTY_PORT                2601
 
@@ -233,5 +237,9 @@ extern void zserv_read_file(char *input);
 
 /* TODO */
 int zebra_finalize(struct thread *event);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _ZEBRA_ZEBRA_H */


### PR DESCRIPTION
Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>

### Summary
Similarly to what was done already for the lib folder, make sure that the headers
in zebra can be linked against from a module compiled in c++. This is required,
for example, to register a c++ dataplane provider using the API defined in `zebra_dplane.h`

### Related Issue
N/A

### Components
zebra
