### PR TITLE
lib: zclient provide interface info during reg_requests

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -414,6 +414,9 @@ void zclient_send_reg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 	/* We need router-id information. */
 	zebra_message_send(zclient, ZEBRA_ROUTER_ID_ADD, vrf_id);
 
+	/* We need interface information. */
+	zebra_message_send(zclient, ZEBRA_INTERFACE_ADD, vrf_id);
+
 	/* Set unwanted redistribute route. */
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)
 		vrf_bitmap_set(zclient->redist[afi][zclient->redist_default],
@@ -477,6 +480,8 @@ void zclient_send_dereg_requests(struct zclient *zclient, vrf_id_t vrf_id)
 
 	/* We need router-id information. */
 	zebra_message_send(zclient, ZEBRA_ROUTER_ID_DELETE, vrf_id);
+
+	zebra_message_send(zclient, ZEBRA_INTERFACE_DELETE, vrf_id);
 
 	/* Set unwanted redistribute route. */
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)


### PR DESCRIPTION
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>

### Summary
Problem found in bgpd where it wasn't learning interface address
information at startup due to the interface information becoming
available before the bgp instance was created. This issue was
caused by an earlier change that tried to make the interface
information discovery process more efficient but left this hole
for bgpd. For now, putting back in the previous method of
gathering interface info via the zclient_send_reg_requests call
and will revisit a more efficient way to get the info in the future.

### Related Issue
PR#3730

### Components
lib