### PR TITLE
topotests: fix missing log file and duplicated output folder

### DIFF
--- a/tests/topotests/lib/topogen.py
+++ b/tests/topotests/lib/topogen.py
@@ -586,9 +586,9 @@ class TopoRouter(TopoGear):
         os.system('chmod -R go+rw /tmp/topotests')
 
         # Open router log file
-        logfile = '{0}/{1}.log'.format(dir, name)
-
+        logfile = '{0}/{1}.log'.format(self.logdir, name)
         self.logger = logger_config.get_logger(name=name, target=logfile)
+
         self.tgen.topo.addNode(self.name, cls=self.cls, **params)
 
     def __str__(self):


### PR DESCRIPTION
### Summary

Fix some issues mentioned in an issue (see below).

It was broken on this commit: https://github.com/FRRouting/frr/commit/e1dfa45e1b225de81604f0289f93b043b57d13a3

When the logs for non-topogen tests were moved to `/tmp/topotests` from `/tmp`.


### Related Issue

#4009


### Components

`topotests`