### PR TITLE
zebra: use the INSTALLED flag consistently in route summary

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1375,7 +1375,7 @@ static void vty_show_ip_route_summary(struct vty *vty,
 			else
 				rib_cnt[re->type]++;
 
-			if (CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED)) {
+			if (CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)) {
 				fib_cnt[ZEBRA_ROUTE_TOTAL]++;
 
 				if (is_ibgp)


### PR DESCRIPTION
The 'sho ip route summary' and 'sho ip route summary <prefix>' paths used different definitions of a 'fib' route. Use the route-entry 'INSTALLED' flag in both places: that seems to be what's used in other similar outputs.

Signed-off-by: Mark Stapp <mjs@voltanet.io>

### Components
zebra