### PR TITLE
zebra: evpn dup detect handle ip state change

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -382,6 +382,9 @@ static int zebra_vxlan_ip_inherit_dad_from_mac(struct zebra_vrf *zvrf,
 		SET_FLAG(nbr->flags, ZEBRA_NEIGH_DUPLICATE);
 		/* Capture Duplicate detection time */
 		nbr->dad_dup_detect_time = monotime(NULL);
+		/* Mark neigh inactive */
+		ZEBRA_NEIGH_SET_INACTIVE(nbr);
+
 		return 1;
 	} else if (is_old_mac_dup && !is_new_mac_dup) {
 		UNSET_FLAG(nbr->flags, ZEBRA_NEIGH_DUPLICATE);
@@ -3192,13 +3195,14 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 		return 0;
 	}
 
-	ZEBRA_NEIGH_SET_ACTIVE(n);
 	n->loc_seq = zmac->loc_seq;
 
-	if (!neigh_on_hold)
+	if (!neigh_on_hold) {
+		ZEBRA_NEIGH_SET_ACTIVE(n);
+
 		return zvni_neigh_send_add_to_client(zvni->vni, ip, macaddr,
 					     n->flags, n->loc_seq);
-	else {
+	} else {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("\tNeighbor on hold not sending");
 	}
@@ -9194,8 +9198,8 @@ static int zebra_vxlan_dad_ip_auto_recovery_exp(struct thread *t)
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug("%s: duplicate addr MAC %s IP %s flags 0x%x learn count %u vni %u auto recovery expired",
 			  __PRETTY_FUNCTION__,
-			  prefix_mac2str(&nbr->emac, buf1, sizeof(buf1)),
-			  ipaddr2str(&nbr->ip, buf2, sizeof(buf2)),
+			  prefix_mac2str(&nbr->emac, buf2, sizeof(buf2)),
+			  ipaddr2str(&nbr->ip, buf1, sizeof(buf1)),
 			  nbr->flags,
 			  nbr->dad_count, zvni->vni);
 
@@ -9205,6 +9209,7 @@ static int zebra_vxlan_dad_ip_auto_recovery_exp(struct thread *t)
 	nbr->detect_start_time.tv_usec = 0;
 	nbr->dad_dup_detect_time = 0;
 	nbr->dad_ip_auto_recovery_timer = NULL;
+	ZEBRA_NEIGH_SET_ACTIVE(nbr);
 
 	/* Send to BGP */
 	if (CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_LOCAL)) {


### PR DESCRIPTION

### Summary
For a MAC-IP pair generally local/netlink msg for MAC is received followed by Neigh.
The MAC can be detected as duplicate during this event.
When a neigh update is received, the neigh inherits DUP flag from its
MAC and along with that mark the neigh as INACTIVE.
Also, In the case of DUP detected neigh, do not update its state
to ACTIVE before determining to send notification to bgpd.

There is a time when Neigh update received prior to MAC update.
In that case neigh is marked as inactive since its MAC is
still in REMOTE state. Once the MAC update is received and
it is detected as DUPLICATE, the neigh would inherit DUP flag
but remained in inactive state.

By fixing the first case, the neigh remains in inactive once
detected as DUPLICATE in both scenarios.

The unfreeze action would mark all inherited neighs to ACTIVE,
and clears DUP flag then sends notification to bgpd (to send type-2).


Testing Done:
Validated dup detection on both environment where neigh and mac
notification can come as either one first.
With the fix, the neigh was remained in "inactive" state
once detected as duplicate.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>

### Related Issue
[fill here if applicable]

### Components
[zebra]
