### PR TITLE
tools/frr.in: Only attempt to load daemons.conf if present

### DIFF
--- a/tools/frr.in
+++ b/tools/frr.in
@@ -504,7 +504,9 @@ check_status()
 
 # Load configuration
 . "$C_PATH/daemons"
-. "$C_PATH/daemons.conf"
+if [ -e "$C_PATH/daemons.conf" ]; then
+	. "$C_PATH/daemons.conf"
+fi
 
 # Read configuration variable file if it is present
 [ -r /etc/default/frr ] && . /etc/default/frr


### PR DESCRIPTION
Apparently, the default changed to use `/etc/frr/daemons` instead of
`/etc/frr/daemons.conf`. Therefore, we should ignore absence of the
latter file, because its absence is not an actuall error but will
cause a confusing error message like this:

    /etc/init.d/frr: line 507: /etc/frr/daemons.conf: No such file or directory