### PR TITLE
doc: exclude bfd-options.rst from toctree

### DIFF
--- a/doc/manpages/conf.py
+++ b/doc/manpages/conf.py
@@ -129,7 +129,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'common-options.rst', 'epilogue.rst', 'defines.rst']
+exclude_patterns = ['_build', 'common-options.rst', 'epilogue.rst', 'defines.rst', 'bfd-options.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
This is an include file, needs to be explicitly excluded to suppress
Sphinx warnings.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>
