### PR TITLE
[6.0] bgpd: fix show bgp labeled_unicast

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10177,7 +10177,11 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 		return;
 	}
 
-	table = bgp->rib[afi][safi];
+	/* labeled-unicast routes live in the unicast table */
+	if (safi == SAFI_LABELED_UNICAST)
+		table = bgp->rib[afi][SAFI_UNICAST];
+	else
+		table = bgp->rib[afi][safi];
 
 	output_count = filtered_count = 0;
 	subgrp = peer_subgroup(peer, afi, safi);
@@ -10400,10 +10404,6 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
 
 	if (use_json)
 		json = json_object_new_object();
-
-	/* labeled-unicast routes live in the unicast table */
-	if (safi == SAFI_LABELED_UNICAST)
-		safi = SAFI_UNICAST;
 
 	if (!peer || !peer->afc[afi][safi]) {
 		if (use_json) {


### PR DESCRIPTION
### Summary
`show bgp ipv4 labeled_unicast neighbors A.B.C.D advertised-routes` was incorrectly showing a `No such neighbor or address family` error despite the address family being configured for that neighbor. 

While labeled_unicast routes should be fetched in the `SAFI_UNICAST` table, we cannot set the safi to `SAFI_UNICAST` in `peer_adj_state` or else the peer afc checks and subgroup retrieval will fail.

If this is approved I'll push similar MRs for master and 7.0

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>

### Related Issue
N/A

### Components
bgpd
