### PR TITLE
bfdd: Clean up assignment without being used SA issue

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1180,6 +1180,9 @@ const char *bs_to_string(const struct bfd_session *bs)
 	if (bs->key.ifname[0])
 		pos += snprintf(buf + pos, sizeof(buf) - pos, " ifname:%s",
 				bs->key.ifname);
+
+	(void)pos;
+
 	return buf;
 }
 


### PR DESCRIPTION
Clang's SA is reporting that we have a assignment without
subsuquent use.  Modify the code such that we no-longer
do this and leave a bread-crumb so that we don't forget
to re-add this if needed when we modify the function in
the future.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
