### PR TITLE
zebra: in termination phase, check against zvrf presence

### DIFF
--- a/zebra/zebra_errors.h
+++ b/zebra/zebra_errors.h
@@ -126,6 +126,7 @@ enum zebra_log_refs {
 	EC_ZEBRA_DUP_MAC_DETECTED,
 	EC_ZEBRA_DUP_IP_INHERIT_DETECTED,
 	EC_ZEBRA_DUP_IP_DETECTED,
+	EC_ZEBRA_VRF_REMOVED,
 };
 
 void zebra_error_init(void);

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -511,3 +511,19 @@ void zebra_vrf_init(void)
 
 	vrf_cmd_init(vrf_config_write, &zserv_privs);
 }
+
+struct zebra_vrf *zvrf_lookup_from_attribute(uint32_t tableid, ns_id_t ns_id)
+{
+	struct vrf *vrf;
+	struct zebra_vrf *zvrf;
+
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+		zvrf = vrf->info;
+		if (zvrf->table_id != tableid)
+			continue;
+		if (zvrf->zns && zvrf->zns->ns_id == ns_id)
+			return zvrf;
+		continue;
+	}
+	return NULL;
+}

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -207,6 +207,8 @@ extern void zebra_vrf_init(void);
 extern void zebra_rtable_node_cleanup(struct route_table *table,
 				      struct route_node *node);
 
+extern struct zebra_vrf *zvrf_lookup_from_attribute(uint32_t tableid,
+						    ns_id_t ns_id);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
zebra vrf structure may be already done, when ending zebra process.
This is due to the fact that zebra_finalise() call is done after
vrf_terminate(). subsequently, the vrf contexts, and the zebra vrf
contexts are no more available.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>

snapshot of crash
```
E           #0  0x00007f2862b69428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
E           #0  0x00007f2862b69428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
E           #1  0x00007f2862b6b02a in __GI_abort () at abort.c:89
E           #2  0x00007f286358901a in core_handler (signo=11, siginfo=0x7ffd1cca13b0, context=0x7ffd1cca1280) at lib/sigevent.c:249
E           #3  <signal handler called>
E           #4  dplane_ctx_route_init (re=0xbdfe30, rn=0xbe0020, op=DPLANE_OP_ROUTE_DELETE, ctx=0xbdc280) at zebra/zebra_dplane.c:709
E           #5  dplane_route_update_internal (rn=rn@entry=0xbe0020, re=re@entry=0xbdfe30, old_re=old_re@entry=0x0, op=op@entry=DPLANE_OP_ROUTE_DELETE) at zebra/zebra_dplane.c:812
E           #6  0x0000000000425e62 in dplane_route_delete (rn=rn@entry=0xbe0020, re=re@entry=0xbdfe30) at zebra/zebra_dplane.c:906
E           #7  0x000000000042f2a4 in rib_uninstall_kernel (rn=rn@entry=0xbe0020, re=0xbdfe30) at zebra/zebra_rib.c:1146
E           #8  0x00000000004311c0 in rib_close_table (table=<optimized out>) at zebra/zebra_rib.c:3203
E           #9  0x0000000000431628 in zebra_router_free_table (zrt=0xbdff10) at zebra/zebra_router.c:144
E           #10 zebra_router_terminate () at zebra/zebra_router.c:158
E           #11 0x000000000041bf67 in zebra_finalize (dummy=<optimized out>) at zebra/main.c:208
E           #12 0x00007f28635938c4 in thread_call (thread=thread@entry=0x7ffd1cca1b68) at lib/thread.c:1606
E           #13 0x00007f286357088d in frr_run (master=0x727f00) at lib/libfrr.c:1030
```