### PR TITLE
bfdd, nhrpd, pimd: When deleting an interface clean up

### DIFF
--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -327,9 +327,11 @@ int nhrp_interface_delete(int cmd, struct zclient *client, zebra_size_t length,
 		return 0;
 
 	debugf(NHRP_DEBUG_IF, "if-delete: %s", ifp->name);
-	if_set_index(ifp, ifp->ifindex);
+
 	nhrp_interface_update(ifp);
-	/* if_delete(ifp); */
+
+	if_set_index(ifp, IFINDEX_INTERNAL);
+
 	return 0;
 }
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -150,6 +150,8 @@ static int pim_zebra_if_del(int command, struct zclient *zclient,
 	if (!if_is_operative(ifp))
 		pim_if_addr_del_all(ifp);
 
+	if_set_index(ifp, IFINDEX_INTERNAL);
+
 	return 0;
 }
 


### PR DESCRIPTION
When we delete an interface, we need to set the interface
ifindex to an internal value so that we don't end up in
a state where the re-addition of the same ifindex, due to
a rename operation, causes an infinite loop.

Fixes:#4007
Fix-Suggested-by: Saravanan K
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
