### PR TITLE
doc: remove unneeded build deps

### DIFF
--- a/doc/developer/building-frr-for-centos6.rst
+++ b/doc/developer/building-frr-for-centos6.rst
@@ -43,7 +43,7 @@ Add packages:
 
 .. code-block:: shell
 
-   sudo yum install git autoconf automake libtool make gawk \
+   sudo yum install git autoconf automake libtool make \
       readline-devel texinfo net-snmp-devel groff pkgconfig \
       json-c-devel pam-devel flex epel-release c-ares-devel
 

--- a/doc/developer/building-frr-for-centos7.rst
+++ b/doc/developer/building-frr-for-centos7.rst
@@ -18,7 +18,7 @@ Add packages:
 
 ::
 
-    sudo yum install git autoconf automake libtool make gawk \
+    sudo yum install git autoconf automake libtool make \
       readline-devel texinfo net-snmp-devel groff pkgconfig \
       json-c-devel pam-devel bison flex pytest c-ares-devel \
       python-devel systemd-devel python-sphinx

--- a/doc/developer/building-frr-for-debian8.rst
+++ b/doc/developer/building-frr-for-debian8.rst
@@ -15,7 +15,7 @@ Add packages:
 
 ::
 
-   sudo apt-get install git autoconf automake libtool make gawk \
+   sudo apt-get install git autoconf automake libtool make \
       libreadline-dev texinfo libjson-c-dev pkg-config bison flex python-pip \
       libc-ares-dev python3-dev python3-sphinx build-essential libsystemd-dev
 

--- a/doc/developer/building-frr-for-fedora.rst
+++ b/doc/developer/building-frr-for-fedora.rst
@@ -11,7 +11,7 @@ Installing Dependencies
 
 .. code-block:: console
 
-   sudo dnf install git autoconf automake libtool make gawk \
+   sudo dnf install git autoconf automake libtool make \
      readline-devel texinfo net-snmp-devel groff pkgconfig json-c-devel \
      pam-devel pytest bison flex c-ares-devel python3-devel python2-sphinx \
      perl-core patch

--- a/doc/developer/building-frr-for-freebsd10.rst
+++ b/doc/developer/building-frr-for-freebsd10.rst
@@ -16,7 +16,7 @@ is first package install and asked)
 
 ::
 
-    pkg install git autoconf automake libtool gmake gawk json-c pkgconf \
+    pkg install git autoconf automake libtool gmake json-c pkgconf \
         bison flex py27-pytest c-ares python3 py-sphinx
 
 Make sure there is no /usr/bin/flex preinstalled (and use the newly

--- a/doc/developer/building-frr-for-freebsd11.rst
+++ b/doc/developer/building-frr-for-freebsd11.rst
@@ -16,7 +16,7 @@ is first package install and asked)
 
 .. code-block:: shell
 
-   pkg install git autoconf automake libtool gmake gawk json-c pkgconf \
+   pkg install git autoconf automake libtool gmake json-c pkgconf \
       bison flex py27-pytest c-ares python3 py36-sphinx texinfo
 
 Make sure there is no /usr/bin/flex preinstalled (and use the newly

--- a/doc/developer/building-frr-for-freebsd9.rst
+++ b/doc/developer/building-frr-for-freebsd9.rst
@@ -16,9 +16,9 @@ is first package install and asked)
 
 ::
 
-    pkg install -y git autoconf automake libtool gmake gawk \
+    pkg install -y git autoconf automake libtool gmake \
         pkgconf texinfo json-c bison flex py27-pytest c-ares \
-        python3 py-sphinx
+        python3 py-sphinx libexecinfo
 
 Make sure there is no /usr/bin/flex preinstalled (and use the newly
 installed in /usr/local/bin): (FreeBSD frequently provides a older flex

--- a/doc/developer/building-frr-for-netbsd6.rst
+++ b/doc/developer/building-frr-for-netbsd6.rst
@@ -22,7 +22,7 @@ Add packages:
 
 ::
 
-    sudo pkg_add git autoconf automake libtool gmake gawk openssl \
+    sudo pkg_add git autoconf automake libtool gmake openssl \
        pkg-config json-c python27 py27-test python35 py-sphinx
 
 Install SSL Root Certificates (for git https access):

--- a/doc/developer/building-frr-for-netbsd7.rst
+++ b/doc/developer/building-frr-for-netbsd7.rst
@@ -13,7 +13,7 @@ Install required packages
 
 ::
 
-    sudo pkgin install git autoconf automake libtool gmake gawk openssl \
+    sudo pkgin install git autoconf automake libtool gmake openssl \
        pkg-config json-c python27 py27-test python35 py-sphinx
 
 Install SSL Root Certificates (for git https access):

--- a/doc/developer/building-frr-for-omnios.rst
+++ b/doc/developer/building-frr-for-omnios.rst
@@ -37,7 +37,7 @@ Add packages:
       library/idnkit/header-idnkit \
       system/header \
       system/library/math/header-math \
-      git libtool gawk pkg-config
+      git libtool pkg-config
 
 Add additional Solaris packages:
 

--- a/doc/developer/building-frr-for-openbsd6.rst
+++ b/doc/developer/building-frr-for-openbsd6.rst
@@ -15,7 +15,7 @@ Add packages:
 ::
 
     pkg_add git autoconf-2.69p2 automake-1.15.1 libtool bison
-    pkg_add gmake gawk dejagnu openssl json-c py-test py-sphinx
+    pkg_add gmake json-c py-test py-sphinx libexecinfo
 
 Select Python2.7 as default (required for pytest)
 

--- a/doc/developer/building-frr-for-openwrt.rst
+++ b/doc/developer/building-frr-for-openwrt.rst
@@ -9,7 +9,7 @@ For Debian based distributions, run:
 ::
 
     sudo apt-get install git build-essential libssl-dev libncurses5-dev \
-       unzip gawk zlib1g-dev subversion mercurial
+       unzip zlib1g-dev subversion mercurial
 
 For other environments, instructions can be found in the
 `official documentation

--- a/doc/developer/building-frr-for-ubuntu1404.rst
+++ b/doc/developer/building-frr-for-ubuntu1404.rst
@@ -11,7 +11,7 @@ Installing Dependencies
 
    apt-get update
    apt-get install \
-      git autoconf automake libtool make gawk libreadline-dev texinfo \
+      git autoconf automake libtool make libreadline-dev texinfo \
       pkg-config libpam0g-dev libjson-c-dev bison flex python-pytest \
       libc-ares-dev python3-dev python3-sphinx install-info build-essential \
       libsnmp-dev perl

--- a/doc/developer/building-frr-for-ubuntu1604.rst
+++ b/doc/developer/building-frr-for-ubuntu1604.rst
@@ -11,7 +11,7 @@ Installing Dependencies
 
    apt-get update
    apt-get install \
-      git autoconf automake libtool make gawk libreadline-dev texinfo \
+      git autoconf automake libtool make libreadline-dev texinfo \
       pkg-config libpam0g-dev libjson-c-dev bison flex python-pytest \
       libc-ares-dev python3-dev libsystemd-dev python-ipaddress python3-sphinx \
       install-info build-essential libsystemd-dev libsnmp-dev perl

--- a/doc/developer/building-frr-for-ubuntu1804.rst
+++ b/doc/developer/building-frr-for-ubuntu1804.rst
@@ -11,7 +11,7 @@ Installing Dependencies
 
    sudo apt update
    sudo apt-get install \
-      git autoconf automake libtool make gawk libreadline-dev texinfo \
+      git autoconf automake libtool make libreadline-dev texinfo \
       pkg-config libpam0g-dev libjson-c-dev bison flex python-pytest \
       libc-ares-dev python3-dev libsystemd-dev python-ipaddress python3-sphinx \
       install-info build-essential libsystemd-dev libsnmp-dev perl


### PR DESCRIPTION
Remove the following:
* gawk
* dejagnu

Add the following for FreeBSD 9 and OpenBSD 6:
* libexecinfo

Tested on Ubuntu 18.04, OpenBSD 6

Fixes #1048 