### PR TITLE
pimd: Introduce mroute_creation in channel oil data structure

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4594,7 +4594,7 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty, bool fill,
 		for (oif_vif_index = 0; oif_vif_index < MAXVIFS;
 		     ++oif_vif_index) {
 			struct interface *ifp_out;
-			char oif_uptime[10];
+			char mroute_uptime[10];
 			int ttl;
 
 			ttl = c_oil->oil.mfcc_ttls[oif_vif_index];
@@ -4603,8 +4603,8 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty, bool fill,
 
 			ifp_out = pim_if_find_by_vif_index(pim, oif_vif_index);
 			pim_time_uptime(
-				oif_uptime, sizeof(oif_uptime),
-				now - c_oil->oif_creation[oif_vif_index]);
+				mroute_uptime, sizeof(mroute_uptime),
+				now - c_oil->mroute_creation);
 			found_oif = 1;
 
 			if (ifp_out)
@@ -4652,7 +4652,7 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty, bool fill,
 						    oif_vif_index);
 				json_object_int_add(json_ifp_out, "ttl", ttl);
 				json_object_string_add(json_ifp_out, "upTime",
-						       oif_uptime);
+						       mroute_uptime);
 				if (!json_oil) {
 					json_oil = json_object_new_object();
 					json_object_object_add(json_source,
@@ -4684,7 +4684,7 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty, bool fill,
 				vty_out(vty,
 					"%-15s %-15s %-6s %-16s %-16s %-3d  %8s\n",
 					src_str, grp_str, proto, in_ifname,
-					out_ifname, ttl, oif_uptime);
+					out_ifname, ttl, mroute_uptime);
 
 				if (first) {
 					src_str[0] = '\0';

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -964,6 +964,8 @@ int pim_mroute_add(struct channel_oil *c_oil, const char *name)
 	}
 
 	c_oil->installed = 1;
+	c_oil->mroute_creation = pim_time_monotonic_sec();
+
 	return 0;
 }
 

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -97,6 +97,7 @@ struct channel_oil {
 	uint32_t oif_flags[MAXVIFS];
 	struct channel_counts cc;
 	struct pim_upstream *up;
+	time_t mroute_creation;
 };
 
 extern struct list *pim_channel_oil_list;


### PR DESCRIPTION
Issue: (*,G) mroute uptime is not updated in mroute table,
after deleting and adding the RP

Root cause: When RP gets deleted or becomes not reachable, then
we un-install the entry from the kernel, but still maintains the
entry in the stack. When  RP gets re-configured or becomes reachable,
"show ip mroute" shows the uptime, when the channel_oil gets created.

Fix: Introduce a new time mroute_creation in the channel_oil, gets
updated when mroute gets installed in the kernel.

Signed-off-by: Sarita Patra <saritap@vmware.com>