### PR TITLE
 Static routes are not added in the RIB if there is a static route with Null0 - staticd regression 

### DIFF
--- a/staticd/static_nht.c
+++ b/staticd/static_nht.c
@@ -52,7 +52,7 @@ static void static_nht_update_safi(struct prefix *p, uint32_t nh_num,
 		reinstall = false;
 		for (si = rn->info; si; si = si->next) {
 			if (si->nh_vrf_id != nh_vrf_id)
-				return;
+				continue;
 
 			if (si->type != STATIC_IPV4_GATEWAY
 			    && si->type != STATIC_IPV4_GATEWAY_IFNAME

--- a/staticd/static_nht.c
+++ b/staticd/static_nht.c
@@ -58,7 +58,7 @@ static void static_nht_update_safi(struct prefix *p, uint32_t nh_num,
 			    && si->type != STATIC_IPV4_GATEWAY_IFNAME
 			    && si->type != STATIC_IPV6_GATEWAY
 			    && si->type != STATIC_IPV6_GATEWAY_IFNAME)
-				return;
+				continue;
 
 			orig = si->nh_valid;
 			if (p->family == AF_INET


### PR DESCRIPTION
Hi,

In this patch 82ce2431961340b15761dfcfef467654 the staticd/static_nht.c was changed. But the new code has a return instead of continue and is stopping the search of installed routes:
This patch is solving the issue #4046 

This patch should be pushed as emergency. In setups with eBGP with multihop if the static route is not installed could lead in routes flaps and when you have 700K routes will overload the Zebra and BGP.
