### PR TITLE
libs: nexthop comparison includes labels if present

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -121,12 +121,17 @@ const char *nexthop_type_to_str(enum nexthop_types_t nh_type)
 /*
  * Check if the labels match for the 2 nexthops specified.
  */
-int nexthop_labels_match(struct nexthop *nh1, struct nexthop *nh2)
+int nexthop_labels_match(const struct nexthop *nh1, const struct nexthop *nh2)
 {
-	struct mpls_label_stack *nhl1, *nhl2;
+	const struct mpls_label_stack *nhl1, *nhl2;
 
 	nhl1 = nh1->nh_label;
 	nhl2 = nh2->nh_label;
+
+	/* No labels is a match */
+	if (!nhl1 && !nhl2)
+		return 1;
+
 	if (!nhl1 || !nhl2)
 		return 0;
 
@@ -212,7 +217,8 @@ bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2)
 		break;
 	}
 
-	return true;
+	/* Compare labels too (if present) */
+	return (!!nexthop_labels_match(nh1, nh2));
 }
 
 /* Update nexthop with label information. */

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -143,10 +143,12 @@ extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
 extern const char *nexthop_type_to_str(enum nexthop_types_t nh_type);
 extern int nexthop_same_no_recurse(const struct nexthop *next1,
 				   const struct nexthop *next2);
-extern int nexthop_labels_match(struct nexthop *nh1, struct nexthop *nh2);
+extern int nexthop_labels_match(const struct nexthop *nh1,
+				const struct nexthop *nh2);
 extern int nexthop_same_firsthop(struct nexthop *next1, struct nexthop *next2);
 
-extern const char *nexthop2str(const struct nexthop *nexthop, char *str, int size);
+extern const char *nexthop2str(const struct nexthop *nexthop,
+			       char *str, int size);
 extern struct nexthop *nexthop_next(struct nexthop *nexthop);
 extern unsigned int nexthop_level(struct nexthop *nexthop);
 


### PR DESCRIPTION
Adjust the nexthop comparison api so that it calls the label-comparison api. Adjust the label-comp api so that "no labels" is "equal". Also made the args to the label-comparison api 'const'.
