### PR TITLE
staticd: Fix static routes that are not added in RIB after Null0 or v…

### DIFF
--- a/staticd/static_nht.c
+++ b/staticd/static_nht.c
@@ -52,13 +52,13 @@ static void static_nht_update_safi(struct prefix *p, uint32_t nh_num,
 		reinstall = false;
 		for (si = rn->info; si; si = si->next) {
 			if (si->nh_vrf_id != nh_vrf_id)
-				return;
+				continue;
 
 			if (si->type != STATIC_IPV4_GATEWAY
 			    && si->type != STATIC_IPV4_GATEWAY_IFNAME
 			    && si->type != STATIC_IPV6_GATEWAY
 			    && si->type != STATIC_IPV6_GATEWAY_IFNAME)
-				return;
+				continue;
 
 			orig = si->nh_valid;
 			if (p->family == AF_INET


### PR DESCRIPTION
…rf routes

When you add a static route like:

ip route 10.0.0.0/24 Null0
ip route 192.168.7.0/24 99.99.99.99 nexthop-vrf EVA

all routes after this command will be ignored by staticd and are not inserted in RIB.
This is the cause of return instead of continue in the for loop in static_nht_update_safi() function that is stopping the search in the routes list and is returning in the previous function without calling static_zebra_route_add() function.

This patch is fixing this issue.

Signed-off-by: Adrian Ban <bugs@abtelcom.ro>