### PR TITLE
lib,bgpd: do not register nexthop 0.0.0.0 to nht

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -243,8 +243,10 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 	if (bgp_route->inst_type == BGP_INSTANCE_TYPE_VIEW) {
 		SET_FLAG(bnc->flags, BGP_NEXTHOP_REGISTERED);
 		SET_FLAG(bnc->flags, BGP_NEXTHOP_VALID);
-	} else if (!CHECK_FLAG(bnc->flags, BGP_NEXTHOP_REGISTERED))
+	} else if (!CHECK_FLAG(bnc->flags, BGP_NEXTHOP_REGISTERED) &&
+		   !is_default_host_route(&bnc->node->p))
 		register_zebra_rnh(bnc, is_bgp_static_route);
+
 	if (pi && pi->nexthop != bnc) {
 		/* Unlink from existing nexthop cache, if any. This will also
 		 * free

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -511,6 +511,19 @@ static inline int is_host_route(struct prefix *p)
 	return 0;
 }
 
+static inline int is_default_host_route(struct prefix *p)
+{
+	if (p->family == AF_INET) {
+		return (p->u.prefix4.s_addr == INADDR_ANY &&
+			p->prefixlen == IPV4_MAX_BITLEN);
+	} else if (p->family == AF_INET6) {
+		return ((!memcmp(&p->u.prefix6, &in6addr_any,
+				 sizeof(struct in6_addr))) &&
+			p->prefixlen == IPV6_MAX_BITLEN);
+	}
+	return 0;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Avoid tracking 0.0.0.0/32 nexthop with RIB.

When routes are aggregated, the originate of the route becomes self.
Do not track next hop self (0.0.0.0) with rib.


Testing Done:

**Before fix-**

tor-11# show ip nht vrf all

VRF blue:
0.0.0.0
 unresolved
 Client list: bgp(fd 16)

VRF default:

VRF green:

VRF magenta:
0.0.0.0
 unresolved
 Client list: bgp(fd 16)

**After fix-**

tor-11# show ip nht vrf all

VRF blue:

VRF default:

VRF green:

VRF magenta:

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>