### PR TITLE
lib: reduce exported var symbols

### DIFF
--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -34,8 +34,8 @@
 
 DEFINE_MTYPE_STATIC(LIB, BFD_INFO, "BFD info")
 
-int bfd_debug = 0;
-struct bfd_gbl bfd_gbl;
+static int bfd_debug = 0;
+static struct bfd_gbl bfd_gbl;
 
 /*
  * bfd_gbl_init - Initialize the BFD global structure

--- a/lib/distribute.c
+++ b/lib/distribute.c
@@ -32,7 +32,7 @@ DEFINE_MTYPE_STATIC(LIB, DISTRIBUTE, "Distribute list")
 DEFINE_MTYPE_STATIC(LIB, DISTRIBUTE_IFNAME, "Dist-list ifname")
 DEFINE_MTYPE_STATIC(LIB, DISTRIBUTE_NAME, "Dist-list name")
 
-struct list *dist_ctx_list;
+static struct list *dist_ctx_list;
 
 static struct distribute *distribute_new(void)
 {

--- a/lib/ferr.c
+++ b/lib/ferr.c
@@ -61,7 +61,7 @@ static void err_key_fini(void)
 /*
  * Global shared hash table holding reference text for all defined errors.
  */
-pthread_mutex_t refs_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t refs_mtx = PTHREAD_MUTEX_INITIALIZER;
 struct hash *refs;
 
 static bool ferr_hash_cmp(const void *a, const void *b)

--- a/lib/grammar_sandbox.c
+++ b/lib/grammar_sandbox.c
@@ -44,7 +44,7 @@ void pretty_print_graph(struct vty *vty, struct graph_node *, int, int,
 void init_cmdgraph(struct vty *, struct graph **);
 
 /** shim interface commands **/
-struct graph *nodegraph = NULL, *nodegraph_free = NULL;
+static struct graph *nodegraph = NULL, *nodegraph_free = NULL;
 
 #define check_nodegraph()                                                      \
 	do {                                                                   \

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -33,7 +33,7 @@ DEFINE_MTYPE(LIB, HASH, "Hash")
 DEFINE_MTYPE(LIB, HASH_BACKET, "Hash Bucket")
 DEFINE_MTYPE_STATIC(LIB, HASH_INDEX, "Hash Index")
 
-pthread_mutex_t _hashes_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t _hashes_mtx = PTHREAD_MUTEX_INITIALIZER;
 static struct list *_hashes;
 
 struct hash *hash_create_size(unsigned int size,

--- a/lib/if.c
+++ b/lib/if.c
@@ -56,9 +56,6 @@ DEFINE_QOBJ_TYPE(interface)
 DEFINE_HOOK(if_add, (struct interface * ifp), (ifp))
 DEFINE_KOOH(if_del, (struct interface * ifp), (ifp))
 
-/* List of interfaces in only the default VRF */
-int ptm_enable = 0;
-
 /* Compare interface names, returning an integer greater than, equal to, or
  * less than 0, (following the strcmp convention), according to the
  * relationship between ifp1 and ifp2.  Interface names consist of an

--- a/lib/if_rmap.c
+++ b/lib/if_rmap.c
@@ -31,7 +31,7 @@ DEFINE_MTYPE_STATIC(LIB, IF_RMAP_CTX_NAME, "Interface route map container name")
 DEFINE_MTYPE_STATIC(LIB, IF_RMAP, "Interface route map")
 DEFINE_MTYPE_STATIC(LIB, IF_RMAP_NAME, "I.f. route map name")
 
-struct list *if_rmap_ctx_list;
+static struct list *if_rmap_ctx_list;
 
 static struct if_rmap *if_rmap_new(void)
 {

--- a/lib/imsg.c
+++ b/lib/imsg.c
@@ -22,9 +22,9 @@
 #include "queue.h"
 #include "imsg.h"
 
-int imsg_fd_overhead = 0;
+static int imsg_fd_overhead = 0;
 
-int imsg_get_fd(struct imsgbuf *);
+static int imsg_get_fd(struct imsgbuf *);
 
 #ifndef __OpenBSD__
 /*

--- a/lib/keychain.c
+++ b/lib/keychain.c
@@ -32,7 +32,7 @@ DEFINE_QOBJ_TYPE(keychain)
 DEFINE_QOBJ_TYPE(key)
 
 /* Master list of key chain. */
-struct list *keychain_list;
+static struct list *keychain_list;
 
 static struct keychain *keychain_new(void)
 {

--- a/lib/log.c
+++ b/lib/log.c
@@ -57,7 +57,7 @@ struct zlog *zlog_default = NULL;
 bool zlog_startup_stderr = true;
 
 /* lock protecting zlog_default for mt-safe zlog */
-pthread_mutex_t loglock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t loglock = PTHREAD_MUTEX_INITIALIZER;
 
 const char *zlog_priority[] = {
 	"emergencies",   "alerts",	"critical",  "errors", "warnings",

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -49,7 +49,7 @@ nexthop_group_cmd_compare(const struct nexthop_group_cmd *nhgc1,
 RB_GENERATE(nhgc_entry_head, nexthop_group_cmd, nhgc_entry,
 	    nexthop_group_cmd_compare)
 
-struct nhgc_entry_head nhgc_entries;
+static struct nhgc_entry_head nhgc_entries;
 
 static inline int
 nexthop_group_cmd_compare(const struct nexthop_group_cmd *nhgc1,

--- a/lib/sigevent.c
+++ b/lib/sigevent.c
@@ -38,7 +38,7 @@
 
 
 /* master signals descriptor struct */
-struct quagga_sigevent_master_t {
+static struct quagga_sigevent_master_t {
 	struct thread *t;
 
 	struct quagga_signal_t *signals;

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -52,10 +52,10 @@ DEFINE_MTYPE_STATIC(LIB, THREAD_STATS, "Thread stats")
 	} while (0);
 
 /* control variable for initializer */
-pthread_once_t init_once = PTHREAD_ONCE_INIT;
+static pthread_once_t init_once = PTHREAD_ONCE_INIT;
 pthread_key_t thread_current;
 
-pthread_mutex_t masters_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t masters_mtx = PTHREAD_MUTEX_INITIALIZER;
 static struct list *masters;
 
 static void thread_free(struct thread_master *master, struct thread *thread);

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -64,7 +64,7 @@ static char vrf_default_name[VRF_NAMSIZ] = VRF_DEFAULT_NAME_INTERNAL;
  * Turn on/off debug code
  * for vrf.
  */
-int debug_vrf = 0;
+static int debug_vrf = 0;
 
 /* Holding VRF hooks  */
 struct vrf_master {

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -93,7 +93,7 @@ struct vty *vty_exclusive_lock;
 static int no_password_check = 0;
 
 /* Integrated configuration file path */
-char integrate_default[] = SYSCONFDIR INTEGRATE_DEFAULT_CONFIG;
+static char integrate_default[] = SYSCONFDIR INTEGRATE_DEFAULT_CONFIG;
 
 static int do_log_commands = 0;
 

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -290,7 +290,6 @@ struct vty_arg {
 #endif
 
 /* Exported variables */
-extern char integrate_default[];
 extern struct vty *vty_exclusive_lock;
 
 /* Prototypes. */

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -49,13 +49,13 @@ enum event { ZCLIENT_SCHEDULE, ZCLIENT_READ, ZCLIENT_CONNECT };
 /* Prototype for event manager. */
 static void zclient_event(enum event, struct zclient *);
 
+struct zclient_options zclient_options_default = {.receive_notify = false};
+
 struct sockaddr_storage zclient_addr;
 socklen_t zclient_addr_len;
 
 /* This file local debug flag. */
-int zclient_debug = 0;
-
-struct zclient_options zclient_options_default = {.receive_notify = false};
+static int zclient_debug;
 
 /* Allocate zclient structure. */
 struct zclient *zclient_new(struct thread_master *master,


### PR DESCRIPTION
Don't need these in our DSO tables

Just variables this time, maybe functions in the future, if anybody knows any tools for finding this stuff please tell me about them

before
```
root@ubuntu-bionic [reduce-exported-vars] ~/f/l/.libs> nm -g libfrr.so.0.0.0 | wc -l
1548
root@ubuntu-bionic [reduce-exported-vars] ~/f/lib> env LD_DEBUG=statistics /usr/lib/frr/bgpd
     31880:
     31880:     runtime linker statistics:
...
     31880:                      number of relocations: 1284
...
     31880:                final number of relocations: 1960
     31880:     final number of relocations from cache: 1539
```
after
```
root@ubuntu-bionic [reduce-exported-vars] ~/f/l/.libs> nm -g libfrr.so.0.0.0 | wc -l
1528
root@ubuntu-bionic [reduce-exported-vars] ~/f/lib> env LD_DEBUG=statistics /usr/lib/frr/bgpd
      8957:
      8957:     runtime linker statistics:
...
      8957:                      number of relocations: 1266
...
      8957:                final number of relocations: 1942
      8957:     final number of relocations from cache: 1539
```
Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>