### PR TITLE
bgpd: Fix rpki command nodes.

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1472,7 +1472,7 @@ static void install_cli_commands(void)
 	install_default(RPKI_NODE);
 	overwrite_exit_commands();
 	install_element(CONFIG_NODE, &rpki_cmd);
-	install_element(VIEW_NODE, &rpki_cmd);
+	install_element(ENABLE_NODE, &rpki_cmd);
 
 	install_element(ENABLE_NODE, &bgp_rpki_start_cmd);
 	install_element(ENABLE_NODE, &bgp_rpki_stop_cmd);
@@ -1505,10 +1505,10 @@ static void install_cli_commands(void)
 	install_element(RPKI_NODE, &no_rpki_cache_cmd);
 
 	/* Install show commands */
-	install_element(ENABLE_NODE, &show_rpki_prefix_table_cmd);
-	install_element(ENABLE_NODE, &show_rpki_cache_connection_cmd);
-	install_element(ENABLE_NODE, &show_rpki_cache_server_cmd);
-	install_element(ENABLE_NODE, &show_rpki_prefix_cmd);
+	install_element(VIEW_NODE, &show_rpki_prefix_table_cmd);
+	install_element(VIEW_NODE, &show_rpki_cache_connection_cmd);
+	install_element(VIEW_NODE, &show_rpki_cache_server_cmd);
+	install_element(VIEW_NODE, &show_rpki_prefix_cmd);
 
 	/* Install debug commands */
 	install_element(CONFIG_NODE, &debug_rpki_cmd);


### PR DESCRIPTION
Move &rpki_cmd from VIEW to ENABLE.  A non-enabled session could
enter into the rpki command node and exit into global config mode
without having to enable.

Move &show_rpki_* from ENABLE to VIEW. Allow non-enabled user to
view cache state and prefix table state.

Signed-off-by: David Teach <dteach@routeviews.org>