### PR TITLE
libs: use const in copy_nexthops api

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -118,11 +118,11 @@ void nexthop_del(struct nexthop_group *nhg, struct nexthop *nh)
 	nh->next = NULL;
 }
 
-void copy_nexthops(struct nexthop **tnh, struct nexthop *nh,
+void copy_nexthops(struct nexthop **tnh, const struct nexthop *nh,
 		   struct nexthop *rparent)
 {
 	struct nexthop *nexthop;
-	struct nexthop *nh1;
+	const struct nexthop *nh1;
 
 	for (nh1 = nh; nh1; nh1 = nh1->next) {
 		nexthop = nexthop_new();

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -44,7 +44,7 @@ void nexthop_group_delete(struct nexthop_group **nhg);
 
 void nexthop_add(struct nexthop **target, struct nexthop *nexthop);
 void nexthop_del(struct nexthop_group *nhg, struct nexthop *nexthop);
-void copy_nexthops(struct nexthop **tnh, struct nexthop *nh,
+void copy_nexthops(struct nexthop **tnh, const struct nexthop *nh,
 		   struct nexthop *rparent);
 
 /* The following for loop allows to iterate over the nexthop


### PR DESCRIPTION
Use const for the source arg to copy_nexthops().
