### PR TITLE
zebra: Make rnh only send response once on first registration

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1107,11 +1107,12 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 		if (orig_flags != rnh->flags)
 			flag_changed = true;
 
-		zebra_add_rnh_client(rnh, client, type, zvrf_id(zvrf));
 		/* Anything not AF_INET/INET6 has been filtered out above */
 		if (!exist || flag_changed)
 			zebra_evaluate_rnh(zvrf, family2afi(p.family), 1, type,
 					   &p);
+
+		zebra_add_rnh_client(rnh, client, type, zvrf_id(zvrf));
 	}
 
 stream_failure:


### PR DESCRIPTION
The current code path of registration does this:

a) Lookup or create the rnh
b) register the client with the rnh for callback
   If this is a new rnh send a response to the client that
   only includes the rnh data that it has (nothing so no path)
   If this is a existing rnh send the actual path to the client,
     if it exists.
c) If a new client or a flag has changed refigure and send result
   to all clients.

This is problematic in that suppose the rnh is new.  Clients
will receive two answers:
  1) A call back with no nexthops
  2) A call back with the resolved # of nexthops

Imagine pim who depends on nht to handle this, pim will create
a mroute( because it does a hard lookup of the rpf as it is registering
the nexthop ), then it will receive the first callback causing
it to tear down the mroute and then receive the second callback
causing it to put it right back.. This is obviously not very
good for mroutes.

This code moves the send to the new client till after the new
client has connected, thus only allowing one callback to the new
client with the actual answer.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>