### PR TITLE
staticd: Allow reinstall of static nexthops on vrf restart

### DIFF
--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -329,6 +329,7 @@ static void static_fixup_vrf(struct static_vrf *svrf,
 				continue;
 
 			si->nh_vrf_id = svrf->vrf->vrf_id;
+			si->nh_registered = false;
 			if (si->ifindex) {
 				ifp = if_lookup_by_name(si->ifname,
 							si->nh_vrf_id);


### PR DESCRIPTION
When staticd receives notification that a vrf that it is using
is back up into a state that can be used, go through and
mark all the si data structures nexthops as not installed.
This will allow us to complete the loop and reinstall routes
that need to be fully resolved.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>