### PR TITLE
Support TCP MD5 auth on prefixes & enable MD5 auth for BGP listen ranges

### DIFF
--- a/bgpd/bgp_network.h
+++ b/bgpd/bgp_network.h
@@ -30,6 +30,8 @@ extern void bgp_close(void);
 extern int bgp_connect(struct peer *);
 extern int bgp_getsockname(struct peer *);
 
+extern int bgp_md5_set_prefix(struct prefix *p, const char *password);
+extern int bgp_md5_unset_prefix(struct prefix *p);
 extern int bgp_md5_set(struct peer *);
 extern int bgp_md5_unset(struct peer *);
 extern int bgp_set_socket_ttl(struct peer *, int fd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2645,6 +2645,11 @@ int peer_group_listen_range_add(struct peer_group *group, struct prefix *range)
 	prefix = prefix_new();
 	prefix_copy(prefix, range);
 	listnode_add(group->listen_range[afi], prefix);
+
+	/* Update passwords for new ranges */
+	if (group->conf->password)
+		bgp_md5_set_prefix(prefix, group->conf->password);
+
 	return 0;
 }
 
@@ -2688,6 +2693,10 @@ int peer_group_listen_range_del(struct peer_group *group, struct prefix *range)
 
 	/* Get rid of the listen range */
 	listnode_delete(group->listen_range[afi], prefix);
+
+	/* Remove passwords for deleted ranges */
+	if (group->conf->password)
+		bgp_md5_unset_prefix(prefix);
 
 	return 0;
 }
@@ -5519,6 +5528,15 @@ int peer_password_set(struct peer *peer, const char *password)
 			ret = BGP_ERR_TCPSIG_FAILED;
 	}
 
+	/* Set flag and configuration on all peer-group listen ranges */
+	struct listnode *ln;
+	struct prefix *lr;
+
+	for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP], ln, lr))
+		bgp_md5_set_prefix(lr, password);
+	for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP6], ln, lr))
+		bgp_md5_set_prefix(lr, password);
+
 	return ret;
 }
 
@@ -5582,6 +5600,15 @@ int peer_password_unset(struct peer *peer)
 		if (!BGP_PEER_SU_UNSPEC(member))
 			bgp_md5_unset(member);
 	}
+
+	/* Set flag and configuration on all peer-group listen ranges */
+	struct listnode *ln;
+	struct prefix *lr;
+
+	for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP], ln, lr))
+		bgp_md5_unset_prefix(lr);
+	for (ALL_LIST_ELEMENTS_RO(peer->group->listen_range[AFI_IP6], ln, lr))
+		bgp_md5_unset_prefix(lr);
 
 	return 0;
 }

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -826,6 +826,30 @@ Defining Peers
    peers ASN is the same as mine as specified under the :clicmd:`router bgp ASN`
    command the connection will be denied.
 
+.. index:: [no] bgp listen range <A.B.C.D/M|X:X::X:X/M> peer-group WORD
+.. clicmd:: [no] bgp listen range <A.B.C.D/M|X:X::X:X/M> peer-group WORD
+
+   Accept connections from any peers in the specified prefix. Configuration
+   from the specified peer-group is used to configure these peers.
+
+.. note::
+
+   When using BGP listen ranges, if the associated peer group has TCP MD5
+   authentication configured, your kernel must support this on prefixes. On
+   Linux, this support was added in kernel version 4.14. If your kernel does
+   not support this feature you will get a warning in the log file, and the
+   listen range will only accept connections from peers without MD5 configured.
+
+   Additionally, we have observed that when using this option at scale (several
+   hundred peers) the kernel may hit its option memory limit. In this situation
+   you will see error messages like:
+
+   ``bgpd: sockopt_tcp_signature: setsockopt(23): Cannot allocate memory``
+
+   In this case you need to increase the value of the sysctl
+   ``net.core.optmem_max`` to allow the kernel to allocate the necessary option
+   memory.
+
 .. _bgp-configuring-peers:
 
 Configuring Peers

--- a/lib/sockopt.h
+++ b/lib/sockopt.h
@@ -100,8 +100,42 @@ extern void sockopt_iphdrincl_swab_htosys(struct ip *iph);
 extern void sockopt_iphdrincl_swab_systoh(struct ip *iph);
 
 extern int sockopt_tcp_rtt(int);
+
+/*
+ * TCP MD5 signature option. This option allows TCP MD5 to be enabled on
+ * addresses.
+ *
+ * sock
+ *    Socket to enable option on.
+ *
+ * su
+ *    Sockunion specifying address to enable option on.
+ *
+ * password
+ *    MD5 auth password
+ */
 extern int sockopt_tcp_signature(int sock, union sockunion *su,
 				 const char *password);
+
+/*
+ * Extended TCP MD5 signature option. This option allows TCP MD5 to be enabled
+ * on prefixes.
+ *
+ * sock
+ *    Socket to enable option on.
+ *
+ * su
+ *    Sockunion specifying address (or prefix) to enable option on.
+ *
+ * prefixlen
+ *    0    - su is an address; fall back to non-extended mode
+ *    Else - su is a prefix; prefixlen is the mask length
+ *
+ * password
+ *    MD5 auth password
+ */
+extern int sockopt_tcp_signature_ext(int sock, union sockunion *su,
+				     uint16_t prefixlen, const char *password);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Linux kernel 4.14+ support TCP MD5 authentication on prefixes in addition to regular addresses. BGP would like to make use of this feature for dynamic peers. Prior to this if you configured a password on a peer-group with a listen range it would silently reject connections from peers configured with that password. Add support for both of these.

If you're on a recent enough kernel it will now work, and if you're not you'll get an explicit warning about it in the log.

Fixes #1631