### PR TITLE
zebra: Allow specification of v[4|6] addrs on some commands

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -931,7 +931,7 @@ void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 }
 
 void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
-			   rnh_type_t type)
+			   rnh_type_t type, struct prefix *p)
 {
 	struct route_table *table;
 	struct route_node *rn;
@@ -942,9 +942,13 @@ void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
 		return;
 	}
 
-	for (rn = route_top(table); rn; rn = route_next(rn))
+	for (rn = route_top(table); rn; rn = route_next(rn)) {
+		if (p && prefix_cmp(&rn->p, p) != 0)
+			continue;
+
 		if (rn->info)
 			print_rnh(rn, vty);
+	}
 }
 
 /**

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -91,7 +91,7 @@ extern void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client,
 extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 			       rnh_type_t type, struct prefix *p);
 extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
-				  rnh_type_t);
+				  rnh_type_t type, struct prefix *p);
 extern char *rnh_str(struct rnh *rnh, char *buf, int size);
 
 #ifdef __cplusplus


### PR DESCRIPTION
The `show ipv[4|6] <nht|import-check> ...` commands are starting
to produce a bunch of output due to multiple daemons now
using the code.  Allow the specification of a v4 or v6 address
to allow the show command to only display the interesting nht.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>