### PR TITLE
Fix a couple of YANG validation issues

### DIFF
--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -504,7 +504,9 @@ int nb_candidate_edit(struct nb_config *candidate,
 		 */
 		if (dnode) {
 			lyd_schema_sort(dnode, 0);
-			lyd_validate(&dnode, LYD_OPT_CONFIG, ly_native_ctx);
+			lyd_validate(&dnode,
+				     LYD_OPT_CONFIG | LYD_OPT_WHENAUTODEL,
+				     ly_native_ctx);
 		}
 		break;
 	case NB_OP_DESTROY:
@@ -570,7 +572,8 @@ int nb_candidate_update(struct nb_config *candidate)
  */
 static int nb_candidate_validate_yang(struct nb_config *candidate)
 {
-	if (lyd_validate(&candidate->dnode, LYD_OPT_STRICT | LYD_OPT_CONFIG,
+	if (lyd_validate(&candidate->dnode,
+			 LYD_OPT_STRICT | LYD_OPT_CONFIG | LYD_OPT_WHENAUTODEL,
 			 ly_native_ctx)
 	    != 0)
 		return NB_ERR_VALIDATION;

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -829,8 +829,10 @@ DEFPY (ip_rip_authentication_mode,
 
 	nb_cli_enqueue_change(vty, "./authentication-scheme/mode", NB_OP_MODIFY,
 			      strmatch(mode, "md5") ? "md5" : "plain-text");
-	nb_cli_enqueue_change(vty, "./authentication-scheme/md5-auth-length",
-			      NB_OP_MODIFY, value);
+	if (strmatch(mode, "md5"))
+		nb_cli_enqueue_change(vty,
+				      "./authentication-scheme/md5-auth-length",
+				      NB_OP_MODIFY, value);
 
 	return nb_cli_apply_changes(vty, "./frr-ripd:rip");
 }
@@ -852,7 +854,7 @@ DEFPY (no_ip_rip_authentication_mode,
 	nb_cli_enqueue_change(vty, "./authentication-scheme/mode", NB_OP_MODIFY,
 			      NULL);
 	nb_cli_enqueue_change(vty, "./authentication-scheme/md5-auth-length",
-			      NB_OP_MODIFY, NULL);
+			      NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, "./frr-ripd:rip");
 }


### PR DESCRIPTION
libyang 0.16-r3 introduced some changes that broke two FRR commands ("ip rip authentication" and "passive-interface default"). Fix these problems.

Related issue: #3953.