### PR TITLE
zebra: dataplane notifications for system route changes

### DIFF
--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -114,7 +114,14 @@ enum dplane_op_e {
 	/* Pseudowire update */
 	DPLANE_OP_PW_INSTALL,
 	DPLANE_OP_PW_UNINSTALL,
+
+	/* System route notification */
+	DPLANE_OP_SYS_ROUTE_ADD,
+	DPLANE_OP_SYS_ROUTE_DELETE,
 };
+
+/* Enable system route notifications */
+void dplane_enable_sys_route_notifs(void);
 
 /*
  * The dataplane context struct is used to exchange info between the main zebra
@@ -248,6 +255,12 @@ enum zebra_dplane_result dplane_route_update(struct route_node *rn,
 
 enum zebra_dplane_result dplane_route_delete(struct route_node *rn,
 					     struct route_entry *re);
+
+/* Notify the dplane when system/connected routes change */
+enum zebra_dplane_result dplane_sys_route_add(struct route_node *rn,
+					      struct route_entry *re);
+enum zebra_dplane_result dplane_sys_route_del(struct route_node *rn,
+					      struct route_entry *re);
 
 /*
  * Enqueue LSP change operations for the dataplane.

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2799,6 +2799,12 @@ int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 			break;
 	}
 
+	/* If this route is kernel/connected route, notify the dataplane. */
+	if (RIB_SYSTEM_ROUTE(re)) {
+		/* Notify dataplane */
+		dplane_sys_route_add(rn, re);
+	}
+
 	/* Link new re to node.*/
 	if (IS_ZEBRA_DEBUG_RIB) {
 		rnode_debug(rn, re->vrf_id,
@@ -3010,6 +3016,11 @@ void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 							       &vtep_ip, p);
 			}
 		}
+
+		/* Notify dplane if system route changes */
+		if (RIB_SYSTEM_ROUTE(re))
+			dplane_sys_route_del(rn, same);
+
 		rib_delnode(rn, same);
 	}
 
@@ -3353,6 +3364,12 @@ static int rib_process_dplane_results(struct thread *thread)
 			case DPLANE_OP_PW_INSTALL:
 			case DPLANE_OP_PW_UNINSTALL:
 				handle_pw_result(ctx);
+				break;
+
+			case DPLANE_OP_SYS_ROUTE_ADD:
+			case DPLANE_OP_SYS_ROUTE_DELETE:
+				/* No further processing in zebra for these. */
+				dplane_ctx_fini(&ctx);
 				break;
 
 			default:


### PR DESCRIPTION
Add notifications from zebra to the dataplane subsystem when kernel or connected routes change. This can help keep a remote dataplane in-sync if there are changes from the local OS. The kernel plugin ignores these, but they pass through to any other dataplane plugins.
