### PR TITLE
Pim nht cleanup

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -4257,7 +4257,6 @@ DEFUN (show_ip_pim_nexthop_lookup,
        "Source/RP address\n"
        "Multicast Group address\n")
 {
-	struct pim_nexthop_cache *pnc = NULL;
 	struct prefix nht_p;
 	int result = 0;
 	struct in_addr src_addr, grp_addr;
@@ -4269,7 +4268,6 @@ DEFUN (show_ip_pim_nexthop_lookup,
 	char grp_str[PREFIX_STRLEN];
 	int idx = 2;
 	struct vrf *vrf = pim_cmd_lookup_vrf(vty, argv, argc, &idx);
-	struct pim_rpf rpf;
 
 	if (!vrf)
 		return CMD_WARNING;
@@ -4315,18 +4313,7 @@ DEFUN (show_ip_pim_nexthop_lookup,
 	grp.u.prefix4 = grp_addr;
 	memset(&nexthop, 0, sizeof(nexthop));
 
-	memset(&rpf, 0, sizeof(struct pim_rpf));
-	rpf.rpf_addr.family = AF_INET;
-	rpf.rpf_addr.prefixlen = IPV4_MAX_BITLEN;
-	rpf.rpf_addr.u.prefix4 = vif_source;
-
-	pnc = pim_nexthop_cache_find(vrf->info, &rpf);
-	if (pnc)
-		result = pim_ecmp_nexthop_search(vrf->info, pnc, &nexthop,
-						 &nht_p, &grp, 0);
-	else
-		result = pim_ecmp_nexthop_lookup(vrf->info, &nexthop, &nht_p,
-						 &grp, 0);
+	result = pim_ecmp_nexthop_lookup(vrf->info, &nexthop, &nht_p, &grp, 0);
 
 	if (!result) {
 		vty_out(vty,

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -899,6 +899,8 @@ int pim_ecmp_fib_lookup_if_vif_index(struct pim_instance *pim,
 	if (PIM_DEBUG_PIM_NHT)
 		pim_inet4_dump("<addr?>", src->u.prefix4, addr_str,
 			       sizeof(addr_str));
+
+	memset(&nhop, 0, sizeof(nhop));
 	if (!pim_ecmp_nexthop_lookup(pim, &nhop, src, grp, 0)) {
 		if (PIM_DEBUG_PIM_NHT)
 			zlog_debug(

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -710,6 +710,7 @@ int pim_parse_nexthop_update(int command, struct zclient *zclient,
 		nexthops_free(pnc->nexthop);
 		pnc->nexthop = NULL;
 	}
+	SET_FLAG(pnc->flags, PIM_NEXTHOP_ANSWER_RECEIVED);
 
 	if (PIM_DEBUG_PIM_NHT) {
 		char buf[PREFIX2STR_BUFFER];
@@ -762,9 +763,11 @@ int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 	rpf.rpf_addr.u.prefix4 = src->u.prefix4;
 
 	pnc = pim_nexthop_cache_find(pim, &rpf);
-	if (pnc)
-		return pim_ecmp_nexthop_search(pim, pnc, nexthop, src, grp,
-					       neighbor_needed);
+	if (pnc) {
+		if (CHECK_FLAG(pnc->flags, PIM_NEXTHOP_ANSWER_RECEIVED))
+		    return pim_ecmp_nexthop_search(pim, pnc, nexthop, src, grp,
+						   neighbor_needed);
+	}
 
 	memset(nexthop_tab, 0,
 	       sizeof(struct pim_zlookup_nexthop) * MULTIPATH_NUM);

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -41,6 +41,7 @@ struct pim_nexthop_cache {
 	int64_t last_update;
 	uint16_t flags;
 #define PIM_NEXTHOP_VALID             (1 << 0)
+#define PIM_NEXTHOP_ANSWER_RECEIVED   (1 << 1)
 
 	struct list *rp_list;
 	struct hash *upstream_hash;

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -56,10 +56,6 @@ void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
 struct pim_nexthop_cache *pim_nexthop_cache_find(struct pim_instance *pim,
 						 struct pim_rpf *rpf);
 uint32_t pim_compute_ecmp_hash(struct prefix *src, struct prefix *grp);
-int pim_ecmp_nexthop_search(struct pim_instance *pim,
-			    struct pim_nexthop_cache *pnc,
-			    struct pim_nexthop *nexthop, struct prefix *src,
-			    struct prefix *grp, int neighbor_needed);
 int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 			    struct pim_nexthop *nexthop, struct prefix *src,
 			    struct prefix *grp, int neighbor_needed);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -564,6 +564,9 @@ int pim_rp_new(struct pim_instance *pim, const char *rp,
 				}
 			}
 
+			pim_rp_check_interfaces(pim, rp_all);
+			pim_rp_refresh_group_to_rp_mapping(pim);
+
 			memset(&pnc, 0, sizeof(struct pim_nexthop_cache));
 			if (pim_find_or_track_nexthop(pim, &nht_p, NULL, rp_all,
 						      &pnc)) {
@@ -578,8 +581,7 @@ int pim_rp_new(struct pim_instance *pim, const char *rp,
 					    &nht_p, &rp_all->group, 1))
 					return PIM_RP_NO_PATH;
 			}
-			pim_rp_check_interfaces(pim, rp_all);
-			pim_rp_refresh_group_to_rp_mapping(pim);
+
 			return PIM_SUCCESS;
 		}
 
@@ -646,6 +648,9 @@ int pim_rp_new(struct pim_instance *pim, const char *rp,
 		}
 	}
 
+	pim_rp_check_interfaces(pim, rp_info);
+	pim_rp_refresh_group_to_rp_mapping(pim);
+
 	/* Register addr with Zebra NHT */
 	nht_p.family = AF_INET;
 	nht_p.prefixlen = IPV4_MAX_BITLEN;
@@ -671,8 +676,6 @@ int pim_rp_new(struct pim_instance *pim, const char *rp,
 			return PIM_RP_NO_PATH;
 	}
 
-	pim_rp_check_interfaces(pim, rp_info);
-	pim_rp_refresh_group_to_rp_mapping(pim);
 	return PIM_SUCCESS;
 }
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1292,11 +1292,15 @@ void pim_upstream_set_sptbit(struct pim_upstream *up,
 	if (!starup
 	    || up->rpf.source_nexthop
 			       .interface != starup->rpf.source_nexthop.interface) {
+		struct pim_upstream *starup = up->parent;
+
 		if (PIM_DEBUG_TRACE)
 			zlog_debug(
 				"%s: %s RPF_interface(S) != RPF_interface(RP(G))",
 				__PRETTY_FUNCTION__, up->sg_str);
 		up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
+
+		pim_jp_agg_single_upstream_send(&starup->rpf, starup, true);
 		return;
 	}
 


### PR DESCRIPTION
1) There exists a code path that the variable nhop could be used without initialization and causing a crash
2) Determination of whether or not we are a RP should happen even if nht has not completly figured out the RPF.
3) Separate the creation of nexthop tracking from the RPF lookup.  Calling functions really can care less
4) Track whether or not we have received a nexthop tracking response via this new flag.
5) When we decide that the spt path is working and the incoming interface RPF(S) != RPF(*,G) initiate a *,G S,G RPT Prune on the *,G path.