### PR TITLE
Clang sa fixes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -239,12 +239,6 @@ struct bgp_path_info_extra *bgp_path_info_extra_get(struct bgp_path_info *pi)
 	return pi->extra;
 }
 
-/* Allocate new bgp info structure. */
-struct bgp_path_info *bgp_path_info_new(void)
-{
-	return XCALLOC(MTYPE_BGP_ROUTE, sizeof(struct bgp_path_info));
-}
-
 /* Free bgp route information. */
 static void bgp_path_info_free(struct bgp_path_info *path)
 {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1941,7 +1941,7 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 				continue;
 			if (BGP_PATH_HOLDDOWN(pi1))
 				continue;
-			if (pi1->peer && pi1->peer != bgp->peer_self)
+			if (pi1->peer != bgp->peer_self)
 				if (pi1->peer->status != Established)
 					continue;
 
@@ -1953,11 +1953,10 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 						continue;
 					if (BGP_PATH_HOLDDOWN(pi2))
 						continue;
-					if (pi2->peer
-					    && pi2->peer != bgp->peer_self
+					if (pi2->peer != bgp->peer_self
 					    && !CHECK_FLAG(
-						       pi2->peer->sflags,
-						       PEER_STATUS_NSF_WAIT))
+						    pi2->peer->sflags,
+						    PEER_STATUS_NSF_WAIT))
 						if (pi2->peer->status
 						    != Established)
 							continue;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -564,7 +564,6 @@ extern void bgp_process_queues_drain_immediate(void);
 extern struct bgp_node *bgp_afi_node_lookup(struct bgp_table *table, afi_t afi,
 					    safi_t safi, struct prefix *p,
 					    struct prefix_rd *prd);
-extern struct bgp_path_info *bgp_path_info_new(void);
 extern void bgp_path_info_restore(struct bgp_node *rn,
 				  struct bgp_path_info *path);
 

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -1059,14 +1059,8 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 		}
 	}
 
-
-	new = bgp_path_info_new();
-	new->type = type;
-	new->sub_type = sub_type;
-	new->peer = rfd->peer;
+	new = info_make(type, sub_type, 0, rfd->peer, new_attr, NULL);
 	SET_FLAG(new->flags, BGP_PATH_VALID);
-	new->attr = new_attr;
-	new->uptime = bgp_clock();
 
 	/* save backref to rfapi handle */
 	assert(bgp_path_info_extra_get(new));

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -509,13 +509,11 @@ static struct bgp_path_info *rfapiBgpInfoCreate(struct attr *attr,
 {
 	struct bgp_path_info *new;
 
-	new = bgp_path_info_new();
-	assert(new);
+	new = info_make(type, sub_type, 0, peer, attr, NULL);
 
-	if (attr) {
-		if (!new->attr)
-			new->attr = bgp_attr_intern(attr);
-	}
+	if (attr)
+		new->attr = bgp_attr_intern(attr);
+
 	bgp_path_info_extra_get(new);
 	if (prd) {
 		new->extra->vnc.import.rd = *prd;
@@ -523,9 +521,7 @@ static struct bgp_path_info *rfapiBgpInfoCreate(struct attr *attr,
 	}
 	if (label)
 		encode_label(*label, &new->extra->label[0]);
-	new->type = type;
-	new->sub_type = sub_type;
-	new->peer = peer;
+
 	peer_lock(peer);
 
 	return new;

--- a/lib/if.c
+++ b/lib/if.c
@@ -519,10 +519,10 @@ const char *if_flag_dump(unsigned long flag)
 #define IFF_OUT_LOG(X, STR)                                                    \
 	if (flag & (X)) {                                                      \
 		if (separator)                                                 \
-			strlcat(logbuf, ",", BUFSIZ);                          \
+			strlcat(logbuf, ",", sizeof(logbuf));                  \
 		else                                                           \
 			separator = 1;                                         \
-		strlcat(logbuf, STR, BUFSIZ);                                  \
+		strlcat(logbuf, STR, sizeof(logbuf));                          \
 	}
 
 	strlcpy(logbuf, "<", BUFSIZ);
@@ -548,7 +548,7 @@ const char *if_flag_dump(unsigned long flag)
 	IFF_OUT_LOG(IFF_IPV4, "IPv4");
 	IFF_OUT_LOG(IFF_IPV6, "IPv6");
 
-	strlcat(logbuf, ">", BUFSIZ);
+	strlcat(logbuf, ">", sizeof(logbuf));
 
 	return logbuf;
 #undef IFF_OUT_LOG

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9733,7 +9733,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 					vty_out(vty, " ip ospf network %s",
 						ospf_int_type_str
 							[params->type]);
-					if (params != IF_DEF_PARAMS(ifp))
+					if (params != IF_DEF_PARAMS(ifp) && rn)
 						vty_out(vty, " %s",
 							inet_ntoa(
 								rn->p.u.prefix4));
@@ -9770,7 +9770,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 
 				vty_out(vty, " ip ospf authentication%s",
 					auth_str);
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");
@@ -9781,7 +9781,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 			    && params->auth_simple[0] != '\0') {
 				vty_out(vty, " ip ospf authentication-key %s",
 					params->auth_simple);
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");
@@ -9794,7 +9794,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 					vty_out(vty,
 						" ip ospf message-digest-key %d md5 %s",
 						ck->key_id, ck->auth_key);
-					if (params != IF_DEF_PARAMS(ifp))
+					if (params != IF_DEF_PARAMS(ifp) && rn)
 						vty_out(vty, " %s",
 							inet_ntoa(
 								rn->p.u.prefix4));
@@ -9806,7 +9806,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 			if (OSPF_IF_PARAM_CONFIGURED(params, output_cost_cmd)) {
 				vty_out(vty, " ip ospf cost %u",
 					params->output_cost_cmd);
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");
@@ -9817,7 +9817,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 			    && params->v_hello != OSPF_HELLO_INTERVAL_DEFAULT) {
 				vty_out(vty, " ip ospf hello-interval %u",
 					params->v_hello);
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");
@@ -9839,7 +9839,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				else
 					vty_out(vty, "%u", params->v_wait);
 
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");
@@ -9851,7 +9851,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				       != OSPF_ROUTER_PRIORITY_DEFAULT) {
 				vty_out(vty, " ip ospf priority %u",
 					params->priority);
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");
@@ -9864,7 +9864,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				       != OSPF_RETRANSMIT_INTERVAL_DEFAULT) {
 				vty_out(vty, " ip ospf retransmit-interval %u",
 					params->retransmit_interval);
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");
@@ -9876,7 +9876,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				       != OSPF_TRANSMIT_DELAY_DEFAULT) {
 				vty_out(vty, " ip ospf transmit-delay %u",
 					params->transmit_delay);
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");
@@ -9895,7 +9895,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 				area_id2str(buf, sizeof(buf), &params->if_area,
 					    params->if_area_id_fmt);
 				vty_out(vty, " area %s", buf);
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");
@@ -9912,7 +9912,7 @@ static int config_write_interface_one(struct vty *vty, struct vrf *vrf)
 					vty_out(vty, " no ip ospf mtu-ignore");
 				else
 					vty_out(vty, " ip ospf mtu-ignore");
-				if (params != IF_DEF_PARAMS(ifp))
+				if (params != IF_DEF_PARAMS(ifp) && rn)
 					vty_out(vty, " %s",
 						inet_ntoa(rn->p.u.prefix4));
 				vty_out(vty, "\n");


### PR DESCRIPTION
Some fixes:

1) lib if.c fix for use of sizeof(buf) -vs- BUFSIZE.  converted to use sizeof(buf) since that is what we want to use anyways.
2) Testing for a `struct bgp_path_info`->peer makes clang sa think it might be null.  But it's impossible since all code paths assume that we have a valid ->peer pointer.
3) rn may be null first time a do {} while () loop, guard against it.
4) Create one function to alloc `struct bgp_path_info` data structures