### PR TITLE
zebra: do not set nexthop flag to active just because route-map permt…

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -393,12 +393,10 @@ static int zebra_rnh_apply_nht_rmap(afi_t afi, struct zebra_vrf *zvrf,
 		     nexthop = nexthop->next) {
 			ret = zebra_nht_route_map_check(
 				afi, proto, &prn->p, zvrf, re, nexthop);
-			if (ret != RMAP_DENYMATCH) {
-				SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+			if (ret != RMAP_DENYMATCH)
 				at_least_one++; /* at least one valid NH */
-			} else {
+			else
 				UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
-			}
 		}
 	}
 	return (at_least_one);


### PR DESCRIPTION
Testing found a crash in zebra during ifdown processing due to trying
to process a nexthop that was not valid.  Root cause of the problem
was that when the nexthop was checked against a route-map, it would
blindly mark it active if the route-map permitted it, even if the
nexthop was marked inactive prior to the route-map check.

Ticket: CM-24440
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>