### PR TITLE
*: setting the socket send/recv buffer sizes doesn't need elevated privs

### DIFF
--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -108,7 +108,6 @@ void eigrp_adjust_sndbuflen(struct eigrp *eigrp, unsigned int buflen)
 	/* Check if any work has to be done at all. */
 	if (eigrp->maxsndbuflen >= buflen)
 		return;
-	frr_elevate_privs(&eigrpd_privs) {
 
 	/* Now we try to set SO_SNDBUF to what our caller has requested
 	 * (the MTU of a newly added interface). However, if the OS has
@@ -117,16 +116,15 @@ void eigrp_adjust_sndbuflen(struct eigrp *eigrp, unsigned int buflen)
 	 * may allocate more buffer space, than requested, this isn't
 	 * a error.
 	 */
-		setsockopt_so_sendbuf(eigrp->fd, buflen);
-		newbuflen = getsockopt_so_sendbuf(eigrp->fd);
-		if (newbuflen < 0 || newbuflen < (int)buflen)
-			zlog_warn("%s: tried to set SO_SNDBUF to %u, but got %d",
-				  __func__, buflen, newbuflen);
-		if (newbuflen >= 0)
-			eigrp->maxsndbuflen = (unsigned int)newbuflen;
-		else
-			zlog_warn("%s: failed to get SO_SNDBUF", __func__);
-	}
+	setsockopt_so_sendbuf(eigrp->fd, buflen);
+	newbuflen = getsockopt_so_sendbuf(eigrp->fd);
+	if (newbuflen < 0 || newbuflen < (int)buflen)
+		zlog_warn("%s: tried to set SO_SNDBUF to %u, but got %d",
+			  __func__, buflen, newbuflen);
+	if (newbuflen >= 0)
+		eigrp->maxsndbuflen = (unsigned int)newbuflen;
+	else
+		zlog_warn("%s: failed to get SO_SNDBUF", __func__);
 }
 
 int eigrp_if_ipmulticast(struct eigrp *top, struct prefix *p,

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -212,10 +212,7 @@ int zclient_socket_connect(struct zclient *zclient)
 		return -1;
 
 	set_cloexec(sock);
-
-	frr_elevate_privs(zclient->privs) {
-		setsockopt_so_sendbuf(sock, 1048576);
-	}
+	setsockopt_so_sendbuf(sock, 1048576);
 
 	/* Connect to zebra. */
 	ret = connect(sock, (struct sockaddr *)&zclient_addr, zclient_addr_len);

--- a/ospfd/ospf_network.c
+++ b/ospfd/ospf_network.c
@@ -234,10 +234,10 @@ int ospf_sock_init(struct ospf *ospf)
 			flog_err(EC_LIB_SOCKET,
 				 "Can't set pktinfo option for fd %d",
 				 ospf_sock);
-
-		setsockopt_so_sendbuf(ospf_sock, bufsize);
-		setsockopt_so_recvbuf(ospf_sock, bufsize);
 	}
+
+	setsockopt_so_sendbuf(ospf_sock, bufsize);
+	setsockopt_so_recvbuf(ospf_sock, bufsize);
 
 	ospf->fd = ospf_sock;
 	return ret;

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1377,9 +1377,9 @@ int rip_create_socket(struct vrf *vrf)
 #ifdef IPTOS_PREC_INTERNETCONTROL
 	setsockopt_ipv4_tos(sock, IPTOS_PREC_INTERNETCONTROL);
 #endif
+	setsockopt_so_recvbuf(sock, RIP_UDP_RCV_BUF);
 
 	frr_elevate_privs(&ripd_privs) {
-		setsockopt_so_recvbuf(sock, RIP_UDP_RCV_BUF);
 		if ((ret = bind(sock, (struct sockaddr *)&addr, sizeof(addr)))
 		    < 0) {
 			zlog_err("%s: Can't bind socket %d to %s port %d: %s",

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -816,10 +816,8 @@ void zserv_start(char *path)
 			unlink(suna->sun_path);
 	}
 
-	frr_elevate_privs(&zserv_privs) {
-		setsockopt_so_recvbuf(zsock, 1048576);
-		setsockopt_so_sendbuf(zsock, 1048576);
-	}
+	setsockopt_so_recvbuf(zsock, 1048576);
+	setsockopt_so_sendbuf(zsock, 1048576);
 
 	frr_elevate_privs((sa.ss_family != AF_UNIX) ? &zserv_privs : NULL) {
 		ret = bind(zsock, (struct sockaddr *)&sa, sa_len);


### PR DESCRIPTION
The less code running under elevated privileges the better.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>