### PR TITLE
ospfd: fix behavior of +/-metric

### DIFF
--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -1499,12 +1499,6 @@ struct in_addr ospf_get_nssa_ip(struct ospf_area *area)
 	return fwd;
 }
 
-#define DEFAULT_DEFAULT_METRIC	             20
-#define DEFAULT_DEFAULT_ORIGINATE_METRIC     10
-#define DEFAULT_DEFAULT_ALWAYS_METRIC	      1
-
-#define DEFAULT_METRIC_TYPE		     EXTERNAL_METRIC_TYPE_2
-
 int metric_type(struct ospf *ospf, uint8_t src, unsigned short instance)
 {
 	struct ospf_redist *red;

--- a/ospfd/ospf_lsa.h
+++ b/ospfd/ospf_lsa.h
@@ -24,6 +24,12 @@
 
 #include "stream.h"
 
+/* OSPF LSA Default metric values */
+#define DEFAULT_DEFAULT_METRIC 20
+#define DEFAULT_DEFAULT_ORIGINATE_METRIC 10
+#define DEFAULT_DEFAULT_ALWAYS_METRIC 1
+#define DEFAULT_METRIC_TYPE EXTERNAL_METRIC_TYPE_2
+
 /* OSPF LSA Range definition. */
 #define OSPF_MIN_LSA		1  /* begin range here */
 #define OSPF_MAX_LSA           12

--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -374,15 +374,16 @@ static route_map_result_t route_set_metric(void *rule,
 		/* Set metric out value. */
 		if (!metric->used)
 			return RMAP_OKAY;
+
+		ei->route_map_set.metric = DEFAULT_DEFAULT_METRIC;
+
 		if (metric->type == metric_increment)
 			ei->route_map_set.metric += metric->metric;
-		if (metric->type == metric_decrement)
+		else if (metric->type == metric_decrement)
 			ei->route_map_set.metric -= metric->metric;
-		if (metric->type == metric_absolute)
+		else if (metric->type == metric_absolute)
 			ei->route_map_set.metric = metric->metric;
 
-		if ((signed int)ei->route_map_set.metric < 1)
-			ei->route_map_set.metric = -1;
 		if (ei->route_map_set.metric > OSPF_LS_INFINITY)
 			ei->route_map_set.metric = OSPF_LS_INFINITY;
 	}


### PR DESCRIPTION
OSPFD uses -1 as a sentinel value for uninitialized metrics. When
applying a route map with a +/-metric to redistributed routes, we were
using -1 as our base value to increment or decrement on, which meant
that if you set e.g. +10, you would end up with a redistributed route of
metric 9.

This patch also removes an off-by-one sanity check that would cause a
set metric +1 to result in a metric value of 20 :-)

Fixes #4003 
Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>