### PR TITLE
zebra: label manager race condition fix (5.0 branch)

### DIFF
--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -151,11 +151,9 @@ static int lm_zclient_read(struct thread *t)
 	/* read response and send it back */
 	ret = relay_response_back();
 
-	/* on error, schedule another read */
-	if (ret == -1)
-		if (!zclient->t_read)
-			thread_add_read(zclient->master, lm_zclient_read, NULL,
-					zclient->sock, &zclient->t_read);
+	/* re-arm read */
+	thread_add_read(zclient->master, lm_zclient_read, NULL,
+			zclient->sock, &zclient->t_read);
 	return ret;
 }
 


### PR DESCRIPTION
Like PR #4095, but for 5.0 branch

This fix covers the case where two or more events are processed but only one
becoming effective. E.g. when mixing a synchronous label request from a LDP
deamon and an asynchronous request from a BGP daemon it could happen to the
BGP having the label chunk, but the LDP stuck waiting for the response.

Given e.g.
```
  ldpd     <-------->
  (sync label request)
                       Zebra (label proxy)  <-->  Zebra (shared label manager)
  bgpd     <-------->
  (async label request)
```
Sequence:
```
   LDP label request ----->
                               Zebra (label proxy FW) ----> Zebra (LM)
   BGP label request ----->
                               Zebra (label proxy FW) ----> Zebra (LM)
                                                      <---- Zebra (LM) RP LDP
                                                      <---- Zebra (LM) RP BGP
```
Signed-off-by: F. Aragon <paco@voltanet.io>