### PR TITLE
zebra: Fix late memset of pbr rule in rule_netlink

### DIFF
--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -185,7 +185,7 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	struct rtattr *tb[FRA_MAX + 1];
 	int len;
 	char *ifname;
-	struct zebra_pbr_rule rule;
+	struct zebra_pbr_rule rule = {};
 	char buf1[PREFIX_STRLEN];
 	char buf2[PREFIX_STRLEN];
 
@@ -230,7 +230,6 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (!rule.ifp)
 		return 0;
 
-	memset(&rule, 0, sizeof(rule));
 	if (tb[FRA_PRIORITY])
 		rule.rule.priority = *(uint32_t *)RTA_DATA(tb[FRA_PRIORITY]);
 


### PR DESCRIPTION
We were memsetting zebra_pbr_rule struct after
we had already put some information in it. Also updated
the init of the struct to use braces instead of a
memset.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>
