### PR TITLE
zebra: avoid removing node twice from rb_tree

### DIFF
--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -202,10 +202,8 @@ void zebra_router_terminate(void)
 {
 	struct zebra_router_table *zrt, *tmp;
 
-	RB_FOREACH_SAFE (zrt, zebra_router_table_head, &zrouter.tables, tmp) {
-		RB_REMOVE(zebra_router_table_head, &zrouter.tables, zrt);
+	RB_FOREACH_SAFE (zrt, zebra_router_table_head, &zrouter.tables, tmp)
 		zebra_router_free_table(zrt);
-	}
 
 	work_queue_free_and_null(&zrouter.ribq);
 	meta_queue_free(zrouter.mq);


### PR DESCRIPTION
In zebra terminate path, the node was attempted to remove
twice from the RB_TREE table. This lead to a crash during
zebra shutdown zebra_router_free_table already calls RB_REMOVE
to remove a node from rb tree table.

    siginfo=0x7fffd9134a30, context=<optimized out>) at lib/sigevent.c:249
     rbt=<optimized out>, t=<optimized out>) at lib/openbsd-tree.c:226
     t=0x56296965ff50 <zebra_router_table_head_RB_INFO>) at lib/openbsd-tree.c:383
    rbt=rbt@entry=0x562969669bd0 <zrouter+16>, elm=elm@entry=0x56296afcf810)
    at lib/openbsd-tree.c:393
    (elm=0x56296afcf810, head=0x562969669bd0 <zrouter+16>) at zebra/zebra_router.h:46

Singned-off-by: Chirag Shah <chirag@cumulusnetworks.com>