### PR TITLE
bgpd: new show cmd - bgp l2vpn evpn route detail

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2385,13 +2385,13 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
  * If 'type' is non-zero, only routes matching that type are shown.
  */
 static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
-				 json_object *json)
+				 json_object *json, int detail)
 {
 	struct bgp_node *rd_rn;
 	struct bgp_table *table;
 	struct bgp_node *rn;
 	struct bgp_path_info *pi;
-	int header = 1;
+	int header = detail ? 0 : 1;
 	int rd_header;
 	afi_t afi;
 	safi_t safi;
@@ -2471,6 +2471,13 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 						    rn->p.prefixlen);
 			}
 
+			/* Prefix and num paths displayed once per prefix. */
+			if (detail)
+				route_vty_out_detail_header(
+					vty, bgp, rn,
+					(struct prefix_rd *)&rd_rn->p,
+					AFI_L2VPN, SAFI_EVPN, json_prefix);
+
 			/* For EVPN, the prefix is displayed for each path (to
 			 * fit in
 			 * with code that already exists).
@@ -2484,8 +2491,13 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 				if (json)
 					json_path = json_object_new_array();
 
-				route_vty_out(vty, &rn->p, pi, 0, SAFI_EVPN,
-					      json_path);
+				if (detail) {
+					route_vty_out_detail(
+						vty, bgp, &rn->p, pi, AFI_L2VPN,
+						SAFI_EVPN, json_path);
+				} else
+					route_vty_out(vty, &rn->p, pi, 0,
+						      SAFI_EVPN, json_path);
 
 				if (json)
 					json_object_array_add(json_paths,
@@ -3622,12 +3634,13 @@ DEFUN(show_bgp_l2vpn_evpn_summary,
  */
 DEFUN(show_bgp_l2vpn_evpn_route,
       show_bgp_l2vpn_evpn_route_cmd,
-      "show bgp l2vpn evpn route [type <macip|multicast|es|prefix>] [json]",
+      "show bgp l2vpn evpn route [detail] [type <macip|multicast|es|prefix>] [json]",
       SHOW_STR
       BGP_STR
       L2VPN_HELP_STR
       EVPN_HELP_STR
       "EVPN route information\n"
+      "Display Detailed Information\n"
       "Specify Route type\n"
       "MAC-IP (Type-2) route\n"
       "Multicast (Type-3) route\n"
@@ -3637,6 +3650,7 @@ DEFUN(show_bgp_l2vpn_evpn_route,
 {
 	struct bgp *bgp;
 	int type_idx = 0;
+	int detail = 0;
 	int type = 0;
 	bool uj = false;
 	json_object *json = NULL;
@@ -3665,7 +3679,10 @@ DEFUN(show_bgp_l2vpn_evpn_route,
 			return CMD_WARNING;
 	}
 
-	evpn_show_all_routes(vty, bgp, type, json);
+	if (argv_find(argv, argc, "detail", &detail))
+		detail = 1;
+
+	evpn_show_all_routes(vty, bgp, type, json, detail);
 
 	if (uj) {
 		vty_out(vty, "%s\n", json_object_to_json_string_ext(
@@ -4279,9 +4296,10 @@ ALIAS_HIDDEN(show_bgp_l2vpn_evpn_summary, show_bgp_evpn_summary_cmd,
 	     "Summary of BGP neighbor status\n" JSON_STR)
 
 ALIAS_HIDDEN(show_bgp_l2vpn_evpn_route, show_bgp_evpn_route_cmd,
-	     "show bgp evpn route [type <macip|multicast>]",
+	     "show bgp evpn route [detail] [type <macip|multicast>]",
 	     SHOW_STR BGP_STR EVPN_HELP_STR
 	     "EVPN route information\n"
+	     "Display Detailed Information\n"
 	     "Specify Route type\n"
 	     "MAC-IP (Type-2) route\n"
 	     "Multicast (Type-3) route\n")


### PR DESCRIPTION
This command is added to provide detailed information. It will be
useful in troubleshooting as we will be able to dump all detailed info
using a single command.
"show bgp l2vpn evpn route [detail] ...". Additional filtering
can be done by providing type of the route.

Command will display the detailed content for all rd and macs-ip as
displayed by "show bgp l2vpn evpn route rd <> mac <>" for a single
rd, mac, ip from the global bgp routing table.

Ticket: CM-24397
Signed-off-by: Nitin Soni <nsoni@cumulusnetworks.com>
Reviewed-by:
Testing-Done: