### PR TITLE
bgpd: Prevent IPv6 routes received via a ibgp session with own ip as nexthop

### DIFF
--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -74,6 +74,12 @@ struct tip_addr {
 	int refcnt;
 };
 
+/* ipv6 connected address info structure */
+struct bgp_addrv6 {
+	struct in6_addr addrv6;
+	struct list *ifp_name_list;
+};
+
 extern void bgp_connected_add(struct bgp *bgp, struct connected *c);
 extern void bgp_connected_delete(struct bgp *bgp, struct connected *c);
 extern int bgp_subgrp_multiaccess_check_v4(struct in_addr nexthop,
@@ -96,4 +102,8 @@ extern void bgp_tip_hash_init(struct bgp *bgp);
 extern void bgp_tip_hash_destroy(struct bgp *bgp);
 
 extern void bgp_nexthop_show_address_hash(struct vty *vty, struct bgp *bgp);
+extern void bgp_ipv6_address_init(struct bgp *bgp);
+extern void bgp_ipv6_address_destroy(struct bgp *bgp);
+extern int bgp_nexthop_self_ipv6(struct bgp *bgp,
+	struct in6_addr *addr);
 #endif /* _QUAGGA_BGP_NEXTHOP_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2939,7 +2939,9 @@ static int bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 			ret = (IN6_IS_ADDR_UNSPECIFIED(&attr->mp_nexthop_global)
 			       || IN6_IS_ADDR_LOOPBACK(&attr->mp_nexthop_global)
 			       || IN6_IS_ADDR_MULTICAST(
-					  &attr->mp_nexthop_global));
+					  &attr->mp_nexthop_global)
+				||bgp_nexthop_self_ipv6(bgp,
+						&attr->mp_nexthop_global));
 			break;
 
 		default:

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3204,6 +3204,7 @@ int bgp_get(struct bgp **bgp_val, as_t *as, const char *name,
 		bgp->vrf_id = vrf_generate_id();
 	bgp_router_id_set(bgp, &bgp->router_id_zebra);
 	bgp_address_init(bgp);
+	bgp_ipv6_address_init(bgp);
 	bgp_tip_hash_init(bgp);
 	bgp_scan_init(bgp);
 	*bgp_val = bgp;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -393,6 +393,9 @@ struct bgp {
 
 	struct hash *address_hash;
 
+	/* ipv6 connected address hash table pointer */
+	struct hash *ipv6_address_hash;
+
 	/* DB for all local tunnel-ips - used mainly for martian checks
 	   Currently it only has all VxLan tunnel IPs*/
 	struct hash *tip_hash;

--- a/lib/jhash.c
+++ b/lib/jhash.c
@@ -185,3 +185,18 @@ uint32_t jhash_1word(uint32_t a, uint32_t initval)
 {
 	return jhash_3words(a, 0, 0, initval);
 }
+
+/* ipv6 hash function */
+uint32_t __ipv6_addr_jhash(const struct in6_addr *a, const uint32_t initval)
+{
+	uint32_t v = 0;
+	uint32_t y[4] = {0};
+
+	/* Since s6_addr32 is not available is few os like FreeBSD, NetBDS,
+	*  OMIBDS & OpenBDS. So recreating in uint32_t format.
+	*/
+	memcpy(y, a->s6_addr, sizeof(struct in6_addr));
+	v = y[0] ^ y[1];
+
+	return jhash_3words(v, y[2], y[3], initval);
+}

--- a/lib/jhash.h
+++ b/lib/jhash.h
@@ -45,6 +45,8 @@ extern uint32_t jhash_3words(uint32_t a, uint32_t b, uint32_t c,
 			     uint32_t initval);
 extern uint32_t jhash_2words(uint32_t a, uint32_t b, uint32_t initval);
 extern uint32_t jhash_1word(uint32_t a, uint32_t initval);
+extern uint32_t __ipv6_addr_jhash(const struct in6_addr *a,
+				const uint32_t initval);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Prevent IPv6 routes received via a ibgp session with one of its own interface 
ip as nexthop from getting installed in the BGP table.

Implemented IPV6 HASH table, where we need to add any ipv6 address as they
gets configured and delete them from the HASH table as the ipv6 addresses
get unconfigured.  The above hash table is used to verify if any route learned
via BGP has nexthop which is equal to one of its its connected ipv6 interface.

Signed-off-by: Biswajit Sadhu <sadhub@vmware.com>