### PR TITLE
zebra: pseudowire event recovery (DoS fix) [6.0]

### DIFF
--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -154,6 +154,7 @@ void zebra_pw_update(struct zebra_pw *pw)
 {
 	if (zebra_pw_check_reachability(pw) < 0) {
 		zebra_pw_uninstall(pw);
+		zebra_pw_install_failure(pw);
 		/* wait for NHT and try again later */
 	} else {
 		/*


### PR DESCRIPTION
When having a route recovery, because of the route installation
cycling and the next hop label check, it could happen that the PW
never gets recovered. The original code shows the intention of retrying,
but the code was missing. The fix includes the call to the timer programming
the recovery attempt.

Example for reproducing the issue:
```
      |P1|  <->  |P2|  <->  |P3|
```
- Being P1, P2, P3 nodes, using IS-IS as IGP, and having a pseudowire
betwen P1 and P3 (P1, P2, P3 having configured LDP daemons).
- After 60 seconds, kill the IS-IS daemon in P2.
- Wait 30 seconds
- Launch again the IS-IS daemon in P2
- The bug/issue is that after P1 <-> P3 recovering connectivity sometimes
  the PW is not recovered because the reason explained in the first paragraph.

Signed-off-by: F. Aragon <paco@voltanet.io>