### PR TITLE
bgpd: EVPN routes are not readvertised to peers after BGPD restart

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2756,9 +2756,11 @@ static void evpn_unset_advertise_subnet(struct bgp *bgp, struct bgpevpn *vpn)
  */
 static void evpn_set_advertise_all_vni(struct bgp *bgp)
 {
-	bgp->advertise_all_vni = 1;
-	bgp_set_evpn(bgp);
-	bgp_zebra_advertise_all_vni(bgp, bgp->advertise_all_vni);
+	if (!bgp->advertise_all_vni) {
+		bgp->advertise_all_vni = 1;
+		bgp_set_evpn(bgp);
+		bgp_zebra_advertise_all_vni(bgp, bgp->advertise_all_vni);
+	}
 }
 
 /*
@@ -2767,10 +2769,12 @@ static void evpn_set_advertise_all_vni(struct bgp *bgp)
  */
 static void evpn_unset_advertise_all_vni(struct bgp *bgp)
 {
-	bgp->advertise_all_vni = 0;
-	bgp_set_evpn(bgp_get_default());
-	bgp_zebra_advertise_all_vni(bgp, bgp->advertise_all_vni);
-	bgp_evpn_cleanup_on_disable(bgp);
+	if (bgp->advertise_all_vni) {
+		bgp->advertise_all_vni = 0;
+		bgp_set_evpn(bgp_get_default());
+		bgp_zebra_advertise_all_vni(bgp, bgp->advertise_all_vni);
+		bgp_evpn_cleanup_on_disable(bgp);
+	}
 }
 
 /*


### PR DESCRIPTION
EVPN is configured on the node to advertise-all-vnis and EVPN
routes are learned. After the routes are learned BGP daemon was restarted,
after which none of the EVPN routes are advertised to the peer.
The rootcause of the issue being the Zebra daemon doesn't notify the BGPd
of the presence of L3VNIs and L2VNIs as well.

Signed-off-by: Kishore Aramalla <karamalla@vmware.com>