### PR TITLE
zebra: L3VNI's are allowed to unconfigure from any VRF

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -8688,6 +8688,13 @@ int zebra_vxlan_process_vrf_vni_cmd(struct zebra_vrf *zvrf, vni_t vni,
 			return -1;
 		}
 
+		if (zvrf->l3vni != vni) {
+			snprintf(err, err_str_sz,
+					"VNI %d doesn't exist in VRF: %s",
+					vni, zvrf->vrf->name);
+			return -1;
+		}
+
 		if (filter && !CHECK_FLAG(zl3vni->filter, PREFIX_ROUTES_ONLY)) {
 			snprintf(err, ERR_STR_SZ,
 				 "prefix-routes-only is not set for the vni");


### PR DESCRIPTION
L3VNI configured in a specific VRF is allowed to unconfigure from any
VRF, including default (global) VRF. This results L3VNI delete notification
to BGP and subsequent type-5 route uninstall from the VRF the L3VNI belong to.
This also resulted in the inconsistent running configuration.

The deleted L3VNI still shows up in its original VRF. The VRF in which the
"no vni <x>" was executed doesn't display its own L3VNI.

Added a VRF check in zebra to prevent this.

Signed-off-by: Kishore Aramalla <karamalla@vmware.com>