### PR TITLE
doc: update libyang build instructions to enable compiler optimizations

### DIFF
--- a/doc/developer/building-libyang.rst
+++ b/doc/developer/building-libyang.rst
@@ -46,7 +46,8 @@ The FRR project builds binary ``libyang`` packages, which we offer for download
    git clone https://github.com/CESNET/libyang.git
    cd libyang
    mkdir build; cd build
-   cmake -DENABLE_LYD_PRIV=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
+   cmake -DENABLE_LYD_PRIV=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+         -D CMAKE_BUILD_TYPE:String="Release" ..
    make
    sudo make install
 


### PR DESCRIPTION
libyang defaults CMAKE_BUILD_TYPE to "Debug", which disables compiler
optimizations. We should instruct our users to build libyang in the
"Release" mode so that compiler optimizations are enabled and they
can benefit from the associated performance improvements.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>