### PR TITLE
BFD speed convergence up

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -282,8 +282,10 @@ static void bgp_bfd_peer_status_update(struct peer *peer, int status)
 	}
 	if ((status == BFD_STATUS_UP) && (old_status == BFD_STATUS_DOWN)
 	    && peer->status != Established) {
-		if (!BGP_PEER_START_SUPPRESSED(peer))
+		if (!BGP_PEER_START_SUPPRESSED(peer)) {
+			bgp_fsm_event_update(peer, 1);
 			BGP_EVENT_ADD(peer, BGP_Start);
+		}
 	}
 }
 

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -280,6 +280,11 @@ static void bgp_bfd_peer_status_update(struct peer *peer, int status)
 		peer->last_reset = PEER_DOWN_BFD_DOWN;
 		BGP_EVENT_ADD(peer, BGP_Stop);
 	}
+	if ((status == BFD_STATUS_UP) && (old_status == BFD_STATUS_DOWN)
+	    && peer->status != Established) {
+		if (!BGP_PEER_START_SUPPRESSED(peer))
+			BGP_EVENT_ADD(peer, BGP_Start);
+	}
 }
 
 /*

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1754,7 +1754,7 @@ static int bgp_fsm_exeption(struct peer *peer)
 	return (bgp_stop(peer));
 }
 
-void bgp_fsm_nht_update(struct peer *peer, int valid)
+void bgp_fsm_event_update(struct peer *peer, int valid)
 {
 	if (!peer)
 		return;
@@ -1787,7 +1787,6 @@ void bgp_fsm_nht_update(struct peer *peer, int valid)
 		break;
 	}
 }
-
 
 /* Finite State Machine structure */
 static const struct {

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -57,7 +57,7 @@
 #define FSM_PEER_TRANSITIONED   3
 
 /* Prototypes. */
-extern void bgp_fsm_nht_update(struct peer *, int valid);
+extern void bgp_fsm_event_update(struct peer *peer, int valid);
 extern int bgp_event(struct thread *);
 extern int bgp_event_update(struct peer *, int event);
 extern int bgp_stop(struct peer *peer);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -793,7 +793,7 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 		if (BGP_DEBUG(nht, NHT))
 			zlog_debug("%s: Updating peer (%s) status with NHT",
 				   __FUNCTION__, peer->host);
-		bgp_fsm_nht_update(peer, bgp_isvalid_nexthop(bnc));
+		bgp_fsm_event_update(peer, bgp_isvalid_nexthop(bnc));
 		SET_FLAG(bnc->flags, BGP_NEXTHOP_PEER_NOTIFIED);
 	}
 


### PR DESCRIPTION
BFD helps for converging down, but also up.
the start timer is fired immediately after the BFD up event is received, if the status of the peer is not established.