### PR TITLE
ospf6d: listhead returns a listnode *

### DIFF
--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -331,8 +331,9 @@ int ospf6_route_get_first_nh_index(struct ospf6_route *route)
 	struct ospf6_nexthop *nh;
 
 	if (route) {
-		if ((nh = (struct ospf6_nexthop *)listhead(route->nh_list)))
-			return (nh->ifindex);
+		nh = listnode_head(route->nh_list);
+		if (nh)
+			return nh->ifindex;
 	}
 
 	return (-1);


### PR DESCRIPTION
The ospf6_route_get_first_nh_index function call calls
listhead which returns a (listnode *) but we are casting
it to a (struct ospf6_nexthop *) and away we go.

Fixes: #4142
Found By: Kwind
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>