### PR TITLE
bfdd: avoid having bfd config inherited from operation context

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -166,6 +166,7 @@ enum bfd_session_flags {
 						 * expires
 						 */
 	BFD_SESS_FLAG_SHUTDOWN = 1 << 7,	/* disable BGP peer function */
+	BFD_SESS_FLAG_CONFIG = 1 << 8,	/* Session configured with bfd NB API */
 };
 
 #define BFD_SET_FLAG(field, flag) (field |= flag)

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -158,6 +158,12 @@ DEFUN_NOSH(
 		}
 	}
 
+	if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG)) {
+		if (bs->refcount)
+			vty_out(vty, "%% session peer is now configurable via bfd daemon.\n");
+		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
+	}
+
 	VTY_PUSH_CONTEXT(BFD_PEER_NODE, bs);
 
 	return CMD_SUCCESS;
@@ -983,6 +989,9 @@ static void _bfdd_peer_write_config_iter(struct hash_bucket *hb, void *arg)
 {
 	struct vty *vty = arg;
 	struct bfd_session *bs = hb->data;
+
+	if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG))
+		return;
 
 	_bfdd_peer_write_config(vty, bs);
 }

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -431,6 +431,10 @@ static void bfdd_dest_deregister(struct stream *msg)
 	/* Unregister client peer notification. */
 	pcn = pcn_lookup(pc, bs);
 	pcn_free(pcn);
+	if (bs->refcount ||
+	    BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG))
+		return;
+	ptm_bfd_ses_del(&bpc);
 }
 
 /*


### PR DESCRIPTION
there are cases where bfd sessions are created from remote daemons. in
that case, the bfd daemon were appearing in both operational and
configuration contexts of bfd. Change that by only keeping operational
contexts.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>