### PR TITLE
lib: rework management of user pointers in the northbound layer

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -136,8 +136,6 @@ DEFPY(ip_router_isis, ip_router_isis_cmd, "ip router isis WORD$tag",
 	const char *circ_type;
 	struct isis_area *area;
 	struct interface *ifp;
-	const struct lyd_node *dnode =
-		yang_dnode_get(running_config->dnode, VTY_CURR_XPATH);
 
 	/* area will be created if it is not present. make sure the yang model
 	 * is synced with FRR and call the appropriate NB cb.
@@ -190,7 +188,7 @@ DEFPY(ip_router_isis, ip_router_isis_cmd, "ip router isis WORD$tag",
 	}
 
 	/* check if the interface is a loopback and if so set it as passive */
-	ifp = yang_dnode_get_entry(dnode, false);
+	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
 	if (ifp && if_is_loopback(ifp))
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/passive",
 				      NB_OP_MODIFY, "true");
@@ -208,8 +206,6 @@ DEFPY(ip6_router_isis, ip6_router_isis_cmd, "ipv6 router isis WORD$tag",
 	const char *circ_type;
 	struct isis_area *area;
 	struct interface *ifp;
-	const struct lyd_node *dnode =
-		yang_dnode_get(running_config->dnode, VTY_CURR_XPATH);
 
 	/* area will be created if it is not present. make sure the yang model
 	 * is synced with FRR and call the appropriate NB cb.
@@ -262,7 +258,7 @@ DEFPY(ip6_router_isis, ip6_router_isis_cmd, "ipv6 router isis WORD$tag",
 	}
 
 	/* check if the interface is a loopback and if so set it as passive */
-	ifp = yang_dnode_get_entry(dnode, false);
+	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
 	if (ifp && if_is_loopback(ifp))
 		nb_cli_enqueue_change(vty, "./frr-isisd:isis/passive",
 				      NB_OP_MODIFY, "true");
@@ -373,9 +369,9 @@ DEFPY(no_is_type, no_is_type_cmd,
       "Act as an area router only\n")
 {
 	const char *value = NULL;
-	const struct lyd_node *dnode =
-		yang_dnode_get(running_config->dnode, VTY_CURR_XPATH);
-	struct isis_area *area = yang_dnode_get_entry(dnode, false);
+	struct isis_area *area;
+
+	area = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
 
 	/*
 	 * Put the is-type back to defaults:
@@ -1761,7 +1757,6 @@ DEFPY(no_isis_circuit_type, no_isis_circuit_type_cmd,
       "Level-1-2 adjacencies are formed\n"
       "Level-2 only adjacencies are formed\n")
 {
-	const struct lyd_node *dnode;
 	struct interface *ifp;
 	struct isis_circuit *circuit;
 	int is_type;
@@ -1772,8 +1767,7 @@ DEFPY(no_isis_circuit_type, no_isis_circuit_type_cmd,
 	 * and the is-type of the area if there is one. So we need to do this
 	 * here.
 	 */
-	dnode = yang_dnode_get(running_config->dnode, VTY_CURR_XPATH);
-	ifp = yang_dnode_get_entry(dnode, false);
+	ifp = nb_running_get_entry(NULL, VTY_CURR_XPATH, false);
 	if (!ifp)
 		goto def_val;
 

--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -67,7 +67,7 @@ static int isis_instance_create(enum nb_event event,
 
 	area = isis_area_create(area_tag);
 	/* save area in dnode to avoid looking it up all the time */
-	yang_dnode_set_entry(dnode, area);
+	nb_running_set_entry(dnode, area);
 
 	return NB_OK;
 }
@@ -75,13 +75,13 @@ static int isis_instance_create(enum nb_event event,
 static int isis_instance_destroy(enum nb_event event,
 				const struct lyd_node *dnode)
 {
-	const char *area_tag;
+	struct isis_area *area;
 
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area_tag = yang_dnode_get_string(dnode, "./area-tag");
-	isis_area_destroy(area_tag);
+	area = nb_running_unset_entry(dnode);
+	isis_area_destroy(area->area_tag);
 
 	return NB_OK;
 }
@@ -99,7 +99,7 @@ static int isis_instance_is_type_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, NULL);
 	isis_area_is_type_set(area, type);
 
@@ -150,7 +150,7 @@ static int isis_instance_area_address_create(enum nb_event event,
 		XFREE(MTYPE_ISIS_AREA_ADDR, resource->ptr);
 		break;
 	case NB_EV_APPLY:
-		area = yang_dnode_get_entry(dnode, true);
+		area = nb_running_get_entry(dnode, NULL, true);
 		addrr = resource->ptr;
 
 		if (isis->sysid_set == 0) {
@@ -208,7 +208,7 @@ static int isis_instance_area_address_destroy(enum nb_event event,
 	net_title = yang_dnode_get_string(dnode, NULL);
 	addr.addr_len = dotformat2buff(buff, net_title);
 	memcpy(addr.area_addr, buff, (int)addr.addr_len);
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	for (ALL_LIST_ELEMENTS_RO(area->area_addrs, node, addrp)) {
 		if ((addrp->addr_len + ISIS_SYS_ID_LEN + 1) == addr.addr_len
 		    && !memcmp(addrp->area_addr, addr.area_addr, addr.addr_len))
@@ -244,7 +244,7 @@ static int isis_instance_dynamic_hostname_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	isis_area_dynhostname_set(area, yang_dnode_get_bool(dnode, NULL));
 
 	return NB_OK;
@@ -263,7 +263,7 @@ static int isis_instance_attached_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	attached = yang_dnode_get_bool(dnode, NULL);
 	isis_area_attached_bit_set(area, attached);
 
@@ -283,7 +283,7 @@ static int isis_instance_overload_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	overload = yang_dnode_get_bool(dnode, NULL);
 	isis_area_overload_bit_set(area, overload);
 
@@ -304,7 +304,7 @@ static int isis_instance_metric_style_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	old_metric = (metric_style == ISIS_WIDE_METRIC) ? false : true;
 	new_metric = (metric_style == ISIS_NARROW_METRIC) ? false : true;
 	isis_area_metricstyle_set(area, old_metric, new_metric);
@@ -324,7 +324,7 @@ static int isis_instance_purge_originator_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	area->purge_originator = yang_dnode_get_bool(dnode, NULL);
 
 	return NB_OK;
@@ -344,7 +344,7 @@ static int isis_instance_lsp_mtu_modify(enum nb_event event,
 
 	switch (event) {
 	case NB_EV_VALIDATE:
-		area = yang_dnode_get_entry(dnode, false);
+		area = nb_running_get_entry(dnode, NULL, false);
 		if (!area)
 			break;
 		for (ALL_LIST_ELEMENTS_RO(area->circuit_list, node, circuit)) {
@@ -365,7 +365,7 @@ static int isis_instance_lsp_mtu_modify(enum nb_event event,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		area = yang_dnode_get_entry(dnode, true);
+		area = nb_running_get_entry(dnode, NULL, true);
 		isis_area_lsp_mtu_set(area, lsp_mtu);
 		break;
 	}
@@ -388,7 +388,7 @@ isis_instance_lsp_refresh_interval_level_1_modify(enum nb_event event,
 		return NB_OK;
 
 	refr_int = yang_dnode_get_uint16(dnode, NULL);
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	isis_area_lsp_refresh_set(area, IS_LEVEL_1, refr_int);
 
 	return NB_OK;
@@ -409,7 +409,7 @@ isis_instance_lsp_refresh_interval_level_2_modify(enum nb_event event,
 		return NB_OK;
 
 	refr_int = yang_dnode_get_uint16(dnode, NULL);
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	isis_area_lsp_refresh_set(area, IS_LEVEL_2, refr_int);
 
 	return NB_OK;
@@ -430,7 +430,7 @@ isis_instance_lsp_maximum_lifetime_level_1_modify(enum nb_event event,
 		return NB_OK;
 
 	max_lt = yang_dnode_get_uint16(dnode, NULL);
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	isis_area_max_lsp_lifetime_set(area, IS_LEVEL_1, max_lt);
 
 	return NB_OK;
@@ -451,7 +451,7 @@ isis_instance_lsp_maximum_lifetime_level_2_modify(enum nb_event event,
 		return NB_OK;
 
 	max_lt = yang_dnode_get_uint16(dnode, NULL);
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	isis_area_max_lsp_lifetime_set(area, IS_LEVEL_2, max_lt);
 
 	return NB_OK;
@@ -471,7 +471,7 @@ static int isis_instance_lsp_generation_interval_level_1_modify(
 		return NB_OK;
 
 	gen_int = yang_dnode_get_uint16(dnode, NULL);
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	area->lsp_gen_interval[0] = gen_int;
 
 	return NB_OK;
@@ -491,7 +491,7 @@ static int isis_instance_lsp_generation_interval_level_2_modify(
 		return NB_OK;
 
 	gen_int = yang_dnode_get_uint16(dnode, NULL);
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	area->lsp_gen_interval[1] = gen_int;
 
 	return NB_OK;
@@ -507,7 +507,7 @@ static void ietf_backoff_delay_apply_finish(const struct lyd_node *dnode)
 	long long_delay = yang_dnode_get_uint16(dnode, "./long-delay");
 	long holddown = yang_dnode_get_uint16(dnode, "./hold-down");
 	long timetolearn = yang_dnode_get_uint16(dnode, "./time-to-learn");
-	struct isis_area *area = yang_dnode_get_entry(dnode, true);
+	struct isis_area *area = nb_running_get_entry(dnode, NULL, true);
 	size_t bufsiz = strlen(area->area_tag) + sizeof("IS-IS  Lx");
 	char *buf = XCALLOC(MTYPE_TMP, bufsiz);
 
@@ -544,7 +544,7 @@ isis_instance_spf_ietf_backoff_delay_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	spf_backoff_free(area->spf_delay_ietf[0]);
 	spf_backoff_free(area->spf_delay_ietf[1]);
 	area->spf_delay_ietf[0] = NULL;
@@ -621,7 +621,7 @@ isis_instance_spf_minimum_interval_level_1_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	area->min_spf_interval[0] = yang_dnode_get_uint16(dnode, NULL);
 
 	return NB_OK;
@@ -640,7 +640,7 @@ isis_instance_spf_minimum_interval_level_2_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	area->min_spf_interval[1] = yang_dnode_get_uint16(dnode, NULL);
 
 	return NB_OK;
@@ -652,7 +652,7 @@ isis_instance_spf_minimum_interval_level_2_modify(enum nb_event event,
 static void area_password_apply_finish(const struct lyd_node *dnode)
 {
 	const char *password = yang_dnode_get_string(dnode, "./password");
-	struct isis_area *area = yang_dnode_get_entry(dnode, true);
+	struct isis_area *area = nb_running_get_entry(dnode, NULL, true);
 	int pass_type = yang_dnode_get_enum(dnode, "./password-type");
 	uint8_t snp_auth = yang_dnode_get_enum(dnode, "./authenticate-snp");
 
@@ -684,7 +684,7 @@ static int isis_instance_area_password_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	isis_area_passwd_unset(area, IS_LEVEL_1);
 
 	return NB_OK;
@@ -731,7 +731,7 @@ static int isis_instance_area_password_authenticate_snp_modify(
 static void domain_password_apply_finish(const struct lyd_node *dnode)
 {
 	const char *password = yang_dnode_get_string(dnode, "./password");
-	struct isis_area *area = yang_dnode_get_entry(dnode, true);
+	struct isis_area *area = nb_running_get_entry(dnode, NULL, true);
 	int pass_type = yang_dnode_get_enum(dnode, "./password-type");
 	uint8_t snp_auth = yang_dnode_get_enum(dnode, "./authenticate-snp");
 
@@ -763,7 +763,7 @@ static int isis_instance_domain_password_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	isis_area_passwd_unset(area, IS_LEVEL_2);
 
 	return NB_OK;
@@ -813,7 +813,7 @@ static void default_info_origin_apply_finish(const struct lyd_node *dnode,
 	int originate_type = DEFAULT_ORIGINATE;
 	unsigned long metric = 0;
 	const char *routemap = NULL;
-	struct isis_area *area = yang_dnode_get_entry(dnode, true);
+	struct isis_area *area = nb_running_get_entry(dnode, NULL, true);
 	int level = yang_dnode_get_enum(dnode, "./level");
 
 	if (yang_dnode_get_bool(dnode, "./always")) {
@@ -860,7 +860,7 @@ static int isis_instance_default_information_originate_ipv4_destroy(
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	level = yang_dnode_get_enum(dnode, "./level");
 	isis_redist_unset(area, level, AF_INET, DEFAULT_ROUTE);
 
@@ -927,7 +927,7 @@ static int isis_instance_default_information_originate_ipv6_destroy(
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	level = yang_dnode_get_enum(dnode, "./level");
 	isis_redist_unset(area, level, AF_INET6, DEFAULT_ROUTE);
 
@@ -987,7 +987,7 @@ static void redistribute_apply_finish(const struct lyd_node *dnode, int family)
 
 	type = yang_dnode_get_enum(dnode, "./protocol");
 	level = yang_dnode_get_enum(dnode, "./level");
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 
 	if (yang_dnode_exists(dnode, "./metric"))
 		metric = yang_dnode_get_uint32(dnode, "./metric");
@@ -1024,7 +1024,7 @@ static int isis_instance_redistribute_ipv4_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	level = yang_dnode_get_enum(dnode, "./level");
 	type = yang_dnode_get_enum(dnode, "./protocol");
 	isis_redist_unset(area, level, AF_INET, type);
@@ -1084,7 +1084,7 @@ static int isis_instance_redistribute_ipv6_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	level = yang_dnode_get_enum(dnode, "./level");
 	type = yang_dnode_get_enum(dnode, "./protocol");
 	isis_redist_unset(area, level, AF_INET6, type);
@@ -1147,7 +1147,7 @@ static int isis_multi_topology_common(enum nb_event event,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		area = yang_dnode_get_entry(dnode, true);
+		area = nb_running_get_entry(dnode, NULL, true);
 		setting = area_get_mt_setting(area, mtid);
 		setting->enabled = create;
 		lsp_regenerate_schedule(area, IS_LEVEL_1 | IS_LEVEL_2, 0);
@@ -1169,7 +1169,7 @@ static int isis_multi_topology_overload_common(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	setting = area_get_mt_setting(area, mtid);
 	setting->overload = yang_dnode_get_bool(dnode, NULL);
 	if (setting->enabled)
@@ -1358,7 +1358,7 @@ isis_instance_log_adjacency_changes_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	area->log_adj_changes = log ? 1 : 0;
 
 	return NB_OK;
@@ -1517,10 +1517,10 @@ static int lib_interface_isis_create(enum nb_event event,
 		abort();
 	}
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	circuit = isis_circuit_create(area, ifp);
 	assert(circuit->state == C_STATE_CONF || circuit->state == C_STATE_UP);
-	yang_dnode_set_entry(dnode, circuit);
+	nb_running_set_entry(dnode, circuit);
 
 	return NB_OK;
 }
@@ -1533,7 +1533,7 @@ static int lib_interface_isis_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_unset_entry(dnode);
 	if (!circuit)
 		return NB_ERR_INCONSISTENCY;
 	/* delete circuit through csm changes */
@@ -1629,7 +1629,7 @@ static int lib_interface_isis_circuit_type_modify(enum nb_event event,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		circuit = yang_dnode_get_entry(dnode, true);
+		circuit = nb_running_get_entry(dnode, NULL, true);
 		isis_circuit_is_type_set(circuit, circ_type);
 		break;
 	}
@@ -1650,7 +1650,7 @@ static int lib_interface_isis_ipv4_routing_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	ipv4 = yang_dnode_get_bool(dnode, NULL);
 	ipv6 = yang_dnode_get_bool(dnode, "../ipv6-routing");
 	isis_circuit_af_set(circuit, ipv4, ipv6);
@@ -1671,7 +1671,7 @@ static int lib_interface_isis_ipv6_routing_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	ipv4 = yang_dnode_exists(dnode, "../ipv4-routing");
 	ipv6 = yang_dnode_get_bool(dnode, NULL);
 	isis_circuit_af_set(circuit, ipv4, ipv6);
@@ -1692,7 +1692,7 @@ lib_interface_isis_csnp_interval_level_1_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	circuit->csnp_interval[0] = yang_dnode_get_uint16(dnode, NULL);
 
 	return NB_OK;
@@ -1711,7 +1711,7 @@ lib_interface_isis_csnp_interval_level_2_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	circuit->csnp_interval[1] = yang_dnode_get_uint16(dnode, NULL);
 
 	return NB_OK;
@@ -1730,7 +1730,7 @@ lib_interface_isis_psnp_interval_level_1_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	circuit->psnp_interval[0] = yang_dnode_get_uint16(dnode, NULL);
 
 	return NB_OK;
@@ -1749,7 +1749,7 @@ lib_interface_isis_psnp_interval_level_2_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	circuit->psnp_interval[1] = yang_dnode_get_uint16(dnode, NULL);
 
 	return NB_OK;
@@ -1767,7 +1767,7 @@ static int lib_interface_isis_hello_padding_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	circuit->pad_hellos = yang_dnode_get_bool(dnode, NULL);
 
 	return NB_OK;
@@ -1787,7 +1787,7 @@ lib_interface_isis_hello_interval_level_1_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	interval = yang_dnode_get_uint32(dnode, NULL);
 	circuit->hello_interval[0] = interval;
 
@@ -1808,7 +1808,7 @@ lib_interface_isis_hello_interval_level_2_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	interval = yang_dnode_get_uint32(dnode, NULL);
 	circuit->hello_interval[1] = interval;
 
@@ -1829,7 +1829,7 @@ lib_interface_isis_hello_multiplier_level_1_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	multi = yang_dnode_get_uint16(dnode, NULL);
 	circuit->hello_multiplier[0] = multi;
 
@@ -1850,7 +1850,7 @@ lib_interface_isis_hello_multiplier_level_2_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	multi = yang_dnode_get_uint16(dnode, NULL);
 	circuit->hello_multiplier[1] = multi;
 
@@ -1871,7 +1871,7 @@ lib_interface_isis_metric_level_1_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	met = yang_dnode_get_uint32(dnode, NULL);
 	isis_circuit_metric_set(circuit, IS_LEVEL_1, met);
 
@@ -1892,7 +1892,7 @@ lib_interface_isis_metric_level_2_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	met = yang_dnode_get_uint32(dnode, NULL);
 	isis_circuit_metric_set(circuit, IS_LEVEL_2, met);
 
@@ -1912,7 +1912,7 @@ lib_interface_isis_priority_level_1_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	circuit->priority[0] = yang_dnode_get_uint8(dnode, NULL);
 
 	return NB_OK;
@@ -1931,7 +1931,7 @@ lib_interface_isis_priority_level_2_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	circuit->priority[1] = yang_dnode_get_uint8(dnode, NULL);
 
 	return NB_OK;
@@ -1949,7 +1949,7 @@ static int lib_interface_isis_network_type_modify(enum nb_event event,
 
 	switch (event) {
 	case NB_EV_VALIDATE:
-		circuit = yang_dnode_get_entry(dnode, false);
+		circuit = nb_running_get_entry(dnode, NULL, false);
 		if (!circuit)
 			break;
 		if (circuit->circ_type == CIRCUIT_T_LOOPBACK) {
@@ -1971,7 +1971,7 @@ static int lib_interface_isis_network_type_modify(enum nb_event event,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		circuit = yang_dnode_get_entry(dnode, true);
+		circuit = nb_running_get_entry(dnode, NULL, true);
 		isis_circuit_circ_type_set(circuit, net_type);
 		break;
 	}
@@ -1993,7 +1993,7 @@ static int lib_interface_isis_passive_modify(enum nb_event event,
 
 	/* validation only applies if we are setting passive to false */
 	if (!passive && event == NB_EV_VALIDATE) {
-		circuit = yang_dnode_get_entry(dnode, false);
+		circuit = nb_running_get_entry(dnode, NULL, false);
 		if (!circuit)
 			return NB_OK;
 		ifp = circuit->interface;
@@ -2009,7 +2009,7 @@ static int lib_interface_isis_passive_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	if (circuit->state != C_STATE_UP) {
 		circuit->is_passive = passive;
 	} else {
@@ -2040,7 +2040,7 @@ static int lib_interface_isis_password_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	isis_circuit_passwd_unset(circuit);
 
 	return NB_OK;
@@ -2061,7 +2061,7 @@ lib_interface_isis_password_password_modify(enum nb_event event,
 		return NB_OK;
 
 	password = yang_dnode_get_string(dnode, NULL);
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 
 	isis_circuit_passwd_set(circuit, circuit->passwd.type, password);
 
@@ -2083,7 +2083,7 @@ lib_interface_isis_password_password_type_modify(enum nb_event event,
 		return NB_OK;
 
 	pass_type = yang_dnode_get_enum(dnode, NULL);
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	circuit->passwd.type = pass_type;
 
 	return NB_OK;
@@ -2102,7 +2102,7 @@ static int lib_interface_isis_disable_three_way_handshake_modify(
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	circuit = yang_dnode_get_entry(dnode, true);
+	circuit = nb_running_get_entry(dnode, NULL, true);
 	circuit->disable_threeway_adj = yang_dnode_get_bool(dnode, NULL);
 
 	return NB_OK;
@@ -2120,7 +2120,7 @@ static int lib_interface_isis_multi_topology_common(
 
 	switch (event) {
 	case NB_EV_VALIDATE:
-		circuit = yang_dnode_get_entry(dnode, false);
+		circuit = nb_running_get_entry(dnode, NULL, false);
 		if (circuit && circuit->area && circuit->area->oldmetric) {
 			flog_warn(
 				EC_LIB_NB_CB_CONFIG_VALIDATE,
@@ -2132,7 +2132,7 @@ static int lib_interface_isis_multi_topology_common(
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
-		circuit = yang_dnode_get_entry(dnode, true);
+		circuit = nb_running_get_entry(dnode, NULL, true);
 		value = yang_dnode_get_bool(dnode, NULL);
 		isis_circuit_mt_enabled_set(circuit, mtid, value);
 		break;

--- a/lib/if.c
+++ b/lib/if.c
@@ -1303,7 +1303,7 @@ static int lib_interface_create(enum nb_event event,
 #else
 		ifp = if_get_by_name(ifname, vrf->vrf_id);
 #endif /* SUNOS_5 */
-		yang_dnode_set_entry(dnode, ifp);
+		nb_running_set_entry(dnode, ifp);
 		break;
 	}
 
@@ -1315,10 +1315,10 @@ static int lib_interface_destroy(enum nb_event event,
 {
 	struct interface *ifp;
 
-	ifp = yang_dnode_get_entry(dnode, true);
 
 	switch (event) {
 	case NB_EV_VALIDATE:
+		ifp = nb_running_get_entry(dnode, NULL, true);
 		if (CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
 			zlog_warn("%s: only inactive interfaces can be deleted",
 				  __func__);
@@ -1329,6 +1329,7 @@ static int lib_interface_destroy(enum nb_event event,
 	case NB_EV_ABORT:
 		break;
 	case NB_EV_APPLY:
+		ifp = nb_running_unset_entry(dnode);
 		if_delete(ifp);
 		break;
 	}
@@ -1349,7 +1350,7 @@ static int lib_interface_description_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	XFREE(MTYPE_TMP, ifp->desc);
 	description = yang_dnode_get_string(dnode, NULL);
 	ifp->desc = XSTRDUP(MTYPE_TMP, description);
@@ -1365,7 +1366,7 @@ static int lib_interface_description_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	XFREE(MTYPE_TMP, ifp->desc);
 
 	return NB_OK;

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -22,6 +22,7 @@
 #include "libfrr.h"
 #include "log.h"
 #include "lib_errors.h"
+#include "hash.h"
 #include "command.h"
 #include "debug.h"
 #include "db.h"
@@ -31,9 +32,13 @@
 
 DEFINE_MTYPE_STATIC(LIB, NB_NODE, "Northbound Node")
 DEFINE_MTYPE_STATIC(LIB, NB_CONFIG, "Northbound Configuration")
+DEFINE_MTYPE_STATIC(LIB, NB_CONFIG_ENTRY, "Northbound Configuration Entry")
 
 /* Running configuration - shouldn't be modified directly. */
 struct nb_config *running_config;
+
+/* Hash table of user pointers associated with configuration entries. */
+static struct hash *running_config_entries;
 
 /*
  * Global lock used to prevent multiple configuration transactions from
@@ -535,38 +540,6 @@ int nb_candidate_update(struct nb_config *candidate)
 }
 
 /*
- * The northbound configuration callbacks use the 'priv' pointer present in the
- * libyang lyd_node structure to store pointers to FRR internal variables
- * associated to YANG lists and presence containers. Before commiting a
- * candidate configuration, we must restore the 'priv' pointers stored in the
- * running configuration since they might be lost while editing the candidate.
- */
-static void nb_candidate_restore_priv_pointers(struct nb_config *candidate)
-{
-	struct lyd_node *root, *next, *dnode_iter;
-
-	LY_TREE_FOR (running_config->dnode, root) {
-		LY_TREE_DFS_BEGIN (root, next, dnode_iter) {
-			struct lyd_node *dnode_candidate;
-			char xpath[XPATH_MAXLEN];
-
-			if (!dnode_iter->priv)
-				goto next;
-
-			yang_dnode_get_path(dnode_iter, xpath, sizeof(xpath));
-			dnode_candidate =
-				yang_dnode_get(candidate->dnode, xpath);
-			if (dnode_candidate)
-				yang_dnode_set_entry(dnode_candidate,
-						     dnode_iter->priv);
-
-		next:
-			LY_TREE_DFS_END(root, next, dnode_iter);
-		}
-	}
-}
-
-/*
  * Perform YANG syntactic and semantic validation.
  *
  * WARNING: lyd_validate() can change the configuration as part of the
@@ -588,7 +561,6 @@ static int nb_candidate_validate_changes(struct nb_config *candidate,
 {
 	struct nb_config_cb *cb;
 
-	nb_candidate_restore_priv_pointers(candidate);
 	RB_FOREACH (cb, nb_config_cbs, changes) {
 		struct nb_config_change *change = (struct nb_config_change *)cb;
 		int ret;
@@ -1548,6 +1520,116 @@ int nb_notification_send(const char *xpath, struct list *arguments)
 	return ret;
 }
 
+/* Running configuration user pointers management. */
+struct nb_config_entry {
+	char xpath[XPATH_MAXLEN];
+	void *entry;
+};
+
+static bool running_config_entry_cmp(const void *value1, const void *value2)
+{
+	const struct nb_config_entry *c1 = value1;
+	const struct nb_config_entry *c2 = value2;
+
+	return strmatch(c1->xpath, c2->xpath);
+}
+
+static unsigned int running_config_entry_key_make(void *value)
+{
+	return string_hash_make(value);
+}
+
+static void *running_config_entry_alloc(void *p)
+{
+	struct nb_config_entry *new, *key = p;
+
+	new = XCALLOC(MTYPE_NB_CONFIG_ENTRY, sizeof(*new));
+	strlcpy(new->xpath, key->xpath, sizeof(new->xpath));
+
+	return new;
+}
+
+static void running_config_entry_free(void *arg)
+{
+	XFREE(MTYPE_NB_CONFIG_ENTRY, arg);
+}
+
+void nb_running_set_entry(const struct lyd_node *dnode, void *entry)
+{
+	struct nb_config_entry *config, s;
+
+	yang_dnode_get_path(dnode, s.xpath, sizeof(s.xpath));
+	config = hash_get(running_config_entries, &s,
+			  running_config_entry_alloc);
+	config->entry = entry;
+}
+
+static void *nb_running_unset_entry_helper(const struct lyd_node *dnode)
+{
+	struct nb_config_entry *config, s;
+	struct lyd_node *child;
+	void *entry = NULL;
+
+	yang_dnode_get_path(dnode, s.xpath, sizeof(s.xpath));
+	config = hash_release(running_config_entries, &s);
+	if (config) {
+		entry = config->entry;
+		running_config_entry_free(config);
+	}
+
+	/* Unset user pointers from the child nodes. */
+	if (CHECK_FLAG(dnode->schema->nodetype, LYS_LIST | LYS_CONTAINER)) {
+		LY_TREE_FOR (dnode->child, child) {
+			(void)nb_running_unset_entry_helper(child);
+		}
+	}
+
+	return entry;
+}
+
+void *nb_running_unset_entry(const struct lyd_node *dnode)
+{
+	void *entry;
+
+	entry = nb_running_unset_entry_helper(dnode);
+	assert(entry);
+
+	return entry;
+}
+
+void *nb_running_get_entry(const struct lyd_node *dnode, const char *xpath,
+			   bool abort_if_not_found)
+{
+	const struct lyd_node *orig_dnode = dnode;
+	char xpath_buf[XPATH_MAXLEN];
+
+	assert(dnode || xpath);
+
+	if (!dnode)
+		dnode = yang_dnode_get(running_config->dnode, xpath);
+
+	while (dnode) {
+		struct nb_config_entry *config, s;
+
+		yang_dnode_get_path(dnode, s.xpath, sizeof(s.xpath));
+		config = hash_lookup(running_config_entries, &s);
+		if (config)
+			return config->entry;
+
+		dnode = dnode->parent;
+	}
+
+	if (!abort_if_not_found)
+		return NULL;
+
+	yang_dnode_get_path(orig_dnode, xpath_buf, sizeof(xpath_buf));
+	flog_err(EC_LIB_YANG_DNODE_NOT_FOUND,
+		 "%s: failed to find entry [xpath %s]", __func__, xpath_buf);
+	zlog_backtrace(LOG_ERR);
+	abort();
+}
+
+/* Logging functions. */
 const char *nb_event_name(enum nb_event event)
 {
 	switch (event) {
@@ -1685,6 +1767,9 @@ void nb_init(struct thread_master *tm,
 
 	/* Create an empty running configuration. */
 	running_config = nb_config_new(NULL);
+	running_config_entries = hash_create(running_config_entry_key_make,
+					     running_config_entry_cmp,
+					     "Running Configuration Entries");
 
 	/* Initialize the northbound CLI. */
 	nb_cli_init(tm);
@@ -1699,5 +1784,7 @@ void nb_terminate(void)
 	nb_nodes_delete();
 
 	/* Delete the running configuration. */
+	hash_clean(running_config_entries, running_config_entry_free);
+	hash_free(running_config_entries);
 	nb_config_free(running_config);
 }

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -808,6 +808,75 @@ extern bool nb_operation_is_valid(enum nb_operation operation,
 extern int nb_notification_send(const char *xpath, struct list *arguments);
 
 /*
+ * Associate a user pointer to a configuration node.
+ *
+ * This should be called by northbound 'create' callbacks in the NB_EV_APPLY
+ * phase only.
+ *
+ * dnode
+ *    libyang data node - only its XPath is used.
+ *
+ * entry
+ *    Arbitrary user-specified pointer.
+ */
+extern void nb_running_set_entry(const struct lyd_node *dnode, void *entry);
+
+/*
+ * Unset the user pointer associated to a configuration node.
+ *
+ * This should be called by northbound 'destroy' callbacks in the NB_EV_APPLY
+ * phase only.
+ *
+ * dnode
+ *    libyang data node - only its XPath is used.
+ *
+ * Returns:
+ *    The user pointer that was unset.
+ */
+extern void *nb_running_unset_entry(const struct lyd_node *dnode);
+
+/*
+ * Find the user pointer (if any) associated to a configuration node.
+ *
+ * The XPath associated to the configuration node can be provided directly or
+ * indirectly through a libyang data node.
+ *
+ * If an user point is not found, this function follows the parent nodes in the
+ * running configuration until an user pointer is found or until the root node
+ * is reached.
+ *
+ * dnode
+ *    libyang data node - only its XPath is used (can be NULL if 'xpath' is
+ *    provided).
+ *
+ * xpath
+ *    XPath of the configuration node (can be NULL if 'dnode' is provided).
+ *
+ * abort_if_not_found
+ *    When set to true, abort the program if no user pointer is found.
+ *
+ *    As a rule of thumb, this parameter should be set to true in the following
+ *    scenarios:
+ *    - Calling this function from any northbound configuration callback during
+ *      the NB_EV_APPLY phase.
+ *    - Calling this function from a 'delete' northbound configuration callback
+ *      during any phase.
+ *
+ *    In both the above cases, the given configuration node should contain an
+ *    user pointer except when there's a bug in the code, in which case it's
+ *    better to abort the program right away and eliminate the need for
+ *    unnecessary NULL checks.
+ *
+ *    In all other cases, this parameter should be set to false and the caller
+ *    should check if the function returned NULL or not.
+ *
+ * Returns:
+ *    User pointer if found, NULL otherwise.
+ */
+extern void *nb_running_get_entry(const struct lyd_node *dnode, const char *xpath,
+				  bool abort_if_not_found);
+
+/*
  * Return a human-readable string representing a northbound event.
  *
  * event

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -513,42 +513,6 @@ void yang_dnode_change_leaf(struct lyd_node *dnode, const char *value)
 	lyd_change_leaf((struct lyd_node_leaf_list *)dnode, value);
 }
 
-void yang_dnode_set_entry(const struct lyd_node *dnode, void *entry)
-{
-	assert(CHECK_FLAG(dnode->schema->nodetype, LYS_LIST | LYS_CONTAINER));
-	lyd_set_private(dnode, entry);
-}
-
-void *yang_dnode_get_entry(const struct lyd_node *dnode,
-			   bool abort_if_not_found)
-{
-	const struct lyd_node *orig_dnode = dnode;
-	char xpath[XPATH_MAXLEN];
-
-	while (dnode) {
-		switch (dnode->schema->nodetype) {
-		case LYS_CONTAINER:
-		case LYS_LIST:
-			if (dnode->priv)
-				return dnode->priv;
-			break;
-		default:
-			break;
-		}
-
-		dnode = dnode->parent;
-	}
-
-	if (!abort_if_not_found)
-		return NULL;
-
-	yang_dnode_get_path(orig_dnode, xpath, sizeof(xpath));
-	flog_err(EC_LIB_YANG_DNODE_NOT_FOUND,
-		 "%s: failed to find entry [xpath %s]", __func__, xpath);
-	zlog_backtrace(LOG_ERR);
-	abort();
-}
-
 struct lyd_node *yang_dnode_new(struct ly_ctx *ly_ctx, bool config_only)
 {
 	struct lyd_node *dnode;
@@ -627,12 +591,6 @@ struct yang_data *yang_data_list_find(const struct list *list,
 			return data;
 
 	return NULL;
-}
-
-static void *ly_dup_cb(const void *priv)
-{
-	/* Make a shallow copy of the priv pointer. */
-	return (void *)priv;
 }
 
 /* Make libyang log its errors using FRR logging infrastructure. */
@@ -724,7 +682,6 @@ CPP_NOTICE("lib/yang: deprecated libyang <0.16.74 extension loading in use!")
 		flog_err(EC_LIB_LIBYANG, "%s: ly_ctx_new() failed", __func__);
 		exit(1);
 	}
-	ly_ctx_set_priv_dup_clb(ly_native_ctx, ly_dup_cb);
 
 #ifndef LIBYANG_EXT_BUILTIN
 	/* Detect if the required libyang plugin(s) were loaded successfully. */

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -403,51 +403,6 @@ extern bool yang_dnode_is_default_recursive(const struct lyd_node *dnode);
 extern void yang_dnode_change_leaf(struct lyd_node *dnode, const char *value);
 
 /*
- * Set the libyang private pointer to a user pointer. Can only be used on YANG
- * lists and containers.
- *
- * dnode
- *    libyang data node to operate on.
- *
- * entry
- *    Arbitrary user-specified pointer.
- */
-extern void yang_dnode_set_entry(const struct lyd_node *dnode, void *entry);
-
-/*
- * Find the user pointer associated to the given libyang data node.
- *
- * The data node is traversed by following the parent pointers until an user
- * pointer is found or until the root node is reached.
- *
- * dnode
- *    libyang data node to operate on.
- *
- * abort_if_not_found
- *    When set to true, abort the program if no user pointer is found.
- *
- *    As a rule of thumb, this parameter should be set to true in the following
- *    scenarios:
- *    - Calling this function from any northbound configuration callback during
- *      the NB_EV_APPLY phase.
- *    - Calling this function from a 'delete' northbound configuration callback
- *      during any phase.
- *
- *    In both the above cases, the libyang data node should contain an user
- *    pointer except when there's a bug in the code, in which case it's better
- *    to abort the program right away and eliminate the need for unnecessary
- *    NULL checks.
- *
- *    In all other cases, this parameter should be set to false and the caller
- *    should check if the function returned NULL or not.
- *
- * Returns:
- *    User pointer if found, NULL otherwise.
- */
-extern void *yang_dnode_get_entry(const struct lyd_node *dnode,
-				  bool abort_if_not_found);
-
-/*
  * Create a new libyang data node.
  *
  * ly_ctx

--- a/ripd/rip_northbound.c
+++ b/ripd/rip_northbound.c
@@ -79,7 +79,7 @@ static int ripd_instance_create(enum nb_event event,
 			socket = -1;
 
 		rip = rip_create(vrf_name, vrf, socket);
-		yang_dnode_set_entry(dnode, rip);
+		nb_running_set_entry(dnode, rip);
 		break;
 	}
 
@@ -94,7 +94,7 @@ static int ripd_instance_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_unset_entry(dnode);
 	rip_clean(rip);
 
 	return NB_OK;
@@ -144,7 +144,7 @@ static int ripd_instance_allow_ecmp_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rip->ecmp = yang_dnode_get_bool(dnode, NULL);
 	if (!rip->ecmp)
 		rip_ecmp_disable(rip);
@@ -167,7 +167,7 @@ ripd_instance_default_information_originate_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	default_information = yang_dnode_get_bool(dnode, NULL);
 
 	memset(&p, 0, sizeof(struct prefix_ipv4));
@@ -199,7 +199,7 @@ static int ripd_instance_default_metric_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rip->default_metric = yang_dnode_get_uint8(dnode, NULL);
 	/* rip_update_default_metric (); */
 
@@ -218,7 +218,7 @@ static int ripd_instance_distance_default_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rip->distance = yang_dnode_get_uint8(dnode, NULL);
 
 	return NB_OK;
@@ -242,10 +242,10 @@ static int ripd_instance_distance_source_create(enum nb_event event,
 	apply_mask_ipv4(&prefix);
 
 	/* Get RIP distance node. */
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rn = route_node_get(rip->distance_table, (struct prefix *)&prefix);
 	rn->info = rip_distance_new();
-	yang_dnode_set_entry(dnode, rn);
+	nb_running_set_entry(dnode, rn);
 
 	return NB_OK;
 }
@@ -259,7 +259,7 @@ static int ripd_instance_distance_source_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rn = yang_dnode_get_entry(dnode, true);
+	rn = nb_running_unset_entry(dnode);
 	rdistance = rn->info;
 	rip_distance_free(rdistance);
 	rn->info = NULL;
@@ -284,7 +284,7 @@ ripd_instance_distance_source_distance_modify(enum nb_event event,
 		return NB_OK;
 
 	/* Set distance value. */
-	rn = yang_dnode_get_entry(dnode, true);
+	rn = nb_running_get_entry(dnode, NULL, true);
 	distance = yang_dnode_get_uint8(dnode, NULL);
 	rdistance = rn->info;
 	rdistance->distance = distance;
@@ -310,7 +310,7 @@ ripd_instance_distance_source_access_list_modify(enum nb_event event,
 	acl_name = yang_dnode_get_string(dnode, NULL);
 
 	/* Set access-list */
-	rn = yang_dnode_get_entry(dnode, true);
+	rn = nb_running_get_entry(dnode, NULL, true);
 	rdistance = rn->info;
 	if (rdistance->access_list)
 		free(rdistance->access_list);
@@ -330,7 +330,7 @@ ripd_instance_distance_source_access_list_destroy(enum nb_event event,
 		return NB_OK;
 
 	/* Reset access-list configuration. */
-	rn = yang_dnode_get_entry(dnode, true);
+	rn = nb_running_get_entry(dnode, NULL, true);
 	rdistance = rn->info;
 	free(rdistance->access_list);
 	rdistance->access_list = NULL;
@@ -351,7 +351,7 @@ static int ripd_instance_explicit_neighbor_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	p.family = AF_INET;
 	p.prefixlen = IPV4_MAX_BITLEN;
 	yang_dnode_get_ipv4(&p.prefix, dnode, NULL);
@@ -368,7 +368,7 @@ static int ripd_instance_explicit_neighbor_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	p.family = AF_INET;
 	p.prefixlen = IPV4_MAX_BITLEN;
 	yang_dnode_get_ipv4(&p.prefix, dnode, NULL);
@@ -389,7 +389,7 @@ static int ripd_instance_network_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv4p(&p, dnode, NULL);
 	apply_mask_ipv4((struct prefix_ipv4 *)&p);
 
@@ -405,7 +405,7 @@ static int ripd_instance_network_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv4p(&p, dnode, NULL);
 	apply_mask_ipv4((struct prefix_ipv4 *)&p);
 
@@ -425,7 +425,7 @@ static int ripd_instance_interface_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return rip_enable_if_add(rip, ifname);
@@ -440,7 +440,7 @@ static int ripd_instance_interface_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return rip_enable_if_delete(rip, ifname);
@@ -460,11 +460,11 @@ static int ripd_instance_offset_list_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, "./interface");
 
 	offset = rip_offset_list_new(rip, ifname);
-	yang_dnode_set_entry(dnode, offset);
+	nb_running_set_entry(dnode, offset);
 
 	return NB_OK;
 }
@@ -480,7 +480,7 @@ static int ripd_instance_offset_list_destroy(enum nb_event event,
 
 	direct = yang_dnode_get_enum(dnode, "./direction");
 
-	offset = yang_dnode_get_entry(dnode, true);
+	offset = nb_running_unset_entry(dnode);
 	if (offset->direct[direct].alist_name) {
 		free(offset->direct[direct].alist_name);
 		offset->direct[direct].alist_name = NULL;
@@ -510,7 +510,7 @@ ripd_instance_offset_list_access_list_modify(enum nb_event event,
 	direct = yang_dnode_get_enum(dnode, "../direction");
 	alist_name = yang_dnode_get_string(dnode, NULL);
 
-	offset = yang_dnode_get_entry(dnode, true);
+	offset = nb_running_get_entry(dnode, NULL, true);
 	if (offset->direct[direct].alist_name)
 		free(offset->direct[direct].alist_name);
 	offset->direct[direct].alist_name = strdup(alist_name);
@@ -535,7 +535,7 @@ static int ripd_instance_offset_list_metric_modify(enum nb_event event,
 	direct = yang_dnode_get_enum(dnode, "../direction");
 	metric = yang_dnode_get_uint8(dnode, NULL);
 
-	offset = yang_dnode_get_entry(dnode, true);
+	offset = nb_running_get_entry(dnode, NULL, true);
 	offset->direct[direct].metric = metric;
 
 	return NB_OK;
@@ -553,7 +553,7 @@ static int ripd_instance_passive_default_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rip->passive_default = yang_dnode_get_bool(dnode, NULL);
 	rip_passive_nondefault_clean(rip);
 
@@ -573,7 +573,7 @@ static int ripd_instance_passive_interface_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return rip_passive_nondefault_set(rip, ifname);
@@ -588,7 +588,7 @@ static int ripd_instance_passive_interface_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return rip_passive_nondefault_unset(rip, ifname);
@@ -608,7 +608,7 @@ ripd_instance_non_passive_interface_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return rip_passive_nondefault_unset(rip, ifname);
@@ -624,7 +624,7 @@ ripd_instance_non_passive_interface_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return rip_passive_nondefault_set(rip, ifname);
@@ -643,7 +643,7 @@ static int ripd_instance_redistribute_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "./protocol");
 
 	rip->redist[type].enabled = true;
@@ -660,7 +660,7 @@ static int ripd_instance_redistribute_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "./protocol");
 
 	rip->redist[type].enabled = false;
@@ -684,7 +684,7 @@ ripd_instance_redistribute_apply_finish(const struct lyd_node *dnode)
 	struct rip *rip;
 	int type;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "./protocol");
 
 	if (rip->enabled)
@@ -706,7 +706,7 @@ ripd_instance_redistribute_route_map_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "../protocol");
 	rmap_name = yang_dnode_get_string(dnode, NULL);
 
@@ -728,7 +728,7 @@ ripd_instance_redistribute_route_map_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "../protocol");
 
 	free(rip->redist[type].route_map.name);
@@ -753,7 +753,7 @@ ripd_instance_redistribute_metric_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "../protocol");
 	metric = yang_dnode_get_uint8(dnode, NULL);
 
@@ -773,7 +773,7 @@ ripd_instance_redistribute_metric_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "../protocol");
 
 	rip->redist[type].metric_config = false;
@@ -796,7 +796,7 @@ static int ripd_instance_static_route_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv4p(&p, dnode, NULL);
 	apply_mask_ipv4(&p);
 
@@ -817,7 +817,7 @@ static int ripd_instance_static_route_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv4p(&p, dnode, NULL);
 	apply_mask_ipv4(&p);
 
@@ -833,7 +833,7 @@ static void ripd_instance_timers_apply_finish(const struct lyd_node *dnode)
 {
 	struct rip *rip;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 
 	/* Reset update timer thread. */
 	rip_event(rip, RIP_UPDATE_EVENT, 0);
@@ -852,7 +852,7 @@ ripd_instance_timers_flush_interval_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rip->garbage_time = yang_dnode_get_uint32(dnode, NULL);
 
 	return NB_OK;
@@ -871,7 +871,7 @@ ripd_instance_timers_holddown_interval_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rip->timeout_time = yang_dnode_get_uint32(dnode, NULL);
 
 	return NB_OK;
@@ -890,7 +890,7 @@ ripd_instance_timers_update_interval_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rip->update_time = yang_dnode_get_uint32(dnode, NULL);
 
 	return NB_OK;
@@ -908,7 +908,7 @@ static int ripd_instance_version_receive_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rip->version_recv = yang_dnode_get_enum(dnode, NULL);
 
 	return NB_OK;
@@ -926,7 +926,7 @@ static int ripd_instance_version_send_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	rip = yang_dnode_get_entry(dnode, true);
+	rip = nb_running_get_entry(dnode, NULL, true);
 	rip->version_send = yang_dnode_get_enum(dnode, NULL);
 
 	return NB_OK;
@@ -945,7 +945,7 @@ static int lib_interface_rip_split_horizon_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	ri->split_horizon = yang_dnode_get_enum(dnode, NULL);
 
@@ -965,7 +965,7 @@ static int lib_interface_rip_v2_broadcast_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	ri->v2_broadcast = yang_dnode_get_bool(dnode, NULL);
 
@@ -986,7 +986,7 @@ lib_interface_rip_version_receive_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	ri->ri_receive = yang_dnode_get_enum(dnode, NULL);
 
@@ -1006,7 +1006,7 @@ static int lib_interface_rip_version_send_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	ri->ri_send = yang_dnode_get_enum(dnode, NULL);
 
@@ -1026,7 +1026,7 @@ static int lib_interface_rip_authentication_scheme_mode_modify(
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	ri->auth_type = yang_dnode_get_enum(dnode, NULL);
 
@@ -1047,7 +1047,7 @@ static int lib_interface_rip_authentication_scheme_md5_auth_length_modify(
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	ri->md5_auth_len = yang_dnode_get_enum(dnode, NULL);
 
@@ -1063,7 +1063,7 @@ static int lib_interface_rip_authentication_scheme_md5_auth_length_destroy(
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	ri->md5_auth_len = yang_get_default_enum(
 		"%s/authentication-scheme/md5-auth-length", RIP_IFACE);
@@ -1085,7 +1085,7 @@ lib_interface_rip_authentication_password_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	XFREE(MTYPE_RIP_INTERFACE_STRING, ri->auth_str);
 	ri->auth_str = XSTRDUP(MTYPE_RIP_INTERFACE_STRING,
@@ -1104,7 +1104,7 @@ lib_interface_rip_authentication_password_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	XFREE(MTYPE_RIP_INTERFACE_STRING, ri->auth_str);
 
@@ -1125,7 +1125,7 @@ lib_interface_rip_authentication_key_chain_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	XFREE(MTYPE_RIP_INTERFACE_STRING, ri->key_chain);
 	ri->key_chain = XSTRDUP(MTYPE_RIP_INTERFACE_STRING,
@@ -1144,7 +1144,7 @@ lib_interface_rip_authentication_key_chain_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	XFREE(MTYPE_RIP_INTERFACE_STRING, ri->key_chain);
 

--- a/ripngd/ripng_northbound.c
+++ b/ripngd/ripng_northbound.c
@@ -81,7 +81,7 @@ static int ripngd_instance_create(enum nb_event event,
 			socket = -1;
 
 		ripng = ripng_create(vrf_name, vrf, socket);
-		yang_dnode_set_entry(dnode, ripng);
+		nb_running_set_entry(dnode, ripng);
 		break;
 	}
 
@@ -96,7 +96,7 @@ static int ripngd_instance_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_unset_entry(dnode);
 	ripng_clean(ripng);
 
 	return NB_OK;
@@ -147,7 +147,7 @@ static int ripngd_instance_allow_ecmp_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ripng->ecmp = yang_dnode_get_bool(dnode, NULL);
 	if (!ripng->ecmp)
 		ripng_ecmp_disable(ripng);
@@ -169,7 +169,7 @@ static int ripngd_instance_default_information_originate_modify(
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	default_information = yang_dnode_get_bool(dnode, NULL);
 
 	str2prefix_ipv6("::/0", &p);
@@ -196,7 +196,7 @@ static int ripngd_instance_default_metric_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ripng->default_metric = yang_dnode_get_uint8(dnode, NULL);
 
 	return NB_OK;
@@ -215,7 +215,7 @@ static int ripngd_instance_network_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv6p(&p, dnode, NULL);
 	apply_mask_ipv6((struct prefix_ipv6 *)&p);
 
@@ -231,7 +231,7 @@ static int ripngd_instance_network_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv6p(&p, dnode, NULL);
 	apply_mask_ipv6((struct prefix_ipv6 *)&p);
 
@@ -251,7 +251,7 @@ static int ripngd_instance_interface_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return ripng_enable_if_add(ripng, ifname);
@@ -266,7 +266,7 @@ static int ripngd_instance_interface_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return ripng_enable_if_delete(ripng, ifname);
@@ -286,11 +286,11 @@ static int ripngd_instance_offset_list_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, "./interface");
 
 	offset = ripng_offset_list_new(ripng, ifname);
-	yang_dnode_set_entry(dnode, offset);
+	nb_running_set_entry(dnode, offset);
 
 	return NB_OK;
 }
@@ -306,7 +306,7 @@ static int ripngd_instance_offset_list_destroy(enum nb_event event,
 
 	direct = yang_dnode_get_enum(dnode, "./direction");
 
-	offset = yang_dnode_get_entry(dnode, true);
+	offset = nb_running_unset_entry(dnode);
 	if (offset->direct[direct].alist_name) {
 		free(offset->direct[direct].alist_name);
 		offset->direct[direct].alist_name = NULL;
@@ -336,7 +336,7 @@ ripngd_instance_offset_list_access_list_modify(enum nb_event event,
 	direct = yang_dnode_get_enum(dnode, "../direction");
 	alist_name = yang_dnode_get_string(dnode, NULL);
 
-	offset = yang_dnode_get_entry(dnode, true);
+	offset = nb_running_get_entry(dnode, NULL, true);
 	if (offset->direct[direct].alist_name)
 		free(offset->direct[direct].alist_name);
 	offset->direct[direct].alist_name = strdup(alist_name);
@@ -362,7 +362,7 @@ ripngd_instance_offset_list_metric_modify(enum nb_event event,
 	direct = yang_dnode_get_enum(dnode, "../direction");
 	metric = yang_dnode_get_uint8(dnode, NULL);
 
-	offset = yang_dnode_get_entry(dnode, true);
+	offset = nb_running_get_entry(dnode, NULL, true);
 	offset->direct[direct].metric = metric;
 
 	return NB_OK;
@@ -382,7 +382,7 @@ ripngd_instance_passive_interface_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return ripng_passive_interface_set(ripng, ifname);
@@ -398,7 +398,7 @@ ripngd_instance_passive_interface_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ifname = yang_dnode_get_string(dnode, NULL);
 
 	return ripng_passive_interface_unset(ripng, ifname);
@@ -417,7 +417,7 @@ static int ripngd_instance_redistribute_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "./protocol");
 
 	ripng->redist[type].enabled = true;
@@ -434,7 +434,7 @@ static int ripngd_instance_redistribute_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "./protocol");
 
 	ripng->redist[type].enabled = false;
@@ -458,7 +458,7 @@ ripngd_instance_redistribute_apply_finish(const struct lyd_node *dnode)
 	struct ripng *ripng;
 	int type;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "./protocol");
 
 	if (ripng->enabled)
@@ -480,7 +480,7 @@ ripngd_instance_redistribute_route_map_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "../protocol");
 	rmap_name = yang_dnode_get_string(dnode, NULL);
 
@@ -502,7 +502,7 @@ ripngd_instance_redistribute_route_map_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "../protocol");
 
 	free(ripng->redist[type].route_map.name);
@@ -527,7 +527,7 @@ ripngd_instance_redistribute_metric_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "../protocol");
 	metric = yang_dnode_get_uint8(dnode, NULL);
 
@@ -547,7 +547,7 @@ ripngd_instance_redistribute_metric_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	type = yang_dnode_get_enum(dnode, "../protocol");
 
 	ripng->redist[type].metric_config = false;
@@ -569,7 +569,7 @@ static int ripngd_instance_static_route_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv6p(&p, dnode, NULL);
 	apply_mask_ipv6(&p);
 
@@ -588,7 +588,7 @@ static int ripngd_instance_static_route_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv6p(&p, dnode, NULL);
 	apply_mask_ipv6(&p);
 
@@ -612,7 +612,7 @@ ripngd_instance_aggregate_address_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv6p(&p, dnode, NULL);
 	apply_mask_ipv6(&p);
 
@@ -631,7 +631,7 @@ ripngd_instance_aggregate_address_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	yang_dnode_get_ipv6p(&p, dnode, NULL);
 	apply_mask_ipv6(&p);
 
@@ -647,7 +647,7 @@ static void ripngd_instance_timers_apply_finish(const struct lyd_node *dnode)
 {
 	struct ripng *ripng;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 
 	/* Reset update timer thread. */
 	ripng_event(ripng, RIPNG_UPDATE_EVENT, 0);
@@ -666,7 +666,7 @@ ripngd_instance_timers_flush_interval_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ripng->garbage_time = yang_dnode_get_uint16(dnode, NULL);
 
 	return NB_OK;
@@ -685,7 +685,7 @@ ripngd_instance_timers_holddown_interval_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ripng->timeout_time = yang_dnode_get_uint16(dnode, NULL);
 
 	return NB_OK;
@@ -704,7 +704,7 @@ ripngd_instance_timers_update_interval_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ripng = yang_dnode_get_entry(dnode, true);
+	ripng = nb_running_get_entry(dnode, NULL, true);
 	ripng->update_time = yang_dnode_get_uint16(dnode, NULL);
 
 	return NB_OK;
@@ -999,7 +999,7 @@ lib_interface_ripng_split_horizon_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	ifp = yang_dnode_get_entry(dnode, true);
+	ifp = nb_running_get_entry(dnode, NULL, true);
 	ri = ifp->info;
 	ri->split_horizon = yang_dnode_get_enum(dnode, NULL);
 


### PR DESCRIPTION
Introduce a hash table to keep track of user pointers associated
to configuration entries. The previous strategy was to embed
the user pointers inside libyang data nodes, but this solution
incurred a substantial performance overhead. The user pointers
embedded in candidate configurations could be lost while the
configuration was being edited, so they needed to be regenerated
before the candidate could be committed.  This was done by the
nb_candidate_restore_priv_pointers() function, which was extremely
expensive for large configurations. The new hash table solves this
performance problem.

The yang_dnode_[gs]et_entry() functions were renamed and moved from
yang.[ch] to northbound.[ch], which is a more appropriate place
for them. This patch also introduces the nb_running_unset_entry()
function, the counterpart of nb_running_set_entry() (unsetting
user pointers was done automatically before, now it needs to be
done manually).

As a consequence of these changes, we shouldn't need support for
libyang private pointers anymore (-DENABLE_LYD_PRIV=ON). But it's
probably a good idea to keep requiring this feature as we might
need it in the future for other things (e.g. disable configuration
settings without removing them).

Fixes #4136.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>