### PR TITLE
ripd, ripngd: fix cleaning up of offset lists

### DIFF
--- a/lib/if_rmap.c
+++ b/lib/if_rmap.c
@@ -291,6 +291,7 @@ int config_write_if_rmap(struct vty *vty,
 
 void if_rmap_ctx_delete(struct if_rmap_ctx *ctx)
 {
+	listnode_delete(if_rmap_ctx_list, ctx);
 	hash_clean(ctx->ifrmaphash, (void (*)(void *))if_rmap_free);
 	if (ctx->name)
 		XFREE(MTYPE_IF_RMAP_CTX_NAME, ctx);

--- a/ripd/rip_offset.c
+++ b/ripd/rip_offset.c
@@ -50,6 +50,11 @@ struct rip_offset_list *rip_offset_list_new(struct rip *rip, const char *ifname)
 void offset_list_del(struct rip_offset_list *offset)
 {
 	listnode_delete(offset->rip->offset_list_master, offset);
+	offset_list_free(offset);
+}
+
+void offset_list_free(struct rip_offset_list *offset)
+{
 	if (OFFSET_LIST_IN_NAME(offset))
 		free(OFFSET_LIST_IN_NAME(offset));
 	if (OFFSET_LIST_OUT_NAME(offset))

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -2712,7 +2712,7 @@ struct rip *rip_create(const char *vrf_name, struct vrf *vrf, int socket)
 	rip->passive_nondefault = vector_init(1);
 	rip->offset_list_master = list_new();
 	rip->offset_list_master->cmp = (int (*)(void *, void *))offset_list_cmp;
-	rip->offset_list_master->del = (void (*)(void *))offset_list_del;
+	rip->offset_list_master->del = (void (*)(void *))offset_list_free;
 
 	/* Distribute list install. */
 	rip->distribute_ctx = distribute_list_ctx_create(vrf);

--- a/ripd/ripd.h
+++ b/ripd/ripd.h
@@ -507,6 +507,7 @@ extern struct rip_info *rip_ecmp_delete(struct rip *rip,
 extern struct rip_offset_list *rip_offset_list_new(struct rip *rip,
 						   const char *ifname);
 extern void offset_list_del(struct rip_offset_list *offset);
+extern void offset_list_free(struct rip_offset_list *offset);
 extern struct rip_offset_list *rip_offset_list_lookup(struct rip *rip,
 						      const char *ifname);
 extern int rip_offset_list_apply_in(struct prefix_ipv4 *, struct interface *,

--- a/ripngd/ripng_offset.c
+++ b/ripngd/ripng_offset.c
@@ -56,6 +56,11 @@ struct ripng_offset_list *ripng_offset_list_new(struct ripng *ripng,
 void ripng_offset_list_del(struct ripng_offset_list *offset)
 {
 	listnode_delete(offset->ripng->offset_list_master, offset);
+	ripng_offset_list_free(offset);
+}
+
+void ripng_offset_list_free(struct ripng_offset_list *offset)
+{
 	if (OFFSET_LIST_IN_NAME(offset))
 		free(OFFSET_LIST_IN_NAME(offset));
 	if (OFFSET_LIST_OUT_NAME(offset))

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -1889,7 +1889,7 @@ struct ripng *ripng_create(const char *vrf_name, struct vrf *vrf, int socket)
 	ripng->offset_list_master->cmp =
 		(int (*)(void *, void *))offset_list_cmp;
 	ripng->offset_list_master->del =
-		(void (*)(void *))ripng_offset_list_del;
+		(void (*)(void *))ripng_offset_list_free;
 	ripng->distribute_ctx = distribute_list_ctx_create(vrf);
 	distribute_list_add_hook(ripng->distribute_ctx,
 				 ripng_distribute_update);

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -421,6 +421,7 @@ extern void ripng_peer_list_del(void *arg);
 extern struct ripng_offset_list *ripng_offset_list_new(struct ripng *ripng,
 						       const char *ifname);
 extern void ripng_offset_list_del(struct ripng_offset_list *offset);
+extern void ripng_offset_list_free(struct ripng_offset_list *offset);
 extern struct ripng_offset_list *ripng_offset_list_lookup(struct ripng *ripng,
 							  const char *ifname);
 extern int ripng_offset_list_apply_in(struct ripng *ripng,


### PR DESCRIPTION
We should never attempt to remove a list item in the "del" callback
of the list. This is already performed by the list_delete() function,
doing it twice leads to crashes or memory corruption.

Introduce the offset_list_free() function so that we can separate the
removal and deallocation of offset lists into separate functions,
without code duplication. offset_list_del() will be used by the
northbound callbacks to remove offset lists, while offset_list_free()
will be used by rip_clean() to clean up all RIP offset lists using
list_delete(). Do the same for ripngd.

This is a fallout from the ripd/ripngd northbound conversion.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>