### PR TITLE
bgpd: instance delete unimport evpn routes

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4218,6 +4218,13 @@ static void bgp_cleanup_table(struct bgp *bgp, struct bgp_table *table,
 	for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn))
 		for (pi = bgp_node_get_bgp_path_info(rn); pi; pi = next) {
 			next = pi->next;
+
+			/* Unimport EVPN routes from VRFs */
+			if (safi == SAFI_EVPN)
+				bgp_evpn_unimport_route(bgp, AFI_L2VPN,
+							SAFI_EVPN,
+							&rn->p, pi);
+
 			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED)
 			    && pi->type == ZEBRA_ROUTE_BGP
 			    && (pi->sub_type == BGP_ROUTE_NORMAL


### PR DESCRIPTION
EVPN routes (type-2/type-5) are imported from default bgp instance
(where they are learnt) to non-default vrf instance.

When a bgp instance (default) is deleted, un-import evpn routes from vrfs.

In absence of un-import, the imported routes in vrf has parent path info
points to default instance's path info which is no longer valid
(if instance is deleted).
When accessing parent path info leads to a crash in non-default vrf instance.

The bgp instance is not cleaned up when 'no router bgp ASN' is performed,
the instance's reference count remains for evpn imported routes.


Testing Done:
Validated via learning EVPN type-2/type-5 routes in symmetric routing scenario.
The routes are imported to VRFs based on corresponding L3VNI. 
When the default instance is removed, the evpn routes are cleaned up from the VRF instance.

TURTLE(config)# do show bgp vrf vrf3 ipv4 unicast

   Network          Next Hop            Metric LocPrf Weight Path
*> 70.1.0.0/16      0.0.0.0                            32768 i
s  70.1.1.24/32     110.0.0.2                              0 65100 65002 i
s>                  110.0.0.2                              0 65100 65002 i
s  70.1.1.43/32     110.0.0.4                              0 65100 65004 i
s>                  110.0.0.4                              0 65100 65004 i

TURTLE(config)# no router bgp 65050
TURTLE(config)# do show bgp vrf vrf3 ipv4 unicast
No BGP prefixes displayed, 0 exist

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>