### PR TITLE
bgpd: lock the tenant-vrf associated with the l2-vni

### DIFF
--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -237,6 +237,7 @@ static inline void bgpevpn_unlink_from_l3vni(struct bgpevpn *vpn)
 	listnode_delete(vpn->bgp_vrf->l2vnis, vpn);
 
 	/* remove the backpointer to the vrf instance */
+	bgp_unlock(vpn->bgp_vrf);
 	vpn->bgp_vrf = NULL;
 }
 
@@ -253,7 +254,7 @@ static inline void bgpevpn_link_to_l3vni(struct bgpevpn *vpn)
 		return;
 
 	/* associate the vpn to the bgp_vrf instance */
-	vpn->bgp_vrf = bgp_vrf;
+	vpn->bgp_vrf = bgp_lock(bgp_vrf);
 	listnode_add_sort(bgp_vrf->l2vnis, vpn);
 
 	/* check if we are advertising two labels for this vpn */


### PR DESCRIPTION
The l2vni (bgpevpn instance) was maintaining a back pointer to the
tenant vrf without locking it. This would result in bgp_terminate crashing
as the tenant-vrf is released before the underlay-vrf (vpn->bgp_vrf->l2vnis
is NULL). Call stack -
BGP: [bt 3] /lib/libfrr.so.0(listnode_delete+0x11) [0x7f041c967f51]
BGP: [bt 4] /usr/lib/frr/bgpd(bgp_evpn_free+0x26) [0x55e3428eea46]
BGP: [bt 5] /lib/libfrr.so.0(hash_iterate+0x4a) [0x7f041c95f00a]
BGP: [bt 6] /usr/lib/frr/bgpd(bgp_evpn_cleanup+0x22) [0x55e3428f0a72]
BGP: [bt 7] /usr/lib/frr/bgpd(bgp_free+0x180) [0x55e342955f50]
PIM: vxlan SG (*,239.1.1.111) term mroute-up del
BGP: [bt 8] /usr/lib/frr/bgpd(bgp_delete+0x43a) [0x55e342959d7a]
BGP: [bt 9] /usr/lib/frr/bgpd(sigint+0xee) [0x55e3428d6a5e]

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>
Reviewed-by: Vivek Venkataraman <vivek@cumulusnetworks.com>
Reviewed-by: Chirag Shah <chirag@cumulusnetworks.com>