### PR TITLE
lib: fix warning in linklist api

### DIFF
--- a/lib/linklist.c
+++ b/lib/linklist.c
@@ -328,7 +328,7 @@ void list_sort(struct list *list, int (*cmp)(const void **, const void **))
 	XFREE(MTYPE_TMP, items);
 }
 
-void listnode_add_force(struct list **list, void *val)
+struct listnode *listnode_add_force(struct list **list, void *val)
 {
 	if (*list == NULL)
 		*list = list_new();

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -343,7 +343,13 @@ extern void list_add_list(struct list *list, struct list *add);
 
 extern struct listnode *listnode_lookup_nocheck(struct list *list, void *data);
 
-extern void listnode_add_force(struct list **list, void *val);
+/*
+ * Add a node to *list, if non-NULL. Otherwise, allocate a new list, mail
+ * it back in *list, and add a new node.
+ *
+ * Return: the new node.
+ */
+extern struct listnode *listnode_add_force(struct list **list, void *val);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add return value and comment to new/recent linklist api to clean up compile warning.
