### PR TITLE
pimd: When creating new upstream state, figure out what we should join

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -584,9 +584,10 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 	pim_upstream_update_assert_tracking_desired(up);
 
 	if (new_state == PIM_UPSTREAM_JOINED) {
+		pim_upstream_inherited_olist_decide(pim, up);
 		if (old_state != PIM_UPSTREAM_JOINED) {
 			int old_fhr = PIM_UPSTREAM_FLAG_TEST_FHR(up->flags);
-			forward_on(up);
+
 			pim_msdp_up_join_state_changed(pim, up);
 			if (pim_upstream_could_register(up)) {
 				PIM_UPSTREAM_FLAG_SET_FHR(up->flags);
@@ -601,8 +602,6 @@ void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 				pim_upstream_send_join(up);
 				join_timer_start(up);
 			}
-		} else {
-			forward_on(up);
 		}
 	} else {
 


### PR DESCRIPTION
Always when creating a new S,G state look at all possible ifchannels
to decide what the mroute should be.

The bug that this is fixing is this:

Suppose two incoming `*,G` joins on swp1, and swp2.
Now suppose that one of those ifchannel `*,G` sends a `*,G S,G RPT Prune`.
We were creating the S,G upstream state as we should but we were
only looking at the S,G ifchannel to decide the S,G mroute we would
be creating.  As such what we need to do is to look over the associated
*,G ifchannels and allow us to associate correct oil needed.

Ticket: CM-24732
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>