### PR TITLE
lib: fix issue with interface node access at startup

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -133,13 +133,12 @@ int bfd_session_enable(struct bfd_session *bs)
 				"session-enable: specified VRF doesn't exists.");
 			return 0;
 		}
-	}
-
+	} else
+		vrf = vrf_lookup_by_id(VRF_DEFAULT);
+	if (!vrf)
+		return 0;
 	if (bs->key.ifname[0]) {
-		if (vrf)
-			ifp = if_lookup_by_name(bs->key.ifname, vrf->vrf_id);
-		else
-			ifp = if_lookup_by_name_all_vrf(bs->key.ifname);
+		ifp = if_lookup_by_name(bs->key.ifname, vrf->vrf_id);
 		if (ifp == NULL) {
 			log_error(
 				  "session-enable: specified interface doesn't exists.");

--- a/bfdd/bfdctl.h
+++ b/bfdd/bfdctl.h
@@ -41,7 +41,8 @@ struct sockaddr_any {
 };
 
 #ifndef MAXNAMELEN
-#define MAXNAMELEN 32
+/* aligned with VRF_NAMSIZ + 1 defined in vrf.h */
+#define MAXNAMELEN 37
 #endif
 
 #define BPC_DEF_DETECTMULTIPLIER 3

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2985,7 +2985,7 @@ void bgp_zebra_announce_default(struct bgp *bgp, struct nexthop *nh,
 		/* create default route with interface <VRF>
 		 * with nexthop-vrf <VRF>
 		 */
-		ifp = if_lookup_by_name_all_vrf(vrf->name);
+		ifp = if_lookup_by_name(vrf->name, nh->vrf_id);
 		if (!ifp)
 			return;
 		api_nh->vrf_id = nh->vrf_id;

--- a/lib/if.h
+++ b/lib/if.h
@@ -496,7 +496,8 @@ extern struct interface *if_lookup_prefix(struct prefix *prefix,
 size_t if_lookup_by_hwaddr(const uint8_t *hw_addr, size_t addrsz,
 			   struct interface ***result, vrf_id_t vrf_id);
 
-extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
+/* These 3 functions are to be used when the ifname argument is terminated
+   by a '\0' character: */
 extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
 extern struct interface *if_get_by_name(const char *ifname, vrf_id_t vrf_id);
 extern struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);

--- a/ospfd/ospf_asbr.c
+++ b/ospfd/ospf_asbr.c
@@ -148,6 +148,7 @@ ospf_external_info_add(struct ospf *ospf, uint8_t type, unsigned short instance,
 	new = ospf_external_info_new(type, instance);
 	new->p = p;
 	new->ifindex = ifindex;
+	new->vrf_id = ospf->vrf_id;
 	new->nexthop = nexthop;
 	new->tag = tag;
 

--- a/ospfd/ospf_asbr.h
+++ b/ospfd/ospf_asbr.h
@@ -49,6 +49,8 @@ struct external_info {
 	struct route_map_set_values route_map_set;
 #define ROUTEMAP_METRIC(E)      (E)->route_map_set.metric
 #define ROUTEMAP_METRIC_TYPE(E) (E)->route_map_set.metric_type
+
+	vrf_id_t vrf_id;
 };
 
 #define OSPF_ASBR_CHECK_DELAY 30

--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -329,7 +329,7 @@ route_match_interface(void *rule, const struct prefix *prefix,
 
 	if (type == RMAP_OSPF) {
 		ei = object;
-		ifp = if_lookup_by_name_all_vrf((char *)rule);
+		ifp = if_lookup_by_name((char *)rule, ei->vrf_id);
 
 		if (ifp == NULL || ifp->ifindex != ei->ifindex)
 			return RMAP_NOMATCH;


### PR DESCRIPTION
When duplicate name is on two network namespaces, at startup, the
wrong interface is picked up. Because we are at startup, force to return
the exact interface name.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>