### PR TITLE
[7.0] lib: fix uninit and incorrect array-size in privs.c

### DIFF
--- a/lib/privs.c
+++ b/lib/privs.c
@@ -808,7 +808,7 @@ void zprivs_preinit(struct zebra_privs_t *zprivs)
 
 void zprivs_init(struct zebra_privs_t *zprivs)
 {
-	gid_t groups[NGROUPS_MAX];
+	gid_t groups[NGROUPS_MAX] = {};
 	int i, ngroups = 0;
 	int found = 0;
 
@@ -818,7 +818,7 @@ void zprivs_init(struct zebra_privs_t *zprivs)
 		return;
 
 	if (zprivs->user) {
-		ngroups = sizeof(groups);
+		ngroups = array_size(groups);
 		if (getgrouplist(zprivs->user, zprivs_state.zgid, groups,
 				 &ngroups)
 		    < 0) {


### PR DESCRIPTION
Double commit of PR 3805 to 7.0.

Signed-off-by: Mark Stapp <mjs@voltanet.io>