### PR TITLE
bgp_vrf_ipv6_rtadv: test bgp ipv6 on separate vrf

### DIFF
--- a/tests/topotests/bgp_vrf_ipv6_rtadv/r1/bgpd.conf
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/r1/bgpd.conf
@@ -1,0 +1,13 @@
+router bgp 101 vrf r1-cust1
+ bgp router-id 10.254.254.1
+ neighbor r2g peer-group
+ neighbor r2g remote-as external
+ neighbor r2g bfd
+ neighbor r1-eth0 interface peer-group r2g
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ address-family ipv6 unicast
+  neighbor r2g activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_vrf_ipv6_rtadv/r1/ipv4_routes.json
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/r1/ipv4_routes.json
@@ -1,0 +1,44 @@
+{
+    "10.254.254.2/32": [
+        {
+            "distance": 20,
+            "protocol": "bgp",
+            "internalFlags": 8,
+            "metric": 0,
+            "selected": true,
+            "destSelected": true,
+            "prefix": "10.254.254.2/32",
+            "nexthops": [
+                {
+                    "interfaceName": "r1-eth0",
+                    "interfaceIndex": 2,
+                    "fib": true,
+                    "flags": 3,
+                    "active": true,
+                    "afi": "ipv6"
+                }
+            ]
+        }
+    ],
+    "10.254.254.1/32": [
+        {
+            "distance": 0,
+            "protocol": "connected",
+            "internalFlags": 8,
+            "metric": 0,
+            "selected": true,
+            "destSelected": true,
+            "prefix": "10.254.254.1/32",
+            "nexthops": [
+                {
+                    "directlyConnected": true,
+                    "interfaceName": "lo",
+                    "interfaceIndex": 1,
+                    "fib": true,
+                    "flags": 3,
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/topotests/bgp_vrf_ipv6_rtadv/r1/ipv6_routes.json
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/r1/ipv6_routes.json
@@ -1,0 +1,39 @@
+{
+  "2001:db8:1::/64": [
+    {
+      "distance": 20,
+      "protocol": "bgp",
+      "internalFlags": 0,
+      "metric": 0,
+      "prefix": "2001:db8:1::/64",
+      "nexthops": [
+        {
+          "interfaceName": "r1-eth0",
+          "interfaceIndex": 2,
+          "flags": 1,
+          "active": true,
+          "afi": "ipv6"
+        }
+      ]
+    },
+    {
+      "distance": 0,
+      "protocol": "connected",
+      "internalFlags": 8,
+      "metric": 0,
+      "selected": true,
+      "destSelected": true,
+      "prefix": "2001:db8:1::/64",
+      "nexthops": [
+        {
+          "directlyConnected": true,
+          "interfaceName": "r1-eth0",
+          "interfaceIndex": 2,
+          "fib": true,
+          "flags": 3,
+          "active": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/bgp_vrf_ipv6_rtadv/r1/zebra.conf
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/r1/zebra.conf
@@ -1,0 +1,9 @@
+debug zebra packet recv
+debug zebra packet send
+log stdout
+interface lo vrf r1-cust1
+ ip address 10.254.254.1/32
+!
+interface r1-eth0 vrf r1-cust1
+ ipv6 address 2001:db8:1::1/64
+!

--- a/tests/topotests/bgp_vrf_ipv6_rtadv/r2/bgpd.conf
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/r2/bgpd.conf
@@ -1,0 +1,16 @@
+router bgp 102 vrf r2-cust1
+ bgp router-id 10.254.254.2
+ neighbor r2g peer-group
+ neighbor r2g remote-as external
+ neighbor r2g bfd
+ neighbor r2-eth0 interface peer-group r2g
+ !
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  redistribute connected
+  neighbor r2g activate
+ exit-address-family
+!

--- a/tests/topotests/bgp_vrf_ipv6_rtadv/r2/ipv4_routes.json
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/r2/ipv4_routes.json
@@ -1,0 +1,44 @@
+{
+  "10.254.254.2/32": [
+    {
+      "distance": 0,
+      "protocol": "connected",
+      "internalFlags": 8,
+      "metric": 0,
+      "selected": true,
+      "destSelected": true,
+      "prefix": "10.254.254.2/32",
+      "nexthops": [
+        {
+          "directlyConnected": true,
+          "interfaceName": "lo",
+          "interfaceIndex": 1,
+          "fib": true,
+          "flags": 3,
+          "active": true
+        }
+      ]
+    }
+  ],
+  "10.254.254.1/32": [
+    {
+      "distance": 20,
+      "protocol": "bgp",
+      "internalFlags": 8,
+      "metric": 0,
+      "selected": true,
+      "destSelected": true,
+      "prefix": "10.254.254.1/32",
+      "nexthops": [
+        {
+          "interfaceName": "r2-eth0",
+          "interfaceIndex": 2,
+          "fib": true,
+          "flags": 3,
+          "active": true,
+          "afi": "ipv6"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/bgp_vrf_ipv6_rtadv/r2/ipv6_routes.json
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/r2/ipv6_routes.json
@@ -1,0 +1,23 @@
+{
+  "2001:db8:1::/64": [
+    {
+      "distance": 0,
+      "protocol": "connected",
+      "internalFlags": 8,
+      "metric": 0,
+      "selected": true,
+      "destSelected": true,
+      "prefix": "2001:db8:1::/64",
+      "nexthops": [
+        {
+          "directlyConnected": true,
+          "interfaceName": "r2-eth0",
+          "interfaceIndex": 2,
+          "fib": true,
+          "flags": 3,
+          "active": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/topotests/bgp_vrf_ipv6_rtadv/r2/zebra.conf
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/r2/zebra.conf
@@ -1,0 +1,9 @@
+ip forwarding
+ipv6 forwarding
+!
+interface lo vrf r2-cust1
+ ip address 10.254.254.2/32
+!
+interface r2-eth0 vrf r2-cust1
+ ipv6 address 2001:db8:1::2/64
+!

--- a/tests/topotests/bgp_vrf_ipv6_rtadv/test_bgp_vrf_ipv6_rtadv.dot
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/test_bgp_vrf_ipv6_rtadv.dot
@@ -1,0 +1,44 @@
+## Color coding:
+#########################
+##  Main FRR: #f08080  red
+##  Switches: #d0e0d0  gray
+##  RIP:      #19e3d9  Cyan
+##  RIPng:    #fcb314  dark yellow
+##  OSPFv2:   #32b835  Green
+##  OSPFv3:   #19e3d9  Cyan
+##  ISIS IPv4 #fcb314  dark yellow
+##  ISIS IPv6 #9a81ec  purple
+##  BGP IPv4  #eee3d3  beige
+##  BGP IPv6  #fdff00  yellow
+##### Colors (see http://www.color-hex.com/)
+
+graph template {
+  label="bfd-topo2";
+
+  # Routers
+  r1 [
+    shape=doubleoctagon,
+    label="r1",
+    fillcolor="#f08080",
+    style=filled,
+  ];
+  r2 [
+    shape=doubleoctagon
+    label="r2",
+    fillcolor="#f08080",
+    style=filled,
+  ];
+
+  # Switches
+  sw1 [
+    shape=oval,
+    label="sw1\n2001:db8:1::/64",
+    fillcolor="#d0e0d0",
+    style=filled,
+  ];
+
+  # Connections
+  r1 -- sw1 [label="eth0"];
+  r2 -- sw1 [label="eth0"];
+
+}

--- a/tests/topotests/bgp_vrf_ipv6_rtadv/test_bgp_vrf_ipv6_rtadv.py
+++ b/tests/topotests/bgp_vrf_ipv6_rtadv/test_bgp_vrf_ipv6_rtadv.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_ipv6_rtadv.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2019 by 6WIND
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+ test_bgp_ipv6_rtadv.py: Test the FRR/Quagga BGP daemon with BGP IPv6 interface
+ with route advertisements on a separate netns.
+"""
+
+import os
+import sys
+import json
+from functools import partial
+import pytest
+
+# Save the Current Working Directory to find configuration files.
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+# Import topogen and topotest helpers
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+
+# Required to instantiate the topology builder class.
+from mininet.topo import Topo
+
+
+class BGPIPV6RTADVVRFTopo(Topo):
+    "Test topology builder"
+    def build(self, *_args, **_opts):
+        "Build function"
+        tgen = get_topogen(self)
+
+        # Create 2 routers.
+        tgen.add_router('r1')
+        tgen.add_router('r2')
+
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
+
+def setup_module(mod):
+    "Sets up the pytest environment"
+    tgen = Topogen(BGPIPV6RTADVVRFTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    # check for zebra capability
+    for rname, router in router_list.iteritems():
+        if router.check_capability(
+                TopoRouter.RD_ZEBRA,
+                '--vrfwnetns'
+        ) == False:
+            return  pytest.skip('Skipping BGP IPv6 RTADV VRF NETNS feature. VRF NETNS backend not available on FRR')
+
+    if os.system('ip netns list') != 0:
+        return  pytest.skip('Skipping BGP IPv6 RTADV VRF NETNS Test. NETNS not available on System')
+
+    logger.info('Testing with VRF Namespace support')
+
+    cmds = ['if [ -e /var/run/netns/{0}-cust1 ] ; then ip netns del {0}-cust1 ; fi',
+            'ip netns add {0}-cust1',
+            'ip link set dev {0}-eth0 netns {0}-cust1',
+            'ip netns exec {0}-cust1 ifconfig {0}-eth0 up',
+            'ip netns exec {0}-cust1 ip link set dev lo up']
+
+    for rname, router in router_list.iteritems():
+        # create VRF rx-cust1 and link rx-eth0 to rx-cust1
+        for cmd in cmds:
+            output = tgen.net[rname].cmd(cmd.format(rname))
+
+    for rname, router in router_list.iteritems():
+        router.load_config(
+            TopoRouter.RD_ZEBRA,
+            os.path.join(CWD, '{}/zebra.conf'.format(rname)),
+            '--vrfwnetns'
+        )
+        router.load_config(
+            TopoRouter.RD_BGP,
+            os.path.join(CWD, '{}/bgpd.conf'.format(rname))
+        )
+
+    # Initialize all routers.
+    tgen.start_router()
+
+def teardown_module(_mod):
+    "Teardown the pytest environment"
+    tgen = get_topogen()
+    cmds = ['ip netns exec {0}-cust1 ip link set {0}-eth0 netns 1',
+            'ip netns delete {0}-cust1']
+
+    router_list = tgen.routers()
+    for rname, router in router_list.iteritems():
+        for cmd in cmds:
+            tgen.net[rname].cmd(cmd.format(rname))
+    tgen.stop_topology()
+
+
+def test_protocols_convergence():
+    """
+    Assert that all protocols have converged
+    statuses as they depend on it.
+    """
+    tgen = get_topogen()
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    # Check IPv4 routing tables.
+    logger.info("Checking IPv4 routes for convergence")
+    for router in tgen.routers().values():
+        json_file = '{}/{}/ipv4_routes.json'.format(CWD, router.name)
+        if not os.path.isfile(json_file):
+            logger.info('skipping file {}'.format(json_file))
+            continue
+
+        expected = json.loads(open(json_file).read())
+        test_func = partial(topotest.router_json_cmp,
+                            router, 'show ip route vrf {}-cust1 json'.format(router.name), expected)
+        _, result = topotest.run_and_expect(test_func, None, count=160,
+                                            wait=0.5)
+        assertmsg = '"{}" JSON output mismatches'.format(router.name)
+        assert result is None, assertmsg
+
+    # Check IPv6 routing tables.
+    logger.info("Checking IPv6 routes for convergence")
+    for router in tgen.routers().values():
+        json_file = '{}/{}/ipv6_routes.json'.format(CWD, router.name)
+        if not os.path.isfile(json_file):
+            logger.info('skipping file {}'.format(json_file))
+            continue
+
+        expected = json.loads(open(json_file).read())
+        test_func = partial(topotest.router_json_cmp,
+                            router, 'show ipv6 route vrf {}-cust1 json'.format(router.name), expected)
+        _, result = topotest.run_and_expect(test_func, None, count=160,
+                                            wait=0.5)
+        assertmsg = '"{}" JSON output mismatches'.format(router.name)
+        assert result is None, assertmsg
+
+def test_memory_leak():
+    "Run the memory leak test and report results."
+    tgen = get_topogen()
+    if not tgen.is_memleak_enabled():
+        pytest.skip('Memory leak test/report is disabled')
+
+    tgen.report_memory_leaks()
+
+
+if __name__ == '__main__':
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
bgp ipv6 implies that routing advertisements be available for all vrf.
in the case of the vrf backend is network namespace, this should be
tested too. in addition to configure addresses per interface on a
separate vrf, the test also checks for BGP connectivity.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>