### PR TITLE
Issue #4032: Add IS-IS-TE support per Area

### DIFF
--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -121,8 +121,7 @@ struct isis_circuit {
 	uint16_t psnp_interval[2];    /* psnp-interval in seconds */
 	uint8_t metric[2];
 	uint32_t te_metric[2];
-	struct mpls_te_circuit
-		*mtc;   /* Support for MPLS-TE parameters - see isis_te.[c,h] */
+	struct mpls_te_circuit *mtc; /* MPLS-TE parameters */
 	int ip_router;  /* Route IP ? */
 	int is_passive; /* Is Passive ? */
 	struct list *mt_settings;   /* IS-IS MT Settings */

--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -928,12 +928,12 @@ void cli_show_isis_purge_origin(struct vty *vty, struct lyd_node *dnode,
 }
 
 /*
- * XPath: /frr-isisd:isis/mpls-te
+ * XPath: /frr-isisd:isis/instance/mpls-te
  */
 DEFPY(isis_mpls_te_on, isis_mpls_te_on_cmd, "mpls-te on",
       MPLS_TE_STR "Enable the MPLS-TE functionality\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-isisd:isis/mpls-te", NB_OP_CREATE,
+	nb_cli_enqueue_change(vty, "./mpls-te", NB_OP_CREATE,
 			      NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -942,9 +942,9 @@ DEFPY(isis_mpls_te_on, isis_mpls_te_on_cmd, "mpls-te on",
 DEFPY(no_isis_mpls_te_on, no_isis_mpls_te_on_cmd, "no mpls-te [on]",
       NO_STR
       "Disable the MPLS-TE functionality\n"
-      "Enable the MPLS-TE functionality\n")
+      "Disable the MPLS-TE functionality\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-isisd:isis/mpls-te", NB_OP_DESTROY,
+	nb_cli_enqueue_change(vty, "./mpls-te", NB_OP_DESTROY,
 			      NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
@@ -957,7 +957,7 @@ void cli_show_isis_mpls_te(struct vty *vty, struct lyd_node *dnode,
 }
 
 /*
- * XPath: /frr-isisd:isis/mpls-te/router-address
+ * XPath: /frr-isisd:isis/instance/mpls-te/router-address
  */
 DEFPY(isis_mpls_te_router_addr, isis_mpls_te_router_addr_cmd,
       "mpls-te router-address A.B.C.D",
@@ -965,8 +965,20 @@ DEFPY(isis_mpls_te_router_addr, isis_mpls_te_router_addr_cmd,
       "Stable IP address of the advertising router\n"
       "MPLS-TE router address in IPv4 address format\n")
 {
-	nb_cli_enqueue_change(vty, "/frr-isisd:isis/mpls-te/router-address",
+	nb_cli_enqueue_change(vty, "./mpls-te/router-address",
 			      NB_OP_MODIFY, router_address_str);
+
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY(no_isis_mpls_te_router_addr, no_isis_mpls_te_router_addr_cmd,
+      "no mpls-te router-address [A.B.C.D]",
+      NO_STR MPLS_TE_STR
+      "Delete IP address of the advertising router\n"
+      "MPLS-TE router address in IPv4 address format\n")
+{
+	nb_cli_enqueue_change(vty, "./mpls-te/router-address",
+			      NB_OP_DESTROY, NULL);
 
 	return nb_cli_apply_changes(vty, NULL);
 }
@@ -986,7 +998,7 @@ DEFPY(isis_mpls_te_inter_as, isis_mpls_te_inter_as_cmd,
       "AREA native mode self originate INTER-AS LSP with L1 and L2 flooding scope\n"
       "AS native mode self originate INTER-AS LSP with L2 only flooding scope\n")
 {
-	vty_out(vty, "MPLS-TE Inter-AS is not yet supported.");
+	vty_out(vty, "MPLS-TE Inter-AS is not yet supported\n");
 	return CMD_SUCCESS;
 }
 
@@ -1967,6 +1979,7 @@ void isis_cli_init(void)
 	install_element(ISIS_NODE, &isis_mpls_te_on_cmd);
 	install_element(ISIS_NODE, &no_isis_mpls_te_on_cmd);
 	install_element(ISIS_NODE, &isis_mpls_te_router_addr_cmd);
+	install_element(ISIS_NODE, &no_isis_mpls_te_router_addr_cmd);
 	install_element(ISIS_NODE, &isis_mpls_te_inter_as_cmd);
 
 	install_element(ISIS_NODE, &isis_default_originate_cmd);

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -1070,7 +1070,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 						uint8_t subtlvs[256];
 						uint8_t subtlv_len;
 
-						if (IS_MPLS_TE(isisMplsTE)
+						if (IS_MPLS_TE(area->mta)
 						    && circuit->interface
 						    && HAS_LINK_PARAMS(
 							       circuit->interface))
@@ -1112,7 +1112,7 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
 					uint8_t subtlvs[256];
 					uint8_t subtlv_len;
 
-					if (IS_MPLS_TE(isisMplsTE)
+					if (IS_MPLS_TE(area->mta)
 					    && circuit->interface != NULL
 					    && HAS_LINK_PARAMS(
 						       circuit->interface))

--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -1365,19 +1365,40 @@ isis_instance_log_adjacency_changes_modify(enum nb_event event,
 }
 
 /*
- * XPath: /frr-isisd:isis/mpls-te
+ * XPath: /frr-isisd:isis/instance/mpls-te
  */
-static int isis_mpls_te_create(enum nb_event event,
+static int isis_instance_mpls_te_create(enum nb_event event,
 			       const struct lyd_node *dnode,
 			       union nb_resource *resource)
 {
 	struct listnode *node;
+	struct isis_area *area;
 	struct isis_circuit *circuit;
 
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	isisMplsTE.status = enable;
+	area = yang_dnode_get_entry(dnode, true);
+	if (area->mta == NULL) {
+
+		struct mpls_te_area *new;
+
+		zlog_debug("ISIS MPLS-TE: Initialize area %s",
+			area->area_tag);
+
+		new = XCALLOC(MTYPE_ISIS_MPLS_TE, sizeof(struct mpls_te_area));
+
+		/* Initialize MPLS_TE structure */
+		new->status = enable;
+		new->level = 0;
+		new->inter_as = off;
+		new->interas_areaid.s_addr = 0;
+		new->router_id.s_addr = 0;
+
+		area->mta = new;
+	} else {
+		area->mta->status = enable;
+	}
 
 	/*
 	 * Following code is intended to handle two cases;
@@ -1387,11 +1408,11 @@ static int isis_mpls_te_create(enum nb_event event,
 	 * MPLS_TE flag
 	 * 2) MPLS-TE was once enabled then disabled, and now enabled again.
 	 */
-	for (ALL_LIST_ELEMENTS_RO(isisMplsTE.cir_list, node, circuit)) {
+	for (ALL_LIST_ELEMENTS_RO(area->circuit_list, node, circuit)) {
 		if (circuit->mtc == NULL || IS_FLOOD_AS(circuit->mtc->type))
 			continue;
 
-		if ((circuit->mtc->status == disable)
+		if (!IS_MPLS_TE(circuit->mtc)
 		    && HAS_LINK_PARAMS(circuit->interface))
 			circuit->mtc->status = enable;
 		else
@@ -1406,19 +1427,24 @@ static int isis_mpls_te_create(enum nb_event event,
 	return NB_OK;
 }
 
-static int isis_mpls_te_destroy(enum nb_event event,
+static int isis_instance_mpls_te_destroy(enum nb_event event,
 			       const struct lyd_node *dnode)
 {
 	struct listnode *node;
+	struct isis_area *area;
 	struct isis_circuit *circuit;
 
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	isisMplsTE.status = disable;
+	area = yang_dnode_get_entry(dnode, true);
+	if (IS_MPLS_TE(area->mta))
+		area->mta->status = disable;
+	else
+		return NB_OK;
 
 	/* Flush LSP if circuit engage */
-	for (ALL_LIST_ELEMENTS_RO(isisMplsTE.cir_list, node, circuit)) {
+	for (ALL_LIST_ELEMENTS_RO(area->circuit_list, node, circuit)) {
 		if (circuit->mtc == NULL || (circuit->mtc->status == disable))
 			continue;
 
@@ -1435,55 +1461,53 @@ static int isis_mpls_te_destroy(enum nb_event event,
 }
 
 /*
- * XPath: /frr-isisd:isis/mpls-te/router-address
+ * XPath: /frr-isisd:isis/instance/mpls-te/router-address
  */
-static int isis_mpls_te_router_address_modify(enum nb_event event,
+static int isis_instance_mpls_te_router_address_modify(enum nb_event event,
 					      const struct lyd_node *dnode,
 					      union nb_resource *resource)
 {
 	struct in_addr value;
-	struct listnode *node;
 	struct isis_area *area;
 
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	yang_dnode_get_ipv4(&value, dnode, NULL);
-	isisMplsTE.router_id.s_addr = value.s_addr;
+	area = yang_dnode_get_entry(dnode, true);
 	/* only proceed if MPLS-TE is enabled */
-	if (isisMplsTE.status == disable)
+	if (!IS_MPLS_TE(area->mta))
 		return NB_OK;
 
-	/* Update main Router ID in isis global structure */
-	isis->router_id = value.s_addr;
+	/* Update Area Router ID */
+	yang_dnode_get_ipv4(&value, dnode, NULL);
+	area->mta->router_id.s_addr = value.s_addr;
+
 	/* And re-schedule LSP update */
-	for (ALL_LIST_ELEMENTS_RO(isis->area_list, node, area))
-		if (listcount(area->area_addrs) > 0)
-			lsp_regenerate_schedule(area, area->is_type, 0);
+	if (listcount(area->area_addrs) > 0)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
 
-static int isis_mpls_te_router_address_destroy(enum nb_event event,
+static int isis_instance_mpls_te_router_address_destroy(enum nb_event event,
 					      const struct lyd_node *dnode)
 {
-	struct listnode *node;
 	struct isis_area *area;
 
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	isisMplsTE.router_id.s_addr = INADDR_ANY;
+	area = yang_dnode_get_entry(dnode, true);
 	/* only proceed if MPLS-TE is enabled */
-	if (isisMplsTE.status == disable)
+	if (!IS_MPLS_TE(area->mta))
 		return NB_OK;
 
-	/* Update main Router ID in isis global structure */
-	isis->router_id = 0;
+	/* Reset Area Router ID */
+	area->mta->router_id.s_addr = INADDR_ANY;
+
 	/* And re-schedule LSP update */
-	for (ALL_LIST_ELEMENTS_RO(isis->area_list, node, area))
-		if (listcount(area->area_addrs) > 0)
-			lsp_regenerate_schedule(area, area->is_type, 0);
+	if (listcount(area->area_addrs) > 0)
+		lsp_regenerate_schedule(area, area->is_type, 0);
 
 	return NB_OK;
 }
@@ -3015,15 +3039,15 @@ const struct frr_yang_module_info frr_isisd_info = {
 			.cbs.cli_show = cli_show_isis_log_adjacency,
 		},
 		{
-			.xpath = "/frr-isisd:isis/mpls-te",
-			.cbs.create = isis_mpls_te_create,
-			.cbs.destroy = isis_mpls_te_destroy,
+			.xpath = "/frr-isisd:isis/instance/mpls-te",
+			.cbs.create = isis_instance_mpls_te_create,
+			.cbs.destroy = isis_instance_mpls_te_destroy,
 			.cbs.cli_show = cli_show_isis_mpls_te,
 		},
 		{
-			.xpath = "/frr-isisd:isis/mpls-te/router-address",
-			.cbs.modify = isis_mpls_te_router_address_modify,
-			.cbs.destroy = isis_mpls_te_router_address_destroy,
+			.xpath = "/frr-isisd:isis/instance/mpls-te/router-address",
+			.cbs.modify = isis_instance_mpls_te_router_address_modify,
+			.cbs.destroy = isis_instance_mpls_te_router_address_destroy,
 			.cbs.cli_show = cli_show_isis_mpls_te_router_addr,
 		},
 		{

--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -1378,7 +1378,7 @@ static int isis_instance_mpls_te_create(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	if (area->mta == NULL) {
 
 		struct mpls_te_area *new;
@@ -1437,7 +1437,7 @@ static int isis_instance_mpls_te_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	if (IS_MPLS_TE(area->mta))
 		area->mta->status = disable;
 	else
@@ -1473,7 +1473,7 @@ static int isis_instance_mpls_te_router_address_modify(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	/* only proceed if MPLS-TE is enabled */
 	if (!IS_MPLS_TE(area->mta))
 		return NB_OK;
@@ -1497,7 +1497,7 @@ static int isis_instance_mpls_te_router_address_destroy(enum nb_event event,
 	if (event != NB_EV_APPLY)
 		return NB_OK;
 
-	area = yang_dnode_get_entry(dnode, true);
+	area = nb_running_get_entry(dnode, NULL, true);
 	/* only proceed if MPLS-TE is enabled */
 	if (!IS_MPLS_TE(area->mta))
 		return NB_OK;

--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -201,8 +201,9 @@ static int process_p2p_hello(struct iih_info *iih)
 				      adj);
 
 	/* Update MPLS TE Remote IP address parameter if possible */
-	if (IS_MPLS_TE(isisMplsTE) && iih->circuit->mtc
-	    && IS_CIRCUIT_TE(iih->circuit->mtc) && adj->ipv4_address_count)
+	if (IS_MPLS_TE(iih->circuit->area->mta)
+	    && IS_MPLS_TE(iih->circuit->mtc)
+	    && adj->ipv4_address_count)
 		set_circuitparams_rmt_ipaddr(iih->circuit->mtc,
 					     adj->ipv4_addresses[0]);
 

--- a/isisd/isis_te.c
+++ b/isisd/isis_te.c
@@ -58,9 +58,6 @@
 #include "isisd/isis_spf.h"
 #include "isisd/isis_te.h"
 
-/* Global varial for MPLS TE management */
-struct isis_mpls_te isisMplsTE;
-
 const char *mode2text[] = {"Disable", "Area", "AS", "Emulate"};
 
 /*------------------------------------------------------------------------*
@@ -624,7 +621,7 @@ void isis_link_params_update(struct isis_circuit *circuit,
 
 /* Finally Update LSP */
 #if 0
-  if (IS_MPLS_TE(isisMplsTE) && circuit->area)
+  if (circuit->area && IS_MPLS_TE(circuit->area->mta))
        lsp_regenerate_schedule (circuit->area, circuit->is_type, 0);
 #endif
 	return;
@@ -646,7 +643,7 @@ void isis_mpls_te_update(struct interface *ifp)
 	isis_link_params_update(circuit, ifp);
 
 	/* ... and LSP */
-	if (IS_MPLS_TE(isisMplsTE) && circuit->area)
+	if (circuit->area && IS_MPLS_TE(circuit->area->mta))
 		lsp_regenerate_schedule(circuit->area, circuit->is_type, 0);
 
 	return;
@@ -1058,34 +1055,10 @@ void mpls_te_print_detail(struct sbuf *buf, int indent,
 	return;
 }
 
-/* Specific MPLS TE router parameters write function */
-void isis_mpls_te_config_write_router(struct vty *vty)
-{
-	if (IS_MPLS_TE(isisMplsTE)) {
-		vty_out(vty, "  mpls-te on\n");
-		vty_out(vty, "  mpls-te router-address %s\n",
-			inet_ntoa(isisMplsTE.router_id));
-	}
-
-	return;
-}
-
-
 /*------------------------------------------------------------------------*
  * Followings are vty command functions.
  *------------------------------------------------------------------------*/
 #ifndef FABRICD
-
-/* Search MPLS TE Circuit context from Interface */
-static struct mpls_te_circuit *lookup_mpls_params_by_ifp(struct interface *ifp)
-{
-	struct isis_circuit *circuit;
-
-	if ((circuit = circuit_scan_by_ifp(ifp)) == NULL)
-		return NULL;
-
-	return circuit->mtc;
-}
 
 DEFUN (show_isis_mpls_te_router,
        show_isis_mpls_te_router_cmd,
@@ -1095,84 +1068,73 @@ DEFUN (show_isis_mpls_te_router,
        MPLS_TE_STR
        "Router information\n")
 {
-	if (IS_MPLS_TE(isisMplsTE)) {
-		vty_out(vty, "--- MPLS-TE router parameters ---\n");
 
-		if (ntohs(isisMplsTE.router_id.s_addr) != 0)
-			vty_out(vty, "  Router-Address: %s\n",
-				inet_ntoa(isisMplsTE.router_id));
+	struct listnode *anode;
+	struct isis_area *area;
+
+	if (!isis) {
+		vty_out(vty, "IS-IS Routing Process not enabled\n");
+		return CMD_SUCCESS;
+	}
+
+	for (ALL_LIST_ELEMENTS_RO(isis->area_list, anode, area)) {
+
+		if (!IS_MPLS_TE(area->mta))
+			continue;
+
+		vty_out(vty, "Area %s:\n", area->area_tag);
+		if (ntohs(area->mta->router_id.s_addr) != 0)
+			vty_out(vty, "  MPLS-TE Router-Address: %s\n",
+				inet_ntoa(area->mta->router_id));
 		else
 			vty_out(vty, "  N/A\n");
-	} else
-		vty_out(vty, "  MPLS-TE is disable on this router\n");
+	}
 
 	return CMD_SUCCESS;
 }
 
-static void show_mpls_te_sub(struct vty *vty, struct interface *ifp)
+static void show_mpls_te_sub(struct vty *vty, char *name,
+			     struct mpls_te_circuit *mtc)
 {
-	struct mpls_te_circuit *mtc;
 	struct sbuf buf;
 
 	sbuf_init(&buf, NULL, 0);
 
-	if ((IS_MPLS_TE(isisMplsTE))
-	    && ((mtc = lookup_mpls_params_by_ifp(ifp)) != NULL)) {
-		/* Continue only if interface is not passive or support Inter-AS
-		 * TEv2 */
-		if (mtc->status != enable) {
-			if (IS_INTER_AS(mtc->type)) {
-				vty_out(vty,
-					"-- Inter-AS TEv2 link parameters for %s --\n",
-					ifp->name);
-			} else {
-				/* MPLS-TE is not activate on this interface */
-				/* or this interface is passive and Inter-AS
-				 * TEv2 is not activate */
-				vty_out(vty,
-					"  %s: MPLS-TE is disabled on this interface\n",
-					ifp->name);
-				return;
-			}
-		} else {
-			vty_out(vty, "-- MPLS-TE link parameters for %s --\n",
-				ifp->name);
-		}
+	if (mtc->status != enable)
+		return;
 
-		sbuf_reset(&buf);
-		print_subtlv_admin_grp(&buf, 4, &mtc->admin_grp);
+	vty_out(vty, "-- MPLS-TE link parameters for %s --\n", name);
 
-		if (SUBTLV_TYPE(mtc->local_ipaddr) != 0)
-			print_subtlv_local_ipaddr(&buf, 4, &mtc->local_ipaddr);
-		if (SUBTLV_TYPE(mtc->rmt_ipaddr) != 0)
-			print_subtlv_rmt_ipaddr(&buf, 4, &mtc->rmt_ipaddr);
+	sbuf_reset(&buf);
+	print_subtlv_admin_grp(&buf, 4, &mtc->admin_grp);
 
-		print_subtlv_max_bw(&buf, 4, &mtc->max_bw);
-		print_subtlv_max_rsv_bw(&buf, 4, &mtc->max_rsv_bw);
-		print_subtlv_unrsv_bw(&buf, 4, &mtc->unrsv_bw);
-		print_subtlv_te_metric(&buf, 4, &mtc->te_metric);
+	if (SUBTLV_TYPE(mtc->local_ipaddr) != 0)
+		print_subtlv_local_ipaddr(&buf, 4, &mtc->local_ipaddr);
+	if (SUBTLV_TYPE(mtc->rmt_ipaddr) != 0)
+		print_subtlv_rmt_ipaddr(&buf, 4, &mtc->rmt_ipaddr);
 
-		if (IS_INTER_AS(mtc->type)) {
-			if (SUBTLV_TYPE(mtc->ras) != 0)
-				print_subtlv_ras(&buf, 4, &mtc->ras);
-			if (SUBTLV_TYPE(mtc->rip) != 0)
-				print_subtlv_rip(&buf, 4, &mtc->rip);
-		}
+	print_subtlv_max_bw(&buf, 4, &mtc->max_bw);
+	print_subtlv_max_rsv_bw(&buf, 4, &mtc->max_rsv_bw);
+	print_subtlv_unrsv_bw(&buf, 4, &mtc->unrsv_bw);
+	print_subtlv_te_metric(&buf, 4, &mtc->te_metric);
 
-		print_subtlv_av_delay(&buf, 4, &mtc->av_delay);
-		print_subtlv_mm_delay(&buf, 4, &mtc->mm_delay);
-		print_subtlv_delay_var(&buf, 4, &mtc->delay_var);
-		print_subtlv_pkt_loss(&buf, 4, &mtc->pkt_loss);
-		print_subtlv_res_bw(&buf, 4, &mtc->res_bw);
-		print_subtlv_ava_bw(&buf, 4, &mtc->ava_bw);
-		print_subtlv_use_bw(&buf, 4, &mtc->use_bw);
-
-		vty_multiline(vty, "", "%s", sbuf_buf(&buf));
-		vty_out(vty, "---------------\n\n");
-	} else {
-		vty_out(vty, "  %s: MPLS-TE is disabled on this interface\n",
-			ifp->name);
+	if (IS_INTER_AS(mtc->type)) {
+		if (SUBTLV_TYPE(mtc->ras) != 0)
+			print_subtlv_ras(&buf, 4, &mtc->ras);
+		if (SUBTLV_TYPE(mtc->rip) != 0)
+			print_subtlv_rip(&buf, 4, &mtc->rip);
 	}
+
+	print_subtlv_av_delay(&buf, 4, &mtc->av_delay);
+	print_subtlv_mm_delay(&buf, 4, &mtc->mm_delay);
+	print_subtlv_delay_var(&buf, 4, &mtc->delay_var);
+	print_subtlv_pkt_loss(&buf, 4, &mtc->pkt_loss);
+	print_subtlv_res_bw(&buf, 4, &mtc->res_bw);
+	print_subtlv_ava_bw(&buf, 4, &mtc->ava_bw);
+	print_subtlv_use_bw(&buf, 4, &mtc->use_bw);
+
+	vty_multiline(vty, "", "%s", sbuf_buf(&buf));
+	vty_out(vty, "---------------\n\n");
 
 	sbuf_free(&buf);
 	return;
@@ -1187,23 +1149,45 @@ DEFUN (show_isis_mpls_te_interface,
        "Interface information\n"
        "Interface name\n")
 {
-	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
-	int idx_interface = 4;
+	struct listnode *anode, *cnode;
+	struct isis_area *area;
+	struct isis_circuit *circuit;
 	struct interface *ifp;
+	int idx_interface = 4;
 
-	/* Show All Interfaces. */
-	if (argc == 4) {
-		FOR_ALL_INTERFACES (vrf, ifp)
-			show_mpls_te_sub(vty, ifp);
+	if (!isis) {
+		vty_out(vty, "IS-IS Routing Process not enabled\n");
+		return CMD_SUCCESS;
 	}
-	/* Interface name is specified. */
-	else {
-		if ((ifp = if_lookup_by_name(argv[idx_interface]->arg,
-					     VRF_DEFAULT))
-		    == NULL)
+
+	if (argc == idx_interface) {
+		/* Show All Interfaces. */
+		for (ALL_LIST_ELEMENTS_RO(isis->area_list, anode, area)) {
+
+			if (!IS_MPLS_TE(area->mta))
+				continue;
+
+			vty_out(vty, "Area %s:\n", area->area_tag);
+
+			for (ALL_LIST_ELEMENTS_RO(area->circuit_list, cnode,
+						  circuit))
+				show_mpls_te_sub(vty, circuit->interface->name,
+						 circuit->mtc);
+		}
+	} else {
+		/* Interface name is specified. */
+		ifp = if_lookup_by_name(argv[idx_interface]->arg, VRF_DEFAULT);
+		if (ifp == NULL)
 			vty_out(vty, "No such interface name\n");
-		else
-			show_mpls_te_sub(vty, ifp);
+		else {
+			circuit = circuit_scan_by_ifp(ifp);
+			if (!circuit)
+				vty_out(vty,
+					"ISIS is not enabled on circuit %s\n",
+					ifp->name);
+			else
+				show_mpls_te_sub(vty, ifp->name, circuit->mtc);
+		}
 	}
 
 	return CMD_SUCCESS;
@@ -1213,16 +1197,6 @@ DEFUN (show_isis_mpls_te_interface,
 /* Initialize MPLS_TE */
 void isis_mpls_te_init(void)
 {
-
-	zlog_debug("ISIS MPLS-TE: Initialize");
-
-	/* Initialize MPLS_TE structure */
-	isisMplsTE.status = disable;
-	isisMplsTE.level = 0;
-	isisMplsTE.inter_as = off;
-	isisMplsTE.interas_areaid.s_addr = 0;
-	isisMplsTE.cir_list = list_new();
-	isisMplsTE.router_id.s_addr = 0;
 
 #ifndef FABRICD
 	/* Register new VTY commands */

--- a/isisd/isis_te.h
+++ b/isisd/isis_te.h
@@ -244,11 +244,10 @@ typedef enum _status_t { disable, enable, learn } status_t;
 /* Mode for Inter-AS LSP */ /* TODO: Check how if LSP is flooded in RFC5316 */
 typedef enum _interas_mode_t { off, region, as, emulate } interas_mode_t;
 
-#define IS_MPLS_TE(m)    (m.status == enable)
-#define IS_CIRCUIT_TE(c) (c->status == enable)
+#define IS_MPLS_TE(m)    (m && m->status == enable)
 
-/* Following structure are internal use only. */
-struct isis_mpls_te {
+/* Per area MPLS-TE parameters */
+struct mpls_te_area {
 	/* Status of MPLS-TE: enable or disable */
 	status_t status;
 
@@ -259,15 +258,11 @@ struct isis_mpls_te {
 	interas_mode_t inter_as;
 	struct in_addr interas_areaid;
 
-	/* Circuit list on which TE are enable */
-	struct list *cir_list;
-
 	/* MPLS_TE router ID */
 	struct in_addr router_id;
 };
 
-extern struct isis_mpls_te isisMplsTE;
-
+/* Per Circuit MPLS-TE parameters */
 struct mpls_te_circuit {
 
 	/* Status of MPLS-TE on this interface */
@@ -318,6 +313,5 @@ uint8_t add_te_subtlvs(uint8_t *, struct mpls_te_circuit *);
 uint8_t build_te_subtlvs(uint8_t *, struct isis_circuit *);
 void isis_link_params_update(struct isis_circuit *, struct interface *);
 void isis_mpls_te_update(struct interface *);
-void isis_mpls_te_config_write_router(struct vty *);
 
 #endif /* _ZEBRA_ISIS_MPLS_TE_H */

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -61,13 +61,6 @@ static int isis_router_id_update_zebra(int command, struct zclient *zclient,
 	struct listnode *node;
 	struct prefix router_id;
 
-	/*
-	 * If ISIS TE is enable, TE Router ID is set through specific command.
-	 * See mpls_te_router_addr() command in isis_te.c
-	 */
-	if (IS_MPLS_TE(isisMplsTE))
-		return 0;
-
 	zebra_router_id_update_read(zclient->ibuf, &router_id);
 	if (isis->router_id == router_id.u.prefix4.s_addr)
 		return 0;

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -95,7 +95,6 @@ void isis_new(unsigned long process_id)
 	 * uncomment the next line for full debugs
 	 */
 	/* isis->debugs = 0xFFFF; */
-	isisMplsTE.status = disable; /* Only support TE metric */
 
 	QOBJ_REG(isis, isis);
 }
@@ -257,6 +256,10 @@ int isis_area_destroy(const char *area_tag)
 
 	if (fabricd)
 		fabricd_finish(area->fabricd);
+
+	/* Disable MPLS if necessary before flooding LSP */
+	if (IS_MPLS_TE(area->mta))
+		area->mta->status = disable;
 
 	if (area->circuit_list) {
 		for (ALL_LIST_ELEMENTS(area->circuit_list, node, nnode,
@@ -2137,7 +2140,6 @@ int isis_config_write(struct vty *vty)
 			write += area_write_mt_settings(area, vty);
 			write += fabricd_write_settings(area, vty);
 		}
-		isis_mpls_te_config_write_router(vty);
 	}
 
 	return write;

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -165,6 +165,8 @@ struct isis_area {
 	uint8_t log_adj_changes;
 	/* multi topology settings */
 	struct list *mt_settings;
+	/* MPLS-TE settings */
+	struct mpls_te_area *mta;
 	int ipv6_circuits;
 	bool purge_originator;
 	/* Counters */

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -707,16 +707,16 @@ module frr-isisd {
         description
           "Log changes to the IS-IS adjacencies in this area.";
       }
-    }
 
-    container mpls-te {
-      presence "Present if MPLS-TE is enabled.";
-      description
-        "Enable MPLS-TE functionality.";
-      leaf router-address {
-        type inet:ipv4-address;
+      container mpls-te {
+        presence "Present if MPLS-TE is enabled.";
         description
-          "Stable IP address of the advertising router.";
+          "Enable MPLS-TE functionality.";
+        leaf router-address {
+          type inet:ipv4-address;
+          description
+            "Stable IP address of the advertising router.";
+        }
       }
     }
   }


### PR DESCRIPTION
 - Change MPLS-TE from global to per Area
 - Add new mpls_te_area structure to area in replacement of global variable
isisMPLS_TE
 - Move mpls-te from global to instance in frr-isisd.yang
 - Change code in isis_te.c, isis_northbound.c, isis_cli.c, isis_pdu.c,
isis_lsp.c and isis_zebra.c accordingly

Note: This the second submission following a revert trying to solve the new SA Warning

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>