### PR TITLE
tools: frr-reload.py stop bouncing peers on bfd timer change

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -742,6 +742,27 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
                         lines_to_add_to_del.append((tmp_ctx_keys, swpx_peergroup))
 
                 '''
+                Changing the bfd timers on neighbors is allowed without doing
+                a delete/add process. Since doing a "no neighbor blah bfd ..."
+                will cause the peer to bounce unnecessarily, just skip the delete
+                and just do the add.
+                '''
+                re_nbr_bfd_timers = re.search(r'neighbor (\S+) bfd (\S+) (\S+) (\S+)', line)
+
+                if re_nbr_bfd_timers:
+                    nbr = re_nbr_bfd_timers.group(1)
+                    bfd_nbr = "neighbor %s" % nbr
+
+                    for (ctx_keys, add_line) in lines_to_add:
+                        re_add_nbr_bfd_timers = re.search(r'neighbor (\S+) bfd (\S+) (\S+) (\S+)', add_line)
+
+                        if re_add_nbr_bfd_timers:
+                            found_add_bfd_nbr = line_exist(lines_to_add, ctx_keys, bfd_nbr, False)
+
+                            if found_add_bfd_nbr:
+                                lines_to_del_to_del.append((ctx_keys, line))
+
+                '''
                 We changed how we display the neighbor interface command. Older
                 versions of frr would display the following:
                     neighbor swp1 interface


### PR DESCRIPTION
Problem reported that if a bgp neighbor had a bfd timer change
made in frr.conf and systemctl reload frr performed, the neighbor
with the timer changed bounced.  If the change is made in vtysh
by just adding the new timer values, no peer bounce occurs.  This
fix skips the delete part of the delete/add process in frr-reload
so the peers stay up.

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>