### PR TITLE
pimd: Deletion of a ifchannel does not immediately mean remove from OIL

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -135,9 +135,20 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 		if (ch->upstream->flags & PIM_UPSTREAM_FLAG_MASK_SRC_IGMP)
 			mask = PIM_OIF_FLAG_PROTO_IGMP;
 
-		/* SGRpt entry could have empty oil */
-		pim_channel_del_oif(ch->upstream->channel_oil, ch->interface,
-				    mask);
+		/*
+		 * A S,G RPT channel can have an empty oil, we also
+		 * need to take into account the fact that a ifchannel
+		 * might have been suppressing a *,G ifchannel from
+		 * being inherited.  So let's figure out what
+		 * needs to be done here
+		 */
+		if (pim_upstream_evaluate_join_desired_interface(
+			    ch->upstream, ch, ch->parent))
+			pim_channel_add_oif(ch->upstream->channel_oil,
+					    ch->interface, mask);
+		else
+			pim_channel_del_oif(ch->upstream->channel_oil,
+					    ch->interface, mask);
 		/*
 		 * Do we have any S,G's that are inheriting?
 		 * Nuke from on high too.

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -1305,8 +1305,16 @@ void pim_forward_stop(struct pim_ifchannel *ch, bool install_it)
 			   install_it, up->channel_oil->installed);
 	}
 
-	pim_channel_del_oif(up->channel_oil, ch->interface,
-			    PIM_OIF_FLAG_PROTO_PIM);
+	/*
+	 * If a channel is being removed, check to see if we still need
+	 * to inherit the interface.  If so make sure it is added in
+	 */
+	if (pim_upstream_evaluate_join_desired_interface(up, ch, ch->parent))
+		pim_channel_add_oif(up->channel_oil, ch->interface,
+				    PIM_OIF_FLAG_PROTO_PIM);
+	else
+		pim_channel_del_oif(up->channel_oil, ch->interface,
+				    PIM_OIF_FLAG_PROTO_PIM);
 
 	if (install_it && !up->channel_oil->installed)
 		pim_mroute_add(up->channel_oil, __PRETTY_FUNCTION__);


### PR DESCRIPTION
So when we remove a ifchannel from the system we should check to
see if we still care about the S,G having it in the OIL still
due to inheritance rules.  The deletion does not necessarily
mean it should not be in the OIL for the S,G.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>