### PR TITLE
bgpd: [5.0] Incorrect number of peers count in "show bgp ipv6 summary" output

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7811,7 +7811,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					json, "ribMemory",
 					ents * sizeof(struct bgp_node));
 
-				ents = listcount(bgp->peer);
+				ents = bgp->af_peer_count[afi][safi];
 				json_object_int_add(json, "peerCount", ents);
 				json_object_int_add(json, "peerMemory",
 						    ents * sizeof(struct peer));
@@ -7851,7 +7851,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 								   bgp_node)));
 
 				/* Peer related usage */
-				ents = listcount(bgp->peer);
+				ents = bgp->af_peer_count[afi][safi];
 				vty_out(vty, "Peers %ld, using %s of memory\n",
 					ents,
 					mtype_memstr(

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -369,6 +369,9 @@ struct bgp {
 #define BGP_CONFIG_VRF_TO_VRF_EXPORT			(1 << 8)
 #define BGP_DEFAULT_NAME		"default"
 
+	/* BGP per AF peer count */
+	uint32_t af_peer_count[AFI_MAX][SAFI_MAX];
+
 	/* Route table for next-hop lookup cache. */
 	struct bgp_table *nexthop_cache_table[AFI_MAX];
 


### PR DESCRIPTION
Since topotests for 5 and 6 release include this https://github.com/FRRouting/topotests/pull/147. This change should be cherry-picked in 5 branch as well.

It brokes builds https://ci1.netdef.org/browse/FRR-FRRPULLREQ-TOPOU1804-7388

Fix : Now the peers count displays the number of neighbors activated per afi/safi.

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>