### PR TITLE
zebra: add nexthop information to some FPM messages

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -233,13 +233,6 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 	ri->rtm_table = zvrf_id(rib_dest_vrf(dest));
 	ri->rtm_protocol = RTPROT_UNSPEC;
 
-	/*
-	 * An RTM_DELROUTE need not be accompanied by any nexthops,
-	 * particularly in our communication with the FPM.
-	 */
-	if (cmd == RTM_DELROUTE && !re)
-		return 1;
-
 	if (!re) {
 		zfpm_debug("%s: Expected non-NULL re pointer",
 			   __PRETTY_FUNCTION__);

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -263,7 +263,6 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 				ri->rtm_type = RTN_BLACKHOLE;
 				break;
 			}
-			return 1;
 		}
 
 		if ((cmd == RTM_NEWROUTE


### PR DESCRIPTION
## Summary

This PR wants to add more nexthop information to FPM netlink messages:

  * Send nexthop information on route delete messages;
  * Add blackhole type nexthop peer information to messages;

This is the netlink FPM code import commit which shows that since the beginning we don't add nexthop information to route delete:
https://github.com/FRRouting/frr/commit/5adc2528d386f037cc39e8029616295c3fec2db4#diff-5a8179517459ff1c1eb6a3568aea74e5R299

This commit adds the blackhole information handling which contains (maybe accidental?) code that prevents blackhole nexthop to be informed:
https://github.com/FRRouting/frr/commit/a830942228110cbec0e857d0877d624206627f81#diff-5a8179517459ff1c1eb6a3568aea74e5R272


## Components

`zebra`