### PR TITLE
zebra: Modify how we display/store os description

### DIFF
--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -342,6 +342,9 @@ struct zebra_if {
 	bool v6_2_v4_ll_neigh_entry;
 	char neigh_mac[6];
 	struct in6_addr v6_2_v4_ll_addr6;
+
+	/* The description of the interface */
+	char *desc;
 };
 
 DECLARE_HOOK(zebra_if_extra_info, (struct vty * vty, struct interface *ifp),


### PR DESCRIPTION
The alias/description of an interface in linux was being
used to override the internal description.  As such let's
fix the display to keep track of both if we have it.

Config in FRR:
```
!
interface docker0
 description another combination
!
interface enp3s0
 description BAMBOOZLE ME WILL YOU
!
```
Config in linux:
```
sharpd@robot ~/f/zebra> ip link show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    alias This is the loopback you cabbage
2: enp3s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 74:d0:2b:9c:16:eb brd ff:ff:ff:ff:ff:ff
    alias HI HI HI
```
Now the 'show int descr' command:
```
robot# show int description
Interface       Status  Protocol  Description
docker0         up      down      another combination
enp3s0          up      up        BAMBOOZLE ME WILL YOU
                                  HI HI HI
lo              up      up        This is the loopback you cabbage
```
Fixes: #4191
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>