### PR TITLE
zebra: Fix incorrect reading of REMOTE_VTEP_[ADD|DEL]

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -7858,11 +7858,17 @@ void zebra_vxlan_remote_vtep_del(ZAPI_HANDLER_ARGS)
 	s = msg;
 
 	while (l < hdr->length) {
+		int flood_control;
+
 		/* Obtain each remote VTEP and process. */
 		STREAM_GETL(s, vni);
 		l += 4;
 		STREAM_GET(&vtep_ip.s_addr, s, IPV4_MAX_BYTELEN);
 		l += IPV4_MAX_BYTELEN;
+
+		/* Flood control is intentionally ignored right now */
+		STREAM_GETL(s, flood_control);
+		l += 4;
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("Recv VTEP_DEL %s VNI %u from %s",
@@ -7949,7 +7955,7 @@ void zebra_vxlan_remote_vtep_add(ZAPI_HANDLER_ARGS)
 		l += 4;
 		STREAM_GET(&vtep_ip.s_addr, s, IPV4_MAX_BYTELEN);
 		STREAM_GETL(s, flood_control);
-		l += IPV4_MAX_BYTELEN;
+		l += IPV4_MAX_BYTELEN + 4;
 
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug("Recv VTEP_ADD %s VNI %u flood %d from %s",

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -7858,7 +7858,7 @@ void zebra_vxlan_remote_vtep_del(ZAPI_HANDLER_ARGS)
 	s = msg;
 
 	while (l < hdr->length) {
-		int flood_control;
+		int flood_control __attribute__((unused));
 
 		/* Obtain each remote VTEP and process. */
 		STREAM_GETL(s, vni);


### PR DESCRIPTION
With flooding control added recently we were not properly handling
the new flood control parameter in zebra_vxlan.c handler functions.
The error message that was being repeatedly seen:

2019/05/01 00:47:32 ZEBRA: [EC 100663311] stream_get2: Attempt to get out of bounds
2019/05/01 00:47:32 ZEBRA: [EC 100663311] &(struct stream): 0x7f0f04001740, size: 22, getp: 22, endp: 22

The fix was to ensure that both the _add and _del functions kept proper
sizing of amount of data read *and* the _del function was not
reading the flood_control data from the stream.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>