### PR TITLE
pimd: Stop crash in show of single interface

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1207,6 +1207,8 @@ static void pim_show_interfaces_single(struct pim_instance *pim,
 			print_header = 1;
 			for (ALL_LIST_ELEMENTS_RO(pim->upstream_list, upnode,
 						  up)) {
+				if (!up->rpf.source_nexthop.interface)
+					continue;
 
 				if (strcmp(ifp->name,
 					   up->rpf.source_nexthop


### PR DESCRIPTION
There exists a possiblity that we have upstream data but
at this point in time the rpf failed because there is no
path.  As such the rpf interface will be NULL and we
should not necessarily trust it.  Prevent a crash

Ticket: CM-24857
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>