### PR TITLE
bgpd: Do not advertise a prefix if nexhop address belongs to peer

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -472,6 +472,24 @@ int bgp_nexthop_self(struct bgp *bgp, struct in_addr nh_addr)
 	return 0;
 }
 
+int bgp_nexthop_peer_self(struct update_subgroup *subgrp,
+			  struct in_addr nh_addr)
+{
+	union sockunion nh_su;
+	char *nh_str;
+	struct peer_af *paf;
+
+	nh_str = inet_ntoa(nh_addr);
+	str2sockunion(nh_str, &nh_su);
+
+	SUBGRP_FOREACH_PEER (subgrp, paf) {
+		if (sockunion_cmp(&paf->peer->su, &nh_su) == 0)
+			return 1;
+	}
+
+	return 0;
+}
+
 int bgp_multiaccess_check_v4(struct in_addr nexthop, struct peer *peer)
 {
 	struct bgp_node *rn1;

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -81,6 +81,7 @@ extern int bgp_subgrp_multiaccess_check_v4(struct in_addr nexthop,
 extern int bgp_multiaccess_check_v4(struct in_addr, struct peer *);
 extern int bgp_config_write_scan_time(struct vty *);
 extern int bgp_nexthop_self(struct bgp *, struct in_addr);
+extern int bgp_nexthop_peer_self(struct update_subgroup *, struct in_addr);
 extern struct bgp_nexthop_cache *bnc_new(void);
 extern void bnc_free(struct bgp_nexthop_cache *bnc);
 extern void bnc_nexthop_free(struct bgp_nexthop_cache *bnc);

--- a/tests/topotests/bgp_nexthop_peer_address/r1/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_peer_address/r1/bgpd.conf
@@ -1,0 +1,5 @@
+router bgp 65000
+  neighbor 192.168.255.2 remote-as 65001
+  address-family ipv4 unicast
+    redistribute connected
+    redistribute static

--- a/tests/topotests/bgp_nexthop_peer_address/r1/zebra.conf
+++ b/tests/topotests/bgp_nexthop_peer_address/r1/zebra.conf
@@ -1,0 +1,10 @@
+!
+interface lo
+ ip address 172.16.255.254/32
+!
+interface r1-eth0
+ ip address 192.168.255.1/24
+!
+ip forwarding
+ip route 10.255.255.0/24 192.168.255.2
+!

--- a/tests/topotests/bgp_nexthop_peer_address/r2/bgpd.conf
+++ b/tests/topotests/bgp_nexthop_peer_address/r2/bgpd.conf
@@ -1,0 +1,2 @@
+router bgp 65001
+  neighbor 192.168.255.1 remote-as 65000

--- a/tests/topotests/bgp_nexthop_peer_address/r2/zebra.conf
+++ b/tests/topotests/bgp_nexthop_peer_address/r2/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r2-eth0
+ ip address 192.168.255.2/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_nexthop_peer_address/test_bgp_nexthop_peer_address.py
+++ b/tests/topotests/bgp_nexthop_peer_address/test_bgp_nexthop_peer_address.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+#
+# bgp_nexthop_peer_address.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2019 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+bgp_nexthop_peer_address.py:
+Test if route is not advertised if nexthop belongs to peer.
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+class TemplateTopo(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        for routern in range(1, 3):
+            tgen.add_router('r{}'.format(routern))
+
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
+
+def setup_module(mod):
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA,
+            os.path.join(CWD, '{}/zebra.conf'.format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP,
+            os.path.join(CWD, '{}/bgpd.conf'.format(rname))
+        )
+
+    tgen.start_router()
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_bgp_nexthop_peer_address():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _bgp_converge(router):
+        while True:
+            cmd = "show ip bgp neighbor 192.168.255.2 json"
+            peer = json.loads(tgen.gears[router].vtysh_cmd(cmd))
+            if peer['192.168.255.2']['bgpState'] == 'Established':
+                time.sleep(1)
+                return True
+            time.sleep(1)
+
+    def _bgp_advertised_routes(router):
+        cmd = "show ip bgp neighbor 192.168.255.2 advertised-routes json"
+        output = json.loads(tgen.gears[router].vtysh_cmd(cmd))
+        return output['advertisedRoutes']
+
+
+    if _bgp_converge('r1'):
+        for prefix in _bgp_advertised_routes('r1'):
+            assert prefix != "10.255.255.0"
+
+if __name__ == '__main__':
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
The inbound direction is handled and the route is not accepted if belongs to self.
This update applies to the outbound direction to deny advertisement for a prefix
which is the same as peer's address.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

Related: https://github.com/FRRouting/frr/issues/4135