### PR TITLE
Pimd : S,G Mroute entries are not expiring  even after KAT expiry, remain as stale entries.

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1181,8 +1181,16 @@ struct pim_upstream *pim_upstream_keep_alive_timer_proc(
 				"kat expired on %s[%s]; remove stream reference",
 				up->sg_str, pim->vrf->name);
 		PIM_UPSTREAM_FLAG_UNSET_SRC_STREAM(up->flags);
-		up = pim_upstream_del(pim, up, __PRETTY_FUNCTION__);
-	} else if (PIM_UPSTREAM_FLAG_TEST_SRC_LHR(up->flags)) {
+
+		/* Return if upstream entry got deleted.*/
+		if (!pim_upstream_del(pim, up, __PRETTY_FUNCTION__))
+			return NULL;
+	}
+	/* upstream reference would have been added to track the local
+	 * membership if it is LHR. We have to clear it when KAT expires.
+	 * Otherwise would result in stale entry with uncleared ref count.
+	 */
+	if (PIM_UPSTREAM_FLAG_TEST_SRC_LHR(up->flags)) {
 		struct pim_upstream *parent = up->parent;
 
 		PIM_UPSTREAM_FLAG_UNSET_SRC_LHR(up->flags);


### PR DESCRIPTION
     
Scenario :

Source
|
FHR
| 
RP ------ LHR --- Recv1
  |
Recv2
 
Root case : When RP  acts as a  LHR i.e RP has a local receiver and registed for the same group
Where LHR connected receiver also registered  for the same multicast group.
When RP receives a (s,g) join form LHR , it increments upstream ref count to two  to track the
Local membership as well.
But at the time of KAT expiry in RP , upstream reference  is not being removed  Which is added
to track local membership which is causing to make these entries as stale in RP and FHR.
 
Fix : Made the change such that it removes the upstream reference if it is added to track the
Local memberships.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>