### PR TITLE
doc: Fix failing `make doc`

### DIFF
--- a/doc/developer/subdir.am
+++ b/doc/developer/subdir.am
@@ -40,7 +40,7 @@ dev_RSTFILES = \
 	doc/developer/ospf-sr.rst \
 	doc/developer/ospf.rst \
 	doc/developer/packaging-debian.rst \
-	doc/developer/packaging-redhat.rst
+	doc/developer/packaging-redhat.rst \
 	doc/developer/packaging.rst \
 	doc/developer/testing.rst \
 	doc/developer/topotests-snippets.rst \


### PR DESCRIPTION
This build system bug was introduced with 9251d1f596.

Signed-off-by: Juergen Werner <pogojotz@gmx.net>