### PR TITLE
ZAPI callback args macro

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -66,7 +66,7 @@ static struct cmd_node babel_interface_node =  /* babeld's interface node.    */
 
 
 int
-babel_interface_up (int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf)
+babel_interface_up (ZAPI_CALLBACK_ARGS)
 {
     struct stream *s = NULL;
     struct interface *ifp = NULL;
@@ -74,7 +74,7 @@ babel_interface_up (int cmd, struct zclient *client, zebra_size_t length, vrf_id
     debugf(BABEL_DEBUG_IF, "receive a 'interface up'");
 
     s = zclient->ibuf;
-    ifp = zebra_interface_state_read(s, vrf); /* it updates iflist */
+    ifp = zebra_interface_state_read(s, vrf_id); /* it updates iflist */
 
     if (ifp == NULL) {
         return 0;
@@ -85,7 +85,7 @@ babel_interface_up (int cmd, struct zclient *client, zebra_size_t length, vrf_id
 }
 
 int
-babel_interface_down (int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf)
+babel_interface_down (ZAPI_CALLBACK_ARGS)
 {
     struct stream *s = NULL;
     struct interface *ifp = NULL;
@@ -93,7 +93,7 @@ babel_interface_down (int cmd, struct zclient *client, zebra_size_t length, vrf_
     debugf(BABEL_DEBUG_IF, "receive a 'interface down'");
 
     s = zclient->ibuf;
-    ifp = zebra_interface_state_read(s, vrf); /* it updates iflist */
+    ifp = zebra_interface_state_read(s, vrf_id); /* it updates iflist */
 
     if (ifp == NULL) {
         return 0;
@@ -104,14 +104,14 @@ babel_interface_down (int cmd, struct zclient *client, zebra_size_t length, vrf_
 }
 
 int
-babel_interface_add (int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf)
+babel_interface_add (ZAPI_CALLBACK_ARGS)
 {
     struct interface *ifp = NULL;
 
     debugf(BABEL_DEBUG_IF, "receive a 'interface add'");
 
     /* read and add the interface in the iflist. */
-    ifp = zebra_interface_add_read (zclient->ibuf, vrf);
+    ifp = zebra_interface_add_read (zclient->ibuf, vrf_id);
 
     if (ifp == NULL) {
         return 0;
@@ -122,7 +122,7 @@ babel_interface_add (int cmd, struct zclient *client, zebra_size_t length, vrf_i
 }
 
 int
-babel_interface_delete (int cmd, struct zclient *client, zebra_size_t length, vrf_id_t vrf)
+babel_interface_delete (ZAPI_CALLBACK_ARGS)
 {
     struct interface *ifp;
     struct stream *s;
@@ -130,7 +130,7 @@ babel_interface_delete (int cmd, struct zclient *client, zebra_size_t length, vr
     debugf(BABEL_DEBUG_IF, "receive a 'interface delete'");
 
     s = zclient->ibuf;
-    ifp = zebra_interface_state_read(s, vrf); /* it updates iflist */
+    ifp = zebra_interface_state_read(s, vrf_id); /* it updates iflist */
 
     if (ifp == NULL)
         return 0;
@@ -146,8 +146,7 @@ babel_interface_delete (int cmd, struct zclient *client, zebra_size_t length, vr
 }
 
 int
-babel_interface_address_add (int cmd, struct zclient *client,
-                             zebra_size_t length, vrf_id_t vrf)
+babel_interface_address_add (ZAPI_CALLBACK_ARGS)
 {
     babel_interface_nfo *babel_ifp;
     struct connected *ifc;
@@ -156,7 +155,7 @@ babel_interface_address_add (int cmd, struct zclient *client,
     debugf(BABEL_DEBUG_IF, "receive a 'interface address add'");
 
     ifc = zebra_interface_address_read (ZEBRA_INTERFACE_ADDRESS_ADD,
-                                        zclient->ibuf, vrf);
+                                        zclient->ibuf, vrf_id);
 
     if (ifc == NULL)
         return 0;
@@ -183,8 +182,7 @@ babel_interface_address_add (int cmd, struct zclient *client,
 }
 
 int
-babel_interface_address_delete (int cmd, struct zclient *client,
-                                zebra_size_t length, vrf_id_t vrf)
+babel_interface_address_delete (ZAPI_CALLBACK_ARGS)
 {
     babel_interface_nfo *babel_ifp;
     struct connected *ifc;
@@ -193,7 +191,7 @@ babel_interface_address_delete (int cmd, struct zclient *client,
     debugf(BABEL_DEBUG_IF, "receive a 'interface address delete'");
 
     ifc = zebra_interface_address_read (ZEBRA_INTERFACE_ADDRESS_DELETE,
-                                        zclient->ibuf, vrf);
+                                        zclient->ibuf, vrf_id);
 
     if (ifc == NULL)
         return 0;

--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -56,8 +56,7 @@ static struct {
 
 /* Zebra route add and delete treatment. */
 static int
-babel_zebra_read_route (int command, struct zclient *zclient,
-		        zebra_size_t length, vrf_id_t vrf)
+babel_zebra_read_route (ZAPI_CALLBACK_ARGS)
 {
     struct zapi_route api;
 
@@ -68,7 +67,7 @@ babel_zebra_read_route (int command, struct zclient *zclient,
     if (CHECK_FLAG(api.message, ZAPI_MESSAGE_SRCPFX))
         return 0;
 
-    if (command == ZEBRA_REDISTRIBUTE_ROUTE_ADD) {
+    if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD) {
         babel_route_add(&api);
     } else {
         babel_route_delete(&api);

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -487,9 +487,9 @@ stream_failure:
 	log_error("ptm-del-client: failed to deregister client");
 }
 
-static int bfdd_replay(int cmd, struct zclient *zc, uint16_t len, vrf_id_t vid)
+static int bfdd_replay(ZAPI_CALLBACK_ARGS)
 {
-	struct stream *msg = zc->ibuf;
+	struct stream *msg = zclient->ibuf;
 	uint32_t rcmd;
 
 	STREAM_GETL(msg, rcmd);
@@ -590,9 +590,7 @@ static void bfdd_sessions_disable_interface(struct interface *ifp)
 	}
 }
 
-static int bfdd_interface_update(int cmd, struct zclient *zc,
-				 uint16_t len __attribute__((__unused__)),
-				 vrf_id_t vrfid)
+static int bfdd_interface_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -602,7 +600,7 @@ static int bfdd_interface_update(int cmd, struct zclient *zc,
 	 * rolling our own.
 	 */
 	if (cmd == ZEBRA_INTERFACE_ADD) {
-		ifp = zebra_interface_add_read(zc->ibuf, vrfid);
+		ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
 		if (ifp == NULL)
 			return 0;
 
@@ -611,7 +609,7 @@ static int bfdd_interface_update(int cmd, struct zclient *zc,
 	}
 
 	/* Update interface information. */
-	ifp = zebra_interface_state_read(zc->ibuf, vrfid);
+	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
 	if (ifp == NULL)
 		return 0;
 
@@ -622,16 +620,12 @@ static int bfdd_interface_update(int cmd, struct zclient *zc,
 	return 0;
 }
 
-static int bfdd_interface_vrf_update(int command __attribute__((__unused__)),
-				     struct zclient *zclient,
-				     zebra_size_t length
-				     __attribute__((__unused__)),
-				     vrf_id_t vrfid)
+static int bfdd_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	vrf_id_t nvrfid;
 
-	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrfid, &nvrfid);
+	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrf_id, &nvrfid);
 	if (ifp == NULL)
 		return 0;
 
@@ -666,14 +660,11 @@ static void bfdd_sessions_enable_address(struct connected *ifc)
 	}
 }
 
-static int bfdd_interface_address_update(int cmd, struct zclient *zc,
-					 zebra_size_t len
-					 __attribute__((__unused__)),
-					 vrf_id_t vrfid)
+static int bfdd_interface_address_update(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 
-	ifc = zebra_interface_address_read(cmd, zc->ibuf, vrfid);
+	ifc = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 	if (ifc == NULL)
 		return 0;
 

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -234,8 +234,7 @@ static void bgp_bfd_update_type(struct peer *peer)
  * bgp_bfd_dest_replay - Replay all the peers that have BFD enabled
  *                       to zebra
  */
-static int bgp_bfd_dest_replay(int command, struct zclient *client,
-			       zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_bfd_dest_replay(ZAPI_CALLBACK_ARGS)
 {
 	struct listnode *mnode, *node, *nnode;
 	struct bgp *bgp;
@@ -294,8 +293,7 @@ static void bgp_bfd_peer_status_update(struct peer *peer, int status)
  *                       has changed and bring down the peer
  *                       connectivity if the BFD session went down.
  */
-static int bgp_bfd_dest_update(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_bfd_dest_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct prefix dp;

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -83,8 +83,7 @@ static inline int bgp_install_info_to_zebra(struct bgp *bgp)
 int zclient_num_connects;
 
 /* Router-id update message from zebra. */
-static int bgp_router_id_update(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_router_id_update(ZAPI_CALLBACK_ARGS)
 {
 	struct prefix router_id;
 
@@ -101,17 +100,15 @@ static int bgp_router_id_update(int command, struct zclient *zclient,
 }
 
 /* Nexthop update message from zebra. */
-static int bgp_read_nexthop_update(int command, struct zclient *zclient,
-				   zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_read_nexthop_update(ZAPI_CALLBACK_ARGS)
 {
-	bgp_parse_nexthop_update(command, vrf_id);
+	bgp_parse_nexthop_update(cmd, vrf_id);
 	return 0;
 }
 
-static int bgp_read_import_check_update(int command, struct zclient *zclient,
-					zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_read_import_check_update(ZAPI_CALLBACK_ARGS)
 {
-	bgp_parse_nexthop_update(command, vrf_id);
+	bgp_parse_nexthop_update(cmd, vrf_id);
 	return 0;
 }
 
@@ -206,8 +203,7 @@ static void bgp_nbr_connected_delete(struct bgp *bgp, struct nbr_connected *ifc,
 }
 
 /* Inteface addition message from zebra. */
-static int bgp_interface_add(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct bgp *bgp;
@@ -229,8 +225,7 @@ static int bgp_interface_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int bgp_interface_delete(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_interface_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -255,8 +250,7 @@ static int bgp_interface_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int bgp_interface_up(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_interface_up(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -290,8 +284,7 @@ static int bgp_interface_up(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int bgp_interface_down(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_interface_down(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -350,15 +343,14 @@ static int bgp_interface_down(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int bgp_interface_address_add(int command, struct zclient *zclient,
-				     zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_interface_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 	struct bgp *bgp;
 
 	bgp = bgp_lookup_by_vrf_id(vrf_id);
 
-	ifc = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	ifc = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (ifc == NULL)
 		return 0;
@@ -388,15 +380,14 @@ static int bgp_interface_address_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int bgp_interface_address_delete(int command, struct zclient *zclient,
-					zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 	struct bgp *bgp;
 
 	bgp = bgp_lookup_by_vrf_id(vrf_id);
 
-	ifc = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	ifc = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (ifc == NULL)
 		return 0;
@@ -417,13 +408,12 @@ static int bgp_interface_address_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int bgp_interface_nbr_address_add(int command, struct zclient *zclient,
-					 zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_interface_nbr_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct nbr_connected *ifc = NULL;
 	struct bgp *bgp;
 
-	ifc = zebra_interface_nbr_address_read(command, zclient->ibuf, vrf_id);
+	ifc = zebra_interface_nbr_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (ifc == NULL)
 		return 0;
@@ -444,15 +434,12 @@ static int bgp_interface_nbr_address_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int bgp_interface_nbr_address_delete(int command,
-					    struct zclient *zclient,
-					    zebra_size_t length,
-					    vrf_id_t vrf_id)
+static int bgp_interface_nbr_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct nbr_connected *ifc = NULL;
 	struct bgp *bgp;
 
-	ifc = zebra_interface_nbr_address_read(command, zclient->ibuf, vrf_id);
+	ifc = zebra_interface_nbr_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (ifc == NULL)
 		return 0;
@@ -476,8 +463,7 @@ static int bgp_interface_nbr_address_delete(int command,
 }
 
 /* VRF update for an interface. */
-static int bgp_interface_vrf_update(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	vrf_id_t new_vrf_id;
@@ -532,8 +518,7 @@ static int bgp_interface_vrf_update(int command, struct zclient *zclient,
 }
 
 /* Zebra route add and delete treatment. */
-static int zebra_read_route(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+static int zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	enum nexthop_types_t nhtype;
 	struct zapi_route api;
@@ -562,7 +547,7 @@ static int zebra_read_route(int command, struct zclient *zclient,
 	ifindex = api.nexthops[0].ifindex;
 	nhtype = api.nexthops[0].type;
 
-	add = (command == ZEBRA_REDISTRIBUTE_ROUTE_ADD);
+	add = (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD);
 	if (add) {
 		/*
 		 * The ADD message is actually an UPDATE and there is no
@@ -2101,8 +2086,7 @@ int bgp_zebra_dup_addr_detection(struct bgp *bgp)
 	return zclient_send_message(zclient);
 }
 
-static int rule_notify_owner(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+static int rule_notify_owner(ZAPI_CALLBACK_ARGS)
 {
 	uint32_t seqno, priority, unique;
 	enum zapi_rule_notify_owner note;
@@ -2171,8 +2155,7 @@ static int rule_notify_owner(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ipset_notify_owner(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+static int ipset_notify_owner(ZAPI_CALLBACK_ARGS)
 {
 	uint32_t unique;
 	enum zapi_ipset_notify_owner note;
@@ -2217,8 +2200,7 @@ static int ipset_notify_owner(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ipset_entry_notify_owner(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int ipset_entry_notify_owner(ZAPI_CALLBACK_ARGS)
 {
 	uint32_t unique;
 	char ipset_name[ZEBRA_IPSET_NAME_SIZE];
@@ -2275,8 +2257,7 @@ static int ipset_entry_notify_owner(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int iptable_notify_owner(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int iptable_notify_owner(ZAPI_CALLBACK_ARGS)
 {
 	uint32_t unique;
 	enum zapi_iptable_notify_owner note;
@@ -2322,7 +2303,7 @@ static int iptable_notify_owner(int command, struct zclient *zclient,
 
 /* this function is used to forge ip rule,
  * - either for iptable/ipset using fwmark id
- * - or for sample ip rule command
+ * - or for sample ip rule cmd
  */
 static void bgp_encode_pbr_rule_action(struct stream *s,
 				       struct bgp_pbr_action *pbra,
@@ -2470,8 +2451,7 @@ static void bgp_zebra_connected(struct zclient *zclient)
 	 */
 }
 
-static int bgp_zebra_process_local_es(int cmd, struct zclient *zclient,
-				      zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_zebra_process_local_es(ZAPI_CALLBACK_ARGS)
 {
 	esi_t esi;
 	struct bgp *bgp = NULL;
@@ -2504,8 +2484,7 @@ static int bgp_zebra_process_local_es(int cmd, struct zclient *zclient,
 	return 0;
 }
 
-static int bgp_zebra_process_local_l3vni(int cmd, struct zclient *zclient,
-					 zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_zebra_process_local_l3vni(ZAPI_CALLBACK_ARGS)
 {
 	int filter = 0;
 	char buf[ETHER_ADDR_STRLEN];
@@ -2545,8 +2524,7 @@ static int bgp_zebra_process_local_l3vni(int cmd, struct zclient *zclient,
 	return 0;
 }
 
-static int bgp_zebra_process_local_vni(int command, struct zclient *zclient,
-				       zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_zebra_process_local_vni(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	vni_t vni;
@@ -2557,7 +2535,7 @@ static int bgp_zebra_process_local_vni(int command, struct zclient *zclient,
 
 	s = zclient->ibuf;
 	vni = stream_getl(s);
-	if (command == ZEBRA_VNI_ADD) {
+	if (cmd == ZEBRA_VNI_ADD) {
 		vtep_ip.s_addr = stream_get_ipv4(s);
 		stream_get(&tenant_vrf_id, s, sizeof(vrf_id_t));
 		mcast_grp.s_addr = stream_get_ipv4(s);
@@ -2569,11 +2547,11 @@ static int bgp_zebra_process_local_vni(int command, struct zclient *zclient,
 
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("Rx VNI %s VRF %s VNI %u tenant-vrf %s",
-			   (command == ZEBRA_VNI_ADD) ? "add" : "del",
+			   (cmd == ZEBRA_VNI_ADD) ? "add" : "del",
 			   vrf_id_to_name(vrf_id), vni,
 			   vrf_id_to_name(tenant_vrf_id));
 
-	if (command == ZEBRA_VNI_ADD)
+	if (cmd == ZEBRA_VNI_ADD)
 		return bgp_evpn_local_vni_add(
 			bgp, vni, vtep_ip.s_addr ? vtep_ip : bgp->router_id,
 			tenant_vrf_id, mcast_grp);
@@ -2581,8 +2559,7 @@ static int bgp_zebra_process_local_vni(int command, struct zclient *zclient,
 		return bgp_evpn_local_vni_del(bgp, vni);
 }
 
-static int bgp_zebra_process_local_macip(int command, struct zclient *zclient,
-					 zebra_size_t length, vrf_id_t vrf_id)
+static int bgp_zebra_process_local_macip(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	vni_t vni;
@@ -2605,7 +2582,7 @@ static int bgp_zebra_process_local_macip(int command, struct zclient *zclient,
 	    && ipa_len != IPV6_MAX_BYTELEN) {
 		flog_err(EC_BGP_MACIP_LEN,
 			 "%u:Recv MACIP %s with invalid IP addr length %d",
-			 vrf_id, (command == ZEBRA_MACIP_ADD) ? "Add" : "Del",
+			 vrf_id, (cmd == ZEBRA_MACIP_ADD) ? "Add" : "Del",
 			 ipa_len);
 		return -1;
 	}
@@ -2615,7 +2592,7 @@ static int bgp_zebra_process_local_macip(int command, struct zclient *zclient,
 			(ipa_len == IPV4_MAX_BYTELEN) ? IPADDR_V4 : IPADDR_V6;
 		stream_get(&ip.ip.addr, s, ipa_len);
 	}
-	if (command == ZEBRA_MACIP_ADD) {
+	if (cmd == ZEBRA_MACIP_ADD) {
 		flags = stream_getc(s);
 		seqnum = stream_getl(s);
 	} else {
@@ -2628,21 +2605,19 @@ static int bgp_zebra_process_local_macip(int command, struct zclient *zclient,
 
 	if (BGP_DEBUG(zebra, ZEBRA))
 		zlog_debug("%u:Recv MACIP %s flags 0x%x MAC %s IP %s VNI %u seq %u state %d",
-			   vrf_id, (command == ZEBRA_MACIP_ADD) ? "Add" : "Del",
+			   vrf_id, (cmd == ZEBRA_MACIP_ADD) ? "Add" : "Del",
 			   flags, prefix_mac2str(&mac, buf, sizeof(buf)),
 			   ipaddr2str(&ip, buf1, sizeof(buf1)), vni, seqnum,
 			   state);
 
-	if (command == ZEBRA_MACIP_ADD)
+	if (cmd == ZEBRA_MACIP_ADD)
 		return bgp_evpn_local_macip_add(bgp, vni, &mac, &ip,
 						flags, seqnum);
 	else
 		return bgp_evpn_local_macip_del(bgp, vni, &mac, &ip, state);
 }
 
-static void bgp_zebra_process_local_ip_prefix(int cmd, struct zclient *zclient,
-					      zebra_size_t length,
-					      vrf_id_t vrf_id)
+static void bgp_zebra_process_local_ip_prefix(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s = NULL;
 	struct bgp *bgp_vrf = NULL;
@@ -2682,11 +2657,7 @@ static void bgp_zebra_process_local_ip_prefix(int cmd, struct zclient *zclient,
 	}
 }
 
-static void bgp_zebra_process_label_chunk(
-	int cmd,
-	struct zclient *zclient,
-	zebra_size_t length,
-	vrf_id_t vrf_id)
+static void bgp_zebra_process_label_chunk(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s = NULL;
 	uint8_t response_keep;

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -344,8 +344,7 @@ static void vnc_redistribute_withdraw(struct bgp *bgp, afi_t afi, uint8_t type)
  *
  * Assumes 1 nexthop
  */
-static int vnc_zebra_read_route(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int vnc_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route api;
 	int add;
@@ -357,7 +356,7 @@ static int vnc_zebra_read_route(int command, struct zclient *zclient,
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_SRCPFX))
 		return 0;
 
-	add = (command == ZEBRA_REDISTRIBUTE_ROUTE_ADD);
+	add = (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD);
 	if (add)
 		vnc_redistribute_add(&api.prefix, api.metric, api.type);
 	else

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -53,21 +53,15 @@
 #include "eigrpd/eigrp_topology.h"
 #include "eigrpd/eigrp_fsm.h"
 
-static int eigrp_interface_add(int, struct zclient *, zebra_size_t, vrf_id_t);
-static int eigrp_interface_delete(int, struct zclient *, zebra_size_t,
-				  vrf_id_t);
-static int eigrp_interface_address_add(int, struct zclient *, zebra_size_t,
-				       vrf_id_t vrf_id);
-static int eigrp_interface_address_delete(int, struct zclient *, zebra_size_t,
-					  vrf_id_t vrf_id);
-static int eigrp_interface_state_up(int, struct zclient *, zebra_size_t,
-				    vrf_id_t vrf_id);
-static int eigrp_interface_state_down(int, struct zclient *, zebra_size_t,
-				      vrf_id_t vrf_id);
+static int eigrp_interface_add(ZAPI_CALLBACK_ARGS);
+static int eigrp_interface_delete(ZAPI_CALLBACK_ARGS);
+static int eigrp_interface_address_add(ZAPI_CALLBACK_ARGS);
+static int eigrp_interface_address_delete(ZAPI_CALLBACK_ARGS);
+static int eigrp_interface_state_up(ZAPI_CALLBACK_ARGS);
+static int eigrp_interface_state_down(ZAPI_CALLBACK_ARGS);
 static struct interface *zebra_interface_if_lookup(struct stream *);
 
-static int eigrp_zebra_read_route(int, struct zclient *, zebra_size_t,
-				  vrf_id_t vrf_id);
+static int eigrp_zebra_read_route(ZAPI_CALLBACK_ARGS);
 
 /* Zebra structure to hold current status. */
 struct zclient *zclient = NULL;
@@ -77,8 +71,7 @@ extern struct thread_master *master;
 struct in_addr router_id_zebra;
 
 /* Router-id update message from zebra. */
-static int eigrp_router_id_update_zebra(int command, struct zclient *zclient,
-					zebra_size_t length, vrf_id_t vrf_id)
+static int eigrp_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 {
 	struct eigrp *eigrp;
 	struct prefix router_id;
@@ -94,8 +87,7 @@ static int eigrp_router_id_update_zebra(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int eigrp_zebra_route_notify_owner(int command, struct zclient *zclient,
-					  zebra_size_t length, vrf_id_t vrf_id)
+static int eigrp_zebra_route_notify_owner(ZAPI_CALLBACK_ARGS)
 {
 	struct prefix p;
 	enum zapi_route_notify_owner note;
@@ -134,8 +126,7 @@ void eigrp_zebra_init(void)
 
 
 /* Zebra route add and delete treatment. */
-static int eigrp_zebra_read_route(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+static int eigrp_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route api;
 	struct eigrp *eigrp;
@@ -150,9 +141,9 @@ static int eigrp_zebra_read_route(int command, struct zclient *zclient,
 	if (eigrp == NULL)
 		return 0;
 
-	if (command == ZEBRA_REDISTRIBUTE_ROUTE_ADD) {
+	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD) {
 
-	} else /* if (command == ZEBRA_REDISTRIBUTE_ROUTE_DEL) */
+	} else /* if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_DEL) */
 	{
 	}
 
@@ -160,8 +151,7 @@ static int eigrp_zebra_read_route(int command, struct zclient *zclient,
 }
 
 /* Inteface addition message from zebra. */
-static int eigrp_interface_add(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+static int eigrp_interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct eigrp_interface *ei;
@@ -180,8 +170,7 @@ static int eigrp_interface_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int eigrp_interface_delete(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+static int eigrp_interface_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -211,12 +200,11 @@ static int eigrp_interface_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int eigrp_interface_address_add(int command, struct zclient *zclient,
-				       zebra_size_t length, vrf_id_t vrf_id)
+static int eigrp_interface_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 
-	c = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (c == NULL)
 		return 0;
@@ -233,14 +221,13 @@ static int eigrp_interface_address_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int eigrp_interface_address_delete(int command, struct zclient *zclient,
-					  zebra_size_t length, vrf_id_t vrf_id)
+static int eigrp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	struct interface *ifp;
 	struct eigrp_interface *ei;
 
-	c = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (c == NULL)
 		return 0;
@@ -266,8 +253,7 @@ static int eigrp_interface_address_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int eigrp_interface_state_up(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int eigrp_interface_state_up(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -323,8 +309,7 @@ static int eigrp_interface_state_up(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int eigrp_interface_state_down(int command, struct zclient *zclient,
-				      zebra_size_t length, vrf_id_t vrf_id)
+static int eigrp_interface_state_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -92,8 +92,7 @@ static void bfd_adj_event(struct isis_adjacency *adj, struct prefix *dst,
 	isis_adj_state_change(adj, ISIS_ADJ_DOWN, "bfd session went down");
 }
 
-static int isis_bfd_interface_dest_update(int command, struct zclient *zclient,
-					  zebra_size_t length, vrf_id_t vrf_id)
+static int isis_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct prefix dst_ip;
@@ -138,8 +137,7 @@ static int isis_bfd_interface_dest_update(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int isis_bfd_nbr_replay(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+static int isis_bfd_nbr_replay(ZAPI_CALLBACK_ARGS)
 {
 	bfd_client_sendmsg(zclient, ZEBRA_BFD_CLIENT_REGISTER);
 

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -53,8 +53,7 @@
 struct zclient *zclient = NULL;
 
 /* Router-id update message from zebra. */
-static int isis_router_id_update_zebra(int command, struct zclient *zclient,
-				       zebra_size_t length, vrf_id_t vrf_id)
+static int isis_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 {
 	struct isis_area *area;
 	struct listnode *node;
@@ -72,8 +71,7 @@ static int isis_router_id_update_zebra(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int isis_zebra_if_add(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+static int isis_zebra_if_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -86,8 +84,7 @@ static int isis_zebra_if_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int isis_zebra_if_del(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+static int isis_zebra_if_del(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -113,8 +110,7 @@ static int isis_zebra_if_del(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int isis_zebra_if_state_up(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+static int isis_zebra_if_state_up(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -128,8 +124,7 @@ static int isis_zebra_if_state_up(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int isis_zebra_if_state_down(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int isis_zebra_if_state_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct isis_circuit *circuit;
@@ -147,8 +142,7 @@ static int isis_zebra_if_state_down(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int isis_zebra_if_address_add(int command, struct zclient *zclient,
-				     zebra_size_t length, vrf_id_t vrf_id)
+static int isis_zebra_if_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	struct prefix *p;
@@ -175,8 +169,7 @@ static int isis_zebra_if_address_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int isis_zebra_if_address_del(int command, struct zclient *client,
-				     zebra_size_t length, vrf_id_t vrf_id)
+static int isis_zebra_if_address_del(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	struct interface *ifp;
@@ -210,8 +203,7 @@ static int isis_zebra_if_address_del(int command, struct zclient *client,
 	return 0;
 }
 
-static int isis_zebra_link_params(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+static int isis_zebra_link_params(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -346,8 +338,7 @@ void isis_zebra_route_update(struct prefix *prefix,
 		isis_zebra_route_del_route(prefix, src_p, route_info);
 }
 
-static int isis_zebra_read(int command, struct zclient *zclient,
-			   zebra_size_t length, vrf_id_t vrf_id)
+static int isis_zebra_read(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route api;
 
@@ -367,10 +358,10 @@ static int isis_zebra_read(int command, struct zclient *zclient,
 	if (api.prefix.prefixlen == 0
 	    && api.src_prefix.prefixlen == 0
 	    && api.type == PROTO_TYPE) {
-		command = ZEBRA_REDISTRIBUTE_ROUTE_DEL;
+		cmd = ZEBRA_REDISTRIBUTE_ROUTE_DEL;
 	}
 
-	if (command == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
+	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
 		isis_redist_add(api.type, &api.prefix, &api.src_prefix,
 				api.distance, api.metric);
 	else

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2371,9 +2371,7 @@ int zebra_send_pw(struct zclient *zclient, int command, struct zapi_pw *pw)
 /*
  * Receive PW status update from Zebra and send it to LDE process.
  */
-void zebra_read_pw_status_update(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id,
-				 struct zapi_pw_status *pw)
+void zebra_read_pw_status_update(ZAPI_CALLBACK_ARGS, struct zapi_pw_status *pw)
 {
 	struct stream *s;
 
@@ -2386,8 +2384,7 @@ void zebra_read_pw_status_update(int command, struct zclient *zclient,
 	pw->status = stream_getl(s);
 }
 
-static void zclient_capability_decode(int command, struct zclient *zclient,
-				      zebra_size_t length, vrf_id_t vrf_id)
+static void zclient_capability_decode(ZAPI_CALLBACK_ARGS)
 {
 	struct zclient_capabilities cap;
 	struct stream *s = zclient->ibuf;

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -221,66 +221,49 @@ struct zclient {
 	/* Redistribute defauilt. */
 	vrf_bitmap_t default_information[AFI_MAX];
 
+#define ZAPI_CALLBACK_ARGS                                                     \
+	int cmd, struct zclient *zclient, uint16_t length, vrf_id_t vrf_id
+
 	/* Pointer to the callback functions. */
 	void (*zebra_connected)(struct zclient *);
 	void (*zebra_capabilities)(struct zclient_capabilities *cap);
-	int (*router_id_update)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_add)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_delete)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_up)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_down)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_address_add)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_address_delete)(int, struct zclient *, uint16_t,
-					vrf_id_t);
-	int (*interface_link_params)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*interface_bfd_dest_update)(int, struct zclient *, uint16_t,
-					 vrf_id_t);
-	int (*interface_nbr_address_add)(int, struct zclient *, uint16_t,
-					 vrf_id_t);
-	int (*interface_nbr_address_delete)(int, struct zclient *, uint16_t,
-					    vrf_id_t);
-	int (*interface_vrf_update)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*nexthop_update)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*import_check_update)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*bfd_dest_replay)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*redistribute_route_add)(int, struct zclient *, uint16_t,
-				      vrf_id_t);
-	int (*redistribute_route_del)(int, struct zclient *, uint16_t,
-				      vrf_id_t);
+	int (*router_id_update)(ZAPI_CALLBACK_ARGS);
+	int (*interface_add)(ZAPI_CALLBACK_ARGS);
+	int (*interface_delete)(ZAPI_CALLBACK_ARGS);
+	int (*interface_up)(ZAPI_CALLBACK_ARGS);
+	int (*interface_down)(ZAPI_CALLBACK_ARGS);
+	int (*interface_address_add)(ZAPI_CALLBACK_ARGS);
+	int (*interface_address_delete)(ZAPI_CALLBACK_ARGS);
+	int (*interface_link_params)(ZAPI_CALLBACK_ARGS);
+	int (*interface_bfd_dest_update)(ZAPI_CALLBACK_ARGS);
+	int (*interface_nbr_address_add)(ZAPI_CALLBACK_ARGS);
+	int (*interface_nbr_address_delete)(ZAPI_CALLBACK_ARGS);
+	int (*interface_vrf_update)(ZAPI_CALLBACK_ARGS);
+	int (*nexthop_update)(ZAPI_CALLBACK_ARGS);
+	int (*import_check_update)(ZAPI_CALLBACK_ARGS);
+	int (*bfd_dest_replay)(ZAPI_CALLBACK_ARGS);
+	int (*redistribute_route_add)(ZAPI_CALLBACK_ARGS);
+	int (*redistribute_route_del)(ZAPI_CALLBACK_ARGS);
 	int (*fec_update)(int, struct zclient *, uint16_t);
-	int (*local_es_add)(int command, struct zclient *zclient,
-			    uint16_t length, vrf_id_t vrf_id);
-	int (*local_es_del)(int command, struct zclient *zclient,
-			    uint16_t length, vrf_id_t vrf_id);
-	int (*local_vni_add)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*local_vni_del)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*local_l3vni_add)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*local_l3vni_del)(int, struct zclient *, uint16_t, vrf_id_t);
-	void (*local_ip_prefix_add)(int, struct zclient *, uint16_t, vrf_id_t);
-	void (*local_ip_prefix_del)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*local_macip_add)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*local_macip_del)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*pw_status_update)(int, struct zclient *, uint16_t, vrf_id_t);
-	int (*route_notify_owner)(int command, struct zclient *zclient,
-				  uint16_t length, vrf_id_t vrf_id);
-	int (*rule_notify_owner)(int command, struct zclient *zclient,
-				 uint16_t length, vrf_id_t vrf_id);
-	void (*label_chunk)(int command, struct zclient *zclient,
-				uint16_t length, vrf_id_t vrf_id);
-	int (*ipset_notify_owner)(int command, struct zclient *zclient,
-				 uint16_t length, vrf_id_t vrf_id);
-	int (*ipset_entry_notify_owner)(int command,
-				       struct zclient *zclient,
-				       uint16_t length,
-				       vrf_id_t vrf_id);
-	int (*iptable_notify_owner)(int command,
-				    struct zclient *zclient,
-				    uint16_t length,
-				    vrf_id_t vrf_id);
-	int (*vxlan_sg_add)(int command, struct zclient *client,
-			uint16_t length, vrf_id_t vrf_id);
-	int (*vxlan_sg_del)(int command, struct zclient *client,
-			uint16_t length, vrf_id_t vrf_id_t);
+	int (*local_es_add)(ZAPI_CALLBACK_ARGS);
+	int (*local_es_del)(ZAPI_CALLBACK_ARGS);
+	int (*local_vni_add)(ZAPI_CALLBACK_ARGS);
+	int (*local_vni_del)(ZAPI_CALLBACK_ARGS);
+	int (*local_l3vni_add)(ZAPI_CALLBACK_ARGS);
+	int (*local_l3vni_del)(ZAPI_CALLBACK_ARGS);
+	void (*local_ip_prefix_add)(ZAPI_CALLBACK_ARGS);
+	void (*local_ip_prefix_del)(ZAPI_CALLBACK_ARGS);
+	int (*local_macip_add)(ZAPI_CALLBACK_ARGS);
+	int (*local_macip_del)(ZAPI_CALLBACK_ARGS);
+	int (*pw_status_update)(ZAPI_CALLBACK_ARGS);
+	int (*route_notify_owner)(ZAPI_CALLBACK_ARGS);
+	int (*rule_notify_owner)(ZAPI_CALLBACK_ARGS);
+	void (*label_chunk)(ZAPI_CALLBACK_ARGS);
+	int (*ipset_notify_owner)(ZAPI_CALLBACK_ARGS);
+	int (*ipset_entry_notify_owner)(ZAPI_CALLBACK_ARGS);
+	int (*iptable_notify_owner)(ZAPI_CALLBACK_ARGS);
+	int (*vxlan_sg_add)(ZAPI_CALLBACK_ARGS);
+	int (*vxlan_sg_del)(ZAPI_CALLBACK_ARGS);
 };
 
 /* Zebra API message flag. */

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -580,9 +580,7 @@ extern int tm_release_table_chunk(struct zclient *zclient, uint32_t start,
 
 extern int zebra_send_pw(struct zclient *zclient, int command,
 			 struct zapi_pw *pw);
-extern void zebra_read_pw_status_update(int command, struct zclient *zclient,
-					zebra_size_t length, vrf_id_t vrf_id,
-					struct zapi_pw_status *pw);
+extern void zebra_read_pw_status_update(ZAPI_CALLBACK_ARGS, struct zapi_pw_status *pw);
 
 extern int zclient_route_send(uint8_t, struct zclient *, struct zapi_route *);
 extern int zclient_send_rnh(struct zclient *zclient, int command,

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -296,13 +296,12 @@ void nhrp_interface_update(struct interface *ifp)
 	}
 }
 
-int nhrp_interface_add(int cmd, struct zclient *client, zebra_size_t length,
-		       vrf_id_t vrf_id)
+int nhrp_interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
 	/* read and add the interface in the iflist. */
-	ifp = zebra_interface_add_read(client->ibuf, vrf_id);
+	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
 	if (ifp == NULL)
 		return 0;
 
@@ -315,13 +314,12 @@ int nhrp_interface_add(int cmd, struct zclient *client, zebra_size_t length,
 	return 0;
 }
 
-int nhrp_interface_delete(int cmd, struct zclient *client, zebra_size_t length,
-			  vrf_id_t vrf_id)
+int nhrp_interface_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
 
-	s = client->ibuf;
+	s = zclient->ibuf;
 	ifp = zebra_interface_state_read(s, vrf_id);
 	if (ifp == NULL)
 		return 0;
@@ -335,12 +333,11 @@ int nhrp_interface_delete(int cmd, struct zclient *client, zebra_size_t length,
 	return 0;
 }
 
-int nhrp_interface_up(int cmd, struct zclient *client, zebra_size_t length,
-		      vrf_id_t vrf_id)
+int nhrp_interface_up(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
-	ifp = zebra_interface_state_read(client->ibuf, vrf_id);
+	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
 	if (ifp == NULL)
 		return 0;
 
@@ -350,12 +347,11 @@ int nhrp_interface_up(int cmd, struct zclient *client, zebra_size_t length,
 	return 0;
 }
 
-int nhrp_interface_down(int cmd, struct zclient *client, zebra_size_t length,
-			vrf_id_t vrf_id)
+int nhrp_interface_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
-	ifp = zebra_interface_state_read(client->ibuf, vrf_id);
+	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
 	if (ifp == NULL)
 		return 0;
 
@@ -364,13 +360,12 @@ int nhrp_interface_down(int cmd, struct zclient *client, zebra_size_t length,
 	return 0;
 }
 
-int nhrp_interface_address_add(int cmd, struct zclient *client,
-			       zebra_size_t length, vrf_id_t vrf_id)
+int nhrp_interface_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 	char buf[PREFIX_STRLEN];
 
-	ifc = zebra_interface_address_read(cmd, client->ibuf, vrf_id);
+	ifc = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 	if (ifc == NULL)
 		return 0;
 
@@ -383,13 +378,12 @@ int nhrp_interface_address_add(int cmd, struct zclient *client,
 	return 0;
 }
 
-int nhrp_interface_address_delete(int cmd, struct zclient *client,
-				  zebra_size_t length, vrf_id_t vrf_id)
+int nhrp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 	char buf[PREFIX_STRLEN];
 
-	ifc = zebra_interface_address_read(cmd, client->ibuf, vrf_id);
+	ifc = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 	if (ifc == NULL)
 		return 0;
 

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -184,8 +184,7 @@ void nhrp_route_announce(int add, enum nhrp_cache_type type,
 			   &api);
 }
 
-int nhrp_route_read(int cmd, struct zclient *zclient, zebra_size_t length,
-		    vrf_id_t vrf_id)
+int nhrp_route_read(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route api;
 	struct zapi_nexthop *api_nh;

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -314,18 +314,12 @@ void nhrp_interface_init(void);
 void nhrp_interface_update(struct interface *ifp);
 void nhrp_interface_update_mtu(struct interface *ifp, afi_t afi);
 
-int nhrp_interface_add(int cmd, struct zclient *client, zebra_size_t length,
-		       vrf_id_t vrf_id);
-int nhrp_interface_delete(int cmd, struct zclient *client, zebra_size_t length,
-			  vrf_id_t vrf_id);
-int nhrp_interface_up(int cmd, struct zclient *client, zebra_size_t length,
-		      vrf_id_t vrf_id);
-int nhrp_interface_down(int cmd, struct zclient *client, zebra_size_t length,
-			vrf_id_t vrf_id);
-int nhrp_interface_address_add(int cmd, struct zclient *client,
-			       zebra_size_t length, vrf_id_t vrf_id);
-int nhrp_interface_address_delete(int cmd, struct zclient *client,
-				  zebra_size_t length, vrf_id_t vrf_id);
+int nhrp_interface_add(ZAPI_CALLBACK_ARGS);
+int nhrp_interface_delete(ZAPI_CALLBACK_ARGS);
+int nhrp_interface_up(ZAPI_CALLBACK_ARGS);
+int nhrp_interface_down(ZAPI_CALLBACK_ARGS);
+int nhrp_interface_address_add(ZAPI_CALLBACK_ARGS);
+int nhrp_interface_address_delete(ZAPI_CALLBACK_ARGS);
 
 void nhrp_interface_notify_add(struct interface *ifp, struct notifier_block *n,
 			       notifier_fn_t fn);
@@ -349,8 +343,7 @@ void nhrp_route_update_nhrp(const struct prefix *p, struct interface *ifp);
 void nhrp_route_announce(int add, enum nhrp_cache_type type,
 			 const struct prefix *p, struct interface *ifp,
 			 const union sockunion *nexthop, uint32_t mtu);
-int nhrp_route_read(int command, struct zclient *zclient, zebra_size_t length,
-		    vrf_id_t vrf_id);
+int nhrp_route_read(ZAPI_CALLBACK_ARGS);
 int nhrp_route_get_nexthop(const union sockunion *addr, struct prefix *p,
 			   union sockunion *via, struct interface **ifp);
 enum nhrp_route_type nhrp_route_address(struct interface *in_ifp,

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -138,8 +138,7 @@ static void ospf6_bfd_reg_dereg_all_nbr(struct ospf6_interface *oi, int command)
  * ospf6_bfd_nbr_replay - Replay all the neighbors that have BFD enabled
  *                        to zebra
  */
-static int ospf6_bfd_nbr_replay(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int ospf6_bfd_nbr_replay(ZAPI_CALLBACK_ARGS)
 {
 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
 	struct listnode *node;
@@ -182,8 +181,7 @@ static int ospf6_bfd_nbr_replay(int command, struct zclient *zclient,
  *                                   has changed and bring down the neighbor
  *                                   connectivity if BFD down is received.
  */
-static int ospf6_bfd_interface_dest_update(int command, struct zclient *zclient,
-					   zebra_size_t length, vrf_id_t vrf_id)
+static int ospf6_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct ospf6_interface *oi;

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -48,8 +48,7 @@ unsigned char conf_debug_ospf6_zebra = 0;
 struct zclient *zclient = NULL;
 
 /* Router-id update message from zebra. */
-static int ospf6_router_id_update_zebra(int command, struct zclient *zclient,
-					zebra_size_t length, vrf_id_t vrf_id)
+static int ospf6_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 {
 	struct prefix router_id;
 	struct ospf6 *o = ospf6;
@@ -99,8 +98,7 @@ void ospf6_zebra_no_redistribute(int type)
 }
 
 /* Inteface addition message from zebra. */
-static int ospf6_zebra_if_add(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int ospf6_zebra_if_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -112,8 +110,7 @@ static int ospf6_zebra_if_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ospf6_zebra_if_del(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int ospf6_zebra_if_del(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -132,8 +129,7 @@ static int ospf6_zebra_if_del(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ospf6_zebra_if_state_update(int command, struct zclient *zclient,
-				       zebra_size_t length, vrf_id_t vrf_id)
+static int ospf6_zebra_if_state_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -152,10 +148,7 @@ static int ospf6_zebra_if_state_update(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ospf6_zebra_if_address_update_add(int command,
-					     struct zclient *zclient,
-					     zebra_size_t length,
-					     vrf_id_t vrf_id)
+static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	char buf[128];
@@ -179,10 +172,7 @@ static int ospf6_zebra_if_address_update_add(int command,
 	return 0;
 }
 
-static int ospf6_zebra_if_address_update_delete(int command,
-						struct zclient *zclient,
-						zebra_size_t length,
-						vrf_id_t vrf_id)
+static int ospf6_zebra_if_address_update_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	char buf[128];
@@ -209,8 +199,7 @@ static int ospf6_zebra_if_address_update_delete(int command,
 	return 0;
 }
 
-static int ospf6_zebra_read_route(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+static int ospf6_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route api;
 	unsigned long ifindex;
@@ -240,13 +229,13 @@ static int ospf6_zebra_read_route(int command, struct zclient *zclient,
 
 		zlog_debug(
 			"Zebra Receive route %s: %s %s nexthop %s ifindex %ld tag %" ROUTE_TAG_PRI,
-			(command == ZEBRA_REDISTRIBUTE_ROUTE_ADD ? "add"
-								 : "delete"),
+			(cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD ? "add"
+							     : "delete"),
 			zebra_route_string(api.type), prefixstr, nexthopstr,
 			ifindex, api.tag);
 	}
 
-	if (command == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
+	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
 		ospf6_asbr_redistribute_add(api.type, ifindex, &api.prefix,
 					    api.nexthop_num, nexthop, api.tag);
 	else

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -141,8 +141,7 @@ static int ospf_bfd_reg_dereg_all_nbr(struct interface *ifp, int command)
  * ospf_bfd_nbr_replay - Replay all the neighbors that have BFD enabled
  *                       to zebra
  */
-static int ospf_bfd_nbr_replay(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_bfd_nbr_replay(ZAPI_CALLBACK_ARGS)
 {
 	struct listnode *inode, *node, *onode;
 	struct ospf *ospf;
@@ -195,8 +194,7 @@ static int ospf_bfd_nbr_replay(int command, struct zclient *zclient,
  *                                  connectivity if the BFD status changed to
  *                                  down.
  */
-static int ospf_bfd_interface_dest_update(int command, struct zclient *zclient,
-					  zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct ospf_interface *oi;

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -65,8 +65,7 @@ struct zclient *zclient = NULL;
 extern struct thread_master *master;
 
 /* Router-id update message from zebra. */
-static int ospf_router_id_update_zebra(int command, struct zclient *zclient,
-				       zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 {
 	struct ospf *ospf = NULL;
 	struct prefix router_id;
@@ -99,8 +98,7 @@ static int ospf_router_id_update_zebra(int command, struct zclient *zclient,
 }
 
 /* Inteface addition message from zebra. */
-static int ospf_interface_add(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp = NULL;
 	struct ospf *ospf = NULL;
@@ -138,8 +136,7 @@ static int ospf_interface_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ospf_interface_delete(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_interface_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -181,8 +178,7 @@ static struct interface *zebra_interface_if_lookup(struct stream *s,
 	return if_lookup_by_name(ifname_tmp, vrf_id);
 }
 
-static int ospf_interface_state_up(int command, struct zclient *zclient,
-				   zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_interface_state_up(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct ospf_interface *oi;
@@ -238,8 +234,7 @@ static int ospf_interface_state_up(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ospf_interface_state_down(int command, struct zclient *zclient,
-				     zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_interface_state_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct ospf_interface *oi;
@@ -263,14 +258,13 @@ static int ospf_interface_state_down(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ospf_interface_address_add(int command, struct zclient *zclient,
-				      zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_interface_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	struct ospf *ospf = NULL;
 
 
-	c = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (c == NULL)
 		return 0;
@@ -294,8 +288,7 @@ static int ospf_interface_address_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ospf_interface_address_delete(int command, struct zclient *zclient,
-					 zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	struct interface *ifp;
@@ -303,7 +296,7 @@ static int ospf_interface_address_delete(int command, struct zclient *zclient,
 	struct route_node *rn;
 	struct prefix p;
 
-	c = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (c == NULL)
 		return 0;
@@ -339,8 +332,7 @@ static int ospf_interface_address_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int ospf_interface_link_params(int command, struct zclient *zclient,
-				      zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_interface_link_params(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -356,8 +348,7 @@ static int ospf_interface_link_params(int command, struct zclient *zclient,
 }
 
 /* VRF update for an interface. */
-static int ospf_interface_vrf_update(int command, struct zclient *zclient,
-				     zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp = NULL;
 	vrf_id_t new_vrf_id;
@@ -1003,8 +994,7 @@ void ospf_routemap_unset(struct ospf_redist *red)
 }
 
 /* Zebra route add and delete treatment. */
-static int ospf_zebra_read_route(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+static int ospf_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route api;
 	struct prefix_ipv4 p;
@@ -1047,7 +1037,7 @@ static int ospf_zebra_read_route(int command, struct zclient *zclient,
 			   zebra_route_string(api.type), vrf_id, buf_prefix);
 	}
 
-	if (command == ZEBRA_REDISTRIBUTE_ROUTE_ADD) {
+	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD) {
 		/* XXX|HACK|TODO|FIXME:
 		 * Maybe we should ignore reject/blackhole routes? Testing
 		 * shows that there is no problems though and this is only way
@@ -1108,7 +1098,7 @@ static int ospf_zebra_read_route(int command, struct zclient *zclient,
 				}
 			}
 		}
-	} else /* if (command == ZEBRA_REDISTRIBUTE_ROUTE_DEL) */
+	} else /* if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_DEL) */
 	{
 		ospf_external_info_delete(ospf, rt_type, api.instance, p);
 		if (is_prefix_default(&p))

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -59,8 +59,7 @@ struct pbr_interface *pbr_if_new(struct interface *ifp)
 }
 
 /* Inteface addition message from zebra. */
-static int interface_add(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+static int interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -80,8 +79,7 @@ static int interface_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_delete(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+static int interface_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -102,13 +100,12 @@ static int interface_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_address_add(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+static int interface_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	char buf[PREFIX_STRLEN];
 
-	c = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	DEBUGD(&pbr_dbg_zebra,
 	       "%s: %s added %s", __PRETTY_FUNCTION__, c->ifp->name,
@@ -117,13 +114,12 @@ static int interface_address_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_address_delete(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	char buf[PREFIX_STRLEN];
 
-	c = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (!c)
 		return 0;
@@ -136,8 +132,7 @@ static int interface_address_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_state_up(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int interface_state_up(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -151,8 +146,7 @@ static int interface_state_up(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_state_down(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int interface_state_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -166,8 +160,7 @@ static int interface_state_down(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int route_notify_owner(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int route_notify_owner(ZAPI_CALLBACK_ARGS)
 {
 	struct prefix p;
 	enum zapi_route_notify_owner note;
@@ -212,8 +205,7 @@ static int route_notify_owner(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int rule_notify_owner(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+static int rule_notify_owner(ZAPI_CALLBACK_ARGS)
 {
 	uint32_t seqno, priority, unique;
 	enum zapi_rule_notify_owner note;
@@ -401,8 +393,7 @@ void route_delete(struct pbr_nexthop_group_cache *pnhgc, afi_t afi)
 	}
 }
 
-static int pbr_zebra_nexthop_update(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int pbr_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 {
 	struct zapi_route nhr;
 	char buf[PREFIX2STR_BUFFER];

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -208,8 +208,7 @@ void pim_bfd_if_param_set(struct interface *ifp, uint32_t min_rx,
  *                                  connectivity if the BFD status changed to
  *                                  down.
  */
-static int pim_bfd_interface_dest_update(int command, struct zclient *zclient,
-					 zebra_size_t length, vrf_id_t vrf_id)
+static int pim_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp = NULL;
 	struct pim_interface *pim_ifp = NULL;
@@ -288,8 +287,7 @@ static int pim_bfd_interface_dest_update(int command, struct zclient *zclient,
  * pim_bfd_nbr_replay - Replay all the neighbors that have BFD enabled
  *                       to zebra
  */
-static int pim_bfd_nbr_replay(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int pim_bfd_nbr_replay(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp = NULL;
 	struct pim_interface *pim_ifp = NULL;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -553,8 +553,7 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 
 /* This API is used to parse Registered address nexthop update coming from Zebra
  */
-int pim_parse_nexthop_update(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS)
 {
 	struct nexthop *nexthop;
 	struct nexthop *nhlist_head = NULL;
@@ -581,7 +580,7 @@ int pim_parse_nexthop_update(int command, struct zclient *zclient,
 		return 0;
 	}
 
-	if (command == ZEBRA_NEXTHOP_UPDATE) {
+	if (cmd == ZEBRA_NEXTHOP_UPDATE) {
 		prefix_copy(&rpf.rpf_addr, &nhr.prefix);
 		pnc = pim_nexthop_cache_find(pim, &rpf);
 		if (!pnc) {

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -47,8 +47,7 @@ struct pim_nexthop_cache {
 	struct hash *upstream_hash;
 };
 
-int pim_parse_nexthop_update(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id);
+int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS);
 int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
 			      struct pim_upstream *up, struct rp_info *rp,
 			      struct pim_nexthop_cache *out_pnc);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -54,8 +54,7 @@ static struct zclient *zclient = NULL;
 
 
 /* Router-id update message from zebra. */
-static int pim_router_id_update_zebra(int command, struct zclient *zclient,
-				      zebra_size_t length, vrf_id_t vrf_id)
+static int pim_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 {
 	struct prefix router_id;
 
@@ -64,8 +63,7 @@ static int pim_router_id_update_zebra(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int pim_zebra_if_add(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+static int pim_zebra_if_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct pim_instance *pim;
@@ -126,8 +124,7 @@ static int pim_zebra_if_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int pim_zebra_if_del(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+static int pim_zebra_if_del(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct pim_instance *pim;
@@ -166,8 +163,7 @@ static int pim_zebra_if_del(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int pim_zebra_if_state_up(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+static int pim_zebra_if_state_up(ZAPI_CALLBACK_ARGS)
 {
 	struct pim_instance *pim;
 	struct interface *ifp;
@@ -235,8 +231,7 @@ static int pim_zebra_if_state_up(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int pim_zebra_if_state_down(int command, struct zclient *zclient,
-				   zebra_size_t length, vrf_id_t vrf_id)
+static int pim_zebra_if_state_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -280,8 +275,7 @@ static int pim_zebra_if_state_down(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int pim_zebra_interface_vrf_update(int command, struct zclient *zclient,
-					  zebra_size_t length, vrf_id_t vrf_id)
+static int pim_zebra_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	vrf_id_t new_vrf_id;
@@ -326,8 +320,7 @@ static void dump_if_address(struct interface *ifp)
 }
 #endif
 
-static int pim_zebra_if_address_add(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int pim_zebra_if_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	struct prefix *p;
@@ -342,7 +335,7 @@ static int pim_zebra_if_address_add(int command, struct zclient *zclient,
 	  will add address to interface list by calling
 	  connected_add_by_prefix()
 	*/
-	c = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 	if (!c)
 		return 0;
 
@@ -406,8 +399,7 @@ static int pim_zebra_if_address_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int pim_zebra_if_address_del(int command, struct zclient *client,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int pim_zebra_if_address_del(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	struct prefix *p;
@@ -426,7 +418,7 @@ static int pim_zebra_if_address_del(int command, struct zclient *client,
 	  will remove address from interface list by calling
 	  connected_delete_by_prefix()
 	*/
-	c = zebra_interface_address_read(command, client->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 	if (!c)
 		return 0;
 
@@ -554,8 +546,7 @@ void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 	pim_upstream_update_join_desired(pim, up);
 }
 
-static int pim_zebra_vxlan_sg_proc(int command, struct zclient *zclient,
-		zebra_size_t length, vrf_id_t vrf_id)
+static int pim_zebra_vxlan_sg_proc(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	struct pim_instance *pim;
@@ -577,11 +568,11 @@ static int pim_zebra_vxlan_sg_proc(int command, struct zclient *zclient,
 
 		pim_str_sg_set(&sg, sg_str);
 		zlog_debug("%u:recv SG %s %s", vrf_id,
-			(command == ZEBRA_VXLAN_SG_ADD)?"add":"del",
+			(cmd == ZEBRA_VXLAN_SG_ADD)?"add":"del",
 			sg_str);
 	}
 
-	if (command == ZEBRA_VXLAN_SG_ADD)
+	if (cmd == ZEBRA_VXLAN_SG_ADD)
 		pim_vxlan_sg_add(pim, &sg);
 	else
 		pim_vxlan_sg_del(pim, &sg);

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -344,8 +344,7 @@ int if_check_address(struct rip *rip, struct in_addr addr)
 }
 
 /* Inteface link down message processing. */
-int rip_interface_down(int command, struct zclient *zclient,
-		       zebra_size_t length, vrf_id_t vrf_id)
+int rip_interface_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -372,8 +371,7 @@ int rip_interface_down(int command, struct zclient *zclient,
 }
 
 /* Inteface link up message processing */
-int rip_interface_up(int command, struct zclient *zclient, zebra_size_t length,
-		     vrf_id_t vrf_id)
+int rip_interface_up(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -405,8 +403,7 @@ int rip_interface_up(int command, struct zclient *zclient, zebra_size_t length,
 }
 
 /* Inteface addition message from zebra. */
-int rip_interface_add(int command, struct zclient *zclient, zebra_size_t length,
-		      vrf_id_t vrf_id)
+int rip_interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -436,8 +433,7 @@ int rip_interface_add(int command, struct zclient *zclient, zebra_size_t length,
 	return 0;
 }
 
-int rip_interface_delete(int command, struct zclient *zclient,
-			 zebra_size_t length, vrf_id_t vrf_id)
+int rip_interface_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -468,8 +464,7 @@ int rip_interface_delete(int command, struct zclient *zclient,
 }
 
 /* VRF update for an interface. */
-int rip_interface_vrf_update(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+int rip_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	vrf_id_t new_vrf_id;
@@ -615,8 +610,7 @@ static void rip_apply_address_add(struct connected *ifc)
 				     0);
 }
 
-int rip_interface_address_add(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+int rip_interface_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 	struct prefix *p;
@@ -669,8 +663,7 @@ static void rip_apply_address_del(struct connected *ifc)
 				&address, ifc->ifp->ifindex);
 }
 
-int rip_interface_address_delete(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+int rip_interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 	struct prefix *p;

--- a/ripd/rip_interface.h
+++ b/ripd/rip_interface.h
@@ -30,8 +30,7 @@ extern int rip_interface_address_add(int, struct zclient *, zebra_size_t,
 				     vrf_id_t);
 extern int rip_interface_address_delete(int, struct zclient *, zebra_size_t,
 					vrf_id_t);
-extern int rip_interface_vrf_update(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id);
+extern int rip_interface_vrf_update(ZAPI_CALLBACK_ARGS);
 extern void rip_interface_sync(struct interface *ifp);
 
 #endif /* _QUAGGA_RIP_INTERFACE_H */

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -118,8 +118,7 @@ void rip_zebra_ipv4_delete(struct rip *rip, struct route_node *rp)
 }
 
 /* Zebra route add and delete treatment. */
-static int rip_zebra_read_route(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int rip_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct rip *rip;
 	struct zapi_route api;
@@ -138,11 +137,11 @@ static int rip_zebra_read_route(int command, struct zclient *zclient,
 	nh.ifindex = api.nexthops[0].ifindex;
 
 	/* Then fetch IPv4 prefixes. */
-	if (command == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
+	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
 		rip_redistribute_add(rip, api.type, RIP_ROUTE_REDISTRIBUTE,
 				     (struct prefix_ipv4 *)&api.prefix, &nh,
 				     api.metric, api.distance, api.tag);
-	else if (command == ZEBRA_REDISTRIBUTE_ROUTE_DEL)
+	else if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_DEL)
 		rip_redistribute_delete(rip, api.type, RIP_ROUTE_REDISTRIBUTE,
 					(struct prefix_ipv4 *)&api.prefix,
 					nh.ifindex);

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -193,8 +193,7 @@ static int ripng_if_down(struct interface *ifp)
 }
 
 /* Inteface link up message processing. */
-int ripng_interface_up(int command, struct zclient *zclient,
-		       zebra_size_t length, vrf_id_t vrf_id)
+int ripng_interface_up(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -228,8 +227,7 @@ int ripng_interface_up(int command, struct zclient *zclient,
 }
 
 /* Inteface link down message processing. */
-int ripng_interface_down(int command, struct zclient *zclient,
-			 zebra_size_t length, vrf_id_t vrf_id)
+int ripng_interface_down(ZAPI_CALLBACK_ARGS)
 {
 	struct stream *s;
 	struct interface *ifp;
@@ -255,8 +253,7 @@ int ripng_interface_down(int command, struct zclient *zclient,
 }
 
 /* Inteface addition message from zebra. */
-int ripng_interface_add(int command, struct zclient *zclient,
-			zebra_size_t length, vrf_id_t vrf_id)
+int ripng_interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -281,8 +278,7 @@ int ripng_interface_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-int ripng_interface_delete(int command, struct zclient *zclient,
-			   zebra_size_t length, vrf_id_t vrf_id)
+int ripng_interface_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -313,8 +309,7 @@ int ripng_interface_delete(int command, struct zclient *zclient,
 }
 
 /* VRF update for an interface. */
-int ripng_interface_vrf_update(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+int ripng_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	vrf_id_t new_vrf_id;
@@ -383,8 +378,7 @@ static void ripng_apply_address_add(struct connected *ifc)
 				       ifc->ifp->ifindex, NULL, 0);
 }
 
-int ripng_interface_address_add(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+int ripng_interface_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 	struct prefix *p;
@@ -450,8 +444,7 @@ static void ripng_apply_address_del(struct connected *ifc)
 				  ifc->ifp->ifindex);
 }
 
-int ripng_interface_address_delete(int command, struct zclient *zclient,
-				   zebra_size_t length, vrf_id_t vrf_id)
+int ripng_interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *ifc;
 	struct prefix *p;

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -113,8 +113,7 @@ void ripng_zebra_ipv6_delete(struct ripng *ripng, struct agg_node *rp)
 }
 
 /* Zebra route add and delete treatment. */
-static int ripng_zebra_read_route(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+static int ripng_zebra_read_route(ZAPI_CALLBACK_ARGS)
 {
 	struct ripng *ripng;
 	struct zapi_route api;
@@ -138,7 +137,7 @@ static int ripng_zebra_read_route(int command, struct zclient *zclient,
 	nexthop = api.nexthops[0].gate.ipv6;
 	ifindex = api.nexthops[0].ifindex;
 
-	if (command == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
+	if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD)
 		ripng_redistribute_add(ripng, api.type,
 				       RIPNG_ROUTE_REDISTRIBUTE,
 				       (struct prefix_ipv6 *)&api.prefix,

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -468,20 +468,13 @@ extern int ripng_send_packet(caddr_t buf, int bufsize, struct sockaddr_in6 *to,
 extern void ripng_packet_dump(struct ripng_packet *packet, int size,
 			      const char *sndrcv);
 
-extern int ripng_interface_up(int command, struct zclient *, zebra_size_t,
-			      vrf_id_t);
-extern int ripng_interface_down(int command, struct zclient *, zebra_size_t,
-				vrf_id_t);
-extern int ripng_interface_add(int command, struct zclient *, zebra_size_t,
-			       vrf_id_t);
-extern int ripng_interface_delete(int command, struct zclient *, zebra_size_t,
-				  vrf_id_t);
-extern int ripng_interface_address_add(int command, struct zclient *,
-				       zebra_size_t, vrf_id_t);
-extern int ripng_interface_address_delete(int command, struct zclient *,
-					  zebra_size_t, vrf_id_t);
-extern int ripng_interface_vrf_update(int command, struct zclient *zclient,
-				      zebra_size_t length, vrf_id_t vrf_id);
+extern int ripng_interface_up(ZAPI_CALLBACK_ARGS);
+extern int ripng_interface_down(ZAPI_CALLBACK_ARGS);
+extern int ripng_interface_add(ZAPI_CALLBACK_ARGS);
+extern int ripng_interface_delete(ZAPI_CALLBACK_ARGS);
+extern int ripng_interface_address_add(ZAPI_CALLBACK_ARGS);
+extern int ripng_interface_address_delete(ZAPI_CALLBACK_ARGS);
+extern int ripng_interface_vrf_update(ZAPI_CALLBACK_ARGS);
 extern void ripng_interface_sync(struct interface *ifp);
 
 extern struct ripng *ripng_lookup_by_vrf_id(vrf_id_t vrf_id);

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -58,8 +58,7 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 }
 
 /* Inteface addition message from zebra. */
-static int interface_add(int command, struct zclient *zclient,
-			 zebra_size_t length, vrf_id_t vrf_id)
+static int interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -71,8 +70,7 @@ static int interface_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_delete(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+static int interface_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -90,21 +88,19 @@ static int interface_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_address_add(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+static int interface_address_add(ZAPI_CALLBACK_ARGS)
 {
 
-	zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	return 0;
 }
 
-static int interface_address_delete(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 
-	c = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (!c)
 		return 0;
@@ -113,8 +109,7 @@ static int interface_address_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_state_up(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int interface_state_up(ZAPI_CALLBACK_ARGS)
 {
 
 	zebra_interface_if_lookup(zclient->ibuf);
@@ -122,8 +117,7 @@ static int interface_state_up(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_state_down(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int interface_state_down(ZAPI_CALLBACK_ARGS)
 {
 
 	zebra_interface_state_read(zclient->ibuf, vrf_id);
@@ -202,8 +196,7 @@ static void handle_repeated(bool installed)
 	}
 }
 
-static int route_notify_owner(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int route_notify_owner(ZAPI_CALLBACK_ARGS)
 {
 	struct timeval r;
 	struct prefix p;
@@ -345,8 +338,7 @@ void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id, bool import,
 			  __PRETTY_FUNCTION__);
 }
 
-static int sharp_nexthop_update(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int sharp_nexthop_update(ZAPI_CALLBACK_ARGS)
 {
 	struct sharp_nh_tracker *nht;
 	struct zapi_route nhr;

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -59,8 +59,7 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 }
 
 /* Inteface addition message from zebra. */
-static int interface_add(int command, struct zclient *zclient,
-			       zebra_size_t length, vrf_id_t vrf_id)
+static int interface_add(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -73,8 +72,7 @@ static int interface_add(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_delete(int command, struct zclient *zclient,
-			    zebra_size_t length, vrf_id_t vrf_id)
+static int interface_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct stream *s;
@@ -93,20 +91,18 @@ static int interface_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_address_add(int command, struct zclient *zclient,
-				 zebra_size_t length, vrf_id_t vrf_id)
+static int interface_address_add(ZAPI_CALLBACK_ARGS)
 {
-	zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	return 0;
 }
 
-static int interface_address_delete(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
 
-	c = zebra_interface_address_read(command, zclient->ibuf, vrf_id);
+	c = zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	if (!c)
 		return 0;
@@ -115,8 +111,7 @@ static int interface_address_delete(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_state_up(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int interface_state_up(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
@@ -138,16 +133,14 @@ static int interface_state_up(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int interface_state_down(int command, struct zclient *zclient,
-				zebra_size_t length, vrf_id_t vrf_id)
+static int interface_state_down(ZAPI_CALLBACK_ARGS)
 {
 	zebra_interface_state_read(zclient->ibuf, vrf_id);
 
 	return 0;
 }
 
-static int route_notify_owner(int command, struct zclient *zclient,
-			      zebra_size_t length, vrf_id_t vrf_id)
+static int route_notify_owner(ZAPI_CALLBACK_ARGS)
 {
 	struct prefix p;
 	enum zapi_route_notify_owner note;
@@ -194,8 +187,7 @@ struct static_nht_data {
 	uint8_t nh_num;
 };
 
-static int static_zebra_nexthop_update(int command, struct zclient *zclient,
-				       zebra_size_t length, vrf_id_t vrf_id)
+static int static_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 {
 	struct static_nht_data *nhtd, lookup;
 	struct zapi_route nhr;


### PR DESCRIPTION
Similar to `ZAPI_HANDLER_ARGS` used in Zebra, define and use a macro that defines the arguments given to all (but 3) ZAPI callbacks. Cause it looks like crap right now.

    This macro:
    - Marks ZAPI callbacks for readability
    - Standardizes argument names
    - Makes it simple to add ZAPI arguments in the future
    - Ensures proper types
    - Looks better
    - Shortens function declarations