### PR TITLE
doc, zebra: Remove "table X" command

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -268,14 +268,6 @@ Link Parameters Commands
    for InterASv2 link in OSPF (RFC5392).  Note that this option is not yet
    supported for ISIS (RFC5316).
 
-.. index:: table TABLENO
-.. clicmd:: table TABLENO
-
-   Select the primary kernel routing table to be used. This only works for
-   kernels supporting multiple routing tables (like GNU/Linux 2.2.x and later).
-   After setting TABLENO with this command, static routes defined after this
-   are added to the specified table.
-
 .. index:: ip nht resolve-via-default
 .. clicmd:: ip nht resolve-via-default
 

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -209,8 +209,16 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 		.ifindex = ifp->ifindex,
 		.vrf_id = ifp->vrf_id,
 	};
+	struct zebra_vrf *zvrf;
 	uint32_t metric;
 
+	zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	if (!zvrf) {
+		flog_err(EC_ZEBRA_VRF_NOT_FOUND,
+			 "%s: Received Up for interface but no associated zvrf: %d",
+			 __PRETTY_FUNCTION__, ifp->vrf_id);
+		return;
+	}
 	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_REAL))
 		return;
 
@@ -246,11 +254,11 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 
 	metric = (ifc->metric < (uint32_t)METRIC_MAX) ?
 				ifc->metric : ifp->metric;
-	rib_add(afi, SAFI_UNICAST, ifp->vrf_id, ZEBRA_ROUTE_CONNECT, 0, 0, &p,
-		NULL, &nh, RT_TABLE_MAIN, metric, 0, 0, 0);
+	rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT,
+		0, 0, &p, NULL, &nh, zvrf->table_id, metric, 0, 0, 0);
 
-	rib_add(afi, SAFI_MULTICAST, ifp->vrf_id, ZEBRA_ROUTE_CONNECT, 0, 0, &p,
-		NULL, &nh, RT_TABLE_MAIN, metric, 0, 0, 0);
+	rib_add(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT,
+		0, 0, &p, NULL, &nh, zvrf->table_id, metric, 0, 0, 0);
 
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED) {
 		char buf[PREFIX_STRLEN];
@@ -260,19 +268,19 @@ void connected_up(struct interface *ifp, struct connected *ifc)
 			ifp->vrf_id, ifp->name,
 			prefix2str(&p, buf, sizeof(buf)));
 	}
-	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
+	rib_update(zvrf->vrf->vrf_id, RIB_UPDATE_IF_CHANGE);
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
-	if (ifp->vrf_id == VRF_DEFAULT) {
+	if (zvrf->vrf->vrf_id == VRF_DEFAULT) {
 		if (IS_ZEBRA_DEBUG_MPLS) {
 			char buf[PREFIX_STRLEN];
 
 			zlog_debug(
 				"%u: IF %s IP %s address add/up, scheduling MPLS processing",
-				ifp->vrf_id, ifp->name,
+				zvrf->vrf->vrf_id, ifp->name,
 				prefix2str(&p, buf, sizeof(buf)));
 		}
-		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id), &p);
+		mpls_mark_lsps_for_processing(zvrf, &p);
 	}
 }
 
@@ -377,6 +385,15 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 		.ifindex = ifp->ifindex,
 		.vrf_id = ifp->vrf_id,
 	};
+	struct zebra_vrf *zvrf;
+
+	zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	if (!zvrf) {
+		flog_err(EC_ZEBRA_VRF_NOT_FOUND,
+			 "%s: Received Up for interface but no associated zvrf: %d",
+			 __PRETTY_FUNCTION__, ifp->vrf_id);
+		return;
+	}
 
 	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_REAL))
 		return;
@@ -410,34 +427,34 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 	 * Same logic as for connected_up(): push the changes into the
 	 * head.
 	 */
-	rib_delete(afi, SAFI_UNICAST, ifp->vrf_id, ZEBRA_ROUTE_CONNECT, 0, 0,
-		   &p, NULL, &nh, 0, 0, 0, false);
+	rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT,
+		   0, 0, &p, NULL, &nh, zvrf->table_id, 0, 0, false);
 
-	rib_delete(afi, SAFI_MULTICAST, ifp->vrf_id, ZEBRA_ROUTE_CONNECT, 0, 0,
-		   &p, NULL, &nh, 0, 0, 0, false);
+	rib_delete(afi, SAFI_MULTICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT,
+		   0, 0, &p, NULL, &nh, zvrf->table_id, 0, 0, false);
 
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED) {
 		char buf[PREFIX_STRLEN];
 
 		zlog_debug(
 			"%u: IF %s IP %s address down, scheduling RIB processing",
-			ifp->vrf_id, ifp->name,
+			zvrf->vrf->vrf_id, ifp->name,
 			prefix2str(&p, buf, sizeof(buf)));
 	}
 
-	rib_update(ifp->vrf_id, RIB_UPDATE_IF_CHANGE);
+	rib_update(zvrf->vrf->vrf_id, RIB_UPDATE_IF_CHANGE);
 
 	/* Schedule LSP forwarding entries for processing, if appropriate. */
-	if (ifp->vrf_id == VRF_DEFAULT) {
+	if (zvrf->vrf->vrf_id == VRF_DEFAULT) {
 		if (IS_ZEBRA_DEBUG_MPLS) {
 			char buf[PREFIX_STRLEN];
 
 			zlog_debug(
 				"%u: IF %s IP %s address down, scheduling MPLS processing",
-				ifp->vrf_id, ifp->name,
+				zvrf->vrf->vrf_id, ifp->name,
 				prefix2str(&p, buf, sizeof(buf)));
 		}
-		mpls_mark_lsps_for_processing(vrf_info_lookup(ifp->vrf_id), &p);
+		mpls_mark_lsps_for_processing(zvrf, &p);
 	}
 }
 

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1138,14 +1138,16 @@ void rtm_read(struct rt_msghdr *rtm)
 	 */
 	if (rtm->rtm_type == RTM_CHANGE)
 		rib_delete(afi, SAFI_UNICAST, VRF_DEFAULT, ZEBRA_ROUTE_KERNEL,
-			   0, zebra_flags, &p, NULL, NULL, 0, 0, 0, true);
+			   0, zebra_flags, &p, NULL, NULL, RT_TABLE_MAIN,
+			   0, 0, true);
 	if (rtm->rtm_type == RTM_GET || rtm->rtm_type == RTM_ADD
 	    || rtm->rtm_type == RTM_CHANGE)
 		rib_add(afi, SAFI_UNICAST, VRF_DEFAULT, ZEBRA_ROUTE_KERNEL, 0,
-			zebra_flags, &p, NULL, &nh, 0, 0, 0, 0, 0);
+			zebra_flags, &p, NULL, &nh, RT_TABLE_MAIN, 0, 0, 0, 0);
 	else
 		rib_delete(afi, SAFI_UNICAST, VRF_DEFAULT, ZEBRA_ROUTE_KERNEL,
-			   0, zebra_flags, &p, NULL, &nh, 0, 0, 0, true);
+			   0, zebra_flags, &p, NULL, &nh, RT_TABLE_MAIN,
+			   0, 0, true);
 }
 
 /* Interface function for the kernel routing table updates.  Support

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -612,7 +612,7 @@ int zebra_add_import_table_entry(struct route_node *rn, struct route_entry *re,
 	newre->flags = re->flags;
 	newre->metric = re->metric;
 	newre->mtu = re->mtu;
-	newre->table = zrouter.rtm_table_default;
+	newre->table = 0;
 	newre->nexthop_num = 0;
 	newre->uptime = time(NULL);
 	newre->instance = re->table;
@@ -632,8 +632,8 @@ int zebra_del_import_table_entry(struct route_node *rn, struct route_entry *re)
 	prefix_copy(&p, &rn->p);
 
 	rib_delete(afi, SAFI_UNICAST, re->vrf_id, ZEBRA_ROUTE_TABLE, re->table,
-		   re->flags, &p, NULL, re->ng.nexthop,
-		   zrouter.rtm_table_default, re->metric, re->distance, false);
+		   re->flags, &p, NULL, re->ng.nexthop, 0, re->metric,
+		   re->distance, false);
 
 	return 0;
 }
@@ -647,8 +647,7 @@ int zebra_import_table(afi_t afi, uint32_t table_id, uint32_t distance,
 	struct route_node *rn;
 
 	if (!is_zebra_valid_kernel_table(table_id)
-	    || ((table_id == RT_TABLE_MAIN)
-		|| (table_id == zrouter.rtm_table_default)))
+	    || (table_id == RT_TABLE_MAIN))
 		return (-1);
 
 	if (afi >= AFI_MAX)

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -165,8 +165,7 @@ int is_zebra_valid_kernel_table(uint32_t table_id)
 
 int is_zebra_main_routing_table(uint32_t table_id)
 {
-	if ((table_id == RT_TABLE_MAIN)
-	    || (table_id == zrouter.rtm_table_default))
+	if (table_id == RT_TABLE_MAIN)
 		return 1;
 	return 0;
 }

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -226,7 +226,6 @@ void zebra_router_init(void)
 {
 	zrouter.sequence_num = 0;
 
-	zrouter.rtm_table_default = 0;
 	zrouter.packets_to_process = ZEBRA_ZAPI_PACKETS_TO_PROCESS;
 
 	zebra_vxlan_init();

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -89,9 +89,6 @@ struct zebra_router {
 	/* A sequence number used for tracking routes */
 	_Atomic uint32_t sequence_num;
 
-	/* The default table used for this router */
-	uint32_t rtm_table_default;
-
 	/* rib work queue */
 #define ZEBRA_RIB_PROCESS_HOLD_TIME 10
 #define ZEBRA_RIB_PROCESS_RETRY_TIME 1

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -326,15 +326,13 @@ struct route_table *zebra_vrf_table_with_table_id(afi_t afi, safi_t safi,
 		return NULL;
 
 	if (vrf_id == VRF_DEFAULT) {
-		if (table_id == RT_TABLE_MAIN
-		    || table_id == zrouter.rtm_table_default)
+		if (table_id == RT_TABLE_MAIN)
 			table = zebra_vrf_table(afi, safi, vrf_id);
 		else
 			table = zebra_vrf_other_route_table(afi, table_id,
 							    vrf_id);
 	} else if (vrf_is_backend_netns()) {
-		if (table_id == RT_TABLE_MAIN
-		    || table_id == zrouter.rtm_table_default)
+		if (table_id == RT_TABLE_MAIN)
 			table = zebra_vrf_table(afi, safi, vrf_id);
 		else
 			table = zebra_vrf_other_route_table(afi, table_id,
@@ -452,10 +450,8 @@ struct route_table *zebra_vrf_other_route_table(afi_t afi, uint32_t table_id,
 	if (afi >= AFI_MAX)
 		return NULL;
 
-	if ((table_id != RT_TABLE_MAIN)
-	    && (table_id != zrouter.rtm_table_default)) {
-		if (zvrf->table_id == RT_TABLE_MAIN ||
-		    zvrf->table_id == zrouter.rtm_table_default) {
+	if (table_id != RT_TABLE_MAIN) {
+		if (zvrf->table_id == RT_TABLE_MAIN) {
 			/* this VRF use default table
 			 * so in all cases, it does not use specific table
 			 * so it is possible to configure tables in this VRF

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2556,40 +2556,6 @@ static int config_write_protocol(struct vty *vty)
 	return 1;
 }
 
-#ifdef HAVE_NETLINK
-/* Display default rtm_table for all clients. */
-DEFUN (show_table,
-       show_table_cmd,
-       "show table",
-       SHOW_STR
-       "default routing table to use for all clients\n")
-{
-	vty_out(vty, "table %d\n", zrouter.rtm_table_default);
-	return CMD_SUCCESS;
-}
-
-DEFUN (config_table,
-       config_table_cmd,
-       "table TABLENO",
-       "Configure target kernel routing table\n"
-       "TABLE integer\n")
-{
-	zrouter.rtm_table_default = strtol(argv[1]->arg, (char **)0, 10);
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_config_table,
-       no_config_table_cmd,
-       "no table [TABLENO]",
-       NO_STR
-       "Configure target kernel routing table\n"
-       "TABLE integer\n")
-{
-	zrouter.rtm_table_default = 0;
-	return CMD_SUCCESS;
-}
-#endif
-
 DEFUN (show_zebra,
        show_zebra_cmd,
        "show zebra",
@@ -2833,8 +2799,6 @@ DEFUN (zebra_show_routing_tables_summary,
 /* Table configuration write function. */
 static int config_write_table(struct vty *vty)
 {
-	if (zrouter.rtm_table_default)
-		vty_out(vty, "table %d\n", zrouter.rtm_table_default);
 	return 0;
 }
 
@@ -2937,12 +2901,6 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &ip_forwarding_cmd);
 	install_element(CONFIG_NODE, &no_ip_forwarding_cmd);
 	install_element(ENABLE_NODE, &show_zebra_cmd);
-
-#ifdef HAVE_NETLINK
-	install_element(VIEW_NODE, &show_table_cmd);
-	install_element(CONFIG_NODE, &config_table_cmd);
-	install_element(CONFIG_NODE, &no_config_table_cmd);
-#endif /* HAVE_NETLINK */
 
 	install_element(VIEW_NODE, &show_ipv6_forwarding_cmd);
 	install_element(CONFIG_NODE, &ipv6_forwarding_cmd);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -697,9 +697,6 @@ static struct zserv *zserv_client_create(int sock)
 	pthread_mutex_init(&client->obuf_mtx, NULL);
 	client->wb = buffer_new(0);
 
-	/* Set table number. */
-	client->rtm_table = zrouter.rtm_table_default;
-
 	atomic_store_explicit(&client->connect_time, (uint32_t) monotime(NULL),
 			      memory_order_relaxed);
 
@@ -907,7 +904,6 @@ static void zebra_show_client_detail(struct vty *vty, struct zserv *client)
 
 	vty_out(vty, "------------------------ \n");
 	vty_out(vty, "FD: %d \n", client->sock);
-	vty_out(vty, "Route Table ID: %d \n", client->rtm_table);
 
 	connect_time = (time_t) atomic_load_explicit(&client->connect_time,
 						     memory_order_relaxed);

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -83,9 +83,6 @@ struct zserv {
 	/* Threads for the main pthread */
 	struct thread *t_cleanup;
 
-	/* default routing table this client munges */
-	int rtm_table;
-
 	/* This client's redistribute flag. */
 	struct redist_proto mi_redist[AFI_MAX][ZEBRA_ROUTE_MAX];
 	vrf_bitmap_t redist[AFI_MAX][ZEBRA_ROUTE_MAX];


### PR DESCRIPTION
This command is broken and has been broken since the introduction
of vrf's.  Since no-one has complained it is safe to assume that
there is no call for this specialized linux command.  Remove
from the system with extreme prejudice.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>