### PR TITLE
bgpd: no router bgp cleanup vrf leaked vpn routes

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1597,11 +1597,13 @@ void vrf_import_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp,
 {
 	const char *export_name;
 	vpn_policy_direction_t idir, edir;
-	char *vname;
-	char buf[1000];
+	char *vname, *tmp_name;
+	char buf[RD_ADDRSTRLEN];
 	struct ecommunity *ecom;
 	bool first_export = false;
 	int debug;
+	struct listnode *node;
+	bool is_inst_match = false;
 
 	export_name = to_bgp->name ? to_bgp->name : VRF_DEFAULT_NAME;
 	idir = BGP_VPN_POLICY_DIR_FROMVPN;
@@ -1616,14 +1618,40 @@ void vrf_import_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp,
 	 */
 	vname = (from_bgp->name ? XSTRDUP(MTYPE_TMP, from_bgp->name)
 			       : XSTRDUP(MTYPE_TMP, VRF_DEFAULT_NAME));
+	if (!listcount(to_bgp->vpn_policy[afi].import_vrf))
+		listnode_add(to_bgp->vpn_policy[afi].import_vrf, vname);
+	else {
+		is_inst_match = false;
+		for (ALL_LIST_ELEMENTS_RO(to_bgp->vpn_policy[afi].import_vrf,
+					  node, tmp_name)) {
+			if (strcmp(vname, tmp_name) == 0) {
+				is_inst_match = true;
+				break;
+			}
+		}
+		if (!is_inst_match)
+			listnode_add(to_bgp->vpn_policy[afi].import_vrf,
+					     vname);
+	}
 
-	listnode_add(to_bgp->vpn_policy[afi].import_vrf, vname);
-
-	if (!listcount(from_bgp->vpn_policy[afi].export_vrf))
-		first_export = true;
 	vname = XSTRDUP(MTYPE_TMP, export_name);
-	listnode_add(from_bgp->vpn_policy[afi].export_vrf, vname);
-
+	if (!listcount(from_bgp->vpn_policy[afi].export_vrf)) {
+		first_export = true;
+		listnode_add(from_bgp->vpn_policy[afi].export_vrf,
+					     vname);
+	} else {
+		is_inst_match = false;
+		for (ALL_LIST_ELEMENTS_RO(from_bgp->vpn_policy[afi].export_vrf,
+					  node, tmp_name)) {
+			if (strcmp(vname, tmp_name) == 0) {
+				is_inst_match = true;
+				break;
+			}
+		}
+		if (!is_inst_match)
+			listnode_add(from_bgp->vpn_policy[afi].export_vrf,
+				     vname);
+	}
 	/* Update import RT for current VRF using export RT of the VRF we're
 	 * importing from. First though, make sure "import_vrf" has that
 	 * set.
@@ -1685,7 +1713,7 @@ void vrf_unimport_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp,
 	const char *export_name, *tmp_name;
 	vpn_policy_direction_t idir, edir;
 	char *vname;
-	struct ecommunity *ecom;
+	struct ecommunity *ecom = NULL;
 	struct listnode *node;
 	int debug;
 
@@ -1730,10 +1758,12 @@ void vrf_unimport_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp,
 	if (to_bgp->vpn_policy[afi].import_vrf->count == 0) {
 		UNSET_FLAG(to_bgp->af_flags[afi][safi],
 			   BGP_CONFIG_VRF_TO_VRF_IMPORT);
-		ecommunity_free(&to_bgp->vpn_policy[afi].rtlist[idir]);
+		if (to_bgp->vpn_policy[afi].rtlist[idir])
+			ecommunity_free(&to_bgp->vpn_policy[afi].rtlist[idir]);
 	} else {
 		ecom = from_bgp->vpn_policy[afi].rtlist[edir];
-		ecommunity_del_val(to_bgp->vpn_policy[afi].rtlist[idir],
+		if (ecom)
+			ecommunity_del_val(to_bgp->vpn_policy[afi].rtlist[idir],
 				   (struct ecommunity_val *)ecom->val);
 		vpn_leak_postchange(idir, afi, bgp_get_default(), to_bgp);
 	}
@@ -1766,8 +1796,11 @@ void vrf_unimport_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp,
 	 *
 	 * import_vrf and export_vrf must match in having
 	 * the in/out names as appropriate.
+	 * export_vrf list could have been cleaned up
+	 * as part of no router bgp source instnace.
 	 */
-	assert(vname);
+	if (!vname)
+		return;
 
 	listnode_delete(from_bgp->vpn_policy[afi].export_vrf, vname);
 	XFREE(MTYPE_TMP, vname);
@@ -2452,5 +2485,181 @@ void vpn_leak_postchange_all(void)
 			AFI_IP6,
 			bgp_default,
 			bgp);
+	}
+}
+
+/* When a bgp vrf instance is unconfigured, remove its routes
+ * from the VPN table and this vrf could be importing routes from other
+ * bgp vrf instnaces, unimport them.
+ * VRF X and VRF Y are exporting routes to each other.
+ * When VRF X is deleted, unimport its routes from all target vrfs,
+ * also VRF Y should unimport its routes from VRF X table.
+ * This will ensure VPN table is cleaned up appropriately.
+ */
+int bgp_vpn_leak_unimport(struct bgp *from_bgp, struct vty *vty)
+{
+	struct bgp *to_bgp;
+	const char *tmp_name;
+	char *vname;
+	struct listnode *node, *next;
+	safi_t safi = SAFI_UNICAST;
+	afi_t afi;
+	bool is_vrf_leak_bind;
+	int debug;
+
+	debug = (BGP_DEBUG(vpn, VPN_LEAK_TO_VRF) |
+		     BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF));
+
+	tmp_name = from_bgp->name ? from_bgp->name : VRF_DEFAULT_NAME;
+
+	/* Default instnace can not be removed if VRF leak is enabled
+	 * across any vrf instance.
+	 */
+	if (from_bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) {
+		if (is_bgp_vpn_leak_present()) {
+			vty_out(vty,
+			"%% VRF Leak is present, cannot remove default instance.\n");
+			return -1;
+		}
+		return 0;
+	}
+
+	if (from_bgp->inst_type != BGP_INSTANCE_TYPE_VRF)
+		return 0;
+
+	for (afi = 0; afi < AFI_MAX; ++afi) {
+		/* vrf leak is for IPv4 and IPv6 Unicast only */
+		if (afi != AFI_IP && afi != AFI_IP6)
+			continue;
+
+		for (ALL_LIST_ELEMENTS_RO(bm->bgp, next, to_bgp)) {
+			if (from_bgp == to_bgp)
+				continue;
+
+			/* Unimport and remove source vrf from the
+			 * other vrfs import list.
+			 */
+			struct vpn_policy *to_vpolicy;
+
+			is_vrf_leak_bind = false;
+			to_vpolicy = &(to_bgp->vpn_policy[afi]);
+			for (ALL_LIST_ELEMENTS_RO(to_vpolicy->import_vrf, node,
+						  vname)) {
+				if (strcmp(vname, tmp_name) == 0) {
+					is_vrf_leak_bind = true;
+					break;
+				}
+			}
+			/* skip this bgp instance as there is no leak to this
+			 * vrf instance.
+			 */
+			if (!is_vrf_leak_bind)
+				continue;
+
+			if (debug)
+				zlog_debug("%s: unimport routes from %s to_bgp %s afi %s import vrfs count %u",
+					   __func__, from_bgp->name_pretty,
+					   to_bgp->name_pretty, afi2str(afi),
+					   to_vpolicy->import_vrf->count);
+
+			vrf_unimport_from_vrf(to_bgp, from_bgp, afi, safi);
+
+			/* readd vrf name as unimport removes import vrf name
+			 * from the destination vrf's import list where the
+			 * `import vrf` configuration still exist.
+			 */
+			vname = XSTRDUP(MTYPE_TMP, tmp_name);
+			listnode_add(to_bgp->vpn_policy[afi].import_vrf,
+				     vname);
+			SET_FLAG(to_bgp->af_flags[afi][safi],
+				 BGP_CONFIG_VRF_TO_VRF_IMPORT);
+
+			/* If to_bgp exports its routes to the bgp vrf
+			 * which is being deleted, un-import the
+			 * to_bgp routes from VPN.
+			 */
+			for (ALL_LIST_ELEMENTS_RO(to_bgp->vpn_policy[afi]
+						  .export_vrf, node,
+						  vname)) {
+				if (strcmp(vname, tmp_name) == 0) {
+					vrf_unimport_from_vrf(from_bgp, to_bgp,
+						      afi, safi);
+					break;
+				}
+			}
+		}
+	}
+	return 0;
+}
+
+/* When a router bgp is configured, there could be a bgp vrf
+ * instance importing routes from this newly configured
+ * bgp vrf instance. Export routes from configured
+ * bgp vrf to VPN.
+ * VRF Y has import from bgp vrf x,
+ * when a bgp vrf x instance is created, export its routes
+ * to VRF Y instance.
+ */
+void bgp_vpn_leak_export(struct bgp *from_bgp)
+{
+	afi_t afi;
+	const char *export_name;
+	char *vname;
+	struct listnode *node, *next;
+	struct ecommunity *ecom;
+	vpn_policy_direction_t idir, edir;
+	safi_t safi = SAFI_UNICAST;
+	struct bgp *to_bgp;
+	int debug;
+
+	debug = (BGP_DEBUG(vpn, VPN_LEAK_TO_VRF) |
+		     BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF));
+
+	idir = BGP_VPN_POLICY_DIR_FROMVPN;
+	edir = BGP_VPN_POLICY_DIR_TOVPN;
+
+	export_name = (from_bgp->name ? XSTRDUP(MTYPE_TMP, from_bgp->name)
+			       : XSTRDUP(MTYPE_TMP, VRF_DEFAULT_NAME));
+
+	for (afi = 0; afi < AFI_MAX; ++afi) {
+		/* vrf leak is for IPv4 and IPv6 Unicast only */
+		if (afi != AFI_IP && afi != AFI_IP6)
+			continue;
+
+		for (ALL_LIST_ELEMENTS_RO(bm->bgp, next, to_bgp)) {
+			if (from_bgp == to_bgp)
+				continue;
+
+			/* bgp instance has import list, check to see if newly
+			 * configured bgp instance is the list.
+			 */
+			struct vpn_policy *to_vpolicy;
+
+			to_vpolicy = &(to_bgp->vpn_policy[afi]);
+			for (ALL_LIST_ELEMENTS_RO(to_vpolicy->import_vrf,
+						  node, vname)) {
+				if (strcmp(vname, export_name) != 0)
+					continue;
+
+				if (debug)
+					zlog_debug("%s: found from_bgp %s in to_bgp %s import list, import routes.",
+					   __func__,
+					   export_name, to_bgp->name_pretty);
+
+				ecom = from_bgp->vpn_policy[afi].rtlist[edir];
+				/* remove import rt, it will be readded
+				 * as part of import from vrf.
+				 */
+				if (ecom)
+					ecommunity_del_val(
+						to_vpolicy->rtlist[idir],
+						(struct ecommunity_val *)
+							ecom->val);
+				vrf_import_from_vrf(to_bgp, from_bgp,
+						    afi, safi);
+				break;
+
+			}
+		}
 	}
 }

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -259,11 +259,32 @@ static inline bool is_pi_family_vpn(struct bgp_path_info *pi)
 		is_pi_family_matching(pi, AFI_IP6, SAFI_MPLS_VPN));
 }
 
+static inline bool is_bgp_vpn_leak_present(void)
+{
+	struct listnode *next;
+	struct bgp *bgp;
+	afi_t afi;
+
+	for (afi = 0; afi < AFI_MAX; ++afi) {
+		if (afi != AFI_IP && afi != AFI_IP6)
+			continue;
+		for (ALL_LIST_ELEMENTS_RO(bm->bgp, next, bgp)) {
+			if (vpn_leak_to_vpn_active(bgp, afi, NULL))
+				return true;
+			if (vpn_leak_from_vpn_active(bgp, afi, NULL))
+				return true;
+		}
+	}
+	return false;
+}
+
 extern void vpn_policy_routemap_event(const char *rmap_name);
 
 extern vrf_id_t get_first_vrf_for_redirect_with_rt(struct ecommunity *eckey);
 
 extern void vpn_leak_postchange_all(void);
+extern int bgp_vpn_leak_unimport(struct bgp *from_bgp, struct vty *vty);
+extern void bgp_vpn_leak_export(struct bgp *from_bgp);
 extern void vpn_handle_router_id_update(struct bgp *bgp, bool withdraw);
 
 #endif /* _QUAGGA_BGP_MPLSVPN_H */


### PR DESCRIPTION
A VRF leak is configured between two vrfs, bgp VRF X and VRF Y.
When a bgp VRF X is removed, unimport bgp VRF X routes
from VPN and VRF Y.
If VRF X is also importing from bgp VRF Y, remove X from export
list of Y and do required route cleanup.

When a default bgp instance is attempt to remove, check if any of the VRF leak is configured.
Reject removal of default when leak is present as default
instance is a mediator for hosting VPN route table.

Testing Done:

nl1(config)# no router bgp 64902
% VRF Leak is present, cannot remove default instance.
nl1(config)#

Test2:

Before deleteing vrf1002:
nl1# show ip route vrf vrf1003 9.9.2.4/32
Routing entry for 9.9.2.4/32
  Known via "bgp", distance 200, metric 0, vrf vrf1003, best
  Last update 00:04:51 ago
  * 200.2.8.2, via swp1.2(vrf vrf1002)
  * 200.2.9.2, via swp2.2(vrf vrf1002)
  * 200.2.10.2, via swp3.2(vrf vrf1002)

Instance vrf1003:
This VRF is importing IPv4 Unicast routes from the following VRFs:
  vrf1002
Import RT(s): 6.0.2.9:2
This VRF is exporting IPv4 Unicast routes to the following VRFs:
  vrf1002
RD: 6.0.3.9:3
Export RT: 6.0.3.9:3

After deleting vrf1002:
nl1(config)# no router bgp 64902 vrf vrf1002

nl1# show ip route vrf vrf1003 9.9.2.4/32
Routing entry for 9.9.2.4/32
  Known via "bgp", distance 20, metric 0, vrf vrf1003, best
  Last update 00:00:32 ago
  * 200.3.8.2, via swp1.3
  * 200.3.9.2, via swp2.3
  * 200.3.10.2, via swp3.3

Instance vrf1003:
This VRF is importing IPv4 Unicast routes from the following VRFs:
  vrf1002
Import RT(s):
This VRF is not exporting IPv4 Unicast routes to any other VRF

nl1# show bgp ipv4 vpn
No BGP prefixes displayed, 0 exist

Re-add vrf1002:
points back to source vrf
nl1# show ip route vrf vrf1003 9.9.2.4/32
Routing entry for 9.9.2.4/32
  Known via "bgp", distance 200, metric 0, vrf vrf1003, best
  Last update 00:00:21 ago
  * 200.2.8.2, via swp1.2(vrf vrf1002)
  * 200.2.9.2, via swp2.2(vrf vrf1002)
  * 200.2.10.2, via swp3.2(vrf vrf1002)

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>