### PR TITLE
More traces for BFD clients

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -276,6 +276,11 @@ static void bgp_bfd_peer_status_update(struct peer *peer, int status)
 	bfd_info->status = status;
 	bfd_info->last_update = bgp_clock();
 
+	if (status != old_status) {
+		if (BGP_DEBUG(neighbor_events, NEIGHBOR_EVENTS))
+			zlog_debug("[%s]: BFD %s", peer->host,
+				   bfd_get_status_str(status));
+	}
 	if ((status == BFD_STATUS_DOWN) && (old_status == BFD_STATUS_UP)) {
 		peer->last_reset = PEER_DOWN_BFD_DOWN;
 		BGP_EVENT_ADD(peer, BGP_Stop);

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -251,6 +251,13 @@ static int ospf_bfd_interface_dest_update(int command, struct zclient *zclient,
 
 			OSPF_NSM_EVENT_SCHEDULE(nbr, NSM_InactivityTimer);
 		}
+		if ((status == BFD_STATUS_UP)
+		    && (old_status == BFD_STATUS_DOWN)) {
+			if (IS_DEBUG_OSPF(nsm, NSM_EVENTS))
+				zlog_debug("NSM[%s:%s]: BFD Up",
+					   IF_NAME(nbr->oi),
+					   inet_ntoa(nbr->address.u.prefix4));
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Add some more traces around daemons using BFD : OSPF, and BGP.
