### PR TITLE
bgpd: ability to export prefixes entries to a kernel table identifier

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -520,6 +520,7 @@ unsigned int attrhash_key_make(const void *p)
 	key = jhash(attr->mp_nexthop_global.s6_addr, IPV6_MAX_BYTELEN, key);
 	key = jhash(attr->mp_nexthop_local.s6_addr, IPV6_MAX_BYTELEN, key);
 	MIX3(attr->nh_ifindex, attr->nh_lla_ifindex, attr->distance);
+	MIX(attr->rmap_table_id);
 
 	return key;
 }
@@ -546,6 +547,7 @@ bool attrhash_cmp(const void *p1, const void *p2)
 		    && attr1->lcommunity == attr2->lcommunity
 		    && attr1->cluster == attr2->cluster
 		    && attr1->transit == attr2->transit
+		    && attr1->rmap_table_id == attr2->rmap_table_id
 		    && (attr1->encap_tunneltype == attr2->encap_tunneltype)
 		    && encap_same(attr1->encap_subtlvs, attr2->encap_subtlvs)
 #if ENABLE_BGP_VNC

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -209,6 +209,9 @@ struct attr {
 
 	/* Distance as applied by Route map */
 	uint8_t distance;
+
+	/* rmap set table */
+	uint32_t rmap_table_id;
 };
 
 /* rmap_change_flags definition */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3165,6 +3165,13 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 		goto filtered;
 	}
 
+	if (pi && pi->attr &&
+	    pi->attr->rmap_table_id != new_attr.rmap_table_id) {
+		if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
+			/* remove from RIB previous entry */
+			bgp_zebra_withdraw(p, pi, bgp, safi);
+	}
+
 	if (peer->sort == BGP_PEER_EBGP) {
 
 		/* If we receive the graceful-shutdown community from an eBGP

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1499,6 +1499,11 @@ void bgp_zebra_withdraw(struct prefix *p, struct bgp_path_info *info,
 	api.safi = safi;
 	api.prefix = *p;
 
+	if (info->attr->rmap_table_id) {
+		SET_FLAG(api.message, ZAPI_MESSAGE_TABLEID);
+		api.tableid = info->attr->rmap_table_id;
+	}
+
 	/* If the route's source is EVPN, flag as such. */
 	if (is_route_parent_evpn(info))
 		SET_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1228,6 +1228,11 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 
 		SET_FLAG(api.flags, ZEBRA_FLAG_ALLOW_RECURSION);
 
+	if (info->attr->rmap_table_id) {
+		SET_FLAG(api.message, ZAPI_MESSAGE_TABLEID);
+		api.tableid = info->attr->rmap_table_id;
+	}
+
 	/* Metric is currently based on the best-path only */
 	metric = info->attr->med;
 	for (mpinfo = info; mpinfo; mpinfo = bgp_path_info_mpath_next(mpinfo)) {

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -306,6 +306,11 @@ Route Map Set Command
 
    Set BGP route origin.
 
+.. index:: set table (1-4294967295)
+.. clicmd:: set table (1-4294967295)
+
+   Set the BGP table to a given table identifier
+
 .. _route-map-call-command:
 
 Route Map Call Command

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1425,7 +1425,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	re->flags = api.flags;
 	re->uptime = monotime(NULL);
 	re->vrf_id = vrf_id;
-	if (api.tableid && vrf_id == VRF_DEFAULT)
+	if (api.tableid)
 		re->table = api.tableid;
 	else
 		re->table = zvrf->table_id;
@@ -1624,7 +1624,7 @@ static void zread_route_del(ZAPI_HANDLER_ARGS)
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_SRCPFX))
 		src_p = &api.src_prefix;
 
-	if (api.vrf_id == VRF_DEFAULT && api.tableid != 0)
+	if (api.tableid)
 		table_id = api.tableid;
 	else
 		table_id = zvrf->table_id;


### PR DESCRIPTION
this table identifier can be used for policy routing. incoming entries
are locally exported to that local table identifier.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>