### PR TITLE
bgpd : dynamic modification in lcomm-list is not taking effect.

### DIFF
--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -1049,8 +1049,10 @@ int lcommunity_list_set(struct community_list_handler *ch, const char *name,
 	/* Do not put duplicated community entry.  */
 	if (community_list_dup_check(list, entry))
 		community_entry_free(entry);
-	else
+	else {
 		community_list_entry_add(list, entry);
+		route_map_notify_dependencies(name, RMAP_EVENT_LLIST_ADDED);
+	}
 
 	return 0;
 }
@@ -1075,6 +1077,7 @@ int lcommunity_list_unset(struct community_list_handler *ch, const char *name,
 	/* Delete all of entry belongs to this community-list.  */
 	if (!str) {
 		community_list_delete(cm, list);
+		route_map_notify_dependencies(name, RMAP_EVENT_LLIST_DELETED);
 		return 0;
 	}
 
@@ -1100,6 +1103,7 @@ int lcommunity_list_unset(struct community_list_handler *ch, const char *name,
 		return COMMUNITY_LIST_ERR_CANT_FIND_LIST;
 
 	community_list_entry_delete(cm, list, entry);
+	route_map_notify_dependencies(name, RMAP_EVENT_LLIST_DELETED);
 
 	return 0;
 }


### PR DESCRIPTION
lcomm-list is configured and attached to route-map via match clause.
If you modify the lcomm-list then it is not taking into effect via routemap.

Signed-off-by: vishaldhingra <vdhingra@vmware.com>