### PR TITLE
zebra Other tables

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -653,7 +653,8 @@ int zebra_import_table(afi_t afi, uint32_t table_id, uint32_t distance,
 	if (afi >= AFI_MAX)
 		return (-1);
 
-	table = zebra_vrf_other_route_table(afi, table_id, VRF_DEFAULT);
+	table = zebra_vrf_table_with_table_id(afi, SAFI_UNICAST,
+					      table_id, VRF_DEFAULT);
 	if (table == NULL) {
 		return 0;
 	} else if (IS_ZEBRA_DEBUG_RIB) {
@@ -767,8 +768,8 @@ void zebra_import_table_rm_update(const char *rmap)
 			rmap_name = zebra_get_import_table_route_map(afi, i);
 			if ((!rmap_name) || (strcmp(rmap_name, rmap) != 0))
 				continue;
-			table = zebra_vrf_other_route_table(afi, i,
-							    VRF_DEFAULT);
+			table = zebra_vrf_table_with_table_id(afi, SAFI_UNICAST,
+							      i, VRF_DEFAULT);
 			for (rn = route_top(table); rn; rn = route_next(rn)) {
 				/* For each entry in the non-default
 				 * routing table,

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3227,18 +3227,23 @@ unsigned long rib_score_proto(uint8_t proto, unsigned short instance)
 {
 	struct vrf *vrf;
 	struct zebra_vrf *zvrf;
+	struct other_route_table *ort;
 	unsigned long cnt = 0;
 
-	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id)
-		if ((zvrf = vrf->info) != NULL)
-			cnt += rib_score_proto_table(
-				       proto, instance,
-				       zvrf->table[AFI_IP][SAFI_UNICAST])
-			       + rib_score_proto_table(
-					 proto, instance,
-					 zvrf->table[AFI_IP6][SAFI_UNICAST]);
+	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
+		zvrf = vrf->info;
+		if (!zvrf)
+			continue;
 
-	cnt += zebra_router_score_proto(proto, instance);
+		cnt += rib_score_proto_table(proto, instance,
+					     zvrf->table[AFI_IP][SAFI_UNICAST])
+		       + rib_score_proto_table(
+			       proto, instance,
+			       zvrf->table[AFI_IP6][SAFI_UNICAST]);
+
+		for_each(otable, &zvrf->other_tables, ort) cnt +=
+			rib_score_proto_table(proto, instance, ort->table);
+	}
 
 	return cnt;
 }

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -117,19 +117,6 @@ struct route_table *zebra_router_get_table(struct zebra_vrf *zvrf,
 	return zrt->table;
 }
 
-unsigned long zebra_router_score_proto(uint8_t proto, unsigned short instance)
-{
-	struct zebra_router_table *zrt;
-	unsigned long cnt = 0;
-
-	RB_FOREACH (zrt, zebra_router_table_head, &zrouter.tables) {
-		if (zrt->ns_id != NS_DEFAULT)
-			continue;
-		cnt += rib_score_proto_table(proto, instance, zrt->table);
-	}
-	return cnt;
-}
-
 void zebra_router_show_table_summary(struct vty *vty)
 {
 	struct zebra_router_table *zrt;

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -128,8 +128,6 @@ extern void zebra_router_release_table(struct zebra_vrf *zvrf, uint32_t tableid,
 
 extern int zebra_router_config_write(struct vty *vty);
 
-extern unsigned long zebra_router_score_proto(uint8_t proto,
-					      unsigned short instance);
 extern void zebra_router_sweep_route(void);
 
 extern void zebra_router_show_table_summary(struct vty *vty);

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -43,6 +43,18 @@ struct zebra_rmap {
 	struct route_map *map;
 };
 
+PREDECL_RBTREE_UNIQ(otable);
+
+struct other_route_table {
+	struct otable_item next;
+
+	afi_t afi;
+	safi_t safi;
+	uint32_t table_id;
+
+	struct route_table *table;
+};
+
 /* Routing table instance.  */
 struct zebra_vrf {
 	/* Back pointer */
@@ -68,6 +80,8 @@ struct zebra_vrf {
 
 	/* Import check table (used mostly by BGP */
 	struct route_table *import_check_table[AFI_MAX];
+
+	struct otable_head other_tables;
 
 	/* 2nd pointer type used primarily to quell a warning on
 	 * ALL_LIST_ELEMENTS_RO
@@ -191,6 +205,25 @@ static inline bool zvrf_is_active(struct zebra_vrf *zvrf)
 {
 	return zvrf->vrf->status & VRF_ACTIVE;
 }
+
+static inline int
+zvrf_other_table_compare_func(const struct other_route_table *a,
+			      const struct other_route_table *b)
+{
+	if (a->afi != b->afi)
+		return a->afi - b->afi;
+
+	if (a->safi != b->safi)
+		return a->safi - b->safi;
+
+	if (a->table_id != b->table_id)
+		return a->table_id - b->table_id;
+
+	return 0;
+}
+
+DECLARE_RBTREE_UNIQ(otable, struct other_route_table, next,
+		    zvrf_other_table_compare_func)
 
 struct route_table *zebra_vrf_table_with_table_id(afi_t afi, safi_t safi,
 						  vrf_id_t vrf_id,

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -202,8 +202,6 @@ extern struct zebra_vrf *zebra_vrf_lookup_by_name(const char *);
 extern struct zebra_vrf *zebra_vrf_alloc(void);
 extern struct route_table *zebra_vrf_table(afi_t, safi_t, vrf_id_t);
 
-extern struct route_table *
-zebra_vrf_other_route_table(afi_t afi, uint32_t table_id, vrf_id_t vrf_id);
 extern int zebra_vrf_has_config(struct zebra_vrf *zvrf);
 extern void zebra_vrf_init(void);
 


### PR DESCRIPTION
Convert zebra to have 2 functions for table creation instead of 3.  Additionally track all table creation on a per vrf basis and cleanup appropriately those tables.