### PR TITLE
lib, yang: disable libyang custom user types temporarily

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,7 +96,6 @@ noinst_LIBRARIES =
 nodist_noinst_DATA =
 lib_LTLIBRARIES =
 module_LTLIBRARIES =
-libyang_plugins_LTLIBRARIES =
 pkginclude_HEADERS =
 nodist_pkginclude_HEADERS =
 dist_examples_DATA =
@@ -111,7 +110,6 @@ vtysh_scan =
 $(AUTOMAKE_DUMMY)install-moduleLTLIBRARIES: install-libLTLIBRARIES
 $(AUTOMAKE_DUMMY)install-binPROGRAMS: install-libLTLIBRARIES
 $(AUTOMAKE_DUMMY)install-sbinPROGRAMS: install-libLTLIBRARIES
-$(AUTOMAKE_DUMMY)install-libyang_pluginsLTLIBRARIES: install-libLTLIBRARIES
 
 include doc/subdir.am
 include doc/user/subdir.am

--- a/configure.ac
+++ b/configure.ac
@@ -1690,24 +1690,6 @@ AC_CHECK_MEMBER([struct lyd_node.priv], [], [
 ], [[#include <libyang/libyang.h>]])
 CFLAGS="$ac_cflags_save"
 
-ac_libs_save="$LIBS"
-LIBS="$LIBS $LIBYANG_LIBS"
-AC_CHECK_FUNC([ly_register_types], [
-  libyang_ext_builtin=true
-  AC_DEFINE([LIBYANG_EXT_BUILTIN], [1], [have ly_register_types()])
-], [
-  libyang_ext_builtin=false
-  AC_MSG_WARN([===== old libyang (before 0.16.74) detected =====])
-  AC_MSG_WARN([The available version of libyang does not seem to support])
-  AC_MSG_WARN([built-in YANG extension modules.  This will cause "make check"])
-  AC_MSG_WARN([to fail and may create installation and version mismatch issues.])
-  AC_MSG_WARN([Support for the old mechanism will be removed at some point.])
-  AC_MSG_WARN([Please update libyang to version 0.16.74 or newer.])
-  AC_MSG_WARN([===== old libyang (before 0.16.74) detected =====])
-])
-AM_CONDITIONAL([LIBYANG_EXT_BUILTIN], [$libyang_ext_builtin])
-LIBS="$ac_libs_save"
-
 dnl ---------------
 dnl configuration rollbacks
 dnl ---------------

--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -817,7 +817,7 @@ void yang_dnode_get_ipv4(struct in_addr *addr, const struct lyd_node *dnode,
 
 	dleaf = (const struct lyd_node_leaf_list *)dnode;
 	assert(dleaf->value_type == LY_TYPE_STRING);
-	memcpy(addr, dleaf->value.ptr, sizeof(*addr));
+	(void)inet_pton(AF_INET, dleaf->value_str, addr);
 }
 
 void yang_get_default_ipv4(struct in_addr *var, const char *xpath_fmt, ...)
@@ -874,7 +874,7 @@ void yang_dnode_get_ipv4p(union prefixptr prefix, const struct lyd_node *dnode,
 
 	dleaf = (const struct lyd_node_leaf_list *)dnode;
 	assert(dleaf->value_type == LY_TYPE_STRING);
-	memcpy(prefix4, dleaf->value.ptr, sizeof(*prefix4));
+	(void)str2prefix_ipv4(dleaf->value_str, prefix4);
 }
 
 void yang_get_default_ipv4p(union prefixptr var, const char *xpath_fmt, ...)
@@ -927,7 +927,7 @@ void yang_dnode_get_ipv6(struct in6_addr *addr, const struct lyd_node *dnode,
 
 	dleaf = (const struct lyd_node_leaf_list *)dnode;
 	assert(dleaf->value_type == LY_TYPE_STRING);
-	memcpy(addr, dleaf->value.ptr, sizeof(*addr));
+	(void)inet_pton(AF_INET6, dleaf->value_str, addr);
 }
 
 void yang_get_default_ipv6(struct in6_addr *var, const char *xpath_fmt, ...)
@@ -984,7 +984,7 @@ void yang_dnode_get_ipv6p(union prefixptr prefix, const struct lyd_node *dnode,
 
 	dleaf = (const struct lyd_node_leaf_list *)dnode;
 	assert(dleaf->value_type == LY_TYPE_STRING);
-	memcpy(prefix6, dleaf->value.ptr, sizeof(*prefix6));
+	(void)str2prefix_ipv6(dleaf->value_str, prefix6);
 }
 
 void yang_get_default_ipv6p(union prefixptr var, const char *xpath_fmt, ...)

--- a/yang/libyang_plugins/subdir.am
+++ b/yang/libyang_plugins/subdir.am
@@ -2,13 +2,6 @@
 # libyang user types
 #
 
-if LIBYANG_EXT_BUILTIN
-lib_libfrr_la_SOURCES += yang/libyang_plugins/frr_user_types.c
-else
-libyang_plugins_LTLIBRARIES += yang/libyang_plugins/frr_user_types.la
-endif
-
-yang_libyang_plugins_frr_user_types_la_CFLAGS = $(WERROR) $(LIBYANG_CFLAGS)
-yang_libyang_plugins_frr_user_types_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
-yang_libyang_plugins_frr_user_types_la_LIBADD =
-yang_libyang_plugins_frr_user_types_la_SOURCES = yang/libyang_plugins/frr_user_types.c
+# XXX: disable support for libyang custom user types temporarily to facilitate
+# the transition from libyang 0.x to libyang 1.x.
+#lib_libfrr_la_SOURCES += yang/libyang_plugins/frr_user_types.c


### PR DESCRIPTION
libyang 1.0 introduced a few changes in the user types API, and
these changes made FRR incompatible with libyang 1.x. In order to
ease our migration from libyang 0.x to libyang 1.x, let's disable
our libyang custom user types temporarily so that FRR can work
with both libyang 0.x and libyang 1.x. This should be especially
helpful to the CI systems during the transition. Once the migration
to libyang 1.x is complete, this commit will be reverted.

Disabling our libyang custom user types should have only
minimal performance implications when processing configuration
transactions. The user types infrastructure should be more important
in the future to perform canonization of YANG data values when
necessary.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>