### PR TITLE
[7.0] lib, yang: disable libyang custom user types temporarily

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,7 +96,6 @@ noinst_LIBRARIES =
 nodist_noinst_DATA =
 lib_LTLIBRARIES =
 module_LTLIBRARIES =
-libyang_plugins_LTLIBRARIES =
 pkginclude_HEADERS =
 nodist_pkginclude_HEADERS =
 dist_examples_DATA =
@@ -111,7 +110,6 @@ vtysh_scan =
 $(AUTOMAKE_DUMMY)install-moduleLTLIBRARIES: install-libLTLIBRARIES
 $(AUTOMAKE_DUMMY)install-binPROGRAMS: install-libLTLIBRARIES
 $(AUTOMAKE_DUMMY)install-sbinPROGRAMS: install-libLTLIBRARIES
-$(AUTOMAKE_DUMMY)install-libyang_pluginsLTLIBRARIES: install-libLTLIBRARIES
 
 include doc/subdir.am
 include doc/user/subdir.am

--- a/configure.ac
+++ b/configure.ac
@@ -1611,24 +1611,6 @@ AC_CHECK_MEMBER([struct lyd_node.priv], [], [
 ], [[#include <libyang/libyang.h>]])
 CFLAGS="$ac_cflags_save"
 
-ac_libs_save="$LIBS"
-LIBS="$LIBS $LIBYANG_LIBS"
-AC_CHECK_FUNC([ly_register_types], [
-  libyang_ext_builtin=true
-  AC_DEFINE([LIBYANG_EXT_BUILTIN], [1], [have ly_register_types()])
-], [
-  libyang_ext_builtin=false
-  AC_MSG_WARN([===== old libyang (before 0.16.74) detected =====])
-  AC_MSG_WARN([The available version of libyang does not seem to support])
-  AC_MSG_WARN([built-in YANG extension modules.  This will cause "make check"])
-  AC_MSG_WARN([to fail and may create installation and version mismatch issues.])
-  AC_MSG_WARN([Support for the old mechanism will be removed at some point.])
-  AC_MSG_WARN([Please update libyang to version 0.16.74 or newer.])
-  AC_MSG_WARN([===== old libyang (before 0.16.74) detected =====])
-])
-AM_CONDITIONAL([LIBYANG_EXT_BUILTIN], [$libyang_ext_builtin])
-LIBS="$ac_libs_save"
-
 dnl ---------------
 dnl configuration rollbacks
 dnl ---------------

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -641,14 +641,6 @@ static void ly_log_cb(LY_LOG_LEVEL level, const char *msg, const char *path)
 		zlog(priority, "libyang: %s", msg);
 }
 
-#if CONFDATE > 20190401
-CPP_NOTICE("lib/yang: time to remove non-LIBYANG_EXT_BUILTIN support")
-#endif
-
-#ifdef LIBYANG_EXT_BUILTIN
-extern struct lytype_plugin_list frr_user_types[];
-#endif
-
 struct ly_ctx *yang_ctx_new_setup(void)
 {
 	struct ly_ctx *ctx;
@@ -674,30 +666,9 @@ struct ly_ctx *yang_ctx_new_setup(void)
 
 void yang_init(void)
 {
-#ifndef LIBYANG_EXT_BUILTIN
-CPP_NOTICE("lib/yang: deprecated libyang <0.16.74 extension loading in use!")
-	static char ly_plugin_dir[PATH_MAX];
-	const char *const *ly_loaded_plugins;
-	const char *ly_plugin;
-	bool found_ly_frr_types = false;
-
-	/* Tell libyang where to find its plugins. */
-	snprintf(ly_plugin_dir, sizeof(ly_plugin_dir), "%s=%s",
-		 "LIBYANG_USER_TYPES_PLUGINS_DIR", LIBYANG_PLUGINS_PATH);
-	putenv(ly_plugin_dir);
-#endif
-
 	/* Initialize libyang global parameters that affect all containers. */
 	ly_set_log_clb(ly_log_cb, 1);
 	ly_log_options(LY_LOLOG | LY_LOSTORE);
-
-#ifdef LIBYANG_EXT_BUILTIN
-	if (ly_register_types(frr_user_types, "frr_user_types")) {
-		flog_err(EC_LIB_LIBYANG_PLUGIN_LOAD,
-			 "ly_register_types() failed");
-		exit(1);
-	}
-#endif
 
 	/* Initialize libyang container for native models. */
 	ly_native_ctx = yang_ctx_new_setup();
@@ -706,22 +677,6 @@ CPP_NOTICE("lib/yang: deprecated libyang <0.16.74 extension loading in use!")
 		exit(1);
 	}
 	ly_ctx_set_priv_dup_clb(ly_native_ctx, ly_dup_cb);
-
-#ifndef LIBYANG_EXT_BUILTIN
-	/* Detect if the required libyang plugin(s) were loaded successfully. */
-	ly_loaded_plugins = ly_get_loaded_plugins();
-	for (size_t i = 0; (ly_plugin = ly_loaded_plugins[i]); i++) {
-		if (strmatch(ly_plugin, "frr_user_types")) {
-			found_ly_frr_types = true;
-			break;
-		}
-	}
-	if (!found_ly_frr_types) {
-		flog_err(EC_LIB_LIBYANG_PLUGIN_LOAD,
-			 "%s: failed to load frr_user_types.so", __func__);
-		exit(1);
-	}
-#endif
 
 	yang_translator_init();
 }

--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -817,7 +817,7 @@ void yang_dnode_get_ipv4(struct in_addr *addr, const struct lyd_node *dnode,
 
 	dleaf = (const struct lyd_node_leaf_list *)dnode;
 	assert(dleaf->value_type == LY_TYPE_STRING);
-	memcpy(addr, dleaf->value.ptr, sizeof(*addr));
+	(void)inet_pton(AF_INET, dleaf->value_str, addr);
 }
 
 void yang_get_default_ipv4(struct in_addr *var, const char *xpath_fmt, ...)
@@ -874,7 +874,7 @@ void yang_dnode_get_ipv4p(union prefixptr prefix, const struct lyd_node *dnode,
 
 	dleaf = (const struct lyd_node_leaf_list *)dnode;
 	assert(dleaf->value_type == LY_TYPE_STRING);
-	memcpy(prefix4, dleaf->value.ptr, sizeof(*prefix4));
+	(void)str2prefix_ipv4(dleaf->value_str, prefix4);
 }
 
 void yang_get_default_ipv4p(union prefixptr var, const char *xpath_fmt, ...)
@@ -927,7 +927,7 @@ void yang_dnode_get_ipv6(struct in6_addr *addr, const struct lyd_node *dnode,
 
 	dleaf = (const struct lyd_node_leaf_list *)dnode;
 	assert(dleaf->value_type == LY_TYPE_STRING);
-	memcpy(addr, dleaf->value.ptr, sizeof(*addr));
+	(void)inet_pton(AF_INET6, dleaf->value_str, addr);
 }
 
 void yang_get_default_ipv6(struct in6_addr *var, const char *xpath_fmt, ...)
@@ -984,7 +984,7 @@ void yang_dnode_get_ipv6p(union prefixptr prefix, const struct lyd_node *dnode,
 
 	dleaf = (const struct lyd_node_leaf_list *)dnode;
 	assert(dleaf->value_type == LY_TYPE_STRING);
-	memcpy(prefix6, dleaf->value.ptr, sizeof(*prefix6));
+	(void)str2prefix_ipv6(dleaf->value_str, prefix6);
 }
 
 void yang_get_default_ipv6p(union prefixptr var, const char *xpath_fmt, ...)

--- a/yang/libyang_plugins/subdir.am
+++ b/yang/libyang_plugins/subdir.am
@@ -2,13 +2,6 @@
 # libyang user types
 #
 
-if LIBYANG_EXT_BUILTIN
-lib_libfrr_la_SOURCES += yang/libyang_plugins/frr_user_types.c
-else
-libyang_plugins_LTLIBRARIES += yang/libyang_plugins/frr_user_types.la
-endif
-
-yang_libyang_plugins_frr_user_types_la_CFLAGS = $(WERROR) $(LIBYANG_CFLAGS)
-yang_libyang_plugins_frr_user_types_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
-yang_libyang_plugins_frr_user_types_la_LIBADD =
-yang_libyang_plugins_frr_user_types_la_SOURCES = yang/libyang_plugins/frr_user_types.c
+# XXX: disable support for libyang custom user types temporarily to facilitate
+# the transition from libyang 0.x to libyang 1.x.
+#lib_libfrr_la_SOURCES += yang/libyang_plugins/frr_user_types.c


### PR DESCRIPTION
7.0 version of #4270 as requested by @mwinter-osr.