### PR TITLE
pimd: Re-deisgn the "clear ip mroute" command.

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3840,6 +3840,55 @@ static void mroute_del_all(struct pim_instance *pim)
 	}
 }
 
+static void clear_mroute(struct pim_instance *pim)
+{
+	struct pim_upstream *up;
+	struct interface *ifp;
+
+	/* scan interfaces */
+	FOR_ALL_INTERFACES (pim->vrf, ifp) {
+		struct pim_interface *pim_ifp = ifp->info;
+		struct listnode *sock_node;
+		struct igmp_sock *igmp;
+		struct pim_ifchannel *ch;
+
+		if (!pim_ifp)
+			continue;
+
+		/* deleting all ifchannels */
+		while (!RB_EMPTY(pim_ifchannel_rb, &pim_ifp->ifchannel_rb)) {
+			ch = RB_ROOT(pim_ifchannel_rb, &pim_ifp->ifchannel_rb);
+
+			pim_ifchannel_delete(ch);
+		}
+
+		/* clean up all igmp groups */
+		/* scan igmp sockets */
+		for (ALL_LIST_ELEMENTS_RO(pim_ifp->igmp_socket_list, sock_node,
+					igmp)) {
+
+			struct igmp_group *grp;
+
+			if (igmp->igmp_group_list) {
+				while (igmp->igmp_group_list->count) {
+					grp = listnode_head(
+						igmp->igmp_group_list);
+					igmp_group_delete(grp);
+				}
+			}
+
+		}
+	}
+
+	/* clean up all upstreams*/
+	if (pim->upstream_list) {
+		while (pim->upstream_list->count) {
+			up = listnode_head(pim->upstream_list);
+			pim_upstream_del(pim, up, __PRETTY_FUNCTION__);
+		}
+	}
+}
+
 DEFUN (clear_ip_mroute,
        clear_ip_mroute_cmd,
        "clear ip mroute [vrf NAME]",
@@ -3854,8 +3903,7 @@ DEFUN (clear_ip_mroute,
 	if (!vrf)
 		return CMD_WARNING;
 
-	mroute_del_all(vrf->info);
-	mroute_add_all(vrf->info);
+	clear_mroute(vrf->info);
 
 	return CMD_SUCCESS;
 }

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -741,7 +741,7 @@ static void igmp_group_free(struct igmp_group *group)
 	XFREE(MTYPE_PIM_IGMP_GROUP, group);
 }
 
-static void igmp_group_delete(struct igmp_group *group)
+void igmp_group_delete(struct igmp_group *group)
 {
 	struct listnode *src_node;
 	struct listnode *src_nextnode;

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -197,4 +197,5 @@ void igmp_send_query(int igmp_version, struct igmp_group *group, int fd,
 		     int query_max_response_time_dsec, uint8_t s_flag,
 		     uint8_t querier_robustness_variable,
 		     uint16_t querier_query_interval);
+void igmp_group_delete(struct igmp_group *group);
 #endif /* PIM_IGMP_H */


### PR DESCRIPTION
Currently , "clear ip mroute" deletes the mroutes in data path and adds it back.
The ideal expectation is to delete all the upstream and its states in FRR to start fresh learning. 
Made changes to clean up the all upstreams and ifchannels
in FRR apart from cleanup datapath mroutes when this command
issued.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>