### PR TITLE
Zebra-FPM: EVPN remote RMAC download via FPM channel using netlink ms…

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -30,7 +30,9 @@
 #include "network.h"
 #include "command.h"
 #include "version.h"
+#include "jhash.h"
 
+#include "zebra/zebra_router.h"
 #include "zebra/rib.h"
 #include "zebra/zserv.h"
 #include "zebra/zebra_ns.h"
@@ -39,6 +41,12 @@
 
 #include "fpm/fpm.h"
 #include "zebra_fpm_private.h"
+#include "memory.h"
+#include "zebra/zebra_memory.h"
+
+#define debug_rmac_fpm
+
+DEFINE_MTYPE_STATIC(ZEBRA, FPM_MAC_INFO, "FPM_MAC_INFO");
 
 /*
  * Interval at which we attempt to connect to the FPM.
@@ -62,6 +70,9 @@
  * Interval over which we collect statistics.
  */
 #define ZFPM_STATS_IVL_SECS        10
+#define FPM_MAX_MAC_MSG_LEN 512
+
+static void zfpm_iterate_rmac_table(struct hash_backet *backet, void *args);
 
 /*
  * Structure that holds state for iterating over all route_node
@@ -179,6 +190,25 @@ typedef struct zfpm_glob_t_ {
 	TAILQ_HEAD(zfpm_dest_q, rib_dest_t_) dest_q;
 
 	/*
+	 * List of fpm_mac_info structures to be processed
+	 */
+	TAILQ_HEAD(zfpm_mac_q, fpm_mac_info_t) mac_q;
+
+	/*
+	 * Hash table of fpm_mac_info_t entries
+	 *
+	 * While adding fpm_mac_info_t for a MAC to the mac_q,
+	 * it is possible that another fpm_mac_info_t node for the this MAC
+	 * is already present in the queue.
+	 * This is possible in the case of consecutive add->delete operations.
+	 * To avoid such duplicate insertions in the mac_q,
+	 * define a hash table for fpm_mac_info_t which can be looked up
+	 * to see if an fpm_mac_info_t node for a MAC is already present
+	 * in the mac_q.
+	 */
+	struct hash *fpm_mac_info_table;
+
+	/*
 	 * Stream socket to the FPM.
 	 */
 	int sock;
@@ -259,6 +289,7 @@ static int zfpm_write_cb(struct thread *thread);
 static void zfpm_set_state(zfpm_state_t state, const char *reason);
 static void zfpm_start_connect_timer(const char *reason);
 static void zfpm_start_stats_timer(void);
+static void zfpm_mac_info_del(struct fpm_mac_info_t *fpm_mac);
 
 /*
  * zfpm_thread_should_yield
@@ -492,6 +523,9 @@ static int zfpm_conn_up_thread_cb(struct thread *thread)
 		goto done;
 	}
 
+	/* Enqueue FPM updates for all the RMAC entries */
+	hash_iterate(zrouter.l3vni_table, zfpm_iterate_rmac_table, NULL);
+
 	while ((rnode = zfpm_rnodes_iter_next(iter))) {
 		dest = rib_dest_from_rnode(rnode);
 
@@ -591,8 +625,15 @@ static int zfpm_conn_down_thread_cb(struct thread *thread)
 	struct route_node *rnode;
 	zfpm_rnodes_iter_t *iter;
 	rib_dest_t *dest;
+	struct fpm_mac_info_t *mac = NULL;
 
 	assert(zfpm_g->state == ZFPM_STATE_IDLE);
+
+	/* Delink and free all fpm_mac_info_t nodes
+	 * in the mac_q and fpm_mac_info_hash
+	 */
+	while ((mac = TAILQ_FIRST(&zfpm_g->mac_q)) != NULL)
+		zfpm_mac_info_del(mac);
 
 	zfpm_g->t_conn_down = NULL;
 
@@ -778,6 +819,14 @@ done:
 	return 0;
 }
 
+static bool zfpm_updates_pending(void)
+{
+	if (!(TAILQ_EMPTY(&zfpm_g->dest_q)) || !(TAILQ_EMPTY(&zfpm_g->mac_q)))
+		return true;
+
+	return false;
+}
+
 /*
  * zfpm_writes_pending
  *
@@ -794,9 +843,9 @@ static int zfpm_writes_pending(void)
 		return 1;
 
 	/*
-	 * Check if there are any prefixes on the outbound queue.
+	 * Check if there are any updates scheduled on the outbound queues.
 	 */
-	if (!TAILQ_EMPTY(&zfpm_g->dest_q))
+	if (zfpm_updates_pending())
 		return 1;
 
 	return 0;
@@ -861,41 +910,59 @@ struct route_entry *zfpm_route_for_update(rib_dest_t *dest)
 }
 
 /*
- * zfpm_build_updates
+ * Define an enum for return codes for queue processing functions
  *
- * Process the outgoing queue and write messages to the outbound
- * buffer.
+ * FPM_WRITE_STOP: This return code indicates that the write buffer is full.
+ * Stop processing all the queues and empty the buffer by writing its content
+ * to the socket.
+ *
+ * FPM_GOTO_NEXT_Q: This return code indicates that either this queue is
+ * empty or we have processed enough updates from this queue.
+ * So, move on to the next queue.
  */
-static void zfpm_build_updates(void)
+enum {
+	FPM_WRITE_STOP = 0,
+	FPM_GOTO_NEXT_Q = 1
+};
+
+#define FPM_QUEUE_PROCESS_LIMIT 10000
+
+/*
+ * zfpm_build_route_updates
+ *
+ * Process the dest_q queue and write FPM messages to the outbound buffer.
+ */
+static int zfpm_build_route_updates(void)
 {
 	struct stream *s;
 	rib_dest_t *dest;
 	unsigned char *buf, *data, *buf_end;
-	size_t msg_len;
-	size_t data_len;
 	fpm_msg_hdr_t *hdr;
 	struct route_entry *re;
 	int is_add, write_msg;
+	size_t data_len, msg_len;
 	fpm_msg_type_e msg_type;
+	uint16_t q_limit;
+
+	if (TAILQ_EMPTY(&zfpm_g->dest_q))
+		return FPM_GOTO_NEXT_Q;
 
 	s = zfpm_g->obuf;
+	q_limit = FPM_QUEUE_PROCESS_LIMIT;
 
-	assert(stream_empty(s));
-
-	do {
-
+	do  {
 		/*
 		 * Make sure there is enough space to write another message.
 		 */
 		if (STREAM_WRITEABLE(s) < FPM_MAX_MSG_LEN)
-			break;
+			return FPM_WRITE_STOP;
 
 		buf = STREAM_DATA(s) + stream_get_endp(s);
 		buf_end = buf + STREAM_WRITEABLE(s);
 
 		dest = TAILQ_FIRST(&zfpm_g->dest_q);
 		if (!dest)
-			break;
+			return FPM_GOTO_NEXT_Q;
 
 		assert(CHECK_FLAG(dest->flags, RIB_DEST_UPDATE_FPM));
 
@@ -911,17 +978,17 @@ static void zfpm_build_updates(void)
 
 		/*
 		 * If this is a route deletion, and we have not sent the route
-		 * to
-		 * the FPM previously, skip it.
+		 * to the FPM previously, skip it.
 		 */
-		if (!is_add && !CHECK_FLAG(dest->flags, RIB_DEST_SENT_TO_FPM)) {
+		if (!is_add &&
+			!CHECK_FLAG(dest->flags, RIB_DEST_SENT_TO_FPM)) {
 			write_msg = 0;
 			zfpm_g->stats.nop_deletes_skipped++;
 		}
 
 		if (write_msg) {
 			data_len = zfpm_encode_route(dest, re, (char *)data,
-						     buf_end - data, &msg_type);
+						buf_end - data, &msg_type);
 
 			assert(data_len);
 			if (data_len) {
@@ -955,7 +1022,138 @@ static void zfpm_build_updates(void)
 		if (rib_gc_dest(dest->rnode))
 			zfpm_g->stats.dests_del_after_update++;
 
+		q_limit--;
+		if (q_limit == 0) {
+			/*
+			 * We have processed enough updates in this queue.
+			 * Now yield for other queues.
+			 */
+			return FPM_GOTO_NEXT_Q;
+		}
 	} while (1);
+}
+
+/*
+ * zfpm_encode_mac
+ *
+ * Encode a message to FPM with information about the given MAC.
+ *
+ * Returns the number of bytes written to the buffer. 0 or a negative
+ * value indicates an error.
+ */
+static inline int zfpm_encode_mac(struct fpm_mac_info_t *mac, char *in_buf,
+				size_t in_buf_len, fpm_msg_type_e *msg_type)
+{
+	size_t len;
+
+	len = 0;
+	*msg_type = FPM_MSG_TYPE_NONE;
+
+	switch (zfpm_g->message_format) {
+
+	/* We support only netlink encoding for MAC */
+	case ZFPM_MSG_FORMAT_NETLINK:
+#ifdef HAVE_NETLINK
+		len = zfpm_netlink_encode_mac(mac, in_buf, in_buf_len);
+		assert(fpm_msg_align(len) == len);
+		*msg_type = FPM_MSG_TYPE_NETLINK;
+#endif /* HAVE_NETLINK */
+		break;
+
+	default:
+		break;
+	}
+
+	return len;
+}
+
+static int zfpm_build_mac_updates(void)
+{
+	struct stream *s;
+	struct fpm_mac_info_t *mac;
+	unsigned char *buf, *data, *buf_end;
+	fpm_msg_hdr_t *hdr;
+	size_t data_len, msg_len;
+	fpm_msg_type_e msg_type;
+	uint16_t q_limit;
+
+	if (TAILQ_EMPTY(&zfpm_g->mac_q))
+		return FPM_GOTO_NEXT_Q;
+
+	s = zfpm_g->obuf;
+	q_limit = FPM_QUEUE_PROCESS_LIMIT;
+
+	do  {
+		/* Make sure there is enough space to write another message. */
+		if (STREAM_WRITEABLE(s) < FPM_MAX_MAC_MSG_LEN)
+			return FPM_WRITE_STOP;
+
+		buf = STREAM_DATA(s) + stream_get_endp(s);
+		buf_end = buf + STREAM_WRITEABLE(s);
+
+		mac = TAILQ_FIRST(&zfpm_g->mac_q);
+		if (!mac)
+			return FPM_GOTO_NEXT_Q;
+
+		/* Check for no-op */
+		if (!CHECK_FLAG(mac->fpm_flags, ZEBRA_MAC_UPDATE_FPM)) {
+			zfpm_g->stats.nop_deletes_skipped++;
+			zfpm_mac_info_del(mac);
+			continue;
+		}
+
+		hdr = (fpm_msg_hdr_t *)buf;
+		hdr->version = FPM_PROTO_VERSION;
+
+		data = fpm_msg_data(hdr);
+		data_len = zfpm_encode_mac(mac, (char *)data, buf_end - data,
+						&msg_type);
+		assert(data_len);
+
+		if (data_len) {
+			hdr->msg_type = msg_type;
+			msg_len = fpm_data_len_to_msg_len(data_len);
+			hdr->msg_len = htons(msg_len);
+			stream_forward_endp(s, msg_len);
+		}
+
+		/* Remove the MAC from the queue, and delete it. */
+		zfpm_mac_info_del(mac);
+
+		q_limit--;
+		if (q_limit == 0) {
+			/*
+			 * We have processed enough updates in this queue.
+			 * Now yield for other queues.
+			 */
+			return FPM_GOTO_NEXT_Q;
+		}
+	} while (1);
+}
+
+/*
+ * zfpm_build_updates
+ *
+ * Process the outgoing queues and write messages to the outbound
+ * buffer.
+ */
+static void zfpm_build_updates(void)
+{
+	struct stream *s;
+
+	s = zfpm_g->obuf;
+	assert(stream_empty(s));
+
+	do {
+		/*
+		 * Stop processing the queues if zfpm_g->obuf is full
+		 * or we do not have more updates to process
+		 */
+		if (zfpm_build_mac_updates() == FPM_WRITE_STOP)
+			break;
+		if (zfpm_build_route_updates() == FPM_WRITE_STOP)
+			break;
+	} while (zfpm_updates_pending());
 }
 
 /*
@@ -1277,6 +1475,243 @@ static int zfpm_trigger_update(struct route_node *rn, const char *reason)
 }
 
 /*
+ * Generate Key for FPM MAC info hash entry
+ * Key is generated using MAC address and VNI id which should be sufficient
+ * to provide uniqueness
+ */
+static unsigned int zfpm_mac_info_hash_keymake(void *p)
+{
+	struct fpm_mac_info_t *fpm_mac = p;
+	uint32_t mac_key;
+
+	mac_key = jhash(fpm_mac->macaddr.octet, ETH_ALEN, 0xa5a5a55a);
+
+	return jhash_2words(mac_key, fpm_mac->vni, 0);
+}
+
+/*
+ * Compare function for FPM MAC info hash lookup
+ */
+static bool zfpm_mac_info_cmp(const void *p1, const void *p2)
+{
+	const struct fpm_mac_info_t *fpm_mac1 = p1;
+	const struct fpm_mac_info_t *fpm_mac2 = p2;
+
+	if (fpm_mac1 == NULL && fpm_mac2 == NULL)
+		return true;
+	if (fpm_mac1 == NULL || fpm_mac2 == NULL)
+		return false;
+
+	if (memcmp(fpm_mac1->macaddr.octet, fpm_mac2->macaddr.octet, ETH_ALEN)
+			!= 0)
+		return false;
+	if (memcmp(&fpm_mac1->r_vtep_ip, &fpm_mac2->r_vtep_ip,
+			sizeof(struct in_addr)) != 0)
+		return false;
+	if (fpm_mac1->vni != fpm_mac2->vni)
+		return false;
+
+	return true;
+}
+
+/*
+ * Lookup FPM MAC info hash entry.
+ */
+static struct fpm_mac_info_t *zfpm_mac_info_lookup(struct fpm_mac_info_t *key)
+{
+	if (!key)
+		return NULL;
+
+	return hash_lookup(zfpm_g->fpm_mac_info_table, key);
+}
+
+/*
+ * Callback to allocate fpm_mac_info_t structure.
+ */
+static void *zfpm_mac_info_alloc(void *p)
+{
+	const struct fpm_mac_info_t *key = p;
+	struct fpm_mac_info_t *fpm_mac;
+
+	fpm_mac = XCALLOC(MTYPE_FPM_MAC_INFO, sizeof(struct fpm_mac_info_t));
+	if (!fpm_mac)
+		return NULL;
+	memcpy(&fpm_mac->macaddr, &key->macaddr, ETH_ALEN);
+	memcpy(&fpm_mac->r_vtep_ip, &key->r_vtep_ip, sizeof(struct in_addr));
+	fpm_mac->vni = key->vni;
+
+	return ((void *)fpm_mac);
+}
+
+static void fpm_mac_q_print(const char *reason)
+{
+#ifdef debug_rmac_fpm
+	struct fpm_mac_info_t *fm;
+	char buf[ETHER_ADDR_STRLEN];
+
+	zlog_debug("Display FPM queue start: Reason: %s\n\n", reason);
+	TAILQ_FOREACH(fm, &zfpm_g->mac_q, fpm_mac_q_entries) {
+		zlog_debug("FPM member: mac: %s, zflags: 0x%x, vxlan: %u, svi: %u, VTEP: %s, FPM flags 0x%x\n",
+			prefix_mac2str(&fm->macaddr, buf, sizeof(buf)),
+			fm->zebra_flags, fm->vxlan_if, fm->svi_if,
+			inet_ntoa(fm->r_vtep_ip), fm->fpm_flags);
+	}
+	zlog_debug("Display FPM queue end:\n\n");
+#endif
+}
+
+/*
+ * Delink and free fpm_mac_info_t.
+ */
+static void zfpm_mac_info_del(struct fpm_mac_info_t *fpm_mac)
+{
+	hash_release(zfpm_g->fpm_mac_info_table, fpm_mac);
+	TAILQ_REMOVE(&zfpm_g->mac_q, fpm_mac, fpm_mac_q_entries);
+	XFREE(MTYPE_FPM_MAC_INFO, fpm_mac);
+
+	fpm_mac_q_print("MAC info delete");
+}
+
+/*
+ * zfpm_trigger_rmac_update
+ *
+ * Zebra code invokes this function to indicate that we should
+ * send an update to FPM for given MAC entry.
+ *
+ * This function checks if we already have enqueued an update for this RMAC,
+ * If yes, update the same fpm_mac_info_t. Else, create and enqueue an update.
+ */
+static int zfpm_trigger_rmac_update(zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
+					bool delete, const char *reason)
+{
+	char buf[ETHER_ADDR_STRLEN];
+	struct fpm_mac_info_t *fpm_mac, key;
+	struct interface *vxlan_if, *svi_if;
+
+	/*
+	 * Ignore if the connection is down. We will update the FPM about
+	 * all destinations once the connection comes up.
+	 */
+	if (!zfpm_conn_is_up())
+		return 0;
+
+	if (reason) {
+		zfpm_debug("triggering update to FPM - Reason: %s - %s",
+			reason,
+			prefix_mac2str(&rmac->macaddr, buf, sizeof(buf)));
+	}
+
+	vxlan_if = zl3vni_map_to_vxlan_if(zl3vni);
+	svi_if = zl3vni_map_to_svi_if(zl3vni);
+
+	memset(&key, 0, sizeof(struct fpm_mac_info_t));
+
+	memcpy(&key.macaddr, &rmac->macaddr, ETH_ALEN);
+	memcpy(&key.r_vtep_ip, &rmac->fwd_info.r_vtep_ip,
+		sizeof(struct in_addr));
+	key.vni = zl3vni->vni;
+
+	/* Check if this MAC is already present in the queue. */
+	fpm_mac = zfpm_mac_info_lookup(&key);
+
+	if (fpm_mac) {
+		if (!!CHECK_FLAG(fpm_mac->fpm_flags, ZEBRA_MAC_DELETE_FPM)
+			== delete) {
+			/*
+			 * MAC is already present in the queue
+			 * with the same op as this one. Do nothing
+			 */
+			zfpm_g->stats.redundant_triggers++;
+			return 0;
+		}
+
+		/*
+		 * A new op for an already existing fpm_mac_info_t node.
+		 * Update the existing node for the new op.
+		 */
+		if (!delete) {
+			/*
+			 * New op is "add". Previous op is "delete".
+			 * Update the fpm_mac_info_t for the new add.
+			 */
+			memcpy(&fpm_mac->zebra_flags, &rmac->flags,
+				sizeof(uint32_t));
+
+			fpm_mac->vxlan_if = vxlan_if ? vxlan_if->ifindex : 0;
+			fpm_mac->svi_if = svi_if ? svi_if->ifindex : 0;
+
+			UNSET_FLAG(fpm_mac->fpm_flags, ZEBRA_MAC_DELETE_FPM);
+			SET_FLAG(fpm_mac->fpm_flags, ZEBRA_MAC_UPDATE_FPM);
+		} else {
+			/*
+			 * New op is "delete". Previous op is "add".
+			 * Thus, no-op. Unset ZEBRA_MAC_UPDATE_FPM flag.
+			 */
+			SET_FLAG(fpm_mac->fpm_flags, ZEBRA_MAC_DELETE_FPM);
+			UNSET_FLAG(fpm_mac->fpm_flags, ZEBRA_MAC_UPDATE_FPM);
+		}
+
+		fpm_mac_q_print("MAC info update");
+
+		return 0;
+	}
+
+	fpm_mac = hash_get(zfpm_g->fpm_mac_info_table, &key,
+				zfpm_mac_info_alloc);
+	if (!fpm_mac)
+		return 0;
+
+	memcpy(&fpm_mac->zebra_flags, &rmac->flags, sizeof(uint32_t));
+
+	fpm_mac->vxlan_if = vxlan_if ? vxlan_if->ifindex : 0;
+	fpm_mac->svi_if = svi_if ? svi_if->ifindex : 0;
+
+	SET_FLAG(fpm_mac->fpm_flags, ZEBRA_MAC_UPDATE_FPM);
+	if (delete)
+		SET_FLAG(fpm_mac->fpm_flags, ZEBRA_MAC_DELETE_FPM);
+
+	TAILQ_INSERT_TAIL(&zfpm_g->mac_q, fpm_mac, fpm_mac_q_entries);
+
+	fpm_mac_q_print("MAC info add");
+
+	zfpm_g->stats.updates_triggered++;
+
+	 /* If writes are already enabled, return. */
+	if (zfpm_g->t_write)
+		return 0;
+
+	zfpm_write_on();
+	return 0;
+}
+
+/*
+ * This function is called when the FPM connections is established.
+ * Iterate over all the RMAC entries for the given L3VNI
+ * and enqueue the RMAC for FPM processing.
+ */
+static void zfpm_trigger_rmac_update_wrapper(struct hash_backet *backet,
+						void *args)
+{
+	zebra_mac_t *zrmac = (zebra_mac_t *)backet->data;
+	zebra_l3vni_t *zl3vni = (zebra_l3vni_t *)args;
+
+	zfpm_trigger_rmac_update(zrmac, zl3vni, false, "RMAC added");
+}
+
+/*
+ * This function is called when the FPM connections is established.
+ * This function iterates over all the L3VNIs to trigger
+ * FPM updates for RMACs currently available.
+ */
+static void zfpm_iterate_rmac_table(struct hash_backet *backet, void *args)
+{
+	zebra_l3vni_t *zl3vni = (zebra_l3vni_t *)backet->data;
+
+	hash_iterate(zl3vni->rmac_table, zfpm_trigger_rmac_update_wrapper,
+			(void *)zl3vni);
+}
+
+/*
  * zfpm_stats_timer_cb
  */
 static int zfpm_stats_timer_cb(struct thread *t)
@@ -1589,6 +2024,13 @@ static int zfpm_init(struct thread_master *master)
 	memset(zfpm_g, 0, sizeof(*zfpm_g));
 	zfpm_g->master = master;
 	TAILQ_INIT(&zfpm_g->dest_q);
+	TAILQ_INIT(&zfpm_g->mac_q);
+
+	/* Create hash table for fpm_mac_info_t enties */
+	zfpm_g->fpm_mac_info_table = hash_create(zfpm_mac_info_hash_keymake,
+						zfpm_mac_info_cmp,
+						"FPM MAC info hash table");
+
 	zfpm_g->sock = -1;
 	zfpm_g->state = ZFPM_STATE_IDLE;
 
@@ -1631,6 +2073,7 @@ static int zfpm_init(struct thread_master *master)
 static int zebra_fpm_module_init(void)
 {
 	hook_register(rib_update, zfpm_trigger_update);
+	hook_register(zebra_rmac_update, zfpm_trigger_rmac_update);
 	hook_register(frr_late_init, zfpm_init);
 	return 0;
 }

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -40,6 +40,7 @@
 #include "nexthop.h"
 
 #include "zebra/zebra_fpm_private.h"
+#include "zebra/zebra_vxlan_private.h"
 
 /*
  * addr_to_a
@@ -101,6 +102,49 @@ static size_t af_addr_size(uint8_t af)
 }
 
 /*
+ * We plan to use RTA_ENCAP_TYPE attribute for VxLAN encap as well.
+ * Currently, values 0 to 8 for this attribute are used by lwtunnel_encap_types
+ * So, we cannot use these values for VxLAN encap.
+ */
+enum fpm_nh_encap_type_t {
+	FPM_NH_ENCAP_NONE = 0,
+	FPM_NH_ENCAP_VXLAN = 100,
+	FPM_NH_ENCAP_MAX,
+};
+
+/*
+ * fpm_nh_encap_type_to_str
+ */
+static const char *fpm_nh_encap_type_to_str(enum fpm_nh_encap_type_t encap_type)
+{
+	switch (encap_type) {
+	case FPM_NH_ENCAP_NONE:
+		return "none";
+
+	case FPM_NH_ENCAP_VXLAN:
+		return "VxLAN";
+
+	default:
+		return "Invalid";
+	}
+}
+
+struct vxlan_encap_info_t {
+	vni_t vni;
+};
+
+enum vxlan_encap_info_type_t {
+	VXLAN_VNI = 0,
+};
+
+struct fpm_nh_encap_info_t {
+	enum fpm_nh_encap_type_t encap_type;
+	union {
+		struct vxlan_encap_info_t vxlan_encap;
+	};
+};
+
+/*
  * netlink_nh_info_t
  *
  * Holds information about a single nexthop for netlink. These info
@@ -117,6 +161,7 @@ typedef struct netlink_nh_info_t_ {
 	 */
 	int recursive;
 	enum nexthop_types_t type;
+	struct fpm_nh_encap_info_t encap_info;
 } netlink_nh_info_t;
 
 /*
@@ -150,10 +195,12 @@ typedef struct netlink_route_info_t_ {
  * Returns TRUE if a nexthop was added, FALSE otherwise.
  */
 static int netlink_route_info_add_nh(netlink_route_info_t *ri,
-				     struct nexthop *nexthop)
+				     struct nexthop *nexthop,
+				     struct route_entry *re)
 {
 	netlink_nh_info_t nhi;
 	union g_addr *src;
+	zebra_l3vni_t *zl3vni = NULL;
 
 	memset(&nhi, 0, sizeof(nhi));
 	src = NULL;
@@ -184,6 +231,17 @@ static int netlink_route_info_add_nh(netlink_route_info_t *ri,
 
 	if (!nhi.gateway && nhi.if_index == 0)
 		return 0;
+
+	if (re && CHECK_FLAG(re->flags, ZEBRA_FLAG_EVPN_ROUTE)) {
+		nhi.encap_info.encap_type = FPM_NH_ENCAP_VXLAN;
+
+		zl3vni = zl3vni_from_vrf(ri->rtm_table);
+		if (zl3vni && is_l3vni_oper_up(zl3vni)) {
+
+			/* Add VNI to VxLAN encap info */
+			nhi.encap_info.vxlan_encap.vni = zl3vni->vni;
+		}
+	}
 
 	/*
 	 * We have a valid nhi. Copy the structure over to the route_info.
@@ -277,7 +335,7 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 		     && CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 		    || (cmd == RTM_DELROUTE
 			&& CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED))) {
-			netlink_route_info_add_nh(ri, nexthop);
+			netlink_route_info_add_nh(ri, nexthop, re);
 		}
 	}
 
@@ -303,6 +361,10 @@ static int netlink_route_info_encode(netlink_route_info_t *ri, char *in_buf,
 	unsigned int nexthop_num = 0;
 	size_t buf_offset;
 	netlink_nh_info_t *nhi;
+	enum fpm_nh_encap_type_t encap;
+	struct rtattr *nest;
+	struct vxlan_encap_info_t *vxlan;
+	int nest_len;
 
 	struct {
 		struct nlmsghdr n;
@@ -327,7 +389,14 @@ static int netlink_route_info_encode(netlink_route_info_t *ri, char *in_buf,
 	req->n.nlmsg_flags = NLM_F_CREATE | NLM_F_REQUEST;
 	req->n.nlmsg_type = ri->nlmsg_type;
 	req->r.rtm_family = ri->af;
-	req->r.rtm_table = ri->rtm_table;
+
+	if (ri->rtm_table < 256)
+		req->r.rtm_table = ri->rtm_table;
+	else {
+		req->r.rtm_table = RT_TABLE_UNSPEC;
+		addattr32(&req->n, in_buf_len, RTA_TABLE, ri->rtm_table);
+	}
+
 	req->r.rtm_dst_len = ri->prefix->prefixlen;
 	req->r.rtm_protocol = ri->rtm_protocol;
 	req->r.rtm_scope = RT_SCOPE_UNIVERSE;
@@ -353,6 +422,24 @@ static int netlink_route_info_encode(netlink_route_info_t *ri, char *in_buf,
 
 		if (nhi->if_index) {
 			addattr32(&req->n, in_buf_len, RTA_OIF, nhi->if_index);
+		}
+
+		encap = nhi->encap_info.encap_type;
+		if (encap > FPM_NH_ENCAP_NONE) {
+			addattr_l(&req->n, in_buf_len, RTA_ENCAP_TYPE, &encap,
+					sizeof(uint16_t));
+			switch (encap) {
+			case FPM_NH_ENCAP_VXLAN:
+				vxlan = &nhi->encap_info.vxlan_encap;
+				nest = addattr_nest(&req->n, in_buf_len,
+							RTA_ENCAP);
+				addattr32(&req->n, in_buf_len, VXLAN_VNI,
+						vxlan->vni);
+				addattr_nest_end(&req->n, nest);
+				break;
+			default:
+				break;
+			}
 		}
 
 		goto done;
@@ -386,6 +473,26 @@ static int netlink_route_info_encode(netlink_route_info_t *ri, char *in_buf,
 
 		if (nhi->if_index) {
 			rtnh->rtnh_ifindex = nhi->if_index;
+		}
+
+		encap = nhi->encap_info.encap_type;
+		if (encap > FPM_NH_ENCAP_NONE) {
+			rta_addattr_l(rta, sizeof(buf), RTA_ENCAP_TYPE,
+					&encap, sizeof(uint16_t));
+			rtnh->rtnh_len += sizeof(struct rtattr) +
+						sizeof(uint16_t);
+			switch (encap) {
+			case FPM_NH_ENCAP_VXLAN:
+				vxlan = &nhi->encap_info.vxlan_encap;
+				nest = rta_nest(rta, sizeof(buf), RTA_ENCAP);
+				rta_addattr_l(rta, sizeof(buf), VXLAN_VNI,
+						&vxlan->vni, sizeof(uint32_t));
+				nest_len = rta_nest_end(rta, nest);
+				rtnh->rtnh_len += nest_len;
+				break;
+			default:
+				break;
+			}
 		}
 
 		rtnh = RTNH_NEXT(rtnh);
@@ -424,10 +531,11 @@ static void zfpm_log_route_info(netlink_route_info_t *ri, const char *label)
 
 	for (i = 0; i < ri->num_nhs; i++) {
 		nhi = &ri->nhs[i];
-		zfpm_debug("  Intf: %u, Gateway: %s, Recursive: %s, Type: %s",
-			   nhi->if_index, addr_to_a(ri->af, nhi->gateway),
-			   nhi->recursive ? "yes" : "no",
-			   nexthop_type_to_str(nhi->type));
+		zfpm_debug("  Intf: %u, Gateway: %s, Recursive: %s, Type: %s, Encap type: %s",
+			nhi->if_index, addr_to_a(ri->af, nhi->gateway),
+			nhi->recursive ? "yes" : "no",
+			nexthop_type_to_str(nhi->type),
+			fpm_nh_encap_type_to_str(nhi->encap_info.encap_type));
 	}
 }
 
@@ -453,6 +561,70 @@ int zfpm_netlink_encode_route(int cmd, rib_dest_t *dest, struct route_entry *re,
 	zfpm_log_route_info(ri, __FUNCTION__);
 
 	return netlink_route_info_encode(ri, in_buf, in_buf_len);
+}
+
+/*
+ * zfpm_netlink_encode_mac
+ *
+ * Create a netlink message corresponding to the given MAC.
+ *
+ * Returns the number of bytes written to the buffer. 0 or a negative
+ * value indicates an error.
+ */
+int zfpm_netlink_encode_mac(struct fpm_mac_info_t *mac, char *in_buf,
+				size_t in_buf_len)
+{
+	char buf1[ETHER_ADDR_STRLEN];
+	size_t buf_offset;
+
+	struct {
+		struct nlmsghdr hdr;
+		struct ndmsg ndm;
+		char buf[0];
+	} *req;
+	req = (void *)in_buf;
+
+	buf_offset = ((char *)req->buf) - ((char *)req);
+	if (in_buf_len < buf_offset)
+		return 0;
+	memset(req, 0, buf_offset);
+
+	/* Construct nlmsg header */
+	req->hdr.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
+	req->hdr.nlmsg_type = CHECK_FLAG(mac->fpm_flags, ZEBRA_MAC_DELETE_FPM) ?
+				RTM_DELNEIGH : RTM_NEWNEIGH;
+	req->hdr.nlmsg_flags = NLM_F_REQUEST;
+	if (req->hdr.nlmsg_type == RTM_NEWNEIGH)
+		req->hdr.nlmsg_flags |= (NLM_F_CREATE | NLM_F_REPLACE);
+
+	/* Construct ndmsg */
+	req->ndm.ndm_family = AF_BRIDGE;
+	req->ndm.ndm_ifindex = mac->vxlan_if;
+
+	req->ndm.ndm_state = NUD_REACHABLE;
+	req->ndm.ndm_flags |= NTF_SELF | NTF_MASTER;
+	if (CHECK_FLAG(mac->zebra_flags,
+		(ZEBRA_MAC_STICKY | ZEBRA_MAC_REMOTE_DEF_GW)))
+		req->ndm.ndm_state |= NUD_NOARP;
+	else
+		req->ndm.ndm_flags |= NTF_EXT_LEARNED;
+
+	/* Add attributes */
+	addattr_l(&req->hdr, in_buf_len, NDA_LLADDR, &mac->macaddr, 6);
+	addattr_l(&req->hdr, in_buf_len, NDA_DST, &mac->r_vtep_ip, 4);
+	addattr32(&req->hdr, in_buf_len, NDA_MASTER, mac->svi_if);
+	addattr32(&req->hdr, in_buf_len, NDA_VNI, mac->vni);
+
+	assert(req->hdr.nlmsg_len < in_buf_len);
+
+	zfpm_debug("Tx %s family %s ifindex %u MAC %s DEST %s",
+			nl_msg_type_to_str(req->hdr.nlmsg_type),
+			nl_family_to_str(req->ndm.ndm_family),
+			req->ndm.ndm_ifindex,
+			prefix_mac2str(&mac->macaddr, buf1, sizeof(buf1)),
+			inet_ntoa(mac->r_vtep_ip));
+
+	return req->hdr.nlmsg_len;
 }
 
 #endif /* HAVE_NETLINK */

--- a/zebra/zebra_fpm_private.h
+++ b/zebra/zebra_fpm_private.h
@@ -25,12 +25,42 @@
 #define _ZEBRA_FPM_PRIVATE_H
 
 #include "zebra/debug.h"
+#include "zebra_vxlan_private.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+
+/* This structure contains the MAC addresses enqueued for FPM processing. */
+struct fpm_mac_info_t {
+	struct ethaddr macaddr;
+	uint32_t zebra_flags; /* Could be used to build FPM messages */
+	vni_t vni;
+	ifindex_t vxlan_if;
+	ifindex_t svi_if; /* L2 or L3 Bridge interface */
+	struct in_addr r_vtep_ip; /* Remote VTEP IP */
+
+	/* Linkage to put MAC on the FPM processing queue. */
+	TAILQ_ENTRY(fpm_mac_info_t) fpm_mac_q_entries;
+
+	uint8_t fpm_flags;
+
+#define ZEBRA_MAC_UPDATE_FPM 0x1 /* This flag indicates if we want to upadte
+				  * data plane for this MAC. If a MAC is added
+				  * and then deleted immediately, we do not want
+				  * to update data plane for such operation.
+				  * Unset the ZEBRA_MAC_UPDATE_FPM flag in this
+				  * case. FPM thread while processing the queue
+				  * node will check this flag and dequeue the
+				  * node silently without sending any update to
+				  * the data plane.
+				  */
+#define ZEBRA_MAC_DELETE_FPM 0x2 /* This flag is set if it is a delete operation
+				  * for the MAC.
+				  */
+};
 
 #define zfpm_debug(...)                                                        \
 	do {                                                                   \
@@ -65,6 +95,9 @@ extern int zfpm_protobuf_encode_route(rib_dest_t *dest, struct route_entry *re,
 				      uint8_t *in_buf, size_t in_buf_len);
 
 extern struct route_entry *zfpm_route_for_update(rib_dest_t *dest);
+
+extern int zfpm_netlink_encode_mac(struct fpm_mac_info_t *mac, char *in_buf,
+				size_t in_buf_len);
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -430,6 +430,14 @@ struct nh_walk_ctx {
 	struct json_object *json;
 };
 
+extern struct interface *zl3vni_map_to_vxlan_if(zebra_l3vni_t *zl3vni);
+extern struct interface *zl3vni_map_to_svi_if(zebra_l3vni_t *zl3vni);
+extern zebra_l3vni_t *zl3vni_from_vrf(vrf_id_t vrf_id);
+
+DECLARE_HOOK(zebra_rmac_update, (zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
+		bool delete, const char *reason),
+		(rmac, zl3vni, delete, reason))
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
…g format

FPM enhancements for EVPN type-5 routes:
- Remote RMAC info is stored in zebra for a given L3VNI. We need to send this
info to the data plane using FPM module.
- A queue is used for FPM processing of the route nodes. We plan to use another
queue structure for RMAC updates.
- After zebra RMAC info is populated in the corresponding L3VNI table, zebra
read thread will schedule this RMAC for FPM processing using a mac_q.
- FPM thread will dequeue the RMAC updates one by one, encode this update into
an FPM message (using NETLINK encoding format) and send this message for write
over the FPM socket.
- We will use a generic fpm_mac_info_t structure to store RMAC into the FPM
queue. Thus, this design can be extended in the future for other EVPN MAC
updates as well.
- Thus, each EVPN route type-5 update will generate 2 FPM messages. One message
will contain RMAC info (RMAC, RVTEP and L3VNI). Another message will contain
route info (prefix, nexthop).
- For data plane processing, we also need to add encap type and L3VNI info to
the route message.

Design details:

Data structures for RMAC in FPM:
- FPM MAC structure: This data structure will contain all the information
required for FPM message generation for an RMAC.
struct fpm_mac_info_t {
	struct ethaddr macaddr;
	uint32_t zebra_flags; /* Could be used to build FPM messages */
	vni_t vni;
	ifindex_t vxlan_if;
	ifindex_t svi_if; /* L2 or L3 Bridge interface */
	struct in_addr r_vtep_ip; /* Remote VTEP IP */
	/* Linkage to put MAC on the FPM processing queue. */
	TAILQ_ENTRY(fpm_mac_info_t) fpm_mac_q_entries;
	uint8_t fpm_flags;
};

- Queue structure for FPM processing:
For FPM processing, we build a queue of "fpm_mac_info_t". When RMAC is added or
deleted from zebra, fpm_mac_info_t node is enqueued in this queue for the
corresponding operation. FPM thread will dequeue these nodes one by one to
generate a netlink message.

TAILQ_HEAD(zfpm_mac_q, fpm_mac_info_t) mac_q;

- Hash table for "fpm_mac_info_t"
When zebra tries to enqueue fpm_mac_info_t for a new RMAC add/delete operation,
it is possible that this RMAC is already present in the queue. So, to avoid
multiple messages for duplicate RMAC nodes, insert fpm_mac_info_t into a hash
table.
/*
 * Hash of MAC entries in mac_q
 * This is needed for fast lookup to avoid duplicate insertion in mac_q
 */
struct hash *fpm_mac_info_table;

    - Before enqueueing any RMAC, try to fetch the fpm_mac_info_t from the hash
    table first.
    - Entry is deleted from the hash table when the node is dequeued.
    - For hash table key generation, parameters used are "mac adress" and "vni"
    This will provide a fairly unique key for a MAC (fpm_mac_info_hash_keymake).
    - Compare function uses "mac address", "RVTEP address" and "VNI" as the key
    which is sufficient to distinguish any two RMACs. This compare function is
    used for fpm_mac_info_t lookup (zfpm_mac_info_cmp).

- Handle RMAC add/delete operation in Zebra
    - Define a hook "zebra_mac_update" which can be registered by multiple
      data plane components (e.g. FPM, dplane).
DEFINE_HOOK(zebra_rmac_update, (zebra_mac_t *rmac, zebra_l3vni_t *zl3vni, bool
delete, const char *reason), (rmac, zl3vni, delete, reason))
    - While performing RMAC add/delete for an L3VNI, call "zebra_mac_update"
      hook.
    - This hook call triggers "zfpm_trigger_rmac_update". In this function, we
      do a lookup for the RMAC in fpm_mac_info_table. If already present, this
      node is updated with the latest RMAC info. Else, a new fpm_mac_info_t node
      is created and inserted in the queue and hash data structures.

- FPM processing of mac_q and dest_q
    - FPM write thread calls "zfpm_build_updates()" to process mac_q and dest_q
      and to write update buffer over the FPM socket.
    - "zfpm_build_updates()" processes all the update queues one by one in a
      while loop. It will break the while loop and return if Queue processing
      function returns "FPM_WRITE_STOP" OR FPM write buffer is full OR all the
      queues are empty (no more update to process).
    - "zfpm_build_route_updates()" dequeues and processes route nodes from
      "dest_q".
    - "zfpm_build_mac_updates()" dequeues and processes RMAC nodes from "mac_q"
    - These queue processing functions return with "FPM_WRITE_STOP" if the write
      buffer is full. Return value is "FPM_GOTO_NEXT_Q" if enough updates are
      processed from this queue and we want to move on to the next queue.
    - In each call, a queue processing function will process max
      "FPM_QUEUE_PROCESS_LIMIT (10000)" updates to avoid starvation of other
      queues.

- Nelink message for RMAC updates
    - Function "zfpm_netlink_encode_mac()" builds a netlink message for RMAC
      updates.
    - To build a netlink message for RMAC updates, we use "ndmsg" in rtlink.
    - FPM Message structure is: FPM header -> nlmsg header -> ndmsg fields -> ndmsg attributes
Netlink message will look like:
{'ndm_type': 0, 'family': 7, '__pad': (), 'header': {'flags': 1281, 'length':
64, 'type': 28, 'pid': 0, 'sequence_number': 0}, 'state': 2, 'flags': 22,
'attrs': [('NDA_LLADDR', 'b2:66:eb:b9:5b:d3'), ('NDA_DST', '10.100.0.2'),
('NDA_MASTER', 11), ('NDA_VNI', 1000)], 'ifindex': 18}
Message bytestring:
'@\x00\x00\x00\x1c\x00\x01\x05\x00\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x12\x00\x00\x00\x02\x00\x16\x00\n\x00\x02\x00\xe6+\xf5{\x17\xbf\x00\x00\x08\x00\x01\x00\nd\x00\x03\x08\x00\t\x00\x0b\x00\x00\x00\x08\x00\x07\x00\xe8\x03\x00\x00'

- Message details:
nlmsghdr.nlmsg_type = RTM_NEWNEIGH(28) or RTM_DELNEIGH(29)
nlmsghdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_REPLACE for "add" ,
"NLM_F_REQUEST" for delete.
ndmsg.ndm_family = AF_BRIDGE
ndmsg.ndm_ifindex = mac?vxlan_if (ifindex)
ndmsg.ndm_state = NUD_REACHABLE
ndmsg.ndm_flags |= NTF_SELF | NTF_MASTER | NTF_EXT_LEARNED
Attribute "NDA_LLADDR" for MAC address
Attribute "NDA_DST" for remote vtep ip.
Attribute "NDA_MASTER" for bridge interface ifindex.
Attribute "NDA_VNI" for VNI id.

- Changes for route message

Encap type:
    - For data plane processing, we need to add encap type and L3VNI info to the
      route message.
    - Add "RTA_ENCAP_TYPE" attribute for VxLAN encap with value 100. This value
      is not currently used for RTA_ENCAP_TYPE
    - If "RTA_ENCAP_TYPE" is 100, add "RTA_ENCAP" attribute with "RTA_VNI" as a
      nested attribute of RTA_ENCAP

    Format of VNI attribute:
    Len(2 bytes)    type (2 bytes)    Value(4 bytes)(VNI)
    00    08     :     00    00     :            1000

    RTA_VNI attribute is a custom attribute.

Table ID:
    - rtm_table field in the rtmsg is used to encode vrf_id for a netlink msg.
      This field is 8 bit long. Thus, it cannot accommodate a vrf_id that is
      greater than 255
    - Thus, for a vrf_id greater than 255, set rtm_table to RT_TABLE_UNSPEC and
      add RTA_TABLE attribute with value set to vrf_id

- Handle FPM connection up/down events
When the connection with the FPM socket is established, iterate through all the
L3VNIs and send all the RMACs for FPM processing "zfpm_conn_up_thread_cb"
When the FPM connection goes down, empty mac_q and FPM mac info hash table
"zfpm_conn_down_thread_cb"

Signed-off-by: Ameya Dharkar <adharkar@vmware.com>