### PR TITLE
Zebra: EVPN remote RMAC download via FPM channel using netlink msg format

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1052,6 +1052,11 @@ static inline int zfpm_encode_mac(struct fpm_mac_info_t *mac, char *in_buf,
 	case ZFPM_MSG_FORMAT_NONE:
 		break;
 	case ZFPM_MSG_FORMAT_NETLINK:
+#ifdef HAVE_NETLINK
+		len = zfpm_netlink_encode_mac(mac, in_buf, in_buf_len);
+		assert(fpm_msg_align(len) == len);
+		*msg_type = FPM_MSG_TYPE_NETLINK;
+#endif /* HAVE_NETLINK */
 		break;
 	case ZFPM_MSG_FORMAT_PROTOBUF:
 		break;
@@ -1100,7 +1105,7 @@ static int zfpm_build_mac_updates(void)
 		data = fpm_msg_data(hdr);
 		data_len = zfpm_encode_mac(mac, (char *)data, buf_end - data,
 						&msg_type);
-		/* assert(data_len); */
+		assert(data_len);
 
 		hdr->msg_type = msg_type;
 		msg_len = fpm_data_len_to_msg_len(data_len);

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1030,7 +1030,7 @@ static int zfpm_build_route_updates(void)
 			 */
 			return FPM_GOTO_NEXT_Q;
 		}
-	} while (1);
+	} while (true);
 }
 
 /*
@@ -1623,8 +1623,7 @@ static int zfpm_trigger_rmac_update(zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
 	if (!fpm_mac)
 		return 0;
 
-	memcpy(&fpm_mac->zebra_flags, &rmac->flags, sizeof(uint32_t));
-
+	fpm_mac->zebra_flags = rmac->flags;
 	fpm_mac->vxlan_if = vxlan_if ? vxlan_if->ifindex : 0;
 	fpm_mac->svi_if = svi_if ? svi_if->ifindex : 0;
 

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -594,14 +594,14 @@ int zfpm_netlink_encode_mac(struct fpm_mac_info_t *mac, char *in_buf,
 	char buf1[ETHER_ADDR_STRLEN];
 	size_t buf_offset;
 
-	struct {
+	struct macmsg {
 		struct nlmsghdr hdr;
 		struct ndmsg ndm;
 		char buf[0];
 	} *req;
 	req = (void *)in_buf;
 
-	buf_offset = ((char *)req->buf) - ((char *)req);
+	buf_offset = offsetof(struct macmsg, buf);
 	if (in_buf_len < buf_offset)
 		return 0;
 	memset(req, 0, buf_offset);

--- a/zebra/zebra_fpm_private.h
+++ b/zebra/zebra_fpm_private.h
@@ -53,6 +53,34 @@ static inline void zfpm_debug(const char *format, ...)
 }
 #endif
 
+/* This structure contains the MAC addresses enqueued for FPM processing. */
+struct fpm_mac_info_t {
+	struct ethaddr macaddr;
+	uint32_t zebra_flags; /* Could be used to build FPM messages */
+	vni_t vni;
+	ifindex_t vxlan_if;
+	ifindex_t svi_if; /* L2 or L3 Bridge interface */
+	struct in_addr r_vtep_ip; /* Remote VTEP IP */
+
+	/* Linkage to put MAC on the FPM processing queue. */
+	TAILQ_ENTRY(fpm_mac_info_t) fpm_mac_q_entries;
+
+	uint8_t fpm_flags;
+
+#define ZEBRA_MAC_UPDATE_FPM 0x1 /* This flag indicates if we want to upadte
+				  * data plane for this MAC. If a MAC is added
+				  * and then deleted immediately, we do not want
+				  * to update data plane for such operation.
+				  * Unset the ZEBRA_MAC_UPDATE_FPM flag in this
+				  * case. FPM thread while processing the queue
+				  * node will check this flag and dequeue the
+				  * node silently without sending any update to
+				  * the data plane.
+				  */
+#define ZEBRA_MAC_DELETE_FPM 0x2 /* This flag is set if it is a delete operation
+				  * for the MAC.
+				  */
+};
 
 /*
  * Externs

--- a/zebra/zebra_fpm_private.h
+++ b/zebra/zebra_fpm_private.h
@@ -92,6 +92,9 @@ extern int zfpm_netlink_encode_route(int cmd, rib_dest_t *dest,
 extern int zfpm_protobuf_encode_route(rib_dest_t *dest, struct route_entry *re,
 				      uint8_t *in_buf, size_t in_buf_len);
 
+extern int zfpm_netlink_encode_mac(struct fpm_mac_info_t *mac, char *in_buf,
+				   size_t in_buf_len);
+
 extern struct route_entry *zfpm_route_for_update(rib_dest_t *dest);
 
 #ifdef __cplusplus

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -60,6 +60,9 @@ DEFINE_MTYPE_STATIC(ZEBRA, MAC, "VNI MAC");
 DEFINE_MTYPE_STATIC(ZEBRA, NEIGH, "VNI Neighbor");
 DEFINE_MTYPE_STATIC(ZEBRA, ZVXLAN_SG, "zebra VxLAN multicast group");
 
+DEFINE_HOOK(zebra_rmac_update, (zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
+	    bool delete, const char *reason), (rmac, zl3vni, delete, reason))
+
 /* definitions */
 /* PMSI strings. */
 #define VXLAN_FLOOD_STR_NO_INFO "-"
@@ -143,8 +146,6 @@ static zebra_l3vni_t *zl3vni_lookup(vni_t vni);
 static void *zl3vni_alloc(void *p);
 static zebra_l3vni_t *zl3vni_add(vni_t vni, vrf_id_t vrf_id);
 static int zl3vni_del(zebra_l3vni_t *zl3vni);
-static struct interface *zl3vni_map_to_svi_if(zebra_l3vni_t *zl3vni);
-static struct interface *zl3vni_map_to_vxlan_if(zebra_l3vni_t *zl3vni);
 static void zebra_vxlan_process_l3vni_oper_up(zebra_l3vni_t *zl3vni);
 static void zebra_vxlan_process_l3vni_oper_down(zebra_l3vni_t *zl3vni);
 
@@ -4459,6 +4460,10 @@ static int zl3vni_remote_rmac_add(zebra_l3vni_t *zl3vni, struct ethaddr *rmac,
 		memset(&zrmac->fwd_info, 0, sizeof(zrmac->fwd_info));
 		zrmac->fwd_info.r_vtep_ip = vtep_ip->ipaddr_v4;
 
+		/* Send RMAC for FPM processing */
+		hook_call(zebra_rmac_update, zrmac, zl3vni, false,
+			  "new RMAC added");
+
 		/* install rmac in kernel */
 		zl3vni_rmac_install(zl3vni, zrmac);
 	}
@@ -4478,6 +4483,10 @@ static void zl3vni_remote_rmac_del(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac,
 	if (RB_EMPTY(host_rb_tree_entry, &zrmac->host_rb)) {
 		/* uninstall from kernel */
 		zl3vni_rmac_uninstall(zl3vni, zrmac);
+
+		/* Send RMAC for FPM processing */
+		hook_call(zebra_rmac_update, zrmac, zl3vni, true,
+			  "RMAC deleted");
 
 		/* del the rmac entry */
 		zl3vni_rmac_del(zl3vni, zrmac);
@@ -4790,7 +4799,7 @@ static int zl3vni_del(zebra_l3vni_t *zl3vni)
 	return 0;
 }
 
-static struct interface *zl3vni_map_to_vxlan_if(zebra_l3vni_t *zl3vni)
+struct interface *zl3vni_map_to_vxlan_if(zebra_l3vni_t *zl3vni)
 {
 	struct zebra_ns *zns = NULL;
 	struct route_node *rn = NULL;
@@ -4821,7 +4830,7 @@ static struct interface *zl3vni_map_to_vxlan_if(zebra_l3vni_t *zl3vni)
 	return NULL;
 }
 
-static struct interface *zl3vni_map_to_svi_if(zebra_l3vni_t *zl3vni)
+struct interface *zl3vni_map_to_svi_if(zebra_l3vni_t *zl3vni)
 {
 	struct zebra_if *zif = NULL;	   /* zebra_if for vxlan_if */
 	struct zebra_l2info_vxlan *vxl = NULL; /* l2 info for vxlan_if */
@@ -5089,6 +5098,10 @@ static void zl3vni_del_rmac_hash_entry(struct hash_bucket *bucket, void *ctx)
 	zrmac = (zebra_mac_t *)bucket->data;
 	zl3vni = (zebra_l3vni_t *)ctx;
 	zl3vni_rmac_uninstall(zl3vni, zrmac);
+
+	/* Send RMAC for FPM processing */
+	hook_call(zebra_rmac_update, zrmac, zl3vni, true, "RMAC deleted");
+
 	zl3vni_rmac_del(zl3vni, zrmac);
 }
 

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -431,6 +431,12 @@ struct nh_walk_ctx {
 };
 
 extern zebra_l3vni_t *zl3vni_from_vrf(vrf_id_t vrf_id);
+extern struct interface *zl3vni_map_to_vxlan_if(zebra_l3vni_t *zl3vni);
+extern struct interface *zl3vni_map_to_svi_if(zebra_l3vni_t *zl3vni);
+
+DECLARE_HOOK(zebra_rmac_update, (zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
+	     bool delete, const char *reason), (rmac, zl3vni, delete, reason))
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
FPM enhancements for EVPN type-5 routes:
- Remote RMAC info is stored in zebra for a given L3VNI. We need to send this
info to the data plane using FPM module.
- A queue is used for FPM processing of the route nodes. We plan to use another
queue structure for RMAC updates.
- After zebra RMAC info is populated in the corresponding L3VNI table, zebra
read thread will schedule this RMAC for FPM processing using a mac_q.
- FPM thread will dequeue the RMAC updates one by one, encode this update into
an FPM message (using NETLINK encoding format) and send this message for write
over the FPM socket.
- We will use a generic fpm_mac_info_t structure to store RMAC into the FPM
queue. Thus, this design can be extended in the future for other EVPN MAC
updates as well.
- Thus, each EVPN route type-5 update will generate 2 FPM messages. One message
will contain RMAC info (RMAC, RVTEP and L3VNI). Another message will contain
route info (prefix, nexthop).

Design details:

Data structures for RMAC in FPM:
- FPM MAC structure: This data structure will contain all the information
required for FPM message generation for an RMAC.
struct fpm_mac_info_t {
	struct ethaddr macaddr;
	uint32_t zebra_flags; /* Could be used to build FPM messages */
	vni_t vni;
	ifindex_t vxlan_if;
	ifindex_t svi_if; /* L2 or L3 Bridge interface */
	struct in_addr r_vtep_ip; /* Remote VTEP IP */
	/* Linkage to put MAC on the FPM processing queue. */
	TAILQ_ENTRY(fpm_mac_info_t) fpm_mac_q_entries;
	uint8_t fpm_flags;
};

- Queue structure for FPM processing:
For FPM processing, we build a queue of "fpm_mac_info_t". When RMAC is added or
deleted from zebra, fpm_mac_info_t node is enqueued in this queue for the
corresponding operation. FPM thread will dequeue these nodes one by one to
generate a netlink message.

TAILQ_HEAD(zfpm_mac_q, fpm_mac_info_t) mac_q;

- Hash table for "fpm_mac_info_t"
When zebra tries to enqueue fpm_mac_info_t for a new RMAC add/delete operation,
it is possible that this RMAC is already present in the queue. So, to avoid
multiple messages for duplicate RMAC nodes, insert fpm_mac_info_t into a hash
table.
/*
 * Hash of MAC entries in mac_q
 * This is needed for fast lookup to avoid duplicate insertion in mac_q
 */
struct hash *fpm_mac_info_table;

    - Before enqueueing any RMAC, try to fetch the fpm_mac_info_t from the hash
    table first.
    - Entry is deleted from the hash table when the node is dequeued.
    - For hash table key generation, parameters used are "mac adress" and "vni"
    This will provide a fairly unique key for a MAC (fpm_mac_info_hash_keymake).
    - Compare function uses "mac address", "RVTEP address" and "VNI" as the key
    which is sufficient to distinguish any two RMACs. This compare function is
    used for fpm_mac_info_t lookup (zfpm_mac_info_cmp).

- Handle RMAC add/delete operation in Zebra
    - Define a hook "zebra_mac_update" which can be registered by multiple
      data plane components (e.g. FPM, dplane).
DEFINE_HOOK(zebra_rmac_update, (zebra_mac_t *rmac, zebra_l3vni_t *zl3vni, bool
delete, const char *reason), (rmac, zl3vni, delete, reason))
    - While performing RMAC add/delete for an L3VNI, call "zebra_mac_update"
      hook.
    - This hook call triggers "zfpm_trigger_rmac_update". In this function, we
      do a lookup for the RMAC in fpm_mac_info_table. If already present, this
      node is updated with the latest RMAC info. Else, a new fpm_mac_info_t node
      is created and inserted in the queue and hash data structures.

- FPM processing of mac_q and dest_q
    - FPM write thread calls "zfpm_build_updates()" to process mac_q and dest_q
      and to write update buffer over the FPM socket.
    - "zfpm_build_updates()" processes all the update queues one by one in a
      while loop. It will break the while loop and return if Queue processing
      function returns "FPM_WRITE_STOP" OR FPM write buffer is full OR all the
      queues are empty (no more update to process).
    - "zfpm_build_route_updates()" dequeues and processes route nodes from
      "dest_q".
    - "zfpm_build_mac_updates()" dequeues and processes RMAC nodes from "mac_q"
    - These queue processing functions return with "FPM_WRITE_STOP" if the write
      buffer is full. Return value is "FPM_GOTO_NEXT_Q" if enough updates are
      processed from this queue and we want to move on to the next queue.
    - In each call, a queue processing function will process max
      "FPM_QUEUE_PROCESS_LIMIT (10000)" updates to avoid starvation of other
      queues.

- Nelink message for RMAC updates
    - Function "zfpm_netlink_encode_mac()" builds a netlink message for RMAC
      updates.
    - To build a netlink message for RMAC updates, we use "ndmsg" in rtlink.
    - FPM Message structure is: FPM header -> nlmsg header -> ndmsg fields -> ndmsg attributes
Netlink message will look like:
{'ndm_type': 0, 'family': 7, '__pad': (), 'header': {'flags': 1281, 'length':
64, 'type': 28, 'pid': 0, 'sequence_number': 0}, 'state': 2, 'flags': 22,
'attrs': [('NDA_LLADDR', 'b2:66:eb:b9:5b:d3'), ('NDA_DST', '10.100.0.2'),
('NDA_MASTER', 11), ('NDA_VNI', 1000)], 'ifindex': 18}
Message bytestring:
'@\x00\x00\x00\x1c\x00\x01\x05\x00\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x12\x00\x00\x00\x02\x00\x16\x00\n\x00\x02\x00\xe6+\xf5{\x17\xbf\x00\x00\x08\x00\x01\x00\nd\x00\x03\x08\x00\t\x00\x0b\x00\x00\x00\x08\x00\x07\x00\xe8\x03\x00\x00'

- Message details:
nlmsghdr.nlmsg_type = RTM_NEWNEIGH(28) or RTM_DELNEIGH(29)
nlmsghdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_REPLACE for "add" ,
"NLM_F_REQUEST" for delete.
ndmsg.ndm_family = AF_BRIDGE
ndmsg.ndm_ifindex = mac?vxlan_if (ifindex)
ndmsg.ndm_state = NUD_REACHABLE
ndmsg.ndm_flags |= NTF_SELF | NTF_MASTER | NTF_EXT_LEARNED
Attribute "NDA_LLADDR" for MAC address
Attribute "NDA_DST" for remote vtep ip.
Attribute "NDA_MASTER" for bridge interface ifindex.
Attribute "NDA_VNI" for VNI id.

- Handle FPM connection up/down events
When the connection with the FPM socket is established, iterate through all the
L3VNIs and send all the RMACs for FPM processing "zfpm_conn_up_thread_cb"
When the FPM connection goes down, empty mac_q and FPM mac info hash table
"zfpm_conn_down_thread_cb"

Signed-off-by: Ameya Dharkar <adharkar@vmware.com>