### PR TITLE
topotests: ifindex values are not guaranteed to be the same

### DIFF
--- a/tests/topotests/all-protocol-startup/r1/show_ip_ospf_interface.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_ip_ospf_interface.ref
@@ -1,5 +1,5 @@
 r1-eth0 is up
-  ifindex 2, MTU 1500 bytes, BW XX Mbit <UP,BROADCAST,RUNNING,MULTICAST>
+  ifindex X, MTU 1500 bytes, BW XX Mbit <UP,BROADCAST,RUNNING,MULTICAST>
   Internet Address 192.168.0.1/24, Broadcast 192.168.0.255, Area 0.0.0.0
   MTU mismatch detection: enabled
   Router ID 192.168.0.1, Network Type BROADCAST, Cost: 10
@@ -10,7 +10,7 @@ r1-eth0 is up
     Hello due in XX.XXXs
   Neighbor Count is 0, Adjacent neighbor count is 0
 r1-eth3 is up
-  ifindex 5, MTU 1500 bytes, BW XX Mbit <UP,BROADCAST,RUNNING,MULTICAST>
+  ifindex X, MTU 1500 bytes, BW XX Mbit <UP,BROADCAST,RUNNING,MULTICAST>
   Internet Address 192.168.3.1/26, Broadcast 192.168.3.63, Area 0.0.0.0
   MTU mismatch detection: enabled
   Router ID 192.168.0.1, Network Type BROADCAST, Cost: 10

--- a/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
+++ b/tests/topotests/all-protocol-startup/test_all_protocol_startup.py
@@ -480,6 +480,8 @@ def test_ospfv2_interfaces():
             actual = net['r%s' % i].cmd('vtysh -c "show ip ospf interface" 2> /dev/null').rstrip()
             # Mask out Bandwidth portion. They may change..
             actual = re.sub(r"BW [0-9]+ Mbit", "BW XX Mbit", actual)
+	    actual = re.sub(r"ifindex [0-9]", "ifindex X", actual)
+
             # Drop time in next due 
             actual = re.sub(r"Hello due in [0-9\.]+s", "Hello due in XX.XXXs", actual)
             # Fix 'MTU mismatch detection: enabled' vs 'MTU mismatch detection:enabled' - accept both


### PR DESCRIPTION
Different versions of linux are assigned different interface
ifindexes.  Mask that cabbage out.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>