### PR TITLE
Lib: Debugs for route-map code in FRR

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -84,6 +84,7 @@ const char *node_names[] = {
 	"vrf debug",		    // VRF_DEBUG_NODE,
 	"northbound debug",	    // NORTHBOUND_DEBUG_NODE,
 	"vnc debug",		    // DEBUG_VNC_NODE,
+	"route-map debug",	    /* RMAP_DEBUG_NODE */
 	"aaa",			    // AAA_NODE,
 	"keychain",		    // KEYCHAIN_NODE,
 	"keychain key",		    // KEYCHAIN_KEY_NODE,

--- a/lib/command.h
+++ b/lib/command.h
@@ -94,6 +94,7 @@ enum node_type {
 	VRF_DEBUG_NODE,		 /* Vrf Debug node. */
 	NORTHBOUND_DEBUG_NODE,	 /* Northbound Debug node. */
 	DEBUG_VNC_NODE,		 /* Debug VNC node. */
+	RMAP_DEBUG_NODE,         /* Route-map debug node */
 	AAA_NODE,		 /* AAA node. */
 	KEYCHAIN_NODE,		 /* Key-chain node. */
 	KEYCHAIN_KEY_NODE,       /* Key-chain key node. */

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -373,6 +373,10 @@ void vtysh_config_parse_line(void *arg, const char *line)
 				 strlen("debug northbound"))
 			 == 0)
 			config = config_get(NORTHBOUND_DEBUG_NODE, line);
+		else if (strncmp(line, "debug route-map",
+				 strlen("debug route-map"))
+			 == 0)
+			config = config_get(RMAP_DEBUG_NODE, line);
 		else if (strncmp(line, "debug", strlen("debug")) == 0)
 			config = config_get(DEBUG_NODE, line);
 		else if (strncmp(line, "password", strlen("password")) == 0
@@ -418,7 +422,8 @@ void vtysh_config_parse_line(void *arg, const char *line)
 	 || (I) == ACCESS_IPV6_NODE || (I) == ACCESS_MAC_NODE                  \
 	 || (I) == PREFIX_IPV6_NODE || (I) == FORWARDING_NODE                  \
 	 || (I) == DEBUG_NODE || (I) == AAA_NODE || (I) == VRF_DEBUG_NODE      \
-	 || (I) == NORTHBOUND_DEBUG_NODE || (I) == MPLS_NODE)
+	 || (I) == NORTHBOUND_DEBUG_NODE || (I) == RMAP_DEBUG_NODE             \
+	 || (I) == MPLS_NODE)
 
 /* Display configuration to file pointer. */
 void vtysh_config_dump(void)


### PR DESCRIPTION
Added a CLI "debug route-map" to enble route-map debugs

Added debugs for following triggers
1. Add/delete a route-map
2. Add/delete a sequence in route-map
3. Add/delete a match statement(dependency)
4. Update a dependency
5. Apply a route-map

Signed-off-by: Ameya Dharkar <adharkar@vmware.com>