### PR TITLE
zebra: Add kernel level graceful restart

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -23,10 +23,6 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
    Runs in batch mode. *zebra* parses configuration file and terminates
    immediately.
 
-.. option:: -k, --keep_kernel
-
-   When zebra starts up, don't delete old self inserted routes.
-
 .. option:: -K TIME, --graceful_restart TIME
 
    If this option is specified, the graceful restart time is TIME seconds.

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -27,6 +27,13 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 
    When zebra starts up, don't delete old self inserted routes.
 
+.. option:: -K TIME, --graceful_restart TIME
+
+   If this option is specified, the graceful restart time is TIME seconds.
+   Zebra, when started, will read in routes.  Those routes that Zebra
+   identifies that it was the originator of will be swept in TIME seconds.
+   If no time is specified then we will sweep those routes immediately.
+
 .. option:: -r, --retain
 
    When program terminates, do not flush routes installed by *zebra* from the

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -400,7 +400,7 @@ extern struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *p,
 extern void rib_update(vrf_id_t vrf_id, rib_update_event_t event);
 extern void rib_update_table(struct route_table *table,
 			     rib_update_event_t event);
-extern void rib_sweep_route(void);
+extern int rib_sweep_route(struct thread *t);
 extern void rib_sweep_table(struct route_table *table);
 extern void rib_close_table(struct route_table *table);
 extern void rib_init(void);

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -112,7 +112,14 @@ struct zebra_router {
 	struct zebra_vrf *evpn_vrf;
 
 	uint32_t multipath_num;
+
+	/*
+	 * Time for when we sweep the rib from old routes
+	 */
+	time_t startup_time;
 };
+
+#define GRACEFUL_RESTART_TIME 60
 
 extern struct zebra_router zrouter;
 


### PR DESCRIPTION
<Initial Code from Praveen Chaudhary>

Add the a `--graceful_restart X` flag to zebra start that
now creates a timer that pops in X seconds and will go
through and remove all routes that are older than startup.

If graceful_restart is not specified then we will just pop
a timer that cleans everything up immediately.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>