### PR TITLE
staticd: static route config should get fail if nexthop configured as  its local connected ip.

### DIFF
--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -35,7 +35,6 @@
 #ifndef VTYSH_EXTRACT_PL
 #include "staticd/static_vty_clippy.c"
 #endif
-
 static struct static_vrf *static_vty_get_unknown_vrf(struct vty *vty,
 						     const char *vrf_name)
 {
@@ -479,6 +478,23 @@ static int static_route_leak(
 			return CMD_WARNING_CONFIG_FAILED;
 		}
 		gatep = &gate;
+
+		if (afi == AFI_IP && !negate) {
+			if (if_lookup_exact_address(&gatep->ipv4, AF_INET,
+							svrf->vrf->vrf_id))
+				if (vty)
+					vty_out(vty,
+						"%% Warning!! Local connected address is configured as Gateway IP(%s)\n",
+						gate_str);
+		} else if (afi == AFI_IP6 && !negate) {
+			if (if_lookup_exact_address(&gatep->ipv6, AF_INET6,
+							svrf->vrf->vrf_id))
+				if (vty)
+					vty_out(vty,
+						"%% Warning!! Local connected address is configured as Gateway IPv6(%s)\n",
+						gate_str);
+		}
+
 	}
 
 	if (gate_str == NULL && ifname == NULL)

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -200,6 +200,25 @@ struct static_nht_data {
 	uint8_t nh_num;
 };
 
+/* API to check whether the configured nexthop address is
+ * one of its local connected address or not.
+ */
+static bool
+static_nexthop_is_local(vrf_id_t vrfid, struct prefix *addr, int family)
+{
+	if (family == AF_INET) {
+		if (if_lookup_exact_address(&addr->u.prefix4,
+					AF_INET,
+					vrfid))
+			return true;
+	} else if (family == AF_INET6) {
+		if (if_lookup_exact_address(&addr->u.prefix6,
+					AF_INET6,
+					vrfid))
+			return true;
+	}
+	return false;
+}
 static int static_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 {
 	struct static_nht_data *nhtd, lookup;
@@ -213,6 +232,12 @@ static int static_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 
 	if (nhr.prefix.family == AF_INET6)
 		afi = AFI_IP6;
+
+	if (nhr.type == ZEBRA_ROUTE_CONNECT) {
+		if (static_nexthop_is_local(vrf_id, &nhr.prefix,
+					nhr.prefix.family))
+			nhr.nexthop_num = 0;
+	}
 
 	memset(&lookup, 0, sizeof(lookup));
 	lookup.nh = &nhr.prefix;


### PR DESCRIPTION
Added a validation check in static route configuration to validate
the nexthop address.If the configured next hop address is part of
local ip then making  the configuration failed.
For this , every interface pointer ifp maintains the list of connected ip address including
both primary and secondary.So when a static route is  configured , the gateway address  is
being validated against all the interfaces connected list in the corresponding VRF.
If match occurs  throwing an warning msg and return failure.

Made the generic change to address this scenario for both ipv4 and ipv6.

Signed-off-by: Rajesh Girada <rgirada@vmware.com>