### PR TITLE
Route map switch

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3447,7 +3447,7 @@ static void bgp_route_map_delete(const char *rmap_name)
 	route_map_notify_dependencies(rmap_name, RMAP_EVENT_MATCH_DELETED);
 }
 
-static void bgp_route_map_event(route_map_event_t event, const char *rmap_name)
+static void bgp_route_map_event(const char *rmap_name)
 {
 	if (route_map_mark_updated(rmap_name) == 0)
 		bgp_route_map_mark_update(rmap_name);

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2208,24 +2208,6 @@ void vnc_routemap_update(struct bgp *bgp, const char *unused)
 	vnc_zlog_debug_verbose("%s done", __func__);
 }
 
-#if 0 /* superseded */
-static void vnc_routemap_event(route_map_event_t type, /* ignored */
-			       const char *rmap_name)  /* ignored */
-{
-	struct listnode *mnode, *mnnode;
-	struct bgp *bgp;
-
-	vnc_zlog_debug_verbose("%s(event type=%d)", __func__, type);
-	if (bm->bgp == NULL) /* may be called during cleanup */
-		return;
-
-	for (ALL_LIST_ELEMENTS(bm->bgp, mnode, mnnode, bgp))
-		vnc_routemap_update(bgp, rmap_name);
-
-	vnc_zlog_debug_verbose("%s: done", __func__);
-}
-#endif
-
 /*-------------------------------------------------------------------------
  *			nve-group
  *-----------------------------------------------------------------------*/
@@ -3699,10 +3681,6 @@ bgp_rfapi_get_ecommunity_by_lni_label(struct bgp *bgp, uint32_t is_import,
 
 void bgp_rfapi_cfg_init(void)
 {
-	/* main bgpd code does not use this hook, but vnc does */
-	/* superseded by bgp_route_map_process_update_cb() */
-	/* bgp_route_map_event_hook_add(vnc_routemap_event); */
-
 	install_node(&bgp_vnc_defaults_node, NULL);
 	install_node(&bgp_vnc_nve_group_node, NULL);
 	install_node(&bgp_vrf_policy_node, NULL);

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -616,7 +616,7 @@ struct route_map_list {
 
 	void (*add_hook)(const char *);
 	void (*delete_hook)(const char *);
-	void (*event_hook)(route_map_event_t, const char *);
+	void (*event_hook)(const char *);
 };
 
 /* Master list of route map. */
@@ -1077,8 +1077,7 @@ static void route_map_index_delete(struct route_map_index *index, int notify)
 
 	/* Execute event hook. */
 	if (route_map_master.event_hook && notify) {
-		(*route_map_master.event_hook)(RMAP_EVENT_INDEX_DELETED,
-					       index->map->name);
+		(*route_map_master.event_hook)(index->map->name);
 		route_map_notify_dependencies(index->map->name,
 					      RMAP_EVENT_CALL_ADDED);
 	}
@@ -1137,8 +1136,7 @@ route_map_index_add(struct route_map *map, enum route_map_type type, int pref)
 
 	/* Execute event hook. */
 	if (route_map_master.event_hook) {
-		(*route_map_master.event_hook)(RMAP_EVENT_INDEX_ADDED,
-					       map->name);
+		(*route_map_master.event_hook)(map->name);
 		route_map_notify_dependencies(map->name, RMAP_EVENT_CALL_ADDED);
 	}
 	return index;
@@ -1337,10 +1335,7 @@ int route_map_add_match(struct route_map_index *index, const char *match_name,
 
 	/* Execute event hook. */
 	if (route_map_master.event_hook) {
-		(*route_map_master.event_hook)(
-			replaced ? RMAP_EVENT_MATCH_REPLACED
-				 : RMAP_EVENT_MATCH_ADDED,
-			index->map->name);
+		(*route_map_master.event_hook)(index->map->name);
 		route_map_notify_dependencies(index->map->name,
 					      RMAP_EVENT_CALL_ADDED);
 	}
@@ -1365,9 +1360,7 @@ int route_map_delete_match(struct route_map_index *index,
 			route_map_rule_delete(&index->match_list, rule);
 			/* Execute event hook. */
 			if (route_map_master.event_hook) {
-				(*route_map_master.event_hook)(
-					RMAP_EVENT_MATCH_DELETED,
-					index->map->name);
+				(*route_map_master.event_hook)(index->map->name);
 				route_map_notify_dependencies(
 					index->map->name,
 					RMAP_EVENT_CALL_ADDED);
@@ -1425,10 +1418,7 @@ int route_map_add_set(struct route_map_index *index, const char *set_name,
 
 	/* Execute event hook. */
 	if (route_map_master.event_hook) {
-		(*route_map_master.event_hook)(replaced
-						       ? RMAP_EVENT_SET_REPLACED
-						       : RMAP_EVENT_SET_ADDED,
-					       index->map->name);
+		(*route_map_master.event_hook)(index->map->name);
 		route_map_notify_dependencies(index->map->name,
 					      RMAP_EVENT_CALL_ADDED);
 	}
@@ -1452,9 +1442,7 @@ int route_map_delete_set(struct route_map_index *index, const char *set_name,
 			route_map_rule_delete(&index->set_list, rule);
 			/* Execute event hook. */
 			if (route_map_master.event_hook) {
-				(*route_map_master.event_hook)(
-					RMAP_EVENT_SET_DELETED,
-					index->map->name);
+				(*route_map_master.event_hook)(index->map->name);
 				route_map_notify_dependencies(
 					index->map->name,
 					RMAP_EVENT_CALL_ADDED);
@@ -1651,7 +1639,7 @@ void route_map_delete_hook(void (*func)(const char *))
 	route_map_master.delete_hook = func;
 }
 
-void route_map_event_hook(void (*func)(route_map_event_t, const char *))
+void route_map_event_hook(void (*func)(const char *name))
 {
 	route_map_master.event_hook = func;
 }
@@ -1874,13 +1862,12 @@ static struct hash *route_map_get_dep_hash(route_map_event_t event)
 static void route_map_process_dependency(struct hash_bucket *bucket, void *data)
 {
 	char *rmap_name = (char *)bucket->data;
-	route_map_event_t type = (route_map_event_t)(ptrdiff_t)data;
 
 	if (rmap_debug)
 		zlog_debug("%s: Notifying %s of dependency",
 			   __FUNCTION__, rmap_name);
 	if (route_map_master.event_hook)
-		(*route_map_master.event_hook)(type, rmap_name);
+		(*route_map_master.event_hook)(rmap_name);
 }
 
 void route_map_upd8_dependency(route_map_event_t type, const char *arg,

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -902,7 +902,7 @@ static const char *route_map_type_str(enum route_map_type type)
 	case RMAP_DENY:
 		return "deny";
 		break;
-	default:
+	case RMAP_ANY:
 		return "";
 		break;
 	}
@@ -1795,7 +1795,14 @@ static int route_map_dep_update(struct hash *dephash, const char *dep_name,
 			dep = NULL;
 		}
 		break;
-	default:
+	case RMAP_EVENT_SET_ADDED:
+	case RMAP_EVENT_SET_DELETED:
+	case RMAP_EVENT_SET_REPLACED:
+	case RMAP_EVENT_MATCH_ADDED:
+	case RMAP_EVENT_MATCH_DELETED:
+	case RMAP_EVENT_MATCH_REPLACED:
+	case RMAP_EVENT_INDEX_ADDED:
+	case RMAP_EVENT_INDEX_DELETED:
 		break;
 	}
 
@@ -1846,7 +1853,18 @@ static struct hash *route_map_get_dep_hash(route_map_event_t event)
 	case RMAP_EVENT_FILTER_DELETED:
 		upd8_hash = route_map_dep_hash[ROUTE_MAP_DEP_FILTER];
 		break;
-	default:
+	/*
+	 * Should we actually be ignoring these?
+	 * I am not sure but at this point in time, let
+	 * us get them into this switch and we can peel
+	 * them into the appropriate place in the future
+	 */
+	case RMAP_EVENT_SET_ADDED:
+	case RMAP_EVENT_SET_DELETED:
+	case RMAP_EVENT_SET_REPLACED:
+	case RMAP_EVENT_MATCH_REPLACED:
+	case RMAP_EVENT_INDEX_ADDED:
+	case RMAP_EVENT_INDEX_DELETED:
 		upd8_hash = NULL;
 		break;
 	}

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -238,7 +238,15 @@ extern route_map_result_t route_map_apply(struct route_map *map,
 
 extern void route_map_add_hook(void (*func)(const char *));
 extern void route_map_delete_hook(void (*func)(const char *));
-extern void route_map_event_hook(void (*func)(route_map_event_t, const char *));
+
+/*
+ * This is the callback for when something has changed about a
+ * route-map.  The interested parties can register to receive
+ * this data.
+ *
+ * name - Is the name of the changed route-map
+ */
+extern void route_map_event_hook(void (*func)(const char *name));
 extern int route_map_mark_updated(const char *name);
 extern void route_map_walk_update_list(void (*update_fn)(char *name));
 extern void route_map_upd8_dependency(route_map_event_t type, const char *arg,

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -956,7 +956,7 @@ static void ospf6_asbr_routemap_update(const char *mapname)
 	}
 }
 
-static void ospf6_asbr_routemap_event(route_map_event_t event, const char *name)
+static void ospf6_asbr_routemap_event(const char *name)
 {
 	int type;
 

--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -97,7 +97,7 @@ static void ospf_route_map_update(const char *name)
 	}
 }
 
-static void ospf_route_map_event(route_map_event_t event, const char *name)
+static void ospf_route_map_event(const char *name)
 {
 	struct ospf *ospf;
 	int type;

--- a/pimd/pim_routemap.c
+++ b/pimd/pim_routemap.c
@@ -36,7 +36,7 @@ static void pim_route_map_delete(const char *rmap_name)
 	route_map_notify_dependencies(rmap_name, RMAP_EVENT_MATCH_DELETED);
 }
 
-static void pim_route_map_event(route_map_event_t event, const char *rmap_name)
+static void pim_route_map_event(const char *rmap_name)
 {
 	route_map_notify_dependencies(rmap_name, RMAP_EVENT_MATCH_ADDED);
 }

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1798,8 +1798,7 @@ static void zebra_route_map_delete(const char *rmap_name)
 	route_map_notify_dependencies(rmap_name, RMAP_EVENT_MATCH_DELETED);
 }
 
-static void zebra_route_map_event(route_map_event_t event,
-				  const char *rmap_name)
+static void zebra_route_map_event(const char *rmap_name)
 {
 	if (route_map_mark_updated(rmap_name) == 0)
 		zebra_route_map_mark_update(rmap_name);


### PR DESCRIPTION
1) cleanup use of default: for switch statements over enum in routemap.c.  It has become obvious that people have added functionality without properly ensuring the new functionality works because the switch statements were missed.

2) Remove passing of route_map_event_t from the event call back function.  No-one is doing anything with this data, nor do I see an easy way to actually take advantage of it.  Let's remove the false hope here.

Note -> I would like to wait on this PR until 4297 is in or not.  