### PR TITLE
doc: Provide info on what pkg to install if mpls-router module is missing

### DIFF
--- a/doc/developer/building-frr-for-ubuntu1804.rst
+++ b/doc/developer/building-frr-for-ubuntu1804.rst
@@ -104,6 +104,10 @@ And load the kernel modules on the running system:
 
    sudo modprobe mpls-router mpls-iptunnel
 
+If the above command returns an error, you may need to install the appropriate
+or latest linux-modules-extra-<kernel-version>-generic package. For example
+``apt-get install linux-modules-extra-`uname -r`-generic``
+
 Enable MPLS Forwarding
 """"""""""""""""""""""
 

--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -105,6 +105,8 @@ Execute all tests with output to console
 
    py.test -s -v --tb=no
 
+The above command must be executed from inside the topotests directory.
+
 All test\_\* scripts in subdirectories are detected and executed (unless
 disabled in ``pytest.ini`` file).
 
@@ -118,6 +120,13 @@ Execute single test
 
    cd test_to_be_run
    ./test_to_be_run.py
+
+For example, and assuming you are inside the frr directory:
+
+.. code:: shell
+
+   cd tests/topotests/bgp_l3vpn_to_bgp_vrf
+   ./test_bgp_l3vpn_to_bgp_vrf.py
 
 For further options, refer to pytest documentation.
 


### PR DESCRIPTION
The mpls-route module may be missing from Ubuntu 18.4. Provide info on
what pkg to install plus what directory py.test needs to be run from.

Signed-off-by: nikos <ntriantafillis@gmail.com>