### PR TITLE
bgpd: Extract tunnel type from extended communities

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -51,7 +51,6 @@
 #include "bgp_encap_types.h"
 #include "bgp_vnc_types.h"
 #endif
-#include "bgp_encap_types.h"
 #include "bgp_evpn.h"
 #include "bgp_flowspec_private.h"
 #include "bgp_mac.h"
@@ -1956,6 +1955,10 @@ bgp_attr_ext_communities(struct bgp_attr_parser_args *args)
 
 	}
 
+	/* Get the tunnel type from encap extended community */
+	bgp_attr_extcom_tunnel_type(attr,
+		(bgp_encap_types *)&attr->encap_tunneltype);
+
 	return BGP_ATTR_PARSE_PROCEED;
 }
 
@@ -2753,6 +2756,38 @@ bgp_attr_parse_ret_t bgp_attr_parse(struct peer *peer, struct attr *attr,
 #endif
 
 	return BGP_ATTR_PARSE_PROCEED;
+}
+
+/*
+ * Extract the tunnel type from extended community
+ */
+void bgp_attr_extcom_tunnel_type(struct attr *attr,
+					bgp_encap_types *tunnel_type)
+{
+	struct ecommunity *ecom;
+	int i;
+	if (!attr)
+		return false;
+
+	ecom = attr->ecommunity;
+	if (!ecom || !ecom->size)
+		return false;
+
+	for (i = 0; i < ecom->size; i++) {
+		uint8_t *pnt;
+		uint8_t type, sub_type;
+
+		pnt = (ecom->val + (i * ECOMMUNITY_SIZE));
+		type = pnt[0];
+		sub_type = pnt[1];
+		if (!(type == ECOMMUNITY_ENCODE_OPAQUE &&
+		      sub_type == ECOMMUNITY_OPAQUE_SUBTYPE_ENCAP))
+			continue;
+		*tunnel_type = ((pnt[6] << 8) | pnt[7]);
+		return true;
+	}
+
+	return false;
 }
 
 size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -23,6 +23,7 @@
 
 #include "mpls.h"
 #include "bgp_attr_evpn.h"
+#include "bgpd/bgp_encap_types.h"
 
 /* Simple bit mapping. */
 #define BITMAP_NBBY 8
@@ -316,6 +317,9 @@ extern struct bgp_attr_encap_subtlv *
 encap_tlv_dup(struct bgp_attr_encap_subtlv *orig);
 
 extern void bgp_attr_flush_encap(struct attr *attr);
+
+extern void bgp_attr_extcom_tunnel_type(struct attr *attr,
+					 bgp_encap_types *tunnel_type);
 
 /**
  * Set of functions to encode MP_REACH_NLRI and MP_UNREACH_NLRI attributes.

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -22,6 +22,7 @@
 #define _QUAGGA_BGP_ECOMMUNITY_H
 
 #include "bgpd/bgp_route.h"
+#include "bgpd/bgpd.h"
 
 /* High-order octet of the Extended Communities type field.  */
 #define ECOMMUNITY_ENCODE_AS                0x00

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -306,8 +306,6 @@ extern int rfapiCliGetPrefixAddr(struct vty *vty, const char *str,
 
 extern int rfapiGetVncLifetime(struct attr *attr, uint32_t *lifetime);
 
-extern int rfapiGetTunnelType(struct attr *attr, bgp_encap_types *type);
-
 extern int rfapiGetVncTunnelUnAddr(struct attr *attr, struct prefix *p);
 
 extern int rfapi_reopen(struct rfapi_descriptor *rfd, struct bgp *bgp);

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1020,7 +1020,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 	struct prefix pfx_vn;
 	uint8_t cost;
 	uint32_t lifetime;
-	bgp_encap_types tun_type;
+	bgp_encap_types tun_type = BGP_ENCAP_TYPE_MPLS;/*Default tunnel type*/
 
 	char buf_pfx[BUFSIZ];
 	char buf_ntop[BUFSIZ];
@@ -1055,7 +1055,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 				   BUFSIZ));
 	}
 
-	rfapiGetTunnelType(bpi->attr, &tun_type);
+	bgp_attr_extcom_tunnel_type(bpi->attr, &tun_type);
 	/*
 	 * VN addr
 	 */


### PR DESCRIPTION
This diff contains 2 parts:
1. Extract the tunnel type info from bgp extended communities.
2. Make rfapi use this common tunnel type api

### Related fix
This fix is needed for the parent PR https://github.com/FRRouting/frr/pull/4078
Signed-off-by: Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>