### PR TITLE
lib: Introducing a 3rd state for route-map match cmd: RMAP_NOOP

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4411,7 +4411,7 @@ void bgp_evpn_advertise_type5_routes(struct bgp *bgp_vrf, afi_t afi,
 
 				/* apply the route-map */
 				if (bgp_vrf->adv_cmd_rmap[afi][safi].map) {
-					int ret = 0;
+					route_map_result_t ret;
 
 					ret = route_map_apply(
 						bgp_vrf->adv_cmd_rmap[afi][safi]

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1458,7 +1458,7 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 	struct bgp *bgp;
 	struct attr *piattr;
 	char buf[PREFIX_STRLEN];
-	int ret;
+	route_map_result_t ret;
 	int transparent;
 	int reflect;
 	afi_t afi;
@@ -2526,12 +2526,12 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 
 			/* apply the route-map */
 			if (bgp->adv_cmd_rmap[afi][safi].map) {
-				int ret = 0;
+				route_map_result_t ret;
 
 				ret = route_map_apply(
 					bgp->adv_cmd_rmap[afi][safi].map,
 					&rn->p, RMAP_BGP, new_select);
-				if (ret == RMAP_MATCH)
+				if (ret == RMAP_PERMITMATCH)
 					bgp_evpn_advertise_type5_route(
 						bgp, &rn->p, new_select->attr,
 						afi, safi);
@@ -4557,7 +4557,7 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 	struct bgp_path_info rmap_path;
 	struct attr attr;
 	struct attr *attr_new;
-	int ret;
+	route_map_result_t ret;
 #if ENABLE_BGP_VNC
 	int vnc_implicit_withdraw = 0;
 #endif
@@ -4905,7 +4905,7 @@ static void bgp_static_update_safi(struct bgp *bgp, struct prefix *p,
 	if (bgp_static->rmap.name) {
 		struct attr attr_tmp = attr;
 		struct bgp_path_info rmap_path;
-		int ret;
+		route_map_result_t ret;
 
 		rmap_path.peer = bgp->peer_self;
 		rmap_path.attr = &attr_tmp;
@@ -6567,7 +6567,7 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 	struct attr attr;
 	struct attr *new_attr;
 	afi_t afi;
-	int ret;
+	route_map_result_t ret;
 	struct bgp_redist *red;
 
 	/* Make default attribute. */
@@ -9082,7 +9082,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				struct route_map *rmap = output_arg;
 				struct bgp_path_info path;
 				struct attr dummy_attr;
-				int ret;
+				route_map_result_t ret;
 
 				bgp_attr_dup(&dummy_attr, pi->attr);
 

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -237,10 +237,9 @@ struct bgp_match_peer_compiled {
 /* Compares the peer specified in the 'match peer' clause with the peer
     received in bgp_path_info->peer. If it is the same, or if the peer structure
     received is a peer_group containing it, returns RMAP_MATCH. */
-static route_map_result_t route_match_peer(void *rule,
-					   const struct prefix *prefix,
-					   route_map_object_t type,
-					   void *object)
+static enum route_map_match_result_t
+route_match_peer(void *rule, const struct prefix *prefix,
+		 route_map_object_t type, void *object)
 {
 	struct bgp_match_peer_compiled *pc;
 	union sockunion *su;
@@ -333,10 +332,9 @@ struct route_map_rule_cmd route_match_peer_cmd = {"peer", route_match_peer,
 						  route_match_peer_free};
 
 #if defined(HAVE_LUA)
-static route_map_result_t route_match_command(void *rule,
-					      const struct prefix *prefix,
-					      route_map_object_t type,
-					      void *object)
+static enum route_map_match_result_t
+route_match_command(void *rule, const struct prefix *prefix,
+		    route_map_object_t type, void *object)
 {
 	int status = RMAP_NOMATCH;
 	u_int32_t locpref = 0;
@@ -432,10 +430,9 @@ struct route_map_rule_cmd route_match_command_cmd = {
 
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_ip_address(void *rule,
-						 const struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_ip_address(void *rule, const struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 
@@ -472,10 +469,9 @@ struct route_map_rule_cmd route_match_ip_address_cmd = {
 /* `match ip next-hop IP_ADDRESS' */
 
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_ip_next_hop(void *rule,
-						  const struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_match_ip_next_hop(void *rule, const struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 	struct bgp_path_info *path;
@@ -519,10 +515,9 @@ struct route_map_rule_cmd route_match_ip_next_hop_cmd = {
 /* `match ip route-source ACCESS-LIST' */
 
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_ip_route_source(void *rule,
-						      const struct prefix *pfx,
-						      route_map_object_t type,
-						      void *object)
+static enum route_map_match_result_t
+route_match_ip_route_source(void *rule, const struct prefix *pfx,
+			    route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 	struct bgp_path_info *path;
@@ -571,7 +566,7 @@ struct route_map_rule_cmd route_match_ip_route_source_cmd = {
 
 /* `match ip address prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_address_prefix_list(void *rule, const struct prefix *prefix,
 				   route_map_object_t type, void *object)
 {
@@ -606,7 +601,7 @@ struct route_map_rule_cmd route_match_ip_address_prefix_list_cmd = {
 
 /* `match ip next-hop prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
 				    route_map_object_t type, void *object)
 {
@@ -648,7 +643,7 @@ struct route_map_rule_cmd route_match_ip_next_hop_prefix_list_cmd = {
 
 /* `match ip next-hop type <blackhole>' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_next_hop_type(void *rule, const struct prefix *prefix,
 			     route_map_object_t type, void *object)
 {
@@ -687,7 +682,7 @@ static struct route_map_rule_cmd route_match_ip_next_hop_type_cmd = {
 
 /* `match ip route-source prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_route_source_prefix_list(void *rule,
 					const struct prefix *prefix,
 					route_map_object_t type, void *object)
@@ -737,10 +732,9 @@ struct route_map_rule_cmd route_match_ip_route_source_prefix_list_cmd = {
 /* `match evpn default-route' */
 
 /* Match function should return 1 if match is success else 0 */
-static route_map_result_t route_match_evpn_default_route(void *rule,
-							 const struct prefix *p,
-							 route_map_object_t
-							 type, void *object)
+static enum route_map_match_result_t
+route_match_evpn_default_route(void *rule, const struct prefix *p,
+			       route_map_object_t type, void *object)
 {
 	if (type == RMAP_BGP && is_evpn_prefix_default(p))
 		return RMAP_MATCH;
@@ -756,10 +750,9 @@ struct route_map_rule_cmd route_match_evpn_default_route_cmd = {
 
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_mac_address(void *rule,
-						  const struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_match_mac_address(void *rule, const struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 	struct prefix p;
@@ -806,9 +799,9 @@ struct route_map_rule_cmd route_match_mac_address_cmd = {
 
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_vni(void *rule,
-					  const struct prefix *prefix,
-					  route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_match_vni(void *rule, const struct prefix *prefix,
+		route_map_object_t type, void *object)
 {
 	vni_t vni = 0;
 	struct bgp_path_info *path = NULL;
@@ -859,10 +852,9 @@ struct route_map_rule_cmd route_match_evpn_vni_cmd = {
 
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_evpn_route_type(void *rule,
-						      const struct prefix *pfx,
-						      route_map_object_t type,
-						      void *object)
+static enum route_map_match_result_t
+route_match_evpn_route_type(void *rule, const struct prefix *pfx,
+			    route_map_object_t type, void *object)
 {
 	uint8_t route_type = 0;
 
@@ -905,7 +897,7 @@ struct route_map_rule_cmd route_match_evpn_route_type_cmd = {
 	route_match_evpn_route_type_compile, route_match_evpn_route_type_free};
 
 /* Route map commands for VRF route leak with source vrf matching */
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_vrl_source_vrf(void *rule, const struct prefix *prefix,
 			   route_map_object_t type, void *object)
 {
@@ -954,10 +946,9 @@ struct route_map_rule_cmd route_match_vrl_source_vrf_cmd = {
 /* `match local-preference LOCAL-PREF' */
 
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_local_pref(void *rule,
-						 const struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_local_pref(void *rule, const struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	uint32_t *local_pref;
 	struct bgp_path_info *path;
@@ -1011,10 +1002,9 @@ struct route_map_rule_cmd route_match_local_pref_cmd = {
 /* `match metric METRIC' */
 
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_metric(void *rule,
-					     const struct prefix *prefix,
-					     route_map_object_t type,
-					     void *object)
+static enum route_map_match_result_t
+route_match_metric(void *rule, const struct prefix *prefix,
+		   route_map_object_t type, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
@@ -1035,10 +1025,9 @@ struct route_map_rule_cmd route_match_metric_cmd = {
 /* `match as-path ASPATH' */
 
 /* Match function for as-path match.  I assume given object is */
-static route_map_result_t route_match_aspath(void *rule,
-					     const struct prefix *prefix,
-					     route_map_object_t type,
-					     void *object)
+static enum route_map_match_result_t
+route_match_aspath(void *rule, const struct prefix *prefix,
+		   route_map_object_t type, void *object)
 {
 
 	struct as_list *as_list;
@@ -1085,10 +1074,9 @@ struct rmap_community {
 };
 
 /* Match function for community match. */
-static route_map_result_t route_match_community(void *rule,
-						const struct prefix *prefix,
-						route_map_object_t type,
-						void *object)
+static enum route_map_match_result_t
+route_match_community(void *rule, const struct prefix *prefix,
+		      route_map_object_t type, void *object)
 {
 	struct community_list *list;
 	struct bgp_path_info *path;
@@ -1155,10 +1143,9 @@ struct route_map_rule_cmd route_match_community_cmd = {
 	route_match_community_free};
 
 /* Match function for lcommunity match. */
-static route_map_result_t route_match_lcommunity(void *rule,
-						 const struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_lcommunity(void *rule, const struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	struct community_list *list;
 	struct bgp_path_info *path;
@@ -1218,10 +1205,9 @@ struct route_map_rule_cmd route_match_lcommunity_cmd = {
 
 
 /* Match function for extcommunity match. */
-static route_map_result_t route_match_ecommunity(void *rule,
-						 const struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_ecommunity(void *rule, const struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	struct community_list *list;
 	struct bgp_path_info *path;
@@ -1272,10 +1258,9 @@ struct route_map_rule_cmd route_match_ecommunity_cmd = {
    and `address-family vpnv4'.  */
 
 /* `match origin' */
-static route_map_result_t route_match_origin(void *rule,
-					     const struct prefix *prefix,
-					     route_map_object_t type,
-					     void *object)
+static enum route_map_match_result_t
+route_match_origin(void *rule, const struct prefix *prefix,
+		   route_map_object_t type, void *object)
 {
 	uint8_t *origin;
 	struct bgp_path_info *path;
@@ -1320,10 +1305,9 @@ struct route_map_rule_cmd route_match_origin_cmd = {
 
 /* match probability  { */
 
-static route_map_result_t route_match_probability(void *rule,
-						  const struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_match_probability(void *rule, const struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	long r = random();
 
@@ -1375,10 +1359,9 @@ struct route_map_rule_cmd route_match_probability_cmd = {
 /* `match interface IFNAME' */
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_interface(void *rule,
-						const struct prefix *prefix,
-						route_map_object_t type,
-						void *object)
+static enum route_map_match_result_t
+route_match_interface(void *rule, const struct prefix *prefix,
+		      route_map_object_t type, void *object)
 {
 	struct interface *ifp;
 	struct bgp_path_info *path;
@@ -1422,9 +1405,9 @@ struct route_map_rule_cmd route_match_interface_cmd = {
 /* `set ip next-hop IP_ADDRESS' */
 
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_tag(void *rule,
-					  const struct prefix *prefix,
-					  route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_match_tag(void *rule, const struct prefix *prefix,
+		route_map_object_t type, void *object)
 {
 	route_tag_t *tag;
 	struct bgp_path_info *path;
@@ -1454,10 +1437,9 @@ struct rmap_ip_nexthop_set {
 	int unchanged;
 };
 
-static route_map_result_t route_set_ip_nexthop(void *rule,
-					       const struct prefix *prefix,
-					       route_map_object_t type,
-					       void *object)
+static enum route_map_match_result_t
+route_set_ip_nexthop(void *rule, const struct prefix *prefix,
+		     route_map_object_t type, void *object)
 {
 	struct rmap_ip_nexthop_set *rins = rule;
 	struct bgp_path_info *path;
@@ -1560,10 +1542,9 @@ struct route_map_rule_cmd route_set_ip_nexthop_cmd = {
 /* `set local-preference LOCAL_PREF' */
 
 /* Set local preference. */
-static route_map_result_t route_set_local_pref(void *rule,
-					       const struct prefix *prefix,
-					       route_map_object_t type,
-					       void *object)
+static enum route_map_match_result_t
+route_set_local_pref(void *rule, const struct prefix *prefix,
+		     route_map_object_t type, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
@@ -1595,10 +1576,9 @@ struct route_map_rule_cmd route_set_local_pref_cmd = {
 /* `set weight WEIGHT' */
 
 /* Set weight. */
-static route_map_result_t route_set_weight(void *rule,
-					   const struct prefix *prefix,
-					   route_map_object_t type,
-					   void *object)
+static enum route_map_match_result_t
+route_set_weight(void *rule, const struct prefix *prefix,
+		 route_map_object_t type, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
@@ -1623,10 +1603,9 @@ struct route_map_rule_cmd route_set_weight_cmd = {
 /* `set metric METRIC' */
 
 /* Set metric to attribute. */
-static route_map_result_t route_set_metric(void *rule,
-					   const struct prefix *prefix,
-					   route_map_object_t type,
-					   void *object)
+static enum route_map_match_result_t
+route_set_metric(void *rule, const struct prefix *prefix,
+		 route_map_object_t type, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
@@ -1654,10 +1633,9 @@ struct route_map_rule_cmd route_set_metric_cmd = {
 /* `set as-path prepend ASPATH' */
 
 /* For AS path prepend mechanism. */
-static route_map_result_t route_set_aspath_prepend(void *rule,
-						   const struct prefix *prefix,
-						   route_map_object_t type,
-						   void *object)
+static enum route_map_match_result_t
+route_set_aspath_prepend(void *rule, const struct prefix *prefix,
+			 route_map_object_t type, void *object)
 {
 	struct aspath *aspath;
 	struct aspath *new;
@@ -1717,10 +1695,9 @@ struct route_map_rule_cmd route_set_aspath_prepend_cmd = {
  * one.
  * Make a deep copy of existing AS_PATH, but for the first ASn only.
  */
-static route_map_result_t route_set_aspath_exclude(void *rule,
-						   const struct prefix *dummy,
-						   route_map_object_t type,
-						   void *object)
+static enum route_map_match_result_t
+route_set_aspath_exclude(void *rule, const struct prefix *dummy,
+			 route_map_object_t type, void *object)
 {
 	struct aspath *new_path, *exclude_path;
 	struct bgp_path_info *path;
@@ -1752,10 +1729,9 @@ struct rmap_com_set {
 };
 
 /* For community set mechanism. */
-static route_map_result_t route_set_community(void *rule,
-					      const struct prefix *prefix,
-					      route_map_object_t type,
-					      void *object)
+static enum route_map_match_result_t
+route_set_community(void *rule, const struct prefix *prefix,
+		    route_map_object_t type, void *object)
 {
 	struct rmap_com_set *rcs;
 	struct bgp_path_info *path;
@@ -1868,10 +1844,9 @@ struct rmap_lcom_set {
 
 
 /* For lcommunity set mechanism. */
-static route_map_result_t route_set_lcommunity(void *rule,
-					       const struct prefix *prefix,
-					       route_map_object_t type,
-					       void *object)
+static enum route_map_match_result_t
+route_set_lcommunity(void *rule, const struct prefix *prefix,
+		     route_map_object_t type, void *object)
 {
 	struct rmap_lcom_set *rcs;
 	struct bgp_path_info *path;
@@ -1981,10 +1956,9 @@ struct route_map_rule_cmd route_set_lcommunity_cmd = {
 /* `set large-comm-list (<1-99>|<100-500>|WORD) delete' */
 
 /* For large community set mechanism. */
-static route_map_result_t route_set_lcommunity_delete(void *rule,
-						      const struct prefix *pfx,
-						      route_map_object_t type,
-						      void *object)
+static enum route_map_match_result_t
+route_set_lcommunity_delete(void *rule, const struct prefix *pfx,
+			    route_map_object_t type, void *object)
 {
 	struct community_list *list;
 	struct lcommunity *merge;
@@ -2065,11 +2039,9 @@ struct route_map_rule_cmd route_set_lcommunity_delete_cmd = {
 /* `set comm-list (<1-99>|<100-500>|WORD) delete' */
 
 /* For community set mechanism. */
-static route_map_result_t route_set_community_delete(
-	void *rule,
-	const struct prefix *prefix,
-	route_map_object_t type,
-	void *object)
+static enum route_map_match_result_t
+route_set_community_delete(void *rule, const struct prefix *prefix,
+			   route_map_object_t type, void *object)
 {
 	struct community_list *list;
 	struct community *merge;
@@ -2149,10 +2121,9 @@ struct route_map_rule_cmd route_set_community_delete_cmd = {
 /* `set extcommunity rt COMMUNITY' */
 
 /* For community set mechanism.  Used by _rt and _soo. */
-static route_map_result_t route_set_ecommunity(void *rule,
-					       const struct prefix *prefix,
-					       route_map_object_t type,
-					       void *object)
+static enum route_map_match_result_t
+route_set_ecommunity(void *rule, const struct prefix *prefix,
+		     route_map_object_t type, void *object)
 {
 	struct ecommunity *ecom;
 	struct ecommunity *new_ecom;
@@ -2237,10 +2208,9 @@ struct route_map_rule_cmd route_set_ecommunity_soo_cmd = {
 /* `set origin ORIGIN' */
 
 /* For origin set. */
-static route_map_result_t route_set_origin(void *rule,
-					   const struct prefix *prefix,
-					   route_map_object_t type,
-					   void *object)
+static enum route_map_match_result_t
+route_set_origin(void *rule, const struct prefix *prefix,
+		 route_map_object_t type, void *object)
 {
 	uint8_t *origin;
 	struct bgp_path_info *path;
@@ -2287,10 +2257,9 @@ struct route_map_rule_cmd route_set_origin_cmd = {
 /* `set atomic-aggregate' */
 
 /* For atomic aggregate set. */
-static route_map_result_t route_set_atomic_aggregate(void *rule,
-						     const struct prefix *pfx,
-						     route_map_object_t type,
-						     void *object)
+static enum route_map_match_result_t
+route_set_atomic_aggregate(void *rule, const struct prefix *pfx,
+			   route_map_object_t type, void *object)
 {
 	struct bgp_path_info *path;
 
@@ -2326,10 +2295,9 @@ struct aggregator {
 	struct in_addr address;
 };
 
-static route_map_result_t route_set_aggregator_as(void *rule,
-						  const struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_set_aggregator_as(void *rule, const struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	struct bgp_path_info *path;
 	struct aggregator *aggregator;
@@ -2380,9 +2348,9 @@ struct route_map_rule_cmd route_set_aggregator_as_cmd = {
 };
 
 /* Set tag to object. object must be pointer to struct bgp_path_info */
-static route_map_result_t route_set_tag(void *rule,
-					const struct prefix *prefix,
-					route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_set_tag(void *rule, const struct prefix *prefix,
+	      route_map_object_t type, void *object)
 {
 	route_tag_t *tag;
 	struct bgp_path_info *path;
@@ -2405,10 +2373,9 @@ static struct route_map_rule_cmd route_set_tag_cmd = {
 };
 
 /* Set label-index to object. object must be pointer to struct bgp_path_info */
-static route_map_result_t route_set_label_index(void *rule,
-						const struct prefix *prefix,
-						route_map_object_t type,
-						void *object)
+static enum route_map_match_result_t
+route_set_label_index(void *rule, const struct prefix *prefix,
+		      route_map_object_t type, void *object)
 {
 	struct rmap_value *rv;
 	struct bgp_path_info *path;
@@ -2438,10 +2405,9 @@ static struct route_map_rule_cmd route_set_label_index_cmd = {
 
 /* `match ipv6 address IP_ACCESS_LIST' */
 
-static route_map_result_t route_match_ipv6_address(void *rule,
-						   const struct prefix *prefix,
-						   route_map_object_t type,
-						   void *object)
+static enum route_map_match_result_t
+route_match_ipv6_address(void *rule, const struct prefix *prefix,
+			 route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 
@@ -2474,10 +2440,9 @@ struct route_map_rule_cmd route_match_ipv6_address_cmd = {
 
 /* `match ipv6 next-hop IP_ADDRESS' */
 
-static route_map_result_t route_match_ipv6_next_hop(void *rule,
-						    const struct prefix *prefix,
-						    route_map_object_t type,
-						    void *object)
+static enum route_map_match_result_t
+route_match_ipv6_next_hop(void *rule, const struct prefix *prefix,
+			  route_map_object_t type, void *object)
 {
 	struct in6_addr *addr = rule;
 	struct bgp_path_info *path;
@@ -2526,7 +2491,7 @@ struct route_map_rule_cmd route_match_ipv6_next_hop_cmd = {
 
 /* `match ipv6 address prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ipv6_address_prefix_list(void *rule, const struct prefix *prefix,
 				     route_map_object_t type, void *object)
 {
@@ -2561,9 +2526,9 @@ struct route_map_rule_cmd route_match_ipv6_address_prefix_list_cmd = {
 
 /* `match ipv6 next-hop type <TYPE>' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ipv6_next_hop_type(void *rule, const struct prefix *prefix,
-			      route_map_object_t type, void *object)
+			       route_map_object_t type, void *object)
 {
 	struct bgp_path_info *path;
 	struct in6_addr *addr = rule;
@@ -2609,10 +2574,9 @@ struct route_map_rule_cmd route_match_ipv6_next_hop_type_cmd = {
 /* `set ipv6 nexthop global IP_ADDRESS' */
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
-static route_map_result_t route_set_ipv6_nexthop_global(void *rule,
-							const struct prefix *p,
-							route_map_object_t type,
-							void *object)
+static enum route_map_match_result_t
+route_set_ipv6_nexthop_global(void *rule, const struct prefix *p,
+			      route_map_object_t type, void *object)
 {
 	struct in6_addr *address;
 	struct bgp_path_info *path;
@@ -2668,7 +2632,7 @@ struct route_map_rule_cmd route_set_ipv6_nexthop_global_cmd = {
 	route_set_ipv6_nexthop_global_free};
 
 /* Set next-hop preference value. */
-static route_map_result_t
+static enum route_map_match_result_t
 route_set_ipv6_nexthop_prefer_global(void *rule, const struct prefix *prefix,
 				     route_map_object_t type, void *object)
 {
@@ -2722,10 +2686,9 @@ struct route_map_rule_cmd route_set_ipv6_nexthop_prefer_global_cmd = {
 /* `set ipv6 nexthop local IP_ADDRESS' */
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
-static route_map_result_t route_set_ipv6_nexthop_local(void *rule,
-						       const struct prefix *p,
-						       route_map_object_t type,
-						       void *object)
+static enum route_map_match_result_t
+route_set_ipv6_nexthop_local(void *rule, const struct prefix *p,
+			     route_map_object_t type, void *object)
 {
 	struct in6_addr *address;
 	struct bgp_path_info *path;
@@ -2785,10 +2748,9 @@ struct route_map_rule_cmd route_set_ipv6_nexthop_local_cmd = {
 /* `set ipv6 nexthop peer-address' */
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
-static route_map_result_t route_set_ipv6_nexthop_peer(void *rule,
-						      const struct prefix *pfx,
-						      route_map_object_t type,
-						      void *object)
+static enum route_map_match_result_t
+route_set_ipv6_nexthop_peer(void *rule, const struct prefix *pfx,
+			    route_map_object_t type, void *object)
 {
 	struct in6_addr peer_address;
 	struct bgp_path_info *path;
@@ -2863,10 +2825,9 @@ struct route_map_rule_cmd route_set_ipv6_nexthop_peer_cmd = {
 
 /* `set ipv4 vpn next-hop A.B.C.D' */
 
-static route_map_result_t route_set_vpnv4_nexthop(void *rule,
-						  const struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_set_vpnv4_nexthop(void *rule, const struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	struct in_addr *address;
 	struct bgp_path_info *path;
@@ -2903,10 +2864,9 @@ static void *route_set_vpnv4_nexthop_compile(const char *arg)
 
 /* `set ipv6 vpn next-hop A.B.C.D' */
 
-static route_map_result_t route_set_vpnv6_nexthop(void *rule,
-						  const struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_set_vpnv6_nexthop(void *rule, const struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	struct in6_addr *address;
 	struct bgp_path_info *path;
@@ -2959,10 +2919,9 @@ struct route_map_rule_cmd route_set_vpnv6_nexthop_cmd = {
 /* `set originator-id' */
 
 /* For origin set. */
-static route_map_result_t route_set_originator_id(void *rule,
-						  const struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_set_originator_id(void *rule, const struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	struct in_addr *address;
 	struct bgp_path_info *path;

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -129,8 +129,10 @@ static void print_record(const struct pfx_record *record, struct vty *vty);
 static int is_synchronized(void);
 static int is_running(void);
 static void route_match_free(void *rule);
-static route_map_result_t route_match(void *rule, const struct prefix *prefix,
-				      route_map_object_t type, void *object);
+static enum route_map_match_result_t route_match(void *rule,
+						 const struct prefix *prefix,
+						 route_map_object_t type,
+						 void *object);
 static void *route_match_compile(const char *arg);
 static void revalidate_bgp_node(struct bgp_node *bgp_node, afi_t afi,
 				safi_t safi);
@@ -213,8 +215,10 @@ static void ipv6_addr_to_host_byte_order(const uint32_t *src, uint32_t *dest)
 		dest[i] = ntohl(src[i]);
 }
 
-static route_map_result_t route_match(void *rule, const struct prefix *prefix,
-				      route_map_object_t type, void *object)
+static enum route_map_match_result_t route_match(void *rule,
+						 const struct prefix *prefix,
+						 route_map_object_t type,
+						 void *object)
 {
 	int *rpki_status = rule;
 	struct bgp_path_info *path;

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -716,7 +716,7 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 	struct bgp_node *rn;
 	struct bgp_path_info *ri;
 	struct peer *peer;
-	int ret = RMAP_DENYMATCH;
+	route_map_result_t ret = RMAP_DENYMATCH;
 	afi_t afi;
 	safi_t safi;
 

--- a/eigrpd/eigrp_routemap.c
+++ b/eigrpd/eigrp_routemap.c
@@ -251,9 +251,9 @@ void eigrp_route_map_update(const char *notused)
 
 /* `match metric METRIC' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_metric(void *rule, struct prefix *prefix,
-					     route_map_object_t type,
-					     void *object)
+static enum route_map_match_result_t
+route_match_metric(void *rule, struct prefix *prefix, route_map_object_t type,
+		   void *object)
 {
 	//  uint32_t *metric;
 	//  uint32_t  check;
@@ -311,10 +311,9 @@ struct route_map_rule_cmd route_match_metric_cmd = {
 
 /* `match interface IFNAME' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_interface(void *rule,
-						struct prefix *prefix,
-						route_map_object_t type,
-						void *object)
+static enum route_map_match_result_t
+route_match_interface(void *rule, struct prefix *prefix,
+		      route_map_object_t type, void *object)
 {
 	//  struct rip_info *rinfo;
 	//  struct interface *ifp;
@@ -360,10 +359,9 @@ struct route_map_rule_cmd route_match_interface_cmd = {
 /* `match ip next-hop IP_ACCESS_LIST' */
 
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_ip_next_hop(void *rule,
-						  struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_match_ip_next_hop(void *rule, struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	//  struct access_list *alist;
 	//  struct rip_info *rinfo;
@@ -407,7 +405,7 @@ static struct route_map_rule_cmd route_match_ip_next_hop_cmd = {
 
 /* `match ip next-hop prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_next_hop_prefix_list(void *rule, struct prefix *prefix,
 				    route_map_object_t type, void *object)
 {
@@ -452,10 +450,9 @@ static struct route_map_rule_cmd route_match_ip_next_hop_prefix_list_cmd = {
 
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_ip_address(void *rule,
-						 struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_ip_address(void *rule, struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 
@@ -491,7 +488,7 @@ static struct route_map_rule_cmd route_match_ip_address_cmd = {
 
 /* `match ip address prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_address_prefix_list(void *rule, struct prefix *prefix,
 				   route_map_object_t type, void *object)
 {
@@ -526,8 +523,9 @@ static struct route_map_rule_cmd route_match_ip_address_prefix_list_cmd = {
 
 /* `match tag TAG' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_tag(void *rule, struct prefix *prefix,
-					  route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_match_tag(void *rule, struct prefix *prefix, route_map_object_t type,
+		void *object)
 {
 	//  unsigned short *tag;
 	//  struct rip_info *rinfo;
@@ -568,9 +566,9 @@ struct route_map_rule_cmd route_match_tag_cmd = {
 	"tag", route_match_tag, route_match_tag_compile, route_match_tag_free};
 
 /* Set metric to attribute. */
-static route_map_result_t route_set_metric(void *rule, struct prefix *prefix,
-					   route_map_object_t type,
-					   void *object)
+static enum route_map_match_result_t
+route_set_metric(void *rule, struct prefix *prefix,
+		 route_map_object_t type, void *object)
 {
 	//  if (type == RMAP_RIP)
 	//    {
@@ -662,10 +660,9 @@ static struct route_map_rule_cmd route_set_metric_cmd = {
 /* `set ip next-hop IP_ADDRESS' */
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
-static route_map_result_t route_set_ip_nexthop(void *rule,
-					       struct prefix *prefix,
-					       route_map_object_t type,
-					       void *object)
+static enum route_map_match_result_t
+route_set_ip_nexthop(void *rule, struct prefix *prefix,
+		     route_map_object_t type, void *object)
 {
 	//  struct in_addr *address;
 	//  struct rip_info *rinfo;
@@ -718,8 +715,9 @@ static struct route_map_rule_cmd route_set_ip_nexthop_cmd = {
 /* `set tag TAG' */
 
 /* Set tag to object.  ojbect must be pointer to struct attr. */
-static route_map_result_t route_set_tag(void *rule, struct prefix *prefix,
-					route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_set_tag(void *rule, struct prefix *prefix,
+	      route_map_object_t type, void *object)
 {
 	//  unsigned short *tag;
 	//  struct rip_info *rinfo;

--- a/isisd/isis_routemap.c
+++ b/isisd/isis_routemap.c
@@ -48,10 +48,9 @@
 #include "isis_zebra.h"
 #include "isis_routemap.h"
 
-static route_map_result_t route_match_ip_address(void *rule,
-						 const struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_ip_address(void *rule, const struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 
@@ -81,7 +80,7 @@ static struct route_map_rule_cmd route_match_ip_address_cmd = {
 
 /* ------------------------------------------------------------*/
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_address_prefix_list(void *rule, const struct prefix *prefix,
 				   route_map_object_t type, void *object)
 {
@@ -114,10 +113,9 @@ struct route_map_rule_cmd route_match_ip_address_prefix_list_cmd = {
 
 /* ------------------------------------------------------------*/
 
-static route_map_result_t route_match_ipv6_address(void *rule,
-						   const struct prefix *prefix,
-						   route_map_object_t type,
-						   void *object)
+static enum route_map_match_result_t
+route_match_ipv6_address(void *rule, const struct prefix *prefix,
+			 route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 
@@ -147,7 +145,7 @@ static struct route_map_rule_cmd route_match_ipv6_address_cmd = {
 
 /* ------------------------------------------------------------*/
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ipv6_address_prefix_list(void *rule, const struct prefix *prefix,
 				     route_map_object_t type, void *object)
 {
@@ -180,10 +178,9 @@ struct route_map_rule_cmd route_match_ipv6_address_prefix_list_cmd = {
 
 /* ------------------------------------------------------------*/
 
-static route_map_result_t route_set_metric(void *rule,
-					   const struct prefix *prefix,
-					   route_map_object_t type,
-					   void *object)
+static enum route_map_match_result_t
+route_set_metric(void *rule, const struct prefix *prefix,
+		 route_map_object_t type, void *object)
 {
 	uint32_t *metric;
 	struct isis_ext_info *info;

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1456,14 +1456,14 @@ int route_map_delete_set(struct route_map_index *index, const char *set_name,
    (note, this includes the description for the "NEXT"
    and "GOTO" frobs now
 
-	      Match   |   No Match
-		      |
-    permit    action  |     cont
-		      |
-    ------------------+---------------
-		      |
-    deny      deny    |     cont
-		      |
+	   |   Match   |   No Match   | No op
+	   |-----------|--------------|-------
+    permit |   action  |     cont     | cont.
+	   |           | default:deny | default:permit
+    -------------------+-----------------------
+	   |   deny    |     cont     | cont.
+    deny   |           | default:deny | default:permit
+	   |-----------|--------------|--------
 
    action)
       -Apply Set statements, accept route
@@ -1497,12 +1497,12 @@ int route_map_delete_set(struct route_map_index *index, const char *set_name,
    We need to make sure our route-map processing matches the above
 */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_map_apply_match(struct route_map_rule_list *match_list,
 		      const struct prefix *prefix, route_map_object_t type,
 		      void *object)
 {
-	route_map_result_t ret = RMAP_NOMATCH;
+	enum route_map_match_result_t ret = RMAP_NOMATCH;
 	struct route_map_rule *match;
 
 
@@ -1534,7 +1534,8 @@ route_map_result_t route_map_apply(struct route_map *map,
 				   route_map_object_t type, void *object)
 {
 	static int recursion = 0;
-	int ret = 0;
+	enum route_map_match_result_t match_ret = RMAP_NOMATCH;
+	route_map_result_t ret = 0;
 	struct route_map_index *index;
 	struct route_map_rule *set;
 
@@ -1554,24 +1555,33 @@ route_map_result_t route_map_apply(struct route_map *map,
 	for (index = map->head; index; index = index->next) {
 		/* Apply this index. */
 		index->applied++;
-		ret = route_map_apply_match(&index->match_list, prefix, type,
-					    object);
+		match_ret = route_map_apply_match(&index->match_list, prefix,
+						  type, object);
 
 		/* Now we apply the matrix from above */
-		if (ret == RMAP_NOMATCH)
+		if (match_ret == RMAP_NOMATCH || match_ret == RMAP_NOOP)
 			/* 'cont' from matrix - continue to next route-map
 			 * sequence */
 			continue;
-		else if (ret == RMAP_MATCH) {
+		else if (match_ret == RMAP_MATCH) {
 			if (index->type == RMAP_PERMIT)
 			/* 'action' */
 			{
+				/* Match succeeded, rmap is of type permit */
+				ret = RMAP_PERMITMATCH;
+
 				/* permit+match must execute sets */
 				for (set = index->set_list.head; set;
 				     set = set->next)
-					ret = (*set->cmd->func_apply)(
-						set->value, prefix, type,
-						object);
+					/*
+					 * We dont care abt the return value
+					 * for set cmd.  Almost always,
+					 * RMAP_OKAY is returned. Rarely
+					 * do we see RMAP_ERROR
+					 */
+					match_ret = (*set->cmd->func_apply)(
+						     set->value, prefix, type,
+						     object);
 
 				/* Call another route-map if available */
 				if (index->nextrm) {
@@ -1622,6 +1632,10 @@ route_map_result_t route_map_apply(struct route_map *map,
 			}
 		}
 	}
+
+	if (match_ret == RMAP_NOOP)
+		return RMAP_PERMITMATCH;
+
 	/* Finally route-map does not match at all. */
 	return RMAP_DENYMATCH;
 }

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -34,15 +34,36 @@ DECLARE_MTYPE(ROUTE_MAP_NAME)
 DECLARE_MTYPE(ROUTE_MAP_RULE)
 DECLARE_MTYPE(ROUTE_MAP_COMPILED)
 
+/*
+ * Route-map match or set result "Eg: match evpn vni xx"
+ * route-map match cmd always returns match/nomatch/noop
+ *    match--> found a match
+ *    nomatch--> didnt find a match
+ *    noop--> invalid
+ * route-map set retuns okay/error
+ *    okay --> set was successful
+ *    error --> set was not successful
+ */
+enum route_map_match_result_t {
+	/*
+	 * route-map match cmd results
+	 */
+	RMAP_MATCH,
+	RMAP_NOMATCH,
+	RMAP_NOOP,
+	/*
+	 * route-map set cmd results
+	 */
+	RMAP_OKAY,
+	RMAP_ERROR
+};
+
 /* Route map's type. */
 enum route_map_type { RMAP_PERMIT, RMAP_DENY, RMAP_ANY };
 
 typedef enum {
-	RMAP_MATCH,
 	RMAP_DENYMATCH,
-	RMAP_NOMATCH,
-	RMAP_ERROR,
-	RMAP_OKAY
+	RMAP_PERMITMATCH
 } route_map_result_t;
 
 typedef enum {
@@ -91,10 +112,10 @@ struct route_map_rule_cmd {
 	const char *str;
 
 	/* Function for value set or match. */
-	route_map_result_t (*func_apply)(void *rule,
-					 const struct prefix *prefix,
-					 route_map_object_t type,
-					 void *object);
+	enum route_map_match_result_t (*func_apply)(void *rule,
+						    const struct prefix *prefix,
+						    route_map_object_t type,
+						    void *object);
 
 	/* Compile argument and return result as void *. */
 	void *(*func_compile)(const char *);

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1018,7 +1018,7 @@ void ospf6_asbr_redistribute_add(int type, ifindex_t ifindex,
 				 unsigned int nexthop_num,
 				 struct in6_addr *nexthop, route_tag_t tag)
 {
-	int ret;
+	route_map_result_t ret;
 	struct ospf6_route troute;
 	struct ospf6_external_info tinfo;
 	struct ospf6_route *route, *match;
@@ -1355,7 +1355,7 @@ static void ospf6_redistribute_show_config(struct vty *vty)
 
 
 /* Routemap Functions */
-static route_map_result_t
+static enum route_map_match_result_t
 ospf6_routemap_rule_match_address_prefixlist(void *rule,
 					     const struct prefix *prefix,
 					     route_map_object_t type,
@@ -1395,7 +1395,7 @@ struct route_map_rule_cmd ospf6_routemap_rule_match_address_prefixlist_cmd = {
 /* `match interface IFNAME' */
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t
+static enum route_map_match_result_t
 ospf6_routemap_rule_match_interface(void *rule, const struct prefix *prefix,
 				    route_map_object_t type, void *object)
 {
@@ -1433,10 +1433,9 @@ struct route_map_rule_cmd ospf6_routemap_rule_match_interface_cmd = {
 	ospf6_routemap_rule_match_interface_free};
 
 /* Match function for matching route tags */
-static route_map_result_t ospf6_routemap_rule_match_tag(void *rule,
-							const struct prefix *p,
-							route_map_object_t type,
-							void *object)
+static enum route_map_match_result_t
+ospf6_routemap_rule_match_tag(void *rule, const struct prefix *p,
+			      route_map_object_t type, void *object)
 {
 	route_tag_t *tag = rule;
 	struct ospf6_route *route = object;
@@ -1453,7 +1452,7 @@ static struct route_map_rule_cmd ospf6_routemap_rule_match_tag_cmd = {
 	route_map_rule_tag_free,
 };
 
-static route_map_result_t
+static enum route_map_match_result_t
 ospf6_routemap_rule_set_metric_type(void *rule, const struct prefix *prefix,
 				    route_map_object_t type, void *object)
 {
@@ -1489,7 +1488,7 @@ struct route_map_rule_cmd ospf6_routemap_rule_set_metric_type_cmd = {
 	ospf6_routemap_rule_set_metric_type_free,
 };
 
-static route_map_result_t
+static enum route_map_match_result_t
 ospf6_routemap_rule_set_metric(void *rule, const struct prefix *prefix,
 			       route_map_object_t type, void *object)
 {
@@ -1524,7 +1523,7 @@ struct route_map_rule_cmd ospf6_routemap_rule_set_metric_cmd = {
 	ospf6_routemap_rule_set_metric_free,
 };
 
-static route_map_result_t
+static enum route_map_match_result_t
 ospf6_routemap_rule_set_forwarding(void *rule, const struct prefix *prefix,
 				   route_map_object_t type, void *object)
 {
@@ -1562,10 +1561,9 @@ struct route_map_rule_cmd ospf6_routemap_rule_set_forwarding_cmd = {
 	ospf6_routemap_rule_set_forwarding_free,
 };
 
-static route_map_result_t ospf6_routemap_rule_set_tag(void *rule,
-						      const struct prefix *p,
-						      route_map_object_t type,
-						      void *object)
+static enum route_map_match_result_t
+ospf6_routemap_rule_set_tag(void *rule, const struct prefix *p,
+			    route_map_object_t type, void *object)
 {
 	route_tag_t *tag = rule;
 	struct ospf6_route *route = object;

--- a/ospfd/ospf_routemap.c
+++ b/ospfd/ospf_routemap.c
@@ -126,10 +126,9 @@ static void ospf_route_map_event(const char *name)
 
 /* `match ip netxthop ' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_ip_nexthop(void *rule,
-						 const struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_ip_nexthop(void *rule, const struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 	struct external_info *ei = object;
@@ -171,7 +170,7 @@ struct route_map_rule_cmd route_match_ip_nexthop_cmd = {
 
 /* `match ip next-hop prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
 				    route_map_object_t type, void *object)
 {
@@ -213,10 +212,9 @@ struct route_map_rule_cmd route_match_ip_next_hop_prefix_list_cmd = {
 /* `match ip address IP_ACCESS_LIST' */
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_ip_address(void *rule,
-						 const struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_ip_address(void *rule, const struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 	/* struct prefix_ipv4 match; */
@@ -252,7 +250,7 @@ struct route_map_rule_cmd route_match_ip_address_cmd = {
 	route_match_ip_address_free};
 
 /* `match ip address prefix-list PREFIX_LIST' */
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_address_prefix_list(void *rule, const struct prefix *prefix,
 				   route_map_object_t type, void *object)
 {
@@ -288,10 +286,9 @@ struct route_map_rule_cmd route_match_ip_address_prefix_list_cmd = {
 /* `match interface IFNAME' */
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_interface(void *rule,
-						const struct prefix *prefix,
-						route_map_object_t type,
-						void *object)
+static enum route_map_match_result_t
+route_match_interface(void *rule, const struct prefix *prefix,
+		      route_map_object_t type, void *object)
 {
 	struct interface *ifp;
 	struct external_info *ei;
@@ -327,9 +324,9 @@ struct route_map_rule_cmd route_match_interface_cmd = {
 	route_match_interface_free};
 
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_tag(void *rule,
-					  const struct prefix *prefix,
-					  route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_match_tag(void *rule, const struct prefix *prefix,
+		route_map_object_t type, void *object)
 {
 	route_tag_t *tag;
 	struct external_info *ei;
@@ -358,10 +355,9 @@ struct ospf_metric {
 
 /* `set metric METRIC' */
 /* Set metric to attribute. */
-static route_map_result_t route_set_metric(void *rule,
-					   const struct prefix *prefix,
-					   route_map_object_t type,
-					   void *object)
+static enum route_map_match_result_t
+route_set_metric(void *rule, const struct prefix *prefix,
+		 route_map_object_t type, void *object)
 {
 	struct ospf_metric *metric;
 	struct external_info *ei;
@@ -439,10 +435,9 @@ struct route_map_rule_cmd route_set_metric_cmd = {
 
 /* `set metric-type TYPE' */
 /* Set metric-type to attribute. */
-static route_map_result_t route_set_metric_type(void *rule,
-						const struct prefix *prefix,
-						route_map_object_t type,
-						void *object)
+static enum route_map_match_result_t
+route_set_metric_type(void *rule, const struct prefix *prefix,
+		      route_map_object_t type, void *object)
 {
 	uint32_t *metric_type;
 	struct external_info *ei;
@@ -489,8 +484,9 @@ struct route_map_rule_cmd route_set_metric_type_cmd = {
 	route_set_metric_type_free,
 };
 
-static route_map_result_t route_set_tag(void *rule, const struct prefix *prefix,
-					route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_set_tag(void *rule, const struct prefix *prefix, route_map_object_t type,
+	      void *object)
 {
 	route_tag_t *tag;
 	struct external_info *ei;

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -943,7 +943,7 @@ int ospf_redistribute_check(struct ospf *ospf, struct external_info *ei,
 	/* apply route-map if needed */
 	red = ospf_redist_lookup(ospf, type, instance);
 	if (red && ROUTEMAP_NAME(red)) {
-		int ret;
+		route_map_result_t ret;
 
 		ret = route_map_apply(ROUTEMAP(red), (struct prefix *)p,
 				      RMAP_OSPF, ei);

--- a/ripd/rip_routemap.c
+++ b/ripd/rip_routemap.c
@@ -42,10 +42,9 @@ struct rip_metric_modifier {
 
 /* `match metric METRIC' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_metric(void *rule,
-					     const struct prefix *prefix,
-					     route_map_object_t type,
-					     void *object)
+static enum route_map_match_result_t
+route_match_metric(void *rule, const struct prefix *prefix,
+		   route_map_object_t type, void *object)
 {
 	uint32_t *metric;
 	uint32_t check;
@@ -95,10 +94,9 @@ struct route_map_rule_cmd route_match_metric_cmd = {
 
 /* `match interface IFNAME' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_interface(void *rule,
-						const struct prefix *prefix,
-						route_map_object_t type,
-						void *object)
+static enum route_map_match_result_t
+route_match_interface(void *rule, const struct prefix *prefix,
+		      route_map_object_t type, void *object)
 {
 	struct rip_info *rinfo;
 	struct interface *ifp;
@@ -143,10 +141,9 @@ struct route_map_rule_cmd route_match_interface_cmd = {
 /* `match ip next-hop IP_ACCESS_LIST' */
 
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_ip_next_hop(void *rule,
-						  const struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_match_ip_next_hop(void *rule, const struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 	struct rip_info *rinfo;
@@ -190,7 +187,7 @@ static struct route_map_rule_cmd route_match_ip_next_hop_cmd = {
 
 /* `match ip next-hop prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
 				    route_map_object_t type, void *object)
 {
@@ -235,10 +232,9 @@ static struct route_map_rule_cmd route_match_ip_next_hop_prefix_list_cmd = {
 
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_ip_address(void *rule,
-						 const struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_ip_address(void *rule, const struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 
@@ -274,7 +270,7 @@ static struct route_map_rule_cmd route_match_ip_address_cmd = {
 
 /* `match ip address prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_address_prefix_list(void *rule, const struct prefix *prefix,
 				   route_map_object_t type, void *object)
 {
@@ -309,8 +305,9 @@ static struct route_map_rule_cmd route_match_ip_address_prefix_list_cmd = {
 
 /* `match tag TAG' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_tag(void *rule, const struct prefix *p,
-					  route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_match_tag(void *rule, const struct prefix *p, route_map_object_t type,
+		void *object)
 {
 	route_tag_t *tag;
 	struct rip_info *rinfo;
@@ -339,10 +336,9 @@ static struct route_map_rule_cmd route_match_tag_cmd = {
 /* `set metric METRIC' */
 
 /* Set metric to attribute. */
-static route_map_result_t route_set_metric(void *rule,
-					   const struct prefix *prefix,
-					   route_map_object_t type,
-					   void *object)
+static enum route_map_match_result_t
+route_set_metric(void *rule, const struct prefix *prefix,
+		 route_map_object_t type, void *object)
 {
 	if (type == RMAP_RIP) {
 		struct rip_metric_modifier *mod;
@@ -438,7 +434,7 @@ static struct route_map_rule_cmd route_set_metric_cmd = {
 /* `set ip next-hop IP_ADDRESS' */
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
-static route_map_result_t route_set_ip_nexthop(void *rule,
+static enum route_map_match_result_t route_set_ip_nexthop(void *rule,
 					       const struct prefix *prefix,
 					       route_map_object_t type,
 					       void *object)
@@ -491,8 +487,9 @@ static struct route_map_rule_cmd route_set_ip_nexthop_cmd = {
 /* `set tag TAG' */
 
 /* Set tag to object.  ojbect must be pointer to struct attr. */
-static route_map_result_t route_set_tag(void *rule, const struct prefix *prefix,
-					route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_set_tag(void *rule, const struct prefix *prefix, route_map_object_t type,
+	      void *object)
 {
 	route_tag_t *tag;
 	struct rip_info *rinfo;

--- a/ripngd/ripng_routemap.c
+++ b/ripngd/ripng_routemap.c
@@ -38,10 +38,9 @@ struct rip_metric_modifier {
 
 /* `match metric METRIC' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_metric(void *rule,
-					     const struct prefix *prefix,
-					     route_map_object_t type,
-					     void *object)
+static enum route_map_match_result_t
+route_match_metric(void *rule, const struct prefix *prefix,
+		   route_map_object_t type, void *object)
 {
 	uint32_t *metric;
 	struct ripng_info *rinfo;
@@ -86,10 +85,9 @@ static struct route_map_rule_cmd route_match_metric_cmd = {
 
 /* `match interface IFNAME' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_interface(void *rule,
-						const struct prefix *prefix,
-						route_map_object_t type,
-						void *object)
+static enum route_map_match_result_t
+route_match_interface(void *rule, const struct prefix *prefix,
+		      route_map_object_t type, void *object)
 {
 	struct ripng_info *rinfo;
 	struct interface *ifp;
@@ -129,9 +127,10 @@ static struct route_map_rule_cmd route_match_interface_cmd = {
 
 /* `match tag TAG' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_tag(void *rule,
-					  const struct prefix *prefix,
-					  route_map_object_t type, void *object)
+static enum route_map_match_result_t route_match_tag(void *rule,
+						const struct prefix *prefix,
+						route_map_object_t type,
+						void *object)
 {
 	route_tag_t *tag;
 	struct ripng_info *rinfo;
@@ -159,10 +158,9 @@ static struct route_map_rule_cmd route_match_tag_cmd = {
 /* `set metric METRIC' */
 
 /* Set metric to attribute. */
-static route_map_result_t route_set_metric(void *rule,
-					   const struct prefix *prefix,
-					   route_map_object_t type,
-					   void *object)
+static enum route_map_match_result_t
+route_set_metric(void *rule, const struct prefix *prefix,
+		 route_map_object_t type, void *object)
 {
 	if (type == RMAP_RIPNG) {
 		struct rip_metric_modifier *mod;
@@ -256,10 +254,9 @@ static struct route_map_rule_cmd route_set_metric_cmd = {
 /* `set ipv6 next-hop local IP_ADDRESS' */
 
 /* Set nexthop to object.  ojbect must be pointer to struct attr. */
-static route_map_result_t route_set_ipv6_nexthop_local(void *rule,
-						       const struct prefix *p,
-						       route_map_object_t type,
-						       void *object)
+static enum route_map_match_result_t
+route_set_ipv6_nexthop_local(void *rule, const struct prefix *p,
+			     route_map_object_t type, void *object)
 {
 	struct in6_addr *address;
 	struct ripng_info *rinfo;
@@ -310,9 +307,9 @@ static struct route_map_rule_cmd route_set_ipv6_nexthop_local_cmd = {
 /* `set tag TAG' */
 
 /* Set tag to object.  ojbect must be pointer to struct attr. */
-static route_map_result_t route_set_tag(void *rule,
-					const struct prefix *prefix,
-					route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_set_tag(void *rule, const struct prefix *prefix, route_map_object_t type,
+	      void *object)
 {
 	route_tag_t *tag;
 	struct ripng_info *rinfo;

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -574,7 +574,7 @@ int zebra_add_import_table_entry(struct route_node *rn, struct route_entry *re,
 	struct route_entry *newre;
 	struct route_entry *same;
 	struct prefix p;
-	route_map_result_t ret = RMAP_MATCH;
+	route_map_result_t ret = RMAP_PERMITMATCH;
 	afi_t afi;
 
 	afi = family2afi(rn->p.family);
@@ -583,7 +583,7 @@ int zebra_add_import_table_entry(struct route_node *rn, struct route_entry *re,
 			afi, re->type, re->instance, &rn->p, re->ng.nexthop,
 			re->vrf_id, re->tag, rmap_name);
 
-	if (ret != RMAP_MATCH) {
+	if (ret != RMAP_PERMITMATCH) {
 		UNSET_FLAG(re->flags, ZEBRA_FLAG_SELECTED);
 		zebra_del_import_table_entry(rn, re);
 		return 0;

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -338,7 +338,7 @@ static unsigned nexthop_active_check(struct route_node *rn,
 				     struct nexthop *nexthop)
 {
 	struct interface *ifp;
-	route_map_result_t ret = RMAP_MATCH;
+	route_map_result_t ret = RMAP_PERMITMATCH;
 	int family;
 	char buf[SRCDEST2STR_BUFFER];
 	const struct prefix *p, *src_p;

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -400,7 +400,7 @@ static int zebra_rnh_apply_nht_rmap(afi_t afi, struct zebra_vrf *zvrf,
 {
 	int at_least_one = 0;
 	struct nexthop *nexthop;
-	int ret;
+	route_map_result_t ret;
 
 	if (prn && re) {
 		for (nexthop = re->ng.nexthop; nexthop;

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -136,9 +136,9 @@ static int zebra_route_match_delete(struct vty *vty, const char *command,
 /* 'match tag TAG'
  * Match function return 1 if match is success else return 0
  */
-static route_map_result_t route_match_tag(void *rule,
-					  const struct prefix *prefix,
-					  route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_match_tag(void *rule, const struct prefix *prefix,
+		route_map_object_t type, void *object)
 {
 	route_tag_t *tag;
 	struct nh_rmap_obj *nh_data;
@@ -162,10 +162,9 @@ static struct route_map_rule_cmd route_match_tag_cmd = {
 
 /* `match interface IFNAME' */
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_interface(void *rule,
-						const struct prefix *prefix,
-						route_map_object_t type,
-						void *object)
+static enum route_map_match_result_t
+route_match_interface(void *rule, const struct prefix *prefix,
+		      route_map_object_t type, void *object)
 {
 	struct nh_rmap_obj *nh_data;
 	char *ifname = rule;
@@ -1025,10 +1024,9 @@ DEFPY (show_ipv6_protocol_nht,
 /* `match ip next-hop IP_ACCESS_LIST' */
 
 /* Match function return 1 if match is success else return zero. */
-static route_map_result_t route_match_ip_next_hop(void *rule,
-						  const struct prefix *prefix,
-						  route_map_object_t type,
-						  void *object)
+static enum route_map_match_result_t
+route_match_ip_next_hop(void *rule, const struct prefix *prefix,
+			route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 	struct nh_rmap_obj *nh_data;
@@ -1083,7 +1081,7 @@ static struct route_map_rule_cmd route_match_ip_next_hop_cmd = {
 
 /* `match ip next-hop prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_next_hop_prefix_list(void *rule, const struct prefix *prefix,
 				    route_map_object_t type, void *object)
 {
@@ -1139,10 +1137,9 @@ static struct route_map_rule_cmd route_match_ip_next_hop_prefix_list_cmd = {
 
 /* Match function should return 1 if match is success else return
    zero. */
-static route_map_result_t route_match_address(afi_t afi, void *rule,
-					      const struct prefix *prefix,
-					      route_map_object_t type,
-					      void *object)
+static enum route_map_match_result_t
+route_match_address(afi_t afi, void *rule, const struct prefix *prefix,
+		    route_map_object_t type, void *object)
 {
 	struct access_list *alist;
 
@@ -1158,19 +1155,16 @@ static route_map_result_t route_match_address(afi_t afi, void *rule,
 	return RMAP_NOMATCH;
 }
 
-static route_map_result_t route_match_ip_address(void *rule,
-						 const struct prefix *prefix,
-						 route_map_object_t type,
-						 void *object)
+static enum route_map_match_result_t
+route_match_ip_address(void *rule, const struct prefix *prefix,
+		       route_map_object_t type, void *object)
 {
 	return route_match_address(AFI_IP, rule, prefix, type, object);
 }
 
-static route_map_result_t route_match_ipv6_address(void *rule,
-						   const struct prefix *prefix,
-						   route_map_object_t type,
-						   void *object)
-
+static enum route_map_match_result_t
+route_match_ipv6_address(void *rule, const struct prefix *prefix,
+			 route_map_object_t type, void *object)
 {
 	return route_match_address(AFI_IP6, rule, prefix, type, object);
 }
@@ -1200,7 +1194,7 @@ static struct route_map_rule_cmd route_match_ipv6_address_cmd = {
 
 /* `match ip address prefix-list PREFIX_LIST' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_address_prefix_list(void *rule, const struct prefix *prefix,
 			route_map_object_t type, void *object, afi_t afi)
 {
@@ -1218,7 +1212,7 @@ route_match_address_prefix_list(void *rule, const struct prefix *prefix,
 	return RMAP_NOMATCH;
 }
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_address_prefix_list(void *rule, const struct prefix *prefix,
 				   route_map_object_t type, void *object)
 {
@@ -1241,7 +1235,7 @@ static struct route_map_rule_cmd route_match_ip_address_prefix_list_cmd = {
 	route_match_address_prefix_list_compile,
 	route_match_address_prefix_list_free};
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ipv6_address_prefix_list(void *rule, const struct prefix *prefix,
 					route_map_object_t type, void *object)
 {
@@ -1256,7 +1250,7 @@ static struct route_map_rule_cmd route_match_ipv6_address_prefix_list_cmd = {
 
 /* `match ip address prefix-len PREFIXLEN' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_address_prefix_len(void *rule, const struct prefix *prefix,
 			       route_map_object_t type, void *object)
 {
@@ -1307,7 +1301,7 @@ static struct route_map_rule_cmd route_match_ipv6_address_prefix_len_cmd = {
 
 /* `match ip nexthop prefix-len PREFIXLEN' */
 
-static route_map_result_t
+static enum route_map_match_result_t
 route_match_ip_nexthop_prefix_len(void *rule, const struct prefix *prefix,
 				  route_map_object_t type, void *object)
 {
@@ -1347,10 +1341,9 @@ static struct route_map_rule_cmd route_match_ip_nexthop_prefix_len_cmd = {
 
 /* `match source-protocol PROTOCOL' */
 
-static route_map_result_t route_match_source_protocol(void *rule,
-						      const struct prefix *p,
-						      route_map_object_t type,
-						      void *object)
+static enum route_map_match_result_t
+route_match_source_protocol(void *rule, const struct prefix *p,
+			    route_map_object_t type, void *object)
 {
 	uint32_t *rib_type = (uint32_t *)rule;
 	struct nh_rmap_obj *nh_data;
@@ -1389,10 +1382,9 @@ static struct route_map_rule_cmd route_match_source_protocol_cmd = {
 	route_match_source_protocol_compile, route_match_source_protocol_free};
 
 /* `source-instance` */
-static route_map_result_t route_match_source_instance(void *rule,
-						      const struct prefix *p,
-						      route_map_object_t type,
-						      void *object)
+static enum route_map_match_result_t
+route_match_source_instance(void *rule, const struct prefix *p,
+			    route_map_object_t type, void *object)
 {
 	uint8_t *instance = (uint8_t *)rule;
 	struct nh_rmap_obj *nh_data;
@@ -1432,8 +1424,9 @@ static struct route_map_rule_cmd route_match_source_instance_cmd = {
 /* `set src A.B.C.D' */
 
 /* Set src. */
-static route_map_result_t route_set_src(void *rule, const struct prefix *prefix,
-					route_map_object_t type, void *object)
+static enum route_map_match_result_t
+route_set_src(void *rule, const struct prefix *prefix, route_map_object_t type,
+	      void *object)
 {
 	struct nh_rmap_obj *nh_data;
 
@@ -1699,7 +1692,7 @@ zebra_route_map_check(int family, int rib_type, uint8_t instance,
 		      struct zebra_vrf *zvrf, route_tag_t tag)
 {
 	struct route_map *rmap = NULL;
-	route_map_result_t ret = RMAP_MATCH;
+	route_map_result_t ret = RMAP_PERMITMATCH;
 	struct nh_rmap_obj nh_obj;
 
 	nh_obj.nexthop = nexthop;
@@ -1745,7 +1738,7 @@ zebra_import_table_route_map_check(int family, int re_type, uint8_t instance,
 				   const char *rmap_name)
 {
 	struct route_map *rmap = NULL;
-	route_map_result_t ret = RMAP_DENYMATCH;
+	enum route_map_match_result_t ret = RMAP_DENYMATCH;
 	struct nh_rmap_obj nh_obj;
 
 	nh_obj.nexthop = nexthop;
@@ -1771,7 +1764,7 @@ route_map_result_t zebra_nht_route_map_check(afi_t afi, int client_proto,
 					     struct nexthop *nexthop)
 {
 	struct route_map *rmap = NULL;
-	route_map_result_t ret = RMAP_MATCH;
+	route_map_result_t ret = RMAP_PERMITMATCH;
 	struct nh_rmap_obj nh_obj;
 
 	nh_obj.nexthop = nexthop;


### PR DESCRIPTION
Introducing a 3rd state for route_map_apply library function: RMAP_NOOP

### Background
Traditionally route map match rule apis  were designed to return a binary response, consisting of either RMAP_MATCH or RMAP_NOMATCH. (Route-map set rule apis return RMAP_OKAY or RMAP_ERROR).
Depending on this response, the following statemachine decided the course of action:

ACTION: route-map match cmd is applied and produces binary response.
**State1**: Receveived `RMAP_MATCH`
THEN: If Routemap type is PERMIT, execute other rules within route-map if applicable, otherwise we PERMIT!
Else: If Routemap type is DENY, we DENYMATCH right away

**State2**: Received `RMAP_NOMATCH`, continue on to next route-map, otherwise, return DENYMATCH by default if nothing matched.

### Reference/Context
With reference to PR 4078 (https://github.com/FRRouting/frr/pull/4078),
we require a 3rd state because of the following situation:

_**The issue - what if, the rule api needs to abort or ignore a rule?:**_
"`match evpn vni xx`" route-map filter can be applied to incoming routes regardless of whether the tunnel type is vxlan or mpls.
This rule should be N/A for mpls based evpn route, but applicable to only vxlan based evpn route.

Today, the filter produces either a match or nomatch response regardless of whether it is mpls/vxlan, resulting in either permitting or denying the route.. So an mpls evpn route may get filtered out incorrectly.
Eg: "`route-map RM1 permit 10 ; match evpn vni 20`" or "`route-map RM2 deny 20 ; match vni 20`"

With the introduction of the 3rd state, we can abort this rule check safely.
How? The match rules api can now return RMAP_NOOP (or another enum) to indicate that it encountered an invalid check, and needs to abort just that rule, but continue with other rules.

_Question_: Do we repurpose an existing enum RMAP_OKAY or RMAP_ERROR
as the 3rd state (or create a new enum like RMAP_IGNORE)?
(route-map set cmd uses RMAP_OKAY  and RMAP_ERROR, so its best not to use them)

We chose to go with RMAP_NOOP (but open to ideas), as a way to bypass the rmap filter

As a result we have a 3rd state:
**State3**: Received RMAP_NOOP
Then, proceed to other route-maps, otherwise return PERMIT by default.

Signed-off-by:Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>