### PR TITLE
doc: fix ospf6d router-id cmd

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -15,8 +15,8 @@ OSPF6 router
 .. index:: router ospf6
 .. clicmd:: router ospf6
 
-.. index:: router-id A.B.C.D
-.. clicmd:: router-id A.B.C.D
+.. index:: ospf6 router-id A.B.C.D
+.. clicmd:: ospf6 router-id A.B.C.D
 
    Set router's Router-ID.
 


### PR DESCRIPTION
in ospf6d, the 'router-id' command must be prefixed with 'ospf6'.
Update the docs to reflect this.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>