### PR TITLE
zebra: Switch to using monotime(NULL) for re->uptime

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -614,7 +614,7 @@ int zebra_add_import_table_entry(struct route_node *rn, struct route_entry *re,
 	newre->mtu = re->mtu;
 	newre->table = 0;
 	newre->nexthop_num = 0;
-	newre->uptime = time(NULL);
+	newre->uptime = monotime(NULL);
 	newre->instance = re->table;
 	route_entry_copy_nexthops(newre, re->ng.nexthop);
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -583,7 +583,7 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 			re->vrf_id = vrf_id;
 			re->table = table;
 			re->nexthop_num = 0;
-			re->uptime = time(NULL);
+			re->uptime = monotime(NULL);
 			re->tag = tag;
 
 			for (;;) {

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1388,7 +1388,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	re->type = api.type;
 	re->instance = api.instance;
 	re->flags = api.flags;
-	re->uptime = time(NULL);
+	re->uptime = monotime(NULL);
 	re->vrf_id = vrf_id;
 	if (api.tableid && vrf_id == VRF_DEFAULT)
 		re->table = api.tableid;

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3003,7 +3003,7 @@ int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 	re->table = table_id;
 	re->vrf_id = vrf_id;
 	re->nexthop_num = 0;
-	re->uptime = time(NULL);
+	re->uptime = monotime(NULL);
 	re->tag = tag;
 
 	/* Add nexthop. */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -230,7 +230,7 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 		time_t uptime;
 		struct tm *tm;
 
-		uptime = time(NULL);
+		uptime = monotime(NULL);
 		uptime -= re->uptime;
 		tm = gmtime(&uptime);
 
@@ -385,7 +385,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 	struct tm *tm;
 	rib_dest_t *dest = rib_dest_from_rnode(rn);
 
-	uptime = time(NULL);
+	uptime = monotime(NULL);
 	uptime -= re->uptime;
 	tm = gmtime(&uptime);
 


### PR DESCRIPTION
The re->uptime usage of time(NULL) leaves it open to
timing changes from outside influence.  Switching
to monotime allows us to ensure that we have a timestamp
that is always increasing.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>