### PR TITLE
zebra: Make RIB_SYSTEM|KERNEL_ROUTE a property of rib.h

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -148,6 +148,11 @@ struct route_entry {
 	uint32_t dplane_sequence;
 };
 
+#define RIB_SYSTEM_ROUTE(R)                                                    \
+	((R)->type == ZEBRA_ROUTE_KERNEL || (R)->type == ZEBRA_ROUTE_CONNECT)
+
+#define RIB_KERNEL_ROUTE(R) ((R)->type == ZEBRA_ROUTE_KERNEL)
+
 /* meta-queue structure:
  * sub-queue 0: connected, kernel
  * sub-queue 1: static

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -148,10 +148,9 @@ struct route_entry {
 	uint32_t dplane_sequence;
 };
 
-#define RIB_SYSTEM_ROUTE(R)                                                    \
-	((R)->type == ZEBRA_ROUTE_KERNEL || (R)->type == ZEBRA_ROUTE_CONNECT)
+#define RIB_SYSTEM_ROUTE(R) RSYSTEM_ROUTE((R)->type)
 
-#define RIB_KERNEL_ROUTE(R) ((R)->type == ZEBRA_ROUTE_KERNEL)
+#define RIB_KERNEL_ROUTE(R) RKERNEL_ROUTE((R)->type)
 
 /* meta-queue structure:
  * sub-queue 0: connected, kernel

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -35,8 +35,10 @@
 extern "C" {
 #endif
 
-#define RSYSTEM_ROUTE(type)						\
-	((type) == ZEBRA_ROUTE_KERNEL || (type) == ZEBRA_ROUTE_CONNECT)
+#define RKERNEL_ROUTE(type) ((type) == ZEBRA_ROUTE_KERNEL)
+
+#define RSYSTEM_ROUTE(type)                                                    \
+	((RKERNEL_ROUTE(type)) || (type) == ZEBRA_ROUTE_CONNECT)
 
 /*
  * Update or delete a route, LSP, or pseudowire from the kernel,

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -797,12 +797,6 @@ struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *p, vrf_id_t vrf_id)
 	return NULL;
 }
 
-#define RIB_SYSTEM_ROUTE(R)                                                    \
-	((R)->type == ZEBRA_ROUTE_KERNEL || (R)->type == ZEBRA_ROUTE_CONNECT)
-
-#define RIB_KERNEL_ROUTE(R)						\
-	((R)->type == ZEBRA_ROUTE_KERNEL)
-
 /* This function verifies reachability of one given nexthop, which can be
  * numbered or unnumbered, IPv4 or IPv6. The result is unconditionally stored
  * in nexthop->flags field. The nexthop->ifindex will be updated


### PR DESCRIPTION
These defines should be available from rib.h

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>