### PR TITLE
lib: Add nexthop_cmp

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -474,8 +474,7 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 				continue;
 
 			for (oldnh = bnc->nexthop; oldnh; oldnh = oldnh->next)
-				if (nexthop_same_no_recurse(oldnh, nexthop) &&
-				    nexthop_labels_match(oldnh, nexthop))
+				if (nexthop_same(oldnh, nexthop))
 					break;
 
 			if (!oldnh)

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -36,6 +36,34 @@
 DEFINE_MTYPE_STATIC(LIB, NEXTHOP, "Nexthop")
 DEFINE_MTYPE_STATIC(LIB, NH_LABEL, "Nexthop label")
 
+static int nexthop_labels_cmp(const struct nexthop *nh1,
+			      const struct nexthop *nh2)
+{
+	const struct mpls_label_stack *nhl1 = NULL;
+	const struct mpls_label_stack *nhl2 = NULL;
+
+	nhl1 = nh1->nh_label;
+	nhl2 = nh2->nh_label;
+
+	/* No labels is a match */
+	if (!nhl1 && !nhl2)
+		return 0;
+
+	if (nhl1 && !nhl2)
+		return 1;
+
+	if (nhl2 && !nhl1)
+		return -1;
+
+	if (nhl1->num_labels > nhl2->num_labels)
+		return 1;
+
+	if (nhl1->num_labels < nhl2->num_labels)
+		return -1;
+
+	return memcmp(nhl1->label, nhl2->label, nhl1->num_labels);
+}
+
 int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 {
 	int ret;

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -92,13 +92,13 @@ int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 		break;
 	case NEXTHOP_TYPE_IPV6:
 		ret = memcmp(&next1->gate, &next2->gate, sizeof(union g_addr));
-		if (!ret)
+		if (ret)
 			return ret;
 		break;
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
 		ret = memcmp(&next1->gate, &next2->gate, sizeof(union g_addr));
-		if (!ret)
+		if (ret)
 			return ret;
 		/* Intentional Fall-Through */
 	case NEXTHOP_TYPE_IFINDEX:

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -206,27 +206,12 @@ const char *nexthop_type_to_str(enum nexthop_types_t nh_type)
 /*
  * Check if the labels match for the 2 nexthops specified.
  */
-int nexthop_labels_match(const struct nexthop *nh1, const struct nexthop *nh2)
+bool nexthop_labels_match(const struct nexthop *nh1, const struct nexthop *nh2)
 {
-	const struct mpls_label_stack *nhl1, *nhl2;
+	if (nexthop_labels_cmp(nh1, nh2) != 0)
+		return false;
 
-	nhl1 = nh1->nh_label;
-	nhl2 = nh2->nh_label;
-
-	/* No labels is a match */
-	if (!nhl1 && !nhl2)
-		return 1;
-
-	if (!nhl1 || !nhl2)
-		return 0;
-
-	if (nhl1->num_labels != nhl2->num_labels)
-		return 0;
-
-	if (memcmp(nhl1->label, nhl2->label, nhl1->num_labels))
-		return 0;
-
-	return 1;
+	return true;
 }
 
 struct nexthop *nexthop_new(void)

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -66,8 +66,9 @@ static int nexthop_labels_cmp(const struct nexthop *nh1,
 
 int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 {
-	int ret;
-	uint32_t n1, n2;
+	int ret = 0;
+	uint32_t n1 = 0;
+	uint32_2 n2 = 0;
 
 	if (next1->vrf_id < next2->vrf_id)
 		return -1;
@@ -81,7 +82,7 @@ int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 	if (next1->type > next2->type)
 		return 1;
 
-	switch(next1->type) {
+	switch (next1->type) {
 	case NEXTHOP_TYPE_IPV4:
 		n1 = ntohl(next1->gate.ipv4.s_addr);
 		n2 = ntohl(next2->gate.ipv4.s_addr);
@@ -118,6 +119,10 @@ int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 	}
 
 	ret = memcmp(&next1->src, &next2->src, sizeof(union g_addr));
+	if (ret)
+		return ret;
+
+	ret = nexthop_labels_cmp(next1, next2);
 	return ret;
 }
 

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -126,42 +126,6 @@ int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 	return ret;
 }
 
-/* check if nexthops are same, non-recursive */
-int nexthop_same_no_recurse(const struct nexthop *next1,
-			    const struct nexthop *next2)
-{
-	if (next1->type != next2->type)
-		return 0;
-
-	switch (next1->type) {
-	case NEXTHOP_TYPE_IPV4:
-	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		if (!IPV4_ADDR_SAME(&next1->gate.ipv4, &next2->gate.ipv4))
-			return 0;
-		if (next1->ifindex && (next1->ifindex != next2->ifindex))
-			return 0;
-		break;
-	case NEXTHOP_TYPE_IFINDEX:
-		if (next1->ifindex != next2->ifindex)
-			return 0;
-		break;
-	case NEXTHOP_TYPE_IPV6:
-		if (!IPV6_ADDR_SAME(&next1->gate.ipv6, &next2->gate.ipv6))
-			return 0;
-		break;
-	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		if (!IPV6_ADDR_SAME(&next1->gate.ipv6, &next2->gate.ipv6))
-			return 0;
-		if (next1->ifindex != next2->ifindex)
-			return 0;
-		break;
-	default:
-		/* do nothing */
-		break;
-	}
-	return 1;
-}
-
 int nexthop_same_firsthop(struct nexthop *next1, struct nexthop *next2)
 {
 	int type1 = NEXTHOP_FIRSTHOPTYPE(next1->type);

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -68,7 +68,7 @@ int nexthop_cmp(const struct nexthop *next1, const struct nexthop *next2)
 {
 	int ret = 0;
 	uint32_t n1 = 0;
-	uint32_2 n2 = 0;
+	uint32_t n2 = 0;
 
 	if (next1->vrf_id < next2->vrf_id)
 		return -1;
@@ -255,45 +255,10 @@ bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2)
 	if (nh1 == nh2)
 		return true;
 
-	if (nh1->vrf_id != nh2->vrf_id)
+	if (nexthop_cmp(nh1, nh2) != 0)
 		return false;
 
-	if (nh1->type != nh2->type)
-		return false;
-
-	switch (nh1->type) {
-	case NEXTHOP_TYPE_IFINDEX:
-		if (nh1->ifindex != nh2->ifindex)
-			return false;
-		break;
-	case NEXTHOP_TYPE_IPV4:
-		if (nh1->gate.ipv4.s_addr != nh2->gate.ipv4.s_addr)
-			return false;
-		break;
-	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		if (nh1->gate.ipv4.s_addr != nh2->gate.ipv4.s_addr)
-			return false;
-		if (nh1->ifindex != nh2->ifindex)
-			return false;
-		break;
-	case NEXTHOP_TYPE_IPV6:
-		if (memcmp(&nh1->gate.ipv6, &nh2->gate.ipv6, 16))
-			return false;
-		break;
-	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		if (memcmp(&nh1->gate.ipv6, &nh2->gate.ipv6, 16))
-			return false;
-		if (nh1->ifindex != nh2->ifindex)
-			return false;
-		break;
-	case NEXTHOP_TYPE_BLACKHOLE:
-		if (nh1->bh_type != nh2->bh_type)
-			return false;
-		break;
-	}
-
-	/* Compare labels too (if present) */
-	return (!!nexthop_labels_match(nh1, nh2));
+	return true;
 }
 
 /* Update nexthop with label information. */

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -139,6 +139,7 @@ void nexthop_del_labels(struct nexthop *);
 uint32_t nexthop_hash(const struct nexthop *nexthop);
 
 extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
+extern int nexthop_cmp(const struct nexthop *nh1, const struct nexthop *nh2);
 
 extern const char *nexthop_type_to_str(enum nexthop_types_t nh_type);
 extern int nexthop_same_no_recurse(const struct nexthop *next1,

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -144,8 +144,8 @@ extern int nexthop_cmp(const struct nexthop *nh1, const struct nexthop *nh2);
 extern const char *nexthop_type_to_str(enum nexthop_types_t nh_type);
 extern int nexthop_same_no_recurse(const struct nexthop *next1,
 				   const struct nexthop *next2);
-extern int nexthop_labels_match(const struct nexthop *nh1,
-				const struct nexthop *nh2);
+extern bool nexthop_labels_match(const struct nexthop *nh1,
+				 const struct nexthop *nh2);
 extern int nexthop_same_firsthop(struct nexthop *next1, struct nexthop *next2);
 
 extern const char *nexthop2str(const struct nexthop *nexthop,

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -139,6 +139,8 @@ void nexthop_del_labels(struct nexthop *);
 uint32_t nexthop_hash(const struct nexthop *nexthop);
 
 extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
+extern bool nexthop_same_no_labels(const struct nexthop *nh1,
+				   const struct nexthop *nh2);
 extern int nexthop_cmp(const struct nexthop *nh1, const struct nexthop *nh2);
 
 extern const char *nexthop_type_to_str(enum nexthop_types_t nh_type);

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -142,8 +142,6 @@ extern bool nexthop_same(const struct nexthop *nh1, const struct nexthop *nh2);
 extern int nexthop_cmp(const struct nexthop *nh1, const struct nexthop *nh2);
 
 extern const char *nexthop_type_to_str(enum nexthop_types_t nh_type);
-extern int nexthop_same_no_recurse(const struct nexthop *next1,
-				   const struct nexthop *next2);
 extern bool nexthop_labels_match(const struct nexthop *nh1,
 				 const struct nexthop *nh2);
 extern int nexthop_same_firsthop(struct nexthop *next1, struct nexthop *next2);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2855,7 +2855,11 @@ void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 				break;
 			}
 			for (ALL_NEXTHOPS(re->ng, rtnh))
-				if (nexthop_same(rtnh, nh)) {
+				/*
+				 * No guarantee all kernel send nh with labels
+				 * on delete.
+				 */
+				if (nexthop_same_no_labels(rtnh, nh)) {
 					same = re;
 					break;
 				}

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2855,7 +2855,7 @@ void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 				break;
 			}
 			for (ALL_NEXTHOPS(re->ng, rtnh))
-				if (nexthop_same_no_recurse(rtnh, nh)) {
+				if (nexthop_same(rtnh, nh)) {
 					same = re;
 					break;
 				}


### PR DESCRIPTION
Add function to allow us to have a sorted order
of nexthops.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>