### PR TITLE
lib: Add a couple functions to nexthop_group.c

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -425,6 +425,23 @@ uint32_t nexthop_hash(const struct nexthop *nexthop)
 	return key;
 }
 
+void nexthop_copy(struct nexthop *copy, const struct nexthop *nexthop,
+		  struct nexthop *rparent)
+{
+	copy->vrf_id = nexthop->vrf_id;
+	copy->ifindex = nexthop->ifindex;
+	copy->type = nexthop->type;
+	copy->flags = nexthop->flags;
+	memcpy(&copy->gate, &nexthop->gate, sizeof(nexthop->gate));
+	memcpy(&copy->src, &nexthop->src, sizeof(nexthop->src));
+	memcpy(&copy->rmap_src, &nexthop->rmap_src, sizeof(nexthop->rmap_src));
+	copy->rparent = rparent;
+	if (nexthop->nh_label)
+		nexthop_add_labels(copy, nexthop->nh_label_type,
+				   nexthop->nh_label->num_labels,
+				   &nexthop->nh_label->label[0]);
+}
+
 /*
  * nexthop printing variants:
  *	%pNHvv

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -442,6 +442,15 @@ void nexthop_copy(struct nexthop *copy, const struct nexthop *nexthop,
 				   &nexthop->nh_label->label[0]);
 }
 
+struct nexthop *nexthop_dup(const struct nexthop *nexthop,
+			    struct nexthop *rparent)
+{
+	struct nexthop *new = nexthop_new();
+
+	nexthop_copy(new, nexthop, rparent);
+	return new;
+}
+
 /*
  * nexthop printing variants:
  *	%pNHvv

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -152,8 +152,12 @@ extern const char *nexthop2str(const struct nexthop *nexthop,
 			       char *str, int size);
 extern struct nexthop *nexthop_next(struct nexthop *nexthop);
 extern unsigned int nexthop_level(struct nexthop *nexthop);
+/* Copies to an already allocated nexthop struct */
 extern void nexthop_copy(struct nexthop *copy, const struct nexthop *nexthop,
 			 struct nexthop *rparent);
+/* Duplicates a nexthop and returns the newly allocated nexthop */
+extern struct nexthop *nexthop_dup(const struct nexthop *nexthop,
+				   struct nexthop *rparent);
 
 #ifdef __cplusplus
 }

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -152,6 +152,8 @@ extern const char *nexthop2str(const struct nexthop *nexthop,
 			       char *str, int size);
 extern struct nexthop *nexthop_next(struct nexthop *nexthop);
 extern unsigned int nexthop_level(struct nexthop *nexthop);
+extern void nexthop_copy(struct nexthop *copy, const struct nexthop *nexthop,
+			 struct nexthop *rparent);
 
 #ifdef __cplusplus
 }

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -185,9 +185,7 @@ void copy_nexthops(struct nexthop **tnh, const struct nexthop *nh,
 	const struct nexthop *nh1;
 
 	for (nh1 = nh; nh1; nh1 = nh1->next) {
-		nexthop = nexthop_new();
-		nexthop_copy(nexthop, nh1, rparent);
-
+		nexthop = nexthop_dup(nh1, rparent);
 		nexthop_add(tnh, nexthop);
 
 		if (CHECK_FLAG(nh1->flags, NEXTHOP_FLAG_RECURSIVE))

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -186,19 +186,8 @@ void copy_nexthops(struct nexthop **tnh, const struct nexthop *nh,
 
 	for (nh1 = nh; nh1; nh1 = nh1->next) {
 		nexthop = nexthop_new();
-		nexthop->vrf_id = nh1->vrf_id;
-		nexthop->ifindex = nh1->ifindex;
-		nexthop->type = nh1->type;
-		nexthop->flags = nh1->flags;
-		memcpy(&nexthop->gate, &nh1->gate, sizeof(nh1->gate));
-		memcpy(&nexthop->src, &nh1->src, sizeof(nh1->src));
-		memcpy(&nexthop->rmap_src, &nh1->rmap_src,
-		       sizeof(nh1->rmap_src));
-		nexthop->rparent = rparent;
-		if (nh1->nh_label)
-			nexthop_add_labels(nexthop, nh1->nh_label_type,
-					   nh1->nh_label->num_labels,
-					   &nh1->nh_label->label[0]);
+		nexthop_copy(nexthop, nh1, rparent);
+
 		nexthop_add(tnh, nexthop);
 
 		if (CHECK_FLAG(nh1->flags, NEXTHOP_FLAG_RECURSIVE))

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -43,6 +43,10 @@ struct nexthop_group *nexthop_group_new(void);
 void nexthop_group_delete(struct nexthop_group **nhg);
 
 void nexthop_add(struct nexthop **target, struct nexthop *nexthop);
+void nexthop_group_add_sorted(struct nexthop_group *nhg,
+			      struct nexthop *nexthop);
+void nexthop_group_copy(struct nexthop_group *to,
+			struct nexthop_group *from);
 void nexthop_del(struct nexthop_group *nhg, struct nexthop *nexthop);
 void copy_nexthops(struct nexthop **tnh, const struct nexthop *nh,
 		   struct nexthop *rparent);

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -42,12 +42,8 @@ struct nexthop_group {
 struct nexthop_group *nexthop_group_new(void);
 void nexthop_group_delete(struct nexthop_group **nhg);
 
-void nexthop_add(struct nexthop **target, struct nexthop *nexthop);
-void nexthop_group_add_sorted(struct nexthop_group *nhg,
-			      struct nexthop *nexthop);
 void nexthop_group_copy(struct nexthop_group *to,
 			struct nexthop_group *from);
-void nexthop_del(struct nexthop_group *nhg, struct nexthop *nexthop);
 void copy_nexthops(struct nexthop **tnh, const struct nexthop *nh,
 		   struct nexthop *rparent);
 

--- a/lib/nexthop_group_private.h
+++ b/lib/nexthop_group_private.h
@@ -1,0 +1,45 @@
+/*
+ * Nexthop Group Private Functions.
+ * Copyright (C) 2019 Cumulus Networks, Inc.
+ *                    Stephen Worley
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * These functions should only be used internally for nexthop groups
+ * and in certain special cases. Please use `lib/nexthop_group.h` for
+ * any general nexthop_group api needs.
+ */
+
+#ifndef __NEXTHOP_GROUP_PRIVATE__
+#define __NEXTHOP_GROUP_PRIVATE__
+
+#include <nexthop_group.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void _nexthop_add(struct nexthop **target, struct nexthop *nexthop);
+void _nexthop_del(struct nexthop_group *nhg, struct nexthop *nexthop);
+void _nexthop_group_add_sorted(struct nexthop_group *nhg,
+			       struct nexthop *nexthop);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __NEXTHOP_GROUP_PRIVATE__ */

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -188,6 +188,7 @@ pkginclude_HEADERS += \
 	lib/network.h \
 	lib/nexthop.h \
 	lib/nexthop_group.h \
+	lib/nexthop_group_private.h \
 	lib/northbound.h \
 	lib/northbound_cli.h \
 	lib/northbound_db.h \

--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -21,7 +21,8 @@
 
 #include <log.h>
 #include <nexthop.h>
-#include <nexthop_group.h>
+#include "nexthop_group.h"
+#include "nexthop_group_private.h"
 #include <hash.h>
 #include <jhash.h>
 #include <vty.h>
@@ -576,7 +577,7 @@ void pbr_nht_delete_individual_nexthop(struct pbr_map_sequence *pbrms)
 
 	hash_release(pbr_nhg_hash, pnhgc);
 
-	nexthop_del(pbrms->nhg, nh);
+	_nexthop_del(pbrms->nhg, nh);
 	nexthop_free(nh);
 	nexthop_group_delete(&pbrms->nhg);
 	XFREE(MTYPE_TMP, pbrms->internal_nhg_name);
@@ -723,7 +724,7 @@ static void pbr_nexthop_group_cache_iterate_to_group(struct hash_bucket *b,
 
 	copy_nexthops(&nh, pnhc->nexthop, NULL);
 
-	nexthop_add(&nhg->nexthop, nh);
+	_nexthop_add(&nhg->nexthop, nh);
 }
 
 static void

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -25,6 +25,7 @@
 #include "vrf.h"
 #include "nexthop.h"
 #include "nexthop_group.h"
+#include "nexthop_group_private.h"
 #include "log.h"
 #include "debug.h"
 #include "pbr.h"
@@ -329,7 +330,7 @@ DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
 		nh = nexthop_new();
 
 		memcpy(nh, &nhop, sizeof(nhop));
-		nexthop_add(&pbrms->nhg->nexthop, nh);
+		_nexthop_add(&pbrms->nhg->nexthop, nh);
 
 		pbr_nht_add_individual_nexthop(pbrms);
 		pbr_map_check(pbrms);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -23,6 +23,7 @@
 #include <zebra.h>
 
 #include "lib/nexthop.h"
+#include "lib/nexthop_group_private.h"
 #include "lib/routemap.h"
 
 #include "zebra/connected.h"
@@ -100,7 +101,7 @@ static void nexthop_set_resolved(afi_t afi, const struct nexthop *newhop,
 				   &newhop->nh_label->label[0]);
 
 	resolved_hop->rparent = nexthop;
-	nexthop_add(&nexthop->resolved, resolved_hop);
+	_nexthop_add(&nexthop->resolved, resolved_hop);
 }
 
 /*

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -36,6 +36,7 @@
 #include "thread.h"
 #include "vrf.h"
 #include "workqueue.h"
+#include "nexthop_group_private.h"
 
 #include "zebra/zebra_router.h"
 #include "zebra/connected.h"
@@ -192,7 +193,7 @@ int zebra_check_addr(const struct prefix *p)
 /* Add nexthop to the end of a rib node's nexthop list */
 void route_entry_nexthop_add(struct route_entry *re, struct nexthop *nexthop)
 {
-	nexthop_add(&re->ng.nexthop, nexthop);
+	_nexthop_add(&re->ng.nexthop, nexthop);
 	re->nexthop_num++;
 }
 
@@ -1589,7 +1590,7 @@ static bool rib_update_re_from_ctx(struct route_entry *re,
 		 */
 		nexthop = nexthop_new();
 		nexthop->type = NEXTHOP_TYPE_IPV4;
-		nexthop_add(&(re->fib_ng.nexthop), nexthop);
+		_nexthop_add(&(re->fib_ng.nexthop), nexthop);
 	}
 
 done:


### PR DESCRIPTION
Add nexthop_group_copy and nexthop_group_add_sorted functions.

nexthop_group_copy -> Copy src nexthop_group into dst nexthop_group
nexthop_group_add_sorted -> Adds a new nexthop to the nexthop group
in a sorted manner.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>