### PR TITLE
lib: fix crash in the CLI grammar sandbox

### DIFF
--- a/lib/grammar_sandbox_main.c
+++ b/lib/grammar_sandbox_main.c
@@ -58,6 +58,8 @@ int main(int argc, char **argv)
 
 	vty_init(master);
 	memory_init();
+	yang_init();
+	nb_init(master, NULL, 0);
 
 	vty_stdio(vty_do_exit);
 


### PR DESCRIPTION
The CLI grammer sandbox needs to initialize the northbound subsystem
otherwise the running_config global variable won't be set, which
leads to crashes.

Fixes #4319.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>