### PR TITLE
zebra: Move multipath_num into zrouter

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -119,8 +119,6 @@ struct zebra_privs_t zserv_privs = {
 	.cap_num_p = array_size(_caps_p),
 	.cap_num_i = 0};
 
-unsigned int multipath_num = MULTIPATH_NUM;
-
 /* SIGHUP handler. */
 static void sighup(void)
 {
@@ -322,9 +320,9 @@ int main(int argc, char **argv)
 			keep_kernel_mode = 1;
 			break;
 		case 'e':
-			multipath_num = atoi(optarg);
-			if (multipath_num > MULTIPATH_NUM
-			    || multipath_num <= 0) {
+			zrouter.multipath_num = atoi(optarg);
+			if (zrouter.multipath_num > MULTIPATH_NUM
+			    || zrouter.multipath_num <= 0) {
 				flog_err(
 					EC_ZEBRA_BAD_MULTIPATH_NUM,
 					"Multipath Number specified must be less than %d and greater than 0",

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1339,14 +1339,14 @@ static void zread_interface_delete(ZAPI_HANDLER_ARGS)
 void zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 			    const unsigned int nexthop_num)
 {
-	if (nexthop_num > multipath_num) {
+	if (nexthop_num > zrouter.multipath_num) {
 		char buff[PREFIX2STR_BUFFER];
 
 		prefix2str(p, buff, sizeof(buff));
 		flog_warn(
 			EC_ZEBRA_MORE_NH_THAN_MULTIPATH,
 			"%s: Prefix %s has %d nexthops, but we can only use the first %d",
-			caller, buff, nexthop_num, multipath_num);
+			caller, buff, nexthop_num, zrouter.multipath_num);
 	}
 }
 
@@ -1651,7 +1651,7 @@ static void zsend_capabilities(struct zserv *client, struct zebra_vrf *zvrf)
 	zclient_create_header(s, ZEBRA_CAPABILITIES, zvrf->vrf->vrf_id);
 	stream_putl(s, vrf_get_backend());
 	stream_putc(s, mpls_enabled);
-	stream_putl(s, multipath_num);
+	stream_putl(s, zrouter.multipath_num);
 	stream_putc(s, zebra_mlag_get_role());
 
 	stream_putw_at(s, 0, stream_get_endp(s));

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -32,6 +32,7 @@
 #include "prefix.h"
 
 #include "zebra/zserv.h"
+#include "zebra/zebra_router.h"
 #include "zebra/zebra_dplane.h"
 #include "zebra/zebra_ns.h"
 #include "zebra/zebra_vrf.h"
@@ -251,7 +252,7 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 	ri->metric = &re->metric;
 
 	for (ALL_NEXTHOPS(re->ng, nexthop)) {
-		if (ri->num_nhs >= multipath_num)
+		if (ri->num_nhs >= zrouter.multipath_num)
 			break;
 
 		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -27,6 +27,7 @@
 #include "zebra/zebra_mpls.h"
 #include "zebra/debug.h"
 #include "zebra/zebra_errors.h"
+#include "zebra/zebra_router.h"
 
 #include "privs.h"
 #include "prefix.h"
@@ -262,7 +263,7 @@ static int kernel_lsp_cmd(struct zebra_dplane_ctx *ctx)
 		if (!nexthop)
 			continue;
 
-		if (nexthop_num >= multipath_num)
+		if (nexthop_num >= zrouter.multipath_num)
 			break;
 
 		if (((action == RTM_ADD || action == RTM_CHANGE)

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -961,7 +961,8 @@ static int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 		 * decision point.
 		 */
 		new_active = nexthop_active_check(rn, re, nexthop);
-		if (new_active && re->nexthop_active_num >= multipath_num) {
+		if (new_active
+		    && re->nexthop_active_num >= zrouter.multipath_num) {
 			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 			new_active = 0;
 		}

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -30,7 +30,9 @@
 #include "zebra_vxlan.h"
 #include "zebra_mlag.h"
 
-struct zebra_router zrouter;
+struct zebra_router zrouter = {
+	.multipath_num = MULTIPATH_NUM,
+};
 
 static inline int
 zebra_router_table_entry_compare(const struct zebra_router_table *e1,

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -110,6 +110,8 @@ struct zebra_router {
 	 * The EVPN instance, if any
 	 */
 	struct zebra_vrf *evpn_vrf;
+
+	uint32_t multipath_num;
 };
 
 extern struct zebra_router zrouter;

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -173,8 +173,6 @@ struct zserv {
 DECLARE_HOOK(zserv_client_connect, (struct zserv *client), (client));
 DECLARE_KOOH(zserv_client_close, (struct zserv *client), (client));
 
-extern unsigned int multipath_num;
-
 /*
  * Initialize Zebra API server.
  *


### PR DESCRIPTION
The multipath_num variable is a property of zebra_router,
so move it there.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>