### PR TITLE
zebra: Reorder `struct route_entry` to reduce size

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -99,9 +99,6 @@ struct route_entry {
 	/* Type fo this route. */
 	int type;
 
-	/* Source protocol instance */
-	unsigned short instance;
-
 	/* VRF identifier. */
 	vrf_id_t vrf_id;
 
@@ -114,9 +111,6 @@ struct route_entry {
 	/* MTU */
 	uint32_t mtu;
 	uint32_t nexthop_mtu;
-
-	/* Distance. */
-	uint8_t distance;
 
 	/* Flags of this route.
 	 * This flag's definition is in lib/zebra.h ZEBRA_FLAG_* and is exposed
@@ -146,6 +140,12 @@ struct route_entry {
 
 	/* Sequence value incremented for each dataplane operation */
 	uint32_t dplane_sequence;
+
+	/* Source protocol instance */
+	uint16_t instance;
+
+	/* Distance. */
+	uint8_t distance;
 };
 
 /* meta-queue structure:


### PR DESCRIPTION
Reduce the size of the data structure from 88 bytes to 80 bytes.

By aligning the data here, we save a few bytes.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>