### PR TITLE
lib: Add const to openbsd-tree functions

### DIFF
--- a/lib/openbsd-tree.c
+++ b/lib/openbsd-tree.c
@@ -435,7 +435,8 @@ void *_rb_insert(const struct rb_type *t, struct rbt_tree *rbt, void *elm)
 }
 
 /* Finds the node with the same key as elm */
-void *_rb_find(const struct rb_type *t, struct rbt_tree *rbt, const void *key)
+void *_rb_find(const struct rb_type *t, const struct rbt_tree *rbt,
+	       const void *key)
 {
 	struct rb_entry *tmp = RBH_ROOT(rbt);
 	void *node;
@@ -456,7 +457,8 @@ void *_rb_find(const struct rb_type *t, struct rbt_tree *rbt, const void *key)
 }
 
 /* Finds the first node greater than or equal to the search key */
-void *_rb_nfind(const struct rb_type *t, struct rbt_tree *rbt, const void *key)
+void *_rb_nfind(const struct rb_type *t, const struct rbt_tree *rbt,
+		const void *key)
 {
 	struct rb_entry *tmp = RBH_ROOT(rbt);
 	void *node;
@@ -522,14 +524,14 @@ void *_rb_prev(const struct rb_type *t, void *elm)
 	return (rbe == NULL ? NULL : rb_e2n(t, rbe));
 }
 
-void *_rb_root(const struct rb_type *t, struct rbt_tree *rbt)
+void *_rb_root(const struct rb_type *t, const struct rbt_tree *rbt)
 {
 	struct rb_entry *rbe = RBH_ROOT(rbt);
 
 	return (rbe == NULL ? rbe : rb_e2n(t, rbe));
 }
 
-void *_rb_min(const struct rb_type *t, struct rbt_tree *rbt)
+void *_rb_min(const struct rb_type *t, const struct rbt_tree *rbt)
 {
 	struct rb_entry *rbe = RBH_ROOT(rbt);
 	struct rb_entry *parent = NULL;
@@ -542,7 +544,7 @@ void *_rb_min(const struct rb_type *t, struct rbt_tree *rbt)
 	return (parent == NULL ? NULL : rb_e2n(t, parent));
 }
 
-void *_rb_max(const struct rb_type *t, struct rbt_tree *rbt)
+void *_rb_max(const struct rb_type *t, const struct rbt_tree *rbt)
 {
 	struct rb_entry *rbe = RBH_ROOT(rbt);
 	struct rb_entry *parent = NULL;

--- a/lib/openbsd-tree.h
+++ b/lib/openbsd-tree.h
@@ -364,18 +364,18 @@ static inline void _rb_init(struct rbt_tree *rbt)
 	rbt->rbt_root = NULL;
 }
 
-static inline int _rb_empty(struct rbt_tree *rbt)
+static inline int _rb_empty(const struct rbt_tree *rbt)
 {
 	return (rbt->rbt_root == NULL);
 }
 
 void *_rb_insert(const struct rb_type *, struct rbt_tree *, void *);
 void *_rb_remove(const struct rb_type *, struct rbt_tree *, void *);
-void *_rb_find(const struct rb_type *, struct rbt_tree *, const void *);
-void *_rb_nfind(const struct rb_type *, struct rbt_tree *, const void *);
-void *_rb_root(const struct rb_type *, struct rbt_tree *);
-void *_rb_min(const struct rb_type *, struct rbt_tree *);
-void *_rb_max(const struct rb_type *, struct rbt_tree *);
+void *_rb_find(const struct rb_type *, const struct rbt_tree *, const void *);
+void *_rb_nfind(const struct rb_type *, const struct rbt_tree *, const void *);
+void *_rb_root(const struct rb_type *, const struct rbt_tree *);
+void *_rb_min(const struct rb_type *, const struct rbt_tree *);
+void *_rb_max(const struct rb_type *, const struct rbt_tree *);
 void *_rb_next(const struct rb_type *, void *);
 void *_rb_prev(const struct rb_type *, void *);
 void *_rb_left(const struct rb_type *, void *);
@@ -401,56 +401,58 @@ int _rb_check(const struct rb_type *, void *, unsigned long);
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_INSERT(struct _name *head, struct _type *elm)      \
 	{                                                                      \
-		return (struct _type *)_rb_insert(                             \
-			_name##_RB_TYPE, &head->rbh_root, elm);                \
+		return (struct _type *)_rb_insert(_name##_RB_TYPE,             \
+						  &head->rbh_root, elm);       \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
 		*_name##_RB_REMOVE(struct _name *head, struct _type *elm)      \
 	{                                                                      \
-		return (struct _type *)_rb_remove(                             \
-			_name##_RB_TYPE, &head->rbh_root, elm);                \
+		return (struct _type *)_rb_remove(_name##_RB_TYPE,             \
+						  &head->rbh_root, elm);       \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
-		*_name##_RB_FIND(struct _name *head, const struct _type *key)  \
+		*_name##_RB_FIND(const struct _name *head,                     \
+				 const struct _type *key)                      \
 	{                                                                      \
-		return (struct _type *)_rb_find(                               \
-			_name##_RB_TYPE, &head->rbh_root, key);                \
+		return (struct _type *)_rb_find(_name##_RB_TYPE,               \
+						&head->rbh_root, key);         \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
-		*_name##_RB_NFIND(struct _name *head, const struct _type *key) \
+		*_name##_RB_NFIND(const struct _name *head,                    \
+				  const struct _type *key)                     \
 	{                                                                      \
-		return (struct _type *)_rb_nfind(                              \
-			_name##_RB_TYPE, &head->rbh_root, key);                \
+		return (struct _type *)_rb_nfind(_name##_RB_TYPE,              \
+						 &head->rbh_root, key);        \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
-		*_name##_RB_ROOT(struct _name *head)                           \
+		*_name##_RB_ROOT(const struct _name *head)                     \
 	{                                                                      \
-		return (struct _type *)_rb_root(                               \
-			_name##_RB_TYPE, &head->rbh_root);                     \
+		return (struct _type *)_rb_root(_name##_RB_TYPE,               \
+						&head->rbh_root);              \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline int _name##_RB_EMPTY(        \
-		struct _name *head)                                            \
+		const struct _name *head)                                      \
 	{                                                                      \
 		return _rb_empty(&head->rbh_root);                             \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
-		*_name##_RB_MIN(struct _name *head)                            \
+		*_name##_RB_MIN(const struct _name *head)                      \
 	{                                                                      \
-		return (struct _type *)_rb_min(                                \
-			_name##_RB_TYPE, &head->rbh_root);                     \
+		return (struct _type *)_rb_min(_name##_RB_TYPE,                \
+					       &head->rbh_root);               \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \
-		*_name##_RB_MAX(struct _name *head)                            \
+		*_name##_RB_MAX(const struct _name *head)                      \
 	{                                                                      \
-		return (struct _type *)_rb_max(                                \
-			_name##_RB_TYPE, &head->rbh_root);                     \
+		return (struct _type *)_rb_max(_name##_RB_TYPE,                \
+					       &head->rbh_root);               \
 	}                                                                      \
                                                                                \
 	__attribute__((__unused__)) static inline struct _type                 \


### PR DESCRIPTION
A few of the functions in openbsd's RB tree implementation
needed to have const in their parameters.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>