### PR TITLE
bgpd : add prefix-length in show ip bgp neighbor advertised routes key

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7504,10 +7504,9 @@ void route_vty_out_tmp(struct vty *vty, struct prefix *p, struct attr *attr,
 		json_object_object_add(json_net, "appliedStatusSymbols",
 				       json_status);
 		char buf_cut[BUFSIZ];
-		json_object_object_add(
-			json_ar,
-			inet_ntop(p->family, &p->u.prefix, buf_cut, BUFSIZ),
-			json_net);
+
+		prefix2str(p, buf_cut, PREFIX_STRLEN);
+		json_object_object_add(json_ar, buf_cut, json_net);
 	} else
 		vty_out(vty, "\n");
 }


### PR DESCRIPTION
Issue:
ip route 15.1.1.0/24 10.112.158.15
ip route 15.1.1.0/32 10.112.158.15
Brought up ebgp session between two FRR routers and
redistributed static routes via BGP and verfied the advertising
routes in the peer.

Verify the command "show ip  bgp neighbors <neighbor address>
advertised-routes json". It only shows 15.1.1.0/32 route details.

Root casue:
For both the routes "15.1.1.0/24" and "15.1.1.0/32" the advertised
routes key is the prefix i.e. "15.1.1.0".

Fix:
Modify the key to prefix/prefix-length.

Signed-off-by: Sarita Patra <saritap@vmware.com>