### PR TITLE
zebra: [7.0] remove vrf LSPs when vrf is deleted

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2799,7 +2799,11 @@ void zebra_mpls_print_lsp_table(struct vty *vty, struct zebra_vrf *zvrf,
 					ifp = if_lookup_by_index_per_ns(
 							zns,
 							nexthop->ifindex);
-					vty_out(vty, "%15s", ifp->name);
+					if (ifp)
+						vty_out(vty, "%15s", ifp->name);
+					else
+						vty_out(vty, "%15s", "Null");
+
 					break;
 				}
 				case NEXTHOP_TYPE_IPV4:
@@ -2924,11 +2928,30 @@ int zebra_mpls_write_label_block_config(struct vty *vty, struct zebra_vrf *zvrf)
 /*
  * Called when VRF becomes inactive, cleans up information but keeps
  * the table itself.
- * NOTE: Currently supported only for default VRF.
  */
 void zebra_mpls_cleanup_tables(struct zebra_vrf *zvrf)
 {
-	hash_iterate(zvrf->lsp_table, lsp_uninstall_from_kernel, NULL);
+	struct zebra_vrf *def_zvrf;
+	afi_t afi;
+
+	if (zvrf_id(zvrf) == VRF_DEFAULT)
+		hash_iterate(zvrf->lsp_table, lsp_uninstall_from_kernel, NULL);
+	else {
+		/*
+		 * For other vrfs, we try to remove associated LSPs; we locate
+		 * the LSPs in the default vrf.
+		 */
+		def_zvrf = zebra_vrf_lookup_by_id(VRF_DEFAULT);
+
+		/* At shutdown, the default may be gone already */
+		if (def_zvrf == NULL)
+			return;
+
+		for (afi = AFI_IP; afi < AFI_MAX; afi++) {
+			if (zvrf->label[afi] != MPLS_LABEL_NONE)
+				lsp_uninstall(def_zvrf, zvrf->label[afi]);
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
7.0 version: try to remove any LSPs associated with a vrf when the vrf is deleted. The vrf code was calling a helpful zebra_mpls api, but that api was basically a no-op for vrfs other than the default.