### PR TITLE
zebra: send nexthop blackhole information in FPM

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -270,7 +270,6 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 				ri->rtm_type = RTN_BLACKHOLE;
 				break;
 			}
-			return 1;
 		}
 
 		if ((cmd == RTM_NEWROUTE


### PR DESCRIPTION
## Summary

This PR wants to add more nexthop information to FPM netlink messages:

  * Add blackhole type nexthop peer information to messages;

This commit adds the blackhole information handling which contains (maybe accidental?) code that prevents blackhole nexthop to be informed:
https://github.com/FRRouting/frr/commit/a830942228110cbec0e857d0877d624206627f81#diff-5a8179517459ff1c1eb6a3568aea74e5R272


## Components

`zebra`