### PR TITLE
lib,bgpd,pbrd: Add AFI_UNSPEC to AFI enum

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -119,6 +119,7 @@ static enum node_type bgp_node_type(afi_t afi, safi_t safi)
 	case AFI_L2VPN:
 		return BGP_EVPN_NODE;
 		break;
+	case AFI_UNSPEC:
 	case AFI_MAX:
 		// We should never be here but to clarify the switch statement..
 		return BGP_IPV4_NODE;

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -422,7 +422,13 @@ extern const char *zserv_command_string(unsigned int command);
 #endif
 
 /* Address family numbers from RFC1700. */
-typedef enum { AFI_IP = 1, AFI_IP6 = 2, AFI_L2VPN = 3, AFI_MAX = 4 } afi_t;
+typedef enum {
+	AFI_UNSPEC = 0,
+	AFI_IP = 1,
+	AFI_IP6 = 2,
+	AFI_L2VPN = 3,
+	AFI_MAX = 4
+} afi_t;
 
 /* Subsequent Address Family Identifier. */
 typedef enum {

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -349,6 +349,11 @@ void route_add(struct pbr_nexthop_group_cache *pnhgc, struct nexthop_group nhg,
 		       "%s: Asked to install unsupported route type: L2VPN",
 		       __PRETTY_FUNCTION__);
 		break;
+	case AFI_UNSPEC:
+		DEBUGD(&pbr_dbg_zebra,
+		       "%s: Asked to install unspecified route type",
+		       __PRETTY_FUNCTION__);
+		break;
 	}
 }
 
@@ -389,6 +394,11 @@ void route_delete(struct pbr_nexthop_group_cache *pnhgc, afi_t afi)
 	case AFI_L2VPN:
 		DEBUGD(&pbr_dbg_zebra,
 		       "%s: Asked to delete unsupported route type: L2VPN",
+		       __PRETTY_FUNCTION__);
+		break;
+	case AFI_UNSPEC:
+		DEBUGD(&pbr_dbg_zebra,
+		       "%s: Asked to delete unspecified route type",
 		       __PRETTY_FUNCTION__);
 		break;
 	}


### PR DESCRIPTION
Add an upspecified option to the AFI enum and update
switch statements using it in bgpd and pbrd.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>