### PR TITLE
lib: hashing functions should take const arguments

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1271,16 +1271,16 @@ void bs_to_bpc(struct bfd_session *bs, struct bfd_peer_cfg *bpc)
 static struct hash *bfd_id_hash;
 static struct hash *bfd_key_hash;
 
-static unsigned int bfd_id_hash_do(void *p);
-static unsigned int bfd_key_hash_do(void *p);
+static unsigned int bfd_id_hash_do(const void *p);
+static unsigned int bfd_key_hash_do(const void *p);
 
 static void _bfd_free(struct hash_bucket *hb,
 		      void *arg __attribute__((__unused__)));
 
 /* BFD hash for our discriminator. */
-static unsigned int bfd_id_hash_do(void *p)
+static unsigned int bfd_id_hash_do(const void *p)
 {
-	struct bfd_session *bs = p;
+	const struct bfd_session *bs = p;
 
 	return jhash_1word(bs->discrs.my_discr, 0);
 }
@@ -1293,9 +1293,9 @@ static bool bfd_id_hash_cmp(const void *n1, const void *n2)
 }
 
 /* BFD hash for single hop. */
-static unsigned int bfd_key_hash_do(void *p)
+static unsigned int bfd_key_hash_do(const void *p)
 {
-	struct bfd_session *bs = p;
+	const struct bfd_session *bs = p;
 
 	return jhash(&bs->key, sizeof(bs->key), 0);
 }

--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -64,9 +64,9 @@ static void *baa_hash_alloc(void *p)
 	return baa;
 }
 
-unsigned int baa_hash_key(void *p)
+unsigned int baa_hash_key(const void *p)
 {
-	struct bgp_advertise_attr *baa = (struct bgp_advertise_attr *)p;
+	const struct bgp_advertise_attr *baa = p;
 
 	return attrhash_key_make(baa->attr);
 }

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -144,7 +144,7 @@ extern void bgp_adj_in_remove(struct bgp_node *, struct bgp_adj_in *);
 
 extern void bgp_sync_init(struct peer *);
 extern void bgp_sync_delete(struct peer *);
-extern unsigned int baa_hash_key(void *p);
+extern unsigned int baa_hash_key(const void *p);
 extern bool baa_hash_cmp(const void *p1, const void *p2);
 extern void bgp_advertise_add(struct bgp_advertise_attr *baa,
 			      struct bgp_advertise *adv);

--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -2008,13 +2008,13 @@ struct aspath *aspath_str2aspath(const char *str)
 }
 
 /* Make hash value by raw aspath data. */
-unsigned int aspath_key_make(void *p)
+unsigned int aspath_key_make(const void *p)
 {
-	struct aspath *aspath = (struct aspath *)p;
+	const struct aspath *aspath = p;
 	unsigned int key = 0;
 
 	if (!aspath->str)
-		aspath_str_update(aspath, false);
+		aspath_str_update((struct aspath *)aspath, false);
 
 	key = jhash(aspath->str, aspath->str_len, 2334325);
 

--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -102,7 +102,7 @@ extern const char *aspath_print(struct aspath *);
 extern void aspath_print_vty(struct vty *, const char *, struct aspath *,
 			     const char *);
 extern void aspath_print_all_vty(struct vty *);
-extern unsigned int aspath_key_make(void *);
+extern unsigned int aspath_key_make(const void *);
 extern unsigned int aspath_get_first_as(struct aspath *);
 extern unsigned int aspath_get_last_as(struct aspath *);
 extern int aspath_loop_check(struct aspath *, as_t);

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -140,7 +140,7 @@ int cluster_loop_check(struct cluster_list *cluster, struct in_addr originator)
 	return 0;
 }
 
-static unsigned int cluster_hash_key_make(void *p)
+static unsigned int cluster_hash_key_make(const void *p)
 {
 	const struct cluster_list *cluster = p;
 
@@ -348,7 +348,7 @@ static void encap_unintern(struct bgp_attr_encap_subtlv **encapp,
 	}
 }
 
-static unsigned int encap_hash_key_make(void *p)
+static unsigned int encap_hash_key_make(const void *p)
 {
 	const struct bgp_attr_encap_subtlv *encap = p;
 
@@ -433,7 +433,7 @@ void transit_unintern(struct transit *transit)
 	}
 }
 
-static unsigned int transit_hash_key_make(void *p)
+static unsigned int transit_hash_key_make(const void *p)
 {
 	const struct transit *transit = p;
 
@@ -484,7 +484,7 @@ unsigned long int attr_unknown_count(void)
 	return transit_hash->count;
 }
 
-unsigned int attrhash_key_make(void *p)
+unsigned int attrhash_key_make(const void *p)
 {
 	const struct attr *attr = (struct attr *)p;
 	uint32_t key = 0;

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -282,7 +282,7 @@ extern bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *,
 extern void bgp_dump_routes_attr(struct stream *, struct attr *,
 				 struct prefix *);
 extern bool attrhash_cmp(const void *arg1, const void *arg2);
-extern unsigned int attrhash_key_make(void *);
+extern unsigned int attrhash_key_make(const void *);
 extern void attr_show_all(struct vty *);
 extern unsigned long int attr_count(void);
 extern unsigned long int attr_unknown_count(void);

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -36,9 +36,9 @@
 #include "bgpd/bgp_regex.h"
 #include "bgpd/bgp_clist.h"
 
-static uint32_t bgp_clist_hash_key_community_list(void *data)
+static uint32_t bgp_clist_hash_key_community_list(const void *data)
 {
-	struct community_list *cl = data;
+	struct community_list *cl = (struct community_list *) data;
 
 	if (cl->name_hash)
 		return cl->name_hash;

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -574,7 +574,7 @@ char *community_str(struct community *com, bool make_json)
 
 /* Make hash value of community attribute. This function is used by
    hash package.*/
-unsigned int community_hash_make(struct community *com)
+unsigned int community_hash_make(const struct community *com)
 {
 	uint32_t *pnt = (uint32_t *)com->val;
 
@@ -897,7 +897,7 @@ struct hash *community_hash(void)
 void community_init(void)
 {
 	comhash =
-		hash_create((unsigned int (*)(void *))community_hash_make,
+		hash_create((unsigned int (*)(const void *))community_hash_make,
 			    (bool (*)(const void *, const void *))community_cmp,
 			    "BGP Community Hash");
 }
@@ -957,7 +957,7 @@ void bgp_compute_aggregate_community(struct bgp_aggregate *aggregate,
 	 */
 	if (aggregate->community_hash == NULL)
 		aggregate->community_hash = hash_create(
-			(unsigned int (*)(void *))community_hash_make,
+			(unsigned int (*)(const void *))community_hash_make,
 			(bool (*)(const void *, const void *))community_cmp,
 			"BGP Aggregator community hash");
 

--- a/bgpd/bgp_community.h
+++ b/bgpd/bgp_community.h
@@ -75,7 +75,7 @@ extern struct community *community_parse(uint32_t *, unsigned short);
 extern struct community *community_intern(struct community *);
 extern void community_unintern(struct community **);
 extern char *community_str(struct community *, bool make_json);
-extern unsigned int community_hash_make(struct community *);
+extern unsigned int community_hash_make(const struct community *);
 extern struct community *community_str2com(const char *);
 extern int community_match(const struct community *, const struct community *);
 extern bool community_cmp(const struct community *c1,

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -241,7 +241,7 @@ void ecommunity_unintern(struct ecommunity **ecom)
 }
 
 /* Utinity function to make hash key.  */
-unsigned int ecommunity_hash_make(void *arg)
+unsigned int ecommunity_hash_make(const void *arg)
 {
 	const struct ecommunity *ecom = arg;
 	int size = ecom->size * ECOMMUNITY_SIZE;

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -162,7 +162,7 @@ extern struct ecommunity *ecommunity_uniq_sort(struct ecommunity *);
 extern struct ecommunity *ecommunity_intern(struct ecommunity *);
 extern bool ecommunity_cmp(const void *arg1, const void *arg2);
 extern void ecommunity_unintern(struct ecommunity **);
-extern unsigned int ecommunity_hash_make(void *);
+extern unsigned int ecommunity_hash_make(const void *);
 extern struct ecommunity *ecommunity_str2com(const char *, int, int);
 extern char *ecommunity_ecom2str(struct ecommunity *, int, int);
 extern void ecommunity_strfree(char **s);

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -83,9 +83,9 @@ static int evpn_vtep_ip_cmp(void *p1, void *p2)
 /*
  * Make hash key for ESI.
  */
-static unsigned int esi_hash_keymake(void *p)
+static unsigned int esi_hash_keymake(const void *p)
 {
-	struct evpnes *pes = p;
+	const struct evpnes *pes = p;
 	const void *pnt = (void *)pes->esi.val;
 
 	return jhash(pnt, ESI_BYTES, 0xa5a5a55a);
@@ -111,9 +111,9 @@ static bool esi_cmp(const void *p1, const void *p2)
 /*
  * Make vni hash key.
  */
-static unsigned int vni_hash_key_make(void *p)
+static unsigned int vni_hash_key_make(const void *p)
 {
-	struct bgpevpn *vpn = p;
+	const struct bgpevpn *vpn = p;
 	return (jhash_1word(vpn->vni, 0));
 }
 
@@ -143,10 +143,10 @@ static int vni_list_cmp(void *p1, void *p2)
 /*
  * Make vrf import route target hash key.
  */
-static unsigned int vrf_import_rt_hash_key_make(void *p)
+static unsigned int vrf_import_rt_hash_key_make(const void *p)
 {
-	struct vrf_irt_node *irt = p;
-	char *pnt = irt->rt.val;
+	const struct vrf_irt_node *irt = p;
+	const char *pnt = irt->rt.val;
 
 	return jhash(pnt, 8, 0x5abc1234);
 }
@@ -259,10 +259,10 @@ static int is_vrf_present_in_irt_vrfs(struct list *vrfs, struct bgp *bgp_vrf)
 /*
  * Make import route target hash key.
  */
-static unsigned int import_rt_hash_key_make(void *p)
+static unsigned int import_rt_hash_key_make(const void *p)
 {
-	struct irt_node *irt = p;
-	char *pnt = irt->rt.val;
+	const struct irt_node *irt = p;
+	const char *pnt = irt->rt.val;
 
 	return jhash(pnt, 8, 0xdeadbeef);
 }

--- a/bgpd/bgp_keepalives.c
+++ b/bgpd/bgp_keepalives.c
@@ -131,9 +131,9 @@ static bool peer_hash_cmp(const void *f, const void *s)
 	return p1->peer == p2->peer;
 }
 
-static unsigned int peer_hash_key(void *arg)
+static unsigned int peer_hash_key(const void *arg)
 {
-	struct pkat *pkat = arg;
+	const struct pkat *pkat = arg;
 	return (uintptr_t)pkat->peer;
 }
 

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -301,7 +301,7 @@ char *lcommunity_str(struct lcommunity *lcom, bool make_json)
 }
 
 /* Utility function to make hash key.  */
-unsigned int lcommunity_hash_make(void *arg)
+unsigned int lcommunity_hash_make(const void *arg)
 {
 	const struct lcommunity *lcom = arg;
 	int size = lcom_length(lcom);

--- a/bgpd/bgp_lcommunity.h
+++ b/bgpd/bgp_lcommunity.h
@@ -63,7 +63,7 @@ extern struct lcommunity *lcommunity_uniq_sort(struct lcommunity *);
 extern struct lcommunity *lcommunity_intern(struct lcommunity *);
 extern bool lcommunity_cmp(const void *arg1, const void *arg2);
 extern void lcommunity_unintern(struct lcommunity **);
-extern unsigned int lcommunity_hash_make(void *);
+extern unsigned int lcommunity_hash_make(const void *);
 extern struct hash *lcommunity_hash(void);
 extern struct lcommunity *lcommunity_str2com(const char *);
 extern int lcommunity_match(const struct lcommunity *,

--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -40,9 +40,9 @@ struct bgp_self_mac {
 	struct list *ifp_list;
 };
 
-static unsigned int bgp_mac_hash_key_make(void *data)
+static unsigned int bgp_mac_hash_key_make(const void *data)
 {
-	struct bgp_self_mac *bsm = data;
+	const struct bgp_self_mac *bsm = data;
 
 	return jhash(&bsm->macaddr, ETH_ALEN, 0xa5a5dead);
 }

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -114,7 +114,7 @@ static void bgp_tip_hash_free(void *addr)
 	XFREE(MTYPE_TIP_ADDR, addr);
 }
 
-static unsigned int bgp_tip_hash_key_make(void *p)
+static unsigned int bgp_tip_hash_key_make(const void *p)
 {
 	const struct tip_addr *addr = p;
 
@@ -237,7 +237,7 @@ static void bgp_address_hash_free(void *data)
 	XFREE(MTYPE_BGP_ADDR, addr);
 }
 
-static unsigned int bgp_address_hash_key_make(void *p)
+static unsigned int bgp_address_hash_key_make(const void *p)
 {
 	const struct bgp_addr *addr = p;
 

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -964,9 +964,9 @@ static void *bgp_pbr_match_entry_alloc_intern(void *arg)
 	return new;
 }
 
-uint32_t bgp_pbr_match_hash_key(void *arg)
+uint32_t bgp_pbr_match_hash_key(const void *arg)
 {
-	struct bgp_pbr_match *pbm = (struct bgp_pbr_match *)arg;
+	const struct bgp_pbr_match *pbm = arg;
 	uint32_t key;
 
 	key = jhash_1word(pbm->vrf_id, 0x4312abde);
@@ -1019,9 +1019,9 @@ bool bgp_pbr_match_hash_equal(const void *arg1, const void *arg2)
 	return true;
 }
 
-uint32_t bgp_pbr_rule_hash_key(void *arg)
+uint32_t bgp_pbr_rule_hash_key(const void *arg)
 {
-	struct bgp_pbr_rule *pbr = (struct bgp_pbr_rule *)arg;
+	const struct bgp_pbr_rule *pbr = arg;
 	uint32_t key;
 
 	key = prefix_hash_key(&pbr->src);
@@ -1057,12 +1057,12 @@ bool bgp_pbr_rule_hash_equal(const void *arg1, const void *arg2)
 	return true;
 }
 
-uint32_t bgp_pbr_match_entry_hash_key(void *arg)
+uint32_t bgp_pbr_match_entry_hash_key(const void *arg)
 {
-	struct bgp_pbr_match_entry *pbme;
+	const struct bgp_pbr_match_entry *pbme;
 	uint32_t key;
 
-	pbme = (struct bgp_pbr_match_entry *)arg;
+	pbme = arg;
 	key = prefix_hash_key(&pbme->src);
 	key = jhash_1word(prefix_hash_key(&pbme->dst), key);
 	key = jhash(&pbme->dst_port_min, 2, key);
@@ -1111,12 +1111,12 @@ bool bgp_pbr_match_entry_hash_equal(const void *arg1, const void *arg2)
 	return true;
 }
 
-uint32_t bgp_pbr_action_hash_key(void *arg)
+uint32_t bgp_pbr_action_hash_key(const void *arg)
 {
-	struct bgp_pbr_action *pbra;
+	const struct bgp_pbr_action *pbra;
 	uint32_t key;
 
-	pbra = (struct bgp_pbr_action *)arg;
+	pbra = arg;
 	key = jhash_1word(pbra->table_id, 0x4312abde);
 	key = jhash_1word(pbra->fwmark, key);
 	return key;

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -273,16 +273,16 @@ extern struct bgp_pbr_match *bgp_pbr_match_iptable_lookup(vrf_id_t vrf_id,
 extern void bgp_pbr_cleanup(struct bgp *bgp);
 extern void bgp_pbr_init(struct bgp *bgp);
 
-extern uint32_t bgp_pbr_rule_hash_key(void *arg);
+extern uint32_t bgp_pbr_rule_hash_key(const void *arg);
 extern bool bgp_pbr_rule_hash_equal(const void *arg1,
 				   const void *arg2);
-extern uint32_t bgp_pbr_action_hash_key(void *arg);
+extern uint32_t bgp_pbr_action_hash_key(const void *arg);
 extern bool bgp_pbr_action_hash_equal(const void *arg1,
 				     const void *arg2);
-extern uint32_t bgp_pbr_match_entry_hash_key(void *arg);
+extern uint32_t bgp_pbr_match_entry_hash_key(const void *arg);
 extern bool bgp_pbr_match_entry_hash_equal(const void *arg1,
 					  const void *arg2);
-extern uint32_t bgp_pbr_match_hash_key(void *arg);
+extern uint32_t bgp_pbr_match_hash_key(const void *arg);
 extern bool bgp_pbr_match_hash_equal(const void *arg1,
 				    const void *arg2);
 

--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -288,7 +288,7 @@ static void *updgrp_hash_alloc(void *p)
  *       16. Local-as should match, if configured.
  *      )
  */
-static unsigned int updgrp_hash_key_make(void *p)
+static unsigned int updgrp_hash_key_make(const void *p)
 {
 	const struct update_group *updgrp;
 	const struct peer *peer;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -812,9 +812,9 @@ int peer_cmp(struct peer *p1, struct peer *p2)
 	return sockunion_cmp(&p1->su, &p2->su);
 }
 
-static unsigned int peer_hash_key_make(void *p)
+static unsigned int peer_hash_key_make(const void *p)
 {
-	struct peer *peer = p;
+	const struct peer *peer = p;
 	return sockunion_hash(&peer->su);
 }
 

--- a/isisd/fabricd.c
+++ b/isisd/fabricd.c
@@ -108,9 +108,9 @@ static void neighbor_lists_clear(struct fabricd *f)
 	hash_clean(f->neighbors_neighbors, neighbor_entry_del_void);
 }
 
-static unsigned neighbor_entry_hash_key(void *np)
+static unsigned neighbor_entry_hash_key(const void *np)
 {
-	struct neighbor_entry *n = np;
+	const struct neighbor_entry *n = np;
 
 	return jhash(n->id, sizeof(n->id), 0x55aa5a5a);
 }

--- a/isisd/isis_spf_private.h
+++ b/isisd/isis_spf_private.h
@@ -79,9 +79,9 @@ struct isis_vertex_queue {
 };
 
 __attribute__((__unused__))
-static unsigned isis_vertex_queue_hash_key(void *vp)
+static unsigned isis_vertex_queue_hash_key(const void *vp)
 {
-	struct isis_vertex *vertex = vp;
+	const struct isis_vertex *vertex = vp;
 
 	if (VTYPE_IP(vertex->type)) {
 		uint32_t key;

--- a/isisd/isis_tx_queue.c
+++ b/isisd/isis_tx_queue.c
@@ -50,9 +50,9 @@ struct isis_tx_queue_entry {
 	struct isis_tx_queue *queue;
 };
 
-static unsigned tx_queue_hash_key(void *p)
+static unsigned tx_queue_hash_key(const void *p)
 {
-	struct isis_tx_queue_entry *e = p;
+	const struct isis_tx_queue_entry *e = p;
 
 	uint32_t id_key = jhash(e->lsp->hdr.lsp_id,
 				ISIS_SYS_ID_LEN + 2, 0x55aa5a5a);

--- a/lib/command.c
+++ b/lib/command.c
@@ -332,7 +332,7 @@ int argv_find(struct cmd_token **argv, int argc, const char *text, int *index)
 	return found;
 }
 
-static unsigned int cmd_hash_key(void *p)
+static unsigned int cmd_hash_key(const void *p)
 {
 	int size = sizeof(p);
 

--- a/lib/distribute.c
+++ b/lib/distribute.c
@@ -131,7 +131,7 @@ static struct distribute *distribute_get(struct distribute_ctx *ctx,
 	return ret;
 }
 
-static unsigned int distribute_hash_make(void *arg)
+static unsigned int distribute_hash_make(const void *arg)
 {
 	const struct distribute *dist = arg;
 

--- a/lib/ferr.c
+++ b/lib/ferr.c
@@ -72,9 +72,9 @@ static bool ferr_hash_cmp(const void *a, const void *b)
 	return f_a->code == f_b->code;
 }
 
-static inline unsigned int ferr_hash_key(void *a)
+static inline unsigned int ferr_hash_key(const void *a)
 {
-	struct log_ref *f = a;
+	const struct log_ref *f = a;
 
 	return f->code;
 }

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -37,7 +37,7 @@ static pthread_mutex_t _hashes_mtx = PTHREAD_MUTEX_INITIALIZER;
 static struct list *_hashes;
 
 struct hash *hash_create_size(unsigned int size,
-			      unsigned int (*hash_key)(void *),
+			      unsigned int (*hash_key)(const void *),
 			      bool (*hash_cmp)(const void *, const void *),
 			      const char *name)
 {
@@ -66,7 +66,7 @@ struct hash *hash_create_size(unsigned int size,
 	return hash;
 }
 
-struct hash *hash_create(unsigned int (*hash_key)(void *),
+struct hash *hash_create(unsigned int (*hash_key)(const void *),
 			 bool (*hash_cmp)(const void *, const void *),
 			 const char *name)
 {

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -79,7 +79,7 @@ struct hash {
 	unsigned int max_size;
 
 	/* Key make function. */
-	unsigned int (*hash_key)(void *);
+	unsigned int (*hash_key)(const void *);
 
 	/* Data compare function. */
 	bool (*hash_cmp)(const void *, const void *);
@@ -123,7 +123,7 @@ struct hash {
  * Returns:
  *    a new hash table
  */
-extern struct hash *hash_create(unsigned int (*hash_key)(void *),
+extern struct hash *hash_create(unsigned int (*hash_key)(const void *),
 				bool (*hash_cmp)(const void *, const void *),
 				const char *name);
 
@@ -158,7 +158,7 @@ extern struct hash *hash_create(unsigned int (*hash_key)(void *),
  *    a new hash table
  */
 extern struct hash *
-hash_create_size(unsigned int size, unsigned int (*hash_key)(void *),
+hash_create_size(unsigned int size, unsigned int (*hash_key)(const void *),
 		 bool (*hash_cmp)(const void *, const void *),
 		 const char *name);
 

--- a/lib/if_rmap.c
+++ b/lib/if_rmap.c
@@ -107,7 +107,7 @@ static struct if_rmap *if_rmap_get(struct if_rmap_ctx *ctx, const char *ifname)
 	return ret;
 }
 
-static unsigned int if_rmap_hash_make(void *data)
+static unsigned int if_rmap_hash_make(const void *data)
 {
 	const struct if_rmap *if_rmap = data;
 

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -1654,7 +1654,7 @@ static bool running_config_entry_cmp(const void *value1, const void *value2)
 	return strmatch(c1->xpath, c2->xpath);
 }
 
-static unsigned int running_config_entry_key_make(void *value)
+static unsigned int running_config_entry_key_make(const void *value)
 {
 	return string_hash_make(value);
 }

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -623,7 +623,7 @@ struct route_map_list {
 static struct route_map_list route_map_master = {NULL, NULL, NULL, NULL, NULL};
 struct hash *route_map_master_hash = NULL;
 
-static unsigned int route_map_hash_key_make(void *p)
+static unsigned int route_map_hash_key_make(const void *p)
 {
 	const struct route_map *map = p;
 	return string_hash_make(map->name);
@@ -673,7 +673,7 @@ struct route_map_dep {
 /* Hashes maintaining dependency between various sublists used by route maps */
 struct hash *route_map_dep_hash[ROUTE_MAP_DEP_MAX];
 
-static unsigned int route_map_dep_hash_make_key(void *p);
+static unsigned int route_map_dep_hash_make_key(const void *p);
 static void route_map_clear_all_references(char *rmap_name);
 static void route_map_rule_delete(struct route_map_rule_list *,
 				  struct route_map_rule *);
@@ -1709,7 +1709,7 @@ static void *route_map_name_hash_alloc(void *p)
 	return ((void *)XSTRDUP(MTYPE_ROUTE_MAP_NAME, (const char *)p));
 }
 
-static unsigned int route_map_dep_hash_make_key(void *p)
+static unsigned int route_map_dep_hash_make_key(const void *p)
 {
 	return (string_hash_make((char *)p));
 }

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -63,7 +63,7 @@ static struct list *masters;
 static void thread_free(struct thread_master *master, struct thread *thread);
 
 /* CLI start ---------------------------------------------------------------- */
-static unsigned int cpu_record_hash_key(struct cpu_thread_history *a)
+static unsigned int cpu_record_hash_key(const struct cpu_thread_history *a)
 {
 	int size = sizeof(a->func);
 
@@ -433,7 +433,7 @@ struct thread_master *thread_master_create(const char *name)
 			    sizeof(struct thread *) * rv->fd_limit);
 
 	rv->cpu_record = hash_create_size(
-		8, (unsigned int (*)(void *))cpu_record_hash_key,
+		8, (unsigned int (*)(const void *))cpu_record_hash_key,
 		(bool (*)(const void *, const void *))cpu_record_hash_cmp,
 		"Thread Hash");
 

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -362,9 +362,9 @@ struct vrf_bit_set {
 	bool set;
 };
 
-static unsigned int vrf_hash_bitmap_key(void *data)
+static unsigned int vrf_hash_bitmap_key(const void *data)
 {
-	struct vrf_bit_set *bit = data;
+	const struct vrf_bit_set *bit = data;
 
 	return bit->vrf_id;
 }

--- a/lib/wheel.c
+++ b/lib/wheel.c
@@ -80,7 +80,7 @@ static int wheel_timer_thread(struct thread *t)
 }
 
 struct timer_wheel *wheel_init(struct thread_master *master, int period,
-			       size_t slots, unsigned int (*slot_key)(void *),
+			       size_t slots, unsigned int (*slot_key)(const void *),
 			       void (*slot_run)(void *),
 			       const char *run_name)
 {

--- a/lib/wheel.h
+++ b/lib/wheel.h
@@ -38,7 +38,7 @@ struct timer_wheel {
 	/*
 	 * Key to determine what slot the item belongs in
 	 */
-	unsigned int (*slot_key)(void *);
+	unsigned int (*slot_key)(const void *);
 
 	void (*slot_run)(void *);
 };
@@ -80,9 +80,9 @@ struct timer_wheel {
  * of running your code.
  */
 struct timer_wheel *wheel_init(struct thread_master *master, int period,
-			       size_t slots, unsigned int (*slot_key)(void *),
-			       void (*slot_run)(void *),
-			       const char *run_name);
+			       size_t slots,
+			       unsigned int (*slot_key)(const void *),
+			       void (*slot_run)(void *), const char *run_name);
 
 /*
  * Delete the specified timer wheel created

--- a/lib/yang_translator.c
+++ b/lib/yang_translator.c
@@ -61,7 +61,7 @@ static bool yang_mapping_hash_cmp(const void *value1, const void *value2)
 	return strmatch(c1->xpath_from_canonical, c2->xpath_from_canonical);
 }
 
-static unsigned int yang_mapping_hash_key(void *value)
+static unsigned int yang_mapping_hash_key(const void *value)
 {
 	return string_hash_make(value);
 }

--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -30,9 +30,9 @@ const char *const nhrp_cache_type_str[] = {
 		[NHRP_CACHE_LOCAL] = "local",
 };
 
-static unsigned int nhrp_cache_protocol_key(void *peer_data)
+static unsigned int nhrp_cache_protocol_key(const void *peer_data)
 {
-	struct nhrp_cache *p = peer_data;
+	const struct nhrp_cache *p = peer_data;
 	return sockunion_hash(&p->remote_addr);
 }
 

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -151,9 +151,9 @@ static void nhrp_peer_ifp_notify(struct notifier_block *n, unsigned long cmd)
 	nhrp_peer_unref(p);
 }
 
-static unsigned int nhrp_peer_key(void *peer_data)
+static unsigned int nhrp_peer_key(const void *peer_data)
 {
-	struct nhrp_peer *p = peer_data;
+	const struct nhrp_peer *p = peer_data;
 	return sockunion_hash(&p->vc->remote.nbma);
 }
 

--- a/nhrpd/nhrp_vc.c
+++ b/nhrpd/nhrp_vc.c
@@ -28,9 +28,9 @@ struct child_sa {
 static struct hash *nhrp_vc_hash;
 static struct list_head childlist_head[512];
 
-static unsigned int nhrp_vc_key(void *peer_data)
+static unsigned int nhrp_vc_key(const void *peer_data)
 {
-	struct nhrp_vc *vc = peer_data;
+	const struct nhrp_vc *vc = peer_data;
 	return jhash_2words(sockunion_hash(&vc->local.nbma),
 			    sockunion_hash(&vc->remote.nbma), 0);
 }

--- a/nhrpd/reqid.c
+++ b/nhrpd/reqid.c
@@ -2,9 +2,9 @@
 #include "hash.h"
 #include "nhrpd.h"
 
-static unsigned int nhrp_reqid_key(void *data)
+static unsigned int nhrp_reqid_key(const void *data)
 {
-	struct nhrp_reqid *r = data;
+	const struct nhrp_reqid *r = data;
 	return r->request_id;
 }
 

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -86,7 +86,7 @@ static inline void del_sid_nhlfe(struct sr_nhlfe nhlfe);
  */
 
 /* Hash function for Segment Routing entry */
-static unsigned int sr_hash(void *p)
+static unsigned int sr_hash(const void *p)
 {
 	const struct in_addr *rid = p;
 

--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -129,10 +129,10 @@ static void pbr_nh_delete_iterate(struct hash_bucket *b, void *p)
 	pbr_nh_delete((struct pbr_nexthop_cache **)&b->data);
 }
 
-static uint32_t pbr_nh_hash_key(void *arg)
+static uint32_t pbr_nh_hash_key(const void *arg)
 {
 	uint32_t key;
-	struct pbr_nexthop_cache *pbrnc = (struct pbr_nexthop_cache *)arg;
+	const struct pbr_nexthop_cache *pbrnc = arg;
 
 	key = nexthop_hash(pbrnc->nexthop);
 
@@ -789,10 +789,9 @@ void pbr_nht_nexthop_interface_update(struct interface *ifp)
 		     ifp);
 }
 
-static uint32_t pbr_nhg_hash_key(void *arg)
+static uint32_t pbr_nhg_hash_key(const void *arg)
 {
-	struct pbr_nexthop_group_cache *nhgc =
-		(struct pbr_nexthop_group_cache *)arg;
+	const struct pbr_nexthop_group_cache *nhgc = arg;
 
 	return jhash(&nhgc->name, strlen(nhgc->name), 0x52c34a96);
 }
@@ -940,7 +939,7 @@ void pbr_nht_init(void)
 	pbr_nhg_hash = hash_create_size(
 		16, pbr_nhg_hash_key, pbr_nhg_hash_equal, "PBR NHG Cache Hash");
 	pbr_nhrc_hash =
-		hash_create_size(16, (unsigned int (*)(void *))nexthop_hash,
+		hash_create_size(16, (unsigned int (*)(const void *))nexthop_hash,
 				 pbr_nhrc_hash_equal, "PBR NH Hash");
 
 	pbr_nhg_low_table = PBR_NHT_DEFAULT_LOW_TABLEID;

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1425,9 +1425,9 @@ void pim_ifchannel_set_star_g_join_state(struct pim_ifchannel *ch, int eom,
 		pim_jp_agg_single_upstream_send(&starup->rpf, starup, true);
 }
 
-unsigned int pim_ifchannel_hash_key(void *arg)
+unsigned int pim_ifchannel_hash_key(const void *arg)
 {
-	struct pim_ifchannel *ch = (struct pim_ifchannel *)arg;
+	const struct pim_ifchannel *ch = arg;
 
 	return jhash_2words(ch->sg.src.s_addr, ch->sg.grp.s_addr, 0);
 }

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -155,5 +155,5 @@ void pim_ifchannel_set_star_g_join_state(struct pim_ifchannel *ch, int eom,
 int pim_ifchannel_compare(const struct pim_ifchannel *ch1,
 			  const struct pim_ifchannel *ch2);
 
-unsigned int pim_ifchannel_hash_key(void *arg);
+unsigned int pim_ifchannel_hash_key(const void *arg);
 #endif /* PIM_IFCHANNEL_H */

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -829,9 +829,9 @@ void igmp_sock_delete_all(struct interface *ifp)
 	}
 }
 
-static unsigned int igmp_group_hash_key(void *arg)
+static unsigned int igmp_group_hash_key(const void *arg)
 {
-	struct igmp_group *group = (struct igmp_group *)arg;
+	const struct igmp_group *group = arg;
 
 	return jhash_1word(group->group_addr.s_addr, 0);
 }

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -680,9 +680,9 @@ void pim_msdp_up_del(struct pim_instance *pim, struct prefix_sg *sg)
 }
 
 /* sa hash and peer list helpers */
-static unsigned int pim_msdp_sa_hash_key_make(void *p)
+static unsigned int pim_msdp_sa_hash_key_make(const void *p)
 {
-	struct pim_msdp_sa *sa = p;
+	const struct pim_msdp_sa *sa = p;
 
 	return (jhash_2words(sa->sg.src.s_addr, sa->sg.grp.s_addr, 0));
 }
@@ -1215,9 +1215,9 @@ enum pim_msdp_err pim_msdp_peer_del(struct pim_instance *pim,
 }
 
 /* peer hash and peer list helpers */
-static unsigned int pim_msdp_peer_hash_key_make(void *p)
+static unsigned int pim_msdp_peer_hash_key_make(const void *p)
 {
-	struct pim_msdp_peer *mp = p;
+	const struct pim_msdp_peer *mp = p;
 	return (jhash_1word(mp->peer.s_addr, 0));
 }
 

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -91,9 +91,9 @@ static bool pim_oil_equal(const void *arg1, const void *arg2)
 	return false;
 }
 
-static unsigned int pim_oil_hash_key(void *arg)
+static unsigned int pim_oil_hash_key(const void *arg)
 {
-	struct channel_oil *oil = (struct channel_oil *)arg;
+	const struct channel_oil *oil = arg;
 
 	return jhash_2words(oil->oil.mfcc_mcastgrp.s_addr,
 			    oil->oil.mfcc_origin.s_addr, 0);

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -426,9 +426,9 @@ int pim_rpf_is_same(struct pim_rpf *rpf1, struct pim_rpf *rpf2)
 	return 0;
 }
 
-unsigned int pim_rpf_hash_key(void *arg)
+unsigned int pim_rpf_hash_key(const void *arg)
 {
-	struct pim_nexthop_cache *r = (struct pim_nexthop_cache *)arg;
+	const struct pim_nexthop_cache *r = arg;
 
 	return jhash_1word(r->rpf.rpf_addr.u.prefix4.s_addr, 0);
 }

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -56,7 +56,7 @@ enum pim_rpf_result { PIM_RPF_OK = 0, PIM_RPF_CHANGED, PIM_RPF_FAILURE };
 
 struct pim_upstream;
 
-unsigned int pim_rpf_hash_key(void *arg);
+unsigned int pim_rpf_hash_key(const void *arg);
 bool pim_rpf_equal(const void *arg1, const void *arg2);
 
 bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1629,9 +1629,9 @@ void pim_upstream_find_new_rpf(struct pim_instance *pim)
 	}
 }
 
-unsigned int pim_upstream_hash_key(void *arg)
+unsigned int pim_upstream_hash_key(const void *arg)
 {
-	struct pim_upstream *up = (struct pim_upstream *)arg;
+	const struct pim_upstream *up = arg;
 
 	return jhash_2words(up->sg.src.s_addr, up->sg.grp.s_addr, 0);
 }

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -308,7 +308,7 @@ void pim_upstream_remove_lhr_star_pimreg(struct pim_instance *pim,
 void pim_upstream_spt_prefix_list_update(struct pim_instance *pim,
 					 struct prefix_list *pl);
 
-unsigned int pim_upstream_hash_key(void *arg);
+unsigned int pim_upstream_hash_key(const void *arg);
 bool pim_upstream_equal(const void *arg1, const void *arg2);
 struct pim_upstream *pim_upstream_keep_alive_timer_proc(
 		struct pim_upstream *up);

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -623,9 +623,9 @@ static void pim_vxlan_term_mr_del(struct pim_vxlan_sg *vxlan_sg)
 }
 
 /************************** vxlan SG cache management ************************/
-static unsigned int pim_vxlan_sg_hash_key_make(void *p)
+static unsigned int pim_vxlan_sg_hash_key_make(const void *p)
 {
-	struct pim_vxlan_sg *vxlan_sg = p;
+	const struct pim_vxlan_sg *vxlan_sg = p;
 
 	return (jhash_2words(vxlan_sg->sg.src.s_addr,
 				vxlan_sg->sg.grp.s_addr, 0));

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -223,9 +223,9 @@ static void static_zebra_capabilities(struct zclient_capabilities *cap)
 	mpls_enabled = cap->mpls_enabled;
 }
 
-static unsigned int static_nht_hash_key(void *data)
+static unsigned int static_nht_hash_key(const void *data)
 {
-	struct static_nht_data *nhtd = data;
+	const struct static_nht_data *nhtd = data;
 	unsigned int key = 0;
 
 	key = prefix_hash_key(nhtd->nh);

--- a/tests/lib/test_srcdest_table.c
+++ b/tests/lib/test_srcdest_table.c
@@ -81,9 +81,9 @@ static char *format_srcdest(const struct prefix_ipv6 *dst_p,
 	return rv;
 }
 
-static unsigned int log_key(void *data)
+static unsigned int log_key(const void *data)
 {
-	struct prefix *hash_entry = data;
+	const struct prefix *hash_entry = data;
 	struct prefix_ipv6 *dst_p = (struct prefix_ipv6 *)&hash_entry[0];
 	struct prefix_ipv6 *src_p = (struct prefix_ipv6 *)&hash_entry[1];
 	unsigned int hash = 0;

--- a/tools/coccinelle/hash_const.cocci
+++ b/tools/coccinelle/hash_const.cocci
@@ -1,0 +1,76 @@
+//
+// Transition hash key signatures to take their argument as const.
+// Does not handle headers or weirdly named hash functions.
+//
+@noconst disable optional_qualifier@
+identifier A;
+identifier func =~ ".*key$|.*key_make$|.*hash_make$|.*hash_keymake$|.*hash_key$|.*hash_key.*";
+@@
+
+- func (void *A)
++ func (const void *A)
+  { ... }
+
+@ depends on noconst disable optional_qualifier @
+identifier noconst.A;
+identifier noconst.func;
+identifier b;
+type T;
+@@
+
+func( ... ) {
+<...
+-  T b = A;
++  const T b = A;
+...>
+  }
+
+@ depends on noconst disable optional_qualifier @
+identifier noconst.A;
+identifier noconst.func;
+identifier b;
+type T;
+@@
+
+func(...)
+  {
+<...
+-  T b = (T) A;
++  const T b = A;
+...>
+  }
+
+@ depends on noconst disable optional_qualifier @
+identifier noconst.A;
+identifier noconst.func;
+identifier b;
+type T;
+@@
+
+func(...)
+  {
+<...
+-  T b;
++  const T b;
+...
+   b = A;
+...>
+  }
+
+@ depends on noconst disable optional_qualifier @
+identifier noconst.A;
+identifier noconst.func;
+identifier b;
+type T;
+@@
+
+func(...)
+  {
+<...
+-  T b;
++  const T b;
+...
+-  b = (T) A;
++  b = A;
+...>
+  }

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -76,7 +76,7 @@ static zebra_fec_t *fec_add(struct route_table *table, struct prefix *p,
 			    uint32_t label_index);
 static int fec_del(zebra_fec_t *fec);
 
-static unsigned int label_hash(void *p);
+static unsigned int label_hash(const void *p);
 static bool label_cmp(const void *p1, const void *p2);
 static int nhlfe_nexthop_active_ipv4(zebra_nhlfe_t *nhlfe,
 				     struct nexthop *nexthop);
@@ -577,7 +577,7 @@ static int fec_del(zebra_fec_t *fec)
 /*
  * Hash function for label.
  */
-static unsigned int label_hash(void *p)
+static unsigned int label_hash(const void *p)
 {
 	const zebra_ile_t *ile = p;
 

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -135,12 +135,12 @@ void zebra_pbr_rules_free(void *arg)
 	XFREE(MTYPE_TMP, rule);
 }
 
-uint32_t zebra_pbr_rules_hash_key(void *arg)
+uint32_t zebra_pbr_rules_hash_key(const void *arg)
 {
-	struct zebra_pbr_rule *rule;
+	const struct zebra_pbr_rule *rule;
 	uint32_t key;
 
-	rule = (struct zebra_pbr_rule *)arg;
+	rule = arg;
 	key = jhash_3words(rule->rule.seq, rule->rule.priority,
 			   rule->rule.action.table,
 			   prefix_hash_key(&rule->rule.filter.src_ip));
@@ -250,9 +250,9 @@ void zebra_pbr_ipset_free(void *arg)
 	XFREE(MTYPE_TMP, ipset);
 }
 
-uint32_t zebra_pbr_ipset_hash_key(void *arg)
+uint32_t zebra_pbr_ipset_hash_key(const void *arg)
 {
-	struct zebra_pbr_ipset *ipset = (struct zebra_pbr_ipset *)arg;
+	const struct zebra_pbr_ipset *ipset = arg;
 	uint32_t *pnt = (uint32_t *)&ipset->ipset_name;
 	uint32_t key = jhash_1word(ipset->vrf_id, 0x63ab42de);
 
@@ -290,12 +290,12 @@ void zebra_pbr_ipset_entry_free(void *arg)
 	XFREE(MTYPE_TMP, ipset);
 }
 
-uint32_t zebra_pbr_ipset_entry_hash_key(void *arg)
+uint32_t zebra_pbr_ipset_entry_hash_key(const void *arg)
 {
-	struct zebra_pbr_ipset_entry *ipset;
+	const struct zebra_pbr_ipset_entry *ipset;
 	uint32_t key;
 
-	ipset = (struct zebra_pbr_ipset_entry *)arg;
+	ipset = arg;
 	key = prefix_hash_key(&ipset->src);
 	key = jhash_1word(ipset->unique, key);
 	key = jhash_1word(prefix_hash_key(&ipset->dst), key);
@@ -359,9 +359,9 @@ void zebra_pbr_iptable_free(void *arg)
 	XFREE(MTYPE_TMP, iptable);
 }
 
-uint32_t zebra_pbr_iptable_hash_key(void *arg)
+uint32_t zebra_pbr_iptable_hash_key(const void *arg)
 {
-	struct zebra_pbr_iptable *iptable = (struct zebra_pbr_iptable *)arg;
+	const struct zebra_pbr_iptable *iptable = arg;
 	uint32_t *pnt = (uint32_t *)&(iptable->ipset_name);
 	uint32_t key;
 

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -211,7 +211,7 @@ extern void kernel_pbr_iptable_add_del_status(struct zebra_pbr_iptable *iptable,
 extern int kernel_pbr_rule_del(struct zebra_pbr_rule *rule);
 
 extern void zebra_pbr_rules_free(void *arg);
-extern uint32_t zebra_pbr_rules_hash_key(void *arg);
+extern uint32_t zebra_pbr_rules_hash_key(const void *arg);
 extern bool zebra_pbr_rules_hash_equal(const void *arg1, const void *arg2);
 
 /* has operates on 32bit pointer
@@ -220,16 +220,16 @@ extern bool zebra_pbr_rules_hash_equal(const void *arg1, const void *arg2);
 #define ZEBRA_IPSET_NAME_HASH_SIZE (ZEBRA_IPSET_NAME_SIZE / 4)
 
 extern void zebra_pbr_ipset_free(void *arg);
-extern uint32_t zebra_pbr_ipset_hash_key(void *arg);
+extern uint32_t zebra_pbr_ipset_hash_key(const void *arg);
 extern bool zebra_pbr_ipset_hash_equal(const void *arg1, const void *arg2);
 
 extern void zebra_pbr_ipset_entry_free(void *arg);
-extern uint32_t zebra_pbr_ipset_entry_hash_key(void *arg);
+extern uint32_t zebra_pbr_ipset_entry_hash_key(const void *arg);
 extern bool zebra_pbr_ipset_entry_hash_equal(const void *arg1,
 					     const void *arg2);
 
 extern void zebra_pbr_iptable_free(void *arg);
-extern uint32_t zebra_pbr_iptable_hash_key(void *arg);
+extern uint32_t zebra_pbr_iptable_hash_key(const void *arg);
 extern bool zebra_pbr_iptable_hash_equal(const void *arg1, const void *arg2);
 
 extern void zebra_pbr_init(void);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -93,7 +93,7 @@ static void zvni_print_hash(struct hash_bucket *bucket, void *ctxt[]);
 static int zvni_macip_send_msg_to_client(vni_t vni, struct ethaddr *macaddr,
 					 struct ipaddr *ip, uint8_t flags,
 					 uint32_t seq, int state, uint16_t cmd);
-static unsigned int neigh_hash_keymake(void *p);
+static unsigned int neigh_hash_keymake(const void *p);
 static void *zvni_neigh_alloc(void *p);
 static zebra_neigh_t *zvni_neigh_add(zebra_vni_t *zvni, struct ipaddr *ip,
 				     struct ethaddr *mac);
@@ -149,7 +149,7 @@ static struct interface *zl3vni_map_to_vxlan_if(zebra_l3vni_t *zl3vni);
 static void zebra_vxlan_process_l3vni_oper_up(zebra_l3vni_t *zl3vni);
 static void zebra_vxlan_process_l3vni_oper_down(zebra_l3vni_t *zl3vni);
 
-static unsigned int mac_hash_keymake(void *p);
+static unsigned int mac_hash_keymake(const void *p);
 static bool mac_cmp(const void *p1, const void *p2);
 static void *zvni_mac_alloc(void *p);
 static zebra_mac_t *zvni_mac_add(zebra_vni_t *zvni, struct ethaddr *macaddr);
@@ -168,7 +168,7 @@ static int zvni_mac_install(zebra_vni_t *zvni, zebra_mac_t *mac);
 static int zvni_mac_uninstall(zebra_vni_t *zvni, zebra_mac_t *mac);
 static void zvni_install_mac_hash(struct hash_bucket *bucket, void *ctxt);
 
-static unsigned int vni_hash_keymake(void *p);
+static unsigned int vni_hash_keymake(const void *p);
 static void *zvni_alloc(void *p);
 static zebra_vni_t *zvni_lookup(vni_t vni);
 static zebra_vni_t *zvni_add(vni_t vni);
@@ -213,7 +213,7 @@ static void zebra_vxlan_dup_addr_detect_for_mac(struct zebra_vrf *zvrf,
 						bool do_dad,
 						bool *is_dup_detect,
 						bool is_local);
-static unsigned int zebra_vxlan_sg_hash_key_make(void *p);
+static unsigned int zebra_vxlan_sg_hash_key_make(const void *p);
 static bool zebra_vxlan_sg_hash_eq(const void *p1, const void *p2);
 static void zebra_vxlan_sg_do_deref(struct zebra_vrf *zvrf,
 		struct in_addr sip, struct in_addr mcast_grp);
@@ -2158,10 +2158,10 @@ static int zvni_macip_send_msg_to_client(vni_t vni, struct ethaddr *macaddr,
 /*
  * Make hash key for neighbors.
  */
-static unsigned int neigh_hash_keymake(void *p)
+static unsigned int neigh_hash_keymake(const void *p)
 {
-	zebra_neigh_t *n = p;
-	struct ipaddr *ip = &n->ip;
+	const zebra_neigh_t *n = p;
+	const struct ipaddr *ip = &n->ip;
 
 	if (IS_IPADDR_V4(ip))
 		return jhash_1word(ip->ipaddr_v4.s_addr, 0);
@@ -3296,9 +3296,9 @@ static int zvni_remote_neigh_update(zebra_vni_t *zvni,
 /*
  * Make hash key for MAC.
  */
-static unsigned int mac_hash_keymake(void *p)
+static unsigned int mac_hash_keymake(const void *p)
 {
-	zebra_mac_t *pmac = p;
+	const zebra_mac_t *pmac = p;
 	const void *pnt = (void *)pmac->macaddr.octet;
 
 	return jhash(pnt, ETH_ALEN, 0xa5a5a55a);
@@ -3815,7 +3815,7 @@ static void zvni_read_mac_neigh(zebra_vni_t *zvni, struct interface *ifp)
 /*
  * Hash function for VNI.
  */
-static unsigned int vni_hash_keymake(void *p)
+static unsigned int vni_hash_keymake(const void *p)
 {
 	const zebra_vni_t *zvni = p;
 
@@ -4688,7 +4688,7 @@ static int zl3vni_local_nh_del(zebra_l3vni_t *zl3vni, struct ipaddr *ip)
 /*
  * Hash function for L3 VNI.
  */
-static unsigned int l3vni_hash_keymake(void *p)
+static unsigned int l3vni_hash_keymake(const void *p)
 {
 	const zebra_l3vni_t *zl3vni = p;
 
@@ -9457,9 +9457,9 @@ static int zebra_vxlan_sg_send(struct prefix_sg *sg,
 	return zserv_send_message(client, s);
 }
 
-static unsigned int zebra_vxlan_sg_hash_key_make(void *p)
+static unsigned int zebra_vxlan_sg_hash_key_make(const void *p)
 {
-	zebra_vxlan_sg_t *vxlan_sg = p;
+	const zebra_vxlan_sg_t *vxlan_sg = p;
 
 	return (jhash_2words(vxlan_sg->sg.src.s_addr,
 				vxlan_sg->sg.grp.s_addr, 0));


### PR DESCRIPTION
It doesn't make much sense for a hash function to modify its argument,
so const the hash input.

BGP does it in a couple places, those now cast away the const. Not great but
not any worse than it was.

Cocci patch is in `tools/coccinelle/hash_const.cocci`

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>