### PR TITLE
lib: Changes made to dependencies of a route-map do not take effect dynamically.

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2975,7 +2975,7 @@ static int bgp_route_match_add(struct vty *vty, const char *command,
 	int retval = CMD_SUCCESS;
 	int ret;
 
-	ret = route_map_add_match(index, command, arg);
+	ret = route_map_add_match(index, command, arg, type);
 	switch (ret) {
 	case RMAP_RULE_MISSING:
 		vty_out(vty, "%% BGP Can't find rule.\n");

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1407,7 +1407,8 @@ DEFUN (match_rpki,
 	VTY_DECLVAR_CONTEXT(route_map_index, index);
 	int ret;
 
-	ret = route_map_add_match(index, "rpki", argv[2]->arg);
+	ret = route_map_add_match(index, "rpki", argv[2]->arg,
+				  RMAP_EVENT_MATCH_ADDED);
 	if (ret) {
 		switch (ret) {
 		case RMAP_RULE_MISSING:

--- a/eigrpd/eigrp_routemap.c
+++ b/eigrpd/eigrp_routemap.c
@@ -136,7 +136,7 @@ static int eigrp_route_match_add(struct vty *vty, struct route_map_index *index,
 				 const char *command, const char *arg)
 {
 	int ret;
-	ret = route_map_add_match(index, command, arg);
+	ret = route_map_add_match(index, command, arg, type);
 	switch (ret) {
 	case RMAP_RULE_MISSING:
 		vty_out(vty, "%% Can't find rule.\n");

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -125,13 +125,18 @@ struct route_map_rule_cmd {
 };
 
 /* Route map apply error. */
-enum { RMAP_COMPILE_SUCCESS,
+enum {
+	RMAP_COMPILE_SUCCESS,
 
-       /* Route map rule is missing. */
-       RMAP_RULE_MISSING,
+	/* Route map rule is missing. */
+	RMAP_RULE_MISSING,
 
-       /* Route map rule can't compile */
-       RMAP_COMPILE_ERROR };
+	/* Route map rule can't compile */
+	RMAP_COMPILE_ERROR,
+
+	/* Route map rule is duplicate */
+	RMAP_DUPLICATE_RULE
+};
 
 /* Route map rule list. */
 struct route_map_rule_list {
@@ -213,7 +218,8 @@ extern void route_map_finish(void);
 
 /* Add match statement to route map. */
 extern int route_map_add_match(struct route_map_index *index,
-			       const char *match_name, const char *match_arg);
+			       const char *match_name, const char *match_arg,
+			       route_map_event_t type);
 
 /* Delete specified route match rule. */
 extern int route_map_delete_match(struct route_map_index *index,

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -67,7 +67,7 @@ static int zebra_route_match_add(struct vty *vty, const char *command,
 	int ret;
 	int retval = CMD_SUCCESS;
 
-	ret = route_map_add_match(index, command, arg);
+	ret = route_map_add_match(index, command, arg, type);
 	switch (ret) {
 	case RMAP_RULE_MISSING:
 		vty_out(vty, "%% Zebra Can't find rule.\n");


### PR DESCRIPTION
Say, more than one sequence of a route-map uses the same named entity in its match clause. After that entity is removed from any one of the route-map sequences, any further changes made to that entity doesn't dynamically take effect.

The way the dependency of a route-map on named entities like prefix-lists, community-lists, as-path access-lists, etc is maintained currently doesn't take into account the number of sequences of the same route-map that use the named entities.
Due to this, even if one of the sequences of the route-map removes the named entity from its match clause, the dependency of route-map on that entity is completely broken.

A reference counter has been introduced to address this issue.

Signed-off-by: NaveenThanikachalam <nthanikachal@vmware.com>