### PR TITLE
bgpd: do not unregister bfd session when bgp session goes down

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2232,6 +2232,8 @@ int peer_delete(struct peer *peer)
 
 	SET_FLAG(peer->flags, PEER_FLAG_DELETE);
 
+	bgp_bfd_deregister_peer(peer);
+
 	/* If this peer belongs to peer group, clear up the
 	   relationship.  */
 	if (peer->group) {


### PR DESCRIPTION
This commit fixes a previous commit:
"bfdd: remove operational bfd sessions from remote daemons"
where the handling of unregister call triggers the deletion of bfd
session.
Actually, the BFD session should not be deleted, while bgp session is
configured with BGP. this permits to receive BFD events up, and permit
quicker reconnecion.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>