### PR TITLE
doc: update bgp.rst

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1862,10 +1862,11 @@ address-family:
 .. index:: label vpn export (0..1048575)|auto
 .. clicmd:: label vpn export (0..1048575)|auto
 
-   Enables an MPLS label to be attached to a route exported from the current unicast VRF to VPN. 
-   If label is specified as auto, the label value is automatically assigned from a pool maintained by the zebra daemon. 
-   If zebra is not running, or if this command is not configured, automatic label assignment will not complete, which 
-   will block corresponding route export.
+   Enables an MPLS label to be attached to a route exported from the current 
+   unicast VRF to VPN. If label is specified as auto, the label value is 
+   automatically assigned from a pool maintained by the zebra daemon. 
+   If zebra is not running, or if this command is not configured, automatic 
+   label assignment will not complete, which will block corresponding route export.
 
 .. index:: no label vpn export [(0..1048575)|auto]
 .. clicmd:: no label vpn export [(0..1048575)|auto]

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1862,11 +1862,10 @@ address-family:
 .. index:: label vpn export (0..1048575)|auto
 .. clicmd:: label vpn export (0..1048575)|auto
 
-   Specifies an optional MPLS label to be attached to a route exported from the
-   current unicast VRF to VPN. If label is specified as ``auto``, the label
-   value is automatically assigned from a pool maintained by the zebra
-   daemon. If zebra is not running, automatic label assignment will not
-   complete, which will block corresponding route export.
+   Enables an MPLS label to be attached to a route exported from the current unicast VRF to VPN. 
+   If label is specified as auto, the label value is automatically assigned from a pool maintained by the zebra daemon. 
+   If zebra is not running, or if this command is not configured, automatic label assignment will not complete, which 
+   will block corresponding route export.
 
 .. index:: no label vpn export [(0..1048575)|auto]
 .. clicmd:: no label vpn export [(0..1048575)|auto]


### PR DESCRIPTION
in the section:
http://docs.frrouting.org/en/latest/bgp.html#clicmd-labelvpnexport(0..1048575)|auto

The current wording is:
Specifies an optional MPLS label to be attached to a route exported from the current unicast VRF to VPN. If label is specified as auto, the label value is automatically assigned from a pool maintained by the zebra daemon. If zebra is not running, automatic label assignment will not complete, which will block corresponding route export.

This can sometimes be misinterpreted that this command is optional, but for an MPLS-VPN to function a VPN label MUST be assigned to routes exported from the VPN.

I think this should be changed to:
Enables an MPLS label to be attached to a route exported from the current unicast VRF to VPN. If label is specified as auto, the label value is automatically assigned from a pool maintained by the zebra daemon. If zebra is not running, or if this command is not configured, automatic label assignment will not complete, which will block corresponding route export.