### PR TITLE
Bgp reason

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -681,7 +681,7 @@ static void show_vni_routes(struct bgp *bgp, struct bgpevpn *vpn, int type,
 				json_path = json_object_new_array();
 
 			if (detail)
-				route_vty_out_detail(vty, bgp, &rn->p, pi,
+				route_vty_out_detail(vty, bgp, rn, pi,
 						     AFI_L2VPN, SAFI_EVPN,
 						     json_path);
 			else
@@ -2089,7 +2089,7 @@ static void evpn_show_route_vni_multicast(struct vty *vty, struct bgp *bgp,
 		if (json)
 			json_path = json_object_new_array();
 
-		route_vty_out_detail(vty, bgp, &rn->p, pi, afi, safi,
+		route_vty_out_detail(vty, bgp, rn, pi, afi, safi,
 				     json_path);
 
 		if (json)
@@ -2159,7 +2159,7 @@ static void evpn_show_route_vni_macip(struct vty *vty, struct bgp *bgp,
 		if (json)
 			json_path = json_object_new_array();
 
-		route_vty_out_detail(vty, bgp, &rn->p, pi, afi, safi,
+		route_vty_out_detail(vty, bgp, rn, pi, afi, safi,
 				     json_path);
 
 		if (json)
@@ -2266,7 +2266,7 @@ static void evpn_show_route_rd_macip(struct vty *vty, struct bgp *bgp,
 		if (json)
 			json_path = json_object_new_array();
 
-		route_vty_out_detail(vty, bgp, &rn->p, pi, afi, safi,
+		route_vty_out_detail(vty, bgp, rn, pi, afi, safi,
 				     json_path);
 
 		if (json)
@@ -2371,7 +2371,7 @@ static void evpn_show_route_rd(struct vty *vty, struct bgp *bgp,
 			if (json)
 				json_path = json_object_new_array();
 
-			route_vty_out_detail(vty, bgp, &rn->p, pi, afi, safi,
+			route_vty_out_detail(vty, bgp, rn, pi, afi, safi,
 					     json_path);
 
 			if (json)
@@ -2521,7 +2521,7 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 
 				if (detail) {
 					route_vty_out_detail(
-						vty, bgp, &rn->p, pi, AFI_L2VPN,
+						vty, bgp, rn, pi, AFI_L2VPN,
 						SAFI_EVPN, json_path);
 				} else
 					route_vty_out(vty, &rn->p, pi, 0,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7822,9 +7822,9 @@ static void route_vty_out_tx_ids(struct vty *vty,
 	}
 }
 
-void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
-			  struct bgp_path_info *path, afi_t afi, safi_t safi,
-			  json_object *json_paths)
+void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
+			  struct bgp_node *bn, struct bgp_path_info *path,
+			  afi_t afi, safi_t safi, json_object *json_paths)
 {
 	char buf[INET6_ADDRSTRLEN];
 	char buf1[BUFSIZ];
@@ -7864,7 +7864,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 	if (!json_paths && safi == SAFI_EVPN) {
 		char tag_buf[30];
 
-		bgp_evpn_route2str((struct prefix_evpn *)p, buf2, sizeof(buf2));
+		bgp_evpn_route2str((struct prefix_evpn *)&bn->p,
+				   buf2, sizeof(buf2));
 		vty_out(vty, "  Route %s", buf2);
 		tag_buf[0] = '\0';
 		if (path->extra && path->extra->num_labels) {
@@ -7979,8 +7980,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 
 		/* Line2 display Next-hop, Neighbor, Router-id */
 		/* Display the nexthop */
-		if ((p->family == AF_INET || p->family == AF_ETHERNET
-		     || p->family == AF_EVPN)
+		if ((bn->p.family == AF_INET || bn->p.family == AF_ETHERNET
+		     || bn->p.family == AF_EVPN)
 		    && (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP
 			|| safi == SAFI_EVPN
 			|| !BGP_ATTR_NEXTHOP_AFI_IP6(attr))) {
@@ -8062,7 +8063,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 		if (path->peer == bgp->peer_self) {
 
 			if (safi == SAFI_EVPN
-			    || (p->family == AF_INET
+			    || (bn->p.family == AF_INET
 				&& !BGP_ATTR_NEXTHOP_AFI_IP6(attr))) {
 				if (json_paths)
 					json_object_string_add(
@@ -9429,7 +9430,7 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 						       BGP_PATH_MULTIPATH)
 					    || CHECK_FLAG(pi->flags,
 							  BGP_PATH_SELECTED))))
-					route_vty_out_detail(vty, bgp, &rm->p,
+					route_vty_out_detail(vty, bgp, rm,
 							     pi, AFI_IP, safi,
 							     json_paths);
 			}
@@ -9473,7 +9474,7 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 							       pi->flags,
 							       BGP_PATH_SELECTED))))
 						route_vty_out_detail(
-							vty, bgp, &rn->p, pi,
+							vty, bgp, rn, pi,
 							afi, safi, json_paths);
 				}
 			}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7868,6 +7868,79 @@ static void route_vty_out_tx_ids(struct vty *vty,
 	}
 }
 
+static const char *bgp_path_selection_reason2str(
+	enum bgp_path_selection_reason reason)
+{
+	switch (reason) {
+	case bgp_path_selection_none:
+		return "Nothing to Select";
+		break;
+	case bgp_path_selection_first:
+		return "First path received";
+		break;
+	case bgp_path_selection_evpn_sticky_mac:
+		return "EVPN Sticky Mac";
+		break;
+	case bgp_path_selection_evpn_seq:
+		return "EVPN sequence number";
+		break;
+	case bgp_path_selection_evpn_lower_ip:
+		return "EVPN lower IP";
+		break;
+	case bgp_path_selection_weight:
+		return "Weight";
+		break;
+	case bgp_path_selection_local_pref:
+		return "Local Pref";
+		break;
+	case bgp_path_selection_local_route:
+		return "Local Route";
+		break;
+	case bgp_path_selection_confed_as_path:
+		return "Confederation based AS Path";
+		break;
+	case bgp_path_selection_as_path:
+		return "AS Path";
+		break;
+	case bgp_path_selection_origin:
+		return "Origin";
+		break;
+	case bgp_path_selection_med:
+		return "MED";
+		break;
+	case bgp_path_selection_peer:
+		return "Peer Type";
+		break;
+	case bgp_path_selection_confed:
+		return "Confed Peer Type";
+		break;
+	case bgp_path_selection_igp_metric:
+		return "IGP Metric";
+		break;
+	case bgp_path_selection_older:
+		return "Older Path";
+		break;
+	case bgp_path_selection_router_id:
+		return "Router ID";
+		break;
+	case bgp_path_selection_cluster_length:
+		return "Cluser length";
+		break;
+	case bgp_path_selection_stale:
+		return "Path Staleness";
+		break;
+	case bgp_path_selection_local_configured:
+		return "Locally configured route";
+		break;
+	case bgp_path_selection_neighbor_ip:
+		return "Neighbor IP";
+		break;
+	case bgp_path_selection_default:
+		return "Nothing left to compare";
+		break;
+	}
+}
+
 void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 			  struct bgp_node *bn, struct bgp_path_info *path,
 			  afi_t afi, safi_t safi, json_object *json_paths)
@@ -8463,8 +8536,14 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 						json_object_new_object();
 				json_object_boolean_true_add(json_bestpath,
 							     "overall");
-			} else
+				json_object_string_add(json_bestpath,
+						       "selectionReason",
+						       bgp_path_selection_reason2str(bn->reason));
+			} else {
 				vty_out(vty, ", best");
+				vty_out(vty, " (%s)",
+					bgp_path_selection_reason2str(bn->reason));
+			}
 		}
 
 		if (json_bestpath)

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -604,7 +604,8 @@ extern void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 					struct prefix_rd *prd, afi_t afi,
 					safi_t safi, json_object *json);
 extern void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
-				 struct prefix *p, struct bgp_path_info *path,
+				 struct bgp_node *bn,
+				 struct bgp_path_info *path,
 				 afi_t afi, safi_t safi,
 				 json_object *json_paths);
 extern int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, safi_t safi,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -588,7 +588,8 @@ extern void bgp_path_info_restore(struct bgp_node *rn,
 extern int bgp_path_info_cmp_compatible(struct bgp *bgp,
 					struct bgp_path_info *new,
 					struct bgp_path_info *exist,
-					char *pfx_buf, afi_t afi, safi_t safi);
+					char *pfx_buf, afi_t afi, safi_t safi,
+					enum bgp_path_selection_reason *reason);
 extern void bgp_attr_add_gshut_community(struct attr *attr);
 
 extern void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -42,6 +42,31 @@ struct bgp_table {
 	uint64_t version;
 };
 
+enum bgp_path_selection_reason {
+	bgp_path_selection_none,
+	bgp_path_selection_first,
+	bgp_path_selection_evpn_sticky_mac,
+	bgp_path_selection_evpn_seq,
+	bgp_path_selection_evpn_lower_ip,
+	bgp_path_selection_weight,
+	bgp_path_selection_local_pref,
+	bgp_path_selection_local_route,
+	bgp_path_selection_confed_as_path,
+	bgp_path_selection_as_path,
+	bgp_path_selection_origin,
+	bgp_path_selection_med,
+	bgp_path_selection_peer,
+	bgp_path_selection_confed,
+	bgp_path_selection_igp_metric,
+	bgp_path_selection_older,
+	bgp_path_selection_router_id,
+	bgp_path_selection_cluster_length,
+	bgp_path_selection_stale,
+	bgp_path_selection_local_configured,
+	bgp_path_selection_neighbor_ip,
+	bgp_path_selection_default,
+};
+
 struct bgp_node {
 	/*
 	 * CAUTION
@@ -72,6 +97,8 @@ struct bgp_node {
 #define BGP_NODE_REGISTERED_FOR_LABEL   (1 << 3)
 
 	struct bgp_addpath_node_data tx_addpath;
+
+	enum bgp_path_selection_reason reason;
 };
 
 /*

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -1984,11 +1984,14 @@ static void rfapiBgpInfoAttachSorted(struct agg_node *rn,
 
 	for (prev = NULL, next = rn->info; next;
 	     prev = next, next = next->next) {
+		enum bgp_path_selection_reason reason;
+
 		if (!bgp
 		    || (!CHECK_FLAG(info_new->flags, BGP_PATH_REMOVED)
 			&& CHECK_FLAG(next->flags, BGP_PATH_REMOVED))
 		    || bgp_path_info_cmp_compatible(bgp, info_new, next,
-						    pfx_buf, afi, safi)
+						    pfx_buf, afi, safi,
+						    &reason)
 			       == -1) { /* -1 if 1st is better */
 			break;
 		}


### PR DESCRIPTION
Store the reason a bgp_path_info was choosen as best and display it when you get detailed output

robot# show bgp ipv4 uni 223.255.254.0
BGP routing table entry for 223.255.254.0/24
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  annie(192.168.201.136)
  64539 15096 6939 7473 3758 55415
    192.168.201.136 from annie(192.168.201.136) (192.168.201.136)
      Origin IGP, valid, external, bestpath-from-AS 64539, best (First path received)
      Last update: Wed May 15 21:15:48 2019


Question for reviewers -> I added the enum to bgp_table.h.  Where does it really go?  I'm having a hard time figuring it out.
I would also like a review of reason strings to find maybe something better