### PR TITLE
pimd: new cli command show ip mroute summary

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -322,6 +322,12 @@ cause great confusion.
    Display information about installed into the kernel S,G mroutes and in
    addition display data about packet flow for the mroutes.
 
+.. index:: show ip mroute summary
+.. clicmd:: show ip mroute summary
+
+   Display total number of S,G mroutes and number of S,G mroutes installed
+   into the kernel.
+
 .. index:: show ip pim assert
 .. clicmd:: show ip pim assert
 


### PR DESCRIPTION
Introduced a new command "show ip mroute summary"
to display total number of (*, G) and (S, G) mroutes
created and number of mroutes installed in the kernel.

Signed-off-by: Sarita Patra <saritap@vmware.com>