### PR TITLE
zebra: Continue rm update if table not found

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -770,6 +770,13 @@ void zebra_import_table_rm_update(const char *rmap)
 				continue;
 			table = zebra_vrf_table_with_table_id(afi, SAFI_UNICAST,
 							      i, VRF_DEFAULT);
+			if (!table) {
+				if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+					zlog_debug("%s: Table id=%d not found",
+						   __func__, i);
+				continue;
+			}
+
 			for (rn = route_top(table); rn; rn = route_next(rn)) {
 				/* For each entry in the non-default
 				 * routing table,


### PR DESCRIPTION
Add a check for after table lookup during route map update.
If the table ID does not exist, continue.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>