### PR TITLE
zebra: Fix possible NULL deref

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -770,6 +770,10 @@ void zebra_import_table_rm_update(const char *rmap)
 				continue;
 			table = zebra_vrf_table_with_table_id(afi, SAFI_UNICAST,
 							      i, VRF_DEFAULT);
+
+			if (!table)
+				continue;
+
 			for (rn = route_top(table); rn; rn = route_next(rn)) {
 				/* For each entry in the non-default
 				 * routing table,


### PR DESCRIPTION
When calling zebra_vrf_table_with_table_id it is possible it
returns a NULL. So act accordingly.  Spotted by coverity
SA run.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>