### PR TITLE
doc: add libsnmp-dev to debian 9 build deps

### DIFF
--- a/doc/developer/building-frr-for-debian8.rst
+++ b/doc/developer/building-frr-for-debian8.rst
@@ -17,7 +17,8 @@ Add packages:
 
    sudo apt-get install git autoconf automake libtool make \
       libreadline-dev texinfo libjson-c-dev pkg-config bison flex python-pip \
-      libc-ares-dev python3-dev python3-sphinx build-essential libsystemd-dev
+      libc-ares-dev python3-dev python3-sphinx build-essential libsystemd-dev \
+      libsnmp-dev
 
 Install newer pytest (>3.0) from pip
 

--- a/doc/developer/building-frr-for-debian9.rst
+++ b/doc/developer/building-frr-for-debian9.rst
@@ -11,7 +11,7 @@ Add packages:
    sudo apt-get install git autoconf automake libtool make \
      libreadline-dev texinfo libjson-c-dev pkg-config bison flex python-pip \
      libc-ares-dev python3-dev python-pytest python3-sphinx build-essential \
-     libsystemd-dev
+     libsnmp-dev libsystemd-dev
 
 .. include:: building-libyang.rst
 


### PR DESCRIPTION
Needed for `--enable-snmp`

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>