### PR TITLE
vrrpd: fix coverity warnings

### DIFF
--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -763,7 +763,7 @@ static void vrrp_send_advertisement(struct vrrp_router *r)
 
 	const char *group = r->family == AF_INET ? VRRP_MCASTV4_GROUP_STR
 						 : VRRP_MCASTV6_GROUP_STR;
-	str2sockunion(group, &dest);
+	(void)str2sockunion(group, &dest);
 
 	ssize_t sent = sendto(r->sock_tx, pkt, (size_t)pktsz, 0, &dest.sa,
 			      sockunion_sizeof(&dest));
@@ -969,7 +969,7 @@ static int vrrp_read(struct thread *thread)
 	uint8_t control[64];
 	struct ipaddr src = {};
 
-	struct msghdr m;
+	struct msghdr m = {};
 	struct iovec iov;
 
 	iov.iov_base = r->ibuf;
@@ -1384,7 +1384,6 @@ static void vrrp_change_state_backup(struct vrrp_router *r)
  */
 static void vrrp_change_state_initialize(struct vrrp_router *r)
 {
-	r->vr->advertisement_interval = r->vr->advertisement_interval;
 	r->master_adver_interval = 0;
 	vrrp_recalculate_timers(r);
 

--- a/vrrpd/vrrp_arp.c
+++ b/vrrpd/vrrp_arp.c
@@ -124,13 +124,21 @@ void vrrp_garp_send(struct vrrp_router *r, struct in_addr *v4)
 	if (ifp->flags & IFF_NOARP) {
 		zlog_warn(
 			VRRP_LOGPFX VRRP_LOGPFX_VRID VRRP_LOGPFX_FAM
-			"Unable to send gratuitous ARP on %s; has IFF_NOARP\n",
+			"Unable to send gratuitous ARP on %s; has IFF_NOARP",
 			r->vr->vrid, family2str(r->family), ifp->name);
 		return;
 	}
 
 	/* Build garp */
 	garpbuf_len = vrrp_build_garp(garpbuf, ifp, v4);
+
+	if (garpbuf_len < 0) {
+		zlog_warn(
+			VRRP_LOGPFX VRRP_LOGPFX_VRID VRRP_LOGPFX_FAM
+			"Unable to send gratuitous ARP on %s; MAC address unknown",
+			r->vr->vrid, family2str(r->family), ifp->name);
+		return;
+	};
 
 	/* Send garp */
 	inet_ntop(AF_INET, v4, astr, sizeof(astr));

--- a/vrrpd/vrrp_ndisc.c
+++ b/vrrpd/vrrp_ndisc.c
@@ -139,7 +139,10 @@ static int vrrp_ndisc_una_build(struct interface *ifp, struct ipaddr *ip,
 	ph.dst = ip6h->ip6_dst;
 	ph.ulpl = htonl(len);
 	ph.next_hdr = IPPROTO_ICMPV6;
-	icmp6h->icmp6_cksum = in_cksum_with_ph6(&ph, (void *)icmp6h, len);
+
+	/* Suppress static analysis warnings about accessing icmp6 oob */
+	void *offset = icmp6h;
+	icmp6h->icmp6_cksum = in_cksum_with_ph6(&ph, offset, len);
 
 	return 0;
 }


### PR DESCRIPTION
* Suppress false positive on out of bounds access
* Suppress false positive on unchecked str2sockunion
* Remove self assignment
* Initialze struct msghdr to zero

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>