### PR TITLE
doc: clarify mpls label export docs

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1862,11 +1862,11 @@ address-family:
 .. index:: label vpn export (0..1048575)|auto
 .. clicmd:: label vpn export (0..1048575)|auto
 
-   Specifies an optional MPLS label to be attached to a route exported from the
-   current unicast VRF to VPN. If label is specified as ``auto``, the label
-   value is automatically assigned from a pool maintained by the zebra
-   daemon. If zebra is not running, automatic label assignment will not
-   complete, which will block corresponding route export.
+   Enables an MPLS label to be attached to a route exported from the current
+   unicast VRF to VPN. If the value specified is ``auto``, the label value is
+   automatically assigned from a pool maintained by the Zebra daemon. If Zebra
+   is not running, or if this command is not configured, automatic label
+   assignment will not complete, which will block corresponding route export.
 
 .. index:: no label vpn export [(0..1048575)|auto]
 .. clicmd:: no label vpn export [(0..1048575)|auto]


### PR DESCRIPTION
The current wording can sometimes be misinterpreted to mean that this
command is optional, but for an MPLS-VPN to function a VPN label MUST be
assigned to routes exported from the VPN.

This is a fixed up version of #4348. Needs review for correctness.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>