### PR TITLE
pimd: new cli to configure last-member-query-count & last-member-quer…

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -218,6 +218,19 @@ is in a vrf, enter the interface command with the vrf keyword at the end.
    or IGMP report is received on this interface and the Group is denied by the
    prefix-list, PIM will ignore the join or report.
 
+.. index:: ip igmp last-member-query-count (1-7)
+.. clicmd:: ip igmp last-member-query-count (1-7)
+
+   Set the IGMP last member query count. The default value is 2. 'no' form of
+   this command is used to to configure back to the default value.
+
+.. index:: ip igmp last-member-query-interval (1-255)
+.. clicmd:: ip igmp last-member-query-interval (1-255)
+
+   Set the IGMP last member query interval in deciseconds. The default value is
+   10 deciseconds. 'no' form of this command is used to to configure back to the
+   default value.
+
 .. _pim-multicast-rib-insertion:
 
 PIM Multicast RIB insertion:

--- a/pimd/pim_cmd.h
+++ b/pimd/pim_cmd.h
@@ -35,6 +35,8 @@
 #define IFACE_IGMP_QUERY_INTERVAL_STR          "IGMP host query interval\n"
 #define IFACE_IGMP_QUERY_MAX_RESPONSE_TIME_STR      "IGMP max query response value (seconds)\n"
 #define IFACE_IGMP_QUERY_MAX_RESPONSE_TIME_DSEC_STR "IGMP max query response value (deciseconds)\n"
+#define IFACE_IGMP_LAST_MEMBER_QUERY_INTERVAL_STR   "IGMP last member query interval\n"
+#define IFACE_IGMP_LAST_MEMBER_QUERY_COUNT_STR      "IGMP last member query count\n"
 #define DEBUG_IGMP_STR                              "IGMP protocol activity\n"
 #define DEBUG_IGMP_EVENTS_STR                       "IGMP protocol events\n"
 #define DEBUG_IGMP_PACKETS_STR                      "IGMP protocol packets\n"

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -131,6 +131,8 @@ struct pim_interface *pim_if_new(struct interface *ifp, bool igmp, bool pim,
 		IGMP_QUERY_MAX_RESPONSE_TIME_DSEC;
 	pim_ifp->igmp_specific_query_max_response_time_dsec =
 		IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC;
+	pim_ifp->igmp_last_member_query_count =
+		IGMP_DEFAULT_ROBUSTNESS_VARIABLE;
 
 	/*
 	  RFC 3376: 8.3. Query Response Interval

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -88,8 +88,14 @@ struct pim_interface {
 	int igmp_query_max_response_time_dsec; /* IGMPv3 Max Response Time in
 						  dsecs for general queries */
 	int igmp_specific_query_max_response_time_dsec; /* IGMPv3 Max Response
-							   Time in dsecs for
-							   specific queries */
+							   Time in dsecs called
+							   as last member query
+							   interval, defines the
+							   maximum response time
+							   advertised in IGMP
+							   group-specific
+							   queries */
+	int igmp_last_member_query_count; /* IGMP last member query count */
 	struct list *igmp_socket_list; /* list of struct igmp_sock */
 	struct list *igmp_join_list;   /* list of struct igmp_join */
 

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -997,7 +997,7 @@ static void group_retransmit_group(struct igmp_group *group)
 
 	char query_buf[query_buf_size];
 
-	lmqc = igmp->querier_robustness_variable;
+	lmqc = pim_ifp->igmp_last_member_query_count;
 	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
@@ -1076,7 +1076,7 @@ static int group_retransmit_sources(struct igmp_group *group,
 	igmp = group->group_igmp_sock;
 	pim_ifp = igmp->interface->info;
 
-	lmqc = igmp->querier_robustness_variable;
+	lmqc = pim_ifp->igmp_last_member_query_count;
 	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
@@ -1314,9 +1314,13 @@ static long igmp_source_timer_remain_msec(struct igmp_source *source)
 */
 static void group_query_send(struct igmp_group *group)
 {
+	struct pim_interface *pim_ifp;
+	struct igmp_sock *igmp;
 	long lmqc; /* Last Member Query Count */
 
-	lmqc = group->group_igmp_sock->querier_robustness_variable;
+	igmp = group->group_igmp_sock;
+	pim_ifp = igmp->interface->info;
+	lmqc = pim_ifp->igmp_last_member_query_count;
 
 	/* lower group timer to lmqt */
 	igmp_group_timer_lower_to_lmqt(group);
@@ -1351,7 +1355,7 @@ static void source_query_send_by_flag(struct igmp_group *group,
 	igmp = group->group_igmp_sock;
 	pim_ifp = igmp->interface->info;
 
-	lmqc = igmp->querier_robustness_variable;
+	lmqc = pim_ifp->igmp_last_member_query_count;
 	lmqi_msec = 100 * pim_ifp->igmp_specific_query_max_response_time_dsec;
 	lmqt_msec = lmqc * lmqi_msec;
 
@@ -1509,7 +1513,7 @@ void igmp_group_timer_lower_to_lmqt(struct igmp_group *group)
 	ifname = ifp->name;
 
 	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
-	lmqc = igmp->querier_robustness_variable;
+	lmqc = pim_ifp->igmp_last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 
@@ -1546,7 +1550,7 @@ void igmp_source_timer_lower_to_lmqt(struct igmp_source *source)
 	ifname = ifp->name;
 
 	lmqi_dsec = pim_ifp->igmp_specific_query_max_response_time_dsec;
-	lmqc = igmp->querier_robustness_variable;
+	lmqc = pim_ifp->igmp_last_member_query_count;
 	lmqt_msec = PIM_IGMP_LMQT_MSEC(
 		lmqi_dsec, lmqc); /* lmqt_msec = (100 * lmqi_dsec) * lmqc */
 

--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -344,6 +344,24 @@ int pim_interface_config_write(struct vty *vty)
 					++writes;
 				}
 
+				/* IF ip igmp last-member_query-count */
+				if (pim_ifp->igmp_last_member_query_count
+				    != IGMP_DEFAULT_ROBUSTNESS_VARIABLE) {
+					vty_out(vty,
+						" ip igmp last-member-query-count %d\n",
+						pim_ifp->igmp_last_member_query_count);
+					++writes;
+				}
+
+				/* IF ip igmp last-member_query-interval */
+				if (pim_ifp->igmp_specific_query_max_response_time_dsec
+				    != IGMP_SPECIFIC_QUERY_MAX_RESPONSE_TIME_DSEC) {
+					vty_out(vty,
+						" ip igmp last-member-query-interval %d\n",
+						pim_ifp->igmp_specific_query_max_response_time_dsec);
+					  ++writes;
+				}
+
 				/* IF ip igmp join */
 				if (pim_ifp->igmp_join_list) {
 					struct listnode *node;


### PR DESCRIPTION
…y-interval

Introduce new cli commands ip igmp last-member-query-count <1-7>
ip igmp last-member-query-interval <1-255> deciseconds.

Display the config in show running config and show ip igmp interface

Signed-off-by: Sarita Patra <saritap@vmware.com>