### PR TITLE
bgpd: fix compiler warning in reason2str

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8005,6 +8005,7 @@ static const char *bgp_path_selection_reason2str(
 		return "Nothing left to compare";
 		break;
 	}
+	return "Invalid (internal error)";
 }
 
 void route_vty_out_detail(struct vty *vty, struct bgp *bgp,


### PR DESCRIPTION
```
bgpd/bgp_route.c: In function 'bgp_path_selection_reason2str':
bgpd/bgp_route.c:8008:1: error: control reaches end of non-void function [-Werror=return-type]
```