### PR TITLE
lib: DECLARE_DLIST + DECLARE_HEAP + other datastructure improvements

### DIFF
--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -23,7 +23,7 @@
 
 #include "lib/typesafe.h"
 
-PREDECL_LIST(bgp_adv_fifo)
+PREDECL_DLIST(bgp_adv_fifo)
 
 struct update_subgroup;
 
@@ -60,7 +60,7 @@ struct bgp_advertise {
 	struct bgp_path_info *pathi;
 };
 
-DECLARE_LIST(bgp_adv_fifo, struct bgp_advertise, fifo)
+DECLARE_DLIST(bgp_adv_fifo, struct bgp_advertise, fifo)
 
 /* BGP adjacency out.  */
 struct bgp_adj_out {

--- a/doc/developer/lists.rst
+++ b/doc/developer/lists.rst
@@ -19,6 +19,8 @@ For unsorted lists, the following implementations exist:
 
 - single-linked list with tail pointer (e.g. STAILQ in BSD)
 
+- double-linked list
+
 - atomic single-linked list with tail pointer
 
 
@@ -70,6 +72,7 @@ Available types:
 
    DECLARE_LIST
    DECLARE_ATOMLIST
+   DECLARE_DLIST
 
    DECLARE_SORTLIST_UNIQ
    DECLARE_SORTLIST_NONUNIQ
@@ -313,8 +316,8 @@ are several functions exposed to insert data:
 
 .. c:function:: DECLARE_XXX(Z, type, field)
 
-   :param listtype XXX: ``LIST`` or ``ATOMLIST`` to select a data structure
-      implementation.
+   :param listtype XXX: ``LIST``, ``DLIST`` or ``ATOMLIST`` to select a data
+      structure implementation.
    :param token Z: Gives the name prefix that is used for the functions
       created for this instantiation.  ``DECLARE_XXX(foo, ...)``
       gives ``struct foo_item``, ``foo_add_head()``, ``foo_count()``, etc.  Note

--- a/lib/atomlist.h
+++ b/lib/atomlist.h
@@ -152,6 +152,15 @@ macro_inline type *prefix ## _next_safe(struct prefix##_head *h, type *item)   \
 {	return item ? prefix##_next(h, item) : NULL; }                         \
 macro_inline size_t prefix ## _count(struct prefix##_head *h)                  \
 {	return atomic_load_explicit(&h->ah.count, memory_order_relaxed); }     \
+macro_inline void prefix ## _init(struct prefix##_head *h)                     \
+{                                                                              \
+	memset(h, 0, sizeof(*h));                                              \
+}                                                                              \
+macro_inline void prefix ## _fini(struct prefix##_head *h)                     \
+{                                                                              \
+	assert(prefix ## _count(h) == 0);                                      \
+	memset(h, 0, sizeof(*h));                                              \
+}                                                                              \
 /* ... */
 
 /* add_head:

--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -76,6 +76,15 @@ extern "C" {
 #define _DEPRECATED(x) deprecated
 #endif
 
+/* pure = function does not modify memory & return value is the same if
+ * memory hasn't changed (=> allows compiler to optimize)
+ *
+ * Mostly autodetected by the compiler if function body is available (i.e.
+ * static inline functions in headers).  Since that implies it should only be
+ * used in headers for non-inline functions, the "extern" is included here.
+ */
+#define ext_pure	extern __attribute__((pure))
+
 /* for helper functions defined inside macros */
 #define macro_inline	static inline __attribute__((unused))
 #define macro_pure	static inline __attribute__((unused, pure))

--- a/lib/table.c
+++ b/lib/table.c
@@ -191,7 +191,7 @@ static void set_link(struct route_node *node, struct route_node *new)
 }
 
 /* Find matched prefix. */
-struct route_node *route_node_match(const struct route_table *table,
+struct route_node *route_node_match(struct route_table *table,
 				    union prefixconstptr pu)
 {
 	const struct prefix *p = pu.p;
@@ -221,7 +221,7 @@ struct route_node *route_node_match(const struct route_table *table,
 	return NULL;
 }
 
-struct route_node *route_node_match_ipv4(const struct route_table *table,
+struct route_node *route_node_match_ipv4(struct route_table *table,
 					 const struct in_addr *addr)
 {
 	struct prefix_ipv4 p;
@@ -234,7 +234,7 @@ struct route_node *route_node_match_ipv4(const struct route_table *table,
 	return route_node_match(table, (struct prefix *)&p);
 }
 
-struct route_node *route_node_match_ipv6(const struct route_table *table,
+struct route_node *route_node_match_ipv6(struct route_table *table,
 					 const struct in6_addr *addr)
 {
 	struct prefix_ipv6 p;
@@ -248,7 +248,7 @@ struct route_node *route_node_match_ipv6(const struct route_table *table,
 }
 
 /* Lookup same prefix node.  Return NULL when we can't find route. */
-struct route_node *route_node_lookup(const struct route_table *table,
+struct route_node *route_node_lookup(struct route_table *table,
 				     union prefixconstptr pu)
 {
 	struct route_node rn, *node;
@@ -260,7 +260,7 @@ struct route_node *route_node_lookup(const struct route_table *table,
 }
 
 /* Lookup same prefix node.  Return NULL when we can't find route. */
-struct route_node *route_node_lookup_maynull(const struct route_table *table,
+struct route_node *route_node_lookup_maynull(struct route_table *table,
 					     union prefixconstptr pu)
 {
 	struct route_node rn, *node;
@@ -272,7 +272,7 @@ struct route_node *route_node_lookup_maynull(const struct route_table *table,
 }
 
 /* Add node to routing table. */
-struct route_node *route_node_get(struct route_table *const table,
+struct route_node *route_node_get(struct route_table *table,
 				  union prefixconstptr pu)
 {
 	struct route_node search;
@@ -471,7 +471,7 @@ struct route_node *route_next_until(struct route_node *node,
 	return NULL;
 }
 
-unsigned long route_table_count(const struct route_table *table)
+unsigned long route_table_count(struct route_table *table)
 {
 	return table->count;
 }
@@ -606,7 +606,7 @@ static struct route_node *route_get_subtree_next(struct route_node *node)
  * @see route_table_get_next
  */
 static struct route_node *
-route_table_get_next_internal(const struct route_table *table,
+route_table_get_next_internal(struct route_table *table,
 			      const struct prefix *p)
 {
 	struct route_node *node, *tmp_node;
@@ -707,7 +707,7 @@ route_table_get_next_internal(const struct route_table *table,
  * Find the node that occurs after the given prefix in order of
  * iteration.
  */
-struct route_node *route_table_get_next(const struct route_table *table,
+struct route_node *route_table_get_next(struct route_table *table,
 					union prefixconstptr pu)
 {
 	const struct prefix *p = pu.p;

--- a/lib/table.h
+++ b/lib/table.h
@@ -198,26 +198,29 @@ static inline void route_table_set_info(struct route_table *table, void *d)
 	table->info = d;
 }
 
-extern void route_table_finish(struct route_table *table);
-extern struct route_node *route_top(struct route_table *table);
-extern struct route_node *route_next(struct route_node *node);
-extern struct route_node *route_next_until(struct route_node *node,
-					   const struct route_node *limit);
-extern struct route_node *route_node_get(struct route_table *const table,
-					 union prefixconstptr pu);
-extern struct route_node *route_node_lookup(const struct route_table *table,
-					    union prefixconstptr pu);
-extern struct route_node *
-route_node_lookup_maynull(const struct route_table *table,
-			  union prefixconstptr pu);
-extern struct route_node *route_node_match(const struct route_table *table,
-					   union prefixconstptr pu);
-extern struct route_node *route_node_match_ipv4(const struct route_table *table,
-						const struct in_addr *addr);
-extern struct route_node *route_node_match_ipv6(const struct route_table *table,
-						const struct in6_addr *addr);
+/* ext_pure => extern __attribute__((pure))
+ *   does not modify memory (but depends on mem), allows compiler to optimize
+ */
 
-extern unsigned long route_table_count(const struct route_table *table);
+extern void route_table_finish(struct route_table *table);
+ext_pure struct route_node *route_top(struct route_table *table);
+ext_pure struct route_node *route_next(struct route_node *node);
+ext_pure struct route_node *route_next_until(struct route_node *node,
+					     const struct route_node *limit);
+extern struct route_node *route_node_get(struct route_table *table,
+					 union prefixconstptr pu);
+ext_pure struct route_node *route_node_lookup(struct route_table *table,
+					      union prefixconstptr pu);
+ext_pure struct route_node *route_node_lookup_maynull(struct route_table *table,
+						      union prefixconstptr pu);
+ext_pure struct route_node *route_node_match(struct route_table *table,
+					     union prefixconstptr pu);
+ext_pure struct route_node *route_node_match_ipv4(struct route_table *table,
+						  const struct in_addr *addr);
+ext_pure struct route_node *route_node_match_ipv6(struct route_table *table,
+						  const struct in6_addr *addr);
+
+ext_pure unsigned long route_table_count(struct route_table *table);
 
 extern struct route_node *route_node_create(route_table_delegate_t *delegate,
 					    struct route_table *table);
@@ -226,10 +229,10 @@ extern void route_node_destroy(route_table_delegate_t *delegate,
 			       struct route_table *table,
 			       struct route_node *node);
 
-extern struct route_node *route_table_get_next(const struct route_table *table,
-					       union prefixconstptr pu);
-extern int route_table_prefix_iter_cmp(const struct prefix *p1,
-				       const struct prefix *p2);
+ext_pure struct route_node *route_table_get_next(struct route_table *table,
+						 union prefixconstptr pu);
+ext_pure int route_table_prefix_iter_cmp(const struct prefix *p1,
+					 const struct prefix *p2);
 
 /*
  * Iterator functions.

--- a/lib/typesafe.c
+++ b/lib/typesafe.c
@@ -22,6 +22,7 @@
 
 DEFINE_MTYPE_STATIC(LIB, TYPEDHASH_BUCKET, "Typed-hash bucket")
 DEFINE_MTYPE_STATIC(LIB, SKIPLIST_OFLOW, "Skiplist overflow")
+DEFINE_MTYPE_STATIC(LIB, HEAP_ARRAY, "Typed-heap array")
 
 #if 0
 static void hash_consistency_check(struct thash_head *head)
@@ -406,4 +407,149 @@ struct sskip_item *typesafe_skiplist_pop(struct sskip_head *head)
 	memset(item, 0, sizeof(*item));
 
 	return item;
+}
+
+/* heap */
+
+#if 0
+static void heap_consistency_check(struct heap_head *head,
+				   int (*cmpfn)(const struct heap_item *a,
+						const struct heap_item *b),
+				   uint32_t pos)
+{
+	uint32_t rghtpos = pos + 1;
+	uint32_t downpos = HEAP_NARY * (pos + 1);
+
+	if (pos + 1 > ~0U / HEAP_NARY)
+		downpos = ~0U;
+
+	if ((pos & (HEAP_NARY - 1)) != HEAP_NARY - 1 && rghtpos < head->count) {
+		assert(cmpfn(head->array[rghtpos], head->array[pos]) >= 0);
+		heap_consistency_check(head, cmpfn, rghtpos);
+	}
+	if (downpos < head->count) {
+		assert(cmpfn(head->array[downpos], head->array[pos]) >= 0);
+		heap_consistency_check(head, cmpfn, downpos);
+	}
+}
+#else
+#define heap_consistency_check(head, cmpfn, pos)
+#endif
+
+void typesafe_heap_resize(struct heap_head *head, bool grow)
+{
+	uint32_t newsize;
+
+	if (grow) {
+		newsize = head->arraysz;
+		if (newsize <= 36)
+			newsize = 72;
+		else if (newsize < 262144)
+			newsize += newsize / 2;
+		else if (newsize < 0xaaaa0000)
+			newsize += newsize / 3;
+		else
+			assert(!newsize);
+	} else if (head->count > 0) {
+		newsize = head->count;
+	} else {
+		XFREE(MTYPE_HEAP_ARRAY, head->array);
+		head->arraysz = 0;
+		return;
+	}
+
+	newsize += HEAP_NARY - 1;
+	newsize &= ~(HEAP_NARY - 1);
+	if (newsize == head->arraysz)
+		return;
+	
+	head->array = XREALLOC(MTYPE_HEAP_ARRAY, head->array,
+			       newsize * sizeof(struct heap_item *));
+	head->arraysz = newsize;
+}
+
+void typesafe_heap_pushdown(struct heap_head *head, uint32_t pos,
+		struct heap_item *item,
+		int (*cmpfn)(const struct heap_item *a,
+			     const struct heap_item *b))
+{
+	uint32_t rghtpos, downpos, moveto;
+
+	while (1) {
+		/* rghtpos: neighbor to the "right", inside block of NARY.
+		 *          may be invalid if last in block, check nary_last()
+		 * downpos: first neighbor in the "downwards" block further
+		 *          away from the root
+		 */
+		rghtpos = pos + 1;
+
+		/* make sure we can use the full 4G items */
+		downpos = HEAP_NARY * (pos + 1);
+		if (pos + 1 > ~0U / HEAP_NARY)
+			/* multiplication overflowed.  ~0U is guaranteed
+			 * to be an invalid index; size limit is enforced in
+			 * resize()
+			 */
+			downpos = ~0U;
+
+		/* only used on break */
+		moveto = pos;
+
+#define nary_last(x) (((x) & (HEAP_NARY - 1)) == HEAP_NARY - 1)
+		if (downpos >= head->count
+		    || cmpfn(head->array[downpos], item) >= 0) {
+			/* not moving down; either at end or down is >= item */
+			if (nary_last(pos) || rghtpos >= head->count
+			    || cmpfn(head->array[rghtpos], item) >= 0)
+				/* not moving right either - got our spot */
+				break;
+
+			moveto = rghtpos;
+
+		/* else: downpos is valid and < item.  choose between down
+		 * or right (if the latter is an option) */
+		} else if (nary_last(pos) || cmpfn(head->array[rghtpos],
+						   head->array[downpos]) >= 0)
+			moveto = downpos;
+		else
+			moveto = rghtpos;
+#undef nary_last
+
+		head->array[pos] = head->array[moveto];
+		head->array[pos]->index = pos;
+		pos = moveto;
+	}
+
+	head->array[moveto] = item;
+	item->index = moveto;
+
+	heap_consistency_check(head, cmpfn, 0);
+}
+
+void typesafe_heap_pullup(struct heap_head *head, uint32_t pos,
+		struct heap_item *item,
+		int (*cmpfn)(const struct heap_item *a,
+			     const struct heap_item *b))
+{
+	uint32_t moveto;
+
+	while (pos != 0) {
+		if ((pos & (HEAP_NARY - 1)) == 0)
+			moveto = pos / HEAP_NARY - 1;
+		else
+			moveto = pos - 1;
+
+		if (cmpfn(head->array[moveto], item) <= 0)
+			break;
+
+		head->array[pos] = head->array[moveto];
+		head->array[pos]->index = pos;
+
+		pos = moveto;
+	}
+
+	head->array[pos] = item;
+	item->index = pos;
+
+	heap_consistency_check(head, cmpfn, 0);
 }

--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -490,7 +490,7 @@ macro_pure size_t prefix ## _count(struct prefix##_head *h)                    \
 #define DECLARE_SORTLIST_UNIQ(prefix, type, field, cmpfn)                      \
 	_DECLARE_SORTLIST(prefix, type, field, cmpfn, cmpfn)                   \
                                                                                \
-macro_inline type *prefix ## _find(const struct prefix##_head *h, const type *item)  \
+macro_inline type *prefix ## _find(struct prefix##_head *h, const type *item)  \
 {                                                                              \
 	struct ssort_item *sitem = h->sh.first;                                \
 	int cmpval = 0;                                                        \
@@ -598,7 +598,7 @@ macro_inline type *prefix ## _add(struct prefix##_head *h, type *item)         \
 	*np = &item->field.hi;                                                 \
 	return NULL;                                                           \
 }                                                                              \
-macro_inline type *prefix ## _find(const struct prefix##_head *h, const type *item)  \
+macro_inline type *prefix ## _find(struct prefix##_head *h, const type *item)  \
 {                                                                              \
 	if (!h->hh.tabshift)                                                   \
 		return NULL;                                                   \
@@ -788,7 +788,7 @@ macro_inline int prefix ## __cmp(const struct sskip_item *a,                   \
 	return cmpfn(container_of(a, type, field.si),                          \
 			container_of(b, type, field.si));                      \
 }                                                                              \
-macro_inline type *prefix ## _find(const struct prefix##_head *h, const type *item)  \
+macro_inline type *prefix ## _find(struct prefix##_head *h, const type *item)  \
 {                                                                              \
 	struct sskip_item *sitem = typesafe_skiplist_find(&h->sh,              \
 			&item->field.si, &prefix ## __cmp);                    \

--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -538,11 +538,8 @@ macro_inline void prefix ## _del(struct prefix##_head *h, type *item)          \
 }                                                                              \
 macro_inline type *prefix ## _pop(struct prefix##_head *h)                     \
 {                                                                              \
-	struct sskip_item *sitem = h->sh.hitem.next[0];                        \
-	if (!sitem)                                                            \
-		return NULL;                                                   \
-	typesafe_skiplist_del(&h->sh, sitem, cmpfn_uq);                        \
-	return container_of(sitem, type, field.si);                            \
+	struct sskip_item *sitem = typesafe_skiplist_pop(&h->sh);              \
+	return container_of_null(sitem, type, field.si);                       \
 }                                                                              \
 macro_pure type *prefix ## _first(struct prefix##_head *h)                     \
 {                                                                              \
@@ -636,6 +633,7 @@ extern void typesafe_skiplist_del(struct sskip_head *head,
 		struct sskip_item *item, int (*cmpfn)(
 			const struct sskip_item *a,
 			const struct sskip_item *b));
+extern struct sskip_item *typesafe_skiplist_pop(struct sskip_head *head);
 
 /* this needs to stay at the end because both files include each other.
  * the resolved order is typesafe.h before typerb.h

--- a/tests/lib/test_typelist.c
+++ b/tests/lib/test_typelist.c
@@ -32,6 +32,7 @@
 #include "atomlist.h"
 #include "memory.h"
 #include "monotime.h"
+#include "jhash.h"
 
 #include "tests/helpers/c/prng.h"
 
@@ -105,6 +106,12 @@ static void ts_end(void)
 #define TYPE HASH
 #include "test_typelist.h"
 
+#define TYPE HASH_collisions
+#define REALTYPE HASH
+#define SHITTY_HASH
+#include "test_typelist.h"
+#undef SHITTY_HASH
+
 #define TYPE SKIPLIST_UNIQ
 #include "test_typelist.h"
 
@@ -130,6 +137,7 @@ int main(int argc, char **argv)
 	test_SORTLIST_UNIQ();
 	test_SORTLIST_NONUNIQ();
 	test_HASH();
+	test_HASH_collisions();
 	test_SKIPLIST_UNIQ();
 	test_SKIPLIST_NONUNIQ();
 	test_RBTREE_UNIQ();

--- a/tests/lib/test_typelist.c
+++ b/tests/lib/test_typelist.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <assert.h>
+#include <arpa/inet.h>
 
 #define WNO_ATOMLIST_UNSAFE_FIND
 
@@ -33,6 +34,7 @@
 #include "memory.h"
 #include "monotime.h"
 #include "jhash.h"
+#include "sha256.h"
 
 #include "tests/helpers/c/prng.h"
 
@@ -49,6 +51,21 @@
 #define PREDECL(type, ...)	_PREDECL(type, __VA_ARGS__)
 #define _DECLARE(type, ...)	DECLARE_##type(__VA_ARGS__)
 #define DECLARE(type, ...)	_DECLARE(type, __VA_ARGS__)
+
+#define _S_LIST			0
+#define _S_DLIST		0
+#define _S_SORTLIST_UNIQ	1
+#define _S_SORTLIST_NONUNIQ	1
+#define _S_HASH			1
+#define _S_SKIPLIST_UNIQ	1
+#define _S_SKIPLIST_NONUNIQ	1
+#define _S_RBTREE_UNIQ		1
+#define _S_RBTREE_NONUNIQ	1
+#define _S_ATOMSORT_UNIQ	1
+#define _S_ATOMSORT_NONUNIQ	1
+
+#define _IS_SORTED(type)	_S_##type
+#define IS_SORTED(type)		_IS_SORTED(type)
 
 #define _U_SORTLIST_UNIQ	1
 #define _U_SORTLIST_NONUNIQ	0
@@ -97,6 +114,12 @@ static void ts_end(void)
 	printf("%7"PRId64"us  total\n", us);
 }
 
+#define TYPE LIST
+#include "test_typelist.h"
+
+#define TYPE DLIST
+#include "test_typelist.h"
+
 #define TYPE SORTLIST_UNIQ
 #include "test_typelist.h"
 
@@ -134,6 +157,8 @@ int main(int argc, char **argv)
 {
 	srandom(1);
 
+	test_LIST();
+	test_DLIST();
 	test_SORTLIST_UNIQ();
 	test_SORTLIST_NONUNIQ();
 	test_HASH();

--- a/tests/lib/test_typelist.c
+++ b/tests/lib/test_typelist.c
@@ -52,46 +52,32 @@
 #define _DECLARE(type, ...)	DECLARE_##type(__VA_ARGS__)
 #define DECLARE(type, ...)	_DECLARE(type, __VA_ARGS__)
 
-#define _S_LIST			0
-#define _S_DLIST		0
-#define _S_SORTLIST_UNIQ	1
-#define _S_SORTLIST_NONUNIQ	1
-#define _S_HASH			1
-#define _S_SKIPLIST_UNIQ	1
-#define _S_SKIPLIST_NONUNIQ	1
-#define _S_RBTREE_UNIQ		1
-#define _S_RBTREE_NONUNIQ	1
-#define _S_ATOMSORT_UNIQ	1
-#define _S_ATOMSORT_NONUNIQ	1
+#define T_SORTED		(1 << 0)
+#define T_UNIQ			(1 << 1)
+#define T_HASH			(1 << 2)
+#define T_HEAP			(1 << 3)
+#define T_ATOMIC		(1 << 4)
 
-#define _IS_SORTED(type)	_S_##type
-#define IS_SORTED(type)		_IS_SORTED(type)
+#define _T_LIST			(0)
+#define _T_DLIST		(0)
+#define _T_ATOMLIST		(0                 | T_ATOMIC)
+#define _T_HEAP			(T_SORTED          | T_HEAP)
+#define _T_SORTLIST_UNIQ	(T_SORTED | T_UNIQ)
+#define _T_SORTLIST_NONUNIQ	(T_SORTED)
+#define _T_HASH			(T_SORTED | T_UNIQ | T_HASH)
+#define _T_SKIPLIST_UNIQ	(T_SORTED | T_UNIQ)
+#define _T_SKIPLIST_NONUNIQ	(T_SORTED)
+#define _T_RBTREE_UNIQ		(T_SORTED | T_UNIQ)
+#define _T_RBTREE_NONUNIQ	(T_SORTED)
+#define _T_ATOMSORT_UNIQ	(T_SORTED | T_UNIQ | T_ATOMIC)
+#define _T_ATOMSORT_NONUNIQ	(T_SORTED          | T_ATOMIC)
 
-#define _U_SORTLIST_UNIQ	1
-#define _U_SORTLIST_NONUNIQ	0
-#define _U_HASH			1
-#define _U_SKIPLIST_UNIQ	1
-#define _U_SKIPLIST_NONUNIQ	0
-#define _U_RBTREE_UNIQ		1
-#define _U_RBTREE_NONUNIQ	0
-#define _U_ATOMSORT_UNIQ	1
-#define _U_ATOMSORT_NONUNIQ	0
-
-#define _IS_UNIQ(type)		_U_##type
-#define IS_UNIQ(type)		_IS_UNIQ(type)
-
-#define _H_SORTLIST_UNIQ	0
-#define _H_SORTLIST_NONUNIQ	0
-#define _H_HASH			1
-#define _H_SKIPLIST_UNIQ	0
-#define _H_SKIPLIST_NONUNIQ	0
-#define _H_RBTREE_UNIQ		0
-#define _H_RBTREE_NONUNIQ	0
-#define _H_ATOMSORT_UNIQ	0
-#define _H_ATOMSORT_NONUNIQ	0
-
-#define _IS_HASH(type)		_H_##type
-#define IS_HASH(type)		_IS_HASH(type)
+#define _T_TYPE(type)		_T_##type
+#define IS_SORTED(type)		(_T_TYPE(type) & T_SORTED)
+#define IS_UNIQ(type)		(_T_TYPE(type) & T_UNIQ)
+#define IS_HASH(type)		(_T_TYPE(type) & T_HASH)
+#define IS_HEAP(type)		(_T_TYPE(type) & T_HEAP)
+#define IS_ATOMIC(type)		(_T_TYPE(type) & T_ATOMIC)
 
 static struct timeval ref, ref0;
 
@@ -118,6 +104,12 @@ static void ts_end(void)
 #include "test_typelist.h"
 
 #define TYPE DLIST
+#include "test_typelist.h"
+
+#define TYPE ATOMLIST
+#include "test_typelist.h"
+
+#define TYPE HEAP
 #include "test_typelist.h"
 
 #define TYPE SORTLIST_UNIQ
@@ -159,6 +151,8 @@ int main(int argc, char **argv)
 
 	test_LIST();
 	test_DLIST();
+	test_ATOMLIST();
+	test_HEAP();
 	test_SORTLIST_UNIQ();
 	test_SORTLIST_NONUNIQ();
 	test_HASH();

--- a/tests/lib/test_typelist.py
+++ b/tests/lib/test_typelist.py
@@ -5,6 +5,8 @@ class TestTypelist(frrtest.TestMultiOut):
 
 TestTypelist.onesimple('LIST end')
 TestTypelist.onesimple('DLIST end')
+TestTypelist.onesimple('ATOMLIST end')
+TestTypelist.onesimple('HEAP end')
 TestTypelist.onesimple('SORTLIST_UNIQ end')
 TestTypelist.onesimple('SORTLIST_NONUNIQ end')
 TestTypelist.onesimple('HASH end')

--- a/tests/lib/test_typelist.py
+++ b/tests/lib/test_typelist.py
@@ -3,6 +3,8 @@ import frrtest
 class TestTypelist(frrtest.TestMultiOut):
     program = './test_typelist'
 
+TestTypelist.onesimple('LIST end')
+TestTypelist.onesimple('DLIST end')
 TestTypelist.onesimple('SORTLIST_UNIQ end')
 TestTypelist.onesimple('SORTLIST_NONUNIQ end')
 TestTypelist.onesimple('HASH end')

--- a/tests/lib/test_typelist.py
+++ b/tests/lib/test_typelist.py
@@ -6,6 +6,7 @@ class TestTypelist(frrtest.TestMultiOut):
 TestTypelist.onesimple('SORTLIST_UNIQ end')
 TestTypelist.onesimple('SORTLIST_NONUNIQ end')
 TestTypelist.onesimple('HASH end')
+TestTypelist.onesimple('HASH_collisions end')
 TestTypelist.onesimple('SKIPLIST_UNIQ end')
 TestTypelist.onesimple('SKIPLIST_NONUNIQ end')
 TestTypelist.onesimple('RBTREE_UNIQ end')


### PR DESCRIPTION
DLIST: double-linked list, for faster delete
HEAP: partially sorted (to be used for timers in thread.c)

some `const`-y and cast-y changes in lib/table.c

new batch of unit tests included

Fixes: #4278