### PR TITLE
tools: set ownership of syslog created log file to frr

### DIFF
--- a/tools/etc/rsyslog.d/45-frr.conf
+++ b/tools/etc/rsyslog.d/45-frr.conf
@@ -1,6 +1,12 @@
 # The lines below cause all FRR daemons and process to go
 # to /var/log/frr/frr.log, then drops the message so it does
 # not also go to /var/log/syslog, so the messages are not duplicated
+# Set file ownership of the frr.log file so frr can reference it from
+# CLI. Without this, log file is created with root ownership which can
+# cause issues.
+
+$FileOwner frr
+$FileGroup frrvty
 
 $outchannel frr_log,/var/log/frr/frr.log
 if  $programname == 'babeld' or


### PR DESCRIPTION
Problem reported with errors if "log file /var/log/frr/frr.log" is
entered and the file had been created by syslog with root ownership.
This fix sets the ownership to frr/frrvty so that the file can be
referenced and defined within frr if syslog created it.

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>
Ticket: CM-18981