### PR TITLE
[7.1] DLIST / BGP adv_fifo deletion fix

### DIFF
--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -23,7 +23,7 @@
 
 #include "lib/typesafe.h"
 
-PREDECL_LIST(bgp_adv_fifo)
+PREDECL_DLIST(bgp_adv_fifo)
 
 struct update_subgroup;
 
@@ -60,7 +60,7 @@ struct bgp_advertise {
 	struct bgp_path_info *pathi;
 };
 
-DECLARE_LIST(bgp_adv_fifo, struct bgp_advertise, fifo)
+DECLARE_DLIST(bgp_adv_fifo, struct bgp_advertise, fifo)
 
 /* BGP adjacency out.  */
 struct bgp_adj_out {

--- a/doc/developer/lists.rst
+++ b/doc/developer/lists.rst
@@ -19,6 +19,8 @@ For unsorted lists, the following implementations exist:
 
 - single-linked list with tail pointer (e.g. STAILQ in BSD)
 
+- double-linked list
+
 - atomic single-linked list with tail pointer
 
 
@@ -70,6 +72,7 @@ Available types:
 
    DECLARE_LIST
    DECLARE_ATOMLIST
+   DECLARE_DLIST
 
    DECLARE_SORTLIST_UNIQ
    DECLARE_SORTLIST_NONUNIQ
@@ -311,8 +314,8 @@ are several functions exposed to insert data:
 
 .. c:function:: DECLARE_XXX(Z, type, field)
 
-   :param listtype XXX: ``LIST`` or ``ATOMLIST`` to select a data structure
-      implementation.
+   :param listtype XXX: ``LIST``, ``DLIST`` or ``ATOMLIST`` to select a data
+      structure implementation.
    :param token Z: Gives the name prefix that is used for the functions
       created for this instantiation.  ``DECLARE_XXX(foo, ...)``
       gives ``struct foo_item``, ``foo_add_head()``, ``foo_count()``, etc.  Note


### PR DESCRIPTION
This fixes #4278 for the 7.1 branch by cherrypicking 2 commits from #4373.