### PR TITLE
bgpd: disable deleting default instance if vrf instances exist

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1129,9 +1129,24 @@ DEFUN (no_router_bgp,
 		}
 
 		if (bgp->l3vni) {
-			vty_out(vty, "%% Please unconfigure l3vni %u",
+			vty_out(vty, "%% Please unconfigure l3vni %u\n",
 				bgp->l3vni);
 			return CMD_WARNING_CONFIG_FAILED;
+		}
+
+		/* Cannot delete default instance if vrf instances exist */
+		if (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT) {
+			struct listnode *node;
+			struct bgp *tmp_bgp;
+
+			for (ALL_LIST_ELEMENTS_RO(bm->bgp, node, tmp_bgp)) {
+				if (tmp_bgp->inst_type
+				    == BGP_INSTANCE_TYPE_VRF) {
+					vty_out(vty,
+						"%% Cannot delete default BGP instance. Dependent VRF instances exist\n");
+					return CMD_WARNING_CONFIG_FAILED;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Problem reported with deleting the default BGP instance where there
are vrf instances that depend on it (like l2vpn evpn vrfs).  Since
importing for vrf route-leaking also requires the existence of the
default instance, disallowing deleting the BGP default instance if
anyt vrf instance is also defined.

Signed-off-by: Don Slice <dslice@cumulusnetworks.com>