### PR TITLE
zebra: Clean up BGP EVPN configuration when the client, BGPD, goes down

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -55,6 +55,7 @@
 #include "zebra/zebra_netns_notify.h"
 #include "zebra/zebra_rnh.h"
 #include "zebra/zebra_pbr.h"
+#include "zebra/zebra_vxlan.h"
 
 #if defined(HANDLE_NETLINK_FUZZING)
 #include "zebra/kernel_netlink.h"
@@ -452,6 +453,9 @@ int main(int argc, char **argv)
 
 	/* RNH init */
 	zebra_rnh_init();
+
+	/* Config handler Init */
+	zebra_evpn_init();
 
 	/* Error init */
 	zebra_error_init();

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -212,6 +212,7 @@ extern int zebra_vxlan_clear_dup_detect_vni_all(struct vty *vty,
 extern int zebra_vxlan_clear_dup_detect_vni(struct vty *vty,
 					    struct zebra_vrf *zvrf,
 					    vni_t vni);
+extern void zebra_evpn_init(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When BGP daemon is down, Clean up its configuration state from zebra.
When the BGP daemon is up again, it will push its configuration to zebra

bgpd: prevent duplicate advertise-all-vni update to zebra.

Signed-off-by: Kishore Aramalla karamalla@vmware.com