### PR TITLE
lib: rename begins_with, add frrstr_endswith

### DIFF
--- a/lib/frrstr.c
+++ b/lib/frrstr.c
@@ -178,7 +178,7 @@ char *frrstr_replace(const char *str, const char *find, const char *replace)
 	return nustr;
 }
 
-bool begins_with(const char *str, const char *prefix)
+bool frrstr_startswith(const char *str, const char *prefix)
 {
 	if (!str || !prefix)
 		return false;
@@ -190,6 +190,20 @@ bool begins_with(const char *str, const char *prefix)
 		return false;
 
 	return strncmp(str, prefix, lenprefix) == 0;
+}
+
+bool frrstr_endswith(const char *str, const char *suffix)
+{
+	if (!str || !suffix)
+		return false;
+
+	size_t lenstr = strlen(str);
+	size_t lensuffix = strlen(suffix);
+
+	if (lensuffix > lenstr)
+		return false;
+
+	return strncmp(&str[lenstr - lensuffix], suffix, lensuffix) == 0;
 }
 
 int all_digit(const char *str)

--- a/lib/frrstr.h
+++ b/lib/frrstr.h
@@ -109,6 +109,7 @@ void frrstr_strvec_free(vector v);
  *    the replacement on 'str'. This must be freed by the caller.
  */
 char *frrstr_replace(const char *str, const char *find, const char *replace);
+
 /*
  * Prefix match for string.
  *
@@ -119,9 +120,23 @@ char *frrstr_replace(const char *str, const char *find, const char *replace);
  *    prefix to look for
  *
  * Returns:
- *   true str starts with prefix, false otherwise
+ *   true if str starts with prefix, false otherwise
  */
-bool begins_with(const char *str, const char *prefix);
+bool frrstr_startswith(const char *str, const char *prefix);
+
+/*
+ * Suffix match for string.
+ *
+ * str
+ *    string to check for suffix match
+ *
+ * suffix
+ *    suffix to look for
+ *
+ * Returns:
+ *   true if str ends with suffix, false otherwise
+ */
+bool frrstr_endswith(const char *str, const char *suffix);
 
 /*
  * Check the string only contains digit characters.

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3347,7 +3347,7 @@ static void vtysh_update_all_instances(struct vtysh_client *head_client)
 	dir = opendir(vtydir);
 	if (dir) {
 		while ((file = readdir(dir)) != NULL) {
-			if (begins_with(file->d_name, "ospfd-")
+			if (frrstr_startswith(file->d_name, "ospfd-")
 			    && ends_with(file->d_name, ".vty")) {
 				if (n == MAXIMUM_INSTANCES) {
 					fprintf(stderr,


### PR DESCRIPTION
* Change 'begins_with' to 'frrstr_startswith' for consistency
* Add suffix checker, frrstr_endswith()
* Update vtysh to use the new function

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>