### PR TITLE
fix centos7 build - set SPHINXBUILD to match centos7 yum installed package

### DIFF
--- a/doc/developer/building-frr-for-centos7.rst
+++ b/doc/developer/building-frr-for-centos7.rst
@@ -70,7 +70,8 @@ an example.)
         --disable-ldpd \
         --enable-fpm \
         --with-pkg-git-version \
-        --with-pkg-extra-version=-MyOwnFRRVersion
+        --with-pkg-extra-version=-MyOwnFRRVersion \
+	SPHINXBUILD=/usr/bin/sphinx-build
     make
     make check
     sudo make install


### PR DESCRIPTION
fixes make error seen when following instructions:
```
  SPHINX   doc/user/_build/.doctrees/environment.pickle
/bin/sh: line 2: sphinx-build2.7: command not found
make[1]: *** [doc/user/_build/.doctrees/environment.pickle] Error 127

```