### PR TITLE
isisd: del routes when area is unconfigured

### DIFF
--- a/isisd/isis_route.c
+++ b/isisd/isis_route.c
@@ -543,7 +543,8 @@ void isis_route_verify_merge(struct isis_area *area,
 						ISIS_ROUTE_FLAG_ZEBRA_SYNCED
 					);
 					continue;
-				} else {
+				} else if (CHECK_FLAG(rinfo->flag,
+						      ISIS_ROUTE_FLAG_ACTIVE)) {
 					/* Clear the ZEBRA_SYNCED flag on the L1
 					 * route when L2 wins, otherwise L1
 					 * won't get reinstalled when it
@@ -553,6 +554,11 @@ void isis_route_verify_merge(struct isis_area *area,
 						mrinfo->flag,
 						ISIS_ROUTE_FLAG_ZEBRA_SYNCED
 					);
+				} else if (
+					CHECK_FLAG(
+						mrinfo->flag,
+						ISIS_ROUTE_FLAG_ZEBRA_SYNCED)) {
+					continue;
 				}
 			}
 			mrnode->info = rnode->info;

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -272,7 +272,7 @@ int isis_area_destroy(const char *area_tag)
 	lsp_db_fini(&area->lspdb[1]);
 
 	/* invalidate and verify to delete all routes from zebra */
-	isis_area_invalidate_routes(area, ISIS_LEVEL1 & ISIS_LEVEL2);
+	isis_area_invalidate_routes(area, area->is_type);
 	isis_area_verify_routes(area);
 
 	spftree_area_del(area);


### PR DESCRIPTION
attempt to fix #4399

Not at all sure that this is the correct fix in `isis_route_verify_merge`, 
but I figured I would at least kick off the process. 

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>