### PR TITLE
bgpd: fix debug to have proper nhop display

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2472,7 +2472,7 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 
 	if (bgp_debug_zebra(NULL)) {
 		zlog_debug(
-			"installing evpn prefix %s as ip prefix %s in vrf %s",
+			"import evpn prefix %s as ip prefix %s in vrf %s",
 			prefix2str(evp, buf, sizeof(buf)),
 			prefix2str(pp, buf1, sizeof(buf)),
 			vrf_id_to_name(bgp_vrf->vrf_id));

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1435,15 +1435,29 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 		for (i = 0; i < api.nexthop_num; i++) {
 			api_nh = &api.nexthops[i];
 
-			if (api_nh->type == NEXTHOP_TYPE_IFINDEX)
+			switch (api_nh->type) {
+			case NEXTHOP_TYPE_IFINDEX:
 				nh_buf[0] = '\0';
-			else {
-				if (api_nh->type == NEXTHOP_TYPE_IPV4)
-					nh_family = AF_INET;
-				else
-					nh_family = AF_INET6;
+				break;
+			case NEXTHOP_TYPE_IPV4:
+			case NEXTHOP_TYPE_IPV4_IFINDEX:
+				nh_family = AF_INET;
 				inet_ntop(nh_family, &api_nh->gate, nh_buf,
 					  sizeof(nh_buf));
+				break;
+			case NEXTHOP_TYPE_IPV6:
+			case NEXTHOP_TYPE_IPV6_IFINDEX:
+				nh_family = AF_INET6;
+				inet_ntop(nh_family, &api_nh->gate, nh_buf,
+					  sizeof(nh_buf));
+				break;
+			case NEXTHOP_TYPE_BLACKHOLE:
+				strlcpy(nh_buf, "blackhole", sizeof(nh_buf));
+				break;
+			default:
+				/* Note: add new nexthop case */
+				assert(0);
+				break;
 			}
 
 			label_buf[0] = '\0';


### PR DESCRIPTION
Display nexthop based on route type.


Testing Done:

evpn route:
*  [2]:[0]:[0]:[48]:[aa:aa:aa:aa:01:1a]:[32]:[45.0.2.111]
    36.0.0.25              0 64000 5560 i

old:
BGP: Tx route add VRF 46 45.0.2.111/32 metric 0 tag 0 flags 0x1409 nhnum 1
BGP:   nhop [1]: 2400:1d:: if 50 VRF 46

New:
BGP: import evpn prefix [2]:[aa:aa:aa:aa:01:1a]:[45.0.2.111]/224 as
ip prefix 45.0.2.111/32 in vrf vrf1

BGP: bgp_zebra_announce: p=45.0.2.111/32, bgp_is_valid_label: 2
BGP: Tx route add VRF 46 45.0.2.111/32 metric 0 tag 0 flags 0x1409 nhnum 1
BGP:   nhop [1]: 36.0.0.25 if 50 VRF 46

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>