### PR TITLE
[7.0] snapcraft: Add libdb5.3 dependency

### DIFF
--- a/snapcraft/snapcraft.yaml.in
+++ b/snapcraft/snapcraft.yaml.in
@@ -308,6 +308,7 @@ parts:
            - libc-ares2
            - libatm1
            - libprotobuf-c1
+           - libdb5.3
         plugin: autotools
         source: ../frr-@PACKAGE_VERSION@.tar.gz
         configflags:


### PR DESCRIPTION
New dependency which needs to be part of the snap package

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>