### PR TITLE
bgpd: Update an fsm debug message

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -949,9 +949,15 @@ void bgp_fsm_change_status(struct peer *peer, int status)
 	else if ((peer->status == Established) && (status != Established))
 		bgp->established_peers--;
 
-	if (BGP_DEBUG(neighbor_events, NEIGHBOR_EVENTS))
-		zlog_debug("%s : vrf %u, established_peers %u", __func__,
-				bgp->vrf_id, bgp->established_peers);
+	if (bgp_debug_neighbor_events(peer)) {
+		struct vrf *vrf = vrf_lookup_by_id(bgp->vrf_id);
+
+		zlog_debug("%s : vrf %s(%u), Status: %s established_peers %u", __func__,
+			   vrf ? vrf->name : "Unknown", bgp->vrf_id,
+			   lookup_msg(bgp_status_msg, status, NULL),
+			   bgp->established_peers);
+	}
+
 	/* Set to router ID to the value provided by RIB if there are no peers
 	 * in the established state and peer count did not change
 	 */


### PR DESCRIPTION
When debugging I was having a hard time correlating some data and noticed that
a particular debug was not being very useful.

Signed-off-by: Donald Sharp <sharpd@cumulusnstworks.com>