### PR TITLE
zebra: Move multicast mode to being a property of the router

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -340,19 +340,6 @@ extern void route_entry_copy_nexthops(struct route_entry *re,
 extern void _route_entry_dump(const char *func, union prefixconstptr pp,
 			      union prefixconstptr src_pp,
 			      const struct route_entry *re);
-/* RPF lookup behaviour */
-enum multicast_mode {
-	MCAST_NO_CONFIG = 0,  /* MIX_MRIB_FIRST, but no show in config write */
-	MCAST_MRIB_ONLY,      /* MRIB only */
-	MCAST_URIB_ONLY,      /* URIB only */
-	MCAST_MIX_MRIB_FIRST, /* MRIB, if nothing at all then URIB */
-	MCAST_MIX_DISTANCE,   /* MRIB & URIB, lower distance wins */
-	MCAST_MIX_PFXLEN,     /* MRIB & URIB, longer prefix wins */
-			      /* on equal value, MRIB wins for last 2 */
-};
-
-extern void multicast_mode_ipv4_set(enum multicast_mode mode);
-extern enum multicast_mode multicast_mode_ipv4_get(void);
 
 extern void rib_lookup_and_dump(struct prefix_ipv4 *p, vrf_id_t vrf_id);
 extern void rib_lookup_and_pushup(struct prefix_ipv4 *p, vrf_id_t vrf_id);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -108,10 +108,6 @@ static const struct {
 	/* no entry/default: 150 */
 };
 
-/* RPF lookup behaviour */
-static enum multicast_mode ipv4_multicast_mode = MCAST_NO_CONFIG;
-
-
 static void __attribute__((format(printf, 5, 6)))
 _rnode_zlog(const char *_func, vrf_id_t vrf_id, struct route_node *rn,
 	    int priority, const char *msgfmt, ...)
@@ -404,7 +400,7 @@ struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
 	struct route_node *m_rn = NULL, *u_rn = NULL;
 	union g_addr gaddr = {.ipv4 = addr};
 
-	switch (ipv4_multicast_mode) {
+	switch (zrouter.ipv4_multicast_mode) {
 	case MCAST_MRIB_ONLY:
 		return rib_match(AFI_IP, SAFI_MULTICAST, vrf_id, &gaddr,
 				 rn_out);
@@ -454,19 +450,6 @@ struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
 			   re == ure ? "URIB" : re == mre ? "MRIB" : "none");
 	}
 	return re;
-}
-
-void multicast_mode_ipv4_set(enum multicast_mode mode)
-{
-	if (IS_ZEBRA_DEBUG_RIB)
-		zlog_debug("%s: multicast lookup mode set (%d)", __func__,
-			   mode);
-	ipv4_multicast_mode = mode;
-}
-
-enum multicast_mode multicast_mode_ipv4_get(void)
-{
-	return ipv4_multicast_mode;
 }
 
 struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *p, vrf_id_t vrf_id)

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -29,9 +29,12 @@
 #include "zebra_pbr.h"
 #include "zebra_vxlan.h"
 #include "zebra_mlag.h"
+#include "zebra_nhg.h"
+#include "debug.h"
 
 struct zebra_router zrouter = {
 	.multipath_num = MULTIPATH_NUM,
+	.ipv4_multicast_mode = MCAST_NO_CONFIG,
 };
 
 static inline int
@@ -185,6 +188,19 @@ uint32_t zebra_router_get_next_sequence(void)
 	return 1
 	       + atomic_fetch_add_explicit(&zrouter.sequence_num, 1,
 					   memory_order_relaxed);
+}
+
+void multicast_mode_ipv4_set(enum multicast_mode mode)
+{
+	if (IS_ZEBRA_DEBUG_RIB)
+		zlog_debug("%s: multicast lookup mode set (%d)", __func__,
+			   mode);
+	zrouter.ipv4_multicast_mode = mode;
+}
+
+enum multicast_mode multicast_mode_ipv4_get(void)
+{
+	return zrouter.ipv4_multicast_mode;
 }
 
 void zebra_router_terminate(void)

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -50,6 +50,17 @@ RB_HEAD(zebra_router_table_head, zebra_router_table);
 RB_PROTOTYPE(zebra_router_table_head, zebra_router_table,
 	     zebra_router_table_entry, zebra_router_table_entry_compare)
 
+/* RPF lookup behaviour */
+enum multicast_mode {
+	MCAST_NO_CONFIG = 0,  /* MIX_MRIB_FIRST, but no show in config write */
+	MCAST_MRIB_ONLY,      /* MRIB only */
+	MCAST_URIB_ONLY,      /* URIB only */
+	MCAST_MIX_MRIB_FIRST, /* MRIB, if nothing at all then URIB */
+	MCAST_MIX_DISTANCE,   /* MRIB & URIB, lower distance wins */
+	MCAST_MIX_PFXLEN,     /* MRIB & URIB, longer prefix wins */
+			      /* on equal value, MRIB wins for last 2 */
+};
+
 struct zebra_mlag_info {
 	/* Role this zebra router is playing */
 	enum mlag_role role;
@@ -113,6 +124,9 @@ struct zebra_router {
 
 	uint32_t multipath_num;
 
+	/* RPF Lookup behavior */
+	enum multicast_mode ipv4_multicast_mode;
+
 	/*
 	 * Time for when we sweep the rib from old routes
 	 */
@@ -152,6 +166,10 @@ static inline struct zebra_vrf *zebra_vrf_get_evpn(void)
 	return zrouter.evpn_vrf ? zrouter.evpn_vrf
 			        : zebra_vrf_lookup_by_id(VRF_DEFAULT);
 }
+
+extern void multicast_mode_ipv4_set(enum multicast_mode mode);
+
+extern enum multicast_mode multicast_mode_ipv4_get(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The multicast mode enum was a global static in zebra_rib.c
it does not belong there, it belongs in zebra_router, moving.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>