### PR TITLE
bgpd: [7.0] Show FQDN in `show [ip] bgp` output

### DIFF
--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r1/bgpd.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r1/bgpd.conf
@@ -1,0 +1,4 @@
+router bgp 65000
+  neighbor 192.168.255.2 remote-as 65001
+  address-family ipv4 unicast
+    redistribute connected

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r1/zebra.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r1/zebra.conf
@@ -1,0 +1,9 @@
+!
+interface lo
+ ip address 172.16.255.254/32
+!
+interface r1-eth0
+ ip address 192.168.255.1/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r2/bgpd.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r2/bgpd.conf
@@ -1,0 +1,5 @@
+router bgp 65001
+  bgp default show-hostname
+  neighbor 192.168.255.1 remote-as 65000
+  address-family ipv4 unicast
+    redistribute connected

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/r2/zebra.conf
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/r2/zebra.conf
@@ -1,0 +1,9 @@
+!
+interface lo
+ ip address 172.16.255.253/32
+!
+interface r2-eth0
+ ip address 192.168.255.2/24
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_show_ip_bgp_fqdn/test_bgp_show_ip_bgp_fqdn.py
+++ b/tests/topotests/bgp_show_ip_bgp_fqdn/test_bgp_show_ip_bgp_fqdn.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_show_ip_bgp_fqdn.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2019 by
+# Network Device Education Foundation, Inc. ("NetDEF")
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+test_bgp_show_ip_bgp_fqdn.py:
+Test if FQND is visible in `show [ip] bgp` output if
+`bgp default show-hostname` is toggled.
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+class TemplateTopo(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        for routern in range(1, 3):
+            tgen.add_router('r{}'.format(routern))
+
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
+
+def setup_module(mod):
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA,
+            os.path.join(CWD, '{}/zebra.conf'.format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP,
+            os.path.join(CWD, '{}/bgpd.conf'.format(rname))
+        )
+
+    tgen.start_router()
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_bgp_maximum_prefix_invalid():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _bgp_converge(router, neighbor):
+        cmd = "show ip bgp neighbor {0} json".format(neighbor)
+        while True:
+            output = json.loads(tgen.gears[router].vtysh_cmd(cmd))
+            if output[neighbor]['bgpState'] == 'Established':
+                time.sleep(3)
+                return True
+
+    def _bgp_show_nexthop(router, prefix):
+        cmd = "show ip bgp json"
+        output = json.loads(tgen.gears[router].vtysh_cmd(cmd))
+        for nh in output['routes'][prefix][0]['nexthops']:
+            if 'fqdn' in nh:
+                return 'fqdn'
+        return 'ip'
+
+    if _bgp_converge('r2', '192.168.255.1'):
+        assert _bgp_show_nexthop('r2', '172.16.255.254/32') == 'fqdn'
+
+    if _bgp_converge('r1', '192.168.255.2'):
+        assert _bgp_show_nexthop('r1', '172.16.255.253/32') == 'ip'
+
+if __name__ == '__main__':
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
We already show this information in `show [ip] bgp <prefix`, thus why don't
show it in global output. It's very handy when using at scale and to see
the whole picture instead of resolving neighbor manually.

It will show FQDN only if `bgp default show-hostname` is toggled.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>