### PR TITLE
lib: crash when FRR hostname length > 80 chars

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1962,7 +1962,15 @@ DEFUN (config_hostname,
 	struct cmd_token *word = argv[1];
 
 	if (!isalnum((int)word->arg[0])) {
-		vty_out(vty, "Please specify string starting with alphabet\n");
+		vty_out(vty,
+		    "Please specify string starting with alphabet or number\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	/* With reference to RFC 1123 Section 2.1 */
+	if (strlen(word->arg) > HOSTNAME_LEN) {
+		vty_out(vty, "Hostname length should be less than %d chars\n",
+			HOSTNAME_LEN);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -37,6 +37,17 @@ extern "C" {
 DECLARE_MTYPE(HOST)
 DECLARE_MTYPE(COMPLETION)
 
+/*
+ * From RFC 1123 (Requirements for Internet Hosts), Section 2.1 on hostnames:
+ * One aspect of host name syntax is hereby changed: the restriction on
+ * the first character is relaxed to allow either a letter or a digit.
+ * Host software MUST support this more liberal syntax.
+ *
+ * Host software MUST handle host names of up to 63 characters and
+ * SHOULD handle host names of up to 255 characters.
+ */
+#define HOSTNAME_LEN   255
+
 /* Host configuration variable */
 struct host {
 	/* Host name of this router. */

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3429,7 +3429,7 @@ void vtysh_readline_init(void)
 
 char *vtysh_prompt(void)
 {
-	static char buf[100];
+	static char buf[512];
 
 	snprintf(buf, sizeof buf, cmd_prompt(vty->node), cmd_hostname_get());
 	return buf;

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -521,10 +521,10 @@ int vtysh_read_config(const char *config_default_dir)
  */
 void vtysh_config_write(void)
 {
-	char line[81];
+	char line[512];
 
 	if (cmd_hostname_get()) {
-		sprintf(line, "hostname %s", cmd_hostname_get());
+		snprintf(line, sizeof(line), "hostname %s", cmd_hostname_get());
 		vtysh_config_parse_line(NULL, line);
 	}
 


### PR DESCRIPTION
Although the RFC states hostname length should be < 255 chars, FRR allows infinite length technically. However, when you try to set a hostname > 80 chars, you would immediately notice a crash.

RCA: Crash due to buffer overflow. Large buffer sprintf'd into smaller buffer. Usage of sprintf function instead of snprintf which is safer.

Signed-off-by: Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>