### PR TITLE
Switch over to `-N FOO` adding FOO to the various directories/files we open up

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -68,7 +68,7 @@ const unsigned char ones[16] =
     {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
-static char state_file[512];
+static char state_file[1024];
 
 unsigned char protocol_group[16]; /* babel's link-local multicast address */
 int protocol_port;                /* babel's port */

--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -68,7 +68,7 @@ const unsigned char ones[16] =
     {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
-static const char *state_file = DAEMON_VTY_DIR "/babel-state";
+static char state_file[512];
 
 unsigned char protocol_group[16]; /* babel's link-local multicast address */
 int protocol_port;                /* babel's port */
@@ -186,6 +186,9 @@ main(int argc, char **argv)
 	    break;
 	  }
     }
+
+    snprintf(state_file, sizeof(state_file), "%s/%s",
+	     frr_vtydir, "babel-state");
 
     /* create the threads handler */
     master = frr_init ();

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -158,7 +158,8 @@ static void bg_init(void)
 
 int main(int argc, char *argv[])
 {
-	const char *ctl_path = BFDD_CONTROL_SOCKET;
+	char ctl_path[512];
+	bool ctlsockused = false;
 	int opt;
 
 	/* Initialize system sockets. */
@@ -168,6 +169,8 @@ int main(int argc, char *argv[])
 	frr_opt_add("", longopts,
 		    "      --bfdctl       Specify bfdd control socket\n");
 
+	snprintf(ctl_path, sizeof(ctl_path), BFDD_CONTROL_SOCKET,
+		 "", "");
 	while (true) {
 		opt = frr_getopt(argc, argv, NULL);
 		if (opt == EOF)
@@ -175,7 +178,8 @@ int main(int argc, char *argv[])
 
 		switch (opt) {
 		case OPTION_CTLSOCK:
-			ctl_path = optarg;
+			strlcpy(ctl_path, optarg, sizeof(ctl_path));
+			ctlsockused = true;
 			break;
 
 		default:
@@ -183,6 +187,10 @@ int main(int argc, char *argv[])
 			break;
 		}
 	}
+
+	if (bfdd_di.pathspace && !ctlsockused)
+		snprintf(ctl_path, sizeof(ctl_path), BFDD_CONTROL_SOCKET,
+			 "/", bfdd_di.pathspace);
 
 #if 0 /* TODO add support for JSON configuration files. */
 	parse_config(conf);

--- a/configure.ac
+++ b/configure.ac
@@ -2202,7 +2202,7 @@ fi
 AC_MSG_RESULT([${frr_statedir}])
 AC_SUBST([frr_statedir])
 
-AC_DEFINE_UNQUOTED([LDPD_SOCKET], ["$frr_statedir/ldpd.sock"], [ldpd control socket])
+AC_DEFINE_UNQUOTED([LDPD_SOCKET], ["$frr_statedir%s%s/ldpd.sock"], [ldpd control socket])
 AC_DEFINE_UNQUOTED([ZEBRA_SERV_PATH], ["$frr_statedir%s%s/zserv.api"], [zebra api socket])
 AC_DEFINE_UNQUOTED([BFDD_CONTROL_SOCKET], ["$frr_statedir%s%s/bfdd.sock"], [bfdd control socket])
 AC_DEFINE_UNQUOTED([DAEMON_VTY_DIR], ["$frr_statedir"], [daemon vty directory])

--- a/configure.ac
+++ b/configure.ac
@@ -2203,7 +2203,7 @@ AC_MSG_RESULT([${frr_statedir}])
 AC_SUBST([frr_statedir])
 
 AC_DEFINE_UNQUOTED([LDPD_SOCKET], ["$frr_statedir/ldpd.sock"], [ldpd control socket])
-AC_DEFINE_UNQUOTED([ZEBRA_SERV_PATH], ["$frr_statedir/zserv.api"], [zebra api socket])
+AC_DEFINE_UNQUOTED([ZEBRA_SERV_PATH], ["$frr_statedir%s%s/zserv.api"], [zebra api socket])
 AC_DEFINE_UNQUOTED([BFDD_CONTROL_SOCKET], ["$frr_statedir/bfdd.sock"], [bfdd control socket])
 AC_DEFINE_UNQUOTED([DAEMON_VTY_DIR], ["$frr_statedir"], [daemon vty directory])
 AC_DEFINE_UNQUOTED([DAEMON_DB_DIR], ["$frr_statedir"], [daemon database directory])

--- a/configure.ac
+++ b/configure.ac
@@ -2204,7 +2204,7 @@ AC_SUBST([frr_statedir])
 
 AC_DEFINE_UNQUOTED([LDPD_SOCKET], ["$frr_statedir/ldpd.sock"], [ldpd control socket])
 AC_DEFINE_UNQUOTED([ZEBRA_SERV_PATH], ["$frr_statedir%s%s/zserv.api"], [zebra api socket])
-AC_DEFINE_UNQUOTED([BFDD_CONTROL_SOCKET], ["$frr_statedir/bfdd.sock"], [bfdd control socket])
+AC_DEFINE_UNQUOTED([BFDD_CONTROL_SOCKET], ["$frr_statedir%s%s/bfdd.sock"], [bfdd control socket])
 AC_DEFINE_UNQUOTED([DAEMON_VTY_DIR], ["$frr_statedir"], [daemon vty directory])
 AC_DEFINE_UNQUOTED([DAEMON_DB_DIR], ["$frr_statedir"], [daemon database directory])
 

--- a/configure.ac
+++ b/configure.ac
@@ -2205,7 +2205,7 @@ AC_SUBST([frr_statedir])
 AC_DEFINE_UNQUOTED([LDPD_SOCKET], ["$frr_statedir%s%s/ldpd.sock"], [ldpd control socket])
 AC_DEFINE_UNQUOTED([ZEBRA_SERV_PATH], ["$frr_statedir%s%s/zserv.api"], [zebra api socket])
 AC_DEFINE_UNQUOTED([BFDD_CONTROL_SOCKET], ["$frr_statedir%s%s/bfdd.sock"], [bfdd control socket])
-AC_DEFINE_UNQUOTED([DAEMON_VTY_DIR], ["$frr_statedir"], [daemon vty directory])
+AC_DEFINE_UNQUOTED([DAEMON_VTY_DIR], ["$frr_statedir%s%s"], [daemon vty directory])
 AC_DEFINE_UNQUOTED([DAEMON_DB_DIR], ["$frr_statedir"], [daemon database directory])
 
 dnl autoconf does this, but it does it too late...

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -479,6 +479,12 @@ These options apply to all |PACKAGE_NAME| daemons.
 
    Set the user and group to run as.
 
+.. option:: -N <namespace>
+
+   Set the namespace that the daemon will run in.  A "/<namespace>" will
+   be added to all files that use the statedir.  If you have "/var/run/frr"
+   as the default statedir then it will become "/var/run/frr/<namespace>".
+
 .. option:: -v, --version
 
    Print program version.

--- a/doc/user/bfd.rst
+++ b/doc/user/bfd.rst
@@ -47,6 +47,9 @@ may also be specified (:ref:`common-invocation-options`).
 
       #define BFDD_CONTROL_SOCKET "|INSTALL_PREFIX_STATE|/bfdd.sock"
 
+   This option overrides the location addition that the -N option provides
+   to the bfdd.sock
+
 
 .. _bfd-commands:
 

--- a/doc/user/ldpd.rst
+++ b/doc/user/ldpd.rst
@@ -24,6 +24,12 @@ Running Ldpd
 The *ldpd* daemon can be invoked with any of the common
 options (:ref:`common-invocation-options`).
 
+..option:: --ctl_socket
+
+   This option allows you to override the path to the ldpd.sock file
+   used to control this daemon.  If specified this option overrides
+   the -N option path addition.
+
 The *zebra* daemon must be running before *ldpd* is invoked.
 
 Configuration of *ldpd* is done in its configuration file

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -58,6 +58,12 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 
    .. seealso:: :ref:`zebra-vrf`
 
+.. option:: -z <path_to_socket>, --socket <path_to_socket>
+
+   If this option is supplied on the cli, the path to the zebra
+   control socket(zapi), is used.  This option overrides a -N <namespace>
+   option if handed to it on the cli.
+
 .. option:: --v6-rr-semantics
 
    The linux kernel is receiving the ability to use the same route

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -116,7 +116,7 @@ struct zebra_privs_t ldpd_privs =
 };
 
 /* CTL Socket path */
-char ctl_sock_path[MAXPATHLEN] = LDPD_SOCKET;
+char ctl_sock_path[MAXPATHLEN];
 
 /* LDPd options. */
 #define OPTION_CTLSOCK 1001
@@ -219,6 +219,10 @@ main(int argc, char *argv[])
 	int			 pipe_parent2lde[2], pipe_parent2lde_sync[2];
 	char			*ctl_sock_name;
 	struct thread           *thread = NULL;
+	bool                    ctl_sock_used = false;
+
+	snprintf(ctl_sock_path, sizeof(ctl_sock_path), LDPD_SOCKET,
+		 "", "");
 
 	ldpd_process = PROC_MAIN;
 	log_procname = log_procnames[ldpd_process];
@@ -244,6 +248,7 @@ main(int argc, char *argv[])
 		case 0:
 			break;
 		case OPTION_CTLSOCK:
+			ctl_sock_used = true;
 			ctl_sock_name = strrchr(LDPD_SOCKET, '/');
 			if (ctl_sock_name)
 				/* skip '/' */
@@ -276,6 +281,10 @@ main(int argc, char *argv[])
 			break;
 		}
 	}
+
+	if (ldpd_di.pathspace && !ctl_sock_used)
+		snprintf(ctl_sock_path, sizeof(ctl_sock_path), LDPD_SOCKET,
+			 "/", ldpd_di.pathspace);
 
 	strlcpy(init.user, ldpd_privs.user, sizeof(init.user));
 	strlcpy(init.group, ldpd_privs.group, sizeof(init.group));

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -179,7 +179,7 @@ bool frr_zclient_addr(struct sockaddr_storage *sa, socklen_t *sa_len,
 	memset(sa, 0, sizeof(*sa));
 
 	if (!path)
-		path = ZEBRA_SERV_PATH;
+		path = frr_zclientpath;
 
 	if (!strncmp(path, ZAPI_TCP_PATHNAME, strlen(ZAPI_TCP_PATHNAME))) {
 		/* note: this functionality is disabled at bottom */
@@ -319,8 +319,6 @@ void frr_preinit(struct frr_daemon_info *daemon, int argc, char **argv)
 	strlcpy(frr_protoname, di->logname, sizeof(frr_protoname));
 	strlcpy(frr_protonameinst, di->logname, sizeof(frr_protonameinst));
 
-	strlcpy(frr_zclientpath, ZEBRA_SERV_PATH, sizeof(frr_zclientpath));
-
 	di->cli_mode = FRR_CLI_CLASSIC;
 }
 
@@ -407,6 +405,9 @@ static int frr_opt(int opt)
 			break;
 		}
 		di->pathspace = optarg;
+
+		snprintf(frr_zclientpath, sizeof(frr_zclientpath),
+			 ZEBRA_SERV_PATH, "/", di->pathspace);
 		break;
 #ifdef HAVE_SQLITE3
 	case OPTION_DB_FILE:
@@ -511,6 +512,9 @@ int frr_getopt(int argc, char *const argv[], int *longindex)
 {
 	int opt;
 	int lidx;
+
+	snprintf(frr_zclientpath, sizeof(frr_zclientpath),
+		 ZEBRA_SERV_PATH, "", "");
 
 	comb_next_lo->name = NULL;
 

--- a/lib/libfrr.h
+++ b/lib/libfrr.h
@@ -81,7 +81,10 @@ struct frr_daemon_info {
 #endif
 	const char *vty_path;
 	const char *module_path;
+
 	const char *pathspace;
+	bool zpathspace;
+
 	const char *early_logging;
 	const char *early_loglevel;
 
@@ -120,6 +123,7 @@ struct frr_daemon_info {
 			  .version = FRR_VERSION, )                            \
 /* end */
 
+extern void frr_init_vtydir(void);
 extern void frr_preinit(struct frr_daemon_info *daemon, int argc, char **argv);
 extern void frr_opt_add(const char *optstr, const struct option *longopts,
 			const char *helpstr);
@@ -150,7 +154,7 @@ extern void frr_fini(void);
 extern char config_default[512];
 extern char frr_zclientpath[256];
 extern const char frr_sysconfdir[];
-extern const char frr_vtydir[];
+extern char frr_vtydir[256];
 extern const char frr_moduledir[];
 
 extern char frr_protoname[];

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -332,6 +332,8 @@ int main(int argc, char **argv, char **env)
 	progname = ((p = strrchr(argv[0], '/')) ? ++p : argv[0]);
 
 	strlcpy(sysconfdir, frr_sysconfdir, sizeof(sysconfdir));
+
+	frr_init_vtydir();
 	strlcpy(vtydir, frr_vtydir, sizeof(vtydir));
 
 	/* Option handling. */

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -648,7 +648,7 @@ static void daemon_send_ready(int exitcode)
 {
 	FILE *fp;
 	static int sent = 0;
-	char started[512];
+	char started[1024];
 
 	if (sent)
 		return;

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -648,6 +648,7 @@ static void daemon_send_ready(int exitcode)
 {
 	FILE *fp;
 	static int sent = 0;
+	char started[512];
 
 	if (sent)
 		return;
@@ -669,7 +670,9 @@ static void daemon_send_ready(int exitcode)
 
 	frr_detach();
 
-	fp = fopen(DAEMON_VTY_DIR "/watchfrr.started", "w");
+	snprintf(started, sizeof(started), "%s%s", frr_vtydir,
+		 "watchfrr.started");
+	fp = fopen(started, "w");
 	if (fp)
 		fclose(fp);
 #if defined HAVE_SYSTEMD

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -340,8 +340,7 @@ static void netlink_write_incoming(const char *buf, const unsigned int size,
 	char fname[MAXPATHLEN];
 	FILE *f;
 
-	snprintf(fname, MAXPATHLEN, "%s/%s_%u", DAEMON_VTY_DIR, "netlink",
-		 counter);
+	snprintf(fname, MAXPATHLEN, "%s/%s_%u", frr_vtydir, "netlink", counter);
 	frr_elevate_privs(&zserv_privs) {
 		f = fopen(fname, "w");
 	}

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2526,7 +2526,7 @@ static void zserv_write_incoming(struct stream *orig, uint16_t command)
 	copy = stream_dup(orig);
 	stream_set_getp(copy, 0);
 
-	snprintf(fname, MAXPATHLEN, "%s/%u", DAEMON_VTY_DIR, command);
+	snprintf(fname, MAXPATHLEN, "%s/%u", frr_vtydir, command);
 
 	frr_elevate_privs(&zserv_privs) {
 		fd = open(fname, O_CREAT | O_WRONLY | O_EXCL, 0644);


### PR DESCRIPTION
There are a bunch of places where we use configuration files/named sockets that when we are running in a namespace it would be convenient to add FOO to the directory path.  This is a series of commits that does this.