### PR TITLE
lib, zebra: Ensure route encoding has enough space

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -62,10 +62,13 @@ struct zclient *zclient_new(struct thread_master *master,
 			    struct zclient_options *opt)
 {
 	struct zclient *zclient;
+	size_t stream_size =
+		MAX(ZEBRA_MAX_PACKET_SIZ, sizeof(struct zapi_route));
+
 	zclient = XCALLOC(MTYPE_ZCLIENT, sizeof(struct zclient));
 
-	zclient->ibuf = stream_new(ZEBRA_MAX_PACKET_SIZ);
-	zclient->obuf = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	zclient->ibuf = stream_new(stream_size);
+	zclient->obuf = stream_new(stream_size);
 	zclient->wb = buffer_new(0);
 	zclient->master = master;
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -39,7 +39,7 @@
 #include "mlag.h"
 
 /* For input/output buffer to zebra. */
-#define ZEBRA_MAX_PACKET_SIZ          16384
+#define ZEBRA_MAX_PACKET_SIZ          16384U
 
 /* Zebra header size. */
 #define ZEBRA_HEADER_SIZE             10

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -524,6 +524,8 @@ int zsend_redistribute_route(int cmd, struct zserv *client,
 	struct nexthop *nexthop;
 	int count = 0;
 	afi_t afi;
+	size_t stream_size =
+		MAX(ZEBRA_MAX_PACKET_SIZ, sizeof(struct zapi_route));
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = re->vrf_id;
@@ -605,7 +607,7 @@ int zsend_redistribute_route(int cmd, struct zserv *client,
 	SET_FLAG(api.message, ZAPI_MESSAGE_MTU);
 	api.mtu = re->mtu;
 
-	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	struct stream *s = stream_new(stream_size);
 
 	/* Encode route and send. */
 	if (zapi_route_encode(cmd, s, &api) < 0) {

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -682,6 +682,8 @@ static int zserv_handle_client_fail(struct thread *thread)
 static struct zserv *zserv_client_create(int sock)
 {
 	struct zserv *client;
+	size_t stream_size =
+		MAX(ZEBRA_MAX_PACKET_SIZ, sizeof(struct zapi_route));
 	int i;
 	afi_t afi;
 
@@ -691,8 +693,8 @@ static struct zserv *zserv_client_create(int sock)
 	client->sock = sock;
 	client->ibuf_fifo = stream_fifo_new();
 	client->obuf_fifo = stream_fifo_new();
-	client->ibuf_work = stream_new(ZEBRA_MAX_PACKET_SIZ);
-	client->obuf_work = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	client->ibuf_work = stream_new(stream_size);
+	client->obuf_work = stream_new(stream_size);
 	pthread_mutex_init(&client->ibuf_mtx, NULL);
 	pthread_mutex_init(&client->obuf_mtx, NULL);
 	client->wb = buffer_new(0);


### PR DESCRIPTION
When you have compiled FRR with a large multipath number
then encoding large ecmp routes between zebra and the
routing daemons.  There exists a theoritical size
of multipath that will cause the encoding to be larger
than the ZEBRA_MAX_PACKET_SIZ.  In the cases where
we have allocated streams that will encode routes
then let's ensure that whatever size we have will
auto-fit what we say we can send.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>