### PR TITLE
tools: On shutdown no need to flush from tools/frr.in script

### DIFF
--- a/tools/frr.in
+++ b/tools/frr.in
@@ -561,30 +561,7 @@ case "$1" in
 			stop_prio 0 $dmn
 		fi
 
-		if [ -z "$dmn" -o "$dmn" = "zebra" ]; then
-			echo "Removing all routes made by FRR."
-			# Specific values for each proto can be found
-			# in /etc/iproute2/rt_protos as well as FRR
-			# specific ones in /etc/iproute2/rt_protos.d
-			# Additionally if a new protocol is added
-			# we need to add it here as well as
-			# in rt_netlink.h( follow the directions! )
-			ip route flush proto 4
-			ip route flush proto 11
-			ip route flush proto 42
-			ip route flush proto 186
-			ip route flush proto 187
-			ip route flush proto 188
-			ip route flush proto 189
-			ip route flush proto 190
-			ip route flush proto 191
-			ip route flush proto 192
-			ip route flush proto 193
-			ip route flush proto 194
-			ip route flush proto 195
-			ip route flush proto 196
-			ip route flush proto 197
-		else
+		if [ [ -n "$dmn" ] && [ "$dmn" != "zebra" ] ]; then
 			[ -n "$dmn" ] && eval "${dmn/-/_}=0"
 			start_watchfrr
 		fi


### PR DESCRIPTION
Zebra already flushes routes on proper shutdown if you are not
using the -K option.  If you are using the -K option then you
do not want the tools/frr script to flush routes.

If zebra crashes and we restart then load up will either delete
the routes or leave them depending on the -K option.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>