### PR TITLE
bfdd: migrate to northbound

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1289,8 +1289,6 @@ static unsigned int bfd_key_hash_do(const void *p);
 
 static void _bfd_free(struct hash_bucket *hb,
 		      void *arg __attribute__((__unused__)));
-int _bfd_session_next(struct hash_bucket *hb, void *arg);
-void _bfd_session_remove_manual(struct hash_bucket *hb, void *arg);
 
 /* BFD hash for our discriminator. */
 static unsigned int bfd_id_hash_do(const void *p)
@@ -1343,9 +1341,10 @@ struct bfd_key_walk_partial_lookup {
 };
 
 /* ignore some parameters */
-static int bfd_key_lookup_ignore_partial_walker(struct hash_bucket *b, void *data)
+static int bfd_key_lookup_ignore_partial_walker(struct hash_bucket *b,
+						void *data)
 {
-	struct bfd_key_walk_partial_lookup  *ctx =
+	struct bfd_key_walk_partial_lookup *ctx =
 		(struct bfd_key_walk_partial_lookup *)data;
 	struct bfd_session *given = ctx->given;
 	struct bfd_session *parsed = b->data;
@@ -1354,7 +1353,8 @@ static int bfd_key_lookup_ignore_partial_walker(struct hash_bucket *b, void *dat
 		return HASHWALK_CONTINUE;
 	if (given->key.mhop != parsed->key.mhop)
 		return HASHWALK_CONTINUE;
-	if (memcmp(&given->key.peer, &parsed->key.peer, sizeof(struct in6_addr)))
+	if (memcmp(&given->key.peer, &parsed->key.peer,
+		   sizeof(struct in6_addr)))
 		return HASHWALK_CONTINUE;
 	if (memcmp(given->key.vrfname, parsed->key.vrfname, MAXNAMELEN))
 		return HASHWALK_CONTINUE;
@@ -1538,7 +1538,7 @@ struct bfd_session_iterator {
 	const struct bfd_session *bsi_bs;
 };
 
-int _bfd_session_next(struct hash_bucket *hb, void *arg)
+static int _bfd_session_next(struct hash_bucket *hb, void *arg)
 {
 	struct bfd_session_iterator *bsi = arg;
 	struct bfd_session *bs = hb->data;
@@ -1588,8 +1588,8 @@ const struct bfd_session *bfd_session_next(const struct bfd_session *bs,
 	return bsi.bsi_bs;
 }
 
-void _bfd_session_remove_manual(struct hash_bucket *hb,
-				void *arg __attribute__((__unused__)))
+static void _bfd_session_remove_manual(struct hash_bucket *hb,
+				       void *arg __attribute__((__unused__)))
 {
 	struct bfd_session *bs = hb->data;
 

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -596,6 +596,29 @@ void bfdd_vty_init(void);
  */
 void bfdd_cli_init(void);
 
+void bfd_cli_show_header(struct vty *vty, struct lyd_node *dnode,
+			 bool show_defaults);
+void bfd_cli_show_header_end(struct vty *vty, struct lyd_node *dnode);
+void bfd_cli_show_single_hop_peer(struct vty *vty,
+				  struct lyd_node *dnode,
+				  bool show_defaults);
+void bfd_cli_show_multi_hop_peer(struct vty *vty,
+				 struct lyd_node *dnode,
+				 bool show_defaults);
+void bfd_cli_show_peer_end(struct vty *vty, struct lyd_node *dnode);
+void bfd_cli_show_mult(struct vty *vty, struct lyd_node *dnode,
+		       bool show_defaults);
+void bfd_cli_show_tx(struct vty *vty, struct lyd_node *dnode,
+		     bool show_defaults);
+void bfd_cli_show_rx(struct vty *vty, struct lyd_node *dnode,
+		     bool show_defaults);
+void bfd_cli_show_shutdown(struct vty *vty, struct lyd_node *dnode,
+			   bool show_defaults);
+void bfd_cli_show_echo(struct vty *vty, struct lyd_node *dnode,
+			   bool show_defaults);
+void bfd_cli_show_echo_interval(struct vty *vty, struct lyd_node *dnode,
+				bool show_defaults);
+
 
 /*
  * ptm_adapter.c

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -546,6 +546,12 @@ void bs_observer_del(struct bfd_session_observer *bso);
 
 void bs_to_bpc(struct bfd_session *bs, struct bfd_peer_cfg *bpc);
 
+void gen_bfd_key(struct bfd_key *key, struct sockaddr_any *peer,
+		 struct sockaddr_any *local, bool mhop, const char *ifname,
+		 const char *vrfname);
+struct bfd_session *bfd_session_new(void);
+struct bfd_session *bs_registrate(struct bfd_session *bs);
+void bfd_session_free(struct bfd_session *bs);
 /* BFD hash data structures interface */
 void bfd_initialize(void);
 void bfd_shutdown(void);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -550,6 +550,7 @@ struct bfd_session *bs_registrate(struct bfd_session *bs);
 void bfd_session_free(struct bfd_session *bs);
 const struct bfd_session *bfd_session_next(const struct bfd_session *bs,
 					   bool mhop);
+void bfd_sessions_remove_manual(void);
 
 /* BFD hash data structures interface */
 void bfd_initialize(void);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -252,11 +252,7 @@ struct bfd_session {
 	struct bfd_timers remote_timers;
 
 	uint64_t refcount; /* number of pointers referencing this. */
-
-	/* VTY context data. */
-	QOBJ_FIELDS
 };
-DECLARE_QOBJ_TYPE(bfd_session)
 
 struct peer_label {
 	TAILQ_ENTRY(peer_label) pl_entry;
@@ -552,6 +548,9 @@ void gen_bfd_key(struct bfd_key *key, struct sockaddr_any *peer,
 struct bfd_session *bfd_session_new(void);
 struct bfd_session *bs_registrate(struct bfd_session *bs);
 void bfd_session_free(struct bfd_session *bs);
+const struct bfd_session *bfd_session_next(const struct bfd_session *bs,
+					   bool mhop);
+
 /* BFD hash data structures interface */
 void bfd_initialize(void);
 void bfd_shutdown(void);
@@ -591,6 +590,14 @@ void bfdd_vty_init(void);
 
 
 /*
+ * bfdd_cli.c
+ *
+ * BFD daemon CLI implementation.
+ */
+void bfdd_cli_init(void);
+
+
+/*
  * ptm_adapter.c
  */
 void bfdd_zclient_init(struct zebra_privs_t *bfdd_priv);
@@ -601,5 +608,13 @@ void bfdd_sessions_enable_vrf(struct vrf *vrf);
 void bfdd_sessions_disable_vrf(struct vrf *vrf);
 
 int ptm_bfd_notify(struct bfd_session *bs);
+
+
+/*
+ * bfdd_northbound.c
+ *
+ * BFD northbound callbacks.
+ */
+extern const struct frr_yang_module_info frr_bfdd_info;
 
 #endif /* _BFD_H_ */

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -93,10 +93,17 @@ static struct quagga_signal_t bfd_signals[] = {
 	},
 };
 
+static const struct frr_yang_module_info *bfdd_yang_modules[] = {
+	&frr_interface_info,
+	&frr_bfdd_info,
+};
+
 FRR_DAEMON_INFO(bfdd, BFD, .vty_port = 2617,
 		.proghelp = "Implementation of the BFD protocol.",
 		.signals = bfd_signals, .n_signals = array_size(bfd_signals),
-		.privs = &bglobal.bfdd_privs)
+		.privs = &bglobal.bfdd_privs,
+		.yang_modules = bfdd_yang_modules,
+		.n_yang_modules = array_size(bfdd_yang_modules))
 
 #define OPTION_CTLSOCK 1001
 static struct option longopts[] = {

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -39,6 +39,9 @@ struct thread_master *master;
 /* BFDd privileges */
 static zebra_capabilities_t _caps_p[] = {ZCAP_BIND, ZCAP_SYS_ADMIN, ZCAP_NET_RAW};
 
+/* BFD daemon information. */
+static struct frr_daemon_info bfdd_di;
+
 void socket_close(int *s)
 {
 	if (*s <= 0)
@@ -78,6 +81,14 @@ static void sigterm_handler(void)
 	exit(0);
 }
 
+static void sighup_handler(void)
+{
+	zlog_info("SIGHUP received");
+
+	/* Reload config file. */
+	vty_read_config(NULL, bfdd_di.config_file, config_default);
+}
+
 static struct quagga_signal_t bfd_signals[] = {
 	{
 		.signal = SIGUSR1,
@@ -90,6 +101,10 @@ static struct quagga_signal_t bfd_signals[] = {
 	{
 		.signal = SIGINT,
 		.handler = &sigterm_handler,
+	},
+	{
+		.signal = SIGHUP,
+		.handler = &sighup_handler,
 	},
 };
 

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -1,0 +1,232 @@
+/*
+ * BFD daemon CLI implementation.
+ *
+ * Copyright (C) 2019 Network Device Education Foundation, Inc. ("NetDEF")
+ *                    Rafael Zalamena
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+#include "lib/command.h"
+#include "lib/log.h"
+#include "lib/northbound_cli.h"
+
+#ifndef VTYSH_EXTRACT_PL
+#include "bfdd/bfdd_cli_clippy.c"
+#endif /* VTYSH_EXTRACT_PL */
+
+#include "bfd.h"
+
+/*
+ * Definitions.
+ */
+#define PEER_STR "Configure peer\n"
+#define INTERFACE_NAME_STR "Configure interface name to use\n"
+#define PEER_IPV4_STR "IPv4 peer address\n"
+#define PEER_IPV6_STR "IPv6 peer address\n"
+#define MHOP_STR "Configure multihop\n"
+#define LOCAL_STR "Configure local address\n"
+#define LOCAL_IPV4_STR "IPv4 local address\n"
+#define LOCAL_IPV6_STR "IPv6 local address\n"
+#define LOCAL_INTF_STR "Configure local interface name to use\n"
+#define VRF_STR "Configure VRF\n"
+#define VRF_NAME_STR "Configure VRF name\n"
+
+/*
+ * Prototypes.
+ */
+
+/*
+ * Functions.
+ */
+DEFPY_NOSH(
+	bfd_peer_enter, bfd_peer_enter_cmd,
+	"peer <A.B.C.D|X:X::X:X> [{multihop$multihop|local-address <A.B.C.D|X:X::X:X>|interface IFNAME$ifname|vrf NAME}]",
+	PEER_STR
+	PEER_IPV4_STR
+	PEER_IPV6_STR
+	MHOP_STR
+	LOCAL_STR
+	LOCAL_IPV4_STR
+	LOCAL_IPV6_STR
+	INTERFACE_STR
+	LOCAL_INTF_STR
+	VRF_STR
+	VRF_NAME_STR)
+{
+	int ret, slen;
+	char xpath[XPATH_MAXLEN];
+	char source_str[INET6_ADDRSTRLEN];
+
+	if (multihop)
+		snprintf(source_str, sizeof(source_str), "[source-addr='%s']",
+			 local_address_str);
+	else
+		source_str[0] = 0;
+
+	slen = snprintf(xpath, sizeof(xpath),
+			"/frr-bfdd:bfdd/bfd/sessions/%s%s[dest-addr='%s']",
+			multihop ? "multi-hop" : "single-hop", source_str,
+			peer_str);
+	if (ifname)
+		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
+				 "[interface='%s']", ifname);
+	else
+		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
+				 "[interface='']");
+	if (vrf)
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
+	else
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']",
+			 VRF_DEFAULT_NAME);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+
+	/* Apply settings immediatly. */
+	ret = nb_cli_apply_changes(vty, NULL);
+	if (ret == CMD_SUCCESS)
+		VTY_PUSH_XPATH(BFD_PEER_NODE, xpath);
+
+	return ret;
+}
+
+DEFPY(
+	bfd_no_peer, bfd_no_peer_cmd,
+	"no peer <A.B.C.D|X:X::X:X> [{multihop$multihop|local-address <A.B.C.D|X:X::X:X>|interface IFNAME$ifname|vrf NAME}]",
+	NO_STR
+	PEER_STR
+	PEER_IPV4_STR
+	PEER_IPV6_STR
+	MHOP_STR
+	LOCAL_STR
+	LOCAL_IPV4_STR
+	LOCAL_IPV6_STR
+	INTERFACE_STR
+	LOCAL_INTF_STR
+	VRF_STR
+	VRF_NAME_STR)
+{
+	int slen;
+	char xpath[XPATH_MAXLEN];
+	char source_str[INET6_ADDRSTRLEN];
+
+	if (multihop)
+		snprintf(source_str, sizeof(source_str), "[source-addr='%s']",
+			 local_address_str);
+	else
+		source_str[0] = 0;
+
+	slen = snprintf(xpath, sizeof(xpath),
+			"/frr-bfdd:bfdd/bfd/sessions/%s%s[dest-addr='%s']",
+			multihop ? "multi-hop" : "single-hop", source_str,
+			peer_str);
+	if (ifname)
+		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
+				 "[interface='%s']", ifname);
+	else
+		slen += snprintf(xpath + slen, sizeof(xpath) - slen,
+				 "[interface='']");
+	if (vrf)
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']", vrf);
+	else
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']",
+			 VRF_DEFAULT_NAME);
+
+	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+
+	/* Apply settings immediatly. */
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY(
+	bfd_peer_shutdown, bfd_peer_shutdown_cmd,
+	"[no] shutdown",
+	NO_STR
+	"Disable BFD peer")
+{
+	nb_cli_enqueue_change(vty, "./administrative-down", NB_OP_MODIFY,
+			      no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY(
+	bfd_peer_mult, bfd_peer_mult_cmd,
+	"detect-multiplier (2-255)$multiplier",
+	"Configure peer detection multiplier\n"
+	"Configure peer detection multiplier value\n")
+{
+	nb_cli_enqueue_change(vty, "./detection-multiplier", NB_OP_MODIFY,
+			      multiplier_str);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY(
+	bfd_peer_rx, bfd_peer_rx_cmd,
+	"receive-interval (10-60000)$interval",
+	"Configure peer receive interval\n"
+	"Configure peer receive interval value in milliseconds\n")
+{
+	nb_cli_enqueue_change(vty, "./required-receive-interval", NB_OP_MODIFY,
+			      interval_str);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY(
+	bfd_peer_tx, bfd_peer_tx_cmd,
+	"transmit-interval (10-60000)$interval",
+	"Configure peer transmit interval\n"
+	"Configure peer transmit interval value in milliseconds\n")
+{
+	nb_cli_enqueue_change(vty, "./desired-transmission-interval",
+			      NB_OP_MODIFY, interval_str);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY(
+	bfd_peer_echo, bfd_peer_echo_cmd,
+	"[no] echo-mode",
+	NO_STR
+	"Configure echo mode\n")
+{
+	nb_cli_enqueue_change(vty, "./echo-mode", NB_OP_MODIFY,
+			      no ? "false" : "true");
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+DEFPY(
+	bfd_peer_echo_interval, bfd_peer_echo_interval_cmd,
+	"echo-interval (10-60000)$interval",
+	"Configure peer echo interval\n"
+	"Configure peer echo interval value in milliseconds\n")
+{
+	nb_cli_enqueue_change(vty, "./desired-echo-transmission-interval",
+			      NB_OP_MODIFY, interval_str);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
+void
+bfdd_cli_init(void)
+{
+	install_element(BFD_NODE, &bfd_peer_enter_cmd);
+	install_element(BFD_NODE, &bfd_no_peer_cmd);
+
+	install_element(BFD_PEER_NODE, &bfd_peer_shutdown_cmd);
+	install_element(BFD_PEER_NODE, &bfd_peer_mult_cmd);
+	install_element(BFD_PEER_NODE, &bfd_peer_rx_cmd);
+	install_element(BFD_PEER_NODE, &bfd_peer_tx_cmd);
+	install_element(BFD_PEER_NODE, &bfd_peer_echo_cmd);
+	install_element(BFD_PEER_NODE, &bfd_peer_echo_interval_cmd);
+}

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -52,6 +52,16 @@
 /*
  * Functions.
  */
+DEFUN(
+	bfd_config_reset, bfd_config_reset_cmd,
+	"no bfd",
+	NO_STR
+	"Configure BFD peers\n")
+{
+	nb_cli_enqueue_change(vty, "/frr-bfdd:bfdd/bfd", NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, NULL);
+}
+
 void bfd_cli_show_header(struct vty *vty,
 			 struct lyd_node *dnode __attribute__((__unused__)),
 			 bool show_defaults __attribute__((__unused__)))
@@ -343,6 +353,8 @@ void bfd_cli_show_echo_interval(struct vty *vty, struct lyd_node *dnode,
 void
 bfdd_cli_init(void)
 {
+	install_element(CONFIG_NODE, &bfd_config_reset_cmd);
+
 	install_element(BFD_NODE, &bfd_peer_enter_cmd);
 	install_element(BFD_NODE, &bfd_no_peer_cmd);
 

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -108,8 +108,8 @@ DEFPY_NOSH(
 	VRF_NAME_STR)
 {
 	int ret, slen;
-	char xpath[XPATH_MAXLEN];
 	char source_str[INET6_ADDRSTRLEN];
+	char xpath[XPATH_MAXLEN], xpath_srcaddr[XPATH_MAXLEN + 32];
 
 	if (multihop)
 		snprintf(source_str, sizeof(source_str), "[source-addr='%s']",
@@ -134,6 +134,12 @@ DEFPY_NOSH(
 			 VRF_DEFAULT_NAME);
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+	if (multihop == NULL && local_address_str != NULL) {
+		snprintf(xpath_srcaddr, sizeof(xpath_srcaddr),
+			 "%s/source-addr", xpath);
+		nb_cli_enqueue_change(vty, xpath_srcaddr, NB_OP_MODIFY,
+				      local_address_str);
+	}
 
 	/* Apply settings immediately. */
 	ret = nb_cli_apply_changes(vty, NULL);

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -269,20 +269,27 @@ DEFPY(
 	"Configure peer receive interval\n"
 	"Configure peer receive interval value in milliseconds\n")
 {
+	char value[32];
+
+	snprintf(value, sizeof(value), "%ld", interval * 1000);
 	nb_cli_enqueue_change(vty, "./required-receive-interval", NB_OP_MODIFY,
-			      interval_str);
+			      value);
+
 	return nb_cli_apply_changes(vty, NULL);
 }
 
 void bfd_cli_show_rx(struct vty *vty, struct lyd_node *dnode,
 		     bool show_defaults)
 {
+	uint32_t value;
+
 	if (show_defaults)
 		vty_out(vty, "  receive-interval %d\n",
 			BFD_DEFREQUIREDMINRX);
-	else
-		vty_out(vty, "  receive-interval %s\n",
-			yang_dnode_get_string(dnode, NULL));
+	else {
+		value = yang_dnode_get_uint32(dnode, NULL);
+		vty_out(vty, "  receive-interval %" PRIu32 "\n", value / 1000);
+	}
 }
 
 DEFPY(
@@ -291,20 +298,27 @@ DEFPY(
 	"Configure peer transmit interval\n"
 	"Configure peer transmit interval value in milliseconds\n")
 {
+	char value[32];
+
+	snprintf(value, sizeof(value), "%ld", interval * 1000);
 	nb_cli_enqueue_change(vty, "./desired-transmission-interval",
-			      NB_OP_MODIFY, interval_str);
+			      NB_OP_MODIFY, value);
+
 	return nb_cli_apply_changes(vty, NULL);
 }
 
 void bfd_cli_show_tx(struct vty *vty, struct lyd_node *dnode,
 		     bool show_defaults)
 {
+	uint32_t value;
+
 	if (show_defaults)
 		vty_out(vty, "  transmit-interval %d\n",
 			BFD_DEFDESIREDMINTX);
-	else
-		vty_out(vty, "  transmit-interval %s\n",
-			yang_dnode_get_string(dnode, NULL));
+	else {
+		value = yang_dnode_get_uint32(dnode, NULL);
+		vty_out(vty, "  transmit-interval %" PRIu32 "\n", value / 1000);
+	}
 }
 
 DEFPY(
@@ -334,20 +348,27 @@ DEFPY(
 	"Configure peer echo interval\n"
 	"Configure peer echo interval value in milliseconds\n")
 {
+	char value[32];
+
+	snprintf(value, sizeof(value), "%ld", interval * 1000);
 	nb_cli_enqueue_change(vty, "./desired-echo-transmission-interval",
-			      NB_OP_MODIFY, interval_str);
+			      NB_OP_MODIFY, value);
+
 	return nb_cli_apply_changes(vty, NULL);
 }
 
 void bfd_cli_show_echo_interval(struct vty *vty, struct lyd_node *dnode,
 				bool show_defaults)
 {
+	uint32_t value;
+
 	if (show_defaults)
 		vty_out(vty, "  echo-interval %d\n",
 			BFD_DEF_REQ_MIN_ECHO);
-	else
-		vty_out(vty, "  echo-interval %s\n",
-			yang_dnode_get_string(dnode, NULL));
+	else {
+		value = yang_dnode_get_uint32(dnode, NULL);
+		vty_out(vty, "  echo-interval %" PRIu32 "\n", value / 1000);
+	}
 }
 
 void

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -54,6 +54,21 @@
 /*
  * Functions.
  */
+DEFPY_NOSH(
+	bfd_enter, bfd_enter_cmd,
+	"bfd",
+	"Configure BFD peers\n")
+{
+	int ret;
+
+	nb_cli_enqueue_change(vty, "/frr-bfdd:bfdd/bfd", NB_OP_CREATE, NULL);
+	ret = nb_cli_apply_changes(vty, NULL);
+	if (ret == CMD_SUCCESS)
+		VTY_PUSH_XPATH(BFD_NODE, "/frr-bfdd:bfdd/bfd");
+
+	return ret;
+}
+
 DEFUN(
 	bfd_config_reset, bfd_config_reset_cmd,
 	"no bfd",
@@ -120,7 +135,7 @@ DEFPY_NOSH(
 
 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
 
-	/* Apply settings immediatly. */
+	/* Apply settings immediately. */
 	ret = nb_cli_apply_changes(vty, NULL);
 	if (ret == CMD_SUCCESS)
 		VTY_PUSH_XPATH(BFD_PEER_NODE, xpath);
@@ -376,6 +391,7 @@ void bfd_cli_show_echo_interval(struct vty *vty, struct lyd_node *dnode,
 void
 bfdd_cli_init(void)
 {
+	install_element(CONFIG_NODE, &bfd_enter_cmd);
 	install_element(CONFIG_NODE, &bfd_config_reset_cmd);
 
 	install_element(BFD_NODE, &bfd_peer_enter_cmd);

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -224,7 +224,7 @@ DEFPY(
 	bfd_peer_shutdown, bfd_peer_shutdown_cmd,
 	"[no] shutdown",
 	NO_STR
-	"Disable BFD peer")
+	"Disable BFD peer\n")
 {
 	nb_cli_enqueue_change(vty, "./administrative-down", NB_OP_MODIFY,
 			      no ? "false" : "true");

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -20,6 +20,8 @@
  * 02110-1301 USA.
  */
 
+#include <zebra.h>
+
 #include "lib/command.h"
 #include "lib/log.h"
 #include "lib/northbound_cli.h"

--- a/bfdd/bfdd_northbound.c
+++ b/bfdd/bfdd_northbound.c
@@ -1,0 +1,1060 @@
+/*
+ * BFD daemon northbound implementation.
+ *
+ * Copyright (C) 2019 Network Device Education Foundation, Inc. ("NetDEF")
+ *                    Rafael Zalamena
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+#include "lib/log.h"
+#include "lib/northbound.h"
+
+#include "bfd.h"
+
+/*
+ * Prototypes.
+ */
+void bfd_session_get_key(bool mhop, const struct lyd_node *dnode,
+			 struct bfd_key *bk);
+int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
+		       union nb_resource *resource, bool mhop);
+int bfd_session_destroy(enum nb_event event, const struct lyd_node *dnode,
+			bool mhop);
+
+/*
+ * Helpers.
+ */
+void bfd_session_get_key(bool mhop, const struct lyd_node *dnode,
+			 struct bfd_key *bk)
+{
+	const char *ifname = NULL, *vrfname = NULL;
+	struct sockaddr_any psa, lsa;
+
+	/* Required destination parameter. */
+	strtosa(yang_dnode_get_string(dnode, "./dest-addr"), &psa);
+
+	/* Get optional source address. */
+	memset(&lsa, 0, sizeof(lsa));
+	if (yang_dnode_exists(dnode, "./source-addr"))
+		strtosa(yang_dnode_get_string(dnode, "./source-addr"), &lsa);
+
+	/* Get optional interface and vrf names. */
+	if (yang_dnode_exists(dnode, "./interface"))
+		ifname = yang_dnode_get_string(dnode, "./interface");
+	if (yang_dnode_exists(dnode, "./vrf"))
+		vrfname = yang_dnode_get_string(dnode, "./vrf");
+
+	/* Generate the corresponding key. */
+	gen_bfd_key(bk, &psa, &lsa, mhop, ifname, vrfname);
+}
+
+int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
+		       union nb_resource *resource, bool mhop)
+{
+	struct bfd_session *bs;
+	struct bfd_key bk;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		bfd_session_get_key(mhop, dnode, &bk);
+		if (bfd_key_lookup(bk))
+			return NB_ERR_VALIDATION;
+		break;
+
+	case NB_EV_PREPARE:
+		bs = bfd_session_new();
+		if (bs == NULL)
+			return NB_ERR_RESOURCE;
+
+		/* Fill the session key. */
+		bfd_session_get_key(mhop, dnode, &bs->key);
+
+		/* Set configuration flags. */
+		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG);
+		if (mhop)
+			BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_MH);
+		if (bs->key.family == AF_INET6)
+			BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_IPV6);
+
+		resource->ptr = bs;
+		break;
+
+	case NB_EV_APPLY:
+		bs = resource->ptr;
+		if (bs_registrate(bs) == NULL)
+			return NB_ERR_RESOURCE;
+
+		nb_running_set_entry(dnode, bs);
+		break;
+
+	case NB_EV_ABORT:
+		bfd_session_free(resource->ptr);
+		break;
+	}
+
+	return NB_OK;
+}
+
+int bfd_session_destroy(enum nb_event event, const struct lyd_node *dnode,
+			bool mhop)
+{
+	struct bfd_key bk;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		bfd_session_get_key(mhop, dnode, &bk);
+		if (bfd_key_lookup(bk) == NULL)
+			return NB_ERR_VALIDATION;
+		break;
+
+	case NB_EV_PREPARE:
+		/* NOTHING */
+		break;
+
+	case NB_EV_APPLY:
+		bfd_session_free(nb_running_unset_entry(dnode));
+		break;
+
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd
+ */
+static int bfdd_bfd_create(enum nb_event event,
+			   const struct lyd_node *dnode
+			   __attribute__((__unused__)),
+			   union nb_resource *resource
+			   __attribute__((__unused__)))
+{
+	/* NOTHING */
+	return NB_OK;
+}
+
+static int bfdd_bfd_destroy(enum nb_event event, const struct lyd_node *dnode)
+{
+	/* NOTHING */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop
+ */
+static int bfdd_bfd_sessions_single_hop_create(enum nb_event event,
+					       const struct lyd_node *dnode,
+					       union nb_resource *resource)
+{
+	return bfd_session_create(event, dnode, resource, false);
+}
+
+static int bfdd_bfd_sessions_single_hop_destroy(enum nb_event event,
+						const struct lyd_node *dnode)
+{
+	return bfd_session_destroy(event, dnode, false);
+}
+
+static const void *
+bfdd_bfd_sessions_single_hop_get_next(const void *parent_list_entry
+				      __attribute__((__unused__)),
+				      const void *list_entry)
+{
+	return bfd_session_next(list_entry, false);
+}
+
+static int bfdd_bfd_sessions_single_hop_get_keys(const void *list_entry,
+						 struct yang_list_keys *keys)
+{
+	const struct bfd_session *bs = list_entry;
+	char dstbuf[INET6_ADDRSTRLEN];
+
+	inet_ntop(bs->key.family, &bs->key.peer, dstbuf, sizeof(dstbuf));
+
+	keys->num = 3;
+	strlcpy(keys->key[0], dstbuf, sizeof(keys->key[0]));
+	strlcpy(keys->key[1], bs->key.ifname, sizeof(keys->key[1]));
+	strlcpy(keys->key[2], bs->key.vrfname, sizeof(keys->key[2]));
+
+	return NB_OK;
+}
+
+static const void *
+bfdd_bfd_sessions_single_hop_lookup_entry(const void *parent_list_entry
+					  __attribute__((__unused__)),
+					  const struct yang_list_keys *keys)
+{
+	const char *dest_addr = keys->key[0];
+	const char *ifname = keys->key[1];
+	const char *vrf = keys->key[2];
+	struct sockaddr_any psa, lsa;
+	struct bfd_key bk;
+
+	strtosa(dest_addr, &psa);
+	memset(&lsa, 0, sizeof(lsa));
+	gen_bfd_key(&bk, &psa, &lsa, false, ifname, vrf);
+
+	return bfd_key_lookup(bk);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/source-addr
+ */
+static int bfdd_bfd_sessions_single_hop_source_addr_modify(
+	enum nb_event event __attribute__((__unused__)),
+	const struct lyd_node *dnode __attribute__((__unused__)),
+	union nb_resource *resource __attribute__((__unused__)))
+{
+	return NB_OK;
+}
+
+static int bfdd_bfd_sessions_single_hop_source_addr_destroy(
+	enum nb_event event __attribute__((__unused__)),
+	const struct lyd_node *dnode __attribute__((__unused__)))
+{
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/detection-multiplier
+ */
+static int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource __attribute__((__unused__)))
+{
+	uint8_t detection_multiplier = yang_dnode_get_uint8(dnode, NULL);
+	struct bfd_session *bs;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		if (detection_multiplier == 1)
+			return NB_ERR_VALIDATION;
+		break;
+
+	case NB_EV_PREPARE:
+		/* NOTHING */
+		break;
+
+	case NB_EV_APPLY:
+		bs = nb_running_get_entry(dnode, NULL, true);
+		bs->detect_mult = detection_multiplier;
+		break;
+
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/desired-transmission-interval
+ */
+static int bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource __attribute__((__unused__)))
+{
+	uint32_t tx_interval = yang_dnode_get_uint32(dnode, NULL);
+	struct bfd_session *bs;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		if (tx_interval < 10 || tx_interval > 60000)
+			return NB_ERR_VALIDATION;
+		break;
+
+	case NB_EV_PREPARE:
+		/* NOTHING */
+		break;
+
+	case NB_EV_APPLY:
+		bs = nb_running_get_entry(dnode, NULL, true);
+
+		tx_interval *= 1000;
+		if (tx_interval == bs->timers.desired_min_tx)
+			return NB_OK;
+
+		bs->timers.desired_min_tx = tx_interval;
+		bfd_set_polling(bs);
+		break;
+
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/required-receive-interval
+ */
+static int bfdd_bfd_sessions_single_hop_required_receive_interval_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource __attribute__((__unused__)))
+{
+	uint32_t rx_interval = yang_dnode_get_uint32(dnode, NULL);
+	struct bfd_session *bs;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		if (rx_interval < 10 || rx_interval > 60000)
+			return NB_ERR_VALIDATION;
+		break;
+
+	case NB_EV_PREPARE:
+		/* NOTHING */
+		break;
+
+	case NB_EV_APPLY:
+		bs = nb_running_get_entry(dnode, NULL, true);
+
+		rx_interval *= 1000;
+		if (rx_interval == bs->timers.required_min_rx)
+			return NB_OK;
+
+		bs->timers.required_min_rx = rx_interval;
+		bfd_set_polling(bs);
+		break;
+
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/administrative-down
+ */
+static int bfdd_bfd_sessions_single_hop_administrative_down_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource __attribute__((__unused__)))
+{
+	bool shutdown = yang_dnode_get_bool(dnode, NULL);
+	struct bfd_session *bs;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+		return NB_OK;
+
+	case NB_EV_APPLY:
+		break;
+
+	case NB_EV_ABORT:
+		return NB_OK;
+	}
+
+	bs = nb_running_get_entry(dnode, NULL, true);
+
+	if (shutdown == false) {
+		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+			return NB_OK;
+
+		BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
+
+		/* Change and notify state change. */
+		bs->ses_state = PTM_BFD_DOWN;
+		control_notify(bs);
+
+		/* Enable all timers. */
+		bfd_recvtimer_update(bs);
+		bfd_xmttimer_update(bs, bs->xmt_TO);
+		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO)) {
+			bfd_echo_recvtimer_update(bs);
+			bfd_echo_xmttimer_update(bs, bs->echo_xmt_TO);
+		}
+	} else {
+		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+			return NB_OK;
+
+		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN);
+
+		/* Disable all events. */
+		bfd_recvtimer_delete(bs);
+		bfd_echo_recvtimer_delete(bs);
+		bfd_xmttimer_delete(bs);
+		bfd_echo_xmttimer_delete(bs);
+
+		/* Change and notify state change. */
+		bs->ses_state = PTM_BFD_ADM_DOWN;
+		control_notify(bs);
+
+		ptm_bfd_snd(bs, 0);
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/echo-mode
+ */
+static int bfdd_bfd_sessions_single_hop_echo_mode_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource __attribute__((__unused__)))
+{
+	bool echo = yang_dnode_get_bool(dnode, NULL);
+	struct bfd_session *bs;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+		return NB_OK;
+
+	case NB_EV_APPLY:
+		break;
+
+	case NB_EV_ABORT:
+		return NB_OK;
+	}
+
+	bs = nb_running_get_entry(dnode, NULL, true);
+
+	if (echo == false) {
+		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+			return NB_OK;
+
+		BFD_UNSET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
+		ptm_bfd_echo_stop(bs);
+	} else {
+		if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+			return NB_OK;
+
+		BFD_SET_FLAG(bs->flags, BFD_SESS_FLAG_ECHO);
+		/* Apply setting immediately. */
+		if (!BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_SHUTDOWN))
+			bs_echo_timer_handler(bs);
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath:
+ * /frr-bfdd:bfdd/bfd/sessions/single-hop/desired-echo-transmission-interval
+ */
+static int
+bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource __attribute__((__unused__)))
+{
+	uint32_t echo_interval = yang_dnode_get_uint32(dnode, NULL);
+	struct bfd_session *bs;
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		if (echo_interval < 10 || echo_interval > 60000)
+			return NB_ERR_VALIDATION;
+		break;
+
+	case NB_EV_PREPARE:
+		/* NOTHING */
+		break;
+
+	case NB_EV_APPLY:
+		bs = nb_running_get_entry(dnode, NULL, true);
+
+		echo_interval *= 1000;
+		if (echo_interval == bs->timers.required_min_echo)
+			return NB_OK;
+
+		bs->timers.required_min_echo = echo_interval;
+		break;
+
+	case NB_EV_ABORT:
+		/* NOTHING */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-discriminator
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint32(xpath, bs->discrs.my_discr);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-state
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_local_state_get_elem(const char *xpath,
+							const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_enum(xpath, bs->ses_state);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-diagnostic
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_enum(xpath, bs->local_diag);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-multiplier
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_int8(xpath, bs->detect_mult);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-discriminator
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint32(xpath, bs->discrs.remote_discr);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-state
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem(const char *xpath,
+							 const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_enum(xpath, bs->ses_state);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-diagnostic
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_enum(xpath, bs->remote_diag);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-multiplier
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_int8(xpath, bs->remote_detect_mult);
+}
+
+/*
+ * XPath:
+ * /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/negotiated-transmission-interval
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint32(xpath,
+				    bs->remote_timers.desired_min_tx / 1000);
+}
+
+/*
+ * XPath:
+ * /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/negotiated-receive-interval
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint32(xpath,
+				    bs->remote_timers.required_min_rx / 1000);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/detection-mode
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+	int detection_mode;
+
+	/*
+	 * Detection mode:
+	 *   1. Async with echo
+	 *   2. Async without echo
+	 *   3. Demand with echo
+	 *   4. Demand without echo
+	 *
+	 * TODO: support demand mode.
+	 */
+	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_ECHO))
+		detection_mode = 1;
+	else
+		detection_mode = 2;
+
+	return yang_data_new_enum(xpath, detection_mode);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/last-down-time
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem(
+	const char *xpath __attribute__((__unused__)),
+	const void *list_entry __attribute__((__unused__)))
+{
+	/*
+	 * TODO: implement me.
+	 *
+	 * No yang support for time elements yet.
+	 */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/last-up-time
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem(
+	const char *xpath __attribute__((__unused__)),
+	const void *list_entry __attribute__((__unused__)))
+{
+	/*
+	 * TODO: implement me.
+	 *
+	 * No yang support for time elements yet.
+	 */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/session-down-count
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint64(xpath, bs->stats.session_down);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/session-up-count
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint64(xpath, bs->stats.session_up);
+}
+
+/*
+ * XPath:
+ * /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-input-count
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint64(xpath, bs->stats.rx_ctrl_pkt);
+}
+
+/*
+ * XPath:
+ * /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-output-count
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint64(xpath, bs->stats.tx_ctrl_pkt);
+}
+
+/*
+ * XPath:
+ * /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/negotiated-echo-transmission-interval
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint32(xpath,
+				    bs->remote_timers.required_min_echo / 1000);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/echo-packet-input-count
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint64(xpath, bs->stats.rx_echo_pkt);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/stats/echo-packet-output-count
+ */
+static struct yang_data *
+bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	const struct bfd_session *bs = list_entry;
+
+	return yang_data_new_uint64(xpath, bs->stats.tx_echo_pkt);
+}
+
+/*
+ * XPath: /frr-bfdd:bfdd/bfd/sessions/multi-hop
+ */
+static int bfdd_bfd_sessions_multi_hop_create(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
+{
+	return bfd_session_create(event, dnode, resource, true);
+}
+
+static int bfdd_bfd_sessions_multi_hop_destroy(enum nb_event event,
+					       const struct lyd_node *dnode)
+{
+	return bfd_session_destroy(event, dnode, true);
+}
+
+static const void *
+bfdd_bfd_sessions_multi_hop_get_next(const void *parent_list_entry
+				     __attribute__((__unused__)),
+				     const void *list_entry)
+{
+	return bfd_session_next(list_entry, true);
+}
+
+static int bfdd_bfd_sessions_multi_hop_get_keys(const void *list_entry,
+						struct yang_list_keys *keys)
+{
+	const struct bfd_session *bs = list_entry;
+	char dstbuf[INET6_ADDRSTRLEN], srcbuf[INET6_ADDRSTRLEN];
+
+	inet_ntop(bs->key.family, &bs->key.peer, dstbuf, sizeof(dstbuf));
+	inet_ntop(bs->key.family, &bs->key.local, srcbuf, sizeof(srcbuf));
+
+	keys->num = 4;
+	strlcpy(keys->key[0], srcbuf, sizeof(keys->key[0]));
+	strlcpy(keys->key[1], dstbuf, sizeof(keys->key[1]));
+	strlcpy(keys->key[2], bs->key.ifname, sizeof(keys->key[2]));
+	strlcpy(keys->key[3], bs->key.vrfname, sizeof(keys->key[3]));
+
+	return NB_OK;
+}
+
+static const void *
+bfdd_bfd_sessions_multi_hop_lookup_entry(const void *parent_list_entry
+					 __attribute__((__unused__)),
+					 const struct yang_list_keys *keys)
+{
+	const char *source_addr = keys->key[0];
+	const char *dest_addr = keys->key[1];
+	const char *ifname = keys->key[2];
+	const char *vrf = keys->key[3];
+	struct sockaddr_any psa, lsa;
+	struct bfd_key bk;
+
+	strtosa(dest_addr, &psa);
+	strtosa(source_addr, &lsa);
+	gen_bfd_key(&bk, &psa, &lsa, true, ifname, vrf);
+
+	return bfd_key_lookup(bk);
+}
+
+/* clang-format off */
+const struct frr_yang_module_info frr_bfdd_info = {
+	.name = "frr-bfdd",
+	.nodes = {
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd",
+			.cbs.create = bfdd_bfd_create,
+			.cbs.destroy = bfdd_bfd_destroy,
+			.cbs.cli_show = bfd_cli_show_header,
+			.cbs.cli_show_end = bfd_cli_show_header_end,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop",
+			.cbs.create = bfdd_bfd_sessions_single_hop_create,
+			.cbs.destroy = bfdd_bfd_sessions_single_hop_destroy,
+			.cbs.get_next = bfdd_bfd_sessions_single_hop_get_next,
+			.cbs.get_keys = bfdd_bfd_sessions_single_hop_get_keys,
+			.cbs.lookup_entry = bfdd_bfd_sessions_single_hop_lookup_entry,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/source-addr",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_source_addr_modify,
+			.cbs.destroy = bfdd_bfd_sessions_single_hop_source_addr_destroy,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/detection-multiplier",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/desired-transmission-interval",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/required-receive-interval",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/administrative-down",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/echo-mode",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_echo_mode_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/desired-echo-transmission-interval",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-discriminator",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-state",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_state_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-diagnostic",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-multiplier",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-discriminator",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-state",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-diagnostic",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-multiplier",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/negotiated-transmission-interval",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/negotiated-receive-interval",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/detection-mode",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/last-down-time",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/last-up-time",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/session-down-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/session-up-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-input-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-output-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/negotiated-echo-transmission-interval",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/echo-packet-input-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/echo-packet-output-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop",
+			.cbs.create = bfdd_bfd_sessions_multi_hop_create,
+			.cbs.destroy = bfdd_bfd_sessions_multi_hop_destroy,
+			.cbs.get_next = bfdd_bfd_sessions_multi_hop_get_next,
+			.cbs.get_keys = bfdd_bfd_sessions_multi_hop_get_keys,
+			.cbs.lookup_entry = bfdd_bfd_sessions_multi_hop_lookup_entry,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/detection-multiplier",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/desired-transmission-interval",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/required-receive-interval",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/administrative-down",
+			.cbs.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/local-discriminator",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/local-state",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_state_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/local-diagnostic",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/local-multiplier",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/remote-discriminator",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/remote-state",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/remote-diagnostic",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/remote-multiplier",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/negotiated-transmission-interval",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/negotiated-receive-interval",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/detection-mode",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/last-down-time",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/last-up-time",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/session-down-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/session-up-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/control-packet-input-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/control-packet-output-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/negotiated-echo-transmission-interval",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/echo-packet-input-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem,
+		},
+		{
+			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/echo-packet-output-count",
+			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem,
+		},
+		{
+			.xpath = NULL,
+		},
+	}
+};

--- a/bfdd/bfdd_northbound.c
+++ b/bfdd/bfdd_northbound.c
@@ -839,6 +839,8 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.cbs.get_next = bfdd_bfd_sessions_single_hop_get_next,
 			.cbs.get_keys = bfdd_bfd_sessions_single_hop_get_keys,
 			.cbs.lookup_entry = bfdd_bfd_sessions_single_hop_lookup_entry,
+			.cbs.cli_show = bfd_cli_show_single_hop_peer,
+			.cbs.cli_show_end = bfd_cli_show_peer_end,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/source-addr",
@@ -848,26 +850,32 @@ const struct frr_yang_module_info frr_bfdd_info = {
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/detection-multiplier",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
+			.cbs.cli_show = bfd_cli_show_mult,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/desired-transmission-interval",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
+			.cbs.cli_show = bfd_cli_show_tx,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/required-receive-interval",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
+			.cbs.cli_show = bfd_cli_show_rx,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/administrative-down",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
+			.cbs.cli_show = bfd_cli_show_shutdown,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/echo-mode",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_echo_mode_modify,
+			.cbs.cli_show = bfd_cli_show_echo,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/desired-echo-transmission-interval",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify,
+			.cbs.cli_show = bfd_cli_show_echo_interval,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-discriminator",
@@ -956,22 +964,28 @@ const struct frr_yang_module_info frr_bfdd_info = {
 			.cbs.get_next = bfdd_bfd_sessions_multi_hop_get_next,
 			.cbs.get_keys = bfdd_bfd_sessions_multi_hop_get_keys,
 			.cbs.lookup_entry = bfdd_bfd_sessions_multi_hop_lookup_entry,
+			.cbs.cli_show = bfd_cli_show_multi_hop_peer,
+			.cbs.cli_show_end = bfd_cli_show_peer_end,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/detection-multiplier",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
+			.cbs.cli_show = bfd_cli_show_mult,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/desired-transmission-interval",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
+			.cbs.cli_show = bfd_cli_show_tx,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/required-receive-interval",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
+			.cbs.cli_show = bfd_cli_show_rx,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/administrative-down",
 			.cbs.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
+			.cbs.cli_show = bfd_cli_show_shutdown,
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/local-discriminator",

--- a/bfdd/bfdd_northbound.c
+++ b/bfdd/bfdd_northbound.c
@@ -546,6 +546,9 @@ bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem(
 {
 	const struct bfd_session *bs = list_entry;
 
+	if (bs->discrs.remote_discr == 0)
+		return NULL;
+
 	return yang_data_new_uint32(xpath, bs->discrs.remote_discr);
 }
 

--- a/bfdd/bfdd_northbound.c
+++ b/bfdd/bfdd_northbound.c
@@ -72,12 +72,6 @@ int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
 
 	switch (event) {
 	case NB_EV_VALIDATE:
-		bfd_session_get_key(mhop, dnode, &bk);
-		bs = bfd_key_lookup(bk);
-
-		/* This session was already configured by CLI. */
-		if (bs != NULL && BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG))
-			return NB_ERR_VALIDATION;
 		break;
 
 	case NB_EV_PREPARE:
@@ -142,7 +136,7 @@ int bfd_session_destroy(enum nb_event event, const struct lyd_node *dnode,
 	case NB_EV_VALIDATE:
 		bfd_session_get_key(mhop, dnode, &bk);
 		if (bfd_key_lookup(bk) == NULL)
-			return NB_ERR_VALIDATION;
+			return NB_ERR_INCONSISTENCY;
 		break;
 
 	case NB_EV_PREPARE:
@@ -296,8 +290,6 @@ static int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(
 
 	switch (event) {
 	case NB_EV_VALIDATE:
-		if (detection_multiplier == 1)
-			return NB_ERR_VALIDATION;
 		break;
 
 	case NB_EV_PREPARE:

--- a/bfdd/bfdd_northbound.c
+++ b/bfdd/bfdd_northbound.c
@@ -28,20 +28,10 @@
 #include "bfd.h"
 
 /*
- * Prototypes.
- */
-void bfd_session_get_key(bool mhop, const struct lyd_node *dnode,
-			 struct bfd_key *bk);
-int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
-		       union nb_resource *resource, bool mhop);
-int bfd_session_destroy(enum nb_event event, const struct lyd_node *dnode,
-			bool mhop);
-
-/*
  * Helpers.
  */
-void bfd_session_get_key(bool mhop, const struct lyd_node *dnode,
-			 struct bfd_key *bk)
+static void bfd_session_get_key(bool mhop, const struct lyd_node *dnode,
+				struct bfd_key *bk)
 {
 	const char *ifname = NULL, *vrfname = NULL;
 	struct sockaddr_any psa, lsa;
@@ -64,8 +54,8 @@ void bfd_session_get_key(bool mhop, const struct lyd_node *dnode,
 	gen_bfd_key(bk, &psa, &lsa, mhop, ifname, vrfname);
 }
 
-int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
-		       union nb_resource *resource, bool mhop)
+static int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
+			      union nb_resource *resource, bool mhop)
 {
 	struct bfd_session *bs;
 	struct bfd_key bk;
@@ -126,8 +116,8 @@ int bfd_session_create(enum nb_event event, const struct lyd_node *dnode,
 	return NB_OK;
 }
 
-int bfd_session_destroy(enum nb_event event, const struct lyd_node *dnode,
-			bool mhop)
+static int bfd_session_destroy(enum nb_event event,
+			       const struct lyd_node *dnode, bool mhop)
 {
 	struct bfd_session *bs;
 	struct bfd_key bk;

--- a/bfdd/bfdd_northbound.c
+++ b/bfdd/bfdd_northbound.c
@@ -327,7 +327,7 @@ static int bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify(
 
 	switch (event) {
 	case NB_EV_VALIDATE:
-		if (tx_interval < 10 || tx_interval > 60000)
+		if (tx_interval < 10000 || tx_interval > 60000000)
 			return NB_ERR_VALIDATION;
 		break;
 
@@ -337,8 +337,6 @@ static int bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify(
 
 	case NB_EV_APPLY:
 		bs = nb_running_get_entry(dnode, NULL, true);
-
-		tx_interval *= 1000;
 		if (tx_interval == bs->timers.desired_min_tx)
 			return NB_OK;
 
@@ -366,7 +364,7 @@ static int bfdd_bfd_sessions_single_hop_required_receive_interval_modify(
 
 	switch (event) {
 	case NB_EV_VALIDATE:
-		if (rx_interval < 10 || rx_interval > 60000)
+		if (rx_interval < 10000 || rx_interval > 60000000)
 			return NB_ERR_VALIDATION;
 		break;
 
@@ -376,8 +374,6 @@ static int bfdd_bfd_sessions_single_hop_required_receive_interval_modify(
 
 	case NB_EV_APPLY:
 		bs = nb_running_get_entry(dnode, NULL, true);
-
-		rx_interval *= 1000;
 		if (rx_interval == bs->timers.required_min_rx)
 			return NB_OK;
 
@@ -513,7 +509,7 @@ bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify(
 
 	switch (event) {
 	case NB_EV_VALIDATE:
-		if (echo_interval < 10 || echo_interval > 60000)
+		if (echo_interval < 10000 || echo_interval > 60000000)
 			return NB_ERR_VALIDATION;
 		break;
 
@@ -523,8 +519,6 @@ bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify(
 
 	case NB_EV_APPLY:
 		bs = nb_running_get_entry(dnode, NULL, true);
-
-		echo_interval *= 1000;
 		if (echo_interval == bs->timers.required_min_echo)
 			return NB_OK;
 
@@ -648,8 +642,7 @@ bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem(
 {
 	const struct bfd_session *bs = list_entry;
 
-	return yang_data_new_uint32(xpath,
-				    bs->remote_timers.desired_min_tx / 1000);
+	return yang_data_new_uint32(xpath, bs->remote_timers.desired_min_tx);
 }
 
 /*
@@ -662,8 +655,7 @@ bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem(
 {
 	const struct bfd_session *bs = list_entry;
 
-	return yang_data_new_uint32(xpath,
-				    bs->remote_timers.required_min_rx / 1000);
+	return yang_data_new_uint32(xpath, bs->remote_timers.required_min_rx);
 }
 
 /*
@@ -785,8 +777,7 @@ bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_ele
 {
 	const struct bfd_session *bs = list_entry;
 
-	return yang_data_new_uint32(xpath,
-				    bs->remote_timers.required_min_echo / 1000);
+	return yang_data_new_uint32(xpath, bs->remote_timers.required_min_echo);
 }
 
 /*

--- a/bfdd/bfdd_northbound.c
+++ b/bfdd/bfdd_northbound.c
@@ -20,6 +20,8 @@
  * 02110-1301 USA.
  */
 
+#include <zebra.h>
+
 #include "lib/log.h"
 #include "lib/northbound.h"
 

--- a/bfdd/bfdd_northbound.c
+++ b/bfdd/bfdd_northbound.c
@@ -871,245 +871,353 @@ const struct frr_yang_module_info frr_bfdd_info = {
 	.nodes = {
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd",
-			.cbs.create = bfdd_bfd_create,
-			.cbs.destroy = bfdd_bfd_destroy,
-			.cbs.cli_show = bfd_cli_show_header,
-			.cbs.cli_show_end = bfd_cli_show_header_end,
+			.cbs = {
+				.create = bfdd_bfd_create,
+				.destroy = bfdd_bfd_destroy,
+				.cli_show = bfd_cli_show_header,
+				.cli_show_end = bfd_cli_show_header_end,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop",
-			.cbs.create = bfdd_bfd_sessions_single_hop_create,
-			.cbs.destroy = bfdd_bfd_sessions_single_hop_destroy,
-			.cbs.get_next = bfdd_bfd_sessions_single_hop_get_next,
-			.cbs.get_keys = bfdd_bfd_sessions_single_hop_get_keys,
-			.cbs.lookup_entry = bfdd_bfd_sessions_single_hop_lookup_entry,
-			.cbs.cli_show = bfd_cli_show_single_hop_peer,
-			.cbs.cli_show_end = bfd_cli_show_peer_end,
+			.cbs = {
+				.create = bfdd_bfd_sessions_single_hop_create,
+				.destroy = bfdd_bfd_sessions_single_hop_destroy,
+				.get_next = bfdd_bfd_sessions_single_hop_get_next,
+				.get_keys = bfdd_bfd_sessions_single_hop_get_keys,
+				.lookup_entry = bfdd_bfd_sessions_single_hop_lookup_entry,
+				.cli_show = bfd_cli_show_single_hop_peer,
+				.cli_show_end = bfd_cli_show_peer_end,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/source-addr",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_source_addr_modify,
-			.cbs.destroy = bfdd_bfd_sessions_single_hop_source_addr_destroy,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_source_addr_modify,
+				.destroy = bfdd_bfd_sessions_single_hop_source_addr_destroy,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/detection-multiplier",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
-			.cbs.cli_show = bfd_cli_show_mult,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
+				.cli_show = bfd_cli_show_mult,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/desired-transmission-interval",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
-			.cbs.cli_show = bfd_cli_show_tx,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
+				.cli_show = bfd_cli_show_tx,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/required-receive-interval",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
-			.cbs.cli_show = bfd_cli_show_rx,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
+				.cli_show = bfd_cli_show_rx,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/administrative-down",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
-			.cbs.cli_show = bfd_cli_show_shutdown,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
+				.cli_show = bfd_cli_show_shutdown,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/echo-mode",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_echo_mode_modify,
-			.cbs.cli_show = bfd_cli_show_echo,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_echo_mode_modify,
+				.cli_show = bfd_cli_show_echo,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/desired-echo-transmission-interval",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify,
-			.cbs.cli_show = bfd_cli_show_echo_interval,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_desired_echo_transmission_interval_modify,
+				.cli_show = bfd_cli_show_echo_interval,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-discriminator",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-state",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_state_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_state_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-diagnostic",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/local-multiplier",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-discriminator",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-state",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-diagnostic",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/remote-multiplier",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/negotiated-transmission-interval",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/negotiated-receive-interval",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/detection-mode",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/last-down-time",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/last-up-time",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/session-down-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/session-up-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-input-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/control-packet-output-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/negotiated-echo-transmission-interval",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/echo-packet-input-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/single-hop/stats/echo-packet-output-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop",
-			.cbs.create = bfdd_bfd_sessions_multi_hop_create,
-			.cbs.destroy = bfdd_bfd_sessions_multi_hop_destroy,
-			.cbs.get_next = bfdd_bfd_sessions_multi_hop_get_next,
-			.cbs.get_keys = bfdd_bfd_sessions_multi_hop_get_keys,
-			.cbs.lookup_entry = bfdd_bfd_sessions_multi_hop_lookup_entry,
-			.cbs.cli_show = bfd_cli_show_multi_hop_peer,
-			.cbs.cli_show_end = bfd_cli_show_peer_end,
+			.cbs = {
+				.create = bfdd_bfd_sessions_multi_hop_create,
+				.destroy = bfdd_bfd_sessions_multi_hop_destroy,
+				.get_next = bfdd_bfd_sessions_multi_hop_get_next,
+				.get_keys = bfdd_bfd_sessions_multi_hop_get_keys,
+				.lookup_entry = bfdd_bfd_sessions_multi_hop_lookup_entry,
+				.cli_show = bfd_cli_show_multi_hop_peer,
+				.cli_show_end = bfd_cli_show_peer_end,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/detection-multiplier",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
-			.cbs.cli_show = bfd_cli_show_mult,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_detection_multiplier_modify,
+				.cli_show = bfd_cli_show_mult,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/desired-transmission-interval",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
-			.cbs.cli_show = bfd_cli_show_tx,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_desired_transmission_interval_modify,
+				.cli_show = bfd_cli_show_tx,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/required-receive-interval",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
-			.cbs.cli_show = bfd_cli_show_rx,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_required_receive_interval_modify,
+				.cli_show = bfd_cli_show_rx,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/administrative-down",
-			.cbs.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
-			.cbs.cli_show = bfd_cli_show_shutdown,
+			.cbs = {
+				.modify = bfdd_bfd_sessions_single_hop_administrative_down_modify,
+				.cli_show = bfd_cli_show_shutdown,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/local-discriminator",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_discriminator_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/local-state",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_state_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_state_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/local-diagnostic",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_diagnostic_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/local-multiplier",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_local_multiplier_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/remote-discriminator",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_discriminator_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/remote-state",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_state_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/remote-diagnostic",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_diagnostic_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/remote-multiplier",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_remote_multiplier_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/negotiated-transmission-interval",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_transmission_interval_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/negotiated-receive-interval",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_receive_interval_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/detection-mode",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_detection_mode_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/last-down-time",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_last_down_time_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/last-up-time",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_last_up_time_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/session-down-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_session_down_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/session-up-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_session_up_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/control-packet-input-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_input_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/control-packet-output-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_control_packet_output_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/negotiated-echo-transmission-interval",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_negotiated_echo_transmission_interval_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/echo-packet-input-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_input_count_get_elem,
+			}
 		},
 		{
 			.xpath = "/frr-bfdd:bfdd/bfd/sessions/multi-hop/stats/echo-packet-output-count",
-			.cbs.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem,
+			.cbs = {
+				.get_elem = bfdd_bfd_sessions_single_hop_stats_echo_packet_output_count_get_elem,
+			}
 		},
 		{
 			.xpath = NULL,

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -296,27 +296,6 @@ DEFPY(bfd_peer_echo, bfd_peer_echo_cmd, "[no] echo-mode",
 	return CMD_SUCCESS;
 }
 
-DEFPY(bfd_peer_label, bfd_peer_label_cmd, "label WORD$label",
-      "Register peer label\n"
-      "Register peer label identification\n")
-{
-	struct bfd_session *bs;
-
-	/* Validate label length. */
-	if (strlen(label) >= MAXNAMELEN) {
-		vty_out(vty, "%% Label name is too long\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	bs = VTY_GET_CONTEXT(bfd_session);
-	if (bfd_session_update_label(bs, label) == -1) {
-		vty_out(vty, "%% Failed to update peer label.\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	return CMD_SUCCESS;
-}
-
 DEFPY(bfd_no_peer, bfd_no_peer_cmd,
       "no peer <A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname|vrf NAME$vrfname}]",
       NO_STR
@@ -1103,5 +1082,4 @@ void bfdd_vty_init(void)
 	install_element(BFD_PEER_NODE, &bfd_peer_echointerval_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_shutdown_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_cmd);
-	install_element(BFD_PEER_NODE, &bfd_peer_label_cmd);
 }

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -72,15 +72,6 @@ _find_peer_or_error(struct vty *vty, int argc, struct cmd_token **argv,
 		    const char *local_str, const char *ifname,
 		    const char *vrfname);
 
-/*
- * Commands definition.
- */
-DEFUN_NOSH(bfd_enter, bfd_enter_cmd, "bfd", "Configure BFD peers\n")
-{
-	vty->node = BFD_NODE;
-	return CMD_SUCCESS;
-}
-
 
 /*
  * Show commands helper functions
@@ -743,7 +734,6 @@ void bfdd_vty_init(void)
 	install_element(ENABLE_NODE, &bfd_show_peer_counters_cmd);
 	install_element(ENABLE_NODE, &bfd_show_peers_cmd);
 	install_element(ENABLE_NODE, &bfd_show_peer_cmd);
-	install_element(CONFIG_NODE, &bfd_enter_cmd);
 	install_element(ENABLE_NODE, &show_debugging_bfd_cmd);
 
 	/* Install BFD node and commands. */

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -678,12 +678,6 @@ static int bfd_configure_peer(struct bfd_peer_cfg *bpc, bool mhop,
 
 	/* Handle interface specification configuration. */
 	if (ifname) {
-		if (bpc->bpc_mhop) {
-			snprintf(ebuf, ebuflen,
-				 "multihop doesn't accept interface names");
-			return -1;
-		}
-
 		bpc->bpc_has_localif = true;
 		if (strlcpy(bpc->bpc_localif, ifname, sizeof(bpc->bpc_localif))
 		    > sizeof(bpc->bpc_localif)) {

--- a/bfdd/subdir.am
+++ b/bfdd/subdir.am
@@ -35,5 +35,9 @@ noinst_HEADERS += \
 	bfdd/bfd.h \
 	# end
 
+nodist_bfdd_bfdd_SOURCES = \
+	yang/frr-bfdd.yang.c \
+	# end
+
 bfdd_bfdd_SOURCES = bfdd/bfdd.c
 bfdd_bfdd_LDADD = bfdd/libbfd.a lib/libfrr.la

--- a/bfdd/subdir.am
+++ b/bfdd/subdir.am
@@ -7,12 +7,15 @@ noinst_LIBRARIES += bfdd/libbfd.a
 sbin_PROGRAMS += bfdd/bfdd
 dist_examples_DATA += bfdd/bfdd.conf.sample
 vtysh_scan += $(top_srcdir)/bfdd/bfdd_vty.c
+vtysh_scan += $(top_srcdir)/bfdd/bfdd_cli.c
 man8 += $(MANBUILD)/bfdd.8
 endif
 
 bfdd_libbfd_a_SOURCES = \
 	bfdd/bfd.c \
+	bfdd/bfdd_northbound.c \
 	bfdd/bfdd_vty.c \
+	bfdd/bfdd_cli.c \
 	bfdd/bfd_packet.c \
 	bfdd/config.c \
 	bfdd/control.c \
@@ -23,6 +26,9 @@ bfdd_libbfd_a_SOURCES = \
 
 bfdd/bfdd_vty_clippy.c: $(CLIPPY_DEPS)
 bfdd/bfdd_vty.$(OBJEXT): bfdd/bfdd_vty_clippy.c
+
+bfdd/bfdd_cli_clippy.c: $(CLIPPY_DEPS)
+bfdd/bfdd_cli.$(OBJEXT): bfdd/bfdd_cli_clippy.c
 
 noinst_HEADERS += \
 	bfdd/bfdctl.h \

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -337,6 +337,27 @@ struct nb_callbacks {
 	 */
 	void (*cli_show)(struct vty *vty, struct lyd_node *dnode,
 			 bool show_defaults);
+
+	/*
+	 * Optional callback to show the CLI node end for lists or containers.
+	 *
+	 * vty
+	 *    The vty terminal to dump the configuration to.
+	 *
+	 * dnode
+	 *    libyang data node that should be shown in the form of a CLI
+	 *    command.
+	 *
+	 * show_defaults
+	 *    Specify whether to display default configuration values or not.
+	 *    This parameter can be ignored most of the time since the
+	 *    northbound doesn't call this callback for default leaves or
+	 *    non-presence containers that contain only default child nodes.
+	 *    The exception are commands associated to multiple configuration
+	 *    nodes, in which case it might be desirable to hide one or more
+	 *    parts of the command when this parameter is set to false.
+	 */
+	void (*cli_show_end)(struct vty *vty, struct lyd_node *dnode);
 };
 
 /*

--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -440,7 +440,7 @@ static int nb_cli_candidate_load_transaction(struct vty *vty,
  * This function detects whether next node in the iteration is upwards,
  * then return the node otherwise return NULL.
  */
-static struct lyd_node *ly_iter_next_up(struct lyd_node *elem)
+static struct lyd_node *ly_iter_next_up(const struct lyd_node *elem)
 {
 	/* Are we going downwards? Is this still not a leaf? */
 	if (!(elem->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_ANYDATA)))

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -1,0 +1,387 @@
+module frr-bfdd {
+  yang-version 1.1;
+  namespace "http://frrouting.org/yang/bfdd";
+  prefix frr-bfdd;
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import frr-interface {
+    prefix frr-interface;
+  }
+  import frr-route-types {
+    prefix frr-route-types;
+  }
+
+  organization "Free Range Routing";
+  contact
+    "FRR Users List:       <mailto:frog@lists.frrouting.org>
+     FRR Development List: <mailto:dev@lists.frrouting.org>";
+  description
+    "This module defines a model for managing FRR bfdd daemon.";
+
+  revision 2019-05-09 {
+    description "Initial revision.";
+    reference
+      "RFC 5880: Bidirectional Forwarding Detection (BFD).
+       RFC 5881: Bidirectional Forwarding Detection (BFD)
+                 for IPv4 and IPv6 (Single Hop).
+       RFC 5882: Bidirectional Forwarding Detection (BFD) for Multihop Paths.";
+  }
+
+
+  /*
+   * BFD types declaration.
+   */
+  typedef multiplier {
+    description "Detection multiplier";
+    type uint8 {
+      range 2..255;
+    }
+  }
+
+  typedef discriminator {
+    description "BFD session identification";
+    type uint32 {
+      range 1..4294967295;
+    }
+  }
+
+  typedef state {
+    description "BFD session state";
+    type enumeration {
+      enum admin-down {
+        value 0;
+        description "Administratively down";
+      }
+      enum down {
+        value 1;
+        description "Down";
+      }
+      enum init {
+        value 2;
+        description "Initializing";
+      }
+      enum up {
+        value 3;
+        description "Up";
+      }
+    }
+  }
+
+  typedef diagnostic {
+    description "BFD session diagnostic";
+    type enumeration {
+      enum ok {
+        value 0;
+        description "Ok";
+      }
+      enum control-expired {
+        value 1;
+        description "Control timer expired";
+      }
+      enum echo-failed {
+        value 2;
+        description "Echo function failed";
+      }
+      enum neighbor-down {
+        value 3;
+        description "Neighbor signaled session down";
+      }
+      enum forwarding-reset {
+        value 4;
+        description "Forwarding plane reset";
+      }
+      enum path-down {
+        value 5;
+        description "Path down";
+      }
+      enum concatenated-path-down {
+        value 6;
+        description "Concatenated path down";
+      }
+      enum administratively-down {
+        value 7;
+        description "Administratively down";
+      }
+      enum reverse-concat-path-down {
+        value 8;
+        description "Reverse concatenated path down";
+      }
+    }
+  }
+
+  /*
+   * Shared BFD items.
+   */
+  grouping session-common {
+    description "Common BFD session settings";
+
+    leaf detection-multiplier {
+      type multiplier;
+      default 3;
+      description "Local session detection multiplier";
+    }
+
+    leaf desired-transmission-interval {
+      type uint32;
+      units milliseconds;
+      default 300;
+      description "Minimum desired control packet transmission interval";
+    }
+
+    leaf required-receive-interval {
+      type uint32;
+      units milliseconds;
+      default 300;
+      description "Minimum required control packet receive interval";
+    }
+
+    leaf administrative-down {
+      type boolean;
+      default true;
+      description "Disables or enables the session administratively";
+    }
+  }
+
+  grouping session-echo {
+    description "BFD session echo settings";
+
+    leaf echo-mode {
+      type boolean;
+      default false;
+      description "Use echo packets to detect failures";
+    }
+
+    leaf desired-echo-transmission-interval {
+      type uint32;
+      units milliseconds;
+      default 50;
+      description "Minimum desired control packet transmission interval";
+    }
+  }
+
+  grouping session-states {
+    /*
+     * Local settings.
+     */
+    leaf local-discriminator {
+      type discriminator;
+      description "Local session identifier";
+    }
+
+    leaf local-state {
+      type state;
+      description "Local session state";
+    }
+
+    leaf local-diagnostic {
+      type diagnostic;
+      description "Local session diagnostic";
+    }
+
+    leaf local-multiplier {
+      type multiplier;
+      description "Local session current multiplier";
+    }
+
+    /*
+     * Remote settings.
+     */
+    leaf remote-discriminator {
+      type discriminator;
+      description "Remote session identifier";
+    }
+
+    leaf remote-state {
+      type state;
+      description "Remote session state";
+    }
+
+    leaf remote-diagnostic {
+      type diagnostic;
+      description "Local session diagnostic";
+    }
+
+    leaf remote-multiplier {
+      type multiplier;
+      description "Remote session detection multiplier";
+    }
+
+    /*
+     * Negotiated settings.
+     */
+    leaf negotiated-transmission-interval {
+      description "Negotiated transmit interval";
+      type uint32;
+      units milliseconds;
+    }
+
+    leaf negotiated-receive-interval {
+      description "Negotiated receive interval";
+      type uint32;
+      units milliseconds;
+    }
+
+    leaf detection-mode {
+      description "Detection mode";
+
+      type enumeration {
+        enum async-with-echo {
+          value "1";
+          description "Async with echo";
+        }
+        enum async-without-echo {
+          value "2";
+          description "Async without echo";
+        }
+        enum demand-with-echo {
+          value "3";
+          description "Demand with echo";
+        }
+        enum demand-without-echo {
+          value "4";
+          description "Demand without echo";
+        }
+      }
+    }
+
+    /*
+     * Statistics.
+     */
+    leaf last-down-time {
+      type yang:date-and-time;
+      description "Time and date of the last time session was down";
+    }
+
+    leaf last-up-time {
+      type yang:date-and-time;
+      description "Time and date of the last time session was up";
+    }
+
+    leaf session-down-count {
+      type uint32;
+      description "Amount of times the session went down";
+    }
+
+    leaf session-up-count {
+      type uint32;
+      description "Amount of times the session went up";
+    }
+
+    leaf control-packet-input-count {
+      type uint64;
+      description "Amount of control packets received";
+    }
+
+    leaf control-packet-output-count {
+      type uint64;
+      description "Amount of control packets sent";
+    }
+
+    /*
+     * Echo mode operational data.
+     */
+    leaf negotiated-echo-transmission-interval {
+      type uint32;
+      units milliseconds;
+      description "Negotiated echo transmit interval";
+    }
+
+    /*
+     * Statistics.
+     */
+    leaf echo-packet-input-count {
+      type uint64;
+      description "Amount of echo packets received";
+    }
+
+    leaf echo-packet-output-count {
+      type uint64;
+      description "Amount of echo packets sent";
+    }
+  }
+
+  /*
+   * BFD operational.
+   */
+  container bfdd {
+    container bfd {
+      presence "Present if the BFD protocol is enabled";
+
+      container sessions {
+        list single-hop {
+          key "dest-addr interface vrf";
+          description "List of single hop sessions";
+
+          leaf source-addr {
+            type inet:ip-address;
+            description "Local IP address";
+          }
+
+          leaf dest-addr {
+            type inet:ip-address;
+            description "IP address of the peer";
+          }
+
+          leaf interface {
+            type string {
+              length "0..16";
+            }
+            description "Interface to use to contact peer";
+          }
+
+          leaf vrf {
+            type string;
+            description "Virtual Routing Domain name";
+          }
+
+          uses session-common;
+          uses session-echo;
+
+          container stats {
+            uses session-states;
+            config false;
+          }
+        }
+
+        list multi-hop {
+          key "source-addr dest-addr interface vrf";
+          description "List of multi hop sessions";
+
+          leaf source-addr {
+            type inet:ip-address;
+            description "Local IP address";
+          }
+
+          leaf dest-addr {
+            type inet:ip-address;
+            description "IP address of the peer";
+          }
+
+          leaf interface {
+            type string {
+              length "0..16";
+            }
+            description "Interface to use to contact peer";
+          }
+
+          leaf vrf {
+            type string;
+            description "Virtual Routing Domain name";
+          }
+
+          uses session-common;
+
+          container stats {
+            uses session-states;
+            config false;
+          }
+        }
+      }
+    }
+  }
+}

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -317,11 +317,6 @@ module frr-bfdd {
           key "dest-addr interface vrf";
           description "List of single hop sessions";
 
-          leaf source-addr {
-            type inet:ip-address;
-            description "Local IP address";
-          }
-
           leaf dest-addr {
             type inet:ip-address;
             description "IP address of the peer";
@@ -337,6 +332,11 @@ module frr-bfdd {
           leaf vrf {
             type string;
             description "Virtual Routing Domain name";
+          }
+
+          leaf source-addr {
+            type inet:ip-address;
+            description "Local IP address";
           }
 
           uses session-common;

--- a/yang/frr-bfdd.yang
+++ b/yang/frr-bfdd.yang
@@ -128,15 +128,15 @@ module frr-bfdd {
 
     leaf desired-transmission-interval {
       type uint32;
-      units milliseconds;
-      default 300;
+      units microseconds;
+      default 300000;
       description "Minimum desired control packet transmission interval";
     }
 
     leaf required-receive-interval {
       type uint32;
-      units milliseconds;
-      default 300;
+      units microseconds;
+      default 300000;
       description "Minimum required control packet receive interval";
     }
 
@@ -158,8 +158,8 @@ module frr-bfdd {
 
     leaf desired-echo-transmission-interval {
       type uint32;
-      units milliseconds;
-      default 50;
+      units microseconds;
+      default 50000;
       description "Minimum desired control packet transmission interval";
     }
   }
@@ -217,13 +217,13 @@ module frr-bfdd {
     leaf negotiated-transmission-interval {
       description "Negotiated transmit interval";
       type uint32;
-      units milliseconds;
+      units microseconds;
     }
 
     leaf negotiated-receive-interval {
       description "Negotiated receive interval";
       type uint32;
-      units milliseconds;
+      units microseconds;
     }
 
     leaf detection-mode {
@@ -287,7 +287,7 @@ module frr-bfdd {
      */
     leaf negotiated-echo-transmission-interval {
       type uint32;
-      units milliseconds;
+      units microseconds;
       description "Negotiated echo transmit interval";
     }
 

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -24,6 +24,10 @@ dist_yangmodels_DATA += yang/frr-test-module.yang
 dist_yangmodels_DATA += yang/frr-interface.yang
 dist_yangmodels_DATA += yang/frr-route-types.yang
 
+if BFDD
+dist_yangmodels_DATA += yang/frr-bfdd.yang
+endif
+
 if RIPD
 dist_yangmodels_DATA += yang/frr-ripd.yang
 endif


### PR DESCRIPTION
## Summary

This Pull Request changes the `bfdd` daemon to use the northbound and defines a YANG specification. It is still not the final version but has enough changes to have its own PR.

Highlights:

  * BFD YANG model based on IETF less notifications and unsupported features;
  * Northbound API feature: add callback to print node end (this was required to implement `peer` block ends inside the `bfd` node);
  * SIGHUP / configuration reload support;
  * New `no bfd` command to global reset BFD sessions configuration;

## Components

`bfdd`, `lib`