### PR TITLE
pimd: Remove unused functions

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3082,7 +3082,7 @@ static void pim_show_group_rp_mappings_info(struct pim_instance *pim,
 	json_object *json_row = NULL;
 
 	if (pim->global_scope.current_bsr.s_addr == INADDR_ANY)
-		strncpy(bsr_str, "0.0.0.0", sizeof(bsr_str));
+		strlcpy(bsr_str, "0.0.0.0", sizeof(bsr_str));
 
 	else
 		pim_inet4_dump("<bsr?>", pim->global_scope.current_bsr, bsr_str,
@@ -3650,7 +3650,7 @@ static void pim_show_bsr(struct pim_instance *pim,
 	vty_out(vty, "PIMv2 Bootstrap information\n");
 
 	if (pim->global_scope.current_bsr.s_addr == INADDR_ANY) {
-		strncpy(bsr_str, "0.0.0.0", sizeof(bsr_str));
+		strlcpy(bsr_str, "0.0.0.0", sizeof(bsr_str));
 		pim_time_uptime(uptime, sizeof(uptime),
 				pim->global_scope.current_bsr_first_ts);
 		pim_time_uptime(last_bsm_seen, sizeof(last_bsm_seen),
@@ -3669,16 +3669,16 @@ static void pim_show_bsr(struct pim_instance *pim,
 
 	switch (pim->global_scope.state) {
 	case NO_INFO:
-		strncpy(bsr_state, "NO_INFO", sizeof(bsr_state));
+		strlcpy(bsr_state, "NO_INFO", sizeof(bsr_state));
 		break;
 	case ACCEPT_ANY:
-		strncpy(bsr_state, "ACCEPT_ANY", sizeof(bsr_state));
+		strlcpy(bsr_state, "ACCEPT_ANY", sizeof(bsr_state));
 		break;
 	case ACCEPT_PREFERRED:
-		strncpy(bsr_state, "ACCEPT_PREFERRED", sizeof(bsr_state));
+		strlcpy(bsr_state, "ACCEPT_PREFERRED", sizeof(bsr_state));
 		break;
 	default:
-		strncpy(bsr_state, "", sizeof(bsr_state));
+		strlcpy(bsr_state, "", sizeof(bsr_state));
 	}
 
 	if (uj) {

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3806,48 +3806,6 @@ DEFUN (clear_ip_pim_statistics,
 	return CMD_SUCCESS;
 }
 
-static void mroute_add_all(struct pim_instance *pim)
-{
-	struct listnode *node;
-	struct channel_oil *c_oil;
-
-	for (ALL_LIST_ELEMENTS_RO(pim->channel_oil_list, node, c_oil)) {
-		if (pim_mroute_add(c_oil, __PRETTY_FUNCTION__)) {
-			/* just log warning */
-			char source_str[INET_ADDRSTRLEN];
-			char group_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<source?>", c_oil->oil.mfcc_origin,
-				       source_str, sizeof(source_str));
-			pim_inet4_dump("<group?>", c_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			zlog_warn("%s %s: (S,G)=(%s,%s) failure writing MFC",
-				  __FILE__, __PRETTY_FUNCTION__, source_str,
-				  group_str);
-		}
-	}
-}
-
-static void mroute_del_all(struct pim_instance *pim)
-{
-	struct listnode *node;
-	struct channel_oil *c_oil;
-
-	for (ALL_LIST_ELEMENTS_RO(pim->channel_oil_list, node, c_oil)) {
-		if (pim_mroute_del(c_oil, __PRETTY_FUNCTION__)) {
-			/* just log warning */
-			char source_str[INET_ADDRSTRLEN];
-			char group_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<source?>", c_oil->oil.mfcc_origin,
-				       source_str, sizeof(source_str));
-			pim_inet4_dump("<group?>", c_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			zlog_warn("%s %s: (S,G)=(%s,%s) failure clearing MFC",
-				  __FILE__, __PRETTY_FUNCTION__, source_str,
-				  group_str);
-		}
-	}
-}
-
 static void clear_mroute(struct pim_instance *pim)
 {
 	struct pim_upstream *up;


### PR DESCRIPTION
Recent commits rewrote the `clear mroute` command and this caused
these two two functions to no longer be used, remove.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>