### PR TITLE
build: refactor & revamp python autoconf logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,15 +183,17 @@ AC_DEFUN([AC_LINK_IFELSE_FLAGS], [{
 	AC_LINK_IFELSE(
 		[$3],
 		[
-			AC_MSG_RESULT([yes])
 			CFLAGS="$ac_cflags_save"
 			LIBS="$ac_libs_save"
-			$5
+			m4_default([$5], [
+				AC_MSG_RESULT([yes])
+			])
 		], [
-			AC_MSG_RESULT([no])
 			CFLAGS="$ac_cflags_save"
 			LIBS="$ac_libs_save"
-			$4
+			m4_default([$4], [
+				AC_MSG_RESULT([no])
+			])
 		])
 	AC_LANG_POP([C])
 	}])
@@ -609,92 +611,30 @@ AM_CONDITIONAL([FPM], [test "x$enable_fpm" = "xyes"])
 # Python for clippy
 #
 
-AC_DEFUN([FRR_PYTHON_CHECK_WORKING], [
-  AC_MSG_CHECKING([whether we found a working Python version])
-  AC_LINK_IFELSE_FLAGS([$PYTHON_CFLAGS], [$PYTHON_LIBS], [AC_LANG_PROGRAM([
-#include <Python.h>
-#if PY_VERSION_HEX < 0x02070000
-#error python too old
-#endif
-int main(void);
-],
-[
-{
-  Py_Initialize();
-  return 0;
-}
-])], [
-    # some python installs are missing the zlib dependency...
-    PYTHON_LIBS="${PYTHON_LIBS} -lz"
-    AC_LINK_IFELSE_FLAGS([$PYTHON_CFLAGS], [$PYTHON_LIBS], [AC_LANG_PROGRAM([
-#include <Python.h>
-#if PY_VERSION_HEX < 0x02070000
-#error python too old
-#endif
-int main(void);
-],
-[
-{
-  Py_Initialize();
-  return 0;
-}
-])], [
-      m4_if([$1], [], [
-        PYTHONCONFIG=""
-        unset PYTHON_LIBS
-        unset PYTHON_CFLAGS
-      ], [$1])
-    ])
-  ])
-])
-
 AS_IF([test "$host" = "$build"], [
-  PYTHONCONFIG=""
-
-  # ordering:
-  # 1.  try python3, but respect the user's preference on which minor ver
-  # 2.  try python, which might be py3 or py2 again on the user's preference
-  # 3.  try python2 (can really only be 2.7 but eh)
-  # 4.  try 3.6 > 3.5 > 3.4 > 3.3 > 3.2 > 2.7 through pkg-config (no user pref)
-  #
-  # (AX_PYTHON_DEVEL has no clue about py3 vs py2)
-  # (AX_PYTHON does not do what we need)
-
-  AC_CHECK_TOOLS([PYTHONCONFIG], [ \
-	python3-config \
-	python-config \
-	python2-config \
-	python3.6-config \
-	python3.5-config \
-	python3.4-config \
-	python3.3-config \
-	python3.2-config \
-	python2.7-config ])
-  if test -n "$PYTHONCONFIG"; then
-    PYTHON_CFLAGS="`\"${PYTHONCONFIG}\" --includes`"
-    PYTHON_LIBS="`\"${PYTHONCONFIG}\" --ldflags`"
-
-    FRR_PYTHON_CHECK_WORKING([])
-  fi
-
-  if test -z "$PYTHONCONFIG"; then
-    PKG_CHECK_MODULES([PYTHON], [python-3.6], [], [
-      PKG_CHECK_MODULES([PYTHON], [python-3.5], [], [
-        PKG_CHECK_MODULES([PYTHON], [python-3.4], [], [
-          PKG_CHECK_MODULES([PYTHON], [python-3.3], [], [
-            PKG_CHECK_MODULES([PYTHON], [python-3.2], [], [
-              PKG_CHECK_MODULES([PYTHON], [python-2.7], [], [
-                AC_MSG_FAILURE([could not find python-config or pkg-config python, please install Python development files from libpython-dev or similar])
-                ])])])])])])
-
-
-    FRR_PYTHON_CHECK_WORKING([
-      AC_MSG_FAILURE([could not find python-config or pkg-config python, please install Python development files from libpython-dev or similar])
-    ])
-  fi
+  FRR_PYTHON_DEV
+], [
+  FRR_PYTHON
 ])
-AC_SUBST([PYTHON_CFLAGS])
-AC_SUBST([PYTHON_LIBS])
+
+FRR_PYTHON_MODULES([pytest])
+
+if test "${enable_doc}" != "no"; then
+  FRR_PYTHON_MODULES([sphinx], , [
+    if test "${enable_doc}" = "yes"; then
+      AC_MSG_ERROR([Documentation was explicitly requested with --enable-doc but sphinx is not available for $PYTHON. Please disable docs or install sphinx.])
+    fi
+  ])
+fi
+AM_CONDITIONAL([DOC], [test "${enable_doc}" != "no" -a "$frr_py_mod_sphinx" != "false"])
+AM_CONDITIONAL([DOC_HTML], [test "${enable_doc_html}" = "yes"])
+
+FRR_PYTHON_MOD_EXEC([sphinx], [--version], [
+  PYSPHINX="-m sphinx"
+], [
+  PYSPHINX="-c 'import sys; from sphinx import main; sys.exit(main(sys.argv))'"
+])
+AC_SUBST([PYSPHINX])
 
 #
 # Logic for protobuf support.
@@ -1507,16 +1447,6 @@ FRR_INCLUDES
 #endif
 ])dnl
 
-dnl disable doc check
-AC_CHECK_PROGS([SPHINXBUILD], [sphinx-build sphinx-build3 sphinx-build2], [/bin/false])
-if test "$SPHINXBUILD" = "/bin/false"; then
-  if test "${enable_doc}" = "yes"; then
-    AC_MSG_ERROR([Documentation was explicitly requested with --enable-doc but sphinx-build is not available. Please disable docs or install sphinx.])
-  fi
-fi
-AM_CONDITIONAL([DOC], [test "${enable_doc}" != "no" -a "$SPHINXBUILD" != "/bin/false"])
-AM_CONDITIONAL([DOC_HTML], [test "${enable_doc_html}" = "yes"])
-
 dnl --------------------
 dnl Daemon disable check
 dnl --------------------
@@ -1666,6 +1596,7 @@ int main(void);
   return 0;
 }
 ])], [
+     AC_MSG_RESULT([no])
      AC_MSG_ERROR([--enable-snmp given but not usable])])
    case "${enable_snmp}" in
      yes)
@@ -2356,7 +2287,9 @@ zebra protobuf enabled  : ${enable_protobuf:-no}
 The above user and group must have read/write access to the state file
 directory and to the config files in the config file directory."
 
-if test "${enable_doc}" != "no";then
-  AS_IF([test "$SPHINXBUILD" = /bin/false],
-     AC_MSG_WARN([sphinx-build is missing but required to build documentation]))
+if test "${enable_doc}" != "no" -a "$frr_py_mod_sphinx" = false; then
+  AC_MSG_WARN([sphinx is missing but required to build documentation])
+fi
+if test "$frr_py_mod_pytest" = false; then
+  AC_MSG_WARN([pytest is missing, unit tests cannot be performed])
 fi

--- a/doc/developer/building-frr-for-centos6.rst
+++ b/doc/developer/building-frr-for-centos6.rst
@@ -163,10 +163,9 @@ an example.)
         --disable-ldpd \
         --enable-fpm \
         --with-pkg-git-version \
-        --with-pkg-extra-version=-MyOwnFRRVersion \
-        SPHINXBUILD=sphinx-build2.7
+        --with-pkg-extra-version=-MyOwnFRRVersion
     make
-    make check PYTHON=/usr/bin/python2.7
+    make check
     sudo make install
 
 Create empty FRR configuration files

--- a/doc/developer/building-frr-for-debian8.rst
+++ b/doc/developer/building-frr-for-debian8.rst
@@ -16,7 +16,7 @@ Add packages:
 ::
 
    sudo apt-get install git autoconf automake libtool make \
-      libreadline-dev texinfo libjson-c-dev pkg-config bison flex python-pip \
+      libreadline-dev texinfo libjson-c-dev pkg-config bison flex python3-pip \
       libc-ares-dev python3-dev python3-sphinx build-essential libsystemd-dev \
       libsnmp-dev
 
@@ -24,7 +24,7 @@ Install newer pytest (>3.0) from pip
 
 ::
 
-    sudo pip install pytest
+    sudo pip3 install pytest
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-debian9.rst
+++ b/doc/developer/building-frr-for-debian9.rst
@@ -9,8 +9,8 @@ Add packages:
 ::
 
    sudo apt-get install git autoconf automake libtool make \
-     libreadline-dev texinfo libjson-c-dev pkg-config bison flex python-pip \
-     libc-ares-dev python3-dev python-pytest python3-sphinx build-essential \
+     libreadline-dev texinfo libjson-c-dev pkg-config bison flex \
+     libc-ares-dev python3-dev python3-pytest python3-sphinx build-essential \
      libsnmp-dev libsystemd-dev
 
 .. include:: building-libyang.rst

--- a/doc/developer/building-frr-for-fedora.rst
+++ b/doc/developer/building-frr-for-fedora.rst
@@ -13,8 +13,8 @@ Installing Dependencies
 
    sudo dnf install git autoconf automake libtool make \
      readline-devel texinfo net-snmp-devel groff pkgconfig json-c-devel \
-     pam-devel pytest bison flex c-ares-devel python3-devel python2-sphinx \
-     perl-core patch
+     pam-devel python3-pytest bison flex c-ares-devel python3-devel \
+     python3-sphinx perl-core patch
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-freebsd10.rst
+++ b/doc/developer/building-frr-for-freebsd10.rst
@@ -17,7 +17,7 @@ is first package install and asked)
 ::
 
     pkg install git autoconf automake libtool gmake json-c pkgconf \
-        bison flex py27-pytest c-ares python3 py-sphinx
+        bison flex py36-pytest c-ares python3.6 py36-sphinx
 
 Make sure there is no /usr/bin/flex preinstalled (and use the newly
 installed in /usr/local/bin): (FreeBSD frequently provides a older flex

--- a/doc/developer/building-frr-for-freebsd11.rst
+++ b/doc/developer/building-frr-for-freebsd11.rst
@@ -17,7 +17,7 @@ is first package install and asked)
 .. code-block:: shell
 
    pkg install git autoconf automake libtool gmake json-c pkgconf \
-      bison flex py27-pytest c-ares python3 py36-sphinx texinfo
+      bison flex py36-pytest c-ares python3.6 py36-sphinx texinfo
 
 Make sure there is no /usr/bin/flex preinstalled (and use the newly
 installed in /usr/local/bin): (FreeBSD frequently provides a older flex

--- a/doc/developer/building-frr-for-freebsd9.rst
+++ b/doc/developer/building-frr-for-freebsd9.rst
@@ -17,8 +17,8 @@ is first package install and asked)
 ::
 
     pkg install -y git autoconf automake libtool gmake \
-        pkgconf texinfo json-c bison flex py27-pytest c-ares \
-        python3 py-sphinx libexecinfo
+        pkgconf texinfo json-c bison flex py36-pytest c-ares \
+        python3 py36-sphinx libexecinfo
 
 Make sure there is no /usr/bin/flex preinstalled (and use the newly
 installed in /usr/local/bin): (FreeBSD frequently provides a older flex

--- a/doc/developer/building-frr-for-netbsd6.rst
+++ b/doc/developer/building-frr-for-netbsd6.rst
@@ -23,7 +23,7 @@ Add packages:
 ::
 
     sudo pkg_add git autoconf automake libtool gmake openssl \
-       pkg-config json-c python27 py27-test python35 py-sphinx
+       pkg-config json-c py36-test python36 py36-sphinx
 
 Install SSL Root Certificates (for git https access):
 
@@ -32,13 +32,6 @@ Install SSL Root Certificates (for git https access):
     sudo pkg_add mozilla-rootcerts
     sudo touch /etc/openssl/openssl.cnf
     sudo mozilla-rootcerts install
-
-Select default Python and py.test
-
-::
-
-    sudo ln -s /usr/pkg/bin/python2.7 /usr/bin/python
-    sudo ln -s /usr/pkg/bin/py.test-2.7 /usr/bin/py.test
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-netbsd7.rst
+++ b/doc/developer/building-frr-for-netbsd7.rst
@@ -14,7 +14,7 @@ Install required packages
 ::
 
     sudo pkgin install git autoconf automake libtool gmake openssl \
-       pkg-config json-c python27 py27-test python35 py-sphinx
+       pkg-config json-c python36 py36-test py36-sphinx
 
 Install SSL Root Certificates (for git https access):
 
@@ -23,13 +23,6 @@ Install SSL Root Certificates (for git https access):
     sudo pkgin install mozilla-rootcerts
     sudo touch /etc/openssl/openssl.cnf
     sudo mozilla-rootcerts install
-
-Select default Python and py.test
-
-::
-
-    sudo ln -s /usr/pkg/bin/python2.7 /usr/bin/python
-    sudo ln -s /usr/pkg/bin/py.test-2.7 /usr/bin/py.test
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-ubuntu1404.rst
+++ b/doc/developer/building-frr-for-ubuntu1404.rst
@@ -12,7 +12,7 @@ Installing Dependencies
    apt-get update
    apt-get install \
       git autoconf automake libtool make libreadline-dev texinfo \
-      pkg-config libpam0g-dev libjson-c-dev bison flex python-pytest \
+      pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
       libc-ares-dev python3-dev python3-sphinx install-info build-essential \
       libsnmp-dev perl
 

--- a/doc/developer/building-frr-for-ubuntu1604.rst
+++ b/doc/developer/building-frr-for-ubuntu1604.rst
@@ -12,7 +12,7 @@ Installing Dependencies
    apt-get update
    apt-get install \
       git autoconf automake libtool make libreadline-dev texinfo \
-      pkg-config libpam0g-dev libjson-c-dev bison flex python-pytest \
+      pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
       libc-ares-dev python3-dev libsystemd-dev python-ipaddress python3-sphinx \
       install-info build-essential libsystemd-dev libsnmp-dev perl
 

--- a/doc/developer/building-frr-for-ubuntu1804.rst
+++ b/doc/developer/building-frr-for-ubuntu1804.rst
@@ -12,7 +12,7 @@ Installing Dependencies
    sudo apt update
    sudo apt-get install \
       git autoconf automake libtool make libreadline-dev texinfo \
-      pkg-config libpam0g-dev libjson-c-dev bison flex python-pytest \
+      pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
       libc-ares-dev python3-dev libsystemd-dev python-ipaddress python3-sphinx \
       install-info build-essential libsystemd-dev libsnmp-dev perl
 

--- a/doc/developer/packaging-redhat.rst
+++ b/doc/developer/packaging-redhat.rst
@@ -32,7 +32,7 @@ Tested on CentOS 6, CentOS 7 and Fedora 24.
 
       cd frr
       ./bootstrap.sh
-      ./configure --with-pkg-extra-version=-MyRPMVersion SPHINXBUILD=sphinx-build2.7
+      ./configure --with-pkg-extra-version=-MyRPMVersion
       make dist
 
    .. note::

--- a/doc/subdir.am
+++ b/doc/subdir.am
@@ -4,7 +4,6 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
 PAPER         ?=
 
 # Internal variables.
@@ -32,20 +31,20 @@ am__v_MAKEINFO_1 =
 doc/%/_build/.doctrees/environment.pickle:
 	$(AM_V_SPHINX) ( \
 		subdoc="$@"; subdoc="$${subdoc#doc/}"; subdoc="doc/$${subdoc%%/*}"; \
-		$(SPHINXBUILD) -a -q -b text -d "$${subdoc}/_build/.doctrees" \
+		$(PYTHON) $(PYSPHINX) -a -q -b text -d "$${subdoc}/_build/.doctrees" \
 			$(ALLSPHINXOPTS) "$(top_srcdir)/$${subdoc}" "$${subdoc}/_build/text" \
 	)
 doc/%/_build/html/.buildinfo: doc/%/_build/.doctrees/environment.pickle
 	$(AM_V_SPHINX) ( \
 		subdoc="$@"; subdoc="$${subdoc#doc/}"; subdoc="doc/$${subdoc%%/*}"; \
-		$(SPHINXBUILD) -q -b html -d "$${subdoc}/_build/.doctrees" \
+		$(PYTHON) $(PYSPHINX) -q -b html -d "$${subdoc}/_build/.doctrees" \
 			$(ALLSPHINXOPTS) "$(top_srcdir)/$${subdoc}" "$${subdoc}/_build/html" \
 	)
 .PRECIOUS: doc/%/_build/texinfo/frr.texi
 doc/%/_build/texinfo/frr.texi: doc/%/_build/.doctrees/environment.pickle
 	$(AM_V_SPHINX) ( \
 		subdoc="$@"; subdoc="$${subdoc#doc/}"; subdoc="doc/$${subdoc%%/*}"; \
-		$(SPHINXBUILD) -q -b texinfo -d "$${subdoc}/_build/.doctrees" \
+		$(PYTHON) $(PYSPHINX) -q -b texinfo -d "$${subdoc}/_build/.doctrees" \
 			$(ALLSPHINXOPTS) "$(top_srcdir)/$${subdoc}" "$${subdoc}/_build/texinfo" \
 	)
 doc/%/_build/texinfo/frr.info: doc/%/_build/texinfo/frr.texi
@@ -54,7 +53,7 @@ doc/%/_build/man/man.stamp: doc/%/_build/.doctrees/environment.pickle
 	$(AM_V_SPHINX) ( \
 		subdoc="$@"; subdoc="$${subdoc#doc/}"; subdoc="doc/$${subdoc%%/*}"; \
 		$(MKDIR_P) "$${subdoc}/_build/man"; touch $@.tmp; \
-		$(SPHINXBUILD) -a -q -b man -d "$${subdoc}/_build/.doctrees" \
+		$(PYTHON) $(PYSPHINX) -a -q -b man -d "$${subdoc}/_build/.doctrees" \
 			$(ALLSPHINXOPTS) "$(top_srcdir)/$${subdoc}" "$${subdoc}/_build/man" && \
 			mv -f $@.tmp $@ \
 	)
@@ -80,7 +79,7 @@ $(M_SPHINXTARGETS): doc/%/_build/.doctrees/environment.pickle
 		builder="$${target##*/}"; \
 		subdoc="$${target#doc/}"; subdoc="doc/$${subdoc%%/*}"; \
 		rm -rf "$@"; \
-		$(SPHINXBUILD) -q -b $${builder} -d $${subdoc}/_build/.doctrees \
+		$(PYTHON) $(PYSPHINX) -q -b $${builder} -d $${subdoc}/_build/.doctrees \
 			$(ALLSPHINXOPTS) $(top_srcdir)/$${subdoc} $@ \
 	)
 

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -347,6 +347,27 @@ compile directory:
    ./configure --with-libyang-pluginsdir="`pwd`/yang/libyang_plugins/.libs" \
                --with-yangmodelsdir="`pwd`/yang"
 
+Python dependency, documentation and tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+FRR's documentation and basic unit tests heavily use code written in Python.
+Additionally, FRR ships Python extensions written in C which are used during
+its build process.
+
+To this extent, FRR needs the following:
+
+* an installation of CPython, preferably version 3.2 or newer (2.7 works but
+  is end of life and will stop working at some point.)
+* development files (mostly headers) for that version of CPython
+* an installation of `sphinx` for that version of CPython, to build the
+  documentation
+* an installation of `pytest` for that version of CPython, to run the unit
+  tests
+
+The `sphinx` and `pytest` dependencies can be avoided by not building
+documentation / not running ``make check``, but the CPython dependency is a
+hard dependency of the FRR build process (for the `clippy` tool.)
+
 .. _least-privilege-support:
 
 Least-Privilege Support

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -4,6 +4,7 @@
 !ax_compare_version.m4
 !ax_prog_perl_modules.m4
 !ax_pthread.m4
+!ax_python.m4
 !ax_sys_weak_alias.m4
 !ax_sys_weak_alias.m4
 !pkg.m4

--- a/m4/ax_python.m4
+++ b/m4/ax_python.m4
@@ -1,0 +1,284 @@
+dnl FRR Python autoconf magic
+dnl 2019 David Lamparter for NetDEF, Inc.
+dnl SPDX-License-Identifier: GPL-2.0-or-later
+
+dnl the _ at the beginning will be cut off (to support the empty version string)
+m4_define_default([_FRR_PY_VERS], [_3 _ _2 _3.7 _3.6 _3.5 _3.4 _3.3 _3.2 _2.7])
+
+dnl check basic interpreter properties (py2/py3)
+dnl doubles as simple check whether the interpreter actually works
+dnl also swaps in the full path to the interpreter
+dnl arg1: if-true, arg2: if-false
+AC_DEFUN([_FRR_PYTHON_INTERP], [dnl
+AC_ARG_VAR([PYTHON], [Python interpreter to use])dnl
+  AC_MSG_CHECKING([python interpreter $PYTHON])
+  AC_RUN_LOG(["$PYTHON" -c 'import sys; open("conftest.pyver", "w").write(sys.executable or ""); sys.exit(not (sys.version_info.major == 2 and sys.version_info.minor >= 7))'])
+  py2=$ac_status
+  _py2_full="`cat conftest.pyver 2>/dev/null`"
+  rm -f "conftest.pyver" >/dev/null 2>/dev/null
+
+  AC_RUN_LOG(["$PYTHON" -c 'import sys; open("conftest.pyver", "w").write(sys.executable or ""); sys.exit(not ((sys.version_info.major == 3 and sys.version_info.minor >= 2) or sys.version_info.major > 3))'])
+  py3=$ac_status
+  _py3_full="`cat conftest.pyver 2>/dev/null`"
+  rm -f "conftest.pyver" >/dev/null 2>/dev/null
+
+  case "p${py2}p${py3}" in
+  p0p1) frr_cv_python=python2
+        _python_full="$_py2_full" ;;
+  p1p0) frr_cv_python=python3
+        _python_full="$_py3_full" ;;
+  *)    frr_cv_python=none ;;
+  esac
+
+  if test "$frr_cv_python" = none; then
+    AC_MSG_RESULT([not working])
+    $2
+  else
+    test -n "$_python_full" -a -x "$_python_full" && PYTHON="$_python_full"
+    AC_MSG_RESULT([$PYTHON ($frr_cv_python)])
+    $1
+  fi
+
+  dnl return value
+  test "$frr_cv_python" != none
+])
+
+dnl check whether $PYTHON has modules available
+dnl arg1: list of modules (space separated)
+dnl arg2: if all true, arg3: if any missing
+dnl also sets frr_py_mod_<name> to "true" or "false"
+AC_DEFUN([FRR_PYTHON_MODULES], [
+  result=true
+  for pymod in $1; do
+    AC_MSG_CHECKING([whether $PYTHON module $pymod is available])
+    AC_RUN_LOG(["$PYTHON" -c "import $pymod"])
+    sane="`echo \"$pymod\" | tr -c '[a-zA-Z0-9\n]' '_'`"
+    if test "$ac_status" -eq 0; then
+      AC_MSG_RESULT([yes])
+      eval frr_py_mod_$sane=true
+    else
+      AC_MSG_RESULT([no])
+      eval frr_py_mod_$sane=false
+      result=false
+    fi
+  done
+  if $result; then
+    m4_default([$2], [:])
+  else
+    m4_default([$3], [:])
+  fi
+  $result
+])
+
+dnl check whether $PYTHON has modules available
+dnl arg1: list of modules (space separated)
+dnl arg2: command line parameters for executing
+dnl arg3: if all true, arg4: if any missing
+dnl also sets frr_py_modexec_<name> to "true" or "false"
+AC_DEFUN([FRR_PYTHON_MOD_EXEC], [
+  result=true
+  for pymod in $1; do
+    AC_MSG_CHECKING([whether $PYTHON module $pymod is executable])
+    AC_RUN_LOG(["$PYTHON" -m "$pymod" $2 > /dev/null])
+    sane="`echo \"$pymod\" | tr -c '[a-zA-Z0-9\n]' '_'`"
+    if test "$ac_status" -eq 0; then
+      AC_MSG_RESULT([yes])
+      eval frr_py_modexec_$sane=true
+    else
+      AC_MSG_RESULT([no])
+      eval frr_py_modexec_$sane=false
+      result=false
+    fi
+  done
+  if $result; then
+    m4_default([$3], [:])
+  else
+    m4_default([$4], [:])
+  fi
+  $result
+])
+
+dnl check whether we can build & link python bits
+dnl input: PYTHON_CFLAGS and PYTHON_LIBS
+AC_DEFUN([_FRR_PYTHON_DEVENV], [
+  result=true
+  AC_LINK_IFELSE_FLAGS([$PYTHON_CFLAGS], [$PYTHON_LIBS], [AC_LANG_PROGRAM([
+#include <Python.h>
+#if PY_VERSION_HEX < 0x02070000
+#error python too old
+#endif
+int main(void);
+],
+[
+{
+  Py_Initialize();
+  return 0;
+}
+])], [
+    # some python installs are missing the zlib dependency...
+    PYTHON_LIBS="${PYTHON_LIBS} -lz"
+    AC_LINK_IFELSE_FLAGS([$PYTHON_CFLAGS], [$PYTHON_LIBS], [AC_LANG_PROGRAM([
+#include <Python.h>
+#if PY_VERSION_HEX < 0x02070000
+#error python too old
+#endif
+int main(void);
+],
+[
+{
+  Py_Initialize();
+  return 0;
+}
+])], [
+      result=false
+      AC_MSG_RESULT([no])
+    ], [:])
+  ], [:])
+
+  if $result; then
+    AC_LINK_IFELSE_FLAGS([$PYTHON_CFLAGS], [$PYTHON_LIBS], [AC_LANG_PROGRAM([
+#include <Python.h>
+#if PY_VERSION_HEX != $1
+#error python version mismatch
+#endif
+int main(void);
+],
+[
+{
+  Py_Initialize();
+  return 0;
+}
+])], [
+      result=false
+      AC_MSG_RESULT([version mismatch])
+    ], [
+      AC_MSG_RESULT([yes])
+    ])
+  fi
+
+  if $result; then
+    m4_default([$2], [:])
+  else
+    m4_default([$3], [
+      unset PYTHON_LIBS
+      unset PYTHON_CFLAGS
+    ])
+  fi
+])
+
+AC_DEFUN([_FRR_PYTHON_GETDEV], [dnl
+AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+
+  py_abi="`   \"$1\" -c \"import sys; print(getattr(sys, 'abiflags', ''))\"`"
+  py_hex="`   \"$1\" -c \"import sys; print(hex(sys.hexversion))\"`"
+  py_ldver="` \"$1\" -c \"import sysconfig; print(sysconfig.get_config_var('LDVERSION') or '')\"`"
+  py_ver="`   \"$1\" -c \"import sysconfig; print(sysconfig.get_config_var('VERSION') or '')\"`"
+  py_bindir="`\"$1\" -c \"import sysconfig; print(sysconfig.get_config_var('BINDIR') or '')\"`"
+  test -z "$py_bindir" || py_bindir="$py_bindir/"
+  echo "py_abi=${py_abi} py_ldver=${py_ldver} py_ver=${py_ver} py_bindir=${py_bindir}" >&AS_MESSAGE_LOG_FD
+
+  py_found=false
+
+  for tryver in "${py_ldver}" "${py_ver}"; do
+    pycfg="${py_bindir}python${tryver}-config"
+    AC_MSG_CHECKING([whether ${pycfg} is available])
+    if "$pycfg" --configdir >/dev/null 2>/dev/null; then
+      AC_MSG_RESULT([yes])
+
+      PYTHON_CFLAGS="`\"$pycfg\" --includes`"
+      PYTHON_LIBS="`\"$pycfg\" --ldflags`"
+
+      AC_MSG_CHECKING([whether ${pycfg} provides a working build environment])
+      _FRR_PYTHON_DEVENV([$py_hex], [
+        py_found=true
+        break
+      ])
+    else
+      AC_MSG_RESULT([no])
+    fi
+
+    pkg_failed=no
+    AC_MSG_CHECKING([whether pkg-config python-${tryver} is available])
+    unset PYTHON_CFLAGS
+    unset PYTHON_LIBS
+    pkg="python-${tryver}"
+    pkg="${pkg%-}"
+    _PKG_CONFIG([PYTHON_CFLAGS], [cflags], [${pkg}])
+    _PKG_CONFIG([PYTHON_LIBS], [libs], [${pkg}])
+    if test $pkg_failed = no; then
+      AC_MSG_RESULT([yes])
+
+      PYTHON_CFLAGS=$pkg_cv_PYTHON_CFLAGS
+      PYTHON_LIBS=$pkg_cv_PYTHON_LIBS
+
+      AC_MSG_CHECKING([whether pkg-config python-${tryver} provides a working build environment])
+      _FRR_PYTHON_DEVENV([$py_hex], [
+        py_found=true
+        break
+      ])
+    else
+      AC_MSG_RESULT([no])
+    fi
+  done
+
+  if $py_found; then
+    m4_default([$2], [:])
+  else
+    unset PYTHON_CFLAGS
+    unset PYTHON_LIBS
+    m4_default([$3], [:])
+  fi
+])
+
+dnl just find python without checking headers/libs
+AC_DEFUN([FRR_PYTHON], [
+  dnl user override
+  if test "x$PYTHON" != "x"; then
+    _FRR_PYTHON_INTERP([], [
+      AC_MSG_ERROR([PYTHON ($PYTHON) explicitly specified but not working])
+    ])
+  else
+    for frr_pyver in _FRR_PY_VERS; do
+      PYTHON="python${frr_pyver#_}"
+      _FRR_PYTHON_INTERP([break])
+      PYTHON=":"
+    done
+    if test "$PYTHON" = ":"; then
+      AC_MSG_ERROR([no working python version found])
+    fi
+  fi
+  AC_SUBST([PYTHON])
+])
+
+dnl find python with checking headers/libs
+AC_DEFUN([FRR_PYTHON_DEV], [dnl
+AC_ARG_VAR([PYTHON_CFLAGS], [C compiler flags for Python])dnl
+AC_ARG_VAR([PYTHON_LIBS], [linker flags for Python])dnl
+
+  dnl user override
+  if test "x$PYTHON" != "x"; then
+    _FRR_PYTHON_INTERP([], [
+      AC_MSG_ERROR([PYTHON ($PYTHON) explicitly specified but not working])
+    ])
+    _FRR_PYTHON_GETDEV([$PYTHON], [], [
+      AC_MSG_ERROR([PYTHON ($PYTHON) explicitly specified but development environment not working])
+    ])
+  else
+    for frr_pyver in _FRR_PY_VERS; do
+      PYTHON="python${frr_pyver#_}"
+      _FRR_PYTHON_INTERP([
+        _FRR_PYTHON_GETDEV([$PYTHON], [
+          break
+        ])
+      ])
+      PYTHON=":"
+    done
+    if test "$PYTHON" = ":"; then
+      AC_MSG_ERROR([no working python version found])
+    fi
+  fi
+
+  AC_SUBST([PYTHON_CFLAGS])
+  AC_SUBST([PYTHON_LIBS])
+  AC_SUBST([PYTHON])
+])

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -44,12 +44,6 @@
 # defines for configure
 %define     rundir  %{_localstatedir}/run/%{name}
 
-# define for sphinx-build binary
-%if 0%{?rhel} && 0%{?rhel} < 7
-    %define sphinx sphinx-build2.7
-%else
-    %define sphinx sphinx-build
-%endif
 ############################################################################
 
 #### Version String tweak
@@ -360,7 +354,7 @@ developing OSPF-API and frr applications.
 %else
     --disable-bfdd \
 %endif
-    SPHINXBUILD=%{sphinx}
+    # end
 
 make %{?_smp_mflags} MAKEINFO="makeinfo --no-split"
 

--- a/tests/subdir.am
+++ b/tests/subdir.am
@@ -2,8 +2,6 @@
 # tests
 #
 
-PYTHON ?= python
-
 if BGPD
 TESTS_BGPD = \
 	tests/bgpd/test_aspath \


### PR DESCRIPTION
not much to be said here; this improves our python build glue by quite a bit.

Replaces PR #3986.

Note that this adds a new requirement for `sphinx` and `pytest` to be installed for the **same** version as the one we're building `clippy` for.  This is intentional because I want to use `clippy` in `sphinx`.

This means that if we're building clippy for CPython 3.6, sphinx and pytest need to be installed for CPython 3.6. (A 2.7 or 3.4 or whatever else version will just be ignored.)