### PR TITLE
lib: Cleanup recent commit warn->werror issues in lib/routemap.c

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1333,6 +1333,13 @@ static route_map_event_t get_route_map_delete_event(route_map_event_t type)
 		 */
 		assert(0);
 	}
+
+	assert(0);
+	/*
+	 * Return to make c happy but if we get here something has gone
+	 * terribly terribly wrong, so yes this return makes no sense.
+	 */
+	return RMAP_EVENT_CALL_ADDED;
 }
 
 /* Add match statement to route map. */


### PR DESCRIPTION
The get_route_map_delete_event function should return a value
even if we never get to that part of the function.  Make sure
we know why we are here so it can be fixed appropriately in
the future.

Signed-off-by: Donald Sharp <sharpd@cumulusnetwork.com>