### PR TITLE
zebra: When displaying `show evpn arp-cache vni XX` add local and rem…

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -839,9 +839,9 @@ static void zvni_print_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 			return;
 
 		if (json_vni == NULL) {
-			vty_out(vty, "%*s %-6s %-8s %-17s\n",
+			vty_out(vty, "%*s %-6s %-8s %-17s                       %u/%u\n",
 				-wctx->addr_width, buf2, "local",
-				state_str, buf1);
+				state_str, buf1, n->loc_seq, n->rem_seq);
 		} else {
 			json_object_string_add(json_row, "type", "local");
 			json_object_string_add(json_row, "state", state_str);
@@ -875,9 +875,9 @@ static void zvni_print_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 					"%*s %-6s %-8s %-17s %-21s\n",
 					-wctx->addr_width, "Neighbor", "Type",
 					"State", "MAC", "Remote VTEP");
-			vty_out(vty, "%*s %-6s %-8s %-17s %-21s\n",
+			vty_out(vty, "%*s %-6s %-8s %-17s %-21s %u/%u\n",
 				-wctx->addr_width, buf2, "remote", state_str,
-				buf1, inet_ntoa(n->r_vtep_ip));
+				buf1, inet_ntoa(n->r_vtep_ip), n->loc_seq, n->rem_seq);
 		} else {
 			json_object_string_add(json_row, "type", "remote");
 			json_object_string_add(json_row, "state", state_str);
@@ -987,9 +987,9 @@ static void zvni_print_neigh_hash_all_vni(struct hash_bucket *bucket,
 	hash_iterate(zvni->neigh_table, zvni_find_neigh_addr_width, &wctx);
 
 	if (json == NULL) {
-		vty_out(vty, "%*s %-6s %-8s %-17s %-21s\n",
+		vty_out(vty, "%*s %-6s %-8s %-17s %-21s %s\n",
 			-wctx.addr_width, "IP", "Type",
-			"State", "MAC", "Remote VTEP");
+			"State", "MAC", "Remote VTEP", "Seq #'s");
 	}
 	if (print_dup)
 		hash_iterate(zvni->neigh_table, zvni_print_dad_neigh_hash,


### PR DESCRIPTION
…ote seq

Add the local and remote sequence number to the `show evpn arp-cache vni XX` command.

VNI 1000111 #ARP (IPv4 and IPv6, local and remote) 15

IP                       Type   State    MAC               Remote VTEP           Seq #'s
fe80::202:ff:fe00:15     remote active   00:02:00:00:00:15 6.0.0.31              0/0
fe80::202:ff:fe00:8      local  active   00:02:00:00:00:08                       0/0
60.1.1.111               local  active   00:02:00:00:00:08                       0/0
2060:1:1:1::11           local  active   00:e0:ec:38:49:a1                       0/0
fe80::202:ff:fe00:11     remote active   00:02:00:00:00:11 6.0.0.30              0/0
2060:1:1:1::211          remote active   00:02:00:00:00:11 6.0.0.30              0/0
2060:1:1:1::121          remote active   00:02:00:00:00:0c 6.0.0.29              0/0
60.1.1.211               remote active   00:02:00:00:00:11 6.0.0.30              0/0
fe80::202:ff:fe00:c      remote active   00:02:00:00:00:0c 6.0.0.29              0/0
60.1.1.11                local  active   00:e0:ec:38:49:a1                       0/0
fe80::2e0:ecff:fe38:49a1 local  active   00:e0:ec:38:49:a1                       0/0
60.1.1.221               remote active   00:02:00:00:00:15 6.0.0.31              0/0
2060:1:1:1::111          local  active   00:02:00:00:00:08                       0/0
2060:1:1:1::221          remote active   00:02:00:00:00:15 6.0.0.31              0/0
60.1.1.121               remote active   00:02:00:00:00:0c 6.0.0.29              0/0

The seq numbers are at 0/0 because we have had no mobility events.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>