### PR TITLE
bfdd: Modify bfdd to quietly accept access-lists

### DIFF
--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -20,6 +20,8 @@
 
 #include <zebra.h>
 
+#include "filter.h"
+
 #include "bfd.h"
 #include "lib/version.h"
 
@@ -201,6 +203,8 @@ int main(int argc, char *argv[])
 	bfd_initialize();
 
 	bfd_vrf_init();
+
+	access_list_init();
 
 	/* Initialize zebra connection. */
 	bfdd_zclient_init(&bglobal.bfdd_privs);


### PR DESCRIPTION
The `access-list ...` command was causing bfdd to return
'unknown commands'.  Make bfdd at least cognizant of
access-lists enough to not create strange error messages

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>