### PR TITLE
7.1: bfdd: Modify bfdd to quietly accept access-lists

### DIFF
--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -20,6 +20,8 @@
 
 #include <zebra.h>
 
+#include "filter.h"
+
 #include "bfd.h"
 #include "lib/version.h"
 
@@ -207,6 +209,8 @@ int main(int argc, char *argv[])
 
 	/* Initialize BFD data structures. */
 	bfd_initialize();
+
+	access_list_init();
 
 	/* Initialize zebra connection. */
 	bfdd_zclient_init(&bfdd_privs);


### PR DESCRIPTION
The `access-list ...` command was causing bfdd to return
'unknown commands'.  Make bfdd at least cognizant of
access-lists enough to not create strange error messages

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>