### PR TITLE
Bgp mac rescan

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1060,6 +1060,9 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 
 				json_object_int_add(json_prefix_info,
 					"prefixLen", rm->p.prefixlen);
+
+				if (rd_header)
+					json_nroute = json_object_new_object();
 			}
 
 			for (pi = bgp_node_get_bgp_path_info(rm); pi;
@@ -1132,8 +1135,6 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 					else if (type == RD_TYPE_IP)
 						decode_rd_ip(pnt + 2, &rd_ip);
 					if (use_json) {
-						json_nroute =
-						      json_object_new_object();
 						if (type == RD_TYPE_AS
 						    || type == RD_TYPE_AS4)
 							sprintf(rd_str, "%u:%d",
@@ -1184,6 +1185,7 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 						      SAFI_EVPN, json_array);
 				output_count++;
 			}
+			rd_header = 0;
 			if (use_json) {
 				json_object_object_add(json_prefix_info,
 					"paths", json_array);

--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -138,7 +138,6 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 {
 	struct bgp_node *prn, *rn;
 	struct bgp_path_info *pi;
-	uint32_t count = 0;
 
 	for (prn = bgp_table_top(table); prn; prn = bgp_route_next(prn)) {
 		struct bgp_table *sub = prn->info;
@@ -162,7 +161,6 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 			else
 				rn_affected = false;
 
-			count++;
 			for (pi = rn->info; pi; pi = pi->next) {
 				if (pi->peer == peer)
 					break;


### PR DESCRIPTION
two major fixes see individual commits for more detail

1) mac rescan was stupidly expensive and can be optimized for better performance
2) Crash when we have no rd data on a show json command