### PR TITLE
initial fwmark support for pbr matches #4460

### DIFF
--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -352,7 +352,7 @@ pbr_map_sequence_check_nexthops_valid(struct pbr_map_sequence *pbrms)
 
 static void pbr_map_sequence_check_src_dst_valid(struct pbr_map_sequence *pbrms)
 {
-	if (!pbrms->src && !pbrms->dst)
+	if (!pbrms->src && !pbrms->dst && !pbrms->fwmark)
 		pbrms->reason |= PBR_MAP_INVALID_SRCDST;
 }
 

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -87,6 +87,7 @@ struct pbr_map_sequence {
 	 */
 	struct prefix *src;
 	struct prefix *dst;
+	unsigned int fwmark;
 
 	/*
 	 * Family of the src/dst.  Needed when deleting since we clear them

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -526,7 +526,7 @@ static void pbr_encode_pbr_map_sequence(struct stream *s,
 	stream_putw(s, 0);  /* src port */
 	pbr_encode_pbr_map_sequence_prefix(s, pbrms->dst, family);
 	stream_putw(s, 0);  /* dst port */
-	stream_putl(s, 0);  /* fwmark */
+	stream_putl(s, pbrms->fwmark);
 	if (pbrms->nhgrp_name)
 		stream_putl(s, pbr_nht_get_table(pbrms->nhgrp_name));
 	else if (pbrms->nhg)


### PR DESCRIPTION
This commit adds possibility to match on fwmark in pbr-map (in decimal notation). It can be used to implement more advanced PBR scenarios with netfilter based marking rules.