### PR TITLE
7.0 isisd: The RFC states that v6 addresses are limited to 16 in a hello …

### DIFF
--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -3253,13 +3253,18 @@ void isis_tlvs_add_ipv6_addresses(struct isis_tlvs *tlvs,
 {
 	struct listnode *node;
 	struct prefix_ipv6 *ip_addr;
+	unsigned int addr_count = 0;
 
 	for (ALL_LIST_ELEMENTS_RO(addresses, node, ip_addr)) {
+		if (addr_count >= 15)
+			break;
+
 		struct isis_ipv6_address *a =
 			XCALLOC(MTYPE_ISIS_TLV, sizeof(*a));
 
 		a->addr = ip_addr->prefix;
 		append_item(&tlvs->ipv6_address, (struct isis_item *)a);
+		addr_count++;
 	}
 }
 


### PR DESCRIPTION
…packet

The RFC states we can send only up to 16 v6 addresses in a hello packet
and cannot send sub tlv's of that type.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>