### PR TITLE
*: fix some dumb printf format warnings

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -96,8 +96,10 @@ static void vty_out_cpu_thread_history(struct vty *vty,
 				       struct cpu_thread_history *a)
 {
 	vty_out(vty, "%5zu %10zu.%03zu %9zu %8zu %9zu %8zu %9zu",
-		a->total_active, a->cpu.total / 1000, a->cpu.total % 1000,
-		a->total_calls, a->cpu.total / a->total_calls, a->cpu.max,
+		(size_t)a->total_active,
+		a->cpu.total / 1000, a->cpu.total % 1000,
+		(size_t)a->total_calls,
+		a->cpu.total / a->total_calls, a->cpu.max,
 		a->real.total / a->total_calls, a->real.max);
 	vty_out(vty, " %c%c%c%c%c %s\n",
 		a->types & (1 << THREAD_READ) ? 'R' : ' ',

--- a/sharpd/sharp_vty.c
+++ b/sharpd/sharp_vty.c
@@ -145,12 +145,12 @@ DEFPY (install_routes_data_dump,
 	struct timeval r;
 
 	timersub(&sg.r.t_end, &sg.r.t_start, &r);
-	vty_out(vty, "Prefix: %s Total: %u %u %u Time: %ld.%ld\n",
+	vty_out(vty, "Prefix: %s Total: %u %u %u Time: %jd.%ld\n",
 		prefix2str(&sg.r.orig_prefix, buf, sizeof(buf)),
 		sg.r.total_routes,
 		sg.r.installed_routes,
 		sg.r.removed_routes,
-		r.tv_sec, (long int)r.tv_usec);
+		(intmax_t)r.tv_sec, (long)r.tv_usec);
 
 	return CMD_SUCCESS;
 }

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -212,8 +212,8 @@ static int route_notify_owner(ZAPI_CALLBACK_ARGS)
 		if (sg.r.total_routes == sg.r.installed_routes) {
 			monotime(&sg.r.t_end);
 			timersub(&sg.r.t_end, &sg.r.t_start, &r);
-			zlog_debug("Installed All Items %ld.%ld", r.tv_sec,
-				   (long int)r.tv_usec);
+			zlog_debug("Installed All Items %jd.%ld",
+				   (intmax_t)r.tv_sec, (long)r.tv_usec);
 			handle_repeated(true);
 		}
 		break;
@@ -228,8 +228,8 @@ static int route_notify_owner(ZAPI_CALLBACK_ARGS)
 		if (sg.r.total_routes == sg.r.removed_routes) {
 			monotime(&sg.r.t_end);
 			timersub(&sg.r.t_end, &sg.r.t_start, &r);
-			zlog_debug("Removed all Items %ld.%ld", r.tv_sec,
-				   (long int)r.tv_usec);
+			zlog_debug("Removed all Items %jd.%ld",
+				   (intmax_t)r.tv_sec, (long)r.tv_usec);
 			handle_repeated(false);
 		}
 		break;

--- a/watchfrr/watchfrr.c
+++ b/watchfrr/watchfrr.c
@@ -1021,10 +1021,11 @@ void watchfrr_status(struct vty *vty)
 		else if (dmn->state == DAEMON_DOWN &&
 			time_elapsed(&delay, &dmn->restart.time)->tv_sec
 				< dmn->restart.interval)
-			vty_out(vty, "      restarting in %ld seconds"
-				" (%lds backoff interval)\n",
-				dmn->restart.interval - delay.tv_sec,
-				dmn->restart.interval);
+			vty_out(vty, "      restarting in %jd seconds"
+				" (%jds backoff interval)\n",
+				(intmax_t)dmn->restart.interval
+					- (intmax_t)delay.tv_sec,
+				(intmax_t)dmn->restart.interval);
 	}
 }
 


### PR DESCRIPTION
Some types like `time_t` vary across platforms and always need to be
cast when printed.

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>