### PR TITLE
zebra: Set re as changed if its nexthops change

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -506,6 +506,9 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 		}
 	}
 
+	if (CHECK_FLAG(re->status, ROUTE_ENTRY_NEXTHOPS_CHANGED))
+		SET_FLAG(re->status, ROUTE_ENTRY_CHANGED);
+
 	return re->nexthop_active_num;
 }
 


### PR DESCRIPTION
In the nexthop_active_update() check, if the nexthops
change in some way (new resolved), then mark the
route entry as changed as well.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>