### PR TITLE
bgpd: Enumerate hostname if exists for show bgp neighbors cmd

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6930,7 +6930,7 @@ static void route_vty_short_status_out(struct vty *vty,
 		vty_out(vty, " ");
 }
 
-static char *bgp_nexthop_fqdn(struct peer *peer)
+char *bgp_nexthop_fqdn(struct peer *peer)
 {
 	if (peer->hostname && bgp_flag_check(peer->bgp, BGP_FLAG_SHOW_HOSTNAME))
 		return peer->hostname;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -463,6 +463,7 @@ extern void bgp_clear_adj_in(struct peer *, afi_t, safi_t);
 extern void bgp_clear_stale_route(struct peer *, afi_t, safi_t);
 extern int bgp_outbound_policy_exists(struct peer *, struct bgp_filter *);
 extern int bgp_inbound_policy_exists(struct peer *, struct bgp_filter *);
+extern char *bgp_nexthop_fqdn(struct peer *peer);
 
 extern struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
 					 safi_t safi, struct prefix *p,

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -12751,6 +12751,13 @@ static void bgp_ac_neighbor(vector comps, struct cmd_token *token)
 				continue;
 
 			vector_set(comps, XSTRDUP(MTYPE_COMPLETION, name));
+
+			if (bgp_nexthop_fqdn(peer)
+			    && strncmp(token->varname, "neighbors",
+				       strlen("neighbors"))
+				       == 0)
+				vector_set(comps, XSTRDUP(MTYPE_COMPLETION,
+							  peer->hostname));
 		}
 	}
 }


### PR DESCRIPTION
This applied only for show command.

exit1# show bgp neighbors ?
  <cr>
  A.B.C.D   Neighbor to display information about
     10.10.10.200 10.10.10.201 spine1-debian-9
  WORD      Neighbor on BGP configured interface
  X:X::X:X  Neighbor to display information about
     2a02:4780::1
  json      JavaScript Object Notation
exit1# show bgp neighbors

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>