### PR TITLE
bgpd: add l2vpn evpn to afi safi parse utility

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -217,6 +217,10 @@ int argv_find_and_parse_afi(struct cmd_token **argv, int argc, int *index,
 		ret = 1;
 		if (afi)
 			*afi = AFI_IP6;
+	} else if (argv_find(argv, argc, "l2vpn", index)) {
+		ret = 1;
+		if (afi)
+			*afi = AFI_L2VPN;
 	}
 	return ret;
 }
@@ -260,6 +264,10 @@ int argv_find_and_parse_safi(struct cmd_token **argv, int argc, int *index,
 		ret = 1;
 		if (safi)
 			*safi = SAFI_MPLS_VPN;
+	} else if (argv_find(argv, argc, "evpn", index)) {
+		ret = 1;
+		if (safi)
+			*safi = SAFI_EVPN;
 	} else if (argv_find(argv, argc, "flowspec", index)) {
 		ret = 1;
 		if (safi)


### PR DESCRIPTION
Problem reported with "clear bgp l2vpn evpn * soft" clearing the
wrong afi/safi (cleared ipv6 unicast instead).  Determined that
the calling function used the argv_find_and_parse_afi/safi routines
to determine the correct afi/safi to pass on.  Since l2vpn/evpn were
missing from the lookup, the command defaulted to ipv6 unicast.  This
fix just adds that afi/safi to the lookup routine.

Ticket: CM-25167
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>