### PR TITLE
pimd: The PIM_OIF_FLAG_PROTO_SRC flag was never used

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2117,7 +2117,7 @@ static void pim_show_state(struct pim_instance *pim, struct vty *vty,
 			} else {
 				if (first_oif) {
 					first_oif = 0;
-					vty_out(vty, "%s(%c%c%c%c%c)", out_ifname,
+					vty_out(vty, "%s(%c%c%c%c)", out_ifname,
 						(c_oil->oif_flags[oif_vif_index]
 						 & PIM_OIF_FLAG_PROTO_IGMP)
 							? 'I'
@@ -2131,15 +2131,11 @@ static void pim_show_state(struct pim_instance *pim, struct vty *vty,
 							? 'V'
 							: ' ',
 						(c_oil->oif_flags[oif_vif_index]
-						 & PIM_OIF_FLAG_PROTO_SOURCE)
-							? 'S'
-							: ' ',
-						(c_oil->oif_flags[oif_vif_index]
 						 & PIM_OIF_FLAG_PROTO_STAR)
 							? '*'
 							: ' ');
 				} else
-					vty_out(vty, ", %s(%c%c%c%c%c)",
+					vty_out(vty, ", %s(%c%c%c%c)",
 						out_ifname,
 						(c_oil->oif_flags[oif_vif_index]
 						 & PIM_OIF_FLAG_PROTO_IGMP)
@@ -2152,10 +2148,6 @@ static void pim_show_state(struct pim_instance *pim, struct vty *vty,
 						(c_oil->oif_flags[oif_vif_index]
 						 & PIM_OIF_FLAG_PROTO_VXLAN)
 							? 'V'
-							: ' ',
-						(c_oil->oif_flags[oif_vif_index]
-						 & PIM_OIF_FLAG_PROTO_SOURCE)
-							? 'S'
 							: ' ',
 						(c_oil->oif_flags[oif_vif_index]
 						 & PIM_OIF_FLAG_PROTO_STAR)
@@ -5332,11 +5324,6 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 						json_ifp_out, "protocolVxlan");
 
 				if (c_oil->oif_flags[oif_vif_index]
-				    & PIM_OIF_FLAG_PROTO_SOURCE)
-					json_object_boolean_true_add(
-						json_ifp_out, "protocolSource");
-
-				if (c_oil->oif_flags[oif_vif_index]
 				    & PIM_OIF_FLAG_PROTO_STAR)
 					json_object_boolean_true_add(
 						json_ifp_out,
@@ -5376,11 +5363,6 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 				if (c_oil->oif_flags[oif_vif_index]
 				    & PIM_OIF_FLAG_PROTO_VXLAN) {
 					strlcpy(proto, "VxLAN", sizeof(proto));
-				}
-
-				if (c_oil->oif_flags[oif_vif_index]
-				    & PIM_OIF_FLAG_PROTO_SOURCE) {
-					strlcpy(proto, "SRC", sizeof(proto));
 				}
 
 				if (c_oil->oif_flags[oif_vif_index]

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -32,13 +32,11 @@
  */
 #define PIM_OIF_FLAG_PROTO_IGMP   (1 << 0)
 #define PIM_OIF_FLAG_PROTO_PIM    (1 << 1)
-#define PIM_OIF_FLAG_PROTO_SOURCE (1 << 2)
-#define PIM_OIF_FLAG_PROTO_STAR   (1 << 3)
-#define PIM_OIF_FLAG_PROTO_VXLAN  (1 << 4)
+#define PIM_OIF_FLAG_PROTO_STAR   (1 << 2)
+#define PIM_OIF_FLAG_PROTO_VXLAN  (1 << 3)
 #define PIM_OIF_FLAG_PROTO_ANY                                 \
 	(PIM_OIF_FLAG_PROTO_IGMP | PIM_OIF_FLAG_PROTO_PIM      \
-	 | PIM_OIF_FLAG_PROTO_SOURCE | PIM_OIF_FLAG_PROTO_STAR \
-	 | PIM_OIF_FLAG_PROTO_VXLAN)
+	 | PIM_OIF_FLAG_PROTO_STAR | PIM_OIF_FLAG_PROTO_VXLAN)
 
 /*
  * We need a pimreg vif id from the kernel.


### PR DESCRIPTION
Nor should it be.  So remove from system.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>