### PR TITLE
pimd: Add a debug to indicate the ifchannel expiry timer has popped

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -613,6 +613,10 @@ static int on_ifjoin_expiry_timer(struct thread *t)
 
 	ch = THREAD_ARG(t);
 
+	if (PIM_DEBUG_TRACE)
+		zlog_debug("%s: ifchannel %s expiry timer", __PRETTY_FUNCTION__,
+			   ch->sg_str);
+
 	ifjoin_to_noinfo(ch, true);
 	/* ch may have been deleted */
 


### PR DESCRIPTION
The pim ifchannel expiry timer was not setting any debug output.
Let's add something in to help us understand what is going on.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>