### PR TITLE
ldpd: Fix shutdown

### DIFF
--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -447,7 +447,7 @@ ldpd_shutdown(void)
 			if (errno == EINTR)
 				continue;
 			/* No more processes were found. */
-			if (errno != ECHILD)
+			if (errno == ECHILD)
 				break;
 
 			/* Unhandled errno condition. */


### PR DESCRIPTION
When we stopped ldpd, we get fatal error message from wait().
This commit fix it.

Signed-off-by: Dmitrii Turlupov <dturlupov@factor-ts.ru>