### PR TITLE
bgpd: Process core when bgp instance is deleted

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5787,6 +5787,13 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 	unsigned long match = 0;
 	uint8_t atomic_aggregate = 0;
 
+	/* If the bgp instance is being deleted or self peer is deleted
+	 * then do not create aggregate route
+	 */
+	if (bgp_flag_check(bgp, BGP_FLAG_DELETE_IN_PROGRESS) ||
+	   (bgp->peer_self == NULL))
+		return;
+
 	/* ORIGIN attribute: If at least one route among routes that are
 	   aggregated has ORIGIN with the value INCOMPLETE, then the
 	   aggregated route must have the ORIGIN attribute with the value

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3287,6 +3287,9 @@ int bgp_delete(struct bgp *bgp)
 	THREAD_OFF(bgp->t_update_delay);
 	THREAD_OFF(bgp->t_establish_wait);
 
+	/* Set flag indicating bgp instance delete in progress */
+	bgp_flag_set(bgp, BGP_FLAG_DELETE_IN_PROGRESS);
+
 	if (BGP_DEBUG(zebra, ZEBRA)) {
 		if (bgp->inst_type == BGP_INSTANCE_TYPE_DEFAULT)
 			zlog_debug("Deleting Default VRF");

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -361,6 +361,7 @@ struct bgp {
 #define BGP_FLAG_SHOW_HOSTNAME            (1 << 19)
 #define BGP_FLAG_GR_PRESERVE_FWD          (1 << 20)
 #define BGP_FLAG_GRACEFUL_SHUTDOWN        (1 << 21)
+#define BGP_FLAG_DELETE_IN_PROGRESS       (1 << 22)
 
 	/* BGP Per AF flags */
 	uint16_t af_flags[AFI_MAX][SAFI_MAX];


### PR DESCRIPTION
* When the bgp is being deleted and routes are in clear workqueue
  and new aggregate address being allocated
* Added flag BGP_FLAG_DELETE_IN_PROGRESS in bgp structure to
  bgp instance is being  deleted
* When adding aggregate route check this flag and  peer_self is valid

Signed-off-by: Soman K S <somanks@vmware.com>