### PR TITLE
lib,zebra: add zclient pid

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -374,6 +374,9 @@ static int zebra_hello_send(struct zclient *zclient)
 		else
 			stream_putc(s, 0);
 
+		/* Include the client's pid */
+		stream_putl(s, (uint32_t)getpid());
+
 		stream_putw_at(s, 0, stream_get_endp(s));
 		return zclient_send_message(zclient);
 	}

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1719,13 +1719,14 @@ static void zread_hello(ZAPI_HANDLER_ARGS)
 	STREAM_GETC(msg, notify);
 	if (notify)
 		client->notify_owner = true;
+	STREAM_GETL(msg, client->client_pid);
 
 	/* accept only dynamic routing protocols */
 	if ((proto < ZEBRA_ROUTE_MAX) && (proto > ZEBRA_ROUTE_CONNECT)) {
 		zlog_notice(
-			"client %d says hello and bids fair to announce only %s routes vrf=%u",
-			client->sock, zebra_route_string(proto),
-			zvrf->vrf->vrf_id);
+			"client %d [%u] says hello and bids fair to announce only %s routes vrf=%u",
+			client->sock, client->client_pid,
+			zebra_route_string(proto), zvrf->vrf->vrf_id);
 		if (instance)
 			zlog_notice("client protocol instance %d", instance);
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -899,7 +899,8 @@ static void zebra_show_client_detail(struct vty *vty, struct zserv *client)
 	time_t connect_time, last_read_time, last_write_time;
 	uint32_t last_read_cmd, last_write_cmd;
 
-	vty_out(vty, "Client: %s", zebra_route_string(client->proto));
+	vty_out(vty, "Client: %s Pid: %u", zebra_route_string(client->proto),
+		client->client_pid);
 	if (client->instance)
 		vty_out(vty, " Instance: %d", client->instance);
 	vty_out(vty, "\n");

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -60,6 +60,9 @@ struct zserv {
 	/* Client file descriptor. */
 	int sock;
 
+	/* Client pid */
+	uint32_t client_pid;
+
 	/* Input/output buffer to the client. */
 	pthread_mutex_t ibuf_mtx;
 	struct stream_fifo *ibuf_fifo;


### PR DESCRIPTION
Add the zclient's pid to its HELLO message; store that in zebra, and report it with 'show zebra client'
Example vty with pid added:

```
mjs-uvm18# sho zebra client 
Client: sharp Pid: 55912
------------------------ 
FD: 22 

[...]
```