### PR TITLE
[7.0] lib: fix outdated candidate configuration issue

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1052,9 +1052,16 @@ static int cmd_execute_command_real(vector vline, enum filter_type filter,
 	if (matched_element->daemon)
 		ret = CMD_SUCCESS_DAEMON;
 	else {
-		/* Clear enqueued configuration changes. */
-		vty->num_cfg_changes = 0;
-		memset(&vty->cfg_changes, 0, sizeof(vty->cfg_changes));
+		if (vty->config) {
+			/* Clear array of enqueued configuration changes. */
+			vty->num_cfg_changes = 0;
+			memset(&vty->cfg_changes, 0, sizeof(vty->cfg_changes));
+
+			/* Regenerate candidate configuration. */
+			if (frr_get_cli_mode() == FRR_CLI_CLASSIC)
+				nb_config_replace(vty->candidate_config,
+						  running_config, true);
+		}
 
 		ret = matched_element->func(matched_element, vty, argc, argv);
 	}

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2314,6 +2314,7 @@ static void vty_read_file(struct nb_config *config, FILE *confp)
 	vty->wfd = STDERR_FILENO;
 	vty->type = VTY_FILE;
 	vty->node = CONFIG_NODE;
+	vty->config = true;
 	if (config)
 		vty->candidate_config = config;
 	else {


### PR DESCRIPTION
Even when using the classic CLI mode (i.e. when --tcli is not
used), the northbound code still uses vty->candidate_config
to perform configuration changes. From the perspective of the
user, the running configuration is being edited directly, but
under the hood the northbound layer does a full configuration
transaction for each command.  When the running configuration is
edited by a northbound client other than the CLI (e.g. kernel,
gRPC), vty->candidate_config might become outdated, and this can
lead to lots of weird problems. To fix this, always regenerate
vty->candidate_config before each configuration command when
using the classic CLI mode. When using the transactional CLI,
the user needs to update the candidate manually using the "update"
command, otherwise the "commit" command will fail with this error:
"% Candidate configuration needs to be updated before commit".

Fixes some problems reported by Don after moving an interface from
one VRF to another one while zebra is running.

Reported-by: Don Slice <dslice@cumulusnetworks.com>
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>