### PR TITLE
lib: make printfrr int64_t usable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -237,9 +237,7 @@ else
    fi
    if test "z$orig_cflags" = "z"; then
       AC_C_FLAG([-g])
-      AC_C_FLAG([-Os], [
-        AC_C_FLAG([-O2])
-      ])
+      AC_C_FLAG([-O2])
    fi
 fi
 AM_CONDITIONAL([DEV_BUILD], [test "x$enable_dev_build" = "xyes"])

--- a/isisd/isis_misc.c
+++ b/isisd/isis_misc.c
@@ -23,6 +23,7 @@
 
 #include <zebra.h>
 
+#include "printfrr.h"
 #include "stream.h"
 #include "vty.h"
 #include "hash.h"
@@ -511,42 +512,14 @@ void zlog_dump_data(void *data, int len)
 	return;
 }
 
-static char *qasprintf(const char *format, va_list ap)
-{
-	va_list aq;
-	va_copy(aq, ap);
-
-	int size = 0;
-	char *p = NULL;
-
-	size = vsnprintf(p, size, format, ap);
-
-	if (size < 0) {
-		va_end(aq);
-		return NULL;
-	}
-
-	size++;
-	p = XMALLOC(MTYPE_TMP, size);
-
-	size = vsnprintf(p, size, format, aq);
-	va_end(aq);
-
-	if (size < 0) {
-		XFREE(MTYPE_TMP, p);
-		return NULL;
-	}
-
-	return p;
-}
-
 void log_multiline(int priority, const char *prefix, const char *format, ...)
 {
+	char shortbuf[256];
 	va_list ap;
 	char *p;
 
 	va_start(ap, format);
-	p = qasprintf(format, ap);
+	p = asnprintfrr(MTYPE_TMP, shortbuf, sizeof(shortbuf), format, ap);
 	va_end(ap);
 
 	if (!p)
@@ -558,16 +531,18 @@ void log_multiline(int priority, const char *prefix, const char *format, ...)
 		zlog(priority, "%s%s", prefix, line);
 	}
 
-	XFREE(MTYPE_TMP, p);
+	if (p != shortbuf)
+		XFREE(MTYPE_TMP, p);
 }
 
 void vty_multiline(struct vty *vty, const char *prefix, const char *format, ...)
 {
+	char shortbuf[256];
 	va_list ap;
 	char *p;
 
 	va_start(ap, format);
-	p = qasprintf(format, ap);
+	p = asnprintfrr(MTYPE_TMP, shortbuf, sizeof(shortbuf), format, ap);
 	va_end(ap);
 
 	if (!p)
@@ -579,7 +554,8 @@ void vty_multiline(struct vty *vty, const char *prefix, const char *format, ...)
 		vty_out(vty, "%s%s\n", prefix, line);
 	}
 
-	XFREE(MTYPE_TMP, p);
+	if (p != shortbuf)
+		XFREE(MTYPE_TMP, p);
 }
 
 void vty_out_timestr(struct vty *vty, time_t uptime)

--- a/isisd/isis_misc.h
+++ b/isisd/isis_misc.h
@@ -79,9 +79,9 @@ enum { ISIS_UI_LEVEL_BRIEF,
 
 #include "lib/log.h"
 void log_multiline(int priority, const char *prefix, const char *format, ...)
-	PRINTF_ATTRIBUTE(3, 4);
+	PRINTFRR(3, 4);
 struct vty;
 void vty_multiline(struct vty *vty, const char *prefix, const char *format, ...)
-	PRINTF_ATTRIBUTE(3, 4);
+	PRINTFRR(3, 4);
 void vty_out_timestr(struct vty *vty, time_t uptime);
 #endif

--- a/lib/log.h
+++ b/lib/log.h
@@ -81,20 +81,13 @@ extern void openzlog(const char *progname, const char *protoname,
 /* Close zlog function. */
 extern void closezlog(void);
 
-/* GCC have printf type attribute check.  */
-#ifdef __GNUC__
-#define PRINTF_ATTRIBUTE(a,b) __attribute__ ((__format__ (__printf__, a, b)))
-#else
-#define PRINTF_ATTRIBUTE(a,b)
-#endif /* __GNUC__ */
-
 /* Handy zlog functions. */
-extern void zlog_err(const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
-extern void zlog_warn(const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
-extern void zlog_info(const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
-extern void zlog_notice(const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
-extern void zlog_debug(const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
-extern void zlog(int priority, const char *format, ...) PRINTF_ATTRIBUTE(2, 3);
+extern void zlog_err(const char *format, ...) PRINTFRR(1, 2);
+extern void zlog_warn(const char *format, ...) PRINTFRR(1, 2);
+extern void zlog_info(const char *format, ...) PRINTFRR(1, 2);
+extern void zlog_notice(const char *format, ...) PRINTFRR(1, 2);
+extern void zlog_debug(const char *format, ...) PRINTFRR(1, 2);
+extern void zlog(int priority, const char *format, ...) PRINTFRR(2, 3);
 
 /* For logs which have error codes associated with them */
 #define flog_err(ferr_id, format, ...)                                        \

--- a/lib/sbuf.c
+++ b/lib/sbuf.c
@@ -22,6 +22,7 @@
  */
 #include <zebra.h>
 
+#include "printfrr.h"
 #include "sbuf.h"
 #include "memory.h"
 
@@ -68,7 +69,7 @@ void sbuf_push(struct sbuf *buf, int indent, const char *format, ...)
 
 		written1 = indent;
 		va_start(args, format);
-		written2 = vsnprintf(NULL, 0, format, args);
+		written2 = vsnprintfrr(NULL, 0, format, args);
 		va_end(args);
 
 		new_size = buf->size;
@@ -92,8 +93,8 @@ void sbuf_push(struct sbuf *buf, int indent, const char *format, ...)
 		buf->pos = buf->size;
 
 	va_start(args, format);
-	written = vsnprintf(buf->buf + buf->pos, buf->size - buf->pos, format,
-			    args);
+	written = vsnprintfrr(buf->buf + buf->pos, buf->size - buf->pos,
+			      format, args);
 	va_end(args);
 
 	if (written >= 0)

--- a/lib/sbuf.h
+++ b/lib/sbuf.h
@@ -78,7 +78,7 @@ const char *sbuf_buf(struct sbuf *buf);
 void sbuf_free(struct sbuf *buf);
 #include "lib/log.h"
 void sbuf_push(struct sbuf *buf, int indent, const char *format, ...)
-	PRINTF_ATTRIBUTE(3, 4);
+	PRINTFRR(3, 4);
 
 #ifdef __cplusplus
 }

--- a/lib/termtable.c
+++ b/lib/termtable.c
@@ -20,6 +20,7 @@
 #include <zebra.h>
 #include <stdio.h>
 
+#include "printfrr.h"
 #include "memory.h"
 #include "termtable.h"
 
@@ -134,6 +135,7 @@ static struct ttable_cell *ttable_insert_row_va(struct ttable *tt, int i,
 {
 	assert(i >= -1 && i < tt->nrows);
 
+	char shortbuf[256];
 	char *res, *orig, *section;
 	struct ttable_cell *row;
 	int col = 0;
@@ -158,9 +160,7 @@ static struct ttable_cell *ttable_insert_row_va(struct ttable *tt, int i,
 	/* CALLOC a block of cells */
 	row = XCALLOC(MTYPE_TTABLE, tt->ncols * sizeof(struct ttable_cell));
 
-	res = NULL;
-	vasprintf(&res, format, ap);
-
+	res = vasnprintfrr(MTYPE_TMP, shortbuf, sizeof(shortbuf), format, ap);
 	orig = res;
 
 	while (res && col < tt->ncols) {
@@ -170,7 +170,8 @@ static struct ttable_cell *ttable_insert_row_va(struct ttable *tt, int i,
 		col++;
 	}
 
-	free(orig);
+	if (orig != shortbuf)
+		XFREE(MTYPE_TMP, orig);
 
 	/* insert row */
 	if (i == -1 || i == tt->nrows)

--- a/lib/termtable.h
+++ b/lib/termtable.h
@@ -137,8 +137,7 @@ void ttable_cell_del(struct ttable_cell *cell);
  * columns were specified
  */
 struct ttable_cell *ttable_insert_row(struct ttable *tt, unsigned int row,
-				      const char *format, ...)
-	PRINTF_ATTRIBUTE(3, 4);
+				      const char *format, ...) PRINTFRR(3, 4);
 /**
  * Inserts a new row at the end of the table.
  *
@@ -164,7 +163,7 @@ struct ttable_cell *ttable_insert_row(struct ttable *tt, unsigned int row,
  * columns were specified
  */
 struct ttable_cell *ttable_add_row(struct ttable *tt, const char *format, ...)
-	PRINTF_ATTRIBUTE(2, 3);
+	PRINTFRR(2, 3);
 
 /**
  * Removes a row from the table.

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -105,8 +105,8 @@ void vty_frame(struct vty *vty, const char *format, ...)
 	va_list args;
 
 	va_start(args, format);
-	vsnprintf(vty->frame + vty->frame_pos,
-		  sizeof(vty->frame) - vty->frame_pos, format, args);
+	vsnprintfrr(vty->frame + vty->frame_pos,
+		    sizeof(vty->frame) - vty->frame_pos, format, args);
 	vty->frame_pos = strlen(vty->frame);
 	va_end(args);
 }

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -302,8 +302,8 @@ extern struct vty *vty_stdio(void (*atclose)(int isexit));
  * - vty_endframe() clears the buffer without printing it, and prints an
  *   extra string if the buffer was empty before (for context-end markers)
  */
-extern int vty_out(struct vty *, const char *, ...) PRINTF_ATTRIBUTE(2, 3);
-extern void vty_frame(struct vty *, const char *, ...) PRINTF_ATTRIBUTE(2, 3);
+extern int vty_out(struct vty *, const char *, ...) PRINTFRR(2, 3);
+extern void vty_frame(struct vty *, const char *, ...) PRINTFRR(2, 3);
 extern void vty_endframe(struct vty *, const char *);
 bool vty_set_include(struct vty *vty, const char *regexp);
 

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -244,13 +244,6 @@ size_t strlcpy(char *__restrict dest,
 	       const char *__restrict src, size_t destsize);
 #endif
 
-/* GCC have printf type attribute check.  */
-#ifdef __GNUC__
-#define PRINTF_ATTRIBUTE(a,b) __attribute__ ((__format__ (__printf__, a, b)))
-#else
-#define PRINTF_ATTRIBUTE(a,b)
-#endif /* __GNUC__ */
-
 /*
  * RFC 3542 defines several macros for using struct cmsghdr.
  * Here, we define those that are not present

--- a/tests/lib/test_printfrr.c
+++ b/tests/lib/test_printfrr.c
@@ -27,6 +27,7 @@
 
 static int errors;
 
+static void printcmp(const char *fmt, ...) PRINTFRR(1, 2);
 static void printcmp(const char *fmt, ...)
 {
 	va_list ap;
@@ -58,6 +59,7 @@ static void printcmp(const char *fmt, ...)
 		errors++;
 }
 
+static void printchk(const char *ref, const char *fmt, ...) PRINTFRR(2, 3);
 static void printchk(const char *ref, const char *fmt, ...)
 {
 	va_list ap;

--- a/tools/frr.vim
+++ b/tools/frr.vim
@@ -1,0 +1,36 @@
+" settings & syntax hilighting for FRR codebase
+" 2019 by David Lamparter, placed in public domain
+
+let c_gnu=1
+
+function! CStyleFRR()
+	syn clear	cFormat
+	syn match	cFormat		display "%\(\d\+\$\)\=[-+' #0*]*\(\d*\|\*\|\*\d\+\$\)\(\.\(\d*\|\*\|\*\d\+\$\)\)\=\([hlLjzt]\|ll\|hh\)\=\([aAbiuoxXDOUfFeEgGcCsSn]\|[pd]\([A-Z][A-Z0-9]*[a-z]*\|\)\|\[\^\=.[^]]*\]\)" contained
+	syn match	cFormat		display "%%" contained
+
+	syn keyword	cIterator	frr_each frr_each_safe frr_each_from
+	syn keyword	cMacroOp	offsetof container_of container_of_null array_size
+
+	syn keyword	cStorageClass	atomic
+	syn keyword	cFormatConst	PRId64	PRIu64	PRIx64
+	syn keyword	cFormatConst	PRId32	PRIu32	PRIx32
+	syn keyword	cFormatConst	PRId16	PRIu16	PRIx16
+	syn keyword	cFormatConst	PRId8	PRIu8	PRIx8
+
+	" you can unlink these by just giving them their own hilighting / color
+	hi link cFormatConst	cFormat
+	hi link cIterator	cRepeat
+	hi link cMacroOp	cOperator
+
+	" indentation
+	setlocal cindent
+	setlocal cinoptions=:0,(0,u4,w1,W8
+	setlocal shiftwidth=8
+	setlocal softtabstop=0
+	setlocal textwidth=0
+	setlocal fo=croql
+	setlocal noet
+endfunction
+
+" auto-apply the above based on path rules
+"autocmd BufRead,BufNewFile /home/.../frr/*.[ch] call CStyleFRR()

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1517,7 +1517,6 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 #endif /* HAVE_PROC_NET_DEV */
 
 #ifdef HAVE_NET_RT_IFLIST
-#if defined(__bsdi__) || defined(__NetBSD__)
 	/* Statistics print out using sysctl (). */
 	vty_out(vty,
 		"    input packets %llu, bytes %llu, dropped %llu,"
@@ -1542,25 +1541,6 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 
 	vty_out(vty, "    collisions %llu\n",
 		(unsigned long long)ifp->stats.ifi_collisions);
-#else
-	/* Statistics print out using sysctl (). */
-	vty_out(vty,
-		"    input packets %lu, bytes %lu, dropped %lu,"
-		" multicast packets %lu\n",
-		ifp->stats.ifi_ipackets, ifp->stats.ifi_ibytes,
-		ifp->stats.ifi_iqdrops, ifp->stats.ifi_imcasts);
-
-	vty_out(vty, "    input errors %lu\n", ifp->stats.ifi_ierrors);
-
-	vty_out(vty,
-		"    output packets %lu, bytes %lu, multicast packets %lu\n",
-		ifp->stats.ifi_opackets, ifp->stats.ifi_obytes,
-		ifp->stats.ifi_omcasts);
-
-	vty_out(vty, "    output errors %lu\n", ifp->stats.ifi_oerrors);
-
-	vty_out(vty, "    collisions %lu\n", ifp->stats.ifi_collisions);
-#endif /* __bsdi__ || __NetBSD__ */
 #endif /* HAVE_NET_RT_IFLIST */
 }
 


### PR DESCRIPTION
also moves from `-Os` to `-O2` & adds a vim snippet

with this, `%Lu` should actually be usable.