### PR TITLE
bgpd: auto router-id should not change configured vpn RD/RT

### DIFF
--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -264,6 +264,7 @@ extern void vpn_policy_routemap_event(const char *rmap_name);
 extern vrf_id_t get_first_vrf_for_redirect_with_rt(struct ecommunity *eckey);
 
 extern void vpn_leak_postchange_all(void);
-extern void vpn_handle_router_id_update(struct bgp *bgp, bool withdraw);
+extern void vpn_handle_router_id_update(struct bgp *bgp, bool withdraw,
+					bool is_config);
 
 #endif /* _QUAGGA_BGP_MPLSVPN_H */


### PR DESCRIPTION
A router-id change that isn't explicitly configured (a change from zebra, for example) should not replace configured vpn import/export config.

We've observed that if a vrf clause contains rd and rt statements but no explicit `router-id` statement, the configured rd and rt may be replaced with auto-generated policies based on an interface in the vrf. The replacement only occurs if no peers have been established, so there's a race involved. This PR proposes a fix that prevents auto-generation if explicit rd/rt config is present.
