### PR TITLE
*: kill more warnings

### DIFF
--- a/bgpd/bgp_addpath.c
+++ b/bgpd/bgp_addpath.c
@@ -17,6 +17,10 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "bgp_addpath.h"
 #include "bgp_route.h"
 

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1045,7 +1045,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 	uint16_t holdtime;
 	uint16_t send_holdtime;
 	as_t remote_as;
-	as_t as4 = 0;
+	as_t as4 = 0, as4_be;
 	struct in_addr remote_id;
 	int mp_capability;
 	uint8_t notify_data_remote_as[2];
@@ -1088,8 +1088,10 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		 * that we do not know which peer is connecting to us now.
 		 */
 		as4 = peek_for_as4_capability(peer, optlen);
-		memcpy(notify_data_remote_as4, &as4, 4);
 	}
+
+	as4_be = htonl(as4);
+	memcpy(notify_data_remote_as4, &as4_be, 4);
 
 	/* Just in case we have a silly peer who sends AS4 capability set to 0
 	 */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -22,6 +22,7 @@
 #include <zebra.h>
 #include <math.h>
 
+#include "printfrr.h"
 #include "prefix.h"
 #include "linklist.h"
 #include "memory.h"

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7570,8 +7570,6 @@ void route_vty_out_tag(struct vty *vty, struct prefix *p,
 			       && BGP_ATTR_NEXTHOP_AFI_IP6(attr))
 			   || (BGP_ATTR_NEXTHOP_AFI_IP6(attr))) {
 			char buf_a[512];
-			char buf_b[512];
-			char buf_c[BUFSIZ];
 			if (attr->mp_nexthop_len
 			    == BGP_ATTR_NHLEN_IPV6_GLOBAL) {
 				if (json)
@@ -7589,27 +7587,15 @@ void route_vty_out_tag(struct vty *vty, struct prefix *p,
 							buf_a, sizeof(buf_a)));
 			} else if (attr->mp_nexthop_len
 				   == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL) {
-				if (json) {
-					inet_ntop(AF_INET6,
-						  &attr->mp_nexthop_global,
-						  buf_a, sizeof(buf_a));
-					inet_ntop(AF_INET6,
-						  &attr->mp_nexthop_local,
-						  buf_b, sizeof(buf_b));
-					sprintf(buf_c, "%s(%s)", buf_a, buf_b);
+				snprintfrr(buf_a, sizeof(buf_a), "%pI6(%pI6)",
+					   &attr->mp_nexthop_global,
+					   &attr->mp_nexthop_local);
+				if (json)
 					json_object_string_add(
 						json_out,
-						"mpNexthopGlobalLocal", buf_c);
-				} else
-					vty_out(vty, "%s(%s)",
-						inet_ntop(
-							AF_INET6,
-							&attr->mp_nexthop_global,
-							buf_a, sizeof(buf_a)),
-						inet_ntop(
-							AF_INET6,
-							&attr->mp_nexthop_local,
-							buf_b, sizeof(buf_b)));
+						"mpNexthopGlobalLocal", buf_a);
+				else
+					vty_out(vty, "%s", buf_a);
 			}
 		}
 	}

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -2929,7 +2929,7 @@ DEFUN (debug_rfapi_open,
 {
 	struct rfapi_ip_addr vn;
 	struct rfapi_ip_addr un;
-	uint32_t lifetime;
+	uint32_t lifetime = 0;
 	int rc;
 	rfapi_handle handle;
 

--- a/configure.ac
+++ b/configure.ac
@@ -371,14 +371,19 @@ AC_SUBST([ARFLAGS])
 AC_SUBST([AR_FLAGS])
 
 AC_MSG_CHECKING([whether $RANLIB supports D option])
-if $RANLIB -D conftest.a >/dev/null 2>/dev/null; then
-  AC_MSG_RESULT([yes])
-  RANLIB="$RANLIB -D"
+if $RANLIB -D conftest.a >conftest.err 2>&1; then
+  if grep -q -- '-D' conftest.err; then
+    AC_MSG_RESULT([no])
+  else
+    AC_MSG_RESULT([yes])
+    RANLIB="$RANLIB -D"
+  fi
 else
   AC_MSG_RESULT([no])
 fi
 AC_SUBST([RANLIB])
 
+test -f conftest.err && rm conftest.err
 test -f conftest.a && rm conftest.a
 
 dnl ----------------------

--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -2741,478 +2741,680 @@ const struct frr_yang_module_info frr_isisd_info = {
 	.nodes = {
 		{
 			.xpath = "/frr-isisd:isis/instance",
-			.cbs.create = isis_instance_create,
-			.cbs.destroy = isis_instance_destroy,
-			.cbs.cli_show = cli_show_router_isis,
+			.cbs = {
+				.cli_show = cli_show_router_isis,
+				.create = isis_instance_create,
+				.destroy = isis_instance_destroy,
+			},
 			.priority = NB_DFLT_PRIORITY - 1,
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/is-type",
-			.cbs.modify = isis_instance_is_type_modify,
-			.cbs.cli_show = cli_show_isis_is_type,
+			.cbs = {
+				.cli_show = cli_show_isis_is_type,
+				.modify = isis_instance_is_type_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/area-address",
-			.cbs.create = isis_instance_area_address_create,
-			.cbs.destroy = isis_instance_area_address_destroy,
-			.cbs.cli_show = cli_show_isis_area_address,
+			.cbs = {
+				.cli_show = cli_show_isis_area_address,
+				.create = isis_instance_area_address_create,
+				.destroy = isis_instance_area_address_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/dynamic-hostname",
-			.cbs.modify = isis_instance_dynamic_hostname_modify,
-			.cbs.cli_show = cli_show_isis_dynamic_hostname,
+			.cbs = {
+				.cli_show = cli_show_isis_dynamic_hostname,
+				.modify = isis_instance_dynamic_hostname_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/attached",
-			.cbs.modify = isis_instance_attached_modify,
-			.cbs.cli_show = cli_show_isis_attached,
+			.cbs = {
+				.cli_show = cli_show_isis_attached,
+				.modify = isis_instance_attached_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/overload",
-			.cbs.modify = isis_instance_overload_modify,
-			.cbs.cli_show = cli_show_isis_overload,
+			.cbs = {
+				.cli_show = cli_show_isis_overload,
+				.modify = isis_instance_overload_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/metric-style",
-			.cbs.modify = isis_instance_metric_style_modify,
-			.cbs.cli_show = cli_show_isis_metric_style,
+			.cbs = {
+				.cli_show = cli_show_isis_metric_style,
+				.modify = isis_instance_metric_style_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/purge-originator",
-			.cbs.modify = isis_instance_purge_originator_modify,
-			.cbs.cli_show = cli_show_isis_purge_origin,
+			.cbs = {
+				.cli_show = cli_show_isis_purge_origin,
+				.modify = isis_instance_purge_originator_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/mtu",
-			.cbs.modify = isis_instance_lsp_mtu_modify,
-			.cbs.cli_show = cli_show_isis_lsp_mtu,
+			.cbs = {
+				.cli_show = cli_show_isis_lsp_mtu,
+				.modify = isis_instance_lsp_mtu_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/refresh-interval",
-			.cbs.cli_show = cli_show_isis_lsp_ref_interval,
+			.cbs = {
+				.cli_show = cli_show_isis_lsp_ref_interval,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/refresh-interval/level-1",
-			.cbs.modify = isis_instance_lsp_refresh_interval_level_1_modify,
+			.cbs = {
+				.modify = isis_instance_lsp_refresh_interval_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/refresh-interval/level-2",
-			.cbs.modify = isis_instance_lsp_refresh_interval_level_2_modify,
+			.cbs = {
+				.modify = isis_instance_lsp_refresh_interval_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/maximum-lifetime",
-			.cbs.cli_show = cli_show_isis_lsp_max_lifetime,
+			.cbs = {
+				.cli_show = cli_show_isis_lsp_max_lifetime,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/maximum-lifetime/level-1",
-			.cbs.modify = isis_instance_lsp_maximum_lifetime_level_1_modify,
+			.cbs = {
+				.modify = isis_instance_lsp_maximum_lifetime_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/maximum-lifetime/level-2",
-			.cbs.modify = isis_instance_lsp_maximum_lifetime_level_2_modify,
+			.cbs = {
+				.modify = isis_instance_lsp_maximum_lifetime_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/generation-interval",
-			.cbs.cli_show = cli_show_isis_lsp_gen_interval,
+			.cbs = {
+				.cli_show = cli_show_isis_lsp_gen_interval,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/generation-interval/level-1",
-			.cbs.modify = isis_instance_lsp_generation_interval_level_1_modify,
+			.cbs = {
+				.modify = isis_instance_lsp_generation_interval_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/lsp/generation-interval/level-2",
-			.cbs.modify = isis_instance_lsp_generation_interval_level_2_modify,
+			.cbs = {
+				.modify = isis_instance_lsp_generation_interval_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/ietf-backoff-delay",
-			.cbs.create = isis_instance_spf_ietf_backoff_delay_create,
-			.cbs.destroy = isis_instance_spf_ietf_backoff_delay_destroy,
-			.cbs.apply_finish = ietf_backoff_delay_apply_finish,
-			.cbs.cli_show = cli_show_isis_spf_ietf_backoff,
+			.cbs = {
+				.apply_finish = ietf_backoff_delay_apply_finish,
+				.cli_show = cli_show_isis_spf_ietf_backoff,
+				.create = isis_instance_spf_ietf_backoff_delay_create,
+				.destroy = isis_instance_spf_ietf_backoff_delay_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/ietf-backoff-delay/init-delay",
-			.cbs.modify = isis_instance_spf_ietf_backoff_delay_init_delay_modify,
+			.cbs = {
+				.modify = isis_instance_spf_ietf_backoff_delay_init_delay_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/ietf-backoff-delay/short-delay",
-			.cbs.modify = isis_instance_spf_ietf_backoff_delay_short_delay_modify,
+			.cbs = {
+				.modify = isis_instance_spf_ietf_backoff_delay_short_delay_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/ietf-backoff-delay/long-delay",
-			.cbs.modify = isis_instance_spf_ietf_backoff_delay_long_delay_modify,
+			.cbs = {
+				.modify = isis_instance_spf_ietf_backoff_delay_long_delay_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/ietf-backoff-delay/hold-down",
-			.cbs.modify = isis_instance_spf_ietf_backoff_delay_hold_down_modify,
+			.cbs = {
+				.modify = isis_instance_spf_ietf_backoff_delay_hold_down_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/ietf-backoff-delay/time-to-learn",
-			.cbs.modify = isis_instance_spf_ietf_backoff_delay_time_to_learn_modify,
+			.cbs = {
+				.modify = isis_instance_spf_ietf_backoff_delay_time_to_learn_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/minimum-interval",
-			.cbs.cli_show = cli_show_isis_spf_min_interval,
+			.cbs = {
+				.cli_show = cli_show_isis_spf_min_interval,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/minimum-interval/level-1",
-			.cbs.modify = isis_instance_spf_minimum_interval_level_1_modify,
+			.cbs = {
+				.modify = isis_instance_spf_minimum_interval_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/spf/minimum-interval/level-2",
-			.cbs.modify = isis_instance_spf_minimum_interval_level_2_modify,
+			.cbs = {
+				.modify = isis_instance_spf_minimum_interval_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/area-password",
-			.cbs.create = isis_instance_area_password_create,
-			.cbs.destroy = isis_instance_area_password_destroy,
-			.cbs.apply_finish = area_password_apply_finish,
-			.cbs.cli_show = cli_show_isis_area_pwd,
+			.cbs = {
+				.apply_finish = area_password_apply_finish,
+				.cli_show = cli_show_isis_area_pwd,
+				.create = isis_instance_area_password_create,
+				.destroy = isis_instance_area_password_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/area-password/password",
-			.cbs.modify = isis_instance_area_password_password_modify,
+			.cbs = {
+				.modify = isis_instance_area_password_password_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/area-password/password-type",
-			.cbs.modify = isis_instance_area_password_password_type_modify,
+			.cbs = {
+				.modify = isis_instance_area_password_password_type_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/area-password/authenticate-snp",
-			.cbs.modify = isis_instance_area_password_authenticate_snp_modify,
+			.cbs = {
+				.modify = isis_instance_area_password_authenticate_snp_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/domain-password",
-			.cbs.create = isis_instance_domain_password_create,
-			.cbs.destroy = isis_instance_domain_password_destroy,
-			.cbs.apply_finish = domain_password_apply_finish,
-			.cbs.cli_show = cli_show_isis_domain_pwd,
+			.cbs = {
+				.apply_finish = domain_password_apply_finish,
+				.cli_show = cli_show_isis_domain_pwd,
+				.create = isis_instance_domain_password_create,
+				.destroy = isis_instance_domain_password_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/domain-password/password",
-			.cbs.modify = isis_instance_domain_password_password_modify,
+			.cbs = {
+				.modify = isis_instance_domain_password_password_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/domain-password/password-type",
-			.cbs.modify = isis_instance_domain_password_password_type_modify,
+			.cbs = {
+				.modify = isis_instance_domain_password_password_type_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/domain-password/authenticate-snp",
-			.cbs.modify = isis_instance_domain_password_authenticate_snp_modify,
+			.cbs = {
+				.modify = isis_instance_domain_password_authenticate_snp_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4",
-			.cbs.create = isis_instance_default_information_originate_ipv4_create,
-			.cbs.destroy = isis_instance_default_information_originate_ipv4_destroy,
-			.cbs.apply_finish = default_info_origin_ipv4_apply_finish,
-			.cbs.cli_show = cli_show_isis_def_origin_ipv4,
+			.cbs = {
+				.apply_finish = default_info_origin_ipv4_apply_finish,
+				.cli_show = cli_show_isis_def_origin_ipv4,
+				.create = isis_instance_default_information_originate_ipv4_create,
+				.destroy = isis_instance_default_information_originate_ipv4_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4/always",
-			.cbs.modify = isis_instance_default_information_originate_ipv4_always_modify,
+			.cbs = {
+				.modify = isis_instance_default_information_originate_ipv4_always_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4/route-map",
-			.cbs.modify = isis_instance_default_information_originate_ipv4_route_map_modify,
-			.cbs.destroy = isis_instance_default_information_originate_ipv4_route_map_destroy,
+			.cbs = {
+				.destroy = isis_instance_default_information_originate_ipv4_route_map_destroy,
+				.modify = isis_instance_default_information_originate_ipv4_route_map_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv4/metric",
-			.cbs.modify = isis_instance_default_information_originate_ipv4_metric_modify,
+			.cbs = {
+				.modify = isis_instance_default_information_originate_ipv4_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6",
-			.cbs.create = isis_instance_default_information_originate_ipv6_create,
-			.cbs.destroy = isis_instance_default_information_originate_ipv6_destroy,
-			.cbs.apply_finish = default_info_origin_ipv6_apply_finish,
-			.cbs.cli_show = cli_show_isis_def_origin_ipv6,
+			.cbs = {
+				.apply_finish = default_info_origin_ipv6_apply_finish,
+				.cli_show = cli_show_isis_def_origin_ipv6,
+				.create = isis_instance_default_information_originate_ipv6_create,
+				.destroy = isis_instance_default_information_originate_ipv6_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6/always",
-			.cbs.modify = isis_instance_default_information_originate_ipv6_always_modify,
+			.cbs = {
+				.modify = isis_instance_default_information_originate_ipv6_always_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6/route-map",
-			.cbs.modify = isis_instance_default_information_originate_ipv6_route_map_modify,
-			.cbs.destroy = isis_instance_default_information_originate_ipv6_route_map_destroy,
+			.cbs = {
+				.destroy = isis_instance_default_information_originate_ipv6_route_map_destroy,
+				.modify = isis_instance_default_information_originate_ipv6_route_map_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/default-information-originate/ipv6/metric",
-			.cbs.modify = isis_instance_default_information_originate_ipv6_metric_modify,
+			.cbs = {
+				.modify = isis_instance_default_information_originate_ipv6_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4",
-			.cbs.create = isis_instance_redistribute_ipv4_create,
-			.cbs.destroy = isis_instance_redistribute_ipv4_destroy,
-			.cbs.apply_finish = redistribute_ipv4_apply_finish,
-			.cbs.cli_show = cli_show_isis_redistribute_ipv4,
+			.cbs = {
+				.apply_finish = redistribute_ipv4_apply_finish,
+				.cli_show = cli_show_isis_redistribute_ipv4,
+				.create = isis_instance_redistribute_ipv4_create,
+				.destroy = isis_instance_redistribute_ipv4_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4/route-map",
-			.cbs.modify = isis_instance_redistribute_ipv4_route_map_modify,
-			.cbs.destroy = isis_instance_redistribute_ipv4_route_map_destroy,
+			.cbs = {
+				.destroy = isis_instance_redistribute_ipv4_route_map_destroy,
+				.modify = isis_instance_redistribute_ipv4_route_map_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv4/metric",
-			.cbs.modify = isis_instance_redistribute_ipv4_metric_modify,
+			.cbs = {
+				.modify = isis_instance_redistribute_ipv4_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6",
-			.cbs.create = isis_instance_redistribute_ipv6_create,
-			.cbs.destroy = isis_instance_redistribute_ipv6_destroy,
-			.cbs.apply_finish = redistribute_ipv6_apply_finish,
-			.cbs.cli_show = cli_show_isis_redistribute_ipv6,
+			.cbs = {
+				.apply_finish = redistribute_ipv6_apply_finish,
+				.cli_show = cli_show_isis_redistribute_ipv6,
+				.create = isis_instance_redistribute_ipv6_create,
+				.destroy = isis_instance_redistribute_ipv6_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6/route-map",
-			.cbs.modify = isis_instance_redistribute_ipv6_route_map_modify,
-			.cbs.destroy = isis_instance_redistribute_ipv6_route_map_destroy,
+			.cbs = {
+				.destroy = isis_instance_redistribute_ipv6_route_map_destroy,
+				.modify = isis_instance_redistribute_ipv6_route_map_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/redistribute/ipv6/metric",
-			.cbs.modify = isis_instance_redistribute_ipv6_metric_modify,
+			.cbs = {
+				.modify = isis_instance_redistribute_ipv6_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv4-multicast",
-			.cbs.create = isis_instance_multi_topology_ipv4_multicast_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv4_multicast_destroy,
-			.cbs.cli_show = cli_show_isis_mt_ipv4_multicast,
+			.cbs = {
+				.cli_show = cli_show_isis_mt_ipv4_multicast,
+				.create = isis_instance_multi_topology_ipv4_multicast_create,
+				.destroy = isis_instance_multi_topology_ipv4_multicast_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv4-multicast/overload",
-			.cbs.modify = isis_instance_multi_topology_ipv4_multicast_overload_modify,
+			.cbs = {
+				.modify = isis_instance_multi_topology_ipv4_multicast_overload_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv4-management",
-			.cbs.create = isis_instance_multi_topology_ipv4_management_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv4_management_destroy,
-			.cbs.cli_show = cli_show_isis_mt_ipv4_mgmt,
+			.cbs = {
+				.cli_show = cli_show_isis_mt_ipv4_mgmt,
+				.create = isis_instance_multi_topology_ipv4_management_create,
+				.destroy = isis_instance_multi_topology_ipv4_management_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv4-management/overload",
-			.cbs.modify = isis_instance_multi_topology_ipv4_management_overload_modify,
+			.cbs = {
+				.modify = isis_instance_multi_topology_ipv4_management_overload_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-unicast",
-			.cbs.create = isis_instance_multi_topology_ipv6_unicast_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv6_unicast_destroy,
-			.cbs.cli_show = cli_show_isis_mt_ipv6_unicast,
+			.cbs = {
+				.cli_show = cli_show_isis_mt_ipv6_unicast,
+				.create = isis_instance_multi_topology_ipv6_unicast_create,
+				.destroy = isis_instance_multi_topology_ipv6_unicast_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-unicast/overload",
-			.cbs.modify = isis_instance_multi_topology_ipv6_unicast_overload_modify,
+			.cbs = {
+				.modify = isis_instance_multi_topology_ipv6_unicast_overload_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-multicast",
-			.cbs.create = isis_instance_multi_topology_ipv6_multicast_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv6_multicast_destroy,
-			.cbs.cli_show = cli_show_isis_mt_ipv6_multicast,
+			.cbs = {
+				.cli_show = cli_show_isis_mt_ipv6_multicast,
+				.create = isis_instance_multi_topology_ipv6_multicast_create,
+				.destroy = isis_instance_multi_topology_ipv6_multicast_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-multicast/overload",
-			.cbs.modify = isis_instance_multi_topology_ipv6_multicast_overload_modify,
+			.cbs = {
+				.modify = isis_instance_multi_topology_ipv6_multicast_overload_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-management",
-			.cbs.create = isis_instance_multi_topology_ipv6_management_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv6_management_destroy,
-			.cbs.cli_show = cli_show_isis_mt_ipv6_mgmt,
+			.cbs = {
+				.cli_show = cli_show_isis_mt_ipv6_mgmt,
+				.create = isis_instance_multi_topology_ipv6_management_create,
+				.destroy = isis_instance_multi_topology_ipv6_management_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-management/overload",
-			.cbs.modify = isis_instance_multi_topology_ipv6_management_overload_modify,
+			.cbs = {
+				.modify = isis_instance_multi_topology_ipv6_management_overload_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-dstsrc",
-			.cbs.create = isis_instance_multi_topology_ipv6_dstsrc_create,
-			.cbs.destroy = isis_instance_multi_topology_ipv6_dstsrc_destroy,
-			.cbs.cli_show = cli_show_isis_mt_ipv6_dstsrc,
+			.cbs = {
+				.cli_show = cli_show_isis_mt_ipv6_dstsrc,
+				.create = isis_instance_multi_topology_ipv6_dstsrc_create,
+				.destroy = isis_instance_multi_topology_ipv6_dstsrc_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/multi-topology/ipv6-dstsrc/overload",
-			.cbs.modify = isis_instance_multi_topology_ipv6_dstsrc_overload_modify,
+			.cbs = {
+				.modify = isis_instance_multi_topology_ipv6_dstsrc_overload_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/log-adjacency-changes",
-			.cbs.modify = isis_instance_log_adjacency_changes_modify,
-			.cbs.cli_show = cli_show_isis_log_adjacency,
+			.cbs = {
+				.cli_show = cli_show_isis_log_adjacency,
+				.modify = isis_instance_log_adjacency_changes_modify,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/mpls-te",
-			.cbs.create = isis_instance_mpls_te_create,
-			.cbs.destroy = isis_instance_mpls_te_destroy,
-			.cbs.cli_show = cli_show_isis_mpls_te,
+			.cbs = {
+				.cli_show = cli_show_isis_mpls_te,
+				.create = isis_instance_mpls_te_create,
+				.destroy = isis_instance_mpls_te_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-isisd:isis/instance/mpls-te/router-address",
-			.cbs.modify = isis_instance_mpls_te_router_address_modify,
-			.cbs.destroy = isis_instance_mpls_te_router_address_destroy,
-			.cbs.cli_show = cli_show_isis_mpls_te_router_addr,
+			.cbs = {
+				.cli_show = cli_show_isis_mpls_te_router_addr,
+				.destroy = isis_instance_mpls_te_router_address_destroy,
+				.modify = isis_instance_mpls_te_router_address_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis",
-			.cbs.create = lib_interface_isis_create,
-			.cbs.destroy = lib_interface_isis_destroy,
+			.cbs = {
+				.create = lib_interface_isis_create,
+				.destroy = lib_interface_isis_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/area-tag",
-			.cbs.modify = lib_interface_isis_area_tag_modify,
+			.cbs = {
+				.modify = lib_interface_isis_area_tag_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/circuit-type",
-			.cbs.modify = lib_interface_isis_circuit_type_modify,
-			.cbs.cli_show = cli_show_ip_isis_circ_type,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_circ_type,
+				.modify = lib_interface_isis_circuit_type_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/ipv4-routing",
-			.cbs.modify = lib_interface_isis_ipv4_routing_modify,
-			.cbs.cli_show = cli_show_ip_isis_ipv4,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_ipv4,
+				.modify = lib_interface_isis_ipv4_routing_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/ipv6-routing",
-			.cbs.modify = lib_interface_isis_ipv6_routing_modify,
-			.cbs.cli_show = cli_show_ip_isis_ipv6,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_ipv6,
+				.modify = lib_interface_isis_ipv6_routing_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/csnp-interval",
-			.cbs.cli_show = cli_show_ip_isis_csnp_interval,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_csnp_interval,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/csnp-interval/level-1",
-			.cbs.modify = lib_interface_isis_csnp_interval_level_1_modify,
+			.cbs = {
+				.modify = lib_interface_isis_csnp_interval_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/csnp-interval/level-2",
-			.cbs.modify = lib_interface_isis_csnp_interval_level_2_modify,
+			.cbs = {
+				.modify = lib_interface_isis_csnp_interval_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/psnp-interval",
-			.cbs.cli_show = cli_show_ip_isis_psnp_interval,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_psnp_interval,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/psnp-interval/level-1",
-			.cbs.modify = lib_interface_isis_psnp_interval_level_1_modify,
+			.cbs = {
+				.modify = lib_interface_isis_psnp_interval_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/psnp-interval/level-2",
-			.cbs.modify = lib_interface_isis_psnp_interval_level_2_modify,
+			.cbs = {
+				.modify = lib_interface_isis_psnp_interval_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/hello/padding",
-			.cbs.modify = lib_interface_isis_hello_padding_modify,
-			.cbs.cli_show = cli_show_ip_isis_hello_padding,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_hello_padding,
+				.modify = lib_interface_isis_hello_padding_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/hello/interval",
-			.cbs.cli_show = cli_show_ip_isis_hello_interval,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_hello_interval,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/hello/interval/level-1",
-			.cbs.modify = lib_interface_isis_hello_interval_level_1_modify,
+			.cbs = {
+				.modify = lib_interface_isis_hello_interval_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/hello/interval/level-2",
-			.cbs.modify = lib_interface_isis_hello_interval_level_2_modify,
+			.cbs = {
+				.modify = lib_interface_isis_hello_interval_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/hello/multiplier",
-			.cbs.cli_show = cli_show_ip_isis_hello_multi,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_hello_multi,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/hello/multiplier/level-1",
-			.cbs.modify = lib_interface_isis_hello_multiplier_level_1_modify,
+			.cbs = {
+				.modify = lib_interface_isis_hello_multiplier_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/hello/multiplier/level-2",
-			.cbs.modify = lib_interface_isis_hello_multiplier_level_2_modify,
+			.cbs = {
+				.modify = lib_interface_isis_hello_multiplier_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/metric",
-			.cbs.cli_show = cli_show_ip_isis_metric,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_metric,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/metric/level-1",
-			.cbs.modify = lib_interface_isis_metric_level_1_modify,
+			.cbs = {
+				.modify = lib_interface_isis_metric_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/metric/level-2",
-			.cbs.modify = lib_interface_isis_metric_level_2_modify,
+			.cbs = {
+				.modify = lib_interface_isis_metric_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/priority",
-			.cbs.cli_show = cli_show_ip_isis_priority,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_priority,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/priority/level-1",
-			.cbs.modify = lib_interface_isis_priority_level_1_modify,
+			.cbs = {
+				.modify = lib_interface_isis_priority_level_1_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/priority/level-2",
-			.cbs.modify = lib_interface_isis_priority_level_2_modify,
+			.cbs = {
+				.modify = lib_interface_isis_priority_level_2_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/network-type",
-			.cbs.modify = lib_interface_isis_network_type_modify,
-			.cbs.cli_show = cli_show_ip_isis_network_type,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_network_type,
+				.modify = lib_interface_isis_network_type_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/passive",
-			.cbs.modify = lib_interface_isis_passive_modify,
-			.cbs.cli_show = cli_show_ip_isis_passive,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_passive,
+				.modify = lib_interface_isis_passive_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/password",
-			.cbs.create = lib_interface_isis_password_create,
-			.cbs.destroy = lib_interface_isis_password_destroy,
-			.cbs.cli_show = cli_show_ip_isis_password,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_password,
+				.create = lib_interface_isis_password_create,
+				.destroy = lib_interface_isis_password_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/password/password",
-			.cbs.modify = lib_interface_isis_password_password_modify,
+			.cbs = {
+				.modify = lib_interface_isis_password_password_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/password/password-type",
-			.cbs.modify = lib_interface_isis_password_password_type_modify,
+			.cbs = {
+				.modify = lib_interface_isis_password_password_type_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/disable-three-way-handshake",
-			.cbs.modify = lib_interface_isis_disable_three_way_handshake_modify,
-			.cbs.cli_show = cli_show_ip_isis_threeway_shake,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_threeway_shake,
+				.modify = lib_interface_isis_disable_three_way_handshake_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv4-unicast",
-			.cbs.modify = lib_interface_isis_multi_topology_ipv4_unicast_modify,
-			.cbs.cli_show = cli_show_ip_isis_mt_ipv4_unicast,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_mt_ipv4_unicast,
+				.modify = lib_interface_isis_multi_topology_ipv4_unicast_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv4-multicast",
-			.cbs.modify = lib_interface_isis_multi_topology_ipv4_multicast_modify,
-			.cbs.cli_show = cli_show_ip_isis_mt_ipv4_multicast,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_mt_ipv4_multicast,
+				.modify = lib_interface_isis_multi_topology_ipv4_multicast_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv4-management",
-			.cbs.modify = lib_interface_isis_multi_topology_ipv4_management_modify,
-			.cbs.cli_show = cli_show_ip_isis_mt_ipv4_mgmt,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_mt_ipv4_mgmt,
+				.modify = lib_interface_isis_multi_topology_ipv4_management_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv6-unicast",
-			.cbs.modify = lib_interface_isis_multi_topology_ipv6_unicast_modify,
-			.cbs.cli_show = cli_show_ip_isis_mt_ipv6_unicast,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_mt_ipv6_unicast,
+				.modify = lib_interface_isis_multi_topology_ipv6_unicast_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv6-multicast",
-			.cbs.modify = lib_interface_isis_multi_topology_ipv6_multicast_modify,
-			.cbs.cli_show = cli_show_ip_isis_mt_ipv6_multicast,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_mt_ipv6_multicast,
+				.modify = lib_interface_isis_multi_topology_ipv6_multicast_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv6-management",
-			.cbs.modify = lib_interface_isis_multi_topology_ipv6_management_modify,
-			.cbs.cli_show = cli_show_ip_isis_mt_ipv6_mgmt,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_mt_ipv6_mgmt,
+				.modify = lib_interface_isis_multi_topology_ipv6_management_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-isisd:isis/multi-topology/ipv6-dstsrc",
-			.cbs.modify = lib_interface_isis_multi_topology_ipv6_dstsrc_modify,
-			.cbs.cli_show = cli_show_ip_isis_mt_ipv6_dstsrc,
+			.cbs = {
+				.cli_show = cli_show_ip_isis_mt_ipv6_dstsrc,
+				.modify = lib_interface_isis_multi_topology_ipv6_dstsrc_modify,
+			},
 		},
 		{
 			.xpath = NULL,

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -618,12 +618,17 @@ session_read(struct thread *thread)
 			len -= msg_size;
 		}
 		free(buf);
+		buf = NULL;
 		if (len != 0) {
 			session_shutdown(nbr, S_BAD_PDU_LEN, 0, 0);
 			return (0);
 		}
 	}
 
+	/* shouldn't happen, session_get_pdu should be > 0 if buf was
+	 * allocated - but let's get rid of the SA warning.
+	 */
+	free(buf);
 	return (0);
 }
 

--- a/lib/command_py.c
+++ b/lib/command_py.c
@@ -22,6 +22,12 @@
  * memory leak or SEGV for things that haven't been well-tested.
  */
 
+/* This file is "exempt" from having
+#include "config.h"
+ * as the first include statement because Python.h also does environment
+ * setup & these trample over each other.
+ */
+
 #include <Python.h>
 #include "structmember.h"
 #include <string.h>

--- a/lib/command_py.c
+++ b/lib/command_py.c
@@ -321,6 +321,7 @@ static struct PyModuleDef pymoddef_clippy = {
 	} while (0)
 #endif
 
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 PyMODINIT_FUNC command_py_init(void)
 {
 	PyObject *pymod;

--- a/lib/frrlua.c
+++ b/lib/frrlua.c
@@ -20,7 +20,6 @@
  * with FRR; see the file COPYING.  If not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
-#include <stdio.h>
 
 #include <zebra.h>
 

--- a/lib/id_alloc.c
+++ b/lib/id_alloc.c
@@ -17,6 +17,10 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "id_alloc.h"
 
 #include "log.h"

--- a/lib/if.c
+++ b/lib/if.c
@@ -1422,15 +1422,19 @@ const struct frr_yang_module_info frr_interface_info = {
 	.nodes = {
 		{
 			.xpath = "/frr-interface:lib/interface",
-			.cbs.create = lib_interface_create,
-			.cbs.destroy = lib_interface_destroy,
-			.cbs.cli_show = cli_show_interface,
+			.cbs = {
+				.create = lib_interface_create,
+				.destroy = lib_interface_destroy,
+				.cli_show = cli_show_interface,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/description",
-			.cbs.modify = lib_interface_description_modify,
-			.cbs.destroy = lib_interface_description_destroy,
-			.cbs.cli_show = cli_show_interface_desc,
+			.cbs = {
+				.modify = lib_interface_description_modify,
+				.destroy = lib_interface_description_destroy,
+				.cli_show = cli_show_interface_desc,
+			},
 		},
 		{
 			.xpath = NULL,

--- a/lib/ntop.c
+++ b/lib/ntop.c
@@ -81,7 +81,7 @@ static inline void puthex(uint16_t word, char **posx)
 
 const char *frr_inet_ntop(int af, const void * restrict src,
 			  char * restrict dst, socklen_t size)
-	__attribute__((flatten)) DSO_SELF OPTIMIZE;
+	__attribute__((flatten)) OPTIMIZE;
 
 const char *frr_inet_ntop(int af, const void * restrict src,
 			  char * restrict dst, socklen_t size)
@@ -170,5 +170,5 @@ inet4:
  * as frr_inet_ntop (to avoid confusion while debugging)
  */
 const char *inet_ntop(int af, const void *src, char *dst, socklen_t size)
-	__attribute__((alias ("frr_inet_ntop"))) DSO_SELF;
+	__attribute__((alias ("frr_inet_ntop")));
 #endif

--- a/lib/typerb.c
+++ b/lib/typerb.c
@@ -41,6 +41,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "typerb.h"
 
 #define RB_BLACK	0

--- a/lib/typesafe.c
+++ b/lib/typesafe.c
@@ -14,6 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -879,6 +879,9 @@ static void ospf_spf_next(struct vertex *v, struct ospf *ospf,
 					  "Invalid LSA link type %d", type);
 				continue;
 			}
+
+			/* step (d) below */
+			distance = v->distance + ntohs(l->m[0].metric);
 		} else {
 			/* In case of V is Network-LSA. */
 			r = (struct in_addr *)p;
@@ -892,6 +895,9 @@ static void ospf_spf_next(struct vertex *v, struct ospf *ospf,
 					zlog_debug("found Router LSA %s",
 						   inet_ntoa(w_lsa->data->id));
 			}
+
+			/* step (d) below */
+			distance = v->distance;
 		}
 
 		/* (b cont.) If the LSA does not exist, or its LS age is equal
@@ -929,11 +935,7 @@ static void ospf_spf_next(struct vertex *v, struct ospf *ospf,
 		   vertex V and the advertised cost of the link between vertices
 		   V and W.  If D is: */
 
-		/* calculate link cost D. */
-		if (v->lsa->type == OSPF_ROUTER_LSA)
-			distance = v->distance + ntohs(l->m[0].metric);
-		else /* v is not a Router-LSA */
-			distance = v->distance;
+		/* calculate link cost D -- moved above */
 
 		/* Is there already vertex W in candidate list? */
 		if (w_lsa->stat == LSA_SPF_NOT_EXPLORED) {

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -19,6 +19,11 @@
  * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
  * MA 02110-1301 USA
  */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "if.h"
 #include "pimd.h"
 #include "pim_iface.h"

--- a/ripd/rip_northbound.c
+++ b/ripd/rip_northbound.c
@@ -103,12 +103,12 @@ static int ripd_instance_destroy(enum nb_event event,
 static const void *ripd_instance_get_next(const void *parent_list_entry,
 					  const void *list_entry)
 {
-	const struct rip *rip = list_entry;
+	struct rip *rip = (struct rip *)list_entry;
 
 	if (list_entry == NULL)
 		rip = RB_MIN(rip_instance_head, &rip_instances);
 	else
-		rip = RB_NEXT(rip_instance_head, (struct rip *)rip);
+		rip = RB_NEXT(rip_instance_head, rip);
 
 	return rip;
 }

--- a/ripd/rip_northbound.c
+++ b/ripd/rip_northbound.c
@@ -1483,241 +1483,337 @@ const struct frr_yang_module_info frr_ripd_info = {
 	.nodes = {
 		{
 			.xpath = "/frr-ripd:ripd/instance",
-			.cbs.create = ripd_instance_create,
-			.cbs.destroy = ripd_instance_destroy,
-			.cbs.get_next = ripd_instance_get_next,
-			.cbs.get_keys = ripd_instance_get_keys,
-			.cbs.lookup_entry = ripd_instance_lookup_entry,
-			.cbs.cli_show = cli_show_router_rip,
+			.cbs = {
+				.cli_show = cli_show_router_rip,
+				.create = ripd_instance_create,
+				.destroy = ripd_instance_destroy,
+				.get_keys = ripd_instance_get_keys,
+				.get_next = ripd_instance_get_next,
+				.lookup_entry = ripd_instance_lookup_entry,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/allow-ecmp",
-			.cbs.modify = ripd_instance_allow_ecmp_modify,
-			.cbs.cli_show = cli_show_rip_allow_ecmp,
+			.cbs = {
+				.cli_show = cli_show_rip_allow_ecmp,
+				.modify = ripd_instance_allow_ecmp_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/default-information-originate",
-			.cbs.modify = ripd_instance_default_information_originate_modify,
-			.cbs.cli_show = cli_show_rip_default_information_originate,
+			.cbs = {
+				.cli_show = cli_show_rip_default_information_originate,
+				.modify = ripd_instance_default_information_originate_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/default-metric",
-			.cbs.modify = ripd_instance_default_metric_modify,
-			.cbs.cli_show = cli_show_rip_default_metric,
+			.cbs = {
+				.cli_show = cli_show_rip_default_metric,
+				.modify = ripd_instance_default_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/distance/default",
-			.cbs.modify = ripd_instance_distance_default_modify,
-			.cbs.cli_show = cli_show_rip_distance,
+			.cbs = {
+				.cli_show = cli_show_rip_distance,
+				.modify = ripd_instance_distance_default_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/distance/source",
-			.cbs.create = ripd_instance_distance_source_create,
-			.cbs.destroy = ripd_instance_distance_source_destroy,
-			.cbs.cli_show = cli_show_rip_distance_source,
+			.cbs = {
+				.cli_show = cli_show_rip_distance_source,
+				.create = ripd_instance_distance_source_create,
+				.destroy = ripd_instance_distance_source_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/distance/source/distance",
-			.cbs.modify = ripd_instance_distance_source_distance_modify,
+			.cbs = {
+				.modify = ripd_instance_distance_source_distance_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/distance/source/access-list",
-			.cbs.modify = ripd_instance_distance_source_access_list_modify,
-			.cbs.destroy = ripd_instance_distance_source_access_list_destroy,
+			.cbs = {
+				.destroy = ripd_instance_distance_source_access_list_destroy,
+				.modify = ripd_instance_distance_source_access_list_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/explicit-neighbor",
-			.cbs.create = ripd_instance_explicit_neighbor_create,
-			.cbs.destroy = ripd_instance_explicit_neighbor_destroy,
-			.cbs.cli_show = cli_show_rip_neighbor,
+			.cbs = {
+				.cli_show = cli_show_rip_neighbor,
+				.create = ripd_instance_explicit_neighbor_create,
+				.destroy = ripd_instance_explicit_neighbor_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/network",
-			.cbs.create = ripd_instance_network_create,
-			.cbs.destroy = ripd_instance_network_destroy,
-			.cbs.cli_show = cli_show_rip_network_prefix,
+			.cbs = {
+				.cli_show = cli_show_rip_network_prefix,
+				.create = ripd_instance_network_create,
+				.destroy = ripd_instance_network_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/interface",
-			.cbs.create = ripd_instance_interface_create,
-			.cbs.destroy = ripd_instance_interface_destroy,
-			.cbs.cli_show = cli_show_rip_network_interface,
+			.cbs = {
+				.cli_show = cli_show_rip_network_interface,
+				.create = ripd_instance_interface_create,
+				.destroy = ripd_instance_interface_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/offset-list",
-			.cbs.create = ripd_instance_offset_list_create,
-			.cbs.destroy = ripd_instance_offset_list_destroy,
-			.cbs.cli_show = cli_show_rip_offset_list,
+			.cbs = {
+				.cli_show = cli_show_rip_offset_list,
+				.create = ripd_instance_offset_list_create,
+				.destroy = ripd_instance_offset_list_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/offset-list/access-list",
-			.cbs.modify = ripd_instance_offset_list_access_list_modify,
+			.cbs = {
+				.modify = ripd_instance_offset_list_access_list_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/offset-list/metric",
-			.cbs.modify = ripd_instance_offset_list_metric_modify,
+			.cbs = {
+				.modify = ripd_instance_offset_list_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/passive-default",
-			.cbs.modify = ripd_instance_passive_default_modify,
-			.cbs.cli_show = cli_show_rip_passive_default,
+			.cbs = {
+				.cli_show = cli_show_rip_passive_default,
+				.modify = ripd_instance_passive_default_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/passive-interface",
-			.cbs.create = ripd_instance_passive_interface_create,
-			.cbs.destroy = ripd_instance_passive_interface_destroy,
-			.cbs.cli_show = cli_show_rip_passive_interface,
+			.cbs = {
+				.cli_show = cli_show_rip_passive_interface,
+				.create = ripd_instance_passive_interface_create,
+				.destroy = ripd_instance_passive_interface_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/non-passive-interface",
-			.cbs.create = ripd_instance_non_passive_interface_create,
-			.cbs.destroy = ripd_instance_non_passive_interface_destroy,
-			.cbs.cli_show = cli_show_rip_non_passive_interface,
+			.cbs = {
+				.cli_show = cli_show_rip_non_passive_interface,
+				.create = ripd_instance_non_passive_interface_create,
+				.destroy = ripd_instance_non_passive_interface_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/redistribute",
-			.cbs.create = ripd_instance_redistribute_create,
-			.cbs.destroy = ripd_instance_redistribute_destroy,
-			.cbs.apply_finish = ripd_instance_redistribute_apply_finish,
-			.cbs.cli_show = cli_show_rip_redistribute,
+			.cbs = {
+				.apply_finish = ripd_instance_redistribute_apply_finish,
+				.cli_show = cli_show_rip_redistribute,
+				.create = ripd_instance_redistribute_create,
+				.destroy = ripd_instance_redistribute_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/redistribute/route-map",
-			.cbs.modify = ripd_instance_redistribute_route_map_modify,
-			.cbs.destroy = ripd_instance_redistribute_route_map_destroy,
+			.cbs = {
+				.destroy = ripd_instance_redistribute_route_map_destroy,
+				.modify = ripd_instance_redistribute_route_map_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/redistribute/metric",
-			.cbs.modify = ripd_instance_redistribute_metric_modify,
-			.cbs.destroy = ripd_instance_redistribute_metric_destroy,
+			.cbs = {
+				.destroy = ripd_instance_redistribute_metric_destroy,
+				.modify = ripd_instance_redistribute_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/static-route",
-			.cbs.create = ripd_instance_static_route_create,
-			.cbs.destroy = ripd_instance_static_route_destroy,
-			.cbs.cli_show = cli_show_rip_route,
+			.cbs = {
+				.cli_show = cli_show_rip_route,
+				.create = ripd_instance_static_route_create,
+				.destroy = ripd_instance_static_route_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/timers",
-			.cbs.apply_finish = ripd_instance_timers_apply_finish,
-			.cbs.cli_show = cli_show_rip_timers,
+			.cbs = {
+				.apply_finish = ripd_instance_timers_apply_finish,
+				.cli_show = cli_show_rip_timers,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/timers/flush-interval",
-			.cbs.modify = ripd_instance_timers_flush_interval_modify,
+			.cbs = {
+				.modify = ripd_instance_timers_flush_interval_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/timers/holddown-interval",
-			.cbs.modify = ripd_instance_timers_holddown_interval_modify,
+			.cbs = {
+				.modify = ripd_instance_timers_holddown_interval_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/timers/update-interval",
-			.cbs.modify = ripd_instance_timers_update_interval_modify,
+			.cbs = {
+				.modify = ripd_instance_timers_update_interval_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/version",
-			.cbs.cli_show = cli_show_rip_version,
+			.cbs = {
+				.cli_show = cli_show_rip_version,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/version/receive",
-			.cbs.modify = ripd_instance_version_receive_modify,
+			.cbs = {
+				.modify = ripd_instance_version_receive_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/version/send",
-			.cbs.modify = ripd_instance_version_send_modify,
+			.cbs = {
+				.modify = ripd_instance_version_send_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/split-horizon",
-			.cbs.modify = lib_interface_rip_split_horizon_modify,
-			.cbs.cli_show = cli_show_ip_rip_split_horizon,
+			.cbs = {
+				.cli_show = cli_show_ip_rip_split_horizon,
+				.modify = lib_interface_rip_split_horizon_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/v2-broadcast",
-			.cbs.modify = lib_interface_rip_v2_broadcast_modify,
-			.cbs.cli_show = cli_show_ip_rip_v2_broadcast,
+			.cbs = {
+				.cli_show = cli_show_ip_rip_v2_broadcast,
+				.modify = lib_interface_rip_v2_broadcast_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/version-receive",
-			.cbs.modify = lib_interface_rip_version_receive_modify,
-			.cbs.cli_show = cli_show_ip_rip_receive_version,
+			.cbs = {
+				.cli_show = cli_show_ip_rip_receive_version,
+				.modify = lib_interface_rip_version_receive_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/version-send",
-			.cbs.modify = lib_interface_rip_version_send_modify,
-			.cbs.cli_show = cli_show_ip_rip_send_version,
+			.cbs = {
+				.cli_show = cli_show_ip_rip_send_version,
+				.modify = lib_interface_rip_version_send_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/authentication-scheme",
-			.cbs.cli_show = cli_show_ip_rip_authentication_scheme,
+			.cbs = {
+				.cli_show = cli_show_ip_rip_authentication_scheme,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/authentication-scheme/mode",
-			.cbs.modify = lib_interface_rip_authentication_scheme_mode_modify,
+			.cbs = {
+				.modify = lib_interface_rip_authentication_scheme_mode_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/authentication-scheme/md5-auth-length",
-			.cbs.modify = lib_interface_rip_authentication_scheme_md5_auth_length_modify,
-			.cbs.destroy = lib_interface_rip_authentication_scheme_md5_auth_length_destroy,
+			.cbs = {
+				.destroy = lib_interface_rip_authentication_scheme_md5_auth_length_destroy,
+				.modify = lib_interface_rip_authentication_scheme_md5_auth_length_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/authentication-password",
-			.cbs.modify = lib_interface_rip_authentication_password_modify,
-			.cbs.destroy = lib_interface_rip_authentication_password_destroy,
-			.cbs.cli_show = cli_show_ip_rip_authentication_string,
+			.cbs = {
+				.cli_show = cli_show_ip_rip_authentication_string,
+				.destroy = lib_interface_rip_authentication_password_destroy,
+				.modify = lib_interface_rip_authentication_password_modify,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripd:rip/authentication-key-chain",
-			.cbs.modify = lib_interface_rip_authentication_key_chain_modify,
-			.cbs.destroy = lib_interface_rip_authentication_key_chain_destroy,
-			.cbs.cli_show = cli_show_ip_rip_authentication_key_chain,
+			.cbs = {
+				.cli_show = cli_show_ip_rip_authentication_key_chain,
+				.destroy = lib_interface_rip_authentication_key_chain_destroy,
+				.modify = lib_interface_rip_authentication_key_chain_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/neighbors/neighbor",
-			.cbs.get_next = ripd_instance_state_neighbors_neighbor_get_next,
-			.cbs.get_keys = ripd_instance_state_neighbors_neighbor_get_keys,
-			.cbs.lookup_entry = ripd_instance_state_neighbors_neighbor_lookup_entry,
+			.cbs = {
+				.get_keys = ripd_instance_state_neighbors_neighbor_get_keys,
+				.get_next = ripd_instance_state_neighbors_neighbor_get_next,
+				.lookup_entry = ripd_instance_state_neighbors_neighbor_lookup_entry,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/neighbors/neighbor/address",
-			.cbs.get_elem = ripd_instance_state_neighbors_neighbor_address_get_elem,
+			.cbs = {
+				.get_elem = ripd_instance_state_neighbors_neighbor_address_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/neighbors/neighbor/last-update",
-			.cbs.get_elem = ripd_instance_state_neighbors_neighbor_last_update_get_elem,
+			.cbs = {
+				.get_elem = ripd_instance_state_neighbors_neighbor_last_update_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/neighbors/neighbor/bad-packets-rcvd",
-			.cbs.get_elem = ripd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem,
+			.cbs = {
+				.get_elem = ripd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/neighbors/neighbor/bad-routes-rcvd",
-			.cbs.get_elem = ripd_instance_state_neighbors_neighbor_bad_routes_rcvd_get_elem,
+			.cbs = {
+				.get_elem = ripd_instance_state_neighbors_neighbor_bad_routes_rcvd_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/routes/route",
-			.cbs.get_next = ripd_instance_state_routes_route_get_next,
-			.cbs.get_keys = ripd_instance_state_routes_route_get_keys,
-			.cbs.lookup_entry = ripd_instance_state_routes_route_lookup_entry,
+			.cbs = {
+				.get_keys = ripd_instance_state_routes_route_get_keys,
+				.get_next = ripd_instance_state_routes_route_get_next,
+				.lookup_entry = ripd_instance_state_routes_route_lookup_entry,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/routes/route/prefix",
-			.cbs.get_elem = ripd_instance_state_routes_route_prefix_get_elem,
+			.cbs = {
+				.get_elem = ripd_instance_state_routes_route_prefix_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/routes/route/next-hop",
-			.cbs.get_elem = ripd_instance_state_routes_route_next_hop_get_elem,
+			.cbs = {
+				.get_elem = ripd_instance_state_routes_route_next_hop_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/routes/route/interface",
-			.cbs.get_elem = ripd_instance_state_routes_route_interface_get_elem,
+			.cbs = {
+				.get_elem = ripd_instance_state_routes_route_interface_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:ripd/instance/state/routes/route/metric",
-			.cbs.get_elem = ripd_instance_state_routes_route_metric_get_elem,
+			.cbs = {
+				.get_elem = ripd_instance_state_routes_route_metric_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripd:clear-rip-route",
-			.cbs.rpc = clear_rip_route_rpc,
+			.cbs = {
+				.rpc = clear_rip_route_rpc,
+			},
 		},
 		{
 			.xpath = NULL,

--- a/ripngd/ripng_northbound.c
+++ b/ripngd/ripng_northbound.c
@@ -1012,158 +1012,220 @@ const struct frr_yang_module_info frr_ripngd_info = {
 	.nodes = {
 		{
 			.xpath = "/frr-ripngd:ripngd/instance",
-			.cbs.create = ripngd_instance_create,
-			.cbs.destroy = ripngd_instance_destroy,
-			.cbs.get_next = ripngd_instance_get_next,
-			.cbs.get_keys = ripngd_instance_get_keys,
-			.cbs.lookup_entry = ripngd_instance_lookup_entry,
-			.cbs.cli_show = cli_show_router_ripng,
+			.cbs = {
+				.cli_show = cli_show_router_ripng,
+				.create = ripngd_instance_create,
+				.destroy = ripngd_instance_destroy,
+				.get_keys = ripngd_instance_get_keys,
+				.get_next = ripngd_instance_get_next,
+				.lookup_entry = ripngd_instance_lookup_entry,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/allow-ecmp",
-			.cbs.modify = ripngd_instance_allow_ecmp_modify,
-			.cbs.cli_show = cli_show_ripng_allow_ecmp,
+			.cbs = {
+				.cli_show = cli_show_ripng_allow_ecmp,
+				.modify = ripngd_instance_allow_ecmp_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/default-information-originate",
-			.cbs.modify = ripngd_instance_default_information_originate_modify,
-			.cbs.cli_show = cli_show_ripng_default_information_originate,
+			.cbs = {
+				.cli_show = cli_show_ripng_default_information_originate,
+				.modify = ripngd_instance_default_information_originate_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/default-metric",
-			.cbs.modify = ripngd_instance_default_metric_modify,
-			.cbs.cli_show = cli_show_ripng_default_metric,
+			.cbs = {
+				.cli_show = cli_show_ripng_default_metric,
+				.modify = ripngd_instance_default_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/network",
-			.cbs.create = ripngd_instance_network_create,
-			.cbs.destroy = ripngd_instance_network_destroy,
-			.cbs.cli_show = cli_show_ripng_network_prefix,
+			.cbs = {
+				.cli_show = cli_show_ripng_network_prefix,
+				.create = ripngd_instance_network_create,
+				.destroy = ripngd_instance_network_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/interface",
-			.cbs.create = ripngd_instance_interface_create,
-			.cbs.destroy = ripngd_instance_interface_destroy,
-			.cbs.cli_show = cli_show_ripng_network_interface,
+			.cbs = {
+				.cli_show = cli_show_ripng_network_interface,
+				.create = ripngd_instance_interface_create,
+				.destroy = ripngd_instance_interface_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/offset-list",
-			.cbs.create = ripngd_instance_offset_list_create,
-			.cbs.destroy = ripngd_instance_offset_list_destroy,
-			.cbs.cli_show = cli_show_ripng_offset_list,
+			.cbs = {
+				.cli_show = cli_show_ripng_offset_list,
+				.create = ripngd_instance_offset_list_create,
+				.destroy = ripngd_instance_offset_list_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/offset-list/access-list",
-			.cbs.modify = ripngd_instance_offset_list_access_list_modify,
+			.cbs = {
+				.modify = ripngd_instance_offset_list_access_list_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/offset-list/metric",
-			.cbs.modify = ripngd_instance_offset_list_metric_modify,
+			.cbs = {
+				.modify = ripngd_instance_offset_list_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/passive-interface",
-			.cbs.create = ripngd_instance_passive_interface_create,
-			.cbs.destroy = ripngd_instance_passive_interface_destroy,
-			.cbs.cli_show = cli_show_ripng_passive_interface,
+			.cbs = {
+				.cli_show = cli_show_ripng_passive_interface,
+				.create = ripngd_instance_passive_interface_create,
+				.destroy = ripngd_instance_passive_interface_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/redistribute",
-			.cbs.create = ripngd_instance_redistribute_create,
-			.cbs.destroy = ripngd_instance_redistribute_destroy,
-			.cbs.apply_finish = ripngd_instance_redistribute_apply_finish,
-			.cbs.cli_show = cli_show_ripng_redistribute,
+			.cbs = {
+				.apply_finish = ripngd_instance_redistribute_apply_finish,
+				.cli_show = cli_show_ripng_redistribute,
+				.create = ripngd_instance_redistribute_create,
+				.destroy = ripngd_instance_redistribute_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/redistribute/route-map",
-			.cbs.modify = ripngd_instance_redistribute_route_map_modify,
-			.cbs.destroy = ripngd_instance_redistribute_route_map_destroy,
+			.cbs = {
+				.destroy = ripngd_instance_redistribute_route_map_destroy,
+				.modify = ripngd_instance_redistribute_route_map_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/redistribute/metric",
-			.cbs.modify = ripngd_instance_redistribute_metric_modify,
-			.cbs.destroy = ripngd_instance_redistribute_metric_destroy,
+			.cbs = {
+				.destroy = ripngd_instance_redistribute_metric_destroy,
+				.modify = ripngd_instance_redistribute_metric_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/static-route",
-			.cbs.create = ripngd_instance_static_route_create,
-			.cbs.destroy = ripngd_instance_static_route_destroy,
-			.cbs.cli_show = cli_show_ripng_route,
+			.cbs = {
+				.cli_show = cli_show_ripng_route,
+				.create = ripngd_instance_static_route_create,
+				.destroy = ripngd_instance_static_route_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/aggregate-address",
-			.cbs.create = ripngd_instance_aggregate_address_create,
-			.cbs.destroy = ripngd_instance_aggregate_address_destroy,
-			.cbs.cli_show = cli_show_ripng_aggregate_address,
+			.cbs = {
+				.cli_show = cli_show_ripng_aggregate_address,
+				.create = ripngd_instance_aggregate_address_create,
+				.destroy = ripngd_instance_aggregate_address_destroy,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/timers",
-			.cbs.apply_finish = ripngd_instance_timers_apply_finish,
-			.cbs.cli_show = cli_show_ripng_timers,
+			.cbs = {
+				.apply_finish = ripngd_instance_timers_apply_finish,
+				.cli_show = cli_show_ripng_timers,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/timers/flush-interval",
-			.cbs.modify = ripngd_instance_timers_flush_interval_modify,
+			.cbs = {
+				.modify = ripngd_instance_timers_flush_interval_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/timers/holddown-interval",
-			.cbs.modify = ripngd_instance_timers_holddown_interval_modify,
+			.cbs = {
+				.modify = ripngd_instance_timers_holddown_interval_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/timers/update-interval",
-			.cbs.modify = ripngd_instance_timers_update_interval_modify,
+			.cbs = {
+				.modify = ripngd_instance_timers_update_interval_modify,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/neighbors/neighbor",
-			.cbs.get_next = ripngd_instance_state_neighbors_neighbor_get_next,
-			.cbs.get_keys = ripngd_instance_state_neighbors_neighbor_get_keys,
-			.cbs.lookup_entry = ripngd_instance_state_neighbors_neighbor_lookup_entry,
+			.cbs = {
+				.get_keys = ripngd_instance_state_neighbors_neighbor_get_keys,
+				.get_next = ripngd_instance_state_neighbors_neighbor_get_next,
+				.lookup_entry = ripngd_instance_state_neighbors_neighbor_lookup_entry,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/neighbors/neighbor/address",
-			.cbs.get_elem = ripngd_instance_state_neighbors_neighbor_address_get_elem,
+			.cbs = {
+				.get_elem = ripngd_instance_state_neighbors_neighbor_address_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/neighbors/neighbor/last-update",
-			.cbs.get_elem = ripngd_instance_state_neighbors_neighbor_last_update_get_elem,
+			.cbs = {
+				.get_elem = ripngd_instance_state_neighbors_neighbor_last_update_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/neighbors/neighbor/bad-packets-rcvd",
-			.cbs.get_elem = ripngd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem,
+			.cbs = {
+				.get_elem = ripngd_instance_state_neighbors_neighbor_bad_packets_rcvd_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/neighbors/neighbor/bad-routes-rcvd",
-			.cbs.get_elem = ripngd_instance_state_neighbors_neighbor_bad_routes_rcvd_get_elem,
+			.cbs = {
+				.get_elem = ripngd_instance_state_neighbors_neighbor_bad_routes_rcvd_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/routes/route",
-			.cbs.get_next = ripngd_instance_state_routes_route_get_next,
-			.cbs.get_keys = ripngd_instance_state_routes_route_get_keys,
-			.cbs.lookup_entry = ripngd_instance_state_routes_route_lookup_entry,
+			.cbs = {
+				.get_keys = ripngd_instance_state_routes_route_get_keys,
+				.get_next = ripngd_instance_state_routes_route_get_next,
+				.lookup_entry = ripngd_instance_state_routes_route_lookup_entry,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/routes/route/prefix",
-			.cbs.get_elem = ripngd_instance_state_routes_route_prefix_get_elem,
+			.cbs = {
+				.get_elem = ripngd_instance_state_routes_route_prefix_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/routes/route/next-hop",
-			.cbs.get_elem = ripngd_instance_state_routes_route_next_hop_get_elem,
+			.cbs = {
+				.get_elem = ripngd_instance_state_routes_route_next_hop_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/routes/route/interface",
-			.cbs.get_elem = ripngd_instance_state_routes_route_interface_get_elem,
+			.cbs = {
+				.get_elem = ripngd_instance_state_routes_route_interface_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:ripngd/instance/state/routes/route/metric",
-			.cbs.get_elem = ripngd_instance_state_routes_route_metric_get_elem,
+			.cbs = {
+				.get_elem = ripngd_instance_state_routes_route_metric_get_elem,
+			},
 		},
 		{
 			.xpath = "/frr-ripngd:clear-ripng-route",
-			.cbs.rpc = clear_ripng_route_rpc,
+			.cbs = {
+				.rpc = clear_ripng_route_rpc,
+			},
 		},
 		{
 			.xpath = "/frr-interface:lib/interface/frr-ripngd:ripng/split-horizon",
-			.cbs.modify = lib_interface_ripng_split_horizon_modify,
-			.cbs.cli_show = cli_show_ipv6_ripng_split_horizon,
+			.cbs = {
+				.cli_show = cli_show_ipv6_ripng_split_horizon,
+				.modify = lib_interface_ripng_split_horizon_modify,
+			},
 		},
 		{
 			.xpath = NULL,

--- a/ripngd/ripng_northbound.c
+++ b/ripngd/ripng_northbound.c
@@ -105,12 +105,12 @@ static int ripngd_instance_destroy(enum nb_event event,
 static const void *ripngd_instance_get_next(const void *parent_list_entry,
 					    const void *list_entry)
 {
-	const struct ripng *ripng = list_entry;
+	struct ripng *ripng = (struct ripng *)list_entry;
 
 	if (list_entry == NULL)
 		ripng = RB_MIN(ripng_instance_head, &ripng_instances);
 	else
-		ripng = RB_NEXT(ripng_instance_head, (struct ripng *)ripng);
+		ripng = RB_NEXT(ripng_instance_head, ripng);
 
 	return ripng;
 }

--- a/tests/lib/test_idalloc.c
+++ b/tests/lib/test_idalloc.c
@@ -1,3 +1,7 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "id_alloc.h"
 
 #include <inttypes.h>

--- a/tests/lib/test_seqlock.c
+++ b/tests/lib/test_seqlock.c
@@ -18,6 +18,10 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdio.h>
 #include <stdint.h>
 #include <inttypes.h>

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -17,6 +17,10 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "lib/libfrr.h"
 #include "lib/debug.h"
 #include "lib/frratomic.h"


### PR DESCRIPTION
As far as NetDEF CI is concerned, only the following two systems have warnings remaining:

* CentOS 6 (can't be fixed within reason)
* CentOS 7 (will be fixed by updating to Python3)

Also, this fixes all current clang-SA warnings, except one possible warning in `lib/defun_lex.c` (which NetDEF CI doesn't show because it runs on [outdated] flex 2.6.0).  That issue is the end boss of the warnings game, with a fix posted in westes/flex#380 not going anywhere for the past 9 months...