### PR TITLE
bgpd: show bgp vrfs formatting

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7463,11 +7463,14 @@ DEFUN (show_bgp_vrfs,
 			continue;
 
 		count++;
-		if (!uj && count == 1)
+		if (!uj && count == 1) {
 			vty_out(vty,
-				"%4s  %-5s  %-16s  %9s  %10s  %-37s %-10s %-15s\n",
+				"%4s  %-5s  %-16s  %9s  %10s  %-37s\n",
 				"Type", "Id", "routerId", "#PeersVfg",
-				"#PeersEstb", "Name", "L3-VNI", "Rmac");
+				"#PeersEstb", "Name");
+			vty_out(vty, "%11s  %-16s  %-21s  %-6s\n", " ",
+				"L3-VNI", "RouterMAC", "Interface");
+		}
 
 		peers_cfg = peers_estb = 0;
 		if (uj)
@@ -7508,16 +7511,24 @@ DEFUN (show_bgp_vrfs,
 			json_object_string_add(
 				json_vrf, "rmac",
 				prefix_mac2str(&bgp->rmac, buf, sizeof(buf)));
+			json_object_string_add(json_vrf, "interface",
+				ifindex2ifname(bgp->l3vni_svi_ifindex,
+					       bgp->vrf_id));
 			json_object_object_add(json_vrfs, name, json_vrf);
-		} else
+		} else {
 			vty_out(vty,
-				"%4s  %-5d  %-16s  %9u  %10u  %-37s %-10u %-15s\n",
+				"%4s  %-5d  %-16s  %-9u  %-10u  %-37s\n",
 				type,
 				bgp->vrf_id == VRF_UNKNOWN ? -1
 							   : (int)bgp->vrf_id,
 				inet_ntoa(bgp->router_id), peers_cfg,
-				peers_estb, name, bgp->l3vni,
-				prefix_mac2str(&bgp->rmac, buf, sizeof(buf)));
+				peers_estb, name);
+			vty_out(vty,"%11s  %-16u  %-21s  %-20s\n", " ",
+				bgp->l3vni,
+				prefix_mac2str(&bgp->rmac, buf, sizeof(buf)),
+				ifindex2ifname(bgp->l3vni_svi_ifindex,
+					       bgp->vrf_id));
+		}
 	}
 
 	if (uj) {


### PR DESCRIPTION
show bgp vrfs command is formatted with couple
of things.

show bgp vrfs to include bgp vrf instance's
SVI interface.
Move L3vni, RMAC and SVI value in next line.

Testing Done:

New Output:

```
TORS1# show bgp vrfs
Type  Id     routerId          #PeersVfg  #PeersEstb  Name
             L3-VNI            RouterMAC              Interface
DFLT  0      27.0.0.15         2          2           default
             0                 00:00:00:00:00:00      unknown
 VRF  31     45.0.8.2          0          0           vrf3
             4003              00:02:00:00:00:4e      vlan4003
 VRF  35     45.0.2.2          0          0           vrf1
             4001              00:02:00:00:00:4e      vlan4001
 VRF  25     45.0.6.2          0          0           vrf2
             4002              00:02:00:00:00:4e      vlan4002

Total number of VRFs (including default): 4
```




Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>