### PR TITLE
pimd: fix DR at LHR scenario where non DR is connected to RP

### DIFF
--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -344,10 +344,12 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	  IGMP must be protected against adding looped MFC entries created
 	  by both source and receiver attached to the same interface. See
 	  TODO T22.
+	  We shall allow igmp to create upstream when it is DR for the intf.
+	  Assume RP reachable via non DR.
 	*/
-	if (channel_oil->up &&
-			PIM_UPSTREAM_FLAG_TEST_ALLOW_IIF_IN_OIL(
-				channel_oil->up->flags)) {
+	if ((channel_oil->up &&
+	    PIM_UPSTREAM_FLAG_TEST_ALLOW_IIF_IN_OIL(channel_oil->up->flags)) ||
+	    ((proto_mask == PIM_OIF_FLAG_PROTO_IGMP) && PIM_I_am_DR(pim_ifp))) {
 		allow_iif_in_oil = true;
 	}
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -1043,10 +1043,12 @@ void igmp_source_forward_start(struct pim_instance *pim,
 				 * Protect IGMP against adding looped MFC
 				 * entries created by both source and receiver
 				 * attached to the same interface. See TODO
-				 * T22.
+				 * T22. Block only when the intf is non DR
+				 * DR must create upstream.
 				 */
-				if (input_iface_vif_index ==
-				    pim_oif->mroute_vif_index) {
+				if ((input_iface_vif_index ==
+				    pim_oif->mroute_vif_index) &&
+				    !(PIM_I_am_DR(pim_oif))) {
 					/* ignore request for looped MFC entry
 					 */
 					if (PIM_DEBUG_IGMP_TRACE) {


### PR DESCRIPTION
In Scenario where receiver is present in a subnet where 2 or more pim mrouters. When IGMP query received on a DR interface and RP is reachable through non DR. Currently we are blocking to create upstream where iif == oif. So pim join not generated towards RP. We have to allow the DR router in the network to create an upstream.

Signed-off-by: Saravanan K <saravanank@vmware.com>