### PR TITLE
bgpd: address issue #4479 crash during instance removal

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2310,6 +2310,17 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 	char pfx_buf[PREFIX2STR_BUFFER];
 	int debug = 0;
 
+	if (bgp_flag_check(bgp, BGP_FLAG_DELETE_IN_PROGRESS)) {
+		if (rn)
+			debug = bgp_debug_bestpath(&rn->p);
+		if (debug) {
+			prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
+			zlog_debug(
+			     "%s: bgp delete in progress, ignoring event, p=%s",
+			     __func__, pfx_buf);
+		}
+		return;
+	}
 	/* Is it end of initial update? (after startup) */
 	if (!rn) {
 		quagga_timestamp(3, bgp->update_delay_zebra_resume_time,

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -2402,6 +2402,18 @@ static int rfapiWithdrawTimerVPN(struct thread *t)
 	struct rfapi_monitor_vpn *moved;
 	afi_t afi;
 
+	if (bgp == NULL) {
+		vnc_zlog_debug_verbose(
+                   "%s: NULL BGP pointer, assume shutdown race condition!!!",
+                   __func__);
+		return 0;
+	}
+	if (bgp_flag_check(bgp, BGP_FLAG_DELETE_IN_PROGRESS)) {
+		vnc_zlog_debug_verbose(
+                   "%s: BGP delete in progress, assume shutdown race condition!!!",
+                   __func__);
+		return 0;
+	}
 	assert(wcb->node);
 	assert(bpi);
 	assert(wcb->import_table);

--- a/tests/topotests/bgp_instance_del_test/ce1
+++ b/tests/topotests/bgp_instance_del_test/ce1
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/ce1

--- a/tests/topotests/bgp_instance_del_test/ce2
+++ b/tests/topotests/bgp_instance_del_test/ce2
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/ce2

--- a/tests/topotests/bgp_instance_del_test/ce3
+++ b/tests/topotests/bgp_instance_del_test/ce3
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/ce3

--- a/tests/topotests/bgp_instance_del_test/ce4
+++ b/tests/topotests/bgp_instance_del_test/ce4
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/ce4

--- a/tests/topotests/bgp_instance_del_test/customize.py
+++ b/tests/topotests/bgp_instance_del_test/customize.py
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/customize.py

--- a/tests/topotests/bgp_instance_del_test/r1
+++ b/tests/topotests/bgp_instance_del_test/r1
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/r1

--- a/tests/topotests/bgp_instance_del_test/r2
+++ b/tests/topotests/bgp_instance_del_test/r2
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/r2

--- a/tests/topotests/bgp_instance_del_test/r3
+++ b/tests/topotests/bgp_instance_del_test/r3
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/r3

--- a/tests/topotests/bgp_instance_del_test/r4
+++ b/tests/topotests/bgp_instance_del_test/r4
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/r4

--- a/tests/topotests/bgp_instance_del_test/scripts
+++ b/tests/topotests/bgp_instance_del_test/scripts
@@ -1,0 +1,1 @@
+../bgp_l3vpn_to_bgp_vrf/scripts

--- a/tests/topotests/bgp_instance_del_test/test_bgp_instance_del_test.py
+++ b/tests/topotests/bgp_instance_del_test/test_bgp_instance_del_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+#
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2018, LabN Consulting, L.L.C.
+# Authored by Lou Berger <lberger@labn.net>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../'))
+
+from lib.ltemplate import *
+
+def test_check_linux_vrf():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    #CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', iproute2=\'4.9\')'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, iproute2=\'4.9\')'
+    ltemplateTest('scripts/check_linux_vrf.py', False, CliOnFail, CheckFunc)
+
+def test_adjacencies():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    #CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\')'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True)'
+    ltemplateTest('scripts/adjacencies.py', False, CliOnFail, CheckFunc)
+
+def SKIP_test_add_routes():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    #CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\')'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True)'
+    ltemplateTest('scripts/add_routes.py', False, CliOnFail, CheckFunc)
+
+def test_check_routes():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    #CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\')'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True)'
+    ltemplateTest('scripts/check_routes.py', False, CliOnFail, CheckFunc)
+
+#manual data path setup test - remove once have bgp/zebra vrf path working
+def test_check_linux_mpls():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    #CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\', iproute2=\'4.9\')'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True, iproute2=\'4.9\')'
+    ltemplateTest('scripts/check_linux_mpls.py', False, CliOnFail, CheckFunc)
+
+def test_del_bgp_instances():
+    CliOnFail = None
+    # For debugging, uncomment the next line
+    #CliOnFail = 'tgen.mininet_cli'
+    CheckFunc = 'ltemplateVersionCheck(\'4.1\')'
+    #uncomment next line to start cli *before* script is run
+    #CheckFunc = 'ltemplateVersionCheck(\'4.1\', cli=True)'
+    ltemplateTest('scripts/del_bgp_instances.py', False, CliOnFail, CheckFunc)
+
+if __name__ == '__main__':
+    retval = pytest.main(["-s"])
+    sys.exit(retval)

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/del_bgp_instances.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/del_bgp_instances.py
@@ -1,0 +1,7 @@
+from lutil import luCommand
+
+luCommand('r1','/usr/lib/frr/vtysh -c "conf ter" -c "no router bgp 5227 vrf r1-cust1" -c "no router bgp 5226"','.','none','Cleared bgp instances')
+luCommand('r2','/usr/lib/frr/vtysh -c "conf ter" -c "no router bgp 5226"','.','none','Cleared bgp instances')
+luCommand('r3','/usr/lib/frr/vtysh -c "conf ter" -c "no router bgp 5227 vrf r3-cust1" -c "no router bgp 5226"','.','none','Cleared bgp instances')
+luCommand('r4','/usr/lib/frr/vtysh -c "conf ter" -c "no router bgp 5228 vrf r4-cust2" -c "no router bgp 5227 vrf r4-cust1"  -c "no router bgp 5226"','.','none','Cleared bgp instances')
+

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_down.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_down.py
@@ -6,7 +6,7 @@ if ret != False and found != None:
     luCommand('ce3', 'vtysh -c "show bgp sum"',
 	      '.', 'pass', 'See %s sharp routes' % num)
     if num > 0:
-        wait = num/500
+        wait = 2*num/500
         luCommand('ce1', 'vtysh -c "sharp remove routes 10.0.0.0 {}"'.format(num),'.','none','Removing {} routes'.format(num))
         luCommand('ce2', 'vtysh -c "sharp remove routes 10.0.0.0 {}"'.format(num),'.','none','Removing {} routes'.format(num))
         rtrs = ['ce1', 'ce2', 'ce3']

--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_up.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/scripts/scale_up.py
@@ -10,7 +10,7 @@ if c > 0:
     d = r - c * 256 - 1 
 else:
     d = r
-wait = num/1000
+wait = 2*num/1000
 mem = {}
 rtrs = ['ce1', 'ce2', 'ce3', 'r1', 'r2', 'r3', 'r4']
 for rtr in rtrs:


### PR DESCRIPTION
Build on #4499 and use test for flag and bgp==null in events firing during/after the bgp instance removal.,

Also add topotest to validate this case.