### PR TITLE
doc: add config file name for mpls config

### DIFF
--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -465,7 +465,8 @@ Additional kernel modules are also needed to support MPLS forwarding.
       mpls_router
       mpls_iptunnel
 
-   The following is an example to enable MPLS forwarding in the kernel:
+   The following is an example to enable MPLS forwarding in the
+   kernel, typically by editing :file:`/etc/sysctl.conf`:
 
    .. code-block:: shell
 


### PR DESCRIPTION
We say something about what needs to be configured - but don't name the file where the change needs to go. The developer docs name the file - but the user doc doesn't; this just adds the filename.
