### PR TITLE
[7.1] tools: retain sanity when reloading under systemd

### DIFF
--- a/tools/frrinit.sh.in
+++ b/tools/frrinit.sh.in
@@ -71,12 +71,37 @@ reload)
 		exit 1
 	fi
 
+	# systemd doesn't set WATCHDOG_USEC for reload commands.
+	watchfrr_pidfile="$V_PATH/watchfrr.pid"
+	watchfrr_pid="`cat \"$watchfrr_pidfile\"`"
+	if [ -d "/proc/$watchfrr_pid" ]; then
+		wdt="`tr '\0' '\n' < /proc/$watchfrr_pid/environ | grep '^WATCHDOG_USEC='`"
+		wdt="${wdt#WATCHDOG_USEC=}"
+		[ -n "$wdt" ] && : ${WATCHDOG_USEC:=$wdt}
+		[ -n "$WATCHDOG_USEC" ] && export WATCHDOG_USEC
+	fi
+
 	# restart watchfrr to pick up added daemons.
 	# NB: This will NOT cause the other daemons to be restarted.
 	daemon_list daemons
 	watchfrr_options="$watchfrr_options $daemons"
 	daemon_stop watchfrr && \
 		daemon_start watchfrr
+
+	# make systemd not kill watchfrr after ExecReload completes
+	# 3 goats were sacrificed to restore sanity after coding this
+	watchfrr_pid="`cat \"$watchfrr_pidfile\"`"
+	if [ -f "/proc/$watchfrr_pid/cgroup" -a -d "/sys/fs/cgroup/systemd" ]; then
+		cg="`egrep '^[0-9]+:name=systemd:' \"/proc/$watchfrr_pid/cgroup\"`"
+		cg="${cg#*:*:}"
+
+		cgmain="$cg"
+		cgmain="${cgmain%/.control}"
+		cgmain="${cgmain%/control}"
+
+		[ -n "$cg" -a "$cg" != "$cgmain" ] && \
+			echo "$watchfrr_pid" > "/sys/fs/cgroup/systemd/$cgmain/tasks"
+	fi
 
 	NEW_CONFIG_FILE="${2:-$C_PATH/frr.conf}"
 	[ ! -r $NEW_CONFIG_FILE ] && log_failure_msg "Unable to read new configuration file $NEW_CONFIG_FILE" && exit 1


### PR DESCRIPTION
Without this, we end up restarting watchfrr with the systemd watchdog
non-functional & tripped a bit later.  Also, if watchfrr is in the
"control" cgroup, systemd 232 will kill it.  (241 apparently doesn't.
Can't find anything about this in systemd's ChangeLog though.)

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>
(cherry picked from commit 9c251d376ad8e604c25767b32c2816e9ae75a738)