### PR TITLE
bgpd: Fix memleak of Mac Hash String upon insertion

### DIFF
--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -282,8 +282,10 @@ void bgp_mac_add_mac_entry(struct interface *ifp)
 		 * If old mac address is the same as the new,
 		 * then there is nothing to do here
 		 */
-		if (old_bsm == bsm)
+		if (old_bsm == bsm) {
+			XFREE(MTYPE_BSM_STRING, ifname);
 			return;
+		}
 
 		if (old_bsm)
 			bgp_mac_remove_ifp_internal(old_bsm, ifp->name);


### PR DESCRIPTION
If we get a callback for a interface change but we do not
actually have to move the mac entry in the hash then
we were accidently leaking the Mac Hash String all over
ourselves.  Messy Messy!

Ticket: CM-25351
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>