### PR TITLE
bgpd: print ecom in evpn route output

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2480,6 +2480,8 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 					bgp_evpn_show_route_header(vty, bgp,
 								   tbl_ver,
 								   json);
+					vty_out(vty, "%19s Extended Community\n"
+							, " ");
 					header = 0;
 				}
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6965,6 +6965,7 @@ void route_vty_out(struct vty *vty, struct prefix *p,
 	json_object *json_nexthops = NULL;
 	json_object *json_nexthop_global = NULL;
 	json_object *json_nexthop_ll = NULL;
+	json_object *json_ext_community = NULL;
 	char vrf_id_str[VRF_NAMSIZ] = {0};
 	bool nexthop_self =
 		CHECK_FLAG(path->flags, BGP_PATH_ANNC_NH_SELF) ? true : false;
@@ -7330,6 +7331,17 @@ void route_vty_out(struct vty *vty, struct prefix *p,
 		vty_out(vty, "%s", bgp_origin_str[attr->origin]);
 
 	if (json_paths) {
+		if (safi == SAFI_EVPN &&
+		    attr->flag & ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES)) {
+			json_ext_community = json_object_new_object();
+			json_object_string_add(json_ext_community,
+					       "string",
+					       attr->ecommunity->str);
+			json_object_object_add(json_path,
+					       "extendedCommunity",
+					       json_ext_community);
+		}
+
 		if (nexthop_self)
 			json_object_boolean_true_add(json_path,
 				"announceNexthopSelf");
@@ -7363,6 +7375,13 @@ void route_vty_out(struct vty *vty, struct prefix *p,
 		json_object_array_add(json_paths, json_path);
 	} else {
 		vty_out(vty, "\n");
+
+		if (safi == SAFI_EVPN &&
+		    attr->flag & ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES)) {
+			vty_out(vty, "%*s", 20, " ");
+			vty_out(vty, "%s\n", attr->ecommunity->str);
+		}
+
 #if ENABLE_BGP_VNC
 		/* prints an additional line, indented, with VNC info, if
 		 * present */


### PR DESCRIPTION
EVPN route's extended community include
important information like Mobility sequence,
router mac, and RT values, include the ecomm
in evpn brief output.

Testing Done:

Validated in evpn deployment with routes.
```
TOR#show bgp l2vpn evpn route
BGP table version is 4, local router ID is 27.0.0.11
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
                    Extended Community
Route Distinguisher: 27.0.0.11:3
*> [2]:[0]:[0]:[48]:[00:02:00:00:00:04]:[128]:[fe80::202:ff:fe00:4]
                    36.0.0.11                              0 4435 5546 i
                    RT:5546:1008 ET:8 ND:Router Flag
*  [2]:[0]:[0]:[48]:[00:02:00:00:00:36]
                    36.0.0.11                              0 4435 5546 i
                    RT:5546:1008 RT:5546:4003 ET:8 MM:0, sticky MAC Rmac:44:38:39:ff:ff:01
*> [2]:[0]:[0]:[48]:[00:02:00:00:00:36]
                    36.0.0.11                              0 4435 5546 i
                    RT:5546:1008 RT:5546:4003 ET:8 MM:0, sticky MAC Rmac:44:38:39:ff:ff:01
*  [3]:[0]:[32]:[36.0.0.11]
                    36.0.0.11                              0 4435 5546 i
                    RT:5546:1008 ET:8
*> [3]:[0]:[32]:[36.0.0.11]
                    36.0.0.11                              0 4435 5546 i
                    RT:5546:1008 ET:8
```
Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>