### PR TITLE
zebra: When displaying `show evpn mac vni XX` add local and remote seq

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1386,7 +1386,9 @@ static void zvni_print_mac_hash(struct hash_bucket *bucket, void *ctxt)
 				vty_out(vty, " %-5u", vid);
 			else
 				json_object_int_add(json_mac, "vlan", vid);
-		}
+		} else /* No vid? fill out the space */
+			vty_out(vty, " %-5s", "");
+		vty_out(vty, " %u/%u", mac->loc_seq, mac->rem_seq);
 		if (json_mac_hdr == NULL) {
 			vty_out(vty, "\n");
 		} else {
@@ -1418,11 +1420,13 @@ static void zvni_print_mac_hash(struct hash_bucket *bucket, void *ctxt)
 			if ((wctx->flags & SHOW_REMOTE_MAC_FROM_VTEP) &&
 			    (wctx->count == 0)) {
 				vty_out(vty, "\nVNI %u\n\n", wctx->zvni->vni);
-				vty_out(vty, "%-17s %-6s %-21s %-5s\n", "MAC",
-					"Type", "Intf/Remote VTEP", "VLAN");
+				vty_out(vty, "%-17s %-6s %-21s %-5s %s\n",
+					"MAC", "Type", "Intf/Remote VTEP",
+					"VLAN", "Seq #'s");
 			}
-			vty_out(vty, "%-17s %-6s %-21s\n", buf1, "remote",
-				inet_ntoa(mac->fwd_info.r_vtep_ip));
+			vty_out(vty, "%-17s %-6s %-21s %-5s %u/%u\n", buf1,
+				"remote", inet_ntoa(mac->fwd_info.r_vtep_ip),
+				"", mac->loc_seq, mac->rem_seq);
 		} else {
 			json_object_string_add(json_mac, "type", "remote");
 			json_object_string_add(json_mac, "remoteVtep",
@@ -1536,8 +1540,8 @@ static void zvni_print_mac_hash_all_vni(struct hash_bucket *bucket, void *ctxt)
 		if (json == NULL) {
 			vty_out(vty, "\nVNI %u #MACs (local and remote) %u\n\n",
 				zvni->vni, num_macs);
-			vty_out(vty, "%-17s %-6s %-21s %-5s\n", "MAC", "Type",
-				"Intf/Remote VTEP", "VLAN");
+			vty_out(vty, "%-17s %-6s %-21s %-5s %s\n", "MAC",
+				"Type", "Intf/Remote VTEP", "VLAN", "Seq #'s");
 		} else
 			json_object_int_add(json_vni, "numMacs", num_macs);
 	}


### PR DESCRIPTION
Add the local and remote sequence number to the `show evpn mac vni XX`
command.

VNI 1000213 #MACs (local and remote) 2

MAC               Type   Intf/Remote VTEP      VLAN  Seq #'s
00:02:00:00:00:21 local  swp5                  213   0/0
00:02:00:00:00:43 local  vlan213               213   0/0

VNI 1000214 #MACs (local and remote) 2

MAC               Type   Intf/Remote VTEP      VLAN  Seq #'s
00:02:00:00:00:22 local  swp6                  214   0/0
00:02:00:00:00:43 local  vlan214               214   0/0

VNI 1000112 #MACs (local and remote) 5

MAC               Type   Intf/Remote VTEP      VLAN  Seq #'s
00:02:00:00:00:1b remote 6.0.0.2                     0/0
00:02:00:00:00:24 remote 6.0.0.31                    0/0
00:02:00:00:00:17 remote 6.0.0.1                     0/0
00:02:00:00:00:20 local  swp4                  112   0/0
00:02:00:00:00:43 local  vlan112               112   0/0

VNI 1000111 #MACs (local and remote) 5

MAC               Type   Intf/Remote VTEP      VLAN  Seq #'s
00:02:00:00:00:1f local  swp3                  111   0/0
00:02:00:00:00:23 remote 6.0.0.31                    0/0
00:02:00:00:00:16 remote 6.0.0.1                     0/0
00:02:00:00:00:1a remote 6.0.0.2                     0/0
00:02:00:00:00:43 local  vlan111               111   0/0

Ticket: CM-25120
Signed-off-by: Nitin Soni <nsoni@cumulusnetworks.com>
Reviewed-by: CCR-8836
Testing-Done: