### PR TITLE
zebra: Increase debugs to understand why we rejected a kernel route

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -128,8 +128,18 @@ static const struct message family_str[] = {{AF_INET, "ipv4"},
 					    {RTNL_FAMILY_IP6MR, "ipv6MR"},
 					    {0}};
 
-static const struct message rttype_str[] = {{RTN_UNICAST, "unicast"},
+static const struct message rttype_str[] = {{RTN_UNSPEC, "none"},
+					    {RTN_UNICAST, "unicast"},
+					    {RTN_LOCAL, "local"},
+					    {RTN_BROADCAST, "broadcast"},
+					    {RTN_ANYCAST, "anycast"},
 					    {RTN_MULTICAST, "multicast"},
+					    {RTN_BLACKHOLE, "blackhole"},
+					    {RTN_UNREACHABLE, "unreachable"},
+					    {RTN_PROHIBIT, "prohibited"},
+					    {RTN_THROW, "throw"},
+					    {RTN_NAT, "nat"},
+					    {RTN_XRESOLVE, "resolver"},
 					    {0}};
 
 extern struct thread_master *master;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -330,6 +330,10 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 		bh_type = BLACKHOLE_ADMINPROHIB;
 		break;
 	default:
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("Route rtm_type: %s(%d) intentionally ignoring",
+				   nl_rttype_to_str(rtm->rtm_type),
+				   rtm->rtm_type);
 		return 0;
 	}
 


### PR DESCRIPTION
Add a bit of extra code to indicate to the operator why
we intentionally rejected a kernel route from being used.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>