### PR TITLE
bgpd: Even though the prefix's are getting filtered after applying ip prefix list, the hit count is showing 0 always in 'show ip prefix-list'.

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -750,6 +750,7 @@ enum prefix_list_type prefix_list_apply_which_prefix(
 	if (pbest == NULL)
 		return PREFIX_DENY;
 
+	pbest->hitcnt++;
 	return pbest->type;
 }
 


### PR DESCRIPTION
Summary

bgpd: BGP Prefix-list hit count not incrementing

When a prefix-list is applied to a BGP neighbor to deny the learning 
of specific routes, the hit count is showing 0 for BGP even though 
the routes are being filtered correctly due to the configured 
prefix-list.
    
Before fix:
    
        c1# show ip prefix-list nag seq 10
        ZEBRA: seq 10 permit any (hit count: 0, refcount: 0)
        BGP: seq 10 permit any (hit count: 0, refcount: 0)
        c1# show ip prefix-list nag seq 5
        ZEBRA: seq 5 deny 1.0.1.0/24 (hit count: 0, refcount: 0)
        BGP: seq 5 deny 1.0.1.0/24 (hit count: 0, refcount: 0)
    
Fix: Increment the prefix-list's hit count whenever rule match occurs.
    
After Fix:

        c1# show ip prefix-list nag seq 10
        ZEBRA: seq 10 permit any (hit count: 0, refcount: 0)
        BGP: seq 10 permit any (hit count: 6, refcount: 0)
        c1# show ip prefix-list nag seq 5
        ZEBRA: seq 5 deny 1.0.1.0/24 (hit count: 0, refcount: 0)
        BGP: seq 5 deny 1.0.1.0/24 (hit count: 1, refcount: 0)
    
   
Signed-off-by: Visakha Erina visakha.erina@broadcom.com

Related Issue


Components
[bgpd]
