### PR TITLE
topotest: configure l3mdev_accept for a range of kernels

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
@@ -149,7 +149,9 @@ def ltemplatePreRouterStartHook():
     krel = platform.release()
     tgen = get_topogen()
     logger.info('pre router-start hook, kernel=' + krel)
-    if topotest.version_cmp(krel, '4.15') == 0:
+
+    if topotest.version_cmp(krel, '4.15') >= 0 and \
+       topotest.version_cmp(krel, '4.18') <= 0:
         l3mdev_accept = 1
     else:
         l3mdev_accept = 0


### PR DESCRIPTION
Improve vrf support in the l3vpn topotest by configuring l3mdev_accept for a range of kernels. The test was only using the config for the 4.15 kernel, so a fresh install of ubuntu 18 with a 4.18 kernel would fail.