### PR TITLE
Misc vrf update name

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1756,6 +1756,51 @@ void bfd_session_update_vrf_name(struct bfd_session *bs, struct vrf *vrf)
 		return;
 	/* update key */
 	hash_release(bfd_key_hash, bs);
+	/*
+	 * HACK: Change the BFD VRF in the running configuration directly,
+	 * bypassing the northbound layer. This is necessary to avoid deleting
+	 * the BFD and readding it in the new VRF, which would have
+	 * several implications.
+	 */
+	if (yang_module_find("frr-bfdd") && bs->key.vrfname[0]) {
+		struct lyd_node *bfd_dnode;
+		char xpath[XPATH_MAXLEN], xpath_srcaddr[XPATH_MAXLEN + 32];
+		char addr_buf[INET6_ADDRSTRLEN];
+		int slen;
+
+		/* build xpath */
+		if (bs->key.mhop) {
+			inet_ntop(bs->key.family, &bs->key.local, addr_buf, sizeof(addr_buf));
+			snprintf(xpath_srcaddr, sizeof(xpath_srcaddr), "[source-addr='%s']",
+				 addr_buf);
+		} else
+			xpath_srcaddr[0] = 0;
+		inet_ntop(bs->key.family, &bs->key.peer, addr_buf, sizeof(addr_buf));
+		slen = snprintf(xpath, sizeof(xpath),
+				"/frr-bfdd:bfdd/bfd/sessions/%s%s[dest-addr='%s']",
+				bs->key.mhop ? "multi-hop" : "single-hop", xpath_srcaddr,
+				addr_buf);
+		if (bs->key.ifname[0])
+			slen += snprintf(xpath + slen, sizeof(xpath) - slen,
+					 "[interface='%s']", bs->key.ifname);
+		else
+			slen += snprintf(xpath + slen, sizeof(xpath) - slen,
+					 "[interface='']");
+		snprintf(xpath + slen, sizeof(xpath) - slen, "[vrf='%s']/vrf",
+			 bs->key.vrfname);
+
+		pthread_rwlock_wrlock(&running_config->lock);
+		{
+			bfd_dnode = yang_dnode_get(
+						   running_config->dnode,
+						   xpath, bs->key.vrfname);
+			if (bfd_dnode) {
+				yang_dnode_change_leaf(bfd_dnode, vrf->name);
+				running_config->version++;
+			}
+			pthread_rwlock_unlock(&running_config->lock);
+		}
+	}
 	memset(bs->key.vrfname, 0, sizeof(bs->key.vrfname));
 	strlcpy(bs->key.vrfname, vrf->name, sizeof(bs->key.vrfname));
 	hash_get(bfd_key_hash, bs, hash_alloc_intern);

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1630,6 +1630,16 @@ static int bfd_vrf_delete(struct vrf *vrf)
 	return 0;
 }
 
+static int bfd_vrf_update(struct vrf *vrf)
+{
+	if (!vrf_is_enabled(vrf))
+		return 0;
+	log_debug("VRF update: %s(%u)", vrf->name, vrf->vrf_id);
+	/* a different name is given; update bfd list */
+	bfdd_sessions_enable_vrf(vrf);
+	return 0;
+}
+
 static int bfd_vrf_enable(struct vrf *vrf)
 {
 	struct bfd_vrf_global *bvrf;
@@ -1715,7 +1725,7 @@ static int bfd_vrf_disable(struct vrf *vrf)
 void bfd_vrf_init(void)
 {
 	vrf_init(bfd_vrf_new, bfd_vrf_enable, bfd_vrf_disable,
-		 bfd_vrf_delete, NULL);
+		 bfd_vrf_delete, bfd_vrf_update);
 }
 
 void bfd_vrf_terminate(void)

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1749,3 +1749,14 @@ struct bfd_vrf_global *bfd_vrf_look_by_session(struct bfd_session *bfd)
 		return NULL;
 	return bfd->vrf->info;
 }
+
+void bfd_session_update_vrf_name(struct bfd_session *bs, struct vrf *vrf)
+{
+	if (!vrf || !bs)
+		return;
+	/* update key */
+	hash_release(bfd_key_hash, bs);
+	memset(bs->key.vrfname, 0, sizeof(bs->key.vrfname));
+	strlcpy(bs->key.vrfname, vrf->name, sizeof(bs->key.vrfname));
+	hash_get(bfd_key_hash, bs, hash_alloc_intern);
+}

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -391,10 +391,8 @@ struct bfd_session *ptm_bfd_sess_find(struct bfd_pkt *cp,
 
 	/* Search for session without using discriminator. */
 	ifp = if_lookup_by_index(ifindex, vrfid);
-	if (vrfid != VRF_DEFAULT)
-		vrf = vrf_lookup_by_id(vrfid);
-	else
-		vrf = NULL;
+
+	vrf = vrf_lookup_by_id(vrfid);
 
 	gen_bfd_key(&key, peer, local, is_mhop, ifp ? ifp->name : NULL,
 		    vrf ? vrf->name : VRF_DEFAULT_NAME);

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -630,6 +630,7 @@ void bfdd_zclient_unregister(vrf_id_t vrf_id);
 void bfdd_zclient_register(vrf_id_t vrf_id);
 void bfdd_sessions_enable_vrf(struct vrf *vrf);
 void bfdd_sessions_disable_vrf(struct vrf *vrf);
+void bfd_session_update_vrf_name(struct bfd_session *bs, struct vrf *vrf);
 
 int ptm_bfd_notify(struct bfd_session *bs);
 

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -685,6 +685,9 @@ static int bfd_configure_peer(struct bfd_peer_cfg *bpc, bool mhop,
 			snprintf(ebuf, ebuflen, "vrf name too long");
 			return -1;
 		}
+	} else {
+		bpc->bpc_has_vrfname = true;
+		strlcpy(bpc->bpc_vrfname, VRF_DEFAULT_NAME, sizeof(bpc->bpc_vrfname));
 	}
 
 	return 0;

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -630,6 +630,11 @@ void bfdd_sessions_enable_vrf(struct vrf *vrf)
 	/* it may affect configs without interfaces */
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
 		bs = bso->bso_bs;
+		/* update name */
+		if (bs->vrf && bs->vrf == vrf) {
+			if (!strmatch(bs->key.vrfname, vrf->name))
+				bfd_session_update_vrf_name(bs, vrf);
+		}
 		if (bs->vrf)
 			continue;
 		if (bs->key.vrfname[0] &&

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -376,6 +376,9 @@ static int _ptm_msg_read(struct stream *msg, int command, vrf_id_t vrf_id,
 			log_error("ptm-read: vrf id %u could not be identified", vrf_id);
 			return -1;
 		}
+	} else {
+		bpc->bpc_has_vrfname = true;
+		strlcpy(bpc->bpc_vrfname, VRF_DEFAULT_NAME, sizeof(bpc->bpc_vrfname));
 	}
 
 	STREAM_GETC(msg, bpc->bpc_cbit);

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -216,16 +216,6 @@ int main(int argc, char **argv)
 	/* OSPF errors init */
 	ospf_error_init();
 
-	/* Need to initialize the default ospf structure, so the interface mode
-	   commands can be duly processed if they are received before 'router
-	   ospf',
-	   when quagga(ospfd) is restarted */
-	if (!ospf_get_instance(instance)) {
-		flog_err(EC_OSPF_INIT_FAIL, "OSPF instance init failed: %s",
-			 strerror(errno));
-		exit(1);
-	}
-
 	frr_config_fork();
 	frr_run(master);
 

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -2158,7 +2158,7 @@ static int ospf_vrf_disable(struct vrf *vrf)
 void ospf_vrf_init(void)
 {
 	vrf_init(ospf_vrf_new, ospf_vrf_enable, ospf_vrf_disable,
-		 ospf_vrf_delete, NULL);
+		 ospf_vrf_delete, ospf_vrf_enable);
 }
 
 void ospf_vrf_terminate(void)

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3682,7 +3682,7 @@ static int rip_vrf_disable(struct vrf *vrf)
 void rip_vrf_init(void)
 {
 	vrf_init(rip_vrf_new, rip_vrf_enable, rip_vrf_disable, rip_vrf_delete,
-		 NULL);
+		 rip_vrf_enable);
 }
 
 void rip_vrf_terminate(void)

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3641,6 +3641,41 @@ static int rip_vrf_enable(struct vrf *vrf)
 	int socket;
 
 	rip = rip_lookup_by_vrf_name(vrf->name);
+	if (!rip) {
+		char *old_vrf_name = NULL;
+
+		rip = (struct rip *)vrf->info;
+		if (!rip)
+			return 0;
+		/* update vrf name */
+		if (rip->vrf_name)
+			old_vrf_name = rip->vrf_name;
+		rip->vrf_name = XSTRDUP(MTYPE_RIP_VRF_NAME, vrf->name);
+		/*
+		 * HACK: Change the RIP VRF in the running configuration directly,
+		 * bypassing the northbound layer. This is necessary to avoid deleting
+		 * the RIP and readding it in the new VRF, which would have
+		 * several implications.
+		 */
+		if (yang_module_find("frr-ripd") && old_vrf_name) {
+			struct lyd_node *rip_dnode;
+
+			pthread_rwlock_wrlock(&running_config->lock);
+			{
+				rip_dnode = yang_dnode_get(
+						   running_config->dnode,
+						   "/frr-ripd:ripd/instance[vrf='%s']/vrf",
+						   old_vrf_name);
+				if (rip_dnode) {
+					yang_dnode_change_leaf(rip_dnode, vrf->name);
+					running_config->version++;
+				}
+			}
+			pthread_rwlock_unlock(&running_config->lock);
+		}
+		if (old_vrf_name)
+			XFREE(MTYPE_RIP_VRF_NAME, old_vrf_name);
+	}
 	if (!rip || rip->enabled)
 		return 0;
 

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2777,7 +2777,43 @@ static int ripng_vrf_enable(struct vrf *vrf)
 	int socket;
 
 	ripng = ripng_lookup_by_vrf_name(vrf->name);
-	if (!ripng || ripng->enabled)
+	if (!ripng) {
+		char *old_vrf_name = NULL;
+
+		ripng = (struct ripng *)vrf->info;
+		if (!ripng)
+			return 0;
+		/* update vrf name */
+		if (ripng->vrf_name)
+			old_vrf_name = ripng->vrf_name;
+		ripng->vrf_name = XSTRDUP(MTYPE_RIPNG_VRF_NAME, vrf->name);
+		/*
+		 * HACK: Change the RIPng VRF in the running configuration directly,
+		 * bypassing the northbound layer. This is necessary to avoid deleting
+		 * the RIPng and readding it in the new VRF, which would have
+		 * several implications.
+		 */
+		if (yang_module_find("frr-ripngd") && old_vrf_name) {
+			struct lyd_node *ripng_dnode;
+
+			pthread_rwlock_wrlock(&running_config->lock);
+			{
+				ripng_dnode = yang_dnode_get(
+						   running_config->dnode,
+						   "/frr-ripngd:ripngd/instance[vrf='%s']/vrf",
+						   old_vrf_name);
+				if (ripng_dnode) {
+					yang_dnode_change_leaf(ripng_dnode, vrf->name);
+					running_config->version++;
+				}
+			}
+			pthread_rwlock_unlock(&running_config->lock);
+		}
+		if (old_vrf_name)
+			XFREE(MTYPE_RIPNG_VRF_NAME, old_vrf_name);
+	}
+
+	if (ripng->enabled)
 		return 0;
 
 	if (IS_RIPNG_DEBUG_EVENT)
@@ -2785,13 +2821,11 @@ static int ripng_vrf_enable(struct vrf *vrf)
 			   vrf->vrf_id);
 
 	/* Activate the VRF RIPng instance. */
-	if (!ripng->enabled) {
-		socket = ripng_make_socket(vrf);
-		if (socket < 0)
-			return -1;
+	socket = ripng_make_socket(vrf);
+	if (socket < 0)
+		return -1;
 
-		ripng_instance_enable(ripng, vrf, socket);
-	}
+	ripng_instance_enable(ripng, vrf, socket);
 
 	return 0;
 }

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2818,7 +2818,7 @@ static int ripng_vrf_disable(struct vrf *vrf)
 void ripng_vrf_init(void)
 {
 	vrf_init(ripng_vrf_new, ripng_vrf_enable, ripng_vrf_disable,
-		 ripng_vrf_delete, NULL);
+		 ripng_vrf_delete, ripng_vrf_enable);
 }
 
 void ripng_vrf_terminate(void)


### PR DESCRIPTION
This is a series of commits that fix the use case where the zebra daemon is being forced with a default vrf name different than default one, by using '-o' option.
It appears that vrf_update_name hook handler can be useful, but some more work needs to be done in daemons.