### PR TITLE
lib: Add `clear route-map counters [WORD]` command

### DIFF
--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -85,6 +85,23 @@ deny
 cont
    goto next route-map entry
 
+.. _route-map-show-command:
+
+.. index:: show route-map [WORD]
+.. clicmd:: show route-map [WORD]
+
+   Display data about each daemons knowledge of individual route-maps.
+   If WORD is supplied narrow choice to that particular route-map.
+
+.. _route-map-clear-counter-command:
+
+.. index:: clear route-map counter [WORD]
+.. clicmd:: clear route-map counter [WORD]
+
+   Clear counters that are being stored about the route-map utilization
+   so that subsuquent show commands will indicate since the last clear.
+   If WORD is specified clear just that particular route-map's counters.
+
 .. _route-map-command:
 
 Route Map Command
@@ -314,6 +331,7 @@ Route Map Exit Action Command
 .. clicmd:: continue N
 
    Proceed processing the route-map at the first entry whose order is >= N
+
 
 Route Map Examples
 ==================

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -960,12 +960,12 @@ static void vty_show_route_map_entry(struct vty *vty, struct route_map *map)
 	struct route_map_rule *rule;
 
 	vty_out(vty, "route-map: %s Invoked: %" PRIu64 "\n",
-		map->name, map->applied);
+		map->name, map->applied - map->applied_clear);
 
 	for (index = map->head; index; index = index->next) {
 		vty_out(vty, " %s, sequence %d Invoked %" PRIu64 "\n",
 			route_map_type_str(index->type), index->pref,
-			index->applied);
+			index->applied - index->applied_clear);
 
 		/* Description */
 		if (index->description)
@@ -2956,6 +2956,46 @@ DEFUN (no_rmap_continue,
 	return no_rmap_onmatch_goto(self, vty, argc, argv);
 }
 
+static void clear_route_map_helper(struct route_map *map)
+{
+	struct route_map_index *index;
+
+	map->applied_clear = map->applied;
+	for (index = map->head; index; index = index->next)
+		index->applied_clear = index->applied;
+}
+
+DEFUN (rmap_clear_counters,
+       rmap_clear_counters_cmd,
+       "clear route-map counters [WORD]",
+       CLEAR_STR
+       "route-map information\n"
+       "counters associated with the specified route-map\n"
+       "route-map name\n")
+{
+	int idx_word = 2;
+	struct route_map *map;
+
+	const char *name = (argc == 3 ) ? argv[idx_word]->arg : NULL;
+
+	if (name) {
+		map = route_map_lookup_by_name(name);
+
+		if (map)
+			clear_route_map_helper(map);
+		else {
+			vty_out(vty, "%s: 'route-map %s' not found\n",
+				frr_protonameinst, name);
+			return CMD_SUCCESS;
+		}
+	} else {
+		for (map = route_map_master.head; map; map = map->next)
+			clear_route_map_helper(map);
+	}
+
+	return CMD_SUCCESS;
+
+}
 
 DEFUN (rmap_show_name,
        rmap_show_name_cmd,
@@ -3291,6 +3331,8 @@ void route_map_init(void)
 	install_element(RMAP_NODE, &no_rmap_description_cmd);
 
 	/* Install show command */
+	install_element(ENABLE_NODE, &rmap_clear_counters_cmd);
+
 	install_element(ENABLE_NODE, &rmap_show_name_cmd);
 	install_element(ENABLE_NODE, &rmap_show_unused_cmd);
 

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -3133,8 +3133,15 @@ static int route_map_config_write(struct vty *vty)
 	struct route_map_rule *rule;
 	int first = 1;
 	int write = 0;
+	struct listnode *ln;
+	struct list *maplist = list_new();
 
 	for (map = route_map_master.head; map; map = map->next)
+		listnode_add(maplist, map);
+
+	list_sort(maplist, sort_route_map);
+
+	for (ALL_LIST_ELEMENTS_RO(maplist, ln, map))
 		for (index = map->head; index; index = index->next) {
 			if (!first)
 				vty_out(vty, "!\n");
@@ -3167,6 +3174,8 @@ static int route_map_config_write(struct vty *vty)
 
 			write++;
 		}
+
+	list_delete(&maplist);
 	return write;
 }
 

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -153,6 +153,7 @@ struct route_map_index {
 
 	/* Keep track how many times we've try to apply */
 	uint64_t applied;
+	uint64_t applied_clear;
 
 	QOBJ_FIELDS
 };
@@ -177,6 +178,7 @@ struct route_map {
 
 	/* How many times have we applied this route-map */
 	uint64_t applied;
+	uint64_t applied_clear;
 
 	/* Counter to track active usage of this route-map */
 	uint16_t use_count;


### PR DESCRIPTION
This will allow the end-user to clear the counters associated
with the route-map.  Subsuquent `show route-map ..` commands
will display counters since the last clear.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>