### PR TITLE
pimd: Fixing encoded group & source address packing in right byte order

### DIFF
--- a/pimd/pim_msg.h
+++ b/pimd/pim_msg.h
@@ -66,9 +66,19 @@ struct pim_encoded_ipv4_unicast {
 	struct in_addr addr;
 } __attribute__((packed));
 
+/*
+ *  Encoded Group format. RFC 4601 Sec 4.9.1
+ *   0                   1                   2                   3
+ *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  |  Addr Family  | Encoding Type |B| Reserved  |Z|  Mask Len     |
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  |                Group multicast Address
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+...
+ */
 struct pim_encoded_group_ipv4 {
-	uint8_t ne;
 	uint8_t family;
+	uint8_t ne;
 	uint8_t bidir : 1;	/* Bidir bit */
 	uint8_t reserved : 6;	/* Reserved */
 	uint8_t sz : 1;		/* scope zone bit */
@@ -76,9 +86,20 @@ struct pim_encoded_group_ipv4 {
 	struct in_addr addr;
 } __attribute__((packed));
 
+
+/*
+ *  Encoded Source format. RFC 4601 Sec 4.9.1
+ *   0                   1                   2                   3
+ *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  | Addr Family   | Encoding Type | Rsrvd   |S|W|R|  Mask Len     |
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  |                        Source Address
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-...
+ */
 struct pim_encoded_source_ipv4 {
-	uint8_t ne;
 	uint8_t family;
+	uint8_t ne;
 	uint8_t bits;
 	uint8_t mask;
 	struct in_addr addr;


### PR DESCRIPTION
Position of address family and encoding type is defined wrongly in the packed structure. This will correct the position as per RFC 4601 4.9.1

Signed-off-by: Saravanan K <saravanank@vmware.com>