### PR TITLE
bgpd: Do not display to end user not found afi/safi's

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -624,17 +624,11 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 			if (ret < 0)
 				bgp_clear_vty_error(vty, peer, afi, safi, ret);
-			else
-				found = true;
 		}
 
 		/* This is to apply read-only mode on this clear. */
 		if (stype == BGP_CLEAR_SOFT_NONE)
 			bgp->update_delay_over = 0;
-
-		if (!found)
-			vty_out(vty, "%%BGP: No %s peer configured\n",
-				afi_safi_print(afi, safi));
 
 		return CMD_SUCCESS;
 	}


### PR DESCRIPTION
When we are issuing a new command:

router bgp
   bgp default local-preference ..
   -or-
   bgp cluster-id ...
   -or-
   bgp disable-ebgp-connected-route-check

Do not tell them that afi/safi's are not configured.  There is nothing
to do with this information and it will create confusion in the
end user that we are looking for afi/safi's that are never going to
be configed.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>