### PR TITLE
pimd: Remove output of `debug igmp trace detail` from show commands

### DIFF
--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -70,10 +70,6 @@ int pim_debug_config_write(struct vty *vty)
 		vty_out(vty, "debug igmp trace\n");
 		++writes;
 	}
-	if (PIM_DEBUG_IGMP_TRACE_DETAIL) {
-		vty_out(vty, "debug igmp trace detail\n");
-		++writes;
-	}
 
 	if (PIM_DEBUG_MROUTE) {
 		vty_out(vty, "debug mroute\n");


### PR DESCRIPTION
There has never been a `debug igmp trace detail` but we have
had code to display this when we had the appropriate flags
set.  Since we never can accept this, let's remove this.

This showed up because of commit:0ab16492d2d9fcc6cba7e001227deed6765ed261

where we re-arranged some debugs to combine them being turned on.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>