### PR TITLE
vrrpd: Allow vrrp to gracefully ignore access list commands

### DIFF
--- a/vrrpd/vrrp_main.c
+++ b/vrrpd/vrrp_main.c
@@ -144,6 +144,7 @@ int main(int argc, char **argv, char **envp)
 
 	master = frr_init();
 
+	access_list_init();
 	vrrp_debug_init();
 	vrrp_zebra_init();
 	vrrp_vty_init();


### PR DESCRIPTION
VRRPD was not gracefully ignoring any access-list commands.
Modify the code so that it does.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>