### PR TITLE
bgpd: 'show bgp ipv6 neighbors <X::Y> prefix-counts' prefix-count is not getting displayed

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10992,7 +10992,7 @@ DEFUN (show_ip_bgp_instance_neighbor_prefix_counts,
 	if (!peer)
 		return CMD_WARNING;
 
-	return bgp_peer_counts(vty, peer, AFI_IP, SAFI_UNICAST, uj);
+	return bgp_peer_counts(vty, peer, afi, safi, uj);
 }
 
 #ifdef KEEP_OLD_VPN_COMMANDS


### PR DESCRIPTION
Neighbour prefix-count is not getting displayed with IPV6 neighbours
and displays the o/p “ % No such neighbor or address family ”.
However, I observed it is working fine for IPV4 neighbour.

Signed-off-by: Biswajit Sadhu <sadhub@vmware.com>