### PR TITLE
bgpd: When a peer group is created on a already configured ebgp neighbor, ebgp-multihop command is removed automatically.

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2431,8 +2431,13 @@ static void peer_group2peer_config_copy(struct peer_group *group,
 	if (!CHECK_FLAG(peer->flags_override, PEER_FLAG_LOCAL_AS))
 		peer->change_local_as = conf->change_local_as;
 
-	/* TTL */
-	peer->ttl = conf->ttl;
+	/* TTL ... Retain the Peer's TTL if it is not configured in the peer group.  It'll be over-ridden later. */
+	if ((conf->ttl == BGP_DEFAULT_TTL) && (peer->ttl != BGP_DEFAULT_TTL)) {
+		/* Do Nothing */
+ 	}
+	else {
+ 		peer->ttl = conf->ttl;
+	}
 
 	/* GTSM hops */
 	peer->gtsm_hops = conf->gtsm_hops;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -47,6 +47,9 @@
 /* Default interval for IPv6 RAs when triggered by BGP unnumbered neighbor. */
 #define BGP_UNNUM_DEFAULT_RA_INTERVAL 10
 
+/* Default interval for eBGP multihop TTL. */
+#define BGP_DEFAULT_TTL 1
+
 struct update_subgroup;
 struct bpacket;
 struct bgp_pbr_config;


### PR DESCRIPTION
Summary

bgpd: ebgp multihop TTL is getting over-written

When a peer group is created on a already configured ebgp neighbor,
ebgp-multihop command is removed automatically.

Before fix:

Create a e-BGP sessions over a loopback interface, enable ebgp
multi-hop. Now create a peer group on the same neighbor. Observed
that ebgp multi-hop config command is being deleted automatically.

sonic(config-router)# do sh running-config
...
router bgp 11
bgp router-id 11.11.11.11
neighbor 3.3.3.3 remote-as 12
neighbor 3.3.3.3 ebgp-multihop 255 << initially configured TTL 255
...
sonic(config-router)#neighbor 3.3.3.3 peer-group A8 <<<added peer group
sonic(config-router)# do sh running-config
...
router bgp 11
bgp router-id 11.11.11.11
neighbor A8 peer-group
neighbor 3.3.3.3 remote-as 12 <<<ebgp multi-hop cmd removed from config
neighbor 3.3.3.3 peer-group A8

Root-Cause: ebgp multihop TTL is getting over-written when an
existing peer is added to a peer group template.
Fix: Retain the Peer's TTL if it is not configured in the peer
group. It'll be over-ridden later.

After Fix:

sonic(config-router)# do sh running-config
...
router bgp 11
bgp router-id 11.11.11.11
neighbor 3.3.3.3 remote-as 12
neighbor 3.3.3.3 ebgp-multihop 255 << initially configured TTL 255
...
sonic(config-router)#neighbor 3.3.3.3 peer-group A8 <<<added peer group
sonic(config-router)# do sh running-config
...
router bgp 11
bgp router-id 11.11.11.11
neighbor A8 peer-group
neighbor 3.3.3.3 remote-as 12
neighbor 3.3.3.3 peer-group A8
neighbor 3.3.3.3 ebgp-multihop 255 << initially configured TTL command

Components
[bgpd]

Signed-off-by: Visakha Erina <visakha.erina@broadcom.com>