### PR TITLE
mutex syntactic sugar

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -29,7 +29,7 @@ ForEachMacros:
   - frr_each_safe
   - frr_each_from
   - frr_with_mutex
-  - frr_elevate_privs
+  - frr_with_privs
   - LIST_FOREACH
   - LIST_FOREACH_SAFE
   - SLIST_FOREACH

--- a/.clang-format
+++ b/.clang-format
@@ -28,6 +28,8 @@ ForEachMacros:
   - frr_each
   - frr_each_safe
   - frr_each_from
+  - frr_with_mutex
+  - frr_elevate_privs
   - LIST_FOREACH
   - LIST_FOREACH_SAFE
   - SLIST_FOREACH

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -894,7 +894,7 @@ int bp_udp_shop(vrf_id_t vrf_id)
 {
 	int sd;
 
-	frr_elevate_privs(&bglobal.bfdd_privs) {
+	frr_with_privs(&bglobal.bfdd_privs) {
 		sd = vrf_socket(AF_INET, SOCK_DGRAM, PF_UNSPEC, vrf_id, NULL);
 	}
 	if (sd == -1)
@@ -909,7 +909,7 @@ int bp_udp_mhop(vrf_id_t vrf_id)
 {
 	int sd;
 
-	frr_elevate_privs(&bglobal.bfdd_privs) {
+	frr_with_privs(&bglobal.bfdd_privs) {
 		sd = vrf_socket(AF_INET, SOCK_DGRAM, PF_UNSPEC, vrf_id, NULL);
 	}
 	if (sd == -1)
@@ -934,7 +934,7 @@ int bp_peer_socket(const struct bfd_session *bs)
 	    && bs->key.vrfname[0])
 		device_to_bind = (const char *)bs->key.vrfname;
 
-	frr_elevate_privs(&bglobal.bfdd_privs) {
+	frr_with_privs(&bglobal.bfdd_privs) {
 		sd = vrf_socket(AF_INET, SOCK_DGRAM, PF_UNSPEC,
 				bs->vrf->vrf_id, device_to_bind);
 	}
@@ -1001,7 +1001,7 @@ int bp_peer_socketv6(const struct bfd_session *bs)
 	    && bs->key.vrfname[0])
 		device_to_bind = (const char *)bs->key.vrfname;
 
-	frr_elevate_privs(&bglobal.bfdd_privs) {
+	frr_with_privs(&bglobal.bfdd_privs) {
 		sd = vrf_socket(AF_INET6, SOCK_DGRAM, PF_UNSPEC,
 				bs->vrf->vrf_id, device_to_bind);
 	}
@@ -1121,7 +1121,7 @@ int bp_udp6_shop(vrf_id_t vrf_id)
 {
 	int sd;
 
-	frr_elevate_privs(&bglobal.bfdd_privs) {
+	frr_with_privs(&bglobal.bfdd_privs) {
 		sd = vrf_socket(AF_INET6, SOCK_DGRAM, PF_UNSPEC, vrf_id, NULL);
 	}
 	if (sd == -1)
@@ -1137,7 +1137,7 @@ int bp_udp6_mhop(vrf_id_t vrf_id)
 {
 	int sd;
 
-	frr_elevate_privs(&bglobal.bfdd_privs) {
+	frr_with_privs(&bglobal.bfdd_privs) {
 		sd = vrf_socket(AF_INET6, SOCK_DGRAM, PF_UNSPEC, vrf_id, NULL);
 	}
 	if (sd == -1)
@@ -1153,7 +1153,7 @@ int bp_echo_socket(vrf_id_t vrf_id)
 {
 	int s;
 
-	frr_elevate_privs(&bglobal.bfdd_privs) {
+	frr_with_privs(&bglobal.bfdd_privs) {
 		s = vrf_socket(AF_INET, SOCK_DGRAM, 0, vrf_id, NULL);
 	}
 	if (s == -1)
@@ -1169,7 +1169,7 @@ int bp_echov6_socket(vrf_id_t vrf_id)
 {
 	int s;
 
-	frr_elevate_privs(&bglobal.bfdd_privs) {
+	frr_with_privs(&bglobal.bfdd_privs) {
 		s = vrf_socket(AF_INET6, SOCK_DGRAM, 0, vrf_id, NULL);
 	}
 	if (s == -1)

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -132,12 +132,10 @@ static int bgp_process_writes(struct thread *thread)
 
 	struct frr_pthread *fpt = bgp_pth_io;
 
-	pthread_mutex_lock(&peer->io_mtx);
-	{
+	frr_with_mutex(&peer->io_mtx) {
 		status = bgp_write(peer);
 		reschedule = (stream_fifo_head(peer->obuf) != NULL);
 	}
-	pthread_mutex_unlock(&peer->io_mtx);
 
 	/* no problem */
 	if (CHECK_FLAG(status, BGP_IO_TRANS_ERR)) {
@@ -184,11 +182,9 @@ static int bgp_process_reads(struct thread *thread)
 
 	struct frr_pthread *fpt = bgp_pth_io;
 
-	pthread_mutex_lock(&peer->io_mtx);
-	{
+	frr_with_mutex(&peer->io_mtx) {
 		status = bgp_read(peer);
 	}
-	pthread_mutex_unlock(&peer->io_mtx);
 
 	/* error checking phase */
 	if (CHECK_FLAG(status, BGP_IO_TRANS_ERR)) {
@@ -237,11 +233,9 @@ static int bgp_process_reads(struct thread *thread)
 			assert(ringbuf_get(ibw, pktbuf, pktsize) == pktsize);
 			stream_put(pkt, pktbuf, pktsize);
 
-			pthread_mutex_lock(&peer->io_mtx);
-			{
+			frr_with_mutex(&peer->io_mtx) {
 				stream_fifo_push(peer->ibuf, pkt);
 			}
-			pthread_mutex_unlock(&peer->io_mtx);
 
 			added_pkt = true;
 		} else

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -1282,8 +1282,7 @@ static int rfapi_open_inner(struct rfapi_descriptor *rfd, struct bgp *bgp,
 	 * since this peer is not on the I/O thread, this lock is not strictly
 	 * necessary, but serves as a reminder to those who may meddle...
 	 */
-	pthread_mutex_lock(&rfd->peer->io_mtx);
-	{
+	frr_with_mutex(&rfd->peer->io_mtx) {
 		// we don't need any I/O related facilities
 		if (rfd->peer->ibuf)
 			stream_fifo_free(rfd->peer->ibuf);
@@ -1300,7 +1299,6 @@ static int rfapi_open_inner(struct rfapi_descriptor *rfd, struct bgp *bgp,
 		rfd->peer->obuf_work = NULL;
 		rfd->peer->ibuf_work = NULL;
 	}
-	pthread_mutex_unlock(&rfd->peer->io_mtx);
 
 	{ /* base code assumes have valid host pointer */
 		char buf[BUFSIZ];

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -191,8 +191,7 @@ static void vnc_redistribute_add(struct prefix *p, uint32_t metric,
 			 * is not strictly necessary, but serves as a reminder
 			 * to those who may meddle...
 			 */
-			pthread_mutex_lock(&vncHD1VR.peer->io_mtx);
-			{
+			frr_with_mutex(&vncHD1VR.peer->io_mtx) {
 				// we don't need any I/O related facilities
 				if (vncHD1VR.peer->ibuf)
 					stream_fifo_free(vncHD1VR.peer->ibuf);
@@ -209,7 +208,6 @@ static void vnc_redistribute_add(struct prefix *p, uint32_t metric,
 				vncHD1VR.peer->obuf_work = NULL;
 				vncHD1VR.peer->ibuf_work = NULL;
 			}
-			pthread_mutex_unlock(&vncHD1VR.peer->io_mtx);
 
 			/* base code assumes have valid host pointer */
 			vncHD1VR.peer->host =

--- a/doc/developer/library.rst
+++ b/doc/developer/library.rst
@@ -11,6 +11,7 @@ Library Facilities (libfrr)
    rcu
    lists
    logging
+   locking
    hooks
    cli
    modules

--- a/doc/developer/locking.rst
+++ b/doc/developer/locking.rst
@@ -1,0 +1,73 @@
+Locking
+=======
+
+FRR ships two small wrappers around ``pthread_mutex_lock()`` /
+``pthread_mutex_unlock``.  Use ``#include "frr_pthread.h"`` to get these
+macros.
+
+.. c:function:: frr_with_mutex(pthread_mutex_t *mutex)
+
+   Begin a C statement block that is executed with the mutex locked.  Any
+   exit from the block (``break``, ``return``, ``goto``, end of block) will
+   cause the mutex to be unlocked::
+
+      int somefunction(int option)
+      {
+          frr_with_mutex(&my_mutex) {
+              /* mutex will be locked */
+
+              if (!option)
+                  /* mutex will be unlocked before return */
+                  return -1;
+
+              if (something(option))
+                  /* mutex will be unlocked before goto */
+                  goto out_err;
+
+              somethingelse();
+
+              /* mutex will be unlocked at end of block */
+          }
+
+          return 0;
+
+      out_err:
+          somecleanup();
+          return -1;
+      }
+
+   This is a macro that internally uses a ``for`` loop.  It is explicitly
+   acceptable to use ``break`` to get out of the block.  Even though a single
+   statement works correctly, FRR coding style requires that this macro always
+   be used with a ``{ ... }`` block.
+
+.. c:function:: frr_mutex_lock_autounlock(pthread_mutex_t *mutex)
+
+   Lock mutex and unlock at the end of the current C statement block::
+
+      int somefunction(int option)
+      {
+          frr_mutex_lock_autounlock(&my_mutex);
+          /* mutex will be locked */
+
+          ...
+          if (error)
+            /* mutex will be unlocked before return */
+            return -1;
+          ...
+
+          /* mutex will be unlocked before return */
+          return 0;
+      }
+
+   This is a macro that internally creates a variable with a destructor.
+   When the variable goes out of scope (i.e. the block ends), the mutex is
+   released.
+
+   .. warning::
+
+      This macro should only used when :c:func:`frr_with_mutex` would
+      result in excessively/weirdly nested code.  This generally is an
+      indicator that the code might be trying to do too many things with
+      the lock held.  Try any possible venues to reduce the amount of
+      code covered by the lock and move to :c:func:`frr_with_mutex`.

--- a/doc/developer/subdir.am
+++ b/doc/developer/subdir.am
@@ -31,6 +31,7 @@ dev_RSTFILES = \
 	doc/developer/index.rst \
 	doc/developer/library.rst \
 	doc/developer/lists.rst \
+	doc/developer/locking.rst \
 	doc/developer/logging.rst \
 	doc/developer/maintainer-release-build.rst \
 	doc/developer/memtypes.rst \

--- a/doc/developer/workflow.rst
+++ b/doc/developer/workflow.rst
@@ -767,6 +767,28 @@ ways that can be unexpected for the original implementor. As such debugs
 ability to turn on/off debugs from the CLI and it is expected that the
 developer will use this convention to allow control of their debugs.
 
+Custom syntax-like block macros
+-------------------------------
+
+FRR uses some macros that behave like the ``for`` or ``if`` C keywords.  These
+macros follow these patterns:
+
+- loop-style macros are named ``frr_each_*`` (and ``frr_each``)
+- single run macros are named ``frr_with_*``
+- to avoid confusion, ``frr_with_*`` macros must always use a ``{ ... }``
+  block even if the block only contains one statement.  The ``frr_each``
+  constructs are assumed to be well-known enough to use normal ``for`` rules.
+- ``break``, ``return`` and ``goto`` all work correctly.  For loop-style
+  macros, ``continue`` works correctly too.
+
+Both the ``each`` and ``with`` keywords are inspired by other (more
+higher-level) programming languages that provide these constructs.
+
+There are also some older iteration macros, e.g. ``ALL_LIST_ELEMENTS`` and
+``FOREACH_AFI_SAFI``.  These macros in some cases do **not** fulfill the above
+pattern (e.g. ``break`` does not work in ``FOREACH_AFI_SAFI`` because it
+expands to 2 nested loops.)
+
 Static Analysis and Sanitizers
 ------------------------------
 Clang/LLVM and GCC come with a variety of tools that can be used to help find

--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -61,7 +61,7 @@ int eigrp_sock_init(struct vrf *vrf)
 	int hincl = 1;
 #endif
 
-	frr_elevate_privs(&eigrpd_privs) {
+	frr_with_privs(&eigrpd_privs) {
 		eigrp_sock = vrf_socket(
 			AF_INET, SOCK_RAW, IPPROTO_EIGRPIGP, vrf->vrf_id,
 			vrf->vrf_id != VRF_DEFAULT ? vrf->name : NULL);

--- a/isisd/isis_bpf.c
+++ b/isisd/isis_bpf.c
@@ -187,7 +187,7 @@ int isis_sock_init(struct isis_circuit *circuit)
 {
 	int retval = ISIS_OK;
 
-	frr_elevate_privs(&isisd_privs) {
+	frr_with_privs(&isisd_privs) {
 
 		retval = open_bpf_dev(circuit);
 

--- a/isisd/isis_dlpi.c
+++ b/isisd/isis_dlpi.c
@@ -467,7 +467,7 @@ int isis_sock_init(struct isis_circuit *circuit)
 {
 	int retval = ISIS_OK;
 
-	frr_elevate_privs(&isisd_privs) {
+	frr_with_privs(&isisd_privs) {
 
 		retval = open_dlpi_dev(circuit);
 

--- a/isisd/isis_pfpacket.c
+++ b/isisd/isis_pfpacket.c
@@ -183,7 +183,7 @@ int isis_sock_init(struct isis_circuit *circuit)
 {
 	int retval = ISIS_OK;
 
-	frr_elevate_privs(&isisd_privs) {
+	frr_with_privs(&isisd_privs) {
 
 		retval = open_packet_socket(circuit);
 

--- a/ldpd/socket.c
+++ b/ldpd/socket.c
@@ -79,7 +79,7 @@ ldp_create_socket(int af, enum socket_type type)
 		sock_set_bindany(fd, 1);
 		break;
 	}
-	frr_elevate_privs(&ldpd_privs) {
+	frr_with_privs(&ldpd_privs) {
 		if (sock_set_reuse(fd, 1) == -1) {
 			close(fd);
 			return (-1);
@@ -254,7 +254,7 @@ int
 sock_set_bindany(int fd, int enable)
 {
 #ifdef HAVE_SO_BINDANY
-	frr_elevate_privs(&ldpd_privs) {
+	frr_with_privs(&ldpd_privs) {
 		if (setsockopt(fd, SOL_SOCKET, SO_BINDANY, &enable,
 			       sizeof(int)) < 0) {
 			log_warn("%s: error setting SO_BINDANY", __func__);
@@ -269,7 +269,7 @@ sock_set_bindany(int fd, int enable)
 	}
 	return (0);
 #elif defined(IP_BINDANY)
-	frr_elevate_privs(&ldpd_privs) {
+	frr_with_privs(&ldpd_privs) {
 		if (setsockopt(fd, IPPROTO_IP, IP_BINDANY, &enable, sizeof(int))
 		    < 0) {
 			log_warn("%s: error setting IP_BINDANY", __func__);
@@ -304,7 +304,7 @@ sock_set_md5sig(int fd, int af, union ldpd_addr *addr, const char *password)
 #if HAVE_DECL_TCP_MD5SIG
 	addr2sa(af, addr, 0, &su);
 
-	frr_elevate_privs(&ldpe_privs) {
+	frr_with_privs(&ldpe_privs) {
 		ret = sockopt_tcp_signature(fd, &su, password);
 		save_errno = errno;
 	}

--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -121,6 +121,49 @@ extern "C" {
 #define macro_inline	static inline __attribute__((unused))
 #define macro_pure	static inline __attribute__((unused, pure))
 
+
+/* variadic macros, use like:
+ * #define V_0()  ...
+ * #define V_1(x) ...
+ * #define V(...) MACRO_VARIANT(V, ##__VA_ARGS__)(__VA_ARGS__)
+ */
+#define _MACRO_VARIANT(A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,A10, N, ...) N
+
+#define _CONCAT2(a, b) a ## b
+#define _CONCAT(a, b) _CONCAT2(a,b)
+
+#define MACRO_VARIANT(NAME, ...) \
+	_CONCAT(NAME, _MACRO_VARIANT(0, ##__VA_ARGS__, \
+			_10, _9, _8, _7, _6, _5, _4, _3, _2, _1, _0))
+
+#define NAMECTR(name) _CONCAT(name, __COUNTER__)
+
+/* per-arg repeat macros, use like:
+ * #define PERARG(n) ...n...
+ * #define FOO(...) MACRO_REPEAT(PERARG, ##__VA_ARGS__)
+ */
+
+#define _MACRO_REPEAT_0(NAME)
+#define _MACRO_REPEAT_1(NAME, A1) \
+	NAME(A1)
+#define _MACRO_REPEAT_2(NAME, A1, A2) \
+	NAME(A1) NAME(A2)
+#define _MACRO_REPEAT_3(NAME, A1, A2, A3) \
+	NAME(A1) NAME(A2) NAME(A3)
+#define _MACRO_REPEAT_4(NAME, A1, A2, A3, A4) \
+	NAME(A1) NAME(A2) NAME(A3) NAME(A4)
+#define _MACRO_REPEAT_5(NAME, A1, A2, A3, A4, A5) \
+	NAME(A1) NAME(A2) NAME(A3) NAME(A4) NAME(A5)
+#define _MACRO_REPEAT_6(NAME, A1, A2, A3, A4, A5, A6) \
+	NAME(A1) NAME(A2) NAME(A3) NAME(A4) NAME(A5) NAME(A6)
+#define _MACRO_REPEAT_7(NAME, A1, A2, A3, A4, A5, A6, A7) \
+	NAME(A1) NAME(A2) NAME(A3) NAME(A4) NAME(A5) NAME(A6) NAME(A7)
+#define _MACRO_REPEAT_8(NAME, A1, A2, A3, A4, A5, A6, A7, A8) \
+	NAME(A1) NAME(A2) NAME(A3) NAME(A4) NAME(A5) NAME(A6) NAME(A7) NAME(A8)
+
+#define MACRO_REPEAT(NAME, ...) \
+	MACRO_VARIANT(_MACRO_REPEAT, ##__VA_ARGS__)(NAME, ##__VA_ARGS__)
+
 /*
  * for warnings on macros, put in the macro content like this:
  *   #define MACRO BLA CPP_WARN("MACRO has been deprecated")

--- a/lib/frr_pthread.h
+++ b/lib/frr_pthread.h
@@ -215,6 +215,54 @@ void frr_pthread_stop_all(void);
 #define pthread_condattr_setclock(A, B)
 #endif
 
+/* mutex auto-lock/unlock */
+
+/* variant 1:
+ * (for short blocks, multiple mutexes supported)
+ * break & return can be used for aborting the block
+ *
+ * frr_with_mutex(&mtx, &mtx2) {
+ *    if (error)
+ *       break;
+ *    ...
+ * }
+ */
+#define _frr_with_mutex(mutex)                                                 \
+	*NAMECTR(_mtx_) __attribute__((                                        \
+		unused, cleanup(_frr_mtx_unlock))) = _frr_mtx_lock(mutex),     \
+	/* end */
+
+#define frr_with_mutex(...)                                                    \
+	for (pthread_mutex_t MACRO_REPEAT(_frr_with_mutex, ##__VA_ARGS__)      \
+	     *_once = NULL; _once == NULL; _once = (void *)1)                  \
+	/* end */
+
+/* variant 2:
+ * (more suitable for long blocks, no extra indentation)
+ *
+ * frr_mutex_lock_autounlock(&mtx);
+ * ...
+ */
+#define frr_mutex_lock_autounlock(mutex)                                       \
+	pthread_mutex_t *NAMECTR(_mtx_)                                        \
+		__attribute__((unused, cleanup(_frr_mtx_unlock))) =            \
+				    _frr_mtx_lock(mutex)                       \
+	/* end */
+
+static inline pthread_mutex_t *_frr_mtx_lock(pthread_mutex_t *mutex)
+{
+	pthread_mutex_lock(mutex);
+	return mutex;
+}
+
+static inline void _frr_mtx_unlock(pthread_mutex_t **mutex)
+{
+	if (!*mutex)
+		return;
+	pthread_mutex_unlock(*mutex);
+	*mutex = NULL;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -28,6 +28,7 @@
 #include "vty.h"
 #include "command.h"
 #include "libfrr.h"
+#include "frr_pthread.h"
 
 DEFINE_MTYPE_STATIC(LIB, HASH, "Hash")
 DEFINE_MTYPE_STATIC(LIB, HASH_BACKET, "Hash Bucket")
@@ -54,14 +55,12 @@ struct hash *hash_create_size(unsigned int size,
 	hash->name = name ? XSTRDUP(MTYPE_HASH, name) : NULL;
 	hash->stats.empty = hash->size;
 
-	pthread_mutex_lock(&_hashes_mtx);
-	{
+	frr_with_mutex(&_hashes_mtx) {
 		if (!_hashes)
 			_hashes = list_new();
 
 		listnode_add(_hashes, hash);
 	}
-	pthread_mutex_unlock(&_hashes_mtx);
 
 	return hash;
 }
@@ -311,8 +310,7 @@ struct list *hash_to_list(struct hash *hash)
 
 void hash_free(struct hash *hash)
 {
-	pthread_mutex_lock(&_hashes_mtx);
-	{
+	frr_with_mutex(&_hashes_mtx) {
 		if (_hashes) {
 			listnode_delete(_hashes, hash);
 			if (_hashes->count == 0) {
@@ -320,7 +318,6 @@ void hash_free(struct hash *hash)
 			}
 		}
 	}
-	pthread_mutex_unlock(&_hashes_mtx);
 
 	XFREE(MTYPE_HASH, hash->name);
 

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -26,6 +26,7 @@
 #include "command.h"
 #include "debug.h"
 #include "db.h"
+#include "frr_pthread.h"
 #include "northbound.h"
 #include "northbound_cli.h"
 #include "northbound_db.h"
@@ -723,8 +724,7 @@ int nb_running_lock(enum nb_client client, const void *user)
 {
 	int ret = -1;
 
-	pthread_mutex_lock(&running_config_mgmt_lock.mtx);
-	{
+	frr_with_mutex(&running_config_mgmt_lock.mtx) {
 		if (!running_config_mgmt_lock.locked) {
 			running_config_mgmt_lock.locked = true;
 			running_config_mgmt_lock.owner_client = client;
@@ -732,7 +732,6 @@ int nb_running_lock(enum nb_client client, const void *user)
 			ret = 0;
 		}
 	}
-	pthread_mutex_unlock(&running_config_mgmt_lock.mtx);
 
 	return ret;
 }
@@ -741,8 +740,7 @@ int nb_running_unlock(enum nb_client client, const void *user)
 {
 	int ret = -1;
 
-	pthread_mutex_lock(&running_config_mgmt_lock.mtx);
-	{
+	frr_with_mutex(&running_config_mgmt_lock.mtx) {
 		if (running_config_mgmt_lock.locked
 		    && running_config_mgmt_lock.owner_client == client
 		    && running_config_mgmt_lock.owner_user == user) {
@@ -752,7 +750,6 @@ int nb_running_unlock(enum nb_client client, const void *user)
 			ret = 0;
 		}
 	}
-	pthread_mutex_unlock(&running_config_mgmt_lock.mtx);
 
 	return ret;
 }
@@ -761,14 +758,12 @@ int nb_running_lock_check(enum nb_client client, const void *user)
 {
 	int ret = -1;
 
-	pthread_mutex_lock(&running_config_mgmt_lock.mtx);
-	{
+	frr_with_mutex(&running_config_mgmt_lock.mtx) {
 		if (!running_config_mgmt_lock.locked
 		    || (running_config_mgmt_lock.owner_client == client
 			&& running_config_mgmt_lock.owner_user == user))
 			ret = 0;
 	}
-	pthread_mutex_unlock(&running_config_mgmt_lock.mtx);
 
 	return ret;
 }

--- a/lib/privs.h
+++ b/lib/privs.h
@@ -109,16 +109,16 @@ extern void zprivs_get_ids(struct zprivs_ids_t *);
 
 /*
  * Wrapper around zprivs, to be used as:
- *   frr_elevate_privs(&privs) {
+ *   frr_with_privs(&privs) {
  *     ... code ...
  *     if (error)
  *       break;         -- break can be used to get out of the block
  *     ... code ...
  *   }
  *
- * The argument to frr_elevate_privs() can be NULL to leave privileges as-is
+ * The argument to frr_with_privs() can be NULL to leave privileges as-is
  * (mostly useful for conditional privilege-raising, i.e.:)
- *   frr_elevate_privs(cond ? &privs : NULL) {}
+ *   frr_with_privs(cond ? &privs : NULL) {}
  *
  * NB: The code block is always executed, regardless of whether privileges
  * could be raised or not, or whether NULL was given or not.  This is fully
@@ -138,7 +138,7 @@ extern struct zebra_privs_t *_zprivs_raise(struct zebra_privs_t *privs,
 					   const char *funcname);
 extern void _zprivs_lower(struct zebra_privs_t **privs);
 
-#define frr_elevate_privs(privs)                                               \
+#define frr_with_privs(privs)                                               \
 	for (struct zebra_privs_t *_once = NULL,                               \
 				  *_privs __attribute__(                       \
 					  (unused, cleanup(_zprivs_lower))) =  \

--- a/lib/stream.c
+++ b/lib/stream.c
@@ -28,6 +28,7 @@
 #include "network.h"
 #include "prefix.h"
 #include "log.h"
+#include "frr_pthread.h"
 #include "lib_errors.h"
 
 DEFINE_MTYPE_STATIC(LIB, STREAM, "Stream")
@@ -1136,11 +1137,9 @@ void stream_fifo_push(struct stream_fifo *fifo, struct stream *s)
 
 void stream_fifo_push_safe(struct stream_fifo *fifo, struct stream *s)
 {
-	pthread_mutex_lock(&fifo->mtx);
-	{
+	frr_with_mutex(&fifo->mtx) {
 		stream_fifo_push(fifo, s);
 	}
-	pthread_mutex_unlock(&fifo->mtx);
 }
 
 /* Delete first stream from fifo. */
@@ -1170,11 +1169,9 @@ struct stream *stream_fifo_pop_safe(struct stream_fifo *fifo)
 {
 	struct stream *ret;
 
-	pthread_mutex_lock(&fifo->mtx);
-	{
+	frr_with_mutex(&fifo->mtx) {
 		ret = stream_fifo_pop(fifo);
 	}
-	pthread_mutex_unlock(&fifo->mtx);
 
 	return ret;
 }
@@ -1188,11 +1185,9 @@ struct stream *stream_fifo_head_safe(struct stream_fifo *fifo)
 {
 	struct stream *ret;
 
-	pthread_mutex_lock(&fifo->mtx);
-	{
+	frr_with_mutex(&fifo->mtx) {
 		ret = stream_fifo_head(fifo);
 	}
-	pthread_mutex_unlock(&fifo->mtx);
 
 	return ret;
 }
@@ -1212,11 +1207,9 @@ void stream_fifo_clean(struct stream_fifo *fifo)
 
 void stream_fifo_clean_safe(struct stream_fifo *fifo)
 {
-	pthread_mutex_lock(&fifo->mtx);
-	{
+	frr_with_mutex(&fifo->mtx) {
 		stream_fifo_clean(fifo);
 	}
-	pthread_mutex_unlock(&fifo->mtx);
 }
 
 size_t stream_fifo_count_safe(struct stream_fifo *fifo)

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -755,7 +755,7 @@ DEFUN_NOSH (vrf_netns,
 	if (!pathname)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	frr_elevate_privs(vrf_daemon_privs) {
+	frr_with_privs(vrf_daemon_privs) {
 		ret = vrf_netns_handler_create(vty, vrf, pathname,
 					       NS_UNKNOWN, NS_UNKNOWN);
 	}

--- a/ospf6d/ospf6_network.c
+++ b/ospf6d/ospf6_network.c
@@ -85,7 +85,7 @@ void ospf6_serv_close(void)
 /* Make ospf6d's server socket. */
 int ospf6_serv_sock(void)
 {
-	frr_elevate_privs(&ospf6d_privs) {
+	frr_with_privs(&ospf6d_privs) {
 
 		ospf6_sock = socket(AF_INET6, SOCK_RAW, IPPROTO_OSPFIGP);
 		if (ospf6_sock < 0) {

--- a/ospfd/ospf_network.c
+++ b/ospfd/ospf_network.c
@@ -190,7 +190,7 @@ int ospf_sock_init(struct ospf *ospf)
 		/* silently return since VRF is not ready */
 		return -1;
 	}
-	frr_elevate_privs(&ospfd_privs) {
+	frr_with_privs(&ospfd_privs) {
 		ospf_sock = vrf_socket(AF_INET, SOCK_RAW, IPPROTO_OSPFIGP,
 				       ospf->vrf_id, ospf->name);
 		if (ospf_sock < 0) {

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -2097,7 +2097,7 @@ static int ospf_vrf_enable(struct vrf *vrf)
 				old_vrf_id);
 
 		if (old_vrf_id != ospf->vrf_id) {
-			frr_elevate_privs(&ospfd_privs) {
+			frr_with_privs(&ospfd_privs) {
 				/* stop zebra redist to us for old vrf */
 				zclient_send_dereg_requests(zclient,
 							    old_vrf_id);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -57,7 +57,7 @@ static int pim_mroute_set(struct pim_instance *pim, int enable)
 	 * We need to create the VRF table for the pim mroute_socket
 	 */
 	if (pim->vrf_id != VRF_DEFAULT) {
-		frr_elevate_privs(&pimd_privs) {
+		frr_with_privs(&pimd_privs) {
 
 			data = pim->vrf->data.l.table_id;
 			err = setsockopt(pim->mroute_socket, IPPROTO_IP,
@@ -75,7 +75,7 @@ static int pim_mroute_set(struct pim_instance *pim, int enable)
 		}
 	}
 
-	frr_elevate_privs(&pimd_privs) {
+	frr_with_privs(&pimd_privs) {
 		opt = enable ? MRT_INIT : MRT_DONE;
 		/*
 		 * *BSD *cares* about what value we pass down
@@ -735,7 +735,7 @@ int pim_mroute_socket_enable(struct pim_instance *pim)
 {
 	int fd;
 
-	frr_elevate_privs(&pimd_privs) {
+	frr_with_privs(&pimd_privs) {
 
 		fd = socket(AF_INET, SOCK_RAW, IPPROTO_IGMP);
 

--- a/pimd/pim_msdp_socket.c
+++ b/pimd/pim_msdp_socket.c
@@ -175,7 +175,7 @@ int pim_msdp_sock_listen(struct pim_instance *pim)
 		}
 	}
 
-	frr_elevate_privs(&pimd_privs) {
+	frr_with_privs(&pimd_privs) {
 		/* bind to well known TCP port */
 		rc = bind(sock, (struct sockaddr *)&sin, socklen);
 	}

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -46,7 +46,7 @@ int pim_socket_raw(int protocol)
 {
 	int fd;
 
-	frr_elevate_privs(&pimd_privs) {
+	frr_with_privs(&pimd_privs) {
 
 		fd = socket(AF_INET, SOCK_RAW, protocol);
 
@@ -65,7 +65,7 @@ void pim_socket_ip_hdr(int fd)
 {
 	const int on = 1;
 
-	frr_elevate_privs(&pimd_privs) {
+	frr_with_privs(&pimd_privs) {
 
 		if (setsockopt(fd, IPPROTO_IP, IP_HDRINCL, &on, sizeof(on)))
 			zlog_err("%s: Could not turn on IP_HDRINCL option: %s",
@@ -83,7 +83,7 @@ int pim_socket_bind(int fd, struct interface *ifp)
 	int ret = 0;
 #ifdef SO_BINDTODEVICE
 
-	frr_elevate_privs(&pimd_privs) {
+	frr_with_privs(&pimd_privs) {
 
 		ret = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, ifp->name,
 				 strlen(ifp->name));

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -1395,7 +1395,7 @@ int rip_create_socket(struct vrf *vrf)
 	/* Make datagram socket. */
 	if (vrf->vrf_id != VRF_DEFAULT)
 		vrf_dev = vrf->name;
-	frr_elevate_privs(&ripd_privs) {
+	frr_with_privs(&ripd_privs) {
 		sock = vrf_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, vrf->vrf_id,
 				  vrf_dev);
 		if (sock < 0) {
@@ -1415,7 +1415,7 @@ int rip_create_socket(struct vrf *vrf)
 #endif
 	setsockopt_so_recvbuf(sock, RIP_UDP_RCV_BUF);
 
-	frr_elevate_privs(&ripd_privs) {
+	frr_with_privs(&ripd_privs) {
 		if ((ret = bind(sock, (struct sockaddr *)&addr, sizeof(addr)))
 		    < 0) {
 			zlog_err("%s: Can't bind socket %d to %s port %d: %s",

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -75,7 +75,7 @@ static int ripng_multicast_join(struct interface *ifp, int sock)
 		 * While this is bogus, privs are available and easy to use
 		 * for this call as a workaround.
 		 */
-		frr_elevate_privs(&ripngd_privs) {
+		frr_with_privs(&ripngd_privs) {
 
 			ret = setsockopt(sock, IPPROTO_IPV6, IPV6_JOIN_GROUP,
 					 (char *)&mreq, sizeof(mreq));

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -120,8 +120,7 @@ int ripng_make_socket(struct vrf *vrf)
 	/* Make datagram socket. */
 	if (vrf->vrf_id != VRF_DEFAULT)
 		vrf_dev = vrf->name;
-	frr_elevate_privs(&ripngd_privs)
-	{
+	frr_with_privs(&ripngd_privs) {
 		sock = vrf_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP,
 				  vrf->vrf_id, vrf_dev);
 		if (sock < 0) {
@@ -160,7 +159,7 @@ int ripng_make_socket(struct vrf *vrf)
 #endif /* SIN6_LEN */
 	ripaddr.sin6_port = htons(RIPNG_PORT_DEFAULT);
 
-	frr_elevate_privs(&ripngd_privs) {
+	frr_with_privs(&ripngd_privs) {
 		ret = bind(sock, (struct sockaddr *)&ripaddr, sizeof(ripaddr));
 		if (ret < 0) {
 			zlog_err("Can't bind ripng socket: %s.",

--- a/tests/lib/test_privs.c
+++ b/tests/lib/test_privs.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
 	((test_privs.current_state() == ZPRIVS_RAISED) ? "Raised" : "Lowered")
 
 	printf("%s\n", PRIV_STATE());
-	frr_elevate_privs(&test_privs) {
+	frr_with_privs(&test_privs) {
 		printf("%s\n", PRIV_STATE());
 	}
 
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
 
 	/* but these should continue to work... */
 	printf("%s\n", PRIV_STATE());
-	frr_elevate_privs(&test_privs) {
+	frr_with_privs(&test_privs) {
 		printf("%s\n", PRIV_STATE());
 	}
 

--- a/tools/checkpatch.pl
+++ b/tools/checkpatch.pl
@@ -3351,7 +3351,7 @@ sub process {
 
 # if/while/etc brace do not go on next line, unless defining a do while loop,
 # or if that brace on the next line is for something else
-		if ($line =~ /(.*)\b((?:if|while|for|switch|(?:[a-z_]+|)for_each[a-z_]+)\s*\(|do\b|else\b)/ && $line !~ /^.\s*\#/) {
+		if ($line =~ /(.*)\b((?:if|while|for|switch|(?:[a-z_]+|)frr_(each|with)[a-z_]+)\s*\(|do\b|else\b)/ && $line !~ /^.\s*\#/) {
 			my $pre_ctx = "$1$2";
 
 			my ($level, @ctx) = ctx_statement_level($linenr, $realcnt, 0);
@@ -3397,7 +3397,7 @@ sub process {
 		}
 
 # Check relative indent for conditionals and blocks.
-		if ($line =~ /\b(?:(?:if|while|for|(?:[a-z_]+|)for_each[a-z_]+)\s*\(|(?:do|else)\b)/ && $line !~ /^.\s*#/ && $line !~ /\}\s*while\s*/) {
+		if ($line =~ /\b(?:(?:if|while|for|(?:[a-z_]+|)frr_(each|with)[a-z_]+)\s*\(|(?:do|else)\b)/ && $line !~ /^.\s*#/ && $line !~ /\}\s*while\s*/) {
 			($stat, $cond, $line_nr_next, $remain_next, $off_next) =
 				ctx_statement_block($linenr, $realcnt, 0)
 					if (!defined $stat);
@@ -5174,6 +5174,31 @@ sub process {
 
 				WARN("BRACES",
 				     "braces {} are not necessary for single statement blocks\n" . $herectx);
+			}
+		}
+
+		if (!defined $suppress_ifbraces{$linenr - 1} &&
+					$line =~ /\b(frr_with_)/) {
+			my ($level, $endln, @chunks) =
+				ctx_statement_full($linenr, $realcnt, $-[0]);
+
+			# Check the condition.
+			my ($cond, $block) = @{$chunks[0]};
+			#print "CHECKING<$linenr> cond<$cond> block<$block>\n";
+			if (defined $cond) {
+				substr($block, 0, length($cond), '');
+			}
+
+			if ($level == 0 && $block !~ /^\s*\{/) {
+				my $herectx = $here . "\n";
+				my $cnt = statement_rawlines($block);
+
+				for (my $n = 0; $n < $cnt; $n++) {
+					$herectx .= raw_line($linenr, $n) . "\n";
+				}
+
+				WARN("BRACES",
+				     "braces {} are mandatory for frr_with_* blocks\n" . $herectx);
 			}
 		}
 

--- a/tools/coccinelle/frr_with_mutex.cocci
+++ b/tools/coccinelle/frr_with_mutex.cocci
@@ -1,0 +1,23 @@
+@@
+expression E;
+iterator name frr_with_mutex;
+@@
+
+- pthread_mutex_lock(E);
++ frr_with_mutex(E) {
+- {
+    ...
+- }
+- pthread_mutex_unlock(E);
++ }
+
+
+@@
+expression E;
+@@
+
+- pthread_mutex_lock(E);
++ frr_with_mutex(E) {
+  ...
+- pthread_mutex_unlock(E);
++ }

--- a/tools/coccinelle/zprivs.cocci
+++ b/tools/coccinelle/zprivs.cocci
@@ -2,12 +2,12 @@
 identifier change;
 identifier end;
 expression E, f, g;
-iterator name frr_elevate_privs;
+iterator name frr_with_privs;
 @@
 
 - if (E.change(ZPRIVS_RAISE))
 -   f;
-+ frr_elevate_privs(&E) {
++ frr_with_privs(&E) {
   <+...
 -   goto end;
 +   break;
@@ -20,7 +20,7 @@ iterator name frr_elevate_privs;
 @@
 identifier change, errno, safe_strerror, exit;
 expression E, f1, f2, f3, ret, fn;
-iterator name frr_elevate_privs;
+iterator name frr_with_privs;
 @@
 
   if (E.change(ZPRIVS_RAISE))
@@ -44,7 +44,7 @@ iterator name frr_elevate_privs;
 @@
 identifier change;
 expression E, f1, f2, f3, ret;
-iterator name frr_elevate_privs;
+iterator name frr_with_privs;
 @@
 
   if (E.change(ZPRIVS_RAISE))
@@ -64,12 +64,12 @@ iterator name frr_elevate_privs;
 @@
 identifier change;
 expression E, f, g;
-iterator name frr_elevate_privs;
+iterator name frr_with_privs;
 @@
 
 - if (E.change(ZPRIVS_RAISE))
 -   f;
-+ frr_elevate_privs(&E) {
++ frr_with_privs(&E) {
   ...
 - if (E.change(ZPRIVS_LOWER))
 -   g;

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -1065,8 +1065,7 @@ static int vrrp_socket(struct vrrp_router *r)
 	int ret;
 	bool failed = false;
 
-	frr_elevate_privs(&vrrp_privs)
-	{
+	frr_with_privs(&vrrp_privs) {
 		r->sock_rx = socket(r->family, SOCK_RAW, IPPROTO_VRRP);
 		r->sock_tx = socket(r->family, SOCK_RAW, IPPROTO_VRRP);
 	}
@@ -1102,8 +1101,7 @@ static int vrrp_socket(struct vrrp_router *r)
 		setsockopt_ipv4_multicast_loop(r->sock_tx, 0);
 
 		/* Bind Rx socket to exact interface */
-		frr_elevate_privs(&vrrp_privs)
-		{
+		frr_with_privs(&vrrp_privs) {
 			ret = setsockopt(r->sock_rx, SOL_SOCKET,
 					 SO_BINDTODEVICE, r->vr->ifp->name,
 					 strlen(r->vr->ifp->name));
@@ -1213,8 +1211,7 @@ static int vrrp_socket(struct vrrp_router *r)
 		setsockopt_ipv6_multicast_loop(r->sock_tx, 0);
 
 		/* Bind Rx socket to exact interface */
-		frr_elevate_privs(&vrrp_privs)
-		{
+		frr_with_privs(&vrrp_privs) {
 			ret = setsockopt(r->sock_rx, SOL_SOCKET,
 					 SO_BINDTODEVICE, r->vr->ifp->name,
 					 strlen(r->vr->ifp->name));

--- a/vrrpd/vrrp_arp.c
+++ b/vrrpd/vrrp_arp.c
@@ -188,7 +188,7 @@ void vrrp_garp_init(void)
 	/* Create the socket descriptor */
 	/* FIXME: why ETH_P_RARP? */
 	errno = 0;
-	frr_elevate_privs(&vrrp_privs) {
+	frr_with_privs(&vrrp_privs) {
 		garp_fd = socket(PF_PACKET, SOCK_RAW | SOCK_CLOEXEC,
 				 htons(ETH_P_RARP));
 	}

--- a/vrrpd/vrrp_ndisc.c
+++ b/vrrpd/vrrp_ndisc.c
@@ -214,8 +214,7 @@ int vrrp_ndisc_una_send_all(struct vrrp_router *r)
 
 void vrrp_ndisc_init(void)
 {
-	frr_elevate_privs(&vrrp_privs)
-	{
+	frr_with_privs(&vrrp_privs) {
 		ndisc_fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_IPV6));
 	}
 

--- a/zebra/if_ioctl_solaris.c
+++ b/zebra/if_ioctl_solaris.c
@@ -60,7 +60,7 @@ static int interface_list_ioctl(int af)
 	size_t needed, lastneeded = 0;
 	char *buf = NULL;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		sock = socket(af, SOCK_DGRAM, 0);
 	}
 
@@ -72,7 +72,7 @@ static int interface_list_ioctl(int af)
 	}
 
 calculate_lifc_len:
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		lifn.lifn_family = af;
 		lifn.lifn_flags = LIFC_NOXMIT;
 		/* we want NOXMIT interfaces too */
@@ -107,7 +107,7 @@ calculate_lifc_len:
 	lifconf.lifc_len = needed;
 	lifconf.lifc_buf = buf;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		ret = ioctl(sock, SIOCGLIFCONF, &lifconf);
 	}
 

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -385,7 +385,7 @@ static int get_iflink_speed(struct interface *interface)
 	ifdata.ifr_data = (caddr_t)&ecmd;
 
 	/* use ioctl to get IP address of an interface */
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		sd = vrf_socket(PF_INET, SOCK_DGRAM, IPPROTO_IP,
 				interface->vrf_id,
 				NULL);

--- a/zebra/ioctl.c
+++ b/zebra/ioctl.c
@@ -57,7 +57,7 @@ int if_ioctl(unsigned long request, caddr_t buffer)
 	int ret;
 	int err = 0;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		sock = socket(AF_INET, SOCK_DGRAM, 0);
 		if (sock < 0) {
 			zlog_err("Cannot create UDP socket: %s",
@@ -83,7 +83,7 @@ int vrf_if_ioctl(unsigned long request, caddr_t buffer, vrf_id_t vrf_id)
 	int ret;
 	int err = 0;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		sock = vrf_socket(AF_INET, SOCK_DGRAM, 0, vrf_id, NULL);
 		if (sock < 0) {
 			zlog_err("Cannot create UDP socket: %s",
@@ -110,7 +110,7 @@ static int if_ioctl_ipv6(unsigned long request, caddr_t buffer)
 	int ret;
 	int err = 0;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		sock = socket(AF_INET6, SOCK_DGRAM, 0);
 		if (sock < 0) {
 			zlog_err("Cannot create IPv6 datagram socket: %s",

--- a/zebra/ioctl_solaris.c
+++ b/zebra/ioctl_solaris.c
@@ -66,7 +66,7 @@ int if_ioctl(unsigned long request, caddr_t buffer)
 	int ret;
 	int err;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 
 		sock = socket(AF_INET, SOCK_DGRAM, 0);
 		if (sock < 0) {
@@ -96,7 +96,7 @@ int if_ioctl_ipv6(unsigned long request, caddr_t buffer)
 	int ret;
 	int err;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 
 		sock = socket(AF_INET6, SOCK_DGRAM, 0);
 		if (sock < 0) {

--- a/zebra/ipforward_proc.c
+++ b/zebra/ipforward_proc.c
@@ -76,7 +76,7 @@ int ipforward_on(void)
 {
 	FILE *fp;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 
 		fp = fopen(proc_ipv4_forwarding, "w");
 
@@ -97,7 +97,7 @@ int ipforward_off(void)
 {
 	FILE *fp;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 
 		fp = fopen(proc_ipv4_forwarding, "w");
 
@@ -143,7 +143,7 @@ int ipforward_ipv6_on(void)
 {
 	FILE *fp;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 
 		fp = fopen(proc_ipv6_forwarding, "w");
 
@@ -165,7 +165,7 @@ int ipforward_ipv6_off(void)
 {
 	FILE *fp;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 
 		fp = fopen(proc_ipv6_forwarding, "w");
 

--- a/zebra/ipforward_solaris.c
+++ b/zebra/ipforward_solaris.c
@@ -83,7 +83,7 @@ static int solaris_nd(const int cmd, const char *parameter, const int value)
 	strioctl.ic_len = ND_BUFFER_SIZE;
 	strioctl.ic_dp = nd_buf;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		if ((fd = open(device, O_RDWR)) < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
 				     "failed to open device %s - %s", device,

--- a/zebra/ipforward_sysctl.c
+++ b/zebra/ipforward_sysctl.c
@@ -56,7 +56,7 @@ int ipforward_on(void)
 	int ipforwarding = 1;
 
 	len = sizeof ipforwarding;
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib, MIB_SIZ, NULL, NULL, &ipforwarding, len) < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
 				     "Can't set ipforwarding on");
@@ -72,7 +72,7 @@ int ipforward_off(void)
 	int ipforwarding = 0;
 
 	len = sizeof ipforwarding;
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib, MIB_SIZ, NULL, NULL, &ipforwarding, len) < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
 				     "Can't set ipforwarding on");
@@ -97,7 +97,7 @@ int ipforward_ipv6(void)
 	int ip6forwarding = 0;
 
 	len = sizeof ip6forwarding;
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib_ipv6, MIB_SIZ, &ip6forwarding, &len, 0, 0) < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
 				     "can't get ip6forwarding value");
@@ -113,7 +113,7 @@ int ipforward_ipv6_on(void)
 	int ip6forwarding = 1;
 
 	len = sizeof ip6forwarding;
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len)
 		    < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
@@ -130,7 +130,7 @@ int ipforward_ipv6_off(void)
 	int ip6forwarding = 0;
 
 	len = sizeof ip6forwarding;
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len)
 		    < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -82,7 +82,7 @@ int irdp_sock_init(void)
 	int save_errno;
 	int sock;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 
 		sock = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
 		save_errno = errno;

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -183,7 +183,7 @@ static int netlink_recvbuf(struct nlsock *nl, uint32_t newsize)
 	}
 
 	/* Try force option (linux >= 2.6.14) and fall back to normal set */
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		ret = setsockopt(nl->sock, SOL_SOCKET, SO_RCVBUFFORCE,
 				 &nl_rcvbufsize,
 				 sizeof(nl_rcvbufsize));
@@ -220,7 +220,7 @@ static int netlink_socket(struct nlsock *nl, unsigned long groups,
 	int sock;
 	int namelen;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		sock = ns_socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE, ns_id);
 		if (sock < 0) {
 			zlog_err("Can't open %s socket: %s", nl->name,
@@ -352,7 +352,7 @@ static void netlink_write_incoming(const char *buf, const unsigned int size,
 	FILE *f;
 
 	snprintf(fname, MAXPATHLEN, "%s/%s_%u", frr_vtydir, "netlink", counter);
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		f = fopen(fname, "w");
 	}
 	if (f) {
@@ -373,7 +373,7 @@ static long netlink_read_file(char *buf, const char *fname)
 	FILE *f;
 	long file_bytes = -1;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		f = fopen(fname, "r");
 	}
 	if (f) {
@@ -989,7 +989,7 @@ int netlink_talk_info(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 			n->nlmsg_flags);
 
 	/* Send message to netlink interface. */
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		status = sendmsg(nl->sock, &msg, 0);
 		save_errno = errno;
 	}
@@ -1056,7 +1056,7 @@ int netlink_request(struct nlsock *nl, struct nlmsghdr *n)
 	snl.nl_family = AF_NETLINK;
 
 	/* Raise capabilities and send message, then lower capabilities. */
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		ret = sendto(nl->sock, (void *)n, n->nlmsg_len, 0,
 			     (struct sockaddr *)&snl, sizeof snl);
 	}

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1426,7 +1426,7 @@ static int kernel_read(struct thread *thread)
 /* Make routing socket. */
 static void routing_socket(struct zebra_ns *zns)
 {
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		routing_sock = ns_socket(AF_ROUTE, SOCK_RAW, 0, zns->ns_id);
 
 		dplane_routing_sock =

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -314,7 +314,7 @@ enum zebra_dplane_result kernel_route_update(struct zebra_dplane_ctx *ctx)
 	type = dplane_ctx_get_type(ctx);
 	old_type = dplane_ctx_get_old_type(ctx);
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 
 		if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_DELETE) {
 			if (!RSYSTEM_ROUTE(type))

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -760,7 +760,7 @@ static int rtadv_make_socket(ns_id_t ns_id)
 	int ret = 0;
 	struct icmp6_filter filter;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 
 		sock = ns_socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6, ns_id);
 

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2507,7 +2507,7 @@ static void zserv_write_incoming(struct stream *orig, uint16_t command)
 
 	snprintf(fname, MAXPATHLEN, "%s/%u", frr_vtydir, command);
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		fd = open(fname, O_CREAT | O_WRONLY | O_EXCL, 0644);
 	}
 	stream_flush(copy, fd);

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -119,7 +119,7 @@ static int kernel_send_rtmsg_v4(int action, mpls_label_t in_label,
 			hdr.rtm_mpls = MPLS_OP_SWAP;
 	}
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		ret = writev(kr_state.fd, iov, iovcnt);
 	}
 
@@ -226,7 +226,7 @@ static int kernel_send_rtmsg_v6(int action, mpls_label_t in_label,
 			hdr.rtm_mpls = MPLS_OP_SWAP;
 	}
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		ret = writev(kr_state.fd, iov, iovcnt);
 	}
 

--- a/zebra/zebra_netns_notify.c
+++ b/zebra/zebra_netns_notify.c
@@ -77,7 +77,7 @@ static void zebra_ns_notify_create_context_from_entry_name(const char *name)
 	if (netnspath == NULL)
 		return;
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		ns_id = zebra_ns_id_get(netnspath);
 	}
 	if (ns_id == NS_UNKNOWN)
@@ -97,7 +97,7 @@ static void zebra_ns_notify_create_context_from_entry_name(const char *name)
 		ns_map_nsid_with_external(ns_id, false);
 		return;
 	}
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		ret = vrf_netns_handler_create(NULL, vrf, netnspath,
 					       ns_id_external, ns_id);
 	}
@@ -202,14 +202,14 @@ static int zebra_ns_ready_read(struct thread *t)
 	netnspath = zns_info->netnspath;
 	if (--zns_info->retries == 0)
 		stop_retry = 1;
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		err = ns_switch_to_netns(netnspath);
 	}
 	if (err < 0)
 		return zebra_ns_continue_read(zns_info, stop_retry);
 
 	/* go back to default ns */
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		err = ns_switchback_to_initial();
 	}
 	if (err < 0)

--- a/zebra/zebra_ns.c
+++ b/zebra/zebra_ns.c
@@ -180,7 +180,7 @@ int zebra_ns_init(const char *optional_default_name)
 
 	dzns = zebra_ns_alloc();
 
-	frr_elevate_privs(&zserv_privs) {
+	frr_with_privs(&zserv_privs) {
 		ns_id = zebra_ns_id_get_default();
 	}
 	ns_id_external = ns_map_nsid_with_external(ns_id, true);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -231,13 +231,11 @@ static int zserv_write(struct thread *thread)
 
 	cache = stream_fifo_new();
 
-	pthread_mutex_lock(&client->obuf_mtx);
-	{
+	frr_with_mutex(&client->obuf_mtx) {
 		while (stream_fifo_head(client->obuf_fifo))
 			stream_fifo_push(cache,
 					 stream_fifo_pop(client->obuf_fifo));
 	}
-	pthread_mutex_unlock(&client->obuf_mtx);
 
 	if (cache->tail) {
 		msg = cache->tail;
@@ -427,13 +425,11 @@ static int zserv_read(struct thread *thread)
 				      memory_order_relaxed);
 
 		/* publish read packets on client's input queue */
-		pthread_mutex_lock(&client->ibuf_mtx);
-		{
+		frr_with_mutex(&client->ibuf_mtx) {
 			while (cache->head)
 				stream_fifo_push(client->ibuf_fifo,
 						 stream_fifo_pop(cache));
 		}
-		pthread_mutex_unlock(&client->ibuf_mtx);
 
 		/* Schedule job to process those packets */
 		zserv_event(client, ZSERV_PROCESS_MESSAGES);
@@ -499,8 +495,7 @@ static int zserv_process_messages(struct thread *thread)
 	uint32_t p2p = zrouter.packets_to_process;
 	bool need_resched = false;
 
-	pthread_mutex_lock(&client->ibuf_mtx);
-	{
+	frr_with_mutex(&client->ibuf_mtx) {
 		uint32_t i;
 		for (i = 0; i < p2p && stream_fifo_head(client->ibuf_fifo);
 		     ++i) {
@@ -516,7 +511,6 @@ static int zserv_process_messages(struct thread *thread)
 		if (stream_fifo_head(client->ibuf_fifo))
 			need_resched = true;
 	}
-	pthread_mutex_unlock(&client->ibuf_mtx);
 
 	while (stream_fifo_head(cache)) {
 		msg = stream_fifo_pop(cache);
@@ -535,11 +529,9 @@ static int zserv_process_messages(struct thread *thread)
 
 int zserv_send_message(struct zserv *client, struct stream *msg)
 {
-	pthread_mutex_lock(&client->obuf_mtx);
-	{
+	frr_with_mutex(&client->obuf_mtx) {
 		stream_fifo_push(client->obuf_fifo, msg);
 	}
-	pthread_mutex_unlock(&client->obuf_mtx);
 
 	zserv_client_event(client, ZSERV_CLIENT_WRITE);
 

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -782,7 +782,7 @@ void zserv_start(char *path)
 	setsockopt_so_recvbuf(zsock, 1048576);
 	setsockopt_so_sendbuf(zsock, 1048576);
 
-	frr_elevate_privs((sa.ss_family != AF_UNIX) ? &zserv_privs : NULL) {
+	frr_with_privs((sa.ss_family != AF_UNIX) ? &zserv_privs : NULL) {
 		ret = bind(zsock, (struct sockaddr *)&sa, sa_len);
 	}
 	if (ret < 0) {


### PR DESCRIPTION
This adds
```
frr_with_mutex(&mutex) {
    ...
}
```
which is equivalent to
```
pthread_mutex_lock(&mutex);
...
pthread_mutex_unlock(&mutex);
```
except that the mutex is *always* unlocked regardless of how the block is exited (goto, break, return, ... all works).