### PR TITLE
zebra: Mixed json and vty output causes issues

### DIFF
--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1387,10 +1387,13 @@ static void zvni_print_mac_hash(struct hash_bucket *bucket, void *ctxt)
 				vty_out(vty, " %-5u", vid);
 			else
 				json_object_int_add(json_mac, "vlan", vid);
-		} else /* No vid? fill out the space */
-			vty_out(vty, " %-5s", "");
-		vty_out(vty, " %u/%u", mac->loc_seq, mac->rem_seq);
-		if (json_mac_hdr == NULL) {
+		} else  {/* No vid? fill out the space */
+			if (!json_mac_hdr)
+				vty_out(vty, " %-5s", "");
+		}
+
+		if (!json_mac_hdr) {
+			vty_out(vty, " %u/%u", mac->loc_seq, mac->rem_seq);
 			vty_out(vty, "\n");
 		} else {
 			json_object_int_add(json_mac, "localSequence",


### PR DESCRIPTION
The `show evpn mac vni X json` command was allowing vty_out
and json output to be intermixed.  This is causing json
output to be a mix of normal vty output and json output
making it illegible.

Ticket: CM-25409
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>