### PR TITLE
vtysh: Try to be perscriptive about pam failures

### DIFF
--- a/vtysh/vtysh_user.c
+++ b/vtysh/vtysh_user.c
@@ -62,35 +62,20 @@ static int vtysh_pam(const char *user)
 
 	/* Start PAM. */
 	ret = pam_start(FRR_PAM_NAME, user, &conv, &pamh);
-	/* printf ("ret %d\n", ret); */
 
 	/* Is user really user? */
 	if (ret == PAM_SUCCESS)
 		ret = pam_authenticate(pamh, 0);
-/* printf ("ret %d\n", ret); */
 
-#if 0
-  /* Permitted access? */
-  if (ret == PAM_SUCCESS)
-    ret = pam_acct_mgmt (pamh, 0);
-  printf ("ret %d\n", ret);
-
-  if (ret == PAM_AUTHINFO_UNAVAIL)
-    ret = PAM_SUCCESS;
-#endif /* 0 */
-
-/* This is where we have been authorized or not. */
-#ifdef DEBUG
-	if (ret == PAM_SUCCESS)
-		printf("Authenticated\n");
-	else
-		printf("Not Authenticated\n");
-#endif /* DEBUG */
+	if (ret != PAM_SUCCESS)
+		fprintf(stderr, "vtysh_pam: Failure to initialize pam: %s(%d)",
+			pam_strerror(pamh, ret), ret);
 
 	/* close Linux-PAM */
 	if (pam_end(pamh, ret) != PAM_SUCCESS) {
 		pamh = NULL;
-		fprintf(stderr, "vtysh_pam: failed to release authenticator\n");
+		fprintf(stderr, "vtysh_pam: failed to release authenticator: %s(%d)\n",
+			pam_strerror(pamh, ret), ret);
 		exit(1);
 	}
 


### PR DESCRIPTION
When using pam for authentication, the code just silently
fails and gives no indication to the end user what has gone
wrong.  Try to increase messaging about what has gone wrong
by outputting some more data.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>