### PR TITLE
[7.0]pimd: Dissallow query to be received from a non-connected source

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -305,6 +305,13 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 		return -1;
 	}
 
+	if (!pim_if_connected_to_source(ifp, from)) {
+		if (PIM_DEBUG_IGMP_PACKETS)
+			zlog_debug("Recv IGMP query on interface: %s from a non-connected source: %s",
+				   ifp->name, from_str);
+		return 0;
+	}
+
 	/* Collecting IGMP Rx stats */
 	switch (query_version) {
 	case 1:


### PR DESCRIPTION
When we receive an igmp query on a interface, ensure that the
source address of the packet is connected to the incoming
interface.  This will prevent a meanie from crafting a igmp
packet with a source address less than ours and causing
us to suspend query activities.

Fixes: #1692
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>