### PR TITLE
bgpd: fix bgp-lu update bug

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2974,6 +2974,8 @@ size_t bgp_packet_mpattr_prefix_size(afi_t afi, safi_t safi, struct prefix *p)
 	int size = PSIZE(p->prefixlen);
 	if (safi == SAFI_MPLS_VPN)
 		size += 88;
+	else if (safi == SAFI_LABELED_UNICAST)
+		size += BGP_LABEL_BYTES;
 	else if (afi == AFI_L2VPN && safi == SAFI_EVPN)
 		size += 232; // TODO: Maximum possible for type-2, type-3 and
 			     // type-5


### PR DESCRIPTION
bgp update messages were not correctly calculating the size
for a labeled-unicast prefix, as they were not accounting
for the label. If the update message was large enough to
overflow the maximum packet size (4096 bytes) this could
cause bgpd to send a malformed update packet.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>