### PR TITLE
lib: add process pids to 'show modules'

### DIFF
--- a/lib/memory_vty.c
+++ b/lib/memory_vty.c
@@ -171,6 +171,9 @@ DEFUN (show_modules,
 		}
 		plug = plug->next;
 	}
+
+	vty_out(vty, "pid: %u\n", (uint32_t)(getpid()));
+
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
Add the process pids to the output produced by 'show modules'. At least in a development setting, where there may be multiple instances of frr running, it can be handy to be able to see the exact pids, for debugging e.g.

The output looks like this:
```
mjs-uvm18# sho mod
Module information for zebra:
Module Name  Version                   Description

libfrr       7.2-dev-WORK              libfrr core module
zebra        7.2-dev-WORK              zebra daemon
pid: 38143

Module information for sharpd:
Module Name  Version                   Description

libfrr       7.2-dev-WORK              libfrr core module
sharpd       7.2-dev-WORK              sharpd daemon
pid: 38162
```