### PR TITLE
ospfd: Do not modify list when using _RO loop

### DIFF
--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -766,7 +766,7 @@ static void ospf_finish_final(struct ospf *ospf)
 		if (!ext_list)
 			continue;
 
-		for (ALL_LIST_ELEMENTS_RO(ext_list, node, ext)) {
+		for (ALL_LIST_ELEMENTS(ext_list, node, nnode, ext)) {
 			if (ext->external_info)
 				for (rn = route_top(ext->external_info); rn;
 				     rn = route_next(rn)) {


### PR DESCRIPTION
The shutdown of ospf was causing crashes because the shutdown
was calling a ALL_LIST_ELEMENTS_RO macro and modifying the
underlying data structures.  Switch to using ALL_LIST_ELEMENTS.

This is caused by this change:

commit f9e1501aea5d429be2ecda1a3e2bde17e6ad5e4b
Author: Donald Sharp <sharpd@cumulusnetworks.com>
Date:   Wed Feb 27 15:08:29 2019 -0500

    ospfd: Cleanup ospf->redist and ospf->external on shutdown

Effectively my original testing for this only had one external
route and as such we would not have a crash here.  It only
showed up after multiple externals have been introduced.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>