### PR TITLE
make c-ares DNS resolver available as lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1560,7 +1560,7 @@ if test "${NHRPD}" != ""; then
     AC_MSG_ERROR([trying to build nhrpd, but libcares not found. install c-ares and its -dev headers.])
   ])
 fi
-
+AM_CONDITIONAL([CARES], [test "${NHRPD}" != ""])
 
 dnl ------------------
 dnl check Net-SNMP library

--- a/debian/frr.install
+++ b/debian/frr.install
@@ -2,6 +2,7 @@ etc/
 usr/bin/vtysh
 usr/bin/mtracebis
 usr/lib/*/frr/libfrr.*
+usr/lib/*/frr/libfrrcares.*
 usr/lib/*/frr/libfrrospfapiclient.*
 usr/lib/frr/*.sh
 usr/lib/frr/*d

--- a/lib/command.c
+++ b/lib/command.c
@@ -85,6 +85,7 @@ const char *node_names[] = {
 	"northbound debug",	    // NORTHBOUND_DEBUG_NODE,
 	"vnc debug",		    // DEBUG_VNC_NODE,
 	"route-map debug",	    /* RMAP_DEBUG_NODE */
+	"resolver debug",	    /* RESOLVER_DEBUG_NODE */
 	"aaa",			    // AAA_NODE,
 	"keychain",		    // KEYCHAIN_NODE,
 	"keychain key",		    // KEYCHAIN_KEY_NODE,

--- a/lib/command.h
+++ b/lib/command.h
@@ -94,6 +94,7 @@ enum node_type {
 	NORTHBOUND_DEBUG_NODE,	 /* Northbound Debug node. */
 	DEBUG_VNC_NODE,		 /* Debug VNC node. */
 	RMAP_DEBUG_NODE,         /* Route-map debug node */
+	RESOLVER_DEBUG_NODE,	 /* Resolver debug node */
 	AAA_NODE,		 /* AAA node. */
 	KEYCHAIN_NODE,		 /* Key-chain node. */
 	KEYCHAIN_KEY_NODE,       /* Key-chain key node. */

--- a/lib/lib_errors.c
+++ b/lib/lib_errors.c
@@ -357,6 +357,12 @@ static struct log_ref ferr_lib_err[] = {
 		.suggestion = "Gather log data and open an Issue.",
 	},
 	{
+		.code = EC_LIB_RESOLVER,
+		.title = "DNS Resolution",
+		.description = "An error was detected while attempting to resolve a hostname",
+		.suggestion = "Ensure that DNS is working properly and the hostname is configured in dns.  If you are still seeing this error, open an issue"
+	},
+	{
 		.code = END_FERR,
 	}
 };

--- a/lib/lib_errors.h
+++ b/lib/lib_errors.h
@@ -84,6 +84,7 @@ enum lib_log_refs {
 	EC_LIB_GRPC_INIT,
 	EC_LIB_ID_CONSISTENCY,
 	EC_LIB_ID_EXHAUST,
+	EC_LIB_RESOLVER,
 };
 
 extern void lib_error_init(void);

--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -145,14 +145,17 @@ static void ares_address_cb(void *arg, int status, int timeouts,
 {
 	struct resolver_query *query = (struct resolver_query *)arg;
 	union sockunion addr[16];
+	void (*callback)(struct resolver_query *, int, union sockunion *);
 	size_t i;
+
+	callback = query->callback;
+	query->callback = NULL;
 
 	if (status != ARES_SUCCESS) {
 		if (resolver_debug)
 			zlog_debug("[%p] Resolving failed", query);
 
-		query->callback(query, -1, NULL);
-		query->callback = NULL;
+		callback(query, -1, NULL);
 		return;
 	}
 
@@ -174,8 +177,7 @@ static void ares_address_cb(void *arg, int status, int timeouts,
 	if (resolver_debug)
 		zlog_debug("[%p] Resolved with %d results", query, (int)i);
 
-	query->callback(query, i, &addr[0]);
-	query->callback = NULL;
+	callback(query, i, &addr[0]);
 }
 
 void resolver_resolve(struct resolver_query *query, int af,

--- a/lib/resolver.h
+++ b/lib/resolver.h
@@ -1,0 +1,25 @@
+/* C-Ares integration to Quagga mainloop
+ * Copyright (c) 2014-2015 Timo Teräs
+ *
+ * This file is free software: you may copy, redistribute and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef _FRR_RESOLVER_H
+#define _FRR_RESOLVER_H
+
+#include "thread.h"
+#include "sockunion.h"
+
+struct resolver_query {
+	void (*callback)(struct resolver_query *, int n, union sockunion *);
+};
+
+void resolver_init(struct thread_master *tm);
+void resolver_resolve(struct resolver_query *query, int af,
+		      const char *hostname, void (*cb)(struct resolver_query *,
+						       int, union sockunion *));
+
+#endif /* _FRR_RESOLVER_H */

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -286,6 +286,21 @@ lib_libfrrsnmp_la_SOURCES = \
 	# end
 
 #
+# c-ares support
+#
+if CARES
+lib_LTLIBRARIES += lib/libfrrcares.la
+pkginclude_HEADERS += lib/resolver.h
+endif
+
+lib_libfrrcares_la_CFLAGS = $(WERROR) $(CARES_CFLAGS)
+lib_libfrrcares_la_LDFLAGS = -version-info 0:0:0
+lib_libfrrcares_la_LIBADD = $(CARES_LIBS)
+lib_libfrrcares_la_SOURCES = \
+	lib/resolver.c \
+	#end
+
+#
 # ZeroMQ support
 #
 if ZEROMQ

--- a/nhrpd/nhrp_errors.c
+++ b/nhrpd/nhrp_errors.c
@@ -32,12 +32,6 @@ static struct log_ref ferr_nhrp_err[] = {
 		.suggestion = "Ensure that StrongSwan is configured correctly.  Restart StrongSwan and FRR"
 	},
 	{
-		.code = EC_NHRP_RESOLVER,
-		.title = "NHRP DNS Resolution",
-		.description = "NHRP has detected an error in an attempt to resolve a hostname",
-		.suggestion = "Ensure that DNS is working properly and the hostname is configured in dns.  If you are still seeing this error, open an issue"
-	},
-	{
 		.code = END_FERR,
 	}
 };

--- a/nhrpd/nhrp_errors.h
+++ b/nhrpd/nhrp_errors.h
@@ -25,7 +25,6 @@
 
 enum nhrp_log_refs {
 	EC_NHRP_SWAN = NHRP_FERR_START,
-	EC_NHRP_RESOLVER,
 };
 
 extern void nhrp_error_init(void);

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
 	nhrp_error_init();
 	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	nhrp_interface_init();
-	resolver_init();
+	resolver_init(master);
 
 	/* Run with elevated capabilities, as for all netlink activity
 	 * we need privileges anyway. */

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -16,6 +16,7 @@
 #include "zclient.h"
 #include "debug.h"
 #include "memory.h"
+#include "resolver.h"
 
 DECLARE_MGROUP(NHRPD)
 
@@ -83,15 +84,6 @@ static inline int notifier_active(struct notifier_list *l)
 {
 	return !list_empty(&l->notifier_head);
 }
-
-struct resolver_query {
-	void (*callback)(struct resolver_query *, int n, union sockunion *);
-};
-
-void resolver_init(void);
-void resolver_resolve(struct resolver_query *query, int af,
-		      const char *hostname, void (*cb)(struct resolver_query *,
-						       int, union sockunion *));
 
 void nhrp_zebra_init(void);
 void nhrp_zebra_terminate(void);

--- a/nhrpd/subdir.am
+++ b/nhrpd/subdir.am
@@ -8,8 +8,7 @@ vtysh_scan += $(top_srcdir)/nhrpd/nhrp_vty.c
 man8 += $(MANBUILD)/nhrpd.8
 endif
 
-nhrpd_nhrpd_LDADD = lib/libfrr.la $(LIBCAP) $(CARES_LIBS)
-nhrpd_nhrpd_CFLAGS = $(AM_CFLAGS) $(CARES_CFLAGS)
+nhrpd_nhrpd_LDADD = lib/libfrr.la lib/libfrrcares.la $(LIBCAP)
 nhrpd_nhrpd_SOURCES = \
 	nhrpd/linux.c \
 	nhrpd/netlink_arp.c \
@@ -27,7 +26,6 @@ nhrpd_nhrpd_SOURCES = \
 	nhrpd/nhrp_vc.c \
 	nhrpd/nhrp_vty.c \
 	nhrpd/reqid.c \
-	nhrpd/resolver.c \
 	nhrpd/vici.c \
 	nhrpd/zbuf.c \
 	nhrpd/znl.c \

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -377,6 +377,9 @@ void vtysh_config_parse_line(void *arg, const char *line)
 				 strlen("debug route-map"))
 			 == 0)
 			config = config_get(RMAP_DEBUG_NODE, line);
+		else if (strncmp(line, "debug resolver",
+				 strlen("debug resolver")) == 0)
+			config = config_get(RESOLVER_DEBUG_NODE, line);
 		else if (strncmp(line, "debug", strlen("debug")) == 0)
 			config = config_get(DEBUG_NODE, line);
 		else if (strncmp(line, "password", strlen("password")) == 0
@@ -423,7 +426,7 @@ void vtysh_config_parse_line(void *arg, const char *line)
 	 || (I) == PREFIX_IPV6_NODE || (I) == FORWARDING_NODE                  \
 	 || (I) == DEBUG_NODE || (I) == AAA_NODE || (I) == VRF_DEBUG_NODE      \
 	 || (I) == NORTHBOUND_DEBUG_NODE || (I) == RMAP_DEBUG_NODE             \
-	 || (I) == MPLS_NODE)
+	 || (I) == RESOLVER_DEBUG_NODE || (I) == MPLS_NODE)
 
 /* Display configuration to file pointer. */
 void vtysh_config_dump(void)


### PR DESCRIPTION
This is preparation work for BMP, which also uses c-ares to resolve host names.

To isolate the c-ares dependency, the respective code is in a separate `libfrrcares` which is used by `nhrpd` (and will be used by the BMP module.)  This makes it so that problems with `c-ares` only affect nhrpd & bgp_bmp.