### PR TITLE
doc: inform user to use pytest < version 5.0

### DIFF
--- a/doc/developer/building-frr-for-omnios.rst
+++ b/doc/developer/building-frr-for-omnios.rst
@@ -60,7 +60,7 @@ Add pytest:
 
 ::
 
-    pip install pytest
+    pip install "pytest<5"
 
 Install Sphinx:::
 

--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -22,7 +22,7 @@ Installing Mininet Infrastructure
    apt-get install python-pip
    apt-get install iproute
    pip install ipaddr
-   pip install pytest
+   pip install "pytest<5"
    pip install exabgp==3.4.17 (Newer 4.0 version of exabgp is not yet
    supported)
    useradd -d /var/run/exabgp/ -s /bin/false exabgp


### PR DESCRIPTION
pytest intends to deprecate users not having python 2 on the system.
in order to make topotest work, just use an older pytest version.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>