### PR TITLE
bgp: add hook_unregister to bgp_dump_finish

### DIFF
--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -877,4 +877,5 @@ void bgp_dump_finish(void)
 
 	stream_free(bgp_dump_obuf);
 	bgp_dump_obuf = NULL;
+	hook_unregister(bgp_packet_dump, bgp_dump_packet);
 }


### PR DESCRIPTION
restores clean memory on bgpd exit
(issue introduced in #4640)