### PR TITLE
bgpd: fix implicit declaration warning

### DIFF
--- a/bgpd/bgp_labelpool.c
+++ b/bgpd/bgp_labelpool.c
@@ -34,6 +34,7 @@
 #include "bgpd/bgp_labelpool.h"
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_errors.h"
+#include "bgpd/bgp_route.h"
 
 /*
  * Definitions and external declarations.


### PR DESCRIPTION
Add header with prototype for bgp_path_info_unlock

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>