### PR TITLE
vrrpd: set interface ifindex to internal upon deletion

### DIFF
--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -208,6 +208,8 @@ static int vrrp_zebra_if_address_del(int command, struct zclient *client,
 
 	vrrp_if_address_del(c->ifp);
 
+	if_set_index(c->ifp, IFINDEX_INTERNAL);
+
 	return 0;
 }
 


### PR DESCRIPTION
Redux #4041, but for VRRP

Fixes #4644 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>