### PR TITLE
[7.1] lib: fix outdated candidate configuration issue

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1052,9 +1052,16 @@ static int cmd_execute_command_real(vector vline, enum cmd_filter_type filter,
 	if (matched_element->daemon)
 		ret = CMD_SUCCESS_DAEMON;
 	else {
-		/* Clear enqueued configuration changes. */
-		vty->num_cfg_changes = 0;
-		memset(&vty->cfg_changes, 0, sizeof(vty->cfg_changes));
+		if (vty->config) {
+			/* Clear array of enqueued configuration changes. */
+			vty->num_cfg_changes = 0;
+			memset(&vty->cfg_changes, 0, sizeof(vty->cfg_changes));
+
+			/* Regenerate candidate configuration. */
+			if (frr_get_cli_mode() == FRR_CLI_CLASSIC)
+				nb_config_replace(vty->candidate_config,
+						  running_config, true);
+		}
 
 		ret = matched_element->func(matched_element, vty, argc, argv);
 	}

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2308,6 +2308,7 @@ static void vty_read_file(struct nb_config *config, FILE *confp)
 	vty->wfd = STDERR_FILENO;
 	vty->type = VTY_FILE;
 	vty->node = CONFIG_NODE;
+	vty->config = true;
 	if (config)
 		vty->candidate_config = config;
 	else {


### PR DESCRIPTION
Somehow this fix didn't make it to 7.1. Fix this now (original PR is #4506).