### PR TITLE
zebra: Add a conditional guard if zvrf lookup fail

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -811,7 +811,9 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 	}
 
 	if (IS_ZEBRA_DEBUG_KERNEL) {
-		struct interface *ifp;
+		struct interface *ifp = NULL;
+		struct zebra_vrf *zvrf = NULL;
+
 		strlcpy(sbuf, inet_ntoa(m->sg.src), sizeof(sbuf));
 		strlcpy(gbuf, inet_ntoa(m->sg.grp), sizeof(gbuf));
 		for (count = 0; count < oif_count; count++) {
@@ -822,13 +824,14 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 				oif[count]);
 			strlcat(oif_list, temp, sizeof(oif_list));
 		}
-		struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(vrf);
+		zvrf = zebra_vrf_lookup_by_id(vrf);
 		ifp = if_lookup_by_index(iif, vrf);
-		zlog_debug("MCAST VRF: %s(%d) %s (%s,%s) IIF: %s(%d) OIF: %s jiffies: %lld",
-			   zvrf->vrf->name, vrf,
-			   nl_msg_type_to_str(h->nlmsg_type),
-			   sbuf, gbuf, ifp ? ifp->name : "Unknown", iif,
-			   oif_list, m->lastused);
+		zlog_debug(
+			"MCAST VRF: %s(%d) %s (%s,%s) IIF: %s(%d) OIF: %s jiffies: %lld",
+			(zvrf ? zvrf->vrf->name : "Unknown"), vrf,
+			nl_msg_type_to_str(h->nlmsg_type), sbuf, gbuf,
+			ifp ? ifp->name : "Unknown", iif, oif_list,
+			m->lastused);
 	}
 	return 0;
 }


### PR DESCRIPTION
Add a conditional to guard against segfaulting on the debug
statement when zvrf lookup fails.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>