### PR TITLE
bgpd: fix show bgp l2vpn evpn route json

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2480,7 +2480,9 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 					bgp_evpn_show_route_header(vty, bgp,
 								   tbl_ver,
 								   json);
-					vty_out(vty, "%19s Extended Community\n"
+					if (!json)
+						vty_out(vty,
+							"%19s Extended Community\n"
 							, " ");
 					header = 0;
 				}


### PR DESCRIPTION
PR-4544 has introduced a new filed extended community
in show bgp l2vpn evpn route command.
The header has missed checking json is enabled.


Testing Done:

```
TORS1# show bgp l2vpn evpn route json
{
  "27.0.0.15:8":{
    "rd":"27.0.0.15:8",
    "[2]:[0]:[48]:[00:02:00:00:00:0a]":{
      "prefix":"[2]:[0]:[48]:[00:02:00:00:00:0a]",
      "prefixLen":288,
      "paths":[
        [
          {
            "valid":true,
            "bestpath":true,
            "pathFrom":"external",
            "routeType":2,
            "ethTag":0,
            "macLen":48,
            "mac":"00:02:00:00:00:0a",
            "weight":32768,
            "peerId":"(unspec)",
            "aspath":"",
            "path":"",
            "origin":"IGP",
            "extendedCommunity":{
              "string":"ET:8 RT:5550:1002"
            },
            "nexthops":[
              {
                "ip":"27.0.0.15",
                "afi":"ipv4",
                "used":true
              }
            ]
          }
        ]
      ]
    },
   ...
  },
  "numPrefix":187,
  "numPaths":343
}
```
Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>