### PR TITLE
pimd: handle endianness in pim header structure

### DIFF
--- a/pimd/pim_msg.h
+++ b/pimd/pim_msg.h
@@ -42,7 +42,7 @@ enum pim_msg_address_family {
 };
 
 /*
- * Network Order pim_msg_hdr
+ * pim_msg_hdr
  * =========================
  *  PIM Header definition as per RFC 5059. N bit introduced to indicate
  *  do-not-forward option in PIM Boot strap Message.
@@ -53,10 +53,19 @@ enum pim_msg_address_family {
  *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  */
 struct pim_msg_header {
+#if (BYTE_ORDER == LITTLE_ENDIAN)
 	uint8_t type : 4;
 	uint8_t ver : 4;
+	uint8_t reserved : 7;
+	uint8_t Nbit : 1; /* No Fwd Bit */
+#elif (BYTE_ORDER == BIG_ENDIAN)
+	uint8_t ver : 4;
+	uint8_t type : 4;
 	uint8_t Nbit : 1; /* No Fwd Bit */
 	uint8_t reserved : 7;
+#else
+#error"Please set byte order"
+#endif
 	uint16_t checksum;
 } __attribute__((packed));
 
@@ -79,9 +88,17 @@ struct pim_encoded_ipv4_unicast {
 struct pim_encoded_group_ipv4 {
 	uint8_t family;
 	uint8_t ne;
+#if (BYTE_ORDER == LITTLE_ENDIAN)
+	uint8_t sz : 1;	/* scope zone bit */
+	uint8_t reserved : 6;	/* Reserved */
+	uint8_t bidir : 1;	/* Bidir bit */
+#elif (BYTE_ORDER == BIG_ENDIAN)
 	uint8_t bidir : 1;	/* Bidir bit */
 	uint8_t reserved : 6;	/* Reserved */
 	uint8_t sz : 1;		/* scope zone bit */
+#else
+#error"Please set byte order"
+#endif
 	uint8_t mask;
 	struct in_addr addr;
 } __attribute__((packed));


### PR DESCRIPTION
structures with bit fields in pim_msg.h should consider endianness

Signed-off-by: Binu <binu_abraham@looptelecom.com>