### PR TITLE
ldpd: Fix to release MPLS label if its not used anymore

### DIFF
--- a/ldpd/lde.h
+++ b/ldpd/lde.h
@@ -147,6 +147,7 @@ void		 lde_imsg_compose_parent_sync(int, pid_t, void *, uint16_t);
 int		 lde_imsg_compose_ldpe(int, uint32_t, pid_t, void *, uint16_t);
 int		 lde_acl_check(char *, int, union ldpd_addr *, uint8_t);
 uint32_t	 lde_update_label(struct fec_node *);
+void		 lde_free_label(uint32_t label);
 void		 lde_send_change_klabel(struct fec_node *, struct fec_nh *);
 void		 lde_send_delete_klabel(struct fec_node *, struct fec_nh *);
 void		 lde_fec2map(struct fec *, struct map *);

--- a/ldpd/lde_lib.c
+++ b/ldpd/lde_lib.c
@@ -919,6 +919,9 @@ lde_gc_timer(struct thread *thread)
 		    !RB_EMPTY(lde_map_head, &fn->upstream))
 			continue;
 
+		if (fn->local_label != NO_LABEL)
+			lde_free_label(fn->local_label);
+
 		fec_remove(&ft, &fn->fec);
 		free(fn);
 		count++;


### PR DESCRIPTION
LDP should release labels allocated from zebra if its not getting used.

Signed-off-by: Binu <binu_abraham@looptelecom.com>