### PR TITLE
ospfd,ripd: Enabling openssl library for md5 authentication in RIP and OSPF

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -572,6 +572,20 @@ AC_ARG_ENABLE([thread-sanitizer],
   AS_HELP_STRING([--enable-thread-sanitizer], [enable ThreadSanitizer support for detecting data races]))
 AC_ARG_ENABLE([memory-sanitizer],
   AS_HELP_STRING([--enable-memory-sanitizer], [enable MemorySanitizer support for detecting uninitialized memory reads]))
+AC_ARG_WITH([crypto],
+  AS_HELP_STRING([--with-crypto=<internal|openssl>], [choose between different implementations of cryptographic functions(default value is --with-crypto=internal)]))
+
+#if openssl, else use the internal
+AS_IF([test x"${with_crypto}" = x"openssl"], [
+AC_CHECK_LIB([crypto], [EVP_DigestInit], [LIBS="$LIBS -lcrypto"], [], [])
+if test $ac_cv_lib_crypto_EVP_DigestInit = no; then
+  AC_MSG_ERROR([build with openssl has been specified but openssl library was not found on your system])
+else
+  AC_DEFINE([CRYPTO_OPENSSL], [1], [Compile with openssl support])
+fi
+], [test x"${with_crypto}" = x"internal" || test x"${with_crypto}" = x"" ], [AC_DEFINE([CRYPTO_INTERNAL], [1], [Compile with internal cryptographic implementation])
+], [AC_MSG_ERROR([Unknown value for --with-crypto])]
+)
 
 AS_IF([test "${enable_clippy_only}" != "yes"], [
 AC_CHECK_HEADERS([json-c/json.h])

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -134,6 +134,10 @@ typedef unsigned char uint8_t;
 #endif
 #endif
 
+#ifdef CRYPTO_OPENSSL
+#include <openssl/evp.h>
+#endif
+
 #include "openbsd-tree.h"
 
 #include <netinet/in.h>

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -37,7 +37,9 @@
 #include "if_rmap.h"
 #include "plist.h"
 #include "distribute.h"
+#ifdef CRYPTO_INTERNAL
 #include "md5.h"
+#endif
 #include "keychain.h"
 #include "privs.h"
 #include "lib_errors.h"
@@ -870,7 +872,11 @@ static int rip_auth_md5(struct rip_packet *packet, struct sockaddr_in *from,
 	struct rip_md5_data *md5data;
 	struct keychain *keychain;
 	struct key *key;
+#ifdef CRYPTO_OPENSSL
+	EVP_MD_CTX *ctx;
+#elif CRYPTO_INTERNAL
 	MD5_CTX ctx;
+#endif
 	uint8_t digest[RIP_AUTH_MD5_SIZE];
 	uint16_t packet_len;
 	char auth_str[RIP_AUTH_MD5_SIZE] = {};
@@ -934,11 +940,21 @@ static int rip_auth_md5(struct rip_packet *packet, struct sockaddr_in *from,
 		return 0;
 
 	/* MD5 digest authentication. */
+#ifdef CRYPTO_OPENSSL
+	unsigned int md5_size = RIP_AUTH_MD5_SIZE;
+	ctx = EVP_MD_CTX_new();
+	EVP_DigestInit(ctx, EVP_md5());
+	EVP_DigestUpdate(ctx, packet, packet_len + RIP_HEADER_SIZE);
+	EVP_DigestUpdate(ctx, auth_str, RIP_AUTH_MD5_SIZE);
+	EVP_DigestFinal(ctx, digest, &md5_size);
+	EVP_MD_CTX_free(ctx);
+#elif CRYPTO_INTERNAL
 	memset(&ctx, 0, sizeof(ctx));
 	MD5Init(&ctx);
 	MD5Update(&ctx, packet, packet_len + RIP_HEADER_SIZE);
 	MD5Update(&ctx, auth_str, RIP_AUTH_MD5_SIZE);
 	MD5Final(digest, &ctx);
+#endif
 
 	if (memcmp(md5data->digest, digest, RIP_AUTH_MD5_SIZE) == 0)
 		return packet_len;
@@ -1063,7 +1079,11 @@ static void rip_auth_md5_set(struct stream *s, struct rip_interface *ri,
 			     size_t doff, char *auth_str, int authlen)
 {
 	unsigned long len;
+#ifdef CRYPTO_OPENSSL
+	EVP_MD_CTX *ctx;
+#elif CRYPTO_INTERNAL
 	MD5_CTX ctx;
+#endif
 	unsigned char digest[RIP_AUTH_MD5_SIZE];
 
 	/* Make it sure this interface is configured as MD5
@@ -1092,11 +1112,21 @@ static void rip_auth_md5_set(struct stream *s, struct rip_interface *ri,
 	stream_putw(s, RIP_AUTH_DATA);
 
 	/* Generate a digest for the RIP packet. */
+#ifdef CRYPTO_OPENSSL
+	unsigned int md5_size = RIP_AUTH_MD5_SIZE;
+	ctx = EVP_MD_CTX_new();
+	EVP_DigestInit(ctx, EVP_md5());
+	EVP_DigestUpdate(ctx, STREAM_DATA(s), stream_get_endp(s));
+	EVP_DigestUpdate(ctx, auth_str, RIP_AUTH_MD5_SIZE);
+	EVP_DigestFinal(ctx, digest, &md5_size);
+	EVP_MD_CTX_free(ctx);
+#elif CRYPTO_INTERNAL
 	memset(&ctx, 0, sizeof(ctx));
 	MD5Init(&ctx);
 	MD5Update(&ctx, STREAM_DATA(s), stream_get_endp(s));
 	MD5Update(&ctx, auth_str, RIP_AUTH_MD5_SIZE);
 	MD5Final(digest, &ctx);
+#endif
 
 	/* Copy the digest to the packet. */
 	stream_write(s, digest, RIP_AUTH_MD5_SIZE);


### PR DESCRIPTION
I have added openssl support for md5 authentication in RIP a OSPF. The openssl-enabled build is turned on with '--with-openssl' option in the configure script. It is disabled by default so that there is no change on distributions where this is not wanted. I tested this on Fedora 30 with FRR-7.1 and it works as expected.

I am planning to create another PR for IS-IS but I will need a little bit more time. I was planning to do this with EIGRP as well but it seems that the md5 authentication is broken. I will do PR for EIGRP as well once the issue is resolved.