### PR TITLE
tests: Topotests are not giving sufficient time to propagate data

### DIFF
--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -1157,7 +1157,7 @@ def verify_rib(tgen, addr_type, dut, input_dict, next_hop=None, protocol=None):
                 else:
                     command = "show ipv6 route json"
 
-            sleep(2)
+            sleep(10)
             logger.info("Checking router %s RIB:", router)
             rib_routes_json = rnode.vtysh_cmd(command, isjson=True)
 


### PR DESCRIPTION
A bunch of our current tests setup data and redistribute
it across some bgp connections and then test for it
being there.  A delay of 2 seconds that was initially
there to ensure that the data has propagated does not
actually work all the time when you have a loaded
virtualized environment.

Make the sleep 10 seconds.  I agree this is not the ideal
solution but I would rather get the damn tests up and running
again.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>