### PR TITLE
bgpd: [6.0] solve issue entering aggregate twice

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5481,6 +5481,9 @@ static int bgp_aggregate_info_same(struct bgp_info *ri, uint8_t origin,
 	if (!community_cmp(ri->attr->community, comm))
 		return 0;
 
+	if (!CHECK_FLAG(ri->flags, BGP_INFO_VALID))
+		return 0;
+
 	return 1;
 }
 


### PR DESCRIPTION
Problem reported that frr-relaod.py was not installing an aggregate
properly.  Problem was actually that frr-reload.py does the command
twice, and the second time the aggregate command was entered, it would
appear in the config but the aggregate was removed from the bgp table
and not advertised to peers.  Solved by noticing when an aggregate
was marked for deletion (info_invalid) and allowing the re-entry if
the old one was being removed.

Ticket: CM-22509
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>

Closes https://github.com/FRRouting/frr/issues/4679