### PR TITLE
ospfd: no router ospf crash fix

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -660,6 +660,14 @@ static int ospf_write(struct thread *thread)
 	struct in_pktinfo *pi;
 #endif
 
+	if (ospf->fd < 0 || ospf->oi_running == 0) {
+		if (IS_DEBUG_OSPF_EVENT)
+			zlog_debug(
+				"ospf_write failed to send, fd %d, instance %u"
+				,ospf->fd, ospf->oi_running);
+		return -1;
+	}
+
 	ospf->t_write = NULL;
 
 	node = listhead(ospf->oi_write_q);


### PR DESCRIPTION
no router ospf triggers to cancel all threads including read/write (receive/send packets) threads,
cleans up resources fd, message queue and data.

Last job of write (packet) thread invoked where the ospf instance is referenced is not running nor the socket fd valid.

Thread callback should check if fd is valid and ospf instance is running before proceeding to send a message over socket.

It should address issues [4542](https://github.com/FRRouting/frr/issues/4542) and [4248](https://github.com/FRRouting/frr/issues/4248)


Testing Done:

Performed the multiple 'no router ospf' with the fix in topology where the crash was seen.
Post fix the crash is not observed.

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>