### PR TITLE
tests: remove strlen assert in inet_ntop tests

### DIFF
--- a/tests/lib/test_ntop.c
+++ b/tests/lib/test_ntop.c
@@ -81,7 +81,6 @@ int main(int argc, char **argv)
 
 		assert(inet_pton(AF_INET6, buf1, &i6check));
 		assert(!memcmp(&i6, &i6check, sizeof(i6)));
-		assert(strlen(buf1) <= strlen(buf2));
 	}
 	return 0;
 }


### PR DESCRIPTION
Some platform libc's like to render some v6 addresses as v4 mapped where
others render the same addresses as v6 with leading zeroes. Binary
equivalence checks pass but strlen checks sometimes fail here. Remove
assert causing the failure.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>