### PR TITLE
Staticstuff

### DIFF
--- a/staticd/static_nht.h
+++ b/staticd/static_nht.h
@@ -20,6 +20,18 @@
 #ifndef __STATIC_NHT_H__
 #define __STATIC_NHT_H__
 
-extern void static_nht_update(struct prefix *p, uint32_t nh_num,
-			      afi_t afi, vrf_id_t vrf_id);
+/*
+ * When we get notification that nexthop tracking has an answer for
+ * us call this function to find the nexthop we are tracking so it
+ * can be installed or removed.
+ *
+ * sp -> The route we are looking at.  If NULL then look at all
+ *       routes.
+ * nhp -> The nexthop that is being tracked.
+ * nh_num -> number of valid nexthops.
+ * afi -> The afi we are working in.
+ * vrf_id -> The vrf the nexthop is in.
+ */
+extern void static_nht_update(struct prefix *sp, struct prefix *nhp,
+			      uint32_t nh_num, afi_t afi, vrf_id_t vrf_id);
 #endif

--- a/staticd/static_nht.h
+++ b/staticd/static_nht.h
@@ -34,4 +34,17 @@
  */
 extern void static_nht_update(struct prefix *sp, struct prefix *nhp,
 			      uint32_t nh_num, afi_t afi, vrf_id_t vrf_id);
+
+/*
+ * For the given tracked nexthop, nhp, mark all routes that use
+ * this route as in starting state again.
+ */
+extern void static_nht_reset_start(struct prefix *nhp, afi_t afi,
+				   vrf_id_t nh_vrf_id);
+
+/*
+ * For the given prefix, sp, mark it as in a particular state
+ */
+extern void static_nht_mark_state(struct prefix *sp, vrf_id_t vrf_id,
+				  enum static_install_states state);
 #endif

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -39,7 +39,7 @@ static void static_install_route(struct route_node *rn,
 	struct static_route *si;
 
 	for (si = rn->info; si; si = si->next)
-		static_zebra_nht_register(si, true);
+		static_zebra_nht_register(rn, si, true);
 
 	si = rn->info;
 	if (si)
@@ -242,7 +242,7 @@ int static_delete_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 		return 0;
 	}
 
-	static_zebra_nht_register(si, false);
+	static_zebra_nht_register(rn, si, false);
 
 	/* Unlink static route from linked list. */
 	if (si->prev)

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -183,7 +183,7 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 
 	/* check whether interface exists in system & install if it does */
 	if (!ifname)
-		static_install_route(rn, si, safi);
+		static_zebra_nht_register(rn, si, true);
 	else {
 		struct interface *ifp;
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -43,6 +43,8 @@
 #include "static_nht.h"
 #include "static_vty.h"
 
+bool debug;
+
 /* Zebra structure to hold current status. */
 struct zclient *zclient;
 static struct hash *static_nht_hash;
@@ -316,7 +318,10 @@ void static_zebra_nht_register(struct route_node *rn,
 				static_nht_hash_alloc);
 		nhtd->refcount++;
 
-		if (nhtd->refcount > 1) {
+		if (debug)
+			zlog_debug("Registered nexthop(%pFX) for %pRN %d", &p,
+				   rn, nhtd->nh_num);
+		if (nhtd->refcount > 1 && nhtd->nh_num) {
 			static_nht_update(&rn->p, nhtd->nh, nhtd->nh_num,
 					  afi, si->nh_vrf_id);
 			return;

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -210,7 +210,7 @@ static int static_zebra_nexthop_update(ZAPI_CALLBACK_ARGS)
 	if (nhtd) {
 		nhtd->nh_num = nhr.nexthop_num;
 
-		static_nht_update(&nhr.prefix, nhr.nexthop_num, afi,
+		static_nht_update(NULL, &nhr.prefix, nhr.nexthop_num, afi,
 				  nhtd->nh_vrf_id);
 	} else
 		zlog_err("No nhtd?");
@@ -267,7 +267,8 @@ static void static_nht_hash_free(void *data)
 	XFREE(MTYPE_TMP, nhtd);
 }
 
-void static_zebra_nht_register(struct static_route *si, bool reg)
+void static_zebra_nht_register(struct route_node *rn,
+			       struct static_route *si, bool reg)
 {
 	struct static_nht_data *nhtd, lookup;
 	uint32_t cmd;
@@ -316,7 +317,7 @@ void static_zebra_nht_register(struct static_route *si, bool reg)
 		nhtd->refcount++;
 
 		if (nhtd->refcount > 1) {
-			static_nht_update(nhtd->nh, nhtd->nh_num,
+			static_nht_update(&rn->p, nhtd->nh, nhtd->nh_num,
 					  afi, si->nh_vrf_id);
 			return;
 		}

--- a/staticd/static_zebra.h
+++ b/staticd/static_zebra.h
@@ -21,7 +21,8 @@
 
 extern struct thread_master *master;
 
-extern void static_zebra_nht_register(struct static_route *si, bool reg);
+extern void static_zebra_nht_register(struct route_node *rn,
+				      struct static_route *si, bool reg);
 
 extern void static_zebra_route_add(struct route_node *rn,
 				   struct static_route *si_changed,


### PR DESCRIPTION
Static routes when installing routes with the same nexthop we ended up with a n! number of route insertions/updates and changes.

Modify the code base to allow the insertion of a much higher level of allowed static routes.

In my test cases I have a config file with 11k routes, prior to these changes my home machine would have FRR stopped due to much memory being used. ( effectively we were passing so much data to zebra to install the routes that it would fill zebra's buffers up and we would fill up main memory ).  After these changes take:

```sharpd@robot ~/frr4> time vtysh -f foo.1
0.36user 0.06system 0:00.92elapsed 46%CPU (0avgtext+0avgdata 16548maxresident)k
0inputs+0outputs (0major+2662minor)pagefaults 0swaps
sharpd@robot ~/frr4> vtysh -c "show ip route summ"
Route Source         Routes               FIB  (vrf default)
kernel               1                    1                    
connected            2                    2                    
static               11115                11114                
ebgp                 760299               0                    
ibgp                 0                    0                    
------
Totals               771417               11117                

sharpd@robot ~/frr4> time vtysh -f foo.4
0.42user 0.08system 0:01.07elapsed 46%CPU (0avgtext+0avgdata 16428maxresident)k
0inputs+0outputs (0major+2661minor)pagefaults 0swaps
sharpd@robot ~/frr4> vtysh -c "show ip route summ"
Route Source         Routes               FIB  (vrf default)
kernel               1                    1                    
connected            2                    2                    
static               4                    3                    
ebgp                 771360               0                    
ibgp                 0                    0                    
------
Totals               771367               6                    ```

[foo.log](https://github.com/FRRouting/frr/files/3397028/foo.log)


