### PR TITLE
frr-reload.py: fix reload with different settings

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -393,8 +393,10 @@ end
         # is not the main router bgp block, but enabling multi-instance
         oneline_ctx_keywords = ("access-list ",
                                 "agentx",
+                                "allow-external-route-update",
                                 "bgp ",
                                 "debug ",
+                                "domainname ",
                                 "dump ",
                                 "enable ",
                                 "frr ",


### PR DESCRIPTION
## Commit Message

Add `allow-external-route-update` and `domainname` to the one line
context list, otherwise reload will fail when those commands show up in
the running configuration.

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>


## Summary

I've reproduced the problem with the following configuration:

**file: /etc/frr/frr.conf**
```
frr version 7.2-dev-debian-buster
frr defaults traditional
hostname frr-debian-10
no ip forwarding
no ipv6 forwarding
allow-external-route-update
!
router bgp 100
 bgp router-id 1.2.3.4
!
line vty
!
```

Now start FRR and configure the following:

```
vtysh
# configure terminal
config# router bgp 100
config(bgp)# neighbor 1.2.3.4 remote 200
```

Run `frr-reload.py`:

```
sudo /usr/lib/frr/frr-reload.py --reload /etc/frr/frr.conf
```

The configuration `neighbor 1.2.3.4 remote 200` should have gone away, however it doesn't. Same thing happens if you configure a `domainname`. You can make it appear on `show running-config` with the Linux command:

```
sudo domainname test
```


## Components

`tools`