### PR TITLE
Revert "bgpd: [7.1] Show `delete` sub-option for `set [l]comm-list <list> delete`"

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4320,12 +4320,9 @@ DEFUN (set_community_delete,
        "Delete matching communities\n")
 {
 	int idx_comm_list = 2;
-	char *args;
 
-	args = argv_concat(argv, argc, idx_comm_list);
 	generic_set_add(vty, VTY_GET_CONTEXT(route_map_index), "comm-list",
-			args);
-	XFREE(MTYPE_TMP, args);
+			argv[idx_comm_list]->arg);
 
 	return CMD_SUCCESS;
 }
@@ -4415,13 +4412,8 @@ DEFUN (set_lcommunity_delete,
        "Large Community-list name\n"
        "Delete matching large communities\n")
 {
-	int idx_lcomm_list = 2;
-	char *args;
-
-	args = argv_concat(argv, argc, idx_lcomm_list);
 	generic_set_add(vty, VTY_GET_CONTEXT(route_map_index),
-			"large-comm-list", args);
-	XFREE(MTYPE_TMP, args);
+			"large-comm-list", argv[2]->arg);
 
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
Reverts FRRouting/frr#4665
Related: https://github.com/FRRouting/frr/issues/4696