### PR TITLE
bgpd: Strip `delete` keyword when looking up for large communities

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2092,11 +2092,18 @@ static route_map_result_t route_set_lcommunity_delete(void *rule,
 static void *route_set_lcommunity_delete_compile(const char *arg)
 {
 	struct rmap_community *rcom;
+	char **splits;
+	int num;
+
+	frrstr_split(arg, " ", &splits, &num);
 
 	rcom = XCALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(struct rmap_community));
-
-	rcom->name = XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, arg);
+	rcom->name = XSTRDUP(MTYPE_ROUTE_MAP_COMPILED, splits[0]);
 	rcom->name_hash = bgp_clist_hash_key(rcom->name);
+
+	for (int i = 0; i < num; i++)
+		XFREE(MTYPE_TMP, splits[i]);
+	XFREE(MTYPE_TMP, splits);
 
 	return rcom;
 }


### PR DESCRIPTION
Related: https://github.com/FRRouting/frr/issues/4692
Related: https://github.com/FRRouting/frr/issues/4696

![issue_4692](https://user-images.githubusercontent.com/3352707/61457726-a4099200-a971-11e9-925e-2c6f0e58be7c.gif)

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>