### PR TITLE
vtysh: mark exit-vrf with end when using vtysh -m

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -851,11 +851,15 @@ int vtysh_mark_file(const char *filename)
 			return CMD_ERR_INCOMPLETE;
 		case CMD_SUCCESS:
 			vty_out(vty, "%s", vty->buf);
+			if (strmatch(vty_buf_trimmed, "exit-vrf"))
+				vty_out(vty, "end\n");
 			break;
 		case CMD_SUCCESS_DAEMON: {
 			int cmd_stat;
 
 			vty_out(vty, "%s", vty->buf);
+			if (strmatch(vty_buf_trimmed, "exit-vrf"))
+				vty_out(vty, "end\n");
 			cmd_stat = vtysh_client_execute(&vtysh_client[0],
 							vty->buf);
 			if (cmd_stat != CMD_SUCCESS)


### PR DESCRIPTION
VRF context blocks have a context-specific exit command in order to
explicitly force an exit to the top level config node. This command
exists because 'ip route' commands are accepted in both `VRF_NODE` and
`CONFIG_NODE`, so static routes intended to be accepted in `CONFIG_NODE`
that immediately follow a `VRF_NODE` block will be shoved into the
`VRF_NODE` block unless the VRF context is explicitly exited.

However, because this is a command that exits to `CONFIG_NODE`, `vtysh -m`
should be printing an `end` at the end of the context, since
`frr-reload.py` relies on this context ender to know when it's back in
`CONFIG_NODE`. But since this is the only explicit context exit command
that also exits to `CONFIG_NODE` we don't really have a good way of doing
this already. Hence this god-awful patch.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>