### PR TITLE
Fix zebra route redistribution of removed routes

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1680,20 +1680,15 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 	 * info.
 	 */
 	RNODE_FOREACH_RE(rn, rib) {
-
-		if (re == NULL) {
-			if (rib_route_match_ctx(rib, ctx, false))
-				re = rib;
-		}
-
+		if (re == NULL && rib_route_match_ctx(rib, ctx, false))
+			re = rib;
 		/* Check for old route match */
-		if (is_update && (old_re == NULL)) {
-			if (rib_route_match_ctx(rib, ctx, true /*is_update*/))
-				old_re = rib;
-		}
+		else if (is_update && old_re == NULL &&
+			 rib_route_match_ctx(rib, ctx, true /*is_update*/))
+			old_re = rib;
 
 		/* Have we found the routes we need to work on? */
-		if (re && ((!is_update || old_re)))
+		if (re && (!is_update || old_re))
 			break;
 	}
 


### PR DESCRIPTION
Zebra route redistribution can be incorrect when routes are removed.

A simple example of this is when a pair of OSPFv2 routers redistribute the same static route, but this also happens in more complex scenarios with redistribution between other routing protocols.

Example configuration for the first router:
```
hostname r1
router-id 0.0.0.1
!
ip route 10.1.1.1/32 lo
!
interface eth0
  ip address 10.0.0.1/24
!
router ospf
  network 10.0.0.0/24 area 0
  redistribute static
```

Example configuration for the second router:
```
hostname r2
router-id 0.0.0.2
!
ip route 10.1.1.1/32 lo
!
interface eth0
  ip address 10.0.0.2/24
!
router ospf
  network 10.0.0.0/24 area 0
  redistribute static
```

After the adjacency is full, on router `r1` do `no ip route 10.1.1.1/32 lo`.  Running the following show commands indicate that the external route for `10.1.1.1/32` is still being advertised (incorrectly), although the installed route is correct:
```
r1# show ip ospf database self-originate
...
                AS External Link States

Link ID         ADV Router      Age  Seq#       CkSum  Route
10.1.1.1        0.0.0.1          215 0x80000002 0xffaf E2 10.1.1.1/32 [0x0]
...
r1# sh ip route
...
O>* 10.1.1.1/32 [110/20] via 10.0.0.2, eth0, 00:05:58
```

Then on router `r2` also do `no ip route 10.1.1.1/32 lo`.  Now both routers are advertising a route to `10.1.1.1/32` incorrectly and a routing loop occurs:
```
r1# sh ip route
...
O>* 10.1.1.1/32 [110/20] via 10.0.0.2, eth0, 00:08:12
```
```
r2# sh ip route
...
O>* 10.1.1.1/32 [110/20] via 10.0.0.1, eth0, 00:08:16
```

These patches fix this issue.