### PR TITLE
List API add const and return object on `*_del`

### DIFF
--- a/lib/atomlist.h
+++ b/lib/atomlist.h
@@ -135,8 +135,10 @@ macro_inline void prefix ## _add_tail(struct prefix##_head *h, type *item)     \
 macro_inline void prefix ## _del_hint(struct prefix##_head *h, type *item,     \
 		_Atomic atomptr_t *hint)                                       \
 {	atomlist_del_hint(&h->ah, &item->field.ai, hint); }                    \
-macro_inline void prefix ## _del(struct prefix##_head *h, type *item)          \
-{	atomlist_del_hint(&h->ah, &item->field.ai, NULL); }                    \
+macro_inline type *prefix ## _del(struct prefix##_head *h, type *item)         \
+{	atomlist_del_hint(&h->ah, &item->field.ai, NULL);                      \
+	/* TODO: Return NULL if not found */                                   \
+	return item; }                                                         \
 macro_inline type *prefix ## _pop(struct prefix##_head *h)                     \
 {	char *p = (char *)atomlist_pop(&h->ah);                                \
 	return p ? (type *)(p - offsetof(type, field)) : NULL; }               \
@@ -273,9 +275,11 @@ macro_inline void prefix ## _del_hint(struct prefix##_head *h, type *item,     \
 {                                                                              \
 	atomsort_del_hint(&h->ah, &item->field.ai, hint);                      \
 }                                                                              \
-macro_inline void prefix ## _del(struct prefix##_head *h, type *item)          \
+macro_inline type *prefix ## _del(struct prefix##_head *h, type *item)         \
 {                                                                              \
 	atomsort_del_hint(&h->ah, &item->field.ai, NULL);                      \
+	/* TODO: Return NULL if not found */                                   \
+	return item;                                                           \
 }                                                                              \
 macro_inline size_t prefix ## _count(struct prefix##_head *h)                  \
 {                                                                              \

--- a/lib/typerb.c
+++ b/lib/typerb.c
@@ -333,9 +333,10 @@ color:
 	return (old);
 }
 
-void typed_rb_remove(struct rbt_tree *rbt, struct rb_entry *rbe)
+struct typed_rb_entry *typed_rb_remove(struct rbt_tree *rbt,
+				       struct rb_entry *rbe)
 {
-	rbe_remove(rbt, rbe);
+	return rbe_remove(rbt, rbe);
 }
 
 struct typed_rb_entry *typed_rb_insert(struct rbt_tree *rbt,

--- a/lib/typerb.h
+++ b/lib/typerb.h
@@ -133,7 +133,7 @@ macro_pure type *prefix ## _next_safe(struct prefix##_head *h, type *item)     \
 	re = item ? typed_rb_next(&item->field.re) : NULL;                     \
 	return container_of_null(re, type, field.re);                          \
 }                                                                              \
-macro_pure size_t prefix ## _count(struct prefix##_head *h)                    \
+macro_pure size_t prefix ## _count(const struct prefix##_head *h)              \
 {                                                                              \
 	return h->rr.count;                                                    \
 }                                                                              \

--- a/lib/typerb.h
+++ b/lib/typerb.h
@@ -43,7 +43,8 @@ struct typed_rb_entry *typed_rb_insert(struct typed_rb_root *,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b));
-void typed_rb_remove(struct typed_rb_root *, struct typed_rb_entry *rbe);
+struct typed_rb_entry *typed_rb_remove(struct typed_rb_root *,
+				       struct typed_rb_entry *rbe);
 struct typed_rb_entry *typed_rb_find(struct typed_rb_root *,
 		const struct typed_rb_entry *rbe,
 		int (*cmpfn)(
@@ -99,9 +100,11 @@ macro_inline type *prefix ## _find_lt(struct prefix##_head *h,                 \
 	re = typed_rb_find_lt(&h->rr, &item->field.re, cmpfn_nuq);             \
 	return container_of_null(re, type, field.re);                          \
 }                                                                              \
-macro_inline void prefix ## _del(struct prefix##_head *h, type *item)          \
+macro_inline type *prefix ## _del(struct prefix##_head *h, type *item)         \
 {                                                                              \
-	typed_rb_remove(&h->rr, &item->field.re);                              \
+	struct typed_rb_entry *re;                                             \
+	re = typed_rb_remove(&h->rr, &item->field.re);                         \
+	return container_of_null(re, type, field.re);                          \
 }                                                                              \
 macro_inline type *prefix ## _pop(struct prefix##_head *h)                     \
 {                                                                              \

--- a/lib/typerb.h
+++ b/lib/typerb.h
@@ -38,30 +38,30 @@ struct typed_rb_root {
 	size_t count;
 };
 
-struct typed_rb_entry *typed_rb_insert(struct typed_rb_root *,
+struct typed_rb_entry *typed_rb_insert(struct typed_rb_root *rbt,
 		struct typed_rb_entry *rbe,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b));
-struct typed_rb_entry *typed_rb_remove(struct typed_rb_root *,
+struct typed_rb_entry *typed_rb_remove(struct typed_rb_root *rbt,
 				       struct typed_rb_entry *rbe);
-struct typed_rb_entry *typed_rb_find(struct typed_rb_root *,
+struct typed_rb_entry *typed_rb_find(struct typed_rb_root *rbt,
 		const struct typed_rb_entry *rbe,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b));
-struct typed_rb_entry *typed_rb_find_gteq(struct typed_rb_root *,
+struct typed_rb_entry *typed_rb_find_gteq(struct typed_rb_root *rbt,
 		const struct typed_rb_entry *rbe,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b));
-struct typed_rb_entry *typed_rb_find_lt(struct typed_rb_root *,
+struct typed_rb_entry *typed_rb_find_lt(struct typed_rb_root *rbt,
 		const struct typed_rb_entry *rbe,
 		int (*cmpfn)(
 			const struct typed_rb_entry *a,
 			const struct typed_rb_entry *b));
-struct typed_rb_entry *typed_rb_min(struct typed_rb_root *);
-struct typed_rb_entry *typed_rb_next(struct typed_rb_entry *);
+struct typed_rb_entry *typed_rb_min(struct typed_rb_root *rbt);
+struct typed_rb_entry *typed_rb_next(struct typed_rb_entry *rbe);
 
 #define _PREDECL_RBTREE(prefix)                                                \
 struct prefix ## _head { struct typed_rb_root rr; };                           \

--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -150,7 +150,7 @@ macro_pure type *prefix ## _next_safe(struct prefix##_head *h, type *item)     \
 	sitem = &item->field.si;                                               \
 	return container_of_null(sitem->next, type, field.si);                 \
 }                                                                              \
-macro_pure size_t prefix ## _count(struct prefix##_head *h)                    \
+macro_pure size_t prefix ## _count(const struct prefix##_head *h)              \
 {                                                                              \
 	return h->sh.count;                                                    \
 }                                                                              \
@@ -252,7 +252,7 @@ macro_pure type *prefix ## _next_safe(struct prefix##_head *h, type *item)     \
 		return NULL;                                                   \
 	return prefix ## _next(h, item);                                       \
 }                                                                              \
-macro_pure size_t prefix ## _count(struct prefix##_head *h)                    \
+macro_pure size_t prefix ## _count(const struct prefix##_head *h)              \
 {                                                                              \
 	return h->dh.count;                                                    \
 }                                                                              \
@@ -357,7 +357,7 @@ macro_pure type *prefix ## _next_safe(struct prefix##_head *h, type *item)     \
 		return NULL;                                                   \
 	return prefix ## _next(h, item);                                       \
 }                                                                              \
-macro_pure size_t prefix ## _count(struct prefix##_head *h)                    \
+macro_pure size_t prefix ## _count(const struct prefix##_head *h)              \
 {                                                                              \
 	return h->hh.count;                                                    \
 }                                                                              \
@@ -489,7 +489,7 @@ macro_pure type *prefix ## _next_safe(struct prefix##_head *h, type *item)     \
 	sitem = &item->field.si;                                               \
 	return container_of_null(sitem->next, type, field.si);                 \
 }                                                                              \
-macro_pure size_t prefix ## _count(struct prefix##_head *h)                    \
+macro_pure size_t prefix ## _count(const struct prefix##_head *h)              \
 {                                                                              \
 	return h->sh.count;                                                    \
 }                                                                              \
@@ -680,7 +680,7 @@ macro_pure type *prefix ## _next_safe(struct prefix##_head *h, type *item)     \
 		return NULL;                                                   \
 	return prefix ## _next(h, item);                                       \
 }                                                                              \
-macro_pure size_t prefix ## _count(struct prefix##_head *h)                    \
+macro_pure size_t prefix ## _count(const struct prefix##_head *h)              \
 {                                                                              \
 	return h->hh.count;                                                    \
 }                                                                              \
@@ -783,7 +783,7 @@ macro_pure type *prefix ## _next_safe(struct prefix##_head *h, type *item)     \
 	next = item ? item->field.si.next[0] : NULL;                           \
 	return container_of_null(next, type, field.si);                        \
 }                                                                              \
-macro_pure size_t prefix ## _count(struct prefix##_head *h)                    \
+macro_pure size_t prefix ## _count(const struct prefix##_head *h)              \
 {                                                                              \
 	return h->sh.count;                                                    \
 }                                                                              \

--- a/tests/lib/test_typelist.h
+++ b/tests/lib/test_typelist.h
@@ -209,7 +209,7 @@ static void concat(test_, TYPE)(void)
 			assert(list_add(&head, &dummy) == &itm[j]);
 		else {
 			assert(list_add(&head, &dummy) == NULL);
-			list_del(&head, &dummy);
+			assert(list_del(&head, &dummy) != NULL);
 		}
 	}
 	ts_hashx("add-dup", "a538546a6e6ab0484e925940aa8dd02fd934408bbaed8cb66a0721841584d838");
@@ -255,7 +255,7 @@ static void concat(test_, TYPE)(void)
 					list_first(&head) == &dummy);
 		} else if (list_next(&head, &dummy))
 			assert(list_next(&head, &dummy)->val > j);
-		list_del(&head, &dummy);
+		assert(list_del(&head, &dummy) != NULL);
 	}
 	ts_hash("add-dup+find_{lt,gteq}", "a538546a6e6ab0484e925940aa8dd02fd934408bbaed8cb66a0721841584d838");
 #endif
@@ -295,7 +295,7 @@ static void concat(test_, TYPE)(void)
 		(void)prng_rand(prng);
 		j = prng_rand(prng) % NITEM;
 		if (itm[j].scratchpad == 1) {
-			list_del(&head, &itm[j]);
+			assert(list_del(&head, &itm[j]) != NULL);
 			itm[j].scratchpad = 0;
 			l++;
 		}
@@ -307,7 +307,7 @@ static void concat(test_, TYPE)(void)
 		assert(item->scratchpad != 0);
 
 		if (item->val & 1) {
-			list_del(&head, item);
+			assert(list_del(&head, item) != NULL);
 			item->scratchpad = 0;
 			l++;
 		}
@@ -333,7 +333,7 @@ static void concat(test_, TYPE)(void)
 	for (i = 0; i < NITEM / 2; i++) {
 		j = prng_rand(prng) % NITEM;
 		if (itm[j].scratchpad == 1) {
-			list_del(&head, &itm[j]);
+			assert(list_del(&head, &itm[j]) != NULL);
 			itm[j].scratchpad = 0;
 			k--;
 		}
@@ -371,7 +371,7 @@ static void concat(test_, TYPE)(void)
 	for (i = 0; i < NITEM / 2; i++) {
 		j = prng_rand(prng) % NITEM;
 		if (itm[j].scratchpad == 1) {
-			list_del(&head, &itm[j]);
+			assert(list_del(&head, &itm[j]) != NULL);
 			itm[j].scratchpad = 0;
 			k--;
 		}
@@ -424,7 +424,7 @@ static void concat(test_, TYPE)(void)
 				item = &itm[j];
 				if (item->scratchpad == 0)
 					continue;
-				list_del(&head, item);
+				assert(list_del(&head, item) != NULL);
 			}
 			item->scratchpad = 0;
 			k--;
@@ -469,7 +469,7 @@ static void concat(test_, TYPE)(void)
 				item = &itm[j];
 				if (item->scratchpad == 0)
 					continue;
-				list_del(&head, item);
+				assert(list_del(&head, item) != NULL);
 			}
 			item->scratchpad = 0;
 			k--;


### PR DESCRIPTION
Add const where appropriate to the new list APIs.

We were not implementing the `*_del()` API according to our docs here: http://docs.frrouting.org/projects/dev-guide/en/latest/lists.html#c.Z_del

This patch implements `*_del` appropriately for all but the atomic list API. For that, it will return the object that was passed, but no `NULL` return is done if its not found in the list. This will remain a **TODO** for someone who has a better understanding of the atomic code path.
