### PR TITLE
vtysh: only show error codes once

### DIFF
--- a/lib/ferr.c
+++ b/lib/ferr.c
@@ -126,10 +126,8 @@ void log_ref_display(struct vty *vty, uint32_t code, bool json)
 
 	if (code) {
 		ref = log_ref_get(code);
-		if (!ref) {
-			vty_out(vty, "Code %"PRIu32" - Unknown\n", code);
+		if (!ref)
 			return;
-		}
 		listnode_add(errlist, ref);
 	}
 
@@ -197,8 +195,6 @@ void log_ref_init(void)
 				   "Error Reference Texts");
 	}
 	pthread_mutex_unlock(&refs_mtx);
-
-	install_element(VIEW_NODE, &show_error_code_cmd);
 }
 
 void log_ref_fini(void)
@@ -211,6 +207,12 @@ void log_ref_fini(void)
 	}
 	pthread_mutex_unlock(&refs_mtx);
 }
+
+void log_ref_vty_init(void)
+{
+	install_element(VIEW_NODE, &show_error_code_cmd);
+}
+
 
 const struct ferr *ferr_get_last(ferr_r errval)
 {

--- a/lib/ferr.h
+++ b/lib/ferr.h
@@ -158,6 +158,7 @@ void log_ref_display(struct vty *vty, uint32_t code, bool json);
  */
 void log_ref_init(void);
 void log_ref_fini(void);
+void log_ref_vty_init(void);
 
 /* get error details.
  *

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -681,6 +681,7 @@ struct thread_master *frr_init(void)
 	log_filter_cmd_init();
 
 	log_ref_init();
+	log_ref_vty_init();
 	lib_error_init();
 
 	yang_init();

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2404,12 +2404,14 @@ DEFUN (vtysh_show_error_code,
 	if (arg < LIB_FERR_START || arg > LIB_FERR_END) {
 		char *fcmd = argv_concat(argv, argc, 0);
 		char cmd[256];
+
 		snprintf(cmd, sizeof(cmd), "do %s", fcmd);
 		show_per_daemon(cmd, "");
 		XFREE(MTYPE_TMP, fcmd);
 		/* Otherwise, print it ourselves to avoid duplication */
 	} else {
 		bool json = strmatch(argv[argc - 1]->text, "json");
+
 		if (!strmatch(argv[2]->text, "all"))
 			arg = strtoul(argv[2]->arg, NULL, 10);
 

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -47,6 +47,8 @@
 #include "linklist.h"
 #include "memory_vty.h"
 #include "libfrr.h"
+#include "ferr.h"
+#include "lib_errors.h"
 
 #include "vtysh/vtysh.h"
 #include "vtysh/vtysh_user.h"
@@ -461,6 +463,9 @@ int main(int argc, char **argv, char **env)
 		vtysh_read_config(vtysh_config);
 		suid_off();
 	}
+	/* Error code library system */
+	log_ref_init();
+	lib_error_init();
 
 	if (markfile) {
 		if (!inputfile) {


### PR DESCRIPTION
When using `show error` commands, show errors shared between multiple
daemons only once.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>