### PR TITLE
bgpd: solve invalid error message when clearing interface peer

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7287,6 +7287,9 @@ DEFUN (clear_ip_bgp_all,
 	} else if (argv_find(argv, argc, "PGNAME", &idx)) {
 		clr_sort = clear_peer;
 		clr_arg = argv[idx]->arg;
+	} else if (argv_find(argv, argc, "WORD", &idx)) {
+		clr_sort = clear_peer;
+		clr_arg = argv[idx]->arg;
 	} else if (argv_find(argv, argc, "(1-4294967295)", &idx)) {
 		clr_sort = clear_as;
 		clr_arg = argv[idx]->arg;


### PR DESCRIPTION
Problem reported that if "clear bgp swp1" is issued, an error
message is received saying the name or address is malformed. This
was because of a change in bgp_vty.c that removed the storing
and passing of the interface name for this command. Commit that
caused the problem was ac5dec7e88ce2f8cd2943bb61437046718fb34c2.

Ticket: CM-25737
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>