### PR TITLE
zebra: skip queued entries when resolving nexthop

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1364,6 +1364,7 @@ static void zebra_rib_fixup_system(struct route_node *rn)
 			continue;
 
 		SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+		UNSET_FLAG(re->status, ROUTE_ENTRY_QUEUED);
 
 		for (ALL_NEXTHOPS(re->ng, nhop)) {
 			if (CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_RECURSIVE))

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -465,6 +465,7 @@ zebra_rnh_resolve_import_entry(struct zebra_vrf *zvrf, afi_t afi,
 	RNODE_FOREACH_RE (rn, re) {
 		if (!CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED)
 		    && CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED)
+		    && !CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED)
 		    && (re->type != ZEBRA_ROUTE_BGP))
 			break;
 	}
@@ -675,6 +676,14 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 					zlog_debug(
 						"\tRoute Entry %s !selected",
+						zebra_route_string(re->type));
+				continue;
+			}
+
+			if (CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED)) {
+				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
+					zlog_debug(
+						"\tRoute Entry %s queued",
 						zebra_route_string(re->type));
 				continue;
 			}


### PR DESCRIPTION
Problem reported where certain routes were not being passed on to
clients if they were operated on while still queued for kernel
installation.   Changed it to defer working on entries that were
queued to dplane so we could operate on them after getting an
answer back from kernel installation.

Ticket: CM-25480
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>