### PR TITLE
topotest: fix bgp-path-attributes-topology

### DIFF
--- a/tests/topotests/bgp-path-attributes-topo1/test_bgp_path_attributes.py
+++ b/tests/topotests/bgp-path-attributes-topo1/test_bgp_path_attributes.py
@@ -218,11 +218,8 @@ def test_next_hop_attribute(request):
     # Verifying RIB routes
     dut = "r1"
     protocol = "bgp"
-    result = verify_rib(tgen, "ipv4", dut, input_dict, protocol=protocol)
-    try:
-        assert result is True
-    except AssertionError:
-        logger.info("Expected behaviour: %s", result)
+    result = verify_rib(tgen, "ipv4", dut, input_dict, protocol=protocol, expected=False)
+    assert result is not True
 
     # Configure next-hop-self to bgp neighbor
     input_dict_1 = {


### PR DESCRIPTION
## Summary

Fix BGP Path attributes topology test to avoid spending 5 minutes on bogus test.


## Commit Message

The first RIB check wants to assert that we don't have the r7's routes
in r1, so right after that code the routers r2 and r3 are configured
then `verify_rib` is called again to check for those routes.

This test never passed, but it didn't cause failures because of the
`try`/`except`.

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>


## Components

`topotest`