### PR TITLE
zebra: implement pref64/NAT64 RA option

### DIFF
--- a/lib/compiler.h
+++ b/lib/compiler.h
@@ -165,6 +165,13 @@ extern "C" {
 		_min_a < _min_b ? _min_a : _min_b;                             \
 	})
 
+#define numcmp(a, b)                                                           \
+	({                                                                     \
+		typeof(a) _cmp_a = (a);                                        \
+		typeof(b) _cmp_b = (b);                                        \
+		(_cmp_a < _cmp_b) ? -1 : ((_cmp_a > _cmp_b) ? 1 : 0);          \
+	})
+
 #ifndef offsetof
 #ifdef __compiler_offsetof
 #define offsetof(TYPE, MEMBER) __compiler_offsetof(TYPE,MEMBER)

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -628,8 +628,11 @@ int prefix_match_network_statement(const struct prefix *n,
 	return 1;
 }
 
-void prefix_copy(struct prefix *dest, const struct prefix *src)
+void prefix_copy(union prefixptr udest, union prefixconstptr usrc)
 {
+	struct prefix *dest = udest.p;
+	const struct prefix *src = usrc.p;
+
 	dest->family = src->family;
 	dest->prefixlen = src->prefixlen;
 
@@ -674,8 +677,11 @@ void prefix_copy(struct prefix *dest, const struct prefix *src)
  * the same.  Note that this routine has the same return value sense
  * as '==' (which is different from prefix_cmp).
  */
-int prefix_same(const struct prefix *p1, const struct prefix *p2)
+int prefix_same(union prefixconstptr up1, union prefixconstptr up2)
 {
+	const struct prefix *p1 = up1.p;
+	const struct prefix *p2 = up2.p;
+
 	if ((p1 && !p2) || (!p1 && p2))
 		return 0;
 
@@ -722,8 +728,10 @@ int prefix_same(const struct prefix *p1, const struct prefix *p2)
  * this routine has the same return sense as strcmp (which is different
  * from prefix_same).
  */
-int prefix_cmp(const struct prefix *p1, const struct prefix *p2)
+int prefix_cmp(union prefixconstptr up1, union prefixconstptr up2)
 {
+	const struct prefix *p1 = up1.p;
+	const struct prefix *p2 = up2.p;
 	int offset;
 	int shift;
 	int i;

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -410,10 +410,10 @@ extern const char *prefix2str(union prefixconstptr, char *, int);
 extern int prefix_match(const struct prefix *, const struct prefix *);
 extern int prefix_match_network_statement(const struct prefix *,
 					  const struct prefix *);
-extern int prefix_same(const struct prefix *, const struct prefix *);
-extern int prefix_cmp(const struct prefix *, const struct prefix *);
+extern int prefix_same(union prefixconstptr, union prefixconstptr);
+extern int prefix_cmp(union prefixconstptr, union prefixconstptr);
 extern int prefix_common_bits(const struct prefix *, const struct prefix *);
-extern void prefix_copy(struct prefix *dest, const struct prefix *src);
+extern void prefix_copy(union prefixptr, union prefixconstptr);
 extern void apply_mask(struct prefix *);
 
 extern struct prefix *sockunion2prefix(const union sockunion *dest,

--- a/lib/typesafe.h
+++ b/lib/typesafe.h
@@ -434,7 +434,7 @@ macro_inline type *prefix ## _find_gteq(struct prefix##_head *h,               \
 	struct ssort_item *sitem = h->sh.first;                                \
 	int cmpval = 0;                                                        \
 	while (sitem && (cmpval = cmpfn_nuq(                                   \
-			container_of(sitem, type, field.si), item) < 0))       \
+			container_of(sitem, type, field.si), item)) < 0)       \
 		sitem = sitem->next;                                           \
 	return container_of_null(sitem, type, field.si);                       \
 }                                                                              \
@@ -444,7 +444,7 @@ macro_inline type *prefix ## _find_lt(struct prefix##_head *h,                 \
 	struct ssort_item *prev = NULL, *sitem = h->sh.first;                  \
 	int cmpval = 0;                                                        \
 	while (sitem && (cmpval = cmpfn_nuq(                                   \
-			container_of(sitem, type, field.si), item) < 0))       \
+			container_of(sitem, type, field.si), item)) < 0)       \
 		sitem = (prev = sitem)->next;                                  \
 	return container_of_null(prev, type, field.si);                        \
 }                                                                              \
@@ -499,7 +499,7 @@ macro_inline type *prefix ## _find(struct prefix##_head *h, const type *item)  \
 	struct ssort_item *sitem = h->sh.first;                                \
 	int cmpval = 0;                                                        \
 	while (sitem && (cmpval = cmpfn(                                       \
-			container_of(sitem, type, field.si), item) < 0))       \
+			container_of(sitem, type, field.si), item)) < 0)       \
 		sitem = sitem->next;                                           \
 	if (!sitem || cmpval > 0)                                              \
 		return NULL;                                                   \

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -22,6 +22,7 @@
 #ifndef _ZEBRA_INTERFACE_H
 #define _ZEBRA_INTERFACE_H
 
+#include "typesafe.h"
 #include "redistribute.h"
 #include "vrf.h"
 #include "hook.h"
@@ -42,6 +43,9 @@ extern "C" {
 #define IF_ZEBRA_SHUTDOWN_ON     1
 
 #if defined(HAVE_RTADV)
+
+PREDECL_SORTLIST_UNIQ(pref64_advs)
+
 /* Router advertisement parameter.  From RFC4861, RFC6275 and RFC4191. */
 struct rtadvconf {
 	/* A flag indicating whether or not the router sends periodic Router
@@ -187,6 +191,11 @@ struct rtadvconf {
 	 * Default: empty list; do not emit DNSSL option
 	 */
 	struct list *AdvDNSSLList;
+
+	/* NAT64 prefix advertisements
+	 * [https://tools.ietf.org/html/draft-ietf-6man-ra-pref64-03]
+	 */
+	struct pref64_advs_head pref64_advs;
 
 	uint8_t inFastRexmit; /* True if we're rexmits faster than usual */
 

--- a/zebra/rtadv.h
+++ b/zebra/rtadv.h
@@ -101,6 +101,9 @@ struct nd_opt_homeagent_info { /* Home Agent info */
 #ifndef ND_OPT_DNSSL
 #define ND_OPT_DNSSL 31
 #endif
+#ifndef ND_OPT_PREF64
+#define ND_OPT_PREF64 253 /* XXX FIXME XXX*/
+#endif
 
 #ifndef HAVE_STRUCT_ND_OPT_RDNSS
 struct nd_opt_rdnss { /* Recursive DNS server option [RFC8106 5.1] */
@@ -126,7 +129,25 @@ struct nd_opt_dnssl { /* DNS search list option [RFC8106 5.2] */
 } __attribute__((__packed__));
 #endif
 
+#if 1 /* not in a system header yet */
+struct nd_opt_pref64 {
+	uint8_t nd_opt_pref64_type;
+	uint8_t nd_opt_pref64_len;
+	uint16_t nd_opt_pref64_lifetime;
+	uint8_t nd_opt_pref64_prefix[16];
+	uint8_t nd_opt_pref64_prefixlen;
+	uint8_t nd_opt_pref64_padding[3];
+} __attribute__((__packed__));
+#endif
+
 extern const char *rtadv_pref_strs[];
+
+struct pref64_adv {
+	struct pref64_advs_item itm;
+
+	struct prefix_ipv6 p;
+	uint16_t lifetime;
+};
 
 #endif /* HAVE_RTADV */
 

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -110,6 +110,9 @@ zebra/zebra_vty.$(OBJEXT): zebra/zebra_vty_clippy.c
 zebra/zebra_routemap_clippy.c: $(CLIPPY_DEPS)
 zebra/zebra_routemap.$(OBJEXT): zebra/zebra_routemap_clippy.c
 
+zebra/rtadv_clippy.c: $(CLIPPY_DEPS)
+zebra/rtadv.$(OBJEXT): zebra/rtadv_clippy.c
+
 noinst_HEADERS += \
 	zebra/connected.h \
 	zebra/debug.h \


### PR DESCRIPTION
https://tools.ietf.org/html/draft-ietf-6man-ra-pref64-03 (in WGLC)

No ICMPv6 option codepoint assigned yet, so can't be merged yet.

Also our RA code direly needs a cleanup...