### PR TITLE
bgpd: stop removing and replacing private asn if it matches the peer

### DIFF
--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -112,8 +112,9 @@ extern struct aspath *aspath_replace_specific_asn(struct aspath *aspath,
 						  as_t target_asn,
 						  as_t our_asn);
 extern struct aspath *aspath_replace_private_asns(struct aspath *aspath,
-						  as_t asn);
-extern struct aspath *aspath_remove_private_asns(struct aspath *aspath);
+						  as_t asn, as_t peer_asn);
+extern struct aspath *aspath_remove_private_asns(struct aspath *aspath,
+						 as_t peer_asn);
 extern int aspath_firstas_check(struct aspath *, as_t);
 extern int aspath_confed_check(struct aspath *);
 extern int aspath_left_confed_check(struct aspath *);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1366,7 +1366,7 @@ static void bgp_peer_remove_private_as(struct bgp *bgp, afi_t afi, safi_t safi,
 				    peer, afi, safi,
 				    PEER_FLAG_REMOVE_PRIVATE_AS_ALL_REPLACE))
 				attr->aspath = aspath_replace_private_asns(
-					attr->aspath, bgp->as);
+					attr->aspath, bgp->as, peer->as);
 
 			// The entire aspath consists of private ASNs so create
 			// an empty aspath
@@ -1377,7 +1377,7 @@ static void bgp_peer_remove_private_as(struct bgp *bgp, afi_t afi, safi_t safi,
 			// the private ASNs
 			else
 				attr->aspath = aspath_remove_private_asns(
-					attr->aspath);
+					attr->aspath, peer->as);
 		}
 
 		// 'all' was not specified so the entire aspath must be private
@@ -1388,7 +1388,7 @@ static void bgp_peer_remove_private_as(struct bgp *bgp, afi_t afi, safi_t safi,
 				    peer, afi, safi,
 				    PEER_FLAG_REMOVE_PRIVATE_AS_REPLACE))
 				attr->aspath = aspath_replace_private_asns(
-					attr->aspath, bgp->as);
+					attr->aspath, bgp->as, peer->as);
 			else
 				attr->aspath = aspath_empty_get();
 		}


### PR DESCRIPTION
Problems reported that if multiple peers have "remove-private-AS
replace-AS" with each other and all are using private asns, the as-path
gets hosed and continues to grow when a prefix is removed.  This fix
disallows removing and replacing the private asn if it matches the
peer's ASN so that normal as-path loop prevention will operate correctly.

Ticket: CM-25489
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>