### PR TITLE
vrrpd: set interface ifindex to internal upon interface deletion

### DIFF
--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -113,6 +113,8 @@ static int vrrp_zebra_if_del(int command, struct zclient *zclient,
 
 	vrrp_if_del(ifp);
 
+	if_set_index(ifp, IFINDEX_INTERNAL);
+
 	return 0;
 }
 
@@ -207,8 +209,6 @@ static int vrrp_zebra_if_address_del(int command, struct zclient *client,
 	vrrp_zebra_debug_if_dump_address(c->ifp, __func__);
 
 	vrrp_if_address_del(c->ifp);
-
-	if_set_index(c->ifp, IFINDEX_INTERNAL);
 
 	return 0;
 }


### PR DESCRIPTION
This fix was in the wrong place, we were scrubbing our ifindex when we got an address deletion instead of a full interface deletion. This was causing us to forget ifindexes when interfaces went down (since an interface down event generates address deletion events for all connected addrs) and subsequently lose the ability to query and change them.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>