### PR TITLE
tools: improve gen_northbound_callbacks

### DIFF
--- a/tools/gen_northbound_callbacks.c
+++ b/tools/gen_northbound_callbacks.c
@@ -153,6 +153,36 @@ static void generate_callback_name(struct lys_node *snode,
 	replace_hyphens_by_underscores(buffer);
 }
 
+static void generate_callback(const struct nb_callback_info *ncinfo,
+			      const char *cb_name)
+{
+	printf("static %s%s(%s)\n{\n",
+	       ncinfo->return_type, cb_name, ncinfo->arguments);
+
+	switch (ncinfo->operation) {
+	case NB_OP_CREATE:
+	case NB_OP_MODIFY:
+	case NB_OP_DESTROY:
+	case NB_OP_MOVE:
+		printf("\tswitch (event) {\n"
+		       "\tcase NB_EV_VALIDATE:\n"
+		       "\tcase NB_EV_PREPARE:\n"
+		       "\tcase NB_EV_ABORT:\n"
+		       "\tcase NB_EV_APPLY:\n"
+		       "\t\t/* TODO: implement me. */\n"
+		       "\t\tbreak;\n"
+		       "\t}\n\n"
+		       );
+		break;
+
+	default:
+		printf("\t/* TODO: implement me. */\n");
+		break;
+	}
+
+	printf("\treturn %s;\n}\n\n", ncinfo->return_value);
+}
+
 static int generate_callbacks(const struct lys_node *snode, void *arg)
 {
 	bool first = true;
@@ -192,14 +222,7 @@ static int generate_callbacks(const struct lys_node *snode, void *arg)
 
 		generate_callback_name((struct lys_node *)snode, cb->operation,
 				       cb_name, sizeof(cb_name));
-		printf("static %s%s(%s)\n"
-		       "{\n"
-		       "\t/* TODO: implement me. */\n"
-		       "\treturn %s;\n"
-		       "}\n\n",
-		       nb_callbacks[cb->operation].return_type, cb_name,
-		       nb_callbacks[cb->operation].arguments,
-		       nb_callbacks[cb->operation].return_value);
+		generate_callback(cb, cb_name);
 	}
 
 	return YANG_ITER_CONTINUE;

--- a/tools/gen_northbound_callbacks.c
+++ b/tools/gen_northbound_callbacks.c
@@ -238,17 +238,20 @@ static int generate_nb_nodes(const struct lys_node *snode, void *arg)
 			printf("\t\t{\n"
 			       "\t\t\t.xpath = \"%s\",\n",
 			       xpath);
+			printf("\t\t\t.cbs = {\n");
 			first = false;
 		}
 
 		generate_callback_name((struct lys_node *)snode, cb->operation,
 				       cb_name, sizeof(cb_name));
-		printf("\t\t\t.cbs.%s = %s,\n",
-		       nb_operation_name(cb->operation), cb_name);
+		printf("\t\t\t\t.%s = %s,\n", nb_operation_name(cb->operation),
+		       cb_name);
 	}
 
-	if (!first)
+	if (!first) {
+		printf("\t\t\t}\n");
 		printf("\t\t},\n");
+	}
 
 	return YANG_ITER_CONTINUE;
 }


### PR DESCRIPTION
## Summary

Three new improvements to our northbound code generator:

  * Allow user to specify YANG models path;
  * Generate struct initialization that works with old compilers;
  * Callbacks with multiple steps now include `switch`/`case` boiler plate;

More info below.


### Specify YANG Model Path

Allows developers to specify YANG search path, so we don't need to install the model while developing the YANG file.

```sh
cd frr
tools/gen_northbound_callbacks frr-XXX
# bad output
2019/07/30 15:42:00 unknown: [EC 100663318] yang_module_load: failed to load data model: frr-XXX
```

With search path:

```sh
cd frr
tools/gen_northbound_callbacks -p yang frr-XXX
# good output!
```


### Old Compilers Warning Fix

```c
// Old generated struct initialization:
const struct frr_yang_module_info frr_bfdd_info = {
        .name = "frr-bfdd",
        .nodes = {
                {
                        .xpath = "/frr-bfdd:bfdd/bfd",
                        .cbs.create = bfdd_bfd_create,
                        .cbs.destroy = bfdd_bfd_destroy,
                },
        // ...
        }
};

// New generated struct initialization code:
const struct frr_yang_module_info frr_bfdd_info = {
        .name = "frr-bfdd",
        .nodes = {
                {
                        .xpath = "/frr-bfdd:bfdd/bfd",
                        .cbs = {
                                .create = bfdd_bfd_create,
                                .destroy = bfdd_bfd_destroy,
                        }
                },
        // ...
        }
};
```


### Boiler Plate Code

```c
// Old generated code example:
/*
 * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/detection-multiplier
 */
static int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(enum nb_event event, const struct lyd_node *dnode, union nb_resource *resource)
{
        /* TODO: implement me. */
        return NB_OK;
}

// New generated code example:
/*
 * XPath: /frr-bfdd:bfdd/bfd/sessions/single-hop/detection-multiplier
 */
static int bfdd_bfd_sessions_single_hop_detection_multiplier_modify(enum nb_event event, const struct lyd_node *dnode, union nb_resource *resource)
{
        switch (event) {
        case NB_EV_VALIDATE:
        case NB_EV_PREPARE:
        case NB_EV_ABORT:
        case NB_EV_APPLY:
                /* TODO: implement me. */
                break;
        }

        return NB_OK;
}
```