### PR TITLE
doc: Fix ospf router-id doc suggestion

### DIFF
--- a/doc/user/ospf6d.rst
+++ b/doc/user/ospf6d.rst
@@ -195,7 +195,7 @@ Example of ospf6d configured on one interface and area:
     ipv6 ospf6 instance-id 0
    !
    router ospf6
-    router-id 212.17.55.53
+    ospf6 router-id 212.17.55.53
     area 0.0.0.0 range 2001:770:105:2::/64
     interface eth0 area 0.0.0.0
    !

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -69,7 +69,7 @@ The instance number should be specified in the config when addressing a particul
 .. code-block:: frr
 
    router ospf 5
-      router-id 1.2.3.4
+      ospf router-id 1.2.3.4
       area 0.0.0.0 authentication message-digest
       ...
 


### PR DESCRIPTION
The v2 and v3 ospf documentation was suggesting
that the user should use a deprecated command.

Fixes: #4734
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>