### PR TITLE
doc: fix "match as-path" documentation

### DIFF
--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -153,8 +153,8 @@ Route Map Match Command
 
    Matches the specified `ipv4_addr`.
 
-.. index:: match aspath AS_PATH
-.. clicmd:: match aspath AS_PATH
+.. index:: match as-path AS_PATH
+.. clicmd:: match as-path AS_PATH
 
    Matches the specified `as_path`.
 


### PR DESCRIPTION
The documentation says "match aspath" to match an AS path in a
route-map while the directive is "match as-path".

Signed-off-by: Vincent Bernat <vincent@bernat.ch>