### PR TITLE
Import check fixup

### DIFF
--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -71,7 +71,7 @@ keyword. At present, no sharp commands will be preserved in the config.
    be used for pop and forward operations when the specified label is seen.
 
 .. index:: sharp watch
-.. clicmd:: [no] sharp watch <nexthop|import> <A.B.C.D|X:X::X:X> [connected]
+.. clicmd:: [no] sharp watch <nexthop <A.B.C.D|X:X::X:X>|import <A.B.C.D/M:X:X::X:X/M> [connected]
 
    Instruct zebra to monitor and notify sharp when the specified nexthop is
    changed. The notification from zebra is written into the debug log.

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -917,7 +917,7 @@ void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
 	}
 
 	for (rn = route_top(table); rn; rn = route_next(rn)) {
-		if (p && prefix_cmp(&rn->p, p) != 0)
+		if (p && !prefix_match(&rn->p, p))
 			continue;
 
 		if (rn->info)


### PR DESCRIPTION
1) Allow sharp daemon to have a bit finer grain control of import-check watch statements
2) Fix display of `show ip import-check A.B.C.D` to allow it to match instead of compare