### PR TITLE
zebra: fix evpn dad clear cmd mac parsing

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2444,7 +2444,7 @@ DEFPY (clear_evpn_dup_addr,
 
 	zvrf = zebra_vrf_get_evpn();
 	if (vni_str) {
-		if (mac) {
+		if (!is_zero_mac(&mac->eth_addr)) {
 			ret = zebra_vxlan_clear_dup_detect_vni_mac(vty, zvrf,
 								   vni,
 								   &mac->eth_addr);


### PR DESCRIPTION
The changes came as part of PR #4730, checks
only variable mac, which is never null. Even
for ip version of cli hits "mac" case statement
and failing the clear cli.

Testing Done:

Before Fix:

VTEP-03# show evpn arp-cache vni 1002 duplicate
VNI 1002 #ARP (IPv4 and IPv6, local and remote) 1

IP                        Type   State    MAC               Remote VTEP
Seq #'s
11.11.11.11               remote active   aa:22:aa:aa:aa:aa 27.0.0.16
7/8

VTEP-03# clear evpn dup-addr vni 1002 ip 11.11.11.11
% Requested MAC does not exist in VNI 1002

Post fix:

VTEP-03# clear evpn dup-addr vni 1002 ip 11.11.11.11
VTEP-03#

VTEP-03# show evpn mac vni all duplicat
VNI 1002 #MACs (local and remote) 1

MAC               Type   Intf/Remote VTEP      VLAN  Seq #'s
aa:aa:aa:aa:aa:aa remote 27.0.0.16                   7/8

Post fix:

VTEP-03# clear evpn dup-addr vni 1002 mac aa:aa:aa:aa:aa:aa
VTEP-03#

VTEP-03# clear evpn dup-addr vni 1002 ip 11.11.11.11
VTEP-03#

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>