### PR TITLE
doc: Add warning to doc about v6 ecmp route deletion

### DIFF
--- a/doc/user/overview.rst
+++ b/doc/user/overview.rst
@@ -239,6 +239,13 @@ The indicators have the following semantics:
 * :mark:`CP` - control plane only (i.e. BGP route server / route reflector)
 * :mark:`N` - daemon/feature not supported by operating system
 
+.. Known Kernel Issues:
+
+- Linux
+   v6 Route Replacement - Linux kernels before 4.11 can cause issues with v6 route deletion when you
+   have ecmp routes installed into the kernel.  This especially becomes apparent if the route is being
+   transformed from one ecmp path to another.
+
 .. _supported-rfcs:
 
 Supported RFCs


### PR DESCRIPTION
Add a warning to the user documentation about v6 ecmp route
deletion and what version of the linux kernel that you should
be using.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>