### PR TITLE
zebra: Redistribution should be told about the old route

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1774,7 +1774,7 @@ static void rib_process_result(struct zebra_dplane_ctx *ctx)
 
 				/* Redistribute */
 				redistribute_update(dest_pfx, src_pfx,
-						    re, NULL);
+						    re, old_re);
 			}
 
 			/*


### PR DESCRIPTION
When we are sending a redistribute_update, pass the old_re in
so that if we still have it around we can update the calling protocol.

Test:

router ospf
  redistribute sharp
!

sharp install route 4.5.6.7 nexthop 192.168.201.1 1

Now add a `ip route 4.5.6.7/32 192.168.201.1`.
This causes zebra to replace the sharp route with the static route.
No update is sent to ospf and debug:
2019/08/01 19:02:38.271998 ZEBRA: 0:4.5.6.7/32: Redist update re 0x12fdbda0 (static), old 0x0 (None)

With fix:

2019/08/01 19:15:09.644499 ZEBRA: 0:4.5.6.7/32: Redist update re 0x1ba5bce0 (static), old 0x1beea4e0 (sharp)
2019/08/01 19:15:09.645462 OSPF: ospf_zebra_read_route: from client sharp: vrf_id 0, p 4.5.6.7/32

Ticket: CM-25847
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>