### PR TITLE
zebra: [6.0] Always resend nexthop information when registered

### DIFF
--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -211,10 +211,14 @@ void zebra_add_rnh_client(struct rnh *rnh, struct zserv *client,
 			   zebra_route_string(client->proto),
 			   rnh_str(rnh, buf, sizeof(buf)), type);
 	}
-	if (!listnode_lookup(rnh->client_list, client)) {
+	if (!listnode_lookup(rnh->client_list, client))
 		listnode_add(rnh->client_list, client);
-		send_client(rnh, client, type, vrf_id);
-	}
+
+	/*
+	 * We always need to respond with known information,
+	 * currently multiple daemons expect this behavior
+	 */
+	send_client(rnh, client, type, vrf_id);
 }
 
 void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client,


### PR DESCRIPTION
Always resend the nexthop information when we get a registration
event.  Multiple daemons expect this information.

Closes https://github.com/FRRouting/frr/issues/4762
Closes https://github.com/FRRouting/frr/issues/3264

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com.