### PR TITLE
bgpd: resolve memleak on show bgp vrf all ipv6 unicast summary json

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8202,14 +8202,14 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 }
 
 static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
-				      int safi, bool use_json,
-				      json_object *json)
+				      int safi, bool use_json)
 {
 	int is_first = 1;
 	int afi_wildcard = (afi == AFI_MAX);
 	int safi_wildcard = (safi == SAFI_MAX);
 	int is_wildcard = (afi_wildcard || safi_wildcard);
 	bool nbr_output = false;
+	json_object *json = NULL;
 
 	if (use_json && is_wildcard)
 		vty_out(vty, "{\n");
@@ -8221,6 +8221,10 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 		while (safi < SAFI_MAX) {
 			if (bgp_afi_safi_peer_exists(bgp, afi, safi)) {
 				nbr_output = true;
+
+				if (use_json)
+					json = json_object_new_object();
+
 				if (is_wildcard) {
 					/*
 					 * So limit output to those afi/safi
@@ -8229,8 +8233,6 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 					 * them
 					 */
 					if (use_json) {
-						json = json_object_new_object();
-
 						if (!is_first)
 							vty_out(vty, ",\n");
 						else
@@ -8272,7 +8274,6 @@ static void bgp_show_all_instances_summary_vty(struct vty *vty, afi_t afi,
 {
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
-	json_object *json = NULL;
 	int is_first = 1;
 	bool nbr_output = false;
 
@@ -8282,8 +8283,6 @@ static void bgp_show_all_instances_summary_vty(struct vty *vty, afi_t afi,
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
 		nbr_output = true;
 		if (use_json) {
-			json = json_object_new_object();
-
 			if (!is_first)
 				vty_out(vty, ",\n");
 			else
@@ -8299,7 +8298,7 @@ static void bgp_show_all_instances_summary_vty(struct vty *vty, afi_t afi,
 					? VRF_DEFAULT_NAME
 					: bgp->name);
 		}
-		bgp_show_summary_afi_safi(vty, bgp, afi, safi, use_json, json);
+		bgp_show_summary_afi_safi(vty, bgp, afi, safi, use_json);
 	}
 
 	if (use_json)
@@ -8330,8 +8329,8 @@ int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
 				return CMD_WARNING;
 			}
 
-			bgp_show_summary_afi_safi(vty, bgp, afi, safi, use_json,
-						  NULL);
+			bgp_show_summary_afi_safi(vty, bgp, afi, safi,
+						  use_json);
 			return CMD_SUCCESS;
 		}
 	}
@@ -8339,7 +8338,7 @@ int bgp_show_summary_vty(struct vty *vty, const char *name, afi_t afi,
 	bgp = bgp_get_default();
 
 	if (bgp)
-		bgp_show_summary_afi_safi(vty, bgp, afi, safi, use_json, NULL);
+		bgp_show_summary_afi_safi(vty, bgp, afi, safi, use_json);
 	else {
 		if (use_json)
 			vty_out(vty, "{}\n");

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7770,7 +7770,7 @@ static void bgp_show_bestpath_json(struct bgp *bgp, json_object *json)
 
 /* Show BGP peer's summary information. */
 static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
-			    bool use_json, json_object *json)
+			    bool use_json)
 {
 	struct peer *peer;
 	struct listnode *node, *nnode;
@@ -7781,6 +7781,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 	int len;
 	int max_neighbor_width = 0;
 	int pfx_rcd_safi;
+	json_object *json = NULL;
 	json_object *json_peer = NULL;
 	json_object *json_peers = NULL;
 	struct peer_af *paf;
@@ -7795,9 +7796,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 		pfx_rcd_safi = safi;
 
 	if (use_json) {
-		if (json == NULL)
-			json = json_object_new_object();
-
+		json = json_object_new_object();
 		json_peers = json_object_new_object();
 	} else {
 		/* Loop over all neighbors that will be displayed to determine
@@ -8209,7 +8208,6 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 	int safi_wildcard = (safi == SAFI_MAX);
 	int is_wildcard = (afi_wildcard || safi_wildcard);
 	bool nbr_output = false;
-	json_object *json = NULL;
 
 	if (use_json && is_wildcard)
 		vty_out(vty, "{\n");
@@ -8221,9 +8219,6 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 		while (safi < SAFI_MAX) {
 			if (bgp_afi_safi_peer_exists(bgp, afi, safi)) {
 				nbr_output = true;
-
-				if (use_json)
-					json = json_object_new_object();
 
 				if (is_wildcard) {
 					/*
@@ -8247,8 +8242,7 @@ static void bgp_show_summary_afi_safi(struct vty *vty, struct bgp *bgp, int afi,
 								       safi));
 					}
 				}
-				bgp_show_summary(vty, bgp, afi, safi, use_json,
-						 json);
+				bgp_show_summary(vty, bgp, afi, safi, use_json);
 			}
 			safi++;
 			if (!safi_wildcard)


### PR DESCRIPTION
Problem reported with memory leak when the command "show bgp vrf all
ipv6 unicast summary json" is issued.  Found that the problem only
occurs if the configuration does not actually include the ipv6
address-family but does contain ipv4 unicast peers. If we didn't
match a peer in the address-family being displayed, we would create
the json object but never free it.  This fix actually stops creating
the json object in this section of code and lets the create happen
in the area where the match occurs.

Ticket: CM-25616
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>