### PR TITLE
ipv4_broadcast_addr() didn't comply with RFC3021

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1468,11 +1468,11 @@ in_addr_t ipv4_broadcast_addr(in_addr_t hostaddr, int masklen)
 
 	masklen2ip(masklen, &mask);
 	return (masklen != IPV4_MAX_PREFIXLEN - 1) ?
-						   /* normal case */
-		       (hostaddr | ~mask.s_addr)
-						   :
-						   /* special case for /31 */
-		       (hostaddr ^ ~mask.s_addr);
+		/* normal case */
+		(hostaddr | ~mask.s_addr)
+		   :
+		/* For prefix 31 return 255.255.255.255 (RFC3021) */
+		htonl(0xFFFFFFFF);
 }
 
 /* Utility function to convert ipv4 netmask to prefixes

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -451,8 +451,7 @@ extern void masklen2ip(const int, struct in_addr *);
 extern in_addr_t ipv4_network_addr(in_addr_t hostaddr, int masklen);
 /* given the address of a host on a network and the network mask length,
  * calculate the broadcast address for that network;
- * special treatment for /31: returns the address of the other host
- * on the network by flipping the host bit */
+ * special treatment for /31 according to RFC3021 section 3.3 */
 extern in_addr_t ipv4_broadcast_addr(in_addr_t hostaddr, int masklen);
 
 extern int netmask_str2prefix_str(const char *, const char *, char *);


### PR DESCRIPTION
The function ipv4_broadcast_addr() does not calculate correct broadcast
addresses for point-to-point connections with prefix 31. RFC3021
section 3.3 [1] specifies:

"The 255.255.255.255 IP broadcast address MUST be used for broadcast
Address Mask Replies in point-to-point links with 31-bit subnet masks"

The issue causes Zebra to print the following warning when IPv4 address
with 31 prefix (e.g. 192.168.222.240/31) is configured on a network
interface:

ZEBRA: [EC 4043309141] warning: interface VNS broadcast addr 255.255.255.255/31 != calculated 192.168.222.241, routing protocols may malfunction

The issue has been originally found in Quagga [2], but it is present also
in FRR.

[1] https://tools.ietf.org/html/rfc3021#section-3.3
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1713449

Signed-off-by: Tomas Hozza <thozza@redhat.com>