### PR TITLE
Fix VRRP rarely getting stuck in Initialize

### DIFF
--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -196,14 +196,14 @@ static struct vrrp_vrouter *vrrp_lookup_by_if_mvl(struct interface *mvl_ifp)
 {
 	struct interface *p;
 
-	if (!mvl_ifp || !mvl_ifp->link_ifindex
+	if (!mvl_ifp || mvl_ifp->link_ifindex == 0
 	    || !vrrp_ifp_has_vrrp_mac(mvl_ifp)) {
-		if (!mvl_ifp->link_ifindex)
+		if (mvl_ifp && mvl_ifp->link_ifindex == 0)
 			DEBUGD(&vrrp_dbg_zebra,
 			       VRRP_LOGPFX
 			       "Interface %s has no parent ifindex; disregarding",
 			       mvl_ifp->name);
-		if (!vrrp_ifp_has_vrrp_mac(mvl_ifp))
+		if (mvl_ifp && !vrrp_ifp_has_vrrp_mac(mvl_ifp))
 			DEBUGD(&vrrp_dbg_zebra,
 			       VRRP_LOGPFX
 			       "Interface %s has a non-VRRP MAC; disregarding",

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -2133,9 +2133,13 @@ void vrrp_if_down(struct interface *ifp)
 	struct listnode *ln;
 	struct list *vrs;
 
+	vrrp_bind_pending(ifp);
+
 	vrs = vrrp_lookup_by_if_any(ifp);
 
 	for (ALL_LIST_ELEMENTS_RO(vrs, ln, vr)) {
+		vrrp_check_start(vr);
+
 		if (vr->ifp == ifp || vr->v4->mvl_ifp == ifp
 		    || vr->v6->mvl_ifp == ifp) {
 			DEBUGD(&vrrp_dbg_auto,

--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -38,9 +38,11 @@ static void vrrp_zebra_debug_if_state(struct interface *ifp, vrf_id_t vrf_id,
 				      const char *func)
 {
 	DEBUGD(&vrrp_dbg_zebra,
-	       "%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
-	       func, ifp->name, ifp->ifindex, vrf_id, (long)ifp->flags,
-	       ifp->metric, ifp->mtu, if_is_operative(ifp));
+	       "%s: %s index %d(%u) parent %d mac %02x:%02x:%02x:%02x:%02x:%02x flags %ld metric %d mtu %d operative %d",
+	       func, ifp->name, vrf_id, ifp->link_ifindex, ifp->ifindex,
+	       ifp->hw_addr[0], ifp->hw_addr[1], ifp->hw_addr[2],
+	       ifp->hw_addr[3], ifp->hw_addr[4], ifp->hw_addr[5],
+	       (long)ifp->flags, ifp->metric, ifp->mtu, if_is_operative(ifp));
 }
 
 static void vrrp_zebra_debug_if_dump_address(struct interface *ifp,

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1347,6 +1347,12 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 							"Intf %s(%u) has come UP",
 							name, ifp->ifindex);
 					if_up(ifp);
+				} else {
+					if (IS_ZEBRA_DEBUG_KERNEL)
+						zlog_debug(
+							"Intf %s(%u) has gone DOW",
+							name, ifp->ifindex);
+					if_down(ifp);
 				}
 			}
 


### PR DESCRIPTION
When macvlan devices are created for VRRP, they are initially assigned a random MAC address. Shortly thereafter, depending on what is creating the interfaces the MAC is changed to a VRRP mac. So what happens is vrrpd gets the "interface created" notification, but ignores the interface as a candidate for binding to a VRRP instance because it doesn't have a VRRP mac (00:00:5e:00:0X:XX).

Now, normally what happens is that we also get an "interface is up" notification shortly after the creation notification. Since vrrpd is very opportunistic when it comes to looking for appropriate interfaces, when we get an "interface is up" notification we again check if the interface is a candidate for binding to a VRRP instance. By this time, ifupdown2 or whatever is creating the interfaces has usually set the MAC to a VRRP MAC, so we recognize the interface as usable for VRRP things, are able to bind successfully and continue with the rest of instance setup.

Sometimes, if the interface is set down very fast after creation, it happens that vrrpd receives only the initial creation message with the random MAC, and then never gets the "iface is up" message or any other message containing the correct MAC. So it never realizes that this interface is in fact usable by VRRP, never binds to it, and thus any VRRP instances dependent on that interface never come up. This requires two race conditions to line up to manifest, which is why this is rare.

The fix here is to change Zebra to send interface updates even when interfaces are down, and to make vrrpd pay attention to those events. This is done by sending if_down events with the updated info, similar to how if_up events are sent repeatedly for interface updates.