### PR TITLE
zebra: use dataplane for evpn macs 

### DIFF
--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -41,7 +41,7 @@ extern "C" {
 	((RKERNEL_ROUTE(type)) || (type) == ZEBRA_ROUTE_CONNECT)
 
 /*
- * Update or delete a route, LSP, or pseudowire from the kernel,
+ * Update or delete a route, LSP, pseudowire, or vxlan MAC from the kernel,
  * using info from a dataplane context.
  */
 extern enum zebra_dplane_result kernel_route_update(
@@ -54,6 +54,8 @@ enum zebra_dplane_result kernel_pw_update(struct zebra_dplane_ctx *ctx);
 
 enum zebra_dplane_result kernel_address_update_ctx(
 	struct zebra_dplane_ctx *ctx);
+
+enum zebra_dplane_result kernel_mac_update_ctx(struct zebra_dplane_ctx *ctx);
 
 extern int kernel_neigh_update(int cmd, int ifindex, uint32_t addr, char *lla,
 			       int llalen, ns_id_t ns_id);
@@ -68,12 +70,6 @@ extern int kernel_add_vtep(vni_t vni, struct interface *ifp,
 			   struct in_addr *vtep_ip);
 extern int kernel_del_vtep(vni_t vni, struct interface *ifp,
 			   struct in_addr *vtep_ip);
-extern int kernel_add_mac(struct interface *ifp, vlanid_t vid,
-			  struct ethaddr *mac, struct in_addr vtep_ip,
-			  bool sticky);
-extern int kernel_del_mac(struct interface *ifp, vlanid_t vid,
-			  struct ethaddr *mac, struct in_addr vtep_ip);
-
 extern int kernel_add_neigh(struct interface *ifp, struct ipaddr *ip,
 			    struct ethaddr *mac, uint8_t flags);
 extern int kernel_del_neigh(struct interface *ifp, struct ipaddr *ip);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2279,33 +2279,70 @@ int netlink_macfdb_read_specific_mac(struct zebra_ns *zns,
 
 	return ret;
 }
-static int netlink_macfdb_update(struct interface *ifp, vlanid_t vid,
-				 struct ethaddr *mac, struct in_addr vtep_ip,
-				 int cmd, bool sticky)
+
+/*
+ * Netlink-specific handler for MAC updates using dataplane context object.
+ */
+static enum zebra_dplane_result
+netlink_macfdb_update_ctx(struct zebra_dplane_ctx *ctx)
 {
-	struct zebra_ns *zns;
 	struct {
 		struct nlmsghdr n;
 		struct ndmsg ndm;
 		char buf[256];
 	} req;
+	int ret;
 	int dst_alen;
 	struct zebra_if *zif;
 	struct interface *br_if;
 	struct zebra_if *br_zif;
-	char buf[ETHER_ADDR_STRLEN];
 	int vid_present = 0;
 	char vid_buf[20];
-	char dst_buf[30];
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	struct zebra_ns *zns;
+	struct interface *ifp;
+	int cmd;
+	struct in_addr vtep_ip;
+	vlanid_t vid;
 
-	zns = zvrf->zns;
+	if (dplane_ctx_get_op(ctx) == DPLANE_OP_MAC_INSTALL)
+		cmd = RTM_NEWNEIGH;
+	else
+		cmd = RTM_DELNEIGH;
+
+	/* Locate zebra ns and interface objects from context data */
+	zns = zebra_ns_lookup(dplane_ctx_get_ns(ctx)->ns_id);
+	if (zns == NULL) {
+		/* Nothing to be done */
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("MAC %s on IF %s(%u) - zebra ns unknown",
+				   (cmd == RTM_NEWNEIGH) ? "add" : "del",
+				   dplane_ctx_get_ifname(ctx),
+				   dplane_ctx_get_ifindex(ctx));
+
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+
+	ifp = if_lookup_by_index_per_ns(zns, dplane_ctx_get_ifindex(ctx));
+	if (ifp == NULL) {
+		/* Nothing to be done */
+		/* Nothing to be done */
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("MAC %s on IF %s(%u) - interface unknown",
+				   (cmd == RTM_NEWNEIGH) ? "add" : "del",
+				   dplane_ctx_get_ifname(ctx),
+				   dplane_ctx_get_ifindex(ctx));
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
+	}
+
+	vid = dplane_ctx_mac_get_vlan(ctx);
+
 	zif = ifp->info;
 	if ((br_if = zif->brslave_info.br_if) == NULL) {
-		zlog_debug("MAC %s on IF %s(%u) - no mapping to bridge",
-			   (cmd == RTM_NEWNEIGH) ? "add" : "del", ifp->name,
-			   ifp->ifindex);
-		return -1;
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("MAC %s on IF %s(%u) - no mapping to bridge",
+				   (cmd == RTM_NEWNEIGH) ? "add" : "del",
+				   ifp->name, ifp->ifindex);
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
 	}
 
 	memset(&req, 0, sizeof(req));
@@ -2319,16 +2356,19 @@ static int netlink_macfdb_update(struct interface *ifp, vlanid_t vid,
 	req.ndm.ndm_flags |= NTF_SELF | NTF_MASTER;
 	req.ndm.ndm_state = NUD_REACHABLE;
 
-	if (sticky)
+	if (dplane_ctx_mac_is_sticky(ctx))
 		req.ndm.ndm_state |= NUD_NOARP;
 	else
 		req.ndm.ndm_flags |= NTF_EXT_LEARNED;
 
-	addattr_l(&req.n, sizeof(req), NDA_LLADDR, mac, 6);
+	addattr_l(&req.n, sizeof(req), NDA_LLADDR,
+		  dplane_ctx_mac_get_addr(ctx), 6);
 	req.ndm.ndm_ifindex = ifp->ifindex;
+
 	dst_alen = 4; // TODO: hardcoded
+	vtep_ip = *(dplane_ctx_mac_get_vtep_ip(ctx));
 	addattr_l(&req.n, sizeof(req), NDA_DST, &vtep_ip, dst_alen);
-	sprintf(dst_buf, " dst %s", inet_ntoa(vtep_ip));
+
 	br_zif = (struct zebra_if *)br_if->info;
 	if (IS_ZEBRA_IF_BRIDGE_VLAN_AWARE(br_zif) && vid > 0) {
 		addattr16(&req.n, sizeof(req), NDA_VLAN, vid);
@@ -2337,16 +2377,29 @@ static int netlink_macfdb_update(struct interface *ifp, vlanid_t vid,
 	}
 	addattr32(&req.n, sizeof(req), NDA_MASTER, br_if->ifindex);
 
-	if (IS_ZEBRA_DEBUG_KERNEL)
+	if (IS_ZEBRA_DEBUG_KERNEL) {
+		char ipbuf[PREFIX_STRLEN];
+		char buf[ETHER_ADDR_STRLEN];
+		char dst_buf[PREFIX_STRLEN + 10];
+
+		inet_ntop(AF_INET, &vtep_ip, ipbuf, sizeof(ipbuf));
+		snprintf(dst_buf, sizeof(dst_buf), " dst %s", ipbuf);
+		prefix_mac2str(dplane_ctx_mac_get_addr(ctx), buf, sizeof(buf));
+
 		zlog_debug("Tx %s family %s IF %s(%u)%s %sMAC %s%s",
 			   nl_msg_type_to_str(cmd),
 			   nl_family_to_str(req.ndm.ndm_family), ifp->name,
 			   ifp->ifindex, vid_present ? vid_buf : "",
-			   sticky ? "sticky " : "",
-			   prefix_mac2str(mac, buf, sizeof(buf)), dst_buf);
+			   dplane_ctx_mac_is_sticky(ctx) ? "sticky " : "",
+			   buf, dst_buf);
+	}
 
-	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,
-			    0);
+	ret = netlink_talk_info(netlink_talk_filter, &req.n,
+				dplane_ctx_get_ns(ctx), 0);
+	if (ret == 0)
+		return ZEBRA_DPLANE_REQUEST_SUCCESS;
+	else
+		return ZEBRA_DPLANE_REQUEST_FAILURE;
 }
 
 /*
@@ -2759,17 +2812,12 @@ static int netlink_neigh_update2(struct interface *ifp, struct ipaddr *ip,
 			    0);
 }
 
-int kernel_add_mac(struct interface *ifp, vlanid_t vid, struct ethaddr *mac,
-		   struct in_addr vtep_ip, bool sticky)
+/*
+ * Update MAC, using dataplane context object.
+ */
+enum zebra_dplane_result kernel_mac_update_ctx(struct zebra_dplane_ctx *ctx)
 {
-	return netlink_macfdb_update(ifp, vid, mac, vtep_ip, RTM_NEWNEIGH,
-				     sticky);
-}
-
-int kernel_del_mac(struct interface *ifp, vlanid_t vid, struct ethaddr *mac,
-		   struct in_addr vtep_ip)
-{
-	return netlink_macfdb_update(ifp, vid, mac, vtep_ip, RTM_DELNEIGH, 0);
+	return netlink_macfdb_update_ctx(ctx);
 }
 
 int kernel_add_neigh(struct interface *ifp, struct ipaddr *ip,

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -386,16 +386,12 @@ int kernel_del_vtep(vni_t vni, struct interface *ifp, struct in_addr *vtep_ip)
 	return 0;
 }
 
-int kernel_add_mac(struct interface *ifp, vlanid_t vid, struct ethaddr *mac,
-		   struct in_addr vtep_ip, bool sticky)
+/*
+ * Update MAC, using dataplane context object. No-op here for now.
+ */
+enum zebra_dplane_result kernel_mac_update_ctx(struct zebra_dplane_ctx *ctx)
 {
-	return 0;
-}
-
-int kernel_del_mac(struct interface *ifp, vlanid_t vid, struct ethaddr *mac,
-		   struct in_addr vtep_ip)
-{
-	return 0;
+	return ZEBRA_DPLANE_REQUEST_SUCCESS;
 }
 
 int kernel_add_neigh(struct interface *ifp, struct ipaddr *ip,

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2196,7 +2196,35 @@ int dplane_show_helper(struct vty *vty, bool detailed)
 	vty_out(vty, "Route update queue limit: %"PRIu64"\n", limit);
 	vty_out(vty, "Route update queue depth: %"PRIu64"\n", queued);
 	vty_out(vty, "Route update queue max:   %"PRIu64"\n", queue_max);
-	vty_out(vty, "Dplane update yields:      %"PRIu64"\n", yields);
+	vty_out(vty, "Dplane update yields:     %"PRIu64"\n", yields);
+
+	incoming = atomic_load_explicit(&zdplane_info.dg_lsps_in,
+					memory_order_relaxed);
+	errs = atomic_load_explicit(&zdplane_info.dg_lsp_errors,
+				    memory_order_relaxed);
+	vty_out(vty, "LSP updates:              %"PRIu64"\n", incoming);
+	vty_out(vty, "LSP update errors:        %"PRIu64"\n", errs);
+
+	incoming = atomic_load_explicit(&zdplane_info.dg_pws_in,
+					memory_order_relaxed);
+	errs = atomic_load_explicit(&zdplane_info.dg_pw_errors,
+				    memory_order_relaxed);
+	vty_out(vty, "PW updates:               %"PRIu64"\n", incoming);
+	vty_out(vty, "PW update errors:         %"PRIu64"\n", errs);
+
+	incoming = atomic_load_explicit(&zdplane_info.dg_intf_addrs_in,
+					memory_order_relaxed);
+	errs = atomic_load_explicit(&zdplane_info.dg_intf_addr_errors,
+				    memory_order_relaxed);
+	vty_out(vty, "Intf addr updates:        %"PRIu64"\n", incoming);
+	vty_out(vty, "Intf addr errors:         %"PRIu64"\n", errs);
+
+	incoming = atomic_load_explicit(&zdplane_info.dg_macs_in,
+					memory_order_relaxed);
+	errs = atomic_load_explicit(&zdplane_info.dg_mac_errors,
+				    memory_order_relaxed);
+	vty_out(vty, "EVPN MAC updates:         %"PRIu64"\n", incoming);
+	vty_out(vty, "EVPN MAC errors:          %"PRIu64"\n", errs);
 
 	return CMD_SUCCESS;
 }

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -180,6 +180,8 @@ const char *dplane_op2str(enum dplane_op_e op);
 const struct prefix *dplane_ctx_get_dest(const struct zebra_dplane_ctx *ctx);
 void dplane_ctx_set_dest(struct zebra_dplane_ctx *ctx,
 			 const struct prefix *dest);
+const char *dplane_ctx_get_ifname(const struct zebra_dplane_ctx *ctx);
+ifindex_t dplane_ctx_get_ifindex(const struct zebra_dplane_ctx *ctx);
 
 /* Retrieve last/current provider id */
 uint32_t dplane_ctx_get_provider(const struct zebra_dplane_ctx *ctx);
@@ -262,7 +264,6 @@ const zebra_nhlfe_t *dplane_ctx_set_best_nhlfe(struct zebra_dplane_ctx *ctx,
 uint32_t dplane_ctx_get_lsp_num_ecmp(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for pseudowire information */
-const char *dplane_ctx_get_pw_ifname(const struct zebra_dplane_ctx *ctx);
 mpls_label_t dplane_ctx_get_pw_local_label(const struct zebra_dplane_ctx *ctx);
 mpls_label_t dplane_ctx_get_pw_remote_label(const struct zebra_dplane_ctx *ctx);
 int dplane_ctx_get_pw_type(const struct zebra_dplane_ctx *ctx);
@@ -277,8 +278,6 @@ const struct nexthop_group *dplane_ctx_get_pw_nhg(
 	const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for interface information */
-const char *dplane_ctx_get_ifname(const struct zebra_dplane_ctx *ctx);
-ifindex_t dplane_ctx_get_ifindex(const struct zebra_dplane_ctx *ctx);
 uint32_t dplane_ctx_get_intf_metric(const struct zebra_dplane_ctx *ctx);
 /* Is interface addr p2p? */
 bool dplane_ctx_intf_is_connected(const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -25,6 +25,7 @@
 #include "lib/nexthop.h"
 #include "lib/nexthop_group.h"
 #include "lib/queue.h"
+#include "lib/vlan.h"
 #include "zebra/zebra_ns.h"
 #include "zebra/rib.h"
 #include "zebra/zserv.h"
@@ -124,6 +125,10 @@ enum dplane_op_e {
 	/* Interface address update */
 	DPLANE_OP_ADDR_INSTALL,
 	DPLANE_OP_ADDR_UNINSTALL,
+
+	/* MAC address update */
+	DPLANE_OP_MAC_INSTALL,
+	DPLANE_OP_MAC_DELETE,
 };
 
 /* Enable system route notifications */
@@ -291,6 +296,14 @@ const struct prefix *dplane_ctx_get_intf_dest(
 bool dplane_ctx_intf_has_label(const struct zebra_dplane_ctx *ctx);
 const char *dplane_ctx_get_intf_label(const struct zebra_dplane_ctx *ctx);
 
+/* Accessors for MAC information */
+vlanid_t dplane_ctx_mac_get_vlan(const struct zebra_dplane_ctx *ctx);
+bool dplane_ctx_mac_is_sticky(const struct zebra_dplane_ctx *ctx);
+const struct ethaddr *dplane_ctx_mac_get_addr(
+	const struct zebra_dplane_ctx *ctx);
+const struct in_addr *dplane_ctx_mac_get_vtep_ip(
+	const struct zebra_dplane_ctx *ctx);
+
 /* Namespace info - esp. for netlink communication */
 const struct zebra_dplane_info *dplane_ctx_get_ns(
 	const struct zebra_dplane_ctx *ctx);
@@ -352,6 +365,19 @@ enum zebra_dplane_result dplane_intf_addr_set(const struct interface *ifp,
 enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
 						const struct connected *ifc);
 
+/*
+ * Enqueue evpn mac operations for the dataplane.
+ */
+enum zebra_dplane_result dplane_mac_add(const struct interface *ifp,
+					vlanid_t vid,
+					const struct ethaddr *mac,
+					struct in_addr vtep_ip,
+					bool sticky);
+
+enum zebra_dplane_result dplane_mac_del(const struct interface *ifp,
+					vlanid_t vid,
+					const struct ethaddr *mac,
+					struct in_addr vtep_ip);
 
 /* Retrieve the limit on the number of pending, unprocessed updates. */
 uint32_t dplane_get_in_queue_limit(void);

--- a/zebra/zebra_mpls_openbsd.c
+++ b/zebra/zebra_mpls_openbsd.c
@@ -369,7 +369,7 @@ static enum zebra_dplane_result kmpw_install(struct zebra_dplane_ctx *ctx)
 
 	/* ioctl */
 	memset(&ifr, 0, sizeof(ifr));
-	strlcpy(ifr.ifr_name, dplane_ctx_get_pw_ifname(ctx),
+	strlcpy(ifr.ifr_name, dplane_ctx_get_ifname(ctx),
 		sizeof(ifr.ifr_name));
 	ifr.ifr_data = (caddr_t)&imr;
 	if (ioctl(kr_state.ioctl_fd, SIOCSETMPWCFG, &ifr) == -1) {
@@ -388,7 +388,7 @@ static enum zebra_dplane_result kmpw_uninstall(struct zebra_dplane_ctx *ctx)
 
 	memset(&ifr, 0, sizeof(ifr));
 	memset(&imr, 0, sizeof(imr));
-	strlcpy(ifr.ifr_name, dplane_ctx_get_pw_ifname(ctx),
+	strlcpy(ifr.ifr_name, dplane_ctx_get_ifname(ctx),
 		sizeof(ifr.ifr_name));
 	ifr.ifr_data = (caddr_t)&imr;
 	if (ioctl(kr_state.ioctl_fd, SIOCSETMPWCFG, &ifr) == -1) {

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3220,7 +3220,7 @@ static int handle_pw_result(struct zebra_dplane_ctx *ctx)
 
 	if (dplane_ctx_get_status(ctx) != ZEBRA_DPLANE_REQUEST_SUCCESS) {
 		vrf = zebra_vrf_lookup_by_id(dplane_ctx_get_vrf(ctx));
-		pw = zebra_pw_find(vrf, dplane_ctx_get_pw_ifname(ctx));
+		pw = zebra_pw_find(vrf, dplane_ctx_get_ifname(ctx));
 		if (pw)
 			zebra_pw_install_failure(pw);
 	}

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3312,6 +3312,11 @@ static int rib_process_dplane_results(struct thread *thread)
 				dplane_ctx_fini(&ctx);
 				break;
 
+			case DPLANE_OP_MAC_INSTALL:
+			case DPLANE_OP_MAC_DELETE:
+				zebra_vxlan_handle_result(ctx);
+				break;
+
 			default:
 				/* Don't expect this: just return the struct? */
 				dplane_ctx_fini(&ctx);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3694,13 +3694,14 @@ static struct interface *zvni_map_to_svi(vlanid_t vid, struct interface *br_if)
 }
 
 /*
- * Install remote MAC into the kernel.
+ * Install remote MAC into the forwarding plane.
  */
 static int zvni_mac_install(zebra_vni_t *zvni, zebra_mac_t *mac)
 {
 	struct zebra_if *zif;
 	struct zebra_l2info_vxlan *vxl;
 	bool sticky;
+	enum zebra_dplane_result res;
 
 	if (!(mac->flags & ZEBRA_MAC_REMOTE))
 		return 0;
@@ -3713,12 +3714,16 @@ static int zvni_mac_install(zebra_vni_t *zvni, zebra_mac_t *mac)
 	sticky = !!CHECK_FLAG(mac->flags,
 			 (ZEBRA_MAC_STICKY | ZEBRA_MAC_REMOTE_DEF_GW));
 
-	return kernel_add_mac(zvni->vxlan_if, vxl->access_vlan, &mac->macaddr,
-			      mac->fwd_info.r_vtep_ip, sticky);
+	res = dplane_mac_add(zvni->vxlan_if, vxl->access_vlan, &mac->macaddr,
+			     mac->fwd_info.r_vtep_ip, sticky);
+	if (res != ZEBRA_DPLANE_REQUEST_FAILURE)
+		return 0;
+	else
+		return -1;
 }
 
 /*
- * Uninstall remote MAC from the kernel.
+ * Uninstall remote MAC from the forwarding plane.
  */
 static int zvni_mac_uninstall(zebra_vni_t *zvni, zebra_mac_t *mac)
 {
@@ -3726,6 +3731,7 @@ static int zvni_mac_uninstall(zebra_vni_t *zvni, zebra_mac_t *mac)
 	struct zebra_l2info_vxlan *vxl;
 	struct in_addr vtep_ip;
 	struct interface *ifp;
+	enum zebra_dplane_result res;
 
 	if (!(mac->flags & ZEBRA_MAC_REMOTE))
 		return 0;
@@ -3744,7 +3750,11 @@ static int zvni_mac_uninstall(zebra_vni_t *zvni, zebra_mac_t *mac)
 	ifp = zvni->vxlan_if;
 	vtep_ip = mac->fwd_info.r_vtep_ip;
 
-	return kernel_del_mac(ifp, vxl->access_vlan, &mac->macaddr, vtep_ip);
+	res = dplane_mac_del(ifp, vxl->access_vlan, &mac->macaddr, vtep_ip);
+	if (res != ZEBRA_DPLANE_REQUEST_FAILURE)
+		return 0;
+	else
+		return -1;
 }
 
 /*
@@ -4431,12 +4441,13 @@ static int zl3vni_rmac_del(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 }
 
 /*
- * Install remote RMAC into the kernel.
+ * Install remote RMAC into the forwarding plane.
  */
 static int zl3vni_rmac_install(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 {
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
+	enum zebra_dplane_result res;
 
 	if (!(CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE))
 	    || !(CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE_RMAC)))
@@ -4448,18 +4459,23 @@ static int zl3vni_rmac_install(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 
 	vxl = &zif->l2info.vxl;
 
-	return kernel_add_mac(zl3vni->vxlan_if, vxl->access_vlan,
-			      &zrmac->macaddr, zrmac->fwd_info.r_vtep_ip, 0);
+	res = dplane_mac_add(zl3vni->vxlan_if, vxl->access_vlan,
+			     &zrmac->macaddr, zrmac->fwd_info.r_vtep_ip, 0);
+	if (res != ZEBRA_DPLANE_REQUEST_FAILURE)
+		return 0;
+	else
+		return -1;
 }
 
 /*
- * Uninstall remote RMAC from the kernel.
+ * Uninstall remote RMAC from the forwarding plane.
  */
 static int zl3vni_rmac_uninstall(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 {
 	char buf[ETHER_ADDR_STRLEN];
 	struct zebra_if *zif = NULL;
 	struct zebra_l2info_vxlan *vxl = NULL;
+	enum zebra_dplane_result res;
 
 	if (!(CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE))
 	    || !(CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE_RMAC)))
@@ -4479,8 +4495,12 @@ static int zl3vni_rmac_uninstall(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 
 	vxl = &zif->l2info.vxl;
 
-	return kernel_del_mac(zl3vni->vxlan_if, vxl->access_vlan,
-			      &zrmac->macaddr, zrmac->fwd_info.r_vtep_ip);
+	res = dplane_mac_del(zl3vni->vxlan_if, vxl->access_vlan,
+			     &zrmac->macaddr, zrmac->fwd_info.r_vtep_ip);
+	if (res != ZEBRA_DPLANE_REQUEST_FAILURE)
+		return 0;
+	else
+		return -1;
 }
 
 /* handle rmac add */
@@ -9870,6 +9890,15 @@ static int zebra_evpn_cfg_clean_up(struct zserv *client)
 		return zebra_evpn_pim_cfg_clean_up(client);
 
 	return 0;
+}
+
+/*
+ * Handle results for vxlan dataplane operations.
+ */
+extern void zebra_vxlan_handle_result(struct zebra_dplane_ctx *ctx)
+{
+	/* TODO -- anything other than freeing the context? */
+	dplane_ctx_fini(&ctx);
 }
 
 /* Cleanup BGP EVPN configuration upon client disconnect */

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -35,6 +35,7 @@
 #include "lib/json.h"
 #include "zebra/zebra_vrf.h"
 #include "zebra/zserv.h"
+#include "zebra/zebra_dplane.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -213,6 +214,8 @@ extern int zebra_vxlan_clear_dup_detect_vni_all(struct vty *vty,
 extern int zebra_vxlan_clear_dup_detect_vni(struct vty *vty,
 					    struct zebra_vrf *zvrf,
 					    vni_t vni);
+extern void zebra_vxlan_handle_result(struct zebra_dplane_ctx *ctx);
+
 extern void zebra_evpn_init(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Move the installation of evpn macs to the dataplane subsystem. This is a first round of evpn/vxlan programming changes. There's also a bit of internal cleanup - to improve some of the stats cli output, for example.