### PR TITLE
sharpd: Fix repeat sub-command to work

### DIFF
--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -188,7 +188,7 @@ static void handle_repeated(bool installed)
 					   sg.r.inst, sg.r.total_routes);
 	}
 
-	if (installed) {
+	if (!installed) {
 		sg.r.installed_routes = 0;
 		sharp_install_routes_helper(&p, sg.r.vrf_id, sg.r.inst,
 					    &sg.r.nhop_group,


### PR DESCRIPTION
The repeat sub-command was not properly repeating.  It was starting
the removal during the install:

2019/08/03 00:10:14.351 SHARP: Inserting 300000 routes
2019/08/03 00:13:01.556 SHARP: Installed All Items 167.204747
2019/08/03 00:13:01.556 SHARP: Removing 300000 routes
2019/08/03 00:13:03.126 SHARP: Inserting 300000 routes
2019/08/03 00:14:34.794 SHARP: Removed all Items 91.668040
2019/08/03 00:16:11.743 SHARP: Installed All Items 188.616462
2019/08/03 00:16:11.743 SHARP: Removing 300000 routes
2019/08/03 00:16:14.256 SHARP: Inserting 300000 routes

This command allows the remove to wait till the install is fully
finished and vice versa:

2019/08/03 00:22:54 SHARP: Inserting 10000 routes
2019/08/03 00:22:55 SHARP: Installed All Items 0.572028
2019/08/03 00:22:55 SHARP: Removing 10000 routes
2019/08/03 00:22:55 SHARP: Removed all Items 0.568284
2019/08/03 00:22:55 SHARP: Inserting 10000 routes
2019/08/03 00:22:56 SHARP: Installed All Items 0.567687
2019/08/03 00:22:56 SHARP: Removing 10000 routes
2019/08/03 00:22:56 SHARP: Removed all Items 0.551011

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>