### PR TITLE
zebra: clear route QUEUED flag in async notification handler

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1926,6 +1926,9 @@ static void rib_process_dplane_notify(struct zebra_dplane_ctx *ctx)
 		goto done;
 	}
 
+	/* Ensure we clear the QUEUED flag */
+	UNSET_FLAG(re->status, ROUTE_ENTRY_QUEUED);
+
 	/* Is this a notification that ... matters? We only really care about
 	 * the route that is currently selected for installation.
 	 */
@@ -1990,7 +1993,7 @@ static void rib_process_dplane_notify(struct zebra_dplane_ctx *ctx)
 				   dplane_ctx_get_vrf(ctx), dest_str);
 
 		/* We expect this to be the selected route, so we want
-		 * to tell others about this transistion.
+		 * to tell others about this transition.
 		 */
 		SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
 


### PR DESCRIPTION
Ensure that the route-entry QUEUED flag is cleared in the async notification path, as it is in the normal results processing code path.
