### PR TITLE
*: fix ctype casts

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -1885,7 +1885,7 @@ static const char *aspath_gettoken(const char *buf, enum as_token *token,
 	const char *p = buf;
 
 	/* Skip seperators (space for sequences, ',' for sets). */
-	while (isspace((int)*p) || *p == ',')
+	while (isspace((unsigned char)*p) || *p == ',')
 		p++;
 
 	/* Check the end of the string and type specify characters
@@ -1920,14 +1920,14 @@ static const char *aspath_gettoken(const char *buf, enum as_token *token,
 	}
 
 	/* Check actual AS value. */
-	if (isdigit((int)*p)) {
+	if (isdigit((unsigned char)*p)) {
 		as_t asval;
 
 		*token = as_token_asval;
 		asval = (*p - '0');
 		p++;
 
-		while (isdigit((int)*p)) {
+		while (isdigit((unsigned char)*p)) {
 			asval *= 10;
 			asval += (*p - '0');
 			p++;

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -157,7 +157,7 @@ community_list_insert(struct community_list_handler *ch, const char *name,
 	/* If name is made by all digit character.  We treat it as
 	   number. */
 	for (number = 0, i = 0; i < strlen(name); i++) {
-		if (isdigit((int)name[i]))
+		if (isdigit((unsigned char)name[i]))
 			number = (number * 10) + (name[i] - '0');
 		else
 			break;

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -651,7 +651,7 @@ community_gettoken(const char *buf, enum community_token *token, uint32_t *val)
 	const char *p = buf;
 
 	/* Skip white space. */
-	while (isspace((int)*p))
+	while (isspace((unsigned char)*p))
 		p++;
 
 	/* Check the end of the line. */
@@ -659,7 +659,7 @@ community_gettoken(const char *buf, enum community_token *token, uint32_t *val)
 		return NULL;
 
 	/* Well known community string check. */
-	if (isalpha((int)*p)) {
+	if (isalpha((unsigned char)*p)) {
 		if (strncmp(p, "internet", strlen("internet")) == 0) {
 			*val = COMMUNITY_INTERNET;
 			*token = community_token_no_export;
@@ -770,13 +770,13 @@ community_gettoken(const char *buf, enum community_token *token, uint32_t *val)
 	}
 
 	/* Community value. */
-	if (isdigit((int)*p)) {
+	if (isdigit((unsigned char)*p)) {
 		int separator = 0;
 		int digit = 0;
 		uint32_t community_low = 0;
 		uint32_t community_high = 0;
 
-		while (isdigit((int)*p) || *p == ':') {
+		while (isdigit((unsigned char)*p) || *p == ':') {
 			if (*p == ':') {
 				if (separator) {
 					*token = community_token_unknown;

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -584,7 +584,7 @@ static unsigned int bgp_dump_parse_time(const char *str)
 	len = strlen(str);
 
 	for (i = 0; i < len; i++) {
-		if (isdigit((int)str[i])) {
+		if (isdigit((unsigned char)str[i])) {
 			time *= 10;
 			time += str[i] - '0';
 		} else if (str[i] == 'H' || str[i] == 'h') {

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -352,7 +352,7 @@ static const char *ecommunity_gettoken(const char *str,
 	char buf[INET_ADDRSTRLEN + 1];
 
 	/* Skip white space. */
-	while (isspace((int)*p)) {
+	while (isspace((unsigned char)*p)) {
 		p++;
 		str++;
 	}
@@ -362,38 +362,38 @@ static const char *ecommunity_gettoken(const char *str,
 		return NULL;
 
 	/* "rt" and "soo" keyword parse. */
-	if (!isdigit((int)*p)) {
+	if (!isdigit((unsigned char)*p)) {
 		/* "rt" match check.  */
-		if (tolower((int)*p) == 'r') {
+		if (tolower((unsigned char)*p) == 'r') {
 			p++;
-			if (tolower((int)*p) == 't') {
+			if (tolower((unsigned char)*p) == 't') {
 				p++;
 				*token = ecommunity_token_rt;
 				return p;
 			}
-			if (isspace((int)*p) || *p == '\0') {
+			if (isspace((unsigned char)*p) || *p == '\0') {
 				*token = ecommunity_token_rt;
 				return p;
 			}
 			goto error;
 		}
 		/* "soo" match check.  */
-		else if (tolower((int)*p) == 's') {
+		else if (tolower((unsigned char)*p) == 's') {
 			p++;
-			if (tolower((int)*p) == 'o') {
+			if (tolower((unsigned char)*p) == 'o') {
 				p++;
-				if (tolower((int)*p) == 'o') {
+				if (tolower((unsigned char)*p) == 'o') {
 					p++;
 					*token = ecommunity_token_soo;
 					return p;
 				}
-				if (isspace((int)*p) || *p == '\0') {
+				if (isspace((unsigned char)*p) || *p == '\0') {
 					*token = ecommunity_token_soo;
 					return p;
 				}
 				goto error;
 			}
-			if (isspace((int)*p) || *p == '\0') {
+			if (isspace((unsigned char)*p) || *p == '\0') {
 				*token = ecommunity_token_soo;
 				return p;
 			}
@@ -415,7 +415,7 @@ static const char *ecommunity_gettoken(const char *str,
 	 * OPQR:    Four byte value
 	 *
 	 */
-	while (isdigit((int)*p) || *p == ':' || *p == '.') {
+	while (isdigit((unsigned char)*p) || *p == ':' || *p == '.') {
 		if (*p == ':') {
 			if (separator)
 				goto error;

--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -193,7 +193,7 @@ static struct as_list *as_list_insert(const char *name)
 	/* If name is made by all digit character.  We treat it as
 	   number. */
 	for (number = 0, i = 0; i < strlen(name); i++) {
-		if (isdigit((int)name[i]))
+		if (isdigit((unsigned char)name[i]))
 			number = (number * 10) + (name[i] - '0');
 		else
 			break;

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -359,7 +359,7 @@ static const char *lcommunity_gettoken(const char *str,
 	const char *p = str;
 
 	/* Skip white space. */
-	while (isspace((int)*p)) {
+	while (isspace((unsigned char)*p)) {
 		p++;
 		str++;
 	}
@@ -369,14 +369,14 @@ static const char *lcommunity_gettoken(const char *str,
 		return NULL;
 
 	/* Community value. */
-	if (isdigit((int)*p)) {
+	if (isdigit((unsigned char)*p)) {
 		int separator = 0;
 		int digit = 0;
 		uint32_t globaladmin = 0;
 		uint32_t localdata1 = 0;
 		uint32_t localdata2 = 0;
 
-		while (isdigit((int)*p) || *p == ':') {
+		while (isdigit((unsigned char)*p) || *p == ':') {
 			if (*p == ':') {
 				if (separator == 2) {
 					*token = lcommunity_token_unknown;

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,13 @@
+
+/.debhelper/
+/*/
+!/tests/
+!/source
+
+/*.log
+/*.substvars
+/*.debhelper
+/autoreconf.*
+/files
+/frr.init
+/frr.service

--- a/isisd/isis_misc.c
+++ b/isisd/isis_misc.c
@@ -117,7 +117,8 @@ int dotformat2buff(uint8_t *buff, const char *dotted)
 			break;
 		}
 
-		if ((isxdigit((int)*pos)) && (isxdigit((int)*(pos + 1)))) {
+		if ((isxdigit((unsigned char)*pos)) &&
+		    (isxdigit((unsigned char)*(pos + 1)))) {
 			memcpy(number, pos, 2);
 			pos += 2;
 		} else {
@@ -157,7 +158,8 @@ int sysid2buff(uint8_t *buff, const char *dotted)
 			pos++;
 			continue;
 		}
-		if ((isxdigit((int)*pos)) && (isxdigit((int)*(pos + 1)))) {
+		if ((isxdigit((unsigned char)*pos)) &&
+		    (isxdigit((unsigned char)*(pos + 1)))) {
 			memcpy(number, pos, 2);
 			pos += 2;
 		} else {

--- a/isisd/isis_tlvs.c
+++ b/isisd/isis_tlvs.c
@@ -1478,7 +1478,7 @@ static int unpack_tlv_dynamic_hostname(enum isis_tlv_context context,
 	bool sane = true;
 	for (uint8_t i = 0; i < tlv_len; i++) {
 		if ((unsigned char)tlvs->hostname[i] > 127
-		    || !isprint((int)tlvs->hostname[i])) {
+		    || !isprint((unsigned char)tlvs->hostname[i])) {
 			sane = false;
 			tlvs->hostname[i] = '?';
 		}

--- a/lib/command.c
+++ b/lib/command.c
@@ -290,7 +290,7 @@ vector cmd_make_strvec(const char *string)
 	const char *copy = string;
 
 	/* skip leading whitespace */
-	while (isspace((int)*copy) && *copy != '\0')
+	while (isspace((unsigned char)*copy) && *copy != '\0')
 		copy++;
 
 	/* if the entire string was whitespace or a comment, return */
@@ -1936,7 +1936,7 @@ DEFUN(config_domainname,
 {
 	struct cmd_token *word = argv[1];
 
-	if (!isalpha((int)word->arg[0])) {
+	if (!isalpha((unsigned char)word->arg[0])) {
 		vty_out(vty, "Please specify string starting with alphabet\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
@@ -1970,7 +1970,7 @@ DEFUN (config_hostname,
 {
 	struct cmd_token *word = argv[1];
 
-	if (!isalnum((int)word->arg[0])) {
+	if (!isalnum((unsigned char)word->arg[0])) {
 		vty_out(vty,
 		    "Please specify string starting with alphabet or number\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -2018,7 +2018,7 @@ DEFUN (config_password,
 		return CMD_SUCCESS;
 	}
 
-	if (!isalnum((int)argv[idx_8]->arg[0])) {
+	if (!isalnum((unsigned char)argv[idx_8]->arg[0])) {
 		vty_out(vty,
 			"Please specify string starting with alphanumeric\n");
 		return CMD_WARNING_CONFIG_FAILED;
@@ -2098,7 +2098,7 @@ DEFUN (config_enable_password,
 		}
 	}
 
-	if (!isalnum((int)argv[idx_8]->arg[0])) {
+	if (!isalnum((unsigned char)argv[idx_8]->arg[0])) {
 		vty_out(vty,
 			"Please specify string starting with alphanumeric\n");
 		return CMD_WARNING_CONFIG_FAILED;

--- a/lib/command_graph.c
+++ b/lib/command_graph.c
@@ -97,7 +97,7 @@ void cmd_token_varname_set(struct cmd_token *token, const char *varname)
 			token->varname[i] = '_';
 			break;
 		default:
-			token->varname[i] = tolower((int)varname[i]);
+			token->varname[i] = tolower((unsigned char)varname[i]);
 		}
 	token->varname[len] = '\0';
 }

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -714,7 +714,7 @@ static enum match_type match_ipv4(const char *str)
 				dots++;
 				break;
 			}
-			if (!isdigit((int)*str))
+			if (!isdigit((unsigned char)*str))
 				return no_match;
 
 			str++;
@@ -765,7 +765,7 @@ static enum match_type match_ipv4_prefix(const char *str)
 				break;
 			}
 
-			if (!isdigit((int)*str))
+			if (!isdigit((unsigned char)*str))
 				return no_match;
 
 			str++;
@@ -797,7 +797,7 @@ static enum match_type match_ipv4_prefix(const char *str)
 
 	sp = str;
 	while (*str != '\0') {
-		if (!isdigit((int)*str))
+		if (!isdigit((unsigned char)*str))
 			return no_match;
 
 		str++;

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -273,7 +273,7 @@ static struct access_list *access_list_insert(afi_t afi, const char *name)
 	/* If name is made by all digit character.  We treat it as
 	   number. */
 	for (number = 0, i = 0; i < strlen(name); i++) {
-		if (isdigit((int)name[i]))
+		if (isdigit((unsigned char)name[i]))
 			number = (number * 10) + (name[i] - '0');
 		else
 			break;

--- a/lib/frrstr.c
+++ b/lib/frrstr.c
@@ -209,7 +209,7 @@ bool frrstr_endswith(const char *str, const char *suffix)
 int all_digit(const char *str)
 {
 	for (; *str != '\0'; str++)
-		if (!isdigit((int)*str))
+		if (!isdigit((unsigned char)*str))
 			return 0;
 	return 1;
 }

--- a/lib/log.c
+++ b/lib/log.c
@@ -1269,6 +1269,7 @@ void zlog_hexdump(const void *mem, unsigned int len)
 	size_t bs = ((len / 8) + 1) * 53 + 1;
 	char buf[bs];
 	char *s = buf;
+	const unsigned char *memch = mem;
 
 	memset(buf, 0, sizeof(buf));
 
@@ -1277,12 +1278,11 @@ void zlog_hexdump(const void *mem, unsigned int len)
 		/* print offset */
 		if (i % columns == 0)
 			s += snprintf(s, bs - (s - buf),
-				      "0x%016lx: ", (unsigned long)mem + i);
+				      "0x%016lx: ", (unsigned long)memch + i);
 
 		/* print hex data */
 		if (i < len)
-			s += snprintf(s, bs - (s - buf), "%02x ",
-				      0xFF & ((const char *)mem)[i]);
+			s += snprintf(s, bs - (s - buf), "%02x ", memch[i]);
 
 		/* end of block, just aligning for ASCII dump */
 		else
@@ -1294,10 +1294,9 @@ void zlog_hexdump(const void *mem, unsigned int len)
 				/* end of block not really printing */
 				if (j >= len)
 					s += snprintf(s, bs - (s - buf), " ");
-				else if (isprint((int)((const char *)mem)[j]))
-					s += snprintf(
-						s, bs - (s - buf), "%c",
-						0xFF & ((const char *)mem)[j]);
+				else if (isprint(memch[j]))
+					s += snprintf(s, bs - (s - buf), "%c",
+						      memch[j]);
 				else /* other char */
 					s += snprintf(s, bs - (s - buf), ".");
 			}

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -218,7 +218,7 @@ static struct prefix_list *prefix_list_insert(afi_t afi, int orf,
 	/* If name is made by all digit character.  We treat it as
 	   number. */
 	for (number = 0, i = 0; i < strlen(name); i++) {
-		if (isdigit((int)name[i]))
+		if (isdigit((unsigned char)name[i]))
 			number = (number * 10) + (name[i] - '0');
 		else
 			break;

--- a/lib/ptm_lib.c
+++ b/lib/ptm_lib.c
@@ -125,7 +125,7 @@ static int _ptm_lib_decode_header(csv_t *csv, int *msglen, int *version,
 	}
 	/* remove leading spaces */
 	for (i = j = 0; i < csv_field_len(fld); i++) {
-		if (!isspace((int)hdr[i])) {
+		if (!isspace((unsigned char)hdr[i])) {
 			client_name[j] = hdr[i];
 			j++;
 		}

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -337,7 +337,8 @@ void vty_hello(struct vty *vty)
 				/* work backwards to ignore trailling isspace()
 				 */
 				for (s = buf + strlen(buf);
-				     (s > buf) && isspace((int)*(s - 1)); s--)
+				     (s > buf) && isspace((unsigned char)s[-1]);
+				     s--)
 					;
 				*s = '\0';
 				vty_out(vty, "%s\n", buf);
@@ -468,7 +469,7 @@ static int vty_command(struct vty *vty, char *buf)
 		cp = buf;
 	if (cp != NULL) {
 		/* Skip white spaces. */
-		while (isspace((int)*cp) && *cp != '\0')
+		while (isspace((unsigned char)*cp) && *cp != '\0')
 			cp++;
 	}
 	if (cp != NULL && *cp != '\0') {
@@ -892,7 +893,7 @@ static void vty_complete_command(struct vty *vty)
 		return;
 
 	/* In case of 'help \t'. */
-	if (isspace((int)vty->buf[vty->length - 1]))
+	if (isspace((unsigned char)vty->buf[vty->length - 1]))
 		vector_set(vline, NULL);
 
 	matched = cmd_complete_command(vline, vty, &ret);
@@ -1006,7 +1007,7 @@ static void vty_describe_command(struct vty *vty)
 	if (vline == NULL) {
 		vline = vector_init(1);
 		vector_set(vline, NULL);
-	} else if (isspace((int)vty->buf[vty->length - 1]))
+	} else if (isspace((unsigned char)vty->buf[vty->length - 1]))
 		vector_set(vline, NULL);
 
 	describe = cmd_describe_command(vline, vty, &ret);

--- a/tests/lib/cli/test_commands.c
+++ b/tests/lib/cli/test_commands.c
@@ -243,7 +243,8 @@ static void test_run(struct prng *prng, struct vty *vty, const char *cmd,
 				       (test_buf[0] != '\0') ? ", " : "",
 				       test_buf);
 
-			if (isspace((int)test_str[strlen(test_str) - 1])) {
+			if (isspace((unsigned char)test_str[
+				    strlen(test_str) - 1])) {
 				vector_set(vline, NULL);
 				appended_null = 1;
 			}

--- a/tools/coccinelle/ctype_cast.cocci
+++ b/tools/coccinelle/ctype_cast.cocci
@@ -1,0 +1,11 @@
+
+@@
+identifier func =~ "^(to|is)(alnum|cntrl|print|xdigit|alpha|digit|punct|ascii|graph|space|blank|lower|upper)$";
+expression e;
+@@
+
+ func(
+-  (int)
++  (unsigned char)
+  e)
+

--- a/tools/start-stop-daemon.c
+++ b/tools/start-stop-daemon.c
@@ -401,7 +401,7 @@ static void parse_schedule_item(const char *string, struct schedule_item *item)
 
 	if (!strcmp(string, "forever")) {
 		item->type = sched_forever;
-	} else if (isdigit((int)string[0])) {
+	} else if (isdigit((unsigned char)string[0])) {
 		item->type = sched_timeout;
 		if (parse_integer(string, &item->value) != 0)
 			badusage("invalid timeout value in schedule");

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -668,11 +668,11 @@ static char *trim(char *s)
 		return s;
 
 	end = s + size - 1;
-	while (end >= s && isspace((int)*end))
+	while (end >= s && isspace((unsigned char)*end))
 		end--;
 	*(end + 1) = '\0';
 
-	while (*s && isspace((int)*s))
+	while (*s && isspace((unsigned char)*s))
 		s++;
 
 	return s;
@@ -979,7 +979,7 @@ static int vtysh_process_questionmark(const char *input, int input_len)
 	if (vline == NULL) {
 		vline = vector_init(1);
 		vector_set(vline, NULL);
-	} else if (input_len && isspace((int)input[input_len - 1]))
+	} else if (input_len && isspace((unsigned char)input[input_len - 1]))
 		vector_set(vline, NULL);
 
 	describe = cmd_describe_command(vline, vty, &ret);
@@ -1127,7 +1127,8 @@ static char *command_generator(const char *text, int state)
 		if (vline == NULL)
 			return NULL;
 
-		if (rl_end && isspace((int)rl_line_buffer[rl_end - 1]))
+		if (rl_end &&
+		    isspace((unsigned char)rl_line_buffer[rl_end - 1]))
 			vector_set(vline, NULL);
 
 		matched = cmd_complete_command(vline, vty, &complete_status);


### PR DESCRIPTION
The correct cast for these is (unsigned char), because "char" could be
signed and thus have some negative value.  isalpha & co. expect an int
arg that is positive, i.e. 0-255.  So we need to cast to (unsigned char)
when calling any of these.

Bonus: .gitignore update for debian/