### PR TITLE
docs: Add notes about limited MPLS-TE support

### DIFF
--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -149,6 +149,11 @@ options from the list below.
    Turn off building of pimd.  On some BSD platforms pimd will not build properly due
    to lack of kernel support.
 
+.. option:: --disable-vrrpd
+
+   Turn off building of vrrpd. Linux is required for vrrpd support;
+   other platforms are not supported.
+
 .. option:: --disable-pbrd
 
    Turn off building of pbrd.  This daemon currently requires linux in order to function
@@ -194,11 +199,6 @@ options from the list below.
 
    Disable building of the example OSPF-API client.
 
-.. option:: --disable-ospf-ri
-
-   Disable support for OSPF Router Information (RFC4970 & RFC5088) this
-   requires support for Opaque LSAs and Traffic Engineering.
-
 .. option:: --disable-isisd
 
    Do not build isisd.
@@ -210,10 +210,6 @@ options from the list below.
 .. option:: --enable-isis-topology
 
    Enable IS-IS topology generator.
-
-.. option:: --enable-isis-te
-
-   Enable Traffic Engineering Extension for ISIS (RFC5305)
 
 .. option:: --enable-realms
 

--- a/doc/user/isisd.rst
+++ b/doc/user/isisd.rst
@@ -423,6 +423,12 @@ Showing ISIS information
 Traffic Engineering
 ===================
 
+.. note::
+
+   At this time, FRR offers partial support for some of the routing
+   protocol extensions that can be used with MPLS-TE. FRR does not
+   support a complete RSVP-TE solution currently.
+
 .. index:: mpls-te on
 .. clicmd:: mpls-te on
 

--- a/doc/user/ospfd.rst
+++ b/doc/user/ospfd.rst
@@ -906,10 +906,13 @@ Opaque LSA
 .. index:: no capability opaque
 .. clicmd:: no capability opaque
 
-   *ospfd* supports Opaque LSA (:rfc:`2370`) as fundamental for MPLS Traffic
-   Engineering LSA. Prior to used MPLS TE, opaque-lsa must be enable in the
-   configuration file. Alternate command could be "mpls-te on"
-   (:ref:`ospf-traffic-engineering`).
+   *ospfd* supports Opaque LSA (:rfc:`2370`) as partial support for
+   MPLS Traffic Engineering LSAs. The opaque-lsa capability must be
+   enabled in the configuration. An alternate command could be
+   "mpls-te on" (:ref:`ospf-traffic-engineering`). Note that FRR
+   offers only partial support for some of the routing protocol
+   extensions that are used with MPLS-TE; it does not support a
+   complete RSVP-TE solution.
 
 .. index:: show ip ospf database (opaque-link|opaque-area|opaque-external)
 .. clicmd:: show ip ospf database (opaque-link|opaque-area|opaque-external)
@@ -935,6 +938,12 @@ Opaque LSA
 
 Traffic Engineering
 ===================
+
+.. note::
+
+   At this time, FRR offers partial support for some of the routing
+   protocol extensions that can be used with MPLS-TE. FRR does not
+   support a complete RSVP-TE solution currently.
 
 .. index:: mpls-te on
 .. clicmd:: mpls-te on

--- a/doc/user/overview.rst
+++ b/doc/user/overview.rst
@@ -239,7 +239,9 @@ The indicators have the following semantics:
 * :mark:`CP` - control plane only (i.e. BGP route server / route reflector)
 * :mark:`N` - daemon/feature not supported by operating system
 
-.. Known Kernel Issues:
+
+Known Kernel Issues:
+====================
 
 - Linux
    v6 Route Replacement - Linux kernels before 4.11 can cause issues with v6 route deletion when you

--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -193,18 +193,25 @@ Standard Commands
 Link Parameters Commands
 ------------------------
 
+.. note::
+
+   At this time, FRR offers partial support for some of the routing
+   protocol extensions that can be used with MPLS-TE. FRR does not
+   support a complete RSVP-TE solution currently.
+
 .. index:: link-params
 .. clicmd:: link-params
 
 .. index:: no link-param
 .. clicmd:: no link-param
 
-   Enter into the link parameters sub node. At least 'enable' must be set to
-   activate the link parameters, and consequently Traffic Engineering on this
-   interface. MPLS-TE must be enable at the OSPF
-   (:ref:`ospf-traffic-engineering`) or ISIS (:ref:`isis-traffic-engineering`)
-   router level in complement to this.  Disable link parameters for this
-   interface.
+   Enter into the link parameters sub node. At least 'enable' must be
+   set to activate the link parameters, and consequently routing
+   information that could be used as part of Traffic Engineering on
+   this interface. MPLS-TE must be enable at the OSPF
+   (:ref:`ospf-traffic-engineering`) or ISIS
+   (:ref:`isis-traffic-engineering`) router level in complement to
+   this.  Disable link parameters for this interface.
 
    Under link parameter statement, the following commands set the different TE values:
 


### PR DESCRIPTION
Add notes to several doc files about the limits to FRR's current MPLS-TE support, which is limited to some routing protocol LSA/TLV support. It wasn't very clear that FRR does not offer a complete TE/RSVP-TE solution at this time.

Also removed some stale info about configure script options that don't seem to be present.
