### PR TITLE
doc: suggest the installation of the libcap development library

### DIFF
--- a/doc/developer/building-frr-for-centos6.rst
+++ b/doc/developer/building-frr-for-centos6.rst
@@ -45,7 +45,7 @@ Add packages:
 
    sudo yum install git autoconf automake libtool make \
       readline-devel texinfo net-snmp-devel groff pkgconfig \
-      json-c-devel pam-devel flex epel-release c-ares-devel
+      json-c-devel pam-devel flex epel-release c-ares-devel libcap-devel
 
 Install newer version of bison (CentOS 6 package source is too old) from CentOS
 7:

--- a/doc/developer/building-frr-for-centos7.rst
+++ b/doc/developer/building-frr-for-centos7.rst
@@ -21,7 +21,7 @@ Add packages:
     sudo yum install git autoconf automake libtool make \
       readline-devel texinfo net-snmp-devel groff pkgconfig \
       json-c-devel pam-devel bison flex pytest c-ares-devel \
-      python-devel systemd-devel python-sphinx
+      python-devel systemd-devel python-sphinx libcap-devel
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-debian8.rst
+++ b/doc/developer/building-frr-for-debian8.rst
@@ -18,7 +18,7 @@ Add packages:
    sudo apt-get install git autoconf automake libtool make \
       libreadline-dev texinfo libjson-c-dev pkg-config bison flex python3-pip \
       libc-ares-dev python3-dev python3-sphinx build-essential libsystemd-dev \
-      libsnmp-dev
+      libsnmp-dev libcap-dev
 
 Install newer pytest (>3.0) from pip
 

--- a/doc/developer/building-frr-for-debian9.rst
+++ b/doc/developer/building-frr-for-debian9.rst
@@ -11,7 +11,7 @@ Add packages:
    sudo apt-get install git autoconf automake libtool make \
      libreadline-dev texinfo libjson-c-dev pkg-config bison flex \
      libc-ares-dev python3-dev python3-pytest python3-sphinx build-essential \
-     libsnmp-dev libsystemd-dev
+     libsnmp-dev libsystemd-dev libcap-dev
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-fedora.rst
+++ b/doc/developer/building-frr-for-fedora.rst
@@ -14,7 +14,7 @@ Installing Dependencies
    sudo dnf install git autoconf automake libtool make \
      readline-devel texinfo net-snmp-devel groff pkgconfig json-c-devel \
      pam-devel python3-pytest bison flex c-ares-devel python3-devel \
-     python3-sphinx perl-core patch systemd-devel
+     python3-sphinx perl-core patch systemd-devel libcap-devel
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-ubuntu1404.rst
+++ b/doc/developer/building-frr-for-ubuntu1404.rst
@@ -14,7 +14,7 @@ Installing Dependencies
       git autoconf automake libtool make libreadline-dev texinfo \
       pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
       libc-ares-dev python3-dev python3-sphinx install-info build-essential \
-      libsnmp-dev perl
+      libsnmp-dev perl libcap-dev
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-ubuntu1604.rst
+++ b/doc/developer/building-frr-for-ubuntu1604.rst
@@ -14,7 +14,7 @@ Installing Dependencies
       git autoconf automake libtool make libreadline-dev texinfo \
       pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
       libc-ares-dev python3-dev libsystemd-dev python-ipaddress python3-sphinx \
-      install-info build-essential libsystemd-dev libsnmp-dev perl
+      install-info build-essential libsystemd-dev libsnmp-dev perl libcap-dev
 
 .. include:: building-libyang.rst
 

--- a/doc/developer/building-frr-for-ubuntu1804.rst
+++ b/doc/developer/building-frr-for-ubuntu1804.rst
@@ -14,7 +14,7 @@ Installing Dependencies
       git autoconf automake libtool make libreadline-dev texinfo \
       pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
       libc-ares-dev python3-dev libsystemd-dev python-ipaddress python3-sphinx \
-      install-info build-essential libsystemd-dev libsnmp-dev perl
+      install-info build-essential libsystemd-dev libsnmp-dev perl libcap-dev
 
 .. include:: building-libyang.rst
 


### PR DESCRIPTION
All FRR Linux packages are built using libcap-dev (or libcap-devel)
installed in the system. Update the build instructions to suggest
FRR developers to do the same. The main motivation for this is that
the seteuid() system call is too expensive and overall less secure
compared to using the Linux capabilities framework.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>