### PR TITLE
bgpd: tx addpath info for labeled unicast

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2956,7 +2956,8 @@ void bgp_packet_mpattr_prefix(struct stream *s, afi_t afi, safi_t safi,
 				       addpath_encode, addpath_tx_id);
 	} else if (safi == SAFI_LABELED_UNICAST) {
 		/* Prefix write with label. */
-		stream_put_labeled_prefix(s, p, label);
+		stream_put_labeled_prefix(s, p, label, addpath_encode,
+					  addpath_tx_id);
 	} else if (safi == SAFI_FLOWSPEC) {
 		if (PSIZE (p->prefixlen)+2 < FLOWSPEC_NLRI_SIZELIMIT)
 			stream_putc(s, PSIZE (p->prefixlen)+2);

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -199,7 +199,8 @@ extern int stream_put_prefix_addpath(struct stream *, struct prefix *,
 				     uint32_t addpath_tx_id);
 extern int stream_put_prefix(struct stream *, struct prefix *);
 extern int stream_put_labeled_prefix(struct stream *, struct prefix *,
-				     mpls_label_t *);
+				     mpls_label_t *, int addpath_encode,
+				     uint32_t addpath_tx_id);
 extern void stream_get(void *, struct stream *, size_t);
 extern bool stream_get2(void *data, struct stream *s, size_t size);
 extern void stream_get_from(void *, struct stream *, size_t, size_t);


### PR DESCRIPTION
Labeled unicast needs path IDs too!

Fixes #4759 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>