### PR TITLE
zebra: Allow v4 or v6 addresses to be optional after `vrf X` in show …

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1028,7 +1028,7 @@ DEFPY (show_route_all_table_vrf,
 
 DEFPY (show_ip_nht,
        show_ip_nht_cmd,
-       "show <ip$ipv4|ipv6$ipv6> <nht|import-check>$type [<A.B.C.D|X:X::X:X>$addr|vrf NAME$vrf_name <A.B.C.D|X:X::X:X>$addr|vrf all$vrf_all]",
+       "show <ip$ipv4|ipv6$ipv6> <nht|import-check>$type [<A.B.C.D|X:X::X:X>$addr|vrf NAME$vrf_name [<A.B.C.D|X:X::X:X>$addr]|vrf all$vrf_all]",
        SHOW_STR
        IP_STR
        IP6_STR


### PR DESCRIPTION
…ip nht

The `show ip nht vrf EVA ...` command was not allowing you to only
specify the vrf anymore.  Fix this:

robot# show ip nht vrf EVA
  <cr>
  A.B.C.D   IPv4 Address
  X:X::X:X  IPv6 Address
robot# show ip nht vrf EVA 4.5.6.7
robot# show ip nht vrf EVA
robot#

Ticket: CM-25831
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>