### PR TITLE
staticd: Fix blackhole routes being installed

### DIFF
--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -73,6 +73,7 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 	struct static_route *cp;
 	struct static_route *update = NULL;
 	struct route_table *stable = svrf->stable[afi][safi];
+	struct interface *ifp;
 
 	if (!stable)
 		return -1;
@@ -182,11 +183,26 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 	si->next = cp;
 
 	/* check whether interface exists in system & install if it does */
-	if (!ifname)
+	switch (si->type) {
+	case STATIC_IPV4_GATEWAY:
+	case STATIC_IPV6_GATEWAY:
 		static_zebra_nht_register(rn, si, true);
-	else {
-		struct interface *ifp;
+		break;
+	case STATIC_IPV4_GATEWAY_IFNAME:
+	case STATIC_IPV6_GATEWAY_IFNAME:
+		ifp =  if_lookup_by_name(ifname, nh_svrf->vrf->vrf_id);
+		if (ifp && ifp->ifindex != IFINDEX_INTERNAL)
+			si->ifindex = ifp->ifindex;
+		else
+			zlog_warn("Static Route using %s interface not installed because the interface does not exist in specified vrf",
+				  ifname);
 
+		static_zebra_nht_register(rn, si, true);
+		break;
+	case STATIC_BLACKHOLE:
+		static_install_route(rn, si, safi);
+		break;
+	case STATIC_IFNAME:
 		ifp = if_lookup_by_name(ifname, nh_svrf->vrf->vrf_id);
 		if (ifp && ifp->ifindex != IFINDEX_INTERNAL) {
 			si->ifindex = ifp->ifindex;
@@ -194,6 +210,8 @@ int static_add_route(afi_t afi, safi_t safi, uint8_t type, struct prefix *p,
 		} else
 			zlog_warn("Static Route using %s interface not installed because the interface does not exist in specified vrf",
 				  ifname);
+
+		break;
 	}
 
 	return 1;

--- a/tests/topotests/all-protocol-startup/r1/ipv4_routes.ref
+++ b/tests/topotests/all-protocol-startup/r1/ipv4_routes.ref
@@ -10,3 +10,9 @@ C>* 192.168.8.0/26 is directly connected, r1-eth8, XX:XX:XX
 C>* 192.168.9.0/26 is directly connected, r1-eth9, XX:XX:XX
 O   192.168.0.0/24 [110/10] is directly connected, r1-eth0, XX:XX:XX
 O   192.168.3.0/26 [110/10] is directly connected, r1-eth3, XX:XX:XX
+S>* 4.5.6.10/32 [1/0] via 192.168.0.2, r1-eth0, XX:XX:XX
+S>* 4.5.6.11/32 [1/0] via 192.168.0.2, r1-eth0, XX:XX:XX
+S>* 4.5.6.12/32 [1/0] is directly connected, r1-eth0, XX:XX:XX
+S>* 4.5.6.7/32 [1/0] unreachable (blackhole), XX:XX:XX
+S>* 4.5.6.8/32 [1/0] unreachable (blackhole), XX:XX:XX
+S>* 4.5.6.9/32 [1/0] unreachable (ICMP unreachable), XX:XX:XX

--- a/tests/topotests/all-protocol-startup/r1/ipv6_routes.ref
+++ b/tests/topotests/all-protocol-startup/r1/ipv6_routes.ref
@@ -20,3 +20,9 @@ C * fe80::/64 is directly connected, r1-eth7, XX:XX:XX
 C * fe80::/64 is directly connected, r1-eth8, XX:XX:XX
 C * fe80::/64 is directly connected, r1-eth9, XX:XX:XX
 O   fc00:0:0:4::/64 [110/10] is directly connected, r1-eth4, XX:XX:XX
+S>* 4:5::/32 [1/0] is directly connected, r1-eth0, XX:XX:XX
+S>* 4:5::6:10/128 [1/0] via fc00::2, r1-eth0, XX:XX:XX
+S>* 4:5::6:11/128 [1/0] via fc00::2, r1-eth0, XX:XX:XX
+S>* 4:5::6:7/128 [1/0] unreachable (blackhole), XX:XX:XX
+S>* 4:5::6:8/128 [1/0] unreachable (blackhole), XX:XX:XX
+S>* 4:5::6:9/128 [1/0] unreachable (ICMP unreachable), XX:XX:XX

--- a/tests/topotests/all-protocol-startup/r1/zebra.conf
+++ b/tests/topotests/all-protocol-startup/r1/zebra.conf
@@ -2,6 +2,23 @@ log file zebra.log
 !
 hostname r1
 !
+# Create the various blackhole route types
+ip route 4.5.6.7/32 blackhole
+ipv6 route 4:5::6:7/128 blackhole
+ip route 4.5.6.8/32 Null0
+ipv6 route 4:5::6:8/128 Null0
+ip route 4.5.6.9/32 reject
+ipv6 route 4:5::6:9/128 reject
+# Create normal gateway routes
+ip route 4.5.6.10/32 192.168.0.2
+ipv6 route 4:5::6:10/128 fc00:0:0:0::2
+# Create normal gateway + interface routes
+ip route 4.5.6.11/32 192.168.0.2 r1-eth0
+ipv6 route 4:5::6:11/128 fc00:0:0:0::2 r1-eth0
+# Create ifname routes
+ip route 4.5.6.12/32 r1-eth0
+ipv6 route 4:5::6:12/32 r1-eth0
+!
 interface r1-eth0
  description to sw0 - no routing protocol
  ip address 192.168.0.1/24


### PR DESCRIPTION
When we are ready to install a route, we were treating
blackhole routes as something that should be nexthop tracked
which does not work as well as one would expect.

Additionally add some test code to show that this actually
fixes this issue.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>