### PR TITLE
lib,zebra: Append labels on nexthop resolve

### DIFF
--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -119,6 +119,8 @@ void nexthops_free(struct nexthop *nexthop);
 
 void nexthop_add_labels(struct nexthop *, enum lsp_types_t, uint8_t,
 			mpls_label_t *);
+void nexthop_append_labels(struct nexthop *, enum lsp_types_t, uint8_t,
+			   mpls_label_t *);
 void nexthop_del_labels(struct nexthop *);
 
 /*

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1019,33 +1019,28 @@ static void _netlink_route_build_singlepath(const char *routedesc, int bytelen,
 	label_buf[0] = '\0';
 
 	assert(nexthop);
-	for (const struct nexthop *nh = nexthop; nh; nh = nh->rparent) {
-		char label_buf1[20];
+	char label_buf1[20];
 
-		nh_label = nh->nh_label;
-		if (!nh_label || !nh_label->num_labels)
+	nh_label = nexthop->nh_label;
+
+	for (int i = 0; nh_label && i < nh_label->num_labels; i++) {
+		if (nh_label->label[i] == MPLS_LABEL_IMPLICIT_NULL)
 			continue;
 
-		for (int i = 0; i < nh_label->num_labels; i++) {
-			if (nh_label->label[i] == MPLS_LABEL_IMPLICIT_NULL)
-				continue;
-
-			if (IS_ZEBRA_DEBUG_KERNEL) {
-				if (!num_labels)
-					sprintf(label_buf, "label %u",
-						nh_label->label[i]);
-				else {
-					sprintf(label_buf1, "/%u",
-						nh_label->label[i]);
-					strlcat(label_buf, label_buf1,
-						sizeof(label_buf));
-				}
+		if (IS_ZEBRA_DEBUG_KERNEL) {
+			if (!num_labels)
+				sprintf(label_buf, "label %u",
+					nh_label->label[i]);
+			else {
+				sprintf(label_buf1, "/%u", nh_label->label[i]);
+				strlcat(label_buf, label_buf1,
+					sizeof(label_buf));
 			}
-
-			out_lse[num_labels] =
-				mpls_lse_encode(nh_label->label[i], 0, 0, 0);
-			num_labels++;
 		}
+
+		out_lse[num_labels] =
+			mpls_lse_encode(nh_label->label[i], 0, 0, 0);
+		num_labels++;
 	}
 
 	if (num_labels) {
@@ -1210,33 +1205,28 @@ static void _netlink_route_build_multipath(const char *routedesc, int bytelen,
 	label_buf[0] = '\0';
 
 	assert(nexthop);
-	for (const struct nexthop *nh = nexthop; nh; nh = nh->rparent) {
-		char label_buf1[20];
+	char label_buf1[20];
 
-		nh_label = nh->nh_label;
-		if (!nh_label || !nh_label->num_labels)
+	nh_label = nexthop->nh_label;
+
+	for (int i = 0; nh_label && i < nh_label->num_labels; i++) {
+		if (nh_label->label[i] == MPLS_LABEL_IMPLICIT_NULL)
 			continue;
 
-		for (int i = 0; i < nh_label->num_labels; i++) {
-			if (nh_label->label[i] == MPLS_LABEL_IMPLICIT_NULL)
-				continue;
-
-			if (IS_ZEBRA_DEBUG_KERNEL) {
-				if (!num_labels)
-					sprintf(label_buf, "label %u",
-						nh_label->label[i]);
-				else {
-					sprintf(label_buf1, "/%u",
-						nh_label->label[i]);
-					strlcat(label_buf, label_buf1,
-						sizeof(label_buf));
-				}
+		if (IS_ZEBRA_DEBUG_KERNEL) {
+			if (!num_labels)
+				sprintf(label_buf, "label %u",
+					nh_label->label[i]);
+			else {
+				sprintf(label_buf1, "/%u", nh_label->label[i]);
+				strlcat(label_buf, label_buf1,
+					sizeof(label_buf));
 			}
-
-			out_lse[num_labels] =
-				mpls_lse_encode(nh_label->label[i], 0, 0, 0);
-			num_labels++;
 		}
+
+		out_lse[num_labels] =
+			mpls_lse_encode(nh_label->label[i], 0, 0, 0);
+		num_labels++;
 	}
 
 	if (num_labels) {

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -100,6 +100,16 @@ static void nexthop_set_resolved(afi_t afi, const struct nexthop *newhop,
 				   newhop->nh_label->num_labels,
 				   &newhop->nh_label->label[0]);
 
+	/* Append labels of parent as well.
+	 * We have to do this since nexthop objects being
+	 * installed need all of them. We can't iterate up the tree
+	 * when we install the route like we used to.
+	 */
+	if (nexthop->nh_label)
+		nexthop_append_labels(resolved_hop, nexthop->nh_label_type,
+				      nexthop->nh_label->num_labels,
+				      &nexthop->nh_label->label[0]);
+
 	resolved_hop->rparent = nexthop;
 	_nexthop_add(&nexthop->resolved, resolved_hop);
 }


### PR DESCRIPTION
When we resolve a nexthop appends its labels to the resolved nexthop, whether it already has labels or not. Before, we were iterating up the resolution tree to get all labels right before install.

```
K>* 7.7.7.7/32 [0/0] is directly connected, dummy1, label 11111, 00:06:29
D>  8.8.8.8/32 [150/0] via 7.7.7.7 (recursive), 00:06:20
  *                      via 7.7.7.7, dummy1 onlink, label 11111, 00:06:20
S>  9.9.9.9/32 [1/0] via 7.7.7.7 (recursive), label 2222, 00:03:49
  *                    via 7.7.7.7, dummy1 onlink, label 11111/2222, 00:03:49
S>  10.10.10.10/32 [1/0] via 7.7.7.7 (recursive), label 3333, 00:00:05
  *                        via 7.7.7.7, dummy1 onlink, label 11111/3333, 00:00:05
C>* 192.168.122.0/24 is directly connected, ens3, 00:06:29
K>* 192.168.122.1/32 [0/100] is directly connected, ens3, 00:06:29
ubuntu_nh# 
```