### PR TITLE
bgpd: hook for bgp peer status change events

### DIFF
--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -494,13 +494,13 @@ static void bgp_dump_common(struct stream *obuf, struct peer *peer,
 }
 
 /* Dump BGP status change. */
-void bgp_dump_state(struct peer *peer, int status_old, int status_new)
+int bgp_dump_state(struct peer *peer)
 {
 	struct stream *obuf;
 
 	/* If dump file pointer is disabled return immediately. */
 	if (bgp_dump_all.fp == NULL)
-		return;
+		return 0;
 
 	/* Make dump stream. */
 	obuf = bgp_dump_obuf;
@@ -510,8 +510,8 @@ void bgp_dump_state(struct peer *peer, int status_old, int status_new)
 			bgp_dump_all.type);
 	bgp_dump_common(obuf, peer, 1); /* force this in as4speak*/
 
-	stream_putw(obuf, status_old);
-	stream_putw(obuf, status_new);
+	stream_putw(obuf, peer->ostatus);
+	stream_putw(obuf, peer->status);
 
 	/* Set length. */
 	bgp_dump_set_size(obuf, MSG_PROTOCOL_BGP4MP);
@@ -519,6 +519,7 @@ void bgp_dump_state(struct peer *peer, int status_old, int status_new)
 	/* Write to the stream. */
 	fwrite(STREAM_DATA(obuf), stream_get_endp(obuf), 1, bgp_dump_all.fp);
 	fflush(bgp_dump_all.fp);
+	return 0;
 }
 
 static void bgp_dump_packet_func(struct bgp_dump *bgp_dump, struct peer *peer,
@@ -867,6 +868,7 @@ void bgp_dump_init(void)
 	install_element(CONFIG_NODE, &no_dump_bgp_all_cmd);
 
 	hook_register(bgp_packet_dump, bgp_dump_packet);
+	hook_register(peer_status_changed, bgp_dump_state);
 }
 
 void bgp_dump_finish(void)
@@ -878,4 +880,5 @@ void bgp_dump_finish(void)
 	stream_free(bgp_dump_obuf);
 	bgp_dump_obuf = NULL;
 	hook_unregister(bgp_packet_dump, bgp_dump_packet);
+	hook_unregister(peer_status_changed, bgp_dump_state);
 }

--- a/bgpd/bgp_dump.h
+++ b/bgpd/bgp_dump.h
@@ -51,6 +51,6 @@
 
 extern void bgp_dump_init(void);
 extern void bgp_dump_finish(void);
-extern void bgp_dump_state(struct peer *, int, int);
+extern int bgp_dump_state(struct peer *);
 
 #endif /* _QUAGGA_BGP_DUMP_H */

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -57,7 +57,7 @@
 #include "bgpd/bgp_zebra.h"
 
 DEFINE_HOOK(peer_backward_transition, (struct peer * peer), (peer))
-DEFINE_HOOK(peer_established, (struct peer * peer), (peer))
+DEFINE_HOOK(peer_status_changed, (struct peer * peer), (peer))
 
 /* Definition of display strings corresponding to FSM events. This should be
  * kept consistent with the events defined in bgpd.h
@@ -941,8 +941,6 @@ void bgp_fsm_change_status(struct peer *peer, int status)
 	struct bgp *bgp;
 	uint32_t peer_count;
 
-	bgp_dump_state(peer, peer->status, status);
-
 	bgp = peer->bgp;
 	peer_count = bgp->established_peers;
 
@@ -1003,6 +1001,9 @@ void bgp_fsm_change_status(struct peer *peer, int status)
 
 	/* Save event that caused status change. */
 	peer->last_major_event = peer->cur_event;
+
+	/* Operations after status change */
+	hook_call(peer_status_changed, peer);
 
 	if (status == Established)
 		UNSET_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER);
@@ -1643,8 +1644,6 @@ static int bgp_establish(struct peer *peer)
 			zlog_debug("%s graceful restart timer stopped",
 				   peer->host);
 	}
-
-	hook_call(peer_established, peer);
 
 	/* Reset uptime, turn on keepalives, send current table. */
 	if (!peer->v_holdtime)

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -88,6 +88,5 @@ extern void bgp_adjust_routeadv(struct peer *);
 
 #include "hook.h"
 DECLARE_HOOK(peer_backward_transition, (struct peer * peer), (peer))
-DECLARE_HOOK(peer_established, (struct peer * peer), (peer))
 
 #endif /* _QUAGGA_BGP_FSM_H */

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -894,6 +894,10 @@ static int bgpTrapEstablished(struct peer *peer)
 	struct in_addr addr;
 	oid index[sizeof(oid) * IN_ADDR_SIZE];
 
+	/* Check if this peer just went to Established */
+	if ((peer->last_major_event != OpenConfirm) || !(peer_established(peer)))
+		return 0;
+
 	ret = inet_aton(peer->host, &addr);
 	if (ret == 0)
 		return 0;
@@ -935,7 +939,7 @@ static int bgp_snmp_init(struct thread_master *tm)
 
 static int bgp_snmp_module_init(void)
 {
-	hook_register(peer_established, bgpTrapEstablished);
+	hook_register(peer_status_changed, bgpTrapEstablished);
 	hook_register(peer_backward_transition, bgpTrapBackwardTransition);
 	hook_register(frr_late_init, bgp_snmp_init);
 	return 0;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1931,4 +1931,7 @@ extern struct peer *peer_new(struct bgp *bgp);
 extern struct peer *peer_lookup_in_view(struct vty *vty, struct bgp *bgp,
 					const char *ip_str, bool use_json);
 
+/* Hooks */
+DECLARE_HOOK(peer_status_changed, (struct peer * peer), (peer))
+
 #endif /* _QUAGGA_BGPD_H */


### PR DESCRIPTION
Generally available hook for plugging application-specific
code in for bgp peer change events.

Signed-off-by: Marton Kun-Szabo <martonk@amazon.com>