### PR TITLE
Fix potential frr_pthread.c stale pointer

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7931,8 +7931,6 @@ static void bgp_pthreads_init(void)
 	assert(!bgp_pth_io);
 	assert(!bgp_pth_ka);
 
-	frr_pthread_init();
-
 	struct frr_pthread_attr io = {
 		.start = frr_pthread_attr_default.start,
 		.stop = frr_pthread_attr_default.stop,
@@ -7958,7 +7956,6 @@ void bgp_pthreads_run(void)
 void bgp_pthreads_finish(void)
 {
 	frr_pthread_stop_all();
-	frr_pthread_finish();
 }
 
 void bgp_init(unsigned short instance)

--- a/lib/libfrr.c
+++ b/lib/libfrr.c
@@ -42,6 +42,7 @@
 #include "northbound_db.h"
 #include "debug.h"
 #include "frrcu.h"
+#include "frr_pthread.h"
 
 DEFINE_HOOK(frr_late_init, (struct thread_master * tm), (tm))
 DEFINE_KOOH(frr_early_fini, (), ())
@@ -681,6 +682,8 @@ struct thread_master *frr_init(void)
 	memory_init();
 	log_filter_cmd_init();
 
+	frr_pthread_init();
+
 	log_ref_init();
 	log_ref_vty_init();
 	lib_error_init();
@@ -1076,6 +1079,7 @@ void frr_fini(void)
 	db_close();
 #endif
 	log_ref_fini();
+	frr_pthread_finish();
 	zprivs_terminate(di->privs);
 	/* signal_init -> nothing needed */
 	thread_master_free(master);

--- a/tests/bgpd/test_aspath.c
+++ b/tests/bgpd/test_aspath.c
@@ -1379,6 +1379,7 @@ int main(void)
 
 	i = 0;
 
+	frr_pthread_init();
 	bgp_pthreads_init();
 	bgp_pth_ka->running = true;
 

--- a/tests/bgpd/test_capability.c
+++ b/tests/bgpd/test_capability.c
@@ -916,6 +916,7 @@ int main(void)
 	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 
+	frr_pthread_init();
 	bgp_pthreads_init();
 	bgp_pth_ka->running = true;
 

--- a/tests/bgpd/test_peer_attr.c
+++ b/tests/bgpd/test_peer_attr.c
@@ -1391,6 +1391,7 @@ static void bgp_startup(void)
 	bgp_master_init(master);
 	bgp_option_set(BGP_OPT_NO_LISTEN);
 	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	frr_pthread_init();
 	bgp_init(0);
 	bgp_pthreads_run();
 }

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -36,7 +36,6 @@
 #include "vrf.h"
 #include "libfrr.h"
 #include "routemap.h"
-#include "frr_pthread.h"
 
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_errors.h"
@@ -374,9 +373,6 @@ int main(int argc, char **argv)
 	}
 
 	zrouter.master = frr_init();
-
-	/* Initialize pthread library */
-	frr_pthread_init();
 
 	/* Zebra related initialize. */
 	zebra_router_init();


### PR DESCRIPTION
We forgot to delete the frr_pthread struct corresponding to a pthread from the list tracking existing pthreads upon calling `frr_pthread_destroy()`, which would leave dangling references in the list. Pretty sure this would cause a crash if a thread was destroyed and then a list lookup was made, e.g. `show thread cpu`.

This change also inits and finis libfrr pthread facilities automatically during libfrr init and removes manual init and fini from bgpd and zebra. Incidentally, if Zebra had remembered to `frr_pthread_finish()`, we would have been hitting the above bug.