### PR TITLE
Zebra: Incorrect L3VNI for FPM rtmsg for EVPN RT-5 prefix

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -238,7 +238,7 @@ static int netlink_route_info_add_nh(netlink_route_info_t *ri,
 	if (re && CHECK_FLAG(re->flags, ZEBRA_FLAG_EVPN_ROUTE)) {
 		nhi.encap_info.encap_type = FPM_NH_ENCAP_VXLAN;
 
-		zl3vni = zl3vni_from_vrf(ri->rtm_table);
+		zl3vni = zl3vni_from_vrf(nexthop->vrf_id);
 		if (zl3vni && is_l3vni_oper_up(zl3vni)) {
 
 			/* Add VNI to VxLAN encap info */


### PR DESCRIPTION
We used the vrf_id in the rtm_table field of the netlink rtmsg to fetch L3VNI.
But, now we program table_id to rtm_table field instead of vrf_id.
Thus, L3VNI fetched using rtm_table is incorrect.

Instead, use nexthop->vrf_id to fetch correct L3VNI.

Signed-off-by: Ameya Dharkar <adharkar@vmware.com>