### PR TITLE
bgpd: Standard large-communities CLI does not return error when it's configured with reg-ex.

### DIFF
--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -439,7 +439,8 @@ struct lcommunity *lcommunity_str2com(const char *str)
 	enum lcommunity_token token = lcommunity_token_unknown;
 	struct lcommunity_val lval;
 
-	while ((str = lcommunity_gettoken(str, &lval, &token))) {
+	do {
+		str = lcommunity_gettoken(str, &lval, &token);
 		switch (token) {
 		case lcommunity_token_val:
 			if (lcom == NULL)
@@ -452,7 +453,8 @@ struct lcommunity *lcommunity_str2com(const char *str)
 				lcommunity_free(&lcom);
 			return NULL;
 		}
-	}
+	} while (str);
+
 	return lcom;
 }
 


### PR DESCRIPTION
The CLI to configure the standard format large-communities attribute
accepts regular expressions as well.
For ex., the below configuration is accepted.
         "bgp large-community-list standard TEST permit 1:1 100:*"

The code to parse the large-communities does identify the configuration
as invalid however, the error returned isn't processed.
The code has to be modified to handle the error.

Signed-off-by: NaveenThanikachalam nthanikachal@vmware.com