### PR TITLE
bgpd: Assertion failed during shutdown.

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5332,6 +5332,13 @@ static void bgp_purge_af_static_redist_routes(struct bgp *bgp, afi_t afi,
 	struct bgp_node *rn;
 	struct bgp_path_info *pi;
 
+	/* Do not install the aggregate route if BGP is in the
+	 * process of termination.
+	 */
+	if (bgp_flag_check(bgp, BGP_FLAG_DELETE_IN_PROGRESS) ||
+	    (bgp->peer_self == NULL))
+		return;
+
 	table = bgp->rib[afi][safi];
 	for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
 		for (pi = bgp_node_get_bgp_path_info(rn); pi; pi = pi->next) {


### PR DESCRIPTION
A race condition causes the failure.
The function "make_info()" sets the path info's peer to
bgp instance's "peer_self" which is created when BGP is first
configured and deleted only when BGP is brought down completely.
A race condition causes the bgp instances's "peer_self" to be
removed before the routes are being pulled off from the aggregate
address.

If the bgp instance's "peer_self" is NULL or, if BGP is being deleted,
the aggregate route must not be reinstalled.

Signed-off-by: NaveenThanikachalam nthanikachal@vmware.com