### PR TITLE
bgpd : route aggregation optimisation

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -2114,15 +2114,12 @@ static void *bgp_aggr_aspath_hash_alloc(void *p)
 
 static void bgp_aggr_aspath_prepare(struct hash_backet *hb, void *arg)
 {
-	struct aspath *asmerge = NULL;
 	struct aspath *hb_aspath = hb->data;
 	struct aspath **aggr_aspath = arg;
 
-	if (*aggr_aspath) {
-		asmerge = aspath_aggregate(*aggr_aspath, hb_aspath);
-		aspath_free(*aggr_aspath);
-		*aggr_aspath = asmerge;
-	} else
+	if (*aggr_aspath)
+		*aggr_aspath = aspath_aggregate(*aggr_aspath, hb_aspath);
+	else
 		*aggr_aspath = aspath_dup(hb_aspath);
 }
 
@@ -2135,6 +2132,15 @@ void bgp_aggr_aspath_remove(void *arg)
 
 void bgp_compute_aggregate_aspath(struct bgp_aggregate *aggregate,
 				  struct aspath *aspath)
+{
+	bgp_compute_aggregate_aspath_hash(aggregate, aspath);
+	bgp_compute_aggregate_aspath_val(aggregate);
+
+}
+
+
+void bgp_compute_aggregate_aspath_hash(struct bgp_aggregate *aggregate,
+				       struct aspath *aspath)
 {
 	struct aspath *aggr_aspath = NULL;
 
@@ -2154,17 +2160,29 @@ void bgp_compute_aggregate_aspath(struct bgp_aggregate *aggregate,
 		 */
 		aggr_aspath = hash_get(aggregate->aspath_hash, aspath,
 				       bgp_aggr_aspath_hash_alloc);
-
-		/* Compute aggregate's as-path.
-		 */
-		hash_iterate(aggregate->aspath_hash,
-			     bgp_aggr_aspath_prepare,
-			     &aggregate->aspath);
 	}
 
 	/* Increment refernce counter.
 	 */
 	aggr_aspath->refcnt++;
+}
+
+void bgp_compute_aggregate_aspath_val(struct bgp_aggregate *aggregate)
+{
+	if (aggregate == NULL)
+		return;
+	/* Re-compute aggregate's as-path.
+	 */
+	if (aggregate->aspath) {
+		aspath_free(aggregate->aspath);
+		aggregate->aspath = NULL;
+	}
+	if (aggregate->aspath_hash
+	    && aggregate->aspath_hash->count) {
+		hash_iterate(aggregate->aspath_hash,
+			     bgp_aggr_aspath_prepare,
+			     &aggregate->aspath);
+	}
 }
 
 void bgp_remove_aspath_from_aggregate(struct bgp_aggregate *aggregate,
@@ -2173,10 +2191,9 @@ void bgp_remove_aspath_from_aggregate(struct bgp_aggregate *aggregate,
 	struct aspath *aggr_aspath = NULL;
 	struct aspath *ret_aspath = NULL;
 
-	if ((aggregate == NULL) || (aspath == NULL))
-		return;
-
-	if (aggregate->aspath_hash == NULL)
+	if ((!aggregate)
+	    || (!aggregate->aspath_hash)
+	    || (!aspath))
 		return;
 
 	/* Look-up the aspath in the hash.
@@ -2189,17 +2206,42 @@ void bgp_remove_aspath_from_aggregate(struct bgp_aggregate *aggregate,
 			ret_aspath = hash_release(aggregate->aspath_hash,
 						  aggr_aspath);
 			aspath_free(ret_aspath);
+			ret_aspath = NULL;
 
 			/* Remove aggregate's old as-path.
 			 */
 			aspath_free(aggregate->aspath);
 			aggregate->aspath = NULL;
 
-			/* Compute aggregate's as-path.
-			 */
-			hash_iterate(aggregate->aspath_hash,
-				     bgp_aggr_aspath_prepare,
-				     &aggregate->aspath);
+			bgp_compute_aggregate_aspath_val(aggregate);
+
 		}
 	}
 }
+
+void bgp_remove_aspath_from_aggregate_hash(struct bgp_aggregate *aggregate,
+					   struct aspath *aspath)
+{
+	struct aspath *aggr_aspath = NULL;
+	struct aspath *ret_aspath = NULL;
+
+	if ((!aggregate)
+	    || (!aggregate->aspath_hash)
+	    || (!aspath))
+		return;
+
+	/* Look-up the aspath in the hash.
+	 */
+	aggr_aspath = bgp_aggr_aspath_lookup(aggregate, aspath);
+	if (aggr_aspath) {
+		aggr_aspath->refcnt--;
+
+		if (aggr_aspath->refcnt == 0) {
+			ret_aspath = hash_release(aggregate->aspath_hash,
+						  aggr_aspath);
+			aspath_free(ret_aspath);
+			ret_aspath = NULL;
+		}
+	}
+}
+

--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -134,8 +134,16 @@ extern uint8_t *aspath_snmp_pathseg(struct aspath *, size_t *);
 
 extern void bgp_compute_aggregate_aspath(struct bgp_aggregate *aggregate,
 					 struct aspath *aspath);
+
+extern void bgp_compute_aggregate_aspath_hash(struct bgp_aggregate *aggregate,
+					      struct aspath *aspath);
+extern void bgp_compute_aggregate_aspath_val(struct bgp_aggregate *aggregate);
 extern void bgp_remove_aspath_from_aggregate(struct bgp_aggregate *aggregate,
 					     struct aspath *aspath);
+extern void bgp_remove_aspath_from_aggregate_hash(
+						struct bgp_aggregate *aggregate,
+						struct aspath *aspath);
+
 extern void bgp_aggr_aspath_remove(void *arg);
 
 #endif /* _QUAGGA_BGP_ASPATH_H */

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -910,15 +910,13 @@ static void *bgp_aggr_communty_hash_alloc(void *p)
 
 static void bgp_aggr_community_prepare(struct hash_backet *hb, void *arg)
 {
-	struct community *commerge = NULL;
 	struct community *hb_community = hb->data;
 	struct community **aggr_community = arg;
 
-	if (*aggr_community) {
-		commerge = community_merge(*aggr_community, hb_community);
-		*aggr_community = community_uniq_sort(commerge);
-		community_free(&commerge);
-	} else
+	if (*aggr_community)
+		*aggr_community = community_merge(*aggr_community,
+						  hb_community);
+	else
 		*aggr_community = community_dup(hb_community);
 }
 
@@ -931,6 +929,14 @@ void bgp_aggr_community_remove(void *arg)
 
 void bgp_compute_aggregate_community(struct bgp_aggregate *aggregate,
 				     struct community *community)
+{
+	bgp_compute_aggregate_community_hash(aggregate, community);
+	bgp_compute_aggregate_community_val(aggregate);
+}
+
+
+void bgp_compute_aggregate_community_hash(struct bgp_aggregate *aggregate,
+					  struct community *community)
 {
 	struct community *aggr_community = NULL;
 
@@ -951,15 +957,6 @@ void bgp_compute_aggregate_community(struct bgp_aggregate *aggregate,
 		 */
 		aggr_community = hash_get(aggregate->community_hash, community,
 					  bgp_aggr_communty_hash_alloc);
-
-		/* Re-compute aggregate's community.
-		 */
-		if (aggregate->community)
-			community_free(&aggregate->community);
-
-		hash_iterate(aggregate->community_hash,
-			     bgp_aggr_community_prepare,
-			     &aggregate->community);
 	}
 
 	/* Increment refernce counter.
@@ -967,16 +964,39 @@ void bgp_compute_aggregate_community(struct bgp_aggregate *aggregate,
 	aggr_community->refcnt++;
 }
 
+void bgp_compute_aggregate_community_val(struct bgp_aggregate *aggregate)
+{
+	struct community *commerge = NULL;
+
+	if (aggregate == NULL)
+		return;
+
+	/* Re-compute aggregate's community.
+	 */
+	if (aggregate->community)
+		community_free(&aggregate->community);
+	if (aggregate->community_hash &&
+	    aggregate->community_hash->count) {
+		hash_iterate(aggregate->community_hash,
+			     bgp_aggr_community_prepare,
+			     &aggregate->community);
+		commerge = aggregate->community;
+		aggregate->community = community_uniq_sort(commerge);
+		community_free(&commerge);
+	}
+}
+
+
+
 void bgp_remove_community_from_aggregate(struct bgp_aggregate *aggregate,
 					 struct community *community)
 {
 	struct community *aggr_community = NULL;
 	struct community *ret_comm = NULL;
 
-	if ((aggregate == NULL) || (community == NULL))
-		return;
-
-	if (aggregate->community_hash == NULL)
+	if ((!aggregate)
+	    || (!aggregate->community_hash)
+	    || (!community))
 		return;
 
 	/* Look-up the community in the hash.
@@ -990,13 +1010,33 @@ void bgp_remove_community_from_aggregate(struct bgp_aggregate *aggregate,
 						aggr_community);
 			community_free(&ret_comm);
 
-			community_free(&aggregate->community);
+			bgp_compute_aggregate_community_val(aggregate);
+		}
+	}
+}
 
-			/* Compute aggregate's community.
-			 */
-			hash_iterate(aggregate->community_hash,
-				     bgp_aggr_community_prepare,
-				     &aggregate->community);
+void bgp_remove_comm_from_aggregate_hash(struct bgp_aggregate *aggregate,
+		struct community *community)
+{
+
+	struct community *aggr_community = NULL;
+	struct community *ret_comm = NULL;
+
+	if ((!aggregate)
+	    || (!aggregate->community_hash)
+	    || (!community))
+		return;
+
+	/* Look-up the community in the hash.
+	 */
+	aggr_community = bgp_aggr_community_lookup(aggregate, community);
+	if (aggr_community) {
+		aggr_community->refcnt--;
+
+		if (aggr_community->refcnt == 0) {
+			ret_comm = hash_release(aggregate->community_hash,
+						aggr_community);
+			community_free(&ret_comm);
 		}
 	}
 }

--- a/bgpd/bgp_community.h
+++ b/bgpd/bgp_community.h
@@ -92,7 +92,15 @@ extern struct hash *community_hash(void);
 extern uint32_t community_val_get(struct community *com, int i);
 extern void bgp_compute_aggregate_community(struct bgp_aggregate *aggregate,
 					    struct community *community);
+
+extern void bgp_compute_aggregate_community_val(
+					       struct bgp_aggregate *aggregate);
+extern void bgp_compute_aggregate_community_hash(
+						struct bgp_aggregate *aggregate,
+						struct community *community);
 extern void bgp_remove_community_from_aggregate(struct bgp_aggregate *aggregate,
+						struct community *community);
+extern void bgp_remove_comm_from_aggregate_hash(struct bgp_aggregate *aggregate,
 						struct community *community);
 extern void bgp_aggr_community_remove(void *arg);
 

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -1042,15 +1042,13 @@ static void *bgp_aggr_ecommunty_hash_alloc(void *p)
 
 static void bgp_aggr_ecommunity_prepare(struct hash_backet *hb, void *arg)
 {
-	struct ecommunity *ecommerge = NULL;
 	struct ecommunity *hb_ecommunity = hb->data;
 	struct ecommunity **aggr_ecommunity = arg;
 
-	if (*aggr_ecommunity) {
-		ecommerge = ecommunity_merge(*aggr_ecommunity, hb_ecommunity);
-		*aggr_ecommunity = ecommunity_uniq_sort(ecommerge);
-		ecommunity_free(&ecommerge);
-	} else
+	if (*aggr_ecommunity)
+		*aggr_ecommunity = ecommunity_merge(*aggr_ecommunity,
+						    hb_ecommunity);
+	else
 		*aggr_ecommunity = ecommunity_dup(hb_ecommunity);
 }
 
@@ -1063,6 +1061,14 @@ void bgp_aggr_ecommunity_remove(void *arg)
 
 void bgp_compute_aggregate_ecommunity(struct bgp_aggregate *aggregate,
 				      struct ecommunity *ecommunity)
+{
+	bgp_compute_aggregate_ecommunity_hash(aggregate, ecommunity);
+	bgp_compute_aggregate_ecommunity_val(aggregate);
+}
+
+
+void bgp_compute_aggregate_ecommunity_hash(struct bgp_aggregate *aggregate,
+					   struct ecommunity *ecommunity)
 {
 	struct ecommunity *aggr_ecommunity = NULL;
 
@@ -1083,15 +1089,6 @@ void bgp_compute_aggregate_ecommunity(struct bgp_aggregate *aggregate,
 		aggr_ecommunity = hash_get(aggregate->ecommunity_hash,
 					   ecommunity,
 					   bgp_aggr_ecommunty_hash_alloc);
-
-		/* Re-compute aggregate's ecommunity.
-		 */
-		if (aggregate->ecommunity)
-			ecommunity_free(&aggregate->ecommunity);
-
-		hash_iterate(aggregate->ecommunity_hash,
-			     bgp_aggr_ecommunity_prepare,
-			     &aggregate->ecommunity);
 	}
 
 	/* Increment refernce counter.
@@ -1099,16 +1096,38 @@ void bgp_compute_aggregate_ecommunity(struct bgp_aggregate *aggregate,
 	aggr_ecommunity->refcnt++;
 }
 
+void bgp_compute_aggregate_ecommunity_val(struct bgp_aggregate *aggregate)
+{
+	struct ecommunity *ecommerge = NULL;
+
+	if (aggregate == NULL)
+		return;
+
+	/* Re-compute aggregate's ecommunity.
+	 */
+	if (aggregate->ecommunity)
+		ecommunity_free(&aggregate->ecommunity);
+	if (aggregate->ecommunity_hash
+	    && aggregate->ecommunity_hash->count) {
+		hash_iterate(aggregate->ecommunity_hash,
+			     bgp_aggr_ecommunity_prepare,
+			     &aggregate->ecommunity);
+		ecommerge = aggregate->ecommunity;
+		aggregate->ecommunity = ecommunity_uniq_sort(ecommerge);
+		ecommunity_free(&ecommerge);
+	}
+}
+
+
 void bgp_remove_ecommunity_from_aggregate(struct bgp_aggregate *aggregate,
 					  struct ecommunity *ecommunity)
 {
 	struct ecommunity *aggr_ecommunity = NULL;
 	struct ecommunity *ret_ecomm = NULL;
 
-	if ((aggregate == NULL) || (ecommunity == NULL))
-		return;
-
-	if (aggregate->ecommunity_hash == NULL)
+	if ((!aggregate)
+	    || (!aggregate->ecommunity_hash)
+	    || (!ecommunity))
 		return;
 
 	/* Look-up the ecommunity in the hash.
@@ -1121,14 +1140,33 @@ void bgp_remove_ecommunity_from_aggregate(struct bgp_aggregate *aggregate,
 			ret_ecomm = hash_release(aggregate->ecommunity_hash,
 						 aggr_ecommunity);
 			ecommunity_free(&ret_ecomm);
+			bgp_compute_aggregate_ecommunity_val(aggregate);
+		}
+	}
+}
 
-			ecommunity_free(&aggregate->ecommunity);
+void bgp_remove_ecomm_from_aggregate_hash(struct bgp_aggregate *aggregate,
+					  struct ecommunity *ecommunity)
+{
 
-			/* Compute aggregate's ecommunity.
-			 */
-			hash_iterate(aggregate->ecommunity_hash,
-				     bgp_aggr_ecommunity_prepare,
-				     &aggregate->ecommunity);
+	struct ecommunity *aggr_ecommunity = NULL;
+	struct ecommunity *ret_ecomm = NULL;
+
+	if ((!aggregate)
+	    || (!aggregate->ecommunity_hash)
+	    || (!ecommunity))
+		return;
+
+	/* Look-up the ecommunity in the hash.
+	 */
+	aggr_ecommunity = bgp_aggr_ecommunity_lookup(aggregate, ecommunity);
+	if (aggr_ecommunity) {
+		aggr_ecommunity->refcnt--;
+
+		if (aggr_ecommunity->refcnt == 0) {
+			ret_ecomm = hash_release(aggregate->ecommunity_hash,
+						 aggr_ecommunity);
+			ecommunity_free(&ret_ecomm);
 		}
 	}
 }

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -190,7 +190,16 @@ extern int ecommunity_fill_pbr_action(struct ecommunity_val *ecom_eval,
 extern void bgp_compute_aggregate_ecommunity(
 					struct bgp_aggregate *aggregate,
 					struct ecommunity *ecommunity);
+
+extern void bgp_compute_aggregate_ecommunity_hash(
+					struct bgp_aggregate *aggregate,
+					struct ecommunity *ecommunity);
+extern void bgp_compute_aggregate_ecommunity_val(
+					struct bgp_aggregate *aggregate);
 extern void bgp_remove_ecommunity_from_aggregate(
+					struct bgp_aggregate *aggregate,
+					struct ecommunity *ecommunity);
+extern void bgp_remove_ecomm_from_aggregate_hash(
 					struct bgp_aggregate *aggregate,
 					struct ecommunity *ecommunity);
 extern void bgp_aggr_ecommunity_remove(void *arg);

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -555,15 +555,13 @@ static void *bgp_aggr_lcommunty_hash_alloc(void *p)
 
 static void bgp_aggr_lcommunity_prepare(struct hash_backet *hb, void *arg)
 {
-	struct lcommunity *lcommerge = NULL;
 	struct lcommunity *hb_lcommunity = hb->data;
 	struct lcommunity **aggr_lcommunity = arg;
 
-	if (*aggr_lcommunity) {
-		lcommerge = lcommunity_merge(*aggr_lcommunity, hb_lcommunity);
-		*aggr_lcommunity = lcommunity_uniq_sort(lcommerge);
-		lcommunity_free(&lcommerge);
-	} else
+	if (*aggr_lcommunity)
+		*aggr_lcommunity = lcommunity_merge(*aggr_lcommunity,
+						    hb_lcommunity);
+	else
 		*aggr_lcommunity = lcommunity_dup(hb_lcommunity);
 }
 
@@ -577,6 +575,15 @@ void bgp_aggr_lcommunity_remove(void *arg)
 void bgp_compute_aggregate_lcommunity(struct bgp_aggregate *aggregate,
 				      struct lcommunity *lcommunity)
 {
+
+	bgp_compute_aggregate_lcommunity_hash(aggregate, lcommunity);
+	bgp_compute_aggregate_lcommunity_val(aggregate);
+}
+
+void bgp_compute_aggregate_lcommunity_hash(struct bgp_aggregate *aggregate,
+					   struct lcommunity *lcommunity)
+{
+
 	struct lcommunity *aggr_lcommunity = NULL;
 
 	if ((aggregate == NULL) || (lcommunity == NULL))
@@ -585,8 +592,8 @@ void bgp_compute_aggregate_lcommunity(struct bgp_aggregate *aggregate,
 	/* Create hash if not already created.
 	 */
 	if (aggregate->lcommunity_hash == NULL)
-		aggregate->lcommunity_hash = hash_create(
-					lcommunity_hash_make, lcommunity_cmp,
+		aggregate->lcommunity_hash = hash_create(lcommunity_hash_make,
+							 lcommunity_cmp,
 					"BGP Aggregator lcommunity hash");
 
 	aggr_lcommunity = bgp_aggr_lcommunity_lookup(aggregate, lcommunity);
@@ -596,20 +603,33 @@ void bgp_compute_aggregate_lcommunity(struct bgp_aggregate *aggregate,
 		aggr_lcommunity = hash_get(aggregate->lcommunity_hash,
 					   lcommunity,
 					   bgp_aggr_lcommunty_hash_alloc);
-
-		/* Re-compute aggregate's lcommunity.
-		 */
-		if (aggregate->lcommunity)
-			lcommunity_free(&aggregate->lcommunity);
-
-		hash_iterate(aggregate->lcommunity_hash,
-			     bgp_aggr_lcommunity_prepare,
-			     &aggregate->lcommunity);
 	}
 
 	/* Increment refernce counter.
 	 */
 	aggr_lcommunity->refcnt++;
+}
+
+void bgp_compute_aggregate_lcommunity_val(struct bgp_aggregate *aggregate)
+{
+	struct lcommunity *lcommerge = NULL;
+
+	if (aggregate == NULL)
+		return;
+
+	/* Re-compute aggregate's lcommunity.
+	 */
+	if (aggregate->lcommunity)
+		lcommunity_free(&aggregate->lcommunity);
+	if (aggregate->lcommunity_hash &&
+	    aggregate->lcommunity_hash->count) {
+		hash_iterate(aggregate->lcommunity_hash,
+			     bgp_aggr_lcommunity_prepare,
+			     &aggregate->lcommunity);
+		lcommerge = aggregate->lcommunity;
+		aggregate->lcommunity = lcommunity_uniq_sort(lcommerge);
+		lcommunity_free(&lcommerge);
+	}
 }
 
 void bgp_remove_lcommunity_from_aggregate(struct bgp_aggregate *aggregate,
@@ -618,10 +638,9 @@ void bgp_remove_lcommunity_from_aggregate(struct bgp_aggregate *aggregate,
 	struct lcommunity *aggr_lcommunity = NULL;
 	struct lcommunity *ret_lcomm = NULL;
 
-	if ((aggregate == NULL) || (lcommunity == NULL))
-		return;
-
-	if (aggregate->lcommunity_hash == NULL)
+	if ((!aggregate)
+	    || (!aggregate->lcommunity_hash)
+	    || (!lcommunity))
 		return;
 
 	/* Look-up the lcommunity in the hash.
@@ -635,13 +654,34 @@ void bgp_remove_lcommunity_from_aggregate(struct bgp_aggregate *aggregate,
 						 aggr_lcommunity);
 			lcommunity_free(&ret_lcomm);
 
-			lcommunity_free(&aggregate->lcommunity);
+			bgp_compute_aggregate_lcommunity_val(aggregate);
 
-			/* Compute aggregate's lcommunity.
-			 */
-			hash_iterate(aggregate->lcommunity_hash,
-				     bgp_aggr_lcommunity_prepare,
-				     &aggregate->lcommunity);
+		}
+	}
+}
+
+void bgp_remove_lcomm_from_aggregate_hash(struct bgp_aggregate *aggregate,
+					  struct lcommunity *lcommunity)
+{
+
+	struct lcommunity *aggr_lcommunity = NULL;
+	struct lcommunity *ret_lcomm = NULL;
+
+	if ((!aggregate)
+	    || (!aggregate->lcommunity_hash)
+	    || (!lcommunity))
+		return;
+
+	/* Look-up the lcommunity in the hash.
+	 */
+	aggr_lcommunity = bgp_aggr_lcommunity_lookup(aggregate, lcommunity);
+	if (aggr_lcommunity) {
+		aggr_lcommunity->refcnt--;
+
+		if (aggr_lcommunity->refcnt == 0) {
+			ret_lcomm = hash_release(aggregate->lcommunity_hash,
+						 aggr_lcommunity);
+			lcommunity_free(&ret_lcomm);
 		}
 	}
 }

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -439,7 +439,8 @@ struct lcommunity *lcommunity_str2com(const char *str)
 	enum lcommunity_token token = lcommunity_token_unknown;
 	struct lcommunity_val lval;
 
-	while ((str = lcommunity_gettoken(str, &lval, &token))) {
+	do {
+		str = lcommunity_gettoken(str, &lval, &token);
 		switch (token) {
 		case lcommunity_token_val:
 			if (lcom == NULL)
@@ -452,7 +453,8 @@ struct lcommunity *lcommunity_str2com(const char *str)
 				lcommunity_free(&lcom);
 			return NULL;
 		}
-	}
+	} while (str);
+
 	return lcom;
 }
 

--- a/bgpd/bgp_lcommunity.h
+++ b/bgpd/bgp_lcommunity.h
@@ -75,7 +75,17 @@ extern void lcommunity_del_val(struct lcommunity *lcom, uint8_t *ptr);
 extern void bgp_compute_aggregate_lcommunity(
 					struct bgp_aggregate *aggregate,
 					struct lcommunity *lcommunity);
+
+extern void bgp_compute_aggregate_lcommunity_hash(
+					struct bgp_aggregate *aggregate,
+					struct lcommunity *lcommunity);
+extern void bgp_compute_aggregate_lcommunity_val(
+					struct bgp_aggregate *aggregate);
+
 extern void bgp_remove_lcommunity_from_aggregate(
+					struct bgp_aggregate *aggregate,
+					struct lcommunity *lcommunity);
+extern void bgp_remove_lcomm_from_aggregate_hash(
 					struct bgp_aggregate *aggregate,
 					struct lcommunity *lcommunity);
 extern void bgp_aggr_lcommunity_remove(void *arg);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5920,8 +5920,8 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 			 */
 			/* Compute aggregate route's as-path.
 			 */
-			bgp_compute_aggregate_aspath(aggregate,
-						     pi->attr->aspath);
+			bgp_compute_aggregate_aspath_hash(aggregate,
+							  pi->attr->aspath);
 
 			/* Compute aggregate route's community.
 			 */
@@ -5948,6 +5948,7 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 			bgp_process(bgp, rn, afi, safi);
 	}
 	if (aggregate->as_set) {
+		bgp_compute_aggregate_aspath_val(aggregate);
 		bgp_compute_aggregate_community_val(aggregate);
 		bgp_compute_aggregate_ecommunity_val(aggregate);
 		bgp_compute_aggregate_lcommunity_val(aggregate);
@@ -6034,7 +6035,7 @@ static void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 			if (aggregate->as_set) {
 				/* Remove as-path from aggregate.
 				 */
-				bgp_remove_aspath_from_aggregate(
+				bgp_remove_aspath_from_aggregate_hash(
 							aggregate,
 							pi->attr->aspath);
 
@@ -6067,6 +6068,8 @@ static void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 			bgp_process(bgp, rn, afi, safi);
 	}
 	if (aggregate->as_set) {
+		aspath_free(aggregate->aspath);
+		aggregate->aspath = NULL;
 		if (aggregate->community)
 			community_free(&aggregate->community);
 		if (aggregate->ecommunity)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5940,13 +5940,16 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 			/* Compute aggregate route's large community.
 			 */
 			if (pi->attr->lcommunity)
-				bgp_compute_aggregate_lcommunity(
+				bgp_compute_aggregate_lcommunity_hash(
 							aggregate,
 							pi->attr->lcommunity);
 		}
 		if (match)
 			bgp_process(bgp, rn, afi, safi);
 	}
+	if (aggregate->as_set)
+		bgp_compute_aggregate_lcommunity_val(aggregate);
+
 	bgp_unlock_node(top);
 
 
@@ -6048,7 +6051,7 @@ static void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 				if (pi->attr->lcommunity)
 					/* Remove lcommunity from aggregate.
 					 */
-					bgp_remove_lcommunity_from_aggregate(
+					bgp_remove_lcomm_from_aggregate_hash(
 							aggregate,
 							pi->attr->lcommunity);
 			}
@@ -6059,6 +6062,11 @@ static void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 		if (match)
 			bgp_process(bgp, rn, afi, safi);
 	}
+	if (aggregate->as_set) {
+		if (aggregate->lcommunity)
+			lcommunity_free(&aggregate->lcommunity);
+	}
+
 	bgp_unlock_node(top);
 }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5933,7 +5933,7 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 			/* Compute aggregate route's extended community.
 			 */
 			if (pi->attr->ecommunity)
-				bgp_compute_aggregate_ecommunity(
+				bgp_compute_aggregate_ecommunity_hash(
 							aggregate,
 							pi->attr->ecommunity);
 
@@ -5949,6 +5949,7 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 	}
 	if (aggregate->as_set) {
 		bgp_compute_aggregate_community_val(aggregate);
+		bgp_compute_aggregate_ecommunity_val(aggregate);
 		bgp_compute_aggregate_lcommunity_val(aggregate);
 	}
 
@@ -6047,7 +6048,7 @@ static void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 				if (pi->attr->ecommunity)
 					/* Remove ecommunity from aggregate.
 					 */
-					bgp_remove_ecommunity_from_aggregate(
+					bgp_remove_ecomm_from_aggregate_hash(
 							aggregate,
 							pi->attr->ecommunity);
 
@@ -6068,6 +6069,8 @@ static void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 	if (aggregate->as_set) {
 		if (aggregate->community)
 			community_free(&aggregate->community);
+		if (aggregate->ecommunity)
+			ecommunity_free(&aggregate->ecommunity);
 		if (aggregate->lcommunity)
 			lcommunity_free(&aggregate->lcommunity);
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5926,7 +5926,7 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 			/* Compute aggregate route's community.
 			 */
 			if (pi->attr->community)
-				bgp_compute_aggregate_community(
+				bgp_compute_aggregate_community_hash(
 							aggregate,
 							pi->attr->community);
 
@@ -5947,8 +5947,11 @@ static void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 		if (match)
 			bgp_process(bgp, rn, afi, safi);
 	}
-	if (aggregate->as_set)
+	if (aggregate->as_set) {
+		bgp_compute_aggregate_community_val(aggregate);
 		bgp_compute_aggregate_lcommunity_val(aggregate);
+	}
+
 
 	bgp_unlock_node(top);
 
@@ -6037,7 +6040,7 @@ static void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 				if (pi->attr->community)
 					/* Remove community from aggregate.
 					 */
-					bgp_remove_community_from_aggregate(
+					bgp_remove_comm_from_aggregate_hash(
 							aggregate,
 							pi->attr->community);
 
@@ -6063,6 +6066,8 @@ static void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 			bgp_process(bgp, rn, afi, safi);
 	}
 	if (aggregate->as_set) {
+		if (aggregate->community)
+			community_free(&aggregate->community);
 		if (aggregate->lcommunity)
 			lcommunity_free(&aggregate->lcommunity);
 	}


### PR DESCRIPTION
Problems Statement:
There are 10K routes in BGP RIB with all routes have unique 32 large-communities 
values. When bgp aggregation command is coming for all 10K routes, then 
aggregation flow is taking one route at a time and start preparing the hash and
calculating the resulting lcomm value for that route. This includes unique
sort and merging of lcomm values. This merge and unique sort operation is
making the bgp to go 100% for a longer duration as it gets run for 10K times.

Fix Summary:
While configuring aggregate route prepare the hash table first, then prepare the 
aggregated ecomm value and then do the unique sort once for ecommunity.

This problem is applicable for standard community, ecommunity and AS-path. 

Tests Done:
1. aggregate the routes and remove aggregate the routes when
   routes are in the system and no routes in the system.
2. aggregate the routes and send the route from remote.
3. aggregate the routes and remove the routes from remote,
4. aggregate the routes and add, delete routes locally. 