### PR TITLE
zebra : blackhole_type was not set correctly in recursive routes

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -87,7 +87,7 @@ static void nexthop_set_resolved(afi_t afi, const struct nexthop *newhop,
 		break;
 	case NEXTHOP_TYPE_BLACKHOLE:
 		resolved_hop->type = NEXTHOP_TYPE_BLACKHOLE;
-		resolved_hop->bh_type = nexthop->bh_type;
+		resolved_hop->bh_type = newhop->bh_type;
 		break;
 	}
 


### PR DESCRIPTION
If there is a recursive route resolved over blackhole route, then
the resolved blackhole_type is not getting set correctly.
This fix updates the bh_type correctly for resursive routes.

Signed-off-by: vishaldhingra <vdhingra@vmware.com>