### PR TITLE
Clean up zebra's show interface display

### DIFF
--- a/lib/if.h
+++ b/lib/if.h
@@ -478,7 +478,9 @@ extern int if_cmp_name_func(const char *p1, const char *p2);
  */
 extern void if_update_to_new_vrf(struct interface *, vrf_id_t vrf_id);
 extern struct interface *if_create(const char *name, vrf_id_t vrf_id);
+extern struct interface *if_create_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
 extern struct interface *if_lookup_by_index(ifindex_t, vrf_id_t vrf_id);
+extern struct interface *if_lookup_by_index_all_vrf(ifindex_t);
 extern struct interface *if_lookup_exact_address(void *matchaddr, int family,
 						 vrf_id_t vrf_id);
 extern struct connected *if_lookup_address(void *matchaddr, int family,
@@ -493,6 +495,7 @@ size_t if_lookup_by_hwaddr(const uint8_t *hw_addr, size_t addrsz,
 extern struct interface *if_lookup_by_name_all_vrf(const char *ifname);
 extern struct interface *if_lookup_by_name(const char *ifname, vrf_id_t vrf_id);
 extern struct interface *if_get_by_name(const char *ifname, vrf_id_t vrf_id);
+extern struct interface *if_get_by_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
 extern void if_set_index(struct interface *ifp, ifindex_t ifindex);
 
 /* Delete the interface, but do not free the structure, and leave it in the

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -590,7 +590,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	char *kind = NULL;
 	char *desc = NULL;
 	char *slave_kind = NULL;
-	struct zebra_ns *zns;
+	struct zebra_ns *zns = NULL;
 	vrf_id_t vrf_id = VRF_DEFAULT;
 	zebra_iftype_t zif_type = ZEBRA_IF_OTHER;
 	zebra_slave_iftype_t zif_slave_type = ZEBRA_IF_SLAVE_NONE;
@@ -598,6 +598,7 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	ifindex_t link_ifindex = IFINDEX_INTERNAL;
 	ifindex_t bond_ifindex = IFINDEX_INTERNAL;
 	struct zebra_if *zif;
+	struct vrf *vrf = NULL;
 
 	zns = zebra_ns_lookup(ns_id);
 	ifi = NLMSG_DATA(h);
@@ -681,9 +682,17 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (tb[IFLA_LINK])
 		link_ifindex = *(ifindex_t *)RTA_DATA(tb[IFLA_LINK]);
 
-	/* Add interface. */
-	ifp = if_get_by_name(name, vrf_id);
-	set_ifindex(ifp, ifi->ifi_index, zns);
+	vrf = vrf_get(vrf_id, NULL);
+	/* Add interface.
+	 * We add by index first because in some cases such as the master
+	 * interface, we have the index before we have the name. Fixing
+	 * back references on the slave interfaces is painful if not done
+	 * this way, i.e. by creating by ifindex.
+	 */
+	ifp = if_get_by_ifindex(ifi->ifi_index, vrf_id);
+	set_ifindex(ifp, ifi->ifi_index, zns); /* add it to ns struct */
+	strlcpy(ifp->name, name, sizeof(ifp->name));
+	IFNAME_RB_INSERT(vrf, ifp);
 	ifp->flags = ifi->ifi_flags & 0x0000fffff;
 	ifp->mtu6 = ifp->mtu = *(uint32_t *)RTA_DATA(tb[IFLA_MTU]);
 	ifp->metric = 0;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1382,26 +1382,35 @@ static void if_dump_vty(struct vty *vty, struct interface *ifp)
 		struct zebra_l2info_brslave *br_slave;
 
 		br_slave = &zebra_if->brslave_info;
-		if (br_slave->bridge_ifindex != IFINDEX_INTERNAL)
-			vty_out(vty, "  Master (bridge) ifindex %u\n",
-				br_slave->bridge_ifindex);
+		if (br_slave->bridge_ifindex != IFINDEX_INTERNAL) {
+			if (br_slave->br_if)
+				vty_out(vty, "  Master interface: %s\n",
+					br_slave->br_if->name);
+			else
+				vty_out(vty, "  Master ifindex: %u\n",
+					br_slave->bridge_ifindex);
+		}
 	}
 
 	if (IS_ZEBRA_IF_BOND_SLAVE(ifp)) {
 		struct zebra_l2info_bondslave *bond_slave;
 
 		bond_slave = &zebra_if->bondslave_info;
-		if (bond_slave->bond_ifindex != IFINDEX_INTERNAL)
-			vty_out(vty, "  Master (bond) ifindex %u\n",
-				bond_slave->bond_ifindex);
+		if (bond_slave->bond_ifindex != IFINDEX_INTERNAL) {
+			if (bond_slave->bond_if)
+				vty_out(vty, "  Master interface: %s\n",
+					bond_slave->bond_if->name);
+			else
+				vty_out(vty, "  Master ifindex: %u\n",
+					bond_slave->bond_ifindex);
+		}
 	}
 
 	if (zebra_if->link_ifindex != IFINDEX_INTERNAL) {
-		vty_out(vty, "  Link ifindex %u", zebra_if->link_ifindex);
 		if (zebra_if->link)
-			vty_out(vty, "(%s)\n", zebra_if->link->name);
+			vty_out(vty, "  Parent interface: %s\n", zebra_if->link->name);
 		else
-			vty_out(vty, "(Unknown)\n");
+			vty_out(vty, "  Parent ifindex: %d\n", zebra_if->link_ifindex);
 	}
 
 	if (HAS_LINK_PARAMS(ifp)) {

--- a/zebra/zebra_l2.h
+++ b/zebra/zebra_l2.h
@@ -81,7 +81,7 @@ extern void zebra_l2_map_slave_to_bridge(struct zebra_l2info_brslave *br_slave);
 extern void
 zebra_l2_unmap_slave_from_bridge(struct zebra_l2info_brslave *br_slave);
 extern void
-zebra_l2_map_slave_to_bond(struct zebra_l2info_bondslave *bond_slave);
+zebra_l2_map_slave_to_bond(struct zebra_l2info_bondslave *bond_slave, vrf_id_t);
 extern void
 zebra_l2_unmap_slave_from_bond(struct zebra_l2info_bondslave *bond_slave);
 extern void zebra_l2_bridge_add_update(struct interface *ifp,


### PR DESCRIPTION
The two patches submitted clean up zebra's show interface display to display master/parent interface names instead of interface ifindices.