### PR TITLE
zebra : zebra redistributing IPV4 link local connected routes inconsistently.

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -172,6 +172,13 @@ void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 			  __FUNCTION__);
 		return;
 	}
+	if (!zebra_check_addr(p)) {
+		if (IS_ZEBRA_DEBUG_RIB)
+			zlog_debug("Redist update filter prefix %s",
+				   prefix2str(p, buf, sizeof(buf)));
+		return;
+	}
+
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		send_redistribute = 0;
@@ -243,6 +250,13 @@ void redistribute_delete(const struct prefix *p, const struct prefix *src_p,
 		flog_warn(EC_ZEBRA_REDISTRIBUTE_UNKNOWN_AF,
 			  "%s: Unknown AFI/SAFI prefix received\n",
 			  __FUNCTION__);
+		return;
+	}
+
+	if (!zebra_check_addr(p)) {
+		if (IS_ZEBRA_DEBUG_RIB)
+			zlog_debug("Redist delete filter prefix %s",
+				   prefix2str(p, buf, sizeof(buf)));
 		return;
 	}
 


### PR DESCRIPTION
Create an interface with IP4 link local address 169.254.0.131/25.
In BGP enable the redistribute connected. Now Zebra will not send
the route corresponding to IPV4 link local address. Now made this
interface down and up. Zebra sends the route to BGP.
Zebra should not send this route to BGP.
This Fix would make the behaviour consistent and would not send the
routes corresponding to IPV4 Link local addresses.

Signed-off-by: vishaldhingra <vdhingra@vmware.com>