### PR TITLE
build: add check for python-3.8

### DIFF
--- a/m4/ax_python.m4
+++ b/m4/ax_python.m4
@@ -186,7 +186,11 @@ AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
       AC_MSG_RESULT([yes])
 
       PYTHON_CFLAGS="`\"$pycfg\" --includes`"
-      PYTHON_LIBS="`\"$pycfg\" --ldflags`"
+      if test x"${py_ver}" == x"3.8" || test x"{py_ver}" == x"3.9"; then
+        PYTHON_LIBS="`\"$pycfg\" --ldflags --embed`"
+      else
+        PYTHON_LIBS="`\"$pycfg\" --ldflags`"
+      fi
 
       AC_MSG_CHECKING([whether ${pycfg} provides a working build environment])
       _FRR_PYTHON_DEVENV([$py_hex], [


### PR DESCRIPTION
In python-3.8, the --embed needs to be added to pythonX.Y-config

Signed-off-by: Michal Ruprich <michalruprich@gmail.com>