### PR TITLE
bgpd: Adding new bgp evpn cli's for ip-prefix lookup

### DIFF
--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -190,5 +190,6 @@ extern void bgp_evpn_flood_control_change(struct bgp *bgp);
 extern void bgp_evpn_cleanup_on_disable(struct bgp *bgp);
 extern void bgp_evpn_cleanup(struct bgp *bgp);
 extern void bgp_evpn_init(struct bgp *bgp);
+extern int bgp_evpn_get_type5_prefixlen(struct prefix *pfx);
 
 #endif /* _QUAGGA_BGP_EVPN_H */

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -407,6 +407,8 @@ extern void prefix_mcast_inet4_dump(const char *onfail, struct in_addr addr,
 				char *buf, int buf_size);
 extern const char *prefix_sg2str(const struct prefix_sg *sg, char *str);
 extern const char *prefix2str(union prefixconstptr, char *, int);
+extern int evpn_type5_prefix_match(const struct prefix *evpn_pfx,
+				   const struct prefix *match_pfx);
 extern int prefix_match(const struct prefix *, const struct prefix *);
 extern int prefix_match_network_statement(const struct prefix *,
 					  const struct prefix *);


### PR DESCRIPTION
Implement the following CLIs to filter for ip-prefix of evpn type5 routes:
**(Note that this filter would return longest prefix only, and not all the matching prefixes.)**
```
1) show bgp l2vpn evpn A.B.C.D
2) show bgp l2vpn evpn A.B.C.D json
3) show bgp l2vpn evpn A.B.C.D/M
4) show bgp l2vpn evpn A.B.C.D/M json
5) show bgp l2vpn evpn X:X::X:X
6) show bgp l2vpn evpn X:X::X:X json
7) show bgp l2vpn evpn X:X::X:X/M
8) show bgp l2vpn evpn X:X::X:X/M json
```

```
# Note that 100.100.99.x also returns the same output
leaf-1# sh bgp l2vpn evpn 100.100.99.0 json
{
  "10.101.1.2:2":{
    "rd":"10.101.1.2:2",
    "routeType":5,
    "ethTag":0,
    "ipLen": 25,
    "ip":"100.100.99.0",
    "advertisedTo":{
      "203.0.113.2":{
        "hostname":"leaf-2"
      },
      "203.0.113.4":{
        "hostname":"rs"
      }
    },
    "paths":[
      {
        "VNI":"1000",
        "aspath":{
          "string":"Local",
          "segments":[
          ],
          "length":0
        },
        "origin":"IGP",
        "med":0,
        "metric":0,
        "weight":32768,
        "valid":true,
        "sourced":true,
        "local":true,
        "bestpath":{
          "overall":true,
          "selectionReason":"First path received"
        },
        "extendedCommunity":{
          "string":"ET:8 RT:65000:1000 Rmac:66:af:cc:19:4b:fb"
        },
        "lastUpdate":{
          "epoch":1568155067,
          "string":"Tue Sep 10 15:37:47 2019\n"
        },
        "nexthops":[
          {
            "ip":"10.100.0.1",
            "afi":"ipv4",
            "metric":0,
            "accessible":true,
            "used":true
          }
        ],
        "peer":{
          "peerId":"0.0.0.0",
          "routerId":"10.100.0.1"
        }
      }
    ]
  },
  "10.101.1.4:4":{
    "rd":"10.101.1.4:4",
    "routeType":5,
    "ethTag":0,
    "ipLen":24,
    "ip":"100.100.99.0",
    "advertisedTo":{
      "203.0.113.2":{
        "hostname":"leaf-2"
      },
      "203.0.113.4":{
        "hostname":"rs"
      }
    },
    "paths":[
      {
        "VNI":"1000",
        "aspath":{
          "string":"65002",
          "segments":[
            {
              "type":"as-sequence",
              "list":[
                65002
              ]
            }
          ],
          "length":1
        },
        "origin":"IGP",
        "med":0,
        "metric":0,
        "valid":true,
        "bestpath":{
          "overall":true,
          "selectionReason":"First path received"
        },
        "extendedCommunity":{
          "string":"RT:65002:1000 ET:8 Rmac:46:48:76:4d:09:75"
        },
        "lastUpdate":{
          "epoch":1568155069,
          "string":"Tue Sep 10 15:37:49 2019\n"
        },
        "nexthops":[
          {
            "ip":"10.100.0.2",
            "afi":"ipv4",
            "metric":0,
            "accessible":true,
            "used":true
          }
        ],
        "peer":{
          "peerId":"203.0.113.2",
          "routerId":"10.100.0.2",
          "hostname":"leaf-2",
          "type":"external"
        }
      }
    ]
  }
}
leaf-1#
leaf-1#
leaf-1# sh bgp l2vpn evpn 100.100.99.0
BGP routing table entry for 10.101.1.2:2:[5]:[0]:[25]:[100.100.99.0]
Paths: (1 available, best #1)
  Advertised to non peer-group peers:
  203.0.113.2 203.0.113.4
  Route [5]:[0]:[25]:[100.100.99.0] VNI 1000
  Local
    10.100.0.1 from 0.0.0.0 (10.100.0.1)
      Origin IGP, metric 0, weight 32768, valid, sourced, local, best (First path received)
      Extended Community: ET:8 RT:65000:1000 Rmac:66:af:cc:19:4b:fb
      Last update: Tue Sep 10 15:37:47 2019

BGP routing table entry for 10.101.1.4:4:[5]:[0]:[24]:[100.100.99.0]
Paths: (1 available, best #1)
  Advertised to non peer-group peers:
  203.0.113.2 203.0.113.4
  Route [5]:[0]:[24]:[100.100.99.0] VNI 1000
  65002
    10.100.0.2 from 203.0.113.2 (10.100.0.2)
      Origin IGP, metric 0, valid, external, best (First path received)
      Extended Community: RT:65002:1000 ET:8 Rmac:46:48:76:4d:09:75
      Last update: Tue Sep 10 15:37:49 2019

leaf-1#
leaf-1#
```



Signed-off-by: Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>