### PR TITLE
bgpd: Remove declarations of unused functions

### DIFF
--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -57,9 +57,6 @@ extern void bgp_notify_send_with_data(struct peer *, uint8_t, uint8_t,
 extern void bgp_route_refresh_send(struct peer *, afi_t, safi_t, uint8_t,
 				   uint8_t, int);
 extern void bgp_capability_send(struct peer *, afi_t, safi_t, int, int);
-extern void bgp_default_update_send(struct peer *, struct attr *, afi_t, safi_t,
-				    struct peer *);
-extern void bgp_default_withdraw_send(struct peer *, afi_t, safi_t);
 
 extern int bgp_capability_receive(struct peer *, bgp_size_t);
 


### PR DESCRIPTION
Code inspection found some functions being declared
in a .h file but FRR does not have the functions
implemented.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>