### PR TITLE
vtysh: [7.0] exit-vrf cli is broken

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1892,7 +1892,7 @@ DEFUNSH(VTYSH_BGPD, rpki_quit, rpki_quit_cmd, "quit",
 	return rpki_exit(self, vty, argc, argv);
 }
 
-DEFUNSH(VTYSH_PIMD|VTYSH_ZEBRA, exit_vrf_config, exit_vrf_config_cmd, "exit-vrf",
+DEFUNSH(VTYSH_VRF, exit_vrf_config, exit_vrf_config_cmd, "exit-vrf",
 	"Exit from VRF configuration mode\n")
 {
 	if (vty->node == VRF_NODE)


### PR DESCRIPTION
exit-vrf is not working any more, so anything configured after executing exit-vrf command are still configured under that VRF context.

For example: Below configuration
```
vrf VRF_A
ip route 11.11.11.11/32 Null0
exit-vrf
ip route 21.21.21.21/32 Null0
```
results in ...

```
vrf VRF_A
 ip route 11.11.11.11/32 Null0
 ip route 21.21.21.21/32 Null0
 exit-vrf
!
```

It should have been

```
!
ip route 21.21.21.21/32 Null0
!
vrf VRF_A
 ip route 11.11.11.11/32 Null0
 exit-vrf
```

Porting #4725 from FRR master.

Signed-off-by: Sri Mohana Singamsetty <msingamsetty@vmware.com>