### PR TITLE
BGP: Rectifying the log messages.

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1304,7 +1304,7 @@ static int bgp_connect_check(struct thread *thread)
 
 	/* If getsockopt is fail, this is fatal error. */
 	if (ret < 0) {
-		zlog_info("can't get sockopt for nonblocking connect: %d(%s)",
+		zlog_err("can't get sockopt for nonblocking connect: %d(%s)",
 			  errno, safe_strerror(errno));
 		BGP_EVENT_ADD(peer, TCP_fatal_error);
 		return -1;

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1031,7 +1031,7 @@ as_t peek_for_as4_capability(struct peer *peer, uint8_t length)
 	as_t as4 = 0;
 
 	if (BGP_DEBUG(as4, AS4))
-		zlog_info(
+		zlog_debug(
 			"%s [AS4] rcv OPEN w/ OPTION parameter len: %u,"
 			" peeking for as4",
 			peer->host, length);
@@ -1075,7 +1075,7 @@ as_t peek_for_as4_capability(struct peer *peer, uint8_t length)
 
 				if (hdr.code == CAPABILITY_CODE_AS4) {
 					if (BGP_DEBUG(as4, AS4))
-						zlog_info(
+						zlog_debug(
 							"[AS4] found AS4 capability, about to parse");
 					as4 = bgp_capability_as4(peer, &hdr);
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2047,7 +2047,7 @@ int peer_activate(struct peer *peer, afi_t afi, safi_t safi)
 	    && !bgp->allocate_mpls_labels[afi][SAFI_UNICAST]) {
 
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_info(
+			zlog_debug(
 				"peer(s) are now active for labeled-unicast, allocate MPLS labels");
 
 		bgp->allocate_mpls_labels[afi][SAFI_UNICAST] = 1;
@@ -2150,7 +2150,7 @@ int peer_deactivate(struct peer *peer, afi_t afi, safi_t safi)
 	    && !bgp_afi_safi_peer_exists(bgp, afi, safi)) {
 
 		if (BGP_DEBUG(zebra, ZEBRA))
-			zlog_info(
+			zlog_debug(
 				"peer(s) are no longer active for labeled-unicast, deallocate MPLS labels");
 
 		bgp->allocate_mpls_labels[afi][SAFI_UNICAST] = 0;


### PR DESCRIPTION
This change addresses the following:
1) Ensures logs under DEBUG macro checks are categorized
   as zlog_debug instead of zlog_info.
2) Error logs are categorized as zlog_err instead of zlog_info.
3) Rephrasing certain logs to make them appear more intuitive.

Signed-off-by: NaveenThanikachalam <nthanikachal@vmware.com>