### PR TITLE
bgpd: evpn convey svi_ip knob to zebra post vni add

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -505,7 +505,9 @@ static void unmap_vni_from_rt(struct bgp *bgp, struct bgpevpn *vpn,
 static void form_auto_rt(struct bgp *bgp, vni_t vni, struct list *rtl)
 {
 	struct ecommunity_val eval;
-	struct ecommunity *ecomadd;
+	struct ecommunity *ecomadd, *ecom;
+	bool ecom_found = false;
+	struct listnode *node;
 
 	if (bgp->advertise_autort_rfc8365)
 		vni |= EVPN_AUTORT_VXLAN;
@@ -513,7 +515,12 @@ static void form_auto_rt(struct bgp *bgp, vni_t vni, struct list *rtl)
 
 	ecomadd = ecommunity_new();
 	ecommunity_add_val(ecomadd, &eval);
-	listnode_add_sort(rtl, ecomadd);
+	for (ALL_LIST_ELEMENTS_RO(rtl, node, ecom))
+		if (ecommunity_cmp(ecomadd, ecom))
+			ecom_found = true;
+
+	if (!ecom_found)
+		listnode_add_sort(rtl, ecomadd);
 }
 
 /*

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5808,6 +5808,9 @@ int bgp_evpn_local_vni_add(struct bgp *bgp, vni_t vni,
 	   It needs to be conveyed again to zebra */
 	bgp_zebra_advertise_gw_macip(bgp, vpn->advertise_gw_macip, vpn->vni);
 
+	/* advertise svi mac-ip knob to zebra */
+	bgp_zebra_advertise_svi_macip(bgp, vpn->advertise_svi_macip, vpn->vni);
+
 	return 0;
 }
 


### PR DESCRIPTION
1) 
With advertise_svi_ip knob enabled per vni. Post vni flap, svi MAC-IP route are not originated.
Fix: When a vni is flapped, upon re-add of the VNI, send advetise_svi_ip knob to zebra.

Workaround:
re-configure advertise-svi-ip under l2vpn/evpn.

2) 
 bgpd: fix evpn ecommunity auto rts

Evpn extended communities like auto rts (import/export) should
check if its present in list before adding it, to avoid duplicate addition.
L3vni_add callback from zebra to bgp may see updates to vnis.
The auto import/export rt derivation may call multiple times.

Testing Done:

    Before:
    TORC11# show bgp l2vpn evpn vni 4001
    VNI: 4001 (known to the kernel)
      Type: L3
      Tenant VRF: vrf1
      RD: 45.0.2.2:3
      Originator IP: 36.0.0.11
      Advertise-gw-macip : n/a
      Import Route Target:
        5546:4001
        5546:4001
      Export Route Target:
        5546:4001
        5546:4001

