### PR TITLE
tests: Add a couple simple Null0 spelling tests

### DIFF
--- a/tests/topotests/all-protocol-startup/r1/ipv4_routes.ref
+++ b/tests/topotests/all-protocol-startup/r1/ipv4_routes.ref
@@ -13,6 +13,8 @@ O   192.168.3.0/26 [110/10] is directly connected, r1-eth3, XX:XX:XX
 S>* 4.5.6.10/32 [1/0] via 192.168.0.2, r1-eth0, XX:XX:XX
 S>* 4.5.6.11/32 [1/0] via 192.168.0.2, r1-eth0, XX:XX:XX
 S>* 4.5.6.12/32 [1/0] is directly connected, r1-eth0, XX:XX:XX
+S>* 4.5.6.13/32 [1/0] unreachable (blackhole), XX:XX:XX
+S>* 4.5.6.14/32 [1/0] unreachable (blackhole), XX:XX:XX
 S>* 4.5.6.7/32 [1/0] unreachable (blackhole), XX:XX:XX
 S>* 4.5.6.8/32 [1/0] unreachable (blackhole), XX:XX:XX
 S>* 4.5.6.9/32 [1/0] unreachable (ICMP unreachable), XX:XX:XX

--- a/tests/topotests/all-protocol-startup/r1/zebra.conf
+++ b/tests/topotests/all-protocol-startup/r1/zebra.conf
@@ -9,6 +9,9 @@ ip route 4.5.6.8/32 Null0
 ipv6 route 4:5::6:8/128 Null0
 ip route 4.5.6.9/32 reject
 ipv6 route 4:5::6:9/128 reject
+# Test various spellings of NULL0 to make sure we accept them
+ip route 4.5.6.13/32 null0
+ip route 4.5.6.14/32 NULL0
 # Create normal gateway routes
 ip route 4.5.6.10/32 192.168.0.2
 ipv6 route 4:5::6:10/128 fc00:0:0:0::2


### PR DESCRIPTION
Add a bit of code to test different spelling of Null0 routes.
This was broken at some point in the past and with recent
changes is working again, but it would be nice to
know when this breaks again.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>