### PR TITLE
lib: remove deprecated stream_resize api

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -186,14 +186,6 @@ size_t stream_resize_inplace(struct stream **sptr, size_t newsize)
 	return orig->size;
 }
 
-size_t __attribute__((deprecated))stream_resize_orig(struct stream *s,
-						     size_t newsize)
-{
-	assert("stream_resize: Switch code to use stream_resize_inplace" == NULL);
-
-	return stream_resize_inplace(&s, newsize);
-}
-
 size_t stream_get_getp(struct stream *s)
 {
 	STREAM_VERIFY_SANE(s);

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -153,11 +153,6 @@ extern void stream_free(struct stream *);
 extern struct stream *stream_copy(struct stream *, struct stream *src);
 extern struct stream *stream_dup(struct stream *);
 
-#if CONFDATE > 20190821
-CPP_NOTICE("lib: time to remove stream_resize_orig")
-#endif
-extern size_t stream_resize_orig(struct stream *s, size_t newsize);
-#define stream_resize stream_resize_orig
 extern size_t stream_resize_inplace(struct stream **sptr, size_t newsize);
 
 extern size_t stream_get_getp(struct stream *);


### PR DESCRIPTION
Today is the day... remove deprecated api and noisy preprocessor notice.