### PR TITLE
Zebra: Rectifying the log messages.

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -385,7 +385,7 @@ void connected_down(struct interface *ifp, struct connected *ifc)
 			return;
 		break;
 	default:
-		zlog_info("Unknown AFI: %s", afi2str(afi));
+		zlog_warn("Unknown AFI: %s", afi2str(afi));
 		break;
 	}
 

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1032,7 +1032,8 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 	/* addr is primary key, SOL if we don't have one */
 	if (addr == NULL) {
-		zlog_debug("%s: NULL address", __func__);
+		zlog_debug("%s: Local Interface Address is NULL for %s",
+			   __func__, ifp->name);
 		return -1;
 	}
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -2034,13 +2034,13 @@ DEFUN (link_params_enable,
 	/* This command could be issue at startup, when activate MPLS TE */
 	/* on a new interface or after a ON / OFF / ON toggle */
 	/* In all case, TE parameters are reset to their default factory */
-	if (IS_ZEBRA_DEBUG_EVENT)
+	if (IS_ZEBRA_DEBUG_EVENT || IS_ZEBRA_DEBUG_MPLS)
 		zlog_debug(
 			"Link-params: enable TE link parameters on interface %s",
 			ifp->name);
 
 	if (!if_link_params_get(ifp)) {
-		if (IS_ZEBRA_DEBUG_EVENT)
+		if (IS_ZEBRA_DEBUG_EVENT || IS_ZEBRA_DEBUG_MPLS)
 			zlog_debug(
 				"Link-params: failed to init TE link parameters  %s",
 				ifp->name);
@@ -2063,8 +2063,9 @@ DEFUN (no_link_params_enable,
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 
-	zlog_debug("MPLS-TE: disable TE link parameters on interface %s",
-		   ifp->name);
+	if (IS_ZEBRA_DEBUG_EVENT || IS_ZEBRA_DEBUG_MPLS)
+		zlog_debug("MPLS-TE: disable TE link parameters on interface %s",
+			   ifp->name);
 
 	if_link_params_free(ifp);
 

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -119,7 +119,7 @@ static void zebra_redistribute(struct zserv *client, int type,
 
 			srcdest_rnode_prefixes(rn, &dst_p, &src_p);
 
-			if (IS_ZEBRA_DEBUG_EVENT)
+			if (IS_ZEBRA_DEBUG_RIB)
 				zlog_debug(
 					"%s: client %s %s(%u) checking: selected=%d, type=%d, distance=%d, metric=%d zebra_check_addr=%d",
 					__func__,
@@ -201,7 +201,7 @@ void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 			send_redistribute = 1;
 
 		if (send_redistribute) {
-			if (IS_ZEBRA_DEBUG_EVENT) {
+			if (IS_ZEBRA_DEBUG_RIB) {
 				zlog_debug(
 					   "%s: client %s %s(%u), type=%d, distance=%d, metric=%d",
 					   __func__,

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -711,7 +711,6 @@ static void zfpm_connection_down(const char *detail)
 	 * Start thread to clean up state after the connection goes down.
 	 */
 	assert(!zfpm_g->t_conn_down);
-	zfpm_debug("Starting conn_down thread");
 	zfpm_rnodes_iter_init(&zfpm_g->t_conn_down_state.iter);
 	zfpm_g->t_conn_down = NULL;
 	thread_add_timer_msec(zfpm_g->master, zfpm_conn_down_thread_cb, NULL, 0,
@@ -805,8 +804,6 @@ static int zfpm_read_cb(struct thread *thread)
 		if (nbyte != (ssize_t)(msg_len - already))
 			goto done;
 	}
-
-	zfpm_debug("Read out a full fpm message");
 
 	/*
 	 * Just throw it away for now.
@@ -1249,7 +1246,7 @@ static int zfpm_connect_cb(struct thread *t)
 
 	sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0) {
-		zfpm_debug("Failed to create socket for connect(): %s",
+		zlog_err("Failed to create socket for connect(): %s",
 			   strerror(errno));
 		zfpm_g->stats.connect_no_sock++;
 		return 0;

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -337,7 +337,7 @@ static void addr2hostprefix(int af, const union g_addr *addr,
 		break;
 	default:
 		memset(prefix, 0, sizeof(*prefix));
-		zlog_debug("%s: unknown address family %d", __func__, af);
+		zlog_warn("%s: unknown address family %d", __func__, af);
 		break;
 	}
 }
@@ -916,7 +916,8 @@ void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, struct vty *vty,
 
 	table = get_rnh_table(vrfid, afi, type);
 	if (!table) {
-		zlog_debug("print_rnhs: rnh table not found");
+		if (IS_ZEBRA_DEBUG_NHT)
+			zlog_debug("print_rnhs: rnh table not found");
 		return;
 	}
 

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -92,7 +92,7 @@ static int zebra_vrf_new(struct vrf *vrf)
 	struct zebra_vrf *zvrf;
 
 	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_info("VRF %s created, id %u", vrf->name, vrf->vrf_id);
+		zlog_debug("VRF %s created, id %u", vrf->name, vrf->vrf_id);
 
 	zvrf = zebra_vrf_alloc();
 	vrf->info = zvrf;


### PR DESCRIPTION
This change addresses the following :
1. Ensures zlog_debug should be under DEBUG macro check
2. Ensures zlog_err and zlog_warn wherever applicable.
3. Removed few posivite logs from fpm handling, whose frequency is high.
4. Removal of function names in the log messages.

Signed-off-by: vishaldhingra <vdhingra@vmware.com>