### PR TITLE
zebra: move evpn neighbors to dataplane

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -441,7 +441,7 @@ void prefix_hexdump(const struct prefix *p)
 	zlog_hexdump(p, sizeof(struct prefix));
 }
 
-int is_zero_mac(struct ethaddr *mac)
+int is_zero_mac(const struct ethaddr *mac)
 {
 	int i = 0;
 

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -470,7 +470,7 @@ extern void masklen2ip6(const int, struct in6_addr *);
 
 extern const char *inet6_ntoa(struct in6_addr);
 
-extern int is_zero_mac(struct ethaddr *mac);
+extern int is_zero_mac(const struct ethaddr *mac);
 extern int prefix_str2mac(const char *str, struct ethaddr *mac);
 extern char *prefix_mac2str(const struct ethaddr *mac, char *buf, int size);
 

--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -57,6 +57,8 @@ enum zebra_dplane_result kernel_address_update_ctx(
 
 enum zebra_dplane_result kernel_mac_update_ctx(struct zebra_dplane_ctx *ctx);
 
+enum zebra_dplane_result kernel_neigh_update_ctx(struct zebra_dplane_ctx *ctx);
+
 extern int kernel_neigh_update(int cmd, int ifindex, uint32_t addr, char *lla,
 			       int llalen, ns_id_t ns_id);
 extern int kernel_interface_set_master(struct interface *master,
@@ -70,11 +72,6 @@ extern int kernel_add_vtep(vni_t vni, struct interface *ifp,
 			   struct in_addr *vtep_ip);
 extern int kernel_del_vtep(vni_t vni, struct interface *ifp,
 			   struct in_addr *vtep_ip);
-extern int kernel_add_neigh(struct interface *ifp, struct ipaddr *ip,
-			    struct ethaddr *mac, uint8_t flags);
-extern int kernel_del_neigh(struct interface *ifp, struct ipaddr *ip);
-extern int kernel_upd_neigh(struct interface *ifp, struct ipaddr *ip,
-                           struct ethaddr *mac, uint8_t flags, uint16_t state);
 
 /*
  * Southbound Initialization routines to get initial starting

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -92,6 +92,41 @@ void rt_netlink_init(void)
 	inet_pton(AF_INET, ipv4_ll_buf, &ipv4_ll);
 }
 
+/*
+ * Mapping from dataplane neighbor flags to netlink flags
+ */
+static uint8_t neigh_flags_to_netlink(uint8_t dplane_flags)
+{
+	uint8_t flags = 0;
+
+	if (dplane_flags & DPLANE_NTF_EXT_LEARNED)
+		flags |= NTF_EXT_LEARNED;
+	if (dplane_flags & DPLANE_NTF_ROUTER)
+		flags |= NTF_ROUTER;
+
+	return flags;
+}
+
+/*
+ * Mapping from dataplane neighbor state to netlink state
+ */
+static uint16_t neigh_state_to_netlink(uint16_t dplane_state)
+{
+	uint16_t state = 0;
+
+	if (dplane_state & DPLANE_NUD_REACHABLE)
+		state |= NUD_REACHABLE;
+	if (dplane_state & DPLANE_NUD_STALE)
+		state |= NUD_STALE;
+	if (dplane_state & DPLANE_NUD_NOARP)
+		state |= NUD_NOARP;
+	if (dplane_state & DPLANE_NUD_PROBE)
+		state |= NUD_PROBE;
+
+	return state;
+}
+
+
 static inline int is_selfroute(int proto)
 {
 	if ((proto == RTPROT_BGP) || (proto == RTPROT_OSPF)
@@ -2778,9 +2813,11 @@ int netlink_neigh_change(struct nlmsghdr *h, ns_id_t ns_id)
 	return 0;
 }
 
-static int netlink_neigh_update2(struct interface *ifp, struct ipaddr *ip,
-				 struct ethaddr *mac, uint8_t flags,
-				 uint16_t state, int cmd)
+/*
+ * Utility neighbor-update function, using info from dplane context.
+ */
+static int netlink_neigh_update_ctx(const struct zebra_dplane_ctx *ctx,
+				    int cmd)
 {
 	struct {
 		struct nlmsghdr n;
@@ -2788,14 +2825,22 @@ static int netlink_neigh_update2(struct interface *ifp, struct ipaddr *ip,
 		char buf[256];
 	} req;
 	int ipa_len;
-
-	struct zebra_ns *zns;
 	char buf[INET6_ADDRSTRLEN];
 	char buf2[ETHER_ADDR_STRLEN];
-	struct zebra_vrf *zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+	const struct ipaddr *ip;
+	const struct ethaddr *mac;
+	uint8_t flags;
+	uint16_t state;
 
-	zns = zvrf->zns;
 	memset(&req, 0, sizeof(req));
+
+	ip = dplane_ctx_neigh_get_ipaddr(ctx);
+	mac = dplane_ctx_neigh_get_mac(ctx);
+	if (is_zero_mac(mac))
+		mac = NULL;
+
+	flags = neigh_flags_to_netlink(dplane_ctx_neigh_get_flags(ctx));
+	state = neigh_state_to_netlink(dplane_ctx_neigh_get_state(ctx));
 
 	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
 	req.n.nlmsg_flags = NLM_F_REQUEST;
@@ -2804,7 +2849,7 @@ static int netlink_neigh_update2(struct interface *ifp, struct ipaddr *ip,
 	req.n.nlmsg_type = cmd; // RTM_NEWNEIGH or RTM_DELNEIGH
 	req.ndm.ndm_family = IS_IPADDR_V4(ip) ? AF_INET : AF_INET6;
 	req.ndm.ndm_state = state;
-	req.ndm.ndm_ifindex = ifp->ifindex;
+	req.ndm.ndm_ifindex = dplane_ctx_get_ifindex(ctx);
 	req.ndm.ndm_type = RTN_UNICAST;
 	req.ndm.ndm_flags = flags;
 
@@ -2816,13 +2861,16 @@ static int netlink_neigh_update2(struct interface *ifp, struct ipaddr *ip,
 	if (IS_ZEBRA_DEBUG_KERNEL)
 		zlog_debug("Tx %s family %s IF %s(%u) Neigh %s MAC %s flags 0x%x state 0x%x",
 			   nl_msg_type_to_str(cmd),
-			   nl_family_to_str(req.ndm.ndm_family), ifp->name,
-			   ifp->ifindex, ipaddr2str(ip, buf, sizeof(buf)),
+			   nl_family_to_str(req.ndm.ndm_family),
+			   dplane_ctx_get_ifname(ctx),
+			   dplane_ctx_get_ifindex(ctx),
+			   ipaddr2str(ip, buf, sizeof(buf)),
 			   mac ? prefix_mac2str(mac, buf2, sizeof(buf2))
-			       : "null", flags, state);
+			       : "null",
+			   flags, state);
 
-	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,
-			    0);
+	return netlink_talk_info(netlink_talk_filter, &req.n,
+				 dplane_ctx_get_ns(ctx), 0);
 }
 
 /*
@@ -2833,23 +2881,24 @@ enum zebra_dplane_result kernel_mac_update_ctx(struct zebra_dplane_ctx *ctx)
 	return netlink_macfdb_update_ctx(ctx);
 }
 
-int kernel_add_neigh(struct interface *ifp, struct ipaddr *ip,
-		     struct ethaddr *mac, uint8_t flags)
+enum zebra_dplane_result kernel_neigh_update_ctx(struct zebra_dplane_ctx *ctx)
 {
-	return netlink_neigh_update2(ifp, ip, mac, flags,
-				     NUD_NOARP, RTM_NEWNEIGH);
-}
+	int ret = -1;
 
-int kernel_del_neigh(struct interface *ifp, struct ipaddr *ip)
-{
-	return netlink_neigh_update2(ifp, ip, NULL, 0, 0, RTM_DELNEIGH);
-}
+	switch (dplane_ctx_get_op(ctx)) {
+	case DPLANE_OP_NEIGH_INSTALL:
+	case DPLANE_OP_NEIGH_UPDATE:
+		ret = netlink_neigh_update_ctx(ctx, RTM_NEWNEIGH);
+		break;
+	case DPLANE_OP_NEIGH_DELETE:
+		ret = netlink_neigh_update_ctx(ctx, RTM_DELNEIGH);
+		break;
+	default:
+		break;
+	}
 
-int kernel_upd_neigh(struct interface *ifp, struct ipaddr *ip,
-		     struct ethaddr *mac, uint8_t flags, uint16_t state)
-{
-	return netlink_neigh_update2(ifp, ip, mac, flags,
-				     state, RTM_NEWNEIGH);
+	return (ret == 0 ?
+		ZEBRA_DPLANE_REQUEST_SUCCESS : ZEBRA_DPLANE_REQUEST_FAILURE);
 }
 
 /*

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -371,6 +371,12 @@ int kernel_neigh_update(int add, int ifindex, uint32_t addr, char *lla,
 	return 0;
 }
 
+/* NYI on routing-socket platforms, but we've always returned 'success'... */
+enum zebra_dplane_result kernel_neigh_update_ctx(struct zebra_dplane_ctx *ctx)
+{
+	return ZEBRA_DPLANE_REQUEST_SUCCESS;
+}
+
 extern int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *mroute)
 {
 	return 0;
@@ -392,17 +398,6 @@ int kernel_del_vtep(vni_t vni, struct interface *ifp, struct in_addr *vtep_ip)
 enum zebra_dplane_result kernel_mac_update_ctx(struct zebra_dplane_ctx *ctx)
 {
 	return ZEBRA_DPLANE_REQUEST_SUCCESS;
-}
-
-int kernel_add_neigh(struct interface *ifp, struct ipaddr *ip,
-		     struct ethaddr *mac, uint8_t flags)
-{
-	return 0;
-}
-
-int kernel_del_neigh(struct interface *ifp, struct ipaddr *ip)
-{
-	return 0;
 }
 
 extern int kernel_interface_set_master(struct interface *master,

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -485,6 +485,8 @@ static void dplane_ctx_free(struct zebra_dplane_ctx **pctx)
 
 	case DPLANE_OP_MAC_INSTALL:
 	case DPLANE_OP_MAC_DELETE:
+	case DPLANE_OP_NEIGH_INSTALL:
+	case DPLANE_OP_NEIGH_DELETE:
 	case DPLANE_OP_NONE:
 		break;
 	}
@@ -650,6 +652,13 @@ const char *dplane_op2str(enum dplane_op_e op)
 		break;
 	case DPLANE_OP_MAC_DELETE:
 		ret = "MAC_DELETE";
+		break;
+
+	case DPLANE_OP_NEIGH_INSTALL:
+		ret = "NEIGH_INSTALL";
+		break;
+	case DPLANE_OP_NEIGH_DELETE:
+		ret = "NEIGH_DELETE";
 		break;
 	}
 

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -159,6 +159,16 @@ struct dplane_mac_info {
 };
 
 /*
+ * EVPN neighbor info for the dataplane
+ */
+struct dplane_neigh_info {
+	struct ipaddr ip_addr;
+	struct ethaddr mac;
+	uint32_t flags;
+	uint16_t state;
+};
+
+/*
  * The context block used to exchange info about route updates across
  * the boundary between the zebra main context (and pthread) and the
  * dataplane layer (and pthread).
@@ -204,6 +214,7 @@ struct zebra_dplane_ctx {
 		struct dplane_pw_info pw;
 		struct dplane_intf_info intf;
 		struct dplane_mac_info macinfo;
+		struct dplane_neigh_info neigh;
 	} u;
 
 	/* Namespace info, used especially for netlink kernel communication */
@@ -321,6 +332,9 @@ static struct zebra_dplane_globals {
 	_Atomic uint32_t dg_macs_in;
 	_Atomic uint32_t dg_mac_errors;
 
+	_Atomic uint32_t dg_neighs_in;
+	_Atomic uint32_t dg_neigh_errors;
+
 	_Atomic uint32_t dg_update_yields;
 
 	/* Dataplane pthread */
@@ -365,6 +379,12 @@ static enum zebra_dplane_result mac_update_internal(
 	enum dplane_op_e op, const struct interface *ifp,
 	vlanid_t vid, const struct ethaddr *mac,
 	struct in_addr vtep_ip,	bool sticky);
+static enum zebra_dplane_result neigh_update_internal(
+	enum dplane_op_e op,
+	const struct interface *ifp,
+	const struct ethaddr *mac,
+	const struct ipaddr *ip,
+	uint32_t flags, uint16_t state);
 
 /*
  * Public APIs
@@ -486,6 +506,7 @@ static void dplane_ctx_free(struct zebra_dplane_ctx **pctx)
 	case DPLANE_OP_MAC_INSTALL:
 	case DPLANE_OP_MAC_DELETE:
 	case DPLANE_OP_NEIGH_INSTALL:
+	case DPLANE_OP_NEIGH_UPDATE:
 	case DPLANE_OP_NEIGH_DELETE:
 	case DPLANE_OP_NONE:
 		break;
@@ -656,6 +677,9 @@ const char *dplane_op2str(enum dplane_op_e op)
 
 	case DPLANE_OP_NEIGH_INSTALL:
 		ret = "NEIGH_INSTALL";
+		break;
+	case DPLANE_OP_NEIGH_UPDATE:
+		ret = "NEIGH_UPDATE";
 		break;
 	case DPLANE_OP_NEIGH_DELETE:
 		ret = "NEIGH_DELETE";
@@ -1238,6 +1262,33 @@ const struct in_addr *dplane_ctx_mac_get_vtep_ip(
 {
 	DPLANE_CTX_VALID(ctx);
 	return &(ctx->u.macinfo.vtep_ip);
+}
+
+/* Accessors for neighbor information */
+const struct ipaddr *dplane_ctx_neigh_get_ipaddr(
+	const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return &(ctx->u.neigh.ip_addr);
+}
+
+const struct ethaddr *dplane_ctx_neigh_get_mac(
+	const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return &(ctx->u.neigh.mac);
+}
+
+uint32_t dplane_ctx_neigh_get_flags(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.neigh.flags;
+}
+
+uint16_t dplane_ctx_neigh_get_state(const struct zebra_dplane_ctx *ctx)
+{
+	DPLANE_CTX_VALID(ctx);
+	return ctx->u.neigh.state;
 }
 
 /*
@@ -2173,6 +2224,116 @@ mac_update_internal(enum dplane_op_e op,
 }
 
 /*
+ * Enqueue evpn neighbor add for the dataplane.
+ */
+enum zebra_dplane_result dplane_neigh_add(const struct interface *ifp,
+					  const struct ipaddr *ip,
+					  const struct ethaddr *mac,
+					  uint32_t flags)
+{
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+
+	result = neigh_update_internal(DPLANE_OP_NEIGH_INSTALL,
+				       ifp, mac, ip, flags, 0);
+
+	return result;
+}
+
+/*
+ * Enqueue evpn neighbor update for the dataplane.
+ */
+enum zebra_dplane_result dplane_neigh_update(const struct interface *ifp,
+					     const struct ipaddr *ip,
+					     const struct ethaddr *mac)
+{
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+
+	result = neigh_update_internal(DPLANE_OP_NEIGH_UPDATE,
+				       ifp, mac, ip, 0, DPLANE_NUD_PROBE);
+
+	return result;
+}
+
+/*
+ * Enqueue evpn neighbor delete for the dataplane.
+ */
+enum zebra_dplane_result dplane_neigh_delete(const struct interface *ifp,
+					     const struct ipaddr *ip)
+{
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+
+	result = neigh_update_internal(DPLANE_OP_NEIGH_DELETE,
+				       ifp, NULL, ip, 0, 0);
+
+	return result;
+}
+
+/*
+ * Common helper api for evpn neighbor updates
+ */
+static enum zebra_dplane_result
+neigh_update_internal(enum dplane_op_e op,
+		      const struct interface *ifp,
+		      const struct ethaddr *mac,
+		      const struct ipaddr *ip,
+		      uint32_t flags, uint16_t state)
+{
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+	int ret;
+	struct zebra_dplane_ctx *ctx = NULL;
+	struct zebra_ns *zns;
+
+	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
+		char buf1[ETHER_ADDR_STRLEN], buf2[PREFIX_STRLEN];
+
+		zlog_debug("init neigh ctx %s: ifp %s, mac %s, ip %s",
+			   dplane_op2str(op),
+			   prefix_mac2str(mac, buf1, sizeof(buf1)),
+			   ifp->name,
+			   ipaddr2str(ip, buf2, sizeof(buf2)));
+	}
+
+	ctx = dplane_ctx_alloc();
+
+	ctx->zd_op = op;
+	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
+	ctx->zd_vrf_id = ifp->vrf_id;
+
+	zns = zebra_ns_lookup(ifp->vrf_id);
+	dplane_ctx_ns_init(ctx, zns, false);
+
+	strlcpy(ctx->zd_ifname, ifp->name, sizeof(ctx->zd_ifname));
+	ctx->zd_ifindex = ifp->ifindex;
+
+	/* Init the neighbor-specific data area */
+	memset(&ctx->u.neigh, 0, sizeof(ctx->u.neigh));
+
+	ctx->u.neigh.ip_addr = *ip;
+	if (mac)
+		ctx->u.neigh.mac = *mac;
+	ctx->u.neigh.flags = flags;
+	ctx->u.neigh.state = state;
+
+	/* Enqueue for processing on the dplane pthread */
+	ret = dplane_update_enqueue(ctx);
+
+	/* Increment counter */
+	atomic_fetch_add_explicit(&zdplane_info.dg_neighs_in, 1,
+				  memory_order_relaxed);
+
+	if (ret == AOK)
+		result = ZEBRA_DPLANE_REQUEST_QUEUED;
+	else {
+		/* Error counter */
+		atomic_fetch_add_explicit(&zdplane_info.dg_neigh_errors, 1,
+					  memory_order_relaxed);
+		dplane_ctx_free(&ctx);
+	}
+
+	return result;
+}
+
+/*
  * Handler for 'show dplane'
  */
 int dplane_show_helper(struct vty *vty, bool detailed)
@@ -2234,6 +2395,13 @@ int dplane_show_helper(struct vty *vty, bool detailed)
 				    memory_order_relaxed);
 	vty_out(vty, "EVPN MAC updates:         %"PRIu64"\n", incoming);
 	vty_out(vty, "EVPN MAC errors:          %"PRIu64"\n", errs);
+
+	incoming = atomic_load_explicit(&zdplane_info.dg_neighs_in,
+					memory_order_relaxed);
+	errs = atomic_load_explicit(&zdplane_info.dg_neigh_errors,
+				    memory_order_relaxed);
+	vty_out(vty, "EVPN neigh updates:       %"PRIu64"\n", incoming);
+	vty_out(vty, "EVPN neigh errors:        %"PRIu64"\n", errs);
 
 	return CMD_SUCCESS;
 }
@@ -2628,7 +2796,7 @@ kernel_dplane_address_update(struct zebra_dplane_ctx *ctx)
 }
 
 /*
- * Handler for kernel-facing MAC address updates
+ * Handler for kernel-facing EVPN MAC address updates
  */
 static enum zebra_dplane_result
 kernel_dplane_mac_update(struct zebra_dplane_ctx *ctx)
@@ -2650,6 +2818,34 @@ kernel_dplane_mac_update(struct zebra_dplane_ctx *ctx)
 
 	if (res != ZEBRA_DPLANE_REQUEST_SUCCESS)
 		atomic_fetch_add_explicit(&zdplane_info.dg_mac_errors,
+					  1, memory_order_relaxed);
+
+	return res;
+}
+
+/*
+ * Handler for kernel-facing EVPN neighbor updates
+ */
+static enum zebra_dplane_result
+kernel_dplane_neigh_update(struct zebra_dplane_ctx *ctx)
+{
+	enum zebra_dplane_result res;
+
+	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
+		char buf[PREFIX_STRLEN];
+
+		ipaddr2str(dplane_ctx_neigh_get_ipaddr(ctx), buf,
+			   sizeof(buf));
+
+		zlog_debug("Dplane %s, ip %s, ifindex %u",
+			   dplane_op2str(dplane_ctx_get_op(ctx)),
+			   buf, dplane_ctx_get_ifindex(ctx));
+	}
+
+	res = kernel_neigh_update_ctx(ctx);
+
+	if (res != ZEBRA_DPLANE_REQUEST_SUCCESS)
+		atomic_fetch_add_explicit(&zdplane_info.dg_neigh_errors,
 					  1, memory_order_relaxed);
 
 	return res;
@@ -2712,6 +2908,12 @@ static int kernel_dplane_process_func(struct zebra_dplane_provider *prov)
 		case DPLANE_OP_MAC_INSTALL:
 		case DPLANE_OP_MAC_DELETE:
 			res = kernel_dplane_mac_update(ctx);
+			break;
+
+		case DPLANE_OP_NEIGH_INSTALL:
+		case DPLANE_OP_NEIGH_UPDATE:
+		case DPLANE_OP_NEIGH_DELETE:
+			res = kernel_dplane_neigh_update(ctx);
 			break;
 
 		/* Ignore 'notifications' - no-op */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -132,8 +132,25 @@ enum dplane_op_e {
 
 	/* EVPN neighbor updates */
 	DPLANE_OP_NEIGH_INSTALL,
+	DPLANE_OP_NEIGH_UPDATE,
 	DPLANE_OP_NEIGH_DELETE,
 };
+
+/*
+ * The vxlan/evpn neighbor management code needs some values to use
+ * when programming neighbor changes. Offer some platform-neutral values
+ * here for use within the dplane apis and plugins.
+ */
+
+/* Neighbor cache flags */
+#define DPLANE_NTF_EXT_LEARNED    0x01
+#define DPLANE_NTF_ROUTER         0x02
+
+/* Neighbor cache states */
+#define DPLANE_NUD_REACHABLE      0x01
+#define DPLANE_NUD_STALE          0x02
+#define DPLANE_NUD_NOARP          0x04
+#define DPLANE_NUD_PROBE          0x08
 
 /* Enable system route notifications */
 void dplane_enable_sys_route_notifs(void);
@@ -308,6 +325,14 @@ const struct ethaddr *dplane_ctx_mac_get_addr(
 const struct in_addr *dplane_ctx_mac_get_vtep_ip(
 	const struct zebra_dplane_ctx *ctx);
 
+/* Accessors for neighbor information */
+const struct ipaddr *dplane_ctx_neigh_get_ipaddr(
+	const struct zebra_dplane_ctx *ctx);
+const struct ethaddr *dplane_ctx_neigh_get_mac(
+	const struct zebra_dplane_ctx *ctx);
+uint32_t dplane_ctx_neigh_get_flags(const struct zebra_dplane_ctx *ctx);
+uint16_t dplane_ctx_neigh_get_state(const struct zebra_dplane_ctx *ctx);
+
 /* Namespace info - esp. for netlink communication */
 const struct zebra_dplane_info *dplane_ctx_get_ns(
 	const struct zebra_dplane_ctx *ctx);
@@ -389,9 +414,12 @@ enum zebra_dplane_result dplane_mac_del(const struct interface *ifp,
 enum zebra_dplane_result dplane_neigh_add(const struct interface *ifp,
 					  const struct ipaddr *ip,
 					  const struct ethaddr *mac,
-					  int32_t flags);
-enum zebra_dplane_result dplane_neigh_del(const struct interface *ifp,
-					  const struct ipaddr *ip);
+					  uint32_t flags);
+enum zebra_dplane_result dplane_neigh_update(const struct interface *ifp,
+					     const struct ipaddr *ip,
+					     const struct ethaddr *mac);
+enum zebra_dplane_result dplane_neigh_delete(const struct interface *ifp,
+					     const struct ipaddr *ip);
 
 /* Retrieve the limit on the number of pending, unprocessed updates. */
 uint32_t dplane_get_in_queue_limit(void);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -129,6 +129,10 @@ enum dplane_op_e {
 	/* MAC address update */
 	DPLANE_OP_MAC_INSTALL,
 	DPLANE_OP_MAC_DELETE,
+
+	/* EVPN neighbor updates */
+	DPLANE_OP_NEIGH_INSTALL,
+	DPLANE_OP_NEIGH_DELETE,
 };
 
 /* Enable system route notifications */
@@ -378,6 +382,16 @@ enum zebra_dplane_result dplane_mac_del(const struct interface *ifp,
 					vlanid_t vid,
 					const struct ethaddr *mac,
 					struct in_addr vtep_ip);
+
+/*
+ * Enqueue evpn neighbor updates for the dataplane.
+ */
+enum zebra_dplane_result dplane_neigh_add(const struct interface *ifp,
+					  const struct ipaddr *ip,
+					  const struct ethaddr *mac,
+					  int32_t flags);
+enum zebra_dplane_result dplane_neigh_del(const struct interface *ifp,
+					  const struct ipaddr *ip);
 
 /* Retrieve the limit on the number of pending, unprocessed updates. */
 uint32_t dplane_get_in_queue_limit(void);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3275,10 +3275,17 @@ static int rib_process_dplane_results(struct thread *thread)
 				zebra_vxlan_handle_result(ctx);
 				break;
 
-			default:
+			/* Some op codes not handled here */
+			case DPLANE_OP_ADDR_INSTALL:
+			case DPLANE_OP_ADDR_UNINSTALL:
+			case DPLANE_OP_NEIGH_INSTALL:
+			case DPLANE_OP_NEIGH_UPDATE:
+			case DPLANE_OP_NEIGH_DELETE:
+			case DPLANE_OP_NONE:
 				/* Don't expect this: just return the struct? */
 				dplane_ctx_fini(&ctx);
 				break;
+
 			} /* Dispatch by op code */
 
 			ctx = dplane_ctx_dequeue(&ctxlist);


### PR DESCRIPTION
Next phase of evpn/vxlan conversion to the async dataplane. This PR moves neighbor programming used in evpn to the dataplane - still netlink-only.