### PR TITLE
bgpd: Add 'no set as-path prepend last-as X' command

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -4158,6 +4158,18 @@ DEFUN (no_set_aspath_prepend,
 	return ret;
 }
 
+DEFUN (no_set_aspath_prepend_lastas,
+       no_set_aspath_prepend_lastas_cmd,
+       "no set as-path prepend last-as [(1-10)]",
+       NO_STR
+       SET_STR
+       "Transform BGP AS_PATH attribute\n"
+       "Prepend to the as-path\n"
+       "Use the peers AS-number\n"
+       "Number of times to insert\n")
+{
+	return no_set_aspath_prepend(self, vty, argc, argv);
+}
 
 DEFUN (set_aspath_exclude,
        set_aspath_exclude_cmd,
@@ -5123,6 +5135,7 @@ void bgp_route_map_init(void)
 	install_element(RMAP_NODE, &set_aspath_prepend_lastas_cmd);
 	install_element(RMAP_NODE, &set_aspath_exclude_cmd);
 	install_element(RMAP_NODE, &no_set_aspath_prepend_cmd);
+	install_element(RMAP_NODE, &no_set_aspath_prepend_lastas_cmd);
 	install_element(RMAP_NODE, &no_set_aspath_exclude_cmd);
 	install_element(RMAP_NODE, &no_set_aspath_exclude_all_cmd);
 	install_element(RMAP_NODE, &set_origin_cmd);

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1169,19 +1169,24 @@ AS path access list is user defined AS path.
 Using AS Path in Route Map
 --------------------------
 
-.. index:: match as-path WORD
-.. clicmd:: match as-path WORD
+.. index:: [no] match as-path WORD
+.. clicmd:: [no] match as-path WORD
 
+   For a given as-path, WORD, match it on the BGP as-path given for the prefix
+   and if it matches do normal route-map actions.  The no form of the command
+   removes this match from the route-map.
 
-.. index:: set as-path prepend AS-PATH
-.. clicmd:: set as-path prepend AS-PATH
+.. index:: [no] set as-path prepend AS-PATH
+.. clicmd:: [no] set as-path prepend AS-PATH
 
-   Prepend the given string of AS numbers to the AS_PATH.
+   Prepend the given string of AS numbers to the AS_PATH of the BGP path's NLRI.
+   The no form of this command removes this set operation from the route-map.
 
-.. index:: set as-path prepend last-as NUM
-.. clicmd:: set as-path prepend last-as NUM
+.. index:: [no] set as-path prepend last-as NUM
+.. clicmd:: [no] set as-path prepend last-as NUM
 
    Prepend the existing last AS number (the leftmost ASN) to the AS_PATH.
+   The no form of this command removes this set operation from the route-map.
 
 .. _bgp-communities-attribute:
 


### PR DESCRIPTION
The `set as-path prepend last-as X` command had no, 'no' form
of the command.  Add this into the cli.

Testing:
!
route-map BLARBLE permit 10
 set as-path prepend last-as 3
!
!
router bgp 9999
 neighbor 10.50.12.118 remote-as external
 neighbor 10.50.12.118 ebgp-multihop 30
 !
 address-family ipv4 unicast
  neighbor 10.50.12.118 route-map BLARBLE in
 !
!

eva# show bgp ipv4 uni 4.4.4.4
BGP routing table entry for 4.4.4.4/32
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  10.50.12.118
  999 999 999 999
    10.50.12.118 from 10.50.12.118 (10.50.12.118)
      Origin incomplete, metric 0, valid, external, best (First path received)
      Last update: Mon Aug 26 09:47:17 2019

eva# conf
eva(config)# route-map BLARBLE permit 10
eva(config-route-map)# no set as-path prepend last-as 3
eva(config-route-map)# end
eva# clear bgp ipv4 uni *
eva# show bgp ipv4 uni 4.4.4.4
BGP routing table entry for 4.4.4.4/32
Paths: (1 available, best #1, table default)
  Advertised to non peer-group peers:
  10.50.12.118
  999
    10.50.12.118 from 10.50.12.118 (10.50.12.118)
      Origin incomplete, metric 0, valid, external, best (First path received)
      Last update: Mon Aug 26 09:48:31 2019

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>