### PR TITLE
Zebra: use dataplane for evpn vtep programming

### DIFF
--- a/zebra/rt.h
+++ b/zebra/rt.h
@@ -68,10 +68,6 @@ extern int mpls_kernel_init(void);
 
 extern uint32_t kernel_get_speed(struct interface *ifp);
 extern int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *mroute);
-extern int kernel_add_vtep(vni_t vni, struct interface *ifp,
-			   struct in_addr *vtep_ip);
-extern int kernel_del_vtep(vni_t vni, struct interface *ifp,
-			   struct in_addr *vtep_ip);
 
 /*
  * Southbound Initialization routines to get initial starting

--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -382,16 +382,6 @@ extern int kernel_get_ipmr_sg_stats(struct zebra_vrf *zvrf, void *mroute)
 	return 0;
 }
 
-int kernel_add_vtep(vni_t vni, struct interface *ifp, struct in_addr *vtep_ip)
-{
-	return 0;
-}
-
-int kernel_del_vtep(vni_t vni, struct interface *ifp, struct in_addr *vtep_ip)
-{
-	return 0;
-}
-
 /*
  * Update MAC, using dataplane context object. No-op here for now.
  */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -134,6 +134,10 @@ enum dplane_op_e {
 	DPLANE_OP_NEIGH_INSTALL,
 	DPLANE_OP_NEIGH_UPDATE,
 	DPLANE_OP_NEIGH_DELETE,
+
+	/* EVPN VTEP updates */
+	DPLANE_OP_VTEP_ADD,
+	DPLANE_OP_VTEP_DELETE,
 };
 
 /*
@@ -420,6 +424,17 @@ enum zebra_dplane_result dplane_neigh_update(const struct interface *ifp,
 					     const struct ethaddr *mac);
 enum zebra_dplane_result dplane_neigh_delete(const struct interface *ifp,
 					     const struct ipaddr *ip);
+
+/*
+ * Enqueue evpn VTEP updates for the dataplane.
+ */
+enum zebra_dplane_result dplane_vtep_add(const struct interface *ifp,
+					 const struct in_addr *ip,
+					 vni_t vni);
+enum zebra_dplane_result dplane_vtep_delete(const struct interface *ifp,
+					    const struct in_addr *ip,
+					    vni_t vni);
+
 
 /* Retrieve the limit on the number of pending, unprocessed updates. */
 uint32_t dplane_get_in_queue_limit(void);

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3280,6 +3280,8 @@ static int rib_process_dplane_results(struct thread *thread)
 			case DPLANE_OP_NEIGH_INSTALL:
 			case DPLANE_OP_NEIGH_UPDATE:
 			case DPLANE_OP_NEIGH_DELETE:
+			case DPLANE_OP_VTEP_ADD:
+			case DPLANE_OP_VTEP_DELETE:
 			case DPLANE_OP_NONE:
 				/* Don't expect this: just return the struct? */
 				dplane_ctx_fini(&ctx);


### PR DESCRIPTION
Move EVPN vtep updates to the async dataplane, and remove sync kernel-facing apis.
