### PR TITLE
pimd: sh config is showing detail debug, though not configured

### DIFF
--- a/pimd/pim_vty.c
+++ b/pimd/pim_vty.c
@@ -81,7 +81,7 @@ int pim_debug_config_write(struct vty *vty)
 		++writes;
 	}
 
-	if (PIM_DEBUG_MROUTE_DETAIL) {
+	if (PIM_DEBUG_MROUTE_DETAIL_ONLY) {
 		vty_out(vty, "debug mroute detail\n");
 		++writes;
 	}
@@ -107,7 +107,7 @@ int pim_debug_config_write(struct vty *vty)
 		vty_out(vty, "debug pim trace\n");
 		++writes;
 	}
-	if (PIM_DEBUG_PIM_TRACE_DETAIL) {
+	if (PIM_DEBUG_PIM_TRACE_DETAIL_ONLY) {
 		vty_out(vty, "debug pim trace detail\n");
 		++writes;
 	}

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -163,6 +163,8 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DEBUG_PIM_TRACE (router->debugs & PIM_MASK_PIM_TRACE)
 #define PIM_DEBUG_PIM_TRACE_DETAIL                                             \
 	(router->debugs & (PIM_MASK_PIM_TRACE_DETAIL | PIM_MASK_PIM_TRACE))
+#define PIM_DEBUG_PIM_TRACE_DETAIL_ONLY                                        \
+	(router->debugs & PIM_MASK_PIM_TRACE_DETAIL)
 #define PIM_DEBUG_IGMP_EVENTS (router->debugs & PIM_MASK_IGMP_EVENTS)
 #define PIM_DEBUG_IGMP_PACKETS (router->debugs & PIM_MASK_IGMP_PACKETS)
 #define PIM_DEBUG_IGMP_TRACE (router->debugs & PIM_MASK_IGMP_TRACE)
@@ -173,6 +175,7 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DEBUG_MROUTE (router->debugs & PIM_MASK_MROUTE)
 #define PIM_DEBUG_MROUTE_DETAIL                                                \
 	(router->debugs & (PIM_MASK_MROUTE_DETAIL | PIM_MASK_MROUTE))
+#define PIM_DEBUG_MROUTE_DETAIL_ONLY (router->debugs & PIM_MASK_MROUTE_DETAIL)
 #define PIM_DEBUG_PIM_HELLO (router->debugs & PIM_MASK_PIM_HELLO)
 #define PIM_DEBUG_PIM_J_P (router->debugs & PIM_MASK_PIM_J_P)
 #define PIM_DEBUG_PIM_REG (router->debugs & PIM_MASK_PIM_REG)


### PR DESCRIPTION
Original Idea is to display normal & detailed debugs when detailed
debug alone is configured. because of this "sh debugs" are showing
wrong Information, because same macro is used to disply the configured
debugs.

that means even if Normal debug is configured, detailed macro returns
TRUE. To avoid this ambiguity check whetehr detailed debug is configured
or not during dumping configured debugs. In all other places using
old macro.

Signed-off-by: Satheesh Kumar K <sathk@cumulusnetworks.com>