### PR TITLE
lib: rmap dep table is not correct in case of exact-match clause

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -1210,10 +1210,26 @@ static void route_match_community_free(void *rule)
 	XFREE(MTYPE_ROUTE_MAP_COMPILED, rcom);
 }
 
+/*
+ * In routemap processing there is a need to add the
+ * name as a rule_key in the dependency table. Routemap
+ * lib is unaware of rule_key when exact-match clause
+ * is in use. routemap lib uses the compiled output to
+ * get the rule_key value.
+ */
+static void *route_match_get_community_key(void *rule)
+{
+	struct rmap_community *rcom;
+
+	rcom = rule;
+	return rcom->name;
+}
+
+
 /* Route map commands for community matching. */
 struct route_map_rule_cmd route_match_community_cmd = {
 	"community", route_match_community, route_match_community_compile,
-	route_match_community_free};
+	route_match_community_free, route_match_get_community_key};
 
 /* Match function for lcommunity match. */
 static enum route_map_cmd_result_t
@@ -1284,7 +1300,8 @@ static void route_match_lcommunity_free(void *rule)
 /* Route map commands for community matching. */
 struct route_map_rule_cmd route_match_lcommunity_cmd = {
 	"large-community", route_match_lcommunity,
-	route_match_lcommunity_compile, route_match_lcommunity_free};
+	route_match_lcommunity_compile, route_match_lcommunity_free,
+	route_match_get_community_key};
 
 
 /* Match function for extcommunity match. */
@@ -3073,11 +3090,6 @@ static int bgp_route_match_add(struct vty *vty, const char *command,
 		retval = CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
-		if (type != RMAP_EVENT_MATCH_ADDED) {
-			route_map_upd8_dependency(type, arg, index->map->name);
-		}
-		break;
-	case RMAP_DUPLICATE_RULE:
 		/*
 		 * Intentionally doing nothing here.
 		 */
@@ -3111,7 +3123,7 @@ static int bgp_route_match_delete(struct vty *vty, const char *command,
 		rmap_name = XSTRDUP(MTYPE_ROUTE_MAP_NAME, index->map->name);
 	}
 
-	ret = route_map_delete_match(index, command, dep_name);
+	ret = route_map_delete_match(index, command, dep_name, type);
 	switch (ret) {
 	case RMAP_RULE_MISSING:
 		vty_out(vty, "%% BGP Can't find rule.\n");
@@ -3122,10 +3134,6 @@ static int bgp_route_match_delete(struct vty *vty, const char *command,
 		retval = CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
-		if (type != RMAP_EVENT_MATCH_DELETED && dep_name)
-			route_map_upd8_dependency(type, dep_name, rmap_name);
-		break;
-	case RMAP_DUPLICATE_RULE:
 		/*
 		 * Nothing to do here
 		 */

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1420,7 +1420,6 @@ DEFUN (match_rpki,
 			vty_out(vty, "%% BGP Argument is malformed.\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		case RMAP_COMPILE_SUCCESS:
-		case RMAP_DUPLICATE_RULE:
 			/*
 			 * Intentionally doing nothing here
 			 */
@@ -1443,7 +1442,8 @@ DEFUN (no_match_rpki,
 	VTY_DECLVAR_CONTEXT(route_map_index, index);
 	enum rmap_compile_rets ret;
 
-	ret = route_map_delete_match(index, "rpki", argv[3]->arg);
+	ret = route_map_delete_match(index, "rpki", argv[3]->arg,
+				     RMAP_EVENT_MATCH_DELETED);
 	if (ret) {
 		switch (ret) {
 		case RMAP_RULE_MISSING:
@@ -1453,7 +1453,6 @@ DEFUN (no_match_rpki,
 			vty_out(vty, "%% BGP Argument is malformed.\n");
 			break;
 		case RMAP_COMPILE_SUCCESS:
-		case RMAP_DUPLICATE_RULE:
 			/*
 			 * Nothing to do here
 			 */

--- a/eigrpd/eigrp_routemap.c
+++ b/eigrpd/eigrp_routemap.c
@@ -148,7 +148,6 @@ static int eigrp_route_match_add(struct vty *vty, struct route_map_index *index,
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
-	case RMAP_DUPLICATE_RULE:
 		/*
 		 * Intentionally not handling these cases
 		 */
@@ -165,7 +164,7 @@ static int eigrp_route_match_delete(struct vty *vty,
 {
 	enum rmap_compile_rets ret;
 
-	ret = route_map_delete_match(index, command, arg);
+	ret = route_map_delete_match(index, command, arg, type);
 	switch (ret) {
 	case RMAP_RULE_MISSING:
 		vty_out(vty, "%% Can't find rule.\n");
@@ -176,7 +175,6 @@ static int eigrp_route_match_delete(struct vty *vty,
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
-	case RMAP_DUPLICATE_RULE:
 		/*
 		 * These cases intentionally ignored
 		 */
@@ -211,7 +209,6 @@ static int eigrp_route_set_add(struct vty *vty, struct route_map_index *index,
 		}
 		break;
 	case RMAP_COMPILE_SUCCESS:
-	case RMAP_DUPLICATE_RULE:
 		/*
 		 * These cases intentionally left blank here
 		 */
@@ -239,7 +236,6 @@ static int eigrp_route_set_delete(struct vty *vty,
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
-	case RMAP_DUPLICATE_RULE:
 		/*
 		 * These cases intentionally not handled
 		 */

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -123,6 +123,9 @@ struct route_map_rule_cmd {
 
 	/* Free allocated value by func_compile (). */
 	void (*func_free)(void *);
+
+	/** To get the rule key after Compilation **/
+	void *(*func_get_rmap_rule_key)(void *val);
 };
 
 /* Route map apply error. */
@@ -135,8 +138,6 @@ enum rmap_compile_rets {
 	/* Route map rule can't compile */
 	RMAP_COMPILE_ERROR,
 
-	/* Route map rule is duplicate */
-	RMAP_DUPLICATE_RULE
 };
 
 /* Route map rule list. */
@@ -228,7 +229,8 @@ extern enum rmap_compile_rets route_map_add_match(struct route_map_index *index,
 /* Delete specified route match rule. */
 extern enum rmap_compile_rets
 route_map_delete_match(struct route_map_index *index,
-		       const char *match_name, const char *match_arg);
+		       const char *match_name, const char *match_arg,
+		       route_map_event_t type);
 
 extern const char *route_map_get_match_arg(struct route_map_index *index,
 					   const char *match_name);

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1593,7 +1593,6 @@ static int route_map_command_status(struct vty *vty, enum rmap_compile_rets ret)
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
-	case RMAP_DUPLICATE_RULE:
 		break;
 	}
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -78,11 +78,6 @@ static int zebra_route_match_add(struct vty *vty, const char *command,
 		retval = CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
-		if (type != RMAP_EVENT_MATCH_ADDED) {
-			route_map_upd8_dependency(type, arg, index->map->name);
-		}
-		break;
-	case RMAP_DUPLICATE_RULE:
 		/*
 		 * Nothing to do here
 		 */
@@ -116,7 +111,7 @@ static int zebra_route_match_delete(struct vty *vty, const char *command,
 		rmap_name = XSTRDUP(MTYPE_ROUTE_MAP_NAME, index->map->name);
 	}
 
-	ret = route_map_delete_match(index, command, arg);
+	ret = route_map_delete_match(index, command, arg, type);
 	switch (ret) {
 	case RMAP_RULE_MISSING:
 		vty_out(vty, "%% Zebra Can't find rule.\n");
@@ -127,10 +122,6 @@ static int zebra_route_match_delete(struct vty *vty, const char *command,
 		retval = CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
-		if (type != RMAP_EVENT_MATCH_DELETED && dep_name)
-			route_map_upd8_dependency(type, dep_name, rmap_name);
-		break;
-	case RMAP_DUPLICATE_RULE:
 		/*
 		 * Nothing to do here
 		 */


### PR DESCRIPTION


User pass the string match large-community 1 exact-match from CLI.
Now route map lib has got the string as "1 exact-match". It passes the string
to call back for compilation. BGP will parse this string and came to know
that for "1" it has to do exact match. Routemap lib has to save "1" in it’s
dependency table. Here routemap is saving this as a “1 exact-match”
which is wrong. The solution is used the compiled data.

Signed-off-by: vishaldhingra <vdhingra@vmware.com>