### PR TITLE
Rmap cleanup

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -3057,7 +3057,7 @@ static int bgp_route_match_add(struct vty *vty, const char *command,
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, index);
 	int retval = CMD_SUCCESS;
-	int ret;
+	enum rmap_compile_rets ret;
 
 	ret = route_map_add_match(index, command, arg, type);
 	switch (ret) {
@@ -3074,6 +3074,11 @@ static int bgp_route_match_add(struct vty *vty, const char *command,
 			route_map_upd8_dependency(type, arg, index->map->name);
 		}
 		break;
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * Intentionally doing nothing here.
+		 */
+		break;
 	}
 
 	return retval;
@@ -3084,7 +3089,7 @@ static int bgp_route_match_delete(struct vty *vty, const char *command,
 				  const char *arg, route_map_event_t type)
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, index);
-	int ret;
+	enum rmap_compile_rets ret;
 	int retval = CMD_SUCCESS;
 	char *dep_name = NULL;
 	const char *tmpstr;
@@ -3116,6 +3121,11 @@ static int bgp_route_match_delete(struct vty *vty, const char *command,
 	case RMAP_COMPILE_SUCCESS:
 		if (type != RMAP_EVENT_MATCH_DELETED && dep_name)
 			route_map_upd8_dependency(type, dep_name, rmap_name);
+		break;
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * Nothing to do here
+		 */
 		break;
 	}
 

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -1385,7 +1385,7 @@ DEFUN (match_rpki,
        "Prefix not found\n")
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, index);
-	int ret;
+	enum rmap_compile_rets ret;
 
 	ret = route_map_add_match(index, "rpki", argv[2]->arg,
 				  RMAP_EVENT_MATCH_ADDED);
@@ -1397,6 +1397,12 @@ DEFUN (match_rpki,
 		case RMAP_COMPILE_ERROR:
 			vty_out(vty, "%% BGP Argument is malformed.\n");
 			return CMD_WARNING_CONFIG_FAILED;
+		case RMAP_COMPILE_SUCCESS:
+		case RMAP_DUPLICATE_RULE:
+			/*
+			 * Intentionally doing nothing here
+			 */
+			break;
 		}
 	}
 	return CMD_SUCCESS;
@@ -1413,7 +1419,7 @@ DEFUN (no_match_rpki,
        "Prefix not found\n")
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, index);
-	int ret;
+	enum rmap_compile_rets ret;
 
 	ret = route_map_delete_match(index, "rpki", argv[3]->arg);
 	if (ret) {
@@ -1423,6 +1429,12 @@ DEFUN (no_match_rpki,
 			break;
 		case RMAP_COMPILE_ERROR:
 			vty_out(vty, "%% BGP Argument is malformed.\n");
+			break;
+		case RMAP_COMPILE_SUCCESS:
+		case RMAP_DUPLICATE_RULE:
+			/*
+			 * Nothing to do here
+			 */
 			break;
 		}
 		return CMD_WARNING_CONFIG_FAILED;

--- a/eigrpd/eigrp_routemap.c
+++ b/eigrpd/eigrp_routemap.c
@@ -135,7 +135,8 @@ void eigrp_rmap_update(const char *notused)
 static int eigrp_route_match_add(struct vty *vty, struct route_map_index *index,
 				 const char *command, const char *arg)
 {
-	int ret;
+	enum rmap_compile_rets ret;
+
 	ret = route_map_add_match(index, command, arg, type);
 	switch (ret) {
 	case RMAP_RULE_MISSING:
@@ -147,6 +148,10 @@ static int eigrp_route_match_add(struct vty *vty, struct route_map_index *index,
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * Intentionally not handling these cases
+		 */
 		break;
 	}
 
@@ -158,7 +163,8 @@ static int eigrp_route_match_delete(struct vty *vty,
 				    struct route_map_index *index,
 				    const char *command, const char *arg)
 {
-	int ret;
+	enum rmap_compile_rets ret;
+
 	ret = route_map_delete_match(index, command, arg);
 	switch (ret) {
 	case RMAP_RULE_MISSING:
@@ -170,6 +176,10 @@ static int eigrp_route_match_delete(struct vty *vty,
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * These cases intentionally ignored
+		 */
 		break;
 	}
 
@@ -180,7 +190,7 @@ static int eigrp_route_match_delete(struct vty *vty,
 static int eigrp_route_set_add(struct vty *vty, struct route_map_index *index,
 			       const char *command, const char *arg)
 {
-	int ret;
+	enum rmap_compile_rets ret;
 
 	ret = route_map_add_set(index, command, arg);
 	switch (ret) {
@@ -201,6 +211,10 @@ static int eigrp_route_set_add(struct vty *vty, struct route_map_index *index,
 		}
 		break;
 	case RMAP_COMPILE_SUCCESS:
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * These cases intentionally left blank here
+		 */
 		break;
 	}
 
@@ -212,7 +226,7 @@ static int eigrp_route_set_delete(struct vty *vty,
 				  struct route_map_index *index,
 				  const char *command, const char *arg)
 {
-	int ret;
+	enum rmap_compile_rets ret;
 
 	ret = route_map_delete_set(index, command, arg);
 	switch (ret) {
@@ -225,6 +239,10 @@ static int eigrp_route_set_delete(struct vty *vty,
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * These cases intentionally not handled
+		 */
 		break;
 	}
 

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -474,7 +474,7 @@ int generic_match_add(struct vty *vty, struct route_map_index *index,
 		      const char *command, const char *arg,
 		      route_map_event_t type)
 {
-	int ret;
+	enum rmap_compile_rets ret;
 
 	ret = route_map_add_match(index, command, arg, type);
 	switch (ret) {
@@ -493,6 +493,11 @@ int generic_match_add(struct vty *vty, struct route_map_index *index,
 			frr_protonameinst);
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * Nothing to do here move along
+		 */
+		break;
 	}
 
 	return CMD_SUCCESS;
@@ -502,7 +507,7 @@ int generic_match_delete(struct vty *vty, struct route_map_index *index,
 			 const char *command, const char *arg,
 			 route_map_event_t type)
 {
-	int ret;
+	enum rmap_compile_rets ret;
 	int retval = CMD_SUCCESS;
 	char *dep_name = NULL;
 	const char *tmpstr;
@@ -537,6 +542,11 @@ int generic_match_delete(struct vty *vty, struct route_map_index *index,
 		if (type != RMAP_EVENT_MATCH_DELETED && dep_name)
 			route_map_upd8_dependency(type, dep_name, rmap_name);
 		break;
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * Nothing to do here
+		 */
+		break;
 	}
 
 	XFREE(MTYPE_ROUTE_MAP_RULE, dep_name);
@@ -548,7 +558,7 @@ int generic_match_delete(struct vty *vty, struct route_map_index *index,
 int generic_set_add(struct vty *vty, struct route_map_index *index,
 		    const char *command, const char *arg)
 {
-	int ret;
+	enum rmap_compile_rets ret;
 
 	ret = route_map_add_set(index, command, arg);
 	switch (ret) {
@@ -563,6 +573,7 @@ int generic_set_add(struct vty *vty, struct route_map_index *index,
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
+	case RMAP_DUPLICATE_RULE:
 		break;
 	}
 
@@ -572,7 +583,7 @@ int generic_set_add(struct vty *vty, struct route_map_index *index,
 int generic_set_delete(struct vty *vty, struct route_map_index *index,
 		       const char *command, const char *arg)
 {
-	int ret;
+	enum rmap_compile_rets ret;
 
 	ret = route_map_delete_set(index, command, arg);
 	switch (ret) {
@@ -587,6 +598,7 @@ int generic_set_delete(struct vty *vty, struct route_map_index *index,
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
+	case RMAP_DUPLICATE_RULE:
 		break;
 	}
 
@@ -1388,8 +1400,10 @@ static route_map_event_t get_route_map_delete_event(route_map_event_t type)
 }
 
 /* Add match statement to route map. */
-int route_map_add_match(struct route_map_index *index, const char *match_name,
-			const char *match_arg, route_map_event_t type)
+enum rmap_compile_rets route_map_add_match(struct route_map_index *index,
+					   const char *match_name,
+					   const char *match_arg,
+					   route_map_event_t type)
 {
 	struct route_map_rule *rule;
 	struct route_map_rule *next;
@@ -1464,8 +1478,9 @@ int route_map_add_match(struct route_map_index *index, const char *match_name,
 }
 
 /* Delete specified route match rule. */
-int route_map_delete_match(struct route_map_index *index,
-			   const char *match_name, const char *match_arg)
+enum rmap_compile_rets route_map_delete_match(struct route_map_index *index,
+					      const char *match_name,
+					      const char *match_arg)
 {
 	struct route_map_rule *rule;
 	struct route_map_rule_cmd *cmd;
@@ -1492,8 +1507,9 @@ int route_map_delete_match(struct route_map_index *index,
 }
 
 /* Add route-map set statement to the route map. */
-int route_map_add_set(struct route_map_index *index, const char *set_name,
-		      const char *set_arg)
+enum rmap_compile_rets route_map_add_set(struct route_map_index *index,
+					 const char *set_name,
+					 const char *set_arg)
 {
 	struct route_map_rule *rule;
 	struct route_map_rule *next;
@@ -1543,8 +1559,9 @@ int route_map_add_set(struct route_map_index *index, const char *set_name,
 }
 
 /* Delete route map set rule. */
-int route_map_delete_set(struct route_map_index *index, const char *set_name,
-			 const char *set_arg)
+enum rmap_compile_rets route_map_delete_set(struct route_map_index *index,
+					    const char *set_name,
+					    const char *set_arg)
 {
 	struct route_map_rule *rule;
 	struct route_map_rule_cmd *cmd;

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -1472,7 +1472,7 @@ int route_map_delete_match(struct route_map_index *index,
 
 	cmd = route_map_lookup_match(match_name);
 	if (cmd == NULL)
-		return 1;
+		return RMAP_RULE_MISSING;
 
 	for (rule = index->match_list.head; rule; rule = rule->next)
 		if (rule->cmd == cmd && (rulecmp(rule->rule_str, match_arg) == 0
@@ -1485,10 +1485,10 @@ int route_map_delete_match(struct route_map_index *index,
 					index->map->name,
 					RMAP_EVENT_CALL_ADDED);
 			}
-			return 0;
+			return RMAP_COMPILE_SUCCESS;
 		}
 	/* Can't find matched rule. */
-	return 1;
+	return RMAP_RULE_MISSING;
 }
 
 /* Add route-map set statement to the route map. */
@@ -1551,7 +1551,7 @@ int route_map_delete_set(struct route_map_index *index, const char *set_name,
 
 	cmd = route_map_lookup_set(set_name);
 	if (cmd == NULL)
-		return 1;
+		return RMAP_RULE_MISSING;
 
 	for (rule = index->set_list.head; rule; rule = rule->next)
 		if ((rule->cmd == cmd) && (rulecmp(rule->rule_str, set_arg) == 0
@@ -1564,10 +1564,10 @@ int route_map_delete_set(struct route_map_index *index, const char *set_name,
 					index->map->name,
 					RMAP_EVENT_CALL_ADDED);
 			}
-			return 0;
+			return RMAP_COMPILE_SUCCESS;
 		}
 	/* Can't find matched rule. */
-	return 1;
+	return RMAP_RULE_MISSING;
 }
 
 static enum route_map_cmd_result_t

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -126,7 +126,7 @@ struct route_map_rule_cmd {
 };
 
 /* Route map apply error. */
-enum {
+enum rmap_compile_rets {
 	RMAP_COMPILE_SUCCESS,
 
 	/* Route map rule is missing. */
@@ -220,25 +220,28 @@ extern void route_map_init(void);
 extern void route_map_finish(void);
 
 /* Add match statement to route map. */
-extern int route_map_add_match(struct route_map_index *index,
-			       const char *match_name, const char *match_arg,
-			       route_map_event_t type);
+extern enum rmap_compile_rets route_map_add_match(struct route_map_index *index,
+						  const char *match_name,
+						  const char *match_arg,
+						  route_map_event_t type);
 
 /* Delete specified route match rule. */
-extern int route_map_delete_match(struct route_map_index *index,
-				  const char *match_name,
-				  const char *match_arg);
+extern enum rmap_compile_rets
+route_map_delete_match(struct route_map_index *index,
+		       const char *match_name, const char *match_arg);
 
 extern const char *route_map_get_match_arg(struct route_map_index *index,
 					   const char *match_name);
 
 /* Add route-map set statement to the route map. */
-extern int route_map_add_set(struct route_map_index *index,
-			     const char *set_name, const char *set_arg);
+extern enum rmap_compile_rets route_map_add_set(struct route_map_index *index,
+						const char *set_name,
+						const char *set_arg);
 
 /* Delete route map set rule. */
-extern int route_map_delete_set(struct route_map_index *index,
-				const char *set_name, const char *set_arg);
+extern enum rmap_compile_rets
+route_map_delete_set(struct route_map_index *index,
+		     const char *set_name, const char *set_arg);
 
 /* Install rule command to the match list. */
 extern void route_map_install_match(struct route_map_rule_cmd *cmd);

--- a/ospf6d/ospf6_asbr.c
+++ b/ospf6d/ospf6_asbr.c
@@ -1581,7 +1581,7 @@ static struct route_map_rule_cmd ospf6_routemap_rule_set_tag_cmd = {
 	route_map_rule_tag_free,
 };
 
-static int route_map_command_status(struct vty *vty, int ret)
+static int route_map_command_status(struct vty *vty, enum rmap_compile_rets ret)
 {
 	switch (ret) {
 	case RMAP_RULE_MISSING:
@@ -1593,6 +1593,7 @@ static int route_map_command_status(struct vty *vty, int ret)
 		return CMD_WARNING_CONFIG_FAILED;
 		break;
 	case RMAP_COMPILE_SUCCESS:
+	case RMAP_DUPLICATE_RULE:
 		break;
 	}
 
@@ -1610,8 +1611,10 @@ DEFUN (ospf6_routemap_set_metric_type,
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, route_map_index);
 	int idx_external = 2;
-	int ret = route_map_add_set(route_map_index, "metric-type",
-				    argv[idx_external]->arg);
+	enum rmap_compile_rets ret = route_map_add_set(route_map_index,
+						       "metric-type",
+						       argv[idx_external]->arg);
+
 	return route_map_command_status(vty, ret);
 }
 
@@ -1627,7 +1630,9 @@ DEFUN (ospf6_routemap_no_set_metric_type,
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, route_map_index);
 	char *ext = (argc == 4) ? argv[3]->text : NULL;
-	int ret = route_map_delete_set(route_map_index, "metric-type", ext);
+	enum rmap_compile_rets ret = route_map_delete_set(route_map_index,
+							  "metric-type", ext);
+
 	return route_map_command_status(vty, ret);
 }
 
@@ -1641,8 +1646,10 @@ DEFUN (ospf6_routemap_set_forwarding,
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, route_map_index);
 	int idx_ipv6 = 2;
-	int ret = route_map_add_set(route_map_index, "forwarding-address",
-				    argv[idx_ipv6]->arg);
+	enum rmap_compile_rets ret = route_map_add_set(route_map_index,
+						       "forwarding-address",
+						       argv[idx_ipv6]->arg);
+
 	return route_map_command_status(vty, ret);
 }
 
@@ -1657,8 +1664,10 @@ DEFUN (ospf6_routemap_no_set_forwarding,
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, route_map_index);
 	int idx_ipv6 = 3;
-	int ret = route_map_delete_set(route_map_index, "forwarding-address",
-				       argv[idx_ipv6]->arg);
+	enum rmap_compile_rets ret = route_map_delete_set(route_map_index,
+							  "forwarding-address",
+							  argv[idx_ipv6]->arg);
+
 	return route_map_command_status(vty, ret);
 }
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -64,7 +64,7 @@ static int zebra_route_match_add(struct vty *vty, const char *command,
 				 const char *arg, route_map_event_t type)
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, index);
-	int ret;
+	enum rmap_compile_rets ret;
 	int retval = CMD_SUCCESS;
 
 	ret = route_map_add_match(index, command, arg, type);
@@ -82,6 +82,11 @@ static int zebra_route_match_add(struct vty *vty, const char *command,
 			route_map_upd8_dependency(type, arg, index->map->name);
 		}
 		break;
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * Nothing to do here
+		 */
+		break;
 	}
 
 	return retval;
@@ -92,7 +97,7 @@ static int zebra_route_match_delete(struct vty *vty, const char *command,
 				    const char *arg, route_map_event_t type)
 {
 	VTY_DECLVAR_CONTEXT(route_map_index, index);
-	int ret;
+	enum rmap_compile_rets ret;
 	int retval = CMD_SUCCESS;
 	char *dep_name = NULL;
 	const char *tmpstr;
@@ -124,6 +129,11 @@ static int zebra_route_match_delete(struct vty *vty, const char *command,
 	case RMAP_COMPILE_SUCCESS:
 		if (type != RMAP_EVENT_MATCH_DELETED && dep_name)
 			route_map_upd8_dependency(type, dep_name, rmap_name);
+		break;
+	case RMAP_DUPLICATE_RULE:
+		/*
+		 * Nothing to do here
+		 */
 		break;
 	}
 


### PR DESCRIPTION
See individual commits for what is going on but effectively we have an enumerated type for route map compilation functions.  Use it and ensure all calling functions handle it appropriately via switch mechanisms