### PR TITLE
*: Start process of possibly deprecating Solaris

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1061,6 +1061,7 @@ case "$host_os" in
     AC_CHECK_LIB([nsl], [main])
     AC_CHECK_LIB([umem], [main])
     SOLARIS="solaris"
+    AC_MSG_WARN([--Solaris support is being considered for deprecation, please let us know if you are still using this--])
     ;;
   linux*)
     AC_MSG_RESULT([Linux])

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -348,6 +348,15 @@ void vty_hello(struct vty *vty)
 			vty_out(vty, "MOTD file not found\n");
 	} else if (host.motd)
 		vty_out(vty, "%s", host.motd);
+
+#if CONFDATE > 20200901
+	CPP_NOTICE("Please remove solaris code from system as it is deprecated");
+#endif
+#ifdef SUNOS_5
+	zlog_warn("If you are using FRR on Solaris, the FRR developers would love to hear from you\n");
+	zlog_warn("Please send email to dev@lists.frrouting.org about this message\n");
+	zlog_warn("We are considering deprecating Solaris and want to find users of Solaris systems\n");
+#endif
 }
 
 /* Put out prompt and wait input from user. */


### PR DESCRIPTION
The FRR community has run into an issue where keeping up our
CI system to work with solaris has become a fairly large burden.
We have also sent emails and asked around and have not found
anyone standing up saying that they are using Solaris.

Given the fact that we do not have any comprehensive testing
being done w/ solaris and the fact that we are getting a steady
stream of new features that will never work on solaris and
we cannot find anyone to say that they are using it.  Let's
start the drawn out process of deprecating the code.

If in the mean-time someone comes forward with the fact that
they are using it we can then not deprecate it.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>