### PR TITLE
Interface zapi update

### DIFF
--- a/staticd/static_vrf.c
+++ b/staticd/static_vrf.c
@@ -27,6 +27,7 @@
 #include "static_memory.h"
 #include "static_vrf.h"
 #include "static_routes.h"
+#include "static_zebra.h"
 #include "static_vty.h"
 
 static void zebra_stable_node_cleanup(struct route_table *table,
@@ -76,6 +77,8 @@ static int static_vrf_new(struct vrf *vrf)
 
 static int static_vrf_enable(struct vrf *vrf)
 {
+	static_zebra_vrf_register(vrf);
+
 	static_fixup_vrf_ids(vrf->info);
 
 	/*
@@ -89,6 +92,7 @@ static int static_vrf_enable(struct vrf *vrf)
 
 static int static_vrf_disable(struct vrf *vrf)
 {
+	static_zebra_vrf_unregister(vrf);
 	return 0;
 }
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -526,3 +526,17 @@ void static_zebra_init(void)
 				      static_nht_hash_cmp,
 				      "Static Nexthop Tracking hash");
 }
+
+void static_zebra_vrf_register(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void static_zebra_vrf_unregister(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}

--- a/staticd/static_zebra.h
+++ b/staticd/static_zebra.h
@@ -28,4 +28,7 @@ extern void static_zebra_route_add(struct route_node *rn,
 				   struct static_route *si_changed,
 				   vrf_id_t vrf_id, safi_t safi, bool install);
 extern void static_zebra_init(void);
+extern void static_zebra_vrf_register(struct vrf *vrf);
+extern void static_zebra_vrf_unregister(struct vrf *vrf);
+
 #endif


### PR DESCRIPTION
two fixes:
- static daemon is able to receive per vrf interface add/delete events
- interface add events are sent only if interface is present ( done in the 15 seconds thread timer)