### PR TITLE
tests: Modify docker build for local to have dev build

### DIFF
--- a/tests/topotests/docker/inner/compile_frr.sh
+++ b/tests/topotests/docker/inner/compile_frr.sh
@@ -84,6 +84,7 @@ if [ ! -e Makefile ]; then
 		--enable-static-bin \
 		--enable-static \
 		--enable-shared \
+		--enable-dev-build \
 		--with-moduledir=/usr/lib/frr/modules \
 		--prefix=/usr \
 		--localstatedir=/var/run/frr \


### PR DESCRIPTION
Allow a local build of a frr docker container to be built with
`--enable-dev-build`.  This allows better decodes of symbols
which could be useful when you are trying to fix something
that is broken inside the docker container.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>