### PR TITLE
lib: resolver per vrf support

### DIFF
--- a/lib/resolver.h
+++ b/lib/resolver.h
@@ -18,7 +18,7 @@ struct resolver_query {
 };
 
 void resolver_init(struct thread_master *tm);
-void resolver_resolve(struct resolver_query *query, int af,
+void resolver_resolve(struct resolver_query *query, int af, vrf_id_t vrf_id,
 		      const char *hostname, void (*cb)(struct resolver_query *,
 						       int, union sockunion *));
 

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -296,7 +296,7 @@ static int nhrp_nhs_resolve(struct thread *t)
 {
 	struct nhrp_nhs *nhs = THREAD_ARG(t);
 
-	resolver_resolve(&nhs->dns_resolve, AF_INET, nhs->nbma_fqdn,
+	resolver_resolve(&nhs->dns_resolve, AF_INET, VRF_DEFAULT, nhs->nbma_fqdn,
 			 nhrp_nhs_resolve_cb);
 
 	return 0;


### PR DESCRIPTION
add a parameter to resolver api that is the vrf identifier. this permits
to make resolution self to each vrf. in case vrf netns backend is used,
this is very practical, since resolution can happen on one netns, while
it is not the case in an other one.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
