### PR TITLE
ospfd: Do not turn on write thread unless we have something in it

### DIFF
--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -285,7 +285,6 @@ extern void ospf_if_update_params(struct interface *, struct in_addr);
 
 extern int ospf_if_new_hook(struct interface *);
 extern void ospf_if_init(void);
-extern void ospf_if_stream_set(struct ospf_interface *);
 extern void ospf_if_stream_unset(struct ospf_interface *);
 extern void ospf_if_reset_variables(struct ospf_interface *);
 extern int ospf_if_is_enable(struct ospf_interface *);

--- a/ospfd/ospf_ism.h
+++ b/ospfd/ospf_ism.h
@@ -53,8 +53,9 @@
 			listnode_add((O)->oi_write_q, oi);                     \
 			oi->on_write_q = 1;                                    \
 		}                                                              \
-		thread_add_write(master, ospf_write, (O), (O)->fd,             \
-				 &(O)->t_write);                               \
+		if (!list_isempty((O)->oi_write_q))                            \
+			thread_add_write(master, ospf_write, (O), (O)->fd,     \
+					 &(O)->t_write);                       \
 	} while (0)
 
 /* Macro for OSPF ISM timer turn on. */

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -132,7 +132,7 @@ static int ospf_auth_type(struct ospf_interface *oi)
 	return auth_type;
 }
 
-struct ospf_packet *ospf_packet_new(size_t size)
+static struct ospf_packet *ospf_packet_new(size_t size)
 {
 	struct ospf_packet *new;
 
@@ -231,7 +231,7 @@ void ospf_fifo_free(struct ospf_fifo *fifo)
 	XFREE(MTYPE_OSPF_FIFO, fifo);
 }
 
-void ospf_packet_add(struct ospf_interface *oi, struct ospf_packet *op)
+static void ospf_packet_add(struct ospf_interface *oi, struct ospf_packet *op)
 {
 	if (!oi->obuf) {
 		flog_err(
@@ -278,7 +278,7 @@ static void ospf_packet_add_top(struct ospf_interface *oi,
 	/* ospf_fifo_debug (oi->obuf); */
 }
 
-void ospf_packet_delete(struct ospf_interface *oi)
+static void ospf_packet_delete(struct ospf_interface *oi)
 {
 	struct ospf_packet *op;
 
@@ -288,7 +288,7 @@ void ospf_packet_delete(struct ospf_interface *oi)
 		ospf_packet_free(op);
 }
 
-struct ospf_packet *ospf_packet_dup(struct ospf_packet *op)
+static struct ospf_packet *ospf_packet_dup(struct ospf_packet *op)
 {
 	struct ospf_packet *new;
 

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -233,20 +233,6 @@ void ospf_fifo_free(struct ospf_fifo *fifo)
 
 static void ospf_packet_add(struct ospf_interface *oi, struct ospf_packet *op)
 {
-	if (!oi->obuf) {
-		flog_err(
-			EC_OSPF_PKT_PROCESS,
-			"ospf_packet_add(interface %s in state %d [%s], packet type %s, "
-			"destination %s) called with NULL obuf, ignoring "
-			"(please report this bug)!\n",
-			IF_NAME(oi), oi->state,
-			lookup_msg(ospf_ism_state_msg, oi->state, NULL),
-			lookup_msg(ospf_packet_type_str,
-				   stream_getc_from(op->s, 1), NULL),
-			inet_ntoa(op->dst));
-		return;
-	}
-
 	/* Add packet to end of queue. */
 	ospf_fifo_push(oi->obuf, op);
 
@@ -257,20 +243,6 @@ static void ospf_packet_add(struct ospf_interface *oi, struct ospf_packet *op)
 static void ospf_packet_add_top(struct ospf_interface *oi,
 				struct ospf_packet *op)
 {
-	if (!oi->obuf) {
-		flog_err(
-			EC_OSPF_PKT_PROCESS,
-			"ospf_packet_add(interface %s in state %d [%s], packet type %s, "
-			"destination %s) called with NULL obuf, ignoring "
-			"(please report this bug)!\n",
-			IF_NAME(oi), oi->state,
-			lookup_msg(ospf_ism_state_msg, oi->state, NULL),
-			lookup_msg(ospf_packet_type_str,
-				   stream_getc_from(op->s, 1), NULL),
-			inet_ntoa(op->dst));
-		return;
-	}
-
 	/* Add packet to head of queue. */
 	ospf_fifo_push_head(oi->obuf, op);
 

--- a/ospfd/ospf_packet.h
+++ b/ospfd/ospf_packet.h
@@ -131,8 +131,6 @@ struct ospf_ls_update {
 #define IS_SET_DD_ALL(X)        ((X) & OSPF_DD_FLAG_ALL)
 
 /* Prototypes. */
-extern void ospf_output_forward(struct stream *, int);
-extern struct ospf_packet *ospf_packet_new(size_t);
 extern void ospf_packet_free(struct ospf_packet *);
 extern struct ospf_fifo *ospf_fifo_new(void);
 extern void ospf_fifo_push(struct ospf_fifo *, struct ospf_packet *);
@@ -140,10 +138,6 @@ extern struct ospf_packet *ospf_fifo_pop(struct ospf_fifo *);
 extern struct ospf_packet *ospf_fifo_head(struct ospf_fifo *);
 extern void ospf_fifo_flush(struct ospf_fifo *);
 extern void ospf_fifo_free(struct ospf_fifo *);
-extern void ospf_packet_add(struct ospf_interface *, struct ospf_packet *);
-extern void ospf_packet_delete(struct ospf_interface *);
-extern struct stream *ospf_stream_dup(struct stream *);
-extern struct ospf_packet *ospf_packet_dup(struct ospf_packet *);
 
 extern int ospf_read(struct thread *);
 extern void ospf_hello_send(struct ospf_interface *);


### PR DESCRIPTION
I am rarely seeing this crash:

r2: ospfd crashed. Core file found - Backtrace follows:
[New LWP 32748]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
Core was generated by `/usr/lib/frr/ospfd'.
Program terminated with signal SIGABRT, Aborted.
2019-08-29 15:59:36,149 ERROR: assert failed at "test_ospf_sr_topo1/test_memory_leak":

Which translates to this code:

	node = listhead(ospf->oi_write_q);
	assert(node);
	oi = listgetdata(node);
	assert(oi);

So if we get into ospf_write without anything on the oi_write_q
we are stopping the program.

The only place that I see where we could possibly have this condition
was in OSPF_ISM_WRITE_ON(O).  Modify the macro to not just blindly
turn on ospf_write since we do not always add to the oi_write_q.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>