### PR TITLE
isisd: fix northbound circuit deletion

### DIFF
--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -1561,21 +1561,8 @@ static int lib_interface_isis_destroy(enum nb_event event,
 	circuit = nb_running_unset_entry(dnode);
 	if (!circuit)
 		return NB_ERR_INCONSISTENCY;
-	/* delete circuit through csm changes */
-	switch (circuit->state) {
-	case C_STATE_UP:
-		isis_csm_state_change(IF_DOWN_FROM_Z, circuit,
-				      circuit->interface);
+	if (circuit->state == C_STATE_UP || circuit->state == C_STATE_CONF)
 		isis_csm_state_change(ISIS_DISABLE, circuit, circuit->area);
-		break;
-	case C_STATE_CONF:
-		isis_csm_state_change(ISIS_DISABLE, circuit, circuit->area);
-		break;
-	case C_STATE_INIT:
-		isis_csm_state_change(IF_DOWN_FROM_Z, circuit,
-				      circuit->interface);
-		break;
-	}
 
 	return NB_OK;
 }


### PR DESCRIPTION
circuit deletion was being enforced by sending a fake IF_DOWN_FROM_Z
event for the circuit interface. This created a problem when the
circuit was enabled again, since isisd internal state machine was
expecting to see an IF_UP_FROM_Z that never came.

As a consequence, disabling + re-enabling isis on an interface or
area would leave interfaces in a CONFIG state, and adjacencies were
not restored. Fix this by following the state machine and simply
disabling circuits rather than attempting to delete them forcefully.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>