### PR TITLE
lib: Fix erroneously setting pointer values_cnt as NULL

### DIFF
--- a/lib/northbound_sysrepo.c
+++ b/lib/northbound_sysrepo.c
@@ -425,7 +425,7 @@ static int frr_sr_state_cb(const char *xpath, sr_val_t **values,
 exit:
 	list_delete(&elements);
 	*values = NULL;
-	values_cnt = 0;
+	*values_cnt = 0;
 
 	return SR_ERR_OK;
 }


### PR DESCRIPTION
It should be :
```
*values_cnt = 0;
```
not
```
values_cnt = 0;
```

Signed-off-by: Bi-Ruei, Chiu <biruei.chiu@gmail.com>