### PR TITLE
build: error out on implicit missing libcap, warn for protobuf FPM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2007,6 +2007,20 @@ if test "${enable_capabilities}" != "no"; then
        -o x"${frr_ac_lcaps}" = x"yes"; then
     AC_DEFINE([HAVE_CAPABILITIES], [1], [capabilities])
   fi
+
+  case "$host_os" in
+  linux*)
+    if test "$frr_ac_lcaps" != "yes"; then
+      AC_MSG_ERROR([libcap and/or its headers were not found.  Running FRR without libcap support built in causes a huge performance penalty.])
+    fi
+    ;;
+  esac
+else
+  case "$host_os" in
+  linux*)
+    AC_MSG_WARN([Running FRR without libcap support built in causes a huge performance penalty.])
+    ;;
+  esac
 fi
 AC_SUBST([LIBCAP])
 

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1927,6 +1927,9 @@ static inline void zfpm_init_message_format(const char *format)
 				"FPM protobuf message format is not available");
 			return;
 		}
+		flog_warn(EC_ZEBRA_PROTOBUF_NOT_AVAILABLE,
+			  "FPM protobuf message format is deprecated and scheduled to be removed. "
+			  "Please convert to using netlink format or contact dev@lists.frrouting.org with your use case.");
 		zfpm_g->message_format = ZFPM_MSG_FORMAT_PROTOBUF;
 		return;
 	}


### PR DESCRIPTION
- not finding libcap was previously triggering a "slient" fallback on UID/GID switching. Make this an error instead; if the user _really_ wants it they can still get it with `--disable-capabilities` (this is Linux-only.)
- add a deprecation warning for Protobuf FPM