### PR TITLE
bfdd: close bfd echo sockets, upon vrf disable

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1706,6 +1706,8 @@ static int bfd_vrf_disable(struct vrf *vrf)
 	socket_close(&bvrf->bg_mhop);
 	socket_close(&bvrf->bg_shop6);
 	socket_close(&bvrf->bg_mhop6);
+	socket_close(&bvrf->bg_echo);
+	socket_close(&bvrf->bg_echov6);
 
 	/* free context */
 	XFREE(MTYPE_BFDD_VRF, bvrf);


### PR DESCRIPTION
upon vrf disable, an event informs bfd daemon that the vrf contexts
should be removed. in the case a vrf backend is netns based, all sockets
opened under that netns have to be closed. otherwise it is impossible
for the system to completely close the network namespace. that implies
that some interfaces may not be deleted, and may not be given back to
default vrf.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>
