### PR TITLE
pbrd: support mark matches

### DIFF
--- a/pbrd/pbr_map.c
+++ b/pbrd/pbr_map.c
@@ -316,7 +316,7 @@ struct pbr_map_sequence *pbrms_get(const char *name, uint32_t seqno)
 		pbrms->ruleno = pbr_nht_get_next_rule(seqno);
 		pbrms->parent = pbrm;
 		pbrms->reason =
-			PBR_MAP_INVALID_SRCDST |
+			PBR_MAP_INVALID_EMPTY |
 			PBR_MAP_INVALID_NO_NEXTHOPS;
 
 		QOBJ_REG(pbrms, pbr_map_sequence);
@@ -350,10 +350,10 @@ pbr_map_sequence_check_nexthops_valid(struct pbr_map_sequence *pbrms)
 	}
 }
 
-static void pbr_map_sequence_check_src_dst_valid(struct pbr_map_sequence *pbrms)
+static void pbr_map_sequence_check_not_empty(struct pbr_map_sequence *pbrms)
 {
-	if (!pbrms->src && !pbrms->dst)
-		pbrms->reason |= PBR_MAP_INVALID_SRCDST;
+	if (!pbrms->src && !pbrms->dst && !pbrms->mark)
+		pbrms->reason |= PBR_MAP_INVALID_EMPTY;
 }
 
 /*
@@ -364,7 +364,7 @@ static void pbr_map_sequence_check_valid(struct pbr_map_sequence *pbrms)
 {
 	pbr_map_sequence_check_nexthops_valid(pbrms);
 
-	pbr_map_sequence_check_src_dst_valid(pbrms);
+	pbr_map_sequence_check_not_empty(pbrms);
 }
 
 static bool pbr_map_check_valid_internal(struct pbr_map *pbrm)

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -87,6 +87,7 @@ struct pbr_map_sequence {
 	 */
 	struct prefix *src;
 	struct prefix *dst;
+	uint32_t mark;
 
 	/*
 	 * Family of the src/dst.  Needed when deleting since we clear them
@@ -126,7 +127,7 @@ struct pbr_map_sequence {
 #define PBR_MAP_INVALID_NEXTHOP        (1 << 1)
 #define PBR_MAP_INVALID_NO_NEXTHOPS    (1 << 2)
 #define PBR_MAP_INVALID_BOTH_NHANDGRP  (1 << 3)
-#define PBR_MAP_INVALID_SRCDST         (1 << 4)
+#define PBR_MAP_INVALID_EMPTY          (1 << 4)
 	uint64_t reason;
 
 	QOBJ_FIELDS

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -526,7 +526,7 @@ static void pbr_encode_pbr_map_sequence(struct stream *s,
 	stream_putw(s, 0);  /* src port */
 	pbr_encode_pbr_map_sequence_prefix(s, pbrms->dst, family);
 	stream_putw(s, 0);  /* dst port */
-	stream_putl(s, 0);  /* fwmark */
+	stream_putl(s, pbrms->mark);
 	if (pbrms->nhgrp_name)
 		stream_putl(s, pbr_nht_get_table(pbrms->nhgrp_name));
 	else if (pbrms->nhg)


### PR DESCRIPTION
Adds support to specify marks in pbr-map match clause.
Marks should be provided as decimal (unsigned int).

Currently supported on Linux only. Attempting to configure
marks on other platform will result in:

"pbr marks are not supported on this platform"

Signed-off-by: Marcin Matlag <marcin.matlag@gmail.com>
Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>