### PR TITLE
bgpd: Fixes to error message printed for failed peerings

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -552,10 +552,11 @@ const char *peer_down_str[] = {"",
 			       "Intf peering v6only config change",
 			       "BFD down received",
 			       "Interface down",
-			       "Neighbor address lost"
+			       "Neighbor address lost",
 			       "Waiting for NHT",
-			       "Waiting for Peer IPv6 Addr",
-			       "Waiting for VRF to be initialized"};
+			       "Waiting for Peer IPv6 LLA",
+			       "Waiting for VRF to be initialized",
+			       "No AFI/SAFI activated for peer"};
 
 static int bgp_graceful_restart_timer_expire(struct thread *thread)
 {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7921,6 +7921,8 @@ static void bgp_show_peer_reset(struct vty * vty, struct peer *peer,
 		} 
 		json_object_string_add(json_peer, "lastResetDueTo",
 				       peer_down_str[(int)peer->last_reset]);
+		json_object_int_add(json_peer, "lastResetCode",
+				    peer->last_reset);
 	} else {
 		if (peer->last_reset == PEER_DOWN_NOTIFY_SEND
 		    || peer->last_reset == PEER_DOWN_NOTIFY_RECEIVED) {

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1582,6 +1582,12 @@ struct peer *peer_create(union sockunion *su, const char *conf_if,
 	}
 
 	active = peer_active(peer);
+	if (!active) {
+		if (peer->su.sa.sa_family == AF_UNSPEC)
+			peer->last_reset = PEER_DOWN_NBR_ADDR;
+		else
+			peer->last_reset = PEER_DOWN_NOAFI_ACTIVATED;
+	}
 
 	/* Last read and reset time set */
 	peer->readtime = peer->resettime = bgp_clock();

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1197,6 +1197,7 @@ struct peer {
 #define PEER_DOWN_WAITING_NHT           27 /* Waiting for NHT to resolve */
 #define PEER_DOWN_NBR_ADDR              28 /* Waiting for peer IPv6 IP Addr */
 #define PEER_DOWN_VRF_UNINIT            29 /* Associated VRF is not init yet */
+#define PEER_DOWN_NOAFI_ACTIVATED       30 /* No AFI/SAFI activated for peer */
 	size_t last_reset_cause_size;
 	uint8_t last_reset_cause[BGP_MAX_PACKET_SIZE];
 


### PR DESCRIPTION
There was a silly bug introduced when the command to show failed sessions
was added. A missing "," caused the wrong error message to be printed.
Debugging this led down a path that:
   - Led to discovering one more error message that needed to be added
   - Providing the error code along with the string in the JSON output
     to allow programs to key off numbers rather than strings.
   - Fixing the missing ","
   - Changing the error message to "Waiting for Peer IPv6 LLA" to
     make it clear that we're waiting for the link local addr.

Signed-off-by: Dinesh G Dutt <5016467+ddutt@users.noreply.github.com>