### PR TITLE
eigrpd: Fix SA issue with setting but not using

### DIFF
--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -285,7 +285,7 @@ void eigrp_if_update(struct interface *ifp)
 {
 	struct listnode *node, *nnode;
 	struct route_node *rn;
-	struct eigrp *eigrp  = eigrp_lookup(ifp->vrf_id);
+	struct eigrp *eigrp;
 
 	/*
 	 * In the event there are multiple eigrp autonymnous systems running,


### PR DESCRIPTION
We assign a value to the eigrp data structure and then
immediately overwrite it in the for loop.  No need to
do a eigrp_lookup.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>