### PR TITLE
isisd: Enabling build with openssl

### DIFF
--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -136,6 +136,7 @@ typedef unsigned char uint8_t;
 
 #ifdef CRYPTO_OPENSSL
 #include <openssl/evp.h>
+#include <openssl/hmac.h>
 #endif
 
 #include "openbsd-tree.h"


### PR DESCRIPTION
Similar to PR #4677, I am enabling the openssl library for md5
authentication in IS-IS

Signed-off-by: Michal Ruprich <michalruprich@gmail.com>