### PR TITLE
staticd: Re-send/Remove routes on interface events

### DIFF
--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -130,6 +130,7 @@ static int interface_state_up(ZAPI_CALLBACK_ARGS)
 
 		/* Install any static reliant on this interface coming up */
 		static_install_intf_nh(ifp);
+		static_ifindex_update(ifp, true);
 	}
 
 	return 0;
@@ -137,7 +138,12 @@ static int interface_state_up(ZAPI_CALLBACK_ARGS)
 
 static int interface_state_down(ZAPI_CALLBACK_ARGS)
 {
-	zebra_interface_state_read(zclient->ibuf, vrf_id);
+	struct interface *ifp;
+
+	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
+
+	if (ifp)
+		static_ifindex_update(ifp, false);
 
 	return 0;
 }


### PR DESCRIPTION
We were not processing interface up/down events for device only
static routes. This patch looks up the ifp and then calls
the same API we are using for interface add/remove events.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>