### PR TITLE
bgpd: clear l3vni prefix-only flag upon deletion

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5668,6 +5668,8 @@ int bgp_evpn_local_l3vni_del(vni_t l3vni, vrf_id_t vrf_id)
 	for (ALL_LIST_ELEMENTS(bgp_vrf->l2vnis, node, next, vpn))
 		bgpevpn_unlink_from_l3vni(vpn);
 
+	UNSET_FLAG(bgp_vrf->vrf_flags, BGP_VRF_L3VNI_PREFIX_ROUTES_ONLY);
+
 	/* Delete the instance if it was autocreated */
 	if (CHECK_FLAG(bgp_vrf->vrf_flags, BGP_VRF_AUTO))
 		bgp_delete(bgp_vrf);


### PR DESCRIPTION
When L3vni is created with prefix-only flag,
the flag is set at bgp vrf instance level.
In the case of bgp instance is non auto created,
means user configured instance (i.e 'router bgp x vrf <name>')

Upon deletion of l3vni, clear the prefix-only flag from bgp vrf instance.

Testing Done:
```
vrf vrf1
 vni 104001
 exit-vrf
!
router bgp 650030 vrf vrf1
!

tor-21(config)# vrf vrf1
tor-21(config-vrf)# vni 104001 prefix-routes-only
tor-21(config-vrf)# no vni 104001 prefix-routes-only
tor-21(config-vrf)# end
```
Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>