### PR TITLE
lib: optimize non-transactional cli

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1061,8 +1061,10 @@ static int cmd_execute_command_real(vector vline, enum cmd_filter_type filter,
 			vty->num_cfg_changes = 0;
 			memset(&vty->cfg_changes, 0, sizeof(vty->cfg_changes));
 
-			/* Regenerate candidate configuration. */
-			if (frr_get_cli_mode() == FRR_CLI_CLASSIC)
+			/* Regenerate candidate configuration if necessary. */
+			if (frr_get_cli_mode() == FRR_CLI_CLASSIC
+			    && running_config->version
+				       > vty->candidate_config->version)
 				nb_config_replace(vty->candidate_config,
 						  running_config, true);
 		}


### PR DESCRIPTION
Commit eaf6705d7a fixed a problem caused by configuration changes
coming from the kernel. The fix consisted of regenerating the
candidate configuration before every configuration command (when
using the non-transactional CLI mode). There's no need, however,
to regenerate the candidate when it's identical to the running
configuration. Since the northbound keeps track of the version
of each configuration, we can use that information to prevent
regenerating the candidate configuration when that is not necessary.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>