### PR TITLE
[7.2]tests: Ensure we wait 1 bgp timeout period before declaring failure

### DIFF
--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -864,7 +864,7 @@ def clear_bgp_and_verify(tgen, topo, router):
 
     peer_uptime_before_clear_bgp = {}
     # Verifying BGP convergence before bgp clear command
-    for retry in range(1, 11):
+    for retry in range(31):
         sleeptime = 3
         # Waiting for BGP to converge
         logger.info("Waiting for %s sec for BGP to converge on router"
@@ -944,7 +944,7 @@ def clear_bgp_and_verify(tgen, topo, router):
 
     peer_uptime_after_clear_bgp = {}
     # Verifying BGP convergence after bgp clear command
-    for retry in range(11):
+    for retry in range(31):
         sleeptime = 3
         # Waiting for BGP to converge
         logger.info("Waiting for %s sec for BGP to converge on router"


### PR DESCRIPTION
The lib/bgp.py test code is bringing up neighbors and clearing them
to test that things are working appropriately.  The problem we have
is that we are only waiting 30 seconds for declaration of failure.
In a high load system packets can be lost and as such the initial
convergence may not happen.  Modify the test to wait for 1 retry
window test period before declaring failure.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>