### PR TITLE
topotests: Add libcap-dev to the Dockerfile

### DIFF
--- a/tests/topotests/Dockerfile
+++ b/tests/topotests/Dockerfile
@@ -19,6 +19,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         libpython-dev \
         libreadline-dev \
         libc-ares-dev \
+        libcap-dev \
         man \
         mininet \
         pkg-config \


### PR DESCRIPTION
Add libcap-dev to the Dockerfile now that its a required depency.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>