### PR TITLE
yang: create interface reference type

### DIFF
--- a/yang/frr-eigrpd.yang
+++ b/yang/frr-eigrpd.yang
@@ -23,6 +23,11 @@ module frr-eigrpd {
   description
     "This module defines a model for managing FRR eigrpd daemon.";
 
+  revision 2019-09-09 {
+    description
+      "Changed interface references to use
+      frr-interface:interface-ref typedef";
+  }
   revision 2019-06-19 {
     description "Initial revision.";
     reference
@@ -94,9 +99,7 @@ module frr-eigrpd {
 
       leaf-list passive-interface {
         description "List of suppressed interfaces";
-        type string {
-          length "1..16";
-        }
+        type frr-interface:interface-ref;
       }
 
       leaf active-time {

--- a/yang/frr-interface.yang
+++ b/yang/frr-interface.yang
@@ -11,6 +11,10 @@ module frr-interface {
   description
     "This module defines a model for managing FRR interfaces.";
 
+  revision 2019-09-09 {
+    description
+      "Added interface-ref typedef";
+  }
   revision 2018-03-28 {
     description
       "Initial revision.";
@@ -42,5 +46,14 @@ module frr-interface {
           "Interface description.";
       }
     }
+  }
+
+  typedef interface-ref {
+    type leafref {
+      require-instance false;
+      path "/frr-interface:lib/frr-interface:interface/frr-interface:name";
+    }
+    description
+      "Reference to an interface";
   }
 }

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -27,6 +27,11 @@ module frr-isisd {
   description
     "This module defines a model for managing FRR isisd daemon.";
 
+  revision 2019-09-09 {
+    description
+      "Changed interface references to use
+      frr-interface:interface-ref typedef";
+  }
   revision 2018-07-26 {
     description
       "Initial revision.";
@@ -296,7 +301,7 @@ module frr-isisd {
     description
       "Interface specific IS-IS notification data grouping";
     leaf interface-name {
-      type string;
+      type frr-interface:interface-ref;
       description
         "IS-IS interface name";
     }

--- a/yang/frr-ripd.yang
+++ b/yang/frr-ripd.yang
@@ -24,6 +24,11 @@ module frr-ripd {
   description
     "This module defines a model for managing FRR ripd daemon.";
 
+  revision 2019-09-09 {
+    description
+      "Changed interface references to use
+      frr-interface:interface-ref typedef";
+  }
   revision 2017-12-06 {
     description
       "Initial revision.";
@@ -113,9 +118,7 @@ module frr-ripd {
           "Enable RIP on the specified IP network.";
       }
       leaf-list interface {
-        type string {
-          length "1..16";
-        }
+        type frr-interface:interface-ref;
         description
           "Enable RIP on the specified interface.";
       }
@@ -124,7 +127,15 @@ module frr-ripd {
         description
           "Offset-list to modify route metric.";
         leaf interface {
-          type string;
+          type union {
+            type frr-interface:interface-ref;
+            type enumeration {
+              enum '*' {
+                description
+                  "Match all interfaces.";
+              }
+            }
+          }
           description
             "Interface to match. Use '*' to match all interfaces.";
         }
@@ -168,18 +179,14 @@ module frr-ripd {
       }
       leaf-list passive-interface {
         when "../passive-default = 'false'";
-        type string {
-          length "1..16";
-        }
+        type frr-interface:interface-ref;
         description
           "A list of interfaces where the sending of RIP packets
            is disabled.";
       }
       leaf-list non-passive-interface {
         when "../passive-default = 'true'";
-        type string {
-          length "1..16";
-        }
+        type frr-interface:interface-ref;
         description
           "A list of interfaces where the sending of RIP packets
            is enabled.";

--- a/yang/frr-ripngd.yang
+++ b/yang/frr-ripngd.yang
@@ -24,6 +24,11 @@ module frr-ripngd {
   description
     "This module defines a model for managing FRR ripngd daemon.";
 
+  revision 2019-09-09 {
+    description
+      "Changed interface references to use
+      frr-interface:interface-ref typedef";
+  }
   revision 2018-11-27 {
     description
       "Initial revision.";
@@ -71,9 +76,7 @@ module frr-ripngd {
           "Enable RIPng on the specified IPv6 network.";
       }
       leaf-list interface {
-        type string {
-          length "1..16";
-        }
+        type frr-interface:interface-ref;
         description
           "Enable RIPng on the specified interface.";
       }
@@ -82,7 +85,15 @@ module frr-ripngd {
         description
           "Offset-list to modify route metric.";
         leaf interface {
-          type string;
+          type union {
+            type frr-interface:interface-ref;
+            type enumeration {
+              enum '*' {
+                description
+                  "Match all interfaces.";
+              }
+            }
+          }
           description
             "Interface to match. Use '*' to match all interfaces.";
         }
@@ -118,9 +129,7 @@ module frr-ripngd {
         }
       }
       leaf-list passive-interface {
-        type string {
-          length "1..16";
-        }
+        type frr-interface:interface-ref;
         description
           "A list of interfaces where the sending of RIPng packets
            is disabled.";


### PR DESCRIPTION
Instead of copy-pasting a 16 character string type for use as an
interface reference, create a new typedef that leafref's the name node
of an interface. This way the constraints change with the constraints on
an interface name itself, and it's self documenting.

Incidentally ripd and ripngd forgot the 16 character constraint in their
offset-list configs and IS-IS forgot it entirely, so this also fixes
minor bugs.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>