### PR TITLE
pimd: Slightly loosen pim assert message length tests

### DIFF
--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -259,11 +259,11 @@ int pim_assert_recv(struct interface *ifp, struct pim_neighbor *neigh,
 	curr += offset;
 	curr_size -= offset;
 
-	if (curr_size != 8) {
+	if (curr_size < 8) {
 		char src_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<src?>", src_addr, src_str, sizeof(src_str));
 		zlog_warn(
-			"%s: preference/metric size is not 8: size=%d from %s on interface %s",
+			"%s: preference/metric size is less than 8 bytes: size=%d from %s on interface %s",
 			__PRETTY_FUNCTION__, curr_size, src_str, ifp->name);
 		return -3;
 	}


### PR DESCRIPTION
The Pim RFC does not appear to state any length requirements
of pim, other than the checksum must be correct.

Certain vendors are sending extra data at the end of a pim assert
message.  This while not explicitly against the rules was a bit
of surprise to pim when we threw the assert message on the floor
for being too long.

Modify the test to see if length left will allow us to read
the 8 bytes of data that we need.  If it is sufficient for
that allow the packet to be used.

Fixes: #4957
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>