### PR TITLE
bgpd: [7.0] `neighbor X:X::X default-originate` complains about (null)

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -4867,14 +4867,15 @@ static int peer_default_originate_set_vty(struct vty *vty, const char *peer_str,
 {
 	int ret;
 	struct peer *peer;
-	struct route_map *route_map;
+	struct route_map *route_map = NULL;
 
 	peer = peer_and_group_lookup_vty(vty, peer_str);
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
 	if (set) {
-		route_map = route_map_lookup_warn_noexist(vty, rmap);
+		if (rmap)
+			route_map = route_map_lookup_warn_noexist(vty, rmap);
 		ret = peer_default_originate_set(peer, afi, safi,
 						 rmap, route_map);
 	} else


### PR DESCRIPTION
The `neighbor X:X::X default-originate command is complaining
that:
The route-map '(null)' does not exist.

Upon inspection of the code we were passing a NULL
string to the lookup.  Testing for null gets us this:

donna.cumulusnetworks.com# conf t
donna.cumulusnetworks.com(config)# router bgp 99
donna.cumulusnetworks.com(config-router)# neighbor 2001:1::1:2 remote-as 99
donna.cumulusnetworks.com(config-router)# neighbor 2001:1::1:2 default-originate
donna.cumulusnetworks.com(config-router)# end
donna.cumulusnetworks.com# show run
Building configuration...

Current configuration:
!
frr version 7.2-dev
frr defaults datacenter
hostname donna.cumulusnetworks.com
log stdout
no ipv6 forwarding
!
ip route 4.5.6.7/32 10.50.11.4
!
router bgp 99
 neighbor 2001:1::1:2 remote-as 99
 !
 address-family ipv4 unicast
  neighbor 2001:1::1:2 default-originate

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>