### PR TITLE
yang: add user type for ip-address

### DIFF
--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -1000,3 +1000,56 @@ void yang_get_default_ipv6p(union prefixptr var, const char *xpath_fmt, ...)
 	value = yang_get_default_value(xpath);
 	yang_str2ipv6p(value, var);
 }
+
+/*
+ * Derived type: ip.
+ */
+void yang_str2ip(const char *value, struct ipaddr *ip)
+{
+	(void)str2ipaddr(value, ip);
+}
+
+struct yang_data *yang_data_new_ip(const char *xpath, const struct ipaddr *addr)
+{
+	size_t sz = IS_IPADDR_V4(addr) ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
+	char value_str[sz];
+
+	ipaddr2str(addr, value_str, sizeof(value_str));
+	return yang_data_new(xpath, value_str);
+}
+
+void yang_dnode_get_ip(struct ipaddr *addr, const struct lyd_node *dnode,
+		       const char *xpath_fmt, ...)
+{
+	const struct lyd_node_leaf_list *dleaf;
+
+	assert(dnode);
+	if (xpath_fmt) {
+		va_list ap;
+		char xpath[XPATH_MAXLEN];
+
+		va_start(ap, xpath_fmt);
+		vsnprintf(xpath, sizeof(xpath), xpath_fmt, ap);
+		va_end(ap);
+		dnode = yang_dnode_get(dnode, xpath);
+		YANG_DNODE_GET_ASSERT(dnode, xpath);
+	}
+
+	dleaf = (const struct lyd_node_leaf_list *)dnode;
+	assert(dleaf->value_type == LY_TYPE_STRING);
+	(void)str2ipaddr(dleaf->value_str, addr);
+}
+
+void yang_get_default_ip(struct ipaddr *var, const char *xpath_fmt, ...)
+{
+	char xpath[XPATH_MAXLEN];
+	const char *value;
+	va_list ap;
+
+	va_start(ap, xpath_fmt);
+	vsnprintf(xpath, sizeof(xpath), xpath_fmt, ap);
+	va_end(ap);
+
+	value = yang_get_default_value(xpath);
+	yang_str2ip(value, var);
+}

--- a/lib/yang_wrappers.h
+++ b/lib/yang_wrappers.h
@@ -154,4 +154,12 @@ extern void yang_dnode_get_ipv6p(union prefixptr prefix,
 extern void yang_get_default_ipv6p(union prefixptr var, const char *xpath_fmt,
 				   ...);
 
+/* ip */
+extern void yang_str2ip(const char *value, struct ipaddr *addr);
+extern struct yang_data *yang_data_new_ip(const char *xpath,
+					  const struct ipaddr *addr);
+extern void yang_dnode_get_ip(struct ipaddr *addr, const struct lyd_node *dnode,
+			      const char *xpath_fmt, ...);
+extern void yang_get_default_ip(struct ipaddr *var, const char *xpath_fmt, ...);
+
 #endif /* _FRR_NORTHBOUND_WRAPPERS_H_ */

--- a/yang/libyang_plugins/frr_user_types.c
+++ b/yang/libyang_plugins/frr_user_types.c
@@ -20,6 +20,7 @@
 #include <zebra.h>
 
 #include "prefix.h"
+#include "ipaddr.h"
 
 #include <libyang/user_types.h>
 
@@ -46,6 +47,21 @@ static int ipv6_address_store_clb(const char *type_name, const char *value_str,
 		return 1;
 
 	if (inet_pton(AF_INET6, value_str, value->ptr) != 1) {
+		free(value->ptr);
+		return 1;
+	}
+
+	return 0;
+}
+
+static int ip_address_store_clb(const char *type_name, const char *value_str,
+				lyd_val *value, char **err_msg)
+{
+	value->ptr = malloc(sizeof(struct ipaddr));
+	if (!value->ptr)
+		return 1;
+
+	if (str2ipaddr(value_str, value->ptr)) {
 		free(value->ptr);
 		return 1;
 	}
@@ -92,6 +108,8 @@ struct lytype_plugin_list frr_user_types[] = {
 	 ipv6_address_store_clb, free},
 	{"ietf-inet-types", "2013-07-15", "ipv6-address-no-zone",
 	 ipv6_address_store_clb, free},
+	{"ietf-inet-types", "2013-07-15", "ip-address", ip_address_store_clb,
+	 free},
 	{"ietf-inet-types", "2013-07-15", "ipv4-prefix", ipv4_prefix_store_clb,
 	 free},
 	{"ietf-inet-types", "2013-07-15", "ipv6-prefix", ipv6_prefix_store_clb,


### PR DESCRIPTION
Convert `ietf-inet-types:ip-address` to `struct ipaddr`.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>