### PR TITLE
[7.2] Disable bgp-ecmp-topo2 topotest until proper fix is developed

### DIFF
--- a/tests/topotests/pytest.ini
+++ b/tests/topotests/pytest.ini
@@ -1,6 +1,6 @@
 # Skip pytests example directory
 [pytest]
-norecursedirs = .git example-test example-topojson-test lib docker
+norecursedirs = .git example-test example-topojson-test lib docker bgp-ecmp-topo2
 
 [topogen]
 # Default configuration values


### PR DESCRIPTION
Disables the  bgp-ecmp-topo2 topotests as a temp workaround.
Can be re-enabled together with a proper fix for the test

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>