### PR TITLE
* evpn primary address advertisement

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -504,29 +504,29 @@ static void bgp_evpn_get_rmac_nexthop(struct bgpevpn *vpn,
 	if (!bgp_vrf)
 		return;
 
-	if (p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE) {
-		/* Copy sys (pip) RMAC and PIP IP as nexthop
-		 * in case of route is self MAC-IP,
-		 * advertise-pip and advertise-svi-ip features
-		 * are enabled.
-		 * Otherwise, for all host MAC-IP route's
-		 * copy anycast RMAC
-		 */
-		if (CHECK_FLAG(flags, BGP_EVPN_MACIP_TYPE_SVI_IP)
-		    && bgp_evpn_is_svi_macip_enabled(vpn)) {
-			/* copy sys rmac */
-			memcpy(&attr->rmac, &bgp_vrf->evpn_info->pip_rmac,
-			       ETH_ALEN);
-			if (bgp_vrf->evpn_info->advertise_pip &&
-			    bgp_vrf->evpn_info->is_anycast_mac) {
-				attr->nexthop = bgp_vrf->evpn_info->pip_ip;
-				attr->mp_nexthop_global_in =
-					bgp_vrf->evpn_info->pip_ip;
-			}
-		} else
-			memcpy(&attr->rmac, &bgp_vrf->rmac, ETH_ALEN);
-	}
+	if (p->prefix.route_type != BGP_EVPN_MAC_IP_ROUTE)
+		return;
+
+	/* Copy sys (pip) RMAC and PIP IP as nexthop
+	 * in case of route is self MAC-IP,
+	 * advertise-pip and advertise-svi-ip features
+	 * are enabled.
+	 * Otherwise, for all host MAC-IP route's
+	 * copy anycast RMAC
+	 */
+	if (CHECK_FLAG(flags, BGP_EVPN_MACIP_TYPE_SVI_IP)
+	    && bgp_vrf->evpn_info->advertise_pip &&
+	    bgp_vrf->evpn_info->is_anycast_mac) {
+		/* copy sys rmac */
+		memcpy(&attr->rmac, &bgp_vrf->evpn_info->pip_rmac,
+		       ETH_ALEN);
+		attr->nexthop = bgp_vrf->evpn_info->pip_ip;
+		attr->mp_nexthop_global_in =
+			bgp_vrf->evpn_info->pip_ip;
+	} else
+		memcpy(&attr->rmac, &bgp_vrf->rmac, ETH_ALEN);
 }
+
 /*
  * Create RT extended community automatically from passed information:
  * of the form AS:VNI.

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -494,6 +494,39 @@ static void unmap_vni_from_rt(struct bgp *bgp, struct bgpevpn *vpn,
 	}
 }
 
+static void bgp_evpn_get_rmac_nexthop(struct bgpevpn *vpn,
+				      struct prefix_evpn *p,
+				      struct attr *attr, uint8_t flags)
+{
+	struct bgp *bgp_vrf = vpn->bgp_vrf;
+
+	memset(&attr->rmac, 0, sizeof(struct ethaddr));
+	if (!bgp_vrf)
+		return;
+
+	if (p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE) {
+		/* Copy sys (pip) RMAC and PIP IP as nexthop
+		 * in case of route is self MAC-IP,
+		 * advertise-pip and advertise-svi-ip features
+		 * are enabled.
+		 * Otherwise, for all host MAC-IP route's
+		 * copy anycast RMAC
+		 */
+		if (CHECK_FLAG(flags, BGP_EVPN_MACIP_TYPE_SVI_IP)
+		    && bgp_evpn_is_svi_macip_enabled(vpn)) {
+			/* copy sys rmac */
+			memcpy(&attr->rmac, &bgp_vrf->evpn_info->pip_rmac,
+			       ETH_ALEN);
+			if (bgp_vrf->evpn_info->advertise_pip &&
+			    bgp_vrf->evpn_info->is_anycast_mac) {
+				attr->nexthop = bgp_vrf->evpn_info->pip_ip;
+				attr->mp_nexthop_global_in =
+					bgp_vrf->evpn_info->pip_ip;
+			}
+		} else
+			memcpy(&attr->rmac, &bgp_vrf->rmac, ETH_ALEN);
+	}
+}
 /*
  * Create RT extended community automatically from passed information:
  * of the form AS:VNI.
@@ -1685,6 +1718,9 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 
 		memcpy(&tmp_pi->extra->label, label, sizeof(label));
 		tmp_pi->extra->num_labels = num_labels;
+		/* Mark route as self type-2 route */
+		if (flags && CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_SVI_IP))
+			tmp_pi->extra->af_flags = BGP_EVPN_MACIP_TYPE_SVI_IP;
 		bgp_path_info_add(rn, tmp_pi);
 	} else {
 		tmp_pi = local_pi;
@@ -1828,8 +1864,29 @@ static int update_evpn_route(struct bgp *bgp, struct bgpevpn *vpn,
 	}
 
 	/* router mac is only needed for type-2 routes here. */
-	if (p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE)
-		bgpevpn_get_rmac(vpn, &attr.rmac);
+	if (p->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE) {
+		uint8_t af_flags = 0;
+
+		if (CHECK_FLAG(flags, ZEBRA_MACIP_TYPE_SVI_IP))
+			SET_FLAG(af_flags, BGP_EVPN_MACIP_TYPE_SVI_IP);
+
+		bgp_evpn_get_rmac_nexthop(vpn, p, &attr, af_flags);
+
+		if (bgp_debug_zebra(NULL)) {
+			char buf[ETHER_ADDR_STRLEN];
+			char buf1[PREFIX_STRLEN];
+
+			zlog_debug("VRF %s vni %u type-2 route evp %s RMAC %s nexthop %s",
+				   vpn->bgp_vrf ?
+				   vrf_id_to_name(vpn->bgp_vrf->vrf_id) : " ",
+				   vpn->vni,
+				   prefix2str(p, buf1, sizeof(buf1)),
+				   prefix_mac2str(&attr.rmac, buf,
+						  sizeof(buf)),
+				   inet_ntoa(attr.mp_nexthop_global_in));
+		}
+	}
+
 	vni2label(vpn->vni, &(attr.label));
 
 	/* Include L3 VNI related RTs and RMAC for type-2 routes, if they're
@@ -2104,7 +2161,8 @@ static int update_all_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
 		attr.nexthop = vpn->originator_ip;
 		attr.mp_nexthop_global_in = vpn->originator_ip;
 		attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV4;
-		bgpevpn_get_rmac(vpn, &attr.rmac);
+		bgp_evpn_get_rmac_nexthop(vpn, evp, &attr,
+					  tmp_pi->extra->af_flags);
 
 		if (evpn_route_is_sticky(bgp, rn))
 			attr.sticky = 1;
@@ -2112,6 +2170,19 @@ static int update_all_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
 			attr.default_gw = 1;
 			if (is_evpn_prefix_ipaddr_v6(evp))
 				attr.router_flag = 1;
+		}
+
+		if (bgp_debug_zebra(NULL)) {
+			char buf[ETHER_ADDR_STRLEN];
+			char buf1[PREFIX_STRLEN];
+
+			zlog_debug("VRF %s vni %u evp %s RMAC %s nexthop %s",
+				   vpn->bgp_vrf ?
+				   vrf_id_to_name(vpn->bgp_vrf->vrf_id) : " ",
+				   vpn->vni,
+				   prefix2str(evp, buf1, sizeof(buf1)),
+				   prefix_mac2str(&attr.rmac, buf, sizeof(buf)),
+				   inet_ntoa(attr.mp_nexthop_global_in));
 		}
 
 		/* Add L3 VNI RTs and RMAC for non IPv6 link-local if
@@ -2301,7 +2372,7 @@ static int bgp_evpn_vni_flood_mode_get(struct bgp *bgp,
  * situations need the route in the per-VNI table as well as the global
  * table to be updated (as attributes change).
  */
-static int update_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn)
+int update_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn)
 {
 	int ret;
 	struct prefix_evpn p;

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -512,7 +512,7 @@ static void bgp_evpn_get_rmac_nexthop(struct bgpevpn *vpn,
 	 * advertise-pip and advertise-svi-ip features
 	 * are enabled.
 	 * Otherwise, for all host MAC-IP route's
-	 * copy anycast RMAC
+	 * copy anycast RMAC.
 	 */
 	if (CHECK_FLAG(flags, BGP_EVPN_MACIP_TYPE_SVI_IP)
 	    && bgp_vrf->evpn_info->advertise_pip &&
@@ -1577,18 +1577,19 @@ static int update_evpn_type5_route(struct bgp *bgp_vrf, struct prefix_evpn *evp,
 		bgp_attr_default_set(&attr, BGP_ORIGIN_IGP);
 	}
 
-	/* copy sys rmac */
-	memcpy(&attr.rmac, &bgp_vrf->evpn_info->pip_rmac, ETH_ALEN);
 	/* Advertise Primary IP (PIP) is enabled, send individual
 	 * IP (default instance router-id) as nexthop.
 	 * PIP is disabled or vrr interface is not present
-	 * use anycast-IP as nexthop.
+	 * use anycast-IP as nexthop and anycast RMAC.
 	 */
 	if (!bgp_vrf->evpn_info->advertise_pip ||
 	    (!bgp_vrf->evpn_info->is_anycast_mac)) {
 		attr.nexthop = bgp_vrf->originator_ip;
 		attr.mp_nexthop_global_in = bgp_vrf->originator_ip;
+		memcpy(&attr.rmac, &bgp_vrf->rmac, ETH_ALEN);
 	} else {
+		/* copy sys rmac */
+		memcpy(&attr.rmac, &bgp_vrf->evpn_info->pip_rmac, ETH_ALEN);
 		if (bgp_vrf->evpn_info->pip_ip.s_addr != INADDR_ANY) {
 			attr.nexthop = bgp_vrf->evpn_info->pip_ip;
 			attr.mp_nexthop_global_in = bgp_vrf->evpn_info->pip_ip;

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -1605,12 +1605,14 @@ static int update_evpn_type5_route(struct bgp *bgp_vrf, struct prefix_evpn *evp,
 	if (bgp_debug_zebra(NULL)) {
 		char buf[ETHER_ADDR_STRLEN];
 		char buf1[PREFIX_STRLEN];
+		char buf2[INET6_ADDRSTRLEN];
 
 		zlog_debug("VRF %s type-5 route evp %s RMAC %s nexthop %s",
 			   vrf_id_to_name(bgp_vrf->vrf_id),
 			   prefix2str(evp, buf1, sizeof(buf1)),
 			   prefix_mac2str(&attr.rmac, buf, sizeof(buf)),
-			   inet_ntoa(attr.nexthop));
+			   inet_ntop(AF_INET, &attr.nexthop, buf2,
+				     INET_ADDRSTRLEN));
 	}
 
 	attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV4;

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -174,8 +174,9 @@ extern int bgp_evpn_local_macip_add(struct bgp *bgp, vni_t vni,
 				    uint8_t flags, uint32_t seq);
 extern int bgp_evpn_local_l3vni_add(vni_t vni, vrf_id_t vrf_id,
 				    struct ethaddr *rmac,
+				    struct ethaddr *vrr_rmac,
 				    struct in_addr originator_ip, int filter,
-				    ifindex_t svi_ifindex);
+				    ifindex_t svi_ifindex, bool is_anycast_mac);
 extern int bgp_evpn_local_l3vni_del(vni_t vni, vrf_id_t vrf_id);
 extern int bgp_evpn_local_vni_del(struct bgp *bgp, vni_t vni);
 extern int bgp_evpn_local_vni_add(struct bgp *bgp, vni_t vni,

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -192,5 +192,6 @@ extern void bgp_evpn_cleanup(struct bgp *bgp);
 extern void bgp_evpn_init(struct bgp *bgp);
 extern int bgp_evpn_get_type5_prefixlen(struct prefix *pfx);
 extern bool bgp_evpn_is_prefix_nht_supported(struct prefix *pfx);
+extern void update_advertise_vrf_routes(struct bgp *bgp_vrf);
 
 #endif /* _QUAGGA_BGP_EVPN_H */

--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -188,6 +188,16 @@ struct bgp_evpn_info {
 	/* EVPN enable - advertise svi macip routes */
 	int advertise_svi_macip;
 
+	/* PIP feature knob */
+	bool advertise_pip;
+	/* PIP IP (sys ip) */
+	struct in_addr pip_ip;
+	struct in_addr pip_ip_static;
+	/* PIP MAC (sys MAC) */
+	struct ethaddr pip_rmac;
+	struct ethaddr pip_rmac_static;
+	struct ethaddr pip_rmac_zebra;
+	bool is_anycast_mac;
 };
 
 static inline int is_vrf_rd_configured(struct bgp *bgp_vrf)

--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -511,6 +511,16 @@ static inline int is_es_local(struct evpnes *es)
 	return CHECK_FLAG(es->flags, EVPNES_LOCAL) ? 1 : 0;
 }
 
+static inline bool bgp_evpn_is_svi_macip_enabled(struct bgpevpn *vpn)
+{
+	struct bgp *bgp_evpn = NULL;
+
+	bgp_evpn = bgp_get_evpn();
+
+	return (bgp_evpn->evpn_info->advertise_svi_macip ||
+		vpn->advertise_svi_macip);
+}
+
 extern void bgp_evpn_install_uninstall_default_route(struct bgp *bgp_vrf,
 						     afi_t afi, safi_t safi,
 						     bool add);
@@ -553,4 +563,5 @@ extern struct evpnes *bgp_evpn_es_new(struct bgp *bgp, esi_t *esi,
 				      struct ipaddr *originator_ip);
 extern void bgp_evpn_es_free(struct bgp *bgp, struct evpnes *es);
 extern bool bgp_evpn_lookup_l3vni_l2vni_table(vni_t vni);
+extern int update_routes_for_vni(struct bgp *bgp, struct bgpevpn *vpn);
 #endif /* _BGP_EVPN_PRIVATE_H */

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -387,7 +387,9 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 				       bgp_vrf->evpn_info->advertise_pip ?
 				       "Enabled" : "Disabled");
 		json_object_string_add(json, "sysIP",
-				       inet_ntoa(bgp_vrf->evpn_info->pip_ip));
+				       inet_ntop(AF_INET,
+					&bgp_vrf->evpn_info->pip_ip,
+					buf1, INET_ADDRSTRLEN));
 		json_object_string_add(json, "sysMac",
 				prefix_mac2str(&bgp_vrf->evpn_info->pip_rmac,
 					       buf2, sizeof(buf2)));
@@ -411,7 +413,8 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 		vty_out(vty, "  Advertise-pip: %s\n",
 			bgp_vrf->evpn_info->advertise_pip ? "Yes" : "No");
 		vty_out(vty, "  System-IP: %s\n",
-			inet_ntoa(bgp_vrf->evpn_info->pip_ip));
+			inet_ntop(AF_INET, &bgp_vrf->evpn_info->pip_ip,
+				  buf1, INET_ADDRSTRLEN));
 		vty_out(vty, "  System-MAC: %s\n",
 				prefix_mac2str(&bgp_vrf->evpn_info->pip_rmac,
 					       buf2, sizeof(buf2)));
@@ -5538,6 +5541,7 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 				safi_t safi)
 {
 	char buf1[RD_ADDRSTRLEN];
+	char buf2[INET6_ADDRSTRLEN];
 
 	if (bgp->vnihash) {
 		struct list *vnilist = hash_to_list(bgp->vnihash);
@@ -5618,7 +5622,9 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 		if (bgp->evpn_info->advertise_pip) {
 			if (bgp->evpn_info->pip_ip_static.s_addr != INADDR_ANY)
 				vty_out(vty, "  advertise-pip ip %s",
-				inet_ntoa(bgp->evpn_info->pip_ip_static));
+					inet_ntop(AF_INET,
+					&bgp->evpn_info->pip_ip_static,
+					buf2, INET_ADDRSTRLEN));
 			if (!is_zero_mac(&(bgp->evpn_info->pip_rmac_static))) {
 				char buf[ETHER_ADDR_STRLEN];
 

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3767,7 +3767,17 @@ DEFPY (bgp_evpn_advertise_pip_ip_mac,
 	}
 
 	if (is_evpn_enabled()) {
+		struct listnode *node = NULL;
+		struct bgpevpn *vpn = NULL;
+
 		update_advertise_vrf_routes(bgp_vrf);
+
+		/* Update (svi) type-2 routes */
+		for (ALL_LIST_ELEMENTS_RO(bgp_vrf->l2vnis, node, vpn)) {
+			if (!bgp_evpn_is_svi_macip_enabled(vpn))
+				continue;
+			update_routes_for_vni(bgp_evpn, vpn);
+		}
 	}
 
 	return CMD_SUCCESS;

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -3690,7 +3690,7 @@ DEFPY (bgp_evpn_advertise_pip_ip_mac,
 	if (EVPN_ENABLED(bgp_vrf)) {
 		vty_out(vty,
 			"This command is supported under L3VNI BGP EVPN VRF\n");
-		return CMD_WARNING;
+		return CMD_WARNING_CONFIG_FAILED;
 	}
 	bgp_evpn = bgp_get_evpn();
 

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -364,6 +364,7 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 	struct ecommunity *ecom;
 	json_object *json_import_rtl = NULL;
 	json_object *json_export_rtl = NULL;
+	char buf2[ETHER_ADDR_STRLEN];
 
 	json_import_rtl = json_export_rtl = 0;
 
@@ -382,6 +383,17 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 		json_object_string_add(json, "advertiseSviMacip", "n/a");
 		json_object_to_json_string_ext(json,
 					       JSON_C_TO_STRING_NOSLASHESCAPE);
+		json_object_string_add(json, "advertisePip",
+				       bgp_vrf->evpn_info->advertise_pip ?
+				       "Enabled" : "Disabled");
+		json_object_string_add(json, "sysIP",
+				       inet_ntoa(bgp_vrf->evpn_info->pip_ip));
+		json_object_string_add(json, "sysMac",
+				prefix_mac2str(&bgp_vrf->evpn_info->pip_rmac,
+					       buf2, sizeof(buf2)));
+		json_object_string_add(json, "rmac",
+				prefix_mac2str(&bgp_vrf->rmac,
+					       buf2, sizeof(buf2)));
 	} else {
 		vty_out(vty, "VNI: %d", bgp_vrf->l3vni);
 		vty_out(vty, " (known to the kernel)");
@@ -396,6 +408,16 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 			inet_ntoa(bgp_vrf->originator_ip));
 		vty_out(vty, "  Advertise-gw-macip : %s\n", "n/a");
 		vty_out(vty, "  Advertise-svi-macip : %s\n", "n/a");
+		vty_out(vty, "  Advertise-pip: %s\n",
+			bgp_vrf->evpn_info->advertise_pip ? "Yes" : "No");
+		vty_out(vty, "  System-IP: %s\n",
+			inet_ntoa(bgp_vrf->evpn_info->pip_ip));
+		vty_out(vty, "  System-MAC: %s\n",
+				prefix_mac2str(&bgp_vrf->evpn_info->pip_rmac,
+					       buf2, sizeof(buf2)));
+		vty_out(vty, "  Router-MAC: %s\n",
+				prefix_mac2str(&bgp_vrf->rmac,
+					       buf2, sizeof(buf2)));
 	}
 
 	if (!json)

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -114,6 +114,10 @@ struct bgp_path_info_extra {
 	mpls_label_t label[BGP_MAX_LABELS];
 	uint32_t num_labels;
 
+	/* af specific flags */
+	uint16_t af_flags;
+#define BGP_EVPN_MACIP_TYPE_SVI_IP (1 << 0)
+
 #if ENABLE_BGP_VNC
 	union {
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2056,6 +2056,61 @@ address-family:
    the VPN RIB as intermediary.
 
 
+.. _bgp-evpn:
+
+Ethernet Virtual Network - EVPN
+-------------------------------
+
+.. _bgp-evpn-advertise-pip:
+
+EVPN advertise-PIP
+^^^^^^^^^^^^^^^^^^
+
+In a EVPN symmetric routing MLAG deployment, all EVPN routes advertised
+with anycast-IP as next-hop IP and anycast MAC as the Router MAC (RMAC - in
+BGP EVPN Extended-Community).
+EVPN picks up the next-hop IP from the VxLAN interface's local tunnel IP and
+the RMAC is obtained from the MAC of the L3VNI's SVI interface.
+Note: Next-hop IP is used for EVPN routes whether symmetric routing is
+deployed or not but the RMAC is only relevant for symmetric routing scenario.
+
+Current behavior is not ideal for Prefix (type-5) and self (type-2)
+routes. This is because the traffic from remote VTEPs routed sub optimally
+if they land on the system where the route does not belong.
+
+The advertise-pip feature advertises Prefix (type-5) and self (type-2)
+routes with system's individual (primary) IP as the next-hop and individual
+(system) MAC as Router-MAC (RMAC), while leaving the behavior unchanged for
+other EVPN routes.
+
+To support this feature there needs to have ability to co-exist a
+(system-MAC, system-IP) pair with a (anycast-MAC, anycast-IP) pair with the
+ability to terminate VxLAN-encapsulated packets received for either pair on
+the same L3VNI (i.e associated VLAN). This capability is need per tenant
+VRF instance.
+
+To derive the system-MAC and the anycast MAC, there needs to have a
+separate/additional MAC-VLAN interface corresponding to L3VNI’s SVI.
+The SVI interface’s MAC address can be interpreted as system-MAC
+and MAC-VLAN interface's MAC as anycast MAC.
+
+To derive system-IP and anycast-IP, the default BGP instance's router-id is used
+as system-IP and the VxLAN interface’s local tunnel IP as the anycast-IP.
+
+User has an option to configure the system-IP and/or system-MAC value if the
+auto derived value is not preferred.
+
+Note: By default, advertise-pip feature is enabled and user has an option to
+disable the feature via configuration CLI. Once the feature is disable under
+bgp vrf instance or MAC-VLAN interface is not configured, all the routes follow
+the same behavior of using same next-hop and RMAC values.
+
+.. index:: [no] advertise-pip [ip <addr> [mac <addr>]]
+.. clicmd:: [no] advertise-pip [ip <addr> [mac <addr>]]
+
+Enables or disables advertise-pip feature, specifiy system-IP and/or system-MAC
+parameters.
+
 .. _bgp-cisco-compatibility:
 
 Cisco Compatibility

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -490,6 +490,7 @@ enum zapi_iptable_notify_owner {
 #define ZEBRA_MACIP_TYPE_GW                    0x02 /* gateway (SVI) mac*/
 #define ZEBRA_MACIP_TYPE_ROUTER_FLAG           0x04 /* Router Flag - proxy NA */
 #define ZEBRA_MACIP_TYPE_OVERRIDE_FLAG         0x08 /* Override Flag */
+#define ZEBRA_MACIP_TYPE_SVI_IP                0x10 /* SVI MAC-IP */
 
 enum zebra_neigh_state { ZEBRA_NEIGH_INACTIVE = 0, ZEBRA_NEIGH_ACTIVE = 1 };
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -1060,7 +1060,9 @@ void if_up(struct interface *ifp)
 						    zif->link_ifindex);
 		if (link_if)
 			zebra_vxlan_svi_up(ifp, link_if);
-	}
+	} else if (IS_ZEBRA_IF_MACVLAN(ifp))
+		zebra_vxlan_macvlan_up(ifp);
+
 }
 
 /* Interface goes down.  We have to manage different behavior of based
@@ -1092,7 +1094,8 @@ void if_down(struct interface *ifp)
 						    zif->link_ifindex);
 		if (link_if)
 			zebra_vxlan_svi_down(ifp, link_if);
-	}
+	} else if (IS_ZEBRA_IF_MACVLAN(ifp))
+		zebra_vxlan_macvlan_down(ifp);
 
 
 	/* Notify to the protocol daemons. */

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -1816,6 +1816,8 @@ static void zl3vni_print(zebra_l3vni_t *zl3vni, void **ctx)
 			CHECK_FLAG(zl3vni->filter, PREFIX_ROUTES_ONLY)
 				? "prefix-routes-only"
 				: "none");
+		vty_out(vty, "  System MAC: %s\n",
+			zl3vni_sysmac2str(zl3vni, buf, sizeof(buf)));
 		vty_out(vty, "  Router MAC: %s\n",
 			zl3vni_rmac2str(zl3vni, buf, sizeof(buf)));
 		vty_out(vty, "  L2 VNIs: ");
@@ -1834,6 +1836,9 @@ static void zl3vni_print(zebra_l3vni_t *zl3vni, void **ctx)
 				       zl3vni_svi_if_name(zl3vni));
 		json_object_string_add(json, "state", zl3vni_state2str(zl3vni));
 		json_object_string_add(json, "vrf", zl3vni_vrf_name(zl3vni));
+		json_object_string_add(
+			json, "sysMac",
+			zl3vni_sysmac2str(zl3vni, buf, sizeof(buf)));
 		json_object_string_add(
 			json, "routerMac",
 			zl3vni_rmac2str(zl3vni, buf, sizeof(buf)));

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -118,6 +118,8 @@ static int zvni_neigh_probe(zebra_vni_t *zvni, zebra_neigh_t *n);
 static zebra_vni_t *zvni_from_svi(struct interface *ifp,
 				  struct interface *br_if);
 static struct interface *zvni_map_to_svi(vlanid_t vid, struct interface *br_if);
+static struct interface *zvni_map_to_macvlan(struct interface *br_if,
+					     struct interface *svi_if);
 
 /* l3-vni next-hop neigh related APIs */
 static zebra_neigh_t *zl3vni_nh_lookup(zebra_l3vni_t *zl3vni,
@@ -3684,7 +3686,7 @@ static zebra_vni_t *zvni_from_svi(struct interface *ifp,
  * of two cases:
  * (a) In the case of a VLAN-aware bridge, the SVI is a L3 VLAN interface
  * linked to the bridge
- * (b) In the case of a VLAN-unaware bridge, the SVI is the bridge inteface
+ * (b) In the case of a VLAN-unaware bridge, the SVI is the bridge interface
  * itself
  */
 static struct interface *zvni_map_to_svi(vlanid_t vid, struct interface *br_if)
@@ -3734,6 +3736,52 @@ static struct interface *zvni_map_to_svi(vlanid_t vid, struct interface *br_if)
 
 	return found ? tmp_if : NULL;
 }
+
+/* Map to MAC-VLAN interface corresponding to specified SVI interface.
+ */
+static struct interface *zvni_map_to_macvlan(struct interface *br_if,
+					     struct interface *svi_if)
+{
+	struct zebra_ns *zns;
+	struct route_node *rn;
+	struct interface *tmp_if = NULL;
+	struct zebra_if *zif;
+	int found = 0;
+
+	/* Defensive check, caller expected to invoke only with valid bridge. */
+	if (!br_if)
+		return NULL;
+
+	if (!svi_if) {
+		zlog_debug("svi_if is not passed.");
+		return NULL;
+	}
+
+	/* Determine if bridge is VLAN-aware or not */
+	zif = br_if->info;
+	assert(zif);
+
+	/* Identify corresponding VLAN interface. */
+	zns = zebra_ns_lookup(NS_DEFAULT);
+	for (rn = route_top(zns->if_table); rn; rn = route_next(rn)) {
+		tmp_if = (struct interface *)rn->info;
+		/* Check oper status of the SVI. */
+		if (!tmp_if || !if_is_operative(tmp_if))
+			continue;
+		zif = tmp_if->info;
+
+		if (!zif || zif->zif_type != ZEBRA_IF_MACVLAN)
+			continue;
+
+		if (zif->link == svi_if) {
+			found = 1;
+			break;
+		}
+	}
+
+	return found ? tmp_if : NULL;
+}
+
 
 /*
  * Install remote MAC into the forwarding plane.
@@ -4150,6 +4198,16 @@ static void zvni_build_hash_table(void)
 			 * with vxlan-intf is complete
 			 */
 			zl3vni->svi_if = zl3vni_map_to_svi_if(zl3vni);
+
+			/* Associate l3vni to mac-vlan and extract VRR MAC */
+			zl3vni->mac_vlan_if = zl3vni_map_to_mac_vlan_if(zl3vni);
+
+			if (IS_ZEBRA_DEBUG_VXLAN)
+				zlog_debug("create l3vni %u svi_if %s mac_vlan_if %s",
+				   vni, zl3vni->svi_if ? zl3vni->svi_if->name
+				   : "NIL",
+				   zl3vni->mac_vlan_if ?
+				   zl3vni->mac_vlan_if->name : "NIL");
 
 			if (is_l3vni_oper_up(zl3vni))
 				zebra_vxlan_process_l3vni_oper_up(zl3vni);
@@ -5056,6 +5114,24 @@ struct interface *zl3vni_map_to_svi_if(zebra_l3vni_t *zl3vni)
 	return zvni_map_to_svi(vxl->access_vlan, zif->brslave_info.br_if);
 }
 
+struct interface *zl3vni_map_to_mac_vlan_if(zebra_l3vni_t *zl3vni)
+{
+	struct zebra_if *zif = NULL;	   /* zebra_if for vxlan_if */
+
+	if (!zl3vni)
+		return NULL;
+
+	if (!zl3vni->vxlan_if)
+		return NULL;
+
+	zif = zl3vni->vxlan_if->info;
+	if (!zif)
+		return NULL;
+
+	return zvni_map_to_macvlan(zif->brslave_info.br_if, zl3vni->svi_if);
+}
+
+
 zebra_l3vni_t *zl3vni_from_vrf(vrf_id_t vrf_id)
 {
 	struct zebra_vrf *zvrf = NULL;
@@ -5139,6 +5215,19 @@ static zebra_l3vni_t *zl3vni_from_svi(struct interface *ifp,
 	return zl3vni;
 }
 
+static inline void zl3vni_get_vrr_rmac(zebra_l3vni_t *zl3vni,
+				       struct ethaddr *rmac)
+{
+	if (!zl3vni)
+		return;
+
+	if (!is_l3vni_oper_up(zl3vni))
+		return;
+
+	if (zl3vni->mac_vlan_if && if_is_operative(zl3vni->mac_vlan_if))
+		memcpy(rmac->octet, zl3vni->mac_vlan_if->hw_addr, ETH_ALEN);
+}
+
 /*
  * Inform BGP about l3-vni.
  */
@@ -5146,35 +5235,54 @@ static int zl3vni_send_add_to_client(zebra_l3vni_t *zl3vni)
 {
 	struct stream *s = NULL;
 	struct zserv *client = NULL;
-	struct ethaddr rmac;
+	struct ethaddr svi_rmac, vrr_rmac = {.octet = {0} };
+	struct zebra_vrf *zvrf;
 	char buf[ETHER_ADDR_STRLEN];
+	char buf1[ETHER_ADDR_STRLEN];
+	bool is_anycast_mac = true;
 
 	client = zserv_find_client(ZEBRA_ROUTE_BGP, 0);
 	/* BGP may not be running. */
 	if (!client)
 		return 0;
 
-	/* get the rmac */
-	memset(&rmac, 0, sizeof(struct ethaddr));
-	zl3vni_get_rmac(zl3vni, &rmac);
+	zvrf = zebra_vrf_lookup_by_id(zl3vni->vrf_id);
+	assert(zvrf);
+
+	/* get the svi and vrr rmac values */
+	memset(&svi_rmac, 0, sizeof(struct ethaddr));
+	zl3vni_get_svi_rmac(zl3vni, &svi_rmac);
+	zl3vni_get_vrr_rmac(zl3vni, &vrr_rmac);
+
+	/* In absence of vrr mac use svi mac as anycast MAC value */
+	if (is_zero_mac(&vrr_rmac)) {
+		memcpy(&vrr_rmac, &svi_rmac, ETH_ALEN);
+		is_anycast_mac = false;
+	}
 
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
+	/* The message is used for both vni add and/or update like
+	 * vrr mac is added for l3vni SVI.
+	 */
 	zclient_create_header(s, ZEBRA_L3VNI_ADD, zl3vni_vrf_id(zl3vni));
 	stream_putl(s, zl3vni->vni);
-	stream_put(s, &rmac, sizeof(struct ethaddr));
+	stream_put(s, &svi_rmac, sizeof(struct ethaddr));
 	stream_put_in_addr(s, &zl3vni->local_vtep_ip);
 	stream_put(s, &zl3vni->filter, sizeof(int));
 	stream_putl(s, zl3vni->svi_if->ifindex);
+	stream_put(s, &vrr_rmac, sizeof(struct ethaddr));
+	stream_putl(s, is_anycast_mac);
 
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
 		zlog_debug(
-			"Send L3_VNI_ADD %u VRF %s RMAC %s local-ip %s filter %s to %s",
+			"Send L3_VNI_ADD %u VRF %s RMAC %s VRR %s local-ip %s filter %s to %s",
 			zl3vni->vni, vrf_id_to_name(zl3vni_vrf_id(zl3vni)),
-			prefix_mac2str(&rmac, buf, sizeof(buf)),
+			prefix_mac2str(&svi_rmac, buf, sizeof(buf)),
+			prefix_mac2str(&vrr_rmac, buf1, sizeof(buf1)),
 			inet_ntoa(zl3vni->local_vtep_ip),
 			CHECK_FLAG(zl3vni->filter, PREFIX_ROUTES_ONLY)
 				? "prefix-routes-only"
@@ -8531,15 +8639,18 @@ int zebra_vxlan_if_up(struct interface *ifp)
 
 	zl3vni = zl3vni_lookup(vni);
 	if (zl3vni) {
-
-		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("Intf %s(%u) L3-VNI %u is UP", ifp->name,
-				   ifp->ifindex, vni);
-
 		/* we need to associate with SVI, if any, we can associate with
 		 * svi-if only after association with vxlan-intf is complete
 		 */
 		zl3vni->svi_if = zl3vni_map_to_svi_if(zl3vni);
+		zl3vni->mac_vlan_if = zl3vni_map_to_mac_vlan_if(zl3vni);
+
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug("Intf %s(%u) L3-VNI %u is UP svi_if %s mac_vlan_if %s"
+				, ifp->name, ifp->ifindex, vni,
+				zl3vni->svi_if ? zl3vni->svi_if->name : "NIL",
+				zl3vni->mac_vlan_if ?
+				zl3vni->mac_vlan_if->name : "NIL");
 
 		if (is_l3vni_oper_up(zl3vni))
 			zebra_vxlan_process_l3vni_oper_up(zl3vni);
@@ -8702,6 +8813,8 @@ int zebra_vxlan_if_update(struct interface *ifp, uint16_t chgflags)
 				zebra_vxlan_process_l3vni_oper_down(zl3vni);
 				zl3vni->svi_if = NULL;
 				zl3vni->svi_if = zl3vni_map_to_svi_if(zl3vni);
+				zl3vni->mac_vlan_if =
+					zl3vni_map_to_mac_vlan_if(zl3vni);
 				zl3vni->local_vtep_ip = vxl->vtep_ip;
 				if (is_l3vni_oper_up(zl3vni))
 					zebra_vxlan_process_l3vni_oper_up(
@@ -8861,6 +8974,8 @@ int zebra_vxlan_if_add(struct interface *ifp)
 		 * after association with vxlan_if is complete */
 		zl3vni->svi_if = zl3vni_map_to_svi_if(zl3vni);
 
+		zl3vni->mac_vlan_if = zl3vni_map_to_mac_vlan_if(zl3vni);
+
 		if (is_l3vni_oper_up(zl3vni))
 			zebra_vxlan_process_l3vni_oper_up(zl3vni);
 	} else {
@@ -8992,6 +9107,16 @@ int zebra_vxlan_process_vrf_vni_cmd(struct zebra_vrf *zvrf, vni_t vni,
 		 * complete
 		 */
 		zl3vni->svi_if = zl3vni_map_to_svi_if(zl3vni);
+
+		zl3vni->mac_vlan_if = zl3vni_map_to_mac_vlan_if(zl3vni);
+
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug("%s: l3vni %u svi_if %s mac_vlan_if %s",
+				   __PRETTY_FUNCTION__, vni,
+				   zl3vni->svi_if ?
+				   zl3vni->svi_if->name : "NIL",
+				   zl3vni->mac_vlan_if ?
+				   zl3vni->mac_vlan_if->name : "NIL");
 
 		/* formulate l2vni list */
 		hash_iterate(zvrf_evpn->vni_table, zvni_add_to_l3vni_list,

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -8582,6 +8582,13 @@ void zebra_vxlan_macvlan_down(struct interface *ifp)
 	zif = ifp->info;
 	assert(zif);
 	link_ifp = zif->link;
+	if (!link_ifp) {
+		if (IS_ZEBRA_DEBUG_VXLAN)
+			zlog_debug("macvlan %s parent link is not found. Parent index %d ifp %s",
+				ifp->name, zif->link_ifindex,
+				if_lookup_by_index_all_vrf(zif->link_ifindex));
+		return;
+	}
 	link_zif = link_ifp->info;
 	assert(link_zif);
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -2493,6 +2493,8 @@ static int zvni_neigh_send_add_to_client(vni_t vni, struct ipaddr *ip,
 	/* Set router flag (R-bit) based on local neigh entry add */
 	if (CHECK_FLAG(neigh_flags, ZEBRA_NEIGH_ROUTER_FLAG))
 		SET_FLAG(flags, ZEBRA_MACIP_TYPE_ROUTER_FLAG);
+	if (CHECK_FLAG(neigh_flags, ZEBRA_NEIGH_SVI_IP))
+		SET_FLAG(flags, ZEBRA_MACIP_TYPE_SVI_IP);
 
 	return zvni_macip_send_msg_to_client(vni, macaddr, ip, flags,
 			     seq, ZEBRA_NEIGH_ACTIVE, ZEBRA_MACIP_ADD);
@@ -2813,6 +2815,7 @@ static int zvni_gw_macip_add(struct interface *ifp, zebra_vni_t *zvni,
 					      n->flags, n->loc_seq);
 	} else if (advertise_svi_macip_enabled(zvni)) {
 
+		SET_FLAG(n->flags, ZEBRA_NEIGH_SVI_IP);
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
 			"SVI %s(%u) L2-VNI %u, sending SVI MAC %s IP %s add to BGP with flags 0x%x",

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -8583,10 +8583,14 @@ void zebra_vxlan_macvlan_down(struct interface *ifp)
 	assert(zif);
 	link_ifp = zif->link;
 	if (!link_ifp) {
-		if (IS_ZEBRA_DEBUG_VXLAN)
+		if (IS_ZEBRA_DEBUG_VXLAN) {
+			struct interface *ifp;
+
+			ifp = if_lookup_by_index_all_vrf(zif->link_ifindex);
 			zlog_debug("macvlan %s parent link is not found. Parent index %d ifp %s",
 				ifp->name, zif->link_ifindex,
-				if_lookup_by_index_all_vrf(zif->link_ifindex));
+				ifp ? ifp->name : " ");
+		}
 		return;
 	}
 	link_zif = link_ifp->info;

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -217,6 +217,8 @@ extern int zebra_vxlan_clear_dup_detect_vni(struct vty *vty,
 extern void zebra_vxlan_handle_result(struct zebra_dplane_ctx *ctx);
 
 extern void zebra_evpn_init(void);
+extern void zebra_vxlan_macvlan_up(struct interface *ifp);
+extern void zebra_vxlan_macvlan_down(struct interface *ifp);
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -125,6 +125,8 @@ struct zebra_l3vni_t_ {
 	/* SVI interface corresponding to the l3vni */
 	struct interface *svi_if;
 
+	struct interface *mac_vlan_if;
+
 	/* list of L2 VNIs associated with the L3 VNI */
 	struct list *l2vnis;
 
@@ -215,7 +217,8 @@ static inline vrf_id_t zl3vni_vrf_id(zebra_l3vni_t *zl3vni)
 	return zl3vni->vrf_id;
 }
 
-static inline void zl3vni_get_rmac(zebra_l3vni_t *zl3vni, struct ethaddr *rmac)
+static inline void zl3vni_get_svi_rmac(zebra_l3vni_t *zl3vni,
+				       struct ethaddr *rmac)
 {
 	if (!zl3vni)
 		return;
@@ -433,6 +436,7 @@ struct nh_walk_ctx {
 extern zebra_l3vni_t *zl3vni_from_vrf(vrf_id_t vrf_id);
 extern struct interface *zl3vni_map_to_vxlan_if(zebra_l3vni_t *zl3vni);
 extern struct interface *zl3vni_map_to_svi_if(zebra_l3vni_t *zl3vni);
+extern struct interface *zl3vni_map_to_mac_vlan_if(zebra_l3vni_t *zl3vni);
 
 DECLARE_HOOK(zebra_rmac_update, (zebra_mac_t *rmac, zebra_l3vni_t *zl3vni,
 	     bool delete, const char *reason), (rmac, zl3vni, delete, reason))

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -366,6 +366,7 @@ struct zebra_neigh_t_ {
 #define ZEBRA_NEIGH_DEF_GW    0x08
 #define ZEBRA_NEIGH_ROUTER_FLAG 0x10
 #define ZEBRA_NEIGH_DUPLICATE 0x20
+#define ZEBRA_NEIGH_SVI_IP 0x40
 
 	enum zebra_neigh_state state;
 

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -169,6 +169,44 @@ static inline const char *zl3vni_rmac2str(zebra_l3vni_t *zl3vni, char *buf,
 		ptr = buf;
 	}
 
+	if (zl3vni->mac_vlan_if)
+		snprintf(ptr, (ETHER_ADDR_STRLEN),
+			 "%02x:%02x:%02x:%02x:%02x:%02x",
+			 (uint8_t)zl3vni->mac_vlan_if->hw_addr[0],
+			 (uint8_t)zl3vni->mac_vlan_if->hw_addr[1],
+			 (uint8_t)zl3vni->mac_vlan_if->hw_addr[2],
+			 (uint8_t)zl3vni->mac_vlan_if->hw_addr[3],
+			 (uint8_t)zl3vni->mac_vlan_if->hw_addr[4],
+			 (uint8_t)zl3vni->mac_vlan_if->hw_addr[5]);
+	else if (zl3vni->svi_if)
+		snprintf(ptr, (ETHER_ADDR_STRLEN),
+			 "%02x:%02x:%02x:%02x:%02x:%02x",
+			 (uint8_t)zl3vni->svi_if->hw_addr[0],
+			 (uint8_t)zl3vni->svi_if->hw_addr[1],
+			 (uint8_t)zl3vni->svi_if->hw_addr[2],
+			 (uint8_t)zl3vni->svi_if->hw_addr[3],
+			 (uint8_t)zl3vni->svi_if->hw_addr[4],
+			 (uint8_t)zl3vni->svi_if->hw_addr[5]);
+	else
+		snprintf(ptr, ETHER_ADDR_STRLEN, "None");
+
+	return ptr;
+}
+
+/* get the sys mac string */
+static inline const char *zl3vni_sysmac2str(zebra_l3vni_t *zl3vni, char *buf,
+					    int size)
+{
+	char *ptr;
+
+	if (!buf)
+		ptr = (char *)XMALLOC(MTYPE_TMP,
+				      ETHER_ADDR_STRLEN * sizeof(char));
+	else {
+		assert(size >= ETHER_ADDR_STRLEN);
+		ptr = buf;
+	}
+
 	if (zl3vni->svi_if)
 		snprintf(ptr, (ETHER_ADDR_STRLEN),
 			 "%02x:%02x:%02x:%02x:%02x:%02x",


### PR DESCRIPTION
The objective of this PR is to announce type-5 routes and self type-2 routes in a EVPN symmetric routing MLAG deployment, with the switch’s individual (primary) IP as the next hop IP and the individual (system) MAC as router mac (RMAC) while leaving the behavior unchanged. 
The current behavior picks up the next hop IP from the VxLAN interface’s local tunnel IP and RMAC from L3-VNI SVI interface's MAC (anycast MAC).  This can lead to scenario where traffic forward to a switch which does not have a route and needs to make additional hop to go over peerlink. 

To achieve individual system MAC in conjunction with anycast MAC per VLAN/VNI basis, additional interface mac-vlan (VRR) interface required to be created. The SVI interface is configured with individual MAC and mac-vlan interface is configured with anycast MAC. 
To achieve individual system IP, the router-id of the bgp default instance is used.

User can enable/disable PIP feature, configure system IP and or configure system mac via cli
`[no] advertise-pip [<system-ip> [<system-mac>]]`
User configured value takes precedence and advertise along with type-5 and type-2 self routes.
By default, advertise-pip is enabled per bgp vrf instance and user can disable the feature via  cli  in that case existing anycast mac is used as RMAC and vxlan tunnel IP is used as nexthop. 

Testing:

type-5 route with system-IP 27.0.0.11 and system Mac 00:02:00:00:00:2e as RMAC when feature is enaled.
```
*> [5]:[0]:[24]:[81.6.1.0]
                    27.0.0.11                0             0 5541 i
                    ET:8 RT:5546:4002 Rmac:00:02:00:00:00:2e

TORC11# show bgp l2vpn evpn vni 4002
VNI: 4002 (known to the kernel)
  Type: L3
  Tenant VRF: vrf2
  RD: 141.2.1.2:7
  Originator IP: 36.0.0.11
  Advertise-gw-macip : n/a
  Advertise-pip: Yes
  System-IP: 27.0.0.11
  System-MAC: 00:02:00:00:00:2e
  Router-MAC: 44:38:39:ff:ff:01
  Import Route Target:
    5546:4002
  Export Route Target:
    5546:4002

```



