### PR TITLE
bgpd: Use defined constants for NHLEN instead of numeric values

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -781,12 +781,12 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 			static_attr.nexthop.s_addr = nexthop->u.prefix4.s_addr;
 
 			static_attr.mp_nexthop_global_in = nexthop->u.prefix4;
-			static_attr.mp_nexthop_len = 4;
+			static_attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV4;
 			break;
 
 		case AF_INET6:
 			static_attr.mp_nexthop_global = nexthop->u.prefix6;
-			static_attr.mp_nexthop_len = 16;
+			static_attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
 			break;
 
 		default:
@@ -802,7 +802,8 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 				 */
 				static_attr.mp_nexthop_global_in =
 					static_attr.nexthop;
-				static_attr.mp_nexthop_len = 4;
+				static_attr.mp_nexthop_len =
+					BGP_ATTR_NHLEN_IPV4;
 				/*
 				 * XXX Leave static_attr.nexthop
 				 * intact for NHT
@@ -821,7 +822,8 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 			    && !BGP_ATTR_NEXTHOP_AFI_IP6(path_vrf->attr)) {
 				static_attr.mp_nexthop_global_in.s_addr =
 					static_attr.nexthop.s_addr;
-				static_attr.mp_nexthop_len = 4;
+				static_attr.mp_nexthop_len =
+					BGP_ATTR_NHLEN_IPV4;
 				static_attr.flag |=
 					ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
 			}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7269,7 +7269,8 @@ void route_vty_out(struct vty *vty, struct prefix *p,
 
 			/* We display both LL & GL if both have been
 			 * received */
-			if ((attr->mp_nexthop_len == 32)
+			if ((attr->mp_nexthop_len
+			     == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
 			    || (path->peer->conf_if)) {
 				json_nexthop_ll = json_object_new_object();
 				json_object_string_add(
@@ -7301,7 +7302,8 @@ void route_vty_out(struct vty *vty, struct prefix *p,
 		} else {
 			/* Display LL if LL/Global both in table unless
 			 * prefer-global is set */
-			if (((attr->mp_nexthop_len == 32)
+			if (((attr->mp_nexthop_len
+			      == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
 			     && !attr->mp_nexthop_prefer_global)
 			    || (path->peer->conf_if)) {
 				if (path->peer->conf_if) {

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2856,12 +2856,15 @@ route_set_ipv6_nexthop_peer(void *rule, const struct prefix *pfx,
 			/* Set next hop value and length in attribute. */
 			if (IN6_IS_ADDR_LINKLOCAL(&peer_address)) {
 				path->attr->mp_nexthop_local = peer_address;
-				if (path->attr->mp_nexthop_len != 32)
-					path->attr->mp_nexthop_len = 32;
+				if (path->attr->mp_nexthop_len
+				    != BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
+					path->attr->mp_nexthop_len =
+						BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL;
 			} else {
 				path->attr->mp_nexthop_global = peer_address;
 				if (path->attr->mp_nexthop_len == 0)
-					path->attr->mp_nexthop_len = 16;
+					path->attr->mp_nexthop_len =
+						BGP_ATTR_NHLEN_IPV6_GLOBAL;
 			}
 
 		} else if (CHECK_FLAG(peer->rmap_type, PEER_RMAP_TYPE_OUT)) {
@@ -2926,7 +2929,7 @@ route_set_vpnv4_nexthop(void *rule, const struct prefix *prefix,
 
 		/* Set next hop value. */
 		path->attr->mp_nexthop_global_in = *address;
-		path->attr->mp_nexthop_len = 4;
+		path->attr->mp_nexthop_len = BGP_ATTR_NHLEN_IPV4;
 	}
 
 	return RMAP_OKAY;

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -880,12 +880,12 @@ void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
 		attr.nexthop.s_addr = nexthop->addr.v4.s_addr;
 
 		attr.mp_nexthop_global_in = nexthop->addr.v4;
-		attr.mp_nexthop_len = 4;
+		attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV4;
 		break;
 
 	case AF_INET6:
 		attr.mp_nexthop_global = nexthop->addr.v6;
-		attr.mp_nexthop_len = 16;
+		attr.mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL;
 		break;
 
 	default:

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -86,13 +86,13 @@ static void encap_attr_export_ce(struct attr *new, struct attr *orig,
 	switch (use_nexthop->family) {
 	case AF_INET:
 		new->nexthop = use_nexthop->u.prefix4;
-		new->mp_nexthop_len = 4; /* bytes */
+		new->mp_nexthop_len = BGP_ATTR_NHLEN_IPV4; /* bytes */
 		new->flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
 		break;
 
 	case AF_INET6:
 		new->mp_nexthop_global = use_nexthop->u.prefix6;
-		new->mp_nexthop_len = 16; /* bytes */
+		new->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL; /* bytes */
 		break;
 
 	default:
@@ -624,13 +624,13 @@ encap_attr_export(struct attr *new, struct attr *orig,
 	switch (use_nexthop->family) {
 	case AF_INET:
 		new->nexthop = use_nexthop->u.prefix4;
-		new->mp_nexthop_len = 4; /* bytes */
+		new->mp_nexthop_len = BGP_ATTR_NHLEN_IPV4; /* bytes */
 		new->flag |= ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP);
 		break;
 
 	case AF_INET6:
 		new->mp_nexthop_global = use_nexthop->u.prefix6;
-		new->mp_nexthop_len = 16; /* bytes */
+		new->mp_nexthop_len = BGP_ATTR_NHLEN_IPV6_GLOBAL; /* bytes */
 		break;
 
 	default:


### PR DESCRIPTION
This is better in cases when you need to find specific pattern and/or
replacing.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>