### PR TITLE
bgpd: Remove trailing whitespaces from some header files

### DIFF
--- a/bgpd/bgp_open.h
+++ b/bgpd/bgp_open.h
@@ -68,13 +68,13 @@ struct graceful_restart_af {
 /* Cooperative Route Filtering Capability.  */
 
 /* ORF Type */
-#define ORF_TYPE_PREFIX                64 
+#define ORF_TYPE_PREFIX                64
 #define ORF_TYPE_PREFIX_OLD           128
 
 /* ORF Mode */
-#define ORF_MODE_RECEIVE                1 
-#define ORF_MODE_SEND                   2 
-#define ORF_MODE_BOTH                   3 
+#define ORF_MODE_RECEIVE                1
+#define ORF_MODE_SEND                   2
+#define ORF_MODE_BOTH                   3
 
 /* Capability Message Action.  */
 #define CAPABILITY_ACTION_SET           0

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -39,14 +39,14 @@ DECLARE_HOOK(bgp_packet_send,
 
 /* When to refresh */
 #define REFRESH_IMMEDIATE 1
-#define REFRESH_DEFER     2 
+#define REFRESH_DEFER     2
 
 /* ORF Common part flag */
-#define ORF_COMMON_PART_ADD        0x00 
-#define ORF_COMMON_PART_REMOVE     0x80 
-#define ORF_COMMON_PART_REMOVE_ALL 0xC0 
-#define ORF_COMMON_PART_PERMIT     0x00 
-#define ORF_COMMON_PART_DENY       0x20 
+#define ORF_COMMON_PART_ADD        0x00
+#define ORF_COMMON_PART_REMOVE     0x80
+#define ORF_COMMON_PART_REMOVE_ALL 0xC0
+#define ORF_COMMON_PART_PERMIT     0x00
+#define ORF_COMMON_PART_DENY       0x20
 
 /* Packet send and receive function prototypes. */
 extern void bgp_keepalive_send(struct peer *);

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -236,9 +236,9 @@ struct bgp_path_info {
 #define BGP_ROUTE_NORMAL       0
 #define BGP_ROUTE_STATIC       1
 #define BGP_ROUTE_AGGREGATE    2
-#define BGP_ROUTE_REDISTRIBUTE 3 
+#define BGP_ROUTE_REDISTRIBUTE 3
 #ifdef ENABLE_BGP_VNC
-# define BGP_ROUTE_RFP          4 
+# define BGP_ROUTE_RFP          4
 #endif
 #define BGP_ROUTE_IMPORTED     5        /* from another bgp instance/safi */
 


### PR DESCRIPTION
This is annoying when editing a file and saving the file. IDEs like
VSCode can automatically remove trailing whitespaces, hence it would be better
having a clean code before pushing other changes.

I step onto this not the first time.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>