### PR TITLE
ospf6d: fix interface type handling

### DIFF
--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -355,8 +355,6 @@ void ospf6_interface_state_update(struct interface *ifp)
 	oi = (struct ospf6_interface *)ifp->info;
 	if (oi == NULL)
 		return;
-	if (oi->area == NULL)
-		return;
 	if (CHECK_FLAG(oi->flag, OSPF6_INTERFACE_DISABLE))
 		return;
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -772,8 +772,7 @@ int interface_up(struct thread *thread)
 	}
 
 	/* decide next interface state */
-	if ((if_is_pointopoint(oi->interface))
-	    || (oi->type == OSPF_IFTYPE_POINTOPOINT)) {
+	if (oi->type == OSPF_IFTYPE_POINTOPOINT) {
 		ospf6_interface_state_change(OSPF6_INTERFACE_POINTTOPOINT, oi);
 	} else if (oi->priority == 0)
 		ospf6_interface_state_change(OSPF6_INTERFACE_DROTHER, oi);

--- a/ospf6d/ospf6_interface.h
+++ b/ospf6d/ospf6_interface.h
@@ -55,6 +55,7 @@ struct ospf6_interface {
 
 	/* Network Type */
 	uint8_t type;
+	bool type_cfg;
 
 	/* Router Priority */
 	uint8_t priority;

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -618,7 +618,7 @@ static void ospf6_neighbor_show(struct vty *vty, struct ospf6_neighbor *on)
 	snprintf(deadtime, sizeof(deadtime), "%02ld:%02ld:%02ld", h, m, s);
 
 	/* Neighbor State */
-	if (if_is_pointopoint(on->ospf6_if->interface))
+	if (on->ospf6_if->type == OSPF_IFTYPE_POINTOPOINT)
 		snprintf(nstate, sizeof(nstate), "PointToPoint");
 	else {
 		if (on->router_id == on->drouter)

--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -1130,9 +1130,9 @@ static uint8_t *ospfv3IfEntry(struct variable *v, oid *name, size_t *length,
 			return SNMP_INTEGER(ntohl(oi->area->area_id));
 		break;
 	case OSPFv3IFTYPE:
-		if (if_is_broadcast(oi->interface))
+		if (oi->type == OSPF_IFTYPE_BROADCAST)
 			return SNMP_INTEGER(1);
-		else if (if_is_pointopoint(oi->interface))
+		else if (oi->type == OSPF_IFTYPE_POINTOPOINT)
 			return SNMP_INTEGER(3);
 		else
 			break; /* Unknown, don't put anything */


### PR DESCRIPTION
cf. #3930 & #4873 

This only worked in Quagga because we get interface state before reading config.  For any interface added later when there was already some config in ospf6d, it'd go to broadcast mode.