### PR TITLE
build: fix "make tags"

### DIFF
--- a/fpm/subdir.am
+++ b/fpm/subdir.am
@@ -12,9 +12,13 @@ fpm_libfrrfpm_pb_la_SOURCES = \
 	fpm/fpm_pb.c \
 	# end
 
+if FPM
+if HAVE_PROTOBUF
 nodist_fpm_libfrrfpm_pb_la_SOURCES = \
 	fpm/fpm.pb-c.c \
 	# end
+endif
+endif
 
 CLEANFILES += \
 	fpm/fpm.pb-c.c \

--- a/grpc/subdir.am
+++ b/grpc/subdir.am
@@ -5,10 +5,12 @@ endif
 grpc_libfrrgrpc_pb_la_LDFLAGS = -version-info 0:0:0
 grpc_libfrrgrpc_pb_la_CPPFLAGS = $(AM_CPPFLAGS) $(GRPC_CXXFLAGS)
 
+if GRPC
 nodist_grpc_libfrrgrpc_pb_la_SOURCES = \
 	grpc/frr-northbound.pb.cc \
 	grpc/frr-northbound.grpc.pb.cc \
 	# end
+endif
 
 CLEANFILES += \
 	grpc/frr-northbound.pb.cc \

--- a/qpb/subdir.am
+++ b/qpb/subdir.am
@@ -10,9 +10,12 @@ qpb_libfrr_pb_la_SOURCES = \
 	qpb/qpb.c \
 	qpb/qpb_allocator.c \
 	# end
+
+if HAVE_PROTOBUF
 nodist_qpb_libfrr_pb_la_SOURCES = \
 	qpb/qpb.pb-c.c \
 	# end
+endif
 
 noinst_HEADERS += \
 	qpb/linear_allocator.h \


### PR DESCRIPTION
Anything we list in a xxx_SOURCES variable will be included for "make
tags", including filess marked as nodist_xxx_SOURCES.  So if we don't
have Protobuf enabled, even though the entire library isn't built, "make
tags" will still try to process these files... which we can't
autogenerate because Protobuf is disabled.  Same for gRPC.

Fixes: #3266