### PR TITLE
[7.2] zebra: dplane route updates need to check all nexthops

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1547,7 +1547,9 @@ static bool rib_update_re_from_ctx(struct route_entry *re,
 				changed_p = true;
 
 			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_FIB);
-			break;
+
+			/* Keep checking nexthops */
+			continue;
 		}
 
 		if (CHECK_FLAG(ctx_nexthop->flags, NEXTHOP_FLAG_FIB)) {
@@ -1983,6 +1985,9 @@ static void rib_process_dplane_notify(struct zebra_dplane_ctx *ctx)
 	 * not-installed; or not-installed to installed.
 	 */
 	if (start_count > 0 && end_count > 0) {
+		if (debug_p)
+			zlog_debug("%u:%s applied nexthop changes from dplane notification",
+				   dplane_ctx_get_vrf(ctx), dest_str);
 
 		/* Changed nexthops - update kernel/others */
 		dplane_route_notif_update(rn, re,


### PR DESCRIPTION
[7.2 version of #4979 ]
dataplane updates were not doing a complete comparison of installed/fib nexthops with the zebra rib-level nexthops, in one path: we needed a 'continue' instead of a 'break'