### PR TITLE
BFD Enhancements and bug fixes

### DIFF
--- a/bfdd/bfd_debug.c
+++ b/bfdd/bfd_debug.c
@@ -1,0 +1,106 @@
+/*********************************************************************
+ * Copyright 2019 Broadcom Inc.  All rights reserved. 
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * bfd_debug.c: implements the BFD debug functions.
+ *
+ * Authors
+ * -------
+ * Sayed Mohd Saquib [sayed.saquib@broadcom.com]
+ */
+
+#include "command.h"
+#include "bfd.h"
+
+bool conf_bfd_debug;
+bool term_bfd_debug;
+
+DEFUN (debug_bfd,
+       debug_bfd_cmd,
+       "debug bfd",
+       DEBUG_STR
+       BFD_STR)
+{
+	if (vty->node == CONFIG_NODE)
+		BFD_DEBUG_ON();
+	else {
+		BFD_TERM_DEBUG_ON();
+		vty_out(vty, "BFD debugging is on\n");
+	}
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_debug_bfd,
+       no_debug_bfd_cmd,
+       "no debug bfd",
+       NO_STR
+       DEBUG_STR
+       BFD_STR)
+{
+	if (vty->node == CONFIG_NODE)
+		BFD_DEBUG_OFF();
+	else {
+		BFD_TERM_DEBUG_OFF();
+		vty_out(vty, "BFD debugging is off\n");
+	}
+	return CMD_SUCCESS;
+}
+
+DEFUN_NOSH (show_debugging_bfd,
+	    show_debugging_bfd_cmd,
+	    "show debugging [bfd]",
+	    SHOW_STR
+	    DEBUG_STR
+	    BFD_STR)
+{
+	vty_out(vty, "BFD debugging status:\n");
+
+	if (BFD_DEBUG())
+		vty_out(vty, "  BFD debugging is on\n");
+
+	vty_out(vty, "\n");
+	return CMD_SUCCESS;
+}
+
+static int bfd_config_write_debug(struct vty *vty)
+{
+	int write = 0;
+
+	if (CONF_BFD_DEBUG()) {
+		vty_out(vty, "debug bfd\n");
+		write++;
+	}
+
+	return write;
+}
+
+static struct cmd_node debug_node = {DEBUG_NODE, "", 1};
+
+void bfd_debug_init(void)
+{
+	install_node(&debug_node, bfd_config_write_debug);
+
+	install_element(ENABLE_NODE, &show_debugging_bfd_cmd);
+
+	install_element(ENABLE_NODE, &debug_bfd_cmd);
+	install_element(CONFIG_NODE, &debug_bfd_cmd);
+
+	install_element(ENABLE_NODE, &no_debug_bfd_cmd);
+	install_element(CONFIG_NODE, &no_debug_bfd_cmd);
+
+}
+
+

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -214,52 +214,72 @@ static int ptm_bfd_process_echo_pkt(struct bfd_vrf_global *bvrf, int s)
 
 void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 {
-	struct bfd_pkt cp;
+	struct bfd_pkt cp = {0};
+	struct bfd_pkt *pst_bfd_pkt = NULL;
 
-	/* Set fields according to section 6.5.7 */
-	cp.diag = bfd->local_diag;
-	BFD_SETVER(cp.diag, BFD_VERSION);
-	cp.flags = 0;
-	BFD_SETSTATE(cp.flags, bfd->ses_state);
-
-	if (BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_CBIT))
-		BFD_SETCBIT(cp.flags, BFD_CBIT);
-
-	BFD_SETDEMANDBIT(cp.flags, BFD_DEF_DEMAND);
-
-	/*
-	 * Polling and Final can't be set at the same time.
-	 *
-	 * RFC 5880, Section 6.5.
-	 */
-	BFD_SETFBIT(cp.flags, fbit);
-	if (fbit == 0)
-		BFD_SETPBIT(cp.flags, bfd->polling);
-
-	cp.detect_mult = bfd->detect_mult;
-	cp.len = BFD_PKT_LEN;
-	cp.discrs.my_discr = htonl(bfd->discrs.my_discr);
-	cp.discrs.remote_discr = htonl(bfd->discrs.remote_discr);
-	if (bfd->polling) {
-		cp.timers.desired_min_tx =
-			htonl(bfd->timers.desired_min_tx);
-		cp.timers.required_min_rx =
-			htonl(bfd->timers.required_min_rx);
-	} else {
-		/*
-		 * We can only announce current setting on poll, this
-		 * avoids timing mismatch with our peer and give it
-		 * the oportunity to learn. See `bs_final_handler` for
-		 * more information.
-		 */
-		cp.timers.desired_min_tx =
-			htonl(bfd->cur_timers.desired_min_tx);
-		cp.timers.required_min_rx =
-			htonl(bfd->cur_timers.required_min_rx);
+	if ((true == bfd->bfd_tx_pkt_stored) &&
+		(bfd->ses_state == PTM_BFD_UP) && (!bfd->polling) && (!fbit))
+	{
+		pst_bfd_pkt = &(bfd->bfd_tx_pkt);
 	}
-	cp.timers.required_min_echo = htonl(bfd->timers.required_min_echo);
+	else
+	{
+		/* Set fields according to section 6.5.7 */
+		cp.diag = bfd->local_diag;
+		BFD_SETVER(cp.diag, BFD_VERSION);
+		cp.flags = 0;
+		BFD_SETSTATE(cp.flags, bfd->ses_state);
 
-	if (_ptm_bfd_send(bfd, NULL, &cp, BFD_PKT_LEN) != 0)
+		if (BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_CBIT))
+			BFD_SETCBIT(cp.flags, BFD_CBIT);
+
+		BFD_SETDEMANDBIT(cp.flags, BFD_DEF_DEMAND);
+	
+		/*
+	 	* Polling and Final can't be set at the same time.
+	 	*
+	 	* RFC 5880, Section 6.5.
+	 	*/
+		BFD_SETFBIT(cp.flags, fbit);
+		if (fbit == 0)
+			BFD_SETPBIT(cp.flags, bfd->polling);
+
+		cp.detect_mult = bfd->detect_mult;
+		cp.len = BFD_PKT_LEN;
+		cp.discrs.my_discr = htonl(bfd->discrs.my_discr);
+		cp.discrs.remote_discr = htonl(bfd->discrs.remote_discr);
+		if (bfd->polling) {
+			cp.timers.desired_min_tx =
+				htonl(bfd->timers.desired_min_tx);
+			cp.timers.required_min_rx =
+				htonl(bfd->timers.required_min_rx);
+		} else {
+			/*
+		 	* We can only announce current setting on poll, this
+		 	* avoids timing mismatch with our peer and give it
+		 	* the oportunity to learn. See `bs_final_handler` for
+		 	* more information.
+		 	*/
+			cp.timers.desired_min_tx =
+				htonl(bfd->cur_timers.desired_min_tx);
+			cp.timers.required_min_rx =
+				htonl(bfd->cur_timers.required_min_rx);
+		}
+
+		cp.timers.required_min_echo = htonl(bfd->timers.required_min_echo);
+		
+		pst_bfd_pkt = &cp;
+
+		if ((BFD_GETSTATE(cp.flags) == PTM_BFD_UP) && (!bfd->polling) && !(fbit)) {
+			
+			memcpy (&(bfd->bfd_tx_pkt), pst_bfd_pkt, sizeof (struct bfd_pkt));
+			bfd->bfd_tx_pkt_stored = true;
+
+			log_debug_info("storing-packet: session-id: %d",bfd->discrs.my_discr);
+		}
+	}
+
+	if (_ptm_bfd_send(bfd, NULL, pst_bfd_pkt, BFD_PKT_LEN) != 0)
 		return;
 
 	bfd->stats.tx_ctrl_pkt++;
@@ -604,8 +624,9 @@ int bfd_recv_cb(struct thread *t)
 	/* Find the session that this packet belongs. */
 	bfd = ptm_bfd_sess_find(cp, &peer, &local, ifindex, vrfid, is_mhop);
 	if (bfd == NULL) {
-		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
-			 "no session found");
+		if (BFD_DEBUG())
+			cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
+			 	"no session found");
 		return 0;
 	}
 

--- a/bfdd/bfdd_cli.c
+++ b/bfdd/bfdd_cli.c
@@ -409,4 +409,6 @@ bfdd_cli_init(void)
 	install_element(BFD_PEER_NODE, &bfd_peer_tx_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_cmd);
 	install_element(BFD_PEER_NODE, &bfd_peer_echo_interval_cmd);
+	
+	bfd_debug_init();
 }

--- a/bfdd/bfdd_northbound.c
+++ b/bfdd/bfdd_northbound.c
@@ -405,7 +405,7 @@ static int bfdd_bfd_sessions_single_hop_administrative_down_modify(
 
 		/* Change and notify state change. */
 		bs->ses_state = PTM_BFD_DOWN;
-		control_notify(bs);
+		control_notify(bs, PTM_BFD_DOWN);
 
 		/* Enable all timers. */
 		bfd_recvtimer_update(bs);
@@ -428,7 +428,7 @@ static int bfdd_bfd_sessions_single_hop_administrative_down_modify(
 
 		/* Change and notify state change. */
 		bs->ses_state = PTM_BFD_ADM_DOWN;
-		control_notify(bs);
+		control_notify(bs, PTM_BFD_ADM_DOWN);
 
 		ptm_bfd_snd(bs, 0);
 	}

--- a/bfdd/config.c
+++ b/bfdd/config.c
@@ -70,7 +70,7 @@ static int config_add(struct bfd_peer_cfg *bpc,
 static int config_del(struct bfd_peer_cfg *bpc,
 		      void *arg __attribute__((unused)))
 {
-	return ptm_bfd_sess_del(bpc) != 0;
+	return ptm_bfd_sess_del(bpc, NULL, 0) != 0;
 }
 
 static int parse_config_json(struct json_object *jo, bpc_handle h, void *arg)

--- a/bfdd/control.c
+++ b/bfdd/control.c
@@ -774,13 +774,13 @@ static void _control_notify(struct bfd_control_socket *bcs,
 	control_queue_enqueue(bcs, bcm);
 }
 
-int control_notify(struct bfd_session *bs)
+int control_notify(struct bfd_session *bs, uint8_t notify_state)
 {
 	struct bfd_control_socket *bcs;
 	struct bfd_notify_peer *bnp;
 
 	/* Notify zebra listeners as well. */
-	ptm_bfd_notify(bs);
+	ptm_bfd_notify(bs, notify_state);
 
 	/*
 	 * PERFORMANCE: reuse the bfd_control_msg allocated data for

--- a/bfdd/log.c
+++ b/bfdd/log.c
@@ -95,6 +95,18 @@ void log_debug(const char *fmt, ...)
 	va_end(vl);
 }
 
+void log_debug_info(const char *fmt, ...)
+{
+	va_list vl;
+
+	if (!BFD_DEBUG())
+		return;
+
+	va_start(vl, fmt);
+	log_msg(BLOG_DEBUG, fmt, vl);
+	va_end(vl);
+}
+
 void log_error(const char *fmt, ...)
 {
 	va_list vl;

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -153,7 +153,7 @@ static int _ptm_msg_address(struct stream *msg, int family, const void *addr)
 	return 0;
 }
 
-int ptm_bfd_notify(struct bfd_session *bs)
+int ptm_bfd_notify(struct bfd_session *bs, uint8_t notify_state)
 {
 	struct stream *msg;
 
@@ -204,12 +204,15 @@ int ptm_bfd_notify(struct bfd_session *bs)
 	_ptm_msg_address(msg, bs->key.family, &bs->key.peer);
 
 	/* BFD status */
-	switch (bs->ses_state) {
+	switch (notify_state) {
 	case PTM_BFD_UP:
 		stream_putl(msg, BFD_STATUS_UP);
 		break;
 
 	case PTM_BFD_ADM_DOWN:
+		stream_putl(msg, BFD_STATUS_ADMIN_DOWN);
+        break;
+
 	case PTM_BFD_DOWN:
 	case PTM_BFD_INIT:
 		stream_putl(msg, BFD_STATUS_DOWN);
@@ -432,7 +435,7 @@ static void bfdd_dest_register(struct stream *msg, vrf_id_t vrf_id)
 		return;
 	}
 
-	ptm_bfd_notify(bs);
+	ptm_bfd_notify(bs, bs->ses_state);
 }
 
 static void bfdd_dest_deregister(struct stream *msg, vrf_id_t vrf_id)
@@ -461,7 +464,13 @@ static void bfdd_dest_deregister(struct stream *msg, vrf_id_t vrf_id)
 	if (bs->refcount ||
 	    BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG))
 		return;
-	ptm_bfd_sess_del(&bpc);
+
+	bfd_clear_stored_pkt(bs);
+
+	bs->ses_state = PTM_BFD_ADM_DOWN;
+	ptm_bfd_snd(bs, 0);
+
+	ptm_bfd_sess_del(&bpc, NULL, 0);
 }
 
 /*

--- a/bfdd/subdir.am
+++ b/bfdd/subdir.am
@@ -8,6 +8,7 @@ sbin_PROGRAMS += bfdd/bfdd
 dist_examples_DATA += bfdd/bfdd.conf.sample
 vtysh_scan += $(top_srcdir)/bfdd/bfdd_vty.c
 vtysh_scan += $(top_srcdir)/bfdd/bfdd_cli.c
+vtysh_scan += $(top_srcdir)/bfdd/bfd_debug.c
 man8 += $(MANBUILD)/bfdd.8
 endif
 
@@ -22,6 +23,7 @@ bfdd_libbfd_a_SOURCES = \
 	bfdd/event.c \
 	bfdd/log.c \
 	bfdd/ptm_adapter.c \
+	bfdd/bfd_debug.c \
 	# end
 
 bfdd/bfdd_vty_clippy.c: $(CLIPPY_DEPS)

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -283,6 +283,8 @@ static void bgp_bfd_peer_status_update(struct peer *peer, int status,
 
 	old_status = bfd_info->status;
 	bfd_info->status = status;
+	if (status == BFD_STATUS_ADMIN_DOWN)
+		bfd_info->status = BFD_STATUS_DOWN;
 	bfd_info->last_update = bgp_clock();
 
 	if (status != old_status) {

--- a/isisd/isis_bfd.c
+++ b/isisd/isis_bfd.c
@@ -119,6 +119,8 @@ static void bfd_adj_event(struct isis_adjacency *adj, struct prefix *dst,
 	int old_status = adj->bfd_session->status;
 
 	adj->bfd_session->status = new_status;
+	if (new_status == BFD_STATUS_ADMIN_DOWN)
+		adj->bfd_session->status = BFD_STATUS_DOWN;
 	if (old_status == new_status)
 		return;
 

--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -51,9 +51,10 @@ struct bfd_gbl {
 #define BFD_FLAG_BFD_CBIT_ON (1 << 3) /* Peer registered with CBIT set to on */
 #define BFD_FLAG_BFD_CHECK_CONTROLPLANE (1 << 4) /* BFD and controlplane daemon are linked */
 
-#define BFD_STATUS_UNKNOWN (1 << 0) /* BFD session status never received */
-#define BFD_STATUS_DOWN    (1 << 1) /* BFD session status is down */
-#define BFD_STATUS_UP      (1 << 2) /* BFD session status is up */
+#define BFD_STATUS_UNKNOWN    (1 << 0) /* BFD session status never received */
+#define BFD_STATUS_DOWN       (1 << 1) /* BFD session status is down */
+#define BFD_STATUS_UP         (1 << 2) /* BFD session status is up */
+#define BFD_STATUS_ADMIN_DOWN (1 << 3) /* BFD session is administatrively down */
 
 enum bfd_sess_type {
 	BFD_TYPE_NOT_CONFIGURED,

--- a/lib/command.h
+++ b/lib/command.h
@@ -398,6 +398,7 @@ struct cmd_node {
 #define WATCHFRR_STR "watchfrr information\n"
 #define ZEBRA_STR "Zebra information\n"
 #define FILTER_LOG_STR "Filter Logs\n"
+#define BFD_STR "BFD information\n"
 
 #define CMD_VNI_RANGE "(1-16777215)"
 #define CONF_BACKUP_EXT ".sav"

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -237,6 +237,8 @@ static int ospf6_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 
 		old_status = bfd_info->status;
 		bfd_info->status = status;
+		if (status == BFD_STATUS_ADMIN_DOWN)
+			bfd_info->status = BFD_STATUS_DOWN;
 		monotime(&tv);
 		bfd_info->last_update = tv.tv_sec;
 

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -241,6 +241,8 @@ static int ospf_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 
 		old_status = bfd_info->status;
 		bfd_info->status = status;
+		if (status == BFD_STATUS_ADMIN_DOWN)
+			bfd_info->status = BFD_STATUS_DOWN;
 		monotime(&tv);
 		bfd_info->last_update = tv.tv_sec;
 

--- a/pimd/pim_bfd.c
+++ b/pimd/pim_bfd.c
@@ -271,6 +271,8 @@ static int pim_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
 		}
 		old_status = bfd_info->status;
 		bfd_info->status = status;
+		if (status == BFD_STATUS_ADMIN_DOWN)
+			bfd_info->status = BFD_STATUS_DOWN;
 		monotime(&tv);
 		bfd_info->last_update = tv.tv_sec;
 


### PR DESCRIPTION
This Pull request incorporates few enhancement and bug fixes

1. Added new command "clear bfd counter"
2. Added new command "show bfd peers brief"
3.Added new command "debug bfd"
4. Added enhancement to store BFD packet and use the stored packet for transmission instead of constructing entire packet on every Tx expiry.
5. Added Bug Fix "Admin-Down of BFD remote or local brings Down BGP session"
6. Fixed core dump on executing CLI "Peer x.x.x.x"
7. Added new fields in "show bfd peer" to display if it a configured or dynamic session, new filed to display detect multiplier.