### PR TITLE
zebra: fix mpls ftn uninstall

### DIFF
--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2326,8 +2326,10 @@ static int zebra_mpls_cleanup_zclient_labels(struct zserv *client)
 			     &args);
 
 		/* Cleanup FTNs. */
-		mpls_ftn_uninstall_all(zvrf, AFI_IP, client->proto);
-		mpls_ftn_uninstall_all(zvrf, AFI_IP6, client->proto);
+		mpls_ftn_uninstall_all(zvrf, AFI_IP,
+				       lsp_type_from_re_type(client->proto));
+		mpls_ftn_uninstall_all(zvrf, AFI_IP6,
+				       lsp_type_from_re_type(client->proto));
 	}
 
 	return 0;


### PR DESCRIPTION
when a zebra client disconnects, we iterate over the routing table to
remove any label that originated from that client. However we
were erroneously passing the route type to the function, while
it was expecting the lsp type. As a result, for example, killing
ldpd would not remove the ldp labels from the routes.

Kudos to @rwestphal for pointing me to the source of the issue.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>