### PR TITLE
lib, zebra: Allow for interface deletion when kernel event happens

### DIFF
--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -86,15 +86,9 @@ babel_interface_up (ZAPI_CALLBACK_ARGS)
 }
 
 int
-babel_interface_down (ZAPI_CALLBACK_ARGS)
+babel_ifp_down(struct interface *ifp)
 {
-    struct stream *s = NULL;
-    struct interface *ifp = NULL;
-
     debugf(BABEL_DEBUG_IF, "receive a 'interface down'");
-
-    s = zclient->ibuf;
-    ifp = zebra_interface_state_read(s, vrf_id); /* it updates iflist */
 
     if (ifp == NULL) {
         return 0;
@@ -1252,11 +1246,6 @@ DEFUN (show_babel_parameters,
 }
 
 int babel_ifp_up(struct interface *ifp)
-{
-	return 0;
-}
-
-int babel_ifp_down(struct interface *ifp)
 {
 	return 0;
 }

--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -104,23 +104,14 @@ babel_interface_down (ZAPI_CALLBACK_ARGS)
     return 0;
 }
 
-int
-babel_interface_add (ZAPI_CALLBACK_ARGS)
+int babel_ifp_create (struct interface *ifp)
 {
-    struct interface *ifp = NULL;
-
     debugf(BABEL_DEBUG_IF, "receive a 'interface add'");
 
-    /* read and add the interface in the iflist. */
-    ifp = zebra_interface_add_read (zclient->ibuf, vrf_id);
-
-    if (ifp == NULL) {
-        return 0;
-    }
-
     interface_recalculate(ifp);
-    return 0;
-}
+    
+     return 0;
+ }
 
 int
 babel_interface_delete (ZAPI_CALLBACK_ARGS)
@@ -1258,11 +1249,6 @@ DEFUN (show_babel_parameters,
         config_show_distribute(vty, babel_ctx->distribute_ctx);
     }
     return CMD_SUCCESS;
-}
-
-int babel_ifp_create(struct interface *ifp)
-{
-	return 0;
 }
 
 int babel_ifp_up(struct interface *ifp)

--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -1260,6 +1260,26 @@ DEFUN (show_babel_parameters,
     return CMD_SUCCESS;
 }
 
+int babel_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+int babel_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+int babel_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+int babel_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 void
 babel_if_init(void)
 {

--- a/babeld/babel_interface.c
+++ b/babeld/babel_interface.c
@@ -103,30 +103,17 @@ int babel_ifp_create (struct interface *ifp)
     debugf(BABEL_DEBUG_IF, "receive a 'interface add'");
 
     interface_recalculate(ifp);
-    
+
      return 0;
  }
 
 int
-babel_interface_delete (ZAPI_CALLBACK_ARGS)
+babel_ifp_destroy(struct interface *ifp)
 {
-    struct interface *ifp;
-    struct stream *s;
-
     debugf(BABEL_DEBUG_IF, "receive a 'interface delete'");
-
-    s = zclient->ibuf;
-    ifp = zebra_interface_state_read(s, vrf_id); /* it updates iflist */
-
-    if (ifp == NULL)
-        return 0;
 
     if (IS_ENABLE(ifp))
         interface_reset(ifp);
-
-    /* To support pseudo interface do not free interface structure.  */
-    /* if_delete(ifp); */
-    if_set_index(ifp, IFINDEX_INTERNAL);
 
     return 0;
 }
@@ -1246,11 +1233,6 @@ DEFUN (show_babel_parameters,
 }
 
 int babel_ifp_up(struct interface *ifp)
-{
-	return 0;
-}
-
-int babel_ifp_destroy(struct interface *ifp)
 {
 	return 0;
 }

--- a/babeld/babel_interface.h
+++ b/babeld/babel_interface.h
@@ -121,6 +121,11 @@ int babel_interface_delete (int, struct zclient *, zebra_size_t, vrf_id_t);
 int babel_interface_address_add (int, struct zclient *, zebra_size_t, vrf_id_t);
 int babel_interface_address_delete (int, struct zclient *, zebra_size_t, vrf_id_t);
 
+int babel_ifp_create(struct interface *ifp);
+int babel_ifp_up(struct interface *ifp);
+int babel_ifp_down(struct interface *ifp);
+int babel_ifp_destroy(struct interface *ifp);
+
 unsigned jitter(babel_interface_nfo *, int);
 unsigned update_jitter(babel_interface_nfo *babel_ifp, int urgent);
 /* return "true" if "address" is one of our ipv6 addresses */

--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -202,6 +202,8 @@ main(int argc, char **argv)
     babel_replace_by_null(STDIN_FILENO);
 
     /* init some quagga's dependencies, and babeld's commands */
+    if_zapi_callbacks(babel_ifp_create, babel_ifp_up,
+		      babel_ifp_down, babel_ifp_destroy);
     babeld_quagga_init();
     /* init zebra client's structure and it's commands */
     /* this replace kernel_setup && kernel_setup_socket */

--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -240,7 +240,6 @@ void babelz_zebra_init(void)
     zclient_init(zclient, ZEBRA_ROUTE_BABEL, 0, &babeld_privs);
 
     zclient->zebra_connected = babel_zebra_connected;
-    zclient->interface_delete = babel_interface_delete;
     zclient->interface_address_add = babel_interface_address_add;
     zclient->interface_address_delete = babel_interface_address_delete;
     zclient->redistribute_route_add = babel_zebra_read_route;

--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -241,7 +241,6 @@ void babelz_zebra_init(void)
 
     zclient->zebra_connected = babel_zebra_connected;
     zclient->interface_delete = babel_interface_delete;
-    zclient->interface_down = babel_interface_down;
     zclient->interface_address_add = babel_interface_address_add;
     zclient->interface_address_delete = babel_interface_address_delete;
     zclient->redistribute_route_add = babel_zebra_read_route;

--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -240,7 +240,6 @@ void babelz_zebra_init(void)
     zclient_init(zclient, ZEBRA_ROUTE_BABEL, 0, &babeld_privs);
 
     zclient->zebra_connected = babel_zebra_connected;
-    zclient->interface_add = babel_interface_add;
     zclient->interface_delete = babel_interface_delete;
     zclient->interface_up = babel_interface_up;
     zclient->interface_down = babel_interface_down;

--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -241,7 +241,6 @@ void babelz_zebra_init(void)
 
     zclient->zebra_connected = babel_zebra_connected;
     zclient->interface_delete = babel_interface_delete;
-    zclient->interface_up = babel_interface_up;
     zclient->interface_down = babel_interface_down;
     zclient->interface_address_add = babel_interface_address_add;
     zclient->interface_address_delete = babel_interface_address_delete;

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -673,18 +673,9 @@ void bfdd_sessions_disable_vrf(struct vrf *vrf)
 	}
 }
 
-static int bfdd_interface_update(ZAPI_CALLBACK_ARGS)
+static int bfd_ifp_destroy(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	/* Update interface information. */
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-	if (ifp == NULL)
-		return 0;
-
 	bfdd_sessions_disable_interface(ifp);
-
-	if_set_index(ifp, IFINDEX_INTERNAL);
 
 	return 0;
 }
@@ -749,11 +740,6 @@ static int bfd_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-static int bfd_ifp_destroy(struct interface *ifp)
-{
-	return 0;
-}
-
 void bfdd_zclient_init(struct zebra_privs_t *bfdd_priv)
 {
 	if_zapi_callbacks(bfd_ifp_create, NULL, NULL, bfd_ifp_destroy);
@@ -770,9 +756,6 @@ void bfdd_zclient_init(struct zebra_privs_t *bfdd_priv)
 
 	/* Send replay request on zebra connect. */
 	zclient->zebra_connected = bfdd_zebra_connected;
-
-	/* Learn interfaces from zebra instead of the OS. */
-	zclient->interface_delete = bfdd_interface_update;
 
 	/* Learn about interface VRF. */
 	zclient->interface_vrf_update = bfdd_interface_vrf_update;

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -677,20 +677,6 @@ static int bfdd_interface_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 
-	/*
-	 * `zebra_interface_add_read` will handle the interface creation
-	 * on `lib/if.c`. We'll use that data structure instead of
-	 * rolling our own.
-	 */
-	if (cmd == ZEBRA_INTERFACE_ADD) {
-		ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-		if (ifp == NULL)
-			return 0;
-
-		bfdd_sessions_enable_interface(ifp);
-		return 0;
-	}
-
 	/* Update interface information. */
 	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
 	if (ifp == NULL)
@@ -758,6 +744,8 @@ static int bfdd_interface_address_update(ZAPI_CALLBACK_ARGS)
 
 static int bfd_ifp_create(struct interface *ifp)
 {
+	bfdd_sessions_enable_interface(ifp);
+
 	return 0;
 }
 
@@ -784,7 +772,6 @@ void bfdd_zclient_init(struct zebra_privs_t *bfdd_priv)
 	zclient->zebra_connected = bfdd_zebra_connected;
 
 	/* Learn interfaces from zebra instead of the OS. */
-	zclient->interface_add = bfdd_interface_update;
 	zclient->interface_delete = bfdd_interface_update;
 
 	/* Learn about interface VRF. */

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -756,8 +756,19 @@ static int bfdd_interface_address_update(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
+static int bfd_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int bfd_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 void bfdd_zclient_init(struct zebra_privs_t *bfdd_priv)
 {
+	if_zapi_callbacks(bfd_ifp_create, NULL, NULL, bfd_ifp_destroy);
 	zclient = zclient_new(master, &zclient_options_default);
 	assert(zclient != NULL);
 	zclient_init(zclient, ZEBRA_ROUTE_BFD, 0, bfdd_priv);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2721,9 +2721,32 @@ stream_failure:		/* for STREAM_GETX */
 
 extern struct zebra_privs_t bgpd_privs;
 
+static int bgp_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int bgp_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int bgp_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int bgp_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 {
 	zclient_num_connects = 0;
+
+	if_zapi_callbacks(bgp_ifp_create, bgp_ifp_up,
+			  bgp_ifp_down, bgp_ifp_destroy);
 
 	/* Set default values. */
 	zclient = zclient_new(master, &zclient_options_default);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -253,27 +253,20 @@ static int bgp_ifp_up(struct interface *ifp)
 	return 0;
 }
 
-static int bgp_interface_down(ZAPI_CALLBACK_ARGS)
+static int bgp_ifp_down(struct interface *ifp)
 {
-	struct stream *s;
-	struct interface *ifp;
 	struct connected *c;
 	struct nbr_connected *nc;
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
 	struct peer *peer;
 
-	bgp = bgp_lookup_by_vrf_id(vrf_id);
-
-	s = zclient->ibuf;
-	ifp = zebra_interface_state_read(s, vrf_id);
-	if (!ifp)
-		return 0;
+	bgp = bgp_lookup_by_vrf_id(ifp->vrf_id);
 
 	bgp_mac_del_mac_entry(ifp);
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Rx Intf down VRF %u IF %s", vrf_id, ifp->name);
+		zlog_debug("Rx Intf down VRF %u IF %s", ifp->vrf_id, ifp->name);
 
 	if (!bgp)
 		return 0;
@@ -2707,11 +2700,6 @@ static int bgp_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-static int bgp_ifp_down(struct interface *ifp)
-{
-	return 0;
-}
-
 static int bgp_ifp_destroy(struct interface *ifp)
 {
 	return 0;
@@ -2738,7 +2726,6 @@ void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 	zclient->interface_vrf_update = bgp_interface_vrf_update;
 	zclient->redistribute_route_add = zebra_read_route;
 	zclient->redistribute_route_del = zebra_read_route;
-	zclient->interface_down = bgp_interface_down;
 	zclient->nexthop_update = bgp_read_nexthop_update;
 	zclient->import_check_update = bgp_read_import_check_update;
 	zclient->fec_update = bgp_read_fec_update;

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -227,27 +227,19 @@ static int bgp_interface_delete(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int bgp_interface_up(ZAPI_CALLBACK_ARGS)
+static int bgp_ifp_up(struct interface *ifp)
 {
-	struct stream *s;
-	struct interface *ifp;
 	struct connected *c;
 	struct nbr_connected *nc;
 	struct listnode *node, *nnode;
 	struct bgp *bgp;
 
-	bgp = bgp_lookup_by_vrf_id(vrf_id);
-
-	s = zclient->ibuf;
-	ifp = zebra_interface_state_read(s, vrf_id);
-
-	if (!ifp)
-		return 0;
+	bgp = bgp_lookup_by_vrf_id(ifp->vrf_id);
 
 	bgp_mac_add_mac_entry(ifp);
 
 	if (BGP_DEBUG(zebra, ZEBRA))
-		zlog_debug("Rx Intf up VRF %u IF %s", vrf_id, ifp->name);
+		zlog_debug("Rx Intf up VRF %u IF %s", ifp->vrf_id, ifp->name);
 
 	if (!bgp)
 		return 0;
@@ -2715,11 +2707,6 @@ static int bgp_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-static int bgp_ifp_up(struct interface *ifp)
-{
-	return 0;
-}
-
 static int bgp_ifp_down(struct interface *ifp)
 {
 	return 0;
@@ -2751,7 +2738,6 @@ void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 	zclient->interface_vrf_update = bgp_interface_vrf_update;
 	zclient->redistribute_route_add = zebra_read_route;
 	zclient->redistribute_route_del = zebra_read_route;
-	zclient->interface_up = bgp_interface_up;
 	zclient->interface_down = bgp_interface_down;
 	zclient->nexthop_update = bgp_read_nexthop_update;
 	zclient->import_check_update = bgp_read_import_check_update;

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -184,6 +184,13 @@ static int eigrp_ifp_up(struct interface *ifp)
 
 static int eigrp_ifp_down(struct interface *ifp)
 {
+	if (IS_DEBUG_EIGRP(zebra, ZEBRA_INTERFACE))
+		zlog_debug("Zebra: Interface[%s] state change to down.",
+			   ifp->name);
+
+	if (ifp->info)
+		eigrp_if_down(ifp->info);
+
 	return 0;
 }
 

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -196,6 +196,19 @@ static int eigrp_ifp_down(struct interface *ifp)
 
 static int eigrp_ifp_destroy(struct interface *ifp)
 {
+	if (if_is_up(ifp))
+		zlog_warn("Zebra: got delete of %s, but interface is still up",
+			  ifp->name);
+
+	if (IS_DEBUG_EIGRP(zebra, ZEBRA_INTERFACE))
+		zlog_debug(
+			"Zebra: interface delete %s index %d flags %llx metric %d mtu %d",
+			ifp->name, ifp->ifindex, (unsigned long long)ifp->flags,
+			ifp->metric, ifp->mtu);
+
+	if (ifp->info)
+		eigrp_if_free(ifp->info, INTERFACE_DOWN_BY_ZEBRA);
+
 	return 0;
 }
 

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -124,6 +124,15 @@ int eigrp_if_delete_hook(struct interface *ifp)
 
 static int eigrp_ifp_create(struct interface *ifp)
 {
+	struct eigrp_interface *ei = ifp->info;
+
+	if (!ei)
+		return 0;
+
+	ei->params.type = eigrp_default_iftype(ifp);
+
+	eigrp_if_update(ifp);
+
 	return 0;
 }
 

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -122,10 +122,32 @@ int eigrp_if_delete_hook(struct interface *ifp)
 	return 0;
 }
 
+static int eigrp_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int eigrp_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int eigrp_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int eigrp_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 struct list *eigrp_iflist;
 
 void eigrp_if_init(void)
 {
+	if_zapi_callbacks(eigrp_ifp_create, eigrp_ifp_up,
+			  eigrp_ifp_down, eigrp_ifp_destroy);
 	/* Initialize Zebra interface data structure. */
 	// hook_register_prio(if_add, 0, eigrp_if_new);
 	hook_register_prio(if_del, 0, eigrp_if_delete_hook);

--- a/eigrpd/eigrp_interface.h
+++ b/eigrpd/eigrp_interface.h
@@ -63,5 +63,4 @@ extern uint32_t eigrp_scaled_to_bandwidth(uint32_t);
 extern uint32_t eigrp_delay_to_scaled(uint32_t);
 extern uint32_t eigrp_scaled_to_delay(uint32_t);
 
-
 #endif /* ZEBRA_EIGRP_INTERFACE_H_ */

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -56,7 +56,6 @@
 static int eigrp_interface_delete(ZAPI_CALLBACK_ARGS);
 static int eigrp_interface_address_add(ZAPI_CALLBACK_ARGS);
 static int eigrp_interface_address_delete(ZAPI_CALLBACK_ARGS);
-static int eigrp_interface_state_down(ZAPI_CALLBACK_ARGS);
 
 static int eigrp_zebra_read_route(ZAPI_CALLBACK_ARGS);
 
@@ -111,7 +110,6 @@ void eigrp_zebra_init(void)
 	zclient->zebra_connected = eigrp_zebra_connected;
 	zclient->router_id_update = eigrp_router_id_update_zebra;
 	zclient->interface_delete = eigrp_interface_delete;
-	zclient->interface_down = eigrp_interface_state_down;
 	zclient->interface_address_add = eigrp_interface_address_add;
 	zclient->interface_address_delete = eigrp_interface_address_delete;
 	zclient->redistribute_route_add = eigrp_zebra_read_route;
@@ -224,25 +222,6 @@ static int eigrp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 		eigrp_if_free(ei, INTERFACE_DOWN_BY_ZEBRA);
 
 	connected_free(c);
-
-	return 0;
-}
-
-static int eigrp_interface_state_down(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
-	if (IS_DEBUG_EIGRP(zebra, ZEBRA_INTERFACE))
-		zlog_debug("Zebra: Interface[%s] state change to down.",
-			   ifp->name);
-
-	if (ifp->info)
-		eigrp_if_down(ifp->info);
 
 	return 0;
 }

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -56,10 +56,7 @@
 static int eigrp_interface_delete(ZAPI_CALLBACK_ARGS);
 static int eigrp_interface_address_add(ZAPI_CALLBACK_ARGS);
 static int eigrp_interface_address_delete(ZAPI_CALLBACK_ARGS);
-static int eigrp_interface_state_up(ZAPI_CALLBACK_ARGS);
 static int eigrp_interface_state_down(ZAPI_CALLBACK_ARGS);
-static struct interface *zebra_interface_if_lookup(struct stream *,
-						   vrf_id_t vrf_id);
 
 static int eigrp_zebra_read_route(ZAPI_CALLBACK_ARGS);
 
@@ -114,7 +111,6 @@ void eigrp_zebra_init(void)
 	zclient->zebra_connected = eigrp_zebra_connected;
 	zclient->router_id_update = eigrp_router_id_update_zebra;
 	zclient->interface_delete = eigrp_interface_delete;
-	zclient->interface_up = eigrp_interface_state_up;
 	zclient->interface_down = eigrp_interface_state_down;
 	zclient->interface_address_add = eigrp_interface_address_add;
 	zclient->interface_address_delete = eigrp_interface_address_delete;
@@ -232,62 +228,6 @@ static int eigrp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int eigrp_interface_state_up(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-
-	ifp = zebra_interface_if_lookup(zclient->ibuf, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
-	/* Interface is already up. */
-	if (if_is_operative(ifp)) {
-		/* Temporarily keep ifp values. */
-		struct interface if_tmp;
-		memcpy(&if_tmp, ifp, sizeof(struct interface));
-
-		zebra_interface_if_set_value(zclient->ibuf, ifp);
-
-		if (IS_DEBUG_EIGRP(zebra, ZEBRA_INTERFACE))
-			zlog_debug("Zebra: Interface[%s] state update.",
-				   ifp->name);
-
-		if (if_tmp.bandwidth != ifp->bandwidth) {
-			if (IS_DEBUG_EIGRP(zebra, ZEBRA_INTERFACE))
-				zlog_debug(
-					"Zebra: Interface[%s] bandwidth change %d -> %d.",
-					ifp->name, if_tmp.bandwidth,
-					ifp->bandwidth);
-
-			//          eigrp_if_recalculate_output_cost (ifp);
-		}
-
-		if (if_tmp.mtu != ifp->mtu) {
-			if (IS_DEBUG_EIGRP(zebra, ZEBRA_INTERFACE))
-				zlog_debug(
-					"Zebra: Interface[%s] MTU change %u -> %u.",
-					ifp->name, if_tmp.mtu, ifp->mtu);
-
-			/* Must reset the interface (simulate down/up) when MTU
-			 * changes. */
-			eigrp_if_reset(ifp);
-		}
-		return 0;
-	}
-
-	zebra_interface_if_set_value(zclient->ibuf, ifp);
-
-	if (IS_DEBUG_EIGRP(zebra, ZEBRA_INTERFACE))
-		zlog_debug("Zebra: Interface[%s] state change to up.",
-			   ifp->name);
-
-	if (ifp->info)
-		eigrp_if_up(ifp->info);
-
-	return 0;
-}
-
 static int eigrp_interface_state_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
@@ -305,18 +245,6 @@ static int eigrp_interface_state_down(ZAPI_CALLBACK_ARGS)
 		eigrp_if_down(ifp->info);
 
 	return 0;
-}
-
-static struct interface *zebra_interface_if_lookup(struct stream *s,
-						   vrf_id_t vrf_id)
-{
-	char ifname_tmp[INTERFACE_NAMSIZ];
-
-	/* Read interface name. */
-	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
-
-	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, vrf_id);
 }
 
 void eigrp_zebra_route_add(struct eigrp *eigrp, struct prefix *p,

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -53,7 +53,6 @@
 #include "eigrpd/eigrp_topology.h"
 #include "eigrpd/eigrp_fsm.h"
 
-static int eigrp_interface_add(ZAPI_CALLBACK_ARGS);
 static int eigrp_interface_delete(ZAPI_CALLBACK_ARGS);
 static int eigrp_interface_address_add(ZAPI_CALLBACK_ARGS);
 static int eigrp_interface_address_delete(ZAPI_CALLBACK_ARGS);
@@ -114,7 +113,6 @@ void eigrp_zebra_init(void)
 	zclient_init(zclient, ZEBRA_ROUTE_EIGRP, 0, &eigrpd_privs);
 	zclient->zebra_connected = eigrp_zebra_connected;
 	zclient->router_id_update = eigrp_router_id_update_zebra;
-	zclient->interface_add = eigrp_interface_add;
 	zclient->interface_delete = eigrp_interface_delete;
 	zclient->interface_up = eigrp_interface_state_up;
 	zclient->interface_down = eigrp_interface_state_down;
@@ -147,26 +145,6 @@ static int eigrp_zebra_read_route(ZAPI_CALLBACK_ARGS)
 	} else /* if (cmd == ZEBRA_REDISTRIBUTE_ROUTE_DEL) */
 	{
 	}
-
-	return 0;
-}
-
-/* Inteface addition message from zebra. */
-static int eigrp_interface_add(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-	struct eigrp_interface *ei;
-
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-
-	if (!ifp->info)
-		return 0;
-
-	ei = ifp->info;
-
-	ei->params.type = eigrp_default_iftype(ifp);
-
-	eigrp_if_update(ifp);
 
 	return 0;
 }

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -61,6 +61,8 @@
 
 DEFINE_QOBJ_TYPE(isis_circuit)
 
+DEFINE_HOOK(isis_if_new_hook, (struct interface *ifp), (ifp))
+
 /*
  * Prototypes.
  */
@@ -1391,6 +1393,12 @@ int isis_if_delete_hook(struct interface *ifp)
 
 static int isis_ifp_create(struct interface *ifp)
 {
+	if (if_is_operative(ifp))
+		isis_csm_state_change(IF_UP_FROM_Z, circuit_scan_by_ifp(ifp),
+				      ifp);
+
+	hook_call(isis_if_new_hook, ifp);
+
 	return 0;
 }
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1411,6 +1411,13 @@ static int isis_ifp_up(struct interface *ifp)
 
 static int isis_ifp_down(struct interface *ifp)
 {
+	struct isis_circuit *circuit;
+
+	circuit = isis_csm_state_change(IF_DOWN_FROM_Z,
+					circuit_scan_by_ifp(ifp), ifp);
+	if (circuit)
+		SET_FLAG(circuit->flags, ISIS_CIRCUIT_FLAPPED_AFTER_SPF);
+
 	return 0;
 }
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1389,6 +1389,26 @@ int isis_if_delete_hook(struct interface *ifp)
 	return 0;
 }
 
+static int isis_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int isis_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int isis_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int isis_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 void isis_circuit_init(void)
 {
 	/* Initialize Zebra interface data structure */
@@ -1398,4 +1418,6 @@ void isis_circuit_init(void)
 	/* Install interface node */
 	install_node(&interface_node, isis_interface_config_write);
 	if_cmd_init();
+	if_zapi_callbacks(isis_ifp_create, isis_ifp_up,
+			  isis_ifp_down, isis_ifp_destroy);
 }

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1404,6 +1404,8 @@ static int isis_ifp_create(struct interface *ifp)
 
 static int isis_ifp_up(struct interface *ifp)
 {
+	isis_csm_state_change(IF_UP_FROM_Z, circuit_scan_by_ifp(ifp), ifp);
+
 	return 0;
 }
 

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1423,6 +1423,16 @@ static int isis_ifp_down(struct interface *ifp)
 
 static int isis_ifp_destroy(struct interface *ifp)
 {
+	if (if_is_operative(ifp))
+		zlog_warn("Zebra: got delete of %s, but interface is still up",
+			  ifp->name);
+
+	isis_csm_state_change(IF_DOWN_FROM_Z, circuit_scan_by_ifp(ifp), ifp);
+
+	/* Cannot call if_delete because we should retain the pseudo interface
+	   in case there is configuration info attached to it. */
+	if_delete_retain(ifp);
+
 	return 0;
 }
 

--- a/isisd/isis_circuit.h
+++ b/isisd/isis_circuit.h
@@ -32,6 +32,8 @@
 #include "isis_constants.h"
 #include "isis_common.h"
 
+DECLARE_HOOK(isis_if_new_hook, (struct interface *ifp), (ifp));
+
 struct isis_lsp;
 
 struct password {

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -53,8 +53,6 @@
 
 struct zclient *zclient = NULL;
 
-DEFINE_HOOK(isis_if_new_hook, (struct interface *ifp), (ifp))
-
 /* Router-id update message from zebra. */
 static int isis_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 {
@@ -70,21 +68,6 @@ static int isis_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 	for (ALL_LIST_ELEMENTS_RO(isis->area_list, node, area))
 		if (listcount(area->area_addrs) > 0)
 			lsp_regenerate_schedule(area, area->is_type, 0);
-
-	return 0;
-}
-
-static int isis_zebra_if_add(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-
-	if (if_is_operative(ifp))
-		isis_csm_state_change(IF_UP_FROM_Z, circuit_scan_by_ifp(ifp),
-				      ifp);
-
-	hook_call(isis_if_new_hook, ifp);
 
 	return 0;
 }
@@ -388,7 +371,6 @@ void isis_zebra_init(struct thread_master *master)
 	zclient_init(zclient, PROTO_TYPE, 0, &isisd_privs);
 	zclient->zebra_connected = isis_zebra_connected;
 	zclient->router_id_update = isis_router_id_update_zebra;
-	zclient->interface_add = isis_zebra_if_add;
 	zclient->interface_delete = isis_zebra_if_del;
 	zclient->interface_up = isis_zebra_if_state_up;
 	zclient->interface_down = isis_zebra_if_state_down;

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -98,24 +98,6 @@ static int isis_zebra_if_del(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int isis_zebra_if_state_down(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-	struct isis_circuit *circuit;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
-	circuit = isis_csm_state_change(IF_DOWN_FROM_Z,
-					circuit_scan_by_ifp(ifp), ifp);
-	if (circuit)
-		SET_FLAG(circuit->flags, ISIS_CIRCUIT_FLAPPED_AFTER_SPF);
-
-	return 0;
-}
-
 static int isis_zebra_if_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
@@ -358,7 +340,6 @@ void isis_zebra_init(struct thread_master *master)
 	zclient->zebra_connected = isis_zebra_connected;
 	zclient->router_id_update = isis_router_id_update_zebra;
 	zclient->interface_delete = isis_zebra_if_del;
-	zclient->interface_down = isis_zebra_if_state_down;
 	zclient->interface_address_add = isis_zebra_if_address_add;
 	zclient->interface_address_delete = isis_zebra_if_address_del;
 	zclient->interface_link_params = isis_zebra_link_params;

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -98,20 +98,6 @@ static int isis_zebra_if_del(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int isis_zebra_if_state_up(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
-	isis_csm_state_change(IF_UP_FROM_Z, circuit_scan_by_ifp(ifp), ifp);
-
-	return 0;
-}
-
 static int isis_zebra_if_state_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
@@ -372,7 +358,6 @@ void isis_zebra_init(struct thread_master *master)
 	zclient->zebra_connected = isis_zebra_connected;
 	zclient->router_id_update = isis_router_id_update_zebra;
 	zclient->interface_delete = isis_zebra_if_del;
-	zclient->interface_up = isis_zebra_if_state_up;
 	zclient->interface_down = isis_zebra_if_state_down;
 	zclient->interface_address_add = isis_zebra_if_address_add;
 	zclient->interface_address_delete = isis_zebra_if_address_del;

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -24,8 +24,6 @@
 
 extern struct zclient *zclient;
 
-DECLARE_HOOK(isis_if_new_hook, (struct interface *ifp), (ifp));
-
 void isis_zebra_init(struct thread_master *);
 void isis_zebra_stop(void);
 

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -39,7 +39,6 @@ static void	 ifc2kaddr(struct interface *, struct connected *,
 		    struct kaddr *);
 static int	 ldp_zebra_send_mpls_labels(int, struct kroute *);
 static int	 ldp_router_id_update(ZAPI_CALLBACK_ARGS);
-static int	 ldp_interface_add(ZAPI_CALLBACK_ARGS);
 static int	 ldp_interface_delete(ZAPI_CALLBACK_ARGS);
 static int	 ldp_interface_status_change(ZAPI_CALLBACK_ARGS);
 static int	 ldp_interface_address_add(ZAPI_CALLBACK_ARGS);
@@ -264,19 +263,17 @@ ldp_router_id_update(ZAPI_CALLBACK_ARGS)
 }
 
 static int
-ldp_interface_add(ZAPI_CALLBACK_ARGS)
+ldp_ifp_create(struct interface *ifp)
 {
-	struct interface	*ifp;
 	struct kif		 kif;
 
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
 	debug_zebra_in("interface add %s index %d mtu %d", ifp->name,
 	    ifp->ifindex, ifp->mtu);
 
 	ifp2kif(ifp, &kif);
 	main_imsg_compose_both(IMSG_IFSTATUS, &kif, sizeof(kif));
 
-	return (0);
+	return 0;
 }
 
 static int
@@ -532,11 +529,6 @@ ldp_zebra_connected(struct zclient *zclient)
 
 extern struct zebra_privs_t ldpd_privs;
 
-static int ldp_ifp_create(struct interface *ifp)
-{
-	return 0;
-}
-
 static int ldp_ifp_up(struct interface *ifp)
 {
 	return 0;
@@ -565,7 +557,6 @@ ldp_zebra_init(struct thread_master *master)
 	/* set callbacks */
 	zclient->zebra_connected = ldp_zebra_connected;
 	zclient->router_id_update = ldp_router_id_update;
-	zclient->interface_add = ldp_interface_add;
 	zclient->interface_delete = ldp_interface_delete;
 	zclient->interface_up = ldp_interface_status_change;
 	zclient->interface_down = ldp_interface_status_change;

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -532,9 +532,32 @@ ldp_zebra_connected(struct zclient *zclient)
 
 extern struct zebra_privs_t ldpd_privs;
 
+static int ldp_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ldp_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ldp_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ldp_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 void
 ldp_zebra_init(struct thread_master *master)
 {
+	if_zapi_callbacks(ldp_ifp_create, ldp_ifp_up,
+			  ldp_ifp_down, ldp_ifp_destroy);
+
 	/* Set default values. */
 	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, ZEBRA_ROUTE_LDP, 0, &ldpd_privs);

--- a/lib/if.c
+++ b/lib/if.c
@@ -187,6 +187,8 @@ void if_destroy_via_zapi(struct interface *ifp)
 		(*ifp_master.destroy_hook)(ifp);
 
 	if_set_index(ifp, IFINDEX_INTERNAL);
+	if (!ifp->configured)
+		if_delete(ifp);
 }
 
 void if_up_via_zapi(struct interface *ifp)

--- a/lib/if.c
+++ b/lib/if.c
@@ -175,6 +175,12 @@ static struct interface *if_create_backend(const char *name, ifindex_t ifindex,
 	return ifp;
 }
 
+void if_new_via_zapi(struct interface *ifp)
+{
+	if (ifp_master.create_hook)
+		(*ifp_master.create_hook)(ifp);
+}
+
 struct interface *if_create(const char *name, vrf_id_t vrf_id)
 {
 	return if_create_backend(name, IFINDEX_INTERNAL, vrf_id);

--- a/lib/if.c
+++ b/lib/if.c
@@ -58,6 +58,13 @@ DEFINE_QOBJ_TYPE(interface)
 DEFINE_HOOK(if_add, (struct interface * ifp), (ifp))
 DEFINE_KOOH(if_del, (struct interface * ifp), (ifp))
 
+struct interface_master{
+	int (*create_hook)(struct interface *ifp);
+	int (*up_hook)(struct interface *ifp);
+	int (*down_hook)(struct interface *ifp);
+	int (*destroy_hook)(struct interface *ifp);
+} ifp_master = { 0, };
+
 /* Compare interface names, returning an integer greater than, equal to, or
  * less than 0, (following the strcmp convention), according to the
  * relationship between ifp1 and ifp2.  Interface names consist of an
@@ -1365,6 +1372,17 @@ void if_cmd_init(void)
 	install_default(INTERFACE_NODE);
 	install_element(INTERFACE_NODE, &interface_desc_cmd);
 	install_element(INTERFACE_NODE, &no_interface_desc_cmd);
+}
+
+void if_zapi_callbacks(int (*create)(struct interface *ifp),
+		       int (*up)(struct interface *ifp),
+		       int (*down)(struct interface *ifp),
+		       int (*destroy)(struct interface *ifp))
+{
+	ifp_master.create_hook = create;
+	ifp_master.up_hook = up;
+	ifp_master.down_hook = down;
+	ifp_master.destroy_hook = destroy;
 }
 
 /* ------- Northbound callbacks ------- */

--- a/lib/if.c
+++ b/lib/if.c
@@ -187,6 +187,12 @@ void if_up_via_zapi(struct interface *ifp)
 		(*ifp_master.up_hook)(ifp);
 }
 
+void if_down_via_zapi(struct interface *ifp)
+{
+	if (ifp_master.down_hook)
+		(*ifp_master.down_hook)(ifp);
+}
+
 struct interface *if_create(const char *name, vrf_id_t vrf_id)
 {
 	return if_create_backend(name, IFINDEX_INTERNAL, vrf_id);

--- a/lib/if.c
+++ b/lib/if.c
@@ -1423,6 +1423,8 @@ static int lib_interface_create(enum nb_event event,
 #else
 		ifp = if_get_by_name(ifname, vrf->vrf_id);
 #endif /* SUNOS_5 */
+
+		ifp->configured = true;
 		nb_running_set_entry(dnode, ifp);
 		break;
 	}
@@ -1450,6 +1452,8 @@ static int lib_interface_destroy(enum nb_event event,
 		break;
 	case NB_EV_APPLY:
 		ifp = nb_running_unset_entry(dnode);
+
+		ifp->configured = false;
 		if_delete(ifp);
 		break;
 	}

--- a/lib/if.c
+++ b/lib/if.c
@@ -181,6 +181,12 @@ void if_new_via_zapi(struct interface *ifp)
 		(*ifp_master.create_hook)(ifp);
 }
 
+void if_up_via_zapi(struct interface *ifp)
+{
+	if (ifp_master.up_hook)
+		(*ifp_master.up_hook)(ifp);
+}
+
 struct interface *if_create(const char *name, vrf_id_t vrf_id)
 {
 	return if_create_backend(name, IFINDEX_INTERNAL, vrf_id);

--- a/lib/if.c
+++ b/lib/if.c
@@ -181,6 +181,14 @@ void if_new_via_zapi(struct interface *ifp)
 		(*ifp_master.create_hook)(ifp);
 }
 
+void if_destroy_via_zapi(struct interface *ifp)
+{
+	if (ifp_master.destroy_hook)
+		(*ifp_master.destroy_hook)(ifp);
+
+	if_set_index(ifp, IFINDEX_INTERNAL);
+}
+
 void if_up_via_zapi(struct interface *ifp)
 {
 	if (ifp_master.up_hook)

--- a/lib/if.h
+++ b/lib/if.h
@@ -563,6 +563,8 @@ extern void if_zapi_callbacks(int (*create)(struct interface *ifp),
 			      int (*down)(struct interface *ifp),
 			      int (*destroy)(struct interface *ifp));
 
+extern void if_new_via_zapi(struct interface *ifp);
+
 extern const struct frr_yang_module_info frr_interface_info;
 
 #ifdef __cplusplus

--- a/lib/if.h
+++ b/lib/if.h
@@ -293,6 +293,12 @@ struct interface {
 	struct route_node *node;
 	vrf_id_t vrf_id;
 
+	/*
+	 * Has the end users entered `interface XXXX` from the cli in some
+	 * fashion?
+	 */
+	bool configured;
+
 	QOBJ_FIELDS
 };
 

--- a/lib/if.h
+++ b/lib/if.h
@@ -558,6 +558,11 @@ void if_link_params_free(struct interface *);
 
 /* Northbound. */
 extern void if_cmd_init(void);
+extern void if_zapi_callbacks(int (*create)(struct interface *ifp),
+			      int (*up)(struct interface *ifp),
+			      int (*down)(struct interface *ifp),
+			      int (*destroy)(struct interface *ifp));
+
 extern const struct frr_yang_module_info frr_interface_info;
 
 #ifdef __cplusplus

--- a/lib/if.h
+++ b/lib/if.h
@@ -564,6 +564,7 @@ extern void if_zapi_callbacks(int (*create)(struct interface *ifp),
 			      int (*destroy)(struct interface *ifp));
 
 extern void if_new_via_zapi(struct interface *ifp);
+extern void if_up_via_zapi(struct interface *ifp);
 
 extern const struct frr_yang_module_info frr_interface_info;
 

--- a/lib/if.h
+++ b/lib/if.h
@@ -565,6 +565,7 @@ extern void if_zapi_callbacks(int (*create)(struct interface *ifp),
 
 extern void if_new_via_zapi(struct interface *ifp);
 extern void if_up_via_zapi(struct interface *ifp);
+extern void if_down_via_zapi(struct interface *ifp);
 
 extern const struct frr_yang_module_info frr_interface_info;
 

--- a/lib/if.h
+++ b/lib/if.h
@@ -566,6 +566,7 @@ extern void if_zapi_callbacks(int (*create)(struct interface *ifp),
 extern void if_new_via_zapi(struct interface *ifp);
 extern void if_up_via_zapi(struct interface *ifp);
 extern void if_down_via_zapi(struct interface *ifp);
+extern void if_destroy_via_zapi(struct interface *ifp);
 
 extern const struct frr_yang_module_info frr_interface_info;
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1605,6 +1605,19 @@ static void zclient_interface_up(struct zclient *zclient, vrf_id_t vrf_id)
 	if_up_via_zapi(ifp);
 }
 
+static void zclient_interface_down(struct zclient *zclient, vrf_id_t vrf_id)
+{
+	struct interface *ifp;
+	struct stream *s = zclient->ibuf;
+
+	ifp = zebra_interface_state_read(s, vrf_id);
+
+	if (!ifp)
+		return;
+
+	if_down_via_zapi(ifp);
+}
+
 static void link_params_set_value(struct stream *s, struct if_link_params *iflp)
 {
 
@@ -2838,9 +2851,7 @@ static int zclient_read(struct thread *thread)
 		zclient_interface_up(zclient, vrf_id);
 		break;
 	case ZEBRA_INTERFACE_DOWN:
-		if (zclient->interface_down)
-			(*zclient->interface_down)(command, zclient, length,
-						   vrf_id);
+		zclient_interface_down(zclient, vrf_id);
 		break;
 	case ZEBRA_INTERFACE_VRF_UPDATE:
 		if (zclient->interface_vrf_update)

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -49,6 +49,9 @@ enum event { ZCLIENT_SCHEDULE, ZCLIENT_READ, ZCLIENT_CONNECT };
 /* Prototype for event manager. */
 static void zclient_event(enum event, struct zclient *);
 
+static void zebra_interface_if_set_value(struct stream *s,
+					 struct interface *ifp);
+
 struct zclient_options zclient_options_default = {.receive_notify = false};
 
 struct sockaddr_storage zclient_addr;
@@ -1696,7 +1699,8 @@ struct interface *zebra_interface_link_params_read(struct stream *s,
 	return ifp;
 }
 
-void zebra_interface_if_set_value(struct stream *s, struct interface *ifp)
+static void zebra_interface_if_set_value(struct stream *s,
+					 struct interface *ifp)
 {
 	uint8_t link_params_status = 0;
 	ifindex_t old_ifindex;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1592,6 +1592,20 @@ struct interface *zebra_interface_state_read(struct stream *s, vrf_id_t vrf_id)
 	return ifp;
 }
 
+static void zclient_interface_delete(struct zclient *zclient, vrf_id_t vrf_id)
+{
+	struct interface *ifp;
+	struct stream *s = zclient->ibuf;
+
+	ifp = zebra_interface_state_read(s, vrf_id);
+
+	if (ifp == NULL)
+		return;
+
+	if_destroy_via_zapi(ifp);
+	return;
+}
+
 static void zclient_interface_up(struct zclient *zclient, vrf_id_t vrf_id)
 {
 	struct interface *ifp;
@@ -2818,9 +2832,7 @@ static int zclient_read(struct thread *thread)
 		zclient_interface_add(zclient, vrf_id);
 		break;
 	case ZEBRA_INTERFACE_DELETE:
-		if (zclient->interface_delete)
-			(*zclient->interface_delete)(command, zclient, length,
-						     vrf_id);
+		zclient_interface_delete(zclient, vrf_id);
 		break;
 	case ZEBRA_INTERFACE_ADDRESS_ADD:
 		if (zclient->interface_address_add)

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1592,6 +1592,19 @@ struct interface *zebra_interface_state_read(struct stream *s, vrf_id_t vrf_id)
 	return ifp;
 }
 
+static void zclient_interface_up(struct zclient *zclient, vrf_id_t vrf_id)
+{
+	struct interface *ifp;
+	struct stream *s = zclient->ibuf;
+
+	ifp = zebra_interface_state_read(s, vrf_id);
+
+	if (!ifp)
+		return;
+
+	if_up_via_zapi(ifp);
+}
+
 static void link_params_set_value(struct stream *s, struct if_link_params *iflp)
 {
 
@@ -2822,9 +2835,7 @@ static int zclient_read(struct thread *thread)
 				command, zclient, length, vrf_id);
 		break;
 	case ZEBRA_INTERFACE_UP:
-		if (zclient->interface_up)
-			(*zclient->interface_up)(command, zclient, length,
-						 vrf_id);
+		zclient_interface_up(zclient, vrf_id);
 		break;
 	case ZEBRA_INTERFACE_DOWN:
 		if (zclient->interface_down)

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -240,7 +240,6 @@ struct zclient {
 	void (*zebra_connected)(struct zclient *);
 	void (*zebra_capabilities)(struct zclient_capabilities *cap);
 	int (*router_id_update)(ZAPI_CALLBACK_ARGS);
-	int (*interface_delete)(ZAPI_CALLBACK_ARGS);
 	int (*interface_address_add)(ZAPI_CALLBACK_ARGS);
 	int (*interface_address_delete)(ZAPI_CALLBACK_ARGS);
 	int (*interface_link_params)(ZAPI_CALLBACK_ARGS);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -621,7 +621,6 @@ zebra_interface_nbr_address_read(int, struct stream *, vrf_id_t);
 extern struct interface *zebra_interface_vrf_update_read(struct stream *s,
 							 vrf_id_t vrf_id,
 							 vrf_id_t *new_vrf_id);
-extern void zebra_interface_if_set_value(struct stream *, struct interface *);
 extern void zebra_router_id_update_read(struct stream *s, struct prefix *rid);
 
 extern struct interface *zebra_interface_link_params_read(struct stream *s,

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -240,7 +240,6 @@ struct zclient {
 	void (*zebra_connected)(struct zclient *);
 	void (*zebra_capabilities)(struct zclient_capabilities *cap);
 	int (*router_id_update)(ZAPI_CALLBACK_ARGS);
-	int (*interface_add)(ZAPI_CALLBACK_ARGS);
 	int (*interface_delete)(ZAPI_CALLBACK_ARGS);
 	int (*interface_up)(ZAPI_CALLBACK_ARGS);
 	int (*interface_down)(ZAPI_CALLBACK_ARGS);
@@ -617,7 +616,6 @@ extern bool zapi_parse_header(struct stream *zmsg, struct zmsghdr *hdr);
 extern void zclient_interface_set_master(struct zclient *client,
 					 struct interface *master,
 					 struct interface *slave);
-extern struct interface *zebra_interface_add_read(struct stream *, vrf_id_t);
 extern struct interface *zebra_interface_state_read(struct stream *s, vrf_id_t);
 extern struct connected *zebra_interface_address_read(int, struct stream *,
 						      vrf_id_t);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -241,7 +241,6 @@ struct zclient {
 	void (*zebra_capabilities)(struct zclient_capabilities *cap);
 	int (*router_id_update)(ZAPI_CALLBACK_ARGS);
 	int (*interface_delete)(ZAPI_CALLBACK_ARGS);
-	int (*interface_down)(ZAPI_CALLBACK_ARGS);
 	int (*interface_address_add)(ZAPI_CALLBACK_ARGS);
 	int (*interface_address_delete)(ZAPI_CALLBACK_ARGS);
 	int (*interface_link_params)(ZAPI_CALLBACK_ARGS);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -241,7 +241,6 @@ struct zclient {
 	void (*zebra_capabilities)(struct zclient_capabilities *cap);
 	int (*router_id_update)(ZAPI_CALLBACK_ARGS);
 	int (*interface_delete)(ZAPI_CALLBACK_ARGS);
-	int (*interface_up)(ZAPI_CALLBACK_ARGS);
 	int (*interface_down)(ZAPI_CALLBACK_ARGS);
 	int (*interface_address_add)(ZAPI_CALLBACK_ARGS);
 	int (*interface_address_delete)(ZAPI_CALLBACK_ARGS);

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -326,14 +326,8 @@ int nhrp_interface_delete(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-int nhrp_interface_up(ZAPI_CALLBACK_ARGS)
+int nhrp_ifp_up(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-	if (ifp == NULL)
-		return 0;
-
 	debugf(NHRP_DEBUG_IF, "if-up: %s", ifp->name);
 	nhrp_interface_update_nbma(ifp);
 
@@ -428,11 +422,6 @@ void nhrp_interface_set_source(struct interface *ifp, const char *ifname)
 	nifp->source = ifname ? strdup(ifname) : NULL;
 
 	nhrp_interface_update_nbma(ifp);
-}
-
-int nhrp_ifp_up(struct interface *ifp)
-{
-	return 0;
 }
 
 int nhrp_ifp_down(struct interface *ifp)

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -436,3 +436,23 @@ void nhrp_interface_set_source(struct interface *ifp, const char *ifname)
 
 	nhrp_interface_update_nbma(ifp);
 }
+
+int nhrp_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+int nhrp_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+int nhrp_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+int nhrp_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -296,15 +296,8 @@ void nhrp_interface_update(struct interface *ifp)
 	}
 }
 
-int nhrp_interface_add(ZAPI_CALLBACK_ARGS)
+int nhrp_ifp_create(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	/* read and add the interface in the iflist. */
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-	if (ifp == NULL)
-		return 0;
-
 	debugf(NHRP_DEBUG_IF, "if-add: %s, ifindex: %u, hw_type: %d %s",
 	       ifp->name, ifp->ifindex, ifp->ll_type,
 	       if_link_type_str(ifp->ll_type));
@@ -435,11 +428,6 @@ void nhrp_interface_set_source(struct interface *ifp, const char *ifname)
 	nifp->source = ifname ? strdup(ifname) : NULL;
 
 	nhrp_interface_update_nbma(ifp);
-}
-
-int nhrp_ifp_create(struct interface *ifp)
-{
-	return 0;
 }
 
 int nhrp_ifp_up(struct interface *ifp)

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -334,16 +334,11 @@ int nhrp_ifp_up(struct interface *ifp)
 	return 0;
 }
 
-int nhrp_interface_down(ZAPI_CALLBACK_ARGS)
+int nhrp_ifp_down(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-	if (ifp == NULL)
-		return 0;
-
 	debugf(NHRP_DEBUG_IF, "if-down: %s", ifp->name);
 	nhrp_interface_update(ifp);
+
 	return 0;
 }
 
@@ -422,11 +417,6 @@ void nhrp_interface_set_source(struct interface *ifp, const char *ifname)
 	nifp->source = ifname ? strdup(ifname) : NULL;
 
 	nhrp_interface_update_nbma(ifp);
-}
-
-int nhrp_ifp_down(struct interface *ifp)
-{
-	return 0;
 }
 
 int nhrp_ifp_destroy(struct interface *ifp)

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -307,21 +307,11 @@ int nhrp_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-int nhrp_interface_delete(ZAPI_CALLBACK_ARGS)
+int nhrp_ifp_destroy(struct interface *ifp)
 {
-	struct interface *ifp;
-	struct stream *s;
-
-	s = zclient->ibuf;
-	ifp = zebra_interface_state_read(s, vrf_id);
-	if (ifp == NULL)
-		return 0;
-
 	debugf(NHRP_DEBUG_IF, "if-delete: %s", ifp->name);
 
 	nhrp_interface_update(ifp);
-
-	if_set_index(ifp, IFINDEX_INTERNAL);
 
 	return 0;
 }
@@ -417,9 +407,4 @@ void nhrp_interface_set_source(struct interface *ifp, const char *ifname)
 	nifp->source = ifname ? strdup(ifname) : NULL;
 
 	nhrp_interface_update_nbma(ifp);
-}
-
-int nhrp_ifp_destroy(struct interface *ifp)
-{
-	return 0;
 }

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -152,6 +152,8 @@ int main(int argc, char **argv)
 	nhrp_vc_init();
 	nhrp_packet_init();
 	vici_init();
+	if_zapi_callbacks(nhrp_ifp_create, nhrp_ifp_up,
+			  nhrp_ifp_down, nhrp_ifp_destroy);
 	nhrp_zebra_init();
 	nhrp_shortcut_init();
 

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -345,7 +345,6 @@ void nhrp_zebra_init(void)
 
 	zclient = zclient_new(master, &zclient_options_default);
 	zclient->zebra_connected = nhrp_zebra_connected;
-	zclient->interface_add = nhrp_interface_add;
 	zclient->interface_delete = nhrp_interface_delete;
 	zclient->interface_up = nhrp_interface_up;
 	zclient->interface_down = nhrp_interface_down;

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -346,7 +346,6 @@ void nhrp_zebra_init(void)
 	zclient = zclient_new(master, &zclient_options_default);
 	zclient->zebra_connected = nhrp_zebra_connected;
 	zclient->interface_delete = nhrp_interface_delete;
-	zclient->interface_up = nhrp_interface_up;
 	zclient->interface_down = nhrp_interface_down;
 	zclient->interface_address_add = nhrp_interface_address_add;
 	zclient->interface_address_delete = nhrp_interface_address_delete;

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -346,7 +346,6 @@ void nhrp_zebra_init(void)
 	zclient = zclient_new(master, &zclient_options_default);
 	zclient->zebra_connected = nhrp_zebra_connected;
 	zclient->interface_delete = nhrp_interface_delete;
-	zclient->interface_down = nhrp_interface_down;
 	zclient->interface_address_add = nhrp_interface_address_add;
 	zclient->interface_address_delete = nhrp_interface_address_delete;
 	zclient->redistribute_route_add = nhrp_route_read;

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -345,7 +345,6 @@ void nhrp_zebra_init(void)
 
 	zclient = zclient_new(master, &zclient_options_default);
 	zclient->zebra_connected = nhrp_zebra_connected;
-	zclient->interface_delete = nhrp_interface_delete;
 	zclient->interface_address_add = nhrp_interface_address_add;
 	zclient->interface_address_delete = nhrp_interface_address_delete;
 	zclient->redistribute_route_add = nhrp_route_read;

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -319,6 +319,10 @@ void nhrp_interface_notify_del(struct interface *ifp, struct notifier_block *n);
 void nhrp_interface_set_protection(struct interface *ifp, const char *profile,
 				   const char *fallback_profile);
 void nhrp_interface_set_source(struct interface *ifp, const char *ifname);
+extern int nhrp_ifp_create(struct interface *ifp);
+extern int nhrp_ifp_up(struct interface *ifp);
+extern int nhrp_ifp_down(struct interface *ifp);
+extern int nhrp_ifp_destroy(struct interface *ifp);
 
 int nhrp_nhs_add(struct interface *ifp, afi_t afi, union sockunion *proto_addr,
 		 const char *nbma_fqdn);

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -42,6 +42,7 @@
 #include "ospf6_spf.h"
 #include "ospf6d.h"
 #include "ospf6_bfd.h"
+#include "ospf6_zebra.h"
 
 DEFINE_MTYPE_STATIC(OSPF6D, CFG_PLIST_NAME, "configured prefix list names")
 DEFINE_QOBJ_TYPE(ospf6_interface)
@@ -1937,6 +1938,11 @@ static struct cmd_node interface_node = {
 
 static int ospf6_ifp_create(struct interface *ifp)
 {
+	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
+		zlog_debug("Zebra Interface add: %s index %d mtu %d", ifp->name,
+			   ifp->ifindex, ifp->mtu6);
+	ospf6_interface_if_add(ifp);
+
 	return 0;
 }
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1948,6 +1948,15 @@ static int ospf6_ifp_create(struct interface *ifp)
 
 static int ospf6_ifp_up(struct interface *ifp)
 {
+	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
+		zlog_debug(
+			"Zebra Interface state change: "
+			"%s index %d flags %llx metric %d mtu %d bandwidth %d",
+			ifp->name, ifp->ifindex, (unsigned long long)ifp->flags,
+			ifp->metric, ifp->mtu6, ifp->bandwidth);
+
+	ospf6_interface_state_update(ifp);
+
 	return 0;
 }
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1976,6 +1976,14 @@ static int ospf6_ifp_down(struct interface *ifp)
 
 static int ospf6_ifp_destroy(struct interface *ifp)
 {
+	if (if_is_up(ifp))
+		zlog_warn("Zebra: got delete of %s, but interface is still up",
+			  ifp->name);
+
+	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
+		zlog_debug("Zebra Interface delete: %s index %d mtu %d",
+			   ifp->name, ifp->ifindex, ifp->mtu6);
+
 	return 0;
 }
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1962,6 +1962,15 @@ static int ospf6_ifp_up(struct interface *ifp)
 
 static int ospf6_ifp_down(struct interface *ifp)
 {
+	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
+		zlog_debug(
+			"Zebra Interface state change: "
+			"%s index %d flags %llx metric %d mtu %d bandwidth %d",
+			ifp->name, ifp->ifindex, (unsigned long long)ifp->flags,
+			ifp->metric, ifp->mtu6, ifp->bandwidth);
+
+	ospf6_interface_state_update(ifp);
+
 	return 0;
 }
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -1935,11 +1935,33 @@ static struct cmd_node interface_node = {
 	INTERFACE_NODE, "%s(config-if)# ", 1 /* VTYSH */
 };
 
+static int ospf6_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ospf6_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ospf6_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ospf6_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 void ospf6_interface_init(void)
 {
 	/* Install interface node. */
 	install_node(&interface_node, config_write_ospf6_interface);
 	if_cmd_init();
+	if_zapi_callbacks(ospf6_ifp_create, ospf6_ifp_up,
+			  ospf6_ifp_down, ospf6_ifp_destroy);
 
 	install_element(VIEW_NODE, &show_ipv6_ospf6_interface_prefix_cmd);
 	install_element(VIEW_NODE, &show_ipv6_ospf6_interface_ifname_cmd);

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -116,25 +116,6 @@ static int ospf6_zebra_if_del(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int ospf6_zebra_if_state_update(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-	if (ifp == NULL)
-		return 0;
-
-	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
-		zlog_debug(
-			"Zebra Interface state change: "
-			"%s index %d flags %llx metric %d mtu %d bandwidth %d",
-			ifp->name, ifp->ifindex, (unsigned long long)ifp->flags,
-			ifp->metric, ifp->mtu6, ifp->bandwidth);
-
-	ospf6_interface_state_update(ifp);
-	return 0;
-}
-
 static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
@@ -571,7 +552,6 @@ void ospf6_zebra_init(struct thread_master *master)
 	zclient->zebra_connected = ospf6_zebra_connected;
 	zclient->router_id_update = ospf6_router_id_update_zebra;
 	zclient->interface_delete = ospf6_zebra_if_del;
-	zclient->interface_down = ospf6_zebra_if_state_update;
 	zclient->interface_address_add = ospf6_zebra_if_address_update_add;
 	zclient->interface_address_delete =
 		ospf6_zebra_if_address_update_delete;

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -97,19 +97,6 @@ void ospf6_zebra_no_redistribute(int type)
 					AFI_IP6, type, 0, VRF_DEFAULT);
 }
 
-/* Inteface addition message from zebra. */
-static int ospf6_zebra_if_add(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
-		zlog_debug("Zebra Interface add: %s index %d mtu %d", ifp->name,
-			   ifp->ifindex, ifp->mtu6);
-	ospf6_interface_if_add(ifp);
-	return 0;
-}
-
 static int ospf6_zebra_if_del(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
@@ -583,7 +570,6 @@ void ospf6_zebra_init(struct thread_master *master)
 	zclient_init(zclient, ZEBRA_ROUTE_OSPF6, 0, &ospf6d_privs);
 	zclient->zebra_connected = ospf6_zebra_connected;
 	zclient->router_id_update = ospf6_router_id_update_zebra;
-	zclient->interface_add = ospf6_zebra_if_add;
 	zclient->interface_delete = ospf6_zebra_if_del;
 	zclient->interface_up = ospf6_zebra_if_state_update;
 	zclient->interface_down = ospf6_zebra_if_state_update;

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -97,25 +97,6 @@ void ospf6_zebra_no_redistribute(int type)
 					AFI_IP6, type, 0, VRF_DEFAULT);
 }
 
-static int ospf6_zebra_if_del(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-
-	if (!(ifp = zebra_interface_state_read(zclient->ibuf, vrf_id)))
-		return 0;
-
-	if (if_is_up(ifp))
-		zlog_warn("Zebra: got delete of %s, but interface is still up",
-			  ifp->name);
-
-	if (IS_OSPF6_DEBUG_ZEBRA(RECV))
-		zlog_debug("Zebra Interface delete: %s index %d mtu %d",
-			   ifp->name, ifp->ifindex, ifp->mtu6);
-
-	if_set_index(ifp, IFINDEX_INTERNAL);
-	return 0;
-}
-
 static int ospf6_zebra_if_address_update_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
@@ -551,7 +532,6 @@ void ospf6_zebra_init(struct thread_master *master)
 	zclient_init(zclient, ZEBRA_ROUTE_OSPF6, 0, &ospf6d_privs);
 	zclient->zebra_connected = ospf6_zebra_connected;
 	zclient->router_id_update = ospf6_router_id_update_zebra;
-	zclient->interface_delete = ospf6_zebra_if_del;
 	zclient->interface_address_add = ospf6_zebra_if_address_update_add;
 	zclient->interface_address_delete =
 		ospf6_zebra_if_address_update_delete;

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -571,7 +571,6 @@ void ospf6_zebra_init(struct thread_master *master)
 	zclient->zebra_connected = ospf6_zebra_connected;
 	zclient->router_id_update = ospf6_router_id_update_zebra;
 	zclient->interface_delete = ospf6_zebra_if_del;
-	zclient->interface_up = ospf6_zebra_if_state_update;
 	zclient->interface_down = ospf6_zebra_if_state_update;
 	zclient->interface_address_add = ospf6_zebra_if_address_update_add;
 	zclient->interface_address_delete =

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1305,6 +1305,19 @@ static int ospf_ifp_up(struct interface *ifp)
 
 static int ospf_ifp_down(struct interface *ifp)
 {
+	struct ospf_interface *oi;
+	struct route_node *node;
+
+	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
+		zlog_debug("Zebra: Interface[%s] state change to down.",
+			   ifp->name);
+
+	for (node = route_top(IF_OIFS(ifp)); node; node = route_next(node)) {
+		if ((oi = node->info) == NULL)
+			continue;
+		ospf_if_down(oi);
+	}
+
 	return 0;
 }
 

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1218,8 +1218,31 @@ uint8_t ospf_default_iftype(struct interface *ifp)
 		return OSPF_IFTYPE_BROADCAST;
 }
 
+static int ospf_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ospf_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ospf_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ospf_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 void ospf_if_init(void)
 {
+	if_zapi_callbacks(ospf_ifp_create, ospf_ifp_up,
+			  ospf_ifp_down, ospf_ifp_destroy);
+
 	/* Initialize Zebra interface data structure. */
 	hook_register_prio(if_add, 0, ospf_if_new_hook);
 	hook_register_prio(if_del, 0, ospf_if_delete_hook);

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -321,7 +321,10 @@ extern int ospf_interface_neighbor_count(struct ospf_interface *oi);
    state of the interface. */
 extern void ospf_if_set_multicast(struct ospf_interface *);
 
+extern void ospf_if_interface(struct interface *ifp);
+
 DECLARE_HOOK(ospf_vl_add, (struct ospf_vl_data * vd), (vd))
 DECLARE_HOOK(ospf_vl_delete, (struct ospf_vl_data * vd), (vd))
 
+DECLARE_HOOK(ospf_if_update, (struct interface * ifp), (ifp))
 #endif /* _ZEBRA_OSPF_INTERFACE_H */

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -327,4 +327,6 @@ DECLARE_HOOK(ospf_vl_add, (struct ospf_vl_data * vd), (vd))
 DECLARE_HOOK(ospf_vl_delete, (struct ospf_vl_data * vd), (vd))
 
 DECLARE_HOOK(ospf_if_update, (struct interface * ifp), (ifp))
+DECLARE_HOOK(ospf_if_delete, (struct interface * ifp), (ifp))
+
 #endif /* _ZEBRA_OSPF_INTERFACE_H */

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -126,30 +126,6 @@ static int ospf_interface_delete(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int ospf_interface_state_down(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-	struct ospf_interface *oi;
-	struct route_node *node;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
-	if (IS_DEBUG_OSPF(zebra, ZEBRA_INTERFACE))
-		zlog_debug("Zebra: Interface[%s] state change to down.",
-			   ifp->name);
-
-	for (node = route_top(IF_OIFS(ifp)); node; node = route_next(node)) {
-		if ((oi = node->info) == NULL)
-			continue;
-		ospf_if_down(oi);
-	}
-
-	return 0;
-}
-
 static int ospf_interface_address_add(ZAPI_CALLBACK_ARGS)
 {
 	struct connected *c;
@@ -1417,7 +1393,6 @@ void ospf_zebra_init(struct thread_master *master, unsigned short instance)
 	zclient->zebra_connected = ospf_zebra_connected;
 	zclient->router_id_update = ospf_router_id_update_zebra;
 	zclient->interface_delete = ospf_interface_delete;
-	zclient->interface_down = ospf_interface_state_down;
 	zclient->interface_address_add = ospf_interface_address_add;
 	zclient->interface_address_delete = ospf_interface_address_delete;
 	zclient->interface_link_params = ospf_interface_link_params;

--- a/ospfd/ospf_zebra.h
+++ b/ospfd/ospf_zebra.h
@@ -87,7 +87,6 @@ extern void ospf_zebra_init(struct thread_master *, unsigned short);
 extern void ospf_zebra_vrf_register(struct ospf *ospf);
 extern void ospf_zebra_vrf_deregister(struct ospf *ospf);
 
-DECLARE_HOOK(ospf_if_update, (struct interface * ifp), (ifp))
 DECLARE_HOOK(ospf_if_delete, (struct interface * ifp), (ifp))
 
 #endif /* _ZEBRA_OSPF_ZEBRA_H */

--- a/ospfd/ospf_zebra.h
+++ b/ospfd/ospf_zebra.h
@@ -87,6 +87,4 @@ extern void ospf_zebra_init(struct thread_master *, unsigned short);
 extern void ospf_zebra_vrf_register(struct ospf *ospf);
 extern void ospf_zebra_vrf_deregister(struct ospf *ospf);
 
-DECLARE_HOOK(ospf_if_delete, (struct interface * ifp), (ifp))
-
 #endif /* _ZEBRA_OSPF_ZEBRA_H */

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -1339,6 +1339,7 @@ void ospf_if_update(struct ospf *ospf, struct interface *ifp)
 
 	/* Update connected redistribute. */
 	update_redistributed(ospf, 1);
+
 }
 
 void ospf_remove_vls_through_area(struct ospf *ospf, struct ospf_area *area)

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -166,6 +166,8 @@ int main(int argc, char **argv, char **envp)
 	access_list_init();
 	pbr_nht_init();
 	pbr_map_init();
+	if_zapi_callbacks(pbr_ifp_create, pbr_ifp_up,
+			  pbr_ifp_down, pbr_ifp_destroy);
 	pbr_zebra_init();
 	pbr_vty_init();
 

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -136,12 +136,8 @@ int pbr_ifp_up(struct interface *ifp)
 	return 0;
 }
 
-static int interface_state_down(ZAPI_CALLBACK_ARGS)
+int pbr_ifp_down(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
 	DEBUGD(&pbr_dbg_zebra,
 	       "%s: %s is down", __PRETTY_FUNCTION__, ifp->name);
 
@@ -437,7 +433,6 @@ void pbr_zebra_init(void)
 	zclient_init(zclient, ZEBRA_ROUTE_PBR, 0, &pbr_privs);
 	zclient->zebra_connected = zebra_connected;
 	zclient->interface_delete = interface_delete;
-	zclient->interface_down = interface_state_down;
 	zclient->interface_address_add = interface_address_add;
 	zclient->interface_address_delete = interface_address_delete;
 	zclient->route_notify_owner = route_notify_owner;
@@ -565,11 +560,6 @@ void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	zclient_send_message(zclient);
-}
-
-int pbr_ifp_down(struct interface *ifp)
-{
-	return 0;
 }
 
 int pbr_ifp_destroy(struct interface *ifp)

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -72,23 +72,10 @@ int pbr_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-static int interface_delete(ZAPI_CALLBACK_ARGS)
+int pbr_ifp_destroy(struct interface *ifp)
 {
-	struct interface *ifp;
-	struct stream *s;
-
-	s = zclient->ibuf;
-	/* zebra_interface_state_read () updates interface structure in iflist
-	 */
-	ifp = zebra_interface_state_read(s, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
 	DEBUGD(&pbr_dbg_zebra,
 	       "%s: %s", __PRETTY_FUNCTION__, ifp->name);
-
-	if_set_index(ifp, IFINDEX_INTERNAL);
 
 	return 0;
 }
@@ -432,7 +419,6 @@ void pbr_zebra_init(void)
 
 	zclient_init(zclient, ZEBRA_ROUTE_PBR, 0, &pbr_privs);
 	zclient->zebra_connected = zebra_connected;
-	zclient->interface_delete = interface_delete;
 	zclient->interface_address_add = interface_address_add;
 	zclient->interface_address_delete = interface_address_delete;
 	zclient->route_notify_owner = route_notify_owner;
@@ -560,9 +546,4 @@ void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	zclient_send_message(zclient);
-}
-
-int pbr_ifp_destroy(struct interface *ifp)
-{
-	return 0;
 }

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -59,15 +59,8 @@ struct pbr_interface *pbr_if_new(struct interface *ifp)
 }
 
 /* Inteface addition message from zebra. */
-static int interface_add(ZAPI_CALLBACK_ARGS)
+int pbr_ifp_create(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-
-	if (!ifp)
-		return 0;
-
 	DEBUGD(&pbr_dbg_zebra,
 	       "%s: %s", __PRETTY_FUNCTION__, ifp->name);
 
@@ -447,7 +440,6 @@ void pbr_zebra_init(void)
 
 	zclient_init(zclient, ZEBRA_ROUTE_PBR, 0, &pbr_privs);
 	zclient->zebra_connected = zebra_connected;
-	zclient->interface_add = interface_add;
 	zclient->interface_delete = interface_delete;
 	zclient->interface_up = interface_state_up;
 	zclient->interface_down = interface_state_down;
@@ -578,11 +570,6 @@ void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	zclient_send_message(zclient);
-}
-
-int pbr_ifp_create(struct interface *ifp)
-{
-	return 0;
 }
 
 int pbr_ifp_up(struct interface *ifp)

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -126,12 +126,8 @@ static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int interface_state_up(ZAPI_CALLBACK_ARGS)
+int pbr_ifp_up(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
 	DEBUGD(&pbr_dbg_zebra,
 	       "%s: %s is up", __PRETTY_FUNCTION__, ifp->name);
 
@@ -441,7 +437,6 @@ void pbr_zebra_init(void)
 	zclient_init(zclient, ZEBRA_ROUTE_PBR, 0, &pbr_privs);
 	zclient->zebra_connected = zebra_connected;
 	zclient->interface_delete = interface_delete;
-	zclient->interface_up = interface_state_up;
 	zclient->interface_down = interface_state_down;
 	zclient->interface_address_add = interface_address_add;
 	zclient->interface_address_delete = interface_address_delete;
@@ -570,11 +565,6 @@ void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 	stream_putw_at(s, 0, stream_get_endp(s));
 
 	zclient_send_message(zclient);
-}
-
-int pbr_ifp_up(struct interface *ifp)
-{
-	return 0;
 }
 
 int pbr_ifp_down(struct interface *ifp)

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -579,3 +579,23 @@ void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 
 	zclient_send_message(zclient);
 }
+
+int pbr_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+int pbr_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+int pbr_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+int pbr_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}

--- a/pbrd/pbr_zebra.h
+++ b/pbrd/pbr_zebra.h
@@ -39,4 +39,10 @@ extern void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 			     struct pbr_map_interface *pmi, bool install);
 
 extern struct pbr_interface *pbr_if_new(struct interface *ifp);
+
+extern int pbr_ifp_create(struct interface *ifp);
+extern int pbr_ifp_up(struct interface *ifp);
+extern int pbr_ifp_down(struct interface *ifp);
+extern int pbr_ifp_destroy(struct interface *ifp);
+
 #endif

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1673,5 +1673,22 @@ int pim_ifp_down(struct interface *ifp)
 
 int pim_ifp_destroy(struct interface *ifp)
 {
+	struct pim_instance *pim;
+
+	if (PIM_DEBUG_ZEBRA) {
+		zlog_debug(
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
+			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex,
+			ifp->vrf_id, (long)ifp->flags, ifp->metric, ifp->mtu,
+			if_is_operative(ifp));
+	}
+
+	if (!if_is_operative(ifp))
+		pim_if_addr_del_all(ifp);
+
+	pim = pim_get_pim_instance(ifp->vrf_id);
+	if (pim && pim->vxlan.term_if == ifp)
+		pim_vxlan_del_term_dev(pim);
+
 	return 0;
 }

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1526,3 +1526,23 @@ int pim_if_ifchannel_count(struct pim_interface *pim_ifp)
 
 	return count;
 }
+
+int pim_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+int pim_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+int pim_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+int pim_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1639,6 +1639,35 @@ int pim_ifp_up(struct interface *ifp)
 
 int pim_ifp_down(struct interface *ifp)
 {
+	if (PIM_DEBUG_ZEBRA) {
+		zlog_debug(
+			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
+			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex,
+			ifp->vrf_id, (long)ifp->flags, ifp->metric, ifp->mtu,
+			if_is_operative(ifp));
+	}
+
+	if (!if_is_operative(ifp)) {
+		pim_ifchannel_delete_all(ifp);
+		/*
+		  pim_if_addr_del_all() suffices for shutting down IGMP,
+		  but not for shutting down PIM
+		*/
+		pim_if_addr_del_all(ifp);
+
+		/*
+		  pim_sock_delete() closes the socket, stops read and timer
+		  threads,
+		  and kills all neighbors.
+		*/
+		if (ifp->info) {
+			pim_sock_delete(ifp, "link down");
+		}
+	}
+
+	if (ifp->info)
+		pim_if_del_vif(ifp);
+
 	return 0;
 }
 

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -227,4 +227,10 @@ int pim_update_source_set(struct interface *ifp, struct in_addr source);
 bool pim_if_is_vrf_device(struct interface *ifp);
 
 int pim_if_ifchannel_count(struct pim_interface *pim_ifp);
+
+extern int pim_ifp_create(struct interface *ifp);
+extern int pim_ifp_up(struct interface *ifp);
+extern int pim_ifp_down(struct interface *ifp);
+extern int pim_ifp_destroy(struct interface *ifp);
+
 #endif /* PIM_IFACE_H */

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -127,6 +127,8 @@ int main(int argc, char **argv, char **envp)
 	/*
 	 * Initialize zclient "update" and "lookup" sockets
 	 */
+	if_zapi_callbacks(pim_ifp_create, pim_ifp_up,
+			  pim_ifp_down, pim_ifp_destroy);
 	pim_zebra_init();
 	pim_bfd_init();
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -63,82 +63,11 @@ static int pim_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int pim_zebra_if_add(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-	struct pim_instance *pim;
-
-	/*
-	  zebra api adds/dels interfaces using the same call
-	  interface_add_read below, see comments in lib/zclient.c
-	*/
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-	if (!ifp)
-		return 0;
-
-	pim = pim_get_pim_instance(vrf_id);
-	if (PIM_DEBUG_ZEBRA) {
-		zlog_debug(
-			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
-			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
-			(long)ifp->flags, ifp->metric, ifp->mtu,
-			if_is_operative(ifp));
-	}
-
-	if (if_is_operative(ifp)) {
-		struct pim_interface *pim_ifp;
-
-		pim_ifp = ifp->info;
-		/*
-		 * If we have a pim_ifp already and this is an if_add
-		 * that means that we probably have a vrf move event
-		 * If that is the case, set the proper vrfness.
-		 */
-		if (pim_ifp)
-			pim_ifp->pim = pim;
-		pim_if_addr_add_all(ifp);
-	}
-
-	/*
-	 * If we are a vrf device that is up, open up the pim_socket for
-	 * listening
-	 * to incoming pim messages irrelevant if the user has configured us
-	 * for pim or not.
-	 */
-	if (pim_if_is_vrf_device(ifp)) {
-		struct pim_interface *pim_ifp;
-
-		if (!ifp->info) {
-			pim_ifp = pim_if_new(ifp, false, false, false,
-					false /*vxlan_term*/);
-			ifp->info = pim_ifp;
-		}
-
-		pim_sock_add(ifp);
-	}
-
-	if (!strncmp(ifp->name, PIM_VXLAN_TERM_DEV_NAME,
-				sizeof(PIM_VXLAN_TERM_DEV_NAME)))
-		pim_vxlan_add_term_dev(pim, ifp);
-
-	return 0;
-}
-
 static int pim_zebra_if_del(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
 	struct pim_instance *pim;
 
-	/*
-	  zebra api adds/dels interfaces using the same call
-	  interface_add_read below, see comments in lib/zclient.c
-
-	  comments in lib/zclient.c seem to indicate that calling
-	  zebra_interface_add_read is the correct call, but that
-	  results in an attemted out of bounds read which causes
-	  pimd to assert. Other clients use zebra_interface_state_read
-	  and it appears to work just fine.
-	*/
 	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
 	if (!ifp)
 		return 0;
@@ -793,7 +722,6 @@ void pim_zebra_init(void)
 	zclient->zebra_capabilities = pim_zebra_capabilities;
 	zclient->zebra_connected = pim_zebra_connected;
 	zclient->router_id_update = pim_router_id_update_zebra;
-	zclient->interface_add = pim_zebra_if_add;
 	zclient->interface_delete = pim_zebra_if_del;
 	zclient->interface_up = pim_zebra_if_state_up;
 	zclient->interface_down = pim_zebra_if_state_down;

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -92,74 +92,6 @@ static int pim_zebra_if_del(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int pim_zebra_if_state_up(ZAPI_CALLBACK_ARGS)
-{
-	struct pim_instance *pim;
-	struct interface *ifp;
-	uint32_t table_id;
-
-	/*
-	  zebra api notifies interface up/down events by using the same call
-	  zebra_interface_state_read below, see comments in lib/zclient.c
-	*/
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-	if (!ifp)
-		return 0;
-
-	if (PIM_DEBUG_ZEBRA) {
-		zlog_debug(
-			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
-			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
-			(long)ifp->flags, ifp->metric, ifp->mtu,
-			if_is_operative(ifp));
-	}
-
-	pim = pim_get_pim_instance(vrf_id);
-	if (if_is_operative(ifp)) {
-		struct pim_interface *pim_ifp;
-
-		pim_ifp = ifp->info;
-		/*
-		 * If we have a pim_ifp already and this is an if_add
-		 * that means that we probably have a vrf move event
-		 * If that is the case, set the proper vrfness.
-		 */
-		if (pim_ifp)
-			pim_ifp->pim = pim;
-
-		/*
-		  pim_if_addr_add_all() suffices for bringing up both IGMP and
-		  PIM
-		*/
-		pim_if_addr_add_all(ifp);
-	}
-
-	/*
-	 * If we have a pimreg device callback and it's for a specific
-	 * table set the master appropriately
-	 */
-	if (sscanf(ifp->name, "pimreg%" SCNu32, &table_id) == 1) {
-		struct vrf *vrf;
-		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-			if ((table_id == vrf->data.l.table_id)
-			    && (ifp->vrf_id != vrf->vrf_id)) {
-				struct interface *master = if_lookup_by_name(
-					vrf->name, vrf->vrf_id);
-
-				if (!master) {
-					zlog_debug(
-						"%s: Unable to find Master interface for %s",
-						__PRETTY_FUNCTION__, vrf->name);
-					return 0;
-				}
-				zclient_interface_set_master(zclient, master,
-							     ifp);
-			}
-		}
-	}
-	return 0;
-}
-
 static int pim_zebra_if_state_down(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
@@ -723,7 +655,6 @@ void pim_zebra_init(void)
 	zclient->zebra_connected = pim_zebra_connected;
 	zclient->router_id_update = pim_router_id_update_zebra;
 	zclient->interface_delete = pim_zebra_if_del;
-	zclient->interface_up = pim_zebra_if_state_up;
 	zclient->interface_down = pim_zebra_if_state_down;
 	zclient->interface_address_add = pim_zebra_if_address_add;
 	zclient->interface_address_delete = pim_zebra_if_address_del;
@@ -1228,4 +1159,10 @@ struct zclient *pim_zebra_zclient_get(void)
 		return zclient;
 	else
 		return NULL;
+}
+
+void pim_zebra_interface_set_master(struct interface *vrf,
+				    struct interface *ifp)
+{
+	zclient_interface_set_master(zclient, vrf, ifp);
 }

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -63,35 +63,6 @@ static int pim_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int pim_zebra_if_del(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-	struct pim_instance *pim;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-	if (!ifp)
-		return 0;
-
-	if (PIM_DEBUG_ZEBRA) {
-		zlog_debug(
-			"%s: %s index %d(%u) flags %ld metric %d mtu %d operative %d",
-			__PRETTY_FUNCTION__, ifp->name, ifp->ifindex, vrf_id,
-			(long)ifp->flags, ifp->metric, ifp->mtu,
-			if_is_operative(ifp));
-	}
-
-	if (!if_is_operative(ifp))
-		pim_if_addr_del_all(ifp);
-
-	if_set_index(ifp, IFINDEX_INTERNAL);
-
-	pim = pim_get_pim_instance(vrf_id);
-	if (pim && pim->vxlan.term_if == ifp)
-		pim_vxlan_del_term_dev(pim);
-
-	return 0;
-}
-
 static int pim_zebra_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 {
 	struct interface *ifp;
@@ -610,7 +581,6 @@ void pim_zebra_init(void)
 	zclient->zebra_capabilities = pim_zebra_capabilities;
 	zclient->zebra_connected = pim_zebra_connected;
 	zclient->router_id_update = pim_router_id_update_zebra;
-	zclient->interface_delete = pim_zebra_if_del;
 	zclient->interface_address_add = pim_zebra_if_address_add;
 	zclient->interface_address_delete = pim_zebra_if_address_del;
 	zclient->interface_vrf_update = pim_zebra_interface_vrf_update;

--- a/pimd/pim_zebra.h
+++ b/pimd/pim_zebra.h
@@ -51,4 +51,7 @@ void pim_zebra_update_all_interfaces(struct pim_instance *pim);
 void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 				    struct pim_upstream *up,
 				    struct pim_rpf *old);
+
+void pim_zebra_interface_set_master(struct interface *vrf,
+				    struct interface *ifp);
 #endif /* PIM_ZEBRA_H */

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -346,20 +346,8 @@ int if_check_address(struct rip *rip, struct in_addr addr)
 }
 
 /* Inteface link down message processing. */
-int rip_interface_down(ZAPI_CALLBACK_ARGS)
+static int rip_ifp_down(struct interface *ifp)
 {
-	struct interface *ifp;
-	struct stream *s;
-
-	s = zclient->ibuf;
-
-	/* zebra_interface_state_read() updates interface structure in
-	   iflist. */
-	ifp = zebra_interface_state_read(s, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
 	rip_interface_sync(ifp);
 	rip_if_down(ifp);
 
@@ -1238,11 +1226,6 @@ static int rip_interface_delete_hook(struct interface *ifp)
 	rip_interface_reset(ifp->info);
 	XFREE(MTYPE_RIP_INTERFACE, ifp->info);
 	ifp->info = NULL;
-	return 0;
-}
-
-static int rip_ifp_down(struct interface *ifp)
-{
 	return 0;
 }
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -411,19 +411,8 @@ static int rip_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-int rip_interface_delete(ZAPI_CALLBACK_ARGS)
+static int rip_ifp_destroy(struct interface *ifp)
 {
-	struct interface *ifp;
-	struct stream *s;
-
-
-	s = zclient->ibuf;
-	/* zebra_interface_state_read() updates interface structure in iflist */
-	ifp = zebra_interface_state_read(s, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
 	rip_interface_sync(ifp);
 	if (if_is_up(ifp)) {
 		rip_if_down(ifp);
@@ -433,10 +422,6 @@ int rip_interface_delete(ZAPI_CALLBACK_ARGS)
 		"interface delete %s vrf %u index %d flags %#llx metric %d mtu %d",
 		ifp->name, ifp->vrf_id, ifp->ifindex,
 		(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
-
-	/* To support pseudo interface do not free interface structure.  */
-	/* if_delete(ifp); */
-	if_set_index(ifp, IFINDEX_INTERNAL);
 
 	return 0;
 }
@@ -1226,11 +1211,6 @@ static int rip_interface_delete_hook(struct interface *ifp)
 	rip_interface_reset(ifp->info);
 	XFREE(MTYPE_RIP_INTERFACE, ifp->info);
 	ifp->info = NULL;
-	return 0;
-}
-
-static int rip_ifp_destroy(struct interface *ifp)
-{
 	return 0;
 }
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -373,17 +373,8 @@ int rip_interface_down(ZAPI_CALLBACK_ARGS)
 }
 
 /* Inteface link up message processing */
-int rip_interface_up(ZAPI_CALLBACK_ARGS)
+static int rip_ifp_up(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	/* zebra_interface_state_read () updates interface structure in
-	   iflist. */
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
 	if (IS_RIP_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface %s vrf %u index %d flags %#llx metric %d mtu %d is up",
@@ -1247,11 +1238,6 @@ static int rip_interface_delete_hook(struct interface *ifp)
 	rip_interface_reset(ifp->info);
 	XFREE(MTYPE_RIP_INTERFACE, ifp->info);
 	ifp->info = NULL;
-	return 0;
-}
-
-static int rip_ifp_up(struct interface *ifp)
-{
 	return 0;
 }
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -405,11 +405,8 @@ int rip_interface_up(ZAPI_CALLBACK_ARGS)
 }
 
 /* Inteface addition message from zebra. */
-int rip_interface_add(ZAPI_CALLBACK_ARGS)
+static int rip_ifp_create(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
 	rip_interface_sync(ifp);
 
 	if (IS_RIP_DEBUG_ZEBRA)
@@ -1250,11 +1247,6 @@ static int rip_interface_delete_hook(struct interface *ifp)
 	rip_interface_reset(ifp->info);
 	XFREE(MTYPE_RIP_INTERFACE, ifp->info);
 	ifp->info = NULL;
-	return 0;
-}
-
-static int rip_ifp_create(struct interface *ifp)
-{
 	return 0;
 }
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -1253,6 +1253,26 @@ static int rip_interface_delete_hook(struct interface *ifp)
 	return 0;
 }
 
+static int rip_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int rip_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int rip_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int rip_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 /* Allocate and initialize interface vector. */
 void rip_if_init(void)
 {
@@ -1263,4 +1283,6 @@ void rip_if_init(void)
 	/* Install interface node. */
 	install_node(&interface_node, rip_interface_config_write);
 	if_cmd_init();
+	if_zapi_callbacks(rip_ifp_create, rip_ifp_up,
+			  rip_ifp_down, rip_ifp_destroy);
 }

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -238,7 +238,6 @@ void rip_zclient_init(struct thread_master *master)
 	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, ZEBRA_ROUTE_RIP, 0, &ripd_privs);
 	zclient->zebra_connected = rip_zebra_connected;
-	zclient->interface_delete = rip_interface_delete;
 	zclient->interface_address_add = rip_interface_address_add;
 	zclient->interface_address_delete = rip_interface_address_delete;
 	zclient->interface_vrf_update = rip_interface_vrf_update;

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -241,7 +241,6 @@ void rip_zclient_init(struct thread_master *master)
 	zclient->interface_delete = rip_interface_delete;
 	zclient->interface_address_add = rip_interface_address_add;
 	zclient->interface_address_delete = rip_interface_address_delete;
-	zclient->interface_up = rip_interface_up;
 	zclient->interface_down = rip_interface_down;
 	zclient->interface_vrf_update = rip_interface_vrf_update;
 	zclient->redistribute_route_add = rip_zebra_read_route;

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -241,7 +241,6 @@ void rip_zclient_init(struct thread_master *master)
 	zclient->interface_delete = rip_interface_delete;
 	zclient->interface_address_add = rip_interface_address_add;
 	zclient->interface_address_delete = rip_interface_address_delete;
-	zclient->interface_down = rip_interface_down;
 	zclient->interface_vrf_update = rip_interface_vrf_update;
 	zclient->redistribute_route_add = rip_zebra_read_route;
 	zclient->redistribute_route_del = rip_zebra_read_route;

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -238,7 +238,6 @@ void rip_zclient_init(struct thread_master *master)
 	zclient = zclient_new(master, &zclient_options_default);
 	zclient_init(zclient, ZEBRA_ROUTE_RIP, 0, &ripd_privs);
 	zclient->zebra_connected = rip_zebra_connected;
-	zclient->interface_add = rip_interface_add;
 	zclient->interface_delete = rip_interface_delete;
 	zclient->interface_address_add = rip_interface_address_add;
 	zclient->interface_address_delete = rip_interface_address_delete;

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -256,11 +256,8 @@ int ripng_interface_down(ZAPI_CALLBACK_ARGS)
 }
 
 /* Inteface addition message from zebra. */
-int ripng_interface_add(ZAPI_CALLBACK_ARGS)
+static int ripng_ifp_create(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
 	ripng_interface_sync(ifp);
 
 	if (IS_RIPNG_DEBUG_ZEBRA)
@@ -988,11 +985,6 @@ static int interface_config_write(struct vty *vty)
 static struct cmd_node interface_node = {
 	INTERFACE_NODE, "%s(config-if)# ", 1 /* VTYSH */
 };
-
-static int ripng_ifp_create(struct interface *ifp)
-{
-	return 0;
-}
 
 static int ripng_ifp_up(struct interface *ifp)
 {

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -256,19 +256,8 @@ static int ripng_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-int ripng_interface_delete(ZAPI_CALLBACK_ARGS)
+static int ripng_ifp_destroy(struct interface *ifp)
 {
-	struct interface *ifp;
-	struct stream *s;
-
-	s = zclient->ibuf;
-	/*  zebra_interface_state_read() updates interface structure in iflist
-	 */
-	ifp = zebra_interface_state_read(s, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
 	ripng_interface_sync(ifp);
 	if (if_is_up(ifp)) {
 		ripng_if_down(ifp);
@@ -278,10 +267,6 @@ int ripng_interface_delete(ZAPI_CALLBACK_ARGS)
 		"interface delete %s vrf %u index %d flags %#llx metric %d mtu %d",
 		ifp->name, ifp->vrf_id, ifp->ifindex,
 		(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
-
-	/* To support pseudo interface do not free interface structure.  */
-	/* if_delete(ifp); */
-	if_set_index(ifp, IFINDEX_INTERNAL);
 
 	return 0;
 }
@@ -963,11 +948,6 @@ static int interface_config_write(struct vty *vty)
 static struct cmd_node interface_node = {
 	INTERFACE_NODE, "%s(config-if)# ", 1 /* VTYSH */
 };
-
-static int ripng_ifp_destroy(struct interface *ifp)
-{
-	return 0;
-}
 
 /* Initialization of interface. */
 void ripng_if_init(void)

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -989,6 +989,26 @@ static struct cmd_node interface_node = {
 	INTERFACE_NODE, "%s(config-if)# ", 1 /* VTYSH */
 };
 
+static int ripng_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ripng_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ripng_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int ripng_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 /* Initialization of interface. */
 void ripng_if_init(void)
 {
@@ -999,4 +1019,6 @@ void ripng_if_init(void)
 	/* Install interface node. */
 	install_node(&interface_node, interface_config_write);
 	if_cmd_init();
+	if_zapi_callbacks(ripng_ifp_create, ripng_ifp_up,
+			  ripng_ifp_down, ripng_ifp_destroy);
 }

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -196,19 +196,8 @@ static int ripng_if_down(struct interface *ifp)
 }
 
 /* Inteface link up message processing. */
-int ripng_interface_up(ZAPI_CALLBACK_ARGS)
+static int ripng_ifp_up(struct interface *ifp)
 {
-	struct stream *s;
-	struct interface *ifp;
-
-	/* zebra_interface_state_read() updates interface structure in iflist.
-	 */
-	s = zclient->ibuf;
-	ifp = zebra_interface_state_read(s, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
 	if (IS_RIPNG_DEBUG_ZEBRA)
 		zlog_debug(
 			"interface up %s vrf %u index %d flags %llx metric %d mtu %d",
@@ -985,11 +974,6 @@ static int interface_config_write(struct vty *vty)
 static struct cmd_node interface_node = {
 	INTERFACE_NODE, "%s(config-if)# ", 1 /* VTYSH */
 };
-
-static int ripng_ifp_up(struct interface *ifp)
-{
-	return 0;
-}
 
 static int ripng_ifp_down(struct interface *ifp)
 {

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -219,19 +219,8 @@ static int ripng_ifp_up(struct interface *ifp)
 }
 
 /* Inteface link down message processing. */
-int ripng_interface_down(ZAPI_CALLBACK_ARGS)
+static int ripng_ifp_down(struct interface *ifp)
 {
-	struct stream *s;
-	struct interface *ifp;
-
-	/* zebra_interface_state_read() updates interface structure in iflist.
-	 */
-	s = zclient->ibuf;
-	ifp = zebra_interface_state_read(s, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
 	ripng_interface_sync(ifp);
 	ripng_if_down(ifp);
 
@@ -974,11 +963,6 @@ static int interface_config_write(struct vty *vty)
 static struct cmd_node interface_node = {
 	INTERFACE_NODE, "%s(config-if)# ", 1 /* VTYSH */
 };
-
-static int ripng_ifp_down(struct interface *ifp)
-{
-	return 0;
-}
 
 static int ripng_ifp_destroy(struct interface *ifp)
 {

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -242,7 +242,6 @@ void zebra_init(struct thread_master *master)
 	zclient_init(zclient, ZEBRA_ROUTE_RIPNG, 0, &ripngd_privs);
 
 	zclient->zebra_connected = ripng_zebra_connected;
-	zclient->interface_up = ripng_interface_up;
 	zclient->interface_down = ripng_interface_down;
 	zclient->interface_delete = ripng_interface_delete;
 	zclient->interface_address_add = ripng_interface_address_add;

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -242,7 +242,6 @@ void zebra_init(struct thread_master *master)
 	zclient_init(zclient, ZEBRA_ROUTE_RIPNG, 0, &ripngd_privs);
 
 	zclient->zebra_connected = ripng_zebra_connected;
-	zclient->interface_delete = ripng_interface_delete;
 	zclient->interface_address_add = ripng_interface_address_add;
 	zclient->interface_address_delete = ripng_interface_address_delete;
 	zclient->interface_vrf_update = ripng_interface_vrf_update;

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -244,7 +244,6 @@ void zebra_init(struct thread_master *master)
 	zclient->zebra_connected = ripng_zebra_connected;
 	zclient->interface_up = ripng_interface_up;
 	zclient->interface_down = ripng_interface_down;
-	zclient->interface_add = ripng_interface_add;
 	zclient->interface_delete = ripng_interface_delete;
 	zclient->interface_address_add = ripng_interface_address_add;
 	zclient->interface_address_delete = ripng_interface_address_delete;

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -242,7 +242,6 @@ void zebra_init(struct thread_master *master)
 	zclient_init(zclient, ZEBRA_ROUTE_RIPNG, 0, &ripngd_privs);
 
 	zclient->zebra_connected = ripng_zebra_connected;
-	zclient->interface_down = ripng_interface_down;
 	zclient->interface_delete = ripng_interface_delete;
 	zclient->interface_address_add = ripng_interface_address_add;
 	zclient->interface_address_delete = ripng_interface_address_delete;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -58,15 +58,8 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 }
 
 /* Inteface addition message from zebra. */
-static int interface_add(ZAPI_CALLBACK_ARGS)
+static int sharp_ifp_create(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-
-	if (!ifp->info)
-		return 0;
-
 	return 0;
 }
 
@@ -392,11 +385,6 @@ static int sharp_nexthop_update(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int sharp_ifp_create(struct interface *ifp)
-{
-	return 0;
-}
-
 static int sharp_ifp_up(struct interface *ifp)
 {
 	return 0;
@@ -425,7 +413,6 @@ void sharp_zebra_init(void)
 
 	zclient_init(zclient, ZEBRA_ROUTE_SHARP, 0, &sharp_privs);
 	zclient->zebra_connected = zebra_connected;
-	zclient->interface_add = interface_add;
 	zclient->interface_delete = interface_delete;
 	zclient->interface_up = interface_state_up;
 	zclient->interface_down = interface_state_down;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -46,17 +46,6 @@ struct zclient *zclient = NULL;
 /* For registering threads. */
 extern struct thread_master *master;
 
-static struct interface *zebra_interface_if_lookup(struct stream *s)
-{
-	char ifname_tmp[INTERFACE_NAMSIZ];
-
-	/* Read interface name. */
-	stream_get(ifname_tmp, s, INTERFACE_NAMSIZ);
-
-	/* And look it up. */
-	return if_lookup_by_name(ifname_tmp, VRF_DEFAULT);
-}
-
 /* Inteface addition message from zebra. */
 static int sharp_ifp_create(struct interface *ifp)
 {
@@ -102,11 +91,8 @@ static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int interface_state_up(ZAPI_CALLBACK_ARGS)
+static int sharp_ifp_up(struct interface *ifp)
 {
-
-	zebra_interface_if_lookup(zclient->ibuf);
-
 	return 0;
 }
 
@@ -385,11 +371,6 @@ static int sharp_nexthop_update(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int sharp_ifp_up(struct interface *ifp)
-{
-	return 0;
-}
-
 static int sharp_ifp_down(struct interface *ifp)
 {
 	return 0;
@@ -414,7 +395,6 @@ void sharp_zebra_init(void)
 	zclient_init(zclient, ZEBRA_ROUTE_SHARP, 0, &sharp_privs);
 	zclient->zebra_connected = zebra_connected;
 	zclient->interface_delete = interface_delete;
-	zclient->interface_up = interface_state_up;
 	zclient->interface_down = interface_state_down;
 	zclient->interface_address_add = interface_address_add;
 	zclient->interface_address_delete = interface_address_delete;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -96,11 +96,8 @@ static int sharp_ifp_up(struct interface *ifp)
 	return 0;
 }
 
-static int interface_state_down(ZAPI_CALLBACK_ARGS)
+static int sharp_ifp_down(struct interface *ifp)
 {
-
-	zebra_interface_state_read(zclient->ibuf, vrf_id);
-
 	return 0;
 }
 
@@ -371,11 +368,6 @@ static int sharp_nexthop_update(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int sharp_ifp_down(struct interface *ifp)
-{
-	return 0;
-}
-
 static int sharp_ifp_destroy(struct interface *ifp)
 {
 	return 0;
@@ -395,7 +387,6 @@ void sharp_zebra_init(void)
 	zclient_init(zclient, ZEBRA_ROUTE_SHARP, 0, &sharp_privs);
 	zclient->zebra_connected = zebra_connected;
 	zclient->interface_delete = interface_delete;
-	zclient->interface_down = interface_state_down;
 	zclient->interface_address_add = interface_address_add;
 	zclient->interface_address_delete = interface_address_delete;
 	zclient->route_notify_owner = route_notify_owner;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -392,11 +392,34 @@ static int sharp_nexthop_update(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
+static int sharp_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int sharp_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int sharp_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int sharp_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 extern struct zebra_privs_t sharp_privs;
 
 void sharp_zebra_init(void)
 {
 	struct zclient_options opt = {.receive_notify = true};
+
+	if_zapi_callbacks(sharp_ifp_create, sharp_ifp_up,
+			  sharp_ifp_down, sharp_ifp_destroy);
 
 	zclient = zclient_new(master, &opt);
 

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -52,27 +52,13 @@ static int sharp_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-static int interface_delete(ZAPI_CALLBACK_ARGS)
+static int sharp_ifp_destroy(struct interface *ifp)
 {
-	struct interface *ifp;
-	struct stream *s;
-
-	s = zclient->ibuf;
-	/* zebra_interface_state_read () updates interface structure in iflist
-	 */
-	ifp = zebra_interface_state_read(s, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
-	if_set_index(ifp, IFINDEX_INTERNAL);
-
 	return 0;
 }
 
 static int interface_address_add(ZAPI_CALLBACK_ARGS)
 {
-
 	zebra_interface_address_read(cmd, zclient->ibuf, vrf_id);
 
 	return 0;
@@ -368,11 +354,6 @@ static int sharp_nexthop_update(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int sharp_ifp_destroy(struct interface *ifp)
-{
-	return 0;
-}
-
 extern struct zebra_privs_t sharp_privs;
 
 void sharp_zebra_init(void)
@@ -386,7 +367,6 @@ void sharp_zebra_init(void)
 
 	zclient_init(zclient, ZEBRA_ROUTE_SHARP, 0, &sharp_privs);
 	zclient->zebra_connected = zebra_connected;
-	zclient->interface_delete = interface_delete;
 	zclient->interface_address_add = interface_address_add;
 	zclient->interface_address_delete = interface_address_delete;
 	zclient->route_notify_owner = route_notify_owner;

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -112,14 +112,9 @@ static int static_ifp_up(struct interface *ifp)
 	return 0;
 }
 
-static int interface_state_down(ZAPI_CALLBACK_ARGS)
+static int static_ifp_down(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
-	if (ifp)
-		static_ifindex_update(ifp, false);
+	static_ifindex_update(ifp, false);
 
 	return 0;
 }
@@ -481,11 +476,6 @@ extern void static_zebra_route_add(struct route_node *rn,
 			   zclient, &api);
 }
 
-static int static_ifp_down(struct interface *ifp)
-{
-	return 0;
-}
-
 static int static_ifp_destroy(struct interface *ifp)
 {
 	return 0;
@@ -504,7 +494,6 @@ void static_zebra_init(void)
 	zclient->zebra_capabilities = static_zebra_capabilities;
 	zclient->zebra_connected = zebra_connected;
 	zclient->interface_delete = interface_delete;
-	zclient->interface_down = interface_state_down;
 	zclient->interface_address_add = interface_address_add;
 	zclient->interface_address_delete = interface_address_delete;
 	zclient->route_notify_owner = route_notify_owner;

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -504,9 +504,33 @@ extern void static_zebra_route_add(struct route_node *rn,
 			   ZEBRA_ROUTE_ADD : ZEBRA_ROUTE_DELETE,
 			   zclient, &api);
 }
+
+static int static_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+static int static_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+static int static_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+static int static_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 void static_zebra_init(void)
 {
 	struct zclient_options opt = { .receive_notify = true };
+
+	if_zapi_callbacks(static_ifp_create, static_ifp_up,
+			  static_ifp_down, static_ifp_destroy);
 
 	zclient = zclient_new(master, &opt);
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -57,21 +57,8 @@ static int static_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-static int interface_delete(ZAPI_CALLBACK_ARGS)
+static int static_ifp_destroy(struct interface *ifp)
 {
-	struct interface *ifp;
-	struct stream *s;
-
-	s = zclient->ibuf;
-	/* zebra_interface_state_read () updates interface structure in iflist
-	 */
-	ifp = zebra_interface_state_read(s, vrf_id);
-
-	if (ifp == NULL)
-		return 0;
-
-	if_set_index(ifp, IFINDEX_INTERNAL);
-
 	static_ifindex_update(ifp, false);
 	return 0;
 }
@@ -476,11 +463,6 @@ extern void static_zebra_route_add(struct route_node *rn,
 			   zclient, &api);
 }
 
-static int static_ifp_destroy(struct interface *ifp)
-{
-	return 0;
-}
-
 void static_zebra_init(void)
 {
 	struct zclient_options opt = { .receive_notify = true };
@@ -493,7 +475,6 @@ void static_zebra_init(void)
 	zclient_init(zclient, ZEBRA_ROUTE_STATIC, 0, &static_privs);
 	zclient->zebra_capabilities = static_zebra_capabilities;
 	zclient->zebra_connected = zebra_connected;
-	zclient->interface_delete = interface_delete;
 	zclient->interface_address_add = interface_address_add;
 	zclient->interface_address_delete = interface_address_delete;
 	zclient->route_notify_owner = route_notify_owner;

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -61,16 +61,10 @@ static struct interface *zebra_interface_if_lookup(struct stream *s)
 }
 
 /* Inteface addition message from zebra. */
-static int interface_add(ZAPI_CALLBACK_ARGS)
+static int static_ifp_create(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-
-	if (!ifp)
-		return 0;
-
 	static_ifindex_update(ifp, true);
+
 	return 0;
 }
 
@@ -505,11 +499,6 @@ extern void static_zebra_route_add(struct route_node *rn,
 			   zclient, &api);
 }
 
-static int static_ifp_create(struct interface *ifp)
-{
-	return 0;
-}
-
 static int static_ifp_up(struct interface *ifp)
 {
 	return 0;
@@ -537,7 +526,6 @@ void static_zebra_init(void)
 	zclient_init(zclient, ZEBRA_ROUTE_STATIC, 0, &static_privs);
 	zclient->zebra_capabilities = static_zebra_capabilities;
 	zclient->zebra_connected = zebra_connected;
-	zclient->interface_add = interface_add;
 	zclient->interface_delete = interface_delete;
 	zclient->interface_up = interface_state_up;
 	zclient->interface_down = interface_state_down;

--- a/vrrpd/vrrp_vty.c
+++ b/vrrpd/vrrp_vty.c
@@ -30,6 +30,7 @@
 #include "vrrp.h"
 #include "vrrp_debug.h"
 #include "vrrp_vty.h"
+#include "vrrp_zebra.h"
 #ifndef VTYSH_EXTRACT_PL
 #include "vrrpd/vrrp_vty_clippy.c"
 #endif

--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -108,22 +108,9 @@ static int vrrp_zebra_if_del(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int vrrp_zebra_if_state_up(int command, struct zclient *zclient,
-				  zebra_size_t length, vrf_id_t vrf_id)
+int vrrp_ifp_up(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	/*
-	 * zebra api notifies interface up/down events by using the same call
-	 * zebra_interface_state_read below, see comments in lib/zclient.c ifp =
-	 * zebra_interface_state_read(zclient->ibuf, vrf_id);
-	 */
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
-	if (!ifp)
-		return 0;
-
-	vrrp_zebra_debug_if_state(ifp, vrf_id, __func__);
+	vrrp_zebra_debug_if_state(ifp, ifp->vrf_id, __func__);
 
 	vrrp_if_up(ifp);
 
@@ -224,11 +211,6 @@ int vrrp_zclient_send_interface_protodown(struct interface *ifp, bool down)
 						down);
 }
 
-int vrrp_ifp_up(struct interface *ifp)
-{
-	return 0;
-}
-
 int vrrp_ifp_down(struct interface *ifp)
 {
 	return 0;
@@ -250,7 +232,6 @@ void vrrp_zebra_init(void)
 	zclient->zebra_connected = vrrp_zebra_connected;
 	zclient->router_id_update = vrrp_router_id_update_zebra;
 	zclient->interface_delete = vrrp_zebra_if_del;
-	zclient->interface_up = vrrp_zebra_if_state_up;
 	zclient->interface_down = vrrp_zebra_if_state_down;
 	zclient->interface_address_add = vrrp_zebra_if_address_add;
 	zclient->interface_address_delete = vrrp_zebra_if_address_del;

--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -80,21 +80,9 @@ static int vrrp_router_id_update_zebra(int command, struct zclient *zclient,
 	return 0;
 }
 
-static int vrrp_zebra_if_add(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+int vrrp_ifp_create(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	/*
-	 * zebra api adds/dels interfaces using the same call
-	 * interface_add_read below, see comments in lib/zclient.c
-	 */
-	ifp = zebra_interface_add_read(zclient->ibuf, vrf_id);
-
-	if (!ifp)
-		return 0;
-
-	vrrp_zebra_debug_if_state(ifp, vrf_id, __func__);
+	vrrp_zebra_debug_if_state(ifp, ifp->vrf_id, __func__);
 
 	vrrp_if_add(ifp);
 
@@ -236,11 +224,6 @@ int vrrp_zclient_send_interface_protodown(struct interface *ifp, bool down)
 						down);
 }
 
-int vrrp_ifp_create(struct interface *ifp)
-{
-	return 0;
-}
-
 int vrrp_ifp_up(struct interface *ifp)
 {
 	return 0;
@@ -266,7 +249,6 @@ void vrrp_zebra_init(void)
 
 	zclient->zebra_connected = vrrp_zebra_connected;
 	zclient->router_id_update = vrrp_router_id_update_zebra;
-	zclient->interface_add = vrrp_zebra_if_add;
 	zclient->interface_delete = vrrp_zebra_if_del;
 	zclient->interface_up = vrrp_zebra_if_state_up;
 	zclient->interface_down = vrrp_zebra_if_state_down;

--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -89,21 +89,11 @@ int vrrp_ifp_create(struct interface *ifp)
 	return 0;
 }
 
-static int vrrp_zebra_if_del(int command, struct zclient *zclient,
-			     zebra_size_t length, vrf_id_t vrf_id)
+int vrrp_ifp_destroy(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
-	if (!ifp)
-		return 0;
-
-	vrrp_zebra_debug_if_state(ifp, vrf_id, __func__);
+	vrrp_zebra_debug_if_state(ifp, ifp->vrf_id, __func__);
 
 	vrrp_if_del(ifp);
-
-	if_set_index(ifp, IFINDEX_INTERNAL);
 
 	return 0;
 }
@@ -199,11 +189,6 @@ int vrrp_zclient_send_interface_protodown(struct interface *ifp, bool down)
 						down);
 }
 
-int vrrp_ifp_destroy(struct interface *ifp)
-{
-	return 0;
-}
-
 void vrrp_zebra_init(void)
 {
 	if_zapi_callbacks(vrrp_ifp_create, vrrp_ifp_up,
@@ -214,7 +199,6 @@ void vrrp_zebra_init(void)
 
 	zclient->zebra_connected = vrrp_zebra_connected;
 	zclient->router_id_update = vrrp_router_id_update_zebra;
-	zclient->interface_delete = vrrp_zebra_if_del;
 	zclient->interface_address_add = vrrp_zebra_if_address_add;
 	zclient->interface_address_delete = vrrp_zebra_if_address_del;
 

--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -236,8 +236,31 @@ int vrrp_zclient_send_interface_protodown(struct interface *ifp, bool down)
 						down);
 }
 
+int vrrp_ifp_create(struct interface *ifp)
+{
+	return 0;
+}
+
+int vrrp_ifp_up(struct interface *ifp)
+{
+	return 0;
+}
+
+int vrrp_ifp_down(struct interface *ifp)
+{
+	return 0;
+}
+
+int vrrp_ifp_destroy(struct interface *ifp)
+{
+	return 0;
+}
+
 void vrrp_zebra_init(void)
 {
+	if_zapi_callbacks(vrrp_ifp_create, vrrp_ifp_up,
+			  vrrp_ifp_down, vrrp_ifp_destroy);
+
 	/* Socket for receiving updates from Zebra daemon */
 	zclient = zclient_new(master, &zclient_options_default);
 

--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -117,21 +117,9 @@ int vrrp_ifp_up(struct interface *ifp)
 	return 0;
 }
 
-static int vrrp_zebra_if_state_down(int command, struct zclient *zclient,
-				    zebra_size_t length, vrf_id_t vrf_id)
+int vrrp_ifp_down(struct interface *ifp)
 {
-	struct interface *ifp;
-
-	/*
-	 * zebra api notifies interface up/down events by using the same call
-	 * zebra_interface_state_read below, see comments in lib/zclient.c
-	 */
-	ifp = zebra_interface_state_read(zclient->ibuf, vrf_id);
-
-	if (!ifp)
-		return 0;
-
-	vrrp_zebra_debug_if_state(ifp, vrf_id, __func__);
+	vrrp_zebra_debug_if_state(ifp, ifp->vrf_id, __func__);
 
 	vrrp_if_down(ifp);
 
@@ -211,11 +199,6 @@ int vrrp_zclient_send_interface_protodown(struct interface *ifp, bool down)
 						down);
 }
 
-int vrrp_ifp_down(struct interface *ifp)
-{
-	return 0;
-}
-
 int vrrp_ifp_destroy(struct interface *ifp)
 {
 	return 0;
@@ -232,7 +215,6 @@ void vrrp_zebra_init(void)
 	zclient->zebra_connected = vrrp_zebra_connected;
 	zclient->router_id_update = vrrp_router_id_update_zebra;
 	zclient->interface_delete = vrrp_zebra_if_del;
-	zclient->interface_down = vrrp_zebra_if_state_down;
 	zclient->interface_address_add = vrrp_zebra_if_address_add;
 	zclient->interface_address_delete = vrrp_zebra_if_address_del;
 

--- a/vrrpd/vrrp_zebra.h
+++ b/vrrpd/vrrp_zebra.h
@@ -29,4 +29,9 @@ extern void vrrp_zebra_radv_set(struct vrrp_router *r, bool enable);
 extern int vrrp_zclient_send_interface_protodown(struct interface *ifp,
 						 bool down);
 
+extern int vrrp_ifp_create(struct interface *ifp);
+extern int vrrp_ifp_up(struct interface *ifp);
+extern int vrrp_ifp_down(struct interface *ifp);
+extern int vrrp_ifp_destroy(struct interface *ifp);
+
 #endif /* __VRRP_ZEBRA_H__ */

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1376,6 +1376,13 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 			else if (IS_ZEBRA_IF_BOND_SLAVE(ifp) || was_bond_slave)
 				zebra_l2if_update_bond_slave(ifp, bond_ifindex);
 		}
+
+		zif = ifp->info;
+		if (zif) {
+			XFREE(MTYPE_TMP, zif->desc);
+			if (desc)
+				zif->desc = XSTRDUP(MTYPE_TMP, desc);
+		}
 	} else {
 		/* Delete interface notification from kernel */
 		if (ifp == NULL) {
@@ -1400,13 +1407,6 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 
 		if (!IS_ZEBRA_IF_VRF(ifp))
 			if_delete_update(ifp);
-	}
-
-	zif = ifp->info;
-	if (zif) {
-		XFREE(MTYPE_TMP, zif->desc);
-		if (desc)
-			zif->desc = XSTRDUP(MTYPE_TMP, desc);
 	}
 
 	return 0;

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -767,6 +767,13 @@ void if_delete_update(struct interface *ifp)
 		memset(&zif->brslave_info, 0,
 		       sizeof(struct zebra_l2info_brslave));
 	}
+
+	if (!ifp->configured) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("interface %s is being deleted from the system",
+				   ifp->name);
+		if_delete(ifp);
+	}
 }
 
 /* VRF change for an interface */

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -3202,6 +3202,11 @@ void zebra_if_init(void)
 	install_node(&interface_node, if_config_write);
 	install_node(&link_params_node, NULL);
 	if_cmd_init();
+	/*
+	 * This is *intentionally* setting this to NULL, signaling
+	 * that interface creation for zebra acts differently
+	 */
+	if_zapi_callbacks(NULL, NULL, NULL, NULL);
 
 	install_element(VIEW_NODE, &show_interface_cmd);
 	install_element(VIEW_NODE, &show_interface_vrf_all_cmd);


### PR DESCRIPTION
When zebra gets a callback from the kernel that an interface has
actually been deleted *and* the end users has not configured
the interface, then allow for deletion of the interface from zebra.

This is especially important in a docker environment where containers
and their veth interfaces are treated as ephermeal.  FRR can quickly
have an inordinate amount of interfaces sitting around that are
not in the kernel and we have no way to clean them up either.

My expectation is that this will cause a second order crashes
in upper level protocols, but I am not sure how to catch these
and fix them now ( suggestions welcome ).  There are too many
use patterns and order based events that I cannot know for certain
that we are going to see any at all, until someone sees this problem
as a crash :(  I do not recommend that this be put in the current
stabilization branch and allow this to soak in master for some time
first.

Testing:

sharpd@donna ~/frr4> sudo ip link add vethdj type veth peer name vethjd
sharpd@donna ~/frr4> sudo ip link add vethaa type veth peer name vethab
sharpd@donna ~/frr4> sudo vtysh -c "show int brief"
Interface       Status  VRF             Addresses
---------       ------  ---             ---------
dummy1          down    default
enp0s3          up      default         10.0.2.15/24
enp0s8          up      default         192.168.209.2/24
enp0s9          up      default         192.168.210.2/24
enp0s10         up      default         192.168.212.4/24
lo              up      default         10.22.89.38/32
vethaa          down    default
vethab          down    default
vethdj          down    default
vethjd          down    default
virbr0          up      default         192.168.122.1/24
virbr0-nic      down    default

sharpd@donna ~/frr4> sudo ip link set vethaa up
sharpd@donna ~/frr4> sudo ip link set vethab up
sharpd@donna ~/frr4> sudo ip link del vethdj
sharpd@donna ~/frr4> sudo vtysh -c "show int brief"
Interface       Status  VRF             Addresses
---------       ------  ---             ---------
dummy1          down    default
enp0s3          up      default         10.0.2.15/24
enp0s8          up      default         192.168.209.2/24
enp0s9          up      default         192.168.210.2/24
enp0s10         up      default         192.168.212.4/24
lo              up      default         10.22.89.38/32
vethaa          up      default
vethab          up      default
virbr0          up      default         192.168.122.1/24
virbr0-nic      down    default

sharpd@donna ~/frr4> sudo ip link del vethaa
sharpd@donna ~/frr4> sudo vtysh -c "show int brief"
Interface       Status  VRF             Addresses
---------       ------  ---             ---------
dummy1          down    default
enp0s3          up      default         10.0.2.15/24
enp0s8          up      default         192.168.209.2/24
enp0s9          up      default         192.168.210.2/24
enp0s10         up      default         192.168.212.4/24
lo              up      default         10.22.89.38/32
virbr0          up      default         192.168.122.1/24
virbr0-nic      down    default

sharpd@donna ~/frr4> sudo ip link add vethaa type veth peer name vethab
sharpd@donna ~/frr4> sudo vtysh -c "show int brief"
Interface       Status  VRF             Addresses
---------       ------  ---             ---------
dummy1          down    default
enp0s3          up      default         10.0.2.15/24
enp0s8          up      default         192.168.209.2/24
enp0s9          up      default         192.168.210.2/24
enp0s10         up      default         192.168.212.4/24
lo              up      default         10.22.89.38/32
vethaa          down    default
vethab          down    default
virbr0          up      default         192.168.122.1/24
virbr0-nic      down    default

sharpd@donna ~/frr4> sudo vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 7.2-dev
frr defaults datacenter
hostname donna.cumulusnetworks.com
log stdout
no ipv6 forwarding
!
ip route 192.168.3.0/24 192.168.209.1
ip route 192.168.4.0/24 blackhole
ip route 192.168.5.0/24 192.168.209.1
ip route 192.168.6.0/24 192.168.209.1
ip route 192.168.7.0/24 99.99.99.99 nexthop-vrf EVA
ip route 192.168.8.0/24 192.168.209.1
ip route 4.5.6.7/32 12.13.14.15
!
interface dummy1
 ip address 12.13.14.15/32
!
interface vethaa
 description FROO
!
line vty
!
end
sharpd@donna ~/frr4> sudo ip link del vethaa
sharpd@donna ~/frr4> sudo vtysh -c "show int brief"
Interface       Status  VRF             Addresses
---------       ------  ---             ---------
dummy1          down    default
enp0s3          up      default         10.0.2.15/24
enp0s8          up      default         192.168.209.2/24
enp0s9          up      default         192.168.210.2/24
enp0s10         up      default         192.168.212.4/24
lo              up      default         10.22.89.38/32
vethaa          down    default
virbr0          up      default         192.168.122.1/24
virbr0-nic      down    default

sharpd@donna ~/frr4> sudo vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 7.2-dev
frr defaults datacenter
hostname donna.cumulusnetworks.com
log stdout
no ipv6 forwarding
!
ip route 192.168.3.0/24 192.168.209.1
ip route 192.168.4.0/24 blackhole
ip route 192.168.5.0/24 192.168.209.1
ip route 192.168.6.0/24 192.168.209.1
ip route 192.168.7.0/24 99.99.99.99 nexthop-vrf EVA
ip route 192.168.8.0/24 192.168.209.1
ip route 4.5.6.7/32 12.13.14.15
!
interface dummy1
 ip address 12.13.14.15/32
!
interface vethaa
 description FROO
!
line vty
!
end

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>