### PR TITLE
bfdd: Adding new fields to display show bfd peer

### DIFF
--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -242,6 +242,11 @@ struct bfd_session {
 	/* BFD session flags */
 	enum bfd_session_flags flags;
 
+	/* Flag to indicate if Tx packet is filled in below structure */
+	bool bfd_tx_pkt_stored;
+	/* Stored packet for Tx in Async mode */
+	struct bfd_pkt bfd_tx_pkt;
+
 	struct bfd_session_stats stats;
 
 	struct timeval uptime;   /* last up time */
@@ -369,6 +374,7 @@ int control_notify(struct bfd_session *bs, uint8_t notify_state);
 int control_notify_config(const char *op, struct bfd_session *bs);
 int control_accept(struct thread *t);
 
+void bfd_clear_stored_pkt(struct bfd_session *bs);
 
 /*
  * bfdd.c
@@ -567,6 +573,8 @@ typedef void (*hash_iter_func)(struct hash_bucket *hb, void *arg);
 void bfd_id_iterate(hash_iter_func hif, void *arg);
 void bfd_key_iterate(hash_iter_func hif, void *arg);
 
+unsigned long bfd_get_session_count(void);
+
 /* Export callback functions for `event.c`. */
 extern struct thread_master *master;
 
@@ -593,6 +601,28 @@ void bfdd_vty_init(void);
  */
 void bfdd_cli_init(void);
 
+void bfd_cli_show_header(struct vty *vty, struct lyd_node *dnode,
+			 bool show_defaults);
+void bfd_cli_show_header_end(struct vty *vty, struct lyd_node *dnode);
+void bfd_cli_show_single_hop_peer(struct vty *vty,
+				  struct lyd_node *dnode,
+				  bool show_defaults);
+void bfd_cli_show_multi_hop_peer(struct vty *vty,
+				 struct lyd_node *dnode,
+				 bool show_defaults);
+void bfd_cli_show_peer_end(struct vty *vty, struct lyd_node *dnode);
+void bfd_cli_show_mult(struct vty *vty, struct lyd_node *dnode,
+		       bool show_defaults);
+void bfd_cli_show_tx(struct vty *vty, struct lyd_node *dnode,
+		     bool show_defaults);
+void bfd_cli_show_rx(struct vty *vty, struct lyd_node *dnode,
+		     bool show_defaults);
+void bfd_cli_show_shutdown(struct vty *vty, struct lyd_node *dnode,
+			   bool show_defaults);
+void bfd_cli_show_echo(struct vty *vty, struct lyd_node *dnode,
+			   bool show_defaults);
+void bfd_cli_show_echo_interval(struct vty *vty, struct lyd_node *dnode,
+				bool show_defaults);
 
 /*
  * ptm_adapter.c

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -215,51 +215,67 @@ static int ptm_bfd_process_echo_pkt(struct bfd_vrf_global *bvrf, int s)
 void ptm_bfd_snd(struct bfd_session *bfd, int fbit)
 {
 	struct bfd_pkt cp;
+	struct bfd_pkt *pst_bfd_pkt = NULL;
 
-	/* Set fields according to section 6.5.7 */
-	cp.diag = bfd->local_diag;
-	BFD_SETVER(cp.diag, BFD_VERSION);
-	cp.flags = 0;
-	BFD_SETSTATE(cp.flags, bfd->ses_state);
-
-	if (BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_CBIT))
-		BFD_SETCBIT(cp.flags, BFD_CBIT);
-
-	BFD_SETDEMANDBIT(cp.flags, BFD_DEF_DEMAND);
-
-	/*
-	 * Polling and Final can't be set at the same time.
-	 *
-	 * RFC 5880, Section 6.5.
-	 */
-	BFD_SETFBIT(cp.flags, fbit);
-	if (fbit == 0)
-		BFD_SETPBIT(cp.flags, bfd->polling);
-
-	cp.detect_mult = bfd->detect_mult;
-	cp.len = BFD_PKT_LEN;
-	cp.discrs.my_discr = htonl(bfd->discrs.my_discr);
-	cp.discrs.remote_discr = htonl(bfd->discrs.remote_discr);
-	if (bfd->polling) {
-		cp.timers.desired_min_tx =
-			htonl(bfd->timers.desired_min_tx);
-		cp.timers.required_min_rx =
-			htonl(bfd->timers.required_min_rx);
+	if ((true == bfd->bfd_tx_pkt_stored) &&
+		(bfd->ses_state == PTM_BFD_UP) && (!bfd->polling) && (!fbit)) {
+		pst_bfd_pkt = &(bfd->bfd_tx_pkt);
 	} else {
-		/*
-		 * We can only announce current setting on poll, this
-		 * avoids timing mismatch with our peer and give it
-		 * the oportunity to learn. See `bs_final_handler` for
-		 * more information.
-		 */
-		cp.timers.desired_min_tx =
-			htonl(bfd->cur_timers.desired_min_tx);
-		cp.timers.required_min_rx =
-			htonl(bfd->cur_timers.required_min_rx);
-	}
-	cp.timers.required_min_echo = htonl(bfd->timers.required_min_echo);
+		/* Set fields according to section 6.5.7 */
+		cp.diag = bfd->local_diag;
+		BFD_SETVER(cp.diag, BFD_VERSION);
+		cp.flags = 0;
+		BFD_SETSTATE(cp.flags, bfd->ses_state);
 
-	if (_ptm_bfd_send(bfd, NULL, &cp, BFD_PKT_LEN) != 0)
+		if (BFD_CHECK_FLAG(bfd->flags, BFD_SESS_FLAG_CBIT))
+			BFD_SETCBIT(cp.flags, BFD_CBIT);
+
+		BFD_SETDEMANDBIT(cp.flags, BFD_DEF_DEMAND);
+
+		/*
+		 * Polling and Final can't be set at the same time.
+		 *
+		 * RFC 5880, Section 6.5.
+		 */
+		BFD_SETFBIT(cp.flags, fbit);
+		if (fbit == 0)
+			BFD_SETPBIT(cp.flags, bfd->polling);
+
+		cp.detect_mult = bfd->detect_mult;
+		cp.len = BFD_PKT_LEN;
+		cp.discrs.my_discr = htonl(bfd->discrs.my_discr);
+		cp.discrs.remote_discr = htonl(bfd->discrs.remote_discr);
+		if (bfd->polling) {
+			cp.timers.desired_min_tx =
+				htonl(bfd->timers.desired_min_tx);
+			cp.timers.required_min_rx =
+				htonl(bfd->timers.required_min_rx);
+		} else {
+			/*
+			 * We can only announce current setting on poll, this
+			 * avoids timing mismatch with our peer and give it
+			 * the oportunity to learn. See `bs_final_handler` for
+			 * more information.
+			 */
+			cp.timers.desired_min_tx =
+				htonl(bfd->cur_timers.desired_min_tx);
+			cp.timers.required_min_rx =
+				htonl(bfd->cur_timers.required_min_rx);
+		}
+
+		cp.timers.required_min_echo = htonl(bfd->timers.required_min_echo);
+
+		pst_bfd_pkt = &cp;
+
+		if ((BFD_GETSTATE(cp.flags) == PTM_BFD_UP) &&
+				(!bfd->polling) && !(fbit)) {
+			memcpy(&(bfd->bfd_tx_pkt), pst_bfd_pkt,
+			       sizeof(struct bfd_pkt));
+			bfd->bfd_tx_pkt_stored = true;
+		}
+	}
+
+	if (_ptm_bfd_send(bfd, NULL, pst_bfd_pkt, BFD_PKT_LEN) != 0)
 		return;
 
 	bfd->stats.tx_ctrl_pkt++;
@@ -431,7 +447,8 @@ ssize_t bfd_recv_ipv6(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
 				local->sa_sin6.sin6_family = AF_INET6;
 				local->sa_sin6.sin6_addr = pi6->ipi6_addr;
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
-				local->sa_sin6.sin6_len = sizeof(local->sa_sin6);
+				local->sa_sin6.sin6_len =
+						sizeof(local->sa_sin6);
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 
 				*ifindex = pi6->ipi6_ifindex;
@@ -442,7 +459,8 @@ ssize_t bfd_recv_ipv6(int sd, uint8_t *msgbuf, size_t msgbuflen, uint8_t *ttl,
 					peer->sa_sin6.sin6_scope_id = *ifindex;
 				if (IN6_IS_ADDR_LINKLOCAL(
 					    &local->sa_sin6.sin6_addr))
-					local->sa_sin6.sin6_scope_id = *ifindex;
+					local->sa_sin6.sin6_scope_id =
+								*ifindex;
 			}
 		}
 	}

--- a/bfdd/bfdd_vty.c
+++ b/bfdd/bfdd_vty.c
@@ -142,8 +142,12 @@ static void _display_peer(struct vty *vty, struct bfd_session *bs)
 
 	vty_out(vty, "\t\tDiagnostics: %s\n", diag2str(bs->local_diag));
 	vty_out(vty, "\t\tRemote diagnostics: %s\n", diag2str(bs->remote_diag));
+	vty_out(vty, "\t\tPeer Type: %s\n",
+		BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG) ? "configured" : "dynamic");
 
 	vty_out(vty, "\t\tLocal timers:\n");
+	vty_out(vty, "\t\t\tDetect-multiplier: %" PRIu32 "\n",
+		bs->detect_mult);
 	vty_out(vty, "\t\t\tReceive interval: %" PRIu32 "ms\n",
 		bs->timers.required_min_rx / 1000);
 	vty_out(vty, "\t\t\tTransmission interval: %" PRIu32 "ms\n",
@@ -152,6 +156,8 @@ static void _display_peer(struct vty *vty, struct bfd_session *bs)
 		bs->timers.required_min_echo / 1000);
 
 	vty_out(vty, "\t\tRemote timers:\n");
+	vty_out(vty, "\t\t\tDetect-multiplier: %" PRIu32 "\n",
+		bs->remote_detect_mult);
 	vty_out(vty, "\t\t\tReceive interval: %" PRIu32 "ms\n",
 		bs->remote_timers.required_min_rx / 1000);
 	vty_out(vty, "\t\t\tTransmission interval: %" PRIu32 "ms\n",
@@ -235,12 +241,16 @@ static struct json_object *__display_peer_json(struct bfd_session *bs)
 	else
 		json_object_int_add(jo, "echo-interval", 0);
 
+	json_object_int_add(jo, "detect-multiplier", bs->detect_mult);
+
 	json_object_int_add(jo, "remote-receive-interval",
 			    bs->remote_timers.required_min_rx / 1000);
 	json_object_int_add(jo, "remote-transmit-interval",
 			    bs->remote_timers.desired_min_tx / 1000);
 	json_object_int_add(jo, "remote-echo-interval",
 			    bs->remote_timers.required_min_echo / 1000);
+	json_object_int_add(jo, "remote-detect-multiplier",
+			    bs->remote_detect_mult);
 
 	return jo;
 }
@@ -305,9 +315,8 @@ static void _display_peer_json_iter(struct hash_bucket *hb, void *arg)
 static void _display_all_peers(struct vty *vty, char *vrfname, bool use_json)
 {
 	struct json_object *jo;
-	struct bfd_vrf_tuple bvt;
+	struct bfd_vrf_tuple bvt = {0};
 
-	memset(&bvt, 0, sizeof(bvt));
 	bvt.vrfname = vrfname;
 
 	if (!use_json) {
@@ -413,12 +422,12 @@ static void _display_peer_counter_json_iter(struct hash_bucket *hb, void *arg)
 	json_object_array_add(jo, jon);
 }
 
-static void _display_peers_counter(struct vty *vty, char *vrfname, bool use_json)
+static void _display_peers_counter(struct vty *vty, char *vrfname,
+				   bool use_json)
 {
 	struct json_object *jo;
-	struct bfd_vrf_tuple bvt;
+	struct bfd_vrf_tuple bvt = {0};
 
-	memset(&bvt, 0, sizeof(struct bfd_vrf_tuple));
 	bvt.vrfname = vrfname;
 	if (!use_json) {
 		bvt.vty = vty;
@@ -430,6 +439,95 @@ static void _display_peers_counter(struct vty *vty, char *vrfname, bool use_json
 	jo = json_object_new_array();
 	bvt.jo = jo;
 	bfd_id_iterate(_display_peer_counter_json_iter, jo);
+
+	vty_out(vty, "%s\n", json_object_to_json_string_ext(jo, 0));
+	json_object_free(jo);
+}
+
+static void _clear_peer_counter(struct bfd_session *bs)
+{
+	/* Clear only pkt stats, intention is not to loose system
+	 * events counters
+	 */
+	bs->stats.rx_ctrl_pkt = 0;
+	bs->stats.tx_ctrl_pkt = 0;
+	bs->stats.rx_echo_pkt = 0;
+	bs->stats.tx_echo_pkt = 0;
+}
+
+static void _display_peer_brief(struct vty *vty, struct bfd_session *bs)
+{
+	char addr_buf[INET6_ADDRSTRLEN];
+
+	if (BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH)) {
+		vty_out(vty, "%-10u", bs->discrs.my_discr);
+		inet_ntop(bs->key.family, &bs->key.local, addr_buf,
+			  sizeof(addr_buf));
+		vty_out(vty, " %-40s", addr_buf);
+		inet_ntop(bs->key.family, &bs->key.peer, addr_buf,
+			  sizeof(addr_buf));
+		vty_out(vty, " %-40s", addr_buf);
+		vty_out(vty, "%-15s\n", state_list[bs->ses_state].str);
+	} else {
+		vty_out(vty, "%-10u", bs->discrs.my_discr);
+		vty_out(vty, " %-40s", satostr(&bs->local_address));
+		inet_ntop(bs->key.family, &bs->key.peer, addr_buf,
+			  sizeof(addr_buf));
+		vty_out(vty, " %-40s", addr_buf);
+
+		vty_out(vty, "%-15s\n", state_list[bs->ses_state].str);
+	}
+}
+
+static void _display_peer_brief_iter(struct hash_backet *hb, void *arg)
+{
+	struct bfd_vrf_tuple *bvt = arg;
+	struct vty *vty;
+	struct bfd_session *bs = hb->data;
+
+	if (!bvt)
+		return;
+	vty = bvt->vty;
+
+	if (bvt->vrfname) {
+		if (!bs->key.vrfname[0] ||
+			!strmatch(bs->key.vrfname, bvt->vrfname))
+			return;
+	}
+
+	_display_peer_brief(vty, bs);
+}
+
+static void _display_peers_brief(struct vty *vty, char *vrfname,
+				 bool use_json)
+{
+	struct json_object *jo;
+	struct bfd_vrf_tuple bvt = {0};
+
+	bvt.vrfname = vrfname;
+
+	if (use_json == false) {
+		bvt.vty = vty;
+
+		vty_out(vty, "Session count: %lu\n", bfd_get_session_count());
+		vty_out(vty, "%-10s", "SessionId");
+		vty_out(vty, " %-40s", "LocalAddress");
+		vty_out(vty, " %-40s", "PeerAddress");
+		vty_out(vty, "%-15s\n", "Status");
+
+		vty_out(vty, "%-10s", "=========");
+		vty_out(vty, " %-40s", "============");
+		vty_out(vty, " %-40s", "===========");
+		vty_out(vty, "%-15s\n", "======");
+
+		bfd_id_iterate(_display_peer_brief_iter, &bvt);
+		return;
+	}
+
+	jo = json_object_new_array();
+	bvt.jo = jo;
+
+	bfd_id_iterate(_display_peer_json_iter, &bvt);
 
 	vty_out(vty, "%s\n", json_object_to_json_string_ext(jo, 0));
 	json_object_free(jo);
@@ -596,6 +694,56 @@ DEFPY(bfd_show_peers_counters, bfd_show_peers_counters_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFPY(bfd_clear_peer_counters, bfd_clear_peer_counters_cmd,
+      "clear bfd [vrf <NAME$vrfname>] peer <WORD$label|<A.B.C.D|X:X::X:X>$peer [{multihop|local-address <A.B.C.D|X:X::X:X>$local|interface IFNAME$ifname}]> counters",
+      SHOW_STR
+      "Bidirection Forwarding Detection\n"
+      VRF_CMD_HELP_STR
+      "BFD peers status\n"
+      "Peer label\n"
+      PEER_IPV4_STR
+      PEER_IPV6_STR
+      MHOP_STR
+      LOCAL_STR
+      LOCAL_IPV4_STR
+      LOCAL_IPV6_STR
+      INTERFACE_STR
+      LOCAL_INTF_STR
+      "clear BFD peer counters information\n")
+{
+	struct bfd_session *bs;
+
+	/* Look up the BFD peer. */
+	bs = _find_peer_or_error(vty, argc, argv, label, peer_str, local_str,
+				 ifname, vrfname);
+
+	if (bs == NULL)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	_clear_peer_counter(bs);
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(bfd_show_peers_brief, bfd_show_peers_brief_cmd,
+      "show bfd [vrf <NAME$vrfname>] peers brief [json]",
+      SHOW_STR
+      "Bidirection Forwarding Detection\n"
+      VRF_CMD_HELP_STR
+      "BFD peers status\n"
+      "Show BFD peer information in tabular form\n"
+      JSON_STR)
+{
+	char *vrf_name = NULL;
+	int idx_vrf = 0;
+
+	if (argv_find(argv, argc, "vrf", &idx_vrf))
+		vrf_name = argv[idx_vrf + 1]->arg;
+
+	_display_peers_brief(vty, vrf_name, use_json(argc, argv));
+
+	return CMD_SUCCESS;
+}
 
 /*
  * Function definitions.
@@ -680,14 +828,16 @@ static int bfd_configure_peer(struct bfd_peer_cfg *bpc, bool mhop,
 	/* Handle VRF configuration. */
 	if (vrfname) {
 		bpc->bpc_has_vrfname = true;
-		if (strlcpy(bpc->bpc_vrfname, vrfname, sizeof(bpc->bpc_vrfname))
+		if (strlcpy(bpc->bpc_vrfname, vrfname,
+			    sizeof(bpc->bpc_vrfname))
 		    > sizeof(bpc->bpc_vrfname)) {
 			snprintf(ebuf, ebuflen, "vrf name too long");
 			return -1;
 		}
 	} else {
 		bpc->bpc_has_vrfname = true;
-		strlcpy(bpc->bpc_vrfname, VRF_DEFAULT_NAME, sizeof(bpc->bpc_vrfname));
+		strlcpy(bpc->bpc_vrfname, VRF_DEFAULT_NAME,
+			sizeof(bpc->bpc_vrfname));
 	}
 
 	return 0;
@@ -735,8 +885,10 @@ void bfdd_vty_init(void)
 {
 	install_element(ENABLE_NODE, &bfd_show_peers_counters_cmd);
 	install_element(ENABLE_NODE, &bfd_show_peer_counters_cmd);
+	install_element(ENABLE_NODE, &bfd_clear_peer_counters_cmd);
 	install_element(ENABLE_NODE, &bfd_show_peers_cmd);
 	install_element(ENABLE_NODE, &bfd_show_peer_cmd);
+	install_element(ENABLE_NODE, &bfd_show_peers_brief_cmd);
 	install_element(ENABLE_NODE, &show_debugging_bfd_cmd);
 
 	/* Install BFD node and commands. */

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -465,6 +465,8 @@ static void bfdd_dest_deregister(struct stream *msg, vrf_id_t vrf_id)
 	    BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_CONFIG))
 		return;
 
+	bfd_clear_stored_pkt(bs);
+
 	bs->ses_state = PTM_BFD_ADM_DOWN;
 	ptm_bfd_snd(bs, 0);
 


### PR DESCRIPTION
This pull request is for below changes:

1. Adding 2 two new fields
     - Peer type, configured/dynamic
     - Detect multiplier
2. Added new command "clear bfd counters"

3. Added new command "show bfd peers brief"

Signed-off-by: Sayed Mohd Saquib <sayed.saquib@broadcom.com>