### PR TITLE
bfdd: Fixing coredump in log

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1432,7 +1432,7 @@ struct bfd_session *bfd_key_lookup(struct bfd_key key)
 	if (ctx.result) {
 		bsp = ctx.result;
 		log_debug(" peer %s found, but ifp"
-			  " and/or loc-addr params ignored");
+			  " and/or loc-addr params ignored", peer_buf);
 	}
 	return bsp;
 }


### PR DESCRIPTION
Param missing in debug log, leading to coredump

Signed-off-by: Sayed Mohd Saquib <sayed.saquib@broadcom.com>