### PR TITLE
bgpd: evpn fix advertise-svi-ip display in show commands

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -358,6 +358,9 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 		json_object_string_add(json, "originatorIp",
 				       inet_ntoa(bgp_vrf->originator_ip));
 		json_object_string_add(json, "advertiseGatewayMacip", "n/a");
+		json_object_string_add(json, "advertiseSviMacip", "n/a");
+		json_object_to_json_string_ext(json,
+					       JSON_C_TO_STRING_NOSLASHESCAPE);
 	} else {
 		vty_out(vty, "VNI: %d", bgp_vrf->l3vni);
 		vty_out(vty, " (known to the kernel)");
@@ -371,6 +374,7 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 		vty_out(vty, "  Originator IP: %s\n",
 			inet_ntoa(bgp_vrf->originator_ip));
 		vty_out(vty, "  Advertise-gw-macip : %s\n", "n/a");
+		vty_out(vty, "  Advertise-svi-macip : %s\n", "n/a");
 	}
 
 	if (!json)
@@ -477,6 +481,8 @@ static void display_vni(struct vty *vty, struct bgpevpn *vpn, json_object *json)
 				inet_ntoa(vpn->mcast_grp));
 		json_object_string_add(json, "advertiseGatewayMacip",
 				       vpn->advertise_gw_macip ? "Yes" : "No");
+		json_object_string_add(json, "advertiseSviMacip",
+				       vpn->advertise_svi_macip ? "Yes" : "No");
 	} else {
 		vty_out(vty, "VNI: %d", vpn->vni);
 		if (is_vni_live(vpn))
@@ -3587,6 +3593,9 @@ DEFUN(show_bgp_l2vpn_evpn_vni,
 					       bgp_evpn->advertise_gw_macip
 						       ? "Enabled"
 						       : "Disabled");
+			json_object_string_add(json, "advertiseSviMacip",
+					bgp_evpn->evpn_info->advertise_svi_macip
+					? "Enabled" : "Disabled");
 			json_object_string_add(json, "advertiseAllVnis",
 					       is_evpn_enabled() ? "Enabled"
 								 : "Disabled");


### PR DESCRIPTION
 1) Fix advertise-gw-macip and advertise-svi-macip fields to display as enabled at per vni output
when global knob is enabled.

 ```
    TOR1#show running-config bgpd
    router bgp 5587
     ...
     address-family l2vpn evpn
      advertise-all-vni
      advertise-svi-ip
    ...

    TOR1# show bgp l2vpn evpn vni 1004 json
    {
      "vni":1004,
      "type":"L2",
      "kernelFlag":"Yes",
      "rd":"37.0.1.11:7",
      "originatorIp":"37.0.1.11",
      "mcastGroup":"0.0.0.0",
      "advertiseGatewayMacip":"No",
      "advertiseSviMacip":"Yes",
      "importRts":[
        "5587:1004"
      ],
      "exportRts":[
        "5587:1004"
      ]
    }
````


2)    add advertise-svi-macip value in json output

  Testing Done:
```
    TOR1# show bgp l2vpn evpn vni 1004  json
    {
      "vni":1004,
      "type":"L2",
      "kernelFlag":"Yes",
      "rd":"37.0.1.11:7",
      "originatorIp":"37.0.1.11",
      "mcastGroup":"0.0.0.0",
      "advertiseGatewayMacip":"No",
      "advertiseSviMacip":"No",
      "importRts":[
        "5587:1004"
      ],
      "exportRts":[
        "5587:1004"
      ]
    }
``` 