### PR TITLE
build: Fix Docker based Alpine build

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -13,13 +13,13 @@ makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     c-ares c-ares-dev ca-certificates cryptsetup-libs curl
     device-mapper-libs expat fakeroot flex fortify-headers gdbm
     git gmp isl json-c-dev kmod lddtree libacl libatomic libattr
-    libblkid libburn libbz2 libc-dev libcap libcurl libedit libffi libgcc
+    libblkid libburn libbz2 libc-dev libcap-dev libcurl libedit libffi libgcc
     libgomp libisoburn libisofs libltdl libressl libssh2
     libstdc++ libtool libuuid libyang-dev linux-headers lzip lzo m4 make mkinitfs mpc1
     mpfr3 mtools musl-dev ncurses-libs ncurses-terminfo ncurses-terminfo-base
     patch pax-utils pcre perl pkgconf python2 python2-dev readline
     readline-dev sqlite-libs squashfs-tools sudo tar texinfo xorriso xz-libs
-    py-sphinx rtrlib rtrlib-dev"
+    py-pip py-sphinx rtrlib rtrlib-dev"
 checkdepends="pytest py-setuptools"
 install="$pkgname.pre-install $pkgname.pre-deinstall $pkgname.post-deinstall"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg"

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -9,7 +9,8 @@ RUN source /src/alpine/APKBUILD.in \
 		--no-cache \
 		--update-cache \
 		$makedepends \
-		gzip
+		gzip \
+	&& pip install pytest
 
 COPY . /src
 ARG PKGVER

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -29,6 +29,8 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/reposit
 		abuild \
 		alpine-conf \
 		alpine-sdk \
+		py-pip \
+	&& pip install pytest \
 	&& setup-apkcache /var/cache/apk \
 	&& mkdir -p /pkgs/apk \
 	&& echo 'builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Added pip and installed pytest to in the `source-builder` stage and in the `alpine-builder` stage. Additionally replaced `libcap` with `libcap-dev` which is required to build from source successfully.

Resolves: #5035 