### PR TITLE
isisd: fix crash during candidate validation

### DIFF
--- a/isisd/isis_northbound.c
+++ b/isisd/isis_northbound.c
@@ -1542,9 +1542,9 @@ static int lib_interface_isis_create(enum nb_event event,
 		/* check if interface mtu is sufficient. If the area has not
 		 * been created yet, assume default MTU for the area
 		 */
-		ifp = nb_running_get_entry(dnode, NULL, true);
+		ifp = nb_running_get_entry(dnode, NULL, false);
 		/* zebra might not know yet about the MTU - nothing we can do */
-		if (ifp->mtu == 0)
+		if (!ifp || ifp->mtu == 0)
 			break;
 		actual_mtu =
 			if_is_broadcast(ifp) ? ifp->mtu - LLC_LEN : ifp->mtu;


### PR DESCRIPTION
The "abort_if_not_found" parameter of nb_running_get_entry()
should be set to true only when this function is called during the
NB_EV_APPLY phase of a northbound callback. Failure to respect this
can lead to crashes when multiple configuration changes are being
committed at the same time.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>