### PR TITLE
pimd: Mark Default TOS Values for PIM & IGMP Outgoing packets

### DIFF
--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -574,6 +574,7 @@ int pim_msg_send(int fd, struct in_addr src, struct in_addr dst,
 	ip->ip_id = htons(++ip_id);
 	ip->ip_hl = 5;
 	ip->ip_v = 4;
+	ip->ip_tos = IPTOS_PREC_INTERNETCONTROL;
 	ip->ip_p = PIM_IP_PROTO_PIM;
 	ip->ip_src = src;
 	ip->ip_dst = dst;

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -255,6 +255,12 @@ int pim_socket_mcast(int protocol, struct in_addr ifaddr, struct interface *ifp,
 		}
 	}
 
+	/* Set Tx socket DSCP byte */
+	if (setsockopt_ipv4_tos(fd, IPTOS_PREC_INTERNETCONTROL)) {
+		zlog_warn("can't set sockopt IP_TOS to PIM/IGMP socket %d: %s",
+			  fd, safe_strerror(errno));
+	}
+
 	return fd;
 }
 


### PR DESCRIPTION
This will facilitate the Hardware to prefer control packets over
Normal Data packets while queuing, so that during congestion, the
chance of dropping control packet will be minimised.

Signed-off-by: Satheesh Kumar K <sathk@cumulusnetworks.com>