### PR TITLE
7.2 bgpd: rmap_type is 8 bit but we have 9 bits of flags

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1202,7 +1202,7 @@ struct peer {
 	uint8_t last_reset_cause[BGP_MAX_PACKET_SIZE];
 
 	/* The kind of route-map Flags.*/
-	uint8_t rmap_type;
+	uint16_t rmap_type;
 #define PEER_RMAP_TYPE_IN             (1 << 0) /* neighbor route-map in */
 #define PEER_RMAP_TYPE_OUT            (1 << 1) /* neighbor route-map out */
 #define PEER_RMAP_TYPE_NETWORK        (1 << 2) /* network route-map */


### PR DESCRIPTION
The newly added PEER_RMAP_TYPE_AGGREGATE flag is setup to
be the 9th bit:

But the flag we are putting it into:
uint8_t rmap_type;

is 8 bits.  Adjust the size.

Found by Coverity SA Scan
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>