### PR TITLE
zebra: fix memory leak

### DIFF
--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -261,8 +261,10 @@ struct interface *if_lookup_by_name_per_ns(struct zebra_ns *ns,
 
 	for (rn = route_top(ns->if_table); rn; rn = route_next(rn)) {
 		ifp = (struct interface *)rn->info;
-		if (ifp && strcmp(ifp->name, ifname) == 0)
+		if (ifp && strcmp(ifp->name, ifname) == 0) {
+			route_unlock_node(rn);
 			return (ifp);
+		}
 	}
 
 	return NULL;


### PR DESCRIPTION
the if_lookup_by_name_per_ns keeps a lock on the node where the
searched ifp is stored. Then this node can not be freed even if
the ifp is removed from the node. Just add the missing unlock
(as for the if_lookup_by_index_per_ns lookup function)

Fixes: b8af3fbbafc8 ("zebra: fix detection of interface renames")
Signed-off-by: Thibaut Collet <thibaut.collet@6wind.com>
Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>