### PR TITLE
zebra: handle config write for dataplane values

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2511,6 +2511,18 @@ int dplane_show_provs_helper(struct vty *vty, bool detailed)
 }
 
 /*
+ * Helper for 'show run' etc.
+ */
+int dplane_config_write_helper(struct vty *vty)
+{
+	if (zdplane_info.dg_max_queued_updates != DPLANE_DEFAULT_MAX_QUEUED)
+		vty_out(vty, "zebra dplane limit %u\n",
+			zdplane_info.dg_max_queued_updates);
+
+	return 0;
+}
+
+/*
  * Provider registration
  */
 int dplane_provider_register(const char *name,

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -455,6 +455,7 @@ uint32_t dplane_get_in_queue_len(void);
  */
 int dplane_show_helper(struct vty *vty, bool detailed);
 int dplane_show_provs_helper(struct vty *vty, bool detailed);
+int dplane_config_write_helper(struct vty *vty);
 
 /*
  * Dataplane providers: modules that process or consume dataplane events.

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2655,6 +2655,10 @@ static int config_write_protocol(struct vty *vty)
 								      == MCAST_MIX_DISTANCE
 							      ? "lower-distance"
 							      : "longer-prefix");
+
+	/* Include dataplane info */
+	dplane_config_write_helper(vty);
+
 	return 1;
 }
 


### PR DESCRIPTION
Add the (single) dataplane config value to the output of config write, 'show run' - missed this during dplane development - sorry about that!

Here's an example showing the result:
```
mjs-uvm18(config)# do sho run
Building configuration...

Current configuration:
!
frr version 7.2-dev-MJS
frr defaults traditional
hostname mjs-uvm18
!
line vty
!
end
mjs-uvm18(config)#  zebra dplane limit 2
mjs-uvm18(config)# do sho run
Building configuration...

Current configuration:
!
frr version 7.2-dev-MJS
frr defaults traditional
hostname mjs-uvm18
zebra dplane limit 2
!
line vty
!
end
mjs-uvm18(config)# no zebra dplane limit 2
mjs-uvm18(config)# do sho run
Building configuration...

Current configuration:
!
frr version 7.2-dev-MJS
frr defaults traditional
hostname mjs-uvm18
!
line vty
!
end
mjs-uvm18(config)#
```