### PR TITLE
[7.2] zebra: add dataplane variables to show run

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2499,6 +2499,18 @@ int dplane_show_provs_helper(struct vty *vty, bool detailed)
 }
 
 /*
+ * Helper for 'show run' etc.
+ */
+int dplane_config_write_helper(struct vty *vty)
+{
+	if (zdplane_info.dg_max_queued_updates != DPLANE_DEFAULT_MAX_QUEUED)
+		vty_out(vty, "zebra dplane limit %u\n",
+			zdplane_info.dg_max_queued_updates);
+
+	return 0;
+}
+
+/*
  * Provider registration
  */
 int dplane_provider_register(const char *name,

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -452,6 +452,7 @@ uint32_t dplane_get_in_queue_len(void);
  */
 int dplane_show_helper(struct vty *vty, bool detailed);
 int dplane_show_provs_helper(struct vty *vty, bool detailed);
+int dplane_config_write_helper(struct vty *vty);
 
 /*
  * Dataplane providers: modules that process or consume dataplane events.

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2651,6 +2651,10 @@ static int config_write_protocol(struct vty *vty)
 								      == MCAST_MIX_DISTANCE
 							      ? "lower-distance"
 							      : "longer-prefix");
+
+	/* Include dataplane info */
+	dplane_config_write_helper(vty);
+
 	return 1;
 }
 


### PR DESCRIPTION
[7.2 version] Add the dataplane configurables to the output of 'show run'.