### PR TITLE
zebra: fix evpn prefix-routes-only for default vrf

### DIFF
--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -487,7 +487,11 @@ static int vrf_config_write(struct vty *vty)
 
 		if (zvrf_id(zvrf) == VRF_DEFAULT) {
 			if (zvrf->l3vni)
-				vty_out(vty, "vni %u\n", zvrf->l3vni);
+				vty_out(vty, "vni %u%s\n", zvrf->l3vni,
+					is_l3vni_for_prefix_routes_only(
+						zvrf->l3vni)
+						? " prefix-routes-only"
+						: "");
 			if (zvrf->zebra_rnh_ip_default_route)
 				vty_out(vty, "ip nht resolve-via-default\n");
 


### PR DESCRIPTION
asymmetric routing default vrf vni configuration is not displayed as part of running-config.

Testing Done:

T11# config t
T11(config)# vni 4004 prefix-routes-only
T11(config)# end

Before:

T11# show running-config
...
vni 4004
...

After:

T11# show running-config
...
vni 4004 prefix-routes-only
...

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>