### PR TITLE
bgpd: aggregate-address A.B.C.D A.B.C.D summary-only was missreading …

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6562,6 +6562,7 @@ DEFUN (aggregate_address_mask,
 	argv_find(argv, argc, "A.B.C.D", &idx);
 	char *prefix = argv[idx]->arg;
 	char *mask = argv[idx + 1]->arg;
+	bool rmap_found;
 	char *rmap = NULL;
 	int as_set =
 		argv_find(argv, argc, "as-set", &idx) ? AGGREGATE_AS_SET : 0;
@@ -6570,8 +6571,8 @@ DEFUN (aggregate_address_mask,
 				   ? AGGREGATE_SUMMARY_ONLY
 				   : 0;
 
-	argv_find(argv, argc, "WORD", &idx);
-	if (idx)
+	rmap_found = argv_find(argv, argc, "WORD", &idx);
+	if (rmap_found)
 		rmap = argv[idx]->arg;
 
 	char prefix_str[BUFSIZ];


### PR DESCRIPTION
…config

The `aggregate-address 30.0.5.0 255.255.255.0 summary-only` command
was missreading the inputed data and translating it into:

`aggregate-address 30.0.5.0/24 summary-only route-map summary-only`

This is not quite correct.  Fix this behavior:

donna.cumulusnetworks.com# conf
donna.cumulusnetworks.com(config)# router bgp
donna.cumulusnetworks.com(config-router)# aggregate-address 30.0.5.0 255.255.255.0 summary-only
donna.cumulusnetworks.com(config-router)# do show run
Building configuration...

Current configuration:
!
frr version 7.3-dev
frr defaults datacenter
hostname donna.cumulusnetworks.com
log file /var/log/frr/frr.log
no ipv6 forwarding
frr version 7.2-dev
!
router bgp 500
 neighbor 192.168.209.1 remote-as external
 neighbor 192.168.209.1 ebgp-multihop 255
 neighbor 192.168.210.1 remote-as external
 !
 address-family ipv4 unicast
  network 192.168.9.0/24
  network 192.168.10.0/24
  aggregate-address 30.0.5.0/24 summary-only
 exit-address-family
!

Issue: #5054
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>