### PR TITLE
bgpd: [7.2] aggregate-address X:X::X:X/M summary-only was missreading config

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6628,6 +6628,7 @@ DEFUN (ipv6_aggregate_address,
 	argv_find(argv, argc, "X:X::X:X/M", &idx);
 	char *prefix = argv[idx]->arg;
 	char *rmap = NULL;
+	bool rmap_found;
 	int as_set =
 		argv_find(argv, argc, "as-set", &idx) ? AGGREGATE_AS_SET : 0;
 
@@ -6636,8 +6637,8 @@ DEFUN (ipv6_aggregate_address,
 			       ? AGGREGATE_SUMMARY_ONLY
 			       : 0;
 
-	argv_find(argv, argc, "WORD", &idx);
-	if (idx)
+	rmap_found = argv_find(argv, argc, "WORD", &idx);
+	if (rmap_found)
 		rmap = argv[idx]->arg;
 
 	return bgp_aggregate_set(vty, prefix, AFI_IP6, SAFI_UNICAST, rmap,


### PR DESCRIPTION
Entering:
aggregate-address 2a02:4780::/48 summary-only

Will transform this to:
aggregate-address 2a02:4780::/48 summary-only route-map summary-only

This patch fixes that.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>