### PR TITLE
7.2: zebra: if_is_loopback_or_vrf crash if if_lookup_by_index return …

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1046,14 +1046,18 @@ static struct route_entry *rib_choose_best(struct route_entry *current,
 		struct nexthop *nexthop = NULL;
 
 		for (ALL_NEXTHOPS(alternate->ng, nexthop)) {
-			if (if_is_loopback_or_vrf(if_lookup_by_index(
-				    nexthop->ifindex, alternate->vrf_id)))
+			struct interface *ifp = if_lookup_by_index(
+				nexthop->ifindex, alternate->vrf_id);
+
+			if (ifp && if_is_loopback_or_vrf(ifp))
 				return alternate;
 		}
 
 		for (ALL_NEXTHOPS(current->ng, nexthop)) {
-			if (if_is_loopback_or_vrf(if_lookup_by_index(
-				    nexthop->ifindex, current->vrf_id)))
+			struct interface *ifp = if_lookup_by_index(
+				nexthop->ifindex, current->vrf_id);
+
+			if (ifp && if_is_loopback_or_vrf(ifp))
 				return current;
 		}
 


### PR DESCRIPTION
…NULL

Function if_lookup_by_index() can return NULL, but in if_is_loopback_or_vrf() we don't chech NULL and get next:

Sep 2 07:44:34 XXX zebra[4616]: /usr/lib64/libfrr.so.0(zlog_backtrace_sigsafe+0x48) [0x7fb5f704cf18]
Sep 2 07:44:34 XXX zebra[4616]: /usr/lib64/libfrr.so.0(zlog_signal+0x378) [0x7fb5f704d728]
Sep 2 07:44:34 XXX zebra[4616]: /usr/lib64/libfrr.so.0(+0x6b495) [0x7fb5f706b495]
Sep 2 07:44:34 XXX zebra[4616]: /lib64/libpthread.so.0(+0x123b0) [0x7fb5f6d573b0]
Sep 2 07:44:34 XXX zebra[4616]: /usr/lib64/libfrr.so.0(if_is_loopback+0) [0x7fb5f7045160]
Sep 2 07:44:34 XXX zebra[4616]: /usr/lib64/libfrr.so.0(if_is_loopback_or_vrf+0x11) [0x7fb5f7045191]
Sep 2 07:44:34 XXX zebra[4616]: /usr/sbin/zebra() [0x43b26d]
Sep 2 07:44:34 XXX zebra[4616]: /usr/sbin/zebra() [0x43db6f]
Sep 2 07:44:34 XXX zebra[4616]: /usr/lib64/libfrr.so.0(work_queue_run+0xc8) [0x7fb5f7080de8]
Sep 2 07:44:34 XXX zebra[4616]: /usr/lib64/libfrr.so.0(thread_call+0x47) [0x7fb5f7077d27]
Sep 2 07:44:34 XXX zebra[4616]: /usr/lib64/libfrr.so.0(frr_run+0xd8) [0x7fb5f704b448]

Signed-off-by: Dmitrii Turlupov dturlupov@factor-ts.ru