### PR TITLE
zebra: during shutdown processing, drop dplane results

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -142,6 +142,9 @@ static void sigint(void)
 
 	zlog_notice("Terminating on signal");
 
+	atomic_store_explicit(&zrouter.in_shutdown, true,
+			      memory_order_relaxed);
+
 	frr_early_fini();
 
 	zebra_dplane_pre_finish();

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -3204,6 +3204,7 @@ static int rib_process_dplane_results(struct thread *thread)
 {
 	struct zebra_dplane_ctx *ctx;
 	struct dplane_ctx_q ctxlist;
+	bool shut_p = false;
 
 	/* Dequeue a list of completed updates with one lock/unlock cycle */
 
@@ -3222,6 +3223,21 @@ static int rib_process_dplane_results(struct thread *thread)
 		/* If we've emptied the results queue, we're done */
 		if (ctx == NULL)
 			break;
+
+		/* If zebra is shutting down, avoid processing results,
+		 * just drain the results queue.
+		 */
+		shut_p = atomic_load_explicit(&zrouter.in_shutdown,
+					      memory_order_relaxed);
+		if (shut_p) {
+			while (ctx) {
+				dplane_ctx_fini(&ctx);
+
+				ctx = dplane_ctx_dequeue(&ctxlist);
+			}
+
+			continue;
+		}
 
 		while (ctx) {
 			switch (dplane_ctx_get_op(ctx)) {

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -74,6 +74,8 @@ struct zebra_mlag_info {
 };
 
 struct zebra_router {
+	atomic_bool in_shutdown;
+
 	/* Thread master */
 	struct thread_master *master;
 


### PR DESCRIPTION
Don't process dataplane results in zebra during shutdown (after sigint has been seen). The dplane continues to run in order to clean up, but the zebra main pthread just drops results. There was a report about some dataplane results that were being processed during shutdown where some of the zebra internal data structs had been freed; this is one, fairly simple, try at preventing that.
