### PR TITLE
isisd: Fix handling of neighbor circuit id in three way handshake

### DIFF
--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -187,7 +187,7 @@ static int process_p2p_hello(struct iih_info *iih)
 		adj->sys_type = ISIS_SYSTYPE_UNKNOWN;
 	}
 
-	if (tw_adj && adj->threeway_state == ISIS_THREEWAY_DOWN)
+	if (tw_adj)
 		adj->ext_circuit_id = tw_adj->local_circuit_id;
 
 	/* 8.2.6 Monitoring point-to-point adjacencies */


### PR DESCRIPTION
RFC 5303 states:

      If the system ID and Extended Local Circuit ID of the neighboring
      system are known (in adjacency three-way state Initializing or
      Up), the neighbor's system ID SHALL be reported in the Neighbor
      System ID field, and the neighbor's Extended Local Circuit ID
      SHALL be reported in the Neighbor Extended Local Circuit ID field.

There is nothing written about only setting the Extended circuit ID of the
adjacency only when we bring the three-way adjacency up.

In fact, we should always update it, to avoid the problem described in #4783.

Fixes: #4783
Signed-off-by: Christian Franke <chris@opensourcerouting.org>