### PR TITLE
topotests: skip tests when any assert fails

### DIFF
--- a/tests/topotests/conftest.py
+++ b/tests/topotests/conftest.py
@@ -74,3 +74,9 @@ def pytest_runtest_makereport(item, call):
     parent._previousfailed = item
     logger.error('assert failed at "{}/{}": {}'.format(
         modname, item.name, call.excinfo.value))
+
+    # (topogen) Set topology error to avoid advancing in the test.
+    tgen = get_topogen()
+    if tgen is not None:
+        # This will cause topogen to report error on `routers_have_failure`.
+        tgen.set_error('{}/{}'.format(modname, item.name))


### PR DESCRIPTION
When an `assert` fails we should skip all other tests on the file. Once
a failure is detected we can't rely on the setup anymore, since most of
the tests assume the previous worked.

---

This will help tests to end earlier in case of tests failures and will only skip tests with the guard:

```py
    if tgen.routers_have_failure():
        pytest.skip(tgen.errors) 
```

(this only applies to topologies using topogen)

Reported by @rwestphal