### PR TITLE
lib: Revert usage of asm-code in MTYPE definitions

### DIFF
--- a/doc/developer/memtypes.rst
+++ b/doc/developer/memtypes.rst
@@ -52,6 +52,12 @@ Definition
    a function taking a ``struct memtype *`` argument can be called with an
    ``MTYPE_name`` argument (as opposed to ``&MTYPE_name``.)
 
+   .. note::
+
+      As ``MTYPE_name`` is a variable assigned from ``&_mt_name`` and not a
+      constant expression, it cannot be used as initializer for static
+      variables. In the case please fall back to ``&_mt_name``.
+
 .. c:macro:: DECLARE_MGROUP(name)
 
    This macro forward-declares a memory group and should be placed in a

--- a/doc/developer/memtypes.rst
+++ b/doc/developer/memtypes.rst
@@ -48,7 +48,7 @@ Definition
    should be used to create these, but in some cases it is useful to pass a
    ``struct memtype *`` pointer to some helper function.
 
-   The ``MTYPE_name`` created by the macros is declared as an array, i.e.
+   The ``MTYPE_name`` created by the macros is declared as a pointer, i.e.
    a function taking a ``struct memtype *`` argument can be called with an
    ``MTYPE_name`` argument (as opposed to ``&MTYPE_name``.)
 

--- a/lib/frrcu.c
+++ b/lib/frrcu.c
@@ -55,6 +55,7 @@
 #include "atomlist.h"
 
 DEFINE_MTYPE_STATIC(LIB, RCU_THREAD,    "RCU thread")
+DEFINE_MTYPE_STATIC(LIB, RCU_NEXT,      "RCU sequence barrier")
 
 DECLARE_ATOMLIST(rcu_heads, struct rcu_head, head)
 
@@ -225,7 +226,7 @@ static void rcu_bump(void)
 {
 	struct rcu_next *rn;
 
-	rn = XMALLOC(MTYPE_RCU_THREAD, sizeof(*rn));
+	rn = XMALLOC(MTYPE_RCU_NEXT, sizeof(*rn));
 
 	/* note: each RCUA_NEXT item corresponds to exactly one seqno bump.
 	 * This means we don't need to communicate which seqno is which
@@ -268,7 +269,7 @@ static void rcu_bump(void)
 	 * "last item is being deleted - start over" case, and then we may end
 	 * up accessing old RCU queue items that are already free'd.
 	 */
-	rcu_free_internal(MTYPE_RCU_THREAD, rn, head_free);
+	rcu_free_internal(MTYPE_RCU_NEXT, rn, head_free);
 
 	/* Only allow the RCU sweeper to run after these 2 items are queued.
 	 *

--- a/lib/frrcu.c
+++ b/lib/frrcu.c
@@ -206,7 +206,7 @@ void rcu_thread_unprepare(struct rcu_thread *rt)
 	rcu_bump();
 	if (rt != &rcu_thread_main)
 		/* this free() happens after seqlock_release() below */
-		rcu_free_internal(MTYPE_RCU_THREAD, rt, rcu_head);
+		rcu_free_internal(&_mt_RCU_THREAD, rt, rcu_head);
 
 	rcu_threads_del(&rcu_threads, rt);
 	seqlock_release(&rt->rcu);
@@ -269,7 +269,7 @@ static void rcu_bump(void)
 	 * "last item is being deleted - start over" case, and then we may end
 	 * up accessing old RCU queue items that are already free'd.
 	 */
-	rcu_free_internal(MTYPE_RCU_NEXT, rn, head_free);
+	rcu_free_internal(&_mt_RCU_NEXT, rn, head_free);
 
 	/* Only allow the RCU sweeper to run after these 2 items are queued.
 	 *


### PR DESCRIPTION
The asm-code was interpreted inconsistently for different platforms.
In particular for AArch64 this caused UB, if multiple static MTYPEs
where defined in one file. All static MTYPE_* could point to the same
memory location (namely the first defined MTYPE) OR to their respective
(correct) locations depending on the context of their usage.

Fixes #4833