### PR TITLE
lib: Decode vrf_id update appropriately from zapi

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1988,7 +1988,7 @@ struct interface *zebra_interface_vrf_update_read(struct stream *s,
 	}
 
 	/* Fetch new VRF Id. */
-	new_id = stream_getw(s);
+	new_id = stream_getl(s);
 
 	*new_vrf_id = new_id;
 	return ifp;


### PR DESCRIPTION
The vrf_id in `zsend_interface_vrf_update()` is encoded as
a long via `stream_putl()`, we should decode it as such
as well.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>