### PR TITLE
bgpd: Keep the session down if maximum-prefix is reached

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -438,12 +438,15 @@ static int bgp_accept(struct thread *thread)
 		return -1;
 	}
 
-	/* Check whether max prefix restart timer is set for the peer */
-	if (peer1->t_pmax_restart) {
+	/* Do not try to reconnect if the peer reached maximum
+	 * prefixes, restart timer is still running or the peer
+	 * is shutdown.
+	 */
+	if (BGP_PEER_START_SUPPRESSED(peer1)) {
 		if (bgp_debug_neighbor_events(peer1))
 			zlog_debug(
-				"%s - incoming conn rejected - "
-				"peer max prefix timer is active",
+				"[Event] Incoming BGP connection rejected from %s "
+				"due to maximum-prefix or shutdown",
 				peer1->host);
 		close(bgp_sock);
 		return -1;

--- a/tests/topotests/bgp_maximum_prefix_invalid_update/test_bgp_maximum_prefix_invalid_update.py
+++ b/tests/topotests/bgp_maximum_prefix_invalid_update/test_bgp_maximum_prefix_invalid_update.py
@@ -89,9 +89,8 @@ def test_bgp_maximum_prefix_invalid():
     def _bgp_converge(router):
         while True:
             output = json.loads(tgen.gears[router].vtysh_cmd("show ip bgp neighbor 192.168.255.1 json"))
-            if output['192.168.255.1']['connectionsEstablished'] > 3:
+            if output['192.168.255.1']['connectionsEstablished'] > 0:
                 return True
-            time.sleep(1)
 
     def _bgp_parsing_nlri(router):
         cmd_max_exceeded = 'grep "%MAXPFXEXCEED: No. of IPv4 Unicast prefix received" bgpd.log'


### PR DESCRIPTION
Under high load instances with hundreds of thousands of prefixes this
could result in very unstable systems.

When maximum-prefix is set, but restart timer is not set then the session
flaps between Idle(Pfx) -> Established -> Idle(Pfx) states.

Related: https://github.com/FRRouting/frr/issues/5065

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

Before the patch:
![issue_5065](https://user-images.githubusercontent.com/3352707/66056309-98c10e00-e53f-11e9-8f86-5ab724d7f1a8.gif)

After the patch:
![issue_5065_patched](https://user-images.githubusercontent.com/3352707/66056581-05d4a380-e540-11e9-822f-21365753d1a7.gif)