### PR TITLE
lib, watchfrr: Add some additional status messages to systemd

### DIFF
--- a/lib/systemd.c
+++ b/lib/systemd.c
@@ -86,6 +86,7 @@ static int systemd_get_watchdog_time(int the_process)
 
 void systemd_send_stopping(void)
 {
+	systemd_send_information("STATUS=");
 	systemd_send_information("STOPPING=1");
 }
 
@@ -115,4 +116,12 @@ void systemd_send_started(struct thread_master *m, int the_process)
 	systemd_send_information("READY=1");
 	if (wsecs != 0)
 		thread_add_timer(m, systemd_send_watchdog, m, wsecs, NULL);
+}
+
+void systemd_send_status(const char *status)
+{
+	char buffer[1024];
+
+	snprintf(buffer, sizeof(buffer), "STATUS=%s", status);
+	systemd_send_information(buffer);
 }

--- a/lib/systemd.h
+++ b/lib/systemd.h
@@ -42,6 +42,11 @@ void systemd_send_stopping(void);
  */
 void systemd_send_started(struct thread_master *master, int the_process);
 
+/*
+ * status - A status string to send to systemd
+ */
+void systemd_send_status(const char *status);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Allow systemd to be informed about operational state so operators can
infer a bit about what is going on with FRR from the systemd status
cli.

sharpd@robot ~/frr4> systemctl status frr
● frr.service - FRRouting
   Loaded: loaded (/usr/lib/systemd/system/frr.service; enabled; vendor preset: disabled)
   Active: active (running) since Thu 2019-10-03 21:09:04 EDT; 7s ago
     Docs: https://frrouting.readthedocs.io/en/latest/setup.html
  Process: 32455 ExecStart=/usr/lib/frr/frrinit.sh start (code=exited, status=0/SUCCESS)
   Status: "FRR Operational"
    Tasks: 12 (limit: 4915)
   Memory: 76.5M
   CGroup: /system.slice/frr.service
           ├─32468 /usr/lib/frr/watchfrr -d zebra bgpd staticd
           ├─32487 /usr/lib/frr/zebra -d -A 127.0.0.1 -s 90000000
           ├─32492 /usr/lib/frr/bgpd -d -A 127.0.0.1
           └─32500 /usr/lib/frr/staticd -d -A 127.0.0.1

Please note the `Status: ...` line above.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>