### PR TITLE
[WIP] *: Rework interface vrf change zapi handling

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -202,8 +202,8 @@ main(int argc, char **argv)
     babel_replace_by_null(STDIN_FILENO);
 
     /* init some quagga's dependencies, and babeld's commands */
-    if_zapi_callbacks(babel_ifp_create, babel_ifp_up,
-		      babel_ifp_down, babel_ifp_destroy);
+    if_zapi_callbacks(babel_ifp_create, babel_ifp_up, babel_ifp_down,
+		      babel_ifp_destroy, NULL);
     babeld_quagga_init();
     /* init zebra client's structure and it's commands */
     /* this replace kernel_setup && kernel_setup_socket */

--- a/eigrpd/eigrp_interface.c
+++ b/eigrpd/eigrp_interface.c
@@ -216,8 +216,8 @@ struct list *eigrp_iflist;
 
 void eigrp_if_init(void)
 {
-	if_zapi_callbacks(eigrp_ifp_create, eigrp_ifp_up,
-			  eigrp_ifp_down, eigrp_ifp_destroy);
+	if_zapi_callbacks(eigrp_ifp_create, eigrp_ifp_up, eigrp_ifp_down,
+			  eigrp_ifp_destroy, NULL);
 	/* Initialize Zebra interface data structure. */
 	// hook_register_prio(if_add, 0, eigrp_if_new);
 	hook_register_prio(if_del, 0, eigrp_if_delete_hook);

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1445,6 +1445,6 @@ void isis_circuit_init(void)
 	/* Install interface node */
 	install_node(&interface_node, isis_interface_config_write);
 	if_cmd_init();
-	if_zapi_callbacks(isis_ifp_create, isis_ifp_up,
-			  isis_ifp_down, isis_ifp_destroy);
+	if_zapi_callbacks(isis_ifp_create, isis_ifp_up, isis_ifp_down,
+			  isis_ifp_destroy, NULL);
 }

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -521,8 +521,8 @@ extern struct zebra_privs_t ldpd_privs;
 void
 ldp_zebra_init(struct thread_master *master)
 {
-	if_zapi_callbacks(ldp_ifp_create, ldp_ifp_up,
-			  ldp_ifp_down, ldp_ifp_destroy);
+	if_zapi_callbacks(ldp_ifp_create, ldp_ifp_up, ldp_ifp_down,
+			  ldp_ifp_destroy, NULL);
 
 	/* Set default values. */
 	zclient = zclient_new(master, &zclient_options_default);

--- a/lib/if.c
+++ b/lib/if.c
@@ -63,6 +63,7 @@ struct interface_master{
 	int (*up_hook)(struct interface *ifp);
 	int (*down_hook)(struct interface *ifp);
 	int (*destroy_hook)(struct interface *ifp);
+	int (*vrf_update_hook)(struct interface *ifp, vrf_id_t new_vrf_id);
 } ifp_master = { 0, };
 
 /* Compare interface names, returning an integer greater than, equal to, or
@@ -191,6 +192,14 @@ void if_down_via_zapi(struct interface *ifp)
 {
 	if (ifp_master.down_hook)
 		(*ifp_master.down_hook)(ifp);
+}
+
+void if_vrf_update_via_zapi(struct interface *ifp, vrf_id_t new_vrf_id)
+{
+	if (ifp_master.vrf_update_hook)
+		(*ifp_master.vrf_update_hook)(ifp, new_vrf_id);
+
+	if_update_to_new_vrf(ifp, new_vrf_id);
 }
 
 struct interface *if_create_name(const char *name, vrf_id_t vrf_id)
@@ -1432,12 +1441,15 @@ void if_cmd_init(void)
 void if_zapi_callbacks(int (*create)(struct interface *ifp),
 		       int (*up)(struct interface *ifp),
 		       int (*down)(struct interface *ifp),
-		       int (*destroy)(struct interface *ifp))
+		       int (*destroy)(struct interface *ifp),
+		       int (*vrf_update)(struct interface *ifp,
+					 vrf_id_t new_vrf_id))
 {
 	ifp_master.create_hook = create;
 	ifp_master.up_hook = up;
 	ifp_master.down_hook = down;
 	ifp_master.destroy_hook = destroy;
+	ifp_master.vrf_update_hook = vrf_update;
 }
 
 /* ------- Northbound callbacks ------- */

--- a/lib/if.h
+++ b/lib/if.h
@@ -567,12 +567,15 @@ extern void if_cmd_init(void);
 extern void if_zapi_callbacks(int (*create)(struct interface *ifp),
 			      int (*up)(struct interface *ifp),
 			      int (*down)(struct interface *ifp),
-			      int (*destroy)(struct interface *ifp));
+			      int (*destroy)(struct interface *ifp),
+			      int (*vrf_update)(struct interface *ifp,
+						vrf_id_t new_vrf_id));
 
 extern void if_new_via_zapi(struct interface *ifp);
 extern void if_up_via_zapi(struct interface *ifp);
 extern void if_down_via_zapi(struct interface *ifp);
 extern void if_destroy_via_zapi(struct interface *ifp);
+extern void if_vrf_update_via_zapi(struct interface *ifp, vrf_id_t new_vrf_id);
 
 extern const struct frr_yang_module_info frr_interface_info;
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -246,7 +246,6 @@ struct zclient {
 	int (*interface_bfd_dest_update)(ZAPI_CALLBACK_ARGS);
 	int (*interface_nbr_address_add)(ZAPI_CALLBACK_ARGS);
 	int (*interface_nbr_address_delete)(ZAPI_CALLBACK_ARGS);
-	int (*interface_vrf_update)(ZAPI_CALLBACK_ARGS);
 	int (*nexthop_update)(ZAPI_CALLBACK_ARGS);
 	int (*import_check_update)(ZAPI_CALLBACK_ARGS);
 	int (*bfd_dest_replay)(ZAPI_CALLBACK_ARGS);
@@ -619,9 +618,6 @@ extern struct connected *zebra_interface_address_read(int, struct stream *,
 						      vrf_id_t);
 extern struct nbr_connected *
 zebra_interface_nbr_address_read(int, struct stream *, vrf_id_t);
-extern struct interface *zebra_interface_vrf_update_read(struct stream *s,
-							 vrf_id_t vrf_id,
-							 vrf_id_t *new_vrf_id);
 extern void zebra_router_id_update_read(struct stream *s, struct prefix *rid);
 
 extern struct interface *zebra_interface_link_params_read(struct stream *s,

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -152,8 +152,8 @@ int main(int argc, char **argv)
 	nhrp_vc_init();
 	nhrp_packet_init();
 	vici_init();
-	if_zapi_callbacks(nhrp_ifp_create, nhrp_ifp_up,
-			  nhrp_ifp_down, nhrp_ifp_destroy);
+	if_zapi_callbacks(nhrp_ifp_create, nhrp_ifp_up, nhrp_ifp_down,
+			  nhrp_ifp_destroy, NULL);
 	nhrp_zebra_init();
 	nhrp_shortcut_init();
 

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -2003,8 +2003,8 @@ void ospf6_interface_init(void)
 	/* Install interface node. */
 	install_node(&interface_node, config_write_ospf6_interface);
 	if_cmd_init();
-	if_zapi_callbacks(ospf6_ifp_create, ospf6_ifp_up,
-			  ospf6_ifp_down, ospf6_ifp_destroy);
+	if_zapi_callbacks(ospf6_ifp_create, ospf6_ifp_up, ospf6_ifp_down,
+			  ospf6_ifp_destroy, NULL);
 
 	install_element(VIEW_NODE, &show_ipv6_ospf6_interface_prefix_cmd);
 	install_element(VIEW_NODE, &show_ipv6_ospf6_interface_ifname_cmd);

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -1344,8 +1344,8 @@ static int ospf_ifp_destroy(struct interface *ifp)
 
 void ospf_if_init(void)
 {
-	if_zapi_callbacks(ospf_ifp_create, ospf_ifp_up,
-			  ospf_ifp_down, ospf_ifp_destroy);
+	if_zapi_callbacks(ospf_ifp_create, ospf_ifp_up, ospf_ifp_down,
+			  ospf_ifp_destroy, NULL);
 
 	/* Initialize Zebra interface data structure. */
 	hook_register_prio(if_add, 0, ospf_if_new_hook);

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -183,29 +183,6 @@ static int ospf_interface_link_params(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-/* VRF update for an interface. */
-static int ospf_interface_vrf_update(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp = NULL;
-	vrf_id_t new_vrf_id;
-
-	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrf_id,
-					      &new_vrf_id);
-	if (!ifp)
-		return 0;
-
-	if (IS_DEBUG_OSPF_EVENT)
-		zlog_debug(
-			"%s: Rx Interface %s VRF change vrf_id %u New vrf %s id %u",
-			__PRETTY_FUNCTION__, ifp->name, vrf_id,
-			ospf_vrf_id_to_name(new_vrf_id), new_vrf_id);
-
-	/*if_update(ifp, ifp->name, strlen(ifp->name), new_vrf_id);*/
-	if_update_to_new_vrf(ifp, new_vrf_id);
-
-	return 0;
-}
-
 void ospf_zebra_add(struct ospf *ospf, struct prefix_ipv4 *p,
 		    struct ospf_route * or)
 {
@@ -1363,7 +1340,6 @@ void ospf_zebra_init(struct thread_master *master, unsigned short instance)
 	zclient->interface_address_add = ospf_interface_address_add;
 	zclient->interface_address_delete = ospf_interface_address_delete;
 	zclient->interface_link_params = ospf_interface_link_params;
-	zclient->interface_vrf_update = ospf_interface_vrf_update;
 
 	zclient->redistribute_route_add = ospf_zebra_read_route;
 	zclient->redistribute_route_del = ospf_zebra_read_route;

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -166,8 +166,8 @@ int main(int argc, char **argv, char **envp)
 	access_list_init();
 	pbr_nht_init();
 	pbr_map_init();
-	if_zapi_callbacks(pbr_ifp_create, pbr_ifp_up,
-			  pbr_ifp_down, pbr_ifp_destroy);
+	if_zapi_callbacks(pbr_ifp_create, pbr_ifp_up, pbr_ifp_down,
+			  pbr_ifp_destroy, NULL);
 	pbr_zebra_init();
 	pbr_vty_init();
 

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -127,8 +127,8 @@ int main(int argc, char **argv, char **envp)
 	/*
 	 * Initialize zclient "update" and "lookup" sockets
 	 */
-	if_zapi_callbacks(pim_ifp_create, pim_ifp_up,
-			  pim_ifp_down, pim_ifp_destroy);
+	if_zapi_callbacks(pim_ifp_create, pim_ifp_up, pim_ifp_down,
+			  pim_ifp_destroy, NULL);
 	pim_zebra_init();
 	pim_bfd_init();
 

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -63,26 +63,6 @@ static int pim_router_id_update_zebra(ZAPI_CALLBACK_ARGS)
 	return 0;
 }
 
-static int pim_zebra_interface_vrf_update(ZAPI_CALLBACK_ARGS)
-{
-	struct interface *ifp;
-	vrf_id_t new_vrf_id;
-
-	ifp = zebra_interface_vrf_update_read(zclient->ibuf, vrf_id,
-					      &new_vrf_id);
-	if (!ifp)
-		return 0;
-
-	if (PIM_DEBUG_ZEBRA)
-		zlog_debug("%s: %s updating from %u to %u",
-			   __PRETTY_FUNCTION__,
-			   ifp->name, vrf_id, new_vrf_id);
-
-	if_update_to_new_vrf(ifp, new_vrf_id);
-
-	return 0;
-}
-
 #ifdef PIM_DEBUG_IFADDR_DUMP
 static void dump_if_address(struct interface *ifp)
 {
@@ -583,7 +563,6 @@ void pim_zebra_init(void)
 	zclient->router_id_update = pim_router_id_update_zebra;
 	zclient->interface_address_add = pim_zebra_if_address_add;
 	zclient->interface_address_delete = pim_zebra_if_address_del;
-	zclient->interface_vrf_update = pim_zebra_interface_vrf_update;
 	zclient->nexthop_update = pim_parse_nexthop_update;
 	zclient->vxlan_sg_add = pim_zebra_vxlan_sg_proc;
 	zclient->vxlan_sg_del = pim_zebra_vxlan_sg_proc;

--- a/ripd/rip_interface.h
+++ b/ripd/rip_interface.h
@@ -33,7 +33,6 @@ extern int rip_interface_address_add(int, struct zclient *, zebra_size_t,
 				     vrf_id_t);
 extern int rip_interface_address_delete(int, struct zclient *, zebra_size_t,
 					vrf_id_t);
-extern int rip_interface_vrf_update(ZAPI_CALLBACK_ARGS);
-extern void rip_interface_sync(struct interface *ifp);
+extern void rip_interface_sync(struct interface *ifp, vrf_id_t new_vrf_id);
 
 #endif /* _QUAGGA_RIP_INTERFACE_H */

--- a/ripd/rip_zebra.c
+++ b/ripd/rip_zebra.c
@@ -240,7 +240,6 @@ void rip_zclient_init(struct thread_master *master)
 	zclient->zebra_connected = rip_zebra_connected;
 	zclient->interface_address_add = rip_interface_address_add;
 	zclient->interface_address_delete = rip_interface_address_delete;
-	zclient->interface_vrf_update = rip_interface_vrf_update;
 	zclient->redistribute_route_add = rip_zebra_read_route;
 	zclient->redistribute_route_del = rip_zebra_read_route;
 }

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -3532,7 +3532,7 @@ static void rip_vrf_link(struct rip *rip, struct vrf *vrf)
 	vrf->info = rip;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
-		rip_interface_sync(ifp);
+		rip_interface_sync(ifp, ifp->vrf_id);
 }
 
 /* Unlink RIP instance from VRF. */
@@ -3545,7 +3545,7 @@ static void rip_vrf_unlink(struct rip *rip, struct vrf *vrf)
 	vrf->info = NULL;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
-		rip_interface_sync(ifp);
+		rip_interface_sync(ifp, ifp->vrf_id);
 }
 
 static void rip_instance_enable(struct rip *rip, struct vrf *vrf, int sock)

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -244,7 +244,6 @@ void zebra_init(struct thread_master *master)
 	zclient->zebra_connected = ripng_zebra_connected;
 	zclient->interface_address_add = ripng_interface_address_add;
 	zclient->interface_address_delete = ripng_interface_address_delete;
-	zclient->interface_vrf_update = ripng_interface_vrf_update;
 	zclient->redistribute_route_add = ripng_zebra_read_route;
 	zclient->redistribute_route_del = ripng_zebra_read_route;
 }

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -2654,7 +2654,7 @@ static void ripng_vrf_link(struct ripng *ripng, struct vrf *vrf)
 	vrf->info = ripng;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
-		ripng_interface_sync(ifp);
+		ripng_interface_sync(ifp, ifp->vrf_id);
 }
 
 /* Unlink RIPng instance from VRF. */
@@ -2667,7 +2667,7 @@ static void ripng_vrf_unlink(struct ripng *ripng, struct vrf *vrf)
 	vrf->info = NULL;
 
 	FOR_ALL_INTERFACES (vrf, ifp)
-		ripng_interface_sync(ifp);
+		ripng_interface_sync(ifp, ifp->vrf_id);
 }
 
 static void ripng_instance_enable(struct ripng *ripng, struct vrf *vrf,

--- a/ripngd/ripngd.h
+++ b/ripngd/ripngd.h
@@ -469,14 +469,9 @@ extern int ripng_send_packet(caddr_t buf, int bufsize, struct sockaddr_in6 *to,
 extern void ripng_packet_dump(struct ripng_packet *packet, int size,
 			      const char *sndrcv);
 
-extern int ripng_interface_up(ZAPI_CALLBACK_ARGS);
-extern int ripng_interface_down(ZAPI_CALLBACK_ARGS);
-extern int ripng_interface_add(ZAPI_CALLBACK_ARGS);
-extern int ripng_interface_delete(ZAPI_CALLBACK_ARGS);
 extern int ripng_interface_address_add(ZAPI_CALLBACK_ARGS);
 extern int ripng_interface_address_delete(ZAPI_CALLBACK_ARGS);
-extern int ripng_interface_vrf_update(ZAPI_CALLBACK_ARGS);
-extern void ripng_interface_sync(struct interface *ifp);
+extern void ripng_interface_sync(struct interface *ifp, vrf_id_t vrf_id);
 
 extern struct ripng *ripng_lookup_by_vrf_id(vrf_id_t vrf_id);
 extern struct ripng *ripng_lookup_by_vrf_name(const char *vrf_name);

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -393,8 +393,8 @@ void sharp_zebra_init(void)
 {
 	struct zclient_options opt = {.receive_notify = true};
 
-	if_zapi_callbacks(sharp_ifp_create, sharp_ifp_up,
-			  sharp_ifp_down, sharp_ifp_destroy);
+	if_zapi_callbacks(sharp_ifp_create, sharp_ifp_up, sharp_ifp_down,
+			  sharp_ifp_destroy, NULL);
 
 	zclient = zclient_new(master, &opt);
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -467,8 +467,8 @@ void static_zebra_init(void)
 {
 	struct zclient_options opt = { .receive_notify = true };
 
-	if_zapi_callbacks(static_ifp_create, static_ifp_up,
-			  static_ifp_down, static_ifp_destroy);
+	if_zapi_callbacks(static_ifp_create, static_ifp_up, static_ifp_down,
+			  static_ifp_destroy, NULL);
 
 	zclient = zclient_new(master, &opt);
 

--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -191,8 +191,8 @@ int vrrp_zclient_send_interface_protodown(struct interface *ifp, bool down)
 
 void vrrp_zebra_init(void)
 {
-	if_zapi_callbacks(vrrp_ifp_create, vrrp_ifp_up,
-			  vrrp_ifp_down, vrrp_ifp_destroy);
+	if_zapi_callbacks(vrrp_ifp_create, vrrp_ifp_up, vrrp_ifp_down,
+			  vrrp_ifp_destroy, NULL);
 
 	/* Socket for receiving updates from Zebra daemon */
 	zclient = zclient_new(master, &zclient_options_default);

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -803,16 +803,11 @@ void if_handle_vrf_change(struct interface *ifp, vrf_id_t vrf_id)
 	/* Delete all neighbor addresses learnt through IPv6 RA */
 	if_down_del_nbr_connected(ifp);
 
-	/* Send out notification on interface VRF change. */
-	/* This is to issue an UPDATE or a DELETE, as appropriate. */
-	zebra_interface_vrf_update_del(ifp, vrf_id);
-
 	/* update VRF */
 	if_update_to_new_vrf(ifp, vrf_id);
 
 	/* Send out notification on interface VRF change. */
-	/* This is to issue an ADD, if needed. */
-	zebra_interface_vrf_update_add(ifp, old_vrf_id);
+	zebra_interface_vrf_update(ifp, old_vrf_id);
 
 	/* Install connected routes (in new VRF). */
 	if (if_is_operative(ifp))
@@ -3218,7 +3213,7 @@ void zebra_if_init(void)
 	 * This is *intentionally* setting this to NULL, signaling
 	 * that interface creation for zebra acts differently
 	 */
-	if_zapi_callbacks(NULL, NULL, NULL, NULL);
+	if_zapi_callbacks(NULL, NULL, NULL, NULL, NULL);
 
 	install_element(VIEW_NODE, &show_interface_cmd);
 	install_element(VIEW_NODE, &show_interface_vrf_all_cmd);

--- a/zebra/redistribute.h
+++ b/zebra/redistribute.h
@@ -67,10 +67,7 @@ extern void zebra_interface_address_add_update(struct interface *,
 extern void zebra_interface_address_delete_update(struct interface *,
 						  struct connected *c);
 extern void zebra_interface_parameters_update(struct interface *);
-extern void zebra_interface_vrf_update_del(struct interface *,
-					   vrf_id_t new_vrf_id);
-extern void zebra_interface_vrf_update_add(struct interface *,
-					   vrf_id_t old_vrf_id);
+extern void zebra_interface_vrf_update(struct interface *, vrf_id_t old_vrf_id);
 
 extern int zebra_import_table(afi_t afi, vrf_id_t vrf_id,
 			      uint32_t table_id, uint32_t distance,

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -420,19 +420,17 @@ int zsend_interface_addresses(struct zserv *client, struct interface *ifp)
 	return 0;
 }
 
-/* Notify client about interface moving from one VRF to another.
- * Whether client is interested in old and new VRF is checked by caller.
- */
+/* Notify client about interface moving from one VRF to another. */
 int zsend_interface_vrf_update(struct zserv *client, struct interface *ifp,
-			       vrf_id_t vrf_id)
+			       vrf_id_t old_vrf_id)
 {
 	struct stream *s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
-	zclient_create_header(s, ZEBRA_INTERFACE_VRF_UPDATE, ifp->vrf_id);
+	zclient_create_header(s, ZEBRA_INTERFACE_VRF_UPDATE, old_vrf_id);
 
 	/* Fill in the name of the interface and its new VRF (id) */
 	stream_put(s, ifp->name, INTERFACE_NAMSIZ);
-	stream_putl(s, vrf_id);
+	stream_putl(s, ifp->vrf_id);
 
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));

--- a/zebra/zapi_msg.h
+++ b/zebra/zapi_msg.h
@@ -70,7 +70,8 @@ extern int zsend_redistribute_route(int cmd, struct zserv *zclient,
 extern int zsend_router_id_update(struct zserv *zclient, struct prefix *p,
 				  vrf_id_t vrf_id);
 extern int zsend_interface_vrf_update(struct zserv *zclient,
-				      struct interface *ifp, vrf_id_t vrf_id);
+				      struct interface *ifp,
+				      vrf_id_t old_vrf_id);
 extern int zsend_interface_link_params(struct zserv *zclient,
 				       struct interface *ifp);
 extern int zsend_pw_update(struct zserv *client, struct zebra_pw *pw);


### PR DESCRIPTION
Rework vrf interface zapi handling into the new interface callbacks.
Now, you put your callback into the `if_zapi_callbacks()` along with
the other interface callbacks. The callback handler will take care of
updating the interface structures with the new vrf (this was pretty
much the same code in every daemon) and the daemon just does
whatever `extra` handling it needs to do.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>