### PR TITLE
lib: reject leading 0 in ipv4 decimal quad

### DIFF
--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -724,7 +724,12 @@ static enum match_type match_ipv4(const char *str)
 			return no_match;
 
 		memcpy(buf, sp, str - sp);
-		if (atoi(buf) > 255)
+
+		int v = atoi(buf);
+
+		if (v > 255)
+			return no_match;
+		if (v > 0 && buf[0] == '0')
 			return no_match;
 
 		nums++;
@@ -775,7 +780,12 @@ static enum match_type match_ipv4_prefix(const char *str)
 			return no_match;
 
 		memcpy(buf, sp, str - sp);
-		if (atoi(buf) > 255)
+
+		int v = atoi(buf);
+
+		if (v > 255)
+			return no_match;
+		if (v > 0 && buf[0] == '0')
 			return no_match;
 
 		if (dots == 3) {


### PR DESCRIPTION
inet_pton() is used to parse ipv4 addresses internally, therefore FRR
does not support octal notation for quads. The ipv4 cli token validator
should make sure that str2prefix() can parse tokens it allows, and
str2prefix uses inet_pton, so we have to disallow leading zeros in ipv4
quads.

In short, 1.1.1.01 is no longer valid and must be expressed as 1.1.1.1.

c.f. #5111, which should be closed in favor of this PR.