### PR TITLE
bgpd: [7.1] Use uint32_t for maximum-prefix

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2672,8 +2672,8 @@ int bgp_maximum_prefix_overflow(struct peer *peer, afi_t afi, safi_t safi,
 			return 0;
 
 		zlog_info(
-			"%%MAXPFXEXCEED: No. of %s prefix received from %s %ld exceed, "
-			"limit %ld",
+			"%%MAXPFXEXCEED: No. of %s prefix received from %s %" PRIu32
+			" exceed, limit %" PRIu32,
 			afi_safi_print(afi, safi), peer->host,
 			peer->pcount[afi][safi], peer->pmax[afi][safi]);
 		SET_FLAG(peer->af_sflags[afi][safi], PEER_STATUS_PREFIX_LIMIT);
@@ -2734,7 +2734,8 @@ int bgp_maximum_prefix_overflow(struct peer *peer, afi_t afi, safi_t safi,
 			return 0;
 
 		zlog_info(
-			"%%MAXPFX: No. of %s prefix received from %s reaches %ld, max %ld",
+			"%%MAXPFX: No. of %s prefix received from %s reaches %" PRIu32
+			", max %" PRIu32,
 			afi_safi_print(afi, safi), peer->host,
 			peer->pcount[afi][safi], peer->pmax[afi][safi]);
 		SET_FLAG(peer->af_sflags[afi][safi],
@@ -10670,7 +10671,7 @@ static int bgp_peer_counts(struct vty *vty, struct peer *peer, afi_t afi,
 				afi_safi_print(afi, safi));
 		}
 
-		vty_out(vty, "PfxCt: %ld\n", peer->pcount[afi][safi]);
+		vty_out(vty, "PfxCt: %" PRIu32 "\n", peer->pcount[afi][safi]);
 		vty_out(vty, "\nCounts from RIB table walk:\n\n");
 
 		for (i = 0; i < PCOUNT_MAX; i++)

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8231,7 +8231,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 
 			if (peer->status == Established)
 				if (peer->afc_recv[afi][safi])
-					vty_out(vty, " %12ld",
+					vty_out(vty, " %12" PRIu32,
 						peer->pcount[afi]
 							    [pfx_rcd_safi]);
 				else
@@ -9182,11 +9182,13 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 				filter->usmap.name);
 
 		/* Receive prefix count */
-		vty_out(vty, "  %ld accepted prefixes\n", p->pcount[afi][safi]);
+		vty_out(vty, "  %" PRIu32 " accepted prefixes\n",
+			p->pcount[afi][safi]);
 
 		/* Maximum prefix */
 		if (CHECK_FLAG(p->af_flags[afi][safi], PEER_FLAG_MAX_PREFIX)) {
-			vty_out(vty, "  Maximum prefixes allowed %ld%s\n",
+			vty_out(vty,
+				"  Maximum prefixes allowed %" PRIu32 "%s\n",
 				p->pmax[afi][safi],
 				CHECK_FLAG(p->af_flags[afi][safi],
 					   PEER_FLAG_MAX_PREFIX_WARNING)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7378,7 +7378,7 @@ static void bgp_config_write_peer_af(struct vty *vty, struct bgp *bgp,
 
 	/* maximum-prefix. */
 	if (peergroup_af_flag_check(peer, afi, safi, PEER_FLAG_MAX_PREFIX)) {
-		vty_out(vty, "  neighbor %s maximum-prefix %lu", addr,
+		vty_out(vty, "  neighbor %s maximum-prefix %" PRIu32, addr,
 			peer->pmax[afi][safi]);
 
 		if (peer->pmax_threshold[afi][safi]

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1139,10 +1139,10 @@ struct peer {
 	int rcvd_attr_printed;
 
 	/* Prefix count. */
-	unsigned long pcount[AFI_MAX][SAFI_MAX];
+	uint32_t pcount[AFI_MAX][SAFI_MAX];
 
 	/* Max prefix count. */
-	unsigned long pmax[AFI_MAX][SAFI_MAX];
+	uint32_t pmax[AFI_MAX][SAFI_MAX];
 	uint8_t pmax_threshold[AFI_MAX][SAFI_MAX];
 	uint16_t pmax_restart[AFI_MAX][SAFI_MAX];
 #define MAXIMUM_PREFIX_THRESHOLD_DEFAULT 75


### PR DESCRIPTION
Currently we have unsigned long which is not what we defined
in CLI (1-4294967295).

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>