### PR TITLE
bgpd: Implement "sh bgp l2vpn evpn community|large-community X"

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -37,6 +37,8 @@
 #include "bgpd/bgp_vty.h"
 #include "bgpd/bgp_errors.h"
 #include "bgpd/bgp_ecommunity.h"
+#include "bgpd/bgp_lcommunity.h"
+#include "bgpd/bgp_community.h"
 
 #define SHOW_DISPLAY_STANDARD 0
 #define SHOW_DISPLAY_TAGS 1
@@ -1079,6 +1081,38 @@ static int bgp_show_ethernet_vpn(struct vty *vty, struct prefix_rd *prd,
 					if (peer_cmp(peer, pi->peer) != 0)
 						continue;
 				}
+				if (type == bgp_show_type_lcommunity_exact) {
+					struct lcommunity *lcom = output_arg;
+
+					if (!pi->attr->lcommunity ||
+						!lcommunity_cmp(
+						pi->attr->lcommunity, lcom))
+						continue;
+				}
+				if (type == bgp_show_type_lcommunity) {
+					struct lcommunity *lcom = output_arg;
+
+					if (!pi->attr->lcommunity ||
+						!lcommunity_match(
+						pi->attr->lcommunity, lcom))
+						continue;
+				}
+				if (type == bgp_show_type_community) {
+					struct community *com = output_arg;
+
+					if (!pi->attr->community ||
+						!community_match(
+						pi->attr->community, com))
+						continue;
+				}
+				if (type == bgp_show_type_community_exact) {
+					struct community *com = output_arg;
+
+					if (!pi->attr->community ||
+						!community_cmp(
+						pi->attr->community, com))
+						continue;
+				}
 				if (header) {
 					if (use_json) {
 						json_object_int_add(
@@ -1652,6 +1686,71 @@ DEFUN(show_ip_bgp_evpn_rd_overlay,
 	return bgp_show_ethernet_vpn(vty, &prd, bgp_show_type_normal, NULL,
 				     SHOW_DISPLAY_OVERLAY,
 				     use_json(argc, argv));
+}
+
+DEFUN(show_bgp_l2vpn_evpn_com,
+      show_bgp_l2vpn_evpn_com_cmd,
+      "show bgp l2vpn evpn \
+      <community AA:NN|large-community AA:BB:CC> \
+      [exact-match] [json]",
+      SHOW_STR
+      BGP_STR
+      L2VPN_HELP_STR
+      EVPN_HELP_STR
+      "Display routes matching the community\n"
+      "Community number where AA and NN are (0-65535)\n"
+      "Display routes matching the large-community\n"
+      "List of large-community numbers\n"
+      "Exact match of the communities\n"
+      JSON_STR)
+{
+	int idx = 0;
+	int ret = 0;
+	const char *clist_number_or_name;
+	int show_type = bgp_show_type_normal;
+	struct community *com;
+	struct lcommunity *lcom;
+
+	if (argv_find(argv, argc, "large-community", &idx)) {
+		clist_number_or_name = argv[++idx]->arg;
+		show_type = bgp_show_type_lcommunity;
+
+		if (++idx < argc && strmatch(argv[idx]->text, "exact-match"))
+			show_type = bgp_show_type_lcommunity_exact;
+
+		lcom = lcommunity_str2com(clist_number_or_name);
+		if (!lcom) {
+			vty_out(vty, "%% Large-community malformed\n");
+			return CMD_WARNING;
+		}
+
+		ret = bgp_show_ethernet_vpn(vty, NULL, show_type, lcom,
+					    SHOW_DISPLAY_STANDARD,
+					    use_json(argc, argv));
+
+		lcommunity_free(&lcom);
+	} else if (argv_find(argv, argc, "community", &idx)) {
+		clist_number_or_name = argv[++idx]->arg;
+		show_type = bgp_show_type_community;
+
+		if (++idx < argc && strmatch(argv[idx]->text, "exact-match"))
+			show_type = bgp_show_type_community_exact;
+
+		com = community_str2com(clist_number_or_name);
+
+		if (!com) {
+			vty_out(vty, "%% Community malformed: %s\n",
+				clist_number_or_name);
+			return CMD_WARNING;
+		}
+
+		ret = bgp_show_ethernet_vpn(vty, NULL, show_type, com,
+					    SHOW_DISPLAY_STANDARD,
+					    use_json(argc, argv));
+		community_free(&com);
+	}
+
+	return ret;
 }
 
 /* For testing purpose, static route of EVPN RT-5. */
@@ -5444,6 +5543,7 @@ void bgp_ethernetvpn_init(void)
 	install_element(VIEW_NODE, &show_bgp_evpn_route_vni_all_cmd);
 	install_element(VIEW_NODE, &show_bgp_evpn_import_rt_cmd);
 	install_element(VIEW_NODE, &show_bgp_vrf_l3vni_info_cmd);
+	install_element(VIEW_NODE, &show_bgp_l2vpn_evpn_com_cmd);
 
 	install_element(BGP_EVPN_NODE, &bgp_evpn_vni_cmd);
 	install_element(BGP_EVPN_NODE, &no_bgp_evpn_vni_cmd);


### PR DESCRIPTION
**CLI output (similar output for community)**
```
leaf-1# sh bgp l2vpn evpn large-community 13:13:13
BGP table version is 1, local router ID is 10.100.0.1
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: ip 10.100.0.2:2

*> [3]:[0]:[32]:[10.100.0.2]
                    10.100.0.2                             0 65002 i
                    RT:65002:100 ET:8
Route Distinguisher: ip 10.101.1.4:4

*> [5]:[0]:[24]:[100.100.99.0]
                    10.100.0.2               0             0 65002 i
                    RT:65002:1000 ET:8 Rmac:ba:c0:2b:39:de:bf
*> [5]:[0]:[32]:[200.200.200.200]
                    10.100.0.2               0             0 65002 i
                    RT:65002:1000 ET:8 Rmac:ba:c0:2b:39:de:bf

Displayed 3 out of 7 total prefixes
```
**JSON output (similar output for community)**
```
leaf-1# sh bgp l2vpn evpn large-community 13:13:13 json
{
  "bgpTableVersion":1,
  "bgpLocalRouterId":"10.100.0.1",
  "defaultLocPrf":100,
  "localAS":65000,
  "10.100.0.2:2":{
    "[5]:[0]:[64]:[111::]":{
      "prefix":"[5]:[0]:[64]:[111::]",
      "prefixLen":288,
      "paths":[
      ]
    }
  },
  "10.101.1.4:4":{
    "rd":"10.101.1.4:4",
    "[5]:[0]:[24]:[100.100.99.0]":{
      "prefix":"[5]:[0]:[24]:[100.100.99.0]",
      "prefixLen":288,
      "paths":[
        {
          "valid":true,
          "bestpath":true,
          "pathFrom":"external",
          "med":0,
          "metric":0,
          "weight":0,
          "peerId":"203.0.113.2",
          "aspath":"65002",
          "path":"65002",
          "origin":"IGP",
          "extendedCommunity":{
            "string":"RT:65002:1000 ET:8 Rmac:ba:c0:2b:39:de:bf"
          },
          "nexthops":[
            {
              "ip":"10.100.0.2",
              "afi":"ipv4",
              "used":true
            }
          ]
        }
      ]
    },
    "[5]:[0]:[32]:[200.200.200.200]":{
      "prefix":"[5]:[0]:[32]:[200.200.200.200]",
      "prefixLen":288,
      "paths":[
        {
          "valid":true,
          "bestpath":true,
          "pathFrom":"external",
          "med":0,
          "metric":0,
          "weight":0,
          "peerId":"203.0.113.2",
          "aspath":"65002",
          "path":"65002",
          "origin":"IGP",
          "extendedCommunity":{
            "string":"RT:65002:1000 ET:8 Rmac:ba:c0:2b:39:de:bf"
          },
          "nexthops":[
            {
              "ip":"10.100.0.2",
              "afi":"ipv4",
              "used":true
            }
          ]
        }
      ]
    }
  },
  "numPrefix":3,
  "totalPrefix":7
}
leaf-1#

```
Signed-off-by: Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>