### PR TITLE
pbrd: Don't track ipv6 link locals

### DIFF
--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -363,7 +363,9 @@ DEFPY(pbr_map_nexthop, pbr_map_nexthop_cmd,
 		pbr_map_check(pbrms);
 	}
 
-	if (nhop.type == NEXTHOP_TYPE_IFINDEX) {
+	if (nhop.type == NEXTHOP_TYPE_IFINDEX
+	    || (nhop.type == NEXTHOP_TYPE_IPV6_IFINDEX
+		&& IN6_IS_ADDR_LINKLOCAL(&nhop.gate.ipv6))) {
 		struct interface *ifp;
 
 		ifp = if_lookup_by_index(nhop.ifindex, nhop.vrf_id);

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -450,6 +450,12 @@ void pbr_send_rnh(struct nexthop *nhop, bool reg)
 		p.family = AF_INET6;
 		memcpy(&p.u.prefix6, &nhop->gate.ipv6, 16);
 		p.prefixlen = 128;
+		if (IN6_IS_ADDR_LINKLOCAL(&nhop->gate.ipv6))
+			/*
+			 * Don't bother tracking link locals, just track their
+			 * interface state.
+			 */
+			return;
 		break;
 	}
 


### PR DESCRIPTION
Don't bother tracking ipv6 link locals to determine if a map
should be installed. Every interface has a route of `fe80::/64`
so its just going to return the arbitrarily first one it finds
when it resolves it and hands it back to us.

Instead, just track the interface we specify along with it.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>