### PR TITLE
pimd: Fix zlog_warn when we mean debug and vice versa

### DIFF
--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -62,7 +62,7 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 		pim_inet4_dump("<upstream?>", upstream, up_str, sizeof(up_str));
 		pim_inet4_dump("<neigh?>", neigh->source_addr, neigh_str,
 			       sizeof(neigh_str));
-		zlog_warn(
+		zlog_debug(
 			"%s: join (S,G)=%s rpt=%d wc=%d upstream=%s holdtime=%d from %s on %s",
 			__PRETTY_FUNCTION__, pim_str_sg_dump(sg),
 			!!(source_flags & PIM_RPT_BIT_MASK),
@@ -94,11 +94,8 @@ static void recv_join(struct interface *ifp, struct pim_neighbor *neigh,
 				       sizeof(received_rp));
 			pim_inet4_dump("<local?>", rp->rpf_addr.u.prefix4,
 				       local_rp, sizeof(local_rp));
-			if (PIM_DEBUG_PIM_TRACE)
-				zlog_warn(
-					"%s: Specified RP(%s) in join is different than our configured RP(%s)",
-					__PRETTY_FUNCTION__, received_rp,
-					local_rp);
+			zlog_warn("%s: Specified RP(%s) in join is different than our configured RP(%s)",
+				  __PRETTY_FUNCTION__, received_rp, local_rp);
 			return;
 		}
 
@@ -122,7 +119,7 @@ static void recv_prune(struct interface *ifp, struct pim_neighbor *neigh,
 		pim_inet4_dump("<upstream?>", upstream, up_str, sizeof(up_str));
 		pim_inet4_dump("<neigh?>", neigh->source_addr, neigh_str,
 			       sizeof(neigh_str));
-		zlog_warn(
+		zlog_debug(
 			"%s: prune (S,G)=%s rpt=%d wc=%d upstream=%s holdtime=%d from %s on %s",
 			__PRETTY_FUNCTION__, pim_str_sg_dump(sg),
 			source_flags & PIM_RPT_BIT_MASK,
@@ -185,15 +182,11 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 	  Check upstream address family
 	 */
 	if (msg_upstream_addr.family != AF_INET) {
-		if (PIM_DEBUG_PIM_J_P) {
-			char src_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<src?>", src_addr, src_str,
-				       sizeof(src_str));
-			zlog_warn(
-				"%s: ignoring join/prune directed to unexpected addr family=%d from %s on %s",
-				__PRETTY_FUNCTION__, msg_upstream_addr.family,
-				src_str, ifp->name);
-		}
+		char src_str[INET_ADDRSTRLEN];
+		pim_inet4_dump("<src?>", src_addr, src_str, sizeof(src_str));
+		zlog_warn("%s: ignoring join/prune directed to unexpected addr family=%d from %s on %s",
+			  __PRETTY_FUNCTION__, msg_upstream_addr.family,
+			  src_str, ifp->name);
 		return -2;
 	}
 
@@ -270,7 +263,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 				       upstream_str, sizeof(upstream_str));
 			pim_inet4_dump("<grp?>", sg.grp, group_str,
 				       sizeof(group_str));
-			zlog_warn(
+			zlog_debug(
 				"%s: join/prune upstream=%s group=%s/32 join_src=%d prune_src=%d from %s on %s",
 				__PRETTY_FUNCTION__, upstream_str, group_str,
 				msg_num_joined_sources, msg_num_pruned_sources,

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -611,7 +611,7 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 			pim_inet4_dump("<dst?>", ip_hdr->ip_dst, ip_dst_str,
 				       sizeof(ip_dst_str));
 
-			zlog_warn(
+			zlog_debug(
 				"%s(%s): igmp kernel upcall on %s(%p) for %s -> %s",
 				__PRETTY_FUNCTION__, pim->vrf->name, ifp->name,
 				igmp, ip_src_str, ip_dst_str);
@@ -643,7 +643,7 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 				       sizeof(src_str));
 			pim_inet4_dump("<grp?>", msg->im_dst, grp_str,
 				       sizeof(grp_str));
-			zlog_warn(
+			zlog_debug(
 				"%s: pim kernel upcall %s type=%d ip_p=%d from fd=%d for (S,G)=(%s,%s) on %s vifi=%d  size=%d",
 				__PRETTY_FUNCTION__,
 				igmpmsgtype2str[msg->im_msgtype],
@@ -698,12 +698,9 @@ static int mroute_read(struct thread *t)
 			if (errno == EWOULDBLOCK || errno == EAGAIN)
 				break;
 
-			if (PIM_DEBUG_MROUTE)
-				zlog_warn(
-					"%s: failure reading rd=%d: fd=%d: errno=%d: %s",
-					__PRETTY_FUNCTION__, rd,
-					pim->mroute_socket, errno,
-					safe_strerror(errno));
+			zlog_warn("%s: failure reading rd=%d: fd=%d: errno=%d: %s",
+				  __PRETTY_FUNCTION__, rd, pim->mroute_socket,
+				  errno, safe_strerror(errno));
 			goto done;
 		}
 
@@ -1085,18 +1082,14 @@ void pim_mroute_update_counters(struct channel_oil *c_oil)
 
 	pim_zlookup_sg_statistics(c_oil);
 	if (ioctl(pim->mroute_socket, SIOCGETSGCNT, &sgreq)) {
-		if (PIM_DEBUG_MROUTE) {
-			struct prefix_sg sg;
+		struct prefix_sg sg;
 
-			sg.src = c_oil->oil.mfcc_origin;
-			sg.grp = c_oil->oil.mfcc_mcastgrp;
+		sg.src = c_oil->oil.mfcc_origin;
+		sg.grp = c_oil->oil.mfcc_mcastgrp;
 
-			zlog_warn(
-				"ioctl(SIOCGETSGCNT=%lu) failure for (S,G)=%s: errno=%d: %s",
-				(unsigned long)SIOCGETSGCNT,
-				pim_str_sg_dump(&sg), errno,
-				safe_strerror(errno));
-		}
+		zlog_warn("ioctl(SIOCGETSGCNT=%lu) failure for (S,G)=%s: errno=%d: %s",
+			  (unsigned long)SIOCGETSGCNT, pim_str_sg_dump(&sg),
+			  errno, safe_strerror(errno));
 		return;
 	}
 


### PR DESCRIPTION
There are several places in the pim where we are mixing up
zlog_warn w/ zlog_debug and vice versa.  If we are protecting
a zlog_warn w/ a debug is it really a warn?  If we have an actual
error situation we should also warn about it.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>