### PR TITLE
lib: fix gRPC northbound plugin build

### DIFF
--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -18,6 +18,8 @@
 //
 
 #include <zebra.h>
+#include <grpcpp/grpcpp.h>
+#include "grpc/frr-northbound.grpc.pb.h"
 
 #include "log.h"
 #include "libfrr.h"
@@ -31,9 +33,6 @@
 #include <sstream>
 #include <memory>
 #include <string>
-
-#include <grpcpp/grpcpp.h>
-#include "grpc/frr-northbound.grpc.pb.h"
 
 #define GRPC_DEFAULT_PORT 50051
 


### PR DESCRIPTION
Some issues with our internal vector type being typedef'd as `vector`,
which conflicts with the C++ standard vector class...