### PR TITLE
configure.ac/doc: update address sanitizer pointers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -328,8 +328,8 @@ if test "$enable_thread_sanitizer" = "yes"; then
   ])
 fi
 if test "$enable_memory_sanitizer" = "yes"; then
-  AC_C_FLAG([-fsanitize=thread -fPIE -pie], [
-    AC_MSG_ERROR([$CC does not support Thread Sanitizer.])
+  AC_C_FLAG([-fsanitize=memory -fPIE -pie], [
+    AC_MSG_ERROR([$CC does not support Memory Sanitizer.])
   ], [
     SAN_FLAGS="-fsanitize=memory -fPIE -pie"
   ])

--- a/doc/developer/topotests.rst
+++ b/doc/developer/topotests.rst
@@ -189,11 +189,8 @@ for ``master`` branch:
    git clone https://github.com/FRRouting/frr.git
    cd frr
    ./bootstrap.sh
-   export CC=gcc
-   export CFLAGS="-O1 -g -fsanitize=address -fno-omit-frame-pointer"
-   export LD=gcc
-   export LDFLAGS="-g -fsanitize=address -ldl"
-   ./configure --enable-shared=no \
+   ./configure \
+       --enable-address-sanitizer \
        --prefix=/usr/lib/frr --sysconfdir=/etc/frr \
        --localstatedir=/var/run/frr \
        --sbindir=/usr/lib/frr --bindir=/usr/lib/frr \


### PR DESCRIPTION
## Summary

Lets fix a possible copy & paste mistake here:
https://github.com/FRRouting/frr/commit/dbac691da646e624addc8f3ed5e744f9d3f8d69f#diff-67e997bcfdac55191033d57a16d1408aR266

And update the topotest address sanitizer docs.