### PR TITLE
yang: zebra modules formatting

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -104,6 +104,7 @@ lib_libfrr_la_SOURCES = \
 nodist_lib_libfrr_la_SOURCES = \
 	yang/frr-interface.yang.c \
 	yang/frr-route-types.yang.c \
+	yang/ietf/ietf-routing-types.yang.c \
 	yang/frr-module-translator.yang.c \
 	# end
 

--- a/yang/frr-nexthop.yang
+++ b/yang/frr-nexthop.yang
@@ -25,40 +25,40 @@ module frr-nexthop {
   }
 
   typedef gateway-address {
-      type inet:ip-address;
+    type inet:ip-address;
   }
 
   typedef nexthop-type {
     type enumeration {
       enum "ifindex" {
-	value 1;
-	description
-	  "Specific interface.";
+        value 1;
+        description
+          "Specific interface.";
       }
       enum "ip4" {
-	value 2;
-	description
-	  "IPv4 address.";
+        value 2;
+        description
+          "IPv4 address.";
       }
       enum "ip4-ifindex" {
-	value 3;
-	description
-	  "IPv4 address and interface.";
+        value 3;
+        description
+          "IPv4 address and interface.";
       }
       enum "ip6" {
-	value 4;
-	description
-	  "IPv6 address.";
+        value 4;
+        description
+          "IPv6 address.";
       }
       enum "ip6-ifindex" {
-	value 5;
-	description
-	  "IPv6 address and interface.";
+        value 5;
+        description
+          "IPv6 address and interface.";
       }
       enum "blackhole" {
-	value 6;
-	description
-	  "Unreachable or prohibited.";
+        value 6;
+        description
+          "Unreachable or prohibited.";
       }
     }
     description
@@ -68,24 +68,24 @@ module frr-nexthop {
   typedef blackhole-type {
     type enumeration {
       enum "unspec" {
-	value 0;
-	description
-	  "Generic unreachable.";
+        value 0;
+        description
+          "Generic unreachable.";
       }
       enum "null" {
-	value 1;
-	description
-	  "Null type.";
+        value 1;
+        description
+          "Null type.";
       }
       enum "reject" {
-	value 2;
-	description
-	  "ICMP unreachable.";
+        value 2;
+        description
+          "ICMP unreachable.";
       }
       enum "prohibited" {
-	value 3;
-	description
-	  "ICMP admin-prohibited.";
+        value 3;
+        description
+          "ICMP admin-prohibited.";
       }
     }
     default "null";
@@ -96,85 +96,89 @@ module frr-nexthop {
   /*
    * Nexthop object
    */
+
   grouping frr-nexthop {
     leaf nh-type {
       type nexthop-type;
       mandatory true;
       description
-	"The nexthop type.";
+        "The nexthop type.";
     }
 
     leaf gateway {
       type gateway-address;
       description
-	"The nexthop gateway address.";
+        "The nexthop gateway address.";
     }
 
     leaf vrf {
       type string;
       description
-	"The nexthop vrf name, if different from the route.";
+        "The nexthop vrf name, if different from the route.";
     }
 
     leaf interface {
       type string;
       description
-	"The nexthop egress interface.";
+        "The nexthop egress interface.";
     }
 
     leaf bh-type {
       type blackhole-type;
       description
-	"A blackhole sub-type, if the nexthop is a blackhole type.";
+        "A blackhole sub-type, if the nexthop is a blackhole type.";
     }
 
     leaf flags {
       type uint32;
       description
-	"The nexthop's raw flags value.";
+        "The nexthop's raw flags value.";
     }
 
     leaf is-duplicate {
       type empty;
       description
-	"Duplicate nexthop; will be ignored.";
+        "Duplicate nexthop; will be ignored.";
     }
+
     leaf is-recursive {
       type empty;
       description
-	"Nexthop must be resolved through another gateway.";
+        "Nexthop must be resolved through another gateway.";
     }
+
     leaf is-onlink {
       type empty;
       description
-	"Nexthop is directly connected.";
+        "Nexthop is directly connected.";
     }
+
     leaf is-active {
       type empty;
       description
-	"Nexthop is active.";
+        "Nexthop is active.";
     }
 
     uses rt-types:mpls-label-stack {
       description
-	"Nexthop's MPLS label stack.";
+        "Nexthop's MPLS label stack.";
     }
 
     leaf mtu {
       type uint32;
       description
-	"The nexthop's specific MTU.";
+        "The nexthop's specific MTU.";
     }
+  }
 
-  } // End of nexthop
-
+  // End of nexthop
   /*
    * Nexthop-group container
    */
+
   grouping frr-nexthop-group {
     description
       "A nexthop-group, represented as a list of nexthop objects.";
-
     leaf name {
       type string;
       description
@@ -193,8 +197,8 @@ module frr-nexthop {
       }
 
       uses frr-nexthop;
-
     }
-  } // End of frr-nexthop-group
+  }
 
+  // End of frr-nexthop-group
 }

--- a/yang/frr-nexthop.yang
+++ b/yang/frr-nexthop.yang
@@ -10,6 +10,9 @@ module frr-nexthop {
   import ietf-routing-types {
     prefix rt-types;
   }
+  import frr-interface {
+    prefix frr-interface;
+  }
 
   organization
     "Free Range Routing";
@@ -112,13 +115,15 @@ module frr-nexthop {
     }
 
     leaf vrf {
-      type string;
+      type string {
+        length "1..36";
+      }
       description
         "The nexthop vrf name, if different from the route.";
     }
 
     leaf interface {
-      type string;
+      type frr-interface:interface-ref;
       description
         "The nexthop egress interface.";
     }

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -129,7 +129,9 @@ module frr-zebra {
     description
       "Common information about a route.";
     leaf vrf {
-      type string;
+      type string {
+        length "1..36";
+      }
       description
         "The route's vrf name.";
     }
@@ -306,7 +308,9 @@ module frr-zebra {
     }
 
     leaf vrf {
-      type string;
+      type string {
+        length "1..36";
+      }
       description
         "The tenant VRF.";
     }
@@ -360,7 +364,7 @@ module frr-zebra {
 
   grouping vni-l3-detail {
     leaf svi-interface {
-      type string;
+      type frr-interface:interface-ref;
       description
         "The SVI interface.";
     }
@@ -556,7 +560,9 @@ module frr-zebra {
       choice vrf-choice {
         case single {
           leaf vrf {
-            type string;
+            type string {
+              length "1..36";
+            }
             description
               "Retrieve routes in a non-default vrf.";
           }
@@ -654,7 +660,9 @@ module frr-zebra {
       choice vrf-choice {
         case single {
           leaf vrf {
-            type string;
+            type string {
+              length "1..36";
+            }
             description
               "Retrieve routes in a non-default vrf.";
           }
@@ -690,7 +698,9 @@ module frr-zebra {
     output {
       list vrf-list {
         leaf name {
-          type string;
+          type string {
+            length "1..36";
+          }
           description
             "The VRF name";
         }
@@ -745,7 +755,9 @@ module frr-zebra {
     output {
       list vrf-vni-list {
         leaf vrf-name {
-          type string;
+          type string {
+            length "1..36";
+          }
           description
             "The VRF name.";
         }
@@ -1467,7 +1479,9 @@ module frr-zebra {
   rpc get-pbr-ipset {
     input {
       leaf name {
-        type string;
+        type string {
+          length "1..32";
+        }
         description
           "An optional specific IPset name.";
       }
@@ -1476,7 +1490,9 @@ module frr-zebra {
     output {
       list ipset-list {
         leaf name {
-          type string;
+          type string {
+            length "1..32";
+          }
           description
             "The IPset name.";
         }
@@ -1606,7 +1622,9 @@ module frr-zebra {
   rpc get-pbr-iptable {
     input {
       leaf name {
-        type string;
+        type string {
+          length "1..32";
+        }
         description
           "An optional single IPtable name.";
       }
@@ -1615,7 +1633,9 @@ module frr-zebra {
     output {
       list iptable-list {
         leaf name {
-          type string;
+          type string {
+            length "1..32";
+          }
           description
             "The IPtable name.";
         }

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -50,171 +50,49 @@ module frr-zebra {
   /*
    * Multicast RPF mode configurable type
    */
+
   typedef mcast-rpf-lookup-mode {
     type enumeration {
       enum "none" {
-	value 0;
-	description
-	  "No mode set.";
+        value 0;
+        description
+          "No mode set.";
       }
       enum "mrib-only" {
-	value 1;
-	description
-	  "Lookup in unicast RIB only.";
+        value 1;
+        description
+          "Lookup in unicast RIB only.";
       }
       enum "urib-only" {
-	value 2;
-	description
-	  "Lookup in multicast RIB only.";
+        value 2;
+        description
+          "Lookup in multicast RIB only.";
       }
       enum "mrib-then-urib" {
-	value 3;
-	description
-	  "Try multicast RIB first, fall back to unicast RIB.";
+        value 3;
+        description
+          "Try multicast RIB first, fall back to unicast RIB.";
       }
       enum "lower-distance" {
-	value 4;
-	description
-	  "Lookup both unicast and mcast, use entry with lower distance.";
+        value 4;
+        description
+          "Lookup both unicast and mcast, use entry with lower distance.";
       }
       enum "longer-prefix" {
-	value 5;
-	description
-	  "Lookup both unicast and mcast, use entry with longer prefix.";
+        value 5;
+        description
+          "Lookup both unicast and mcast, use entry with longer prefix.";
       }
     }
     description
       "Multicast RPF lookup behavior";
   }
 
-  /*
-   * Common route data, shared by v4 and v6 routes.
-   */
-  grouping route-common {
-    description
-      "Common information about a route.";
-
-    leaf vrf {
-      type string;
-      description
-	"The route's vrf name.";
-    }
-
-    leaf distance {
-      type uint8;
-      description
-        "Admin distance based on routing protocol.";
-    }
-    leaf metric {
-      type uint32;
-      description
-        "Route metric value.";
-    }
-    leaf tag {
-      type uint32 {
-        range "1..4294967295";
-      }
-      description
-        "Route tag value.";
-    }
-
-    leaf is-selected {
-      type empty;
-      description
-        "Route is the selected or preferred route for the prefix.";
-    }
-    leaf is-installed {
-      type empty;
-      description
-        "Route is installed in the FIB.";
-    }
-    leaf is-failed {
-      type empty;
-      description
-        "Route installation in FIB has failed.";
-    }
-    leaf is-queued {
-      type empty;
-      description
-        "Route has a pending FIB operation that has not completed.";
-    }
-
-    leaf internal-flags {
-      type int32;
-      description
-        "Internal flags for the route.";
-    }
-    leaf internal-status {
-      type int32;
-      description
-        "Internal status for the route.";
-    }
-
-    leaf uptime {
-      type uint32;
-      units "seconds";
-      description
-        "Uptime for the route.";
-    }
-
-    container nexthop-group {
-      description
-        "Nexthop information for the route.";
-
-      uses frr-nh:frr-nexthop-group;
-    }
-
-  } // End of route-common
-
-  /*
-   * IPv4 Route object.
-   */
-  grouping ip4-route {
-    description
-      "An IPv4 route.";
-
-    leaf prefix {
-      type inet:ipv4-prefix;
-      description
-        "IP address (in the form A.B.C.D) and prefix length,
-         separated by the slash (/) character. The range of
-         values for the prefix-length is 0 to 32.";
-    }
-    leaf "protocol" {
-      type frr-route-types:frr-route-types-v4;
-      description
-        "The protocol owning the route.";
-    }
-
-    uses route-common;
-
-  } // End of ip4-route
-
-  /*
-   * IPv6 Route object.
-   */
-  grouping ip6-route {
-    description
-      "An IPv6 route.";
-
-    leaf prefix {
-      type inet:ipv6-prefix;
-      description
-        "The route's IPv6 prefix.";
-    }
-    leaf "protocol" {
-      type frr-route-types:frr-route-types-v6;
-      description
-        "The protocol owning the route.";
-    }
-
-    uses route-common;
-
-  } // End of ip6-route
-
+  // End of ip6-route
   /*
    * VxLAN Network Identifier type
    */
+
   typedef vni-id-type {
     type uint32 {
       range "0..16777215";
@@ -235,7 +113,7 @@ module frr-zebra {
         description
           "Flooding disabled.";
       }
-      enum pim-sm {
+      enum "pim-sm" {
         value 2;
         description
           "Multicast PIM-SM.";
@@ -244,87 +122,232 @@ module frr-zebra {
   }
 
   /*
+   * Common route data, shared by v4 and v6 routes.
+   */
+
+  grouping route-common {
+    description
+      "Common information about a route.";
+    leaf vrf {
+      type string;
+      description
+        "The route's vrf name.";
+    }
+
+    leaf distance {
+      type uint8;
+      description
+        "Admin distance based on routing protocol.";
+    }
+
+    leaf metric {
+      type uint32;
+      description
+        "Route metric value.";
+    }
+
+    leaf tag {
+      type uint32 {
+        range "1..4294967295";
+      }
+      description
+        "Route tag value.";
+    }
+
+    leaf is-selected {
+      type empty;
+      description
+        "Route is the selected or preferred route for the prefix.";
+    }
+
+    leaf is-installed {
+      type empty;
+      description
+        "Route is installed in the FIB.";
+    }
+
+    leaf is-failed {
+      type empty;
+      description
+        "Route installation in FIB has failed.";
+    }
+
+    leaf is-queued {
+      type empty;
+      description
+        "Route has a pending FIB operation that has not completed.";
+    }
+
+    leaf internal-flags {
+      type int32;
+      description
+        "Internal flags for the route.";
+    }
+
+    leaf internal-status {
+      type int32;
+      description
+        "Internal status for the route.";
+    }
+
+    leaf uptime {
+      type uint32;
+      units "seconds";
+      description
+        "Uptime for the route.";
+    }
+
+    container nexthop-group {
+      description
+        "Nexthop information for the route.";
+      uses frr-nh:frr-nexthop-group;
+    }
+  }
+
+  // End of route-common
+  /*
+   * IPv4 Route object.
+   */
+
+  grouping ip4-route {
+    description
+      "An IPv4 route.";
+    leaf prefix {
+      type inet:ipv4-prefix;
+      description
+        "IP address (in the form A.B.C.D) and prefix length,
+         separated by the slash (/) character. The range of
+         values for the prefix-length is 0 to 32.";
+    }
+
+    leaf protocol {
+      type frr-route-types:frr-route-types-v4;
+      description
+        "The protocol owning the route.";
+    }
+
+    uses route-common;
+  }
+
+  // End of ip4-route
+  /*
+   * IPv6 Route object.
+   */
+
+  grouping ip6-route {
+    description
+      "An IPv6 route.";
+    leaf prefix {
+      type inet:ipv6-prefix;
+      description
+        "The route's IPv6 prefix.";
+    }
+
+    leaf protocol {
+      type frr-route-types:frr-route-types-v6;
+      description
+        "The protocol owning the route.";
+    }
+
+    uses route-common;
+  }
+
+  /*
    * Information about EVPN VNIs
    */
+
   grouping vni-information {
-      choice type-choice {
-        case l2 {
-          leaf is-layer2 {
-            type empty;
-            description
-              "Information about an L2 VNI.";
-          }
-          leaf vtep-count {
-            type uint32;
-            description
-              "Number of VTEPs.";
-          }
+    choice type-choice {
+      case l2 {
+        leaf is-layer2 {
+          type empty;
+          description
+            "Information about an L2 VNI.";
         }
-        case l3 {
-          leaf is-layer3 {
-            type empty;
-            description
-              "Information about an L3 VNI.";
-          }
+
+        leaf vtep-count {
+          type uint32;
+          description
+            "Number of VTEPs.";
         }
       }
-      leaf vni-id {
-        type vni-id-type;
-        description
-          "The VNI identifier.";
+
+      case l3 {
+        leaf is-layer3 {
+          type empty;
+          description
+            "Information about an L3 VNI.";
+        }
       }
-      leaf vxlan-ifname {
-        type frr-interface:interface-ref;
-        description
-          "The VxLAN interface name.";
-      }
-      leaf mac-count {
-        type uint32;
-        description
-          "Number of valid MACs.";
-      }
-      leaf neighbor-count {
-        type uint32;
-        description
-          "Number of neighbors.";
-      }
-      leaf vrf {
-        type string;
-        description
-          "The tenant VRF.";
-      }
-      leaf local-vtep-addr {
-        type inet:ipv4-address;
-        description
-          "The local VTEP IP address.";
-      }
+    }
+
+    leaf vni-id {
+      type vni-id-type;
+      description
+        "The VNI identifier.";
+    }
+
+    leaf vxlan-ifname {
+      type frr-interface:interface-ref;
+      description
+        "The VxLAN interface name.";
+    }
+
+    leaf mac-count {
+      type uint32;
+      description
+        "Number of valid MACs.";
+    }
+
+    leaf neighbor-count {
+      type uint32;
+      description
+        "Number of neighbors.";
+    }
+
+    leaf vrf {
+      type string;
+      description
+        "The tenant VRF.";
+    }
+
+    leaf local-vtep-addr {
+      type inet:ipv4-address;
+      description
+        "The local VTEP IP address.";
+    }
   }
 
   /*
    * Detailed EVPN VNI information for L2.
    */
+
   grouping vni-l2-detail {
     leaf if-index {
       type uint32;
       description
         "The VxLAN ifindex.";
     }
+
     leaf advertise-gw {
       type empty;
       description
         "The gateway MAC-IP is being advertised.";
     }
+
     leaf mcase-group {
       type rt-types:ipv4-multicast-group-address;
       description
         "The VNI multicast group for BUM traffic.";
     }
+
     list remote-vtep-list {
       leaf remote-vtep {
         type inet:ipv4-address;
         description
           "The remote VTEP IP address.";
       }
+
       leaf vtep-flood {
         type vni-vtep-flood-type;
       }
@@ -334,27 +357,32 @@ module frr-zebra {
   /*
    * Detailed EVPN VNI information for L3.
    */
+
   grouping vni-l3-detail {
     leaf svi-interface {
       type string;
       description
         "The SVI interface.";
     }
+
     leaf is-up {
       type empty;
       description
         "The state is active.";
     }
+
     leaf prefix-only {
       type empty;
       description
         "Prefix routes only";
     }
+
     leaf router-mac {
       type yang:mac-address;
       description
         "The VNI Router MAC address.";
     }
+
     list vni-list {
       description
         "A list of the associated L2 VNIs.";
@@ -369,238 +397,125 @@ module frr-zebra {
   /*
    * Debug options
    */
+
   grouping zebra-debugs {
     leaf debug-events {
       type boolean;
-      description "Debug ZAPI events.";
+      description
+        "Debug ZAPI events.";
     }
+
     leaf debug-zapi-send {
       type boolean;
-      description "Debug ZAPI messages sent.";
+      description
+        "Debug ZAPI messages sent.";
     }
+
     leaf debug-zapi-recv {
       type boolean;
-      description "Debug ZAPI messages received.";
+      description
+        "Debug ZAPI messages received.";
     }
+
     leaf debug-zapi-detail {
       type boolean;
-      description "Debug ZAPI details.";
+      description
+        "Debug ZAPI details.";
     }
+
     leaf debug-kernel {
       type boolean;
-      description "Debug kernel events.";
+      description
+        "Debug kernel events.";
     }
+
     leaf debug-kernel-msg-send {
       type boolean;
-      description "Debug kernel messages sent.";
+      description
+        "Debug kernel messages sent.";
     }
     leaf debug-kernel-msg-recv {
       type boolean;
-      description "Debug kernel messages received.";
+      description
+        "Debug kernel messages received.";
     }
+
     leaf debug-rib {
       type boolean;
-      description "Debug RIB processing.";
+      description
+        "Debug RIB processing.";
     }
+
     leaf debug-rib-detail {
       type boolean;
-      description "Debug RIB processing details.";
+      description
+        "Debug RIB processing details.";
     }
+
     leaf debug-fpm {
       type boolean;
-      description "Debug the FIB Push Interface subsystem.";
+      description
+        "Debug the FIB Push Interface subsystem.";
     }
+
     leaf debug-nht {
       type boolean;
-      description "Debug Nexthop-tracking.";
+      description
+        "Debug Nexthop-tracking.";
     }
+
     leaf debug-nht-detail {
       type boolean;
-      description "Debug Nexthop-tracking details.";
+      description
+        "Debug Nexthop-tracking details.";
     }
+
     leaf debug-mpls {
       type boolean;
-      description "Debug MPLS.";
+      description
+        "Debug MPLS.";
     }
+
     leaf debug-vxlan {
       type boolean;
-      description "Debug VxLAN.";
+      description
+        "Debug VxLAN.";
     }
+
     leaf debug-pw {
       type boolean;
-      description "Debug pseudowires.";
+      description
+        "Debug pseudowires.";
     }
+
     leaf debug-dplane {
       type boolean;
-      description "Debug the dataplane subsystem.";
+      description
+        "Debug the dataplane subsystem.";
     }
+
     leaf debug-dplane-detail {
       type boolean;
-      description "Debug dataplane subsystem details.";
+      description
+        "Debug dataplane subsystem details.";
     }
+
     leaf debug-mlag {
       type boolean;
-      description "Debug MLAG.";
+      description
+        "Debug MLAG.";
     }
   }
 
-  /*
-   * Main zebra container
-   */ 
-  container zebra {
-    description
-      "Data model for the Zebra daemon.";
-
-    leaf mcast-rpf-lookup {
-      type frr-zebra:mcast-rpf-lookup-mode;
-      default "mrib-then-urib";
-      description
-	"Multicast RPF lookup behavior.";
-    }
-
-    leaf ip-forwarding {
-      type boolean;
-      description
-	"IP forwarding status.";
-    }
-
-    leaf ipv6-forwarding {
-      type enumeration {
-	enum "unknown" {
-	  value -1;
-	  description
-	    "Unknown state.";
-	}
-	enum "off" {
-	  value 0;
-	  description
-	    "IPv6 forwarding disabled.";
-	}
-	enum "on" {
-	  value 1;
-	  description
-	    "IPv6 forwarding enabled.";
-	}
-      }
-      description
-	"IPv6 forwarding status.";
-    }
-
-    leaf workqueue-hold-timer {
-      type uint32 {
-        range "0..10000";
-      }
-      units "milliseconds";
-      default "10";
-      description
-        "Work-queue processing hold timer, in milliseconds.";
-    }
-
-    leaf zapi-packets {
-      type uint32 {
-        range "1..10000";
-      }
-      default "1000";
-      description
-        "Number of ZAPI packets to process before relinquishing
-        the main thread.";
-    }
-
-    container import-kernel-table {
-      description
-        "Parameters to use when importing IPv4 routes from a non-main kernel
-        routing table.";
-
-      leaf table-id {
-        type uint32 {
-          range "1..252";
-        }
-        description
-          "The kernel table id.";
-      }
-      leaf distance {
-        type uint32 {
-          range "1..255";
-        }
-        default "15";
-        description
-          "The admin distance to use for imported routes.";
-      }
-      leaf route-map {
-        type string;
-        description
-          "A route-map to filter imported routes.";
-      }
-    }
-
-    leaf allow-external-route-update {
-      type empty;
-      description
-        "Allow FRR-controlled routes to be overwritten by external processes";
-    }
-
-    leaf dplane-queue-limit {
-      type uint32 {
-        range "0..10000";
-      }
-      default "200";
-      description
-        "Limit on the number of updates queued to the dataplane subsystem.";
-    }
-
-    list vrf-vni-mapping {
-      description
-        "EVPN VNI mapping corresponding to a VRF.";
-      key "vrf-id";
-      leaf vrf-id {
-        type uint32;
-        description
-          "The identifier for a VRF.";
-      }
-      leaf vni-id {
-        type vni-id-type;
-        description
-          "The VNI id to map to the VRF.";
-      }
-      leaf prefix-only {
-        type empty;
-        description
-          "Prefix routes only.";
-      }
-    }
-
-    /*
-     * Debug options
-     */
-    container debugs {
-      uses zebra-debugs;
-    } /* End of debugs */
-
-    /*
-     * End of configuration attributes
-     */
-
-    /*
-     * Operational data.
-     */
-    container state {
-      config false;
-      description
-	"Operational data.";
-          
-    } // End of operational / state container
-
-  } // End of zebra container
-  
+  // End of zebra container
   /*
    * RPCs
    */
+
   rpc get-route-information {
     description
       "Retrieve IPv4 or IPv6 unicast routes.";
-
     input {
-
       choice ip-type {
         case v4 {
           leaf ipv4 {
@@ -614,12 +529,14 @@ module frr-zebra {
             description
               "Retrieve routes matching a specific prefix.";
           }
+
           leaf supernets-only {
             type empty;
             description
               "Skip routes that are subnets of classful prefix sizes.";
           }
         }
+
         case v6 {
           leaf ipv6 {
             type empty;
@@ -627,6 +544,7 @@ module frr-zebra {
             description
               "Retrieve IPv6 routes.";
           }
+
           leaf prefix-v6 {
             type inet:ipv6-prefix;
             description
@@ -643,6 +561,7 @@ module frr-zebra {
               "Retrieve routes in a non-default vrf.";
           }
         }
+
         case all {
           leaf all-vrfs {
             type empty;
@@ -671,6 +590,7 @@ module frr-zebra {
         description
           "Retrieve routes from a specific protocol daemon.";
       }
+
       leaf ospf-instance {
         type uint32 {
           range "1..65535";
@@ -688,6 +608,7 @@ module frr-zebra {
               "Include detailed information.";
           }
         }
+
         case summ {
           leaf summary {
             type empty;
@@ -696,8 +617,8 @@ module frr-zebra {
           }
         }
       }
-    } // End of input
-
+    }
+    // End of input
     output {
       choice route-list {
         case v4 {
@@ -709,6 +630,7 @@ module frr-zebra {
             }
           }
         }
+
         case v6 {
           container routes-v6 {
             description
@@ -719,14 +641,15 @@ module frr-zebra {
           }
         }
       }
-    } // End of output
+    }
+    // End of output
+  }
 
-  } // End get-route-information
+  // End get-route-information
 
   rpc get-v6-mroute-info {
     description
       "Retrieve IPv6 multicast routes.";
-
     input {
       choice vrf-choice {
         case single {
@@ -736,6 +659,7 @@ module frr-zebra {
               "Retrieve routes in a non-default vrf.";
           }
         }
+
         case all {
           leaf all-vrfs {
             type empty;
@@ -755,16 +679,14 @@ module frr-zebra {
         }
       }
     }
+  }
 
-  }// End get-v6-mroute-info
-
+  // End get-v6-mroute-info
 
   rpc get-vrf-info {
     description
       "Retrieve VRF information; the default VRF is elided.";
-
     // Note: no input clause.
-
     output {
       list vrf-list {
         leaf name {
@@ -772,16 +694,19 @@ module frr-zebra {
           description
             "The VRF name";
         }
+
         leaf is-user-config {
           type empty;
           description
             "The VRF was configured by an admin.";
         }
+
         leaf vrf-id {
           type uint32;
           description
             "The VRF id.";
         }
+
         choice vrf-type {
           case inactive {
             leaf is-inactive {
@@ -790,6 +715,7 @@ module frr-zebra {
                 "The VRF is inactive.";
             }
           }
+
           case netns {
             leaf netns-name {
               type string;
@@ -797,6 +723,7 @@ module frr-zebra {
                 "The net namespace name associated with the VRF.";
             }
           }
+
           case table {
             leaf table-id {
               type uint32;
@@ -807,14 +734,14 @@ module frr-zebra {
         }
       }
     }
-  } // End get-vrf-info
+  }
+
+  // End get-vrf-info
 
   rpc get-vrf-vni-info {
     description
       "Retrieve mappings between EVPN VNI and VRF.";
-
     // Note: no input clause.
-
     output {
       list vrf-vni-list {
         leaf vrf-name {
@@ -822,26 +749,31 @@ module frr-zebra {
           description
             "The VRF name.";
         }
+
         leaf vni-id {
           type vni-id-type;
           description
             "The EVPN VNI.";
         }
+
         leaf vxlan-if-name {
           type frr-interface:interface-ref;
           description
             "The VxLAN interface name.";
         }
+
         leaf svi-if-name {
           type frr-interface:interface-ref;
           description
             "The SVI interface name.";
         }
+
         leaf router-mac-addr {
           type yang:mac-address;
           description
             "Router MAC address.";
         }
+
         leaf is-up {
           type empty;
           description
@@ -849,51 +781,58 @@ module frr-zebra {
         }
       }
     }
-  } // End get-vrf-vni-info
+  }
+
+  // End get-vrf-vni-info
 
   rpc get-evpn-info {
     description
       "Retrieve global information about EVPN.";
-
     // Note: No input clause.
-
     output {
       leaf l2vni-count {
         type uint32;
         description
           "Number of L2 VNIs.";
       }
+
       leaf l3vni-count {
         type uint32;
         description
           "Number of L3 VNIs.";
       }
+
       leaf advertise-gateway {
         type empty;
         description
           "Advertise the gateway MAC-IP.";
       }
+
       leaf advertise-svi {
         type empty;
         description
           "Advertise SVI MAC-IP.";
       }
+
       leaf dup-detect {
         type empty;
         description
           "Duplicate address detection is enabled.";
       }
+
       leaf dad-max-moves {
         type uint32;
         description
           "Maximum moves allowed before address is considered duplicate.";
       }
+
       leaf dad-timeout {
         type uint32;
         units "seconds";
         description
           "Duplicate address detection timeout.";
       }
+
       leaf dad-freeze {
         type empty;
         description
@@ -908,6 +847,7 @@ module frr-zebra {
               "Duplicate address detection freeze is permanent.";
           }
         }
+
         case freeze-time {
           leaf dad-freeze-time {
             type uint32;
@@ -918,7 +858,9 @@ module frr-zebra {
         }
       }
     }
-  } // End get-evpn-info
+  }
+
+  // End get-evpn-info
 
   rpc get-vni-info {
     // If no vni is specified, retrieve global list.
@@ -932,6 +874,7 @@ module frr-zebra {
               "Retrieve information about all VNIs.";
           }
         }
+
         case single-vni {
           leaf vni-id {
             type vni-id-type;
@@ -940,6 +883,7 @@ module frr-zebra {
           }
         }
       }
+
       leaf detailed-info {
         type empty;
         description
@@ -951,7 +895,6 @@ module frr-zebra {
       list vni-list {
         description
           "Information about EVPN VNI objects.";
-
         uses vni-information;
 
         choice detail-choice {
@@ -960,6 +903,7 @@ module frr-zebra {
               "Detailed L2 information.";
             uses vni-l2-detail;
           }
+
           case l3 {
             description
               "Detailed L3 information.";
@@ -968,12 +912,13 @@ module frr-zebra {
         }
       }
     }
-  } // End get-vni-info
+  }
+
+  // End get-vni-info
 
   rpc get-evpn-vni-rmac {
     description
       "Retrieve information about VxLAN VNI RMACs.";
-
     input {
       choice vni-choice {
         default "all-vnis";
@@ -984,12 +929,14 @@ module frr-zebra {
               "Retrieve information about all VNIs.";
           }
         }
+
         case single-vni {
           leaf vni-id {
             type vni-id-type;
             description
               "Retrieve information about a specific EVPN VNI.";
           }
+
           leaf vni-rmac {
             type yang:mac-address;
             description
@@ -1006,16 +953,19 @@ module frr-zebra {
           description
             "The RMAC address.";
         }
+
         leaf remote-vtep {
           type inet:ipv4-address;
           description
             "The remote VTEP IP address.";
         }
+
         leaf refcount {
           type uint32;
           description
             "The refcount of the RMAC.";
         }
+
         list prefix-list {
           leaf prefix-item {
             type inet:ip-prefix;
@@ -1025,12 +975,13 @@ module frr-zebra {
         }
       }
     }
-  } // End get-evpn-vni-rmac
+  }
+
+  // End get-evpn-vni-rmac
 
   rpc get-evpn-vni-nexthops {
     description
       "Retrieve information about EVPN nexthops.";
-
     input {
       choice vni-choice {
         default "all-vnis";
@@ -1041,12 +992,14 @@ module frr-zebra {
               "Retrieve information about all VNIs.";
           }
         }
+
         case single-vni {
           leaf vni-id {
             type vni-id-type;
             description
               "Retrieve information about a specific EVPN VNI.";
           }
+
           leaf vni-ipaddr {
             type inet:ip-address;
             description
@@ -1063,16 +1016,19 @@ module frr-zebra {
           description
             "The nexthop IP address.";
         }
+
         leaf mac-addr {
           type yang:mac-address;
           description
             "The nexthop MAC address.";
         }
+
         leaf refcount {
           type uint32;
           description
             "The refcount of the RMAC.";
         }
+
         list prefix-list {
           leaf prefix-item {
             type inet:ip-prefix;
@@ -1080,9 +1036,11 @@ module frr-zebra {
               "IP prefixes associated with the RMAC.";
           }
         }
-      }      
+      }
     }
-  } // End get-evpn-vni-vteps
+  }
+
+  // End get-evpn-vni-vteps
 
   rpc clear-evpn-dup-addr {
     description
@@ -1096,12 +1054,14 @@ module frr-zebra {
               "Clear all VNIs.";
           }
         }
+
         case single-case {
           leaf vni-id {
             type vni-id-type;
             description
               "Clear state for a single EVPN VNI.";
           }
+
           choice ip-mac-choice {
             description
               "Clear state for a specific MAC or IP address.";
@@ -1112,6 +1072,7 @@ module frr-zebra {
                   "A specific IP address (v4 or v6).";
               }
             }
+
             case mac-case {
               leaf mac-addr {
                 type yang:mac-address;
@@ -1123,7 +1084,9 @@ module frr-zebra {
         }
       }
     }
-  } // End clear-evpn-dup-addr
+  }
+
+  // End clear-evpn-dup-addr
 
   rpc get-evpn-macs {
     description
@@ -1131,13 +1094,13 @@ module frr-zebra {
     input {
       choice all-choice {
         default "all-vni";
-
         case all-vni {
           leaf all-vnis {
             type empty;
             description
               "Retrieve information for all VNIs.";
           }
+
           choice all-choices {
             case detail-case {
               leaf all-detail {
@@ -1146,6 +1109,7 @@ module frr-zebra {
                   "Include detailed results.";
               }
             }
+
             case vtep-case {
               leaf all-vtep-addr {
                 type inet:ipv4-address;
@@ -1153,6 +1117,7 @@ module frr-zebra {
                   "A single VTEP address.";
               }
             }
+
             case dup-case {
               leaf all-dup {
                 type empty;
@@ -1162,12 +1127,14 @@ module frr-zebra {
             }
           }
         }
+
         case single-vni {
           leaf vni-id {
             type vni-id-type;
             description
               "Retrieve information for a single VNI.";
           }
+
           choice single-choices {
             case detail-case {
               leaf single-detail {
@@ -1176,6 +1143,7 @@ module frr-zebra {
                   "Include detailed results.";
               }
             }
+
             case mac-case {
               leaf single-mac {
                 type yang:mac-address;
@@ -1183,6 +1151,7 @@ module frr-zebra {
                   "A specific MAC address.";
               }
             }
+
             case vtep-case {
               leaf single-vtep {
                 type inet:ipv4-address;
@@ -1190,6 +1159,7 @@ module frr-zebra {
                   "A single VTEP address.";
               }
             }
+
             case dup-case {
               leaf single-dup {
                 type empty;
@@ -1200,8 +1170,8 @@ module frr-zebra {
           }
         }
       }
-    } // End of input section
-
+    }
+    // End of input section
     output {
       list mac-list {
         leaf mac-addr {
@@ -1209,42 +1179,50 @@ module frr-zebra {
           description
             "The MAC address.";
         }
+
         leaf vni {
           type vni-id-type;
           description
             "The VNI value.";
         }
+
         leaf local-sequence {
           type uint32;
           description
             "Local sequence number.";
         }
+
         leaf remote-sequence {
           type uint32;
           description
             "Remote sequence number.";
         }
+
         leaf dad-count {
           type uint32;
           description
             "Duplicate detection counter.";
         }
+
         leaf is-duplicate {
           type empty;
           description
             "Duplicate MAC detected.";
         }
+
         leaf dup-detect-time {
           type unix-timestamp;
           description
             "If a duplicate, the detection time.";
         }
+
         container dup-detect-started {
           leaf dup-detect-start {
             type unix-timestamp;
             description
               "Duplicate detection process start time.";
           }
+
           leaf dup-count {
             type uint32;
             description
@@ -1257,27 +1235,32 @@ module frr-zebra {
           description
             "This is an Auto MAC.";
         }
+
         leaf is-sticky {
           type empty;
           description
             "This is a sticky MAC.";
         }
+
         leaf is-default-gw {
           type empty;
           description
             "This is a default-gateway MAC.";
         }
+
         leaf is-remote-gw {
           type empty;
           description
             "This is a remote-gateway MAC.";
         }
+
         list neighbor-list {
           leaf neighbor-addr {
             type inet:ip-address;
             description
               "Neighbor address.";
           }
+
           leaf is-active {
             type empty;
             description
@@ -1290,6 +1273,7 @@ module frr-zebra {
           description
             "Number of MACs (local and remote).";
         }
+
         choice local-rem-choice {
           case local-case {
             leaf intf {
@@ -1297,12 +1281,14 @@ module frr-zebra {
               description
                 "The local interface name.";
             }
+
             leaf vlan {
               type uint32;
               description
                 "A VLAN id.";
             }
           }
+
           case remote-case {
             leaf vtep-addr {
               type inet:ipv4-address;
@@ -1313,7 +1299,9 @@ module frr-zebra {
         }
       }
     }
-  } // End get-evpn-macs
+  }
+
+  // End get-evpn-macs
 
   rpc get-evpn-arp-cache {
     description
@@ -1321,13 +1309,13 @@ module frr-zebra {
     input {
       choice all-choice {
         default "all-vni";
-
         case all-vni {
           leaf all-vnis {
             type empty;
             description
               "Retrieve information for all VNIs.";
           }
+
           choice all-choices {
             case detail-case {
               leaf all-detail {
@@ -1336,6 +1324,7 @@ module frr-zebra {
                   "Include detailed results.";
               }
             }
+
             case dup-case {
               leaf all-dup {
                 type empty;
@@ -1345,12 +1334,14 @@ module frr-zebra {
             }
           }
         }
+
         case single-vni {
           leaf vni-id {
             type vni-id-type;
             description
               "Retrieve information for a single VNI.";
           }
+
           choice single-choices {
             case vtep-case {
               leaf single-vtep {
@@ -1359,6 +1350,7 @@ module frr-zebra {
                   "A single VTEP address.";
               }
             }
+
             case neighbor-case {
               leaf neighbor-addr {
                 type inet:ip-address;
@@ -1366,6 +1358,7 @@ module frr-zebra {
                   "A single neighbor address.";
               }
             }
+
             case dup-case {
               leaf single-dup {
                 type empty;
@@ -1376,8 +1369,8 @@ module frr-zebra {
           }
         }
       }
-    } // End input section
-
+    }
+    // End input section
     output {
       list vni-list {
         container vni-container {
@@ -1388,20 +1381,22 @@ module frr-zebra {
             description
               "The VNI id.";
           }
+
           list neigh-list {
             description
               "Information about a VNI's neighbor cache.";
-
             leaf mac-addr {
               type yang:mac-address;
               description
                 "A neighbor MAC address.";
             }
+
             leaf ip-addr {
               type inet:ip-address;
               description
                 "A neighbor IP address.";
             }
+
             leaf state-active {
               type empty;
               description
@@ -1416,6 +1411,7 @@ module frr-zebra {
                     "The entry is local.";
                 }
               }
+
               case remote-case {
                 leaf is-remote {
                   type empty;
@@ -1430,26 +1426,31 @@ module frr-zebra {
               description
                 "The entry is a detected duplicate.";
             }
+
             leaf is-default-gw {
               type empty;
               description
                 "The entry is a default gateway.";
             }
+
             leaf is-router {
               type empty;
               description
                 "The entry is a router.";
             }
+
             leaf local-sequence {
               type uint32;
               description
                 "The local sequence number.";
             }
+
             leaf remote-sequence {
               type uint32;
               description
                 "The remote sequence number.";
             }
+
             leaf remote-vtep {
               type inet:ipv4-address;
               description
@@ -1459,7 +1460,9 @@ module frr-zebra {
         }
       }
     }
-  } // End get-evpn-arp-cache
+  }
+
+  // End get-evpn-arp-cache
 
   rpc get-pbr-ipset {
     input {
@@ -1477,6 +1480,7 @@ module frr-zebra {
           description
             "The IPset name.";
         }
+
         leaf ipset-type {
           type enumeration {
             enum "net-net" {
@@ -1501,21 +1505,25 @@ module frr-zebra {
             }
           }
         }
+
         leaf src-prefix {
           type inet:ip-prefix;
           description
             "";
         }
+
         leaf dest-prefix {
           type inet:ip-prefix;
           description
             "";
         }
+
         leaf src-port {
           type inet:port-number;
           description
             "";
         }
+
         leaf dest-port {
           type inet:port-number;
           description
@@ -1532,6 +1540,7 @@ module frr-zebra {
                 "Filter TCP/UDP ports only.";
             }
           }
+
           case proto-case {
             leaf proto {
               type uint32;
@@ -1540,6 +1549,7 @@ module frr-zebra {
             }
           }
         }
+
         container icmp-info {
           description
             "Additional information for ICMP filters.";
@@ -1548,33 +1558,39 @@ module frr-zebra {
             description
               "";
           }
+
           leaf type-max {
             type uint8;
             description
               "";
           }
+
           leaf code-min {
             type uint8;
             description
               "";
           }
+
           leaf code-max {
             type uint8;
             description
               "";
           }
         }
+
         container ipset-stats {
           leaf is-unique {
             type empty;
             description
               "";
           }
+
           leaf packet-counter {
             type uint64;
             description
               "";
           }
+
           leaf bytes-counter {
             type uint64;
             description
@@ -1583,7 +1599,9 @@ module frr-zebra {
         }
       }
     }
-  } // End get-pbr-ipset
+  }
+
+  // End get-pbr-ipset
 
   rpc get-pbr-iptable {
     input {
@@ -1601,95 +1619,117 @@ module frr-zebra {
           description
             "The IPtable name.";
         }
+
         leaf unique-val {
           type uint32;
           description
             "";
         }
+
         choice action-choice {
-          description "The table action.";
+          description
+            "The table action.";
           case drop-case {
             leaf action-drop {
               type empty;
-              description "";
+              description
+                "";
             }
           }
+
           case redirect-case {
             leaf action-redirect {
               type empty;
-              description "";
+              description
+                "";
             }
           }
         }
+
         leaf min-packet {
           type uint32;
           description
             "";
         }
+
         leaf max-packet {
           type uint32;
           description
             "";
         }
+
         leaf lookup-src-port {
           type empty;
           description
             "";
         }
+
         leaf lookup-dst-port {
           type empty;
           description
             "";
         }
+
         leaf tcp-flags {
           type uint16;
           description
             "";
         }
+
         leaf tcp-flags-mask {
           type uint16;
           description
             "";
         }
+
         leaf protocol-val {
           type uint32;
-          description "An IP protocol number.";
+          description
+            "An IP protocol number.";
         }
+
         container dscp-info {
           leaf dscp-value {
             type uint32;
             description
               "A DSCP value to match.";
           }
+
           leaf invert-match {
             type empty;
             description
               "If set, exclude the specified value";
           }
         }
+
         container fragment-info {
           leaf fragment-val {
             type uint32;
-            description "An IP fragment value.";
+            description
+              "An IP fragment value.";
           }
+
           leaf invert-match {
             type empty;
             description
               "If set, exclude the specified value.";
           }
         }
+
         container iptable-stats {
           leaf packet-counter {
             type uint64;
             description
               "";
           }
+
           leaf bytes-counter {
             type uint64;
             description
               "";
           }
         }
+
         container rule-info {
           description
             "Information about a rule, for redirect tables.";
@@ -1698,6 +1738,7 @@ module frr-zebra {
             description
               "The rule table id.";
           }
+
           leaf table-fwmark {
             type uint32;
             description
@@ -1706,25 +1747,29 @@ module frr-zebra {
         }
       }
     }
-  } // End get-pbr-iptable
+  }
 
+  // End get-pbr-iptable
   /*
    * Handy 'all-at-once' api to retrieve debugs
    */
+
   rpc get-debugs {
     output {
       uses zebra-debugs;
     }
-  } // End get-debugs
+  }
+
+  // End get-debugs
 
   augment "/frr-interface:lib/frr-interface:interface" {
     description
       "Extends interface model with Zebra-related parameters.";
     container zebra {
       list ip4-addr-list {
+        key "ip4-prefix";
         description
           "IPv4 prefixes for an interface.";
-        key "ip4-prefix";
         leaf ip4-prefix {
           type inet:ipv4-prefix;
           description
@@ -1742,9 +1787,9 @@ module frr-zebra {
         }
       }
       list ip6-addr-list {
+        key "ip6-prefix";
         description
           "IPv6 prefixes for an interface.";
-        key "ip6-prefix";
         leaf ip6-prefix {
           type inet:ipv6-prefix;
           description
@@ -1779,10 +1824,145 @@ module frr-zebra {
         description
           "Link bandwidth informational parameter, in megabits.";
       }
-
       // TODO -- link-params for (experimental/partial TE use in IGP extensions)
-
     }
-  } // End interface model augmentation
+  }
 
+  /*
+   * Main zebra container
+   */
+
+  container zebra {
+    description
+      "Data model for the Zebra daemon.";
+    leaf mcast-rpf-lookup {
+      type frr-zebra:mcast-rpf-lookup-mode;
+      default "mrib-then-urib";
+      description
+        "Multicast RPF lookup behavior.";
+    }
+    leaf ip-forwarding {
+      type boolean;
+      description
+        "IP forwarding status.";
+    }
+    leaf ipv6-forwarding {
+      type enumeration {
+        enum unknown {
+          value -1;
+          description
+            "Unknown state.";
+        }
+        enum off {
+          value 0;
+          description
+            "IPv6 forwarding disabled.";
+        }
+        enum on {
+          value 1;
+          description
+            "IPv6 forwarding enabled.";
+        }
+      }
+      description
+        "IPv6 forwarding status.";
+    }
+    leaf workqueue-hold-timer {
+      type uint32 {
+        range "0..10000";
+      }
+      units "milliseconds";
+      default "10";
+      description
+        "Work-queue processing hold timer, in milliseconds.";
+    }
+    leaf zapi-packets {
+      type uint32 {
+        range "1..10000";
+      }
+      default "1000";
+      description
+        "Number of ZAPI packets to process before relinquishing
+         the main thread.";
+    }
+    container import-kernel-table {
+      description
+        "Parameters to use when importing IPv4 routes from a non-main kernel
+         routing table.";
+      leaf table-id {
+        type uint32 {
+          range "1..252";
+        }
+        description
+          "The kernel table id.";
+      }
+      leaf distance {
+        type uint32 {
+          range "1..255";
+        }
+        default "15";
+        description
+          "The admin distance to use for imported routes.";
+      }
+      leaf route-map {
+        type string;
+        description
+          "A route-map to filter imported routes.";
+      }
+    }
+    leaf allow-external-route-update {
+      type empty;
+      description
+        "Allow FRR-controlled routes to be overwritten by external processes";
+    }
+    leaf dplane-queue-limit {
+      type uint32 {
+        range "0..10000";
+      }
+      default "200";
+      description
+        "Limit on the number of updates queued to the dataplane subsystem.";
+    }
+    list vrf-vni-mapping {
+      key "vrf-id";
+      description
+        "EVPN VNI mapping corresponding to a VRF.";
+      leaf vrf-id {
+        type uint32;
+        description
+          "The identifier for a VRF.";
+      }
+      leaf vni-id {
+        type vni-id-type;
+        description
+          "The VNI id to map to the VRF.";
+      }
+      leaf prefix-only {
+        type empty;
+        description
+          "Prefix routes only.";
+      }
+    }
+    /*
+     * Debug options
+     */
+    container debugs {
+      uses zebra-debugs;
+    }
+    /* End of debugs */
+    /*
+     * End of configuration attributes
+     */
+    /*
+     * Operational data.
+     */
+    container state {
+      config false;
+      description
+        "Operational data.";
+    }
+    // End of operational / state container
+  }
+
+  // End interface model augmentation
 }

--- a/yang/ietf/ietf-routing-types.yang
+++ b/yang/ietf/ietf-routing-types.yang
@@ -1,0 +1,751 @@
+module ietf-routing-types {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-routing-types";
+  prefix rt-types;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  organization
+    "IETF RTGWG - Routing Area Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/rtgwg/>
+     WG List:  <mailto:rtgwg@ietf.org>
+     Editors:  Xufeng Liu
+               <mailto:Xufeng_Liu@jabail.com>
+               Yingzhen Qu
+               <mailto:yingzhen.qu@huawei.com>
+               Acee Lindem
+               <mailto:acee@cisco.com>
+               Christian Hopps
+               <mailto:chopps@chopps.org>
+               Lou Berger
+               <mailto:lberger@labn.com>";
+
+  description
+    "This module contains a collection of YANG data types
+     considered generally useful for routing protocols.
+     Copyright (c) 2017 IETF Trust and the persons
+     identified as authors of the code.  All rights reserved.
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+     This version of this YANG module is part of RFC 8294; see
+     the RFC itself for full legal notices.";
+   revision 2017-12-04 {
+     description "Initial revision.";
+     reference
+       "RFC 8294: Common YANG Data Types for the Routing Area.
+        Section 3.";
+  }
+
+  /*** Identities related to MPLS/GMPLS ***/
+
+  identity mpls-label-special-purpose-value {
+    description
+      "Base identity for deriving identities describing
+       special-purpose Multiprotocol Label Switching (MPLS) label
+       values.";
+    reference
+      "RFC 7274: Allocating and Retiring Special-Purpose MPLS
+       Labels.";
+  }
+
+  identity ipv4-explicit-null-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the IPv4 Explicit NULL Label.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.  Section 2.1.";
+  }
+
+  identity router-alert-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Router Alert Label.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.  Section 2.1.";
+  }
+
+  identity ipv6-explicit-null-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the IPv6 Explicit NULL Label.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.  Section 2.1.";
+  }
+
+  identity implicit-null-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Implicit NULL Label.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.  Section 2.1.";
+  }
+
+  identity entropy-label-indicator {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Entropy Label Indicator.";
+    reference
+      "RFC 6790: The Use of Entropy Labels in MPLS Forwarding.
+       Sections 3 and 10.1.";
+  }
+
+  identity gal-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Generic Associated Channel
+       (G-ACh) Label (GAL).";
+    reference
+      "RFC 5586: MPLS Generic Associated Channel.
+       Sections 4 and 10.";
+  }
+
+  identity oam-alert-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the OAM Alert Label.";
+    reference
+      "RFC 3429: Assignment of the 'OAM Alert Label' for
+       Multiprotocol Label Switching Architecture (MPLS)
+       Operation and Maintenance (OAM) Functions.
+       Sections 3 and 6.";
+  }
+
+  identity extension-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Extension Label.";
+    reference
+      "RFC 7274: Allocating and Retiring Special-Purpose MPLS
+       Labels.  Sections 3.1 and 5.";
+  }
+
+  /*** Collection of types related to routing ***/
+
+  typedef router-id {
+    type yang:dotted-quad;
+    description
+      "A 32-bit number in the dotted-quad format assigned to each
+       router.  This number uniquely identifies the router within
+       an Autonomous System.";
+  }
+
+  /*** Collection of types related to VPNs ***/
+
+  typedef route-target {
+    type string {
+      pattern
+        '(0:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0):(429496729[0-5]|'
+      +     '42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
+      +     '42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|429[0-3][0-9]{6}|'
+      +     '42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0))|'
+      + '(1:((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|'
+      +     '25[0-5])\.){3}([0-9]|[1-9][0-9]|'
+      +     '1[0-9]{2}|2[0-4][0-9]|25[0-5])):(6553[0-5]|'
+      +     '655[0-2][0-9]|'
+      +     '65[0-4][0-9]{2}|6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(2:(429496729[0-5]|42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|'
+      +     '429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|'
+      +     '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0):'
+      +     '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(6(:[a-fA-F0-9]{2}){6})|'
+      + '(([3-57-9a-fA-F]|[1-9a-fA-F][0-9a-fA-F]{1,3}):'
+      +     '[0-9a-fA-F]{1,12})';
+    }
+
+    description
+      "A Route Target is an 8-octet BGP extended community
+       initially identifying a set of sites in a BGP VPN
+       (RFC 4364).  However, it has since taken on a more general
+       role in BGP route filtering.  A Route Target consists of two
+       or three fields: a 2-octet Type field, an administrator
+       field, and, optionally, an assigned number field.
+       According to the data formats for types 0, 1, 2, and 6 as
+       defined in RFC 4360, RFC 5668, and RFC 7432, the encoding
+       pattern is defined as:
+       0:2-octet-asn:4-octet-number
+       1:4-octet-ipv4addr:2-octet-number
+       2:4-octet-asn:2-octet-number
+       6:6-octet-mac-address
+       Additionally, a generic pattern is defined for future
+       Route Target types:
+       2-octet-other-hex-number:6-octet-hex-number
+       Some valid examples are 0:100:100, 1:1.1.1.1:100,
+       2:1234567890:203, and 6:26:00:08:92:78:00.";
+    reference
+      "RFC 4360: BGP Extended Communities Attribute.
+       RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).
+       RFC 5668: 4-Octet AS Specific BGP Extended Community.
+       RFC 7432: BGP MPLS-Based Ethernet VPN.";
+  }
+
+  typedef ipv6-route-target {
+    type string {
+      pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+          + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+          + '(((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}'
+          + '(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])))'
+          + ':'
+          + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          + '6[0-4][0-9]{3}|'
+          + '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)';
+      pattern '((([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+          + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))'
+          + ':'
+          + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          + '6[0-4][0-9]{3}|'
+          + '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)';
+    }
+    description
+      "An IPv6 Route Target is a 20-octet BGP IPv6 Address
+       Specific Extended Community serving the same function
+       as a standard 8-octet Route Target, except that it only
+       allows an IPv6 address as the global administrator.
+       The format is <ipv6-address:2-octet-number>.
+       Two valid examples are 2001:db8::1:6544 and
+       2001:db8::5eb1:791:6b37:17958.";
+    reference
+      "RFC 5701: IPv6 Address Specific BGP Extended Community
+       Attribute.";
+  }
+
+  typedef route-target-type {
+    type enumeration {
+      enum import {
+        value 0;
+        description
+          "The Route Target applies to route import.";
+      }
+      enum export {
+        value 1;
+        description
+          "The Route Target applies to route export.";
+      }
+
+      enum both {
+        value 2;
+        description
+          "The Route Target applies to both route import and
+           route export.";
+      }
+    }
+    description
+      "Indicates the role a Route Target takes in route filtering.";
+    reference
+      "RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).";
+  }
+
+  typedef route-distinguisher {
+    type string {
+      pattern
+        '(0:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0):(429496729[0-5]|'
+      +     '42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
+      +     '42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|429[0-3][0-9]{6}|'
+      +     '42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0))|'
+      + '(1:((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|'
+      +     '25[0-5])\.){3}([0-9]|[1-9][0-9]|'
+      +     '1[0-9]{2}|2[0-4][0-9]|25[0-5])):(6553[0-5]|'
+      +     '655[0-2][0-9]|'
+      +     '65[0-4][0-9]{2}|6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(2:(429496729[0-5]|42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|'
+      +     '429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|'
+      +     '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0):'
+      +     '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(6(:[a-fA-F0-9]{2}){6})|'
+      + '(([3-57-9a-fA-F]|[1-9a-fA-F][0-9a-fA-F]{1,3}):'
+      +     '[0-9a-fA-F]{1,12})';
+    }
+
+    description
+      "A Route Distinguisher is an 8-octet value used to
+       distinguish routes from different BGP VPNs (RFC 4364).
+       A Route Distinguisher will have the same format as a
+       Route Target as per RFC 4360 and will consist of
+       two or three fields: a 2-octet Type field, an administrator
+       field, and, optionally, an assigned number field.
+       According to the data formats for types 0, 1, 2, and 6 as
+       defined in RFC 4360, RFC 5668, and RFC 7432, the encoding
+       pattern is defined as:
+       0:2-octet-asn:4-octet-number
+       1:4-octet-ipv4addr:2-octet-number
+       2:4-octet-asn:2-octet-number
+       6:6-octet-mac-address
+       Additionally, a generic pattern is defined for future
+       route discriminator types:
+       2-octet-other-hex-number:6-octet-hex-number
+       Some valid examples are 0:100:100, 1:1.1.1.1:100,
+       2:1234567890:203, and 6:26:00:08:92:78:00.";
+    reference
+      "RFC 4360: BGP Extended Communities Attribute.
+       RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).
+       RFC 5668: 4-Octet AS Specific BGP Extended Community.
+       RFC 7432: BGP MPLS-Based Ethernet VPN.";
+  }
+
+  typedef route-origin {
+    type string {
+      pattern
+        '(0:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0):(429496729[0-5]|'
+      +     '42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
+      +     '42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|429[0-3][0-9]{6}|'
+      +     '42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0))|'
+      + '(1:((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|'
+      +     '25[0-5])\.){3}([0-9]|[1-9][0-9]|'
+      +     '1[0-9]{2}|2[0-4][0-9]|25[0-5])):(6553[0-5]|'
+      +     '655[0-2][0-9]|'
+      +     '65[0-4][0-9]{2}|6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(2:(429496729[0-5]|42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|'
+      +     '429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|'
+      +     '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0):'
+      +     '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(6(:[a-fA-F0-9]{2}){6})|'
+      + '(([3-57-9a-fA-F]|[1-9a-fA-F][0-9a-fA-F]{1,3}):'
+      +    '[0-9a-fA-F]{1,12})';
+    }
+    description
+      "A Route Origin is an 8-octet BGP extended community
+       identifying the set of sites where the BGP route
+       originated (RFC 4364).  A Route Origin will have the same
+       format as a Route Target as per RFC 4360 and will consist
+       of two or three fields: a 2-octet Type field, an
+       administrator field, and, optionally, an assigned number
+       field.
+       According to the data formats for types 0, 1, 2, and 6 as
+       defined in RFC 4360, RFC 5668, and RFC 7432, the encoding
+       pattern is defined as:
+       0:2-octet-asn:4-octet-number
+       1:4-octet-ipv4addr:2-octet-number
+       2:4-octet-asn:2-octet-number
+       6:6-octet-mac-address
+       Additionally, a generic pattern is defined for future
+       Route Origin types:
+       2-octet-other-hex-number:6-octet-hex-number
+       Some valid examples are 0:100:100, 1:1.1.1.1:100,
+       2:1234567890:203, and 6:26:00:08:92:78:00.";
+    reference
+      "RFC 4360: BGP Extended Communities Attribute.
+       RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).
+       RFC 5668: 4-Octet AS Specific BGP Extended Community.
+       RFC 7432: BGP MPLS-Based Ethernet VPN.";
+  }
+
+  typedef ipv6-route-origin {
+    type string {
+      pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+          + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+          + '(((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}'
+          + '(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])))'
+          + ':'
+          + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          + '6[0-4][0-9]{3}|'
+          + '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)';
+      pattern '((([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+          + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))'
+          + ':'
+          + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          + '6[0-4][0-9]{3}|'
+          + '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)';
+    }
+    description
+      "An IPv6 Route Origin is a 20-octet BGP IPv6 Address
+       Specific Extended Community serving the same function
+       as a standard 8-octet route, except that it only allows
+       an IPv6 address as the global administrator.  The format
+       is <ipv6-address:2-octet-number>.
+       Two valid examples are 2001:db8::1:6544 and
+       2001:db8::5eb1:791:6b37:17958.";
+    reference
+      "RFC 5701: IPv6 Address Specific BGP Extended Community
+       Attribute.";
+  }
+
+  /*** Collection of types common to multicast ***/
+
+  typedef ipv4-multicast-group-address {
+    type inet:ipv4-address {
+      pattern '(2((2[4-9])|(3[0-9]))\.).*';
+    }
+    description
+      "This type represents an IPv4 multicast group address,
+       which is in the range of 224.0.0.0 to 239.255.255.255.";
+    reference
+      "RFC 1112: Host Extensions for IP Multicasting.";
+  }
+
+  typedef ipv6-multicast-group-address {
+    type inet:ipv6-address {
+      pattern '(([fF]{2}[0-9a-fA-F]{2}):).*';
+    }
+    description
+      "This type represents an IPv6 multicast group address,
+       which is in the range of ff00::/8.";
+    reference
+      "RFC 4291: IP Version 6 Addressing Architecture.  Section 2.7.
+       RFC 7346: IPv6 Multicast Address Scopes.";
+  }
+
+  typedef ip-multicast-group-address {
+    type union {
+      type ipv4-multicast-group-address;
+      type ipv6-multicast-group-address;
+    }
+    description
+      "This type represents a version-neutral IP multicast group
+       address.  The format of the textual representation implies
+       the IP version.";
+  }
+
+  typedef ipv4-multicast-source-address {
+    type union {
+      type enumeration {
+        enum * {
+          description
+            "Any source address.";
+        }
+      }
+      type inet:ipv4-address;
+    }
+    description
+      "Multicast source IPv4 address type.";
+  }
+
+  typedef ipv6-multicast-source-address {
+    type union {
+      type enumeration {
+        enum * {
+          description
+            "Any source address.";
+        }
+      }
+      type inet:ipv6-address;
+    }
+    description
+      "Multicast source IPv6 address type.";
+  }
+
+  /*** Collection of types common to protocols ***/
+
+  typedef bandwidth-ieee-float32 {
+    type string {
+      pattern
+        '0[xX](0((\.0?)?[pP](\+)?0?|(\.0?))|'
+      + '1(\.([0-9a-fA-F]{0,5}[02468aAcCeE]?)?)?[pP](\+)?(12[0-7]|'
+      + '1[01][0-9]|0?[0-9]?[0-9])?)';
+    }
+    description
+      "Bandwidth in IEEE 754 floating-point 32-bit binary format:
+       (-1)**(S) * 2**(Exponent-127) * (1 + Fraction),
+       where Exponent uses 8 bits and Fraction uses 23 bits.
+       The units are octets per second.
+       The encoding format is the external hexadecimal-significant
+       character sequences specified in IEEE 754 and ISO/IEC C99.
+       The format is restricted to be normalized, non-negative, and
+       non-fraction: 0x1.hhhhhhp{+}d, 0X1.HHHHHHP{+}D, or 0x0p0,
+       where 'h' and 'H' are hexadecimal digits and 'd' and 'D' are
+       integers in the range of [0..127].
+       When six hexadecimal digits are used for 'hhhhhh' or
+       'HHHHHH', the least significant digit must be an even
+       number.  'x' and 'X' indicate hexadecimal; 'p' and 'P'
+       indicate a power of two.  Some examples are 0x0p0, 0x1p10,
+       and 0x1.abcde2p+20.";
+    reference
+      "IEEE Std 754-2008: IEEE Standard for Floating-Point
+       Arithmetic.
+       ISO/IEC C99: Information technology - Programming
+       Languages - C.";
+  }
+
+  typedef link-access-type {
+    type enumeration {
+      enum broadcast {
+        description
+          "Specify broadcast multi-access network.";
+      }
+      enum non-broadcast-multiaccess {
+        description
+          "Specify Non-Broadcast Multi-Access (NBMA) network.";
+      }
+      enum point-to-multipoint {
+        description
+          "Specify point-to-multipoint network.";
+      }
+      enum point-to-point {
+        description
+          "Specify point-to-point network.";
+      }
+    }
+    description
+      "Link access type.";
+  }
+
+  typedef timer-multiplier {
+    type uint8;
+    description
+      "The number of timer value intervals that should be
+       interpreted as a failure.";
+  }
+
+  typedef timer-value-seconds16 {
+    type union {
+      type uint16 {
+        range "1..65535";
+      }
+      type enumeration {
+        enum infinity {
+          description
+            "The timer is set to infinity.";
+        }
+        enum not-set {
+          description
+            "The timer is not set.";
+        }
+      }
+    }
+    units "seconds";
+    description
+      "Timer value type, in seconds (16-bit range).";
+  }
+
+  typedef timer-value-seconds32 {
+    type union {
+      type uint32 {
+        range "1..4294967295";
+      }
+      type enumeration {
+        enum infinity {
+          description
+            "The timer is set to infinity.";
+        }
+        enum not-set {
+          description
+            "The timer is not set.";
+        }
+      }
+    }
+    units "seconds";
+    description
+      "Timer value type, in seconds (32-bit range).";
+  }
+
+  typedef timer-value-milliseconds {
+    type union {
+      type uint32 {
+        range "1..4294967295";
+      }
+      type enumeration {
+        enum infinity {
+          description
+            "The timer is set to infinity.";
+        }
+        enum not-set {
+          description
+            "The timer is not set.";
+        }
+      }
+    }
+    units "milliseconds";
+    description
+      "Timer value type, in milliseconds.";
+  }
+
+  typedef percentage {
+    type uint8 {
+      range "0..100";
+    }
+    description
+      "Integer indicating a percentage value.";
+  }
+
+  typedef timeticks64 {
+    type uint64;
+    description
+      "This type is based on the timeticks type defined in
+       RFC 6991, but with 64-bit width.  It represents the time,
+       modulo 2^64, in hundredths of a second between two epochs.";
+    reference
+      "RFC 6991: Common YANG Data Types.";
+  }
+
+  typedef uint24 {
+    type uint32 {
+      range "0..16777215";
+    }
+    description
+      "24-bit unsigned integer.";
+  }
+
+  /*** Collection of types related to MPLS/GMPLS ***/
+
+  typedef generalized-label {
+    type binary;
+    description
+      "Generalized Label.  Nodes sending and receiving the
+       Generalized Label are aware of the link-specific
+       label context and type.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description.  Section 3.2.";
+  }
+
+  typedef mpls-label-special-purpose {
+    type identityref {
+      base mpls-label-special-purpose-value;
+    }
+    description
+      "This type represents the special-purpose MPLS label values.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.
+       RFC 7274: Allocating and Retiring Special-Purpose MPLS
+       Labels.";
+  }
+
+  typedef mpls-label-general-use {
+    type uint32 {
+      range "16..1048575";
+    }
+    description
+      "The 20-bit label value in an MPLS label stack as specified
+       in RFC 3032.  This label value does not include the
+       encodings of Traffic Class and TTL (Time to Live).
+       The label range specified by this type is for general use,
+       with special-purpose MPLS label values excluded.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.";
+  }
+
+  typedef mpls-label {
+    type union {
+      type mpls-label-special-purpose;
+      type mpls-label-general-use;
+    }
+    description
+      "The 20-bit label value in an MPLS label stack as specified
+       in RFC 3032.  This label value does not include the
+       encodings of Traffic Class and TTL.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.";
+  }
+
+  /*** Groupings **/
+
+  grouping mpls-label-stack {
+    description
+      "This grouping specifies an MPLS label stack.  The label
+       stack is encoded as a list of label stack entries.  The
+       list key is an identifier that indicates the relative
+       ordering of each entry, with the lowest-value identifier
+       corresponding to the top of the label stack.";
+    container mpls-label-stack {
+      description
+        "Container for a list of MPLS label stack entries.";
+      list entry {
+        key "id";
+        description
+          "List of MPLS label stack entries.";
+        leaf id {
+          type uint8;
+          description
+            "Identifies the entry in a sequence of MPLS label
+             stack entries.  An entry with a smaller identifier
+             value precedes an entry with a larger identifier
+             value in the label stack.  The value of this ID has
+             no semantic meaning other than relative ordering
+             and referencing the entry.";
+        }
+        leaf label {
+          type rt-types:mpls-label;
+          description
+            "Label value.";
+        }
+
+        leaf ttl {
+          type uint8;
+          description
+            "Time to Live (TTL).";
+          reference
+            "RFC 3032: MPLS Label Stack Encoding.";
+        }
+        leaf traffic-class {
+          type uint8 {
+            range "0..7";
+          }
+          description
+            "Traffic Class (TC).";
+          reference
+            "RFC 5462: Multiprotocol Label Switching (MPLS) Label
+             Stack Entry: 'EXP' Field Renamed to 'Traffic Class'
+             Field.";
+        }
+      }
+    }
+  }
+
+  grouping vpn-route-targets {
+    description
+      "A grouping that specifies Route Target import-export rules
+       used in BGP-enabled VPNs.";
+    reference
+      "RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).
+       RFC 4664: Framework for Layer 2 Virtual Private Networks
+       (L2VPNs).";
+    list vpn-target {
+      key "route-target";
+      description
+        "List of Route Targets.";
+      leaf route-target {
+        type rt-types:route-target;
+        description
+          "Route Target value.";
+      }
+      leaf route-target-type {
+        type rt-types:route-target-type;
+        mandatory true;
+        description
+          "Import/export type of the Route Target.";
+      }
+    }
+  }
+}

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -23,6 +23,7 @@ dist_yangmodels_DATA += yang/frr-module-translator.yang
 dist_yangmodels_DATA += yang/frr-test-module.yang
 dist_yangmodels_DATA += yang/frr-interface.yang
 dist_yangmodels_DATA += yang/frr-route-types.yang
+dist_yangmodels_DATA += yang/ietf/ietf-routing-types.yang
 
 if BFDD
 dist_yangmodels_DATA += yang/frr-bfdd.yang


### PR DESCRIPTION
Add ietf routing types module to frr repository. 
Align zebra yang modules (frr-zebra.yang and frr-nexthop.yang) based pyang lint format. 
Add range to various string nodes in zebra yang modules 

Further work to generate northbound apis  and include in makefile will be in future PRs. 