### PR TITLE
bgpd: AS paths are uint32_t instead of integers

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -576,7 +576,7 @@ static void aspath_make_str_count(struct aspath *as, bool make_json)
 			if (make_json)
 				json_object_array_add(
 					jseg_list,
-					json_object_new_int(seg->as[i]));
+					json_object_new_int64(seg->as[i]));
 
 			len += snprintf(str_buf + len, str_size - len, "%u",
 					seg->as[i]);

--- a/lib/json.c
+++ b/lib/json.c
@@ -47,11 +47,7 @@ void json_object_string_add(struct json_object *obj, const char *key,
 
 void json_object_int_add(struct json_object *obj, const char *key, int64_t i)
 {
-#if defined(HAVE_JSON_C_JSON_H)
 	json_object_object_add(obj, key, json_object_new_int64(i));
-#else
-	json_object_object_add(obj, key, json_object_new_int((int)i));
-#endif
 }
 
 void json_object_boolean_false_add(struct json_object *obj, const char *key)
@@ -78,16 +74,3 @@ void json_object_free(struct json_object *obj)
 {
 	json_object_put(obj);
 }
-
-#if !defined(HAVE_JSON_C_JSON_H)
-int json_object_object_get_ex(struct json_object *obj, const char *key,
-			      struct json_object **value)
-{
-	*value = json_object_object_get(obj, key);
-
-	if (*value)
-		return 1;
-
-	return 0;
-}
-#endif

--- a/lib/json.h
+++ b/lib/json.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif
 
-#if defined(HAVE_JSON_C_JSON_H)
+#include "command.h"
 #include <json-c/json.h>
 
 /*
@@ -40,21 +40,6 @@ extern "C" {
 	    (join) = json_object_iter_end((jo));                               \
 	     json_object_iter_equal(&(joi), &(join)) == 0;                     \
 	     json_object_iter_next(&(joi)))
-
-#else
-#include <json/json.h>
-
-/*
- * json_object_to_json_string_ext is only available for json-c
- * so let's just turn it back to the original usage.
- */
-#define json_object_to_json_string_ext(A, B) json_object_to_json_string (A)
-
-extern int json_object_object_get_ex(struct json_object *obj, const char *key,
-				     struct json_object **value);
-#endif
-
-#include "command.h"
 
 extern bool use_json(const int argc, struct cmd_token *argv[]);
 extern void json_object_string_add(struct json_object *obj, const char *key,


### PR DESCRIPTION
We have some JSON output that was displaying high order
AS path data as negative numbers:

{
 "paths":[
    {
      "aspath":{
        "string":"4200010118 4200010000 20473 1299",
        "segments":[
          {
            "type":"as-sequence",
            "list":[
              -94957178,
              -94957296,
              20473,
              1299
            ]
          }
        ],

Notice "String" output -vs- the list.

With fixed code:

  "paths":[
    {
      "aspath":{
        "string":"64539 4294967000 15096 6939 7922 7332 4249",
        "segments":[
          {
            "type":"as-sequence",
            "list":[
              64539,
              4294967000,
              15096,
              6939,
              7922,
              7332,
              4249
            ]
          }
        ],

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>