### PR TITLE
bgpd: When creating extra from stack ensure it is zero'ed out

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -109,7 +109,7 @@ int bgp_nlri_parse_vpn(struct peer *peer, struct attr *attr,
 	uint16_t type;
 	struct rd_as rd_as;
 	struct rd_ip rd_ip;
-	struct prefix_rd prd;
+	struct prefix_rd prd = {0};
 	mpls_label_t label = {0};
 	afi_t afi;
 	safi_t safi;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1785,9 +1785,9 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 
 	/* Route map & unsuppress-map apply. */
 	if (ROUTE_MAP_OUT_NAME(filter) || (pi->extra && pi->extra->suppress)) {
-		struct bgp_path_info rmap_path;
-		struct bgp_path_info_extra dummy_rmap_path_extra;
-		struct attr dummy_attr;
+		struct bgp_path_info rmap_path = {0};
+		struct bgp_path_info_extra dummy_rmap_path_extra = {0};
+		struct attr dummy_attr = {0};
 
 		memset(&rmap_path, 0, sizeof(struct bgp_path_info));
 		rmap_path.peer = peer;

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -2179,8 +2179,8 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 {
 	struct skiplist *sl;
 	int rc;
-	struct bgp_path_info bpi_fake;
-	struct bgp_path_info_extra bpi_extra;
+	struct bgp_path_info bpi_fake = {0};
+	struct bgp_path_info_extra bpi_extra = {0};
 	struct bgp_path_info *bpi_result;
 
 	sl = RFAPI_RDINDEX(rn);

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -773,8 +773,18 @@ int prefix_cmp(union prefixconstptr up1, union prefixconstptr up2)
 	if (i)
 		return i;
 
-	return numcmp(pp1[offset] & maskbit[shift],
-		      pp2[offset] & maskbit[shift]);
+	/*
+	 * At this point offset was the same, if we have shift
+	 * that means we still have data to compare, if shift is
+	 * 0 then we are at the end of the data structure
+	 * and should just return, as that we will be accessing
+	 * memory beyond the end of the party zone
+	 */
+	if (shift)
+		return numcmp(pp1[offset] & maskbit[shift],
+			      pp2[offset] & maskbit[shift]);
+
+	return 0;
 }
 
 /*


### PR DESCRIPTION
BGP code assumes that the extra data is zero'ed out.  Ensure that we
are not leaving any situation that the data on the stack is actually all
0's when we pass it around as a pointer later.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>