### PR TITLE
lib, zebra: Fix last write command written

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -293,6 +293,10 @@ int zclient_send_message(struct zclient *zclient)
 	return 0;
 }
 
+/*
+ * If we add more data to this structure please ensure that
+ * struct zmsghdr in lib/zclient.h is updated as appropriate.
+ */
 void zclient_create_header(struct stream *s, uint16_t command, vrf_id_t vrf_id)
 {
 	/* length placeholder, caller can update */

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -298,7 +298,8 @@ struct zmsghdr {
 	uint8_t version;
 	vrf_id_t vrf_id;
 	uint16_t command;
-};
+} __attribute__((packed));
+#define ZAPI_HEADER_CMD_LOCATION offsetof(struct zmsghdr, command)
 
 struct zapi_nexthop {
 	enum nexthop_types_t type;

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -240,7 +240,7 @@ static int zserv_write(struct thread *thread)
 	if (cache->tail) {
 		msg = cache->tail;
 		stream_set_getp(msg, 0);
-		wcmd = stream_getw_from(msg, 6);
+		wcmd = stream_getw_from(msg, ZAPI_HEADER_CMD_LOCATION);
 	}
 
 	while (stream_fifo_head(cache)) {


### PR DESCRIPTION
With commit: a9ff90c41b0a95195d19d451ee83eb460e1599d0
the vrf_id_t was changed from a uint16_t to a uint32_t

Zebra tracked the last command sent to it's peer via peeking
into the data it was sending to each client ( since we had
lost the idea of what the command was when it was time to track
the data ).

Add a define to track this and add a bit of verbiage
to the code to allow us to notice when we screw with
the header again so that this is just fixed correctly
when it happens again.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>