### PR TITLE
bfdd: pack of bug fixes

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1432,7 +1432,7 @@ struct bfd_session *bfd_key_lookup(struct bfd_key key)
 	if (ctx.result) {
 		bsp = ctx.result;
 		log_debug(" peer %s found, but ifp"
-			  " and/or loc-addr params ignored");
+			  " and/or loc-addr params ignored", peer_buf);
 	}
 	return bsp;
 }

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1709,6 +1709,15 @@ static int bfd_vrf_disable(struct vrf *vrf)
 	}
 
 	log_debug("VRF disable %s id %d", vrf->name, vrf->vrf_id);
+
+	/* Disable read/write poll triggering. */
+	THREAD_OFF(bvrf->bg_ev[0]);
+	THREAD_OFF(bvrf->bg_ev[1]);
+	THREAD_OFF(bvrf->bg_ev[2]);
+	THREAD_OFF(bvrf->bg_ev[3]);
+	THREAD_OFF(bvrf->bg_ev[4]);
+	THREAD_OFF(bvrf->bg_ev[5]);
+
 	/* Close all descriptors. */
 	socket_close(&bvrf->bg_echo);
 	socket_close(&bvrf->bg_shop);

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1217,19 +1217,10 @@ int bs_observer_add(struct bfd_session *bs)
 	struct bfd_session_observer *bso;
 
 	bso = XCALLOC(MTYPE_BFDD_SESSION_OBSERVER, sizeof(*bso));
-	bso->bso_isaddress = false;
 	bso->bso_bs = bs;
-	bso->bso_isinterface = !BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH);
-	if (bso->bso_isinterface)
-		strlcpy(bso->bso_entryname, bs->key.ifname,
-			sizeof(bso->bso_entryname));
-	/* Handle socket binding failures caused by missing local addresses. */
-	if (bs->sock == -1) {
-		bso->bso_isaddress = true;
-		bso->bso_addr.family = bs->key.family;
-		memcpy(&bso->bso_addr.u.prefix, &bs->key.local,
-		       sizeof(bs->key.local));
-	}
+	bso->bso_addr.family = bs->key.family;
+	memcpy(&bso->bso_addr.u.prefix, &bs->key.local,
+	       sizeof(bs->key.local));
 
 	TAILQ_INSERT_TAIL(&bglobal.bg_obslist, bso, bso_entry);
 

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -216,6 +216,7 @@ void bfd_session_disable(struct bfd_session *bs)
 	bfd_echo_recvtimer_delete(bs);
 	bfd_xmttimer_delete(bs);
 	bfd_echo_xmttimer_delete(bs);
+	bs->vrf = NULL;
 }
 
 static uint32_t ptm_bfd_gen_ID(void)

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -274,12 +274,8 @@ struct bfd_state_str_list {
 
 struct bfd_session_observer {
 	struct bfd_session *bso_bs;
-	bool bso_isinterface;
-	bool bso_isaddress;
-	union {
-		char bso_entryname[MAXNAMELEN];
-		struct prefix bso_addr;
-	};
+	char bso_entryname[MAXNAMELEN];
+	struct prefix bso_addr;
 
 	TAILQ_ENTRY(bfd_session_observer) bso_entry;
 };

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -579,8 +579,6 @@ static void bfdd_sessions_enable_interface(struct interface *ifp)
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
 		bs = bso->bso_bs;
-		if (bso->bso_isinterface == false)
-			continue;
 		/* Interface name mismatch. */
 		if (strcmp(ifp->name, bs->key.ifname))
 			continue;
@@ -605,10 +603,6 @@ static void bfdd_sessions_disable_interface(struct interface *ifp)
 	struct bfd_session *bs;
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
-		if (bso->bso_isinterface == false)
-			continue;
-
-		/* Interface name mismatch. */
 		bs = bso->bso_bs;
 		if (strcmp(ifp->name, bs->key.ifname))
 			continue;
@@ -616,7 +610,6 @@ static void bfdd_sessions_disable_interface(struct interface *ifp)
 		if (bs->sock == -1)
 			continue;
 
-		/* Try to enable it. */
 		bfd_session_disable(bs);
 
 	}
@@ -658,8 +651,6 @@ void bfdd_sessions_disable_vrf(struct vrf *vrf)
 	struct bfd_session *bs;
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
-		if (bso->bso_isinterface)
-			continue;
 		bs = bso->bso_bs;
 		if (bs->key.vrfname[0] &&
 		    strcmp(vrf->name, bs->key.vrfname))
@@ -668,7 +659,6 @@ void bfdd_sessions_disable_vrf(struct vrf *vrf)
 		if (bs->sock == -1)
 			continue;
 
-		/* Try to enable it. */
 		bfd_session_disable(bs);
 	}
 }
@@ -701,9 +691,6 @@ static void bfdd_sessions_enable_address(struct connected *ifc)
 	struct prefix prefix;
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
-		if (bso->bso_isaddress == false)
-			continue;
-
 		/* Skip enabled sessions. */
 		bs = bso->bso_bs;
 		if (bs->sock != -1)

--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -799,7 +799,7 @@ struct yang_data *yang_data_new_prefix(const char *xpath,
 	return yang_data_new(xpath, value_str);
 }
 
-void yang_dnode_get_prefix(union prefixptr prefix, const struct lyd_node *dnode,
+void yang_dnode_get_prefix(struct prefix *prefix, const struct lyd_node *dnode,
 			   const char *xpath_fmt, ...)
 {
 	const struct lyd_node_leaf_list *dleaf;
@@ -816,9 +816,15 @@ void yang_dnode_get_prefix(union prefixptr prefix, const struct lyd_node *dnode,
 		YANG_DNODE_GET_ASSERT(dnode, xpath);
 	}
 
+	/*
+	 * Initialize prefix to avoid static analyzer complaints about
+	 * uninitialized memory.
+	 */
+	memset(prefix, 0, sizeof(*prefix));
+
 	dleaf = (const struct lyd_node_leaf_list *)dnode;
 	assert(dleaf->value_type == LY_TYPE_STRING);
-	(void)str2prefix(dleaf->value_str, prefix.p);
+	(void)str2prefix(dleaf->value_str, prefix);
 }
 
 void yang_get_default_prefix(union prefixptr var, const char *xpath_fmt, ...)

--- a/lib/yang_wrappers.h
+++ b/lib/yang_wrappers.h
@@ -118,7 +118,7 @@ extern void yang_get_default_string_buf(char *buf, size_t size,
 extern void yang_str2prefix(const char *value, union prefixptr prefix);
 extern struct yang_data *yang_data_new_prefix(const char *xpath,
 					      union prefixconstptr prefix);
-extern void yang_dnode_get_prefix(union prefixptr prefix,
+extern void yang_dnode_get_prefix(struct prefix *prefix,
 				  const struct lyd_node *dnode,
 				  const char *xpath_fmt, ...);
 extern void yang_get_default_prefix(union prefixptr var, const char *xpath_fmt,


### PR DESCRIPTION
## Summary

A pack of `bfdd` bug fixes found recently by a number of people. Some of these were taken from PRs which are not moving forward due review issues.

Bug fixes:

*   Fix crash on session lookup debug message (fixed by @SumitAgarwal123 - #5017 );
*   Partial VRF crash fix on VRF removal (fixed by @pguibert6WIND - #5135 );
*   Disable VRF socket pulling when `close`/`free`ing the data structures (avoids unecessary wake ups);
*   Set session to down state while disabling it (if a session is disabled due dependencies, then it is down);
*   Simplify observers code: look for all possible cenarios, don't try to optimize it (fixes a use-after-free caused by optimization of observers skipping);
*   Don't allow creating peers with link-local address without specifying interface (spotted by @zays26 - #5137 );

This should also fix issue #5133 .