### PR TITLE
Northbound optimizations

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -1709,6 +1709,8 @@ static int vty_write_config(struct vty *vty)
 	if (host.noconfig)
 		return CMD_SUCCESS;
 
+	nb_cli_show_config_prepare(running_config, false);
+
 	if (vty->type == VTY_TERM) {
 		vty_out(vty, "\nCurrent configuration:\n");
 		vty_out(vty, "!\n");

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -516,17 +516,6 @@ int nb_candidate_edit(struct nb_config *candidate,
 				  __func__);
 			return NB_ERR;
 		}
-
-		/*
-		 * If a new node was created, call lyd_validate() only to create
-		 * default child nodes.
-		 */
-		if (dnode) {
-			lyd_schema_sort(dnode, 0);
-			lyd_validate(&dnode,
-				     LYD_OPT_CONFIG | LYD_OPT_WHENAUTODEL,
-				     ly_native_ctx);
-		}
 		break;
 	case NB_OP_DESTROY:
 		dnode = yang_dnode_get(candidate->dnode, xpath_edit);

--- a/lib/northbound.c
+++ b/lib/northbound.c
@@ -381,7 +381,6 @@ static void nb_config_diff_add_change(struct nb_config_cbs *changes,
 	change->cb.seq = *seq;
 	*seq = *seq + 1;
 	change->cb.nb_node = dnode->schema->priv;
-	yang_dnode_get_path(dnode, change->cb.xpath, sizeof(change->cb.xpath));
 	change->cb.dnode = dnode;
 
 	RB_INSERT(nb_config_cbs, changes, &change->cb);
@@ -810,7 +809,7 @@ static int nb_callback_configuration(const enum nb_event event,
 				     struct nb_config_change *change)
 {
 	enum nb_operation operation = change->cb.operation;
-	const char *xpath = change->cb.xpath;
+	char xpath[XPATH_MAXLEN];
 	const struct nb_node *nb_node = change->cb.nb_node;
 	const struct lyd_node *dnode = change->cb.dnode;
 	union nb_resource *resource;
@@ -822,6 +821,7 @@ static int nb_callback_configuration(const enum nb_event event,
 		if (dnode && !yang_snode_is_typeless_data(dnode->schema))
 			value = yang_dnode_get_string(dnode, NULL);
 
+		yang_dnode_get_path(dnode, xpath, sizeof(xpath));
 		nb_log_callback(event, operation, xpath, value);
 	}
 
@@ -844,6 +844,7 @@ static int nb_callback_configuration(const enum nb_event event,
 		ret = (*nb_node->cbs.move)(event, dnode);
 		break;
 	default:
+		yang_dnode_get_path(dnode, xpath, sizeof(xpath));
 		flog_err(EC_LIB_DEVELOPMENT,
 			 "%s: unknown operation (%u) [xpath %s]", __func__,
 			 operation, xpath);
@@ -853,6 +854,8 @@ static int nb_callback_configuration(const enum nb_event event,
 	if (ret != NB_OK) {
 		int priority;
 		enum lib_log_refs ref;
+
+		yang_dnode_get_path(dnode, xpath, sizeof(xpath));
 
 		switch (event) {
 		case NB_EV_VALIDATE:
@@ -1024,14 +1027,12 @@ static int nb_transaction_process(enum nb_event event,
 }
 
 static struct nb_config_cb *
-nb_apply_finish_cb_new(struct nb_config_cbs *cbs, const char *xpath,
-		       const struct nb_node *nb_node,
+nb_apply_finish_cb_new(struct nb_config_cbs *cbs, const struct nb_node *nb_node,
 		       const struct lyd_node *dnode)
 {
 	struct nb_config_cb *cb;
 
 	cb = XCALLOC(MTYPE_TMP, sizeof(*cb));
-	strlcpy(cb->xpath, xpath, sizeof(cb->xpath));
 	cb->nb_node = nb_node;
 	cb->dnode = dnode;
 	RB_INSERT(nb_config_cbs, cbs, cb);
@@ -1057,6 +1058,7 @@ static void nb_transaction_apply_finish(struct nb_transaction *transaction)
 {
 	struct nb_config_cbs cbs;
 	struct nb_config_cb *cb;
+	char xpath[XPATH_MAXLEN];
 
 	/* Initialize tree of 'apply_finish' callbacks. */
 	RB_INIT(nb_config_cbs, &cbs);
@@ -1073,8 +1075,6 @@ static void nb_transaction_apply_finish(struct nb_transaction *transaction)
 		 * be called though).
 		 */
 		if (change->cb.operation == NB_OP_DESTROY) {
-			char xpath[XPATH_MAXLEN];
-
 			dnode = dnode->parent;
 			if (!dnode)
 				break;
@@ -1090,7 +1090,6 @@ static void nb_transaction_apply_finish(struct nb_transaction *transaction)
 					       xpath);
 		}
 		while (dnode) {
-			char xpath[XPATH_MAXLEN];
 			struct nb_node *nb_node;
 
 			nb_node = dnode->schema->priv;
@@ -1101,11 +1100,10 @@ static void nb_transaction_apply_finish(struct nb_transaction *transaction)
 			 * Don't call the callback more than once for the same
 			 * data node.
 			 */
-			yang_dnode_get_path(dnode, xpath, sizeof(xpath));
 			if (nb_apply_finish_cb_find(&cbs, nb_node, dnode))
 				goto next;
 
-			nb_apply_finish_cb_new(&cbs, xpath, nb_node, dnode);
+			nb_apply_finish_cb_new(&cbs, nb_node, dnode);
 
 		next:
 			dnode = dnode->parent;
@@ -1114,9 +1112,11 @@ static void nb_transaction_apply_finish(struct nb_transaction *transaction)
 
 	/* Call the 'apply_finish' callbacks, sorted by their priorities. */
 	RB_FOREACH (cb, nb_config_cbs, &cbs) {
-		if (DEBUG_MODE_CHECK(&nb_dbg_cbs_config, DEBUG_MODE_ALL))
-			nb_log_callback(NB_EV_APPLY, NB_OP_APPLY_FINISH,
-					cb->xpath, NULL);
+		if (DEBUG_MODE_CHECK(&nb_dbg_cbs_config, DEBUG_MODE_ALL)) {
+			yang_dnode_get_path(cb->dnode, xpath, sizeof(xpath));
+			nb_log_callback(NB_EV_APPLY, NB_OP_APPLY_FINISH, xpath,
+					NULL);
+		}
 
 		(*cb->nb_node->cbs.apply_finish)(cb->dnode);
 	}

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -458,7 +458,6 @@ struct nb_config_cb {
 	RB_ENTRY(nb_config_cb) entry;
 	enum nb_operation operation;
 	uint32_t seq;
-	char xpath[XPATH_MAXLEN];
 	const struct nb_node *nb_node;
 	const struct lyd_node *dnode;
 };

--- a/lib/northbound_cli.h
+++ b/lib/northbound_cli.h
@@ -109,6 +109,8 @@ extern void nb_cli_show_dnode_cmds(struct vty *vty, struct lyd_node *dnode,
 				   bool show_defaults);
 
 /* Prototypes of internal functions. */
+extern void nb_cli_show_config_prepare(struct nb_config *config,
+				       bool with_defaults);
 extern void nb_cli_confirmed_commit_clean(struct vty *vty);
 extern int nb_cli_confirmed_commit_rollback(struct vty *vty);
 extern void nb_cli_install_default(int node);

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2341,8 +2341,7 @@ static void vty_read_file(struct nb_config *config, FILE *confp)
 	 * Automatically commit the candidate configuration after
 	 * reading the configuration file.
 	 */
-	if (config == NULL && vty->candidate_config
-	    && frr_get_cli_mode() == FRR_CLI_TRANSACTIONAL) {
+	if (config == NULL) {
 		ret = nb_candidate_commit(vty->candidate_config, NB_CLIENT_CLI,
 					  vty, true, "Read configuration file",
 					  NULL);

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -254,7 +254,8 @@ static inline void vty_push_context(struct vty *vty, int node, uint64_t id)
 
 #define VTY_CHECK_XPATH                                                        \
 	do {                                                                   \
-		if (vty->xpath_index > 0                                       \
+		if (vty->type != VTY_FILE && !vty->private_config              \
+		    && vty->xpath_index > 0                                    \
 		    && !yang_dnode_exists(vty->candidate_config->dnode,        \
 					  VTY_CURR_XPATH)) {                   \
 			vty_out(vty,                                           \


### PR DESCRIPTION
This PR contains a few simple optimizations that drastically improve the performance of the FRR northbound layer.

With these optimizations, the northbound should be able to load large configurations in a few seconds instead of minutes. Also, the transaction processing now scales linearly according to the size of the candidate being committed.

The table below shows some numbers I got during my tests (`time(1)` was used to measure how much time ripd takes to load large configurations using either the CLI or the gRPC plugin):

|                             | CLI     | gRPC/JSON |
| ----------------------------| ------- | --------- |
| **100 thousand RIP routes** | 1.161s  | 0.574s    |
| **1 million RIP routes**    | 11.885s | 5.817s    |

Other commands like `route-map` take slightly slower to process. This depends on the complexity of the associated YANG module and how many validations libyang needs to perform (and how many default nodes it needs to create).

This PR still doesn't solve the performance issues completely when `--tcli` is not used (i.e. when the northbound creates a separate transaction for every configuration command). This can only be solved by optimizing the libyang `lyd_validate()` function, and work is being done to get that done, along with other libyang general performance enhancements.

No regressions were detected using ANVL. Please refer to the individual commit messages for more details.