### PR TITLE
bgpd: move assert out of error case

### DIFF
--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -242,13 +242,13 @@ static int bgp_process_reads(struct thread *thread)
 			break;
 	}
 
-	assert(ringbuf_space(peer->ibuf_work) >= BGP_MAX_PACKET_SIZE);
-
 	/* handle invalid header */
 	if (fatal) {
 		/* wipe buffer just in case someone screwed up */
 		ringbuf_wipe(peer->ibuf_work);
 	} else {
+		assert(ringbuf_space(peer->ibuf_work) >= BGP_MAX_PACKET_SIZE);
+
 		thread_add_read(fpt->master, bgp_process_reads, peer, peer->fd,
 				&peer->t_read);
 		if (added_pkt)


### PR DESCRIPTION
bgp_process_packets has an assert to make sure an appropriate amount of
working space in the input buffer has been freed up for future reads.
However, this assert shouldn't be made when we have encountered an error
that's going to tear down the session, because in this case we may not
be able to process the full contents of the input buffer.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>