### PR TITLE
lib: fix harmless lyd_schema_sort() warning

### DIFF
--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -424,6 +424,10 @@ static struct lyd_node *ly_iter_next_up(const struct lyd_node *elem)
 /* Prepare the configuration for display. */
 void nb_cli_show_config_prepare(struct nb_config *config, bool with_defaults)
 {
+	/* Nothing to do for daemons that don't implement any YANG module. */
+	if (config->dnode == NULL)
+		return;
+
 	lyd_schema_sort(config->dnode, 1);
 
 	/*


### PR DESCRIPTION
The dnode member of the nb_config structure can be null on
daemons that don't implement any YANG module. As such, update
the nb_cli_show_config_prepare() function to always check if the
libyang data node that is going to be displayed is null or not
before operating on it.

This fixes the following warning (introduced by commit 5e6a9350c1):
libyang: Invalid arguments (lyd_schema_sort())

Reported-by: Donald Sharp <sharpd@cumulusnetworks.com>
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>