### PR TITLE
lib: Let libyang log everything possible

### DIFF
--- a/lib/yang.c
+++ b/lib/yang.c
@@ -595,7 +595,7 @@ struct yang_data *yang_data_list_find(const struct list *list,
 /* Make libyang log its errors using FRR logging infrastructure. */
 static void ly_log_cb(LY_LOG_LEVEL level, const char *msg, const char *path)
 {
-	int priority;
+	int priority = LOG_ERR;
 
 	switch (level) {
 	case LY_LLERR:
@@ -605,10 +605,9 @@ static void ly_log_cb(LY_LOG_LEVEL level, const char *msg, const char *path)
 		priority = LOG_WARNING;
 		break;
 	case LY_LLVRB:
+	case LY_LLDBG:
 		priority = LOG_DEBUG;
 		break;
-	default:
-		return;
 	}
 
 	if (path)
@@ -645,6 +644,10 @@ void yang_init(void)
 	/* Initialize libyang global parameters that affect all containers. */
 	ly_set_log_clb(ly_log_cb, 1);
 	ly_log_options(LY_LOLOG | LY_LOSTORE);
+
+	/* Let libyang log everything possible. */
+	ly_verb(LY_LLDBG);
+	ly_verb_dbg(0xFF);
 
 	/* Initialize libyang container for native models. */
 	ly_native_ctx = yang_ctx_new_setup();


### PR DESCRIPTION
Currently libyang logs errors only (LY_LLERR by default), independent of
FRR's log level. This commit lets libyang log everything including all
sorts of debug logs (when libyang is built in 'Debug' mode). FRR's
logging infrastructure filters logs out according to the configured log
level.

There is a very small performance overhead involved, even when libyang
is build in 'Release' mode. This overhead is mainly affecting config
processing and barely measurable being around 0-3% of the processing
time without this change.

Signed-off-by: Sascha Kattelmann <sascha@netdef.org>