### PR TITLE
bgpd: Soft reconfig-in should find the right bgp_path_info

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3934,11 +3934,15 @@ static void bgp_soft_reconfig_table(struct peer *peer, afi_t afi, safi_t safi,
 			if (ain->peer != peer)
 				continue;
 
-			struct bgp_path_info *pi =
-				bgp_node_get_bgp_path_info(rn);
+			struct bgp_path_info *pi;
 			uint32_t num_labels = 0;
 			mpls_label_t *label_pnt = NULL;
 			struct bgp_route_evpn evpn;
+
+			for (pi = bgp_node_get_bgp_path_info(rn); pi;
+			     pi = pi->next)
+				if (pi->peer == peer)
+					break;
 
 			if (pi && pi->extra)
 				num_labels = pi->extra->num_labels;


### PR DESCRIPTION
When using soft reconfiguration inbound we are storing packet
data on the side for replaying when necessary.  The problem here
is that we are just grabbing the first bgp_path_info and using
that as the base.  What happens when we have soft-reconfig turned
on with multiple bgp_path_info's for a path?  This was introduced
in commit 8692c506520f6b268525b80890702432c95f13c4, yes back
in 2012!  I would argue, though, that it was just broken
in a different way before this.

Choose the correct bgp_path_info that corresponds to the peer
we received the data from for rethinking.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>