### PR TITLE
[7.2] bfdd: pack of bug fixes

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1434,7 +1434,7 @@ struct bfd_session *bfd_key_lookup(struct bfd_key key)
 	if (ctx.result) {
 		bsp = ctx.result;
 		log_debug(" peer %s found, but ifp"
-			  " and/or loc-addr params ignored");
+			  " and/or loc-addr params ignored", peer_buf);
 	}
 	return bsp;
 }

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1219,19 +1219,10 @@ int bs_observer_add(struct bfd_session *bs)
 	struct bfd_session_observer *bso;
 
 	bso = XCALLOC(MTYPE_BFDD_SESSION_OBSERVER, sizeof(*bso));
-	bso->bso_isaddress = false;
 	bso->bso_bs = bs;
-	bso->bso_isinterface = !BFD_CHECK_FLAG(bs->flags, BFD_SESS_FLAG_MH);
-	if (bso->bso_isinterface)
-		strlcpy(bso->bso_entryname, bs->key.ifname,
-			sizeof(bso->bso_entryname));
-	/* Handle socket binding failures caused by missing local addresses. */
-	if (bs->sock == -1) {
-		bso->bso_isaddress = true;
-		bso->bso_addr.family = bs->key.family;
-		memcpy(&bso->bso_addr.u.prefix, &bs->key.local,
-		       sizeof(bs->key.local));
-	}
+	bso->bso_addr.family = bs->key.family;
+	memcpy(&bso->bso_addr.u.prefix, &bs->key.local,
+	       sizeof(bs->key.local));
 
 	TAILQ_INSERT_TAIL(&bglobal.bg_obslist, bso, bso_entry);
 

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1701,6 +1701,15 @@ static int bfd_vrf_disable(struct vrf *vrf)
 	}
 
 	log_debug("VRF disable %s id %d", vrf->name, vrf->vrf_id);
+
+	/* Disable read/write poll triggering. */
+	THREAD_OFF(bvrf->bg_ev[0]);
+	THREAD_OFF(bvrf->bg_ev[1]);
+	THREAD_OFF(bvrf->bg_ev[2]);
+	THREAD_OFF(bvrf->bg_ev[3]);
+	THREAD_OFF(bvrf->bg_ev[4]);
+	THREAD_OFF(bvrf->bg_ev[5]);
+
 	/* Close all descriptors. */
 	socket_close(&bvrf->bg_echo);
 	socket_close(&bvrf->bg_shop);

--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -216,6 +216,7 @@ void bfd_session_disable(struct bfd_session *bs)
 	bfd_echo_recvtimer_delete(bs);
 	bfd_xmttimer_delete(bs);
 	bfd_echo_xmttimer_delete(bs);
+	bs->vrf = NULL;
 }
 
 static uint32_t ptm_bfd_gen_ID(void)

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -274,12 +274,8 @@ struct bfd_state_str_list {
 
 struct bfd_session_observer {
 	struct bfd_session *bso_bs;
-	bool bso_isinterface;
-	bool bso_isaddress;
-	union {
-		char bso_entryname[MAXNAMELEN];
-		struct prefix bso_addr;
-	};
+	char bso_entryname[MAXNAMELEN];
+	struct prefix bso_addr;
 
 	TAILQ_ENTRY(bfd_session_observer) bso_entry;
 };

--- a/bfdd/ptm_adapter.c
+++ b/bfdd/ptm_adapter.c
@@ -576,8 +576,6 @@ static void bfdd_sessions_enable_interface(struct interface *ifp)
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
 		bs = bso->bso_bs;
-		if (bso->bso_isinterface == false)
-			continue;
 		/* Interface name mismatch. */
 		if (strcmp(ifp->name, bs->key.ifname))
 			continue;
@@ -602,10 +600,6 @@ static void bfdd_sessions_disable_interface(struct interface *ifp)
 	struct bfd_session *bs;
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
-		if (bso->bso_isinterface == false)
-			continue;
-
-		/* Interface name mismatch. */
 		bs = bso->bso_bs;
 		if (strcmp(ifp->name, bs->key.ifname))
 			continue;
@@ -613,7 +607,6 @@ static void bfdd_sessions_disable_interface(struct interface *ifp)
 		if (bs->sock == -1)
 			continue;
 
-		/* Try to enable it. */
 		bfd_session_disable(bs);
 
 	}
@@ -650,8 +643,6 @@ void bfdd_sessions_disable_vrf(struct vrf *vrf)
 	struct bfd_session *bs;
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
-		if (bso->bso_isinterface)
-			continue;
 		bs = bso->bso_bs;
 		if (bs->key.vrfname[0] &&
 		    strcmp(vrf->name, bs->key.vrfname))
@@ -660,7 +651,6 @@ void bfdd_sessions_disable_vrf(struct vrf *vrf)
 		if (bs->sock == -1)
 			continue;
 
-		/* Try to enable it. */
 		bfd_session_disable(bs);
 	}
 }
@@ -716,9 +706,6 @@ static void bfdd_sessions_enable_address(struct connected *ifc)
 	struct prefix prefix;
 
 	TAILQ_FOREACH(bso, &bglobal.bg_obslist, bso_entry) {
-		if (bso->bso_isaddress == false)
-			continue;
-
 		/* Skip enabled sessions. */
 		bs = bso->bso_bs;
 		if (bs->sock != -1)


### PR DESCRIPTION
## Summary

This is a backport of PR #5141 .

Two modifications:

1.  The commit `lib: use `prefix` for yang get prefix wrapper` has not been included since that function doesn't exist here.
2.  Edited the `bfdd: don't allow link-local without interface` commit to use `yang_dnode_get_ipv6` instead of `yang_dnode_get_prefix`.