### PR TITLE
lib,zebra: Fix PBR Rule Ifp Reference if Interface is Deleted

### DIFF
--- a/lib/pbr.h
+++ b/lib/pbr.h
@@ -90,7 +90,7 @@ struct pbr_rule {
 	uint32_t unique;
 	struct pbr_filter filter;
 	struct pbr_action action;
-	uint32_t ifindex;
+	ifindex_t ifindex;
 };
 
 /* TCP flags value shared

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -123,7 +123,7 @@ static int netlink_rule_update(int cmd, struct zebra_pbr_rule *rule)
 			"Tx %s family %s IF %s(%u) Pref %u Fwmark %u Src %s Dst %s Table %u",
 			nl_msg_type_to_str(cmd), nl_family_to_str(family),
 			rule->ifp ? rule->ifp->name : "Unknown",
-			rule->ifp ? rule->ifp->ifindex : 0, rule->rule.priority,
+			rule->rule.ifindex, rule->rule.priority,
 			rule->rule.filter.fwmark,
 			prefix2str(&rule->rule.filter.src_ip, buf1,
 				   sizeof(buf1)),

--- a/zebra/rule_netlink.c
+++ b/zebra/rule_netlink.c
@@ -86,9 +86,8 @@ static int netlink_rule_update(int cmd, struct zebra_pbr_rule *rule)
 	addattr32(&req.n, sizeof(req), FRA_PRIORITY, rule->rule.priority);
 
 	/* interface on which applied */
-	if (rule->ifp)
-		addattr_l(&req.n, sizeof(req), FRA_IFNAME, rule->ifp->name,
-			  strlen(rule->ifp->name) + 1);
+	addattr_l(&req.n, sizeof(req), FRA_IFNAME, rule->ifname,
+		  strlen(rule->ifname) + 1);
 
 	/* source IP, if specified */
 	if (IS_RULE_FILTERING_ON_SRC_IP(rule)) {
@@ -122,8 +121,7 @@ static int netlink_rule_update(int cmd, struct zebra_pbr_rule *rule)
 		zlog_debug(
 			"Tx %s family %s IF %s(%u) Pref %u Fwmark %u Src %s Dst %s Table %u",
 			nl_msg_type_to_str(cmd), nl_family_to_str(family),
-			rule->ifp ? rule->ifp->name : "Unknown",
-			rule->rule.ifindex, rule->rule.priority,
+			rule->ifname, rule->rule.ifindex, rule->rule.priority,
 			rule->rule.filter.fwmark,
 			prefix2str(&rule->rule.filter.src_ip, buf1,
 				   sizeof(buf1)),
@@ -227,12 +225,14 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	if (tb[FRA_IFNAME] == NULL)
 		return 0;
 
-	/* If we don't know the interface, we don't care. */
 	ifname = (char *)RTA_DATA(tb[FRA_IFNAME]);
 	zns = zebra_ns_lookup(ns_id);
-	rule.ifp = if_lookup_by_name_per_ns(zns, ifname);
-	if (!rule.ifp)
+
+	/* If we don't know the interface, we don't care. */
+	if (!if_lookup_by_name_per_ns(zns, ifname))
 		return 0;
+
+	strlcpy(rule.ifname, ifname, sizeof(rule.ifname));
 
 	if (tb[FRA_PRIORITY])
 		rule.rule.priority = *(uint32_t *)RTA_DATA(tb[FRA_PRIORITY]);
@@ -268,8 +268,8 @@ int netlink_rule_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		zlog_debug(
 			"Rx %s family %s IF %s(%u) Pref %u Src %s Dst %s Table %u",
 			nl_msg_type_to_str(h->nlmsg_type),
-			nl_family_to_str(frh->family), rule.ifp->name,
-			rule.ifp->ifindex, rule.rule.priority,
+			nl_family_to_str(frh->family), rule.ifname,
+			rule.rule.ifindex, rule.rule.priority,
 			prefix2str(&rule.rule.filter.src_ip, buf1,
 				   sizeof(buf1)),
 			prefix2str(&rule.rule.filter.dst_ip, buf2,

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2294,7 +2294,6 @@ static inline void zread_rule(ZAPI_HANDLER_ARGS)
 	struct zebra_pbr_rule zpr;
 	struct stream *s;
 	uint32_t total, i;
-	ifindex_t ifindex;
 
 	s = msg;
 	STREAM_GETL(s, total);
@@ -2319,15 +2318,14 @@ static inline void zread_rule(ZAPI_HANDLER_ARGS)
 		STREAM_GETW(s, zpr.rule.filter.dst_port);
 		STREAM_GETL(s, zpr.rule.filter.fwmark);
 		STREAM_GETL(s, zpr.rule.action.table);
-		STREAM_GETL(s, ifindex);
+		STREAM_GETL(s, zpr.rule.ifindex);
 
-		if (ifindex) {
-			zpr.ifp = if_lookup_by_index_per_ns(
-						zvrf->zns,
-						ifindex);
+		if (zpr.rule.ifindex) {
+			zpr.ifp = if_lookup_by_index_per_ns(zvrf->zns,
+							    zpr.rule.ifindex);
 			if (!zpr.ifp) {
 				zlog_debug("Failed to lookup ifindex: %u",
-					   ifindex);
+					   zpr.rule.ifindex);
 				return;
 			}
 		}

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -191,7 +191,7 @@ bool zebra_pbr_rules_hash_equal(const void *arg1, const void *arg2)
 	if (!prefix_same(&r1->rule.filter.dst_ip, &r2->rule.filter.dst_ip))
 		return false;
 
-	if (r1->ifp != r2->ifp)
+	if (r1->rule.ifindex != r2->rule.ifindex)
 		return false;
 
 	if (r1->vrf_id != r2->vrf_id)

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -144,17 +144,12 @@ uint32_t zebra_pbr_rules_hash_key(const void *arg)
 	key = jhash_3words(rule->rule.seq, rule->rule.priority,
 			   rule->rule.action.table,
 			   prefix_hash_key(&rule->rule.filter.src_ip));
-	if (rule->ifp)
-		key = jhash_1word(rule->ifp->ifindex, key);
-	else
-		key = jhash_1word(0, key);
 
 	if (rule->rule.filter.fwmark)
-		key = jhash_1word(rule->rule.filter.fwmark, key);
+		key = jhash_3words(rule->rule.filter.fwmark, rule->vrf_id,
+				   rule->rule.ifindex, key);
 	else
-		key = jhash_1word(0, key);
-
-	key = jhash_1word(rule->vrf_id, key);
+		key = jhash_2words(rule->vrf_id, rule->rule.ifindex, key);
 
 	return jhash_3words(rule->rule.filter.src_port,
 			    rule->rule.filter.dst_port,
@@ -208,7 +203,7 @@ bool zebra_pbr_rules_hash_equal(const void *arg1, const void *arg2)
 struct pbr_rule_unique_lookup {
 	struct zebra_pbr_rule *rule;
 	uint32_t unique;
-	struct interface *ifp;
+	ifindex_t ifindex;
 	vrf_id_t vrf_id;
 };
 
@@ -218,7 +213,7 @@ static int pbr_rule_lookup_unique_walker(struct hash_bucket *b, void *data)
 	struct zebra_pbr_rule *rule = b->data;
 
 	if (pul->unique == rule->rule.unique
-	    && pul->ifp == rule->ifp
+	    && pul->ifindex == rule->rule.ifindex
 	    && pul->vrf_id == rule->vrf_id) {
 		pul->rule = rule;
 		return HASHWALK_ABORT;
@@ -233,7 +228,7 @@ pbr_rule_lookup_unique(struct zebra_pbr_rule *zrule)
 	struct pbr_rule_unique_lookup pul;
 
 	pul.unique = zrule->rule.unique;
-	pul.ifp = zrule->ifp;
+	pul.ifindex = zrule->rule.ifindex;
 	pul.rule = NULL;
 	pul.vrf_id = zrule->vrf_id;
 	hash_walk(zrouter.rules_hash, &pbr_rule_lookup_unique_walker, &pul);

--- a/zebra/zebra_pbr.c
+++ b/zebra/zebra_pbr.c
@@ -471,8 +471,12 @@ static void zebra_pbr_cleanup_rules(struct hash_bucket *b, void *data)
 
 	if (rule->sock == *sock) {
 		(void)kernel_del_pbr_rule(rule);
-		hash_release(zrouter.rules_hash, rule);
-		XFREE(MTYPE_TMP, rule);
+		if (hash_release(zrouter.rules_hash, rule))
+			XFREE(MTYPE_TMP, rule);
+		else
+			zlog_debug(
+				"%s: Rule seq: %u is being cleaned but we can't find it in our tables",
+				__func__, rule->rule.seq);
 	}
 }
 

--- a/zebra/zebra_pbr.h
+++ b/zebra/zebra_pbr.h
@@ -41,7 +41,7 @@ struct zebra_pbr_rule {
 
 	struct pbr_rule rule;
 
-	struct interface *ifp;
+	char ifname[INTERFACE_NAMSIZ];
 
 	vrf_id_t vrf_id;
 };


### PR DESCRIPTION
You can produce a double free for a pbr rule if the interface your rule is on is deleted and cleared from
running config, then issue a shutdown. Our rule hash key was using the interface pointer to create the key, thus if that interface is deleted we can no longer hash to it and release the data after `pbrd` decides what to do with the new information.

Further, in the same case of interface deletion, the ifp is freed so when we go into `rule_netlink` to delete the rule from the kernel, we are referencing the `ifp->name` value which is now uninitialized memory.

I fixed this in a few ways:

1) If the hash_release fails, don't free the rule entry
2) Don't hash on the ifp pointer, use an ifindex value on the rule itself
3) Don't bother referencing the ifp pointer at all (it was only used for ifname) and just store the name on the `zebra_pbr_rule` struct

To reproduce the problem:

```
!
ipv6 route dddd::/64 dummy4
ipv6 route dddd::1/128 dummy1
ipv6 route dddd::2/128 dummy2
ipv6 route eeee::/64 dddd::1
!
interface dummy33
 pbr-policy CHANGE
!
nexthop-group change
 nexthop eeee:1
 nexthop eeee:2
 nexthop eeee::1
 nexthop eeee::2
!
nexthop-group dummy
 nexthop dddd::1
 nexthop dddd::2
!
pbr-map CHANGE seq 222
 match src-ip ffff::1/128
 set nexthop-group change
!
```

Then do:

```
root@ubuntu_nh:/# ip link del dummy33
```
```
ubuntu_nh(config)# no interface dummy33 
```

```
stop pbrd
stop zebra
```