### PR TITLE
nhrpd: be more careful in linkedlist macro

### DIFF
--- a/nhrpd/list.h
+++ b/nhrpd/list.h
@@ -199,7 +199,8 @@ static inline int list_empty(const struct list_head *n)
 
 #define list_for_each_entry_safe(pos, n, head, member)                         \
 	for (pos = list_entry((head)->next, typeof(*pos), member),             \
-	    n = list_entry(pos->member.next, typeof(*pos), member);            \
+	     n = (&pos->member != (head) ?                                     \
+		  list_entry(pos->member.next, typeof(*pos), member) : NULL);  \
 	     &pos->member != (head);                                           \
 	     pos = n, n = list_entry(n->member.next, typeof(*n), member))
 

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -76,8 +76,10 @@ static inline void notifier_del(struct notifier_block *n)
 static inline void notifier_call(struct notifier_list *l, int cmd)
 {
 	struct notifier_block *n, *nn;
-	list_for_each_entry_safe(n, nn, &l->notifier_head, notifier_entry)
-		n->action(n, cmd);
+	list_for_each_entry_safe(n, nn, &l->notifier_head, notifier_entry) {
+		if (n)
+			n->action(n, cmd);
+	}
 }
 
 static inline int notifier_active(struct notifier_list *l)


### PR DESCRIPTION
NHRPD has its own linked-list implementation, and one of the apis is a little free and easy with pointers. We've been getting an SA warning about this - trying to see if this change clears it up.
