### PR TITLE
*: Allow disabling of `getrusage` calls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -536,6 +536,8 @@ AC_ARG_ENABLE([backtrace],
   AS_HELP_STRING([--disable-backtrace,], [disable crash backtraces (default autodetect)]))
 AC_ARG_ENABLE([time-check],
   AS_HELP_STRING([--disable-time-check], [disable slow thread warning messages]))
+AC_ARG_ENABLE([cpu-time],
+  AS_HELP_STRING([--disable-cpu-time], [disable cpu usage data gathering]))
 AC_ARG_ENABLE([pcreposix],
   AS_HELP_STRING([--enable-pcreposix], [enable using PCRE Posix libs for regex functions]))
 AC_ARG_ENABLE([fpm],
@@ -613,6 +615,14 @@ if test x"${enable_time_check}" != x"no" ; then
     AC_DEFINE_UNQUOTED([CONSUMED_TIME_CHECK], [$enable_time_check], [Consumed Time Check])
   fi
 fi
+
+case "${enable_cpu_time}" in
+  "no")
+  AC_DEFINE([EXCLUDE_CPU_TIME], [1], [Exclude getrusage data gathering])
+  ;;
+  "*")
+  ;;
+esac
 
 case "${enable_systemd}" in
   "no") ;;

--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -451,7 +451,8 @@ Terminal Mode Commands
    This command displays system run statistics for all the different event
    types. If no options is specified all different run types are displayed
    together.  Additionally you can ask to look at (r)ead, (w)rite, (t)imer,
-   (e)vent and e(x)ecute thread event types.
+   (e)vent and e(x)ecute thread event types.  If you have compiled with
+   disable-cpu-time then this command will not show up.
 
 .. index:: show thread poll
 .. clicmd:: show thread poll

--- a/doc/user/installation.rst
+++ b/doc/user/installation.rst
@@ -302,6 +302,23 @@ options from the list below.
 
    Build the Sysrepo northbound plugin.
 
+.. option:: --enable-time-check XXX
+
+   When this is enabled with a XXX value in microseconds, any thread that
+   runs for over this value will cause a warning to be issued to the log.
+   If you do not specify any value or don't include this option then
+   the default time is 5 seconds.  If --disable-time-check is specified
+   then no warning is issued for any thread run length.
+
+.. option:: --disable-cpu-time
+
+   Disable cpu process accounting, this command also disables the `show thread cpu`
+   command.  If this option is disabled, --enable-time-check is ignored.  This
+   disabling of cpu time effectively means that the getrusage call is skipped.
+   Since this is a process switch into the kernel, systems with high FRR
+   load might see improvement in behavior.  Be aware that `show thread cpu`
+   is considered a good data gathering tool from the perspective of developers.
+
 You may specify any combination of the above options to the configure
 script. By default, the executables are placed in :file:`/usr/local/sbin`
 and the configuration files in :file:`/usr/local/etc`. The :file:`/usr/local/`

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -109,6 +109,7 @@ static void cpu_record_hash_free(void *a)
 	XFREE(MTYPE_THREAD_STATS, hist);
 }
 
+#ifndef EXCLUDE_CPU_TIME
 static void vty_out_cpu_thread_history(struct vty *vty,
 				       struct cpu_thread_history *a)
 {
@@ -219,6 +220,7 @@ static void cpu_record_print(struct vty *vty, uint8_t filter)
 	if (tmp.total_calls > 0)
 		vty_out_cpu_thread_history(vty, &tmp);
 }
+#endif
 
 static void cpu_record_hash_clear(struct hash_bucket *bucket, void *args[])
 {
@@ -288,6 +290,7 @@ static uint8_t parse_filter(const char *filterstr)
 	return filter;
 }
 
+#ifndef EXCLUDE_CPU_TIME
 DEFUN (show_thread_cpu,
        show_thread_cpu_cmd,
        "show thread cpu [FILTER]",
@@ -313,6 +316,7 @@ DEFUN (show_thread_cpu,
 	cpu_record_print(vty, filter);
 	return CMD_SUCCESS;
 }
+#endif
 
 static void show_thread_poll_helper(struct vty *vty, struct thread_master *m)
 {
@@ -403,7 +407,9 @@ DEFUN (clear_thread_cpu,
 
 void thread_cmd_init(void)
 {
+#ifndef EXCLUDE_CPU_TIME
 	install_element(VIEW_NODE, &show_thread_cpu_cmd);
+#endif
 	install_element(VIEW_NODE, &show_thread_poll_cmd);
 	install_element(ENABLE_NODE, &clear_thread_cpu_cmd);
 }
@@ -1511,7 +1517,9 @@ void thread_getrusage(RUSAGE_T *r)
 #define FRR_RUSAGE RUSAGE_SELF
 #endif
 	monotime(&r->real);
+#ifndef EXCLUDE_CPU_TIME
 	getrusage(FRR_RUSAGE, &(r->cpu));
+#endif
 }
 
 /*
@@ -1527,9 +1535,11 @@ void thread_getrusage(RUSAGE_T *r)
  */
 void thread_call(struct thread *thread)
 {
+#ifndef EXCLUDE_CPU_TIME
 	_Atomic unsigned long realtime, cputime;
 	unsigned long exp;
 	unsigned long helper;
+#endif
 	RUSAGE_T before, after;
 
 	GETRUSAGE(&before);
@@ -1541,6 +1551,7 @@ void thread_call(struct thread *thread)
 
 	GETRUSAGE(&after);
 
+#ifndef EXCLUDE_CPU_TIME
 	realtime = thread_consumed_time(&after, &before, &helper);
 	cputime = helper;
 
@@ -1585,6 +1596,7 @@ void thread_call(struct thread *thread)
 			realtime / 1000, cputime / 1000);
 	}
 #endif /* CONSUMED_TIME_CHECK */
+#endif /* Exclude CPU Time */
 }
 
 /* Execute thread */

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2255,6 +2255,7 @@ DEFUN (vtysh_show_poll,
 	return ret;
 }
 
+#ifndef EXCLUDE_CPU_TIME
 DEFUN (vtysh_show_thread,
        vtysh_show_thread_cmd,
        "show thread cpu [FILTER]",
@@ -2281,6 +2282,7 @@ DEFUN (vtysh_show_thread,
 		}
 	return ret;
 }
+#endif
 
 DEFUN (vtysh_show_work_queues,
        vtysh_show_work_queues_cmd,
@@ -4077,7 +4079,9 @@ void vtysh_init_vty(void)
 	install_element(VIEW_NODE, &vtysh_show_modules_cmd);
 	install_element(VIEW_NODE, &vtysh_show_work_queues_cmd);
 	install_element(VIEW_NODE, &vtysh_show_work_queues_daemon_cmd);
+#ifndef EXCLUDE_CPU_TIME
 	install_element(VIEW_NODE, &vtysh_show_thread_cmd);
+#endif
 	install_element(VIEW_NODE, &vtysh_show_poll_cmd);
 
 	/* Logging */


### PR DESCRIPTION
getrusage, in a heavily stressed system, can account for
signficant running time due to process switching to the kernel.
Allow the end-operator to specify `--disable-cpu-time` to
avoid this call.  Additionally we cause `show thread cpu` to
not show up if this is selected.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>