### PR TITLE
[7.2] bfdd: VRF security improvement

### DIFF
--- a/bfdd/bfd.c
+++ b/bfdd/bfd.c
@@ -1649,17 +1649,17 @@ static int bfd_vrf_enable(struct vrf *vrf)
 	if (vrf->vrf_id == VRF_DEFAULT ||
 	    vrf_get_backend() == VRF_BACKEND_NETNS) {
 		if (!bvrf->bg_shop)
-			bvrf->bg_shop = bp_udp_shop(vrf->vrf_id);
+			bvrf->bg_shop = bp_udp_shop(vrf);
 		if (!bvrf->bg_mhop)
-			bvrf->bg_mhop = bp_udp_mhop(vrf->vrf_id);
+			bvrf->bg_mhop = bp_udp_mhop(vrf);
 		if (!bvrf->bg_shop6)
-			bvrf->bg_shop6 = bp_udp6_shop(vrf->vrf_id);
+			bvrf->bg_shop6 = bp_udp6_shop(vrf);
 		if (!bvrf->bg_mhop6)
-			bvrf->bg_mhop6 = bp_udp6_mhop(vrf->vrf_id);
+			bvrf->bg_mhop6 = bp_udp6_mhop(vrf);
 		if (!bvrf->bg_echo)
-			bvrf->bg_echo = bp_echo_socket(vrf->vrf_id);
+			bvrf->bg_echo = bp_echo_socket(vrf);
 		if (!bvrf->bg_echov6)
-			bvrf->bg_echov6 = bp_echov6_socket(vrf->vrf_id);
+			bvrf->bg_echov6 = bp_echov6_socket(vrf);
 
 		/* Add descriptors to the event loop. */
 		if (!bvrf->bg_ev[0])

--- a/bfdd/bfd.h
+++ b/bfdd/bfd.h
@@ -461,14 +461,14 @@ int bp_set_tosv6(int sd, uint8_t value);
 int bp_set_tos(int sd, uint8_t value);
 int bp_bind_dev(int sd, const char *dev);
 
-int bp_udp_shop(vrf_id_t vrf_id);
-int bp_udp_mhop(vrf_id_t vrf_id);
-int bp_udp6_shop(vrf_id_t vrf_id);
-int bp_udp6_mhop(vrf_id_t vrf_id);
+int bp_udp_shop(const struct vrf *vrf);
+int bp_udp_mhop(const struct vrf *vrf);
+int bp_udp6_shop(const struct vrf *vrf);
+int bp_udp6_mhop(const struct vrf *vrf);
 int bp_peer_socket(const struct bfd_session *bs);
 int bp_peer_socketv6(const struct bfd_session *bs);
-int bp_echo_socket(vrf_id_t vrf_id);
-int bp_echov6_socket(vrf_id_t vrf_id);
+int bp_echo_socket(const struct vrf *vrf);
+int bp_echov6_socket(const struct vrf *vrf);
 
 void ptm_bfd_snd(struct bfd_session *bfd, int fbit);
 void ptm_bfd_echo_snd(struct bfd_session *bfd);

--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -890,12 +890,13 @@ static void bp_bind_ip(int sd, uint16_t port)
 		log_fatal("bind-ip: bind: %s", strerror(errno));
 }
 
-int bp_udp_shop(vrf_id_t vrf_id)
+int bp_udp_shop(const struct vrf *vrf)
 {
 	int sd;
 
 	frr_with_privs(&bglobal.bfdd_privs) {
-		sd = vrf_socket(AF_INET, SOCK_DGRAM, PF_UNSPEC, vrf_id, NULL);
+		sd = vrf_socket(AF_INET, SOCK_DGRAM, PF_UNSPEC, vrf->vrf_id,
+				vrf->name);
 	}
 	if (sd == -1)
 		log_fatal("udp-shop: socket: %s", strerror(errno));
@@ -905,12 +906,13 @@ int bp_udp_shop(vrf_id_t vrf_id)
 	return sd;
 }
 
-int bp_udp_mhop(vrf_id_t vrf_id)
+int bp_udp_mhop(const struct vrf *vrf)
 {
 	int sd;
 
 	frr_with_privs(&bglobal.bfdd_privs) {
-		sd = vrf_socket(AF_INET, SOCK_DGRAM, PF_UNSPEC, vrf_id, NULL);
+		sd = vrf_socket(AF_INET, SOCK_DGRAM, PF_UNSPEC, vrf->vrf_id,
+				vrf->name);
 	}
 	if (sd == -1)
 		log_fatal("udp-mhop: socket: %s", strerror(errno));
@@ -1117,12 +1119,13 @@ static void bp_bind_ipv6(int sd, uint16_t port)
 		log_fatal("bind-ipv6: bind: %s", strerror(errno));
 }
 
-int bp_udp6_shop(vrf_id_t vrf_id)
+int bp_udp6_shop(const struct vrf *vrf)
 {
 	int sd;
 
 	frr_with_privs(&bglobal.bfdd_privs) {
-		sd = vrf_socket(AF_INET6, SOCK_DGRAM, PF_UNSPEC, vrf_id, NULL);
+		sd = vrf_socket(AF_INET6, SOCK_DGRAM, PF_UNSPEC, vrf->vrf_id,
+				vrf->name);
 	}
 	if (sd == -1)
 		log_fatal("udp6-shop: socket: %s", strerror(errno));
@@ -1133,12 +1136,13 @@ int bp_udp6_shop(vrf_id_t vrf_id)
 	return sd;
 }
 
-int bp_udp6_mhop(vrf_id_t vrf_id)
+int bp_udp6_mhop(const struct vrf *vrf)
 {
 	int sd;
 
 	frr_with_privs(&bglobal.bfdd_privs) {
-		sd = vrf_socket(AF_INET6, SOCK_DGRAM, PF_UNSPEC, vrf_id, NULL);
+		sd = vrf_socket(AF_INET6, SOCK_DGRAM, PF_UNSPEC, vrf->vrf_id,
+				vrf->name);
 	}
 	if (sd == -1)
 		log_fatal("udp6-mhop: socket: %s", strerror(errno));
@@ -1149,12 +1153,12 @@ int bp_udp6_mhop(vrf_id_t vrf_id)
 	return sd;
 }
 
-int bp_echo_socket(vrf_id_t vrf_id)
+int bp_echo_socket(const struct vrf *vrf)
 {
 	int s;
 
 	frr_with_privs(&bglobal.bfdd_privs) {
-		s = vrf_socket(AF_INET, SOCK_DGRAM, 0, vrf_id, NULL);
+		s = vrf_socket(AF_INET, SOCK_DGRAM, 0, vrf->vrf_id, vrf->name);
 	}
 	if (s == -1)
 		log_fatal("echo-socket: socket: %s", strerror(errno));
@@ -1165,12 +1169,12 @@ int bp_echo_socket(vrf_id_t vrf_id)
 	return s;
 }
 
-int bp_echov6_socket(vrf_id_t vrf_id)
+int bp_echov6_socket(const struct vrf *vrf)
 {
 	int s;
 
 	frr_with_privs(&bglobal.bfdd_privs) {
-		s = vrf_socket(AF_INET6, SOCK_DGRAM, 0, vrf_id, NULL);
+		s = vrf_socket(AF_INET6, SOCK_DGRAM, 0, vrf->vrf_id, vrf->name);
 	}
 	if (s == -1)
 		log_fatal("echov6-socket: socket: %s", strerror(errno));


### PR DESCRIPTION
## Summary

Make public the `bfdd` VRF security improvement for everyone.

This PR makes `bfdd` work with `net.ipv4.udp_l3mdev_accept` disabled by always binding all sockets either to the interface or the VRF virtual device.

I've attempted to run this branch in Ubuntu 18.04.3 with the following kernel versions (available on their repository):

*   4.15 (package `linux-generic`, default package)
*   4.18 (package `linux-image-4.18.0-25-generic`, don't forget to install `linux-module-extras` for it)
*   5.0 (package `linux-generic-hwe`)

All of the versions above fail to run BFD successfuly on VRFs without `net.ipv4.udp_l3mdev_accept` set to `1`.

I'd like to receive reports of people who managed to successfully run BFD with the sysctl `net.ipv4.udp_l3mdev_accept` set to `0` and using VRFs. Please, include kernel version, linux distribution (VRF is not avaible to non-linux OSes at the moment) and the `show running-config`.


## More Information

Please read this issue: https://github.com/FRRouting/frr/issues/5146#issuecomment-542325234

Or the following related links:

*   http://docs.frrouting.org/en/latest/installation.html#linux-sysctl-settings-and-kernel-modules
*   https://www.kernel.org/doc/Documentation/networking/vrf.txt
*   https://github.com/FRRouting/frr/issues/5049