### PR TITLE
lib, vtysh: add new libyang option to the "debug northbound" command

### DIFF
--- a/lib/northbound_grpc.cpp
+++ b/lib/northbound_grpc.cpp
@@ -616,6 +616,11 @@ class NorthboundImpl final : public frr::Northbound::Service
 			return LYD_JSON;
 		case frr::XML:
 			return LYD_XML;
+		default:
+			flog_err(EC_LIB_DEVELOPMENT,
+				 "%s: unknown data encoding format (%u)",
+				 __func__, encoding);
+			exit(1);
 		}
 	}
 

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -616,6 +616,17 @@ static void ly_log_cb(LY_LOG_LEVEL level, const char *msg, const char *path)
 		zlog(priority, "libyang: %s", msg);
 }
 
+void yang_debugging_set(bool enable)
+{
+	if (enable) {
+		ly_verb(LY_LLDBG);
+		ly_verb_dbg(0xFF);
+	} else {
+		ly_verb(LY_LLERR);
+		ly_verb_dbg(0);
+	}
+}
+
 struct ly_ctx *yang_ctx_new_setup(void)
 {
 	struct ly_ctx *ctx;
@@ -644,10 +655,6 @@ void yang_init(void)
 	/* Initialize libyang global parameters that affect all containers. */
 	ly_set_log_clb(ly_log_cb, 1);
 	ly_log_options(LY_LOLOG | LY_LOSTORE);
-
-	/* Let libyang log everything possible. */
-	ly_verb(LY_LLDBG);
-	ly_verb_dbg(0xFF);
 
 	/* Initialize libyang container for native models. */
 	ly_native_ctx = yang_ctx_new_setup();

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -486,6 +486,14 @@ extern struct yang_data *yang_data_list_find(const struct list *list,
 extern struct ly_ctx *yang_ctx_new_setup(void);
 
 /*
+ * Enable or disable libyang verbose debugging.
+ *
+ * enable
+ *    When set to true, enable libyang verbose debugging, otherwise disable it.
+ */
+extern void yang_debugging_set(bool enable);
+
+/*
  * Initialize the YANG subsystem. Should be called only once during the
  * daemon initialization process.
  */

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1339,7 +1339,7 @@ DEFUNSH(VTYSH_REALLYALL, vtysh_end_all, vtysh_end_all_cmd, "end",
 }
 
 DEFUNSH(VTYSH_BGPD, router_bgp, router_bgp_cmd,
-	"router bgp [(1-4294967295)$instasn [<view|vrf> WORD]]",
+	"router bgp [(1-4294967295) [<view|vrf> WORD]]",
 	ROUTER_STR BGP_STR AS_STR
 	"BGP view\nBGP VRF\n"
 	"View/VRF name\n")
@@ -2427,10 +2427,10 @@ DEFUN (vtysh_show_error_code,
 /* Northbound. */
 DEFUN (show_yang_operational_data,
        show_yang_operational_data_cmd,
-       "show yang operational-data XPATH$xpath\
+       "show yang operational-data XPATH\
          [{\
-	   format <json$json|xml$xml>\
-	   |translate WORD$translator_family\
+	   format <json|xml>\
+	   |translate WORD\
 	 }]" DAEMONS_LIST,
        SHOW_STR
        "YANG information\n"
@@ -2454,9 +2454,9 @@ DEFUNSH(VTYSH_ALL, debug_nb,
 	debug_nb_cmd,
 	"[no] debug northbound\
 	   [<\
-	    callbacks$cbs [{configuration$cbs_cfg|state$cbs_state|rpc$cbs_rpc}]\
-	    |notifications$notifications\
-	    |events$events\
+	    callbacks [{configuration|state|rpc}]\
+	    |notifications\
+	    |events\
 	   >]",
 	NO_STR
 	DEBUG_STR

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -2457,6 +2457,7 @@ DEFUNSH(VTYSH_ALL, debug_nb,
 	    callbacks [{configuration|state|rpc}]\
 	    |notifications\
 	    |events\
+	    |libyang\
 	   >]",
 	NO_STR
 	DEBUG_STR
@@ -2466,7 +2467,8 @@ DEFUNSH(VTYSH_ALL, debug_nb,
 	"State\n"
 	"RPC\n"
 	"Notifications\n"
-	"Events\n")
+	"Events\n"
+	"libyang debugging\n")
 {
 	return CMD_SUCCESS;
 }


### PR DESCRIPTION
Guard the libyang debug messages under this command so that only
people interested on those messages will see them.
    
Signed-off-by: Renato Westphal <renato@opensourcerouting.org>
