### PR TITLE
nhrpd: clean up SA warning

### DIFF
--- a/nhrpd/list.h
+++ b/nhrpd/list.h
@@ -198,10 +198,12 @@ static inline int list_empty(const struct list_head *n)
 	     pos = list_entry(pos->member.next, typeof(*pos), member))
 
 #define list_for_each_entry_safe(pos, n, head, member)                         \
-	for (pos = list_entry((head)->next, typeof(*pos), member),             \
-	     n = (&pos->member != (head) ?                                     \
+	for (pos = ((head)->next != head ?                                     \
+		    list_entry((head)->next, typeof(*pos), member) :	       \
+		    NULL),			                               \
+	     n = (pos ?                                                        \
 		  list_entry(pos->member.next, typeof(*pos), member) : NULL);  \
-	     &pos->member != (head);                                           \
+	     pos && (&pos->member != (head));                                  \
 	     pos = n, n = list_entry(n->member.next, typeof(*n), member))
 
 #endif

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -77,8 +77,7 @@ static inline void notifier_call(struct notifier_list *l, int cmd)
 {
 	struct notifier_block *n, *nn;
 	list_for_each_entry_safe(n, nn, &l->notifier_head, notifier_entry) {
-		if (n)
-			n->action(n, cmd);
+		n->action(n, cmd);
 	}
 }
 


### PR DESCRIPTION
Try to signal to SA/clang more clearly to clean up an SA warning.
