### PR TITLE
zebra: Rib Update Event Scheduler For Un-managed Routes, etc.

### DIFF
--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -1104,6 +1104,14 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 					      NULL, ifa->ifa_prefixlen);
 	}
 
+
+	/*
+	 * Linux kernel does not send route delete on interface down/addr del
+	 * so we have to re-process routes it owns (i.e. kernel routes)
+	 */
+	if (h->nlmsg_type != RTM_NEWADDR)
+		rib_update(RIB_UPDATE_KERNEL);
+
 	return 0;
 }
 
@@ -1332,6 +1340,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 							"Intf %s(%u) has gone DOWN",
 							name, ifp->ifindex);
 					if_down(ifp);
+					rib_update(RIB_UPDATE_KERNEL);
 				} else if (if_is_operative(ifp)) {
 					/* Must notify client daemons of new
 					 * interface status. */
@@ -1371,6 +1380,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 							"Intf %s(%u) has gone DOWN",
 							name, ifp->ifindex);
 					if_down(ifp);
+					rib_update(RIB_UPDATE_KERNEL);
 				}
 			}
 

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -301,8 +301,10 @@ typedef struct rib_tables_iter_t_ {
 
 /* Events/reasons triggering a RIB update. */
 typedef enum {
+	RIB_UPDATE_KERNEL,
 	RIB_UPDATE_RMAP_CHANGE,
-	RIB_UPDATE_OTHER
+	RIB_UPDATE_OTHER,
+	RIB_UPDATE_MAX
 } rib_update_event_t;
 
 extern struct nexthop *route_entry_nexthop_ifindex_add(struct route_entry *re,
@@ -384,7 +386,8 @@ extern struct route_entry *rib_match_ipv4_multicast(vrf_id_t vrf_id,
 extern struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *p,
 					   vrf_id_t vrf_id);
 
-extern void rib_update(vrf_id_t vrf_id, rib_update_event_t event);
+extern void rib_update(rib_update_event_t event);
+extern void rib_update_vrf(vrf_id_t vrf_id, rib_update_event_t event);
 extern void rib_update_table(struct route_table *table,
 			     rib_update_event_t event);
 extern int rib_sweep_route(struct thread *t);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -177,10 +177,16 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 	re->nexthop_mtu = 0;
 
 	/*
-	 * If the kernel has sent us a route, then
+	 * If the kernel has sent us a NEW route, then
 	 * by golly gee whiz it's a good route.
+	 *
+	 * If its an already INSTALLED route we have already handled, then the
+	 * kernel route's nexthop might have became unreachable
+	 * and we have to handle that.
 	 */
-	if (re->type == ZEBRA_ROUTE_KERNEL || re->type == ZEBRA_ROUTE_SYSTEM)
+	if (!CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)
+	    && (re->type == ZEBRA_ROUTE_KERNEL
+		|| re->type == ZEBRA_ROUTE_SYSTEM))
 		return 1;
 
 	/*


### PR DESCRIPTION
This patch extends the `rib_update()` api to be scheduled as events on the `zrouter.master` rather than processing them immediately.

Certain situations exists when we need to do a batch process of all the routes in the rib.

One such example is System/Kernel routes. Since they are not `owned` by any daemon, its zebra's job to manage them in its rib. This was not really a problem until recently when the kernel decided to stop sending `route delete` messages when routes become unreachable (interface down/addr del events).

As such, at least in the linux case, we need to re-process all the kernel routes to verify they are still reachable.
