### PR TITLE
[RFC] zebra: partial revert #1434, fix ospf vti ipsec

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -253,20 +253,9 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 	while (rn) {
 		route_unlock_node(rn);
 
-		/* Lookup should halt if we've matched against ourselves ('top',
-		 * if specified) - i.e., we cannot have a nexthop NH1 is
-		 * resolved by a route NH1. The exception is if the route is a
-		 * host route.
-		 */
-		if (top && rn == top)
-			if (((afi == AFI_IP) && (rn->p.prefixlen != 32))
-			    || ((afi == AFI_IP6) && (rn->p.prefixlen != 128))) {
-				if (IS_ZEBRA_DEBUG_RIB_DETAILED)
-					zlog_debug(
-						"\t%s: Matched against ourself and prefix length is not max bit length",
-						__PRETTY_FUNCTION__);
-				return 0;
-			}
+		/* If lookup self prefix return immediately. */
+		if (rn == top)
+		    return 0;
 
 		/* Pick up selected route. */
 		/* However, do not resolve over default route unless explicitly


### PR DESCRIPTION
using vti ipsec interfaces with frr starting from commit 67f1e3aa18a5b7356a3ea91e5188aff814d4a6ac
would not work reliably, some routes will be marked inactive

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Don't know if this is the proper fix, but it solves the problems that I have with vti ipsec interfaces against a fortigate router
fix for #4882