### PR TITLE
vrrpd: fix startup error message reporting

### DIFF
--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -281,7 +281,7 @@ void vrrp_check_start(struct vrrp_vrouter *vr)
 {
 	struct vrrp_router *r;
 	bool start;
-	const char *whynot = NULL;
+	const char *whynot;
 
 	if (vr->shutdown || vr->ifp == NULL)
 		return;
@@ -289,27 +289,28 @@ void vrrp_check_start(struct vrrp_vrouter *vr)
 	r = vr->v4;
 	/* Must not already be started */
 	start = r->fsm.state == VRRP_STATE_INITIALIZE;
+	whynot = NULL;
 	/* Must have a parent interface */
 	start = start && (vr->ifp != NULL);
-	whynot = (!start && !whynot) ? "No base interface" : NULL;
+	whynot = (!start && !whynot) ? "No base interface" : whynot;
 #if 0
 	/* Parent interface must be up */
 	start = start && if_is_operative(vr->ifp);
 #endif
 	/* Parent interface must have at least one v4 */
 	start = start && vr->ifp->connected->count > 1;
-	whynot = (!start && !whynot) ? "No primary IPv4 address" : NULL;
+	whynot = (!start && !whynot) ? "No primary IPv4 address" : whynot;
 	/* Must have a macvlan interface */
 	start = start && (r->mvl_ifp != NULL);
-	whynot = (!start && !whynot) ? "No VRRP interface" : NULL;
+	whynot = (!start && !whynot) ? "No VRRP interface" : whynot;
 #if 0
 	/* Macvlan interface must be admin up */
 	start = start && CHECK_FLAG(r->mvl_ifp->flags, IFF_UP);
 #endif
 	/* Must have at least one VIP configured */
 	start = start && r->addrs->count > 0;
-	whynot =
-		(!start && !whynot) ? "No Virtual IP address configured" : NULL;
+	whynot = (!start && !whynot) ? "No Virtual IP address configured"
+				     : whynot;
 	if (start)
 		vrrp_event(r, VRRP_EVENT_STARTUP);
 	else if (whynot)
@@ -320,19 +321,20 @@ void vrrp_check_start(struct vrrp_vrouter *vr)
 	r = vr->v6;
 	/* Must not already be started */
 	start = r->fsm.state == VRRP_STATE_INITIALIZE;
+	whynot = NULL;
 	/* Must not be v2 */
 	start = start && vr->version != 2;
-	whynot = (!start && !whynot) ? "VRRPv2 does not support v6" : NULL;
+	whynot = (!start && !whynot) ? "VRRPv2 does not support v6" : whynot;
 	/* Must have a parent interface */
 	start = start && (vr->ifp != NULL);
-	whynot = (!start && !whynot) ? "No base interface" : NULL;
+	whynot = (!start && !whynot) ? "No base interface" : whynot;
 #if 0
 	/* Parent interface must be up */
 	start = start && if_is_operative(vr->ifp);
 #endif
 	/* Must have a macvlan interface */
 	start = start && (r->mvl_ifp != NULL);
-	whynot = (!start && !whynot) ? "No VRRP interface" : NULL;
+	whynot = (!start && !whynot) ? "No VRRP interface" : whynot;
 #if 0
 	/* Macvlan interface must be admin up */
 	start = start && CHECK_FLAG(r->mvl_ifp->flags, IFF_UP);


### PR DESCRIPTION
Due to some extremely shoddy programming on my part, the error messages
for certain errors was pretty much always wrong. We would start with the
correct error message, then on the next check, regardless of whether it
passed or failed, we would null out the error message, then on the next
one set it again (to the wrong message), then null it, and just keep
alternating. So errors were sometimes not being reported, sometimes
being reported correctly (if the condition parity happened to match the
appropriate condition), and sometimes being reported correctly.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>