### PR TITLE
vtysh: Add an option to set banner motd from an input

### DIFF
--- a/doc/user/basic.rst
+++ b/doc/user/basic.rst
@@ -238,6 +238,17 @@ Basic Config Commands
 
    Set default motd string.
 
+.. index:: banner motd file FILE
+.. clicmd:: banner motd file FILE
+
+   Set motd string from file. The file must be in directory specified
+   under ``--sysconfdir``.
+
+.. index:: banner motd line LINE
+.. clicmd:: banner motd line LINE
+
+   Set motd string from an input.
+
 .. index:: no banner motd
 .. clicmd:: no banner motd
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -78,7 +78,7 @@ struct host {
 	int encrypt;
 
 	/* Banner configuration. */
-	const char *motd;
+	char *motd;
 	char *motdfile;
 };
 
@@ -499,6 +499,7 @@ extern void host_config_set(const char *);
 extern void print_version(const char *);
 
 extern int cmd_banner_motd_file(const char *);
+extern void cmd_banner_motd_line(const char *line);
 
 /* struct host global, ick */
 extern struct host host;

--- a/vtysh/vtysh_user.c
+++ b/vtysh/vtysh_user.c
@@ -147,6 +147,26 @@ DEFUN (vtysh_banner_motd_file,
 	return cmd_banner_motd_file(argv[idx_file]->arg);
 }
 
+DEFUN (vtysh_banner_motd_line,
+       vtysh_banner_motd_line_cmd,
+       "banner motd line LINE...",
+       "Set banner\n"
+       "Banner for motd\n"
+       "Banner from an input\n"
+       "Text\n")
+{
+	int idx = 0;
+	char *motd;
+
+	argv_find(argv, argc, "LINE", &idx);
+	motd = argv_concat(argv, argc, idx);
+
+	cmd_banner_motd_line(motd);
+	XFREE(MTYPE_TMP, motd);
+
+	return CMD_SUCCESS;
+}
+
 DEFUN (username_nopassword,
        username_nopassword_cmd,
        "username WORD nopassword",
@@ -203,4 +223,5 @@ void vtysh_user_init(void)
 	userlist = list_new();
 	install_element(CONFIG_NODE, &username_nopassword_cmd);
 	install_element(CONFIG_NODE, &vtysh_banner_motd_file_cmd);
+	install_element(CONFIG_NODE, &vtysh_banner_motd_line_cmd);
 }


### PR DESCRIPTION
This allows to set motd from an input instead of creating a file.

Example:

root@exit2-debian-9:~/frr# telnet 127.0.0.1 2605
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.
Hello, this is bgpd
User Access Verification

Password:
exit2-debian-9> enable
exit2-debian-9# sh run

Current configuration:
!
frr version 7.3-dev-MyOwnFRRVersion
frr defaults traditional
!
hostname exit2-debian-9
password belekas
log file /var/log/frr/labas.log
log syslog informational
banner motd line Hello, this is bgpd
!
!
!
line vty
!
end
exit2-debian-9#

Closes https://github.com/FRRouting/frr/issues/4819

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>