### PR TITLE
bgpd: clarify evpn datastruct use for SA

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2608,9 +2608,10 @@ static int install_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 		    && (struct bgp_path_info *)pi->extra->parent == parent_pi)
 			break;
 
-	if (!pi)
-		pi = bgp_create_evpn_bgp_path_info(parent_pi, rn);
-	else {
+	if (!pi) {
+		/* Create an info */
+		(void)bgp_create_evpn_bgp_path_info(parent_pi, rn);
+	} else {
 		if (attrhash_cmp(pi->attr, parent_pi->attr)
 		    && !CHECK_FLAG(pi->flags, BGP_PATH_REMOVED)) {
 			bgp_unlock_node(rn);


### PR DESCRIPTION
Clear up an SA report by clarifying a function call in the bgp evpn code. We managed to let this SA warning slip in recently...