### PR TITLE
topotests: Adapt to linux kernel 5+

### DIFF
--- a/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
+++ b/tests/topotests/bgp_l3vpn_to_bgp_vrf/customize.py
@@ -153,8 +153,10 @@ def ltemplatePreRouterStartHook():
     if topotest.version_cmp(krel, '4.15') >= 0 and \
        topotest.version_cmp(krel, '4.18') <= 0:
         l3mdev_accept = 1
-    else:
-        l3mdev_accept = 0
+
+    if topotest.version_cmp(krel, '5.0') >= 0:
+        l3mdev_accept = 1
+
     logger.info('setting net.ipv4.tcp_l3mdev_accept={}'.format(l3mdev_accept))
     #check for mpls
     if tgen.hasmpls != True:

--- a/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
+++ b/tests/topotests/bgp_vrf_lite_ipv6_rtadv/test_bgp_vrf_lite_ipv6_rtadv.py
@@ -31,6 +31,7 @@ import sys
 import json
 from functools import partial
 import pytest
+import platform
 
 # Save the Current Working Directory to find configuration files.
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -68,6 +69,19 @@ def setup_module(mod):
     router_list = tgen.routers()
 
     logger.info('Testing with VRF Lite support')
+    krel = platform.release()
+
+    # May need to adjust handling of vrf traffic depending on kernel version
+    l3mdev_accept = 0
+    if topotest.version_cmp(krel, '4.15') >= 0 and \
+       topotest.version_cmp(krel, '4.18') <= 0:
+        l3mdev_accept = 1
+
+    if topotest.version_cmp(krel, '5.0') >= 0:
+        l3mdev_accept = 1
+
+    logger.info('krel \'{0}\' setting net.ipv4.tcp_l3mdev_accept={1}'.format(
+        krel, l3mdev_accept))
 
     cmds = ['ip link add {0}-cust1 type vrf table 1001',
             'ip link add loop1 type dummy',
@@ -77,6 +91,15 @@ def setup_module(mod):
     for rname, router in router_list.iteritems():
         for cmd in cmds:
             output = tgen.net[rname].cmd(cmd.format(rname))
+
+        output = tgen.net[rname].cmd('sysctl -n net.ipv4.tcp_l3mdev_accept')
+        logger.info(
+            'router {0}: existing tcp_l3mdev_accept was {1}'.format(
+                rname, output))
+
+        if l3mdev_accept:
+            output = tgen.net[rname].cmd(
+                'sysctl -w net.ipv4.tcp_l3mdev_accept={}'.format(l3mdev_accept))
 
     for rname, router in router_list.iteritems():
         router.load_config(


### PR DESCRIPTION
Make a few changes to try to support topotests that use vrfs on kernel 5 and later; Ubuntu 18 and 19 can end up with kernel 5+ at this point.