### PR TITLE
staticd: check tuple (vrf, name) when interface events received

### DIFF
--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -310,9 +310,13 @@ static void static_ifindex_update_af(struct interface *ifp, bool up, afi_t afi,
 				if (up) {
 					if (strcmp(si->ifname, ifp->name))
 						continue;
+					if (si->nh_vrf_id != ifp->vrf_id)
+						continue;
 					si->ifindex = ifp->ifindex;
 				} else {
 					if (si->ifindex != ifp->ifindex)
+						continue;
+					if (si->nh_vrf_id != ifp->vrf_id)
 						continue;
 					si->ifindex = IFINDEX_INTERNAL;
 				}


### PR DESCRIPTION
with network namespace vrf backend, there is possibilities that the same
interface name can be used across two different vrfs. Then, enforce the
check when static daemon receives interface events. Adding to the
interface name, check for the vrf id, too.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>