### PR TITLE
bgpd: 7.2 - remove error message for unkown afi/safi combination

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -159,10 +159,8 @@ static const char *get_afi_safi_vty_str(afi_t afi, safi_t safi)
 		return "IPv6 Flowspec";
 	else if (afi == AFI_L2VPN && safi == SAFI_EVPN)
 		return "L2VPN EVPN";
-	else {
-		flog_err(EC_LIB_DEVELOPMENT, "New afi/safi that needs to be taken care of?");
+	else
 		return "Unknown";
-	}
 }
 
 /*
@@ -199,10 +197,8 @@ static const char *get_afi_safi_json_str(afi_t afi, safi_t safi)
 		return "ipv6Flowspec";
 	else if (afi == AFI_L2VPN && safi == SAFI_EVPN)
 		return "l2VpnEvpn";
-	else {
-		flog_err(EC_LIB_DEVELOPMENT, "New afi/safi that needs to be taken care of?");
+	else
 		return "Unknown";
-	}
 }
 
 /* Utility function to get address family from current node.  */


### PR DESCRIPTION
Problem reported with error messages appearing in the log
complaining about invalid afi/safi combinations.  Determined
that the error messages were recently added in the function
that turns afi and safi values to strings.  Unfortunately,
the function is called from places using FOREACH_AFI_SAFI,
which spins thru every afi and safi number including some
that are not legal together (ipv4 evpn and l2vpn multicast
for example.)   This fix removes these error messages since
it is not necessarily an error to call it with invalid
combinations.

Ticket: CM-26883
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>