### PR TITLE
zebra: Reinstate zclient->ifinfo restrictions

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -47,6 +47,7 @@ THE SOFTWARE.
 #include "resend.h"
 #include "babel_zebra.h"
 #include "babel_errors.h"
+#include "babel_vrf.h"
 
 static void babel_fail(void);
 static void babel_init_random(void);
@@ -208,6 +209,8 @@ main(int argc, char **argv)
     /* init zebra client's structure and it's commands */
     /* this replace kernel_setup && kernel_setup_socket */
     babelz_zebra_init ();
+
+    babel_vrf_init();
 
     /* init buffer */
     rc = resize_receive_buffer(1500);

--- a/babeld/babel_vrf.c
+++ b/babeld/babel_vrf.c
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * babel - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -20,35 +20,34 @@
 #include <zebra.h>
 
 #include "vrf.h"
+#include "babel_vrf.h"
+#include "babel_zebra.h"
 
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
 
-
-static int eigrp_vrf_new(struct vrf *vrf)
+static int babel_vrf_new(struct vrf *vrf)
 {
 	return 0;
 }
 
-static int eigrp_vrf_enable(struct vrf *vrf)
+static int babel_vrf_enable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_register(vrf);
+	babel_zebra_vrf_register(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_disable(struct vrf *vrf)
+static int babel_vrf_disable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_unregister(vrf);
+	babel_zebra_vrf_unregister(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_delete(struct vrf *vrf)
+static int babel_vrf_delete(struct vrf *vrf)
 {
 	return 0;
 }
 
-void eigrp_vrf_init(void)
+void babel_vrf_init(void)
 {
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
+	vrf_init(babel_vrf_new, babel_vrf_enable, babel_vrf_disable,
+		 babel_vrf_delete, NULL);
 }

--- a/babeld/babel_vrf.h
+++ b/babeld/babel_vrf.h
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * babel - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,38 +17,7 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <zebra.h>
+#ifndef __BABEL_VRF_H__
 
-#include "vrf.h"
-
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
-
-
-static int eigrp_vrf_new(struct vrf *vrf)
-{
-	return 0;
-}
-
-static int eigrp_vrf_enable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_register(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_disable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_unregister(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_delete(struct vrf *vrf)
-{
-	return 0;
-}
-
-void eigrp_vrf_init(void)
-{
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
-}
+void babel_vrf_init(void);
+#endif

--- a/babeld/babel_zebra.c
+++ b/babeld/babel_zebra.c
@@ -260,3 +260,17 @@ babel_zebra_close_connexion(void)
     zclient_stop(zclient);
     zclient_free(zclient);
 }
+
+void babel_zebra_vrf_register(struct vrf *vrf)
+{
+        if (vrf->vrf_id == VRF_DEFAULT)
+                return;
+        zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void babel_zebra_vrf_unregister(struct vrf *vrf)
+{
+        if (vrf->vrf_id == VRF_DEFAULT)
+                return;
+        zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}

--- a/babeld/babel_zebra.h
+++ b/babeld/babel_zebra.h
@@ -31,4 +31,6 @@ void babelz_zebra_init(void);
 void babel_zebra_close_connexion(void);
 extern int debug_babel_config_write (struct vty *);
 
+void babel_zebra_vrf_register(struct vrf *vrf);
+void babel_zebra_vrf_unregister(struct vrf *vrf);
 #endif

--- a/babeld/subdir.am
+++ b/babeld/subdir.am
@@ -28,6 +28,7 @@ babeld_libbabel_a_SOURCES = \
 	babeld/source.c \
 	babeld/util.c \
 	babeld/xroute.c \
+	babeld/babel_vrf.c \
 	# end
 
 noinst_HEADERS += \
@@ -46,6 +47,7 @@ noinst_HEADERS += \
 	babeld/source.h \
 	babeld/util.h \
 	babeld/xroute.h \
+	babeld/babel_vrf.h \
 	# end
 
 babeld_babeld_SOURCES = babeld/babel_main.c

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -185,7 +185,6 @@ int main(int argc, char **argv, char **envp)
 
 	eigrp_error_init();
 	eigrp_vrf_init();
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
 
 	/*EIGRPd init*/
 	eigrp_if_init();

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -317,3 +317,17 @@ int eigrp_redistribute_unset(struct eigrp *eigrp, int type)
 
 	return CMD_SUCCESS;
 }
+
+void eigrp_zebra_vrf_register(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void eigrp_zebra_vrf_unregister(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}

--- a/eigrpd/eigrp_zebra.h
+++ b/eigrpd/eigrp_zebra.h
@@ -30,6 +30,7 @@
 
 #include "vty.h"
 #include "vrf.h"
+#include "eigrp_structs.h"
 
 extern void eigrp_zebra_init(void);
 
@@ -39,4 +40,6 @@ extern void eigrp_zebra_route_delete(struct eigrp *eigrp, struct prefix *);
 extern int eigrp_redistribute_set(struct eigrp *, int, struct eigrp_metrics);
 extern int eigrp_redistribute_unset(struct eigrp *, int);
 
+extern void eigrp_zebra_vrf_register(struct vrf *vrf);
+extern void eigrp_zebra_vrf_unregister(struct vrf *vrf);
 #endif /* _ZEBRA_EIGRP_ZEBRA_H_ */

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -51,6 +51,7 @@
 #include "isisd/isis_route.h"
 #include "isisd/isis_routemap.h"
 #include "isisd/isis_zebra.h"
+#include "isisd/isis_vrf.h"
 #include "isisd/isis_te.h"
 #include "isisd/isis_errors.h"
 #include "isisd/isis_bfd.h"
@@ -227,7 +228,7 @@ int main(int argc, char **argv, char **envp)
 	 */
 	isis_error_init();
 	access_list_init();
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	isis_vrf_init();
 	prefix_list_init();
 	isis_init();
 	isis_circuit_init();

--- a/isisd/isis_vrf.c
+++ b/isisd/isis_vrf.c
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * isis - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -21,34 +21,34 @@
 
 #include "vrf.h"
 
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
+#include "isisd/isis_vrf.h"
+#include "isisd/isis_zebra.h"
 
 
-static int eigrp_vrf_new(struct vrf *vrf)
+static int isis_vrf_new(struct vrf *vrf)
 {
 	return 0;
 }
 
-static int eigrp_vrf_enable(struct vrf *vrf)
+static int isis_vrf_enable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_register(vrf);
+	isis_zebra_vrf_register(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_disable(struct vrf *vrf)
+static int isis_vrf_disable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_unregister(vrf);
+	isis_zebra_vrf_unregister(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_delete(struct vrf *vrf)
+static int isis_vrf_delete(struct vrf *vrf)
 {
 	return 0;
 }
 
-void eigrp_vrf_init(void)
+void isis_vrf_init(void)
 {
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
+	vrf_init(isis_vrf_new, isis_vrf_enable, isis_vrf_disable,
+		 isis_vrf_delete, NULL);
 }

--- a/isisd/isis_vrf.h
+++ b/isisd/isis_vrf.h
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * isis - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,38 +17,7 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <zebra.h>
+#ifndef __ISIS_VRF_H__
 
-#include "vrf.h"
-
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
-
-
-static int eigrp_vrf_new(struct vrf *vrf)
-{
-	return 0;
-}
-
-static int eigrp_vrf_enable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_register(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_disable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_unregister(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_delete(struct vrf *vrf)
-{
-	return 0;
-}
-
-void eigrp_vrf_init(void)
-{
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
-}
+void isis_vrf_init(void);
+#endif

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -328,3 +328,17 @@ void isis_zebra_stop(void)
 	zclient_free(zclient);
 	frr_fini();
 }
+
+void isis_zebra_vrf_register(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void isis_zebra_vrf_unregister(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}

--- a/isisd/isis_zebra.h
+++ b/isisd/isis_zebra.h
@@ -39,4 +39,7 @@ int isis_distribute_list_update(int routetype);
 void isis_zebra_redistribute_set(afi_t afi, int type);
 void isis_zebra_redistribute_unset(afi_t afi, int type);
 
+void isis_zebra_vrf_register(struct vrf *vrf);
+void isis_zebra_vrf_unregister(struct vrf *vrf);
+
 #endif /* _ZEBRA_ISIS_ZEBRA_H */

--- a/isisd/subdir.am
+++ b/isisd/subdir.am
@@ -55,6 +55,7 @@ noinst_HEADERS += \
 	isisd/isisd.h \
 	isisd/iso_checksum.h \
 	isisd/fabricd.h \
+	isisd/isis_vrf.h \
 	# end
 
 LIBISIS_SOURCES = \
@@ -84,6 +85,7 @@ LIBISIS_SOURCES = \
 	isisd/isisd.c \
 	isisd/iso_checksum.c \
 	isisd/fabricd.c \
+	isisd/isis_vrf.c \
 	# end
 
 ISIS_SOURCES = \

--- a/ldpd/ldp_vrf.c
+++ b/ldpd/ldp_vrf.c
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * ldp - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -21,34 +21,34 @@
 
 #include "vrf.h"
 
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
+#include "ldpd/ldp_vrf.h"
+#include "ldpd/ldp_zebra.h"
 
 
-static int eigrp_vrf_new(struct vrf *vrf)
+static int ldp_vrf_new(struct vrf *vrf)
 {
 	return 0;
 }
 
-static int eigrp_vrf_enable(struct vrf *vrf)
+static int ldp_vrf_enable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_register(vrf);
+	ldp_zebra_vrf_register(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_disable(struct vrf *vrf)
+static int ldp_vrf_disable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_unregister(vrf);
+	ldp_zebra_vrf_unregister(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_delete(struct vrf *vrf)
+static int ldp_vrf_delete(struct vrf *vrf)
 {
 	return 0;
 }
 
-void eigrp_vrf_init(void)
+void ldp_vrf_init(void)
 {
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
+	vrf_init(ldp_vrf_new, ldp_vrf_enable, ldp_vrf_disable,
+		 ldp_vrf_delete, NULL);
 }

--- a/ldpd/ldp_vrf.h
+++ b/ldpd/ldp_vrf.h
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * ldpd - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,38 +17,7 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <zebra.h>
+#ifndef __LDP_VRF_H__
 
-#include "vrf.h"
-
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
-
-
-static int eigrp_vrf_new(struct vrf *vrf)
-{
-	return 0;
-}
-
-static int eigrp_vrf_enable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_register(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_disable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_unregister(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_delete(struct vrf *vrf)
-{
-	return 0;
-}
-
-void eigrp_vrf_init(void)
-{
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
-}
+extern void ldp_vrf_init(void);
+#endif

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -33,6 +33,8 @@
 #include "lde.h"
 #include "log.h"
 #include "ldp_debug.h"
+#include "ldp_vrf.h"
+#include "ldp_zebra.h"
 
 static void	 ifp2kif(struct interface *, struct kif *);
 static void	 ifc2kaddr(struct interface *, struct connected *,
@@ -544,4 +546,18 @@ ldp_zebra_destroy(void)
 	zclient_stop(zclient);
 	zclient_free(zclient);
 	zclient = NULL;
+}
+
+void ldp_zebra_vrf_register(struct vrf *vrf)
+{
+        if (vrf->vrf_id == VRF_DEFAULT)
+                return;
+        zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void ldp_zebra_vrf_unregister(struct vrf *vrf)
+{
+        if (vrf->vrf_id == VRF_DEFAULT)
+                return;
+        zclient_send_dereg_requests(zclient, vrf->vrf_id);
 }

--- a/ldpd/ldp_zebra.h
+++ b/ldpd/ldp_zebra.h
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * ldp - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,38 +17,12 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <zebra.h>
 
-#include "vrf.h"
+#ifndef _ZEBRA_LDP_ZEBRA_H
+#define _ZEBRA_LDP_ZEBRA_H
 
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
+void ldp_zebra_init(struct thread_master *);
+void ldp_zebra_vrf_register(struct vrf *vrf);
+void ldp_zebra_vrf_unregister(struct vrf *vrf);
 
-
-static int eigrp_vrf_new(struct vrf *vrf)
-{
-	return 0;
-}
-
-static int eigrp_vrf_enable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_register(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_disable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_unregister(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_delete(struct vrf *vrf)
-{
-	return 0;
-}
-
-void eigrp_vrf_init(void)
-{
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
-}
+#endif /* _ZEBRA_ISIS_ZEBRA_H */

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -43,6 +43,7 @@
 #include "qobj.h"
 #include "libfrr.h"
 #include "lib_errors.h"
+#include "ldp_vrf.h"
 
 static void		 ldpd_shutdown(void);
 static pid_t		 start_child(enum ldpd_process, char *, int, int);
@@ -347,7 +348,7 @@ main(int argc, char *argv[])
 
 	master = frr_init();
 
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	ldp_vrf_init();
 	access_list_init();
 	ldp_vty_init();
 	ldp_zebra_init(master);

--- a/ldpd/subdir.am
+++ b/ldpd/subdir.am
@@ -38,6 +38,7 @@ ldpd_libldp_a_SOURCES = \
 	ldpd/pfkey.c \
 	ldpd/socket.c \
 	ldpd/util.c \
+	ldpd/ldp_vrf.c \
 	# end
 
 ldpd/ldp_vty_cmds_clippy.c: $(CLIPPY_DEPS)
@@ -52,6 +53,8 @@ noinst_HEADERS += \
 	ldpd/ldpd.h \
 	ldpd/ldpe.h \
 	ldpd/log.h \
+	ldpd/ldp_vrf.h \
+	ldpd/ldp_zebra.h \
 	# end
 
 ldpd_ldpd_SOURCES = ldpd/ldpd.c

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -25,6 +25,7 @@
 #include "libfrr.h"
 
 #include "nhrpd.h"
+#include "nhrp_vrf.h"
 #include "netlink.h"
 #include "nhrp_errors.h"
 
@@ -138,7 +139,7 @@ int main(int argc, char **argv)
 	/* Library inits. */
 	master = frr_init();
 	nhrp_error_init();
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	nhrp_vrf_init();
 	nhrp_interface_init();
 	resolver_init(master);
 

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -359,3 +359,17 @@ void nhrp_zebra_terminate(void)
 	route_table_finish(zebra_rib[AFI_IP]);
 	route_table_finish(zebra_rib[AFI_IP6]);
 }
+
+void nhrp_zebra_vrf_register(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void nhrp_zebra_vrf_unregister(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}

--- a/nhrpd/nhrp_vrf.c
+++ b/nhrpd/nhrp_vrf.c
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * nhrp - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -20,35 +20,33 @@
 #include <zebra.h>
 
 #include "vrf.h"
+#include "nhrpd.h"
+#include "nhrp_vrf.h"
 
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
-
-
-static int eigrp_vrf_new(struct vrf *vrf)
+static int nhrp_vrf_new(struct vrf *vrf)
 {
 	return 0;
 }
 
-static int eigrp_vrf_enable(struct vrf *vrf)
+static int nhrp_vrf_enable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_register(vrf);
+	nhrp_zebra_vrf_register(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_disable(struct vrf *vrf)
+static int nhrp_vrf_disable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_unregister(vrf);
+	nhrp_zebra_vrf_unregister(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_delete(struct vrf *vrf)
+static int nhrp_vrf_delete(struct vrf *vrf)
 {
 	return 0;
 }
 
-void eigrp_vrf_init(void)
+void nhrp_vrf_init(void)
 {
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
+	vrf_init(nhrp_vrf_new, nhrp_vrf_enable, nhrp_vrf_disable,
+		 nhrp_vrf_delete, NULL);
 }

--- a/nhrpd/nhrp_vrf.h
+++ b/nhrpd/nhrp_vrf.h
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * nhrpd - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,38 +17,7 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <zebra.h>
+#ifndef __NHRP_VRF_H__
 
-#include "vrf.h"
-
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
-
-
-static int eigrp_vrf_new(struct vrf *vrf)
-{
-	return 0;
-}
-
-static int eigrp_vrf_enable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_register(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_disable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_unregister(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_delete(struct vrf *vrf)
-{
-	return 0;
-}
-
-void eigrp_vrf_init(void)
-{
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
-}
+void nhrp_vrf_init(void);
+#endif

--- a/nhrpd/nhrpd.h
+++ b/nhrpd/nhrpd.h
@@ -444,4 +444,6 @@ void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb);
 void nhrp_peer_send(struct nhrp_peer *p, struct zbuf *zb);
 void nhrp_peer_send_indication(struct interface *ifp, uint16_t, struct zbuf *);
 
+extern void nhrp_zebra_vrf_register(struct vrf *vrf);
+extern void nhrp_zebra_vrf_unregister(struct vrf *vrf);
 #endif

--- a/nhrpd/subdir.am
+++ b/nhrpd/subdir.am
@@ -29,6 +29,7 @@ nhrpd_nhrpd_SOURCES = \
 	nhrpd/vici.c \
 	nhrpd/zbuf.c \
 	nhrpd/znl.c \
+	nhrpd/nhrp_vrf.c \
 	# end
 
 noinst_HEADERS += \
@@ -42,4 +43,5 @@ noinst_HEADERS += \
 	nhrpd/vici.h \
 	nhrpd/zbuf.h \
 	nhrpd/znl.h \
+	nhrpd/nhrp_vrf.h \
 	# end

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -47,6 +47,7 @@
 #include "ospf6_lsa.h"
 #include "ospf6_interface.h"
 #include "ospf6_zebra.h"
+#include "ospf6_vrf.h"
 
 /* Default configuration file name for ospf6d. */
 #define OSPF6_DEFAULT_CONFIG       "ospf6d.conf"
@@ -217,7 +218,7 @@ int main(int argc, char *argv[], char *envp[])
 	/* thread master */
 	master = frr_init();
 
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	ospf6_vrf_init();
 	access_list_init();
 	prefix_list_init();
 

--- a/ospf6d/ospf6_vrf.c
+++ b/ospf6d/ospf6_vrf.c
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * ospf6 - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -21,34 +21,35 @@
 
 #include "vrf.h"
 
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
+#include "ospf6_route.h"
+#include "ospf6_vrf.h"
+#include "ospf6_zebra.h"
 
 
-static int eigrp_vrf_new(struct vrf *vrf)
+static int ospf6_vrf_new(struct vrf *vrf)
 {
 	return 0;
 }
 
-static int eigrp_vrf_enable(struct vrf *vrf)
+static int ospf6_vrf_enable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_register(vrf);
+	ospf6_zebra_vrf_register(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_disable(struct vrf *vrf)
+static int ospf6_vrf_disable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_unregister(vrf);
+	ospf6_zebra_vrf_unregister(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_delete(struct vrf *vrf)
+static int ospf6_vrf_delete(struct vrf *vrf)
 {
 	return 0;
 }
 
-void eigrp_vrf_init(void)
+void ospf6_vrf_init(void)
 {
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
+	vrf_init(ospf6_vrf_new, ospf6_vrf_enable, ospf6_vrf_disable,
+		 ospf6_vrf_delete, NULL);
 }

--- a/ospf6d/ospf6_vrf.h
+++ b/ospf6d/ospf6_vrf.h
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * ospf6 - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,38 +17,7 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <zebra.h>
+#ifndef __OSPF6_VRF_H__
 
-#include "vrf.h"
-
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
-
-
-static int eigrp_vrf_new(struct vrf *vrf)
-{
-	return 0;
-}
-
-static int eigrp_vrf_enable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_register(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_disable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_unregister(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_delete(struct vrf *vrf)
-{
-	return 0;
-}
-
-void eigrp_vrf_init(void)
-{
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
-}
+extern void ospf6_vrf_init(void);
+#endif

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -616,3 +616,18 @@ void install_element_ospf6_debug_zebra(void)
 	install_element(CONFIG_NODE, &debug_ospf6_zebra_sendrecv_cmd);
 	install_element(CONFIG_NODE, &no_debug_ospf6_zebra_sendrecv_cmd);
 }
+
+void ospf6_zebra_vrf_register(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void ospf6_zebra_vrf_unregister(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}
+

--- a/ospf6d/ospf6_zebra.h
+++ b/ospf6d/ospf6_zebra.h
@@ -65,4 +65,6 @@ extern int ospf6_distance_unset(struct vty *, struct ospf6 *, const char *,
 extern int config_write_ospf6_debug_zebra(struct vty *vty);
 extern void install_element_ospf6_debug_zebra(void);
 
+extern void ospf6_zebra_vrf_register(struct vrf *vrf);
+extern void ospf6_zebra_vrf_unregister(struct vrf *vrf);
 #endif /*OSPF6_ZEBRA_H*/

--- a/ospf6d/subdir.am
+++ b/ospf6d/subdir.am
@@ -21,6 +21,7 @@ vtysh_scan += \
 	$(top_srcdir)/ospf6d/ospf6_spf.c \
 	$(top_srcdir)/ospf6d/ospf6_top.c \
 	$(top_srcdir)/ospf6d/ospf6_zebra.c \
+	$(top_srcdir)/ospf6d/ospf6_vrf.c \
 	$(top_srcdir)/ospf6d/ospf6d.c \
 	# end
 if SNMP
@@ -48,6 +49,7 @@ ospf6d_libospf6_a_SOURCES = \
 	ospf6d/ospf6_spf.c \
 	ospf6d/ospf6_top.c \
 	ospf6d/ospf6_zebra.c \
+	ospf6d/ospf6_vrf.c \
 	ospf6d/ospf6d.c \
 	# end
 
@@ -70,6 +72,7 @@ noinst_HEADERS += \
 	ospf6d/ospf6_spf.h \
 	ospf6d/ospf6_top.h \
 	ospf6d/ospf6_zebra.h \
+	ospf6d/ospf6_vrf.h \
 	ospf6d/ospf6d.h \
 	# end
 

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -46,6 +46,7 @@
 #include "pbr_nht.h"
 #include "pbr_map.h"
 #include "pbr_zebra.h"
+#include "pbr_vrf.h"
 #include "pbr_vty.h"
 #include "pbr_debug.h"
 #include "pbr_vrf.h"

--- a/pbrd/pbr_vrf.c
+++ b/pbrd/pbr_vrf.c
@@ -21,6 +21,8 @@
 
 #include "vrf.h"
 
+#include "pbr_nht.h"
+#include "pbr_zebra.h"
 #include "pbr_vrf.h"
 #include "pbr_memory.h"
 #include "pbr_map.h"
@@ -61,6 +63,7 @@ static int pbr_vrf_enable(struct vrf *vrf)
 
 	pbr_map_vrf_update(vrf->info);
 
+	pbr_zebra_vrf_register(vrf);
 	return 0;
 }
 
@@ -70,6 +73,7 @@ static int pbr_vrf_disable(struct vrf *vrf)
 
 	pbr_map_vrf_update(vrf->info);
 
+	pbr_zebra_vrf_unregister(vrf);
 	return 0;
 }
 

--- a/pbrd/pbr_vrf.h
+++ b/pbrd/pbr_vrf.h
@@ -38,6 +38,5 @@ extern struct pbr_vrf *pbr_vrf_lookup_by_id(vrf_id_t vrf_id);
 extern struct pbr_vrf *pbr_vrf_lookup_by_name(const char *name);
 extern bool pbr_vrf_is_valid(const struct pbr_vrf *pbr_vrf);
 extern bool pbr_vrf_is_enabled(const struct pbr_vrf *pbr_vrf);
-
 extern void pbr_vrf_init(void);
 #endif

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -605,3 +605,17 @@ void pbr_send_pbr_map(struct pbr_map_sequence *pbrms,
 
 	zclient_send_message(zclient);
 }
+
+void pbr_zebra_vrf_register(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void pbr_zebra_vrf_unregister(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}

--- a/pbrd/pbr_zebra.h
+++ b/pbrd/pbr_zebra.h
@@ -45,4 +45,7 @@ extern int pbr_ifp_up(struct interface *ifp);
 extern int pbr_ifp_down(struct interface *ifp);
 extern int pbr_ifp_destroy(struct interface *ifp);
 
+void pbr_zebra_vrf_register(struct vrf *vrf);
+void pbr_zebra_vrf_unregister(struct vrf *vrf);
+
 #endif

--- a/pbrd/subdir.am
+++ b/pbrd/subdir.am
@@ -15,6 +15,7 @@ endif
 
 pbrd_libpbr_a_SOURCES = \
 	pbrd/pbr_zebra.c \
+	pbrd/pbr_vrf.c \
 	pbrd/pbr_vty.c \
 	pbrd/pbr_map.c \
 	pbrd/pbr_memory.c \
@@ -29,6 +30,7 @@ noinst_HEADERS += \
 	pbrd/pbr_nht.h \
 	pbrd/pbr_vty.h \
 	pbrd/pbr_zebra.h \
+	pbrd/pbr_vrf.h \
 	pbrd/pbr_debug.h \
 	pbrd/pbr_vrf.h \
 	# end

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -45,6 +45,7 @@
 #include "nexthop_group.h"
 
 #include "sharp_zebra.h"
+#include "sharp_vrf.h"
 #include "sharp_vty.h"
 #include "sharp_globals.h"
 
@@ -159,7 +160,7 @@ int main(int argc, char **argv, char **envp)
 	sharp_global_init();
 
 	nexthop_group_init(NULL, NULL, NULL, NULL);
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	sharpd_vrf_init();
 
 	access_list_init();
 	route_map_init();

--- a/sharpd/sharp_vrf.c
+++ b/sharpd/sharp_vrf.c
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * sharpd - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -21,34 +21,36 @@
 
 #include "vrf.h"
 
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
+#include "nexthop.h"
+#include "nexthop_group.h"
+#include "sharp_vrf.h"
+#include "sharp_zebra.h"
 
 
-static int eigrp_vrf_new(struct vrf *vrf)
+static int sharpd_vrf_new(struct vrf *vrf)
 {
 	return 0;
 }
 
-static int eigrp_vrf_enable(struct vrf *vrf)
+static int sharpd_vrf_enable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_register(vrf);
+	sharpd_zebra_vrf_register(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_disable(struct vrf *vrf)
+static int sharpd_vrf_disable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_unregister(vrf);
+	sharpd_zebra_vrf_unregister(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_delete(struct vrf *vrf)
+static int sharpd_vrf_delete(struct vrf *vrf)
 {
 	return 0;
 }
 
-void eigrp_vrf_init(void)
+void sharpd_vrf_init(void)
 {
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
+	vrf_init(sharpd_vrf_new, sharpd_vrf_enable, sharpd_vrf_disable,
+		 sharpd_vrf_delete, NULL);
 }

--- a/sharpd/sharp_vrf.h
+++ b/sharpd/sharp_vrf.h
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * sharpd - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,38 +17,7 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <zebra.h>
+#ifndef __SHARP_VRF_H__
 
-#include "vrf.h"
-
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
-
-
-static int eigrp_vrf_new(struct vrf *vrf)
-{
-	return 0;
-}
-
-static int eigrp_vrf_enable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_register(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_disable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_unregister(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_delete(struct vrf *vrf)
-{
-	return 0;
-}
-
-void eigrp_vrf_init(void)
-{
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
-}
+extern void sharpd_vrf_init(void);
+#endif

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -422,3 +422,18 @@ void sharp_zebra_init(void)
 	zclient->redistribute_route_add = sharp_redistribute_route;
 	zclient->redistribute_route_del = sharp_redistribute_route;
 }
+
+void sharpd_zebra_vrf_register(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void sharpd_zebra_vrf_unregister(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}
+

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -37,4 +37,6 @@ extern void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 					uint32_t routes);
 extern void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 				       uint8_t instance, uint32_t routes);
+extern void sharpd_zebra_vrf_register(struct vrf *vrf);
+extern void sharpd_zebra_vrf_unregister(struct vrf *vrf);
 #endif

--- a/sharpd/subdir.am
+++ b/sharpd/subdir.am
@@ -13,6 +13,7 @@ endif
 sharpd_libsharp_a_SOURCES = \
 	sharpd/sharp_nht.c \
 	sharpd/sharp_zebra.c \
+	sharpd/sharp_vrf.c \
 	sharpd/sharp_vty.c \
 	# end
 
@@ -21,6 +22,7 @@ noinst_HEADERS += \
 	sharpd/sharp_vty.h \
 	sharpd/sharp_globals.h \
 	sharpd/sharp_zebra.h \
+	sharpd/sharp_vrf.h \
 	# end
 
 sharpd/sharp_vty_clippy.c: $(CLIPPY_DEPS)

--- a/vrrpd/subdir.am
+++ b/vrrpd/subdir.am
@@ -19,6 +19,7 @@ vrrpd_libvrrp_a_SOURCES = \
 	vrrpd/vrrp_packet.c \
 	vrrpd/vrrp_vty.c \
 	vrrpd/vrrp_zebra.c \
+	vrrpd/vrrp_vrf.c \
 	# end
 
 noinst_HEADERS += \
@@ -29,6 +30,7 @@ noinst_HEADERS += \
 	vrrpd/vrrp_packet.h \
 	vrrpd/vrrp_vty.h \
 	vrrpd/vrrp_zebra.h \
+	vrrpd/vrrp_vrf.h \
 	# end
 
 vrrpd/vrrp_vty_clippy.c: $(CLIPPY_DEPS)

--- a/vrrpd/vrrp.c
+++ b/vrrpd/vrrp.c
@@ -37,6 +37,7 @@
 #include "vrrp_ndisc.h"
 #include "vrrp_packet.h"
 #include "vrrp_zebra.h"
+#include "vrrp_vrf.h"
 
 #define VRRP_LOGPFX "[CORE] "
 
@@ -2369,7 +2370,7 @@ void vrrp_init(void)
 	vrrp_autoconfig_version = 3;
 	vrrp_vrouters_hash = hash_create(&vrrp_hash_key, vrrp_hash_cmp,
 					 "VRRP virtual router hash");
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
+	vrrp_vrf_init();
 }
 
 void vrrp_fini(void)

--- a/vrrpd/vrrp_vrf.c
+++ b/vrrpd/vrrp_vrf.c
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * vrrp - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -20,35 +20,34 @@
 #include <zebra.h>
 
 #include "vrf.h"
+#include "vrrp.h"
+#include "vrrp_vrf.h"
+#include "vrrp_zebra.h"
 
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
-
-
-static int eigrp_vrf_new(struct vrf *vrf)
+static int vrrp_vrf_new(struct vrf *vrf)
 {
 	return 0;
 }
 
-static int eigrp_vrf_enable(struct vrf *vrf)
+static int vrrp_vrf_enable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_register(vrf);
+	vrrp_zebra_vrf_register(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_disable(struct vrf *vrf)
+static int vrrp_vrf_disable(struct vrf *vrf)
 {
-	eigrp_zebra_vrf_unregister(vrf);
+	vrrp_zebra_vrf_unregister(vrf);
 	return 0;
 }
 
-static int eigrp_vrf_delete(struct vrf *vrf)
+static int vrrp_vrf_delete(struct vrf *vrf)
 {
 	return 0;
 }
 
-void eigrp_vrf_init(void)
+void vrrp_vrf_init(void)
 {
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
+	vrf_init(vrrp_vrf_new, vrrp_vrf_enable, vrrp_vrf_disable,
+		 vrrp_vrf_delete, NULL);
 }

--- a/vrrpd/vrrp_vrf.h
+++ b/vrrpd/vrrp_vrf.h
@@ -1,7 +1,7 @@
 /*
- * eigrp - vrf code
- * Copyright (C) 2019 Cumulus Networks, Inc.
- *               Donald Sharp
+ * vrrp - vrf code
+ * Copyright (C) 2019 VMware Inc.
+ *               Kishore Aramalla
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,38 +17,7 @@
  * with this program; see the file COPYING; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <zebra.h>
+#ifndef __VRRP_VRF_H__
 
-#include "vrf.h"
-
-#include "eigrpd/eigrp_vrf.h"
-#include "eigrpd/eigrp_zebra.h"
-
-
-static int eigrp_vrf_new(struct vrf *vrf)
-{
-	return 0;
-}
-
-static int eigrp_vrf_enable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_register(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_disable(struct vrf *vrf)
-{
-	eigrp_zebra_vrf_unregister(vrf);
-	return 0;
-}
-
-static int eigrp_vrf_delete(struct vrf *vrf)
-{
-	return 0;
-}
-
-void eigrp_vrf_init(void)
-{
-	vrf_init(eigrp_vrf_new, eigrp_vrf_enable,
-		 eigrp_vrf_disable, eigrp_vrf_delete, NULL);
-}
+extern void vrrp_vrf_init(void);
+#endif

--- a/vrrpd/vrrp_zebra.c
+++ b/vrrpd/vrrp_zebra.c
@@ -29,6 +29,7 @@
 #include "vrrp.h"
 #include "vrrp_debug.h"
 #include "vrrp_zebra.h"
+#include "vrrp_vrf.h"
 
 #define VRRP_LOGPFX "[ZEBRA] "
 
@@ -206,3 +207,18 @@ void vrrp_zebra_init(void)
 
 	zlog_notice("%s: zclient socket initialized", __PRETTY_FUNCTION__);
 }
+
+void vrrp_zebra_vrf_register(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_reg_requests(zclient, vrf->vrf_id);
+}
+
+void vrrp_zebra_vrf_unregister(struct vrf *vrf)
+{
+	if (vrf->vrf_id == VRF_DEFAULT)
+		return;
+	zclient_send_dereg_requests(zclient, vrf->vrf_id);
+}
+

--- a/vrrpd/vrrp_zebra.h
+++ b/vrrpd/vrrp_zebra.h
@@ -34,4 +34,6 @@ extern int vrrp_ifp_up(struct interface *ifp);
 extern int vrrp_ifp_down(struct interface *ifp);
 extern int vrrp_ifp_destroy(struct interface *ifp);
 
+void vrrp_zebra_vrf_register(struct vrf *vrf);
+void vrrp_zebra_vrf_unregister(struct vrf *vrf);
 #endif /* __VRRP_ZEBRA_H__ */

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -463,15 +463,19 @@ void zebra_interface_up_update(struct interface *ifp)
 	struct listnode *node, *nnode;
 	struct zserv *client;
 
-	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_UP %s(%u)",
-			   ifp->name, ifp->vrf_id);
-
 	if (ifp->ptm_status || !ifp->ptm_enable) {
 		for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode,
 				       client)) {
-			zsend_interface_update(ZEBRA_INTERFACE_UP,
-					       client, ifp);
+			if (!vrf_bitmap_check(client->vrf_reg_info,
+					     ifp->vrf_id))
+				continue;
+
+			if (IS_ZEBRA_DEBUG_EVENT)
+				zlog_debug("ZEBRA_INTERFACE_UP %s(%u) to zclient: %s",
+					   ifp->name, ifp->vrf_id,
+					   zebra_route_string(client->proto));
+
+			zsend_interface_update(ZEBRA_INTERFACE_UP, client, ifp);
 			zsend_interface_link_params(client, ifp);
 		}
 	}
@@ -483,11 +487,15 @@ void zebra_interface_down_update(struct interface *ifp)
 	struct listnode *node, *nnode;
 	struct zserv *client;
 
-	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_DOWN %s(%u)",
-			   ifp->name, ifp->vrf_id);
-
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
+		if (!vrf_bitmap_check(client->vrf_reg_info, ifp->vrf_id))
+			continue;
+
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("ZEBRA_INTERFACE_DOWN %s(%u) to zclient: %s",
+				   ifp->name, ifp->vrf_id,
+				   zebra_route_string(client->proto));
+
 		zsend_interface_update(ZEBRA_INTERFACE_DOWN, client, ifp);
 	}
 }
@@ -498,11 +506,15 @@ void zebra_interface_add_update(struct interface *ifp)
 	struct listnode *node, *nnode;
 	struct zserv *client;
 
-	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADD %s(%u)", ifp->name,
-			   ifp->vrf_id);
-
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
+		if (!vrf_bitmap_check(client->vrf_reg_info, ifp->vrf_id))
+			continue;
+
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("ZEBRA_INTERFACE_ADD %s(%u) to zclient: %s",
+				   ifp->name, ifp->vrf_id,
+				   zebra_route_string(client->proto));
+
 		client->ifadd_cnt++;
 		zsend_interface_add(client, ifp);
 		zsend_interface_link_params(client, ifp);
@@ -514,11 +526,15 @@ void zebra_interface_delete_update(struct interface *ifp)
 	struct listnode *node, *nnode;
 	struct zserv *client;
 
-	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_DELETE %s(%u)",
-			   ifp->name, ifp->vrf_id);
-
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
+		if (!vrf_bitmap_check(client->vrf_reg_info, ifp->vrf_id))
+			continue;
+
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("ZEBRA_INTERFACE_DELETE %s(%u) to zclient: %s",
+				   ifp->name, ifp->vrf_id,
+				   zebra_route_string(client->proto));
+
 		client->ifdel_cnt++;
 		zsend_interface_delete(client, ifp);
 	}
@@ -531,14 +547,16 @@ void zebra_interface_address_add_update(struct interface *ifp,
 	struct listnode *node, *nnode;
 	struct zserv *client;
 	struct prefix *p;
+	char buf1[256];
 
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		char buf[PREFIX_STRLEN];
 
 		p = ifc->address;
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADDRESS_ADD %s on %s(%u)",
-			   prefix2str(p, buf, sizeof(buf)), ifp->name,
-			   ifp->vrf_id);
+		snprintf(buf1, sizeof(buf1),
+			 "ZEBRA_INTERFACE_ADDRESS_ADD %s on %s(%u)",
+			 prefix2str(p, buf, sizeof(buf)), ifp->name,
+			 ifp->vrf_id);
 	}
 
 	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_REAL))
@@ -550,12 +568,21 @@ void zebra_interface_address_add_update(struct interface *ifp,
 
 	router_id_add_address(ifc);
 
-	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client))
+	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		if (CHECK_FLAG(ifc->conf, ZEBRA_IFC_REAL)) {
+			if (!vrf_bitmap_check(client->vrf_reg_info,
+					      ifp->vrf_id))
+				continue;
+
+			if (IS_ZEBRA_DEBUG_EVENT)
+				zlog_debug("%s to zclient: %s", buf1,
+				    zebra_route_string(client->proto));
+
 			client->connected_rt_add_cnt++;
 			zsend_interface_address(ZEBRA_INTERFACE_ADDRESS_ADD,
 						client, ifp, ifc);
 		}
+	}
 }
 
 /* Interface address deletion. */
@@ -565,26 +592,37 @@ void zebra_interface_address_delete_update(struct interface *ifp,
 	struct listnode *node, *nnode;
 	struct zserv *client;
 	struct prefix *p;
+	char buf1[256];
 
 	if (IS_ZEBRA_DEBUG_EVENT) {
 		char buf[PREFIX_STRLEN];
 
 		p = ifc->address;
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_ADDRESS_DELETE %s on %s(%u)",
-			   prefix2str(p, buf, sizeof(buf)),
-			   ifp->name, ifp->vrf_id);
+		snprintf(buf1, sizeof(buf1),
+			 "ZEBRA_INTERFACE_ADDRESS_DELETE %s on %s(%u)",
+			 prefix2str(p, buf, sizeof(buf)),
+			 ifp->name, ifp->vrf_id);
 	}
 
 	zebra_vxlan_add_del_gw_macip(ifp, ifc->address, 0);
 
 	router_id_del_address(ifc);
 
-	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client))
+	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		if (CHECK_FLAG(ifc->conf, ZEBRA_IFC_REAL)) {
+			if (!vrf_bitmap_check(client->vrf_reg_info,
+					      ifp->vrf_id))
+				continue;
+
+			if (IS_ZEBRA_DEBUG_EVENT)
+				zlog_debug("%s to zclient: %s", buf1,
+				    zebra_route_string(client->proto));
+
 			client->connected_rt_del_cnt++;
 			zsend_interface_address(ZEBRA_INTERFACE_ADDRESS_DELETE,
 						client, ifp, ifc);
 		}
+	}
 }
 
 /* Interface VRF change. May need to delete from clients not interested in
@@ -594,19 +632,26 @@ void zebra_interface_vrf_update_del(struct interface *ifp, vrf_id_t new_vrf_id)
 {
 	struct listnode *node, *nnode;
 	struct zserv *client;
+	char buf[256];
 
 	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug(
-			"MESSAGE: ZEBRA_INTERFACE_VRF_UPDATE/DEL %s VRF Id %u -> %u",
-			ifp->name, ifp->vrf_id, new_vrf_id);
+		snprintf(buf, sizeof(buf),
+			 "ZEBRA_INTERFACE_VRF_UPDATE/DEL %s VRF Id %u -> %u",
+			 ifp->name, ifp->vrf_id, new_vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Need to delete if the client is not interested in the new
 		 * VRF. */
+		if (!vrf_bitmap_check(client->vrf_reg_info, ifp->vrf_id))
+			continue;
+
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s to zclient: %s", buf,
+			    zebra_route_string(client->proto));
+
 		zsend_interface_update(ZEBRA_INTERFACE_DOWN, client, ifp);
 		client->ifdel_cnt++;
 		zsend_interface_delete(client, ifp);
-		zsend_interface_vrf_update(client, ifp, new_vrf_id);
 	}
 }
 
@@ -617,17 +662,25 @@ void zebra_interface_vrf_update_add(struct interface *ifp, vrf_id_t old_vrf_id)
 {
 	struct listnode *node, *nnode;
 	struct zserv *client;
+	char buf[256];
 
 	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug(
-			"MESSAGE: ZEBRA_INTERFACE_VRF_UPDATE/ADD %s VRF Id %u -> %u",
-			ifp->name, old_vrf_id, ifp->vrf_id);
+		snprintf(buf, sizeof(buf),
+			 "ZEBRA_INTERFACE_VRF_UPDATE/ADD %s VRF Id %u -> %u",
+			 ifp->name, old_vrf_id, ifp->vrf_id);
 
 	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
 		/* Need to add if the client is interested in the new VRF. */
+		if (!vrf_bitmap_check(client->vrf_reg_info, ifp->vrf_id))
+			continue;
+
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s to zclient: %s", buf,
+			    zebra_route_string(client->proto));
+
 		client->ifadd_cnt++;
 		zsend_interface_add(client, ifp);
-		zsend_interface_addresses(client, ifp);
+		zsend_interface_link_params(client, ifp);
 	}
 }
 
@@ -907,10 +960,15 @@ void zebra_interface_parameters_update(struct interface *ifp)
 	struct listnode *node, *nnode;
 	struct zserv *client;
 
-	if (IS_ZEBRA_DEBUG_EVENT)
-		zlog_debug("MESSAGE: ZEBRA_INTERFACE_LINK_PARAMS %s(%u)",
-			   ifp->name, ifp->vrf_id);
+	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client)) {
+		if (!vrf_bitmap_check(client->vrf_reg_info, ifp->vrf_id))
+			continue;
 
-	for (ALL_LIST_ELEMENTS(zrouter.client_list, node, nnode, client))
+		if (IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("ZEBRA_INTERFACE_LINK_PARAMS %s(%u) to zclient: %s",
+				   ifp->name, ifp->vrf_id,
+				   zebra_route_string(client->proto));
+
 		zsend_interface_link_params(client, ifp);
+	}
 }

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1344,22 +1344,53 @@ static void zread_interface_add(ZAPI_HANDLER_ARGS)
 	struct vrf *vrf;
 	struct interface *ifp;
 
-	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
-		FOR_ALL_INTERFACES (vrf, ifp) {
-			/* Skip pseudo interface. */
-			if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE))
-				continue;
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("zclient: %s registers vrf_id: %d vrf_name: %s",
+			   zebra_route_string(client->proto), zvrf_id(zvrf),
+			   zvrf_name(zvrf));
 
-			zsend_interface_add(client, ifp);
-			zsend_interface_link_params(client, ifp);
-			zsend_interface_addresses(client, ifp);
-		}
+	vrf_bitmap_set(client->vrf_reg_info, zvrf_id(zvrf));
+
+	vrf = vrf_lookup_by_id(zvrf_id(zvrf));
+	if (!vrf)
+		return;
+
+	FOR_ALL_INTERFACES (vrf, ifp) {
+		/* Skip pseudo interface. */
+		if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE))
+			continue;
+
+		zsend_interface_add(client, ifp);
+		zsend_interface_link_params(client, ifp);
+		zsend_interface_addresses(client, ifp);
 	}
 }
 
 /* Unregister zebra server interface information. */
 static void zread_interface_delete(ZAPI_HANDLER_ARGS)
 {
+	struct vrf *vrf;
+	struct interface *ifp;
+
+	if (IS_ZEBRA_DEBUG_EVENT)
+		zlog_debug("zclient: %s unregisters vrf_id: %d vrf_name: %s",
+			   zebra_route_string(client->proto), zvrf_id(zvrf),
+			   zvrf_name(zvrf));
+
+	vrf_bitmap_unset(client->vrf_reg_info, zvrf_id(zvrf));
+
+	vrf = vrf_lookup_by_id(zvrf_id(zvrf));
+	if (!vrf)
+		return;
+
+	FOR_ALL_INTERFACES (vrf, ifp) {
+		/* Skip pseudo interface. */
+		if (!CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE))
+			continue;
+
+		zsend_interface_update(ZEBRA_INTERFACE_DOWN, client, ifp);
+		zsend_interface_delete(client, ifp);
+	}
 }
 
 /*

--- a/zebra/zebra_ptm_redistribute.c
+++ b/zebra/zebra_ptm_redistribute.c
@@ -36,6 +36,10 @@ static int zsend_interface_bfd_update(int cmd, struct zserv *client,
 	int blen;
 	struct stream *s;
 
+	/* Check this client need interface information. */
+	if (!vrf_bitmap_check(client->vrf_reg_info, vrf_id))
+		return 0;
+
 	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
 
 	zclient_create_header(s, cmd, vrf_id);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -604,6 +604,7 @@ static void zserv_client_free(struct zserv *client)
 
 		vrf_bitmap_free(client->redist_default[afi]);
 	}
+	vrf_bitmap_free(client->vrf_reg_info);
 	vrf_bitmap_free(client->ridinfo);
 
 	/*
@@ -705,6 +706,7 @@ static struct zserv *zserv_client_create(int sock)
 			client->redist[afi][i] = vrf_bitmap_init();
 		client->redist_default[afi] = vrf_bitmap_init();
 	}
+	client->vrf_reg_info = vrf_bitmap_init();
 	client->ridinfo = vrf_bitmap_init();
 
 	/* Add this client to linked list. */

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -126,6 +126,9 @@ struct zserv {
 	/* Redistribute default route flag. */
 	vrf_bitmap_t redist_default[AFI_MAX];
 
+	/* VRF registration information. */
+	vrf_bitmap_t vrf_reg_info;
+
 	/* Router-id information. */
 	vrf_bitmap_t ridinfo;
 


### PR DESCRIPTION
Protocol daemons register with Zebra for interface events. While some protocol
daemons have VRF-based registration, others register for Default VRF only.

For lack of VRF awareness, when a protocol daemon registers for a specific VRF.
Zebra sends out the Interface events for all interfaces in the system.

In a scaled environment with hundereds of VRFs and thousands of interfaces,
this is cause an unnecessary flood of events to daemons such as BGP, OSPF etc.

So, I have reinstated the VRF awareness for zclients.

Signed-off-by: Kishore Aramalla <kishore.aramalla@vmware.com>