### PR TITLE
Interface fixup

### DIFF
--- a/eigrpd/eigrp_structs.h
+++ b/eigrpd/eigrp_structs.h
@@ -176,6 +176,8 @@ struct eigrp_interface {
 
 	/* To which multicast groups do we currently belong? */
 
+	uint32_t curr_bandwidth;
+	uint32_t curr_mtu;
 
 	uint8_t multicast_memberships;
 

--- a/ospfd/ospf_interface.h
+++ b/ospfd/ospf_interface.h
@@ -117,6 +117,8 @@ struct ospf_if_info {
 	struct route_table *oifs;
 	unsigned int
 		membership_counts[MEMBER_MAX]; /* multicast group refcnts */
+
+	uint32_t curr_mtu;
 };
 
 struct ospf_interface;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -4154,7 +4154,7 @@ DEFUN (show_ip_ospf_interface_traffic,
 
 static void show_ip_ospf_neighbour_header(struct vty *vty)
 {
-	vty_out(vty, "\n%-15s %3s %-15s %9s %-15s %-20s %5s %5s %5s\n",
+	vty_out(vty, "\n%-15s %3s %-15s %9s %-15s %-32s %5s %5s %5s\n",
 		"Neighbor ID", "Pri", "State", "Dead Time", "Address",
 		"Interface", "RXmtL", "RqstL", "DBsmL");
 }
@@ -4260,7 +4260,7 @@ static void show_ip_ospf_neighbor_sub(struct vty *vty,
 							timebuf,
 							sizeof(timebuf)));
 				vty_out(vty, "%-15s ", inet_ntoa(nbr->src));
-				vty_out(vty, "%-20s %5ld %5ld %5d\n",
+				vty_out(vty, "%-32s %5ld %5ld %5d\n",
 					IF_NAME(oi),
 					ospf_ls_retransmit_count(nbr),
 					ospf_ls_request_count(nbr),
@@ -4524,7 +4524,7 @@ static int show_ip_ospf_neighbor_all_common(struct vty *vty, struct ospf *ospf,
 						"-", nbr_nbma->priority, "Down",
 						"-");
 					vty_out(vty,
-						"%-15s %-20s %5d %5d %5d\n",
+						"%-32s %-20s %5d %5d %5d\n",
 						inet_ntoa(nbr_nbma->addr),
 						IF_NAME(oi), 0, 0, 0);
 				}

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1481,6 +1481,13 @@ void pim_if_create_pimreg(struct pim_instance *pim)
 
 		pim_if_new(pim->regiface, false, false, true,
 			false /*vxlan_term*/);
+		/*
+		 * On vrf moves we delete the interface if there
+		 * is nothing going on with it.  We cannot have
+		 * the pimregiface deleted.
+		 */
+		pim->regiface->configured = true;
+
 	}
 }
 
@@ -1581,6 +1588,7 @@ int pim_ifp_create(struct interface *ifp)
 
 int pim_ifp_up(struct interface *ifp)
 {
+	struct pim_interface *pim_ifp;
 	struct pim_instance *pim;
 	uint32_t table_id;
 
@@ -1593,24 +1601,21 @@ int pim_ifp_up(struct interface *ifp)
 	}
 
 	pim = pim_get_pim_instance(ifp->vrf_id);
-	if (if_is_operative(ifp)) {
-		struct pim_interface *pim_ifp;
 
-		pim_ifp = ifp->info;
-		/*
-		 * If we have a pim_ifp already and this is an if_add
-		 * that means that we probably have a vrf move event
-		 * If that is the case, set the proper vrfness.
-		 */
-		if (pim_ifp)
-			pim_ifp->pim = pim;
+	pim_ifp = ifp->info;
+	/*
+	 * If we have a pim_ifp already and this is an if_add
+	 * that means that we probably have a vrf move event
+	 * If that is the case, set the proper vrfness.
+	 */
+	if (pim_ifp)
+		pim_ifp->pim = pim;
 
-		/*
-		  pim_if_addr_add_all() suffices for bringing up both IGMP and
-		  PIM
-		*/
-		pim_if_addr_add_all(ifp);
-	}
+	/*
+	  pim_if_addr_add_all() suffices for bringing up both IGMP and
+	  PIM
+	*/
+	pim_if_addr_add_all(ifp);
 
 	/*
 	 * If we have a pimreg device callback and it's for a specific


### PR DESCRIPTION
See individual commits
1) Cleanup display of some show ip ospf neighbor commands to not handle large interface names
2) Fix a previous commit where an assumption about interface state got violated.