### PR TITLE
bgpd: [7.2] Override peer's TTL only if peer-group is configured with TTL

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -632,6 +632,8 @@ struct bgp_nexthop {
 #define RMAP_OUT 1
 #define RMAP_MAX 2
 
+#define BGP_DEFAULT_TTL 1
+
 #include "filter.h"
 
 /* BGP filter structure. */


### PR DESCRIPTION
When a peer-group is configured for an already configured eBGP neighbor,
ebgp-multihop command is removed for that peer.

This fix remains configured peer's ebgp-multihop value if peer-group does
not have ebgp-multihop configured.

!
router bgp 100
 neighbor A8 peer-group
 neighbor A9 peer-group
 neighbor A9 ebgp-multihop 12
 neighbor 3.3.3.3 remote-as 123
 neighbor 3.3.3.3 ebgp-multihop 255
 neighbor 4.4.4.4 remote-as 123
 !

spine1-debian-9#
spine1-debian-9# conf
spine1-debian-9(config)# router bgp 100
spine1-debian-9(config-router)# neighbor 3.3.3.3 peer-group A8
spine1-debian-9(config-router)# do sh run

!
router bgp 100
 neighbor A8 peer-group
 neighbor A9 peer-group
 neighbor A9 ebgp-multihop 12
 neighbor 3.3.3.3 remote-as 123
 neighbor 3.3.3.3 peer-group A8
 neighbor 3.3.3.3 ebgp-multihop 255
 neighbor 4.4.4.4 remote-as 123
!

spine1-debian-9(config-router)# neighbor 4.4.4.4 peer-group A9
spine1-debian-9(config-router)# do sh run

!
router bgp 100
 neighbor A8 peer-group
 neighbor A9 peer-group
 neighbor A9 ebgp-multihop 12
 neighbor 3.3.3.3 remote-as 123
 neighbor 3.3.3.3 peer-group A8
 neighbor 3.3.3.3 ebgp-multihop 255
 neighbor 4.4.4.4 remote-as 123
 neighbor 4.4.4.4 peer-group A9
!

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>