### PR TITLE
bgpd: [7.1] Override peer's TTL only if peer-group is configured with TTL

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1588,7 +1588,7 @@ struct peer *peer_create(union sockunion *su, const char *conf_if,
 	peer->readtime = peer->resettime = bgp_clock();
 
 	/* Default TTL set. */
-	peer->ttl = (peer->sort == BGP_PEER_IBGP) ? MAXTTL : 1;
+	peer->ttl = (peer->sort == BGP_PEER_IBGP) ? MAXTTL : BGP_DEFAULT_TTL;
 
 	SET_FLAG(peer->flags, PEER_FLAG_CONFIG_NODE);
 
@@ -1675,7 +1675,7 @@ void peer_as_change(struct peer *peer, as_t as, int as_specified)
 	if (peer_sort(peer) == BGP_PEER_IBGP)
 		peer->ttl = MAXTTL;
 	else if (type == BGP_PEER_IBGP)
-		peer->ttl = 1;
+		peer->ttl = BGP_DEFAULT_TTL;
 
 	/* reflector-client reset */
 	if (peer_sort(peer) != BGP_PEER_IBGP) {
@@ -2435,7 +2435,7 @@ struct peer_group *peer_group_get(struct bgp *bgp, const char *name)
 	group->conf->host = XSTRDUP(MTYPE_BGP_PEER_HOST, name);
 	group->conf->group = group;
 	group->conf->as = 0;
-	group->conf->ttl = 1;
+	group->conf->ttl = BGP_DEFAULT_TTL;
 	group->conf->gtsm_hops = 0;
 	group->conf->v_routeadv = BGP_DEFAULT_EBGP_ROUTEADV;
 	SET_FLAG(group->conf->sflags, PEER_STATUS_GROUP);
@@ -2460,8 +2460,9 @@ static void peer_group2peer_config_copy(struct peer_group *group,
 	if (!CHECK_FLAG(peer->flags_override, PEER_FLAG_LOCAL_AS))
 		peer->change_local_as = conf->change_local_as;
 
-	/* TTL */
-	peer->ttl = conf->ttl;
+	/* If peer-group has configured TTL then override it */
+	if (conf->ttl != BGP_DEFAULT_TTL)
+		peer->ttl = conf->ttl;
 
 	/* GTSM hops */
 	peer->gtsm_hops = conf->gtsm_hops;
@@ -4383,7 +4384,7 @@ int peer_ebgp_multihop_unset(struct peer *peer)
 	if (peer_group_active(peer))
 		peer->ttl = peer->group->conf->ttl;
 	else
-		peer->ttl = 1;
+		peer->ttl = BGP_DEFAULT_TTL;
 
 	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
 		if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->status))
@@ -4397,7 +4398,7 @@ int peer_ebgp_multihop_unset(struct peer *peer)
 			if (peer->sort == BGP_PEER_IBGP)
 				continue;
 
-			peer->ttl = 1;
+			peer->ttl = BGP_DEFAULT_TTL;
 
 			if (peer->fd >= 0) {
 				if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->status))

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -627,6 +627,8 @@ struct bgp_nexthop {
 #define RMAP_OUT 1
 #define RMAP_MAX 2
 
+#define BGP_DEFAULT_TTL 1
+
 #include "filter.h"
 
 /* BGP filter structure. */


### PR DESCRIPTION
When a peer-group is configured for an already configured eBGP neighbor,
ebgp-multihop command is removed for that peer.

This fix remains configured peer's ebgp-multihop value if peer-group does
not have ebgp-multihop configured.

!
router bgp 100
 neighbor A8 peer-group
 neighbor A9 peer-group
 neighbor A9 ebgp-multihop 12
 neighbor 3.3.3.3 remote-as 123
 neighbor 3.3.3.3 ebgp-multihop 255
 neighbor 4.4.4.4 remote-as 123
 !

spine1-debian-9#
spine1-debian-9# conf
spine1-debian-9(config)# router bgp 100
spine1-debian-9(config-router)# neighbor 3.3.3.3 peer-group A8
spine1-debian-9(config-router)# do sh run

!
router bgp 100
 neighbor A8 peer-group
 neighbor A9 peer-group
 neighbor A9 ebgp-multihop 12
 neighbor 3.3.3.3 remote-as 123
 neighbor 3.3.3.3 peer-group A8
 neighbor 3.3.3.3 ebgp-multihop 255
 neighbor 4.4.4.4 remote-as 123
!

spine1-debian-9(config-router)# neighbor 4.4.4.4 peer-group A9
spine1-debian-9(config-router)# do sh run

!
router bgp 100
 neighbor A8 peer-group
 neighbor A9 peer-group
 neighbor A9 ebgp-multihop 12
 neighbor 3.3.3.3 remote-as 123
 neighbor 3.3.3.3 peer-group A8
 neighbor 3.3.3.3 ebgp-multihop 255
 neighbor 4.4.4.4 remote-as 123
 neighbor 4.4.4.4 peer-group A9
!

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>