### PR TITLE
nhrp: [7.1] Make sure `no ip nhrp map <something>` works as expected

### DIFF
--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -523,7 +523,7 @@ DEFUN(if_no_nhrp_map, if_no_nhrp_map_cmd,
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
 	afi_t afi = cmd_to_afi(argv[1]);
-	union sockunion proto_addr;
+	union sockunion proto_addr, nbma_addr;
 	struct nhrp_cache *c;
 
 	if (str2sockunion(argv[4]->arg, &proto_addr) < 0
@@ -534,7 +534,8 @@ DEFUN(if_no_nhrp_map, if_no_nhrp_map_cmd,
 	if (!c || !c->map)
 		return nhrp_vty_return(vty, NHRP_ERR_ENTRY_NOT_FOUND);
 
-	nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL);
+	nhrp_cache_update_binding(c, c->cur.type, -1,
+				  nhrp_peer_get(ifp, &nbma_addr), 0, NULL);
 	return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
We passed peer as NULL and nothing happened.

exit2-debian-9# conf
exit2-debian-9(config)# int gre1
exit2-debian-9(config-if)# ip nhrp map 1.1.1.1 local
exit2-debian-9(config-if)# ip nhrp map 2.2.2.2 3.3.3.3
exit2-debian-9(config-if)# do sh run
...
!
interface gre1
 ip nhrp map 1.1.1.1 local
 ip nhrp map 2.2.2.2 3.3.3.3
!
...
exit2-debian-9(config-if)# no ip nhrp map 1.1.1.1
exit2-debian-9(config-if)# do sh run
...
!
interface gre1
 ip nhrp map 2.2.2.2 3.3.3.3
!

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>