### PR TITLE
zebra:Prevent installing of routes into kernel using option(-X)

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -93,6 +93,7 @@ struct option longopts[] = {
 	{"retain", no_argument, NULL, 'r'},
 	{"vrfdefaultname", required_argument, NULL, 'o'},
 	{"graceful_restart", required_argument, NULL, 'K'},
+	{"skip_kernel", no_argument, NULL, 'X'},
 #ifdef HAVE_NETLINK
 	{"vrfwnetns", no_argument, NULL, 'n'},
 	{"nl-bufsize", required_argument, NULL, 's'},
@@ -268,7 +269,7 @@ int main(int argc, char **argv)
 	frr_preinit(&zebra_di, argc, argv);
 
 	frr_opt_add(
-		"baz:e:o:rK:"
+		"baz:e:o:rK:X"
 #ifdef HAVE_NETLINK
 		"s:n"
 #endif
@@ -287,6 +288,7 @@ int main(int argc, char **argv)
 		"  -r, --retain             When program terminates, retain added route by zebra.\n"
 		"  -o, --vrfdefaultname     Set default VRF name.\n"
 		"  -K, --graceful_restart   Graceful restart at the kernel level, timer in seconds for expiration\n"
+		"  -X, --skip_kernel        Do not install routes into kernel if this flag is present.\n"
 #ifdef HAVE_NETLINK
 		"  -n, --vrfwnetns          Use NetNS as VRF backend\n"
 		"  -s, --nl-bufsize         Set netlink receive buffer size\n"
@@ -328,6 +330,9 @@ int main(int argc, char **argv)
 			break;
 		case 'o':
 			vrf_default_name_configured = optarg;
+			break;
+		case 'X':
+			zrouter.skip_kernel_install = true;
 			break;
 		case 'z':
 			zserv_path = optarg;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1535,6 +1535,12 @@ static int netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 		char buf[NL_PKT_BUF_SIZE];
 	} req;
 
+	if (zrouter.skip_kernel_install) {
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("skip installing routes into kernel.");
+		return 0;
+	}
+
 	p = dplane_ctx_get_dest(ctx);
 	src_p = dplane_ctx_get_src(ctx);
 

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -37,6 +37,7 @@ DEFINE_MTYPE_STATIC(ZEBRA, RIB_TABLE_INFO, "RIB table info")
 struct zebra_router zrouter = {
 	.multipath_num = MULTIPATH_NUM,
 	.ipv4_multicast_mode = MCAST_NO_CONFIG,
+	.skip_kernel_install = false,
 };
 
 static inline int

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -138,6 +138,9 @@ struct zebra_router {
 	 */
 	struct hash *nhgs;
 	struct hash *nhgs_id;
+
+	/* skip installing routes into kernel*/
+	bool skip_kernel_install;
 };
 
 #define GRACEFUL_RESTART_TIME 60


### PR DESCRIPTION
Kernel route run time flags needed to enable/disable installing routes into kernel.
Added run time flags to enable/disable install of routes into kernel using -X.

* When -X option is present it would not install the routes
  into kernel.
* When -X option is NOT present it would install the routes
  into kernel.

Signed-off-by: Biswajit Sadhu <sadhub@vmware.com>