### PR TITLE
bgpd: sender side AS path loop detection

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1639,9 +1639,9 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 		return 0;
 	}
 
-#ifdef BGP_SEND_ASPATH_CHECK
 	/* AS path loop check. */
-	if (onlypeer && aspath_loop_check(piattr->aspath, onlypeer->as)) {
+	if (onlypeer && onlypeer->as_path_loop_detection
+	    && aspath_loop_check(piattr->aspath, onlypeer->as)) {
 		if (bgp_debug_update(NULL, p, subgrp->update_group, 0))
 			zlog_debug(
 				"%s [Update:SEND] suppress announcement to peer AS %u "
@@ -1649,7 +1649,6 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 				onlypeer->host, onlypeer->as);
 		return 0;
 	}
-#endif /* BGP_SEND_ASPATH_CHECK */
 
 	/* If we're a CONFED we need to loop check the CONFED ID too */
 	if (CHECK_FLAG(bgp->config, BGP_CONFIG_CONFEDERATION)) {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6381,6 +6381,44 @@ ALIAS_HIDDEN(no_neighbor_addpath_tx_bestpath_per_as,
 	     NO_STR NEIGHBOR_STR NEIGHBOR_ADDR_STR2
 	     "Use addpath to advertise the bestpath per each neighboring AS\n")
 
+DEFPY(
+	neighbor_aspath_loop_detection, neighbor_aspath_loop_detection_cmd,
+	"neighbor <A.B.C.D|X:X::X:X|WORD>$neighbor sender-as-path-loop-detection",
+	NEIGHBOR_STR
+	NEIGHBOR_ADDR_STR2
+	"Detect AS loops before sending to neighbor\n")
+{
+	struct peer *peer;
+
+	peer = peer_and_group_lookup_vty(vty, neighbor);
+	if (!peer)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	peer->as_path_loop_detection = true;
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(
+	no_neighbor_aspath_loop_detection,
+	no_neighbor_aspath_loop_detection_cmd,
+	"no neighbor <A.B.C.D|X:X::X:X|WORD>$neighbor sender-as-path-loop-detection",
+	NO_STR
+	NEIGHBOR_STR
+	NEIGHBOR_ADDR_STR2
+	"Detect AS loops before sending to neighbor\n")
+{
+	struct peer *peer;
+
+	peer = peer_and_group_lookup_vty(vty, neighbor);
+	if (!peer)
+		return CMD_WARNING_CONFIG_FAILED;
+
+	peer->as_path_loop_detection = false;
+
+	return CMD_SUCCESS;
+}
+
 static int set_ecom_list(struct vty *vty, int argc, struct cmd_token **argv,
 			 struct ecommunity **list)
 {
@@ -13677,6 +13715,10 @@ void bgp_vty_init(void)
 			&neighbor_addpath_tx_bestpath_per_as_cmd);
 	install_element(BGP_VPNV6_NODE,
 			&no_neighbor_addpath_tx_bestpath_per_as_cmd);
+
+	/* "neighbor sender-as-path-loop-detection" commands. */
+	install_element(BGP_NODE, &neighbor_aspath_loop_detection_cmd);
+	install_element(BGP_NODE, &no_neighbor_aspath_loop_detection_cmd);
 
 	/* "neighbor passive" commands. */
 	install_element(BGP_NODE, &neighbor_passive_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7166,6 +7166,11 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 	/* strict-capability-match */
 	if (peergroup_flag_check(peer, PEER_FLAG_STRICT_CAP_MATCH))
 		vty_out(vty, " neighbor %s strict-capability-match\n", addr);
+
+	/* Sender side AS path loop detection. */
+	if (peer->as_path_loop_detection)
+		vty_out(vty, " neighbor %s sender-as-path-loop-detection\n",
+			addr);
 }
 
 /* BGP peer configuration display function. */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1225,6 +1225,9 @@ struct peer {
 	char *hostname;
 	char *domainname;
 
+	/* Sender side AS path loop detection. */
+	bool as_path_loop_detection;
+
 	QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(peer)
@@ -1446,9 +1449,6 @@ struct bgp_nlri {
 /* Default configuration settings for bgpd.  */
 #define BGP_VTY_PORT                          2605
 #define BGP_DEFAULT_CONFIG             "bgpd.conf"
-
-/* Check AS path loop when we send NLRI.  */
-/* #define BGP_SEND_ASPATH_CHECK */
 
 /* BGP Dynamic Neighbors feature */
 #define BGP_DYNAMIC_NEIGHBORS_LIMIT_DEFAULT    100

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1137,6 +1137,14 @@ Peer Filtering
    on reflected routes. This option allows the modifications to be reflected as
    well. Once enabled, it affects all reflected routes.
 
+.. index:: [no] neighbor PEER sender-as-path-loop-detection
+.. clicmd:: [no] neighbor PEER sender-as-path-loop-detection
+
+   Enable the detection of sender side AS path loops and filter the
+   bad routes before they are sent.
+
+   This setting is disabled by default.
+
 .. _bgp-peer-group:
 
 Peer Groups


### PR DESCRIPTION
## Summary

Lets allow users to use the implemented sender side AS path by adding a run-time knob to enable it.

Fixes #5238 .