### PR TITLE
bgpd: Implementing a hash table for connected address - ipv4/ipv6

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -5395,8 +5395,9 @@ int bgp_filter_evpn_routes_upon_martian_nh_change(struct bgp *bgp)
 				if (!(pi->type == ZEBRA_ROUTE_BGP
 				      && pi->sub_type == BGP_ROUTE_NORMAL))
 					continue;
-
-				if (bgp_nexthop_self(bgp, pi->attr->nexthop)) {
+				if (bgp_nexthop_self(bgp, afi,
+						pi->type, pi->sub_type,
+						pi->attr, rn)) {
 
 					char attr_str[BUFSIZ] = {0};
 					char pbuf[PREFIX_STRLEN];

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -180,7 +180,7 @@ void bgp_tip_del(struct bgp *bgp, struct in_addr *tip)
 
 /* BGP own address structure */
 struct bgp_addr {
-	struct in_addr addr;
+	struct prefix *p;
 	struct list *ifp_name_list;
 };
 
@@ -190,9 +190,19 @@ static void show_address_entry(struct hash_bucket *bucket, void *args)
 	struct bgp_addr *addr = (struct bgp_addr *)bucket->data;
 	char *name;
 	struct listnode *node;
+	char str[INET6_ADDRSTRLEN] = {0};
 
-	vty_out(vty, "addr: %s, count: %d : ", inet_ntoa(addr->addr),
-		addr->ifp_name_list->count);
+	if (addr->p->family == AF_INET) {
+		vty_out(vty, "addr: %s, count: %d : ", inet_ntop(AF_INET,
+				&(addr->p->u.prefix4),
+				str, INET_ADDRSTRLEN),
+				addr->ifp_name_list->count);
+	} else if (addr->p->family == AF_INET6) {
+		vty_out(vty, "addr: %s, count: %d : ", inet_ntop(AF_INET6,
+				&(addr->p->u.prefix6),
+				str, INET6_ADDRSTRLEN),
+				addr->ifp_name_list->count);
+	}
 
 	for (ALL_LIST_ELEMENTS_RO(addr->ifp_name_list, node, name)) {
 		vty_out(vty, " %s,", name);
@@ -217,11 +227,12 @@ static void bgp_address_hash_string_del(void *val)
 
 static void *bgp_address_hash_alloc(void *p)
 {
-	const struct in_addr *val = (const struct in_addr *)p;
-	struct bgp_addr *addr;
+	struct bgp_addr *copy_addr = p;
+	struct bgp_addr *addr = NULL;
 
 	addr = XMALLOC(MTYPE_BGP_ADDR, sizeof(struct bgp_addr));
-	addr->addr.s_addr = val->s_addr;
+	addr->p = prefix_new();
+	prefix_copy(addr->p, copy_addr->p);
 
 	addr->ifp_name_list = list_new();
 	addr->ifp_name_list->del = bgp_address_hash_string_del;
@@ -233,6 +244,7 @@ static void bgp_address_hash_free(void *data)
 {
 	struct bgp_addr *addr = data;
 
+	prefix_free(&addr->p);
 	list_delete(&addr->ifp_name_list);
 	XFREE(MTYPE_BGP_ADDR, addr);
 }
@@ -241,7 +253,7 @@ static unsigned int bgp_address_hash_key_make(const void *p)
 {
 	const struct bgp_addr *addr = p;
 
-	return jhash_1word(addr->addr.s_addr, 0);
+	return prefix_hash_key((const void *)(addr->p));
 }
 
 static bool bgp_address_hash_cmp(const void *p1, const void *p2)
@@ -249,14 +261,14 @@ static bool bgp_address_hash_cmp(const void *p1, const void *p2)
 	const struct bgp_addr *addr1 = p1;
 	const struct bgp_addr *addr2 = p2;
 
-	return addr1->addr.s_addr == addr2->addr.s_addr;
+	return prefix_same(addr1->p, addr2->p);
 }
 
 void bgp_address_init(struct bgp *bgp)
 {
 	bgp->address_hash =
 		hash_create(bgp_address_hash_key_make, bgp_address_hash_cmp,
-			    "BGP Address Hash");
+				"BGP Connected Address Hash");
 }
 
 void bgp_address_destroy(struct bgp *bgp)
@@ -276,7 +288,12 @@ static void bgp_address_add(struct bgp *bgp, struct connected *ifc,
 	struct listnode *node;
 	char *name;
 
-	tmp.addr = p->u.prefix4;
+	tmp.p = p;
+
+	if (tmp.p->family == AF_INET)
+		tmp.p->prefixlen = IPV4_MAX_BITLEN;
+	else if (tmp.p->family == AF_INET6)
+		tmp.p->prefixlen = IPV6_MAX_BITLEN;
 
 	addr = hash_get(bgp->address_hash, &tmp, bgp_address_hash_alloc);
 
@@ -298,7 +315,12 @@ static void bgp_address_del(struct bgp *bgp, struct connected *ifc,
 	struct listnode *node;
 	char *name;
 
-	tmp.addr = p->u.prefix4;
+	tmp.p = p;
+
+	if (tmp.p->family == AF_INET)
+		tmp.p->prefixlen = IPV4_MAX_BITLEN;
+	else if (tmp.p->family == AF_INET6)
+		tmp.p->prefixlen = IPV6_MAX_BITLEN;
 
 	addr = hash_lookup(bgp->address_hash, &tmp);
 	/* may have been deleted earlier by bgp_interface_down() */
@@ -379,6 +401,8 @@ void bgp_connected_add(struct bgp *bgp, struct connected *ifc)
 		if (IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6))
 			return;
 
+		bgp_address_add(bgp, ifc, addr);
+
 		rn = bgp_node_get(bgp->connected_table[AFI_IP6],
 				  (struct prefix *)&p);
 
@@ -419,6 +443,8 @@ void bgp_connected_delete(struct bgp *bgp, struct connected *ifc)
 		if (IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6))
 			return;
 
+		bgp_address_del(bgp, ifc, addr);
+
 		rn = bgp_node_lookup(bgp->connected_table[AFI_IP6],
 				     (struct prefix *)&p);
 	}
@@ -453,21 +479,85 @@ static void bgp_connected_cleanup(struct route_table *table,
 	}
 }
 
-int bgp_nexthop_self(struct bgp *bgp, struct in_addr nh_addr)
+int bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type, uint8_t sub_type,
+		struct attr *attr, struct bgp_node *rn)
 {
-	struct bgp_addr tmp, *addr;
-	struct tip_addr tmp_tip, *tip;
+	struct prefix p = {0};
+	afi_t new_afi = afi;
+	struct bgp_addr tmp_addr = {0}, *addr = NULL;
+	struct tip_addr tmp_tip, *tip = NULL;
 
-	tmp.addr = nh_addr;
+	bool is_bgp_static_route = ((type == ZEBRA_ROUTE_BGP)
+			&& (sub_type == BGP_ROUTE_STATIC))
+			? true
+			: false;
 
-	addr = hash_lookup(bgp->address_hash, &tmp);
+	if (!is_bgp_static_route)
+		new_afi = BGP_ATTR_NEXTHOP_AFI_IP6(attr) ? AFI_IP6 : AFI_IP;
+
+	switch (new_afi) {
+	case AFI_IP:
+		p.family = AF_INET;
+		if (is_bgp_static_route) {
+			p.u.prefix4 = rn->p.u.prefix4;
+			p.prefixlen = rn->p.prefixlen;
+		} else {
+			/* Here we need to find out which nexthop to be used*/
+			if (attr->flag &
+					ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP)) {
+
+				p.u.prefix4 = attr->nexthop;
+				p.prefixlen = IPV4_MAX_BITLEN;
+
+			} else if ((attr->mp_nexthop_len) &&
+					((attr->mp_nexthop_len ==
+					  BGP_ATTR_NHLEN_IPV4) ||
+					 (attr->mp_nexthop_len ==
+					  BGP_ATTR_NHLEN_VPNV4))) {
+				p.u.prefix4 =
+					attr->mp_nexthop_global_in;
+				p.prefixlen = IPV4_MAX_BITLEN;
+			} else
+				return 0;
+		}
+		break;
+	case AFI_IP6:
+		p.family = AF_INET6;
+
+		if (is_bgp_static_route) {
+			p.u.prefix6 = rn->p.u.prefix6;
+			p.prefixlen = rn->p.prefixlen;
+		} else {
+			p.u.prefix6 = attr->mp_nexthop_global;
+			p.prefixlen = IPV6_MAX_BITLEN;
+		}
+		break;
+	default:
+		break;
+	}
+
+	tmp_addr.p = &p;
+	addr = hash_lookup(bgp->address_hash, &tmp_addr);
 	if (addr)
 		return 1;
 
-	tmp_tip.addr = nh_addr;
-	tip = hash_lookup(bgp->tip_hash, &tmp_tip);
-	if (tip)
-		return 1;
+	if (new_afi == AFI_IP) {
+		memset(&tmp_tip, 0, sizeof(struct tip_addr));
+		tmp_tip.addr = attr->nexthop;
+
+		if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_NEXT_HOP)) {
+			tmp_tip.addr = attr->nexthop;
+		} else if ((attr->mp_nexthop_len) &&
+				((attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV4)
+				 || (attr->mp_nexthop_len ==
+					 BGP_ATTR_NHLEN_VPNV4))) {
+			tmp_tip.addr = attr->mp_nexthop_global_in;
+		}
+
+		tip = hash_lookup(bgp->tip_hash, &tmp_tip);
+		if (tip)
+			return 1;
+	}
 
 	return 0;
 }

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -88,7 +88,9 @@ extern int bgp_subgrp_multiaccess_check_v6(struct in6_addr nexthop,
 extern int bgp_multiaccess_check_v4(struct in_addr nexthop, struct peer *peer);
 extern int bgp_multiaccess_check_v6(struct in6_addr nexthop, struct peer *peer);
 extern int bgp_config_write_scan_time(struct vty *);
-extern int bgp_nexthop_self(struct bgp *, struct in_addr);
+extern int bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
+				uint8_t sub_type, struct attr *attr,
+				struct bgp_node *rn);
 extern struct bgp_nexthop_cache *bnc_new(void);
 extern void bnc_free(struct bgp_nexthop_cache *bnc);
 extern void bnc_nexthop_free(struct bgp_nexthop_cache *bnc);


### PR DESCRIPTION
*  IPv6 routes received via a ibgp session with one of its own interface as
   nexthop are getting installed in the BGP table.
*  A common table to be implemented should take cares of both
   ipv4 and ipv6 connected addresses.

Change Summary:

1 A common HASH table should is implemented which stores both
  ipv4 and ipv6 connected addresses in one table.

2 Ipv6/ipv4 routes received via a bgp session are not validating
  the next hop (i.e. whether the next hop is one of its own interface).
  So those routes were getting installed in the bgp table which is not
  correct.

3 In this HASH table  (which is missing for  ipv6 connected routes),
  we need to add any ipv4/ipv6 address as they gets configured and
  delete them from the HASH table as the ipv4/ipv6 addresses get
  unconfigured.
4 We would use the above hash table to verify if any route learned
  via BGP has nexthop which is one of its its connected ipv4/ipv6
  interface.
5 These code changes involves changing some common API called for EVPN
  and MPLS Tunnel end point ip.
6 The show functions has been modified to dump both ip4/ipv6 entries
  in the has table

Signed-off-by: Biswajit Sadhu sadhub@vmware.com