### PR TITLE
Convert some XXX_free lib functions to a double pointer

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -209,7 +209,7 @@ static void bgp_debug_list_free(struct list *list)
 			listnode_delete(list, filter);
 
 			if (filter->p)
-				prefix_free(filter->p);
+				prefix_free(&filter->p);
 
 			if (filter->host)
 				XFREE(MTYPE_BGP_DEBUG_STR, filter->host);
@@ -323,7 +323,7 @@ static int bgp_debug_list_remove_entry(struct list *list, const char *host,
 		} else if (p && filter->p->prefixlen == p->prefixlen
 			   && prefix_match(filter->p, p)) {
 			listnode_delete(list, filter);
-			prefix_free(filter->p);
+			prefix_free(&filter->p);
 			XFREE(MTYPE_BGP_DEBUG_FILTER, filter);
 			return 1;
 		}
@@ -1412,7 +1412,7 @@ DEFPY (debug_bgp_update_prefix_afi_safi,
 
 	ret = bgp_debug_parse_evpn_prefix(vty, argv, argc, &argv_p);
 	if (ret != CMD_SUCCESS) {
-		prefix_free(argv_p);
+		prefix_free(&argv_p);
 		return ret;
 	}
 
@@ -1425,7 +1425,7 @@ DEFPY (debug_bgp_update_prefix_afi_safi,
 		vty_out(vty,
 			"BGP updates debugging is already enabled for %s\n",
 			buf);
-		prefix_free(argv_p);
+		prefix_free(&argv_p);
 		return CMD_SUCCESS;
 	}
 
@@ -1438,7 +1438,7 @@ DEFPY (debug_bgp_update_prefix_afi_safi,
 		vty_out(vty, "BGP updates debugging is on for %s\n", buf);
 	}
 
-	prefix_free(argv_p);
+	prefix_free(&argv_p);
 
 	return CMD_SUCCESS;
 }
@@ -1477,7 +1477,7 @@ DEFPY (no_debug_bgp_update_prefix_afi_safi,
 
 	ret = bgp_debug_parse_evpn_prefix(vty, argv, argc, &argv_p);
 	if (ret != CMD_SUCCESS) {
-		prefix_free(argv_p);
+		prefix_free(&argv_p);
 		return ret;
 	}
 
@@ -1505,7 +1505,7 @@ DEFPY (no_debug_bgp_update_prefix_afi_safi,
 		vty_out(vty, "BGP updates debugging was not enabled for %s\n",
 			buf);
 
-	prefix_free(argv_p);
+	prefix_free(&argv_p);
 
 	return ret;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10548,7 +10548,7 @@ static int bgp_show_prefix_longer(struct vty *vty, struct bgp *bgp,
 	}
 
 	ret = bgp_show(vty, bgp, afi, safi, type, p, 0);
-	prefix_free(p);
+	prefix_free(&p);
 	return ret;
 }
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -357,7 +357,7 @@ static int bgp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 		bgp_connected_delete(bgp, ifc);
 	}
 
-	connected_free(ifc);
+	connected_free(&ifc);
 
 	return 0;
 }

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2586,7 +2586,7 @@ int peer_group_delete(struct peer_group *group)
 	for (afi = AFI_IP; afi < AFI_MAX; afi++) {
 		for (ALL_LIST_ELEMENTS(group->listen_range[afi], node, nnode,
 				       prefix)) {
-			prefix_free(prefix);
+			prefix_free(&prefix);
 		}
 		list_delete(&group->listen_range[afi]);
 	}

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -1512,7 +1512,7 @@ static int rfapiNhlAddNodeRoutes(
 	}
 
 	seen_nexthops =
-		skiplist_new(0, vnc_prefix_cmp, (void (*)(void *))prefix_free);
+		skiplist_new(0, vnc_prefix_cmp, prefix_free_lists);
 
 	for (bpi = rn->info; bpi; bpi = bpi->next) {
 
@@ -4359,7 +4359,7 @@ rfapiImportTableRefAdd(struct bgp *bgp, struct ecommunity *rt_import_list,
 		it->rt_import_list = ecommunity_dup(rt_import_list);
 		it->rfg = rfg;
 		it->monitor_exterior_orphans =
-			skiplist_new(0, NULL, (void (*)(void *))prefix_free);
+			skiplist_new(0, NULL, prefix_free_lists);
 
 		/*
 		 * fill import route tables from RIBs

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -1807,8 +1807,7 @@ static void vnc_import_bgp_exterior_add_route_it(
 					RFAPI_MONITOR_EXTERIOR(rn)->source =
 						skiplist_new(
 							0, NULL,
-							(void (*)(void *))
-								prefix_free);
+							prefix_free_lists);
 					agg_lock_node(rn); /* for skiplist */
 				}
 				agg_lock_node(rn); /* for skiplist entry */
@@ -2194,8 +2193,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 					     ->source) {
 					RFAPI_MONITOR_EXTERIOR(rn_interior)
 						->source = skiplist_new(
-						0, NULL,
-						(void (*)(void *))prefix_free);
+						0, NULL, prefix_free_lists);
 					agg_lock_node(rn_interior);
 				}
 				skiplist_insert(
@@ -2337,8 +2335,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 			if (!RFAPI_MONITOR_EXTERIOR(rn_interior)->source) {
 				RFAPI_MONITOR_EXTERIOR(rn_interior)->source =
 					skiplist_new(
-						0, NULL,
-						(void (*)(void *))prefix_free);
+						0, NULL, prefix_free_lists);
 				agg_lock_node(rn_interior); /* sl */
 			}
 			skiplist_insert(
@@ -2527,8 +2524,7 @@ void vnc_import_bgp_exterior_del_route_interior(
 			if (!RFAPI_MONITOR_EXTERIOR(par)->source) {
 				RFAPI_MONITOR_EXTERIOR(par)->source =
 					skiplist_new(
-						0, NULL,
-						(void (*)(void *))prefix_free);
+						0, NULL, prefix_free_lists);
 				agg_lock_node(par); /* sl */
 			}
 			skiplist_insert(RFAPI_MONITOR_EXTERIOR(par)->source,

--- a/eigrpd/eigrp_network.c
+++ b/eigrpd/eigrp_network.c
@@ -327,8 +327,7 @@ int eigrp_network_unset(struct eigrp *eigrp, struct prefix *p)
 	if (!IPV4_ADDR_SAME(&pref->u.prefix4, &p->u.prefix4))
 		return 0;
 
-	prefix_ipv4_free(rn->info);
-	rn->info = NULL;
+	prefix_ipv4_free((struct prefix_ipv4 **)&rn->info);
 	route_unlock_node(rn); /* initial reference */
 
 	/* Find interfaces that not configured already.  */

--- a/eigrpd/eigrp_topology.c
+++ b/eigrpd/eigrp_topology.c
@@ -197,7 +197,7 @@ void eigrp_prefix_entry_delete(struct eigrp *eigrp, struct route_table *table,
 	list_delete(&pe->entries);
 	list_delete(&pe->rij);
 	eigrp_zebra_route_delete(eigrp, pe->destination);
-	prefix_free(pe->destination);
+	prefix_free(&pe->destination);
 
 	rn->info = NULL;
 	route_unlock_node(rn); // Lookup above

--- a/eigrpd/eigrp_zebra.c
+++ b/eigrpd/eigrp_zebra.c
@@ -189,7 +189,7 @@ static int eigrp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 	if (prefix_cmp(&ei->address, c->address) == 0)
 		eigrp_if_free(ei, INTERFACE_DOWN_BY_ZEBRA);
 
-	connected_free(c);
+	connected_free(&c);
 
 	return 0;
 }

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -338,7 +338,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 
 		if (ip) {
 			listnode_delete(circuit->ip_addrs, ip);
-			prefix_ipv4_free(ip);
+			prefix_ipv4_free(&ip);
 			if (circuit->area)
 				lsp_regenerate_schedule(circuit->area,
 							circuit->is_type, 0);
@@ -358,7 +358,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 			zlog_warn("End of addresses");
 		}
 
-		prefix_ipv4_free(ipv4);
+		prefix_ipv4_free(&ipv4);
 	}
 	if (connected->address->family == AF_INET6) {
 		ipv6 = prefix_ipv6_new();
@@ -374,7 +374,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 			}
 			if (ip6) {
 				listnode_delete(circuit->ipv6_link, ip6);
-				prefix_ipv6_free(ip6);
+				prefix_ipv6_free(&ip6);
 				found = 1;
 			}
 		} else {
@@ -386,7 +386,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 			}
 			if (ip6) {
 				listnode_delete(circuit->ipv6_non_link, ip6);
-				prefix_ipv6_free(ip6);
+				prefix_ipv6_free(&ip6);
 				found = 1;
 			}
 		}
@@ -417,7 +417,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 			lsp_regenerate_schedule(circuit->area, circuit->is_type,
 						0);
 
-		prefix_ipv6_free(ipv6);
+		prefix_ipv6_free(&ipv6);
 	}
 	return;
 }

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -128,7 +128,7 @@ static int isis_zebra_if_address_del(ZAPI_CALLBACK_ARGS)
 
 	if (if_is_operative(ifp))
 		isis_circuit_del_addr(circuit_scan_by_ifp(ifp), c);
-	connected_free(c);
+	connected_free(&c);
 
 	return 0;
 }

--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -368,7 +368,7 @@ ldp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 
 	ifp = ifc->ifp;
 	ifc2kaddr(ifp, ifc, &ka);
-	connected_free(ifc);
+	connected_free(&ifc);
 
 	/* Filter invalid addresses.  */
 	if (bad_addr(ka.af, &ka.addr))

--- a/lib/if.c
+++ b/lib/if.c
@@ -869,10 +869,10 @@ struct nbr_connected *nbr_connected_new(void)
 void connected_free(struct connected *connected)
 {
 	if (connected->address)
-		prefix_free(connected->address);
+		prefix_free(&connected->address);
 
 	if (connected->destination)
-		prefix_free(connected->destination);
+		prefix_free(&connected->destination);
 
 	XFREE(MTYPE_CONNECTED_LABEL, connected->label);
 
@@ -883,7 +883,7 @@ void connected_free(struct connected *connected)
 void nbr_connected_free(struct nbr_connected *connected)
 {
 	if (connected->address)
-		prefix_free(connected->address);
+		prefix_free(&connected->address);
 
 	XFREE(MTYPE_NBR_CONNECTED, connected);
 }

--- a/lib/if.h
+++ b/lib/if.h
@@ -513,7 +513,7 @@ extern void if_delete_retain(struct interface *);
 
 /* Delete and free the interface structure: calls if_delete_retain and then
    deletes it from the interface list and frees the structure. */
-extern void if_delete(struct interface *);
+extern void if_delete(struct interface **ifp);
 
 extern int if_is_up(const struct interface *ifp);
 extern int if_is_running(const struct interface *ifp);

--- a/lib/if.h
+++ b/lib/if.h
@@ -543,7 +543,7 @@ extern ifindex_t ifname2ifindex(const char *ifname, vrf_id_t vrf_id);
 
 /* Connected address functions. */
 extern struct connected *connected_new(void);
-extern void connected_free(struct connected *);
+extern void connected_free(struct connected **connected);
 extern void connected_add(struct interface *, struct connected *);
 extern struct connected *
 connected_add_by_prefix(struct interface *, struct prefix *, struct prefix *);

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -905,9 +905,9 @@ struct prefix_ipv4 *prefix_ipv4_new(void)
 }
 
 /* Free prefix_ipv4 structure. */
-void prefix_ipv4_free(struct prefix_ipv4 *p)
+void prefix_ipv4_free(struct prefix_ipv4 **p)
 {
-	prefix_free((struct prefix *)p);
+	prefix_free((struct prefix **)p);
 }
 
 /* If given string is valid return 1 else return 0 */
@@ -1077,9 +1077,9 @@ struct prefix_ipv6 *prefix_ipv6_new(void)
 }
 
 /* Free prefix for IPv6. */
-void prefix_ipv6_free(struct prefix_ipv6 *p)
+void prefix_ipv6_free(struct prefix_ipv6 **p)
 {
-	prefix_free((struct prefix *)p);
+	prefix_free((struct prefix **)p);
 }
 
 /* If given string is valid return 1 else return 0 */
@@ -1484,10 +1484,18 @@ struct prefix *prefix_new(void)
 	return p;
 }
 
-/* Free prefix structure. */
-void prefix_free(struct prefix *p)
+void prefix_free_lists(void *arg)
 {
-	XFREE(MTYPE_PREFIX, p);
+	struct prefix *p = arg;
+
+	prefix_free(&p);
+}
+
+/* Free prefix structure. */
+void prefix_free(struct prefix **p)
+{
+	XFREE(MTYPE_PREFIX, *p);
+	*p = NULL;
 }
 
 /* Utility function to convert ipv4 prefixes to Classful prefixes */

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -396,7 +396,11 @@ extern unsigned int prefix6_bit(const struct in6_addr *prefix,
 				const uint16_t prefixlen);
 
 extern struct prefix *prefix_new(void);
-extern void prefix_free(struct prefix *);
+extern void prefix_free(struct prefix **p);
+/*
+ * Function to handle prefix_free being used as a del function.
+ */
+extern void prefix_free_lists(void *arg);
 extern const char *prefix_family_str(const struct prefix *);
 extern int prefix_blen(const struct prefix *);
 extern int str2prefix(const char *, struct prefix *);
@@ -435,7 +439,7 @@ extern void prefix2sockunion(const struct prefix *, union sockunion *);
 extern int str2prefix_eth(const char *, struct prefix_eth *);
 
 extern struct prefix_ipv4 *prefix_ipv4_new(void);
-extern void prefix_ipv4_free(struct prefix_ipv4 *);
+extern void prefix_ipv4_free(struct prefix_ipv4 **p);
 extern int str2prefix_ipv4(const char *, struct prefix_ipv4 *);
 extern void apply_mask_ipv4(struct prefix_ipv4 *);
 
@@ -460,7 +464,7 @@ extern in_addr_t ipv4_broadcast_addr(in_addr_t hostaddr, int masklen);
 extern int netmask_str2prefix_str(const char *, const char *, char *);
 
 extern struct prefix_ipv6 *prefix_ipv6_new(void);
-extern void prefix_ipv6_free(struct prefix_ipv6 *);
+extern void prefix_ipv6_free(struct prefix_ipv6 **p);
 extern int str2prefix_ipv6(const char *, struct prefix_ipv6 *);
 extern void apply_mask_ipv6(struct prefix_ipv6 *);
 

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -364,7 +364,7 @@ int nhrp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 
 	nhrp_interface_update_address(
 		ifc->ifp, family2afi(PREFIX_FAMILY(ifc->address)), 0);
-	connected_free(ifc);
+	connected_free(&ifc);
 
 	return 0;
 }

--- a/ospf6d/ospf6_zebra.c
+++ b/ospf6d/ospf6_zebra.c
@@ -143,7 +143,7 @@ static int ospf6_zebra_if_address_update_delete(ZAPI_CALLBACK_ARGS)
 		ospf6_interface_state_update(c->ifp);
 	}
 
-	connected_free(c);
+	connected_free(&c);
 
 	return 0;
 }

--- a/ospfd/ospf_interface.c
+++ b/ospfd/ospf_interface.c
@@ -902,11 +902,10 @@ struct ospf_interface *ospf_vl_new(struct ospf *ospf,
 
 static void ospf_vl_if_delete(struct ospf_vl_data *vl_data)
 {
-	struct interface *ifp = vl_data->vl_oi->ifp;
 	vl_data->vl_oi->address->u.prefix4.s_addr = 0;
 	vl_data->vl_oi->address->prefixlen = 0;
 	ospf_if_free(vl_data->vl_oi);
-	if_delete(ifp);
+	if_delete(&vl_data->vl_oi->ifp);
 	vlink_count--;
 }
 

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -150,7 +150,7 @@ static int ospf_interface_address_delete(ZAPI_CALLBACK_ARGS)
 
 	rn = route_node_lookup(IF_OIFS(ifp), &p);
 	if (!rn) {
-		connected_free(c);
+		connected_free(&c);
 		return 0;
 	}
 
@@ -163,7 +163,7 @@ static int ospf_interface_address_delete(ZAPI_CALLBACK_ARGS)
 
 	ospf_if_interface(c->ifp);
 
-	connected_free(c);
+	connected_free(&c);
 
 	return 0;
 }

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -133,10 +133,8 @@ DEFPY(pbr_map_match_src, pbr_map_match_src_cmd,
 		if (!pbrms->src)
 			pbrms->src = prefix_new();
 		prefix_copy(pbrms->src, prefix);
-	} else {
-		prefix_free(pbrms->src);
-		pbrms->src = 0;
-	}
+	} else
+		prefix_free(&pbrms->src);
 
 	pbr_map_check(pbrms);
 
@@ -162,10 +160,8 @@ DEFPY(pbr_map_match_dst, pbr_map_match_dst_cmd,
 		if (!pbrms->dst)
 			pbrms->dst = prefix_new();
 		prefix_copy(pbrms->dst, prefix);
-	} else {
-		prefix_free(pbrms->dst);
-		pbrms->dst = NULL;
-	}
+	} else
+		prefix_free(&pbrms->dst);
 
 	pbr_map_check(pbrms);
 

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -109,7 +109,7 @@ static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 	       "%s: %s deleted %s", __PRETTY_FUNCTION__, c->ifp->name,
 	       prefix2str(c->address, buf, sizeof(buf)));
 
-	connected_free(c);
+	connected_free(&c);
 	return 0;
 }
 

--- a/pimd/pim_neighbor.c
+++ b/pimd/pim_neighbor.c
@@ -767,7 +767,7 @@ static void delete_from_neigh_addr(struct interface *ifp,
 						other_neigh_str, ifp->name);
 
 					listnode_delete(neigh->prefix_list, p);
-					prefix_free(p);
+					prefix_free(&p);
 				}
 			}
 

--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -757,8 +757,7 @@ int pim_tlv_parse_addr_list(const char *ifname, struct in_addr src_addr,
 		 */
 		if (!*hello_option_addr_list) {
 			*hello_option_addr_list = list_new();
-			(*hello_option_addr_list)->del =
-				(void (*)(void *))prefix_free;
+			(*hello_option_addr_list)->del = prefix_free_lists;
 		}
 
 		/*

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -233,7 +233,7 @@ static int pim_zebra_if_address_del(ZAPI_CALLBACK_ARGS)
 		pim_i_am_rp_re_evaluate(pim);
 	}
 
-	connected_free(c);
+	connected_free(&c);
 	return 0;
 }
 

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -648,7 +648,7 @@ int rip_interface_address_delete(ZAPI_CALLBACK_ARGS)
 			rip_apply_address_del(ifc);
 		}
 
-		connected_free(ifc);
+		connected_free(&ifc);
 	}
 
 	return 0;

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -430,7 +430,7 @@ int ripng_interface_address_delete(ZAPI_CALLBACK_ARGS)
 			/* Check wether this prefix needs to be removed. */
 			ripng_apply_address_del(ifc);
 		}
-		connected_free(ifc);
+		connected_free(&ifc);
 	}
 
 	return 0;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -73,7 +73,7 @@ static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 	if (!c)
 		return 0;
 
-	connected_free(c);
+	connected_free(&c);
 	return 0;
 }
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -79,7 +79,7 @@ static int interface_address_delete(ZAPI_CALLBACK_ARGS)
 	if (!c)
 		return 0;
 
-	connected_free(c);
+	connected_free(&c);
 	return 0;
 }
 

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -260,7 +260,7 @@ static void static_nht_hash_free(void *data)
 {
 	struct static_nht_data *nhtd = data;
 
-	prefix_free(nhtd->nh);
+	prefix_free(&nhtd->nh);
 	XFREE(MTYPE_TMP, nhtd);
 }
 

--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -65,7 +65,7 @@ static void connected_withdraw(struct connected *ifc)
 
 	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_CONFIGURED)) {
 		listnode_delete(ifc->ifp->connected, ifc);
-		connected_free(ifc);
+		connected_free(&ifc);
 	}
 }
 
@@ -177,7 +177,7 @@ static void connected_update(struct interface *ifp, struct connected *ifc)
 		 */
 		if (connected_same(current, ifc)) {
 			/* nothing to do */
-			connected_free(ifc);
+			connected_free(&ifc);
 			return;
 		}
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -829,7 +829,7 @@ void if_delete_update(struct interface *ifp)
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug("interface %s is being deleted from the system",
 				   ifp->name);
-		if_delete(ifp);
+		if_delete(&ifp);
 	}
 }
 

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -738,7 +738,7 @@ static void if_delete_connected(struct interface *ifp)
 							ZEBRA_IFC_CONFIGURED)) {
 						listnode_delete(ifp->connected,
 								ifc);
-						connected_free(ifc);
+						connected_free(&ifc);
 					} else
 						last = node;
 				}
@@ -759,7 +759,7 @@ static void if_delete_connected(struct interface *ifp)
 				last = node;
 			else {
 				listnode_delete(ifp->connected, ifc);
-				connected_free(ifc);
+				connected_free(&ifc);
 			}
 		} else {
 			last = node;
@@ -2878,7 +2878,7 @@ static int ip_address_uninstall(struct vty *vty, struct interface *ifp,
 	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_QUEUED)
 	    || !CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
 		listnode_delete(ifp->connected, ifc);
-		connected_free(ifc);
+		connected_free(&ifc);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
@@ -3103,7 +3103,7 @@ static int ipv6_address_uninstall(struct vty *vty, struct interface *ifp,
 	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_QUEUED)
 	    || !CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
 		listnode_delete(ifp->connected, ifc);
-		connected_free(ifc);
+		connected_free(&ifc);
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 


### PR DESCRIPTION
Convert some XXX_free lib functions to a double pointer to allow for a NULL value to be set.