### PR TITLE
pimd: Do not spew a million warnings

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -191,11 +191,13 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 		pim_upstream_del(pim_ifp->pim, ch->upstream,
 			__PRETTY_FUNCTION__);
 
-	else
-		zlog_warn("%s: Avoiding deletion of upstream with ref_count %d "
-			"from ifchannel(%s): %s", __PRETTY_FUNCTION__,
-			ch->upstream->ref_count, ch->interface->name,
-			ch->sg_str);
+	else {
+		if (PIM_DEBUG_PIM_TRACE)
+			zlog_debug("%s: Avoiding deletion of upstream with ref_count %d "
+				   "from ifchannel(%s): %s", __PRETTY_FUNCTION__,
+				   ch->upstream->ref_count, ch->interface->name,
+				   ch->sg_str);
+	}
 
 	ch->upstream = NULL;
 


### PR DESCRIPTION
We have a zlog_warn that is unguarded ( and really is a debug message )
as that there is nothing the end user can do and nothing to note
here other than a debug message to track refcounts.  Change
to an appropriate debug and zlog_debug it instead.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>