### PR TITLE
bgpd: Send "Peer De-configured" notification before closing the socket

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -685,8 +685,11 @@ void bgp_notify_send_with_data(struct peer *peer, uint8_t code,
 	/* Set BGP packet length. */
 	bgp_packet_set_size(s);
 
-	/* wipe output buffer */
-	stream_fifo_clean(peer->obuf);
+	/* Output buffer could be already cleaned by bgp_stop()
+	 * thus check if it's not NULL.
+	 */
+	if (peer->obuf)
+		stream_fifo_clean(peer->obuf);
 
 	/*
 	 * If possible, store last packet for debugging purposes. This check is
@@ -753,7 +756,8 @@ void bgp_notify_send_with_data(struct peer *peer, uint8_t code,
 		peer->last_reset = PEER_DOWN_NOTIFY_SEND;
 
 	/* Add packet to peer's output queue */
-	stream_fifo_push(peer->obuf, s);
+	if (peer->obuf)
+		stream_fifo_push(peer->obuf, s);
 
 	bgp_write_notify(peer);
 }


### PR DESCRIPTION
rfc4486 states:
If a BGP speaker decides to de-configure a peer, then the speaker
SHOULD send a NOTIFICATION message with the Error Code Cease and
the Error Subcode "Peer De-configured".

Before the patch:

~# vtysh -c 'show ip bgp neighbors 192.168.0.2 json' | \
	jq '."192.168.0.2".lastNotificationReason'
null

~# vtysh -c 'show ip bgp neighbors 192.168.0.2 json' | \
	jq '."192.168.0.2".lastResetDueTo'
"Peer closed the session"

After the patch:

~# vtysh -c 'show ip bgp neighbors 192.168.0.2 json' | \
	jq '."192.168.0.2".lastNotificationReason'
"Cease/Peer Unconfigured"

Closes https://github.com/FRRouting/frr/issues/5262

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>