### PR TITLE
tools: fix emacs configuration file

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,7 +2,7 @@
 ;;; For more information see (info "(emacs) Directory Variables")
 ;;; Match project coding conventions
 
-((c-mode
-  (indent-tabs-mode . t)
-  (show-trailing-whitespace . t)
-  (c-basic-offset . 8)))
+((c-mode . ((indent-tabs-mode . t)
+            (show-trailing-whitespace . t)
+            (c-basic-offset . 8)
+            )))


### PR DESCRIPTION
## Summary

It was missing a set of parentheses and a dot before `indent-tabs-mode'.

More information here:
https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html#Directory-Variables


## Extra

I also have a extra configuration for `flycheck`:

```el
((c-mode . (
            ;; Add path to `lib' and `config.h' so flycheck can find them
            ;; (include path are relative to the open file).
            (flycheck-gcc-include-path . ("." "../" "../lib"))
            (flycheck-clang-include-path . ("." "../" "../lib"))
            ;; Tell the compiler about the makefile guards.
            (flycheck-gcc-args . ("-std=gnu11"
                                  "-DHAVE_CONFIG_H"
                                  "-Wall"
                                  "-Wextra"
                                  "-Wstrict-prototypes"
                                  "-Wmissing-prototypes"
                                  "-Wmissing-declarations"
                                  "-Wshadow"
                                  "-Wpointer-arith"
                                  "-Wconversion"
                                  "-Wpacked"
                                  "-Wswitch-enum"
                                  "-Wimplicit-fallthrough"
                                  "-Wsuggest-attribute=const"
                                  "-Wsuggest-attribute=malloc"
                                  "-Walloc-zero"))
            (flycheck-clang-args . ("-std=gnu11"
                                    "-DHAVE_CONFIG_H"
                                    "-Wall"
                                    "-Wextra"
                                    "-Wstrict-prototypes"
                                    "-Wmissing-prototypes"
                                    "-Wmissing-declarations"
                                    "-Wshadow"
                                    "-Wpointer-arith"
                                    "-Wconversion"
                                    "-Wpacked"
                                    "-Wswitch-enum"
                                    "-Wimplicit-fallthrough"
                                    "-Wsuggest-attribute=const"
                                    "-Wsuggest-attribute=malloc"
                                    "-Walloc-zero"))
            )))
```

The snippet above can be added to `.dir-locals.el` or to `.dir-locals-2.el` (if using recent emacs version) to enable more flycheck warnings. `flycheck` can be found as a package in emacs melpa repositories and you'll also need `flycheck-clang-analyzer` for the `clang` compiler.

NOTE: emacs will warn/ask you about the flycheck variables since you could theoretically pass malicious arguments.