### PR TITLE
BGPD: Prevent IPv6-LL being fwd to IBGP peers not on same link.

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1941,19 +1941,19 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 					__func__, family2str(family));
 			subgroup_announce_reset_nhop(family, attr);
 		}
+	}
 
-		/* If IPv6/MP and nexthop does not have any override and happens
-		 * to
-		 * be a link-local address, reset it so that we don't pass along
-		 * the
-		 * source's link-local IPv6 address to recipients who may not be
-		 * on
-		 * the same interface.
-		 */
-		if (p->family == AF_INET6 || peer_cap_enhe(peer, afi, safi)) {
-			if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_global))
-				subgroup_announce_reset_nhop(AF_INET6, attr);
-		}
+	/* If IPv6/MP and nexthop does not have any override and happens
+	 * to
+	 * be a link-local address, reset it so that we don't pass along
+	 * the
+	 * source's link-local IPv6 address to recipients who may not be
+	 * on
+	 * the same interface.
+	 */
+	if (p->family == AF_INET6 || peer_cap_enhe(peer, afi, safi)) {
+		if (IN6_IS_ADDR_LINKLOCAL(&attr->mp_nexthop_global))
+			subgroup_announce_reset_nhop(AF_INET6, attr);
 	}
 
 	return 1;


### PR DESCRIPTION
Prevent IPv6 Link-local address being forward to IBGP peer, which are not directly connected.

R1----IPV6-unnumbered-EBGP-------R2-----IPV6-IBGP-----R3

Configure route-map to set preferred global address on and apply route-map-IN on R2 for R1-R2 session. Now check on R3's BGP and RIB table has route nexthop as R1 link-local address, which is not correct.

As of now we clear link-local address info from mp_nexthop_global, only if mp_nexthop_global is populated with link-local address.

We should do it even if route-map is configured boz forwarding link-local address from one link scope to another is violation of the standards.

Signed-off-by: Biswajit Sadhu sadhub@vmware.com