### PR TITLE
bgpd: Have Nexthop Tracking specify vrf we are in for debugs

### DIFF
--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -234,9 +234,9 @@ static void bgp_dump_routes_index_table(struct bgp *bgp)
 	stream_put_in_addr(obuf, &bgp->router_id);
 
 	/* View name */
-	if (bgp->name) {
-		stream_putw(obuf, strlen(bgp->name));
-		stream_put(obuf, bgp->name, strlen(bgp->name));
+	if (bgp->name_pretty) {
+		stream_putw(obuf, strlen(bgp->name_pretty));
+		stream_put(obuf, bgp->name_pretty, strlen(bgp->name_pretty));
 	} else {
 		stream_putw(obuf, 0);
 	}


### PR DESCRIPTION
Recently had a case where I was attempting to debug a nexthop tracking
issue across multiple bgp vrf's and since the setup vrf's in it with
overlapping address ranges, it became real fun real fast to track
vrf data associated.  Add a bit of code to allow us to figure out
what vrf we are in when we print out debug messages.

Additionally, the `bgp->name` value is not filled in if it is the
default vrf.  Fix the code to put something in it.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>