### PR TITLE
pbrd: Add `set vrf NAME` and `set vrf unchanged`

### DIFF
--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -107,6 +107,14 @@ end destination.
    Use this individual nexthop as the place to forward packets when the match
    commands have matched a packet.
 
+.. clicmd:: set vrf unchanged|NAME
+
+   If unchanged is set, the rule will use the vrf table the interface is in
+   as its lookup. If NAME is specified, the rule will use that vrf table as
+   its lookup.
+
+   Not supported with NETNS VRF backend.
+
 .. _pbr-policy:
 
 PBR Policy

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -48,6 +48,7 @@
 #include "pbr_zebra.h"
 #include "pbr_vty.h"
 #include "pbr_debug.h"
+#include "pbr_vrf.h"
 
 zebra_capabilities_t _caps_p[] = {
 	ZCAP_NET_RAW, ZCAP_BIND, ZCAP_NET_ADMIN,
@@ -153,7 +154,6 @@ int main(int argc, char **argv, char **envp)
 
 	pbr_debug_init();
 
-	vrf_init(NULL, NULL, NULL, NULL, NULL);
 	nexthop_group_init(pbr_nhgroup_add_cb,
 			   pbr_nhgroup_add_nexthop_cb,
 			   pbr_nhgroup_del_nexthop_cb,
@@ -169,6 +169,7 @@ int main(int argc, char **argv, char **envp)
 	if_zapi_callbacks(pbr_ifp_create, pbr_ifp_up,
 			  pbr_ifp_down, pbr_ifp_destroy);
 	pbr_zebra_init();
+	pbr_vrf_init();
 	pbr_vty_init();
 
 	frr_config_fork();

--- a/pbrd/pbr_map.h
+++ b/pbrd/pbr_map.h
@@ -22,6 +22,8 @@
 
 #include <bitfield.h>
 
+#include "pbr_vrf.h"
+
 struct pbr_map {
 	/*
 	 * RB Tree of the pbr_maps
@@ -95,6 +97,21 @@ struct pbr_map_sequence {
 	unsigned char family;
 
 	/*
+	 * Use interface's vrf.
+	 */
+	bool vrf_unchanged;
+
+	/*
+	 * The vrf to lookup in was directly configured.
+	 */
+	bool vrf_lookup;
+
+	/*
+	 * VRF to lookup.
+	 */
+	char vrf_name[VRF_NAMSIZ + 1];
+
+	/*
 	 * The nexthop group we auto create
 	 * for when the user specifies a individual
 	 * nexthop
@@ -122,12 +139,13 @@ struct pbr_map_sequence {
 	 * A reason of 0 means we think the pbr_map_sequence is good to go
 	 * We can accumuluate multiple failure states
 	 */
-#define PBR_MAP_VALID_SEQUENCE_NUMBER  0
-#define PBR_MAP_INVALID_NEXTHOP_GROUP  (1 << 0)
-#define PBR_MAP_INVALID_NEXTHOP        (1 << 1)
-#define PBR_MAP_INVALID_NO_NEXTHOPS    (1 << 2)
-#define PBR_MAP_INVALID_BOTH_NHANDGRP  (1 << 3)
-#define PBR_MAP_INVALID_EMPTY          (1 << 4)
+#define PBR_MAP_VALID_SEQUENCE_NUMBER    0
+#define PBR_MAP_INVALID_NEXTHOP_GROUP    (1 << 0)
+#define PBR_MAP_INVALID_NEXTHOP          (1 << 1)
+#define PBR_MAP_INVALID_NO_NEXTHOPS      (1 << 2)
+#define PBR_MAP_INVALID_BOTH_NHANDGRP    (1 << 3)
+#define PBR_MAP_INVALID_EMPTY            (1 << 4)
+#define PBR_MAP_INVALID_VRF              (1 << 5)
 	uint64_t reason;
 
 	QOBJ_FIELDS
@@ -144,12 +162,21 @@ pbrms_lookup_unique(uint32_t unique, ifindex_t ifindex,
 
 extern struct pbr_map *pbrm_find(const char *name);
 extern void pbr_map_delete(struct pbr_map_sequence *pbrms);
-extern void pbr_map_delete_nexthop_group(struct pbr_map_sequence *pbrms);
+extern void pbr_map_delete_nexthops(struct pbr_map_sequence *pbrms);
+extern void pbr_map_delete_vrf(struct pbr_map_sequence *pbrms);
 extern void pbr_map_add_interface(struct pbr_map *pbrm, struct interface *ifp);
 extern void pbr_map_interface_delete(struct pbr_map *pbrm,
 				     struct interface *ifp);
+
+/* Update maps installed on interface */
+extern void pbr_map_policy_interface_update(const struct interface *ifp,
+					    bool state_up);
+
 extern void pbr_map_final_interface_deletion(struct pbr_map *pbrm,
 					     struct pbr_map_interface *pmi);
+
+extern void pbr_map_vrf_update(const struct pbr_vrf *pbr_vrf);
+
 extern void pbr_map_write_interfaces(struct vty *vty, struct interface *ifp);
 extern void pbr_map_init(void);
 

--- a/pbrd/pbr_nht.c
+++ b/pbrd/pbr_nht.c
@@ -548,20 +548,10 @@ void pbr_nht_delete_individual_nexthop(struct pbr_map_sequence *pbrms)
 	struct pbr_nexthop_group_cache find;
 	struct pbr_nexthop_cache *pnhc;
 	struct pbr_nexthop_cache lup;
-	struct pbr_map *pbrm = pbrms->parent;
-	struct listnode *node;
-	struct pbr_map_interface *pmi;
 	struct nexthop *nh;
 	enum nexthop_types_t nh_type = 0;
 
-	if (pbrm->valid && pbrms->nhs_installed && pbrm->incoming->count) {
-		for (ALL_LIST_ELEMENTS_RO(pbrm->incoming, node, pmi))
-			pbr_send_pbr_map(pbrms, pmi, false);
-	}
-
-	pbrm->valid = false;
-	pbrms->nhs_installed = false;
-	pbrms->reason |= PBR_MAP_INVALID_NO_NEXTHOPS;
+	pbr_map_delete_nexthops(pbrms);
 
 	memset(&find, 0, sizeof(find));
 	snprintf(find.name, sizeof(find.name), "%s", pbrms->internal_nhg_name);

--- a/pbrd/pbr_vrf.c
+++ b/pbrd/pbr_vrf.c
@@ -1,0 +1,137 @@
+/*
+ * PBR - vrf code
+ * Copyright (C) 2019 Cumulus Networks, Inc.
+ *               Stephen Worley
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include <zebra.h>
+
+#include "vrf.h"
+
+#include "pbr_vrf.h"
+#include "pbr_memory.h"
+#include "pbr_map.h"
+#include "pbr_debug.h"
+
+DEFINE_MTYPE_STATIC(PBRD, PBR_MAP_VRF, "PBR Map VRF")
+
+static struct pbr_vrf *pbr_vrf_alloc(void)
+{
+	struct pbr_vrf *pbr_vrf;
+
+	pbr_vrf = XCALLOC(MTYPE_PBR_MAP_VRF, sizeof(struct pbr_vrf));
+
+	return pbr_vrf;
+}
+
+static void pbr_vrf_free(struct pbr_vrf *pbr_vrf)
+{
+	XFREE(MTYPE_PBR_MAP_VRF, pbr_vrf);
+}
+
+static int pbr_vrf_new(struct vrf *vrf)
+{
+	struct pbr_vrf *pbr_vrf;
+
+	DEBUGD(&pbr_dbg_event, "%s: %u (%s)", __func__, vrf->vrf_id, vrf->name);
+
+	pbr_vrf = pbr_vrf_alloc();
+	vrf->info = pbr_vrf;
+	pbr_vrf->vrf = vrf;
+
+	return 0;
+}
+
+static int pbr_vrf_enable(struct vrf *vrf)
+{
+	DEBUGD(&pbr_dbg_event, "%s: %u (%s)", __func__, vrf->vrf_id, vrf->name);
+
+	pbr_map_vrf_update(vrf->info);
+
+	return 0;
+}
+
+static int pbr_vrf_disable(struct vrf *vrf)
+{
+	DEBUGD(&pbr_dbg_event, "%s: %u (%s)", __func__, vrf->vrf_id, vrf->name);
+
+	pbr_map_vrf_update(vrf->info);
+
+	return 0;
+}
+
+static int pbr_vrf_delete(struct vrf *vrf)
+{
+	DEBUGD(&pbr_dbg_event, "%s: %u (%s)", __func__, vrf->vrf_id, vrf->name);
+
+	/*
+	 * Make sure vrf is always marked disabled first so we handle
+	 * pbr rules using it.
+	 */
+	assert(!vrf_is_enabled(vrf));
+
+	pbr_vrf_free(vrf->info);
+	vrf->info = NULL;
+
+	return 0;
+}
+
+struct pbr_vrf *pbr_vrf_lookup_by_id(vrf_id_t vrf_id)
+{
+	struct vrf *vrf;
+
+	vrf = vrf_lookup_by_id(vrf_id);
+	if (vrf)
+		return ((struct pbr_vrf *)vrf->info);
+
+	return NULL;
+}
+
+struct pbr_vrf *pbr_vrf_lookup_by_name(const char *name)
+{
+	struct vrf *vrf;
+
+	if (!name)
+		name = VRF_DEFAULT_NAME;
+
+	vrf = vrf_lookup_by_name(name);
+	if (vrf)
+		return ((struct pbr_vrf *)vrf->info);
+
+	return NULL;
+}
+
+bool pbr_vrf_is_enabled(const struct pbr_vrf *pbr_vrf)
+{
+	return vrf_is_enabled(pbr_vrf->vrf) ? true : false;
+}
+
+bool pbr_vrf_is_valid(const struct pbr_vrf *pbr_vrf)
+{
+	if (vrf_is_backend_netns())
+		return false;
+
+	if (!pbr_vrf->vrf)
+		return false;
+
+	return pbr_vrf_is_enabled(pbr_vrf);
+}
+
+void pbr_vrf_init(void)
+{
+	vrf_init(pbr_vrf_new, pbr_vrf_enable, pbr_vrf_disable, pbr_vrf_delete,
+		 NULL);
+}

--- a/pbrd/pbr_vrf.h
+++ b/pbrd/pbr_vrf.h
@@ -1,0 +1,43 @@
+/*
+ * VRF library for PBR
+ * Copyright (C) 2019 Cumulus Networks, Inc.
+ *               Stephen Worley
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef __PBR_VRF_H__
+#define __PBR_VRF_H__
+
+struct pbr_vrf {
+	struct vrf *vrf;
+};
+
+static inline const char *pbr_vrf_name(const struct pbr_vrf *pbr_vrf)
+{
+	return pbr_vrf->vrf->name;
+}
+
+static inline vrf_id_t pbr_vrf_id(const struct pbr_vrf *pbr_vrf)
+{
+	return pbr_vrf->vrf->vrf_id;
+}
+
+extern struct pbr_vrf *pbr_vrf_lookup_by_id(vrf_id_t vrf_id);
+extern struct pbr_vrf *pbr_vrf_lookup_by_name(const char *name);
+extern bool pbr_vrf_is_valid(const struct pbr_vrf *pbr_vrf);
+extern bool pbr_vrf_is_enabled(const struct pbr_vrf *pbr_vrf);
+
+extern void pbr_vrf_init(void);
+#endif

--- a/pbrd/subdir.am
+++ b/pbrd/subdir.am
@@ -20,6 +20,7 @@ pbrd_libpbr_a_SOURCES = \
 	pbrd/pbr_memory.c \
 	pbrd/pbr_nht.c \
 	pbrd/pbr_debug.c \
+	pbrd/pbr_vrf.c \
 	# end
 
 noinst_HEADERS += \
@@ -29,6 +30,7 @@ noinst_HEADERS += \
 	pbrd/pbr_vty.h \
 	pbrd/pbr_zebra.h \
 	pbrd/pbr_debug.h \
+	pbrd/pbr_vrf.h \
 	# end
 
 pbrd/pbr_vty_clippy.c: $(CLIPPY_DEPS)


### PR DESCRIPTION
`set vrf NAME` allows the pbr map to point to an arbitrary vrf table.

`set vrf unchanged` will use the interface its added to's vrf as for
table lookup.

Further, add functionality for pbr to respond to interface events
such as interface vrf changes & interface creation/deletion.

Ex)
ubuntu_nh# show pbr map
  pbr-map TEST valid: 1
    Seq: 1 rule: 300 Installed: 3(1) Reason: Valid
        SRC Match: 3.3.3.3/32
        VRF Unchanged (use interface vrf)
  pbr-map TEST2 valid: 1
    Seq: 2 rule: 301 Installed: 3(2) Reason: Valid
        SRC Match: 4.4.4.4/32
        VRF Lookup: vrf-red

root@ubuntu_nh:/home# ip rule show
0:      from all lookup local
300:    from 3.3.3.3 iif dummy2 lookup main
300:    from 3.3.3.3 iif dummyVRF lookup 1111
301:    from 4.4.4.4 iif dummy1 lookup 1111
301:    from 4.4.4.4 iif dummy3 lookup 1111

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com-