### PR TITLE
zebra: [6.0] Re-evaluate the nexthop tracking if flags changed

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1023,6 +1023,8 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 	uint8_t flags = 0;
 	uint16_t type = cmd2type[hdr->command];
 	bool exist;
+	bool flag_changed = false;
+	uint8_t orig_flags;
 
 	if (IS_ZEBRA_DEBUG_NHT)
 		zlog_debug(
@@ -1069,6 +1071,7 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 		if (!rnh)
 			return;
 
+		orig_flags = rnh->flags;
 		if (type == RNH_NEXTHOP_TYPE) {
 			if (flags
 			    && !CHECK_FLAG(rnh->flags, ZEBRA_NHT_CONNECTED))
@@ -1086,9 +1089,12 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 				UNSET_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH);
 		}
 
+		if (orig_flags != rnh->flags)
+			flag_changed = true;
+
 		zebra_add_rnh_client(rnh, client, type, zvrf_id(zvrf));
 		/* Anything not AF_INET/INET6 has been filtered out above */
-		if (!exist)
+		if (!exist || flag_changed)
 			zebra_evaluate_rnh(zvrf_id(zvrf), p.family, 1, type,
 					   &p);
 	}


### PR DESCRIPTION
Routing protocols are allowed ( and even encouraged ) to modify
the flags that influence the nexthop tracking.  As such when
we modify the tracking of a nexthop to go from, say, connected force
or not we must re-evaluate the nexthop and send the results
up to the interested parties.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>

Closes https://github.com/FRRouting/frr/issues/4762