### PR TITLE
bgpd: Set nexthop interface correctly for views

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2913,8 +2913,10 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	bgp_lock(bgp);
 	bgp->heuristic_coalesce = true;
 	bgp->inst_type = inst_type;
-	bgp->vrf_id = (inst_type == BGP_INSTANCE_TYPE_DEFAULT) ? VRF_DEFAULT
-							       : VRF_UNKNOWN;
+	bgp->vrf_id = (inst_type == BGP_INSTANCE_TYPE_DEFAULT
+		       || inst_type == BGP_INSTANCE_TYPE_VIEW)
+			      ? VRF_DEFAULT
+			      : VRF_UNKNOWN;
 	bgp->peer_self = peer_new(bgp);
 	XFREE(MTYPE_BGP_PEER_HOST, bgp->peer_self->host);
 	bgp->peer_self->host =

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post4.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post4.1.ref
@@ -1,4 +1,5 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
+Default local pref 100, local AS 100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post6.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1-post6.1.ref
@@ -1,4 +1,4 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
 Default local pref 100, local AS 100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_1.ref
@@ -1,7 +1,9 @@
-BGP table version is XXX, local router ID is 172.30.1.1
-Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
-              i internal, r RIB-failure, S Stale, R Removed
-Origin codes: i - IGP, e - EGP, ? - incomplete
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
+Default local pref 100, local AS 100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
 
    Network          Next Hop            Metric LocPrf Weight Path
 *  10.0.1.0/24      172.16.1.5                             0 65005 i

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post4.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post4.1.ref
@@ -1,4 +1,5 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
+Default local pref 100, local AS 100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post6.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2-post6.1.ref
@@ -1,4 +1,4 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
 Default local pref 100, local AS 100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_2.ref
@@ -1,7 +1,9 @@
-BGP table version is XXX, local router ID is 172.30.1.1
-Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
-              i internal, r RIB-failure, S Stale, R Removed
-Origin codes: i - IGP, e - EGP, ? - incomplete
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
+Default local pref 100, local AS 100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
 
    Network          Next Hop            Metric LocPrf Weight Path
 *  10.0.1.0/24      172.16.1.4                             0 65004 i

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post4.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post4.1.ref
@@ -1,4 +1,5 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
+Default local pref 100, local AS 100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed
 Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post6.1.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3-post6.1.ref
@@ -1,4 +1,4 @@
-BGP table version is XXX, local router ID is 172.30.1.1, vrf id -
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
 Default local pref 100, local AS 100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                i internal, r RIB-failure, S Stale, R Removed

--- a/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3.ref
+++ b/tests/topotests/bgp_multiview_topo1/r1/show_ip_bgp_view_3.ref
@@ -1,7 +1,9 @@
-BGP table version is XXX, local router ID is 172.30.1.1
-Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
-              i internal, r RIB-failure, S Stale, R Removed
-Origin codes: i - IGP, e - EGP, ? - incomplete
+BGP table version is XXX, local router ID is 172.30.1.1, vrf id 0
+Default local pref 100, local AS 100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
 
    Network          Next Hop            Metric LocPrf Weight Path
 *  10.0.1.0/24      172.16.1.8                             0 65008 i


### PR DESCRIPTION
This solves the following issue:

spine1-debian-9 bgpd[9172]: 2a02:123::1 sent a v6 LL next-hop and there's no
peer interface information. Hence, withdrawing spine1-debian-9 bgpd[9172]: [EC
33554487] 2a02:123::1: Attribute MP_REACH_NLRI, parse error - treating as
withdrawal spine1-debian-9 bgpd[9172]: [EC 33554454] 2a02:123::1 rcvd UPDATE
with errors in attr(s)!! Withdrawing route.  spine1-debian-9 bgpd[9172]: [EC
33554454] 2a02:123::1 [Error] Update packet error (wrong prefix length 64 for
afi 1) spine1-debian-9 bgpd[9172]: [EC 33554454] 2a02:123::1 [Error] Error
parsing NLRI spine1-debian-9 bgpd[9172]: %NOTIFICATION: sent to neighbor
2a02:123::1 3/10 (UPDATE Message Error/Invalid Network Field) 0 bytes
spine1-debian-9 bgpd[9172]: [EC 33554454] bgp_process_packet: BGP UPDATE receipt
failed for peer: 2a02:123::1

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

Closes https://github.com/FRRouting/frr/issues/3979