### PR TITLE
bgpd: Fix missed prefix_free conversion in rpki code

### DIFF
--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -406,7 +406,7 @@ static int bgpd_sync_callback(struct thread *thread)
 		}
 	}
 
-	prefix_free(prefix);
+	prefix_free(&prefix);
 	return 0;
 }
 


### PR DESCRIPTION
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>