### PR TITLE
bgpd: Remove not used bgp_find_nexthop() function

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -65,27 +65,6 @@ static int bgp_isvalid_labeled_nexthop(struct bgp_nexthop_cache *bnc)
 		|| (bnc && CHECK_FLAG(bnc->flags, BGP_NEXTHOP_LABELED_VALID)));
 }
 
-int bgp_find_nexthop(struct bgp_path_info *path, int connected)
-{
-	struct bgp_nexthop_cache *bnc = path->nexthop;
-
-	if (!bnc)
-		return 0;
-
-	/*
-	 * We are cheating here.  Views have no associated underlying
-	 * ability to detect nexthops.  So when we have a view
-	 * just tell everyone the nexthop is valid
-	 */
-	if (path->peer && path->peer->bgp->inst_type == BGP_INSTANCE_TYPE_VIEW)
-		return 1;
-
-	if (connected && !(CHECK_FLAG(bnc->flags, BGP_NEXTHOP_CONNECTED)))
-		return 0;
-
-	return (bgp_isvalid_nexthop(bnc));
-}
-
 static void bgp_unlink_nexthop_check(struct bgp_nexthop_cache *bnc)
 {
 	if (LIST_EMPTY(&(bnc->paths)) && !bnc->nht_info) {

--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -27,14 +27,6 @@
 extern void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id);
 
 /**
- * bgp_find_nexthop() - lookup the nexthop cache table for the bnc object
- * ARGUMENTS:
- *   p - path for which the nexthop object is being looked up
- *   connected - True if NH MUST be a connected route
- */
-extern int bgp_find_nexthop(struct bgp_path_info *p, int connected);
-
-/**
  * bgp_find_or_add_nexthop() - lookup the nexthop cache table for the bnc
  *  object. If not found, create a new object and register with ZEBRA for
  *  nexthop notification.

--- a/doc/developer/next-hop-tracking.rst
+++ b/doc/developer/next-hop-tracking.rst
@@ -111,8 +111,6 @@ provides the following APIs:
 +============================+==================================================+
 | bgp_find_or_add_nexthop()  | find or add a nexthop in BGP nexthop table       |
 +----------------------------+--------------------------------------------------+
-| bgp_find_nexthop()         | find a nexthop in BGP nexthop table              |
-+----------------------------+--------------------------------------------------+
 | bgp_parse_nexthop_update() | parse a nexthop update message coming from zebra |
 +----------------------------+--------------------------------------------------+
 


### PR DESCRIPTION
Seems like a dead code.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>