### PR TITLE
staticd: Make blackhole keyword errors more straightforward

### DIFF
--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -431,10 +431,10 @@ static int static_route_leak(
 		    || strcasecmp(ifname, "blackhole") == 0) {
 			if (vty)
 				vty_out(vty,
-					"%% Nexthop interface cannot be Null0, reject or blackhole\n");
+					"%% Nexthop interface name can not be from reserved keywords (Null0, reject, blackhole)\n");
 			else
 				zlog_warn(
-					"%s: Nexthop interface cannot be Null0, reject or blackhole for %s",
+					"%s: %s: Nexthop interface name can not be from reserved keywords (Null0, reject, blackhole)\n",
 					__PRETTY_FUNCTION__, dest_str);
 			return CMD_WARNING_CONFIG_FAILED;
 		}


### PR DESCRIPTION
Previous error was misleading and made it seem like Null0,
reject, or blackhole nexthops on static routes are invalid.
This commit makes it more clear as to why the error is seen.

Signed-off-by: Trey Aspelund <taspelund@cumulusnetworks.com>