### PR TITLE
bgpd: Reject incoming and outgoing UPDATES for AS_SET and AS_CONFED_SET

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -414,6 +414,19 @@ unsigned int aspath_count_hops(const struct aspath *aspath)
 	return count;
 }
 
+/* Check if aspath has AS_SET or AS_CONFED_SET */
+bool aspath_check_as_sets(struct aspath *aspath)
+{
+	struct assegment *seg = aspath->segments;
+
+	while (seg) {
+		if (seg->type == AS_SET || seg->type == AS_CONFED_SET)
+			return true;
+		seg = seg->next;
+	}
+	return false;
+}
+
 /* Estimate size aspath /might/ take if encoded into an
  * ASPATH attribute.
  *

--- a/bgpd/bgp_aspath.h
+++ b/bgpd/bgp_aspath.h
@@ -120,6 +120,7 @@ extern int aspath_confed_check(struct aspath *);
 extern int aspath_left_confed_check(struct aspath *);
 extern unsigned long aspath_count(void);
 extern unsigned int aspath_count_hops(const struct aspath *);
+extern bool aspath_check_as_sets(struct aspath *aspath);
 extern unsigned int aspath_count_confeds(struct aspath *);
 extern unsigned int aspath_size(struct aspath *);
 extern as_t aspath_highest(struct aspath *);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1850,6 +1850,16 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 		if (!bgp_outbound_policy_exists(peer, filter))
 			return 0;
 
+	/* draft-ietf-idr-deprecate-as-set-confed-set
+	 * Filter routes having AS_SET or AS_CONFED_SET in the path.
+	 * Eventually, This document (if approved) updates RFC 4271
+	 * and RFC 5065 by eliminating AS_SET and AS_CONFED_SET types,
+	 * and obsoletes RFC 6472.
+	 */
+	if (peer->bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED)
+		if (aspath_check_as_sets(attr->aspath))
+			return 0;
+
 	if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
 		if (peer->sort == BGP_PEER_IBGP
 		    || peer->sort == BGP_PEER_CONFED) {
@@ -3140,6 +3150,19 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 		if (!bgp_inbound_policy_exists(peer,
 					       &peer->filter[afi][safi])) {
 			reason = "inbound policy missing";
+			goto filtered;
+		}
+
+	/* draft-ietf-idr-deprecate-as-set-confed-set
+	 * Filter routes having AS_SET or AS_CONFED_SET in the path.
+	 * Eventually, This document (if approved) updates RFC 4271
+	 * and RFC 5065 by eliminating AS_SET and AS_CONFED_SET types,
+	 * and obsoletes RFC 6472.
+	 */
+	if (peer->bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED)
+		if (aspath_check_as_sets(attr->aspath)) {
+			reason =
+				"as-path contains AS_SET or AS_CONFED_SET type;";
 			goto filtered;
 		}
 
@@ -6363,6 +6386,7 @@ void bgp_aggregate_decrement(struct bgp *bgp, struct prefix *p,
 /* Aggregate route attribute. */
 #define AGGREGATE_SUMMARY_ONLY 1
 #define AGGREGATE_AS_SET       1
+#define AGGREGATE_AS_UNSET     0
 
 static int bgp_aggregate_unset(struct vty *vty, const char *prefix_str,
 			       afi_t afi, safi_t safi)
@@ -6465,6 +6489,7 @@ static int bgp_aggregate_set(struct vty *vty, const char *prefix_str, afi_t afi,
 	struct prefix p;
 	struct bgp_node *rn;
 	struct bgp_aggregate *aggregate;
+	uint8_t as_set_new = as_set;
 
 	/* Convert string to prefix structure. */
 	ret = str2prefix(prefix_str, &p);
@@ -6499,7 +6524,27 @@ static int bgp_aggregate_set(struct vty *vty, const char *prefix_str, afi_t afi,
 	/* Make aggregate address structure. */
 	aggregate = bgp_aggregate_new();
 	aggregate->summary_only = summary_only;
-	aggregate->as_set = as_set;
+
+	/* Network operators MUST NOT locally generate any new
+	 * announcements containing AS_SET or AS_CONFED_SET. If they have
+	 * announced routes with AS_SET or AS_CONFED_SET in them, then they
+	 * SHOULD withdraw those routes and re-announce routes for the
+	 * aggregate or component prefixes (i.e., the more-specific routes
+	 * subsumed by the previously aggregated route) without AS_SET
+	 * or AS_CONFED_SET in the updates.
+	 */
+	if (bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED) {
+		if (as_set == AGGREGATE_AS_SET) {
+			as_set_new = AGGREGATE_AS_UNSET;
+			zlog_warn(
+				"%s: Ignoring as-set because `bgp reject-as-sets` is enabled.\n",
+				__func__);
+			vty_out(vty,
+				"Ignoring as-set because `bgp reject-as-sets` is enabled.\n");
+		}
+	}
+
+	aggregate->as_set = as_set_new;
 	aggregate->safi = safi;
 
 	if (rmap) {
@@ -6534,8 +6579,8 @@ DEFUN (aggregate_address,
 	argv_find(argv, argc, "A.B.C.D/M", &idx);
 	char *prefix = argv[idx]->arg;
 	char *rmap = NULL;
-	int as_set =
-		argv_find(argv, argc, "as-set", &idx) ? AGGREGATE_AS_SET : 0;
+	int as_set = argv_find(argv, argc, "as-set", &idx) ? AGGREGATE_AS_SET
+							   : AGGREGATE_AS_UNSET;
 	idx = 0;
 	int summary_only = argv_find(argv, argc, "summary-only", &idx)
 				   ? AGGREGATE_SUMMARY_ONLY
@@ -6569,8 +6614,8 @@ DEFUN (aggregate_address_mask,
 	char *mask = argv[idx + 1]->arg;
 	bool rmap_found;
 	char *rmap = NULL;
-	int as_set =
-		argv_find(argv, argc, "as-set", &idx) ? AGGREGATE_AS_SET : 0;
+	int as_set = argv_find(argv, argc, "as-set", &idx) ? AGGREGATE_AS_SET
+							   : AGGREGATE_AS_UNSET;
 	idx = 0;
 	int summary_only = argv_find(argv, argc, "summary-only", &idx)
 				   ? AGGREGATE_SUMMARY_ONLY
@@ -6658,8 +6703,8 @@ DEFUN (ipv6_aggregate_address,
 	char *prefix = argv[idx]->arg;
 	char *rmap = NULL;
 	bool rmap_found;
-	int as_set =
-		argv_find(argv, argc, "as-set", &idx) ? AGGREGATE_AS_SET : 0;
+	int as_set = argv_find(argv, argc, "as-set", &idx) ? AGGREGATE_AS_SET
+							   : AGGREGATE_AS_UNSET;
 
 	idx = 0;
 	int sum_only = argv_find(argv, argc, "summary-only", &idx)

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1921,6 +1921,56 @@ DEFUN(no_bgp_ebgp_requires_policy, no_bgp_ebgp_requires_policy_cmd,
 	return CMD_SUCCESS;
 }
 
+DEFUN(bgp_reject_as_sets, bgp_reject_as_sets_cmd,
+      "bgp reject-as-sets",
+      "BGP specific commands\n"
+      "Reject routes with AS_SET or AS_CONFED_SET flag\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	struct listnode *node, *nnode;
+	struct peer *peer;
+
+	bgp->reject_as_sets = BGP_REJECT_AS_SETS_ENABLED;
+
+	/* Reset existing BGP sessions to reject routes
+	 * with aspath containing AS_SET or AS_CONFED_SET.
+	 */
+	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
+		if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->status)) {
+			peer->last_reset = PEER_DOWN_AS_SETS_REJECT;
+			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
+					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
+		}
+	}
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_bgp_reject_as_sets, no_bgp_reject_as_sets_cmd,
+      "no bgp reject-as-sets",
+      NO_STR
+      "BGP specific commands\n"
+      "Reject routes with AS_SET or AS_CONFED_SET flag\n")
+{
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	struct listnode *node, *nnode;
+	struct peer *peer;
+
+	bgp->reject_as_sets = BGP_REJECT_AS_SETS_DISABLED;
+
+	/* Reset existing BGP sessions to reject routes
+	 * with aspath containing AS_SET or AS_CONFED_SET.
+	 */
+	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
+		if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->status)) {
+			peer->last_reset = PEER_DOWN_AS_SETS_REJECT;
+			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
+					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
+		}
+	}
+
+	return CMD_SUCCESS;
+}
 
 /* "bgp deterministic-med" configuration. */
 DEFUN (bgp_deterministic_med,
@@ -13127,6 +13177,10 @@ void bgp_vty_init(void)
 	/* bgp ebgp-requires-policy */
 	install_element(BGP_NODE, &bgp_ebgp_requires_policy_cmd);
 	install_element(BGP_NODE, &no_bgp_ebgp_requires_policy_cmd);
+
+	/* bgp reject-as-sets */
+	install_element(BGP_NODE, &bgp_reject_as_sets_cmd);
+	install_element(BGP_NODE, &no_bgp_reject_as_sets_cmd);
 
 	/* "bgp deterministic-med" commands */
 	install_element(BGP_NODE, &bgp_deterministic_med_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2966,6 +2966,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	bgp->dynamic_neighbors_limit = BGP_DYNAMIC_NEIGHBORS_LIMIT_DEFAULT;
 	bgp->dynamic_neighbors_count = 0;
 	bgp->ebgp_requires_policy = DEFAULT_EBGP_POLICY_DISABLED;
+	bgp->reject_as_sets = BGP_REJECT_AS_SETS_DISABLED;
 #if DFLT_BGP_IMPORT_CHECK
 	bgp_flag_set(bgp, BGP_FLAG_IMPORT_CHECK);
 #endif
@@ -7587,6 +7588,10 @@ int bgp_config_write(struct vty *vty)
 		if (bgp->ebgp_requires_policy
 		    == DEFAULT_EBGP_POLICY_ENABLED)
 			vty_out(vty, " bgp ebgp-requires-policy\n");
+
+		/* draft-ietf-idr-deprecate-as-set-confed-set */
+		if (bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED)
+			vty_out(vty, " bgp reject-as-sets\n");
 
 		/* BGP default ipv4-unicast. */
 		if (bgp_flag_check(bgp, BGP_FLAG_NO_DEFAULT_IPV4))

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -504,6 +504,13 @@ struct bgp {
 #define DEFAULT_EBGP_POLICY_DISABLED 0
 #define DEFAULT_EBGP_POLICY_ENABLED 1
 
+	/* draft-ietf-idr-deprecate-as-set-confed-set
+	 * Reject aspaths with AS_SET and/or AS_CONFED_SET.
+	 */
+	bool reject_as_sets;
+#define BGP_REJECT_AS_SETS_DISABLED 0
+#define BGP_REJECT_AS_SETS_ENABLED 1
+
 	struct bgp_evpn_info *evpn_info;
 
 	/* EVPN - use RFC 8365 to auto-derive RT */
@@ -1203,6 +1210,7 @@ struct peer {
 #define PEER_DOWN_NBR_ADDR              28 /* Waiting for peer IPv6 IP Addr */
 #define PEER_DOWN_VRF_UNINIT            29 /* Associated VRF is not init yet */
 #define PEER_DOWN_NOAFI_ACTIVATED       30 /* No AFI/SAFI activated for peer */
+#define PEER_DOWN_AS_SETS_REJECT        31 /* Reject routes with AS_SET */
 	size_t last_reset_cause_size;
 	uint8_t last_reset_cause[BGP_MAX_PACKET_SIZE];
 

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -416,6 +416,14 @@ Require policy on EBGP
 
    This command requires incoming and outgoing filters to be applied for eBGP sessions. Without the incoming filter, no routes will be accepted. Without the outgoing filter, no routes will be announced.
 
+Reject routes with AS_SET or AS_CONFED_SET types
+-------------------------------
+
+.. index:: [no] bgp reject-as-sets
+.. clicmd:: [no] bgp reject-as-sets
+
+   This command enables rejection of incoming and outgoing routes having AS_SET or AS_CONFED_SET type.
+
 .. _bgp-route-flap-dampening:
 
 Route Flap Dampening

--- a/tests/topotests/bgp_reject_as_sets/r1/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r1/bgpd.conf
@@ -1,0 +1,8 @@
+! exit1
+router bgp 65001
+  neighbor 192.168.255.1 remote-as 65002
+  address-family ipv4 unicast
+    redistribute connected
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_reject_as_sets/r1/zebra.conf
+++ b/tests/topotests/bgp_reject_as_sets/r1/zebra.conf
@@ -1,0 +1,9 @@
+! exit1
+interface lo
+ ip address 172.16.255.254/32
+!
+interface r1-eth0
+ ip address 192.168.255.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_reject_as_sets/r2/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r2/bgpd.conf
@@ -1,0 +1,10 @@
+! spine
+router bgp 65002
+  bgp reject-as-sets
+  neighbor 192.168.255.2 remote-as 65001
+  neighbor 192.168.254.2 remote-as 65003
+  address-family ipv4 unicast
+    aggregate-address 172.16.0.0/16 as-set summary-only
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_reject_as_sets/r2/zebra.conf
+++ b/tests/topotests/bgp_reject_as_sets/r2/zebra.conf
@@ -1,0 +1,9 @@
+! spine
+interface r2-eth0
+ ip address 192.168.255.1/30
+!
+interface r2-eth1
+ ip address 192.168.254.1/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_reject_as_sets/r3/bgpd.conf
+++ b/tests/topotests/bgp_reject_as_sets/r3/bgpd.conf
@@ -1,0 +1,9 @@
+! exit2
+router bgp 65003
+  neighbor 192.168.254.1 remote-as 65002
+  address-family ipv4 unicast
+    neighbor 192.168.254.1 allowas-in
+    redistribute connected
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_reject_as_sets/r3/zebra.conf
+++ b/tests/topotests/bgp_reject_as_sets/r3/zebra.conf
@@ -1,0 +1,9 @@
+! exit2
+interface lo
+ ip address 172.16.254.254/32
+!
+interface r3-eth0
+ ip address 192.168.254.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_reject_as_sets/test_bgp_reject_as_sets.py
+++ b/tests/topotests/bgp_reject_as_sets/test_bgp_reject_as_sets.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_reject_as_sets.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2019 by
+# Donatas Abraitis <donatas.abraitis@gmail.com>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Test if an aggregated route with AS_SET is not sent to peers.
+Addressing draft-ietf-idr-deprecate-as-set-confed-set recommendations.
+
+BGP speakers conforming to this document (i.e., conformant BGP
+   speakers) MUST NOT locally generate BGP UPDATE messages containing
+   AS_SET or AS_CONFED_SET.  Conformant BGP speakers SHOULD NOT send BGP
+   UPDATE messages containing AS_SET or AS_CONFED_SET.  Upon receipt of
+   such messages, conformant BGP speakers SHOULD use the "Treat-as-
+   withdraw" error handling behavior as per [RFC7606].
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+class TemplateTopo(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        for routern in range(1, 4):
+            tgen.add_router('r{}'.format(routern))
+
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
+
+        switch = tgen.add_switch('s2')
+        switch.add_link(tgen.gears['r2'])
+        switch.add_link(tgen.gears['r3'])
+
+def setup_module(mod):
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA,
+            os.path.join(CWD, '{}/zebra.conf'.format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP,
+            os.path.join(CWD, '{}/bgpd.conf'.format(rname))
+        )
+
+    tgen.start_router()
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_bgp_reject_as_sets():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears['r2']
+
+    def _bgp_converge(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp neighbor 192.168.255.2 json"))
+        expected = {
+            '192.168.255.2': {
+                'bgpState': 'Established',
+                'addressFamilyInfo': {
+                    'ipv4Unicast': {
+                        'acceptedPrefixCounter': 2
+                    }
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_has_aggregated_route_with_stripped_as_set(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp 172.16.0.0/16 json"))
+        expected = {
+            'paths': [
+                {
+                    'aspath': {
+                        'string': 'Local',
+                        'segments': [
+                        ],
+                        'length': 0
+                    }
+                }
+            ]
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_announce_route_without_as_sets(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp neighbor 192.168.254.2 advertised-routes json"))
+        expected = {
+            'advertisedRoutes': {
+                '172.16.0.0/16': {
+                    'asPath': ''
+                },
+                '192.168.254.0/30': {
+                    'asPath': '65003'
+                },
+                '192.168.255.0/30': {
+                    'asPath': '65001'
+                }
+            },
+            'totalPrefixCounter': 3
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge, router)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+
+    assert result is None, 'Failed bgp convergence in "{}"'.format(router)
+
+    test_func = functools.partial(_bgp_has_aggregated_route_with_stripped_as_set, router)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+
+    assert result is None, 'Failed to see an aggregated route in "{}"'.format(router)
+
+    test_func = functools.partial(_bgp_announce_route_without_as_sets, router)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+
+    assert result is None, 'Route 172.16.0.0/16 should be sent without AS_SET to r3 "{}"'.format(router)
+
+if __name__ == '__main__':
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Related: https://datatracker.ietf.org/doc/html/draft-ietf-idr-deprecate-as-set-confed-set-02

Following what BIRD already has: https://gitlab.labs.nic.cz/labs/bird/commit/a52476c9be41e8d33e4a22e3dc733240ce791b42