### PR TITLE
bgpd: Use BGP_NOTIFY_SUBCODE_UNSPECIFIC value for bgp_notify_send() where 0

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1359,8 +1359,9 @@ static int bgp_connect_success(struct peer *peer)
 		flog_err_sys(EC_LIB_SOCKET,
 			     "%s: bgp_getsockname(): failed for peer %s, fd %d",
 			     __FUNCTION__, peer->host, peer->fd);
-		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR,
-				0); /* internal error */
+		bgp_notify_send(
+			peer, BGP_NOTIFY_FSM_ERR,
+			BGP_NOTIFY_SUBCODE_UNSPECIFIC); /* internal error */
 		bgp_writes_on(peer);
 		return -1;
 	}

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1420,7 +1420,8 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			 "%s [FSM] Update packet received under status %s",
 			 peer->host,
 			 lookup_msg(bgp_status_msg, peer->status, NULL));
-		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR, 0);
+		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR,
+				BGP_NOTIFY_SUBCODE_UNSPECIFIC);
 		return BGP_Stop;
 	}
 
@@ -1792,7 +1793,8 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 			"%s [Error] Route refresh packet received under status %s",
 			peer->host,
 			lookup_msg(bgp_status_msg, peer->status, NULL));
-		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR, 0);
+		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR,
+				BGP_NOTIFY_SUBCODE_UNSPECIFIC);
 		return BGP_Stop;
 	}
 
@@ -1827,7 +1829,8 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 		    < 5) {
 			zlog_info("%s ORF route refresh length error",
 				  peer->host);
-			bgp_notify_send(peer, BGP_NOTIFY_CEASE, 0);
+			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
+					BGP_NOTIFY_SUBCODE_UNSPECIFIC);
 			return BGP_Stop;
 		}
 
@@ -2061,7 +2064,8 @@ static int bgp_capability_msg_parse(struct peer *peer, uint8_t *pnt,
 		 * length. */
 		if (pnt + 3 > end) {
 			zlog_info("%s Capability length error", peer->host);
-			bgp_notify_send(peer, BGP_NOTIFY_CEASE, 0);
+			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
+					BGP_NOTIFY_SUBCODE_UNSPECIFIC);
 			return BGP_Stop;
 		}
 		action = *pnt;
@@ -2072,7 +2076,8 @@ static int bgp_capability_msg_parse(struct peer *peer, uint8_t *pnt,
 		    && action != CAPABILITY_ACTION_UNSET) {
 			zlog_info("%s Capability Action Value error %d",
 				  peer->host, action);
-			bgp_notify_send(peer, BGP_NOTIFY_CEASE, 0);
+			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
+					BGP_NOTIFY_SUBCODE_UNSPECIFIC);
 			return BGP_Stop;
 		}
 
@@ -2084,7 +2089,8 @@ static int bgp_capability_msg_parse(struct peer *peer, uint8_t *pnt,
 		/* Capability length check. */
 		if ((pnt + hdr->length + 3) > end) {
 			zlog_info("%s Capability length error", peer->host);
-			bgp_notify_send(peer, BGP_NOTIFY_CEASE, 0);
+			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
+					BGP_NOTIFY_SUBCODE_UNSPECIFIC);
 			return BGP_Stop;
 		}
 
@@ -2188,7 +2194,8 @@ int bgp_capability_receive(struct peer *peer, bgp_size_t size)
 			"%s [Error] Dynamic capability packet received under status %s",
 			peer->host,
 			lookup_msg(bgp_status_msg, peer->status, NULL));
-		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR, 0);
+		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR,
+				BGP_NOTIFY_SUBCODE_UNSPECIFIC);
 		return BGP_Stop;
 	}
 


### PR DESCRIPTION
Just a code cleanup to keep the code consistent.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>