### PR TITLE
zebra: Allow zebra to install nexthop groups into linux kernel

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2456,7 +2456,6 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	return 0;
 }
 
-#if 0 /* Force off kernel nexthop group installs for now */
 /**
  * netlink_request_nexthop() - Request nextop information from the kernel
  * @zns:	Zebra namespace
@@ -2515,12 +2514,6 @@ int netlink_nexthop_read(struct zebra_ns *zns)
 
 	return ret;
 }
-#else
-int netlink_nexthop_read(struct zebra_ns *zns)
-{
-	return 0;
-}
-#endif
 
 
 int kernel_neigh_update(int add, int ifindex, uint32_t addr, char *lla,


### PR DESCRIPTION
This reverts commit 7d5bb02b1adf4b0e11c6e27590e0b5b3ab841baa.

Allow zebra to actually maintain the nexthop group in the
linux kernel.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>