### PR TITLE
bgpd: fix rd output in show commands for evpn routs

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -298,7 +298,7 @@ static void bgp_evpn_show_route_rd_header(struct vty *vty,
 		if (json)
 			json_object_string_add(json, "rd", rd_str);
 		else
-			vty_out(vty, "as2 %s\n", rd_str);
+			vty_out(vty, "%s\n", rd_str);
 		break;
 
 	case RD_TYPE_AS4:
@@ -307,7 +307,7 @@ static void bgp_evpn_show_route_rd_header(struct vty *vty,
 		if (json)
 			json_object_string_add(json, "rd", rd_str);
 		else
-			vty_out(vty, "as4 %s\n", rd_str);
+			vty_out(vty, "%s\n", rd_str);
 		break;
 
 	case RD_TYPE_IP:
@@ -317,7 +317,7 @@ static void bgp_evpn_show_route_rd_header(struct vty *vty,
 		if (json)
 			json_object_string_add(json, "rd", rd_str);
 		else
-			vty_out(vty, "ip %s\n", rd_str);
+			vty_out(vty, "%s\n", rd_str);
 		break;
 
 	default:
@@ -326,7 +326,7 @@ static void bgp_evpn_show_route_rd_header(struct vty *vty,
 			json_object_string_add(json, "rd", rd_str);
 		} else {
 			snprintf(rd_str, len, "Unknown RD type");
-			vty_out(vty, "ip %s\n", rd_str);
+			vty_out(vty, "%s\n", rd_str);
 		}
 		break;
 	}

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2619,10 +2619,8 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 		prefix_rd2str((struct prefix_rd *)&rd_rn->p, rd_str,
 			      sizeof(rd_str));
 
-		if (json) {
+		if (json)
 			json_rd = json_object_new_object();
-			json_object_string_add(json_rd, "rd", rd_str);
-		}
 
 		rd_header = 1;
 
@@ -2659,7 +2657,7 @@ static void evpn_show_all_routes(struct vty *vty, struct bgp *bgp, int type,
 				/* RD header - per RD. */
 				if (rd_header) {
 					bgp_evpn_show_route_rd_header(
-						vty, rd_rn, NULL, rd_str,
+						vty, rd_rn, json_rd, rd_str,
 						RD_ADDRSTRLEN);
 					rd_header = 0;
 				}


### PR DESCRIPTION
PR 5118 introduce additional (prepend) keywords
like 'ip' to Route Distinguisher output which
breaks existing evpn route show commands parsing.

Restore to original behavior.

Testing Done:

vtysh -c 'show bgp l2vpn evpn route'

Before fix:
Route Distinguisher: ip 27.0.0.15:44

Post fix:
Route Distinguisher: 27.0.0.15:44

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>
