### PR TITLE
bgpd: fix memory leak in vni-vrf route tables for evpn routes

### DIFF
--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2583,6 +2583,8 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 	/* Process for route leaking. */
 	vpn_leak_from_vrf_update(bgp_get_default(), bgp_vrf, pi);
 
+	bgp_unlock_node(rn);
+
 	return ret;
 }
 

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -2638,6 +2638,8 @@ static int install_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	/* Perform route selection and update zebra, if required. */
 	ret = evpn_route_select_install(bgp, vpn, rn);
 
+	bgp_unlock_node(rn);
+
 	return ret;
 }
 


### PR DESCRIPTION
1) bgpd: fix memory leak in vni table for evpn routes

There is a memory leak of the bgp node (route node)
in vni table while processing evpn remote route(s).

During the remote evpn route processing, a new route
is created in per vni route table, the refcount for
the route node is incremented twice. First refcount
is incremented during the node creation and the second
one when the bgp_info_add is added.

Post evpn route creation, the bgp node refcount needs
to be decremented.

Testing Done:

In EVPN topology send 1K MAC routes then check the memory footprint
at the remote VTEP before sending 1K type-2 routes
and after flushing/withdrawal of the routes.
```
Before fix:
-----------
Initial memory footprint:
root@TOR1:~# vtysh -c "show memory" | grep "Hash Bucket \|BGP node \|BGP route"
Hash Bucket                   :       2008      32
BGP node                      :        182     152
BGP route                     :         96     112

With 1K MAC (type-2 routes)
root@TOR1:~# vtysh -c "show memory" | grep "Hash Bucket \|BGP node \|BGP route"
Hash Bucket                   :       6008      32
BGP node                      :       4182     152
BGP route                     :       2096     112

After cleaning up 1K MAC entries from source VTEP which triggers BGP withdraw
at the remote VTEP.
root@TOR1:~# vtysh -c "show memory" | grep "Hash Bucket \|BGP node \|BGP route"
Hash Bucket                   :       4008      32
BGP node                      :       2182     152   <-- Here 2K delta from initial count.
BGP route                     :         96     112

With fix:
---------

After 1K MAC entries cleaned up at the remote VTEP, the memory footprint
(BGP Node and Hash Bucket count) is equilibrium to start of the test.
root@TOR1:~# vtysh -c "show memory" | grep "Hash Bucket \|BGP node \|BGP route"
Hash Bucket                   :       2008      32
BGP node                      :        182     152
BGP route                     :         96     112
```
2) bgpd: fix memory leak in vrf inst for evpn route

There is a memory leak of the bgp node (route node)
in bgp vrf rib table while processing evpn remote routes.

During the remote evpn route processing, a new route
is imported and created in per vrf bgp rib route table,
the refcount for the route node is incremented multiple
times.

Post evpn route creation, the bgp (route) node refcount needs
to be decremented.
```
Before fix:
----------
initial state:
TORC1#vtysh -c "show memory"
BGP node                      :      515    184
BGP route                     :      568    112

with 1 mac-ip route:
TORC1#vtysh -c "show memory"
BGP node                      :      524    184
BGP route                     :      583    112

withdraw 1 mac-ip route:
TORC1#vtysh -c "show memory"
BGP node                      :      520    184
BGP route                     :      568    112

After fix:
withdra 1 mac-ip route
TORC1#vtysh -c "show memory"
BGP node                      :      515    184
BGP route                     :      568    112
```
Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>