### PR TITLE
zebra: Some Zebra_NHG fixes found with the ISIS-SR topotests

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -570,14 +570,6 @@ void rib_install_kernel(struct route_node *rn, struct route_entry *re,
 				nexthops_free(old->fib_ng.nexthop);
 				old->fib_ng.nexthop = NULL;
 			}
-
-			if (!RIB_SYSTEM_ROUTE(old)) {
-				/* Clear old route's FIB flags */
-				for (ALL_NEXTHOPS_PTR(old->ng, nexthop)) {
-					UNSET_FLAG(nexthop->flags,
-						   NEXTHOP_FLAG_FIB);
-				}
-			}
 		}
 
 		if (zvrf)


### PR DESCRIPTION
@rwestphal reported a zebra crash with the new ISIS-SR topotests found here: https://github.com/opensourcerouting/frr/tree/SR-isis-osr

```
    ==23== Thread 1:
    ==23== Invalid read of size 4
    ==23==    at 0x15B20E: zebra_nhg_hash_equal (zebra_nhg.c:365)
    ==23==    by 0x489A2FD: hash_get (hash.c:143)
    ==23==    by 0x489A4BC: hash_lookup (hash.c:183)
    ==23==    by 0x15B5A3: zebra_nhg_find (zebra_nhg.c:494)
    ==23==    by 0x15C536: zebra_nhg_rib_find (zebra_nhg.c:1070)
    ==23==    by 0x1573E8: mpls_ftn_update (zebra_mpls.c:2661)
    ==23==    by 0x1A2554: zread_mpls_labels_replace (zapi_msg.c:1890)
    ==23==    by 0x1A41CD: zserv_handle_commands (zapi_msg.c:2613)
    ==23==    by 0x199B17: zserv_process_messages (zserv.c:517)
    ==23==    by 0x48EE6B7: thread_call (thread.c:1549)
    ==23==    by 0x48A8AD5: frr_run (libfrr.c:1064)
    ==23==    by 0x1391B7: main (main.c:468)
    ==23==  Address 0x5839330 is 0 bytes inside a block of size 80 free'd
    ==23==    at 0x48369AB: free (vg_replace_malloc.c:530)
    ==23==    by 0x48AEE6C: qfree (memory.c:129)
    ==23==    by 0x15C5F8: zebra_nhg_free (zebra_nhg.c:1095)
    ==23==    by 0x15BC8C: zebra_nhg_handle_uninstall (zebra_nhg.c:734)
    ==23==    by 0x15DCFA: zebra_nhg_uninstall_kernel (zebra_nhg.c:1826)
    ==23==    by 0x15C666: zebra_nhg_decrement_ref (zebra_nhg.c:1106)
    ==23==    by 0x15D9D7: zebra_nhg_re_update_ref (zebra_nhg.c:1711)
    ==23==    by 0x15D8B1: nexthop_active_update (zebra_nhg.c:1660)
    ==23==    by 0x167072: rib_process (zebra_rib.c:1154)
    ==23==    by 0x168D72: process_subq_route (zebra_rib.c:2039)
    ==23==    by 0x168E92: process_subq (zebra_rib.c:2078)
    ==23==    by 0x168F5B: meta_queue_process (zebra_rib.c:2112)
    ==23==  Block was alloc'd at
    ==23==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
    ==23==    by 0x48AED56: qcalloc (memory.c:110)
    ==23==    by 0x15B07B: zebra_nhg_copy (zebra_nhg.c:307)
    ==23==    by 0x15B13E: zebra_nhg_hash_alloc (zebra_nhg.c:329)
    ==23==    by 0x489A339: hash_get (hash.c:148)
    ==23==    by 0x15B6CA: zebra_nhg_find (zebra_nhg.c:532)
    ==23==    by 0x15C536: zebra_nhg_rib_find (zebra_nhg.c:1070)
    ==23==    by 0x15D89A: nexthop_active_update (zebra_nhg.c:1658)
    ==23==    by 0x167072: rib_process (zebra_rib.c:1154)
    ==23==    by 0x168D72: process_subq_route (zebra_rib.c:2039)
    ==23==    by 0x168E92: process_subq (zebra_rib.c:2078)
    ==23==    by 0x168F5B: meta_queue_process (zebra_rib.c:2112)
```

These patches fixes the crash and some other issues discovered with his tests.

@mjstapp please review the second commit in particular.