### PR TITLE
[7.2] lib: Remove include of deprecated sysctl.h

### DIFF
--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -52,10 +52,9 @@ typedef unsigned char uint8_t;
 #include <sys/types.h>
 #include <sys/param.h>
 #ifdef HAVE_SYS_SYSCTL_H
-#ifdef GNU_LINUX
-#include <linux/types.h>
-#endif
+#ifndef GNU_LINUX
 #include <sys/sysctl.h>
+#endif
 #endif /* HAVE_SYS_SYSCTL_H */
 #include <sys/ioctl.h>
 #ifdef HAVE_SYS_CONF_H


### PR DESCRIPTION
backport #5213.