### PR TITLE
Pim igmp ignore from ourself

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -619,7 +619,7 @@ static int on_ifjoin_expiry_timer(struct thread *t)
 
 	ch = THREAD_ARG(t);
 
-	if (PIM_DEBUG_TRACE)
+	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug("%s: ifchannel %s expiry timer", __PRETTY_FUNCTION__,
 			   ch->sg_str);
 
@@ -638,7 +638,7 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
 
 	ch = THREAD_ARG(t);
 
-	if (PIM_DEBUG_TRACE)
+	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug(
 			"%s: IFCHANNEL%s %s Prune Pending Timer Popped",
 			__PRETTY_FUNCTION__, pim_str_sg_dump(&ch->sg),
@@ -947,7 +947,7 @@ void pim_ifchannel_prune(struct interface *ifp, struct in_addr upstream,
 
 	ch = pim_ifchannel_find(ifp, sg);
 	if (!ch && !(source_flags & PIM_ENCODE_RPT_BIT)) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"%s: Received prune with no relevant ifchannel %s%s state: %d",
 				__PRETTY_FUNCTION__, ifp->name,

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -478,21 +478,14 @@ int pim_igmp_packet(struct igmp_sock *igmp, char *buf, size_t len)
 
 	ip_hlen = ip_hdr->ip_hl << 2; /* ip_hl gives length in 4-byte words */
 
-	if (PIM_DEBUG_IGMP_PACKETS) {
-		zlog_debug(
-			"Recv IP packet from %s to %s on %s: size=%zu ip_header_size=%zu ip_proto=%d",
-			from_str, to_str, igmp->interface->name, len, ip_hlen,
-			ip_hdr->ip_p);
-	}
-
 	igmp_msg = buf + ip_hlen;
 	msg_type = *igmp_msg;
 	igmp_msg_len = len - ip_hlen;
 
 	if (PIM_DEBUG_IGMP_PACKETS) {
 		zlog_debug(
-			"Recv IGMP packet from %s to %s on %s: ttl=%d msg_type=%d msg_size=%d",
-			from_str, to_str, igmp->interface->name, ip_hdr->ip_ttl,
+			"Recv IGMP packet from %s to %s on %s: size=%zu ttl=%d msg_type=%d msg_size=%d",
+			from_str, to_str, igmp->interface->name, len, ip_hdr->ip_ttl,
 			msg_type, igmp_msg_len);
 	}
 

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -312,6 +312,13 @@ static int igmp_recv_query(struct igmp_sock *igmp, int query_version,
 		return 0;
 	}
 
+	if (if_lookup_address(&from, AF_INET, ifp->vrf_id)) {
+		if (PIM_DEBUG_IGMP_PACKETS)
+			zlog_debug("Recv IGMP query on interface: %s from ourself %s",
+				   ifp->name, from_str);
+		return 0;
+	}
+
 	/* Collecting IGMP Rx stats */
 	switch (query_version) {
 	case 1:

--- a/pimd/pim_igmpv3.c
+++ b/pimd/pim_igmpv3.c
@@ -1927,7 +1927,7 @@ int igmp_v3_recv_report(struct igmp_sock *igmp, struct in_addr from,
 
 		if (PIM_DEBUG_IGMP_PACKETS) {
 			zlog_debug(
-				"Recv IGMP report v3 from %s on %s: record=%d type=%d auxdatalen=%d sources=%d group=%s",
+				"    Recv IGMP report v3 from %s on %s: record=%d type=%d auxdatalen=%d sources=%d group=%s",
 				from_str, ifp->name, i, rec_type,
 				rec_auxdatalen, rec_num_sources,
 				inet_ntoa(rec_group));
@@ -1954,7 +1954,7 @@ int igmp_v3_recv_report(struct igmp_sock *igmp, struct in_addr from,
 					sprintf(src_str, "<source?>");
 
 				zlog_debug(
-					"Recv IGMP report v3 from %s on %s: record=%d group=%s source=%s",
+					"        Recv IGMP report v3 from %s on %s: record=%d group=%s source=%s",
 					from_str, ifp->name, i,
 					inet_ntoa(rec_group), src_str);
 			}

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -332,7 +332,7 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 				struct pim_upstream *up = sg_ch->upstream;
 				PIM_IF_FLAG_SET_S_G_RPT(sg_ch->flags);
 				if (up) {
-					if (PIM_DEBUG_TRACE)
+					if (PIM_DEBUG_PIM_TRACE)
 						zlog_debug(
 							"%s: SGRpt flag is set, del inherit oif from up %s",
 							__PRETTY_FUNCTION__,

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -217,7 +217,7 @@ void pim_jp_agg_upstream_verification(struct pim_upstream *up, bool ignore)
 	struct pim_instance *pim;
 
 	if (!up->rpf.source_nexthop.interface) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: up %s RPF is not present",
 				__PRETTY_FUNCTION__, up->sg_str);
 		return;

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -300,7 +300,7 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 	}
 
 	if (!up->rpf.source_nexthop.interface) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: up %s RPF is not present",
 				__PRETTY_FUNCTION__, up->sg_str);
 		return 0;

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -232,7 +232,7 @@ void pim_null_register_send(struct pim_upstream *up)
 
 	pim_ifp = up->rpf.source_nexthop.interface->info;
 	if (!pim_ifp) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"%s: Cannot send null-register for %s no valid iif",
 				__PRETTY_FUNCTION__, up->sg_str);
@@ -241,7 +241,7 @@ void pim_null_register_send(struct pim_upstream *up)
 
 	rpg = RP(pim_ifp->pim, up->sg.grp);
 	if (!rpg) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"%s: Cannot send null-register for %s no RPF to the RP",
 				__PRETTY_FUNCTION__, up->sg_str);
@@ -260,7 +260,7 @@ void pim_null_register_send(struct pim_upstream *up)
 	src = pim_ifp->primary_address;
 	if (PIM_UPSTREAM_FLAG_TEST_SRC_VXLAN_ORIG(up->flags)) {
 		if (!pim_vxlan_get_register_src(pim_ifp->pim, up, &src)) {
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"%s: Cannot send null-register for %s vxlan-aa PIP unavailable",
 					__PRETTY_FUNCTION__, up->sg_str);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -131,7 +131,7 @@ void pim_rp_init(struct pim_instance *pim)
 
 	rn = route_node_get(pim->rp_table, &rp_info->group);
 	rn->info = rp_info;
-	if (PIM_DEBUG_TRACE)
+	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug(
 			"Allocated: %p for rp_info: %p(224.0.0.0/4) Lock: %d",
 			rn, rp_info, rn->lock);
@@ -245,7 +245,7 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 	}
 
 	rp_info = rn->info;
-	if (PIM_DEBUG_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE) {
 		char buf[PREFIX_STRLEN];
 
 		route_unlock_node(rn);
@@ -348,7 +348,7 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 	pim_rp_set_upstream_addr(pim, &new_upstream_addr, up->sg.src,
 				 up->sg.grp);
 
-	if (PIM_DEBUG_TRACE)
+	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug("%s: pim upstream update for  old upstream %s",
 			   __PRETTY_FUNCTION__,
 			   inet_ntoa(old_upstream_addr));
@@ -366,7 +366,7 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 		nht_p.family = AF_INET;
 		nht_p.prefixlen = IPV4_MAX_BITLEN;
 		nht_p.u.prefix4 = old_upstream_addr;
-		if (PIM_DEBUG_TRACE) {
+		if (PIM_DEBUG_PIM_TRACE) {
 			char buf[PREFIX2STR_BUFFER];
 
 			prefix2str(&nht_p, buf, sizeof(buf));
@@ -646,7 +646,7 @@ int pim_rp_new(struct pim_instance *pim, struct in_addr rp_addr,
 	rn = route_node_get(pim->rp_table, &rp_info->group);
 	rn->info = rp_info;
 
-	if (PIM_DEBUG_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE) {
 		char buf[PREFIX_STRLEN];
 
 		zlog_debug("Allocated: %p for rp_info: %p(%s) Lock: %d", rn,
@@ -751,7 +751,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 		was_plist = true;
 	}
 
-	if (PIM_DEBUG_TRACE)
+	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug("%s: Delete RP %s for the group %s",
 			   __PRETTY_FUNCTION__, rp_str, grp_str);
 
@@ -765,7 +765,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 		if (bsgrp) {
 			bsrp = listnode_head(bsgrp->bsrp_list);
 			if (bsrp) {
-				if (PIM_DEBUG_TRACE) {
+				if (PIM_DEBUG_PIM_TRACE) {
 					char bsrp_str[INET_ADDRSTRLEN];
 
 					if (!inet_ntop(AF_INET, bsrp, bsrp_str,
@@ -780,7 +780,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 						     group, RP_SRC_BSR);
 			}
 		} else {
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"%s: BSM RP not found for the group %s",
 					__PRETTY_FUNCTION__, grp_str);
@@ -839,7 +839,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 					EC_LIB_DEVELOPMENT,
 					"Expected rn->info to be equal to rp_info");
 
-			if (PIM_DEBUG_TRACE) {
+			if (PIM_DEBUG_PIM_TRACE) {
 				char buf[PREFIX_STRLEN];
 
 				zlog_debug(

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -42,7 +42,7 @@ static struct in_addr pim_rpf_find_rpf_addr(struct pim_upstream *up);
 void pim_rpf_set_refresh_time(struct pim_instance *pim)
 {
 	pim->last_route_change_time = pim_time_monotonic_usec();
-	if (PIM_DEBUG_TRACE)
+	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug("%s: vrf(%s) New last route change time: %" PRId64,
 			   __PRETTY_FUNCTION__, pim->vrf->name,
 			   pim->last_route_change_time);
@@ -69,7 +69,7 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 
 	if ((nexthop->last_lookup.s_addr == addr.s_addr)
 	    && (nexthop->last_lookup_time > pim->last_route_change_time)) {
-		if (PIM_DEBUG_TRACE) {
+		if (PIM_DEBUG_PIM_NHT) {
 			char addr_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<addr?>", addr, addr_str,
 				       sizeof(addr_str));
@@ -85,7 +85,7 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 		pim->nexthop_lookups_avoided++;
 		return true;
 	} else {
-		if (PIM_DEBUG_TRACE) {
+		if (PIM_DEBUG_PIM_NHT) {
 			char addr_str[INET_ADDRSTRLEN];
 			pim_inet4_dump("<addr?>", addr, addr_str,
 				       sizeof(addr_str));

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -159,7 +159,7 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 	bool notify_msdp = false;
 	struct prefix nht_p;
 
-	if (PIM_DEBUG_TRACE)
+	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug(
 			"%s(%s): Delete %s[%s] ref count: %d , flags: %d c_oil ref count %d (Pre decrement)",
 			__PRETTY_FUNCTION__, name, up->sg_str, pim->vrf->name,
@@ -231,7 +231,7 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 		nht_p.family = AF_INET;
 		nht_p.prefixlen = IPV4_MAX_BITLEN;
 		nht_p.u.prefix4 = up->upstream_addr;
-		if (PIM_DEBUG_TRACE) {
+		if (PIM_DEBUG_PIM_TRACE) {
 			char buf[PREFIX2STR_BUFFER];
 			prefix2str(&nht_p, buf, sizeof(buf));
 			zlog_debug("%s: Deregister upstream %s addr %s with Zebra NHT",
@@ -248,13 +248,13 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 void pim_upstream_send_join(struct pim_upstream *up)
 {
 	if (!up->rpf.source_nexthop.interface) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: up %s RPF is not present",
 				__PRETTY_FUNCTION__, up->sg_str);
 		return;
 	}
 
-	if (PIM_DEBUG_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE) {
 		char rpf_str[PREFIX_STRLEN];
 		pim_addr_dump("<rpf?>", &up->rpf.rpf_addr, rpf_str,
 			      sizeof(rpf_str));
@@ -280,7 +280,7 @@ static int on_join_timer(struct thread *t)
 	up = THREAD_ARG(t);
 
 	if (!up->rpf.source_nexthop.interface) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: up %s RPF is not present",
 			__PRETTY_FUNCTION__, up->sg_str);
 		return 0;
@@ -381,7 +381,7 @@ void pim_upstream_join_suppress(struct pim_upstream *up,
 	long join_timer_remain_msec;
 
 	if (!up->rpf.source_nexthop.interface) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: up %s RPF is not present",
 				__PRETTY_FUNCTION__, up->sg_str);
 		return;
@@ -393,7 +393,7 @@ void pim_upstream_join_suppress(struct pim_upstream *up,
 
 	join_timer_remain_msec = pim_time_timer_remain_msec(up->t_join_timer);
 
-	if (PIM_DEBUG_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE) {
 		char rpf_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<rpf?>", rpf_addr, rpf_str, sizeof(rpf_str));
 		zlog_debug(
@@ -403,7 +403,7 @@ void pim_upstream_join_suppress(struct pim_upstream *up,
 	}
 
 	if (join_timer_remain_msec < t_joinsuppress_msec) {
-		if (PIM_DEBUG_TRACE) {
+		if (PIM_DEBUG_PIM_TRACE) {
 			zlog_debug(
 				"%s %s: suppressing Join(S,G)=%s for %ld msec",
 				__FILE__, __PRETTY_FUNCTION__, up->sg_str,
@@ -421,7 +421,7 @@ void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
 	int t_override_msec;
 
 	if (!up->rpf.source_nexthop.interface) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: up %s RPF is not present",
 				__PRETTY_FUNCTION__, up->sg_str);
 		return;
@@ -431,7 +431,7 @@ void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
 	t_override_msec =
 		pim_if_t_override_msec(up->rpf.source_nexthop.interface);
 
-	if (PIM_DEBUG_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE) {
 		char rpf_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<rpf?>", up->rpf.rpf_addr.u.prefix4, rpf_str,
 			       sizeof(rpf_str));
@@ -442,7 +442,7 @@ void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
 	}
 
 	if (join_timer_remain_msec > t_override_msec) {
-		if (PIM_DEBUG_TRACE) {
+		if (PIM_DEBUG_PIM_TRACE) {
 			zlog_debug(
 				"%s: decreasing (S,G)=%s join timer to t_override=%d msec",
 				debug_label, up->sg_str, t_override_msec);
@@ -494,7 +494,7 @@ static int pim_upstream_could_register(struct pim_upstream *up)
 	if (up->rpf.source_nexthop.interface)
 		pim_ifp = up->rpf.source_nexthop.interface->info;
 	else {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: up %s RPF is not present",
 				   __PRETTY_FUNCTION__, up->sg_str);
 	}
@@ -694,7 +694,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 	 */
 	if (!pim_rp_set_upstream_addr(pim, &up->upstream_addr, sg->src,
 				      sg->grp)) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: Received a (*,G) with no RP configured",
 				   __PRETTY_FUNCTION__);
 	}
@@ -752,7 +752,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 	} else if (up->upstream_addr.s_addr != INADDR_ANY) {
 		rpf_result = pim_rpf_update(pim, up, NULL);
 		if (rpf_result == PIM_RPF_FAILURE) {
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"%s: Attempting to create upstream(%s), Unable to RPF for source",
 					__PRETTY_FUNCTION__, up->sg_str);
@@ -770,7 +770,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 
 	listnode_add_sort(pim->upstream_list, up);
 
-	if (PIM_DEBUG_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE) {
 		zlog_debug(
 			"%s: Created Upstream %s upstream_addr %s ref count %d increment",
 			__PRETTY_FUNCTION__, up->sg_str,
@@ -806,7 +806,7 @@ struct pim_upstream *pim_upstream_find_or_add(struct prefix_sg *sg,
 		if (!(up->flags & flags)) {
 			up->flags |= flags;
 			up->ref_count++;
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"%s(%s): upstream %s ref count %d increment",
 					__PRETTY_FUNCTION__, name, up->sg_str,
@@ -823,7 +823,7 @@ void pim_upstream_ref(struct pim_upstream *up, int flags, const char *name)
 {
 	up->flags |= flags;
 	++up->ref_count;
-	if (PIM_DEBUG_TRACE)
+	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug("%s(%s): upstream %s ref count %d increment",
 			   __PRETTY_FUNCTION__, name, up->sg_str,
 			   up->ref_count);
@@ -846,7 +846,7 @@ struct pim_upstream *pim_upstream_add(struct pim_instance *pim,
 		up = pim_upstream_new(pim, sg, incoming, flags, ch);
 	}
 
-	if (PIM_DEBUG_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE) {
 		if (up) {
 			char buf[PREFIX2STR_BUFFER];
 			prefix2str(&up->rpf.rpf_addr, buf, sizeof(buf));
@@ -999,7 +999,7 @@ void pim_upstream_rpf_genid_changed(struct pim_instance *pim,
 	 */
 	for (ALL_LIST_ELEMENTS(pim->upstream_list, up_node, up_nextnode, up)) {
 
-		if (PIM_DEBUG_TRACE) {
+		if (PIM_DEBUG_PIM_TRACE) {
 			char neigh_str[INET_ADDRSTRLEN];
 			char rpf_addr_str[PREFIX_STRLEN];
 			pim_inet4_dump("<neigh?>", neigh_addr, neigh_str,
@@ -1108,7 +1108,7 @@ static void pim_upstream_fhr_kat_expiry(struct pim_instance *pim,
 	if (!PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
 		return;
 
-	if (PIM_DEBUG_TRACE)
+	if (PIM_DEBUG_PIM_TRACE)
 		zlog_debug("kat expired on %s; clear fhr reg state",
 			   up->sg_str);
 
@@ -1128,7 +1128,7 @@ static void pim_upstream_fhr_kat_expiry(struct pim_instance *pim,
 static void pim_upstream_fhr_kat_start(struct pim_upstream *up)
 {
 	if (pim_upstream_could_register(up)) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"kat started on %s; set fhr reg state to joined",
 				up->sg_str);
@@ -1174,7 +1174,7 @@ struct pim_upstream *pim_upstream_keep_alive_timer_proc(
 	/* if entry was created because of activity we need to deref it */
 	if (PIM_UPSTREAM_FLAG_TEST_SRC_STREAM(up->flags)) {
 		pim_upstream_fhr_kat_expiry(pim, up);
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"kat expired on %s[%s]; remove stream reference",
 				up->sg_str, pim->vrf->name);
@@ -1222,7 +1222,7 @@ static int pim_upstream_keep_alive_timer(struct thread *t)
 void pim_upstream_keep_alive_timer_start(struct pim_upstream *up, uint32_t time)
 {
 	if (!PIM_UPSTREAM_FLAG_TEST_SRC_STREAM(up->flags)) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("kat start on %s with no stream reference",
 				   up->sg_str);
 	}
@@ -1326,7 +1326,7 @@ void pim_upstream_set_sptbit(struct pim_upstream *up,
 
 	// iif == RPF_interfvace(S)
 	if (up->rpf.source_nexthop.interface != incoming) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"%s: Incoming Interface: %s is different than RPF_interface(S) %s",
 				__PRETTY_FUNCTION__, incoming->name,
@@ -1336,7 +1336,7 @@ void pim_upstream_set_sptbit(struct pim_upstream *up,
 
 	// AND JoinDesired(S,G) == true
 	if (!pim_upstream_evaluate_join_desired(up->channel_oil->pim, up)) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: %s Join is not Desired",
 				   __PRETTY_FUNCTION__, up->sg_str);
 		return;
@@ -1345,7 +1345,7 @@ void pim_upstream_set_sptbit(struct pim_upstream *up,
 	// DirectlyConnected(S) == true
 	if (pim_if_connected_to_source(up->rpf.source_nexthop.interface,
 				       up->sg.src)) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: %s is directly connected to the source",
 				   __PRETTY_FUNCTION__, up->sg_str);
 		up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
@@ -1358,7 +1358,7 @@ void pim_upstream_set_sptbit(struct pim_upstream *up,
 			       .interface != starup->rpf.source_nexthop.interface) {
 		struct pim_upstream *starup = up->parent;
 
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"%s: %s RPF_interface(S) != RPF_interface(RP(G))",
 				__PRETTY_FUNCTION__, up->sg_str);
@@ -1371,7 +1371,7 @@ void pim_upstream_set_sptbit(struct pim_upstream *up,
 	// OR inherited_olist(S,G,rpt) == NULL
 	if (pim_upstream_is_sg_rpt(up)
 	    && pim_upstream_empty_inherited_olist(up)) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: %s OR inherited_olist(S,G,rpt) == NULL",
 				   __PRETTY_FUNCTION__, up->sg_str);
 		up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
@@ -1381,7 +1381,7 @@ void pim_upstream_set_sptbit(struct pim_upstream *up,
 	// OR ( ( RPF'(S,G) == RPF'(*,G) ) AND
 	//      ( RPF'(S,G) != NULL ) )
 	if (up->parent && pim_rpf_is_same(&up->rpf, &up->parent->rpf)) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: %s RPF'(S,G) is the same as RPF'(*,G)",
 				   __PRETTY_FUNCTION__, up->sg_str);
 		up->sptbit = PIM_UPSTREAM_SPTBIT_TRUE;
@@ -1434,7 +1434,7 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 	up = THREAD_ARG(t);
 	pim = up->channel_oil->pim;
 
-	if (PIM_DEBUG_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE) {
 		char state_str[PIM_REG_STATE_STR_LEN];
 		zlog_debug("%s: (S,G)=%s[%s] upstream register stop timer %s",
 			   __PRETTY_FUNCTION__, up->sg_str, pim->vrf->name,
@@ -1452,7 +1452,7 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 		break;
 	case PIM_REG_PRUNE:
 		if (!up->rpf.source_nexthop.interface) {
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug("%s: up %s RPF is not present",
 					__PRETTY_FUNCTION__, up->sg_str);
 			return 0;
@@ -1460,7 +1460,7 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 
 		pim_ifp = up->rpf.source_nexthop.interface->info;
 		if (!pim_ifp) {
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"%s: Interface: %s is not configured for pim",
 					__PRETTY_FUNCTION__,
@@ -1473,7 +1473,7 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 		if (((up->channel_oil->cc.lastused / 100)
 		     > pim->keep_alive_time)
 		    && (I_am_RP(pim_ifp->pim, up->sg.grp))) {
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"%s: Stop sending the register, because I am the RP and we haven't seen a packet in a while",
 					__PRETTY_FUNCTION__);
@@ -1503,7 +1503,7 @@ void pim_upstream_start_register_stop_timer(struct pim_upstream *up,
 	} else
 		time = PIM_REGISTER_PROBE_PERIOD;
 
-	if (PIM_DEBUG_TRACE) {
+	if (PIM_DEBUG_PIM_TRACE) {
 		zlog_debug(
 			"%s: (S,G)=%s Starting upstream register stop timer %d",
 			__PRETTY_FUNCTION__, up->sg_str, time);
@@ -1521,7 +1521,7 @@ int pim_upstream_inherited_olist_decide(struct pim_instance *pim,
 	int output_intf = 0;
 
 	if (!up->rpf.source_nexthop.interface)
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: up %s RPF is not present",
 				   __PRETTY_FUNCTION__, up->sg_str);
 
@@ -1611,7 +1611,7 @@ void pim_upstream_find_new_rpf(struct pim_instance *pim)
 	 */
 	for (ALL_LIST_ELEMENTS(pim->upstream_list, up_node, up_nextnode, up)) {
 		if (up->upstream_addr.s_addr == INADDR_ANY) {
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 				    "%s: RP not configured for Upstream %s",
 				    __PRETTY_FUNCTION__, up->sg_str);
@@ -1619,7 +1619,7 @@ void pim_upstream_find_new_rpf(struct pim_instance *pim)
 		}
 
 		if (pim_rpf_addr_is_inaddr_any(&up->rpf)) {
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"%s: Upstream %s without a path to send join, checking",
 					__PRETTY_FUNCTION__, up->sg_str);
@@ -1725,7 +1725,7 @@ static void pim_upstream_sg_running(void *arg)
 
 	// No packet can have arrived here if this is the case
 	if (!up->channel_oil->installed) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug("%s: %s%s is not installed in mroute",
 				   __PRETTY_FUNCTION__, up->sg_str,
 				   pim->vrf->name);
@@ -1741,7 +1741,7 @@ static void pim_upstream_sg_running(void *arg)
 	 * to get us up and working for the moment
 	 */
 	if (up->channel_oil->oil_inherited_rescan) {
-		if (PIM_DEBUG_TRACE)
+		if (PIM_DEBUG_PIM_TRACE)
 			zlog_debug(
 				"%s: Handling unscanned inherited_olist for %s[%s]",
 				__PRETTY_FUNCTION__, up->sg_str,
@@ -1754,7 +1754,7 @@ static void pim_upstream_sg_running(void *arg)
 	// Have we seen packets?
 	if ((up->channel_oil->cc.oldpktcnt >= up->channel_oil->cc.pktcnt)
 	    && (up->channel_oil->cc.lastused / 100 > 30)) {
-		if (PIM_DEBUG_TRACE) {
+		if (PIM_DEBUG_PIM_TRACE) {
 			zlog_debug(
 				"%s[%s]: %s old packet count is equal or lastused is greater than 30, (%ld,%ld,%lld)",
 				__PRETTY_FUNCTION__, up->sg_str, pim->vrf->name,
@@ -1769,7 +1769,7 @@ static void pim_upstream_sg_running(void *arg)
 		/* Add a source reference to the stream if
 		 * one doesn't already exist */
 		if (!PIM_UPSTREAM_FLAG_TEST_SRC_STREAM(up->flags)) {
-			if (PIM_DEBUG_TRACE)
+			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
 					"source reference created on kat restart %s[%s]",
 					up->sg_str, pim->vrf->name);


### PR DESCRIPTION
See individual commits but:

a) We are receiving( in some cases ) our own query back up the pim kernel socket.  Drop early and often in this case.

b) Cleanup debugs in pim to be a bit better behaved and to allow you to know what is going on a bit better in some cases.