### PR TITLE
zebra: dplane cancel update thread from correct pthread

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3752,7 +3752,9 @@ void zebra_dplane_shutdown(void)
 
 	zdplane_info.dg_run = false;
 
-	THREAD_OFF(zdplane_info.dg_t_update);
+	if (zdplane_info.dg_t_update)
+		thread_cancel_async(zdplane_info.dg_t_update->master,
+				    &zdplane_info.dg_t_update, NULL);
 
 	frr_pthread_stop(zdplane_info.dg_pthread, NULL);
 


### PR DESCRIPTION
This code is called from the zebra main pthread during shutdown
but the thread event is scheduled via the zebra dplane pthread.

Hence, we should be using the `thread_cancel_async()` API to
cancel the thread event on a different pthread.

This is only ever hit in the rare case that we still have work left
to do on the update queue during shutdown.

Found via zebra crash:

```
(gdb) bt
\#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
\#1  0x00007f4e4d3f7535 in __GI_abort () at abort.c:79
\#2  0x00007f4e4d3f740f in __assert_fail_base (fmt=0x7f4e4d559ee0 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x7f4e4d9071d0 "master->owner == pthread_self()",
    file=0x7f4e4d906cf8 "lib/thread.c", line=1185, function=<optimized out>) at assert.c:92
\#3  0x00007f4e4d405102 in __GI___assert_fail (assertion=assertion@entry=0x7f4e4d9071d0 "master->owner == pthread_self()", file=file@entry=0x7f4e4d906cf8 "lib/thread.c",
    line=line@entry=1185, function=function@entry=0x7f4e4d906b68 <__PRETTY_FUNCTION__.15817> "thread_cancel") at assert.c:101
\#4  0x00007f4e4d8d095a in thread_cancel (thread=0x55b40d01a640) at lib/thread.c:1185
\#5  0x000055b40c291845 in zebra_dplane_shutdown () at zebra/zebra_dplane.c:3274
\#6  0x000055b40c27ee13 in zebra_finalize (dummy=<optimized out>) at zebra/main.c:202
\#7  0x00007f4e4d8d1416 in thread_call (thread=thread@entry=0x7ffcbbc08870) at lib/thread.c:1599
\#8  0x00007f4e4d8a1ef8 in frr_run (master=0x55b40ce35510) at lib/libfrr.c:1024
\#9  0x000055b40c270916 in main (argc=8, argv=0x7ffcbbc08c78) at zebra/main.c:483
(gdb) down
\#4  0x00007f4e4d8d095a in thread_cancel (thread=0x55b40d01a640) at lib/thread.c:1185
1185		assert(master->owner == pthread_self());
(gdb)
```

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>
