### PR TITLE
bgpd: Bug fix in "show bgp l2vpn evpn ... advertised-routes'

### DIFF
--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -106,6 +106,9 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 			if (bgp_node_get_bgp_path_info(rm) == NULL)
 				continue;
 
+			if (!attr)
+				continue;
+
 			if (header) {
 				if (use_json) {
 					json_object_int_add(


### PR DESCRIPTION
The bug:
As part of displaying advertised routes to a peer, in the outer loop, we
iterate through all prefixes in the evpn table. In the inner loop,
we iterate through adj_out of each prefix.

If a prefix which is present in the evpn table is not advertised to a peer,
its corresponding attr == NULL. Checking for this condition is the fix.

Signed-off-by: Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>