### PR TITLE
bgpd: route-map support for evpn RD filter

### DIFF
--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -969,6 +969,65 @@ struct route_map_rule_cmd route_match_evpn_route_type_cmd = {
 	"evpn route-type", route_match_evpn_route_type,
 	route_match_evpn_route_type_compile, route_match_evpn_route_type_free};
 
+/* `match rd' */
+
+/* Match function should return 1 if match is success else return zero. */
+static enum route_map_cmd_result_t
+route_match_rd(void *rule, const struct prefix *prefix,
+	       route_map_object_t type, void *object)
+{
+	struct prefix_rd *prd_rule = NULL;
+	struct prefix_rd *prd_route = NULL;
+	struct bgp_path_info *path = NULL;
+
+	if (type == RMAP_BGP) {
+		if (prefix->family != AF_EVPN)
+			return RMAP_NOMATCH;
+
+		prd_rule = (struct prefix_rd *)rule;
+		path = (struct bgp_path_info *)object;
+
+		if (path->net == NULL || path->net->prn == NULL)
+			return RMAP_NOMATCH;
+
+		prd_route = (struct prefix_rd *)&path->net->prn->p;
+		if (memcmp(prd_route->val, prd_rule->val, ECOMMUNITY_SIZE) == 0)
+			return RMAP_MATCH;
+	}
+
+	return RMAP_NOMATCH;
+}
+
+/* Route map `rd' match statement. */
+static void *route_match_rd_compile(const char *arg)
+{
+	struct prefix_rd *prd;
+	int ret;
+
+	prd = XMALLOC(MTYPE_ROUTE_MAP_COMPILED, sizeof(struct prefix_rd));
+	if (!prd)
+		return NULL;
+
+	ret = str2prefix_rd(arg, prd);
+	if (!ret) {
+		XFREE(MTYPE_ROUTE_MAP_COMPILED, prd);
+		return NULL;
+	}
+
+	return prd;
+}
+
+/* Free route map's compiled `rd' value. */
+static void route_match_rd_free(void *rule)
+{
+	XFREE(MTYPE_ROUTE_MAP_COMPILED, rule);
+}
+
+/* Route map commands for rd matching. */
+struct route_map_rule_cmd route_match_evpn_rd_cmd = {
+	"evpn rd", route_match_rd, route_match_rd_compile,
+	route_match_rd_free};
+
 /* Route map commands for VRF route leak with source vrf matching */
 static enum route_map_cmd_result_t
 route_match_vrl_source_vrf(void *rule, const struct prefix *prefix,
@@ -1038,8 +1097,10 @@ route_match_local_pref(void *rule, const struct prefix *prefix,
 	return RMAP_NOMATCH;
 }
 
-/* Route map `match local-preference' match statement.
-   `arg' is local-pref value */
+/*
+ * Route map `match local-preference' match statement.
+ * `arg' is local-pref value
+ */
 static void *route_match_local_pref_compile(const char *arg)
 {
 	uint32_t *local_pref;
@@ -3666,6 +3727,31 @@ DEFUN (no_match_evpn_default_route,
 				      RMAP_EVENT_MATCH_DELETED);
 }
 
+DEFUN (match_evpn_rd,
+       match_evpn_rd_cmd,
+       "match evpn rd ASN:NN_OR_IP-ADDRESS:NN",
+       MATCH_STR
+       EVPN_HELP_STR
+       "Route Distinguisher\n"
+       "ASN:XX or A.B.C.D:XX\n")
+{
+	return bgp_route_match_add(vty, "evpn rd", argv[3]->arg,
+				   RMAP_EVENT_MATCH_ADDED);
+}
+
+DEFUN (no_match_evpn_rd,
+       no_match_evpn_rd_cmd,
+       "no match evpn rd ASN:NN_OR_IP-ADDRESS:NN",
+       NO_STR
+       MATCH_STR
+       EVPN_HELP_STR
+       "Route Distinguisher\n"
+       "ASN:XX or A.B.C.D:XX\n")
+{
+	return bgp_route_match_delete(vty, "evpn rd", argv[4]->arg,
+				      RMAP_EVENT_MATCH_DELETED);
+}
+
 DEFPY(match_vrl_source_vrf,
       match_vrl_source_vrf_cmd,
       "match source-vrf NAME$vrf_name",
@@ -5216,6 +5302,7 @@ void bgp_route_map_init(void)
 	route_map_install_match(&route_match_mac_address_cmd);
 	route_map_install_match(&route_match_evpn_vni_cmd);
 	route_map_install_match(&route_match_evpn_route_type_cmd);
+	route_map_install_match(&route_match_evpn_rd_cmd);
 	route_map_install_match(&route_match_evpn_default_route_cmd);
 	route_map_install_match(&route_match_vrl_source_vrf_cmd);
 
@@ -5256,6 +5343,8 @@ void bgp_route_map_init(void)
 	install_element(RMAP_NODE, &no_match_evpn_vni_cmd);
 	install_element(RMAP_NODE, &match_evpn_route_type_cmd);
 	install_element(RMAP_NODE, &no_match_evpn_route_type_cmd);
+	install_element(RMAP_NODE, &match_evpn_rd_cmd);
+	install_element(RMAP_NODE, &no_match_evpn_rd_cmd);
 	install_element(RMAP_NODE, &match_evpn_default_route_cmd);
 	install_element(RMAP_NODE, &no_match_evpn_default_route_cmd);
 	install_element(RMAP_NODE, &match_vrl_source_vrf_cmd);


### PR DESCRIPTION
With this code change, we can now filter evpn routes based on RD using the match statement, `match evpn rd XX`

### **Unit tests:** 
**Route-map out-filter**
These are all the routes currently being advertised without applying any filter:
```
leaf-1(config-route-map)# do sh bgp l2vpn evpn all neighbors 203.0.113.2 advertised-routes
BGP table version is 0, local router ID is 10.100.0.1
Default local pref 100, local AS 65000
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 10.100.0.1:3
*> [3]:[0]:[32]:[10.100.0.1]
                                       32768 i
Route Distinguisher: 10.100.0.1:4
*> [2]:[0]:[48]:[00:50:56:b5:d2:fd]
                                       32768 i
*> [2]:[0]:[48]:[00:50:56:b7:61:49]
                                       32768 i
*> [3]:[0]:[32]:[10.100.0.1]
                                       32768 i
Route Distinguisher: 10.100.0.2:2
*> [3]:[0]:[32]:[10.100.0.2]
                                           0 65002 i
Route Distinguisher: 10.100.0.2:3
*> [3]:[0]:[32]:[10.100.0.2]
                                           0 65002 i

Total number of prefixes 6
```

Configure route-map out-filter:
```
leaf-1(config)# route-map rm-rd permit 10
leaf-1(config-route-map)# match evpn rd 10.100.0.1:3
leaf-1(config-route-map)# router bgp 65000
leaf-1(config-router)# address-family l2vpn evpn
leaf-1(config-router-af)# neighbor 203.0.113.2 route-map rm-rd out
```

Verify that route-map out-filter kicked in:
```
leaf-1(config-router-af)# do sh bgp l2vpn evpn all neighbors 203.0.113.2 advertised-routes
BGP table version is 0, local router ID is 10.100.0.1
Default local pref 100, local AS 65000
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 10.100.0.1:3
*> [3]:[0]:[32]:[10.100.0.1]
                                       32768 i

Total number of prefixes 1
leaf-1(config-router-af)#
```

Unconfigure:
```
leaf-1(config-router-af)# no neighbor 203.0.113.2 route-map rm-rd out
leaf-1(config-router-af)# do sh bgp l2vpn evpn all neighbors 203.0.113.2 advertised-routes
BGP table version is 0, local router ID is 10.100.0.1
Default local pref 100, local AS 65000
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: 10.100.0.1:3
*> [3]:[0]:[32]:[10.100.0.1]
                                       32768 i
Route Distinguisher: 10.100.0.1:4
*> [2]:[0]:[48]:[00:50:56:b5:d2:fd]
                                       32768 i
*> [2]:[0]:[48]:[00:50:56:b7:61:49]
                                       32768 i
*> [3]:[0]:[32]:[10.100.0.1]
                                       32768 i
Route Distinguisher: 10.100.0.2:2
*> [3]:[0]:[32]:[10.100.0.2]
                                           0 65002 i
Route Distinguisher: 10.100.0.2:3
*> [3]:[0]:[32]:[10.100.0.2]
                                           0 65002 i

Total number of prefixes 6
leaf-1(config-router-af)#
leaf-1(config-router-af)#
leaf-1(config-router-af)# end
```

**Verify route-map in-filter**
These are the received routes before applying the filter:
```
leaf-1(config-router-af)# do show bgp l2vpn evpn all neighbors 203.0.113.2 routes
BGP table version is 1, local router ID is 10.100.0.1
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: ip 10.100.0.2:2
*> [3]:[0]:[32]:[10.100.0.2]
                    10.100.0.2                             0 65002 i
Route Distinguisher: ip 10.100.0.2:3
*> [3]:[0]:[32]:[10.100.0.2]
                    10.100.0.2                             0 65002 i

Displayed 2 out of 6 total prefixes
```

Configure route-map for in-filter:
```
leaf-1# conf t
leaf-1(config)# route-map rm-rd-in permit 10
leaf-1(config-route-map)# match evpn rd 10.100.0.2:2
leaf-1(config-route-map)# router bgp 65000
leaf-1(config-router)# address-family l2vpn evpn
leaf-1(config-router-af)# neighbor 203.0.113.2 route-map rm-rd-in in
leaf-1(config-router-af)#
```

Verify that route-map in-filter filtered the routes:
```
leaf-1(config-router-af)# do show bgp l2vpn evpn all neighbors 203.0.113.2 routes
BGP table version is 2, local router ID is 10.100.0.1
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: ip 10.100.0.2:2
*> [3]:[0]:[32]:[10.100.0.2]
                    10.100.0.2                             0 65002 i

Displayed 1 out of 5 total prefixes
```

Unconfigure:
```
leaf-1(config-router-af)#
leaf-1(config-router-af)# no neighbor 203.0.113.2 route-map rm-rd-in in
leaf-1(config-router-af)# do show bgp l2vpn evpn all neighbors 203.0.113.2 routes
BGP table version is 3, local router ID is 10.100.0.1
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
Route Distinguisher: ip 10.100.0.2:2
*> [3]:[0]:[32]:[10.100.0.2]
                    10.100.0.2                             0 65002 i
Route Distinguisher: ip 10.100.0.2:3
*> [3]:[0]:[32]:[10.100.0.2]
                    10.100.0.2                             0 65002 i

Displayed 2 out of 6 total prefixes
```

Signed-off-by: Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>