### PR TITLE
pimd, lib, zebra : PIM MLAG Support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -129,6 +129,7 @@ include zebra/subdir.am
 include watchfrr/subdir.am
 include qpb/subdir.am
 include fpm/subdir.am
+include mlag/subdir.am
 include grpc/subdir.am
 include tools/subdir.am
 include solaris/subdir.am

--- a/Makefile.am
+++ b/Makefile.am
@@ -125,11 +125,11 @@ include doc/manpages/subdir.am
 include doc/developer/subdir.am
 include include/subdir.am
 include lib/subdir.am
+include mlag/subdir.am
 include zebra/subdir.am
 include watchfrr/subdir.am
 include qpb/subdir.am
 include fpm/subdir.am
-include mlag/subdir.am
 include grpc/subdir.am
 include tools/subdir.am
 include solaris/subdir.am

--- a/lib/mlag.c
+++ b/lib/mlag.c
@@ -40,8 +40,7 @@ char *mlag_role2str(enum mlag_role role, char *buf, size_t size)
 	return buf;
 }
 
-char *zebra_mlag_lib_msgid_to_str(enum mlag_msg_type msg_type, char *buf,
-				  size_t size)
+char *mlag_lib_msgid_to_str(enum mlag_msg_type msg_type, char *buf, size_t size)
 {
 	switch (msg_type) {
 	case MLAG_REGISTER:
@@ -82,7 +81,7 @@ char *zebra_mlag_lib_msgid_to_str(enum mlag_msg_type msg_type, char *buf,
 }
 
 
-int zebra_mlag_lib_decode_mlag_hdr(struct stream *s, struct mlag_msg *msg)
+int mlag_lib_decode_mlag_hdr(struct stream *s, struct mlag_msg *msg)
 {
 	if (s == NULL || msg == NULL)
 		return -1;
@@ -95,8 +94,7 @@ stream_failure:
 	return -1;
 }
 
-int zebra_mlag_lib_decode_mroute_add(struct stream *s,
-				     struct mlag_mroute_add *msg)
+int mlag_lib_decode_mroute_add(struct stream *s, struct mlag_mroute_add *msg)
 {
 	if (s == NULL || msg == NULL)
 		return -1;
@@ -115,8 +113,7 @@ stream_failure:
 	return -1;
 }
 
-int zebra_mlag_lib_decode_mroute_del(struct stream *s,
-				     struct mlag_mroute_del *msg)
+int mlag_lib_decode_mroute_del(struct stream *s, struct mlag_mroute_del *msg)
 {
 	if (s == NULL || msg == NULL)
 		return -1;
@@ -132,7 +129,7 @@ stream_failure:
 	return -1;
 }
 
-int zebra_mlag_lib_decode_mlag_status(struct stream *s, struct mlag_status *msg)
+int mlag_lib_decode_mlag_status(struct stream *s, struct mlag_status *msg)
 {
 	if (s == NULL || msg == NULL)
 		return -1;
@@ -145,7 +142,7 @@ stream_failure:
 	return -1;
 }
 
-int zebra_mlag_lib_decode_vxlan_update(struct stream *s, struct mlag_vxlan *msg)
+int mlag_lib_decode_vxlan_update(struct stream *s, struct mlag_vxlan *msg)
 {
 	if (s == NULL || msg == NULL)
 		return -1;
@@ -158,8 +155,7 @@ stream_failure:
 	return -1;
 }
 
-int zebra_mlag_lib_decode_frr_status(struct stream *s,
-				     struct mlag_frr_status *msg)
+int mlag_lib_decode_frr_status(struct stream *s, struct mlag_frr_status *msg)
 {
 	if (s == NULL || msg == NULL)
 		return -1;

--- a/lib/mlag.c
+++ b/lib/mlag.c
@@ -39,3 +39,133 @@ char *mlag_role2str(enum mlag_role role, char *buf, size_t size)
 
 	return buf;
 }
+
+char *zebra_mlag_lib_msgid_to_str(enum mlag_msg_type msg_type, char *buf,
+				  size_t size)
+{
+	switch (msg_type) {
+	case MLAG_REGISTER:
+		snprintf(buf, size, "Register");
+		break;
+	case MLAG_DEREGISTER:
+		snprintf(buf, size, "De-Register");
+		break;
+	case MLAG_MROUTE_ADD:
+		snprintf(buf, size, "Mroute add");
+		break;
+	case MLAG_MROUTE_DEL:
+		snprintf(buf, size, "Mroute del");
+		break;
+	case MLAG_DUMP:
+		snprintf(buf, size, "Mlag Replay");
+		break;
+	case MLAG_MROUTE_ADD_BULK:
+		snprintf(buf, size, "Mroute Add Batch");
+		break;
+	case MLAG_MROUTE_DEL_BULK:
+		snprintf(buf, size, "Mroute Del Batch");
+		break;
+	case MLAG_STATUS_UPDATE:
+		snprintf(buf, size, "Mlag Status");
+		break;
+	case MLAG_VXLAN_UPDATE:
+		snprintf(buf, size, "Mlag vxlan update");
+		break;
+	case MLAG_PEER_FRR_STATUS:
+		snprintf(buf, size, "Mlag Peer FRR Status");
+		break;
+	default:
+		snprintf(buf, size, "Unknown %d", msg_type);
+		break;
+	}
+	return buf;
+}
+
+
+int zebra_mlag_lib_decode_mlag_hdr(struct stream *s, struct mlag_msg *msg)
+{
+	if (s == NULL || msg == NULL)
+		return -1;
+
+	STREAM_GETL(s, msg->msg_type);
+	STREAM_GETW(s, msg->data_len);
+	STREAM_GETW(s, msg->msg_cnt);
+	return 0;
+stream_failure:
+	return -1;
+}
+
+int zebra_mlag_lib_decode_mroute_add(struct stream *s,
+				     struct mlag_mroute_add *msg)
+{
+	if (s == NULL || msg == NULL)
+		return -1;
+
+	STREAM_GET(msg->vrf_name, s, VRF_NAMSIZ);
+	STREAM_GETL(s, msg->source_ip);
+	STREAM_GETL(s, msg->group_ip);
+	STREAM_GETL(s, msg->cost_to_rp);
+	STREAM_GETL(s, msg->owner_id);
+	STREAM_GETC(s, msg->am_i_dr);
+	STREAM_GETC(s, msg->am_i_dual_active);
+	STREAM_GETL(s, msg->vrf_id);
+	STREAM_GET(msg->intf_name, s, INTERFACE_NAMSIZ);
+	return 0;
+stream_failure:
+	return -1;
+}
+
+int zebra_mlag_lib_decode_mroute_del(struct stream *s,
+				     struct mlag_mroute_del *msg)
+{
+	if (s == NULL || msg == NULL)
+		return -1;
+
+	STREAM_GET(msg->vrf_name, s, VRF_NAMSIZ);
+	STREAM_GETL(s, msg->source_ip);
+	STREAM_GETL(s, msg->group_ip);
+	STREAM_GETL(s, msg->owner_id);
+	STREAM_GETL(s, msg->vrf_id);
+	STREAM_GET(msg->intf_name, s, INTERFACE_NAMSIZ);
+	return 0;
+stream_failure:
+	return -1;
+}
+
+int zebra_mlag_lib_decode_mlag_status(struct stream *s, struct mlag_status *msg)
+{
+	if (s == NULL || msg == NULL)
+		return -1;
+
+	STREAM_GET(msg->peerlink_rif, s, INTERFACE_NAMSIZ);
+	STREAM_GETL(s, msg->my_role);
+	STREAM_GETL(s, msg->peer_state);
+	return 0;
+stream_failure:
+	return -1;
+}
+
+int zebra_mlag_lib_decode_vxlan_update(struct stream *s, struct mlag_vxlan *msg)
+{
+	if (s == NULL || msg == NULL)
+		return -1;
+
+	STREAM_GETL(s, msg->anycast_ip);
+	STREAM_GETL(s, msg->local_ip);
+	return 0;
+
+stream_failure:
+	return -1;
+}
+
+int zebra_mlag_lib_decode_frr_status(struct stream *s,
+				     struct mlag_frr_status *msg)
+{
+	if (s == NULL || msg == NULL)
+		return -1;
+
+	STREAM_GETL(s, msg->frr_state);
+	return 0;
+stream_failure:
+	return -1;
+}

--- a/lib/mlag.h
+++ b/lib/mlag.h
@@ -30,6 +30,8 @@ extern "C" {
 #include "lib/vrf.h"
 #include "lib/stream.h"
 
+#define MLAG_MSG_NULL_PAYLOAD 0
+#define MLAG_MSG_NO_BATCH 1
 #define MLAG_BUF_LIMIT 2048
 
 enum mlag_role {

--- a/lib/mlag.h
+++ b/lib/mlag.h
@@ -119,24 +119,23 @@ struct mlag_msg {
 	uint16_t data_len;
 	uint16_t msg_cnt;
 	uint8_t data[0];
-}__attribute__((packed));
+} __attribute__((packed));
 
 
 extern char *mlag_role2str(enum mlag_role role, char *buf, size_t size);
-extern char *zebra_mlag_lib_msgid_to_str(enum mlag_msg_type msg_type, char *buf,
-					 size_t size);
-extern int zebra_mlag_lib_decode_mlag_hdr(struct stream *s,
-					  struct mlag_msg *msg);
-extern int zebra_mlag_lib_decode_mroute_add(struct stream *s,
-					    struct mlag_mroute_add *msg);
-extern int zebra_mlag_lib_decode_mroute_del(struct stream *s,
-					    struct mlag_mroute_del *msg);
-extern int zebra_mlag_lib_decode_mlag_status(struct stream *s,
-					     struct mlag_status *msg);
-extern int zebra_mlag_lib_decode_vxlan_update(struct stream *s,
-					      struct mlag_vxlan *msg);
-extern int zebra_mlag_lib_decode_frr_status(struct stream *s,
-					    struct mlag_frr_status *msg);
+extern char *mlag_lib_msgid_to_str(enum mlag_msg_type msg_type, char *buf,
+				   size_t size);
+extern int mlag_lib_decode_mlag_hdr(struct stream *s, struct mlag_msg *msg);
+extern int mlag_lib_decode_mroute_add(struct stream *s,
+				      struct mlag_mroute_add *msg);
+extern int mlag_lib_decode_mroute_del(struct stream *s,
+				      struct mlag_mroute_del *msg);
+extern int mlag_lib_decode_mlag_status(struct stream *s,
+				       struct mlag_status *msg);
+extern int mlag_lib_decode_vxlan_update(struct stream *s,
+					struct mlag_vxlan *msg);
+extern int mlag_lib_decode_frr_status(struct stream *s,
+				      struct mlag_frr_status *msg);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/mlag.h
+++ b/lib/mlag.h
@@ -26,10 +26,31 @@
 extern "C" {
 #endif
 
+#define MLAG_BUF_LIMIT 2048
+
 enum mlag_role {
 	MLAG_ROLE_NONE,
 	MLAG_ROLE_PRIMARY,
 	MLAG_ROLE_SECONDARY
+};
+
+/*
+ * This message definition should match mlag.proto
+ * Beacuse mesasge registartion is based on this
+ */
+enum mlag_msg_type {
+	MLAG_MSG_NONE = 0,
+	MLAG_REGISTER = 1,
+	MLAG_DEREGISTER = 2,
+	MLAG_STATUS_UPDATE = 3,
+	MLAG_MROUTE_ADD = 4,
+	MLAG_MROUTE_DEL = 5,
+	MLAG_DUMP = 6,
+	MLAG_MROUTE_ADD_BULK = 7,
+	MLAG_MROUTE_DEL_BULK = 8,
+	MLAG_PIM_CFG_DUMP = 10,
+	MLAG_VXLAN_UPDATE = 11,
+	MLAG_PEER_FRR_STATUS = 12,
 };
 
 extern char *mlag_role2str(enum mlag_role role, char *buf, size_t size);

--- a/lib/mlag.h
+++ b/lib/mlag.h
@@ -26,6 +26,10 @@
 extern "C" {
 #endif
 
+#include "lib/if.h"
+#include "lib/vrf.h"
+#include "lib/stream.h"
+
 #define MLAG_BUF_LIMIT 2048
 
 enum mlag_role {
@@ -34,9 +38,26 @@ enum mlag_role {
 	MLAG_ROLE_SECONDARY
 };
 
+enum mlag_state {
+	MLAG_STATE_DOWN,
+	MLAG_STATE_RUNNING,
+};
+
+enum mlag_frr_state {
+	MLAG_FRR_STATE_NONE,
+	MLAG_FRR_STATE_DOWN,
+	MLAG_FRR_STATE_UP,
+};
+
+enum mlag_owner {
+	MLAG_OWNER_NONE,
+	MLAG_OWNER_INTERFACE,
+	MLAG_OWNER_VXLAN,
+};
+
 /*
  * This message definition should match mlag.proto
- * Beacuse mesasge registartion is based on this
+ * Because message registration is based on this
  */
 enum mlag_msg_type {
 	MLAG_MSG_NONE = 0,
@@ -53,8 +74,67 @@ enum mlag_msg_type {
 	MLAG_PEER_FRR_STATUS = 12,
 };
 
-extern char *mlag_role2str(enum mlag_role role, char *buf, size_t size);
+struct mlag_frr_status {
+	enum mlag_frr_state frr_state;
+};
 
+struct mlag_status {
+	char peerlink_rif[INTERFACE_NAMSIZ];
+	enum mlag_role my_role;
+	enum mlag_state peer_state;
+};
+
+#define MLAG_ROLE_STRSIZE 16
+
+struct mlag_vxlan {
+	uint32_t anycast_ip;
+	uint32_t local_ip;
+};
+
+struct mlag_mroute_add {
+	char vrf_name[VRF_NAMSIZ];
+	uint32_t source_ip;
+	uint32_t group_ip;
+	uint32_t cost_to_rp;
+	enum mlag_owner owner_id;
+	bool am_i_dr;
+	bool am_i_dual_active;
+	vrf_id_t vrf_id;
+	char intf_name[INTERFACE_NAMSIZ];
+};
+
+struct mlag_mroute_del {
+	char vrf_name[VRF_NAMSIZ];
+	uint32_t source_ip;
+	uint32_t group_ip;
+	enum mlag_owner owner_id;
+	vrf_id_t vrf_id;
+	char intf_name[INTERFACE_NAMSIZ];
+};
+
+struct mlag_msg {
+	enum mlag_msg_type msg_type;
+	uint16_t data_len;
+	uint16_t msg_cnt;
+	uint8_t data[0];
+}__attribute__((packed));
+
+
+extern char *mlag_role2str(enum mlag_role role, char *buf, size_t size);
+extern char *zebra_mlag_lib_msgid_to_str(enum mlag_msg_type msg_type, char *buf,
+					 size_t size);
+extern int zebra_mlag_lib_decode_mlag_hdr(struct stream *s,
+					  struct mlag_msg *msg);
+extern int zebra_mlag_lib_decode_mroute_add(struct stream *s,
+					    struct mlag_mroute_add *msg);
+extern int zebra_mlag_lib_decode_mroute_del(struct stream *s,
+					    struct mlag_mroute_del *msg);
+extern int zebra_mlag_lib_decode_mlag_status(struct stream *s,
+					     struct mlag_status *msg);
+extern int zebra_mlag_lib_decode_vxlan_update(struct stream *s,
+					      struct mlag_vxlan *msg);
+extern int zebra_mlag_lib_decode_frr_status(struct stream *s,
+					    struct mlag_frr_status *msg);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2754,6 +2754,24 @@ void zclient_send_mlag_data(struct zclient *client, struct stream *client_s)
 	zclient_send_message(client);
 }
 
+static void zclient_mlag_process_up(ZAPI_CALLBACK_ARGS)
+{
+	if (zclient->mlag_process_up)
+		(*zclient->mlag_process_up)();
+}
+
+static void zclient_mlag_process_down(ZAPI_CALLBACK_ARGS)
+{
+	if (zclient->mlag_process_down)
+		(*zclient->mlag_process_down)();
+}
+
+static void zclient_mlag_handle_msg(ZAPI_CALLBACK_ARGS)
+{
+	if (zclient->mlag_handle_msg)
+		(*zclient->mlag_handle_msg)(zclient->ibuf, length);
+}
+
 /* Zebra client message read function. */
 static int zclient_read(struct thread *thread)
 {
@@ -3047,6 +3065,15 @@ static int zclient_read(struct thread *thread)
 		if (zclient->vxlan_sg_del)
 			(*zclient->vxlan_sg_del)(command, zclient, length,
 						    vrf_id);
+		break;
+	case ZEBRA_MLAG_PROCESS_UP:
+		zclient_mlag_process_up(command, zclient, length, vrf_id);
+		break;
+	case ZEBRA_MLAG_PROCESS_DOWN:
+		zclient_mlag_process_down(command, zclient, length, vrf_id);
+		break;
+	case ZEBRA_MLAG_FORWARD_MSG:
+		zclient_mlag_handle_msg(command, zclient, length, vrf_id);
 		break;
 	default:
 		break;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2721,6 +2721,39 @@ stream_failure:
 	return;
 }
 
+void zclient_send_mlag_register(struct zclient *client, uint32_t bit_map)
+{
+	struct stream *s;
+
+	s = client->obuf;
+	stream_reset(s);
+
+	zclient_create_header(s, ZEBRA_MLAG_CLIENT_REGISTER, VRF_DEFAULT);
+	stream_putl(s, bit_map);
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+	zclient_send_message(client);
+}
+
+void zclient_send_mlag_deregister(struct zclient *client)
+{
+	zebra_message_send(client, ZEBRA_MLAG_CLIENT_UNREGISTER, VRF_DEFAULT);
+}
+
+void zclient_send_mlag_data(struct zclient *client, struct stream *client_s)
+{
+	struct stream *s;
+
+	s = client->obuf;
+	stream_reset(s);
+
+	zclient_create_header(s, ZEBRA_MLAG_FORWARD_MSG, VRF_DEFAULT);
+	stream_put(s, client_s->data, client_s->endp);
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+	zclient_send_message(client);
+}
+
 /* Zebra client message read function. */
 static int zclient_read(struct thread *thread)
 {

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -178,6 +178,9 @@ typedef enum {
 	ZEBRA_VXLAN_SG_ADD,
 	ZEBRA_VXLAN_SG_DEL,
 	ZEBRA_VXLAN_SG_REPLAY,
+	ZEBRA_MLAG_CLIENT_REGISTER,
+	ZEBRA_MLAG_CLIENT_UNREGISTER,
+	ZEBRA_MLAG_FORWARD_MSG,
 } zebra_message_types_t;
 
 struct redist_proto {
@@ -694,5 +697,11 @@ static inline void zapi_route_set_blackhole(struct zapi_route *api,
 	SET_FLAG(api->message, ZAPI_MESSAGE_NEXTHOP);
 };
 
+extern void zclient_send_mlag_register(struct zclient *client,
+				       uint32_t bit_map);
+extern void zclient_send_mlag_deregister(struct zclient *client);
+
+extern void zclient_send_mlag_data(struct zclient *client,
+				   struct stream *client_s);
 
 #endif /* _ZEBRA_ZCLIENT_H */

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -178,6 +178,8 @@ typedef enum {
 	ZEBRA_VXLAN_SG_ADD,
 	ZEBRA_VXLAN_SG_DEL,
 	ZEBRA_VXLAN_SG_REPLAY,
+	ZEBRA_MLAG_PROCESS_UP,
+	ZEBRA_MLAG_PROCESS_DOWN,
 	ZEBRA_MLAG_CLIENT_REGISTER,
 	ZEBRA_MLAG_CLIENT_UNREGISTER,
 	ZEBRA_MLAG_FORWARD_MSG,
@@ -275,6 +277,9 @@ struct zclient {
 	int (*iptable_notify_owner)(ZAPI_CALLBACK_ARGS);
 	int (*vxlan_sg_add)(ZAPI_CALLBACK_ARGS);
 	int (*vxlan_sg_del)(ZAPI_CALLBACK_ARGS);
+	int (*mlag_process_up)(void);
+	int (*mlag_process_down)(void);
+	int (*mlag_handle_msg)(struct stream *msg, int len);
 };
 
 /* Zebra API message flag. */

--- a/mlag/mlag.proto
+++ b/mlag/mlag.proto
@@ -1,0 +1,186 @@
+// See README.txt for information and build instructions.
+//
+// Note: START and END tags are used in comments to define sections used in
+// tutorials.  They are not part of the syntax for Protocol Buffers.
+//
+// To get an in-depth walkthrough of this file and the related examples, see:
+// https://developers.google.com/protocol-buffers/docs/tutorials
+
+// [START declaration]
+syntax = "proto3";
+//package tutorial;
+
+/*
+ * This Contains the Message structures used for PIM MLAG Active-Active support.
+ * Mainly there were two types of messages
+ *
+ *  1. Messages sent from PIM (Node-1) to PIM (Node-2)
+ *  2. Messages sent from CLAG to PIM (status Messages)
+ *
+ * ProtoBuf supports maximum 32 fields, so to make it more generic message
+ * encoding is like below.
+ *    __________________________________________
+ *    |              |                          |
+ *    |    Header    |     bytes                |
+ *    ___________________________________________
+ *
+ *
+ *  Header carries Information about
+ *    1) what Message it is carrying
+ *    2) Bytes carries the actual payload encoded with protobuf
+ *
+ *
+ * Limitations
+ *=============
+ *  Since message-type is 32-bit, there were no real limitations on number of
+ *  messages Infra can support, but each message can carry only 32 fields.
+ *
+ */
+
+
+// [START messages]
+message ZebraMlag_Header {
+    enum MessageType {
+        ZEBRA_MLAG_NONE = 0; //Invalid message-type
+        ZEBRA_MLAG_REGISTER = 1;
+        ZEBRA_MLAG_DEREGISTER = 2;
+        ZEBRA_MLAG_STATUS_UPDATE = 3;
+        ZEBRA_MLAG_MROUTE_ADD = 4;
+        ZEBRA_MLAG_MROUTE_DEL = 5;
+        ZEBRA_MLAG_DUMP = 6;
+        ZEBRA_MLAG_MROUTE_ADD_BULK = 7;
+        ZEBRA_MLAG_MROUTE_DEL_BULK = 8;
+        ZEBRA_MLAG_PIM_CFG_DUMP = 10;
+        ZEBRA_MLAG_VXLAN_UPDATE = 11;
+        ZEBRA_MLAG_ZEBRA_STATUS_UPDATE = 12;
+    }
+
+    /*
+     * tells what type of message this payload carries
+     */
+    MessageType type = 1;
+
+    /*
+     * Length of payload
+     */
+    uint32      len  = 2;
+
+    /*
+     * Actual Encoded payload
+     */
+    bytes       data = 3;
+}
+
+
+/*
+ * ZEBRA_MLAG_REGISTER & ZEBRA_MLAG_DEREGISTER
+ *
+ * After the MLAGD is up, First Zebra has to register to send any data,
+ * otherwise MLAGD will not accept any data from the client.
+ * De-register will be used for the Data cleanup at MLAGD
+ * These are NULL payload message currently
+ */
+
+/*
+ * ZEBRA_MLAG_STATUS_UPDATE
+ *
+ * This message will be posted by CLAGD(an external control plane manager
+ * which monitors CLAG failures) to inform peerlink/CLAG Failure
+ * to zebra, after the failure Notification Node with primary role will
+ * forward the Traffic and Node with standby will drop the traffic
+ */
+
+message ZebraMlagStatusUpdate {
+    enum ClagState {
+        CLAG_STATE_DOWN = 0;
+        CLAG_STATE_RUNNING = 1;
+    }
+
+    enum ClagRole {
+        CLAG_ROLE_NONE = 0;
+        CLAG_ROLE_PRIMAY = 1;
+        CLAG_ROLE_SECONDARY = 2;
+    }
+
+    string    peerlink = 1;
+    ClagRole  my_role = 2;
+    ClagState peer_state = 3;
+}
+
+/*
+ * ZEBRA_MLAG_VXLAN_UPDATE
+ *
+ * This message will be posted by CLAGD(an external control plane Manager
+ * which is responsible for MCLAG) to inform zebra obout anycast/local
+ * ip updates.
+ */
+message ZebraMlagVxlanUpdate {
+	uint32 anycast_ip = 1;
+	uint32 local_ip = 2;
+}
+
+/*
+ * ZebraMlagZebraStatusUpdate
+ *
+ * This message will be posted by CLAGD to advertise FRR state
+ * Change Information to peer
+ */
+
+message ZebraMlagZebraStatusUpdate{
+    enum FrrState {
+        FRR_STATE_NONE = 0;
+        FRR_STATE_DOWN = 1;
+        FRR_STATE_UP = 2;
+    }
+
+    FrrState peer_frrstate = 1;
+}
+
+/*
+ * ZEBRA_MLAG_MROUTE_ADD & ZEBRA_MLAG_MROUTE_DEL
+ *
+ * These messages will be sent from PIM (Node-1) to PIM (Node-2) to perform
+ * DF Election for each Mcast flow. Elected DF will forward the traffic
+ * towards the host and loser will keep the OIL as empty, so that only single
+ * copy will be sent to host
+ * This message will be posted with any change in the params.
+ *
+ * ZEBRA_MLAG_MROUTE_DEL is mainly to delete the record at MLAGD when the
+ * mcast flow is deleted.
+ * key for the MLAGD lookup is (vrf_id, source_ip & group_ip)
+ */
+
+message ZebraMlagMrouteAdd {
+    string   vrf_name = 1;
+    uint32   source_ip = 2;
+    uint32   group_ip = 3;
+    /*
+     * This is the IGP Cost to reach Configured RP in case of (*,G) or
+     * Cost to the source in case of (S,G) entry
+     */
+    uint32   cost_to_rp = 4;
+    uint32   owner_id = 5;
+    bool     am_i_DR = 6;
+    bool     am_i_Dual_active = 7;
+    uint32   vrf_id = 8;
+    string   intf_name = 9;
+}
+
+message ZebraMlagMrouteDel {
+    string   vrf_name = 1;
+    uint32   source_ip = 2;
+    uint32   group_ip = 3;
+    uint32   owner_id = 4;
+    uint32   vrf_id = 5;
+    string   intf_name = 6;
+}
+
+message ZebraMlagMrouteAddBulk {
+    repeated ZebraMlagMrouteAdd mroute_add = 1;
+}
+
+message ZebraMlagMrouteDelBulk {
+    repeated ZebraMlagMrouteDel mroute_del = 1;
+}
+
+// [END messages]

--- a/mlag/subdir.am
+++ b/mlag/subdir.am
@@ -1,0 +1,19 @@
+if HAVE_PROTOBUF
+lib_LTLIBRARIES += mlag/libmlag_pb.la
+endif
+
+mlag_libmlag_pb_la_LDFLAGS = -version-info 0:0:0
+mlag_libmlag_pb_la_CPPFLAGS = $(AM_CPPFLAGS) $(PROTOBUF_C_CFLAGS)
+mlag_libmlag_pb_la_SOURCES = \
+	# end
+
+nodist_mlag_libmlag_pb_la_SOURCES = \
+	mlag/mlag.pb-c.c \
+	# end
+
+CLEANFILES += \
+	mlag/mlag.pb-c.c \
+	mlag/mlag.pb-c.h \
+	# end
+
+EXTRA_DIST += mlag/mlag.proto

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -61,6 +61,7 @@
 #include "pim_nht.h"
 #include "pim_bfd.h"
 #include "pim_vxlan.h"
+#include "pim_mlag.h"
 #include "bfd.h"
 #include "pim_bsm.h"
 
@@ -7458,9 +7459,9 @@ DEFPY_HIDDEN (interface_ip_pim_activeactive,
 
 	pim_ifp = ifp->info;
 	if (no)
-		pim_ifp->activeactive = false;
+		pim_if_unconfigure_mlag_dualactive(pim_ifp);
 	else
-		pim_ifp->activeactive = true;
+		pim_if_configure_mlag_dualactive(pim_ifp);
 
 	return CMD_SUCCESS;
 }
@@ -8375,6 +8376,20 @@ DEFUN (no_debug_pim_zebra,
        DEBUG_PIM_ZEBRA_STR)
 {
 	PIM_DONT_DEBUG_ZEBRA;
+	return CMD_SUCCESS;
+}
+
+DEFUN(debug_pim_mlag, debug_pim_mlag_cmd, "debug pim mlag",
+      DEBUG_STR DEBUG_PIM_STR DEBUG_PIM_MLAG_STR)
+{
+	PIM_DO_DEBUG_MLAG;
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_debug_pim_mlag, no_debug_pim_mlag_cmd, "no debug pim mlag",
+      NO_STR DEBUG_STR DEBUG_PIM_STR DEBUG_PIM_MLAG_STR)
+{
+	PIM_DONT_DEBUG_MLAG;
 	return CMD_SUCCESS;
 }
 
@@ -10404,6 +10419,8 @@ void pim_cmd_init(void)
 	install_element(ENABLE_NODE, &no_debug_ssmpingd_cmd);
 	install_element(ENABLE_NODE, &debug_pim_zebra_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_zebra_cmd);
+	install_element(ENABLE_NODE, &debug_pim_mlag_cmd);
+	install_element(ENABLE_NODE, &no_debug_pim_mlag_cmd);
 	install_element(ENABLE_NODE, &debug_pim_vxlan_cmd);
 	install_element(ENABLE_NODE, &no_debug_pim_vxlan_cmd);
 	install_element(ENABLE_NODE, &debug_msdp_cmd);

--- a/pimd/pim_cmd.h
+++ b/pimd/pim_cmd.h
@@ -54,6 +54,7 @@
 #define DEBUG_PIM_PACKETDUMP_RECV_STR               "Dump received packets\n"
 #define DEBUG_PIM_TRACE_STR                         "PIM internal daemon activity\n"
 #define DEBUG_PIM_ZEBRA_STR                         "ZEBRA protocol activity\n"
+#define DEBUG_PIM_MLAG_STR                          "PIM Mlag activity\n"
 #define DEBUG_PIM_VXLAN_STR                         "PIM VxLAN events\n"
 #define DEBUG_SSMPINGD_STR                          "ssmpingd activity\n"
 #define CLEAR_IP_IGMP_STR                           "IGMP clear commands\n"

--- a/pimd/pim_instance.c
+++ b/pimd/pim_instance.c
@@ -34,6 +34,7 @@
 #include "pim_ssmpingd.h"
 #include "pim_vty.h"
 #include "pim_bsm.h"
+#include "pim_mlag.h"
 
 static void pim_instance_terminate(struct pim_instance *pim)
 {
@@ -46,6 +47,8 @@ static void pim_instance_terminate(struct pim_instance *pim)
 
 	if (pim->static_routes)
 		list_delete(&pim->static_routes);
+
+	pim_instance_mlag_terminate(pim);
 
 	pim_upstream_terminate(pim);
 
@@ -114,6 +117,8 @@ static struct pim_instance *pim_instance_init(struct vrf *vrf)
 	pim_oil_init(pim);
 
 	pim_upstream_init(pim);
+
+	pim_instance_mlag_init(pim);
 
 	pim->last_route_change_time = -1;
 	return pim;

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -64,6 +64,17 @@ struct pim_router {
 	vrf_id_t vrf_id;
 
 	enum mlag_role role;
+	uint32_t pim_mlag_intf_cnt;
+	/* if true we have registered with MLAG */
+	bool mlag_process_register;
+	/* if true local MLAG process reported that it is connected
+	 * with the peer MLAG process
+	 */
+	bool connected_to_mlag;
+	/* Holds the client data(unencoded) that need to be pushed to MCLAGD*/
+	struct stream_fifo *mlag_fifo;
+	struct stream *mlag_stream;
+	struct thread *zpthread_mlag_write;
 };
 
 /* Per VRF PIM DB */
@@ -122,6 +133,9 @@ struct pim_instance {
 
 	bool ecmp_enable;
 	bool ecmp_rebalance_enable;
+	/* No. of Dual active I/fs in pim_instance */
+	uint32_t inst_mlag_intf_cnt;
+
 	/* Bsm related */
 	struct bsm_scope global_scope;
 	uint64_t bsm_rcvd;

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -47,6 +47,7 @@
 #include "pim_msdp.h"
 #include "pim_iface.h"
 #include "pim_bfd.h"
+#include "pim_mlag.h"
 #include "pim_errors.h"
 
 extern struct host host;
@@ -131,6 +132,7 @@ int main(int argc, char **argv, char **envp)
 			  pim_ifp_down, pim_ifp_destroy);
 	pim_zebra_init();
 	pim_bfd_init();
+	pim_mlag_init();
 
 	frr_config_fork();
 

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -1,0 +1,189 @@
+/*
+ * This is an implementation of PIM MLAG Functionality
+ *
+ * Module name: PIM MLAG
+ *
+ * Author: sathesh Kumar karra <sathk@cumulusnetworks.com>
+ *
+ * Copyright (C) 2019 Cumulus Networks http://www.cumulusnetworks.com
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include <zebra.h>
+
+#include "pimd.h"
+#include "pim_mlag.h"
+
+extern struct zclient *zclient;
+
+static int pim_mlag_register_handler(struct thread *thread)
+{
+	uint32_t bit_mask = 0;
+
+	if (!zclient)
+		return -1;
+
+	SET_FLAG(bit_mask, (1 << MLAG_STATUS_UPDATE));
+	SET_FLAG(bit_mask, (1 << MLAG_MROUTE_ADD));
+	SET_FLAG(bit_mask, (1 << MLAG_MROUTE_DEL));
+	SET_FLAG(bit_mask, (1 << MLAG_DUMP));
+	SET_FLAG(bit_mask, (1 << MLAG_MROUTE_ADD_BULK));
+	SET_FLAG(bit_mask, (1 << MLAG_MROUTE_DEL_BULK));
+	SET_FLAG(bit_mask, (1 << MLAG_PIM_CFG_DUMP));
+	SET_FLAG(bit_mask, (1 << MLAG_VXLAN_UPDATE));
+	SET_FLAG(bit_mask, (1 << MLAG_PEER_FRR_STATUS));
+
+	if (PIM_DEBUG_MLAG)
+		zlog_debug("%s: Posting Client Register to MLAG mask: 0x%x",
+			   __func__, bit_mask);
+
+	zclient_send_mlag_register(zclient, bit_mask);
+	return 0;
+}
+
+void pim_mlag_register(void)
+{
+	if (router->mlag_process_register)
+		return;
+
+	router->mlag_process_register = true;
+
+	thread_add_event(router->master, pim_mlag_register_handler, NULL, 0,
+			 NULL);
+}
+
+static int pim_mlag_deregister_handler(struct thread *thread)
+{
+	if (!zclient)
+		return -1;
+
+	if (PIM_DEBUG_MLAG)
+		zlog_debug("%s: Posting Client De-Register to MLAG from PIM",
+			   __func__);
+	router->connected_to_mlag = false;
+	zclient_send_mlag_deregister(zclient);
+	return 0;
+}
+
+void pim_mlag_deregister(void)
+{
+	/* if somebody still interested in the MLAG channel skip de-reg */
+	if (router->pim_mlag_intf_cnt)
+		return;
+
+	/* not registered; nothing do */
+	if (!router->mlag_process_register)
+		return;
+
+	router->mlag_process_register = false;
+
+	thread_add_event(router->master, pim_mlag_deregister_handler, NULL, 0,
+			 NULL);
+}
+
+void pim_if_configure_mlag_dualactive(struct pim_interface *pim_ifp)
+{
+	if (!pim_ifp || !pim_ifp->pim || pim_ifp->activeactive == true)
+		return;
+
+	if (PIM_DEBUG_MLAG)
+		zlog_debug("%s: Configuring active-active on Interface: %s",
+			   __func__, "NULL");
+
+	pim_ifp->activeactive = true;
+	if (pim_ifp->pim)
+		pim_ifp->pim->inst_mlag_intf_cnt++;
+
+	router->pim_mlag_intf_cnt++;
+	if (PIM_DEBUG_MLAG)
+		zlog_debug(
+			"%s: Total MLAG configured Interfaces on router: %d, Inst: %d",
+			__func__, router->pim_mlag_intf_cnt,
+			pim_ifp->pim->inst_mlag_intf_cnt);
+
+	if (router->pim_mlag_intf_cnt == 1) {
+		/*
+		 * atleast one Interface is configured for MLAG, send register
+		 * to Zebra for receiving MLAG Updates
+		 */
+		pim_mlag_register();
+	}
+}
+
+void pim_if_unconfigure_mlag_dualactive(struct pim_interface *pim_ifp)
+{
+	if (!pim_ifp || !pim_ifp->pim || pim_ifp->activeactive == false)
+		return;
+
+	if (PIM_DEBUG_MLAG)
+		zlog_debug("%s: UnConfiguring active-active on Interface: %s",
+			   __func__, "NULL");
+
+	pim_ifp->activeactive = false;
+	if (pim_ifp->pim)
+		pim_ifp->pim->inst_mlag_intf_cnt--;
+
+	router->pim_mlag_intf_cnt--;
+	if (PIM_DEBUG_MLAG)
+		zlog_debug(
+			"%s: Total MLAG configured Interfaces on router: %d, Inst: %d",
+			__func__, router->pim_mlag_intf_cnt,
+			pim_ifp->pim->inst_mlag_intf_cnt);
+
+	if (router->pim_mlag_intf_cnt == 0) {
+		/*
+		 * all the Interfaces are MLAG un-configured, post MLAG
+		 * De-register to Zebra
+		 */
+		pim_mlag_deregister();
+	}
+}
+
+
+void pim_instance_mlag_init(struct pim_instance *pim)
+{
+	if (!pim)
+		return;
+
+	pim->inst_mlag_intf_cnt = 0;
+}
+
+
+void pim_instance_mlag_terminate(struct pim_instance *pim)
+{
+	struct interface *ifp;
+
+	if (!pim)
+		return;
+
+	FOR_ALL_INTERFACES (pim->vrf, ifp) {
+		struct pim_interface *pim_ifp = ifp->info;
+
+		if (!pim_ifp || pim_ifp->activeactive == false)
+			continue;
+
+		pim_if_unconfigure_mlag_dualactive(pim_ifp);
+	}
+	pim->inst_mlag_intf_cnt = 0;
+}
+
+void pim_mlag_init(void)
+{
+	router->pim_mlag_intf_cnt = 0;
+	router->connected_to_mlag = false;
+	router->mlag_fifo = stream_fifo_new();
+	router->zpthread_mlag_write = NULL;
+	router->mlag_stream = stream_new(MLAG_BUF_LIMIT);
+}

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -141,7 +141,7 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 	} break;
 	case MLAG_MROUTE_ADD_BULK: {
 		struct mlag_mroute_add msg;
-		int i = 0;
+		int i;
 
 		for (i = 0; i < mlag_msg.msg_cnt; i++) {
 
@@ -153,7 +153,7 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 	} break;
 	case MLAG_MROUTE_DEL_BULK: {
 		struct mlag_mroute_del msg;
-		int i = 0;
+		int i;
 
 		for (i = 0; i < mlag_msg.msg_cnt; i++) {
 

--- a/pimd/pim_mlag.c
+++ b/pimd/pim_mlag.c
@@ -87,22 +87,22 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 	char buf[ZLOG_FILTER_LENGTH_MAX];
 	int rc = 0;
 
-	rc = zebra_mlag_lib_decode_mlag_hdr(s, &mlag_msg);
+	rc = mlag_lib_decode_mlag_hdr(s, &mlag_msg);
 	if (rc)
 		return (rc);
 
 	if (PIM_DEBUG_MLAG)
 		zlog_debug("%s: Received msg type: %s length: %d, bulk_cnt: %d",
 			   __func__,
-			   zebra_mlag_lib_msgid_to_str(mlag_msg.msg_type, buf,
-						       sizeof(buf)),
+			   mlag_lib_msgid_to_str(mlag_msg.msg_type, buf,
+						 sizeof(buf)),
 			   mlag_msg.data_len, mlag_msg.msg_cnt);
 
 	switch (mlag_msg.msg_type) {
 	case MLAG_STATUS_UPDATE: {
 		struct mlag_status msg;
 
-		rc = zebra_mlag_lib_decode_mlag_status(s, &msg);
+		rc = mlag_lib_decode_mlag_status(s, &msg);
 		if (rc)
 			return (rc);
 		pim_mlag_process_mlagd_state_change(msg);
@@ -110,7 +110,7 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 	case MLAG_PEER_FRR_STATUS: {
 		struct mlag_frr_status msg;
 
-		rc = zebra_mlag_lib_decode_frr_status(s, &msg);
+		rc = mlag_lib_decode_frr_status(s, &msg);
 		if (rc)
 			return (rc);
 		pim_mlag_process_peer_frr_state_change(msg);
@@ -118,7 +118,7 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 	case MLAG_VXLAN_UPDATE: {
 		struct mlag_vxlan msg;
 
-		rc = zebra_mlag_lib_decode_vxlan_update(s, &msg);
+		rc = mlag_lib_decode_vxlan_update(s, &msg);
 		if (rc)
 			return rc;
 		pim_mlag_process_vxlan_update(&msg);
@@ -126,7 +126,7 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 	case MLAG_MROUTE_ADD: {
 		struct mlag_mroute_add msg;
 
-		rc = zebra_mlag_lib_decode_mroute_add(s, &msg);
+		rc = mlag_lib_decode_mroute_add(s, &msg);
 		if (rc)
 			return (rc);
 		pim_mlag_process_mroute_add(msg);
@@ -134,7 +134,7 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 	case MLAG_MROUTE_DEL: {
 		struct mlag_mroute_del msg;
 
-		rc = zebra_mlag_lib_decode_mroute_del(s, &msg);
+		rc = mlag_lib_decode_mroute_del(s, &msg);
 		if (rc)
 			return (rc);
 		pim_mlag_process_mroute_del(msg);
@@ -145,7 +145,7 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 
 		for (i = 0; i < mlag_msg.msg_cnt; i++) {
 
-			rc = zebra_mlag_lib_decode_mroute_add(s, &msg);
+			rc = mlag_lib_decode_mroute_add(s, &msg);
 			if (rc)
 				return (rc);
 			pim_mlag_process_mroute_add(msg);
@@ -157,7 +157,7 @@ int pim_zebra_mlag_handle_msg(struct stream *s, int len)
 
 		for (i = 0; i < mlag_msg.msg_cnt; i++) {
 
-			rc = zebra_mlag_lib_decode_mroute_del(s, &msg);
+			rc = mlag_lib_decode_mroute_del(s, &msg);
 			if (rc)
 				return (rc);
 			pim_mlag_process_mroute_del(msg);

--- a/pimd/pim_mlag.h
+++ b/pimd/pim_mlag.h
@@ -34,4 +34,7 @@ extern void pim_if_configure_mlag_dualactive(struct pim_interface *pim_ifp);
 extern void pim_if_unconfigure_mlag_dualactive(struct pim_interface *pim_ifp);
 extern void pim_mlag_register(void);
 extern void pim_mlag_deregister(void);
+extern int pim_zebra_mlag_process_up(void);
+extern int pim_zebra_mlag_process_down(void);
+extern int pim_zebra_mlag_handle_msg(struct stream *msg, int len);
 #endif

--- a/pimd/pim_mlag.h
+++ b/pimd/pim_mlag.h
@@ -1,0 +1,37 @@
+/*
+ * This is an implementation of PIM MLAG Functionality
+ *
+ * Module name: PIM MLAG
+ *
+ * Author: sathesh Kumar karra <sathk@cumulusnetworks.com>
+ *
+ * Copyright (C) 2019 Cumulus Networks http://www.cumulusnetworks.com
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef __PIM_MLAG_H__
+#define __PIM_MLAG_H__
+
+#include "mlag.h"
+#include "pim_iface.h"
+
+extern void pim_mlag_init(void);
+extern void pim_instance_mlag_init(struct pim_instance *pim);
+extern void pim_instance_mlag_terminate(struct pim_instance *pim);
+extern void pim_if_configure_mlag_dualactive(struct pim_interface *pim_ifp);
+extern void pim_if_unconfigure_mlag_dualactive(struct pim_interface *pim_ifp);
+extern void pim_mlag_register(void);
+extern void pim_mlag_deregister(void);
+#endif

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -46,6 +46,7 @@
 #include "pim_nht.h"
 #include "pim_ssm.h"
 #include "pim_vxlan.h"
+#include "pim_mlag.h"
 
 #undef PIM_DEBUG_IFADDR_DUMP
 #define PIM_DEBUG_IFADDR_DUMP
@@ -587,6 +588,9 @@ void pim_zebra_init(void)
 	zclient->nexthop_update = pim_parse_nexthop_update;
 	zclient->vxlan_sg_add = pim_zebra_vxlan_sg_proc;
 	zclient->vxlan_sg_del = pim_zebra_vxlan_sg_proc;
+	zclient->mlag_process_up = pim_zebra_mlag_process_up;
+	zclient->mlag_process_down = pim_zebra_mlag_process_down;
+	zclient->mlag_handle_msg = pim_zebra_mlag_handle_msg;
 
 	zclient_init(zclient, ZEBRA_ROUTE_PIM, 0, &pimd_privs);
 	if (PIM_DEBUG_PIM_TRACE) {

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -50,7 +50,7 @@
 #undef PIM_DEBUG_IFADDR_DUMP
 #define PIM_DEBUG_IFADDR_DUMP
 
-static struct zclient *zclient = NULL;
+struct zclient *zclient;
 
 
 /* Router-id update message from zebra. */

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -115,6 +115,7 @@
 #define PIM_MASK_MTRACE              (1 << 25)
 #define PIM_MASK_VXLAN               (1 << 26)
 #define PIM_MASK_BSM_PROC            (1 << 27)
+#define PIM_MASK_MLAG                (1 << 28)
 /* Remember 32 bits!!! */
 
 /* PIM error codes */
@@ -171,6 +172,7 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DEBUG_IGMP_TRACE_DETAIL                                            \
 	(router->debugs & (PIM_MASK_IGMP_TRACE_DETAIL | PIM_MASK_IGMP_TRACE))
 #define PIM_DEBUG_ZEBRA (router->debugs & PIM_MASK_ZEBRA)
+#define PIM_DEBUG_MLAG (router->debugs & PIM_MASK_MLAG)
 #define PIM_DEBUG_SSMPINGD (router->debugs & PIM_MASK_SSMPINGD)
 #define PIM_DEBUG_MROUTE (router->debugs & PIM_MASK_MROUTE)
 #define PIM_DEBUG_MROUTE_DETAIL                                                \
@@ -217,6 +219,7 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DO_DEBUG_IGMP_TRACE_DETAIL                                         \
 	(router->debugs |= PIM_MASK_IGMP_TRACE_DETAIL)
 #define PIM_DO_DEBUG_ZEBRA (router->debugs |= PIM_MASK_ZEBRA)
+#define PIM_DO_DEBUG_MLAG (router->debugs |= PIM_MASK_MLAG)
 #define PIM_DO_DEBUG_SSMPINGD (router->debugs |= PIM_MASK_SSMPINGD)
 #define PIM_DO_DEBUG_MROUTE (router->debugs |= PIM_MASK_MROUTE)
 #define PIM_DO_DEBUG_MROUTE_DETAIL (router->debugs |= PIM_MASK_MROUTE_DETAIL)
@@ -248,6 +251,7 @@ extern uint8_t qpim_ecmp_rebalance_enable;
 #define PIM_DONT_DEBUG_IGMP_TRACE_DETAIL                                       \
 	(router->debugs &= ~PIM_MASK_IGMP_TRACE_DETAIL)
 #define PIM_DONT_DEBUG_ZEBRA (router->debugs &= ~PIM_MASK_ZEBRA)
+#define PIM_DONT_DEBUG_MLAG (router->debugs &= ~PIM_MASK_MLAG)
 #define PIM_DONT_DEBUG_SSMPINGD (router->debugs &= ~PIM_MASK_SSMPINGD)
 #define PIM_DONT_DEBUG_MROUTE (router->debugs &= ~PIM_MASK_MROUTE)
 #define PIM_DONT_DEBUG_MROUTE_DETAIL (router->debugs &= ~PIM_MASK_MROUTE_DETAIL)

--- a/pimd/subdir.am
+++ b/pimd/subdir.am
@@ -62,6 +62,7 @@ pimd_libpim_a_SOURCES = \
 	pimd/pim_zebra.c \
 	pimd/pim_zlookup.c \
 	pimd/pim_vxlan.c \
+	pimd/pim_mlag.c \
 	pimd/pimd.c \
 	# end
 
@@ -114,6 +115,7 @@ noinst_HEADERS += \
 	pimd/pim_zebra.h \
 	pimd/pim_zlookup.h \
 	pimd/pim_vxlan.h \
+	pimd/pim_mlag.h \
 	pimd/pim_vxlan_instance.h \
 	pimd/pimd.h \
 	pimd/mtracebis_netlink.h \

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -38,6 +38,9 @@ man8 += $(MANBUILD)/zebra.8
 endif
 
 zebra_zebra_LDADD = lib/libfrr.la $(LIBCAP)
+if HAVE_PROTOBUF
+zebra_zebra_LDADD += mlag/libmlag_pb.la $(PROTOBUF_C_LIBS)
+endif
 zebra_zebra_SOURCES = \
 	zebra/connected.c \
 	zebra/debug.c \
@@ -131,6 +134,7 @@ noinst_HEADERS += \
 	zebra/rtadv.h \
 	zebra/rule_netlink.h \
 	zebra/zebra_mlag.h \
+	zebra/zebra_mlag_private.h \
 	zebra/zebra_fpm_private.h \
 	zebra/zebra_l2.h \
 	zebra/zebra_dplane.h \

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -66,6 +66,7 @@ zebra_zebra_SOURCES = \
 	zebra/rule_netlink.c \
 	zebra/rule_socket.c \
 	zebra/zebra_mlag.c \
+	zebra/zebra_mlag_private.c \
 	zebra/zebra_l2.c \
 	zebra/zebra_memory.c \
 	zebra/zebra_dplane.c \

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2556,6 +2556,9 @@ void (*zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_IPTABLE_DELETE] = zread_iptable,
 	[ZEBRA_VXLAN_FLOOD_CONTROL] = zebra_vxlan_flood_control,
 	[ZEBRA_VXLAN_SG_REPLAY] = zebra_vxlan_sg_replay,
+	[ZEBRA_MLAG_CLIENT_REGISTER] = zebra_mlag_client_register,
+	[ZEBRA_MLAG_CLIENT_UNREGISTER] = zebra_mlag_client_unregister,
+	[ZEBRA_MLAG_FORWARD_MSG] = zebra_mlag_forward_client_msg,
 };
 
 #if defined(HANDLE_ZAPI_FUZZING)

--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -23,15 +23,553 @@
 
 #include "command.h"
 #include "hook.h"
+#include "frr_pthread.h"
+#include "mlag.h"
 
 #include "zebra/zebra_mlag.h"
+#include "zebra/zebra_mlag_private.h"
 #include "zebra/zebra_router.h"
+#include "zebra/zebra_memory.h"
 #include "zebra/zapi_msg.h"
 #include "zebra/debug.h"
 
 #ifndef VTYSH_EXTRACT_PL
 #include "zebra/zebra_mlag_clippy.c"
 #endif
+
+#define ZEBRA_MLAG_METADATA_LEN 4
+#define ZEBRA_MLAG_MSG_BCAST 0xFFFFFFFF
+
+uint8_t mlag_wr_buffer[ZEBRA_MLAG_BUF_LIMIT];
+uint8_t mlag_rd_buffer[ZEBRA_MLAG_BUF_LIMIT];
+uint32_t mlag_rd_buf_offset;
+
+static bool test_mlag_in_progress;
+
+static int zebra_mlag_signal_write_thread(void);
+static int zebra_mlag_terminate_pthread(struct thread *event);
+static int zebra_mlag_post_data_from_main_thread(struct thread *thread);
+static void zebra_mlag_publish_process_state(struct zserv *client,
+					     zebra_message_types_t msg_type);
+
+/**********************MLAG Interaction***************************************/
+
+/*
+ * API to post the Registration to MLAGD
+ * MLAG will not process any messages with out the registration
+ */
+void zebra_mlag_send_register(void)
+{
+	struct stream *s = NULL;
+
+	s = stream_new(sizeof(struct mlag_msg));
+
+	stream_putl(s, MLAG_REGISTER);
+	stream_putw(s, MLAG_MSG_NULL_PAYLOAD);
+	stream_putw(s, MLAG_MSG_NO_BATCH);
+	stream_fifo_push_safe(zrouter.mlag_info.mlag_fifo, s);
+	zebra_mlag_signal_write_thread();
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("%s: Enqueued MLAG Register to MLAG Thread ",
+			   __func__);
+}
+
+/*
+ * API to post the De-Registration to MLAGD
+ * MLAG will not process any messages after the de-registration
+ */
+void zebra_mlag_send_deregister(void)
+{
+	struct stream *s = NULL;
+
+	s = stream_new(sizeof(struct mlag_msg));
+
+	stream_putl(s, MLAG_DEREGISTER);
+	stream_putw(s, MLAG_MSG_NULL_PAYLOAD);
+	stream_putw(s, MLAG_MSG_NO_BATCH);
+	stream_fifo_push_safe(zrouter.mlag_info.mlag_fifo, s);
+	zebra_mlag_signal_write_thread();
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("%s: Enqueued MLAG De-Register to MLAG Thread ",
+			   __func__);
+}
+
+/*
+ * API To handle MLAG Received data
+ * Decodes the data using protobuf and enqueue to main thread
+ * main thread publish this to clients based on client subscription
+ */
+void zebra_mlag_process_mlag_data(uint8_t *data, uint32_t len)
+{
+	struct stream *s = NULL;
+	struct stream *s1 = NULL;
+	int msg_type = 0;
+
+	s = stream_new(ZEBRA_MAX_PACKET_SIZ);
+	msg_type = zebra_mlag_protobuf_decode_message(&s, data, len);
+
+	if (msg_type <= 0) {
+		/* Something went wrong in decoding */
+		stream_free(s);
+		zlog_err("%s: failed to process mlag data-%d, %u", __func__,
+			 msg_type, len);
+		return;
+	}
+
+	/*
+	 * additional four bytes are for message type
+	 */
+	s1 = stream_new(stream_get_endp(s) + ZEBRA_MLAG_METADATA_LEN);
+	stream_putl(s1, msg_type);
+	stream_put(s1, s->data, stream_get_endp(s));
+	thread_add_event(zrouter.master, zebra_mlag_post_data_from_main_thread,
+			 s1, 0, NULL);
+	stream_free(s);
+}
+
+/**********************End of MLAG Interaction********************************/
+
+/************************MLAG Thread Processing*******************************/
+
+/*
+ * after posting every 'ZEBRA_MLAG_POST_LIMIT' packets, MLAG Thread will be
+ * yielded to give CPU for other threads
+ */
+#define ZEBRA_MLAG_POST_LIMIT 100
+
+/*
+ * This thread reads the clients data from the Global queue and encodes with
+ * protobuf and pass on to the MLAG socket.
+ */
+static int zebra_mlag_client_msg_handler(struct thread *event)
+{
+	struct stream *s;
+	uint32_t wr_count = 0;
+	uint32_t msg_type = 0;
+	int len = 0;
+
+	wr_count = stream_fifo_count_safe(zrouter.mlag_info.mlag_fifo);
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug(":%s: Processing MLAG write, %d messages in queue",
+			   __func__, wr_count);
+
+	zrouter.mlag_info.t_write = NULL;
+	for (wr_count = 0; wr_count < ZEBRA_MLAG_POST_LIMIT; wr_count++) {
+		/* FIFO is empty,wait for teh message to be add */
+		if (stream_fifo_count_safe(zrouter.mlag_info.mlag_fifo) == 0)
+			break;
+
+		s = stream_fifo_pop_safe(zrouter.mlag_info.mlag_fifo);
+		if (!s) {
+			zlog_debug(":%s: Got a NULL Messages, some thing wrong",
+				   __func__);
+			break;
+		}
+
+		zebra_mlag_reset_write_buffer();
+		/*
+		 * Encode the data now
+		 */
+		len = zebra_mlag_protobuf_encode_client_data(s, &msg_type);
+
+		/*
+		 * write to MCLAGD
+		 */
+		if (len > 0)
+			zebra_mlag_private_write_data(mlag_wr_buffer, len);
+
+		/*
+		 * If message type is De-register, send a signal to main thread,
+		 * so that necessary cleanup will be done by main thread.
+		 */
+		if (msg_type == MLAG_DEREGISTER) {
+			thread_add_event(zrouter.master,
+					 zebra_mlag_terminate_pthread, NULL, 0,
+					 NULL);
+		}
+
+		stream_free(s);
+	}
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug(":%s: Posted  %d messages to MLAGD", __func__,
+			   wr_count);
+	/*
+	 * Currently there is only message write task is enqueued to this
+	 * thread, yielding was added for future purpose, so that this thread
+	 * can server other tasks also and in case FIFO is empty, this task will
+	 * be schedule when main thread adds some messages
+	 */
+	if (wr_count >= ZEBRA_MLAG_POST_LIMIT)
+		zebra_mlag_signal_write_thread();
+	return 0;
+}
+
+/*
+ * API to handle the process state.
+ * In case of Down, Zebra keep monitoring the MLAG state.
+ * all the state Notifications will be published to clients
+ */
+void zebra_mlag_handle_process_state(enum zebra_mlag_state state)
+{
+	if (state == MLAG_UP) {
+		zrouter.mlag_info.connected = true;
+		zebra_mlag_publish_process_state(NULL, ZEBRA_MLAG_PROCESS_UP);
+		zebra_mlag_send_register();
+	} else if (state == MLAG_DOWN) {
+		zrouter.mlag_info.connected = false;
+		zebra_mlag_publish_process_state(NULL, ZEBRA_MLAG_PROCESS_DOWN);
+		zebra_mlag_private_monitor_state();
+	}
+}
+
+/***********************End of MLAG Thread processing*************************/
+
+/*************************Multi-entratnt Api's********************************/
+
+/*
+ * Provider api to signal that work/events are available
+ * for the Zebra MLAG Write pthread.
+ * This API is called from 2 pthreads..
+ * 1) by main thread when client posts a MLAG Message
+ * 2) by MLAG Thread, in case of yield
+ * though this api, is called from two threads we don't need any locking
+ * because Thread task enqueue is thread safe means internally it had
+ * necessary protection
+ */
+static int zebra_mlag_signal_write_thread(void)
+{
+	if (zrouter.mlag_info.zebra_pth_mlag) {
+		if (IS_ZEBRA_DEBUG_MLAG)
+			zlog_debug(":%s: Scheduling MLAG write", __func__);
+		thread_add_event(zrouter.mlag_info.th_master,
+				 zebra_mlag_client_msg_handler, NULL, 0,
+				 &zrouter.mlag_info.t_write);
+	}
+	return 0;
+}
+
+/*
+ * API will be used to publish the MLAG state to interested clients
+ * In case client is passed, state is posted only for that client,
+ * otherwise to all interested clients
+ * this api can be called from two threads.
+ * 1) from main thread: when client is passed
+ * 2) from MLAG Thread: when client is NULL
+ *
+ * In second case, to avoid global data access data will be post to Main
+ * thread, so that actual posting to clients will happen from Main thread.
+ */
+static void zebra_mlag_publish_process_state(struct zserv *client,
+					     zebra_message_types_t msg_type)
+{
+	struct stream *s;
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("%s: Publishing MLAG process state:%s to %s Client",
+			   __func__,
+			   (msg_type == ZEBRA_MLAG_PROCESS_UP) ? "UP" : "DOWN",
+			   (client) ? "one" : "all");
+
+	if (client) {
+		s = stream_new(ZEBRA_HEADER_SIZE);
+		zclient_create_header(s, msg_type, VRF_DEFAULT);
+		zserv_send_message(client, s);
+		return;
+	}
+
+
+	/*
+	 * additional four bytes are for mesasge type
+	 */
+	s = stream_new(ZEBRA_HEADER_SIZE + ZEBRA_MLAG_METADATA_LEN);
+	stream_putl(s, ZEBRA_MLAG_MSG_BCAST);
+	zclient_create_header(s, msg_type, VRF_DEFAULT);
+	thread_add_event(zrouter.master, zebra_mlag_post_data_from_main_thread,
+			 s, 0, NULL);
+}
+
+/**************************End of Multi-entrant Apis**************************/
+
+/***********************Zebra Main thread processing**************************/
+
+/*
+ * To avoid data corruption, messages will be post to clients only from
+ * main thread, because for that access was needed for clients list.
+ * so instead of forcing the locks, messages will be posted from main thread.
+ */
+static int zebra_mlag_post_data_from_main_thread(struct thread *thread)
+{
+	struct stream *s = THREAD_ARG(thread);
+	struct stream *zebra_s = NULL;
+	struct listnode *node;
+	struct zserv *client;
+	uint32_t msg_type = 0;
+	uint32_t msg_len = 0;
+
+	if (!s)
+		return -1;
+
+	STREAM_GETL(s, msg_type);
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug(
+			"%s: Posting MLAG data for msg_type:0x%x to interested cleints",
+			__func__, msg_type);
+
+	msg_len = s->endp - ZEBRA_MLAG_METADATA_LEN;
+	for (ALL_LIST_ELEMENTS_RO(zrouter.client_list, node, client)) {
+		if (client->mlag_updates_interested == true) {
+			if (msg_type != ZEBRA_MLAG_MSG_BCAST
+			    && !CHECK_FLAG(client->mlag_reg_mask1,
+					   (1 << msg_type))) {
+				continue;
+			}
+
+			if (IS_ZEBRA_DEBUG_MLAG)
+				zlog_debug(
+					"%s: Posting MLAG data of length-%d to client:%d ",
+					__func__, msg_len, client->proto);
+
+			zebra_s = stream_new(msg_len);
+			STREAM_GET(zebra_s->data, s, msg_len);
+			zebra_s->endp = msg_len;
+			stream_putw_at(zebra_s, 0, msg_len);
+
+			/*
+			 * This stream will be enqueued to client_obuf, it will
+			 * be freed after posting to client socket.
+			 */
+			zserv_send_message(client, zebra_s);
+			zebra_s = NULL;
+		}
+	}
+
+	stream_free(s);
+	return 0;
+stream_failure:
+	stream_free(s);
+	if (zebra_s)
+		stream_free(zebra_s);
+	return 0;
+}
+
+/*
+ * Start the MLAG Thread, this will be used to write client data on to
+ * MLAG Process and to read the data from MLAG and post to cleints.
+ * when all clients are un-registered, this Thread will be
+ * suspended.
+ */
+static void zebra_mlag_spawn_pthread(void)
+{
+	/* Start MLAG write pthread */
+
+	struct frr_pthread_attr pattr = {.start =
+						 frr_pthread_attr_default.start,
+					 .stop = frr_pthread_attr_default.stop};
+
+	zrouter.mlag_info.zebra_pth_mlag =
+		frr_pthread_new(&pattr, "Zebra MLAG thread", "Zebra MLAG");
+
+	zrouter.mlag_info.th_master = zrouter.mlag_info.zebra_pth_mlag->master;
+
+
+	/* Enqueue an initial event for the dataplane pthread */
+	zebra_mlag_signal_write_thread();
+
+	frr_pthread_run(zrouter.mlag_info.zebra_pth_mlag, NULL);
+}
+
+/*
+ * all clients are un-registered for MLAG Updates, terminate the
+ * MLAG write thread
+ */
+static int zebra_mlag_terminate_pthread(struct thread *event)
+{
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("Zebra MLAG write thread terminate called");
+
+	if (zrouter.mlag_info.clients_interested_cnt) {
+		if (IS_ZEBRA_DEBUG_MLAG)
+			zlog_debug(
+				"Zebra MLAG: still some clients are interested");
+		return 0;
+	}
+
+	frr_pthread_stop(zrouter.mlag_info.zebra_pth_mlag, NULL);
+
+	/* Destroy pthread */
+	frr_pthread_destroy(zrouter.mlag_info.zebra_pth_mlag);
+	zrouter.mlag_info.zebra_pth_mlag = NULL;
+	zrouter.mlag_info.th_master = NULL;
+	zrouter.mlag_info.t_read = NULL;
+	zrouter.mlag_info.t_write = NULL;
+
+	/*
+	 * Send Notification to clean private data
+	 */
+	zebra_mlag_private_cleanup_data();
+	return 0;
+}
+
+/*
+ * API to register zebra client for MLAG Updates
+ */
+void zebra_mlag_client_register(ZAPI_HANDLER_ARGS)
+{
+	struct stream *s;
+	uint32_t reg_mask = 0;
+	int rc = 0;
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("Received MLAG Registration from client-proto:%d",
+			   client->proto);
+
+
+	/* Get input stream.  */
+	s = msg;
+
+	/* Get data. */
+	STREAM_GETL(s, reg_mask);
+
+	if (client->mlag_updates_interested == true) {
+
+		if (IS_ZEBRA_DEBUG_MLAG)
+			zlog_debug(
+				"Client is registered, existing mask: 0x%x, new mask: 0x%x",
+				client->mlag_reg_mask1, reg_mask);
+		if (client->mlag_reg_mask1 != reg_mask)
+			client->mlag_reg_mask1 = reg_mask;
+		/*
+		 * Client might missed MLAG-UP Notification, post-it again
+		 */
+		zebra_mlag_publish_process_state(client, ZEBRA_MLAG_PROCESS_UP);
+		return;
+	}
+
+
+	client->mlag_updates_interested = true;
+	client->mlag_reg_mask1 = reg_mask;
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("Registering for MLAG Updates with mask: 0x%x, ",
+			   client->mlag_reg_mask1);
+
+	zrouter.mlag_info.clients_interested_cnt++;
+
+	if (zrouter.mlag_info.clients_interested_cnt == 1) {
+		/*
+		 * First-client for MLAG Updates,open the communication channel
+		 * with MLAG
+		 */
+		if (IS_ZEBRA_DEBUG_MLAG)
+			zlog_debug(
+				"First client, opening the channel with MLAG");
+
+		zebra_mlag_spawn_pthread();
+		rc = zebra_mlag_private_open_channel();
+		if (rc < 0) {
+			/*
+			 * For some reason, zebra not able to open the
+			 * comm-channel with MLAG, so post MLAG-DOWN to client.
+			 * later when the channel is open, zebra will send
+			 * MLAG-UP
+			 */
+			if (IS_ZEBRA_DEBUG_MLAG)
+				zlog_debug(
+					"Fail to open channel with MLAG,rc:%d, post Proto-down",
+					rc);
+			zebra_mlag_publish_process_state(
+				client, ZEBRA_MLAG_PROCESS_DOWN);
+		}
+	}
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("Client Registered successfully for MLAG Updates");
+
+	if (zrouter.mlag_info.connected == true)
+		zebra_mlag_publish_process_state(client, ZEBRA_MLAG_PROCESS_UP);
+stream_failure:
+	return;
+}
+
+/*
+ * API to un-register for MLAG Updates
+ */
+void zebra_mlag_client_unregister(ZAPI_HANDLER_ARGS)
+{
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("Received MLAG De-Registration from client-proto:%d",
+			   client->proto);
+
+	if (client->mlag_updates_interested == false)
+		/* Unexpected */
+		return;
+
+	client->mlag_updates_interested = false;
+	client->mlag_reg_mask1 = 0;
+	zrouter.mlag_info.clients_interested_cnt--;
+
+	if (zrouter.mlag_info.clients_interested_cnt == 0) {
+		/*
+		 * No-client is interested for MLAG Updates,close the
+		 * communication channel with MLAG
+		 */
+		if (IS_ZEBRA_DEBUG_MLAG)
+			zlog_debug("Last client for MLAG, close the channel ");
+
+		/*
+		 * Clean up flow:
+		 * =============
+		 * 1) main thread calls socket close which posts De-register
+		 * to MLAG write thread
+		 * 2) after MLAG write thread posts De-register it sends a
+		 * signal back to main thread to do the thread cleanup
+		 * this was mainly to make sure De-register is posted to MCLAGD.
+		 */
+		zebra_mlag_private_close_channel();
+	}
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug(
+			"Client De-Registered successfully for MLAG Updates");
+}
+
+/*
+ * Does following things.
+ * 1) allocated new local stream, and copies the client data and enqueue
+ *    to MLAG Thread
+ *  2) MLAG Thread after dequeing, encode the client data using protobuf
+ *     and write on to MLAG
+ */
+void zebra_mlag_forward_client_msg(ZAPI_HANDLER_ARGS)
+{
+	struct stream *zebra_s;
+	struct stream *mlag_s;
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("Received Client MLAG Data from client-proto:%d",
+			   client->proto);
+
+	/* Get input stream.  */
+	zebra_s = msg;
+	mlag_s = stream_new(zebra_s->endp);
+
+	/*
+	 * Client data is | Zebra Header + MLAG Data |
+	 * we need to enqueue only the MLAG data, skipping Zebra Header
+	 */
+	stream_put(mlag_s, zebra_s->data + zebra_s->getp,
+		   STREAM_READABLE(zebra_s));
+	stream_fifo_push_safe(zrouter.mlag_info.mlag_fifo, mlag_s);
+	zebra_mlag_signal_write_thread();
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("%s: Enqueued Client:%d data to MLAG Thread ",
+			   __func__, client->proto);
+}
+
+/***********************End of Zebra Main thread processing*************/
 
 enum mlag_role zebra_mlag_get_role(void)
 {
@@ -53,15 +591,13 @@ DEFUN_HIDDEN (show_mlag,
 	return CMD_SUCCESS;
 }
 
-DEFPY_HIDDEN (test_mlag,
-	      test_mlag_cmd,
-	      "test zebra mlag <none$none|primary$primary|secondary$secondary>",
-	      "Test code\n"
-	      ZEBRA_STR
-	      "Modify the Mlag state\n"
-	      "Mlag is not setup on the machine\n"
-	      "Mlag is setup to be primary\n"
-	      "Mlag is setup to be the secondary\n")
+DEFPY(test_mlag, test_mlag_cmd,
+      "test zebra mlag <none$none|primary$primary|secondary$secondary>",
+      "Test code\n" ZEBRA_STR
+      "Modify the Mlag state\n"
+      "Mlag is not setup on the machine\n"
+      "Mlag is setup to be primary\n"
+      "Mlag is setup to be the secondary\n")
 {
 	enum mlag_role orig = zrouter.mlag_info.role;
 	char buf1[80], buf2[80];
@@ -78,8 +614,25 @@ DEFPY_HIDDEN (test_mlag,
 			   mlag_role2str(orig, buf1, sizeof(buf1)),
 			   mlag_role2str(orig, buf2, sizeof(buf2)));
 
-	if (orig != zrouter.mlag_info.role)
+	if (orig != zrouter.mlag_info.role) {
 		zsend_capabilities_all_clients();
+		if (zrouter.mlag_info.role != MLAG_ROLE_NONE) {
+			if (zrouter.mlag_info.clients_interested_cnt == 0
+			    && test_mlag_in_progress == false) {
+				if (zrouter.mlag_info.zebra_pth_mlag == NULL)
+					zebra_mlag_spawn_pthread();
+				zrouter.mlag_info.clients_interested_cnt++;
+				test_mlag_in_progress = true;
+				zebra_mlag_private_open_channel();
+			}
+		} else {
+			if (test_mlag_in_progress == true) {
+				test_mlag_in_progress = false;
+				zrouter.mlag_info.clients_interested_cnt--;
+				zebra_mlag_private_close_channel();
+			}
+		}
+	}
 
 	return CMD_SUCCESS;
 }
@@ -88,8 +641,41 @@ void zebra_mlag_init(void)
 {
 	install_element(VIEW_NODE, &show_mlag_cmd);
 	install_element(ENABLE_NODE, &test_mlag_cmd);
+
+	/*
+	 * Intialiaze teh MLAG Global variableis
+	 * write thread will be craeted during actual registration with MCLAG
+	 */
+	zrouter.mlag_info.clients_interested_cnt = 0;
+	zrouter.mlag_info.connected = false;
+	zrouter.mlag_info.timer_running = false;
+	zrouter.mlag_info.mlag_fifo = stream_fifo_new();
+	zrouter.mlag_info.zebra_pth_mlag = NULL;
+	zrouter.mlag_info.th_master = NULL;
+	zrouter.mlag_info.t_read = NULL;
+	zrouter.mlag_info.t_write = NULL;
+	test_mlag_in_progress = false;
+	zebra_mlag_reset_write_buffer();
+	zebra_mlag_reset_read_buffer();
 }
 
 void zebra_mlag_terminate(void)
 {
+}
+
+
+/*
+ *
+ *  ProtoBuf Encoding APIs
+ */
+
+int zebra_mlag_protobuf_encode_client_data(struct stream *s, uint32_t *msg_type)
+{
+	return 0;
+}
+
+int zebra_mlag_protobuf_decode_message(struct stream **s, uint8_t *data,
+				       uint32_t len)
+{
+	return 0;
 }

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -23,18 +23,47 @@
 #define __ZEBRA_MLAG_H__
 
 #include "mlag.h"
+#include "zclient.h"
+#include "zebra/zserv.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#define ZEBRA_MLAG_BUF_LIMIT 2048
+#define ZEBRA_MLAG_LEN_SIZE 4
+
+extern uint8_t mlag_wr_buffer[ZEBRA_MLAG_BUF_LIMIT];
+extern uint8_t mlag_rd_buffer[ZEBRA_MLAG_BUF_LIMIT];
+extern uint32_t mlag_rd_buf_offset;
+
+static inline void zebra_mlag_reset_write_buffer(void)
+{
+	memset(mlag_wr_buffer, 0, ZEBRA_MLAG_BUF_LIMIT);
+}
+
+static inline void zebra_mlag_reset_read_buffer(void)
+{
+	memset(mlag_rd_buffer, 0, ZEBRA_MLAG_BUF_LIMIT);
+	mlag_rd_buf_offset = 0;
+}
+
+enum zebra_mlag_state {
+	MLAG_UP = 1,
+	MLAG_DOWN = 2,
+};
 
 void zebra_mlag_init(void);
 void zebra_mlag_terminate(void);
-
 enum mlag_role zebra_mlag_get_role(void);
-
-#ifdef __cplusplus
-}
-#endif
-
+void zebra_mlag_client_register(ZAPI_HANDLER_ARGS);
+void zebra_mlag_client_unregister(ZAPI_HANDLER_ARGS);
+void zebra_mlag_forward_client_msg(ZAPI_HANDLER_ARGS);
+void zebra_mlag_send_register(void);
+void zebra_mlag_send_deregister(void);
+void zebra_mlag_handle_process_state(enum zebra_mlag_state state);
+void zebra_mlag_process_mlag_data(uint8_t *data, uint32_t len);
+/*
+ * ProtoBuffer Api's
+ */
+int zebra_mlag_protobuf_encode_client_data(struct stream *s,
+					   uint32_t *msg_type);
+int zebra_mlag_protobuf_decode_message(struct stream **s, uint8_t *data,
+				       uint32_t len);
 #endif

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -26,6 +26,10 @@
 #include "zclient.h"
 #include "zebra/zserv.h"
 
+#ifdef HAVE_PROTOBUF
+#include "mlag/mlag.pb-c.h"
+#endif
+
 #define ZEBRA_MLAG_BUF_LIMIT 2048
 #define ZEBRA_MLAG_LEN_SIZE 4
 
@@ -33,14 +37,8 @@ extern uint8_t mlag_wr_buffer[ZEBRA_MLAG_BUF_LIMIT];
 extern uint8_t mlag_rd_buffer[ZEBRA_MLAG_BUF_LIMIT];
 extern uint32_t mlag_rd_buf_offset;
 
-static inline void zebra_mlag_reset_write_buffer(void)
-{
-	memset(mlag_wr_buffer, 0, ZEBRA_MLAG_BUF_LIMIT);
-}
-
 static inline void zebra_mlag_reset_read_buffer(void)
 {
-	memset(mlag_rd_buffer, 0, ZEBRA_MLAG_BUF_LIMIT);
 	mlag_rd_buf_offset = 0;
 }
 
@@ -64,6 +62,6 @@ void zebra_mlag_process_mlag_data(uint8_t *data, uint32_t len);
  */
 int zebra_mlag_protobuf_encode_client_data(struct stream *s,
 					   uint32_t *msg_type);
-int zebra_mlag_protobuf_decode_message(struct stream **s, uint8_t *data,
+int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 				       uint32_t len);
 #endif

--- a/zebra/zebra_mlag_private.c
+++ b/zebra/zebra_mlag_private.c
@@ -166,8 +166,6 @@ static int zebra_mlag_connect(struct thread *thread)
 	/* Reset the Timer-running flag */
 	zrouter.mlag_info.timer_running = false;
 
-	/* Reset, sothat Next task can be scheduled */
-	zrouter.mlag_info.t_read = NULL;
 	svr.sun_family = AF_UNIX;
 #define MLAG_SOCK_NAME "/var/run/clag-zebra.socket"
 	strlcpy(svr.sun_path, MLAG_SOCK_NAME, sizeof(MLAG_SOCK_NAME) + 1);

--- a/zebra/zebra_mlag_private.c
+++ b/zebra/zebra_mlag_private.c
@@ -1,0 +1,300 @@
+/*
+ * This is an implementation of MLAG Functionality
+ *
+ * Module name: Zebra MLAG
+ *
+ * Author: sathesh Kumar karra <sathk@cumulusnetworks.com>
+ *
+ * Copyright (C) 2019 Cumulus Networks http://www.cumulusnetworks.com
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include "zebra.h"
+
+#include "hook.h"
+#include "module.h"
+#include "thread.h"
+#include "libfrr.h"
+#include "version.h"
+#include "network.h"
+
+#include "lib/stream.h"
+
+#include "zebra/debug.h"
+#include "zebra/zebra_router.h"
+#include "zebra/zebra_mlag.h"
+#include "zebra/zebra_mlag_private.h"
+
+#include <sys/un.h>
+
+
+/*
+ * This file will have platform specific apis to communicate with MCLAG.
+ *
+ */
+
+#ifdef HAVE_CUMULUS
+
+static struct thread_master *zmlag_master;
+static int mlag_socket;
+
+static int zebra_mlag_connect(struct thread *thread);
+static int zebra_mlag_read(struct thread *thread);
+
+/*
+ * Write the data to MLAGD
+ */
+int zebra_mlag_private_write_data(uint8_t *data, uint32_t len)
+{
+	int rc = 0;
+
+	if (IS_ZEBRA_DEBUG_MLAG) {
+		zlog_debug("%s: Writing %d length Data to clag", __func__, len);
+		zlog_hexdump(data, len);
+	}
+	rc = write(mlag_socket, data, len);
+	return rc;
+}
+
+static void zebra_mlag_sched_read(void)
+{
+	thread_add_read(zmlag_master, zebra_mlag_read, NULL, mlag_socket,
+			&zrouter.mlag_info.t_read);
+}
+
+static int zebra_mlag_read(struct thread *thread)
+{
+	uint32_t *msglen;
+	uint32_t h_msglen;
+	uint32_t tot_len, curr_len = mlag_rd_buf_offset;
+
+	zrouter.mlag_info.t_read = NULL;
+
+	/*
+	 * Received message in sock_stream looks like below
+	 * | len-1 (4 Bytes) | payload-1 (len-1) |
+	 *   len-2 (4 Bytes) | payload-2 (len-2) | ..
+	 *
+	 * Idea is read one message completely, then process, until message is
+	 * read completely, keep on reading from the socket
+	 */
+	if (curr_len < ZEBRA_MLAG_LEN_SIZE) {
+		ssize_t data_len;
+
+		data_len = read(mlag_socket, mlag_rd_buffer + curr_len,
+				ZEBRA_MLAG_LEN_SIZE - curr_len);
+		if (data_len == 0 || data_len == -1) {
+			if (IS_ZEBRA_DEBUG_MLAG)
+				zlog_debug("MLAG connection closed socket : %d",
+					   mlag_socket);
+			close(mlag_socket);
+			zebra_mlag_handle_process_state(MLAG_DOWN);
+			return -1;
+		}
+		if (data_len != (ssize_t)ZEBRA_MLAG_LEN_SIZE - curr_len) {
+			/* Try again later */
+			zebra_mlag_sched_read();
+			return 0;
+		}
+		curr_len = ZEBRA_MLAG_LEN_SIZE;
+	}
+
+	/* Get the actual packet length */
+	msglen = (uint32_t *)mlag_rd_buffer;
+	h_msglen = ntohl(*msglen);
+
+	/* This will be the actual length of the packet */
+	tot_len = h_msglen + ZEBRA_MLAG_LEN_SIZE;
+
+	if (curr_len < tot_len) {
+		ssize_t data_len;
+
+		data_len = read(mlag_socket, mlag_rd_buffer + curr_len,
+				tot_len - curr_len);
+		if (data_len == 0 || data_len == -1) {
+			if (IS_ZEBRA_DEBUG_MLAG)
+				zlog_debug("MLAG connection closed socket : %d",
+					   mlag_socket);
+			close(mlag_socket);
+			zebra_mlag_handle_process_state(MLAG_DOWN);
+			return -1;
+		}
+		if (data_len != (ssize_t)tot_len - curr_len) {
+			/* Try again later */
+			zebra_mlag_sched_read();
+			return 0;
+		}
+	}
+
+	if (IS_ZEBRA_DEBUG_MLAG) {
+		zlog_debug("Received a MLAG Message from socket: %d, len:%u ",
+			   mlag_socket, tot_len);
+		zlog_hexdump(mlag_rd_buffer, tot_len);
+	}
+
+	tot_len -= ZEBRA_MLAG_LEN_SIZE;
+
+	/* Process the packet */
+	zebra_mlag_process_mlag_data(mlag_rd_buffer + ZEBRA_MLAG_LEN_SIZE,
+				     tot_len);
+
+	/* Register read thread. */
+	zebra_mlag_reset_read_buffer();
+	zebra_mlag_sched_read();
+	return 0;
+}
+
+static int zebra_mlag_connect(struct thread *thread)
+{
+	struct sockaddr_un svr = {0};
+	struct ucred ucred;
+	socklen_t len = 0;
+
+	/* Reset the Timer-running flag */
+	zrouter.mlag_info.timer_running = false;
+
+	/* Reset, sothat Next task can be scheduled */
+	zrouter.mlag_info.t_read = NULL;
+	svr.sun_family = AF_UNIX;
+#define MLAG_SOCK_NAME "/var/run/clag-zebra.socket"
+	strlcpy(svr.sun_path, MLAG_SOCK_NAME, sizeof(MLAG_SOCK_NAME) + 1);
+
+	mlag_socket = socket(svr.sun_family, SOCK_STREAM, 0);
+	if (mlag_socket < 0)
+		return -1;
+
+	if (connect(mlag_socket, (struct sockaddr *)&svr, sizeof(svr)) == -1) {
+		if (IS_ZEBRA_DEBUG_MLAG)
+			zlog_debug(
+				"Unable to connect to %s try again in 10 secs",
+				svr.sun_path);
+		close(mlag_socket);
+		zrouter.mlag_info.timer_running = true;
+		thread_add_timer(zmlag_master, zebra_mlag_connect, NULL, 10,
+				 &zrouter.mlag_info.t_read);
+		return 0;
+	}
+	len = sizeof(struct ucred);
+	ucred.pid = getpid();
+
+	set_nonblocking(mlag_socket);
+	setsockopt(mlag_socket, SOL_SOCKET, SO_PEERCRED, &ucred, len);
+
+	if (IS_ZEBRA_DEBUG_MLAG)
+		zlog_debug("%s: Connection with MLAG is established ",
+			   __func__);
+
+	thread_add_read(zmlag_master, zebra_mlag_read, NULL, mlag_socket,
+			&zrouter.mlag_info.t_read);
+	/*
+	 * Connection is established with MLAGD, post to clients
+	 */
+	zebra_mlag_handle_process_state(MLAG_UP);
+	return 0;
+}
+
+/*
+ * Currently we are doing polling later we will look for better options
+ */
+void zebra_mlag_private_monitor_state(void)
+{
+	thread_add_event(zmlag_master, zebra_mlag_connect, NULL, 0,
+			 &zrouter.mlag_info.t_read);
+}
+
+int zebra_mlag_private_open_channel(void)
+{
+	zmlag_master = zrouter.mlag_info.th_master;
+
+	if (zrouter.mlag_info.connected == true) {
+		if (IS_ZEBRA_DEBUG_MLAG)
+			zlog_debug("%s: Zebra already connected to MLAGD",
+				   __func__);
+		return 0;
+	}
+
+	if (zrouter.mlag_info.timer_running == true) {
+		if (IS_ZEBRA_DEBUG_MLAG)
+			zlog_debug(
+				"%s: Connection retry is in progress for MLAGD",
+				__func__);
+		return 0;
+	}
+
+	if (zrouter.mlag_info.clients_interested_cnt) {
+		/*
+		 * Connect only if any clients are showing interest
+		 */
+		thread_add_event(zmlag_master, zebra_mlag_connect, NULL, 0,
+				 &zrouter.mlag_info.t_read);
+	}
+	return 0;
+}
+
+int zebra_mlag_private_close_channel(void)
+{
+	if (zmlag_master == NULL)
+		return -1;
+
+	if (zrouter.mlag_info.clients_interested_cnt) {
+		if (IS_ZEBRA_DEBUG_MLAG)
+			zlog_debug("%s: still %d clients are connected, skip",
+				   __func__,
+				   zrouter.mlag_info.clients_interested_cnt);
+		return -1;
+	}
+
+	/*
+	 * Post the De-register to MLAG, so that it can do necesasry cleanup
+	 */
+	zebra_mlag_send_deregister();
+
+	return 0;
+}
+
+void zebra_mlag_private_cleanup_data(void)
+{
+	zmlag_master = NULL;
+	zrouter.mlag_info.connected = false;
+	zrouter.mlag_info.timer_running = false;
+
+	close(mlag_socket);
+}
+
+#else  /*HAVE_CUMULUS */
+
+int zebra_mlag_private_write_data(uint8_t *data, uint32_t len)
+{
+	return 0;
+}
+
+void zebra_mlag_private_monitor_state(void)
+{
+}
+
+int zebra_mlag_private_open_channel(void)
+{
+	return 0;
+}
+
+int zebra_mlag_private_close_channel(void)
+{
+	return 0;
+}
+
+void zebra_mlag_private_cleanup_data(void)
+{
+}
+#endif /*HAVE_CUMULUS*/

--- a/zebra/zebra_mlag_private.c
+++ b/zebra/zebra_mlag_private.c
@@ -71,10 +71,8 @@ int zebra_mlag_private_write_data(uint8_t *data, uint32_t len)
 
 static void zebra_mlag_sched_read(void)
 {
-	frr_with_mutex (&zrouter.mlag_info.mlag_th_mtx) {
-		thread_add_read(zmlag_master, zebra_mlag_read, NULL,
-				mlag_socket, &zrouter.mlag_info.t_read);
-	}
+	thread_add_read(zmlag_master, zebra_mlag_read, NULL, mlag_socket,
+			&zrouter.mlag_info.t_read);
 }
 
 static int zebra_mlag_read(struct thread *thread)

--- a/zebra/zebra_mlag_private.h
+++ b/zebra/zebra_mlag_private.h
@@ -1,0 +1,37 @@
+/*
+ * This is an implementation of MLAG Functionality
+ *
+ * Module name: Zebra MLAG
+ *
+ * Author: sathesh Kumar karra <sathk@cumulusnetworks.com>
+ *
+ * Copyright (C) 2019 Cumulus Networks http://www.cumulusnetworks.com
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef __ZEBRA_MLAG_PRIVATE_H__
+#define __ZEBRA_MLAG_PRIVATE_H__
+
+
+/*
+ * all the platform specific API's
+ */
+
+int zebra_mlag_private_open_channel(void);
+int zebra_mlag_private_close_channel(void);
+void zebra_mlag_private_monitor_state(void);
+int zebra_mlag_private_write_data(uint8_t *data, uint32_t len);
+void zebra_mlag_private_cleanup_data(void);
+#endif

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -97,8 +97,14 @@ struct zebra_mlag_info {
 	/* MLAG Thread context 'master' */
 	struct thread_master *th_master;
 
-	/* Threads for read/write. */
+	/*
+	 * Event for Initial MLAG Connection setup & Data Read
+	 * Read can be performed only after successful connection establishment,
+	 * so no issues.
+	 *
+	 */
 	struct thread *t_read;
+	/* Event for MLAG write */
 	struct thread *t_write;
 };
 

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -100,6 +100,7 @@ struct zebra_mlag_info {
 	/* Threads for read/write. */
 	struct thread *t_read;
 	struct thread *t_write;
+	pthread_mutex_t mlag_th_mtx;
 };
 
 struct zebra_router {

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -100,7 +100,6 @@ struct zebra_mlag_info {
 	/* Threads for read/write. */
 	struct thread *t_read;
 	struct thread *t_write;
-	pthread_mutex_t mlag_th_mtx;
 };
 
 struct zebra_router {

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -71,6 +71,35 @@ struct zebra_mlag_info {
 
 	/* The system mac being used */
 	struct ethaddr mac;
+	/*
+	 * Zebra will open the communication channel with MLAGD only if any
+	 * clients are interested and it is controlled dynamically based on
+	 * client registers & un-registers.
+	 */
+	uint32_t clients_interested_cnt;
+
+	/* coomunication channel with MLAGD is established */
+	bool connected;
+
+	/* connection retry timer is running */
+	bool timer_running;
+
+	/* Holds the client data(unencoded) that need to be pushed to MCLAGD*/
+	struct stream_fifo *mlag_fifo;
+
+	/*
+	 * A new Kernel thread will be created to post the data to MCLAGD.
+	 * where as, read will be performed from the zebra main thread, because
+	 * read involves accessing client registartion data structures.
+	 */
+	struct frr_pthread *zebra_pth_mlag;
+
+	/* MLAG Thread context 'master' */
+	struct thread_master *th_master;
+
+	/* Threads for read/write. */
+	struct thread *t_read;
+	struct thread *t_write;
 };
 
 struct zebra_router {

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -99,6 +99,13 @@ struct zserv {
 	uint8_t proto;
 	uint16_t instance;
 
+	/*
+	 * Interested for MLAG Updates, and also stores the client
+	 * interested message mask
+	 */
+	bool mlag_updates_interested;
+	uint32_t mlag_reg_mask1;
+
 	/* Statistics */
 	uint32_t redist_v4_add_cnt;
 	uint32_t redist_v4_del_cnt;


### PR DESCRIPTION
Support for PIM MLAG Functionality:

1. Zebra opens the communication channel with MLAG based on Clients requests.
2. multiple clients can send the register to Zebra at same time.
3. In Rx direction messages are posted to clients from Zebra based on subscriptions during registration.
4. all the messages to/from MLAG are encoded using Protobuf.
5. clients are completely un-aware of this encodes/Decodes.
6. Zebra will take care of encoding the messages in Tx. direction, similarly messages will be posted after protobuf Decode.
7. a New pthread is spawned to process MLAG Messages.
8. this pthread will be closed when there is no MLAG activity

Re-pushing the changes after addressing all Review comments. 

Addressing some open concerns:
1. we can't Delete the Task Initialisation to NULL in Task Handler, because this will block the task Re-scheduling
2. mlag_rd_buff_offset is reset in the  api "zebra_mlag_reset_read_buffer", previously this api is memset's the Buffer to "0" every time, now memset is removed to save the CPU cycles. and this was called after every message processing