### PR TITLE
tools: stop repeating lines to delete for multiple bfd timer changes

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -757,7 +757,7 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
                     bfd_nbr = "neighbor %s" % nbr
 
                     for (ctx_keys, add_line) in lines_to_add:
-                        re_add_nbr_bfd_timers = re.search(r'neighbor (\S+) bfd (\S+) (\S+) (\S+)', add_line)
+                        re_add_nbr_bfd_timers = re.search(r'neighbor bfd_nbr bfd (\S+) (\S+) (\S+)', add_line)
 
                         if re_add_nbr_bfd_timers:
                             found_add_bfd_nbr = line_exist(lines_to_add, ctx_keys, bfd_nbr, False)


### PR DESCRIPTION
Problem reported with tracebacks seen when making multiple bfd timer
changes in frr.conf and applying via frr-reload.py.  Found that when
multiple bfd timer changes are made, the same line can be added for
deletion more than once, causing the traceback when the deletion is
performed.  This fix verifies the correct line is being appended for
deletion.

Ticket: CM-27233
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>