### PR TITLE
bgpd: Add nexthop of received EVPN RT-5 for nexthop tracking

### DIFF
--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -69,6 +69,10 @@
 #define BGP_PREFIX_SID_IPV6_LENGTH            19
 #define BGP_PREFIX_SID_ORIGINATOR_SRGB_LENGTH  6
 
+#define BGP_ATTR_NH_AFI(afi, attr) \
+	((afi != AFI_L2VPN) ? afi : \
+	((attr->mp_nexthop_len == BGP_ATTR_NHLEN_IPV4) ? AFI_IP : AFI_IP6))
+
 /* PMSI tunnel types (RFC 6514) */
 
 struct bgp_attr_encap_subtlv {

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -6026,3 +6026,26 @@ int bgp_evpn_get_type5_prefixlen(struct prefix *pfx)
 
 	return evp->prefix.prefix_addr.ip_prefix_length;
 }
+
+/*
+ * Should we register nexthop for this EVPN prefix for nexthop tracking?
+ */
+bool bgp_evpn_is_prefix_nht_supported(struct prefix *pfx)
+{
+	struct prefix_evpn *evp = (struct prefix_evpn *)pfx;
+
+	/*
+	 * EVPN RT-5 should not be marked as valid and imported to vrfs if the
+	 * BGP nexthop is not reachable. To check for the nexthop reachability,
+	 * Add nexthop for EVPN RT-5 for nexthop tracking.
+	 *
+	 * Ideally, a BGP route should be marked as valid only if the
+	 * nexthop is reachable. Thus, other EVPN route types also should be
+	 * added here after testing is performed for them.
+	 */
+	if (pfx && pfx->family == AF_EVPN &&
+	    evp->prefix.route_type == BGP_EVPN_IP_PREFIX_ROUTE)
+		return true;
+
+	return false;
+}

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -191,5 +191,6 @@ extern void bgp_evpn_cleanup_on_disable(struct bgp *bgp);
 extern void bgp_evpn_cleanup(struct bgp *bgp);
 extern void bgp_evpn_init(struct bgp *bgp);
 extern int bgp_evpn_get_type5_prefixlen(struct prefix *pfx);
+extern bool bgp_evpn_is_prefix_nht_supported(struct prefix *pfx);
 
 #endif /* _QUAGGA_BGP_EVPN_H */

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -43,6 +43,7 @@
 #include "bgpd/bgp_fsm.h"
 #include "bgpd/bgp_zebra.h"
 #include "bgpd/bgp_flowspec_util.h"
+#include "bgpd/bgp_evpn.h"
 
 extern struct zclient *zclient;
 
@@ -772,6 +773,16 @@ static void evaluate_paths(struct bgp_nexthop_cache *bnc)
 		if (CHECK_FLAG(bnc->change_flags, BGP_NEXTHOP_METRIC_CHANGED)
 		    || CHECK_FLAG(bnc->change_flags, BGP_NEXTHOP_CHANGED))
 			SET_FLAG(path->flags, BGP_PATH_IGP_CHANGED);
+
+		if (safi == SAFI_EVPN &&
+		    bgp_evpn_is_prefix_nht_supported(&rn->p)) {
+			if (CHECK_FLAG(path->flags, BGP_PATH_VALID))
+				bgp_evpn_import_route(bgp_path, afi, safi,
+						      &rn->p, path);
+			else
+				bgp_evpn_unimport_route(bgp_path, afi, safi,
+							&rn->p, path);
+		}
 
 		bgp_process(bgp_path, rn, afi, safi);
 	}


### PR DESCRIPTION
Problem statement:
When IPv4/IPv6 prefixes are received in BGP, bgp_update function registers the
nexthop of the route with nexthop tracking module. The BGP route is marked as
valid only if the nexthop is resolved.

Even for EVPN RT-5, route should be marked as valid only if the the nexthop is
resolvable.

Code changes:
1. Add nexthop of EVPN RT-5 for nexthop tracking. Route will be marked as valid
only if the nexthop is resolved.
2. Only the valid EVPN routes are imported to the vrf.
3. When nht update is received in BGP, make sure that the EVPN routes are
imported/unimported based on the route becomes valid/invalid.

Testcases:
1. At rtr-1, advertise EVPN RT-5 with a nexthop 10.100.0.2.
10.100.0.2 is resolved at rtr-2 in default vrf.
At rtr-2, remote EVPN RT-5 should be marked as valid and should be imported into
vrfs.

2. Make the nexthop 10.100.0.2 unreachable at rtr-2
Remote EVPN RT-5 should be marked as invalid and should be unimported from the
vrfs. As this code change deals with EVPN type-5 routes only, other EVPN routes
should be valid.

3. At rtr-2, add a static route to make nexthop 10.100.0.2 reachable.
EVPN RT-5 should again become valid and should be imported into the vrfs.

Signed-off-by: Ameya Dharkar <adharkar@vmware.com>