### PR TITLE
[7.2] ldpd: add missing sanity check in the parsing of label messages

### DIFF
--- a/ldpd/labelmapping.c
+++ b/ldpd/labelmapping.c
@@ -723,6 +723,14 @@ tlv_decode_fec_elm(struct nbr *nbr, struct ldp_msg *msg, char *buf,
 		/* Prefix Length */
 		map->fec.prefix.prefixlen = buf[off];
 		off += sizeof(uint8_t);
+		if ((map->fec.prefix.af == AF_IPV4
+		     && map->fec.prefix.prefixlen > IPV4_MAX_PREFIXLEN)
+		    || (map->fec.prefix.af == AF_IPV6
+			&& map->fec.prefix.prefixlen > IPV6_MAX_PREFIXLEN)) {
+			session_shutdown(nbr, S_BAD_TLV_VAL, msg->id,
+			    msg->type);
+			return (-1);
+		}
 		if (len < off + PREFIX_SIZE(map->fec.prefix.prefixlen)) {
 			session_shutdown(nbr, S_BAD_TLV_LEN, msg->id,
 			    msg->type);


### PR DESCRIPTION
Validate that the FEC prefix length is within the allowed limit
(depending on the FEC address family) in order to prevent possible
buffer overflows in the ldpe child process.

Signed-off-by: Renato Westphal renato@opensourcerouting.org