### PR TITLE
bfdd: remove unused initialization sa warning

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -523,13 +523,14 @@ int bfd_recv_cb(struct thread *t)
 	bool is_mhop;
 	ssize_t mlen = 0;
 	uint8_t ttl = 0;
-	vrf_id_t vrfid = VRF_DEFAULT;
+	vrf_id_t vrfid;
 	ifindex_t ifindex = IFINDEX_INTERNAL;
 	struct sockaddr_any local, peer;
 	uint8_t msgbuf[1516];
 	struct bfd_vrf_global *bvrf = THREAD_ARG(t);
 
 	vrfid = bvrf->vrf->vrf_id;
+
 	/* Schedule next read. */
 	bfd_sd_reschedule(bvrf, sd);
 


### PR DESCRIPTION
There's a variable initialization that's triggering an SA warning - stop doing that.
