### PR TITLE
bgpd: Add missing whitespace in update_subgroup_remove_peer_internal()

### DIFF
--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -917,7 +917,7 @@ static void update_subgroup_remove_peer_internal(struct update_subgroup *subgrp,
 
 	if (BGP_DEBUG(update_groups, UPDATE_GROUPS))
 		zlog_debug("peer %s deleted from subgroup s%"
-			   PRIu64 "peer cnt %d",
+			   PRIu64 " peer cnt %d",
 			   paf->peer->host, subgrp->id, subgrp->peer_count);
 	SUBGRP_INCR_STAT(subgrp, prune_events);
 }


### PR DESCRIPTION
Before the fix:

2019/11/14 19:52:21 BGP: peer 192.168.2.5 deleted from subgroup s4peer
cnt 0 - missing space after s4 before peer

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>