### PR TITLE
PIM state machine fixes

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2089,7 +2089,7 @@ static void pim_show_state(struct pim_instance *pim, struct vty *vty,
 		} else {
 			vty_out(vty, "%-6d %-15s  %-15s  %-3s  %-16s  ",
 					c_oil->installed, src_str, grp_str,
-					isRpt? "y" : "n", in_ifname);
+					isRpt ? "y" : "n", in_ifname);
 		}
 
 		for (oif_vif_index = 0; oif_vif_index < MAXVIFS;

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -5405,6 +5405,11 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 					& PIM_OIF_FLAG_MUTE)
 				continue;
 
+			if (c_oil->oil.mfcc_parent == oif_vif_index &&
+					!pim_mroute_allow_iif_in_oil(c_oil,
+						oif_vif_index))
+				continue;
+
 			ifp_out = pim_if_find_by_vif_index(pim, oif_vif_index);
 			pim_time_uptime(
 				mroute_uptime, sizeof(mroute_uptime),

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -2577,7 +2577,7 @@ static void pim_show_upstream(struct pim_instance *pim, struct vty *vty,
 	}
 }
 
-static void pim_show_join_desired_helper(struct pim_instance *pim,
+static void pim_show_channel_helper(struct pim_instance *pim,
 					 struct vty *vty,
 					 struct pim_interface *pim_ifp,
 					 struct pim_ifchannel *ch,
@@ -2636,7 +2636,7 @@ static void pim_show_join_desired_helper(struct pim_instance *pim,
 	}
 }
 
-static void pim_show_join_desired(struct pim_instance *pim, struct vty *vty,
+static void pim_show_channel(struct pim_instance *pim, struct vty *vty,
 				  bool uj)
 {
 	struct pim_interface *pim_ifp;
@@ -2660,7 +2660,7 @@ static void pim_show_join_desired(struct pim_instance *pim, struct vty *vty,
 
 		RB_FOREACH (ch, pim_ifchannel_rb, &pim_ifp->ifchannel_rb) {
 			/* scan all interfaces */
-			pim_show_join_desired_helper(pim, vty, pim_ifp, ch,
+			pim_show_channel_helper(pim, vty, pim_ifp, ch,
 						     json, uj);
 		}
 	}
@@ -4809,14 +4809,14 @@ DEFUN (show_ip_pim_upstream_vrf_all,
 	return CMD_SUCCESS;
 }
 
-DEFUN (show_ip_pim_upstream_join_desired,
-       show_ip_pim_upstream_join_desired_cmd,
-       "show ip pim [vrf NAME] upstream-join-desired [json]",
+DEFUN (show_ip_pim_channel,
+       show_ip_pim_channel_cmd,
+       "show ip pim [vrf NAME] channel [json]",
        SHOW_STR
        IP_STR
        PIM_STR
        VRF_CMD_HELP_STR
-       "PIM upstream join-desired\n"
+       "PIM downstream channel info\n"
        JSON_STR)
 {
 	int idx = 2;
@@ -4826,7 +4826,7 @@ DEFUN (show_ip_pim_upstream_join_desired,
 	if (!vrf)
 		return CMD_WARNING;
 
-	pim_show_join_desired(vrf->info, vty, uj);
+	pim_show_channel(vrf->info, vty, uj);
 
 	return CMD_SUCCESS;
 }
@@ -10456,7 +10456,7 @@ void pim_cmd_init(void)
 	install_element(VIEW_NODE, &show_ip_pim_state_vrf_all_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_upstream_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_upstream_vrf_all_cmd);
-	install_element(VIEW_NODE, &show_ip_pim_upstream_join_desired_cmd);
+	install_element(VIEW_NODE, &show_ip_pim_channel_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_upstream_rpf_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_rp_cmd);
 	install_element(VIEW_NODE, &show_ip_pim_rp_vrf_all_cmd);

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1414,9 +1414,6 @@ void pim_ifchannel_set_star_g_join_state(struct pim_ifchannel *ch, int eom,
 					__func__);
 				pim_upstream_update_join_desired(pim,
 						child->upstream);
-				pim_jp_agg_single_upstream_send(
-					&child->upstream->rpf, child->upstream,
-					true);
 			}
 			send_upstream_starg = true;
 

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -147,10 +147,11 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 					ch->upstream, ch, ch->parent))
 			pim_channel_add_oif(ch->upstream->channel_oil,
 					ch->interface,
-					PIM_OIF_FLAG_PROTO_STAR);
+					PIM_OIF_FLAG_PROTO_STAR,
+					__func__);
 
 		pim_channel_del_oif(ch->upstream->channel_oil,
-					ch->interface, mask);
+					ch->interface, mask, __func__);
 		/*
 		 * Do we have any S,G's that are inheriting?
 		 * Nuke from on high too.
@@ -163,7 +164,8 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 						  up_node, child))
 				pim_channel_del_oif(child->channel_oil,
 						    ch->interface,
-						    PIM_OIF_FLAG_PROTO_STAR);
+						    PIM_OIF_FLAG_PROTO_STAR,
+							__func__);
 		}
 	}
 
@@ -297,7 +299,8 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 						    pim_ifp->pim, child)) {
 						pim_channel_del_oif(
 							c_oil, ch->interface,
-							PIM_OIF_FLAG_PROTO_STAR);
+							PIM_OIF_FLAG_PROTO_STAR,
+							__func__);
 						pim_upstream_update_join_desired(
 							pim_ifp->pim, child);
 					}
@@ -314,7 +317,8 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 						    [pim_ifp->mroute_vif_index])
 						pim_channel_del_oif(
 							c_oil, ch->interface,
-							PIM_OIF_FLAG_PROTO_STAR);
+							PIM_OIF_FLAG_PROTO_STAR,
+							__func__);
 				}
 			}
 			if (ch->ifjoin_state == PIM_IFJOIN_JOIN) {
@@ -333,7 +337,8 @@ void pim_ifchannel_ifjoin_switch(const char *caller, struct pim_ifchannel *ch,
 						pim_channel_add_oif(
 							child->channel_oil,
 							ch->interface,
-							PIM_OIF_FLAG_PROTO_STAR);
+							PIM_OIF_FLAG_PROTO_STAR,
+							__func__);
 						pim_upstream_update_join_desired(
 							pim_ifp->pim, child);
 					}
@@ -904,7 +909,8 @@ void pim_ifchannel_join_add(struct interface *ifp, struct in_addr neigh_addr,
 							       ch->upstream)) {
 				pim_channel_add_oif(ch->upstream->channel_oil,
 						    ch->interface,
-						    PIM_OIF_FLAG_PROTO_PIM);
+						    PIM_OIF_FLAG_PROTO_PIM,
+							__func__);
 				pim_upstream_update_join_desired(pim_ifp->pim,
 								 ch->upstream);
 			}
@@ -1105,7 +1111,8 @@ int pim_ifchannel_local_membership_add(struct interface *ifp,
 			if (pim_upstream_evaluate_join_desired_interface(
 				    child, ch, starch)) {
 				pim_channel_add_oif(child->channel_oil, ifp,
-						    PIM_OIF_FLAG_PROTO_STAR);
+						    PIM_OIF_FLAG_PROTO_STAR,
+							__func__);
 				pim_upstream_switch(pim, child,
 						    PIM_UPSTREAM_JOINED);
 			}
@@ -1124,12 +1131,14 @@ int pim_ifchannel_local_membership_add(struct interface *ifp,
 				    == PREFIX_DENY) {
 					pim_channel_add_oif(
 						up->channel_oil, pim->regiface,
-						PIM_OIF_FLAG_PROTO_IGMP);
+						PIM_OIF_FLAG_PROTO_IGMP,
+						__func__);
 				}
 			}
 		} else
 			pim_channel_add_oif(up->channel_oil, pim->regiface,
-					    PIM_OIF_FLAG_PROTO_IGMP);
+					PIM_OIF_FLAG_PROTO_IGMP,
+					__func__);
 	}
 
 	return 1;
@@ -1178,7 +1187,8 @@ void pim_ifchannel_local_membership_del(struct interface *ifp,
 			    && !pim_upstream_evaluate_join_desired_interface(
 				       child, ch, starch))
 				pim_channel_del_oif(c_oil, ifp,
-						    PIM_OIF_FLAG_PROTO_STAR);
+						    PIM_OIF_FLAG_PROTO_STAR,
+							__func__);
 
 			/*
 			 * If the S,G has no if channel and the c_oil still
@@ -1189,7 +1199,8 @@ void pim_ifchannel_local_membership_del(struct interface *ifp,
 			if (!chchannel && c_oil
 			    && c_oil->oil.mfcc_ttls[pim_ifp->mroute_vif_index])
 				pim_channel_del_oif(c_oil, ifp,
-						    PIM_OIF_FLAG_PROTO_STAR);
+						    PIM_OIF_FLAG_PROTO_STAR,
+							__func__);
 
 			/* Child node removal/ref count-- will happen as part of
 			 * parent' delete_no_info */
@@ -1408,7 +1419,8 @@ void pim_ifchannel_set_star_g_join_state(struct pim_ifchannel *ch, int eom,
 				child->upstream))) {
 				pim_channel_add_oif(
 					child->upstream->channel_oil,
-					ch->interface, PIM_OIF_FLAG_PROTO_STAR);
+					ch->interface, PIM_OIF_FLAG_PROTO_STAR,
+					__func__);
 				pim_upstream_switch(pim, child->upstream,
 						    PIM_UPSTREAM_JOINED);
 				pim_jp_agg_single_upstream_send(

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -181,9 +181,7 @@ void pim_ifchannel_delete(struct pim_ifchannel *ch)
 
 	listnode_delete(ch->upstream->ifchannels, ch);
 
-	if (ch->ifjoin_state != PIM_IFJOIN_NOINFO) {
-		pim_upstream_update_join_desired(pim_ifp->pim, ch->upstream);
-	}
+	pim_upstream_update_join_desired(pim_ifp->pim, ch->upstream);
 
 	/* upstream is common across ifchannels, check if upstream's
 	   ifchannel list is empty before deleting upstream_del

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -340,7 +340,8 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 					pim_channel_del_oif(
 						up->channel_oil,
 						starg_ch->interface,
-						PIM_OIF_FLAG_PROTO_STAR);
+						PIM_OIF_FLAG_PROTO_STAR,
+						__func__);
 				}
 			}
 		}

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -337,10 +337,9 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 							"%s: SGRpt flag is set, del inherit oif from up %s",
 							__PRETTY_FUNCTION__,
 							up->sg_str);
-					pim_channel_del_oif(
+					pim_channel_del_inherited_oif(
 						up->channel_oil,
 						starg_ch->interface,
-						PIM_OIF_FLAG_PROTO_STAR,
 						__func__);
 				}
 			}

--- a/pimd/pim_join.c
+++ b/pimd/pim_join.c
@@ -316,7 +316,6 @@ int pim_joinprune_recv(struct interface *ifp, struct pim_neighbor *neigh,
 			recv_prune(ifp, neigh, msg_holdtime,
 				   msg_upstream_addr.u.prefix4, &sg,
 				   msg_source_flags);
-
 			/*
 			 * So if we are receiving a S,G,RPT prune
 			 * before we have any data for that S,G

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -338,10 +338,10 @@ void pim_jp_agg_single_upstream_send(struct pim_rpf *rpf,
 	static bool first = true;
 
 	/* skip JP upstream messages if source is directly connected */
-	if (!up || !rpf->source_nexthop.interface || pim_if_connected_to_source(
-							     rpf->source_nexthop
-								     .interface,
-							     up->sg.src))
+	if (!up || !rpf->source_nexthop.interface ||
+		pim_if_connected_to_source(rpf->source_nexthop.interface,
+			up->sg.src) ||
+		if_is_loopback_or_vrf(rpf->source_nexthop.interface))
 		return;
 
 	if (first) {

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -117,9 +117,15 @@ void pim_jp_agg_clear_group(struct list *group)
 static struct pim_iface_upstream_switch *
 pim_jp_agg_get_interface_upstream_switch_list(struct pim_rpf *rpf)
 {
-	struct pim_interface *pim_ifp = rpf->source_nexthop.interface->info;
+	struct interface *ifp = rpf->source_nexthop.interface;
+	struct pim_interface *pim_ifp;
 	struct pim_iface_upstream_switch *pius;
 	struct listnode *node, *nnode;
+
+	if (!ifp)
+		return NULL;
+
+	pim_ifp = ifp->info;
 
 	/* Old interface is pim disabled */
 	if (!pim_ifp)

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -323,7 +323,8 @@ void pim_jp_agg_switch_interface(struct pim_rpf *orpf, struct pim_rpf *nrpf,
 		pim_jp_agg_add_group(opius->us, up, false);
 
 	/* send Join(S,G) to the current upstream neighbor */
-	pim_jp_agg_add_group(npius->us, up, true);
+	if (npius)
+		pim_jp_agg_add_group(npius->us, up, true);
 }
 
 

--- a/pimd/pim_jp_agg.h
+++ b/pimd/pim_jp_agg.h
@@ -37,10 +37,11 @@ void pim_jp_agg_group_list_free(struct pim_jp_agg_group *jag);
 int pim_jp_agg_group_list_cmp(void *arg1, void *arg2);
 
 void pim_jp_agg_clear_group(struct list *group);
-void pim_jp_agg_remove_group(struct list *group, struct pim_upstream *up);
+void pim_jp_agg_remove_group(struct list *group, struct pim_upstream *up,
+		struct pim_neighbor *nbr);
 
 void pim_jp_agg_add_group(struct list *group, struct pim_upstream *up,
-			  bool is_join);
+		bool is_join, struct pim_neighbor *nbr);
 
 void pim_jp_agg_switch_interface(struct pim_rpf *orpf, struct pim_rpf *nrpf,
 				 struct pim_upstream *up);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -323,6 +323,15 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 					pim_str_sg_dump(&sg));
 			return 0;
 		}
+
+		if (!PIM_UPSTREAM_FLAG_TEST_FHR(up->flags)) {
+			if (PIM_DEBUG_PIM_REG)
+				zlog_debug(
+					"%s register forward skipped, not FHR",
+					up->sg_str);
+			return 0;
+		}
+
 		pim_register_send((uint8_t *)buf + sizeof(struct ip),
 				  ntohs(ip_hdr->ip_len) - sizeof(struct ip),
 				  pim_ifp->primary_address, rpg, 0, up);

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -277,8 +277,7 @@ static int pim_mroute_msg_wholepkt(int fd, struct interface *ifp,
 			pim_upstream_keep_alive_timer_start(
 				up, pim_ifp->pim->keep_alive_time);
 			pim_upstream_inherited_olist(pim_ifp->pim, up);
-			pim_upstream_switch(pim_ifp->pim, up,
-					    PIM_UPSTREAM_JOINED);
+			pim_upstream_update_join_desired(pim_ifp->pim, up);
 
 			if (PIM_DEBUG_MROUTE)
 				zlog_debug("%s: Creating %s upstream on LHR",

--- a/pimd/pim_mroute.h
+++ b/pimd/pim_mroute.h
@@ -183,4 +183,6 @@ void pim_static_mroute_iif_update(struct channel_oil *c_oil,
 int pim_mroute_del(struct channel_oil *c_oil, const char *name);
 
 void pim_mroute_update_counters(struct channel_oil *c_oil);
+bool pim_mroute_allow_iif_in_oil(struct channel_oil *c_oil,
+		int oif_index);
 #endif /* PIM_MROUTE_H */

--- a/pimd/pim_mroute.h
+++ b/pimd/pim_mroute.h
@@ -175,7 +175,11 @@ int pim_mroute_add_vif(struct interface *ifp, struct in_addr ifaddr,
 int pim_mroute_del_vif(struct interface *ifp);
 
 int pim_upstream_mroute_add(struct channel_oil *c_oil, const char *name);
+int pim_upstream_mroute_iif_update(struct channel_oil *c_oil, const char *name);
 int pim_static_mroute_add(struct channel_oil *c_oil, const char *name);
+void pim_static_mroute_iif_update(struct channel_oil *c_oil,
+				int input_vif_index,
+				const char *name);
 int pim_mroute_del(struct channel_oil *c_oil, const char *name);
 
 void pim_mroute_update_counters(struct channel_oil *c_oil);

--- a/pimd/pim_mroute.h
+++ b/pimd/pim_mroute.h
@@ -174,7 +174,8 @@ int pim_mroute_add_vif(struct interface *ifp, struct in_addr ifaddr,
 		       unsigned char flags);
 int pim_mroute_del_vif(struct interface *ifp);
 
-int pim_mroute_add(struct channel_oil *c_oil, const char *name);
+int pim_upstream_mroute_add(struct channel_oil *c_oil, const char *name);
+int pim_static_mroute_add(struct channel_oil *c_oil, const char *name);
 int pim_mroute_del(struct channel_oil *c_oil, const char *name);
 
 void pim_mroute_update_counters(struct channel_oil *c_oil);

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -445,10 +445,9 @@ static bool pim_msdp_sa_local_add_ok(struct pim_upstream *up)
 		return false;
 	}
 
-	if (!up->t_ka_timer) {
+	if (!pim_upstream_is_kat_running(up))
 		/* stream is not active */
 		return false;
-	}
 
 	if (!I_am_RP(pim, up->sg.grp)) {
 		/* we are not RP for the group */

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -126,7 +126,12 @@ static void pim_msdp_sa_upstream_del(struct pim_msdp_sa *sa)
 	if (PIM_UPSTREAM_FLAG_TEST_SRC_MSDP(up->flags)) {
 		PIM_UPSTREAM_FLAG_UNSET_SRC_MSDP(up->flags);
 		sa->flags |= PIM_MSDP_SAF_UP_DEL_IN_PROG;
-		pim_upstream_del(sa->pim, up, __PRETTY_FUNCTION__);
+		up = pim_upstream_del(sa->pim, up, __PRETTY_FUNCTION__);
+		/* re-eval joinDesired; clearing peer-msdp-sa flag can
+		 * cause JD to change
+		 */
+		if (up)
+			pim_upstream_update_join_desired(sa->pim, up);
 		sa->flags &= ~PIM_MSDP_SAF_UP_DEL_IN_PROG;
 	}
 

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -446,7 +446,7 @@ static int pim_update_upstream_nh_helper(struct hash_bucket *bucket, void *arg)
 	struct pim_rpf old;
 
 	old.source_nexthop.interface = up->rpf.source_nexthop.interface;
-	rpf_result = pim_rpf_update(pim, up, &old);
+	rpf_result = pim_rpf_update(pim, up, &old, __func__);
 	if (rpf_result == PIM_RPF_FAILURE) {
 		pim_upstream_rpf_clear(pim, up);
 		return HASHWALK_CONTINUE;

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -447,15 +447,16 @@ static int pim_update_upstream_nh_helper(struct hash_bucket *bucket, void *arg)
 
 	old.source_nexthop.interface = up->rpf.source_nexthop.interface;
 	rpf_result = pim_rpf_update(pim, up, &old, __func__);
-	if (rpf_result == PIM_RPF_FAILURE) {
-		pim_upstream_rpf_clear(pim, up);
-		return HASHWALK_CONTINUE;
-	}
 
-	/* update kernel multicast forwarding cache (MFC) */
-	pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+	/* update kernel multicast forwarding cache (MFC); if the
+	 * RPF nbr is now unreachable the MFC has already been updated
+	 * by pim_rpf_clear
+	 */
+	if (rpf_result != PIM_RPF_FAILURE)
+		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 
-	if (rpf_result == PIM_RPF_CHANGED)
+	if (rpf_result == PIM_RPF_CHANGED ||
+		(rpf_result == PIM_RPF_FAILURE && old.source_nexthop.interface))
 		pim_zebra_upstream_rpf_changed(pim, up, &old);
 
 
@@ -464,7 +465,8 @@ static int pim_update_upstream_nh_helper(struct hash_bucket *bucket, void *arg)
 			__PRETTY_FUNCTION__, up->sg_str, pim->vrf->name,
 			old.source_nexthop.interface
 			? old.source_nexthop.interface->name : "Unknown",
-			up->rpf.source_nexthop.interface->name);
+			up->rpf.source_nexthop.interface
+			? up->rpf.source_nexthop.interface->name : "Unknown");
 	}
 
 	return HASHWALK_CONTINUE;

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -352,6 +352,21 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 	return 0;
 }
 
+void pim_channel_del_inherited_oif(struct channel_oil *c_oil,
+		struct interface *oif, const char *caller)
+{
+	struct pim_upstream *up = c_oil->up;
+
+	pim_channel_del_oif(c_oil, oif, PIM_OIF_FLAG_PROTO_STAR,
+			caller);
+
+	/* if an inherited OIF is being removed join-desired can change
+	 * if the inherited OIL is now empty and KAT is running
+	 */
+	if (up && up->sg.src.s_addr != INADDR_ANY &&
+			pim_upstream_empty_inherited_olist(up))
+		pim_upstream_update_join_desired(up->pim, up);
+}
 
 static bool pim_channel_eval_oif_mute(struct channel_oil *c_oil,
 		struct pim_interface *pim_ifp)

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -623,6 +623,10 @@ int pim_channel_oil_empty(struct channel_oil *c_oil)
 	if (!c_oil)
 		return 1;
 
-	return !memcmp(c_oil->oil.mfcc_ttls,
-			null_oil.mfcc_ttls, sizeof(null_oil.mfcc_ttls));
+	/* exclude pimreg from the OIL when checking if the inherited_oil is
+	 * non-NULL.
+	 * pimreg device (in all vrfs) uses a vifi of
+	 * 0 (PIM_OIF_PIM_REGISTER_VIF) so we simply mfcc_ttls[0] */
+	return !memcmp(&c_oil->oil.mfcc_ttls[1], &null_oil.mfcc_ttls[1],
+		sizeof(null_oil.mfcc_ttls) - sizeof(null_oil.mfcc_ttls[0]));
 }

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -178,10 +178,10 @@ void pim_channel_oil_change_iif(struct pim_instance *pim,
 		if (input_vif_index == MAXVIFS)
 			pim_mroute_del(c_oil, name);
 		else
-			pim_mroute_add(c_oil, name);
+			pim_upstream_mroute_add(c_oil, name);
 	} else
 		if (old_vif_index == MAXVIFS)
-			pim_mroute_add(c_oil, name);
+			pim_upstream_mroute_add(c_oil, name);
 
 	return;
 }
@@ -368,7 +368,7 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 	/* clear mute; will be re-evaluated when the OIF becomes valid again */
 	channel_oil->oif_flags[pim_ifp->mroute_vif_index] &= ~PIM_OIF_FLAG_MUTE;
 
-	if (pim_mroute_add(channel_oil, __PRETTY_FUNCTION__)) {
+	if (pim_upstream_mroute_add(channel_oil, __PRETTY_FUNCTION__)) {
 		if (PIM_DEBUG_MROUTE) {
 			char group_str[INET_ADDRSTRLEN];
 			char source_str[INET_ADDRSTRLEN];
@@ -475,7 +475,7 @@ void pim_channel_update_oif_mute(struct channel_oil *c_oil,
 		c_oil->oif_flags[pim_ifp->mroute_vif_index] &=
 			~PIM_OIF_FLAG_MUTE;
 
-	pim_mroute_add(c_oil, __PRETTY_FUNCTION__);
+	pim_upstream_mroute_add(c_oil, __PRETTY_FUNCTION__);
 }
 
 /* pim_upstream has been set or cleared on the c_oil. re-eval mute state
@@ -654,7 +654,7 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 	 * valid to get installed in kernel.
 	 */
 	if (channel_oil->oil.mfcc_parent != MAXVIFS) {
-		if (pim_mroute_add(channel_oil, __PRETTY_FUNCTION__)) {
+		if (pim_upstream_mroute_add(channel_oil, __PRETTY_FUNCTION__)) {
 			if (PIM_DEBUG_MROUTE) {
 				char group_str[INET_ADDRSTRLEN];
 				char source_str[INET_ADDRSTRLEN];

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -273,7 +273,7 @@ void pim_channel_oil_del(struct channel_oil *c_oil, const char *name)
 }
 
 int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
-			uint32_t proto_mask)
+			uint32_t proto_mask, const char *caller)
 {
 	struct pim_interface *pim_ifp;
 
@@ -363,8 +363,8 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 		pim_inet4_dump("<source?>", channel_oil->oil.mfcc_origin,
 			       source_str, sizeof(source_str));
 		zlog_debug(
-			"%s %s: (S,G)=(%s,%s): proto_mask=%u IIF:%d OIF=%s vif_index=%d",
-			__FILE__, __PRETTY_FUNCTION__, source_str, group_str,
+			"%s(%s): (S,G)=(%s,%s): proto_mask=%u IIF:%d OIF=%s vif_index=%d",
+			__PRETTY_FUNCTION__, caller, source_str, group_str,
 			proto_mask, channel_oil->oil.mfcc_parent, oif->name,
 			pim_ifp->mroute_vif_index);
 	}
@@ -374,7 +374,7 @@ int pim_channel_del_oif(struct channel_oil *channel_oil, struct interface *oif,
 
 
 int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
-			uint32_t proto_mask)
+			uint32_t proto_mask, const char *caller)
 {
 	struct pim_interface *pim_ifp;
 	int old_ttl;
@@ -557,8 +557,8 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 		pim_inet4_dump("<source?>", channel_oil->oil.mfcc_origin,
 			       source_str, sizeof(source_str));
 		zlog_debug(
-			"%s %s: (S,G)=(%s,%s): proto_mask=%u OIF=%s vif_index=%d: DONE",
-			__FILE__, __PRETTY_FUNCTION__, source_str, group_str,
+			"%s(%s): (S,G)=(%s,%s): proto_mask=%u OIF=%s vif_index=%d: DONE",
+			__PRETTY_FUNCTION__, caller, source_str, group_str,
 			proto_mask, oif->name, pim_ifp->mroute_vif_index);
 	}
 

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -646,19 +646,11 @@ int pim_channel_add_oif(struct channel_oil *channel_oil, struct interface *oif,
 
 int pim_channel_oil_empty(struct channel_oil *c_oil)
 {
-	static uint32_t zero[MAXVIFS];
-	static int inited = 0;
+	static struct mfcctl null_oil;
 
 	if (!c_oil)
 		return 1;
-	/*
-	 * Not sure that this is necessary, but I would rather ensure
-	 * that this works.
-	 */
-	if (!inited) {
-		memset(&zero, 0, sizeof(uint32_t) * MAXVIFS);
-		inited = 1;
-	}
 
-	return !memcmp(c_oil->oil.mfcc_ttls, zero, MAXVIFS * sizeof(uint32_t));
+	return !memcmp(c_oil->oil.mfcc_ttls,
+			null_oil.mfcc_ttls, sizeof(null_oil.mfcc_ttls));
 }

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -116,7 +116,7 @@ struct channel_oil *pim_find_channel_oil(struct pim_instance *pim,
 					 struct prefix_sg *sg);
 struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 					struct prefix_sg *sg,
-					int input_vif_index, const char *name);
+					const char *name);
 void pim_channel_oil_change_iif(struct pim_instance *pim,
 				struct channel_oil *c_oil, int input_vif_index,
 				const char *name);

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -136,4 +136,7 @@ void pim_channel_update_oif_mute(struct channel_oil *c_oil,
 		struct pim_interface *pim_ifp);
 
 void pim_channel_oil_upstream_deref(struct channel_oil *c_oil);
+void pim_channel_del_inherited_oif(struct channel_oil *c_oil,
+		struct interface *oif, const char *caller);
+
 #endif /* PIM_OIL_H */

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -120,9 +120,9 @@ void pim_channel_oil_change_iif(struct pim_instance *pim,
 void pim_channel_oil_del(struct channel_oil *c_oil, const char *name);
 
 int pim_channel_add_oif(struct channel_oil *c_oil, struct interface *oif,
-			uint32_t proto_mask);
+			uint32_t proto_mask, const char *caller);
 int pim_channel_del_oif(struct channel_oil *c_oil, struct interface *oif,
-			uint32_t proto_mask);
+			uint32_t proto_mask, const char *caller);
 
 int pim_channel_oil_empty(struct channel_oil *c_oil);
 

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -21,6 +21,7 @@
 #define PIM_OIL_H
 
 #include "pim_mroute.h"
+#include "pim_iface.h"
 
 /*
  * Where did we get this (S,G) from?
@@ -38,6 +39,8 @@
 	(PIM_OIF_FLAG_PROTO_IGMP | PIM_OIF_FLAG_PROTO_PIM      \
 	 | PIM_OIF_FLAG_PROTO_STAR | PIM_OIF_FLAG_PROTO_VXLAN)
 
+/* OIF is present in the OIL but must not be used for forwarding traffic */
+#define PIM_OIF_FLAG_MUTE         (1 << 4)
 /*
  * We need a pimreg vif id from the kernel.
  * Since ifindex == vif id for most cases and the number
@@ -127,4 +130,7 @@ int pim_channel_del_oif(struct channel_oil *c_oil, struct interface *oif,
 int pim_channel_oil_empty(struct channel_oil *c_oil);
 
 char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size);
+
+void pim_channel_update_oif_mute(struct channel_oil *c_oil,
+		struct pim_interface *pim_ifp);
 #endif /* PIM_OIL_H */

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -120,7 +120,8 @@ struct channel_oil *pim_channel_oil_add(struct pim_instance *pim,
 void pim_channel_oil_change_iif(struct pim_instance *pim,
 				struct channel_oil *c_oil, int input_vif_index,
 				const char *name);
-void pim_channel_oil_del(struct channel_oil *c_oil, const char *name);
+struct channel_oil *pim_channel_oil_del(struct channel_oil *c_oil,
+		const char *name);
 
 int pim_channel_add_oif(struct channel_oil *c_oil, struct interface *oif,
 			uint32_t proto_mask, const char *caller);
@@ -133,4 +134,6 @@ char *pim_channel_oil_dump(struct channel_oil *c_oil, char *buf, size_t size);
 
 void pim_channel_update_oif_mute(struct channel_oil *c_oil,
 		struct pim_interface *pim_ifp);
+
+void pim_channel_oil_upstream_deref(struct channel_oil *c_oil);
 #endif /* PIM_OIL_H */

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -452,7 +452,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 		}
 
 		if ((upstream->sptbit == PIM_UPSTREAM_SPTBIT_TRUE)
-		    || ((SwitchToSptDesired(pim_ifp->pim, &sg))
+		    || ((SwitchToSptDesiredOnRp(pim_ifp->pim, &sg))
 			&& pim_upstream_inherited_olist(pim_ifp->pim, upstream)
 				   == 0)) {
 			pim_register_stop_send(ifp, &sg, dest_addr, src_addr);
@@ -463,7 +463,7 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 					   upstream->sptbit);
 		}
 		if ((upstream->sptbit == PIM_UPSTREAM_SPTBIT_TRUE)
-		    || (SwitchToSptDesired(pim_ifp->pim, &sg))) {
+		    || (SwitchToSptDesiredOnRp(pim_ifp->pim, &sg))) {
 			if (sentRegisterStop) {
 				pim_upstream_keep_alive_timer_start(
 					upstream,

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -455,7 +455,6 @@ int pim_register_recv(struct interface *ifp, struct in_addr dest_addr,
 		    || ((SwitchToSptDesired(pim_ifp->pim, &sg))
 			&& pim_upstream_inherited_olist(pim_ifp->pim, upstream)
 				   == 0)) {
-			// pim_scan_individual_oil (upstream->channel_oil);
 			pim_register_stop_send(ifp, &sg, dest_addr, src_addr);
 			sentRegisterStop = 1;
 		} else {

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -59,7 +59,7 @@ void pim_register_join(struct pim_upstream *up)
 	}
 
 	pim_channel_add_oif(up->channel_oil, pim->regiface,
-			    PIM_OIF_FLAG_PROTO_PIM);
+			    PIM_OIF_FLAG_PROTO_PIM, __func__);
 	up->reg_state = PIM_REG_JOIN;
 	pim_vxlan_update_sg_reg_state(pim, up, true /*reg_join*/);
 }
@@ -145,7 +145,7 @@ int pim_register_stop_recv(struct interface *ifp, uint8_t *buf, int buf_size)
 	case PIM_REG_JOIN:
 		upstream->reg_state = PIM_REG_PRUNE;
 		pim_channel_del_oif(upstream->channel_oil, pim->regiface,
-				    PIM_OIF_FLAG_PROTO_PIM);
+				    PIM_OIF_FLAG_PROTO_PIM, __func__);
 		pim_upstream_start_register_stop_timer(upstream, 0);
 		pim_vxlan_update_sg_reg_state(pim, upstream,
 			false/*reg_join*/);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -386,20 +386,8 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 		pim_mroute_del(up->channel_oil, __PRETTY_FUNCTION__);
 
 	/* update kernel multicast forwarding cache (MFC) */
-	if (up->rpf.source_nexthop.interface && up->channel_oil) {
-		ifindex_t ifindex = up->rpf.source_nexthop.interface->ifindex;
-		int vif_index = pim_if_find_vifindex_by_ifindex(pim, ifindex);
-		/* Pass Current selected NH vif index to mroute download */
-		if (vif_index)
-			pim_scan_individual_oil(up->channel_oil, vif_index);
-		else {
-			if (PIM_DEBUG_PIM_NHT)
-				zlog_debug(
-				  "%s: NHT upstream %s channel_oil IIF %s vif_index is not valid",
-				  __PRETTY_FUNCTION__, up->sg_str,
-				  up->rpf.source_nexthop.interface->name);
-		}
-	}
+	if (up->rpf.source_nexthop.interface && up->channel_oil)
+		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 
 	if (rpf_result == PIM_RPF_CHANGED)
 		pim_zebra_upstream_rpf_changed(pim, up, &old_rpf);

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -274,6 +274,7 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 static void pim_rp_refresh_group_to_rp_mapping(struct pim_instance *pim)
 {
 	pim_msdp_i_am_rp_changed(pim);
+	pim_upstream_reeval_use_rpt(pim);
 }
 
 void pim_rp_prefix_list_update(struct pim_instance *pim,
@@ -1041,6 +1042,7 @@ void pim_rp_check_on_if_add(struct pim_interface *pim_ifp)
 
 	if (i_am_rp_changed) {
 		pim_msdp_i_am_rp_changed(pim);
+		pim_upstream_reeval_use_rpt(pim);
 	}
 }
 
@@ -1083,6 +1085,7 @@ void pim_i_am_rp_re_evaluate(struct pim_instance *pim)
 
 	if (i_am_rp_changed) {
 		pim_msdp_i_am_rp_changed(pim);
+		pim_upstream_reeval_use_rpt(pim);
 	}
 }
 

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -382,7 +382,7 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 
 	old_rpf.source_nexthop.interface = up->rpf.source_nexthop.interface;
 
-	rpf_result = pim_rpf_update(pim, up, &old_rpf);
+	rpf_result = pim_rpf_update(pim, up, &old_rpf, __func__);
 	if (rpf_result == PIM_RPF_FAILURE)
 		pim_mroute_del(up->channel_oil, __PRETTY_FUNCTION__);
 

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -390,7 +390,9 @@ void pim_upstream_update(struct pim_instance *pim, struct pim_upstream *up)
 	if (up->rpf.source_nexthop.interface && up->channel_oil)
 		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 
-	if (rpf_result == PIM_RPF_CHANGED)
+	if (rpf_result == PIM_RPF_CHANGED ||
+			(rpf_result == PIM_RPF_FAILURE &&
+			 old_rpf.source_nexthop.interface))
 		pim_zebra_upstream_rpf_changed(pim, up, &old_rpf);
 
 	pim_zebra_update_all_interfaces(pim);

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -195,7 +195,8 @@ static int nexthop_mismatch(const struct pim_nexthop *nh1,
 }
 
 enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
-				   struct pim_upstream *up, struct pim_rpf *old)
+		struct pim_upstream *up, struct pim_rpf *old,
+		const char *caller)
 {
 	struct pim_rpf *rpf = &up->rpf;
 	struct pim_rpf saved;
@@ -207,8 +208,8 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 		return PIM_RPF_OK;
 
 	if (up->upstream_addr.s_addr == INADDR_ANY) {
-		zlog_debug("%s: RP is not configured yet for %s",
-			__PRETTY_FUNCTION__, up->sg_str);
+		zlog_debug("%s(%s): RP is not configured yet for %s",
+			__func__, caller, up->sg_str);
 		return PIM_RPF_OK;
 	}
 
@@ -238,8 +239,8 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	rpf->rpf_addr.u.prefix4 = pim_rpf_find_rpf_addr(up);
 	if (pim_rpf_addr_is_inaddr_any(rpf) && PIM_DEBUG_ZEBRA) {
 		/* RPF'(S,G) not found */
-		zlog_debug("%s %s: RPF'%s not found: won't send join upstream",
-			   __FILE__, __PRETTY_FUNCTION__, up->sg_str);
+		zlog_debug("%s(%s): RPF'%s not found: won't send join upstream",
+			   __func__, caller, up->sg_str);
 		/* warning only */
 	}
 
@@ -251,8 +252,8 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 			pim_addr_dump("<addr?>",
 				      &rpf->source_nexthop.mrib_nexthop_addr,
 				      nhaddr_str, sizeof(nhaddr_str));
-			zlog_debug("%s %s: (S,G)=%s source nexthop now is: interface=%s address=%s pref=%d metric=%d",
-		 __FILE__, __PRETTY_FUNCTION__,
+			zlog_debug("%s(%s): (S,G)=%s source nexthop now is: interface=%s address=%s pref=%d metric=%d",
+		 __func__, caller,
 		 up->sg_str,
 		 rpf->source_nexthop.interface ? rpf->source_nexthop.interface->name : "<ifname?>",
 		 nhaddr_str,
@@ -269,8 +270,8 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	if (saved.source_nexthop.interface != rpf->source_nexthop.interface) {
 
 		if (PIM_DEBUG_ZEBRA) {
-			zlog_debug("%s %s: (S,G)=%s RPF_interface(S) changed from %s to %s",
-		 __FILE__, __PRETTY_FUNCTION__,
+			zlog_debug("%s(%s): (S,G)=%s RPF_interface(S) changed from %s to %s",
+		 __func__, caller,
 		 up->sg_str,
 		 saved.source_nexthop.interface ? saved.source_nexthop.interface->name : "<oldif?>",
 		 rpf->source_nexthop.interface ? rpf->source_nexthop.interface->name : "<newif?>");

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -307,11 +307,6 @@ void pim_upstream_rpf_clear(struct pim_instance *pim,
 			    struct pim_upstream *up)
 {
 	if (up->rpf.source_nexthop.interface) {
-		if (up->channel_oil)
-			pim_channel_oil_change_iif(pim, up->channel_oil,
-						   MAXVIFS,
-						   __PRETTY_FUNCTION__);
-
 		pim_upstream_switch(pim, up, PIM_UPSTREAM_NOTJOINED);
 		up->rpf.source_nexthop.interface = NULL;
 		up->rpf.source_nexthop.mrib_nexthop_addr.u.prefix4.s_addr =
@@ -321,6 +316,7 @@ void pim_upstream_rpf_clear(struct pim_instance *pim,
 		up->rpf.source_nexthop.mrib_route_metric =
 			router->infinite_assert_metric.route_metric;
 		up->rpf.rpf_addr.u.prefix4.s_addr = PIM_NET_INADDR_ANY;
+		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 	}
 }
 

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -307,7 +307,6 @@ void pim_upstream_rpf_clear(struct pim_instance *pim,
 			    struct pim_upstream *up)
 {
 	if (up->rpf.source_nexthop.interface) {
-		pim_upstream_switch(pim, up, PIM_UPSTREAM_NOTJOINED);
 		up->rpf.source_nexthop.interface = NULL;
 		up->rpf.source_nexthop.mrib_nexthop_addr.u.prefix4.s_addr =
 			PIM_NET_INADDR_ANY;

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -215,6 +215,10 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 
 	saved.source_nexthop = rpf->source_nexthop;
 	saved.rpf_addr = rpf->rpf_addr;
+	if (old) {
+		old->source_nexthop = saved.source_nexthop;
+		old->rpf_addr = saved.rpf_addr;
+	}
 
 	nht_p.family = AF_INET;
 	nht_p.prefixlen = IPV4_MAX_BITLEN;
@@ -287,11 +291,6 @@ enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 	    || saved.source_nexthop
 			       .interface != rpf->source_nexthop.interface) {
 
-		/* return old rpf to caller ? */
-		if (old) {
-			old->source_nexthop = saved.source_nexthop;
-			old->rpf_addr = saved.rpf_addr;
-		}
 		return PIM_RPF_CHANGED;
 	}
 

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -63,7 +63,7 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 			struct in_addr addr, int neighbor_needed);
 enum pim_rpf_result pim_rpf_update(struct pim_instance *pim,
 				   struct pim_upstream *up,
-				   struct pim_rpf *old);
+				   struct pim_rpf *old, const char *caller);
 void pim_upstream_rpf_clear(struct pim_instance *pim,
 			    struct pim_upstream *up);
 int pim_rpf_addr_is_inaddr_none(struct pim_rpf *rpf);

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -179,7 +179,7 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 
 	s_route->c_oil.pim = pim;
 
-	if (pim_mroute_add(&s_route->c_oil, __PRETTY_FUNCTION__)) {
+	if (pim_static_mroute_add(&s_route->c_oil, __PRETTY_FUNCTION__)) {
 		char gifaddr_str[INET_ADDRSTRLEN];
 		char sifaddr_str[INET_ADDRSTRLEN];
 		pim_inet4_dump("<ifaddr?>", group, gifaddr_str,
@@ -264,7 +264,7 @@ int pim_static_del(struct pim_instance *pim, struct interface *iif,
 			if (s_route->c_oil.oil_ref_count <= 0
 				    ? pim_mroute_del(&s_route->c_oil,
 						     __PRETTY_FUNCTION__)
-				    : pim_mroute_add(&s_route->c_oil,
+				    : pim_static_mroute_add(&s_route->c_oil,
 						     __PRETTY_FUNCTION__)) {
 				char gifaddr_str[INET_ADDRSTRLEN];
 				char sifaddr_str[INET_ADDRSTRLEN];

--- a/pimd/pim_static.c
+++ b/pimd/pim_static.c
@@ -138,7 +138,7 @@ int pim_static_add(struct pim_instance *pim, struct interface *iif,
 			} else {
 				/* input interface changed */
 				s_route->iif = iif_index;
-				pim_channel_oil_change_iif(pim, &s_route->c_oil,
+				pim_static_mroute_iif_update(&s_route->c_oil,
 							   iif_index,
 							   __PRETTY_FUNCTION__);
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -141,14 +141,22 @@ static struct pim_upstream *pim_upstream_find_parent(struct pim_instance *pim,
 
 static void upstream_channel_oil_detach(struct pim_upstream *up)
 {
-	if (up->channel_oil) {
+	struct channel_oil *channel_oil = up->channel_oil;
+
+	if (channel_oil) {
 		/* Detaching from channel_oil, channel_oil may exist post del,
 		   but upstream would not keep reference of it
 		 */
-		up->channel_oil->up = NULL;
-		pim_channel_oil_del(up->channel_oil, __PRETTY_FUNCTION__);
+		channel_oil->up = NULL;
 		up->channel_oil = NULL;
+
+		/* attempt to delete channel_oil; if channel_oil is being held
+		 * because of other references cleanup info such as "Mute"
+		 * inferred from the parent upstream
+		 */
+		pim_channel_oil_upstream_deref(channel_oil);
 	}
+
 }
 
 struct pim_upstream *pim_upstream_del(struct pim_instance *pim,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -845,7 +845,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 			pim_upstream_keep_alive_timer_start(
 				up, pim->keep_alive_time);
 	} else if (up->upstream_addr.s_addr != INADDR_ANY) {
-		rpf_result = pim_rpf_update(pim, up, NULL);
+		rpf_result = pim_rpf_update(pim, up, NULL, __func__);
 		if (rpf_result == PIM_RPF_FAILURE) {
 			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug(
@@ -1768,7 +1768,7 @@ void pim_upstream_find_new_rpf(struct pim_instance *pim)
 				zlog_debug(
 					"%s: Upstream %s without a path to send join, checking",
 					__PRETTY_FUNCTION__, up->sg_str);
-			pim_rpf_update(pim, up, NULL);
+			pim_rpf_update(pim, up, NULL, __func__);
 		}
 	}
 }

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -190,6 +190,11 @@ struct pim_upstream *pim_upstream_del(struct pim_instance *pim,
 	if (up->ref_count >= 1)
 		return up;
 
+	if (PIM_DEBUG_TRACE)
+		zlog_debug(
+				"pim_upstream free vrf:%s %s flags 0x%x",
+				pim->vrf->name, up->sg_str, up->flags);
+
 	THREAD_OFF(up->t_ka_timer);
 	THREAD_OFF(up->t_rs_timer);
 	THREAD_OFF(up->t_msdp_reg_timer);
@@ -333,7 +338,7 @@ static void join_timer_stop(struct pim_upstream *up)
 					up->rpf.rpf_addr.u.prefix4);
 
 	if (nbr)
-		pim_jp_agg_remove_group(nbr->upstream_jp_agg, up);
+		pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
 
 	pim_jp_agg_upstream_verification(up, false);
 }
@@ -355,7 +360,7 @@ void join_timer_start(struct pim_upstream *up)
 	}
 
 	if (nbr)
-		pim_jp_agg_add_group(nbr->upstream_jp_agg, up, 1);
+		pim_jp_agg_add_group(nbr->upstream_jp_agg, up, 1, nbr);
 	else {
 		THREAD_OFF(up->t_join_timer);
 		thread_add_timer(router->master, on_join_timer, up,

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -536,7 +536,8 @@ void pim_upstream_register_reevaluate(struct pim_instance *pim)
 		 * is actually active; if it is not kat setup will trigger
 		 * source
 		 * registration whenever the flow becomes active. */
-		if (!PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) || !up->t_ka_timer)
+		if (!PIM_UPSTREAM_FLAG_TEST_FHR(up->flags) ||
+			!pim_upstream_is_kat_running(up))
 			continue;
 
 		if (pim_is_grp_ssm(pim, up->sg.grp)) {
@@ -1044,11 +1045,6 @@ static bool pim_upstream_empty_immediate_olist(struct pim_instance *pim,
 
 	/* immediate_oil is empty */
 	return true;
-}
-
-static bool pim_upstream_is_kat_running(struct pim_upstream *up)
-{
-	return (up->t_ka_timer != NULL);
 }
 
 /*

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1897,8 +1897,7 @@ static bool pim_upstream_kat_start_ok(struct pim_upstream *up)
 	if (pim_ifp->mroute_vif_index != c_oil->oil.mfcc_parent)
 		return false;
 
-	if (up->rpf.source_nexthop.interface &&
-		pim_if_connected_to_source(up->rpf.source_nexthop.interface,
+	if (pim_if_connected_to_source(up->rpf.source_nexthop.interface,
 				       up->sg.src)) {
 		return true;
 	}

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -78,8 +78,13 @@ static void pim_upstream_remove_children(struct pim_instance *pim,
 			child = pim_upstream_del(pim, child,
 						 __PRETTY_FUNCTION__);
 		}
-		if (child)
+		if (child) {
 			child->parent = NULL;
+			if (PIM_UPSTREAM_FLAG_TEST_USE_RPT(child->flags))
+				pim_upstream_mroute_iif_update(
+						child->channel_oil,
+						__func__);
+		}
 	}
 	list_delete(&up->sources);
 }
@@ -109,6 +114,10 @@ static void pim_upstream_find_new_children(struct pim_instance *pim,
 		    && (child != up)) {
 			child->parent = up;
 			listnode_add_sort(up->sources, child);
+			if (PIM_UPSTREAM_FLAG_TEST_USE_RPT(child->flags))
+				pim_upstream_mroute_iif_update(
+						child->channel_oil,
+						__func__);
 		}
 	}
 }

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1811,14 +1811,16 @@ void pim_upstream_find_new_rpf(struct pim_instance *pim)
 				zlog_debug(
 					"%s: Upstream %s without a path to send join, checking",
 					__PRETTY_FUNCTION__, up->sg_str);
-			old.source_nexthop.interface = up->rpf.source_nexthop.interface;
+			old.source_nexthop.interface =
+				up->rpf.source_nexthop.interface;
 			rpf_result = pim_rpf_update(pim, up, &old, __func__);
 			if (rpf_result == PIM_RPF_CHANGED ||
 					(rpf_result == PIM_RPF_FAILURE &&
 					 old.source_nexthop.interface))
 				pim_zebra_upstream_rpf_changed(pim, up, &old);
 			/* update kernel multicast forwarding cache (MFC) */
-			pim_upstream_mroute_iif_update(up->channel_oil, __func__);
+			pim_upstream_mroute_iif_update(up->channel_oil,
+					__func__);
 		}
 	}
 	pim_zebra_update_all_interfaces(pim);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -865,12 +865,16 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 		pim_upstream_fill_static_iif(up, incoming);
 		pim_ifp = up->rpf.source_nexthop.interface->info;
 		assert(pim_ifp);
+		pim_upstream_update_use_rpt(up,
+				false /*update_mroute*/);
 		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 
 		if (PIM_UPSTREAM_FLAG_TEST_SRC_NOCACHE(up->flags))
 			pim_upstream_keep_alive_timer_start(
 				up, pim->keep_alive_time);
 	} else if (up->upstream_addr.s_addr != INADDR_ANY) {
+		pim_upstream_update_use_rpt(up,
+				false /*update_mroute*/);
 		rpf_result = pim_rpf_update(pim, up, NULL, __func__);
 		if (rpf_result == PIM_RPF_FAILURE) {
 			if (PIM_DEBUG_PIM_TRACE)
@@ -881,12 +885,9 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 
 		if (up->rpf.source_nexthop.interface) {
 			pim_ifp = up->rpf.source_nexthop.interface->info;
-			if (pim_ifp)
-				pim_upstream_mroute_iif_update(up->channel_oil,
-						__func__);
+			pim_upstream_mroute_iif_update(up->channel_oil,
+					__func__);
 		}
-		pim_upstream_update_use_rpt(up,
-				false /*update_mroute*/);
 	}
 
 	listnode_add_sort(pim->upstream_list, up);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -788,7 +788,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 	up->reg_state = PIM_REG_NOINFO;
 	up->state_transition = pim_time_monotonic_sec();
 	up->channel_oil =
-		pim_channel_oil_add(pim, &up->sg, MAXVIFS, __PRETTY_FUNCTION__);
+		pim_channel_oil_add(pim, &up->sg, __PRETTY_FUNCTION__);
 	up->sptbit = PIM_UPSTREAM_SPTBIT_FALSE;
 
 	up->rpf.source_nexthop.interface = NULL;
@@ -813,9 +813,7 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 		pim_upstream_fill_static_iif(up, incoming);
 		pim_ifp = up->rpf.source_nexthop.interface->info;
 		assert(pim_ifp);
-		pim_channel_oil_change_iif(pim, up->channel_oil,
-					   pim_ifp->mroute_vif_index,
-					   __PRETTY_FUNCTION__);
+		pim_upstream_mroute_iif_update(up->channel_oil, __func__);
 
 		if (PIM_UPSTREAM_FLAG_TEST_SRC_NOCACHE(up->flags))
 			pim_upstream_keep_alive_timer_start(
@@ -832,10 +830,8 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 		if (up->rpf.source_nexthop.interface) {
 			pim_ifp = up->rpf.source_nexthop.interface->info;
 			if (pim_ifp)
-				pim_channel_oil_change_iif(
-					pim, up->channel_oil,
-					pim_ifp->mroute_vif_index,
-					__PRETTY_FUNCTION__);
+				pim_upstream_mroute_iif_update(up->channel_oil,
+						__func__);
 		}
 		pim_upstream_update_use_rpt(up,
 				false /*update_mroute*/);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1772,7 +1772,9 @@ void pim_upstream_find_new_rpf(struct pim_instance *pim)
 					__PRETTY_FUNCTION__, up->sg_str);
 			old.source_nexthop.interface = up->rpf.source_nexthop.interface;
 			rpf_result = pim_rpf_update(pim, up, &old, __func__);
-			if (rpf_result == PIM_RPF_CHANGED)
+			if (rpf_result == PIM_RPF_CHANGED ||
+					(rpf_result == PIM_RPF_FAILURE &&
+					 old.source_nexthop.interface))
 				pim_zebra_upstream_rpf_changed(pim, up, &old);
 			/* update kernel multicast forwarding cache (MFC) */
 			pim_upstream_mroute_iif_update(up->channel_oil, __func__);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -532,7 +532,8 @@ void pim_upstream_register_reevaluate(struct pim_instance *pim)
 				/* remove regiface from the OIL if it is there*/
 				pim_channel_del_oif(up->channel_oil,
 						    pim->regiface,
-						    PIM_OIF_FLAG_PROTO_PIM);
+						    PIM_OIF_FLAG_PROTO_PIM,
+							__func__);
 				up->reg_state = PIM_REG_NOINFO;
 			}
 		} else {
@@ -544,7 +545,8 @@ void pim_upstream_register_reevaluate(struct pim_instance *pim)
 						up->sg_str);
 				pim_channel_add_oif(up->channel_oil,
 						    pim->regiface,
-						    PIM_OIF_FLAG_PROTO_PIM);
+						    PIM_OIF_FLAG_PROTO_PIM,
+							__func__);
 				up->reg_state = PIM_REG_JOIN;
 			}
 		}
@@ -1116,7 +1118,7 @@ static void pim_upstream_fhr_kat_expiry(struct pim_instance *pim,
 	THREAD_OFF(up->t_rs_timer);
 	/* remove regiface from the OIL if it is there*/
 	pim_channel_del_oif(up->channel_oil, pim->regiface,
-			    PIM_OIF_FLAG_PROTO_PIM);
+			    PIM_OIF_FLAG_PROTO_PIM, __func__);
 	/* clear the register state */
 	up->reg_state = PIM_REG_NOINFO;
 	PIM_UPSTREAM_FLAG_UNSET_FHR(up->flags);
@@ -1445,7 +1447,8 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 	case PIM_REG_JOIN_PENDING:
 		up->reg_state = PIM_REG_JOIN;
 		pim_channel_add_oif(up->channel_oil, pim->regiface,
-				    PIM_OIF_FLAG_PROTO_PIM);
+				    PIM_OIF_FLAG_PROTO_PIM,
+					__func__);
 		pim_vxlan_update_sg_reg_state(pim, up, true /*reg_join*/);
 		break;
 	case PIM_REG_JOIN:
@@ -1546,7 +1549,8 @@ int pim_upstream_inherited_olist_decide(struct pim_instance *pim,
 			if (!ch)
 				flag = PIM_OIF_FLAG_PROTO_STAR;
 
-			pim_channel_add_oif(up->channel_oil, ifp, flag);
+			pim_channel_add_oif(up->channel_oil, ifp, flag,
+					__func__);
 			output_intf++;
 		}
 	}
@@ -1803,7 +1807,7 @@ void pim_upstream_add_lhr_star_pimreg(struct pim_instance *pim)
 			continue;
 
 		pim_channel_add_oif(up->channel_oil, pim->regiface,
-				    PIM_OIF_FLAG_PROTO_IGMP);
+				    PIM_OIF_FLAG_PROTO_IGMP, __func__);
 	}
 }
 
@@ -1852,17 +1856,18 @@ void pim_upstream_remove_lhr_star_pimreg(struct pim_instance *pim,
 
 		if (!nlist) {
 			pim_channel_del_oif(up->channel_oil, pim->regiface,
-					    PIM_OIF_FLAG_PROTO_IGMP);
+					PIM_OIF_FLAG_PROTO_IGMP, __func__);
 			continue;
 		}
 		g.u.prefix4 = up->sg.grp;
 		apply_new = prefix_list_apply(np, &g);
 		if (apply_new == PREFIX_DENY)
 			pim_channel_add_oif(up->channel_oil, pim->regiface,
-					    PIM_OIF_FLAG_PROTO_IGMP);
+					    PIM_OIF_FLAG_PROTO_IGMP,
+						__func__);
 		else
 			pim_channel_del_oif(up->channel_oil, pim->regiface,
-					    PIM_OIF_FLAG_PROTO_IGMP);
+					PIM_OIF_FLAG_PROTO_IGMP, __func__);
 	}
 }
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -627,6 +627,22 @@ void pim_upstream_update_use_rpt(struct pim_upstream *up,
 	}
 }
 
+/* some events like RP change require re-evaluation of SGrpt across
+ * all groups
+ */
+void pim_upstream_reeval_use_rpt(struct pim_instance *pim)
+{
+	struct pim_upstream *up;
+	struct listnode *node;
+
+	for (ALL_LIST_ELEMENTS_RO(pim->upstream_list, node, up)) {
+		if (up->sg.src.s_addr == INADDR_ANY)
+			continue;
+
+		pim_upstream_update_use_rpt(up, true /*update_mroute*/);
+	}
+}
+
 void pim_upstream_switch(struct pim_instance *pim, struct pim_upstream *up,
 			 enum pim_upstream_state new_state)
 {

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1425,7 +1425,7 @@ void pim_upstream_msdp_reg_timer_start(struct pim_upstream *up)
  *  SwitchToSptDesired(S,G) return true once a single packet has been
  *  received for the source and group.
  */
-int pim_upstream_switch_to_spt_desired(struct pim_instance *pim,
+int pim_upstream_switch_to_spt_desired_on_rp(struct pim_instance *pim,
 				       struct prefix_sg *sg)
 {
 	if (I_am_RP(pim, sg->grp))

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -292,9 +292,9 @@ void pim_upstream_update_my_assert_metric(struct pim_upstream *up);
 void pim_upstream_keep_alive_timer_start(struct pim_upstream *up,
 					 uint32_t time);
 
-int pim_upstream_switch_to_spt_desired(struct pim_instance *pim,
+int pim_upstream_switch_to_spt_desired_on_rp(struct pim_instance *pim,
 				       struct prefix_sg *sg);
-#define SwitchToSptDesired(pim, sg) pim_upstream_switch_to_spt_desired (pim, sg)
+#define SwitchToSptDesiredOnRp(pim, sg) pim_upstream_switch_to_spt_desired_on_rp (pim, sg)
 int pim_upstream_is_sg_rpt(struct pim_upstream *up);
 
 void pim_upstream_set_sptbit(struct pim_upstream *up,

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -336,4 +336,5 @@ void pim_upstream_fill_static_iif(struct pim_upstream *up,
 				struct interface *incoming);
 void pim_upstream_update_use_rpt(struct pim_upstream *up,
 		bool update_mroute);
+void pim_upstream_reeval_use_rpt(struct pim_instance *pim);
 #endif /* PIM_UPSTREAM_H */

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -242,6 +242,11 @@ struct pim_upstream {
 	int64_t state_transition; /* Record current state uptime */
 };
 
+static inline bool pim_upstream_is_kat_running(struct pim_upstream *up)
+{
+	return (up->t_ka_timer != NULL);
+}
+
 struct pim_upstream *pim_upstream_find(struct pim_instance *pim,
 				       struct prefix_sg *sg);
 struct pim_upstream *pim_upstream_find_or_add(struct prefix_sg *sg,

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -262,6 +262,9 @@ int pim_upstream_evaluate_join_desired(struct pim_instance *pim,
 int pim_upstream_evaluate_join_desired_interface(struct pim_upstream *up,
 						 struct pim_ifchannel *ch,
 						 struct pim_ifchannel *starch);
+int pim_upstream_eval_inherit_if(struct pim_upstream *up,
+						 struct pim_ifchannel *ch,
+						 struct pim_ifchannel *starch);
 void pim_upstream_update_join_desired(struct pim_instance *pim,
 				      struct pim_upstream *up);
 

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -80,6 +80,12 @@
  * associated with an upstream
  */
 #define PIM_UPSTREAM_FLAG_MASK_SRC_NOCACHE             (1 << 19)
+/* By default as SG entry will use the SPT for forwarding traffic
+ * unless it was setup as a result of a Prune(S,G,rpt) from a
+ * downstream router and has JoinDesired(S,G) as False.
+ * This flag is only relevant for (S,G) entries.
+ */
+#define PIM_UPSTREAM_FLAG_MASK_USE_RPT                 (1 << 20)
 
 #define PIM_UPSTREAM_FLAG_ALL 0xFFFFFFFF
 
@@ -103,6 +109,7 @@
 #define PIM_UPSTREAM_FLAG_TEST_MLAG_VXLAN(flags) ((flags) & PIM_UPSTREAM_FLAG_MASK_MLAG_VXLAN)
 #define PIM_UPSTREAM_FLAG_TEST_MLAG_NON_DF(flags) ((flags) & PIM_UPSTREAM_FLAG_MASK_MLAG_NON_DF)
 #define PIM_UPSTREAM_FLAG_TEST_SRC_NOCACHE(flags) ((flags) &PIM_UPSTREAM_FLAG_MASK_SRC_NOCACHE)
+#define PIM_UPSTREAM_FLAG_TEST_USE_RPT(flags) ((flags) & PIM_UPSTREAM_FLAG_MASK_USE_RPT)
 
 #define PIM_UPSTREAM_FLAG_SET_DR_JOIN_DESIRED(flags) ((flags) |= PIM_UPSTREAM_FLAG_MASK_DR_JOIN_DESIRED)
 #define PIM_UPSTREAM_FLAG_SET_DR_JOIN_DESIRED_UPDATED(flags) ((flags) |= PIM_UPSTREAM_FLAG_MASK_DR_JOIN_DESIRED_UPDATED)
@@ -122,6 +129,7 @@
 #define PIM_UPSTREAM_FLAG_SET_SRC_VXLAN_TERM(flags) ((flags) |= PIM_UPSTREAM_FLAG_MASK_SRC_VXLAN_TERM)
 #define PIM_UPSTREAM_FLAG_SET_MLAG_VXLAN(flags) ((flags) |= PIM_UPSTREAM_FLAG_MASK_MLAG_VXLAN)
 #define PIM_UPSTREAM_FLAG_SET_MLAG_NON_DF(flags) ((flags) |= PIM_UPSTREAM_FLAG_MASK_MLAG_NON_DF)
+#define PIM_UPSTREAM_FLAG_SET_USE_RPT(flags) ((flags) |= PIM_UPSTREAM_FLAG_MASK_USE_RPT)
 
 #define PIM_UPSTREAM_FLAG_UNSET_DR_JOIN_DESIRED(flags) ((flags) &= ~PIM_UPSTREAM_FLAG_MASK_DR_JOIN_DESIRED)
 #define PIM_UPSTREAM_FLAG_UNSET_DR_JOIN_DESIRED_UPDATED(flags) ((flags) &= ~PIM_UPSTREAM_FLAG_MASK_DR_JOIN_DESIRED_UPDATED)
@@ -142,6 +150,7 @@
 #define PIM_UPSTREAM_FLAG_UNSET_MLAG_VXLAN(flags) ((flags) &= ~PIM_UPSTREAM_FLAG_MASK_MLAG_VXLAN)
 #define PIM_UPSTREAM_FLAG_UNSET_MLAG_NON_DF(flags) ((flags) &= ~PIM_UPSTREAM_FLAG_MASK_MLAG_NON_DF)
 #define PIM_UPSTREAM_FLAG_UNSET_SRC_NOCACHE(flags) ((flags) &= ~PIM_UPSTREAM_FLAG_MASK_SRC_NOCACHE)
+#define PIM_UPSTREAM_FLAG_UNSET_USE_RPT(flags) ((flags) &= ~PIM_UPSTREAM_FLAG_MASK_USE_RPT)
 
 enum pim_upstream_state {
 	PIM_UPSTREAM_NOTJOINED,
@@ -188,6 +197,7 @@ enum pim_upstream_sptbit {
 
 */
 struct pim_upstream {
+	struct pim_instance *pim;
 	struct pim_upstream *parent;
 	struct in_addr upstream_addr;     /* Who we are talking to */
 	struct in_addr upstream_register; /*Who we received a register from*/
@@ -324,4 +334,6 @@ struct pim_upstream *pim_upstream_keep_alive_timer_proc(
 		struct pim_upstream *up);
 void pim_upstream_fill_static_iif(struct pim_upstream *up,
 				struct interface *incoming);
+void pim_upstream_update_use_rpt(struct pim_upstream *up,
+		bool update_mroute);
 #endif /* PIM_UPSTREAM_H */

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -245,7 +245,7 @@ static void pim_vxlan_orig_mr_up_del(struct pim_vxlan_sg *vxlan_sg)
 		 * for nht
 		 */
 		if (up)
-			pim_rpf_update(vxlan_sg->pim, up, NULL);
+			pim_rpf_update(vxlan_sg->pim, up, NULL, __func__);
 	}
 }
 

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -251,20 +251,14 @@ static void pim_vxlan_orig_mr_up_del(struct pim_vxlan_sg *vxlan_sg)
 
 static void pim_vxlan_orig_mr_up_iif_update(struct pim_vxlan_sg *vxlan_sg)
 {
-	int vif_index;
-
 	/* update MFC with the new IIF */
 	pim_upstream_fill_static_iif(vxlan_sg->up, vxlan_sg->iif);
-	vif_index = pim_if_find_vifindex_by_ifindex(vxlan_sg->pim,
-			vxlan_sg->iif->ifindex);
-	if (vif_index > 0)
-		pim_scan_individual_oil(vxlan_sg->up->channel_oil,
-				vif_index);
+	pim_upstream_mroute_iif_update(vxlan_sg->up->channel_oil, __func__);
 
 	if (PIM_DEBUG_VXLAN)
-		zlog_debug("vxlan SG %s orig mroute-up updated with iif %s vifi %d",
+		zlog_debug("vxlan SG %s orig mroute-up updated with iif %s",
 			vxlan_sg->sg_str,
-			vxlan_sg->iif?vxlan_sg->iif->name:"-", vif_index);
+			vxlan_sg->iif?vxlan_sg->iif->name:"-");
 
 }
 

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -386,7 +386,8 @@ static void pim_vxlan_orig_mr_oif_add(struct pim_vxlan_sg *vxlan_sg)
 
 	vxlan_sg->flags |= PIM_VXLAN_SGF_OIF_INSTALLED;
 	pim_channel_add_oif(vxlan_sg->up->channel_oil,
-		vxlan_sg->orig_oif, PIM_OIF_FLAG_PROTO_VXLAN);
+		vxlan_sg->orig_oif, PIM_OIF_FLAG_PROTO_VXLAN,
+		__func__);
 }
 
 static void pim_vxlan_orig_mr_oif_del(struct pim_vxlan_sg *vxlan_sg)
@@ -405,7 +406,7 @@ static void pim_vxlan_orig_mr_oif_del(struct pim_vxlan_sg *vxlan_sg)
 
 	vxlan_sg->flags &= ~PIM_VXLAN_SGF_OIF_INSTALLED;
 	pim_channel_del_oif(vxlan_sg->up->channel_oil,
-		orig_oif, PIM_OIF_FLAG_PROTO_VXLAN);
+			orig_oif, PIM_OIF_FLAG_PROTO_VXLAN, __func__);
 }
 
 static inline struct interface *pim_vxlan_orig_mr_oif_get(

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -292,6 +292,7 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 	struct pim_upstream *up;
 	int flags = 0;
 	struct prefix nht_p;
+	struct pim_instance *pim = vxlan_sg->pim;
 
 	if (vxlan_sg->up) {
 		/* nothing to do */
@@ -349,6 +350,10 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 		pim_upstream_ref(up, flags, __PRETTY_FUNCTION__);
 		vxlan_sg->up = up;
 		pim_vxlan_orig_mr_up_iif_update(vxlan_sg);
+		/* mute pimreg on origination mroutes */
+		if (pim->regiface)
+			pim_channel_update_oif_mute(up->channel_oil,
+					pim->regiface->info);
 	} else {
 		up = pim_upstream_add(vxlan_sg->pim, &vxlan_sg->sg,
 				vxlan_sg->iif, flags,

--- a/pimd/pim_vxlan.c
+++ b/pimd/pim_vxlan.c
@@ -347,6 +347,8 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 			pim_delete_tracked_nexthop(vxlan_sg->pim,
 				&nht_p, up, NULL, false);
 		}
+		/* We are acting FHR; clear out use_rpt setting if any */
+		pim_upstream_update_use_rpt(up, false /*update_mroute*/);
 		pim_upstream_ref(up, flags, __PRETTY_FUNCTION__);
 		vxlan_sg->up = up;
 		pim_vxlan_orig_mr_up_iif_update(vxlan_sg);
@@ -378,6 +380,8 @@ static void pim_vxlan_orig_mr_up_add(struct pim_vxlan_sg *vxlan_sg)
 
 	/* update the inherited OIL */
 	pim_upstream_inherited_olist(vxlan_sg->pim, up);
+	if (!up->channel_oil->installed)
+		pim_upstream_mroute_add(up->channel_oil, __func__);
 }
 
 static void pim_vxlan_orig_mr_oif_add(struct pim_vxlan_sg *vxlan_sg)

--- a/pimd/pim_vxlan.h
+++ b/pimd/pim_vxlan.h
@@ -115,6 +115,13 @@ static inline bool pim_vxlan_is_orig_mroute(struct pim_vxlan_sg *vxlan_sg)
 	return (vxlan_sg->sg.src.s_addr != 0);
 }
 
+static inline bool pim_vxlan_is_local_sip(struct pim_upstream *up)
+{
+	return (up->sg.src.s_addr != INADDR_ANY) &&
+		up->rpf.source_nexthop.interface &&
+		if_is_loopback_or_vrf(up->rpf.source_nexthop.interface);
+}
+
 extern struct pim_vxlan *pim_vxlan_p;
 extern struct pim_vxlan_sg *pim_vxlan_sg_find(struct pim_instance *pim,
 					    struct prefix_sg *sg);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -858,7 +858,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
 	if (PIM_I_am_DR(pim_oif)) {
 		result = pim_channel_add_oif(source->source_channel_oil,
 					     group->group_igmp_sock->interface,
-					     PIM_OIF_FLAG_PROTO_IGMP);
+					     PIM_OIF_FLAG_PROTO_IGMP, __func__);
 		if (result) {
 			if (PIM_DEBUG_MROUTE) {
 				zlog_warn("%s: add_oif() failed with return=%d",
@@ -887,7 +887,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
 
 		pim_channel_del_oif(source->source_channel_oil,
 				    group->group_igmp_sock->interface,
-				    PIM_OIF_FLAG_PROTO_IGMP);
+				    PIM_OIF_FLAG_PROTO_IGMP, __func__);
 		return;
 	}
 
@@ -938,7 +938,8 @@ void igmp_source_forward_stop(struct igmp_source *source)
 	*/
 	result = pim_channel_del_oif(source->source_channel_oil,
 				     group->group_igmp_sock->interface,
-				     PIM_OIF_FLAG_PROTO_IGMP);
+					 PIM_OIF_FLAG_PROTO_IGMP,
+					 __func__);
 	if (result) {
 		if (PIM_DEBUG_IGMP_TRACE)
 			zlog_debug(
@@ -981,7 +982,8 @@ void pim_forward_start(struct pim_ifchannel *ch)
 	if (up->flags & PIM_UPSTREAM_FLAG_MASK_SRC_IGMP)
 		mask = PIM_OIF_FLAG_PROTO_IGMP;
 
-	pim_channel_add_oif(up->channel_oil, ch->interface, mask);
+	pim_channel_add_oif(up->channel_oil, ch->interface,
+			mask, __func__);
 }
 
 void pim_forward_stop(struct pim_ifchannel *ch, bool install_it)
@@ -1000,10 +1002,10 @@ void pim_forward_stop(struct pim_ifchannel *ch, bool install_it)
 	 */
 	if (pim_upstream_evaluate_join_desired_interface(up, ch, ch->parent))
 		pim_channel_add_oif(up->channel_oil, ch->interface,
-				    PIM_OIF_FLAG_PROTO_PIM);
+				    PIM_OIF_FLAG_PROTO_PIM, __func__);
 	else
 		pim_channel_del_oif(up->channel_oil, ch->interface,
-				    PIM_OIF_FLAG_PROTO_PIM);
+				    PIM_OIF_FLAG_PROTO_PIM, __func__);
 
 	if (install_it && !up->channel_oil->installed)
 		pim_mroute_add(up->channel_oil, __PRETTY_FUNCTION__);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -324,6 +324,9 @@ void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 			up->channel_oil->oil_inherited_rescan = 0;
 		}
 
+		if (up->join_state == PIM_UPSTREAM_JOINED)
+			pim_jp_agg_switch_interface(old, &up->rpf, up);
+
 		if (!up->channel_oil->installed)
 			pim_upstream_mroute_add(up->channel_oil,
 					__PRETTY_FUNCTION__);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -386,137 +386,17 @@ static void pim_zebra_vxlan_replay(void)
 	zclient_send_message(zclient);
 }
 
-void pim_scan_individual_oil(struct channel_oil *c_oil, int in_vif_index)
-{
-	struct in_addr vif_source;
-	int input_iface_vif_index;
-
-	pim_rp_set_upstream_addr(c_oil->pim, &vif_source,
-				      c_oil->oil.mfcc_origin,
-				      c_oil->oil.mfcc_mcastgrp);
-
-	if (in_vif_index)
-		input_iface_vif_index = in_vif_index;
-	else {
-		struct prefix src, grp;
-
-		src.family = AF_INET;
-		src.prefixlen = IPV4_MAX_BITLEN;
-		src.u.prefix4 = vif_source;
-		grp.family = AF_INET;
-		grp.prefixlen = IPV4_MAX_BITLEN;
-		grp.u.prefix4 = c_oil->oil.mfcc_mcastgrp;
-
-		if (PIM_DEBUG_ZEBRA) {
-			char source_str[INET_ADDRSTRLEN];
-			char group_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<source?>", c_oil->oil.mfcc_origin,
-				       source_str, sizeof(source_str));
-			pim_inet4_dump("<group?>", c_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			zlog_debug(
-				"%s: channel_oil (%s,%s) upstream info is not present.",
-				__PRETTY_FUNCTION__, source_str, group_str);
-		}
-		input_iface_vif_index = pim_ecmp_fib_lookup_if_vif_index(
-			c_oil->pim, &src, &grp);
-	}
-
-	if (input_iface_vif_index < 1) {
-		if (PIM_DEBUG_ZEBRA) {
-			char source_str[INET_ADDRSTRLEN];
-			char group_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<source?>", c_oil->oil.mfcc_origin,
-				       source_str, sizeof(source_str));
-			pim_inet4_dump("<group?>", c_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			zlog_debug(
-				"%s %s: could not find input interface(%d) for (S,G)=(%s,%s)",
-				__FILE__, __PRETTY_FUNCTION__,
-				c_oil->oil.mfcc_parent, source_str, group_str);
-		}
-		pim_mroute_del(c_oil, __PRETTY_FUNCTION__);
-		return;
-	}
-
-	if (input_iface_vif_index == c_oil->oil.mfcc_parent) {
-		if (!c_oil->installed)
-			pim_upstream_mroute_add(c_oil, __PRETTY_FUNCTION__);
-
-		/* RPF unchanged */
-		return;
-	}
-
-	if (PIM_DEBUG_ZEBRA) {
-		struct interface *old_iif = pim_if_find_by_vif_index(
-			c_oil->pim, c_oil->oil.mfcc_parent);
-		struct interface *new_iif = pim_if_find_by_vif_index(
-			c_oil->pim, input_iface_vif_index);
-		char source_str[INET_ADDRSTRLEN];
-		char group_str[INET_ADDRSTRLEN];
-		pim_inet4_dump("<source?>", c_oil->oil.mfcc_origin, source_str,
-			       sizeof(source_str));
-		pim_inet4_dump("<group?>", c_oil->oil.mfcc_mcastgrp, group_str,
-			       sizeof(group_str));
-		zlog_debug(
-			"%s %s: (S,G)=(%s,%s) input interface changed from %s vif_index=%d to %s vif_index=%d",
-			__FILE__, __PRETTY_FUNCTION__, source_str, group_str,
-			(old_iif) ? old_iif->name : "<old_iif?>",
-			c_oil->oil.mfcc_parent,
-			(new_iif) ? new_iif->name : "<new_iif?>",
-			input_iface_vif_index);
-	}
-
-	/* new iif loops to existing oif ? */
-	if (c_oil->oil.mfcc_ttls[input_iface_vif_index]) {
-		struct interface *new_iif = pim_if_find_by_vif_index(
-			c_oil->pim, input_iface_vif_index);
-
-		if (PIM_DEBUG_ZEBRA) {
-			char source_str[INET_ADDRSTRLEN];
-			char group_str[INET_ADDRSTRLEN];
-			pim_inet4_dump("<source?>", c_oil->oil.mfcc_origin,
-				       source_str, sizeof(source_str));
-			pim_inet4_dump("<group?>", c_oil->oil.mfcc_mcastgrp,
-				       group_str, sizeof(group_str));
-			zlog_debug(
-				"%s %s: (S,G)=(%s,%s) new iif loops to existing oif: %s vif_index=%d",
-				__FILE__, __PRETTY_FUNCTION__, source_str,
-				group_str,
-				(new_iif) ? new_iif->name : "<new_iif?>",
-				input_iface_vif_index);
-		}
-	}
-
-	/* update iif vif_index */
-	pim_channel_oil_change_iif(c_oil->pim, c_oil, input_iface_vif_index,
-				   __PRETTY_FUNCTION__);
-	pim_upstream_mroute_add(c_oil, __PRETTY_FUNCTION__);
-}
-
 void pim_scan_oil(struct pim_instance *pim)
 {
 	struct listnode *node;
 	struct listnode *nextnode;
 	struct channel_oil *c_oil;
-	ifindex_t ifindex;
-	int vif_index = 0;
 
 	pim->scan_oil_last = pim_time_monotonic_sec();
 	++pim->scan_oil_events;
 
 	for (ALL_LIST_ELEMENTS(pim->channel_oil_list, node, nextnode, c_oil)) {
-		if (c_oil->up && c_oil->up->rpf.source_nexthop.interface) {
-			ifindex = c_oil->up->rpf.source_nexthop
-					  .interface->ifindex;
-			vif_index =
-				pim_if_find_vifindex_by_ifindex(pim, ifindex);
-			/* Pass Current selected NH vif index to mroute
-			 * download */
-			if (vif_index)
-				pim_scan_individual_oil(c_oil, vif_index);
-		} else
-			pim_scan_individual_oil(c_oil, 0);
+		pim_upstream_mroute_iif_update(c_oil, __func__);
 	}
 }
 
@@ -755,7 +635,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
 					      source->source_addr, sg.grp)) {
 			/*Create a dummy channel oil */
 			source->source_channel_oil = pim_channel_oil_add(
-				pim, &sg, MAXVIFS, __PRETTY_FUNCTION__);
+				pim, &sg, __PRETTY_FUNCTION__);
 		}
 
 		else {
@@ -806,7 +686,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
 				}
 				source->source_channel_oil =
 					pim_channel_oil_add(
-						pim, &sg, MAXVIFS,
+						pim, &sg,
 						__PRETTY_FUNCTION__);
 			}
 
@@ -840,7 +720,7 @@ void igmp_source_forward_start(struct pim_instance *pim,
 
 				source->source_channel_oil =
 					pim_channel_oil_add(
-						pim, &sg, input_iface_vif_index,
+						pim, &sg,
 						__PRETTY_FUNCTION__);
 				if (!source->source_channel_oil) {
 					if (PIM_DEBUG_IGMP_TRACE) {

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -289,7 +289,7 @@ void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 			 * so install it.
 			 */
 			if (!up->channel_oil->installed)
-				pim_mroute_add(up->channel_oil,
+				pim_upstream_mroute_add(up->channel_oil,
 					__PRETTY_FUNCTION__);
 
 			/*
@@ -325,7 +325,8 @@ void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 		}
 
 		if (!up->channel_oil->installed)
-			pim_mroute_add(up->channel_oil, __PRETTY_FUNCTION__);
+			pim_upstream_mroute_add(up->channel_oil,
+					__PRETTY_FUNCTION__);
 	}
 
 	/* FIXME can join_desired actually be changed by pim_rpf_update()
@@ -440,7 +441,7 @@ void pim_scan_individual_oil(struct channel_oil *c_oil, int in_vif_index)
 
 	if (input_iface_vif_index == c_oil->oil.mfcc_parent) {
 		if (!c_oil->installed)
-			pim_mroute_add(c_oil, __PRETTY_FUNCTION__);
+			pim_upstream_mroute_add(c_oil, __PRETTY_FUNCTION__);
 
 		/* RPF unchanged */
 		return;
@@ -490,7 +491,7 @@ void pim_scan_individual_oil(struct channel_oil *c_oil, int in_vif_index)
 	/* update iif vif_index */
 	pim_channel_oil_change_iif(c_oil->pim, c_oil, input_iface_vif_index,
 				   __PRETTY_FUNCTION__);
-	pim_mroute_add(c_oil, __PRETTY_FUNCTION__);
+	pim_upstream_mroute_add(c_oil, __PRETTY_FUNCTION__);
 }
 
 void pim_scan_oil(struct pim_instance *pim)
@@ -1008,7 +1009,7 @@ void pim_forward_stop(struct pim_ifchannel *ch, bool install_it)
 				    PIM_OIF_FLAG_PROTO_PIM, __func__);
 
 	if (install_it && !up->channel_oil->installed)
-		pim_mroute_add(up->channel_oil, __PRETTY_FUNCTION__);
+		pim_upstream_mroute_add(up->channel_oil, __PRETTY_FUNCTION__);
 }
 
 void pim_zebra_zclient_update(struct vty *vty)

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -271,7 +271,7 @@ void pim_zebra_upstream_rpf_changed(struct pim_instance *pim,
 		nbr = pim_neighbor_find(old->source_nexthop.interface,
 					old->rpf_addr.u.prefix4);
 		if (nbr)
-			pim_jp_agg_remove_group(nbr->upstream_jp_agg, up);
+			pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
 
 		/*
 		 * We have detected a case where we might need


### PR DESCRIPTION
This patch set bring a series of PIM state machine changes to address problems 
with SPT switchover and RPT switchback. These problems were discovered as a 
part of EVPN-PIM testing (and the patch description may refer to such 
problems) but the changes are applicable to PIM in general with or without 
EVPN.

1. First four patches are EVPN-PIM fixes for muting OIFs on non-DFs. These
patches are needed to create the infra that the remaining fixes use.

2. The remaining fixes address problems in the following areas -
a. Choice of RPF interface for (S,G) entries. This was changed to be
RPF(RP) for (S,G,rpt) entries and RPF(S) for (S,G,spt) entries.
b. JoinDesired and Prune(S,G,rpt) macros. These were changed to conform
to the RFC.
c. Some events were not triggering immediate JP messages resulting in
loss of traffic till the JP periodic timer kicked in.

Signed-off-by: Anuradha Karuppiah <anuradhak@cumulusnetworks.com>

Tagging @donaldsharp @Jafaral @srimohans @sarav511 