### PR TITLE
bgpd: IPv4 LU withdraw using 0x000000 label

### DIFF
--- a/bgpd/bgp_label.h
+++ b/bgpd/bgp_label.h
@@ -58,7 +58,7 @@ static inline int bgp_is_withdraw_label(mpls_label_t *label)
 
 	/* The check on pkt[2] for 0x00 or 0x02 is in case bgp_set_valid_label()
 	 * was called on the withdraw label */
-	if ((pkt[0] == 0x80) && (pkt[1] == 0x00)
+	if (((pkt[0] == 0x80) || (pkt[0] == 0x00)) && (pkt[1] == 0x00)
 	    && ((pkt[2] == 0x00) || (pkt[2] == 0x02)))
 		return 1;
 	return 0;


### PR DESCRIPTION
According to RFC 8277 IPv4 LU NLRI can be withdrawn using label 0x000000. This RFC updates RFC3101 where it should be done only with 0x800000 label value. Juniper implementation sets value 0x000000 when prefix is being withdrawn.
Page 12 RFC8277 states:
[RFC3107] also made it possible to withdraw a binding without
specifying the label explicitly, by setting the Compatibility field
to 0x800000. However, some implementations set it to 0x000000. In
order to ensure backwards compatibility, it is RECOMMENDED by this
document that the Compatibility field be set to 0x800000, but it is
REQUIRED that it be ignored upon reception.

Now FRR drops BGP session when receives such BGP update.
