### PR TITLE
pimd: Tighten up `show ip pim rp-info`

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -1261,7 +1261,7 @@ void pim_rp_show_information(struct pim_instance *pim, struct vty *vty, bool uj)
 		json = json_object_new_object();
 	else
 		vty_out(vty,
-			"RP address       group/prefix-list   OIF         I am RP     Source\n");
+			"RP address       group/prefix-list   OIF               I am RP    Source\n");
 	for (ALL_LIST_ELEMENTS_RO(pim->rp_list, node, rp_info)) {
 		if (!pim_rpf_addr_is_inaddr_none(&rp_info->rp)) {
 			char buf[48];
@@ -1338,7 +1338,7 @@ void pim_rp_show_information(struct pim_instance *pim, struct vty *vty, bool uj)
 					vty_out(vty, "%-16s  ", "(Unknown)");
 
 				if (rp_info->i_am_rp)
-					vty_out(vty, "yes\n");
+					vty_out(vty, "yes");
 				else
 					vty_out(vty, "no");
 


### PR DESCRIPTION
We were adding a newline for the source in some cases
but not others and tighten up the display of data

eva# show ip pim rp-info
RP address       group/prefix-list   OIF               I am RP    Source
10.254.0.1       224.0.0.0/4         lo                yes        Static
4.4.4.4          225.1.2.3/32        abcdefghijklmno   yes        Static
10.0.20.45       226.200.100.100/32  r1-eth0           no         Static
eva#

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>