### PR TITLE
[7.1]pimd: Create pimreg interface when we start any interface config

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6527,6 +6527,8 @@ static int pim_cmd_interface_add(struct interface *ifp)
 
 	pim_if_addr_add_all(ifp);
 	pim_if_membership_refresh(ifp);
+
+	pim_if_create_pimreg(pim_ifp->pim);
 	return 1;
 }
 


### PR DESCRIPTION
When you configure interface configuration without explicitly
configuring pim on that interface, we were not creating the pimreg
interface and as such we would crash in an attempted register
since the pimreg device is non-existent.

The crash is this:
==8823== Invalid read of size 8
==8823==    at 0x468614: pim_channel_add_oif (pim_oil.c:392)
==8823==    by 0x46D0F1: pim_register_join (pim_register.c:61)
==8823==    by 0x449AB3: pim_mroute_msg_nocache (pim_mroute.c:242)
==8823==    by 0x449AB3: pim_mroute_msg (pim_mroute.c:661)
==8823==    by 0x449AB3: mroute_read (pim_mroute.c:707)
==8823==    by 0x4FC0676: thread_call (thread.c:1549)
==8823==    by 0x4EF3A2F: frr_run (libfrr.c:1064)
==8823==    by 0x40DCB5: main (pim_main.c:162)
==8823==  Address 0xc8 is not stack'd, malloc'd or (recently) free'd

pim_register_join calls pim_channel_add_oif with:

	pim_channel_add_oif(up->channel_oil, pim->regiface,
			    PIM_OIF_FLAG_PROTO_PIM);

We just need to make srue pim->regiface exists once we start configuring
pim.

Fixes: #5358
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>