### PR TITLE
bgpd: Bug fix in "show bgp l2vpn evpn X:X::X:X/M"

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -11124,7 +11124,7 @@ DEFUN (show_bgp_l2vpn_evpn_route_prefix,
 		argv_find(argv, argc, "X:X::X:X", &idx))
 		network = argv[idx]->arg;
 	else if (argv_find(argv, argc, "A.B.C.D/M", &idx) ||
-		argv_find(argv, argc, "A.B.C.D/M", &idx)) {
+		argv_find(argv, argc, "X:X::X:X/M", &idx)) {
 		network = argv[idx]->arg;
 		prefix_check = 1;
 	} else {


### PR DESCRIPTION
The CLI was not parsing prefix format of ipv6 address.
This fixes the bug: https://github.com/FRRouting/frr/issues/5322

Signed-off-by: Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>