### PR TITLE
bgpd: [7.2] Fix per afi/safi addpath peer counting

### DIFF
--- a/bgpd/bgp_addpath.c
+++ b/bgpd/bgp_addpath.c
@@ -321,6 +321,7 @@ void bgp_addpath_type_changed(struct bgp *bgp)
 		for (type=0; type<BGP_ADDPATH_MAX; type++) {
 			peer_count[afi][safi][type] = 0;
 		}
+		bgp->tx_addpath.total_peercount[afi][safi] = 0;
 	}
 
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
@@ -328,6 +329,7 @@ void bgp_addpath_type_changed(struct bgp *bgp)
 			type = peer->addpath_type[afi][safi];
 			if (type != BGP_ADDPATH_NONE) {
 				peer_count[afi][safi][type] += 1;
+				bgp->tx_addpath.total_peercount[afi][safi] += 1;
 			}
 		}
 	}


### PR DESCRIPTION
The total_peercount table was created as a short cut for queries about
if addpath was enabled at all on a particular afi/safi. However, the
values weren't updated, so BGP would act as if addpath wasn't enabled
when determining if updates should be sent out. The error in behavior
was much more noticeable in tx-all than best-per-as, since changes in
what is sent by best-per-as would often trigger updates even if addpath
wasn't enabled.

Signed-off-by: Mitchell Skiba <mskiba@amazon.com>