### PR TITLE
lib: nexthops compare vrf only if ip type

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -105,12 +105,6 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
 {
 	int ret = 0;
 
-	if (next1->vrf_id < next2->vrf_id)
-		return -1;
-
-	if (next1->vrf_id > next2->vrf_id)
-		return 1;
-
 	if (next1->type < next2->type)
 		return -1;
 
@@ -120,6 +114,12 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
 	switch (next1->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV6:
+		if (next1->vrf_id < next2->vrf_id)
+			return -1;
+
+		if (next1->vrf_id > next2->vrf_id)
+			return 1;
+
 		ret = _nexthop_gateway_cmp(next1, next2);
 		if (ret != 0)
 			return ret;

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -790,12 +790,6 @@ static int zapi_nexthop_cmp_no_labels(const struct zapi_nexthop *next1,
 {
 	int ret = 0;
 
-	if (next1->vrf_id < next2->vrf_id)
-		return -1;
-
-	if (next1->vrf_id > next2->vrf_id)
-		return 1;
-
 	if (next1->type < next2->type)
 		return -1;
 
@@ -805,6 +799,12 @@ static int zapi_nexthop_cmp_no_labels(const struct zapi_nexthop *next1,
 	switch (next1->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV6:
+		if (next1->vrf_id < next2->vrf_id)
+			return -1;
+
+		if (next1->vrf_id > next2->vrf_id)
+			return 1;
+
 		ret = nexthop_g_addr_cmp(next1->type, &next1->gate,
 					 &next2->gate);
 		if (ret != 0)


### PR DESCRIPTION
Using frr7.2, I encounterd a problem that zebra crashes when removing vrf(I would create an issue). And found when changing an interface vrf, route ff00::/8 deletes failed because of nexthop vrf changed. 

To compare nexthops, if given ifindex, it is enough to compare ifindex, the vrf is get from ifindex, and ifindex is more reliable. For blackhole, I think it is a special interface, vrf may be useless. So only type ip need to compare vrf.

logs:
```
2019/11/14 09:48:05 ZEBRA: netlink_parse_info: netlink-listen (NS 0) type RTM_NEWLINK(16), len=1276, seq=0, pid=0
2019/11/14 09:48:05 ZEBRA: RTM_NEWLINK update for Ethernet8(433) sl_type 1 master 0 flags 0x11043
2019/11/14 09:48:05 ZEBRA: Intf Ethernet8(433) PTM up, notifying clients
2019/11/14 09:48:05 ZEBRA: MESSAGE: ZEBRA_INTERFACE_UP Ethernet8(459)
2019/11/14 09:48:05 ZEBRA: netlink_parse_info: netlink-listen (NS 0) type RTM_NEWLINK(16), len=1248, seq=0, pid=0
2019/11/14 09:48:05 ZEBRA: RTM_NEWLINK vrf-change for Ethernet8(433) vrf_id 459 -> 0 flags 0x11043
2019/11/14 09:48:05 ZEBRA: MESSAGE: ZEBRA_INTERFACE_ADDRESS_DELETE fe80::42:acff:fe11:2/64 on Ethernet8(459)
2019/11/14 09:48:05 ZEBRA: rib_delnode: 459:fe80::/64: rn 0x55610789b5c0, re 0x55610788f8a0, removing
2019/11/14 09:48:05 ZEBRA: rib_delnode: 459:fe80::/64 (MRIB): rn 0x55610788ed00, re 0x55610788dc90, removing
2019/11/14 09:48:05 ZEBRA: MESSAGE: ZEBRA_INTERFACE_VRF_UPDATE/DEL Ethernet8 VRF Id 459 -> 0
2019/11/14 09:48:05 ZEBRA: MESSAGE: ZEBRA_INTERFACE_VRF_UPDATE/ADD Ethernet8 VRF Id 459 -> 0
2019/11/14 09:48:05 ZEBRA: MESSAGE: ZEBRA_INTERFACE_ADDRESS_ADD fe80::42:acff:fe11:2/64 on Ethernet8(0)
2019/11/14 09:48:05 ZEBRA: rib_add_multipath: 0:fe80::/64: Inserting route rn 0x5561079b2050, re 0x55610788e7b0 (connected) existing (nil)
2019/11/14 09:48:05 ZEBRA: rib_add_multipath: 0:fe80::/64 (MRIB): Inserting route rn 0x55610789f250, re 0x55610789e040 (connected) existing (nil)
2019/11/14 09:48:05 ZEBRA: netlink_parse_info: netlink-listen (NS 0) type RTM_DELROUTE(25), len=116, seq=0, pid=0
2019/11/14 09:48:05 ZEBRA: RTM_DELROUTE ipv6 unicast proto kernel NS 0
2019/11/14 09:48:05 ZEBRA: netlink_parse_info: netlink-listen (NS 0) type RTM_DELROUTE(25), len=116, seq=0, pid=0
2019/11/14 09:48:05 ZEBRA: RTM_DELROUTE ipv6 unicast proto boot NS 0
2019/11/14 09:48:05 ZEBRA: RTM_DELROUTE ff00::/8 vrf 459(1001) metric: 256 Admin Distance: 0
2019/11/14 09:48:05 ZEBRA: rib_delete: 459:ff00::/8: via :: ifindex 433 type 1 doesn't exist in rib
```