### PR TITLE
pimd: Fix possible read beyond end of data received

### DIFF
--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -190,6 +190,12 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len)
 	no_fwd = header->Nbit;
 
 	if (header->type == PIM_MSG_TYPE_REGISTER) {
+		if (pim_msg_len < PIM_MSG_REGISTER_LEN) {
+			if (PIM_DEBUG_PIM_PACKETS)
+				zlog_debug("PIM Register Message size=%d shorther than min length %d",
+					   pim_msg_len, PIM_MSG_REGISTER_LEN);
+			return -1;
+		}
 		/* First 8 byte header checksum */
 		checksum = in_cksum(pim_msg, PIM_MSG_REGISTER_LEN);
 		if (checksum != pim_checksum) {


### PR DESCRIPTION
If a register packet is received that is less than the PIM_MSG_REGISTER_LEN
in size we can have a possible situation where the data being
checksummed is just random data from the buffer we read into.

2019/11/18 21:45:46 warnings: PIM: int pim_if_add_vif(struct interface *, _Bool, _Bool): could not get address for interface fuzziface ifindex=0
==27636== Invalid read of size 4
==27636==    at 0x4E6EB0D: in_cksum (checksum.c:28)
==27636==    by 0x4463CC: pim_pim_packet (pim_pim.c:194)
==27636==    by 0x40E2B4: main (pim_main.c:117)
==27636==  Address 0x771f818 is 0 bytes after a block of size 24 alloc'd
==27636==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27636==    by 0x40E261: main (pim_main.c:112)
==27636==

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>