### PR TITLE
tools: resolve issue with bfd timer change fix in frr-reload.py

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -755,9 +755,10 @@ def ignore_delete_re_add_lines(lines_to_add, lines_to_del):
                 if re_nbr_bfd_timers:
                     nbr = re_nbr_bfd_timers.group(1)
                     bfd_nbr = "neighbor %s" % nbr
+                    bfd_search_string =  bfd_nbr + r' bfd (\S+) (\S+) (\S+)'
 
                     for (ctx_keys, add_line) in lines_to_add:
-                        re_add_nbr_bfd_timers = re.search(r'neighbor bfd_nbr bfd (\S+) (\S+) (\S+)', add_line)
+                        re_add_nbr_bfd_timers = re.search(bfd_search_string, add_line)
 
                         if re_add_nbr_bfd_timers:
                             found_add_bfd_nbr = line_exist(lines_to_add, ctx_keys, bfd_nbr, False)


### PR DESCRIPTION
Found that while the previous fix solved the traceback and created
the correct configuration, it was doing a delete/add process rather
than just an add.  This was due to an incorrectly created search
string. This commit fixes that search string and testing verifies
that the correct thing is now being done.

Ticket: CM-27233
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>