### PR TITLE
zebra: Router Advertisement socket mess up

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -2120,14 +2120,8 @@ static void rtadv_event(struct zebra_vrf *zvrf, enum rtadv_event event, int val)
 				 &rtadv->ra_timer);
 		break;
 	case RTADV_STOP:
-		if (rtadv->ra_timer) {
-			thread_cancel(rtadv->ra_timer);
-			rtadv->ra_timer = NULL;
-		}
-		if (rtadv->ra_read) {
-			thread_cancel(rtadv->ra_read);
-			rtadv->ra_read = NULL;
-		}
+		THREAD_OFF(rtadv->ra_timer);
+		THREAD_OFF(rtadv->ra_read);
 		break;
 	case RTADV_TIMER:
 		thread_add_timer(zrouter.master, rtadv_timer, zvrf, val,
@@ -2152,10 +2146,11 @@ void rtadv_init(struct zebra_vrf *zvrf)
 	if (vrf_is_backend_netns()) {
 		zvrf->rtadv.sock = rtadv_make_socket(zvrf->zns->ns_id);
 		zrouter.rtadv_sock = -1;
-	} else if (!zrouter.rtadv_sock) {
+	} else {
 		zvrf->rtadv.sock = -1;
-		if (!zrouter.rtadv_sock)
-			zrouter.rtadv_sock = rtadv_make_socket(zvrf->zns->ns_id);
+		if (zrouter.rtadv_sock < 0)
+			zrouter.rtadv_sock =
+				rtadv_make_socket(zvrf->zns->ns_id);
 	}
 }
 

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -245,6 +245,8 @@ void zebra_router_init(void)
 
 	zrouter.packets_to_process = ZEBRA_ZAPI_PACKETS_TO_PROCESS;
 
+	zrouter.rtadv_sock = -1;
+
 	zebra_vxlan_init();
 	zebra_mlag_init();
 


### PR DESCRIPTION
The code for when a new vrf is created to properly handle
router advertisement for it is messed up in several ways:

1) Generation of the zrouter data structure should set the rtadv
socket to -1 so that we don't accidently close someone elses
open file descriptor
2) When you created a new zvrf instance *after* bootup we are XCALLOC'ing
the data structure so the zvrf->fd was 0.  The shutdown code was looking
for the >= 0 to know if the fd existed (since fd 0 is valid!)

This sequence of events would cause zebra to consume 100% of the
cpu:

Run zebra by itself ( no other programs )
ip link add vrf1 type vrf table 1003
ip link del vrf vrf1
vtysh -c "configure" -c "no interface vrf1"

This commit fixes this issue.

Fixes: #5376
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>