### PR TITLE
 bgpd: [7.2] Notify "Peer De-configured" after entering 'no neighbor <neighbor> cmd'

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3173,14 +3173,16 @@ DEFUN (no_neighbor,
 			 * interface. */
 			if (peer->ifp)
 				bgp_zebra_terminate_radv(peer->bgp, peer);
+			peer_notify_unconfig(peer);
 			peer_delete(peer);
 			return CMD_SUCCESS;
 		}
 
 		group = peer_group_lookup(bgp, argv[idx_peer]->arg);
-		if (group)
+		if (group) {
+			peer_group_notify_unconfig(group);
 			peer_group_delete(group);
-		else {
+		} else {
 			vty_out(vty, "%% Create the peer-group first\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		}
@@ -3194,9 +3196,12 @@ DEFUN (no_neighbor,
 			}
 
 			other = peer->doppelganger;
+			peer_notify_unconfig(peer);
 			peer_delete(peer);
-			if (other && other->status != Deleted)
+			if (other && other->status != Deleted) {
+				peer_notify_unconfig(other);
 				peer_delete(other);
+			}
 		}
 	}
 
@@ -3228,6 +3233,7 @@ DEFUN (no_neighbor_interface_config,
 		/* Request zebra to terminate IPv6 RAs on this interface. */
 		if (peer->ifp)
 			bgp_zebra_terminate_radv(peer->bgp, peer);
+		peer_notify_unconfig(peer);
 		peer_delete(peer);
 	} else {
 		vty_out(vty, "%% Create the bgp interface first\n");
@@ -3249,9 +3255,10 @@ DEFUN (no_neighbor_peer_group,
 	struct peer_group *group;
 
 	group = peer_group_lookup(bgp, argv[idx_word]->arg);
-	if (group)
+	if (group) {
+		peer_group_notify_unconfig(group);
 		peer_group_delete(group);
-	else {
+	} else {
 		vty_out(vty, "%% Create the peer-group first\n");
 		return CMD_WARNING_CONFIG_FAILED;
 	}
@@ -3609,6 +3616,7 @@ DEFUN (no_neighbor_set_peer_group,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
+	peer_notify_unconfig(peer);
 	ret = peer_delete(peer);
 
 	return bgp_vty_return(vty, ret);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1634,9 +1634,11 @@ extern int peer_remote_as(struct bgp *, union sockunion *, const char *, as_t *,
 			  int, afi_t, safi_t);
 extern int peer_group_remote_as(struct bgp *, const char *, as_t *, int);
 extern int peer_delete(struct peer *peer);
+extern int peer_notify_unconfig(struct peer *peer);
 extern int peer_group_delete(struct peer_group *);
 extern int peer_group_remote_as_delete(struct peer_group *);
 extern int peer_group_listen_range_add(struct peer_group *, struct prefix *);
+extern int peer_group_notify_unconfig(struct peer_group *group);
 
 extern int peer_activate(struct peer *, afi_t, safi_t);
 extern int peer_deactivate(struct peer *, afi_t, safi_t);


### PR DESCRIPTION
…or> cmd'

Before changes:

~# vtysh -c 'show ip bgp neighbors 192.168.0.2 json' | \
	jq '."192.168.0.2".lastNotificationReason'
null

After changes:

~# vtysh -c 'show ip bgp neighbors 192.168.0.2 json' | \
	jq '."192.168.0.2".lastNotificationReason'
"Cease/Peer Unconfigured"

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>