### PR TITLE
bgpd: Allow failed hostname lookup to continue in bmp

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1669,18 +1669,26 @@ static void bmp_active_resolved(struct resolver_query *resq, int numaddrs,
 	unsigned i;
 
 	if (numaddrs <= 0) {
-		zlog_warn("bmp[%s]: hostname resolution failed", ba->hostname);
-		ba->curretry += ba->curretry / 2;
-		bmp_active_setup(ba);
-		return;
-	}
-	if (numaddrs > (int)array_size(ba->addrs))
-		numaddrs = array_size(ba->addrs);
+		int ret;
 
-	ba->addrpos = 0;
-	ba->addrtotal = numaddrs;
-	for (i = 0; i < ba->addrtotal; i++)
-		memcpy(&ba->addrs[i], &addr[i], sizeof(ba->addrs[0]));
+		ba->addrpos = 0;
+		ba->addrtotal = 1;
+		ret = str2sockunion(ba->hostname, &ba->addrs[0]);
+		if (ret < 0) {
+			ba->addrtotal = 0;
+			ba->curretry += ba->curretry / 2;
+			bmp_active_setup(ba);
+			return;
+		}
+	} else {
+		if (numaddrs > (int)array_size(ba->addrs))
+			numaddrs = array_size(ba->addrs);
+
+		ba->addrpos = 0;
+		ba->addrtotal = numaddrs;
+		for (i = 0; i < ba->addrtotal; i++)
+			memcpy(&ba->addrs[i], &addr[i], sizeof(ba->addrs[0]));
+	}
 
 	bmp_active_connect(ba);
 }


### PR DESCRIPTION
Add a bit of code to allow hostname lookup failure to
not stall bmp communication.

Fixes: #5382
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>