### PR TITLE
zebra: BSD null routes were not being installed

### DIFF
--- a/zebra/rt_socket.c
+++ b/zebra/rt_socket.c
@@ -178,7 +178,7 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 		case NEXTHOP_TYPE_BLACKHOLE:
 			bh_type = nexthop->bh_type;
 			switch (p->family) {
-			case AFI_IP: {
+			case AF_INET: {
 				struct in_addr loopback;
 				loopback.s_addr = htonl(INADDR_LOOPBACK);
 				sin_gate.sin.sin_addr = loopback;
@@ -189,7 +189,8 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 				gate = true;
 			}
 				break;
-			case AFI_IP6:
+			case AF_INET6:
+				zlog_warn("v6 blackhole routes have not been programmed yet");
 				break;
 			}
 		}
@@ -230,13 +231,13 @@ static int kernel_rtm(int cmd, const struct prefix *p,
 					__func__, prefix_buf);
 			} else {
 				switch (p->family) {
-				case AFI_IP:
+				case AF_INET:
 					inet_ntop(AF_INET,
 						  &sin_gate.sin.sin_addr,
 						  gate_buf, sizeof(gate_buf));
 					break;
 
-				case AFI_IP6:
+				case AF_INET6:
 					inet_ntop(AF_INET6,
 						  &sin_gate.sin6.sin6_addr,
 						  gate_buf, sizeof(gate_buf));


### PR DESCRIPTION
On BSD systems null routes were not being installed into the
kernel.  This is because commit 08ea27d1121ef5989cdc54fb178c05a7efc4cd3e
introduced a bug where we were attempting to use the wrong
prefix afi types and as such we were going down the v6 code path.

test27.lab.netdef.org# show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued route, r - rejected route
K>* 0.0.0.0/0 [0/0] via 192.168.122.1, 00:00:23
S>* 4.5.6.8/32 [1/0] unreachable (blackhole), 00:00:11
C>* 192.168.122.0/24 [0/1] is directly connected, vtnet0, 00:00:23
test27.lab.netdef.org# exit
[ci@test27 ~/frr]$ netstat -rn
Routing tables
Internet:
Destination        Gateway            Flags     Netif Expire
default            192.168.122.1      UGS      vtnet0
4.5.6.8/32         127.0.0.1          UG1B        lo0
127.0.0.1          link#2             UH          lo0
192.168.122.0/24   link#1             U        vtnet0
192.168.122.108    link#1             UHS         lo0

Fixes: #4843
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>