### PR TITLE
zebra: Actually respect the multipath number

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1675,9 +1675,7 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 		new_active =
 			nexthop_active_check(rn, re, nexthop);
 
-		if (new_active
-		    && nexthop_group_active_nexthop_num(&new_grp)
-			       >= zrouter.multipath_num) {
+		if (new_active && curr_active >= zrouter.multipath_num) {
 			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 			new_active = 0;
 		}

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1676,7 +1676,12 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 			nexthop_active_check(rn, re, nexthop);
 
 		if (new_active && curr_active >= zrouter.multipath_num) {
-			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
+			struct nexthop *nh;
+
+			/* Set it and its resolved nexthop as inactive. */
+			for (nh = nexthop; nh; nh = nh->resolved)
+				UNSET_FLAG(nh->flags, NEXTHOP_FLAG_ACTIVE);
+
 			new_active = 0;
 		}
 


### PR DESCRIPTION
We were not properly handling the multipath_num in a couple different ways:

1) On every iteration checking the group's active num was bad performance-wise and it was incorectly
marking things inactive when they are == to the wanted ecmp number. See first commit for example.

2) We were not setting the resolved nexthop as inactive so even though we were marking its parent inactive, it still got installed into the kernel. This looks to have been broken since the 6.x timeline.