### PR TITLE
bgpd: Blank RD in "sh bgp l2vpn evpn all neighbors ip advertised-routes json"

### DIFF
--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -85,9 +85,13 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 		if (table == NULL)
 			continue;
 
-
+		/*
+		 * Initialize variables for each RD
+		 * All prefixes under an RD is aggregated within "json_routes"
+		 */
 		rd_header = 1;
 		memset(rd_str, 0, sizeof(rd_str));
+		json_routes = NULL;
 
 		for (rm = bgp_table_top(table); rm; rm = bgp_route_next(rm)) {
 			struct bgp_adj_out *adj = NULL;
@@ -223,7 +227,7 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 			output_count++;
 		}
 
-		if (use_json)
+		if (use_json && json_routes)
 			json_object_object_add(json_adv, rd_str, json_routes);
 	}
 


### PR DESCRIPTION
Bug: While preparing the JSON output, 2 loops are traversed: the outer loop
loops through RD, and the inner loop loops through the prefixes of that RD.

We hit the bug (printing blank RD and stale or null prefix info) when the inner
loop exits with nothing to print, (without allocating json_routes) and the outer
loop still tries to attach it to the parent, json_adv. Thus, we have
key=&lt;BLANK RD&gt;, value=&lt;junk or prev json_routes&gt;

The fix: Avoid attaching json_routes to the parent json if there
is nothing to print.

Signed-off-by: Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>