### PR TITLE
zebra: "show evpn vni details json" prints incorrect JSON format

### DIFF
--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2227,7 +2227,7 @@ DEFUN (show_evpn_vni_vni,
 
 	vni = strtoul(argv[3]->arg, NULL, 10);
 	zvrf = zebra_vrf_get_evpn();
-	zebra_vxlan_print_vni(vty, zvrf, vni, uj);
+	zebra_vxlan_print_vni(vty, zvrf, vni, uj, NULL);
 	return CMD_SUCCESS;
 }
 

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -141,7 +141,8 @@ extern void zebra_vxlan_print_neigh_vni_dad(struct vty *vty,
 					struct zebra_vrf *zvrf, vni_t vni,
 					bool use_json);
 extern void zebra_vxlan_print_vni(struct vty *vty, struct zebra_vrf *zvrf,
-				  vni_t vni, bool use_json);
+				  vni_t vni, bool use_json,
+				  json_object *json_array);
 extern void zebra_vxlan_print_vnis(struct vty *vty, struct zebra_vrf *zvrf,
 				   bool use_json);
 extern void zebra_vxlan_print_vnis_detail(struct vty *vty,


### PR DESCRIPTION
**Before fix:**
```
edge-2> show evpn vni detail json
{
  "vni":79031,
  "type":"L3",
  ...,
  ...
}                                       <<<<<< no comma

{
  "vni":79021,
  "type":"L3",
  ...,
  ...
}                                       <<<<<< no comma

{
}                                       <<<<<< blank
edge-2>

```
The fix is to pack json info into json_array before printing it.

**After fix:**
```
leaf-1# sh evpn vni detail json
[
  {
    "vni":100,
    "type":"L2",
     ...
  },
  {
    "vni":1000,
    "type":"L2",
    ...
  }
]
leaf-1#
```

Signed-off-by: Lakshman Krishnamoorthy <lkrishnamoor@vmware.com>