### PR TITLE
lib,zebra: use shared nexthop-group in route_entry

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -33,6 +33,7 @@
 #include "mpls.h"
 #include "jhash.h"
 #include "printfrr.h"
+#include "vrf.h"
 
 DEFINE_MTYPE_STATIC(LIB, NEXTHOP, "Nexthop")
 DEFINE_MTYPE_STATIC(LIB, NH_LABEL, "Nexthop label")
@@ -279,6 +280,93 @@ bool nexthop_same_no_labels(const struct nexthop *nh1,
 		return false;
 
 	return true;
+}
+
+/*
+ * Allocate a new nexthop object and initialize it from various args.
+ */
+struct nexthop *nexthop_from_ifindex(ifindex_t ifindex, vrf_id_t vrf_id)
+{
+	struct nexthop *nexthop;
+
+	nexthop = nexthop_new();
+	nexthop->type = NEXTHOP_TYPE_IFINDEX;
+	nexthop->ifindex = ifindex;
+	nexthop->vrf_id = vrf_id;
+
+	return nexthop;
+}
+
+struct nexthop *nexthop_from_ipv4(const struct in_addr *ipv4,
+				  const struct in_addr *src,
+				  vrf_id_t vrf_id)
+{
+	struct nexthop *nexthop;
+
+	nexthop = nexthop_new();
+	nexthop->type = NEXTHOP_TYPE_IPV4;
+	nexthop->vrf_id = vrf_id;
+	nexthop->gate.ipv4 = *ipv4;
+	if (src)
+		nexthop->src.ipv4 = *src;
+
+	return nexthop;
+}
+
+struct nexthop *nexthop_from_ipv4_ifindex(const struct in_addr *ipv4,
+					  const struct in_addr *src,
+					  ifindex_t ifindex, vrf_id_t vrf_id)
+{
+	struct nexthop *nexthop;
+
+	nexthop = nexthop_new();
+	nexthop->type = NEXTHOP_TYPE_IPV4_IFINDEX;
+	nexthop->vrf_id = vrf_id;
+	nexthop->gate.ipv4 = *ipv4;
+	if (src)
+		nexthop->src.ipv4 = *src;
+	nexthop->ifindex = ifindex;
+
+	return nexthop;
+}
+
+struct nexthop *nexthop_from_ipv6(const struct in6_addr *ipv6,
+				  vrf_id_t vrf_id)
+{
+	struct nexthop *nexthop;
+
+	nexthop = nexthop_new();
+	nexthop->vrf_id = vrf_id;
+	nexthop->type = NEXTHOP_TYPE_IPV6;
+	nexthop->gate.ipv6 = *ipv6;
+
+	return nexthop;
+}
+
+struct nexthop *nexthop_from_ipv6_ifindex(const struct in6_addr *ipv6,
+					  ifindex_t ifindex, vrf_id_t vrf_id)
+{
+	struct nexthop *nexthop;
+
+	nexthop = nexthop_new();
+	nexthop->vrf_id = vrf_id;
+	nexthop->type = NEXTHOP_TYPE_IPV6_IFINDEX;
+	nexthop->gate.ipv6 = *ipv6;
+	nexthop->ifindex = ifindex;
+
+	return nexthop;
+}
+
+struct nexthop *nexthop_from_blackhole(enum blackhole_type bh_type)
+{
+	struct nexthop *nexthop;
+
+	nexthop = nexthop_new();
+	nexthop->vrf_id = VRF_DEFAULT;
+	nexthop->type = NEXTHOP_TYPE_BLACKHOLE;
+	nexthop->bh_type = bh_type;
+
+	return nexthop;
 }
 
 /* Update nexthop with label information. */

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -122,6 +122,22 @@ void nexthop_add_labels(struct nexthop *, enum lsp_types_t, uint8_t,
 void nexthop_del_labels(struct nexthop *);
 
 /*
+ * Allocate a new nexthop object and initialize it from various args.
+ */
+struct nexthop *nexthop_from_ifindex(ifindex_t ifindex, vrf_id_t vrf_id);
+struct nexthop *nexthop_from_ipv4(const struct in_addr *ipv4,
+				  const struct in_addr *src,
+				  vrf_id_t vrf_id);
+struct nexthop *nexthop_from_ipv4_ifindex(const struct in_addr *ipv4,
+					  const struct in_addr *src,
+					  ifindex_t ifindex, vrf_id_t vrf_id);
+struct nexthop *nexthop_from_ipv6(const struct in6_addr *ipv6,
+				  vrf_id_t vrf_id);
+struct nexthop *nexthop_from_ipv6_ifindex(const struct in6_addr *ipv6,
+					  ifindex_t ifindex, vrf_id_t vrf_id);
+struct nexthop *nexthop_from_blackhole(enum blackhole_type bh_type);
+
+/*
  * Hash a nexthop. Suitable for use with hash tables.
  *
  * This function uses the following values when computing the hash:

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -233,8 +233,8 @@ void _nexthop_add(struct nexthop **target, struct nexthop *nexthop)
 	nexthop->prev = last;
 }
 
-void _nexthop_group_add_sorted(struct nexthop_group *nhg,
-			       struct nexthop *nexthop)
+void nexthop_group_add_sorted(struct nexthop_group *nhg,
+			      struct nexthop *nexthop)
 {
 	struct nexthop *position, *prev, *tail;
 

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -50,6 +50,8 @@ void copy_nexthops(struct nexthop **tnh, const struct nexthop *nh,
 uint32_t nexthop_group_hash_no_recurse(const struct nexthop_group *nhg);
 uint32_t nexthop_group_hash(const struct nexthop_group *nhg);
 void nexthop_group_mark_duplicates(struct nexthop_group *nhg);
+void nexthop_group_add_sorted(struct nexthop_group *nhg,
+			      struct nexthop *nexthop);
 
 /* The following for loop allows to iterate over the nexthop
  * structure of routes.

--- a/lib/nexthop_group_private.h
+++ b/lib/nexthop_group_private.h
@@ -35,8 +35,6 @@ extern "C" {
 
 void _nexthop_add(struct nexthop **target, struct nexthop *nexthop);
 void _nexthop_del(struct nexthop_group *nhg, struct nexthop *nexthop);
-void _nexthop_group_add_sorted(struct nexthop_group *nhg,
-			       struct nexthop *nexthop);
 
 #ifdef __cplusplus
 }

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -35,6 +35,7 @@
 #include "if.h"
 #include "mpls.h"
 #include "srcdest_table.h"
+#include "zebra/zebra_nhg.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -334,6 +335,7 @@ extern void route_entry_nexthop_add(struct route_entry *re,
 				    struct nexthop *nexthop);
 extern void route_entry_copy_nexthops(struct route_entry *re,
 				      struct nexthop *nh);
+int route_entry_update_nhe(struct route_entry *re, struct nhg_hash_entry *new);
 
 #define route_entry_dump(prefix, src, re) _route_entry_dump(__func__, prefix, src, re)
 extern void _route_entry_dump(const char *func, union prefixconstptr pp,

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -1507,7 +1507,8 @@ static int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx,
 	ctx->u.rinfo.zd_safi = info->safi;
 
 	/* Copy nexthops; recursive info is included too */
-	copy_nexthops(&(ctx->u.rinfo.zd_ng.nexthop), re->ng->nexthop, NULL);
+	copy_nexthops(&(ctx->u.rinfo.zd_ng.nexthop),
+		      re->nhe->nhg->nexthop, NULL);
 
 	/* Ensure that the dplane's nexthops flags are clear. */
 	for (ALL_NEXTHOPS(ctx->u.rinfo.zd_ng, nexthop))
@@ -1746,7 +1747,7 @@ static int dplane_ctx_pw_init(struct zebra_dplane_ctx *ctx,
 
 			if (re)
 				copy_nexthops(&(ctx->u.pw.nhg.nexthop),
-					      re->ng->nexthop, NULL);
+					      re->nhe->nhg->nexthop, NULL);
 
 			route_unlock_node(rn);
 		}
@@ -1842,7 +1843,7 @@ dplane_route_update_internal(struct route_node *rn,
 			 * We'll need these to do per-nexthop deletes.
 			 */
 			copy_nexthops(&(ctx->u.rinfo.zd_old_ng.nexthop),
-				      old_re->ng->nexthop, NULL);
+				      old_re->nhe->nhg->nexthop, NULL);
 #endif	/* !HAVE_NETLINK */
 		}
 

--- a/zebra/zebra_fpm_dt.c
+++ b/zebra/zebra_fpm_dt.c
@@ -90,7 +90,7 @@ static int zfpm_dt_find_route(rib_dest_t **dest_p, struct route_entry **re_p)
 		if (!re)
 			continue;
 
-		if (nexthop_group_active_nexthop_num(re->ng) == 0)
+		if (nexthop_group_active_nexthop_num(re->nhe->nhg) == 0)
 			continue;
 
 		*dest_p = dest;

--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -314,7 +314,7 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
 	ri->rtm_type = RTN_UNICAST;
 	ri->metric = &re->metric;
 
-	for (ALL_NEXTHOPS_PTR(re->ng, nexthop)) {
+	for (ALL_NEXTHOPS_PTR(re->nhe->nhg, nexthop)) {
 		if (ri->num_nhs >= zrouter.multipath_num)
 			break;
 

--- a/zebra/zebra_fpm_protobuf.c
+++ b/zebra/zebra_fpm_protobuf.c
@@ -173,7 +173,7 @@ static Fpm__AddRoute *create_add_route_message(qpb_allocator_t *allocator,
 	 * Figure out the set of nexthops to be added to the message.
 	 */
 	num_nhs = 0;
-	for (ALL_NEXTHOPS_PTR(re->ng, nexthop)) {
+	for (ALL_NEXTHOPS_PTR(re->nhe->nhg, nexthop)) {
 		if (num_nhs >= zrouter.multipath_num)
 			break;
 

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -2572,7 +2572,7 @@ static void mpls_zebra_nhg_update(struct route_entry *re, afi_t afi,
 
 	nhe = zebra_nhg_rib_find(0, new_grp, afi);
 
-	zebra_nhg_re_update_ref(re, nhe);
+	route_entry_update_nhe(re, nhe);
 }
 
 static bool mpls_ftn_update_nexthop(int add, struct nexthop *nexthop,

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -185,7 +185,8 @@ static int lsp_install(struct zebra_vrf *zvrf, mpls_label_t label,
 	 * the label advertised by the recursive nexthop (plus we don't have the
 	 * logic yet to push multiple labels).
 	 */
-	for (nexthop = re->ng->nexthop; nexthop; nexthop = nexthop->next) {
+	for (nexthop = re->nhe->nhg->nexthop;
+	     nexthop; nexthop = nexthop->next) {
 		/* Skip inactive and recursive entries. */
 		if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 			continue;
@@ -635,7 +636,7 @@ static int nhlfe_nexthop_active_ipv4(zebra_nhlfe_t *nhlfe,
 		    || !CHECK_FLAG(match->flags, ZEBRA_FLAG_SELECTED))
 			continue;
 
-		for (match_nh = match->ng->nexthop; match_nh;
+		for (match_nh = match->nhe->nhg->nexthop; match_nh;
 		     match_nh = match_nh->next) {
 			if (match->type == ZEBRA_ROUTE_CONNECT
 			    || nexthop->ifindex == match_nh->ifindex) {
@@ -686,10 +687,10 @@ static int nhlfe_nexthop_active_ipv6(zebra_nhlfe_t *nhlfe,
 			break;
 	}
 
-	if (!match || !match->ng->nexthop)
+	if (!match || !match->nhe->nhg->nexthop)
 		return 0;
 
-	nexthop->ifindex = match->ng->nexthop->ifindex;
+	nexthop->ifindex = match->nhe->nhg->nexthop->ifindex;
 	return 1;
 }
 
@@ -2626,7 +2627,7 @@ int mpls_ftn_update(int add, struct zebra_vrf *zvrf, enum lsp_types_t type,
 	 * We can't just change the values here since we are hashing
 	 * on labels. We need to create a whole new group
 	 */
-	nexthop_group_copy(&new_grp, re->ng);
+	nexthop_group_copy(&new_grp, re->nhe->nhg);
 
 	found = false;
 	for (nexthop = new_grp.nexthop; nexthop; nexthop = nexthop->next) {
@@ -2707,7 +2708,7 @@ int mpls_ftn_uninstall(struct zebra_vrf *zvrf, enum lsp_types_t type,
 	if (re == NULL)
 		return -1;
 
-	nexthop_group_copy(&new_grp, re->ng);
+	nexthop_group_copy(&new_grp, re->nhe->nhg);
 
 	for (nexthop = new_grp.nexthop; nexthop; nexthop = nexthop->next)
 		nexthop_del_labels(nexthop);
@@ -2921,7 +2922,7 @@ static void mpls_ftn_uninstall_all(struct zebra_vrf *zvrf,
 		RNODE_FOREACH_RE (rn, re) {
 			struct nexthop_group new_grp = {};
 
-			nexthop_group_copy(&new_grp, re->ng);
+			nexthop_group_copy(&new_grp, re->nhe->nhg);
 
 			for (nexthop = new_grp.nexthop; nexthop;
 			     nexthop = nexthop->next) {

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1704,7 +1704,7 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 
 		new_nhe = zebra_nhg_rib_find(0, &new_grp, rt_afi);
 
-		zebra_nhg_re_update_ref(re, new_nhe);
+		route_entry_update_nhe(re, new_nhe);
 	}
 
 	if (curr_active) {
@@ -1728,40 +1728,6 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 	 */
 	nexthops_free(new_grp.nexthop);
 	return curr_active;
-}
-
-static void zebra_nhg_re_attach_ref(struct route_entry *re,
-				    struct nhg_hash_entry *new)
-{
-	re->ng = new->nhg;
-	re->nhe_id = new->id;
-
-	zebra_nhg_increment_ref(new);
-}
-
-int zebra_nhg_re_update_ref(struct route_entry *re, struct nhg_hash_entry *new)
-{
-	struct nhg_hash_entry *old = NULL;
-	int ret = 0;
-
-	if (new == NULL) {
-		re->ng = NULL;
-		goto done;
-	}
-
-	if (re->nhe_id != new->id) {
-		old = zebra_nhg_lookup_id(re->nhe_id);
-
-		zebra_nhg_re_attach_ref(re, new);
-
-		if (old)
-			zebra_nhg_decrement_ref(old);
-	} else if (!re->ng)
-		/* This is the first time it's being attached */
-		zebra_nhg_re_attach_ref(re, new);
-
-done:
-	return ret;
 }
 
 /* Convert a nhe into a group array */

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -158,6 +158,11 @@ struct nhg_ctx {
  * NHE abstracted tree functions.
  * Use these where possible instead of the direct ones access ones.
  */
+struct nhg_hash_entry *zebra_nhg_alloc(void);
+void zebra_nhg_free(struct nhg_hash_entry *nhe);
+/* In order to clear a generic hash, we need a generic api, sigh. */
+void zebra_nhg_hash_free(void *p);
+
 extern struct nhg_hash_entry *zebra_nhg_resolve(struct nhg_hash_entry *nhe);
 
 extern unsigned int zebra_nhg_depends_count(const struct nhg_hash_entry *nhe);

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -23,10 +23,8 @@
 #ifndef __ZEBRA_NHG_H__
 #define __ZEBRA_NHG_H__
 
-#include "zebra/rib.h"
+#include "lib/nexthop.h"
 #include "lib/nexthop_group.h"
-
-#include "zebra/zebra_dplane.h"
 
 /* This struct is used exclusively for dataplane
  * interaction via a dataplane context.
@@ -201,8 +199,6 @@ zebra_nhg_rib_find(uint32_t id, struct nexthop_group *nhg, afi_t rt_afi);
 /* Reference counter functions */
 extern void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe);
 extern void zebra_nhg_increment_ref(struct nhg_hash_entry *nhe);
-extern int zebra_nhg_re_update_ref(struct route_entry *re,
-				   struct nhg_hash_entry *nhe);
 
 /* Check validity of nhe, if invalid will update dependents as well */
 extern void zebra_nhg_check_valid(struct nhg_hash_entry *nhe);
@@ -224,5 +220,6 @@ extern void zebra_nhg_dplane_result(struct zebra_dplane_ctx *ctx);
 extern void zebra_nhg_sweep_table(struct hash *hash);
 
 /* Nexthop resolution processing */
+struct route_entry; /* Forward ref to avoid circular includes */
 extern int nexthop_active_update(struct route_node *rn, struct route_entry *re);
 #endif

--- a/zebra/zebra_nhg_private.h
+++ b/zebra/zebra_nhg_private.h
@@ -57,6 +57,4 @@ extern void nhg_connected_tree_del_nhe(struct nhg_connected_tree_head *head,
 extern void nhg_connected_tree_add_nhe(struct nhg_connected_tree_head *head,
 				       struct nhg_hash_entry *nhe);
 
-extern void zebra_nhg_free(void *arg);
-
 #endif /* __ZEBRA_NHG_PRIVATE_H__ */

--- a/zebra/zebra_pw.c
+++ b/zebra/zebra_pw.c
@@ -259,7 +259,7 @@ static int zebra_pw_check_reachability(struct zebra_pw *pw)
 	 * Need to ensure that there's a label binding for all nexthops.
 	 * Otherwise, ECMP for this route could render the pseudowire unusable.
 	 */
-	for (ALL_NEXTHOPS_PTR(re->ng, nexthop)) {
+	for (ALL_NEXTHOPS_PTR(re->nhe->nhg, nexthop)) {
 		if (!nexthop->nh_label) {
 			if (IS_ZEBRA_DEBUG_PW)
 				zlog_debug("%s: unlabeled route for %s",

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -384,7 +384,7 @@ static void zebra_rnh_clear_nexthop_rnh_filters(struct route_entry *re)
 	struct nexthop *nexthop;
 
 	if (re) {
-		for (nexthop = re->ng->nexthop; nexthop;
+		for (nexthop = re->nhe->nhg->nexthop; nexthop;
 		     nexthop = nexthop->next) {
 			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_RNH_FILTERED);
 		}
@@ -403,7 +403,7 @@ static int zebra_rnh_apply_nht_rmap(afi_t afi, struct zebra_vrf *zvrf,
 	route_map_result_t ret;
 
 	if (prn && re) {
-		for (nexthop = re->ng->nexthop; nexthop;
+		for (nexthop = re->nhe->nhg->nexthop; nexthop;
 		     nexthop = nexthop->next) {
 			ret = zebra_nht_route_map_check(
 				afi, proto, &prn->p, zvrf, re, nexthop);
@@ -688,7 +688,7 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 			/* Just being SELECTED isn't quite enough - must
 			 * have an installed nexthop to be useful.
 			 */
-			for (ALL_NEXTHOPS_PTR(re->ng, nexthop)) {
+			for (ALL_NEXTHOPS_PTR(re->nhe->nhg, nexthop)) {
 				if (rnh_nexthop_valid(re, nexthop))
 					break;
 			}
@@ -707,7 +707,8 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 					break;
 				if (re->type == ZEBRA_ROUTE_NHRP) {
 
-					for (nexthop = re->ng->nexthop; nexthop;
+					for (nexthop = re->nhe->nhg->nexthop;
+					     nexthop;
 					     nexthop = nexthop->next)
 						if (nexthop->type
 						    == NEXTHOP_TYPE_IFINDEX)
@@ -940,7 +941,7 @@ static void free_state(vrf_id_t vrf_id, struct route_entry *re,
 		return;
 
 	/* free RE and nexthops */
-	nexthop_group_delete(&re->ng);
+	zebra_nhg_free(re->nhe);
 	XFREE(MTYPE_RE, re);
 }
 
@@ -963,9 +964,11 @@ static void copy_state(struct rnh *rnh, struct route_entry *re,
 	state->metric = re->metric;
 	state->vrf_id = re->vrf_id;
 	state->status = re->status;
-	state->ng = nexthop_group_new();
 
-	route_entry_copy_nexthops(state, re->ng->nexthop);
+	state->nhe = zebra_nhg_alloc();
+	state->nhe->nhg = nexthop_group_new();
+
+	nexthop_group_copy(state->nhe->nhg, re->nhe->nhg);
 	rnh->state = state;
 }
 
@@ -983,11 +986,12 @@ static int compare_state(struct route_entry *r1, struct route_entry *r2)
 	if (r1->metric != r2->metric)
 		return 1;
 
-	if (nexthop_group_nexthop_num(r1->ng)
-	    != nexthop_group_nexthop_num(r2->ng))
+	if (nexthop_group_nexthop_num(r1->nhe->nhg)
+	    != nexthop_group_nexthop_num(r2->nhe->nhg))
 		return 1;
 
-	if (nexthop_group_hash(r1->ng) != nexthop_group_hash(r2->ng))
+	if (nexthop_group_hash(r1->nhe->nhg) !=
+	    nexthop_group_hash(r2->nhe->nhg))
 		return 1;
 
 	return 0;
@@ -1037,7 +1041,7 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 		num = 0;
 		nump = stream_get_endp(s);
 		stream_putc(s, 0);
-		for (ALL_NEXTHOPS_PTR(re->ng, nh))
+		for (ALL_NEXTHOPS_PTR(re->nhe->nhg, nh))
 			if (rnh_nexthop_valid(re, nh)) {
 				stream_putl(s, nh->vrf_id);
 				stream_putc(s, nh->type);
@@ -1137,7 +1141,7 @@ static void print_rnh(struct route_node *rn, struct vty *vty)
 	if (rnh->state) {
 		vty_out(vty, " resolved via %s\n",
 			zebra_route_string(rnh->state->type));
-		for (nexthop = rnh->state->ng->nexthop; nexthop;
+		for (nexthop = rnh->state->nhe->nhg->nexthop; nexthop;
 		     nexthop = nexthop->next)
 			print_nh(nexthop, vty);
 	} else

--- a/zebra/zebra_router.c
+++ b/zebra/zebra_router.c
@@ -29,7 +29,7 @@
 #include "zebra_pbr.h"
 #include "zebra_vxlan.h"
 #include "zebra_mlag.h"
-#include "zebra_nhg_private.h"
+#include "zebra_nhg.h"
 #include "debug.h"
 
 DEFINE_MTYPE_STATIC(ZEBRA, RIB_TABLE_INFO, "RIB table info")
@@ -223,7 +223,7 @@ void zebra_router_terminate(void)
 	zebra_vxlan_disable();
 	zebra_mlag_terminate();
 
-	hash_clean(zrouter.nhgs, zebra_nhg_free);
+	hash_clean(zrouter.nhgs, zebra_nhg_hash_free);
 	hash_free(zrouter.nhgs);
 	hash_clean(zrouter.nhgs_id, NULL);
 	hash_free(zrouter.nhgs_id);

--- a/zebra/zebra_snmp.c
+++ b/zebra/zebra_snmp.c
@@ -285,8 +285,8 @@ static void check_replace(struct route_node *np2, struct route_entry *re2,
 		return;
 	}
 
-	if (in_addr_cmp((uint8_t *)&(*re)->ng->nexthop->gate.ipv4,
-			(uint8_t *)&re2->ng->nexthop->gate.ipv4)
+	if (in_addr_cmp((uint8_t *)&(*re)->nhe->nhg->nexthop->gate.ipv4,
+			(uint8_t *)&re2->nhe->nhg->nexthop->gate.ipv4)
 	    <= 0)
 		return;
 
@@ -371,9 +371,9 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 			if (!in_addr_cmp(&(*np)->p.u.prefix,
 					 (uint8_t *)&dest)) {
 				RNODE_FOREACH_RE (*np, *re) {
-					if (!in_addr_cmp((uint8_t *)&(*re)
-								 ->ng->nexthop
-								 ->gate.ipv4,
+					if (!in_addr_cmp((uint8_t *)&(*re)->nhe
+							 ->nhg->nexthop
+							 ->gate.ipv4,
 							 (uint8_t *)&nexthop))
 						if (proto
 						    == proto_trans((*re)->type))
@@ -406,8 +406,8 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 				    || ((policy == policy2) && (proto < proto2))
 				    || ((policy == policy2) && (proto == proto2)
 					&& (in_addr_cmp(
-						    (uint8_t *)&re2->ng->nexthop
-							    ->gate.ipv4,
+						    (uint8_t *)&re2->nhe
+						    ->nhg->nexthop->gate.ipv4,
 						    (uint8_t *)&nexthop)
 					    >= 0)))
 					check_replace(np2, re2, np, re);
@@ -432,7 +432,7 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 	{
 		struct nexthop *nexthop;
 
-		nexthop = (*re)->ng->nexthop;
+		nexthop = (*re)->nhe->nhg->nexthop;
 		if (nexthop) {
 			pnt = (uint8_t *)&nexthop->gate.ipv4;
 			for (i = 0; i < 4; i++)
@@ -462,7 +462,7 @@ static uint8_t *ipFwTable(struct variable *v, oid objid[], size_t *objid_len,
 	if (!np)
 		return NULL;
 
-	nexthop = re->ng->nexthop;
+	nexthop = re->nhe->nhg->nexthop;
 	if (!nexthop)
 		return NULL;
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -263,7 +263,7 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 		if (show_ng)
 			vty_out(vty, "  Nexthop Group ID: %u\n", re->nhe_id);
 
-		for (ALL_NEXTHOPS_PTR(re->ng, nexthop)) {
+		for (ALL_NEXTHOPS_PTR(re->nhe->nhg, nexthop)) {
 			char addrstr[32];
 
 			vty_out(vty, "  %c%s",
@@ -413,7 +413,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 	if (is_fib)
 		nhg = rib_active_nhg(re);
 	else
-		nhg = re->ng;
+		nhg = re->nhe->nhg;
 
 	if (json) {
 		json_route = json_object_new_object();
@@ -466,9 +466,10 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		json_object_int_add(json_route, "internalFlags",
 				    re->flags);
 		json_object_int_add(json_route, "internalNextHopNum",
-				    nexthop_group_nexthop_num(re->ng));
+				    nexthop_group_nexthop_num(re->nhe->nhg));
 		json_object_int_add(json_route, "internalNextHopActiveNum",
-				    nexthop_group_active_nexthop_num(re->ng));
+				    nexthop_group_active_nexthop_num(
+					    re->nhe->nhg));
 		if (uptime < ONE_DAY_SECOND)
 			sprintf(buf, "%02d:%02d:%02d", tm->tm_hour, tm->tm_min,
 				tm->tm_sec);
@@ -1833,7 +1834,7 @@ static void vty_show_ip_route_summary_prefix(struct vty *vty,
 				fib_cnt[ZEBRA_ROUTE_TOTAL]++;
 				fib_cnt[re->type]++;
 			}
-			for (nexthop = re->ng->nexthop; (!cnt && nexthop);
+			for (nexthop = re->nhe->nhg->nexthop; (!cnt && nexthop);
 			     nexthop = nexthop->next) {
 				cnt++;
 				rib_cnt[ZEBRA_ROUTE_TOTAL]++;


### PR DESCRIPTION
Replace the route_entry struct's embedded nexthop_group pointer, which is just a list of nexthops, with a pointer to the actual shared nhg_hash_entry struct that zebra is now using. This allows more direct access to the info in that larger struct.