### PR TITLE
bgpd: fix heap double free in attr parsing

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -421,14 +421,15 @@ static struct transit *transit_intern(struct transit *transit)
 	return find;
 }
 
-void transit_unintern(struct transit *transit)
+static void transit_unintern(struct transit **transit)
 {
-	if (transit->refcnt)
-		transit->refcnt--;
+	if ((*transit)->refcnt)
+		(*transit)->refcnt--;
 
-	if (transit->refcnt == 0) {
-		hash_release(transit_hash, transit);
-		transit_free(transit);
+	if ((*transit)->refcnt == 0) {
+		hash_release(transit_hash, *transit);
+		transit_free(*transit);
+		*transit = NULL;
 	}
 }
 
@@ -860,7 +861,7 @@ void bgp_attr_unintern_sub(struct attr *attr)
 	UNSET_FLAG(attr->flag, ATTR_FLAG_BIT(BGP_ATTR_CLUSTER_LIST));
 
 	if (attr->transit)
-		transit_unintern(attr->transit);
+		transit_unintern(&attr->transit);
 
 	if (attr->encap_subtlvs)
 		encap_unintern(&attr->encap_subtlvs, ENCAP_SUBTLV_TYPE);

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -305,9 +305,6 @@ extern unsigned long int attr_unknown_count(void);
 extern int cluster_loop_check(struct cluster_list *, struct in_addr);
 extern void cluster_unintern(struct cluster_list *);
 
-/* Transit attribute prototypes. */
-void transit_unintern(struct transit *);
-
 /* Below exported for unit-test purposes only */
 struct bgp_attr_parser_args {
 	struct peer *peer;

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -480,7 +480,7 @@ static void bgp_connected_cleanup(struct route_table *table,
 }
 
 int bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type, uint8_t sub_type,
-		struct attr *attr, struct bgp_node *rn)
+		     const struct attr *attr, struct bgp_node *rn)
 {
 	struct prefix p = {0};
 	afi_t new_afi = afi;

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -89,8 +89,8 @@ extern int bgp_multiaccess_check_v4(struct in_addr nexthop, struct peer *peer);
 extern int bgp_multiaccess_check_v6(struct in6_addr nexthop, struct peer *peer);
 extern int bgp_config_write_scan_time(struct vty *);
 extern int bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
-				uint8_t sub_type, struct attr *attr,
-				struct bgp_node *rn);
+			    uint8_t sub_type, const struct attr *attr,
+			    struct bgp_node *rn);
 extern struct bgp_nexthop_cache *bnc_new(void);
 extern void bnc_free(struct bgp_nexthop_cache *bnc);
 extern void bnc_nexthop_free(struct bgp_nexthop_cache *bnc);


### PR DESCRIPTION
We are shallow copying a `struct attr`, and then freeing the shallow
copy with a deep free, freeing the original attribute values.

I barely know if this is correct. Git history shows that this code has
been touched dozens of times to try to fix problems similar to this.
This patch may cause memory leaks, probably when routemaps with `set`
statements are in play.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>