### PR TITLE
bgpd: Do not perform "connected" check for EVPN nexthop

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3454,7 +3454,8 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 		    && (safi == SAFI_UNICAST || safi == SAFI_LABELED_UNICAST))
 		    || (safi == SAFI_EVPN &&
 			bgp_evpn_is_prefix_nht_supported(p))) {
-			if (peer->sort == BGP_PEER_EBGP && peer->ttl == 1
+			if (safi != SAFI_EVPN
+			    && peer->sort == BGP_PEER_EBGP && peer->ttl == 1
 			    && !CHECK_FLAG(peer->flags,
 					   PEER_FLAG_DISABLE_CONNECTED_CHECK)
 			    && !bgp_flag_check(
@@ -3596,7 +3597,8 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 	if (((afi == AFI_IP || afi == AFI_IP6)
 	    && (safi == SAFI_UNICAST || safi == SAFI_LABELED_UNICAST))
 	    || (safi == SAFI_EVPN && bgp_evpn_is_prefix_nht_supported(p))) {
-		if (peer->sort == BGP_PEER_EBGP && peer->ttl == 1
+		if (safi != SAFI_EVPN
+		    && peer->sort == BGP_PEER_EBGP && peer->ttl == 1
 		    && !CHECK_FLAG(peer->flags,
 				   PEER_FLAG_DISABLE_CONNECTED_CHECK)
 		    && !bgp_flag_check(bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))


### PR DESCRIPTION
This changeset follows the PR
https://github.com/FRRouting/frr/pull/5334

Above PR adds nexthop tracking support for EVPN RT-5 nexthops.
This route is marked VALID only if the BGP route has a valid nexthop.

If the EVPN peer is an EBGP pee and "disable_connected_check" flag is not set,
"connected" check is performed for the EVPN nexthop.
But, usually EVPN nexthop is not the BGP peering address, but the VTEP address.
Also, NEXTHOP_UNCHANGED flag is enabled by default for EVPN.
As a result, in a common deployment for EVPN, EVPN nexthop is not connected.

Thus, adding a fix to remove the "connected" check for EVPN nexthops.

Signed-off-by: Ameya Dharkar <adharkar@vmware.com>