### PR TITLE
zebra: cache zebra_nhg lookups coming from client routes

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1144,6 +1144,9 @@ void zebra_nhg_free(void *arg)
 
 void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe)
 {
+	if (!nhe)
+		return;
+
 	nhe->refcnt--;
 
 	if (!zebra_nhg_depends_is_empty(nhe))
@@ -1155,6 +1158,9 @@ void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe)
 
 void zebra_nhg_increment_ref(struct nhg_hash_entry *nhe)
 {
+	if (!nhe)
+		return;
+
 	nhe->refcnt++;
 
 	if (!zebra_nhg_depends_is_empty(nhe))

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -614,6 +614,9 @@ void zserv_close_client(struct zserv *client)
 	THREAD_OFF(client->t_cleanup);
 	THREAD_OFF(client->t_process);
 
+	/* Release cached nhg_hash_entry */
+	zebra_nhg_decrement_ref(zebra_nhg_lookup_id(client->inhg_cache.nhe_id));
+
 	/* destroy pthread */
 	frr_pthread_destroy(client->pthread);
 	client->pthread = NULL;


### PR DESCRIPTION
Add functionality to cache the last nhg_hash_entry found/created
for a route per zebra client.

This way, if we receive a bunch of routes all pointing to the
same nexthop group, we don't have to hash again. This will
save a bit of time being spent inside jhash esspecially
for high ecmp routes being shoved down into zebra quickly.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>
