### PR TITLE
docker: Make docker image on CentOS 7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 **/*.so
 **/.libs
 docker/alpine/pkgs
+docker/centos/pkgs

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -1,0 +1,43 @@
+# This stage builds an rpm from the source
+FROM centos:centos7 as centos-builder
+
+RUN yum install -y rpm-build autoconf automake libtool make \
+        readline-devel texinfo net-snmp-devel groff pkgconfig \
+        json-c-devel pam-devel bison flex pytest c-ares-devel \
+        python-devel systemd-devel python-sphinx libcap-devel \
+        https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-0.16.111-0.x86_64.rpm \
+        https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-devel-0.16.111-0.x86_64.rpm \
+        https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm \
+        https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-devel-0.7.0-1.el7.centos.x86_64.rpm
+
+COPY . /src
+ARG PKGVER
+
+RUN echo '%_smp_mflags %( echo "-j$(/usr/bin/getconf _NPROCESSORS_ONLN)"; )' >> /root/.rpmmacros \
+    && cd /src \
+    && ./bootstrap.sh \
+    && ./configure \
+        --enable-rpki \
+        --enable-numeric-version \
+        --with-pkg-extra-version="_git$PKGVER" \
+    && make dist \
+    && cd / \
+    && mkdir -p /rpmbuild/{SOURCES,SPECS} \
+    && cp /src/frr*.tar.gz /rpmbuild/SOURCES \
+    && cp /src/redhat/frr.spec /rpmbuild/SPECS \
+    && rpmbuild \
+        --define "_topdir /rpmbuild" \
+        -ba /rpmbuild/SPECS/frr.spec
+
+# This stage installs frr from the rpm
+FROM centos:centos7
+RUN mkdir -p /pkgs/rpm \
+    && yum install -y https://ci1.netdef.org/artifact/LIBYANG-YANGRELEASE/shared/build-10/CentOS-7-x86_64-Packages/libyang-0.16.111-0.x86_64.rpm \
+        https://ci1.netdef.org/artifact/RPKI-RTRLIB/shared/build-110/CentOS-7-x86_64-Packages/librtr-0.7.0-1.el7.centos.x86_64.rpm
+
+COPY --from=centos-builder /rpmbuild/RPMS/ /pkgs/rpm/
+
+RUN yum install -y /pkgs/rpm/*/*.rpm \
+    && rm -rf /pkgs
+COPY docker/centos/docker-start /usr/lib/frr/docker-start
+ENTRYPOINT [ "/usr/lib/frr/docker-start" ]

--- a/docker/centos/build.sh
+++ b/docker/centos/build.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+##
+# Package version needs to be decimal
+##
+GITREV="$(git rev-parse --short=10 HEAD)"
+PKGVER="$(printf '%u\n' 0x$GITREV)"
+
+mkdir -p docker/centos/pkgs
+docker build \
+	--file=docker/centos/Dockerfile \
+	--build-arg="PKGVER=$PKGVER" \
+	--tag="frr:centos-builder-$GITREV" \
+	--target=centos-builder \
+	.
+
+# Copy RPM package from container to host
+CONTAINER_ID="$(docker create "frr:centos-builder-$GITREV")"
+docker cp "${CONTAINER_ID}:/rpmbuild/RPMS/x86_64/" docker/centos/pkgs
+docker rm "${CONTAINER_ID}"
+
+docker build \
+	--cache-from="frr:centos-builder-$GITREV" \
+	--file=docker/centos/Dockerfile \
+	--build-arg="PKGVER=$PKGVER" \
+	--tag="frr:centos-$GITREV" \
+	.
+
+docker rmi "frr:centos-builder-$GITREV"

--- a/docker/centos/docker-start
+++ b/docker/centos/docker-start
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+##
+# Change owner for docker volume mount
+##
+chown -R frr:frr /etc/frr
+/usr/lib/frr/frrinit.sh start
+
+# Sleep forever
+exec tail -f /dev/null


### PR DESCRIPTION
- Build rpm package from source on CentOS 7
- Use multi-stage builds to reduce docker image size

Signed-off-by: Toshiki Tsuchiya <taruta0811@gmail.com>