### PR TITLE
bgpd: Autocomplete neighbor for clear bgp

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -7328,7 +7328,7 @@ static int bgp_clear_prefix(struct vty *vty, const char *view_name,
 /* one clear bgp command to rule them all */
 DEFUN (clear_ip_bgp_all,
        clear_ip_bgp_all_cmd,
-       "clear [ip] bgp [<view|vrf> VIEWVRFNAME] [<ipv4|ipv6|l2vpn> [<unicast|multicast|vpn|labeled-unicast|flowspec|evpn>]] <*|A.B.C.D|X:X::X:X|WORD|(1-4294967295)|external|peer-group PGNAME> [<soft [<in|out>]|in [prefix-filter]|out>]",
+       "clear [ip] bgp [<view|vrf> VIEWVRFNAME] [<ipv4|ipv6|l2vpn> [<unicast|multicast|vpn|labeled-unicast|flowspec|evpn>]] <*|A.B.C.D$neighbor|X:X::X:X$neighbor|WORD$neighbor|(1-4294967295)|external|peer-group PGNAME> [<soft [<in|out>]|in [prefix-filter]|out>]",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -7338,7 +7338,7 @@ DEFUN (clear_ip_bgp_all,
        BGP_SAFI_WITH_LABEL_HELP_STR
        "Address Family modifier\n"
        "Clear all peers\n"
-       "BGP neighbor address to clear\n"
+       "BGP IPv4 neighbor to clear\n"
        "BGP IPv6 neighbor to clear\n"
        "BGP neighbor on interface to clear\n"
        "Clear peers with the AS number\n"


### PR DESCRIPTION
```
spine1-debian-9# clear ip bgp 
  (1-4294967295)  Clear peers with the AS number
  *               Clear all peers
  A.B.C.D         BGP IPv4 neighbor to clear
     10.0.0.200 192.168.1.1 
  WORD            BGP neighbor on interface to clear
  X:X::X:X        BGP IPv6 neighbor to clear
  dampening       Clear route flap dampening information
  external        Clear all external peers
  ipv4            Address Family
  ipv6            Address Family
  l2vpn           Address Family
  peer-group      Clear all members of peer-group
  prefix          Clear bestpath and re-advertise
  view            BGP view
  vrf             BGP VRF
spine1-debian-9# clear ip bgp peer-group 
  <cr>    
  PGNAME  BGP peer-group name
     A1 
  in      Send route-refresh unless using 'soft-reconfiguration inbound'
  out     Resend all outbound updates
  soft    Soft reconfig inbound and outbound updates
spine1-debian-9# clear ip bgp peer-group 
```

Closes https://github.com/FRRouting/frr/issues/5433

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>