### PR TITLE
lib: add gcc 4.x workaround for frr_interface_info

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1677,3 +1677,13 @@ const struct frr_yang_module_info frr_interface_info = {
 		},
 	}
 };
+
+#if defined(__GNUC__) && ((__GNUC__ - 0) < 5) && !defined(__clang__)
+/* gcc versions before 5.x miscalculate the size for structs with variable
+ * length arrays (they just count it as size 0)
+ *
+ * NB: the "." below means "current position", i.e. this line must be
+ * immediately after the frr_interface_info variable!
+ */
+__asm__(".size\tfrr_interface_info, .-frr_interface_info\n");
+#endif


### PR DESCRIPTION
gcc 4.x does not properly support structs with variable length array
members.  Specifically, for global variables, it completely ignores the
array, coming up with a size much smaller than what is correct.  This is
broken for both sizeof() as well as ELF object size.

This breaks for frr_interface_info since this variable is in some cases
copy relocated by the linker.  (The linker does this to make the address
of the variable a "constant" for the main program.)  This copying uses
the ELF object size, thereby copying only the non-array part of the
struct.

Breakage ensues...

(This fix is a bit ugly, but it's limited to very old gcc, and it's
better than changing the array to "nodes[1000]" and wasting memory...)

Fixes: #4563
Fixes: #5074
Signed-off-by: David Lamparter <equinox@diac24.net>