### PR TITLE
bgpd: Replace magic number 1 for TTL to BGP_DEFAULT_TTL

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -101,7 +101,7 @@ static int bgp_peer_reg_with_nht(struct peer *peer)
 {
 	int connected = 0;
 
-	if (peer->sort == BGP_PEER_EBGP && peer->ttl == 1
+	if (peer->sort == BGP_PEER_EBGP && peer->ttl == BGP_DEFAULT_TTL
 	    && !CHECK_FLAG(peer->flags, PEER_FLAG_DISABLE_CONNECTED_CHECK)
 	    && !bgp_flag_check(peer->bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
 		connected = 1;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3454,8 +3454,8 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 		    && (safi == SAFI_UNICAST || safi == SAFI_LABELED_UNICAST))
 		    || (safi == SAFI_EVPN &&
 			bgp_evpn_is_prefix_nht_supported(p))) {
-			if (safi != SAFI_EVPN
-			    && peer->sort == BGP_PEER_EBGP && peer->ttl == 1
+			if (safi != SAFI_EVPN && peer->sort == BGP_PEER_EBGP
+			    && peer->ttl == BGP_DEFAULT_TTL
 			    && !CHECK_FLAG(peer->flags,
 					   PEER_FLAG_DISABLE_CONNECTED_CHECK)
 			    && !bgp_flag_check(
@@ -3597,8 +3597,8 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 	if (((afi == AFI_IP || afi == AFI_IP6)
 	    && (safi == SAFI_UNICAST || safi == SAFI_LABELED_UNICAST))
 	    || (safi == SAFI_EVPN && bgp_evpn_is_prefix_nht_supported(p))) {
-		if (safi != SAFI_EVPN
-		    && peer->sort == BGP_PEER_EBGP && peer->ttl == 1
+		if (safi != SAFI_EVPN && peer->sort == BGP_PEER_EBGP
+		    && peer->ttl == BGP_DEFAULT_TTL
 		    && !CHECK_FLAG(peer->flags,
 				   PEER_FLAG_DISABLE_CONNECTED_CHECK)
 		    && !bgp_flag_check(bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10896,7 +10896,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 				json_object_int_add(json_neigh,
 						    "externalBgpNbrMaxHopsAway",
 						    p->gtsm_hops);
-			else if (p->ttl > 1)
+			else if (p->ttl > BGP_DEFAULT_TTL)
 				json_object_int_add(json_neigh,
 						    "externalBgpNbrMaxHopsAway",
 						    p->ttl);
@@ -10905,7 +10905,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 				vty_out(vty,
 					"  External BGP neighbor may be up to %d hops away.\n",
 					p->gtsm_hops);
-			else if (p->ttl > 1)
+			else if (p->ttl > BGP_DEFAULT_TTL)
 				vty_out(vty,
 					"  External BGP neighbor may be up to %d hops away.\n",
 					p->ttl);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -278,12 +278,14 @@ static int bgp_ifp_down(struct interface *ifp)
 			 * 1-hop BFD
 			 * tracked (directly connected) IBGP peers.
 			 */
-			if ((peer->ttl != 1) && (peer->gtsm_hops != 1)
+			if ((peer->ttl != BGP_DEFAULT_TTL)
+			    && (peer->gtsm_hops != 1)
 			    && (!peer->bfd_info
 				|| bgp_bfd_is_peer_multihop(peer)))
 #else
 			/* Take down directly connected EBGP peers */
-			if ((peer->ttl != 1) && (peer->gtsm_hops != 1))
+			if ((peer->ttl != BGP_DEFAULT_TTL)
+			    && (peer->gtsm_hops != 1))
 #endif
 				continue;
 
@@ -448,7 +450,8 @@ static int bgp_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 		/* Fast external-failover */
 		if (!CHECK_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER)) {
 			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
-				if ((peer->ttl != 1) && (peer->gtsm_hops != 1))
+				if ((peer->ttl != BGP_DEFAULT_TTL)
+				    && (peer->gtsm_hops != 1))
 					continue;
 
 				if (ifp == peer->nexthop.ifp)
@@ -1222,7 +1225,7 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 		SET_FLAG(api.flags, ZEBRA_FLAG_ALLOW_RECURSION);
 	}
 
-	if ((peer->sort == BGP_PEER_EBGP && peer->ttl != 1)
+	if ((peer->sort == BGP_PEER_EBGP && peer->ttl != BGP_DEFAULT_TTL)
 	    || CHECK_FLAG(peer->flags, PEER_FLAG_DISABLE_CONNECTED_CHECK)
 	    || bgp_flag_check(bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -6557,16 +6557,17 @@ int is_ebgp_multihop_configured(struct peer *peer)
 	if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
 		group = peer->group;
 		if ((peer_sort(peer) != BGP_PEER_IBGP)
-		    && (group->conf->ttl != 1))
+		    && (group->conf->ttl != BGP_DEFAULT_TTL))
 			return 1;
 
 		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, peer1)) {
 			if ((peer_sort(peer1) != BGP_PEER_IBGP)
-			    && (peer1->ttl != 1))
+			    && (peer1->ttl != BGP_DEFAULT_TTL))
 				return 1;
 		}
 	} else {
-		if ((peer_sort(peer) != BGP_PEER_IBGP) && (peer->ttl != 1))
+		if ((peer_sort(peer) != BGP_PEER_IBGP)
+		    && (peer->ttl != BGP_DEFAULT_TTL))
 			return 1;
 	}
 	return 0;
@@ -7109,7 +7110,7 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 		vty_out(vty, " neighbor %s passive\n", addr);
 
 	/* ebgp-multihop */
-	if (peer->sort != BGP_PEER_IBGP && peer->ttl != 1
+	if (peer->sort != BGP_PEER_IBGP && peer->ttl != BGP_DEFAULT_TTL
 	    && !(peer->gtsm_hops != 0 && peer->ttl == MAXTTL)) {
 		if (!peer_group_active(peer) || g_peer->ttl != peer->ttl) {
 			vty_out(vty, " neighbor %s ebgp-multihop %d\n", addr,


### PR DESCRIPTION
For readability and maintainability purposes.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>