### PR TITLE
lib: support labelled nexthops in nexthop_groups

### DIFF
--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -39,7 +39,7 @@ listing of ECMP nexthops used to forward packets for when a pbr-map is matched.
    sub-mode where you can specify individual nexthops.  To exit this mode type
    exit or end as per normal conventions for leaving a sub-mode.
 
-.. clicmd:: nexthop [A.B.C.D|X:X::X:XX] [interface] [nexthop-vrf NAME]
+.. clicmd:: nexthop [A.B.C.D|X:X::X:XX] [interface] [nexthop-vrf NAME] [label LABELS]
 
    Create a v4 or v6 nexthop.  All normal rules for creating nexthops that you
    are used to are allowed here.  The syntax was intentionally kept the same as

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -70,12 +70,6 @@ void nexthop_group_mark_duplicates(struct nexthop_group *nhg);
 	(nhop) = nexthop_next(nhop)
 
 
-struct nexthop_hold {
-	char *nhvrf_name;
-	union sockunion *addr;
-	char *intf;
-};
-
 struct nexthop_group_cmd {
 
 	RB_ENTRY(nexthop_group_cmd) nhgc_entry;


### PR DESCRIPTION
Add support for labelled nexthops in nexthop-group vty configuration - seems like that'd be useful. Reorg'd a couple of things in the nexthop-group vty handling code to make that work, and reduce a little clutter.