### PR TITLE
lib: fix display of candidate configurations

### DIFF
--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -432,12 +432,12 @@ void nb_cli_show_config_prepare(struct nb_config *config, bool with_defaults)
 	lyd_schema_sort(config->dnode, 1);
 
 	/*
-	 * When "with-defaults" is used, call lyd_validate() only to create
-	 * default child nodes, ignoring any possible validation error. This
-	 * doesn't need to be done when displaying the running configuration
-	 * since it's always fully validated.
+	 * Call lyd_validate() only to create default child nodes, ignoring
+	 * any possible validation error. This doesn't need to be done when
+	 * displaying the running configuration since it's always fully
+	 * validated.
 	 */
-	if (with_defaults && config != running_config)
+	if (config != running_config)
 		(void)lyd_validate(&config->dnode,
 				   LYD_OPT_CONFIG | LYD_OPT_WHENAUTODEL,
 				   ly_native_ctx);


### PR DESCRIPTION
Commit 5e6a9350c16 implemented an optimization where candidate
configurations are validated only before being displayed. The
validation is done only to create default child nodes (due to
how libyang works) and any possible error is ignored (candidate
configurations can be invalid/incomplete).

The problem is that we were calling lyd_validate() only when the
CLI "with-defaults" option was used. But some cli_show() callbacks
assume that default nodes exist and can crash when displaying a
candidate configuration that isn't validated. To fix this, call
lyd_validate() before displaying candidate configuration even when
"with-defaults" is not used (that was a micro-optimization that
shouldn't have been done).

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>