### PR TITLE
lib: fix heap buf overflow when adding prefix orf

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -1891,6 +1891,8 @@ int prefix_bgp_orf_set(char *name, afi_t afi, struct orf_prefix *orfp,
 	if (!plist)
 		return CMD_WARNING_CONFIG_FAILED;
 
+	apply_mask(&orfp->p);
+
 	if (set) {
 		pentry = prefix_list_entry_make(
 			&orfp->p, (permit ? PREFIX_PERMIT : PREFIX_DENY),


### PR DESCRIPTION
Don't lose your way

```
  ==25988== Invalid read of size 8    
  ==25988==    at 0x4EB8D44: trie_install_fn (plist.c:544)    
  ==25988==    by 0x4EB8D0E: trie_walk_affected (plist.c:452)    
  ==25988==    by 0x4EB8C1E: prefix_list_trie_add (plist.c:583)    
  ==25988==    by 0x4EB78DB: prefix_list_entry_add (plist.c:631)    
  ==25988==    by 0x4EB733D: prefix_bgp_orf_set (plist.c:1905)    
  ==25988==    by 0x46B8A8: bgp_route_refresh_receive (bgp_packet.c:1984)    
  ==25988==    by 0x469406: bgp_process_packet (bgp_packet.c:2327)    
  ==25988==    by 0x41B408: main (bgp_main.c:476)    
  ==25988==  Address 0x74b6e48 is 8 bytes after a block of size 4,096 alloc'd    
  ==25988==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)    
  ==25988==    by 0x4EA1888: qcalloc (memory.c:110)    
  ==25988==    by 0x4EB86D5: prefix_list_insert (plist.c:216)    
  ==25988==    by 0x4EB740E: prefix_list_get (plist.c:289)    
  ==25988==    by 0x4EB7295: prefix_bgp_orf_set (plist.c:1891)    
  ==25988==    by 0x46B8A8: bgp_route_refresh_receive (bgp_packet.c:1984)    
  ==25988==    by 0x469406: bgp_process_packet (bgp_packet.c:2327)    
  ==25988==    by 0x41B408: main (bgp_main.c:476)
```

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>