### PR TITLE
alpine: fix build on current 'edge' version of Alpine

### DIFF
--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -17,7 +17,7 @@ makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
     linux-headers lzip lzo m4 make mkinitfs mpc1 mpfr4 mtools musl-dev
     ncurses-libs ncurses-terminfo ncurses-terminfo-base patch pax-utils pcre
     perl pkgconf python2 python2-dev readline readline-dev sqlite-libs
-    squashfs-tools sudo tar texinfo xorriso xz-libs py-pip py-sphinx rtrlib
+    squashfs-tools sudo tar texinfo xorriso xz-libs py-pip rtrlib
     rtrlib-dev"
 checkdepends="pytest py-setuptools"
 install="$pkgname.pre-install $pkgname.pre-deinstall $pkgname.post-deinstall"
@@ -34,6 +34,12 @@ _user=frr
 
 build() {
 	cd "$builddir"
+
+	_localpythondir=$PWD/.python
+	pip2 install --prefix $_localpythondir sphinx
+	export PATH=${_localpythondir}/bin:$PATH
+	export PYTHONPATH=${_localpythondir}/lib/python2.7/site-packages
+
 	./configure \
 		--prefix=/usr \
 		--sbindir=$_sbindir \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -42,6 +42,7 @@ USER builder
 RUN cd /dist \
 	&& abuild-keygen -a -n \
 	&& abuild checksum \
+	&& git init \
 	&& abuild -r -P /pkgs/apk
 
 # This stage installs frr from the apk


### PR DESCRIPTION
The python2 packet py-sphinx was removed from the edge repository, so we
use pip to install it localy for the package build process.

Also abuild assumes it is executed in a git folder and fails if no .git
is found in the folder or its parent folders, so we work around this, by
initializing an empty git repo with `git init`.