### PR TITLE
zebra: capture dplane plugin flags

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2814,6 +2814,7 @@ int dplane_provider_register(const char *name,
 	TAILQ_INIT(&(p->dp_ctx_in_q));
 	TAILQ_INIT(&(p->dp_ctx_out_q));
 
+	p->dp_flags = flags;
 	p->dp_priority = prio;
 	p->dp_fp = fp;
 	p->dp_start = start_fp;


### PR DESCRIPTION
The flags can be important - like "threaded" - so we need to actually capture them when plugins are registered.
