### PR TITLE
Unequality ecmp

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -550,6 +550,7 @@ void nexthop_copy(struct nexthop *copy, const struct nexthop *nexthop,
 	copy->ifindex = nexthop->ifindex;
 	copy->type = nexthop->type;
 	copy->flags = nexthop->flags;
+	copy->weight = nexthop->weight;
 	memcpy(&copy->gate, &nexthop->gate, sizeof(nexthop->gate));
 	memcpy(&copy->src, &nexthop->src, sizeof(nexthop->src));
 	memcpy(&copy->rmap_src, &nexthop->rmap_src, sizeof(nexthop->rmap_src));

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -118,6 +118,12 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
 	if (next1->type > next2->type)
 		return 1;
 
+	if (next1->weight < next2->weight)
+		return -1;
+
+	if (next1->weight > next2->weight)
+		return 1;
+
 	switch (next1->type) {
 	case NEXTHOP_TYPE_IPV4:
 	case NEXTHOP_TYPE_IPV6:

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -110,6 +110,9 @@ struct nexthop {
 
 	/* Label(s) associated with this nexthop. */
 	struct mpls_label_stack *nh_label;
+
+	/* Weight of the nexthop ( for unequal cost ECMP ) */
+	uint8_t weight;
 };
 
 struct nexthop *nexthop_new(void);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -323,6 +323,8 @@ struct zapi_nexthop {
 	mpls_label_t labels[MPLS_MAX_LABELS];
 
 	struct ethaddr rmac;
+
+	uint32_t weight;
 };
 
 /*
@@ -330,6 +332,7 @@ struct zapi_nexthop {
  */
 #define ZAPI_NEXTHOP_FLAG_ONLINK	0x01
 #define ZAPI_NEXTHOP_FLAG_LABEL		0x02
+#define ZAPI_NEXTHOP_FLAG_WEIGHT	0x04
 
 /*
  * Some of these data structures do not map easily to

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -279,6 +279,7 @@ static void route_add_helper(struct zapi_route *api, struct nexthop_group nhg,
 		api_nh = &api->nexthops[i];
 		api_nh->vrf_id = nhop->vrf_id;
 		api_nh->type = nhop->type;
+		api_nh->weight = nhop->weight;
 		switch (nhop->type) {
 		case NEXTHOP_TYPE_IPV4:
 			api_nh->gate.ipv4 = nhop->gate.ipv4;

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -243,6 +243,8 @@ void route_add(struct prefix *p, vrf_id_t vrf_id,
 		api_nh = &api.nexthops[i];
 		api_nh->vrf_id = nh->vrf_id;
 		api_nh->type = nh->type;
+		api_nh->weight = nh->weight;
+
 		switch (nh->type) {
 		case NEXTHOP_TYPE_IPV4:
 			api_nh->gate = nh->gate;

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -567,6 +567,7 @@ int zsend_redistribute_route(int cmd, struct zserv *client,
 		api_nh = &api.nexthops[count];
 		api_nh->vrf_id = nexthop->vrf_id;
 		api_nh->type = nexthop->type;
+		api_nh->weight = nexthop->weight;
 		switch (nexthop->type) {
 		case NEXTHOP_TYPE_BLACKHOLE:
 			api_nh->bh_type = nexthop->bh_type;
@@ -1543,6 +1544,9 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 
 		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK))
 			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK);
+
+		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_WEIGHT))
+			nexthop->weight = api_nh->weight;
 
 		/* MPLS labels for BGP-LU or Segment Routing */
 		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL)

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1790,7 +1790,7 @@ uint8_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe,
 		if (!duplicate) {
 			grp[i].id = depend->id;
 			/* We aren't using weights for anything right now */
-			grp[i].weight = 0;
+			grp[i].weight = depend->nhg->nexthop->weight;
 			i++;
 		}
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -380,6 +380,9 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 						sizeof buf, 1));
 			}
 
+			if (nexthop->weight)
+				vty_out(vty, ", weight %u", nexthop->weight);
+
 			vty_out(vty, "\n");
 		}
 		vty_out(vty, "\n");
@@ -1239,6 +1242,9 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe)
 					       nexthop->nh_label->label, buf,
 					       sizeof(buf), 1));
 		}
+
+		if (nexthop->weight)
+			vty_out(vty, ", weight %u", nexthop->weight);
 
 		vty_out(vty, "\n");
 	}


### PR DESCRIPTION
Add basic functionality to support unequal weighted ecmp routes to FRR

robot# show ip route 10.0.0.1
Routing entry for 10.0.0.1/32
  Known via "sharp", distance 150, metric 0, best
  Last update 00:00:05 ago
  * 192.168.201.44, via enp3s0, weight 33
  * 192.168.201.45, via enp3s0, weight 66
  * 192.168.201.46, via enp3s0, weight 99

robot# show nexthop-group 567
ID: 567
     RefCnt: 2
     VRF: default
     Valid, Installed
     Depends: (552) (559) (568)
           192.168.201.44, enp3s0 (vrf default), weight 33
           192.168.201.45, enp3s0 (vrf default), weight 66
           192.168.201.46, enp3s0 (vrf default), weight 99
robot# exit
sharpd@robot ~/frr4> ip route show 10.0.0.1
10.0.0.1 nhid 567 proto 194 metric 20 
	nexthop via 192.168.201.44 dev enp3s0 weight 33 
	nexthop via 192.168.201.45 dev enp3s0 weight 66 
	nexthop via 192.168.201.46 dev enp3s0 weight 99 
sharpd@robot ~/frr4> ip nexthop show 567
Error: argument "567" is wrong: 
sharpd@robot ~/frr4> ip nexthop show id 567
id 567 group 552,33/559,66/568,99 proto zebra 
sharpd@robot ~/frr4> 

