### PR TITLE
lib,sharpd: support labelled nexthop-groups in sharpd

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -376,6 +376,9 @@ void nexthop_add_labels(struct nexthop *nexthop, enum lsp_types_t type,
 	struct mpls_label_stack *nh_label;
 	int i;
 
+	if (num_labels == 0)
+		return;
+
 	nexthop->nh_label_type = type;
 	nh_label = XCALLOC(MTYPE_NH_LABEL,
 			   sizeof(struct mpls_label_stack)

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -265,6 +265,17 @@ void route_add(struct prefix *p, vrf_id_t vrf_id,
 			api_nh->bh_type = nh->bh_type;
 			break;
 		}
+
+		if (nh->nh_label && nh->nh_label->num_labels > 0) {
+			int j;
+
+			SET_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL);
+
+			api_nh->label_num = nh->nh_label->num_labels;
+			for (j = 0; j < nh->nh_label->num_labels; j++)
+				api_nh->labels[j] = nh->nh_label->label[j];
+		}
+
 		i++;
 	}
 	api.nexthop_num = i;


### PR DESCRIPTION
Update sharpd's zapi client code to support labelled nexthops if they're present in a nexthop-group. With this change, it's possible to create nexthop-groups that include labelled nexthops and use them with sharpd.
