### PR TITLE
pbrd: make the show pbr map output better

### DIFF
--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -115,6 +115,12 @@ end destination.
 
    Not supported with NETNS VRF backend.
 
+.. clicmd:: show pbr map [NAME] [detail]
+
+   Display pbr maps either all or by ``NAME``. If ``detail`` is set, it will
+   give information about the rules unique ID used internally and some extra
+   debugging information about install state for the nexthop/nexthop group.
+
 .. _pbr-policy:
 
 PBR Policy

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -536,11 +536,11 @@ static void vty_show_pbrms(struct vty *vty,
 	vty_out(vty, "    Seq: %u rule: %u\n", pbrms->seqno, pbrms->ruleno);
 
 	if (detail)
-		vty_out(vty, "    Installed: %" PRIu64 "(%u) Reason: %s\n",
+		vty_out(vty, "\tInstalled: %" PRIu64 "(%u) Reason: %s\n",
 			pbrms->installed, pbrms->unique,
 			pbrms->reason ? rbuf : "Valid");
 	else
-		vty_out(vty, "    Installed: %s Reason: %s\n",
+		vty_out(vty, "\tInstalled: %s Reason: %s\n",
 			pbrms->installed ? "yes" : "no",
 			pbrms->reason ? rbuf : "Valid");
 
@@ -554,30 +554,29 @@ static void vty_show_pbrms(struct vty *vty,
 		vty_out(vty, "\tMARK Match: %u\n", pbrms->mark);
 
 	if (pbrms->nhgrp_name) {
+		vty_out(vty, "\tNexthop-Group: %s\n", pbrms->nhgrp_name);
+
 		if (detail)
-			vty_out(vty,
-				"\tNexthop-Group: %s(%u) Installed: %u(%d)\n",
-				pbrms->nhgrp_name,
-				pbr_nht_get_table(pbrms->nhgrp_name),
+			vty_out(vty, "\t\tInstalled: %u(%d) Tableid: %d\n",
 				pbrms->nhs_installed,
-				pbr_nht_get_installed(pbrms->nhgrp_name));
+				pbr_nht_get_installed(pbrms->nhgrp_name),
+				pbr_nht_get_table(pbrms->nhgrp_name));
 		else
-			vty_out(vty, "\tNexthop-Group: %s(%u) Installed: %s\n",
-				pbrms->nhgrp_name,
-				pbr_nht_get_table(pbrms->nhgrp_name),
-				pbr_nht_get_installed(pbrms->nhgrp_name)
-					? "yes"
-					: "no");
+			vty_out(vty, "\t\tInstalled: %s Tableid: %d\n",
+				pbr_nht_get_installed(pbrms->nhgrp_name) ? "yes"
+									 : "no",
+				pbr_nht_get_table(pbrms->nhgrp_name));
+
 	} else if (pbrms->nhg) {
-		vty_out(vty, "     ");
+		vty_out(vty, "\t");
 		nexthop_group_write_nexthop(vty, pbrms->nhg->nexthop);
 		if (detail)
-			vty_out(vty, "\tInstalled: %u(%d) Tableid: %d\n",
+			vty_out(vty, "\t\tInstalled: %u(%d) Tableid: %d\n",
 				pbrms->nhs_installed,
 				pbr_nht_get_installed(pbrms->internal_nhg_name),
 				pbr_nht_get_table(pbrms->internal_nhg_name));
 		else
-			vty_out(vty, "\tInstalled: %s Tableid: %d\n",
+			vty_out(vty, "\t\tInstalled: %s Tableid: %d\n",
 				pbr_nht_get_installed(pbrms->internal_nhg_name)
 					? "yes"
 					: "no",

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -599,7 +599,8 @@ static void vty_show_pbr_map(struct vty *vty, const struct pbr_map *pbrm,
 	struct pbr_map_sequence *pbrms;
 	struct listnode *node;
 
-	vty_out(vty, "  pbr-map %s valid: %d\n", pbrm->name, pbrm->valid);
+	vty_out(vty, "  pbr-map %s valid: %s\n", pbrm->name,
+		pbrm->valid ? "yes" : "no");
 
 	for (ALL_LIST_ELEMENTS_RO(pbrm->seqnumbers, node, pbrms))
 		vty_show_pbrms(vty, pbrms, detail);

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -532,10 +532,17 @@ static void vty_show_pbrms(struct vty *vty,
 
 	if (pbrms->reason)
 		pbr_map_reason_string(pbrms->reason, rbuf, sizeof(rbuf));
-	vty_out(vty,
-		"    Seq: %u rule: %u Installed: %" PRIu64 "(%u) Reason: %s\n",
-		pbrms->seqno, pbrms->ruleno, pbrms->installed, pbrms->unique,
-		pbrms->reason ? rbuf : "Valid");
+
+	vty_out(vty, "    Seq: %u rule: %u\n", pbrms->seqno, pbrms->ruleno);
+
+	if (detail)
+		vty_out(vty, "    Installed: %" PRIu64 "(%u) Reason: %s\n",
+			pbrms->installed, pbrms->unique,
+			pbrms->reason ? rbuf : "Valid");
+	else
+		vty_out(vty, "    Installed: %s Reason: %s\n",
+			pbrms->installed ? "yes" : "no",
+			pbrms->reason ? rbuf : "Valid");
 
 	if (pbrms->src)
 		vty_out(vty, "\tSRC Match: %s\n",
@@ -547,23 +554,41 @@ static void vty_show_pbrms(struct vty *vty,
 		vty_out(vty, "\tMARK Match: %u\n", pbrms->mark);
 
 	if (pbrms->nhgrp_name) {
-		vty_out(vty, "\tNexthop-Group: %s(%u) Installed: %u(%d)\n",
-			pbrms->nhgrp_name, pbr_nht_get_table(pbrms->nhgrp_name),
-			pbrms->nhs_installed,
-			pbr_nht_get_installed(pbrms->nhgrp_name));
+		if (detail)
+			vty_out(vty,
+				"\tNexthop-Group: %s(%u) Installed: %u(%d)\n",
+				pbrms->nhgrp_name,
+				pbr_nht_get_table(pbrms->nhgrp_name),
+				pbrms->nhs_installed,
+				pbr_nht_get_installed(pbrms->nhgrp_name));
+		else
+			vty_out(vty, "\tNexthop-Group: %s(%u) Installed: %s\n",
+				pbrms->nhgrp_name,
+				pbr_nht_get_table(pbrms->nhgrp_name),
+				pbr_nht_get_installed(pbrms->nhgrp_name)
+					? "yes"
+					: "no");
 	} else if (pbrms->nhg) {
 		vty_out(vty, "     ");
 		nexthop_group_write_nexthop(vty, pbrms->nhg->nexthop);
-		vty_out(vty, "\tInstalled: %u(%d) Tableid: %d\n",
-			pbrms->nhs_installed,
-			pbr_nht_get_installed(pbrms->internal_nhg_name),
-			pbr_nht_get_table(pbrms->internal_nhg_name));
+		if (detail)
+			vty_out(vty, "\tInstalled: %u(%d) Tableid: %d\n",
+				pbrms->nhs_installed,
+				pbr_nht_get_installed(pbrms->internal_nhg_name),
+				pbr_nht_get_table(pbrms->internal_nhg_name));
+		else
+			vty_out(vty, "\tInstalled: %s Tableid: %d\n",
+				pbr_nht_get_installed(pbrms->internal_nhg_name)
+					? "yes"
+					: "no",
+				pbr_nht_get_table(pbrms->internal_nhg_name));
+
 	} else if (pbrms->vrf_unchanged) {
 		vty_out(vty, "\tVRF Unchanged (use interface vrf)\n");
 	} else if (pbrms->vrf_lookup) {
 		vty_out(vty, "\tVRF Lookup: %s\n", pbrms->vrf_name);
 	} else {
-		vty_out(vty, "\tNexthop-Group: Unknown Installed: 0(0)\n");
+		vty_out(vty, "\tNexthop-Group: Unknown Installed: no\n");
 	}
 }
 

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -524,6 +524,61 @@ DEFPY (show_pbr,
 	return CMD_SUCCESS;
 }
 
+static void vty_show_pbrms(struct vty *vty,
+			   const struct pbr_map_sequence *pbrms, bool detail)
+{
+	char buf[PREFIX_STRLEN];
+	char rbuf[64];
+
+	if (pbrms->reason)
+		pbr_map_reason_string(pbrms->reason, rbuf, sizeof(rbuf));
+	vty_out(vty,
+		"    Seq: %u rule: %u Installed: %" PRIu64 "(%u) Reason: %s\n",
+		pbrms->seqno, pbrms->ruleno, pbrms->installed, pbrms->unique,
+		pbrms->reason ? rbuf : "Valid");
+
+	if (pbrms->src)
+		vty_out(vty, "\tSRC Match: %s\n",
+			prefix2str(pbrms->src, buf, sizeof(buf)));
+	if (pbrms->dst)
+		vty_out(vty, "\tDST Match: %s\n",
+			prefix2str(pbrms->dst, buf, sizeof(buf)));
+	if (pbrms->mark)
+		vty_out(vty, "\tMARK Match: %u\n", pbrms->mark);
+
+	if (pbrms->nhgrp_name) {
+		vty_out(vty, "\tNexthop-Group: %s(%u) Installed: %u(%d)\n",
+			pbrms->nhgrp_name, pbr_nht_get_table(pbrms->nhgrp_name),
+			pbrms->nhs_installed,
+			pbr_nht_get_installed(pbrms->nhgrp_name));
+	} else if (pbrms->nhg) {
+		vty_out(vty, "     ");
+		nexthop_group_write_nexthop(vty, pbrms->nhg->nexthop);
+		vty_out(vty, "\tInstalled: %u(%d) Tableid: %d\n",
+			pbrms->nhs_installed,
+			pbr_nht_get_installed(pbrms->internal_nhg_name),
+			pbr_nht_get_table(pbrms->internal_nhg_name));
+	} else if (pbrms->vrf_unchanged) {
+		vty_out(vty, "\tVRF Unchanged (use interface vrf)\n");
+	} else if (pbrms->vrf_lookup) {
+		vty_out(vty, "\tVRF Lookup: %s\n", pbrms->vrf_name);
+	} else {
+		vty_out(vty, "\tNexthop-Group: Unknown Installed: 0(0)\n");
+	}
+}
+
+static void vty_show_pbr_map(struct vty *vty, const struct pbr_map *pbrm,
+			     bool detail)
+{
+	struct pbr_map_sequence *pbrms;
+	struct listnode *node;
+
+	vty_out(vty, "  pbr-map %s valid: %d\n", pbrm->name, pbrm->valid);
+
+	for (ALL_LIST_ELEMENTS_RO(pbrm->seqnumbers, node, pbrms))
+		vty_show_pbrms(vty, pbrms, detail);
+}
+
 DEFPY (show_pbr_map,
 	show_pbr_map_cmd,
 	"show pbr map [NAME$name] [detail$detail]",
@@ -533,69 +588,13 @@ DEFPY (show_pbr_map,
 	"PBR Map Name\n"
 	"Detailed information\n")
 {
-	struct pbr_map_sequence *pbrms;
 	struct pbr_map *pbrm;
-	struct listnode *node;
-	char buf[PREFIX_STRLEN];
-	char rbuf[64];
 
 	RB_FOREACH (pbrm, pbr_map_entry_head, &pbr_maps) {
 		if (name && strcmp(name, pbrm->name) != 0)
 			continue;
 
-		vty_out(vty, "  pbr-map %s valid: %d\n", pbrm->name,
-			pbrm->valid);
-
-		for (ALL_LIST_ELEMENTS_RO(pbrm->seqnumbers, node, pbrms)) {
-			if (pbrms->reason)
-				pbr_map_reason_string(pbrms->reason, rbuf,
-						      sizeof(rbuf));
-			vty_out(vty,
-				"    Seq: %u rule: %u Installed: %" PRIu64 "(%u) Reason: %s\n",
-				pbrms->seqno, pbrms->ruleno, pbrms->installed,
-				pbrms->unique, pbrms->reason ? rbuf : "Valid");
-
-			if (pbrms->src)
-				vty_out(vty, "\tSRC Match: %s\n",
-					prefix2str(pbrms->src, buf,
-						   sizeof(buf)));
-			if (pbrms->dst)
-				vty_out(vty, "\tDST Match: %s\n",
-					prefix2str(pbrms->dst, buf,
-						   sizeof(buf)));
-			if (pbrms->mark)
-				vty_out(vty, "\tMARK Match: %u\n", pbrms->mark);
-
-			if (pbrms->nhgrp_name) {
-				vty_out(vty,
-					"\tNexthop-Group: %s(%u) Installed: %u(%d)\n",
-					pbrms->nhgrp_name,
-					pbr_nht_get_table(pbrms->nhgrp_name),
-					pbrms->nhs_installed,
-					pbr_nht_get_installed(
-						pbrms->nhgrp_name));
-			} else if (pbrms->nhg) {
-				vty_out(vty, "     ");
-				nexthop_group_write_nexthop(
-					vty, pbrms->nhg->nexthop);
-				vty_out(vty,
-					"\tInstalled: %u(%d) Tableid: %d\n",
-					pbrms->nhs_installed,
-					pbr_nht_get_installed(
-						pbrms->internal_nhg_name),
-					pbr_nht_get_table(
-						pbrms->internal_nhg_name));
-			} else if (pbrms->vrf_unchanged) {
-				vty_out(vty,
-					"\tVRF Unchanged (use interface vrf)\n");
-			} else if (pbrms->vrf_lookup) {
-				vty_out(vty, "\tVRF Lookup: %s\n",
-					pbrms->vrf_name);
-			} else {
-				vty_out(vty,
-					"\tNexthop-Group: Unknown Installed: 0(0)\n");
-			}
-		}
+		vty_show_pbr_map(vty, pbrm, detail);
 	}
 	return CMD_SUCCESS;
 }

--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -536,58 +536,60 @@ static void vty_show_pbrms(struct vty *vty,
 	vty_out(vty, "    Seq: %u rule: %u\n", pbrms->seqno, pbrms->ruleno);
 
 	if (detail)
-		vty_out(vty, "\tInstalled: %" PRIu64 "(%u) Reason: %s\n",
+		vty_out(vty, "        Installed: %" PRIu64 "(%u) Reason: %s\n",
 			pbrms->installed, pbrms->unique,
 			pbrms->reason ? rbuf : "Valid");
 	else
-		vty_out(vty, "\tInstalled: %s Reason: %s\n",
+		vty_out(vty, "        Installed: %s Reason: %s\n",
 			pbrms->installed ? "yes" : "no",
 			pbrms->reason ? rbuf : "Valid");
 
 	if (pbrms->src)
-		vty_out(vty, "\tSRC Match: %s\n",
+		vty_out(vty, "        SRC Match: %s\n",
 			prefix2str(pbrms->src, buf, sizeof(buf)));
 	if (pbrms->dst)
-		vty_out(vty, "\tDST Match: %s\n",
+		vty_out(vty, "        DST Match: %s\n",
 			prefix2str(pbrms->dst, buf, sizeof(buf)));
 	if (pbrms->mark)
-		vty_out(vty, "\tMARK Match: %u\n", pbrms->mark);
+		vty_out(vty, "        MARK Match: %u\n", pbrms->mark);
 
 	if (pbrms->nhgrp_name) {
-		vty_out(vty, "\tNexthop-Group: %s\n", pbrms->nhgrp_name);
+		vty_out(vty, "        Nexthop-Group: %s\n", pbrms->nhgrp_name);
 
 		if (detail)
-			vty_out(vty, "\t\tInstalled: %u(%d) Tableid: %d\n",
+			vty_out(vty,
+				"          Installed: %u(%d) Tableid: %d\n",
 				pbrms->nhs_installed,
 				pbr_nht_get_installed(pbrms->nhgrp_name),
 				pbr_nht_get_table(pbrms->nhgrp_name));
 		else
-			vty_out(vty, "\t\tInstalled: %s Tableid: %d\n",
+			vty_out(vty, "          Installed: %s Tableid: %d\n",
 				pbr_nht_get_installed(pbrms->nhgrp_name) ? "yes"
 									 : "no",
 				pbr_nht_get_table(pbrms->nhgrp_name));
 
 	} else if (pbrms->nhg) {
-		vty_out(vty, "\t");
+		vty_out(vty, "        ");
 		nexthop_group_write_nexthop(vty, pbrms->nhg->nexthop);
 		if (detail)
-			vty_out(vty, "\t\tInstalled: %u(%d) Tableid: %d\n",
+			vty_out(vty,
+				"          Installed: %u(%d) Tableid: %d\n",
 				pbrms->nhs_installed,
 				pbr_nht_get_installed(pbrms->internal_nhg_name),
 				pbr_nht_get_table(pbrms->internal_nhg_name));
 		else
-			vty_out(vty, "\t\tInstalled: %s Tableid: %d\n",
+			vty_out(vty, "          Installed: %s Tableid: %d\n",
 				pbr_nht_get_installed(pbrms->internal_nhg_name)
 					? "yes"
 					: "no",
 				pbr_nht_get_table(pbrms->internal_nhg_name));
 
 	} else if (pbrms->vrf_unchanged) {
-		vty_out(vty, "\tVRF Unchanged (use interface vrf)\n");
+		vty_out(vty, "        VRF Unchanged (use interface vrf)\n");
 	} else if (pbrms->vrf_lookup) {
-		vty_out(vty, "\tVRF Lookup: %s\n", pbrms->vrf_name);
+		vty_out(vty, "        VRF Lookup: %s\n", pbrms->vrf_name);
 	} else {
-		vty_out(vty, "\tNexthop-Group: Unknown Installed: no\n");
+		vty_out(vty, "        Nexthop-Group: Unknown Installed: no\n");
 	}
 }
 


### PR DESCRIPTION
This patch changes the `show pbr map` output a bit.

It make nexthop/nexthop group output more consistent.

It makes `detail` actually work. Without detail, we only show yes/no installation states. With `detail` we show a bit more debugging information (unique IDs, install states).

Old:
```
alfred# show pbr map 
  pbr-map TEST1 valid: 1
    Seq: 222 rule: 521 Installed: 1(1) Reason: Valid
        SRC Match: 2.2.2.2/32
        Nexthop-Group: blue(10000) Installed: 1(1)
    Seq: 333 rule: 632 Installed: 1(2) Reason: Valid
        SRC Match: 3.3.3.3/32
        Nexthop-Group: blue(10000) Installed: 1(1)
    Seq: 444 rule: 743 Installed: 1(3) Reason: Valid
        SRC Match: 4.4.4.4/32
        Nexthop-Group: blue(10000) Installed: 1(1)
    Seq: 555 rule: 854 Installed: 1(4) Reason: Valid
        SRC Match: 5.5.5.5/32
        Nexthop-Group: red(10001) Installed: 1(1)
    Seq: 666 rule: 965 Installed: 1(5) Reason: Valid
        SRC Match: 6.6.6.6/32
     nexthop 1.1.1.1
        Installed: 1(1) Tableid: 10002
  pbr-map TEST2 valid: 1
    Seq: 700 rule: 999 Installed: 1(6) Reason: Valid
        SRC Match: 7.7.7.7/32
        VRF Lookup: vrf-red
alfred# 
```
```
show pbr map detail looks exactly the same....
```



New:
```
alfred# show pbr map 
  pbr-map TEST1 valid: yes
    Seq: 222 rule: 521
        Installed: yes Reason: Valid
        SRC Match: 2.2.2.2/32
        Nexthop-Group: blue
          Installed: yes Tableid: 10000
    Seq: 333 rule: 632
        Installed: yes Reason: Valid
        SRC Match: 3.3.3.3/32
        Nexthop-Group: blue
          Installed: yes Tableid: 10000
    Seq: 444 rule: 743
        Installed: yes Reason: Valid
        SRC Match: 4.4.4.4/32
        Nexthop-Group: blue
          Installed: yes Tableid: 10000
    Seq: 555 rule: 854
        Installed: yes Reason: Valid
        SRC Match: 5.5.5.5/32
        Nexthop-Group: red
          Installed: yes Tableid: 10001
    Seq: 666 rule: 965
        Installed: yes Reason: Valid
        SRC Match: 6.6.6.6/32
        nexthop 1.1.1.1
          Installed: yes Tableid: 10002
  pbr-map TEST2 valid: yes
    Seq: 700 rule: 999
        Installed: yes Reason: Valid
        SRC Match: 7.7.7.7/32
        VRF Lookup: vrf-red
alfred# 
```
```
alfred# show pbr map detail 
  pbr-map TEST1 valid: yes
    Seq: 222 rule: 521
        Installed: 1(1) Reason: Valid
        SRC Match: 2.2.2.2/32
        Nexthop-Group: blue
          Installed: 1(1) Tableid: 10000
    Seq: 333 rule: 632
        Installed: 1(2) Reason: Valid
        SRC Match: 3.3.3.3/32
        Nexthop-Group: blue
          Installed: 1(1) Tableid: 10000
    Seq: 444 rule: 743
        Installed: 1(3) Reason: Valid
        SRC Match: 4.4.4.4/32
        Nexthop-Group: blue
          Installed: 1(1) Tableid: 10000
    Seq: 555 rule: 854
        Installed: 1(4) Reason: Valid
        SRC Match: 5.5.5.5/32
        Nexthop-Group: red
          Installed: 1(1) Tableid: 10001
    Seq: 666 rule: 965
        Installed: 1(5) Reason: Valid
        SRC Match: 6.6.6.6/32
        nexthop 1.1.1.1
          Installed: 1(1) Tableid: 10002
  pbr-map TEST2 valid: yes
    Seq: 700 rule: 999
        Installed: 1(6) Reason: Valid
        SRC Match: 7.7.7.7/32
        VRF Lookup: vrf-red
alfred# 
```
