### PR TITLE
yang: add vrf model

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -104,6 +104,7 @@ lib_libfrr_la_SOURCES = \
 nodist_lib_libfrr_la_SOURCES = \
 	yang/frr-interface.yang.c \
 	yang/frr-route-types.yang.c \
+	yang/frr-vrf.yang.c \
 	yang/ietf/ietf-routing-types.yang.c \
 	yang/frr-module-translator.yang.c \
 	# end

--- a/yang/frr-vrf.yang
+++ b/yang/frr-vrf.yang
@@ -1,0 +1,75 @@
+module frr-vrf {
+  yang-version 1.1;
+  namespace "http://frrouting.org/yang/vrf";
+  prefix frr-vrf;
+
+  organization
+    "Free Range Routing";
+  contact
+    "FRR Users List:       <mailto:frog@lists.frrouting.org>
+     FRR Development List: <mailto:dev@lists.frrouting.org>";
+  description
+    "This module defines a model for managing FRR VRF.";
+
+  revision 2019-12-06 {
+    description
+      "Initial revision.";
+  }
+
+  /*
+   * Network namespace feature
+   */
+  feature netns {
+    description "Abstracts network namespace as VRF.";
+  }
+
+  container lib {
+    list vrf {
+      key "name";
+      description
+        "VRF.";
+      leaf name {
+        type string {
+          length "1..36";
+        }
+        description
+          "VRF name.";
+      }
+
+      leaf id {
+        type uint32 {
+          range "0..4294967295";
+        }
+        config false;
+        description
+          "VRF Id.";
+      }
+
+      leaf active {
+        type boolean;
+        default "false";
+        config false;
+        description
+          "VRF active in kernel.";
+      }
+
+      container netns {
+        if-feature "netns";
+        leaf name {
+          type string;
+          description
+            "Namespace name.";
+        }
+      }
+    }
+  }
+
+  typedef vrf-ref {
+    type leafref {
+      require-instance false;
+      path "/frr-vrf:lib/frr-vrf:vrf/frr-vrf:name";
+    }
+    description
+      "Reference to a VRF";
+  }
+}

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -22,6 +22,7 @@ EXTRA_DIST += yang/embedmodel.py
 dist_yangmodels_DATA += yang/frr-module-translator.yang
 dist_yangmodels_DATA += yang/frr-test-module.yang
 dist_yangmodels_DATA += yang/frr-interface.yang
+dist_yangmodels_DATA += yang/frr-vrf.yang
 dist_yangmodels_DATA += yang/frr-route-types.yang
 dist_yangmodels_DATA += yang/ietf/ietf-routing-types.yang
 


### PR DESCRIPTION
```    module: frr-vrf
      +--rw lib
         +--rw vrf* [name]
            +--rw name         string
            +--ro id?          uint32
            +--ro active?      boolean <false>
            +--rw netns_vrf {netns}?
               +--rw ns_name?   string

```

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>