### PR TITLE
lib: set entry to xpath in if_update_to_new_vrf

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -218,7 +218,9 @@ void if_update_to_new_vrf(struct interface *ifp, vrf_id_t vrf_id)
 				"/frr-interface:lib/interface[name='%s'][vrf='%s']/vrf",
 				ifp->name, old_vrf->name);
 			if (if_dnode) {
+				nb_running_unset_entry(if_dnode->parent);
 				yang_dnode_change_leaf(if_dnode, vrf->name);
+				nb_running_set_entry(if_dnode->parent, ifp);
 				running_config->version++;
 			}
 		}


### PR DESCRIPTION
when vrf is changed, we change the interface running configuration
without using northbound layer. it causes the nb_running_get_entry to fail