### PR TITLE
isisd: clean ipv4/6 circuit config on destroy

### DIFF
--- a/isisd/isis_nb_config.c
+++ b/isisd/isis_nb_config.c
@@ -1550,9 +1550,13 @@ int lib_interface_isis_destroy(enum nb_event event,
 	circuit = nb_running_unset_entry(dnode);
 	if (!circuit)
 		return NB_ERR_INCONSISTENCY;
-	if (circuit->state == C_STATE_UP || circuit->state == C_STATE_CONF)
-		isis_csm_state_change(ISIS_DISABLE, circuit, circuit->area);
 
+	/* disable both AFs for this circuit. this will also update the
+	 * CSM state by sending an ISIS_DISABLED signal. If there is no
+	 * area associated to the circuit there is nothing to do
+	 */
+	if (circuit->area)
+		isis_circuit_af_set(circuit, false, false);
 	return NB_OK;
 }
 


### PR DESCRIPTION
when deleting an isis interface config with 'no [ip|ipv6] router isis'
we are destroying the isis yang container for that interface, but the
actual circuit struct is kept, and so are the flgs determining whether
that circuit is configured for ipv4 and/or ipv6. This caused issues
when removing and re-adding configuration, as the area counters for
ip circuits were not correctly updated and the topology was never
populated.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>