### PR TITLE
zebra: netlink FPM interface using zebra data plane

### DIFF
--- a/debian/frr.install
+++ b/debian/frr.install
@@ -9,6 +9,7 @@ usr/lib/frr/*d
 usr/lib/frr/watchfrr
 usr/lib/frr/zebra
 usr/lib/*/frr/modules/zebra_cumulus_mlag.so
+usr/lib/*/frr/modules/dplane_fpm_nl.so
 usr/lib/*/frr/modules/zebra_irdp.so
 usr/lib/*/frr/modules/zebra_fpm.so
 usr/lib/*/frr/modules/bgpd_bmp.so

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -25,6 +25,7 @@
 
 #include "prefix.h"
 #include "mpls.h"
+#include "vxlan.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +60,10 @@ enum blackhole_type {
 	((type) == NEXTHOP_TYPE_IFINDEX || (type) == NEXTHOP_TYPE_BLACKHOLE)   \
 		? (type)                                                       \
 		: ((type) | 1)
+
+enum nh_encap_type {
+	NET_VXLAN = 100, /* value copied from FPM_NH_ENCAP_VXLAN. */
+};
 
 /* Nexthop structure. */
 struct nexthop {
@@ -123,6 +128,12 @@ struct nexthop {
 	 * only meaningful if the HAS_BACKUP flag is set.
 	 */
 	uint8_t backup_idx;
+
+	/* Encapsulation information. */
+	enum nh_encap_type nh_encap_type;
+	union {
+		vni_t vni;
+	} nh_encap;
 };
 
 /* Backup index value is limited */

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -675,6 +675,7 @@ fi
     %{_libdir}/frr/modules/bgpd_rpki.so
 %endif
 %{_libdir}/frr/modules/zebra_cumulus_mlag.so
+%{_libdir}/frr/modules/dplane_fpm_nl.so
 %{_libdir}/frr/modules/zebra_irdp.so
 %{_libdir}/frr/modules/bgpd_bmp.so
 %{_bindir}/*

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -1,0 +1,445 @@
+/*
+ * Zebra dataplane plugin for Forwarding Plane Manager (FPM) using netlink.
+ *
+ * Copyright (C) 2019 Network Device Education Foundation, Inc. ("NetDEF")
+ *                    Rafael Zalamena
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <arpa/inet.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#include <errno.h>
+#include <string.h>
+
+#include "config.h" /* Include this explicitly */
+#include "lib/zebra.h"
+#include "lib/libfrr.h"
+#include "lib/memory.h"
+#include "lib/network.h"
+#include "lib/ns.h"
+#include "lib/frr_pthread.h"
+#include "zebra/zebra_dplane.h"
+#include "zebra/kernel_netlink.h"
+#include "zebra/rt_netlink.h"
+#include "zebra/debug.h"
+
+#define SOUTHBOUND_DEFAULT_ADDR INADDR_LOOPBACK
+#define SOUTHBOUND_DEFAULT_PORT 2620
+
+static const char *prov_name = "dplane_fpm_nl";
+
+struct fpm_nl_ctx {
+	/* data plane connection. */
+	int socket;
+	bool connecting;
+	struct sockaddr_storage addr;
+
+	/* data plane buffers. */
+	struct stream *ibuf;
+	struct stream *obuf;
+	pthread_mutex_t obuf_mutex;
+
+	/* data plane events. */
+	struct frr_pthread *fthread;
+	struct thread *t_connect;
+	struct thread *t_read;
+	struct thread *t_write;
+};
+
+/*
+ * FPM functions.
+ */
+static int fpm_connect(struct thread *t);
+
+static void fpm_reconnect(struct fpm_nl_ctx *fnc)
+{
+	/* Grab the lock to empty the stream and stop the zebra thread. */
+	frr_mutex_lock_autounlock(&fnc->obuf_mutex);
+
+	close(fnc->socket);
+	fnc->socket = -1;
+	stream_reset(fnc->ibuf);
+	stream_reset(fnc->obuf);
+	THREAD_OFF(fnc->t_read);
+	THREAD_OFF(fnc->t_write);
+	thread_add_timer(fnc->fthread->master, fpm_connect, fnc, 3,
+			 &fnc->t_connect);
+}
+
+static int fpm_read(struct thread *t)
+{
+	struct fpm_nl_ctx *fnc = THREAD_ARG(t);
+	ssize_t rv;
+
+	/* Let's ignore the input at the moment. */
+	rv = stream_read_try(fnc->ibuf, fnc->socket,
+			     STREAM_WRITEABLE(fnc->ibuf));
+	if (rv == 0) {
+		zlog_debug("%s: connection closed", __func__);
+		fpm_reconnect(fnc);
+		return 0;
+	}
+	if (rv == -1) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK
+		    || errno == EINTR)
+			return 0;
+
+		zlog_debug("%s: connection failure: %s", __func__,
+			   strerror(errno));
+		fpm_reconnect(fnc);
+		return 0;
+	}
+	stream_reset(fnc->ibuf);
+
+	thread_add_read(fnc->fthread->master, fpm_read, fnc, fnc->socket,
+			&fnc->t_read);
+
+	return 0;
+}
+
+static int fpm_write(struct thread *t)
+{
+	struct fpm_nl_ctx *fnc = THREAD_ARG(t);
+	socklen_t statuslen;
+	ssize_t bwritten;
+	int rv, status;
+	size_t btotal;
+
+	if (fnc->connecting == true) {
+		status = 0;
+		statuslen = sizeof(status);
+
+		rv = getsockopt(fnc->socket, SOL_SOCKET, SO_ERROR, &status,
+				&statuslen);
+		if (rv == -1 || status != 0) {
+			if (rv != -1)
+				zlog_debug("%s: connection failed: %s",
+					   __func__, strerror(status));
+			else
+				zlog_debug("%s: SO_ERROR failed: %s", __func__,
+					   strerror(status));
+
+			fpm_reconnect(fnc);
+			return 0;
+		}
+
+		fnc->connecting = false;
+	}
+
+	frr_mutex_lock_autounlock(&fnc->obuf_mutex);
+
+	while (true) {
+		/* Stream is empty: reset pointers and return. */
+		if (STREAM_READABLE(fnc->obuf) == 0) {
+			stream_reset(fnc->obuf);
+			break;
+		}
+
+		/* Try to write all at once. */
+		btotal = stream_get_endp(fnc->obuf) -
+			stream_get_getp(fnc->obuf);
+		bwritten = write(fnc->socket, stream_pnt(fnc->obuf), btotal);
+		if (bwritten == 0) {
+			zlog_debug("%s: connection closed", __func__);
+			break;
+		}
+		if (bwritten == -1) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK
+			    || errno == EINTR)
+				break;
+
+			zlog_debug("%s: connection failure: %s", __func__,
+				   strerror(errno));
+			fpm_reconnect(fnc);
+			break;
+		}
+
+		stream_forward_getp(fnc->obuf, (size_t)bwritten);
+	}
+
+	/* Stream is not empty yet, we must schedule more writes. */
+	if (STREAM_READABLE(fnc->obuf)) {
+		thread_add_write(fnc->fthread->master, fpm_write, fnc,
+				 fnc->socket, &fnc->t_write);
+		return 0;
+	}
+
+	return 0;
+}
+
+static int fpm_connect(struct thread *t)
+{
+	struct fpm_nl_ctx *fnc = THREAD_ARG(t);
+	struct sockaddr_in *sin;
+	int rv, sock;
+	char addrstr[INET6_ADDRSTRLEN];
+
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock == -1) {
+		zlog_err("%s: fpm connection failed: %s", __func__,
+			 strerror(errno));
+		thread_add_timer(fnc->fthread->master, fpm_connect, fnc, 3,
+				 &fnc->t_connect);
+		return 0;
+	}
+
+	set_nonblocking(sock);
+
+	sin = (struct sockaddr_in *)&fnc->addr;
+	memset(sin, 0, sizeof(*sin));
+	sin->sin_family = AF_INET;
+	sin->sin_addr.s_addr = htonl(SOUTHBOUND_DEFAULT_ADDR);
+	sin->sin_port = htons(SOUTHBOUND_DEFAULT_PORT);
+#ifdef HAVE_STRUCT_SOCKADDR_IN_SIN_LEN
+	sin->sin_len = sizeof(sin);
+#endif /* HAVE_STRUCT_SOCKADDR_IN_SIN_LEN */
+
+	inet_ntop(AF_INET, &sin->sin_addr, addrstr, sizeof(addrstr));
+	zlog_debug("%s: attempting to connect to %s:%d", __func__, addrstr,
+		   ntohs(sin->sin_port));
+
+	rv = connect(sock, (struct sockaddr *)sin, sizeof(*sin));
+	if (rv == -1 && errno != EINPROGRESS) {
+		close(sock);
+		zlog_warn("%s: fpm connection failed: %s", __func__,
+			  strerror(errno));
+		thread_add_timer(fnc->fthread->master, fpm_connect, fnc, 3,
+				 &fnc->t_connect);
+		return 0;
+	}
+
+	fnc->connecting = (errno == EINPROGRESS);
+	fnc->socket = sock;
+	thread_add_read(fnc->fthread->master, fpm_read, fnc, sock,
+			&fnc->t_read);
+	thread_add_write(fnc->fthread->master, fpm_write, fnc, sock,
+			 &fnc->t_write);
+
+	return 0;
+}
+
+/**
+ * Encode data plane operation context into netlink and enqueue it in the FPM
+ * output buffer.
+ *
+ * @param fnc the netlink FPM context.
+ * @param ctx the data plane operation context data.
+ * @return 0 on success or -1 on not enough space.
+ */
+static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
+{
+	uint8_t nl_buf[NL_PKT_BUF_SIZE];
+	size_t nl_buf_len;
+	ssize_t rv;
+
+	nl_buf_len = 0;
+
+	frr_mutex_lock_autounlock(&fnc->obuf_mutex);
+
+	switch (dplane_ctx_get_op(ctx)) {
+	case DPLANE_OP_ROUTE_UPDATE:
+	case DPLANE_OP_ROUTE_DELETE:
+		rv = netlink_route_multipath(RTM_DELROUTE, ctx, nl_buf,
+					     sizeof(nl_buf));
+		if (rv <= 0) {
+			zlog_debug("%s: netlink_route_multipath failed",
+				   __func__);
+			return 0;
+		}
+
+		nl_buf_len = (size_t)rv;
+		if (STREAM_WRITEABLE(fnc->obuf) < nl_buf_len) {
+			zlog_debug("%s: not enough output buffer (%ld vs %lu)",
+				   __func__, STREAM_WRITEABLE(fnc->obuf),
+				   nl_buf_len);
+			return -1;
+		}
+
+		/* UPDATE operations need a INSTALL, otherwise just quit. */
+		if (dplane_ctx_get_op(ctx) == DPLANE_OP_ROUTE_DELETE)
+			break;
+
+		/* FALL THROUGH */
+	case DPLANE_OP_ROUTE_INSTALL:
+		rv = netlink_route_multipath(RTM_NEWROUTE, ctx,
+					     &nl_buf[nl_buf_len],
+					     sizeof(nl_buf) - nl_buf_len);
+		if (rv <= 0) {
+			zlog_debug("%s: netlink_route_multipath failed",
+				   __func__);
+			return 0;
+		}
+
+		nl_buf_len += (size_t)rv;
+		if (STREAM_WRITEABLE(fnc->obuf) < nl_buf_len) {
+			zlog_debug("%s: not enough output buffer (%ld vs %lu)",
+				   __func__, STREAM_WRITEABLE(fnc->obuf),
+				   nl_buf_len);
+			return -1;
+		}
+		break;
+
+	case DPLANE_OP_NH_INSTALL:
+	case DPLANE_OP_NH_UPDATE:
+	case DPLANE_OP_NH_DELETE:
+	case DPLANE_OP_LSP_INSTALL:
+	case DPLANE_OP_LSP_UPDATE:
+	case DPLANE_OP_LSP_DELETE:
+	case DPLANE_OP_PW_INSTALL:
+	case DPLANE_OP_PW_UNINSTALL:
+	case DPLANE_OP_ADDR_INSTALL:
+	case DPLANE_OP_ADDR_UNINSTALL:
+	case DPLANE_OP_MAC_INSTALL:
+	case DPLANE_OP_MAC_DELETE:
+	case DPLANE_OP_NEIGH_INSTALL:
+	case DPLANE_OP_NEIGH_UPDATE:
+	case DPLANE_OP_NEIGH_DELETE:
+	case DPLANE_OP_VTEP_ADD:
+	case DPLANE_OP_VTEP_DELETE:
+	case DPLANE_OP_SYS_ROUTE_ADD:
+	case DPLANE_OP_SYS_ROUTE_DELETE:
+	case DPLANE_OP_ROUTE_NOTIFY:
+	case DPLANE_OP_LSP_NOTIFY:
+	case DPLANE_OP_NONE:
+		break;
+
+	default:
+		zlog_debug("%s: unhandled data plane message (%d) %s",
+			   __func__, dplane_ctx_get_op(ctx),
+			   dplane_op2str(dplane_ctx_get_op(ctx)));
+		break;
+	}
+
+	/* Skip empty enqueues. */
+	if (nl_buf_len == 0)
+		return 0;
+
+	/*
+	 * FPM header:
+	 * {
+	 *   version: 1 byte (always 1),
+	 *   type: 1 byte (1 for netlink, 2 protobuf),
+	 *   len: 2 bytes (network order),
+	 * }
+	 */
+	stream_putc(fnc->obuf, 1);
+	stream_putc(fnc->obuf, 1);
+	assert(nl_buf_len < UINT16_MAX);
+	stream_putw(fnc->obuf, nl_buf_len + 4);
+
+	/* Write current data. */
+	stream_write(fnc->obuf, nl_buf, (size_t)nl_buf_len);
+
+	/* Tell the thread to start writing. */
+	thread_add_write(fnc->fthread->master, fpm_write, fnc, fnc->socket,
+			 &fnc->t_write);
+
+	return 0;
+}
+
+/*
+ * Data plane functions.
+ */
+static int fpm_nl_start(struct zebra_dplane_provider *prov)
+{
+	struct fpm_nl_ctx *fnc;
+
+	fnc = dplane_provider_get_data(prov);
+	fnc->fthread = frr_pthread_new(NULL, prov_name, prov_name);
+	assert(frr_pthread_run(fnc->fthread, NULL) == 0);
+	fnc->ibuf = stream_new(NL_PKT_BUF_SIZE);
+	fnc->obuf = stream_new(NL_PKT_BUF_SIZE * 128);
+	pthread_mutex_init(&fnc->obuf_mutex, NULL);
+	fnc->socket = -1;
+
+	thread_add_timer(fnc->fthread->master, fpm_connect, fnc, 1,
+			 &fnc->t_connect);
+
+	return 0;
+}
+
+static int fpm_nl_finish(struct zebra_dplane_provider *prov, bool early)
+{
+	struct fpm_nl_ctx *fnc;
+
+	fnc = dplane_provider_get_data(prov);
+	stream_free(fnc->ibuf);
+	stream_free(fnc->obuf);
+	close(fnc->socket);
+
+	return 0;
+}
+
+static int fpm_nl_process(struct zebra_dplane_provider *prov)
+{
+	struct zebra_dplane_ctx *ctx;
+	struct fpm_nl_ctx *fnc;
+	int counter, limit;
+
+	fnc = dplane_provider_get_data(prov);
+	limit = dplane_provider_get_work_limit(prov);
+	for (counter = 0; counter < limit; counter++) {
+		ctx = dplane_provider_dequeue_in_ctx(prov);
+		if (ctx == NULL)
+			break;
+
+		/*
+		 * Skip all notifications if not connected, we'll walk the RIB
+		 * anyway.
+		 */
+		if (fnc->socket != -1 && fnc->connecting == false)
+			fpm_nl_enqueue(fnc, ctx);
+
+		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
+		dplane_provider_enqueue_out_ctx(prov, ctx);
+	}
+
+	return 0;
+}
+
+static int fpm_nl_new(struct thread_master *tm)
+{
+	struct zebra_dplane_provider *prov = NULL;
+	struct fpm_nl_ctx *fnc;
+	int rv;
+
+	fnc = calloc(1, sizeof(*fnc));
+	rv = dplane_provider_register(prov_name, DPLANE_PRIO_POSTPROCESS,
+				      DPLANE_PROV_FLAG_THREADED, fpm_nl_start,
+				      fpm_nl_process, fpm_nl_finish, fnc,
+				      &prov);
+
+	if (IS_ZEBRA_DEBUG_DPLANE)
+		zlog_debug("%s register status: %d", prov_name, rv);
+
+	return 0;
+}
+
+static int fpm_nl_init(void)
+{
+	hook_register(frr_late_init, fpm_nl_new);
+	return 0;
+}
+
+FRR_MODULE_SETUP(
+	.name = "dplane_fpm_nl",
+	.version = "0.0.1",
+	.description = "Data plane plugin for FPM using netlink.",
+	.init = fpm_nl_init,
+	)

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -103,35 +103,35 @@ struct fpm_nl_ctx {
 	/* Statistic counters. */
 	struct {
 		/* Amount of bytes read into ibuf. */
-		_Atomic uint64_t bytes_read;
+		_Atomic uint32_t bytes_read;
 		/* Amount of bytes written from obuf. */
-		_Atomic uint64_t bytes_sent;
+		_Atomic uint32_t bytes_sent;
 		/* Output buffer current usage. */
-		_Atomic uint64_t obuf_bytes;
+		_Atomic uint32_t obuf_bytes;
 		/* Output buffer peak usage. */
-		_Atomic uint64_t obuf_peak;
+		_Atomic uint32_t obuf_peak;
 
 		/* Amount of connection closes. */
-		_Atomic uint64_t connection_closes;
+		_Atomic uint32_t connection_closes;
 		/* Amount of connection errors. */
-		_Atomic uint64_t connection_errors;
+		_Atomic uint32_t connection_errors;
 
 		/* Amount of user configurations: FNE_RECONNECT. */
-		_Atomic uint64_t user_configures;
+		_Atomic uint32_t user_configures;
 		/* Amount of user disable requests: FNE_DISABLE. */
-		_Atomic uint64_t user_disables;
+		_Atomic uint32_t user_disables;
 
 		/* Amount of data plane context processed. */
-		_Atomic uint64_t dplane_contexts;
+		_Atomic uint32_t dplane_contexts;
 		/* Amount of data plane contexts enqueued. */
-		_Atomic uint64_t ctxqueue_len;
+		_Atomic uint32_t ctxqueue_len;
 		/* Peak amount of data plane contexts enqueued. */
-		_Atomic uint64_t ctxqueue_len_peak;
+		_Atomic uint32_t ctxqueue_len_peak;
 
 		/* Amount of buffer full events. */
-		_Atomic uint64_t buffer_full;
+		_Atomic uint32_t buffer_full;
 	} counters;
-} * gfnc;
+} *gfnc;
 
 enum fpm_nl_events {
 	/* Ask for FPM to reconnect the external server. */
@@ -271,7 +271,7 @@ DEFUN(fpm_show_counters, fpm_show_counters_cmd,
 	vty_out(vty, "%30s\n%30s\n", "FPM counters", "============");
 
 #define SHOW_COUNTER(label, counter) \
-	vty_out(vty, "%28s: %Lu\n", (label), (counter));
+	vty_out(vty, "%28s: %u\n", (label), (counter))
 
 	SHOW_COUNTER("Input bytes", gfnc->counters.bytes_read);
 	SHOW_COUNTER("Output bytes", gfnc->counters.bytes_sent);

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -308,15 +308,19 @@ DEFUN(fpm_show_counters_json, fpm_show_counters_json_cmd,
 	json_object_int_add(jo, "bytes-sent", gfnc->counters.bytes_sent);
 	json_object_int_add(jo, "obuf-bytes", gfnc->counters.obuf_bytes);
 	json_object_int_add(jo, "obuf-bytes-peak", gfnc->counters.obuf_peak);
-	json_object_int_add(jo, "connection-closes", gfnc->counters.connection_closes);
-	json_object_int_add(jo, "connection-errors", gfnc->counters.connection_errors);
-	json_object_int_add(jo, "data-plane-contexts", gfnc->counters.dplane_contexts);
+	json_object_int_add(jo, "connection-closes",
+			    gfnc->counters.connection_closes);
+	json_object_int_add(jo, "connection-errors",
+			    gfnc->counters.connection_errors);
+	json_object_int_add(jo, "data-plane-contexts",
+			    gfnc->counters.dplane_contexts);
 	json_object_int_add(jo, "data-plane-contexts-queue",
 			    gfnc->counters.ctxqueue_len);
 	json_object_int_add(jo, "data-plane-contexts-queue-peak",
 			    gfnc->counters.ctxqueue_len_peak);
 	json_object_int_add(jo, "buffer-full-hits", gfnc->counters.buffer_full);
-	json_object_int_add(jo, "user-configures", gfnc->counters.user_configures);
+	json_object_int_add(jo, "user-configures",
+			    gfnc->counters.user_configures);
 	json_object_int_add(jo, "user-disables", gfnc->counters.user_disables);
 	vty_out(vty, "%s\n", json_object_to_json_string_ext(jo, 0));
 	json_object_free(jo);
@@ -762,14 +766,12 @@ static int fpm_rib_send(struct thread *t)
 		for (rn = route_top(rt); rn; rn = srcdest_route_next(rn)) {
 			dest = rib_dest_from_rnode(rn);
 			/* Skip bad route entries. */
-			if (dest == NULL || dest->selected_fib == NULL) {
+			if (dest == NULL || dest->selected_fib == NULL)
 				continue;
-			}
 
 			/* Check for already sent routes. */
-			if (CHECK_FLAG(dest->flags, RIB_DEST_UPDATE_FPM)) {
+			if (CHECK_FLAG(dest->flags, RIB_DEST_UPDATE_FPM))
 				continue;
-			}
 
 			/* Enqueue route install. */
 			dplane_ctx_reset(ctx);

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -626,7 +626,7 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_ROUTE_UPDATE:
 	case DPLANE_OP_ROUTE_DELETE:
 		rv = netlink_route_multipath(RTM_DELROUTE, ctx, nl_buf,
-					     sizeof(nl_buf));
+					     sizeof(nl_buf), true);
 		if (rv <= 0) {
 			zlog_debug("%s: netlink_route_multipath failed",
 				   __func__);
@@ -643,7 +643,7 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	case DPLANE_OP_ROUTE_INSTALL:
 		rv = netlink_route_multipath(RTM_NEWROUTE, ctx,
 					     &nl_buf[nl_buf_len],
-					     sizeof(nl_buf) - nl_buf_len);
+					     sizeof(nl_buf) - nl_buf_len, true);
 		if (rv <= 0) {
 			zlog_debug("%s: netlink_route_multipath failed",
 				   __func__);
@@ -829,8 +829,8 @@ static void fpm_enqueue_rmac_table(struct hash_backet *backet, void *arg)
 	dplane_ctx_reset(fra->ctx);
 	dplane_ctx_set_op(fra->ctx, DPLANE_OP_MAC_INSTALL);
 	dplane_mac_init(fra->ctx, fra->zl3vni->vxlan_if,
-			zif->brslave_info.br_if, vid, &zrmac->macaddr,
-			zrmac->fwd_info.r_vtep_ip, sticky);
+			zif->brslave_info.br_if, vid,
+			&zrmac->macaddr, zrmac->fwd_info.r_vtep_ip, sticky);
 	if (fpm_nl_enqueue(fra->fnc, fra->ctx) == -1) {
 		thread_add_timer(zrouter.master, fpm_rmac_send,
 				 fra->fnc, 1, &fra->fnc->t_rmacwalk);

--- a/zebra/dplane_fpm_nl.c
+++ b/zebra/dplane_fpm_nl.c
@@ -821,7 +821,7 @@ struct fpm_rmac_arg {
 	zebra_l3vni_t *zl3vni;
 };
 
-static void fpm_enqueue_rmac_table(struct hash_backet *backet, void *arg)
+static void fpm_enqueue_rmac_table(struct hash_bucket *backet, void *arg)
 {
 	struct fpm_rmac_arg *fra = arg;
 	zebra_mac_t *zrmac = backet->data;
@@ -851,7 +851,7 @@ static void fpm_enqueue_rmac_table(struct hash_backet *backet, void *arg)
 	}
 }
 
-static void fpm_enqueue_l3vni_table(struct hash_backet *backet, void *arg)
+static void fpm_enqueue_l3vni_table(struct hash_bucket *backet, void *arg)
 {
 	struct fpm_rmac_arg *fra = arg;
 	zebra_l3vni_t *zl3vni = backet->data;
@@ -903,14 +903,14 @@ static int fpm_rib_reset(struct thread *t)
 /*
  * The next three function will handle RMAC table reset.
  */
-static void fpm_unset_rmac_table(struct hash_backet *backet, void *arg)
+static void fpm_unset_rmac_table(struct hash_bucket *backet, void *arg)
 {
 	zebra_mac_t *zrmac = backet->data;
 
 	UNSET_FLAG(zrmac->flags, ZEBRA_MAC_FPM_SENT);
 }
 
-static void fpm_unset_l3vni_table(struct hash_backet *backet, void *arg)
+static void fpm_unset_l3vni_table(struct hash_bucket *backet, void *arg)
 {
 	zebra_l3vni_t *zl3vni = backet->data;
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1123,6 +1123,7 @@ static void _netlink_route_build_singlepath(const struct prefix *p,
 	char label_buf[256];
 	int num_labels = 0;
 	struct vrf *vrf;
+	char addrstr[INET6_ADDRSTRLEN];
 
 	assert(nexthop);
 
@@ -1179,11 +1180,10 @@ static void _netlink_route_build_singlepath(const struct prefix *p,
 				  &nexthop->src.ipv4, bytelen);
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				" 5549: _netlink_route_build_singlepath() (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
-				routedesc, p, ipv4_ll_buf, label_buf,
-				nexthop->ifindex, VRF_LOGNAME(vrf),
-				nexthop->vrf_id);
+			zlog_debug("%s: 5549 (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+				   __func__, routedesc, p, ipv4_ll_buf,
+				   label_buf, nexthop->ifindex,
+				   VRF_LOGNAME(vrf), nexthop->vrf_id);
 		return;
 	}
 
@@ -1204,12 +1204,14 @@ static void _netlink_route_build_singlepath(const struct prefix *p,
 					  &nexthop->src.ipv4, bytelen);
 		}
 
-		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				"netlink_route_multipath() (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
-				routedesc, p, inet_ntoa(nexthop->gate.ipv4),
-				label_buf, nexthop->ifindex, VRF_LOGNAME(vrf),
-				nexthop->vrf_id);
+		if (IS_ZEBRA_DEBUG_KERNEL) {
+			inet_ntop(AF_INET, &nexthop->gate.ipv4, addrstr,
+				  sizeof(addrstr));
+			zlog_debug("%s: (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+				   __func__, routedesc, p, addrstr, label_buf,
+				   nexthop->ifindex, VRF_LOGNAME(vrf),
+				   nexthop->vrf_id);
+		}
 	}
 
 	if (nexthop->type == NEXTHOP_TYPE_IPV6
@@ -1227,12 +1229,14 @@ static void _netlink_route_build_singlepath(const struct prefix *p,
 					  &nexthop->src.ipv6, bytelen);
 		}
 
-		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				"netlink_route_multipath() (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
-				routedesc, p, inet6_ntoa(nexthop->gate.ipv6),
-				label_buf, nexthop->ifindex, VRF_LOGNAME(vrf),
-				nexthop->vrf_id);
+		if (IS_ZEBRA_DEBUG_KERNEL) {
+			inet_ntop(AF_INET6, &nexthop->gate.ipv6, addrstr,
+				  sizeof(addrstr));
+			zlog_debug("%s: (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+				   __func__, routedesc, p, addrstr, label_buf,
+				   nexthop->ifindex, VRF_LOGNAME(vrf),
+				   nexthop->vrf_id);
+		}
 	}
 
 	/*
@@ -1254,10 +1258,9 @@ static void _netlink_route_build_singlepath(const struct prefix *p,
 		}
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				"netlink_route_multipath() (%s): %pFX nexthop via if %u vrf %s(%u)",
-				routedesc, p, nexthop->ifindex,
-				VRF_LOGNAME(vrf), nexthop->vrf_id);
+			zlog_debug("%s: (%s): %pFX nexthop via if %u vrf %s(%u)",
+				   __func__, routedesc, p, nexthop->ifindex,
+				   VRF_LOGNAME(vrf), nexthop->vrf_id);
 	}
 }
 
@@ -1287,6 +1290,7 @@ _netlink_route_build_multipath(const struct prefix *p, const char *routedesc,
 	char label_buf[256];
 	int num_labels = 0;
 	struct vrf *vrf;
+	char addrstr[INET6_ADDRSTRLEN];
 
 	rtnh->rtnh_len = sizeof(*rtnh);
 	rtnh->rtnh_flags = 0;
@@ -1356,8 +1360,8 @@ _netlink_route_build_multipath(const struct prefix *p, const char *routedesc,
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
 			zlog_debug(
-				" 5549: netlink_route_build_multipath() (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
-				routedesc, p, ipv4_ll_buf, label_buf,
+				"%s: 5549 (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+				__func__, routedesc, p, ipv4_ll_buf, label_buf,
 				nexthop->ifindex, VRF_LOGNAME(vrf),
 				nexthop->vrf_id);
 		return;
@@ -1373,12 +1377,14 @@ _netlink_route_build_multipath(const struct prefix *p, const char *routedesc,
 		else if (nexthop->src.ipv4.s_addr != INADDR_ANY)
 			*src = &nexthop->src;
 
-		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				"netlink_route_multipath() (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
-				routedesc, p, inet_ntoa(nexthop->gate.ipv4),
-				label_buf, nexthop->ifindex, VRF_LOGNAME(vrf),
-				nexthop->vrf_id);
+		if (IS_ZEBRA_DEBUG_KERNEL) {
+			inet_ntop(AF_INET, &nexthop->gate.ipv4, addrstr,
+				  sizeof(addrstr));
+			zlog_debug( "%s: (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+				   __func__, routedesc, p, addrstr, label_buf,
+				   nexthop->ifindex, VRF_LOGNAME(vrf),
+				   nexthop->vrf_id);
+		}
 	}
 	if (nexthop->type == NEXTHOP_TYPE_IPV6
 	    || nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX) {
@@ -1391,12 +1397,14 @@ _netlink_route_build_multipath(const struct prefix *p, const char *routedesc,
 		else if (!IN6_IS_ADDR_UNSPECIFIED(&nexthop->src.ipv6))
 			*src = &nexthop->src;
 
-		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				"netlink_route_multipath() (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
-				routedesc, p, inet6_ntoa(nexthop->gate.ipv6),
-				label_buf, nexthop->ifindex, VRF_LOGNAME(vrf),
-				nexthop->vrf_id);
+		if (IS_ZEBRA_DEBUG_KERNEL) {
+			inet_ntop(AF_INET, &nexthop->gate.ipv6, addrstr,
+				  sizeof(addrstr));
+			zlog_debug( "%s: (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
+				   __func__, routedesc, p, addrstr, label_buf,
+				   nexthop->ifindex, VRF_LOGNAME(vrf),
+				   nexthop->vrf_id);
+		}
 	}
 
 	/*
@@ -1415,10 +1423,9 @@ _netlink_route_build_multipath(const struct prefix *p, const char *routedesc,
 			*src = &nexthop->src;
 
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				"netlink_route_multipath() (%s): %pFX nexthop via if %u vrf %s(%u)",
-				routedesc, p, nexthop->ifindex,
-				VRF_LOGNAME(vrf), nexthop->vrf_id);
+			zlog_debug("%s: (%s): %pFX nexthop via if %u vrf %s(%u)",
+				   __func__, routedesc, p, nexthop->ifindex,
+				   VRF_LOGNAME(vrf), nexthop->vrf_id);
 	}
 
 	if (nexthop->weight)
@@ -1455,37 +1462,6 @@ _netlink_mpls_build_multipath(const struct prefix *p, const char *routedesc,
 	bytelen = (family == AF_INET ? 4 : 16);
 	_netlink_route_build_multipath(p, routedesc, bytelen, nhlfe->nexthop,
 				       rta, rtnh, rtmsg, src);
-}
-
-
-/* Log debug information for netlink_route_multipath
- * if debug logging is enabled.
- *
- * @param cmd: Netlink command which is to be processed
- * @param p: Prefix for which the change is due
- * @param family: Address family which the change concerns
- * @param zvrf: The vrf we are in
- * @param tableid: The table we are working on
- */
-static void _netlink_route_debug(int cmd, const struct prefix *p,
-				 int family, vrf_id_t vrfid,
-				 uint32_t tableid)
-{
-	if (IS_ZEBRA_DEBUG_KERNEL) {
-		char buf[PREFIX_STRLEN];
-		zlog_debug(
-			"netlink_route_multipath(): %s %s vrf %s(%u) table_id: %u",
-			nl_msg_type_to_str(cmd),
-			prefix2str(p, buf, sizeof(buf)), vrf_id_to_name(vrfid),
-			vrfid, tableid);
-	}
-}
-
-static void _netlink_nexthop_debug(int cmd, uint32_t id)
-{
-	if (IS_ZEBRA_DEBUG_KERNEL)
-		zlog_debug("netlink_nexthop(): %s, id=%u",
-			   nl_msg_type_to_str(cmd), id);
 }
 
 static void _netlink_mpls_debug(int cmd, uint32_t label, const char *routedesc)
@@ -1650,7 +1626,11 @@ static int netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx,
 		addattr32(&req->n, datalen, RTA_TABLE, table_id);
 	}
 
-	_netlink_route_debug(cmd, p, family, dplane_ctx_get_vrf(ctx), table_id);
+	if (IS_ZEBRA_DEBUG_KERNEL)
+		zlog_debug(
+			"%s: %s %pFX vrf %u(%u)", __func__,
+			nl_msg_type_to_str(cmd), p, dplane_ctx_get_vrf(ctx),
+			table_id);
 
 	/*
 	 * If we are not updating the route and we have received
@@ -1840,8 +1820,7 @@ static int netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx,
 	/* If there is no useful nexthop then return. */
 	if (nexthop_num == 0) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug(
-				"netlink_route_multipath(): No useful nexthop.");
+			zlog_debug("%s: No useful nexthop.", __func__);
 	}
 
 	return 0;
@@ -2103,7 +2082,9 @@ nexthop_done:
 		return -1;
 	}
 
-	_netlink_nexthop_debug(cmd, id);
+	if (IS_ZEBRA_DEBUG_KERNEL)
+		zlog_debug("%s: %s, id=%u", __func__, nl_msg_type_to_str(cmd),
+			   id);
 
 	return netlink_talk_info(netlink_talk_filter, &req.n,
 				 dplane_ctx_get_ns(ctx), 0);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1290,7 +1290,6 @@ _netlink_route_build_multipath(const struct prefix *p, const char *routedesc,
 	char label_buf[256];
 	int num_labels = 0;
 	struct vrf *vrf;
-	char addrstr[INET6_ADDRSTRLEN];
 
 	rtnh->rtnh_len = sizeof(*rtnh);
 	rtnh->rtnh_flags = 0;
@@ -1377,14 +1376,11 @@ _netlink_route_build_multipath(const struct prefix *p, const char *routedesc,
 		else if (nexthop->src.ipv4.s_addr != INADDR_ANY)
 			*src = &nexthop->src;
 
-		if (IS_ZEBRA_DEBUG_KERNEL) {
-			inet_ntop(AF_INET, &nexthop->gate.ipv4, addrstr,
-				  sizeof(addrstr));
-			zlog_debug( "%s: (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
-				   __func__, routedesc, p, addrstr, label_buf,
-				   nexthop->ifindex, VRF_LOGNAME(vrf),
-				   nexthop->vrf_id);
-		}
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("%s: (%s): %pFX nexthop via %pI4 %s if %u vrf %s(%u)",
+				   __func__, routedesc, p, &nexthop->gate.ipv4,
+				   label_buf, nexthop->ifindex,
+				   VRF_LOGNAME(vrf), nexthop->vrf_id);
 	}
 	if (nexthop->type == NEXTHOP_TYPE_IPV6
 	    || nexthop->type == NEXTHOP_TYPE_IPV6_IFINDEX) {
@@ -1397,14 +1393,11 @@ _netlink_route_build_multipath(const struct prefix *p, const char *routedesc,
 		else if (!IN6_IS_ADDR_UNSPECIFIED(&nexthop->src.ipv6))
 			*src = &nexthop->src;
 
-		if (IS_ZEBRA_DEBUG_KERNEL) {
-			inet_ntop(AF_INET, &nexthop->gate.ipv6, addrstr,
-				  sizeof(addrstr));
-			zlog_debug( "%s: (%s): %pFX nexthop via %s %s if %u vrf %s(%u)",
-				   __func__, routedesc, p, addrstr, label_buf,
-				   nexthop->ifindex, VRF_LOGNAME(vrf),
-				   nexthop->vrf_id);
-		}
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("%s: (%s): %pFX nexthop via %pI6 %s if %u vrf %s(%u)",
+				   __func__, routedesc, p, &nexthop->gate.ipv6,
+				   label_buf, nexthop->ifindex,
+				   VRF_LOGNAME(vrf), nexthop->vrf_id);
 	}
 
 	/*

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -66,6 +66,9 @@ void rt_netlink_init(void);
 /* MPLS label forwarding table change, using dataplane context information. */
 extern int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx);
 
+extern ssize_t netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx,
+				       uint8_t *data, size_t datalen);
+
 extern int netlink_route_change(struct nlmsghdr *h, ns_id_t ns_id, int startup);
 extern int netlink_route_read(struct zebra_ns *zns);
 

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -68,6 +68,8 @@ extern int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx);
 
 extern ssize_t netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx,
 				       uint8_t *data, size_t datalen);
+extern ssize_t netlink_macfdb_update_ctx(struct zebra_dplane_ctx *ctx,
+					 uint8_t *data, size_t datalen);
 
 extern int netlink_route_change(struct nlmsghdr *h, ns_id_t ns_id, int startup);
 extern int netlink_route_read(struct zebra_ns *zns);

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -67,7 +67,8 @@ void rt_netlink_init(void);
 extern int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx);
 
 extern ssize_t netlink_route_multipath(int cmd, struct zebra_dplane_ctx *ctx,
-				       uint8_t *data, size_t datalen);
+				       uint8_t *data, size_t datalen,
+				       bool fpm);
 extern ssize_t netlink_macfdb_update_ctx(struct zebra_dplane_ctx *ctx,
 					 uint8_t *data, size_t datalen);
 

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -32,7 +32,6 @@ module_LTLIBRARIES += zebra/zebra_snmp.la
 endif
 if FPM
 module_LTLIBRARIES += zebra/zebra_fpm.la
-module_LTLIBRARIES += zebra/dplane_fpm_nl.la
 endif
 if LINUX
 module_LTLIBRARIES += zebra/zebra_cumulus_mlag.la
@@ -201,8 +200,12 @@ nodist_zebra_zebra_SOURCES = \
 zebra_zebra_cumulus_mlag_la_SOURCES = zebra/zebra_mlag_private.c
 zebra_zebra_cumulus_mlag_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
 
+if LINUX
+module_LTLIBRARIES += zebra/dplane_fpm_nl.la
+
 zebra_dplane_fpm_nl_la_SOURCES = zebra/dplane_fpm_nl.c
 zebra_dplane_fpm_nl_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
 zebra_dplane_fpm_nl_la_LIBADD  =
 
 vtysh_scan += $(top_srcdir)/zebra/dplane_fpm_nl.c
+endif

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -32,6 +32,7 @@ module_LTLIBRARIES += zebra/zebra_snmp.la
 endif
 if FPM
 module_LTLIBRARIES += zebra/zebra_fpm.la
+module_LTLIBRARIES += zebra/dplane_fpm_nl.la
 endif
 if LINUX
 module_LTLIBRARIES += zebra/zebra_cumulus_mlag.la
@@ -199,3 +200,7 @@ nodist_zebra_zebra_SOURCES = \
 
 zebra_zebra_cumulus_mlag_la_SOURCES = zebra/zebra_mlag_private.c
 zebra_zebra_cumulus_mlag_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
+
+zebra_dplane_fpm_nl_la_SOURCES = zebra/dplane_fpm_nl.c
+zebra_dplane_fpm_nl_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
+zebra_dplane_fpm_nl_la_LIBADD  =

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -204,3 +204,5 @@ zebra_zebra_cumulus_mlag_la_LDFLAGS = -avoid-version -module -shared -export-dyn
 zebra_dplane_fpm_nl_la_SOURCES = zebra/dplane_fpm_nl.c
 zebra_dplane_fpm_nl_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
 zebra_dplane_fpm_nl_la_LIBADD  =
+
+vtysh_scan += $(top_srcdir)/zebra/dplane_fpm_nl.c

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -1525,10 +1525,8 @@ static int dplane_ctx_ns_init(struct zebra_dplane_ctx *ctx,
 /*
  * Initialize a context block for a route update from zebra data structs.
  */
-static int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx,
-				 enum dplane_op_e op,
-				 struct route_node *rn,
-				 struct route_entry *re)
+int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
+			  struct route_node *rn, struct route_entry *re)
 {
 	int ret = EINVAL;
 	const struct route_table *table = NULL;

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -401,7 +401,7 @@ static enum zebra_dplane_result pw_update_internal(struct zebra_pw *pw,
 static enum zebra_dplane_result intf_addr_update_internal(
 	const struct interface *ifp, const struct connected *ifc,
 	enum dplane_op_e op);
-static enum zebra_dplane_result mac_update_internal(
+static enum zebra_dplane_result mac_update_common(
 	enum dplane_op_e op, const struct interface *ifp,
 	const struct interface *br_ifp,
 	vlanid_t vid, const struct ethaddr *mac,
@@ -445,6 +445,123 @@ void dplane_enable_sys_route_notifs(void)
 }
 
 /*
+ * Clean up dependent/internal allocations inside a context object
+ */
+static void dplane_ctx_free_internal(struct zebra_dplane_ctx *ctx)
+{
+	/*
+	 * Some internal allocations may need to be freed, depending on
+	 * the type of info captured in the ctx.
+	 */
+	switch (ctx->zd_op) {
+	case DPLANE_OP_ROUTE_INSTALL:
+	case DPLANE_OP_ROUTE_UPDATE:
+	case DPLANE_OP_ROUTE_DELETE:
+	case DPLANE_OP_SYS_ROUTE_ADD:
+	case DPLANE_OP_SYS_ROUTE_DELETE:
+	case DPLANE_OP_ROUTE_NOTIFY:
+
+		/* Free allocated nexthops */
+		if (ctx->u.rinfo.zd_ng.nexthop) {
+			/* This deals with recursive nexthops too */
+			nexthops_free(ctx->u.rinfo.zd_ng.nexthop);
+
+			ctx->u.rinfo.zd_ng.nexthop = NULL;
+		}
+
+		/* Free backup info also (if present) */
+		if (ctx->u.rinfo.backup_ng.nexthop) {
+			/* This deals with recursive nexthops too */
+			nexthops_free(ctx->u.rinfo.backup_ng.nexthop);
+
+			ctx->u.rinfo.backup_ng.nexthop = NULL;
+		}
+
+		if (ctx->u.rinfo.zd_old_ng.nexthop) {
+			/* This deals with recursive nexthops too */
+			nexthops_free(ctx->u.rinfo.zd_old_ng.nexthop);
+
+			ctx->u.rinfo.zd_old_ng.nexthop = NULL;
+		}
+
+		if (ctx->u.rinfo.old_backup_ng.nexthop) {
+			/* This deals with recursive nexthops too */
+			nexthops_free(ctx->u.rinfo.old_backup_ng.nexthop);
+
+			ctx->u.rinfo.old_backup_ng.nexthop = NULL;
+		}
+
+		break;
+
+	case DPLANE_OP_NH_INSTALL:
+	case DPLANE_OP_NH_UPDATE:
+	case DPLANE_OP_NH_DELETE: {
+		if (ctx->u.rinfo.nhe.ng.nexthop) {
+			/* This deals with recursive nexthops too */
+			nexthops_free(ctx->u.rinfo.nhe.ng.nexthop);
+
+			ctx->u.rinfo.nhe.ng.nexthop = NULL;
+		}
+		break;
+	}
+
+	case DPLANE_OP_LSP_INSTALL:
+	case DPLANE_OP_LSP_UPDATE:
+	case DPLANE_OP_LSP_DELETE:
+	case DPLANE_OP_LSP_NOTIFY:
+	{
+		zebra_nhlfe_t *nhlfe, *next;
+
+		/* Free allocated NHLFEs */
+		for (nhlfe = ctx->u.lsp.nhlfe_list; nhlfe; nhlfe = next) {
+			next = nhlfe->next;
+
+			zebra_mpls_nhlfe_del(nhlfe);
+		}
+
+		/* Clear pointers in lsp struct, in case we're cacheing
+		 * free context structs.
+		 */
+		ctx->u.lsp.nhlfe_list = NULL;
+		ctx->u.lsp.best_nhlfe = NULL;
+
+		break;
+	}
+
+	case DPLANE_OP_PW_INSTALL:
+	case DPLANE_OP_PW_UNINSTALL:
+		/* Free allocated nexthops */
+		if (ctx->u.pw.nhg.nexthop) {
+			/* This deals with recursive nexthops too */
+			nexthops_free(ctx->u.pw.nhg.nexthop);
+
+			ctx->u.pw.nhg.nexthop = NULL;
+		}
+		break;
+
+	case DPLANE_OP_ADDR_INSTALL:
+	case DPLANE_OP_ADDR_UNINSTALL:
+		/* Maybe free label string, if allocated */
+		if (ctx->u.intf.label != NULL &&
+		    ctx->u.intf.label != ctx->u.intf.label_buf) {
+			free(ctx->u.intf.label);
+			ctx->u.intf.label = NULL;
+		}
+		break;
+
+	case DPLANE_OP_MAC_INSTALL:
+	case DPLANE_OP_MAC_DELETE:
+	case DPLANE_OP_NEIGH_INSTALL:
+	case DPLANE_OP_NEIGH_UPDATE:
+	case DPLANE_OP_NEIGH_DELETE:
+	case DPLANE_OP_VTEP_ADD:
+	case DPLANE_OP_VTEP_DELETE:
+	case DPLANE_OP_NONE:
+		break;
+	}
+}
+
+/*
  * Free a dataplane results context.
  */
 static void dplane_ctx_free(struct zebra_dplane_ctx **pctx)
@@ -461,114 +578,19 @@ static void dplane_ctx_free(struct zebra_dplane_ctx **pctx)
 	/* Some internal allocations may need to be freed, depending on
 	 * the type of info captured in the ctx.
 	 */
-	switch ((*pctx)->zd_op) {
-	case DPLANE_OP_ROUTE_INSTALL:
-	case DPLANE_OP_ROUTE_UPDATE:
-	case DPLANE_OP_ROUTE_DELETE:
-	case DPLANE_OP_SYS_ROUTE_ADD:
-	case DPLANE_OP_SYS_ROUTE_DELETE:
-	case DPLANE_OP_ROUTE_NOTIFY:
-
-		/* Free allocated nexthops */
-		if ((*pctx)->u.rinfo.zd_ng.nexthop) {
-			/* This deals with recursive nexthops too */
-			nexthops_free((*pctx)->u.rinfo.zd_ng.nexthop);
-
-			(*pctx)->u.rinfo.zd_ng.nexthop = NULL;
-		}
-
-		/* Free backup info also (if present) */
-		if ((*pctx)->u.rinfo.backup_ng.nexthop) {
-			/* This deals with recursive nexthops too */
-			nexthops_free((*pctx)->u.rinfo.backup_ng.nexthop);
-
-			(*pctx)->u.rinfo.backup_ng.nexthop = NULL;
-		}
-
-		if ((*pctx)->u.rinfo.zd_old_ng.nexthop) {
-			/* This deals with recursive nexthops too */
-			nexthops_free((*pctx)->u.rinfo.zd_old_ng.nexthop);
-
-			(*pctx)->u.rinfo.zd_old_ng.nexthop = NULL;
-		}
-
-		if ((*pctx)->u.rinfo.old_backup_ng.nexthop) {
-			/* This deals with recursive nexthops too */
-			nexthops_free((*pctx)->u.rinfo.old_backup_ng.nexthop);
-
-			(*pctx)->u.rinfo.old_backup_ng.nexthop = NULL;
-		}
-
-		break;
-
-	case DPLANE_OP_NH_INSTALL:
-	case DPLANE_OP_NH_UPDATE:
-	case DPLANE_OP_NH_DELETE: {
-		if ((*pctx)->u.rinfo.nhe.ng.nexthop) {
-			/* This deals with recursive nexthops too */
-			nexthops_free((*pctx)->u.rinfo.nhe.ng.nexthop);
-
-			(*pctx)->u.rinfo.nhe.ng.nexthop = NULL;
-		}
-		break;
-	}
-
-	case DPLANE_OP_LSP_INSTALL:
-	case DPLANE_OP_LSP_UPDATE:
-	case DPLANE_OP_LSP_DELETE:
-	case DPLANE_OP_LSP_NOTIFY:
-	{
-		zebra_nhlfe_t *nhlfe, *next;
-
-		/* Free allocated NHLFEs */
-		for (nhlfe = (*pctx)->u.lsp.nhlfe_list; nhlfe; nhlfe = next) {
-			next = nhlfe->next;
-
-			zebra_mpls_nhlfe_del(nhlfe);
-		}
-
-		/* Clear pointers in lsp struct, in case we're cacheing
-		 * free context structs.
-		 */
-		(*pctx)->u.lsp.nhlfe_list = NULL;
-		(*pctx)->u.lsp.best_nhlfe = NULL;
-
-		break;
-	}
-
-	case DPLANE_OP_PW_INSTALL:
-	case DPLANE_OP_PW_UNINSTALL:
-		/* Free allocated nexthops */
-		if ((*pctx)->u.pw.nhg.nexthop) {
-			/* This deals with recursive nexthops too */
-			nexthops_free((*pctx)->u.pw.nhg.nexthop);
-
-			(*pctx)->u.pw.nhg.nexthop = NULL;
-		}
-		break;
-
-	case DPLANE_OP_ADDR_INSTALL:
-	case DPLANE_OP_ADDR_UNINSTALL:
-		/* Maybe free label string, if allocated */
-		if ((*pctx)->u.intf.label != NULL &&
-		    (*pctx)->u.intf.label != (*pctx)->u.intf.label_buf) {
-			free((*pctx)->u.intf.label);
-			(*pctx)->u.intf.label = NULL;
-		}
-		break;
-
-	case DPLANE_OP_MAC_INSTALL:
-	case DPLANE_OP_MAC_DELETE:
-	case DPLANE_OP_NEIGH_INSTALL:
-	case DPLANE_OP_NEIGH_UPDATE:
-	case DPLANE_OP_NEIGH_DELETE:
-	case DPLANE_OP_VTEP_ADD:
-	case DPLANE_OP_VTEP_DELETE:
-	case DPLANE_OP_NONE:
-		break;
-	}
+	dplane_ctx_free_internal(*pctx);
 
 	XFREE(MTYPE_DP_CTX, *pctx);
+}
+
+/*
+ * Reset an allocated context object for re-use. All internal allocations are
+ * freed and the context is memset.
+ */
+void dplane_ctx_reset(struct zebra_dplane_ctx *ctx)
+{
+	dplane_ctx_free_internal(ctx);
+	memset(ctx, 0, sizeof(*ctx));
 }
 
 /*
@@ -2470,8 +2492,8 @@ enum zebra_dplane_result dplane_mac_add(const struct interface *ifp,
 	enum zebra_dplane_result result;
 
 	/* Use common helper api */
-	result = mac_update_internal(DPLANE_OP_MAC_INSTALL, ifp, bridge_ifp,
-				     vid, mac, vtep_ip, sticky);
+	result = mac_update_common(DPLANE_OP_MAC_INSTALL, ifp, bridge_ifp,
+				   vid, mac, vtep_ip, sticky);
 	return result;
 }
 
@@ -2487,41 +2509,25 @@ enum zebra_dplane_result dplane_mac_del(const struct interface *ifp,
 	enum zebra_dplane_result result;
 
 	/* Use common helper api */
-	result = mac_update_internal(DPLANE_OP_MAC_DELETE, ifp, bridge_ifp,
-				     vid, mac, vtep_ip, false);
+	result = mac_update_common(DPLANE_OP_MAC_DELETE, ifp, bridge_ifp,
+				   vid, mac, vtep_ip, false);
 	return result;
 }
 
 /*
- * Common helper api for MAC address/vxlan updates
+ * Public api to init an empty context - either newly-allocated or
+ * reset/cleared - for a MAC update.
  */
-static enum zebra_dplane_result
-mac_update_internal(enum dplane_op_e op,
-		    const struct interface *ifp,
-		    const struct interface *br_ifp,
-		    vlanid_t vid,
-		    const struct ethaddr *mac,
-		    struct in_addr vtep_ip,
-		    bool sticky)
+void dplane_mac_init(struct zebra_dplane_ctx *ctx,
+		     const struct interface *ifp,
+		     const struct interface *br_ifp,
+		     vlanid_t vid,
+		     const struct ethaddr *mac,
+		     struct in_addr vtep_ip,
+		     bool sticky)
 {
-	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
-	int ret;
-	struct zebra_dplane_ctx *ctx = NULL;
 	struct zebra_ns *zns;
 
-	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
-		char buf1[ETHER_ADDR_STRLEN], buf2[PREFIX_STRLEN];
-
-		zlog_debug("init mac ctx %s: mac %s, ifp %s, vtep %s",
-			   dplane_op2str(op),
-			   prefix_mac2str(mac, buf1, sizeof(buf1)),
-			   ifp->name,
-			   inet_ntop(AF_INET, &vtep_ip, buf2, sizeof(buf2)));
-	}
-
-	ctx = dplane_ctx_alloc();
-
-	ctx->zd_op = op;
 	ctx->zd_status = ZEBRA_DPLANE_REQUEST_SUCCESS;
 	ctx->zd_vrf_id = ifp->vrf_id;
 
@@ -2539,6 +2545,39 @@ mac_update_internal(enum dplane_op_e op,
 	ctx->u.macinfo.mac = *mac;
 	ctx->u.macinfo.vid = vid;
 	ctx->u.macinfo.is_sticky = sticky;
+}
+
+/*
+ * Common helper api for MAC address/vxlan updates
+ */
+static enum zebra_dplane_result
+mac_update_common(enum dplane_op_e op,
+		  const struct interface *ifp,
+		  const struct interface *br_ifp,
+		  vlanid_t vid,
+		  const struct ethaddr *mac,
+		  struct in_addr vtep_ip,
+		  bool sticky)
+{
+	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
+	int ret;
+	struct zebra_dplane_ctx *ctx = NULL;
+
+	if (IS_ZEBRA_DEBUG_DPLANE_DETAIL) {
+		char buf1[ETHER_ADDR_STRLEN], buf2[PREFIX_STRLEN];
+
+		zlog_debug("init mac ctx %s: mac %s, ifp %s, vtep %s",
+			   dplane_op2str(op),
+			   prefix_mac2str(mac, buf1, sizeof(buf1)),
+			   ifp->name,
+			   inet_ntop(AF_INET, &vtep_ip, buf2, sizeof(buf2)));
+	}
+
+	ctx = dplane_ctx_alloc();
+	ctx->zd_op = op;
+
+	/* Common init for the ctx */
+	dplane_mac_init(ctx, ifp, br_ifp, vid, mac, vtep_ip, sticky);
 
 	/* Enqueue for processing on the dplane pthread */
 	ret = dplane_update_enqueue(ctx);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -180,6 +180,12 @@ TAILQ_HEAD(dplane_ctx_q, zebra_dplane_ctx);
 /* Allocate a context object */
 struct zebra_dplane_ctx *dplane_ctx_alloc(void);
 
+/*
+ * Reset an allocated context object for re-use. All internal allocations are
+ * freed.
+ */
+void dplane_ctx_reset(struct zebra_dplane_ctx *ctx);
+
 /* Return a dataplane results context block after use; the caller's pointer will
  * be cleared.
  */
@@ -450,6 +456,15 @@ enum zebra_dplane_result dplane_mac_del(const struct interface *ifp,
 					vlanid_t vid,
 					const struct ethaddr *mac,
 					struct in_addr vtep_ip);
+
+/* Helper api to init an empty or new context for a MAC update */
+void dplane_mac_init(struct zebra_dplane_ctx *ctx,
+		     const struct interface *ifp,
+		     const struct interface *br_ifp,
+		     vlanid_t vid,
+		     const struct ethaddr *mac,
+		     struct in_addr vtep_ip,
+		     bool sticky);
 
 /*
  * Enqueue evpn neighbor updates for the dataplane.

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -489,6 +489,9 @@ enum zebra_dplane_result dplane_vtep_delete(const struct interface *ifp,
 					    const struct in_addr *ip,
 					    vni_t vni);
 
+/* Encode route information into data plane context. */
+int dplane_ctx_route_init(struct zebra_dplane_ctx *ctx, enum dplane_op_e op,
+			  struct route_node *rn, struct route_entry *re);
 
 /* Retrieve the limit on the number of pending, unprocessed updates. */
 uint32_t dplane_get_in_queue_limit(void);

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -444,6 +444,12 @@ enum zebra_dplane_result dplane_intf_addr_unset(const struct interface *ifp,
 /*
  * Enqueue evpn mac operations for the dataplane.
  */
+extern struct zebra_dplane_ctx *mac_update_internal(
+	enum dplane_op_e op, const struct interface *ifp,
+	const struct interface *br_ifp,
+	vlanid_t vid, const struct ethaddr *mac,
+	struct in_addr vtep_ip, bool sticky);
+
 enum zebra_dplane_result dplane_mac_add(const struct interface *ifp,
 					const struct interface *bridge_ifp,
 					vlanid_t vid,

--- a/zebra/zebra_vxlan_private.h
+++ b/zebra/zebra_vxlan_private.h
@@ -301,6 +301,7 @@ struct zebra_mac_t_ {
 /* remote VTEP advertised MAC as default GW */
 #define ZEBRA_MAC_REMOTE_DEF_GW	0x40
 #define ZEBRA_MAC_DUPLICATE 0x80
+#define ZEBRA_MAC_FPM_SENT  0x100 /* whether or not this entry was sent. */
 
 	/* back pointer to zvni */
 	zebra_vni_t     *zvni;


### PR DESCRIPTION
## Summary

In order to reduce code duplication and simplify the FPM code, I've implemented a new FPM netlink interface using the new zebra data plane framework: it reuses all zebra netlink code for encoding messages and does not access zebra data structures directly (no more pointers to data we don't have).

This is a work-in-progress and I'll update it as I finish the todo list below and receive feedback.

I would like to receive reports from FPM netlink users that use RMAC since I don't have the appropriate tools to test it.


## Related

Fixes #5369 .


## TODO

-   [x] Configuration knobs (address/port)
-   [x] Status counters