### PR TITLE
[7.2] zebra: use correct state when installing evpn macs

### DIFF
--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -2239,7 +2239,7 @@ enum zebra_dplane_result dplane_neigh_add(const struct interface *ifp,
 	enum zebra_dplane_result result = ZEBRA_DPLANE_REQUEST_FAILURE;
 
 	result = neigh_update_internal(DPLANE_OP_NEIGH_INSTALL,
-				       ifp, mac, ip, flags, 0);
+				       ifp, mac, ip, flags, DPLANE_NUD_NOARP);
 
 	return result;
 }


### PR DESCRIPTION
[7.2 version] Use correct state/flags when installing EVPN macs; when we converted from raw netlink to the zebra dataplane, a state value got lost.

Fixes #5431 