### PR TITLE
pimd: clear SA warning in pimd

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -884,7 +884,6 @@ static struct pim_upstream *pim_upstream_new(struct pim_instance *pim,
 		}
 
 		if (up->rpf.source_nexthop.interface) {
-			pim_ifp = up->rpf.source_nexthop.interface->info;
 			pim_upstream_mroute_iif_update(up->channel_oil,
 					__func__);
 		}


### PR DESCRIPTION
Remove a dead store in pim_upstream.c to clear up an SA warning.