### PR TITLE
mlag compile issue fixups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1159,6 +1159,7 @@ dnl ##########################################################################
 #
 # Logic for protobuf support.
 #
+PROTO3=false
 if test "$enable_protobuf" = "yes"; then
   # Check for protoc & protoc-c
 
@@ -1173,9 +1174,15 @@ if test "$enable_protobuf" = "yes"; then
   PKG_CHECK_MODULES([PROTOBUF_C], [libprotobuf-c >= 0.14],, [
     AC_MSG_FAILURE([protobuf requested but libprotobuf-c not found.  Install protobuf-c.])
   ])
-  AC_CHECK_HEADER([google/protobuf-c/protobuf-c.h], [], [
-    AC_MSG_FAILURE([protobuf requested but protobuf-c.h not found.  Install protobuf-c.])
-  ])
+
+  PROTO3=true
+  AC_CHECK_HEADER([google/protobuf-c/protobuf-c.h],
+                  [AC_CHECK_DECLS(PROTOBUF_C_LABEL_NONE,
+                                  AC_DEFINE([HAVE_PROTOBUF_VERSION_3],
+                                            [1], [Have Protobuf version 3]),
+                                  [PROTO3=false],
+                                  [#include <google/protobuf-c/protobuf-c.h>])],
+                  [PROTO3=false && AC_MSG_FAILURE([protobuf requested but protobuf-c.h not found.  Install protobuf-c.])])
 
   AC_DEFINE([HAVE_PROTOBUF], [1], [protobuf])
 fi
@@ -2271,6 +2278,7 @@ AM_CONDITIONAL([SNMP], [test "x$SNMP_METHOD" = "xagentx"])
 AM_CONDITIONAL([IRDP], [$IRDP])
 AM_CONDITIONAL([FPM], [test "x$enable_fpm" = "xyes"])
 AM_CONDITIONAL([HAVE_PROTOBUF], [test "x$enable_protobuf" = "xyes"])
+AM_CONDITIONAL([HAVE_PROTOBUF3], [$PROTO3])
 dnl daemons
 AM_CONDITIONAL([VTYSH], [test "x$VTYSH" = "xvtysh"])
 AM_CONDITIONAL([ZEBRA], [test "${enable_zebra}" != "no"])

--- a/mlag/subdir.am
+++ b/mlag/subdir.am
@@ -1,4 +1,4 @@
-if HAVE_PROTOBUF
+if HAVE_PROTOBUF3
 lib_LTLIBRARIES += mlag/libmlag_pb.la
 endif
 

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -10,7 +10,7 @@ vtysh_scan += \
 	$(top_srcdir)/zebra/interface.c \
 	$(top_srcdir)/zebra/router-id.c \
 	$(top_srcdir)/zebra/rtadv.c \
-	$(top_srcdir)/zebra/zebra_mlag.c \
+	$(top_srcdir)/zebra/zebra_mlag_vty.c \
 	$(top_srcdir)/zebra/zebra_mpls_vty.c \
 	$(top_srcdir)/zebra/zebra_ptm.c \
 	$(top_srcdir)/zebra/zebra_pw.c \
@@ -72,6 +72,7 @@ zebra_zebra_SOURCES = \
 	zebra/rule_netlink.c \
 	zebra/rule_socket.c \
 	zebra/zebra_mlag.c \
+	zebra/zebra_mlag_vty.c \
 	zebra/zebra_l2.c \
 	zebra/zebra_memory.c \
 	zebra/zebra_dplane.c \
@@ -105,8 +106,8 @@ zebra_zebra_SOURCES = \
 zebra/debug_clippy.c: $(CLIPPY_DEPS)
 zebra/debug.$(OBJEXT): zebra/debug_clippy.c
 
-zebra/zebra_mlag_clippy.c: $(CLIPPY_DEPS)
-zebra/zebra_mlag.$(OBJEXT): zebra/zebra_mlag_clippy.c
+zebra/zebra_mlag_vty_clippy.c: $(CLIPPY_DEPS)
+zebra/zebra_mlag_vty.$(OBJEXT): zebra/zebra_mlag_vty_clippy.c
 
 zebra/zebra_vty_clippy.c: $(CLIPPY_DEPS)
 zebra/interface_clippy.c: $(CLIPPY_DEPS)

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -41,7 +41,7 @@ man8 += $(MANBUILD)/zebra.8
 endif
 
 zebra_zebra_LDADD = lib/libfrr.la $(LIBCAP)
-if HAVE_PROTOBUF
+if HAVE_PROTOBUF3
 zebra_zebra_LDADD += mlag/libmlag_pb.la $(PROTOBUF_C_LIBS)
 endif
 zebra_zebra_SOURCES = \
@@ -137,6 +137,7 @@ noinst_HEADERS += \
 	zebra/rtadv.h \
 	zebra/rule_netlink.h \
 	zebra/zebra_mlag.h \
+	zebra/zebra_mlag_vty.h \
 	zebra/zebra_fpm_private.h \
 	zebra/zebra_l2.h \
 	zebra/zebra_dplane.h \

--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -32,10 +32,6 @@
 #include "zebra/zapi_msg.h"
 #include "zebra/debug.h"
 
-#ifndef VTYSH_EXTRACT_PL
-#include "zebra/zebra_mlag_clippy.c"
-#endif
-
 DEFINE_HOOK(zebra_mlag_private_write_data,
 	    (uint8_t *data, uint32_t len), (data, len))
 DEFINE_HOOK(zebra_mlag_private_monitor_state, (), ())
@@ -586,29 +582,8 @@ enum mlag_role zebra_mlag_get_role(void)
 	return zrouter.mlag_info.role;
 }
 
-DEFUN_HIDDEN (show_mlag,
-	      show_mlag_cmd,
-	      "show zebra mlag",
-	      SHOW_STR
-	      ZEBRA_STR
-	      "The mlag role on this machine\n")
-{
-	char buf[MLAG_ROLE_STRSIZE];
-
-	vty_out(vty, "MLag is configured to: %s\n",
-		mlag_role2str(zrouter.mlag_info.role, buf, sizeof(buf)));
-
-	return CMD_SUCCESS;
-}
-
-DEFPY_HIDDEN(test_mlag, test_mlag_cmd,
-	     "test zebra mlag <none$none|primary$primary|secondary$secondary>",
-	     "Test code\n"
-	     ZEBRA_STR
-	     "Modify the Mlag state\n"
-	     "Mlag is not setup on the machine\n"
-	     "Mlag is setup to be primary\n"
-	     "Mlag is setup to be the secondary\n")
+int32_t zebra_mlag_test_mlag_internal(const char *none, const char *primary,
+				      const char *secondary)
 {
 	enum mlag_role orig = zrouter.mlag_info.role;
 	char buf1[MLAG_ROLE_STRSIZE], buf2[MLAG_ROLE_STRSIZE];
@@ -650,8 +625,7 @@ DEFPY_HIDDEN(test_mlag, test_mlag_cmd,
 
 void zebra_mlag_init(void)
 {
-	install_element(VIEW_NODE, &show_mlag_cmd);
-	install_element(ENABLE_NODE, &test_mlag_cmd);
+	zebra_mlag_vty_init();
 
 	/*
 	 * Intialiaze the MLAG Global variables

--- a/zebra/zebra_mlag.c
+++ b/zebra/zebra_mlag.c
@@ -27,6 +27,7 @@
 #include "mlag.h"
 
 #include "zebra/zebra_mlag.h"
+#include "zebra/zebra_mlag_vty.h"
 #include "zebra/zebra_router.h"
 #include "zebra/zebra_memory.h"
 #include "zebra/zapi_msg.h"
@@ -653,7 +654,7 @@ void zebra_mlag_terminate(void)
  *  ProtoBuf Encoding APIs
  */
 
-#ifdef HAVE_PROTOBUF
+#ifdef HAVE_PROTOBUF_VERSION_3
 
 DEFINE_MTYPE_STATIC(ZEBRA, MLAG_PBUF, "ZEBRA MLAG PROTOBUF")
 

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -64,6 +64,9 @@ void zebra_mlag_send_register(void);
 void zebra_mlag_send_deregister(void);
 void zebra_mlag_handle_process_state(enum zebra_mlag_state state);
 void zebra_mlag_process_mlag_data(uint8_t *data, uint32_t len);
+int32_t zebra_mlag_test_mlag_internal(const char *none, const char *primary,
+				      const char *secondary);
+
 /*
  * ProtoBuffer Api's
  */
@@ -71,4 +74,5 @@ int zebra_mlag_protobuf_encode_client_data(struct stream *s,
 					   uint32_t *msg_type);
 int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 				       uint32_t len);
+void zebra_mlag_vty_init(void);
 #endif

--- a/zebra/zebra_mlag.h
+++ b/zebra/zebra_mlag.h
@@ -26,7 +26,7 @@
 #include "zclient.h"
 #include "zebra/zserv.h"
 
-#ifdef HAVE_PROTOBUF
+#ifdef HAVE_PROTOBUF_VERSION_3
 #include "mlag/mlag.pb-c.h"
 #endif
 
@@ -64,8 +64,6 @@ void zebra_mlag_send_register(void);
 void zebra_mlag_send_deregister(void);
 void zebra_mlag_handle_process_state(enum zebra_mlag_state state);
 void zebra_mlag_process_mlag_data(uint8_t *data, uint32_t len);
-int32_t zebra_mlag_test_mlag_internal(const char *none, const char *primary,
-				      const char *secondary);
 
 /*
  * ProtoBuffer Api's
@@ -74,5 +72,4 @@ int zebra_mlag_protobuf_encode_client_data(struct stream *s,
 					   uint32_t *msg_type);
 int zebra_mlag_protobuf_decode_message(struct stream *s, uint8_t *data,
 				       uint32_t len);
-void zebra_mlag_vty_init(void);
 #endif

--- a/zebra/zebra_mlag_vty.c
+++ b/zebra/zebra_mlag_vty.c
@@ -1,0 +1,67 @@
+/* Zebra Mlag vty Code.
+ * Copyright (C) 2019 Cumulus Networks, Inc.
+ *                    Donald Sharp
+ *
+ * This file is part of FRR.
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FRR; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+#include <zebra.h>
+
+#include "vty.h"
+#include "command.h"
+
+#include "zebra_router.h"
+#include "zebra_mlag.h"
+#include "debug.h"
+#include "zapi_msg.h"
+
+#ifndef VTYSH_EXTRACT_PL
+#include "zebra/zebra_mlag_vty_clippy.c"
+#endif
+
+DEFUN_HIDDEN (show_mlag,
+	      show_mlag_cmd,
+	      "show zebra mlag",
+	      SHOW_STR
+	      ZEBRA_STR
+	      "The mlag role on this machine\n")
+{
+	char buf[MLAG_ROLE_STRSIZE];
+
+	vty_out(vty, "MLag is configured to: %s\n",
+		mlag_role2str(zrouter.mlag_info.role, buf, sizeof(buf)));
+
+	return CMD_SUCCESS;
+}
+
+DEFPY_HIDDEN(test_mlag, test_mlag_cmd,
+	     "test zebra mlag <none$none|primary$primary|secondary$secondary>",
+	     "Test code\n"
+	     ZEBRA_STR
+	     "Modify the Mlag state\n"
+	     "Mlag is not setup on the machine\n"
+	     "Mlag is setup to be primary\n"
+	     "Mlag is setup to be the secondary\n")
+{
+	return zebra_mlag_test_mlag_internal(none, primary, secondary);
+}
+
+void zebra_mlag_vty_init(void)
+{
+	install_element(VIEW_NODE, &show_mlag_cmd);
+	install_element(ENABLE_NODE, &test_mlag_cmd);
+}

--- a/zebra/zebra_mlag_vty.c
+++ b/zebra/zebra_mlag_vty.c
@@ -25,7 +25,7 @@
 #include "command.h"
 
 #include "zebra_router.h"
-#include "zebra_mlag.h"
+#include "zebra_mlag_vty.h"
 #include "debug.h"
 #include "zapi_msg.h"
 

--- a/zebra/zebra_mlag_vty.h
+++ b/zebra/zebra_mlag_vty.h
@@ -1,0 +1,31 @@
+/* Zebra Mlag vty Code.
+ * Copyright (C) 2019 Cumulus Networks, Inc.
+ *                    Donald Sharp
+ *
+ * This file is part of FRR.
+ *
+ * FRR is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * FRR is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FRR; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+#ifndef __ZEBRA_MLAG_VTY_CODE__
+#define __ZEBRA_MLAG_VTY_CODE__
+
+extern int32_t zebra_mlag_test_mlag_internal(const char *none,
+					     const char *primary,
+					     const char *secondary);
+
+extern void zebra_mlag_vty_init(void);
+
+#endif


### PR DESCRIPTION
1) Allow non -j factor compiles to build properly
2) Allow configure to figure out if protobuf version 3 can be compiled
3) Fix a warnings -> error issue for much older compilers