### PR TITLE
bgpd: Deleting BFD peers when BGP session is Down

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1145,6 +1145,8 @@ int bgp_stop(struct peer *peer)
 
 		/* Reset peer synctime */
 		peer->synctime = 0;
+
+		bgp_bfd_deregister_peer(peer);
 	}
 
 	/* stop keepalives */


### PR DESCRIPTION
This fix is required for below Scenario.

1. Configure BGP neighbour.
2. Enable BFD for BGP neighbour.
3. BGP and BFD session are UP.
4. Change the local interface IP.
5. BGP is DOWN but BFD session is not deleted, BFD has the session with stale Local IP.
6. BGP session comes UP with new Local IP, BFD session will never be UP as the  BFD session still has the previously configured local IP.

Signed-off-by: Sayed Mohd Saquib sayed.saquib@broadcom.com