### PR TITLE
lib/skiplist: fix gcc-9 used-uninitialized warning

### DIFF
--- a/lib/skiplist.c
+++ b/lib/skiplist.c
@@ -608,7 +608,7 @@ void skiplist_test(struct vty *vty)
 	struct skiplist *l;
 	register int i, k;
 	void *keys[sampleSize];
-	void *v;
+	void *v = NULL;
 
 	zlog_debug("%s: entry", __func__);
 


### PR DESCRIPTION
Title says it all, just a really weird gcc 9 warning. (weird because it depends on flag combinations including `-fPIC` which really shouldn't affect optimization behaviour...  *headscratch*)