### PR TITLE
BMP: improve active outbound connection details

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1669,26 +1669,21 @@ static void bmp_active_resolved(struct resolver_query *resq, int numaddrs,
 	unsigned i;
 
 	if (numaddrs <= 0) {
-		int ret;
-
+		zlog_warn("bmp[%s]: hostname resolution failed", ba->hostname);
+		ba->curretry += ba->curretry / 2;
 		ba->addrpos = 0;
-		ba->addrtotal = 1;
-		ret = str2sockunion(ba->hostname, &ba->addrs[0]);
-		if (ret < 0) {
-			ba->addrtotal = 0;
-			ba->curretry += ba->curretry / 2;
-			bmp_active_setup(ba);
-			return;
-		}
-	} else {
-		if (numaddrs > (int)array_size(ba->addrs))
-			numaddrs = array_size(ba->addrs);
-
-		ba->addrpos = 0;
-		ba->addrtotal = numaddrs;
-		for (i = 0; i < ba->addrtotal; i++)
-			memcpy(&ba->addrs[i], &addr[i], sizeof(ba->addrs[0]));
+		ba->addrtotal = 0;
+		bmp_active_setup(ba);
+		return;
 	}
+
+	if (numaddrs > (int)array_size(ba->addrs))
+		numaddrs = array_size(ba->addrs);
+
+	ba->addrpos = 0;
+	ba->addrtotal = numaddrs;
+	for (i = 0; i < ba->addrtotal; i++)
+		memcpy(&ba->addrs[i], &addr[i], sizeof(ba->addrs[0]));
 
 	bmp_active_connect(ba);
 }

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -1669,18 +1669,26 @@ static void bmp_active_resolved(struct resolver_query *resq, int numaddrs,
 	unsigned i;
 
 	if (numaddrs <= 0) {
-		zlog_warn("bmp[%s]: hostname resolution failed", ba->hostname);
-		ba->curretry += ba->curretry / 2;
-		bmp_active_setup(ba);
-		return;
-	}
-	if (numaddrs > (int)array_size(ba->addrs))
-		numaddrs = array_size(ba->addrs);
+		int ret;
 
-	ba->addrpos = 0;
-	ba->addrtotal = numaddrs;
-	for (i = 0; i < ba->addrtotal; i++)
-		memcpy(&ba->addrs[i], &addr[i], sizeof(ba->addrs[0]));
+		ba->addrpos = 0;
+		ba->addrtotal = 1;
+		ret = str2sockunion(ba->hostname, &ba->addrs[0]);
+		if (ret < 0) {
+			ba->addrtotal = 0;
+			ba->curretry += ba->curretry / 2;
+			bmp_active_setup(ba);
+			return;
+		}
+	} else {
+		if (numaddrs > (int)array_size(ba->addrs))
+			numaddrs = array_size(ba->addrs);
+
+		ba->addrpos = 0;
+		ba->addrtotal = numaddrs;
+		for (i = 0; i < ba->addrtotal; i++)
+			memcpy(&ba->addrs[i], &addr[i], sizeof(ba->addrs[0]));
+	}
 
 	bmp_active_connect(ba);
 }

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -2133,12 +2133,16 @@ DEFPY(show_bmp,
 
 			frr_each (bmp_session, &bt->sessions, bmp) {
 				uint64_t total;
+				char uptime[BGP_UPTIME_LEN];
 				size_t q, kq;
 
 				pullwr_stats(bmp->pullwr, &total, &q, &kq);
 
-				ttable_add_row(tt, "%s|-|%Lu|%Lu|%Lu|%Lu|%zu|%zu",
-					       bmp->remote,
+				peer_uptime(bmp->t_up.tv_sec, uptime,
+					    sizeof(uptime), false, NULL);
+
+				ttable_add_row(tt, "%s|%s|%Lu|%Lu|%Lu|%Lu|%zu|%zu",
+					       bmp->remote, uptime,
 					       bmp->cnt_update,
 					       bmp->cnt_mirror,
 					       bmp->cnt_mirror_overruns,

--- a/bgpd/bgp_bmp.h
+++ b/bgpd/bgp_bmp.h
@@ -182,6 +182,7 @@ struct bmp_active {
 	unsigned addrpos, addrtotal;
 	union sockunion addrs[8];
 	int socket;
+	const char *last_err;
 	struct thread *t_timer, *t_read, *t_write;
 };
 

--- a/lib/resolver.h
+++ b/lib/resolver.h
@@ -14,7 +14,8 @@
 #include "sockunion.h"
 
 struct resolver_query {
-	void (*callback)(struct resolver_query *, int n, union sockunion *);
+	void (*callback)(struct resolver_query *, const char *errstr, int n,
+			 union sockunion *);
 
 	/* used to immediate provide the result if IP literal is passed in */
 	union sockunion literal_addr;
@@ -24,6 +25,7 @@ struct resolver_query {
 void resolver_init(struct thread_master *tm);
 void resolver_resolve(struct resolver_query *query, int af,
 		      const char *hostname, void (*cb)(struct resolver_query *,
-						       int, union sockunion *));
+						       const char *, int,
+						       union sockunion *));
 
 #endif /* _FRR_RESOLVER_H */

--- a/lib/resolver.h
+++ b/lib/resolver.h
@@ -15,6 +15,10 @@
 
 struct resolver_query {
 	void (*callback)(struct resolver_query *, int n, union sockunion *);
+
+	/* used to immediate provide the result if IP literal is passed in */
+	union sockunion literal_addr;
+	struct thread *literal_cb;
 };
 
 void resolver_init(struct thread_master *tm);

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -238,8 +238,8 @@ nhrp_reg_by_nbma(struct nhrp_nhs *nhs, const union sockunion *nbma_addr)
 	return NULL;
 }
 
-static void nhrp_nhs_resolve_cb(struct resolver_query *q, int n,
-				union sockunion *addrs)
+static void nhrp_nhs_resolve_cb(struct resolver_query *q, const char *errstr,
+				int n, union sockunion *addrs)
 {
 	struct nhrp_nhs *nhs = container_of(q, struct nhrp_nhs, dns_resolve);
 	struct nhrp_interface *nifp = nhs->ifp->info;


### PR DESCRIPTION
Commit titles say it all really...

- support IP literals inside `resolver_resolve()`
- pass down DNS errors to calling daemon
- fix uptime printing for BMP connections
- print list of configured outbound BMP connections

This is on top of #5399 (which I'll click merge on when CI is green).

Fixes: #5401 