### PR TITLE
lib: yang defination for basic routing frr-routing

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -106,6 +106,7 @@ nodist_lib_libfrr_la_SOURCES = \
 	yang/frr-interface.yang.c \
 	yang/frr-route-types.yang.c \
 	yang/frr-vrf.yang.c \
+	yang/frr-routing.yang.c \
 	yang/ietf/ietf-routing-types.yang.c \
 	yang/frr-module-translator.yang.c \
 	# end

--- a/yang/frr-routing.yang
+++ b/yang/frr-routing.yang
@@ -1,0 +1,135 @@
+module frr-routing {
+  yang-version "1.1";
+  namespace "http://frrouting.org/yang/routing";
+  prefix "rt";
+
+  import ietf-yang-types {
+    prefix "yang";
+  }
+
+  import frr-vrf {
+    prefix frr-vrf;
+  }
+
+  organization
+    "Free Range Routing";
+
+  contact
+    "FRR Users List:       <mailto:frog@lists.frrouting.org>
+     FRR Development List: <mailto:dev@lists.frrouting.org>";
+
+  description
+    "This YANG module defines essential components for the management
+     of a routing subsystem.";
+
+  revision 2019-08-15 {
+    description
+      "Initial revision.";
+  }
+
+  /* Identities */
+
+  identity address-family {
+    description
+      "Base identity from which identities describing address
+       families are derived.";
+  }
+
+  identity ipv4 {
+    base address-family;
+    description
+      "This identity represents an IPv4 address family.";
+  }
+
+  identity ipv6 {
+    base address-family;
+    description
+      "This identity represents an IPv6 address family.";
+  }
+
+  identity control-plane-protocol {
+    description
+      "Base identity from which control-plane protocol identities are
+       derived.";
+  }
+
+  identity routing-protocol {
+    base control-plane-protocol;
+    description
+      "Identity from which Layer 3 routing protocol identities are
+       derived.";
+  }
+
+  /* Type Definitions */
+
+  typedef administrative-distance {
+    type uint8 {
+      range "1..255";
+    }
+    description
+      "Admin distance associated with the route.";
+  }
+
+  /* Groupings */
+
+  grouping address-family {
+    description
+      "This grouping provides a leaf identifying an address
+       family.";
+    leaf address-family {
+      type identityref {
+        base address-family;
+      }
+      mandatory true;
+      description
+        "Address family.";
+    }
+  }
+
+  grouping router-id {
+    description
+      "This grouping provides a router ID.";
+    leaf router-id {
+      type yang:dotted-quad;
+      description
+        "A 32-bit number in the form of a dotted quad that is used by
+         some routing protocols identifying a router.";
+      reference
+        "RFC 2328: OSPF Version 2";
+    }
+  }
+
+  /* Data nodes */
+
+  container routing {
+    description
+      "Configuration parameters for the routing subsystem.";
+    container control-plane-protocols {
+      description
+        "Support for control-plane protocol instances.";
+      list control-plane-protocol {
+        key "type name vrf";
+        description
+          "Each entry contains a control-plane protocol instance.";
+        leaf type {
+          type identityref {
+            base control-plane-protocol;
+          }
+          description
+            "Type of the control-plane protocol";
+        }
+        leaf name {
+          type string;
+          description
+            "An arbitrary name of the control-plane protocol
+             instance.";
+        }
+        leaf vrf {
+          type frr-vrf:vrf-ref;
+          description
+            "vrf for control-plane protocol";
+        }
+      }
+    }
+  }
+}

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -24,6 +24,7 @@ dist_yangmodels_DATA += yang/frr-test-module.yang
 dist_yangmodels_DATA += yang/frr-interface.yang
 dist_yangmodels_DATA += yang/frr-vrf.yang
 dist_yangmodels_DATA += yang/frr-route-types.yang
+dist_yangmodels_DATA += yang/frr-routing.yang
 dist_yangmodels_DATA += yang/ietf/ietf-routing-types.yang
 
 if BFDD


### PR DESCRIPTION
Yang files for basic frr-routing used by other
daemons like staticd and pim

Co-authored-by: Santosh P K <sapk@vmware.com>
Co-authored-by: vishaldhingra <vdhingra@vmware.com>
Signed-off-by: vishaldhingra <vdhingra@vmware.com>