### PR TITLE
Fix ospf ip hl trust

### DIFF
--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2318,7 +2318,7 @@ static struct stream *ospf_recv_packet(struct ospf *ospf, int fd,
 				  safe_strerror(errno));
 		return NULL;
 	}
-	if ((unsigned int)ret < sizeof(iph)) /* ret must be > 0 now */
+	if ((unsigned int)ret < sizeof(struct ip))
 	{
 		flog_warn(
 			EC_OSPF_PACKET,

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -2318,8 +2318,7 @@ static struct stream *ospf_recv_packet(struct ospf *ospf, int fd,
 				  safe_strerror(errno));
 		return NULL;
 	}
-	if ((unsigned int)ret < sizeof(struct ip))
-	{
+	if ((unsigned int)ret < sizeof(struct ip)) {
 		flog_warn(
 			EC_OSPF_PACKET,
 			"ospf_recv_packet: discarding runt packet of length %d "


### PR DESCRIPTION
- Fix a 14yo `sizeof(pointer)` bug
- Fix incorrect assumption that the IHL field was sanitized earlier on