### PR TITLE
yang: zebra rib operational model

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -114,6 +114,7 @@ nodist_lib_libfrr_la_SOURCES = \
 	yang/frr-routing.yang.c \
 	yang/ietf/ietf-routing-types.yang.c \
 	yang/frr-module-translator.yang.c \
+	yang/frr-nexthop.yang.c \
 	# end
 
 vtysh_scan += \

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -79,6 +79,7 @@ static const char *const frr_native_modules[] = {
 	"frr-ripngd",
 	"frr-isisd",
 	"frr-vrrpd",
+	"frr-zebra",
 };
 
 /* Generate the yang_modules tree. */

--- a/lib/yang_wrappers.c
+++ b/lib/yang_wrappers.c
@@ -1113,3 +1113,17 @@ void yang_get_default_ip(struct ipaddr *var, const char *xpath_fmt, ...)
 	value = yang_get_default_value(xpath);
 	yang_str2ip(value, var);
 }
+
+struct yang_data *yang_data_new_mac(const char *xpath,
+				    const struct ethaddr *mac)
+{
+	char value_str[ETHER_ADDR_STRLEN];
+
+	prefix_mac2str(mac, value_str, sizeof(value_str));
+	return yang_data_new(xpath, value_str);
+}
+
+void yang_str2mac(const char *value, struct ethaddr *mac)
+{
+    (void)prefix_str2mac(value, mac);
+}

--- a/lib/yang_wrappers.h
+++ b/lib/yang_wrappers.h
@@ -172,4 +172,9 @@ extern void yang_dnode_get_ip(struct ipaddr *addr, const struct lyd_node *dnode,
 			      const char *xpath_fmt, ...);
 extern void yang_get_default_ip(struct ipaddr *var, const char *xpath_fmt, ...);
 
+/* mac */
+extern struct yang_data *yang_data_new_mac(const char *xpath,
+					   const struct ethaddr *mac);
+extern void yang_str2mac(const char *value, struct ethaddr *mac);
+
 #endif /* _FRR_NORTHBOUND_WRAPPERS_H_ */

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -282,36 +282,6 @@ module frr-zebra {
   // End of ip6-route
 
   /*
-   * IP Prefix Route object.
-   */
-
-  grouping ip-route {
-    description
-      "An IPv4/IPv6 prefix route.";
-    leaf prefix {
-      type inet:ip-prefix;
-      description
-        "The route's prefix.";
-    }
-
-    leaf protocol {
-      when "'../../afi-safi-name' = 'ipv4-unicast'";
-      type frr-route-types:frr-route-types-v4;
-      description
-        "The protocol owning the route.";
-    }
-
-    leaf protocol-v6 {
-      when "'../../afi-safi-name' = 'ipv6-unicast'";
-      type frr-route-types:frr-route-types-v6;
-      description
-        "The protocol owning the route.";
-    }
-
-    uses route-common;
-  }
-
-  /*
    * Information about EVPN VNIs
    */
 
@@ -593,7 +563,27 @@ module frr-zebra {
         list route {
           key "prefix";
           config false;
-          uses ip-route;
+          leaf prefix {
+             type inet:ip-prefix;
+             description
+                "The route's prefix.";
+          }
+
+          leaf protocol {
+             when "'../../afi-safi-name' = 'ipv4-unicast'";
+             type frr-route-types:frr-route-types-v4;
+             description
+                "The protocol owning the route.";
+          }
+
+          leaf protocol-v6 {
+             when "'../../afi-safi-name' = 'ipv6-unicast'";
+             type frr-route-types:frr-route-types-v6;
+             description
+                "The protocol owning the route.";
+          }
+
+          uses route-common;
         }
       }
     }

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -161,11 +161,6 @@ module frr-zebra {
   grouping route-common {
     description
       "Common information about a route.";
-    leaf vrf {
-      type frr-vrf:vrf-ref;
-      description
-        "The route's vrf name.";
-    }
 
     leaf distance {
       type uint8;
@@ -568,22 +563,24 @@ module frr-zebra {
              description
                 "The route's prefix.";
           }
+          list route-entry {
+            key "protocol";
+            leaf protocol {
+               type frr-route-types:frr-route-types-v4;
+               //TODO: Use unified route types done in PR 5183 when it is merged.
+               //type frr-route-types:frr-route-types;
+               description
+                  "The protocol owning the route.";
+            }
 
-          leaf protocol {
-             when "'../../afi-safi-name' = 'ipv4-unicast'";
-             type frr-route-types:frr-route-types-v4;
-             description
-                "The protocol owning the route.";
+            leaf instance {
+              type uint16;
+              must "../protocol = \"ospf\"";
+              description
+              "Retrieve routes from a specific OSPF instance.";
+            }
+            uses route-common;
           }
-
-          leaf protocol-v6 {
-             when "'../../afi-safi-name' = 'ipv6-unicast'";
-             type frr-route-types:frr-route-types-v6;
-             description
-                "The protocol owning the route.";
-          }
-
-          uses route-common;
         }
       }
     }
@@ -1933,7 +1930,7 @@ module frr-zebra {
     uses ribs;
   }
 
-  augment "/frr-vrf:lib/frr-vrf:vrf/ribs/rib/route/nexthop-group/frr-nexthops/nexthop" {
+  augment "/frr-vrf:lib/frr-vrf:vrf/ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop" {
     uses frr-nh:frr-nexthop-operational;
   }
 

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -27,6 +27,10 @@ module frr-zebra {
     prefix frr-interface;
   }
 
+  import frr-vrf {
+    prefix frr-vrf;
+  }
+
   organization
     "Free Range Routing";
   contact
@@ -38,6 +42,35 @@ module frr-zebra {
   revision 2019-06-01 {
     description
       "Initial revision.";
+  }
+
+  identity afi-safi-type {
+    description
+      "Base identity type (AFI,SAFI) tuples for RIB";
+  }
+
+  identity ipv4-unicast {
+    base afi-safi-type;
+    description
+      "This identity represents the IPv4 unicast address family.";
+  }
+
+  identity ipv6-unicast {
+    base afi-safi-type;
+    description
+      "This identity represents the IPv6 unicast address family.";
+  }
+
+  identity ipv4-multicast {
+    base afi-safi-type;
+    description
+      "This identity represents the IPv4 multicast address family.";
+  }
+
+  identity ipv6-multicast {
+    base afi-safi-type;
+    description
+      "This identity represents the IPv6 multicast address family.";
   }
 
   typedef unix-timestamp {
@@ -129,9 +162,7 @@ module frr-zebra {
     description
       "Common information about a route.";
     leaf vrf {
-      type string {
-        length "1..36";
-      }
+      type frr-vrf:vrf-ref;
       description
         "The route's vrf name.";
     }
@@ -156,25 +187,25 @@ module frr-zebra {
         "Route tag value.";
     }
 
-    leaf is-selected {
+    leaf selected {
       type empty;
       description
         "Route is the selected or preferred route for the prefix.";
     }
 
-    leaf is-installed {
+    leaf installed {
       type empty;
       description
         "Route is installed in the FIB.";
     }
 
-    leaf is-failed {
+    leaf failed {
       type empty;
       description
         "Route installation in FIB has failed.";
     }
 
-    leaf is-queued {
+    leaf queued {
       type empty;
       description
         "Route has a pending FIB operation that has not completed.";
@@ -193,17 +224,12 @@ module frr-zebra {
     }
 
     leaf uptime {
-      type uint32;
-      units "seconds";
+      type yang:date-and-time;
       description
         "Uptime for the route.";
     }
 
-    container nexthop-group {
-      description
-        "Nexthop information for the route.";
-      uses frr-nh:frr-nexthop-group;
-    }
+    uses frr-nh:frr-nexthop-grouping;
   }
 
   // End of route-common
@@ -246,6 +272,37 @@ module frr-zebra {
     }
 
     leaf protocol {
+      type frr-route-types:frr-route-types-v6;
+      description
+        "The protocol owning the route.";
+    }
+
+    uses route-common;
+  }
+  // End of ip6-route
+
+  /*
+   * IP Prefix Route object.
+   */
+
+  grouping ip-route {
+    description
+      "An IPv4/IPv6 prefix route.";
+    leaf prefix {
+      type inet:ip-prefix;
+      description
+        "The route's prefix.";
+    }
+
+    leaf protocol {
+      when "'../../afi-safi-name' = 'ipv4-unicast'";
+      type frr-route-types:frr-route-types-v4;
+      description
+        "The protocol owning the route.";
+    }
+
+    leaf protocol-v6 {
+      when "'../../afi-safi-name' = 'ipv6-unicast'";
       type frr-route-types:frr-route-types-v6;
       description
         "The protocol owning the route.";
@@ -438,6 +495,7 @@ module frr-zebra {
       description
         "Debug kernel messages sent.";
     }
+
     leaf debug-kernel-msg-recv {
       type boolean;
       description
@@ -511,6 +569,36 @@ module frr-zebra {
     }
   }
 
+  grouping ribs {
+    container ribs {
+      description
+        "RIBs supported by FRR.";
+      list rib {
+        key "afi-safi-name table-id";
+        leaf table-id {
+          type uint32;
+          description
+            "Routing Table id (default id - 254).";
+        }
+
+        leaf afi-safi-name {
+          type identityref {
+            base afi-safi-type;
+          }
+          mandatory true;
+          description
+            "AFI, SAFI name.";
+        }
+
+        list route {
+          key "prefix";
+          config false;
+          uses ip-route;
+        }
+      }
+    }
+  }
+
   // End of zebra container
   /*
    * RPCs
@@ -528,6 +616,7 @@ module frr-zebra {
             description
               "Retrieve IPv4 routes.";
           }
+
           leaf prefix-v4 {
             type inet:ipv4-prefix;
             description
@@ -601,7 +690,7 @@ module frr-zebra {
         type uint32 {
           range "1..65535";
         }
-        must '../protocol = "ospf"';
+        must "../protocol = \"ospf\"";
         description
           "Retrieve routes from a specific OSPF instance.";
       }
@@ -1846,6 +1935,16 @@ module frr-zebra {
       }
       // TODO -- link-params for (experimental/partial TE use in IGP extensions)
     }
+  }
+
+  augment "/frr-vrf:lib/frr-vrf:vrf" {
+    description
+      "Extends VRF model with Zebra-related parameters.";
+    uses ribs;
+  }
+
+  augment "/frr-vrf:lib/frr-vrf:vrf/ribs/rib/route/nexthop-group/frr-nexthops/nexthop" {
+    uses frr-nh:frr-nexthop-operational;
   }
 
   /*

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -57,3 +57,7 @@ endif
 if STATICD
 dist_yangmodels_DATA += yang/frr-staticd.yang
 endif
+
+if ZEBRA
+dist_yangmodels_DATA += yang/frr-zebra.yang
+endif

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -28,6 +28,7 @@ dist_yangmodels_DATA += yang/frr-vrf.yang
 dist_yangmodels_DATA += yang/frr-route-types.yang
 dist_yangmodels_DATA += yang/frr-routing.yang
 dist_yangmodels_DATA += yang/ietf/ietf-routing-types.yang
+dist_yangmodels_DATA += yang/frr-nexthop.yang
 
 if BFDD
 dist_yangmodels_DATA += yang/frr-bfdd.yang

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -54,6 +54,7 @@
 #include "zebra/zebra_pbr.h"
 #include "zebra/zebra_vxlan.h"
 #include "zebra/zebra_routemap.h"
+#include "zebra/zebra_nb.h"
 
 #if defined(HANDLE_NETLINK_FUZZING)
 #include "zebra/kernel_netlink.h"
@@ -245,6 +246,7 @@ struct quagga_signal_t zebra_signals[] = {
 static const struct frr_yang_module_info *const zebra_yang_modules[] = {
 	&frr_interface_info,
 	&frr_route_map_info,
+	&frr_zebra_info,
 	&frr_vrf_info,
 };
 

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -119,6 +119,10 @@ zebra/zebra_vty.$(OBJEXT): zebra/zebra_vty_clippy.c
 zebra/zebra_routemap_clippy.c: $(CLIPPY_DEPS)
 zebra/zebra_routemap.$(OBJEXT): zebra/zebra_routemap_clippy.c
 
+nodist_zebra_zebra_SOURCES = \
+   yang/frr-zebra.yang.c \
+   # end
+
 noinst_HEADERS += \
 	zebra/connected.h \
 	zebra/debug.h \

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -101,6 +101,10 @@ zebra_zebra_SOURCES = \
 	zebra/zebra_netns_notify.c \
 	zebra/table_manager.c \
 	zebra/zapi_msg.c \
+	zebra/zebra_nb.c \
+	zebra/zebra_nb_config.c \
+	zebra/zebra_nb_rpcs.c \
+	zebra/zebra_nb_state.c \
 	zebra/zebra_errors.c \
 	zebra/zebra_gr.c \
 	# end
@@ -168,6 +172,7 @@ noinst_HEADERS += \
 	zebra/zebra_netns_notify.h \
 	zebra/table_manager.h \
 	zebra/zapi_msg.h \
+	zebra/zebra_nb.h \
 	zebra/zebra_errors.h \
 	# end
 

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -410,195 +410,197 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/protocol",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_protocol_get_elem,
+				.get_next = lib_vrf_ribs_rib_route_route_entry_get_next,
+				.get_keys = lib_vrf_ribs_rib_route_route_entry_get_keys,
+				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/protocol-v6",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/protocol",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_protocol_v6_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_protocol_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/vrf",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/instance",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_vrf_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_instance_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/distance",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/distance",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_distance_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_distance_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/metric",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/metric",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_metric_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_metric_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/tag",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/tag",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_tag_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_tag_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/selected",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/selected",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_selected_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_selected_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/installed",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/installed",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_installed_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_installed_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/failed",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/failed",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_failed_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_failed_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/queued",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/queued",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_queued_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_queued_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/internal-flags",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-flags",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_internal_flags_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/internal-status",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-status",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_internal_status_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/uptime",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/uptime",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_uptime_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_uptime_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_nexthop_group_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_nexthop_group_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_nexthop_group_lookup_entry,
+				.get_next = lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_next,
+				.get_keys = lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_keys,
+				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/name",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/name",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_name_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_lookup_entry,
+				.get_next = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next,
+				.get_keys = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys,
+				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/nh-type",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/nh-type",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/vrf",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/vrf",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_vrf_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/gateway",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/gateway",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_gateway_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/interface",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/interface",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_interface_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/bh-type",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/bh-type",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/onlink",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/onlink",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_onlink_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry",
 			.cbs = {
-				.get_next = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next,
-				.get_keys = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys,
-				.lookup_entry = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry,
+				.get_next = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next,
+				.get_keys = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys,
+				.lookup_entry = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/duplicate",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/duplicate",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/recursive",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/recursive",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_recursive_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/active",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/active",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_active_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem,
 			}
 		},
 		{
-			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/fib",
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/fib",
 			.cbs = {
-				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_fib_get_elem,
+				.get_elem = lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem,
 			}
 		},
 		{

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -1,0 +1,608 @@
+/*
+ * Copyright (C) 2020  Cumulus Networks, Inc.
+ * Chirag Shah
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+#include "northbound.h"
+#include "libfrr.h"
+#include "zebra_nb.h"
+
+/* clang-format off */
+const struct frr_yang_module_info frr_zebra_info = {
+	.name = "frr-zebra",
+	.nodes = {
+		{
+			.xpath = "/frr-zebra:get-route-information",
+			.cbs = {
+				.rpc = get_route_information_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-v6-mroute-info",
+			.cbs = {
+				.rpc = get_v6_mroute_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-vrf-info",
+			.cbs = {
+				.rpc = get_vrf_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-vrf-vni-info",
+			.cbs = {
+				.rpc = get_vrf_vni_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-info",
+			.cbs = {
+				.rpc = get_evpn_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-vni-info",
+			.cbs = {
+				.rpc = get_vni_info_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-vni-rmac",
+			.cbs = {
+				.rpc = get_evpn_vni_rmac_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-vni-nexthops",
+			.cbs = {
+				.rpc = get_evpn_vni_nexthops_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:clear-evpn-dup-addr",
+			.cbs = {
+				.rpc = clear_evpn_dup_addr_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-macs",
+			.cbs = {
+				.rpc = get_evpn_macs_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-evpn-arp-cache",
+			.cbs = {
+				.rpc = get_evpn_arp_cache_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-pbr-ipset",
+			.cbs = {
+				.rpc = get_pbr_ipset_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-pbr-iptable",
+			.cbs = {
+				.rpc = get_pbr_iptable_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:get-debugs",
+			.cbs = {
+				.rpc = get_debugs_rpc,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/mcast-rpf-lookup",
+			.cbs = {
+				.modify = zebra_mcast_rpf_lookup_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/ip-forwarding",
+			.cbs = {
+				.modify = zebra_ip_forwarding_modify,
+				.destroy = zebra_ip_forwarding_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/ipv6-forwarding",
+			.cbs = {
+				.modify = zebra_ipv6_forwarding_modify,
+				.destroy = zebra_ipv6_forwarding_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/workqueue-hold-timer",
+			.cbs = {
+				.modify = zebra_workqueue_hold_timer_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/zapi-packets",
+			.cbs = {
+				.modify = zebra_zapi_packets_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/import-kernel-table/table-id",
+			.cbs = {
+				.modify = zebra_import_kernel_table_table_id_modify,
+				.destroy = zebra_import_kernel_table_table_id_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/import-kernel-table/distance",
+			.cbs = {
+				.modify = zebra_import_kernel_table_distance_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/import-kernel-table/route-map",
+			.cbs = {
+				.modify = zebra_import_kernel_table_route_map_modify,
+				.destroy = zebra_import_kernel_table_route_map_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/allow-external-route-update",
+			.cbs = {
+				.create = zebra_allow_external_route_update_create,
+				.destroy = zebra_allow_external_route_update_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/dplane-queue-limit",
+			.cbs = {
+				.modify = zebra_dplane_queue_limit_modify,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/vrf-vni-mapping",
+			.cbs = {
+				.create = zebra_vrf_vni_mapping_create,
+				.destroy = zebra_vrf_vni_mapping_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/vrf-vni-mapping/vni-id",
+			.cbs = {
+				.modify = zebra_vrf_vni_mapping_vni_id_modify,
+				.destroy = zebra_vrf_vni_mapping_vni_id_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/vrf-vni-mapping/prefix-only",
+			.cbs = {
+				.create = zebra_vrf_vni_mapping_prefix_only_create,
+				.destroy = zebra_vrf_vni_mapping_prefix_only_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-events",
+			.cbs = {
+				.modify = zebra_debugs_debug_events_modify,
+				.destroy = zebra_debugs_debug_events_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-zapi-send",
+			.cbs = {
+				.modify = zebra_debugs_debug_zapi_send_modify,
+				.destroy = zebra_debugs_debug_zapi_send_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-zapi-recv",
+			.cbs = {
+				.modify = zebra_debugs_debug_zapi_recv_modify,
+				.destroy = zebra_debugs_debug_zapi_recv_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-zapi-detail",
+			.cbs = {
+				.modify = zebra_debugs_debug_zapi_detail_modify,
+				.destroy = zebra_debugs_debug_zapi_detail_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-kernel",
+			.cbs = {
+				.modify = zebra_debugs_debug_kernel_modify,
+				.destroy = zebra_debugs_debug_kernel_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-kernel-msg-send",
+			.cbs = {
+				.modify = zebra_debugs_debug_kernel_msg_send_modify,
+				.destroy = zebra_debugs_debug_kernel_msg_send_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-kernel-msg-recv",
+			.cbs = {
+				.modify = zebra_debugs_debug_kernel_msg_recv_modify,
+				.destroy = zebra_debugs_debug_kernel_msg_recv_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-rib",
+			.cbs = {
+				.modify = zebra_debugs_debug_rib_modify,
+				.destroy = zebra_debugs_debug_rib_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-rib-detail",
+			.cbs = {
+				.modify = zebra_debugs_debug_rib_detail_modify,
+				.destroy = zebra_debugs_debug_rib_detail_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-fpm",
+			.cbs = {
+				.modify = zebra_debugs_debug_fpm_modify,
+				.destroy = zebra_debugs_debug_fpm_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-nht",
+			.cbs = {
+				.modify = zebra_debugs_debug_nht_modify,
+				.destroy = zebra_debugs_debug_nht_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-nht-detail",
+			.cbs = {
+				.modify = zebra_debugs_debug_nht_detail_modify,
+				.destroy = zebra_debugs_debug_nht_detail_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-mpls",
+			.cbs = {
+				.modify = zebra_debugs_debug_mpls_modify,
+				.destroy = zebra_debugs_debug_mpls_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-vxlan",
+			.cbs = {
+				.modify = zebra_debugs_debug_vxlan_modify,
+				.destroy = zebra_debugs_debug_vxlan_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-pw",
+			.cbs = {
+				.modify = zebra_debugs_debug_pw_modify,
+				.destroy = zebra_debugs_debug_pw_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-dplane",
+			.cbs = {
+				.modify = zebra_debugs_debug_dplane_modify,
+				.destroy = zebra_debugs_debug_dplane_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-dplane-detail",
+			.cbs = {
+				.modify = zebra_debugs_debug_dplane_detail_modify,
+				.destroy = zebra_debugs_debug_dplane_detail_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-zebra:zebra/debugs/debug-mlag",
+			.cbs = {
+				.modify = zebra_debugs_debug_mlag_modify,
+				.destroy = zebra_debugs_debug_mlag_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list",
+			.cbs = {
+				.create = lib_interface_zebra_ip4_addr_list_create,
+				.destroy = lib_interface_zebra_ip4_addr_list_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/ip4-peer",
+			.cbs = {
+				.modify = lib_interface_zebra_ip4_addr_list_ip4_peer_modify,
+				.destroy = lib_interface_zebra_ip4_addr_list_ip4_peer_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/label",
+			.cbs = {
+				.modify = lib_interface_zebra_ip4_addr_list_label_modify,
+				.destroy = lib_interface_zebra_ip4_addr_list_label_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list",
+			.cbs = {
+				.create = lib_interface_zebra_ip6_addr_list_create,
+				.destroy = lib_interface_zebra_ip6_addr_list_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list/label",
+			.cbs = {
+				.modify = lib_interface_zebra_ip6_addr_list_label_modify,
+				.destroy = lib_interface_zebra_ip6_addr_list_label_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/multicast",
+			.cbs = {
+				.modify = lib_interface_zebra_multicast_modify,
+				.destroy = lib_interface_zebra_multicast_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/link-detect",
+			.cbs = {
+				.modify = lib_interface_zebra_link_detect_modify,
+				.destroy = lib_interface_zebra_link_detect_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/shutdown",
+			.cbs = {
+				.modify = lib_interface_zebra_shutdown_modify,
+				.destroy = lib_interface_zebra_shutdown_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/bandwidth",
+			.cbs = {
+				.modify = lib_interface_zebra_bandwidth_modify,
+				.destroy = lib_interface_zebra_bandwidth_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib",
+			.cbs = {
+				.create = lib_vrf_ribs_rib_create,
+				.destroy = lib_vrf_ribs_rib_destroy,
+				.get_next = lib_vrf_ribs_rib_get_next,
+				.get_keys = lib_vrf_ribs_rib_get_keys,
+				.lookup_entry = lib_vrf_ribs_rib_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route",
+			.cbs = {
+				.get_next = lib_vrf_ribs_rib_route_get_next,
+				.get_keys = lib_vrf_ribs_rib_route_get_keys,
+				.lookup_entry = lib_vrf_ribs_rib_route_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/prefix",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_prefix_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/protocol",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_protocol_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/protocol-v6",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_protocol_v6_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/vrf",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_vrf_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/distance",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_distance_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/metric",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_metric_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/tag",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_tag_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/selected",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_selected_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/installed",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_installed_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/failed",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_failed_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/queued",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_queued_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/internal-flags",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_internal_flags_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/internal-status",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_internal_status_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/uptime",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_uptime_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group",
+			.cbs = {
+				.get_next = lib_vrf_ribs_rib_route_nexthop_group_get_next,
+				.get_keys = lib_vrf_ribs_rib_route_nexthop_group_get_keys,
+				.lookup_entry = lib_vrf_ribs_rib_route_nexthop_group_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/name",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_name_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop",
+			.cbs = {
+				.get_next = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next,
+				.get_keys = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys,
+				.lookup_entry = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/nh-type",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/vrf",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_vrf_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/gateway",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_gateway_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/interface",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_interface_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/bh-type",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/onlink",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_onlink_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry",
+			.cbs = {
+				.get_next = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next,
+				.get_keys = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys,
+				.lookup_entry = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/duplicate",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/recursive",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_recursive_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/active",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_active_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/fib",
+			.cbs = {
+				.get_elem = lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_fib_get_elem,
+			}
+		},
+		{
+			.xpath = NULL,
+		},
+	}
+};

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -1,0 +1,367 @@
+/*
+ * Copyright (C) 2020 Cumulus Networks, Inc.
+ *                    Chirag Shah
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef ZEBRA_ZEBRA_NB_H_
+#define ZEBRA_ZEBRA_NB_H_
+
+extern const struct frr_yang_module_info frr_zebra_info;
+
+/* prototypes */
+int get_route_information_rpc(const char *xpath, const struct list *input,
+			      struct list *output);
+int get_v6_mroute_info_rpc(const char *xpath, const struct list *input,
+			   struct list *output);
+int get_vrf_info_rpc(const char *xpath, const struct list *input,
+		     struct list *output);
+int get_vrf_vni_info_rpc(const char *xpath, const struct list *input,
+			 struct list *output);
+int get_evpn_info_rpc(const char *xpath, const struct list *input,
+		      struct list *output);
+int get_vni_info_rpc(const char *xpath, const struct list *input,
+		     struct list *output);
+int get_evpn_vni_rmac_rpc(const char *xpath, const struct list *input,
+			  struct list *output);
+int get_evpn_vni_nexthops_rpc(const char *xpath, const struct list *input,
+			      struct list *output);
+int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
+			    struct list *output);
+int get_evpn_macs_rpc(const char *xpath, const struct list *input,
+		      struct list *output);
+int get_evpn_arp_cache_rpc(const char *xpath, const struct list *input,
+			   struct list *output);
+int get_pbr_ipset_rpc(const char *xpath, const struct list *input,
+		      struct list *output);
+int get_pbr_iptable_rpc(const char *xpath, const struct list *input,
+			struct list *output);
+int get_debugs_rpc(const char *xpath, const struct list *input,
+		   struct list *output);
+int zebra_mcast_rpf_lookup_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource);
+int zebra_ip_forwarding_modify(enum nb_event event,
+			       const struct lyd_node *dnode,
+			       union nb_resource *resource);
+int zebra_ip_forwarding_destroy(enum nb_event event,
+				const struct lyd_node *dnode);
+int zebra_ipv6_forwarding_modify(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource);
+int zebra_ipv6_forwarding_destroy(enum nb_event event,
+				  const struct lyd_node *dnode);
+int zebra_workqueue_hold_timer_modify(enum nb_event event,
+				      const struct lyd_node *dnode,
+				      union nb_resource *resource);
+int zebra_zapi_packets_modify(enum nb_event event, const struct lyd_node *dnode,
+			      union nb_resource *resource);
+int zebra_import_kernel_table_table_id_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource);
+int zebra_import_kernel_table_table_id_destroy(enum nb_event event,
+					       const struct lyd_node *dnode);
+int zebra_import_kernel_table_distance_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource);
+int zebra_import_kernel_table_route_map_modify(enum nb_event event,
+					       const struct lyd_node *dnode,
+					       union nb_resource *resource);
+int zebra_import_kernel_table_route_map_destroy(enum nb_event event,
+						const struct lyd_node *dnode);
+int zebra_allow_external_route_update_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource);
+int zebra_allow_external_route_update_destroy(enum nb_event event,
+					      const struct lyd_node *dnode);
+int zebra_dplane_queue_limit_modify(enum nb_event event,
+				    const struct lyd_node *dnode,
+				    union nb_resource *resource);
+int zebra_vrf_vni_mapping_create(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource);
+int zebra_vrf_vni_mapping_destroy(enum nb_event event,
+				  const struct lyd_node *dnode);
+int zebra_vrf_vni_mapping_vni_id_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource);
+int zebra_vrf_vni_mapping_vni_id_destroy(enum nb_event event,
+					 const struct lyd_node *dnode);
+int zebra_vrf_vni_mapping_prefix_only_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource);
+int zebra_vrf_vni_mapping_prefix_only_destroy(enum nb_event event,
+					      const struct lyd_node *dnode);
+int zebra_debugs_debug_events_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource);
+int zebra_debugs_debug_events_destroy(enum nb_event event,
+				      const struct lyd_node *dnode);
+int zebra_debugs_debug_zapi_send_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource);
+int zebra_debugs_debug_zapi_send_destroy(enum nb_event event,
+					 const struct lyd_node *dnode);
+int zebra_debugs_debug_zapi_recv_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource);
+int zebra_debugs_debug_zapi_recv_destroy(enum nb_event event,
+					 const struct lyd_node *dnode);
+int zebra_debugs_debug_zapi_detail_modify(enum nb_event event,
+					  const struct lyd_node *dnode,
+					  union nb_resource *resource);
+int zebra_debugs_debug_zapi_detail_destroy(enum nb_event event,
+					   const struct lyd_node *dnode);
+int zebra_debugs_debug_kernel_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource);
+int zebra_debugs_debug_kernel_destroy(enum nb_event event,
+				      const struct lyd_node *dnode);
+int zebra_debugs_debug_kernel_msg_send_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource);
+int zebra_debugs_debug_kernel_msg_send_destroy(enum nb_event event,
+					       const struct lyd_node *dnode);
+int zebra_debugs_debug_kernel_msg_recv_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource);
+int zebra_debugs_debug_kernel_msg_recv_destroy(enum nb_event event,
+					       const struct lyd_node *dnode);
+int zebra_debugs_debug_rib_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource);
+int zebra_debugs_debug_rib_destroy(enum nb_event event,
+				   const struct lyd_node *dnode);
+int zebra_debugs_debug_rib_detail_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource);
+int zebra_debugs_debug_rib_detail_destroy(enum nb_event event,
+					  const struct lyd_node *dnode);
+int zebra_debugs_debug_fpm_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource);
+int zebra_debugs_debug_fpm_destroy(enum nb_event event,
+				   const struct lyd_node *dnode);
+int zebra_debugs_debug_nht_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource);
+int zebra_debugs_debug_nht_destroy(enum nb_event event,
+				   const struct lyd_node *dnode);
+int zebra_debugs_debug_nht_detail_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource);
+int zebra_debugs_debug_nht_detail_destroy(enum nb_event event,
+					  const struct lyd_node *dnode);
+int zebra_debugs_debug_mpls_modify(enum nb_event event,
+				   const struct lyd_node *dnode,
+				   union nb_resource *resource);
+int zebra_debugs_debug_mpls_destroy(enum nb_event event,
+				    const struct lyd_node *dnode);
+int zebra_debugs_debug_vxlan_modify(enum nb_event event,
+				    const struct lyd_node *dnode,
+				    union nb_resource *resource);
+int zebra_debugs_debug_vxlan_destroy(enum nb_event event,
+				     const struct lyd_node *dnode);
+int zebra_debugs_debug_pw_modify(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource);
+int zebra_debugs_debug_pw_destroy(enum nb_event event,
+				  const struct lyd_node *dnode);
+int zebra_debugs_debug_dplane_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource);
+int zebra_debugs_debug_dplane_destroy(enum nb_event event,
+				      const struct lyd_node *dnode);
+int zebra_debugs_debug_dplane_detail_modify(enum nb_event event,
+					    const struct lyd_node *dnode,
+					    union nb_resource *resource);
+int zebra_debugs_debug_dplane_detail_destroy(enum nb_event event,
+					     const struct lyd_node *dnode);
+int zebra_debugs_debug_mlag_modify(enum nb_event event,
+				   const struct lyd_node *dnode,
+				   union nb_resource *resource);
+int zebra_debugs_debug_mlag_destroy(enum nb_event event,
+				    const struct lyd_node *dnode);
+int lib_interface_zebra_ip4_addr_list_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource);
+int lib_interface_zebra_ip4_addr_list_destroy(enum nb_event event,
+					      const struct lyd_node *dnode);
+int lib_interface_zebra_ip4_addr_list_ip4_peer_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource);
+int lib_interface_zebra_ip4_addr_list_ip4_peer_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_interface_zebra_ip4_addr_list_label_modify(enum nb_event event,
+						   const struct lyd_node *dnode,
+						   union nb_resource *resource);
+int lib_interface_zebra_ip4_addr_list_label_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_interface_zebra_ip6_addr_list_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource);
+int lib_interface_zebra_ip6_addr_list_destroy(enum nb_event event,
+					      const struct lyd_node *dnode);
+int lib_interface_zebra_ip6_addr_list_label_modify(enum nb_event event,
+						   const struct lyd_node *dnode,
+						   union nb_resource *resource);
+int lib_interface_zebra_ip6_addr_list_label_destroy(
+	enum nb_event event, const struct lyd_node *dnode);
+int lib_interface_zebra_multicast_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource);
+int lib_interface_zebra_multicast_destroy(enum nb_event event,
+					  const struct lyd_node *dnode);
+int lib_interface_zebra_link_detect_modify(enum nb_event event,
+					   const struct lyd_node *dnode,
+					   union nb_resource *resource);
+int lib_interface_zebra_link_detect_destroy(enum nb_event event,
+					    const struct lyd_node *dnode);
+int lib_interface_zebra_shutdown_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource);
+int lib_interface_zebra_shutdown_destroy(enum nb_event event,
+					 const struct lyd_node *dnode);
+int lib_interface_zebra_bandwidth_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource);
+int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
+					  const struct lyd_node *dnode);
+int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
+			    union nb_resource *resource);
+int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode);
+const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,
+				      const void *list_entry);
+int lib_vrf_ribs_rib_get_keys(const void *list_entry,
+			      struct yang_list_keys *keys);
+const void *lib_vrf_ribs_rib_lookup_entry(const void *parent_list_entry,
+					  const struct yang_list_keys *keys);
+const void *lib_vrf_ribs_rib_route_get_next(const void *parent_list_entry,
+					    const void *list_entry);
+int lib_vrf_ribs_rib_route_get_keys(const void *list_entry,
+				    struct yang_list_keys *keys);
+const void *
+lib_vrf_ribs_rib_route_lookup_entry(const void *parent_list_entry,
+				    const struct yang_list_keys *keys);
+struct yang_data *
+lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
+				       const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_protocol_get_elem(const char *xpath,
+					 const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_protocol_v6_get_elem(const char *xpath,
+					    const void *list_entry);
+struct yang_data *lib_vrf_ribs_rib_route_vrf_get_elem(const char *xpath,
+						      const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_distance_get_elem(const char *xpath,
+					 const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_metric_get_elem(const char *xpath,
+				       const void *list_entry);
+struct yang_data *lib_vrf_ribs_rib_route_tag_get_elem(const char *xpath,
+						      const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_selected_get_elem(const char *xpath,
+					 const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_installed_get_elem(const char *xpath,
+					  const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_failed_get_elem(const char *xpath,
+				       const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_queued_get_elem(const char *xpath,
+				       const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_internal_flags_get_elem(const char *xpath,
+					       const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_internal_status_get_elem(const char *xpath,
+						const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_uptime_get_elem(const char *xpath,
+				       const void *list_entry);
+const void *
+lib_vrf_ribs_rib_route_nexthop_group_get_next(const void *parent_list_entry,
+					      const void *list_entry);
+int lib_vrf_ribs_rib_route_nexthop_group_get_keys(const void *list_entry,
+						  struct yang_list_keys *keys);
+const void *lib_vrf_ribs_rib_route_nexthop_group_lookup_entry(
+	const void *parent_list_entry, const struct yang_list_keys *keys);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_name_get_elem(const char *xpath,
+						   const void *list_entry);
+const void *lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next(
+	const void *parent_list_entry, const void *list_entry);
+int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys(
+	const void *list_entry, struct yang_list_keys *keys);
+const void *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_lookup_entry(
+	const void *parent_list_entry, const struct yang_list_keys *keys);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
+	const char *xpath, const void *list_entry);
+const void *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
+	const void *parent_list_entry, const void *list_entry);
+int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
+	const void *list_entry, struct yang_list_keys *keys);
+const void *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
+	const void *parent_list_entry, const struct yang_list_keys *keys);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_active_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
+	const char *xpath, const void *list_entry);
+
+#endif

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -310,58 +310,132 @@ const void *lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next(
 	const void *parent_list_entry, const void *list_entry);
 int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys(
 	const void *list_entry, struct yang_list_keys *keys);
+int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
+			    union nb_resource *resource);
+int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode);
+const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,
+				      const void *list_entry);
+int lib_vrf_ribs_rib_get_keys(const void *list_entry,
+			      struct yang_list_keys *keys);
+const void *lib_vrf_ribs_rib_lookup_entry(const void *parent_list_entry,
+					  const struct yang_list_keys *keys);
+const void *lib_vrf_ribs_rib_route_get_next(const void *parent_list_entry,
+					    const void *list_entry);
+int lib_vrf_ribs_rib_route_get_keys(const void *list_entry,
+				    struct yang_list_keys *keys);
 const void *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_lookup_entry(
+lib_vrf_ribs_rib_route_lookup_entry(const void *parent_list_entry,
+				    const struct yang_list_keys *keys);
+struct yang_data *
+lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
+				       const void *list_entry);
+const void *
+lib_vrf_ribs_rib_route_route_entry_get_next(const void *parent_list_entry,
+					    const void *list_entry);
+int lib_vrf_ribs_rib_route_route_entry_get_keys(const void *list_entry,
+						struct yang_list_keys *keys);
+const void *lib_vrf_ribs_rib_route_route_entry_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
+lib_vrf_ribs_rib_route_route_entry_protocol_get_elem(const char *xpath,
+						     const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_instance_get_elem(const char *xpath,
+						     const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_distance_get_elem(const char *xpath,
+						     const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_metric_get_elem(const char *xpath,
+						   const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_tag_get_elem(const char *xpath,
+						const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_selected_get_elem(const char *xpath,
+						     const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_installed_get_elem(const char *xpath,
+						      const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_failed_get_elem(const char *xpath,
+						   const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_queued_get_elem(const char *xpath,
+						   const void *list_entry);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
-	const char *xpath, const void *list_entry);
+lib_vrf_ribs_rib_route_route_entry_uptime_get_elem(const char *xpath,
+						   const void *list_entry);
+const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_next(
+	const void *parent_list_entry, const void *list_entry);
+int lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_keys(
+	const void *list_entry, struct yang_list_keys *keys);
+const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry(
+	const void *parent_list_entry, const struct yang_list_keys *keys);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
-	const char *xpath, const void *list_entry);
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
 	const char *xpath, const void *list_entry);
 const void *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next(
 	const void *parent_list_entry, const void *list_entry);
-int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
+int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys(
 	const void *list_entry, struct yang_list_keys *keys);
 const void *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
+	const char *xpath, const void *list_entry);
+const void *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
+	const void *parent_list_entry, const void *list_entry);
+int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
+	const void *list_entry, struct yang_list_keys *keys);
+const void *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
+	const void *parent_list_entry, const struct yang_list_keys *keys);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_active_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
 	const char *xpath, const void *list_entry);
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem(
+	const char *xpath, const void *list_entry);
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
 	const char *xpath, const void *list_entry);
 
 #endif

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1,0 +1,1339 @@
+/*
+ * Copyright (C) 2019  Cumulus Networks, Inc.
+ * Chirag Shah
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+#include "northbound.h"
+#include "libfrr.h"
+#include "zebra_nb.h"
+
+/*
+ * XPath: /frr-zebra:zebra/mcast-rpf-lookup
+ */
+int zebra_mcast_rpf_lookup_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/ip-forwarding
+ */
+int zebra_ip_forwarding_modify(enum nb_event event,
+			       const struct lyd_node *dnode,
+			       union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_ip_forwarding_destroy(enum nb_event event,
+				const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/ipv6-forwarding
+ */
+int zebra_ipv6_forwarding_modify(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_ipv6_forwarding_destroy(enum nb_event event,
+				  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/workqueue-hold-timer
+ */
+int zebra_workqueue_hold_timer_modify(enum nb_event event,
+				      const struct lyd_node *dnode,
+				      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/zapi-packets
+ */
+int zebra_zapi_packets_modify(enum nb_event event, const struct lyd_node *dnode,
+			      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/import-kernel-table/table-id
+ */
+int zebra_import_kernel_table_table_id_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_import_kernel_table_table_id_destroy(enum nb_event event,
+					       const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/import-kernel-table/distance
+ */
+int zebra_import_kernel_table_distance_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/import-kernel-table/route-map
+ */
+int zebra_import_kernel_table_route_map_modify(enum nb_event event,
+					       const struct lyd_node *dnode,
+					       union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_import_kernel_table_route_map_destroy(enum nb_event event,
+						const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/allow-external-route-update
+ */
+int zebra_allow_external_route_update_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_allow_external_route_update_destroy(enum nb_event event,
+					      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/dplane-queue-limit
+ */
+int zebra_dplane_queue_limit_modify(enum nb_event event,
+				    const struct lyd_node *dnode,
+				    union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/vrf-vni-mapping
+ */
+int zebra_vrf_vni_mapping_create(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_vrf_vni_mapping_destroy(enum nb_event event,
+				  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/vrf-vni-mapping/vni-id
+ */
+int zebra_vrf_vni_mapping_vni_id_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_vrf_vni_mapping_vni_id_destroy(enum nb_event event,
+					 const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/vrf-vni-mapping/prefix-only
+ */
+int zebra_vrf_vni_mapping_prefix_only_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_vrf_vni_mapping_prefix_only_destroy(enum nb_event event,
+					      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-events
+ */
+int zebra_debugs_debug_events_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_events_destroy(enum nb_event event,
+				      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-zapi-send
+ */
+int zebra_debugs_debug_zapi_send_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_zapi_send_destroy(enum nb_event event,
+					 const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-zapi-recv
+ */
+int zebra_debugs_debug_zapi_recv_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_zapi_recv_destroy(enum nb_event event,
+					 const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-zapi-detail
+ */
+int zebra_debugs_debug_zapi_detail_modify(enum nb_event event,
+					  const struct lyd_node *dnode,
+					  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_zapi_detail_destroy(enum nb_event event,
+					   const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-kernel
+ */
+int zebra_debugs_debug_kernel_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_kernel_destroy(enum nb_event event,
+				      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-kernel-msg-send
+ */
+int zebra_debugs_debug_kernel_msg_send_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_kernel_msg_send_destroy(enum nb_event event,
+					       const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-kernel-msg-recv
+ */
+int zebra_debugs_debug_kernel_msg_recv_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_kernel_msg_recv_destroy(enum nb_event event,
+					       const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-rib
+ */
+int zebra_debugs_debug_rib_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_rib_destroy(enum nb_event event,
+				   const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-rib-detail
+ */
+int zebra_debugs_debug_rib_detail_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_rib_detail_destroy(enum nb_event event,
+					  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-fpm
+ */
+int zebra_debugs_debug_fpm_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_fpm_destroy(enum nb_event event,
+				   const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-nht
+ */
+int zebra_debugs_debug_nht_modify(enum nb_event event,
+				  const struct lyd_node *dnode,
+				  union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_nht_destroy(enum nb_event event,
+				   const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-nht-detail
+ */
+int zebra_debugs_debug_nht_detail_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_nht_detail_destroy(enum nb_event event,
+					  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-mpls
+ */
+int zebra_debugs_debug_mpls_modify(enum nb_event event,
+				   const struct lyd_node *dnode,
+				   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_mpls_destroy(enum nb_event event,
+				    const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-vxlan
+ */
+int zebra_debugs_debug_vxlan_modify(enum nb_event event,
+				    const struct lyd_node *dnode,
+				    union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_vxlan_destroy(enum nb_event event,
+				     const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-pw
+ */
+int zebra_debugs_debug_pw_modify(enum nb_event event,
+				 const struct lyd_node *dnode,
+				 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_pw_destroy(enum nb_event event,
+				  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-dplane
+ */
+int zebra_debugs_debug_dplane_modify(enum nb_event event,
+				     const struct lyd_node *dnode,
+				     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_dplane_destroy(enum nb_event event,
+				      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-dplane-detail
+ */
+int zebra_debugs_debug_dplane_detail_modify(enum nb_event event,
+					    const struct lyd_node *dnode,
+					    union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_dplane_detail_destroy(enum nb_event event,
+					     const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:zebra/debugs/debug-mlag
+ */
+int zebra_debugs_debug_mlag_modify(enum nb_event event,
+				   const struct lyd_node *dnode,
+				   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int zebra_debugs_debug_mlag_destroy(enum nb_event event,
+				    const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list
+ */
+int lib_interface_zebra_ip4_addr_list_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip4_addr_list_destroy(enum nb_event event,
+					      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/ip4-peer
+ */
+int lib_interface_zebra_ip4_addr_list_ip4_peer_modify(
+	enum nb_event event, const struct lyd_node *dnode,
+	union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip4_addr_list_ip4_peer_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/label
+ */
+int lib_interface_zebra_ip4_addr_list_label_modify(enum nb_event event,
+						   const struct lyd_node *dnode,
+						   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip4_addr_list_label_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list
+ */
+int lib_interface_zebra_ip6_addr_list_create(enum nb_event event,
+					     const struct lyd_node *dnode,
+					     union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip6_addr_list_destroy(enum nb_event event,
+					      const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list/label
+ */
+int lib_interface_zebra_ip6_addr_list_label_modify(enum nb_event event,
+						   const struct lyd_node *dnode,
+						   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_ip6_addr_list_label_destroy(
+	enum nb_event event, const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/multicast
+ */
+int lib_interface_zebra_multicast_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_multicast_destroy(enum nb_event event,
+					  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/link-detect
+ */
+int lib_interface_zebra_link_detect_modify(enum nb_event event,
+					   const struct lyd_node *dnode,
+					   union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_link_detect_destroy(enum nb_event event,
+					    const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/shutdown
+ */
+int lib_interface_zebra_shutdown_modify(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_shutdown_destroy(enum nb_event event,
+					 const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/bandwidth
+ */
+int lib_interface_zebra_bandwidth_modify(enum nb_event event,
+					 const struct lyd_node *dnode,
+					 union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
+					  const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib
+ */
+int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
+			    union nb_resource *resource)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}
+
+int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode)
+{
+	switch (event) {
+	case NB_EV_VALIDATE:
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+	case NB_EV_APPLY:
+		/* TODO: implement me. */
+		break;
+	}
+
+	return NB_OK;
+}

--- a/zebra/zebra_nb_rpcs.c
+++ b/zebra/zebra_nb_rpcs.c
@@ -44,7 +44,7 @@ int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
 
 	if (yang_dup_choice
 	    && strcmp(yang_dup_choice->value, "all-case") == 0) {
-		zebra_vxlan_clear_dup_detect_vni_all(NULL, zvrf);
+		zebra_vxlan_clear_dup_detect_vni_all(zvrf);
 	} else {
 		vni_t vni;
 		struct ipaddr host_ip = {.ipa_type = IPADDR_NONE};
@@ -64,7 +64,7 @@ int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
 				"input/clear-dup-choice/single-case/vni-id/vni-ipaddr");
 
 			if (yang_dup_mac) {
-				yang_str2mac(value, &mac);
+				yang_str2mac(yang_dup_mac->value, &mac);
 				ret = zebra_vxlan_clear_dup_detect_vni_mac(
 					zvrf, vni, &mac);
 			} else if (yang_dup_ip) {

--- a/zebra/zebra_nb_rpcs.c
+++ b/zebra/zebra_nb_rpcs.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2020 Cumulus Networks, Inc.
+ *                    Chirag Shah
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+#include "northbound.h"
+#include "libfrr.h"
+
+#include "zebra/zebra_nb.h"
+
+/*
+ * XPath: /frr-zebra:get-route-information
+ */
+int get_route_information_rpc(const char *xpath, const struct list *input,
+			      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-v6-mroute-info
+ */
+int get_v6_mroute_info_rpc(const char *xpath, const struct list *input,
+			   struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-vrf-info
+ */
+int get_vrf_info_rpc(const char *xpath, const struct list *input,
+		     struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-vrf-vni-info
+ */
+int get_vrf_vni_info_rpc(const char *xpath, const struct list *input,
+			 struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-info
+ */
+int get_evpn_info_rpc(const char *xpath, const struct list *input,
+		      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-vni-info
+ */
+int get_vni_info_rpc(const char *xpath, const struct list *input,
+		     struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-vni-rmac
+ */
+int get_evpn_vni_rmac_rpc(const char *xpath, const struct list *input,
+			  struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-vni-nexthops
+ */
+int get_evpn_vni_nexthops_rpc(const char *xpath, const struct list *input,
+			      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:clear-evpn-dup-addr
+ */
+int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
+			    struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-macs
+ */
+int get_evpn_macs_rpc(const char *xpath, const struct list *input,
+		      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-evpn-arp-cache
+ */
+int get_evpn_arp_cache_rpc(const char *xpath, const struct list *input,
+			   struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-pbr-ipset
+ */
+int get_pbr_ipset_rpc(const char *xpath, const struct list *input,
+		      struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-pbr-iptable
+ */
+int get_pbr_iptable_rpc(const char *xpath, const struct list *input,
+			struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+/*
+ * XPath: /frr-zebra:get-debugs
+ */
+int get_debugs_rpc(const char *xpath, const struct list *input,
+		   struct list *output)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}

--- a/zebra/zebra_nb_rpcs.c
+++ b/zebra/zebra_nb_rpcs.c
@@ -22,6 +22,64 @@
 #include "libfrr.h"
 
 #include "zebra/zebra_nb.h"
+#include "zebra/zebra_router.h"
+#include "zebra/zebra_vrf.h"
+#include "zebra/zebra_vxlan.h"
+
+/*
+ * XPath: /frr-zebra:clear-evpn-dup-addr
+ */
+int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
+			    struct list *output)
+{
+	struct zebra_vrf *zvrf;
+	int ret = NB_OK;
+	struct yang_data *yang_dup_choice = NULL, *yang_dup_vni = NULL,
+			 *yang_dup_ip = NULL, *yang_dup_mac = NULL;
+
+	yang_dup_choice = yang_data_list_find(input, "%s/%s", xpath,
+					      "input/clear-dup-choice");
+
+	zvrf = zebra_vrf_get_evpn();
+
+	if (yang_dup_choice
+	    && strcmp(yang_dup_choice->value, "all-case") == 0) {
+		zebra_vxlan_clear_dup_detect_vni_all(NULL, zvrf);
+	} else {
+		vni_t vni;
+		struct ipaddr host_ip = {.ipa_type = IPADDR_NONE};
+		struct ethaddr mac;
+
+		yang_dup_vni = yang_data_list_find(
+			input, "%s/%s", xpath,
+			"input/clear-dup-choice/single-case/vni-id");
+		if (yang_dup_vni) {
+			vni = yang_str2uint32(yang_dup_vni->value);
+
+			yang_dup_mac = yang_data_list_find(
+				input, "%s/%s", xpath,
+				"input/clear-dup-choice/single-case/vni-id/mac-addr");
+			yang_dup_ip = yang_data_list_find(
+				input, "%s/%s", xpath,
+				"input/clear-dup-choice/single-case/vni-id/vni-ipaddr");
+
+			if (yang_dup_mac) {
+				yang_str2mac(value, &mac);
+				ret = zebra_vxlan_clear_dup_detect_vni_mac(
+					zvrf, vni, &mac);
+			} else if (yang_dup_ip) {
+				yang_str2ip(yang_dup_ip->value, &host_ip);
+				ret = zebra_vxlan_clear_dup_detect_vni_ip(
+					zvrf, vni, &host_ip);
+			} else
+				ret = zebra_vxlan_clear_dup_detect_vni(zvrf,
+								       vni);
+		}
+	}
+	ret = (ret != CMD_SUCCESS) ? NB_ERR : NB_OK;
+
+	return ret;
+}
 
 /*
  * XPath: /frr-zebra:get-route-information
@@ -98,16 +156,6 @@ int get_evpn_vni_rmac_rpc(const char *xpath, const struct list *input,
  */
 int get_evpn_vni_nexthops_rpc(const char *xpath, const struct list *input,
 			      struct list *output)
-{
-	/* TODO: implement me. */
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-zebra:clear-evpn-dup-addr
- */
-int clear_evpn_dup_addr_rpc(const char *xpath, const struct list *input,
-			    struct list *output)
 {
 	/* TODO: implement me. */
 	return NB_OK;

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -79,161 +79,24 @@ struct yang_data *lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
 }
 
 /*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/protocol
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry
  */
-struct yang_data *
-lib_vrf_ribs_rib_route_protocol_get_elem(const char *xpath,
-					 const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/protocol-v6
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_protocol_v6_get_elem(const char *xpath,
+const void *
+lib_vrf_ribs_rib_route_route_entry_get_next(const void *parent_list_entry,
 					    const void *list_entry)
 {
 	/* TODO: implement me. */
 	return NULL;
 }
 
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/vrf
- */
-struct yang_data *lib_vrf_ribs_rib_route_vrf_get_elem(const char *xpath,
-						      const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/distance
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_distance_get_elem(const char *xpath,
-					 const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/metric
- */
-struct yang_data *lib_vrf_ribs_rib_route_metric_get_elem(const char *xpath,
-							 const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/tag
- */
-struct yang_data *lib_vrf_ribs_rib_route_tag_get_elem(const char *xpath,
-						      const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/selected
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_selected_get_elem(const char *xpath,
-					 const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/installed
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_installed_get_elem(const char *xpath,
-					  const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/failed
- */
-struct yang_data *lib_vrf_ribs_rib_route_failed_get_elem(const char *xpath,
-							 const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/queued
- */
-struct yang_data *lib_vrf_ribs_rib_route_queued_get_elem(const char *xpath,
-							 const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/internal-flags
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_internal_flags_get_elem(const char *xpath,
-					       const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/internal-status
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_internal_status_get_elem(const char *xpath,
-						const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/uptime
- */
-struct yang_data *lib_vrf_ribs_rib_route_uptime_get_elem(const char *xpath,
-							 const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group
- */
-const void *
-lib_vrf_ribs_rib_route_nexthop_group_get_next(const void *parent_list_entry,
-					      const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-int lib_vrf_ribs_rib_route_nexthop_group_get_keys(const void *list_entry,
-						  struct yang_list_keys *keys)
+int lib_vrf_ribs_rib_route_route_entry_get_keys(const void *list_entry,
+						struct yang_list_keys *keys)
 {
 	/* TODO: implement me. */
 	return NB_OK;
 }
 
-const void *lib_vrf_ribs_rib_route_nexthop_group_lookup_entry(
+const void *lib_vrf_ribs_rib_route_route_entry_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys)
 {
 	/* TODO: implement me. */
@@ -241,10 +104,43 @@ const void *lib_vrf_ribs_rib_route_nexthop_group_lookup_entry(
 }
 
 /*
- * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/name
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/protocol
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_name_get_elem(const char *xpath,
+lib_vrf_ribs_rib_route_route_entry_protocol_get_elem(const char *xpath,
+						     const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/instance
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_instance_get_elem(const char *xpath,
+						     const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/distance
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_distance_get_elem(const char *xpath,
+						     const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/metric
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_metric_get_elem(const char *xpath,
 						   const void *list_entry)
 {
 	/* TODO: implement me. */
@@ -252,25 +148,109 @@ lib_vrf_ribs_rib_route_nexthop_group_name_get_elem(const char *xpath,
 }
 
 /*
- * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/tag
  */
-const void *lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next(
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_tag_get_elem(const char *xpath,
+						const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/selected
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_selected_get_elem(const char *xpath,
+						     const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/installed
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_installed_get_elem(const char *xpath,
+						      const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/failed
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_failed_get_elem(const char *xpath,
+						   const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/queued
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_queued_get_elem(const char *xpath,
+						   const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-flags
+ */
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_flags_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/internal-status
+ */
+struct yang_data *lib_vrf_ribs_rib_route_route_entry_internal_status_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/uptime
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_uptime_get_elem(const char *xpath,
+						   const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group
+ */
+const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_next(
 	const void *parent_list_entry, const void *list_entry)
 {
 	/* TODO: implement me. */
 	return NULL;
 }
 
-int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys(
+int lib_vrf_ribs_rib_route_route_entry_nexthop_group_get_keys(
 	const void *list_entry, struct yang_list_keys *keys)
 {
 	/* TODO: implement me. */
 	return NB_OK;
 }
 
-const void *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_lookup_entry(
+const void *lib_vrf_ribs_rib_route_route_entry_nexthop_group_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys)
 {
 	/* TODO: implement me. */
@@ -279,10 +259,10 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_lookup_entry(
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/nh-type
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/name
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_name_get_elem(
 	const char *xpath, const void *list_entry)
 {
 	/* TODO: implement me. */
@@ -291,77 +271,17 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/vrf
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
-	const char *xpath, const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/gateway
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
-	const char *xpath, const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/interface
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
-	const char *xpath, const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/bh-type
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
-	const char *xpath, const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/onlink
- */
-struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
-	const char *xpath, const void *list_entry)
-{
-	/* TODO: implement me. */
-	return NULL;
-}
-
-/*
- * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop
  */
 const void *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_next(
 	const void *parent_list_entry, const void *list_entry)
 {
 	/* TODO: implement me. */
 	return NULL;
 }
 
-int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
+int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_get_keys(
 	const void *list_entry, struct yang_list_keys *keys)
 {
 	/* TODO: implement me. */
@@ -369,7 +289,7 @@ int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_e
 }
 
 const void *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_lookup_entry(
 	const void *parent_list_entry, const struct yang_list_keys *keys)
 {
 	/* TODO: implement me. */
@@ -378,10 +298,10 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/nh-type
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
 	const char *xpath, const void *list_entry)
 {
 	/* TODO: implement me. */
@@ -390,10 +310,10 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/vrf
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
 	const char *xpath, const void *list_entry)
 {
 	/* TODO: implement me. */
@@ -402,10 +322,10 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/gateway
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
 	const char *xpath, const void *list_entry)
 {
 	/* TODO: implement me. */
@@ -414,10 +334,10 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/interface
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
 	const char *xpath, const void *list_entry)
 {
 	/* TODO: implement me. */
@@ -426,10 +346,10 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/duplicate
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/bh-type
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
 	const char *xpath, const void *list_entry)
 {
 	/* TODO: implement me. */
@@ -438,10 +358,10 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/recursive
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/onlink
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
 	const char *xpath, const void *list_entry)
 {
 	/* TODO: implement me. */
@@ -450,10 +370,37 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/active
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry
+ */
+const void *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
+	const void *parent_list_entry, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+int lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
+	const void *list_entry, struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+const void *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
+	const void *parent_list_entry, const struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_active_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
 	const char *xpath, const void *list_entry)
 {
 	/* TODO: implement me. */
@@ -462,10 +409,82 @@ lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_active_get_elem(
 
 /*
  * XPath:
- * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/fib
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label
  */
 struct yang_data *
-lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/duplicate
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/recursive
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/active
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_active_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/route-entry/nexthop-group/frr-nexthops/nexthop/fib
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_route_entry_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
 	const char *xpath, const void *list_entry)
 {
 	/* TODO: implement me. */

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -1,0 +1,473 @@
+/*
+ * Copyright (C) 2020  Cumulus Networks, Inc.
+ * Chirag Shah
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+#include "northbound.h"
+#include "libfrr.h"
+#include "zebra_nb.h"
+
+const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,
+				      const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+int lib_vrf_ribs_rib_get_keys(const void *list_entry,
+			      struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+const void *lib_vrf_ribs_rib_lookup_entry(const void *parent_list_entry,
+					  const struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route
+ */
+const void *lib_vrf_ribs_rib_route_get_next(const void *parent_list_entry,
+					    const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+int lib_vrf_ribs_rib_route_get_keys(const void *list_entry,
+				    struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+const void *
+lib_vrf_ribs_rib_route_lookup_entry(const void *parent_list_entry,
+				    const struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/prefix
+ */
+struct yang_data *lib_vrf_ribs_rib_route_prefix_get_elem(const char *xpath,
+							 const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/protocol
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_protocol_get_elem(const char *xpath,
+					 const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/protocol-v6
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_protocol_v6_get_elem(const char *xpath,
+					    const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/vrf
+ */
+struct yang_data *lib_vrf_ribs_rib_route_vrf_get_elem(const char *xpath,
+						      const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/distance
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_distance_get_elem(const char *xpath,
+					 const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/metric
+ */
+struct yang_data *lib_vrf_ribs_rib_route_metric_get_elem(const char *xpath,
+							 const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/tag
+ */
+struct yang_data *lib_vrf_ribs_rib_route_tag_get_elem(const char *xpath,
+						      const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/selected
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_selected_get_elem(const char *xpath,
+					 const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/installed
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_installed_get_elem(const char *xpath,
+					  const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/failed
+ */
+struct yang_data *lib_vrf_ribs_rib_route_failed_get_elem(const char *xpath,
+							 const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/queued
+ */
+struct yang_data *lib_vrf_ribs_rib_route_queued_get_elem(const char *xpath,
+							 const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/internal-flags
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_internal_flags_get_elem(const char *xpath,
+					       const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/internal-status
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_internal_status_get_elem(const char *xpath,
+						const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/uptime
+ */
+struct yang_data *lib_vrf_ribs_rib_route_uptime_get_elem(const char *xpath,
+							 const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group
+ */
+const void *
+lib_vrf_ribs_rib_route_nexthop_group_get_next(const void *parent_list_entry,
+					      const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+int lib_vrf_ribs_rib_route_nexthop_group_get_keys(const void *list_entry,
+						  struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+const void *lib_vrf_ribs_rib_route_nexthop_group_lookup_entry(
+	const void *parent_list_entry, const struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/name
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_name_get_elem(const char *xpath,
+						   const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop
+ */
+const void *lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_next(
+	const void *parent_list_entry, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_get_keys(
+	const void *list_entry, struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+const void *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_lookup_entry(
+	const void *parent_list_entry, const struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/nh-type
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_nh_type_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/vrf
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_vrf_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/gateway
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_gateway_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/interface
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_interface_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/bh-type
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_bh_type_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/onlink
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_onlink_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry
+ */
+const void *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_next(
+	const void *parent_list_entry, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+int lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_get_keys(
+	const void *list_entry, struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NB_OK;
+}
+
+const void *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_lookup_entry(
+	const void *parent_list_entry, const struct yang_list_keys *keys)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/id
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_id_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/label
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_label_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/ttl
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_ttl_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/mpls-label-stack/entry/traffic-class
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_mpls_label_stack_entry_traffic_class_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/duplicate
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_duplicate_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/recursive
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_recursive_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/active
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_active_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath:
+ * /frr-vrf:lib/vrf/frr-zebra:ribs/rib/route/nexthop-group/frr-nexthops/nexthop/fib
+ */
+struct yang_data *
+lib_vrf_ribs_rib_route_nexthop_group_frr_nexthops_nexthop_fib_get_elem(
+	const char *xpath, const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -54,6 +54,7 @@
 #include "zebra/zebra_pbr.h"
 #include "zebra/zebra_nhg.h"
 #include "zebra/interface.h"
+#include "northbound_cli.h"
 
 extern int allow_delete;
 
@@ -2893,15 +2894,28 @@ DEFPY (clear_evpn_dup_addr,
        "IPv4 address\n"
        "IPv6 address\n")
 {
-	struct zebra_vrf *zvrf;
 	struct ipaddr host_ip = {.ipa_type = IPADDR_NONE };
 	int ret = CMD_SUCCESS;
+	struct list *input;
+	struct yang_data *yang_dup = NULL, *yang_dup_ip = NULL,
+			 *yang_dup_mac = NULL;
 
-	zvrf = zebra_vrf_get_evpn();
-	if (vni_str) {
+	input = list_new();
+
+	if (!vni_str) {
+		yang_dup = yang_data_new(
+			"/frr-zebra:clear-evpn-dup-addr/input/clear-dup-choice",
+			"all-case");
+	} else {
+		yang_dup = yang_data_new_uint32(
+			"/frr-zebra:clear-evpn-dup-addr/input/clear-dup-choice/single-case/vni-id",
+			vni);
 		if (!is_zero_mac(&mac->eth_addr)) {
-			ret = zebra_vxlan_clear_dup_detect_vni_mac(
-				zvrf, vni, &mac->eth_addr);
+			yang_dup_mac = yang_data_new_mac(
+				"/frr-zebra:clear-evpn-dup-addr/input/clear-dup-choice/single-case/vni-id/mac-addr",
+				&mac->eth_addr);
+			if (yang_dup_mac)
+				listnode_add(input, yang_dup_mac);
 		} else if (ip) {
 			if (sockunion_family(ip) == AF_INET) {
 				host_ip.ipa_type = IPADDR_V4;
@@ -2911,14 +2925,22 @@ DEFPY (clear_evpn_dup_addr,
 				memcpy(&host_ip.ipaddr_v6, &ip->sin6.sin6_addr,
 				       sizeof(struct in6_addr));
 			}
-			ret = zebra_vxlan_clear_dup_detect_vni_ip(zvrf, vni,
-								  &host_ip);
-		} else
-			ret = zebra_vxlan_clear_dup_detect_vni(zvrf, vni);
 
-	} else {
-		ret = zebra_vxlan_clear_dup_detect_vni_all(zvrf);
+			yang_dup_ip = yang_data_new_ip(
+				"/frr-zebra:clear-evpn-dup-addr/input/clear-dup-choice/single-case/vni-id/vni-ipaddr",
+				&host_ip);
+
+			if (yang_dup_ip)
+				listnode_add(input, yang_dup_ip);
+		}
 	}
+
+	if (yang_dup) {
+		listnode_add(input, yang_dup);
+		ret = nb_cli_rpc("/frr-zebra:clear-evpn-dup-addr", input, NULL);
+	}
+
+	list_delete(&input);
 
 	return ret;
 }

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -2900,10 +2900,9 @@ DEFPY (clear_evpn_dup_addr,
 	zvrf = zebra_vrf_get_evpn();
 	if (vni_str) {
 		if (!is_zero_mac(&mac->eth_addr)) {
-			ret = zebra_vxlan_clear_dup_detect_vni_mac(vty, zvrf,
-								   vni,
-								   &mac->eth_addr);
-	        } else if (ip) {
+			ret = zebra_vxlan_clear_dup_detect_vni_mac(
+				zvrf, vni, &mac->eth_addr);
+		} else if (ip) {
 			if (sockunion_family(ip) == AF_INET) {
 				host_ip.ipa_type = IPADDR_V4;
 				host_ip.ipaddr_v4.s_addr = sockunion2ip(ip);
@@ -2912,14 +2911,13 @@ DEFPY (clear_evpn_dup_addr,
 				memcpy(&host_ip.ipaddr_v6, &ip->sin6.sin6_addr,
 				       sizeof(struct in6_addr));
 			}
-			ret = zebra_vxlan_clear_dup_detect_vni_ip(vty, zvrf,
-								  vni,
+			ret = zebra_vxlan_clear_dup_detect_vni_ip(zvrf, vni,
 								  &host_ip);
 		} else
-			ret = zebra_vxlan_clear_dup_detect_vni(vty, zvrf, vni);
+			ret = zebra_vxlan_clear_dup_detect_vni(zvrf, vni);
 
 	} else {
-		ret = zebra_vxlan_clear_dup_detect_vni_all(vty, zvrf);
+		ret = zebra_vxlan_clear_dup_detect_vni_all(zvrf);
 	}
 
 	return ret;

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -6848,9 +6848,8 @@ void zebra_vxlan_print_macs_vni_dad(struct vty *vty,
 
 }
 
-int zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
-					 struct zebra_vrf *zvrf,
-					 vni_t vni, struct ethaddr *macaddr)
+int zebra_vxlan_clear_dup_detect_vni_mac(struct zebra_vrf *zvrf, vni_t vni,
+					 struct ethaddr *macaddr)
 {
 	zebra_vni_t *zvni;
 	zebra_mac_t *mac;
@@ -6858,24 +6857,23 @@ int zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
 	zebra_neigh_t *nbr = NULL;
 
 	if (!is_evpn_enabled())
-		return CMD_SUCCESS;
+		return 0;
 
 	zvni = zvni_lookup(vni);
 	if (!zvni) {
-		vty_out(vty, "%% VNI %u does not exist\n", vni);
-		return CMD_WARNING;
+		zlog_warn("VNI %u does not exist\n", vni);
+		return -1;
 	}
 
 	mac = zvni_mac_lookup(zvni, macaddr);
 	if (!mac) {
-		vty_out(vty, "%% Requested MAC does not exist in VNI %u\n",
-			vni);
-		return CMD_WARNING;
+		zlog_warn("Requested MAC does not exist in VNI %u\n", vni);
+		return -1;
 	}
 
 	if (!CHECK_FLAG(mac->flags, ZEBRA_MAC_DUPLICATE)) {
-		vty_out(vty, "%% Requested MAC is not duplicate detected\n");
-		return CMD_WARNING;
+		zlog_warn("Requested MAC is not duplicate detected\n");
+		return -1;
 	}
 
 	/* Remove all IPs as duplicate associcated with this MAC */
@@ -6910,7 +6908,7 @@ int zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
 
 	/* warn-only action return */
 	if (!zvrf->dad_freeze)
-		return CMD_SUCCESS;
+		return 0;
 
 	/* Local: Notify Peer VTEPs, Remote: Install the entry */
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_LOCAL)) {
@@ -6919,7 +6917,7 @@ int zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
 					&mac->macaddr,
 					mac->flags,
 					mac->loc_seq))
-			return CMD_SUCCESS;
+			return 0;
 
 		/* Process all neighbors associated with this MAC. */
 		zvni_process_neigh_on_local_mac_change(zvni, mac, 0);
@@ -6931,12 +6929,11 @@ int zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
 		zvni_mac_install(zvni, mac);
 	}
 
-	return CMD_SUCCESS;
+	return 0;
 }
 
-int zebra_vxlan_clear_dup_detect_vni_ip(struct vty *vty,
-					struct zebra_vrf *zvrf,
-					vni_t vni, struct ipaddr *ip)
+int zebra_vxlan_clear_dup_detect_vni_ip(struct zebra_vrf *zvrf, vni_t vni,
+					struct ipaddr *ip)
 {
 	zebra_vni_t *zvni;
 	zebra_neigh_t *nbr;
@@ -6945,38 +6942,35 @@ int zebra_vxlan_clear_dup_detect_vni_ip(struct vty *vty,
 	char buf2[ETHER_ADDR_STRLEN];
 
 	if (!is_evpn_enabled())
-		return CMD_SUCCESS;
+		return 0;
 
 	zvni = zvni_lookup(vni);
 	if (!zvni) {
-		vty_out(vty, "%% VNI %u does not exist\n", vni);
-		return CMD_WARNING;
+		zlog_debug("VNI %u does not exist\n", vni);
+		return -1;
 	}
 
 	nbr = zvni_neigh_lookup(zvni, ip);
 	if (!nbr) {
-		vty_out(vty,
-			"%% Requested host IP does not exist in VNI %u\n",
-			vni);
-		return CMD_WARNING;
+		zlog_warn("Requested host IP does not exist in VNI %u\n", vni);
+		return -1;
 	}
 
 	ipaddr2str(&nbr->ip, buf, sizeof(buf));
 
 	if (!CHECK_FLAG(nbr->flags, ZEBRA_NEIGH_DUPLICATE)) {
-		vty_out(vty,
-			"%% Requested host IP %s is not duplicate detected\n",
-			buf);
-		return CMD_WARNING;
+		zlog_warn("Requested host IP %s is not duplicate detected\n",
+			  buf);
+		return -1;
 	}
 
 	mac = zvni_mac_lookup(zvni, &nbr->emac);
 
 	if (CHECK_FLAG(mac->flags, ZEBRA_MAC_DUPLICATE)) {
-		vty_out(vty,
-			"%% Requested IP's associated MAC %s is still in duplicate state\n",
+		zlog_warn(
+			"Requested IP's associated MAC %s is still in duplicate state\n",
 			prefix_mac2str(&nbr->emac, buf2, sizeof(buf2)));
-		return CMD_WARNING_CONFIG_FAILED;
+		return -1;
 	}
 
 	if (IS_ZEBRA_DEBUG_VXLAN)
@@ -6998,7 +6992,7 @@ int zebra_vxlan_clear_dup_detect_vni_ip(struct vty *vty,
 		zvni_neigh_install(zvni, nbr);
 	}
 
-	return CMD_SUCCESS;
+	return 0;
 }
 
 static void zvni_clear_dup_mac_hash(struct hash_bucket *bucket, void *ctxt)
@@ -7097,7 +7091,6 @@ static void zvni_clear_dup_neigh_hash(struct hash_bucket *bucket, void *ctxt)
 static void zvni_clear_dup_detect_hash_vni_all(struct hash_bucket *bucket,
 					    void **args)
 {
-	struct vty *vty;
 	zebra_vni_t *zvni;
 	struct zebra_vrf *zvrf;
 	struct mac_walk_ctx m_wctx;
@@ -7107,12 +7100,10 @@ static void zvni_clear_dup_detect_hash_vni_all(struct hash_bucket *bucket,
 	if (!zvni)
 		return;
 
-	vty = (struct vty *)args[0];
-	zvrf = (struct zebra_vrf *)args[1];
+	zvrf = (struct zebra_vrf *)args[0];
 
 	if (hashcount(zvni->neigh_table)) {
 		memset(&n_wctx, 0, sizeof(struct neigh_walk_ctx));
-		n_wctx.vty = vty;
 		n_wctx.zvni = zvni;
 		n_wctx.zvrf = zvrf;
 		hash_iterate(zvni->neigh_table, zvni_clear_dup_neigh_hash,
@@ -7122,51 +7113,45 @@ static void zvni_clear_dup_detect_hash_vni_all(struct hash_bucket *bucket,
 	if (num_valid_macs(zvni)) {
 		memset(&m_wctx, 0, sizeof(struct mac_walk_ctx));
 		m_wctx.zvni = zvni;
-		m_wctx.vty = vty;
 		m_wctx.zvrf = zvrf;
 		hash_iterate(zvni->mac_table, zvni_clear_dup_mac_hash, &m_wctx);
 	}
 
 }
 
-int zebra_vxlan_clear_dup_detect_vni_all(struct vty *vty,
-					  struct zebra_vrf *zvrf)
+int zebra_vxlan_clear_dup_detect_vni_all(struct zebra_vrf *zvrf)
 {
-	void *args[2];
+	void *args[1];
 
 	if (!is_evpn_enabled())
-		return CMD_SUCCESS;
+		return 0;
 
-	args[0] = vty;
-	args[1] = zvrf;
+	args[0] = zvrf;
 
 	hash_iterate(zvrf->vni_table,
 		     (void (*)(struct hash_bucket *, void *))
 		     zvni_clear_dup_detect_hash_vni_all, args);
 
-	return CMD_SUCCESS;
+	return 0;
 }
 
-int  zebra_vxlan_clear_dup_detect_vni(struct vty *vty,
-				      struct zebra_vrf *zvrf,
-				      vni_t vni)
+int zebra_vxlan_clear_dup_detect_vni(struct zebra_vrf *zvrf, vni_t vni)
 {
 	zebra_vni_t *zvni;
 	struct mac_walk_ctx m_wctx;
 	struct neigh_walk_ctx n_wctx;
 
 	if (!is_evpn_enabled())
-		return CMD_SUCCESS;
+		return 0;
 
 	zvni = zvni_lookup(vni);
 	if (!zvni) {
-		vty_out(vty, "%% VNI %u does not exist\n", vni);
-		return CMD_WARNING;
+		zlog_warn("VNI %u does not exist\n", vni);
+		return -1;
 	}
 
 	if (hashcount(zvni->neigh_table)) {
 		memset(&n_wctx, 0, sizeof(struct neigh_walk_ctx));
-		n_wctx.vty = vty;
 		n_wctx.zvni = zvni;
 		n_wctx.zvrf = zvrf;
 		hash_iterate(zvni->neigh_table, zvni_clear_dup_neigh_hash,
@@ -7176,12 +7161,11 @@ int  zebra_vxlan_clear_dup_detect_vni(struct vty *vty,
 	if (num_valid_macs(zvni)) {
 		memset(&m_wctx, 0, sizeof(struct mac_walk_ctx));
 		m_wctx.zvni = zvni;
-		m_wctx.vty = vty;
 		m_wctx.zvrf = zvrf;
 		hash_iterate(zvni->mac_table, zvni_clear_dup_mac_hash, &m_wctx);
 	}
 
-	return CMD_SUCCESS;
+	return 0;
 }
 
 /*
@@ -7412,7 +7396,7 @@ void zebra_vxlan_dup_addr_detection(ZAPI_HANDLER_ARGS)
 	 * clear all duplicate detected addresses.
 	 */
 	if (zvrf->dup_addr_detect && !dup_addr_detect)
-		zebra_vxlan_clear_dup_detect_vni_all(NULL, zvrf);
+		zebra_vxlan_clear_dup_detect_vni_all(zvrf);
 
 	zvrf->dup_addr_detect = dup_addr_detect;
 	zvrf->dad_time = time;

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -205,18 +205,13 @@ extern void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id,
 extern void zebra_vxlan_evpn_vrf_route_del(vrf_id_t vrf_id,
 					   struct ipaddr *vtep_ip,
 					   struct prefix *host_prefix);
-extern int zebra_vxlan_clear_dup_detect_vni_mac(struct vty *vty,
-						struct zebra_vrf *zvrf,
+extern int zebra_vxlan_clear_dup_detect_vni_mac(struct zebra_vrf *zvrf,
 						vni_t vni,
 						struct ethaddr *macaddr);
-extern int zebra_vxlan_clear_dup_detect_vni_ip(struct vty *vty,
-					       struct zebra_vrf *zvrf,
+extern int zebra_vxlan_clear_dup_detect_vni_ip(struct zebra_vrf *zvrf,
 					       vni_t vni, struct ipaddr *ip);
-extern int zebra_vxlan_clear_dup_detect_vni_all(struct vty *vty,
-						struct zebra_vrf *zvrf);
-extern int zebra_vxlan_clear_dup_detect_vni(struct vty *vty,
-					    struct zebra_vrf *zvrf,
-					    vni_t vni);
+extern int zebra_vxlan_clear_dup_detect_vni_all(struct zebra_vrf *zvrf);
+extern int zebra_vxlan_clear_dup_detect_vni(struct zebra_vrf *zvrf, vni_t vni);
 extern void zebra_vxlan_handle_result(struct zebra_dplane_ctx *ctx);
 
 extern void zebra_evpn_init(void);


### PR DESCRIPTION
zebra's rib operational model under vrf.

```
module: frr-zebra
  +--rw zebra
  augment /frr-vrf:lib/frr-vrf:vrf:
    +--rw ribs
       +--rw rib* [table-id]
          +--rw table-id         uint32 <254>
          +--rw afi-safi-name    identityref
          +--ro route* [prefix]
             +--ro prefix             ietf-inet-types:ip-prefix
             +--ro protocol?          frr-route-types:frr-route-types-v4
             +--ro protocol-v6?       frr-route-types:frr-route-types-v6
             +--ro vrf?               frr-vrf:vrf-ref
             +--ro distance?          uint8
             +--ro metric?            uint32
             +--ro tag?               uint32
             +--ro selected?          empty
             +--ro installed?         empty
             +--ro failed?            empty
             +--ro queued?            empty
             +--ro internal-flags?    int32
             +--ro internal-status?   int32
             +--ro uptime?            ietf-yang-types:date-and-time
             +--ro nexthop-group
                +--ro name?    string
                +--ro entry* [id]
                   +--ro id                  uint32
                   +--ro nh-type             frr-nexthop:nexthop-type
                   +--ro gateway?            frr-nexthop:gateway-address
                   +--ro vrf?                frr-vrf:vrf-ref
                   +--ro interface?          frr-interface:interface-ref
                   +--ro bh-type?            frr-nexthop:blackhole-type
                   +--ro flags?              uint32
                   +--ro is-duplicate?       empty
                   +--ro is-recursive?       empty
                   +--ro is-onlink?          empty
                   +--ro is-active?          empty
                   +--ro mpls-label-stack
                   |  +--ro entry* [id]
                   |     +--ro id               uint8
                   |     +--ro label?           ietf-routing-types:mpls-label
                   |     +--ro ttl?             uint8
                   |     +--ro traffic-class?   uint8
                   +--ro mtu?                uint32
```

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>