### PR TITLE
yang: igmp yang definition

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -115,6 +115,7 @@ nodist_lib_libfrr_la_SOURCES = \
 	yang/ietf/ietf-routing-types.yang.c \
 	yang/frr-module-translator.yang.c \
 	yang/frr-nexthop.yang.c \
+	yang/frr-igmp.yang.c \
 	# end
 
 vtysh_scan += \

--- a/yang/frr-igmp.yang
+++ b/yang/frr-igmp.yang
@@ -1,0 +1,147 @@
+module frr-igmp {
+  yang-version "1.1";
+  namespace "http://frrouting.org/yang/igmp";
+
+  prefix frr-igmp;
+
+  import frr-routing {
+    prefix "frr-rt";
+  }
+
+  import ietf-routing-types {
+    prefix "rt-types";
+  }
+
+  import ietf-inet-types {
+    prefix "inet";
+  }
+
+  import frr-interface {
+    prefix frr-interface;
+  }
+
+  organization
+    "Free Range Routing";
+
+  contact
+    "FRR Users List:       <mailto:frog@lists.frrouting.org>
+     FRR Development List: <mailto:dev@lists.frrouting.org>";
+
+  description
+    "This module defines a model for managing FRR pimd daemon.";
+
+  revision 2019-11-06 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 2236: IGMP v2.
+       RFC 3376: IGMP v3.";
+  }
+
+  grouping interface-config-attributes {
+    description
+      "Configuration attributes applied to the interface level.";
+
+    leaf igmp-enable {
+      type boolean;
+      default "false";
+      description
+        "Enable IGMP protocol on the interface.";
+    }
+
+    leaf version {
+      type uint8 {
+        range "2..3";
+      }
+      default "3";
+      description
+        "IGMP version.";
+    }
+
+    leaf query-interval {
+      type uint16 {
+        range "1..1800";
+      }
+      units seconds;
+      default "125";
+      description
+        "The Query Interval is the interval between General Queries
+         sent by the Querier.";
+    }
+
+    leaf query-max-response-time {
+      type uint8 {
+        range "10..250";
+      }
+      units deciseconds;
+      default "100";
+      description
+        "Query maximum response time specifies the maximum time
+         allowed before sending a responding report.";
+    }
+
+    leaf last-member-query-interval {
+      type uint8 {
+        range "1..255";
+      }
+      units deciseconds;
+      default "10";
+      description
+        "Last Member Query Interval, which may be tuned to modify
+         the leave latency of the network.";
+    }
+
+    leaf robustness-variable {
+      type uint8 {
+        range "1..7";
+      }
+      default "2";
+      description
+        "Querier's Robustness Variable allows tuning for the
+         expected packet loss on a network.";
+    }
+  }
+
+  grouping per-af-interface-config-attributes {
+    description
+      "Configuration attributes applied to the interface level per address family.";
+
+    list static-group {
+      key "group-addr source-addr";
+      description
+        "A static multicast route, (*,G) or (S,G).
+         The version of IGMP must be 3 to support (S,G).";
+
+      leaf group-addr {
+        type rt-types:ip-multicast-group-address;
+        description
+          "Multicast group address.";
+      }
+      leaf source-addr {
+        type inet:ip-address;
+        description
+          "Multicast source address.";
+      }
+    }
+
+  } // per-af-interface-config-attributes
+
+  /*
+   * Per-interface configuration data
+   */
+  augment "/frr-interface:lib/frr-interface:interface" {
+    container igmp {
+      description
+        "IGMP interface parameters.";
+      uses interface-config-attributes;
+      list address-family {
+        key "address-family";
+        description
+          "Each list entry for one address family.";
+        uses frr-rt:address-family;
+        uses per-af-interface-config-attributes;
+
+        } //address-family
+    }
+  }
+}

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -29,6 +29,7 @@ dist_yangmodels_DATA += yang/frr-route-types.yang
 dist_yangmodels_DATA += yang/frr-routing.yang
 dist_yangmodels_DATA += yang/ietf/ietf-routing-types.yang
 dist_yangmodels_DATA += yang/frr-nexthop.yang
+dist_yangmodels_DATA += yang/frr-igmp.yang
 
 if BFDD
 dist_yangmodels_DATA += yang/frr-bfdd.yang


### PR DESCRIPTION
Defined frr-igmp.yang file for IGMP protocol.

Co-authored-by: Sarita Patra <saritap@vmware.com>
Co-authored-by: Santosh P K <sapk@vmware.com>
Signed-off-by: Sarita Patra <saritap@vmware.com>