### PR TITLE
lib: default nexthop weights to one

### DIFF
--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -230,7 +230,23 @@ bool nexthop_labels_match(const struct nexthop *nh1, const struct nexthop *nh2)
 
 struct nexthop *nexthop_new(void)
 {
-	return XCALLOC(MTYPE_NEXTHOP, sizeof(struct nexthop));
+	struct nexthop *nh;
+
+	nh = XCALLOC(MTYPE_NEXTHOP, sizeof(struct nexthop));
+
+	/*
+	 * Default the weight to 1 here for all nexthops.
+	 * The linux kernel does some weird stuff with adding +1 to
+	 * all nexthop weights it gets over netlink.
+	 * To handle this, just default everything to 1 right from
+	 * from the beggining so we don't have to special case
+	 * default weights in the linux netlink code.
+	 *
+	 * 1 should be a valid on all platforms anyway.
+	 */
+	nh->weight = 1;
+
+	return nh;
 }
 
 /* Free nexthop. */


### PR DESCRIPTION
Default all nexthop weights to one. The linux kernel does
some weird stuff where it adds one to all nexthop weight values
it gets. So, we added df7fb5800b3798057747873c8be245eb13f3ec36 with
some special subtracing/adding to account for this. Though, that patch
did not account for the default case of the weight being zero for
elements in the group.

Hence, this patch defaults the nexthop weight to one during creation.
This should be a valid value on all platforms anyway so shouldn't
affect anything.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>