### PR TITLE
WIP: add top level zapi error handling

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -1093,6 +1093,7 @@ static const struct zebra_desc_table command_types[] = {
 	DESC_ENTRY(ZEBRA_VXLAN_SG_ADD),
 	DESC_ENTRY(ZEBRA_VXLAN_SG_DEL),
 	DESC_ENTRY(ZEBRA_VXLAN_SG_REPLAY),
+	DESC_ENTRY(ZEBRA_ERROR),
 };
 #undef DESC_ENTRY
 

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -347,7 +347,8 @@ static int zclient_lookup_nexthop_once(struct pim_instance *pim,
 
 	s = zlookup->obuf;
 	stream_reset(s);
-	zclient_create_header(s, ZEBRA_IPV4_NEXTHOP_LOOKUP_MRIB, pim->vrf_id);
+	zclient_create_header(s, ZEBRA_IPV4_NEXTHOP_LOOKUP_MRIB,
+			      pim->vrf->vrf_id);
 	stream_put_in_addr(s, &addr);
 	stream_putw_at(s, 0, stream_get_endp(s));
 

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -180,6 +180,15 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 			zclient_lookup_failed(zlookup);
 			return -1;
 		}
+
+		if (command == ZEBRA_ERROR) {
+			zebra_error_types_t error;
+			struct zmsghdr bad_hdr;
+
+			zapi_error_decode(s, &error, &bad_hdr);
+			/* Do nothing with it for now */
+			return -1;
+		}
 	}
 
 	raddr.s_addr = stream_get_ipv4(s);

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -652,8 +652,7 @@ static int zserv_handle_client_fail(struct thread *thread)
 static struct zserv *zserv_client_create(int sock)
 {
 	struct zserv *client;
-	size_t stream_size =
-		MAX(ZEBRA_MAX_PACKET_SIZ, sizeof(struct zapi_route));
+	size_t stream_size = zebra_buffer_size();
 	int i;
 	afi_t afi;
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -146,6 +146,7 @@ struct zserv {
 	uint32_t v6_nh_watch_rem_cnt;
 	uint32_t vxlan_sg_add_cnt;
 	uint32_t vxlan_sg_del_cnt;
+	uint32_t error_cnt;
 
 	time_t nh_reg_time;
 	time_t nh_dereg_time;


### PR DESCRIPTION
This is the patch we have been discussing in #zebra on slack.

the summary again:
```
sworley 10:23 AM
Anybody have any thoughts on the usefulness of this commit: https://github.com/sworleys/frr/commit/f6741be46fe7e521550c9ce38388f4eb6c47761f
There was a bug in pimd where it hung waiting for a response from zebra for a command but zebra didn't reply due to not finding the vrf. So I started thinking about improving the error handling there and wrote this bit.
But I am not confident the daemons actually care about having context for the message that failed. Just sending the error back might be enough. (edited) 
```

Is sending the data back to the client daemons is the real question we are asking here.

Even if they just log it, would it be worth having that in the daemons log as well as zebras?



==================
Add error handling for top level failures (not able to
execute command, unable to find vrf for command, etc.)

With this error handling we add a new zapi message type
of ZEBRA_ERROR used when we are unable to properly handle
a zapi command and pass it down into lower level code.

In the event of this, we wrap the offending message into a new
message of type ZEBRA_ERROR and send that back up to the
upper level daemons to handle.

This could also be extended to go in the reverse direction as well.

The sent packet will look like so:

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|             Length            |     Marker    |    Version    |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                             VRF ID                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|            Command            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|            ERROR TYPE         |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|             Length            |     Marker    |    Version    |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                             VRF ID                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|            Command            |                               |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                              DATA                             |
|                                                               |
|                                                               |
|                                                               |
|                                                               |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

To account for this increased packet size on failure, we increase
the buffers in zserv and zclient to receive the messags and create
a common API to calculate that size.