### PR TITLE
zebra: add 'show router-id'

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -916,3 +916,22 @@ zebra Terminal Mode Commands
 
    Display nexthop groups created by zebra.
 
+
+Router-id
+=========
+
+Many routing protocols require a router-id to be configured. To have a
+consistent router-id across all daemons, the following commands are available
+to configure and display the router-id:
+
+.. index:: [no] router-id A.B.C.D [vrf NAME]
+.. clicmd:: [no] router-id A.B.C.D [vrf NAME]
+
+   Configure the router-id of this router.
+
+.. index:: show router-id [vrf NAME]
+.. clicmd:: show router-id [vrf NAME]
+
+   Display the user configured router-id.
+
+

--- a/zebra/router-id.c
+++ b/zebra/router-id.c
@@ -253,6 +253,36 @@ DEFUN (no_router_id,
 	return CMD_SUCCESS;
 }
 
+DEFUN (show_router_id,
+       show_router_id_cmd,
+       "show router-id [vrf NAME]",
+       SHOW_STR
+       "Show the configured router-id\n"
+       VRF_CMD_HELP_STR)
+{
+        int idx_name = 3;
+
+        vrf_id_t vrf_id = VRF_DEFAULT;
+        struct zebra_vrf *zvrf;
+
+        if (argc > 2)
+                VRF_GET_ID(vrf_id, argv[idx_name]->arg, false);
+
+        zvrf = vrf_info_get(vrf_id);
+
+        if ((zvrf != NULL) && (zvrf->rid_user_assigned.u.prefix4.s_addr)) {
+                vty_out(vty, "zebra:\n");
+                if (vrf_id == VRF_DEFAULT)
+                        vty_out(vty, "     router-id %s vrf default\n",
+                                inet_ntoa(zvrf->rid_user_assigned.u.prefix4));
+                else
+                        vty_out(vty, "     router-id %s vrf %s\n",
+                                inet_ntoa(zvrf->rid_user_assigned.u.prefix4),
+                                argv[idx_name]->arg);
+        }
+
+        return CMD_SUCCESS;
+}
 
 static int router_id_cmp(void *a, void *b)
 {
@@ -267,6 +297,7 @@ void router_id_cmd_init(void)
 {
 	install_element(CONFIG_NODE, &router_id_cmd);
 	install_element(CONFIG_NODE, &no_router_id_cmd);
+	install_element(VIEW_NODE, &show_router_id_cmd);
 }
 
 void router_id_init(struct zebra_vrf *zvrf)


### PR DESCRIPTION
router-id is buried deep in "show running-config", this new
command makes it easy to retrieve the user configured router-id.
Example:
```
  # configure terminal
  (config)# router-id 1.2.3.4
  (config)# end

  # show router-id
  router-id 1.2.3.4

  # configure terminal
  (config)# no router-id 1.2.3.4
  (config)# end

  # show router-id
  #
```
Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>