### PR TITLE
bgpd: Print json output for show_ip_bgp_regexp_cmd

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -10527,7 +10527,7 @@ static int bgp_show_regexp(struct vty *vty, struct bgp *bgp, const char *regstr,
 	int rc;
 
 	if (!config_bgp_aspath_validate(regstr)) {
-		vty_out(vty, "Invalid character in as-path access-list %s\n",
+		vty_out(vty, "Invalid character in REGEX %s\n",
 			regstr);
 		return CMD_WARNING_CONFIG_FAILED;
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9433,7 +9433,8 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 					vty_out(vty, ",\"%s\": ", buf2);
 			}
 			vty_out(vty, "%s",
-				json_object_to_json_string(json_paths));
+				json_object_to_json_string_ext(
+					json_paths, JSON_C_TO_STRING_PRETTY));
 			json_object_free(json_paths);
 			json_paths = NULL;
 			first = 0;


### PR DESCRIPTION
```
exit1-debian-9# show ip bgp regexp ^200_ json 
{
 "vrfId": 0,
 "vrfName": "default",
 "tableVersion": 4,
 "routerId": "192.168.0.1",
 "defaultLocPrf": 100,
 "localAS": 200,
 "routes": { "10.0.0.150/32": [
  {
    "valid":true,
    "bestpath":true,
    "pathFrom":"external",
    "prefix":"10.0.0.150",
    "prefixLen":32,
    "network":"10.0.0.150\/32",
    "med":0,
    "metric":0,
    "weight":32768,
    "peerId":"(unspec)",
    "aspath":"200 200 200",
    "path":"200 200 200",
    "origin":"incomplete",
    "nexthops":[
      {
        "ip":"0.0.0.0",
        "afi":"ipv4",
        "used":true
      }
    ]
  }
...
```

Closes https://github.com/FRRouting/frr/issues/5537