### PR TITLE
isisd, yang: set default is-type to level-1-2

### DIFF
--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -107,13 +107,10 @@ struct isis_area *isis_area_create(const char *area_tag)
 
 	/*
 	 * Fabricd runs only as level-2.
-	 * For IS-IS, the first instance is level-1-2 rest are level-1,
-	 * unless otherwise configured
+	 * For IS-IS, the default is level-1-2
 	 */
-	if (fabricd) {
+	if (fabricd)
 		area->is_type = IS_LEVEL_2;
-	} else if (listcount(isis->area_list) == 0)
-		area->is_type = IS_LEVEL_1_AND_2;
 	else
 		area->is_type = yang_get_default_enum(
 			"/frr-isisd:isis/instance/is-type");

--- a/yang/frr-isisd.yang
+++ b/yang/frr-isisd.yang
@@ -27,6 +27,10 @@ module frr-isisd {
   description
     "This module defines a model for managing FRR isisd daemon.";
 
+  revision 2019-12-17 {
+    description
+      "Changed default area is-type to level-1-2";
+  }
   revision 2019-09-09 {
     description
       "Changed interface references to use
@@ -748,7 +752,7 @@ module frr-isisd {
 
       leaf is-type {
         type level;
-        default "level-1";
+        default "level-1-2";
         description
           "Level of the IS-IS routing instance (OSI only).";
       }


### PR DESCRIPTION
Currently isisd has this strange (legacy) behavior where the
first area is created by default with level-1-2, while every
other subsequent area uses the default defined in the yang model,
which is level-1. This is a source of confusion when trying to
configure the daemon programatically, either with frr-reload
or using the transactional cli. Given how rare having multiple
IS-IS instances is anyway, the easiest solution is to remove
this behavior and default to level-1-2 for every area.

Note that this does not affect fabricd, which continues using
exclusively level-2-only areas.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>