### PR TITLE
zebra: set RTNH_F_ONLINK in nexthop creation

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2044,6 +2044,9 @@ static int netlink_nexthop(int cmd, struct zebra_dplane_ctx *ctx)
 
 			addattr32(&req.n, req_size, NHA_OIF, nh->ifindex);
 
+			if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_ONLINK))
+				req.nhm.nh_flags |= RTNH_F_ONLINK;
+
 			num_labels =
 				build_label_stack(nh->nh_label, out_lse,
 						  label_buf, sizeof(label_buf));


### PR DESCRIPTION
We were not setting the RTNH_F_ONLINK flag where appropriate
when creating nexthop objects in the kernel.

Set it on the nhmsg.nh_flags netlink message.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>