### PR TITLE
zebra: fix kernel-route's deletion on vrf

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -787,34 +787,10 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 		} else {
 			if (!tb[RTA_MULTIPATH]) {
 				struct nexthop nh;
-				size_t sz = (afi == AFI_IP) ? 4 : 16;
 
-				memset(&nh, 0, sizeof(nh));
-				if (bh_type == BLACKHOLE_UNSPEC) {
-					if (index && !gate)
-						nh.type = NEXTHOP_TYPE_IFINDEX;
-					else if (index && gate)
-						nh.type =
-							(afi == AFI_IP)
-								? NEXTHOP_TYPE_IPV4_IFINDEX
-								: NEXTHOP_TYPE_IPV6_IFINDEX;
-					else if (!index && gate)
-						nh.type =
-							(afi == AFI_IP)
-								? NEXTHOP_TYPE_IPV4
-								: NEXTHOP_TYPE_IPV6;
-					else {
-						nh.type =
-							NEXTHOP_TYPE_BLACKHOLE;
-						nh.bh_type = BLACKHOLE_UNSPEC;
-					}
-				} else {
-					nh.type = NEXTHOP_TYPE_BLACKHOLE;
-					nh.bh_type = bh_type;
-				}
-				nh.ifindex = index;
-				if (gate)
-					memcpy(&nh.gate, gate, sz);
+				nh = parse_nexthop_unicast(
+					ns_id, rtm, tb, bh_type, index, prefsrc,
+					gate, afi, vrf_id);
 				rib_delete(afi, SAFI_UNICAST, vrf_id, proto, 0,
 					   flags, &p, &src_p, &nh, 0, table,
 					   metric, distance, true);


### PR DESCRIPTION
zebra can catch the kernel's route deletion by netlink.
but current FRR can't delete kernel-route on vrf(l3mdev)
when kernel operator delete the route on out-side of FRR.
It looks problem about kernel-route deletion.

This problem is caused around _nexthop_cmp_no_labels(nh1,nh2)
that checks the each nexthop's member 'vrf_id'.
And _nexthop_cmp_no_labels's caller doesn't set the vrf_id
of nexthop structure. This commit fix that case.

Signed-off-by: Hiroki Shirokura <slank.dev@gmail.com>