### PR TITLE
lib,zebra: add zapi msg top level error handling

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -1093,6 +1093,7 @@ static const struct zebra_desc_table command_types[] = {
 	DESC_ENTRY(ZEBRA_VXLAN_SG_ADD),
 	DESC_ENTRY(ZEBRA_VXLAN_SG_DEL),
 	DESC_ENTRY(ZEBRA_VXLAN_SG_REPLAY),
+	DESC_ENTRY(ZEBRA_ERROR),
 };
 #undef DESC_ENTRY
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -183,7 +183,33 @@ typedef enum {
 	ZEBRA_MLAG_CLIENT_REGISTER,
 	ZEBRA_MLAG_CLIENT_UNREGISTER,
 	ZEBRA_MLAG_FORWARD_MSG,
+	ZEBRA_ERROR,
 } zebra_message_types_t;
+
+enum zebra_error_types {
+	ZEBRA_UNKNOWN_ERROR,	/* Error of unknown type */
+	ZEBRA_NO_VRF,		/* Vrf in header was not found */
+	ZEBRA_INVALID_MSG_TYPE, /* No handler found for msg type */
+};
+
+static inline const char *zebra_error_type2str(enum zebra_error_types type)
+{
+	const char *ret = "UNKNOWN";
+
+	switch (type) {
+	case ZEBRA_UNKNOWN_ERROR:
+		ret = "ZEBRA_UNKNOWN_ERROR";
+		break;
+	case ZEBRA_NO_VRF:
+		ret = "ZEBRA_NO_VRF";
+		break;
+	case ZEBRA_INVALID_MSG_TYPE:
+		ret = "ZEBRA_INVALID_MSG_TYPE";
+		break;
+	}
+
+	return ret;
+}
 
 struct redist_proto {
 	uint8_t enabled;
@@ -280,6 +306,7 @@ struct zclient {
 	int (*mlag_process_up)(void);
 	int (*mlag_process_down)(void);
 	int (*mlag_handle_msg)(struct stream *msg, int len);
+	int (*handle_error)(enum zebra_error_types error);
 };
 
 /* Zebra API message flag. */
@@ -727,6 +754,9 @@ int zapi_nexthop_from_nexthop(struct zapi_nexthop *znh,
 			      const struct nexthop *nh);
 extern bool zapi_nexthop_update_decode(struct stream *s,
 				       struct zapi_route *nhr);
+
+/* Decode the zebra error message */
+extern bool zapi_error_decode(struct stream *s, enum zebra_error_types *error);
 
 static inline void zapi_route_set_blackhole(struct zapi_route *api,
 					    enum blackhole_type bh_type)

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -180,6 +180,14 @@ static int zclient_read_nexthop(struct pim_instance *pim,
 			zclient_lookup_failed(zlookup);
 			return -1;
 		}
+
+		if (command == ZEBRA_ERROR) {
+			enum zebra_error_types error;
+
+			zapi_error_decode(s, &error);
+			/* Do nothing with it for now */
+			return -1;
+		}
 	}
 
 	raddr.s_addr = stream_get_ipv4(s);

--- a/pimd/pim_zlookup.c
+++ b/pimd/pim_zlookup.c
@@ -346,7 +346,8 @@ static int zclient_lookup_nexthop_once(struct pim_instance *pim,
 
 	s = zlookup->obuf;
 	stream_reset(s);
-	zclient_create_header(s, ZEBRA_IPV4_NEXTHOP_LOOKUP_MRIB, pim->vrf_id);
+	zclient_create_header(s, ZEBRA_IPV4_NEXTHOP_LOOKUP_MRIB,
+			      pim->vrf->vrf_id);
 	stream_put_in_addr(s, &addr);
 	stream_putw_at(s, 0, stream_get_endp(s));
 

--- a/zebra/zserv.h
+++ b/zebra/zserv.h
@@ -146,6 +146,7 @@ struct zserv {
 	uint32_t v6_nh_watch_rem_cnt;
 	uint32_t vxlan_sg_add_cnt;
 	uint32_t vxlan_sg_del_cnt;
+	uint32_t error_cnt;
 
 	time_t nh_reg_time;
 	time_t nh_dereg_time;


### PR DESCRIPTION
This is a re-work of #5542 

It no longer sends back the bad packet and just responds with an error for now. We may enhance this in the future by adding `sequence` numbers to `zapi headers`.

This PR also uses this enhancement in `pimd` to fix a hang issue.


Add error handling for top level failures (not able to
execute command, unable to find vrf for command, etc.)

With this error handling we add a new zapi message type
of ZEBRA_ERROR used when we are unable to properly handle
a zapi command and pass it down into the lower level code.

In the event of this, we reply with a message of type
ZEBRA_ERROR containing the error type.

The sent packet will look like so:

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|             Length            |     Marker    |    Version    |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                             VRF ID                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|            Command            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|            ERROR TYPE         |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

Also add appropriate hooks for clients to subscribe to for
handling these types of errors.