### PR TITLE
bgpd: Remove misleading 'NOTIFICATION' string from End-of-RIB log

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1658,10 +1658,11 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			if (peer->nsf[afi][safi])
 				bgp_clear_stale_route(peer, afi, safi);
 
-			zlog_info("%%NOTIFICATION: rcvd End-of-RIB for %s from %s in vrf %s",
-				  get_afi_safi_str(afi, safi, false), peer->host,
-				  vrf ? vrf->name : VRF_DEFAULT_NAME);
-		}
+                        zlog_info(
+                            "%s: rcvd End-of-RIB for %s from %s in vrf %s",
+                            __func__, get_afi_safi_str(afi, safi, false),
+                            peer->host, vrf ? vrf->name : VRF_DEFAULT_NAME);
+                }
 	}
 
 	/* Everything is done.  We unintern temporary structures which


### PR DESCRIPTION
'NOTIFICATION' string in this message incorrectly implies a BGP
Notification message was the cause of this log. Removing it to
reduce confusion and replacing with function name.

Signed-off-by: Trey Aspelund <taspelund@cumulusnetworks.com>