### PR TITLE
lib: fix build of the northbound plugins

### DIFF
--- a/lib/yang.c
+++ b/lib/yang.c
@@ -87,7 +87,7 @@ static inline int yang_module_compare(const struct yang_module *a,
 }
 RB_GENERATE(yang_modules, yang_module, entry, yang_module_compare)
 
-static struct yang_modules yang_modules = RB_INITIALIZER(&yang_modules);
+struct yang_modules yang_modules = RB_INITIALIZER(&yang_modules);
 
 struct yang_module *yang_module_load(const char *module_name)
 {

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -114,6 +114,9 @@ typedef int (*yang_iterate_cb)(const struct lys_node *snode, void *arg);
 /* Global libyang context for native FRR models. */
 extern struct ly_ctx *ly_native_ctx;
 
+/* Tree of all loaded YANG modules. */
+extern struct yang_modules yang_modules;
+
 /*
  * Create a new YANG module and load it using libyang. If the YANG module is not
  * found in the YANG_MODELS_PATH directory, the program will exit with an error.


### PR DESCRIPTION
Commit 1b3e9a21dd4 removed the global visibility of the yang_modules
variable, breaking the build of all northbound plugins. Revert a
small part of that commit to fix this issue.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>