### PR TITLE
lib: deallocate list of YANG RPC input arguments on nb_cli_rpc()

### DIFF
--- a/lib/northbound_cli.c
+++ b/lib/northbound_cli.c
@@ -200,6 +200,8 @@ int nb_cli_rpc(const char *xpath, struct list *input, struct list *output)
 	}
 
 	ret = nb_callback_rpc(nb_node, xpath, input, output);
+	if (input)
+		list_delete(&input);
 	switch (ret) {
 	case NB_OK:
 		return CMD_SUCCESS;

--- a/ripd/rip_cli.c
+++ b/ripd/rip_cli.c
@@ -1014,8 +1014,6 @@ DEFPY (clear_ip_rip,
 
 	ret = nb_cli_rpc("/frr-ripd:clear-rip-route", input, NULL);
 
-	list_delete(&input);
-
 	return ret;
 }
 

--- a/ripngd/ripng_cli.c
+++ b/ripngd/ripng_cli.c
@@ -498,8 +498,6 @@ DEFPY (clear_ipv6_rip,
 
 	ret = nb_cli_rpc("/frr-ripngd:clear-ripng-route", input, NULL);
 
-	list_delete(&input);
-
 	return ret;
 }
 


### PR DESCRIPTION
For simplicity, it's better to centralize the deallocation of these
'input' lists in the CLI nb_cli_rpc() helper function instead of
doing it on all CLI commands that execute a YANG RPC.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>