### PR TITLE
bgpd: Allow ipv4 multicast to use v4 nexthops

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2905,7 +2905,9 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 
 	/* Nexthop AFI */
 	if (afi == AFI_IP
-	    && (safi == SAFI_UNICAST || safi == SAFI_LABELED_UNICAST))
+	    && (safi == SAFI_UNICAST ||
+		safi == SAFI_LABELED_UNICAST ||
+		safi == SAFI_MULTICAST))
 		nh_afi = peer_cap_enhe(peer, afi, safi) ? AFI_IP6 : AFI_IP;
 	else
 		nh_afi = BGP_NEXTHOP_AFI_FROM_NHLEN(attr->mp_nexthop_len);


### PR DESCRIPTION
When passing a v4 multicast route to a peer send
the v4 nexthop as a preferred methodology.

Fixes: #5582
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>