### PR TITLE
pimd: readd iph length checks

### DIFF
--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -478,21 +478,29 @@ int pim_igmp_packet(struct igmp_sock *igmp, char *buf, size_t len)
 
 	ip_hlen = ip_hdr->ip_hl << 2; /* ip_hl gives length in 4-byte words */
 
+	if (ip_hlen > len) {
+		zlog_warn(
+			"IGMP packet header claims size %zu, but we only have %zu bytes",
+			ip_hlen, len);
+		return -1;
+	}
+
 	igmp_msg = buf + ip_hlen;
-	msg_type = *igmp_msg;
 	igmp_msg_len = len - ip_hlen;
+
+	if (igmp_msg_len < PIM_IGMP_MIN_LEN) {
+		zlog_warn("IGMP message size=%d shorter than minimum=%d",
+			  igmp_msg_len, PIM_IGMP_MIN_LEN);
+		return -1;
+	}
+
+	msg_type = *igmp_msg;
 
 	if (PIM_DEBUG_IGMP_PACKETS) {
 		zlog_debug(
 			"Recv IGMP packet from %s to %s on %s: size=%zu ttl=%d msg_type=%d msg_size=%d",
 			from_str, to_str, igmp->interface->name, len, ip_hdr->ip_ttl,
 			msg_type, igmp_msg_len);
-	}
-
-	if (igmp_msg_len < PIM_IGMP_MIN_LEN) {
-		zlog_warn("IGMP message size=%d shorter than minimum=%d",
-			  igmp_msg_len, PIM_IGMP_MIN_LEN);
-		return -1;
 	}
 
 	switch (msg_type) {

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -590,6 +590,9 @@ static int pim_mroute_msg(struct pim_instance *pim, const char *buf,
 	struct in_addr ifaddr;
 	struct igmp_sock *igmp;
 
+	if (buf_size < (int)sizeof(struct ip))
+		return 0;
+
 	ip_hdr = (const struct ip *)buf;
 
 	if (ip_hdr->ip_p == IPPROTO_IGMP) {


### PR DESCRIPTION
Kernel might not hand us a bad packet, but better safe than sorry here.
Validate the IP header length field. Also adds an additional check that
the packet length is sufficient for an IGMP packet, and a check that we
actually have enough for an ip header at all.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>