### PR TITLE
pimd: fix missing igmp mtrace length check

### DIFF
--- a/pimd/pim_igmp_mtrace.c
+++ b/pimd/pim_igmp_mtrace.c
@@ -864,6 +864,16 @@ int igmp_mtrace_recv_response(struct igmp_sock *igmp, struct ip *ip_hdr,
 	pim_ifp = ifp->info;
 	pim = pim_ifp->pim;
 
+	if (igmp_msg_len < (int)sizeof(struct igmp_mtrace)) {
+		if (PIM_DEBUG_MTRACE)
+			zlog_warn(
+				"Recv mtrace packet from %s on %s: too short,"
+				" len=%d, min=%zu",
+				from_str, ifp->name, igmp_msg_len,
+				sizeof(struct igmp_mtrace));
+		return -1;
+	}
+
 	mtracep = (struct igmp_mtrace *)igmp_msg;
 
 	recv_checksum = mtracep->checksum;


### PR DESCRIPTION
We check that the IGMP message is sufficently sized for an mtrace query,
but not a response, leading to uninitialized stack read.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>