### PR TITLE
lib: [7.1] perform a bind inside vrf_socket() call

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -904,10 +904,16 @@ vrf_id_t vrf_get_default_id(void)
 int vrf_bind(vrf_id_t vrf_id, int fd, const char *name)
 {
 	int ret = 0;
+	struct interface *ifp;
 
 	if (fd < 0 || name == NULL)
 		return fd;
-	if (vrf_is_backend_netns())
+	/* the device should exist
+	 * otherwise we should return
+	 * case ifname = vrf in netns mode => return
+	 */
+	ifp = if_lookup_by_name(name, vrf_id);
+	if (!ifp)
 		return fd;
 #ifdef SO_BINDTODEVICE
 	ret = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, name, strlen(name)+1);


### PR DESCRIPTION
This is an extension to previous behavior, where the bind() operation
was performed only when vrf was not a netns backend kind. This was done
like that because usually the bind parameter is the vrf name itself, and
having an interface name with vrf name is an expectation so that the
bind operation works.
the bind() operation can be performed on whatever device provided that
that name is not null and there is an interface in the vrf that has the
same name as the parameter.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>

Specific case:
When using BGP views (for instance `router bgp 65000 view ISP`), it tries binding to `ISP` device. This backport fixes that.