### PR TITLE
bgpd: Send notification to the peer on FSM error

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1887,7 +1887,7 @@ static const struct {
 		{bgp_fsm_open, OpenConfirm}, /* Receive_OPEN_message         */
 		{bgp_fsm_event_error, Idle}, /* Receive_KEEPALIVE_message    */
 		{bgp_fsm_event_error, Idle}, /* Receive_UPDATE_message       */
-		{bgp_stop_with_error, Idle}, /* Receive_NOTIFICATION_message */
+		{bgp_fsm_event_error, Idle}, /* Receive_NOTIFICATION_message */
 		{bgp_fsm_exeption, Idle},    /* Clearing_Completed           */
 	},
 	{


### PR DESCRIPTION
We should send a NOTIFICATION message with the Error Code Finite State
Machine Error if we receive NOTIFICATION in OpenSent/OpenConfirm/Established
states as defined in https://tools.ietf.org/html/rfc4271#section-8.2.2

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

Closes https://github.com/FRRouting/frr/issues/5588