### PR TITLE
bgpd: Change description for `[no] bgp listen limit` commands

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2691,7 +2691,7 @@ DEFUN (bgp_listen_limit,
        bgp_listen_limit_cmd,
        "bgp listen limit (1-5000)",
        "BGP specific commands\n"
-       "Configure BGP defaults\n"
+       "BGP Dynamic Neighbors listen commands\n"
        "maximum number of BGP Dynamic Neighbors that can be created\n"
        "Configure Dynamic Neighbors listen limit value\n")
 {
@@ -2709,8 +2709,9 @@ DEFUN (bgp_listen_limit,
 DEFUN (no_bgp_listen_limit,
        no_bgp_listen_limit_cmd,
        "no bgp listen limit [(1-5000)]",
+       NO_STR
        "BGP specific commands\n"
-       "Configure BGP defaults\n"
+       "BGP Dynamic Neighbors listen commands\n"
        "unset maximum number of BGP Dynamic Neighbors that can be created\n"
        "Configure Dynamic Neighbors listen limit value to default\n"
        "Configure Dynamic Neighbors listen limit value\n")


### PR DESCRIPTION
It's quite confusing when you see this:
```
exit1-debian-9(config-router)# bgp listen
  listen  Configure BGP defaults
```

And:
```
exit1-debian-9(config-router)# no bgp listen
  listen  unset maximum number of BGP Dynamic Neighbors that can be created
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>