### PR TITLE
doc: Add bgp neighbor password command

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1045,6 +1045,15 @@ Configuring Peers
 .. index:: neighbor PEER port PORT
 .. clicmd:: neighbor PEER port PORT
 
+.. index:: [no] neighbor PEER password PASSWORD
+.. clicmd:: [no] neighbor PEER password PASSWORD
+
+   Set a MD5 password to be used with the tcp socket that is being used
+   to connect to the remote peer.  Please note if you are using this
+   command with a large number of peers on linux you should consider
+   modifying the `net.core.optmem_max` sysctl to a larger value to
+   avoid out of memory errors from the linux kernel.
+
 .. index:: neighbor PEER send-community
 .. clicmd:: neighbor PEER send-community
 


### PR DESCRIPTION
The bgp neighbor password command was not documented additionally
the fact that you may need to instruct the kernel to have more
memory available for tcp sockets when using this feature on a large
number of peers.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>