### PR TITLE
bgpd: skip ra for blackhole nexthop type

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -421,7 +421,8 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 			if (peer && !peer->ifp
 			    && CHECK_FLAG(peer->flags,
 					  PEER_FLAG_CAPABILITY_ENHE)
-			    && nhr.prefix.family == AF_INET6) {
+			    && nhr.prefix.family == AF_INET6
+			    && nexthop->type != NEXTHOP_TYPE_BLACKHOLE) {
 				struct interface *ifp;
 
 				ifp = if_lookup_by_index(nexthop->ifindex,


### PR DESCRIPTION
bgp nexthop cache update triggers RA for global ipv6 nexthop update. In case of blackhole route type the outgoing interface information is NULL which leads to bgpd crash.
Skip sending RA for blackhole nexthop type.

Testing Done:

Configure bgp neighbor over global ipv6 address.
Configure static blackhole route with prefix includes connected ipv6 global address.
Upon link flap, zebra sends nexthop update to bgp.
Bgp nexthop cache skips sending RA for blackhole nexthop type.

router bgp 65002
 bgp router-id 91.189.93.190
 ...
 neighbor 2001:67c:1360::b peer-group internal

static route:
ipv6 route 2001:67c:1360::/48 Null0 254

iface rowlink.4010
        address 91.189.93.190/32
        address 2001:67c:1360::a/128

Trigger ifdown rowlink.4010; ifup rowlink.4010

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>