### PR TITLE
zebra: can't improve efficiency for recursive depends

### DIFF
--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -187,9 +187,16 @@ extern unsigned int nexthop_level(struct nexthop *nexthop);
 /* Copies to an already allocated nexthop struct */
 extern void nexthop_copy(struct nexthop *copy, const struct nexthop *nexthop,
 			 struct nexthop *rparent);
+/* Copies to an already allocated nexthop struct, not including recurse info */
+extern void nexthop_copy_no_recurse(struct nexthop *copy,
+				    const struct nexthop *nexthop,
+				    struct nexthop *rparent);
 /* Duplicates a nexthop and returns the newly allocated nexthop */
 extern struct nexthop *nexthop_dup(const struct nexthop *nexthop,
 				   struct nexthop *rparent);
+/* Duplicates a nexthop and returns the newly allocated nexthop */
+extern struct nexthop *nexthop_dup_no_recurse(const struct nexthop *nexthop,
+					      struct nexthop *rparent);
 
 #ifdef __cplusplus
 }

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -363,10 +363,6 @@ void copy_nexthops(struct nexthop **tnh, const struct nexthop *nh,
 	for (nh1 = nh; nh1; nh1 = nh1->next) {
 		nexthop = nexthop_dup(nh1, rparent);
 		_nexthop_add(tnh, nexthop);
-
-		if (CHECK_FLAG(nh1->flags, NEXTHOP_FLAG_RECURSIVE))
-			copy_nexthops(&nexthop->resolved, nh1->resolved,
-				      nexthop);
 	}
 }
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1054,18 +1054,7 @@ static struct nhg_hash_entry *depends_find_recursive(const struct nexthop *nh,
 	struct nhg_hash_entry *nhe;
 	struct nexthop *lookup = NULL;
 
-	/*
-	 * We need to copy its resolved nexthop if its recursively
-	 * resolved so that has to be handled with allocs/frees since
-	 * it could resolve to a group of unknown size.
-	 */
-	copy_nexthops(&lookup, nh, NULL);
-
-	/* Make it a single, recursive nexthop */
-	nexthops_free(lookup->next);
-	nexthops_free(lookup->prev);
-	lookup->next = NULL;
-	lookup->prev = NULL;
+	lookup = nexthop_dup(nh, NULL);
 
 	nhe = zebra_nhg_find_nexthop(0, lookup, afi, 0);
 
@@ -1083,7 +1072,7 @@ static struct nhg_hash_entry *depends_find_singleton(const struct nexthop *nh,
 	/* Capture a snapshot of this single nh; it might be part of a list,
 	 * so we need to make a standalone copy.
 	 */
-	nexthop_copy(&lookup, nh, NULL);
+	nexthop_copy_no_recurse(&lookup, nh, NULL);
 
 	nhe = zebra_nhg_find_nexthop(0, &lookup, afi, 0);
 


### PR DESCRIPTION
cb86eba3ab3d82f540bdb9ed5f65d361ca301ea8 was causing zebra to crash
when handling a nexthop group that had a nexthop which was recursively resolved.

Steps to recreate:
```
!
nexthop-group red
 nexthop 1.1.1.1
 nexthop 1.1.1.2
!
```
```
sharp install routes 8.8.8.1 nexthop-group red 1
```

=========================================
```
==11898== Invalid write of size 8
==11898==    at 0x48E53B4: _nexthop_add_sorted (nexthop_group.c:254)
==11898==    by 0x48E5336: nexthop_group_add_sorted (nexthop_group.c:296)
==11898==    by 0x453593: handle_recursive_depend (zebra_nhg.c:481)
==11898==    by 0x451CA8: zebra_nhg_find (zebra_nhg.c:572)
==11898==    by 0x4530FB: zebra_nhg_find_nexthop (zebra_nhg.c:597)
==11898==    by 0x4536B4: depends_find (zebra_nhg.c:1065)
==11898==    by 0x453526: depends_find_add (zebra_nhg.c:1087)
==11898==    by 0x451C4D: zebra_nhg_find (zebra_nhg.c:567)
==11898==    by 0x4519DE: zebra_nhg_rib_find (zebra_nhg.c:1126)
==11898==    by 0x452268: nexthop_active_update (zebra_nhg.c:1729)
==11898==    by 0x461517: rib_process (zebra_rib.c:1049)
==11898==    by 0x4610C8: process_subq_route (zebra_rib.c:1967)
==11898==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
```

Zebra crashes because we weren't handling the case of the depend nexthop
being recursive.

For this case, we cannot make the function more efficient. A nexthop
could resolve to a group of any size, thus we need allocs/frees.

To solve this and retain the goal of the original patch, we separate out the
two cases so it will still be more efficient if the nexthop is not recursive.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>