### PR TITLE
Pim rb

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1975,7 +1975,6 @@ static void pim_show_state(struct pim_instance *pim, struct vty *vty,
 			   const char *src_or_group, const char *group, bool uj)
 {
 	struct channel_oil *c_oil;
-	struct listnode *node;
 	json_object *json = NULL;
 	json_object *json_group = NULL;
 	json_object *json_ifp_in = NULL;
@@ -1994,7 +1993,7 @@ static void pim_show_state(struct pim_instance *pim, struct vty *vty,
 			"\nActive Source           Group            RPT  IIF               OIL\n");
 	}
 
-	for (ALL_LIST_ELEMENTS_RO(pim->channel_oil_list, node, c_oil)) {
+	frr_each (rb_pim_oil, &pim->channel_oil_head, c_oil) {
 		char grp_str[INET_ADDRSTRLEN];
 		char src_str[INET_ADDRSTRLEN];
 		char in_ifname[INTERFACE_NAMSIZ + 1];
@@ -5420,7 +5419,7 @@ static void show_mroute(struct pim_instance *pim, struct vty *vty,
 	now = pim_time_monotonic_sec();
 
 	/* print list of PIM and IGMP routes */
-	for (ALL_LIST_ELEMENTS_RO(pim->channel_oil_list, node, c_oil)) {
+	frr_each (rb_pim_oil, &pim->channel_oil_head, c_oil) {
 		found_oif = 0;
 		first = 1;
 		if (!c_oil->installed && !uj)
@@ -5828,7 +5827,7 @@ DEFUN (clear_ip_mroute_count,
 		return CMD_WARNING;
 
 	pim = vrf->info;
-	for (ALL_LIST_ELEMENTS_RO(pim->channel_oil_list, node, c_oil)) {
+	frr_each(rb_pim_oil, &pim->channel_oil_head, c_oil) {
 		if (!c_oil->installed)
 			continue;
 
@@ -5863,7 +5862,7 @@ static void show_mroute_count(struct pim_instance *pim, struct vty *vty)
 		"Source          Group           LastUsed Packets Bytes WrongIf  \n");
 
 	/* Print PIM and IGMP route counts */
-	for (ALL_LIST_ELEMENTS_RO(pim->channel_oil_list, node, c_oil)) {
+	frr_each (rb_pim_oil, &pim->channel_oil_head, c_oil) {
 		char group_str[INET_ADDRSTRLEN];
 		char source_str[INET_ADDRSTRLEN];
 
@@ -5968,7 +5967,7 @@ static void show_mroute_summary(struct pim_instance *pim, struct vty *vty)
 
 	vty_out(vty, "Mroute Type    Installed/Total\n");
 
-	for (ALL_LIST_ELEMENTS_RO(pim->channel_oil_list, node, c_oil)) {
+	frr_each (rb_pim_oil, &pim->channel_oil_head, c_oil) {
 		if (!c_oil->installed) {
 			if (c_oil->oil.mfcc_origin.s_addr == INADDR_ANY)
 				starg_sw_mroute_cnt++;

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -1113,8 +1113,10 @@ struct igmp_group *igmp_add_group_by_addr(struct igmp_sock *igmp,
 	}
 
 	if (pim_is_group_224_0_0_0_24(group_addr)) {
-		zlog_warn("%s: Group specified is part of 224.0.0.0/24",
-			  __PRETTY_FUNCTION__);
+		if (PIM_DEBUG_IGMP_TRACE)
+			zlog_debug(
+				"%s: Group specified %s is part of 224.0.0.0/24",
+				__PRETTY_FUNCTION__, inet_ntoa(group_addr));
 		return NULL;
 	}
 	/*

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -28,6 +28,7 @@
 #include "pim_assert.h"
 #include "pim_bsm.h"
 #include "pim_vxlan_instance.h"
+#include "pim_oil.h"
 
 #if defined(HAVE_LINUX_MROUTE_H)
 #include <linux/mroute.h>
@@ -119,8 +120,7 @@ struct pim_instance {
 
 	int iface_vif_index[MAXVIFS];
 
-	struct list *channel_oil_list;
-	struct hash *channel_oil_hash;
+	struct rb_pim_oil_head channel_oil_head;
 
 	struct pim_msdp msdp;
 	struct pim_vxlan_instance vxlan;

--- a/pimd/pim_instance.h
+++ b/pimd/pim_instance.h
@@ -29,6 +29,7 @@
 #include "pim_bsm.h"
 #include "pim_vxlan_instance.h"
 #include "pim_oil.h"
+#include "pim_upstream.h"
 
 #if defined(HAVE_LINUX_MROUTE_H)
 #include <linux/mroute.h>
@@ -108,8 +109,7 @@ struct pim_instance {
 	struct list *static_routes;
 
 	// Upstream vrf specific information
-	struct list *upstream_list;
-	struct hash *upstream_hash;
+	struct rb_pim_upstream_head upstream_head;
 	struct timer_wheel *upstream_sg_wheel;
 
 	/*

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -565,11 +565,9 @@ void pim_msdp_sa_local_update(struct pim_upstream *up)
 static void pim_msdp_sa_local_setup(struct pim_instance *pim)
 {
 	struct pim_upstream *up;
-	struct listnode *up_node;
 
-	for (ALL_LIST_ELEMENTS_RO(pim->upstream_list, up_node, up)) {
+	frr_each (rb_pim_upstream, &pim->upstream_head, up)
 		pim_msdp_sa_local_update(up);
-	}
 }
 
 /* whenever the RP changes we need to re-evaluate the "local" SA-cache */

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -177,7 +177,6 @@ void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
 	struct pim_nexthop_cache *pnc = NULL;
 	struct pim_nexthop_cache lookup;
 	struct zclient *zclient = NULL;
-	struct listnode *upnode = NULL;
 	struct pim_upstream *upstream = NULL;
 
 	zclient = pim_zebra_zclient_get();
@@ -190,8 +189,8 @@ void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
 			/* Release the (*, G)upstream from pnc->upstream_hash,
 			 * whose Group belongs to the RP getting deleted
 			 */
-			for (ALL_LIST_ELEMENTS_RO(pim->upstream_list, upnode,
-				upstream)) {
+			frr_each (rb_pim_upstream, &pim->upstream_head,
+				  upstream) {
 				struct prefix grp;
 				struct rp_info *trp_info;
 

--- a/pimd/pim_oil.c
+++ b/pimd/pim_oil.c
@@ -86,26 +86,6 @@ int pim_channel_oil_compare(const struct channel_oil *c1,
 	return 0;
 }
 
-static bool pim_oil_equal(const void *arg1, const void *arg2)
-{
-	const struct channel_oil *c1 = (const struct channel_oil *)arg1;
-	const struct channel_oil *c2 = (const struct channel_oil *)arg2;
-
-	if ((c1->oil.mfcc_mcastgrp.s_addr == c2->oil.mfcc_mcastgrp.s_addr)
-	    && (c1->oil.mfcc_origin.s_addr == c2->oil.mfcc_origin.s_addr))
-		return true;
-
-	return false;
-}
-
-static unsigned int pim_oil_hash_key(const void *arg)
-{
-	const struct channel_oil *oil = arg;
-
-	return jhash_2words(oil->oil.mfcc_mcastgrp.s_addr,
-			    oil->oil.mfcc_origin.s_addr, 0);
-}
-
 void pim_oil_init(struct pim_instance *pim)
 {
 	rb_pim_oil_init(&pim->channel_oil_head);

--- a/pimd/pim_oil.h
+++ b/pimd/pim_oil.h
@@ -90,9 +90,12 @@ struct channel_counts {
   installed: indicate if this entry is installed in the kernel.
 
 */
+PREDECL_RBTREE_UNIQ(rb_pim_oil)
 
 struct channel_oil {
 	struct pim_instance *pim;
+
+	struct rb_pim_oil_item oil_rb;
 
 	struct mfcctl oil;
 	int installed;
@@ -105,6 +108,12 @@ struct channel_oil {
 	struct pim_upstream *up;
 	time_t mroute_creation;
 };
+
+extern int pim_channel_oil_compare(const struct channel_oil *c1,
+				   const struct channel_oil *c2);
+DECLARE_RBTREE_UNIQ(rb_pim_oil, struct channel_oil, oil_rb,
+                    pim_channel_oil_compare)
+
 
 extern struct list *pim_channel_oil_list;
 

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -446,7 +446,6 @@ int pim_rp_new(struct pim_instance *pim, struct in_addr rp_addr,
 	struct prefix nht_p;
 	struct route_node *rn;
 	struct pim_upstream *up;
-	struct listnode *upnode;
 
 	if (rp_addr.s_addr == INADDR_ANY ||
 	    rp_addr.s_addr == INADDR_NONE)
@@ -554,8 +553,7 @@ int pim_rp_new(struct pim_instance *pim, struct in_addr rp_addr,
 					__PRETTY_FUNCTION__, buf, buf1);
 			}
 
-			for (ALL_LIST_ELEMENTS_RO(pim->upstream_list, upnode,
-						  up)) {
+			frr_each (rb_pim_upstream, &pim->upstream_head, up) {
 				/* Find (*, G) upstream whose RP is not
 				 * configured yet
 				 */
@@ -650,7 +648,7 @@ int pim_rp_new(struct pim_instance *pim, struct in_addr rp_addr,
 			   rn->lock);
 	}
 
-	for (ALL_LIST_ELEMENTS_RO(pim->upstream_list, upnode, up)) {
+	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
 		if (up->sg.src.s_addr == INADDR_ANY) {
 			struct prefix grp;
 			struct rp_info *trp_info;
@@ -723,7 +721,6 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 	bool was_plist = false;
 	struct rp_info *trp_info;
 	struct pim_upstream *up;
-	struct listnode *upnode;
 	struct bsgrp_node *bsgrp = NULL;
 	struct bsm_rpinfo *bsrp = NULL;
 	char grp_str[PREFIX2STR_BUFFER];
@@ -800,7 +797,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 	rp_all = pim_rp_find_match_group(pim, &g_all);
 
 	if (rp_all == rp_info) {
-		for (ALL_LIST_ELEMENTS_RO(pim->upstream_list, upnode, up)) {
+		frr_each (rb_pim_upstream, &pim->upstream_head, up) {
 			/* Find the upstream (*, G) whose upstream address is
 			 * same as the deleted RP
 			 */
@@ -852,7 +849,7 @@ int pim_rp_del(struct pim_instance *pim, struct in_addr rp_addr,
 
 	pim_rp_refresh_group_to_rp_mapping(pim);
 
-	for (ALL_LIST_ELEMENTS_RO(pim->upstream_list, upnode, up)) {
+	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
 		/* Find the upstream (*, G) whose upstream address is same as
 		 * the deleted RP
 		 */
@@ -893,7 +890,6 @@ int pim_rp_change(struct pim_instance *pim, struct in_addr new_rp_addr,
 	int result = 0;
 	struct rp_info *rp_info = NULL;
 	struct pim_upstream *up;
-	struct listnode *upnode;
 
 	rn = route_node_lookup(pim->rp_table, &group);
 	if (!rn) {
@@ -942,7 +938,7 @@ int pim_rp_change(struct pim_instance *pim, struct in_addr new_rp_addr,
 
 	listnode_add_sort(pim->rp_list, rp_info);
 
-	for (ALL_LIST_ELEMENTS_RO(pim->upstream_list, upnode, up)) {
+	frr_each (rb_pim_upstream, &pim->upstream_head, up) {
 		if (up->sg.src.s_addr == INADDR_ANY) {
 			struct prefix grp;
 			struct rp_info *trp_info;

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -169,6 +169,7 @@ enum pim_upstream_sptbit {
 	PIM_UPSTREAM_SPTBIT_TRUE
 };
 
+PREDECL_RBTREE_UNIQ(rb_pim_upstream);
 /*
   Upstream (S,G) channel in Joined state
   (S,G) in the "Not Joined" state is not represented
@@ -198,6 +199,7 @@ enum pim_upstream_sptbit {
 */
 struct pim_upstream {
 	struct pim_instance *pim;
+	struct rb_pim_upstream_item upstream_rb;
 	struct pim_upstream *parent;
 	struct in_addr upstream_addr;     /* Who we are talking to */
 	struct in_addr upstream_register; /*Who we received a register from*/
@@ -326,7 +328,11 @@ void pim_upstream_init(struct pim_instance *pim);
 void pim_upstream_terminate(struct pim_instance *pim);
 
 void join_timer_start(struct pim_upstream *up);
-int pim_upstream_compare(void *arg1, void *arg2);
+int pim_upstream_compare(const struct pim_upstream *up1,
+			 const struct pim_upstream *up2);
+DECLARE_RBTREE_UNIQ(rb_pim_upstream, struct pim_upstream, upstream_rb,
+		    pim_upstream_compare)
+
 void pim_upstream_register_reevaluate(struct pim_instance *pim);
 
 void pim_upstream_add_lhr_star_pimreg(struct pim_instance *pim);

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -392,16 +392,13 @@ static void pim_zebra_vxlan_replay(void)
 
 void pim_scan_oil(struct pim_instance *pim)
 {
-	struct listnode *node;
-	struct listnode *nextnode;
 	struct channel_oil *c_oil;
 
 	pim->scan_oil_last = pim_time_monotonic_sec();
 	++pim->scan_oil_events;
 
-	for (ALL_LIST_ELEMENTS(pim->channel_oil_list, node, nextnode, c_oil)) {
+	frr_each (rb_pim_oil, &pim->channel_oil_head, c_oil)
 		pim_upstream_mroute_iif_update(c_oil, __func__);
-	}
 }
 
 static int on_rpf_cache_refresh(struct thread *t)


### PR DESCRIPTION
1) At scale, pim is using a bunch of cpu time in sorted list insertion.  First two commits remove the biggest 2 contenders here.
2) Fix a common warn to a debug