### PR TITLE
docker: Use proper container name when creating CentOS 8 container

### DIFF
--- a/docker/centos-8/build.sh
+++ b/docker/centos-8/build.sh
@@ -17,7 +17,7 @@ docker build \
 	.
 
 # Copy RPM package from container to host
-CONTAINER_ID="$(docker create "frr:centos-builder-8-$GITREV")"
+CONTAINER_ID="$(docker create "frr:centos-8-builder-$GITREV")"
 docker cp "${CONTAINER_ID}:/rpmbuild/RPMS/x86_64/" docker/centos-8/pkgs
 docker rm "${CONTAINER_ID}"
 


### PR DESCRIPTION
Related: https://github.com/FRRouting/frr/issues/5587

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>