### PR TITLE
bgpd: Fix excessive doc string in no form of command

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -2713,7 +2713,6 @@ DEFUN (no_bgp_listen_limit,
        "BGP specific commands\n"
        "BGP Dynamic Neighbors listen commands\n"
        "unset maximum number of BGP Dynamic Neighbors that can be created\n"
-       "Configure Dynamic Neighbors listen limit value to default\n"
        "Configure Dynamic Neighbors listen limit value\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);


### PR DESCRIPTION
Commit 1601a46f223be317 introduced extra doc string.
This fixes that issue.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>