### PR TITLE
tests: add basic nexthop group functionality test

### DIFF
--- a/tests/topotests/all-protocol-startup/r1/ipv4_routes.ref
+++ b/tests/topotests/all-protocol-startup/r1/ipv4_routes.ref
@@ -10,6 +10,8 @@ C>* 192.168.8.0/26 is directly connected, r1-eth8, XX:XX:XX
 C>* 192.168.9.0/26 is directly connected, r1-eth9, XX:XX:XX
 O   192.168.0.0/24 [110/10] is directly connected, r1-eth0, XX:XX:XX
 O   192.168.3.0/26 [110/10] is directly connected, r1-eth3, XX:XX:XX
+S>* 1.1.1.1/32 [1/0] is directly connected, r1-eth0, XX:XX:XX
+S>* 1.1.1.2/32 [1/0] is directly connected, r1-eth1, XX:XX:XX
 S>* 4.5.6.10/32 [1/0] via 192.168.0.2, r1-eth0, XX:XX:XX
 S>* 4.5.6.11/32 [1/0] via 192.168.0.2, r1-eth0, XX:XX:XX
 S>* 4.5.6.12/32 [1/0] is directly connected, r1-eth0, XX:XX:XX

--- a/tests/topotests/all-protocol-startup/r1/zebra.conf
+++ b/tests/topotests/all-protocol-startup/r1/zebra.conf
@@ -26,6 +26,11 @@ ipv6 route 4:5::6:12/128 r1-eth0
 # by zebra but not installed.
 ip route 4.5.6.15/32 192.168.0.2 255
 ipv6 route 4:5::6:15/128 fc00:0:0:0::2 255
+
+# Routes to put into a nexthop-group
+ip route 1.1.1.1/32 r1-eth0
+ip route 1.1.1.2/32 r1-eth1
+
 !
 interface r1-eth0
  description to sw0 - no routing protocol


### PR DESCRIPTION
Add a very basic nexthop group functionality test.

This test creates a 2-way ecmp group and installs a route
with it using sharpd. Then we check to see that the nexthop
groups are marked valid/installed in zebra.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>