### PR TITLE
zebra: just set nexthop member in handle_recursive_depend()

### DIFF
--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -250,8 +250,7 @@ static void _nexthop_add_sorted(struct nexthop **head,
 {
 	struct nexthop *position, *prev;
 
-	/* Ensure this gets set */
-	nexthop->next = NULL;
+	assert(!nexthop->next);
 
 	for (position = *head, prev = NULL; position;
 	     prev = position, position = position->next) {
@@ -280,6 +279,8 @@ void nexthop_group_add_sorted(struct nexthop_group *nhg,
 			      struct nexthop *nexthop)
 {
 	struct nexthop *tail;
+
+	assert(!nexthop->next);
 
 	/* Try to just append to the end first;
 	 * trust the list is already sorted

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -478,7 +478,7 @@ static void handle_recursive_depend(struct nhg_connected_tree_head *nhg_depends,
 	struct nhg_hash_entry *depend = NULL;
 	struct nexthop_group resolved_ng = {};
 
-	nexthop_group_add_sorted(&resolved_ng, nh);
+	resolved_ng.nexthop = nh;
 
 	depend = zebra_nhg_rib_find(0, &resolved_ng, afi);
 	depends_add(nhg_depends, depend);


### PR DESCRIPTION
With recent changes to the lib nexthop_group
APIs (e1f3a8eb193267da195088cc515b598ae5a92a12), we are making
new assumptions that this should be adding a single nexthop
to a group, not a list of nexthops.

This broke the case of a recursive nexthop resolving to a group:

```
D>  2.2.2.1/32 [150/0] via 1.1.1.1 (recursive), 00:00:09
  *                      via 1.1.1.1, dummy1 onlink, 00:00:09
                       via 1.1.1.2 (recursive), 00:00:09
  *                      via 1.1.1.2, dummy2 onlink, 00:00:09
D>  3.3.3.1/32 [150/0] via 2.2.2.1 (recursive), 00:00:04
  *                      via 1.1.1.1, dummy1 onlink, 00:00:04
K * 10.0.0.0/8 [0/1] via 172.27.227.148, tun0, 00:00:21
```

This group can instead just directly point to the nh that was passed.
Its only being used for a lookup (the memory gets copied and used
elsewhere if the nexthop is not found).

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>