### PR TITLE
Fix zebra vrf label afi check

### DIFF
--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -360,6 +360,8 @@ typedef enum {
 	AFI_MAX = 4
 } afi_t;
 
+#define IS_VALID_AFI(a) ((a) > AFI_UNSPEC && (a) < AFI_MAX)
+
 /* Subsequent Address Family Identifier. */
 typedef enum {
 	SAFI_UNSPEC = 0,

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2272,6 +2272,12 @@ static void zread_vrf_label(ZAPI_HANDLER_ARGS)
 	s = msg;
 	STREAM_GETL(s, nlabel);
 	STREAM_GETC(s, afi);
+
+	if (!(IS_VALID_AFI(afi))) {
+		zlog_warn("Invalid AFI for VRF label: %u", afi);
+		return;
+	}
+
 	if (nlabel == zvrf->label[afi]) {
 		/*
 		 * Nothing to do here move along


### PR DESCRIPTION
Adds a macro to check if a value is a valid afi, and uses it when reading afi value from vrf label message