### PR TITLE
lib: fix ifindex comparison overflow

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -137,7 +137,12 @@ static int if_cmp_func(const struct interface *ifp1,
 static int if_cmp_index_func(const struct interface *ifp1,
 			     const struct interface *ifp2)
 {
-	return ifp1->ifindex - ifp2->ifindex;
+	if (ifp1->ifindex == ifp2->ifindex)
+		return 0;
+	else if (ifp1->ifindex > ifp2->ifindex)
+		return 1;
+	else
+		return -1;
 }
 
 static void ifp_connected_free(void *arg)


### PR DESCRIPTION
Very small (negative!) ifindexes, when subtracted, can overflow.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>