### PR TITLE
*:  modify two evpn debugs 

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1384,6 +1384,8 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 	if (bgp_debug_zebra(p)) {
 		char prefix_buf[PREFIX_STRLEN];
 		char nh_buf[INET6_ADDRSTRLEN];
+		char eth_buf[ETHER_ADDR_STRLEN + 7] = {'\0'};
+		char buf1[ETHER_ADDR_STRLEN];
 		char label_buf[20];
 		int i;
 
@@ -1421,13 +1423,19 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 			}
 
 			label_buf[0] = '\0';
+			eth_buf[0] = '\0';
 			if (has_valid_label
 			    && !CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE))
 				sprintf(label_buf, "label %u",
 					api_nh->labels[0]);
-			zlog_debug("  nhop [%d]: %s if %u VRF %u %s",
+			if (CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE)
+			    && !is_zero_mac(&api_nh->rmac))
+				sprintf(eth_buf, " RMAC %s",
+					   prefix_mac2str(&api_nh->rmac,
+					   buf1, sizeof(buf1)));
+			zlog_debug("  nhop [%d]: %s if %u VRF %u %s %s",
 				   i + 1, nh_buf, api_nh->ifindex,
-				   api_nh->vrf_id, label_buf);
+				   api_nh->vrf_id, label_buf, eth_buf);
 		}
 	}
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1426,13 +1426,13 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 			eth_buf[0] = '\0';
 			if (has_valid_label
 			    && !CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE))
-				sprintf(label_buf, "label %u",
-					api_nh->labels[0]);
+				snprintf(label_buf, sizeof(label_buf),
+					"label %u", api_nh->labels[0]);
 			if (CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE)
 			    && !is_zero_mac(&api_nh->rmac))
-				sprintf(eth_buf, " RMAC %s",
-					   prefix_mac2str(&api_nh->rmac,
-					   buf1, sizeof(buf1)));
+				snprintf(eth_buf, sizeof(eth_buf), " RMAC %s",
+					 prefix_mac2str(&api_nh->rmac,
+							buf1, sizeof(buf1)));
 			zlog_debug("  nhop [%d]: %s if %u VRF %u %s %s",
 				   i + 1, nh_buf, api_nh->ifindex,
 				   api_nh->vrf_id, label_buf, eth_buf);

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -8624,9 +8624,8 @@ void zebra_vxlan_macvlan_down(struct interface *ifp)
 			struct interface *ifp;
 
 			ifp = if_lookup_by_index_all_vrf(zif->link_ifindex);
-			zlog_debug("macvlan %s parent link is not found. Parent index %d ifp %s",
-				ifp->name, zif->link_ifindex,
-				ifp ? ifp->name : " ");
+			zlog_debug("macvlan parent link is not found. Parent index %d ifp %s",
+				zif->link_ifindex, ifp ? ifp->name : " ");
 		}
 		return;
 	}


### PR DESCRIPTION
1) zebra: fix debug in macvlan down event
 fix a debug where display parent interface name only if it exists.

2) bgpd: add rmac field in route_add debug
    For evpn routes, nexthop and RMAC fileds are synced in route add to zebra.

    In case of EVPN routes display RMAC field in route add debug log.

    Testing Done:
```
    BGP:   nhop [1]: 27.0.0.11 if 30 VRF 26   RMAC 00:02:00:00:00:2e
```
    Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>