### PR TITLE
zebra: Ignore RTM_GETNEIGH messages from the linux kernel

### DIFF
--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -290,6 +290,18 @@ static int netlink_information_fetch(struct nlmsghdr *h, ns_id_t ns_id,
 		return netlink_neigh_change(h, ns_id);
 	case RTM_DELNEIGH:
 		return netlink_neigh_change(h, ns_id);
+	case RTM_GETNEIGH:
+		/*
+		 * Kernel in some situations when it expects
+		 * user space to resolve arp entries, we will
+		 * receive this notification.  As we don't
+		 * need this notification and as that
+		 * we don't want to spam the log file with
+		 * below messages, just ignore.
+		 */
+		if (IS_ZEBRA_DEBUG_KERNEL)
+			zlog_debug("Received RTM_GETNEIGH, ignoring");
+		break;
 	case RTM_NEWRULE:
 		return netlink_rule_change(h, ns_id, startup);
 	case RTM_DELRULE:


### PR DESCRIPTION
The linux kernel will occassionally send RTM_GETNEIGH when
it expects user space to help in resolution of an ARP entry.
See linux kernel commit:

commit 3e25c65ed085b361cc91a8f02e028f1158c9f255
Author: Tim Gardner <tim.gardner@canonical.com>
Date:   Thu Aug 29 06:38:47 2013 -0600

    net: neighbour: Remove CONFIG_ARPD

Since we don't care about this, let's just safely ignore this
message for the moment.  I imagine in the future we might
care when we implement neighbor managment in the system.

Reported By: Stefan Priebe <s.priebe@profihost.ag>
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>