### PR TITLE
packaging: Redirect stderr to /dev/null in %post action (frr.spec.in)

### DIFF
--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -444,7 +444,7 @@ zebra_spec_add_service ()
 {
     # Add port /etc/services entry if it isn't already there
     if [ -f %{_sysconfdir}/services ] && \
-        ! %__sed -e 's/#.*$//' %{_sysconfdir}/services | %__grep -wq $1 ; then
+        ! %__sed -e 's/#.*$//' %{_sysconfdir}/services 2>/dev/null | %__grep -wq $1 ; then
         echo "$1        $2          # $3"  >> %{_sysconfdir}/services
     fi
 }


### PR DESCRIPTION
Solves:
```
/usr/bin/sed: couldn't write 40 items to stdout: Broken pipe
/usr/bin/sed: couldn't write 40 items to stdout: Broken pipe
/usr/bin/sed: couldn't write 40 items to stdout: Broken pipe
/usr/bin/sed: couldn't write 40 items to stdout: Broken pipe
/usr/bin/sed: couldn't write 40 items to stdout: Broken pipe
/usr/bin/sed: couldn't write 40 items to stdout: Broken pipe
/usr/bin/sed: couldn't write 40 items to stdout: Broken pipe
```

This happens because `grep -q` returns immediately after first match
and closes the pipe while sed has more output to write.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>

Related: https://github.com/FRRouting/frr/issues/5587