### PR TITLE
bgpd: Add BGP Extended message support

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2918,7 +2918,7 @@ bgp_attr_parse_ret_t bgp_attr_parse(struct peer *peer, struct attr *attr,
 			 * a stack buffer, since they perform bounds checking
 			 * and we are working with untrusted data.
 			 */
-			unsigned char ndata[BGP_MAX_PACKET_SIZE];
+			unsigned char ndata[peer->max_packet_size];
 			memset(ndata, 0x00, sizeof(ndata));
 			size_t lfl =
 				CHECK_FLAG(flag, BGP_ATTR_FLAG_EXTLEN) ? 2 : 1;

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -579,7 +579,8 @@ const char *const peer_down_str[] = {"",
 			       "No AFI/SAFI activated for peer",
 			       "AS Set config change",
 			       "Waiting for peer OPEN",
-			       "Reached received prefix count"};
+			       "Reached received prefix count",
+			       "BGP Extended Message config change"};
 
 static int bgp_graceful_restart_timer_expire(struct thread *thread)
 {

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -200,8 +200,8 @@ static int bgp_process_reads(struct thread *thread)
 	}
 
 	while (more) {
-		/* static buffer for transferring packets */
-		static unsigned char pktbuf[BGP_MAX_PACKET_SIZE];
+		/* buffer for transferring packets */
+		unsigned char pktbuf[peer->max_packet_size];
 		/* shorter alias to peer's input buffer */
 		struct ringbuf *ibw = peer->ibuf_work;
 		/* packet size as given by header */
@@ -223,7 +223,7 @@ static int bgp_process_reads(struct thread *thread)
 		pktsize = ntohs(pktsize);
 
 		/* if this fails we are seriously screwed */
-		assert(pktsize <= BGP_MAX_PACKET_SIZE);
+		assert(pktsize <= peer->max_packet_size);
 
 		/*
 		 * If we have that much data, chuck it into its own
@@ -248,7 +248,7 @@ static int bgp_process_reads(struct thread *thread)
 		/* wipe buffer just in case someone screwed up */
 		ringbuf_wipe(peer->ibuf_work);
 	} else {
-		assert(ringbuf_space(peer->ibuf_work) >= BGP_MAX_PACKET_SIZE);
+		assert(ringbuf_space(peer->ibuf_work) >= peer->max_packet_size);
 
 		thread_add_read(fpt->master, bgp_process_reads, peer, peer->fd,
 				&peer->t_read);
@@ -447,7 +447,10 @@ static uint16_t bgp_read(struct peer *peer)
 	size_t readsize; // how many bytes we want to read
 	ssize_t nbytes;  // how many bytes we actually read
 	uint16_t status = 0;
-	static uint8_t ibw[BGP_MAX_PACKET_SIZE * BGP_READ_PACKET_MAX];
+	int max_packet_count = peer->max_packet_size == BGP_MAX_PACKET_SIZE
+				       ? BGP_READ_PACKET_MAX
+				       : 1;
+	uint8_t ibw[peer->max_packet_size * max_packet_count];
 
 	readsize = MIN(ringbuf_space(peer->ibuf_work), sizeof(ibw));
 	nbytes = read(peer->fd, ibw, readsize);
@@ -551,7 +554,7 @@ static bool validate_header(struct peer *peer)
 	}
 
 	/* Minimum packet length check. */
-	if ((size < BGP_HEADER_SIZE) || (size > BGP_MAX_PACKET_SIZE)
+	if ((size < BGP_HEADER_SIZE) || (size > peer->max_packet_size)
 	    || (type == BGP_MSG_OPEN && size < BGP_MSG_OPEN_MIN_SIZE)
 	    || (type == BGP_MSG_UPDATE && size < BGP_MSG_UPDATE_MIN_SIZE)
 	    || (type == BGP_MSG_NOTIFY && size < BGP_MSG_NOTIFY_MIN_SIZE)

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -543,6 +543,25 @@ static as_t bgp_capability_as4(struct peer *peer, struct capability_header *hdr)
 	return as4;
 }
 
+static int bgp_capability_ext_message(struct peer *peer,
+				      struct capability_header *hdr)
+{
+	if (hdr->length != CAPABILITY_CODE_EXT_MESSAGE_LEN) {
+		flog_err(
+			EC_BGP_PKT_OPEN,
+			"%s: BGP Extended Message capability has incorrect data length %d",
+			peer->host, hdr->length);
+		return -1;
+	}
+
+	SET_FLAG(peer->cap, PEER_CAP_EXT_MESSAGE_RCV);
+
+	if (CHECK_FLAG(peer->cap, PEER_CAP_EXT_MESSAGE_ADV))
+		peer->max_packet_size = BGP_MAX_EXT_MESSAGE_PACKET_SIZE;
+
+	return 0;
+}
+
 static int bgp_capability_addpath(struct peer *peer,
 				  struct capability_header *hdr)
 {
@@ -769,6 +788,7 @@ static const struct message capcode_str[] = {
 	{CAPABILITY_CODE_REFRESH_OLD, "Route Refresh (Old)"},
 	{CAPABILITY_CODE_ORF_OLD, "ORF (Old)"},
 	{CAPABILITY_CODE_FQDN, "FQDN"},
+	{CAPABILITY_CODE_EXT_MESSAGE, "BGP Extended Message"},
 	{0}};
 
 /* Minimum sizes for length field of each cap (so not inc. the header) */
@@ -785,6 +805,7 @@ static const size_t cap_minsizes[] = {
 		[CAPABILITY_CODE_REFRESH_OLD] = CAPABILITY_CODE_REFRESH_LEN,
 		[CAPABILITY_CODE_ORF_OLD] = CAPABILITY_CODE_ORF_LEN,
 		[CAPABILITY_CODE_FQDN] = CAPABILITY_CODE_MIN_FQDN_LEN,
+		[CAPABILITY_CODE_EXT_MESSAGE] = CAPABILITY_CODE_EXT_MESSAGE_LEN,
 };
 
 /* value the capability must be a multiple of.
@@ -805,6 +826,7 @@ static const size_t cap_modsizes[] = {
 		[CAPABILITY_CODE_REFRESH_OLD] = 1,
 		[CAPABILITY_CODE_ORF_OLD] = 1,
 		[CAPABILITY_CODE_FQDN] = 1,
+		[CAPABILITY_CODE_EXT_MESSAGE] = 1,
 };
 
 /**
@@ -871,6 +893,7 @@ static int bgp_capability_parse(struct peer *peer, size_t length,
 		case CAPABILITY_CODE_DYNAMIC:
 		case CAPABILITY_CODE_DYNAMIC_OLD:
 		case CAPABILITY_CODE_ENHE:
+		case CAPABILITY_CODE_EXT_MESSAGE:
 		case CAPABILITY_CODE_FQDN:
 			/* Check length. */
 			if (caphdr.length < cap_minsizes[caphdr.code]) {
@@ -958,6 +981,9 @@ static int bgp_capability_parse(struct peer *peer, size_t length,
 			break;
 		case CAPABILITY_CODE_ENHE:
 			ret = bgp_capability_enhe(peer, &caphdr);
+			break;
+		case CAPABILITY_CODE_EXT_MESSAGE:
+			ret = bgp_capability_ext_message(peer, &caphdr);
 			break;
 		case CAPABILITY_CODE_FQDN:
 			ret = bgp_capability_hostname(peer, &caphdr);
@@ -1471,6 +1497,15 @@ void bgp_open_capability(struct stream *s, struct peer *peer)
 	else
 		local_as = peer->local_as;
 	stream_putl(s, local_as);
+
+	/* BGP Extended Message */
+	if (peer->bgp->extended_message) {
+		SET_FLAG(peer->cap, PEER_CAP_EXT_MESSAGE_ADV);
+		stream_putc(s, BGP_OPEN_OPT_CAP);
+		stream_putc(s, CAPABILITY_CODE_EXT_MESSAGE_LEN + 2);
+		stream_putc(s, CAPABILITY_CODE_EXT_MESSAGE);
+		stream_putc(s, CAPABILITY_CODE_EXT_MESSAGE_LEN);
+	}
 
 	/* AddPath */
 	FOREACH_AFI_SAFI (afi, safi) {

--- a/bgpd/bgp_open.h
+++ b/bgpd/bgp_open.h
@@ -51,6 +51,7 @@ struct graceful_restart_af {
 #define CAPABILITY_CODE_ADDPATH        69 /* Addpath Capability */
 #define CAPABILITY_CODE_FQDN           73 /* Advertise hostname capability */
 #define CAPABILITY_CODE_ENHE            5 /* Extended Next Hop Encoding */
+#define CAPABILITY_CODE_EXT_MESSAGE     6 /* BGP Extended Message */
 #define CAPABILITY_CODE_REFRESH_OLD   128 /* Route Refresh Capability(cisco) */
 #define CAPABILITY_CODE_ORF_OLD       130 /* Cooperative Route Filtering Capability(cisco) */
 
@@ -64,6 +65,7 @@ struct graceful_restart_af {
 #define CAPABILITY_CODE_ENHE_LEN        6 /* NRLI AFI = 2, SAFI = 2, Nexthop AFI = 2 */
 #define CAPABILITY_CODE_MIN_FQDN_LEN    2
 #define CAPABILITY_CODE_ORF_LEN         5
+#define CAPABILITY_CODE_EXT_MESSAGE_LEN 0
 
 /* Cooperative Route Filtering Capability.  */
 

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -143,7 +143,7 @@ static struct stream *bgp_update_packet_eor(struct peer *peer, afi_t afi,
 		zlog_debug("send End-of-RIB for %s to %s",
 			   get_afi_safi_str(afi, safi, false), peer->host);
 
-	s = stream_new(BGP_MAX_PACKET_SIZE);
+	s = stream_new(peer->max_packet_size);
 
 	/* Make BGP update packet. */
 	bgp_packet_set_marker(s, BGP_MSG_UPDATE);
@@ -683,7 +683,7 @@ void bgp_notify_send_with_data(struct peer *peer, uint8_t code,
 	/* ============================================== */
 
 	/* Allocate new stream. */
-	s = stream_new(BGP_MAX_PACKET_SIZE);
+	s = stream_new(peer->max_packet_size);
 
 	/* Make notify packet. */
 	bgp_packet_set_marker(s, BGP_MSG_NOTIFY);
@@ -821,7 +821,7 @@ void bgp_route_refresh_send(struct peer *peer, afi_t afi, safi_t safi,
 	/* Convert AFI, SAFI to values for packet. */
 	bgp_map_afi_safi_int2iana(afi, safi, &pkt_afi, &pkt_safi);
 
-	s = stream_new(BGP_MAX_PACKET_SIZE);
+	s = stream_new(peer->max_packet_size);
 
 	/* Make BGP update packet. */
 	if (CHECK_FLAG(peer->cap, PEER_CAP_REFRESH_NEW_RCV))
@@ -917,7 +917,7 @@ void bgp_capability_send(struct peer *peer, afi_t afi, safi_t safi,
 	/* Convert AFI, SAFI to values for packet. */
 	bgp_map_afi_safi_int2iana(afi, safi, &pkt_afi, &pkt_safi);
 
-	s = stream_new(BGP_MAX_PACKET_SIZE);
+	s = stream_new(peer->max_packet_size);
 
 	/* Make BGP update packet. */
 	bgp_packet_set_marker(s, BGP_MSG_CAPABILITY);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3025,6 +3025,52 @@ DEFUN (no_bgp_default_show_hostname,
 	return CMD_SUCCESS;
 }
 
+/* BGP Extended Message */
+DEFUN (bgp_ext_message,
+       bgp_ext_message_cmd,
+       "bgp extended-message",
+       "BGP specific commands\n"
+       "Enable BGP Extended Message (65535 bytes)\n")
+{
+	struct peer *peer;
+	struct listnode *node, *nnode;
+
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	bgp->extended_message = BGP_EXTENDED_MESSAGE_ENABLED;
+
+	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
+		if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->status)) {
+			peer->last_reset = PEER_DOWN_EXTENDED_MESSAGE;
+			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
+					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
+		}
+
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_bgp_ext_message,
+       no_bgp_ext_message_cmd,
+       "no bgp extended-message",
+       NO_STR
+       "BGP specific commands\n"
+       "Enable BGP Extended Message (65535 bytes)\n")
+{
+	struct peer *peer;
+	struct listnode *node, *nnode;
+
+	VTY_DECLVAR_CONTEXT(bgp, bgp);
+	bgp->extended_message = BGP_EXTENDED_MESSAGE_DISABLED;
+
+	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer))
+		if (BGP_IS_VALID_STATE_FOR_NOTIF(peer->status)) {
+			peer->last_reset = PEER_DOWN_EXTENDED_MESSAGE;
+			bgp_notify_send(peer, BGP_NOTIFY_CEASE,
+					BGP_NOTIFY_CEASE_CONFIG_CHANGE);
+		}
+
+	return CMD_SUCCESS;
+}
+
 /* "bgp network import-check" configuration.  */
 DEFUN (bgp_network_import_check,
        bgp_network_import_check_cmd,
@@ -10816,6 +10862,24 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 							"received");
 				}
 
+				/* BGP Extended Message */
+				if (CHECK_FLAG(p->cap, PEER_CAP_EXT_MESSAGE_ADV)
+				    && CHECK_FLAG(p->cap,
+						  PEER_CAP_EXT_MESSAGE_RCV))
+					json_object_string_add(
+						json_cap, "extendedMessage",
+						"advertisedAndReceived");
+				else if (CHECK_FLAG(p->cap,
+						    PEER_CAP_EXT_MESSAGE_ADV))
+					json_object_string_add(
+						json_cap, "extendedMessage",
+						"advertised");
+				else if (CHECK_FLAG(p->cap,
+						    PEER_CAP_EXT_MESSAGE_RCV))
+					json_object_string_add(
+						json_cap, "extendedMessage",
+						"received");
+
 				/* AddPath */
 				if (CHECK_FLAG(p->cap, PEER_CAP_ADDPATH_RCV)
 				    || CHECK_FLAG(p->cap,
@@ -11258,6 +11322,27 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 							CHECK_FLAG(
 								p->cap,
 								PEER_CAP_AS4_ADV)
+								? "and "
+								: "");
+					vty_out(vty, "\n");
+				}
+
+				/* BGP Extended Message */
+				if (CHECK_FLAG(p->cap, PEER_CAP_EXT_MESSAGE_RCV)
+				    || CHECK_FLAG(p->cap,
+						  PEER_CAP_EXT_MESSAGE_ADV)) {
+					vty_out(vty, "    Extended Message:");
+					if (CHECK_FLAG(
+						    p->cap,
+						    PEER_CAP_EXT_MESSAGE_ADV))
+						vty_out(vty, " advertised");
+					if (CHECK_FLAG(
+						    p->cap,
+						    PEER_CAP_EXT_MESSAGE_RCV))
+						vty_out(vty, " %sreceived",
+							CHECK_FLAG(
+								p->cap,
+								PEER_CAP_EXT_MESSAGE_ADV)
 								? "and "
 								: "");
 					vty_out(vty, "\n");
@@ -14978,6 +15063,10 @@ int bgp_config_write(struct vty *vty)
 		if (bgp->reject_as_sets == BGP_REJECT_AS_SETS_ENABLED)
 			vty_out(vty, " bgp reject-as-sets\n");
 
+		/* RFC8654 - Extended Message Support for BGP */
+		if (bgp->extended_message == BGP_EXTENDED_MESSAGE_ENABLED)
+			vty_out(vty, " bgp extended-message\n");
+
 		/* BGP default ipv4-unicast. */
 		if (CHECK_FLAG(bgp->flags, BGP_FLAG_NO_DEFAULT_IPV4))
 			vty_out(vty, " no bgp default ipv4-unicast\n");
@@ -15469,6 +15558,10 @@ void bgp_vty_init(void)
 	/* bgp reject-as-sets */
 	install_element(BGP_NODE, &bgp_reject_as_sets_cmd);
 	install_element(BGP_NODE, &no_bgp_reject_as_sets_cmd);
+
+	/* bgp extended-message */
+	install_element(BGP_NODE, &bgp_ext_message_cmd);
+	install_element(BGP_NODE, &no_bgp_ext_message_cmd);
 
 	/* "bgp deterministic-med" commands */
 	install_element(BGP_NODE, &bgp_deterministic_med_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1214,6 +1214,7 @@ struct peer *peer_new(struct bgp *bgp)
 	peer->bgp = bgp_lock(bgp);
 	peer = peer_lock(peer); /* initial reference */
 	peer->password = NULL;
+	peer->max_packet_size = BGP_MAX_PACKET_SIZE;
 
 	/* Set default flags. */
 	FOREACH_AFI_SAFI (afi, safi) {
@@ -1258,12 +1259,12 @@ struct peer *peer_new(struct bgp *bgp)
 	 * bounds checking for every single attribute as we construct an
 	 * UPDATE.
 	 */
-	peer->obuf_work =
-		stream_new(BGP_MAX_PACKET_SIZE + BGP_MAX_PACKET_SIZE_OVERFLOW);
-	peer->ibuf_work =
-		ringbuf_new(BGP_MAX_PACKET_SIZE * BGP_READ_PACKET_MAX);
+	peer->obuf_work = stream_new(BGP_MAX_EXT_MESSAGE_PACKET_SIZE
+				     + BGP_MAX_PACKET_SIZE_OVERFLOW);
+	peer->ibuf_work = ringbuf_new(BGP_MAX_EXT_MESSAGE_PACKET_SIZE
+				      * BGP_READ_PACKET_MAX);
 
-	peer->scratch = stream_new(BGP_MAX_PACKET_SIZE);
+	peer->scratch = stream_new(BGP_MAX_EXT_MESSAGE_PACKET_SIZE);
 
 	bgp_sync_init(peer);
 
@@ -2978,6 +2979,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 	bgp->dynamic_neighbors_count = 0;
 	bgp->ebgp_requires_policy = DEFAULT_EBGP_POLICY_DISABLED;
 	bgp->reject_as_sets = BGP_REJECT_AS_SETS_DISABLED;
+	bgp->extended_message = BGP_EXTENDED_MESSAGE_DISABLED;
 	bgp_addpath_init_bgp_data(&bgp->tx_addpath);
 
 	bgp->as = *as;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -583,6 +583,11 @@ struct bgp {
 #define BGP_REJECT_AS_SETS_DISABLED 0
 #define BGP_REJECT_AS_SETS_ENABLED 1
 
+	/* RFC 8654 - Extended Message Support for BGP */
+	bool extended_message;
+#define BGP_EXTENDED_MESSAGE_DISABLED 0
+#define BGP_EXTENDED_MESSAGE_ENABLED 1
+
 	struct bgp_evpn_info *evpn_info;
 
 	/* EVPN - use RFC 8365 to auto-derive RT */
@@ -776,6 +781,7 @@ typedef enum {
 #define BGP_MARKER_SIZE		                16
 #define BGP_HEADER_SIZE		                19
 #define BGP_MAX_PACKET_SIZE                   4096
+#define BGP_MAX_EXT_MESSAGE_PACKET_SIZE      65535
 #define BGP_MAX_PACKET_SIZE_OVERFLOW          1024
 
 /*
@@ -959,6 +965,8 @@ struct peer {
 #define PEER_CAP_ENHE_RCV                   (1 << 14) /* Extended nexthop received */
 #define PEER_CAP_HOSTNAME_ADV               (1 << 15) /* hostname advertised */
 #define PEER_CAP_HOSTNAME_RCV               (1 << 16) /* hostname received */
+#define PEER_CAP_EXT_MESSAGE_ADV            (1 << 17) /* BGP Extended Message advertised */
+#define PEER_CAP_EXT_MESSAGE_RCV            (1 << 18) /* BGP Extended Message received */
 
 	/* Capability flags (reset in bgp_stop) */
 	uint32_t af_cap[AFI_MAX][SAFI_MAX];
@@ -1352,13 +1360,14 @@ struct peer {
 #define PEER_DOWN_AS_SETS_REJECT        31 /* Reject routes with AS_SET */
 #define PEER_DOWN_WAITING_OPEN          32 /* Waiting for open to succeed */
 #define PEER_DOWN_PFX_COUNT             33 /* Reached received prefix count */
+#define PEER_DOWN_EXTENDED_MESSAGE      34 /* bgp extended-message */
 	/*
 	 * Remember to update peer_down_str in bgp_fsm.c when you add
 	 * a new value to the last_reset reason
 	 */
 
 	size_t last_reset_cause_size;
-	uint8_t last_reset_cause[BGP_MAX_PACKET_SIZE];
+	uint8_t last_reset_cause[BGP_MAX_EXT_MESSAGE_PACKET_SIZE];
 
 	/* The kind of route-map Flags.*/
 	uint16_t rmap_type;
@@ -1381,6 +1390,9 @@ struct peer {
 
 	/* Sender side AS path loop detection. */
 	bool as_path_loop_detection;
+
+	/* Maximum BGP message size */
+	uint16_t max_packet_size;
 
 	QOBJ_FIELDS
 };

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -434,6 +434,15 @@ Disable checking if nexthop is connected on EBGP sessions
    that are reachable by a single hop but are configured on a loopback interface or otherwise
    configured with a non-directly connected IP address.
 
+Extended Message Support for BGP
+--------------------------------
+
+.. index:: [no] bgp extended-message
+.. clicmd:: [no] bgp extended-message
+
+   Extend the maximum message size from 4096 to 65535 bytes for all
+   messages except for OPEN and KEEPALIVE messages.
+
 .. _bgp-route-flap-dampening:
 
 Route Flap Dampening

--- a/doc/user/overview.rst
+++ b/doc/user/overview.rst
@@ -316,6 +316,8 @@ BGP
   :t:`Default External BGP (EBGP) Route Propagation Behavior without Policies. J. Mauch, J. Snijders, G. Hankins. July 2017`
 - :rfc:`8277`
   :t:`Using BGP to Bind MPLS Labels to Address Prefixes. E. Rosen. October 2017`
+- :rfc:`8654`
+  :t:`Extended Message Support for BGP. R. Bush, K. Patel, D. Ward.  October 2019`
 
 
 OSPF

--- a/tests/bgpd/test_aspath.c
+++ b/tests/bgpd/test_aspath.c
@@ -1281,6 +1281,7 @@ static int handle_attr_test(struct aspath_tests *t)
 	peer.host = (char *)"none";
 	peer.fd = -1;
 	peer.cap = t->cap;
+	peer.max_packet_size = BGP_MAX_PACKET_SIZE;
 
 	stream_write(peer.curr, t->attrheader, t->len);
 	datalen = aspath_put(peer.curr, asp, t->as4 == AS4_DATA);

--- a/tests/bgpd/test_aspath.c
+++ b/tests/bgpd/test_aspath.c
@@ -966,7 +966,7 @@ static int validate(struct aspath *as, const struct test_spec *sp)
 
 	/* Excercise AS4 parsing a bit, with a dogfood test */
 	if (!s)
-		s = stream_new(4096);
+		s = stream_new(BGP_MAX_PACKET_SIZE);
 	bytes4 = aspath_put(s, as, 1);
 	as4 = make_aspath(STREAM_DATA(s), bytes4, 1);
 

--- a/tests/topotests/bgp_extended_message/r1/bgpd.conf
+++ b/tests/topotests/bgp_extended_message/r1/bgpd.conf
@@ -1,0 +1,9 @@
+! exit1
+router bgp 65001
+  bgp extended-message
+  neighbor 192.168.255.1 remote-as 65002
+  address-family ipv4 unicast
+    redistribute sharp
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_extended_message/r1/zebra.conf
+++ b/tests/topotests/bgp_extended_message/r1/zebra.conf
@@ -1,0 +1,6 @@
+! exit1
+interface r1-eth0
+ ip address 192.168.255.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_extended_message/r2/bgpd.conf
+++ b/tests/topotests/bgp_extended_message/r2/bgpd.conf
@@ -1,0 +1,4 @@
+! spine
+router bgp 65002
+  neighbor 192.168.255.2 remote-as 65001
+!

--- a/tests/topotests/bgp_extended_message/r2/zebra.conf
+++ b/tests/topotests/bgp_extended_message/r2/zebra.conf
@@ -1,0 +1,6 @@
+! spine
+interface r2-eth0
+ ip address 192.168.255.1/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_extended_message/r3/bgpd.conf
+++ b/tests/topotests/bgp_extended_message/r3/bgpd.conf
@@ -1,0 +1,9 @@
+! exit1
+router bgp 65001
+  bgp extended-message
+  neighbor 192.168.255.1 remote-as 65002
+  address-family ipv4 unicast
+    redistribute sharp
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_extended_message/r3/zebra.conf
+++ b/tests/topotests/bgp_extended_message/r3/zebra.conf
@@ -1,0 +1,6 @@
+! exit1
+interface r3-eth0
+ ip address 192.168.255.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_extended_message/r4/bgpd.conf
+++ b/tests/topotests/bgp_extended_message/r4/bgpd.conf
@@ -1,0 +1,5 @@
+! spine
+router bgp 65002
+  bgp extended-message
+  neighbor 192.168.255.2 remote-as 65001
+!

--- a/tests/topotests/bgp_extended_message/r4/zebra.conf
+++ b/tests/topotests/bgp_extended_message/r4/zebra.conf
@@ -1,0 +1,6 @@
+! spine
+interface r4-eth0
+ ip address 192.168.255.1/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_extended_message/test_bgp_extended_message.py
+++ b/tests/topotests/bgp_extended_message/test_bgp_extended_message.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_extended_message.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2019 by
+# Donatas Abraitis <donatas.abraitis@gmail.com>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Test if Extended Message Support for BGP is negotiated.
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+class TemplateTopo(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        for routern in range(1, 5):
+            tgen.add_router('r{}'.format(routern))
+
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
+
+        switch = tgen.add_switch('s2')
+        switch.add_link(tgen.gears['r3'])
+        switch.add_link(tgen.gears['r4'])
+
+def setup_module(mod):
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA,
+            os.path.join(CWD, '{}/zebra.conf'.format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_SHARP,
+            os.path.join(CWD, '{}/sharpd.conf'.format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP,
+            os.path.join(CWD, '{}/bgpd.conf'.format(rname))
+        )
+
+    tgen.start_router()
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_bgp_extended_message_capability_adv():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    def _install_sharp_routes(router):
+        router.vtysh_cmd('sharp install routes 172.16.0.0 nexthop 192.168.255.2 5000')
+        output = json.loads(router.vtysh_cmd('show ip route summary json'))
+        expected = {
+            'routes': [
+                {
+                    'fib': 1,
+                    'rib': 1,
+                    'type': 'connected'
+                },
+                {
+                    'fib': 5000,
+                    'rib': 5000,
+                    'type': 'sharp'
+                }
+            ],
+            'routesTotal': 5001
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _uninstall_sharp_routes(router):
+        router.vtysh_cmd('sharp remove routes 172.16.0.0 5000')
+        output = json.loads(router.vtysh_cmd('show ip route summary json'))
+        expected = {
+            'routes': [
+                {
+                    'fib': 1,
+                    'rib': 1,
+                    'type': 'connected'
+                }
+            ],
+            'routesTotal': 1
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_converge(router):
+        output = json.loads(router.vtysh_cmd('show ip bgp neighbor 192.168.255.2 json'))
+        expected = {
+            '192.168.255.2': {
+                'bgpState': 'Established',
+                'addressFamilyInfo': {
+                    'ipv4Unicast': {
+                        'acceptedPrefixCounter': 5000
+                    }
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_extended_message_capability_received(router):
+        output = json.loads(router.vtysh_cmd('show ip bgp neighbor 192.168.255.2 json'))
+        expected = {
+            '192.168.255.2': {
+                'neighborCapabilities': {
+                    'extendedMessage': 'received'
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    def _bgp_extended_message_capability_updates_received(router):
+        output = json.loads(router.vtysh_cmd('show ip bgp neighbor 192.168.255.2 json'))
+        return output['192.168.255.2']['messageStats']['updatesRecv']
+
+    def _bgp_extended_message_capability_both(router):
+        output = json.loads(router.vtysh_cmd('show ip bgp neighbor 192.168.255.2 json'))
+        expected = {
+            '192.168.255.2': {
+                'neighborCapabilities': {
+                    'extendedMessage': 'advertisedAndReceived'
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    # Test without BGP extended message capability
+    test_func = functools.partial(_install_sharp_routes, tgen.gears['r1'])
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, 'Failed installing sharp routes "{}"'.format(tgen.gears['r1'])
+
+    test_func = functools.partial(_bgp_converge, tgen.gears['r2'])
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, 'Failed bgp convergence in "{}"'.format(tgen.gears['r2'])
+
+    test_func = functools.partial(_bgp_extended_message_capability_received, tgen.gears['r2'])
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, 'Failed to see an extended message capability in "{}"'.format(tgen.gears['r2'])
+
+    if success:
+        assert _bgp_extended_message_capability_updates_received(tgen.gears['r2']) > 10
+
+    test_func = functools.partial(_uninstall_sharp_routes, tgen.gears['r1'])
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, 'Failed uninstalling sharp routes "{}"'.format(tgen.gears['r1'])
+
+    # Test with BGP extended message capability
+    test_func = functools.partial(_install_sharp_routes, tgen.gears['r3'])
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, 'Failed installing sharp routes "{}"'.format(tgen.gears['r3'])
+
+    test_func = functools.partial(_bgp_converge, tgen.gears['r4'])
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, 'Failed bgp convergence in "{}"'.format(tgen.gears['r4'])
+
+    test_func = functools.partial(_bgp_extended_message_capability_both, tgen.gears['r4'])
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, 'Failed to see an extended message capability in "{}"'.format(tgen.gears['r4'])
+
+    if success:
+        assert _bgp_extended_message_capability_updates_received(tgen.gears['r4']) < 10
+
+    test_func = functools.partial(_uninstall_sharp_routes, tgen.gears['r1'])
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+    assert result is None, 'Failed uninstalling sharp routes "{}"'.format(tgen.gears['r3'])
+
+if __name__ == '__main__':
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Tested with:
```
root@exit1:~# vtysh -c 'sharp install routes 172.16.0.0 nexthop 192.168.0.1 100000'
root@exit1:~# vtysh -c 'clear ip bgp * soft out'
```

Without BGP Extended message capability
```
$ tail -f /var/log/frr/frr.log
2020/01/08 11:58:09 BGP: bgp_read: 192.168.0.1 ringbuf=654067, ibw=40960, readsize=4096, nbytes=4096
2020/01/08 11:58:09 BGP: bgp_read: 192.168.0.1 ringbuf=652807, ibw=40960, readsize=4096, nbytes=4096
2020/01/08 11:58:09 BGP: bgp_read: 192.168.0.1 ringbuf=654218, ibw=40960, readsize=4096, nbytes=4096
2020/01/08 11:58:09 BGP: bgp_read: 192.168.0.1 ringbuf=653018, ibw=40960, readsize=4096, nbytes=4096
2020/01/08 11:58:09 BGP: bgp_read: 192.168.0.1 ringbuf=652564, ibw=40960, readsize=4096, nbytes=4096
2020/01/08 11:58:09 BGP: bgp_read: 192.168.0.1 ringbuf=654671, ibw=40960, readsize=4096, nbytes=2337
2020/01/08 11:58:11 BGP: bgp_read: 192.168.0.1 ringbuf=655350, ibw=40960, readsize=4096, nbytes=3402
```
With BGP Extended message capability:
```
$ tail -f /var/log/frr/frr.log
2020/01/08 11:55:55 BGP: bgp_read: 192.168.0.1 ringbuf=655350, ibw=655350, readsize=65535, nbytes=1511
2020/01/08 11:55:55 BGP: bgp_read: 192.168.0.1 ringbuf=655350, ibw=655350, readsize=65535, nbytes=11061
2020/01/08 11:55:57 BGP: bgp_read: 192.168.0.1 ringbuf=655350, ibw=655350, readsize=65535, nbytes=65535
2020/01/08 11:55:57 BGP: bgp_read: 192.168.0.1 ringbuf=653334, ibw=655350, readsize=65535, nbytes=7343
2020/01/08 11:55:59 BGP: bgp_read: 192.168.0.1 ringbuf=655350, ibw=655350, readsize=65535, nbytes=1576
2020/01/08 11:55:59 BGP: bgp_read: 192.168.0.1 ringbuf=655350, ibw=655350, readsize=65535, nbytes=65535
```