### PR TITLE
bgpd: fix advertise pip running config

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -5620,19 +5620,24 @@ void bgp_config_write_evpn_info(struct vty *vty, struct bgp *bgp, afi_t afi,
 		if (!bgp->evpn_info->advertise_pip)
 			vty_out(vty, "  no advertise-pip\n");
 		if (bgp->evpn_info->advertise_pip) {
-			if (bgp->evpn_info->pip_ip_static.s_addr != INADDR_ANY)
+			if (bgp->evpn_info->pip_ip_static.s_addr
+			    != INADDR_ANY) {
 				vty_out(vty, "  advertise-pip ip %s",
 					inet_ntop(AF_INET,
 					&bgp->evpn_info->pip_ip_static,
 					buf2, INET_ADDRSTRLEN));
-			if (!is_zero_mac(&(bgp->evpn_info->pip_rmac_static))) {
-				char buf[ETHER_ADDR_STRLEN];
+				if (!is_zero_mac(&(
+					    bgp->evpn_info->pip_rmac_static))) {
+					char buf[ETHER_ADDR_STRLEN];
 
-				vty_out(vty, " mac %s",
-				prefix_mac2str(&bgp->evpn_info->pip_rmac,
-						       buf, sizeof(buf)));
+					vty_out(vty, " mac %s",
+						prefix_mac2str(
+							&bgp->evpn_info
+								 ->pip_rmac,
+							buf, sizeof(buf)));
+				}
+				vty_out(vty, "\n");
 			}
-			vty_out(vty, "\n");
 		}
 	}
 	if (CHECK_FLAG(bgp->vrf_flags, BGP_VRF_RD_CFGD))


### PR DESCRIPTION
advertise pip running configuration should display ip followed
by mac parameters value as defined  in cli signature.

advertise-pip is enabled by default, when displaying the running configuration, 
there is '\n' added after ip and mac parameters which was not guarded around
the non-default parameters.

Currently, for every bgp vrf instance it ends up displaying l2vpn address-family section due to unguarded newline.

router bgp 6004 vrf vrf1
 !
 address-family l2vpn evpn
 exit-address-family
!


Testing Done:

With fix when only 'router bgp 6004 vrf vrf1' configured,
running config looks like:

!
router bgp 6004 vrf vrf1
!

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>