### PR TITLE
bgpd: fix unaligned access to addpath id

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4515,7 +4515,8 @@ int bgp_nlri_parse_ip(struct peer *peer, struct attr *attr,
 			if (pnt + BGP_ADDPATH_ID_LEN >= lim)
 				return BGP_NLRI_PARSE_ERROR_PACKET_OVERFLOW;
 
-			addpath_id = ntohl(*((uint32_t *)pnt));
+			memcpy(&addpath_id, pnt, 4);
+			addpath_id = ntohl(addpath_id);
 			pnt += BGP_ADDPATH_ID_LEN;
 		}
 


### PR DESCRIPTION
uint8_t * cannot be cast to uint32_t * unless the pointed-to address is
aligned according to uint32_t's alignment rules. And it usually is not.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>