### PR TITLE
bgpd: avoid memcmp(NULL, NULL)

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -152,8 +152,9 @@ static bool cluster_hash_cmp(const void *p1, const void *p2)
 	const struct cluster_list *cluster2 = p2;
 
 	return (cluster1->length == cluster2->length
-		&& memcmp(cluster1->list, cluster2->list, cluster1->length)
-			   == 0);
+		&& (cluster1->list == cluster2->list
+		    || memcmp(cluster1->list, cluster2->list, cluster1->length)
+			       == 0));
 }
 
 static void cluster_free(struct cluster_list *cluster)


### PR DESCRIPTION
Undefined behavior

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>