### PR TITLE
zebra: fix ptm heap double free

### DIFF
--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -1295,7 +1295,6 @@ static void zebra_ptm_send_bfdd(struct stream *msg)
 	}
 
 	stream_free(msgc);
-	stream_free(msg);
 }
 
 static void zebra_ptm_send_clients(struct stream *msg)
@@ -1327,7 +1326,6 @@ static void zebra_ptm_send_clients(struct stream *msg)
 	}
 
 	stream_free(msgc);
-	stream_free(msg);
 }
 
 static int _zebra_ptm_bfd_client_deregister(struct zserv *zs)


### PR DESCRIPTION
Don't need to free these, they're freed by the caller.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>