### PR TITLE
bgpd: [7.0] fix large route-distinguisher's format

### DIFF
--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -175,15 +175,16 @@ char *prefix_rd2str(struct prefix_rd *prd, char *buf, size_t size)
 
 	if (type == RD_TYPE_AS) {
 		decode_rd_as(pnt + 2, &rd_as);
-		snprintf(buf, size, "%u:%d", rd_as.as, rd_as.val);
+		snprintf(buf, size, "%u:%" PRIu32, rd_as.as, rd_as.val);
 		return buf;
 	} else if (type == RD_TYPE_AS4) {
 		decode_rd_as4(pnt + 2, &rd_as);
-		snprintf(buf, size, "%u:%d", rd_as.as, rd_as.val);
+		snprintf(buf, size, "%u:%" PRIu32, rd_as.as, rd_as.val);
 		return buf;
 	} else if (type == RD_TYPE_IP) {
 		decode_rd_ip(pnt + 2, &rd_ip);
-		snprintf(buf, size, "%s:%d", inet_ntoa(rd_ip.ip), rd_ip.val);
+		snprintf(buf, size, "%s:%" PRIu16, inet_ntoa(rd_ip.ip),
+			 rd_ip.val);
 		return buf;
 	}
 #if ENABLE_BGP_VNC


### PR DESCRIPTION
This commit is about #5629 's issue.
Before this commit, bgpd creates format string of
bgp-route-distinguisher as int32, but correctly format
is uint32. current bgpd's sh-run-cli generate int32 rd,
so if user sets the rd as 1:4294967295(0x1:0xffffffff),
sh-run cli generates 1: -1 as running-config. This
commit fix that issue.

Signed-off-by: Hiroki Shirokura <slank.dev@gmail.com>