### PR TITLE
zebra: Free up leaked memory in zebra_ptm.c

### DIFF
--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -1346,10 +1346,6 @@ static int _zebra_ptm_bfd_client_deregister(struct zserv *zs)
 
 	/* Generate, send message and free() daemon related data. */
 	msg = stream_new(ZEBRA_MAX_PACKET_SIZ);
-	if (msg == NULL) {
-		zlog_debug("%s: not enough memory", __func__);
-		return 0;
-	}
 
 	/*
 	 * The message type will be BFD_DEST_REPLY so we can use only
@@ -1366,6 +1362,8 @@ static int _zebra_ptm_bfd_client_deregister(struct zserv *zs)
 	stream_putw_at(msg, 0, stream_get_endp(msg));
 
 	zebra_ptm_send_bfdd(msg);
+
+	stream_free(msg);
 
 	pp_free(pp);
 
@@ -1426,6 +1424,7 @@ static void _zebra_ptm_reroute(struct zserv *zs, struct zebra_vrf *zvrf,
 	STREAM_GETL(msg, ppid);
 	pp_new(ppid, zs);
 
+	stream_free(msgc);
 	return;
 
 stream_failure:


### PR DESCRIPTION
ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16416 byte(s) in 1 object(s) allocated from:
    #0 0x7f08e3ca8602 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98602)
    #1 0x7f08e389c4b0 in qmalloc lib/memory.c:105
    #2 0x7f08e38e87b4 in stream_new lib/stream.c:106
    #3 0x481d7f in _zebra_ptm_bfd_client_deregister zebra/zebra_ptm.c:1348
    #4 0x4e7b84 in hook_call_zserv_client_close zebra/zserv.c:544
    #5 0x4e7b84 in zserv_client_free zebra/zserv.c:560
    #6 0x4e7b84 in zserv_close_client zebra/zserv.c:625
    #7 0x4e7fe0 in zserv_handle_client_fail zebra/zserv.c:638
    #8 0x7f08e3901995 in thread_call lib/thread.c:1549
    #9 0x7f08e38937d7 in frr_run lib/libfrr.c:1093
    #10 0x41686e in main zebra/main.c:470
    #11 0x7f08e2fe682f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

Direct leak of 16416 byte(s) in 1 object(s) allocated from:
    #0 0x7f08e3ca8602 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98602)
    #1 0x7f08e389c4b0 in qmalloc lib/memory.c:105
    #2 0x7f08e38e87b4 in stream_new lib/stream.c:106
    #3 0x481efe in _zebra_ptm_reroute zebra/zebra_ptm.c:1411
    #4 0x4f7dc9 in zserv_handle_commands zebra/zapi_msg.c:2642
    #5 0x4e6d32 in zserv_process_messages zebra/zserv.c:517
    #6 0x7f08e3901995 in thread_call lib/thread.c:1549
    #7 0x7f08e38937d7 in frr_run lib/libfrr.c:1093
    #8 0x41686e in main zebra/main.c:470
    #9 0x7f08e2fe682f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

SUMMARY: AddressSanitizer: 32832 byte(s) leaked in 2 allocation(s).

This commit fixes these two different leaks.

Fixes: #5658
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>