### PR TITLE
zebra: fix bfd deregister message memleak

### DIFF
--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -1367,6 +1367,8 @@ static int _zebra_ptm_bfd_client_deregister(struct zserv *zs)
 
 	zebra_ptm_send_bfdd(msg);
 
+	stream_free(msg);
+
 	pp_free(pp);
 
 	return 0;


### PR DESCRIPTION
Removing double frees accidentally introduced a memleak

Fixes: #5658 

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>