### PR TITLE
Nhg topotests fixes

### DIFF
--- a/tests/topotests/ospf6-topo1/r1/ip_6_address.nhg.ref
+++ b/tests/topotests/ospf6-topo1/r1/ip_6_address.nhg.ref
@@ -1,0 +1,10 @@
+fc00:1111:1111:1111::/64 nhid XXXX via fc00:1:1:1::1234 dev r1-stubnet proto XXXX metric 20 pref medium
+fc00:1:1:1::/64 dev r1-stubnet proto XXXX metric 256 pref medium
+fc00:2222:2222:2222::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:2:2:2::/64 nhid XXXX via fe80::__(r2-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3333:3333:3333::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:3:3:3::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4444:4444:4444::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:4:4:4::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium
+fc00:a:a:a::/64 dev r1-sw5 proto XXXX metric 256 pref medium
+fc00:b:b:b::/64 nhid XXXX via fe80::__(r3-sw5)__ dev r1-sw5 proto XXXX metric 20 pref medium

--- a/tests/topotests/ospf6-topo1/test_ospf6_topo1.py
+++ b/tests/topotests/ospf6-topo1/test_ospf6_topo1.py
@@ -89,7 +89,7 @@ sys.path.append(os.path.join(CWD, '../'))
 from lib import topotest
 from lib.topogen import Topogen, TopoRouter, get_topogen
 from lib.topolog import logger
-
+import platform
 
 #####################################################
 ##
@@ -319,7 +319,10 @@ def test_linux_ipv6_kernel_routingTable():
     # Now compare the routing tables (after substituting link-local addresses)
 
     for i in range(1, 5):
-        refTableFile = os.path.join(CWD, 'r{}/ip_6_address.ref'.format(i))
+	if topotest.version_cmp(platform.release(), '5.3') < 0:
+            refTableFile = os.path.join(CWD, 'r{}/ip_6_address.ref'.format(i))
+	else:
+	    refTableFile = os.path.join(CWD, 'r{}/ip_6_address.nhg.ref'.format(i))
         if os.path.isfile(refTableFile):
 
             expected = open(refTableFile).read().rstrip()
@@ -333,6 +336,7 @@ def test_linux_ipv6_kernel_routingTable():
                 actual = actual.replace(ll[1], "fe80::__(%s)__" % ll[0])
             # Mask out protocol name or number
             actual = re.sub(r"[ ]+proto [0-9a-z]+ +", "  proto XXXX ", actual)
+            actual = re.sub(r"[ ]+nhid [0-9]+ +", " nhid XXXX ", actual)
             # Remove ff00::/8 routes (seen on some kernels - not from FRR)
             actual = re.sub(r'ff00::/8.*', '', actual)
 

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -592,6 +592,7 @@ struct rtattr *addattr_nest(struct nlmsghdr *n, int maxlen, int type)
 	struct rtattr *nest = NLMSG_TAIL(n);
 
 	addattr_l(n, maxlen, type, NULL, 0);
+	nest->rta_type |= NLA_F_NESTED;
 	return nest;
 }
 
@@ -606,6 +607,7 @@ struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type)
 	struct rtattr *nest = RTA_TAIL(rta);
 
 	rta_addattr_l(rta, maxlen, type, NULL, 0);
+	nest->rta_type |= NLA_F_NESTED;
 	return nest;
 }
 


### PR DESCRIPTION
1) Fix a test issue where `ip route show` did not properly handle the `nhid XX` line.
2) Fix a bug in zebra where we were not passing data to the kernel properly