### PR TITLE
bgpd, ospfd, zebra: Do not use 0 as VRF_DEFAULT

### DIFF
--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1725,7 +1725,7 @@ static void bgp_pbr_policyroute_remove_from_zebra_unit(
 			temp.type = IPSET_NET_NET;
 	}
 	if (bpf->vrf_id == VRF_UNKNOWN) /* XXX case BGP destroy */
-		temp.vrf_id = 0;
+		temp.vrf_id = VRF_DEFAULT;
 	else
 		temp.vrf_id = bpf->vrf_id;
 	bpme = &temp2;

--- a/ospfd/ospf_vty.c
+++ b/ospfd/ospf_vty.c
@@ -9679,7 +9679,7 @@ DEFUN (show_ip_ospf_vrfs,
 		if (uj)
 			json_vrf = json_object_new_object();
 
-		if (ospf->vrf_id == 0)
+		if (ospf->vrf_id == VRF_DEFAULT)
 			name = VRF_DEFAULT_NAME;
 		else
 			name = ospf->name;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2353,7 +2353,7 @@ int netlink_nexthop_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 	unsigned char family;
 	int type;
 	afi_t afi = AFI_UNSPEC;
-	vrf_id_t vrf_id = 0;
+	vrf_id_t vrf_id = VRF_DEFAULT;
 	struct interface *ifp = NULL;
 	struct nhmsg *nhm = NULL;
 	struct nexthop nh = {};

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1416,7 +1416,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	struct nexthop *nexthop = NULL;
 	struct nexthop_group *ng = NULL;
 	int i, ret;
-	vrf_id_t vrf_id = 0;
+	vrf_id_t vrf_id;
 	struct ipaddr vtep_ip;
 
 	s = msg;

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -507,7 +507,7 @@ static bool zebra_nhg_find(struct nhg_hash_entry **nhe, uint32_t id,
 	if (lookup.nhg->nexthop->next) {
 		/* Groups can have all vrfs and AF's in them */
 		lookup.afi = AFI_UNSPEC;
-		lookup.vrf_id = 0;
+		lookup.vrf_id = VRF_DEFAULT;
 	} else {
 		switch (lookup.nhg->nexthop->type) {
 		case (NEXTHOP_TYPE_IFINDEX):


### PR DESCRIPTION
Explicitly spell out what we are trying to do.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>