### PR TITLE
Revert "zebra: fix bfd deregister message memleak"

### DIFF
--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -1367,8 +1367,6 @@ static int _zebra_ptm_bfd_client_deregister(struct zserv *zs)
 
 	zebra_ptm_send_bfdd(msg);
 
-	stream_free(msg);
-
 	pp_free(pp);
 
 	return 0;


### PR DESCRIPTION
This reverts commit 4fa2974c44a69382a1f796febf9c46fe4ea5d4c8.

Causes crash when daemons disconnect from zebra (?)

Signed-off-by: David Lamparter <equinox@diac24.net>