### PR TITLE
zebra: Fix label manager memory leak

### DIFF
--- a/zebra/label_manager.c
+++ b/zebra/label_manager.c
@@ -262,8 +262,12 @@ assign_specific_label_chunk(uint8_t proto, unsigned short instance,
 		 * included in the previous one */
 		for (node = first_node; node && (node != last_node);
 		     node = next) {
+			struct label_manager_chunk *death;
+
 			next = listnextnode(node);
+			death = listgetdata(node);
 			list_delete_node(lbl_mgr.lc_list, node);
+			delete_label_chunk(death);
 		}
 
 		lmc = create_label_chunk(proto, instance, keep, base, end);


### PR DESCRIPTION
```
==25402==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x533302 in calloc (/usr/lib/frr/zebra+0x533302)
    #1 0x7fee84cdc80b in qcalloc /home/qlyoung/frr/lib/memory.c:110:27
    #2 0x5a3032 in create_label_chunk /home/qlyoung/frr/zebra/label_manager.c:188:3
    #3 0x5a3c2b in assign_label_chunk /home/qlyoung/frr/zebra/label_manager.c:354:8
    #4 0x5a2a38 in label_manager_get_chunk /home/qlyoung/frr/zebra/label_manager.c:424:9
    #5 0x5a1412 in hook_call_lm_get_chunk /home/qlyoung/frr/zebra/label_manager.c:60:1
    #6 0x5a1412 in lm_get_chunk_call /home/qlyoung/frr/zebra/label_manager.c:81:2
    #7 0x72a234 in zread_get_label_chunk /home/qlyoung/frr/zebra/zapi_msg.c:2026:2
    #8 0x72a234 in zread_label_manager_request /home/qlyoung/frr/zebra/zapi_msg.c:2073:4
    #9 0x73150c in zserv_handle_commands /home/qlyoung/frr/zebra/zapi_msg.c:2688:2
```
When creating label chunk that has a specified base, we eventually are
calling assign_specific_label_chunk. This function finds the appropriate
list node and deletes it from the lbl_mgr.lc_list but since
the function uses list_delete_node() the deletion function that is
specified for lbl_mgr.lc_list is not called thus dropping the memory.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>