### PR TITLE
[7.3]zebra: bfd message handling cleanup foo

### DIFF
--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -1295,6 +1295,7 @@ static void zebra_ptm_send_bfdd(struct stream *msg)
 	}
 
 	stream_free(msgc);
+	stream_free(msg);
 }
 
 static void zebra_ptm_send_clients(struct stream *msg)
@@ -1326,6 +1327,7 @@ static void zebra_ptm_send_clients(struct stream *msg)
 	}
 
 	stream_free(msgc);
+	stream_free(msg);
 }
 
 static int _zebra_ptm_bfd_client_deregister(struct zserv *zs)
@@ -1366,8 +1368,6 @@ static int _zebra_ptm_bfd_client_deregister(struct zserv *zs)
 	stream_putw_at(msg, 0, stream_get_endp(msg));
 
 	zebra_ptm_send_bfdd(msg);
-
-	stream_free(msg);
 
 	pp_free(pp);
 
@@ -1423,6 +1423,7 @@ static void _zebra_ptm_reroute(struct zserv *zs, struct zebra_vrf *zvrf,
 	stream_putw_at(msgc, 0, STREAM_READABLE(msgc));
 
 	zebra_ptm_send_bfdd(msgc);
+	msgc = NULL;
 
 	/* Registrate process PID for shutdown hook. */
 	STREAM_GETL(msg, ppid);
@@ -1431,7 +1432,8 @@ static void _zebra_ptm_reroute(struct zserv *zs, struct zebra_vrf *zvrf,
 	return;
 
 stream_failure:
-	stream_free(msgc);
+	if (msgc)
+		stream_free(msgc);
 	zlog_err("%s:%d failed to registrate client pid", __FILE__, __LINE__);
 }
 


### PR DESCRIPTION
Previous patches introduced various issues:
- Removal of stream_free() to fix double free caused memleak
- Patch for memleak was incomplete

This should fix it hopefully.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>