### PR TITLE
bgpd: fix memory leak when parsing capabilities

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -747,6 +747,12 @@ static int bgp_capability_hostname(struct peer *peer,
 
 	if (len) {
 		str[len] = '\0';
+
+		if (peer->domainname != NULL) {
+			XFREE(MTYPE_BGP_PEER_HOST, peer->domainname);
+			peer->domainname = NULL;
+		}
+
 		peer->domainname = XSTRDUP(MTYPE_BGP_PEER_HOST, str);
 	}
 


### PR DESCRIPTION
Duplicated domain name capability messages cause memory leak. The amount
of leaked memory is proportional to the size of the duplicated
capabilities. This bug was introduced in 2015.

To hit this, a BGP OPEN message must contain multiple FQDN capabilities.
Memory is leaked when the hostname portion of the capability is of
length 0, but the domainname portion is not, for any of the duplicated
capabilities beyond the first one.

https://tools.ietf.org/html/draft-walton-bgp-hostname-capability-00

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>