### PR TITLE
bgpd: Add an option to limit outgoing prefixes

### DIFF
--- a/bgpd/bgp_updgrp.c
+++ b/bgpd/bgp_updgrp.c
@@ -143,6 +143,7 @@ static void conf_copy(struct peer *dst, struct peer *src, afi_t afi,
 	dst->v_routeadv = src->v_routeadv;
 	dst->flags = src->flags;
 	dst->af_flags[afi][safi] = src->af_flags[afi][safi];
+	dst->pmax_out[afi][safi] = src->pmax_out[afi][safi];
 	XFREE(MTYPE_BGP_PEER_HOST, dst->host);
 
 	dst->host = XSTRDUP(MTYPE_BGP_PEER_HOST, src->host);

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -208,7 +208,7 @@ struct update_subgroup {
 	struct bgp_synchronize *sync;
 
 	/* send prefix count */
-	unsigned long scount;
+	uint32_t scount;
 
 	/* announcement attribute hash */
 	struct hash *hash;

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -744,6 +744,22 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 		addpath_tx_id = adj->addpath_tx_id;
 		path = adv->pathi;
 
+		/* Check if we need to add a prefix to the packet if
+		 * maximum-prefix-out is set for the peer.
+		 */
+		if (CHECK_FLAG(peer->af_flags[afi][safi],
+			       PEER_FLAG_MAX_PREFIX_OUT)
+		    && subgrp->scount >= peer->pmax_out[afi][safi]) {
+			if (BGP_DEBUG(update, UPDATE_OUT)
+			    || BGP_DEBUG(update, UPDATE_PREFIX)) {
+				zlog_debug(
+					"%s reached maximum prefix to be send (%" PRIu32
+					")",
+					peer->host, peer->pmax_out[afi][safi]);
+			}
+			goto next;
+		}
+
 		space_remaining = STREAM_CONCAT_REMAIN(s, snlri, STREAM_SIZE(s))
 				  - BGP_MAX_PACKET_SIZE_OVERFLOW;
 		space_needed =
@@ -894,7 +910,7 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 			subgrp->scount++;
 
 		adj->attr = bgp_attr_intern(adv->baa->attr);
-
+next:
 		adv = bgp_advertise_clean_subgroup(subgrp, adj);
 	}
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -988,6 +988,7 @@ struct peer {
 #define PEER_FLAG_WEIGHT                    (1 << 24) /* weight */
 #define PEER_FLAG_ALLOWAS_IN_ORIGIN         (1 << 25) /* allowas-in origin */
 #define PEER_FLAG_SEND_LARGE_COMMUNITY      (1 << 26) /* Send large Communities */
+#define PEER_FLAG_MAX_PREFIX_OUT            (1 << 27) /* outgoing maximum prefix */
 
 	enum bgp_addpath_strat addpath_type[AFI_MAX][SAFI_MAX];
 
@@ -1120,9 +1121,6 @@ struct peer {
 	/* timestamp when the last msg was written */
 	_Atomic time_t last_update;
 
-	/* Send prefix count. */
-	unsigned long scount[AFI_MAX][SAFI_MAX];
-
 	/* Notify data. */
 	struct bgp_notify notify;
 
@@ -1172,6 +1170,9 @@ struct peer {
 	uint8_t pmax_threshold[AFI_MAX][SAFI_MAX];
 	uint16_t pmax_restart[AFI_MAX][SAFI_MAX];
 #define MAXIMUM_PREFIX_THRESHOLD_DEFAULT 75
+
+	/* Send prefix count. */
+	uint32_t pmax_out[AFI_MAX][SAFI_MAX];
 
 	/* allowas-in. */
 	char allowas_in[AFI_MAX][SAFI_MAX];

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1075,6 +1075,11 @@ Configuring Peers
    granular and offers much smarter matching criterion than number of received
    prefixes, making it more suited to implementing policy.
 
+.. index:: [no] neighbor PEER maximum-prefix-out NUMBER
+.. clicmd:: [no] neighbor PEER maximum-prefix-out NUMBER
+
+   Sets a maximum number of prefixes we can send to a given peer.
+
 .. index:: [no] neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
 .. clicmd:: [no] neighbor PEER local-as AS-NUMBER [no-prepend] [replace-as]
 

--- a/tests/topotests/bgp_maximum_prefix_out/r1/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_out/r1/bgpd.conf
@@ -1,0 +1,9 @@
+!
+router bgp 65001
+  neighbor 192.168.255.1 remote-as 65002
+  address-family ipv4 unicast
+    redistribute connected
+    neighbor 192.168.255.1 maximum-prefix-out 2
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_maximum_prefix_out/r1/zebra.conf
+++ b/tests/topotests/bgp_maximum_prefix_out/r1/zebra.conf
@@ -1,0 +1,13 @@
+!
+interface lo
+ ip address 172.16.255.250/32
+ ip address 172.16.255.251/32
+ ip address 172.16.255.252/32
+ ip address 172.16.255.253/32
+ ip address 172.16.255.254/32
+!
+interface r1-eth0
+ ip address 192.168.255.2/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_maximum_prefix_out/r2/bgpd.conf
+++ b/tests/topotests/bgp_maximum_prefix_out/r2/bgpd.conf
@@ -1,0 +1,6 @@
+!
+router bgp 65002
+  neighbor 192.168.255.2 remote-as 65001
+  exit-address-family
+  !
+!

--- a/tests/topotests/bgp_maximum_prefix_out/r2/zebra.conf
+++ b/tests/topotests/bgp_maximum_prefix_out/r2/zebra.conf
@@ -1,0 +1,6 @@
+!
+interface r2-eth0
+ ip address 192.168.255.1/30
+!
+ip forwarding
+!

--- a/tests/topotests/bgp_maximum_prefix_out/test_bgp_maximum_prefix_out.py
+++ b/tests/topotests/bgp_maximum_prefix_out/test_bgp_maximum_prefix_out.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+#
+# test_bgp_maximum_prefix_out.py
+# Part of NetDEF Topology Tests
+#
+# Copyright (c) 2020 by
+# Donatas Abraitis <donatas.abraitis@gmail.com>
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND NETDEF DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL NETDEF BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+#
+
+"""
+Test if `neighbor <X.X.X.X> maximum-prefix-out <Y>` is working
+correctly.
+"""
+
+import os
+import sys
+import json
+import time
+import pytest
+import functools
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(CWD, '../'))
+
+# pylint: disable=C0413
+from lib import topotest
+from lib.topogen import Topogen, TopoRouter, get_topogen
+from lib.topolog import logger
+from mininet.topo import Topo
+
+class TemplateTopo(Topo):
+    def build(self, *_args, **_opts):
+        tgen = get_topogen(self)
+
+        for routern in range(1, 3):
+            tgen.add_router('r{}'.format(routern))
+
+        switch = tgen.add_switch('s1')
+        switch.add_link(tgen.gears['r1'])
+        switch.add_link(tgen.gears['r2'])
+
+def setup_module(mod):
+    tgen = Topogen(TemplateTopo, mod.__name__)
+    tgen.start_topology()
+
+    router_list = tgen.routers()
+
+    for i, (rname, router) in enumerate(router_list.iteritems(), 1):
+        router.load_config(
+            TopoRouter.RD_ZEBRA,
+            os.path.join(CWD, '{}/zebra.conf'.format(rname))
+        )
+        router.load_config(
+            TopoRouter.RD_BGP,
+            os.path.join(CWD, '{}/bgpd.conf'.format(rname))
+        )
+
+    tgen.start_router()
+
+def teardown_module(mod):
+    tgen = get_topogen()
+    tgen.stop_topology()
+
+def test_bgp_maximum_prefix_out():
+    tgen = get_topogen()
+
+    if tgen.routers_have_failure():
+        pytest.skip(tgen.errors)
+
+    router = tgen.gears['r2']
+
+    def _bgp_converge(router):
+        output = json.loads(router.vtysh_cmd("show ip bgp neighbor 192.168.255.2 json"))
+        expected = {
+            '192.168.255.2': {
+                'bgpState': 'Established',
+                'addressFamilyInfo': {
+                    'ipv4Unicast': {
+                        'acceptedPrefixCounter': 2
+                    }
+                }
+            }
+        }
+        return topotest.json_cmp(output, expected)
+
+    test_func = functools.partial(_bgp_converge, router)
+    success, result = topotest.run_and_expect(test_func, None, count=60, wait=0.5)
+
+    assert result is None, 'Failed bgp convergence in "{}"'.format(router)
+
+if __name__ == '__main__':
+    args = ["-s"] + sys.argv[1:]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
Related: https://github.com/FRRouting/frr/issues/4983