### PR TITLE
[7.3]lib: Fix nexthop encoding

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -899,8 +899,6 @@ int zapi_nexthop_encode(struct stream *s, const struct zapi_nexthop *api_nh,
 		stream_putc(s, api_nh->bh_type);
 		break;
 	case NEXTHOP_TYPE_IPV4:
-		stream_put_in_addr(s, &api_nh->gate.ipv4);
-		break;
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 		stream_put_in_addr(s, &api_nh->gate.ipv4);
 		stream_putl(s, api_nh->ifindex);
@@ -909,9 +907,6 @@ int zapi_nexthop_encode(struct stream *s, const struct zapi_nexthop *api_nh,
 		stream_putl(s, api_nh->ifindex);
 		break;
 	case NEXTHOP_TYPE_IPV6:
-		stream_write(s, (uint8_t *)&api_nh->gate.ipv6,
-			     16);
-		break;
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
 		stream_write(s, (uint8_t *)&api_nh->gate.ipv6,
 			     16);
@@ -1059,9 +1054,6 @@ static int zapi_nexthop_decode(struct stream *s, struct zapi_nexthop *api_nh,
 		STREAM_GETC(s, api_nh->bh_type);
 		break;
 	case NEXTHOP_TYPE_IPV4:
-		STREAM_GET(&api_nh->gate.ipv4.s_addr, s,
-			   IPV4_MAX_BYTELEN);
-		break;
 	case NEXTHOP_TYPE_IPV4_IFINDEX:
 		STREAM_GET(&api_nh->gate.ipv4.s_addr, s,
 			   IPV4_MAX_BYTELEN);
@@ -1071,8 +1063,6 @@ static int zapi_nexthop_decode(struct stream *s, struct zapi_nexthop *api_nh,
 		STREAM_GETL(s, api_nh->ifindex);
 		break;
 	case NEXTHOP_TYPE_IPV6:
-		STREAM_GET(&api_nh->gate.ipv6, s, 16);
-		break;
 	case NEXTHOP_TYPE_IPV6_IFINDEX:
 		STREAM_GET(&api_nh->gate.ipv6, s, 16);
 		STREAM_GETL(s, api_nh->ifindex);


### PR DESCRIPTION
Commit
68a02e06e5f103048d947262c08c569056f74d1c broke nexthop encoding
for nexthop tracking.

This code combined the different types of nexthop encoding
being done in the zapi protocol.  What was missed that
resolved nexthops of type NEXTHOP_TYPE_IPV4|6 have an ifindex
value that was not being reported.  This commit ensures
that we always send this data( even if it is 0).

The following test commit will ensure that this stays working
as is expected by an upper level protocol.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>