### PR TITLE
route-map `on-match goto prefix-list-seqno`

### DIFF
--- a/lib/plist.h
+++ b/lib/plist.h
@@ -67,8 +67,9 @@ extern struct prefix_list *prefix_list_lookup(afi_t, const char *);
 extern enum prefix_list_type
 prefix_list_apply_which_prefix(struct prefix_list *plist,
 			       const struct prefix **which,
+			       uint32_t *seq,
 			       const void *object);
-#define prefix_list_apply(A, B) prefix_list_apply_which_prefix((A), NULL, (B))
+#define prefix_list_apply(A, B) prefix_list_apply_which_prefix((A), NULL, NULL, (B))
 
 extern struct prefix_list *prefix_bgp_orf_lookup(afi_t, const char *);
 extern struct stream *prefix_bgp_orf_entry(struct stream *,

--- a/lib/routemap.h
+++ b/lib/routemap.h
@@ -77,7 +77,12 @@ typedef enum {
 	RMAP_ISIS,
 } route_map_object_t;
 
-typedef enum { RMAP_EXIT, RMAP_GOTO, RMAP_NEXT } route_map_end_t;
+typedef enum {
+	RMAP_EXIT,
+	RMAP_GOTO,
+	RMAP_GOTO_PLIST,
+	RMAP_NEXT,
+} route_map_end_t;
 
 typedef enum {
 	RMAP_EVENT_SET_ADDED,
@@ -107,6 +112,15 @@ typedef enum {
 /* Depth limit in RMAP recursion using RMAP_CALL. */
 #define RMAP_RECURSION_LIMIT      10
 
+struct route_map_state {
+	const struct prefix *prefix;
+
+	route_map_object_t type;
+	void *object;
+
+	uint32_t plist_seqno;
+};
+
 /* Route map rule structure for matching and setting. */
 struct route_map_rule_cmd {
 	/* Route map rule name (e.g. as-path, metric) */
@@ -126,6 +140,10 @@ struct route_map_rule_cmd {
 
 	/** To get the rule key after Compilation **/
 	void *(*func_get_rmap_rule_key)(void *val);
+
+	/* Extended "apply" function */
+	enum route_map_cmd_result_t (*func_apply_ext)(void *rule,
+						struct route_map_state *state);
 };
 
 /* Route map apply error. */

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -218,8 +218,8 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 		if (rp_info->plist) {
 			plist = prefix_list_lookup(AFI_IP, rp_info->plist);
 
-			if (prefix_list_apply_which_prefix(plist, &p, group)
-			    == PREFIX_DENY)
+			if (prefix_list_apply_which_prefix(plist, &p, NULL,
+					group) == PREFIX_DENY)
 				continue;
 
 			if (!best) {


### PR DESCRIPTION
This is an alternate approach / "discussion" PR for #5270.

It uses the sequence number from the prefix list as the "goto" target in the route-map.  This might be a bit "unconventional", but the change is much less intrusive than #5270 and possibly faster too.

```
ip prefix-list foo seq 100 permit 192.0.2.0/24
ip prefix-list foo seq 200 permit 10.0.0.0/8

route-map bar permit 10
  match ip address prefix-list foo
  on-match goto prefix-list-seqno

route-map bar permit 100
  description "goto target for 192.0.2.0/24"
  no on-match next

route-map bar permit 200
  description "goto target for 10.0.0.0/8"
  no on-match next
```

While the concept may be a bit "huh?" to users, I think there is also a benefit in having it be _obvious_ to the user what's happening.

Either way this **PR is for discussion / comparing with #5270**.

(Downside: due to the way we match prefix lists, all the daemons need a similar "mechanical" change as I've done here for bgpd, but I don't think that's a problem.)