### PR TITLE
Move rpm to python3

### DIFF
--- a/doc/developer/packaging-redhat.rst
+++ b/doc/developer/packaging-redhat.rst
@@ -22,6 +22,11 @@ Tested on CentOS 6, CentOS 7, CentOS 8 and Fedora 24.
 
       yum install systemd-devel
 
+   For CentOS 7 and CentOS 8, the package will be built using python3
+   and requires additional python3 packages::
+
+       yum install python3-devel python3-sphinx
+
    .. note::
 
      For CentOS 8 you need to install ``platform-python-devel`` package
@@ -29,13 +34,6 @@ Tested on CentOS 6, CentOS 7, CentOS 8 and Fedora 24.
 
        yum install platform-python-devel
 
-   .. warning::
-
-     ``python2-sphinx`` is not shipped for CentOS 8.
-     Development reached the end of life for Python 2.
-     We need to install it using ```pip``::
-
-        pip2 install sphinx
 
    If ``yum`` is not present on your system, use ``dnf`` instead.
 

--- a/redhat/frr.spec.in
+++ b/redhat/frr.spec.in
@@ -63,6 +63,13 @@
 %endif
 %endif
 
+# Check for python version - use python2.7 on CentOS 6, otherwise python3
+%if 0%{?rhel} && 0%{?rhel} < 7
+    %global use_python2 1
+%else
+    %global use_python2 0
+%endif
+
 # If init system is systemd, then always enable watchfrr
 %if "%{initsystem}" == "systemd"
     %global with_watchfrr 1
@@ -169,14 +176,17 @@ BuildRequires:  libyang-devel >= 0.16.74
 BuildRequires:  python27-devel
 BuildRequires:  python27-sphinx
 %else
-%if 0%{?rhel} && 0%{?rhel} > 7
-BuildRequires:  python2-devel
-#platform-python-devel is needed for /usr/bin/pathfix.py
-BuildRequires:  platform-python-devel
-%else
+%if %{use_python2}
 BuildRequires:  python-devel >= 2.7
 BuildRequires:  python-sphinx
+%else
+BuildRequires:  python3-devel
+BuildRequires:  python3-sphinx
 %endif
+%endif
+%if 0%{?rhel} > 7
+#platform-python-devel is needed for /usr/bin/pathfix.py
+BuildRequires:  platform-python-devel
 %endif
 Requires:       initscripts
 %if %{with_pam}
@@ -223,12 +233,17 @@ Contributed/3rd party tools which may be of use with frr.
 
 %package pythontools
 Summary: python tools for frr
-%if 0%{?rhel} && 0%{?rhel} > 7
-BuildRequires: python2
-Requires: python2-ipaddress
+%if 0%{?rhel} && 0%{?rhel} < 7
+#python27 is available from ius community repo for RedHat/CentOS 6
+BuildRequires:  python27
+Requires:  python27-ipaddress
 %else
-BuildRequires: python
-Requires: python-ipaddress
+%if %{use_python2}
+BuildRequires:  python2
+Requires:  python2-ipaddress
+%else
+BuildRequires:  python3
+%endif
 %endif
 Group: System Environment/Daemons
 
@@ -369,6 +384,16 @@ developing OSPF-API and frr applications.
 
 make %{?_smp_mflags} MAKEINFO="makeinfo --no-split"
 
+%if %{use_python2}
+# Change frr-reload.py to use python2.7
+sed -e '1c #!/usr/bin/python2.7' -i %{zeb_src}/tools/frr-reload.py
+sed -e '1c #!/usr/bin/python2.7' -i %{zeb_src}/tools/generate_support_bundle.py
+%else
+# Change frr-reload.py to use python3
+sed -e '1c #!/usr/bin/python3' -i %{zeb_src}/tools/frr-reload.py
+sed -e '1c #!/usr/bin/python3' -i %{zeb_src}/tools/generate_support_bundle.py
+%endif
+
 pushd doc
 make info
 popd
@@ -408,10 +433,10 @@ install -m644 %{zeb_rh_src}/frr.pam %{buildroot}%{_sysconfdir}/pam.d/frr
 install -m644 %{zeb_rh_src}/frr.logrotate %{buildroot}%{_sysconfdir}/logrotate.d/frr
 install -d -m750 %{buildroot}%{rundir}
 
-%if 0%{?rhel} && 0%{?rhel} > 7
+%if 0%{?rhel} > 7 || 0%{?fedora} > 29
 # avoid `ERROR: ambiguous python shebang in` errors
-pathfix.py -pni "%{__python2} %{py2_shbang_opts}" %{buildroot}/usr/lib/frr/*.py
-%py_byte_compile %{__python2} %{buildroot}/usr/lib/frr/*.py
+pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}/usr/lib/frr/*.py
+%py_byte_compile %{__python3} %{buildroot}/usr/lib/frr/*.py
 %endif
 
 %pre
@@ -674,11 +699,16 @@ fi
 
 %files pythontools
 %{_sbindir}/generate_support_bundle.py
+%{_sbindir}/frr-reload.py
+%if 0%{?rhel} > 7 || 0%{?fedora} > 29
+%{_sbindir}/__pycache__/*
+%else
 %{_sbindir}/generate_support_bundle.pyc
 %{_sbindir}/generate_support_bundle.pyo
 %{_sbindir}/frr-reload.py
 %{_sbindir}/frr-reload.pyc
 %{_sbindir}/frr-reload.pyo
+%endif
 
 
 %files devel

--- a/tools/generate_support_bundle.py
+++ b/tools/generate_support_bundle.py
@@ -30,16 +30,16 @@ def createOutputFile(procName):
   oldFile = LOG_DIR + fileName
   cpFileCmd = "cp " + oldFile + " " + oldFile + ".prev"
   rmFileCmd = "rm -rf " + oldFile
-  print "Making backup of " + oldFile
+  print("Making backup of " + oldFile)
   os.system(cpFileCmd)
-  print "Removing " + oldFile
+  print("Removing " + oldFile)
   os.system(rmFileCmd)
   return fileName
 
 # Open the output file for this process
 def openOutputFile(fileName):
   crt_file_cmd = LOG_DIR + fileName
-  print crt_file_cmd
+  print(crt_file_cmd)
   try:
     outputFile = open(crt_file_cmd, "w")
     return outputFile
@@ -67,14 +67,14 @@ def executeCommand(cmd, outputFile):
       outputFile.write("########################################################\n")
       outputFile.write('\n')
     except:
-      print "Writing to ouptut file Failed"
+      print("Writing to ouptut file Failed")
   except subprocess.CalledProcessError as e:
     dateTime = datetime.datetime.now()
     outputFile.write(">>[" + str(dateTime) + "]" + cmd + "\n")
     outputFile.write(e.output)
     outputFile.write("########################################################\n")
     outputFile.write('\n')
-    print "Error:" + e.output
+    print("Error:" + e.output)
 
 
 # Process the support bundle configuration file
@@ -87,26 +87,26 @@ def processConfFile(lines):
     if cmd_line[0] == "PROC_NAME":
       outputFileName = createOutputFile(cmd_line[1])
       if outputFileName:
-        print outputFileName, "created for", cmd_line[1]
+        print(outputFileName, "created for", cmd_line[1])
     elif cmd_line[0] == "CMD_LIST_START":
       outputFile = openOutputFile(outputFileName)
       if outputFile:
-        print outputFileName, "opened"
+        print(outputFileName, "opened")
       else:
-        print outputFileName, "open failed"
-	return FAIL
+        print(outputFileName, "open failed")
+        return FAIL
     elif cmd_line[0] == "CMD_LIST_END":
       if closeOutputFile(outputFile):
-        print outputFileName, "closed"
+        print(outputFileName, "closed")
       else:
-        print outputFileName, "close failed"
+        print(outputFileName, "close failed")
     else:
-      print "Execute:" , cmd_line[0]
+      print("Execute:" , cmd_line[0])
       executeCommand(cmd_line[0], outputFile)
       
 # Main Function
 lines = openConfFile(inputFile)
 if not lines:
-  print "File support_bundle_commands.conf not present in /etc/frr/ directory"
+  print("File support_bundle_commands.conf not present in /etc/frr/ directory")
 else:
   processConfFile(lines)


### PR DESCRIPTION
Update RPM packages to move them all to Python 3 (instead of Python 2) with the exception of CentOS 6 which stays at Python 2.7

Tested to build on CentOS 6, 7 & 8 and Fedora 29 & 31
