### PR TITLE
lib: Fix missing __be16 typedef on CentOS6

### DIFF
--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -52,7 +52,9 @@ typedef unsigned char uint8_t;
 #include <sys/types.h>
 #include <sys/param.h>
 #ifdef HAVE_SYS_SYSCTL_H
-#ifndef GNU_LINUX
+#ifdef GNU_LINUX
+#include <linux/types.h>
+#else
 #include <sys/sysctl.h>
 #endif
 #endif /* HAVE_SYS_SYSCTL_H */


### PR DESCRIPTION
Need to include linux/types.h on older Linux
Same fix as PR #5710 implemented for master to go into 7.3

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>