### PR TITLE
zebra: NHG fixes in the dataplane conversion function

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1929,8 +1929,10 @@ static uint8_t zebra_nhg_nhe2grp_internal(struct nh_grp *grp,
 
 			/* Check for duplicate IDs, ignore if found. */
 			for (int j = 0; j < i; j++) {
-				if (depend->id == grp[j].id)
+				if (depend->id == grp[j].id) {
 					duplicate = true;
+					break;
+				}
 			}
 
 			if (duplicate) {

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1834,16 +1834,33 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 	return curr_active;
 }
 
-/* Convert a nhe into a group array */
-uint8_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe,
-			  int max_num)
+/* Recursively construct a grp array of fully resolved IDs.
+ *
+ * This function allows us to account for groups within groups,
+ * by converting them into a flat array of IDs.
+ *
+ * nh_grp is modified at every level of recursion to append
+ * to it the next unique, fully resolved ID from the entire tree.
+ *
+ *
+ * Note:
+ * I'm pretty sure we only allow ONE level of group within group currently.
+ * But making this recursive just in case that ever changes.
+ */
+static uint8_t zebra_nhg_nhe2grp_internal(struct nh_grp *grp,
+					  uint8_t curr_index,
+					  struct nhg_hash_entry *nhe,
+					  int max_num)
 {
 	struct nhg_connected *rb_node_dep = NULL;
 	struct nhg_hash_entry *depend = NULL;
-	uint8_t i = 0;
+	uint8_t i = curr_index;
 
 	frr_each(nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
 		bool duplicate = false;
+
+		if (i >= max_num)
+			goto done;
 
 		depend = rb_node_dep->nhe;
 
@@ -1861,25 +1878,34 @@ uint8_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe,
 			}
 		}
 
-		/* Check for duplicate IDs, kernel doesn't like that */
-		for (int j = 0; j < i; j++) {
-			if (depend->id == grp[j].id)
-				duplicate = true;
-		}
+		if (!zebra_nhg_depends_is_empty(depend)) {
+			/* This is a group within a group */
+			i = zebra_nhg_nhe2grp_internal(grp, i, depend, max_num);
+		} else {
+			/* Check for duplicate IDs, kernel doesn't like that */
+			for (int j = 0; j < i; j++) {
+				if (depend->id == grp[j].id)
+					duplicate = true;
+			}
 
-		if (!duplicate) {
-			grp[i].id = depend->id;
-			/* We aren't using weights for anything right now */
-			grp[i].weight = depend->nhg.nexthop->weight;
-			i++;
+			if (!duplicate) {
+				grp[i].id = depend->id;
+				grp[i].weight = depend->nhg.nexthop->weight;
+				i++;
+			}
 		}
-
-		if (i >= max_num)
-			goto done;
 	}
 
 done:
 	return i;
+}
+
+/* Convert a nhe into a group array */
+uint8_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe,
+			  int max_num)
+{
+	/* Call into the recursive function */
+	return zebra_nhg_nhe2grp_internal(grp, 0, nhe, max_num);
 }
 
 void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe)

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1896,17 +1896,24 @@ static uint8_t zebra_nhg_nhe2grp_internal(struct nh_grp *grp,
 				continue;
 			}
 
-			/* Check for duplicate IDs, kernel doesn't like that */
+			/* Check for duplicate IDs, ignore if found. */
 			for (int j = 0; j < i; j++) {
 				if (depend->id == grp[j].id)
 					duplicate = true;
 			}
 
-			if (!duplicate) {
-				grp[i].id = depend->id;
-				grp[i].weight = depend->nhg.nexthop->weight;
-				i++;
+			if (duplicate) {
+				if (IS_ZEBRA_DEBUG_RIB_DETAILED
+				    || IS_ZEBRA_DEBUG_NHG)
+					zlog_debug(
+						"%s: Nexthop ID (%u) is duplicate, not appending to dataplane install group",
+						__func__, depend->id);
+				continue;
 			}
+
+			grp[i].id = depend->id;
+			grp[i].weight = depend->nhg.nexthop->weight;
+			i++;
 		}
 	}
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1882,6 +1882,20 @@ static uint8_t zebra_nhg_nhe2grp_internal(struct nh_grp *grp,
 			/* This is a group within a group */
 			i = zebra_nhg_nhe2grp_internal(grp, i, depend, max_num);
 		} else {
+			/* If the nexthop not installed/queued for install don't
+			 * put in the ID array.
+			 */
+			if (!(CHECK_FLAG(depend->flags, NEXTHOP_GROUP_INSTALLED)
+			      || CHECK_FLAG(depend->flags,
+					    NEXTHOP_GROUP_QUEUED))) {
+				if (IS_ZEBRA_DEBUG_RIB_DETAILED
+				    || IS_ZEBRA_DEBUG_NHG)
+					zlog_debug(
+						"%s: Nexthop ID (%u) not installed or queued for install, not appending to dataplane install group",
+						__func__, depend->id);
+				continue;
+			}
+
 			/* Check for duplicate IDs, kernel doesn't like that */
 			for (int j = 0; j < i; j++) {
 				if (depend->id == grp[j].id)

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1811,19 +1811,8 @@ int nexthop_active_update(struct route_node *rn, struct route_entry *re)
 		route_entry_update_nhe(re, new_nhe);
 	}
 
-	if (curr_active) {
-		struct nhg_hash_entry *nhe = NULL;
-
-		nhe = zebra_nhg_lookup_id(re->nhe_id);
-
-		if (nhe)
-			SET_FLAG(nhe->flags, NEXTHOP_GROUP_VALID);
-		else
-			flog_err(
-				EC_ZEBRA_TABLE_LOOKUP_FAILED,
-				"Active update on NHE id=%u that we do not have in our tables",
-				re->nhe_id);
-	}
+	if (curr_active)
+		SET_FLAG(re->nhe->flags, NEXTHOP_GROUP_VALID);
 
 	/*
 	 * Do not need these nexthops anymore since they


### PR DESCRIPTION
See individual commits.

Fixes are all for bugs in the dataplane NHE to Array of IDs conversion function we call when constructing the dataplane context object for a kernel nexthop group.