### PR TITLE
bgpd: Update some attributes how they are handled if malformed

### DIFF
--- a/tests/bgpd/test_aspath.c
+++ b/tests/bgpd/test_aspath.c
@@ -653,7 +653,7 @@ static struct aspath_tests {
 		&test_segments[6],
 		NULL,
 		AS4_DATA,
-		-1,
+		-2,
 		PEER_CAP_AS4_ADV,
 		{
 			COMMON_ATTRS,


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7606 some of the attributes
MUST be handled as "treat-as-withdraw" approach.

Closes https://github.com/FRRouting/frr/issues/3583

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>