### PR TITLE
yang: add vrf ref to interface model

### DIFF
--- a/yang/frr-interface.yang
+++ b/yang/frr-interface.yang
@@ -3,6 +3,10 @@ module frr-interface {
   namespace "http://frrouting.org/yang/interface";
   prefix frr-interface;
 
+  import frr-vrf {
+    prefix frr-vrf;
+  }
+
   organization
     "Free Range Routing";
   contact
@@ -25,7 +29,6 @@ module frr-interface {
       key "name vrf";
       description
         "Interface.";
-
       leaf name {
         type string {
           length "1..16";
@@ -33,13 +36,13 @@ module frr-interface {
         description
           "Interface name.";
       }
+
       leaf vrf {
-        type string {
-          length "1..36";
-        }
+        type frr-vrf:vrf-ref;
         description
           "VRF this interface is associated with.";
       }
+
       leaf description {
         type string;
         description


### PR DESCRIPTION
```
module: frr-interface
  +--rw lib
     +--rw interface* [name vrf]
        +--rw name           string
        +--rw vrf            frr-vrf:vrf-ref
        +--rw description?   string
```

Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>