### PR TITLE
yang: zebra interface state operational model

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -1746,32 +1746,7 @@ lib_interface_state_phy_address_get_elem(const char *xpath,
 }
 
 /* clang-format off */
-
-#if defined(__GNUC__) && ((__GNUC__ - 0) < 5) && !defined(__clang__)
-/* gcc versions before 5.x miscalculate the size for structs with variable
- * length arrays (they just count it as size 0)
- */
-struct frr_yang_module_info_size3 {
-	/* YANG module name. */
-	const char *name;
-
-	/* Northbound callbacks. */
-	const struct {
-		/* Data path of this YANG node. */
-		const char *xpath;
-
-		/* Callbacks implemented for this node. */
-		struct nb_callbacks cbs;
-
-		/* Priority - lower priorities are processed first. */
-		uint32_t priority;
-	} nodes[3];
-};
-
-const struct frr_yang_module_info_size3 frr_interface_info_size3 asm("frr_interface_info") = {
-#else
 const struct frr_yang_module_info frr_interface_info = {
-#endif
 	.name = "frr-interface",
 	.nodes = {
 		{

--- a/lib/if.c
+++ b/lib/if.c
@@ -1655,6 +1655,96 @@ static int lib_interface_description_destroy(enum nb_event event,
 	return NB_OK;
 }
 
+/*
+ * XPath: /frr-interface:lib/interface/state/if-index
+ */
+struct yang_data *lib_interface_state_if_index_get_elem(const char *xpath,
+							const void *list_entry)
+{
+	const struct interface *ifp = list_entry;
+
+	return yang_data_new_int32(xpath, ifp->ifindex);
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/state/mtu
+ */
+struct yang_data *lib_interface_state_mtu_get_elem(const char *xpath,
+						   const void *list_entry)
+{
+	const struct interface *ifp = list_entry;
+
+	return yang_data_new_uint16(xpath, ifp->mtu);
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/state/mtu6
+ */
+struct yang_data *lib_interface_state_mtu6_get_elem(const char *xpath,
+						    const void *list_entry)
+{
+	const struct interface *ifp = list_entry;
+
+	return yang_data_new_uint32(xpath, ifp->mtu6);
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/state/speed
+ */
+struct yang_data *lib_interface_state_speed_get_elem(const char *xpath,
+						     const void *list_entry)
+{
+	const struct interface *ifp = list_entry;
+
+	return yang_data_new_uint32(xpath, ifp->speed);
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/state/metric
+ */
+struct yang_data *lib_interface_state_metric_get_elem(const char *xpath,
+						      const void *list_entry)
+{
+	const struct interface *ifp = list_entry;
+
+	return yang_data_new_uint32(xpath, ifp->metric);
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/state/flags
+ */
+struct yang_data *lib_interface_state_flags_get_elem(const char *xpath,
+						     const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/state/type
+ */
+struct yang_data *lib_interface_state_type_get_elem(const char *xpath,
+						    const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/state/phy-address
+ */
+struct yang_data *
+lib_interface_state_phy_address_get_elem(const char *xpath,
+					 const void *list_entry)
+{
+	const struct interface *ifp = list_entry;
+	struct ethaddr macaddr;
+
+	memcpy(&macaddr.octet, ifp->hw_addr, ETH_ALEN);
+
+	return yang_data_new_mac(xpath, &macaddr);
+}
+
 /* clang-format off */
 
 #if defined(__GNUC__) && ((__GNUC__ - 0) < 5) && !defined(__clang__)
@@ -1702,6 +1792,54 @@ const struct frr_yang_module_info frr_interface_info = {
 				.destroy = lib_interface_description_destroy,
 				.cli_show = cli_show_interface_desc,
 			},
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/state/if-index",
+			.cbs = {
+				.get_elem = lib_interface_state_if_index_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/state/mtu",
+			.cbs = {
+				.get_elem = lib_interface_state_mtu_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/state/mtu6",
+			.cbs = {
+				.get_elem = lib_interface_state_mtu6_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/state/speed",
+			.cbs = {
+				.get_elem = lib_interface_state_speed_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/state/metric",
+			.cbs = {
+				.get_elem = lib_interface_state_metric_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/state/flags",
+			.cbs = {
+				.get_elem = lib_interface_state_flags_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/state/type",
+			.cbs = {
+				.get_elem = lib_interface_state_type_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/state/phy-address",
+			.cbs = {
+				.get_elem = lib_interface_state_phy_address_get_elem,
+			}
 		},
 		{
 			.xpath = NULL,

--- a/lib/if.h
+++ b/lib/if.h
@@ -577,6 +577,24 @@ extern void if_destroy_via_zapi(struct interface *ifp);
 
 extern const struct frr_yang_module_info frr_interface_info;
 
+struct yang_data *lib_interface_state_if_index_get_elem(const char *xpath,
+							const void *list_entry);
+struct yang_data *lib_interface_state_mtu_get_elem(const char *xpath,
+						   const void *list_entry);
+struct yang_data *lib_interface_state_mtu6_get_elem(const char *xpath,
+						    const void *list_entry);
+struct yang_data *lib_interface_state_speed_get_elem(const char *xpath,
+						     const void *list_entry);
+struct yang_data *lib_interface_state_metric_get_elem(const char *xpath,
+						      const void *list_entry);
+struct yang_data *lib_interface_state_flags_get_elem(const char *xpath,
+						     const void *list_entry);
+struct yang_data *lib_interface_state_type_get_elem(const char *xpath,
+						    const void *list_entry);
+struct yang_data *
+lib_interface_state_phy_address_get_elem(const char *xpath,
+					 const void *list_entry);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -113,6 +113,7 @@ nodist_lib_libfrr_la_SOURCES = \
 	yang/frr-vrf.yang.c \
 	yang/frr-routing.yang.c \
 	yang/ietf/ietf-routing-types.yang.c \
+	yang/ietf/ietf-interfaces.yang.c \
 	yang/frr-module-translator.yang.c \
 	yang/frr-nexthop.yang.c \
 	yang/frr-igmp.yang.c \

--- a/yang/frr-interface.yang
+++ b/yang/frr-interface.yang
@@ -7,6 +7,14 @@ module frr-interface {
     prefix frr-vrf;
   }
 
+  import ietf-interfaces {
+    prefix ietf-if;
+  }
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
   organization
     "Free Range Routing";
   contact
@@ -15,6 +23,10 @@ module frr-interface {
   description
     "This module defines a model for managing FRR interfaces.";
 
+  revision 2020-02-05 {
+    description
+      "Added operational data";
+  }
   revision 2019-09-09 {
     description
       "Added interface-ref typedef";
@@ -22,6 +34,231 @@ module frr-interface {
   revision 2018-03-28 {
     description
       "Initial revision.";
+  }
+
+  identity other {
+    base ietf-if:interface-type;
+    description
+      "Other type";
+  }
+
+  identity unknown {
+    base ietf-if:interface-type;
+    description
+      "Unknown type";
+  }
+
+  identity ethernet {
+    base ietf-if:interface-type;
+    description
+      "Ethernet type";
+  }
+
+  identity exper-ethernet {
+    base ietf-if:interface-type;
+    description
+      "Experimental Ethernet type";
+  }
+
+  identity loopback {
+    base ietf-if:interface-type;
+    description
+      "Loopback type";
+  }
+
+  identity pimreg {
+    base ietf-if:interface-type;
+    description
+      "PIMSM Registration.";
+  }
+
+  identity ipip {
+    base ietf-if:interface-type;
+    description
+      "IPIP Tunnel.";
+  }
+
+  identity ipip6 {
+    base ietf-if:interface-type;
+    description
+      "IPIP6 Tunnel.";
+  }
+
+  identity ipgre {
+    base ietf-if:interface-type;
+    description
+      "GRE over IP.";
+  }
+
+  typedef interface-ref {
+    type leafref {
+      path "/frr-interface:lib/frr-interface:interface/frr-interface:name";
+      require-instance false;
+    }
+    description
+      "Reference to an interface";
+  }
+
+  typedef if-flags-type {
+    type enumeration {
+      enum "up" {
+        value 1;
+        description
+          "Active and ready to transfer packets.";
+      }
+      enum "broadcast" {
+        value 2;
+        description
+          "Broadcast enabled.";
+      }
+      enum "debug" {
+        value 3;
+        description
+          "Debug mode.";
+      }
+      enum "loopback" {
+        value 4;
+        description
+          "Loopback interface.";
+      }
+      enum "point-to-point" {
+        value 5;
+        description
+          "Point-to-Point link.";
+      }
+      enum "notrailers" {
+        value 6;
+        description
+          "This flag is unused in Linux, but it exists for BSD compatibility.
+          Avoid use of trailers";
+      }
+      enum "running" {
+        value 7;
+        description
+          "Up and Running.";
+      }
+      enum "noarp" {
+        value 8;
+        description
+          "Can't perform address resolution protocol.";
+      }
+      enum "promisc" {
+        value 9;
+        description
+          "Promiscuous mode. Receive all packets.";
+      }
+      enum "allmulti" {
+        value 10;
+        description
+          "Receive all multicast packets.";
+      }
+      enum "simplex" {
+        value 11;
+        description
+          "Does not Rx or Tx at the sametime.";
+      }
+      enum "link0" {
+        value 12;
+        description
+          "Link0.";
+      }
+      enum "link1" {
+        value 13;
+        description
+          "Link1.";
+      }
+      enum "link2" {
+        value 14;
+        description
+          "Link2.";
+      }
+      enum "multicast" {
+        value 15;
+        description
+          "Supports multicast transmission.";
+      }
+      enum "notransmit" {
+        value 16;
+        description
+          "Interface is no transmit mode.";
+      }
+      enum "nortexch" {
+        value 17;
+        description
+          "No routing info exchange.";
+      }
+      enum "virtual" {
+        value 18;
+        description
+          "Virtual interface.";
+      }
+      enum "ipv4" {
+        value 19;
+        description
+          "IPv4 enabled.";
+      }
+      enum "ipv6" {
+        value 20;
+        description
+          "IPv6 enabled.";
+      }
+    }
+  }
+
+  grouping if-common-operational {
+    leaf if-index {
+      type int32 {
+        range "0..2147483647";
+      }
+      description
+        "Interface index.";
+    }
+
+    leaf mtu {
+      type uint16;
+      description
+        "The size of the largest IPV4 packet that the interface
+         will send and receive.";
+    }
+
+    leaf mtu6 {
+      type uint32;
+      description
+        "The size of the largest IPV6 packet that the interface
+         will send and receive.";
+    }
+
+    leaf speed {
+      type uint32;
+      description
+        "Interface speed.";
+    }
+
+    leaf metric {
+      type uint32;
+      description
+        "Interface metric.";
+    }
+
+    leaf flags {
+      type if-flags-type;
+      description
+        "Interface flags.";
+    }
+
+    leaf type {
+      type identityref {
+        base ietf-if:interface-type;
+      }
+      description
+        "The link type of the interface.";
+    }
+
+    leaf phy-address {
+      type yang:mac-address;
+      description
+        "The interface's MAC address.";
+    }
   }
 
   container lib {
@@ -52,15 +289,11 @@ module frr-interface {
         description
           "Interface description.";
       }
-    }
-  }
 
-  typedef interface-ref {
-    type leafref {
-      require-instance false;
-      path "/frr-interface:lib/frr-interface:interface/frr-interface:name";
+      container state {
+        config false;
+        uses if-common-operational;
+      }
     }
-    description
-      "Reference to an interface";
   }
 }

--- a/yang/frr-zebra.yang
+++ b/yang/frr-zebra.yang
@@ -23,6 +23,10 @@ module frr-zebra {
     prefix frr-nh;
   }
 
+  import frr-routing {
+    prefix frr-rt;
+  }
+
   import frr-interface {
     prefix frr-interface;
   }
@@ -78,6 +82,65 @@ module frr-zebra {
     units "seconds";
     description
       "An absolute time in seconds since the unix epoch.";
+  }
+
+  identity zebra-interface-type {
+    description
+      "zebra interface type.";
+  }
+
+  identity zif-other {
+    base zebra-interface-type;
+    description
+      "Zebra interface type other.";
+  }
+
+  identity zif-bridge {
+    base zebra-interface-type;
+    description
+      "Zebra interface type bridge.";
+  }
+
+  identity zif-vlan {
+    base zebra-interface-type;
+    description
+      "Zebra interface type vlan.";
+  }
+
+  identity zif-vxlan {
+    base zebra-interface-type;
+    description
+      "Zebra interface type vxlan.";
+  }
+
+  identity zif-vrf {
+    base zebra-interface-type;
+    description
+      "Zebra interface type vrf.";
+  }
+
+  identity zif-veth {
+    base zebra-interface-type;
+    description
+      "Zebra interface type veth.";
+  }
+
+  identity zif-bond {
+    base zebra-interface-type;
+    description
+      "Zebra interface type bond.";
+  }
+
+  identity zif-bond-slave {
+    base zebra-interface-type;
+    description
+      "Zebra interface type bond slave.";
+  }
+
+  identity zif-macvlan {
+    base zebra-interface-type;
+    description
+      "Zebra interface type macvlan.";
   }
 
   /*
@@ -361,7 +424,7 @@ module frr-zebra {
         "The gateway MAC-IP is being advertised.";
     }
 
-    leaf mcase-group {
+    leaf mcast-group {
       type rt-types:ipv4-multicast-group-address;
       description
         "The VNI multicast group for BUM traffic.";
@@ -1862,39 +1925,32 @@ module frr-zebra {
     description
       "Extends interface model with Zebra-related parameters.";
     container zebra {
-      list ip4-addr-list {
-        key "ip4-prefix";
+      list ip-addrs {
+        key "address-family ip-prefix";
         description
-          "IPv4 prefixes for an interface.";
-        leaf ip4-prefix {
-          type inet:ipv4-prefix;
+          "IP prefixes for an interface.";
+        uses frr-rt:address-family {
           description
-            "IPv4 address prefix.";
+            "Address family of the RIB.";
         }
+
+        leaf ip-prefix {
+          type inet:ip-prefix;
+          description
+            "IP address prefix.";
+        }
+
+        leaf label {
+          type string;
+          description
+            "Optional string label for the address.";
+        }
+
         leaf ip4-peer {
+          when "derived-from-or-self(../address-family, 'ipv4')";
           type inet:ipv4-prefix;
           description
             "Peer prefix, for peer-to-peer interfaces.";
-        }
-        leaf label {
-          type string;
-          description
-            "Optional string label for the address.";
-        }
-      }
-      list ip6-addr-list {
-        key "ip6-prefix";
-        description
-          "IPv6 prefixes for an interface.";
-        leaf ip6-prefix {
-          type inet:ipv6-prefix;
-          description
-            "IPv6 address prefix.";
-        }
-        leaf label {
-          type string;
-          description
-            "Optional string label for the address.";
         }
       }
 
@@ -1903,16 +1959,19 @@ module frr-zebra {
         description
           "Multicast flag for the interface.";
       }
+
       leaf link-detect {
         type boolean;
         description
           "Link-detection for the interface.";
       }
+
       leaf shutdown {
         type boolean;
         description
           "Interface admin status.";
       }
+
       leaf bandwidth {
         type uint32 {
           range "1..100000";
@@ -1921,6 +1980,61 @@ module frr-zebra {
           "Link bandwidth informational parameter, in megabits.";
       }
       // TODO -- link-params for (experimental/partial TE use in IGP extensions)
+      container state {
+        config false;
+        description
+          "Operational data.";
+        leaf up-count {
+          type uint16;
+          description
+            "Interface Up count.";
+        }
+
+        leaf down-count {
+          type uint16;
+          description
+            "Interface Down count.";
+        }
+
+        leaf zif-type {
+          type identityref {
+            base zebra-interface-type;
+          }
+          description
+            "zebra interface type.";
+        }
+
+        leaf ptm-status {
+          type string;
+          default "disabled";
+          description
+            "Interface PTM status.";
+        }
+
+        leaf vlan-id {
+          type uint16 {
+            range "1..4094";
+          }
+          description
+            "A VLAN id.";
+        }
+
+        leaf vni-id {
+          type vni-id-type;
+        }
+
+        leaf remote-vtep {
+          type inet:ipv4-address;
+          description
+            "The remote VTEP IP address.";
+        }
+
+        leaf mcast-group {
+          type rt-types:ipv4-multicast-group-address;
+          description
+            "The VNI multicast group for BUM traffic.";
+        }
+      }
     }
   }
 

--- a/yang/ietf/ietf-interfaces.yang
+++ b/yang/ietf/ietf-interfaces.yang
@@ -1,0 +1,1123 @@
+module ietf-interfaces {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces";
+  prefix if;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETMOD (Network Modeling) Working Group";
+
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+
+  description
+    "This module contains a collection of YANG definitions for
+     managing network interfaces.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8343; see
+     the RFC itself for full legal notices.";
+
+  revision 2018-02-20 {
+    description
+      "Updated to support NMDA.";
+    reference
+      "RFC 8343: A YANG Data Model for Interface Management";
+  }
+
+  revision 2014-05-08 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7223: A YANG Data Model for Interface Management";
+  }
+
+  /*
+   * Typedefs
+   */
+
+  typedef interface-ref {
+    type leafref {
+      path "/if:interfaces/if:interface/if:name";
+    }
+    description
+      "This type is used by data models that need to reference
+       interfaces.";
+  }
+
+  /*
+   * Identities
+   */
+
+  identity interface-type {
+    description
+      "Base identity from which specific interface types are
+       derived.";
+  }
+
+  /*
+   * Features
+   */
+
+  feature arbitrary-names {
+    description
+      "This feature indicates that the device allows user-controlled
+       interfaces to be named arbitrarily.";
+  }
+  feature pre-provisioning {
+    description
+      "This feature indicates that the device supports
+       pre-provisioning of interface configuration, i.e., it is
+       possible to configure an interface whose physical interface
+       hardware is not present on the device.";
+  }
+  feature if-mib {
+    description
+      "This feature indicates that the device implements
+       the IF-MIB.";
+    reference
+      "RFC 2863: The Interfaces Group MIB";
+  }
+
+  /*
+   * Data nodes
+   */
+
+  container interfaces {
+    description
+      "Interface parameters.";
+
+    list interface {
+      key "name";
+
+      description
+        "The list of interfaces on the device.
+
+         The status of an interface is available in this list in the
+         operational state.  If the configuration of a
+         system-controlled interface cannot be used by the system
+         (e.g., the interface hardware present does not match the
+         interface type), then the configuration is not applied to
+         the system-controlled interface shown in the operational
+         state.  If the configuration of a user-controlled interface
+         cannot be used by the system, the configured interface is
+         not instantiated in the operational state.
+
+         System-controlled interfaces created by the system are
+         always present in this list in the operational state,
+         whether or not they are configured.";
+
+     leaf name {
+        type string;
+        description
+          "The name of the interface.
+
+           A device MAY restrict the allowed values for this leaf,
+           possibly depending on the type of the interface.
+           For system-controlled interfaces, this leaf is the
+           device-specific name of the interface.
+
+           If a client tries to create configuration for a
+           system-controlled interface that is not present in the
+           operational state, the server MAY reject the request if
+           the implementation does not support pre-provisioning of
+           interfaces or if the name refers to an interface that can
+           never exist in the system.  A Network Configuration
+           Protocol (NETCONF) server MUST reply with an rpc-error
+           with the error-tag 'invalid-value' in this case.
+
+           If the device supports pre-provisioning of interface
+           configuration, the 'pre-provisioning' feature is
+           advertised.
+
+           If the device allows arbitrarily named user-controlled
+           interfaces, the 'arbitrary-names' feature is advertised.
+
+           When a configured user-controlled interface is created by
+           the system, it is instantiated with the same name in the
+           operational state.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+
+      leaf description {
+        type string;
+        description
+          "A textual description of the interface.
+
+           A server implementation MAY map this leaf to the ifAlias
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifAlias.  The definition of
+           such a mechanism is outside the scope of this document.
+
+           Since ifAlias is defined to be stored in non-volatile
+           storage, the MIB implementation MUST map ifAlias to the
+           value of 'description' in the persistently stored
+           configuration.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAlias";
+      }
+
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        description
+          "The type of the interface.
+
+           When an interface entry is created, a server MAY
+           initialize the type leaf with a valid value, e.g., if it
+           is possible to derive the type from the name of the
+           interface.
+
+           If a client tries to set the type of an interface to a
+           value that can never be used by the system, e.g., if the
+           type is not supported or if the type does not match the
+           name of the interface, the server MUST reject the request.
+           A NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "This leaf contains the configured, desired state of the
+           interface.
+
+           Systems that implement the IF-MIB use the value of this
+           leaf in the intended configuration to set
+           IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+           has been initialized, as described in RFC 2863.
+
+           Changes in this leaf in the intended configuration are
+           reflected in ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf link-up-down-trap-enable {
+        if-feature if-mib;
+        type enumeration {
+          enum enabled {
+            value 1;
+            description
+              "The device will generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+          enum disabled {
+            value 2;
+            description
+              "The device will not generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+        }
+        description
+          "Controls whether linkUp/linkDown SNMP notifications
+           should be generated for this interface.
+
+           If this node is not configured, the value 'enabled' is
+           operationally used by the server for interfaces that do
+           not operate on top of any other interface (i.e., there are
+           no 'lower-layer-if' entries), and 'disabled' otherwise.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifLinkUpDownTrapEnable";
+      }
+
+      leaf admin-status {
+        if-feature if-mib;
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf oper-status {
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+
+            description
+              "The interface does not pass any packets.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum unknown {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum dormant {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum not-present {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum lower-layer-down {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+
+      leaf last-change {
+        type yang:date-and-time;
+        config false;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+
+      leaf if-index {
+        if-feature if-mib;
+        type int32 {
+          range "1..2147483647";
+        }
+        config false;
+        mandatory true;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+
+      leaf phys-address {
+        type yang:phys-address;
+        config false;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+
+      leaf-list higher-layer-if {
+        type interface-ref;
+        config false;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf-list lower-layer-if {
+        type interface-ref;
+        config false;
+
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        config false;
+        description
+            "An estimate of the interface's current bandwidth in bits
+             per second.  For interfaces that do not vary in
+             bandwidth or for those where no accurate estimation can
+             be made, this node should contain the nominal bandwidth.
+             For interfaces that have no concept of bandwidth, this
+             node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+
+      container statistics {
+        config false;
+        description
+          "A collection of interface-related statistics objects.";
+
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+
+        leaf in-octets {
+          type yang:counter64;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+
+        leaf in-discards {
+          type yang:counter32;
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+
+        leaf in-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+
+        leaf in-unknown-protos {
+          type yang:counter32;
+
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+
+        leaf out-octets {
+          type yang:counter64;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+
+        leaf out-discards {
+          type yang:counter32;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+
+        leaf out-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+
+    }
+  }
+
+  /*
+   * Legacy typedefs
+   */
+
+  typedef interface-state-ref {
+    type leafref {
+      path "/if:interfaces-state/if:interface/if:name";
+    }
+    status deprecated;
+    description
+      "This type is used by data models that need to reference
+       the operationally present interfaces.";
+  }
+
+  /*
+   * Legacy operational state data nodes
+   */
+
+  container interfaces-state {
+    config false;
+    status deprecated;
+    description
+      "Data nodes for the operational state of interfaces.";
+
+    list interface {
+      key "name";
+      status deprecated;
+
+      description
+        "The list of interfaces on the device.
+
+         System-controlled interfaces created by the system are
+         always present in this list, whether or not they are
+         configured.";
+
+      leaf name {
+        type string;
+        status deprecated;
+        description
+          "The name of the interface.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The type of the interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+
+      leaf admin-status {
+        if-feature if-mib;
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf oper-status {
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "The interface does not pass any packets.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum unknown {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum dormant {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum not-present {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum lower-layer-down {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+
+      leaf last-change {
+        type yang:date-and-time;
+        status deprecated;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+
+      leaf if-index {
+        if-feature if-mib;
+        type int32 {
+          range "1..2147483647";
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+
+      leaf phys-address {
+        type yang:phys-address;
+        status deprecated;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+
+      leaf-list higher-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf-list lower-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        status deprecated;
+        description
+            "An estimate of the interface's current bandwidth in bits
+             per second.  For interfaces that do not vary in
+             bandwidth or for those where no accurate estimation can
+
+             be made, this node should contain the nominal bandwidth.
+             For interfaces that have no concept of bandwidth, this
+             node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+
+      container statistics {
+        status deprecated;
+        description
+          "A collection of interface-related statistics objects.";
+
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          status deprecated;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+
+        leaf in-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+
+        leaf in-discards {
+          type yang:counter32;
+          status deprecated;
+
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+
+        leaf in-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+
+        leaf in-unknown-protos {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+
+        leaf out-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+
+        leaf out-discards {
+          type yang:counter32;
+          status deprecated;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+
+        leaf out-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+    }
+  }
+}

--- a/yang/subdir.am
+++ b/yang/subdir.am
@@ -30,6 +30,7 @@ dist_yangmodels_DATA += yang/frr-routing.yang
 dist_yangmodels_DATA += yang/ietf/ietf-routing-types.yang
 dist_yangmodels_DATA += yang/frr-nexthop.yang
 dist_yangmodels_DATA += yang/frr-igmp.yang
+dist_yangmodels_DATA += yang/ietf/ietf-interfaces.yang
 
 if BFDD
 dist_yangmodels_DATA += yang/frr-bfdd.yang

--- a/zebra/interface.c
+++ b/zebra/interface.c
@@ -500,7 +500,7 @@ void if_flags_update(struct interface *ifp, uint64_t newflags)
 
 /* Wake up configured address if it is not in current kernel
    address. */
-static void if_addr_wakeup(struct interface *ifp)
+void if_addr_wakeup(struct interface *ifp)
 {
 	struct listnode *node, *nnode;
 	struct connected *ifc;
@@ -1881,6 +1881,24 @@ DEFUN (show_interface_desc_vrf_all,
 	return CMD_SUCCESS;
 }
 
+int if_multicast_set(struct interface *ifp)
+{
+	struct zebra_if *if_data;
+
+	if (CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
+		if (if_set_flags(ifp, IFF_MULTICAST) < 0) {
+			zlog_debug("Can't set multicast flag on interface %s",
+				   ifp->name);
+			return -1;
+		}
+		if_refresh(ifp);
+	}
+	if_data = ifp->info;
+	if_data->multicast = IF_ZEBRA_MULTICAST_ON;
+
+	return 0;
+}
+
 DEFUN (multicast,
        multicast_cmd,
        "multicast",
@@ -1902,6 +1920,24 @@ DEFUN (multicast,
 	if_data->multicast = IF_ZEBRA_MULTICAST_ON;
 
 	return CMD_SUCCESS;
+}
+
+int if_multicast_unset(struct interface *ifp)
+{
+	struct zebra_if *if_data;
+
+	if (CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
+		if (if_unset_flags(ifp, IFF_MULTICAST) < 0) {
+			zlog_debug("Can't unset multicast flag on interface %s",
+				   ifp->name);
+			return -1;
+		}
+		if_refresh(ifp);
+	}
+	if_data = ifp->info;
+	if_data->multicast = IF_ZEBRA_MULTICAST_OFF;
+
+	return 0;
 }
 
 DEFUN (no_multicast,
@@ -1928,23 +1964,35 @@ DEFUN (no_multicast,
 	return CMD_SUCCESS;
 }
 
-DEFUN (linkdetect,
-       linkdetect_cmd,
-       "link-detect",
-       "Enable link detection on interface\n")
+int if_linkdetect(struct interface *ifp, bool detect)
 {
-	VTY_DECLVAR_CONTEXT(interface, ifp);
 	int if_was_operative;
 
 	if_was_operative = if_is_no_ptm_operative(ifp);
-	SET_FLAG(ifp->status, ZEBRA_INTERFACE_LINKDETECTION);
+	if (detect) {
+		SET_FLAG(ifp->status, ZEBRA_INTERFACE_LINKDETECTION);
 
-	/* When linkdetection is enabled, if might come down */
-	if (!if_is_no_ptm_operative(ifp) && if_was_operative)
-		if_down(ifp);
+		/* When linkdetection is enabled, if might come down */
+		if (!if_is_no_ptm_operative(ifp) && if_was_operative)
+			if_down(ifp);
+	} else {
+		UNSET_FLAG(ifp->status, ZEBRA_INTERFACE_LINKDETECTION);
 
+		/* Interface may come up after disabling link detection */
+		if (if_is_operative(ifp) && !if_was_operative)
+			if_up(ifp);
+	}
 	/* FIXME: Will defer status change forwarding if interface
 	   does not come down! */
+	return 0;
+}
+
+DEFUN(linkdetect, linkdetect_cmd, "link-detect",
+      "Enable link detection on interface\n")
+{
+	VTY_DECLVAR_CONTEXT(interface, ifp);
+
+	if_linkdetect(ifp, true);
 
 	return CMD_SUCCESS;
 }
@@ -1957,18 +2005,29 @@ DEFUN (no_linkdetect,
        "Disable link detection on interface\n")
 {
 	VTY_DECLVAR_CONTEXT(interface, ifp);
-	int if_was_operative;
 
-	if_was_operative = if_is_no_ptm_operative(ifp);
-	UNSET_FLAG(ifp->status, ZEBRA_INTERFACE_LINKDETECTION);
-
-	/* Interface may come up after disabling link detection */
-	if (if_is_operative(ifp) && !if_was_operative)
-		if_up(ifp);
-
-	/* FIXME: see linkdetect_cmd */
+	if_linkdetect(ifp, false);
 
 	return CMD_SUCCESS;
+}
+
+int if_shutdown(struct interface *ifp)
+{
+	struct zebra_if *if_data;
+
+	if (ifp->ifindex != IFINDEX_INTERNAL) {
+		/* send RA lifetime of 0 before stopping. rfc4861/6.2.5 */
+		rtadv_stop_ra(ifp);
+		if (if_unset_flags(ifp, IFF_UP) < 0) {
+			zlog_debug("Can't shutdown interface %s", ifp->name);
+			return -1;
+		}
+		if_refresh(ifp);
+	}
+	if_data = ifp->info;
+	if_data->shutdown = IF_ZEBRA_SHUTDOWN_ON;
+
+	return 0;
 }
 
 DEFUN (shutdown_if,
@@ -1994,6 +2053,30 @@ DEFUN (shutdown_if,
 	if_data->shutdown = IF_ZEBRA_SHUTDOWN_ON;
 
 	return CMD_SUCCESS;
+}
+
+int if_no_shutdown(struct interface *ifp)
+{
+	struct zebra_if *if_data;
+
+	if (ifp->ifindex != IFINDEX_INTERNAL) {
+		if (if_set_flags(ifp, IFF_UP | IFF_RUNNING) < 0) {
+			zlog_debug("Can't up interface %s", ifp->name);
+			return -1;
+		}
+		if_refresh(ifp);
+
+		/* Some addresses (in particular, IPv6 addresses on Linux) get
+		 * removed when the interface goes down. They need to be
+		 * readded.
+		 */
+		if_addr_wakeup(ifp);
+	}
+
+	if_data = ifp->info;
+	if_data->shutdown = IF_ZEBRA_SHUTDOWN_OFF;
+
+	return 0;
 }
 
 DEFUN (no_shutdown_if,
@@ -2748,6 +2831,79 @@ DEFUN (no_link_params_use_bw,
 	return CMD_SUCCESS;
 }
 
+int if_ip_address_install(struct interface *ifp, struct prefix *prefix,
+			  const char *label, struct prefix *pp)
+{
+	struct zebra_if *if_data;
+	struct prefix_ipv4 lp;
+	struct prefix_ipv4 *p;
+	struct connected *ifc;
+	enum zebra_dplane_result dplane_res;
+
+	if_data = ifp->info;
+
+	lp.family = prefix->family;
+	lp.prefix = prefix->u.prefix4;
+	lp.prefixlen = prefix->prefixlen;
+	apply_mask_ipv4(&lp);
+
+	ifc = connected_check_ptp(ifp, &lp, pp ? pp : NULL);
+	if (!ifc) {
+		ifc = connected_new();
+		ifc->ifp = ifp;
+
+		/* Address. */
+		p = prefix_ipv4_new();
+		*p = lp;
+		ifc->address = (struct prefix *)p;
+
+		if (pp) {
+			SET_FLAG(ifc->flags, ZEBRA_IFA_PEER);
+			p = prefix_ipv4_new();
+			*p = *(struct prefix_ipv4 *)pp;
+			ifc->destination = (struct prefix *)p;
+		}
+
+		/* Label. */
+		if (label)
+			ifc->label = XSTRDUP(MTYPE_CONNECTED_LABEL, label);
+
+		/* Add to linked list. */
+		listnode_add(ifp->connected, ifc);
+	}
+
+	/* This address is configured from zebra. */
+	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_CONFIGURED))
+		SET_FLAG(ifc->conf, ZEBRA_IFC_CONFIGURED);
+
+	/* In case of this route need to install kernel. */
+	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_QUEUED)
+	    && CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)
+	    && !(if_data && if_data->shutdown == IF_ZEBRA_SHUTDOWN_ON)) {
+		/* Some system need to up the interface to set IP address. */
+		if (!if_is_up(ifp)) {
+			if_set_flags(ifp, IFF_UP | IFF_RUNNING);
+			if_refresh(ifp);
+		}
+
+		dplane_res = dplane_intf_addr_set(ifp, ifc);
+		if (dplane_res == ZEBRA_DPLANE_REQUEST_FAILURE) {
+			zlog_debug(
+				"dplane can't set interface IP address: %s.\n",
+				dplane_res2str(dplane_res));
+			return NB_ERR;
+		}
+
+		SET_FLAG(ifc->conf, ZEBRA_IFC_QUEUED);
+		/* The address will be advertised to zebra clients when the
+		 * notification
+		 * from the kernel has been received.
+		 * It will also be added to the subnet chain list, then. */
+	}
+
+	return 0;
+}
+
 static int ip_address_install(struct vty *vty, struct interface *ifp,
 			      const char *addr_str, const char *peer_str,
 			      const char *label)
@@ -2840,6 +2996,51 @@ static int ip_address_install(struct vty *vty, struct interface *ifp,
 	}
 
 	return CMD_SUCCESS;
+}
+
+int if_ip_address_uinstall(struct interface *ifp, struct prefix *prefix)
+{
+	struct connected *ifc = NULL;
+	enum zebra_dplane_result dplane_res;
+
+	if (prefix->family == AF_INET) {
+		/* Check current interface address. */
+		ifc = connected_check_ptp(ifp, prefix, NULL);
+		if (!ifc) {
+			zlog_debug("interface %s Can't find address\n",
+				   ifp->name);
+			return -1;
+		}
+
+	} else if (prefix->family == AF_INET6) {
+		/* Check current interface address. */
+		ifc = connected_check(ifp, prefix);
+	}
+
+	if (!ifc) {
+		zlog_debug("interface %s Can't find address\n", ifp->name);
+		return -1;
+	}
+	UNSET_FLAG(ifc->conf, ZEBRA_IFC_CONFIGURED);
+
+	/* This is not real address or interface is not active. */
+	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_QUEUED)
+	    || !CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
+		listnode_delete(ifp->connected, ifc);
+		connected_free(&ifc);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	/* This is real route. */
+	dplane_res = dplane_intf_addr_unset(ifp, ifc);
+	if (dplane_res == ZEBRA_DPLANE_REQUEST_FAILURE) {
+		zlog_debug("Can't unset interface IP address: %s.\n",
+			   dplane_res2str(dplane_res));
+		return -1;
+	}
+	UNSET_FLAG(ifc->conf, ZEBRA_IFC_QUEUED);
+
+	return 0;
 }
 
 static int ip_address_uninstall(struct vty *vty, struct interface *ifp,
@@ -2994,6 +3195,71 @@ DEFUN (no_ip_address_label,
 				    NULL, argv[idx_line]->arg);
 }
 #endif /* HAVE_NETLINK */
+
+int if_ipv6_address_install(struct interface *ifp, struct prefix *prefix,
+			    const char *label)
+{
+	struct zebra_if *if_data;
+	struct prefix_ipv6 cp;
+	struct connected *ifc;
+	struct prefix_ipv6 *p;
+	enum zebra_dplane_result dplane_res;
+
+	if_data = ifp->info;
+
+	cp.family = prefix->family;
+	cp.prefixlen = prefix->prefixlen;
+	cp.prefix = prefix->u.prefix6;
+	apply_mask_ipv6(&cp);
+
+	ifc = connected_check(ifp, (struct prefix *)&cp);
+	if (!ifc) {
+		ifc = connected_new();
+		ifc->ifp = ifp;
+
+		/* Address. */
+		p = prefix_ipv6_new();
+		*p = cp;
+		ifc->address = (struct prefix *)p;
+
+		/* Label. */
+		if (label)
+			ifc->label = XSTRDUP(MTYPE_CONNECTED_LABEL, label);
+
+		/* Add to linked list. */
+		listnode_add(ifp->connected, ifc);
+	}
+
+	/* This address is configured from zebra. */
+	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_CONFIGURED))
+		SET_FLAG(ifc->conf, ZEBRA_IFC_CONFIGURED);
+
+	/* In case of this route need to install kernel. */
+	if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_QUEUED)
+	    && CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)
+	    && !(if_data && if_data->shutdown == IF_ZEBRA_SHUTDOWN_ON)) {
+		/* Some system need to up the interface to set IP address. */
+		if (!if_is_up(ifp)) {
+			if_set_flags(ifp, IFF_UP | IFF_RUNNING);
+			if_refresh(ifp);
+		}
+
+		dplane_res = dplane_intf_addr_set(ifp, ifc);
+		if (dplane_res == ZEBRA_DPLANE_REQUEST_FAILURE) {
+			zlog_debug(
+				"dplane can't set interface IP address: %s.\n",
+				dplane_res2str(dplane_res));
+			return NB_ERR;
+		}
+
+		SET_FLAG(ifc->conf, ZEBRA_IFC_QUEUED);
+		/* The address will be advertised to zebra clients when the
+		 * notification
+		 * from the kernel has been received. */
+	}
+
+	return 0;
+}
 
 static int ipv6_address_install(struct vty *vty, struct interface *ifp,
 				const char *addr_str, const char *peer_str,

--- a/zebra/interface.h
+++ b/zebra/interface.h
@@ -440,6 +440,17 @@ extern void zebra_if_update_link(struct interface *ifp, ifindex_t link_ifindex,
 				 ns_id_t ns_id);
 extern void zebra_if_update_all_links(void);
 extern void zebra_if_set_protodown(struct interface *ifp, bool down);
+extern int if_ip_address_install(struct interface *ifp, struct prefix *prefix,
+				 const char *label, struct prefix *pp);
+extern int if_ipv6_address_install(struct interface *ifp, struct prefix *prefix,
+				   const char *label);
+extern int if_ip_address_uinstall(struct interface *ifp, struct prefix *prefix);
+extern int if_shutdown(struct interface *ifp);
+extern int if_no_shutdown(struct interface *ifp);
+extern int if_multicast_set(struct interface *ifp);
+extern int if_multicast_unset(struct interface *ifp);
+extern int if_linkdetect(struct interface *ifp, bool detect);
+extern void if_addr_wakeup(struct interface *ifp);
 
 /* Nexthop group connected functions */
 extern void if_nhg_dependents_add(struct interface *ifp,

--- a/zebra/zebra_nb.c
+++ b/zebra/zebra_nb.c
@@ -323,38 +323,24 @@ const struct frr_yang_module_info frr_zebra_info = {
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list",
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip-addrs",
 			.cbs = {
-				.create = lib_interface_zebra_ip4_addr_list_create,
-				.destroy = lib_interface_zebra_ip4_addr_list_destroy,
+				.create = lib_interface_zebra_ip_addrs_create,
+				.destroy = lib_interface_zebra_ip_addrs_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/ip4-peer",
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip-addrs/label",
 			.cbs = {
-				.modify = lib_interface_zebra_ip4_addr_list_ip4_peer_modify,
-				.destroy = lib_interface_zebra_ip4_addr_list_ip4_peer_destroy,
+				.modify = lib_interface_zebra_ip_addrs_label_modify,
+				.destroy = lib_interface_zebra_ip_addrs_label_destroy,
 			}
 		},
 		{
-			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/label",
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip-addrs/ip4-peer",
 			.cbs = {
-				.modify = lib_interface_zebra_ip4_addr_list_label_modify,
-				.destroy = lib_interface_zebra_ip4_addr_list_label_destroy,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list",
-			.cbs = {
-				.create = lib_interface_zebra_ip6_addr_list_create,
-				.destroy = lib_interface_zebra_ip6_addr_list_destroy,
-			}
-		},
-		{
-			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list/label",
-			.cbs = {
-				.modify = lib_interface_zebra_ip6_addr_list_label_modify,
-				.destroy = lib_interface_zebra_ip6_addr_list_label_destroy,
+				.modify = lib_interface_zebra_ip_addrs_ip4_peer_modify,
+				.destroy = lib_interface_zebra_ip_addrs_ip4_peer_destroy,
 			}
 		},
 		{
@@ -383,6 +369,54 @@ const struct frr_yang_module_info frr_zebra_info = {
 			.cbs = {
 				.modify = lib_interface_zebra_bandwidth_modify,
 				.destroy = lib_interface_zebra_bandwidth_destroy,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/state/up-count",
+			.cbs = {
+				.get_elem = lib_interface_zebra_state_up_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/state/down-count",
+			.cbs = {
+				.get_elem = lib_interface_zebra_state_down_count_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/state/zif-type",
+			.cbs = {
+				.get_elem = lib_interface_zebra_state_zif_type_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/state/ptm-status",
+			.cbs = {
+				.get_elem = lib_interface_zebra_state_ptm_status_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/state/vlan-id",
+			.cbs = {
+				.get_elem = lib_interface_zebra_state_vlan_id_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/state/vni-id",
+			.cbs = {
+				.get_elem = lib_interface_zebra_state_vni_id_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/state/remote-vtep",
+			.cbs = {
+				.get_elem = lib_interface_zebra_state_remote_vtep_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-interface:lib/interface/frr-zebra:zebra/state/mcast-group",
+			.cbs = {
+				.get_elem = lib_interface_zebra_state_mcast_group_get_elem,
 			}
 		},
 		{

--- a/zebra/zebra_nb.h
+++ b/zebra/zebra_nb.h
@@ -195,31 +195,21 @@ int zebra_debugs_debug_mlag_modify(enum nb_event event,
 				   union nb_resource *resource);
 int zebra_debugs_debug_mlag_destroy(enum nb_event event,
 				    const struct lyd_node *dnode);
-int lib_interface_zebra_ip4_addr_list_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int lib_interface_zebra_ip4_addr_list_destroy(enum nb_event event,
-					      const struct lyd_node *dnode);
-int lib_interface_zebra_ip4_addr_list_ip4_peer_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource);
-int lib_interface_zebra_ip4_addr_list_ip4_peer_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
-int lib_interface_zebra_ip4_addr_list_label_modify(enum nb_event event,
-						   const struct lyd_node *dnode,
-						   union nb_resource *resource);
-int lib_interface_zebra_ip4_addr_list_label_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
-int lib_interface_zebra_ip6_addr_list_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource);
-int lib_interface_zebra_ip6_addr_list_destroy(enum nb_event event,
-					      const struct lyd_node *dnode);
-int lib_interface_zebra_ip6_addr_list_label_modify(enum nb_event event,
-						   const struct lyd_node *dnode,
-						   union nb_resource *resource);
-int lib_interface_zebra_ip6_addr_list_label_destroy(
-	enum nb_event event, const struct lyd_node *dnode);
+int lib_interface_zebra_ip_addrs_create(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource);
+int lib_interface_zebra_ip_addrs_destroy(enum nb_event event,
+					 const struct lyd_node *dnode);
+int lib_interface_zebra_ip_addrs_label_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource);
+int lib_interface_zebra_ip_addrs_label_destroy(enum nb_event event,
+					       const struct lyd_node *dnode);
+int lib_interface_zebra_ip_addrs_ip4_peer_modify(enum nb_event event,
+						 const struct lyd_node *dnode,
+						 union nb_resource *resource);
+int lib_interface_zebra_ip_addrs_ip4_peer_destroy(enum nb_event event,
+						  const struct lyd_node *dnode);
 int lib_interface_zebra_multicast_modify(enum nb_event event,
 					 const struct lyd_node *dnode,
 					 union nb_resource *resource);
@@ -240,6 +230,30 @@ int lib_interface_zebra_bandwidth_modify(enum nb_event event,
 					 union nb_resource *resource);
 int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
 					  const struct lyd_node *dnode);
+struct yang_data *
+lib_interface_zebra_state_up_count_get_elem(const char *xpath,
+					    const void *list_entry);
+struct yang_data *
+lib_interface_zebra_state_down_count_get_elem(const char *xpath,
+					      const void *list_entry);
+struct yang_data *
+lib_interface_zebra_state_zif_type_get_elem(const char *xpath,
+					    const void *list_entry);
+struct yang_data *
+lib_interface_zebra_state_ptm_status_get_elem(const char *xpath,
+					      const void *list_entry);
+struct yang_data *
+lib_interface_zebra_state_vlan_id_get_elem(const char *xpath,
+					   const void *list_entry);
+struct yang_data *
+lib_interface_zebra_state_vni_id_get_elem(const char *xpath,
+					  const void *list_entry);
+struct yang_data *
+lib_interface_zebra_state_remote_vtep_get_elem(const char *xpath,
+					       const void *list_entry);
+struct yang_data *
+lib_interface_zebra_state_mcast_group_get_elem(const char *xpath,
+					       const void *list_entry);
 int lib_vrf_ribs_rib_create(enum nb_event event, const struct lyd_node *dnode,
 			    union nb_resource *resource);
 int lib_vrf_ribs_rib_destroy(enum nb_event event, const struct lyd_node *dnode);

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -1001,11 +1001,11 @@ int zebra_debugs_debug_mlag_destroy(enum nb_event event,
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip-addrs
  */
-int lib_interface_zebra_ip4_addr_list_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
+int lib_interface_zebra_ip_addrs_create(enum nb_event event,
+					const struct lyd_node *dnode,
+					union nb_resource *resource)
 {
 	switch (event) {
 	case NB_EV_VALIDATE:
@@ -1019,8 +1019,8 @@ int lib_interface_zebra_ip4_addr_list_create(enum nb_event event,
 	return NB_OK;
 }
 
-int lib_interface_zebra_ip4_addr_list_destroy(enum nb_event event,
-					      const struct lyd_node *dnode)
+int lib_interface_zebra_ip_addrs_destroy(enum nb_event event,
+					 const struct lyd_node *dnode)
 {
 	switch (event) {
 	case NB_EV_VALIDATE:
@@ -1035,11 +1035,11 @@ int lib_interface_zebra_ip4_addr_list_destroy(enum nb_event event,
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/ip4-peer
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip-addrs/label
  */
-int lib_interface_zebra_ip4_addr_list_ip4_peer_modify(
-	enum nb_event event, const struct lyd_node *dnode,
-	union nb_resource *resource)
+int lib_interface_zebra_ip_addrs_label_modify(enum nb_event event,
+					      const struct lyd_node *dnode,
+					      union nb_resource *resource)
 {
 	switch (event) {
 	case NB_EV_VALIDATE:
@@ -1053,8 +1053,8 @@ int lib_interface_zebra_ip4_addr_list_ip4_peer_modify(
 	return NB_OK;
 }
 
-int lib_interface_zebra_ip4_addr_list_ip4_peer_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+int lib_interface_zebra_ip_addrs_label_destroy(enum nb_event event,
+					       const struct lyd_node *dnode)
 {
 	switch (event) {
 	case NB_EV_VALIDATE:
@@ -1069,11 +1069,11 @@ int lib_interface_zebra_ip4_addr_list_ip4_peer_destroy(
 }
 
 /*
- * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip4-addr-list/label
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip-addrs/ip4-peer
  */
-int lib_interface_zebra_ip4_addr_list_label_modify(enum nb_event event,
-						   const struct lyd_node *dnode,
-						   union nb_resource *resource)
+int lib_interface_zebra_ip_addrs_ip4_peer_modify(enum nb_event event,
+						 const struct lyd_node *dnode,
+						 union nb_resource *resource)
 {
 	switch (event) {
 	case NB_EV_VALIDATE:
@@ -1087,76 +1087,8 @@ int lib_interface_zebra_ip4_addr_list_label_modify(enum nb_event event,
 	return NB_OK;
 }
 
-int lib_interface_zebra_ip4_addr_list_label_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
-{
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
-
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list
- */
-int lib_interface_zebra_ip6_addr_list_create(enum nb_event event,
-					     const struct lyd_node *dnode,
-					     union nb_resource *resource)
-{
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
-
-	return NB_OK;
-}
-
-int lib_interface_zebra_ip6_addr_list_destroy(enum nb_event event,
-					      const struct lyd_node *dnode)
-{
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
-
-	return NB_OK;
-}
-
-/*
- * XPath: /frr-interface:lib/interface/frr-zebra:zebra/ip6-addr-list/label
- */
-int lib_interface_zebra_ip6_addr_list_label_modify(enum nb_event event,
-						   const struct lyd_node *dnode,
-						   union nb_resource *resource)
-{
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
-
-	return NB_OK;
-}
-
-int lib_interface_zebra_ip6_addr_list_label_destroy(
-	enum nb_event event, const struct lyd_node *dnode)
+int lib_interface_zebra_ip_addrs_ip4_peer_destroy(enum nb_event event,
+						  const struct lyd_node *dnode)
 {
 	switch (event) {
 	case NB_EV_VALIDATE:

--- a/zebra/zebra_nb_config.c
+++ b/zebra/zebra_nb_config.c
@@ -21,6 +21,8 @@
 #include "northbound.h"
 #include "libfrr.h"
 #include "zebra_nb.h"
+#include "zebra/interface.h"
+#include "zebra/connected.h"
 
 /*
  * XPath: /frr-zebra:zebra/mcast-rpf-lookup
@@ -1007,12 +1009,38 @@ int lib_interface_zebra_ip_addrs_create(enum nb_event event,
 					const struct lyd_node *dnode,
 					union nb_resource *resource)
 {
+	struct interface *ifp;
+	struct prefix prefix;
+	char buf[PREFIX_STRLEN] = {0};
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+	// addr_family = yang_dnode_get_enum(dnode, "./address-family");
+	yang_dnode_get_prefix(&prefix, dnode, "./ip-prefix");
+	apply_mask(&prefix);
+
 	switch (event) {
 	case NB_EV_VALIDATE:
+		if (prefix.family == AF_INET
+		    && ipv4_martian(&prefix.u.prefix4)) {
+			zlog_debug("invalid address %s",
+				   prefix2str(&prefix, buf, sizeof(buf)));
+			return NB_ERR_VALIDATION;
+		} else if (prefix.family == AF_INET6
+			   && ipv6_martian(&prefix.u.prefix6)) {
+			zlog_debug("invalid address %s",
+				   prefix2str(&prefix, buf, sizeof(buf)));
+			return NB_ERR_VALIDATION;
+		}
+		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+		break;
 	case NB_EV_APPLY:
-		/* TODO: implement me. */
+		if (prefix.family == AF_INET)
+			if_ip_address_install(ifp, &prefix, NULL, NULL);
+		else if (prefix.family == AF_INET6)
+			if_ipv6_address_install(ifp, &prefix, NULL);
+
 		break;
 	}
 
@@ -1022,12 +1050,54 @@ int lib_interface_zebra_ip_addrs_create(enum nb_event event,
 int lib_interface_zebra_ip_addrs_destroy(enum nb_event event,
 					 const struct lyd_node *dnode)
 {
+	struct interface *ifp;
+	struct prefix prefix;
+	struct connected *ifc;
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+	yang_dnode_get_prefix(&prefix, dnode, "./ip-prefix");
+	apply_mask(&prefix);
+
 	switch (event) {
 	case NB_EV_VALIDATE:
+		if (prefix.family == AF_INET) {
+			/* Check current interface address. */
+			ifc = connected_check_ptp(ifp, &prefix, NULL);
+			if (!ifc) {
+				zlog_debug("interface %s Can't find address\n",
+					   ifp->name);
+				return NB_ERR_VALIDATION;
+			}
+		} else if (prefix.family == AF_INET6) {
+			/* Check current interface address. */
+			ifc = connected_check(ifp, &prefix);
+			if (!ifc) {
+				zlog_debug("interface can't find address %s",
+					   ifp->name);
+				return NB_ERR_VALIDATION;
+			}
+		} else
+			return NB_ERR_VALIDATION;
+
+		/* This is not configured address. */
+		if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_CONFIGURED)) {
+			zlog_debug("interface %s not configured", ifp->name);
+			return NB_ERR_VALIDATION;
+		}
+
+		/* This is not real address or interface is not active. */
+		if (!CHECK_FLAG(ifc->conf, ZEBRA_IFC_QUEUED)
+		    || !CHECK_FLAG(ifp->status, ZEBRA_INTERFACE_ACTIVE)) {
+			listnode_delete(ifp->connected, ifc);
+			connected_free(&ifc);
+			return NB_ERR_VALIDATION;
+		}
+		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+		break;
 	case NB_EV_APPLY:
-		/* TODO: implement me. */
+		if_ip_address_uinstall(ifp, &prefix);
 		break;
 	}
 
@@ -1109,14 +1179,14 @@ int lib_interface_zebra_multicast_modify(enum nb_event event,
 					 const struct lyd_node *dnode,
 					 union nb_resource *resource)
 {
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	struct interface *ifp;
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+
+	if_multicast_set(ifp);
 
 	return NB_OK;
 }
@@ -1124,14 +1194,14 @@ int lib_interface_zebra_multicast_modify(enum nb_event event,
 int lib_interface_zebra_multicast_destroy(enum nb_event event,
 					  const struct lyd_node *dnode)
 {
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	struct interface *ifp;
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+
+	if_multicast_unset(ifp);
 
 	return NB_OK;
 }
@@ -1143,14 +1213,16 @@ int lib_interface_zebra_link_detect_modify(enum nb_event event,
 					   const struct lyd_node *dnode,
 					   union nb_resource *resource)
 {
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	struct interface *ifp;
+	bool link_detect;
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+	link_detect = yang_dnode_get_bool(dnode, "./link-detect");
+
+	if_linkdetect(ifp, link_detect);
 
 	return NB_OK;
 }
@@ -1158,14 +1230,16 @@ int lib_interface_zebra_link_detect_modify(enum nb_event event,
 int lib_interface_zebra_link_detect_destroy(enum nb_event event,
 					    const struct lyd_node *dnode)
 {
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	struct interface *ifp;
+	bool link_detect;
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+	link_detect = yang_dnode_get_bool(dnode, "./link-detect");
+
+	if_linkdetect(ifp, link_detect);
 
 	return NB_OK;
 }
@@ -1177,14 +1251,11 @@ int lib_interface_zebra_shutdown_modify(enum nb_event event,
 					const struct lyd_node *dnode,
 					union nb_resource *resource)
 {
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	struct interface *ifp;
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+
+	if_shutdown(ifp);
 
 	return NB_OK;
 }
@@ -1192,14 +1263,11 @@ int lib_interface_zebra_shutdown_modify(enum nb_event event,
 int lib_interface_zebra_shutdown_destroy(enum nb_event event,
 					 const struct lyd_node *dnode)
 {
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	struct interface *ifp;
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+
+	if_no_shutdown(ifp);
 
 	return NB_OK;
 }
@@ -1211,14 +1279,20 @@ int lib_interface_zebra_bandwidth_modify(enum nb_event event,
 					 const struct lyd_node *dnode,
 					 union nb_resource *resource)
 {
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	struct interface *ifp;
+	uint32_t bandwidth;
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+	bandwidth = yang_dnode_get_uint32(dnode, "./bandwidth");
+
+	ifp->bandwidth = bandwidth;
+
+	/* force protocols to recalculate routes due to cost change */
+	if (if_is_operative(ifp))
+		zebra_interface_up_update(ifp);
 
 	return NB_OK;
 }
@@ -1226,14 +1300,18 @@ int lib_interface_zebra_bandwidth_modify(enum nb_event event,
 int lib_interface_zebra_bandwidth_destroy(enum nb_event event,
 					  const struct lyd_node *dnode)
 {
-	switch (event) {
-	case NB_EV_VALIDATE:
-	case NB_EV_PREPARE:
-	case NB_EV_ABORT:
-	case NB_EV_APPLY:
-		/* TODO: implement me. */
-		break;
-	}
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	struct interface *ifp;
+
+	ifp = nb_running_get_entry(dnode, NULL, true);
+
+	ifp->bandwidth = 0;
+
+	/* force protocols to recalculate routes due to cost change */
+	if (if_is_operative(ifp))
+		zebra_interface_up_update(ifp);
 
 	return NB_OK;
 }

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -21,6 +21,7 @@
 #include "northbound.h"
 #include "libfrr.h"
 #include "zebra_nb.h"
+#include "zebra/interface.h"
 
 /*
  * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/up-count
@@ -29,8 +30,12 @@ struct yang_data *
 lib_interface_zebra_state_up_count_get_elem(const char *xpath,
 					    const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	const struct interface *ifp = list_entry;
+	struct zebra_if *zebra_if;
+
+	zebra_if = ifp->info;
+
+	return yang_data_new_uint16(xpath, zebra_if->up_count);
 }
 
 /*
@@ -40,8 +45,12 @@ struct yang_data *
 lib_interface_zebra_state_down_count_get_elem(const char *xpath,
 					      const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	const struct interface *ifp = list_entry;
+	struct zebra_if *zebra_if;
+
+	zebra_if = ifp->info;
+
+	return yang_data_new_uint16(xpath, zebra_if->down_count);
 }
 
 /*
@@ -73,8 +82,17 @@ struct yang_data *
 lib_interface_zebra_state_vlan_id_get_elem(const char *xpath,
 					   const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	const struct interface *ifp = list_entry;
+	struct zebra_if *zebra_if;
+	struct zebra_l2info_vlan *vlan_info;
+
+	if (!IS_ZEBRA_IF_VLAN(ifp))
+		return NULL;
+
+	zebra_if = ifp->info;
+	vlan_info = &zebra_if->l2info.vl;
+
+	return yang_data_new_uint16(xpath, vlan_info->vid);
 }
 
 /*
@@ -84,8 +102,17 @@ struct yang_data *
 lib_interface_zebra_state_vni_id_get_elem(const char *xpath,
 					  const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	const struct interface *ifp = list_entry;
+	struct zebra_if *zebra_if;
+	struct zebra_l2info_vxlan *vxlan_info;
+
+	if (!IS_ZEBRA_IF_VXLAN(ifp))
+		return NULL;
+
+	zebra_if = ifp->info;
+	vxlan_info = &zebra_if->l2info.vxl;
+
+	return yang_data_new_uint32(xpath, vxlan_info->vni);
 }
 
 /*
@@ -95,8 +122,17 @@ struct yang_data *
 lib_interface_zebra_state_remote_vtep_get_elem(const char *xpath,
 					       const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	const struct interface *ifp = list_entry;
+	struct zebra_if *zebra_if;
+	struct zebra_l2info_vxlan *vxlan_info;
+
+	if (!IS_ZEBRA_IF_VXLAN(ifp))
+		return NULL;
+
+	zebra_if = ifp->info;
+	vxlan_info = &zebra_if->l2info.vxl;
+
+	return yang_data_new_ipv4(xpath, &vxlan_info->vtep_ip);
 }
 
 /*
@@ -106,8 +142,17 @@ struct yang_data *
 lib_interface_zebra_state_mcast_group_get_elem(const char *xpath,
 					       const void *list_entry)
 {
-	/* TODO: implement me. */
-	return NULL;
+	const struct interface *ifp = list_entry;
+	struct zebra_if *zebra_if;
+	struct zebra_l2info_vxlan *vxlan_info;
+
+	if (!IS_ZEBRA_IF_VXLAN(ifp))
+		return NULL;
+
+	zebra_if = ifp->info;
+	vxlan_info = &zebra_if->l2info.vxl;
+
+	return yang_data_new_ipv4(xpath, &vxlan_info->mcast_grp);
 }
 
 const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,

--- a/zebra/zebra_nb_state.c
+++ b/zebra/zebra_nb_state.c
@@ -22,6 +22,94 @@
 #include "libfrr.h"
 #include "zebra_nb.h"
 
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/up-count
+ */
+struct yang_data *
+lib_interface_zebra_state_up_count_get_elem(const char *xpath,
+					    const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/down-count
+ */
+struct yang_data *
+lib_interface_zebra_state_down_count_get_elem(const char *xpath,
+					      const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/zif-type
+ */
+struct yang_data *
+lib_interface_zebra_state_zif_type_get_elem(const char *xpath,
+					    const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/ptm-status
+ */
+struct yang_data *
+lib_interface_zebra_state_ptm_status_get_elem(const char *xpath,
+					      const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/vlan-id
+ */
+struct yang_data *
+lib_interface_zebra_state_vlan_id_get_elem(const char *xpath,
+					   const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/vni-id
+ */
+struct yang_data *
+lib_interface_zebra_state_vni_id_get_elem(const char *xpath,
+					  const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/remote-vtep
+ */
+struct yang_data *
+lib_interface_zebra_state_remote_vtep_get_elem(const char *xpath,
+					       const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
+/*
+ * XPath: /frr-interface:lib/interface/frr-zebra:zebra/state/mcast-group
+ */
+struct yang_data *
+lib_interface_zebra_state_mcast_group_get_elem(const char *xpath,
+					       const void *list_entry)
+{
+	/* TODO: implement me. */
+	return NULL;
+}
+
 const void *lib_vrf_ribs_rib_get_next(const void *parent_list_entry,
 				      const void *list_entry)
 {


### PR DESCRIPTION
```
module: frr-interface
  +--rw lib
     +--rw interface* [name vrf]
        +--rw name           string
        +--rw vrf            frr-vrf:vrf-ref
        +--rw description?   string
        +--ro if-index?      int32
        +--ro mtu?           uint16
        +--ro speed?         uint32
        +--ro type?          identityref
        +--ro phy-address?   ietf-yang-types:mac-address
module: frr-zebra
  augment /frr-interface:lib/frr-interface:interface:
    +--rw zebra
       +--rw ip4-addr-list* [ip4-prefix]
       |  +--rw ip4-prefix    ietf-inet-types:ipv4-prefix
       |  +--rw ip4-peer?     ietf-inet-types:ipv4-prefix
       |  +--rw label?        string
       +--rw ip6-addr-list* [ip6-prefix]
       |  +--rw ip6-prefix    ietf-inet-types:ipv6-prefix
       |  +--rw label?        string
       +--rw multicast?       boolean
       +--rw link-detect?     boolean
       +--rw shutdown?        boolean
       +--rw bandwidth?       uint32
       +--ro state
          +--ro zif-type?      identityref
          +--ro vlan-id?       uint16
          +--ro vni-id?        vni-id-type
          +--ro remote-vtep?   ietf-inet-types:ipv4-address
          +--ro mcase-group?   ietf-routing-types:ipv4-multicast-group-address

```
Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>