### PR TITLE
doc: indicate non-support for dynamic pbr maps

### DIFF
--- a/doc/user/pbr.rst
+++ b/doc/user/pbr.rst
@@ -136,6 +136,11 @@ causes the policy to be installed into the kernel.
    This command is available under interface sub-mode.  This turns
    on the PBR map NAME and allows it to work properly.
 
+.. note::
+   This will not dynamically create PBR maps on sub-interfaces (i.e. vlans)
+   even if one is on the master. Each must have the PBR map explicitly added
+   to the interface.
+
 .. _pbr-details:
 
 PBR Details


### PR DESCRIPTION
Indicate in the doc clearly that we do not support the dynamic
creation of pbr maps for sub-interfaces when the master has
an interface. Such as in vlans. It must be explicitly added.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>