### PR TITLE
Fix bgp gr style

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -2132,11 +2132,10 @@ DEFUN_NOSH (show_debugging_bgp,
 
 	if (BGP_DEBUG(zebra, ZEBRA))
 		bgp_debug_list_print(vty, "  BGP zebra debugging is on",
-					bgp_debug_zebra_prefixes);
+				     bgp_debug_zebra_prefixes);
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-		vty_out(vty,
-			"  BGP graceful-restart debugging is on");
+		vty_out(vty, "  BGP graceful-restart debugging is on");
 
 	if (BGP_DEBUG(allow_martians, ALLOW_MARTIANS))
 		vty_out(vty, "  BGP allow martian next hop debugging is on\n");

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -58,8 +58,7 @@
 
 DEFINE_HOOK(peer_backward_transition, (struct peer * peer), (peer))
 DEFINE_HOOK(peer_status_changed, (struct peer * peer), (peer))
-extern const char *get_afi_safi_str(afi_t afi,
-			safi_t safi, bool for_json);
+extern const char *get_afi_safi_str(afi_t afi, safi_t safi, bool for_json);
 /* Definition of display strings corresponding to FSM events. This should be
  * kept consistent with the events defined in bgpd.h
  */
@@ -255,16 +254,14 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	peer->peer_gr_new_status_flag = from_peer->peer_gr_new_status_flag;
 	bgp_peer_gr_flags_update(peer);
 
-	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(
-			peer->bgp,
-			peer->bgp->peer);
+	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(peer->bgp,
+							  peer->bgp->peer);
 
 	if (bgp_peer_gr_mode_get(peer) == PEER_DISABLE) {
 
 		UNSET_FLAG(peer->sflags, PEER_STATUS_NSF_MODE);
 
-		if (CHECK_FLAG(peer->sflags,
-					PEER_STATUS_NSF_WAIT)) {
+		if (CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT)) {
 			peer_nsf_stop(peer);
 		}
 	}
@@ -1623,8 +1620,8 @@ static int bgp_reconnect(struct peer *peer)
 		return -1;
 
 	/* Send graceful restart capabilty */
-	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(
-			peer->bgp, peer->bgp->peer);
+	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(peer->bgp,
+							  peer->bgp->peer);
 
 	bgp_start(peer);
 	return 0;
@@ -1663,7 +1660,7 @@ static int bgp_fsm_holdtime_expire(struct peer *peer)
 
 /* Start the selection deferral timer thread for the specified AFI, SAFI */
 static int bgp_start_deferral_timer(struct bgp *bgp, afi_t afi, safi_t safi,
-		struct graceful_restart_info *gr_info)
+				    struct graceful_restart_info *gr_info)
 {
 	struct afi_safi_info *thread_info;
 
@@ -1697,8 +1694,8 @@ static int bgp_start_deferral_timer(struct bgp *bgp, afi_t afi, safi_t safi,
 	}
 	if (BGP_DEBUG(update, UPDATE_OUT))
 		zlog_debug("Started the deferral timer for %s eor_required %d",
-				get_afi_safi_str(afi, safi, false),
-				gr_info->eor_required);
+			   get_afi_safi_str(afi, safi, false),
+			   gr_info->eor_required);
 	return 0;
 }
 
@@ -1722,8 +1719,8 @@ static int bgp_update_gr_info(struct peer *peer, afi_t afi, safi_t safi)
 	}
 
 	/* Restarting router */
-	if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer) &&
-	    BGP_PEER_RESTARTING_MODE(peer)) {
+	if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer)
+	    && BGP_PEER_RESTARTING_MODE(peer)) {
 		/* Check if the forwarding state is preserved */
 		if (bgp_flag_check(bgp, BGP_FLAG_GR_PRESERVE_FWD)) {
 			gr_info = &(bgp->gr_info[afi][safi]);
@@ -1788,11 +1785,9 @@ static int bgp_establish(struct peer *peer)
 	UNSET_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT);
 	if (bgp_debug_neighbor_events(peer)) {
 		if (BGP_PEER_RESTARTING_MODE(peer))
-			zlog_debug("peer %s BGP_RESTARTING_MODE",
-				   peer->host);
+			zlog_debug("peer %s BGP_RESTARTING_MODE", peer->host);
 		else if (BGP_PEER_HELPER_MODE(peer))
-			zlog_debug("peer %s BGP_HELPER_MODE",
-				   peer->host);
+			zlog_debug("peer %s BGP_HELPER_MODE", peer->host);
 	}
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)
 		for (safi = SAFI_UNICAST; safi <= SAFI_MPLS_VPN; safi++) {
@@ -1819,15 +1814,18 @@ static int bgp_establish(struct peer *peer)
 					status = bgp_update_gr_info(peer, afi,
 								    safi);
 					if (status < 0)
-						zlog_err("Error in updating graceful restart for %s",
-							get_afi_safi_str(afi,
-							safi, false));
+						zlog_err(
+							"Error in updating graceful restart for %s",
+							get_afi_safi_str(
+								afi, safi,
+								false));
 				} else {
 					if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(
-						peer) &&
-						BGP_PEER_RESTARTING_MODE(peer)
-						&& bgp_flag_check(peer->bgp,
-						BGP_FLAG_GR_PRESERVE_FWD))
+						    peer)
+					    && BGP_PEER_RESTARTING_MODE(peer)
+					    && bgp_flag_check(
+						    peer->bgp,
+						    BGP_FLAG_GR_PRESERVE_FWD))
 						peer->bgp->gr_info[afi][safi]
 							.eor_required++;
 				}
@@ -2255,31 +2253,30 @@ int bgp_event_update(struct peer *peer, int event)
 /* BGP GR Code */
 
 int bgp_gr_lookup_n_update_all_peer(struct bgp *bgp,
-			enum global_mode global_new_state,
-			enum global_mode global_old_state)
+				    enum global_mode global_new_state,
+				    enum global_mode global_old_state)
 {
 	struct peer *peer = {0};
 	struct listnode *node = {0};
 	struct listnode *nnode = {0};
-	enum peer_mode  peer_old_state = PEER_INVALID;
+	enum peer_mode peer_old_state = PEER_INVALID;
 
 	for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 
 		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-			zlog_debug(
-			"%s [BGP_GR] Peer: (%s) :",
-				__func__, peer->host);
+			zlog_debug("%s [BGP_GR] Peer: (%s) :", __func__,
+				   peer->host);
 
 		peer_old_state = bgp_peer_gr_mode_get(peer);
 
 		if (peer_old_state == PEER_GLOBAL_INHERIT) {
 
-		/*
-		 *Reset only these peers and send a
-		 *new open message with the change capabilities.
-		 *Considering the mode to be "global_new_state" and
-		 *do all operation accordingly
-		 */
+			/*
+			 *Reset only these peers and send a
+			 *new open message with the change capabilities.
+			 *Considering the mode to be "global_new_state" and
+			 *do all operation accordingly
+			 */
 
 			switch (global_new_state) {
 			case GLOBAL_HELPER:
@@ -2292,9 +2289,8 @@ int bgp_gr_lookup_n_update_all_peer(struct bgp *bgp,
 				BGP_PEER_GR_DISABLE(peer);
 				break;
 			case GLOBAL_INVALID:
-				zlog_debug(
-				"%s [BGP_GR] GLOBAL_INVALID",
-				__func__);
+				zlog_debug("%s [BGP_GR] GLOBAL_INVALID",
+					   __func__);
 				return BGP_ERR_GR_OPERATION_FAILED;
 			}
 		}
@@ -2311,50 +2307,45 @@ int bgp_gr_update_all(struct bgp *bgp, int global_gr_cmd)
 	enum global_mode global_old_state = GLOBAL_INVALID;
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-		zlog_debug(
-		"%s [BGP_GR]START: global_gr_cmd :%s:",
-			__func__, print_global_gr_cmd(global_gr_cmd));
+		zlog_debug("%s [BGP_GR]START: global_gr_cmd :%s:", __func__,
+			   print_global_gr_cmd(global_gr_cmd));
 
 	global_old_state = bgp_global_gr_mode_get(bgp);
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-		zlog_debug(
-		"[BGP_GR] global_old_gr_state :%s:",
-		print_global_gr_mode(global_old_state));
+		zlog_debug("[BGP_GR] global_old_gr_state :%s:",
+			   print_global_gr_mode(global_old_state));
 
 	if (global_old_state != GLOBAL_INVALID) {
 		global_new_state =
 			bgp->GLOBAL_GR_FSM[global_old_state][global_gr_cmd];
 
 		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-			zlog_debug(
-			"[BGP_GR] global_new_gr_state :%s:",
-			print_global_gr_mode(global_new_state));
+			zlog_debug("[BGP_GR] global_new_gr_state :%s:",
+				   print_global_gr_mode(global_new_state));
 	} else {
-		zlog_err(
-			"%s [BGP_GR] global_old_state == GLOBAL_INVALID",
-			__func__);
+		zlog_err("%s [BGP_GR] global_old_state == GLOBAL_INVALID",
+			 __func__);
 		return BGP_ERR_GR_OPERATION_FAILED;
 	}
 
 	if (global_new_state == GLOBAL_INVALID) {
-		zlog_err(
-			"%s [BGP_GR] global_new_state == GLOBAL_INVALID",
-				__func__);
+		zlog_err("%s [BGP_GR] global_new_state == GLOBAL_INVALID",
+			 __func__);
 		return BGP_ERR_GR_INVALID_CMD;
 	}
 	if (global_new_state == global_old_state) {
 		/* Trace msg */
 		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 			zlog_debug(
-			"%s [BGP_GR] global_new_state == global_old_state :%s",
-			__func__, print_global_gr_mode(global_new_state));
+				"%s [BGP_GR] global_new_state == global_old_state :%s",
+				__func__,
+				print_global_gr_mode(global_new_state));
 		return BGP_GR_NO_OPERATION;
 	}
 
-	return bgp_gr_lookup_n_update_all_peer(bgp,
-					global_new_state,
-					global_old_state);
+	return bgp_gr_lookup_n_update_all_peer(bgp, global_new_state,
+					       global_old_state);
 }
 
 const char *print_peer_gr_mode(enum peer_mode pr_mode)
@@ -2464,11 +2455,10 @@ enum peer_mode bgp_peer_gr_mode_get(struct peer *peer)
 	return peer->peer_gr_present_state;
 }
 
-int bgp_neighbor_graceful_restart(struct peer *peer,
-						int peer_gr_cmd)
+int bgp_neighbor_graceful_restart(struct peer *peer, int peer_gr_cmd)
 {
-	enum peer_mode  peer_new_state = PEER_INVALID;
-	enum peer_mode  peer_old_state = PEER_INVALID;
+	enum peer_mode peer_new_state = PEER_INVALID;
+	enum peer_mode peer_old_state = PEER_INVALID;
 	struct bgp_peer_gr peer_state;
 	int result = BGP_GR_FAILURE;
 
@@ -2479,15 +2469,14 @@ int bgp_neighbor_graceful_restart(struct peer *peer,
 	 */
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-		zlog_debug(
-		"%s [BGP_GR] START:Peer: (%s) : peer_gr_cmd :%s:",
-		  __func__, peer->host, print_peer_gr_cmd(peer_gr_cmd));
+		zlog_debug("%s [BGP_GR] START:Peer: (%s) : peer_gr_cmd :%s:",
+			   __func__, peer->host,
+			   print_peer_gr_cmd(peer_gr_cmd));
 
 	peer_old_state = bgp_peer_gr_mode_get(peer);
 
 	if (peer_old_state == PEER_INVALID) {
-		zlog_debug(
-			"[BGP_GR] peer_old_state == Invalid state !");
+		zlog_debug("[BGP_GR] peer_old_state == Invalid state !");
 		return BGP_ERR_GR_OPERATION_FAILED;
 	}
 
@@ -2501,13 +2490,12 @@ int bgp_neighbor_graceful_restart(struct peer *peer,
 	}
 
 	if (peer_new_state != peer_old_state) {
-		result = peer_state.action_fun(peer,
-						peer_old_state,
-						peer_new_state);
+		result = peer_state.action_fun(peer, peer_old_state,
+					       peer_new_state);
 	} else {
 		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 			zlog_debug(
-			"[BGP_GR] peer_old_state == peer_new_state !");
+				"[BGP_GR] peer_old_state == peer_new_state !");
 		return BGP_GR_NO_OPERATION;
 	}
 
@@ -2516,8 +2504,9 @@ int bgp_neighbor_graceful_restart(struct peer *peer,
 		/* Update the mode i.e peer_new_state into the peer structure */
 		peer->peer_gr_present_state = peer_new_state;
 		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-			zlog_debug("[BGP_GR] Succesfully change the state of the peer to : %s : !",
-					print_peer_gr_mode(peer_new_state));
+			zlog_debug(
+				"[BGP_GR] Succesfully change the state of the peer to : %s : !",
+				print_peer_gr_mode(peer_new_state));
 
 		return BGP_GR_SUCCESS;
 	}
@@ -2525,8 +2514,8 @@ int bgp_neighbor_graceful_restart(struct peer *peer,
 	return result;
 }
 
-unsigned int bgp_peer_gr_action(struct peer *peer,
-				int old_peer_state, int new_peer_state)
+unsigned int bgp_peer_gr_action(struct peer *peer, int old_peer_state,
+				int new_peer_state)
 {
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug(
@@ -2538,19 +2527,20 @@ unsigned int bgp_peer_gr_action(struct peer *peer,
 	unsigned int ret = BGP_GR_FAILURE;
 
 	if (old_peer_state == new_peer_state) {
-	/* Nothing to do over here as the present and old state is the same */
+		/* Nothing to do over here as the present and old state is the
+		 * same */
 		return BGP_GR_NO_OPERATION;
 	}
-	if ((old_peer_state == PEER_INVALID) ||
-		(new_peer_state == PEER_INVALID)) {
-	/* something bad happend , print error message */
+	if ((old_peer_state == PEER_INVALID)
+	    || (new_peer_state == PEER_INVALID)) {
+		/* something bad happend , print error message */
 		return BGP_ERR_GR_INVALID_CMD;
 	}
 
 	bgp_gr_global_mode = bgp_global_gr_mode_get(peer->bgp);
 
-	if ((old_peer_state == PEER_GLOBAL_INHERIT) &&
-		(new_peer_state != PEER_GLOBAL_INHERIT)) {
+	if ((old_peer_state == PEER_GLOBAL_INHERIT)
+	    && (new_peer_state != PEER_GLOBAL_INHERIT)) {
 
 		/* fetch the Mode running in the Global state machine
 		 *from the bgp structure into a variable called
@@ -2566,10 +2556,10 @@ unsigned int bgp_peer_gr_action(struct peer *peer,
 		BGP_PEER_GR_GLOBAL_INHERIT_UNSET(peer);
 
 		if (new_peer_state == bgp_gr_global_mode) {
-		/*This is incremental updates i.e no tear down
-		 *of the existing session
-		 *as the peer is already working in the same mode.
-		 */
+			/*This is incremental updates i.e no tear down
+			 *of the existing session
+			 *as the peer is already working in the same mode.
+			 */
 			ret = BGP_GR_SUCCESS;
 		} else {
 			if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
@@ -2585,8 +2575,8 @@ unsigned int bgp_peer_gr_action(struct peer *peer,
 	/* In the case below peer is going into Global inherit mode i.e.
 	 * the peer would work as the mode configured at the global level
 	 */
-	else if ((new_peer_state == PEER_GLOBAL_INHERIT) &&
-		(old_peer_state != PEER_GLOBAL_INHERIT)) {
+	else if ((new_peer_state == PEER_GLOBAL_INHERIT)
+		 && (old_peer_state != PEER_GLOBAL_INHERIT)) {
 		/* Here in this case it would be destructive
 		 * in all the cases except one case when,
 		 * Global GR is configured Disabled
@@ -2610,7 +2600,8 @@ unsigned int bgp_peer_gr_action(struct peer *peer,
 			 */
 
 			if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-				zlog_debug("[BGP_GR] Peer state changed from :%s",
+				zlog_debug(
+					"[BGP_GR] Peer state changed from :%s",
 					print_peer_gr_mode(old_peer_state));
 
 			bgp_peer_move_to_gr_mode(peer, bgp_gr_global_mode);
@@ -2625,7 +2616,7 @@ unsigned int bgp_peer_gr_action(struct peer *peer,
 		 */
 		if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 			zlog_debug("[BGP_GR] Peer state changed from :%s",
-					print_peer_gr_mode(old_peer_state));
+				   print_peer_gr_mode(old_peer_state));
 
 		bgp_peer_move_to_gr_mode(peer, new_peer_state);
 
@@ -2655,85 +2646,78 @@ inline void bgp_peer_move_to_gr_mode(struct peer *peer, int new_state)
 
 		if (bgp_global_gr_mode == GLOBAL_HELPER) {
 			BGP_PEER_GR_HELPER_ENABLE(peer);
-		} else if (bgp_global_gr_mode  == GLOBAL_GR) {
+		} else if (bgp_global_gr_mode == GLOBAL_GR) {
 			BGP_PEER_GR_ENABLE(peer);
 		} else if (bgp_global_gr_mode == GLOBAL_DISABLE) {
 			BGP_PEER_GR_DISABLE(peer);
 		} else {
 			zlog_err(
-			"[BGP_GR] Default switch inherit mode ::: SOMETHING IS WRONG !!!");
+				"[BGP_GR] Default switch inherit mode ::: SOMETHING IS WRONG !!!");
 		}
 		break;
 	default:
-		zlog_err("[BGP_GR] Default switch mode ::: SOMETHING IS WRONG !!!");
+		zlog_err(
+			"[BGP_GR] Default switch mode ::: SOMETHING IS WRONG !!!");
 		break;
 	}
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug("[BGP_GR] Peer state changed  --to-->  : %d : !",
-					 new_state);
+			   new_state);
 }
 
 void bgp_peer_gr_flags_update(struct peer *peer)
 {
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-		zlog_debug(
-			"%s [BGP_GR] called !",
-				__func__);
+		zlog_debug("%s [BGP_GR] called !", __func__);
 	if (CHECK_FLAG(peer->peer_gr_new_status_flag,
-		PEER_GRACEFUL_RESTART_NEW_STATE_HELPER))
-		SET_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART_HELPER);
+		       PEER_GRACEFUL_RESTART_NEW_STATE_HELPER))
+		SET_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART_HELPER);
 	else
-		UNSET_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART_HELPER);
+		UNSET_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART_HELPER);
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug(
 			"[BGP_GR] Peer %s Flag PEER_FLAG_GRACEFUL_RESTART_HELPER : %s : !",
 			peer->host,
 			(CHECK_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART_HELPER) ?
-				"Set" : "UnSet"));
+				    PEER_FLAG_GRACEFUL_RESTART_HELPER)
+				 ? "Set"
+				 : "UnSet"));
 	if (CHECK_FLAG(peer->peer_gr_new_status_flag,
-		PEER_GRACEFUL_RESTART_NEW_STATE_RESTART))
-		SET_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART);
+		       PEER_GRACEFUL_RESTART_NEW_STATE_RESTART))
+		SET_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART);
 	else
-		UNSET_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART);
+		UNSET_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART);
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug(
 			"[BGP_GR] Peer %s Flag PEER_FLAG_GRACEFUL_RESTART : %s : !",
 			peer->host,
-			(CHECK_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART) ?
-				"Set" : "UnSet"));
+			(CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART)
+				 ? "Set"
+				 : "UnSet"));
 	if (CHECK_FLAG(peer->peer_gr_new_status_flag,
-		PEER_GRACEFUL_RESTART_NEW_STATE_INHERIT))
+		       PEER_GRACEFUL_RESTART_NEW_STATE_INHERIT))
 		SET_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT);
+			 PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT);
 	else
 		UNSET_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT);
+			   PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT);
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug(
-		"[BGP_GR] Peer %s Flag PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT : %s : !",
+			"[BGP_GR] Peer %s Flag PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT : %s : !",
 			peer->host,
 			(CHECK_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT) ?
-			 "Set" : "UnSet"));
+				    PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT)
+				 ? "Set"
+				 : "UnSet"));
 
-	if (!CHECK_FLAG(peer->flags,
-		PEER_FLAG_GRACEFUL_RESTART) &&
-		!CHECK_FLAG(peer->flags,
-			PEER_FLAG_GRACEFUL_RESTART_HELPER)){
-		zlog_debug(
-			"[BGP_GR] Peer %s UNSET PEER_STATUS_NSF_MODE!",
-			peer->host);
+	if (!CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART)
+	    && !CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART_HELPER)) {
+		zlog_debug("[BGP_GR] Peer %s UNSET PEER_STATUS_NSF_MODE!",
+			   peer->host);
 
 		UNSET_FLAG(peer->sflags, PEER_STATUS_NSF_MODE);
 
-		if (CHECK_FLAG(peer->sflags,
-				PEER_STATUS_NSF_WAIT)) {
+		if (CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT)) {
 
 			peer_nsf_stop(peer);
 			zlog_debug(

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -94,19 +94,19 @@
 			UNSET_FLAG(peer->peer_gr_new_status_flag, \
 				PEER_GRACEFUL_RESTART_NEW_STATE_INHERIT)
 
-#define BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer)                         \
-	(CHECK_FLAG(peer->cap, PEER_CAP_RESTART_ADV) &&                 \
-	 CHECK_FLAG(peer->cap, PEER_CAP_RESTART_RCV))
+#define BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer)                                \
+	(CHECK_FLAG(peer->cap, PEER_CAP_RESTART_ADV)                           \
+	 && CHECK_FLAG(peer->cap, PEER_CAP_RESTART_RCV))
 
-#define BGP_PEER_RESTARTING_MODE(peer)\
-	(CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART) && \
-	 CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_ADV) &&     \
-	 !CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_RCV))
+#define BGP_PEER_RESTARTING_MODE(peer)                                         \
+	(CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART)                   \
+	 && CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_ADV)                    \
+	 && !CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_RCV))
 
-#define BGP_PEER_HELPER_MODE(peer)\
-	(CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART_HELPER) && \
-	 CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_RCV) &&           \
-	 !CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_ADV))
+#define BGP_PEER_HELPER_MODE(peer)                                             \
+	(CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART_HELPER)            \
+	 && CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_RCV)                    \
+	 && !CHECK_FLAG(peer->cap, PEER_CAP_RESTART_BIT_ADV))
 
 /* Prototypes. */
 extern void bgp_fsm_event_update(struct peer *peer, int valid);
@@ -143,8 +143,7 @@ DECLARE_HOOK(peer_backward_transition, (struct peer *peer), (peer))
 DECLARE_HOOK(peer_established, (struct peer *peer), (peer))
 
 int bgp_gr_update_all(struct bgp *bgp, int global_gr_cmd);
-int bgp_neighbor_graceful_restart(struct peer *peer,
-			int peer_gr_cmd);
+int bgp_neighbor_graceful_restart(struct peer *peer, int peer_gr_cmd);
 unsigned int bgp_peer_gr_action(struct peer *peer,
 		int old_peer_state, int new_peer_state);
 void bgp_peer_move_to_gr_mode(struct peer *peer, int new_state);

--- a/bgpd/bgp_io.c
+++ b/bgpd/bgp_io.c
@@ -462,12 +462,10 @@ static uint16_t bgp_read(struct peer *peer)
 			 safe_strerror(errno));
 
 		if (peer->status == Established) {
-			if ((CHECK_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART) ||
-				CHECK_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART_HELPER)) &&
-				CHECK_FLAG(peer->sflags,
-				PEER_STATUS_NSF_MODE)) {
+			if ((CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART)
+			     || CHECK_FLAG(peer->flags,
+					   PEER_FLAG_GRACEFUL_RESTART_HELPER))
+			    && CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_MODE)) {
 				peer->last_reset = PEER_DOWN_NSF_CLOSE_SESSION;
 				SET_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT);
 			} else
@@ -480,15 +478,13 @@ static uint16_t bgp_read(struct peer *peer)
 	} else if (nbytes == 0) {
 		if (bgp_debug_neighbor_events(peer))
 			zlog_debug("%s [Event] BGP connection closed fd %d",
-					peer->host, peer->fd);
+				   peer->host, peer->fd);
 
 		if (peer->status == Established) {
-			if ((CHECK_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART) ||
-				CHECK_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART_HELPER)) &&
-				CHECK_FLAG(peer->sflags,
-				PEER_STATUS_NSF_MODE)) {
+			if ((CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART)
+			     || CHECK_FLAG(peer->flags,
+					   PEER_FLAG_GRACEFUL_RESTART_HELPER))
+			    && CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_MODE)) {
 				peer->last_reset = PEER_DOWN_NSF_CLOSE_SESSION;
 				SET_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT);
 			} else

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -489,16 +489,14 @@ static int bgp_accept(struct thread *thread)
 	peer_xfer_config(peer, peer1);
 	bgp_peer_gr_flags_update(peer);
 
-	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(
-			peer->bgp,
-			peer->bgp->peer);
+	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(peer->bgp,
+							  peer->bgp->peer);
 
 	if (bgp_peer_gr_mode_get(peer) == PEER_DISABLE) {
 
 		UNSET_FLAG(peer->sflags, PEER_STATUS_NSF_MODE);
 
-		if (CHECK_FLAG(peer->sflags,
-				PEER_STATUS_NSF_WAIT)) {
+		if (CHECK_FLAG(peer->sflags, PEER_STATUS_NSF_WAIT)) {
 			peer_nsf_stop(peer);
 		}
 	}
@@ -515,7 +513,7 @@ static int bgp_accept(struct thread *thread)
 	SET_FLAG(peer->sflags, PEER_STATUS_ACCEPT_PEER);
 	/* Make dummy peer until read Open packet. */
 	if (peer1->status == Established
-		&& CHECK_FLAG(peer1->sflags, PEER_STATUS_NSF_MODE)) {
+	    && CHECK_FLAG(peer1->sflags, PEER_STATUS_NSF_MODE)) {
 		/* If we have an existing established connection with graceful
 		 * restart
 		 * capability announced with one or more address families, then
@@ -524,12 +522,10 @@ static int bgp_accept(struct thread *thread)
 		 */
 		peer1->last_reset = PEER_DOWN_NSF_CLOSE_SESSION;
 
-		if (CHECK_FLAG(peer1->flags,
-			PEER_FLAG_GRACEFUL_RESTART) ||
-			CHECK_FLAG(peer1->flags,
-			PEER_FLAG_GRACEFUL_RESTART_HELPER))
-			SET_FLAG(peer1->sflags,
-				PEER_STATUS_NSF_WAIT);
+		if (CHECK_FLAG(peer1->flags, PEER_FLAG_GRACEFUL_RESTART)
+		    || CHECK_FLAG(peer1->flags,
+				  PEER_FLAG_GRACEFUL_RESTART_HELPER))
+			SET_FLAG(peer1->sflags, PEER_STATUS_NSF_WAIT);
 
 		bgp_event_update(peer1, TCP_connection_closed);
 	}

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1012,7 +1012,6 @@ static int bgp_capability_parse(struct peer *peer, size_t length,
 			UNSET_FLAG(restart_flag_time, 0xF000);
 			peer->v_gr_restart = restart_flag_time;
 		}
-
 	}
 	return 0;
 }
@@ -1309,7 +1308,7 @@ static void bgp_open_capability_orf(struct stream *s, struct peer *peer,
 }
 
 static void bgp_peer_send_gr_capability(struct stream *s, struct peer *peer,
-				 unsigned long cp)
+					unsigned long cp)
 {
 	int len;
 	iana_afi_t pkt_afi;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -439,33 +439,34 @@ int bgp_generate_updgrp_packets(struct thread *thread)
 			 */
 			if (!next_pkt || !next_pkt->buffer) {
 				if (CHECK_FLAG(peer->cap,
-						PEER_CAP_RESTART_RCV)) {
+					       PEER_CAP_RESTART_RCV)) {
 					if (!(PAF_SUBGRP(paf))->t_coalesce
-						&& peer->afc_nego[afi][safi]
-						&& peer->synctime
-						&& !CHECK_FLAG(
-						peer->af_sflags[afi][safi],
-						PEER_STATUS_EOR_SEND)) {
+					    && peer->afc_nego[afi][safi]
+					    && peer->synctime
+					    && !CHECK_FLAG(
+						    peer->af_sflags[afi][safi],
+						    PEER_STATUS_EOR_SEND)) {
 						/* If EOR is disabled,
 						 * the message is  not sent
 						 */
-						if (BGP_SEND_EOR(peer->bgp,
-								afi, safi)) {
+						if (BGP_SEND_EOR(peer->bgp, afi,
+								 safi)) {
 							SET_FLAG(
-							peer->af_sflags
-							[afi][safi],
-							PEER_STATUS_EOR_SEND);
+								peer->af_sflags
+									[afi]
+									[safi],
+								PEER_STATUS_EOR_SEND);
 
 							/* Update EOR
 							 * send time
 							 */
-							peer->eor_stime
-							[afi][safi] =
-							monotime(NULL);
+							peer->eor_stime[afi]
+								       [safi] =
+								monotime(NULL);
 
 							BGP_UPDATE_EOR_PKT(
-								peer, afi,
-								safi, s);
+								peer, afi, safi,
+								s);
 						}
 					}
 				}
@@ -772,9 +773,8 @@ void bgp_notify_send_with_data(struct peer *peer, uint8_t code,
 	stream_fifo_push(peer->obuf, s);
 
 	bgp_peer_gr_flags_update(peer);
-	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(
-			peer->bgp,
-			peer->bgp->peer);
+	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(peer->bgp,
+							  peer->bgp->peer);
 
 	bgp_write_notify(peer);
 }
@@ -1651,8 +1651,8 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 		struct graceful_restart_info *gr_info;
 
 		/* Restarting router */
-		if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer) &&
-		    BGP_PEER_RESTARTING_MODE(peer))
+		if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer)
+		    && BGP_PEER_RESTARTING_MODE(peer))
 			restart = true;
 
 		/* Non-MP IPv4/Unicast is a completely emtpy UPDATE - already
@@ -1688,11 +1688,11 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 				 * deferral timer is running, cancel the timer
 				 * and invoke the best path calculation
 				 */
-				if (gr_info->eor_required ==
-						gr_info->eor_received) {
-					if (bgp_debug_neighbor_events(
-								peer))
-						zlog_debug("%s %d, %s %d",
+				if (gr_info->eor_required
+				    == gr_info->eor_received) {
+					if (bgp_debug_neighbor_events(peer))
+						zlog_debug(
+							"%s %d, %s %d",
 							"EOR REQ",
 							gr_info->eor_required,
 							"EOR RCV",
@@ -1703,7 +1703,8 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 					gr_info->eor_received = 0;
 					/* Best path selection */
 					if (bgp_best_path_select_defer(
-						peer->bgp, afi, safi) < 0)
+						    peer->bgp, afi, safi)
+					    < 0)
 						return BGP_Stop;
 				}
 			}
@@ -1788,7 +1789,6 @@ static int bgp_notify_receive(struct peer *peer, bgp_size_t size)
 
 					strlcpy(bgp_notify.data, c,
 						bgp_notify.length * 3);
-
 				}
 			bgp_notify.raw_data = (uint8_t *)peer->notify.data;
 		}
@@ -1815,9 +1815,8 @@ static int bgp_notify_receive(struct peer *peer, bgp_size_t size)
 		UNSET_FLAG(peer->sflags, PEER_STATUS_CAPABILITY_OPEN);
 
 	bgp_peer_gr_flags_update(peer);
-	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(
-			peer->bgp,
-			peer->bgp->peer);
+	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(peer->bgp,
+							  peer->bgp->peer);
 
 	return Receive_NOTIFICATION_message;
 }

--- a/bgpd/bgp_packet.h
+++ b/bgpd/bgp_packet.h
@@ -48,13 +48,13 @@ DECLARE_HOOK(bgp_packet_send,
 #define ORF_COMMON_PART_PERMIT     0x00
 #define ORF_COMMON_PART_DENY       0x20
 
-#define BGP_UPDATE_EOR_PKT(_peer, _afi, _safi, _s)       \
-		do { \
-			_s = bgp_update_packet_eor(_peer, _afi, _safi); \
-			if (_s) { \
-				bgp_packet_add(_peer, _s); \
-			} \
-		} while (0)
+#define BGP_UPDATE_EOR_PKT(_peer, _afi, _safi, _s)                             \
+	do {                                                                   \
+		_s = bgp_update_packet_eor(_peer, _afi, _safi);                \
+		if (_s) {                                                      \
+			bgp_packet_add(_peer, _s);                             \
+		}                                                              \
+	} while (0)
 
 /* Packet send and receive function prototypes. */
 extern void bgp_keepalive_send(struct peer *);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -90,8 +90,7 @@
 /* Extern from bgp_dump.c */
 extern const char *bgp_origin_str[];
 extern const char *bgp_origin_long_str[];
-const char *get_afi_safi_str(afi_t afi,
-		safi_t safi, bool for_json);
+const char *get_afi_safi_str(afi_t afi, safi_t safi, bool for_json);
 /* PMSI strings. */
 #define PMSI_TNLTYPE_STR_NO_INFO "No info"
 #define PMSI_TNLTYPE_STR_DEFAULT PMSI_TNLTYPE_STR_NO_INFO
@@ -318,7 +317,8 @@ static int bgp_node_set_defer_flag(struct bgp_node *rn, bool delete)
 	if (CHECK_FLAG(rn->flags, BGP_NODE_PROCESS_SCHEDULED)) {
 		if (BGP_DEBUG(update, UPDATE_OUT)) {
 			prefix2str(&rn->p, buf, PREFIX2STR_BUFFER);
-			zlog_debug("Route %s is in workqueue and being processed, not deferred.",
+			zlog_debug(
+				"Route %s is in workqueue and being processed, not deferred.",
 				buf);
 		}
 		return 0;
@@ -339,17 +339,18 @@ static int bgp_node_set_defer_flag(struct bgp_node *rn, bool delete)
 		/* Route selection is deferred if there is a stale path which
 		 * which indicates peer is in restart mode
 		 */
-		if (CHECK_FLAG(old_pi->flags, BGP_PATH_STALE) &&
-				(old_pi->sub_type == BGP_ROUTE_NORMAL)) {
+		if (CHECK_FLAG(old_pi->flags, BGP_PATH_STALE)
+		    && (old_pi->sub_type == BGP_ROUTE_NORMAL)) {
 			set_flag = 1;
 		} else {
 			/* If the peer is graceful restart capable and peer is
 			 * restarting mode, set the flag BGP_NODE_SELECT_DEFER
 			 */
 			peer = old_pi->peer;
-			if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer) &&
-			    BGP_PEER_RESTARTING_MODE(peer) &&
-			    (old_pi && old_pi->sub_type == BGP_ROUTE_NORMAL)) {
+			if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer)
+			    && BGP_PEER_RESTARTING_MODE(peer)
+			    && (old_pi
+				&& old_pi->sub_type == BGP_ROUTE_NORMAL)) {
 				set_flag = 1;
 			}
 		}
@@ -369,7 +370,7 @@ static int bgp_node_set_defer_flag(struct bgp_node *rn, bool delete)
 					bgp->gr_info[afi][safi].route_list, rn);
 			if (BGP_DEBUG(update, UPDATE_OUT))
 				zlog_debug("DEFER route %s, rn %p, node %p",
-						buf, rn, rn->rt_node);
+					   buf, rn, rn->rt_node);
 			return 0;
 		}
 	}
@@ -2068,8 +2069,8 @@ static int bgp_route_select_timer_expire(struct thread *thread)
 	bgp = info->bgp;
 
 	if (BGP_DEBUG(update, UPDATE_OUT))
-		zlog_debug("afi %d, safi %d : route select timer expired",
-				afi, safi);
+		zlog_debug("afi %d, safi %d : route select timer expired", afi,
+			   safi);
 
 	bgp->gr_info[afi][safi].t_route_select = NULL;
 
@@ -2730,9 +2731,9 @@ int bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
 		BGP_TIMER_OFF(bgp->gr_info[afi][safi].t_route_select);
 
 	if (BGP_DEBUG(update, UPDATE_OUT)) {
-		zlog_debug("%s: processing route for %s : cnt %d",
-			   __func__, get_afi_safi_str(afi, safi, false),
-				listcount(bgp->gr_info[afi][safi].route_list));
+		zlog_debug("%s: processing route for %s : cnt %d", __func__,
+			   get_afi_safi_str(afi, safi, false),
+			   listcount(bgp->gr_info[afi][safi].route_list));
 	}
 
 	/* Process the route list */
@@ -2758,7 +2759,7 @@ int bgp_best_path_select_defer(struct bgp *bgp, afi_t afi, safi_t safi)
 		bgp_send_delayed_eor(bgp);
 		/* Send route processing complete message to RIB */
 		bgp_zebra_update(afi, safi, bgp->vrf_id,
-				ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
+				 ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE);
 		return 0;
 	}
 
@@ -2861,7 +2862,7 @@ void bgp_process(struct bgp *bgp, struct bgp_node *rn, afi_t afi, safi_t safi)
 	if (CHECK_FLAG(rn->flags, BGP_NODE_SELECT_DEFER)) {
 		if (BGP_DEBUG(update, UPDATE_OUT))
 			zlog_debug("BGP_NODE_SELECT_DEFER set for route %p",
-				    rn);
+				   rn);
 		return;
 	}
 
@@ -3042,20 +3043,17 @@ void bgp_rib_remove(struct bgp_node *rn, struct bgp_path_info *pi,
 		 */
 		if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED))
 			delete_route = true;
-		else
-			if (bgp_node_set_defer_flag(rn, true) < 0)
-				delete_route = true;
+		else if (bgp_node_set_defer_flag(rn, true) < 0)
+			delete_route = true;
 		if (delete_route) {
 			if (CHECK_FLAG(rn->flags, BGP_NODE_SELECT_DEFER)) {
 				UNSET_FLAG(rn->flags, BGP_NODE_SELECT_DEFER);
 				bgp = pi->peer->bgp;
-				if ((rn->rt_node) &&
-					(bgp->gr_info[afi][safi]
-					.route_list)) {
-					list_delete_node(
-						bgp->gr_info[afi][safi]
-						.route_list,
-						rn->rt_node);
+				if ((rn->rt_node)
+				    && (bgp->gr_info[afi][safi].route_list)) {
+					list_delete_node(bgp->gr_info[afi][safi]
+								 .route_list,
+							 rn->rt_node);
 					rn->rt_node = NULL;
 				}
 			}

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -153,11 +153,11 @@ void bgp_delete_listnode(struct bgp_node *node)
 
 		if (bgp && rn && rn->lock == 1) {
 			/* Delete the route from the selection pending list */
-			if ((node->rt_node) &&
-			    (bgp->gr_info[afi][safi].route_list)) {
+			if ((node->rt_node)
+			    && (bgp->gr_info[afi][safi].route_list)) {
 				list_delete_node(
 					bgp->gr_info[afi][safi].route_list,
-						node->rt_node);
+					node->rt_node);
 				node->rt_node = NULL;
 			}
 		}

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -105,8 +105,10 @@ DEFINE_HOOK(bgp_inst_config_write,
 		(struct bgp *bgp, struct vty *vty),
 		(bgp, vty))
 
-#define GR_NO_OPER "The Graceful Restart No Operation was executed as cmd same as previous one."
-#define GR_INVALID "The Graceful Restart command used is not valid at this moment."
+#define GR_NO_OPER                                                             \
+	"The Graceful Restart No Operation was executed as cmd same as previous one."
+#define GR_INVALID                                                             \
+	"The Graceful Restart command used is not valid at this moment."
 static struct peer_group *listen_range_exists(struct bgp *bgp,
 					      struct prefix *range, int exact);
 
@@ -120,23 +122,18 @@ enum show_type {
 	show_ipv6_peer
 };
 
-static struct peer_group *listen_range_exists(
-						struct bgp *bgp,
-						struct prefix *range,
-						int exact);
+static struct peer_group *listen_range_exists(struct bgp *bgp,
+					      struct prefix *range, int exact);
 
-static void bgp_show_global_graceful_restart_mode_vty(
-					struct vty *vty,
-					struct bgp *bgp,
-					bool use_json,
-					json_object *json);
+static void bgp_show_global_graceful_restart_mode_vty(struct vty *vty,
+						      struct bgp *bgp,
+						      bool use_json,
+						      json_object *json);
 
-static int bgp_show_neighbor_graceful_restart_afi_all(
-				struct vty *vty,
-				enum show_type type,
-				const char *ip_str,
-				afi_t afi,
-				bool use_json);
+static int bgp_show_neighbor_graceful_restart_afi_all(struct vty *vty,
+						      enum show_type type,
+						      const char *ip_str,
+						      afi_t afi, bool use_json);
 
 static enum node_type bgp_node_type(afi_t afi, safi_t safi)
 {
@@ -838,8 +835,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 			bgp_peer_gr_flags_update(peer);
 
-			if (CHECK_FLAG(peer->flags,
-					PEER_FLAG_GRACEFUL_RESTART))
+			if (CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART))
 				gr_router_detected = true;
 
 			ret = bgp_peer_clear(peer, afi, safi, nnode,
@@ -847,14 +843,13 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 			if (ret < 0)
 				bgp_clear_vty_error(vty, peer, afi, safi, ret);
-
 		}
 
-		if (gr_router_detected &&
-			bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {
+		if (gr_router_detected
+		    && bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {
 			bgp_zebra_send_capabilities(bgp, false);
-		} else if (!gr_router_detected &&
-			bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) {
+		} else if (!gr_router_detected
+			   && bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) {
 			bgp_zebra_send_capabilities(bgp, true);
 		}
 
@@ -942,8 +937,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 			bgp_peer_gr_flags_update(peer);
 
-			if (CHECK_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART))
+			if (CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART))
 				gr_router_detected = true;
 
 			ret = bgp_peer_clear(peer, afi, safi, nnode, stype);
@@ -954,11 +948,11 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 				found = true;
 		}
 
-		if (gr_router_detected &&
-			bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {
+		if (gr_router_detected
+		    && bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {
 			bgp_zebra_send_capabilities(bgp, false);
-		} else if (!gr_router_detected &&
-			bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) {
+		} else if (!gr_router_detected
+			   && bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) {
 			bgp_zebra_send_capabilities(bgp, true);
 		}
 
@@ -980,8 +974,7 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 
 			bgp_peer_gr_flags_update(peer);
 
-			if (CHECK_FLAG(peer->flags,
-				PEER_FLAG_GRACEFUL_RESTART))
+			if (CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART))
 				gr_router_detected = true;
 
 			ret = bgp_peer_clear(peer, afi, safi, nnode, stype);
@@ -992,11 +985,11 @@ static int bgp_clear(struct vty *vty, struct bgp *bgp, afi_t afi, safi_t safi,
 				found = true;
 		}
 
-		if (gr_router_detected &&
-			bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {
+		if (gr_router_detected
+		    && bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {
 			bgp_zebra_send_capabilities(bgp, false);
-		} else if (!gr_router_detected &&
-			bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) {
+		} else if (!gr_router_detected
+			   && bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) {
 			bgp_zebra_send_capabilities(bgp, true);
 		}
 
@@ -2197,8 +2190,8 @@ DEFUN (bgp_graceful_restart,
 
 	ret = bgp_gr_update_all(bgp, GLOBAL_GR_CMD);
 
-	VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp,
-				bgp->peer, ret);
+	VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp, bgp->peer,
+							      ret);
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug("[BGP_GR] bgp_graceful_restart_cmd : END ");
@@ -2224,8 +2217,8 @@ DEFUN (no_bgp_graceful_restart,
 
 	ret = bgp_gr_update_all(bgp, NO_GLOBAL_GR_CMD);
 
-	VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp,
-			bgp->peer, ret);
+	VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp, bgp->peer,
+							      ret);
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug("[BGP_GR] no_bgp_graceful_restart_cmd : END ");
@@ -2409,8 +2402,8 @@ DEFUN (no_bgp_graceful_restart_disable,
 
 	ret = bgp_gr_update_all(bgp, NO_GLOBAL_DISABLE_CMD);
 
-	VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp,
-				bgp->peer, ret);
+	VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp, bgp->peer,
+							      ret);
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 		zlog_debug(
@@ -2555,8 +2548,7 @@ DEFUN (no_bgp_neighbor_graceful_restart_helper,
 		zlog_debug(
 			"[BGP_GR] no_bgp_neighbor_graceful_restart_helper_set_cmd : START ");
 
-	ret = bgp_neighbor_graceful_restart(peer,
-			NO_PEER_HELPER_CMD);
+	ret = bgp_neighbor_graceful_restart(peer, NO_PEER_HELPER_CMD);
 
 	VTY_BGP_GR_ROUTER_DETECT(bgp, peer, peer->bgp->peer);
 	VTY_SEND_BGP_GR_CAPABILITY_TO_ZEBRA(peer->bgp, ret);
@@ -2592,8 +2584,7 @@ DEFUN (bgp_neighbor_graceful_restart_disable_set,
 	if (!peer)
 		return CMD_WARNING_CONFIG_FAILED;
 
-	ret = bgp_neighbor_graceful_restart(peer,
-				PEER_DISABLE_CMD);
+	ret = bgp_neighbor_graceful_restart(peer, PEER_DISABLE_CMD);
 
 	if (peer->bgp->t_startup)
 		bgp_peer_gr_flags_update(peer);
@@ -9760,10 +9751,10 @@ static void bgp_show_neighbor_graceful_restart_capability_per_afi_safi(
 	}
 }
 
-static void  bgp_show_neighbor_graceful_restart_time(struct vty *vty,
-							struct peer *p,
-							bool use_json,
-							json_object *json)
+static void bgp_show_neighbor_graceful_restart_time(struct vty *vty,
+						    struct peer *p,
+						    bool use_json,
+						    json_object *json)
 {
 	if (use_json) {
 		json_object *json_timer = NULL;
@@ -9794,12 +9785,16 @@ static void  bgp_show_neighbor_graceful_restart_time(struct vty *vty,
 			vty_out(vty,
 				"     Restart Time Remaining(sec)   : %ld\n",
 				thread_timer_remain_second(p->t_gr_restart));
+		if (p->t_gr_restart != NULL) {
+			vty_out(vty,
+				"     Restart Time Remaining(sec)   : %ld\n",
+				thread_timer_remain_second(p->t_gr_restart));
+		}
 	}
 }
 
 static void bgp_show_peer_gr_status(struct vty *vty, struct peer *p,
-					bool use_json,
-					json_object *json)
+				    bool use_json, json_object *json)
 {
 	char buf[SU_ADDRSTRLEN] = {0};
 	char dn_flag[2] = {0};
@@ -9826,12 +9821,10 @@ static void bgp_show_peer_gr_status(struct vty *vty, struct peer *p,
 		sprintf(neighborAddr, "%s%s", dn_flag, p->host);
 
 		if (use_json)
-			json_object_string_add(
-				json, "neighborAddr",
-				neighborAddr);
+			json_object_string_add(json, "neighborAddr",
+					       neighborAddr);
 		else
-			vty_out(vty, "BGP neighbor is %s\n",
-				neighborAddr);
+			vty_out(vty, "BGP neighbor is %s\n", neighborAddr);
 	}
 
 	/* more gr info in new format */
@@ -10153,8 +10146,7 @@ static void bgp_show_peer_afi(struct vty *vty, struct peer *p, afi_t afi,
 					p->pmax_restart[afi][safi] * 60000);
 		}
 		json_object_object_add(json_neigh,
-					get_afi_safi_str(afi,
-						safi, true),
+				       get_afi_safi_str(afi, safi, true),
 				       json_addr);
 
 	} else {
@@ -11610,11 +11602,11 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 			json_grace_send = json_object_new_object();
 			json_grace_recv = json_object_new_object();
 
-			if ((p->status == Established) &&
-					CHECK_FLAG(p->cap, PEER_CAP_RESTART_RCV)) {
+			if ((p->status == Established)
+			    && CHECK_FLAG(p->cap, PEER_CAP_RESTART_RCV)) {
 				FOREACH_AFI_SAFI (afi, safi) {
 					if (CHECK_FLAG(p->af_sflags[afi][safi],
-						PEER_STATUS_EOR_SEND)) {
+						       PEER_STATUS_EOR_SEND)) {
 						json_object_boolean_true_add(
 							json_grace_send,
 							get_afi_safi_str(afi,
@@ -11625,8 +11617,8 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 				}
 				FOREACH_AFI_SAFI (afi, safi) {
 					if (CHECK_FLAG(
-						p->af_sflags[afi][safi],
-						PEER_STATUS_EOR_RECEIVED)) {
+						    p->af_sflags[afi][safi],
+						    PEER_STATUS_EOR_RECEIVED)) {
 						json_object_boolean_true_add(
 							json_grace_recv,
 							get_afi_safi_str(afi,
@@ -11636,12 +11628,10 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 					}
 				}
 			}
-			json_object_object_add(json_grace,
-						"endOfRibSend",
-							json_grace_send);
-			json_object_object_add(json_grace,
-						"endOfRibRecv",
-						json_grace_recv);
+			json_object_object_add(json_grace, "endOfRibSend",
+					       json_grace_send);
+			json_object_object_add(json_grace, "endOfRibRecv",
+					       json_grace_recv);
 
 
 			if (p->t_gr_restart)
@@ -11660,13 +11650,13 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 						* 1000);
 			/* more gr info in new format */
 			BGP_SHOW_PEER_GR_CAPABILITY(vty, p, use_json,
-							json_grace);
+						    json_grace);
 			json_object_object_add(
 				json_neigh, "gracefulRestartInfo", json_grace);
 		} else {
 			vty_out(vty, "  Graceful restart informations:\n");
-			if ((p->status == Established) &&
-				CHECK_FLAG(p->cap, PEER_CAP_RESTART_RCV)) {
+			if ((p->status == Established)
+			    && CHECK_FLAG(p->cap, PEER_CAP_RESTART_RCV)) {
 
 				vty_out(vty, "    End-of-RIB send: ");
 				FOREACH_AFI_SAFI (afi, safi) {
@@ -11675,9 +11665,9 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 						vty_out(vty, "%s%s",
 							eor_send_af_count ? ", "
 									  : "",
-							get_afi_safi_str(afi,
-									safi,
-									false));
+							get_afi_safi_str(
+								afi, safi,
+								false));
 						eor_send_af_count++;
 					}
 				}
@@ -12129,12 +12119,11 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 	}
 }
 
-static int bgp_show_neighbor_graceful_restart(struct vty *vty,
-					struct bgp *bgp,
-					enum show_type type,
-					union sockunion *su,
-					const char *conf_if, afi_t afi,
-					bool use_json, json_object *json)
+static int bgp_show_neighbor_graceful_restart(struct vty *vty, struct bgp *bgp,
+					      enum show_type type,
+					      union sockunion *su,
+					      const char *conf_if, afi_t afi,
+					      bool use_json, json_object *json)
 {
 	struct listnode *node, *nnode;
 	struct peer *peer;
@@ -12311,9 +12300,10 @@ static int bgp_show_neighbor(struct vty *vty, struct bgp *bgp,
 	return CMD_SUCCESS;
 }
 
-static void  bgp_show_neighbor_graceful_restart_vty(struct vty *vty,
-				 enum show_type type, const char *ip_str,
-				 afi_t afi, bool use_json)
+static void bgp_show_neighbor_graceful_restart_vty(struct vty *vty,
+						   enum show_type type,
+						   const char *ip_str,
+						   afi_t afi, bool use_json)
 {
 
 	int ret;
@@ -12506,7 +12496,7 @@ DEFUN (show_ip_bgp_neighbors_gracrful_restart,
 	afi_t afi = AFI_MAX;
 	bool uj = use_json(argc, argv);
 
-	if	(!argv_find_and_parse_afi(argv, argc, &idx, &afi))
+	if (!argv_find_and_parse_afi(argv, argc, &idx, &afi))
 		afi = AFI_MAX;
 
 	idx++;
@@ -12523,9 +12513,8 @@ DEFUN (show_ip_bgp_neighbors_gracrful_restart,
 		return CMD_SUCCESS;
 
 
-	return bgp_show_neighbor_graceful_restart_afi_all(vty,
-						sh_type, sh_arg,
-						afi, uj);
+	return bgp_show_neighbor_graceful_restart_afi_all(vty, sh_type, sh_arg,
+							  afi, uj);
 }
 
 /* "show [ip] bgp neighbors" commands.  */
@@ -12669,9 +12658,9 @@ DEFUN (show_ip_bgp_lcommunity_info,
 /* Graceful Restart */
 
 static void bgp_show_global_graceful_restart_mode_vty(struct vty *vty,
-					struct bgp *bgp,
-					bool use_json,
-					json_object *json)
+						      struct bgp *bgp,
+						      bool use_json,
+						      json_object *json)
 {
 
 
@@ -12701,26 +12690,23 @@ static void bgp_show_global_graceful_restart_mode_vty(struct vty *vty,
 	vty_out(vty, "\n");
 }
 
-static int  bgp_show_neighbor_graceful_restart_afi_all(struct vty *vty,
-						enum show_type type,
-						const char *ip_str,
-						afi_t afi,
-						bool use_json)
+static int bgp_show_neighbor_graceful_restart_afi_all(struct vty *vty,
+						      enum show_type type,
+						      const char *ip_str,
+						      afi_t afi, bool use_json)
 {
 	if ((afi == AFI_MAX) && (ip_str == NULL)) {
 		afi = AFI_IP;
 
 		while ((afi != AFI_L2VPN) && (afi < AFI_MAX)) {
 
-			bgp_show_neighbor_graceful_restart_vty(vty,
-							type, ip_str,
-							afi, use_json);
+			bgp_show_neighbor_graceful_restart_vty(
+				vty, type, ip_str, afi, use_json);
 			afi++;
 		}
 	} else if (afi != AFI_MAX) {
-		bgp_show_neighbor_graceful_restart_vty(vty,
-							type, ip_str,
-							afi, use_json);
+		bgp_show_neighbor_graceful_restart_vty(vty, type, ip_str, afi,
+						       use_json);
 	} else {
 		return CMD_ERR_INCOMPLETE;
 	}
@@ -15504,22 +15490,16 @@ void bgp_vty_init(void)
 	install_element(BGP_NODE, &no_bgp_deterministic_med_cmd);
 
 	/* "bgp graceful-restart" command */
-	install_element(BGP_NODE,
-			&bgp_graceful_restart_cmd);
-	install_element(BGP_NODE,
-			&no_bgp_graceful_restart_cmd);
+	install_element(BGP_NODE, &bgp_graceful_restart_cmd);
+	install_element(BGP_NODE, &no_bgp_graceful_restart_cmd);
 
 	/* "bgp graceful-restart-disable" command */
-	install_element(BGP_NODE,
-			&bgp_graceful_restart_disable_cmd);
-	install_element(BGP_NODE,
-			&no_bgp_graceful_restart_disable_cmd);
+	install_element(BGP_NODE, &bgp_graceful_restart_disable_cmd);
+	install_element(BGP_NODE, &no_bgp_graceful_restart_disable_cmd);
 
 	/* "neighbor a:b:c:d graceful-restart" command */
-	install_element(BGP_NODE,
-			&bgp_neighbor_graceful_restart_set_cmd);
-	install_element(BGP_NODE,
-			&no_bgp_neighbor_graceful_restart_set_cmd);
+	install_element(BGP_NODE, &bgp_neighbor_graceful_restart_set_cmd);
+	install_element(BGP_NODE, &no_bgp_neighbor_graceful_restart_set_cmd);
 
 	/* "neighbor a:b:c:d graceful-restart-disable" command */
 	install_element(BGP_NODE,
@@ -16542,8 +16522,7 @@ void bgp_vty_init(void)
 	/* "show [ip] bgp neighbors" commands. */
 	install_element(VIEW_NODE, &show_ip_bgp_neighbors_cmd);
 
-	install_element(VIEW_NODE,
-			&show_ip_bgp_neighbors_graceful_restart_cmd);
+	install_element(VIEW_NODE, &show_ip_bgp_neighbors_graceful_restart_cmd);
 
 	/* "show [ip] bgp peer-group" commands. */
 	install_element(VIEW_NODE, &show_ip_bgp_peer_groups_cmd);

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -68,86 +68,83 @@ struct bgp;
 						vty, p, use_json, json); \
 	} while (0)
 
-#define VTY_BGP_GR_DEFINE_LOOP_VARIABLE \
-		struct peer *peer_loop = NULL; \
-		struct listnode *node = NULL; \
-		struct listnode *nnode = NULL; \
-		bool gr_router_detected = false
+#define VTY_BGP_GR_DEFINE_LOOP_VARIABLE                                        \
+	struct peer *peer_loop = NULL;                                         \
+	struct listnode *node = NULL;                                          \
+	struct listnode *nnode = NULL;                                         \
+	bool gr_router_detected = false
 
-#define VTY_BGP_GR_ROUTER_DETECT( \
-		_bgp, _peer, _peer_list) \
-	do { \
-		if (_peer->bgp->t_startup) \
-			bgp_peer_gr_flags_update(_peer); \
-		for (ALL_LIST_ELEMENTS(_peer_list, \
-			node, nnode, peer_loop)) { \
-			if (CHECK_FLAG(peer_loop->flags,\
-				PEER_FLAG_GRACEFUL_RESTART)) \
-				gr_router_detected = true; \
-		} \
+#define VTY_BGP_GR_ROUTER_DETECT(_bgp, _peer, _peer_list)                      \
+	do {                                                                   \
+		if (_peer->bgp->t_startup)                                     \
+			bgp_peer_gr_flags_update(_peer);                       \
+		for (ALL_LIST_ELEMENTS(_peer_list, node, nnode, peer_loop)) {  \
+			if (CHECK_FLAG(peer_loop->flags,                       \
+				       PEER_FLAG_GRACEFUL_RESTART))            \
+				gr_router_detected = true;                     \
+		}                                                              \
 	} while (0)
 
 
-#define VTY_SEND_BGP_GR_CAPABILITY_TO_ZEBRA(_bgp, _ret) \
-	do { \
-		if (gr_router_detected && \
-			_bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) { \
-			if (bgp_zebra_send_capabilities(_bgp, false)) \
-				_ret = BGP_ERR_INVALID_VALUE;\
-		} else if (!gr_router_detected && \
-			_bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) { \
-			if (bgp_zebra_send_capabilities(_bgp, true)) \
-				_ret = BGP_ERR_INVALID_VALUE;\
-		} \
+#define VTY_SEND_BGP_GR_CAPABILITY_TO_ZEBRA(_bgp, _ret)                        \
+	do {                                                                   \
+		if (gr_router_detected                                         \
+		    && _bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {     \
+			if (bgp_zebra_send_capabilities(_bgp, false))          \
+				_ret = BGP_ERR_INVALID_VALUE;                  \
+		} else if (!gr_router_detected                                 \
+			   && _bgp->present_zebra_gr_state                     \
+				      == ZEBRA_GR_ENABLE) {                    \
+			if (bgp_zebra_send_capabilities(_bgp, true))           \
+				_ret = BGP_ERR_INVALID_VALUE;                  \
+		}                                                              \
 	} while (0)
 
-#define VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA( \
-		_bgp, _peer_list, _ret) \
-	do { \
-		struct peer *peer_loop; \
-		bool gr_router_detected = false; \
-		struct listnode *node = {0}; \
-		struct listnode *nnode = {0}; \
-		for (ALL_LIST_ELEMENTS( \
-					_peer_list, node, \
-					nnode, peer_loop)) { \
-			if (peer_loop->bgp->t_startup) \
-				bgp_peer_gr_flags_update(peer_loop); \
-			if (CHECK_FLAG( \
-						peer_loop->flags, \
-						PEER_FLAG_GRACEFUL_RESTART)) \
-				gr_router_detected = true; \
-		} \
-		if (gr_router_detected && \
-			_bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) { \
-			if (bgp_zebra_send_capabilities(_bgp, false)) \
-				_ret = BGP_ERR_INVALID_VALUE;\
-		} else if (!gr_router_detected && \
-			_bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) { \
-			if (bgp_zebra_send_capabilities(_bgp, true)) \
-				_ret = BGP_ERR_INVALID_VALUE;\
-		} \
+#define VTY_BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(                 \
+	_bgp, _peer_list, _ret)                                                \
+	do {                                                                   \
+		struct peer *peer_loop;                                        \
+		bool gr_router_detected = false;                               \
+		struct listnode *node = {0};                                   \
+		struct listnode *nnode = {0};                                  \
+		for (ALL_LIST_ELEMENTS(_peer_list, node, nnode, peer_loop)) {  \
+			if (peer_loop->bgp->t_startup)                         \
+				bgp_peer_gr_flags_update(peer_loop);           \
+			if (CHECK_FLAG(peer_loop->flags,                       \
+				       PEER_FLAG_GRACEFUL_RESTART))            \
+				gr_router_detected = true;                     \
+		}                                                              \
+		if (gr_router_detected                                         \
+		    && _bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {     \
+			if (bgp_zebra_send_capabilities(_bgp, false))          \
+				_ret = BGP_ERR_INVALID_VALUE;                  \
+		} else if (!gr_router_detected                                 \
+			   && _bgp->present_zebra_gr_state                     \
+				      == ZEBRA_GR_ENABLE) {                    \
+			if (bgp_zebra_send_capabilities(_bgp, true))           \
+				_ret = BGP_ERR_INVALID_VALUE;                  \
+		}                                                              \
 	} while (0)
 
 
-#define PRINT_EOR(_eor_flag) \
-	do {			\
-		if (eor_flag)  \
-			vty_out(vty, "Yes\n");  \
-		else    \
-			vty_out(vty, "No\n"); \
+#define PRINT_EOR(_eor_flag)                                                   \
+	do {                                                                   \
+		if (eor_flag)                                                  \
+			vty_out(vty, "Yes\n");                                 \
+		else                                                           \
+			vty_out(vty, "No\n");                                  \
 	} while (0)
 
-#define PRINT_EOR_JSON(_eor_flag) \
-	do {			\
-		if (eor_flag) \
-			json_object_boolean_true_add( \
-				json_endofrib_status,     \
-				"endOfRibSentAfterUpdate"); \
-		else                            \
-			json_object_boolean_false_add( \
-				json_endofrib_status,      \
-				"endOfRibSentAfterUpdate"); \
+#define PRINT_EOR_JSON(_eor_flag)                                              \
+	do {                                                                   \
+		if (eor_flag)                                                  \
+			json_object_boolean_true_add(                          \
+				json_endofrib_status,                          \
+				"endOfRibSentAfterUpdate");                    \
+		else                                                           \
+			json_object_boolean_false_add(                         \
+				json_endofrib_status,                          \
+				"endOfRibSentAfterUpdate");                    \
 	} while (0)
 
 extern void bgp_vty_init(void);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -3050,8 +3050,8 @@ int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable)
 		api.vrf_id = bgp->vrf_id;
 	}
 
-	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES,
-				      zclient, &api) < 0) {
+	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES, zclient, &api)
+	    < 0) {
 		zlog_err("error sending capability");
 		ret = BGP_GR_FAILURE;
 	} else {
@@ -3092,8 +3092,8 @@ int bgp_zebra_update(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type)
 	api.vrf_id = vrf_id;
 	api.cap = type;
 
-	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES,
-				      zclient, &api) < 0) {
+	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES, zclient, &api)
+	    < 0) {
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("error sending capability");
 		return BGP_GR_FAILURE;
@@ -3124,8 +3124,8 @@ int bgp_zebra_stale_timer_update(struct bgp *bgp)
 	api.cap = ZEBRA_CLIENT_RIB_STALE_TIME;
 	api.stale_removal_time = bgp->rib_stale_time;
 	api.vrf_id = bgp->vrf_id;
-	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES,
-				zclient, &api) < 0) {
+	if (zclient_capabilities_send(ZEBRA_CLIENT_CAPABILITIES, zclient, &api)
+	    < 0) {
 		if (BGP_DEBUG(zebra, ZEBRA))
 			zlog_debug("error sending capability");
 		return BGP_GR_FAILURE;

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -99,7 +99,6 @@ extern void bgp_send_pbr_iptable(struct bgp_pbr_action *pba,
 extern void bgp_zebra_announce_default(struct bgp *bgp, struct nexthop *nh,
 				afi_t afi, uint32_t table_id, bool announce);
 extern int bgp_zebra_send_capabilities(struct bgp *bgp, bool disable);
-extern int bgp_zebra_update(afi_t afi, safi_t safi, vrf_id_t vrf_id,
-			    int type);
+extern int bgp_zebra_update(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type);
 extern int bgp_zebra_stale_timer_update(struct bgp *bgp);
 #endif /* _QUAGGA_BGP_ZEBRA_H */

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1654,9 +1654,7 @@ struct peer *peer_create(union sockunion *su, const char *conf_if,
 		bgp_timer_set(peer);
 
 	bgp_peer_gr_flags_update(peer);
-	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(
-		bgp,
-		bgp->peer);
+	BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(bgp, bgp->peer);
 
 	return peer;
 }
@@ -3077,7 +3075,7 @@ static struct bgp *bgp_create(as_t *as, const char *name,
 		bgp->name = XSTRDUP(MTYPE_BGP, name);
 
 	thread_add_timer(bm->master, bgp_startup_timer_expire, bgp,
-				bgp->restart_time, &bgp->t_startup);
+			 bgp->restart_time, &bgp->t_startup);
 
 	/* printable name we can use in debug messages */
 	if (inst_type == BGP_INSTANCE_TYPE_DEFAULT) {
@@ -7253,22 +7251,20 @@ void bgp_gr_apply_running_config(void)
 	bool gr_router_detected = false;
 
 	if (BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
-		zlog_debug("[BGP_GR] %s called !",
-				__func__);
+		zlog_debug("[BGP_GR] %s called !", __func__);
 
 	for (ALL_LIST_ELEMENTS(bm->bgp, node, nnode, bgp)) {
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 			bgp_peer_gr_flags_update(peer);
-			if (CHECK_FLAG(peer->flags,
-						PEER_FLAG_GRACEFUL_RESTART))
+			if (CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART))
 				gr_router_detected = true;
 		}
 
-		if (gr_router_detected &&
-			bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {
+		if (gr_router_detected
+		    && bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {
 			bgp_zebra_send_capabilities(bgp, true);
-		} else if (!gr_router_detected &&
-			bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) {
+		} else if (!gr_router_detected
+			   && bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) {
 			bgp_zebra_send_capabilities(bgp, false);
 		}
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -238,11 +238,11 @@ enum bgp_instance_type {
 	BGP_INSTANCE_TYPE_VIEW
 };
 
-#define BGP_SEND_EOR(bgp, afi, safi)				\
-	(!bgp_flag_check(bgp, BGP_FLAG_GR_DISABLE_EOR) &&	\
-	((bgp->gr_info[afi][safi].t_select_deferral == NULL) || \
-	 (bgp->gr_info[afi][safi].eor_required ==		\
-	  bgp->gr_info[afi][safi].eor_received)))
+#define BGP_SEND_EOR(bgp, afi, safi)                                           \
+	(!bgp_flag_check(bgp, BGP_FLAG_GR_DISABLE_EOR)                         \
+	 && ((bgp->gr_info[afi][safi].t_select_deferral == NULL)               \
+	     || (bgp->gr_info[afi][safi].eor_required                          \
+		 == bgp->gr_info[afi][safi].eor_received)))
 
 /* BGP GR Global ds */
 
@@ -426,7 +426,7 @@ struct bgp {
 #define BGP_FLAG_GR_DISABLE_EOR           (1 << 24)
 
 	enum global_mode GLOBAL_GR_FSM[BGP_GLOBAL_GR_MODE]
-				[BGP_GLOBAL_GR_EVENT_CMD];
+				      [BGP_GLOBAL_GR_EVENT_CMD];
 	enum global_mode global_gr_present_state;
 
 	/* This variable stores the current Graceful Restart state of Zebra
@@ -659,12 +659,12 @@ DECLARE_HOOK(bgp_inst_config_write,
 		(struct bgp *bgp, struct vty *vty),
 		(bgp, vty))
 
-	/* Thread callback information */
-	struct afi_safi_info {
-		afi_t afi;
-		safi_t safi;
-		struct bgp *bgp;
-	};
+/* Thread callback information */
+struct afi_safi_info {
+	afi_t afi;
+	safi_t safi;
+	struct bgp *bgp;
+};
 
 #define BGP_ROUTE_ADV_HOLD(bgp) (bgp->main_peers_update_hold)
 
@@ -673,7 +673,7 @@ DECLARE_HOOK(bgp_inst_config_write,
 	 || (bgp->inst_type == BGP_INSTANCE_TYPE_VRF                           \
 	     && bgp->vrf_id != VRF_UNKNOWN))
 
-#define BGP_SELECT_DEFER_DISABLE(bgp)                 \
+#define BGP_SELECT_DEFER_DISABLE(bgp)                                          \
 	(bgp_flag_check(bgp, BGP_FLAG_SELECT_DEFER_DISABLE))
 
 /* BGP peer-group support. */
@@ -1922,28 +1922,25 @@ int bgp_global_gr_init(struct bgp *bgp);
 int bgp_peer_gr_init(struct peer *peer);
 
 
-#define BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA( \
-		_bgp, _peer_list) \
-do { \
-	struct peer *peer_loop; \
-	bool gr_router_detected = false; \
-	struct listnode *node = {0}; \
-	for (ALL_LIST_ELEMENTS_RO( \
-				_peer_list, node, \
-				peer_loop)) { \
-		if (CHECK_FLAG( \
-				peer_loop->flags, \
-				PEER_FLAG_GRACEFUL_RESTART)) \
-			gr_router_detected = true; \
-	} \
-	if (gr_router_detected && \
-			_bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) { \
-		bgp_zebra_send_capabilities(_bgp, false); \
-	} else if (!gr_router_detected && \
-			_bgp->present_zebra_gr_state == ZEBRA_GR_ENABLE) { \
-		bgp_zebra_send_capabilities(_bgp, true); \
-	} \
-} while (0)
+#define BGP_GR_ROUTER_DETECT_AND_SEND_CAPABILITY_TO_ZEBRA(_bgp, _peer_list)    \
+	do {                                                                   \
+		struct peer *peer_loop;                                        \
+		bool gr_router_detected = false;                               \
+		struct listnode *node = {0};                                   \
+		for (ALL_LIST_ELEMENTS_RO(_peer_list, node, peer_loop)) {      \
+			if (CHECK_FLAG(peer_loop->flags,                       \
+				       PEER_FLAG_GRACEFUL_RESTART))            \
+				gr_router_detected = true;                     \
+		}                                                              \
+		if (gr_router_detected                                         \
+		    && _bgp->present_zebra_gr_state == ZEBRA_GR_DISABLE) {     \
+			bgp_zebra_send_capabilities(_bgp, false);              \
+		} else if (!gr_router_detected                                 \
+			   && _bgp->present_zebra_gr_state                     \
+				      == ZEBRA_GR_ENABLE) {                    \
+			bgp_zebra_send_capabilities(_bgp, true);               \
+		}                                                              \
+	} while (0)
 
 static inline struct bgp *bgp_lock(struct bgp *bgp)
 {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1928,10 +1928,9 @@ do { \
 	struct peer *peer_loop; \
 	bool gr_router_detected = false; \
 	struct listnode *node = {0}; \
-	struct listnode *nnode = {0}; \
-	for (ALL_LIST_ELEMENTS( \
+	for (ALL_LIST_ELEMENTS_RO( \
 				_peer_list, node, \
-				nnode, peer_loop)) { \
+				peer_loop)) { \
 		if (CHECK_FLAG( \
 				peer_loop->flags, \
 				PEER_FLAG_GRACEFUL_RESTART)) \

--- a/tests/bgpd/test_mpath.c
+++ b/tests/bgpd/test_mpath.c
@@ -315,7 +315,7 @@ static int setup_bgp_path_info_mpath_update(testcase_t *t)
 	str2prefix("42.1.1.0/24", &test_rn.p);
 	rt_node = bgp_node_to_rnode(&test_rn);
 	memcpy((struct route_table *)&rt_node->table, &rt->route_table,
-		sizeof(struct route_table));
+	       sizeof(struct route_table));
 	setup_bgp_mp_list(t);
 	for (i = 0; i < test_mp_list_info_count; i++)
 		bgp_path_info_add(&test_rn, &test_mp_list_info[i]);


### PR DESCRIPTION
@bisdhdh Please read the docs where we extensively documented how to comply with the style guide, including tools that make it effortless.

http://docs.frrouting.org/projects/dev-guide/en/latest/workflow.html#code-formatting

    bgpd, lib: fix style from BGP GR code
    
    This patch fixes the noncompliant style for the following commit range:
    
    4a6e80fbf
    2ba1fe695
    efcb2ebbb
    8c48b3b69
    dc95985fe
    0f0444fbd
    85ef4179a
    eb451ee58
    2d3dd828d
    9e3b51a7f
    d6e3c15b6
    34aa74486
    6102cb7fe
    d7b3cda6f
    2bb5d39b1
    5f9c1aa29
    5cce3f054
    3a75afa4b
    f009ff269
    cfd47646b
    2986cac29
    055679e91
    034e185dc
    794b37d52
    b0965c44e
    949b0f24f
    63696f1d8
    
    Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>
