### PR TITLE
bgpd: Replace bgp_flag_* to [UN]SET/CHECK_FLAG macros

### DIFF
--- a/bgpd/bgp_addpath.c
+++ b/bgpd/bgp_addpath.c
@@ -380,11 +380,13 @@ void bgp_addpath_set_peer_type(struct peer *peer, afi_t afi, safi_t safi,
 
 	if (addpath_type != BGP_ADDPATH_NONE) {
 		if (bgp_addpath_dmed_required(addpath_type)) {
-			if (!bgp_flag_check(bgp, BGP_FLAG_DETERMINISTIC_MED)) {
+			if (!CHECK_FLAG(bgp->flags,
+					BGP_FLAG_DETERMINISTIC_MED)) {
 				zlog_warn(
 					"%s: enabling bgp deterministic-med, this is required for addpath-tx-bestpath-per-AS",
 					peer->host);
-				bgp_flag_set(bgp, BGP_FLAG_DETERMINISTIC_MED);
+				SET_FLAG(bgp->flags,
+					 BGP_FLAG_DETERMINISTIC_MED);
 				bgp_recalculate_all_bestpaths(bgp);
 			}
 		}

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -933,7 +933,7 @@ struct attr *bgp_attr_aggregate_intern(struct bgp *bgp, uint8_t origin,
 		/* If we are not shutting down ourselves and we are
 		 * aggregating a route that contains the GSHUT community we
 		 * need to remove that community when creating the aggregate */
-		if (!bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN)
+		if (!CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN)
 		    && community_include(community, gshut)) {
 			community_del_val(community, &gshut);
 		}
@@ -952,9 +952,8 @@ struct attr *bgp_attr_aggregate_intern(struct bgp *bgp, uint8_t origin,
 		attr.flag |= ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES);
 	}
 
-	if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN))
 		bgp_attr_add_gshut_community(&attr);
-	}
 
 	attr.label_index = BGP_INVALID_LABEL_INDEX;
 	attr.label = MPLS_INVALID_LABEL;
@@ -996,13 +995,13 @@ struct attr *bgp_attr_aggregate_intern(struct bgp *bgp, uint8_t origin,
 			return NULL;
 		}
 
-		if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN))
 			bgp_attr_add_gshut_community(&attr_tmp);
 
 		new = bgp_attr_intern(&attr_tmp);
 	} else {
 
-		if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN))
 			bgp_attr_add_gshut_community(&attr);
 
 		new = bgp_attr_intern(&attr);

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -116,10 +116,10 @@ static void bgp_bfd_peer_sendmsg(struct peer *peer, int command)
 	 * and bfd controlplane check not configured is not kept
 	 * keep bfd independent controlplane bit set to 1
 	 */
-	if (!bgp_flag_check(peer->bgp, BGP_FLAG_GRACEFUL_RESTART)
-	    && !bgp_flag_check(peer->bgp, BGP_FLAG_GR_PRESERVE_FWD)
+	if (!CHECK_FLAG(peer->bgp->flags, BGP_FLAG_GRACEFUL_RESTART)
+	    && !CHECK_FLAG(peer->bgp->flags, BGP_FLAG_GR_PRESERVE_FWD)
 	    && !CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CHECK_CONTROLPLANE))
-		SET_FLAG(bfd_info->flags,  BFD_FLAG_BFD_CBIT_ON);
+		SET_FLAG(bfd_info->flags, BFD_FLAG_BFD_CBIT_ON);
 
 	cbit = CHECK_FLAG(bfd_info->flags, BFD_FLAG_BFD_CBIT_ON);
 

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -511,7 +511,7 @@ void bgp_notify_print(struct peer *peer, struct bgp_notify *bgp_notify,
 	char msg_buf[1024];
 
 	if (BGP_DEBUG(neighbor_events, NEIGHBOR_EVENTS)
-	    || bgp_flag_check(peer->bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES)) {
+	    || CHECK_FLAG(peer->bgp->flags, BGP_FLAG_LOG_NEIGHBOR_CHANGES)) {
 		code_str = bgp_notify_code_str(bgp_notify->code);
 		subcode_str = bgp_notify_subcode_str(bgp_notify->code,
 						     bgp_notify->subcode);

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -103,7 +103,7 @@ static int bgp_peer_reg_with_nht(struct peer *peer)
 
 	if (peer->sort == BGP_PEER_EBGP && peer->ttl == BGP_DEFAULT_TTL
 	    && !CHECK_FLAG(peer->flags, PEER_FLAG_DISABLE_CONNECTED_CHECK)
-	    && !bgp_flag_check(peer->bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
+	    && !CHECK_FLAG(peer->bgp->flags, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
 		connected = 1;
 
 	return bgp_find_or_add_nexthop(
@@ -1144,7 +1144,8 @@ int bgp_stop(struct peer *peer)
 		peer->dropped++;
 
 		/* bgp log-neighbor-changes of neighbor Down */
-		if (bgp_flag_check(peer->bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES)) {
+		if (CHECK_FLAG(peer->bgp->flags,
+			       BGP_FLAG_LOG_NEIGHBOR_CHANGES)) {
 			struct vrf *vrf = vrf_lookup_by_id(peer->bgp->vrf_id);
 
 			zlog_info(
@@ -1722,7 +1723,7 @@ static int bgp_update_gr_info(struct peer *peer, afi_t afi, safi_t safi)
 	if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(peer)
 	    && BGP_PEER_RESTARTING_MODE(peer)) {
 		/* Check if the forwarding state is preserved */
-		if (bgp_flag_check(bgp, BGP_FLAG_GR_PRESERVE_FWD)) {
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD)) {
 			gr_info = &(bgp->gr_info[afi][safi]);
 			ret = bgp_start_deferral_timer(bgp, afi, safi, gr_info);
 		}
@@ -1768,15 +1769,14 @@ static int bgp_establish(struct peer *peer)
 	bgp_fsm_change_status(peer, Established);
 
 	/* bgp log-neighbor-changes of neighbor Up */
-	if (bgp_flag_check(peer->bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES)) {
+	if (CHECK_FLAG(peer->bgp->flags, BGP_FLAG_LOG_NEIGHBOR_CHANGES)) {
 		struct vrf *vrf = vrf_lookup_by_id(peer->bgp->vrf_id);
-		zlog_info("%%ADJCHANGE: neighbor %s(%s) in vrf %s Up",
-			  peer->host,
-			  (peer->hostname) ? peer->hostname : "Unknown",
-			  vrf ? ((vrf->vrf_id != VRF_DEFAULT)
-					? vrf->name
-					: VRF_DEFAULT_NAME)
-			      : "");
+		zlog_info(
+			"%%ADJCHANGE: neighbor %s(%s) in vrf %s Up", peer->host,
+			(peer->hostname) ? peer->hostname : "Unknown",
+			vrf ? ((vrf->vrf_id != VRF_DEFAULT) ? vrf->name
+							    : VRF_DEFAULT_NAME)
+			    : "");
 	}
 	/* assign update-group/subgroup */
 	update_group_adjust_peer_afs(peer);
@@ -1823,8 +1823,8 @@ static int bgp_establish(struct peer *peer)
 					if (BGP_PEER_GRACEFUL_RESTART_CAPABLE(
 						    peer)
 					    && BGP_PEER_RESTARTING_MODE(peer)
-					    && bgp_flag_check(
-						    peer->bgp,
+					    && CHECK_FLAG(
+						    peer->bgp->flags,
 						    BGP_FLAG_GR_PRESERVE_FWD))
 						peer->bgp->gr_info[afi][safi]
 							.eor_required++;

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -721,8 +721,9 @@ void bgp_path_info_mpath_aggregate_update(struct bgp_path_info *new_best,
 
 	attr = *new_best->attr;
 
-	if (new_best->peer && bgp_flag_check(new_best->peer->bgp,
-					     BGP_FLAG_MULTIPATH_RELAX_AS_SET)) {
+	if (new_best->peer
+	    && CHECK_FLAG(new_best->peer->bgp->flags,
+			  BGP_FLAG_MULTIPATH_RELAX_AS_SET)) {
 
 		/* aggregate attribute from multipath constituents */
 		aspath = aspath_dup(attr.aspath);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -186,12 +186,13 @@ int bgp_find_or_add_nexthop(struct bgp *bgp_route, struct bgp *bgp_nexthop,
 		SET_FLAG(bnc->flags, BGP_STATIC_ROUTE);
 
 		/* If we're toggling the type, re-register */
-		if ((bgp_flag_check(bgp_route, BGP_FLAG_IMPORT_CHECK))
+		if ((CHECK_FLAG(bgp_route->flags, BGP_FLAG_IMPORT_CHECK))
 		    && !CHECK_FLAG(bnc->flags, BGP_STATIC_ROUTE_EXACT_MATCH)) {
 			SET_FLAG(bnc->flags, BGP_STATIC_ROUTE_EXACT_MATCH);
 			UNSET_FLAG(bnc->flags, BGP_NEXTHOP_REGISTERED);
 			UNSET_FLAG(bnc->flags, BGP_NEXTHOP_VALID);
-		} else if ((!bgp_flag_check(bgp_route, BGP_FLAG_IMPORT_CHECK))
+		} else if ((!CHECK_FLAG(bgp_route->flags,
+					BGP_FLAG_IMPORT_CHECK))
 			   && CHECK_FLAG(bnc->flags,
 					 BGP_STATIC_ROUTE_EXACT_MATCH)) {
 			UNSET_FLAG(bnc->flags, BGP_STATIC_ROUTE_EXACT_MATCH);

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1341,7 +1341,7 @@ static void bgp_peer_send_gr_capability(struct stream *s, struct peer *peer,
 	 * only when GR config is present
 	 */
 	if (CHECK_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART)) {
-		if (bgp_flag_check(peer->bgp, BGP_FLAG_GR_PRESERVE_FWD)
+		if (CHECK_FLAG(peer->bgp->flags, BGP_FLAG_GR_PRESERVE_FWD)
 		    && BGP_DEBUG(graceful_restart, GRACEFUL_RESTART))
 			zlog_debug("[BGP_GR] F bit Set");
 
@@ -1361,7 +1361,8 @@ static void bgp_peer_send_gr_capability(struct stream *s, struct peer *peer,
 						  &pkt_safi);
 			stream_putw(s, pkt_afi);
 			stream_putc(s, pkt_safi);
-			if (bgp_flag_check(peer->bgp, BGP_FLAG_GR_PRESERVE_FWD))
+			if (CHECK_FLAG(peer->bgp->flags,
+				       BGP_FLAG_GR_PRESERVE_FWD))
 				stream_putc(s, RESTART_F_BIT);
 			else
 				stream_putc(s, 0);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -501,7 +501,7 @@ static uint32_t bgp_med_value(struct attr *attr, struct bgp *bgp)
 	if (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_MULTI_EXIT_DISC))
 		return attr->med;
 	else {
-		if (bgp_flag_check(bgp, BGP_FLAG_MED_MISSING_AS_WORST))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_MED_MISSING_AS_WORST))
 			return BGP_MED_MAX;
 		else
 			return 0;
@@ -747,11 +747,11 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 	}
 
 	/* 4. AS path length check. */
-	if (!bgp_flag_check(bgp, BGP_FLAG_ASPATH_IGNORE)) {
+	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_ASPATH_IGNORE)) {
 		int exist_hops = aspath_count_hops(existattr->aspath);
 		int exist_confeds = aspath_count_confeds(existattr->aspath);
 
-		if (bgp_flag_check(bgp, BGP_FLAG_ASPATH_CONFED)) {
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_ASPATH_CONFED)) {
 			int aspath_hops;
 
 			aspath_hops = aspath_count_hops(newattr->aspath);
@@ -832,8 +832,8 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 			   && aspath_count_hops(newattr->aspath) == 0
 			   && aspath_count_hops(existattr->aspath) == 0);
 
-	if (bgp_flag_check(bgp, BGP_FLAG_ALWAYS_COMPARE_MED)
-	    || (bgp_flag_check(bgp, BGP_FLAG_MED_CONFED) && confed_as_route)
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_ALWAYS_COMPARE_MED)
+	    || (CHECK_FLAG(bgp->flags, BGP_FLAG_MED_CONFED) && confed_as_route)
 	    || aspath_cmp_left(newattr->aspath, existattr->aspath)
 	    || aspath_cmp_left_confed(newattr->aspath, existattr->aspath)
 	    || internal_as_route) {
@@ -978,8 +978,8 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 				zlog_debug(
 					"%s: %s and %s cannot be multipath, one has a label while the other does not",
 					pfx_buf, new_buf, exist_buf);
-		} else if (bgp_flag_check(bgp,
-					  BGP_FLAG_ASPATH_MULTIPATH_RELAX)) {
+		} else if (CHECK_FLAG(bgp->flags,
+				      BGP_FLAG_ASPATH_MULTIPATH_RELAX)) {
 
 			/*
 			 * For the two paths, all comparison steps till IGP
@@ -1041,7 +1041,7 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 	   first (the oldest one).  This step minimizes route-flap, since a
 	   newer path won't displace an older one, even if it was the
 	   preferred route based on the additional decision criteria below.  */
-	if (!bgp_flag_check(bgp, BGP_FLAG_COMPARE_ROUTER_ID)
+	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_COMPARE_ROUTER_ID)
 	    && new_sort == BGP_PEER_EBGP && exist_sort == BGP_PEER_EBGP) {
 		if (CHECK_FLAG(new->flags, BGP_PATH_SELECTED)) {
 			*reason = bgp_path_selection_older;
@@ -1762,7 +1762,8 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 			   check
 			   is already done.  So there is noting to do. */
 			/* no bgp client-to-client reflection check. */
-			if (bgp_flag_check(bgp, BGP_FLAG_NO_CLIENT_TO_CLIENT))
+			if (CHECK_FLAG(bgp->flags,
+				       BGP_FLAG_NO_CLIENT_TO_CLIENT))
 				if (CHECK_FLAG(peer->af_flags[afi][safi],
 					       PEER_FLAG_REFLECTOR_CLIENT))
 					return 0;
@@ -1894,8 +1895,8 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 		 * of the reflected IBGP routes unless explicitly allowed.
 		 */
 		if ((from->sort == BGP_PEER_IBGP && peer->sort == BGP_PEER_IBGP)
-		    && !bgp_flag_check(bgp,
-				       BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY)) {
+		    && !CHECK_FLAG(bgp->flags,
+				   BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY)) {
 			dummy_attr = *attr;
 			rmap_path.attr = &dummy_attr;
 		}
@@ -1945,7 +1946,7 @@ int subgroup_announce_check(struct bgp_node *rn, struct bgp_path_info *pi,
 		if (aspath_check_as_sets(attr->aspath))
 			return 0;
 
-	if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
 		if (peer->sort == BGP_PEER_IBGP
 		    || peer->sort == BGP_PEER_CONFED) {
 			attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF);
@@ -2105,7 +2106,7 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 
 	/* bgp deterministic-med */
 	new_select = NULL;
-	if (bgp_flag_check(bgp, BGP_FLAG_DETERMINISTIC_MED)) {
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DETERMINISTIC_MED)) {
 
 		/* Clear BGP_PATH_DMED_SELECTED for all paths */
 		for (pi1 = bgp_node_get_bgp_path_info(rn); pi1;
@@ -2212,7 +2213,7 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 				continue;
 			}
 
-		if (bgp_flag_check(bgp, BGP_FLAG_DETERMINISTIC_MED)
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_DETERMINISTIC_MED)
 		    && (!CHECK_FLAG(pi->flags, BGP_PATH_DMED_SELECTED))) {
 			bgp_path_info_unset_flag(rn, pi, BGP_PATH_DMED_CHECK);
 			if (debug)
@@ -2445,14 +2446,14 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 	char pfx_buf[PREFIX2STR_BUFFER];
 	int debug = 0;
 
-	if (bgp_flag_check(bgp, BGP_FLAG_DELETE_IN_PROGRESS)) {
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS)) {
 		if (rn)
 			debug = bgp_debug_bestpath(&rn->p);
 		if (debug) {
 			prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
 			zlog_debug(
-			     "%s: bgp delete in progress, ignoring event, p=%s",
-			     __func__, pfx_buf);
+				"%s: bgp delete in progress, ignoring event, p=%s",
+				__func__, pfx_buf);
 		}
 		return;
 	}
@@ -3418,10 +3419,9 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 
 			/* If graceful-shutdown is configured then add the GSHUT
 			 * community to all paths received from eBGP peers */
-		} else if (bgp_flag_check(peer->bgp,
-					  BGP_FLAG_GRACEFUL_SHUTDOWN)) {
+		} else if (CHECK_FLAG(peer->bgp->flags,
+				      BGP_FLAG_GRACEFUL_SHUTDOWN))
 			bgp_attr_add_gshut_community(&new_attr);
-		}
 	}
 
 	if (pi) {
@@ -3707,8 +3707,8 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 			    && peer->ttl == BGP_DEFAULT_TTL
 			    && !CHECK_FLAG(peer->flags,
 					   PEER_FLAG_DISABLE_CONNECTED_CHECK)
-			    && !bgp_flag_check(
-				       bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
+			    && !CHECK_FLAG(bgp->flags,
+					   BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
 				connected = 1;
 			else
 				connected = 0;
@@ -3862,7 +3862,8 @@ int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
 		    && peer->ttl == BGP_DEFAULT_TTL
 		    && !CHECK_FLAG(peer->flags,
 				   PEER_FLAG_DISABLE_CONNECTED_CHECK)
-		    && !bgp_flag_check(bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
+		    && !CHECK_FLAG(bgp->flags,
+				   BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
 			connected = 1;
 		else
 			connected = 0;
@@ -4953,13 +4954,13 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 			return;
 		}
 
-		if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN))
 			bgp_attr_add_gshut_community(&attr_tmp);
 
 		attr_new = bgp_attr_intern(&attr_tmp);
 	} else {
 
-		if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN))
 			bgp_attr_add_gshut_community(&attr);
 
 		attr_new = bgp_attr_intern(&attr);
@@ -4973,7 +4974,7 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 	if (pi) {
 		if (attrhash_cmp(pi->attr, attr_new)
 		    && !CHECK_FLAG(pi->flags, BGP_PATH_REMOVED)
-		    && !bgp_flag_check(bgp, BGP_FLAG_FORCE_STATIC_PROCESS)) {
+		    && !CHECK_FLAG(bgp->flags, BGP_FLAG_FORCE_STATIC_PROCESS)) {
 			bgp_unlock_node(rn);
 			bgp_attr_unintern(&attr_new);
 			aspath_unintern(&attr.aspath);
@@ -5018,7 +5019,7 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 #endif
 
 			/* Nexthop reachability check. */
-			if (bgp_flag_check(bgp, BGP_FLAG_IMPORT_CHECK)
+			if (CHECK_FLAG(bgp->flags, BGP_FLAG_IMPORT_CHECK)
 			    && (safi == SAFI_UNICAST
 				|| safi == SAFI_LABELED_UNICAST)) {
 
@@ -5077,7 +5078,7 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 	new = info_make(ZEBRA_ROUTE_BGP, BGP_ROUTE_STATIC, 0, bgp->peer_self,
 			attr_new, rn);
 	/* Nexthop reachability check. */
-	if (bgp_flag_check(bgp, BGP_FLAG_IMPORT_CHECK)
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_IMPORT_CHECK)
 	    && (safi == SAFI_UNICAST || safi == SAFI_LABELED_UNICAST)) {
 		if (bgp_find_or_add_nexthop(bgp, bgp, afi, new, NULL, 0))
 			bgp_path_info_set_flag(rn, new, BGP_PATH_VALID);
@@ -5596,7 +5597,7 @@ void bgp_static_redo_import_check(struct bgp *bgp)
 	struct bgp_static *bgp_static;
 
 	/* Use this flag to force reprocessing of the route */
-	bgp_flag_set(bgp, BGP_FLAG_FORCE_STATIC_PROCESS);
+	SET_FLAG(bgp->flags, BGP_FLAG_FORCE_STATIC_PROCESS);
 	FOREACH_AFI_SAFI (afi, safi) {
 		for (rn = bgp_table_top(bgp->route[afi][safi]); rn;
 		     rn = bgp_route_next(rn)) {
@@ -5623,7 +5624,7 @@ void bgp_static_redo_import_check(struct bgp *bgp)
 			}
 		}
 	}
-	bgp_flag_unset(bgp, BGP_FLAG_FORCE_STATIC_PROCESS);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_FORCE_STATIC_PROCESS);
 }
 
 static void bgp_purge_af_static_redist_routes(struct bgp *bgp, afi_t afi,
@@ -5636,8 +5637,8 @@ static void bgp_purge_af_static_redist_routes(struct bgp *bgp, afi_t afi,
 	/* Do not install the aggregate route if BGP is in the
 	 * process of termination.
 	 */
-	if (bgp_flag_check(bgp, BGP_FLAG_DELETE_IN_PROGRESS) ||
-	    (bgp->peer_self == NULL))
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS)
+	    || (bgp->peer_self == NULL))
 		return;
 
 	table = bgp->rib[afi][safi];
@@ -6146,8 +6147,8 @@ void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 	/* If the bgp instance is being deleted or self peer is deleted
 	 * then do not create aggregate route
 	 */
-	if (bgp_flag_check(bgp, BGP_FLAG_DELETE_IN_PROGRESS) ||
-	   (bgp->peer_self == NULL))
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS)
+	    || (bgp->peer_self == NULL))
 		return;
 
 	/* ORIGIN attribute: If at least one route among routes that are
@@ -7101,7 +7102,7 @@ void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 			}
 		}
 
-		if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN))
 			bgp_attr_add_gshut_community(&attr_new);
 
 		bn = bgp_afi_node_get(bgp->rib[afi][SAFI_UNICAST], afi,
@@ -7392,7 +7393,8 @@ static void route_vty_short_status_out(struct vty *vty,
 
 static char *bgp_nexthop_hostname(struct peer *peer, struct attr *attr)
 {
-	if (peer->hostname && bgp_flag_check(peer->bgp, BGP_FLAG_SHOW_HOSTNAME)
+	if (peer->hostname
+	    && CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SHOW_HOSTNAME)
 	    && !(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_ORIGINATOR_ID)))
 		return peer->hostname;
 	return NULL;
@@ -8406,7 +8408,7 @@ static void route_vty_out_advertised_to(struct vty *vty, struct peer *peer,
 		}
 
 		if (peer->hostname
-		    && bgp_flag_check(peer->bgp, BGP_FLAG_SHOW_HOSTNAME)) {
+		    && CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SHOW_HOSTNAME)) {
 			if (peer->conf_if)
 				vty_out(vty, " %s(%s)", peer->hostname,
 					peer->conf_if);
@@ -8828,8 +8830,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 		} else {
 			if (path->peer->conf_if) {
 				if (path->peer->hostname
-				    && bgp_flag_check(path->peer->bgp,
-						      BGP_FLAG_SHOW_HOSTNAME))
+				    && CHECK_FLAG(path->peer->bgp->flags,
+						  BGP_FLAG_SHOW_HOSTNAME))
 					vty_out(vty, " from %s(%s)",
 						path->peer->hostname,
 						path->peer->conf_if);
@@ -8838,8 +8840,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 						path->peer->conf_if);
 			} else {
 				if (path->peer->hostname
-				    && bgp_flag_check(path->peer->bgp,
-						      BGP_FLAG_SHOW_HOSTNAME))
+				    && CHECK_FLAG(path->peer->bgp->flags,
+						  BGP_FLAG_SHOW_HOSTNAME))
 					vty_out(vty, " from %s(%s)",
 						path->peer->hostname,
 						path->peer->host);
@@ -11333,7 +11335,7 @@ static int bgp_peer_counts(struct vty *vty, struct peer *peer, afi_t afi,
 	} else {
 
 		if (peer->hostname
-		    && bgp_flag_check(peer->bgp, BGP_FLAG_SHOW_HOSTNAME)) {
+		    && CHECK_FLAG(peer->bgp->flags, BGP_FLAG_SHOW_HOSTNAME)) {
 			vty_out(vty, "Prefix counts for %s/%s, %s\n",
 				peer->hostname, peer->host,
 				get_afi_safi_str(afi, safi, false));

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -783,9 +783,8 @@ void subgroup_default_originate(struct update_subgroup *subgrp, int withdraw)
 		if (!CHECK_FLAG(subgrp->sflags,
 				SUBGRP_STATUS_DEFAULT_ORIGINATE)) {
 
-			if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
+			if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN))
 				bgp_attr_add_gshut_community(new_attr);
-			}
 
 			SET_FLAG(subgrp->sflags,
 				 SUBGRP_STATUS_DEFAULT_ORIGINATE);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -422,13 +422,13 @@ int bgp_get_vty(struct bgp **bgp, as_t *as, const char *name,
 			       DFLT_BGP_CONNECT_RETRY);
 
 		if (DFLT_BGP_IMPORT_CHECK)
-			bgp_flag_set(*bgp, BGP_FLAG_IMPORT_CHECK);
+			SET_FLAG((*bgp)->flags, BGP_FLAG_IMPORT_CHECK);
 		if (DFLT_BGP_SHOW_HOSTNAME)
-			bgp_flag_set(*bgp, BGP_FLAG_SHOW_HOSTNAME);
+			SET_FLAG((*bgp)->flags, BGP_FLAG_SHOW_HOSTNAME);
 		if (DFLT_BGP_LOG_NEIGHBOR_CHANGES)
-			bgp_flag_set(*bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES);
+			SET_FLAG((*bgp)->flags, BGP_FLAG_LOG_NEIGHBOR_CHANGES);
 		if (DFLT_BGP_DETERMINISTIC_MED)
-			bgp_flag_set(*bgp, BGP_FLAG_DETERMINISTIC_MED);
+			SET_FLAG((*bgp)->flags, BGP_FLAG_DETERMINISTIC_MED);
 
 		ret = BGP_SUCCESS;
 	}
@@ -1992,7 +1992,7 @@ DEFUN (bgp_client_to_client_reflection,
        "reflection of routes allowed\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_NO_CLIENT_TO_CLIENT);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_NO_CLIENT_TO_CLIENT);
 	bgp_clear_star_soft_out(vty, bgp->name);
 
 	return CMD_SUCCESS;
@@ -2007,7 +2007,7 @@ DEFUN (no_bgp_client_to_client_reflection,
        "reflection of routes allowed\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_NO_CLIENT_TO_CLIENT);
+	SET_FLAG(bgp->flags, BGP_FLAG_NO_CLIENT_TO_CLIENT);
 	bgp_clear_star_soft_out(vty, bgp->name);
 
 	return CMD_SUCCESS;
@@ -2021,7 +2021,7 @@ DEFUN (bgp_always_compare_med,
        "Allow comparing MED from different neighbors\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_ALWAYS_COMPARE_MED);
+	SET_FLAG(bgp->flags, BGP_FLAG_ALWAYS_COMPARE_MED);
 	bgp_recalculate_all_bestpaths(bgp);
 
 	return CMD_SUCCESS;
@@ -2035,7 +2035,7 @@ DEFUN (no_bgp_always_compare_med,
        "Allow comparing MED from different neighbors\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_ALWAYS_COMPARE_MED);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_ALWAYS_COMPARE_MED);
 	bgp_recalculate_all_bestpaths(bgp);
 
 	return CMD_SUCCESS;
@@ -2123,8 +2123,8 @@ DEFUN (bgp_deterministic_med,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	if (!bgp_flag_check(bgp, BGP_FLAG_DETERMINISTIC_MED)) {
-		bgp_flag_set(bgp, BGP_FLAG_DETERMINISTIC_MED);
+	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_DETERMINISTIC_MED)) {
+		SET_FLAG(bgp->flags, BGP_FLAG_DETERMINISTIC_MED);
 		bgp_recalculate_all_bestpaths(bgp);
 	}
 
@@ -2145,7 +2145,7 @@ DEFUN (no_bgp_deterministic_med,
 	struct peer *peer;
 	struct listnode *node, *nnode;
 
-	if (bgp_flag_check(bgp, BGP_FLAG_DETERMINISTIC_MED)) {
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DETERMINISTIC_MED)) {
 		bestpath_per_as_used = 0;
 
 		for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
@@ -2165,7 +2165,7 @@ DEFUN (no_bgp_deterministic_med,
 				"bgp deterministic-med cannot be disabled while addpath-tx-bestpath-per-AS is in use\n");
 			return CMD_WARNING_CONFIG_FAILED;
 		} else {
-			bgp_flag_unset(bgp, BGP_FLAG_DETERMINISTIC_MED);
+			UNSET_FLAG(bgp->flags, BGP_FLAG_DETERMINISTIC_MED);
 			bgp_recalculate_all_bestpaths(bgp);
 		}
 	}
@@ -2277,9 +2277,9 @@ DEFUN (bgp_graceful_restart_select_defer_time,
 	defer_time = strtoul(argv[idx_number]->arg, NULL, 10);
 	bgp->select_defer_time = defer_time;
 	if (defer_time == 0)
-		bgp_flag_set(bgp, BGP_FLAG_SELECT_DEFER_DISABLE);
+		SET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
 	else
-		bgp_flag_unset(bgp, BGP_FLAG_SELECT_DEFER_DISABLE);
+		UNSET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
 
 	return CMD_SUCCESS;
 }
@@ -2326,7 +2326,7 @@ DEFUN (no_bgp_graceful_restart_select_defer_time,
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
 	bgp->select_defer_time = BGP_DEFAULT_SELECT_DEFERRAL_TIME;
-	bgp_flag_unset(bgp, BGP_FLAG_SELECT_DEFER_DISABLE);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE);
 
 	return CMD_SUCCESS;
 }
@@ -2339,7 +2339,7 @@ DEFUN (bgp_graceful_restart_preserve_fw,
 	"Sets F-bit indication that fib is preserved while doing Graceful Restart\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_GR_PRESERVE_FWD);
+	SET_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD);
 	return CMD_SUCCESS;
 }
 
@@ -2352,7 +2352,7 @@ DEFUN (no_bgp_graceful_restart_preserve_fw,
 	"Unsets F-bit indication that fib is preserved while doing Graceful Restart\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_GR_PRESERVE_FWD);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD);
 	return CMD_SUCCESS;
 }
 
@@ -2646,7 +2646,7 @@ DEFUN_HIDDEN (bgp_graceful_restart_disable_eor,
               "Disable EOR Check\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_GR_DISABLE_EOR);
+	SET_FLAG(bgp->flags, BGP_FLAG_GR_DISABLE_EOR);
 
 	return CMD_SUCCESS;
 }
@@ -2660,7 +2660,7 @@ DEFUN_HIDDEN (no_bgp_graceful_restart_disable_eor,
               "Disable EOR Check\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_GR_DISABLE_EOR);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_GR_DISABLE_EOR);
 
 	return CMD_SUCCESS;
 }
@@ -2714,8 +2714,8 @@ DEFUN (bgp_graceful_shutdown,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	if (!bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
-		bgp_flag_set(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN);
+	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
+		SET_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN);
 		bgp_static_redo_import_check(bgp);
 		bgp_redistribute_redo(bgp);
 		bgp_clear_star_soft_out(vty, bgp->name);
@@ -2734,8 +2734,8 @@ DEFUN (no_bgp_graceful_shutdown,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
-		bgp_flag_unset(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN);
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN)) {
+		UNSET_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN);
 		bgp_static_redo_import_check(bgp);
 		bgp_redistribute_redo(bgp);
 		bgp_clear_star_soft_out(vty, bgp->name);
@@ -2753,7 +2753,7 @@ DEFUN (bgp_fast_external_failover,
        "Immediately reset session if a link to a directly connected external peer goes down\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_NO_FAST_EXT_FAILOVER);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER);
 	return CMD_SUCCESS;
 }
 
@@ -2765,7 +2765,7 @@ DEFUN (no_bgp_fast_external_failover,
        "Immediately reset session if a link to a directly connected external peer goes down\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_NO_FAST_EXT_FAILOVER);
+	SET_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER);
 	return CMD_SUCCESS;
 }
 
@@ -2778,7 +2778,7 @@ DEFUN (bgp_bestpath_compare_router_id,
        "Compare router-id for identical EBGP paths\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_COMPARE_ROUTER_ID);
+	SET_FLAG(bgp->flags, BGP_FLAG_COMPARE_ROUTER_ID);
 	bgp_recalculate_all_bestpaths(bgp);
 
 	return CMD_SUCCESS;
@@ -2793,7 +2793,7 @@ DEFUN (no_bgp_bestpath_compare_router_id,
        "Compare router-id for identical EBGP paths\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_COMPARE_ROUTER_ID);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_COMPARE_ROUTER_ID);
 	bgp_recalculate_all_bestpaths(bgp);
 
 	return CMD_SUCCESS;
@@ -2809,7 +2809,7 @@ DEFUN (bgp_bestpath_aspath_ignore,
        "Ignore as-path length in selecting a route\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_ASPATH_IGNORE);
+	SET_FLAG(bgp->flags, BGP_FLAG_ASPATH_IGNORE);
 	bgp_recalculate_all_bestpaths(bgp);
 
 	return CMD_SUCCESS;
@@ -2825,7 +2825,7 @@ DEFUN (no_bgp_bestpath_aspath_ignore,
        "Ignore as-path length in selecting a route\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_ASPATH_IGNORE);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_ASPATH_IGNORE);
 	bgp_recalculate_all_bestpaths(bgp);
 
 	return CMD_SUCCESS;
@@ -2841,7 +2841,7 @@ DEFUN (bgp_bestpath_aspath_confed,
        "Compare path lengths including confederation sets & sequences in selecting a route\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_ASPATH_CONFED);
+	SET_FLAG(bgp->flags, BGP_FLAG_ASPATH_CONFED);
 	bgp_recalculate_all_bestpaths(bgp);
 
 	return CMD_SUCCESS;
@@ -2857,7 +2857,7 @@ DEFUN (no_bgp_bestpath_aspath_confed,
        "Compare path lengths including confederation sets & sequences in selecting a route\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_ASPATH_CONFED);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_ASPATH_CONFED);
 	bgp_recalculate_all_bestpaths(bgp);
 
 	return CMD_SUCCESS;
@@ -2876,14 +2876,14 @@ DEFUN (bgp_bestpath_aspath_multipath_relax,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int idx = 0;
-	bgp_flag_set(bgp, BGP_FLAG_ASPATH_MULTIPATH_RELAX);
+	SET_FLAG(bgp->flags, BGP_FLAG_ASPATH_MULTIPATH_RELAX);
 
 	/* no-as-set is now the default behavior so we can silently
 	 * ignore it */
 	if (argv_find(argv, argc, "as-set", &idx))
-		bgp_flag_set(bgp, BGP_FLAG_MULTIPATH_RELAX_AS_SET);
+		SET_FLAG(bgp->flags, BGP_FLAG_MULTIPATH_RELAX_AS_SET);
 	else
-		bgp_flag_unset(bgp, BGP_FLAG_MULTIPATH_RELAX_AS_SET);
+		UNSET_FLAG(bgp->flags, BGP_FLAG_MULTIPATH_RELAX_AS_SET);
 
 	bgp_recalculate_all_bestpaths(bgp);
 
@@ -2902,8 +2902,8 @@ DEFUN (no_bgp_bestpath_aspath_multipath_relax,
        "Do not generate an AS_SET\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_ASPATH_MULTIPATH_RELAX);
-	bgp_flag_unset(bgp, BGP_FLAG_MULTIPATH_RELAX_AS_SET);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_ASPATH_MULTIPATH_RELAX);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_MULTIPATH_RELAX_AS_SET);
 	bgp_recalculate_all_bestpaths(bgp);
 
 	return CMD_SUCCESS;
@@ -2917,7 +2917,7 @@ DEFUN (bgp_log_neighbor_changes,
        "Log neighbor up/down and reset reason\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES);
+	SET_FLAG(bgp->flags, BGP_FLAG_LOG_NEIGHBOR_CHANGES);
 	return CMD_SUCCESS;
 }
 
@@ -2929,7 +2929,7 @@ DEFUN (no_bgp_log_neighbor_changes,
        "Log neighbor up/down and reset reason\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_LOG_NEIGHBOR_CHANGES);
 	return CMD_SUCCESS;
 }
 
@@ -2949,10 +2949,10 @@ DEFUN (bgp_bestpath_med,
 
 	int idx = 0;
 	if (argv_find(argv, argc, "confed", &idx))
-		bgp_flag_set(bgp, BGP_FLAG_MED_CONFED);
+		SET_FLAG(bgp->flags, BGP_FLAG_MED_CONFED);
 	idx = 0;
 	if (argv_find(argv, argc, "missing-as-worst", &idx))
-		bgp_flag_set(bgp, BGP_FLAG_MED_MISSING_AS_WORST);
+		SET_FLAG(bgp->flags, BGP_FLAG_MED_MISSING_AS_WORST);
 
 	bgp_recalculate_all_bestpaths(bgp);
 
@@ -2975,10 +2975,10 @@ DEFUN (no_bgp_bestpath_med,
 
 	int idx = 0;
 	if (argv_find(argv, argc, "confed", &idx))
-		bgp_flag_unset(bgp, BGP_FLAG_MED_CONFED);
+		UNSET_FLAG(bgp->flags, BGP_FLAG_MED_CONFED);
 	idx = 0;
 	if (argv_find(argv, argc, "missing-as-worst", &idx))
-		bgp_flag_unset(bgp, BGP_FLAG_MED_MISSING_AS_WORST);
+		UNSET_FLAG(bgp->flags, BGP_FLAG_MED_MISSING_AS_WORST);
 
 	bgp_recalculate_all_bestpaths(bgp);
 
@@ -2995,7 +2995,7 @@ DEFUN (no_bgp_default_ipv4_unicast,
        "Activate ipv4-unicast for a peer by default\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_NO_DEFAULT_IPV4);
+	SET_FLAG(bgp->flags, BGP_FLAG_NO_DEFAULT_IPV4);
 	return CMD_SUCCESS;
 }
 
@@ -3007,7 +3007,7 @@ DEFUN (bgp_default_ipv4_unicast,
        "Activate ipv4-unicast for a peer by default\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_NO_DEFAULT_IPV4);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_NO_DEFAULT_IPV4);
 	return CMD_SUCCESS;
 }
 
@@ -3020,7 +3020,7 @@ DEFUN (bgp_default_show_hostname,
        "Show hostname in certain command outputs\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_SHOW_HOSTNAME);
+	SET_FLAG(bgp->flags, BGP_FLAG_SHOW_HOSTNAME);
 	return CMD_SUCCESS;
 }
 
@@ -3033,7 +3033,7 @@ DEFUN (no_bgp_default_show_hostname,
        "Show hostname in certain command outputs\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_SHOW_HOSTNAME);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_SHOW_HOSTNAME);
 	return CMD_SUCCESS;
 }
 
@@ -3046,8 +3046,8 @@ DEFUN (bgp_network_import_check,
        "Check BGP network route exists in IGP\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	if (!bgp_flag_check(bgp, BGP_FLAG_IMPORT_CHECK)) {
-		bgp_flag_set(bgp, BGP_FLAG_IMPORT_CHECK);
+	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_IMPORT_CHECK)) {
+		SET_FLAG(bgp->flags, BGP_FLAG_IMPORT_CHECK);
 		bgp_static_redo_import_check(bgp);
 	}
 
@@ -3070,8 +3070,8 @@ DEFUN (no_bgp_network_import_check,
        "Check BGP network route exists in IGP\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	if (bgp_flag_check(bgp, BGP_FLAG_IMPORT_CHECK)) {
-		bgp_flag_unset(bgp, BGP_FLAG_IMPORT_CHECK);
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_IMPORT_CHECK)) {
+		UNSET_FLAG(bgp->flags, BGP_FLAG_IMPORT_CHECK);
 		bgp_static_redo_import_check(bgp);
 	}
 
@@ -3158,8 +3158,8 @@ DEFUN (bgp_rr_allow_outbound_policy,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	if (!bgp_flag_check(bgp, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY)) {
-		bgp_flag_set(bgp, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY);
+	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY)) {
+		SET_FLAG(bgp->flags, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY);
 		update_group_announce_rrclients(bgp);
 		bgp_clear_star_soft_out(vty, bgp->name);
 	}
@@ -3177,8 +3177,8 @@ DEFUN (no_bgp_rr_allow_outbound_policy,
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
 
-	if (bgp_flag_check(bgp, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY)) {
-		bgp_flag_unset(bgp, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY);
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY)) {
+		UNSET_FLAG(bgp->flags, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY);
 		update_group_announce_rrclients(bgp);
 		bgp_clear_star_soft_out(vty, bgp->name);
 	}
@@ -3405,7 +3405,7 @@ DEFUN (bgp_disable_connected_route_check,
        "Disable checking if nexthop is connected on ebgp sessions\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_set(bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK);
+	SET_FLAG(bgp->flags, BGP_FLAG_DISABLE_NH_CONNECTED_CHK);
 	bgp_clear_star_soft_in(vty, bgp->name);
 
 	return CMD_SUCCESS;
@@ -3419,7 +3419,7 @@ DEFUN (no_bgp_disable_connected_route_check,
        "Disable checking if nexthop is connected on ebgp sessions\n")
 {
 	VTY_DECLVAR_CONTEXT(bgp, bgp);
-	bgp_flag_unset(bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK);
+	UNSET_FLAG(bgp->flags, BGP_FLAG_DISABLE_NH_CONNECTED_CHK);
 	bgp_clear_star_soft_in(vty, bgp->name);
 
 	return CMD_SUCCESS;
@@ -3558,7 +3558,7 @@ static int peer_conf_interface_get(struct vty *vty, const char *conf_if,
 			ret = peer_remote_as(bgp, NULL, conf_if, &as, as_type,
 					     afi, safi);
 	} else {
-		if (bgp_flag_check(bgp, BGP_FLAG_NO_DEFAULT_IPV4)
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_NO_DEFAULT_IPV4)
 		    && afi == AFI_IP && safi == SAFI_UNICAST)
 			peer = peer_create(NULL, conf_if, bgp, bgp->as, as,
 					   as_type, 0, 0, NULL);
@@ -8513,14 +8513,14 @@ static void bgp_show_bestpath_json(struct bgp *bgp, json_object *json)
 {
 	json_object *bestpath = json_object_new_object();
 
-	if (bgp_flag_check(bgp, BGP_FLAG_ASPATH_IGNORE))
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_ASPATH_IGNORE))
 		json_object_string_add(bestpath, "asPath", "ignore");
 
-	if (bgp_flag_check(bgp, BGP_FLAG_ASPATH_CONFED))
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_ASPATH_CONFED))
 		json_object_string_add(bestpath, "asPath", "confed");
 
-	if (bgp_flag_check(bgp, BGP_FLAG_ASPATH_MULTIPATH_RELAX)) {
-		if (bgp_flag_check(bgp, BGP_FLAG_MULTIPATH_RELAX_AS_SET))
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_ASPATH_MULTIPATH_RELAX)) {
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_MULTIPATH_RELAX_AS_SET))
 			json_object_string_add(bestpath, "multiPathRelax",
 					       "as-set");
 		else
@@ -8529,13 +8529,13 @@ static void bgp_show_bestpath_json(struct bgp *bgp, json_object *json)
 	} else
 		json_object_string_add(bestpath, "multiPathRelax", "false");
 
-	if (bgp_flag_check(bgp, BGP_FLAG_COMPARE_ROUTER_ID))
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_COMPARE_ROUTER_ID))
 		json_object_string_add(bestpath, "compareRouterId", "true");
-	if (bgp_flag_check(bgp, BGP_FLAG_MED_CONFED)
-	    || bgp_flag_check(bgp, BGP_FLAG_MED_MISSING_AS_WORST)) {
-		if (bgp_flag_check(bgp, BGP_FLAG_MED_CONFED))
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_MED_CONFED)
+	    || CHECK_FLAG(bgp->flags, BGP_FLAG_MED_MISSING_AS_WORST)) {
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_MED_CONFED))
 			json_object_string_add(bestpath, "med", "confed");
-		if (bgp_flag_check(bgp, BGP_FLAG_MED_MISSING_AS_WORST))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_MED_MISSING_AS_WORST))
 			json_object_string_add(bestpath, "med",
 					       "missing-as-worst");
 		else
@@ -8658,7 +8658,7 @@ static void bgp_show_failed_summary(struct vty *vty, struct bgp *bgp,
 		dn_flag[1] = '\0';
 		dn_flag[0] = peer_dynamic_neighbor(peer) ? '*' : '\0';
 		if (peer->hostname
-		    && bgp_flag_check(bgp, BGP_FLAG_SHOW_HOSTNAME))
+		    && CHECK_FLAG(bgp->flags, BGP_FLAG_SHOW_HOSTNAME))
 			len = vty_out(vty, "%s%s(%s)", dn_flag,
 				      peer->hostname, peer->host);
 		else
@@ -8741,8 +8741,8 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					dn_flag[0] = '*';
 
 				if (peer->hostname
-				    && bgp_flag_check(bgp,
-						      BGP_FLAG_SHOW_HOSTNAME))
+				    && CHECK_FLAG(bgp->flags,
+						  BGP_FLAG_SHOW_HOSTNAME))
 					sprintf(neighbor_buf, "%s%s(%s) ",
 						dn_flag, peer->hostname,
 						peer->host);
@@ -9103,9 +9103,11 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 				}
 
 				if (peer->hostname
-				    && bgp_flag_check(bgp, BGP_FLAG_SHOW_HOSTNAME))
+				    && CHECK_FLAG(bgp->flags,
+						  BGP_FLAG_SHOW_HOSTNAME))
 					len = vty_out(vty, "%s%s(%s)", dn_flag,
-						      peer->hostname, peer->host);
+						      peer->hostname,
+						      peer->host);
 				else
 					len = vty_out(vty, "%s%s", dn_flag, peer->host);
 
@@ -14603,8 +14605,8 @@ static void bgp_config_write_peer_af(struct vty *vty, struct bgp *bgp,
 	} else {
 		if (peer->afc[afi][safi]) {
 			if ((afi == AFI_IP) && (safi == SAFI_UNICAST)) {
-				if (bgp_flag_check(bgp,
-						   BGP_FLAG_NO_DEFAULT_IPV4)) {
+				if (CHECK_FLAG(bgp->flags,
+					       BGP_FLAG_NO_DEFAULT_IPV4)) {
 					vty_out(vty, "  neighbor %s activate\n",
 						addr);
 				}
@@ -14612,8 +14614,8 @@ static void bgp_config_write_peer_af(struct vty *vty, struct bgp *bgp,
 				vty_out(vty, "  neighbor %s activate\n", addr);
 		} else {
 			if ((afi == AFI_IP) && (safi == SAFI_UNICAST)) {
-				if (!bgp_flag_check(bgp,
-						    BGP_FLAG_NO_DEFAULT_IPV4)) {
+				if (!CHECK_FLAG(bgp->flags,
+						BGP_FLAG_NO_DEFAULT_IPV4)) {
 					vty_out(vty,
 						"  no neighbor %s activate\n",
 						addr);
@@ -14974,16 +14976,16 @@ int bgp_config_write(struct vty *vty)
 				inet_ntoa(bgp->router_id_static));
 
 		/* BGP log-neighbor-changes. */
-		if (!!bgp_flag_check(bgp, BGP_FLAG_LOG_NEIGHBOR_CHANGES)
+		if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_LOG_NEIGHBOR_CHANGES)
 		    != SAVE_BGP_LOG_NEIGHBOR_CHANGES)
 			vty_out(vty, " %sbgp log-neighbor-changes\n",
-				bgp_flag_check(bgp,
-					       BGP_FLAG_LOG_NEIGHBOR_CHANGES)
+				CHECK_FLAG(bgp->flags,
+					   BGP_FLAG_LOG_NEIGHBOR_CHANGES)
 					? ""
 					: "no ");
 
 		/* BGP configuration. */
-		if (bgp_flag_check(bgp, BGP_FLAG_ALWAYS_COMPARE_MED))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_ALWAYS_COMPARE_MED))
 			vty_out(vty, " bgp always-compare-med\n");
 
 		/* RFC8212 default eBGP policy. */
@@ -14996,7 +14998,7 @@ int bgp_config_write(struct vty *vty)
 			vty_out(vty, " bgp reject-as-sets\n");
 
 		/* BGP default ipv4-unicast. */
-		if (bgp_flag_check(bgp, BGP_FLAG_NO_DEFAULT_IPV4))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_NO_DEFAULT_IPV4))
 			vty_out(vty, " no bgp default ipv4-unicast\n");
 
 		/* BGP default local-preference. */
@@ -15005,10 +15007,10 @@ int bgp_config_write(struct vty *vty)
 				bgp->default_local_pref);
 
 		/* BGP default show-hostname */
-		if (!!bgp_flag_check(bgp, BGP_FLAG_SHOW_HOSTNAME)
+		if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_SHOW_HOSTNAME)
 		    != SAVE_BGP_SHOW_HOSTNAME)
 			vty_out(vty, " %sbgp default show-hostname\n",
-				bgp_flag_check(bgp, BGP_FLAG_SHOW_HOSTNAME)
+				CHECK_FLAG(bgp->flags, BGP_FLAG_SHOW_HOSTNAME)
 					? ""
 					: "no ");
 
@@ -15019,7 +15021,7 @@ int bgp_config_write(struct vty *vty)
 				bgp->default_subgroup_pkt_queue_max);
 
 		/* BGP client-to-client reflection. */
-		if (bgp_flag_check(bgp, BGP_FLAG_NO_CLIENT_TO_CLIENT))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_NO_CLIENT_TO_CLIENT))
 			vty_out(vty, " no bgp client-to-client reflection\n");
 
 		/* BGP cluster ID. */
@@ -15028,7 +15030,7 @@ int bgp_config_write(struct vty *vty)
 				inet_ntoa(bgp->cluster_id));
 
 		/* Disable ebgp connected nexthop check */
-		if (bgp_flag_check(bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
 			vty_out(vty,
 				" bgp disable-ebgp-connected-route-check\n");
 
@@ -15050,10 +15052,11 @@ int bgp_config_write(struct vty *vty)
 		}
 
 		/* BGP deterministic-med. */
-		if (!!bgp_flag_check(bgp, BGP_FLAG_DETERMINISTIC_MED)
+		if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_DETERMINISTIC_MED)
 		    != SAVE_BGP_DETERMINISTIC_MED)
 			vty_out(vty, " %sbgp deterministic-med\n",
-				bgp_flag_check(bgp, BGP_FLAG_DETERMINISTIC_MED)
+				CHECK_FLAG(bgp->flags,
+					   BGP_FLAG_DETERMINISTIC_MED)
 					? ""
 					: "no ");
 
@@ -15107,11 +15110,11 @@ int bgp_config_write(struct vty *vty)
 			vty_out(vty, " bgp graceful-restart-disable\n");
 
 		/* BGP graceful-shutdown */
-		if (bgp_flag_check(bgp, BGP_FLAG_GRACEFUL_SHUTDOWN))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GRACEFUL_SHUTDOWN))
 			vty_out(vty, " bgp graceful-shutdown\n");
 
 		/* BGP graceful-restart Preserve State F bit. */
-		if (bgp_flag_check(bgp, BGP_FLAG_GR_PRESERVE_FWD))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_GR_PRESERVE_FWD))
 			vty_out(vty,
 				" bgp graceful-restart preserve-fw-state\n");
 
@@ -15122,14 +15125,14 @@ int bgp_config_write(struct vty *vty)
 				bgp->rib_stale_time);
 
 		/* BGP bestpath method. */
-		if (bgp_flag_check(bgp, BGP_FLAG_ASPATH_IGNORE))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_ASPATH_IGNORE))
 			vty_out(vty, " bgp bestpath as-path ignore\n");
-		if (bgp_flag_check(bgp, BGP_FLAG_ASPATH_CONFED))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_ASPATH_CONFED))
 			vty_out(vty, " bgp bestpath as-path confed\n");
 
-		if (bgp_flag_check(bgp, BGP_FLAG_ASPATH_MULTIPATH_RELAX)) {
-			if (bgp_flag_check(bgp,
-					   BGP_FLAG_MULTIPATH_RELAX_AS_SET)) {
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_ASPATH_MULTIPATH_RELAX)) {
+			if (CHECK_FLAG(bgp->flags,
+				       BGP_FLAG_MULTIPATH_RELAX_AS_SET)) {
 				vty_out(vty,
 					" bgp bestpath as-path multipath-relax as-set\n");
 			} else {
@@ -15138,27 +15141,28 @@ int bgp_config_write(struct vty *vty)
 			}
 		}
 
-		if (bgp_flag_check(bgp, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY)) {
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_RR_ALLOW_OUTBOUND_POLICY)) {
 			vty_out(vty,
 				" bgp route-reflector allow-outbound-policy\n");
 		}
-		if (bgp_flag_check(bgp, BGP_FLAG_COMPARE_ROUTER_ID))
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_COMPARE_ROUTER_ID))
 			vty_out(vty, " bgp bestpath compare-routerid\n");
-		if (bgp_flag_check(bgp, BGP_FLAG_MED_CONFED)
-		    || bgp_flag_check(bgp, BGP_FLAG_MED_MISSING_AS_WORST)) {
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_MED_CONFED)
+		    || CHECK_FLAG(bgp->flags, BGP_FLAG_MED_MISSING_AS_WORST)) {
 			vty_out(vty, " bgp bestpath med");
-			if (bgp_flag_check(bgp, BGP_FLAG_MED_CONFED))
+			if (CHECK_FLAG(bgp->flags, BGP_FLAG_MED_CONFED))
 				vty_out(vty, " confed");
-			if (bgp_flag_check(bgp, BGP_FLAG_MED_MISSING_AS_WORST))
+			if (CHECK_FLAG(bgp->flags,
+				       BGP_FLAG_MED_MISSING_AS_WORST))
 				vty_out(vty, " missing-as-worst");
 			vty_out(vty, "\n");
 		}
 
 		/* BGP network import check. */
-		if (!!bgp_flag_check(bgp, BGP_FLAG_IMPORT_CHECK)
+		if (!!CHECK_FLAG(bgp->flags, BGP_FLAG_IMPORT_CHECK)
 		    != SAVE_BGP_IMPORT_CHECK)
 			vty_out(vty, " %sbgp network import-check\n",
-				bgp_flag_check(bgp, BGP_FLAG_IMPORT_CHECK)
+				CHECK_FLAG(bgp->flags, BGP_FLAG_IMPORT_CHECK)
 					? ""
 					: "no ");
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1227,7 +1227,7 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 
 	if ((peer->sort == BGP_PEER_EBGP && peer->ttl != BGP_DEFAULT_TTL)
 	    || CHECK_FLAG(peer->flags, PEER_FLAG_DISABLE_CONNECTED_CHECK)
-	    || bgp_flag_check(bgp, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
+	    || CHECK_FLAG(bgp->flags, BGP_FLAG_DISABLE_NH_CONNECTED_CHK))
 
 		SET_FLAG(api.flags, ZEBRA_FLAG_ALLOW_RECURSION);
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -201,24 +201,6 @@ int bgp_option_check(int flag)
 	return CHECK_FLAG(bm->options, flag);
 }
 
-/* BGP flag manipulation.  */
-int bgp_flag_set(struct bgp *bgp, int flag)
-{
-	SET_FLAG(bgp->flags, flag);
-	return 0;
-}
-
-int bgp_flag_unset(struct bgp *bgp, int flag)
-{
-	UNSET_FLAG(bgp->flags, flag);
-	return 0;
-}
-
-int bgp_flag_check(struct bgp *bgp, int flag)
-{
-	return CHECK_FLAG(bgp->flags, flag);
-}
-
 /* Internal function to set BGP structure configureation flag.  */
 static void bgp_config_set(struct bgp *bgp, int config)
 {
@@ -1818,7 +1800,7 @@ int peer_remote_as(struct bgp *bgp, union sockunion *su, const char *conf_if,
 		/* If this is IPv4 unicast configuration and "no bgp default
 		   ipv4-unicast" is specified. */
 
-		if (bgp_flag_check(bgp, BGP_FLAG_NO_DEFAULT_IPV4)
+		if (CHECK_FLAG(bgp->flags, BGP_FLAG_NO_DEFAULT_IPV4)
 		    && afi == AFI_IP && safi == SAFI_UNICAST)
 			peer_create(su, conf_if, bgp, local_as, *as, as_type, 0,
 				    0, NULL);
@@ -2428,7 +2410,7 @@ struct peer_group *peer_group_get(struct bgp *bgp, const char *name)
 	for (afi = AFI_IP; afi < AFI_MAX; afi++)
 		group->listen_range[afi] = list_new();
 	group->conf = peer_new(bgp);
-	if (!bgp_flag_check(bgp, BGP_FLAG_NO_DEFAULT_IPV4))
+	if (!CHECK_FLAG(bgp->flags, BGP_FLAG_NO_DEFAULT_IPV4))
 		group->conf->afc[AFI_IP][SAFI_UNICAST] = 1;
 	XFREE(MTYPE_BGP_PEER_HOST, group->conf->host);
 	group->conf->host = XSTRDUP(MTYPE_BGP_PEER_HOST, name);
@@ -3314,7 +3296,7 @@ int bgp_delete(struct bgp *bgp)
 	THREAD_OFF(bgp->t_establish_wait);
 
 	/* Set flag indicating bgp instance delete in progress */
-	bgp_flag_set(bgp, BGP_FLAG_DELETE_IN_PROGRESS);
+	SET_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS);
 
 	/* Delete the graceful restart info */
 	FOREACH_AFI_SAFI (afi, safi) {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -239,7 +239,7 @@ enum bgp_instance_type {
 };
 
 #define BGP_SEND_EOR(bgp, afi, safi)                                           \
-	(!bgp_flag_check(bgp, BGP_FLAG_GR_DISABLE_EOR)                         \
+	(!CHECK_FLAG(bgp->flags, BGP_FLAG_GR_DISABLE_EOR)                      \
 	 && ((bgp->gr_info[afi][safi].t_select_deferral == NULL)               \
 	     || (bgp->gr_info[afi][safi].eor_required                          \
 		 == bgp->gr_info[afi][safi].eor_received)))
@@ -674,7 +674,7 @@ struct afi_safi_info {
 	     && bgp->vrf_id != VRF_UNKNOWN))
 
 #define BGP_SELECT_DEFER_DISABLE(bgp)                                          \
-	(bgp_flag_check(bgp, BGP_FLAG_SELECT_DEFER_DISABLE))
+	(CHECK_FLAG(bgp->flags, BGP_FLAG_SELECT_DEFER_DISABLE))
 
 /* BGP peer-group support. */
 struct peer_group {
@@ -1756,10 +1756,6 @@ extern int bgp_delete(struct bgp *);
 
 extern int bgp_handle_socket(struct bgp *bgp, struct vrf *vrf,
 			     vrf_id_t old_vrf_id, bool create);
-
-extern int bgp_flag_set(struct bgp *, int);
-extern int bgp_flag_unset(struct bgp *, int);
-extern int bgp_flag_check(struct bgp *, int);
 
 extern void bgp_router_id_zebra_bump(vrf_id_t, const struct prefix *);
 extern int bgp_router_id_static_set(struct bgp *, struct in_addr);

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -2388,10 +2388,10 @@ static int rfapiWithdrawTimerVPN(struct thread *t)
                    __func__);
 		return 0;
 	}
-	if (bgp_flag_check(bgp, BGP_FLAG_DELETE_IN_PROGRESS)) {
+	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS)) {
 		vnc_zlog_debug_verbose(
-                   "%s: BGP delete in progress, assume shutdown race condition!!!",
-                   __func__);
+			"%s: BGP delete in progress, assume shutdown race condition!!!",
+			__func__);
 		return 0;
 	}
 	assert(wcb->node);

--- a/scripts/coccinelle/replace_bgp_flag_functions.cocci
+++ b/scripts/coccinelle/replace_bgp_flag_functions.cocci
@@ -1,0 +1,14 @@
+@@
+expression e1, e2;
+@@
+
+(
+- bgp_flag_check(e1, e2)
++ CHECK_FLAG(e1->flags, e2)
+|
+- bgp_flag_set(e1, e2)
++ SET_FLAG(e1->flags, e2)
+|
+- bgp_flag_unset(e1, e2)
++ UNSET_FLAG(e1->flags, e2)
+)


### PR DESCRIPTION
Most of the code uses macros, thus let's keep the code unified.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>