### PR TITLE
sharpd: add support to install/remove lsps

### DIFF
--- a/doc/user/sharp.rst
+++ b/doc/user/sharp.rst
@@ -86,3 +86,20 @@ keyword. At present, no sharp commands will be preserved in the config.
 
    Allow end user to dump associated data with the nexthop tracking that
    may have been turned on.
+
+.. index:: sharp lsp
+.. clicmd:: sharp lsp (0-100000) nexthop-group NAME [prefix A.B.C.D/M TYPE [instance (0-255)]]
+
+   Install an LSP using the specified in-label, with nexthops as
+   listed in nexthop-group ``NAME``. The LSP is installed as type
+   ZEBRA_LSP_SHARP. If ``prefix`` is specified, an existing route with
+   type ``TYPE`` (and optional ``instance`` id) will be updated to use
+   the LSP.
+
+.. index:: sharp remove lsp
+.. clicmd:: sharp remove lsp (0-100000) nexthop-group NAME [prefix A.B.C.D/M TYPE [instance (0-255)]]
+
+   Remove a SHARPD LSP that uses the specified in-label, where the
+   nexthops are specified in nexthop-group ``NAME``. If ``prefix`` is
+   specified, remove label bindings from the route of type ``TYPE``
+   also.

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -37,4 +37,8 @@ extern void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 					uint32_t routes);
 extern void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 				       uint8_t instance, uint32_t routes);
+
+int sharp_install_lsps_helper(bool install_p, const struct prefix *p,
+			      uint8_t type, int instance, uint32_t in_label,
+			      const struct nexthop_group *nhg);
 #endif


### PR DESCRIPTION
First round of support for exercising the lsp and ftn paths using sharpd. This supports lsp-only, and binding to ipv4 prefix.
