### PR TITLE
bgpd: Use readable macros for peer->gtsm_hops instead of literals

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1993,7 +1993,7 @@ void bgp_fsm_event_update(struct peer *peer, int valid)
 	case OpenSent:
 	case OpenConfirm:
 	case Established:
-		if (!valid && (peer->gtsm_hops == 1))
+		if (!valid && (peer->gtsm_hops == BGP_GTSM_HOPS_CONNECTED))
 			BGP_EVENT_ADD(peer, TCP_fatal_error);
 	case Clearing:
 	case Deleted:

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6901,7 +6901,7 @@ DEFUN (neighbor_ttl_security,
 	 * If 'neighbor swpX', then this is for directly connected peers,
 	 * we should not accept a ttl-security hops value greater than 1.
 	 */
-	if (peer->conf_if && (gtsm_hops > 1)) {
+	if (peer->conf_if && (gtsm_hops > BGP_GTSM_HOPS_CONNECTED)) {
 		vty_out(vty,
 			"%s is directly connected peer, hops cannot exceed 1\n",
 			argv[idx_peer]->arg);
@@ -11937,7 +11937,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 	/* EBGP Multihop and GTSM */
 	if (p->sort != BGP_PEER_IBGP) {
 		if (use_json) {
-			if (p->gtsm_hops > 0)
+			if (p->gtsm_hops > BGP_GTSM_HOPS_DISABLED)
 				json_object_int_add(json_neigh,
 						    "externalBgpNbrMaxHopsAway",
 						    p->gtsm_hops);
@@ -11946,7 +11946,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 						    "externalBgpNbrMaxHopsAway",
 						    p->ttl);
 		} else {
-			if (p->gtsm_hops > 0)
+			if (p->gtsm_hops > BGP_GTSM_HOPS_DISABLED)
 				vty_out(vty,
 					"  External BGP neighbor may be up to %d hops away.\n",
 					p->gtsm_hops);
@@ -11956,7 +11956,7 @@ static void bgp_show_peer(struct vty *vty, struct peer *p, bool use_json,
 					p->ttl);
 		}
 	} else {
-		if (p->gtsm_hops > 0) {
+		if (p->gtsm_hops > BGP_GTSM_HOPS_DISABLED) {
 			if (use_json)
 				json_object_int_add(json_neigh,
 						    "internalBgpNbrMaxHopsAway",
@@ -14448,7 +14448,8 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 
 	/* ebgp-multihop */
 	if (peer->sort != BGP_PEER_IBGP && peer->ttl != BGP_DEFAULT_TTL
-	    && !(peer->gtsm_hops != 0 && peer->ttl == MAXTTL)) {
+	    && !(peer->gtsm_hops != BGP_GTSM_HOPS_DISABLED
+		 && peer->ttl == MAXTTL)) {
 		if (!peer_group_active(peer) || g_peer->ttl != peer->ttl) {
 			vty_out(vty, " neighbor %s ebgp-multihop %d\n", addr,
 				peer->ttl);
@@ -14456,7 +14457,7 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 	}
 
 	/* ttl-security hops */
-	if (peer->gtsm_hops != 0) {
+	if (peer->gtsm_hops != BGP_GTSM_HOPS_DISABLED) {
 		if (!peer_group_active(peer)
 		    || g_peer->gtsm_hops != peer->gtsm_hops) {
 			vty_out(vty, " neighbor %s ttl-security hops %d\n",

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -279,13 +279,13 @@ static int bgp_ifp_down(struct interface *ifp)
 			 * tracked (directly connected) IBGP peers.
 			 */
 			if ((peer->ttl != BGP_DEFAULT_TTL)
-			    && (peer->gtsm_hops != 1)
+			    && (peer->gtsm_hops != BGP_GTSM_HOPS_CONNECTED)
 			    && (!peer->bfd_info
 				|| bgp_bfd_is_peer_multihop(peer)))
 #else
 			/* Take down directly connected EBGP peers */
 			if ((peer->ttl != BGP_DEFAULT_TTL)
-			    && (peer->gtsm_hops != 1))
+			    && (peer->gtsm_hops != BGP_GTSM_HOPS_CONNECTED))
 #endif
 				continue;
 
@@ -451,7 +451,8 @@ static int bgp_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 		if (!CHECK_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER)) {
 			for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
 				if ((peer->ttl != BGP_DEFAULT_TTL)
-				    && (peer->gtsm_hops != 1))
+				    && (peer->gtsm_hops
+					!= BGP_GTSM_HOPS_CONNECTED))
 					continue;
 
 				if (ifp == peer->nexthop.ifp)

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2435,7 +2435,7 @@ struct peer_group *peer_group_get(struct bgp *bgp, const char *name)
 	group->conf->group = group;
 	group->conf->as = 0;
 	group->conf->ttl = BGP_DEFAULT_TTL;
-	group->conf->gtsm_hops = 0;
+	group->conf->gtsm_hops = BGP_GTSM_HOPS_DISABLED;
 	group->conf->v_routeadv = BGP_DEFAULT_EBGP_ROUTEADV;
 	SET_FLAG(group->conf->sflags, PEER_STATUS_GROUP);
 	listnode_add_sort(bgp->group, group);
@@ -4339,7 +4339,7 @@ int peer_ebgp_multihop_set(struct peer *peer, int ttl)
 	if (ttl != MAXTTL) {
 		if (CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
 			group = peer->group;
-			if (group->conf->gtsm_hops != 0)
+			if (group->conf->gtsm_hops != BGP_GTSM_HOPS_DISABLED)
 				return BGP_ERR_NO_EBGP_MULTIHOP_WITH_TTLHACK;
 
 			for (ALL_LIST_ELEMENTS(group->peer, node, nnode,
@@ -4347,11 +4347,11 @@ int peer_ebgp_multihop_set(struct peer *peer, int ttl)
 				if (peer1->sort == BGP_PEER_IBGP)
 					continue;
 
-				if (peer1->gtsm_hops != 0)
+				if (peer1->gtsm_hops != BGP_GTSM_HOPS_DISABLED)
 					return BGP_ERR_NO_EBGP_MULTIHOP_WITH_TTLHACK;
 			}
 		} else {
-			if (peer->gtsm_hops != 0)
+			if (peer->gtsm_hops != BGP_GTSM_HOPS_DISABLED)
 				return BGP_ERR_NO_EBGP_MULTIHOP_WITH_TTLHACK;
 		}
 	}
@@ -4392,7 +4392,7 @@ int peer_ebgp_multihop_unset(struct peer *peer)
 	if (peer->sort == BGP_PEER_IBGP)
 		return 0;
 
-	if (peer->gtsm_hops != 0 && peer->ttl != MAXTTL)
+	if (peer->gtsm_hops != BGP_GTSM_HOPS_DISABLED && peer->ttl != MAXTTL)
 		return BGP_ERR_NO_EBGP_MULTIHOP_WITH_TTLHACK;
 
 	if (peer_group_active(peer))
@@ -6585,7 +6585,8 @@ int peer_ttl_security_hops_set(struct peer *peer, int gtsm_hops)
 	   mess of this configuration parameter, and OpenBGPD got it right.
 	*/
 
-	if ((peer->gtsm_hops == 0) && (peer->sort != BGP_PEER_IBGP)) {
+	if ((peer->gtsm_hops == BGP_GTSM_HOPS_DISABLED)
+	    && (peer->sort != BGP_PEER_IBGP)) {
 		if (is_ebgp_multihop_configured(peer))
 			return BGP_ERR_NO_EBGP_MULTIHOP_WITH_TTLHACK;
 
@@ -6648,7 +6649,9 @@ int peer_ttl_security_hops_set(struct peer *peer, int gtsm_hops)
 				 *   no session then do nothing (will get
 				 * handled by next connection)
 				 */
-				if (peer->fd >= 0 && peer->gtsm_hops != 0)
+				if (peer->fd >= 0
+				    && peer->gtsm_hops
+					       != BGP_GTSM_HOPS_DISABLED)
 					sockopt_minttl(
 						peer->su.sa.sa_family, peer->fd,
 						MAXTTL + 1 - peer->gtsm_hops);
@@ -6679,7 +6682,7 @@ int peer_ttl_security_hops_unset(struct peer *peer)
 	if (peer_group_active(peer))
 		peer->gtsm_hops = peer->group->conf->gtsm_hops;
 	else
-		peer->gtsm_hops = 0;
+		peer->gtsm_hops = BGP_GTSM_HOPS_DISABLED;
 
 	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP)) {
 		/* Invoking ebgp_multihop_set will set the TTL back to the
@@ -6702,7 +6705,7 @@ int peer_ttl_security_hops_unset(struct peer *peer)
 	} else {
 		group = peer->group;
 		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, peer)) {
-			peer->gtsm_hops = 0;
+			peer->gtsm_hops = BGP_GTSM_HOPS_DISABLED;
 			if (peer->sort == BGP_PEER_EBGP)
 				ret = peer_ebgp_multihop_unset(peer);
 			else {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -723,7 +723,9 @@ struct bgp_nexthop {
 #define RMAP_OUT 1
 #define RMAP_MAX 2
 
-#define BGP_DEFAULT_TTL 1
+#define BGP_DEFAULT_TTL         1
+#define BGP_GTSM_HOPS_DISABLED  0
+#define BGP_GTSM_HOPS_CONNECTED 1
 
 #include "filter.h"
 


### PR DESCRIPTION
Do the same way like BGP_DEFAULT_TTL

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>