### PR TITLE
bgpd: RFC compliance wrt invalid RMAC, GWIP, ESI and VNI

### DIFF
--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -281,3 +281,25 @@ extern int bgp_build_evpn_prefix(int evpn_type, uint32_t eth_tag,
 		return -1;
 	return 0;
 }
+
+extern bool is_zero_gw_ip(const union gw_addr *gw_ip, const afi_t afi)
+{
+	if (afi == AF_INET6 && IN6_IS_ADDR_UNSPECIFIED(&gw_ip->ipv6))
+		return true;
+
+	if (afi == AF_INET && gw_ip->ipv4.s_addr == INADDR_ANY)
+		return true;
+
+	return false;
+}
+
+extern bool is_zero_esi(const struct eth_segment_id *esi)
+{
+	int i;
+
+	for (i = 0; i < ESI_LEN; i++)
+		if (esi->val[i])
+			return false;
+
+	return true;
+}

--- a/bgpd/bgp_attr_evpn.h
+++ b/bgpd/bgp_attr_evpn.h
@@ -67,4 +67,7 @@ extern uint8_t bgp_attr_default_gw(struct attr *attr);
 
 extern void bgp_attr_evpn_na_flag(struct attr *attr, uint8_t *router_flag);
 
+extern bool is_zero_gw_ip(const union gw_addr *gw_ip, afi_t afi);
+
+extern bool is_zero_esi(const struct eth_segment_id *esi);
 #endif /* _QUAGGA_BGP_ATTR_EVPN_H */

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -56,6 +56,25 @@ int is_zero_mac(const struct ethaddr *mac)
 	return 1;
 }
 
+bool is_bcast_mac(const struct ethaddr *mac)
+{
+	int i = 0;
+
+	for (i = 0; i < ETH_ALEN; i++)
+		if (mac->octet[i] != 0xFF)
+			return false;
+
+	return true;
+}
+
+bool is_mcast_mac(const struct ethaddr *mac)
+{
+	if ((mac->octet[0] & 0x01) == 0x01)
+		return true;
+
+	return false;
+}
+
 unsigned int prefix_bit(const uint8_t *prefix, const uint16_t prefixlen)
 {
 	unsigned int offset = prefixlen / 8;

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -470,6 +470,8 @@ extern void masklen2ip6(const int, struct in6_addr *);
 extern const char *inet6_ntoa(struct in6_addr);
 
 extern int is_zero_mac(const struct ethaddr *mac);
+extern bool is_mcast_mac(const struct ethaddr *mac);
+extern bool is_bcast_mac(const struct ethaddr *mac);
 extern int prefix_str2mac(const char *str, struct ethaddr *mac);
 extern char *prefix_mac2str(const struct ethaddr *mac, char *buf, int size);
 


### PR DESCRIPTION
A route where ESI, GW IP, MAC and Label are all zero at the same time SHOULD
be treat-as-withdraw.
Invalid MAC addresses are broadcast or multicast MAC addresses. The route
MUST be treat-as-withdraw in case of an invalid MAC address.

As FRR support Ethernet NVO Tunnels only.
Route will be withdrawn when ESI, GW IP and MAC are zero or Invalid MAC

Test cases:
1) ET-5 route with valid RMAC extended community
2) ET-5 route no RMAC extended community
3) ET-5 route with Multicast MAC in RMAC extended community
4) ET-5 route with Broadcast MAC in RMAC extended community

Signed-off-by: Kishore Aramalla <karamalla@vmware.com>