### PR TITLE
bgpd: Update failed reason to distinguish some NHT scenarios

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -576,7 +576,9 @@ const char *const peer_down_str[] = {"",
 			       "Waiting for NHT",
 			       "Waiting for Peer IPv6 LLA",
 			       "Waiting for VRF to be initialized",
-			       "No AFI/SAFI activated for peer"};
+			       "No AFI/SAFI activated for peer",
+			       "AS Set config change",
+			       "Waiting for peer OPEN"};
 
 static int bgp_graceful_restart_timer_expire(struct thread *thread)
 {

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1321,10 +1321,10 @@ struct peer {
 #define PEER_DOWN_REMOTE_AS_CHANGE       2 /* neighbor remote-as command */
 #define PEER_DOWN_LOCAL_AS_CHANGE        3 /* neighbor local-as command */
 #define PEER_DOWN_CLID_CHANGE            4 /* bgp cluster-id command */
-#define PEER_DOWN_CONFED_ID_CHANGE       5 /* bgp confederation identifier command */
+#define PEER_DOWN_CONFED_ID_CHANGE       5 /* bgp confederation id command */
 #define PEER_DOWN_CONFED_PEER_CHANGE     6 /* bgp confederation peer command */
-#define PEER_DOWN_RR_CLIENT_CHANGE       7 /* neighbor route-reflector-client command */
-#define PEER_DOWN_RS_CLIENT_CHANGE       8 /* neighbor route-server-client command */
+#define PEER_DOWN_RR_CLIENT_CHANGE       7 /* neighbor rr-client command */
+#define PEER_DOWN_RS_CLIENT_CHANGE       8 /* neighbor rs-client command */
 #define PEER_DOWN_UPDATE_SOURCE_CHANGE   9 /* neighbor update-source command */
 #define PEER_DOWN_AF_ACTIVATE           10 /* neighbor activate command */
 #define PEER_DOWN_USER_SHUTDOWN         11 /* neighbor shutdown command */
@@ -1348,6 +1348,12 @@ struct peer {
 #define PEER_DOWN_VRF_UNINIT            29 /* Associated VRF is not init yet */
 #define PEER_DOWN_NOAFI_ACTIVATED       30 /* No AFI/SAFI activated for peer */
 #define PEER_DOWN_AS_SETS_REJECT        31 /* Reject routes with AS_SET */
+#define PEER_DOWN_WAITING_OPEN          32 /* Waiting for open to succeed */
+	/*
+	 * Remember to update peer_down_str in bgp_fsm.c when you add
+	 * a new value to the last_reset reason
+	 */
+
 	size_t last_reset_cause_size;
 	uint8_t last_reset_cause[BGP_MAX_PACKET_SIZE];
 


### PR DESCRIPTION
Current failed reasons for bgp when you have a peer that
is not online yet is `Waiting for NHT`, even if NHT has
succeeded.  Add some code to differentiate this.

eva# show bgp ipv4 uni summ failed
BGP router identifier 192.168.201.135, local AS number 3923 vrf-id 0
BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 2, using 43 KiB of memory
Neighbor        EstdCnt DropCnt ResetTime Reason
192.168.44.1          0       0    never  Waiting for NHT
192.168.201.139       0       0    never  Waiting for Open to Succeed
Total number of neighbors 2
eva#

eva# show bgp nexthop
Current BGP nexthop cache:
 192.168.44.1 invalid, peer 192.168.44.1
  Must be Connected
  Last update: Mon Feb 10 19:05:19 2020

 192.168.201.139 valid [IGP metric 0], #paths 0, peer 192.168.201.139

So 192.168.201.139 is a peer for a connected route that has not been
created on .139, while 44.1 nexthop tracking has not succeeded yet.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>