### PR TITLE
bgpd: format fields to bgp evpn vni json cmds

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -380,7 +380,7 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 		json_object_string_add(json, "originatorIp",
 				       inet_ntoa(bgp_vrf->originator_ip));
 		json_object_string_add(json, "advertiseGatewayMacip", "n/a");
-		json_object_string_add(json, "advertiseSviMacip", "n/a");
+		json_object_string_add(json, "advertiseSviMacIp", "n/a");
 		json_object_to_json_string_ext(json,
 					       JSON_C_TO_STRING_NOSLASHESCAPE);
 		json_object_string_add(json, "advertisePip",
@@ -544,13 +544,13 @@ static void display_vni(struct vty *vty, struct bgpevpn *vpn, json_object *json)
 					       "Disabled");
 		if (!vpn->advertise_svi_macip && bgp_evpn &&
 		    bgp_evpn->evpn_info->advertise_svi_macip)
-			json_object_string_add(json, "advertiseSviMacip",
+			json_object_string_add(json, "advertiseSviMacIp",
 					       "Active");
 		else if (vpn->advertise_svi_macip)
-			json_object_string_add(json, "advertiseSviMacip",
+			json_object_string_add(json, "advertiseSviMacIp",
 					       "Enabled");
 		else
-			json_object_string_add(json, "advertiseSviMacip",
+			json_object_string_add(json, "advertiseSviMacIp",
 					       "Disabled");
 	} else {
 		vty_out(vty, "VNI: %d", vpn->vni);
@@ -889,7 +889,7 @@ static void show_l3vni_entry(struct vty *vty, struct bgp *bgp,
 			prefix_rd2str(&bgp->vrf_prd, buf2, RD_ADDRSTRLEN));
 		json_object_string_add(json_vni, "advertiseGatewayMacip",
 				       "n/a");
-		json_object_string_add(json_vni, "advertiseSviMacip", "n/a");
+		json_object_string_add(json_vni, "advertiseSviMacIp", "n/a");
 		json_object_to_json_string_ext(json_vni,
 					       JSON_C_TO_STRING_NOSLASHESCAPE);
 		json_object_string_add(
@@ -1072,13 +1072,13 @@ static void show_vni_entry(struct hash_bucket *bucket, void *args[])
 				json_vni, "advertiseGatewayMacip", "Disabled");
 		if (!vpn->advertise_svi_macip && bgp_evpn
 		    && bgp_evpn->evpn_info->advertise_svi_macip)
-			json_object_string_add(json_vni, "advertiseSviMacip",
+			json_object_string_add(json_vni, "advertiseSviMacIp",
 					       "Active");
 		else if (vpn->advertise_svi_macip)
-			json_object_string_add(json_vni, "advertiseSviMacip",
+			json_object_string_add(json_vni, "advertiseSviMacIp",
 					       "Enabled");
 		else
-			json_object_string_add(json_vni, "advertiseSviMacip",
+			json_object_string_add(json_vni, "advertiseSviMacIp",
 					       "Disabled");
 	} else {
 		vty_out(vty, "%-1s %-10u %-4s %-21s", buf1, vpn->vni, "L2",
@@ -3944,7 +3944,7 @@ DEFUN(show_bgp_l2vpn_evpn_vni,
 					       bgp_evpn->advertise_gw_macip
 						       ? "Enabled"
 						       : "Disabled");
-			json_object_string_add(json, "advertiseSviMacip",
+			json_object_string_add(json, "advertiseSviMacIp",
 					bgp_evpn->evpn_info->advertise_svi_macip
 					? "Enabled" : "Disabled");
 			json_object_string_add(json, "advertiseAllVnis",

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -373,7 +373,7 @@ static void display_l3vni(struct vty *vty, struct bgp *bgp_vrf,
 		json_export_rtl = json_object_new_array();
 		json_object_int_add(json, "vni", bgp_vrf->l3vni);
 		json_object_string_add(json, "type", "L3");
-		json_object_string_add(json, "kernelFlag", "Yes");
+		json_object_string_add(json, "inKernel", "True");
 		json_object_string_add(
 			json, "rd",
 			prefix_rd2str(&bgp_vrf->vrf_prd, buf1, RD_ADDRSTRLEN));
@@ -519,8 +519,8 @@ static void display_vni(struct vty *vty, struct bgpevpn *vpn, json_object *json)
 		json_export_rtl = json_object_new_array();
 		json_object_int_add(json, "vni", vpn->vni);
 		json_object_string_add(json, "type", "L2");
-		json_object_string_add(json, "kernelFlag",
-				       is_vni_live(vpn) ? "Yes" : "No");
+		json_object_string_add(json, "inKernel",
+				       is_vni_live(vpn) ? "True" : "False");
 		json_object_string_add(
 			json, "rd",
 			prefix_rd2str(&vpn->prd, buf1, sizeof(buf1)));
@@ -1049,13 +1049,11 @@ static void show_vni_entry(struct hash_bucket *bucket, void *args[])
 		json_object_string_add(json_vni, "type", "L2");
 		json_object_string_add(json_vni, "inKernel",
 				       is_vni_live(vpn) ? "True" : "False");
-		json_object_string_add(json_vni, "originatorIp",
-				       inet_ntoa(vpn->originator_ip));
-		json_object_string_add(json_vni, "originatorIp",
-				       inet_ntoa(vpn->originator_ip));
 		json_object_string_add(
 			json_vni, "rd",
 			prefix_rd2str(&vpn->prd, buf2, sizeof(buf2)));
+		json_object_string_add(json_vni, "originatorIp",
+				       inet_ntoa(vpn->originator_ip));
 		json_object_string_add(json_vni, "mcastGroup",
 				       inet_ntoa(vpn->mcast_grp));
 		/* per vni knob is enabled -- Enabled


### PR DESCRIPTION
1)   Bring 'show bgp l2vpn evpn vni json' inline with 'show bgp l2vpn evpn vni <id> json' in terms of fields.
2) Readjust fields in evpn vni json commands 
    2a) Keep consistant field name, such as "inKernel".
    2b) Keep fields order same for both commands output.

```   
 TORS1# show bgp l2vpn evpn vni 1002 json
    {
      "vni":1002,
      "type":"L2",
      "inKernel":"True",
      "rd":"27.0.0.15:8",
      "originatorIp":"27.0.0.15",
      "mcastGroup":"0.0.0.0",
      "advertiseGatewayMacip":"Disabled",
      "advertiseSviMacip":"Disabled",
      "importRts":[
        "5550:1002"
      ],
      "exportRts":[
        "5550:1002"
      ]
    }
```

```
    TORS1# show bgp l2vpn evpn vni json
    {
      "advertiseGatewayMacip":"Disabled",
      "advertiseSviMacip":"Disabled",
      "advertiseAllVnis":"Enabled",
      "flooding":"Head-end replication",
      "numVnis":8,
      "numL2Vnis":5,
      "numL3Vnis":3,
      "1002":{
        "vni":1002,
        "type":"L2",
        "inKernel":"True",
        "rd":"27.0.0.15:8",
        "originatorIp":"27.0.0.15",
        "mcastGroup":"0.0.0.0",
        "advertiseGatewayMacip":"Disabled",
        "advertiseSviMacip":"Disabled",
        "importRTs":[
          "5550:1002"
        ],
        "exportRTs":[
          "5550:1002"
        ]
      },
      "4001":{
        "vni":4001,
        "type":"L3",
        "inKernel":"True",
        "originatorIp":"27.0.0.15",
        "rd":"45.0.2.2:5",
        "advertiseGatewayMacip":"n\/a",
        "advertiseSviMacip":"n\/a",
        "advertisePip":"Enabled",
        "sysIP":"27.0.0.15",
        "sysMAC":"00:02:00:00:00:4e",
        "rmac":"00:02:00:00:00:4e",
        "importRTs":[
          "5550:4001"
        ],
        "exportRTs":[
          "5550:4001"
        ]
      },
    }
```