### PR TITLE
lib,zebra: remove unused MATCHED nexthop flag

### DIFF
--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -79,10 +79,13 @@ struct nexthop {
 #define NEXTHOP_FLAG_ACTIVE     (1 << 0) /* This nexthop is alive. */
 #define NEXTHOP_FLAG_FIB        (1 << 1) /* FIB nexthop. */
 #define NEXTHOP_FLAG_RECURSIVE  (1 << 2) /* Recursive nexthop. */
-#define NEXTHOP_FLAG_ONLINK     (1 << 3) /* Nexthop should be installed onlink. */
-#define NEXTHOP_FLAG_MATCHED    (1 << 4) /* Already matched vs a nexthop */
-#define NEXTHOP_FLAG_DUPLICATE  (1 << 5) /* nexthop duplicates another active one */
-#define NEXTHOP_FLAG_RNH_FILTERED  (1 << 6) /* rmap filtered, used by rnh */
+#define NEXTHOP_FLAG_ONLINK     (1 << 3) /* Nexthop should be installed
+					  * onlink.
+					  */
+#define NEXTHOP_FLAG_DUPLICATE  (1 << 4) /* nexthop duplicates another
+					  * active one
+					  */
+#define NEXTHOP_FLAG_RNH_FILTERED  (1 << 5) /* rmap filtered, used by rnh */
 #define NEXTHOP_IS_ACTIVE(flags)                                               \
 	(CHECK_FLAG(flags, NEXTHOP_FLAG_ACTIVE)                                \
 	 && !CHECK_FLAG(flags, NEXTHOP_FLAG_DUPLICATE))

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2449,7 +2449,7 @@ void _route_entry_dump(const char *func, union prefixconstptr pp,
 				  INET6_ADDRSTRLEN);
 			break;
 		}
-		zlog_debug("%s: %s %s[%u] vrf %s(%u) with flags %s%s%s%s%s%s",
+		zlog_debug("%s: %s %s[%u] vrf %s(%u) with flags %s%s%s%s%s",
 			   straddr, (nexthop->rparent ? "  NH" : "NH"), nhname,
 			   nexthop->ifindex, vrf ? vrf->name : "Unknown",
 			   nexthop->vrf_id,
@@ -2464,9 +2464,6 @@ void _route_entry_dump(const char *func, union prefixconstptr pp,
 				    : ""),
 			   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK)
 				    ? "ONLINK "
-				    : ""),
-			   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_MATCHED)
-				    ? "MATCHED "
 				    : ""),
 			   (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE)
 				    ? "DUPLICATE "


### PR DESCRIPTION
Remove an unused flag value from the nexthop struct; seems like an opportunity to reclaim the flag bit.