### PR TITLE
zebra: Nexthop Refactoring to Hierarchical Tree Part 1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -57,6 +57,8 @@ ForEachMacros:
   - RE_DEST_FOREACH_ROUTE_SAFE
   - RNODE_FOREACH_RE
   - RNODE_FOREACH_RE_SAFE
+  - zebra_nhg_each
+  - zebra_nhg_each_nexthop
   # bgpd
   - UPDGRP_FOREACH_SUBGRP
   - UPDGRP_FOREACH_SUBGRP_SAFE

--- a/doc/developer/zebra.rst
+++ b/doc/developer/zebra.rst
@@ -529,3 +529,67 @@ All these create an overall ``dependents`` tree that looks like this:
            B ____/
 
 
+Macros:
+==============
+
+.. c:function:: zebra_nhg_nexthop(nhe)
+
+   Accessor macro for the ``lib/nexthop.h`` nexthop.
+
+   Returns ``struct nexthop *``:
+
+   .. code-block:: c
+
+      ->nexthop
+
+Iteration Macros
+----------------
+Iterate over top-level (non-recursive) NHEs (singleton and groups):
+
+ex)
+
+::
+
+   A _____ B
+    \_____ C
+    \_____ D _____ E
+
+
+   for (B, C, D)
+
+::
+
+   A _____ B
+
+   for (A)
+
+.. c:function:: zebra_nhg_each(root, iter)
+
+   If root is a singleton (recursive or not), it just iterates on that,
+   otherwise it iterates on the group.
+
+   .. code-block:: c
+
+      if (root != GROUP)
+              iter = root;
+      else
+              for (iter = root;
+                      iter;
+                      iter = nhg_connected_tree_next(&root->nhg_depends, iter)
+              )
+
+.. c:function:: zebra_nhg_each_nexthop(root, iter)
+
+   Same as above but iterates on the ``struct nexthop *`` in an NHE.
+
+   Equivalent to lib/nexthop iteration:
+
+   .. code-block:: c
+
+      for (iter = root; iter; iter = iter->next)
+
+
+.. warning::
+
+   These are non-safe macros (removing from list while iterating is undefined
+   behavior).

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -421,6 +421,15 @@ void nexthop_del_labels(struct nexthop *nexthop)
 	}
 }
 
+/* Does this nexthop have at least one label? */
+bool nexthop_has_labels(const struct nexthop *nexthop)
+{
+	if (nexthop->nh_label && nexthop->nh_label->num_labels)
+		return true;
+
+	return false;
+}
+
 const char *nexthop2str(const struct nexthop *nexthop, char *str, int size)
 {
 	switch (nexthop->type) {

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -127,6 +127,8 @@ void nexthop_add_labels(struct nexthop *, enum lsp_types_t, uint8_t,
 			mpls_label_t *);
 void nexthop_del_labels(struct nexthop *);
 
+bool nexthop_has_labels(const struct nexthop *nexthop);
+
 /*
  * Allocate a new nexthop object and initialize it from various args.
  */

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -103,13 +103,14 @@ uint8_t nexthop_group_nexthop_num_no_recurse(const struct nexthop_group *nhg)
 	return num;
 }
 
-uint8_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg)
+uint8_t nexthop_group_nexthop_num_has_flag(const struct nexthop_group *nhg,
+					   int flag)
 {
 	struct nexthop *nhop;
 	uint8_t num = 0;
 
 	for (ALL_NEXTHOPS_PTR(nhg, nhop)) {
-		if (CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_ACTIVE))
+		if (CHECK_FLAG(nhop->flags, flag))
 			num++;
 	}
 
@@ -117,17 +118,30 @@ uint8_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg)
 }
 
 uint8_t
-nexthop_group_active_nexthop_num_no_recurse(const struct nexthop_group *nhg)
+nexthop_group_nexthop_num_has_flag_no_recurse(const struct nexthop_group *nhg,
+					      int flag)
 {
 	struct nexthop *nhop;
 	uint8_t num = 0;
 
 	for (nhop = nhg->nexthop; nhop; nhop = nhop->next) {
-		if (CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_ACTIVE))
+		if (CHECK_FLAG(nhop->flags, flag))
 			num++;
 	}
 
 	return num;
+}
+
+uint8_t nexthop_group_active_nexthop_num(const struct nexthop_group *nhg)
+{
+	return nexthop_group_nexthop_num_has_flag(nhg, NEXTHOP_FLAG_ACTIVE);
+}
+
+uint8_t
+nexthop_group_active_nexthop_num_no_recurse(const struct nexthop_group *nhg)
+{
+	return nexthop_group_nexthop_num_has_flag_no_recurse(
+		nhg, NEXTHOP_FLAG_ACTIVE);
 }
 
 struct nexthop *nexthop_exists(const struct nexthop_group *nhg,

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -259,8 +259,7 @@ void _nexthop_add(struct nexthop **target, struct nexthop *nexthop)
 }
 
 /* Add nexthop to sorted list of nexthops */
-static void _nexthop_add_sorted(struct nexthop **head,
-				struct nexthop *nexthop)
+void _nexthop_add_sorted(struct nexthop **head, struct nexthop *nexthop)
 {
 	struct nexthop *position, *prev;
 

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -137,6 +137,11 @@ extern uint8_t
 nexthop_group_active_nexthop_num(const struct nexthop_group *nhg);
 extern uint8_t
 nexthop_group_active_nexthop_num_no_recurse(const struct nexthop_group *nhg);
+extern uint8_t
+nexthop_group_nexthop_num_has_flag(const struct nexthop_group *nhg, int flag);
+extern uint8_t
+nexthop_group_nexthop_num_has_flag_no_recurse(const struct nexthop_group *nhg,
+					      int flag);
 
 #ifdef __cplusplus
 }

--- a/lib/nexthop_group_private.h
+++ b/lib/nexthop_group_private.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+void _nexthop_add_sorted(struct nexthop **head, struct nexthop *nexthop);
 void _nexthop_add(struct nexthop **target, struct nexthop *nexthop);
 void _nexthop_del(struct nexthop_group *nhg, struct nexthop *nexthop);
 

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -645,8 +645,8 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, struct route_node *rn,
 	if (rmap_name)
 		ret = zebra_import_table_route_map_check(
 			afi, re->type, re->instance, &rn->p,
-			re->nhe->nhg->nexthop,
-			zvrf->vrf->vrf_id, re->tag, rmap_name);
+			zebra_nhg_nexthop(re->nhe), zvrf->vrf->vrf_id, re->tag,
+			rmap_name);
 
 	if (ret != RMAP_PERMITMATCH) {
 		UNSET_FLAG(re->flags, ZEBRA_FLAG_SELECTED);
@@ -682,7 +682,7 @@ int zebra_add_import_table_entry(struct zebra_vrf *zvrf, struct route_node *rn,
 	newre->instance = re->table;
 
 	ng = nexthop_group_new();
-	copy_nexthops(&ng->nexthop, re->nhe->nhg->nexthop, NULL);
+	zebra_nhg_nhe2nexthop_group(ng, re->nhe);
 
 	rib_add_multipath(afi, SAFI_UNICAST, &p, NULL, newre, ng);
 
@@ -699,9 +699,8 @@ int zebra_del_import_table_entry(struct zebra_vrf *zvrf, struct route_node *rn,
 	prefix_copy(&p, &rn->p);
 
 	rib_delete(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_TABLE,
-		   re->table, re->flags, &p, NULL, re->nhe->nhg->nexthop,
-		   re->nhe_id, zvrf->table_id, re->metric, re->distance,
-		   false);
+		   re->table, re->flags, &p, NULL, zebra_nhg_nexthop(re->nhe),
+		   re->nhe_id, zvrf->table_id, re->metric, re->distance, false);
 
 	return 0;
 }

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -505,15 +505,25 @@ static inline void rib_tables_iter_cleanup(rib_tables_iter_t *iter)
 DECLARE_HOOK(rib_update, (struct route_node * rn, const char *reason),
 	     (rn, reason))
 
-/*
- * Access active nexthop-group, either RIB or FIB version
- */
-static inline struct nexthop_group *rib_active_nhg(struct route_entry *re)
+
+/* TODO: Should we make fib_ng an NHE tree as well? */
+
+/* Has the FIB nexthop group been set? */
+static inline bool re_has_fib_ng(const struct route_entry *re)
 {
 	if (re->fib_ng.nexthop)
+		return true;
+
+	return false;
+}
+
+/* Accessor for FIB nexthop group */
+static inline struct nexthop_group *re_fib_ng(struct route_entry *re)
+{
+	if (re_has_fib_ng(re))
 		return &(re->fib_ng);
-	else
-		return re->nhe->nhg;
+
+	return NULL;
 }
 
 extern void zebra_vty_init(void);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -312,8 +312,6 @@ typedef enum {
 	RIB_UPDATE_MAX
 } rib_update_event_t;
 
-extern void route_entry_copy_nexthops(struct route_entry *re,
-				      struct nexthop *nh);
 int route_entry_update_nhe(struct route_entry *re, struct nhg_hash_entry *new);
 
 #define route_entry_dump(prefix, src, re) _route_entry_dump(__func__, prefix, src, re)

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -580,8 +580,7 @@ int zsend_redistribute_route(int cmd, struct zserv *client,
 		memcpy(&api.src_prefix, src_p, sizeof(api.src_prefix));
 	}
 
-	for (nexthop = re->nhe->nhg->nexthop;
-	     nexthop; nexthop = nexthop->next) {
+	zebra_nhg_each_nexthop (re->nhe, nexthop) {
 		if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 			continue;
 
@@ -689,10 +688,10 @@ static int zsend_ipv4_nexthop_lookup_mrib(struct zserv *client,
 		 * nexthop we are looking up. Therefore, we will just iterate
 		 * over the top chain of nexthops.
 		 */
-		for (nexthop = re->nhe->nhg->nexthop; nexthop;
-		     nexthop = nexthop->next)
+		zebra_nhg_each_nexthop (re->nhe, nexthop) {
 			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 				num += zserv_encode_nexthop(s, nexthop);
+		}
 
 		/* store nexthop_num */
 		stream_putc_at(s, nump, num);

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -186,8 +186,7 @@ static int lsp_install(struct zebra_vrf *zvrf, mpls_label_t label,
 	 * the label advertised by the recursive nexthop (plus we don't have the
 	 * logic yet to push multiple labels).
 	 */
-	for (nexthop = re->nhe->nhg->nexthop;
-	     nexthop; nexthop = nexthop->next) {
+	zebra_nhg_each_nexthop (re->nhe, nexthop) {
 		/* Skip inactive and recursive entries. */
 		if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
 			continue;
@@ -638,8 +637,7 @@ static int nhlfe_nexthop_active_ipv4(zebra_nhlfe_t *nhlfe,
 		    || !CHECK_FLAG(match->flags, ZEBRA_FLAG_SELECTED))
 			continue;
 
-		for (match_nh = match->nhe->nhg->nexthop; match_nh;
-		     match_nh = match_nh->next) {
+		zebra_nhg_each_nexthop (match->nhe, match_nh) {
 			if (match->type == ZEBRA_ROUTE_CONNECT
 			    || nexthop->ifindex == match_nh->ifindex) {
 				nexthop->ifindex = match_nh->ifindex;
@@ -689,10 +687,10 @@ static int nhlfe_nexthop_active_ipv6(zebra_nhlfe_t *nhlfe,
 			break;
 	}
 
-	if (!match || !match->nhe->nhg->nexthop)
+	if (!match || !zebra_nhg_nexthop(match->nhe))
 		return 0;
 
-	nexthop->ifindex = match->nhe->nhg->nexthop->ifindex;
+	nexthop->ifindex = zebra_nhg_nexthop(match->nhe)->ifindex;
 	return 1;
 }
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -360,6 +360,45 @@ void zebra_nhg_depends_walk_resolved_nexthops(struct nhg_hash_entry *nhe,
 						 &zebra_nhg_is_fully_resolved);
 }
 
+static int nexthop_set_flag(struct nexthop *nexthop, void *flag)
+{
+	SET_FLAG(nexthop->flags, *((int *)flag));
+
+	return NHG_WALK_CONTINUE;
+}
+
+static int nexthop_unset_flag(struct nexthop *nexthop, void *flag)
+{
+	UNSET_FLAG(nexthop->flags, *((int *)flag));
+
+	return NHG_WALK_CONTINUE;
+}
+
+void zebra_nhg_depends_set_all_nexthops_flag(struct nhg_hash_entry *nhe,
+					     int flag)
+{
+	zebra_nhg_depends_walk_nexthops(nhe, &nexthop_set_flag, &flag);
+}
+
+void zebra_nhg_depends_unset_all_nexthops_flag(struct nhg_hash_entry *nhe,
+					       int flag)
+{
+	zebra_nhg_depends_walk_nexthops(nhe, &nexthop_unset_flag, &flag);
+}
+
+void zebra_nhg_depends_set_all_resolved_nexthops_flag(
+	struct nhg_hash_entry *nhe, int flag)
+{
+	zebra_nhg_depends_walk_resolved_nexthops(nhe, &nexthop_set_flag, &flag);
+}
+
+void zebra_nhg_depends_unset_all_resolved_nexthops_flag(
+	struct nhg_hash_entry *nhe, int flag)
+{
+	zebra_nhg_depends_walk_resolved_nexthops(nhe, &nexthop_unset_flag,
+						 &flag);
+}
+
 struct nhg_hash_entry *zebra_nhg_lookup_id(uint32_t id)
 {
 	struct nhg_hash_entry lookup = {};
@@ -562,6 +601,17 @@ bool zebra_nhg_hash_id_equal(const void *arg1, const void *arg2)
 	const struct nhg_hash_entry *nhe2 = arg2;
 
 	return nhe1->id == nhe2->id;
+}
+
+/* lib/nexthop manipulation functions */
+void zebra_nhg_nexthop_set_flag(struct nhg_hash_entry *nhe, int flag)
+{
+	SET_FLAG((zebra_nhg_nexthop(nhe))->flags, flag);
+}
+
+void zebra_nhg_nexthop_unset_flag(struct nhg_hash_entry *nhe, int flag)
+{
+	UNSET_FLAG((zebra_nhg_nexthop(nhe))->flags, flag);
 }
 
 static int zebra_nhg_process_grp(struct nexthop_group *nhg,

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -263,6 +263,51 @@ static void zebra_nhg_depends_release(struct nhg_hash_entry *nhe)
 	}
 }
 
+static int zebra_nhg_is_fully_resolved(const struct nhg_hash_entry *nhe)
+{
+	if (zebra_nhg_depends_is_empty(nhe))
+		return 1;
+
+	return 0;
+}
+
+static int zebra_nhg_depends_walk_internal(
+	struct nhg_hash_entry *nhe,
+	int (*func)(struct nhg_hash_entry *, void *), void *arg,
+	int (*condition)(const struct nhg_hash_entry *nhe))
+{
+	struct nhg_connected *rb_node_dep = NULL;
+
+	frr_each_safe (nhg_connected_tree, &nhe->nhg_depends, rb_node_dep) {
+		if (zebra_nhg_depends_walk_internal(rb_node_dep->nhe, func, arg,
+						    condition)
+		    == NHG_WALK_ABORT)
+			return NHG_WALK_ABORT;
+	}
+
+	if (!condition || condition(nhe))
+		return func(nhe, arg);
+
+	return NHG_WALK_CONTINUE;
+}
+
+/* Walk depends tree/sub-trees */
+void zebra_nhg_depends_walk(struct nhg_hash_entry *nhe,
+			    int (*func)(struct nhg_hash_entry *, void *),
+			    void *arg)
+{
+	zebra_nhg_depends_walk_internal(nhe, func, arg, NULL);
+}
+
+/* Walk only fully resolved depends */
+void zebra_nhg_depends_walk_resolved(struct nhg_hash_entry *nhe,
+				     int (*func)(struct nhg_hash_entry *,
+						 void *),
+				     void *arg)
+{
+	zebra_nhg_depends_walk_internal(nhe, func, arg,
+					&zebra_nhg_is_fully_resolved);
+}
 
 struct nhg_hash_entry *zebra_nhg_lookup_id(uint32_t id)
 {

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -54,15 +54,6 @@ static inline vrf_id_t zebra_nhg_determine_vrf(const struct nexthop *nexthop)
 	return !vrf_is_backend_netns() ? VRF_DEFAULT : nexthop->vrf_id;
 }
 
-static inline bool zebra_nhg_is_group(const struct nhg_hash_entry *nhe)
-{
-	if (!zebra_nhg_depends_is_empty(nhe)
-	    && !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE))
-		return true;
-
-	return false;
-}
-
 /* Determines what the proper afi should be, given a lib/nexthop */
 static inline afi_t zebra_nhg_determine_afi(const struct nexthop *nexthop,
 					    afi_t route_afi)
@@ -679,6 +670,15 @@ void zebra_nhg_depends_unset_all_resolved_nexthops_flag(
 {
 	zebra_nhg_depends_walk_resolved_nexthops(nhe, &nexthop_unset_flag,
 						 &flag);
+}
+
+bool zebra_nhg_is_group(const struct nhg_hash_entry *nhe)
+{
+	if (!zebra_nhg_depends_is_empty(nhe)
+	    && !CHECK_FLAG(nhe->flags, NEXTHOP_GROUP_RECURSIVE))
+		return true;
+
+	return false;
 }
 
 struct nhg_hash_entry *zebra_nhg_lookup_id(uint32_t id)

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -304,6 +304,37 @@ static void zebra_nhg_depends_release(struct nhg_hash_entry *nhe)
 	}
 }
 
+/* matching helper struct */
+struct nhg_match {
+	uint32_t id;		      /* ID we are trying to get */
+	struct nhg_hash_entry *found; /* If found, set this pointer to it */
+};
+
+static int nhg_match_walker(struct nhg_hash_entry *nhe, void *arg)
+{
+	struct nhg_match *nhg_match = arg;
+
+	if (nhe->id == nhg_match->id) {
+		nhg_match->found = nhe;
+		return NHG_WALK_ABORT;
+	}
+
+	return NHG_WALK_CONTINUE;
+}
+
+/* Get depend in tree by ID */
+struct nhg_hash_entry *zebra_nhg_depends_get(struct nhg_hash_entry *nhe,
+					     uint32_t id)
+{
+	struct nhg_match nhg_match = {};
+
+	nhg_match.id = id;
+
+	zebra_nhg_depends_walk(nhe, &nhg_match_walker, &nhg_match);
+
+	return nhg_match.found;
+}
+
 static int zebra_nhg_is_group(const struct nhg_hash_entry *nhe)
 {
 	if (!zebra_nhg_depends_is_empty(nhe)

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -178,6 +178,19 @@ void zebra_nhg_depends_walk_resolved(struct nhg_hash_entry *nhe,
 						 void *),
 				     void *arg);
 
+/* Same but walks only on singleton nexthops (not groups) passing its
+ * lib/nexthop struct directly to `func`.
+ */
+void zebra_nhg_depends_walk_nexthops(struct nhg_hash_entry *nhe,
+				     int (*func)(struct nexthop *, void *),
+				     void *arg);
+
+/* Same as above but only calls `func` for resolved nexthops */
+void zebra_nhg_depends_walk_resolved_nexthops(struct nhg_hash_entry *nhe,
+					      int (*func)(struct nexthop *,
+							  void *),
+					      void *arg);
+
 /* Global control to disable use of kernel nexthops, if available. We can't
  * force the kernel to support nexthop ids, of course, but we can disable
  * zebra's use of them, for testing e.g. By default, if the kernel supports

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -153,6 +153,30 @@ struct nhg_ctx {
 	enum nhg_ctx_status status;
 };
 
+#define NHG_WALK_CONTINUE 0
+#define NHG_WALK_ABORT -1
+
+/* Walk over all depend NHEs in the trees.
+ *
+ * @nhe: starting tree root (`func` is ran with this as well)
+ *
+ * @func: function to call with each NHE (should return NHG_WALK_CONTINUE or
+ * NHG_WALK_ABORT)
+ *
+ * @arg: additional argument passed into every `func` call
+ *
+ * Note: removing items from the tree during walk is undefined behavior
+ */
+void zebra_nhg_depends_walk(struct nhg_hash_entry *nhe,
+			    int (*func)(struct nhg_hash_entry *, void *),
+			    void *arg);
+
+/* Same but `func` is only ran on fully resolved (singleton) NHE's */
+void zebra_nhg_depends_walk_resolved(struct nhg_hash_entry *nhe,
+				     int (*func)(struct nhg_hash_entry *,
+						 void *),
+				     void *arg);
+
 /* Global control to disable use of kernel nexthops, if available. We can't
  * force the kernel to support nexthop ids, of course, but we can disable
  * zebra's use of them, for testing e.g. By default, if the kernel supports

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -232,6 +232,13 @@ extern bool zebra_nhg_dependents_is_empty(const struct nhg_hash_entry *nhe);
 
 /* Lookup ID, doesn't create */
 extern struct nhg_hash_entry *zebra_nhg_lookup_id(uint32_t id);
+/* Lookup single nexthop, doesn't create
+ *
+ * route_afi must be given for blackhole nexthops (their AFI is the route AFI
+ * using). Otherwise, you can just pass AFI_UNSPEC.
+ */
+extern struct nhg_hash_entry *
+zebra_nhg_lookup_nexthop(const struct nexthop *nexthop, afi_t route_afi);
 
 /* Hash functions */
 extern uint32_t zebra_nhg_hash_key(const void *arg);

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -108,6 +108,7 @@ struct nhg_hash_entry {
 /* Was this one we created, either this session or previously? */
 #define ZEBRA_NHG_CREATED(NHE) ((NHE->type) == ZEBRA_ROUTE_NHG)
 
+#define zebra_nhg_nexthop(nhe) (nhe->nhg->nexthop)
 
 enum nhg_ctx_op_e {
 	NHG_CTX_OP_NONE = 0,

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -223,9 +223,19 @@ void zebra_nhg_hash_free(void *p);
 
 extern struct nhg_hash_entry *zebra_nhg_resolve(struct nhg_hash_entry *nhe);
 
+/*
+ * Depend APIs
+ */
 extern unsigned int zebra_nhg_depends_count(const struct nhg_hash_entry *nhe);
 extern bool zebra_nhg_depends_is_empty(const struct nhg_hash_entry *nhe);
 
+/* Get depend by ID in tree. Return NHE if found, otherwise NULL */
+extern struct nhg_hash_entry *zebra_nhg_depends_get(struct nhg_hash_entry *nhe,
+						    uint32_t id);
+
+/*
+ * Dependent APIs
+ */
 extern unsigned int
 zebra_nhg_dependents_count(const struct nhg_hash_entry *nhe);
 extern bool zebra_nhg_dependents_is_empty(const struct nhg_hash_entry *nhe);

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -417,6 +417,13 @@ extern void zebra_nhg_check_valid(struct nhg_hash_entry *nhe);
 /* Convert nhe depends to a grp context that can be passed around safely */
 extern uint8_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe,
 				 int size);
+/* Convert nhe depends to a lib/nexthop_group.
+ *
+ * Returns alloc'd lib/nexthop's that caller is responsible for freeing
+ */
+extern unsigned int
+zebra_nhg_nhe2nexthop_group(struct nexthop_group *to_nhg,
+			    struct nhg_hash_entry *from_nhe);
 
 /* Dataplane install/uninstall */
 extern void zebra_nhg_install_kernel(struct nhg_hash_entry *nhe);

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -190,6 +190,19 @@ void zebra_nhg_depends_walk_resolved_nexthops(struct nhg_hash_entry *nhe,
 					      int (*func)(struct nexthop *,
 							  void *),
 					      void *arg);
+/* Set all nexthops in NHE tree's flag */
+void zebra_nhg_depends_set_all_nexthops_flag(struct nhg_hash_entry *nhe,
+					     int flag);
+/* Unset all nexthops in NHE tree's flag */
+void zebra_nhg_depends_unset_all_nexthops_flag(struct nhg_hash_entry *nhe,
+					       int flag);
+/* Set all fully resolved nexthops in NHE tree's flag */
+void zebra_nhg_depends_set_all_resolved_nexthops_flag(
+	struct nhg_hash_entry *nhe, int flag);
+
+/* Unset all fully resolved nexthops in NHE tree's flag */
+void zebra_nhg_depends_unset_all_resolved_nexthops_flag(
+	struct nhg_hash_entry *nhe, int flag);
 
 /* Global control to disable use of kernel nexthops, if available. We can't
  * force the kernel to support nexthop ids, of course, but we can disable
@@ -226,6 +239,10 @@ extern uint32_t zebra_nhg_id_key(const void *arg);
 
 extern bool zebra_nhg_hash_equal(const void *arg1, const void *arg2);
 extern bool zebra_nhg_hash_id_equal(const void *arg1, const void *arg2);
+
+/* Functions for easily manupulating data on lib/nexthop inside NHEs */
+extern void zebra_nhg_nexthop_set_flag(struct nhg_hash_entry *nhe, int flag);
+extern void zebra_nhg_nexthop_unset_flag(struct nhg_hash_entry *nhe, int flag);
 
 /*
  * Process a context off of a queue.

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -285,6 +285,9 @@ extern struct nhg_hash_entry *zebra_nhg_depends_get(struct nhg_hash_entry *nhe,
  */
 extern bool zebra_nhg_dependents_is_empty(const struct nhg_hash_entry *nhe);
 
+/* Is this NHE a group (non-singleton, non-recursive) */
+extern bool zebra_nhg_is_group(const struct nhg_hash_entry *nhe);
+
 /* Lookup ID, doesn't create */
 extern struct nhg_hash_entry *zebra_nhg_lookup_id(uint32_t id);
 

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -232,13 +232,22 @@ extern bool zebra_nhg_dependents_is_empty(const struct nhg_hash_entry *nhe);
 
 /* Lookup ID, doesn't create */
 extern struct nhg_hash_entry *zebra_nhg_lookup_id(uint32_t id);
-/* Lookup single nexthop, doesn't create
+
+/* Single lib/nexthop APIs
+ *
+ * handles recursive nexthops as well.
  *
  * route_afi must be given for blackhole nexthops (their AFI is the route AFI
  * using). Otherwise, you can just pass AFI_UNSPEC.
  */
+
+/* Lookup only, no create */
 extern struct nhg_hash_entry *
 zebra_nhg_lookup_nexthop(const struct nexthop *nexthop, afi_t route_afi);
+
+/* Find/Create */
+extern struct nhg_hash_entry *
+zebra_nhg_find_nexthop(const struct nexthop *nexthop, afi_t route_afi);
 
 /* Hash functions */
 extern uint32_t zebra_nhg_hash_key(const void *arg);

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -190,6 +190,18 @@ void zebra_nhg_depends_walk_resolved_nexthops(struct nhg_hash_entry *nhe,
 					      int (*func)(struct nexthop *,
 							  void *),
 					      void *arg);
+
+/* Same as above but only calls `func` for nexthops with specified flag */
+void zebra_nhg_depends_walk_nexthops_with_flag(
+	struct nhg_hash_entry *nhe, int flag,
+	int (*func)(struct nexthop *, void *), void *arg);
+
+/* Same as above but only calls `func` for resolved nexthops with specified flag
+ */
+void zebra_nhg_depends_walk_resolved_nexthops_with_flag(
+	struct nhg_hash_entry *nhe, int flag,
+	int (*func)(struct nexthop *, void *), void *arg);
+
 /* Set all nexthops in NHE tree's flag */
 void zebra_nhg_depends_set_all_nexthops_flag(struct nhg_hash_entry *nhe,
 					     int flag);
@@ -226,8 +238,43 @@ extern struct nhg_hash_entry *zebra_nhg_resolve(struct nhg_hash_entry *nhe);
 /*
  * Depend APIs
  */
-extern unsigned int zebra_nhg_depends_count(const struct nhg_hash_entry *nhe);
+/* Number of depends, NOT including self */
+extern unsigned int zebra_nhg_depends_num(struct nhg_hash_entry *nhe);
+/* Number of resolved depends, NOT including self */
+extern unsigned int zebra_nhg_depends_resolved_num(struct nhg_hash_entry *nhe);
 extern bool zebra_nhg_depends_is_empty(const struct nhg_hash_entry *nhe);
+
+/* How many singleton lib/nexthops are in the tree, INCLUDING self if not group.
+ *
+ * We include self here because otherwise a single fully resolved nexthop
+ * passed to these functions would always return 0.
+ *
+ * With just counting the depends above it makes since to not count the
+ * starting root. With counting singleton lib/nexthops, it doesn't.
+ */
+extern unsigned int zebra_nhg_depends_nexthop_num(struct nhg_hash_entry *nhe);
+/* How many fully resolved singleton nexthops are in the tree */
+extern unsigned int
+zebra_nhg_depends_resolved_nexthop_num(struct nhg_hash_entry *nhe);
+/* How many singleton nexthops have this flag set? */
+extern unsigned int
+zebra_nhg_depends_nexthop_num_has_flag(struct nhg_hash_entry *nhe, int flag);
+/* How many fully resolved singleton nexthops have this flag set? */
+extern unsigned int
+zebra_nhg_depends_resolved_nexthop_num_has_flag(struct nhg_hash_entry *nhe,
+						int flag);
+
+/* Does the specified singleton nexthop exist in the depend tree?
+ *
+ * If found, return containing NHE, otherwise NULL.
+ */
+extern struct nhg_hash_entry *
+zebra_nhg_depends_nexthop_exists(struct nhg_hash_entry *nhe,
+				 const struct nexthop *nexthop);
+/* Same as above, but ignores labels when comparing */
+extern struct nhg_hash_entry *
+zebra_nhg_depends_nexthop_exists_ignore_labels(struct nhg_hash_entry *nhe,
+					       const struct nexthop *nexthop);
 
 /* Get depend by ID in tree. Return NHE if found, otherwise NULL */
 extern struct nhg_hash_entry *zebra_nhg_depends_get(struct nhg_hash_entry *nhe,
@@ -236,8 +283,6 @@ extern struct nhg_hash_entry *zebra_nhg_depends_get(struct nhg_hash_entry *nhe,
 /*
  * Dependent APIs
  */
-extern unsigned int
-zebra_nhg_dependents_count(const struct nhg_hash_entry *nhe);
 extern bool zebra_nhg_dependents_is_empty(const struct nhg_hash_entry *nhe);
 
 /* Lookup ID, doesn't create */

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -113,24 +113,24 @@ struct nhg_hash_entry {
 /* Macro for looping over top-level (non-recursive) NHEs
  *
  * EX)
- * 	1:
- * 		-> 2:
- * 			-> 3
- * 		-> 4
- * 		-> 5:
- * 			-> 6
- * 		-> 7
+ *      1:
+ *              -> 2:
+ *                      -> 3
+ *              -> 4
+ *              -> 5:
+ *                      -> 6
+ *              -> 7
  *
- * 	for (2,4,5,7)
+ *      for (2,4,5,7)
  *
  * It will also handle the case of being a passed a singleton NHE (i.e. not a
  * real group). If so, it just loops once over that singleton NHE.
  *
  * Ex)
- * 	1: (recursive singleton)
- * 		-> 2
+ *      1: (recursive singleton)
+ *              -> 2
  *
- * 	for (1)
+ *      for (1)
  *
  *
  * Note Well: These are non-safe macros (do not remove from list while
@@ -140,22 +140,22 @@ struct nhg_hash_entry {
  * Macro Explaination:
  *
  * init:
- * 	- The first ternary is used to force iter as NULL since we use it in the
- * loop condtional. It will always evaluate down the first branch since we are
- * setting it to NULL.
- * 	- Set rb_node_dep to the first depend of the tree.
+ *      - The first ternary is used to force iter as NULL since we use it in the
+ *      loop condtional. It will always evaluate down the first branch since we
+ *      are setting it to NULL.
+ *      - Set rb_node_dep to the first depend of the tree.
  *
  * loop condition:
- * 	- if something is set in rb_node_dep, it found an item in the tree and
- * so we use that to set the iter.
- *  	- otherwise, we may have been passed a singleton NHE. If thats the case,
- * check to make sure we haven't iterated already (!iter). If we haven't check
- * to see if the parent is indeed a group. If its not, then we will just be
- * iterating once on the Parent's NHE so set iter to that.
+ *      - if something is set in rb_node_dep, it found an item in the tree and
+ *      so we use that to set the iter.
+ *      - otherwise, we may have been passed a singleton NHE. If thats the case,
+ *      check to make sure we haven't iterated already (!iter). If we haven't
+ *      check to see if the parent is indeed a group. If its not, then we will
+ *      just be iterating once on the Parent's NHE so set iter to that.
  *
  * iteration:
- * 	- get the next item in the tree. rb_node_dep may be NULL if we were
- * passed a singleton NHE into this macro, so use the safe version.
+ *      - get the next item in the tree. rb_node_dep may be NULL if we were
+ *      passed a singleton NHE into this macro, so use the safe version.
  *
  */
 #define zebra_nhg_each(parent, iter)                                           \

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -193,15 +193,6 @@ int zebra_check_addr(const struct prefix *p)
 	return 1;
 }
 
-/**
- * copy_nexthop - copy a nexthop to the rib structure.
- */
-void route_entry_copy_nexthops(struct route_entry *re, struct nexthop *nh)
-{
-	assert(!re->nhe->nhg->nexthop);
-	copy_nexthops(&re->nhe->nhg->nexthop, nh, NULL);
-}
-
 static void route_entry_attach_ref(struct route_entry *re,
 				   struct nhg_hash_entry *new)
 {

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2391,7 +2391,6 @@ static void rib_addnode(struct route_node *rn,
 void rib_unlink(struct route_node *rn, struct route_entry *re)
 {
 	rib_dest_t *dest;
-	struct nhg_hash_entry *nhe = NULL;
 
 	assert(rn && re);
 
@@ -2406,12 +2405,7 @@ void rib_unlink(struct route_node *rn, struct route_entry *re)
 	if (dest->selected_fib == re)
 		dest->selected_fib = NULL;
 
-	if (re->nhe_id) {
-		nhe = zebra_nhg_lookup_id(re->nhe_id);
-		if (nhe)
-			zebra_nhg_decrement_ref(nhe);
-	} else if (re->nhe->nhg)
-		nexthop_group_delete(&re->nhe->nhg);
+	zebra_nhg_decrement_ref(re->nhe);
 
 	nexthops_free(re->fib_ng.nexthop);
 

--- a/zebra/zebra_snmp.c
+++ b/zebra/zebra_snmp.c
@@ -285,8 +285,8 @@ static void check_replace(struct route_node *np2, struct route_entry *re2,
 		return;
 	}
 
-	if (in_addr_cmp((uint8_t *)&(*re)->nhe->nhg->nexthop->gate.ipv4,
-			(uint8_t *)&re2->nhe->nhg->nexthop->gate.ipv4)
+	if (in_addr_cmp((uint8_t *)&(zebra_nhg_nexthop((*re)->nhe))->gate.ipv4,
+			(uint8_t *)&(zebra_nhg_nexthop(re2->nhe))->gate.ipv4)
 	    <= 0)
 		return;
 
@@ -371,10 +371,12 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 			if (!in_addr_cmp(&(*np)->p.u.prefix,
 					 (uint8_t *)&dest)) {
 				RNODE_FOREACH_RE (*np, *re) {
-					if (!in_addr_cmp((uint8_t *)&(*re)->nhe
-							 ->nhg->nexthop
-							 ->gate.ipv4,
-							 (uint8_t *)&nexthop))
+					if (!in_addr_cmp(
+						    (uint8_t *)&(
+							    zebra_nhg_nexthop(
+								    (*re)->nhe))
+							    ->gate.ipv4,
+						    (uint8_t *)&nexthop))
 						if (proto
 						    == proto_trans((*re)->type))
 							return;
@@ -406,8 +408,10 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 				    || ((policy == policy2) && (proto < proto2))
 				    || ((policy == policy2) && (proto == proto2)
 					&& (in_addr_cmp(
-						    (uint8_t *)&re2->nhe
-						    ->nhg->nexthop->gate.ipv4,
+						    (uint8_t *)&(
+							    zebra_nhg_nexthop(
+								    re2->nhe))
+							    ->gate.ipv4,
 						    (uint8_t *)&nexthop)
 					    >= 0)))
 					check_replace(np2, re2, np, re);
@@ -432,7 +436,7 @@ static void get_fwtable_route_node(struct variable *v, oid objid[],
 	{
 		struct nexthop *nexthop;
 
-		nexthop = (*re)->nhe->nhg->nexthop;
+		nexthop = zebra_nhg_nexthop((*re)->nhe);
 		if (nexthop) {
 			pnt = (uint8_t *)&nexthop->gate.ipv4;
 			for (i = 0; i < 4; i++)
@@ -462,7 +466,7 @@ static uint8_t *ipFwTable(struct variable *v, oid objid[], size_t *objid_len,
 	if (!np)
 		return NULL;
 
-	nexthop = re->nhe->nhg->nexthop;
+	nexthop = zebra_nhg_nexthop(re->nhe);
 	if (!nexthop)
 		return NULL;
 


### PR DESCRIPTION
This set of patches does two things:
	1) Converts all of zebra nexthop manipulation/walking to be accessed through `zebra_nhg.c` APIs.
	2) Converts all of zebra to use the hierarchical Nexthop Group tree
	
Hierarchical Nexthop Group Tree
===============================
see `zebra_nhg.h`

The hierarchical tree was introduce with kernel nexthop object/nexthop caching pathches as a future
enhancement possibility for zebra. This set of patches makes use of it.

Basically, it is a seperation from the linked list nexthop group in lib, into hierarchical RB trees
so we can see ALL of the nexthops in the group or what its resolved to and ALL of its dependents (its rparents and group owners).

The lib/nexthop_group has a limitation in that it only allows for a nexthop to have one recursive rparent. This doesn't make sense with shared nexthop groups. A nexthop may be in 100 groups and be the resolution point for 100 more.

Futher, with using the tree exclusively in zebra, we will be able to do things like nexthop group short circuting and improve nexthop tracking by sending interface down events up the tree to nexthops pointing out them or resolved to them.

Functionally, the tree looks like this:
```
letters = nexthop nodes in the tree

3-way ECMP (A is a group with B,C,D nexthops):
A:
	-B
	-C
	-D

Recursive Resolution (A is recursively resovled to B):
A:
	-B

3-Way ECMP with D also being recursively resolved:
A:
	-B
	-C
	-D:
		-E
```

So, with these patches we move to where everything in zebra operates on this heirarchical tree rather than iterating over `->next` or `->resolved` in the lib structures.

Outside of zebra, we will continue to use the lib/nexthop_group code paths everywhere because it makes sense for now. Most dataplanes and upperlevel protocols have no reason to think of nexthop group as SHARED so the lib/nexthop_group APIs don't have that limitation.

Basically, it looks like this:
```
On ingress into zebra main thread we convert to the tree structure.

On egress into zebra dataplane or back to upper level protocols we convert back to the lib/nexthop_group structure.
```

NOTE:
I did not include modifications for the nexthop resolution code path in these patches as that is complex enough it deserves a seperate PR.

In the future with changes to the resolution path, we may also be able to simplify some of the code in lib/nexthop_group since we know its not going to be used for resolution.

TODO Still Before this PR Can be Merged:
- [x] Document the heirarchical tree in dev guide
- [ ] Document all the zebra_nhg APIs in dev guides so people know how to use them in zebra
- [ ] Might as well Document the lib/nexthop_group APIs in dev guide while I am at it