### PR TITLE
babeld: GCC complaining about no return in non-void function

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -409,6 +409,7 @@ babel_main_loop(struct thread *thread)
     }
 
     assert(0); /* this line should never be reach */
+    return 0;
 }
 
 static void


### PR DESCRIPTION
The babel_main_loop function did not have a return for
a non-void function.  For some reason gcc is starting to complain
about this now.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>