### PR TITLE
bgpd: Show the real reason why the peer is failed

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -578,7 +578,8 @@ const char *const peer_down_str[] = {"",
 			       "Waiting for VRF to be initialized",
 			       "No AFI/SAFI activated for peer",
 			       "AS Set config change",
-			       "Waiting for peer OPEN"};
+			       "Waiting for peer OPEN",
+			       "Reached received prefix count"};
 
 static int bgp_graceful_restart_timer_expire(struct thread *thread)
 {
@@ -1512,6 +1513,10 @@ int bgp_start(struct peer *peer)
 				 "%s [FSM] Trying to start suppressed peer"
 				 " - this is never supposed to happen!",
 				 peer->host);
+		if (CHECK_FLAG(peer->flags, PEER_FLAG_SHUTDOWN))
+			peer->last_reset = PEER_DOWN_USER_SHUTDOWN;
+		else if (CHECK_FLAG(peer->sflags, PEER_STATUS_PREFIX_OVERFLOW))
+			peer->last_reset = PEER_DOWN_PFX_COUNT;
 		return -1;
 	}
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1351,6 +1351,7 @@ struct peer {
 #define PEER_DOWN_NOAFI_ACTIVATED       30 /* No AFI/SAFI activated for peer */
 #define PEER_DOWN_AS_SETS_REJECT        31 /* Reject routes with AS_SET */
 #define PEER_DOWN_WAITING_OPEN          32 /* Waiting for open to succeed */
+#define PEER_DOWN_PFX_COUNT             33 /* Reached received prefix count */
 	/*
 	 * Remember to update peer_down_str in bgp_fsm.c when you add
 	 * a new value to the last_reset reason


### PR DESCRIPTION
If the peer was shutdown locally, it doesn't show up as admin. shutdown.
Instead it's treated as "Waiting for peer OPEN".

The same applies to when the peer reaches maximum-prefix count.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>