### PR TITLE
Print out vrf name as well as id

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -329,19 +329,22 @@ static int bgp_bfd_dest_update(ZAPI_CALLBACK_ARGS)
 				&remote_cbit, vrf_id);
 
 	if (BGP_DEBUG(zebra, ZEBRA)) {
+		struct vrf *vrf;
 		char buf[2][PREFIX2STR_BUFFER];
+
+		vrf = vrf_lookup_by_id(vrf_id);
 		prefix2str(&dp, buf[0], sizeof(buf[0]));
 		if (ifp) {
 			zlog_debug(
-				"Zebra: vrf %u interface %s bfd destination %s %s %s",
-				vrf_id, ifp->name, buf[0],
-				bfd_get_status_str(status),
+				"Zebra: vrf %s(%u) interface %s bfd destination %s %s %s",
+				VRF_LOGNAME(vrf), vrf_id, ifp->name,
+				buf[0], bfd_get_status_str(status),
 				remote_cbit ? "(cbit on)" : "");
 		} else {
 			prefix2str(&sp, buf[1], sizeof(buf[1]));
 			zlog_debug(
-				"Zebra: vrf %u source %s bfd destination %s %s %s",
-				vrf_id, buf[1], buf[0],
+				"Zebra: vrf %s(%u) source %s bfd destination %s %s %s",
+				VRF_LOGNAME(vrf), vrf_id, buf[1], buf[0],
 				bfd_get_status_str(status),
 				remote_cbit ? "(cbit on)" : "");
 		}

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -1403,11 +1403,16 @@ void bgp_pbr_print_policy_route(struct bgp_pbr_entry_main *api)
 				ptr += sprintf(ptr,
 					  "@redirect ip nh %s", local_buff);
 			break;
-		case ACTION_REDIRECT:
+		case ACTION_REDIRECT: {
+			struct vrf *vrf;
+
+			vrf = vrf_lookup_by_id(api->actions[i].u.redirect_vrf);
 			INCREMENT_DISPLAY(ptr, nb_items);
-			ptr += sprintf(ptr, "@redirect vrf %u",
+			ptr += sprintf(ptr, "@redirect vrf %s(%u)",
+				       VRF_LOGNAME(vrf),
 				       api->actions[i].u.redirect_vrf);
 			break;
+		}
 		case ACTION_MARKING:
 			INCREMENT_DISPLAY(ptr, nb_items);
 			ptr += sprintf(ptr, "@set dscp %u",

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8867,8 +8867,13 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 		} else {
 			if (nexthop_vrfid == VRF_UNKNOWN)
 				vty_out(vty, " vrf ?");
-			else
-				vty_out(vty, " vrf %u", nexthop_vrfid);
+			else {
+				struct vrf *vrf;
+
+				vrf = vrf_lookup_by_id(nexthop_vrfid);
+				vty_out(vty, " vrf %s(%u)",
+					VRF_LOGNAME(vrf), nexthop_vrfid);
+			}
 		}
 	}
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -284,8 +284,11 @@ void bgp_router_id_zebra_bump(vrf_id_t vrf_id, const struct prefix *router_id)
 				 */
 				if (bgp->established_peers == 0) {
 					if (BGP_DEBUG(zebra, ZEBRA))
-						zlog_debug("RID change : vrf %u, RTR ID %s",
-					bgp->vrf_id, inet_ntoa(*addr));
+						zlog_debug(
+							"RID change : vrf %s(%u), RTR ID %s",
+							bgp->name_pretty,
+							bgp->vrf_id,
+							inet_ntoa(*addr));
 					bgp_router_id_set(bgp, addr, false);
 				}
 			}
@@ -304,8 +307,11 @@ void bgp_router_id_zebra_bump(vrf_id_t vrf_id, const struct prefix *router_id)
 				 */
 				if (bgp->established_peers == 0) {
 					if (BGP_DEBUG(zebra, ZEBRA))
-						zlog_debug("RID change : vrf %u, RTR ID %s",
-					bgp->vrf_id, inet_ntoa(*addr));
+						zlog_debug(
+							"RID change : vrf %s(%u), RTR ID %s",
+							bgp->name_pretty,
+							bgp->vrf_id,
+							inet_ntoa(*addr));
 					bgp_router_id_set(bgp, addr, false);
 				}
 			}

--- a/lib/if.c
+++ b/lib/if.c
@@ -811,27 +811,25 @@ DEFUN (show_address,
        "address\n"
        VRF_CMD_HELP_STR)
 {
-  int idx_vrf = 3;
-  struct listnode *node;
-  struct interface *ifp;
-  struct connected *ifc;
-  struct prefix *p;
-  vrf_id_t vrf_id = VRF_DEFAULT;
+	int idx_vrf = 3;
+	struct listnode *node;
+	struct interface *ifp;
+	struct connected *ifc;
+	struct prefix *p;
+	vrf_id_t vrf_id = VRF_DEFAULT;
 
-  if (argc > 2)
-    VRF_GET_ID (vrf_id, argv[idx_vrf]->arg);
+	if (argc > 2)
+		VRF_GET_ID (vrf_id, argv[idx_vrf]->arg);
 
-  FOR_ALL_INTERFACES (vrf, ifp)
-    {
-      for (ALL_LIST_ELEMENTS_RO (ifp->connected, node, ifc))
-	{
-	  p = ifc->address;
+	FOR_ALL_INTERFACES (vrf, ifp) {
+		for (ALL_LIST_ELEMENTS_RO (ifp->connected, node, ifc)) {
+			p = ifc->address;
 
-	  if (p->family == AF_INET)
-	    vty_out (vty, "%s/%d\n", inet_ntoa (p->u.prefix4), p->prefixlen);
+			if (p->family == AF_INET)
+				vty_out (vty, "%s/%d\n", inet_ntoa (p->u.prefix4), p->prefixlen);
+		}
 	}
-    }
-  return CMD_SUCCESS;
+	return CMD_SUCCESS;
 }
 
 DEFUN (show_address_vrf_all,
@@ -841,31 +839,29 @@ DEFUN (show_address_vrf_all,
        "address\n"
        VRF_ALL_CMD_HELP_STR)
 {
-  struct vrf *vrf;
-  struct listnode *node;
-  struct interface *ifp;
-  struct connected *ifc;
-  struct prefix *p;
+	struct vrf *vrf;
+	struct listnode *node;
+	struct interface *ifp;
+	struct connected *ifc;
+	struct prefix *p;
 
-  RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
-    {
-      if (RB_EMPTY (if_name_head, &vrf->ifaces_by_name))
-        continue;
+	RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
+	{
+		if (RB_EMPTY (if_name_head, &vrf->ifaces_by_name))
+			continue;
 
-      vty_out (vty, "\nVRF %u\n\n", vrf->vrf_id);
+		vty_out (vty, "\nVRF %u\n\n", vrf->vrf_id);
 
-      FOR_ALL_INTERFACES (vrf, ifp)
-        {
-          for (ALL_LIST_ELEMENTS_RO (ifp->connected, node, ifc))
-            {
-              p = ifc->address;
+		FOR_ALL_INTERFACES (vrf, ifp) {
+			for (ALL_LIST_ELEMENTS_RO (ifp->connected, node, ifc)) {
+				p = ifc->address;
 
-              if (p->family == AF_INET)
-                vty_out (vty, "%s/%d\n", inet_ntoa (p->u.prefix4), p->prefixlen);
-            }
-        }
-    }
-  return CMD_SUCCESS;
+				if (p->family == AF_INET)
+					vty_out (vty, "%s/%d\n", inet_ntoa (p->u.prefix4), p->prefixlen);
+			}
+		}
+	}
+	return CMD_SUCCESS;
 }
 #endif
 

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -114,6 +114,8 @@ extern struct vrf *vrf_get(vrf_id_t, const char *);
 extern const char *vrf_id_to_name(vrf_id_t vrf_id);
 extern vrf_id_t vrf_name_to_id(const char *);
 
+#define VRF_LOGNAME(V) V ? V->name : "Unknown"
+
 #define VRF_GET_ID(V, NAME, USE_JSON)                                          \
 	do {                                                                   \
 		struct vrf *_vrf;                                              \

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -351,11 +351,14 @@ static int rip_ifp_down(struct interface *ifp)
 	rip_interface_sync(ifp);
 	rip_if_down(ifp);
 
-	if (IS_RIP_DEBUG_ZEBRA)
+	if (IS_RIP_DEBUG_ZEBRA) {
+		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+
 		zlog_debug(
-			"interface %s vrf %u index %d flags %llx metric %d mtu %d is down",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			"interface %s vrf %s(%u) index %d flags %llx metric %d mtu %d is down",
+			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
+	}
 
 	return 0;
 }
@@ -363,11 +366,14 @@ static int rip_ifp_down(struct interface *ifp)
 /* Inteface link up message processing */
 static int rip_ifp_up(struct interface *ifp)
 {
-	if (IS_RIP_DEBUG_ZEBRA)
+	if (IS_RIP_DEBUG_ZEBRA) {
+		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+
 		zlog_debug(
-			"interface %s vrf %u index %d flags %#llx metric %d mtu %d is up",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			"interface %s vrf %s(%u) index %d flags %#llx metric %d mtu %d is up",
+			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
+	}
 
 	rip_interface_sync(ifp);
 
@@ -388,11 +394,13 @@ static int rip_ifp_create(struct interface *ifp)
 {
 	rip_interface_sync(ifp);
 
-	if (IS_RIP_DEBUG_ZEBRA)
+	if (IS_RIP_DEBUG_ZEBRA) {
+		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
 		zlog_debug(
-			"interface add %s vrf %u index %d flags %#llx metric %d mtu %d",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			"interface add %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
+			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
+	}
 
 	/* Check if this interface is RIP enabled or not.*/
 	rip_enable_apply(ifp);
@@ -413,14 +421,16 @@ static int rip_ifp_create(struct interface *ifp)
 
 static int rip_ifp_destroy(struct interface *ifp)
 {
+	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+
 	rip_interface_sync(ifp);
 	if (if_is_up(ifp)) {
 		rip_if_down(ifp);
 	}
 
 	zlog_info(
-		"interface delete %s vrf %u index %d flags %#llx metric %d mtu %d",
-		ifp->name, ifp->vrf_id, ifp->ifindex,
+		"interface delete %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
+		ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
 		(unsigned long long)ifp->flags, ifp->metric, ifp->mtu);
 
 	return 0;
@@ -437,9 +447,14 @@ int rip_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 	if (!ifp)
 		return 0;
 
-	if (IS_RIP_DEBUG_ZEBRA)
-		zlog_debug("interface %s VRF change vrf_id %u new vrf id %u",
-			   ifp->name, vrf_id, new_vrf_id);
+	if (IS_RIP_DEBUG_ZEBRA) {
+		struct vrf *vrf = vrf_lookup_by_id(vrf_id);
+		struct vrf *nvrf = vrf_lookup_by_id(new_vrf_id);
+
+		zlog_debug("interface %s VRF change vrf %s(%u) new vrf %s(%u)",
+			   ifp->name, VRF_LOGNAME(vrf), vrf_id,
+			   VRF_LOGNAME(nvrf), new_vrf_id);
+	}
 
 	if_update_to_new_vrf(ifp, new_vrf_id);
 	rip_interface_sync(ifp);

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -198,11 +198,14 @@ static int ripng_if_down(struct interface *ifp)
 /* Inteface link up message processing. */
 static int ripng_ifp_up(struct interface *ifp)
 {
-	if (IS_RIPNG_DEBUG_ZEBRA)
+	if (IS_RIPNG_DEBUG_ZEBRA) {
+		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+
 		zlog_debug(
-			"interface up %s vrf %u index %d flags %llx metric %d mtu %d",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			"interface up %s vrf %s(%u) index %d flags %llx metric %d mtu %d",
+			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
+	}
 
 	ripng_interface_sync(ifp);
 
@@ -224,11 +227,14 @@ static int ripng_ifp_down(struct interface *ifp)
 	ripng_interface_sync(ifp);
 	ripng_if_down(ifp);
 
-	if (IS_RIPNG_DEBUG_ZEBRA)
+	if (IS_RIPNG_DEBUG_ZEBRA) {
+		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+
 		zlog_debug(
-			"interface down %s vrf %u index %d flags %#llx metric %d mtu %d",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			"interface down %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
+			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
+	}
 
 	return 0;
 }
@@ -238,11 +244,14 @@ static int ripng_ifp_create(struct interface *ifp)
 {
 	ripng_interface_sync(ifp);
 
-	if (IS_RIPNG_DEBUG_ZEBRA)
+	if (IS_RIPNG_DEBUG_ZEBRA) {
+		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+
 		zlog_debug(
-			"RIPng interface add %s vrf %u index %d flags %#llx metric %d mtu %d",
-			ifp->name, ifp->vrf_id, ifp->ifindex,
+			"RIPng interface add %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
+			ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
 			(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
+	}
 
 	/* Check is this interface is RIP enabled or not.*/
 	ripng_enable_apply(ifp);
@@ -258,14 +267,16 @@ static int ripng_ifp_create(struct interface *ifp)
 
 static int ripng_ifp_destroy(struct interface *ifp)
 {
+	struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+
 	ripng_interface_sync(ifp);
 	if (if_is_up(ifp)) {
 		ripng_if_down(ifp);
 	}
 
 	zlog_info(
-		"interface delete %s vrf %u index %d flags %#llx metric %d mtu %d",
-		ifp->name, ifp->vrf_id, ifp->ifindex,
+		"interface delete %s vrf %s(%u) index %d flags %#llx metric %d mtu %d",
+		ifp->name, VRF_LOGNAME(vrf), ifp->vrf_id, ifp->ifindex,
 		(unsigned long long)ifp->flags, ifp->metric, ifp->mtu6);
 
 	return 0;
@@ -282,9 +293,14 @@ int ripng_interface_vrf_update(ZAPI_CALLBACK_ARGS)
 	if (!ifp)
 		return 0;
 
-	if (IS_RIPNG_DEBUG_ZEBRA)
-		zlog_debug("interface %s VRF change vrf_id %u new vrf id %u",
-			   ifp->name, vrf_id, new_vrf_id);
+	if (IS_RIPNG_DEBUG_ZEBRA) {
+		struct vrf *vrf = vrf_lookup_by_id(ifp->vrf_id);
+		struct vrf *nvrf = vrf_lookup_by_id(new_vrf_id);
+
+		zlog_debug("interface %s VRF change vrf %s(%u) new vrf %s(%u)",
+			   ifp->name, VRF_LOGNAME(vrf), vrf_id,
+			   VRF_LOGNAME(nvrf), new_vrf_id);
+	}
 
 	if_update_to_new_vrf(ifp, new_vrf_id);
 	ripng_interface_sync(ifp);

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -339,9 +339,10 @@ void zebra_redistribute_add(ZAPI_HANDLER_ARGS)
 
 	if (IS_ZEBRA_DEBUG_EVENT)
 		zlog_debug(
-			"%s: client proto %s afi=%d, wants %s, vrf %u, instance=%d",
+			"%s: client proto %s afi=%d, wants %s, vrf %s(%u), instance=%d",
 			__func__, zebra_route_string(client->proto), afi,
-			zebra_route_string(type), zvrf_id(zvrf), instance);
+			zebra_route_string(type), VRF_LOGNAME(zvrf->vrf),
+			zvrf_id(zvrf), instance);
 
 	if (afi == 0 || afi >= AFI_MAX) {
 		flog_warn(EC_ZEBRA_REDISTRIBUTE_UNKNOWN_AF,
@@ -368,8 +369,10 @@ void zebra_redistribute_add(ZAPI_HANDLER_ARGS)
 		if (!vrf_bitmap_check(client->redist[afi][type],
 				      zvrf_id(zvrf))) {
 			if (IS_ZEBRA_DEBUG_EVENT)
-				zlog_debug("%s: setting vrf %u redist bitmap",
-					   __func__, zvrf_id(zvrf));
+				zlog_debug(
+					"%s: setting vrf %s(%u) redist bitmap",
+					__func__, VRF_LOGNAME(zvrf->vrf),
+					zvrf_id(zvrf));
 			vrf_bitmap_set(client->redist[afi][type],
 				       zvrf_id(zvrf));
 			zebra_redistribute(client, type, 0, zvrf_id(zvrf), afi);

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1946,6 +1946,7 @@ static void zread_table_manager_connect(struct zserv *client,
 	struct stream *s;
 	uint8_t proto;
 	uint16_t instance;
+	struct vrf *vrf = vrf_lookup_by_id(vrf_id);
 
 	s = msg;
 
@@ -1961,8 +1962,9 @@ static void zread_table_manager_connect(struct zserv *client,
 		zsend_table_manager_connect_response(client, vrf_id, 1);
 		return;
 	}
-	zlog_notice("client %d with vrf %u instance %u connected as %s",
-		    client->sock, vrf_id, instance, zebra_route_string(proto));
+	zlog_notice("client %d with vrf %s(%u) instance %u connected as %s",
+		    client->sock, VRF_LOGNAME(vrf), vrf_id, instance,
+		    zebra_route_string(proto));
 	client->proto = proto;
 	client->instance = instance;
 

--- a/zebra/zebra_ptm.c
+++ b/zebra/zebra_ptm.c
@@ -441,15 +441,17 @@ static void if_bfd_session_update(struct interface *ifp, struct prefix *dp,
 				dp->prefixlen, ifp->name,
 				bfd_get_status_str(status));
 		} else {
+			struct vrf *vrf = vrf_lookup_by_id(vrf_id);
+
 			zlog_debug(
 				"MESSAGE: ZEBRA_INTERFACE_BFD_DEST_UPDATE %s/%d "
-				"with src %s/%d and vrf %u %s event",
+				"with src %s/%d and vrf %s(%u) %s event",
 				inet_ntop(dp->family, &dp->u.prefix, buf[0],
 					  INET6_ADDRSTRLEN),
 				dp->prefixlen,
 				inet_ntop(sp->family, &sp->u.prefix, buf[1],
 					  INET6_ADDRSTRLEN),
-				sp->prefixlen, vrf_id,
+				sp->prefixlen, VRF_LOGNAME(vrf), vrf_id,
 				bfd_get_status_str(status));
 		}
 	}

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2408,13 +2408,14 @@ void _route_entry_dump(const char *func, union prefixconstptr pp,
 	char srcaddr[PREFIX_STRLEN];
 	char nhname[PREFIX_STRLEN];
 	struct nexthop *nexthop;
+	struct vrf *vrf = vrf_lookup_by_id(re->vrf_id);
 
-	zlog_debug("%s: dumping RE entry %p for %s%s%s vrf %u", func,
+	zlog_debug("%s: dumping RE entry %p for %s%s%s vrf %s(%u)", func,
 		   (const void *)re, prefix2str(pp, straddr, sizeof(straddr)),
 		   is_srcdst ? " from " : "",
 		   is_srcdst ? prefix2str(src_pp, srcaddr, sizeof(srcaddr))
 			     : "",
-		   re->vrf_id);
+		   VRF_LOGNAME(vrf), re->vrf_id);
 	zlog_debug("%s: uptime == %lu, type == %u, instance == %d, table == %d",
 		   straddr, (unsigned long)re->uptime, re->type, re->instance,
 		   re->table);


### PR DESCRIPTION
The vrf_id is not enough context for people.  Use the
actual name of the vrf if you can.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>