### PR TITLE
zebra: add all ipv6 global addresses to RA messages

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -490,6 +490,10 @@ void connected_add_ipv6(struct interface *ifp, int flags, struct in6_addr *addr,
 	p->prefixlen = prefixlen;
 	ifc->address = (struct prefix *)p;
 
+	/* Add global ipv6 address to the RA prefix list */
+	if (!IN6_IS_ADDR_LINKLOCAL(&p->prefix))
+		rtadv_add_prefix(ifp->info, p);
+
 	if (dest) {
 		p = prefix_ipv6_new();
 		p->family = AF_INET6;
@@ -532,6 +536,10 @@ void connected_delete_ipv6(struct interface *ifp, struct in6_addr *address,
 	p.family = AF_INET6;
 	memcpy(&p.u.prefix6, address, sizeof(struct in6_addr));
 	p.prefixlen = prefixlen;
+
+	/* Delete global ipv6 address from RA prefix list */
+	if (!IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6))
+		rtadv_delete_prefix(ifp->info, &p);
 
 	if (dest) {
 		memset(&d, 0, sizeof(struct prefix));

--- a/zebra/rtadv.h
+++ b/zebra/rtadv.h
@@ -37,6 +37,9 @@ struct rtadv_prefix {
 	/* Prefix to be advertised. */
 	struct prefix_ipv6 prefix;
 
+	/* The prefix was manually/automatically defined. */
+	int AdvPrefixCreate;
+
 	/* The value to be placed in the Valid Lifetime in the Prefix */
 	uint32_t AdvValidLifetime;
 #define RTADV_VALID_LIFETIME 2592000
@@ -133,6 +136,17 @@ struct nd_opt_dnssl { /* DNS search list option [RFC8106 5.2] */
 
 #endif /* HAVE_RTADV */
 
+/*
+ * ipv6 nd prefixes can be manually defined, derived from the kernel interface
+ * configs or both.  If both, manual flag/timer settings are used.
+ */
+enum ipv6_nd_prefix_source {
+	PREFIX_SRC_NONE = 0,
+	PREFIX_SRC_MANUAL,
+	PREFIX_SRC_AUTO,
+	PREFIX_SRC_BOTH,
+};
+
 typedef enum {
 	RA_ENABLE = 0,
 	RA_SUPPRESS,
@@ -145,6 +159,8 @@ extern void rtadv_stop_ra_all(void);
 extern void rtadv_cmd_init(void);
 extern void zebra_interface_radv_disable(ZAPI_HANDLER_ARGS);
 extern void zebra_interface_radv_enable(ZAPI_HANDLER_ARGS);
+extern void rtadv_add_prefix(struct zebra_if *zif, const struct prefix_ipv6 *p);
+extern void rtadv_delete_prefix(struct zebra_if *zif, const struct prefix *p);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
RFC 4861 states that ipv6 RA messages sent out an interface should
contain all global ipv6 addresses on that interface. This fix adds
that capability.  To override the default flags and timer settings
for a particular prefix, the existing "ipv6 nd prefix ..." command
should be used via vtysh under the appropriate interface.

Ticket: CM-20363
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>