### PR TITLE
*: encode zapi labels message using nexthops

### DIFF
--- a/ldpd/ldp_zebra.c
+++ b/ldpd/ldp_zebra.c
@@ -106,7 +106,7 @@ static int
 ldp_zebra_send_mpls_labels(int cmd, struct kroute *kr)
 {
 	struct zapi_labels zl = {};
-	struct zapi_nexthop_label *znh;
+	struct zapi_nexthop *znh;
 
 	if (kr->local_label < MPLS_LABEL_RESERVED_MAX ||
 	    kr->remote_label == NO_LABEL)
@@ -143,16 +143,14 @@ ldp_zebra_send_mpls_labels(int cmd, struct kroute *kr)
 	znh = &zl.nexthops[0];
 	switch (kr->af) {
 	case AF_INET:
-		znh->family = AF_INET;
-		znh->address.ipv4 = kr->nexthop.v4;
+		znh->gate.ipv4 = kr->nexthop.v4;
 		if (kr->ifindex)
 			znh->type = NEXTHOP_TYPE_IPV4_IFINDEX;
 		else
 			znh->type = NEXTHOP_TYPE_IPV4;
 		break;
 	case AF_INET6:
-		znh->family = AF_INET6;
-		znh->address.ipv6 = kr->nexthop.v6;
+		znh->gate.ipv6 = kr->nexthop.v6;
 		if (kr->ifindex)
 			znh->type = NEXTHOP_TYPE_IPV6_IFINDEX;
 		else
@@ -162,7 +160,8 @@ ldp_zebra_send_mpls_labels(int cmd, struct kroute *kr)
 		break;
 	}
 	znh->ifindex = kr->ifindex;
-	znh->label = kr->remote_label;
+	znh->label_num = 1;
+	znh->labels[0] = kr->remote_label;
 
 	return zebra_send_mpls_labels(zclient, cmd, &zl);
 }

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -2604,7 +2604,7 @@ int zebra_send_mpls_labels(struct zclient *zclient, int cmd,
 
 int zapi_labels_encode(struct stream *s, int cmd, struct zapi_labels *zl)
 {
-	struct zapi_nexthop_label *znh;
+	struct zapi_nexthop *znh;
 
 	stream_reset(s);
 
@@ -2633,20 +2633,8 @@ int zapi_labels_encode(struct stream *s, int cmd, struct zapi_labels *zl)
 	for (int i = 0; i < zl->nexthop_num; i++) {
 		znh = &zl->nexthops[i];
 
-		stream_putc(s, znh->type);
-		stream_putw(s, znh->family);
-		switch (znh->family) {
-		case AF_INET:
-			stream_put_in_addr(s, &znh->address.ipv4);
-			break;
-		case AF_INET6:
-			stream_write(s, (uint8_t *)&znh->address.ipv6, 16);
-			break;
-		default:
-			break;
-		}
-		stream_putl(s, znh->ifindex);
-		stream_putl(s, znh->label);
+		if (zapi_nexthop_encode(s, znh, 0) < 0)
+			return -1;
 	}
 
 	/* Put length at the first point of the stream. */
@@ -2657,7 +2645,7 @@ int zapi_labels_encode(struct stream *s, int cmd, struct zapi_labels *zl)
 
 int zapi_labels_decode(struct stream *s, struct zapi_labels *zl)
 {
-	struct zapi_nexthop_label *znh;
+	struct zapi_nexthop *znh;
 
 	memset(zl, 0, sizeof(*zl));
 
@@ -2721,21 +2709,8 @@ int zapi_labels_decode(struct stream *s, struct zapi_labels *zl)
 	for (int i = 0; i < zl->nexthop_num; i++) {
 		znh = &zl->nexthops[i];
 
-		STREAM_GETC(s, znh->type);
-		STREAM_GETW(s, znh->family);
-		switch (znh->family) {
-		case AF_INET:
-			STREAM_GET(&znh->address.ipv4.s_addr, s,
-				   IPV4_MAX_BYTELEN);
-			break;
-		case AF_INET6:
-			STREAM_GET(&znh->address.ipv6, s, 16);
-			break;
-		default:
-			break;
-		}
-		STREAM_GETL(s, znh->ifindex);
-		STREAM_GETL(s, znh->label);
+		if (zapi_nexthop_decode(s, znh, 0) < 0)
+			return -1;
 	}
 
 	return 0;

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -458,14 +458,6 @@ struct zapi_route {
 	uint32_t tableid;
 };
 
-struct zapi_nexthop_label {
-	enum nexthop_types_t type;
-	int family;
-	union g_addr address;
-	ifindex_t ifindex;
-	mpls_label_t label;
-};
-
 struct zapi_labels {
 	uint8_t message;
 #define ZAPI_LABELS_FTN      0x01
@@ -476,8 +468,9 @@ struct zapi_labels {
 		uint8_t type;
 		unsigned short instance;
 	} route;
+
 	uint16_t nexthop_num;
-	struct zapi_nexthop_label nexthops[MULTIPATH_NUM];
+	struct zapi_nexthop nexthops[MULTIPATH_NUM];
 };
 
 struct zapi_pw {

--- a/ospfd/ospf_sr.c
+++ b/ospfd/ospf_sr.c
@@ -609,7 +609,7 @@ static int compute_prefix_nhlfe(struct sr_prefix *srp)
 static int ospf_zebra_send_mpls_labels(int cmd, struct sr_nhlfe nhlfe)
 {
 	struct zapi_labels zl = {};
-	struct zapi_nexthop_label *znh;
+	struct zapi_nexthop *znh;
 
 	if (IS_DEBUG_OSPF_SR)
 		zlog_debug("    |-  %s LSP %u/%u for %s/%u via %u",
@@ -631,10 +631,10 @@ static int ospf_zebra_send_mpls_labels(int cmd, struct sr_nhlfe nhlfe)
 	zl.nexthop_num = 1;
 	znh = &zl.nexthops[0];
 	znh->type = NEXTHOP_TYPE_IPV4_IFINDEX;
-	znh->family = AF_INET;
-	znh->address.ipv4 = nhlfe.nexthop;
+	znh->gate.ipv4 = nhlfe.nexthop;
 	znh->ifindex = nhlfe.ifindex;
-	znh->label = nhlfe.label_out;
+	znh->label_num = 1;
+	znh->labels[0] = nhlfe.label_out;
 
 	return zebra_send_mpls_labels(zclient, cmd, &zl);
 }

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1823,17 +1823,17 @@ static void zread_mpls_labels_add(ZAPI_HANDLER_ARGS)
 		return;
 
 	for (int i = 0; i < zl.nexthop_num; i++) {
-		struct zapi_nexthop_label *znh;
+		struct zapi_nexthop *znh;
 
 		znh = &zl.nexthops[i];
-		mpls_lsp_install(zvrf, zl.type, zl.local_label, 1, &znh->label,
-				 znh->type, &znh->address, znh->ifindex);
+		mpls_lsp_install(zvrf, zl.type, zl.local_label, 1, znh->labels,
+				 znh->type, &znh->gate, znh->ifindex);
 
 		if (CHECK_FLAG(zl.message, ZAPI_LABELS_FTN))
 			mpls_ftn_update(1, zvrf, zl.type, &zl.route.prefix,
-					znh->type, &znh->address, znh->ifindex,
+					znh->type, &znh->gate, znh->ifindex,
 					zl.route.type, zl.route.instance,
-					znh->label);
+					znh->labels[0]);
 	}
 }
 
@@ -1866,19 +1866,20 @@ static void zread_mpls_labels_delete(ZAPI_HANDLER_ARGS)
 
 	if (zl.nexthop_num > 0) {
 		for (int i = 0; i < zl.nexthop_num; i++) {
-			struct zapi_nexthop_label *znh;
+			struct zapi_nexthop *znh;
 
 			znh = &zl.nexthops[i];
 			mpls_lsp_uninstall(zvrf, zl.type, zl.local_label,
-					   znh->type, &znh->address,
+					   znh->type, &znh->gate,
 					   znh->ifindex);
 
 			if (CHECK_FLAG(zl.message, ZAPI_LABELS_FTN))
 				mpls_ftn_update(0, zvrf, zl.type,
 						&zl.route.prefix, znh->type,
-						&znh->address, znh->ifindex,
+						&znh->gate, znh->ifindex,
 						zl.route.type,
-						zl.route.instance, znh->label);
+						zl.route.instance,
+						znh->labels[0]);
 		}
 	} else {
 		mpls_lsp_uninstall_all_vrf(zvrf, zl.type, zl.local_label);
@@ -1924,17 +1925,18 @@ static void zread_mpls_labels_replace(ZAPI_HANDLER_ARGS)
 				   zl.route.type, zl.route.instance);
 
 	for (int i = 0; i < zl.nexthop_num; i++) {
-		struct zapi_nexthop_label *znh;
+		struct zapi_nexthop *znh;
 
 		znh = &zl.nexthops[i];
-		mpls_lsp_install(zvrf, zl.type, zl.local_label, 1, &znh->label,
-				 znh->type, &znh->address, znh->ifindex);
+		mpls_lsp_install(zvrf, zl.type, zl.local_label,
+				 1, znh->labels, znh->type,
+				 &znh->gate, znh->ifindex);
 
 		if (CHECK_FLAG(zl.message, ZAPI_LABELS_FTN)) {
 			mpls_ftn_update(1, zvrf, zl.type, &zl.route.prefix,
-					znh->type, &znh->address, znh->ifindex,
+					znh->type, &znh->gate, znh->ifindex,
 					zl.route.type, zl.route.instance,
-					znh->label);
+					znh->labels[0]);
 		}
 	}
 }


### PR DESCRIPTION
Use the zapi_nexthop struct with the mpls_labels zapi messages instead of the special-purpose (and more limited) nexthop struct that was being used. This lets us remove some special-purpose code, and will add some more flexibility with those messages.