### PR TITLE
bgpd: Add a couple more spaces for output on MsgRcvd and MsgSent

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8979,7 +8979,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					vty_out(vty, "EstdCnt DropCnt ResetTime Reason\n");
 				else
 					vty_out(vty,
-					"V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd\n");
+					"V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd\n");
 			}
 		}
 
@@ -9104,7 +9104,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
 					vty_out(vty, "%*s", max_neighbor_width - len,
 						" ");
 
-				vty_out(vty, "4 %10u %7u %7u %8" PRIu64 " %4d %4zd %8s",
+				vty_out(vty, "4 %10u %9u %9u %8" PRIu64 " %4d %4zd %8s",
 					peer->as, PEER_TOTAL_RX(peer),
 					PEER_TOTAL_TX(peer), peer->version[afi][safi],
 					0, peer->obuf->count,

--- a/tests/topotests/all-protocol-startup/r1/show_bgp_ipv6_summary.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_bgp_ipv6_summary.ref
@@ -3,6 +3,6 @@ BGP table version 1
 RIB entries 1, using XXXX bytes of memory
 Peers 2, using XXXX KiB of memory
 
-Neighbor         V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
-fc00:0:0:8::1000 4        100       0       0        0    0    0    never       Active
-fc00:0:0:8::2000 4        200       0       0        0    0    0    never       Active
+Neighbor         V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
+fc00:0:0:8::1000 4        100         0         0        0    0    0    never       Active
+fc00:0:0:8::2000 4        200         0         0        0    0    0    never       Active

--- a/tests/topotests/all-protocol-startup/r1/show_ip_bgp_summary.ref
+++ b/tests/topotests/all-protocol-startup/r1/show_ip_bgp_summary.ref
@@ -3,8 +3,8 @@ BGP table version 1
 RIB entries 1, using XXXX bytes of memory
 Peers 4, using XXXX KiB of memory
 
-Neighbor         V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
-192.168.7.10     4        100       0       0        0    0    0    never       Active
-192.168.7.20     4        200       0       0        0    0    0    never       Active
-fc00:0:0:8::1000 4        100       0       0        0    0    0    never       Active
-fc00:0:0:8::2000 4        200       0       0        0    0    0    never       Active
+Neighbor         V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
+192.168.7.10     4        100         0         0        0    0    0    never       Active
+192.168.7.20     4        200         0         0        0    0    0    never       Active
+fc00:0:0:8::1000 4        100         0         0        0    0    0    never       Active
+fc00:0:0:8::2000 4        200         0         0        0    0    0    never       Active


### PR DESCRIPTION
annie# show bgp ipv4 uni summ
BGP router identifier 192.168.201.136, local AS number 64539 vrf-id 0
BGP table version 22458946
RIB entries 1458006, using 178 MiB of memory
Peers 4, using 68 KiB of memory

Neighbor               V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
45.33.5.119            4          0       0       0        0    0    0    never       Active
65.19.134.122          4      15096 4611832  108292        0    0    0 6d22h55m       800670
107.13.46.23           4          0       0       0        0    0    0    never      Connect
robot(192.168.201.139) 4      64540 11159975 11365599        0    0    0 05w2d05h      Connect

Total number of neighbors 4

On very busy systems The column output for MsgRcvd and MsgSent can quickly move past 7 columns.
Add a couple more to allow for even display.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>