### PR TITLE
lib: Fix so that `--enable-pcreposix` actually compiles

### DIFF
--- a/lib/frrstr.c
+++ b/lib/frrstr.c
@@ -25,7 +25,11 @@
 #include <string.h>
 #include <ctype.h>
 #include <sys/types.h>
+#ifdef HAVE_LIBPCREPOSIX
+#include <pcreposix.h>
+#else
 #include <regex.h>
+#endif /* HAVE_LIBPCREPOSIX */
 
 #include "frrstr.h"
 #include "memory.h"

--- a/lib/frrstr.h
+++ b/lib/frrstr.h
@@ -22,7 +22,12 @@
 #define _FRRSTR_H_
 
 #include <sys/types.h>
+#include <sys/types.h>
+#ifdef HAVE_LIBPCREPOSIX
+#include <pcreposix.h>
+#else
 #include <regex.h>
+#endif /* HAVE_LIBPCREPOSIX */
 #include <stdbool.h>
 
 #include "vector.h"

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -23,7 +23,12 @@
 
 #include <lib/version.h>
 #include <sys/types.h>
+#include <sys/types.h>
+#ifdef HAVE_LIBPCREPOSIX
+#include <pcreposix.h>
+#else
 #include <regex.h>
+#endif /* HAVE_LIBPCREPOSIX */
 #include <stdio.h>
 
 #include "linklist.h"

--- a/lib/vty.h
+++ b/lib/vty.h
@@ -22,7 +22,11 @@
 #define _ZEBRA_VTY_H
 
 #include <sys/types.h>
+#ifdef HAVE_LIBPCREPOSIX
+#include <pcreposix.h>
+#else
 #include <regex.h>
+#endif /* HAVE_LIBPCREPOSIX */
 
 #include "thread.h"
 #include "log.h"


### PR DESCRIPTION
The `--enable-pcreposix` configure option was not actually compiling
properly.  Follow pre-existing pattern for inclusion of regex.h
or the pcreposix.h header.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>