### PR TITLE
doc: Document attribute-unchanged directive

### DIFF
--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -1205,6 +1205,14 @@ Configuring Peers
    keyword `all` is specified the modification is done also for routes learned
    via iBGP.
 
+.. index:: neighbor PEER attribute-unchanged [{as-path|next-hop|med}]
+.. clicmd:: neighbor PEER attribute-unchanged [{as-path|next-hop|med}]
+
+   This command specifies attributes to be left unchanged for advertisements
+   sent to a peer. Use this to leave the next-hop unchanged in ipv6
+   configurations, as the route-map directive to leave the next-hop unchanged
+   is only available for ipv4.
+
 .. index:: [no] neighbor PEER update-source <IFNAME|ADDRESS>
 .. clicmd:: [no] neighbor PEER update-source <IFNAME|ADDRESS>
 


### PR DESCRIPTION
This directive was undocumented, but is the way to configure the next-hop to be left unchanged for ipv6 setups (in ipv4, a route-map with `set next-hop unchanged` works fine, but this is unavailable for ipv6) .
Signed-off-by: Raphael Bauduin <rb@raphinou.com>