### PR TITLE
zebra: fix missing rtadv stub functions

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -2479,4 +2479,25 @@ void rtadv_cmd_init(void)
 {
 	/* Empty.*/;
 }
+
+void rtadv_add_prefix(struct zebra_if *zif, const struct prefix_ipv6 *p)
+{
+	/* Empty.*/;
+}
+
+void rtadv_delete_prefix(struct zebra_if *zif, const struct prefix *p)
+{
+	/* Empty.*/;
+}
+
+void rtadv_stop_ra(struct interface *ifp)
+{
+	/* Empty.*/;
+}
+
+void rtadv_stop_ra_all(void)
+{
+	/* Empty.*/;
+}
+
 #endif /* HAVE_RTADV */


### PR DESCRIPTION
Add in a few missing stub route-advert functions; these are needed to build frr with v6 route adverts disabled.