### PR TITLE
Small test speedups

### DIFF
--- a/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
+++ b/tests/topotests/bgp_multiview_topo1/test_bgp_multiview_topo1.py
@@ -151,8 +151,7 @@ def setup_module(module):
         net['r%s' % i].startRouter()
 
     # Starting PE Hosts and init ExaBGP on each of them
-    print('*** Starting BGP on all 8 Peers in 10s')
-    sleep(10)
+    print('*** Starting BGP on all 8 Peers')
     for i in range(1, 9):
         net['peer%s' % i].cmd('cp %s/exabgp.env /etc/exabgp/exabgp.env' % thisDir)
         net['peer%s' % i].cmd('cp %s/peer%s/* /etc/exabgp/' % (thisDir, i))
@@ -191,7 +190,6 @@ def test_router_running():
 
     print("\n\n** Check if FRR/Quagga is running on each Router node")
     print("******************************************\n")
-    sleep(5)
 
     # Starting Routers
     for i in range(1, 2):
@@ -215,7 +213,7 @@ def test_bgp_converge():
     # Wait for BGP to converge  (All Neighbors in either Full or TwoWay State)
     print("\n\n** Verify for BGP to converge")
     print("******************************************\n")
-    timeout = 60
+    timeout = 125
     while timeout > 0:
         print("Timeout in %s: " % timeout),
         sys.stdout.flush()
@@ -240,9 +238,9 @@ def test_bgp_converge():
         bgpStatus = net['r%s' % i].cmd('vtysh -c "show ip bgp view %s summary"' % view)
         assert False, "BGP did not converge:\n%s" % bgpStatus
 
-    # Wait for an extra 30s to announce all routes
-    print('Waiting 30s for routes to be announced');
-    sleep(30)
+    # Wait for an extra 5s to announce all routes
+    print('Waiting 5s for routes to be announced');
+    sleep(5)
     
     print("BGP converged.")
 

--- a/tests/topotests/rip-topo1/r1/rip_status.ref
+++ b/tests/topotests/rip-topo1/r1/rip_status.ref
@@ -1,6 +1,6 @@
 Routing Protocol is "rip"
-  Sending updates every 30 seconds with +/-50%, next due in XX seconds
-  Timeout after 180 seconds, garbage collect after 120 seconds
+  Sending updates every 5 seconds with +/-50%, next due in XX seconds
+  Timeout after 180 seconds, garbage collect after 5 seconds
   Outgoing update filter list for all interface is not set
   Incoming update filter list for all interface is not set
   Default redistribution metric is 1

--- a/tests/topotests/rip-topo1/r1/ripd.conf
+++ b/tests/topotests/rip-topo1/r1/ripd.conf
@@ -1,6 +1,7 @@
 log file ripd.log
 !
 router rip
+ timers basic 5 180 5
  version 2
  network 193.1.1.0/26
 !

--- a/tests/topotests/rip-topo1/r2/rip_status.ref
+++ b/tests/topotests/rip-topo1/r2/rip_status.ref
@@ -1,6 +1,6 @@
 Routing Protocol is "rip"
-  Sending updates every 30 seconds with +/-50%, next due in XX seconds
-  Timeout after 180 seconds, garbage collect after 120 seconds
+  Sending updates every 5 seconds with +/-50%, next due in XX seconds
+  Timeout after 180 seconds, garbage collect after 5 seconds
   Outgoing update filter list for all interface is not set
   Incoming update filter list for all interface is not set
   Default redistribution metric is 1

--- a/tests/topotests/rip-topo1/r2/ripd.conf
+++ b/tests/topotests/rip-topo1/r2/ripd.conf
@@ -3,6 +3,7 @@ log file ripd.log
 !
 router rip
  version 2
+ timers basic 5 180 5
  network 193.1.1.0/26
  network 193.1.2.0/24
 !

--- a/tests/topotests/rip-topo1/r3/rip_status.ref
+++ b/tests/topotests/rip-topo1/r3/rip_status.ref
@@ -1,6 +1,6 @@
 Routing Protocol is "rip"
-  Sending updates every 30 seconds with +/-50%, next due in XX seconds
-  Timeout after 180 seconds, garbage collect after 120 seconds
+  Sending updates every 5 seconds with +/-50%, next due in XX seconds
+  Timeout after 180 seconds, garbage collect after 5 seconds
   Outgoing update filter list for all interface is not set
   Incoming update filter list for all interface is not set
   Default redistribution metric is 1

--- a/tests/topotests/rip-topo1/r3/ripd.conf
+++ b/tests/topotests/rip-topo1/r3/ripd.conf
@@ -3,6 +3,7 @@ log file ripd.log
 !
 router rip
  version 2
+ timers basic 5 180 5
  redistribute connected
  redistribute static
  network 193.1.2.0/24

--- a/tests/topotests/rip-topo1/test_rip_topo1.py
+++ b/tests/topotests/rip-topo1/test_rip_topo1.py
@@ -144,7 +144,6 @@ def test_router_running():
 
     print("\n\n** Check if FRR/Quagga is running on each Router node")
     print("******************************************\n")
-    sleep(5)
 
     # Make sure that all daemons are running
     for i in range(1, 4):
@@ -168,8 +167,8 @@ def test_converge_protocols():
     print("\n\n** Waiting for protocols convergence")
     print("******************************************\n")
 
-    # Not really implemented yet - just sleep 60 secs for now
-    sleep(60)
+    # Not really implemented yet - just sleep 11 secs for now
+    sleep(11)
 
     # Make sure that all daemons are still running
     for i in range(1, 4):

--- a/tests/topotests/ripng-topo1/r1/ripng_status.ref
+++ b/tests/topotests/ripng-topo1/r1/ripng_status.ref
@@ -1,6 +1,6 @@
 Routing Protocol is "RIPng"
-  Sending updates every 30 seconds with +/-50%, next due in XX seconds
-  Timeout after 180 seconds, garbage collect after 120 seconds
+  Sending updates every 5 seconds with +/-50%, next due in XX seconds
+  Timeout after 180 seconds, garbage collect after 5 seconds
   Outgoing update filter list for all interface is not set
   Incoming update filter list for all interface is not set
   Default redistribution metric is 1

--- a/tests/topotests/ripng-topo1/r1/ripngd.conf
+++ b/tests/topotests/ripng-topo1/r1/ripngd.conf
@@ -5,6 +5,7 @@ debug ripng packet
 debug ripng zebra
 !
 router ripng
+ timers basic 5 180 5
  network fc00:5::/64
 !
 line vty

--- a/tests/topotests/ripng-topo1/r2/ripng_status.ref
+++ b/tests/topotests/ripng-topo1/r2/ripng_status.ref
@@ -1,6 +1,6 @@
 Routing Protocol is "RIPng"
-  Sending updates every 30 seconds with +/-50%, next due in XX seconds
-  Timeout after 180 seconds, garbage collect after 120 seconds
+  Sending updates every 5 seconds with +/-50%, next due in XX seconds
+  Timeout after 180 seconds, garbage collect after 5 seconds
   Outgoing update filter list for all interface is not set
   Incoming update filter list for all interface is not set
   Default redistribution metric is 1

--- a/tests/topotests/ripng-topo1/r2/ripngd.conf
+++ b/tests/topotests/ripng-topo1/r2/ripngd.conf
@@ -5,6 +5,7 @@ debug ripng packet
 debug ripng zebra
 !
 router ripng
+ timers basic 5 180 5
  network fc00:5::/64
  network fc00:6::/62
 !

--- a/tests/topotests/ripng-topo1/r3/ripng_status.ref
+++ b/tests/topotests/ripng-topo1/r3/ripng_status.ref
@@ -1,6 +1,6 @@
 Routing Protocol is "RIPng"
-  Sending updates every 30 seconds with +/-50%, next due in XX seconds
-  Timeout after 180 seconds, garbage collect after 120 seconds
+  Sending updates every 5 seconds with +/-50%, next due in XX seconds
+  Timeout after 180 seconds, garbage collect after 5 seconds
   Outgoing update filter list for all interface is not set
   Incoming update filter list for all interface is not set
   Default redistribution metric is 1

--- a/tests/topotests/ripng-topo1/r3/ripngd.conf
+++ b/tests/topotests/ripng-topo1/r3/ripngd.conf
@@ -5,6 +5,7 @@ debug ripng packet
 debug ripng zebra
 !
 router ripng
+ timers basic 5 180 5
  network fc00:6::/62
  redistribute connected
  redistribute static

--- a/tests/topotests/ripng-topo1/test_ripng_topo1.py
+++ b/tests/topotests/ripng-topo1/test_ripng_topo1.py
@@ -145,7 +145,6 @@ def test_router_running():
 
     print("\n\n** Check if FRR/Quagga is running on each Router node")
     print("******************************************\n")
-    sleep(5)
 
     # Starting Routers
     for i in range(1, 4):
@@ -169,8 +168,8 @@ def test_converge_protocols():
     print("\n\n** Waiting for protocols convergence")
     print("******************************************\n")
 
-    # Not really implemented yet - just sleep 60 secs for now
-    sleep(60)
+    # Not really implemented yet - just sleep 11 secs for now
+    sleep(11)
 
     # Make sure that all daemons are running
     for i in range(1, 4):


### PR DESCRIPTION
In a couple of tests:

reduce timers for basic operation to be much more aggressive
reduce long sleeps to respect new basic timers.