### PR TITLE
[7.3] zebra: Fix rtadv stubs

### DIFF
--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -2399,4 +2399,15 @@ void rtadv_cmd_init(void)
 {
 	/* Empty.*/;
 }
+
+void rtadv_stop_ra(struct interface *ifp)
+{
+	/* Empty.*/;
+}
+
+void rtadv_stop_ra_all(void)
+{
+	/* Empty.*/;
+}
+
 #endif /* HAVE_RTADV */


### PR DESCRIPTION
[7.3 version] Stubs are used when frr is built without route-advert support; a couple of apis were missing, causing builds to fail.

Should fix #5829 for 7.3
