### PR TITLE
lib: fix route-map coverity scan issue

### DIFF
--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -914,6 +914,7 @@ static struct route_map_index *route_map_index_new(void)
 /* Free route map index. */
 void route_map_index_delete(struct route_map_index *index, int notify)
 {
+	struct routemap_hook_context *rhc;
 	struct route_map_rule *rule;
 
 	QOBJ_UNREG(index);
@@ -923,8 +924,8 @@ void route_map_index_delete(struct route_map_index *index, int notify)
 			   index->map->name, index->pref);
 
 	/* Free route map northbound hook contexts. */
-	while (!TAILQ_EMPTY(&index->rhclist))
-		routemap_hook_context_free(TAILQ_FIRST(&index->rhclist));
+	while ((rhc = TAILQ_FIRST(&index->rhclist)) != NULL)
+		routemap_hook_context_free(rhc);
 
 	/* Free route match. */
 	while ((rule = index->match_list.head) != NULL)


### PR DESCRIPTION
Coverity Scan Issue
-------------------------

```
*** CID 1491240:  Memory - illegal accesses  (USE_AFTER_FREE)
/lib/routemap.c: 930 in route_map_index_delete()
924             if (rmap_debug)
925                     zlog_debug("Deleting route-map %s sequence %d",
926                                index->map->name, index->pref);
927     
928             /* Free route map northbound hook contexts. */
929             while (!TAILQ_EMPTY(&index->rhclist))
>>>     CID 1491240:  Memory - illegal accesses  (USE_AFTER_FREE)
>>>     Calling "routemap_hook_context_free" dereferences freed pointer "index->rhclist.tqh_first".
930                     routemap_hook_context_free(TAILQ_FIRST(&index->rhclist));
931     
932             /* Free route match. */
933             while ((rule = index->match_list.head) != NULL)
934                     route_map_rule_delete(&index->match_list, rule);
935     
```


Commit Message
----------------------

Use better TAILQ free idiom to avoid coverity scan warnings. This fixes
the coverity scan issue 1491240 .

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>