### PR TITLE
bgpd: Add a better breadcrumb for when bgp is missconfiged

### DIFF
--- a/bgpd/bgp_errors.c
+++ b/bgpd/bgp_errors.c
@@ -457,6 +457,12 @@ static struct log_ref ferr_bgp_err[] = {
 		.suggestion = "Gather data and open a Issue so that this developmental escape can be fixed, the peer should have been reset",
 	},
 	{
+		.code = EC_BGP_ROUTER_ID_SAME,
+		.title = "BGP has detected a duplicate router id during collision resolution",
+		.description = "As part of normal collision detection for opening a connection to a peer, BGP has detected that the remote peer's router-id is the same as ours",
+		.suggestion = "Change one of the two router-id's",
+	},
+	{
 		.code = END_FERR,
 	}
 };

--- a/bgpd/bgp_errors.h
+++ b/bgpd/bgp_errors.h
@@ -98,6 +98,7 @@ enum bgp_log_refs {
 	EC_BGP_CAPABILITY_UNKNOWN,
 	EC_BGP_INVALID_NEXTHOP_LENGTH,
 	EC_BGP_DOPPELGANGER_CONFIG,
+	EC_BGP_ROUTER_ID_SAME,
 };
 
 extern void bgp_error_init(void);

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1007,6 +1007,11 @@ static int bgp_collision_detect(struct peer *new, struct in_addr remote_id)
 					return -1;
 				}
 			else {
+				if (ntohl(peer->local_id.s_addr) ==
+				    ntohl(remote_id.s_addr))
+					flog_err(EC_BGP_ROUTER_ID_SAME, "Peer's router-id %s is the same as ours",
+						 inet_ntoa(remote_id));
+
 				/* 3. Otherwise, the local system closes newly
 				   created
 				   BGP connection (the one associated with the


### PR DESCRIPTION
Currently During bgp open collision resolution if both
the router-id's are the same, we correctly follow
the RFC and close the connection.  The problem is of course
that there is no notification of the error in configuration
to the end user other than a subtle open debug message.

Explicitly call out the miss-configuration as an error message
as that this miss-config took several hours of debugging to notice.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>