### PR TITLE
isisd: do not disable circuit on ifdown

### DIFF
--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -1386,7 +1386,6 @@ int isis_if_delete_hook(struct interface *ifp)
 	if (ifp && ifp->info) {
 		circuit = ifp->info;
 		isis_csm_state_change(IF_DOWN_FROM_Z, circuit, circuit->area);
-		isis_csm_state_change(ISIS_DISABLE, circuit, circuit->area);
 	}
 
 	return 0;


### PR DESCRIPTION
when zebra detects that an interface is gone, notify the circuit but do
not disable it - the interface is still configured until it isn't.

Without this fix, removing the interface in the kernel and then immediately removing
the `ip|ipv6 router isis XXX` line from that interface's configuration would cause an assertion.

Backtrace:
```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff6ad442a in __GI_abort () at abort.c:89
#2  0x00007ffff6acbe67 in __assert_fail_base (fmt=<optimized out>, assertion=assertion@entry=0x5555555c982e "circuit == NULL", file=file@entry=0x5555555c97f8 "/purgatori/repos/dm-builder/code/frr/isisd/isi
s_csm.c", line=line@entry=78, function=function@entry=0x5555555c9980 <__PRETTY_FUNCTION__.15278> "isis_csm_state_change") at assert.c:92
#3  0x00007ffff6acbf12 in __GI___assert_fail (assertion=0x5555555c982e "circuit == NULL", file=0x5555555c97f8 "/purgatori/repos/dm-builder/code/frr/isisd/isis_csm.c", line=78, function=0x5555555c9980 <__PR
ETTY_FUNCTION__.15278> "isis_csm_state_change") at assert.c:101
#4  0x00005555555712c8 in isis_csm_state_change (event=3, circuit=0x5555559a6990, arg=0x5555559a6990) at /purgatori/repos/dm-builder/code/frr/isisd/isis_csm.c:78
#5  0x0000555555570957 in isis_circuit_af_set (circuit=0x5555559a6990, ip_router=false, ipv6_router=false) at /purgatori/repos/dm-builder/code/frr/isisd/isis_circuit.c:1255
#6  0x00005555555a9e98 in lib_interface_isis_destroy (event=NB_EV_APPLY, dnode=0x5555559ac920) at /purgatori/repos/dm-builder/code/frr/isisd/isis_nb_config.c:1844
#7  0x00007ffff7b1a938 in nb_callback_configuration (event=NB_EV_APPLY, change=0x5555559aced0) at /purgatori/repos/dm-builder/code/frr/lib/northbound.c:841
#8  0x00007ffff7b1aeb0 in nb_transaction_process (event=NB_EV_APPLY, transaction=0x5555559acaa0) at /purgatori/repos/dm-builder/code/frr/lib/northbound.c:1003
#9  0x00007ffff7b1a49a in nb_candidate_commit_apply (transaction=0x5555559acaa0, save_transaction=false, transaction_id=0x0) at /purgatori/repos/dm-builder/code/frr/lib/northbound.c:708
#10 0x00007ffff7b1a587 in nb_candidate_commit (candidate=0x555555845470, client=NB_CLIENT_CLI, user=0x5555559aef80, save_transaction=false, comment=0x0, transaction_id=0x0) at /purgatori/repos/dm-builder/c
ode/frr/lib/northbound.c:738
#11 0x00007ffff7b206ea in nb_cli_apply_changes (vty=0x5555559aef80, xpath_base_fmt=0x0) at /purgatori/repos/dm-builder/code/frr/lib/northbound_cli.c:171
#12 0x00005555555b5a30 in no_ip_router_isis_magic (self=0x5555557fc000 <no_ip_router_isis_cmd>, vty=0x5555559aef80, argc=5, argv=0x5555559a90c0, ip=0x5555559aa0d0 "ip", tag=0x5555559a9220 "TEST") at /purga
tori/repos/dm-builder/code/frr/isisd/isis_cli.c:306
#13 0x00005555555ad815 in no_ip_router_isis (self=0x5555557fc000 <no_ip_router_isis_cmd>, vty=0x5555559aef80, argc=5, argv=0x5555559a90c0) at ./isisd/isis_cli_clippy.c:243
#14 0x00007ffff7ae2036 in cmd_execute_command_real (vline=0x5555559996e0, filter=FILTER_RELAXED, vty=0x5555559aef80, cmd=0x0) at /purgatori/repos/dm-builder/code/frr/lib/command.c:1076
#15 0x00007ffff7ae219a in cmd_execute_command (vline=0x5555559996e0, vty=0x5555559aef80, cmd=0x0, vtysh=0) at /purgatori/repos/dm-builder/code/frr/lib/command.c:1135
#16 0x00007ffff7ae2699 in cmd_execute (vty=0x5555559aef80, cmd=0x555555997a60 "no ip router isis TEST", matched=0x0, vtysh=0) at /purgatori/repos/dm-builder/code/frr/lib/command.c:1291
#17 0x00007ffff7b587a1 in vty_command (vty=0x5555559aef80, buf=0x555555997a60 "no ip router isis TEST") at /purgatori/repos/dm-builder/code/frr/lib/vty.c:516
#18 0x00007ffff7b5a48f in vty_execute (vty=0x5555559aef80) at /purgatori/repos/dm-builder/code/frr/lib/vty.c:1285
#19 0x00007ffff7b5bf92 in vtysh_read (thread=0x7fffffffdf60) at /purgatori/repos/dm-builder/code/frr/lib/vty.c:2119
#20 0x00007ffff7b52835 in thread_call (thread=0x7fffffffdf60) at /purgatori/repos/dm-builder/code/frr/lib/thread.c:1549
#21 0x00007ffff7b0c89b in frr_run (master=0x555555805590) at /purgatori/repos/dm-builder/code/frr/lib/libfrr.c:1064
#22 0x000055555556aeb1 in main (argc=11, argv=0x7fffffffe188, envp=0x7fffffffe1e8) at /purgatori/repos/dm-builder/code/frr/isisd/isis_main.c:267
```

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>