### PR TITLE
lib: don't allow to recurse inside route-map node

### DIFF
--- a/lib/routemap_cli.c
+++ b/lib/routemap_cli.c
@@ -1064,7 +1064,6 @@ void route_map_cli_init(void)
 	install_element(CONFIG_NODE, &no_route_map_all_cmd);
 
 	/* Install the on-match stuff */
-	install_element(RMAP_NODE, &route_map_cmd);
 	install_element(RMAP_NODE, &rmap_onmatch_next_cmd);
 	install_element(RMAP_NODE, &no_rmap_onmatch_next_cmd);
 	install_element(RMAP_NODE, &rmap_onmatch_goto_cmd);


### PR DESCRIPTION
Summary
---------------

This commit fixes the loading of configuration files with 8 or more route maps:

```
route-map rm-1 permit 5
route-map rm-1 deny 10
route-map rm-1 permit 15
 ! any config
!
route-map rm2 permit 5
route-map rm2 permit 10
route-map rm2 permit 15
route-map rm2 permit 20
route-map rm2 permit 25
route-map rm2 permit 30
!
! and so on
```

Failure message:

```
2020/02/19 20:13:24 BGP: [EC 100663331] nb_callback_configuration: error processing configuration change: error [validation error] event [validate] operation [modify] xpath [/frr-route-map:lib/route-map[name='rm-out-to-reflector']/entry[se
quence='10']/exit-policy]                                                                     
2020/02/19 20:13:24 BGP: [EC 100663337] nb_candidate_commit_prepare: failed to validate candidate configuration
% Reached maximum CLI depth (8)                                                                                                                                                                                                        
% Configuration failed: validation error.
```

Commit Message
---------------------------

vtysh should handle going back up one level to try the command, there is
no need to be able to recurse inside route-map.

This also fixes a problem with northbound hitting the XPath queue limit
of 8 nodes.

Signed-off-by: Rafael Zalamena <rzalamena@opensourcerouting.org>