### PR TITLE
Bgp set mtu

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -669,6 +669,7 @@ unsigned int attrhash_key_make(const void *p)
 	key = jhash(attr->mp_nexthop_local.s6_addr, IPV6_MAX_BYTELEN, key);
 	MIX3(attr->nh_ifindex, attr->nh_lla_ifindex, attr->distance);
 	MIX(attr->rmap_table_id);
+	MIX(attr->mtu);
 
 	return key;
 }

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -250,6 +250,9 @@ struct attr {
 
 	/* rmap set table */
 	uint32_t rmap_table_id;
+
+	/* route map set mtu */
+	uint32_t mtu;
 };
 
 /* rmap_change_flags definition */

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1237,6 +1237,11 @@ void bgp_zebra_announce(struct bgp_node *rn, struct prefix *p,
 		api.tableid = info->attr->rmap_table_id;
 	}
 
+	if (info->attr->mtu) {
+		SET_FLAG(api.message, ZAPI_MESSAGE_MTU);
+		api.mtu = info->attr->mtu;
+	}
+
 	/* Metric is currently based on the best-path only */
 	metric = info->attr->med;
 	for (mpinfo = info; mpinfo; mpinfo = bgp_path_info_mpath_next(mpinfo)) {

--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -314,6 +314,11 @@ Route Map Set Command
 
    Set the BGP table to a given table identifier
 
+.. index:: set mtu (1-9000)
+.. clicmd:: set mtu (1-9000)
+
+   Set the mtu of the route when installed into the kernel on linux.
+
 .. _route-map-call-command:
 
 Route Map Call Command

--- a/tests/topotests/bgp-route-map/test_route_map_topo1.py
+++ b/tests/topotests/bgp-route-map/test_route_map_topo1.py
@@ -577,6 +577,9 @@ def test_route_map_with_action_values_combination_of_prefix_action_p0(
                                     "prefix_lists":
                                         "pf_list_1_{}".format(addr_type)
                                 }
+                            },
+                            "set": {
+                                "mtu": 300
                             }
                         }
                     ]

--- a/tests/topotests/lib/common_config.py
+++ b/tests/topotests/lib/common_config.py
@@ -1212,6 +1212,7 @@ def create_route_maps(tgen, input_dict, build=False):
                         set_action = set_data.setdefault("set_action", None)
                         nexthop = set_data.setdefault("nexthop", None)
                         origin = set_data.setdefault("origin", None)
+			mtu = set_data.setdefault("mtu", None)
 
                         # Local Preference
                         if local_preference:
@@ -1281,6 +1282,10 @@ def create_route_maps(tgen, input_dict, build=False):
                         if weight:
                             rmap_data.append("set weight {}".format(
                                 weight))
+
+			if mtu:
+			    rmap_data.append("set mtu {}".format(mtu))
+
                         if ipv6_data:
                             nexthop = ipv6_data.setdefault("nexthop", None)
                             if nexthop:


### PR DESCRIPTION
Allow operator to use `set mtu XX` as part of a route-map and have that mtu installed into zebra and the kernel