### PR TITLE
zebra: reduce scope of XCALLOC for gr processing

### DIFF
--- a/zebra/zebra_gr.c
+++ b/zebra/zebra_gr.c
@@ -468,9 +468,7 @@ static int32_t zebra_gr_route_stale_delete_timer_expiry(struct thread *thread)
 		LOG_GR("%s: Client %s all starle routes processed", __func__,
 		       zebra_route_string(client->proto));
 
-		if (info->current_prefix != NULL)
-			XFREE(MTYPE_TMP, info->current_prefix);
-		info->current_prefix = NULL;
+		XFREE(MTYPE_TMP, info->current_prefix);
 		info->current_afi = 0;
 		zebra_gr_delete_stale_client(info);
 	}


### PR DESCRIPTION
Somewhat gnarly code flow here that might be leaking memory - can't tell
if it's a test artifact or not, but in any case this reduces the
situations in which we need to alloc a block.

And we don't need to check XCALLOC for success...
And we don't need to null check before XFREE...
Or set XFREE'd pointers to NULL...

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>