### PR TITLE
Make frr able to be built by gcc 10

### DIFF
--- a/pimd/pimd.c
+++ b/pimd/pimd.c
@@ -50,6 +50,7 @@ const char *const PIM_ALL_IGMP_ROUTERS = MCAST_ALL_IGMP_ROUTERS;
 DEFINE_MTYPE_STATIC(PIMD, ROUTER, "PIM Router information");
 
 struct pim_router *router = NULL;
+struct in_addr qpim_all_pim_routers_addr;
 
 void pim_prefix_list_update(struct prefix_list *plist)
 {

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -131,14 +131,14 @@
 #define PIM_UPDATE_SOURCE_DUP           -10
 #define PIM_GROUP_BAD_ADDR_MASK_COMBO   -11
 
-const char *const PIM_ALL_SYSTEMS;
-const char *const PIM_ALL_ROUTERS;
-const char *const PIM_ALL_PIM_ROUTERS;
-const char *const PIM_ALL_IGMP_ROUTERS;
+extern const char *const PIM_ALL_SYSTEMS;
+extern const char *const PIM_ALL_ROUTERS;
+extern const char *const PIM_ALL_PIM_ROUTERS;
+extern const char *const PIM_ALL_IGMP_ROUTERS;
 
 extern struct pim_router *router;
 extern struct zebra_privs_t pimd_privs;
-struct in_addr qpim_all_pim_routers_addr;
+extern struct in_addr qpim_all_pim_routers_addr;
 extern uint8_t qpim_ecmp_enable;
 extern uint8_t qpim_ecmp_rebalance_enable;
 


### PR DESCRIPTION
- Add extern modifier to some declarations in header file and move
qpim_all_pim_routers_addr definition to pimd/pimd.c

`GCC now defaults to -fno-common. As a result, global variable accesses
are more efficient on various targets. In C, global variables with
multiple tentative definitions now result in linker errors.`
Taken from https://gcc.gnu.org/gcc-10/changes.html