### PR TITLE
zebra: check for invalid family in ipset entry msg

### DIFF
--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -2511,6 +2511,19 @@ static inline void zread_ipset_entry(ZAPI_HANDLER_ARGS)
 		if (zpi.proto != 0)
 			zpi.filter_bm |= PBR_FILTER_PROTO;
 
+		if (!(zpi.dst.family == AF_INET
+		      || zpi.dst.family == AF_INET6)) {
+			zlog_warn("Unsupported PBR IP family: %s (%" PRIu8 ")",
+				  family2str(zpi.dst.family), zpi.dst.family);
+			goto stream_failure;
+		}
+		if (!(zpi.src.family == AF_INET
+		      || zpi.src.family == AF_INET6)) {
+			zlog_warn("Unsupported PBR IP family: %s (%" PRIu8 ")",
+				  family2str(zpi.src.family), zpi.src.family);
+			goto stream_failure;
+		}
+
 		/* calculate backpointer */
 		zpi.backpointer =
 			zebra_pbr_lookup_ipset_pername(ipset.ipset_name);


### PR DESCRIPTION
Fixes
```
    #5 0x7f9ff11e1e96 in raise /build/glibc-OTsEL5/glibc-2.27/signal/../sysdeps/unix/sysv/linux/raise.c:48
    #6 0x7f9ff11e3800 in abort /build/glibc-OTsEL5/glibc-2.27/stdlib/abort.c:79
    #7 0x7f9ff11d3399 in __assert_fail_base /build/glibc-OTsEL5/glibc-2.27/assert/assert.c:92
    #8 0x7f9ff11d3411 in __assert_fail /build/glibc-OTsEL5/glibc-2.27/assert/assert.c:101
    #9 0x7f9ff2995549 in prefix_hash_key /home/qlyoung/frr/lib/prefix.c
    #10 0x59f82a in zebra_pbr_ipset_entry_hash_key /home/qlyoung/frr/zebra/zebra_pbr.c:294:8
    #11 0x7f9ff2918c06 in hash_get /home/qlyoung/frr/lib/hash.c:138:8
    #12 0x5a1862 in zebra_pbr_add_ipset_entry /home/qlyoung/frr/zebra/zebra_pbr.c:635:8
    #13 0x6510f7 in zread_ipset_entry /home/qlyoung/frr/zebra/zapi_msg.c:2526:4
    #14 0x65271a in zserv_handle_commands /home/qlyoung/frr/zebra/zapi_msg.c:2709:2
```

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>