### PR TITLE
zebra: when FIB_OVERRIDE flag is set, update nexthop-tracking clients properly

### DIFF
--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -199,6 +199,10 @@ int nhrp_route_read(ZAPI_CALLBACK_ARGS)
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_SRCPFX))
 		return 0;
 
+	/* ignore our routes */
+	if (api.type == ZEBRA_ROUTE_NHRP)
+		return 0;
+
 	sockunion_family(&nexthop_addr) = AF_UNSPEC;
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP)) {
 		api_nh = &api.nexthops[0];

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -669,7 +669,8 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 						zebra_route_string(re->type));
 				continue;
 			}
-			if (!CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED)) {
+			if (!CHECK_FLAG(re->flags, ZEBRA_FLAG_SELECTED) &&
+			    !CHECK_FLAG(re->flags, ZEBRA_FLAG_FIB_OVERRIDE)) {
 				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 					zlog_debug(
 						"\tRoute Entry %s !selected",


### PR DESCRIPTION
The FIB_OVERRIDE flag can be used when one routing daemon wants to force its route to be installed, overriding zebra's normal rib processing logic. This is the case with NHRP, for example. But zebra's nexthop-tracking did not correctly report the status of these OVERRIDE routes to registered daemons, preventing them from seeing that a valid route was installed. We fix zebra's nexthop-tracking code to report the OVERRIDE routes properly.