### PR TITLE
Clang latest

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -793,7 +793,7 @@ static int assegments_parse(struct stream *s, size_t length,
 		if (head)
 			prev->next = seg;
 		else /* it's the first segment */
-			head = prev = seg;
+			head = seg;
 
 		for (i = 0; i < segh.length; i++)
 			seg->as[i] =

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -44,7 +44,7 @@ static int64_t bgp_clist_new_seq_get(struct community_list *list)
 	int64_t newseq;
 	struct community_entry *entry;
 
-	maxseq = newseq = 0;
+	maxseq = 0;
 
 	for (entry = list->head; entry; entry = entry->next) {
 		if (maxseq < entry->seq)

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1303,8 +1303,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 
 	/* Open option part parse. */
 	if (optlen != 0) {
-		if ((ret = bgp_open_option_parse(peer, optlen, &mp_capability))
-		    < 0)
+		if (bgp_open_option_parse(peer, optlen, &mp_capability) < 0)
 			return BGP_Stop;
 	} else {
 		if (bgp_debug_neighbor_events(peer))
@@ -1346,7 +1345,7 @@ static int bgp_open_receive(struct peer *peer, bgp_size_t size)
 		return BGP_Stop;
 
 	/* Get sockname. */
-	if ((ret = bgp_getsockname(peer)) < 0) {
+	if (bgp_getsockname(peer) < 0) {
 		flog_err_sys(EC_LIB_SOCKET,
 			     "%s: bgp_getsockname() failed for peer: %s",
 			     __FUNCTION__, peer->host);
@@ -1972,13 +1971,13 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 					} else
 						p_pnt = p_end;
 
-					if ((ok = (p_pnt < p_end)))
+					if (p_pnt < p_end)
 						orfp.ge =
 							*p_pnt++; /* value
 								     checked in
 								     prefix_bgp_orf_set()
 								     */
-					if ((ok = (p_pnt < p_end)))
+					if (p_pnt < p_end)
 						orfp.le =
 							*p_pnt++; /* value
 								     checked in

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1971,38 +1971,29 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 					} else
 						p_pnt = p_end;
 
+					/* val checked in prefix_bgp_orf_set */
 					if (p_pnt < p_end)
-						orfp.ge =
-							*p_pnt++; /* value
-								     checked in
-								     prefix_bgp_orf_set()
-								     */
+						orfp.ge = *p_pnt++;
+
+					/* val checked in prefix_bgp_orf_set */
 					if (p_pnt < p_end)
-						orfp.le =
-							*p_pnt++; /* value
-								     checked in
-								     prefix_bgp_orf_set()
-								     */
+						orfp.le = *p_pnt++;
+
 					if ((ok = (p_pnt < p_end)))
 						orfp.p.prefixlen = *p_pnt++;
-					orfp.p.family = afi2family(
-						afi); /* afi checked already  */
 
-					psize = PSIZE(
-						orfp.p.prefixlen); /* 0 if not
-								      ok */
-					if (psize
-					    > prefix_blen(
-						      &orfp.p)) /* valid for
-								   family ?   */
-					{
+					/* afi checked already */
+					orfp.p.family = afi2family(afi);
+
+					/* 0 if not ok */
+					psize = PSIZE(orfp.p.prefixlen);
+					/* valid for family ? */
+					if (psize > prefix_blen(&orfp.p)) {
 						ok = 0;
 						psize = prefix_blen(&orfp.p);
 					}
-					if (psize
-					    > (p_end - p_pnt)) /* valid for
-								  packet ?   */
-					{
+					/* valid for packet ? */
+					if (psize > (p_end - p_pnt)) {
 						ok = 0;
 						psize = p_end - p_pnt;
 					}

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -2184,6 +2184,7 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 				rfapiRibUpdatePendingNode(
 					bgp, m->rfd, it, it_node,
 					m->rfd->response_lifetime);
+				agg_unlock_node(rn);
 			}
 		}
 

--- a/ldpd/address.c
+++ b/ldpd/address.c
@@ -67,7 +67,7 @@ send_address(struct nbr *nbr, int af, struct if_addr_head *addr_list,
 		fatalx("send_address: unknown af");
 	}
 
-	while ((if_addr = LIST_FIRST(addr_list)) != NULL) {
+	while (LIST_FIRST(addr_list) != NULL) {
 		/*
 		 * Send as many addresses as possible - respect the session's
 		 * negotiated maximum pdu length.

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -858,7 +858,6 @@ ldp_acl_request(struct imsgev *iev, char *acl_name, int af,
     union ldpd_addr *addr, uint8_t prefixlen)
 {
 	struct imsg	 imsg;
-	ssize_t		 n;
 	struct acl_check acl_check;
 
 	if (acl_name[0] == '\0')
@@ -876,9 +875,9 @@ ldp_acl_request(struct imsgev *iev, char *acl_name, int af,
 	imsg_flush(&iev->ibuf);
 
 	/* receive (blocking) and parse result */
-	if ((n = imsg_read(&iev->ibuf)) == -1)
+	if (imsg_read(&iev->ibuf) == -1)
 		fatal("imsg_read error");
-	if ((n = imsg_get(&iev->ibuf, &imsg)) == -1)
+	if (imsg_get(&iev->ibuf, &imsg) == -1)
 		fatal("imsg_get");
 	if (imsg.hdr.type != IMSG_ACL_CHECK ||
 	    imsg.hdr.len != IMSG_HEADER_SIZE + sizeof(int))
@@ -1408,7 +1407,7 @@ merge_ifaces(struct ldpd_conf *conf, struct ldpd_conf *xconf)
 
 	RB_FOREACH_SAFE(iface, iface_head, &conf->iface_tree, itmp) {
 		/* find deleted interfaces */
-		if ((xi = if_lookup_name(xconf, iface->name)) == NULL) {
+		if (if_lookup_name(xconf, iface->name) == NULL) {
 			switch (ldpd_process) {
 			case PROC_LDP_ENGINE:
 				ldpe_if_exit(iface);
@@ -1469,7 +1468,7 @@ merge_tnbrs(struct ldpd_conf *conf, struct ldpd_conf *xconf)
 			continue;
 
 		/* find deleted tnbrs */
-		if ((xt = tnbr_find(xconf, tnbr->af, &tnbr->addr)) == NULL) {
+		if (tnbr_find(xconf, tnbr->af, &tnbr->addr) == NULL) {
 			switch (ldpd_process) {
 			case PROC_LDP_ENGINE:
 				tnbr->flags &= ~F_TNBR_CONFIGURED;
@@ -1624,7 +1623,7 @@ merge_l2vpns(struct ldpd_conf *conf, struct ldpd_conf *xconf)
 
 	RB_FOREACH_SAFE(l2vpn, l2vpn_head, &conf->l2vpn_tree, ltmp) {
 		/* find deleted l2vpns */
-		if ((xl = l2vpn_find(xconf, l2vpn->name)) == NULL) {
+		if (l2vpn_find(xconf, l2vpn->name) == NULL) {
 			switch (ldpd_process) {
 			case PROC_LDE_ENGINE:
 				l2vpn_exit(l2vpn);
@@ -1680,7 +1679,7 @@ merge_l2vpn(struct ldpd_conf *xconf, struct l2vpn *l2vpn, struct l2vpn *xl)
 	/* merge intefaces */
 	RB_FOREACH_SAFE(lif, l2vpn_if_head, &l2vpn->if_tree, ftmp) {
 		/* find deleted interfaces */
-		if ((xf = l2vpn_if_find(xl, lif->ifname)) == NULL) {
+		if (l2vpn_if_find(xl, lif->ifname) == NULL) {
 			RB_REMOVE(l2vpn_if_head, &l2vpn->if_tree, lif);
 			free(lif);
 		}
@@ -1706,7 +1705,7 @@ merge_l2vpn(struct ldpd_conf *xconf, struct l2vpn *l2vpn, struct l2vpn *xl)
 	/* merge active pseudowires */
 	RB_FOREACH_SAFE(pw, l2vpn_pw_head, &l2vpn->pw_tree, ptmp) {
 		/* find deleted active pseudowires */
-		if ((xp = l2vpn_pw_find_active(xl, pw->ifname)) == NULL) {
+		if (l2vpn_pw_find_active(xl, pw->ifname) == NULL) {
 			switch (ldpd_process) {
 			case PROC_LDE_ENGINE:
 				l2vpn_pw_exit(pw);
@@ -1807,7 +1806,7 @@ merge_l2vpn(struct ldpd_conf *xconf, struct l2vpn *l2vpn, struct l2vpn *xl)
 	/* merge inactive pseudowires */
 	RB_FOREACH_SAFE(pw, l2vpn_pw_head, &l2vpn->pw_inactive_tree, ptmp) {
 		/* find deleted inactive pseudowires */
-		if ((xp = l2vpn_pw_find_inactive(xl, pw->ifname)) == NULL) {
+		if (l2vpn_pw_find_inactive(xl, pw->ifname) == NULL) {
 			RB_REMOVE(l2vpn_pw_head, &l2vpn->pw_inactive_tree, pw);
 			free(pw);
 		}

--- a/ldpd/socket.c
+++ b/ldpd/socket.c
@@ -209,7 +209,7 @@ sock_set_nonblock(int fd)
 
 	flags |= O_NONBLOCK;
 
-	if ((flags = fcntl(fd, F_SETFL, flags)) == -1)
+	if (fcntl(fd, F_SETFL, flags) == -1)
 		fatal("fcntl F_SETFL");
 }
 
@@ -223,7 +223,7 @@ sock_set_cloexec(int fd)
 
 	flags |= FD_CLOEXEC;
 
-	if ((flags = fcntl(fd, F_SETFD, flags)) == -1)
+	if (fcntl(fd, F_SETFD, flags) == -1)
 		fatal("fcntl F_SETFD");
 }
 

--- a/lib/filter.c
+++ b/lib/filter.c
@@ -412,7 +412,7 @@ static int64_t filter_new_seq_get(struct access_list *access)
 	int64_t newseq;
 	struct filter *filter;
 
-	maxseq = newseq = 0;
+	maxseq = 0;
 
 	for (filter = access->head; filter; filter = filter->next) {
 		if (maxseq < filter->seq)

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -387,7 +387,7 @@ static int64_t prefix_new_seq_get(struct prefix_list *plist)
 	int64_t newseq;
 	struct prefix_list_entry *pentry;
 
-	maxseq = newseq = 0;
+	maxseq = 0;
 
 	for (pentry = plist->head; pentry; pentry = pentry->next) {
 		if (maxseq < pentry->seq)

--- a/lib/skiplist.c
+++ b/lib/skiplist.c
@@ -378,7 +378,7 @@ int skiplist_next_value(register struct skiplist *l, /* in */
 			void **valuePointer,	 /* in/out */
 			void **cursor)		     /* in/out */
 {
-	register int k, m;
+	register int k;
 	register struct skiplistnode *p, *q;
 
 	CHECKLAST(l);
@@ -389,7 +389,7 @@ int skiplist_next_value(register struct skiplist *l, /* in */
 
 	if (!cursor || !*cursor) {
 		p = l->header;
-		k = m = l->level;
+		k = l->level;
 
 		/*
 		 * Find matching key

--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -90,12 +90,11 @@ int getsockopt_so_recvbuf(const int sock)
 static void *getsockopt_cmsg_data(struct msghdr *msgh, int level, int type)
 {
 	struct cmsghdr *cmsg;
-	void *ptr = NULL;
 
 	for (cmsg = CMSG_FIRSTHDR(msgh); cmsg != NULL;
 	     cmsg = CMSG_NXTHDR(msgh, cmsg))
 		if (cmsg->cmsg_level == level && cmsg->cmsg_type == type)
-			return (ptr = CMSG_DATA(cmsg));
+			return CMSG_DATA(cmsg);
 
 	return NULL;
 }

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -755,10 +755,9 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
 			if ((type == NHRP_EXTENSION_REVERSE_TRANSIT_NHS)
 			    == (packet_types[hdr->type].type == PACKET_REPLY)) {
 				/* Check NHS list for forwarding loop */
-				while ((cie = nhrp_cie_pull(&extpl, pp->hdr,
-							    &cie_nbma,
-							    &cie_protocol))
-				       != NULL) {
+				while (nhrp_cie_pull(&extpl, pp->hdr,
+						     &cie_nbma,
+						     &cie_protocol) != NULL) {
 					if (sockunion_same(&p->vc->remote.nbma,
 							   &cie_nbma))
 						goto err;

--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -670,8 +670,7 @@ static int ospf_abr_translate_nssa(struct ospf_area *area, struct ospf_lsa *lsa)
 		 * originate translated LSA
 		 */
 
-		if ((new = ospf_translated_nssa_originate(area->ospf, lsa))
-		    == NULL) {
+		if (ospf_translated_nssa_originate(area->ospf, lsa) == NULL) {
 			if (IS_DEBUG_OSPF_NSSA)
 				zlog_debug(
 					"ospf_abr_translate_nssa(): Could not translate "

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -158,12 +158,12 @@ const char *ospf_timeval_dump(struct timeval *t, char *buf, size_t size)
 #define HOUR_IN_SECONDS		(60*MINUTE_IN_SECONDS)
 #define DAY_IN_SECONDS		(24*HOUR_IN_SECONDS)
 #define WEEK_IN_SECONDS		(7*DAY_IN_SECONDS)
-	unsigned long w, d, h, m, s, ms, us;
+	unsigned long w, d, h, m, ms, us;
 
 	if (!t)
 		return "inactive";
 
-	w = d = h = m = s = ms = us = 0;
+	w = d = h = m = ms = 0;
 	memset(buf, 0, size);
 
 	us = t->tv_usec;

--- a/ospfd/ospf_opaque.c
+++ b/ospfd/ospf_opaque.c
@@ -1557,8 +1557,8 @@ struct ospf_lsa *ospf_opaque_lsa_install(struct ospf_lsa *lsa, int rt_recalc)
 		ospf_lsa_unlock(&oipi->lsa);
 		oipi->lsa = ospf_lsa_lock(lsa);
 	}
-	/* Register the new lsa entry and get its control info. */
-	else if ((oipi = register_opaque_lsa(lsa)) == NULL) {
+	/* Register the new lsa entry */
+	else if (register_opaque_lsa(lsa) == NULL) {
 		flog_warn(EC_OSPF_LSA,
 			  "ospf_opaque_lsa_install: register_opaque_lsa() ?");
 		goto out;

--- a/ospfd/ospf_zebra.c
+++ b/ospfd/ospf_zebra.c
@@ -1002,7 +1002,6 @@ static int ospf_distribute_list_update_timer(struct thread *thread)
 void ospf_distribute_list_update(struct ospf *ospf, int type,
 				 unsigned short instance)
 {
-	struct route_table *rt;
 	struct ospf_external *ext;
 	void **args = XCALLOC(MTYPE_OSPF_DIST_ARGS, sizeof(void *) * 2);
 
@@ -1011,7 +1010,7 @@ void ospf_distribute_list_update(struct ospf *ospf, int type,
 
 	/* External info does not exist. */
 	ext = ospf_external_lookup(ospf, type, instance);
-	if (!ext || !(rt = EXTERNAL_INFO(ext))) {
+	if (!ext || !EXTERNAL_INFO(ext)) {
 		XFREE(MTYPE_OSPF_DIST_ARGS, args);
 		return;
 	}

--- a/zebra/ipforward_proc.c
+++ b/zebra/ipforward_proc.c
@@ -34,9 +34,7 @@ static const char proc_net_snmp[] = "/proc/net/snmp";
 
 static void dropline(FILE *fp)
 {
-	int c;
-
-	while ((c = getc(fp)) != '\n')
+	while (getc(fp) != '\n')
 		;
 }
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1532,10 +1532,8 @@ DEFPY (show_route,
 
 	if (vrf_all) {
 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
-			struct route_table *route_table;
-
 			if ((zvrf = vrf->info) == NULL
-			    || (route_table = zvrf->table[afi][SAFI_UNICAST]) == NULL)
+			    || (zvrf->table[afi][SAFI_UNICAST] == NULL))
 				continue;
 
 			if (table_all)


### PR DESCRIPTION
Cleanup a bunch of set but unused variables.

There appears to be a case in the rfapi code where we were locking a node but not unlocking it after using it.  @louberger  can you take a look at this one to ensure it's correct?

Additionally cleanup code indentation in a couple of places.