### PR TITLE
bgpd: turn off RAs when numbered enhe peers are deleted

### DIFF
--- a/bgpd/bgp_nht.h
+++ b/bgpd/bgp_nht.h
@@ -87,6 +87,7 @@ extern void bgp_nht_register_nexthops(struct bgp *bgp);
  * this code can walk the registered nexthops and
  * register the important ones with zebra for RA.
  */
-extern void bgp_nht_register_enhe_capability_interfaces(struct peer *peer);
+extern void bgp_nht_reg_enhe_capability_intfs(struct peer *peer);
+extern void bgp_nht_dereg_enhe_capability_intfs(struct peer *peer);
 
 #endif /* _BGP_NHT_H */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3769,6 +3769,10 @@ DEFUN (no_neighbor,
 
 			other = peer->doppelganger;
 			peer_notify_unconfig(peer);
+
+			if (CHECK_FLAG(peer->flags, PEER_FLAG_CAPABILITY_ENHE))
+				bgp_zebra_terminate_radv(peer->bgp, peer);
+
 			peer_delete(peer);
 			if (other && other->status != Deleted) {
 				peer_notify_unconfig(other);
@@ -4189,6 +4193,10 @@ DEFUN (no_neighbor_set_peer_group,
 	}
 
 	peer_notify_unconfig(peer);
+
+	if (CHECK_FLAG(peer->flags, PEER_FLAG_CAPABILITY_ENHE))
+		bgp_zebra_terminate_radv(peer->bgp, peer);
+
 	ret = peer_delete(peer);
 
 	return bgp_vty_return(vty, ret);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1904,7 +1904,11 @@ void bgp_zebra_terminate_radv(struct bgp *bgp, struct peer *peer)
 		zlog_debug("%u: Terminating RA for peer %s", bgp->vrf_id,
 			   peer->host);
 
-	zclient_send_interface_radv_req(zclient, bgp->vrf_id, peer->ifp, 0, 0);
+	if (peer->ifp)
+		zclient_send_interface_radv_req(zclient, bgp->vrf_id, peer->ifp,
+						false, 0);
+	else
+		bgp_nht_dereg_enhe_capability_intfs(peer);
 }
 
 int bgp_zebra_advertise_subnet(struct bgp *bgp, int advertise, vni_t vni)


### PR DESCRIPTION
Problem reported that the RAs that were originated in order to
bring up numbered IPv6 peers with extended-nexthop capability
enabled (for ipv4 over ipv6) were not stopped on the interfaces
when those peers were deleted. Found several circumstances where
this occurred and fixed them in this patch.

Ticket: CM-26875
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>