### PR TITLE
lib: fix ipaddr_isset

### DIFF
--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -119,10 +119,13 @@ static inline void ipv4_mapped_ipv6_to_ipv4(struct in6_addr *in6,
 	memcpy(in, (char *)in6 + 12, sizeof(struct in_addr));
 }
 
+/*
+ * Check if a struct ipaddr has nonzero value
+ */
 static inline bool ipaddr_isset(struct ipaddr *ip)
 {
 	static struct ipaddr a = {};
-	return (0 == memcmp(&a, ip, sizeof(struct ipaddr)));
+	return (0 != memcmp(&a, ip, sizeof(struct ipaddr)));
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Meaning inverted by mistake

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>