### PR TITLE
Update vrrp.rst

### DIFF
--- a/doc/user/vrrp.rst
+++ b/doc/user/vrrp.rst
@@ -140,7 +140,7 @@ macvlan device. If you are using ``iproute2``, the equivalent configuration is:
    ip link set dev vrrp4-2-1 up
 
    ip link add vrrp6-2-1 link eth0 addrgenmode random type macvlan mode bridge
-   ip link set dev vrrp4-2-1 address 00:00:5e:00:02:05
+   ip link set dev vrrp6-2-1 address 00:00:5e:00:02:05
    ip addr add 2001:db8::370:7334/64 dev vrrp6-2-1
    ip link set dev vrrp6-2-1 up
 


### PR DESCRIPTION
vrrpd: Corrected example code documentation
Corrected example code where the network interface contains a 
copy-paste error from a previous section. Example code is changed from
**ip link set dev vrrp4-2-1 address 00:00:5e:00:02:05** to **ip link 
set dev vrrp6-2-1 address 00:00:5e:00:02:05**.