### PR TITLE
zebra: fix nexthop_group conversion in fpm code

### DIFF
--- a/zebra/zebra_fpm_dt.c
+++ b/zebra/zebra_fpm_dt.c
@@ -90,7 +90,7 @@ static int zfpm_dt_find_route(rib_dest_t **dest_p, struct route_entry **re_p)
 		if (!re)
 			continue;
 
-		if (nexthop_group_active_nexthop_num(re->nhe->nhg) == 0)
+		if (nexthop_group_active_nexthop_num(&(re->nhe->nhg)) == 0)
 			continue;
 
 		*dest_p = dest;

--- a/zebra/zebra_fpm_protobuf.c
+++ b/zebra/zebra_fpm_protobuf.c
@@ -173,7 +173,7 @@ static Fpm__AddRoute *create_add_route_message(qpb_allocator_t *allocator,
 	 * Figure out the set of nexthops to be added to the message.
 	 */
 	num_nhs = 0;
-	for (ALL_NEXTHOPS_PTR(re->nhe->nhg, nexthop)) {
+	for (ALL_NEXTHOPS(re->nhe->nhg, nexthop)) {
 		if (num_nhs >= zrouter.multipath_num)
 			break;
 


### PR DESCRIPTION
Recent commit that embedded the nhg_hash_entry's group missed a couple of fpm modules.
