### PR TITLE
pimd: add show ip multicast count [json] command

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -515,6 +515,16 @@ cause great confusion.
 
    Display multicast traceroute towards source, optionally for particular group.
 
+.. index:: show ip multicast count [vrf NAME] [json]
+.. clicmd:: show ip multicast count [vrf NAME] [json]
+
+   Display multicast data packets count per interface for a vrf.
+
+.. index:: show ip multicast count vrf all [json]
+.. clicmd:: show ip multicast count vrf all [json]
+
+   Display multicast data packets count per interface for all vrf.
+
 PIM Debug Commands
 ==================
 


### PR DESCRIPTION
Added a new show command "show ip multicast", display the multicast data
packet in and out on interface level.

Signed-off-by: Sarita Patra <saritap@vmware.com>