### PR TITLE
pimd: fix pim interface traffic & pim rp-info json command

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1520,6 +1520,10 @@ static void pim_show_interface_traffic(struct pim_instance *pim,
 					    pim_ifp->pim_ifstat_join_recv);
 			json_object_int_add(json_row, "joinTx",
 					    pim_ifp->pim_ifstat_join_send);
+			json_object_int_add(json_row, "pruneTx",
+					    pim_ifp->pim_ifstat_prune_send);
+			json_object_int_add(json_row, "pruneRx",
+					    pim_ifp->pim_ifstat_prune_recv);
 			json_object_int_add(json_row, "registerRx",
 					    pim_ifp->pim_ifstat_reg_recv);
 			json_object_int_add(json_row, "registerTx",

--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -1293,10 +1293,16 @@ void pim_rp_show_information(struct pim_instance *pim, struct vty *vty, bool uj)
 						json_row, "outboundInterface",
 						rp_info->rp.source_nexthop
 							.interface->name);
-
+				else
+					json_object_string_add(
+						json_row, "outboundInterface",
+						"Unknown");
 				if (rp_info->i_am_rp)
 					json_object_boolean_true_add(json_row,
 								     "iAmRP");
+				else
+					json_object_boolean_false_add(json_row,
+								      "iAmRP");
 
 				if (rp_info->plist)
 					json_object_string_add(json_row,


### PR DESCRIPTION
Issue 1: show ip pim interface traffic not show prune TX/RX
Rootcause : not added the variable in the json
Fix : add prune TX/RX in show ip pim interface traffic json

Issue 2: show ip pim rp-info not shows the key iAmRp when it is false
Rootcause: Only display the key when the value is true.
Fix: add iAmRp as false in show ip pim rp-info json

Issue 3: show ip pim rp-info not showing outbound interface if it is empty
Rootcause: Only display when there is any OIL

Fix: When RP is not reachable then, the outbound interface is Unknown
The command "show ip pim rp-info json" not displaying the outbound
interafce if it is unknown

Signed-off-by: Sarita Patra <saritap@vmware.com>