### PR TITLE
zebra: trust directly connected kernel/system routes

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1637,7 +1637,16 @@ static unsigned nexthop_active_check(struct route_node *rn,
 	switch (nexthop->type) {
 	case NEXTHOP_TYPE_IFINDEX:
 		ifp = if_lookup_by_index(nexthop->ifindex, nexthop->vrf_id);
-		if (ifp && if_is_operative(ifp))
+		/*
+		 * If the interface exists and its operative or its a kernel
+		 * route and interface is up, its active. We trust kernel routes
+		 * to be good.
+		 */
+		if (ifp
+		    && (if_is_operative(ifp)
+			|| (if_is_up(ifp)
+			    && (re->type == ZEBRA_ROUTE_KERNEL
+				|| re->type == ZEBRA_ROUTE_SYSTEM))))
 			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 		else
 			UNSET_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);


### PR DESCRIPTION
We made the decision to explicitly trust kernel and system routes
of every other type with 058c16b7e239f1c50a1d4b4376a6aff6b8dad959.

So, we should trust directly connected routes the same way, assuming
the interface exists.

Old Behavior:

K   2.2.2.1/32 [0/0] is directly connected, unknown inactive, 00:00:39

New Behavior:

K>* 2.2.2.1/32 [0/0] is directly connected, test1, 00:00:03

As a bonus, this fixes the issues we were seeing with not removing
directly connected routes of certain interface types when
those interfaces go down/are deleted.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>


Fixes #5816