### PR TITLE
zebra: remove kernel route from rib when new selected

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -898,8 +898,12 @@ static void rib_process_update_fib(struct zebra_vrf *zvrf,
 	}
 
 	/* Update prior route. */
-	if (new != old)
-		UNSET_FLAG(old->status, ROUTE_ENTRY_CHANGED);
+	if (new != old) {
+		if (RIB_KERNEL_ROUTE(old))
+			SET_FLAG(old->status, ROUTE_ENTRY_REMOVED);
+		else
+			UNSET_FLAG(old->status, ROUTE_ENTRY_CHANGED);
+	}
 
 	/* Clear changed flag. */
 	UNSET_FLAG(new->status, ROUTE_ENTRY_CHANGED);


### PR DESCRIPTION
If a kernel route becomes unreachable we remove it from our
rib in `rib_process_del_fib()` because the kernel has also removed
it.

We were not handling this properly in `rib_process_update_fib()`
where we replace the kernel route with another one we have in
the system. This patch adds the code to handle it the same way
as done in `rib_process_del_fib()` when the kernel route is
the only one for that prefix by marking it removed.

Repro steps:

ip link add dummy1 type dummy
ip link add dummy2 type dummy
ip link set dummy1 up
ip link set dummy2 up

ip ro add 2.2.2.1/32 dev dummy1

with staticd running:

vtysh -c "ip route 2.2.2.1/32 dummy2"

K>* 2.2.2.1/32 [0/0] is directly connected, dummy1, 00:00:03
S   2.2.2.1/32 [1/0] is directly connected, dummy2, 00:01:49

ip link set dummy1 down

S>* 2.2.2.1/32 [1/0] is directly connected, dummy1, 00:00:45
K * 2.2.2.1/32 [0/0] is directly connected, test1 inactive, 00:05:49

but the kernel route is no longer present in the linux kernel.

================================================

WITH THIS PATCH we properly remove it from the rib:

S>* 2.2.2.1/32 [1/0] is directly connected, dummy2, 00:01:57

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>