### PR TITLE
[7.2] zebra: add vrf_id to nexthop from netlink route delete

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -772,12 +772,13 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 			} else
 				nh_vrf_id = vrf_id;
 
+			nh.vrf_id = nh_vrf_id;
 			if (prefsrc)
 				memcpy(&nh.src, prefsrc, sz);
 			if (gate)
 				memcpy(&nh.gate, gate, sz);
 
-			rib_delete(afi, SAFI_UNICAST, nh_vrf_id, proto, 0, flags,
+			rib_delete(afi, SAFI_UNICAST, vrf_id, proto, 0, flags,
 				   &p, &src_p, &nh, table, metric, distance,
 				   true);
 		} else {


### PR DESCRIPTION
When we backported 760f39dc082c6739d342225cd71863ada9471a87
on the 7.2 stable branch with 31d682a2ee647fdc0636bebb8129e3cf5922151f

we had to do quite a bit of modification to get the commit
to fit since the codepaths changed so much. When doing so,
we missed adding the `vrf_id` to the nexthop struct before
sending it into `rib_delete()` and instead added it incorrectly
to `rib_delete()` API. The `vrf_id` in `rib_delete()` should correspond
to the route's `vrf_id` whereas the nexthop should be set with the
one we determined from `nh_vrf_id`.

This patch fixes that by setting it after its determined above and
reverting the `rib_delete()` call to use the route's `vrf_id`.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>

Fixes #5883