### PR TITLE
pimd: Update pim register stop statistics

### DIFF
--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -122,6 +122,8 @@ int pim_register_stop_recv(struct interface *ifp, uint8_t *buf, int buf_size)
 	struct prefix_sg sg;
 	int l;
 
+	++pim_ifp->pim_ifstat_reg_stop_recv;
+
 	memset(&sg, 0, sizeof(struct prefix_sg));
 	l = pim_parse_addr_group(&sg, buf, buf_size);
 	buf += l;


### PR DESCRIPTION
Issue: REGISTER-STOP Rx is always displaying 0.

Root-cause: pim_ifstat_reg_stop_recv is not getting
incremented when register stop message is received.

Fix: Increment pim_ifstat_reg_stop_recv on receiving
of pim register stop packet.

Signed-off-by: Sarita Patra <saritap@vmware.com>