### PR TITLE
pimd: neighbor needed true in pim nexthop lookup

### DIFF
--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -1079,7 +1079,7 @@ int pim_ecmp_fib_lookup_if_vif_index(struct pim_instance *pim,
 			       sizeof(addr_str));
 
 	memset(&nhop, 0, sizeof(nhop));
-	if (!pim_ecmp_nexthop_lookup(pim, &nhop, src, grp, 0)) {
+	if (!pim_ecmp_nexthop_lookup(pim, &nhop, src, grp, 1)) {
 		if (PIM_DEBUG_PIM_NHT)
 			zlog_debug(
 				"%s: could not find nexthop ifindex for address %s(%s)",


### PR DESCRIPTION
Issue:
Client---LHR---RP
1. Add kernel route for RP on LHR. Client send join
2. (*,G) will be get created in LHR and RP.
3. Kill the FRR on all the nodes
4. Start FRR only on LHR node
5. In LHR, (*, G) will be created with iif as unknown.

Root cause:
In the step 4, When LHR will receive igmp join, it will call
the function pim_ecmp_fib_lookup_if_vif_index which will look
for nexthop to RP with neighbor needed as false. So RPF lookup will
be true as the route is present in the kernel. It will create a
(*, G) channel_oil with incoming interface as the RPF interface
towards RP and install the (*,G) mroute in kernel.
Along with this (*,G) upstream gets craeted, which call the function
pim_rpf_update, which will look for the nexthop to RP with neighbor
needed as true. As the frr is not running in RP, no neighbor is present
on the nexthop interface. Due to which this will fail and will update
the channel_oil incoming interface as MAXVIFS(32).

Fix:
pim_ecmp_fib_lookup_if_vif_index() call the function pim_ecmp_nexthop_lookup
with neighbor_needed as true.

Signed-off-by: Sarita Patra <saritap@vmware.com>