### PR TITLE
pimd: fix crash seen while executing igmp related configuration

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -7056,6 +7056,9 @@ static void igmp_sock_query_interval_reconfig(struct igmp_sock *igmp)
 
 static void igmp_sock_query_reschedule(struct igmp_sock *igmp)
 {
+	if (igmp->mtrace_only)
+		return;
+
 	if (igmp->t_igmp_query_timer) {
 		/* other querier present */
 		zassert(igmp->t_igmp_query_timer);


### PR DESCRIPTION
Issue 1:
1. Enable pim on an interface.
2. Configure query-interval or query max response time,
which results in pimd crash.

Root cause:
1. When pim is enabled on an interface, it creates a igmp socket
with querier_timer and other_querier time as NULL.
2. When query-interval/max_response_time is configured, it call the
function igmp_sock_query_reschedule() to reshedule the query. This
function check either of querier_timer or other_querier timer should
be running. Since in this case both are NULL, it results in crash.

Issue 2:
1. Enable pim on an interface.
2. Execute no ip igmp query-interval or query max response time,
which results in pimd crash.

Root cause:
1. When pim is enabled on an interface, it creates a pim interface
with querier_timer and other_querier time as NULL.
2. When no ip igmp query-interval/max_response_time is executed, it will
check either of querier_timer or other_querier timer should be running.
Since in this case both are NULL, it results in crash.

Fix:
When pim is enabled on an interface, it creates a igmp socket with
mtrace_only as true. So add a check if mtrace_only is true, then don't
reshedule the query.

Signed-off-by: Sarita Patra <saritap@vmware.com>