### PR TITLE
zebra, lib: Backup nexthop (path) prep work

### DIFF
--- a/lib/ipaddr.h
+++ b/lib/ipaddr.h
@@ -112,7 +112,7 @@ static inline void ipv4_to_ipv4_mapped_ipv6(struct in6_addr *in6,
 /*
  * convert an ipv4 mapped ipv6 address back to ipv4 address
  */
-static inline void ipv4_mapped_ipv6_to_ipv4(struct in6_addr *in6,
+static inline void ipv4_mapped_ipv6_to_ipv4(const struct in6_addr *in6,
 					    struct in_addr *in)
 {
 	memset(in, 0, sizeof(struct in_addr));

--- a/lib/mpls.c
+++ b/lib/mpls.c
@@ -79,7 +79,7 @@ int mpls_str2label(const char *label_str, uint8_t *num_labels,
 /*
  * Label to string conversion, labels in string separated by '/'.
  */
-char *mpls_label2str(uint8_t num_labels, mpls_label_t *labels, char *buf,
+char *mpls_label2str(uint8_t num_labels, const mpls_label_t *labels, char *buf,
 		     int len, int pretty)
 {
 	char label_buf[BUFSIZ];

--- a/lib/mpls.h
+++ b/lib/mpls.h
@@ -209,10 +209,13 @@ static inline char *label2str(mpls_label_t label, char *buf, size_t len)
 int mpls_str2label(const char *label_str, uint8_t *num_labels,
 		   mpls_label_t *labels);
 
+/* Generic string buffer for label-stack-to-str */
+#define MPLS_LABEL_STRLEN 1024
+
 /*
  * Label to string conversion, labels in string separated by '/'.
  */
-char *mpls_label2str(uint8_t num_labels, mpls_label_t *labels, char *buf,
+char *mpls_label2str(uint8_t num_labels, const mpls_label_t *labels, char *buf,
 		     int len, int pretty);
 
 #ifdef __cplusplus

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -393,8 +393,8 @@ struct nexthop *nexthop_from_blackhole(enum blackhole_type bh_type)
 }
 
 /* Update nexthop with label information. */
-void nexthop_add_labels(struct nexthop *nexthop, enum lsp_types_t type,
-			uint8_t num_labels, mpls_label_t *label)
+void nexthop_add_labels(struct nexthop *nexthop, enum lsp_types_t ltype,
+			uint8_t num_labels, const mpls_label_t *labels)
 {
 	struct mpls_label_stack *nh_label;
 	int i;
@@ -402,13 +402,18 @@ void nexthop_add_labels(struct nexthop *nexthop, enum lsp_types_t type,
 	if (num_labels == 0)
 		return;
 
-	nexthop->nh_label_type = type;
+	/* Enforce limit on label stack size */
+	if (num_labels > MPLS_MAX_LABELS)
+		num_labels = MPLS_MAX_LABELS;
+
+	nexthop->nh_label_type = ltype;
+
 	nh_label = XCALLOC(MTYPE_NH_LABEL,
 			   sizeof(struct mpls_label_stack)
 				   + num_labels * sizeof(mpls_label_t));
 	nh_label->num_labels = num_labels;
 	for (i = 0; i < num_labels; i++)
-		nh_label->label[i] = *(label + i);
+		nh_label->label[i] = *(labels + i);
 	nexthop->nh_label = nh_label;
 }
 

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -118,13 +118,22 @@ struct nexthop {
 	uint8_t weight;
 };
 
+
+/* Utility to append one nexthop to another. */
+#define NEXTHOP_APPEND(to, new)           \
+	do {                              \
+		(to)->next = (new);       \
+		(new)->prev = (to);       \
+		(new)->next = NULL;       \
+	} while (0)
+
 struct nexthop *nexthop_new(void);
 
 void nexthop_free(struct nexthop *nexthop);
 void nexthops_free(struct nexthop *nexthop);
 
-void nexthop_add_labels(struct nexthop *, enum lsp_types_t, uint8_t,
-			mpls_label_t *);
+void nexthop_add_labels(struct nexthop *nexthop, enum lsp_types_t ltype,
+			uint8_t num_labels, const mpls_label_t *labels);
 void nexthop_del_labels(struct nexthop *);
 
 /*

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -86,6 +86,8 @@ struct nexthop {
 					  * active one
 					  */
 #define NEXTHOP_FLAG_RNH_FILTERED  (1 << 5) /* rmap filtered, used by rnh */
+#define NEXTHOP_FLAG_HAS_BACKUP (1 << 6)    /* Backup nexthop index is set */
+
 #define NEXTHOP_IS_ACTIVE(flags)                                               \
 	(CHECK_FLAG(flags, NEXTHOP_FLAG_ACTIVE)                                \
 	 && !CHECK_FLAG(flags, NEXTHOP_FLAG_DUPLICATE))
@@ -116,8 +118,15 @@ struct nexthop {
 
 	/* Weight of the nexthop ( for unequal cost ECMP ) */
 	uint8_t weight;
+
+	/* Index of a corresponding backup nexthop in a backup list;
+	 * only meaningful if the HAS_BACKUP flag is set.
+	 */
+	uint8_t backup_idx;
 };
 
+/* Backup index value is limited */
+#define NEXTHOP_BACKUP_IDX_MAX 255
 
 /* Utility to append one nexthop to another. */
 #define NEXTHOP_APPEND(to, new)           \

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -225,6 +225,10 @@ void nexthop_group_copy(struct nexthop_group *to,
 
 void nexthop_group_delete(struct nexthop_group **nhg)
 {
+	/* OK to call with NULL group */
+	if ((*nhg) == NULL)
+		return;
+
 	if ((*nhg)->nexthop)
 		nexthops_free((*nhg)->nexthop);
 

--- a/lib/nexthop_group.c
+++ b/lib/nexthop_group.c
@@ -43,7 +43,11 @@ struct nexthop_hold {
 	char *intf;
 	char *labels;
 	uint32_t weight;
+	int backup_idx; /* Index of backup nexthop, if >= 0 */
 };
+
+/* Invalid/unset value for nexthop_hold's backup_idx */
+#define NHH_BACKUP_IDX_INVALID -1
 
 struct nexthop_group_hooks {
 	void (*new)(const char *name);
@@ -571,11 +575,36 @@ DEFUN_NOSH(no_nexthop_group, no_nexthop_group_cmd, "no nexthop-group NHGNAME",
 	return CMD_SUCCESS;
 }
 
+DEFPY(nexthop_group_backup, nexthop_group_backup_cmd,
+      "backup-group WORD$name",
+      "Specify a group name containing backup nexthops\n"
+      "The name of the backup group\n")
+{
+	VTY_DECLVAR_CONTEXT(nexthop_group_cmd, nhgc);
+
+	strlcpy(nhgc->backup_list_name, name, sizeof(nhgc->backup_list_name));
+
+	return CMD_SUCCESS;
+}
+
+DEFPY(no_nexthop_group_backup, no_nexthop_group_backup_cmd,
+      "no backup-group [WORD$name]",
+      NO_STR
+      "Clear group name containing backup nexthops\n"
+      "The name of the backup group\n")
+{
+	VTY_DECLVAR_CONTEXT(nexthop_group_cmd, nhgc);
+
+	nhgc->backup_list_name[0] = 0;
+
+	return CMD_SUCCESS;
+}
+
 static void nexthop_group_save_nhop(struct nexthop_group_cmd *nhgc,
 				    const char *nhvrf_name,
 				    const union sockunion *addr,
 				    const char *intf, const char *labels,
-				    const uint32_t weight)
+				    const uint32_t weight, int backup_idx)
 {
 	struct nexthop_hold *nh;
 
@@ -591,6 +620,8 @@ static void nexthop_group_save_nhop(struct nexthop_group_cmd *nhgc,
 		nh->labels = XSTRDUP(MTYPE_TMP, labels);
 
 	nh->weight = weight;
+
+	nh->backup_idx = backup_idx;
 
 	listnode_add_sort(nhgc->nhg_list, nh);
 }
@@ -633,7 +664,7 @@ static bool nexthop_group_parse_nexthop(struct nexthop *nhop,
 					const union sockunion *addr,
 					const char *intf, const char *name,
 					const char *labels, int *lbl_ret,
-					uint32_t weight)
+					uint32_t weight, int backup_idx)
 {
 	int ret = 0;
 	struct vrf *vrf;
@@ -692,6 +723,15 @@ static bool nexthop_group_parse_nexthop(struct nexthop *nhop,
 
 	nhop->weight = weight;
 
+	if (backup_idx != NHH_BACKUP_IDX_INVALID) {
+		/* Validate index value */
+		if (backup_idx > NEXTHOP_BACKUP_IDX_MAX)
+			return false;
+
+		SET_FLAG(nhop->flags, NEXTHOP_FLAG_HAS_BACKUP);
+		nhop->backup_idx = backup_idx;
+	}
+
 	return true;
 }
 
@@ -703,7 +743,7 @@ static bool nexthop_group_parse_nhh(struct nexthop *nhop,
 {
 	return (nexthop_group_parse_nexthop(nhop, nhh->addr, nhh->intf,
 					    nhh->nhvrf_name, nhh->labels, NULL,
-					    nhh->weight));
+					    nhh->weight, nhh->backup_idx));
 }
 
 DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
@@ -716,6 +756,7 @@ DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
 	   nexthop-vrf NAME$vrf_name \
 	   |label WORD \
            |weight (1-255) \
+           |backup-idx$bi_str (0-254)$idx \
 	}]",
       NO_STR
       "Specify one of the nexthops in this ECMP group\n"
@@ -728,16 +769,23 @@ DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
       "Specify label(s) for this nexthop\n"
       "One or more labels in the range (16-1048575) separated by '/'\n"
       "Weight to be used by the nexthop for purposes of ECMP\n"
-      "Weight value to be used\n")
+      "Weight value to be used\n"
+      "Backup nexthop index in another group\n"
+      "Nexthop index value\n")
 {
 	VTY_DECLVAR_CONTEXT(nexthop_group_cmd, nhgc);
 	struct nexthop nhop;
 	struct nexthop *nh;
 	int lbl_ret = 0;
 	bool legal;
+	int backup_idx = idx;
+	bool add_update = false;
+
+	if (bi_str == NULL)
+		backup_idx = NHH_BACKUP_IDX_INVALID;
 
 	legal = nexthop_group_parse_nexthop(&nhop, addr, intf, vrf_name, label,
-					    &lbl_ret, weight);
+					    &lbl_ret, weight, backup_idx);
 
 	if (nhop.type == NEXTHOP_TYPE_IPV6
 	    && IN6_IS_ADDR_LINKLOCAL(&nhop.gate.ipv6)) {
@@ -769,19 +817,30 @@ DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
 
 	nh = nexthop_exists(&nhgc->nhg, &nhop);
 
-	if (no) {
+	if (no || nh) {
+		/* Remove or replace cases */
+
+		/* Remove existing config */
 		nexthop_group_unsave_nhop(nhgc, vrf_name, addr, intf, label,
 					  weight);
 		if (nh) {
+			/* Remove nexthop object */
 			_nexthop_del(&nhgc->nhg, nh);
 
 			if (nhg_hooks.del_nexthop)
 				nhg_hooks.del_nexthop(nhgc, nh);
 
 			nexthop_free(nh);
+			nh = NULL;
 		}
-	} else if (!nh) {
-		/* must be adding new nexthop since !no and !nexthop_exists */
+	}
+
+	add_update = !no;
+
+	if (add_update) {
+		/* Add or replace cases */
+
+		/* If valid config, add nexthop object */
 		if (legal) {
 			nh = nexthop_new();
 
@@ -789,8 +848,9 @@ DEFPY(ecmp_nexthops, ecmp_nexthops_cmd,
 			_nexthop_add(&nhgc->nhg.nexthop, nh);
 		}
 
+		/* Save config always */
 		nexthop_group_save_nhop(nhgc, vrf_name, addr, intf, label,
-					weight);
+					weight, backup_idx);
 
 		if (legal && nhg_hooks.add_nexthop)
 			nhg_hooks.add_nexthop(nhgc, nh);
@@ -853,6 +913,9 @@ void nexthop_group_write_nexthop(struct vty *vty, struct nexthop *nh)
 	if (nh->weight)
 		vty_out(vty, " weight %u", nh->weight);
 
+	if (CHECK_FLAG(nh->flags, NEXTHOP_FLAG_HAS_BACKUP))
+		vty_out(vty, " backup-idx %d", nh->backup_idx);
+
 	vty_out(vty, "\n");
 }
 
@@ -878,6 +941,9 @@ static void nexthop_group_write_nexthop_internal(struct vty *vty,
 	if (nh->weight)
 		vty_out(vty, " weight %u", nh->weight);
 
+	if (nh->backup_idx != NHH_BACKUP_IDX_INVALID)
+		vty_out(vty, " backup-idx %d", nh->backup_idx);
+
 	vty_out(vty, "\n");
 }
 
@@ -890,6 +956,10 @@ static int nexthop_group_write(struct vty *vty)
 		struct listnode *node;
 
 		vty_out(vty, "nexthop-group %s\n", nhgc->name);
+
+		if (nhgc->backup_list_name[0])
+			vty_out(vty, " backup-group %s\n",
+				nhgc->backup_list_name);
 
 		for (ALL_LIST_ELEMENTS_RO(nhgc->nhg_list, node, nh)) {
 			vty_out(vty, " ");
@@ -1071,6 +1141,8 @@ void nexthop_group_init(void (*new)(const char *name),
 	install_element(CONFIG_NODE, &no_nexthop_group_cmd);
 
 	install_default(NH_GROUP_NODE);
+	install_element(NH_GROUP_NODE, &nexthop_group_backup_cmd);
+	install_element(NH_GROUP_NODE, &no_nexthop_group_backup_cmd);
 	install_element(NH_GROUP_NODE, &ecmp_nexthops_cmd);
 
 	memset(&nhg_hooks, 0, sizeof(nhg_hooks));

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -81,11 +81,16 @@ void nexthop_group_add_sorted(struct nexthop_group *nhg,
 	(nhop) = nexthop_next(nhop)
 
 
+#define NHGC_NAME_SIZE 80
+
 struct nexthop_group_cmd {
 
 	RB_ENTRY(nexthop_group_cmd) nhgc_entry;
 
-	char name[80];
+	char name[NHGC_NAME_SIZE];
+
+	/* Name of group containing backup nexthops (if set) */
+	char backup_list_name[NHGC_NAME_SIZE];
 
 	struct nexthop_group nhg;
 

--- a/lib/nexthop_group.h
+++ b/lib/nexthop_group.h
@@ -57,6 +57,8 @@ void copy_nexthops(struct nexthop **tnh, const struct nexthop *nh,
 uint32_t nexthop_group_hash_no_recurse(const struct nexthop_group *nhg);
 uint32_t nexthop_group_hash(const struct nexthop_group *nhg);
 void nexthop_group_mark_duplicates(struct nexthop_group *nhg);
+
+/* Add a nexthop to a list, enforcing the canonical sort order. */
 void nexthop_group_add_sorted(struct nexthop_group *nhg,
 			      struct nexthop *nexthop);
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1500,6 +1500,7 @@ int zapi_nexthop_from_nexthop(struct zapi_nexthop *znh,
 
 	znh->type = nh->type;
 	znh->vrf_id = nh->vrf_id;
+	znh->weight = nh->weight;
 	znh->ifindex = nh->ifindex;
 	znh->gate = nh->gate;
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -948,6 +948,10 @@ int zapi_nexthop_encode(struct stream *s, const struct zapi_nexthop *api_nh,
 		stream_put(s, &(api_nh->rmac),
 			   sizeof(struct ethaddr));
 
+	/* Index of backup nexthop */
+	if (CHECK_FLAG(nh_flags, ZAPI_NEXTHOP_FLAG_HAS_BACKUP))
+		stream_putc(s, api_nh->backup_idx);
+
 done:
 	return ret;
 }
@@ -1007,6 +1011,10 @@ int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 			return -1;
 		}
 
+		/* We canonicalize the nexthops by sorting them; this allows
+		 * zebra to resolve the list of nexthops to a nexthop-group
+		 * more efficiently.
+		 */
 		zapi_nexthop_group_sort(api->nexthops, api->nexthop_num);
 
 		stream_putw(s, api->nexthop_num);
@@ -1022,6 +1030,50 @@ int zapi_route_encode(uint8_t cmd, struct stream *s, struct zapi_route *api)
 
 				flog_err(EC_LIB_ZAPI_ENCODE,
 					 "%s: prefix %s: can't encode %u labels (maximum is %u)",
+					 __func__, buf,
+					 api_nh->label_num,
+					 MPLS_MAX_LABELS);
+				return -1;
+			}
+
+			if (zapi_nexthop_encode(s, api_nh, api->flags) != 0)
+				return -1;
+		}
+	}
+
+	/* Backup nexthops  */
+	if (CHECK_FLAG(api->message, ZAPI_MESSAGE_BACKUP_NEXTHOPS)) {
+		/* limit the number of nexthops if necessary */
+		if (api->backup_nexthop_num > MULTIPATH_NUM) {
+			char buf[PREFIX2STR_BUFFER];
+
+			prefix2str(&api->prefix, buf, sizeof(buf));
+			flog_err(
+				EC_LIB_ZAPI_ENCODE,
+				"%s: prefix %s: can't encode %u backup nexthops (maximum is %u)",
+				__func__, buf, api->backup_nexthop_num,
+				MULTIPATH_NUM);
+			return -1;
+		}
+
+		/* Note that we do not sort the list of backup nexthops -
+		 * this list is treated as an array and indexed by each
+		 * primary nexthop that is associated with a backup.
+		 */
+
+		stream_putw(s, api->backup_nexthop_num);
+
+		for (i = 0; i < api->backup_nexthop_num; i++) {
+			api_nh = &api->backup_nexthops[i];
+
+			/* MPLS labels for BGP-LU or Segment Routing */
+			if (api_nh->label_num > MPLS_MAX_LABELS) {
+				char buf[PREFIX2STR_BUFFER];
+
+				prefix2str(&api->prefix, buf, sizeof(buf));
+
+				flog_err(EC_LIB_ZAPI_ENCODE,
+					 "%s: prefix %s: backup: can't encode %u labels (maximum is %u)",
 					 __func__, buf,
 					 api_nh->label_num,
 					 MPLS_MAX_LABELS);
@@ -1107,6 +1159,10 @@ static int zapi_nexthop_decode(struct stream *s, struct zapi_nexthop *api_nh,
 	if (CHECK_FLAG(api_flags, ZEBRA_FLAG_EVPN_ROUTE))
 		STREAM_GET(&(api_nh->rmac), s,
 			   sizeof(struct ethaddr));
+
+	/* Backup nexthop index */
+	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_HAS_BACKUP))
+		STREAM_GETC(s, api_nh->backup_idx);
 
 	/* Success */
 	ret = 0;
@@ -1208,6 +1264,24 @@ int zapi_route_decode(struct stream *s, struct zapi_route *api)
 
 		for (i = 0; i < api->nexthop_num; i++) {
 			api_nh = &api->nexthops[i];
+
+			if (zapi_nexthop_decode(s, api_nh, api->flags) != 0)
+				return -1;
+		}
+	}
+
+	/* Backup nexthops. */
+	if (CHECK_FLAG(api->message, ZAPI_MESSAGE_BACKUP_NEXTHOPS)) {
+		STREAM_GETW(s, api->backup_nexthop_num);
+		if (api->backup_nexthop_num > MULTIPATH_NUM) {
+			flog_err(EC_LIB_ZAPI_ENCODE,
+				 "%s: invalid number of backup nexthops (%u)",
+				 __func__, api->backup_nexthop_num);
+			return -1;
+		}
+
+		for (i = 0; i < api->backup_nexthop_num; i++) {
+			api_nh = &api->backup_nexthops[i];
 
 			if (zapi_nexthop_decode(s, api_nh, api->flags) != 0)
 				return -1;
@@ -1424,6 +1498,11 @@ int zapi_nexthop_from_nexthop(struct zapi_nexthop *znh,
 	znh->gate = nh->gate;
 
 	if (nh->nh_label && (nh->nh_label->num_labels > 0)) {
+
+		/* Validate */
+		if (nh->nh_label->num_labels > MPLS_MAX_LABELS)
+			return -1;
+
 		for (i = 0; i < nh->nh_label->num_labels; i++)
 			znh->labels[i] = nh->nh_label->label[i];
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1388,7 +1388,7 @@ stream_failure:
 	return false;
 }
 
-struct nexthop *nexthop_from_zapi_nexthop(struct zapi_nexthop *znh)
+struct nexthop *nexthop_from_zapi_nexthop(const struct zapi_nexthop *znh)
 {
 	struct nexthop *n = nexthop_new();
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -341,6 +341,9 @@ struct zclient {
 #define ZAPI_MESSAGE_TAG      0x08
 #define ZAPI_MESSAGE_MTU      0x10
 #define ZAPI_MESSAGE_SRCPFX   0x20
+/* Backup nexthops are present */
+#define ZAPI_MESSAGE_BACKUP_NEXTHOPS 0x40
+
 /*
  * This should only be used by a DAEMON that needs to communicate
  * the table being used is not in the VRF.  You must pass the
@@ -377,14 +380,21 @@ struct zapi_nexthop {
 	struct ethaddr rmac;
 
 	uint32_t weight;
+
+	/* Index of backup nexthop */
+	uint8_t backup_idx;
 };
 
 /*
- * ZAPI nexthop flags values
+ * ZAPI nexthop flags values - we're encoding a single octet
+ * initially, so ensure that the on-the-wire encoding continues
+ * to match the number of valid flags.
  */
+
 #define ZAPI_NEXTHOP_FLAG_ONLINK	0x01
 #define ZAPI_NEXTHOP_FLAG_LABEL		0x02
 #define ZAPI_NEXTHOP_FLAG_WEIGHT	0x04
+#define ZAPI_NEXTHOP_FLAG_HAS_BACKUP	0x08 /* Nexthop has a backup */
 
 /*
  * Some of these data structures do not map easily to
@@ -447,6 +457,10 @@ struct zapi_route {
 
 	uint16_t nexthop_num;
 	struct zapi_nexthop nexthops[MULTIPATH_NUM];
+
+	/* Support backup routes for IP FRR, TI-LFA, traffic engineering */
+	uint16_t backup_nexthop_num;
+	struct zapi_nexthop backup_nexthops[MULTIPATH_NUM];
 
 	uint8_t distance;
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -783,10 +783,12 @@ bool zapi_iptable_notify_decode(struct stream *s,
 		uint32_t *unique,
 		enum zapi_iptable_notify_owner *note);
 
-extern struct nexthop *nexthop_from_zapi_nexthop(
-	const struct zapi_nexthop *znh);
+extern struct nexthop *
+nexthop_from_zapi_nexthop(const struct zapi_nexthop *znh);
 int zapi_nexthop_from_nexthop(struct zapi_nexthop *znh,
 			      const struct nexthop *nh);
+int zapi_backup_nexthop_from_nexthop(struct zapi_nexthop *znh,
+				     const struct nexthop *nh);
 extern bool zapi_nexthop_update_decode(struct stream *s,
 				       struct zapi_route *nhr);
 

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -769,7 +769,8 @@ bool zapi_iptable_notify_decode(struct stream *s,
 		uint32_t *unique,
 		enum zapi_iptable_notify_owner *note);
 
-extern struct nexthop *nexthop_from_zapi_nexthop(struct zapi_nexthop *znh);
+extern struct nexthop *nexthop_from_zapi_nexthop(
+	const struct zapi_nexthop *znh);
 int zapi_nexthop_from_nexthop(struct zapi_nexthop *znh,
 			      const struct nexthop *nh);
 extern bool zapi_nexthop_update_decode(struct stream *s,

--- a/sharpd/sharp_globals.h
+++ b/sharpd/sharp_globals.h
@@ -28,9 +28,11 @@ struct sharp_routes {
 	/* The original prefix for route installation */
 	struct prefix orig_prefix;
 
-	/* The nexthop group we are using for installation */
+	/* The nexthop info we are using for installation */
 	struct nexthop nhop;
+	struct nexthop backup_nhop;
 	struct nexthop_group nhop_group;
+	struct nexthop_group backup_nhop_group;
 
 	uint32_t total_routes;
 	uint32_t installed_routes;

--- a/sharpd/sharp_zebra.h
+++ b/sharpd/sharp_zebra.h
@@ -25,15 +25,17 @@
 extern void sharp_zebra_init(void);
 
 extern void vrf_label_add(vrf_id_t vrf_id, afi_t afi, mpls_label_t label);
-extern void route_add(struct prefix *p, vrf_id_t, uint8_t instance,
-		      struct nexthop_group *nhg);
+extern void route_add(const struct prefix *p, vrf_id_t, uint8_t instance,
+		      const struct nexthop_group *nhg,
+		      const struct nexthop_group *backup_nhg);
 extern void route_delete(struct prefix *p, vrf_id_t vrf_id, uint8_t instance);
 extern void sharp_zebra_nexthop_watch(struct prefix *p, vrf_id_t vrf_id,
 				      bool import, bool watch, bool connected);
 
 extern void sharp_install_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 					uint8_t instance,
-					struct nexthop_group *nhg,
+					const struct nexthop_group *nhg,
+					const struct nexthop_group *backup_nhg,
 					uint32_t routes);
 extern void sharp_remove_routes_helper(struct prefix *p, vrf_id_t vrf_id,
 				       uint8_t instance, uint32_t routes);

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -107,7 +107,7 @@ struct route_entry {
 	/* Uptime. */
 	time_t uptime;
 
-	/* Type fo this route. */
+	/* Type of this route. */
 	int type;
 
 	/* VRF identifier. */
@@ -347,10 +347,16 @@ extern int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 		   struct prefix_ipv6 *src_p, const struct nexthop *nh,
 		   uint32_t nhe_id, uint32_t table_id, uint32_t metric,
 		   uint32_t mtu, uint8_t distance, route_tag_t tag);
-
+/*
+ * Multipath route apis.
+ */
 extern int rib_add_multipath(afi_t afi, safi_t safi, struct prefix *p,
 			     struct prefix_ipv6 *src_p, struct route_entry *re,
 			     struct nexthop_group *ng);
+extern int rib_add_multipath_nhe(afi_t afi, safi_t safi, struct prefix *p,
+				 struct prefix_ipv6 *src_p,
+				 struct route_entry *re,
+				 struct nhg_hash_entry *nhe);
 
 extern void rib_delete(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 		       unsigned short instance, int flags, struct prefix *p,

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1413,6 +1413,123 @@ void zserv_nexthop_num_warn(const char *caller, const struct prefix *p,
 	}
 }
 
+/*
+ * Create a new nexthop based on a zapi nexthop.
+ */
+static struct nexthop *nexthop_from_zapi(struct route_entry *re,
+					 const struct zapi_nexthop *api_nh,
+					 const struct zapi_route *api)
+{
+	struct nexthop *nexthop = NULL;
+	struct ipaddr vtep_ip;
+	struct interface *ifp;
+	char nhbuf[INET6_ADDRSTRLEN] = "";
+
+	if (IS_ZEBRA_DEBUG_RECV)
+		zlog_debug("nh type %d", api_nh->type);
+
+	switch (api_nh->type) {
+	case NEXTHOP_TYPE_IFINDEX:
+		nexthop = nexthop_from_ifindex(api_nh->ifindex, api_nh->vrf_id);
+		break;
+	case NEXTHOP_TYPE_IPV4:
+		if (IS_ZEBRA_DEBUG_RECV) {
+			inet_ntop(AF_INET, &api_nh->gate.ipv4, nhbuf,
+				  sizeof(nhbuf));
+			zlog_debug("%s: nh=%s, vrf_id=%d", __func__,
+				   nhbuf, api_nh->vrf_id);
+		}
+		nexthop = nexthop_from_ipv4(&api_nh->gate.ipv4, NULL,
+					    api_nh->vrf_id);
+		break;
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		if (IS_ZEBRA_DEBUG_RECV) {
+			inet_ntop(AF_INET, &api_nh->gate.ipv4, nhbuf,
+				  sizeof(nhbuf));
+			zlog_debug("%s: nh=%s, vrf_id=%d, ifindex=%d",
+				   __func__, nhbuf, api_nh->vrf_id,
+				   api_nh->ifindex);
+		}
+
+		nexthop = nexthop_from_ipv4_ifindex(
+			&api_nh->gate.ipv4, NULL, api_nh->ifindex,
+			api_nh->vrf_id);
+
+		ifp = if_lookup_by_index(api_nh->ifindex, api_nh->vrf_id);
+		if (ifp && connected_is_unnumbered(ifp))
+			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK);
+
+		/* Special handling for IPv4 routes sourced from EVPN:
+		 * the nexthop and associated MAC need to be installed.
+		 */
+		if (CHECK_FLAG(api->flags, ZEBRA_FLAG_EVPN_ROUTE)) {
+			memset(&vtep_ip, 0, sizeof(struct ipaddr));
+			vtep_ip.ipa_type = IPADDR_V4;
+			memcpy(&(vtep_ip.ipaddr_v4), &(api_nh->gate.ipv4),
+			       sizeof(struct in_addr));
+			zebra_vxlan_evpn_vrf_route_add(
+				api_nh->vrf_id, &api_nh->rmac,
+				&vtep_ip, &api->prefix);
+		}
+		break;
+	case NEXTHOP_TYPE_IPV6:
+		if (IS_ZEBRA_DEBUG_RECV) {
+			inet_ntop(AF_INET6, &api_nh->gate.ipv6, nhbuf,
+				  sizeof(nhbuf));
+			zlog_debug("%s: nh=%s, vrf_id=%d", __func__,
+				   nhbuf, api_nh->vrf_id);
+		}
+		nexthop = nexthop_from_ipv6(&api_nh->gate.ipv6, api_nh->vrf_id);
+		break;
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		if (IS_ZEBRA_DEBUG_RECV) {
+			inet_ntop(AF_INET6, &api_nh->gate.ipv6, nhbuf,
+				  sizeof(nhbuf));
+			zlog_debug("%s: nh=%s, vrf_id=%d, ifindex=%d",
+				   __func__, nhbuf, api_nh->vrf_id,
+				   api_nh->ifindex);
+		}
+		nexthop = nexthop_from_ipv6_ifindex(&api_nh->gate.ipv6,
+						    api_nh->ifindex,
+						    api_nh->vrf_id);
+
+		/* Special handling for IPv6 routes sourced from EVPN:
+		 * the nexthop and associated MAC need to be installed.
+		 */
+		if (CHECK_FLAG(api->flags, ZEBRA_FLAG_EVPN_ROUTE)) {
+			memset(&vtep_ip, 0, sizeof(struct ipaddr));
+			vtep_ip.ipa_type = IPADDR_V6;
+			memcpy(&vtep_ip.ipaddr_v6, &(api_nh->gate.ipv6),
+			       sizeof(struct in6_addr));
+			zebra_vxlan_evpn_vrf_route_add(
+				api_nh->vrf_id, &api_nh->rmac,
+				&vtep_ip, &api->prefix);
+		}
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		if (IS_ZEBRA_DEBUG_RECV)
+			zlog_debug("%s: nh blackhole %d",
+				   __func__, api_nh->bh_type);
+
+		nexthop = nexthop_from_blackhole(api_nh->bh_type);
+		break;
+	}
+
+	/* Return early if we couldn't process the zapi nexthop */
+	if (nexthop == NULL) {
+		goto done;
+	}
+
+	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK))
+		SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK);
+
+	if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_WEIGHT))
+		nexthop->weight = api_nh->weight;
+
+done:
+	return nexthop;
+}
+
 static void zread_route_add(ZAPI_HANDLER_ARGS)
 {
 	struct stream *s;
@@ -1421,12 +1538,11 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	afi_t afi;
 	struct prefix_ipv6 *src_p = NULL;
 	struct route_entry *re;
-	struct nexthop *nexthop = NULL;
+	struct nexthop *nexthop = NULL, *last_nh;
 	struct nexthop_group *ng = NULL;
+	struct nexthop_group *backup_ng = NULL;
 	int i, ret;
 	vrf_id_t vrf_id;
-	struct ipaddr vtep_ip;
-	struct interface *ifp;
 
 	s = msg;
 	if (zapi_route_decode(s, &api) < 0) {
@@ -1469,6 +1585,15 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 		return;
 	}
 
+	/* Report misuse of the backup flag */
+	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_BACKUP_NEXTHOPS) &&
+	    api.backup_nexthop_num == 0) {
+		if (IS_ZEBRA_DEBUG_RECV || IS_ZEBRA_DEBUG_EVENT)
+			zlog_debug("%s: client %s: BACKUP flag set but no backup nexthops, prefix %pFX",
+				__func__,
+				zebra_route_string(client->proto), &api.prefix);
+	}
+
 	/* Use temporary list of nexthops */
 	ng = nexthop_group_new();
 
@@ -1479,92 +1604,9 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 	 */
 	for (i = 0; i < api.nexthop_num; i++) {
 		api_nh = &api.nexthops[i];
-		ifindex_t ifindex = 0;
 
-		nexthop = NULL;
-
-		if (IS_ZEBRA_DEBUG_RECV)
-			zlog_debug("nh type %d", api_nh->type);
-
-		switch (api_nh->type) {
-		case NEXTHOP_TYPE_IFINDEX:
-			nexthop = nexthop_from_ifindex(api_nh->ifindex,
-						       api_nh->vrf_id);
-			break;
-		case NEXTHOP_TYPE_IPV4:
-			if (IS_ZEBRA_DEBUG_RECV) {
-				char nhbuf[INET6_ADDRSTRLEN] = {0};
-
-				inet_ntop(AF_INET, &api_nh->gate.ipv4, nhbuf,
-					  INET6_ADDRSTRLEN);
-				zlog_debug("%s: nh=%s, vrf_id=%d", __func__,
-					   nhbuf, api_nh->vrf_id);
-			}
-			nexthop = nexthop_from_ipv4(&api_nh->gate.ipv4,
-						    NULL, api_nh->vrf_id);
-			break;
-		case NEXTHOP_TYPE_IPV4_IFINDEX:
-
-			memset(&vtep_ip, 0, sizeof(struct ipaddr));
-			ifindex = api_nh->ifindex;
-			if (IS_ZEBRA_DEBUG_RECV) {
-				char nhbuf[INET6_ADDRSTRLEN] = {0};
-
-				inet_ntop(AF_INET, &api_nh->gate.ipv4, nhbuf,
-					  INET6_ADDRSTRLEN);
-				zlog_debug(
-					"%s: nh=%s, vrf_id=%d (re->vrf_id=%d), ifindex=%d",
-					__func__, nhbuf, api_nh->vrf_id,
-					re->vrf_id, ifindex);
-			}
-			nexthop = nexthop_from_ipv4_ifindex(
-				&api_nh->gate.ipv4, NULL, ifindex,
-				api_nh->vrf_id);
-
-			ifp = if_lookup_by_index(ifindex, api_nh->vrf_id);
-			if (ifp && connected_is_unnumbered(ifp))
-				SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK);
-			/* Special handling for IPv4 routes sourced from EVPN:
-			 * the nexthop and associated MAC need to be installed.
-			 */
-			if (CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE)) {
-				vtep_ip.ipa_type = IPADDR_V4;
-				memcpy(&(vtep_ip.ipaddr_v4),
-				       &(api_nh->gate.ipv4),
-				       sizeof(struct in_addr));
-				zebra_vxlan_evpn_vrf_route_add(
-					api_nh->vrf_id, &api_nh->rmac,
-					&vtep_ip, &api.prefix);
-			}
-			break;
-		case NEXTHOP_TYPE_IPV6:
-			nexthop = nexthop_from_ipv6(&api_nh->gate.ipv6,
-						    api_nh->vrf_id);
-			break;
-		case NEXTHOP_TYPE_IPV6_IFINDEX:
-			memset(&vtep_ip, 0, sizeof(struct ipaddr));
-			ifindex = api_nh->ifindex;
-			nexthop = nexthop_from_ipv6_ifindex(&api_nh->gate.ipv6,
-							    ifindex,
-							    api_nh->vrf_id);
-
-			/* Special handling for IPv6 routes sourced from EVPN:
-			 * the nexthop and associated MAC need to be installed.
-			 */
-			if (CHECK_FLAG(api.flags, ZEBRA_FLAG_EVPN_ROUTE)) {
-				vtep_ip.ipa_type = IPADDR_V6;
-				memcpy(&vtep_ip.ipaddr_v6, &(api_nh->gate.ipv6),
-				       sizeof(struct in6_addr));
-				zebra_vxlan_evpn_vrf_route_add(
-					api_nh->vrf_id, &api_nh->rmac,
-					&vtep_ip, &api.prefix);
-			}
-			break;
-		case NEXTHOP_TYPE_BLACKHOLE:
-			nexthop = nexthop_from_blackhole(api_nh->bh_type);
-			break;
-		}
-
+		/* Convert zapi nexthop */
+		nexthop = nexthop_from_zapi(re, api_nh, &api);
 		if (!nexthop) {
 			flog_warn(
 				EC_ZEBRA_NEXTHOP_CREATION_FAILED,
@@ -1575,16 +1617,11 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 			return;
 		}
 
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_ONLINK))
-			SET_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK);
-
-		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_WEIGHT))
-			nexthop->weight = api_nh->weight;
-
 		/* MPLS labels for BGP-LU or Segment Routing */
 		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL)
 		    && api_nh->type != NEXTHOP_TYPE_IFINDEX
-		    && api_nh->type != NEXTHOP_TYPE_BLACKHOLE) {
+		    && api_nh->type != NEXTHOP_TYPE_BLACKHOLE
+		    && api_nh->label_num > 0) {
 			enum lsp_types_t label_type;
 
 			label_type = lsp_type_from_re_type(client->proto);
@@ -1603,6 +1640,65 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 
 		/* Add new nexthop to temporary list */
 		nexthop_group_add_sorted(ng, nexthop);
+		nexthop = NULL;
+	}
+
+	/* Allocate temporary list of backup nexthops, if necessary */
+	if (api.backup_nexthop_num > 0) {
+		backup_ng = nexthop_group_new();
+		nexthop = NULL;
+		last_nh = NULL;
+	}
+
+	/* Copy backup nexthops also, if present */
+	for (i = 0; i < api.backup_nexthop_num; i++) {
+		api_nh = &api.backup_nexthops[i];
+
+		/* Convert zapi backup nexthop */
+		nexthop = nexthop_from_zapi(re, api_nh, &api);
+		if (!nexthop) {
+			flog_warn(
+				EC_ZEBRA_NEXTHOP_CREATION_FAILED,
+				"%s: Backup Nexthops Specified: %d but we failed to properly create one",
+				__func__, api.backup_nexthop_num);
+			nexthop_group_delete(&ng);
+			nexthop_group_delete(&backup_ng);
+			XFREE(MTYPE_RE, re);
+			return;
+		}
+
+		/* MPLS labels for BGP-LU or Segment Routing */
+		if (CHECK_FLAG(api_nh->flags, ZAPI_NEXTHOP_FLAG_LABEL)
+		    && api_nh->type != NEXTHOP_TYPE_IFINDEX
+		    && api_nh->type != NEXTHOP_TYPE_BLACKHOLE
+		    && api_nh->label_num > 0) {
+			enum lsp_types_t label_type;
+
+			label_type = lsp_type_from_re_type(client->proto);
+
+			if (IS_ZEBRA_DEBUG_RECV) {
+				zlog_debug(
+					"%s: adding %d labels of type %d (1st=%u)",
+					__func__, api_nh->label_num, label_type,
+					api_nh->labels[0]);
+			}
+
+			nexthop_add_labels(nexthop, label_type,
+					   api_nh->label_num,
+					   &api_nh->labels[0]);
+		}
+
+		/* Note that the order of the backup nexthops is significant
+		 * at this point - we don't sort this list as we do the
+		 * primary nexthops, we just append.
+		 */
+		if (last_nh) {
+			NEXTHOP_APPEND(last_nh, nexthop);
+		} else {
+			backup_ng->nexthop = nexthop;
+		}
+
+		last_nh = nexthop;
 	}
 
 	if (CHECK_FLAG(api.message, ZAPI_MESSAGE_DISTANCE))
@@ -1620,6 +1716,7 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 			  "%s: Received SRC Prefix but afi is not v6",
 			  __func__);
 		nexthop_group_delete(&ng);
+		nexthop_group_delete(&backup_ng);
 		XFREE(MTYPE_RE, re);
 		return;
 	}

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1440,8 +1440,8 @@ static void zread_route_add(ZAPI_HANDLER_ARGS)
 		char buf_prefix[PREFIX_STRLEN];
 
 		prefix2str(&api.prefix, buf_prefix, sizeof(buf_prefix));
-		zlog_debug("%s: p=%s, flags=0x%x",
-			   __func__, buf_prefix, api.flags);
+		zlog_debug("%s: p=%s, msg flags=0x%x, flags=0x%x",
+			   __func__, buf_prefix, (int)api.message, api.flags);
 	}
 
 	/* Allocate new route. */

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -270,10 +270,18 @@ void dplane_ctx_set_distance(struct zebra_dplane_ctx *ctx, uint8_t distance);
 uint8_t dplane_ctx_get_old_distance(const struct zebra_dplane_ctx *ctx);
 
 void dplane_ctx_set_nexthops(struct zebra_dplane_ctx *ctx, struct nexthop *nh);
+
+uint32_t dplane_ctx_get_nhg_id(const struct zebra_dplane_ctx *ctx);
 const struct nexthop_group *dplane_ctx_get_ng(
 	const struct zebra_dplane_ctx *ctx);
 const struct nexthop_group *dplane_ctx_get_old_ng(
 	const struct zebra_dplane_ctx *ctx);
+
+/* Backup nexthop information (list of nexthops) if present. */
+const struct nexthop_group *
+dplane_ctx_get_backup_ng(const struct zebra_dplane_ctx *ctx);
+const struct nexthop_group *
+dplane_ctx_get_old_backup_ng(const struct zebra_dplane_ctx *ctx);
 
 /* Accessors for nexthop information */
 uint32_t dplane_ctx_get_nhe_id(const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_mpls.c
+++ b/zebra/zebra_mpls.c
@@ -98,14 +98,14 @@ static void lsp_free(struct hash *lsp_table, zebra_lsp_t **plsp);
 
 static char *nhlfe2str(zebra_nhlfe_t *nhlfe, char *buf, int size);
 static int nhlfe_nhop_match(zebra_nhlfe_t *nhlfe, enum nexthop_types_t gtype,
-			    union g_addr *gate, ifindex_t ifindex);
+			    const union g_addr *gate, ifindex_t ifindex);
 static zebra_nhlfe_t *nhlfe_find(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
-				 enum nexthop_types_t gtype, union g_addr *gate,
-				 ifindex_t ifindex);
+				 enum nexthop_types_t gtype,
+				 const union g_addr *gate, ifindex_t ifindex);
 static zebra_nhlfe_t *nhlfe_add(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
-				enum nexthop_types_t gtype, union g_addr *gate,
-				ifindex_t ifindex, uint8_t num_labels,
-				mpls_label_t *labels);
+				enum nexthop_types_t gtype,
+				const union g_addr *gate, ifindex_t ifindex,
+				uint8_t num_labels, mpls_label_t *labels);
 static int nhlfe_del(zebra_nhlfe_t *snhlfe);
 static void nhlfe_out_label_update(zebra_nhlfe_t *nhlfe,
 				   struct mpls_label_stack *nh_label);
@@ -117,13 +117,13 @@ static void nhlfe_print(zebra_nhlfe_t *nhlfe, struct vty *vty);
 static void lsp_print(zebra_lsp_t *lsp, void *ctxt);
 static void *slsp_alloc(void *p);
 static int snhlfe_match(zebra_snhlfe_t *snhlfe, enum nexthop_types_t gtype,
-			union g_addr *gate, ifindex_t ifindex);
+			const union g_addr *gate, ifindex_t ifindex);
 static zebra_snhlfe_t *snhlfe_find(zebra_slsp_t *slsp,
 				   enum nexthop_types_t gtype,
-				   union g_addr *gate, ifindex_t ifindex);
+				   const union g_addr *gate, ifindex_t ifindex);
 static zebra_snhlfe_t *snhlfe_add(zebra_slsp_t *slsp,
 				  enum nexthop_types_t gtype,
-				  union g_addr *gate, ifindex_t ifindex,
+				  const union g_addr *gate, ifindex_t ifindex,
 				  mpls_label_t out_label);
 static int snhlfe_del(zebra_snhlfe_t *snhlfe);
 static int snhlfe_del_all(zebra_slsp_t *slsp);
@@ -960,7 +960,7 @@ static wq_item_status lsp_process(struct work_queue *wq, void *data)
 			UNSET_FLAG(lsp->flags, LSP_FLAG_CHANGED);
 
 			/* We leave the INSTALLED flag set here
-			 * so we know an update in in-flight.
+			 * so we know an update is in-flight.
 			 */
 
 			/*
@@ -1149,7 +1149,7 @@ static char *nhlfe2str(zebra_nhlfe_t *nhlfe, char *buf, int size)
  * Check if NHLFE matches with search info passed.
  */
 static int nhlfe_nhop_match(zebra_nhlfe_t *nhlfe, enum nexthop_types_t gtype,
-			    union g_addr *gate, ifindex_t ifindex)
+			    const union g_addr *gate, ifindex_t ifindex)
 {
 	struct nexthop *nhop;
 	int cmp = 1;
@@ -1191,8 +1191,8 @@ static int nhlfe_nhop_match(zebra_nhlfe_t *nhlfe, enum nexthop_types_t gtype,
  * Locate NHLFE that matches with passed info.
  */
 static zebra_nhlfe_t *nhlfe_find(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
-				 enum nexthop_types_t gtype, union g_addr *gate,
-				 ifindex_t ifindex)
+				 enum nexthop_types_t gtype,
+				 const union g_addr *gate, ifindex_t ifindex)
 {
 	zebra_nhlfe_t *nhlfe;
 
@@ -1214,9 +1214,9 @@ static zebra_nhlfe_t *nhlfe_find(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
  * check done.
  */
 static zebra_nhlfe_t *nhlfe_add(zebra_lsp_t *lsp, enum lsp_types_t lsp_type,
-				enum nexthop_types_t gtype, union g_addr *gate,
-				ifindex_t ifindex, uint8_t num_labels,
-				mpls_label_t labels[])
+				enum nexthop_types_t gtype,
+				const union g_addr *gate, ifindex_t ifindex,
+				uint8_t num_labels, mpls_label_t labels[])
 {
 	zebra_nhlfe_t *nhlfe;
 	struct nexthop *nexthop;
@@ -1520,7 +1520,7 @@ static struct list *hash_get_sorted_list(struct hash *hash, void *cmp)
 /*
  * Compare two LSPs based on their label values.
  */
-static int lsp_cmp(zebra_lsp_t *lsp1, zebra_lsp_t *lsp2)
+static int lsp_cmp(const zebra_lsp_t *lsp1, const zebra_lsp_t *lsp2)
 {
 	if (lsp1->ile.in_label < lsp2->ile.in_label)
 		return -1;
@@ -1547,7 +1547,7 @@ static void *slsp_alloc(void *p)
 /*
  * Compare two static LSPs based on their label values.
  */
-static int slsp_cmp(zebra_slsp_t *slsp1, zebra_slsp_t *slsp2)
+static int slsp_cmp(const zebra_slsp_t *slsp1, const zebra_slsp_t *slsp2)
 {
 	if (slsp1->ile.in_label < slsp2->ile.in_label)
 		return -1;
@@ -1562,7 +1562,7 @@ static int slsp_cmp(zebra_slsp_t *slsp1, zebra_slsp_t *slsp2)
  * Check if static NHLFE matches with search info passed.
  */
 static int snhlfe_match(zebra_snhlfe_t *snhlfe, enum nexthop_types_t gtype,
-			union g_addr *gate, ifindex_t ifindex)
+			const union g_addr *gate, ifindex_t ifindex)
 {
 	int cmp = 1;
 
@@ -1593,7 +1593,7 @@ static int snhlfe_match(zebra_snhlfe_t *snhlfe, enum nexthop_types_t gtype,
  */
 static zebra_snhlfe_t *snhlfe_find(zebra_slsp_t *slsp,
 				   enum nexthop_types_t gtype,
-				   union g_addr *gate, ifindex_t ifindex)
+				   const union g_addr *gate, ifindex_t ifindex)
 {
 	zebra_snhlfe_t *snhlfe;
 
@@ -1615,7 +1615,7 @@ static zebra_snhlfe_t *snhlfe_find(zebra_slsp_t *slsp,
  */
 static zebra_snhlfe_t *snhlfe_add(zebra_slsp_t *slsp,
 				  enum nexthop_types_t gtype,
-				  union g_addr *gate, ifindex_t ifindex,
+				  const union g_addr *gate, ifindex_t ifindex,
 				  mpls_label_t out_label)
 {
 	zebra_snhlfe_t *snhlfe;
@@ -2746,7 +2746,7 @@ int mpls_ftn_uninstall(struct zebra_vrf *zvrf, enum lsp_types_t type,
 int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 		     mpls_label_t in_label, uint8_t num_out_labels,
 		     mpls_label_t out_labels[], enum nexthop_types_t gtype,
-		     union g_addr *gate, ifindex_t ifindex)
+		     const union g_addr *gate, ifindex_t ifindex)
 {
 	struct hash *lsp_table;
 	zebra_ile_t tmp_ile;
@@ -2759,11 +2759,12 @@ int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 	if (!lsp_table)
 		return -1;
 
-	/* If entry is present, exit. */
+	/* Find or create LSP object */
 	tmp_ile.in_label = in_label;
 	lsp = hash_get(lsp_table, &tmp_ile, lsp_alloc);
 	if (!lsp)
 		return -1;
+
 	nhlfe = nhlfe_find(lsp, type, gtype, gate, ifindex);
 	if (nhlfe) {
 		struct nexthop *nh = nhlfe->nexthop;
@@ -2780,8 +2781,8 @@ int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 			return 0;
 
 		if (IS_ZEBRA_DEBUG_MPLS) {
-			char buf2[BUFSIZ];
-			char buf3[BUFSIZ];
+			char buf2[MPLS_LABEL_STRLEN];
+			char buf3[MPLS_LABEL_STRLEN];
 
 			nhlfe2str(nhlfe, buf, BUFSIZ);
 			mpls_label2str(num_out_labels, out_labels, buf2,
@@ -2842,7 +2843,7 @@ int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
  */
 int mpls_lsp_uninstall(struct zebra_vrf *zvrf, enum lsp_types_t type,
 		       mpls_label_t in_label, enum nexthop_types_t gtype,
-		       union g_addr *gate, ifindex_t ifindex)
+		       const union g_addr *gate, ifindex_t ifindex)
 {
 	struct hash *lsp_table;
 	zebra_ile_t tmp_ile;
@@ -3056,11 +3057,12 @@ int zebra_mpls_static_lsp_add(struct zebra_vrf *zvrf, mpls_label_t in_label,
 	if (!slsp_table)
 		return -1;
 
-	/* If entry is present, exit. */
+	/* Find or create LSP. */
 	tmp_ile.in_label = in_label;
 	slsp = hash_get(slsp_table, &tmp_ile, slsp_alloc);
 	if (!slsp)
 		return -1;
+
 	snhlfe = snhlfe_find(slsp, gtype, gate, ifindex);
 	if (snhlfe) {
 		if (snhlfe->out_label == out_label)

--- a/zebra/zebra_mpls.h
+++ b/zebra/zebra_mpls.h
@@ -288,7 +288,7 @@ int mpls_ftn_uninstall(struct zebra_vrf *zvrf, enum lsp_types_t type,
 int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
 		     mpls_label_t in_label, uint8_t num_out_labels,
 		     mpls_label_t out_labels[], enum nexthop_types_t gtype,
-		     union g_addr *gate, ifindex_t ifindex);
+		     const union g_addr *gate, ifindex_t ifindex);
 
 /*
  * Uninstall a particular NHLFE in the forwarding table. If this is
@@ -296,7 +296,7 @@ int mpls_lsp_install(struct zebra_vrf *zvrf, enum lsp_types_t type,
  */
 int mpls_lsp_uninstall(struct zebra_vrf *zvrf, enum lsp_types_t type,
 		       mpls_label_t in_label, enum nexthop_types_t gtype,
-		       union g_addr *gate, ifindex_t ifindex);
+		       const union g_addr *gate, ifindex_t ifindex);
 
 /*
  * Uninstall all NHLFEs for a particular LSP forwarding entry.

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -187,11 +187,17 @@ void zebra_nhg_free(struct nhg_hash_entry *nhe);
 /* In order to clear a generic hash, we need a generic api, sigh. */
 void zebra_nhg_hash_free(void *p);
 
+/* Init an nhe, for use in a hash lookup for example. There's some fuzziness
+ * if the nhe represents only a single nexthop, so we try to capture that
+ * variant also.
+ */
+void zebra_nhe_init(struct nhg_hash_entry *nhe, afi_t afi,
+		    const struct nexthop *nh);
+
 /* Allocate, free backup nexthop info objects */
 struct nhg_backup_info *zebra_nhg_backup_alloc(void);
 void zebra_nhg_backup_free(struct nhg_backup_info **p);
 
-struct nhg_hash_entry *zebra_nhg_get_backup_nhe(struct nhg_hash_entry *nhe);
 struct nexthop_group *zebra_nhg_get_backup_nhg(struct nhg_hash_entry *nhe);
 
 extern struct nhg_hash_entry *zebra_nhg_resolve(struct nhg_hash_entry *nhe);
@@ -228,9 +234,13 @@ extern int zebra_nhg_kernel_find(uint32_t id, struct nexthop *nh,
 /* Del via kernel */
 extern int zebra_nhg_kernel_del(uint32_t id, vrf_id_t vrf_id);
 
-/* Find via route creation */
+/* Find an nhe based on a nexthop_group */
 extern struct nhg_hash_entry *
 zebra_nhg_rib_find(uint32_t id, struct nexthop_group *nhg, afi_t rt_afi);
+
+/* Find an nhe based on a route's nhe, used during route creation */
+struct nhg_hash_entry *
+zebra_nhg_rib_find_nhe(struct nhg_hash_entry *rt_nhe, afi_t rt_afi);
 
 /* Reference counter functions */
 extern void zebra_nhg_decrement_ref(struct nhg_hash_entry *nhe);

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -164,7 +164,8 @@ DEFUN (show_ip_rpf_addr,
 	return CMD_SUCCESS;
 }
 
-static char re_status_output_char(struct route_entry *re, struct nexthop *nhop)
+static char re_status_output_char(const struct route_entry *re,
+				  const struct nexthop *nhop)
 {
 	if (CHECK_FLAG(re->status, ROUTE_ENTRY_INSTALLED)) {
 		if (!CHECK_FLAG(nhop->flags, NEXTHOP_FLAG_DUPLICATE) &&
@@ -185,6 +186,152 @@ static char re_status_output_char(struct route_entry *re, struct nexthop *nhop)
 		return 'q';
 
 	return ' ';
+}
+
+/*
+ * TODO -- Show backup nexthop info
+ */
+static void show_nh_backup_helper(struct vty *vty,
+				  const struct nhg_hash_entry *nhe,
+				  const struct nexthop *nexthop)
+{
+	/* Double-check that there _is_ a backup */
+	if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP))
+		return;
+
+	/* Locate the backup nexthop */
+
+	/* Format the backup (indented) */
+
+}
+
+/*
+ * Helper api to format output for a nexthop, used in the 'detailed'
+ * output path.
+ */
+static void show_nexthop_detail_helper(struct vty *vty,
+				       const struct route_entry *re,
+				       const struct nexthop *nexthop)
+{
+	char addrstr[32];
+	char buf[MPLS_LABEL_STRLEN];
+
+	vty_out(vty, "  %c%s",
+		re_status_output_char(re, nexthop),
+		nexthop->rparent ? "  " : "");
+
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		vty_out(vty, " %s",
+			inet_ntoa(nexthop->gate.ipv4));
+		if (nexthop->ifindex)
+			vty_out(vty, ", via %s",
+				ifindex2ifname(
+					nexthop->ifindex,
+					nexthop->vrf_id));
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		vty_out(vty, " %s",
+			inet_ntop(AF_INET6, &nexthop->gate.ipv6,
+				  buf, sizeof(buf)));
+		if (nexthop->ifindex)
+			vty_out(vty, ", via %s",
+				ifindex2ifname(
+					nexthop->ifindex,
+					nexthop->vrf_id));
+		break;
+
+	case NEXTHOP_TYPE_IFINDEX:
+		vty_out(vty, " directly connected, %s",
+			ifindex2ifname(nexthop->ifindex,
+				       nexthop->vrf_id));
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		vty_out(vty, " unreachable");
+		switch (nexthop->bh_type) {
+		case BLACKHOLE_REJECT:
+			vty_out(vty, " (ICMP unreachable)");
+			break;
+		case BLACKHOLE_ADMINPROHIB:
+			vty_out(vty,
+				" (ICMP admin-prohibited)");
+			break;
+		case BLACKHOLE_NULL:
+			vty_out(vty, " (blackhole)");
+			break;
+		case BLACKHOLE_UNSPEC:
+			break;
+		}
+		break;
+	default:
+		break;
+	}
+
+	if ((re->vrf_id != nexthop->vrf_id)
+	    && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
+		struct vrf *vrf =
+			vrf_lookup_by_id(nexthop->vrf_id);
+
+		if (vrf)
+			vty_out(vty, "(vrf %s)", vrf->name);
+		else
+			vty_out(vty, "(vrf UNKNOWN)");
+	}
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
+		vty_out(vty, " (duplicate nexthop removed)");
+
+	if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
+		vty_out(vty, " inactive");
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK))
+		vty_out(vty, " onlink");
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+		vty_out(vty, " (recursive)");
+
+	/* Source specified? */
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		if (nexthop->src.ipv4.s_addr) {
+			if (inet_ntop(AF_INET, &nexthop->src.ipv4,
+				      addrstr, sizeof(addrstr)))
+				vty_out(vty, ", src %s",
+					addrstr);
+		}
+		break;
+
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		if (!IPV6_ADDR_SAME(&nexthop->src.ipv6,
+				    &in6addr_any)) {
+			if (inet_ntop(AF_INET6, &nexthop->src.ipv6,
+				      addrstr, sizeof(addrstr)))
+				vty_out(vty, ", src %s",
+					addrstr);
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	if (re->nexthop_mtu)
+		vty_out(vty, ", mtu %u", re->nexthop_mtu);
+
+	/* Label information */
+	if (nexthop->nh_label && nexthop->nh_label->num_labels) {
+		vty_out(vty, ", label %s",
+			mpls_label2str(nexthop->nh_label->num_labels,
+				       nexthop->nh_label->label, buf,
+				       sizeof(buf), 1 /*pretty*/));
+	}
+
+	if (nexthop->weight)
+		vty_out(vty, ", weight %u", nexthop->weight);
 }
 
 /* New RIB.  Detailed information for IPv4 route. */
@@ -253,129 +400,122 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 			vty_out(vty, "  Nexthop Group ID: %u\n", re->nhe_id);
 
 		for (ALL_NEXTHOPS(re->nhe->nhg, nexthop)) {
-			char addrstr[32];
-
-			vty_out(vty, "  %c%s",
-				re_status_output_char(re, nexthop),
-				nexthop->rparent ? "  " : "");
-
-			switch (nexthop->type) {
-			case NEXTHOP_TYPE_IPV4:
-			case NEXTHOP_TYPE_IPV4_IFINDEX:
-				vty_out(vty, " %s",
-					inet_ntoa(nexthop->gate.ipv4));
-				if (nexthop->ifindex)
-					vty_out(vty, ", via %s",
-						ifindex2ifname(
-							nexthop->ifindex,
-							nexthop->vrf_id));
-				break;
-			case NEXTHOP_TYPE_IPV6:
-			case NEXTHOP_TYPE_IPV6_IFINDEX:
-				vty_out(vty, " %s",
-					inet_ntop(AF_INET6, &nexthop->gate.ipv6,
-						  buf, sizeof(buf)));
-				if (nexthop->ifindex)
-					vty_out(vty, ", via %s",
-						ifindex2ifname(
-							nexthop->ifindex,
-							nexthop->vrf_id));
-				break;
-			case NEXTHOP_TYPE_IFINDEX:
-				vty_out(vty, " directly connected, %s",
-					ifindex2ifname(nexthop->ifindex,
-						       nexthop->vrf_id));
-				break;
-			case NEXTHOP_TYPE_BLACKHOLE:
-				vty_out(vty, " unreachable");
-				switch (nexthop->bh_type) {
-				case BLACKHOLE_REJECT:
-					vty_out(vty, " (ICMP unreachable)");
-					break;
-				case BLACKHOLE_ADMINPROHIB:
-					vty_out(vty,
-						" (ICMP admin-prohibited)");
-					break;
-				case BLACKHOLE_NULL:
-					vty_out(vty, " (blackhole)");
-					break;
-				case BLACKHOLE_UNSPEC:
-					break;
-				}
-				break;
-			default:
-				break;
-			}
-
-			if ((re->vrf_id != nexthop->vrf_id)
-			     && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
-				struct vrf *vrf =
-					vrf_lookup_by_id(nexthop->vrf_id);
-
-				if (vrf)
-					vty_out(vty, "(vrf %s)", vrf->name);
-				else
-					vty_out(vty, "(vrf UNKNOWN)");
-			}
-
-			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_DUPLICATE))
-				vty_out(vty, " (duplicate nexthop removed)");
-
-			if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
-				vty_out(vty, " inactive");
-
-			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK))
-				vty_out(vty, " onlink");
-
-			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
-				vty_out(vty, " (recursive)");
-
-			switch (nexthop->type) {
-			case NEXTHOP_TYPE_IPV4:
-			case NEXTHOP_TYPE_IPV4_IFINDEX:
-				if (nexthop->src.ipv4.s_addr) {
-					if (inet_ntop(AF_INET,
-						      &nexthop->src.ipv4,
-						      addrstr, sizeof(addrstr)))
-						vty_out(vty, ", src %s",
-							addrstr);
-				}
-				break;
-			case NEXTHOP_TYPE_IPV6:
-			case NEXTHOP_TYPE_IPV6_IFINDEX:
-				if (!IPV6_ADDR_SAME(&nexthop->src.ipv6,
-						    &in6addr_any)) {
-					if (inet_ntop(AF_INET6,
-						      &nexthop->src.ipv6,
-						      addrstr, sizeof(addrstr)))
-						vty_out(vty, ", src %s",
-							addrstr);
-				}
-				break;
-			default:
-				break;
-			}
-
-			if (re->nexthop_mtu)
-				vty_out(vty, ", mtu %u", re->nexthop_mtu);
-
-			/* Label information */
-			if (nexthop->nh_label
-			    && nexthop->nh_label->num_labels) {
-				vty_out(vty, ", label %s",
-					mpls_label2str(
-						nexthop->nh_label->num_labels,
-						nexthop->nh_label->label, buf,
-						sizeof(buf), 1));
-			}
-
-			if (nexthop->weight)
-				vty_out(vty, ", weight %u", nexthop->weight);
-
+			/* Use helper to format each nexthop */
+			show_nexthop_detail_helper(vty, re, nexthop);
 			vty_out(vty, "\n");
+
+			/* Include backup info, if present */
+			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP))
+				show_nh_backup_helper(vty, re->nhe, nexthop);
 		}
 		vty_out(vty, "\n");
 	}
+}
+
+/*
+ * Helper for nexthop output, used in the 'show ip route' path
+ */
+static void show_route_nexthop_helper(struct vty *vty,
+				      const struct route_entry *re,
+				      const struct nexthop *nexthop)
+{
+	char buf[MPLS_LABEL_STRLEN];
+
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		vty_out(vty, " via %s", inet_ntoa(nexthop->gate.ipv4));
+		if (nexthop->ifindex)
+			vty_out(vty, ", %s",
+				ifindex2ifname(nexthop->ifindex,
+					       nexthop->vrf_id));
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		vty_out(vty, " via %s",
+			inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf,
+				  sizeof(buf)));
+		if (nexthop->ifindex)
+			vty_out(vty, ", %s",
+				ifindex2ifname(nexthop->ifindex,
+					       nexthop->vrf_id));
+		break;
+
+	case NEXTHOP_TYPE_IFINDEX:
+		vty_out(vty, " is directly connected, %s",
+			ifindex2ifname(nexthop->ifindex,
+				       nexthop->vrf_id));
+		break;
+	case NEXTHOP_TYPE_BLACKHOLE:
+		vty_out(vty, " unreachable");
+		switch (nexthop->bh_type) {
+		case BLACKHOLE_REJECT:
+			vty_out(vty, " (ICMP unreachable)");
+			break;
+		case BLACKHOLE_ADMINPROHIB:
+			vty_out(vty, " (ICMP admin-prohibited)");
+			break;
+		case BLACKHOLE_NULL:
+			vty_out(vty, " (blackhole)");
+			break;
+		case BLACKHOLE_UNSPEC:
+			break;
+		}
+		break;
+	default:
+		break;
+	}
+
+	if ((re == NULL || (nexthop->vrf_id != re->vrf_id)) &&
+	    (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
+		struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
+
+		if (vrf)
+			vty_out(vty, " (vrf %s)", vrf->name);
+		else
+			vty_out(vty, " (vrf UNKNOWN)");
+	}
+
+	if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
+		vty_out(vty, " inactive");
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK))
+		vty_out(vty, " onlink");
+
+	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+		vty_out(vty, " (recursive)");
+
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		if (nexthop->src.ipv4.s_addr) {
+			if (inet_ntop(AF_INET, &nexthop->src.ipv4, buf,
+				      sizeof(buf)))
+				vty_out(vty, ", src %s", buf);
+		}
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		if (!IPV6_ADDR_SAME(&nexthop->src.ipv6, &in6addr_any)) {
+			if (inet_ntop(AF_INET6, &nexthop->src.ipv6, buf,
+				      sizeof(buf)))
+				vty_out(vty, ", src %s", buf);
+		}
+		break;
+	default:
+		break;
+	}
+
+	/* Label information */
+	if (nexthop->nh_label && nexthop->nh_label->num_labels) {
+		vty_out(vty, ", label %s",
+			mpls_label2str(nexthop->nh_label->num_labels,
+				       nexthop->nh_label->label, buf,
+				       sizeof(buf), 1));
+	}
+
+	if ((re == NULL) && nexthop->weight)
+		vty_out(vty, ", weight %u", nexthop->weight);
 }
 
 static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
@@ -660,105 +800,43 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 				len - 3 + (2 * nexthop_level(nexthop)), ' ');
 		}
 
-		switch (nexthop->type) {
-		case NEXTHOP_TYPE_IPV4:
-		case NEXTHOP_TYPE_IPV4_IFINDEX:
-			vty_out(vty, " via %s", inet_ntoa(nexthop->gate.ipv4));
-			if (nexthop->ifindex)
-				vty_out(vty, ", %s",
-					ifindex2ifname(nexthop->ifindex,
-						       nexthop->vrf_id));
-			break;
-		case NEXTHOP_TYPE_IPV6:
-		case NEXTHOP_TYPE_IPV6_IFINDEX:
-			vty_out(vty, " via %s",
-				inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf,
-					  sizeof(buf)));
-			if (nexthop->ifindex)
-				vty_out(vty, ", %s",
-					ifindex2ifname(nexthop->ifindex,
-						       nexthop->vrf_id));
-			break;
-
-		case NEXTHOP_TYPE_IFINDEX:
-			vty_out(vty, " is directly connected, %s",
-				ifindex2ifname(nexthop->ifindex,
-					       nexthop->vrf_id));
-			break;
-		case NEXTHOP_TYPE_BLACKHOLE:
-			vty_out(vty, " unreachable");
-			switch (nexthop->bh_type) {
-			case BLACKHOLE_REJECT:
-				vty_out(vty, " (ICMP unreachable)");
-				break;
-			case BLACKHOLE_ADMINPROHIB:
-				vty_out(vty, " (ICMP admin-prohibited)");
-				break;
-			case BLACKHOLE_NULL:
-				vty_out(vty, " (blackhole)");
-				break;
-			case BLACKHOLE_UNSPEC:
-				break;
-			}
-			break;
-		default:
-			break;
-		}
-
-		if ((nexthop->vrf_id != re->vrf_id)
-		     && (nexthop->type != NEXTHOP_TYPE_BLACKHOLE)) {
-			struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
-
-			if (vrf)
-				vty_out(vty, "(vrf %s)", vrf->name);
-			else
-				vty_out(vty, "(vrf UNKNOWN)");
-		}
-
-		if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
-			vty_out(vty, " inactive");
-
-		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK))
-			vty_out(vty, " onlink");
-
-		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
-			vty_out(vty, " (recursive)");
-
-		switch (nexthop->type) {
-		case NEXTHOP_TYPE_IPV4:
-		case NEXTHOP_TYPE_IPV4_IFINDEX:
-			if (nexthop->src.ipv4.s_addr) {
-				if (inet_ntop(AF_INET, &nexthop->src.ipv4, buf,
-					      sizeof(buf)))
-					vty_out(vty, ", src %s", buf);
-			}
-			break;
-		case NEXTHOP_TYPE_IPV6:
-		case NEXTHOP_TYPE_IPV6_IFINDEX:
-			if (!IPV6_ADDR_SAME(&nexthop->src.ipv6, &in6addr_any)) {
-				if (inet_ntop(AF_INET6, &nexthop->src.ipv6, buf,
-					      sizeof(buf)))
-					vty_out(vty, ", src %s", buf);
-			}
-			break;
-		default:
-			break;
-		}
-
-		/* Label information */
-		if (nexthop->nh_label && nexthop->nh_label->num_labels) {
-			vty_out(vty, ", label %s",
-				mpls_label2str(nexthop->nh_label->num_labels,
-					       nexthop->nh_label->label, buf,
-					       sizeof(buf), 1));
-		}
+		show_route_nexthop_helper(vty, re, nexthop);
 
 		vty_out(vty, ", %s\n", up_str);
+
+		/* Check for backup info */
+		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP)) {
+			struct nexthop *backup;
+			int i;
+
+			if (re->nhe->backup_info == NULL ||
+			    re->nhe->backup_info->nhe == NULL)
+				continue;
+
+			i = 0;
+			for (ALL_NEXTHOPS(re->nhe->backup_info->nhe->nhg,
+					  backup)) {
+				if (i == nexthop->backup_idx)
+					break;
+				i++;
+			}
+
+			/* Print useful backup info */
+			if (backup) {
+				/* TODO -- install state is not accurate */
+				vty_out(vty, "   %*c [backup %d]",
+					/*re_status_output_char(re, backup),*/
+					len - 3 + (2 * nexthop_level(nexthop)),
+					' ', nexthop->backup_idx);
+				show_route_nexthop_helper(vty, re, backup);
+				vty_out(vty, "\n");
+			}
+		}
 	}
 }
 
 static void vty_show_ip_route_detail_json(struct vty *vty,
-					struct route_node *rn, bool use_fib)
+					  struct route_node *rn, bool use_fib)
 {
 	json_object *json = NULL;
 	json_object *json_prefix = NULL;
@@ -1024,110 +1102,6 @@ DEFUN (ip_nht_default_route,
 	return CMD_SUCCESS;
 }
 
-/*
- * Helper that prints out a nexthop in an nhe/nhg
- */
-static void show_nhg_nh_helper(struct vty *vty, const struct nexthop *nexthop)
-{
-	char buf[SRCDEST2STR_BUFFER];
-
-	switch (nexthop->type) {
-	case NEXTHOP_TYPE_IPV4:
-	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		vty_out(vty, " %s", inet_ntoa(nexthop->gate.ipv4));
-		if (nexthop->ifindex)
-			vty_out(vty, ", %s",
-				ifindex2ifname(nexthop->ifindex,
-					       nexthop->vrf_id));
-		break;
-	case NEXTHOP_TYPE_IPV6:
-	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		vty_out(vty, " %s",
-			inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf,
-				  sizeof(buf)));
-		if (nexthop->ifindex)
-			vty_out(vty, ", %s",
-				ifindex2ifname(nexthop->ifindex,
-					       nexthop->vrf_id));
-		break;
-
-	case NEXTHOP_TYPE_IFINDEX:
-		vty_out(vty, " directly connected %s",
-			ifindex2ifname(nexthop->ifindex,
-				       nexthop->vrf_id));
-		break;
-	case NEXTHOP_TYPE_BLACKHOLE:
-		vty_out(vty, " unreachable");
-		switch (nexthop->bh_type) {
-		case BLACKHOLE_REJECT:
-			vty_out(vty, " (ICMP unreachable)");
-			break;
-		case BLACKHOLE_ADMINPROHIB:
-			vty_out(vty, " (ICMP admin-prohibited)");
-			break;
-		case BLACKHOLE_NULL:
-			vty_out(vty, " (blackhole)");
-			break;
-		case BLACKHOLE_UNSPEC:
-			break;
-		}
-		break;
-	default:
-		break;
-	}
-
-	struct vrf *vrf = vrf_lookup_by_id(nexthop->vrf_id);
-
-	if (vrf)
-		vty_out(vty, " (vrf %s)", vrf->name);
-	else
-		vty_out(vty, " (vrf UNKNOWN)");
-
-	if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE))
-		vty_out(vty, " inactive");
-
-	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ONLINK))
-		vty_out(vty, " onlink");
-
-	if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
-		vty_out(vty, " (recursive)");
-
-	switch (nexthop->type) {
-	case NEXTHOP_TYPE_IPV4:
-	case NEXTHOP_TYPE_IPV4_IFINDEX:
-		if (nexthop->src.ipv4.s_addr) {
-			if (inet_ntop(AF_INET, &nexthop->src.ipv4, buf,
-				      sizeof(buf)))
-				vty_out(vty, ", src %s", buf);
-		}
-		break;
-	case NEXTHOP_TYPE_IPV6:
-	case NEXTHOP_TYPE_IPV6_IFINDEX:
-		if (!IPV6_ADDR_SAME(&nexthop->src.ipv6, &in6addr_any)) {
-			if (inet_ntop(AF_INET6, &nexthop->src.ipv6, buf,
-				      sizeof(buf)))
-				vty_out(vty, ", src %s", buf);
-		}
-		break;
-	default:
-		break;
-	}
-
-	/* Label information */
-	if (nexthop->nh_label && nexthop->nh_label->num_labels) {
-		vty_out(vty, ", label %s",
-			mpls_label2str(nexthop->nh_label->num_labels,
-				       nexthop->nh_label->label, buf,
-				       sizeof(buf), 1));
-	}
-
-	if (nexthop->weight)
-		vty_out(vty, ", weight %u", nexthop->weight);
-
-	vty_out(vty, "\n");
-
-}
-
 static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe)
 {
 	struct nexthop *nexthop = NULL;
@@ -1173,7 +1147,39 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe)
 			/* Make recursive nexthops a bit more clear */
 			vty_out(vty, "       ");
 
-		show_nhg_nh_helper(vty, nexthop);
+		show_route_nexthop_helper(vty, NULL, nexthop);
+
+		if (nhe->backup_info == NULL || nhe->backup_info->nhe == NULL) {
+			if (CHECK_FLAG(nexthop->flags,
+				       NEXTHOP_FLAG_HAS_BACKUP))
+				vty_out(vty, " [backup %d]",
+					nexthop->backup_idx);
+
+			vty_out(vty, "\n");
+			continue;
+		}
+
+		/* TODO -- print more useful backup info */
+		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_HAS_BACKUP)) {
+			struct nexthop *backup;
+			int i;
+
+			i = 0;
+			for (ALL_NEXTHOPS(nhe->backup_info->nhe->nhg, backup)) {
+				if (i == nexthop->backup_idx)
+					break;
+				i++;
+			}
+
+			/* TODO */
+			if (backup)
+				vty_out(vty, " [backup %d]",
+					nexthop->backup_idx);
+			else
+				vty_out(vty, " [backup INVALID]");
+		}
+
+		vty_out(vty, "\n");
 	}
 
 	/* Output backup nexthops (if any) */
@@ -1188,7 +1194,8 @@ static void show_nexthop_group_out(struct vty *vty, struct nhg_hash_entry *nhe)
 				/* Make recursive nexthops a bit more clear */
 				vty_out(vty, "       ");
 
-			show_nhg_nh_helper(vty, nexthop);
+			show_route_nexthop_helper(vty, NULL, nexthop);
+			vty_out(vty, "\n");
 		}
 	}
 

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -121,11 +121,11 @@ static struct interface *zvni_map_to_macvlan(struct interface *br_if,
 
 /* l3-vni next-hop neigh related APIs */
 static zebra_neigh_t *zl3vni_nh_lookup(zebra_l3vni_t *zl3vni,
-				       struct ipaddr *ip);
+				       const struct ipaddr *ip);
 static void *zl3vni_nh_alloc(void *p);
 static zebra_neigh_t *zl3vni_nh_add(zebra_l3vni_t *zl3vni,
-				    struct ipaddr *vtep_ip,
-				    struct ethaddr *rmac);
+				    const struct ipaddr *vtep_ip,
+				    const struct ethaddr *rmac);
 static int zl3vni_nh_del(zebra_l3vni_t *zl3vni, zebra_neigh_t *n);
 static int zl3vni_nh_install(zebra_l3vni_t *zl3vni, zebra_neigh_t *n);
 static int zl3vni_nh_uninstall(zebra_l3vni_t *zl3vni, zebra_neigh_t *n);
@@ -133,10 +133,10 @@ static int zl3vni_nh_uninstall(zebra_l3vni_t *zl3vni, zebra_neigh_t *n);
 /* l3-vni rmac related APIs */
 static void zl3vni_print_rmac_hash(struct hash_bucket *, void *);
 static zebra_mac_t *zl3vni_rmac_lookup(zebra_l3vni_t *zl3vni,
-				       struct ethaddr *rmac);
+				       const struct ethaddr *rmac);
 static void *zl3vni_rmac_alloc(void *p);
 static zebra_mac_t *zl3vni_rmac_add(zebra_l3vni_t *zl3vni,
-				    struct ethaddr *rmac);
+				    const struct ethaddr *rmac);
 static int zl3vni_rmac_del(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac);
 static int zl3vni_rmac_install(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac);
 static int zl3vni_rmac_uninstall(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac);
@@ -4434,7 +4434,7 @@ static void zl3vni_cleanup_all(struct hash_bucket *bucket, void *args)
 }
 
 static void rb_find_or_add_host(struct host_rb_tree_entry *hrbe,
-				struct prefix *host)
+				const struct prefix *host)
 {
 	struct host_rb_entry lookup;
 	struct host_rb_entry *hle;
@@ -4473,7 +4473,7 @@ static void rb_delete_host(struct host_rb_tree_entry *hrbe, struct prefix *host)
  * Look up MAC hash entry.
  */
 static zebra_mac_t *zl3vni_rmac_lookup(zebra_l3vni_t *zl3vni,
-				       struct ethaddr *rmac)
+				       const struct ethaddr *rmac)
 {
 	zebra_mac_t tmp;
 	zebra_mac_t *pmac;
@@ -4502,7 +4502,8 @@ static void *zl3vni_rmac_alloc(void *p)
 /*
  * Add RMAC entry to l3-vni
  */
-static zebra_mac_t *zl3vni_rmac_add(zebra_l3vni_t *zl3vni, struct ethaddr *rmac)
+static zebra_mac_t *zl3vni_rmac_add(zebra_l3vni_t *zl3vni,
+				    const struct ethaddr *rmac)
 {
 	zebra_mac_t tmp_rmac;
 	zebra_mac_t *zrmac = NULL;
@@ -4632,9 +4633,10 @@ static int zl3vni_rmac_uninstall(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac)
 }
 
 /* handle rmac add */
-static int zl3vni_remote_rmac_add(zebra_l3vni_t *zl3vni, struct ethaddr *rmac,
-				  struct ipaddr *vtep_ip,
-				  struct prefix *host_prefix)
+static int zl3vni_remote_rmac_add(zebra_l3vni_t *zl3vni,
+				  const struct ethaddr *rmac,
+				  const struct ipaddr *vtep_ip,
+				  const struct prefix *host_prefix)
 {
 	char buf[ETHER_ADDR_STRLEN];
 	char buf1[INET6_ADDRSTRLEN];
@@ -4709,7 +4711,8 @@ static void zl3vni_remote_rmac_del(zebra_l3vni_t *zl3vni, zebra_mac_t *zrmac,
 /*
  * Look up nh hash entry on a l3-vni.
  */
-static zebra_neigh_t *zl3vni_nh_lookup(zebra_l3vni_t *zl3vni, struct ipaddr *ip)
+static zebra_neigh_t *zl3vni_nh_lookup(zebra_l3vni_t *zl3vni,
+				       const struct ipaddr *ip)
 {
 	zebra_neigh_t tmp;
 	zebra_neigh_t *n;
@@ -4739,8 +4742,9 @@ static void *zl3vni_nh_alloc(void *p)
 /*
  * Add neighbor entry.
  */
-static zebra_neigh_t *zl3vni_nh_add(zebra_l3vni_t *zl3vni, struct ipaddr *ip,
-				    struct ethaddr *mac)
+static zebra_neigh_t *zl3vni_nh_add(zebra_l3vni_t *zl3vni,
+				    const struct ipaddr *ip,
+				    const struct ethaddr *mac)
 {
 	zebra_neigh_t tmp_n;
 	zebra_neigh_t *n = NULL;
@@ -4822,9 +4826,10 @@ static int zl3vni_nh_uninstall(zebra_l3vni_t *zl3vni, zebra_neigh_t *n)
 }
 
 /* add remote vtep as a neigh entry */
-static int zl3vni_remote_nh_add(zebra_l3vni_t *zl3vni, struct ipaddr *vtep_ip,
-				struct ethaddr *rmac,
-				struct prefix *host_prefix)
+static int zl3vni_remote_nh_add(zebra_l3vni_t *zl3vni,
+				const struct ipaddr *vtep_ip,
+				const struct ethaddr *rmac,
+				const struct prefix *host_prefix)
 {
 	char buf[ETHER_ADDR_STRLEN];
 	char buf1[ETHER_ADDR_STRLEN];
@@ -5960,9 +5965,9 @@ int is_l3vni_for_prefix_routes_only(vni_t vni)
 }
 
 /* handle evpn route in vrf table */
-void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id, struct ethaddr *rmac,
-				    struct ipaddr *vtep_ip,
-				    struct prefix *host_prefix)
+void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id, const struct ethaddr *rmac,
+				    const struct ipaddr *vtep_ip,
+				    const struct prefix *host_prefix)
 {
 	zebra_l3vni_t *zl3vni = NULL;
 	struct ipaddr ipv4_vtep;

--- a/zebra/zebra_vxlan.h
+++ b/zebra/zebra_vxlan.h
@@ -199,9 +199,9 @@ extern void zebra_vxlan_cleanup_tables(struct zebra_vrf *);
 extern void zebra_vxlan_init(void);
 extern void zebra_vxlan_disable(void);
 extern void zebra_vxlan_evpn_vrf_route_add(vrf_id_t vrf_id,
-					   struct ethaddr *rmac,
-					   struct ipaddr *ip,
-					   struct prefix *host_prefix);
+					   const struct ethaddr *rmac,
+					   const struct ipaddr *ip,
+					   const struct prefix *host_prefix);
 extern void zebra_vxlan_evpn_vrf_route_del(vrf_id_t vrf_id,
 					   struct ipaddr *vtep_ip,
 					   struct prefix *host_prefix);


### PR DESCRIPTION
Some initial prep work to introduce backup nexthops for routes. The basic concept is that a route may have a list of backup nexthops, distinct from the list of ecmp nexthops it has currently. Each primary nexthop can refer to a backup nexthop in that backup list. I've extended the zapi route update messages to add (optional) backup nexthops. The nexthop-group cli and sharpd are extended so that we can exercise the path into zebra. If backups are present, they're including in the output of 'show ip route' and 'show nexthop-group rib'.

Some notes about the design and the goals are here; I'll keep extending this as the work progresses.

https://github.com/mjstapp/frr/wiki/Backup-nexthop-design
