### PR TITLE
Update ISIS-SR with new ZAPI message

### DIFF
--- a/isisd/isis_sr.c
+++ b/isisd/isis_sr.c
@@ -970,7 +970,7 @@ static void isis_sr_adj_sid_install_uninstall(bool install,
 					      const struct sr_adjacency *sra)
 {
 	struct zapi_labels zl;
-	struct zapi_nexthop_label *znh;
+	struct zapi_nexthop *znh;
 	int cmd;
 
 	cmd = install ? ZEBRA_MPLS_LABELS_ADD : ZEBRA_MPLS_LABELS_DELETE;
@@ -980,13 +980,13 @@ static void isis_sr_adj_sid_install_uninstall(bool install,
 	zl.local_label = sra->nexthop.label;
 	zl.nexthop_num = 1;
 	znh = &zl.nexthops[0];
-	znh->family = sra->nexthop.family;
-	znh->address = sra->nexthop.address;
+	znh->gate = sra->nexthop.address;
 	znh->type = (sra->nexthop.family == AF_INET)
 			    ? NEXTHOP_TYPE_IPV4_IFINDEX
 			    : NEXTHOP_TYPE_IPV6_IFINDEX;
 	znh->ifindex = sra->adj->circuit->interface->ifindex;
-	znh->label = MPLS_LABEL_IMPLICIT_NULL;
+	znh->label_num = 1;
+	znh->labels[0] = MPLS_LABEL_IMPLICIT_NULL;
 
 	(void)zebra_send_mpls_labels(zclient, cmd, &zl);
 }

--- a/isisd/isis_zebra.c
+++ b/isisd/isis_zebra.c
@@ -257,7 +257,7 @@ void isis_zebra_route_del_route(struct prefix *prefix,
 void isis_zebra_install_prefix_sid(const struct sr_prefix *srp)
 {
 	struct zapi_labels zl;
-	struct zapi_nexthop_label *znh;
+	struct zapi_nexthop *znh;
 	struct listnode *node;
 	struct isis_nexthop *nexthop;
 	struct interface *ifp;
@@ -280,7 +280,8 @@ void isis_zebra_install_prefix_sid(const struct sr_prefix *srp)
 		znh = &zl.nexthops[zl.nexthop_num++];
 		znh->type = NEXTHOP_TYPE_IFINDEX;
 		znh->ifindex = ifp->ifindex;
-		znh->label = MPLS_LABEL_IMPLICIT_NULL;
+		znh->label_num = 1;
+		znh->labels[0] = MPLS_LABEL_IMPLICIT_NULL;
 		break;
 	case ISIS_SR_PREFIX_REMOTE:
 		/* Update route in the RIB too. */
@@ -301,10 +302,10 @@ void isis_zebra_install_prefix_sid(const struct sr_prefix *srp)
 			znh->type = (srp->prefix.family == AF_INET)
 					    ? NEXTHOP_TYPE_IPV4_IFINDEX
 					    : NEXTHOP_TYPE_IPV6_IFINDEX;
-			znh->family = nexthop->family;
-			znh->address = nexthop->ip;
+			znh->gate = nexthop->ip;
 			znh->ifindex = nexthop->ifindex;
-			znh->label = nexthop->sr.label;
+			znh->label_num = 1;
+			znh->labels[0] = nexthop->sr.label;
 		}
 		break;
 	}


### PR DESCRIPTION
Update label enforcement due to modification in zapi message:
zapi_nexthop_label becomes zapi_nexthop as per PR #5813

Signed-off-by: Olivier Dugeon <olivier.dugeon@orange.com>