### PR TITLE
vtysh: Fixup extract.pl to intentionally fail on error

### DIFF
--- a/vtysh/extract.pl.in
+++ b/vtysh/extract.pl.in
@@ -43,7 +43,9 @@ sub scan_file {
     open (FH, "@CPP@ -DHAVE_CONFIG_H -DVTYSH_EXTRACT_PL -Ivtysh/@top_builddir@ -Ivtysh/@top_srcdir@ -Ivtysh/@top_srcdir@/lib -Ivtysh/@top_builddir@/lib -Ivtysh/@top_srcdir@/bgpd -Ivtysh/@top_srcdir@/bgpd/rfapi @LUA_INCLUDE@ @CPPFLAGS@ $cppadd $file |");
     local $/; undef $/;
     $line = <FH>;
-    close (FH);
+    if (!close (FH)) {
+	printf "File: $file failed to compile, when extracting cli from it please inspect\n"
+    }
 
     # ?: makes a group non-capturing
     @defun = ($line =~ /((?:DEFUN|DEFUN_HIDDEN|ALIAS|ALIAS_HIDDEN)\s*\(.+?\));?\s?\s?\n/sg);


### PR DESCRIPTION
When extracting the cli for vtysh into vtysh_cmd.c when
the compilation fails it will just silently ignore the
issue and not include the cli in vtysh at all.  Leaving
everyone attempting to figure out wtf just happened.

Modify the code to intentionally crash with some modicrum
of a chance to allow the developer to find and fix their
own mistakes.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>