### PR TITLE
 bgpd: Remove a test and return statement after assert

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -122,8 +122,6 @@ struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
 	struct bgp_node *prn = NULL;
 
 	assert(table);
-	if (!table)
-		return NULL;
 
 	if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP)
 	    || (safi == SAFI_EVPN)) {
@@ -4909,8 +4907,6 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 #endif
 
 	assert(bgp_static);
-	if (!bgp_static)
-		return;
 
 	rn = bgp_afi_node_get(bgp->rib[afi][safi], afi, safi, p, NULL);
 

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -330,8 +330,6 @@ void bpacket_queue_remove_peer(struct peer_af *paf)
 
 	q = PAF_PKTQ(paf);
 	assert(q);
-	if (!q)
-		return;
 
 	LIST_REMOVE(paf, pkt_train);
 	paf->next_pkt_to_send = NULL;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1200,8 +1200,6 @@ struct peer *peer_new(struct bgp *bgp)
 
 	/* bgp argument is absolutely required */
 	assert(bgp);
-	if (!bgp)
-		return NULL;
 
 	/* Allocate new peer. */
 	peer = XCALLOC(MTYPE_BGP_PEER, sizeof(struct peer));

--- a/scripts/coccinelle/test_after_assert.cocci
+++ b/scripts/coccinelle/test_after_assert.cocci
@@ -1,0 +1,7 @@
+@@
+identifier i;
+@@
+
+assert(i);
+- if (!i)
+-   return ...;


### PR DESCRIPTION
No need to check if the variable is NULL and return after assert.