### PR TITLE
doc: change slack reference link to main FRR homepage

### DIFF
--- a/doc/user/overview.rst
+++ b/doc/user/overview.rst
@@ -447,4 +447,4 @@ For information on reporting bugs, please see :ref:`bug-reports`.
 .. _frr: |package-url|
 .. _github: https://github.com/frrouting/frr/
 .. _github issues: https://github.com/frrouting/frr/issues
-.. _slack: https://frrouting.slack.com/
+.. _slack: https://frrouting.org/#participate


### PR DESCRIPTION
Change the overview page's link for slack info to point to the main FRR homepage section - that's where the self-serve link/info is. The existing doc link goes off to a slack-specific place that's hard to use.
