### PR TITLE
bgpd: Allow 'show bgp l2vpn evpn route type' to use RT number in addition to existing keywords

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -4098,7 +4098,7 @@ DEFUN(show_bgp_l2vpn_evpn_summary,
  */
 DEFUN(show_bgp_l2vpn_evpn_route,
       show_bgp_l2vpn_evpn_route_cmd,
-      "show bgp l2vpn evpn route [detail] [type <macip|multicast|es|prefix>] [json]",
+      "show bgp l2vpn evpn route [detail] [type <macip|2|multicast|3|es|4|prefix|5>] [json]",
       SHOW_STR
       BGP_STR
       L2VPN_HELP_STR
@@ -4107,8 +4107,12 @@ DEFUN(show_bgp_l2vpn_evpn_route,
       "Display Detailed Information\n"
       "Specify Route type\n"
       "MAC-IP (Type-2) route\n"
+      "MAC-IP (Type-2) route\n"
+      "Multicast (Type-3) route\n"
       "Multicast (Type-3) route\n"
       "Ethernet Segment (Type-4) route\n"
+      "Ethernet Segment (Type-4) route\n"
+      "Prefix (Type-5) route\n"
       "Prefix (Type-5) route\n"
       JSON_STR)
 {
@@ -4131,13 +4135,17 @@ DEFUN(show_bgp_l2vpn_evpn_route,
 	/* get the type */
 	if (argv_find(argv, argc, "type", &type_idx)) {
 		/* Specific type is requested */
-		if (strncmp(argv[type_idx + 1]->arg, "ma", 2) == 0)
+		if ((strncmp(argv[type_idx + 1]->arg, "ma", 2) == 0)
+		    || (strmatch(argv[type_idx + 1]->arg, "2")))
 			type = BGP_EVPN_MAC_IP_ROUTE;
-		else if (strncmp(argv[type_idx + 1]->arg, "mu", 2) == 0)
+		else if ((strncmp(argv[type_idx + 1]->arg, "mu", 2) == 0)
+			 || (strmatch(argv[type_idx + 1]->arg, "3")))
 			type = BGP_EVPN_IMET_ROUTE;
-		else if (strncmp(argv[type_idx + 1]->arg, "e", 1) == 0)
+		else if ((strncmp(argv[type_idx + 1]->arg, "e", 1) == 0)
+			 || (strmatch(argv[type_idx + 1]->arg, "4")))
 			type = BGP_EVPN_ES_ROUTE;
-		else if (strncmp(argv[type_idx + 1]->arg, "p", 1) == 0)
+		else if ((strncmp(argv[type_idx + 1]->arg, "p", 1) == 0)
+			 || (strmatch(argv[type_idx + 1]->arg, "5")))
 			type = BGP_EVPN_IP_PREFIX_ROUTE;
 		else
 			return CMD_WARNING;

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -4108,8 +4108,8 @@ DEFUN(show_bgp_l2vpn_evpn_route,
       "Specify Route type\n"
       "MAC-IP (Type-2) route\n"
       "Multicast (Type-3) route\n"
-      "Ethernet Segment (type-4) route \n"
-      "Prefix (type-5 )route\n"
+      "Ethernet Segment (Type-4) route\n"
+      "Prefix (Type-5) route\n"
       JSON_STR)
 {
 	struct bgp *bgp;

--- a/doc/user/bgp.rst
+++ b/doc/user/bgp.rst
@@ -2646,7 +2646,14 @@ structure is extended with :clicmd:`show bgp [afi] [safi]`.
 
    These commands display BGP routes for the specific routing table indicated by
    the selected afi and the selected safi. If no afi and no safi value is given,
-   the command falls back to the default IPv6 routing table
+   the command falls back to the default IPv6 routing table.
+   For EVPN prefixes, you can display the full BGP table for this AFI/SAFI
+   using the standard `show bgp [afi] [safi]` syntax.
+
+.. index:: show bgp l2vpn evpn route [type <macip|2|multicast|3|es|4|prefix|5>]
+.. clicmd:: show bgp l2vpn evpn route [type <macip|2|multicast|3|es|4|prefix|5>]
+
+   Additionally, you can also filter this output by route type.
 
 .. index:: show bgp [afi] [safi] summary
 .. clicmd:: show bgp [afi] [safi] summary


### PR DESCRIPTION
    bgpd: Add numeric keywords for displaying EVPN route types with
    `show bgp l2vpn evpn route type`.
    
    Signed-off-by: Trey Aspelund <taspelund@cumulusnetworks.com>
