### PR TITLE
lib, *: add a common time interval formatting api

### DIFF
--- a/isisd/isis_misc.c
+++ b/isisd/isis_misc.c
@@ -562,20 +562,12 @@ void vty_multiline(struct vty *vty, const char *prefix, const char *format, ...)
 
 void vty_out_timestr(struct vty *vty, time_t uptime)
 {
-	struct tm tm;
 	time_t difftime = time(NULL);
+	char buf[MONOTIME_STRLEN];
+
 	difftime -= uptime;
 
-	gmtime_r(&difftime, &tm);
+	frrtime_to_interval(difftime, buf, sizeof(buf));
 
-	if (difftime < ONE_DAY_SECOND)
-		vty_out(vty, "%02d:%02d:%02d", tm.tm_hour, tm.tm_min,
-			tm.tm_sec);
-	else if (difftime < ONE_WEEK_SECOND)
-		vty_out(vty, "%dd%02dh%02dm", tm.tm_yday, tm.tm_hour,
-			tm.tm_min);
-	else
-		vty_out(vty, "%02dw%dd%02dh", tm.tm_yday / 7,
-			tm.tm_yday - ((tm.tm_yday / 7) * 7), tm.tm_hour);
-	vty_out(vty, " ago");
+	vty_out(vty, "%s ago", buf);
 }

--- a/isisd/isis_vty_fabricd.c
+++ b/isisd/isis_vty_fabricd.c
@@ -115,6 +115,7 @@ DEFUN (no_triggered_csnp,
 static void lsp_print_flooding(struct vty *vty, struct isis_lsp *lsp)
 {
 	char lspid[255];
+	char buf[MONOTIME_STRLEN];
 
 	lspid_print(lsp->hdr.lsp_id, lspid, true, true);
 	vty_out(vty, "Flooding information for %s\n", lspid);
@@ -129,21 +130,10 @@ static void lsp_print_flooding(struct vty *vty, struct isis_lsp *lsp)
 		lsp->flooding_interface : "(null)");
 
 	time_t uptime = time(NULL) - lsp->flooding_time;
-	struct tm tm;
 
-	gmtime_r(&uptime, &tm);
+	frrtime_to_interval(uptime, buf, sizeof(buf));
 
-	if (uptime < ONE_DAY_SECOND)
-		vty_out(vty, "%02d:%02d:%02d", tm.tm_hour, tm.tm_min,
-			tm.tm_sec);
-	else if (uptime < ONE_WEEK_SECOND)
-		vty_out(vty, "%dd%02dh%02dm", tm.tm_yday, tm.tm_hour,
-			tm.tm_min);
-	else
-		vty_out(vty, "%02dw%dd%02dh", tm.tm_yday / 7,
-			tm.tm_yday - ((tm.tm_yday / 7) * 7),
-			tm.tm_hour);
-	vty_out(vty, " ago)\n");
+	vty_out(vty, "%s ago)\n", buf);
 
 	if (lsp->flooding_circuit_scoped) {
 		vty_out(vty, "    Received as circuit-scoped LSP, so not "

--- a/lib/monotime.h
+++ b/lib/monotime.h
@@ -112,6 +112,26 @@ static inline char *time_to_string(time_t ts, char *buf)
 	return ctime_r(&tbuf, buf);
 }
 
+/* Convert interval to human-friendly string, used in cli output e.g. */
+static inline const char *frrtime_to_interval(time_t t, char *buf,
+					      size_t buflen)
+{
+	struct tm tm;
+
+	gmtime_r(&t, &tm);
+
+	if (t < ONE_DAY_SECOND)
+		snprintf(buf, buflen, "%02d:%02d:%02d", tm.tm_hour, tm.tm_min,
+			 tm.tm_sec);
+	else if (t < ONE_WEEK_SECOND)
+		snprintf(buf, buflen, "%dd%02dh%02dm", tm.tm_yday, tm.tm_hour,
+			 tm.tm_min);
+	else
+		snprintf(buf, buflen, "%02dw%dd%02dh", tm.tm_yday / 7,
+			 tm.tm_yday - ((tm.tm_yday / 7) * 7), tm.tm_hour);
+	return buf;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/ripd/rip_peer.c
+++ b/ripd/rip_peer.c
@@ -131,7 +131,6 @@ void rip_peer_bad_packet(struct rip *rip, struct sockaddr_in *from)
 static char *rip_peer_uptime(struct rip_peer *peer, char *buf, size_t len)
 {
 	time_t uptime;
-	struct tm tm;
 
 	/* If there is no connection has been done before print `never'. */
 	if (peer->uptime == 0) {
@@ -142,17 +141,9 @@ static char *rip_peer_uptime(struct rip_peer *peer, char *buf, size_t len)
 	/* Get current time. */
 	uptime = time(NULL);
 	uptime -= peer->uptime;
-	gmtime_r(&uptime, &tm);
 
-	if (uptime < ONE_DAY_SECOND)
-		snprintf(buf, len, "%02d:%02d:%02d", tm.tm_hour, tm.tm_min,
-			 tm.tm_sec);
-	else if (uptime < ONE_WEEK_SECOND)
-		snprintf(buf, len, "%dd%02dh%02dm", tm.tm_yday, tm.tm_hour,
-			 tm.tm_min);
-	else
-		snprintf(buf, len, "%02dw%dd%02dh", tm.tm_yday / 7,
-			 tm.tm_yday - ((tm.tm_yday / 7) * 7), tm.tm_hour);
+	frrtime_to_interval(uptime, buf, len);
+
 	return buf;
 }
 

--- a/ripngd/ripng_peer.c
+++ b/ripngd/ripng_peer.c
@@ -141,7 +141,6 @@ void ripng_peer_bad_packet(struct ripng *ripng, struct sockaddr_in6 *from)
 static char *ripng_peer_uptime(struct ripng_peer *peer, char *buf, size_t len)
 {
 	time_t uptime;
-	struct tm tm;
 
 	/* If there is no connection has been done before print `never'. */
 	if (peer->uptime == 0) {
@@ -152,17 +151,9 @@ static char *ripng_peer_uptime(struct ripng_peer *peer, char *buf, size_t len)
 	/* Get current time. */
 	uptime = time(NULL);
 	uptime -= peer->uptime;
-	gmtime_r(&uptime, &tm);
 
-	if (uptime < ONE_DAY_SECOND)
-		snprintf(buf, len, "%02d:%02d:%02d", tm.tm_hour, tm.tm_min,
-			 tm.tm_sec);
-	else if (uptime < ONE_WEEK_SECOND)
-		snprintf(buf, len, "%dd%02dh%02dm", tm.tm_yday, tm.tm_hour,
-			 tm.tm_min);
-	else
-		snprintf(buf, len, "%02dw%dd%02dh", tm.tm_yday / 7,
-			 tm.tm_yday - ((tm.tm_yday / 7) * 7), tm.tm_hour);
+	frrtime_to_interval(uptime, buf, len);
+
 	return buf;
 }
 


### PR DESCRIPTION
Add a common api that formats a time interval into a string with different output for short and longer intervals. We do this in several places, for cli/ui output, in the same way.
