### PR TITLE
bgpd: remove unused variable

### DIFF
--- a/bgpd/bgp_attr_evpn.h
+++ b/bgpd/bgp_attr_evpn.h
@@ -34,7 +34,6 @@
 
 #define MAX_ET 0xffffffff
 
-unsigned long eth_tag_id;
 struct attr;
 
 /* EVPN ESI */


### PR DESCRIPTION
This fixes a linking issue on Fedora Rawhide:
/usr/bin/ld: bgpd/libbgp.a(bgp_flowspec.o):/home/ruben/src/frr/./bgpd/bgp_attr_evpn.h:37: multiple definition of `eth_tag_id'; bgpd/bgp_btoa-bgp_btoa.o:/home/ruben/src/frr/./bgpd/bgp_attr_evpn.h:37: first defined here
collect2: error: ld returned 1 exit status

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>