### PR TITLE
staticd: fix build on Fedora Rawhide

### DIFF
--- a/staticd/static_debug.h
+++ b/staticd/static_debug.h
@@ -29,7 +29,7 @@
 #include "lib/debug.h"
 
 /* staticd debugging records */
-struct debug static_dbg_events;
+extern struct debug static_dbg_events;
 
 /*
  * Initialize staticd debugging.


### PR DESCRIPTION
Fixes the following linker issue:
 CC       staticd/static_main.o
  CC       staticd/static_debug.o
  CC       staticd/static_vty.o
  AR       staticd/libstatic.a
  CCLD     staticd/staticd
/usr/bin/ld: staticd/libstatic.a(static_debug.o):/home/ruben/src/frr/staticd/static_debug.h:32: multiple definition of `static_dbg_events'; staticd/static_main.o:/home/ruben/src/frr/staticd/static_debug.h:32: first defined here

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>