### PR TITLE
vrrpd: fix build on Fedora Rawhide

### DIFF
--- a/vrrpd/vrrp_debug.h
+++ b/vrrpd/vrrp_debug.h
@@ -25,13 +25,13 @@
 #include "lib/debug.h"
 
 /* VRRP debugging records */
-struct debug vrrp_dbg_arp;
-struct debug vrrp_dbg_auto;
-struct debug vrrp_dbg_ndisc;
-struct debug vrrp_dbg_pkt;
-struct debug vrrp_dbg_proto;
-struct debug vrrp_dbg_sock;
-struct debug vrrp_dbg_zebra;
+extern struct debug vrrp_dbg_arp;
+extern struct debug vrrp_dbg_auto;
+extern struct debug vrrp_dbg_ndisc;
+extern struct debug vrrp_dbg_pkt;
+extern struct debug vrrp_dbg_proto;
+extern struct debug vrrp_dbg_sock;
+extern struct debug vrrp_dbg_zebra;
 
 /*
  * Initialize VRRP debugging.


### PR DESCRIPTION
Fixes the following linker errors:
make[1]: Entering directory '/home/ruben/src/frr'
  CCLD     vrrpd/vrrpd
/usr/bin/ld: vrrpd/libvrrp.a(vrrp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: multiple definition of `vrrp_dbg_sock'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: multiple definition of `vrrp_dbg_pkt'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: multiple definition of `vrrp_dbg_proto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: multiple definition of `vrrp_dbg_zebra'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: multiple definition of `vrrp_dbg_auto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: multiple definition of `vrrp_dbg_ndisc'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: multiple definition of `vrrp_dbg_arp'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_arp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: multiple definition of `vrrp_dbg_arp'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_arp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: multiple definition of `vrrp_dbg_sock'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_arp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: multiple definition of `vrrp_dbg_zebra'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_arp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: multiple definition of `vrrp_dbg_proto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_arp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: multiple definition of `vrrp_dbg_pkt'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_arp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: multiple definition of `vrrp_dbg_ndisc'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_arp.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: multiple definition of `vrrp_dbg_auto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_debug.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: multiple definition of `vrrp_dbg_proto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_debug.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: multiple definition of `vrrp_dbg_auto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_debug.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: multiple definition of `vrrp_dbg_pkt'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_debug.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: multiple definition of `vrrp_dbg_sock'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_debug.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: multiple definition of `vrrp_dbg_ndisc'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_debug.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: multiple definition of `vrrp_dbg_arp'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_debug.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: multiple definition of `vrrp_dbg_zebra'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_ndisc.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: multiple definition of `vrrp_dbg_ndisc'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_ndisc.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: multiple definition of `vrrp_dbg_pkt'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_ndisc.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: multiple definition of `vrrp_dbg_sock'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_ndisc.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: multiple definition of `vrrp_dbg_zebra'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_ndisc.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: multiple definition of `vrrp_dbg_proto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_ndisc.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: multiple definition of `vrrp_dbg_auto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_ndisc.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: multiple definition of `vrrp_dbg_arp'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_packet.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: multiple definition of `vrrp_dbg_zebra'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_packet.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: multiple definition of `vrrp_dbg_sock'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_packet.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: multiple definition of `vrrp_dbg_proto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_packet.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: multiple definition of `vrrp_dbg_pkt'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_packet.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: multiple definition of `vrrp_dbg_ndisc'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_packet.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: multiple definition of `vrrp_dbg_auto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_packet.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: multiple definition of `vrrp_dbg_arp'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_vty.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: multiple definition of `vrrp_dbg_zebra'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_vty.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: multiple definition of `vrrp_dbg_sock'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_vty.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: multiple definition of `vrrp_dbg_proto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_vty.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: multiple definition of `vrrp_dbg_pkt'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_vty.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: multiple definition of `vrrp_dbg_ndisc'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_vty.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: multiple definition of `vrrp_dbg_auto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_vty.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: multiple definition of `vrrp_dbg_arp'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_zebra.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: multiple definition of `vrrp_dbg_zebra'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:34: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_zebra.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: multiple definition of `vrrp_dbg_sock'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:33: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_zebra.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: multiple definition of `vrrp_dbg_proto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:32: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_zebra.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: multiple definition of `vrrp_dbg_pkt'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:31: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_zebra.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: multiple definition of `vrrp_dbg_ndisc'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:30: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_zebra.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: multiple definition of `vrrp_dbg_auto'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:29: first defined here
/usr/bin/ld: vrrpd/libvrrp.a(vrrp_zebra.o):/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: multiple definition of `vrrp_dbg_arp'; vrrpd/vrrp_main.o:/home/ruben/src/frr/vrrpd/vrrp_debug.h:28: first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:6639: vrrpd/vrrpd] Error 1
make[1]: Leaving directory '/home/ruben/src/frr'
make: *** [Makefile:4525: all] Error 2