### PR TITLE
babeld: fix build on Fedora Rawhide

### DIFF
--- a/babeld/util.h
+++ b/babeld/util.h
@@ -122,7 +122,7 @@ void uchar_to_inaddr(struct in_addr *dest, const unsigned char *src);
 void in6addr_to_uchar(unsigned char *dest, const struct in6_addr *src);
 void uchar_to_in6addr(struct in6_addr *dest, const unsigned char *src);
 int daemonise(void);
-const unsigned char v4prefix[16];
+extern const unsigned char v4prefix[16];
 
 /* If debugging is disabled, we want to avoid calling format_address
    for every omitted debugging message.  So debug is a macro.  But


### PR DESCRIPTION
Fixes the following linker errors:
/usr/bin/ld: babeld/libbabel.a(babel_interface.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(babel_zebra.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(babeld.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(kernel.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(message.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(neighbour.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(net.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(resend.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(route.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(source.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(util.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(xroute.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
/usr/bin/ld: babeld/libbabel.a(babel_filter.o):/home/ruben/src/frr/babeld/util.h:125: multiple definition of `v4prefix'; babeld/babel_main.o:/home/ruben/src/frr/babeld/util.h:125: first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:6015: babeld/babeld] Error 1

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>