### PR TITLE
staticd: Fixing memory leak issue

### DIFF
--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -73,6 +73,8 @@ static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 
+	static_vrf_terminate();
+
 	exit(0);
 }
 

--- a/staticd/static_vrf.c
+++ b/staticd/static_vrf.c
@@ -111,6 +111,7 @@ static int static_vrf_delete(struct vrf *vrf)
 			svrf->stable[afi][safi] = NULL;
 		}
 	}
+	XFREE(MTYPE_TMP, svrf);
 	return 0;
 }
 
@@ -203,4 +204,9 @@ void static_vrf_init(void)
 		 static_vrf_disable, static_vrf_delete, NULL);
 
 	vrf_cmd_init(static_vrf_config_write, &static_privs);
+}
+
+void static_vrf_terminate(void)
+{
+	vrf_terminate();
 }

--- a/staticd/static_vrf.h
+++ b/staticd/static_vrf.h
@@ -35,4 +35,5 @@ void static_vrf_init(void);
 
 struct route_table *static_vrf_static_table(afi_t afi, safi_t safi,
 					    struct static_vrf *svrf);
+extern void static_vrf_terminate(void);
 #endif


### PR DESCRIPTION
###Summary
The Following memoryleak observed in staticd when vrf created and deleted.

==26745== 1,848 bytes in 7 blocks are definitely lost in loss record 6,501 of 6,549
==26745==    at 0x4C2FFAC: calloc (vg_replace_malloc.c:762)
==26745==    by 0x4E824FE: qcalloc (memory.c:111)
==26745==    by 0x10C775: static_vrf_alloc (static_vrf.c:52)
==26745==    by 0x10C775: static_vrf_new (static_vrf.c:71)
==26745==    by 0x4EABC70: vrf_get (vrf.c:209)
==26745==    by 0x4EB9DA0: zclient_vrf_add (zclient.c:1411)
==26745==    by 0x4EB9DA0: zclient_read (zclient.c:2524)
==26745==    by 0x4EAB0EF: thread_call (thread.c:1668)
==26745==    by 0x4E7DB47: frr_run (libfrr.c:1011)
==26745==    by 0x10B57A: main (static_main.c:154)

When vrf created , Memory allocated for staticd specific vrf tables "struct static_vrf".
But   this memory is not getting released when the corresponding vrf is being deleted which interns
leads to memory leak.
 
Released the allocated memory in vrf_deletion API.
Also called the vrf_terminate in sigint() signal int handler  to release all vrf specific memory blocks.

###Components
staticd

Signed-off-by: Rajesh Girada <rgirada@vmware.com>