### PR TITLE
Fix linking error on Fedora Rawhide with GCC 10

### DIFF
--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -97,6 +97,8 @@ static struct quagga_signal_t ldpe_signals[] =
 	},
 };
 
+char *pkt_ptr; /* packet buffer */
+
 /* label distribution protocol engine */
 void
 ldpe(void)

--- a/ldpd/ldpe.h
+++ b/ldpd/ldpe.h
@@ -291,7 +291,7 @@ struct tcp_conn		*tcp_new(int, struct nbr *);
 void			 pending_conn_del(struct pending_conn *);
 struct pending_conn	*pending_conn_find(int, union ldpd_addr *);
 
-char	*pkt_ptr;	/* packet buffer */
+extern char *pkt_ptr; /* packet buffer */
 
 /* pfkey.c */
 #ifdef __OpenBSD__


### PR DESCRIPTION
GCC 10 switched to -fno-common by default, see
https://gcc.gnu.org/gcc-10/porting_to.html#common for details.

Fixes:
  CCLD     ldpd/ldpd
/usr/bin/ld: ldpd/libldp.a(adjacency.o):/home/ruben/src/frr/ldpd/ldpe.h:294: multiple definition of `pkt_ptr'; ldpd/ldpd.o:/home/ruben/src/frr/ldpd/ldpe.h:294: first defined here

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>