### PR TITLE
*: Replace `sizeof something` to sizeof(something)

### DIFF
--- a/babeld/babeld.c
+++ b/babeld/babeld.c
@@ -138,7 +138,7 @@ babel_create_routing_process (void)
     assert (babel_routing_process == NULL);
 
     /* Allocaste Babel instance. */
-    babel_routing_process = XCALLOC (MTYPE_BABEL, sizeof (struct babel));
+    babel_routing_process = XCALLOC(MTYPE_BABEL, sizeof(struct babel));
 
     /* Initialize timeouts */
     gettime(&babel_now);

--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -41,9 +41,9 @@
 #define AS_HEADER_SIZE 2
 
 /* Now FOUR octets are used for AS value. */
-#define AS_VALUE_SIZE         sizeof (as_t)
+#define AS_VALUE_SIZE         sizeof(as_t)
 /* This is the old one */
-#define AS16_VALUE_SIZE	      sizeof (as16_t)
+#define AS16_VALUE_SIZE	      sizeof(as16_t)
 
 /* Maximum protocol segment length value */
 #define AS_SEGMENT_MAX		255
@@ -768,7 +768,7 @@ static int assegments_parse(struct stream *s, size_t length,
 		     * on more, than 8 bits (otherwise it's a warning, bug
 		     * #564).
 		     */
-		    || ((sizeof segh.length > 1)
+		    || ((sizeof(segh.length) > 1)
 			&& (0x10 + segh.length > 0x10 + AS_SEGMENT_MAX))) {
 			if (head)
 				assegment_free_all(head);

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -654,7 +654,7 @@ community_regexp_delete (struct community *com, regex_t * reg)
 	i = 0;
 	while (i < com->size)
 	{
-		memcpy (&comval, com_nthval (com, i), sizeof (uint32_t));
+		memcpy (&comval, com_nthval (com, i), sizeof(uint32_t));
 		comval = ntohl (comval);
 
 		switch (comval) {

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -869,7 +869,7 @@ static int bgpTrapEstablished(struct peer *peer)
 
 	smux_trap(bgp_variables, array_size(bgp_variables), bgp_trap_oid,
 		  array_size(bgp_trap_oid), bgp_oid,
-		  sizeof bgp_oid / sizeof(oid), index, IN_ADDR_SIZE,
+		  sizeof(bgp_oid) / sizeof(oid), index, IN_ADDR_SIZE,
 		  bgpTrapList, array_size(bgpTrapList), BGPESTABLISHED);
 	return 0;
 }
@@ -888,7 +888,7 @@ static int bgpTrapBackwardTransition(struct peer *peer)
 
 	smux_trap(bgp_variables, array_size(bgp_variables), bgp_trap_oid,
 		  array_size(bgp_trap_oid), bgp_oid,
-		  sizeof bgp_oid / sizeof(oid), index, IN_ADDR_SIZE,
+		  sizeof(bgp_oid) / sizeof(oid), index, IN_ADDR_SIZE,
 		  bgpTrapList, array_size(bgpTrapList), BGPBACKWARDTRANSITION);
 	return 0;
 }

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4031,7 +4031,7 @@ static int peer_flag_modify(struct peer *peer, uint32_t flag, int set)
 	struct peer_flag_action action;
 
 	memset(&action, 0, sizeof(struct peer_flag_action));
-	size = sizeof peer_flag_action_list / sizeof(struct peer_flag_action);
+	size = sizeof(peer_flag_action_list) / sizeof(struct peer_flag_action);
 
 	invert = CHECK_FLAG(peer->flags_invert, flag);
 	found = peer_flag_action_set(peer_flag_action_list, size, &action,
@@ -4137,7 +4137,7 @@ static int peer_af_flag_modify(struct peer *peer, afi_t afi, safi_t safi,
 	bgp_peer_sort_t ptype;
 
 	memset(&action, 0, sizeof(struct peer_flag_action));
-	size = sizeof peer_af_flag_action_list
+	size = sizeof(peer_af_flag_action_list)
 	       / sizeof(struct peer_flag_action);
 
 	invert = CHECK_FLAG(peer->af_flags_invert[afi][safi], flag);

--- a/eigrpd/eigrp_routemap.c
+++ b/eigrpd/eigrp_routemap.c
@@ -295,7 +295,7 @@ static void *route_match_metric_compile(const char *arg)
 {
 	//  uint32_t *metric;
 	//
-	//  metric = XMALLOC (MTYPE_ROUTE_MAP_COMPILED, sizeof (uint32_t));
+	//  metric = XMALLOC (MTYPE_ROUTE_MAP_COMPILED, sizeof(uint32_t));
 	//  *metric = atoi (arg);
 	//
 	//  if(*metric > 0)
@@ -574,7 +574,7 @@ static void *route_match_tag_compile(const char *arg)
 {
 	//  unsigned short *tag;
 	//
-	//  tag = XMALLOC (MTYPE_ROUTE_MAP_COMPILED, sizeof (unsigned short));
+	//  tag = XMALLOC (MTYPE_ROUTE_MAP_COMPILED, sizeof(unsigned short));
 	//  *tag = atoi (arg);
 	//
 	//  return tag;
@@ -667,7 +667,7 @@ static void *route_set_metric_compile(const char *arg)
 	//    return NULL;*/
 	//
 	//  mod = XMALLOC (MTYPE_ROUTE_MAP_COMPILED,
-	//    sizeof (struct rip_metric_modifier));
+	//    sizeof(struct rip_metric_modifier));
 	//  mod->type = type;
 	//  mod->metric = metric;
 
@@ -718,7 +718,7 @@ static void *route_set_ip_nexthop_compile(const char *arg)
 	//  int ret;
 	//  struct in_addr *address;
 	//
-	//  address = XMALLOC (MTYPE_ROUTE_MAP_COMPILED, sizeof (struct
+	//  address = XMALLOC (MTYPE_ROUTE_MAP_COMPILED, sizeof(struct
 	//  in_addr));
 	//
 	//  ret = inet_aton (arg, address);
@@ -775,7 +775,7 @@ static void *route_set_tag_compile(const char *arg)
 {
 	//  unsigned short *tag;
 	//
-	//  tag = XMALLOC (MTYPE_ROUTE_MAP_COMPILED, sizeof (unsigned short));
+	//  tag = XMALLOC (MTYPE_ROUTE_MAP_COMPILED, sizeof(unsigned short));
 	//  *tag = atoi (arg);
 	//
 	//  return tag;

--- a/fpm/fpm.h
+++ b/fpm/fpm.h
@@ -175,7 +175,7 @@ static inline size_t fpm_msg_align(size_t len)
  * The (rounded up) size of the FPM message header. This ensures that
  * the message payload always starts at an aligned address.
  */
-#define FPM_MSG_HDR_LEN (sizeof (fpm_msg_hdr_t))
+#define FPM_MSG_HDR_LEN (sizeof(fpm_msg_hdr_t))
 
 #ifndef COMPILE_ASSERT
 #define COMPILE_ASSERT(x) extern int __dummy[2 * !!(x) - 1]

--- a/lib/agentx.c
+++ b/lib/agentx.c
@@ -264,7 +264,7 @@ int smux_trap(struct variable *vp, size_t vp_len, const oid *ename,
 	      uint8_t sptrap)
 {
 	oid objid_snmptrap[] = {1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0};
-	size_t objid_snmptrap_len = sizeof objid_snmptrap / sizeof(oid);
+	size_t objid_snmptrap_len = sizeof(objid_snmptrap) / sizeof(oid);
 	oid notification_oid[MAX_OID_LEN];
 	size_t notification_oid_len;
 	unsigned int i;

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -288,7 +288,7 @@ buffer_status_t buffer_flush_window(struct buffer *b, int fd, int width,
 	/* Previously print out is performed. */
 	if (erase_flag) {
 		iov[iov_index].iov_base = erase;
-		iov[iov_index].iov_len = sizeof erase;
+		iov[iov_index].iov_len = sizeof(erase);
 		iov_index++;
 	}
 
@@ -341,7 +341,7 @@ buffer_status_t buffer_flush_window(struct buffer *b, int fd, int width,
 	/* In case of `more' display need. */
 	if (b->tail && (b->tail->sp < b->tail->cp) && !no_more_flag) {
 		iov[iov_index].iov_base = more;
-		iov[iov_index].iov_len = sizeof more;
+		iov[iov_index].iov_len = sizeof(more);
 		iov_index++;
 	}
 

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -412,8 +412,8 @@ void hmac_md5(unsigned char *text, int text_len, unsigned char *key,
 	 */
 
 	/* start out by storing key in pads */
-	bzero(k_ipad, sizeof k_ipad);
-	bzero(k_opad, sizeof k_opad);
+	bzero(k_ipad, sizeof(k_ipad));
+	bzero(k_opad, sizeof(k_opad));
 	bcopy(key, k_ipad, key_len);
 	bcopy(key, k_opad, key_len);
 

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -1082,7 +1082,7 @@ struct prefix *prefix_new(void)
 {
 	struct prefix *p;
 
-	p = XCALLOC(MTYPE_PREFIX, sizeof *p);
+	p = XCALLOC(MTYPE_PREFIX, sizeof(*p));
 	return p;
 }
 

--- a/lib/printf/printf-pos.c
+++ b/lib/printf/printf-pos.c
@@ -686,7 +686,7 @@ build_arg_table(struct typetable *types, va_list ap, union arg **argtable)
 
 	if (types->tablemax >= STATIC_ARG_TBL_SIZE) {
 		*argtable = (union arg *)
-		    malloc (sizeof (union arg) * (types->tablemax + 1));
+		    malloc (sizeof(union arg) * (types->tablemax + 1));
 		if (*argtable == NULL)
 			return;
 	}

--- a/lib/sockopt.c
+++ b/lib/sockopt.c
@@ -683,7 +683,7 @@ int sockopt_tcp_signature_ext(int sock, union sockunion *su, uint16_t prefixlen,
 #endif /* GNU_LINUX */
 
 	if ((ret = setsockopt(sock, IPPROTO_TCP, optname, &md5sig,
-			      sizeof md5sig))
+			      sizeof(md5sig)))
 	    < 0) {
 		/* ENOENT is harmless.  It is returned when we clear a password
 		   for which

--- a/lib/sockopt.h
+++ b/lib/sockopt.h
@@ -39,7 +39,7 @@ extern int setsockopt_ipv6_hoplimit(int, int);
 extern int setsockopt_ipv6_multicast_loop(int, int);
 extern int setsockopt_ipv6_tclass(int, int);
 
-#define SOPT_SIZE_CMSG_PKTINFO_IPV6() (sizeof (struct in6_pktinfo));
+#define SOPT_SIZE_CMSG_PKTINFO_IPV6() (sizeof(struct in6_pktinfo));
 
 /*
  * Size defines for control messages used to get ifindex.  We define
@@ -49,7 +49,7 @@ extern int setsockopt_ipv6_tclass(int, int);
  */
 #if defined(IP_PKTINFO)
 /* Linux in_pktinfo. */
-#define SOPT_SIZE_CMSG_PKTINFO_IPV4()  (CMSG_SPACE(sizeof (struct in_pktinfo)))
+#define SOPT_SIZE_CMSG_PKTINFO_IPV4()  (CMSG_SPACE(sizeof(struct in_pktinfo)))
 /* XXX This should perhaps be defined even if IP_PKTINFO is not. */
 #define SOPT_SIZE_CMSG_PKTINFO(af)                                             \
   ((af == AF_INET) ? SOPT_SIZE_CMSG_PKTINFO_IPV4() \
@@ -60,9 +60,9 @@ extern int setsockopt_ipv6_tclass(int, int);
 /* BSD/Solaris */
 
 #if defined(SUNOS_5)
-#define SOPT_SIZE_CMSG_RECVIF_IPV4()  (sizeof (uint_t))
+#define SOPT_SIZE_CMSG_RECVIF_IPV4()  (sizeof(uint_t))
 #else
-#define SOPT_SIZE_CMSG_RECVIF_IPV4()	(sizeof (struct sockaddr_dl))
+#define SOPT_SIZE_CMSG_RECVIF_IPV4()	(sizeof(struct sockaddr_dl))
 #endif /* SUNOS_5 */
 #endif /* IP_RECVIF */
 
@@ -72,7 +72,7 @@ extern int setsockopt_ipv6_tclass(int, int);
 #elif defined(SOPT_SIZE_CMSG_RECVIF_IPV4)
 #define SOPT_SIZE_CMSG_IFINDEX_IPV4() SOPT_SIZE_CMSG_RECVIF_IPV4()
 #else  /* Nothing available */
-#define SOPT_SIZE_CMSG_IFINDEX_IPV4() (sizeof (char *))
+#define SOPT_SIZE_CMSG_IFINDEX_IPV4() (sizeof(char *))
 #endif /* SOPT_SIZE_CMSG_IFINDEX_IPV4 */
 
 #define SOPT_SIZE_CMSG_IFINDEX(af)                                             \

--- a/lib/sockunion.c
+++ b/lib/sockunion.c
@@ -214,7 +214,7 @@ enum connect_result sockunion_connect(int fd, const union sockunion *peersu,
 		if (errno != EINPROGRESS) {
 			char str[SU_ADDRSTRLEN];
 			zlog_info("can't connect to %s fd %d : %s",
-				  sockunion_log(&su, str, sizeof str), fd,
+				  sockunion_log(&su, str, sizeof(str)), fd,
 				  safe_strerror(errno));
 			return connect_error;
 		}
@@ -518,8 +518,8 @@ union sockunion *sockunion_getsockname(int fd)
 	} name;
 	union sockunion *su;
 
-	memset(&name, 0, sizeof name);
-	len = sizeof name;
+	memset(&name, 0, sizeof(name));
+	len = sizeof(name);
 
 	ret = getsockname(fd, (struct sockaddr *)&name, &len);
 	if (ret < 0) {
@@ -556,8 +556,8 @@ union sockunion *sockunion_getpeername(int fd)
 	} name;
 	union sockunion *su;
 
-	memset(&name, 0, sizeof name);
-	len = sizeof name;
+	memset(&name, 0, sizeof(name));
+	len = sizeof(name);
 	ret = getpeername(fd, (struct sockaddr *)&name, &len);
 	if (ret < 0) {
 		flog_err(EC_LIB_SOCKET, "Can't get remote address and port: %s",

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -171,7 +171,7 @@ static void cpu_record_print(struct vty *vty, uint8_t filter)
 	struct thread_master *m;
 	struct listnode *ln;
 
-	memset(&tmp, 0, sizeof tmp);
+	memset(&tmp, 0, sizeof(tmp));
 	tmp.funcname = "TOTAL";
 	tmp.types = filter;
 

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1976,7 +1976,7 @@ struct connected *zebra_interface_address_read(int type, struct stream *s,
 					"warning: interface %s address %s with peer flag set, but no peer address!",
 					ifp->name,
 					prefix2str(ifc->address, buf,
-						   sizeof buf));
+						   sizeof(buf)));
 				UNSET_FLAG(ifc->flags, ZEBRA_IFA_PEER);
 			}
 		}

--- a/nhrpd/netlink_arp.c
+++ b/nhrpd/netlink_arp.c
@@ -95,7 +95,7 @@ static void netlink_neigh_msg(struct nlmsghdr *msg, struct zbuf *zb)
 
 	if (msg->nlmsg_type == RTM_GETNEIGH) {
 		debugf(NHRP_DEBUG_KERNEL, "Netlink: who-has %s dev %s",
-		       sockunion2str(&addr, buf, sizeof buf), ifp->name);
+		       sockunion2str(&addr, buf, sizeof(buf)), ifp->name);
 
 		if (c->cur.type >= NHRP_CACHE_CACHED) {
 			nhrp_cache_set_used(c, 1);
@@ -104,7 +104,7 @@ static void netlink_neigh_msg(struct nlmsghdr *msg, struct zbuf *zb)
 		}
 	} else {
 		debugf(NHRP_DEBUG_KERNEL, "Netlink: update %s dev %s nud %x",
-		       sockunion2str(&addr, buf, sizeof buf), ifp->name,
+		       sockunion2str(&addr, buf, sizeof(buf)), ifp->name,
 		       ndm->ndm_state);
 
 		state = (msg->nlmsg_type == RTM_NEWNEIGH) ? ndm->ndm_state

--- a/nhrpd/nhrp_cache.c
+++ b/nhrpd/nhrp_cache.c
@@ -210,7 +210,7 @@ static void nhrp_cache_authorize_binding(struct nhrp_reqid *r, void *arg)
 	char buf[SU_ADDRSTRLEN];
 
 	debugf(NHRP_DEBUG_COMMON, "cache: %s %s: %s", c->ifp->name,
-	       sockunion2str(&c->remote_addr, buf, sizeof buf),
+	       sockunion2str(&c->remote_addr, buf, sizeof(buf)),
 	       (const char *)arg);
 
 	nhrp_reqid_free(&nhrp_event_reqid, r);
@@ -301,7 +301,7 @@ int nhrp_cache_update_binding(struct nhrp_cache *c, enum nhrp_cache_type type,
 			c->cur.remote_nbma_natoa = *nbma_oa;
 		else
 			memset(&c->cur.remote_nbma_natoa, 0,
-			       sizeof c->cur.remote_nbma_natoa);
+			       sizeof(c->cur.remote_nbma_natoa));
 		nhrp_peer_unref(p);
 	} else {
 		c->new.type = type;

--- a/nhrpd/nhrp_interface.c
+++ b/nhrpd/nhrp_interface.c
@@ -112,7 +112,7 @@ static void nhrp_interface_interface_notifier(struct notifier_block *n,
 			      NOTIFY_INTERFACE_NBMA_CHANGED);
 		debugf(NHRP_DEBUG_IF, "%s: NBMA change: address %s",
 		       nifp->ifp->name,
-		       sockunion2str(&nifp->nbma, buf, sizeof buf));
+		       sockunion2str(&nifp->nbma, buf, sizeof(buf)));
 		break;
 	}
 }
@@ -221,7 +221,7 @@ static void nhrp_interface_update_address(struct interface *ifp, afi_t afi,
 	if (best && if_ad->configured
 	    && best->address->prefixlen != 8 * prefix_blen(best->address)) {
 		zlog_notice("%s: %s is not a host prefix", ifp->name,
-			    prefix2str(best->address, buf, sizeof buf));
+			    prefix2str(best->address, buf, sizeof(buf)));
 		best = NULL;
 	}
 
@@ -243,7 +243,7 @@ static void nhrp_interface_update_address(struct interface *ifp, afi_t afi,
 
 	debugf(NHRP_DEBUG_KERNEL, "%s: IPv%d address changed to %s", ifp->name,
 	       afi == AFI_IP ? 4 : 6,
-	       best ? prefix2str(best->address, buf, sizeof buf) : "(none)");
+	       best ? prefix2str(best->address, buf, sizeof(buf)) : "(none)");
 	if_ad->addr = addr;
 
 	if (if_ad->configured && sockunion_family(&if_ad->addr) != AF_UNSPEC) {
@@ -342,7 +342,7 @@ int nhrp_interface_address_add(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	debugf(NHRP_DEBUG_IF, "if-addr-add: %s: %s", ifc->ifp->name,
-	       prefix2str(ifc->address, buf, sizeof buf));
+	       prefix2str(ifc->address, buf, sizeof(buf)));
 
 	nhrp_interface_update_address(
 		ifc->ifp, family2afi(PREFIX_FAMILY(ifc->address)), 0);
@@ -360,7 +360,7 @@ int nhrp_interface_address_delete(ZAPI_CALLBACK_ARGS)
 		return 0;
 
 	debugf(NHRP_DEBUG_IF, "if-addr-del: %s: %s", ifc->ifp->name,
-	       prefix2str(ifc->address, buf, sizeof buf));
+	       prefix2str(ifc->address, buf, sizeof(buf)));
 
 	nhrp_interface_update_address(
 		ifc->ifp, family2afi(PREFIX_FAMILY(ifc->address)), 0);

--- a/nhrpd/nhrp_nhs.c
+++ b/nhrpd/nhrp_nhs.c
@@ -136,7 +136,7 @@ static void nhrp_reg_peer_notify(struct notifier_block *n, unsigned long cmd)
 	case NOTIFY_PEER_MTU_CHANGED:
 		debugf(NHRP_DEBUG_COMMON, "NHS: Flush timer for %s",
 		       sockunion2str(&r->peer->vc->remote.nbma, buf,
-				     sizeof buf));
+				     sizeof(buf)));
 		THREAD_TIMER_OFF(r->t_register);
 		thread_add_timer_msec(master, nhrp_reg_send_req, r, 10,
 				      &r->t_register);
@@ -162,7 +162,7 @@ static int nhrp_reg_send_req(struct thread *t)
 	if (!nhrp_peer_check(r->peer, 2)) {
 		debugf(NHRP_DEBUG_COMMON, "NHS: Waiting link for %s",
 		       sockunion2str(&r->peer->vc->remote.nbma, buf1,
-				     sizeof buf1));
+				     sizeof(buf1)));
 		thread_add_timer(master, nhrp_reg_send_req, r, 120,
 				 &r->t_register);
 		return 0;

--- a/nhrpd/nhrp_peer.c
+++ b/nhrpd/nhrp_peer.c
@@ -305,8 +305,8 @@ void nhrp_peer_send(struct nhrp_peer *p, struct zbuf *zb)
 		return;
 
 	debugf(NHRP_DEBUG_KERNEL, "PACKET: Send %s -> %s",
-	       sockunion2str(&p->vc->local.nbma, buf[0], sizeof buf[0]),
-	       sockunion2str(&p->vc->remote.nbma, buf[1], sizeof buf[1]));
+	       sockunion2str(&p->vc->local.nbma, buf[0], sizeof(buf[0])),
+	       sockunion2str(&p->vc->remote.nbma, buf[1], sizeof(buf[1])));
 
 	os_sendmsg(zb->head, zbuf_used(zb), p->ifp->ifindex,
 		   sockunion_get_addr(&p->vc->remote.nbma),
@@ -584,15 +584,15 @@ void nhrp_peer_send_indication(struct interface *ifp, uint16_t protocol_type,
 		debugf(NHRP_DEBUG_COMMON,
 		       "Send Traffic Indication to %s about packet to %s ignored",
 		       sockunion2str(&p->vc->remote.nbma, buf[0],
-				     sizeof buf[0]),
-		       sockunion2str(&dst, buf[1], sizeof buf[1]));
+				     sizeof(buf[0])),
+		       sockunion2str(&dst, buf[1], sizeof(buf[1])));
 		return;
 	}
 
 	debugf(NHRP_DEBUG_COMMON,
 	       "Send Traffic Indication to %s (online=%d) about packet to %s",
-	       sockunion2str(&p->vc->remote.nbma, buf[0], sizeof buf[0]),
-	       p->online, sockunion2str(&dst, buf[1], sizeof buf[1]));
+	       sockunion2str(&p->vc->remote.nbma, buf[0], sizeof(buf[0])),
+	       p->online, sockunion2str(&dst, buf[1], sizeof(buf[1])));
 
 	/* Create reply */
 	zb = zbuf_alloc(1500);
@@ -622,8 +622,8 @@ static void nhrp_handle_error_ind(struct nhrp_packet_parser *pp)
 
 	debugf(NHRP_DEBUG_COMMON,
 	       "Error Indication from %s about packet to %s ignored",
-	       sockunion2str(&pp->src_proto, buf[0], sizeof buf[0]),
-	       sockunion2str(&dst_proto, buf[1], sizeof buf[1]));
+	       sockunion2str(&pp->src_proto, buf[0], sizeof(buf[0])),
+	       sockunion2str(&dst_proto, buf[1], sizeof(buf[1])));
 
 	reqid = nhrp_reqid_lookup(&nhrp_packet_reqid, htonl(hdr->u.request_id));
 	if (reqid)
@@ -641,8 +641,8 @@ static void nhrp_handle_traffic_ind(struct nhrp_packet_parser *p)
 
 	debugf(NHRP_DEBUG_COMMON,
 	       "Traffic Indication from %s about packet to %s: %s",
-	       sockunion2str(&p->src_proto, buf[0], sizeof buf[0]),
-	       sockunion2str(&dst, buf[1], sizeof buf[1]),
+	       sockunion2str(&p->src_proto, buf[0], sizeof(buf[0])),
+	       sockunion2str(&dst, buf[1], sizeof(buf[1])),
 	       (p->if_ad->flags & NHRP_IFF_SHORTCUT) ? "trying shortcut"
 						     : "ignored");
 
@@ -809,8 +809,8 @@ static void nhrp_packet_debug(struct zbuf *zb, const char *dir)
 	zbuf_init(&zhdr, zb->buf, zb->tail - zb->buf, zb->tail - zb->buf);
 	hdr = nhrp_packet_pull(&zhdr, &src_nbma, &src_proto, &dst_proto);
 
-	sockunion2str(&src_proto, buf[0], sizeof buf[0]);
-	sockunion2str(&dst_proto, buf[1], sizeof buf[1]);
+	sockunion2str(&src_proto, buf[0], sizeof(buf[0]));
+	sockunion2str(&dst_proto, buf[1], sizeof(buf[1]));
 
 	reply = packet_types[hdr->type].type == PACKET_REPLY;
 	debugf(NHRP_DEBUG_COMMON, "%s %s(%d) %s -> %s", dir,
@@ -852,8 +852,8 @@ void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
 	afi_t nbma_afi, proto_afi;
 
 	debugf(NHRP_DEBUG_KERNEL, "PACKET: Recv %s -> %s",
-	       sockunion2str(&vc->remote.nbma, buf[0], sizeof buf[0]),
-	       sockunion2str(&vc->local.nbma, buf[1], sizeof buf[1]));
+	       sockunion2str(&vc->remote.nbma, buf[0], sizeof(buf[0])),
+	       sockunion2str(&vc->local.nbma, buf[1], sizeof(buf[1])));
 
 	if (!p->online) {
 		info = "peer not online";
@@ -885,7 +885,7 @@ void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
 	    || htons(hdr->packet_size) > realsize) {
 		zlog_info(
 			"From %s: error: packet type %d, version %d, AFI %d, proto %x, size %d (real size %d)",
-			sockunion2str(&vc->remote.nbma, buf[0], sizeof buf[0]),
+			sockunion2str(&vc->remote.nbma, buf[0], sizeof(buf[0])),
 			(int)hdr->type, (int)hdr->version, (int)nbma_afi,
 			(int)htons(hdr->protocol_type),
 			(int)htons(hdr->packet_size), (int)realsize);
@@ -962,7 +962,7 @@ drop:
 	if (info) {
 		zlog_info(
 			"From %s: error: %s",
-			sockunion2str(&vc->remote.nbma, buf[0], sizeof buf[0]),
+			sockunion2str(&vc->remote.nbma, buf[0], sizeof(buf[0])),
 			info);
 	}
 	if (peer)

--- a/nhrpd/nhrp_route.c
+++ b/nhrpd/nhrp_route.c
@@ -224,8 +224,8 @@ int nhrp_route_read(ZAPI_CALLBACK_ARGS)
 	added = (cmd == ZEBRA_REDISTRIBUTE_ROUTE_ADD);
 	debugf(NHRP_DEBUG_ROUTE, "if-route-%s: %s via %s dev %s",
 	       added ? "add" : "del",
-	       prefix2str(&api.prefix, buf[0], sizeof buf[0]),
-	       sockunion2str(&nexthop_addr, buf[1], sizeof buf[1]),
+	       prefix2str(&api.prefix, buf[0], sizeof(buf[0])),
+	       sockunion2str(&nexthop_addr, buf[1], sizeof(buf[1])),
 	       ifp ? ifp->name : "(none)");
 
 	nhrp_route_update_zebra(&api.prefix, &nexthop_addr, ifp);
@@ -252,7 +252,7 @@ int nhrp_route_get_nexthop(const union sockunion *addr, struct prefix *p,
 	ri = rn->info;
 	if (ri->nhrp_ifp) {
 		debugf(NHRP_DEBUG_ROUTE, "lookup %s: nhrp_if=%s",
-		       prefix2str(&lookup, buf, sizeof buf),
+		       prefix2str(&lookup, buf, sizeof(buf)),
 		       ri->nhrp_ifp->name);
 
 		if (via)
@@ -261,7 +261,7 @@ int nhrp_route_get_nexthop(const union sockunion *addr, struct prefix *p,
 			*ifp = ri->nhrp_ifp;
 	} else {
 		debugf(NHRP_DEBUG_ROUTE, "lookup %s: zebra route dev %s",
-		       prefix2str(&lookup, buf, sizeof buf),
+		       prefix2str(&lookup, buf, sizeof(buf)),
 		       ri->ifp ? ri->ifp->name : "(none)");
 
 		if (via)

--- a/nhrpd/nhrp_shortcut.c
+++ b/nhrpd/nhrp_shortcut.c
@@ -32,7 +32,7 @@ static void nhrp_shortcut_check_use(struct nhrp_shortcut *s)
 
 	if (s->expiring && s->cache && s->cache->used) {
 		debugf(NHRP_DEBUG_ROUTE, "Shortcut %s used and expiring",
-		       prefix2str(s->p, buf, sizeof buf));
+		       prefix2str(s->p, buf, sizeof(buf)));
 		nhrp_shortcut_send_resolution_req(s);
 	}
 }
@@ -133,7 +133,7 @@ static void nhrp_shortcut_delete(struct nhrp_shortcut *s)
 	nhrp_reqid_free(&nhrp_packet_reqid, &s->reqid);
 
 	debugf(NHRP_DEBUG_ROUTE, "Shortcut %s purged",
-	       prefix2str(s->p, buf, sizeof buf));
+	       prefix2str(s->p, buf, sizeof(buf)));
 
 	nhrp_shortcut_update_binding(s, NHRP_CACHE_INVALID, NULL, 0);
 
@@ -172,7 +172,7 @@ static struct nhrp_shortcut *nhrp_shortcut_get(struct prefix *p)
 		s->p = &rn->p;
 
 		debugf(NHRP_DEBUG_ROUTE, "Shortcut %s created",
-		       prefix2str(s->p, buf, sizeof buf));
+		       prefix2str(s->p, buf, sizeof(buf)));
 	} else {
 		s = rn->info;
 		route_unlock_node(rn);
@@ -217,7 +217,7 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 	}
 
 	/* Parse extensions */
-	memset(&nat_nbma, 0, sizeof nat_nbma);
+	memset(&nat_nbma, 0, sizeof(nat_nbma));
 	while ((ext = nhrp_ext_pull(&pp->extensions, &extpl)) != NULL) {
 		switch (htons(ext->type) & ~NHRP_EXTENSION_FLAG_COMPULSORY) {
 		case NHRP_EXTENSION_NAT_ADDRESS:
@@ -231,8 +231,8 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 	if (!sockunion_same(&cie_proto, &pp->dst_proto)) {
 		debugf(NHRP_DEBUG_COMMON,
 		       "Shortcut: Warning dst_proto altered from %s to %s",
-		       sockunion2str(&cie_proto, buf[0], sizeof buf[0]),
-		       sockunion2str(&pp->dst_proto, buf[1], sizeof buf[1]));
+		       sockunion2str(&cie_proto, buf[0], sizeof(buf[0])),
+		       sockunion2str(&pp->dst_proto, buf[1], sizeof(buf[1])));
 	}
 
 	/* One or more CIEs should be given as reply, we support only one */
@@ -263,10 +263,10 @@ static void nhrp_shortcut_recv_resolution_rep(struct nhrp_reqid *reqid,
 
 	debugf(NHRP_DEBUG_COMMON,
 	       "Shortcut: %s is at proto %s cie-nbma %s nat-nbma %s cie-holdtime %d",
-	       prefix2str(&prefix, bufp, sizeof bufp),
-	       sockunion2str(proto, buf[0], sizeof buf[0]),
-	       sockunion2str(&cie_nbma, buf[1], sizeof buf[1]),
-	       sockunion2str(&nat_nbma, buf[2], sizeof buf[2]),
+	       prefix2str(&prefix, bufp, sizeof(bufp)),
+	       sockunion2str(proto, buf[0], sizeof(buf[0])),
+	       sockunion2str(&cie_nbma, buf[1], sizeof(buf[1])),
+	       sockunion2str(&nat_nbma, buf[2], sizeof(buf[2])),
 	       htons(cie->holding_time));
 
 	/* Update cache entry for the protocol to nbma binding */

--- a/nhrpd/nhrp_vc.c
+++ b/nhrpd/nhrp_vc.c
@@ -142,8 +142,8 @@ int nhrp_vc_ipsec_updown(uint32_t child_id, struct nhrp_vc *vc)
 		sa->vc->abort_migration = 0;
 		debugf(NHRP_DEBUG_COMMON, "IPsec NBMA change of %s to %s",
 		       sockunion2str(&sa->vc->remote.nbma, buf[0],
-				     sizeof buf[0]),
-		       sockunion2str(&vc->remote.nbma, buf[1], sizeof buf[1]));
+				     sizeof(buf[0])),
+		       sockunion2str(&vc->remote.nbma, buf[1], sizeof(buf[1])));
 		nhrp_vc_update(sa->vc, NOTIFY_VC_IPSEC_UPDATE_NBMA);
 		abort_migration = sa->vc->abort_migration;
 	}

--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -613,9 +613,9 @@ static void show_ip_nhrp_cache(struct nhrp_cache *c, void *pctx)
 
 	vty_out(ctx->vty, "%-8s %-8s %-24s %-24s %c%c%c    %s\n", c->ifp->name,
 		nhrp_cache_type_str[c->cur.type],
-		sockunion2str(&c->remote_addr, buf[0], sizeof buf[0]),
+		sockunion2str(&c->remote_addr, buf[0], sizeof(buf[0])),
 		c->cur.peer ? sockunion2str(&c->cur.peer->vc->remote.nbma,
-					    buf[1], sizeof buf[1])
+					    buf[1], sizeof(buf[1]))
 			    : "-",
 		c->used ? 'U' : ' ', c->t_timeout ? 'T' : ' ',
 		c->t_auth ? 'A' : ' ',
@@ -637,10 +637,10 @@ static void show_ip_nhrp_nhs(struct nhrp_nhs *n, struct nhrp_registration *reg,
 
 	vty_out(vty, "%-8s %-24s %-16s %-16s\n", n->ifp->name, n->nbma_fqdn,
 		(reg && reg->peer) ? sockunion2str(&reg->peer->vc->remote.nbma,
-						   buf[0], sizeof buf[0])
+						   buf[0], sizeof(buf[0]))
 				   : "-",
 		sockunion2str(reg ? &reg->proto_addr : &n->proto_addr, buf[1],
-			      sizeof buf[1]));
+			      sizeof(buf[1])));
 }
 
 static void show_ip_nhrp_shortcut(struct nhrp_shortcut *s, void *pctx)
@@ -658,8 +658,8 @@ static void show_ip_nhrp_shortcut(struct nhrp_shortcut *s, void *pctx)
 
 	c = s->cache;
 	vty_out(ctx->vty, "%-8s %-24s %-24s %s\n", nhrp_cache_type_str[s->type],
-		prefix2str(s->p, buf1, sizeof buf1),
-		c ? sockunion2str(&c->remote_addr, buf2, sizeof buf2) : "",
+		prefix2str(s->p, buf1, sizeof(buf1)),
+		c ? sockunion2str(&c->remote_addr, buf2, sizeof(buf2)) : "",
 		(c && c->cur.peer) ? c->cur.peer->vc->remote.id : "");
 }
 
@@ -678,19 +678,19 @@ static void show_ip_opennhrp_cache(struct nhrp_cache *c, void *pctx)
 		nhrp_cache_type_str[c->cur.type],
 		(c->cur.peer && c->cur.peer->online) ? " up" : "",
 		c->used ? " used" : "",
-		sockunion2str(&c->remote_addr, buf, sizeof buf),
+		sockunion2str(&c->remote_addr, buf, sizeof(buf)),
 		8 * family2addrsize(sockunion_family(&c->remote_addr)));
 
 	if (c->cur.peer) {
 		vty_out(ctx->vty, "NBMA-Address: %s\n",
 			sockunion2str(&c->cur.peer->vc->remote.nbma, buf,
-				      sizeof buf));
+				      sizeof(buf)));
 	}
 
 	if (sockunion_family(&c->cur.remote_nbma_natoa) != AF_UNSPEC) {
 		vty_out(ctx->vty, "NBMA-NAT-OA-Address: %s\n",
 			sockunion2str(&c->cur.remote_nbma_natoa, buf,
-				      sizeof buf));
+				      sizeof(buf)));
 	}
 
 	vty_out(ctx->vty, "\n\n");
@@ -741,8 +741,8 @@ static void show_dmvpn_entry(struct nhrp_vc *vc, void *ctx)
 	char buf[2][SU_ADDRSTRLEN];
 
 	vty_out(vty, "%-24s %-24s %c      %-4d %-24s\n",
-		sockunion2str(&vc->local.nbma, buf[0], sizeof buf[0]),
-		sockunion2str(&vc->remote.nbma, buf[1], sizeof buf[1]),
+		sockunion2str(&vc->local.nbma, buf[0], sizeof(buf[0])),
+		sockunion2str(&vc->remote.nbma, buf[1], sizeof(buf[1])),
 		notifier_active(&vc->notifier_list) ? 'n' : ' ', vc->ipsec,
 		vc->remote.id);
 }
@@ -824,11 +824,11 @@ static void interface_config_write_nhrp_map(struct nhrp_cache *c, void *data)
 		return;
 
 	vty_out(vty, " %s nhrp map %s %s\n", ctx->aficmd,
-		sockunion2str(&c->remote_addr, buf[0], sizeof buf[0]),
+		sockunion2str(&c->remote_addr, buf[0], sizeof(buf[0])),
 		c->cur.type == NHRP_CACHE_LOCAL
 			? "local"
 			: sockunion2str(&c->cur.peer->vc->remote.nbma, buf[1],
-					sizeof buf[1]));
+					sizeof(buf[1])));
 }
 
 static int interface_config_write(struct vty *vty)
@@ -904,7 +904,7 @@ static int interface_config_write(struct vty *vty)
 						? "dynamic"
 						: sockunion2str(
 							  &nhs->proto_addr, buf,
-							  sizeof buf),
+							  sizeof(buf)),
 					nhs->nbma_fqdn);
 			}
 		}

--- a/nhrpd/vici.c
+++ b/nhrpd/vici.c
@@ -303,7 +303,7 @@ static void vici_recv_sa(struct vici_conn *vici, struct zbuf *msg, int event)
 	if (ctx.kill_ikesa && ctx.ike_uniqueid) {
 		debugf(NHRP_DEBUG_COMMON, "VICI: Deleting IKE_SA %u",
 		       ctx.ike_uniqueid);
-		snprintf(buf, sizeof buf, "%u", ctx.ike_uniqueid);
+		snprintf(buf, sizeof(buf), "%u", ctx.ike_uniqueid);
 		vici_submit_request(vici, "terminate", VICI_KEY_VALUE, "ike-id",
 				    strlen(buf), buf, VICI_END);
 	}
@@ -527,8 +527,8 @@ void vici_request_vc(const char *profile, union sockunion *src,
 	struct vici_conn *vici = &vici_connection;
 	char buf[2][SU_ADDRSTRLEN];
 
-	sockunion2str(src, buf[0], sizeof buf[0]);
-	sockunion2str(dst, buf[1], sizeof buf[1]);
+	sockunion2str(src, buf[0], sizeof(buf[0]));
+	sockunion2str(dst, buf[1], sizeof(buf[1]));
 
 	vici_submit_request(vici, "initiate", VICI_KEY_VALUE, "child",
 			    strlen(profile), profile, VICI_KEY_VALUE, "timeout",

--- a/ospf6d/ospf6_proto.h
+++ b/ospf6d/ospf6_proto.h
@@ -71,7 +71,7 @@ struct ospf6_prefix {
 #define OSPF6_PREFIX_OPTION_P  (1 << 3)  /* Propagate (NSSA) */
 
 /* caddr_t OSPF6_PREFIX_BODY (struct ospf6_prefix *); */
-#define OSPF6_PREFIX_BODY(x) ((caddr_t)(x) + sizeof (struct ospf6_prefix))
+#define OSPF6_PREFIX_BODY(x) ((caddr_t)(x) + sizeof(struct ospf6_prefix))
 
 /* size_t OSPF6_PREFIX_SPACE (int prefixlength); */
 #define OSPF6_PREFIX_SPACE(x) ((((x) + 31) / 32) * 4)

--- a/ospf6d/ospf6_snmp.c
+++ b/ospf6d/ospf6_snmp.c
@@ -1356,7 +1356,7 @@ static int ospf6TrapNbrStateChange(struct ospf6_neighbor *on, int next_state,
 
 	smux_trap(ospfv3_variables, array_size(ospfv3_variables),
 		  ospfv3_trap_oid, array_size(ospfv3_trap_oid), ospfv3_oid,
-		  sizeof ospfv3_oid / sizeof(oid), index, 3, ospf6NbrTrapList,
+		  sizeof(ospfv3_oid) / sizeof(oid), index, 3, ospf6NbrTrapList,
 		  array_size(ospf6NbrTrapList), NBRSTATECHANGE);
 	return 0;
 }
@@ -1378,7 +1378,7 @@ static int ospf6TrapIfStateChange(struct ospf6_interface *oi, int next_state,
 
 	smux_trap(ospfv3_variables, array_size(ospfv3_variables),
 		  ospfv3_trap_oid, array_size(ospfv3_trap_oid), ospfv3_oid,
-		  sizeof ospfv3_oid / sizeof(oid), index, 2, ospf6IfTrapList,
+		  sizeof(ospfv3_oid) / sizeof(oid), index, 2, ospf6IfTrapList,
 		  array_size(ospf6IfTrapList), IFSTATECHANGE);
 	return 0;
 }

--- a/ospfd/ospf_dump.c
+++ b/ospfd/ospf_dump.c
@@ -386,7 +386,7 @@ static void ospf_packet_db_desc_dump(struct stream *s, uint16_t length)
 	zlog_debug("  Options %d (%s)", dd->options,
 		   ospf_options_dump(dd->options));
 	zlog_debug("  Flags %d (%s)", dd->flags,
-		   ospf_dd_flags_dump(dd->flags, dd_flags, sizeof dd_flags));
+		   ospf_dd_flags_dump(dd->flags, dd_flags, sizeof(dd_flags)));
 	zlog_debug("  Sequence Number 0x%08lx",
 		   (unsigned long)ntohl(dd->dd_seqnum));
 

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -434,7 +434,7 @@ static char link_info_set(struct stream **s, struct in_addr id,
 			/* we futz the size here for simplicity, really we need
 			 * to account
 			 * for just:
-			 * IP Header - (sizeof (struct ip))
+			 * IP Header - (sizeof(struct ip))
 			 * OSPF Header - OSPF_HEADER_SIZE
 			 * LSA Header - OSPF_LSA_HEADER_SIZE
 			 * MD5 auth data, if MD5 is configured -

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -725,7 +725,7 @@ static int ospf_write(struct thread *thread)
 		 * but.. */
 		if (sizeof(struct ip)
 		    > (unsigned int)(iph.ip_hl << OSPF_WRITE_IPHL_SHIFT))
-			iph.ip_hl++; /* we presume sizeof struct ip cant
+			iph.ip_hl++; /* we presume sizeof(struct ip) cant
 					overflow ip_hl.. */
 
 		iph.ip_v = IPVERSION;
@@ -3250,7 +3250,7 @@ static int ospf_make_auth(struct ospf_interface *oi, struct ospf_header *ospfh)
 
 	switch (ospf_auth_type(oi)) {
 	case OSPF_AUTH_NULL:
-		/* memset (ospfh->u.auth_data, 0, sizeof (ospfh->u.auth_data));
+		/* memset (ospfh->u.auth_data, 0, sizeof(ospfh->u.auth_data));
 		 */
 		break;
 	case OSPF_AUTH_SIMPLE:
@@ -3273,7 +3273,7 @@ static int ospf_make_auth(struct ospf_interface *oi, struct ospf_header *ospfh)
 		/* note: the seq is done in ospf_make_md5_digest() */
 		break;
 	default:
-		/* memset (ospfh->u.auth_data, 0, sizeof (ospfh->u.auth_data));
+		/* memset (ospfh->u.auth_data, 0, sizeof(ospfh->u.auth_data));
 		 */
 		break;
 	}

--- a/ospfd/ospf_snmp.c
+++ b/ospfd/ospf_snmp.c
@@ -2463,7 +2463,7 @@ static void ospfTrapNbrStateChange(struct ospf_neighbor *on)
 
 	smux_trap(ospf_variables, array_size(ospf_variables), ospf_trap_oid,
 		  array_size(ospf_trap_oid), ospf_oid,
-		  sizeof ospf_oid / sizeof(oid), index, IN_ADDR_SIZE + 1,
+		  sizeof(ospf_oid) / sizeof(oid), index, IN_ADDR_SIZE + 1,
 		  ospfNbrTrapList, array_size(ospfNbrTrapList), NBRSTATECHANGE);
 }
 
@@ -2478,7 +2478,7 @@ static void ospfTrapVirtNbrStateChange(struct ospf_neighbor *on)
 
 	smux_trap(ospf_variables, array_size(ospf_variables), ospf_trap_oid,
 		  array_size(ospf_trap_oid), ospf_oid,
-		  sizeof ospf_oid / sizeof(oid), index, IN_ADDR_SIZE + 1,
+		  sizeof(ospf_oid) / sizeof(oid), index, IN_ADDR_SIZE + 1,
 		  ospfVirtNbrTrapList, array_size(ospfVirtNbrTrapList),
 		  VIRTNBRSTATECHANGE);
 }
@@ -2517,7 +2517,7 @@ static void ospfTrapIfStateChange(struct ospf_interface *oi)
 
 	smux_trap(ospf_variables, array_size(ospf_variables), ospf_trap_oid,
 		  array_size(ospf_trap_oid), ospf_oid,
-		  sizeof ospf_oid / sizeof(oid), index, IN_ADDR_SIZE + 1,
+		  sizeof(ospf_oid) / sizeof(oid), index, IN_ADDR_SIZE + 1,
 		  ospfIfTrapList, array_size(ospfIfTrapList), IFSTATECHANGE);
 }
 
@@ -2532,7 +2532,7 @@ static void ospfTrapVirtIfStateChange(struct ospf_interface *oi)
 
 	smux_trap(ospf_variables, array_size(ospf_variables), ospf_trap_oid,
 		  array_size(ospf_trap_oid), ospf_oid,
-		  sizeof ospf_oid / sizeof(oid), index, IN_ADDR_SIZE + 1,
+		  sizeof(ospf_oid) / sizeof(oid), index, IN_ADDR_SIZE + 1,
 		  ospfVirtIfTrapList, array_size(ospfVirtIfTrapList),
 		  VIRTIFSTATECHANGE);
 }

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -217,7 +217,7 @@ void pim_delete_tracked_nexthop(struct pim_instance *pim, struct prefix *addr,
 
 		if (PIM_DEBUG_PIM_NHT) {
 			char buf[PREFIX_STRLEN];
-			prefix2str(addr, buf, sizeof buf);
+			prefix2str(addr, buf, sizeof(buf));
 			zlog_debug(
 				"%s: NHT %s(%s) rp_list count:%d upstream count:%ld",
 				__func__, buf, pim->vrf->name,

--- a/pimd/pim_tlv.c
+++ b/pimd/pim_tlv.c
@@ -143,7 +143,7 @@ int pim_encode_addr_ucast(uint8_t *buf, struct prefix *p)
 	}
 }
 
-#define group_ipv4_encoding_len (4 + sizeof (struct in_addr))
+#define group_ipv4_encoding_len (4 + sizeof(struct in_addr))
 
 /*
  * Encoded-Group addresses take the following format:

--- a/ripd/rip_interface.c
+++ b/ripd/rip_interface.c
@@ -216,7 +216,7 @@ rip_request_neighbor (struct in_addr addr)
 {
   struct sockaddr_in to;
 
-  memset (&to, 0, sizeof (struct sockaddr_in));
+  memset (&to, 0, sizeof(struct sockaddr_in));
   to.sin_port = htons (RIP_PORT_DEFAULT);
   to.sin_addr = addr;
 

--- a/ripd/rip_snmp.c
+++ b/ripd/rip_snmp.c
@@ -553,7 +553,7 @@ static uint8_t *rip2PeerTable(struct variable *v, oid name[], size_t *length,
        * - don't support this variable, at all
        * Currently, we do the latter...
        */
-      *val_len = sizeof (time_t);
+      *val_len = sizeof(time_t);
       uptime = peer->uptime; /* now - snmp_agent_startup - peer->uptime */
       return (uint8_t *) &uptime;
 #else

--- a/ripd/ripd.c
+++ b/ripd/ripd.c
@@ -104,7 +104,7 @@ static int sockopt_broadcast(int sock)
 	int on = 1;
 
 	ret = setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char *)&on,
-			 sizeof on);
+			 sizeof(on));
 	if (ret < 0) {
 		zlog_warn("can't set sockopt SO_BROADCAST to socket %d", sock);
 		return -1;

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -271,7 +271,7 @@ static int ripng_recv_packet(int sock, uint8_t *buf, int bufsize,
 	msg.msg_iov = &iov;
 	msg.msg_iovlen = 1;
 	msg.msg_control = (void *)adata;
-	msg.msg_controllen = sizeof adata;
+	msg.msg_controllen = sizeof(adata);
 	iov.iov_base = buf;
 	iov.iov_len = bufsize;
 

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -3670,7 +3670,7 @@ char *vtysh_prompt(void)
 {
 	static char buf[512];
 
-	snprintf(buf, sizeof buf, cmd_prompt(vty->node), cmd_hostname_get());
+	snprintf(buf, sizeof(buf), cmd_prompt(vty->node), cmd_hostname_get());
 	return buf;
 }
 

--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -237,7 +237,7 @@ static void log_it(const char *line)
 	if (!user)
 		user = "boot";
 
-	strftime(tod, sizeof tod, "%Y%m%d-%H:%M.%S", &tmp);
+	strftime(tod, sizeof(tod), "%Y%m%d-%H:%M.%S", &tmp);
 
 	fprintf(logfile, "%s:%s %s\n", tod, user, line);
 }

--- a/zebra/if_netlink.c
+++ b/zebra/if_netlink.c
@@ -286,7 +286,7 @@ static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
 
 	ifi = NLMSG_DATA(h);
 
-	memset(linkinfo, 0, sizeof linkinfo);
+	memset(linkinfo, 0, sizeof(linkinfo));
 	parse_rtattr_nested(linkinfo, IFLA_INFO_MAX, tb);
 
 	if (!linkinfo[IFLA_INFO_DATA]) {
@@ -297,7 +297,7 @@ static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
 		return;
 	}
 
-	memset(attr, 0, sizeof attr);
+	memset(attr, 0, sizeof(attr));
 	parse_rtattr_nested(attr, IFLA_VRF_MAX, linkinfo[IFLA_INFO_DATA]);
 	if (!attr[IFLA_VRF_TABLE]) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
@@ -433,7 +433,7 @@ static int netlink_extract_bridge_info(struct rtattr *link_data,
 	struct rtattr *attr[IFLA_BR_MAX + 1];
 
 	memset(bridge_info, 0, sizeof(*bridge_info));
-	memset(attr, 0, sizeof attr);
+	memset(attr, 0, sizeof(attr));
 	parse_rtattr_nested(attr, IFLA_BR_MAX, link_data);
 	if (attr[IFLA_BR_VLAN_FILTERING])
 		bridge_info->vlan_aware =
@@ -448,7 +448,7 @@ static int netlink_extract_vlan_info(struct rtattr *link_data,
 	vlanid_t vid_in_msg;
 
 	memset(vlan_info, 0, sizeof(*vlan_info));
-	memset(attr, 0, sizeof attr);
+	memset(attr, 0, sizeof(attr));
 	parse_rtattr_nested(attr, IFLA_VLAN_MAX, link_data);
 	if (!attr[IFLA_VLAN_ID]) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
@@ -469,7 +469,7 @@ static int netlink_extract_vxlan_info(struct rtattr *link_data,
 	struct in_addr vtep_ip_in_msg;
 
 	memset(vxl_info, 0, sizeof(*vxl_info));
-	memset(attr, 0, sizeof attr);
+	memset(attr, 0, sizeof(attr));
 	parse_rtattr_nested(attr, IFLA_VXLAN_MAX, link_data);
 	if (!attr[IFLA_VXLAN_ID]) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
@@ -543,7 +543,7 @@ static int netlink_bridge_interface(struct nlmsghdr *h, int len, ns_id_t ns_id,
 
 	/* Fetch name and ifindex */
 	ifi = NLMSG_DATA(h);
-	memset(tb, 0, sizeof tb);
+	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
 
 	if (tb[IFLA_IFNAME] == NULL)
@@ -567,7 +567,7 @@ static int netlink_bridge_interface(struct nlmsghdr *h, int len, ns_id_t ns_id,
 	/* There is a 1-to-1 mapping of VLAN to VxLAN - hence
 	 * only 1 access VLAN is accepted.
 	 */
-	memset(aftb, 0, sizeof aftb);
+	memset(aftb, 0, sizeof(aftb));
 	parse_rtattr_nested(aftb, IFLA_BRIDGE_MAX, tb[IFLA_AF_SPEC]);
 	if (!aftb[IFLA_BRIDGE_VLAN_INFO])
 		return 0;
@@ -628,8 +628,8 @@ static int netlink_interface(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return netlink_bridge_interface(h, len, ns_id, startup);
 
 	/* Looking up interface name. */
-	memset(tb, 0, sizeof tb);
-	memset(linkinfo, 0, sizeof linkinfo);
+	memset(tb, 0, sizeof(tb));
+	memset(linkinfo, 0, sizeof(linkinfo));
 	netlink_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
 
 	/* check for wireless messages to ignore */
@@ -858,7 +858,7 @@ int kernel_interface_set_master(struct interface *master,
 		char buf[NL_PKT_BUF_SIZE];
 	} req;
 
-	memset(&req, 0, sizeof req);
+	memset(&req, 0, sizeof(req));
 
 	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
 	req.n.nlmsg_flags = NLM_F_REQUEST;
@@ -867,8 +867,8 @@ int kernel_interface_set_master(struct interface *master,
 
 	req.ifa.ifi_index = slave->ifindex;
 
-	addattr_l(&req.n, sizeof req, IFLA_MASTER, &master->ifindex, 4);
-	addattr_l(&req.n, sizeof req, IFLA_LINK, &slave->ifindex, 4);
+	addattr_l(&req.n, sizeof(req), IFLA_MASTER, &master->ifindex, 4);
+	addattr_l(&req.n, sizeof(req), IFLA_LINK, &slave->ifindex, 4);
 
 	return netlink_talk(netlink_talk_filter, &req.n, &zns->netlink_cmd, zns,
 			    0);
@@ -982,7 +982,7 @@ int netlink_interface_addr(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return -1;
 	}
 
-	memset(tb, 0, sizeof tb);
+	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, IFA_MAX, IFA_RTA(ifa), len);
 
 	ifp = if_lookup_by_index_per_ns(zns, ifa->ifa_index);
@@ -1188,8 +1188,8 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
 		return netlink_bridge_interface(h, len, ns_id, startup);
 
 	/* Looking up interface name. */
-	memset(tb, 0, sizeof tb);
-	memset(linkinfo, 0, sizeof linkinfo);
+	memset(tb, 0, sizeof(tb));
+	memset(linkinfo, 0, sizeof(linkinfo));
 	netlink_parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), len);
 
 	/* check for wireless messages to ignore */

--- a/zebra/ipforward_sysctl.c
+++ b/zebra/ipforward_sysctl.c
@@ -41,7 +41,7 @@ int ipforward(void)
 	size_t len;
 	int ipforwarding = 0;
 
-	len = sizeof ipforwarding;
+	len = sizeof(ipforwarding);
 	if (sysctl(mib, MIB_SIZ, &ipforwarding, &len, 0, 0) < 0) {
 		flog_err_sys(EC_LIB_SYSTEM_CALL,
 			     "Can't get ipforwarding value");
@@ -55,7 +55,7 @@ int ipforward_on(void)
 	size_t len;
 	int ipforwarding = 1;
 
-	len = sizeof ipforwarding;
+	len = sizeof(ipforwarding);
 	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib, MIB_SIZ, NULL, NULL, &ipforwarding, len) < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
@@ -71,7 +71,7 @@ int ipforward_off(void)
 	size_t len;
 	int ipforwarding = 0;
 
-	len = sizeof ipforwarding;
+	len = sizeof(ipforwarding);
 	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib, MIB_SIZ, NULL, NULL, &ipforwarding, len) < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
@@ -96,7 +96,7 @@ int ipforward_ipv6(void)
 	size_t len;
 	int ip6forwarding = 0;
 
-	len = sizeof ip6forwarding;
+	len = sizeof(ip6forwarding);
 	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib_ipv6, MIB_SIZ, &ip6forwarding, &len, 0, 0) < 0) {
 			flog_err_sys(EC_LIB_SYSTEM_CALL,
@@ -112,7 +112,7 @@ int ipforward_ipv6_on(void)
 	size_t len;
 	int ip6forwarding = 1;
 
-	len = sizeof ip6forwarding;
+	len = sizeof(ip6forwarding);
 	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len)
 		    < 0) {
@@ -129,7 +129,7 @@ int ipforward_ipv6_off(void)
 	size_t len;
 	int ip6forwarding = 0;
 
-	len = sizeof ip6forwarding;
+	len = sizeof(ip6forwarding);
 	frr_with_privs(&zserv_privs) {
 		if (sysctl(mib_ipv6, MIB_SIZ, NULL, NULL, &ip6forwarding, len)
 		    < 0) {

--- a/zebra/irdp_main.c
+++ b/zebra/irdp_main.c
@@ -190,7 +190,7 @@ static void irdp_send(struct interface *ifp, struct prefix *p, struct stream *s)
 
 	if (irdp->flags & IF_DEBUG_MESSAGES)
 		zlog_debug("IRDP: TX Advert on %s %s Holdtime=%d Preference=%d",
-			   ifp->name, prefix2str(p, buf, sizeof buf),
+			   ifp->name, prefix2str(p, buf, sizeof(buf)),
 			   irdp->flags & IF_SHUTDOWN ? 0 : irdp->Lifetime,
 			   get_pref(irdp, p));
 

--- a/zebra/irdp_packet.c
+++ b/zebra/irdp_packet.c
@@ -196,7 +196,7 @@ static int irdp_recvmsg(int sock, uint8_t *buf, int size, int *ifindex)
 	msg.msg_iov = &iov;
 	msg.msg_iovlen = 1;
 	msg.msg_control = (void *)adata;
-	msg.msg_controllen = sizeof adata;
+	msg.msg_controllen = sizeof(adata);
 
 	iov.iov_base = buf;
 	iov.iov_len = size;

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -231,12 +231,12 @@ static int netlink_socket(struct nlsock *nl, unsigned long groups,
 			return -1;
 		}
 
-		memset(&snl, 0, sizeof snl);
+		memset(&snl, 0, sizeof(snl));
 		snl.nl_family = AF_NETLINK;
 		snl.nl_groups = groups;
 
 		/* Bind the socket to the netlink structure for anything. */
-		ret = bind(sock, (struct sockaddr *)&snl, sizeof snl);
+		ret = bind(sock, (struct sockaddr *)&snl, sizeof(snl));
 	}
 
 	if (ret < 0) {
@@ -247,9 +247,9 @@ static int netlink_socket(struct nlsock *nl, unsigned long groups,
 	}
 
 	/* multiple netlink sockets will have different nl_pid */
-	namelen = sizeof snl;
+	namelen = sizeof(snl);
 	ret = getsockname(sock, (struct sockaddr *)&snl, (socklen_t *)&namelen);
-	if (ret < 0 || namelen != sizeof snl) {
+	if (ret < 0 || namelen != sizeof(snl)) {
 		flog_err_sys(EC_LIB_SOCKET, "Can't get %s socket name: %s",
 			     nl->name, safe_strerror(errno));
 		close(sock);
@@ -738,10 +738,10 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 
 	while (1) {
 		char buf[NL_RCV_PKT_BUF_SIZE];
-		struct iovec iov = {.iov_base = buf, .iov_len = sizeof buf};
+		struct iovec iov = {.iov_base = buf, .iov_len = sizeof(buf)};
 		struct sockaddr_nl snl;
 		struct msghdr msg = {.msg_name = (void *)&snl,
-				     .msg_namelen = sizeof snl,
+				     .msg_namelen = sizeof(snl),
 				     .msg_iov = &iov,
 				     .msg_iovlen = 1};
 		struct nlmsghdr *h;
@@ -783,7 +783,7 @@ int netlink_parse_info(int (*filter)(struct nlmsghdr *, ns_id_t, int),
 			return -1;
 		}
 
-		if (msg.msg_namelen != sizeof snl) {
+		if (msg.msg_namelen != sizeof(snl)) {
 			flog_err(EC_ZEBRA_NETLINK_LENGTH_ERROR,
 				 "%s sender address length error: length %d",
 				 nl->name, msg.msg_namelen);
@@ -989,14 +989,14 @@ int netlink_talk_info(int (*filter)(struct nlmsghdr *, ns_id_t, int startup),
 	int save_errno = 0;
 	const struct nlsock *nl;
 
-	memset(&snl, 0, sizeof snl);
-	memset(&iov, 0, sizeof iov);
-	memset(&msg, 0, sizeof msg);
+	memset(&snl, 0, sizeof(snl));
+	memset(&iov, 0, sizeof(iov));
+	memset(&msg, 0, sizeof(msg));
 
 	iov.iov_base = n;
 	iov.iov_len = n->nlmsg_len;
 	msg.msg_name = (void *)&snl;
-	msg.msg_namelen = sizeof snl;
+	msg.msg_namelen = sizeof(snl);
 	msg.msg_iov = &iov;
 	msg.msg_iovlen = 1;
 
@@ -1077,13 +1077,13 @@ int netlink_request(struct nlsock *nl, struct nlmsghdr *n)
 	n->nlmsg_pid = nl->snl.nl_pid;
 	n->nlmsg_seq = ++nl->seq;
 
-	memset(&snl, 0, sizeof snl);
+	memset(&snl, 0, sizeof(snl));
 	snl.nl_family = AF_NETLINK;
 
 	/* Raise capabilities and send message, then lower capabilities. */
 	frr_with_privs(&zserv_privs) {
 		ret = sendto(nl->sock, (void *)n, n->nlmsg_len, 0,
-			     (struct sockaddr *)&snl, sizeof snl);
+			     (struct sockaddr *)&snl, sizeof(snl));
 	}
 
 	if (ret < 0) {

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1371,7 +1371,7 @@ static int kernel_read(struct thread *thread)
 	/* Fetch routing socket. */
 	sock = THREAD_FD(thread);
 
-	nbytes = read(sock, &buf, sizeof buf);
+	nbytes = read(sock, &buf, sizeof(buf));
 
 	if (nbytes <= 0) {
 		if (nbytes < 0 && errno != EWOULDBLOCK && errno != EAGAIN)

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -564,7 +564,7 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 		return -1;
 	}
 
-	memset(tb, 0, sizeof tb);
+	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, RTA_MAX, RTM_RTA(rtm), len);
 
 	if (rtm->rtm_flags & RTM_F_CLONED)
@@ -639,7 +639,7 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 	if (tb[RTA_METRICS]) {
 		struct rtattr *mxrta[RTAX_MAX + 1];
 
-		memset(mxrta, 0, sizeof mxrta);
+		memset(mxrta, 0, sizeof(mxrta));
 		netlink_parse_rtattr(mxrta, RTAX_MAX, RTA_DATA(tb[RTA_METRICS]),
 				     RTA_PAYLOAD(tb[RTA_METRICS]));
 
@@ -849,7 +849,7 @@ static int netlink_route_change_read_multicast(struct nlmsghdr *h,
 
 	len = h->nlmsg_len - NLMSG_LENGTH(sizeof(struct rtmsg));
 
-	memset(tb, 0, sizeof tb);
+	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, RTA_MAX, RTM_RTA(rtm), len);
 
 	if (tb[RTA_TABLE])
@@ -2640,7 +2640,7 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	}
 
 	/* Parse attributes and extract fields of interest. */
-	memset(tb, 0, sizeof tb);
+	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, NDA_MAX, NDA_RTA(ndm), len);
 
 	if (!tb[NDA_LLADDR]) {
@@ -3050,7 +3050,7 @@ static int netlink_ipneigh_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 	zif = (struct zebra_if *)ifp->info;
 
 	/* Parse attributes and extract fields of interest. */
-	memset(tb, 0, sizeof tb);
+	memset(tb, 0, sizeof(tb));
 	netlink_parse_rtattr(tb, NDA_MAX, NDA_RTA(ndm), len);
 
 	if (!tb[NDA_DST]) {

--- a/zebra/rtadv.c
+++ b/zebra/rtadv.c
@@ -130,7 +130,7 @@ static int rtadv_recv_packet(struct zebra_vrf *zvrf, int sock, uint8_t *buf,
 	msg.msg_iov = &iov;
 	msg.msg_iovlen = 1;
 	msg.msg_control = (void *)adata;
-	msg.msg_controllen = sizeof adata;
+	msg.msg_controllen = sizeof(adata);
 	iov.iov_base = buf;
 	iov.iov_len = buflen;
 
@@ -2425,7 +2425,7 @@ static int if_join_all_router(int sock, struct interface *ifp)
 	mreq.ipv6mr_interface = ifp->ifindex;
 
 	ret = setsockopt(sock, IPPROTO_IPV6, IPV6_JOIN_GROUP, (char *)&mreq,
-			 sizeof mreq);
+			 sizeof(mreq));
 	if (ret < 0)
 		flog_err_sys(EC_LIB_SOCKET,
 			     "%s(%u): Failed to join group, socket %u error %s",
@@ -2451,7 +2451,7 @@ static int if_leave_all_router(int sock, struct interface *ifp)
 	mreq.ipv6mr_interface = ifp->ifindex;
 
 	ret = setsockopt(sock, IPPROTO_IPV6, IPV6_LEAVE_GROUP, (char *)&mreq,
-			 sizeof mreq);
+			 sizeof(mreq));
 	if (ret < 0)
 		flog_err_sys(
 			EC_LIB_SOCKET,

--- a/zebra/rtread_getmsg.c
+++ b/zebra/rtread_getmsg.c
@@ -231,7 +231,7 @@ void route_read(struct zebra_ns *zns)
 				    != 0) {
 					zlog_debug(
 						"getmsg(data) returned "
-						"msgdata.len = %d (%% sizeof (mib2_ipRouteEntry_t) != 0)",
+						"msgdata.len = %d (%% sizeof(mib2_ipRouteEntry_t) != 0)",
 						msgdata.len);
 					goto exit;
 				}

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -286,7 +286,7 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 			case NEXTHOP_TYPE_IPV6_IFINDEX:
 				vty_out(vty, " %s",
 					inet_ntop(AF_INET6, &nexthop->gate.ipv6,
-						  buf, sizeof buf));
+						  buf, sizeof(buf)));
 				if (nexthop->ifindex)
 					vty_out(vty, ", via %s",
 						ifindex2ifname(
@@ -348,7 +348,7 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 				if (nexthop->src.ipv4.s_addr) {
 					if (inet_ntop(AF_INET,
 						      &nexthop->src.ipv4,
-						      addrstr, sizeof addrstr))
+						      addrstr, sizeof(addrstr)))
 						vty_out(vty, ", src %s",
 							addrstr);
 				}
@@ -359,7 +359,7 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 						    &in6addr_any)) {
 					if (inet_ntop(AF_INET6,
 						      &nexthop->src.ipv6,
-						      addrstr, sizeof addrstr))
+						      addrstr, sizeof(addrstr)))
 						vty_out(vty, ", src %s",
 							addrstr);
 				}
@@ -378,7 +378,7 @@ static void vty_show_ip_route_detail(struct vty *vty, struct route_node *rn,
 					mpls_label2str(
 						nexthop->nh_label->num_labels,
 						nexthop->nh_label->label, buf,
-						sizeof buf, 1));
+						sizeof(buf), 1));
 			}
 
 			if (nexthop->weight)
@@ -424,7 +424,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		json_nexthops = json_object_new_array();
 
 		json_object_string_add(json_route, "prefix",
-				       srcdest_rnode2str(rn, buf, sizeof buf));
+				       srcdest_rnode2str(rn, buf, sizeof(buf)));
 		json_object_string_add(json_route, "protocol",
 				       zebra_route_string(re->type));
 
@@ -526,7 +526,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 				json_object_string_add(
 					json_nexthop, "ip",
 					inet_ntop(AF_INET6, &nexthop->gate.ipv6,
-						  buf, sizeof buf));
+						  buf, sizeof(buf)));
 				json_object_string_add(json_nexthop, "afi",
 						       "ipv6");
 
@@ -606,7 +606,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 				if (nexthop->src.ipv4.s_addr) {
 					if (inet_ntop(AF_INET,
 						      &nexthop->src.ipv4, buf,
-						      sizeof buf))
+						      sizeof(buf)))
 						json_object_string_add(
 							json_nexthop, "source",
 							buf);
@@ -618,7 +618,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 						    &in6addr_any)) {
 					if (inet_ntop(AF_INET6,
 						      &nexthop->src.ipv6, buf,
-						      sizeof buf))
+						      sizeof(buf)))
 						json_object_string_add(
 							json_nexthop, "source",
 							buf);
@@ -667,7 +667,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 					? '>'
 					: ' ',
 				re_status_output_char(re, nexthop),
-				srcdest_rnode2str(rn, buf, sizeof buf));
+				srcdest_rnode2str(rn, buf, sizeof(buf)));
 
 			/* Distance and metric display. */
 			if (((re->type == ZEBRA_ROUTE_CONNECT) &&
@@ -694,7 +694,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
 			vty_out(vty, " via %s",
 				inet_ntop(AF_INET6, &nexthop->gate.ipv6, buf,
-					  sizeof buf));
+					  sizeof(buf)));
 			if (nexthop->ifindex)
 				vty_out(vty, ", %s",
 					ifindex2ifname(nexthop->ifindex,
@@ -750,7 +750,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		case NEXTHOP_TYPE_IPV4_IFINDEX:
 			if (nexthop->src.ipv4.s_addr) {
 				if (inet_ntop(AF_INET, &nexthop->src.ipv4, buf,
-					      sizeof buf))
+					      sizeof(buf)))
 					vty_out(vty, ", src %s", buf);
 			}
 			break;
@@ -758,7 +758,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
 			if (!IPV6_ADDR_SAME(&nexthop->src.ipv6, &in6addr_any)) {
 				if (inet_ntop(AF_INET6, &nexthop->src.ipv6, buf,
-					      sizeof buf))
+					      sizeof(buf)))
 					vty_out(vty, ", src %s", buf);
 			}
 			break;
@@ -771,7 +771,7 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 			vty_out(vty, ", label %s",
 				mpls_label2str(nexthop->nh_label->num_labels,
 					       nexthop->nh_label->label, buf,
-					       sizeof buf, 1));
+					       sizeof(buf), 1));
 		}
 
 		if (uptime < ONE_DAY_SECOND)


### PR DESCRIPTION
Satisfy checkpatch.pl requirements (check for sizeof without parenthesis)

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>