### PR TITLE
zebra: Only redistribute default routes of the right afi

### DIFF
--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -75,6 +75,10 @@ static void zebra_redistribute_default(struct zserv *client, vrf_id_t vrf_id)
 	struct route_entry *newre;
 
 	for (afi = AFI_IP; afi <= AFI_IP6; afi++) {
+
+		if (!vrf_bitmap_check(client->redist_default[afi], vrf_id))
+			continue;
+
 		/* Lookup table.  */
 		table = zebra_vrf_table(afi, SAFI_UNICAST, vrf_id);
 		if (!table)


### PR DESCRIPTION
Upper level clients ask for default routes of a particular family
This change ensures that they only receive the family that they
have asked for.

Discovered when testing in ospf `default-information originate`

=================================================================
==246306==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffffffa2e8 at pc 0x7ffff73c44e2 bp 0x7fffffffa090 sp 0x7fffffffa088
READ of size 16 at 0x7fffffffa2e8 thread T0
    #0 0x7ffff73c44e1 in prefix_copy lib/prefix.c:310
    #1 0x7ffff741c0aa in route_node_lookup lib/table.c:255
    #2 0x5555556cd263 in ospf_external_info_delete ospfd/ospf_asbr.c:178
    #3 0x5555556a47cc in ospf_zebra_read_route ospfd/ospf_zebra.c:852
    #4 0x7ffff746f5d8 in zclient_read lib/zclient.c:3028
    #5 0x7ffff742fc91 in thread_call lib/thread.c:1549
    #6 0x7ffff7374642 in frr_run lib/libfrr.c:1093
    #7 0x5555555bfaef in main ospfd/ospf_main.c:235
    #8 0x7ffff70a2bba in __libc_start_main ../csu/libc-start.c:308
    #9 0x5555555bf499 in _start (/usr/lib/frr/ospfd+0x6b499)

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>