### PR TITLE
pimd: Don't refresh mroute_creation for kernel-installed mroute

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -1015,8 +1015,10 @@ static int pim_mroute_add(struct channel_oil *c_oil, const char *name)
 			   pim_channel_oil_dump(c_oil, buf, sizeof(buf)));
 	}
 
-	c_oil->installed = 1;
-	c_oil->mroute_creation = pim_time_monotonic_sec();
+	if (!c_oil->installed) {
+		c_oil->installed = 1;
+		c_oil->mroute_creation = pim_time_monotonic_sec();
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Issue: When any interface is getting added/deleted in the outgoing
interface list, it calls pim_mroute_add() which is updating the
mroute_creation time without checking if the mroute is already
installed in the kernel.

Fix: Check if mroute is already installed, then dont refresh the
mroute_creation timer.

Signed-off-by: Sarita Patra <saritap@vmware.com>