### PR TITLE
pimd: remove the pim enabled check on a receiver interface

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8153,8 +8153,6 @@ static int pim_cmd_interface_delete(struct interface *ifp)
 
 	PIM_IF_DONT_PIM(pim_ifp->options);
 
-	pim_if_membership_clear(ifp);
-
 	/*
 	  pim_sock_delete() removes all neighbors from
 	  pim_ifp->pim_neighbor_list.

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -8001,6 +8001,7 @@ static int pim_cmd_interface_add(struct interface *ifp)
 		PIM_IF_DO_PIM(pim_ifp->options);
 
 	pim_if_addr_add_all(ifp);
+	pim_upstream_nh_if_update(pim_ifp->pim, ifp);
 	pim_if_membership_refresh(ifp);
 
 	pim_if_create_pimreg(pim_ifp->pim);
@@ -8161,6 +8162,7 @@ static int pim_cmd_interface_delete(struct interface *ifp)
 
 	if (!PIM_IF_TEST_IGMP(pim_ifp->options)) {
 		pim_if_addr_del_all(ifp);
+		pim_upstream_nh_if_update(pim_ifp->pim, ifp);
 		pim_if_delete(ifp);
 	}
 

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1655,11 +1655,11 @@ int pim_ifp_down(struct interface *ifp)
 			if_is_operative(ifp));
 	}
 
-        if (!ifp->info) {
+	if (!ifp->info) {
 		if (PIM_DEBUG_ZEBRA)
-                zlog_debug("%s: %s is not pim enabled", __PRETTY_FUNCTION__,
-			   ifp->name);
-                return 0;
+			zlog_debug("%s: %s is not pim enabled",
+				   __PRETTY_FUNCTION__, ifp->name);
+		return 0;
 	}
 
 	if (!if_is_operative(ifp)) {

--- a/pimd/pim_iface.c
+++ b/pimd/pim_iface.c
@@ -1655,7 +1655,15 @@ int pim_ifp_down(struct interface *ifp)
 			if_is_operative(ifp));
 	}
 
+        if (!ifp->info) {
+		if (PIM_DEBUG_ZEBRA)
+                zlog_debug("%s: %s is not pim enabled", __PRETTY_FUNCTION__,
+			   ifp->name);
+                return 0;
+	}
+
 	if (!if_is_operative(ifp)) {
+		pim_ifchannel_membership_clear(ifp);
 		pim_ifchannel_delete_all(ifp);
 		/*
 		  pim_if_addr_del_all() suffices for shutting down IGMP,
@@ -1668,13 +1676,10 @@ int pim_ifp_down(struct interface *ifp)
 		  threads,
 		  and kills all neighbors.
 		*/
-		if (ifp->info) {
-			pim_sock_delete(ifp, "link down");
-		}
+		pim_sock_delete(ifp, "link down");
 	}
 
-	if (ifp->info)
-		pim_if_del_vif(ifp);
+	pim_if_del_vif(ifp);
 
 	return 0;
 }

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1175,8 +1175,6 @@ void pim_ifchannel_local_membership_del(struct interface *ifp,
 	pim_ifp = ifp->info;
 	if (!pim_ifp)
 		return;
-	if (!PIM_IF_TEST_PIM(pim_ifp->options))
-		return;
 
 	orig = ch = pim_ifchannel_find(ifp, sg);
 	if (!ch)

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -1094,14 +1094,6 @@ int pim_ifchannel_local_membership_add(struct interface *ifp,
 		return 0;
 	}
 
-	if (!PIM_IF_TEST_PIM(pim_ifp->options)) {
-		if (PIM_DEBUG_EVENTS)
-			zlog_debug(
-				"%s:%s PIM is not configured on this interface %s",
-				__func__, pim_str_sg_dump(sg), ifp->name);
-		return 0;
-	}
-
 	pim = pim_ifp->pim;
 
 	/* skip (*,G) ch creation if G is of type SSM */

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -482,6 +482,41 @@ static int pim_update_upstream_nh(struct pim_instance *pim,
 	return 0;
 }
 
+static int pim_upstream_nh_if_update_helper(struct hash_backet *backet, void *arg)
+{
+	struct pim_nexthop_cache *pnc = (struct pim_nexthop_cache *)
+					 backet->data;
+	struct pnc_hash_walk_data *pwd = (struct pnc_hash_walk_data *)arg;
+	struct pim_instance *pim = pwd->pim;
+	struct interface *ifp = pwd->ifp;
+	struct nexthop *nh_node = NULL;
+	ifindex_t first_ifindex;
+
+	for (nh_node = pnc->nexthop; nh_node; nh_node = nh_node->next) {
+		first_ifindex = nh_node->ifindex;
+		if (ifp != if_lookup_by_index(first_ifindex, pim->vrf_id))
+			return HASHWALK_CONTINUE;
+
+		if (pnc->upstream_hash->count)
+			pim_update_upstream_nh(pim, pnc);
+	}
+	return HASHWALK_CONTINUE;
+}
+
+int pim_upstream_nh_if_update(struct pim_instance *pim,
+			struct interface *ifp)
+{
+	struct pnc_hash_walk_data pwd;
+
+	pwd.pim = pim;
+	pwd.ifp = ifp;
+
+	hash_walk(pim->rpf_hash, pim_upstream_nh_if_update_helper, &pwd);
+
+	return 0;
+}
+
+
 uint32_t pim_compute_ecmp_hash(struct prefix *src, struct prefix *grp)
 {
 	uint32_t hash_val;
@@ -527,7 +562,8 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 	memset(&ifps, 0, sizeof(ifps));
 
 	// Current Nexthop is VALID, check to stay on the current path.
-	if (nexthop->interface && nexthop->interface->info
+	if (nexthop->interface && nexthop->interface->info &&
+	    ((struct pim_interface *)nexthop->interface->info)->options
 	    && nexthop->mrib_nexthop_addr.u.prefix4.s_addr
 		       != PIM_NET_INADDR_ANY) {
 		/* User configured knob to explicitly switch
@@ -653,6 +689,25 @@ static int pim_ecmp_nexthop_search(struct pim_instance *pim,
 			}
 			if (nh_iter == mod_val)
 				mod_val++; // Select nexthpath
+			nh_iter++;
+			continue;
+		}
+
+		if (!PIM_IF_TEST_PIM(((struct pim_interface *)ifp->info)->options)) {
+			if (PIM_DEBUG_PIM_NHT) {
+				char addr_str[INET_ADDRSTRLEN];
+
+				pim_inet4_dump("<addr?>", src->u.prefix4,
+						addr_str, sizeof(addr_str));
+				zlog_debug(
+					"%s: pim not enabled on input interface %s(%s) (ifindex=%d, RPF for source %s)",
+					__PRETTY_FUNCTION__, ifp->name,
+					pim->vrf->name, first_ifindex,
+					addr_str);
+			}
+			// Select nexthpath
+			if (nh_iter == mod_val)
+				mod_val++;
 			nh_iter++;
 			continue;
 		}
@@ -1012,6 +1067,20 @@ int pim_ecmp_nexthop_lookup(struct pim_instance *pim,
 			i++;
 			continue;
 		}
+
+		if (!PIM_IF_TEST_PIM(((struct pim_interface *)ifp->info)->options)) {
+			if (PIM_DEBUG_PIM_NHT)
+				zlog_debug(
+                                        "%s: pim not enabled on input interface %s(%s) (ifindex=%d, RPF for source %s)",
+                                        __PRETTY_FUNCTION__, ifp->name,
+                                        pim->vrf->name, first_ifindex,
+                                        addr_str);
+                        if (i == mod_val)
+                                mod_val++;
+                        i++;
+                        continue;
+                }
+
 		if (neighbor_needed
 		    && !pim_if_connected_to_source(ifp, src->u.prefix4)) {
 			nbr = nbrs[i];

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -53,6 +53,11 @@ struct pim_nexthop_cache {
 	bool bsr_tracking;
 };
 
+struct pnc_hash_walk_data {
+	struct pim_instance *pim;
+	struct interface *ifp;
+};
+
 int pim_parse_nexthop_update(ZAPI_CALLBACK_ARGS);
 int pim_find_or_track_nexthop(struct pim_instance *pim, struct prefix *addr,
 			      struct pim_upstream *up, struct rp_info *rp,
@@ -76,5 +81,6 @@ bool pim_nexthop_match(struct pim_instance *pim, struct in_addr addr,
 		       struct in_addr ip_src);
 bool pim_nexthop_match_nht_cache(struct pim_instance *pim, struct in_addr addr,
 				 struct in_addr ip_src);
-
+int pim_upstream_nh_if_update(struct pim_instance *pim,
+			struct interface *ifp);
 #endif

--- a/pimd/pim_nht.h
+++ b/pimd/pim_nht.h
@@ -81,6 +81,5 @@ bool pim_nexthop_match(struct pim_instance *pim, struct in_addr addr,
 		       struct in_addr ip_src);
 bool pim_nexthop_match_nht_cache(struct pim_instance *pim, struct in_addr addr,
 				 struct in_addr ip_src);
-int pim_upstream_nh_if_update(struct pim_instance *pim,
-			struct interface *ifp);
+int pim_upstream_nh_if_update(struct pim_instance *pim, struct interface *ifp);
 #endif

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -139,6 +139,19 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 					addr_str);
 			}
 			i++;
+
+		} else if (!PIM_IF_TEST_PIM(((struct pim_interface *)ifp->info)->options)) {
+			if (PIM_DEBUG_ZEBRA) {
+				char addr_str[INET_ADDRSTRLEN];
+				pim_inet4_dump("<addr?>", addr, addr_str,
+					sizeof(addr_str));
+				zlog_debug(
+					"%s: pim not enabled on input interface %s (ifindex=%d, RPF for source %s)",
+					__PRETTY_FUNCTION__, ifp->name,
+					first_ifindex, addr_str);
+			}
+			i++;
+
 		} else if (neighbor_needed
 			   && !pim_if_connected_to_source(ifp, addr)) {
 			nbr = pim_neighbor_find(

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -158,6 +158,7 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 		if (PIM_DEBUG_ZEBRA) {
 			char nexthop_str[PREFIX_STRLEN];
 			char addr_str[INET_ADDRSTRLEN];
+
 			pim_addr_dump("<nexthop?>",
 				      &nexthop_tab[i].nexthop_addr, nexthop_str,
 				      sizeof(nexthop_str));

--- a/pimd/pim_rpf.c
+++ b/pimd/pim_rpf.c
@@ -140,11 +140,12 @@ bool pim_nexthop_lookup(struct pim_instance *pim, struct pim_nexthop *nexthop,
 			}
 			i++;
 
-		} else if (!PIM_IF_TEST_PIM(((struct pim_interface *)ifp->info)->options)) {
+		} else if (!PIM_IF_TEST_PIM(((struct pim_interface *)ifp->info)
+						    ->options)) {
 			if (PIM_DEBUG_ZEBRA) {
 				char addr_str[INET_ADDRSTRLEN];
 				pim_inet4_dump("<addr?>", addr, addr_str,
-					sizeof(addr_str));
+					       sizeof(addr_str));
 				zlog_debug(
 					"%s: pim not enabled on input interface %s (ifindex=%d, RPF for source %s)",
 					__PRETTY_FUNCTION__, ifp->name,


### PR DESCRIPTION
Issue: Client----R1-----R2
R1: the interface connected to client is only igmp enabled, but
not pim enabled, frr creates (*,G) mroute with iif towards RP and
OIL none and install this mroute into kernel. (*,G) upstream wont
be present.

Root Casue: In the function pim_ifchannel_local_membership_add(),
it checkes for the outgoing interface should be pim enabled, if not,
it deletes the interface from the oil and wont create any upstream.

Fix: Allow the interface to be added in the oil list, if it is igmp
enabled.

Signed-off-by: Sarita Patra <saritap@vmware.com>

pimd: remove the pim enabled check on prune received interface

Issue: Client----R1-----R2(RP)
LHR dont process the IGMP prune packet, if PIM is not enabled on the
receiver connected interface.

Root cause: When R1 receives IGMP prune, there is check in the function
pim_ifchannel_local_membership_del(), that the receiver interface connected
to the client should be PIM enabled. This is the reason R1 wont process
the IGMP prune packet.

Fix: Remove the PIM enabled check.

Signed-off-by: Sarita Patra <saritap@vmware.com>

pimd: clear (*,g) ifchannel local_ifmembership

Issue:
Setup:-
LHR(RP)-----------FHR
Start join , then start traffic
When shut the receiver connected interface in LHR. LHR not
sending (s,g) prune to FHR. So FHR still sends multicast
traffic to LHR even there is no receiver present to LHR.
(s,g) upstream in LHR is also in joined state and send
continuous (s,g) join to FHR

Root Cause:
When shut the receiver connected interface in LHR, zebra
sends notification to PIMD i.e. pim_ifp_down().
It delete all the ifchannels associated with this interface.
In this case it will delete the (*,G) ifchannel associated with
this interface which was created because of IGMP Join.
(*,G) ifchannel_delete remove this interface from the child (s,g)
oil list, but not able to update the (s,g) join desired to false,
since local_receiver_include for parent (*,G) is still true.

Fix:
pim_ifp_down() should clear the (*,G) ifchannel->local_ifmembership
i.e set to NOINFO, before deleting the (*,G) ifchannel.

Signed-off-by: Sarita Patra <saritap@vmware.com>

pimd: rpf update when pim disabled/enabled

Fix: pim upstream rpf update taken care when pim is enabled
or disabled on an interface.

Signed-off-by: Sarita Patra <saritap@vmware.com>