### PR TITLE
Vrf stoppage

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -290,7 +290,7 @@ static inline int proto2zebra(int proto, int family, bool is_nexthop)
 /*
 Pending: create an efficient table_id (in a tree/hash) based lookup)
  */
-static vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
+vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 {
 	struct vrf *vrf;
 	struct zebra_vrf *zvrf;

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -92,6 +92,7 @@ extern int netlink_macfdb_read_specific_mac(struct zebra_ns *zns,
 					    struct ethaddr *mac, uint16_t vid);
 extern int netlink_neigh_read_specific_ip(struct ipaddr *ip,
 					  struct interface *vlan_if);
+extern vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id);
 
 #ifdef __cplusplus
 }

--- a/zebra/zebra_errors.c
+++ b/zebra/zebra_errors.c
@@ -786,6 +786,12 @@ static struct log_ref ferr_zebra_err[] = {
 			"See if the nexthop you are trying to add is already present in the fib."
 	},
 	{
+		.code = EC_ZEBRA_VRF_MISCONFIGURED,
+		.title = "Duplicate VRF table id detected",
+		.description = "Zebra has detected a situation where there are two vrf devices with the exact same tableid.  This is considered a complete misconfiguration of VRF devices and breaks a fundamental assumption in FRR about how VRF's work",
+		.suggestion = "Use different table id's for the VRF's in question"
+	},
+	{
 		.code = END_FERR,
 	}
 };

--- a/zebra/zebra_errors.h
+++ b/zebra/zebra_errors.h
@@ -132,6 +132,7 @@ enum zebra_log_refs {
 	EC_ZEBRA_DUP_IP_DETECTED,
 	EC_ZEBRA_BAD_NHG_MESSAGE,
 	EC_ZEBRA_DUPLICATE_NHG_MESSAGE,
+	EC_ZEBRA_VRF_MISCONFIGURED,
 };
 
 void zebra_error_init(void);


### PR DESCRIPTION
Currently the linux kernel allows you to specify the same
table id -> multiple vrf's.  While I am arguing with
the kernel people about proper behavior here let's
just remove this as a possiblity from happening and
mark it a zebra stopable missconfiguration.
    
(Effectively we are preventing a crash down the line
as that all over FRR we assume it's a unique
mapping not a many to one).
    
Why fail hard?  Because we hope to get the person
who missconfigured it to actually notice immediately
not hours or days down the line when shit hits the fan.
