### PR TITLE
bgpd: support for match ip address next-hop address command

### DIFF
--- a/doc/user/routemap.rst
+++ b/doc/user/routemap.rst
@@ -151,10 +151,15 @@ Route Map Match Command
 
    Matches the specified `prefix-len`. This is a Zebra specific command.
 
-.. index:: match ip next-hop IPV4_ADDR
-.. clicmd:: match ip next-hop IPV4_ADDR
+.. index:: match ip next-hop address IPV4_ADDR
+.. clicmd:: match ip next-hop address IPV4_ADDR
 
-   Matches the specified `ipv4_addr`.
+   This is a BGP specific match command. Matches the specified `ipv4_addr`.
+
+.. index:: match ipv6 next-hop IPV6_ADDR
+.. clicmd:: match ipv6 next-hop IPV6_ADDR
+
+   This is a BGP specific match command. Matches the specified `ipv6_addr`.
 
 .. index:: match as-path AS_PATH
 .. clicmd:: match as-path AS_PATH


### PR DESCRIPTION
this command is missing, compared with 'match ipv6 next-hop' command
available. Adding it by taking into account the backward compatible
effect when supposing that some people have configured acls with name
being an ipv4 address.
the command is:
match ip next-hop address <A.B.C.D>

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>