### PR TITLE
Fix a warning while building manpages

### DIFF
--- a/doc/manpages/conf.py
+++ b/doc/manpages/conf.py
@@ -192,7 +192,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
$ make doc
  SPHINX   doc/manpages/_build/.doctrees/environment.pickle
WARNING: html_static_path entry '_static' does not exist

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>