### PR TITLE
build: fix building with -Werror=undef

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -47,7 +47,7 @@
 #include "bgpd/bgp_lcommunity.h"
 #include "bgpd/bgp_updgrp.h"
 #include "bgpd/bgp_encap_types.h"
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 #include "bgpd/rfapi/bgp_rfapi_cfg.h"
 #include "bgp_encap_types.h"
 #include "bgp_vnc_types.h"
@@ -79,7 +79,7 @@ static const struct message attr_str[] = {
 	{BGP_ATTR_AS_PATHLIMIT, "AS_PATHLIMIT"},
 	{BGP_ATTR_PMSI_TUNNEL, "PMSI_TUNNEL_ATTRIBUTE"},
 	{BGP_ATTR_ENCAP, "ENCAP"},
-#if ENABLE_BGP_VNC_ATTR
+#ifdef ENABLE_BGP_VNC_ATTR
 	{BGP_ATTR_VNC, "VNC"},
 #endif
 	{BGP_ATTR_LARGE_COMMUNITIES, "LARGE_COMMUNITY"},
@@ -199,7 +199,7 @@ static void cluster_finish(void)
 }
 
 static struct hash *encap_hash = NULL;
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 static struct hash *vnc_hash = NULL;
 #endif
 static struct hash *srv6_l3vpn_hash;
@@ -247,7 +247,7 @@ void bgp_attr_flush_encap(struct attr *attr)
 		encap_free(attr->encap_subtlvs);
 		attr->encap_subtlvs = NULL;
 	}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (attr->vnc_subtlvs) {
 		encap_free(attr->vnc_subtlvs);
 		attr->vnc_subtlvs = NULL;
@@ -309,7 +309,7 @@ static void *encap_hash_alloc(void *p)
 
 typedef enum {
 	ENCAP_SUBTLV_TYPE,
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	VNC_SUBTLV_TYPE
 #endif
 } encap_subtlv_type;
@@ -319,7 +319,7 @@ encap_intern(struct bgp_attr_encap_subtlv *encap, encap_subtlv_type type)
 {
 	struct bgp_attr_encap_subtlv *find;
 	struct hash *hash = encap_hash;
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (type == VNC_SUBTLV_TYPE)
 		hash = vnc_hash;
 #endif
@@ -341,7 +341,7 @@ static void encap_unintern(struct bgp_attr_encap_subtlv **encapp,
 
 	if (encap->refcnt == 0) {
 		struct hash *hash = encap_hash;
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		if (type == VNC_SUBTLV_TYPE)
 			hash = vnc_hash;
 #endif
@@ -368,7 +368,7 @@ static void encap_init(void)
 {
 	encap_hash = hash_create(encap_hash_key_make, encap_hash_cmp,
 				 "BGP Encap Hash");
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	vnc_hash = hash_create(encap_hash_key_make, encap_hash_cmp,
 			       "BGP VNC Hash");
 #endif
@@ -379,7 +379,7 @@ static void encap_finish(void)
 	hash_clean(encap_hash, (void (*)(void *))encap_free);
 	hash_free(encap_hash);
 	encap_hash = NULL;
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	hash_clean(vnc_hash, (void (*)(void *))encap_free);
 	hash_free(vnc_hash);
 	vnc_hash = NULL;
@@ -660,7 +660,7 @@ unsigned int attrhash_key_make(const void *p)
 		MIX(transit_hash_key_make(attr->transit));
 	if (attr->encap_subtlvs)
 		MIX(encap_hash_key_make(attr->encap_subtlvs));
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (attr->vnc_subtlvs)
 		MIX(encap_hash_key_make(attr->vnc_subtlvs));
 #endif
@@ -698,7 +698,7 @@ bool attrhash_cmp(const void *p1, const void *p2)
 		    && attr1->rmap_table_id == attr2->rmap_table_id
 		    && (attr1->encap_tunneltype == attr2->encap_tunneltype)
 		    && encap_same(attr1->encap_subtlvs, attr2->encap_subtlvs)
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		    && encap_same(attr1->vnc_subtlvs, attr2->vnc_subtlvs)
 #endif
 		    && IPV6_ADDR_SAME(&attr1->mp_nexthop_global,
@@ -780,7 +780,7 @@ static void *bgp_attr_hash_alloc(void *p)
 	if (val->encap_subtlvs) {
 		val->encap_subtlvs = NULL;
 	}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (val->vnc_subtlvs) {
 		val->vnc_subtlvs = NULL;
 	}
@@ -856,7 +856,7 @@ struct attr *bgp_attr_intern(struct attr *attr)
 		else
 			attr->srv6_vpn->refcnt++;
 	}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (attr->vnc_subtlvs) {
 		if (!attr->vnc_subtlvs->refcnt)
 			attr->vnc_subtlvs = encap_intern(attr->vnc_subtlvs,
@@ -1041,7 +1041,7 @@ void bgp_attr_unintern_sub(struct attr *attr)
 	if (attr->encap_subtlvs)
 		encap_unintern(&attr->encap_subtlvs, ENCAP_SUBTLV_TYPE);
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (attr->vnc_subtlvs)
 		encap_unintern(&attr->vnc_subtlvs, VNC_SUBTLV_TYPE);
 #endif
@@ -1125,7 +1125,7 @@ void bgp_attr_flush(struct attr *attr)
 		encap_free(attr->encap_subtlvs);
 		attr->encap_subtlvs = NULL;
 	}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (attr->vnc_subtlvs && !attr->vnc_subtlvs->refcnt) {
 		encap_free(attr->vnc_subtlvs);
 		attr->vnc_subtlvs = NULL;
@@ -2265,7 +2265,7 @@ static int bgp_attr_encap(uint8_t type, struct peer *peer, /* IN */
 			subtype = stream_getc(BGP_INPUT(peer));
 			sublength = stream_getc(BGP_INPUT(peer));
 			length -= 2;
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		} else {
 			subtype = stream_getw(BGP_INPUT(peer));
 			sublength = stream_getw(BGP_INPUT(peer));
@@ -2304,7 +2304,7 @@ static int bgp_attr_encap(uint8_t type, struct peer *peer, /* IN */
 			} else {
 				attr->encap_subtlvs = tlv;
 			}
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		} else {
 			struct bgp_attr_encap_subtlv *stlv_last;
 			for (stlv_last = attr->vnc_subtlvs;
@@ -3019,7 +3019,7 @@ bgp_attr_parse_ret_t bgp_attr_parse(struct peer *peer, struct attr *attr,
 		case BGP_ATTR_EXT_COMMUNITIES:
 			ret = bgp_attr_ext_communities(&attr_args);
 			break;
-#if ENABLE_BGP_VNC_ATTR
+#ifdef ENABLE_BGP_VNC_ATTR
 		case BGP_ATTR_VNC:
 #endif
 		case BGP_ATTR_ENCAP:
@@ -3171,7 +3171,7 @@ done:
 		if (attr->encap_subtlvs)
 			attr->encap_subtlvs = encap_intern(attr->encap_subtlvs,
 							   ENCAP_SUBTLV_TYPE);
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		if (attr->vnc_subtlvs)
 			attr->vnc_subtlvs = encap_intern(attr->vnc_subtlvs,
 							 VNC_SUBTLV_TYPE);
@@ -3190,7 +3190,7 @@ done:
 		assert(attr->transit->refcnt > 0);
 	if (attr->encap_subtlvs)
 		assert(attr->encap_subtlvs->refcnt > 0);
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	if (attr->vnc_subtlvs)
 		assert(attr->vnc_subtlvs->refcnt > 0);
 #endif
@@ -3440,7 +3440,7 @@ static void bgp_packet_mpattr_tea(struct bgp *bgp, struct peer *peer,
 		attrhdrlen = 1 + 1;   /* subTLV T + L */
 		break;
 
-#if ENABLE_BGP_VNC_ATTR
+#ifdef ENABLE_BGP_VNC_ATTR
 	case BGP_ATTR_VNC:
 		attrname = "VNC";
 		subtlvs = attr->vnc_subtlvs;
@@ -3491,7 +3491,7 @@ static void bgp_packet_mpattr_tea(struct bgp *bgp, struct peer *peer,
 		if (attrtype == BGP_ATTR_ENCAP) {
 			stream_putc(s, st->type);
 			stream_putc(s, st->length);
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 		} else {
 			stream_putw(s, st->type);
 			stream_putw(s, st->length);
@@ -3976,7 +3976,7 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 		/* Tunnel Encap attribute */
 		bgp_packet_mpattr_tea(bgp, peer, s, attr, BGP_ATTR_ENCAP);
 
-#if ENABLE_BGP_VNC_ATTR
+#ifdef ENABLE_BGP_VNC_ATTR
 		/* VNC attribute */
 		bgp_packet_mpattr_tea(bgp, peer, s, attr, BGP_ATTR_VNC);
 #endif

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -555,7 +555,7 @@ struct bgp {
 
 	struct bgp_addpath_bgp_data tx_addpath;
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 	struct rfapi_cfg *rfapi_cfg;
 	struct rfapi *rfapi;
 #endif
@@ -1482,7 +1482,7 @@ struct bgp_nlri {
 #define BGP_ATTR_ENCAP                          23
 #define BGP_ATTR_LARGE_COMMUNITIES              32
 #define BGP_ATTR_PREFIX_SID                     40
-#if ENABLE_BGP_VNC_ATTR
+#ifdef ENABLE_BGP_VNC_ATTR
 #define BGP_ATTR_VNC                           255
 #endif
 

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -47,7 +47,7 @@
 #include "bgpd/rfapi/vnc_import_bgp.h"
 #include "bgpd/rfapi/vnc_debug.h"
 
-#if ENABLE_BGP_VNC
+#ifdef ENABLE_BGP_VNC
 
 #undef BGP_VNC_DEBUG_MATCH_GROUP
 
@@ -168,7 +168,7 @@ struct rfapi_nve_group_cfg *bgp_rfapi_cfg_match_group(struct rfapi_cfg *hc,
 		agg_unlock_node(rn_un);
 	}
 
-#if BGP_VNC_DEBUG_MATCH_GROUP
+#ifdef BGP_VNC_DEBUG_MATCH_GROUP
 	{
 		char buf[PREFIX_STRLEN];
 

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -2150,7 +2150,7 @@ int rfapi_close(void *handle)
 
 	vnc_zlog_debug_verbose("%s: rfd=%p", __func__, rfd);
 
-#if RFAPI_WHO_IS_CALLING_ME
+#ifdef RFAPI_WHO_IS_CALLING_ME
 #ifdef HAVE_GLIBC_BACKTRACE
 #define RFAPI_DEBUG_BACKTRACE_NENTRIES 5
 	{

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -200,7 +200,7 @@ void rfapiCheckRouteCount(void)
 	}
 }
 
-#if DEBUG_ROUTE_COUNTERS
+#ifdef DEBUG_ROUTE_COUNTERS
 #define VNC_ITRCCK do {rfapiCheckRouteCount();} while (0)
 #else
 #define VNC_ITRCCK
@@ -458,7 +458,7 @@ int rfapiGetUnAddrOfVpnBi(struct bgp_path_info *bpi, struct prefix *p)
 		default:
 			if (p)
 				p->family = 0;
-#if DEBUG_ENCAP_MONITOR
+#ifdef DEBUG_ENCAP_MONITOR
 			vnc_zlog_debug_verbose(
 				"%s: bpi->extra->vnc.import.un_family is 0, no UN addr",
 				__func__);
@@ -609,7 +609,7 @@ rfapiMonitorMoveShorter(struct agg_node *original_vpn_node, int lockoffset)
 
 	RFAPI_CHECK_REFCOUNT(original_vpn_node, SAFI_MPLS_VPN, lockoffset);
 
-#if DEBUG_MONITOR_MOVE_SHORTER
+#ifdef DEBUG_MONITOR_MOVE_SHORTER
 	{
 		char buf[PREFIX_STRLEN];
 
@@ -628,7 +628,7 @@ rfapiMonitorMoveShorter(struct agg_node *original_vpn_node, int lockoffset)
 		struct prefix pfx;
 
 		if (!rfapiGetUnAddrOfVpnBi(bpi, &pfx)) {
-#if DEBUG_MONITOR_MOVE_SHORTER
+#ifdef DEBUG_MONITOR_MOVE_SHORTER
 			vnc_zlog_debug_verbose(
 				"%s: have valid UN at original node, no change",
 				__func__);
@@ -744,7 +744,7 @@ rfapiMonitorMoveShorter(struct agg_node *original_vpn_node, int lockoffset)
 		agg_unlock_node(original_vpn_node);
 	}
 
-#if DEBUG_MONITOR_MOVE_SHORTER
+#ifdef DEBUG_MONITOR_MOVE_SHORTER
 	{
 		char buf[PREFIX_STRLEN];
 
@@ -953,7 +953,7 @@ void rfapiImportTableRefDelByIt(struct bgp *bgp,
 	}
 }
 
-#if RFAPI_REQUIRE_ENCAP_BEEC
+#ifdef RFAPI_REQUIRE_ENCAP_BEEC
 /*
  * Look for magic BGP Encapsulation Extended Community value
  * Format in RFC 5512 Sect. 4.5
@@ -1267,7 +1267,7 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 	struct rfapi_next_hop_entry *new;
 	int have_vnc_tunnel_un = 0;
 
-#if DEBUG_ENCAP_MONITOR
+#ifdef DEBUG_ENCAP_MONITOR
 	vnc_zlog_debug_verbose("%s: entry, bpi %p, rn %p", __func__, bpi, rn);
 #endif
 
@@ -1401,7 +1401,7 @@ rfapiRouteInfo2NextHopEntry(struct rfapi_ip_prefix *rprefix,
 
 	new->un_options = rfapi_encap_tlv_to_un_option(bpi->attr);
 
-#if DEBUG_ENCAP_MONITOR
+#ifdef DEBUG_ENCAP_MONITOR
 	vnc_zlog_debug_verbose("%s: line %d: have_vnc_tunnel_un=%d", __func__,
 			       __LINE__, have_vnc_tunnel_un);
 #endif
@@ -1448,7 +1448,7 @@ int rfapiHasNonRemovedRoutes(struct agg_node *rn)
 	return 0;
 }
 
-#if DEBUG_IT_NODES
+#ifdef DEBUG_IT_NODES
 /*
  * DEBUG FUNCTION
  */
@@ -1517,7 +1517,7 @@ static int rfapiNhlAddNodeRoutes(
 		struct prefix *newpfx;
 
 		if (removed && !CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED)) {
-#if DEBUG_RETURNED_NHL
+#ifdef DEBUG_RETURNED_NHL
 			vnc_zlog_debug_verbose(
 				"%s: want holddown, this route not holddown, skip",
 				__func__);
@@ -1549,7 +1549,7 @@ static int rfapiNhlAddNodeRoutes(
 			rfapiNexthop2Prefix(bpi->attr, &pfx_vn);
 		}
 		if (!skiplist_search(seen_nexthops, &pfx_vn, NULL)) {
-#if DEBUG_RETURNED_NHL
+#ifdef DEBUG_RETURNED_NHL
 			char buf[PREFIX_STRLEN];
 
 			prefix2str(&pfx_vn, buf, sizeof(buf));
@@ -1561,7 +1561,7 @@ static int rfapiNhlAddNodeRoutes(
 		}
 
 		if (rfapiGetUnAddrOfVpnBi(bpi, &pfx_un)) {
-#if DEBUG_ENCAP_MONITOR
+#ifdef DEBUG_ENCAP_MONITOR
 			vnc_zlog_debug_verbose(
 				"%s: failed to get UN address of this VPN bpi",
 				__func__);
@@ -1715,7 +1715,7 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 	int count = 0;
 	struct agg_node *rib_rn;
 
-#if DEBUG_RETURNED_NHL
+#ifdef DEBUG_RETURNED_NHL
 	{
 		char buf[PREFIX_STRLEN];
 
@@ -1746,7 +1746,7 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 					    pfx_target_original);
 		vnc_zlog_debug_verbose("%s: %d nexthops, answer=%p", __func__,
 				       count, answer);
-#if DEBUG_RETURNED_NHL
+#ifdef DEBUG_RETURNED_NHL
 		rfapiPrintNhl(NULL, answer);
 #endif
 		if (rib_rn)
@@ -1806,7 +1806,7 @@ struct rfapi_next_hop_entry *rfapiRouteNode2NextHopList(
 
 	vnc_zlog_debug_verbose("%s: %d nexthops, answer=%p", __func__, count,
 			       answer);
-#if DEBUG_RETURNED_NHL
+#ifdef DEBUG_RETURNED_NHL
 	rfapiPrintNhl(NULL, answer);
 #endif
 	return answer;
@@ -1868,7 +1868,7 @@ struct rfapi_next_hop_entry *rfapiEthRouteNode2NextHopList(
 	count = rfapiNhlAddNodeRoutes(rn, rprefix, lifetime, 0, &answer, &last,
 				      NULL, rib_rn, pfx_target_original);
 
-#if DEBUG_ENCAP_MONITOR
+#ifdef DEBUG_ENCAP_MONITOR
 	vnc_zlog_debug_verbose("%s: node %p: %d non-holddown routes", __func__,
 			       rn, count);
 #endif
@@ -1884,7 +1884,7 @@ struct rfapi_next_hop_entry *rfapiEthRouteNode2NextHopList(
 	if (rib_rn)
 		agg_unlock_node(rib_rn);
 
-#if DEBUG_RETURNED_NHL
+#ifdef DEBUG_RETURNED_NHL
 	rfapiPrintNhl(NULL, answer);
 #endif
 
@@ -2164,7 +2164,7 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 	if (!sl)
 		return NULL;
 
-#if DEBUG_BI_SEARCH
+#ifdef DEBUG_BI_SEARCH
 	{
 		char buf[RD_ADDRSTRLEN];
 		char buf_aux_pfx[PREFIX_STRLEN];
@@ -2185,13 +2185,13 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 
 	/* threshold is a WAG */
 	if (sl->count < 3) {
-#if DEBUG_BI_SEARCH
+#ifdef DEBUG_BI_SEARCH
 		vnc_zlog_debug_verbose("%s: short list algorithm", __func__);
 #endif
 		/* if short list, linear search might be faster */
 		for (bpi_result = rn->info; bpi_result;
 		     bpi_result = bpi_result->next) {
-#if DEBUG_BI_SEARCH
+#ifdef DEBUG_BI_SEARCH
 			{
 				char buf[RD_ADDRSTRLEN];
 
@@ -2208,7 +2208,7 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 						   ->vnc.import.rd,
 					   (struct prefix *)prd)) {
 
-#if DEBUG_BI_SEARCH
+#ifdef DEBUG_BI_SEARCH
 				vnc_zlog_debug_verbose(
 					"%s: peer and RD same, doing aux_prefix check",
 					__func__);
@@ -2219,7 +2219,7 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 					       &bpi_result->extra->vnc.import
 							.aux_prefix)) {
 
-#if DEBUG_BI_SEARCH
+#ifdef DEBUG_BI_SEARCH
 					vnc_zlog_debug_verbose("%s: match",
 							       __func__);
 #endif
@@ -2244,13 +2244,13 @@ static struct bgp_path_info *rfapiItBiIndexSearch(
 	rc = skiplist_search(sl, (void *)&bpi_fake, (void *)&bpi_result);
 
 	if (rc) {
-#if DEBUG_BI_SEARCH
+#ifdef DEBUG_BI_SEARCH
 		vnc_zlog_debug_verbose("%s: no match", __func__);
 #endif
 		return NULL;
 	}
 
-#if DEBUG_BI_SEARCH
+#ifdef DEBUG_BI_SEARCH
 	vnc_zlog_debug_verbose("%s: matched bpi=%p", __func__, bpi_result);
 #endif
 
@@ -2958,7 +2958,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 				__func__);
 			return;
 		}
-#if RFAPI_REQUIRE_ENCAP_BEEC
+#ifdef RFAPI_REQUIRE_ENCAP_BEEC
 		if (!rfapiEcommunitiesMatchBeec(attr->ecommunity)) {
 			vnc_zlog_debug_verbose(
 				"%s: it=%p: no match for BGP Encapsulation ecommunity",
@@ -3007,7 +3007,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 	 */
 	rn = agg_node_lookup(rt, p);
 
-#if DEBUG_ENCAP_MONITOR
+#ifdef DEBUG_ENCAP_MONITOR
 	vnc_zlog_debug_verbose("%s: initial encap lookup(it=%p) rn=%p",
 			       __func__, import_table, rn);
 #endif
@@ -3241,7 +3241,7 @@ static void rfapiBgpInfoFilteredImportEncap(
 /*
  * iterate over the set of monitors at this ENCAP node.
  */
-#if DEBUG_ENCAP_MONITOR
+#ifdef DEBUG_ENCAP_MONITOR
 		vnc_zlog_debug_verbose("%s: examining monitors at rn=%p",
 				       __func__, rn);
 #endif
@@ -3997,7 +3997,7 @@ void rfapiProcessWithdraw(struct peer *peer, void *rfd, struct prefix *p,
 		     rc == 0; rc = skiplist_next(h->import_mac, NULL,
 						 (void **)&it, &cursor)) {
 
-#if DEBUG_L2_EXTRA
+#ifdef DEBUG_L2_EXTRA
 			vnc_zlog_debug_verbose(
 				"%s: calling rfapiBgpInfoFilteredImportVPN(it=%p, afi=AFI_L2VPN)",
 				__func__, it);
@@ -4408,7 +4408,7 @@ static void rfapiDeleteRemotePrefixesIt(
 {
 	afi_t afi;
 
-#if DEBUG_L2_EXTRA
+#ifdef DEBUG_L2_EXTRA
 	{
 		char buf_pfx[PREFIX_STRLEN];
 
@@ -4487,7 +4487,7 @@ static void rfapiDeleteRemotePrefixesIt(
 				if (vn) {
 					if (!qpt_valid
 					    || !prefix_match(vn, &qpt)) {
-#if DEBUG_L2_EXTRA
+#ifdef DEBUG_L2_EXTRA
 						vnc_zlog_debug_verbose(
 							"%s: continue at vn && !qpt_valid || !prefix_match(vn, &qpt)",
 							__func__);
@@ -4502,7 +4502,7 @@ static void rfapiDeleteRemotePrefixesIt(
 				if (un) {
 					if (!qct_valid
 					    || !prefix_match(un, &qct)) {
-#if DEBUG_L2_EXTRA
+#ifdef DEBUG_L2_EXTRA
 						vnc_zlog_debug_verbose(
 							"%s: continue at un && !qct_valid || !prefix_match(un, &qct)",
 							__func__);

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -479,7 +479,7 @@ void rfapiRibClear(struct rfapi_descriptor *rfd)
 		bgp = rfd->bgp;
 	else
 		bgp = bgp_get_default();
-#if DEBUG_L2_EXTRA
+#ifdef DEBUG_L2_EXTRA
 	vnc_zlog_debug_verbose("%s: rfd=%p", __func__, rfd);
 #endif
 
@@ -1487,7 +1487,7 @@ static void rib_do_callback_onepass(struct rfapi_descriptor *rfd, afi_t afi)
 	struct rfapi_next_hop_entry *tail = NULL;
 	struct agg_node *rn;
 
-#if DEBUG_L2_EXTRA
+#ifdef DEBUG_L2_EXTRA
 	vnc_zlog_debug_verbose("%s: rfd=%p, afi=%d", __func__, rfd, afi);
 #endif
 
@@ -1812,7 +1812,7 @@ int rfapiRibFTDFilterRecentPrefix(
 	if (it_rn->p.family == AF_ETHERNET)
 		return 0;
 
-#if DEBUG_FTD_FILTER_RECENT
+#ifdef DEBUG_FTD_FILTER_RECENT
 	{
 		char buf_pfx[PREFIX_STRLEN];
 
@@ -1825,7 +1825,7 @@ int rfapiRibFTDFilterRecentPrefix(
 	 * prefix covers target address, so allow prefix
 	 */
 	if (prefix_match(&it_rn->p, pfx_target_original)) {
-#if DEBUG_FTD_FILTER_RECENT
+#ifdef DEBUG_FTD_FILTER_RECENT
 		vnc_zlog_debug_verbose("%s: prefix covers target, allowed",
 				       __func__);
 #endif
@@ -1840,7 +1840,7 @@ int rfapiRibFTDFilterRecentPrefix(
 	if (trn->lock > 1)
 		agg_unlock_node(trn);
 
-#if DEBUG_FTD_FILTER_RECENT
+#ifdef DEBUG_FTD_FILTER_RECENT
 	vnc_zlog_debug_verbose("%s: last sent time %lu, last allowed time %lu",
 			       __func__, prefix_time,
 			       rfd->ftd_last_allowed_time);
@@ -2311,7 +2311,7 @@ static int print_rib_sl(int (*fp)(void *, const char *, ...), struct vty *vty,
 			*p = 0;
 
 		rfapiFormatSeconds(ri->lifetime, str_lifetime, BUFSIZ);
-#if RFAPI_REGISTRATIONS_REPORT_AGE
+#ifdef RFAPI_REGISTRATIONS_REPORT_AGE
 		rfapiFormatAge(ri->last_sent_time, str_age, BUFSIZ);
 #else
 		{
@@ -2451,12 +2451,12 @@ void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 					   "   %-20s %-15s %-15s %4s %-8s %-8s\n",
 					   "Prefix", "Registered VN",
 					   "Registered UN", "Cost", "Lifetime",
-#if RFAPI_REGISTRATIONS_REPORT_AGE
+#ifdef RFAPI_REGISTRATIONS_REPORT_AGE
 					   "Age"
 #else
 					   "Remaining"
 #endif
-					   );
+					);
 				}
 				if (!printednve) {
 					char str_vn[BUFSIZ];

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1123,7 +1123,7 @@ static int rfapiPrintRemoteRegBi(struct bgp *bgp, void *stream,
 			(struct thread *)bpi->extra->vnc.import.timer;
 		remaining = thread_timer_remain_second(t);
 
-#if RFAPI_REGISTRATIONS_REPORT_AGE
+#ifdef RFAPI_REGISTRATIONS_REPORT_AGE
 		/*
 		 * Calculate when the timer started. Doing so here saves
 		 * us a timestamp field in "struct bgp_path_info".
@@ -1311,7 +1311,7 @@ static int rfapiShowRemoteRegistrationsIt(struct bgp *bgp, void *stream,
 					}
 					fp(out, "%s", HVTYNL);
 					if (show_expiring) {
-#if RFAPI_REGISTRATIONS_REPORT_AGE
+#ifdef RFAPI_REGISTRATIONS_REPORT_AGE
 						agetype = "Age";
 #else
 						agetype = "Remaining";

--- a/configure.ac
+++ b/configure.ac
@@ -1026,7 +1026,7 @@ AC_CHECK_HEADERS([net/if_var.h], [], [], [FRR_INCLUDES])
 
 m4_define([FRR_INCLUDES],
 FRR_INCLUDES
-[#if HAVE_NET_IF_VAR_H
+[#ifdef HAVE_NET_IF_VAR_H
 # include <net/if_var.h>
 #endif
 ])dnl
@@ -1061,22 +1061,22 @@ FRR_INCLUDES
 [
 #include <sys/un.h>
 #include <netinet/in_systm.h>
-#if HAVE_NETINET_IN_VAR_H
+#ifdef HAVE_NETINET_IN_VAR_H
 # include <netinet/in_var.h>
 #endif
-#if HAVE_NET_IF_DL_H
+#ifdef HAVE_NET_IF_DL_H
 # include <net/if_dl.h>
 #endif
-#if HAVE_NET_NETOPT_H
+#ifdef HAVE_NET_NETOPT_H
 # include <net/netopt.h>
 #endif
 #include <net/route.h>
-#if HAVE_INET_ND_H
+#ifdef HAVE_INET_ND_H
 # include <inet/nd.h>
 #endif
 #include <arpa/inet.h>
 /* Required for IDRP */
-#if HAVE_NETINET_IP_ICMP_H
+#ifdef HAVE_NETINET_IP_ICMP_H
 # include <netinet/ip_icmp.h>
 #endif
 ])dnl
@@ -1401,7 +1401,7 @@ AC_CHECK_HEADERS([linux/mroute.h], [], [],[
 
 m4_define([FRR_INCLUDES],
 FRR_INCLUDES
-[#if HAVE_LINUX_MROUTE_H
+[#ifdef HAVE_LINUX_MROUTE_H
 # include <linux/mroute.h>
 #endif
 ])dnl
@@ -1415,7 +1415,7 @@ AC_CHECK_HEADERS([netinet/ip_mroute.h], [], [],[
 
 m4_define([FRR_INCLUDES],
 FRR_INCLUDES
-[#if HAVE_NETINET_IP_MROUTE_H
+[#ifdef HAVE_NETINET_IP_MROUTE_H
 # include <netinet/ip_mroute.h>
 #endif
 ])dnl
@@ -1528,17 +1528,17 @@ AC_CHECK_HEADERS([netinet6/in6.h netinet/in6_var.h \
 
 m4_define([FRR_INCLUDES],dnl
 FRR_INCLUDES
-[#if HAVE_NETINET6_IN6_H
+[#ifdef HAVE_NETINET6_IN6_H
 #include <netinet6/in6.h>
 #endif
-#if HAVE_NETINET_IN6_VAR_H
+#ifdef HAVE_NETINET_IN6_VAR_H
 #include <netinet/in6_var.h>
 #endif
 #include <netinet/icmp6.h>
-#if HAVE_NETINET6_IN6_VAR_H
+#ifdef HAVE_NETINET6_IN6_VAR_H
 # include <netinet6/in6_var.h>
 #endif
-#if HAVE_NETINET6_ND6_H
+#ifdef HAVE_NETINET6_ND6_H
 # include <netinet6/nd6.h>
 #endif
 ])dnl

--- a/lib/getopt.h
+++ b/lib/getopt.h
@@ -111,7 +111,7 @@ struct option {
 
 #if defined(__STDC__) && __STDC__
 
-#if REALLY_NEED_PLAIN_GETOPT
+#ifdef REALLY_NEED_PLAIN_GETOPT
 
 /*
  * getopt is defined in POSIX.2.  Assume that if the system defines

--- a/lib/seqlock.c
+++ b/lib/seqlock.c
@@ -165,7 +165,7 @@ bool seqlock_timedwait(struct seqlock *sqlo, seqlock_val_t val,
 /*
  * ABS_REALTIME - used on NetBSD, Solaris and OSX
  */
-#if TIME_ABS_REALTIME
+#ifdef TIME_ABS_REALTIME
 #define time_arg1 &abs_rt
 #define time_arg2 NULL
 #define time_prep
@@ -187,7 +187,7 @@ bool seqlock_timedwait(struct seqlock *sqlo, seqlock_val_t val,
 /*
  * RELATIVE - used on OpenBSD (might get a patch to get absolute monotime)
  */
-#elif TIME_RELATIVE
+#elif defined(TIME_RELATIVE)
 	struct timespec reltime;
 
 #define time_arg1 abs_monotime_limit

--- a/lib/skiplist.c
+++ b/lib/skiplist.c
@@ -211,12 +211,12 @@ int skiplist_insert(register struct skiplist *l, register void *key,
 	q = newNodeOfLevel(k);
 	q->key = key;
 	q->value = value;
-#if SKIPLIST_0TIMER_DEBUG
+#ifdef SKIPLIST_0TIMER_DEBUG
 	q->flags = SKIPLIST_NODE_FLAG_INSERTED; /* debug */
 #endif
 
 	++(l->stats->forward[k]);
-#if SKIPLIST_DEBUG
+#ifdef SKIPLIST_DEBUG
 	zlog_debug("%s: incremented stats @%p:%d, now %ld", __func__, l, k,
 		   l->stats->forward[k] - (struct skiplistnode *)NULL);
 #endif
@@ -281,7 +281,7 @@ int skiplist_delete(register struct skiplist *l, register void *key,
 /*
  * found node to delete
  */
-#if SKIPLIST_0TIMER_DEBUG
+#ifdef SKIPLIST_0TIMER_DEBUG
 			q->flags &= ~SKIPLIST_NODE_FLAG_INSERTED;
 #endif
 			/*
@@ -300,7 +300,7 @@ int skiplist_delete(register struct skiplist *l, register void *key,
 				p->forward[k] = q->forward[k];
 			}
 			--(l->stats->forward[k - 1]);
-#if SKIPLIST_DEBUG
+#ifdef SKIPLIST_DEBUG
 			zlog_debug("%s: decremented stats @%p:%d, now %ld",
 				   __func__, l, k - 1,
 				   l->stats->forward[k - 1]
@@ -549,7 +549,7 @@ int skiplist_delete_first(register struct skiplist *l)
 		}
 	}
 
-#if SKIPLIST_0TIMER_DEBUG
+#ifdef SKIPLIST_0TIMER_DEBUG
 	q->flags &= ~SKIPLIST_NODE_FLAG_INSERTED;
 #endif
 	/*
@@ -561,7 +561,7 @@ int skiplist_delete_first(register struct skiplist *l)
 	}
 
 	--(l->stats->forward[nodelevel]);
-#if SKIPLIST_DEBUG
+#ifdef SKIPLIST_DEBUG
 	zlog_debug("%s: decremented stats @%p:%d, now %ld", __func__, l,
 		   nodelevel,
 		   l->stats->forward[nodelevel] - (struct skiplistnode *)NULL);

--- a/ripngd/ripngd.c
+++ b/ripngd/ripngd.c
@@ -1455,7 +1455,7 @@ static int ripng_update(struct thread *t)
 		if (ri->passive)
 			continue;
 
-#if RIPNG_ADVANCED
+#ifdef RIPNG_ADVANCED
 		if (ri->ri_send == RIPNG_SEND_OFF) {
 			if (IS_RIPNG_DEBUG_EVENT)
 				zlog_debug(

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -3331,7 +3331,7 @@ skip_one:
 	return 0;
 }
 
-#if DPLANE_TEST_PROVIDER
+#ifdef DPLANE_TEST_PROVIDER
 
 /*
  * Test dataplane provider plugin
@@ -3415,7 +3415,7 @@ static void dplane_provider_init(void)
 		zlog_err("Unable to register kernel dplane provider: %d",
 			 ret);
 
-#if DPLANE_TEST_PROVIDER
+#ifdef DPLANE_TEST_PROVIDER
 	/* Optional test provider ... */
 	ret = dplane_provider_register("Test",
 				       DPLANE_PRIO_PRE_KERNEL,


### PR DESCRIPTION
In the unlikely event you are building with -Werror=undef, several
configure checks fail. Fix those.

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>