### PR TITLE
bgpd: When deleting an afi/safi and we fail give more detail

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2102,8 +2102,8 @@ static int non_peergroup_deactivate_af(struct peer *peer, afi_t afi,
 
 	if (peer_af_delete(peer, afi, safi) != 0) {
 		flog_err(EC_BGP_PEER_DELETE,
-			 "couldn't delete af structure for peer %s",
-			 peer->host);
+			 "couldn't delete af structure for peer %s(%s, %s)",
+			 peer->host, afi2str(afi), safi2str(safi));
 		return 1;
 	}
 
@@ -2152,9 +2152,10 @@ int peer_deactivate(struct peer *peer, afi_t afi, safi_t safi)
 		group = peer->group;
 
 		if (peer_af_delete(peer, afi, safi) != 0) {
-			flog_err(EC_BGP_PEER_DELETE,
-				 "couldn't delete af structure for peer %s",
-				 peer->host);
+			flog_err(
+				EC_BGP_PEER_DELETE,
+				"couldn't delete af structure for peer %s(%s, %s)",
+				peer->host, afi2str(afi), safi2str(safi));
 		}
 
 		for (ALL_LIST_ELEMENTS(group->peer, node, nnode, tmp_peer)) {


### PR DESCRIPTION
It would be nice to know which afi/safi we couldn't delete
on a peer in the flog message.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>