### PR TITLE
isisd: fix a bunch of build warnings with GCC 10

### DIFF
--- a/lib/stream.h
+++ b/lib/stream.h
@@ -110,7 +110,7 @@ struct stream {
 	size_t getp;	       /* next get position */
 	size_t endp;	       /* last valid data position */
 	size_t size;	       /* size of data segment */
-	unsigned char data[0]; /* data pointer */
+	unsigned char data[];  /* data pointer */
 };
 
 /* First in first out queue structure. */


### PR DESCRIPTION
GCC 10 thinks we memcpy into a 0-sized array (which we're not).
Use a C99 flexible array member instead.

Fixes:

  CC       lib/stream.lo
lib/stream.c: In function ‘stream_put_in_addr’:
lib/stream.c:824:2: warning: writing 4 bytes into a region of size 0 [-Wstringop-overflow=]
  824 |  memcpy(s->data + s->endp, addr, sizeof(uint32_t));
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

isisd/isis_tlvs.c: In function ‘auth_validator_hmac_md5’:
isisd/isis_tlvs.c:4279:2: warning: writing 16 bytes into a region of size 0 [-Wstringop-overflow=]
 4279 |  memcpy(STREAM_DATA(stream) + auth->offset, auth->value, 16);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘update_auth_hmac_md5’,
    inlined from ‘update_auth’ at isisd/isis_tlvs.c:3734:4,
    inlined from ‘isis_pack_tlvs’ at isisd/isis_tlvs.c:3897:2:
isisd/isis_tlvs.c:3722:2: warning: writing 16 bytes into a region of size 0 [-Wstringop-overflow=]
 3722 |  memcpy(STREAM_DATA(s) + auth->offset, digest, 16);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
isisd/isis_tlvs.c:3722:2: warning: writing 16 bytes into a region of size 0 [-Wstringop-overflow=]

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>