### PR TITLE
build: enable -Wundef warnings

### DIFF
--- a/bfdd/bfd_packet.c
+++ b/bfdd/bfd_packet.c
@@ -779,7 +779,7 @@ int bp_udp_send(int sd, uint8_t ttl, uint8_t *data, size_t datalen,
 			cmsg->cmsg_level = IPPROTO_IPV6;
 			cmsg->cmsg_type = IPV6_HOPLIMIT;
 		} else {
-#if BFD_LINUX
+#ifdef BFD_LINUX
 			cmsg->cmsg_level = IPPROTO_IP;
 			cmsg->cmsg_type = IP_TTL;
 #else

--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,7 @@ AC_C_FLAG([-Wmissing-declarations])
 AC_C_FLAG([-Wpointer-arith])
 AC_C_FLAG([-Wbad-function-cast])
 AC_C_FLAG([-Wwrite-strings])
+AC_C_FLAG([-Wundef])
 if test "$enable_gcc_ultra_verbose" = "yes" ; then
   AC_C_FLAG([-Wcast-qual])
   AC_C_FLAG([-Wstrict-prototypes])


### PR DESCRIPTION
Now that we've fixed all of them, enable them by default if the compiler
supports it.

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>