### PR TITLE
ldpd: During code inspection we are mixing data sizes

### DIFF
--- a/ldpd/hello.c
+++ b/ldpd/hello.c
@@ -169,7 +169,7 @@ recv_hello(struct in_addr lsr_id, struct ldp_msg *msg, int af,
 	int			 tlvs_rcvd;
 	int			 ds_tlv;
 	union ldpd_addr		 trans_addr;
-	uint32_t		 scope_id = 0;
+	ifindex_t		 scope_id = 0;
 	uint32_t		 conf_seqnum;
 	uint16_t		 trans_pref;
 	int			 r;

--- a/ldpd/interface.c
+++ b/ldpd/interface.c
@@ -109,7 +109,7 @@ ldpe_if_exit(struct iface *iface)
 }
 
 struct iface *
-if_lookup(struct ldpd_conf *xconf, unsigned short ifindex)
+if_lookup(struct ldpd_conf *xconf, ifindex_t ifindex)
 {
 	struct iface *iface;
 

--- a/ldpd/ldpd.h
+++ b/ldpd/ldpd.h
@@ -306,7 +306,7 @@ struct iface_af {
 struct iface {
 	RB_ENTRY(iface)		 entry;
 	char			 name[IF_NAMESIZE];
-	unsigned int		 ifindex;
+	ifindex_t		 ifindex;
 	struct if_addr_head	 addr_list;
 	struct in6_addr		 linklocal;
 	enum iface_type		 type;
@@ -391,7 +391,7 @@ struct l2vpn_if {
 	RB_ENTRY(l2vpn_if)	 entry;
 	struct l2vpn		*l2vpn;
 	char			 ifname[IF_NAMESIZE];
-	unsigned int		 ifindex;
+	ifindex_t		 ifindex;
 	int			 operative;
 	uint8_t			 mac[ETH_ALEN];
 	QOBJ_FIELDS
@@ -408,7 +408,7 @@ struct l2vpn_pw {
 	union ldpd_addr		 addr;
 	uint32_t		 pwid;
 	char			 ifname[IF_NAMESIZE];
-	unsigned int		 ifindex;
+	ifindex_t		 ifindex;
 	bool			 enabled;
 	uint32_t		 remote_group;
 	uint16_t		 remote_mtu;
@@ -433,7 +433,7 @@ struct l2vpn {
 	int			 pw_type;
 	int			 mtu;
 	char			 br_ifname[IF_NAMESIZE];
-	unsigned int		 br_ifindex;
+	ifindex_t		 br_ifindex;
 	struct l2vpn_if_head	 if_tree;
 	struct l2vpn_pw_head	 pw_tree;
 	struct l2vpn_pw_head	 pw_inactive_tree;
@@ -542,7 +542,7 @@ struct kroute {
 	union ldpd_addr		 nexthop;
 	uint32_t		 local_label;
 	uint32_t		 remote_label;
-	unsigned short		 ifindex;
+	ifindex_t		 ifindex;
 	uint8_t			 route_type;
 	uint8_t			 route_instance;
 	uint16_t		 flags;
@@ -550,7 +550,7 @@ struct kroute {
 
 struct kaddr {
 	char			 ifname[IF_NAMESIZE];
-	unsigned short		 ifindex;
+	ifindex_t		 ifindex;
 	int			 af;
 	union ldpd_addr		 addr;
 	uint8_t			 prefixlen;
@@ -559,7 +559,7 @@ struct kaddr {
 
 struct kif {
 	char			 ifname[IF_NAMESIZE];
-	unsigned short		 ifindex;
+	ifindex_t		 ifindex;
 	int			 flags;
 	int			 operative;
 	uint8_t			 mac[ETH_ALEN];
@@ -577,7 +577,7 @@ struct acl_check {
 struct ctl_iface {
 	int			 af;
 	char			 name[IF_NAMESIZE];
-	unsigned int		 ifindex;
+	ifindex_t		 ifindex;
 	int			 state;
 	enum iface_type		 type;
 	uint16_t		 hello_holdtime;
@@ -760,7 +760,7 @@ int		 sock_set_bindany(int, int);
 int		 sock_set_md5sig(int, int, union ldpd_addr *, const char *);
 int		 sock_set_ipv4_tos(int, int);
 int		 sock_set_ipv4_pktinfo(int, int);
-int		 sock_set_ipv4_recvdstaddr(int, int);
+int		 sock_set_ipv4_recvdstaddr(int fd, ifindex_t ifindex);
 int		 sock_set_ipv4_recvif(int, int);
 int		 sock_set_ipv4_minttl(int, int);
 int		 sock_set_ipv4_ucast_ttl(int fd, int);
@@ -783,7 +783,8 @@ struct fec;
 
 const char	*log_sockaddr(void *);
 const char	*log_in6addr(const struct in6_addr *);
-const char	*log_in6addr_scope(const struct in6_addr *, unsigned int);
+const char	*log_in6addr_scope(const struct in6_addr *addr,
+				   ifindex_t ifidx);
 const char	*log_addr(int, const union ldpd_addr *);
 char		*log_label(uint32_t);
 const char	*log_time(time_t);

--- a/ldpd/ldpe.c
+++ b/ldpd/ldpe.c
@@ -41,7 +41,7 @@ static int	 ldpe_dispatch_pfkey(struct thread *);
 #endif
 static void	 ldpe_setup_sockets(int, int, int, int);
 static void	 ldpe_close_sockets(int);
-static void	 ldpe_iface_af_ctl(struct ctl_conn *, int, unsigned int);
+static void	 ldpe_iface_af_ctl(struct ctl_conn *c, int af, ifindex_t ifidx);
 
 struct ldpd_conf	*leconf;
 #ifdef __OpenBSD__
@@ -827,7 +827,7 @@ ldpe_stop_init_backoff(int af)
 }
 
 static void
-ldpe_iface_af_ctl(struct ctl_conn *c, int af, unsigned int idx)
+ldpe_iface_af_ctl(struct ctl_conn *c, int af, ifindex_t idx)
 {
 	struct iface		*iface;
 	struct iface_af		*ia;
@@ -847,7 +847,7 @@ ldpe_iface_af_ctl(struct ctl_conn *c, int af, unsigned int idx)
 }
 
 void
-ldpe_iface_ctl(struct ctl_conn *c, unsigned int idx)
+ldpe_iface_ctl(struct ctl_conn *c, ifindex_t idx)
 {
 	ldpe_iface_af_ctl(c, AF_INET, idx);
 	ldpe_iface_af_ctl(c, AF_INET6, idx);

--- a/ldpd/ldpe.h
+++ b/ldpd/ldpe.h
@@ -92,7 +92,7 @@ struct nbr {
 	struct in_addr		 id;		/* lsr id */
 	union ldpd_addr		 laddr;		/* local address */
 	union ldpd_addr		 raddr;		/* remote address */
-	uint32_t		 raddr_scope;	/* remote address scope (v6) */
+	ifindex_t		 raddr_scope;	/* remote address scope (v6) */
 	time_t			 uptime;
 	int			 fd;
 	int			 state;
@@ -208,7 +208,7 @@ void		 ldpe_reset_ds_nbrs(void);
 void		 ldpe_remove_dynamic_tnbrs(int);
 void		 ldpe_stop_init_backoff(int);
 struct ctl_conn;
-void		 ldpe_iface_ctl(struct ctl_conn *, unsigned int);
+void		 ldpe_iface_ctl(struct ctl_conn *c, ifindex_t ifidx);
 void		 ldpe_adj_ctl(struct ctl_conn *);
 void		 ldpe_adj_detail_ctl(struct ctl_conn *);
 void		 ldpe_nbr_ctl(struct ctl_conn *);
@@ -219,7 +219,7 @@ void		 mapping_list_clr(struct mapping_head *);
 struct iface	*if_new(const char *);
 void		 ldpe_if_init(struct iface *);
 void		 ldpe_if_exit(struct iface *);
-struct iface	*if_lookup(struct ldpd_conf *, unsigned short);
+struct iface	*if_lookup(struct ldpd_conf *c, ifindex_t ifidx);
 struct iface	*if_lookup_name(struct ldpd_conf *, const char *);
 void		 if_update_info(struct iface *, struct kif *);
 struct iface_af *iface_af_get(struct iface *, int);

--- a/ldpd/logmsg.c
+++ b/ldpd/logmsg.c
@@ -59,7 +59,7 @@ log_in6addr(const struct in6_addr *addr)
 }
 
 const char *
-log_in6addr_scope(const struct in6_addr *addr, unsigned int ifindex)
+log_in6addr_scope(const struct in6_addr *addr, ifindex_t ifindex)
 {
 	struct sockaddr_in6	sa_in6;
 

--- a/ldpd/socket.c
+++ b/ldpd/socket.c
@@ -329,7 +329,7 @@ sock_set_ipv4_tos(int fd, int tos)
 }
 
 int
-sock_set_ipv4_recvif(int fd, int enable)
+sock_set_ipv4_recvif(int fd, ifindex_t enable)
 {
 	return (setsockopt_ifindex(AF_INET, fd, enable));
 }


### PR DESCRIPTION
As I understand it ldpd was originally developed as a standalone
daemon for *BSD land.  Then ported to FRR.  FRR uses ifindex_t
as the base type for the ifindex.  Mixing `unsigned short` and
`int` and `unsigned int` is going to lead to fun somewhere
along the way.  Especially when we get to run on a system
with ifindex churn( I'm looking at you docker ).

Attempt to convert all of ldpd to think of the ifindex as a
`ifindex_t`.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>