### PR TITLE
build: Add Python 3.8

### DIFF
--- a/m4/ax_python.m4
+++ b/m4/ax_python.m4
@@ -3,7 +3,7 @@ dnl 2019 David Lamparter for NetDEF, Inc.
 dnl SPDX-License-Identifier: GPL-2.0-or-later
 
 dnl the _ at the beginning will be cut off (to support the empty version string)
-m4_define_default([_FRR_PY_VERS], [_3 _ _2 _3.7 _3.6 _3.5 _3.4 _3.3 _3.2 _2.7])
+m4_define_default([_FRR_PY_VERS], [_3 _ _2 _3.8 _3.7 _3.6 _3.5 _3.4 _3.3 _3.2 _2.7])
 
 dnl check basic interpreter properties (py2/py3)
 dnl doubles as simple check whether the interpreter actually works


### PR DESCRIPTION
Fixes detection of python on OpenBSD

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>