### PR TITLE
zebra: [7.3] add config to disable use of kernel nexthops

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -49,6 +49,9 @@ DEFINE_MTYPE_STATIC(ZEBRA, NHG_CTX, "Nexthop Group Context");
 /* id counter to keep in sync with kernel */
 uint32_t id_counter;
 
+/*  */
+static bool g_nexthops_enabled = true;
+
 static struct nhg_hash_entry *depends_find(const struct nexthop *nh,
 					   afi_t afi);
 static void depends_add(struct nhg_connected_tree_head *head,
@@ -2003,4 +2006,19 @@ static void zebra_nhg_sweep_entry(struct hash_bucket *bucket, void *arg)
 void zebra_nhg_sweep_table(struct hash *hash)
 {
 	hash_iterate(hash, zebra_nhg_sweep_entry, NULL);
+}
+
+/* Global control to disable use of kernel nexthops, if available. We can't
+ * force the kernel to support nexthop ids, of course, but we can disable
+ * zebra's use of them, for testing e.g. By default, if the kernel supports
+ * nexthop ids, zebra uses them.
+ */
+void zebra_nhg_enable_kernel_nexthops(bool set)
+{
+	g_nexthops_enabled = set;
+}
+
+bool zebra_nhg_kernel_nexthops_enabled(void)
+{
+	return g_nexthops_enabled;
 }

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -153,6 +153,13 @@ struct nhg_ctx {
 	enum nhg_ctx_status status;
 };
 
+/* Global control to disable use of kernel nexthops, if available. We can't
+ * force the kernel to support nexthop ids, of course, but we can disable
+ * zebra's use of them, for testing e.g. By default, if the kernel supports
+ * nexthop ids, zebra uses them.
+ */
+void zebra_nhg_enable_kernel_nexthops(bool set);
+bool zebra_nhg_kernel_nexthops_enabled(void);
 
 /**
  * NHE abstracted tree functions.
@@ -227,4 +234,5 @@ extern void zebra_nhg_sweep_table(struct hash *hash);
 /* Nexthop resolution processing */
 struct route_entry; /* Forward ref to avoid circular includes */
 extern int nexthop_active_update(struct route_node *rn, struct route_entry *re);
-#endif
+
+#endif	/* __ZEBRA_NHG_H__ */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -1410,6 +1410,19 @@ DEFPY (show_nexthop_group,
 	return CMD_SUCCESS;
 }
 
+DEFPY_HIDDEN(nexthop_group_use_enable,
+	     nexthop_group_use_enable_cmd,
+	     "[no] zebra nexthop kernel enable",
+	     NO_STR
+	     ZEBRA_STR
+	     "Nexthop configuration \n"
+	     "Configure use of kernel nexthops\n"
+	     "Enable kernel nexthops\n")
+{
+	zebra_nhg_enable_kernel_nexthops(!no);
+	return CMD_SUCCESS;
+}
+
 DEFUN (no_ip_nht_default_route,
        no_ip_nht_default_route_cmd,
        "no ip nht resolve-via-default",
@@ -3121,6 +3134,10 @@ static int config_write_protocol(struct vty *vty)
 	/* Include dataplane info */
 	dplane_config_write_helper(vty);
 
+	/* Include nexthop-group config */
+	if (!zebra_nhg_kernel_nexthops_enabled())
+		vty_out(vty, "no zebra nexthop kernel enable\n");
+
 	return 1;
 }
 
@@ -3492,6 +3509,7 @@ void zebra_vty_init(void)
 	install_element(CONFIG_NODE, &no_zebra_workqueue_timer_cmd);
 	install_element(CONFIG_NODE, &zebra_packet_process_cmd);
 	install_element(CONFIG_NODE, &no_zebra_packet_process_cmd);
+	install_element(CONFIG_NODE, &nexthop_group_use_enable_cmd);
 
 	install_element(VIEW_NODE, &show_nexthop_group_cmd);
 	install_element(VIEW_NODE, &show_interface_nexthop_group_cmd);


### PR DESCRIPTION
Add a config that disables use of kernel-level nexthop ids.
Currently, zebra always uses nexthop ids if the kernel supports
them.

Signed-off-by: Mark Stapp <mjs@voltanet.io>