### PR TITLE
lib: include any mem ever allocd in `show memory`

### DIFF
--- a/lib/lib_vty.c
+++ b/lib/lib_vty.c
@@ -93,7 +93,7 @@ static int qmem_walker(void *arg, struct memgroup *mg, struct memtype *mt)
 #endif
 			);
 	} else {
-		if (mt->n_alloc != 0) {
+		if (mt->n_max != 0) {
 			char size[32];
 			snprintf(size, sizeof(size), "%6zu", mt->size);
 #ifdef HAVE_MALLOC_USABLE_SIZE


### PR DESCRIPTION
Include memory types that were ever allocated when doing
a `show memory`.

Before, we were only including memory that existed currently
in the system, so we lost memory that was alloc'd/dealloc'd.

With this patch, we check max number rather than current number.

Ex) dataplane context objects

Old:
==============================================================================
```
Type                          : Current#   Size       Total     Max#  MaxBytes
--- qmem zebra ---
Type                          : Current#   Size       Total     Max#  MaxBytes
Zebra Interface Information   :       48    360       17280       48     17280
Router Advertisement Prefix   :        3     48         168        3       168
Route Entry                   :      128     80       11264      128     11264
RIB destination               :       64     88        5632       64      5632
Zebra DPlane Provider         :        1    232         232        1       232
Nexthop Group Entry           :       78     80        6928      114     10032
Nexthop Group Connected       :       78     40        3168      114      4560
Zebra Name Space              :       13 variable      1000       13      1000
RIB table info                :       12     16         288       12       288
ZEBRA VRF                     :        3   4744       14232        3     14232
```
New:
==============================================================================
```
Type                          : Current#   Size       Total     Max#  MaxBytes
--- qmem zebra ---
Type                          : Current#   Size       Total     Max#  MaxBytes
Zebra Interface Information   :       48    360       17280       48     17280
Router Advertisement Prefix   :        3     48         168        3       168
Route Entry                   :      128     80       11264      128     11264
RIB destination               :       64     88        5632       64      5632
Zebra DPlane Ctx              :        0   2424           0       87    210888
Zebra DPlane Provider         :        1    232         232        1       232
Nexthop Group Entry           :       78     80        6928      114     10032
Nexthop Group Connected       :       78     40        3168      114      4560
Zebra Name Space              :       13 variable      1000       13      1000
RIB table info                :       12     16         288       12       288
ZEBRA VRF                     :        3   4744       14232        3     14232
```
Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>