### PR TITLE
zebra: Add vrf name and id to debugs

### DIFF
--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -324,10 +324,7 @@ const char *vrf_id_to_name(vrf_id_t vrf_id)
 	struct vrf *vrf;
 
 	vrf = vrf_lookup_by_id(vrf_id);
-	if (vrf)
-		return vrf->name;
-
-	return "n/a";
+	return VRF_LOGNAME(vrf);
 }
 
 vrf_id_t vrf_name_to_id(const char *name)

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -193,7 +193,7 @@ struct zebra_vrf {
 static inline vrf_id_t zvrf_id(struct zebra_vrf *zvrf)
 {
 	if (!zvrf || !zvrf->vrf)
-		return VRF_UNKNOWN;
+		return VRF_DEFAULT;
 	return zvrf->vrf->vrf_id;
 }
 
@@ -206,6 +206,8 @@ static inline const char *zvrf_ns_name(struct zebra_vrf *zvrf)
 
 static inline const char *zvrf_name(struct zebra_vrf *zvrf)
 {
+	if (!zvrf || !zvrf->vrf)
+		return "Unknown";
 	return zvrf->vrf->name;
 }
 


### PR DESCRIPTION
In some places we log the interface but not the vfr the
interface is in. In others we only output the vrf id, which
can be difficult for human to read. This commit makes zebra
debugs more vrf aware.

Signed-off-by: Jakub Urbańczyk <xthaid@gmail.com>

Before modifying other logs, I would like to know if these changes are useful and if there is something wrong.