### PR TITLE
bgpd: upon reconfiguration or bgp exchange failure, stop bfd.

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1129,7 +1129,7 @@ int bgp_stop(struct peer *peer)
 	peer->nsf_af_count = 0;
 
 	/* deregister peer */
-	if (peer->last_reset != PEER_DOWN_BFD_DOWN)
+	if (peer->last_reset == PEER_DOWN_UPDATE_SOURCE_CHANGE)
 		bgp_bfd_deregister_peer(peer);
 
 	if (peer_dynamic_neighbor(peer)


### PR DESCRIPTION
When bgp is updated with local source, the bgp session is reset; bfd
also must be reset. The bgp_stop() handler handles all kind of
unexpected failures, so the placeholder to deregister from bfd should be
ok, providing that when bgp establishes, a similar function in bgp will
recreate bfd context.
Note that the bfd session is not reset on one specific case, where BFD
down event is the last reset. In that case, we must let BFD to monitor
the link.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>