### PR TITLE
bgpd: reset bfd session when bgp comes up

### DIFF
--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -200,6 +200,25 @@ static void bgp_bfd_update_peer(struct peer *peer)
 	bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_UPDATE);
 }
 
+/**
+ * bgp_bfd_reset_peer - reinitialise bfd
+ * ensures that bfd state machine is restarted
+ * to be synced with remote bfd
+ */
+void bgp_bfd_reset_peer(struct peer *peer)
+{
+	struct bfd_info *bfd_info;
+
+	if (!peer->bfd_info)
+		return;
+	bfd_info = (struct bfd_info *)peer->bfd_info;
+
+	/* if status is not down, reset bfd */
+	if (bfd_info->status != BFD_STATUS_DOWN)
+		bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_DEREGISTER);
+	bgp_bfd_peer_sendmsg(peer, ZEBRA_BFD_DEST_REGISTER);
+}
+
 /*
  * bgp_bfd_update_type - update session type with BFD through zebra.
  */

--- a/bgpd/bgp_bfd.h
+++ b/bgpd/bgp_bfd.h
@@ -31,6 +31,8 @@ extern void bgp_bfd_register_peer(struct peer *peer);
 
 extern void bgp_bfd_deregister_peer(struct peer *peer);
 
+extern void bgp_bfd_reset_peer(struct peer *peer);
+
 extern void bgp_bfd_peer_config_write(struct vty *vty, struct peer *peer,
 				      char *addr);
 

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1935,8 +1935,7 @@ static int bgp_establish(struct peer *peer)
 	hash_release(peer->bgp->peerhash, peer);
 	hash_get(peer->bgp->peerhash, peer, hash_alloc_intern);
 
-	bgp_bfd_deregister_peer(peer);
-	bgp_bfd_register_peer(peer);
+	bgp_bfd_reset_peer(peer);
 	return ret;
 }
 


### PR DESCRIPTION
This scenario has been seen against microtik virtual machine with
bfd enabled. When remote microtik bgp reestablishes the bgp session
after a bgp reset, the bgp establishment comes first, then bfd is
initialising.
The second point is true for microtik, but not for frrouting, as the
frrouting, when receiving bfd down messages, is not at init state.
Actually, bfd state is up, and sees the first bfd down packet from
bfd as an issue. Consequently, the BGP session is cleared.
The fix consists in resetting the BFD session, only if bfd status is
considered as up, once BGP comes up.
That permits to align state machines of both local and remote bfd.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>