### PR TITLE
zebra: add mapping from table id to vrf

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -287,28 +287,23 @@ static inline int proto2zebra(int proto, int family, bool is_nexthop)
 	return proto;
 }
 
-/*
-Pending: create an efficient table_id (in a tree/hash) based lookup)
- */
 static vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 {
 	struct vrf *vrf;
-	struct zebra_vrf *zvrf;
+	struct zebra_vrf *zvrf, target;
 
-	RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
-		zvrf = vrf->info;
-		if (zvrf == NULL)
-			continue;
-		/* case vrf with netns : match the netnsid */
-		if (vrf_is_backend_netns()) {
+	if (vrf_is_backend_netns()) {
+		RB_FOREACH (vrf, vrf_id_head, &vrfs_by_id) {
+			zvrf = vrf->info;
+			if (zvrf == NULL)
+				continue;
 			if (ns_id == zvrf_id(zvrf))
 				return zvrf_id(zvrf);
-		} else {
-			/* VRF is VRF_BACKEND_VRF_LITE */
-			if (zvrf->table_id != table_id)
-				continue;
-			return zvrf_id(zvrf);
-		}
+	}
+	else {
+		target.table_id = table_id;
+		zvrf = vrf_table_id_find(&vrfs_by_table_id, &target);
+		if (table_id == zvrf->table_id) return zvrf_id(zvrf);
 	}
 
 	return VRF_DEFAULT;

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -299,15 +299,17 @@ static vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 				continue;
 			if (ns_id == zvrf_id(zvrf))
 				return zvrf_id(zvrf);
-	}
-	else {
-		target.table_id = table_id;
-		zvrf = vrf_table_id_find(&vrfs_by_table_id, &target);
-		if (table_id == zvrf->table_id) return zvrf_id(zvrf);
-	}
+		}
+		else
+		{
+			target.table_id = table_id;
+			zvrf = vrf_table_id_find(&vrfs_by_table_id, &target);
+			if (table_id == zvrf->table_id)
+				return zvrf_id(zvrf);
+		}
 
 	return VRF_DEFAULT;
-}
+	}
 
 /**
  * @parse_encap_mpls() - Parses encapsulated mpls attributes

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -303,7 +303,7 @@ static vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 	} else {
 		target.table_id = table_id;
 		zvrf = vrf_table_id_find(&vrfs_by_table_id, &target);
-		if (table_id == zvrf->table_id)
+		if (zvrf && table_id == zvrf->table_id)
 			return zvrf_id(zvrf);
 	}
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -300,16 +300,15 @@ static vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 			if (ns_id == zvrf_id(zvrf))
 				return zvrf_id(zvrf);
 		}
-		else
-		{
-			target.table_id = table_id;
-			zvrf = vrf_table_id_find(&vrfs_by_table_id, &target);
-			if (table_id == zvrf->table_id)
-				return zvrf_id(zvrf);
-		}
+	} else {
+		target.table_id = table_id;
+		zvrf = vrf_table_id_find(&vrfs_by_table_id, &target);
+		if (table_id == zvrf->table_id)
+			return zvrf_id(zvrf);
+	}
 
 	return VRF_DEFAULT;
-	}
+}
 
 /**
  * @parse_encap_mpls() - Parses encapsulated mpls attributes

--- a/zebra/zebra_vrf.c
+++ b/zebra/zebra_vrf.c
@@ -104,7 +104,8 @@ static int zebra_vrf_new(struct vrf *vrf)
 
 	router_id_init(zvrf);
 
-	if (!vrf_is_backend_netns()) vrf_table_id_add(&vrfs_by_table_id, zvrf);
+	if (!vrf_is_backend_netns())
+		vrf_table_id_add(&vrfs_by_table_id, zvrf);
 
 	return 0;
 }
@@ -257,7 +258,8 @@ static int zebra_vrf_delete(struct vrf *vrf)
 		zlog_debug("VRF %s id %u deleted", zvrf_name(zvrf),
 			   zvrf_id(zvrf));
 
-	if (!vrf_is_backend_netns()) vrf_table_id_del(&vrfs_by_table_id, zvrf);
+	if (!vrf_is_backend_netns())
+		vrf_table_id_del(&vrfs_by_table_id, zvrf);
 
 	/* clean-up work queues */
 	for (i = 0; i < MQ_SIZE; i++) {
@@ -345,11 +347,14 @@ int zebra_vrf_has_config(struct zebra_vrf *zvrf)
 	return 0;
 }
 
-int zebra_vrf_compare_table_id(const struct zebra_vrf *a, const struct zebra_vrf *b) {
+int zebra_vrf_compare_table_id(const struct zebra_vrf *a,
+			       const struct zebra_vrf *b)
+{
 	return (a->table_id - b->table_id);
 }
 
-unsigned zebra_vrf_hash_table_id(const struct zebra_vrf *v) {
+unsigned zebra_vrf_hash_table_id(const struct zebra_vrf *v)
+{
 	return ((unsigned)v->table_id);
 }
 

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -55,6 +55,11 @@ struct other_route_table {
 	struct route_table *table;
 };
 
+/* these are needed to declare hash table */
+int zebra_vrf_compare_table_id(const struct zebra_vrf *, const struct zebra_vrf *);
+unsigned zebra_vrf_hash_table_id(const struct zebra_vrf *);
+
+PREDECL_HASH(vrf_table_id)
 /* Routing table instance.  */
 struct zebra_vrf {
 	/* Back pointer */
@@ -177,11 +182,16 @@ struct zebra_vrf {
 
 	int zebra_rnh_ip_default_route;
 	int zebra_rnh_ipv6_default_route;
+
+	struct vrf_table_id_item nodehash;
 };
+DECLARE_HASH(vrf_table_id, struct zebra_vrf, nodehash, zebra_vrf_compare_table_id, zebra_vrf_hash_table_id)
 #define PROTO_RM_NAME(zvrf, afi, rtype) zvrf->proto_rm[afi][rtype].name
 #define NHT_RM_NAME(zvrf, afi, rtype) zvrf->nht_rm[afi][rtype].name
 #define PROTO_RM_MAP(zvrf, afi, rtype) zvrf->proto_rm[afi][rtype].map
 #define NHT_RM_MAP(zvrf, afi, rtype) zvrf->nht_rm[afi][rtype].map
+
+extern struct vrf_table_id_head vrfs_by_table_id;
 
 /*
  * special macro to allow us to get the correct zebra_vrf

--- a/zebra/zebra_vrf.h
+++ b/zebra/zebra_vrf.h
@@ -56,7 +56,8 @@ struct other_route_table {
 };
 
 /* these are needed to declare hash table */
-int zebra_vrf_compare_table_id(const struct zebra_vrf *, const struct zebra_vrf *);
+int zebra_vrf_compare_table_id(const struct zebra_vrf *,
+			       const struct zebra_vrf *);
 unsigned zebra_vrf_hash_table_id(const struct zebra_vrf *);
 
 PREDECL_HASH(vrf_table_id)
@@ -185,7 +186,8 @@ struct zebra_vrf {
 
 	struct vrf_table_id_item nodehash;
 };
-DECLARE_HASH(vrf_table_id, struct zebra_vrf, nodehash, zebra_vrf_compare_table_id, zebra_vrf_hash_table_id)
+DECLARE_HASH(vrf_table_id, struct zebra_vrf, nodehash,
+	     zebra_vrf_compare_table_id, zebra_vrf_hash_table_id)
 #define PROTO_RM_NAME(zvrf, afi, rtype) zvrf->proto_rm[afi][rtype].name
 #define NHT_RM_NAME(zvrf, afi, rtype) zvrf->nht_rm[afi][rtype].name
 #define PROTO_RM_MAP(zvrf, afi, rtype) zvrf->proto_rm[afi][rtype].map


### PR DESCRIPTION
I added hash table (vrfs_by_table_id) into zebra_vrf.c and changed `vrf_lookup_by_table` to use hash table.