### PR TITLE
zebra: enable nhg async handling

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -142,6 +142,8 @@ struct route_entry {
 #define ROUTE_ENTRY_INSTALLED        0x10
 /* Route has Failed installation into the Data Plane in some manner */
 #define ROUTE_ENTRY_FAILED           0x20
+/* Route is waiting on NH installation in the Data Plane */
+#define ROUTE_ENTRY_NH_WAIT          0x40
 
 	/* Sequence value incremented for each dataplane operation */
 	uint32_t dplane_sequence;
@@ -308,6 +310,7 @@ typedef struct rib_tables_iter_t_ {
 typedef enum {
 	RIB_UPDATE_KERNEL,
 	RIB_UPDATE_RMAP_CHANGE,
+	RIB_UPDATE_NH_INSTALL,
 	RIB_UPDATE_OTHER,
 	RIB_UPDATE_MAX
 } rib_update_event_t;
@@ -516,6 +519,19 @@ static inline struct nexthop_group *rib_active_nhg(struct route_entry *re)
 		return &(re->fib_ng);
 	else
 		return &(re->nhe->nhg);
+}
+
+/*
+ * Is Route Entry Nexthop Object installed and ready to use?
+ */
+static inline bool rib_nhg_installed(const struct route_entry *re)
+{
+	/* Check the installed flag of the fully resolved Nexthop Object */
+	if (CHECK_FLAG(zebra_nhg_resolve(re->nhe)->flags,
+		       NEXTHOP_GROUP_INSTALLED))
+		return true;
+
+	return false;
 }
 
 extern void zebra_vty_init(void);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1996,7 +1996,7 @@ static int netlink_nexthop(int cmd, struct zebra_dplane_ctx *ctx)
 				dplane_ctx_get_nhe_nh_grp_count(ctx));
 		else {
 			const struct nexthop *nh =
-				dplane_ctx_get_nhe_ng(ctx)->nexthop;
+				dplane_ctx_get_nhe_nexthop(ctx);
 			afi_t afi = dplane_ctx_get_nhe_afi(ctx);
 
 			if (afi == AFI_IP)

--- a/zebra/zebra_dplane.c
+++ b/zebra/zebra_dplane.c
@@ -490,6 +490,12 @@ static void dplane_ctx_free(struct zebra_dplane_ctx **pctx)
 
 			(*pctx)->u.rinfo.nhe.ng.nexthop = NULL;
 		}
+
+		/* Labels may have been allocated */
+		for (int i = 0; i < (*pctx)->u.rinfo.nhe.nh_grp_count; i++)
+			nexthop_del_labels(
+				&(*pctx)->u.rinfo.nhe.nh_grp[i].nexthop);
+
 		break;
 	}
 

--- a/zebra/zebra_dplane.h
+++ b/zebra/zebra_dplane.h
@@ -280,8 +280,8 @@ uint32_t dplane_ctx_get_nhe_id(const struct zebra_dplane_ctx *ctx);
 afi_t dplane_ctx_get_nhe_afi(const struct zebra_dplane_ctx *ctx);
 vrf_id_t dplane_ctx_get_nhe_vrf_id(const struct zebra_dplane_ctx *ctx);
 int dplane_ctx_get_nhe_type(const struct zebra_dplane_ctx *ctx);
-const struct nexthop_group *
-dplane_ctx_get_nhe_ng(const struct zebra_dplane_ctx *ctx);
+const struct nexthop *
+dplane_ctx_get_nhe_nexthop(const struct zebra_dplane_ctx *ctx);
 const struct nh_grp *
 dplane_ctx_get_nhe_nh_grp(const struct zebra_dplane_ctx *ctx);
 uint8_t dplane_ctx_get_nhe_nh_grp_count(const struct zebra_dplane_ctx *ctx);

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -836,6 +836,9 @@ static void zebra_nhg_handle_install(struct nhg_hash_entry *nhe)
 
 	frr_each_safe(nhg_connected_tree, &nhe->nhg_dependents, rb_node_dep)
 		zebra_nhg_set_valid(rb_node_dep->nhe);
+
+	/* Schedule route to be processed/installed now */
+	rib_update(RIB_UPDATE_NH_INSTALL);
 }
 
 /*

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1868,6 +1868,8 @@ uint8_t zebra_nhg_nhe2grp(struct nh_grp *grp, struct nhg_hash_entry *nhe,
 			grp[i].id = depend->id;
 			/* We aren't using weights for anything right now */
 			grp[i].weight = depend->nhg.nexthop->weight;
+			nexthop_copy_no_recurse(&grp[i].nexthop,
+						depend->nhg.nexthop, NULL);
 			i++;
 		}
 

--- a/zebra/zebra_nhg.h
+++ b/zebra/zebra_nhg.h
@@ -35,6 +35,8 @@
 struct nh_grp {
 	uint32_t id;
 	uint8_t weight;
+	/* Dataplanes may need all the nexhtop info when sending the group */
+	struct nexthop nexthop;
 };
 
 PREDECL_RBTREE_UNIQ(nhg_connected_tree);


### PR DESCRIPTION
Enable asynchronous handling of nexthop group installation in zebra.

With this patch, routes wait for installation until their specified nexthop/nexthop group is
installed into the dataplane if available.

On installation of the nexthop group, we get a callback from the dataplane and enable a thread event to process routes waiting on installation.

See individual commits for more info on implementation.