### PR TITLE
lib: fix running_config update when VRF is changed

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -264,12 +264,20 @@ void if_update_to_new_vrf(struct interface *ifp, vrf_id_t vrf_id)
 
 		if_dnode = yang_dnode_get(
 			running_config->dnode,
-			"/frr-interface:lib/interface[name='%s'][vrf='%s']/vrf",
+			"/frr-interface:lib/interface[name='%s'][vrf='%s']",
 			ifp->name, old_vrf->name);
 		if (if_dnode) {
-			nb_running_unset_entry(if_dnode->parent);
-			yang_dnode_change_leaf(if_dnode, vrf->name);
-			nb_running_set_entry(if_dnode->parent, ifp);
+			nb_running_unset_entry(if_dnode);
+			lyd_free(if_dnode);
+			running_config->version++;
+		}
+
+		if_dnode = yang_dnode_new_path(
+			running_config->dnode,
+			"/frr-interface:lib/interface[name='%s'][vrf='%s']",
+			ifp->name, vrf->name);
+		if (if_dnode) {
+			nb_running_set_entry(if_dnode, ifp);
 			running_config->version++;
 		}
 	}

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -393,6 +393,23 @@ const char *yang_dnode_get_schema_name(const struct lyd_node *dnode,
 	return dnode->schema->name;
 }
 
+struct lyd_node *yang_dnode_new_path(struct lyd_node *dnode,
+				     const char *xpath_fmt, ...)
+{
+	va_list ap;
+	char xpath[XPATH_MAXLEN];
+	struct lyd_node *dnode_ret = NULL;
+
+	va_start(ap, xpath_fmt);
+	vsnprintf(xpath, sizeof(xpath), xpath_fmt, ap);
+	va_end(ap);
+
+	dnode_ret = lyd_new_path(dnode, ly_native_ctx, xpath, NULL, 0,
+				 LYD_PATH_OPT_UPDATE);
+
+	return dnode_ret;
+}
+
 struct lyd_node *yang_dnode_get(const struct lyd_node *dnode,
 				const char *xpath_fmt, ...)
 {

--- a/lib/yang.h
+++ b/lib/yang.h
@@ -328,6 +328,22 @@ extern const char *yang_dnode_get_schema_name(const struct lyd_node *dnode,
 					      const char *xpath_fmt, ...);
 
 /*
+ * Create a libyang data node by its YANG data path.
+ *
+ * dnode
+ *    Base libyang data node to operate on.
+ *
+ * xpath_fmt
+ *    XPath expression (absolute or relative).
+ *
+ * Returns:
+ *    Pointer to newly created libyang data node.
+ */
+extern struct lyd_node *yang_dnode_new_path(struct lyd_node *dnode,
+					    const char *xpath_fmt, ...)
+	PRINTFRR(2, 3);
+
+/*
  * Find a libyang data node by its YANG data path.
  *
  * dnode


### PR DESCRIPTION
VRF is a part of the xpath, so we should not only update the leaf, but
recreate the dnode by the new path.

Should fix #5718.