### PR TITLE
bgpd: Add subcodes for BGP Finite State Machine Error

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -170,6 +170,16 @@ static const struct message bgp_notify_capability_msg[] = {
 	{BGP_NOTIFY_CAPABILITY_MALFORMED_CODE, "/Malformed Capability Value"},
 	{0}};
 
+static const struct message bgp_notify_fsm_msg[] = {
+	{BGP_NOTIFY_FSM_ERR_SUBCODE_UNSPECIFIC, "/Unspecific"},
+	{BGP_NOTIFY_FSM_ERR_SUBCODE_OPENSENT,
+	 "/Receive Unexpected Message in OpenSent State"},
+	{BGP_NOTIFY_FSM_ERR_SUBCODE_OPENCONFIRM,
+	 "/Receive Unexpected Message in OpenConfirm State"},
+	{BGP_NOTIFY_FSM_ERR_SUBCODE_ESTABLISHED,
+	 "/Receive Unexpected Message in Established State"},
+	{0}};
+
 /* Origin strings. */
 const char *const bgp_origin_str[] = {"i", "e", "?"};
 const char *const bgp_origin_long_str[] = {"IGP", "EGP", "incomplete"};
@@ -471,7 +481,8 @@ const char *bgp_notify_subcode_str(char code, char subcode)
 	case BGP_NOTIFY_HOLD_ERR:
 		break;
 	case BGP_NOTIFY_FSM_ERR:
-		break;
+		return lookup_msg(bgp_notify_fsm_msg, subcode,
+				  "Unrecognized Error Subcode");
 	case BGP_NOTIFY_CEASE:
 		return lookup_msg(bgp_notify_cease_msg, subcode,
 				  "Unrecognized Error Subcode");

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -121,6 +121,7 @@ extern void bgp_update_delay_end(struct bgp *);
 extern void bgp_maxmed_update(struct bgp *);
 extern int bgp_maxmed_onstartup_configured(struct bgp *);
 extern int bgp_maxmed_onstartup_active(struct bgp *);
+extern int bgp_fsm_error_subcode(int status);
 
 /**
  * Start the route advertisement timer (that honors MRAI) for all the

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -1447,7 +1447,7 @@ static int bgp_update_receive(struct peer *peer, bgp_size_t size)
 			 peer->host,
 			 lookup_msg(bgp_status_msg, peer->status, NULL));
 		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR,
-				BGP_NOTIFY_SUBCODE_UNSPECIFIC);
+				bgp_fsm_error_subcode(peer->status));
 		return BGP_Stop;
 	}
 
@@ -1859,7 +1859,7 @@ static int bgp_route_refresh_receive(struct peer *peer, bgp_size_t size)
 			peer->host,
 			lookup_msg(bgp_status_msg, peer->status, NULL));
 		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR,
-				BGP_NOTIFY_SUBCODE_UNSPECIFIC);
+				bgp_fsm_error_subcode(peer->status));
 		return BGP_Stop;
 	}
 
@@ -2251,7 +2251,7 @@ int bgp_capability_receive(struct peer *peer, bgp_size_t size)
 			peer->host,
 			lookup_msg(bgp_status_msg, peer->status, NULL));
 		bgp_notify_send(peer, BGP_NOTIFY_FSM_ERR,
-				BGP_NOTIFY_SUBCODE_UNSPECIFIC);
+				bgp_fsm_error_subcode(peer->status));
 		return BGP_Stop;
 	}
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1499,6 +1499,12 @@ struct bgp_nlri {
 #define BGP_NOTIFY_CEASE                         6
 #define BGP_NOTIFY_CAPABILITY_ERR                7
 
+/* Subcodes for BGP Finite State Machine Error */
+#define BGP_NOTIFY_FSM_ERR_SUBCODE_UNSPECIFIC  0
+#define BGP_NOTIFY_FSM_ERR_SUBCODE_OPENSENT    1
+#define BGP_NOTIFY_FSM_ERR_SUBCODE_OPENCONFIRM 2
+#define BGP_NOTIFY_FSM_ERR_SUBCODE_ESTABLISHED 3
+
 #define BGP_NOTIFY_SUBCODE_UNSPECIFIC            0
 
 /* BGP_NOTIFY_HEADER_ERR sub codes.  */


### PR DESCRIPTION
Implement https://tools.ietf.org/html/rfc6608

I used python scapy library to send a notification message in OpenSent state:
```
send(IP(dst="192.168.0.1")/TCP(sport=sp,
							dport=179,
							seq=rec.ack,
							ack=rec.seq + 1,
							flags=0x18)/BGPHeader(type=3)/BGPNotification(error_code=4,
														error_subcode=0))
```

Logs from FRR:
```
%NOTIFICATION: sent to neighbor 192.168.0.2 5/1 (Neighbor Events Error/Receive Unexpected Message in OpenSent State) 0 bytes
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>