### PR TITLE
git: Skip .kitchen files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ compile_commands.json
 .dirstamp
 refix
 .vscode
+.kitchen


### PR DESCRIPTION
I use kitchen (https://github.com/test-kitchen/kitchen-vagrant) for
development labs environment. Just skip those garbage files.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>