### PR TITLE
pimd: show ip pim bsr json output - removing vtysh caption

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3732,8 +3732,6 @@ static void pim_show_bsr(struct pim_instance *pim,
 	char bsr_str[PREFIX_STRLEN];
 	json_object *json = NULL;
 
-	vty_out(vty, "PIMv2 Bootstrap information\n");
-
 	if (pim->global_scope.current_bsr.s_addr == INADDR_ANY) {
 		strlcpy(bsr_str, "0.0.0.0", sizeof(bsr_str));
 		pim_time_uptime(uptime, sizeof(uptime),
@@ -3779,6 +3777,7 @@ static void pim_show_bsr(struct pim_instance *pim,
 	}
 
 	else {
+		vty_out(vty, "PIMv2 Bootstrap information\n");
 		vty_out(vty, "Current preferred BSR address: %s\n", bsr_str);
 		vty_out(vty,
 			"Priority        Fragment-Tag       State           UpTime\n");


### PR DESCRIPTION
Root cause: The header display is put in common outside the vtysh/json if-else.
Fix: Brought inside vtysh condition.

Signed-off-by: Saravanan K <saravanank@vmware.com>