### PR TITLE
zebra: Disable rmap update thread before routemap_finish while shutting down Zebra

### DIFF
--- a/zebra/main.c
+++ b/zebra/main.c
@@ -53,6 +53,7 @@
 #include "zebra/zebra_rnh.h"
 #include "zebra/zebra_pbr.h"
 #include "zebra/zebra_vxlan.h"
+#include "zebra/zebra_routemap.h"
 
 #if defined(HANDLE_NETLINK_FUZZING)
 #include "zebra/kernel_netlink.h"
@@ -179,7 +180,13 @@ static void sigint(void)
 
 	access_list_reset();
 	prefix_list_reset();
-	route_map_finish();
+	/*
+	 * zebra_routemap_finish will
+	 * 1 set rmap upd timer to 0 so that rmap update wont be scheduled again
+	 * 2 Put off the rmap update thread
+	 * 3 route_map_finish
+	 */
+	zebra_routemap_finish();
 
 	list_delete(&zrouter.client_list);
 

--- a/zebra/zebra_routemap.c
+++ b/zebra/zebra_routemap.c
@@ -1793,6 +1793,15 @@ static void zebra_route_map_set_delay_timer(uint32_t value)
 	}
 }
 
+void zebra_routemap_finish(void)
+{
+	/* Set zebra_rmap_update_timer to 0 so that it wont schedule again */
+	zebra_rmap_update_timer = 0;
+	/* Thread off if any scheduled already */
+	THREAD_TIMER_OFF(zebra_t_rmap_update);
+	route_map_finish();
+}
+
 void zebra_route_map_write_delay_timer(struct vty *vty)
 {
 	if (vty && (zebra_rmap_update_timer != ZEBRA_RMAP_DEFAULT_UPDATE_TIMER))

--- a/zebra/zebra_routemap.h
+++ b/zebra/zebra_routemap.h
@@ -56,4 +56,5 @@ zebra_nht_route_map_check(afi_t afi, int client_proto, const struct prefix *p,
 }
 #endif
 
+extern void zebra_routemap_finish(void);
 #endif


### PR DESCRIPTION
…ng down zebra

Problem: While zebra going down, rmap update thread is being called as part of
timer event. This make zebra to crash.

RCA: At this time route_map_master_hash is made to 0 by sig int handler.
This is causing Zebrad to crash while executing rmap update thread

Fix: As part of SIGINT handler, before calling routemap_finish,
thread off any routemap update scheduled at that point and make sure that
it wont get scheduled again by making the timeout as 0.

Signed-off-by: Saravanan K <saravanank@vmware.com>