### PR TITLE
pimd: moving the route_unlock_node outside debug function

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -248,12 +248,13 @@ struct rp_info *pim_rp_find_match_group(struct pim_instance *pim,
 	if (PIM_DEBUG_PIM_TRACE) {
 		char buf[PREFIX_STRLEN];
 
-		route_unlock_node(rn);
 		zlog_debug("Lookedup: %p for rp_info: %p(%s) Lock: %d", rn,
 			   rp_info,
 			   prefix2str(&rp_info->group, buf, sizeof(buf)),
 			   rn->lock);
 	}
+
+	route_unlock_node(rn);
 
 	if (!best)
 		return rp_info;


### PR DESCRIPTION
Problem: Route node is not de referenced after search when pim debug events are
not enabled when pim_rp_find_match_group is called. So this memory will not get
released when route node is deleted after hitting this path.

RCA: Dereferencing is done inside debug condition.

Fix: Moving outside debug condition

Signed-off-by: Saravanan K <saravanank@vmware.com>