### PR TITLE
tests: Optimize bgp-basic-functionality-topo1 test suite

### DIFF
--- a/tests/topotests/bgp-basic-functionality-topo1/test_bgp_basic_functionality.py
+++ b/tests/topotests/bgp-basic-functionality-topo1/test_bgp_basic_functionality.py
@@ -79,6 +79,9 @@ try:
 except IOError:
     assert False, "Could not read file {}".format(jsonFile)
 
+#Global Variable
+KEEPALIVETIMER = 2
+HOLDDOWNTIMER = 6
 
 class CreateTopo(Topo):
     """
@@ -292,8 +295,8 @@ def test_bgp_timers_functionality(request):
                                 "r2": {
                                     "dest_link":{
                                         "r1": {
-                                            "keepalivetimer": 60,
-                                            "holddowntimer": 180,
+                                            "keepalivetimer": KEEPALIVETIMER,
+                                            "holddowntimer": HOLDDOWNTIMER
                                         }
                                     }
                                 }
@@ -317,8 +320,6 @@ def test_bgp_timers_functionality(request):
         format(tc_name, result)
 
     write_test_footer(tc_name)
-
-
 
 
 def test_static_routes(request):

--- a/tests/topotests/lib/bgp.py
+++ b/tests/topotests/lib/bgp.py
@@ -382,8 +382,8 @@ def __create_bgp_neighbor(topo, input_dict, router, addr_type, add_neigh=True):
 
             disable_connected = peer.setdefault("disable_connected_check",
                                                 False)
-            keep_alive = peer.setdefault("keep_alive", 60)
-            hold_down = peer.setdefault("hold_down", 180)
+            keep_alive = peer.setdefault("keepalivetimer", 60)
+            hold_down = peer.setdefault("holddowntimer", 180)
             password = peer.setdefault("password", None)
             max_hop_limit = peer.setdefault("ebgp_multihop", 1)
 


### PR DESCRIPTION
1. Used aggressive values to verify keepalive and holddown timers functionality
2. Modified variable name in lib/bgp.py
3. Execution time reduced to ~86 seconds from ~800 seconds

Signed-off-by: Kuldeep Kashyap <kashyapk@vmware.com>