### PR TITLE
pimd: added no ip msdp mesh-group <word>

### DIFF
--- a/doc/user/pim.rst
+++ b/doc/user/pim.rst
@@ -158,6 +158,11 @@ Certain signals have special meanings to *pimd*.
    urib-only
       Lookup in the Unicast Rib only.
 
+.. index:: no ip msdp mesh-group [WORD]
+.. clicmd:: no ip msdp mesh-group [WORD]
+
+   Delete multicast source discovery protocol mesh-group
+
 .. index:: ip igmp generate-query-once [version (2-3)]
 .. clicmd:: ip igmp generate-query-once [version (2-3)]
 

--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -9634,11 +9634,25 @@ DEFUN (no_ip_msdp_mesh_group_source,
        "mesh group local address\n")
 {
 	PIM_DECLVAR_CONTEXT(vrf, pim);
-	if (argc == 7)
-		return ip_no_msdp_mesh_group_cmd_worker(pim, vty, argv[6]->arg);
+
+	return ip_no_msdp_mesh_group_source_cmd_worker(pim, vty, argv[4]->arg);
+}
+
+DEFUN (no_ip_msdp_mesh_group,
+       no_ip_msdp_mesh_group_cmd,
+       "no ip msdp mesh-group [WORD]",
+       NO_STR
+       IP_STR
+       CFG_MSDP_STR
+       "Delete MSDP mesh-group\n"
+       "mesh group name")
+{
+	PIM_DECLVAR_CONTEXT(vrf, pim);
+
+	if (argc == 5)
+		return ip_no_msdp_mesh_group_cmd_worker(pim, vty, argv[4]->arg);
 	else
-		return ip_no_msdp_mesh_group_source_cmd_worker(pim, vty,
-							       argv[4]->arg);
+		return ip_no_msdp_mesh_group_cmd_worker(pim, vty, NULL);
 }
 
 static void print_empty_json_obj(struct vty *vty)
@@ -11024,6 +11038,8 @@ void pim_cmd_init(void)
 	install_element(VRF_NODE, &ip_msdp_mesh_group_source_cmd);
 	install_element(CONFIG_NODE, &no_ip_msdp_mesh_group_source_cmd);
 	install_element(VRF_NODE, &no_ip_msdp_mesh_group_source_cmd);
+	install_element(CONFIG_NODE, &no_ip_msdp_mesh_group_cmd);
+	install_element(VRF_NODE, &no_ip_msdp_mesh_group_cmd);
 	install_element(VIEW_NODE, &show_ip_msdp_peer_detail_cmd);
 	install_element(VIEW_NODE, &show_ip_msdp_peer_detail_vrf_all_cmd);
 	install_element(VIEW_NODE, &show_ip_msdp_sa_detail_cmd);

--- a/pimd/pim_msdp.c
+++ b/pimd/pim_msdp.c
@@ -1286,7 +1286,9 @@ enum pim_msdp_err pim_msdp_mg_del(struct pim_instance *pim,
 	struct pim_msdp_mg *mg = pim->msdp.mg;
 	struct pim_msdp_mg_mbr *mbr;
 
-	if (!mg || strcmp(mg->mesh_group_name, mesh_group_name)) {
+	if (!mg
+	    || (mesh_group_name
+		&& strcmp(mg->mesh_group_name, mesh_group_name))) {
 		return PIM_MSDP_ERR_NO_MG;
 	}
 


### PR DESCRIPTION
Issue: no ip msdp mesh-group <word> source command
deleting the mesh group, which might be used by the member.

Solution: no ip msdp mesh-group <word> source command, deletes
the mesh-group source.
Add a new cli command "no ip msdp mesh-group <word>" to delete
the mesh group.

Signed-off-by: Sarita Patra <saritap@vmware.com>