### PR TITLE
pimd: Do not forward BSM to interfaces that has no pim neighbors

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -874,6 +874,17 @@ static void pim_bsm_fwd_whole_sz(struct pim_instance *pim, uint8_t *buf,
 		pim_ifp = ifp->info;
 		if ((!pim_ifp) || (!pim_ifp->bsm_enable))
 			continue;
+
+		/*
+		 * RFC 5059 Sec 3.4:
+		 * When a Bootstrap message is forwarded, it is forwarded out
+		 * of every multicast-capable interface that has PIM neighbors.
+		 *
+		 * So skipping pim interfaces with no neighbors.
+		 */
+		if (listcount(pim_ifp->pim_neighbor_list) == 0)
+			continue;
+
 		pim_hello_require(ifp);
 		pim_mtu = ifp->mtu - MAX_IP_HDR_LEN;
 		if (pim_mtu < len) {


### PR DESCRIPTION
Problem:
We are receiving PIM BSR packet over the pim interface which has no nbrs

According to RFC 5059 Sec 3.4
   When a Bootstrap message is forwarded, it is forwarded out of every
   multicast-capable interface that has PIM neighbors (including the one
   over which the message was received).

RCA:
We are sending to all pim neighbors.

Fix:
We will avoid the interfaces which has no neighbors.

Verification: Manually verified that Pim router doesn't forward to intf with no nbrs

Signed-off-by: Saravanan K <saravanank@vmware.com>