### PR TITLE
pimd: Join not sent within prune override time when received non local prune

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -462,9 +462,25 @@ void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
 		return;
 	}
 
-	join_timer_remain_msec = pim_time_timer_remain_msec(up->t_join_timer);
 	t_override_msec =
 		pim_if_t_override_msec(up->rpf.source_nexthop.interface);
+
+	if (up->t_join_timer) {
+		join_timer_remain_msec =
+			pim_time_timer_remain_msec(up->t_join_timer);
+	} else {
+		/* upstream join tracked with neighbor jp timer */
+		struct pim_neighbor *nbr;
+
+		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
+					up->rpf.rpf_addr.u.prefix4);
+		if (nbr)
+			join_timer_remain_msec =
+				pim_time_timer_remain_msec(nbr->jp_timer);
+		else
+			/* Manipulate such that override takes place */
+			join_timer_remain_msec = t_override_msec + 1;
+	}
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		char rpf_str[INET_ADDRSTRLEN];


### PR DESCRIPTION
RCA: Periodic join is mostly sent by nbr jp timer except for few scenarios by upstream join timer

Fix: If join timer not running, we have to use nbr jp timer to calculate
remaining time for next join.

Signed-off-by: Saravanan K <saravanank@vmware.com>