### PR TITLE
zebra: Add missing c-bit uint8_t

### DIFF
--- a/zebra/zebra_ptm_redistribute.c
+++ b/zebra/zebra_ptm_redistribute.c
@@ -59,6 +59,9 @@ static int zsend_interface_bfd_update(int cmd, struct zserv *client,
 	stream_put(s, &sp->u.prefix, blen);
 	stream_putc(s, sp->prefixlen);
 
+	/* c-bit bullshit */
+	stream_putc(s, 0);
+
 	/* Write packet size. */
 	stream_putw_at(s, 0, stream_get_endp(s));
 


### PR DESCRIPTION
Add to the ZEBRA_INTERFACE_BFD_DEST_UPDATE code path
in zebra_ptm_redistribute.c the missing c-bit data.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>