### PR TITLE
zebra: Install nexthop's weight for IPv4 routes with IPv6 next hops

### DIFF
--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -1340,6 +1340,8 @@ static void _netlink_route_build_multipath(const char *routedesc, int bytelen,
 			      bytelen);
 		rtnh->rtnh_len += sizeof(struct rtattr) + bytelen;
 		rtnh->rtnh_ifindex = nexthop->ifindex;
+		if (nexthop->weight)
+			rtnh->rtnh_hops = nexthop->weight - 1;
 
 		if (nexthop->rmap_src.ipv4.s_addr != INADDR_ANY)
 			*src = &nexthop->rmap_src;


### PR DESCRIPTION
Ensure that any weight associated with the next hop is installed for
IPv4 routes with IPv6 next hops too.
Updates: lib, zebra: Allow for installation of a weighted nexthop

Signed-off-by: Vivek Venkatraman <vivek@cumulusnetworks.com>