### PR TITLE
pimd: Modified rp-info json o/p

### DIFF
--- a/pimd/pim_rp.c
+++ b/pimd/pim_rp.c
@@ -1289,6 +1289,10 @@ void pim_rp_show_information(struct pim_instance *pim, struct vty *vty, bool uj)
 					json_rp_rows = json_object_new_array();
 
 				json_row = json_object_new_object();
+				json_object_string_add(
+					json_row, "rpAddress",
+					inet_ntoa(rp_info->rp.rpf_addr.u
+							  .prefix4));
 				if (rp_info->rp.source_nexthop.interface)
 					json_object_string_add(
 						json_row, "outboundInterface",


### PR DESCRIPTION
Fix : Added a new field "rpAddress" in "show ip pim rp-info json "
Before:
"40.0.0.2":[
    {
      "outboundInterface":"ens224",
      "group":"224.0.0.0\/4",
      "source":"Static"
    }
After:
"40.0.0.2":[
    {
      "rpAddress":"40.0.0.2",
      "outboundInterface":"ens224",
      "group":"224.0.0.0\/4",
      "source":"Static"
    }

Signed-off-by: Sarita Patra <saritap@vmware.com>