### PR TITLE
bgpd,zebra: replace some more FUNCTION macros with __func__

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2328,7 +2328,7 @@ int bgp_process_packet(struct thread *thread)
 				flog_err(
 					EC_BGP_PKT_OPEN,
 					"%s: BGP OPEN receipt failed for peer: %s",
-					__FUNCTION__, peer->host);
+					__func__, peer->host);
 			break;
 		case BGP_MSG_UPDATE:
 			atomic_fetch_add_explicit(&peer->update_in, 1,
@@ -2339,7 +2339,7 @@ int bgp_process_packet(struct thread *thread)
 				flog_err(
 					EC_BGP_UPDATE_RCV,
 					"%s: BGP UPDATE receipt failed for peer: %s",
-					__FUNCTION__, peer->host);
+					__func__, peer->host);
 			break;
 		case BGP_MSG_NOTIFY:
 			atomic_fetch_add_explicit(&peer->notify_in, 1,
@@ -2349,7 +2349,7 @@ int bgp_process_packet(struct thread *thread)
 				flog_err(
 					EC_BGP_NOTIFY_RCV,
 					"%s: BGP NOTIFY receipt failed for peer: %s",
-					__FUNCTION__, peer->host);
+					__func__, peer->host);
 			break;
 		case BGP_MSG_KEEPALIVE:
 			peer->readtime = monotime(NULL);
@@ -2360,7 +2360,7 @@ int bgp_process_packet(struct thread *thread)
 				flog_err(
 					EC_BGP_KEEP_RCV,
 					"%s: BGP KEEPALIVE receipt failed for peer: %s",
-					__FUNCTION__, peer->host);
+					__func__, peer->host);
 			break;
 		case BGP_MSG_ROUTE_REFRESH_NEW:
 		case BGP_MSG_ROUTE_REFRESH_OLD:
@@ -2371,7 +2371,7 @@ int bgp_process_packet(struct thread *thread)
 				flog_err(
 					EC_BGP_RFSH_RCV,
 					"%s: BGP ROUTEREFRESH receipt failed for peer: %s",
-					__FUNCTION__, peer->host);
+					__func__, peer->host);
 			break;
 		case BGP_MSG_CAPABILITY:
 			atomic_fetch_add_explicit(&peer->dynamic_cap_in, 1,
@@ -2381,7 +2381,7 @@ int bgp_process_packet(struct thread *thread)
 				flog_err(
 					EC_BGP_CAP_RCV,
 					"%s: BGP CAPABILITY receipt failed for peer: %s",
-					__FUNCTION__, peer->host);
+					__func__, peer->host);
 			break;
 		default:
 			/* Suppress uninitialized variable warning */

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -173,8 +173,7 @@ void redistribute_update(const struct prefix *p, const struct prefix *src_p,
 	afi = family2afi(p->family);
 	if (!afi) {
 		flog_warn(EC_ZEBRA_REDISTRIBUTE_UNKNOWN_AF,
-			  "%s: Unknown AFI/SAFI prefix received\n",
-			  __FUNCTION__);
+			  "%s: Unknown AFI/SAFI prefix received\n", __func__);
 		return;
 	}
 	if (!zebra_check_addr(p)) {

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -1030,7 +1030,7 @@ static int send_client(struct rnh *rnh, struct zserv *client, rnh_type_t type,
 	default:
 		flog_err(EC_ZEBRA_RNH_UNKNOWN_FAMILY,
 			 "%s: Unknown family (%d) notification attempted\n",
-			 __FUNCTION__, rn->p.family);
+			 __func__, rn->p.family);
 		break;
 	}
 	if (re) {


### PR DESCRIPTION
Replace some remaining __FUNCTION__ macros with __func__, now that we're trying to converge that way. Found a few that must have been missed by the previous PRs?
