### PR TITLE
lib: Only add custom entry point to libfrr on Linux

### DIFF
--- a/lib/subdir.am
+++ b/lib/subdir.am
@@ -2,7 +2,12 @@
 # libfrr
 #
 lib_LTLIBRARIES += lib/libfrr.la
-lib_libfrr_la_LDFLAGS = -version-info 0:0:0 -Xlinker -e_libfrr_version
+lib_libfrr_la_LDFLAGS = -version-info 0:0:0
+
+if LINUX
+lib_libfrr_la_LDFLAGS += -Xlinker -e_libfrr_version
+endif
+
 lib_libfrr_la_LIBADD = $(LIBCAP) $(UNWIND_LIBS) $(LIBYANG_LIBS) $(LUA_LIB) $(LIBM)
 
 lib_libfrr_la_SOURCES = \


### PR DESCRIPTION
At least the linker on MacOS doesn't support this syntax.
Being able to get the frr version by executing libfrr is not critical
functionality to have.

Fixes:
  CCLD     lib/libfrr.la
ld: unknown option: -e_libfrr_version
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [lib/libfrr.la] Error 1
make: *** [all] Error 2

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>