### PR TITLE
Allow 'sets' in EVPN advertise route-map

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2697,13 +2697,13 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 				ret = route_map_apply(
 					bgp->adv_cmd_rmap[afi][safi].map,
 					&rn->p, RMAP_BGP, new_select);
-				if (ret == RMAP_PERMITMATCH)
+				if (ret == RMAP_DENYMATCH)
+					bgp_evpn_withdraw_type5_route(
+						bgp, &rn->p, afi, safi);
+				else
 					bgp_evpn_advertise_type5_route(
 						bgp, &rn->p, new_select->attr,
 						afi, safi);
-				else
-					bgp_evpn_withdraw_type5_route(
-						bgp, &rn->p, afi, safi);
 			} else {
 				bgp_evpn_advertise_type5_route(bgp,
 							       &rn->p,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -467,6 +467,23 @@ static inline bool is_pi_family_matching(struct bgp_path_info *pi,
 	return false;
 }
 
+static inline void prep_for_rmap_apply(struct bgp_path_info *dst_pi,
+				       struct bgp_path_info_extra *dst_pie,
+				       struct bgp_node *rn,
+				       struct bgp_path_info *src_pi,
+				       struct peer *peer, struct attr *attr)
+{
+	memset(dst_pi, 0, sizeof(struct bgp_path_info));
+	dst_pi->peer = peer;
+	dst_pi->attr = attr;
+	dst_pi->net = rn;
+	if (src_pi->extra) {
+		memcpy(dst_pie, src_pi->extra,
+		       sizeof(struct bgp_path_info_extra));
+		dst_pi->extra = dst_pie;
+	}
+}
+
 /* called before bgp_process() */
 DECLARE_HOOK(bgp_process,
 		(struct bgp *bgp, afi_t afi, safi_t safi,


### PR DESCRIPTION
Allow attributes to be manipulated (i.e., route-map 'set' commands) via the EVPN advertise route-map.