### PR TITLE
nhrpd: fix clear nhrp cache dynamic entries

### DIFF
--- a/nhrpd/nhrp_vty.c
+++ b/nhrpd/nhrp_vty.c
@@ -763,7 +763,7 @@ DEFUN(show_dmvpn, show_dmvpn_cmd,
 static void clear_nhrp_cache(struct nhrp_cache *c, void *data)
 {
 	struct info_ctx *ctx = data;
-	if (c->cur.type <= NHRP_CACHE_CACHED) {
+	if (c->cur.type <= NHRP_CACHE_DYNAMIC) {
 		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL);
 		ctx->count++;
 	}


### PR DESCRIPTION
as the helper said, the dynamic cache entries should be flushed once the
vty command 'clear ip/ipv6 nhrp cache' mentions. This was not the case.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>