### PR TITLE
tests: Increase some wait time in tests

### DIFF
--- a/tests/topotests/bfd-bgp-cbit-topo3/test_bfd_bgp_cbit_topo3.py
+++ b/tests/topotests/bfd-bgp-cbit-topo3/test_bfd_bgp_cbit_topo3.py
@@ -142,7 +142,7 @@ def test_bfd_connection():
 
         test_func = partial(topotest.router_json_cmp,
                             router, 'show bfd peers json', expected)
-        _, result = topotest.run_and_expect(test_func, None, count=8, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=16, wait=0.5)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 
@@ -173,7 +173,7 @@ def test_bfd_loss_intermediate():
 
         test_func = partial(topotest.router_json_cmp,
                             router, 'show bfd peers json', expected)
-        _, result = topotest.run_and_expect(test_func, None, count=8, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=16, wait=0.5)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
 
@@ -229,7 +229,7 @@ def test_bfd_comes_back_again():
 
         test_func = partial(topotest.router_json_cmp,
                             router, 'show bfd peers json', expected)
-        _, result = topotest.run_and_expect(test_func, None, count=8, wait=0.5)
+        _, result = topotest.run_and_expect(test_func, None, count=16, wait=0.5)
         assertmsg = '"{}" JSON output mismatches'.format(router.name)
         assert result is None, assertmsg
     


### PR DESCRIPTION
The bfd-bgp-cbit-topo3 test is testing bfd timers
with some timers that only wait 4 seconds.  The CI
system is failing in various places due to bfd
not converging properly.  Upon logging into a
CI system and running tests with intensive disk i/o
I was able to make the tests fail repeatedly in
a couple of different places.  Add some additional
time to allow the system to converge on our CI
systems that are running in vm's and may not
always have complete control of cpu's.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>