### PR TITLE
bgpd: use the right format specifier

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2659,7 +2659,7 @@ bgp_attr_parse_ret_t bgp_attr_prefix_sid(struct bgp_attr_parser_args *args,
 		if (STREAM_READABLE(peer->curr) < length) {
 			flog_err(
 				EC_BGP_ATTR_LEN,
-				"Malformed Prefix SID attribute - insufficient data (need %" PRIu8
+				"Malformed Prefix SID attribute - insufficient data (need %" PRIu16
 				" for attribute body, have %zu remaining in UPDATE)",
 				length, STREAM_READABLE(peer->curr));
 			return bgp_attr_malformed(args,


### PR DESCRIPTION
Fixes:
/Library/Developer/CommandLineTools/usr/bin/make  all-am
  CC       bgpd/bgp_attr.o
bgpd/bgp_attr.c:2664:5: warning: format specifies type 'unsigned char' but the argument has type 'uint16_t' (aka 'unsigned short') [-Wformat]
                                length, STREAM_READABLE(peer->curr));
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./lib/log.h:94:50: note: expanded from macro 'flog_err'
        zlog_err("[EC %" PRIu32 "] " format, ferr_id, ##__VA_ARGS__)
                                     ~~~~~~             ^~~~~~~~~~~
1 warning generated.

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>