### PR TITLE
pimd: In join suppression period, join is being sent

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -413,7 +413,8 @@ void pim_upstream_join_suppress(struct pim_upstream *up,
 				struct in_addr rpf_addr, int holdtime)
 {
 	long t_joinsuppress_msec;
-	long join_timer_remain_msec;
+	long join_timer_remain_msec = 0;
+	struct pim_neighbor *nbr = NULL;
 
 	if (!up->rpf.source_nexthop.interface) {
 		if (PIM_DEBUG_PIM_TRACE)
@@ -426,7 +427,18 @@ void pim_upstream_join_suppress(struct pim_upstream *up,
 		MIN(pim_if_t_suppressed_msec(up->rpf.source_nexthop.interface),
 		    1000 * holdtime);
 
-	join_timer_remain_msec = pim_time_timer_remain_msec(up->t_join_timer);
+	if (up->t_join_timer)
+		join_timer_remain_msec =
+			pim_time_timer_remain_msec(up->t_join_timer);
+	else {
+		/* Remove it from jp agg from the nbr for suppression */
+		nbr = pim_neighbor_find(up->rpf.source_nexthop.interface,
+					up->rpf.rpf_addr.u.prefix4);
+		if (nbr) {
+			join_timer_remain_msec =
+				pim_time_timer_remain_msec(nbr->jp_timer);
+		}
+	}
 
 	if (PIM_DEBUG_PIM_TRACE) {
 		char rpf_str[INET_ADDRSTRLEN];
@@ -444,6 +456,9 @@ void pim_upstream_join_suppress(struct pim_upstream *up,
 				__FILE__, __func__, up->sg_str,
 				t_joinsuppress_msec);
 		}
+
+		if (nbr)
+			pim_jp_agg_remove_group(nbr->upstream_jp_agg, up, nbr);
 
 		pim_upstream_join_timer_restart_msec(up, t_joinsuppress_msec);
 	}


### PR DESCRIPTION
RCA:
Either JP timer is used to send join or join timer.
We are not removing the group from jp aggregate during suppression.
So even if join timer is restarted, jp aggregate expiry during suppression
is sending join for the group.

Fix:
Remove the group from jp aggregate on the neighbor during jp suppression.

Signed-off-by: Saravanan K <saravanank@vmware.com>