### PR TITLE
pbrd: properly handle duplicate set vrf XX configs

### DIFF
--- a/pbrd/pbr_vty.c
+++ b/pbrd/pbr_vty.c
@@ -423,7 +423,6 @@ DEFPY(pbr_map_vrf, pbr_map_vrf_cmd,
       "Use the interface's VRF for lookup\n")
 {
 	struct pbr_map_sequence *pbrms = VTY_GET_CONTEXT(pbr_map_sequence);
-	int ret = CMD_SUCCESS;
 
 	if (no) {
 		pbr_map_delete_vrf(pbrms);
@@ -434,14 +433,13 @@ DEFPY(pbr_map_vrf, pbr_map_vrf_cmd,
 		pbrms->vrf_lookup = false;
 		pbrms->vrf_unchanged = false;
 
-		goto done;
+		return CMD_SUCCESS;
 	}
 
 	if (pbrms->nhgrp_name || pbrms->nhg) {
 		vty_out(vty,
 			"A `set nexthop/nexthop-group XX` command already exits, please remove that first\n");
-		ret = CMD_WARNING_CONFIG_FAILED;
-		goto done;
+		return CMD_WARNING_CONFIG_FAILED;
 	}
 
 	/*
@@ -459,11 +457,11 @@ DEFPY(pbr_map_vrf, pbr_map_vrf_cmd,
 		    != 0)
 			goto vrf_exists;
 
-		goto done;
+		return CMD_SUCCESS;
 
 	} else if (!vrf_name && pbrms->vrf_unchanged) {
 		/* Unchanged specified and unchanged already exists */
-		goto done;
+		return CMD_SUCCESS;
 
 	} else if (vrf_name && pbrms->vrf_unchanged) {
 		/* New vrf specified and unchanged is already set */
@@ -479,8 +477,7 @@ DEFPY(pbr_map_vrf, pbr_map_vrf_cmd,
 		if (!pbr_vrf_lookup_by_name(vrf_name)) {
 			vty_out(vty, "Specified: %s is non-existent\n",
 				vrf_name);
-			ret = CMD_WARNING_CONFIG_FAILED;
-			goto done;
+			return CMD_WARNING_CONFIG_FAILED;
 		}
 
 		pbrms->vrf_lookup = true;
@@ -490,13 +487,11 @@ DEFPY(pbr_map_vrf, pbr_map_vrf_cmd,
 
 	pbr_map_check(pbrms);
 
-done:
-	return ret;
+	return CMD_SUCCESS;
 
 vrf_exists:
 	vty_out(vty, SET_VRF_EXISTS_STR);
-	ret = CMD_WARNING_CONFIG_FAILED;
-	return ret;
+	return CMD_WARNING_CONFIG_FAILED;
 }
 
 DEFPY (pbr_policy,


### PR DESCRIPTION
Properly handle the case where we are sent the same `set vrf`
configs for a pbr map repeatedly. If we are sent the same
config, we return successfully without doing anyting.

If the config is different and its not a [no], then return failure
as we did before since we don't support atomic replace yet.

Before, we would fail anytime even if the config sent was the same
as is already there. This would cause frr-reload to mark as a
failure when it tried to re-apply the same config.

Signed-off-by: Stephen Worley <sworley@cumulusnetworks.com>