### PR TITLE
bgpd: Fixed snmp and bmp 'just Established' test. 

### DIFF
--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -664,8 +664,7 @@ static int bmp_peer_established(struct peer *peer)
 		return 0;
 
 	/* Check if this peer just went to Established */
-	if ((peer->last_major_event != OpenConfirm) ||
-	    !(peer_established(peer)))
+	if ((peer->ostatus != OpenConfirm) || !(peer_established(peer)))
 		return 0;
 
 	if (peer->doppelganger && (peer->doppelganger->status != Deleted)) {

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -858,7 +858,7 @@ static int bgpTrapEstablished(struct peer *peer)
 	oid index[sizeof(oid) * IN_ADDR_SIZE];
 
 	/* Check if this peer just went to Established */
-	if ((peer->last_major_event != OpenConfirm) || !(peer_established(peer)))
+	if ((peer->ostatus != OpenConfirm) || !(peer_established(peer)))
 		return 0;
 
 	ret = inet_aton(peer->host, &addr);


### PR DESCRIPTION
It was previously comparing an fsm event variable with an fsm status constant.

This fixes issue #5963.