### PR TITLE
pimd: Prune->noinfo state has to put off join expiry timer and delete ifchannel

### DIFF
--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -937,10 +937,13 @@ void pim_ifchannel_join_add(struct interface *ifp, struct in_addr neigh_addr,
 		THREAD_OFF(ch->t_ifjoin_expiry_timer);
 		break;
 	case PIM_IFJOIN_PRUNE:
-		if (source_flags & PIM_ENCODE_RPT_BIT)
+		if (source_flags & PIM_ENCODE_RPT_BIT) {
 			pim_ifchannel_ifjoin_switch(__func__, ch,
 						    PIM_IFJOIN_NOINFO);
-		else
+			THREAD_OFF(ch->t_ifjoin_expiry_timer);
+			delete_on_noinfo(ch);
+			return;
+		} else
 			pim_ifchannel_ifjoin_handler(ch, pim_ifp);
 		break;
 	case PIM_IFJOIN_PRUNE_PENDING:


### PR DESCRIPTION
Problem:
When the ifchannel is in SGRpt prune, if we receive a join, we go into no info
state but mroute still present with none oil

Join Prune Expiry timer on the ifchannel was still running when
Prune pending expired. This causes ifchannel not to be deleted and hence mroute.

Fix:
Stop expiry timer when we move into NOINFO state and delete the ifchannel.

Signed-off-by: Saravanan K <saravanank@vmware.com>