### PR TITLE
bgpd: Convert lots of int type functions to bool/void

### DIFF
--- a/bgpd/bgp_addpath.c
+++ b/bgpd/bgp_addpath.c
@@ -65,8 +65,8 @@ bgp_addpath_names(enum bgp_addpath_strat strat)
 /*
  * Returns if any peer is transmitting addpaths for a given afi/safi.
  */
-int bgp_addpath_is_addpath_used(struct bgp_addpath_bgp_data *d, afi_t afi,
-			      safi_t safi)
+bool bgp_addpath_is_addpath_used(struct bgp_addpath_bgp_data *d, afi_t afi,
+				 safi_t safi)
 {
 	return d->total_peercount[afi][safi] > 0;
 }
@@ -123,15 +123,15 @@ uint32_t bgp_addpath_id_for_peer(struct peer *peer, afi_t afi, safi_t safi,
  * Returns true if the path has an assigned addpath ID for any of the addpath
  * strategies.
  */
-int bgp_addpath_info_has_ids(struct bgp_addpath_info_data *d)
+bool bgp_addpath_info_has_ids(struct bgp_addpath_info_data *d)
 {
 	int i;
 
 	for (i = 0; i < BGP_ADDPATH_MAX; i++)
 		if (d->addpath_tx_id[i] != 0)
-			return 1;
+			return true;
 
-	return 0;
+	return false;
 }
 
 /*
@@ -152,7 +152,7 @@ void bgp_addpath_free_node_data(struct bgp_addpath_bgp_data *bd,
 /*
  * Check to see if the addpath strategy requires DMED to be configured to work.
  */
-int bgp_addpath_dmed_required(int strategy)
+bool bgp_addpath_dmed_required(int strategy)
 {
 	return strategy == BGP_ADDPATH_BEST_PER_AS;
 }
@@ -161,21 +161,20 @@ int bgp_addpath_dmed_required(int strategy)
  * Return true if this is a path we should advertise due to a
  * configured addpath-tx knob
  */
-int bgp_addpath_tx_path(enum bgp_addpath_strat strat,
-			    struct bgp_path_info *pi)
+bool bgp_addpath_tx_path(enum bgp_addpath_strat strat, struct bgp_path_info *pi)
 {
 	switch (strat) {
 	case BGP_ADDPATH_NONE:
-		return 0;
+		return false;
 	case BGP_ADDPATH_ALL:
-		return 1;
+		return true;
 	case BGP_ADDPATH_BEST_PER_AS:
 		if (CHECK_FLAG(pi->flags, BGP_PATH_DMED_SELECTED))
-			return 1;
+			return true;
 		else
-			return 0;
+			return false;
 	default:
-		return 0;
+		return false;
 	}
 }
 

--- a/bgpd/bgp_addpath.h
+++ b/bgpd/bgp_addpath.h
@@ -32,8 +32,8 @@
 
 void bgp_addpath_init_bgp_data(struct bgp_addpath_bgp_data *d);
 
-int bgp_addpath_is_addpath_used(struct bgp_addpath_bgp_data *d, afi_t afi,
-			      safi_t safi);
+bool bgp_addpath_is_addpath_used(struct bgp_addpath_bgp_data *d, afi_t afi,
+				 safi_t safi);
 
 void bgp_addpath_free_node_data(struct bgp_addpath_bgp_data *bd,
 			      struct bgp_addpath_node_data *nd,
@@ -43,7 +43,7 @@ void bgp_addpath_free_info_data(struct bgp_addpath_info_data *d,
 			      struct bgp_addpath_node_data *nd);
 
 
-int bgp_addpath_info_has_ids(struct bgp_addpath_info_data *d);
+bool bgp_addpath_info_has_ids(struct bgp_addpath_info_data *d);
 
 uint32_t bgp_addpath_id_for_peer(struct peer *peer, afi_t afi, safi_t safi,
 				struct bgp_addpath_info_data *d);
@@ -51,14 +51,14 @@ uint32_t bgp_addpath_id_for_peer(struct peer *peer, afi_t afi, safi_t safi,
 const struct bgp_addpath_strategy_names *
 bgp_addpath_names(enum bgp_addpath_strat strat);
 
-int bgp_addpath_dmed_required(int strategy);
+bool bgp_addpath_dmed_required(int strategy);
 
 /*
  * Return true if this is a path we should advertise due to a configured
  * addpath-tx knob
  */
-int bgp_addpath_tx_path(enum bgp_addpath_strat strat,
-			    struct bgp_path_info *pi);
+bool bgp_addpath_tx_path(enum bgp_addpath_strat strat,
+			 struct bgp_path_info *pi);
 /*
  * Change the type of addpath used for a peer.
  */

--- a/bgpd/bgp_advertise.c
+++ b/bgpd/bgp_advertise.c
@@ -144,8 +144,8 @@ void bgp_advertise_unintern(struct hash *hash, struct bgp_advertise_attr *baa)
 	}
 }
 
-int bgp_adj_out_lookup(struct peer *peer, struct bgp_node *rn,
-		       uint32_t addpath_tx_id)
+bool bgp_adj_out_lookup(struct peer *peer, struct bgp_node *rn,
+			uint32_t addpath_tx_id)
 {
 	struct bgp_adj_out *adj;
 	struct peer_af *paf;
@@ -169,11 +169,12 @@ int bgp_adj_out_lookup(struct peer *peer, struct bgp_node *rn,
 				    && adj->addpath_tx_id != addpath_tx_id)
 					continue;
 
-				return (adj->adv ? (adj->adv->baa ? 1 : 0)
-						 : (adj->attr ? 1 : 0));
+				return (adj->adv
+						? (adj->adv->baa ? true : false)
+						: (adj->attr ? true : false));
 			}
 
-	return 0;
+	return false;
 }
 
 
@@ -208,8 +209,8 @@ void bgp_adj_in_remove(struct bgp_node *rn, struct bgp_adj_in *bai)
 	XFREE(MTYPE_BGP_ADJ_IN, bai);
 }
 
-int bgp_adj_in_unset(struct bgp_node *rn, struct peer *peer,
-		     uint32_t addpath_id)
+bool bgp_adj_in_unset(struct bgp_node *rn, struct peer *peer,
+		      uint32_t addpath_id)
 {
 	struct bgp_adj_in *adj;
 	struct bgp_adj_in *adj_next;
@@ -217,7 +218,7 @@ int bgp_adj_in_unset(struct bgp_node *rn, struct peer *peer,
 	adj = rn->adj_in;
 
 	if (!adj)
-		return 0;
+		return false;
 
 	while (adj) {
 		adj_next = adj->next;
@@ -230,7 +231,7 @@ int bgp_adj_in_unset(struct bgp_node *rn, struct peer *peer,
 		adj = adj_next;
 	}
 
-	return 1;
+	return true;
 }
 
 void bgp_sync_init(struct peer *peer)

--- a/bgpd/bgp_advertise.h
+++ b/bgpd/bgp_advertise.h
@@ -139,10 +139,10 @@ struct bgp_synchronize {
 #define BGP_ADJ_IN_DEL(N, A) BGP_PATH_INFO_DEL(N, A, adj_in)
 
 /* Prototypes.  */
-extern int bgp_adj_out_lookup(struct peer *, struct bgp_node *, uint32_t);
+extern bool bgp_adj_out_lookup(struct peer *, struct bgp_node *, uint32_t);
 extern void bgp_adj_in_set(struct bgp_node *, struct peer *, struct attr *,
 			   uint32_t);
-extern int bgp_adj_in_unset(struct bgp_node *, struct peer *, uint32_t);
+extern bool bgp_adj_in_unset(struct bgp_node *, struct peer *, uint32_t);
 extern void bgp_adj_in_remove(struct bgp_node *, struct bgp_adj_in *);
 
 extern void bgp_sync_init(struct peer *);

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -333,7 +333,7 @@ extern unsigned long int attr_count(void);
 extern unsigned long int attr_unknown_count(void);
 
 /* Cluster list prototypes. */
-extern int cluster_loop_check(struct cluster_list *, struct in_addr);
+extern bool cluster_loop_check(struct cluster_list *, struct in_addr);
 extern void cluster_unintern(struct cluster_list *);
 
 /* Below exported for unit-test purposes only */

--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -54,25 +54,25 @@ void bgp_add_routermac_ecom(struct attr *attr, struct ethaddr *routermac)
  * format accepted: AA:BB:CC:DD:EE:FF:GG:HH:II:JJ
  * if id is null, check only is done
  */
-int str2esi(const char *str, struct eth_segment_id *id)
+bool str2esi(const char *str, struct eth_segment_id *id)
 {
 	unsigned int a[ESI_LEN];
 	int i;
 
 	if (!str)
-		return 0;
+		return false;
 	if (sscanf(str, "%2x:%2x:%2x:%2x:%2x:%2x:%2x:%2x:%2x:%2x", a + 0, a + 1,
 		   a + 2, a + 3, a + 4, a + 5, a + 6, a + 7, a + 8, a + 9)
 	    != ESI_LEN) {
 		/* error in incoming str length */
-		return 0;
+		return false;
 	}
 	/* valid mac address */
 	if (!id)
-		return 1;
+		return true;
 	for (i = 0; i < ESI_LEN; ++i)
 		id->val[i] = a[i] & 0xff;
-	return 1;
+	return true;
 }
 
 char *esi2str(struct eth_segment_id *id)

--- a/bgpd/bgp_attr_evpn.h
+++ b/bgpd/bgp_attr_evpn.h
@@ -51,7 +51,7 @@ struct bgp_route_evpn {
 	union gw_addr gw_ip;
 };
 
-extern int str2esi(const char *str, struct eth_segment_id *id);
+extern bool str2esi(const char *str, struct eth_segment_id *id);
 extern char *esi2str(struct eth_segment_id *id);
 extern char *ecom_mac2str(char *ecom_mac);
 

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -72,21 +72,21 @@ void bgp_bfd_peer_group2peer_copy(struct peer *conf, struct peer *peer)
  * bgp_bfd_is_peer_multihop - returns whether BFD peer is multi-hop or single
  * hop.
  */
-int bgp_bfd_is_peer_multihop(struct peer *peer)
+bool bgp_bfd_is_peer_multihop(struct peer *peer)
 {
 	struct bfd_info *bfd_info;
 
 	bfd_info = (struct bfd_info *)peer->bfd_info;
 
 	if (!bfd_info)
-		return 0;
+		return false;
 
 	if ((bfd_info->type == BFD_TYPE_MULTIHOP)
 	    || ((peer->sort == BGP_PEER_IBGP) && !peer->shared_network)
 	    || is_ebgp_multihop_configured(peer))
-		return 1;
+		return true;
 	else
-		return 0;
+		return false;
 }
 
 /*

--- a/bgpd/bgp_bfd.h
+++ b/bgpd/bgp_bfd.h
@@ -39,6 +39,6 @@ extern void bgp_bfd_peer_config_write(struct vty *vty, struct peer *peer,
 extern void bgp_bfd_show_info(struct vty *vty, struct peer *peer, bool use_json,
 			      json_object *json_neigh);
 
-extern int bgp_bfd_is_peer_multihop(struct peer *peer);
+extern bool bgp_bfd_is_peer_multihop(struct peer *peer);
 
 #endif /* _QUAGGA_BGP_BFD_H */

--- a/bgpd/bgp_btoa.c
+++ b/bgpd/bgp_btoa.c
@@ -68,7 +68,7 @@ enum MRT_MSG_TYPES {
 	MSG_TABLE_DUMP		  /* routing table dump */
 };
 
-static int attr_parse(struct stream *s, uint16_t len)
+static void attr_parse(struct stream *s, uint16_t len)
 {
 	unsigned int flag;
 	unsigned int type;
@@ -115,8 +115,6 @@ static int attr_parse(struct stream *s, uint16_t len)
 			break;
 		}
 	}
-
-	return 0;
 }
 
 int main(int argc, char **argv)

--- a/bgpd/bgp_community.c
+++ b/bgpd/bgp_community.c
@@ -128,7 +128,7 @@ static int community_compare(const void *a1, const void *a2)
 	return 0;
 }
 
-int community_include(struct community *com, uint32_t val)
+bool community_include(struct community *com, uint32_t val)
 {
 	int i;
 
@@ -136,9 +136,8 @@ int community_include(struct community *com, uint32_t val)
 
 	for (i = 0; i < com->size; i++)
 		if (memcmp(&val, com_nthval(com, i), sizeof(uint32_t)) == 0)
-			return 1;
-
-	return 0;
+			return true;
+	return false;
 }
 
 uint32_t community_val_get(struct community *com, int i)
@@ -564,19 +563,19 @@ unsigned int community_hash_make(const struct community *com)
 	return jhash2(pnt, com->size, 0x43ea96c1);
 }
 
-int community_match(const struct community *com1, const struct community *com2)
+bool community_match(const struct community *com1, const struct community *com2)
 {
 	int i = 0;
 	int j = 0;
 
 	if (com1 == NULL && com2 == NULL)
-		return 1;
+		return true;
 
 	if (com1 == NULL || com2 == NULL)
-		return 0;
+		return false;
 
 	if (com1->size < com2->size)
-		return 0;
+		return false;
 
 	/* Every community on com2 needs to be on com1 for this to match */
 	while (i < com1->size && j < com2->size) {
@@ -586,9 +585,9 @@ int community_match(const struct community *com1, const struct community *com2)
 	}
 
 	if (j == com2->size)
-		return 1;
+		return true;
 	else
-		return 0;
+		return false;
 }
 
 /* If two aspath have same value then return 1 else return 0. This

--- a/bgpd/bgp_community.h
+++ b/bgpd/bgp_community.h
@@ -77,7 +77,7 @@ extern void community_unintern(struct community **);
 extern char *community_str(struct community *, bool make_json);
 extern unsigned int community_hash_make(const struct community *);
 extern struct community *community_str2com(const char *);
-extern int community_match(const struct community *, const struct community *);
+extern bool community_match(const struct community *, const struct community *);
 extern bool community_cmp(const struct community *c1,
 			  const struct community *c2);
 extern struct community *community_merge(struct community *,
@@ -85,7 +85,7 @@ extern struct community *community_merge(struct community *,
 extern struct community *community_delete(struct community *,
 					  struct community *);
 extern struct community *community_dup(struct community *);
-extern int community_include(struct community *, uint32_t);
+extern bool community_include(struct community *, uint32_t);
 extern void community_del_val(struct community *, uint32_t *);
 extern unsigned long community_count(void);
 extern struct hash *community_hash(void);

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -157,8 +157,8 @@ struct bgp_debug_filter {
 
 extern const char *const bgp_type_str[];
 
-extern int bgp_dump_attr(struct attr *, char *, size_t);
-extern int bgp_debug_peer_updout_enabled(char *host);
+extern bool bgp_dump_attr(struct attr *, char *, size_t);
+extern bool bgp_debug_peer_updout_enabled(char *host);
 extern const char *bgp_notify_code_str(char);
 extern const char *bgp_notify_subcode_str(char, char);
 extern void bgp_notify_print(struct peer *, struct bgp_notify *, const char *);
@@ -166,10 +166,10 @@ extern void bgp_notify_print(struct peer *, struct bgp_notify *, const char *);
 extern const struct message bgp_status_msg[];
 extern int bgp_debug_neighbor_events(struct peer *peer);
 extern int bgp_debug_keepalive(struct peer *peer);
-extern int bgp_debug_update(struct peer *peer, struct prefix *p,
-			    struct update_group *updgrp, unsigned int inbound);
-extern int bgp_debug_bestpath(struct prefix *p);
-extern int bgp_debug_zebra(struct prefix *p);
+extern bool bgp_debug_update(struct peer *peer, struct prefix *p,
+			     struct update_group *updgrp, unsigned int inbound);
+extern bool bgp_debug_bestpath(struct prefix *p);
+extern bool bgp_debug_zebra(struct prefix *p);
 
 extern const char *bgp_debug_rdpfxpath2str(afi_t, safi_t, struct prefix_rd *,
 					   union prefixconstptr, mpls_label_t *,

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -165,22 +165,22 @@ extern unsigned int ecommunity_hash_make(const void *);
 extern struct ecommunity *ecommunity_str2com(const char *, int, int);
 extern char *ecommunity_ecom2str(struct ecommunity *, int, int);
 extern void ecommunity_strfree(char **s);
-extern int ecommunity_match(const struct ecommunity *,
-			    const struct ecommunity *);
+extern bool ecommunity_match(const struct ecommunity *,
+			     const struct ecommunity *);
 extern char *ecommunity_str(struct ecommunity *);
 extern struct ecommunity_val *ecommunity_lookup(const struct ecommunity *,
 						uint8_t, uint8_t);
-extern int ecommunity_add_val(struct ecommunity *ecom,
-			      struct ecommunity_val *eval);
+extern bool ecommunity_add_val(struct ecommunity *ecom,
+			       struct ecommunity_val *eval);
 
 /* for vpn */
 extern struct ecommunity *ecommunity_new(void);
-extern int ecommunity_add_val(struct ecommunity *, struct ecommunity_val *);
-extern int ecommunity_strip(struct ecommunity *ecom, uint8_t type,
-			    uint8_t subtype);
+extern bool ecommunity_add_val(struct ecommunity *, struct ecommunity_val *);
+extern bool ecommunity_strip(struct ecommunity *ecom, uint8_t type,
+			     uint8_t subtype);
 extern struct ecommunity *ecommunity_new(void);
-extern int ecommunity_del_val(struct ecommunity *ecom,
-			      struct ecommunity_val *eval);
+extern bool ecommunity_del_val(struct ecommunity *ecom,
+			       struct ecommunity_val *eval);
 struct bgp_pbr_entry_action;
 extern int ecommunity_fill_pbr_action(struct ecommunity_val *ecom_eval,
 			       struct bgp_pbr_entry_action *api);

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2210,13 +2210,13 @@ static struct bgpevpn *evpn_create_update_vni(struct bgp *bgp, vni_t vni)
  * appropriate action) and the VNI marked as unconfigured; the
  * VNI will continue to exist, purely as a "learnt" entity.
  */
-static int evpn_delete_vni(struct bgp *bgp, struct bgpevpn *vpn)
+static void evpn_delete_vni(struct bgp *bgp, struct bgpevpn *vpn)
 {
 	assert(bgp->vnihash);
 
 	if (!is_vni_live(vpn)) {
 		bgp_evpn_free(bgp, vpn);
-		return 0;
+		return;
 	}
 
 	/* We need to take the unconfigure action for each parameter of this VNI
@@ -2234,8 +2234,6 @@ static int evpn_delete_vni(struct bgp *bgp, struct bgpevpn *vpn)
 	/* Next, deal with the import side. */
 	if (is_import_rt_configured(vpn))
 		evpn_unconfigure_import_rt(bgp, vpn, NULL);
-
-	return 0;
 }
 
 /*

--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -302,12 +302,9 @@ static void as_list_delete(struct as_list *aslist)
 	as_list_free(aslist);
 }
 
-static int as_list_empty(struct as_list *aslist)
+static bool as_list_empty(struct as_list *aslist)
 {
-	if (aslist->head == NULL && aslist->tail == NULL)
-		return 1;
-	else
-		return 0;
+	return aslist->head == NULL && aslist->tail == NULL;
 }
 
 static void as_list_filter_delete(struct as_list *aslist,
@@ -337,11 +334,9 @@ static void as_list_filter_delete(struct as_list *aslist,
 	XFREE(MTYPE_AS_STR, name);
 }
 
-static int as_filter_match(struct as_filter *asfilter, struct aspath *aspath)
+static bool as_filter_match(struct as_filter *asfilter, struct aspath *aspath)
 {
-	if (bgp_regexec(asfilter->reg, aspath) != REG_NOMATCH)
-		return 1;
-	return 0;
+	return bgp_regexec(asfilter->reg, aspath) != REG_NOMATCH;
 }
 
 /* Apply AS path filter to AS. */
@@ -374,26 +369,25 @@ void as_list_delete_hook(void (*func)(const char *))
 	as_list_master.delete_hook = func;
 }
 
-static int as_list_dup_check(struct as_list *aslist, struct as_filter *new)
+static bool as_list_dup_check(struct as_list *aslist, struct as_filter *new)
 {
 	struct as_filter *asfilter;
 
 	for (asfilter = aslist->head; asfilter; asfilter = asfilter->next) {
 		if (asfilter->type == new->type
 		    && strcmp(asfilter->reg_str, new->reg_str) == 0)
-			return 1;
+			return true;
 	}
-	return 0;
+	return false;
 }
 
-int config_bgp_aspath_validate(const char *regstr)
+bool config_bgp_aspath_validate(const char *regstr)
 {
 	char valid_chars[] = "1234567890_^|[,{}() ]$*+.?-\\";
 
 	if (strspn(regstr, valid_chars) == strlen(regstr))
-		return 1;
-
-	return 0;
+		return true;
+	return false;
 }
 
 DEFUN(as_path, bgp_as_path_cmd,

--- a/bgpd/bgp_filter.h
+++ b/bgpd/bgp_filter.h
@@ -31,6 +31,6 @@ extern enum as_filter_type as_list_apply(struct as_list *, void *);
 extern struct as_list *as_list_lookup(const char *);
 extern void as_list_add_hook(void (*func)(char *));
 extern void as_list_delete_hook(void (*func)(const char *));
-extern int config_bgp_aspath_validate(const char *regstr);
+extern bool config_bgp_aspath_validate(const char *regstr);
 
 #endif /* _QUAGGA_BGP_FILTER_H */

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -599,8 +599,8 @@ int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 }
 
 /* return 1 if FS entry invalid or no NH IP */
-int bgp_flowspec_get_first_nh(struct bgp *bgp, struct bgp_path_info *pi,
-			      struct prefix *p)
+bool bgp_flowspec_get_first_nh(struct bgp *bgp, struct bgp_path_info *pi,
+			       struct prefix *p)
 {
 	struct bgp_pbr_entry_main api;
 	int i;
@@ -609,7 +609,7 @@ int bgp_flowspec_get_first_nh(struct bgp *bgp, struct bgp_path_info *pi,
 
 	memset(&api, 0, sizeof(struct bgp_pbr_entry_main));
 	if (bgp_pbr_build_and_validate_entry(&rn->p, pi, &api) < 0)
-		return 1;
+		return true;
 	for (i = 0; i < api.action_num; i++) {
 		api_action = &api.actions[i];
 		if (api_action->action != ACTION_REDIRECT_IP)
@@ -617,7 +617,7 @@ int bgp_flowspec_get_first_nh(struct bgp *bgp, struct bgp_path_info *pi,
 		p->family = AF_INET;
 		p->prefixlen = IPV4_MAX_BITLEN;
 		p->u.prefix4 = api_action->u.zr.redirect_ip_v4;
-		return 0;
+		return false;
 	}
-	return 1;
+	return true;
 }

--- a/bgpd/bgp_flowspec_util.h
+++ b/bgpd/bgp_flowspec_util.h
@@ -54,8 +54,7 @@ extern bool bgp_flowspec_contains_prefix(struct prefix *pfs,
 					 struct prefix *input,
 					 int prefix_check);
 
-extern int bgp_flowspec_get_first_nh(struct bgp *bgp,
-				     struct bgp_path_info *pi,
-				     struct prefix *nh);
+extern bool bgp_flowspec_get_first_nh(struct bgp *bgp, struct bgp_path_info *pi,
+				      struct prefix *nh);
 
 #endif /* _FRR_BGP_FLOWSPEC_UTIL_H */

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -664,32 +664,29 @@ static int bgp_graceful_deferral_timer_expire(struct thread *thread)
 	return bgp_best_path_select_defer(bgp, afi, safi);
 }
 
-static int bgp_update_delay_applicable(struct bgp *bgp)
+static bool bgp_update_delay_applicable(struct bgp *bgp)
 {
 	/* update_delay_over flag should be reset (set to 0) for any new
 	   applicability of the update-delay during BGP process lifetime.
 	   And it should be set after an occurence of the update-delay is
 	   over)*/
 	if (!bgp->update_delay_over)
-		return 1;
-
-	return 0;
+		return true;
+	return false;
 }
 
-int bgp_update_delay_active(struct bgp *bgp)
+bool bgp_update_delay_active(struct bgp *bgp)
 {
 	if (bgp->t_update_delay)
-		return 1;
-
-	return 0;
+		return true;
+	return false;
 }
 
-int bgp_update_delay_configured(struct bgp *bgp)
+bool bgp_update_delay_configured(struct bgp *bgp)
 {
 	if (bgp->v_update_delay)
-		return 1;
-
-	return 0;
+		return true;
+	return false;
 }
 
 /* Do the post-processing needed when bgp comes out of the read-only mode
@@ -840,28 +837,25 @@ void bgp_adjust_routeadv(struct peer *peer)
 	}
 }
 
-static int bgp_maxmed_onstartup_applicable(struct bgp *bgp)
+static bool bgp_maxmed_onstartup_applicable(struct bgp *bgp)
 {
 	if (!bgp->maxmed_onstartup_over)
-		return 1;
-
-	return 0;
+		return true;
+	return false;
 }
 
-int bgp_maxmed_onstartup_configured(struct bgp *bgp)
+bool bgp_maxmed_onstartup_configured(struct bgp *bgp)
 {
 	if (bgp->v_maxmed_onstartup != BGP_MAXMED_ONSTARTUP_UNCONFIGURED)
-		return 1;
-
-	return 0;
+		return true;
+	return false;
 }
 
-int bgp_maxmed_onstartup_active(struct bgp *bgp)
+bool bgp_maxmed_onstartup_active(struct bgp *bgp)
 {
 	if (bgp->t_maxmed_onstartup)
-		return 1;
-
-	return 0;
+		return true;
+	return false;
 }
 
 void bgp_maxmed_update(struct bgp *bgp)

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -119,8 +119,8 @@ extern void bgp_fsm_change_status(struct peer *peer, int status);
 extern const char *const peer_down_str[];
 extern void bgp_update_delay_end(struct bgp *);
 extern void bgp_maxmed_update(struct bgp *);
-extern int bgp_maxmed_onstartup_configured(struct bgp *);
-extern int bgp_maxmed_onstartup_active(struct bgp *);
+extern bool bgp_maxmed_onstartup_configured(struct bgp *);
+extern bool bgp_maxmed_onstartup_active(struct bgp *);
 extern int bgp_fsm_error_subcode(int status);
 
 /**

--- a/bgpd/bgp_lcommunity.c
+++ b/bgpd/bgp_lcommunity.c
@@ -59,8 +59,8 @@ static void lcommunity_hash_free(struct lcommunity *lcom)
    structure, we don't add the value.  Newly added value is sorted by
    numerical order.  When the value is added to the structure return 1
    else return 0.  */
-static int lcommunity_add_val(struct lcommunity *lcom,
-			      struct lcommunity_val *lval)
+static bool lcommunity_add_val(struct lcommunity *lcom,
+			       struct lcommunity_val *lval)
 {
 	uint8_t *p;
 	int ret;
@@ -71,7 +71,7 @@ static int lcommunity_add_val(struct lcommunity *lcom,
 		lcom->size++;
 		lcom->val = XMALLOC(MTYPE_LCOMMUNITY_VAL, lcom_length(lcom));
 		memcpy(lcom->val, lval->val, LCOMMUNITY_SIZE);
-		return 1;
+		return true;
 	}
 
 	/* If the value already exists in the structure return 0.  */
@@ -79,7 +79,7 @@ static int lcommunity_add_val(struct lcommunity *lcom,
 	for (p = lcom->val; c < lcom->size; p += LCOMMUNITY_SIZE, c++) {
 		ret = memcmp(p, lval->val, LCOMMUNITY_SIZE);
 		if (ret == 0)
-			return 0;
+			return false;
 		if (ret > 0)
 			break;
 	}
@@ -94,7 +94,7 @@ static int lcommunity_add_val(struct lcommunity *lcom,
 		(lcom->size - 1 - c) * LCOMMUNITY_SIZE);
 	memcpy(lcom->val + c * LCOMMUNITY_SIZE, lval->val, LCOMMUNITY_SIZE);
 
-	return 1;
+	return true;
 }
 
 /* This function takes pointer to Large Communites strucutre then
@@ -456,7 +456,7 @@ struct lcommunity *lcommunity_str2com(const char *str)
 	return lcom;
 }
 
-int lcommunity_include(struct lcommunity *lcom, uint8_t *ptr)
+bool lcommunity_include(struct lcommunity *lcom, uint8_t *ptr)
 {
 	int i;
 	uint8_t *lcom_ptr;
@@ -464,25 +464,25 @@ int lcommunity_include(struct lcommunity *lcom, uint8_t *ptr)
 	for (i = 0; i < lcom->size; i++) {
 		lcom_ptr = lcom->val + (i * LCOMMUNITY_SIZE);
 		if (memcmp(ptr, lcom_ptr, LCOMMUNITY_SIZE) == 0)
-			return 1;
+			return true;
 	}
-	return 0;
+	return false;
 }
 
-int lcommunity_match(const struct lcommunity *lcom1,
-		     const struct lcommunity *lcom2)
+bool lcommunity_match(const struct lcommunity *lcom1,
+		      const struct lcommunity *lcom2)
 {
 	int i = 0;
 	int j = 0;
 
 	if (lcom1 == NULL && lcom2 == NULL)
-		return 1;
+		return true;
 
 	if (lcom1 == NULL || lcom2 == NULL)
-		return 0;
+		return false;
 
 	if (lcom1->size < lcom2->size)
-		return 0;
+		return false;
 
 	/* Every community on com2 needs to be on com1 for this to match */
 	while (i < lcom1->size && j < lcom2->size) {
@@ -494,9 +494,9 @@ int lcommunity_match(const struct lcommunity *lcom1,
 	}
 
 	if (j == lcom2->size)
-		return 1;
+		return true;
 	else
-		return 0;
+		return false;
 }
 
 /* Delete one lcommunity. */

--- a/bgpd/bgp_lcommunity.h
+++ b/bgpd/bgp_lcommunity.h
@@ -66,10 +66,10 @@ extern void lcommunity_unintern(struct lcommunity **);
 extern unsigned int lcommunity_hash_make(const void *);
 extern struct hash *lcommunity_hash(void);
 extern struct lcommunity *lcommunity_str2com(const char *);
-extern int lcommunity_match(const struct lcommunity *,
-			    const struct lcommunity *);
+extern bool lcommunity_match(const struct lcommunity *,
+			     const struct lcommunity *);
 extern char *lcommunity_str(struct lcommunity *, bool make_json);
-extern int lcommunity_include(struct lcommunity *lcom, uint8_t *ptr);
+extern bool lcommunity_include(struct lcommunity *lcom, uint8_t *ptr);
 extern void lcommunity_del_val(struct lcommunity *lcom, uint8_t *ptr);
 
 extern void bgp_compute_aggregate_lcommunity(

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -385,13 +385,13 @@ int vpn_leak_label_callback(
 	return 0;
 }
 
-static int ecom_intersect(struct ecommunity *e1, struct ecommunity *e2)
+static bool ecom_intersect(struct ecommunity *e1, struct ecommunity *e2)
 {
 	int i;
 	int j;
 
 	if (!e1 || !e2)
-		return 0;
+		return false;
 
 	for (i = 0; i < e1->size; ++i) {
 		for (j = 0; j < e2->size; ++j) {
@@ -399,11 +399,11 @@ static int ecom_intersect(struct ecommunity *e1, struct ecommunity *e2)
 				    e2->val + (j * ECOMMUNITY_SIZE),
 				    ECOMMUNITY_SIZE)) {
 
-				return 1;
+				return true;
 			}
 		}
 	}
-	return 0;
+	return false;
 }
 
 static bool labels_same(struct bgp_path_info *bpi, mpls_label_t *label,

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -81,18 +81,19 @@ struct bgp_addrv6 {
 
 extern void bgp_connected_add(struct bgp *bgp, struct connected *c);
 extern void bgp_connected_delete(struct bgp *bgp, struct connected *c);
-extern int bgp_subgrp_multiaccess_check_v4(struct in_addr nexthop,
-					   struct update_subgroup *subgrp,
-					   struct peer *exclude);
-extern int bgp_subgrp_multiaccess_check_v6(struct in6_addr nexthop,
-					   struct update_subgroup *subgrp,
-					   struct peer *exclude);
-extern int bgp_multiaccess_check_v4(struct in_addr nexthop, struct peer *peer);
-extern int bgp_multiaccess_check_v6(struct in6_addr nexthop, struct peer *peer);
+extern bool bgp_subgrp_multiaccess_check_v4(struct in_addr nexthop,
+					    struct update_subgroup *subgrp,
+					    struct peer *exclude);
+extern bool bgp_subgrp_multiaccess_check_v6(struct in6_addr nexthop,
+					    struct update_subgroup *subgrp,
+					    struct peer *exclude);
+extern bool bgp_multiaccess_check_v4(struct in_addr nexthop, struct peer *peer);
+extern bool bgp_multiaccess_check_v6(struct in6_addr nexthop,
+				     struct peer *peer);
 extern int bgp_config_write_scan_time(struct vty *);
-extern int bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
-				uint8_t sub_type, struct attr *attr,
-				struct bgp_node *rn);
+extern bool bgp_nexthop_self(struct bgp *bgp, afi_t afi, uint8_t type,
+			     uint8_t sub_type, struct attr *attr,
+			     struct bgp_node *rn);
 extern struct bgp_nexthop_cache *bnc_new(void);
 extern void bnc_free(struct bgp_nexthop_cache *bnc);
 extern void bnc_nexthop_free(struct bgp_nexthop_cache *bnc);

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1013,15 +1013,15 @@ static int bgp_auth_parse(struct peer *peer, size_t length)
 	return -1;
 }
 
-static int strict_capability_same(struct peer *peer)
+static bool strict_capability_same(struct peer *peer)
 {
 	int i, j;
 
 	for (i = AFI_IP; i < AFI_MAX; i++)
 		for (j = SAFI_UNICAST; j < SAFI_MAX; j++)
 			if (peer->afc[i][j] != peer->afc_nego[i][j])
-				return 0;
-	return 1;
+				return false;
+	return true;
 }
 
 /* peek into option, stores ASN to *as4 if the AS4 capability was found.

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -587,7 +587,7 @@ void bgp_open_send(struct peer *peer)
  * @param peer
  * @return 0
  */
-static int bgp_write_notify(struct peer *peer)
+static void bgp_write_notify(struct peer *peer)
 {
 	int ret, val;
 	uint8_t type;
@@ -597,7 +597,7 @@ static int bgp_write_notify(struct peer *peer)
 	s = stream_fifo_pop(peer->obuf);
 
 	if (!s)
-		return 0;
+		return;
 
 	assert(stream_get_endp(s) >= BGP_HEADER_SIZE);
 
@@ -617,7 +617,7 @@ static int bgp_write_notify(struct peer *peer)
 	if (ret <= 0) {
 		stream_free(s);
 		BGP_EVENT_ADD(peer, TCP_fatal_error);
-		return 0;
+		return;
 	}
 
 	/* Disable Nagle, make NOTIFY packet go out right away */
@@ -649,8 +649,6 @@ static int bgp_write_notify(struct peer *peer)
 	BGP_EVENT_ADD(peer, BGP_Stop);
 
 	stream_free(s);
-
-	return 0;
 }
 
 /*

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -506,8 +506,8 @@ extern void bgp_clear_route(struct peer *, afi_t, safi_t);
 extern void bgp_clear_route_all(struct peer *);
 extern void bgp_clear_adj_in(struct peer *, afi_t, safi_t);
 extern void bgp_clear_stale_route(struct peer *, afi_t, safi_t);
-extern int bgp_outbound_policy_exists(struct peer *, struct bgp_filter *);
-extern int bgp_inbound_policy_exists(struct peer *, struct bgp_filter *);
+extern bool bgp_outbound_policy_exists(struct peer *, struct bgp_filter *);
+extern bool bgp_inbound_policy_exists(struct peer *, struct bgp_filter *);
 
 extern struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
 					 safi_t safi, struct prefix *p,
@@ -529,7 +529,7 @@ extern void bgp_path_info_path_with_addpath_rx_str(struct bgp_path_info *pi,
 
 extern int bgp_nlri_parse_ip(struct peer *, struct attr *, struct bgp_nlri *);
 
-extern int bgp_maximum_prefix_overflow(struct peer *, afi_t, safi_t, int);
+extern bool bgp_maximum_prefix_overflow(struct peer *, afi_t, safi_t, int);
 
 extern void bgp_redistribute_add(struct bgp *bgp, struct prefix *p,
 				 const union g_addr *nexthop, ifindex_t ifindex,
@@ -614,15 +614,15 @@ extern void route_vty_out_overlay(struct vty *vty, struct prefix *p,
 				  struct bgp_path_info *path, int display,
 				  json_object *json);
 
-extern int subgroup_process_announce_selected(struct update_subgroup *subgrp,
-					      struct bgp_path_info *selected,
-					      struct bgp_node *rn,
-					      uint32_t addpath_tx_id);
+extern void subgroup_process_announce_selected(struct update_subgroup *subgrp,
+					       struct bgp_path_info *selected,
+					       struct bgp_node *rn,
+					       uint32_t addpath_tx_id);
 
-extern int subgroup_announce_check(struct bgp_node *rn,
-				   struct bgp_path_info *pi,
-				   struct update_subgroup *subgrp,
-				   struct prefix *p, struct attr *attr);
+extern bool subgroup_announce_check(struct bgp_node *rn,
+				    struct bgp_path_info *pi,
+				    struct update_subgroup *subgrp,
+				    struct prefix *p, struct attr *attr);
 
 extern void bgp_peer_clear_node_queue_drain_immediate(struct peer *peer);
 extern void bgp_process_queues_drain_immediate(void);
@@ -646,8 +646,8 @@ extern void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 			       struct bgp_path_info_pair *result, afi_t afi,
 			       safi_t safi);
 extern void bgp_zebra_clear_route_change_flags(struct bgp_node *rn);
-extern int bgp_zebra_has_route_changed(struct bgp_node *rn,
-				       struct bgp_path_info *selected);
+extern bool bgp_zebra_has_route_changed(struct bgp_node *rn,
+					struct bgp_path_info *selected);
 
 extern void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 					struct bgp_node *rn,

--- a/bgpd/bgp_updgrp.h
+++ b/bgpd/bgp_updgrp.h
@@ -373,9 +373,9 @@ extern void update_subgroup_remove_peer(struct update_subgroup *,
 					struct peer_af *);
 extern struct bgp_table *update_subgroup_rib(struct update_subgroup *);
 extern void update_subgroup_split_peer(struct peer_af *, struct update_group *);
-extern int update_subgroup_check_merge(struct update_subgroup *, const char *);
-extern int update_subgroup_trigger_merge_check(struct update_subgroup *,
-					       int force);
+extern bool update_subgroup_check_merge(struct update_subgroup *, const char *);
+extern bool update_subgroup_trigger_merge_check(struct update_subgroup *,
+						int force);
 extern void update_group_policy_update(struct bgp *bgp, bgp_policy_type_e ptype,
 				       const char *pname, int route_update,
 				       int start_event);
@@ -404,13 +404,13 @@ extern struct bpacket *bpacket_queue_first(struct bpacket_queue *q);
 struct bpacket *bpacket_queue_last(struct bpacket_queue *q);
 unsigned int bpacket_queue_length(struct bpacket_queue *q);
 unsigned int bpacket_queue_hwm_length(struct bpacket_queue *q);
-int bpacket_queue_is_full(struct bgp *bgp, struct bpacket_queue *q);
+bool bpacket_queue_is_full(struct bgp *bgp, struct bpacket_queue *q);
 extern void bpacket_queue_advance_peer(struct peer_af *paf);
 extern void bpacket_queue_remove_peer(struct peer_af *paf);
 extern void bpacket_add_peer(struct bpacket *pkt, struct peer_af *paf);
 unsigned int bpacket_queue_virtual_length(struct peer_af *paf);
 extern void bpacket_queue_show_vty(struct bpacket_queue *q, struct vty *vty);
-int subgroup_packets_to_build(struct update_subgroup *subgrp);
+bool subgroup_packets_to_build(struct update_subgroup *subgrp);
 extern struct bpacket *subgroup_update_packet(struct update_subgroup *s);
 extern struct bpacket *subgroup_withdraw_packet(struct update_subgroup *s);
 extern struct stream *bpacket_reformat_for_peer(struct bpacket *pkt,

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -226,11 +226,11 @@ unsigned int bpacket_queue_hwm_length(struct bpacket_queue *q)
 	return q->hwm_count - 1;
 }
 
-int bpacket_queue_is_full(struct bgp *bgp, struct bpacket_queue *q)
+bool bpacket_queue_is_full(struct bgp *bgp, struct bpacket_queue *q)
 {
 	if (q->curr_count >= bgp->default_subgroup_pkt_queue_max)
-		return 1;
-	return 0;
+		return true;
+	return false;
 }
 
 void bpacket_add_peer(struct bpacket *pkt, struct peer_af *paf)
@@ -656,22 +656,22 @@ static void bpacket_attr_vec_arr_update(struct bpacket_attr_vec_arr *vecarr,
 /*
  * Return if there are packets to build for this subgroup.
  */
-int subgroup_packets_to_build(struct update_subgroup *subgrp)
+bool subgroup_packets_to_build(struct update_subgroup *subgrp)
 {
 	struct bgp_advertise *adv;
 
 	if (!subgrp)
-		return 0;
+		return false;
 
 	adv = bgp_adv_fifo_first(&subgrp->sync->withdraw);
 	if (adv)
-		return 1;
+		return true;
 
 	adv = bgp_adv_fifo_first(&subgrp->sync->update);
 	if (adv)
-		return 1;
+		return true;
 
-	return 0;
+	return false;
 }
 
 /* Make BGP update packet.  */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -533,7 +533,7 @@ int bgp_vty_find_and_parse_afi_safi_bgp(struct vty *vty,
 	return *idx;
 }
 
-static int peer_address_self_check(struct bgp *bgp, union sockunion *su)
+static bool peer_address_self_check(struct bgp *bgp, union sockunion *su)
 {
 	struct interface *ifp = NULL;
 
@@ -545,9 +545,9 @@ static int peer_address_self_check(struct bgp *bgp, union sockunion *su)
 					      bgp->vrf_id);
 
 	if (ifp)
-		return 1;
+		return true;
 
-	return 0;
+	return false;
 }
 
 /* Utility function for looking up peer from VTY.  */
@@ -14086,7 +14086,8 @@ static bool peergroup_filter_check(struct peer *peer, afi_t afi, safi_t safi,
 /* Return true if the addpath type is set for peer and different from
  * peer-group.
  */
-static int peergroup_af_addpath_check(struct peer *peer, afi_t afi, safi_t safi)
+static bool peergroup_af_addpath_check(struct peer *peer, afi_t afi,
+				       safi_t safi)
 {
 	enum bgp_addpath_strat type, g_type;
 
@@ -14097,15 +14098,15 @@ static int peergroup_af_addpath_check(struct peer *peer, afi_t afi, safi_t safi)
 			g_type = peer->group->conf->addpath_type[afi][safi];
 
 			if (type != g_type)
-				return 1;
+				return true;
 			else
-				return 0;
+				return false;
 		}
 
-		return 1;
+		return true;
 	}
 
-	return 0;
+	return false;
 }
 
 /* This is part of the address-family block (unicast only) */

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -53,10 +53,10 @@ extern struct bgp_redist *bgp_redist_add(struct bgp *, afi_t, uint8_t,
 extern int bgp_redistribute_set(struct bgp *, afi_t, int, unsigned short,
 				bool changed);
 extern int bgp_redistribute_resend(struct bgp *, afi_t, int, unsigned short);
-extern int bgp_redistribute_rmap_set(struct bgp_redist *red, const char *name,
-				     struct route_map *route_map);
-extern int bgp_redistribute_metric_set(struct bgp *, struct bgp_redist *, afi_t,
-				       int, uint32_t);
+extern bool bgp_redistribute_rmap_set(struct bgp_redist *red, const char *name,
+				      struct route_map *route_map);
+extern bool bgp_redistribute_metric_set(struct bgp *, struct bgp_redist *,
+					afi_t, int, uint32_t);
 extern int bgp_redistribute_unset(struct bgp *, afi_t, int, unsigned short);
 extern int bgp_redistribute_unreg(struct bgp *, afi_t, int, unsigned short);
 

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1742,8 +1742,8 @@ extern struct peer *peer_unlock_with_caller(const char *, struct peer *);
 extern bgp_peer_sort_t peer_sort(struct peer *peer);
 extern bgp_peer_sort_t peer_sort_lookup(struct peer *peer);
 
-extern int peer_active(struct peer *);
-extern int peer_active_nego(struct peer *);
+extern bool peer_active(struct peer *);
+extern bool peer_active_nego(struct peer *);
 extern void bgp_recalculate_all_bestpaths(struct bgp *bgp);
 extern struct peer *peer_create(union sockunion *, const char *, struct bgp *,
 				as_t, as_t, int, afi_t, safi_t,
@@ -1777,21 +1777,21 @@ extern int bgp_handle_socket(struct bgp *bgp, struct vrf *vrf,
 			     vrf_id_t old_vrf_id, bool create);
 
 extern void bgp_router_id_zebra_bump(vrf_id_t, const struct prefix *);
-extern int bgp_router_id_static_set(struct bgp *, struct in_addr);
+extern void bgp_router_id_static_set(struct bgp *, struct in_addr);
 
 extern int bgp_cluster_id_set(struct bgp *, struct in_addr *);
 extern int bgp_cluster_id_unset(struct bgp *);
 
 extern int bgp_confederation_id_set(struct bgp *, as_t);
 extern int bgp_confederation_id_unset(struct bgp *);
-extern int bgp_confederation_peers_check(struct bgp *, as_t);
+extern bool bgp_confederation_peers_check(struct bgp *, as_t);
 
 extern int bgp_confederation_peers_add(struct bgp *, as_t);
 extern int bgp_confederation_peers_remove(struct bgp *, as_t);
 
-extern int bgp_timers_set(struct bgp *, uint32_t keepalive, uint32_t holdtime,
-			  uint32_t connect_retry);
-extern int bgp_timers_unset(struct bgp *);
+extern void bgp_timers_set(struct bgp *, uint32_t keepalive, uint32_t holdtime,
+			   uint32_t connect_retry);
+extern void bgp_timers_unset(struct bgp *);
 
 extern int bgp_default_local_preference_set(struct bgp *, uint32_t);
 extern int bgp_default_local_preference_unset(struct bgp *);
@@ -1802,19 +1802,19 @@ extern int bgp_default_subgroup_pkt_queue_max_unset(struct bgp *bgp);
 extern int bgp_listen_limit_set(struct bgp *, int);
 extern int bgp_listen_limit_unset(struct bgp *);
 
-extern int bgp_update_delay_active(struct bgp *);
-extern int bgp_update_delay_configured(struct bgp *);
+extern bool bgp_update_delay_active(struct bgp *);
+extern bool bgp_update_delay_configured(struct bgp *);
 extern int bgp_afi_safi_peer_exists(struct bgp *bgp, afi_t afi, safi_t safi);
 extern void peer_as_change(struct peer *, as_t, int);
 extern int peer_remote_as(struct bgp *, union sockunion *, const char *, as_t *,
 			  int, afi_t, safi_t);
 extern int peer_group_remote_as(struct bgp *, const char *, as_t *, int);
 extern int peer_delete(struct peer *peer);
-extern int peer_notify_unconfig(struct peer *peer);
+extern void peer_notify_unconfig(struct peer *peer);
 extern int peer_group_delete(struct peer_group *);
 extern int peer_group_remote_as_delete(struct peer_group *);
 extern int peer_group_listen_range_add(struct peer_group *, struct prefix *);
-extern int peer_group_notify_unconfig(struct peer_group *group);
+extern void peer_group_notify_unconfig(struct peer_group *group);
 
 extern int peer_activate(struct peer *, afi_t, safi_t);
 extern int peer_deactivate(struct peer *, afi_t, safi_t);
@@ -1839,8 +1839,8 @@ extern int peer_ebgp_multihop_set(struct peer *, int);
 extern int peer_ebgp_multihop_unset(struct peer *);
 extern int is_ebgp_multihop_configured(struct peer *peer);
 
-extern int peer_description_set(struct peer *, const char *);
-extern int peer_description_unset(struct peer *);
+extern void peer_description_set(struct peer *, const char *);
+extern void peer_description_unset(struct peer *);
 
 extern int peer_update_source_if_set(struct peer *, const char *);
 extern int peer_update_source_addr_set(struct peer *, const union sockunion *);
@@ -1851,8 +1851,8 @@ extern int peer_default_originate_set(struct peer *peer, afi_t afi, safi_t safi,
 				      struct route_map *route_map);
 extern int peer_default_originate_unset(struct peer *, afi_t, safi_t);
 
-extern int peer_port_set(struct peer *, uint16_t);
-extern int peer_port_unset(struct peer *);
+extern void peer_port_set(struct peer *, uint16_t);
+extern void peer_port_unset(struct peer *);
 
 extern int peer_weight_set(struct peer *, afi_t, safi_t, uint16_t);
 extern int peer_weight_unset(struct peer *, afi_t, safi_t);
@@ -1909,8 +1909,8 @@ extern int peer_clear_soft(struct peer *, afi_t, safi_t, enum bgp_clear_type);
 extern int peer_ttl_security_hops_set(struct peer *, int);
 extern int peer_ttl_security_hops_unset(struct peer *);
 
-extern int peer_tx_shutdown_message_set(struct peer *, const char *msg);
-extern int peer_tx_shutdown_message_unset(struct peer *);
+extern void peer_tx_shutdown_message_set(struct peer *, const char *msg);
+extern void peer_tx_shutdown_message_unset(struct peer *);
 
 extern int bgp_route_map_update_timer(struct thread *thread);
 extern void bgp_route_map_terminate(void);

--- a/tools/coccinelle/int_to_bool_function.cocci
+++ b/tools/coccinelle/int_to_bool_function.cocci
@@ -1,0 +1,24 @@
+@@
+identifier fn;
+typedef bool;
+symbol false;
+symbol true;
+identifier I;
+struct thread *thread;
+@@
+
+- int
++ bool
+fn (...)
+{
+... when strict
+    when != I = THREAD_ARG(thread);
+(
+- return 0;
++ return false;
+|
+- return 1;
++ return true;
+)
+?...
+}


### PR DESCRIPTION
Some were converted to bool, where true/false status is needed.
Converted to void only those, where the return status was only false or true.