### PR TITLE
Bgp defines to enum

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -131,7 +131,7 @@ static struct peer *peer_xfer_conn(struct peer *from_peer)
 	safi_t safi;
 	int fd;
 	int status, pstatus;
-	unsigned char last_evt, last_maj_evt;
+	enum bgp_fsm_events last_evt, last_maj_evt;
 
 	assert(from_peer != NULL);
 
@@ -2184,7 +2184,7 @@ static const struct {
 /* Execute event process. */
 int bgp_event(struct thread *thread)
 {
-	int event;
+	enum bgp_fsm_events event;
 	struct peer *peer;
 	int ret;
 
@@ -2196,7 +2196,7 @@ int bgp_event(struct thread *thread)
 	return (ret);
 }
 
-int bgp_event_update(struct peer *peer, int event)
+int bgp_event_update(struct peer *peer, enum bgp_fsm_events event)
 {
 	int next;
 	int ret = 0;

--- a/bgpd/bgp_fsm.h
+++ b/bgpd/bgp_fsm.h
@@ -111,7 +111,7 @@
 /* Prototypes. */
 extern void bgp_fsm_event_update(struct peer *peer, int valid);
 extern int bgp_event(struct thread *);
-extern int bgp_event_update(struct peer *, int event);
+extern int bgp_event_update(struct peer *, enum bgp_fsm_events event);
 extern int bgp_stop(struct peer *peer);
 extern void bgp_timer_set(struct peer *);
 extern int bgp_routeadv_timer(struct thread *);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -838,6 +838,24 @@ struct bgp_peer_gr {
 	bgp_peer_gr_action_ptr action_fun;
 };
 
+/* BGP finite state machine events.  */
+enum bgp_fsm_events {
+	BGP_Start = 1,
+	BGP_Stop,
+	TCP_connection_open,
+	TCP_connection_closed,
+	TCP_connection_open_failed,
+	TCP_fatal_error,
+	ConnectRetry_timer_expired,
+	Hold_Timer_expired,
+	KeepAlive_timer_expired,
+	Receive_OPEN_message,
+	Receive_KEEPALIVE_message,
+	Receive_UPDATE_message,
+	Receive_NOTIFICATION_message,
+	Clearing_Completed,
+	BGP_EVENTS_MAX,
+};
 
 /* BGP neighbor structure. */
 struct peer {
@@ -902,9 +920,9 @@ struct peer {
 	/* FSM events, stored for debug purposes.
 	 * Note: uchar used for reduced memory usage.
 	 */
-	unsigned char cur_event;
-	unsigned char last_event;
-	unsigned char last_major_event;
+	enum bgp_fsm_events cur_event;
+	enum bgp_fsm_events last_event;
+	enum bgp_fsm_events last_major_event;
 
 	/* Peer index, used for dumping TABLE_DUMP_V2 format */
 	uint16_t table_dump_index;
@@ -1560,23 +1578,6 @@ struct bgp_nlri {
 #define Clearing                                 7
 #define Deleted                                  8
 #define BGP_STATUS_MAX                           9
-
-/* BGP finite state machine events.  */
-#define BGP_Start                                1
-#define BGP_Stop                                 2
-#define TCP_connection_open                      3
-#define TCP_connection_closed                    4
-#define TCP_connection_open_failed               5
-#define TCP_fatal_error                          6
-#define ConnectRetry_timer_expired               7
-#define Hold_Timer_expired                       8
-#define KeepAlive_timer_expired                  9
-#define Receive_OPEN_message                    10
-#define Receive_KEEPALIVE_message               11
-#define Receive_UPDATE_message                  12
-#define Receive_NOTIFICATION_message            13
-#define Clearing_Completed                      14
-#define BGP_EVENTS_MAX                          15
 
 /* BGP timers default value.  */
 #define BGP_INIT_START_TIMER                     1

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -857,6 +857,19 @@ enum bgp_fsm_events {
 	BGP_EVENTS_MAX,
 };
 
+/* BGP finite state machine status.  */
+enum bgp_fsm_status {
+	Idle = 1,
+	Connect,
+	Active,
+	OpenSent,
+	OpenConfirm,
+	Established,
+	Clearing,
+	Deleted,
+	BGP_STATUS_MAX,
+};
+
 /* BGP neighbor structure. */
 struct peer {
 	/* BGP structure.  */
@@ -914,8 +927,8 @@ struct peer {
 	struct peer *doppelganger;
 
 	/* Status of the peer. */
-	int status;
-	int ostatus;
+	enum bgp_fsm_status status;
+	enum bgp_fsm_status ostatus;
 
 	/* FSM events, stored for debug purposes.
 	 * Note: uchar used for reduced memory usage.
@@ -1567,17 +1580,6 @@ struct bgp_nlri {
 #define BGP_NOTIFY_CAPABILITY_INVALID_ACTION     1
 #define BGP_NOTIFY_CAPABILITY_INVALID_LENGTH     2
 #define BGP_NOTIFY_CAPABILITY_MALFORMED_CODE     3
-
-/* BGP finite state machine status.  */
-#define Idle                                     1
-#define Connect                                  2
-#define Active                                   3
-#define OpenSent                                 4
-#define OpenConfirm                              5
-#define Established                              6
-#define Clearing                                 7
-#define Deleted                                  8
-#define BGP_STATUS_MAX                           9
 
 /* BGP timers default value.  */
 #define BGP_INIT_START_TIMER                     1


### PR DESCRIPTION
A recent PR showed that we had mixed and matched two different sets of defines in bgp.  Convert them to enums so that the compiler can help us differentiate this problem from ever happening
in the future.