### PR TITLE
isisd: fix vty show isis metric

### DIFF
--- a/isisd/isis_cli.c
+++ b/isisd/isis_cli.c
@@ -1398,8 +1398,8 @@ void cli_show_ip_isis_metric(struct vty *vty, struct lyd_node *dnode,
 	if (strmatch(l1, l2))
 		vty_out(vty, " isis metric %s\n", l1);
 	else {
-		vty_out(vty, " isis metric %s level-1\n", l1);
-		vty_out(vty, " isis metric %s level-2\n", l2);
+		vty_out(vty, " isis metric level-1 %s\n", l1);
+		vty_out(vty, " isis metric level-2 %s\n", l2);
 	}
 }
 


### PR DESCRIPTION
the vtysh command to set the isis metric on an interface
is 'isis metric level-1 X', but when showing the running
config we were displaying it as 'isis metric X level-1'.
This would confuse frr-reload.py when attempting to apply
a config file populated with the correct command; on the
other hand, using the show command format would return an
error when running vtysh -C on the file.

Fix this by making the show command return the same format
as the vtysh setting command.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>