### PR TITLE
yang: Partially revert code to restore functionality

### DIFF
--- a/yang/frr-eigrpd.yang
+++ b/yang/frr-eigrpd.yang
@@ -23,11 +23,6 @@ module frr-eigrpd {
   description
     "This module defines a model for managing FRR eigrpd daemon.";
 
-  revision 2019-09-09 {
-    description
-      "Changed interface references to use
-      frr-interface:interface-ref typedef";
-  }
   revision 2019-06-19 {
     description "Initial revision.";
     reference
@@ -99,7 +94,9 @@ module frr-eigrpd {
 
       leaf-list passive-interface {
         description "List of suppressed interfaces";
-        type frr-interface:interface-ref;
+        type string {
+          length "1..16";
+        }
       }
 
       leaf active-time {

--- a/yang/frr-ripd.yang
+++ b/yang/frr-ripd.yang
@@ -24,11 +24,6 @@ module frr-ripd {
   description
     "This module defines a model for managing FRR ripd daemon.";
 
-  revision 2019-09-09 {
-    description
-      "Changed interface references to use
-      frr-interface:interface-ref typedef";
-  }
   revision 2017-12-06 {
     description
       "Initial revision.";
@@ -118,7 +113,9 @@ module frr-ripd {
           "Enable RIP on the specified IP network.";
       }
       leaf-list interface {
-        type frr-interface:interface-ref;
+        type string {
+          length "1..16";
+        }
         description
           "Enable RIP on the specified interface.";
       }
@@ -127,15 +124,7 @@ module frr-ripd {
         description
           "Offset-list to modify route metric.";
         leaf interface {
-          type union {
-            type frr-interface:interface-ref;
-            type enumeration {
-              enum '*' {
-                description
-                  "Match all interfaces.";
-              }
-            }
-          }
+          type string;
           description
             "Interface to match. Use '*' to match all interfaces.";
         }
@@ -179,14 +168,18 @@ module frr-ripd {
       }
       leaf-list passive-interface {
         when "../passive-default = 'false'";
-        type frr-interface:interface-ref;
+        type string {
+          length "1..16";
+        }
         description
           "A list of interfaces where the sending of RIP packets
            is disabled.";
       }
       leaf-list non-passive-interface {
         when "../passive-default = 'true'";
-        type frr-interface:interface-ref;
+        type string {
+          length "1..16";
+        }
         description
           "A list of interfaces where the sending of RIP packets
            is enabled.";

--- a/yang/frr-ripngd.yang
+++ b/yang/frr-ripngd.yang
@@ -24,11 +24,6 @@ module frr-ripngd {
   description
     "This module defines a model for managing FRR ripngd daemon.";
 
-  revision 2019-09-09 {
-    description
-      "Changed interface references to use
-      frr-interface:interface-ref typedef";
-  }
   revision 2018-11-27 {
     description
       "Initial revision.";
@@ -76,7 +71,9 @@ module frr-ripngd {
           "Enable RIPng on the specified IPv6 network.";
       }
       leaf-list interface {
-        type frr-interface:interface-ref;
+        type string {
+          length "1..16";
+        }
         description
           "Enable RIPng on the specified interface.";
       }
@@ -85,15 +82,7 @@ module frr-ripngd {
         description
           "Offset-list to modify route metric.";
         leaf interface {
-          type union {
-            type frr-interface:interface-ref;
-            type enumeration {
-              enum '*' {
-                description
-                  "Match all interfaces.";
-              }
-            }
-          }
+          type string;
           description
             "Interface to match. Use '*' to match all interfaces.";
         }
@@ -129,7 +118,9 @@ module frr-ripngd {
         }
       }
       leaf-list passive-interface {
-        type frr-interface:interface-ref;
+        type string {
+          length "1..16";
+        }
         description
           "A list of interfaces where the sending of RIPng packets
            is disabled.";


### PR DESCRIPTION
Partially revert code from commit:
f22b9250853229c93617ffdad139a4762f5f7348

since this broke passive-interface, network and offset-list
commands in rip and ripng

Fixes: #6001
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>