### PR TITLE
isisd: Expand send/receive buffers to allow for larger mtu

### DIFF
--- a/isisd/isis_bpf.c
+++ b/isisd/isis_bpf.c
@@ -73,7 +73,7 @@ static const uint8_t ALL_ISS[6] = {0x09, 0x00, 0x2B, 0x00, 0x00, 0x05};
 static const uint8_t ALL_ESS[6] = {0x09, 0x00, 0x2B, 0x00, 0x00, 0x04};
 #endif
 
-static char sock_buff[8192];
+static char sock_buff[16384];
 
 static int open_bpf_dev(struct isis_circuit *circuit)
 {

--- a/isisd/isis_dlpi.c
+++ b/isisd/isis_dlpi.c
@@ -62,7 +62,7 @@ static const uint8_t ALL_ISS[6] = {0x09, 0x00, 0x2B, 0x00, 0x00, 0x05};
 static const uint8_t ALL_ESS[6] = {0x09, 0x00, 0x2B, 0x00, 0x00, 0x04};
 #endif
 
-static uint8_t sock_buff[8192];
+static uint8_t sock_buff[16384];
 
 static unsigned short pf_filter[] = {
 	ENF_PUSHWORD + 0,       /* Get the SSAP/DSAP values */


### PR DESCRIPTION
User is reporting:
2020/03/21 03:12:36 ISIS: isis_send_pdu_bcast: sock_buff size 8192 is less than output pdu size 9014 on circuit em0
2020/03/21 03:12:36 ISIS: [EC 67108865] ISIS-Adj (1): Send L2 IIH on em0 failed

MTU's can frequently hit 9k in size, we have buffer limits
that prevent this from being fully used and creating errors.

Modify the code to allow for up to 16k mtu

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>