### PR TITLE
Agg to use rn lookup

### DIFF
--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -2528,12 +2528,12 @@ bool bgp_debug_update(struct peer *peer, const struct prefix *p,
 	return false;
 }
 
-bool bgp_debug_bestpath(struct prefix *p)
+bool bgp_debug_bestpath(struct bgp_node *rn)
 {
 	if (BGP_DEBUG(bestpath, BESTPATH)) {
-		if (bgp_debug_per_prefix(p, term_bgp_debug_bestpath,
-					 BGP_DEBUG_BESTPATH,
-					 bgp_debug_bestpath_prefixes))
+		if (bgp_debug_per_prefix(
+			    &rn->p, term_bgp_debug_bestpath,
+			    BGP_DEBUG_BESTPATH, bgp_debug_bestpath_prefixes))
 			return true;
 	}
 

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -168,7 +168,7 @@ extern int bgp_debug_neighbor_events(struct peer *peer);
 extern int bgp_debug_keepalive(struct peer *peer);
 extern bool bgp_debug_update(struct peer *peer, const struct prefix *p,
 			     struct update_group *updgrp, unsigned int inbound);
-extern bool bgp_debug_bestpath(struct prefix *p);
+extern bool bgp_debug_bestpath(struct bgp_node *rn);
 extern bool bgp_debug_zebra(const struct prefix *p);
 
 extern const char *bgp_debug_rdpfxpath2str(afi_t, safi_t, struct prefix_rd *,

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -3524,7 +3524,7 @@ static int install_uninstall_route_in_vnis(struct bgp *bgp, afi_t afi,
  * Install or uninstall route for appropriate VNIs/ESIs.
  */
 static int install_uninstall_evpn_route(struct bgp *bgp, afi_t afi, safi_t safi,
-					struct prefix *p,
+					const struct prefix *p,
 					struct bgp_path_info *pi, int import)
 {
 	struct prefix_evpn *evp = (struct prefix_evpn *)p;
@@ -5550,7 +5550,7 @@ void bgp_evpn_es_free(struct bgp *bgp, struct evpnes *es)
  * Import evpn route from global table to VNI/VRF/ESI.
  */
 int bgp_evpn_import_route(struct bgp *bgp, afi_t afi, safi_t safi,
-			  struct prefix *p, struct bgp_path_info *pi)
+			  const struct prefix *p, struct bgp_path_info *pi)
 {
 	return install_uninstall_evpn_route(bgp, afi, safi, p, pi, 1);
 }
@@ -5559,7 +5559,7 @@ int bgp_evpn_import_route(struct bgp *bgp, afi_t afi, safi_t safi,
  * Unimport evpn route from VNI/VRF/ESI.
  */
 int bgp_evpn_unimport_route(struct bgp *bgp, afi_t afi, safi_t safi,
-			    struct prefix *p, struct bgp_path_info *pi)
+			    const struct prefix *p, struct bgp_path_info *pi)
 {
 	return install_uninstall_evpn_route(bgp, afi, safi, p, pi, 0);
 }
@@ -6280,7 +6280,7 @@ int bgp_evpn_get_type5_prefixlen(struct prefix *pfx)
 /*
  * Should we register nexthop for this EVPN prefix for nexthop tracking?
  */
-bool bgp_evpn_is_prefix_nht_supported(struct prefix *pfx)
+bool bgp_evpn_is_prefix_nht_supported(const struct prefix *pfx)
 {
 	struct prefix_evpn *evp = (struct prefix_evpn *)pfx;
 

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -164,9 +164,11 @@ extern void bgp_evpn_encode_prefix(struct stream *s, struct prefix *p,
 extern int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 			       struct bgp_nlri *packet, int withdraw);
 extern int bgp_evpn_import_route(struct bgp *bgp, afi_t afi, safi_t safi,
-				 struct prefix *p, struct bgp_path_info *ri);
+				 const struct prefix *p,
+				 struct bgp_path_info *ri);
 extern int bgp_evpn_unimport_route(struct bgp *bgp, afi_t afi, safi_t safi,
-				   struct prefix *p, struct bgp_path_info *ri);
+				   const struct prefix *p,
+				   struct bgp_path_info *ri);
 extern int bgp_filter_evpn_routes_upon_martian_nh_change(struct bgp *bgp);
 extern int bgp_evpn_local_macip_del(struct bgp *bgp, vni_t vni,
 				    struct ethaddr *mac, struct ipaddr *ip,
@@ -194,7 +196,7 @@ extern void bgp_evpn_cleanup_on_disable(struct bgp *bgp);
 extern void bgp_evpn_cleanup(struct bgp *bgp);
 extern void bgp_evpn_init(struct bgp *bgp);
 extern int bgp_evpn_get_type5_prefixlen(struct prefix *pfx);
-extern bool bgp_evpn_is_prefix_nht_supported(struct prefix *pfx);
+extern bool bgp_evpn_is_prefix_nht_supported(const struct prefix *pfx);
 extern void update_advertise_vrf_routes(struct bgp *bgp_vrf);
 
 #endif /* _QUAGGA_BGP_EVPN_H */

--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -358,7 +358,7 @@ void bgp_mac_del_mac_entry(struct interface *ifp)
  * An example: router-mac attribute in any of evpn update
  * requires to compare against local mac.
  */
-bool bgp_mac_exist(struct ethaddr *mac)
+bool bgp_mac_exist(const struct ethaddr *mac)
 {
 	struct bgp_self_mac lookup;
 	struct bgp_self_mac *bsm;
@@ -379,9 +379,9 @@ bool bgp_mac_exist(struct ethaddr *mac)
  * mac against any of local assigned (SVIs) MAC
  * address.
  */
-bool bgp_mac_entry_exists(struct prefix *p)
+bool bgp_mac_entry_exists(const struct prefix *p)
 {
-	struct prefix_evpn *pevpn = (struct prefix_evpn *)p;
+	const struct prefix_evpn *pevpn = (const struct prefix_evpn *)p;
 
 	if (pevpn->family != AF_EVPN)
 		return false;

--- a/bgpd/bgp_mac.h
+++ b/bgpd/bgp_mac.h
@@ -36,7 +36,7 @@ void bgp_mac_dump_table(struct vty *vty);
 /*
  * Function to lookup the prefix and see if we have a matching mac
  */
-bool bgp_mac_entry_exists(struct prefix *p);
-bool bgp_mac_exist(struct ethaddr *mac);
+bool bgp_mac_entry_exists(const struct prefix *p);
+bool bgp_mac_exist(const struct ethaddr *mac);
 
 #endif

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -457,7 +457,7 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 	old_mpath_count = 0;
 	prev_mpath = new_best;
 	mp_node = listhead(mp_list);
-	debug = bgp_debug_bestpath(&rn->p);
+	debug = bgp_debug_bestpath(rn);
 
 	if (debug)
 		prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));

--- a/bgpd/bgp_pbr.c
+++ b/bgpd/bgp_pbr.c
@@ -685,9 +685,9 @@ static int bgp_pbr_validate_policy_route(struct bgp_pbr_entry_main *api)
 }
 
 /* return -1 if build or validation failed */
-int bgp_pbr_build_and_validate_entry(struct prefix *p,
-					    struct bgp_path_info *path,
-					    struct bgp_pbr_entry_main *api)
+int bgp_pbr_build_and_validate_entry(const struct prefix *p,
+				     struct bgp_path_info *path,
+				     struct bgp_pbr_entry_main *api)
 {
 	int ret;
 	int i, action_count = 0;
@@ -2610,7 +2610,7 @@ static void bgp_pbr_handle_entry(struct bgp *bgp, struct bgp_path_info *path,
 	}
 }
 
-void bgp_pbr_update_entry(struct bgp *bgp, struct prefix *p,
+void bgp_pbr_update_entry(struct bgp *bgp, const struct prefix *p,
 			  struct bgp_path_info *info, afi_t afi, safi_t safi,
 			  bool nlri_update)
 {

--- a/bgpd/bgp_pbr.h
+++ b/bgpd/bgp_pbr.h
@@ -291,7 +291,7 @@ void bgp_pbr_print_policy_route(struct bgp_pbr_entry_main *api);
 
 struct bgp_node;
 struct bgp_path_info;
-extern void bgp_pbr_update_entry(struct bgp *bgp, struct prefix *p,
+extern void bgp_pbr_update_entry(struct bgp *bgp, const struct prefix *p,
 				 struct bgp_path_info *new_select, afi_t afi,
 				 safi_t safi, bool nlri_update);
 
@@ -301,7 +301,7 @@ extern void bgp_pbr_reset(struct bgp *bgp, afi_t afi);
 extern struct bgp_pbr_interface *bgp_pbr_interface_lookup(const char *name,
 				   struct bgp_pbr_interface_head *head);
 
-extern int bgp_pbr_build_and_validate_entry(struct prefix *p,
+extern int bgp_pbr_build_and_validate_entry(const struct prefix *p,
 					    struct bgp_path_info *path,
 					    struct bgp_pbr_entry_main *api);
 #endif /* __BGP_PBR_H__ */

--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -76,7 +76,7 @@ void decode_rd_as4(const uint8_t *pnt, struct rd_as *rd_as)
 }
 
 /* type == RD_TYPE_IP */
-void decode_rd_ip(uint8_t *pnt, struct rd_ip *rd_ip)
+void decode_rd_ip(const uint8_t *pnt, struct rd_ip *rd_ip)
 {
 	memcpy(&rd_ip->ip, pnt, 4);
 	pnt += 4;

--- a/bgpd/bgp_rd.h
+++ b/bgpd/bgp_rd.h
@@ -59,7 +59,7 @@ extern void encode_rd_type(uint16_t, uint8_t *);
 
 extern void decode_rd_as(const uint8_t *pnt, struct rd_as *rd_as);
 extern void decode_rd_as4(const uint8_t *pnt, struct rd_as *rd_as);
-extern void decode_rd_ip(uint8_t *pnt, struct rd_ip *rd_ip);
+extern void decode_rd_ip(const uint8_t *pnt, struct rd_ip *rd_ip);
 #if ENABLE_BGP_VNC
 extern void decode_rd_vnc_eth(uint8_t *pnt, struct rd_vnc_eth *rd_vnc_eth);
 #endif

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -116,7 +116,7 @@ DEFINE_HOOK(bgp_process,
 
 
 struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
-				  safi_t safi, struct prefix *p,
+				  safi_t safi, const struct prefix *p,
 				  struct prefix_rd *prd)
 {
 	struct bgp_node *rn;
@@ -1202,7 +1202,8 @@ int bgp_path_info_cmp_compatible(struct bgp *bgp, struct bgp_path_info *new,
 	return ret;
 }
 
-static enum filter_type bgp_input_filter(struct peer *peer, struct prefix *p,
+static enum filter_type bgp_input_filter(struct peer *peer,
+					 const struct prefix *p,
 					 struct attr *attr, afi_t afi,
 					 safi_t safi)
 {
@@ -1322,7 +1323,7 @@ static bool bgp_cluster_filter(struct peer *peer, struct attr *attr)
 	return false;
 }
 
-static int bgp_input_modifier(struct peer *peer, struct prefix *p,
+static int bgp_input_modifier(struct peer *peer, const struct prefix *p,
 			      struct attr *attr, afi_t afi, safi_t safi,
 			      const char *rmap_name, mpls_label_t *label,
 			      uint32_t num_labels, struct bgp_node *rn)
@@ -3258,7 +3259,7 @@ static bool bgp_update_martian_nexthop(struct bgp *bgp, afi_t afi, safi_t safi,
 	return ret;
 }
 
-int bgp_update(struct peer *peer, struct prefix *p, uint32_t addpath_id,
+int bgp_update(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 	       struct attr *attr, afi_t afi, safi_t safi, int type,
 	       int sub_type, struct prefix_rd *prd, mpls_label_t *label,
 	       uint32_t num_labels, int soft_reconfig,
@@ -6614,7 +6615,7 @@ static void bgp_remove_route_from_aggregate(struct bgp *bgp, afi_t afi,
 			      lcommunity, atomic_aggregate, aggregate);
 }
 
-void bgp_aggregate_increment(struct bgp *bgp, struct prefix *p,
+void bgp_aggregate_increment(struct bgp *bgp, const struct prefix *p,
 			     struct bgp_path_info *pi, afi_t afi, safi_t safi)
 {
 	struct bgp_node *child;
@@ -6647,7 +6648,7 @@ void bgp_aggregate_increment(struct bgp *bgp, struct prefix *p,
 	bgp_unlock_node(child);
 }
 
-void bgp_aggregate_decrement(struct bgp *bgp, struct prefix *p,
+void bgp_aggregate_decrement(struct bgp *bgp, const struct prefix *p,
 			     struct bgp_path_info *del, afi_t afi, safi_t safi)
 {
 	struct bgp_node *child;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2096,7 +2096,7 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 	do_mpath =
 		(mpath_cfg->maxpaths_ebgp > 1 || mpath_cfg->maxpaths_ibgp > 1);
 
-	debug = bgp_debug_bestpath(&rn->p);
+	debug = bgp_debug_bestpath(rn);
 
 	if (debug)
 		prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
@@ -2450,7 +2450,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 
 	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS)) {
 		if (rn)
-			debug = bgp_debug_bestpath(&rn->p);
+			debug = bgp_debug_bestpath(rn);
 		if (debug) {
 			prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
 			zlog_debug(
@@ -2477,7 +2477,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 
 	struct prefix *p = &rn->p;
 
-	debug = bgp_debug_bestpath(&rn->p);
+	debug = bgp_debug_bestpath(rn);
 	if (debug) {
 		prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
 		zlog_debug("%s: p=%s afi=%s, safi=%s start", __func__, pfx_buf,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4028,7 +4028,7 @@ filtered:
 	return 0;
 }
 
-int bgp_withdraw(struct peer *peer, struct prefix *p, uint32_t addpath_id,
+int bgp_withdraw(struct peer *peer, const struct prefix *p, uint32_t addpath_id,
 		 struct attr *attr, afi_t afi, safi_t safi, int type,
 		 int sub_type, struct prefix_rd *prd, mpls_label_t *label,
 		 uint32_t num_labels, struct bgp_route_evpn *evpn)

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -510,7 +510,7 @@ extern bool bgp_outbound_policy_exists(struct peer *, struct bgp_filter *);
 extern bool bgp_inbound_policy_exists(struct peer *, struct bgp_filter *);
 
 extern struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
-					 safi_t safi, struct prefix *p,
+					 safi_t safi, const struct prefix *p,
 					 struct prefix_rd *prd);
 extern struct bgp_path_info *bgp_path_info_lock(struct bgp_path_info *path);
 extern struct bgp_path_info *bgp_path_info_unlock(struct bgp_path_info *path);
@@ -558,9 +558,12 @@ extern int bgp_static_unset_safi(afi_t afi, safi_t safi, struct vty *,
 				 const char *, const char *, const char *);
 
 /* this is primarily for MPLS-VPN */
-extern int bgp_update(struct peer *, struct prefix *, uint32_t, struct attr *,
-		      afi_t, safi_t, int, int, struct prefix_rd *,
-		      mpls_label_t *, uint32_t, int, struct bgp_route_evpn *);
+extern int bgp_update(struct peer *peer, const struct prefix *p,
+		      uint32_t addpath_id, struct attr *attr,
+		      afi_t afi, safi_t safi, int type, int sub_type,
+		      struct prefix_rd *prd, mpls_label_t *label,
+		      uint32_t num_labels, int soft_reconfig,
+		      struct bgp_route_evpn *evpn);
 extern int bgp_withdraw(struct peer *, struct prefix *, uint32_t, struct attr *,
 			afi_t, safi_t, int, int, struct prefix_rd *,
 			mpls_label_t *, uint32_t, struct bgp_route_evpn *);
@@ -583,10 +586,10 @@ extern void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 				 safi_t safi, struct bgp_aggregate *aggregate);
 extern void bgp_aggregate_route(struct bgp *bgp, struct prefix *p, afi_t afi,
 				safi_t safi, struct bgp_aggregate *aggregate);
-extern void bgp_aggregate_increment(struct bgp *bgp, struct prefix *p,
+extern void bgp_aggregate_increment(struct bgp *bgp, const struct prefix *p,
 				    struct bgp_path_info *path, afi_t afi,
 				    safi_t safi);
-extern void bgp_aggregate_decrement(struct bgp *bgp, struct prefix *p,
+extern void bgp_aggregate_decrement(struct bgp *bgp, const struct prefix *p,
 				    struct bgp_path_info *path, afi_t afi,
 				    safi_t safi);
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -564,9 +564,11 @@ extern int bgp_update(struct peer *peer, const struct prefix *p,
 		      struct prefix_rd *prd, mpls_label_t *label,
 		      uint32_t num_labels, int soft_reconfig,
 		      struct bgp_route_evpn *evpn);
-extern int bgp_withdraw(struct peer *, struct prefix *, uint32_t, struct attr *,
-			afi_t, safi_t, int, int, struct prefix_rd *,
-			mpls_label_t *, uint32_t, struct bgp_route_evpn *);
+extern int bgp_withdraw(struct peer *peer, const struct prefix *p,
+			uint32_t addpath_id, struct attr *attr, afi_t afi,
+			safi_t safi, int type, int sub_type,
+			struct prefix_rd *prd, mpls_label_t *label,
+			uint32_t num_labels, struct bgp_route_evpn *evpn);
 
 /* for bgp_nexthop and bgp_damp */
 extern void bgp_process(struct bgp *, struct bgp_node *, afi_t, safi_t);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1484,7 +1484,7 @@ void bgp_zebra_announce_table(struct bgp *bgp, afi_t afi, safi_t safi)
 						   safi);
 }
 
-void bgp_zebra_withdraw(struct prefix *p, struct bgp_path_info *info,
+void bgp_zebra_withdraw(const struct prefix *p, struct bgp_path_info *info,
 			struct bgp *bgp, safi_t safi)
 {
 	struct zapi_route api;

--- a/bgpd/bgp_zebra.h
+++ b/bgpd/bgp_zebra.h
@@ -36,8 +36,9 @@ extern void bgp_zebra_announce(struct bgp_node *rn, const struct prefix *p,
 			       struct bgp_path_info *path, struct bgp *bgp,
 			       afi_t afi, safi_t safi);
 extern void bgp_zebra_announce_table(struct bgp *, afi_t, safi_t);
-extern void bgp_zebra_withdraw(struct prefix *p, struct bgp_path_info *path,
-			       struct bgp *bgp, safi_t safi);
+extern void bgp_zebra_withdraw(const struct prefix *p,
+			       struct bgp_path_info *path, struct bgp *bgp,
+			       safi_t safi);
 
 extern void bgp_zebra_initiate_radv(struct bgp *bgp, struct peer *peer);
 extern void bgp_zebra_terminate_radv(struct bgp *bgp, struct peer *peer);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -355,7 +355,7 @@ int rfapi_check(void *handle)
 
 void del_vnc_route(struct rfapi_descriptor *rfd,
 		   struct peer *peer, /* rfd->peer for RFP regs */
-		   struct bgp *bgp, safi_t safi, struct prefix *p,
+		   struct bgp *bgp, safi_t safi, const struct prefix *p,
 		   struct prefix_rd *prd, uint8_t type, uint8_t sub_type,
 		   struct rfapi_nexthop *lnh, int kill)
 {
@@ -557,7 +557,7 @@ void rfapi_vn_options_free(struct rfapi_vn_option *p)
 
 /* Based on bgp_redistribute_add() */
 void add_vnc_route(struct rfapi_descriptor *rfd, /* cookie, VPN UN addr, peer */
-		   struct bgp *bgp, int safi, struct prefix *p,
+		   struct bgp *bgp, int safi, const struct prefix *p,
 		   struct prefix_rd *prd, struct rfapi_ip_addr *nexthop,
 		   uint32_t *local_pref,
 		   uint32_t *lifetime, /* NULL => dont send lifetime */

--- a/bgpd/rfapi/rfapi_ap.c
+++ b/bgpd/rfapi/rfapi_ap.c
@@ -81,10 +81,10 @@
  * is used to spread out the sort for adbs with the same lifetime
  * and thereby make the skip list operations more efficient.
  */
-static int sl_adb_lifetime_cmp(void *adb1, void *adb2)
+static int sl_adb_lifetime_cmp(const void *adb1, const void *adb2)
 {
-	struct rfapi_adb *a1 = adb1;
-	struct rfapi_adb *a2 = adb2;
+	const struct rfapi_adb *a1 = adb1;
+	const struct rfapi_adb *a2 = adb2;
 
 	if (a1->lifetime < a2->lifetime)
 		return -1;

--- a/bgpd/rfapi/rfapi_backend.h
+++ b/bgpd/rfapi/rfapi_backend.h
@@ -35,16 +35,16 @@ extern void rfapi_delete(struct bgp *);
 struct rfapi *bgp_rfapi_new(struct bgp *bgp);
 void bgp_rfapi_destroy(struct bgp *bgp, struct rfapi *h);
 
-extern void rfapiProcessUpdate(struct peer *peer, void *rfd, struct prefix *p,
-			       struct prefix_rd *prd, struct attr *attr,
-			       afi_t afi, safi_t safi, uint8_t type,
-			       uint8_t sub_type, uint32_t *label);
+extern void rfapiProcessUpdate(struct peer *peer, void *rfd,
+			       const struct prefix *p, struct prefix_rd *prd,
+			       struct attr *attr, afi_t afi, safi_t safi,
+			       uint8_t type, uint8_t sub_type, uint32_t *label);
 
 
-extern void rfapiProcessWithdraw(struct peer *peer, void *rfd, struct prefix *p,
-				 struct prefix_rd *prd, struct attr *attr,
-				 afi_t afi, safi_t safi, uint8_t type,
-				 int kill);
+extern void rfapiProcessWithdraw(struct peer *peer, void *rfd,
+				 const struct prefix *p, struct prefix_rd *prd,
+				 struct attr *attr, afi_t afi, safi_t safi,
+				 uint8_t type, int kill);
 
 extern void rfapiProcessPeerDown(struct peer *peer);
 

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -2006,10 +2006,10 @@ static void rfapiBgpInfoDetach(struct agg_node *rn, struct bgp_path_info *bpi)
 /*
  * For L3-indexed import tables
  */
-static int rfapi_bi_peer_rd_cmp(void *b1, void *b2)
+static int rfapi_bi_peer_rd_cmp(const void *b1, const void *b2)
 {
-	struct bgp_path_info *bpi1 = b1;
-	struct bgp_path_info *bpi2 = b2;
+	const struct bgp_path_info *bpi1 = b1;
+	const struct bgp_path_info *bpi2 = b2;
 
 	/*
 	 * Compare peers
@@ -2022,8 +2022,9 @@ static int rfapi_bi_peer_rd_cmp(void *b1, void *b2)
 	/*
 	 * compare RDs
 	 */
-	return vnc_prefix_cmp((struct prefix *)&bpi1->extra->vnc.import.rd,
-			      (struct prefix *)&bpi2->extra->vnc.import.rd);
+	return vnc_prefix_cmp(
+		(const struct prefix *)&bpi1->extra->vnc.import.rd,
+		(const struct prefix *)&bpi2->extra->vnc.import.rd);
 }
 
 /*
@@ -2031,10 +2032,10 @@ static int rfapi_bi_peer_rd_cmp(void *b1, void *b2)
  * The BPIs in these tables should ALWAYS have an aux_prefix set because
  * they arrive via IPv4 or IPv6 advertisements.
  */
-static int rfapi_bi_peer_rd_aux_cmp(void *b1, void *b2)
+static int rfapi_bi_peer_rd_aux_cmp(const void *b1, const void *b2)
 {
-	struct bgp_path_info *bpi1 = b1;
-	struct bgp_path_info *bpi2 = b2;
+	const struct bgp_path_info *bpi1 = b1;
+	const struct bgp_path_info *bpi2 = b2;
 	int rc;
 
 	/*

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -2153,7 +2153,7 @@ static void rfapiItBiIndexDump(struct agg_node *rn)
 static struct bgp_path_info *rfapiItBiIndexSearch(
 	struct agg_node *rn, /* Import table VPN node */
 	struct prefix_rd *prd, struct peer *peer,
-	struct prefix *aux_prefix) /* optional L3 addr for L2 ITs */
+	const struct prefix *aux_prefix) /* optional L3 addr for L2 ITs */
 {
 	struct skiplist *sl;
 	int rc;
@@ -2847,11 +2847,13 @@ rfapiBiStartWithdrawTimer(struct rfapi_import_table *import_table,
 }
 
 
-typedef void(rfapi_bi_filtered_import_f)(struct rfapi_import_table *, int,
-					 struct peer *, void *, struct prefix *,
-					 struct prefix *, afi_t,
-					 struct prefix_rd *, struct attr *,
-					 uint8_t, uint8_t, uint32_t *);
+typedef void(rfapi_bi_filtered_import_f)(struct rfapi_import_table *table,
+					 int action, struct peer *peer,
+					 void *rfd, const struct prefix *prefix,
+					 const struct prefix *aux_prefix,
+					 afi_t afi, struct prefix_rd *prd,
+					 struct attr *attr, uint8_t type,
+					 uint8_t sub_type, uint32_t *label);
 
 
 static void rfapiExpireEncapNow(struct rfapi_import_table *it,
@@ -2900,11 +2902,11 @@ static int rfapiGetNexthop(struct attr *attr, struct prefix *prefix)
 static void rfapiBgpInfoFilteredImportEncap(
 	struct rfapi_import_table *import_table, int action, struct peer *peer,
 	void *rfd, /* set for looped back routes */
-	struct prefix *p,
-	struct prefix *aux_prefix, /* Unused for encap routes */
+	const struct prefix *p,
+	const struct prefix *aux_prefix, /* Unused for encap routes */
 	afi_t afi, struct prefix_rd *prd,
 	struct attr *attr, /* part of bgp_path_info */
-	uint8_t type,      /* part of bgp_path_info */
+	uint8_t type,	   /* part of bgp_path_info */
 	uint8_t sub_type,  /* part of bgp_path_info */
 	uint32_t *label)   /* part of bgp_path_info */
 {
@@ -3361,11 +3363,11 @@ static void rfapiExpireVpnNow(struct rfapi_import_table *it,
 void rfapiBgpInfoFilteredImportVPN(
 	struct rfapi_import_table *import_table, int action, struct peer *peer,
 	void *rfd, /* set for looped back routes */
-	struct prefix *p,
-	struct prefix *aux_prefix, /* AFI_L2VPN: optional IP */
+	const struct prefix *p,
+	const struct prefix *aux_prefix, /* AFI_L2VPN: optional IP */
 	afi_t afi, struct prefix_rd *prd,
 	struct attr *attr, /* part of bgp_path_info */
-	uint8_t type,      /* part of bgp_path_info */
+	uint8_t type,	   /* part of bgp_path_info */
 	uint8_t sub_type,  /* part of bgp_path_info */
 	uint32_t *label)   /* part of bgp_path_info */
 {
@@ -3840,11 +3842,11 @@ void rfapiBgpInfoFilteredImportVPN(
 static void rfapiBgpInfoFilteredImportBadSafi(
 	struct rfapi_import_table *import_table, int action, struct peer *peer,
 	void *rfd, /* set for looped back routes */
-	struct prefix *p,
-	struct prefix *aux_prefix, /* AFI_L2VPN: optional IP */
+	const struct prefix *p,
+	const struct prefix *aux_prefix, /* AFI_L2VPN: optional IP */
 	afi_t afi, struct prefix_rd *prd,
 	struct attr *attr, /* part of bgp_path_info */
-	uint8_t type,      /* part of bgp_path_info */
+	uint8_t type,	   /* part of bgp_path_info */
 	uint8_t sub_type,  /* part of bgp_path_info */
 	uint32_t *label)   /* part of bgp_path_info */
 {
@@ -3870,7 +3872,7 @@ rfapiBgpInfoFilteredImportFunction(safi_t safi)
 
 void rfapiProcessUpdate(struct peer *peer,
 			void *rfd, /* set when looped from RFP/RFAPI */
-			struct prefix *p, struct prefix_rd *prd,
+			const struct prefix *p, struct prefix_rd *prd,
 			struct attr *attr, afi_t afi, safi_t safi, uint8_t type,
 			uint8_t sub_type, uint32_t *label)
 {
@@ -3954,7 +3956,7 @@ void rfapiProcessUpdate(struct peer *peer,
 }
 
 
-void rfapiProcessWithdraw(struct peer *peer, void *rfd, struct prefix *p,
+void rfapiProcessWithdraw(struct peer *peer, void *rfd, const struct prefix *p,
 			  struct prefix_rd *prd, struct attr *attr, afi_t afi,
 			  safi_t safi, uint8_t type, int kill)
 {

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -143,11 +143,11 @@ extern void rfapiUnicastNexthop2Prefix(afi_t afi, struct attr *attr,
 extern void rfapiBgpInfoFilteredImportVPN(
 	struct rfapi_import_table *import_table, int action, struct peer *peer,
 	void *rfd, /* set for looped back routes */
-	struct prefix *p,
-	struct prefix *aux_prefix, /* AFI_ETHER: optional IP */
+	const struct prefix *p,
+	const struct prefix *aux_prefix, /* AFI_ETHER: optional IP */
 	afi_t afi, struct prefix_rd *prd,
 	struct attr *attr, /* part of bgp_path_info */
-	uint8_t type,      /* part of bgp_path_info */
+	uint8_t type,	   /* part of bgp_path_info */
 	uint8_t sub_type,  /* part of bgp_path_info */
 	uint32_t *label);  /* part of bgp_path_info */
 

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -1103,10 +1103,10 @@ static void rfapiMonitorEthTimerRestart(struct rfapi_monitor_eth *m)
 			 m->rfd->response_lifetime, &m->timer);
 }
 
-static int mon_eth_cmp(void *a, void *b)
+static int mon_eth_cmp(const void *a, const void *b)
 {
-	struct rfapi_monitor_eth *m1;
-	struct rfapi_monitor_eth *m2;
+	const struct rfapi_monitor_eth *m1;
+	const struct rfapi_monitor_eth *m2;
 
 	int i;
 

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -789,7 +789,8 @@ static void rfapiMonitorTimerRestart(struct rfapi_monitor_vpn *m)
  * been responsible for the response, i.e., any monitors for
  * the exact prefix or a parent of it.
  */
-void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd, struct prefix *p)
+void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd,
+			       const struct prefix *p)
 {
 	struct agg_node *rn;
 
@@ -818,12 +819,14 @@ void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd, struct prefix *p)
 		for (rn = agg_route_top(rfd->mon); rn;
 		     rn = agg_route_next(rn)) {
 			struct rfapi_monitor_vpn *m;
+			const struct prefix *p_node;
 
 			if (!((m = rn->info)))
 				continue;
 
+			p_node = agg_node_get_prefix(m->node);
 			/* NB order of test is significant ! */
-			if (!m->node || prefix_match(&m->node->p, p)) {
+			if (!m->node || prefix_match(p_node, p)) {
 				rfapiMonitorTimerRestart(m);
 			}
 		}
@@ -841,7 +844,8 @@ void rfapiMonitorItNodeChanged(
 	struct skiplist *nves_seen;
 	struct agg_node *rn = it_node;
 	struct bgp *bgp = bgp_get_default();
-	afi_t afi = family2afi(rn->p.family);
+	const struct prefix *p = agg_node_get_prefix(rn);
+	afi_t afi = family2afi(p->family);
 #if DEBUG_L2_EXTRA
 	char buf_prefix[PREFIX_STRLEN];
 #endif
@@ -931,17 +935,14 @@ void rfapiMonitorItNodeChanged(
 					assert(!skiplist_insert(nves_seen,
 								m->rfd, NULL));
 
-					char buf_attach_pfx[PREFIX_STRLEN];
 					char buf_target_pfx[PREFIX_STRLEN];
 
-					prefix2str(&m->node->p, buf_attach_pfx,
-						   sizeof(buf_attach_pfx));
 					prefix2str(&m->p, buf_target_pfx,
 						   sizeof(buf_target_pfx));
 					vnc_zlog_debug_verbose(
-						"%s: update rfd %p attached to pfx %s (targ=%s)",
-						__func__, m->rfd,
-						buf_attach_pfx, buf_target_pfx);
+						"%s: update rfd %p attached to pfx %pRN (targ=%s)",
+						__func__, m->rfd, m->node,
+						buf_target_pfx);
 
 					/*
 					 * update its RIB

--- a/bgpd/rfapi/rfapi_monitor.h
+++ b/bgpd/rfapi/rfapi_monitor.h
@@ -167,7 +167,7 @@ extern void rfapiMonitorResponseRemovalOn(struct bgp *bgp);
 extern void rfapiMonitorExtraPrune(safi_t safi, struct agg_node *rn);
 
 extern void rfapiMonitorTimersRestart(struct rfapi_descriptor *rfd,
-				      struct prefix *p);
+				      const struct prefix *p);
 
 extern void rfapiMonitorItNodeChanged(struct rfapi_import_table *import_table,
 				      struct agg_node *it_node,

--- a/bgpd/rfapi/rfapi_nve_addr.c
+++ b/bgpd/rfapi/rfapi_nve_addr.c
@@ -58,10 +58,10 @@ static void logdifferent(const char *tag, struct rfapi_nve_addr *a,
 #endif
 
 
-int rfapi_nve_addr_cmp(void *k1, void *k2)
+int rfapi_nve_addr_cmp(const void *k1, const void *k2)
 {
-	struct rfapi_nve_addr *a = (struct rfapi_nve_addr *)k1;
-	struct rfapi_nve_addr *b = (struct rfapi_nve_addr *)k2;
+	const struct rfapi_nve_addr *a = (struct rfapi_nve_addr *)k1;
+	const struct rfapi_nve_addr *b = (struct rfapi_nve_addr *)k2;
 	int ret = 0;
 
 	if (!a || !b) {

--- a/bgpd/rfapi/rfapi_nve_addr.h
+++ b/bgpd/rfapi/rfapi_nve_addr.h
@@ -30,7 +30,7 @@ struct rfapi_nve_addr {
 };
 
 
-extern int rfapi_nve_addr_cmp(void *k1, void *k2);
+extern int rfapi_nve_addr_cmp(const void *k1, const void *k2);
 
 extern void rfapiNveAddr2Str(struct rfapi_nve_addr *na, char *buf, int bufsize);
 

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -272,9 +272,6 @@ struct rfapi {
 			    ? ((prefix)->prefixlen == 128)                     \
 			    : 0))
 
-extern void rfapiQprefix2Rprefix(struct prefix *qprefix,
-				 struct rfapi_ip_prefix *rprefix);
-
 extern int rfapi_find_rfd(struct bgp *bgp, struct rfapi_ip_addr *vn_addr,
 			  struct rfapi_ip_addr *un_addr,
 			  struct rfapi_descriptor **rfd);

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -281,7 +281,7 @@ extern int rfapi_find_rfd(struct bgp *bgp, struct rfapi_ip_addr *vn_addr,
 
 extern void
 add_vnc_route(struct rfapi_descriptor *rfd, /* cookie + UN addr for VPN */
-	      struct bgp *bgp, int safi, struct prefix *p,
+	      struct bgp *bgp, int safi, const struct prefix *p,
 	      struct prefix_rd *prd, struct rfapi_ip_addr *nexthop,
 	      uint32_t *local_pref, /* host byte order */
 	      uint32_t *lifetime,   /* host byte order */
@@ -297,7 +297,7 @@ add_vnc_route(struct rfapi_descriptor *rfd, /* cookie + UN addr for VPN */
 #endif
 
 extern void del_vnc_route(struct rfapi_descriptor *rfd, struct peer *peer,
-			  struct bgp *bgp, safi_t safi, struct prefix *p,
+			  struct bgp *bgp, safi_t safi, const struct prefix *p,
 			  struct prefix_rd *prd, uint8_t type, uint8_t sub_type,
 			  struct rfapi_nexthop *lnh, int kill);
 

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -340,7 +340,6 @@ static void rfapiRibStartTimer(struct rfapi_descriptor *rfd,
 {
 	struct thread *t = ri->timer;
 	struct rfapi_rib_tcb *tcb = NULL;
-	char buf_prefix[PREFIX_STRLEN];
 
 	if (t) {
 		tcb = t->arg;
@@ -361,9 +360,8 @@ static void rfapiRibStartTimer(struct rfapi_descriptor *rfd,
 		UNSET_FLAG(tcb->flags, RFAPI_RIB_TCB_FLAG_DELETED);
 	}
 
-	prefix2str(&rn->p, buf_prefix, sizeof(buf_prefix));
-	vnc_zlog_debug_verbose("%s: rfd %p pfx %s life %u", __func__, rfd,
-			       buf_prefix, ri->lifetime);
+	vnc_zlog_debug_verbose("%s: rfd %p pfx %pRN life %u", __func__, rfd, rn,
+			       ri->lifetime);
 	ri->timer = NULL;
 	thread_add_timer(bm->master, rfapiRibExpireTimer, tcb, ri->lifetime,
 			 &ri->timer);
@@ -741,11 +739,12 @@ int rfapiRibPreloadBi(
 	struct rfapi_rib_key rk;
 	struct agg_node *trn;
 	afi_t afi;
+	const struct prefix *p = agg_node_get_prefix(rfd_rib_node);
 
 	if (!rfd_rib_node)
 		return 0;
 
-	afi = family2afi(rfd_rib_node->p.family);
+	afi = family2afi(p->family);
 
 	rfd = agg_get_table_info(agg_get_table(rfd_rib_node));
 
@@ -803,8 +802,7 @@ int rfapiRibPreloadBi(
 	/*
 	 * Update last sent time for prefix
 	 */
-	trn = agg_node_get(rfd->rsp_times[afi],
-			   &rfd_rib_node->p); /* locks trn */
+	trn = agg_node_get(rfd->rsp_times[afi], p); /* locks trn */
 	trn->info = (void *)(uintptr_t)bgp_clock();
 	if (trn->lock > 1)
 		agg_unlock_node(trn);
@@ -852,10 +850,9 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 	struct list *lPendCost = NULL;
 	struct list *delete_list = NULL;
 	int printedprefix = 0;
-	char buf_prefix[PREFIX_STRLEN];
 	int rib_node_started_nonempty = 0;
 	int sendingsomeroutes = 0;
-
+	const struct prefix *p;
 #if DEBUG_PROCESS_PENDING_NODE
 	unsigned int count_rib_initial = 0;
 	unsigned int count_pend_vn_initial = 0;
@@ -863,12 +860,12 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 #endif
 
 	assert(pn);
-	prefix2str(&pn->p, buf_prefix, sizeof(buf_prefix));
-	vnc_zlog_debug_verbose("%s: afi=%d, %s pn->info=%p", __func__, afi,
-			       buf_prefix, pn->info);
+	p = agg_node_get_prefix(pn);
+	vnc_zlog_debug_verbose("%s: afi=%d, %pRN pn->info=%p", __func__, afi,
+			       pn, pn->info);
 
 	if (AFI_L2VPN != afi) {
-		rfapiQprefix2Rprefix(&pn->p, &hp);
+		rfapiQprefix2Rprefix(p, &hp);
 	}
 
 	RFAPI_RIB_CHECK_COUNTS(1, 0);
@@ -876,7 +873,7 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 	/*
 	 * Find corresponding RIB node
 	 */
-	rn = agg_node_get(rfd->rib[afi], &pn->p); /* locks rn */
+	rn = agg_node_get(rfd->rib[afi], p); /* locks rn */
 
 	/*
 	 * RIB skiplist has key=rfapi_addr={vn,un}, val = rfapi_info,
@@ -935,9 +932,9 @@ static void process_pending_node(struct bgp *bgp, struct rfapi_descriptor *rfd,
 				prefix2str(&ri->rk.vn, buf, sizeof(buf));
 				prefix2str(&ri->un, buf2, sizeof(buf2));
 				vnc_zlog_debug_verbose(
-					"%s:   put dl pfx=%s vn=%s un=%s cost=%d life=%d vn_options=%p",
-					__func__, buf_prefix, buf, buf2,
-					ri->cost, ri->lifetime, ri->vn_options);
+					"%s:   put dl pfx=%pRN vn=%s un=%s cost=%d life=%d vn_options=%p",
+					__func__, pn, buf, buf2, ri->cost,
+					ri->lifetime, ri->vn_options);
 
 				skiplist_delete_first(slRibPt);
 			}
@@ -1186,8 +1183,7 @@ callback:
 
 		vnc_zlog_debug_verbose("%s: lPendCost->count now %d", __func__,
 				       lPendCost->count);
-		vnc_zlog_debug_verbose("%s: For prefix %s (a)", __func__,
-				       buf_prefix);
+		vnc_zlog_debug_verbose("%s: For prefix %pRN (a)", __func__, pn);
 		printedprefix = 1;
 
 		for (ALL_LIST_ELEMENTS(lPendCost, node, nnode, ri)) {
@@ -1246,7 +1242,7 @@ callback:
 			 * update this NVE's timestamp for this prefix
 			 */
 			trn = agg_node_get(rfd->rsp_times[afi],
-					   &pn->p); /* locks trn */
+					   p); /* locks trn */
 			trn->info = (void *)(uintptr_t)bgp_clock();
 			if (trn->lock > 1)
 				agg_unlock_node(trn);
@@ -1268,8 +1264,8 @@ callback:
 		char buf2[BUFSIZ];
 
 		if (!printedprefix) {
-			vnc_zlog_debug_verbose("%s: For prefix %s (d)",
-					       __func__, buf_prefix);
+			vnc_zlog_debug_verbose("%s: For prefix %pRN (d)",
+					       __func__, pn);
 		}
 		vnc_zlog_debug_verbose("%s: delete_list has %d elements",
 				       __func__, delete_list->count);
@@ -1465,7 +1461,7 @@ callback:
 	}
 
 	if (sendingsomeroutes)
-		rfapiMonitorTimersRestart(rfd, &pn->p);
+		rfapiMonitorTimersRestart(rfd, p);
 
 	agg_unlock_node(rn); /* agg_node_get() */
 
@@ -1589,7 +1585,7 @@ void rfapiRibUpdatePendingNode(
 	struct rfapi_import_table *it, /* needed for L2 */
 	struct agg_node *it_node, uint32_t lifetime)
 {
-	struct prefix *prefix;
+	const struct prefix *prefix;
 	struct bgp_path_info *bpi;
 	struct agg_node *pn;
 	afi_t afi;
@@ -1606,7 +1602,7 @@ void rfapiRibUpdatePendingNode(
 
 	RFAPI_RIB_CHECK_COUNTS(1, 0);
 
-	prefix = &it_node->p;
+	prefix = agg_node_get_prefix(it_node);
 	afi = family2afi(prefix->family);
 	prefix2str(prefix, buf, sizeof(buf));
 	vnc_zlog_debug_verbose("%s: prefix=%s", __func__, buf);
@@ -1794,7 +1790,8 @@ int rfapiRibFTDFilterRecentPrefix(
 	struct prefix *pfx_target_original) /* query target */
 {
 	struct bgp *bgp = rfd->bgp;
-	afi_t afi = family2afi(it_rn->p.family);
+	const struct prefix *p = agg_node_get_prefix(it_rn);
+	afi_t afi = family2afi(p->family);
 	time_t prefix_time;
 	struct agg_node *trn;
 
@@ -1809,7 +1806,7 @@ int rfapiRibFTDFilterRecentPrefix(
 	 * This matches behavior of now-obsolete rfapiRibFTDFilterRecent(),
 	 * but we need to decide if that is correct.
 	 */
-	if (it_rn->p.family == AF_ETHERNET)
+	if (p->family == AF_ETHERNET)
 		return 0;
 
 #ifdef DEBUG_FTD_FILTER_RECENT
@@ -1824,7 +1821,7 @@ int rfapiRibFTDFilterRecentPrefix(
 	/*
 	 * prefix covers target address, so allow prefix
 	 */
-	if (prefix_match(&it_rn->p, pfx_target_original)) {
+	if (prefix_match(p, pfx_target_original)) {
 #ifdef DEBUG_FTD_FILTER_RECENT
 		vnc_zlog_debug_verbose("%s: prefix covers target, allowed",
 				       __func__);
@@ -1835,7 +1832,7 @@ int rfapiRibFTDFilterRecentPrefix(
 	/*
 	 * check this NVE's timestamp for this prefix
 	 */
-	trn = agg_node_get(rfd->rsp_times[afi], &it_rn->p); /* locks trn */
+	trn = agg_node_get(rfd->rsp_times[afi], p); /* locks trn */
 	prefix_time = (time_t)trn->info;
 	if (trn->lock > 1)
 		agg_unlock_node(trn);
@@ -2114,11 +2111,10 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 {
 	struct rfapi_descriptor *rfd;
 	struct listnode *node;
-	char buf[PREFIX_STRLEN];
+	const struct prefix *p = agg_node_get_prefix(it_node);
 
-	prefix2str(&it_node->p, buf, sizeof(buf));
-	vnc_zlog_debug_verbose("%s: entry, it=%p, afi=%d, it_node=%p, pfx=%s",
-			       __func__, it, afi, it_node, buf);
+	vnc_zlog_debug_verbose("%s: entry, it=%p, afi=%d, it_node=%p, pfx=%pRN",
+			       __func__, it, afi, it_node, it_node);
 
 	if (AFI_L2VPN == afi) {
 		/*
@@ -2157,7 +2153,7 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 				 * delete
 				 */
 				if ((rn = agg_node_lookup(m->rfd->rib[afi],
-							  &it_node->p))) {
+							  p))) {
 					rfapiRibUpdatePendingNode(
 						bgp, m->rfd, it, it_node,
 						m->rfd->response_lifetime);
@@ -2179,8 +2175,7 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 			 * this
 			 * NVE, it's OK to send an update with the delete
 			 */
-			if ((rn = agg_node_lookup(m->rfd->rib[afi],
-						  &it_node->p))) {
+			if ((rn = agg_node_lookup(m->rfd->rib[afi], p))) {
 				rfapiRibUpdatePendingNode(
 					bgp, m->rfd, it, it_node,
 					m->rfd->response_lifetime);
@@ -2212,8 +2207,7 @@ void rfapiRibPendingDeleteRoute(struct bgp *bgp, struct rfapi_import_table *it,
 			 * prefix
 			 * previously, we should send an updated response.
 			 */
-			if ((rn = agg_node_lookup(rfd->rib[afi],
-						  &it_node->p))) {
+			if ((rn = agg_node_lookup(rfd->rib[afi], p))) {
 				rfapiRibUpdatePendingNode(
 					bgp, rfd, it, it_node,
 					rfd->response_lifetime);
@@ -2416,7 +2410,8 @@ void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 
 			for (rn = agg_route_top(rfd->rib[afi]); rn;
 			     rn = agg_route_next(rn)) {
-
+				const struct prefix *p =
+					agg_node_get_prefix(rn);
 				struct skiplist *sl;
 				char str_pfx[PREFIX_STRLEN];
 				int printedprefix = 0;
@@ -2433,9 +2428,8 @@ void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 				nhs_total += skiplist_count(sl);
 				++prefixes_total;
 
-				if (pfx_match
-				    && !prefix_match(pfx_match, &rn->p)
-				    && !prefix_match(&rn->p, pfx_match))
+				if (pfx_match && !prefix_match(pfx_match, p)
+				    && !prefix_match(p, pfx_match))
 					continue;
 
 				++prefixes_displayed;
@@ -2472,7 +2466,7 @@ void rfapiRibShowResponses(void *stream, struct prefix *pfx_match,
 								str_un,
 								BUFSIZ));
 				}
-				prefix2str(&rn->p, str_pfx, sizeof(str_pfx));
+				prefix2str(p, str_pfx, sizeof(str_pfx));
 				// fp(out, "  %s\n", buf);  /* prefix */
 
 				routes_displayed++;

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -388,10 +388,10 @@ extern void rfapi_rib_key_init(struct prefix *prefix, /* may be NULL */
 /*
  * Compares two <struct rfapi_rib_key>s
  */
-int rfapi_rib_key_cmp(void *k1, void *k2)
+int rfapi_rib_key_cmp(const void *k1, const void *k2)
 {
-	struct rfapi_rib_key *a = (struct rfapi_rib_key *)k1;
-	struct rfapi_rib_key *b = (struct rfapi_rib_key *)k2;
+	const struct rfapi_rib_key *a = (struct rfapi_rib_key *)k1;
+	const struct rfapi_rib_key *b = (struct rfapi_rib_key *)k2;
 	int ret;
 
 	if (!a || !b)

--- a/bgpd/rfapi/rfapi_rib.h
+++ b/bgpd/rfapi/rfapi_rib.h
@@ -147,7 +147,7 @@ extern void rfapi_rib_key_init(struct prefix *prefix, /* may be NULL */
 			       struct prefix *aux,    /* may be NULL */
 			       struct rfapi_rib_key *rk);
 
-extern int rfapi_rib_key_cmp(void *k1, void *k2);
+extern int rfapi_rib_key_cmp(const void *k1, const void *k2);
 
 extern void rfapiAdbFree(struct rfapi_adb *adb);
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -2754,10 +2754,10 @@ static void nve_addr_free(void *hap)
 	XFREE(MTYPE_RFAPI_NVE_ADDR, hap);
 }
 
-static int nve_addr_cmp(void *k1, void *k2)
+static int nve_addr_cmp(const void *k1, const void *k2)
 {
-	struct nve_addr *a = (struct nve_addr *)k1;
-	struct nve_addr *b = (struct nve_addr *)k2;
+	const struct nve_addr *a = (struct nve_addr *)k1;
+	const struct nve_addr *b = (struct nve_addr *)k2;
 	int ret = 0;
 
 	if (!a || !b) {

--- a/bgpd/rfapi/rfapi_vty.h
+++ b/bgpd/rfapi/rfapi_vty.h
@@ -43,7 +43,7 @@ extern void rfapiRprefixApplyMask(struct rfapi_ip_prefix *rprefix);
 extern int rfapiQprefix2Raddr(struct prefix *qprefix,
 			      struct rfapi_ip_addr *raddr);
 
-extern void rfapiQprefix2Rprefix(struct prefix *qprefix,
+extern void rfapiQprefix2Rprefix(const struct prefix *qprefix,
 				 struct rfapi_ip_prefix *rprefix);
 
 extern int rfapiRprefix2Qprefix(struct rfapi_ip_prefix *rprefix,

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -177,7 +177,7 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
 {
 	struct attr *attr = bpi->attr;
 	struct peer *peer = bpi->peer;
-	struct prefix *prefix = &rn->p;
+	const struct prefix *prefix = agg_node_get_prefix(rn);
 	afi_t afi = family2afi(prefix->family);
 	struct bgp_node *urn;
 	struct bgp_path_info *ubpi;
@@ -330,7 +330,8 @@ void vnc_direct_bgp_add_route_ce(struct bgp *bgp, struct agg_node *rn,
 void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
 				 struct bgp_path_info *bpi)
 {
-	afi_t afi = family2afi(rn->p.family);
+	const struct prefix *p = agg_node_get_prefix(rn);
+	afi_t afi = family2afi(p->family);
 	struct bgp_path_info *vbpi;
 	struct prefix ce_nexthop;
 
@@ -395,8 +396,8 @@ void vnc_direct_bgp_del_route_ce(struct bgp *bgp, struct agg_node *rn,
 	/*
 	 * withdraw the route
 	 */
-	bgp_withdraw(bpi->peer, &rn->p, 0, /* addpath_id */
-		     NULL,		   /* attr, ignored */
+	bgp_withdraw(bpi->peer, p, 0, /* addpath_id */
+		     NULL,	      /* attr, ignored */
 		     afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT,
 		     BGP_ROUTE_REDISTRIBUTE, NULL, /* RD not used for unicast */
 		     NULL, 0, NULL); /* tag not used for unicast */
@@ -432,17 +433,11 @@ static void vnc_direct_bgp_vpn_enable_ce(struct bgp *bgp, afi_t afi)
 	 */
 	for (rn = agg_route_top(bgp->rfapi->it_ce->imported_vpn[afi]); rn;
 	     rn = agg_route_next(rn)) {
-
 		if (!rn->info)
 			continue;
 
-		{
-			char prefixstr[PREFIX_STRLEN];
-
-			prefix2str(&rn->p, prefixstr, sizeof(prefixstr));
-			vnc_zlog_debug_verbose("%s: checking prefix %s",
-					       __func__, prefixstr);
-		}
+		vnc_zlog_debug_verbose("%s: checking prefix %pRN", __func__,
+				       rn);
 
 		for (ri = rn->info; ri; ri = ri->next) {
 
@@ -698,7 +693,8 @@ void vnc_direct_bgp_add_prefix(struct bgp *bgp,
 	struct attr attr = {0};
 	struct listnode *node, *nnode;
 	struct rfapi_rfg_name *rfgn;
-	afi_t afi = family2afi(rn->p.family);
+	const struct prefix *p = agg_node_get_prefix(rn);
+	afi_t afi = family2afi(p->family);
 
 	if (!afi) {
 		flog_err(EC_LIB_DEVELOPMENT, "%s: can't get afi of route node",
@@ -769,7 +765,7 @@ void vnc_direct_bgp_add_prefix(struct bgp *bgp,
 		 */
 		if (rfgn->rfg->plist_export_bgp[afi]) {
 			if (prefix_list_apply(rfgn->rfg->plist_export_bgp[afi],
-					      &rn->p)
+					      p)
 			    == PREFIX_DENY)
 
 				continue;
@@ -808,7 +804,8 @@ void vnc_direct_bgp_del_prefix(struct bgp *bgp,
 {
 	struct listnode *node, *nnode;
 	struct rfapi_rfg_name *rfgn;
-	afi_t afi = family2afi(rn->p.family);
+	const struct prefix *p = agg_node_get_prefix(rn);
+	afi_t afi = family2afi(p->family);
 
 	if (!afi) {
 		flog_err(EC_LIB_DEVELOPMENT, "%s: can't get afi route node",
@@ -877,9 +874,9 @@ void vnc_direct_bgp_del_prefix(struct bgp *bgp,
 			if (rfapiRaddr2Qprefix(&irfd->vn_addr, &nhp))
 				continue;
 
-			bgp_withdraw(irfd->peer, &rn->p, /* prefix */
-				     0,			 /* addpath_id */
-				     NULL,		 /* attr, ignored */
+			bgp_withdraw(irfd->peer, p, /* prefix */
+				     0,		    /* addpath_id */
+				     NULL,	    /* attr, ignored */
 				     afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT,
 				     BGP_ROUTE_REDISTRIBUTE,
 				     NULL, /* RD not used for unicast */
@@ -907,9 +904,9 @@ void vnc_direct_bgp_del_prefix(struct bgp *bgp,
 			if (rfapiRaddr2Qprefix(&irfd->vn_addr, &nhp))
 				continue;
 
-			bgp_withdraw(irfd->peer, &rn->p, /* prefix */
-				     0,			 /* addpath_id */
-				     NULL,		 /* attr, ignored */
+			bgp_withdraw(irfd->peer, p, /* prefix */
+				     0,		    /* addpath_id */
+				     NULL,	    /* attr, ignored */
 				     afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT,
 				     BGP_ROUTE_REDISTRIBUTE,
 				     NULL, /* RD not used for unicast */
@@ -998,6 +995,8 @@ void vnc_direct_bgp_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 					struct attr hattr;
 					struct attr *iattr;
 					struct bgp_path_info info;
+					const struct prefix *p =
+						agg_node_get_prefix(rn);
 
 					if (rfapiRaddr2Qprefix(&irfd->vn_addr,
 							       &nhp))
@@ -1010,7 +1009,7 @@ void vnc_direct_bgp_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 						if (prefix_list_apply(
 							    rfgn->rfg->plist_export_bgp
 								    [afi],
-							    &rn->p)
+							    p)
 						    == PREFIX_DENY)
 
 							continue;
@@ -1033,8 +1032,7 @@ void vnc_direct_bgp_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 						ret = route_map_apply(
 							rfgn->rfg
 								->routemap_export_bgp,
-							&rn->p, RMAP_BGP,
-							&info);
+							p, RMAP_BGP, &info);
 						if (ret == RMAP_DENYMATCH) {
 							bgp_attr_flush(&hattr);
 							continue;
@@ -1044,8 +1042,8 @@ void vnc_direct_bgp_add_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 					iattr = bgp_attr_intern(&hattr);
 					bgp_attr_flush(&hattr);
 					bgp_update(
-						irfd->peer, &rn->p, /* prefix */
-						0,     /* addpath_id */
+						irfd->peer, p, /* prefix */
+						0,	       /* addpath_id */
 						iattr, /* bgp_update copies
 							  it */
 						afi, SAFI_UNICAST,
@@ -1134,7 +1132,8 @@ void vnc_direct_bgp_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 			     rn = agg_route_next(rn)) {
 
 				if (rn->info) {
-
+					const struct prefix *p =
+						agg_node_get_prefix(rn);
 					struct prefix nhp;
 					struct rfapi_descriptor *irfd = rfd;
 
@@ -1142,10 +1141,9 @@ void vnc_direct_bgp_del_nve(struct bgp *bgp, struct rfapi_descriptor *rfd)
 							       &nhp))
 						continue;
 
-					bgp_withdraw(irfd->peer,
-						     &rn->p, /* prefix */
-						     0,      /* addpath_id */
-						     NULL,   /* attr, ignored */
+					bgp_withdraw(irfd->peer, p, /* prefix */
+						     0,	   /* addpath_id */
+						     NULL, /* attr, ignored */
 						     afi, SAFI_UNICAST,
 						     ZEBRA_ROUTE_VNC_DIRECT,
 						     BGP_ROUTE_REDISTRIBUTE,
@@ -1169,6 +1167,7 @@ static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 	struct bgp_path_info info;
 	struct attr hattr;
 	struct attr *iattr;
+	const struct prefix *p = agg_node_get_prefix(rn);
 
 	if (irfd == NULL && rfg->type != RFAPI_GROUP_CFG_VRF) {
 		/* need new rfapi_handle, for peer strcture
@@ -1242,8 +1241,8 @@ static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 
 		info.peer = irfd->peer;
 		info.attr = &hattr;
-		ret = route_map_apply(rfg->routemap_export_bgp, &rn->p,
-				      RMAP_BGP, &info);
+		ret = route_map_apply(rfg->routemap_export_bgp, p, RMAP_BGP,
+				      &info);
 		if (ret == RMAP_DENYMATCH) {
 			bgp_attr_flush(&hattr);
 			vnc_zlog_debug_verbose(
@@ -1261,9 +1260,9 @@ static void vnc_direct_add_rn_group_rd(struct bgp *bgp,
 	iattr = bgp_attr_intern(&hattr);
 	bgp_attr_flush(&hattr);
 
-	bgp_update(irfd->peer, &rn->p, /* prefix */
-		   0,		       /* addpath_id */
-		   iattr,	      /* bgp_update copies it */
+	bgp_update(irfd->peer, p, /* prefix */
+		   0,		  /* addpath_id */
+		   iattr,	  /* bgp_update copies it */
 		   afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT,
 		   BGP_ROUTE_REDISTRIBUTE, NULL, /* RD not used for unicast */
 		   NULL,			 /* tag not used for unicast */
@@ -1317,7 +1316,7 @@ static void vnc_direct_bgp_add_group_afi(struct bgp *bgp,
 	for (rn = agg_route_top(rt); rn; rn = agg_route_next(rn)) {
 
 		if (rn->info) {
-
+			const struct prefix *p = agg_node_get_prefix(rn);
 			struct listnode *ln;
 
 			/*
@@ -1325,7 +1324,7 @@ static void vnc_direct_bgp_add_group_afi(struct bgp *bgp,
 			 */
 			if (rfg->plist_export_bgp[afi]) {
 				if (prefix_list_apply(
-					    rfg->plist_export_bgp[afi], &rn->p)
+					    rfg->plist_export_bgp[afi], p)
 				    == PREFIX_DENY)
 
 					continue;
@@ -1374,9 +1373,10 @@ static void vnc_direct_del_rn_group_rd(struct bgp *bgp,
 {
 	if (irfd == NULL)
 		return;
-	bgp_withdraw(irfd->peer, &rn->p, /* prefix */
-		     0,			 /* addpath_id */
-		     NULL,		 /* attr, ignored */
+
+	bgp_withdraw(irfd->peer, agg_node_get_prefix(rn), /* prefix */
+		     0,					  /* addpath_id */
+		     NULL,				  /* attr, ignored */
 		     afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT,
 		     BGP_ROUTE_REDISTRIBUTE, NULL, /* RD not used for unicast */
 		     NULL, 0, NULL); /* tag not used for unicast */
@@ -1493,9 +1493,9 @@ static void vnc_direct_bgp_unexport_table(afi_t afi, struct agg_table *rt,
 							  irfd)) {
 
 					bgp_withdraw(irfd->peer,
-						     &rn->p, /* prefix */
-						     0,      /* addpath_id */
-						     NULL,   /* attr, ignored */
+						     agg_node_get_prefix(rn),
+						     0,	   /* addpath_id */
+						     NULL, /* attr, ignored */
 						     afi, SAFI_UNICAST,
 						     ZEBRA_ROUTE_VNC_DIRECT,
 						     BGP_ROUTE_REDISTRIBUTE,
@@ -1732,13 +1732,14 @@ void vnc_direct_bgp_rh_add_route(struct bgp *bgp, afi_t afi,
 static int vncExportWithdrawTimer(struct thread *t)
 {
 	struct vnc_export_info *eti = t->arg;
+	const struct prefix *p = agg_node_get_prefix(eti->node);
 
 	/*
 	 * withdraw the route
 	 */
-	bgp_withdraw(eti->peer, &eti->node->p, 0, /* addpath_id */
-		     NULL,			  /* attr, ignored */
-		     family2afi(eti->node->p.family), SAFI_UNICAST, eti->type,
+	bgp_withdraw(eti->peer, p, 0, /* addpath_id */
+		     NULL,	      /* attr, ignored */
+		     family2afi(p->family), SAFI_UNICAST, eti->type,
 		     eti->subtype, NULL, /* RD not used for unicast */
 		     NULL, 0,
 		     NULL); /* tag not used for unicast, EVPN neither */

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -1633,7 +1633,7 @@ void vnc_direct_bgp_vpn_disable(struct bgp *bgp, afi_t afi)
  * caller do it?
  */
 void vnc_direct_bgp_rh_add_route(struct bgp *bgp, afi_t afi,
-				 struct prefix *prefix, struct peer *peer,
+				 const struct prefix *prefix, struct peer *peer,
 				 struct attr *attr)
 {
 	struct vnc_export_info *eti;
@@ -1757,7 +1757,7 @@ static int vncExportWithdrawTimer(struct thread *t)
  * caller do it?
  */
 void vnc_direct_bgp_rh_del_route(struct bgp *bgp, afi_t afi,
-				 struct prefix *prefix, struct peer *peer)
+				 const struct prefix *prefix, struct peer *peer)
 {
 	struct vnc_export_info *eti;
 

--- a/bgpd/rfapi/vnc_export_bgp_p.h
+++ b/bgpd/rfapi/vnc_export_bgp_p.h
@@ -61,12 +61,12 @@ extern void vnc_direct_bgp_reexport_group_afi(struct bgp *bgp,
 
 
 extern void vnc_direct_bgp_rh_add_route(struct bgp *bgp, afi_t afi,
-					struct prefix *prefix,
+					const struct prefix *prefix,
 					struct peer *peer, struct attr *attr);
 
 
 extern void vnc_direct_bgp_rh_del_route(struct bgp *bgp, afi_t afi,
-					struct prefix *prefix,
+					const struct prefix *prefix,
 					struct peer *peer);
 
 extern void vnc_direct_bgp_reexport(struct bgp *bgp, afi_t afi);

--- a/bgpd/rfapi/vnc_export_table.c
+++ b/bgpd/rfapi/vnc_export_table.c
@@ -34,7 +34,7 @@
 #include "bgpd/rfapi/vnc_debug.h"
 
 struct agg_node *vnc_etn_get(struct bgp *bgp, vnc_export_type_t type,
-			     struct prefix *p)
+			     const struct prefix *p)
 {
 	struct agg_table *t = NULL;
 	struct agg_node *rn = NULL;
@@ -66,7 +66,7 @@ struct agg_node *vnc_etn_get(struct bgp *bgp, vnc_export_type_t type,
 }
 
 struct agg_node *vnc_etn_lookup(struct bgp *bgp, vnc_export_type_t type,
-				struct prefix *p)
+				const struct prefix *p)
 {
 	struct agg_table *t = NULL;
 	struct agg_node *rn = NULL;
@@ -98,7 +98,7 @@ struct agg_node *vnc_etn_lookup(struct bgp *bgp, vnc_export_type_t type,
 }
 
 struct vnc_export_info *vnc_eti_get(struct bgp *bgp, vnc_export_type_t etype,
-				    struct prefix *p, struct peer *peer,
+				    const struct prefix *p, struct peer *peer,
 				    uint8_t type, uint8_t subtype)
 {
 	struct agg_node *etn;

--- a/bgpd/rfapi/vnc_export_table.h
+++ b/bgpd/rfapi/vnc_export_table.h
@@ -46,15 +46,14 @@ struct vnc_export_info {
 };
 
 extern struct agg_node *vnc_etn_get(struct bgp *bgp, vnc_export_type_t type,
-				    struct prefix *p);
+				    const struct prefix *p);
 
 extern struct agg_node *vnc_etn_lookup(struct bgp *bgp, vnc_export_type_t type,
-				       struct prefix *p);
+				       const struct prefix *p);
 
-extern struct vnc_export_info *vnc_eti_get(struct bgp *bgp,
-					   vnc_export_type_t etype,
-					   struct prefix *p, struct peer *peer,
-					   uint8_t type, uint8_t subtype);
+extern struct vnc_export_info *
+vnc_eti_get(struct bgp *bgp, vnc_export_type_t etype, const struct prefix *p,
+	    struct peer *peer, uint8_t type, uint8_t subtype);
 
 extern void vnc_eti_delete(struct vnc_export_info *goner);
 

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -128,14 +128,14 @@ struct prefix_bag {
 static const uint8_t maskbit[] = {0x00, 0x80, 0xc0, 0xe0, 0xf0,
 				  0xf8, 0xfc, 0xfe, 0xff};
 
-int vnc_prefix_cmp(void *pfx1, void *pfx2)
+int vnc_prefix_cmp(const void *pfx1, const void *pfx2)
 {
 	int offset;
 	int shift;
 	uint8_t mask;
 
-	struct prefix *p1 = pfx1;
-	struct prefix *p2 = pfx2;
+	const struct prefix *p1 = pfx1;
+	const struct prefix *p2 = pfx2;
 
 	if (p1->family < p2->family)
 		return -1;

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -2028,7 +2028,8 @@ void vnc_import_bgp_exterior_add_route_interior(
 	struct agg_node *rn_interior,       /* VPN IT node */
 	struct bgp_path_info *bpi_interior) /* VPN IT route */
 {
-	afi_t afi = family2afi(rn_interior->p.family);
+	const struct prefix *p = agg_node_get_prefix(rn_interior);
+	afi_t afi = family2afi(p->family);
 	struct agg_node *par;
 	struct bgp_path_info *bpi_exterior;
 	struct prefix *pfx_exterior; /* exterior pfx */
@@ -2058,13 +2059,8 @@ void vnc_import_bgp_exterior_add_route_interior(
 	}
 
 	/*debugging */
-	{
-		char str_pfx[PREFIX_STRLEN];
-
-		prefix2str(&rn_interior->p, str_pfx, sizeof(str_pfx));
-		vnc_zlog_debug_verbose("%s: interior prefix=%s, bpi type=%d",
-				       __func__, str_pfx, bpi_interior->type);
-	}
+	vnc_zlog_debug_verbose("%s: interior prefix=%pRN, bpi type=%d",
+			       __func__, rn_interior, bpi_interior->type);
 
 	if (RFAPI_HAS_MONITOR_EXTERIOR(rn_interior)) {
 
@@ -2179,7 +2175,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 			rfapiUnicastNexthop2Prefix(afi, bpi_exterior->attr,
 						   &pfx_nexthop);
 
-			if (prefix_match(&rn_interior->p, &pfx_nexthop)) {
+			if (prefix_match(p, &pfx_nexthop)) {
 
 				struct bgp_path_info *bpi;
 				struct prefix_rd *prd;
@@ -2322,7 +2318,7 @@ void vnc_import_bgp_exterior_add_route_interior(
 		rfapiUnicastNexthop2Prefix(afi, bpi_exterior->attr,
 					   &pfx_nexthop);
 
-		if (prefix_match(&rn_interior->p, &pfx_nexthop)) {
+		if (prefix_match(p, &pfx_nexthop)) {
 
 			struct prefix_rd *prd;
 			struct attr new_attr;
@@ -2410,7 +2406,8 @@ void vnc_import_bgp_exterior_del_route_interior(
 	struct agg_node *rn_interior,       /* VPN IT node */
 	struct bgp_path_info *bpi_interior) /* VPN IT route */
 {
-	afi_t afi = family2afi(rn_interior->p.family);
+	const struct prefix *p = agg_node_get_prefix(rn_interior);
+	afi_t afi = family2afi(p->family);
 	struct agg_node *par;
 	struct bgp_path_info *bpi_exterior;
 	struct prefix *pfx_exterior; /* exterior pfx */
@@ -2444,14 +2441,8 @@ void vnc_import_bgp_exterior_del_route_interior(
 	}
 
 	/*debugging */
-	{
-		char str_pfx[PREFIX_STRLEN];
-
-		prefix2str(&rn_interior->p, str_pfx, sizeof(str_pfx));
-
-		vnc_zlog_debug_verbose("%s: interior prefix=%s, bpi type=%d",
-				       __func__, str_pfx, bpi_interior->type);
-	}
+	vnc_zlog_debug_verbose("%s: interior prefix=%pRN, bpi type=%d",
+			       __func__, rn_interior, bpi_interior->type);
 
 	/*
 	 * Remove constructed routes based on the deleted interior route

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -104,7 +104,7 @@ uint32_t calc_local_pref(struct attr *attr, struct peer *peer)
 	return local_pref;
 }
 
-static int is_host_prefix(struct prefix *p)
+static int is_host_prefix(const struct prefix *p)
 {
 	switch (p->family) {
 	case AF_INET:
@@ -299,9 +299,9 @@ static void vnc_rhnck(char *tag)
  */
 static int process_unicast_route(struct bgp *bgp,		 /* in */
 				 afi_t afi,			 /* in */
-				 struct prefix *prefix,		 /* in */
-				 struct bgp_path_info *info,     /* in */
-				 struct ecommunity **ecom,       /* OUT */
+				 const struct prefix *prefix,	 /* in */
+				 struct bgp_path_info *info,	 /* in */
+				 struct ecommunity **ecom,	 /* OUT */
 				 struct prefix *unicast_nexthop) /* OUT */
 {
 	struct rfapi_cfg *hc = bgp->rfapi_cfg;
@@ -425,10 +425,10 @@ static int process_unicast_route(struct bgp *bgp,		 /* in */
 static void vnc_import_bgp_add_route_mode_resolve_nve_one_bi(
 	struct bgp *bgp, afi_t afi, struct bgp_path_info *bpi, /* VPN bpi */
 	struct prefix_rd *prd,				       /* RD */
-	struct prefix *prefix,   /* unicast route prefix */
-	uint32_t *local_pref,    /* NULL = no local_pref */
-	uint32_t *med,		 /* NULL = no med */
-	struct ecommunity *ecom) /* generated ecoms */
+	const struct prefix *prefix, /* unicast route prefix */
+	uint32_t *local_pref,	     /* NULL = no local_pref */
+	uint32_t *med,		     /* NULL = no med */
+	struct ecommunity *ecom)     /* generated ecoms */
 {
 	struct prefix un;
 	struct prefix nexthop;
@@ -509,11 +509,12 @@ static void vnc_import_bgp_add_route_mode_resolve_nve_one_bi(
 }
 
 static void vnc_import_bgp_add_route_mode_resolve_nve_one_rd(
-	struct prefix_rd *prd,      /* RD */
+	struct prefix_rd *prd,	    /* RD */
 	struct bgp_table *table_rd, /* per-rd VPN route table */
-	afi_t afi, struct bgp *bgp, struct prefix *prefix, /* unicast prefix */
-	struct ecommunity *ecom,			   /* generated ecoms */
-	uint32_t *local_pref,	/* NULL = no local_pref */
+	afi_t afi, struct bgp *bgp,
+	const struct prefix *prefix, /* unicast prefix */
+	struct ecommunity *ecom,     /* generated ecoms */
+	uint32_t *local_pref,	     /* NULL = no local_pref */
 	uint32_t *med,		     /* NULL = no med */
 	struct prefix *ubpi_nexthop) /* unicast nexthop */
 {
@@ -552,8 +553,8 @@ static void vnc_import_bgp_add_route_mode_resolve_nve_one_rd(
 }
 
 static void vnc_import_bgp_add_route_mode_resolve_nve(
-	struct bgp *bgp, struct prefix *prefix, /* unicast prefix */
-	struct bgp_path_info *info)		/* unicast info */
+	struct bgp *bgp, const struct prefix *prefix, /* unicast prefix */
+	struct bgp_path_info *info)		      /* unicast info */
 {
 	afi_t afi = family2afi(prefix->family);
 
@@ -686,7 +687,7 @@ static void vnc_import_bgp_add_route_mode_resolve_nve(
 
 
 static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
-						struct prefix *prefix,
+						const struct prefix *prefix,
 						struct bgp_path_info *info)
 {
 	afi_t afi = family2afi(prefix->family);
@@ -874,10 +875,9 @@ static void vnc_import_bgp_add_route_mode_plain(struct bgp *bgp,
 		ecommunity_free(&ecom);
 }
 
-static void
-vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
-				       struct bgp_path_info *info,
-				       struct rfapi_nve_group_cfg *rfg)
+static void vnc_import_bgp_add_route_mode_nvegroup(
+	struct bgp *bgp, const struct prefix *prefix,
+	struct bgp_path_info *info, struct rfapi_nve_group_cfg *rfg)
 {
 	afi_t afi = family2afi(prefix->family);
 	struct peer *peer = info->peer;
@@ -1080,7 +1080,7 @@ vnc_import_bgp_add_route_mode_nvegroup(struct bgp *bgp, struct prefix *prefix,
 }
 
 static void vnc_import_bgp_del_route_mode_plain(struct bgp *bgp,
-						struct prefix *prefix,
+						const struct prefix *prefix,
 						struct bgp_path_info *info)
 {
 	struct prefix_rd prd;
@@ -1153,7 +1153,7 @@ static void vnc_import_bgp_del_route_mode_plain(struct bgp *bgp,
 }
 
 static void vnc_import_bgp_del_route_mode_nvegroup(struct bgp *bgp,
-						   struct prefix *prefix,
+						   const struct prefix *prefix,
 						   struct bgp_path_info *info)
 {
 	struct prefix_rd prd;
@@ -1236,7 +1236,7 @@ static void vnc_import_bgp_del_route_mode_nvegroup(struct bgp *bgp,
 static void vnc_import_bgp_del_route_mode_resolve_nve_one_bi(
 	struct bgp *bgp, afi_t afi, struct bgp_path_info *bpi, /* VPN bpi */
 	struct prefix_rd *prd,				       /* RD */
-	struct prefix *prefix) /* unicast route prefix */
+	const struct prefix *prefix) /* unicast route prefix */
 {
 	struct prefix un;
 
@@ -1272,8 +1272,9 @@ static void vnc_import_bgp_del_route_mode_resolve_nve_one_bi(
 static void vnc_import_bgp_del_route_mode_resolve_nve_one_rd(
 	struct prefix_rd *prd,
 	struct bgp_table *table_rd, /* per-rd VPN route table */
-	afi_t afi, struct bgp *bgp, struct prefix *prefix, /* unicast prefix */
-	struct prefix *ubpi_nexthop) /* unicast bpi's nexthop */
+	afi_t afi, struct bgp *bgp,
+	const struct prefix *prefix,	   /* unicast prefix */
+	const struct prefix *ubpi_nexthop) /* unicast bpi's nexthop */
 {
 	struct bgp_node *bn;
 	struct bgp_path_info *bpi;
@@ -1312,7 +1313,7 @@ static void vnc_import_bgp_del_route_mode_resolve_nve_one_rd(
 
 static void
 vnc_import_bgp_del_route_mode_resolve_nve(struct bgp *bgp, afi_t afi,
-					  struct prefix *prefix,
+					  const struct prefix *prefix,
 					  struct bgp_path_info *info)
 {
 	struct ecommunity *ecom = NULL;
@@ -1396,7 +1397,7 @@ vnc_import_bgp_del_route_mode_resolve_nve(struct bgp *bgp, afi_t afi,
 void vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
-	struct prefix *prefix,			/* VPN prefix */
+	const struct prefix *prefix,		/* VPN prefix */
 	struct bgp_path_info *bpi)		/* new VPN host route */
 {
 	afi_t afi = family2afi(prefix->family);
@@ -1533,7 +1534,7 @@ void vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
 void vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
-	struct prefix *prefix,			/* VPN prefix */
+	const struct prefix *prefix,		/* VPN prefix */
 	struct bgp_path_info *bpi)		/* old VPN host route */
 {
 	afi_t afi = family2afi(prefix->family);
@@ -1675,8 +1676,8 @@ static int is_usable_interior_route(struct bgp_path_info *bpi_interior)
  */
 static void vnc_import_bgp_exterior_add_route_it(
 	struct bgp *bgp,		    /* exterior instance, we hope */
-	struct prefix *prefix,		    /* unicast prefix */
-	struct bgp_path_info *info,	 /* unicast info */
+	const struct prefix *prefix,	    /* unicast prefix */
+	struct bgp_path_info *info,	    /* unicast info */
 	struct rfapi_import_table *it_only) /* NULL, or limit to this IT */
 {
 	struct rfapi *h;
@@ -1844,9 +1845,9 @@ static void vnc_import_bgp_exterior_add_route_it(
 }
 
 void vnc_import_bgp_exterior_add_route(
-	struct bgp *bgp,	    /* exterior instance, we hope */
-	struct prefix *prefix,      /* unicast prefix */
-	struct bgp_path_info *info) /* unicast info */
+	struct bgp *bgp,	     /* exterior instance, we hope */
+	const struct prefix *prefix, /* unicast prefix */
+	struct bgp_path_info *info)  /* unicast info */
 {
 	vnc_import_bgp_exterior_add_route_it(bgp, prefix, info, NULL);
 }
@@ -1861,8 +1862,8 @@ void vnc_import_bgp_exterior_add_route(
  * right routes.
  */
 void vnc_import_bgp_exterior_del_route(
-	struct bgp *bgp, struct prefix *prefix, /* unicast prefix */
-	struct bgp_path_info *info)		/* unicast info */
+	struct bgp *bgp, const struct prefix *prefix, /* unicast prefix */
+	struct bgp_path_info *info)		      /* unicast info */
 {
 	struct rfapi *h;
 	struct rfapi_cfg *hc;
@@ -2597,7 +2598,7 @@ void vnc_import_bgp_exterior_del_route_interior(
  *			Generic add/delete unicast routes
  ***********************************************************************/
 
-void vnc_import_bgp_add_route(struct bgp *bgp, struct prefix *prefix,
+void vnc_import_bgp_add_route(struct bgp *bgp, const struct prefix *prefix,
 			      struct bgp_path_info *info)
 {
 	afi_t afi = family2afi(prefix->family);
@@ -2666,7 +2667,7 @@ void vnc_import_bgp_add_route(struct bgp *bgp, struct prefix *prefix,
 /*
  * "Withdrawing a Route" import process
  */
-void vnc_import_bgp_del_route(struct bgp *bgp, struct prefix *prefix,
+void vnc_import_bgp_del_route(struct bgp *bgp, const struct prefix *prefix,
 			      struct bgp_path_info *info) /* unicast info */
 {
 	afi_t afi = family2afi(prefix->family);

--- a/bgpd/rfapi/vnc_import_bgp.h
+++ b/bgpd/rfapi/vnc_import_bgp.h
@@ -34,10 +34,12 @@ extern uint32_t calc_local_pref(struct attr *attr, struct peer *peer);
 
 extern int vnc_prefix_cmp(const void *pfx1, const void *pfx2);
 
-extern void vnc_import_bgp_add_route(struct bgp *bgp, struct prefix *prefix,
+extern void vnc_import_bgp_add_route(struct bgp *bgp,
+				     const struct prefix *prefix,
 				     struct bgp_path_info *info);
 
-extern void vnc_import_bgp_del_route(struct bgp *bgp, struct prefix *prefix,
+extern void vnc_import_bgp_del_route(struct bgp *bgp,
+				     const struct prefix *prefix,
 				     struct bgp_path_info *info);
 
 extern void vnc_import_bgp_redist_enable(struct bgp *bgp, afi_t afi);
@@ -51,23 +53,23 @@ extern void vnc_import_bgp_exterior_redist_disable(struct bgp *bgp, afi_t afi);
 
 extern void vnc_import_bgp_exterior_add_route(
 	struct bgp *bgp,	     /* exterior instance, we hope */
-	struct prefix *prefix,       /* unicast prefix */
+	const struct prefix *prefix, /* unicast prefix */
 	struct bgp_path_info *info); /* unicast info */
 
 extern void vnc_import_bgp_exterior_del_route(
-	struct bgp *bgp, struct prefix *prefix, /* unicast prefix */
-	struct bgp_path_info *info);		/* unicast info */
+	struct bgp *bgp, const struct prefix *prefix, /* unicast prefix */
+	struct bgp_path_info *info);		      /* unicast info */
 
 extern void vnc_import_bgp_add_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
-	struct prefix *prefix,			/* VPN prefix */
+	const struct prefix *prefix,		/* VPN prefix */
 	struct bgp_path_info *bpi);		/* new VPN host route */
 
 extern void vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
 	struct bgp *bgp, struct prefix_rd *prd, /* RD */
 	struct bgp_table *table_rd,		/* per-rd VPN route table */
-	struct prefix *prefix,			/* VPN prefix */
+	const struct prefix *prefix,		/* VPN prefix */
 	struct bgp_path_info *bpi);		/* old VPN host route */
 
 #endif /* _QUAGGA_RFAPI_VNC_IMPORT_BGP_H_ */

--- a/bgpd/rfapi/vnc_import_bgp.h
+++ b/bgpd/rfapi/vnc_import_bgp.h
@@ -32,7 +32,7 @@
 
 extern uint32_t calc_local_pref(struct attr *attr, struct peer *peer);
 
-extern int vnc_prefix_cmp(void *pfx1, void *pfx2);
+extern int vnc_prefix_cmp(const void *pfx1, const void *pfx2);
 
 extern void vnc_import_bgp_add_route(struct bgp *bgp, struct prefix *prefix,
 				     struct bgp_path_info *info);

--- a/isisd/fabricd.c
+++ b/isisd/fabricd.c
@@ -122,9 +122,9 @@ static bool neighbor_entry_hash_cmp(const void *a, const void *b)
 	return memcmp(na->id, nb->id, sizeof(na->id)) == 0;
 }
 
-static int neighbor_entry_list_cmp(void *a, void *b)
+static int neighbor_entry_list_cmp(const void *a, const void *b)
 {
-	struct neighbor_entry *na = a, *nb = b;
+	const struct neighbor_entry *na = a, *nb = b;
 
 	return -memcmp(na->id, nb->id, sizeof(na->id));
 }

--- a/isisd/isis_spf_private.h
+++ b/isisd/isis_spf_private.h
@@ -117,11 +117,11 @@ static bool isis_vertex_queue_hash_cmp(const void *a, const void *b)
  * Compares vertizes for sorting in the TENT list. Returns true
  * if candidate should be considered before current, false otherwise.
  */
-__attribute__((__unused__))
-static int isis_vertex_queue_tent_cmp(void *a, void *b)
+__attribute__((__unused__)) static int isis_vertex_queue_tent_cmp(const void *a,
+								  const void *b)
 {
-	struct isis_vertex *va = a;
-	struct isis_vertex *vb = b;
+	const struct isis_vertex *va = a;
+	const struct isis_vertex *vb = b;
 
 	if (va->d_N < vb->d_N)
 		return -1;

--- a/lib/agg_table.h
+++ b/lib/agg_table.h
@@ -155,6 +155,12 @@ static inline struct agg_table *agg_get_table(struct agg_node *node)
 	return (struct agg_table *)route_table_get_info(node->table);
 }
 
+static inline const struct prefix *
+agg_node_get_prefix(const struct agg_node *node)
+{
+	return &node->p;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/skiplist.c
+++ b/lib/skiplist.c
@@ -112,7 +112,7 @@ static int randomLevel(void)
 	return level;
 }
 
-static int default_cmp(void *key1, void *key2)
+static int default_cmp(const void *key1, const void *key2)
 {
 	if (key1 < key2)
 		return -1;
@@ -126,7 +126,8 @@ unsigned int skiplist_count(struct skiplist *l)
 	return l->count;
 }
 
-struct skiplist *skiplist_new(int flags, int (*cmp)(void *key1, void *key2),
+struct skiplist *skiplist_new(int flags,
+			      int (*cmp)(const void *key1, const void *key2),
 			      void (*del)(void *val))
 {
 	struct skiplist *new;
@@ -329,8 +330,8 @@ int skiplist_delete(register struct skiplist *l, register void *key,
  * Also set a cursor for use with skiplist_next_value.
  */
 int skiplist_first_value(register struct skiplist *l, /* in */
-			 register void *key,	  /* in */
-			 void **valuePointer,	 /* out */
+			 register const void *key,    /* in */
+			 void **valuePointer,	      /* out */
 			 void **cursor)		      /* out */
 {
 	register int k;
@@ -374,7 +375,7 @@ int skiplist_search(register struct skiplist *l, register void *key,
  * last element with the given key, -1 is returned.
  */
 int skiplist_next_value(register struct skiplist *l, /* in */
-			register void *key,	  /* in */
+			register const void *key,	  /* in */
 			void **valuePointer,	 /* in/out */
 			void **cursor)		     /* in/out */
 {

--- a/lib/skiplist.h
+++ b/lib/skiplist.h
@@ -68,7 +68,7 @@ struct skiplist {
 	 * Returns -1 if val1 < val2, 0 if equal?, 1 if val1 > val2.
 	 * Used as definition of sorted for listnode_add_sort
 	 */
-	int (*cmp)(void *val1, void *val2);
+	int (*cmp)(const void *val1, const void *val2);
 
 	/* callback to free user-owned data when listnode is deleted. supplying
 	 * this callback is very much encouraged!
@@ -81,8 +81,9 @@ struct skiplist {
 extern struct skiplist *
 skiplist_new(/* encouraged: set list.del callback on new lists */
 	     int flags,
-	     int (*cmp)(void *key1, void *key2), /* NULL => default cmp */
-	     void (*del)(void *val));		 /* NULL => no auto val free */
+	     int (*cmp)(const void *key1,
+			const void *key2), /* NULL => default cmp */
+	     void (*del)(void *val));	   /* NULL => no auto val free */
 
 extern void skiplist_free(struct skiplist *);
 
@@ -96,12 +97,12 @@ extern int skiplist_search(register struct skiplist *l, register void *key,
 			   void **valuePointer);
 
 extern int skiplist_first_value(register struct skiplist *l, /* in */
-				register void *key,	  /* in */
-				void **valuePointer,	 /* in/out */
+				register const void *key,    /* in */
+				void **valuePointer,	     /* in/out */
 				void **cursor);		     /* out */
 
 extern int skiplist_next_value(register struct skiplist *l, /* in */
-			       register void *key,	  /* in */
+			       register const void *key,	  /* in */
 			       void **valuePointer,	 /* in/out */
 			       void **cursor);		    /* in/out */
 

--- a/ripngd/ripng_interface.c
+++ b/ripngd/ripng_interface.c
@@ -867,17 +867,12 @@ int ripng_network_write(struct vty *vty, struct ripng *ripng)
 	unsigned int i;
 	const char *ifname;
 	struct agg_node *node;
-	char buf[BUFSIZ];
 
 	/* Write enable network. */
 	for (node = agg_route_top(ripng->enable_network); node;
 	     node = agg_route_next(node))
-		if (node->info) {
-			struct prefix *p = &node->p;
-			vty_out(vty, "    %s/%d\n",
-				inet_ntop(p->family, &p->u.prefix, buf, BUFSIZ),
-				p->prefixlen);
-		}
+		if (node->info)
+			vty_out(vty, "    %pRN\n", node);
 
 	/* Write enable interface. */
 	for (i = 0; i < vector_active(ripng->enable_if); i++)

--- a/ripngd/ripng_nb_state.c
+++ b/ripngd/ripng_nb_state.c
@@ -158,7 +158,8 @@ int ripngd_instance_state_routes_route_get_keys(const void *list_entry,
 	const struct agg_node *rn = list_entry;
 
 	keys->num = 1;
-	(void)prefix2str(&rn->p, keys->key[0], sizeof(keys->key[0]));
+	(void)prefix2str(agg_node_get_prefix(rn), keys->key[0],
+			 sizeof(keys->key[0]));
 
 	return NB_OK;
 }
@@ -191,7 +192,7 @@ ripngd_instance_state_routes_route_prefix_get_elem(const char *xpath,
 	const struct agg_node *rn = list_entry;
 	const struct ripng_info *rinfo = listnode_head(rn->info);
 
-	return yang_data_new_ipv6p(xpath, &rinfo->rp->p);
+	return yang_data_new_ipv6p(xpath, agg_node_get_prefix(rinfo->rp));
 }
 
 /*

--- a/ripngd/ripng_zebra.c
+++ b/ripngd/ripng_zebra.c
@@ -46,12 +46,13 @@ static void ripng_zebra_ipv6_send(struct ripng *ripng, struct agg_node *rp,
 	struct listnode *listnode = NULL;
 	struct ripng_info *rinfo = NULL;
 	int count = 0;
+	const struct prefix *p = agg_node_get_prefix(rp);
 
 	memset(&api, 0, sizeof(api));
 	api.vrf_id = ripng->vrf->vrf_id;
 	api.type = ZEBRA_ROUTE_RIPNG;
 	api.safi = SAFI_UNICAST;
-	api.prefix = rp->p;
+	api.prefix = *p;
 
 	SET_FLAG(api.message, ZAPI_MESSAGE_NEXTHOP);
 	for (ALL_LIST_ELEMENTS_RO(list, listnode, rinfo)) {
@@ -85,18 +86,17 @@ static void ripng_zebra_ipv6_send(struct ripng *ripng, struct agg_node *rp,
 
 	if (IS_RIPNG_DEBUG_ZEBRA) {
 		if (ripng->ecmp)
-			zlog_debug("%s: %s/%d nexthops %d",
+			zlog_debug("%s: %pRN nexthops %d",
 				   (cmd == ZEBRA_ROUTE_ADD)
 					   ? "Install into zebra"
 					   : "Delete from zebra",
-				   inet6_ntoa(rp->p.u.prefix6), rp->p.prefixlen,
-				   count);
+				   rp, count);
 		else
-			zlog_debug(
-				"%s: %s/%d",
-				(cmd == ZEBRA_ROUTE_ADD) ? "Install into zebra"
-							 : "Delete from zebra",
-				inet6_ntoa(rp->p.u.prefix6), rp->p.prefixlen);
+			zlog_debug("%s: %pRN",
+				   (cmd == ZEBRA_ROUTE_ADD)
+					   ? "Install into zebra"
+					   : "Delete from zebra",
+				   rp);
 	}
 }
 


### PR DESCRIPTION
Goal is to modify the lib/agg_table.h to use a lookup for the prefix in the underlying route_node.  This will make it easier in the long run to force seperation between the different `route_node` types and their lookup functions and if we want to separate them out or chagne the underlying data structure a bit, having an accessor function will make this much easier