### PR TITLE
bgpd: More `const struct prefix` work

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -4130,7 +4130,7 @@ void bgp_attr_finish(void)
 
 /* Make attribute packet. */
 void bgp_dump_routes_attr(struct stream *s, struct attr *attr,
-			  struct prefix *prefix)
+			  const struct prefix *prefix)
 {
 	unsigned long cp;
 	unsigned long len;

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -324,8 +324,8 @@ extern bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *,
 				       struct prefix *, afi_t, safi_t,
 				       struct peer *, struct prefix_rd *,
 				       mpls_label_t *, uint32_t, int, uint32_t);
-extern void bgp_dump_routes_attr(struct stream *, struct attr *,
-				 struct prefix *);
+extern void bgp_dump_routes_attr(struct stream *s, struct attr *attr,
+				 const struct prefix *p);
 extern bool attrhash_cmp(const void *arg1, const void *arg2);
 extern unsigned int attrhash_key_make(const void *);
 extern void attr_show_all(struct vty *);

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -496,7 +496,7 @@ static void unmap_vni_from_rt(struct bgp *bgp, struct bgpevpn *vpn,
 }
 
 static void bgp_evpn_get_rmac_nexthop(struct bgpevpn *vpn,
-				      struct prefix_evpn *p,
+				      const struct prefix_evpn *p,
 				      struct attr *attr, uint8_t flags)
 {
 	struct bgp *bgp_vrf = vpn->bgp_vrf;
@@ -583,7 +583,7 @@ static void evpn_convert_nexthop_to_ipv6(struct attr *attr)
  * Add (update) or delete MACIP from zebra.
  */
 static int bgp_zebra_send_remote_macip(struct bgp *bgp, struct bgpevpn *vpn,
-				       struct prefix_evpn *p,
+				       const struct prefix_evpn *p,
 				       struct in_addr remote_vtep_ip, int add,
 				       uint8_t flags, uint32_t seq)
 {
@@ -651,8 +651,8 @@ static int bgp_zebra_send_remote_macip(struct bgp *bgp, struct bgpevpn *vpn,
  * Add (update) or delete remote VTEP from zebra.
  */
 static int bgp_zebra_send_remote_vtep(struct bgp *bgp, struct bgpevpn *vpn,
-				struct prefix_evpn *p,
-				int flood_control, int add)
+				      const struct prefix_evpn *p,
+				      int flood_control, int add)
 {
 	struct stream *s;
 
@@ -930,7 +930,8 @@ static void add_mac_mobility_to_attr(uint32_t seq_num, struct attr *attr)
 
 /* Install EVPN route into zebra. */
 static int evpn_zebra_install(struct bgp *bgp, struct bgpevpn *vpn,
-			      struct prefix_evpn *p, struct bgp_path_info *pi)
+			      const struct prefix_evpn *p,
+			      struct bgp_path_info *pi)
 {
 	int ret;
 	uint8_t flags;
@@ -970,7 +971,7 @@ static int evpn_zebra_install(struct bgp *bgp, struct bgpevpn *vpn,
 
 /* Uninstall EVPN route from zebra. */
 static int evpn_zebra_uninstall(struct bgp *bgp, struct bgpevpn *vpn,
-				struct prefix_evpn *p,
+				const struct prefix_evpn *p,
 				struct in_addr remote_vtep_ip)
 {
 	int ret;
@@ -1054,9 +1055,8 @@ static int is_vtep_present_in_list(struct list *list,
  * Best path for ES route was changed,
  * update the list of VTEPs for this ES
  */
-static int evpn_es_install_vtep(struct bgp *bgp,
-				struct evpnes *es,
-				struct prefix_evpn *p,
+static int evpn_es_install_vtep(struct bgp *bgp, struct evpnes *es,
+				const struct prefix_evpn *p,
 				struct in_addr rvtep)
 {
 	struct in_addr *vtep_ip;
@@ -1157,7 +1157,7 @@ static int evpn_es_route_select_install(struct bgp *bgp,
 	if (new_select && new_select->type == ZEBRA_ROUTE_BGP
 	    && new_select->sub_type == BGP_ROUTE_IMPORTED) {
 		ret = evpn_es_install_vtep(bgp, es,
-					   (struct prefix_evpn *)&rn->p,
+					   (const struct prefix_evpn *)&rn->p,
 					   new_select->attr->nexthop);
 	} else {
 		if (old_select && old_select->type == ZEBRA_ROUTE_BGP
@@ -2555,7 +2555,7 @@ bgp_create_evpn_bgp_path_info(struct bgp_path_info *parent_pi,
 
 /* Install EVPN route entry in ES */
 static int install_evpn_route_entry_in_es(struct bgp *bgp, struct evpnes *es,
-					  struct prefix_evpn *p,
+					  const struct prefix_evpn *p,
 					  struct bgp_path_info *parent_pi)
 {
 	int ret = 0;
@@ -2619,7 +2619,7 @@ static int install_evpn_route_entry_in_es(struct bgp *bgp, struct evpnes *es,
  * Install route entry into the VRF routing table and invoke route selection.
  */
 static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
-					   struct prefix_evpn *evp,
+					   const struct prefix_evpn *evp,
 					   struct bgp_path_info *parent_pi)
 {
 	struct bgp_node *rn;
@@ -2726,7 +2726,7 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
  * Install route entry into the VNI routing table and invoke route selection.
  */
 static int install_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
-				    struct prefix_evpn *p,
+				    const struct prefix_evpn *p,
 				    struct bgp_path_info *parent_pi)
 {
 	struct bgp_node *rn;
@@ -2782,7 +2782,7 @@ static int install_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 
 /* Uninstall EVPN route entry from ES route table */
 static int uninstall_evpn_route_entry_in_es(struct bgp *bgp, struct evpnes *es,
-					    struct prefix_evpn *p,
+					    const struct prefix_evpn *p,
 					    struct bgp_path_info *parent_pi)
 {
 	int ret;
@@ -2825,7 +2825,7 @@ static int uninstall_evpn_route_entry_in_es(struct bgp *bgp, struct evpnes *es,
  * to zebra, if appropriate.
  */
 static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
-					     struct prefix_evpn *evp,
+					     const struct prefix_evpn *evp,
 					     struct bgp_path_info *parent_pi)
 {
 	struct bgp_node *rn;
@@ -2895,7 +2895,7 @@ static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
  * to zebra, if appropriate.
  */
 static int uninstall_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
-				      struct prefix_evpn *p,
+				      const struct prefix_evpn *p,
 				      struct bgp_path_info *parent_pi)
 {
 	struct bgp_node *rn;
@@ -2932,7 +2932,7 @@ static int uninstall_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 /*
  * Given a prefix, see if it belongs to ES.
  */
-static int is_prefix_matching_for_es(struct prefix_evpn *p,
+static int is_prefix_matching_for_es(const struct prefix_evpn *p,
 				     struct evpnes *es)
 {
 	/* if not an ES route return false */
@@ -3153,7 +3153,7 @@ static int install_uninstall_routes_for_es(struct bgp *bgp,
  * route into bgp vrf table and remote rmac in bridge table.
  */
 static int bgp_evpn_route_rmac_self_check(struct bgp *bgp_vrf,
-					  struct prefix_evpn *evp,
+					  const struct prefix_evpn *evp,
 					  struct bgp_path_info *pi)
 {
 	/* evpn route could have learnt prior to L3vni has come up,
@@ -4465,7 +4465,7 @@ static void update_autort_vni(struct hash_bucket *bucket, struct bgp *bgp)
  */
 
 /* withdraw type-5 route corresponding to ip prefix */
-void bgp_evpn_withdraw_type5_route(struct bgp *bgp_vrf, struct prefix *p,
+void bgp_evpn_withdraw_type5_route(struct bgp *bgp_vrf, const struct prefix *p,
 				   afi_t afi, safi_t safi)
 {
 	int ret = 0;
@@ -4535,7 +4535,7 @@ void bgp_evpn_install_uninstall_default_route(struct bgp *bgp_vrf, afi_t afi,
  * path in the case of the attr. In the case of a local prefix (when we
  * are advertising local subnets), the src_attr will be NULL.
  */
-void bgp_evpn_advertise_type5_route(struct bgp *bgp_vrf, struct prefix *p,
+void bgp_evpn_advertise_type5_route(struct bgp *bgp_vrf, const struct prefix *p,
 				    struct attr *src_attr, afi_t afi,
 				    safi_t safi)
 {
@@ -4900,7 +4900,7 @@ char *bgp_evpn_label2str(mpls_label_t *label, uint32_t num_labels, char *buf,
  * Function to convert evpn route to json format.
  * NOTE: We don't use prefix2str as the output here is a bit different.
  */
-void bgp_evpn_route2json(struct prefix_evpn *p, json_object *json)
+void bgp_evpn_route2json(const struct prefix_evpn *p, json_object *json)
 {
 	char buf1[ETHER_ADDR_STRLEN];
 	char buf2[PREFIX2STR_BUFFER];
@@ -4965,7 +4965,7 @@ void bgp_evpn_route2json(struct prefix_evpn *p, json_object *json)
  * Function to convert evpn route to string.
  * NOTE: We don't use prefix2str as the output here is a bit different.
  */
-char *bgp_evpn_route2str(struct prefix_evpn *p, char *buf, int len)
+char *bgp_evpn_route2str(const struct prefix_evpn *p, char *buf, int len)
 {
 	char buf1[ETHER_ADDR_STRLEN];
 	char buf2[PREFIX2STR_BUFFER];

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -140,11 +140,12 @@ static inline bool is_route_injectable_into_evpn(struct bgp_path_info *pi)
 }
 
 extern void bgp_evpn_advertise_type5_route(struct bgp *bgp_vrf,
-					   struct prefix *p,
+					   const struct prefix *p,
 					   struct attr *src_attr, afi_t afi,
 					   safi_t safi);
-extern void bgp_evpn_withdraw_type5_route(struct bgp *bgp_vrf, struct prefix *p,
-					  afi_t afi, safi_t safi);
+extern void bgp_evpn_withdraw_type5_route(struct bgp *bgp_vrf,
+					  const struct prefix *p, afi_t afi,
+					  safi_t safi);
 extern void bgp_evpn_withdraw_type5_routes(struct bgp *bgp_vrf, afi_t afi,
 					   safi_t safi);
 extern void bgp_evpn_advertise_type5_routes(struct bgp *bgp_vrf, afi_t afi,
@@ -153,8 +154,9 @@ extern void bgp_evpn_vrf_delete(struct bgp *bgp_vrf);
 extern void bgp_evpn_handle_router_id_update(struct bgp *bgp, int withdraw);
 extern char *bgp_evpn_label2str(mpls_label_t *label, uint32_t num_labels,
 				char *buf, int len);
-extern char *bgp_evpn_route2str(struct prefix_evpn *p, char *buf, int len);
-extern void bgp_evpn_route2json(struct prefix_evpn *p, json_object *json);
+extern char *bgp_evpn_route2str(const struct prefix_evpn *p, char *buf,
+				int len);
+extern void bgp_evpn_route2json(const struct prefix_evpn *p, json_object *json);
 extern void bgp_evpn_encode_prefix(struct stream *s, struct prefix *p,
 				   struct prefix_rd *prd, mpls_label_t *label,
 				   uint32_t num_labels, struct attr *attr,

--- a/bgpd/bgp_evpn_private.h
+++ b/bgpd/bgp_evpn_private.h
@@ -366,7 +366,7 @@ static inline void encode_na_flag_extcomm(struct ecommunity_val *eval,
 		eval->val[2] |= ECOMMUNITY_EVPN_SUBTYPE_ND_ROUTER_FLAG;
 }
 
-static inline void ip_prefix_from_type5_prefix(struct prefix_evpn *evp,
+static inline void ip_prefix_from_type5_prefix(const struct prefix_evpn *evp,
 					       struct prefix *ip)
 {
 	memset(ip, 0, sizeof(struct prefix));
@@ -392,7 +392,7 @@ static inline int is_evpn_prefix_default(const struct prefix *evp)
 		1 : 0);
 }
 
-static inline void ip_prefix_from_type2_prefix(struct prefix_evpn *evp,
+static inline void ip_prefix_from_type2_prefix(const struct prefix_evpn *evp,
 					       struct prefix *ip)
 {
 	memset(ip, 0, sizeof(struct prefix));
@@ -409,7 +409,7 @@ static inline void ip_prefix_from_type2_prefix(struct prefix_evpn *evp,
 	}
 }
 
-static inline void ip_prefix_from_evpn_prefix(struct prefix_evpn *evp,
+static inline void ip_prefix_from_evpn_prefix(const struct prefix_evpn *evp,
 					      struct prefix *ip)
 {
 	if (evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE)
@@ -432,8 +432,9 @@ static inline void build_evpn_type2_prefix(struct prefix_evpn *p,
 		memcpy(&p->prefix.macip_addr.ip, ip, sizeof(*ip));
 }
 
-static inline void build_type5_prefix_from_ip_prefix(struct prefix_evpn *evp,
-						     struct prefix *ip_prefix)
+static inline void
+build_type5_prefix_from_ip_prefix(struct prefix_evpn *evp,
+				  const struct prefix *ip_prefix)
 {
 	struct ipaddr ip;
 

--- a/bgpd/bgp_flowspec.h
+++ b/bgpd/bgp_flowspec.h
@@ -43,7 +43,7 @@ extern void bgp_fs_nlri_get_string(unsigned char *nlri_content, size_t len,
 				   char *return_string, int format,
 				   json_object *json_path);
 
-extern void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
+extern void route_vty_out_flowspec(struct vty *vty, const struct prefix *p,
 				   struct bgp_path_info *path, int display,
 				   json_object *json_paths);
 extern int bgp_fs_config_write_pbr(struct vty *vty, struct bgp *bgp,

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -76,9 +76,8 @@ static int bgp_flowspec_call_non_opaque_decode(uint8_t *nlri_content, int len,
 	return ret;
 }
 
-bool bgp_flowspec_contains_prefix(struct prefix *pfs,
-				 struct prefix *input,
-				 int prefix_check)
+bool bgp_flowspec_contains_prefix(const struct prefix *pfs,
+				  struct prefix *input, int prefix_check)
 {
 	uint32_t offset = 0;
 	int type;

--- a/bgpd/bgp_flowspec_util.h
+++ b/bgpd/bgp_flowspec_util.h
@@ -50,7 +50,7 @@ struct bgp_pbr_entry_main;
 extern int bgp_flowspec_match_rules_fill(uint8_t *nlri_content, int len,
 					 struct bgp_pbr_entry_main *bpem);
 
-extern bool bgp_flowspec_contains_prefix(struct prefix *pfs,
+extern bool bgp_flowspec_contains_prefix(const struct prefix *pfs,
 					 struct prefix *input,
 					 int prefix_check);
 

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -252,7 +252,7 @@ void bgp_fs_nlri_get_string(unsigned char *nlri_content, size_t len,
 	}
 }
 
-void route_vty_out_flowspec(struct vty *vty, struct prefix *p,
+void route_vty_out_flowspec(struct vty *vty, const struct prefix *p,
 			    struct bgp_path_info *path, int display,
 			    json_object *json_paths)
 {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -146,7 +146,7 @@ struct bgp_node *bgp_afi_node_get(struct bgp_table *table, afi_t afi,
 }
 
 struct bgp_node *bgp_afi_node_lookup(struct bgp_table *table, afi_t afi,
-				     safi_t safi, struct prefix *p,
+				     safi_t safi, const struct prefix *p,
 				     struct prefix_rd *prd)
 {
 	struct bgp_node *rn;
@@ -7342,7 +7342,7 @@ void bgp_redistribute_withdraw(struct bgp *bgp, afi_t afi, int type,
 }
 
 /* Static function to display route. */
-static void route_vty_out_route(struct prefix *p, struct vty *vty,
+static void route_vty_out_route(const struct prefix *p, struct vty *vty,
 				json_object *json)
 {
 	int len = 0;
@@ -7499,7 +7499,7 @@ static char *bgp_nexthop_hostname(struct peer *peer, struct attr *attr)
 }
 
 /* called from terminal list command */
-void route_vty_out(struct vty *vty, struct prefix *p,
+void route_vty_out(struct vty *vty, const struct prefix *p,
 		   struct bgp_path_info *path, int display, safi_t safi,
 		   json_object *json_paths)
 {
@@ -8095,7 +8095,7 @@ void route_vty_out_tmp(struct vty *vty, struct prefix *p, struct attr *attr,
 		vty_out(vty, "\n");
 }
 
-void route_vty_out_tag(struct vty *vty, struct prefix *p,
+void route_vty_out_tag(struct vty *vty, const struct prefix *p,
 		       struct bgp_path_info *path, int display, safi_t safi,
 		       json_object *json)
 {
@@ -8188,7 +8188,7 @@ void route_vty_out_tag(struct vty *vty, struct prefix *p,
 	}
 }
 
-void route_vty_out_overlay(struct vty *vty, struct prefix *p,
+void route_vty_out_overlay(struct vty *vty, const struct prefix *p,
 			   struct bgp_path_info *path, int display,
 			   json_object *json_paths)
 {

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -601,16 +601,16 @@ extern struct bgp_path_info *info_make(int type, int sub_type,
 				       struct peer *peer, struct attr *attr,
 				       struct bgp_node *rn);
 
-extern void route_vty_out(struct vty *vty, struct prefix *p,
+extern void route_vty_out(struct vty *vty, const struct prefix *p,
 			  struct bgp_path_info *path, int display, safi_t safi,
 			  json_object *json_paths);
-extern void route_vty_out_tag(struct vty *vty, struct prefix *p,
+extern void route_vty_out_tag(struct vty *vty, const struct prefix *p,
 			      struct bgp_path_info *path, int display,
 			      safi_t safi, json_object *json);
 extern void route_vty_out_tmp(struct vty *vty, struct prefix *p,
 			      struct attr *attr, safi_t safi, bool use_json,
 			      json_object *json_ar);
-extern void route_vty_out_overlay(struct vty *vty, struct prefix *p,
+extern void route_vty_out_overlay(struct vty *vty, const struct prefix *p,
 				  struct bgp_path_info *path, int display,
 				  json_object *json);
 
@@ -629,7 +629,7 @@ extern void bgp_process_queues_drain_immediate(void);
 
 /* for encap/vpn */
 extern struct bgp_node *bgp_afi_node_lookup(struct bgp_table *table, afi_t afi,
-					    safi_t safi, struct prefix *p,
+					    safi_t safi, const struct prefix *p,
 					    struct prefix_rd *prd);
 extern void bgp_path_info_restore(struct bgp_node *rn,
 				  struct bgp_path_info *path);

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -226,7 +226,7 @@ static inline struct bgp_node *bgp_node_get(struct bgp_table *const table,
  * bgp_node_lookup
  */
 static inline struct bgp_node *
-bgp_node_lookup(const struct bgp_table *const table, struct prefix *p)
+bgp_node_lookup(const struct bgp_table *const table, const struct prefix *p)
 {
 	return bgp_node_from_rnode(route_node_lookup(table->route_table, p));
 }

--- a/bgpd/rfapi/rfapi_backend.h
+++ b/bgpd/rfapi/rfapi_backend.h
@@ -56,7 +56,7 @@ extern void vnc_zebra_withdraw(struct prefix *p,
 			       struct bgp_path_info *old_select);
 
 
-extern void rfapi_vty_out_vncinfo(struct vty *vty, struct prefix *p,
+extern void rfapi_vty_out_vncinfo(struct vty *vty, const struct prefix *p,
 				  struct bgp_path_info *bpi, safi_t safi);
 
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -393,7 +393,7 @@ int rfapiStream2Vty(void *stream,			   /* input */
 }
 
 /* called from bgpd/bgp_vty.c'route_vty_out() */
-void rfapi_vty_out_vncinfo(struct vty *vty, struct prefix *p,
+void rfapi_vty_out_vncinfo(struct vty *vty, const struct prefix *p,
 			   struct bgp_path_info *bpi, safi_t safi)
 {
 	char *s;


### PR DESCRIPTION
Modify more code to use `const struct prefix` throughout
bgp.  This is all prep work for adding an accessor function
for bgp_node to get the prefix and reduce all the places that
code needs to be touched when we get that work done.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>