### PR TITLE
pimd: bsr election elects wrong bsr

### DIFF
--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -601,7 +601,8 @@ static bool is_preferred_bsr(struct pim_instance *pim, struct in_addr bsr,
 		return true;
 
 	else if (bsr_prio == pim->global_scope.current_bsr_prio) {
-		if (bsr.s_addr >= pim->global_scope.current_bsr.s_addr)
+		if (ntohl(bsr.s_addr)
+		    >= ntohl(pim->global_scope.current_bsr.s_addr))
 			return true;
 		else
 			return false;


### PR DESCRIPTION
RCA: preferred bsr routine, compare address in network byte order

Fix: changed to host format before comparision.

Testing:
Verified between 1.1.2.7 and 10.2.1.1, 10.2.1.1 is chosen as bsr

Initially:
R11# sh ip pim bsr
PIMv2 Bootstrap information
Current preferred BSR address: 1.1.2.7
Priority        Fragment-Tag       State           UpTime
  0               2862            ACCEPT_PREFERRED    00:00:30
Last BSM seen: 00:00:30

After next bsr started:
R11# sh ip pim bsr
PIMv2 Bootstrap information
Current preferred BSR address: 10.2.1.1
Priority        Fragment-Tag       State           UpTime
  0               3578            ACCEPT_PREFERRED    00:00:01
Last BSM seen: 00:00:01
R11# sh ip pim bsr
PIMv2 Bootstrap information
Current preferred BSR address: 10.2.1.1
Priority        Fragment-Tag       State           UpTime
  0               3578            ACCEPT_PREFERRED    00:00:04
Last BSM seen: 00:00:04

Signed-off-by: Saravanan K <saravanank@vmware.com>