### PR TITLE
lib: rework management of user pointers in the northbound layer (v2)

### DIFF
--- a/lib/yang.h
+++ b/lib/yang.h
@@ -434,6 +434,19 @@ extern struct lyd_node *yang_dnode_dup(const struct lyd_node *dnode);
 extern void yang_dnode_free(struct lyd_node *dnode);
 
 /*
+ * Replace one libyang data node by another, doing the least amount of work
+ * possible.
+ *
+ * dnode_dst
+ *    libyang data node to be replaced.
+ *
+ * dnode_src
+ *    libyang data node to replace dnode_dst.
+ */
+extern void yang_dnode_replace(struct lyd_node **dnode_dst,
+			       struct lyd_node *dnode_src);
+
+/*
  * Create a new yang_data structure.
  *
  * xpath


### PR DESCRIPTION
Commit ccd43ada179 introduced a hash table in the northbound
layer to optimize the management of users pointers associated to
YANG configuration nodes (like containers and lists). While that
optimization was enormously effective, it introduced the following
two problems:
* Increased memory usage of 264 bytes per configuration node. This
  might not seem like much, but it can account for hundreds of
  megabytes for large configurations (e.g. thousands of route-maps
  and ACLs).
* Inconsistencies in the hash table when configuration changes come
  from the kernel (bypassing the normal transactional process). This
  in turns leads to problems like the northbound rejecting valid
  configuration changes.

The solution consists of reverting parts of commit ccd43ada179
(the hash table bits) and introducing the yang_dnode_replace()
function. This function was designed to replace one YANG data node by
another one, doing the least amount of work possible. The idea is to
optimize the common use case of reading one configuration command at
time when parsing the startup configuration. Normally replacing one
configuration with 1000 commands by another one with 1001 commands
meant freeing the first one and duplicating the second, both expensive
operations. Now we compare config A with config B and change only
the parts of A that need to be changed. The nice side effect of this
optimization is that the existing user pointers in the original
configuration are not lost during the replace operation. In other
words, we can use the 'priv' pointer of the 'lyd_node' structure again
since they are persistent now. This means the 'running_config_entries'
hash table isn't necessary anymore and can be removed.

Fixes #5718.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>