### PR TITLE
*: vrf northbound callbacks [master]

### DIFF
--- a/babeld/babel_main.c
+++ b/babeld/babel_main.c
@@ -136,10 +136,10 @@ struct option longopts[] =
     { 0 }
   };
 
-static const struct frr_yang_module_info *const babeld_yang_modules[] =
-  {
-    &frr_interface_info,
-  };
+static const struct frr_yang_module_info *const babeld_yang_modules[] = {
+	&frr_interface_info,
+	&frr_vrf_info,
+};
 
 FRR_DAEMON_INFO(babeld, BABELD,
 		.vty_port = BABEL_VTY_PORT,

--- a/bfdd/bfdd.c
+++ b/bfdd/bfdd.c
@@ -112,6 +112,7 @@ static struct quagga_signal_t bfd_signals[] = {
 static const struct frr_yang_module_info *const bfdd_yang_modules[] = {
 	&frr_interface_info,
 	&frr_bfdd_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(bfdd, BFD, .vty_port = 2617,

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -361,6 +361,7 @@ static void bgp_vrf_terminate(void)
 static const struct frr_yang_module_info *const bgpd_yang_modules[] = {
 	&frr_interface_info,
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(bgpd, BGP, .vty_port = BGP_VTY_PORT,

--- a/eigrpd/eigrp_main.c
+++ b/eigrpd/eigrp_main.c
@@ -141,6 +141,7 @@ static const struct frr_yang_module_info *const eigrpd_yang_modules[] = {
 	&frr_eigrpd_info,
 	&frr_interface_info,
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(eigrpd, EIGRP, .vty_port = EIGRP_VTY_PORT,

--- a/isisd/isis_main.c
+++ b/isisd/isis_main.c
@@ -168,6 +168,7 @@ static const struct frr_yang_module_info *const isisd_yang_modules[] = {
 	&frr_isisd_info,
 #endif /* ifndef FABRICD */
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 #ifdef FABRICD

--- a/ldpd/ldpd.c
+++ b/ldpd/ldpd.c
@@ -180,6 +180,7 @@ static struct quagga_signal_t ldp_signals[] =
 };
 
 static const struct frr_yang_module_info *const ldpd_yang_modules[] = {
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(ldpd, LDP,

--- a/lib/northbound.h
+++ b/lib/northbound.h
@@ -417,7 +417,11 @@ struct frr_yang_module_info {
 
 		/* Priority - lower priorities are processed first. */
 		uint32_t priority;
+#if defined(__GNUC__) && ((__GNUC__ - 0) < 5) && !defined(__clang__)
+	} nodes[1000];
+#else
 	} nodes[];
+#endif
 };
 
 /* Northbound error codes. */

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -37,6 +37,7 @@
 #include "nexthop_group.h"
 #include "lib_errors.h"
 #include "northbound.h"
+#include "northbound_cli.h"
 
 /* default VRF ID value used when VRF backend is not NETNS */
 #define VRF_DEFAULT_INTERNAL 0
@@ -604,6 +605,8 @@ int vrf_handler_create(struct vty *vty, const char *vrfname,
 		       struct vrf **vrf)
 {
 	struct vrf *vrfp;
+	char xpath_list[XPATH_MAXLEN];
+	int ret;
 
 	if (strlen(vrfname) > VRF_NAMSIZ) {
 		if (vty)
@@ -618,13 +621,24 @@ int vrf_handler_create(struct vty *vty, const char *vrfname,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	vrfp = vrf_get(VRF_UNKNOWN, vrfname);
+	if (vty) {
+		snprintf(xpath_list, sizeof(xpath_list),
+			 "/frr-vrf:lib/vrf[name='%s']", vrfname);
 
-	if (vty)
-		VTY_PUSH_CONTEXT(VRF_NODE, vrfp);
+		nb_cli_enqueue_change(vty, xpath_list, NB_OP_CREATE, NULL);
+		ret = nb_cli_apply_changes(vty, xpath_list);
+		if (ret == CMD_SUCCESS) {
+			VTY_PUSH_XPATH(VRF_NODE, xpath_list);
+			vrfp = vrf_lookup_by_name(vrfname);
+			if (vrfp)
+				VTY_PUSH_CONTEXT(VRF_NODE, vrfp);
+		}
+	} else {
+		vrfp = vrf_get(VRF_UNKNOWN, vrfname);
 
-	if (vrf)
-		*vrf = vrfp;
+		if (vrf)
+			*vrf = vrfp;
+	}
 	return CMD_SUCCESS;
 }
 
@@ -727,6 +741,7 @@ DEFUN (no_vrf,
        "VRF's name\n")
 {
 	const char *vrfname = argv[2]->arg;
+	char xpath_list[XPATH_MAXLEN];
 
 	struct vrf *vrfp;
 
@@ -742,11 +757,11 @@ DEFUN (no_vrf,
 		return CMD_WARNING_CONFIG_FAILED;
 	}
 
-	/* Clear configured flag and invoke delete. */
-	UNSET_FLAG(vrfp->status, VRF_CONFIGURED);
-	vrf_delete(vrfp);
+	snprintf(xpath_list, sizeof(xpath_list), "/frr-vrf:lib/vrf[name='%s']",
+		 vrfname);
 
-	return CMD_SUCCESS;
+	nb_cli_enqueue_change(vty, xpath_list, NB_OP_DESTROY, NULL);
+	return nb_cli_apply_changes(vty, xpath_list);
 }
 
 
@@ -1039,7 +1054,6 @@ static int lib_vrf_destroy(enum nb_event event, const struct lyd_node *dnode)
 {
 	struct vrf *vrfp;
 
-
 	switch (event) {
 	case NB_EV_VALIDATE:
 		vrfp = nb_running_get_entry(dnode, NULL, true);
@@ -1054,6 +1068,7 @@ static int lib_vrf_destroy(enum nb_event event, const struct lyd_node *dnode)
 		break;
 	case NB_EV_APPLY:
 		vrfp = nb_running_unset_entry(dnode);
+
 		/* Clear configured flag and invoke delete. */
 		UNSET_FLAG(vrfp->status, VRF_CONFIGURED);
 		vrf_delete(vrfp);

--- a/lib/vrf.c
+++ b/lib/vrf.c
@@ -36,6 +36,7 @@
 #include "privs.h"
 #include "nexthop_group.h"
 #include "lib_errors.h"
+#include "northbound.h"
 
 /* default VRF ID value used when VRF backend is not NETNS */
 #define VRF_DEFAULT_INTERNAL 0
@@ -1010,3 +1011,147 @@ vrf_id_t vrf_generate_id(void)
 
 	return ++vrf_id_local;
 }
+
+/* ------- Northbound callbacks ------- */
+
+/*
+ * XPath: /frr-vrf:lib/vrf
+ */
+static int lib_vrf_create(enum nb_event event, const struct lyd_node *dnode,
+			  union nb_resource *resource)
+{
+	const char *vrfname;
+	struct vrf *vrfp;
+
+	vrfname = yang_dnode_get_string(dnode, "./name");
+
+	if (event != NB_EV_APPLY)
+		return NB_OK;
+
+	vrfp = vrf_get(VRF_UNKNOWN, vrfname);
+
+	nb_running_set_entry(dnode, vrfp);
+
+	return NB_OK;
+}
+
+static int lib_vrf_destroy(enum nb_event event, const struct lyd_node *dnode)
+{
+	struct vrf *vrfp;
+
+
+	switch (event) {
+	case NB_EV_VALIDATE:
+		vrfp = nb_running_get_entry(dnode, NULL, true);
+		if (CHECK_FLAG(vrfp->status, VRF_ACTIVE)) {
+			zlog_debug("%s Only inactive VRFs can be deleted",
+				   __func__);
+			return NB_ERR_VALIDATION;
+		}
+		break;
+	case NB_EV_PREPARE:
+	case NB_EV_ABORT:
+		break;
+	case NB_EV_APPLY:
+		vrfp = nb_running_unset_entry(dnode);
+		/* Clear configured flag and invoke delete. */
+		UNSET_FLAG(vrfp->status, VRF_CONFIGURED);
+		vrf_delete(vrfp);
+		break;
+	}
+
+	return NB_OK;
+}
+
+static const void *lib_vrf_get_next(const void *parent_list_entry,
+				    const void *list_entry)
+{
+	struct vrf *vrfp = (struct vrf *)list_entry;
+
+	if (list_entry == NULL) {
+		vrfp = RB_MIN(vrf_name_head, &vrfs_by_name);
+	} else {
+		vrfp = RB_NEXT(vrf_name_head, vrfp);
+	}
+
+	return vrfp;
+}
+
+static int lib_vrf_get_keys(const void *list_entry, struct yang_list_keys *keys)
+{
+	struct vrf *vrfp = (struct vrf *)list_entry;
+
+	keys->num = 1;
+	strlcpy(keys->key[0], vrfp->name, sizeof(keys->key[0]));
+
+	return NB_OK;
+}
+
+static const void *lib_vrf_lookup_entry(const void *parent_list_entry,
+					const struct yang_list_keys *keys)
+{
+	const char *vrfname = keys->key[0];
+
+	struct vrf *vrf = vrf_lookup_by_name(vrfname);
+
+	return vrf;
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/id
+ */
+static struct yang_data *lib_vrf_state_id_get_elem(const char *xpath,
+						   const void *list_entry)
+{
+	struct vrf *vrfp = (struct vrf *)list_entry;
+
+	return yang_data_new_uint32(xpath, vrfp->vrf_id);
+}
+
+/*
+ * XPath: /frr-vrf:lib/vrf/active
+ */
+static struct yang_data *lib_vrf_state_active_get_elem(const char *xpath,
+						       const void *list_entry)
+{
+	struct vrf *vrfp = (struct vrf *)list_entry;
+
+	if (vrfp->status == VRF_ACTIVE)
+		return yang_data_new_bool(
+			xpath, vrfp->status == VRF_ACTIVE ? true : false);
+
+	return NULL;
+}
+
+/* clang-format off */
+const struct frr_yang_module_info frr_vrf_info = {
+	.name = "frr-vrf",
+	.nodes = {
+		{
+			.xpath = "/frr-vrf:lib/vrf",
+			.cbs = {
+				.create = lib_vrf_create,
+				.destroy = lib_vrf_destroy,
+				.get_next = lib_vrf_get_next,
+				.get_keys = lib_vrf_get_keys,
+				.lookup_entry = lib_vrf_lookup_entry,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/state/id",
+			.cbs = {
+				.get_elem = lib_vrf_state_id_get_elem,
+			}
+		},
+		{
+			.xpath = "/frr-vrf:lib/vrf/state/active",
+			.cbs = {
+				.get_elem = lib_vrf_state_active_get_elem,
+			}
+		},
+		{
+			.xpath = NULL,
+		},
+	}
+};
+

--- a/lib/vrf.h
+++ b/lib/vrf.h
@@ -322,6 +322,8 @@ extern int vrf_enable(struct vrf *vrf);
 extern void vrf_delete(struct vrf *vrf);
 extern vrf_id_t vrf_generate_id(void);
 
+extern const struct frr_yang_module_info frr_vrf_info;
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/yang.c
+++ b/lib/yang.c
@@ -74,6 +74,7 @@ static const char *yang_module_imp_clb(const char *mod_name,
 
 static const char *const frr_native_modules[] = {
 	"frr-interface",
+	"frr-vrf",
 	"frr-ripd",
 	"frr-ripngd",
 	"frr-isisd",

--- a/nhrpd/nhrp_main.c
+++ b/nhrpd/nhrp_main.c
@@ -117,6 +117,7 @@ static struct quagga_signal_t sighandlers[] = {
 
 static const struct frr_yang_module_info *const nhrpd_yang_modules[] = {
 	&frr_interface_info,
+    &frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(nhrpd, NHRP, .vty_port = NHRP_VTY_PORT,

--- a/ospf6d/ospf6_main.c
+++ b/ospf6d/ospf6_main.c
@@ -168,6 +168,7 @@ struct quagga_signal_t ospf6_signals[] = {
 static const struct frr_yang_module_info *const ospf6d_yang_modules[] = {
 	&frr_interface_info,
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(ospf6d, OSPF6, .vty_port = OSPF6_VTY_PORT,

--- a/ospfd/ospf_main.c
+++ b/ospfd/ospf_main.c
@@ -128,6 +128,7 @@ struct quagga_signal_t ospf_signals[] = {
 static const struct frr_yang_module_info *const ospfd_yang_modules[] = {
 	&frr_interface_info,
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(ospfd, OSPF, .vty_port = OSPF_VTY_PORT,

--- a/pbrd/pbr_main.c
+++ b/pbrd/pbr_main.c
@@ -114,6 +114,7 @@ struct quagga_signal_t pbr_signals[] = {
 
 static const struct frr_yang_module_info *const pbrd_yang_modules[] = {
 	&frr_interface_info,
+    &frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(pbrd, PBR, .vty_port = PBR_VTY_PORT,

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -75,6 +75,7 @@ struct zebra_privs_t pimd_privs = {
 static const struct frr_yang_module_info *const pimd_yang_modules[] = {
 	&frr_interface_info,
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(pimd, PIM, .vty_port = PIMD_VTY_PORT,

--- a/ripd/rip_main.c
+++ b/ripd/rip_main.c
@@ -117,6 +117,7 @@ static const struct frr_yang_module_info *const ripd_yang_modules[] = {
 	&frr_interface_info,
 	&frr_ripd_info,
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(ripd, RIP, .vty_port = RIP_VTY_PORT,

--- a/ripngd/ripng_main.c
+++ b/ripngd/ripng_main.c
@@ -117,6 +117,7 @@ static const struct frr_yang_module_info *const ripngd_yang_modules[] = {
 	&frr_interface_info,
 	&frr_ripngd_info,
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(ripngd, RIPNG, .vty_port = RIPNG_VTY_PORT,

--- a/sharpd/sharp_main.c
+++ b/sharpd/sharp_main.c
@@ -114,6 +114,7 @@ struct quagga_signal_t sharp_signals[] = {
 static const struct frr_yang_module_info *const sharpd_yang_modules[] = {
 	&frr_interface_info,
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(sharpd, SHARP, .vty_port = SHARP_VTY_PORT,

--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -104,6 +104,7 @@ struct quagga_signal_t static_signals[] = {
 };
 
 static const struct frr_yang_module_info *const staticd_yang_modules[] = {
+	&frr_vrf_info,
 };
 
 #define STATIC_VTY_PORT 2616

--- a/vrrpd/vrrp_main.c
+++ b/vrrpd/vrrp_main.c
@@ -113,6 +113,7 @@ struct quagga_signal_t vrrp_signals[] = {
 static const struct frr_yang_module_info *const vrrp_yang_modules[] = {
 	&frr_interface_info,
 	&frr_vrrpd_info,
+    &frr_vrf_info,
 };
 
 #define VRRP_VTY_PORT 2619

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -245,6 +245,7 @@ struct quagga_signal_t zebra_signals[] = {
 static const struct frr_yang_module_info *const zebra_yang_modules[] = {
 	&frr_interface_info,
 	&frr_route_map_info,
+	&frr_vrf_info,
 };
 
 FRR_DAEMON_INFO(


### PR DESCRIPTION
This PR contains northbound callbacks for yang/frr-vrf.yang module.

Add vrf northbound callbacks.
Insert vrf module in daemons init sequence.


Signed-off-by: Chirag Shah <chirag@cumulusnetworks.com>
