### PR TITLE
pimd: Reg Suppression expiry has to account for couldreg->false while in RegPrune

### DIFF
--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -1697,10 +1697,12 @@ static int pim_upstream_register_stop_timer(struct thread *t)
 	case PIM_REG_JOIN:
 		break;
 	case PIM_REG_PRUNE:
+		/* This is equalent to Couldreg -> False */
 		if (!up->rpf.source_nexthop.interface) {
 			if (PIM_DEBUG_PIM_TRACE)
 				zlog_debug("%s: up %s RPF is not present",
 					   __func__, up->sg_str);
+			up->reg_state = PIM_REG_NOINFO;
 			return 0;
 		}
 


### PR DESCRIPTION
Problem: This happened in once in a while during testing the scenario multiple
times. When regstop timer expire and at that point if rpf interface doesn't
exist, the register state for the upstream gets struck in reg-prune state indefinitely.
This will not recover even when rpf comes back and traffic resumed because
register state is struck on prune.

RCA: Reg suppression expiry is keeping reg state unchanged when iif is absent. There is no way to recover if we are in RegPrune state and RegStop timer is not running. This scenario during Regstop Expiry just return without either changing state or restarting the timer. Ideally state change has to happen here.

Fix: When iif is absent during reg suppression expiry, treat it as couldreg
becoming false and move it NO_INFO state.

Signed-off-by: Saravanan K <saravanank@vmware.com>