### PR TITLE
pimd: increase buffer size for prefix str while printing bsrp-info

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -3016,7 +3016,7 @@ static void pim_show_bsm_db(struct pim_instance *pim, struct vty *vty, bool uj)
 	}
 
 	for (ALL_LIST_ELEMENTS_RO(pim->global_scope.bsm_list, bsmnode, bsm)) {
-		char grp_str[INET_ADDRSTRLEN];
+		char grp_str[PREFIX_STRLEN];
 		char rp_str[INET_ADDRSTRLEN];
 		char bsr_str[INET_ADDRSTRLEN];
 		struct bsmmsg_grpinfo *group;
@@ -3185,7 +3185,7 @@ static void pim_show_group_rp_mappings_info(struct pim_instance *pim,
 		if (!bsgrp)
 			continue;
 
-		char grp_str[INET_ADDRSTRLEN];
+		char grp_str[PREFIX_STRLEN];
 
 		prefix2str(&bsgrp->group, grp_str, sizeof(grp_str));
 


### PR DESCRIPTION
Problem: output is cut short when prefix string all octets are 3 digit.
RCA: Buffer was allocated only to hold ip addr str.

Fix: Added 3 bytes more to hold prefix length and a /.
Modified buffer in 'show ip pim bsrp-info' and 'show ip pim bsm database'

Signed-off-by: Saravanan K <saravanank@vmware.com>