### PR TITLE
bgpd: clean up import vrf route-map command

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1805,8 +1805,9 @@ void vrf_unimport_from_vrf(struct bgp *to_bgp, struct bgp *from_bgp,
 	vpn_leak_prechange(idir, afi, bgp_get_default(), to_bgp);
 
 	if (to_bgp->vpn_policy[afi].import_vrf->count == 0) {
-		UNSET_FLAG(to_bgp->af_flags[afi][safi],
-			   BGP_CONFIG_VRF_TO_VRF_IMPORT);
+		if (!to_bgp->vpn_policy[afi].rmap[idir])
+			UNSET_FLAG(to_bgp->af_flags[afi][safi],
+				   BGP_CONFIG_VRF_TO_VRF_IMPORT);
 		if (to_bgp->vpn_policy[afi].rtlist[idir])
 			ecommunity_free(&to_bgp->vpn_policy[afi].rtlist[idir]);
 	} else {


### PR DESCRIPTION
Problem seen that if "import vrf route-map RMAP" was entered
without any vrfs being imported, the configuration was displayed
as "route-map vpn import RMAP". Additionally, if "import vrf
route-map" was entered without specifying a route-map name,
the command was accepted and the word "route-map" would be
treated as a vrf name.  This fix resolves both of those issues
and also allows deleting the "import vrf route-map" line without
providing the route-map name.

Ticket: CM-28821
Signed-off-by: Don Slice <dslice@cumulusnetworks.com>