### PR TITLE
ospf6d: ospf6_route_add - stack repeats

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -877,6 +877,11 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 	struct listnode *anode;
 	char adv_router[16];
 
+	if (oa->running_ospf6_abr_examin_summary)
+		return;
+
+	oa->running_ospf6_abr_examin_summary = 1;
+
 	memset(&prefix, 0, sizeof(prefix));
 
 	if (lsa->header->type == htons(OSPF6_LSTYPE_INTER_PREFIX)) {
@@ -974,6 +979,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 			zlog_debug("cost is LS_INFINITY, ignore");
 		if (old)
 			ospf6_abr_old_route_remove(lsa, old, table);
+
+		oa->running_ospf6_abr_examin_summary = 0;
 		return;
 	}
 	if (OSPF6_LSA_IS_MAXAGE(lsa)) {
@@ -982,6 +989,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 				   lsa->name);
 		if (old)
 			ospf6_abr_old_route_remove(lsa, old, table);
+
+		oa->running_ospf6_abr_examin_summary = 0;
 		return;
 	}
 
@@ -992,6 +1001,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 				   lsa->name);
 		if (old)
 			ospf6_route_remove(old, table);
+
+		oa->running_ospf6_abr_examin_summary = 0;
 		return;
 	}
 
@@ -1008,6 +1019,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 					"Prefix is equal to address range, ignore");
 			if (old)
 				ospf6_route_remove(old, table);
+
+			oa->running_ospf6_abr_examin_summary = 0;
 			return;
 		}
 
@@ -1019,6 +1032,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 				zlog_debug("Prefix has NU/LA bit set, ignore");
 			if (old)
 				ospf6_route_remove(old, table);
+
+			oa->running_ospf6_abr_examin_summary = 0;
 			return;
 		}
 	}
@@ -1033,6 +1048,7 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 			if (old)
 				ospf6_route_remove(old, table);
 
+			oa->running_ospf6_abr_examin_summary = 0;
 			return;
 		}
 		/* Avoid infinite recursion if someone has maliciously announced
@@ -1047,6 +1063,7 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 			if (old)
 				ospf6_route_remove(old, table);
 
+			oa->running_ospf6_abr_examin_summary = 0;
 			return;
 		}
 	}
@@ -1076,6 +1093,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 				ospf6_route_remove(old, table);
 			}
 		}
+
+		oa->running_ospf6_abr_examin_summary = 0;
 		return;
 	}
 
@@ -1093,6 +1112,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 						"Prefix was denied by import-list");
 				if (old)
 					ospf6_route_remove(old, table);
+
+				oa->running_ospf6_abr_examin_summary = 0;
 				return;
 			}
 	}
@@ -1105,6 +1126,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 				zlog_debug("Prefix was denied by prefix-list");
 			if (old)
 				ospf6_route_remove(old, table);
+
+			oa->running_ospf6_abr_examin_summary = 0;
 			return;
 		}
 	}
@@ -1240,6 +1263,8 @@ void ospf6_abr_examin_summary(struct ospf6_lsa *lsa, struct ospf6_area *oa)
 		/* ospf6_ia_add_nw_route (table, &prefix, route); */
 		ospf6_route_add(route, table);
 	}
+
+	oa->running_ospf6_abr_examin_summary = 0;
 }
 
 void ospf6_abr_examin_brouter(uint32_t router_id)

--- a/ospf6d/ospf6_area.h
+++ b/ospf6d/ospf6_area.h
@@ -53,6 +53,16 @@ struct ospf6_area {
 	/* Brouter traversal protection */
 	int intra_brouter_calc;
 
+	/*
+	 * Temporary fix to avoid the race condition
+	 * #8  in ospf6_abr_examin_summary
+	 * #9  in ospf6_abr_examin_brouter
+	 * #10 in ospf6_top_brouter_hook_add
+	 * #11 in ospf6_route_add
+	 * #12 in ospf6_abr_examin_summary
+	 */
+	int running_ospf6_abr_examin_summary;
+
 	/* OSPF interface list */
 	struct list *if_list;
 


### PR DESCRIPTION
Signed-off-by: Donald Slice <dslice@cumulusnetworks.com>
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>
Reviewed-by: Donald Sharp <sharpd@cumulusnetworks.com>
Reviewed-by: Chirag Shah <chirag@cumulusnetworks.com>
Ticket: CM-17238

This is a temporary fix until the root cause for CM-17238 has been
resolved. The fix for CM-17238 will back this commit out.