### PR TITLE
pimd: avoiding crash in wrvifwhole path

### DIFF
--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -484,7 +484,10 @@ static int pim_mroute_msg_wrvifwhole(int fd, struct interface *ifp,
 		struct pim_upstream *parent;
 		struct pim_nexthop source;
 		struct pim_rpf *rpf = RP(pim_ifp->pim, sg.grp);
-		if (!rpf || !rpf->source_nexthop.interface)
+
+		/* No RPF or No RPF interface or No mcast on RPF interface */
+		if (!rpf || !rpf->source_nexthop.interface
+		    || !rpf->source_nexthop.interface->info)
 			return 0;
 
 		/*


### PR DESCRIPTION
Observed crash in the wrvif whole path.

RCA: Wrongvif path trying to access pim attributes of pim disabled RPF interface.
This was resulting in Null access.
```
(gdb) p/x rpf->source_nexthop
$19 = {last_lookup = {s_addr = 0xa282828}, last_lookup_time = 0x59c0de0828c98,
  interface = 0x1013e5011300, mrib_nexthop_addr = {family = 0x2,
    prefixlen = 0x20, u = {prefix = 0x28, prefix4 = {s_addr = 0xa282828},
      prefix6 = {__in6_u = {__u6_addr8 = {0x28, 0x28, 0x28, 0xa,
            0x0 <repeats 12 times>}, __u6_addr16 = {0x2828, 0xa28, 0x0, 0x0,
            0x0, 0x0, 0x0, 0x0}, __u6_addr32 = {0xa282828, 0x0, 0x0, 0x0}}},
      lp = {id = {s_addr = 0xa282828}, adv_router = {s_addr = 0x0}},
      prefix_eth = {octet = {0x28, 0x28, 0x28, 0xa, 0x0, 0x0}}, val = {0x28,
        0x28, 0x28, 0xa, 0x0 <repeats 12 times>}, ptr = 0xa282828,
      prefix_evpn = {route_type = 0x28, u = {_ead_addr = {esi = {val = {0x0,
                0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}}, eth_tag = 0x0},
          _macip_addr = {eth_tag = 0x0, ip_prefix_length = 0x0, mac = {
              octet = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0}}, ip = {ipa_type = 0x0,
              ip = {addr = 0x0, _v4_addr = {s_addr = 0x0}, _v6_addr = {
                  __in6_u = {__u6_addr8 = {0x0 <repeats 16 times>},
                    __u6_addr16 = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
                    __u6_addr32 = {0x0, 0x0, 0x0, 0x0}}}}}}, _imet_addr = {
            eth_tag = 0x0, ip_prefix_length = 0x0, ip = {ipa_type = 0x0, ip = {
                addr = 0x0, _v4_addr = {s_addr = 0x0}, _v6_addr = {__in6_u = {
                    __u6_addr8 = {0x0 <repeats 16 times>}, __u6_addr16 = {0x0,
                      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, __u6_addr32 = {0x0,
                      0x0, 0x0, 0x0}}}}}}, _es_addr = {esi = {val = {0x0, 0x0,
                0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}},
---Type <return> to continue, or q <return> to quit---q
ip_prefix_length = 0x0Quit
(gdb) p/x rpf->source_nexthop.interface
$20 = 0x1013e5011300
(gdb) p/x rpf->source_nexthop.interface->info
$21 = 0x0 <======================== Pim & Igmp is disabled on this interface
```
Fix: Return when the rpf interface is not pim enabled

Signed-off-by: Saravanan K <saravanank@vmware.com>