### PR TITLE
Bgp node get prefix

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -898,14 +898,11 @@ struct attr *bgp_attr_default_set(struct attr *attr, uint8_t origin)
 }
 
 /* Create the attributes for an aggregate */
-struct attr *bgp_attr_aggregate_intern(struct bgp *bgp, uint8_t origin,
-				       struct aspath *aspath,
-				       struct community *community,
-				       struct ecommunity *ecommunity,
-				       struct lcommunity *lcommunity,
-				       struct bgp_aggregate *aggregate,
-				       uint8_t atomic_aggregate,
-				       struct prefix *p)
+struct attr *bgp_attr_aggregate_intern(
+	struct bgp *bgp, uint8_t origin, struct aspath *aspath,
+	struct community *community, struct ecommunity *ecommunity,
+	struct lcommunity *lcommunity, struct bgp_aggregate *aggregate,
+	uint8_t atomic_aggregate, const struct prefix *p)
 {
 	struct attr attr;
 	struct attr *new;
@@ -3416,10 +3413,10 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 }
 
 void bgp_packet_mpattr_prefix(struct stream *s, afi_t afi, safi_t safi,
-			      struct prefix *p, struct prefix_rd *prd,
-			      mpls_label_t *label, uint32_t num_labels,
-			      int addpath_encode, uint32_t addpath_tx_id,
-			      struct attr *attr)
+			      const struct prefix *p,
+			      const struct prefix_rd *prd, mpls_label_t *label,
+			      uint32_t num_labels, int addpath_encode,
+			      uint32_t addpath_tx_id, struct attr *attr)
 {
 	if (safi == SAFI_MPLS_VPN) {
 		if (addpath_encode)
@@ -3445,7 +3442,8 @@ void bgp_packet_mpattr_prefix(struct stream *s, afi_t afi, safi_t safi,
 		stream_put_prefix_addpath(s, p, addpath_encode, addpath_tx_id);
 }
 
-size_t bgp_packet_mpattr_prefix_size(afi_t afi, safi_t safi, struct prefix *p)
+size_t bgp_packet_mpattr_prefix_size(afi_t afi, safi_t safi,
+				     const struct prefix *p)
 {
 	int size = PSIZE(p->prefixlen);
 	if (safi == SAFI_MPLS_VPN)
@@ -4079,8 +4077,9 @@ size_t bgp_packet_mpunreach_start(struct stream *s, afi_t afi, safi_t safi)
 	return attrlen_pnt;
 }
 
-void bgp_packet_mpunreach_prefix(struct stream *s, struct prefix *p, afi_t afi,
-				 safi_t safi, struct prefix_rd *prd,
+void bgp_packet_mpunreach_prefix(struct stream *s, const struct prefix *p,
+				 afi_t afi, safi_t safi,
+				 const struct prefix_rd *prd,
 				 mpls_label_t *label, uint32_t num_labels,
 				 int addpath_encode, uint32_t addpath_tx_id,
 				 struct attr *attr)

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -310,14 +310,11 @@ extern void bgp_attr_unintern_sub(struct attr *);
 extern void bgp_attr_unintern(struct attr **);
 extern void bgp_attr_flush(struct attr *);
 extern struct attr *bgp_attr_default_set(struct attr *attr, uint8_t);
-extern struct attr *bgp_attr_aggregate_intern(struct bgp *bgp, uint8_t origin,
-					      struct aspath *aspath,
-					      struct community *community,
-					      struct ecommunity *ecommunity,
-					      struct lcommunity *lcommunity,
-					      struct bgp_aggregate *aggregate,
-					      uint8_t atomic_aggregate,
-					      struct prefix *p);
+extern struct attr *bgp_attr_aggregate_intern(
+	struct bgp *bgp, uint8_t origin, struct aspath *aspath,
+	struct community *community, struct ecommunity *ecommunity,
+	struct lcommunity *lcommunity, struct bgp_aggregate *aggregate,
+	uint8_t atomic_aggregate, const struct prefix *p);
 extern bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *,
 				       struct stream *, struct attr *,
 				       struct bpacket_attr_vec_arr *vecarr,
@@ -372,20 +369,21 @@ extern size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer,
 				      struct bpacket_attr_vec_arr *vecarr,
 				      struct attr *attr);
 extern void bgp_packet_mpattr_prefix(struct stream *s, afi_t afi, safi_t safi,
-				     struct prefix *p, struct prefix_rd *prd,
+				     const struct prefix *p,
+				     const struct prefix_rd *prd,
 				     mpls_label_t *label, uint32_t num_labels,
 				     int addpath_encode, uint32_t addpath_tx_id,
 				     struct attr *);
 extern size_t bgp_packet_mpattr_prefix_size(afi_t afi, safi_t safi,
-					    struct prefix *p);
+					    const struct prefix *p);
 extern void bgp_packet_mpattr_end(struct stream *s, size_t sizep);
 
 extern size_t bgp_packet_mpunreach_start(struct stream *s, afi_t afi,
 					 safi_t safi);
-extern void bgp_packet_mpunreach_prefix(struct stream *s, struct prefix *p,
-					afi_t afi, safi_t safi,
-					struct prefix_rd *prd, mpls_label_t *,
-					uint32_t, int, uint32_t, struct attr *);
+extern void bgp_packet_mpunreach_prefix(
+	struct stream *s, const struct prefix *p, afi_t afi, safi_t safi,
+	const struct prefix_rd *prd, mpls_label_t *label, uint32_t num_labels,
+	int addpath_encode, uint32_t addpath_tx_id, struct attr *attr);
 extern void bgp_packet_mpunreach_end(struct stream *s, size_t attrlen_pnt);
 
 extern bgp_attr_parse_ret_t bgp_attr_nexthop_valid(struct peer *peer,

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -765,8 +765,8 @@ static void bmp_eor(struct bmp *bmp, afi_t afi, safi_t safi, uint8_t flags)
 	stream_free(s);
 }
 
-static struct stream *bmp_update(struct prefix *p, struct peer *peer,
-		struct attr *attr, afi_t afi, safi_t safi)
+static struct stream *bmp_update(const struct prefix *p, struct peer *peer,
+				 struct attr *attr, afi_t afi, safi_t safi)
 {
 	struct bpacket_attr_vec_arr vecarr;
 	struct stream *s;
@@ -813,7 +813,8 @@ static struct stream *bmp_update(struct prefix *p, struct peer *peer,
 	return s;
 }
 
-static struct stream *bmp_withdraw(struct prefix *p, afi_t afi, safi_t safi)
+static struct stream *bmp_withdraw(const struct prefix *p, afi_t afi,
+				   safi_t safi)
 {
 	struct stream *s;
 	size_t attrlen_pos = 0, mp_start, mplen_pos;
@@ -853,7 +854,7 @@ static struct stream *bmp_withdraw(struct prefix *p, afi_t afi, safi_t safi)
 }
 
 static void bmp_monitor(struct bmp *bmp, struct peer *peer, uint8_t flags,
-			struct prefix *p, struct attr *attr, afi_t afi,
+			const struct prefix *p, struct attr *attr, afi_t afi,
 			safi_t safi, time_t uptime)
 {
 	struct stream *hdr, *msg;

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -941,7 +941,7 @@ afibreak:
 				return true;
 			}
 			bmp->syncpeerid = 0;
-			prefix_copy(&bmp->syncpos, &bn->p);
+			prefix_copy(&bmp->syncpos, bgp_node_get_prefix(bn));
 		}
 
 		if (bmp->targets->afimon[afi][safi] & BMP_MON_POSTPOLICY) {
@@ -989,12 +989,14 @@ afibreak:
 		bmp->syncpeerid = adjin->peer->qobj_node.nid;
 	}
 
+	const struct prefix *bn_p = bgp_node_get_prefix(bn);
+
 	if (bpi)
-		bmp_monitor(bmp, bpi->peer, BMP_PEER_FLAG_L, &bn->p, bpi->attr,
+		bmp_monitor(bmp, bpi->peer, BMP_PEER_FLAG_L, bn_p, bpi->attr,
 			    afi, safi, bpi->uptime);
 	if (adjin)
-		bmp_monitor(bmp, adjin->peer, 0, &bn->p, adjin->attr,
-			    afi, safi, adjin->uptime);
+		bmp_monitor(bmp, adjin->peer, 0, bn_p, adjin->attr, afi, safi,
+			    adjin->uptime);
 
 	return true;
 }
@@ -1131,16 +1133,13 @@ static void bmp_process_one(struct bmp_targets *bt, struct bgp *bgp,
 	struct bmp *bmp;
 	struct bmp_queue_entry *bqe, bqeref;
 	size_t refcount;
-	char buf[256];
-
-	prefix2str(&bn->p, buf, sizeof(buf));
 
 	refcount = bmp_session_count(&bt->sessions);
 	if (refcount == 0)
 		return;
 
 	memset(&bqeref, 0, sizeof(bqeref));
-	prefix_copy(&bqeref.p, &bn->p);
+	prefix_copy(&bqeref.p, bgp_node_get_prefix(bn));
 	bqeref.peerid = peer->qobj_node.nid;
 	bqeref.afi = afi;
 	bqeref.safi = safi;

--- a/bgpd/bgp_damp.c
+++ b/bgpd/bgp_damp.c
@@ -155,9 +155,9 @@ static int bgp_reuse_timer(struct thread *t)
 			if (bdi->lastrecord == BGP_RECORD_UPDATE) {
 				bgp_path_info_unset_flag(bdi->rn, bdi->path,
 							 BGP_PATH_HISTORY);
-				bgp_aggregate_increment(bgp, &bdi->rn->p,
-							bdi->path, bdi->afi,
-							bdi->safi);
+				bgp_aggregate_increment(
+					bgp, bgp_node_get_prefix(bdi->rn),
+					bdi->path, bdi->afi, bdi->safi);
 				bgp_process(bgp, bdi->rn, bdi->afi, bdi->safi);
 			}
 

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -2553,7 +2553,7 @@ bool bgp_debug_zebra(const struct prefix *p)
 }
 
 const char *bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi,
-				    struct prefix_rd *prd,
+				    const struct prefix_rd *prd,
 				    union prefixconstptr pu,
 				    mpls_label_t *label, uint32_t num_labels,
 				    int addpath_valid, uint32_t addpath_id,

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -2532,7 +2532,7 @@ bool bgp_debug_bestpath(struct bgp_node *rn)
 {
 	if (BGP_DEBUG(bestpath, BESTPATH)) {
 		if (bgp_debug_per_prefix(
-			    &rn->p, term_bgp_debug_bestpath,
+			    bgp_node_get_prefix(rn), term_bgp_debug_bestpath,
 			    BGP_DEBUG_BESTPATH, bgp_debug_bestpath_prefixes))
 			return true;
 	}

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -171,10 +171,11 @@ extern bool bgp_debug_update(struct peer *peer, const struct prefix *p,
 extern bool bgp_debug_bestpath(struct bgp_node *rn);
 extern bool bgp_debug_zebra(const struct prefix *p);
 
-extern const char *bgp_debug_rdpfxpath2str(afi_t, safi_t, struct prefix_rd *,
-					   union prefixconstptr, mpls_label_t *,
-					   uint32_t, int, uint32_t, char *,
-					   int);
+extern const char *
+bgp_debug_rdpfxpath2str(afi_t afi, safi_t safi, const struct prefix_rd *prd,
+			union prefixconstptr pu, mpls_label_t *label,
+			uint32_t num_labels, int addpath_valid,
+			uint32_t addpath_id, char *str, int size);
 const char *bgp_notify_admin_message(char *buf, size_t bufsz, uint8_t *data,
 				     size_t datalen);
 

--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -307,6 +307,7 @@ bgp_dump_route_node_record(int afi, struct bgp_node *rn,
 	struct stream *obuf;
 	size_t sizep;
 	size_t endp;
+	const struct prefix *p = bgp_node_get_prefix(rn);
 
 	obuf = bgp_dump_obuf;
 	stream_reset(obuf);
@@ -325,19 +326,19 @@ bgp_dump_route_node_record(int afi, struct bgp_node *rn,
 	stream_putl(obuf, seq);
 
 	/* Prefix length */
-	stream_putc(obuf, rn->p.prefixlen);
+	stream_putc(obuf, p->prefixlen);
 
 	/* Prefix */
 	if (afi == AFI_IP) {
 		/* We'll dump only the useful bits (those not 0), but have to
 		 * align on 8 bits */
-		stream_write(obuf, (uint8_t *)&rn->p.u.prefix4,
-			     (rn->p.prefixlen + 7) / 8);
+		stream_write(obuf, (uint8_t *)&p->u.prefix4,
+			     (p->prefixlen + 7) / 8);
 	} else if (afi == AFI_IP6) {
 		/* We'll dump only the useful bits (those not 0), but have to
 		 * align on 8 bits */
-		stream_write(obuf, (uint8_t *)&rn->p.u.prefix6,
-			     (rn->p.prefixlen + 7) / 8);
+		stream_write(obuf, (uint8_t *)&p->u.prefix6,
+			     (p->prefixlen + 7) / 8);
 	}
 
 	/* Save where we are now, so we can overwride the entry count later */
@@ -361,7 +362,7 @@ bgp_dump_route_node_record(int afi, struct bgp_node *rn,
 
 		/* Dump attribute. */
 		/* Skip prefix & AFI/SAFI for MP_NLRI */
-		bgp_dump_routes_attr(obuf, path->attr, &rn->p);
+		bgp_dump_routes_attr(obuf, path->attr, p);
 
 		cur_endp = stream_get_endp(obuf);
 		if (cur_endp > BGP_MAX_PACKET_SIZE + BGP_DUMP_MSG_HEADER

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -4297,13 +4297,14 @@ static int process_type5_route(struct peer *peer, afi_t afi, safi_t safi,
 	return ret;
 }
 
-static void evpn_mpattr_encode_type5(struct stream *s, struct prefix *p,
-				     struct prefix_rd *prd, mpls_label_t *label,
-				     uint32_t num_labels, struct attr *attr)
+static void evpn_mpattr_encode_type5(struct stream *s, const struct prefix *p,
+				     const struct prefix_rd *prd,
+				     mpls_label_t *label, uint32_t num_labels,
+				     struct attr *attr)
 {
 	int len;
 	char temp[16];
-	struct evpn_addr *p_evpn_p;
+	const struct evpn_addr *p_evpn_p;
 
 	memset(&temp, 0, 16);
 	if (p->family != AF_EVPN)
@@ -5030,8 +5031,8 @@ char *bgp_evpn_route2str(const struct prefix_evpn *p, char *buf, int len)
 /*
  * Encode EVPN prefix in Update (MP_REACH)
  */
-void bgp_evpn_encode_prefix(struct stream *s, struct prefix *p,
-			    struct prefix_rd *prd, mpls_label_t *label,
+void bgp_evpn_encode_prefix(struct stream *s, const struct prefix *p,
+			    const struct prefix_rd *prd, mpls_label_t *label,
 			    uint32_t num_labels, struct attr *attr,
 			    int addpath_encode, uint32_t addpath_tx_id)
 {
@@ -6264,7 +6265,7 @@ void bgp_evpn_vrf_delete(struct bgp *bgp_vrf)
 /*
  * Get the prefixlen of the ip prefix carried within the type5 evpn route.
  */
-int bgp_evpn_get_type5_prefixlen(struct prefix *pfx)
+int bgp_evpn_get_type5_prefixlen(const struct prefix *pfx)
 {
 	struct prefix_evpn *evp = (struct prefix_evpn *)pfx;
 

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -1005,7 +1005,7 @@ static void evpn_delete_old_local_route(struct bgp *bgp, struct bgpevpn *vpn,
 	 * L3VPN routes.
 	 */
 	global_rn = bgp_afi_node_lookup(bgp->rib[afi][safi], afi, safi,
-					(struct prefix *)&rn->p, &vpn->prd);
+					bgp_node_get_prefix(rn), &vpn->prd);
 	if (global_rn) {
 		/* Delete route entry in the global EVPN table. */
 		delete_evpn_route_entry(bgp, afi, safi, global_rn, &pi);
@@ -1128,7 +1128,7 @@ static int evpn_es_route_select_install(struct bgp *bgp,
 	    && !bgp_addpath_is_addpath_used(&bgp->tx_addpath, afi, safi)) {
 		if (bgp_zebra_has_route_changed(rn, old_select)) {
 			ret = evpn_es_install_vtep(bgp, es,
-						   (struct prefix_evpn *)&rn->p,
+						   (const struct prefix_evpn *)bgp_node_get_prefix(rn),
 						   old_select->attr->nexthop);
 		}
 		UNSET_FLAG(old_select->flags, BGP_PATH_MULTIPATH_CHG);
@@ -1157,13 +1157,13 @@ static int evpn_es_route_select_install(struct bgp *bgp,
 	if (new_select && new_select->type == ZEBRA_ROUTE_BGP
 	    && new_select->sub_type == BGP_ROUTE_IMPORTED) {
 		ret = evpn_es_install_vtep(bgp, es,
-					   (const struct prefix_evpn *)&rn->p,
+					   (const struct prefix_evpn *)bgp_node_get_prefix(rn),
 					   new_select->attr->nexthop);
 	} else {
 		if (old_select && old_select->type == ZEBRA_ROUTE_BGP
 		    && old_select->sub_type == BGP_ROUTE_IMPORTED)
 			ret = evpn_es_uninstall_vtep(
-				bgp, es, (struct prefix_evpn *)&rn->p,
+				bgp, es, (struct prefix_evpn *)bgp_node_get_prefix(rn),
 				old_select->attr->nexthop);
 	}
 
@@ -1208,7 +1208,7 @@ static int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 	    && !bgp_addpath_is_addpath_used(&bgp->tx_addpath, afi, safi)) {
 		if (bgp_zebra_has_route_changed(rn, old_select))
 			ret = evpn_zebra_install(
-				bgp, vpn, (struct prefix_evpn *)&rn->p,
+				bgp, vpn, (const struct prefix_evpn *)bgp_node_get_prefix(rn),
 				old_select);
 		UNSET_FLAG(old_select->flags, BGP_PATH_MULTIPATH_CHG);
 		bgp_zebra_clear_route_change_flags(rn);
@@ -1234,8 +1234,9 @@ static int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 
 	if (new_select && new_select->type == ZEBRA_ROUTE_BGP
 	    && new_select->sub_type == BGP_ROUTE_IMPORTED) {
-		ret = evpn_zebra_install(bgp, vpn, (struct prefix_evpn *)&rn->p,
-					 new_select);
+		ret = evpn_zebra_install(
+			bgp, vpn, (struct prefix_evpn *)bgp_node_get_prefix(rn),
+			new_select);
 
 		/* If an old best existed and it was a "local" route, the only
 		 * reason
@@ -1251,9 +1252,11 @@ static int evpn_route_select_install(struct bgp *bgp, struct bgpevpn *vpn,
 	} else {
 		if (old_select && old_select->type == ZEBRA_ROUTE_BGP
 		    && old_select->sub_type == BGP_ROUTE_IMPORTED)
-			ret = evpn_zebra_uninstall(bgp, vpn,
-						   (struct prefix_evpn *)&rn->p,
-						   old_select->attr->nexthop);
+			ret = evpn_zebra_uninstall(
+				bgp, vpn,
+				(const struct prefix_evpn *)bgp_node_get_prefix(
+					rn),
+				old_select->attr->nexthop);
 	}
 
 	/* Clear any route change flags. */
@@ -1330,11 +1333,11 @@ static int update_evpn_type4_route_entry(struct bgp *bgp, struct evpnes *es,
 	struct bgp_path_info *local_pi = NULL;  /* local route entry if any */
 	struct bgp_path_info *remote_pi = NULL; /* remote route entry if any */
 	struct attr *attr_new = NULL;
-	struct prefix_evpn *evp = NULL;
+	const struct prefix_evpn *evp = NULL;
 
 	*ri = NULL;
 	*route_changed = 1;
-	evp = (struct prefix_evpn *)&rn->p;
+	evp = (const struct prefix_evpn *)bgp_node_get_prefix(rn);
 
 	/* locate the local and remote entries if any */
 	for (tmp_pi = bgp_node_get_bgp_path_info(rn); tmp_pi;
@@ -1662,10 +1665,10 @@ static int update_evpn_route_entry(struct bgp *bgp, struct bgpevpn *vpn,
 	uint32_t num_labels = 1;
 	int route_change = 1;
 	uint8_t sticky = 0;
-	struct prefix_evpn *evp;
+	const struct prefix_evpn *evp;
 
 	*pi = NULL;
-	evp = (struct prefix_evpn *)&rn->p;
+	evp = (const struct prefix_evpn *)bgp_node_get_prefix(rn);
 	memset(&label, 0, sizeof(label));
 
 	/* See if this is an update of an existing route, or a new add. */
@@ -1797,8 +1800,8 @@ static void evpn_zebra_reinstall_best_route(struct bgp *bgp,
 	if (curr_select && curr_select->type == ZEBRA_ROUTE_BGP
 			&& curr_select->sub_type == BGP_ROUTE_IMPORTED)
 		evpn_zebra_install(bgp, vpn,
-				(struct prefix_evpn *)&rn->p,
-				curr_select);
+				   (const struct prefix_evpn *)bgp_node_get_prefix(rn),
+				   curr_select);
 }
 
 /*
@@ -1820,13 +1823,10 @@ static void evpn_cleanup_local_non_best_route(struct bgp *bgp,
 					      struct bgp_node *rn,
 					      struct bgp_path_info *local_pi)
 {
-	char buf[PREFIX_STRLEN];
-
 	/* local path was not picked as the winner; kick it out */
-	if (bgp_debug_zebra(NULL)) {
-		zlog_debug("evicting local evpn prefix %s as remote won",
-					prefix2str(&rn->p, buf, sizeof(buf)));
-	}
+	if (bgp_debug_zebra(NULL))
+		zlog_debug("evicting local evpn prefix %pRN as remote won", rn);
+
 	evpn_delete_old_local_route(bgp, vpn, rn, local_pi);
 	bgp_path_info_reap(rn, local_pi);
 
@@ -2145,7 +2145,7 @@ static int update_all_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
 	 */
 	for (rn = bgp_table_top(vpn->route_table); rn;
 	     rn = bgp_route_next(rn)) {
-		struct prefix_evpn *evp = (struct prefix_evpn *)&rn->p;
+		const struct prefix_evpn *evp = (const struct prefix_evpn *)bgp_node_get_prefix(rn);
 		struct bgp_node *rd_rn;
 		struct bgp_path_info *global_pi;
 
@@ -2278,7 +2278,7 @@ static int delete_global_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
 	if (rdrn && bgp_node_has_bgp_path_info_data(rdrn)) {
 		table = bgp_node_get_bgp_table_info(rdrn);
 		for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
-			struct prefix_evpn *evp = (struct prefix_evpn *)&rn->p;
+			const struct prefix_evpn *evp = (const struct prefix_evpn *)bgp_node_get_prefix(rn);
 
 			if (evp->prefix.route_type != BGP_EVPN_MAC_IP_ROUTE)
 				continue;
@@ -2319,7 +2319,7 @@ static int delete_all_type2_routes(struct bgp *bgp, struct bgpevpn *vpn)
 	/* Next, walk this VNI's route table and delete local type-2 routes. */
 	for (rn = bgp_table_top(vpn->route_table); rn;
 	     rn = bgp_route_next(rn)) {
-		struct prefix_evpn *evp = (struct prefix_evpn *)&rn->p;
+		const struct prefix_evpn *evp = (const struct prefix_evpn *)bgp_node_get_prefix(rn);
 
 		if (evp->prefix.route_type != BGP_EVPN_MAC_IP_ROUTE)
 			continue;
@@ -2709,7 +2709,8 @@ static int install_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 	/* as it is an importation, change nexthop */
 	bgp_path_info_set_flag(rn, pi, BGP_PATH_ANNC_NH_SELF);
 
-	bgp_aggregate_increment(bgp_vrf, &rn->p, pi, afi, safi);
+	bgp_aggregate_increment(bgp_vrf, bgp_node_get_prefix(rn), pi, afi,
+				safi);
 
 	/* Perform route selection and update zebra, if required. */
 	bgp_process(bgp_vrf, rn, afi, safi);
@@ -2876,7 +2877,8 @@ static int uninstall_evpn_route_entry_in_vrf(struct bgp *bgp_vrf,
 	/* Process for route leaking. */
 	vpn_leak_from_vrf_withdraw(bgp_get_default(), bgp_vrf, pi);
 
-	bgp_aggregate_decrement(bgp_vrf, &rn->p, pi, afi, safi);
+	bgp_aggregate_decrement(bgp_vrf, bgp_node_get_prefix(rn), pi, afi,
+				safi);
 
 	/* Mark entry for deletion */
 	bgp_path_info_delete(rn, pi);
@@ -3107,7 +3109,9 @@ static int install_uninstall_routes_for_es(struct bgp *bgp,
 			continue;
 
 		for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
-			struct prefix_evpn *evp = (struct prefix_evpn *)&rn->p;
+			const struct prefix_evpn *evp =
+				(const struct prefix_evpn *)bgp_node_get_prefix(
+					rn);
 
 			for (pi = bgp_node_get_bgp_path_info(rn); pi;
 			     pi = pi->next) {
@@ -3214,7 +3218,7 @@ static int install_uninstall_routes_for_vrf(struct bgp *bgp_vrf, int install)
 			continue;
 
 		for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
-			struct prefix_evpn *evp = (struct prefix_evpn *)&rn->p;
+			const struct prefix_evpn *evp = (const struct prefix_evpn *)bgp_node_get_prefix(rn);
 
 			/* if not mac-ip route skip this route */
 			if (!(evp->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE
@@ -3302,7 +3306,9 @@ static int install_uninstall_routes_for_vni(struct bgp *bgp,
 			continue;
 
 		for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
-			struct prefix_evpn *evp = (struct prefix_evpn *)&rn->p;
+			const struct prefix_evpn *evp =
+				(const struct prefix_evpn *)bgp_node_get_prefix(
+					rn);
 
 			if (evp->prefix.route_type != rtype)
 				continue;
@@ -3774,7 +3780,8 @@ static int update_advertise_vni_routes(struct bgp *bgp, struct bgpevpn *vpn)
 	 */
 	for (rn = bgp_table_top(vpn->route_table); rn;
 	     rn = bgp_route_next(rn)) {
-		struct prefix_evpn *evp = (struct prefix_evpn *)&rn->p;
+		const struct prefix_evpn *evp =
+			(const struct prefix_evpn *)bgp_node_get_prefix(rn);
 
 		/* Identify MAC-IP local routes. */
 		if (evp->prefix.route_type != BGP_EVPN_MAC_IP_ROUTE)
@@ -4500,8 +4507,9 @@ void bgp_evpn_withdraw_type5_routes(struct bgp *bgp_vrf, afi_t afi, safi_t safi)
 		for (pi = bgp_node_get_bgp_path_info(rn); pi; pi = pi->next) {
 			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED)
 			    && is_route_injectable_into_evpn(pi)) {
-				bgp_evpn_withdraw_type5_route(bgp_vrf, &rn->p,
-							      afi, safi);
+				bgp_evpn_withdraw_type5_route(
+					bgp_vrf, bgp_node_get_prefix(rn), afi,
+					safi);
 				break;
 			}
 		}
@@ -4593,18 +4601,21 @@ void bgp_evpn_advertise_type5_routes(struct bgp *bgp_vrf, afi_t afi,
 					ret = route_map_apply(
 						bgp_vrf->adv_cmd_rmap[afi][safi]
 							.map,
-						&rn->p, RMAP_BGP, &tmp_pi);
+						bgp_node_get_prefix(rn),
+						RMAP_BGP, &tmp_pi);
 					if (ret == RMAP_DENYMATCH) {
 						bgp_attr_flush(&tmp_attr);
 						continue;
 					}
 					bgp_evpn_advertise_type5_route(
-						bgp_vrf, &rn->p, &tmp_attr,
-						afi, safi);
+						bgp_vrf,
+						bgp_node_get_prefix(rn),
+						&tmp_attr, afi, safi);
 				} else
 					bgp_evpn_advertise_type5_route(
-						bgp_vrf, &rn->p, pi->attr,
-						afi, safi);
+						bgp_vrf,
+						bgp_node_get_prefix(rn),
+						pi->attr, afi, safi);
 				break;
 			}
 		}
@@ -5602,25 +5613,23 @@ int bgp_filter_evpn_routes_upon_martian_nh_change(struct bgp *bgp)
 				if (bgp_nexthop_self(bgp, afi,
 						pi->type, pi->sub_type,
 						pi->attr, rn)) {
+					const struct prefix *p =
+						bgp_node_get_prefix(rn);
 
-					char attr_str[BUFSIZ] = {0};
-					char pbuf[PREFIX_STRLEN];
+					if (bgp_debug_update(pi->peer, p, NULL,
+							     1)) {
+						char attr_str[BUFSIZ] = {0};
 
-					bgp_dump_attr(pi->attr, attr_str,
-						      BUFSIZ);
+						bgp_dump_attr(pi->attr,
+							      attr_str, BUFSIZ);
 
-					if (bgp_debug_update(pi->peer, &rn->p,
-							     NULL, 1))
 						zlog_debug(
-							"%u: prefix %s with attr %s - DENIED due to martian or self nexthop",
-							bgp->vrf_id,
-							prefix2str(
-								&rn->p, pbuf,
-								sizeof(pbuf)),
+							"%u: prefix %pRN with attr %s - DENIED due to martian or self nexthop",
+							bgp->vrf_id, rn,
 							attr_str);
-
+					}
 					bgp_evpn_unimport_route(bgp, afi, safi,
-								&rn->p, pi);
+								p, pi);
 
 					bgp_rib_remove(rn, pi, pi->peer, afi,
 						       safi);

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -157,10 +157,11 @@ extern char *bgp_evpn_label2str(mpls_label_t *label, uint32_t num_labels,
 extern char *bgp_evpn_route2str(const struct prefix_evpn *p, char *buf,
 				int len);
 extern void bgp_evpn_route2json(const struct prefix_evpn *p, json_object *json);
-extern void bgp_evpn_encode_prefix(struct stream *s, struct prefix *p,
-				   struct prefix_rd *prd, mpls_label_t *label,
-				   uint32_t num_labels, struct attr *attr,
-				   int addpath_encode, uint32_t addpath_tx_id);
+extern void bgp_evpn_encode_prefix(struct stream *s, const struct prefix *p,
+				   const struct prefix_rd *prd,
+				   mpls_label_t *label, uint32_t num_labels,
+				   struct attr *attr, int addpath_encode,
+				   uint32_t addpath_tx_id);
 extern int bgp_nlri_parse_evpn(struct peer *peer, struct attr *attr,
 			       struct bgp_nlri *packet, int withdraw);
 extern int bgp_evpn_import_route(struct bgp *bgp, afi_t afi, safi_t safi,
@@ -195,7 +196,7 @@ extern void bgp_evpn_flood_control_change(struct bgp *bgp);
 extern void bgp_evpn_cleanup_on_disable(struct bgp *bgp);
 extern void bgp_evpn_cleanup(struct bgp *bgp);
 extern void bgp_evpn_init(struct bgp *bgp);
-extern int bgp_evpn_get_type5_prefixlen(struct prefix *pfx);
+extern int bgp_evpn_get_type5_prefixlen(const struct prefix *pfx);
 extern bool bgp_evpn_is_prefix_nht_supported(const struct prefix *pfx);
 extern void update_advertise_vrf_routes(struct bgp *bgp_vrf);
 

--- a/bgpd/bgp_flowspec_util.c
+++ b/bgpd/bgp_flowspec_util.c
@@ -607,7 +607,8 @@ bool bgp_flowspec_get_first_nh(struct bgp *bgp, struct bgp_path_info *pi,
 	struct bgp_pbr_entry_action *api_action;
 
 	memset(&api, 0, sizeof(struct bgp_pbr_entry_main));
-	if (bgp_pbr_build_and_validate_entry(&rn->p, pi, &api) < 0)
+	if (bgp_pbr_build_and_validate_entry(bgp_node_get_prefix(rn), pi, &api)
+	    < 0)
 		return true;
 	for (i = 0; i < api.action_num; i++) {
 		api_action = &api.actions[i];

--- a/bgpd/bgp_flowspec_vty.c
+++ b/bgpd/bgp_flowspec_vty.c
@@ -409,8 +409,8 @@ int bgp_show_table_flowspec(struct vty *vty, struct bgp *bgp, afi_t afi,
 		}
 		for (; pi; pi = pi->next) {
 			total_count++;
-			route_vty_out_flowspec(vty, &rn->p, pi, display,
-					       json_paths);
+			route_vty_out_flowspec(vty, bgp_node_get_prefix(rn), pi,
+					       display, json_paths);
 		}
 		if (use_json) {
 			vty_out(vty, "%s\n",
@@ -554,18 +554,18 @@ extern int bgp_flowspec_display_match_per_ip(afi_t afi, struct bgp_table *rib,
 					     json_object *json_paths)
 {
 	struct bgp_node *rn;
-	struct prefix *prefix;
+	const struct prefix *prefix;
 	int display = 0;
 
 	for (rn = bgp_table_top(rib); rn; rn = bgp_route_next(rn)) {
-		prefix = &rn->p;
+		prefix = bgp_node_get_prefix(rn);
 
 		if (prefix->family != AF_FLOWSPEC)
 			continue;
 
 		if (bgp_flowspec_contains_prefix(prefix, match, prefix_check)) {
 			route_vty_out_flowspec(
-				vty, &rn->p, bgp_node_get_bgp_path_info(rn),
+				vty, prefix, bgp_node_get_bgp_path_info(rn),
 				use_json ? NLRI_STRING_FORMAT_JSON
 					 : NLRI_STRING_FORMAT_LARGE,
 				json_paths);

--- a/bgpd/bgp_label.c
+++ b/bgpd/bgp_label.c
@@ -132,7 +132,6 @@ int bgp_reg_for_label_callback(mpls_label_t new_label, void *labelid,
 {
 	struct bgp_path_info *pi;
 	struct bgp_node *rn;
-	char addr[PREFIX_STRLEN];
 
 	pi = labelid;
 	/* Is this path still valid? */
@@ -145,10 +144,9 @@ int bgp_reg_for_label_callback(mpls_label_t new_label, void *labelid,
 	}
 
 	rn = pi->net;
-	prefix2str(&rn->p, addr, PREFIX_STRLEN);
 
 	if (BGP_DEBUG(labelpool, LABELPOOL))
-		zlog_debug("%s: FEC %s label=%u, allocated=%d", __func__, addr,
+		zlog_debug("%s: FEC %pRN label=%u, allocated=%d", __func__, rn,
 			   new_label, allocated);
 
 	if (!allocated) {
@@ -174,8 +172,8 @@ int bgp_reg_for_label_callback(mpls_label_t new_label, void *labelid,
 	if (pi->attr->label_index != MPLS_INVALID_LABEL_INDEX) {
 		flog_err(
 			EC_BGP_LABEL,
-			"%s: FEC %s Rejecting allocated label %u as Label Index is %u",
-			__func__, addr, new_label, pi->attr->label_index);
+			"%s: FEC %pRN Rejecting allocated label %u as Label Index is %u",
+			__func__, rn, new_label, pi->attr->label_index);
 
 		bgp_register_for_label(pi->net, pi);
 
@@ -189,8 +187,8 @@ int bgp_reg_for_label_callback(mpls_label_t new_label, void *labelid,
 		}
 		/* Shouldn't happen: different label allocation */
 		flog_err(EC_BGP_LABEL,
-			 "%s: %s had label %u but got new assignment %u",
-			 __func__, addr, pi->attr->label, new_label);
+			 "%s: %pRN had label %u but got new assignment %u",
+			 __func__, rn, pi->attr->label, new_label);
 		/* continue means use new one */
 	}
 
@@ -210,14 +208,14 @@ void bgp_reg_dereg_for_label(struct bgp_node *rn, struct bgp_path_info *pi,
 {
 	bool with_label_index = false;
 	struct stream *s;
-	struct prefix *p;
+	const struct prefix *p;
 	mpls_label_t *local_label;
 	int command;
 	uint16_t flags = 0;
 	size_t flags_pos = 0;
 	char addr[PREFIX_STRLEN];
 
-	p = &(rn->p);
+	p = bgp_node_get_prefix(rn);
 	local_label = &(rn->local_label);
 	/* this prevents the loop when we're called by
 	 * bgp_reg_for_label_callback()

--- a/bgpd/bgp_mac.c
+++ b/bgpd/bgp_mac.c
@@ -142,13 +142,15 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 
 	for (prn = bgp_table_top(table); prn; prn = bgp_route_next(prn)) {
 		struct bgp_table *sub = prn->info;
+		const struct prefix *prn_p = bgp_node_get_prefix(prn);
 
 		if (!sub)
 			continue;
 
 		for (rn = bgp_table_top(sub); rn; rn = bgp_route_next(rn)) {
 			bool rn_affected;
-			struct prefix_evpn *pevpn = (struct prefix_evpn *)&rn->p;
+			const struct prefix *p = bgp_node_get_prefix(rn);
+			const struct prefix_evpn *pevpn = (const struct prefix_evpn *)p;
 			struct prefix_rd prd;
 			uint32_t num_labels = 0;
 			mpls_label_t *label_pnt = NULL;
@@ -156,7 +158,7 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 
 			if (pevpn->family == AF_EVPN &&
 			    pevpn->prefix.route_type == BGP_EVPN_MAC_IP_ROUTE &&
-			    memcmp(&rn->p.u.prefix_evpn.macip_addr.mac,
+			    memcmp(&p->u.prefix_evpn.macip_addr.mac,
 				   macaddr, ETH_ALEN) == 0)
 				rn_affected = true;
 			else
@@ -185,15 +187,15 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 
 			prd.family = AF_UNSPEC;
 			prd.prefixlen = 64;
-			memcpy(&prd.val, &prn->p.u.val, 8);
+			memcpy(&prd.val, prn_p->u.val, 8);
 
 			if (CHECK_FLAG(pi->flags, BGP_PATH_REMOVED)) {
-				if (bgp_debug_update(peer, &rn->p, NULL, 1)) {
+				if (bgp_debug_update(peer, p, NULL, 1)) {
 					char pfx_buf[BGP_PRD_PATH_STRLEN];
 
 					bgp_debug_rdpfxpath2str(
 						AFI_L2VPN, SAFI_EVPN, &prd,
-						&rn->p, label_pnt, num_labels,
+						p, label_pnt, num_labels,
 						pi->addpath_rx_id ? 1 : 0,
 						pi->addpath_rx_id, pfx_buf,
 						sizeof(pfx_buf));
@@ -205,7 +207,7 @@ static void bgp_process_mac_rescan_table(struct bgp *bgp, struct peer *peer,
 			}
 
 			memcpy(&evpn, &pi->attr->evpn_overlay, sizeof(evpn));
-			int32_t ret = bgp_update(peer, &rn->p,
+			int32_t ret = bgp_update(peer, p,
 						 pi->addpath_rx_id,
 						 pi->attr, AFI_L2VPN, SAFI_EVPN,
 						 ZEBRA_ROUTE_BGP,

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -447,7 +447,7 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 	struct listnode *mp_node, *mp_next_node;
 	struct bgp_path_info *cur_mpath, *new_mpath, *next_mpath, *prev_mpath;
 	int mpath_changed, debug;
-	char pfx_buf[PREFIX2STR_BUFFER], nh_buf[2][INET6_ADDRSTRLEN];
+	char nh_buf[2][INET6_ADDRSTRLEN];
 	char path_buf[PATH_ADDPATH_STR_BUFFER];
 
 	mpath_changed = 0;
@@ -458,9 +458,6 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 	prev_mpath = new_best;
 	mp_node = listhead(mp_list);
 	debug = bgp_debug_bestpath(rn);
-
-	if (debug)
-		prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
 
 	if (new_best) {
 		mpath_count++;
@@ -480,8 +477,8 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 
 	if (debug)
 		zlog_debug(
-			"%s: starting mpath update, newbest %s num candidates %d old-mpath-count %d",
-			pfx_buf, new_best ? new_best->peer->host : "NONE",
+			"%pRN: starting mpath update, newbest %s num candidates %d old-mpath-count %d",
+			rn, new_best ? new_best->peer->host : "NONE",
 			mp_list ? listcount(mp_list) : 0, old_mpath_count);
 
 	/*
@@ -513,8 +510,8 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 
 		if (debug)
 			zlog_debug(
-				"%s: comparing candidate %s with existing mpath %s",
-				pfx_buf,
+				"%pRN: comparing candidate %s with existing mpath %s",
+				rn,
 				tmp_info ? tmp_info->peer->host : "NONE",
 				cur_mpath ? cur_mpath->peer->host : "NONE");
 
@@ -537,8 +534,8 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 					bgp_path_info_path_with_addpath_rx_str(
 						cur_mpath, path_buf);
 					zlog_debug(
-						"%s: %s is still multipath, cur count %d",
-						pfx_buf, path_buf, mpath_count);
+						"%pRN: %s is still multipath, cur count %d",
+						rn, path_buf, mpath_count);
 				}
 			} else {
 				mpath_changed = 1;
@@ -546,8 +543,8 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 					bgp_path_info_path_with_addpath_rx_str(
 						cur_mpath, path_buf);
 					zlog_debug(
-						"%s: remove mpath %s nexthop %s, cur count %d",
-						pfx_buf, path_buf,
+						"%pRN: remove mpath %s nexthop %s, cur count %d",
+						rn, path_buf,
 						inet_ntop(AF_INET,
 							  &cur_mpath->attr
 								   ->nexthop,
@@ -579,8 +576,8 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 				bgp_path_info_path_with_addpath_rx_str(
 					cur_mpath, path_buf);
 				zlog_debug(
-					"%s: remove mpath %s nexthop %s, cur count %d",
-					pfx_buf, path_buf,
+					"%pRN: remove mpath %s nexthop %s, cur count %d",
+					rn, path_buf,
 					inet_ntop(AF_INET,
 						  &cur_mpath->attr->nexthop,
 						  nh_buf[0], sizeof(nh_buf[0])),
@@ -624,8 +621,8 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 					bgp_path_info_path_with_addpath_rx_str(
 						new_mpath, path_buf);
 					zlog_debug(
-						"%s: add mpath %s nexthop %s, cur count %d",
-						pfx_buf, path_buf,
+						"%pRN: add mpath %s nexthop %s, cur count %d",
+						rn, path_buf,
 						inet_ntop(AF_INET,
 							  &new_mpath->attr
 								   ->nexthop,
@@ -641,8 +638,8 @@ void bgp_path_info_mpath_update(struct bgp_node *rn,
 	if (new_best) {
 		if (debug)
 			zlog_debug(
-				"%s: New mpath count (incl newbest) %d mpath-change %s",
-				pfx_buf, mpath_count,
+				"%pRN: New mpath count (incl newbest) %d mpath-change %s",
+				rn, mpath_count,
 				mpath_changed ? "YES" : "NO");
 
 		bgp_path_info_mpath_count_set(new_best, mpath_count - 1);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -468,18 +468,16 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	    struct bgp *bgp_orig, struct prefix *nexthop_orig,
 	    int nexthop_self_flag, int debug)
 {
-	struct prefix *p = &bn->p;
+	const struct prefix *p = bgp_node_get_prefix(bn);
 	struct bgp_path_info *bpi;
 	struct bgp_path_info *bpi_ultimate;
 	struct bgp_path_info *new;
-	char buf_prefix[PREFIX_STRLEN];
 
-	if (debug) {
-		prefix2str(&bn->p, buf_prefix, sizeof(buf_prefix));
-		zlog_debug("%s: entry: leak-to=%s, p=%s, type=%d, sub_type=%d",
-			   __func__, bgp->name_pretty, buf_prefix,
-			   source_bpi->type, source_bpi->sub_type);
-	}
+	if (debug)
+		zlog_debug(
+			"%s: entry: leak-to=%s, p=%pRN, type=%d, sub_type=%d",
+			__func__, bgp->name_pretty, bn, source_bpi->type,
+			source_bpi->sub_type);
 
 	/*
 	 * Routes that are redistributed into BGP from zebra do not get
@@ -518,9 +516,8 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 			bgp_attr_unintern(&new_attr);
 			if (debug)
 				zlog_debug(
-					"%s: ->%s: %s: Found route, no change",
-					__func__, bgp->name_pretty,
-					buf_prefix);
+					"%s: ->%s: %pRN: Found route, no change",
+					__func__, bgp->name_pretty, bn);
 			return NULL;
 		}
 
@@ -580,8 +577,8 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 		bgp_unlock_node(bn);
 
 		if (debug)
-			zlog_debug("%s: ->%s: %s Found route, changed attr",
-				   __func__, bgp->name_pretty, buf_prefix);
+			zlog_debug("%s: ->%s: %pRN Found route, changed attr",
+				   __func__, bgp->name_pretty, bn);
 
 		return bpi;
 	}
@@ -645,8 +642,8 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	bgp_process(bgp, bn, afi, safi);
 
 	if (debug)
-		zlog_debug("%s: ->%s: %s: Added new route", __func__,
-			   bgp->name_pretty, buf_prefix);
+		zlog_debug("%s: ->%s: %pRN: Added new route", __func__,
+			   bgp->name_pretty, bn);
 
 	return new;
 }
@@ -657,7 +654,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 			      struct bgp_path_info *path_vrf) /* route */
 {
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF);
-	struct prefix *p = &path_vrf->net->p;
+	const struct prefix *p = bgp_node_get_prefix(path_vrf->net);
 	afi_t afi = family2afi(p->family);
 	struct attr static_attr = {0};
 	struct attr *new_attr = NULL;
@@ -891,19 +888,17 @@ void vpn_leak_from_vrf_withdraw(struct bgp *bgp_vpn,		/* to */
 				struct bgp_path_info *path_vrf) /* route */
 {
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF);
-	struct prefix *p = &path_vrf->net->p;
+	const struct prefix *p = bgp_node_get_prefix(path_vrf->net);
 	afi_t afi = family2afi(p->family);
 	safi_t safi = SAFI_MPLS_VPN;
 	struct bgp_path_info *bpi;
 	struct bgp_node *bn;
 	const char *debugmsg;
-	char buf_prefix[PREFIX_STRLEN];
 
 	if (debug) {
-		prefix2str(p, buf_prefix, sizeof(buf_prefix));
 		zlog_debug(
-			"%s: entry: leak-from=%s, p=%s, type=%d, sub_type=%d",
-			__func__, bgp_vrf->name_pretty, buf_prefix,
+			"%s: entry: leak-from=%s, p=%pRN, type=%d, sub_type=%d",
+			__func__, bgp_vrf->name_pretty, path_vrf->net,
 			path_vrf->type, path_vrf->sub_type);
 	}
 
@@ -980,14 +975,10 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn, /* to */
 			continue;
 
 		for (bn = bgp_table_top(table); bn; bn = bgp_route_next(bn)) {
-
-			char buf[PREFIX2STR_BUFFER];
-
 			bpi = bgp_node_get_bgp_path_info(bn);
 			if (debug && bpi) {
-				zlog_debug(
-					"%s: looking at prefix %s", __func__,
-					prefix2str(&bn->p, buf, sizeof(buf)));
+				zlog_debug("%s: looking at prefix %pRN",
+					   __func__, bn);
 			}
 
 			for (; bpi; bpi = bpi->next) {
@@ -1005,8 +996,10 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn, /* to */
 					if (debug)
 						zlog_debug("%s: deleting it",
 							   __func__);
-					bgp_aggregate_decrement(bgp_vpn, &bn->p,
-								bpi, afi, safi);
+					bgp_aggregate_decrement(
+						bgp_vpn,
+						bgp_node_get_prefix(bn), bpi,
+						afi, safi);
 					bgp_path_info_delete(bn, bpi);
 					bgp_process(bgp_vpn, bn, afi, safi);
 				}
@@ -1049,7 +1042,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 			      struct bgp *bgp_vpn,	    /* from */
 			      struct bgp_path_info *path_vpn) /* route */
 {
-	struct prefix *p = &path_vpn->net->p;
+	const struct prefix *p = bgp_node_get_prefix(path_vpn->net);
 	afi_t afi = family2afi(p->family);
 
 	struct attr static_attr = {0};
@@ -1228,12 +1221,9 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 		}
 	}
 
-	if (debug) {
-		char buf_prefix[PREFIX_STRLEN];
-		prefix2str(p, buf_prefix, sizeof(buf_prefix));
-		zlog_debug("%s: pfx %s: num_labels %d", __func__, buf_prefix,
-			   num_labels);
-	}
+	if (debug)
+		zlog_debug("%s: pfx %pRN: num_labels %d", __func__,
+			   path_vpn->net, num_labels);
 
 	/*
 	 * For VRF-2-VRF route-leaking,
@@ -1273,7 +1263,7 @@ void vpn_leak_to_vrf_update(struct bgp *bgp_vpn,	    /* from */
 void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,	    /* from */
 			      struct bgp_path_info *path_vpn) /* route */
 {
-	struct prefix *p;
+	const struct prefix *p;
 	afi_t afi;
 	safi_t safi = SAFI_UNICAST;
 	struct bgp *bgp;
@@ -1281,15 +1271,12 @@ void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,	    /* from */
 	struct bgp_node *bn;
 	struct bgp_path_info *bpi;
 	const char *debugmsg;
-	char buf_prefix[PREFIX_STRLEN];
 
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_TO_VRF);
 
-	if (debug) {
-		prefix2str(&path_vpn->net->p, buf_prefix, sizeof(buf_prefix));
-		zlog_debug("%s: entry: p=%s, type=%d, sub_type=%d", __func__,
-			   buf_prefix, path_vpn->type, path_vpn->sub_type);
-	}
+	if (debug)
+		zlog_debug("%s: entry: p=%pRN, type=%d, sub_type=%d", __func__,
+			   path_vpn->net, path_vpn->type, path_vpn->sub_type);
 
 	if (debug)
 		zlog_debug("%s: start (path_vpn=%p)", __func__, path_vpn);
@@ -1310,7 +1297,7 @@ void vpn_leak_to_vrf_withdraw(struct bgp *bgp_vpn,	    /* from */
 		return;
 	}
 
-	p = &path_vpn->net->p;
+	p = bgp_node_get_prefix(path_vpn->net);
 	afi = family2afi(p->family);
 
 	/* Loop over VRFs */
@@ -1381,8 +1368,9 @@ void vpn_leak_to_vrf_withdraw_all(struct bgp *bgp_vrf, /* to */
 			    && is_pi_family_vpn(bpi->extra->parent)) {
 
 				/* delete route */
-				bgp_aggregate_decrement(bgp_vrf, &bn->p, bpi,
-							afi, safi);
+				bgp_aggregate_decrement(bgp_vrf,
+							bgp_node_get_prefix(bn),
+							bpi, afi, safi);
 				bgp_path_info_delete(bn, bpi);
 				bgp_process(bgp_vrf, bn, afi, safi);
 			}
@@ -1405,7 +1393,7 @@ void vpn_leak_to_vrf_update_all(struct bgp *bgp_vrf, /* to */
 	 */
 	for (prn = bgp_table_top(bgp_vpn->rib[afi][safi]); prn;
 	     prn = bgp_route_next(prn)) {
-
+		const struct prefix *p = bgp_node_get_prefix(prn);
 		struct bgp_table *table;
 		struct bgp_node *bn;
 		struct bgp_path_info *bpi;
@@ -1413,7 +1401,7 @@ void vpn_leak_to_vrf_update_all(struct bgp *bgp_vrf, /* to */
 		memset(&prd, 0, sizeof(prd));
 		prd.family = AF_UNSPEC;
 		prd.prefixlen = 64;
-		memcpy(prd.val, prn->p.u.val, 8);
+		memcpy(prd.val, &p->u.val, 8);
 
 		/* This is the per-RD table of prefixes */
 		table = bgp_node_get_bgp_table_info(prn);

--- a/bgpd/bgp_rd.c
+++ b/bgpd/bgp_rd.c
@@ -87,7 +87,7 @@ void decode_rd_ip(const uint8_t *pnt, struct rd_ip *rd_ip)
 
 #if ENABLE_BGP_VNC
 /* type == RD_TYPE_VNC_ETH */
-void decode_rd_vnc_eth(uint8_t *pnt, struct rd_vnc_eth *rd_vnc_eth)
+void decode_rd_vnc_eth(const uint8_t *pnt, struct rd_vnc_eth *rd_vnc_eth)
 {
 	rd_vnc_eth->type = RD_TYPE_VNC_ETH;
 	rd_vnc_eth->local_nve_id = pnt[1];
@@ -159,9 +159,9 @@ out:
 	return lret;
 }
 
-char *prefix_rd2str(struct prefix_rd *prd, char *buf, size_t size)
+char *prefix_rd2str(const struct prefix_rd *prd, char *buf, size_t size)
 {
-	uint8_t *pnt;
+	const uint8_t *pnt;
 	uint16_t type;
 	struct rd_as rd_as;
 	struct rd_ip rd_ip;

--- a/bgpd/bgp_rd.h
+++ b/bgpd/bgp_rd.h
@@ -61,11 +61,12 @@ extern void decode_rd_as(const uint8_t *pnt, struct rd_as *rd_as);
 extern void decode_rd_as4(const uint8_t *pnt, struct rd_as *rd_as);
 extern void decode_rd_ip(const uint8_t *pnt, struct rd_ip *rd_ip);
 #if ENABLE_BGP_VNC
-extern void decode_rd_vnc_eth(uint8_t *pnt, struct rd_vnc_eth *rd_vnc_eth);
+extern void decode_rd_vnc_eth(const uint8_t *pnt,
+			      struct rd_vnc_eth *rd_vnc_eth);
 #endif
 
 extern int str2prefix_rd(const char *, struct prefix_rd *);
-extern char *prefix_rd2str(struct prefix_rd *, char *, size_t);
+extern char *prefix_rd2str(const struct prefix_rd *, char *, size_t);
 extern void form_auto_rd(struct in_addr router_id, uint16_t rd_id,
 			 struct prefix_rd *prd);
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -303,7 +303,6 @@ static int bgp_node_set_defer_flag(struct bgp_node *rn, bool delete)
 	struct bgp_table *table = NULL;
 	afi_t afi = 0;
 	safi_t safi = 0;
-	char buf[PREFIX2STR_BUFFER];
 
 	/* If the flag BGP_NODE_SELECT_DEFER is set and new path is added
 	 * then the route selection is deferred
@@ -312,12 +311,11 @@ static int bgp_node_set_defer_flag(struct bgp_node *rn, bool delete)
 		return 0;
 
 	if (CHECK_FLAG(rn->flags, BGP_NODE_PROCESS_SCHEDULED)) {
-		if (BGP_DEBUG(update, UPDATE_OUT)) {
-			prefix2str(&rn->p, buf, PREFIX2STR_BUFFER);
+		if (BGP_DEBUG(update, UPDATE_OUT))
 			zlog_debug(
-				"Route %s is in workqueue and being processed, not deferred.",
-				buf);
-		}
+				"Route %pRN is in workqueue and being processed, not deferred.",
+				rn);
+
 		return 0;
 	}
 
@@ -361,13 +359,12 @@ static int bgp_node_set_defer_flag(struct bgp_node *rn, bool delete)
 	if (set_flag && table) {
 		if (bgp && (bgp->gr_info[afi][safi].t_select_deferral)) {
 			SET_FLAG(rn->flags, BGP_NODE_SELECT_DEFER);
-			prefix2str(&rn->p, buf, PREFIX2STR_BUFFER);
 			if (rn->rt_node == NULL)
 				rn->rt_node = listnode_add(
 					bgp->gr_info[afi][safi].route_list, rn);
 			if (BGP_DEBUG(update, UPDATE_OUT))
-				zlog_debug("DEFER route %s, rn %p, node %p",
-					   buf, rn, rn->rt_node);
+				zlog_debug("DEFER route %pRN, rn %p, node %p",
+					   rn, rn, rn->rt_node);
 			return 0;
 		}
 	}
@@ -594,7 +591,8 @@ static int bgp_path_info_cmp(struct bgp *bgp, struct bgp_path_info *new,
 		 */
 		if (newattr->sticky != existattr->sticky) {
 			if (!debug) {
-				prefix2str(&new->net->p, pfx_buf,
+				prefix2str(bgp_node_get_prefix(new->net),
+					   pfx_buf,
 					   sizeof(*pfx_buf)
 						   * PREFIX2STR_BUFFER);
 				bgp_path_info_path_with_addpath_rx_str(new,
@@ -2100,7 +2098,7 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 	debug = bgp_debug_bestpath(rn);
 
 	if (debug)
-		prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
+		prefix2str(bgp_node_get_prefix(rn), pfx_buf, sizeof(pfx_buf));
 
 	rn->reason = bgp_path_selection_none;
 	/* bgp deterministic-med */
@@ -2320,13 +2318,13 @@ void subgroup_process_announce_selected(struct update_subgroup *subgrp,
 					struct bgp_node *rn,
 					uint32_t addpath_tx_id)
 {
-	struct prefix *p;
+	const struct prefix *p;
 	struct peer *onlypeer;
 	struct attr attr;
 	afi_t afi;
 	safi_t safi;
 
-	p = &rn->p;
+	p = bgp_node_get_prefix(rn);
 	afi = SUBGRP_AFI(subgrp);
 	safi = SUBGRP_SAFI(subgrp);
 	onlypeer = ((SUBGRP_PCOUNT(subgrp) == 1) ? (SUBGRP_PFIRST(subgrp))->peer
@@ -2446,18 +2444,15 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 	struct bgp_path_info *new_select;
 	struct bgp_path_info *old_select;
 	struct bgp_path_info_pair old_and_new;
-	char pfx_buf[PREFIX2STR_BUFFER];
 	int debug = 0;
 
 	if (CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS)) {
 		if (rn)
 			debug = bgp_debug_bestpath(rn);
-		if (debug) {
-			prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
+		if (debug)
 			zlog_debug(
-				"%s: bgp delete in progress, ignoring event, p=%s",
-				__func__, pfx_buf);
-		}
+				"%s: bgp delete in progress, ignoring event, p=%pRN",
+				__func__, rn);
 		return;
 	}
 	/* Is it end of initial update? (after startup) */
@@ -2476,14 +2471,12 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 		return;
 	}
 
-	struct prefix *p = &rn->p;
+	const struct prefix *p = bgp_node_get_prefix(rn);
 
 	debug = bgp_debug_bestpath(rn);
-	if (debug) {
-		prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
-		zlog_debug("%s: p=%s afi=%s, safi=%s start", __func__, pfx_buf,
+	if (debug)
+		zlog_debug("%s: p=%pRN afi=%s, safi=%s start", __func__, rn,
 			   afi2str(afi), safi2str(safi));
-	}
 
 	/* The best path calculation for the route is deferred if
 	 * BGP_NODE_SELECT_DEFER is set
@@ -2540,13 +2533,11 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 		bgp_unregister_for_label(rn);
 	}
 
-	if (debug) {
-		prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
+	if (debug)
 		zlog_debug(
-			"%s: p=%s afi=%s, safi=%s, old_select=%p, new_select=%p",
-			__func__, pfx_buf, afi2str(afi), safi2str(safi),
+			"%s: p=%pRN afi=%s, safi=%s, old_select=%p, new_select=%p",
+			__func__, rn, afi2str(afi), safi2str(safi),
 			old_select, new_select);
-	}
 
 	/* If best route remains the same and this is not due to user-initiated
 	 * clear, see exactly what needs to be done.
@@ -2679,6 +2670,8 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 
 	/* advertise/withdraw type-5 routes */
 	if ((afi == AFI_IP || afi == AFI_IP6) && (safi == SAFI_UNICAST)) {
+		const struct prefix *p = bgp_node_get_prefix(rn);
+
 		if (advertise_type5_routes(bgp, afi) &&
 		    new_select &&
 		    is_route_injectable_into_evpn(new_select)) {
@@ -2702,18 +2695,17 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 
 				ret = route_map_apply(
 					bgp->adv_cmd_rmap[afi][safi].map,
-					&rn->p, RMAP_BGP, &rmap_path);
+					p, RMAP_BGP, &rmap_path);
 				if (ret == RMAP_DENYMATCH) {
 					bgp_attr_flush(&dummy_attr);
 					bgp_evpn_withdraw_type5_route(
-						bgp, &rn->p, afi, safi);
+						bgp, p, afi, safi);
 				} else
 					bgp_evpn_advertise_type5_route(
-						bgp, &rn->p, &dummy_attr,
+						bgp, p, &dummy_attr,
 						afi, safi);
 			} else {
-				bgp_evpn_advertise_type5_route(bgp,
-							       &rn->p,
+				bgp_evpn_advertise_type5_route(bgp, p,
 							       new_select->attr,
 							       afi, safi);
 
@@ -2721,7 +2713,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_node *rn,
 		} else if (advertise_type5_routes(bgp, afi) &&
 			   old_select &&
 			   is_route_injectable_into_evpn(old_select))
-			bgp_evpn_withdraw_type5_route(bgp, &rn->p, afi, safi);
+			bgp_evpn_withdraw_type5_route(bgp, p, afi, safi);
 	}
 
 	/* Clear any route change flags. */
@@ -3048,7 +3040,8 @@ void bgp_rib_remove(struct bgp_node *rn, struct bgp_path_info *pi,
 	struct bgp *bgp = NULL;
 	bool delete_route = false;
 
-	bgp_aggregate_decrement(peer->bgp, &rn->p, pi, afi, safi);
+	bgp_aggregate_decrement(peer->bgp, bgp_node_get_prefix(rn),
+				pi, afi, safi);
 
 	if (!CHECK_FLAG(pi->flags, BGP_PATH_HISTORY)) {
 		bgp_path_info_delete(rn, pi); /* keep historical info */
@@ -3083,6 +3076,8 @@ static void bgp_rib_withdraw(struct bgp_node *rn, struct bgp_path_info *pi,
 			     struct peer *peer, afi_t afi, safi_t safi,
 			     struct prefix_rd *prd)
 {
+	const struct prefix *p = bgp_node_get_prefix(rn);
+
 	/* apply dampening, if result is suppressed, we'll be retaining
 	 * the bgp_path_info in the RIB for historical reference.
 	 */
@@ -3090,7 +3085,7 @@ static void bgp_rib_withdraw(struct bgp_node *rn, struct bgp_path_info *pi,
 	    && peer->sort == BGP_PEER_EBGP)
 		if ((bgp_damp_withdraw(pi, rn, afi, safi, 0))
 		    == BGP_DAMP_SUPPRESSED) {
-			bgp_aggregate_decrement(peer->bgp, &rn->p, pi, afi,
+			bgp_aggregate_decrement(peer->bgp, p, pi, afi,
 						safi);
 			return;
 		}
@@ -3106,23 +3101,22 @@ static void bgp_rib_withdraw(struct bgp_node *rn, struct bgp_path_info *pi,
 			table = bgp_node_get_bgp_table_info(prn);
 
 			vnc_import_bgp_del_vnc_host_route_mode_resolve_nve(
-				peer->bgp, prd, table, &rn->p, pi);
+				peer->bgp, prd, table, p, pi);
 		}
 		bgp_unlock_node(prn);
 	}
 	if ((afi == AFI_IP || afi == AFI_IP6) && (safi == SAFI_UNICAST)) {
 		if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED)) {
 
-			vnc_import_bgp_del_route(peer->bgp, &rn->p, pi);
-			vnc_import_bgp_exterior_del_route(peer->bgp, &rn->p,
-							  pi);
+			vnc_import_bgp_del_route(peer->bgp, p, pi);
+			vnc_import_bgp_exterior_del_route(peer->bgp, p, pi);
 		}
 	}
 #endif
 
 	/* If this is an EVPN route, process for un-import. */
 	if (safi == SAFI_EVPN)
-		bgp_evpn_unimport_route(peer->bgp, afi, safi, &rn->p, pi);
+		bgp_evpn_unimport_route(peer->bgp, afi, safi, p, pi);
 
 	bgp_rib_remove(rn, pi, peer, afi, safi);
 }
@@ -4254,8 +4248,9 @@ static void bgp_soft_reconfig_table(struct peer *peer, afi_t afi, safi_t safi,
 			else
 				memset(&evpn, 0, sizeof(evpn));
 
-			ret = bgp_update(peer, &rn->p, ain->addpath_rx_id,
-					 ain->attr, afi, safi, ZEBRA_ROUTE_BGP,
+			ret = bgp_update(peer, bgp_node_get_prefix(rn),
+					 ain->addpath_rx_id, ain->attr,
+					 afi, safi, ZEBRA_ROUTE_BGP,
 					 BGP_ROUTE_NORMAL, prd, label_pnt,
 					 num_labels, 1, &evpn);
 
@@ -4281,16 +4276,18 @@ void bgp_soft_reconfig_in(struct peer *peer, afi_t afi, safi_t safi)
 		for (rn = bgp_table_top(peer->bgp->rib[afi][safi]); rn;
 		     rn = bgp_route_next(rn)) {
 			table = bgp_node_get_bgp_table_info(rn);
-			if (table != NULL) {
-				struct prefix_rd prd;
 
-				prd.family = AF_UNSPEC;
-				prd.prefixlen = 64;
-				memcpy(&prd.val, rn->p.u.val, 8);
+			if (table == NULL)
+				continue;
 
-				bgp_soft_reconfig_table(peer, afi, safi, table,
-							&prd);
-			}
+			const struct prefix *p = bgp_node_get_prefix(rn);
+			struct prefix_rd prd;
+
+			prd.family = AF_UNSPEC;
+			prd.prefixlen = 64;
+			memcpy(&prd.val, p->u.val, 8);
+
+			bgp_soft_reconfig_table(peer, afi, safi, table, &prd);
 		}
 }
 
@@ -4329,7 +4326,8 @@ static wq_item_status bgp_clear_route_node(struct work_queue *wq, void *data)
 			/* If this is an EVPN route, process for
 			 * un-import. */
 			if (safi == SAFI_EVPN)
-				bgp_evpn_unimport_route(bgp, afi, safi, &rn->p,
+				bgp_evpn_unimport_route(bgp, afi, safi,
+							bgp_node_get_prefix(rn),
 							pi);
 			/* Handle withdraw for VRF route-leaking and L3VPN */
 			if (SAFI_UNICAST == safi
@@ -4645,13 +4643,14 @@ static void bgp_cleanup_table(struct bgp *bgp, struct bgp_table *table,
 
 	for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn))
 		for (pi = bgp_node_get_bgp_path_info(rn); pi; pi = next) {
+			const struct prefix *p = bgp_node_get_prefix(rn);
+
 			next = pi->next;
 
 			/* Unimport EVPN routes from VRFs */
 			if (safi == SAFI_EVPN)
 				bgp_evpn_unimport_route(bgp, AFI_L2VPN,
-							SAFI_EVPN,
-							&rn->p, pi);
+							SAFI_EVPN, p, pi);
 
 			if (CHECK_FLAG(pi->flags, BGP_PATH_SELECTED)
 			    && pi->type == ZEBRA_ROUTE_BGP
@@ -4660,8 +4659,7 @@ static void bgp_cleanup_table(struct bgp *bgp, struct bgp_table *table,
 				|| pi->sub_type == BGP_ROUTE_IMPORTED)) {
 
 				if (bgp_fibupd_safi(safi))
-					bgp_zebra_withdraw(&rn->p, pi, bgp,
-							   safi);
+					bgp_zebra_withdraw(p, pi, bgp, safi);
 				bgp_path_info_reap(rn, pi);
 			}
 		}
@@ -5542,13 +5540,14 @@ void bgp_static_add(struct bgp *bgp)
 					bgp_static =
 						bgp_node_get_bgp_static_info(
 							rm);
-					bgp_static_update_safi(bgp, &rm->p,
+					bgp_static_update_safi(bgp,
+							       bgp_node_get_prefix(rm),
 							       bgp_static, afi,
 							       safi);
 				}
 			} else {
 				bgp_static_update(
-					bgp, &rn->p,
+					bgp, bgp_node_get_prefix(rn),
 					bgp_node_get_bgp_static_info(rn), afi,
 					safi);
 			}
@@ -5585,15 +5584,20 @@ void bgp_static_delete(struct bgp *bgp)
 						continue;
 
 					bgp_static_withdraw_safi(
-						bgp, &rm->p, AFI_IP, safi,
-						(struct prefix_rd *)&rn->p);
+						bgp, bgp_node_get_prefix(rm),
+						AFI_IP, safi,
+						(struct prefix_rd *)
+							bgp_node_get_prefix(
+								rn));
 					bgp_static_free(bgp_static);
 					bgp_node_set_bgp_static_info(rn, NULL);
 					bgp_unlock_node(rn);
 				}
 			} else {
 				bgp_static = bgp_node_get_bgp_static_info(rn);
-				bgp_static_withdraw(bgp, &rn->p, afi, safi);
+				bgp_static_withdraw(bgp,
+						    bgp_node_get_prefix(rn),
+						    afi, safi);
 				bgp_static_free(bgp_static);
 				bgp_node_set_bgp_static_info(rn, NULL);
 				bgp_unlock_node(rn);
@@ -5627,13 +5631,15 @@ void bgp_static_redo_import_check(struct bgp *bgp)
 					bgp_static =
 						bgp_node_get_bgp_static_info(
 							rm);
-					bgp_static_update_safi(bgp, &rm->p,
+					bgp_static_update_safi(bgp,
+							       bgp_node_get_prefix(rm),
 							       bgp_static, afi,
 							       safi);
 				}
 			} else {
 				bgp_static = bgp_node_get_bgp_static_info(rn);
-				bgp_static_update(bgp, &rn->p, bgp_static, afi,
+				bgp_static_update(bgp, bgp_node_get_prefix(rn),
+						  bgp_static, afi,
 						  safi);
 			}
 		}
@@ -5664,8 +5670,9 @@ static void bgp_purge_af_static_redist_routes(struct bgp *bgp, afi_t afi,
 				|| (pi->type != ZEBRA_ROUTE_BGP
 				    && pi->sub_type
 					       == BGP_ROUTE_REDISTRIBUTE))) {
-				bgp_aggregate_decrement(bgp, &rn->p, pi, afi,
-							safi);
+				bgp_aggregate_decrement(bgp,
+							bgp_node_get_prefix(rn),
+							pi, afi, safi);
 				bgp_unlink_nexthop(pi);
 				bgp_path_info_delete(rn, pi);
 				bgp_process(bgp, rn, afi, safi);
@@ -6176,7 +6183,9 @@ void bgp_aggregate_route(struct bgp *bgp, const struct prefix *p, afi_t afi,
 	top = bgp_node_get(table, p);
 	for (rn = bgp_node_get(table, p); rn;
 	     rn = bgp_route_next_until(rn, top)) {
-		if (rn->p.prefixlen <= p->prefixlen)
+		const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
+		if (rn_p->prefixlen <= p->prefixlen)
 			continue;
 
 		match = 0;
@@ -6325,7 +6334,9 @@ void bgp_aggregate_delete(struct bgp *bgp, const struct prefix *p, afi_t afi,
 	top = bgp_node_get(table, p);
 	for (rn = bgp_node_get(table, p); rn;
 	     rn = bgp_route_next_until(rn, top)) {
-		if (rn->p.prefixlen <= p->prefixlen)
+		const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
+		if (rn_p->prefixlen <= p->prefixlen)
 			continue;
 		match = 0;
 
@@ -6636,10 +6647,12 @@ void bgp_aggregate_increment(struct bgp *bgp, const struct prefix *p,
 
 	/* Aggregate address configuration check. */
 	for (rn = child; rn; rn = bgp_node_parent_nolock(rn)) {
+		const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
 		aggregate = bgp_node_get_bgp_aggregate_info(rn);
-		if (aggregate != NULL && rn->p.prefixlen < p->prefixlen) {
-			bgp_add_route_to_aggregate(bgp, &rn->p, pi, afi,
-						   safi, aggregate);
+		if (aggregate != NULL && rn_p->prefixlen < p->prefixlen) {
+			bgp_add_route_to_aggregate(bgp, rn_p, pi, afi, safi,
+						   aggregate);
 		}
 	}
 	bgp_unlock_node(child);
@@ -6666,10 +6679,12 @@ void bgp_aggregate_decrement(struct bgp *bgp, const struct prefix *p,
 
 	/* Aggregate address configuration check. */
 	for (rn = child; rn; rn = bgp_node_parent_nolock(rn)) {
+		const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
 		aggregate = bgp_node_get_bgp_aggregate_info(rn);
-		if (aggregate != NULL && rn->p.prefixlen < p->prefixlen) {
-			bgp_remove_route_from_aggregate(bgp, afi, safi,
-							del, aggregate, &rn->p);
+		if (aggregate != NULL && rn_p->prefixlen < p->prefixlen) {
+			bgp_remove_route_from_aggregate(bgp, afi, safi, del,
+							aggregate, rn_p);
 		}
 	}
 	bgp_unlock_node(child);
@@ -7332,8 +7347,8 @@ void bgp_redistribute_withdraw(struct bgp *bgp, afi_t afi, int type,
 				vpn_leak_from_vrf_withdraw(bgp_get_default(),
 							   bgp, pi);
 			}
-			bgp_aggregate_decrement(bgp, &rn->p, pi, afi,
-						SAFI_UNICAST);
+			bgp_aggregate_decrement(bgp, bgp_node_get_prefix(rn),
+						pi, afi, SAFI_UNICAST);
 			bgp_path_info_delete(rn, pi);
 			bgp_process(bgp, rn, afi, SAFI_UNICAST);
 		}
@@ -8643,8 +8658,10 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 		}
 		if (safi == SAFI_EVPN) {
 			if (!json_paths) {
-				bgp_evpn_route2str((struct prefix_evpn *)&bn->p,
-						   buf2, sizeof(buf2));
+				bgp_evpn_route2str(
+					(struct prefix_evpn *)
+						bgp_node_get_prefix(bn),
+					buf2, sizeof(buf2));
 				vty_out(vty, "  Route %s", buf2);
 				if (tag_buf[0] != '\0')
 					vty_out(vty, " VNI %s", tag_buf);
@@ -8664,11 +8681,14 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 			rn = parent_ri->net;
 			if (rn && rn->prn) {
 				prn = rn->prn;
-				prefix_rd2str((struct prefix_rd *)&prn->p,
+				prefix_rd2str((struct prefix_rd *)
+						      bgp_node_get_prefix(prn),
 					      buf1, sizeof(buf1));
 				if (is_pi_family_evpn(parent_ri)) {
-					bgp_evpn_route2str((struct prefix_evpn *)&rn->p,
-							   buf2, sizeof(buf2));
+					bgp_evpn_route2str(
+						(struct prefix_evpn *)
+							bgp_node_get_prefix(rn),
+						buf2, sizeof(buf2));
 					vty_out(vty, "  Imported from %s:%s, VNI %s\n", buf1, buf2, tag_buf);
 				} else
 					vty_out(vty, "  Imported from %s:%s\n", buf1, buf2);
@@ -8757,8 +8777,10 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 
 	/* Line2 display Next-hop, Neighbor, Router-id */
 	/* Display the nexthop */
-	if ((bn->p.family == AF_INET || bn->p.family == AF_ETHERNET
-	     || bn->p.family == AF_EVPN)
+	const struct prefix *bn_p = bgp_node_get_prefix(bn);
+
+	if ((bn_p->family == AF_INET || bn_p->family == AF_ETHERNET
+	     || bn_p->family == AF_EVPN)
 	    && (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP || safi == SAFI_EVPN
 		|| !BGP_ATTR_NEXTHOP_AFI_IP6(attr))) {
 		if (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP
@@ -8859,7 +8881,7 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 	if (path->peer == bgp->peer_self) {
 
 		if (safi == SAFI_EVPN
-		    || (bn->p.family == AF_INET
+		    || (bn_p->family == AF_INET
 			&& !BGP_ATTR_NEXTHOP_AFI_IP6(attr))) {
 			if (json_paths)
 				json_object_string_add(json_peer, "peerId",
@@ -9529,6 +9551,8 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 
 	/* Start processing of routes. */
 	for (rn = bgp_table_top(table); rn; rn = bgp_route_next(rn)) {
+		const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
 		pi = bgp_node_get_bgp_path_info(rn);
 		if (pi == NULL)
 			continue;
@@ -9558,7 +9582,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 			if (type == bgp_show_type_prefix_list) {
 				struct prefix_list *plist = output_arg;
 
-				if (prefix_list_apply(plist, &rn->p)
+				if (prefix_list_apply(plist, rn_p)
 				    != PREFIX_PERMIT)
 					continue;
 			}
@@ -9580,7 +9604,7 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 				path.peer = pi->peer;
 				path.attr = &dummy_attr;
 
-				ret = route_map_apply(rmap, &rn->p, RMAP_BGP,
+				ret = route_map_apply(rmap, rn_p, RMAP_BGP,
 						      &path);
 				if (ret == RMAP_DENYMATCH)
 					continue;
@@ -9598,20 +9622,20 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 			if (type == bgp_show_type_cidr_only) {
 				uint32_t destination;
 
-				destination = ntohl(rn->p.u.prefix4.s_addr);
+				destination = ntohl(rn_p->u.prefix4.s_addr);
 				if (IN_CLASSC(destination)
-				    && rn->p.prefixlen == 24)
+				    && rn_p->prefixlen == 24)
 					continue;
 				if (IN_CLASSB(destination)
-				    && rn->p.prefixlen == 16)
+				    && rn_p->prefixlen == 16)
 					continue;
 				if (IN_CLASSA(destination)
-				    && rn->p.prefixlen == 8)
+				    && rn_p->prefixlen == 8)
 					continue;
 			}
 			if (type == bgp_show_type_prefix_longer) {
 				p = output_arg;
-				if (!prefix_match(p, &rn->p))
+				if (!prefix_match(p, rn_p))
 					continue;
 			}
 			if (type == bgp_show_type_community_all) {
@@ -9724,14 +9748,16 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 			}
 			if (type == bgp_show_type_dampend_paths
 			    || type == bgp_show_type_damp_neighbor)
-				damp_route_vty_out(vty, &rn->p, pi, display, AFI_IP,
-						   safi, use_json, json_paths);
+				damp_route_vty_out(vty, rn_p, pi, display,
+						   AFI_IP, safi, use_json,
+						   json_paths);
 			else if (type == bgp_show_type_flap_statistics
 				 || type == bgp_show_type_flap_neighbor)
-				flap_route_vty_out(vty, &rn->p, pi, display, AFI_IP,
-						   safi, use_json, json_paths);
+				flap_route_vty_out(vty, rn_p, pi, display,
+						   AFI_IP, safi, use_json,
+						   json_paths);
 			else
-				route_vty_out(vty, &rn->p, pi, display, safi,
+				route_vty_out(vty, rn_p, pi, display, safi,
 					      json_paths);
 			display++;
 		}
@@ -9741,28 +9767,25 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 			if (!use_json)
 				continue;
 
-			p = &rn->p;
 			/* encode prefix */
-			if (p->family == AF_FLOWSPEC) {
+			if (rn_p->family == AF_FLOWSPEC) {
 				char retstr[BGP_FLOWSPEC_STRING_DISPLAY_MAX];
 
-				bgp_fs_nlri_get_string((unsigned char *)
-						       p->u.prefix_flowspec.ptr,
-						       p->u.prefix_flowspec
-						       .prefixlen,
-						       retstr,
-						       NLRI_STRING_FORMAT_MIN,
-						       NULL);
+				bgp_fs_nlri_get_string(
+					(unsigned char *)
+						rn_p->u.prefix_flowspec.ptr,
+					rn_p->u.prefix_flowspec.prefixlen,
+					retstr, NLRI_STRING_FORMAT_MIN, NULL);
 				if (first)
-					vty_out(vty, "\"%s/%d\": ",
-						retstr,
-						p->u.prefix_flowspec.prefixlen);
+					vty_out(vty, "\"%s/%d\": ", retstr,
+						rn_p->u.prefix_flowspec
+							.prefixlen);
 				else
-					vty_out(vty, ",\"%s/%d\": ",
-						retstr,
-						p->u.prefix_flowspec.prefixlen);
+					vty_out(vty, ",\"%s/%d\": ", retstr,
+						rn_p->u.prefix_flowspec
+							.prefixlen);
 			} else {
-				prefix2str(p, buf2, sizeof(buf2));
+				prefix2str(rn_p, buf2, sizeof(buf2));
 				if (first)
 					vty_out(vty, "\"%s\": ", buf2);
 				else
@@ -9828,8 +9851,10 @@ int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, safi_t safi,
 	show_msg = (!use_json && type == bgp_show_type_normal);
 
 	for (rn = bgp_table_top(table); rn; rn = next) {
+		const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
 		next = bgp_route_next(rn);
-		if (prd_match && memcmp(rn->p.u.val, prd_match->val, 8) != 0)
+		if (prd_match && memcmp(rn_p->u.val, prd_match->val, 8) != 0)
 			continue;
 
 		itable = bgp_node_get_bgp_table_info(rn);
@@ -9837,7 +9862,7 @@ int bgp_show_table_rd(struct vty *vty, struct bgp *bgp, safi_t safi,
 			struct prefix_rd prd;
 			char rd[RD_ADDRSTRLEN];
 
-			memcpy(&prd, &(rn->p), sizeof(struct prefix_rd));
+			memcpy(&prd, rn_p, sizeof(struct prefix_rd));
 			prefix_rd2str(&prd, rd, sizeof(rd));
 			bgp_show_table(vty, bgp, safi, itable, type, output_arg,
 				       use_json, rd, next == NULL, &output_cum,
@@ -9940,7 +9965,7 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 				 afi_t afi, safi_t safi, json_object *json)
 {
 	struct bgp_path_info *pi;
-	struct prefix *p;
+	const struct prefix *p;
 	struct peer *peer;
 	struct listnode *node, *nnode;
 	char buf1[RD_ADDRSTRLEN];
@@ -9968,7 +9993,7 @@ void route_vty_out_detail_header(struct vty *vty, struct bgp *bgp,
 	mpls_label_t label = 0;
 	json_object *json_adv_to = NULL;
 
-	p = &rn->p;
+	p = bgp_node_get_prefix(rn);
 	has_valid_label = bgp_is_valid_label(&rn->local_label);
 
 	if (has_valid_label)
@@ -10228,7 +10253,9 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 
 	if (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP) {
 		for (rn = bgp_table_top(rib); rn; rn = bgp_route_next(rn)) {
-			if (prd && memcmp(rn->p.u.val, prd->val, 8) != 0)
+			const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
+			if (prd && memcmp(rn_p->u.val, prd->val, 8) != 0)
 				continue;
 			table = bgp_node_get_bgp_table_info(rn);
 			if (!table)
@@ -10237,15 +10264,16 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 			if ((rm = bgp_node_match(table, &match)) == NULL)
 				continue;
 
+			const struct prefix *rm_p = bgp_node_get_prefix(rm);
 			if (prefix_check
-			    && rm->p.prefixlen != match.prefixlen) {
+			    && rm_p->prefixlen != match.prefixlen) {
 				bgp_unlock_node(rm);
 				continue;
 			}
 
-			bgp_show_path_info((struct prefix_rd *)&rn->p, rm,
-					   vty, bgp, afi, safi, json,
-					   pathtype, &display);
+			bgp_show_path_info((struct prefix_rd *)rn_p, rm, vty,
+					   bgp, afi, safi, json, pathtype,
+					   &display);
 
 			bgp_unlock_node(rm);
 		}
@@ -10254,7 +10282,9 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 		bool is_exact_pfxlen_match = FALSE;
 
 		for (rn = bgp_table_top(rib); rn; rn = bgp_route_next(rn)) {
-			if (prd && memcmp(rn->p.u.val, prd->val, 8) != 0)
+			const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
+			if (prd && memcmp(&rn_p->u.val, prd->val, 8) != 0)
 				continue;
 			table = bgp_node_get_bgp_table_info(rn);
 			if (!table)
@@ -10270,15 +10300,18 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 			 */
 			for (rm = bgp_table_top(table); rm;
 				rm = bgp_route_next(rm)) {
+				const struct prefix *rm_p =
+					bgp_node_get_prefix(rm);
 				/*
 				 * Get prefixlen of the ip-prefix within type5
 				 * evpn route
 				 */
-				if (evpn_type5_prefix_match(&rm->p,
-					&match) && rm->info) {
+				if (evpn_type5_prefix_match(rm_p, &match)
+				    && rm->info) {
 					longest_pfx = rm;
 					int type5_pfxlen =
-					   bgp_evpn_get_type5_prefixlen(&rm->p);
+						bgp_evpn_get_type5_prefixlen(
+							rm_p);
 					if (type5_pfxlen == match.prefixlen) {
 						is_exact_pfxlen_match = TRUE;
 						bgp_unlock_node(rm);
@@ -10296,9 +10329,9 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 			rm = longest_pfx;
 			bgp_lock_node(rm);
 
-			bgp_show_path_info((struct prefix_rd *)&rn->p, rm,
-					   vty, bgp, afi, safi, json,
-					   pathtype, &display);
+			bgp_show_path_info((struct prefix_rd *)rn_p, rm, vty,
+					   bgp, afi, safi, json, pathtype,
+					   &display);
 
 			bgp_unlock_node(rm);
 		}
@@ -10315,8 +10348,9 @@ static int bgp_show_route_in_table(struct vty *vty, struct bgp *bgp,
 			json_object_object_add(json, "paths", json_paths);
 	} else {
 		if ((rn = bgp_node_match(rib, &match)) != NULL) {
+			const struct prefix *rn_p = bgp_node_get_prefix(rn);
 			if (!prefix_check
-			    || rn->p.prefixlen == match.prefixlen) {
+			    || rn_p->prefixlen == match.prefixlen) {
 				bgp_show_path_info(NULL, rn, vty, bgp, afi,
 						   safi, json,
 						   pathtype, &display);
@@ -11027,6 +11061,7 @@ static void bgp_table_stats_rn(struct bgp_node *rn, struct bgp_node *top,
 {
 	struct bgp_node *prn = bgp_node_parent_nolock(rn);
 	struct bgp_path_info *pi;
+	const struct prefix *rn_p;
 
 	if (rn == top)
 		return;
@@ -11034,14 +11069,15 @@ static void bgp_table_stats_rn(struct bgp_node *rn, struct bgp_node *top,
 	if (!bgp_node_has_bgp_path_info_data(rn))
 		return;
 
+	rn_p = bgp_node_get_prefix(rn);
 	ts->counts[BGP_STATS_PREFIXES]++;
-	ts->counts[BGP_STATS_TOTPLEN] += rn->p.prefixlen;
+	ts->counts[BGP_STATS_TOTPLEN] += rn_p->prefixlen;
 
 #if 0
       ts->counts[BGP_STATS_AVGPLEN]
         = ravg_tally (ts->counts[BGP_STATS_PREFIXES],
                       ts->counts[BGP_STATS_AVGPLEN],
-                      rn->p.prefixlen);
+                      rn_p->prefixlen);
 #endif
 
 	/* check if the prefix is included by any other announcements */
@@ -11052,7 +11088,7 @@ static void bgp_table_stats_rn(struct bgp_node *rn, struct bgp_node *top,
 		ts->counts[BGP_STATS_UNAGGREGATEABLE]++;
 		/* announced address space */
 		if (space)
-			ts->total_space += pow(2.0, space - rn->p.prefixlen);
+			ts->total_space += pow(2.0, space - rn_p->prefixlen);
 	} else if (bgp_node_has_bgp_path_info_data(prn))
 		ts->counts[BGP_STATS_MAX_AGGREGATEABLE]++;
 
@@ -11724,14 +11760,17 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 				/* Filter prefix using distribute list,
 				 * filter list or prefix list
 				 */
-				if ((bgp_input_filter(peer, &rn->p, &attr, afi,
-						safi)) == FILTER_DENY)
+				const struct prefix *rn_p =
+					bgp_node_get_prefix(rn);
+				if ((bgp_input_filter(peer, rn_p, &attr, afi,
+						      safi))
+				    == FILTER_DENY)
 					route_filtered = true;
 
 				/* Filter prefix using route-map */
-				ret = bgp_input_modifier(peer, &rn->p, &attr,
-						afi, safi, rmap_name, NULL, 0,
-						NULL);
+				ret = bgp_input_modifier(peer, rn_p, &attr, afi,
+							 safi, rmap_name, NULL,
+							 0, NULL);
 
 				if (type == bgp_show_adj_route_filtered &&
 					!route_filtered && ret != RMAP_DENY) {
@@ -11743,7 +11782,7 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 					(route_filtered || ret == RMAP_DENY))
 					filtered_count++;
 
-				route_vty_out_tmp(vty, &rn->p, &attr, safi,
+				route_vty_out_tmp(vty, rn_p, &attr, safi,
 						  use_json, json_ar);
 				bgp_attr_undup(&attr, ain->attr);
 				output_count++;
@@ -11820,16 +11859,18 @@ static void show_adj_route(struct vty *vty, struct peer *peer, afi_t afi,
 						header2 = 0;
 					}
 
+					const struct prefix *rn_p =
+						bgp_node_get_prefix(rn);
+
 					attr = *adj->attr;
 					ret = bgp_output_modifier(
-						peer, &rn->p, &attr, afi, safi,
+						peer, rn_p, &attr, afi, safi,
 						rmap_name);
 
 					if (ret != RMAP_DENY) {
-						route_vty_out_tmp(vty, &rn->p,
-								  &attr, safi,
-								  use_json,
-								  json_ar);
+						route_vty_out_tmp(
+							vty, rn_p, &attr, safi,
+							use_json, json_ar);
 						output_count++;
 					} else {
 						filtered_count++;
@@ -12659,7 +12700,9 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 	    || (safi == SAFI_EVPN)) {
 		for (rn = bgp_table_top(bgp->rib[AFI_IP][safi]); rn;
 		     rn = bgp_route_next(rn)) {
-			if (prd && memcmp(rn->p.u.val, prd->val, 8) != 0)
+			const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
+			if (prd && memcmp(rn_p->u.val, prd->val, 8) != 0)
 				continue;
 			table = bgp_node_get_bgp_table_info(rn);
 			if (!table)
@@ -12667,8 +12710,10 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 			if ((rm = bgp_node_match(table, &match)) == NULL)
 				continue;
 
+			const struct prefix *rm_p = bgp_node_get_prefix(rn);
+
 			if (!prefix_check
-			    || rm->p.prefixlen == match.prefixlen) {
+			    || rm_p->prefixlen == match.prefixlen) {
 				pi = bgp_node_get_bgp_path_info(rm);
 				while (pi) {
 					if (pi->extra && pi->extra->damp_info) {
@@ -12687,8 +12732,10 @@ static int bgp_clear_damp_route(struct vty *vty, const char *view_name,
 	} else {
 		if ((rn = bgp_node_match(bgp->rib[afi][safi], &match))
 		    != NULL) {
+			const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
 			if (!prefix_check
-			    || rn->p.prefixlen == match.prefixlen) {
+			    || rn_p->prefixlen == match.prefixlen) {
 				pi = bgp_node_get_bgp_path_info(rn);
 				while (pi) {
 					if (pi->extra && pi->extra->damp_info) {
@@ -12824,8 +12871,8 @@ static void bgp_config_write_network_vpn(struct vty *vty, struct bgp *bgp,
 	struct bgp_node *prn;
 	struct bgp_node *rn;
 	struct bgp_table *table;
-	struct prefix *p;
-	struct prefix_rd *prd;
+	const struct prefix *p;
+	const struct prefix_rd *prd;
 	struct bgp_static *bgp_static;
 	mpls_label_t label;
 	char buf[SU_ADDRSTRLEN];
@@ -12843,8 +12890,9 @@ static void bgp_config_write_network_vpn(struct vty *vty, struct bgp *bgp,
 			if (bgp_static == NULL)
 				continue;
 
-			p = &rn->p;
-			prd = (struct prefix_rd *)&prn->p;
+			p = bgp_node_get_prefix(rn);
+			prd = (const struct prefix_rd *)bgp_node_get_prefix(
+				prn);
 
 			/* "network" configuration display.  */
 			prefix_rd2str(prd, rdbuf, sizeof(rdbuf));
@@ -12875,8 +12923,8 @@ static void bgp_config_write_network_evpn(struct vty *vty, struct bgp *bgp,
 	struct bgp_node *prn;
 	struct bgp_node *rn;
 	struct bgp_table *table;
-	struct prefix *p;
-	struct prefix_rd *prd;
+	const struct prefix *p;
+	const struct prefix_rd *prd;
 	struct bgp_static *bgp_static;
 	char buf[PREFIX_STRLEN * 2];
 	char buf2[SU_ADDRSTRLEN];
@@ -12902,8 +12950,8 @@ static void bgp_config_write_network_evpn(struct vty *vty, struct bgp *bgp,
 					bgp_static->router_mac, NULL, 0);
 			if (bgp_static->eth_s_id)
 				esi = esi2str(bgp_static->eth_s_id);
-			p = &rn->p;
-			prd = (struct prefix_rd *)&prn->p;
+			p = bgp_node_get_prefix(rn);
+			prd = (struct prefix_rd *)bgp_node_get_prefix(prn);
 
 			/* "network" configuration display.  */
 			prefix_rd2str(prd, rdbuf, sizeof(rdbuf));
@@ -12946,7 +12994,7 @@ void bgp_config_write_network(struct vty *vty, struct bgp *bgp, afi_t afi,
 			      safi_t safi)
 {
 	struct bgp_node *rn;
-	struct prefix *p;
+	const struct prefix *p;
 	struct bgp_static *bgp_static;
 	struct bgp_aggregate *bgp_aggregate;
 	char buf[SU_ADDRSTRLEN];
@@ -12968,7 +13016,7 @@ void bgp_config_write_network(struct vty *vty, struct bgp *bgp, afi_t afi,
 		if (bgp_static == NULL)
 			continue;
 
-		p = &rn->p;
+		p = bgp_node_get_prefix(rn);
 
 		vty_out(vty, "  network %s/%d",
 			inet_ntop(p->family, &p->u.prefix, buf, SU_ADDRSTRLEN),
@@ -12994,7 +13042,7 @@ void bgp_config_write_network(struct vty *vty, struct bgp *bgp, afi_t afi,
 		if (bgp_aggregate == NULL)
 			continue;
 
-		p = &rn->p;
+		p = bgp_node_get_prefix(rn);
 
 		vty_out(vty, "  aggregate-address %s/%d",
 			inet_ntop(p->family, &p->u.prefix, buf, SU_ADDRSTRLEN),
@@ -13039,15 +13087,11 @@ void bgp_config_write_distance(struct vty *vty, struct bgp *bgp, afi_t afi,
 	for (rn = bgp_table_top(bgp_distance_table[afi][safi]); rn;
 	     rn = bgp_route_next(rn)) {
 		bdistance = bgp_node_get_bgp_distance_info(rn);
-		if (bdistance != NULL) {
-			char buf[PREFIX_STRLEN];
-
-			vty_out(vty, "  distance %d %s %s\n",
-				bdistance->distance,
-				prefix2str(&rn->p, buf, sizeof(buf)),
+		if (bdistance != NULL)
+			vty_out(vty, "  distance %d %pRN %s\n",
+				bdistance->distance, rn,
 				bdistance->access_list ? bdistance->access_list
 						       : "");
-		}
 	}
 }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1381,7 +1381,7 @@ static int bgp_input_modifier(struct peer *peer, const struct prefix *p,
 	return RMAP_PERMIT;
 }
 
-static int bgp_output_modifier(struct peer *peer, struct prefix *p,
+static int bgp_output_modifier(struct peer *peer, const struct prefix *p,
 			       struct attr *attr, afi_t afi, safi_t safi,
 			       const char *rmap_name)
 {
@@ -4910,7 +4910,7 @@ static void bgp_static_free(struct bgp_static *bgp_static)
 	XFREE(MTYPE_BGP_STATIC, bgp_static);
 }
 
-void bgp_static_update(struct bgp *bgp, struct prefix *p,
+void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 		       struct bgp_static *bgp_static, afi_t afi, safi_t safi)
 {
 	struct bgp_node *rn;
@@ -5139,7 +5139,7 @@ void bgp_static_update(struct bgp *bgp, struct prefix *p,
 	aspath_unintern(&attr.aspath);
 }
 
-void bgp_static_withdraw(struct bgp *bgp, struct prefix *p, afi_t afi,
+void bgp_static_withdraw(struct bgp *bgp, const struct prefix *p, afi_t afi,
 			 safi_t safi)
 {
 	struct bgp_node *rn;
@@ -5173,7 +5173,7 @@ void bgp_static_withdraw(struct bgp *bgp, struct prefix *p, afi_t afi,
 /*
  * Used for SAFI_MPLS_VPN and SAFI_ENCAP
  */
-static void bgp_static_withdraw_safi(struct bgp *bgp, struct prefix *p,
+static void bgp_static_withdraw_safi(struct bgp *bgp, const struct prefix *p,
 				     afi_t afi, safi_t safi,
 				     struct prefix_rd *prd)
 {
@@ -5208,7 +5208,7 @@ static void bgp_static_withdraw_safi(struct bgp *bgp, struct prefix *p,
 	bgp_unlock_node(rn);
 }
 
-static void bgp_static_update_safi(struct bgp *bgp, struct prefix *p,
+static void bgp_static_update_safi(struct bgp *bgp, const struct prefix *p,
 				   struct bgp_static *bgp_static, afi_t afi,
 				   safi_t safi)
 {
@@ -6058,14 +6058,11 @@ static bool bgp_aggregate_info_same(struct bgp_path_info *pi, uint8_t origin,
 	return true;
 }
 
-static void bgp_aggregate_install(struct bgp *bgp, afi_t afi, safi_t safi,
-				  struct prefix *p, uint8_t origin,
-				  struct aspath *aspath,
-				  struct community *community,
-				  struct ecommunity *ecommunity,
-				  struct lcommunity *lcommunity,
-				  uint8_t atomic_aggregate,
-				  struct bgp_aggregate *aggregate)
+static void bgp_aggregate_install(
+	struct bgp *bgp, afi_t afi, safi_t safi, const struct prefix *p,
+	uint8_t origin, struct aspath *aspath, struct community *community,
+	struct ecommunity *ecommunity, struct lcommunity *lcommunity,
+	uint8_t atomic_aggregate, struct bgp_aggregate *aggregate)
 {
 	struct bgp_node *rn;
 	struct bgp_table *table;
@@ -6142,9 +6139,8 @@ static void bgp_aggregate_install(struct bgp *bgp, afi_t afi, safi_t safi,
 }
 
 /* Update an aggregate as routes are added/removed from the BGP table */
-void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
-				afi_t afi, safi_t safi,
-				struct bgp_aggregate *aggregate)
+void bgp_aggregate_route(struct bgp *bgp, const struct prefix *p, afi_t afi,
+			 safi_t safi, struct bgp_aggregate *aggregate)
 {
 	struct bgp_table *table;
 	struct bgp_node *top;
@@ -6314,8 +6310,8 @@ void bgp_aggregate_route(struct bgp *bgp, struct prefix *p,
 			      aggregate);
 }
 
-void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
-				 safi_t safi, struct bgp_aggregate *aggregate)
+void bgp_aggregate_delete(struct bgp *bgp, const struct prefix *p, afi_t afi,
+			  safi_t safi, struct bgp_aggregate *aggregate)
 {
 	struct bgp_table *table;
 	struct bgp_node *top;
@@ -6405,7 +6401,8 @@ void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
 	bgp_unlock_node(top);
 }
 
-static void bgp_add_route_to_aggregate(struct bgp *bgp, struct prefix *aggr_p,
+static void bgp_add_route_to_aggregate(struct bgp *bgp,
+				       const struct prefix *aggr_p,
 				       struct bgp_path_info *pinew, afi_t afi,
 				       safi_t safi,
 				       struct bgp_aggregate *aggregate)
@@ -6511,7 +6508,7 @@ static void bgp_remove_route_from_aggregate(struct bgp *bgp, afi_t afi,
 					    safi_t safi,
 					    struct bgp_path_info *pi,
 					    struct bgp_aggregate *aggregate,
-					    struct prefix *aggr_p)
+					    const struct prefix *aggr_p)
 {
 	uint8_t origin;
 	struct aspath *aspath = NULL;
@@ -7934,8 +7931,9 @@ void route_vty_out(struct vty *vty, const struct prefix *p,
 }
 
 /* called from terminal list command */
-void route_vty_out_tmp(struct vty *vty, struct prefix *p, struct attr *attr,
-		       safi_t safi, bool use_json, json_object *json_ar)
+void route_vty_out_tmp(struct vty *vty, const struct prefix *p,
+		       struct attr *attr, safi_t safi, bool use_json,
+		       json_object *json_ar)
 {
 	json_object *json_status = NULL;
 	json_object *json_net = NULL;
@@ -8314,9 +8312,10 @@ void route_vty_out_overlay(struct vty *vty, const struct prefix *p,
 }
 
 /* dampening route */
-static void damp_route_vty_out(struct vty *vty, struct prefix *p,
-			       struct bgp_path_info *path, int display, afi_t afi,
-			       safi_t safi, bool use_json, json_object *json)
+static void damp_route_vty_out(struct vty *vty, const struct prefix *p,
+			       struct bgp_path_info *path, int display,
+			       afi_t afi, safi_t safi, bool use_json,
+			       json_object *json)
 {
 	struct attr *attr;
 	int len;
@@ -8378,9 +8377,10 @@ static void damp_route_vty_out(struct vty *vty, struct prefix *p,
 }
 
 /* flap route */
-static void flap_route_vty_out(struct vty *vty, struct prefix *p,
-			       struct bgp_path_info *path, int display, afi_t afi,
-			       safi_t safi, bool use_json, json_object *json)
+static void flap_route_vty_out(struct vty *vty, const struct prefix *p,
+			       struct bgp_path_info *path, int display,
+			       afi_t afi, safi_t safi, bool use_json,
+			       json_object *json)
 {
 	struct attr *attr;
 	struct bgp_damp_info *bdi;

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -544,9 +544,10 @@ extern void bgp_static_add(struct bgp *);
 extern void bgp_static_delete(struct bgp *);
 extern void bgp_static_redo_import_check(struct bgp *);
 extern void bgp_purge_static_redist_routes(struct bgp *bgp);
-extern void bgp_static_update(struct bgp *, struct prefix *,
-			      struct bgp_static *, afi_t, safi_t);
-extern void bgp_static_withdraw(struct bgp *, struct prefix *, afi_t, safi_t);
+extern void bgp_static_update(struct bgp *bgp, const struct prefix *p,
+			      struct bgp_static *s, afi_t afi, safi_t safi);
+extern void bgp_static_withdraw(struct bgp *bgp, const struct prefix *p,
+				afi_t afi, safi_t safi);
 
 extern int bgp_static_set_safi(afi_t afi, safi_t safi, struct vty *vty,
 			       const char *, const char *, const char *,
@@ -584,10 +585,12 @@ extern void bgp_config_write_network(struct vty *, struct bgp *, afi_t, safi_t);
 extern void bgp_config_write_distance(struct vty *, struct bgp *, afi_t,
 				      safi_t);
 
-extern void bgp_aggregate_delete(struct bgp *bgp, struct prefix *p, afi_t afi,
-				 safi_t safi, struct bgp_aggregate *aggregate);
-extern void bgp_aggregate_route(struct bgp *bgp, struct prefix *p, afi_t afi,
-				safi_t safi, struct bgp_aggregate *aggregate);
+extern void bgp_aggregate_delete(struct bgp *bgp, const struct prefix *p,
+				 afi_t afi, safi_t safi,
+				 struct bgp_aggregate *aggregate);
+extern void bgp_aggregate_route(struct bgp *bgp, const struct prefix *p,
+				afi_t afi, safi_t safi,
+				struct bgp_aggregate *aggregate);
 extern void bgp_aggregate_increment(struct bgp *bgp, const struct prefix *p,
 				    struct bgp_path_info *path, afi_t afi,
 				    safi_t safi);
@@ -613,7 +616,7 @@ extern void route_vty_out(struct vty *vty, const struct prefix *p,
 extern void route_vty_out_tag(struct vty *vty, const struct prefix *p,
 			      struct bgp_path_info *path, int display,
 			      safi_t safi, json_object *json);
-extern void route_vty_out_tmp(struct vty *vty, struct prefix *p,
+extern void route_vty_out_tmp(struct vty *vty, const struct prefix *p,
 			      struct attr *attr, safi_t safi, bool use_json,
 			      json_object *json_ar);
 extern void route_vty_out_overlay(struct vty *vty, const struct prefix *p,

--- a/bgpd/bgp_rpki.c
+++ b/bgpd/bgp_rpki.c
@@ -438,10 +438,10 @@ static void revalidate_bgp_node(struct bgp_node *bgp_node, afi_t afi,
 			label = path->extra->label;
 			num_labels = path->extra->num_labels;
 		}
-		ret = bgp_update(ain->peer, &bgp_node->p, ain->addpath_rx_id,
-				 ain->attr, afi, safi, ZEBRA_ROUTE_BGP,
-				 BGP_ROUTE_NORMAL, NULL, label, num_labels, 1,
-				 NULL);
+		ret = bgp_update(ain->peer, bgp_node_get_prefix(bgp_node),
+				 ain->addpath_rx_id, ain->attr, afi, safi,
+				 ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, NULL, label,
+				 num_labels, 1, NULL);
 
 		if (ret < 0)
 			return;

--- a/bgpd/bgp_snmp.c
+++ b/bgpd/bgp_snmp.c
@@ -761,20 +761,23 @@ static struct bgp_path_info *bgp4PathAttrLookup(struct variable *v, oid name[],
 			}
 
 			if (min) {
+				const struct prefix *rn_p =
+					bgp_node_get_prefix(rn);
+
 				*length =
 					v->namelen + BGP_PATHATTR_ENTRY_OFFSET;
 
 				offset = name + v->namelen;
-				oid_copy_addr(offset, &rn->p.u.prefix4,
+				oid_copy_addr(offset, &rn_p->u.prefix4,
 					      IN_ADDR_SIZE);
 				offset += IN_ADDR_SIZE;
-				*offset = rn->p.prefixlen;
+				*offset = rn_p->prefixlen;
 				offset++;
 				oid_copy_addr(offset,
 					      &min->peer->su.sin.sin_addr,
 					      IN_ADDR_SIZE);
-				addr->prefix = rn->p.u.prefix4;
-				addr->prefixlen = rn->p.prefixlen;
+				addr->prefix = rn_p->u.prefix4;
+				addr->prefixlen = rn_p->prefixlen;
 
 				bgp_unlock_node(rn);
 

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -168,13 +168,22 @@ static struct bgp_node *
 bgp_route_next_until_maxlen(struct bgp_node *node, const struct bgp_node *limit,
 			    const uint8_t maxlen)
 {
-	if (node->l_left && node->p.prefixlen < maxlen
-	    && node->l_left->p.prefixlen <= maxlen) {
-		return bgp_node_from_rnode(node->l_left);
+	const struct prefix *p = bgp_node_get_prefix(node);
+
+	if (node->l_left) {
+		const struct prefix *left_p =
+			bgp_node_get_prefix(bgp_node_from_rnode(node->l_left));
+
+		if (p->prefixlen < maxlen && left_p->prefixlen <= maxlen)
+			return bgp_node_from_rnode(node->l_left);
 	}
-	if (node->l_right && node->p.prefixlen < maxlen
-	    && node->l_right->p.prefixlen <= maxlen) {
-		return bgp_node_from_rnode(node->l_right);
+
+	if (node->l_right) {
+		const struct prefix *right_p =
+			bgp_node_get_prefix(bgp_node_from_rnode(node->l_right));
+
+		if (p->prefixlen < maxlen && right_p->prefixlen <= maxlen)
+			return bgp_node_from_rnode(node->l_right);
 	}
 
 	while (node->parent && node != limit) {
@@ -197,24 +206,29 @@ void bgp_table_range_lookup(const struct bgp_table *table,
 	if (node == NULL)
 		return;
 
-	while (node &&
-	       node->p.prefixlen <= p->prefixlen && prefix_match(&node->p, p)) {
+	const struct prefix *node_p = bgp_node_get_prefix(node);
+
+	while (node && node_p->prefixlen <= p->prefixlen
+	       && prefix_match(node_p, p)) {
 		if (bgp_node_has_bgp_path_info_data(node)
-		    && node->p.prefixlen == p->prefixlen) {
+		    && node_p->prefixlen == p->prefixlen) {
 			matched = node;
 			break;
 		}
 		node = bgp_node_from_rnode(node->link[prefix_bit(
-			&p->u.prefix, node->p.prefixlen)]);
+			&p->u.prefix, node_p->prefixlen)]);
+		node_p = bgp_node_get_prefix(node);
 	}
 
 	if (!node)
 		return;
 
-	if (matched == NULL && node->p.prefixlen <= maxlen
-	    && prefix_match(p, &node->p) && node->parent == NULL)
+	node_p = bgp_node_get_prefix(node);
+	if (matched == NULL && node_p->prefixlen <= maxlen
+	    && prefix_match(p, node_p) && node->parent == NULL)
 		matched = node;
-	else if ((matched == NULL && node->p.prefixlen > maxlen) || !node->parent)
+	else if ((matched == NULL && node_p->prefixlen > maxlen)
+		 || !node->parent)
 		return;
 	else if (matched == NULL && node->parent)
 		matched = node = bgp_node_from_rnode(node->parent);
@@ -228,7 +242,8 @@ void bgp_table_range_lookup(const struct bgp_table *table,
 	}
 
 	while ((node = bgp_route_next_until_maxlen(node, matched, maxlen))) {
-		if (prefix_match(p, &node->p)) {
+		node_p = bgp_node_get_prefix(node);
+		if (prefix_match(p, node_p)) {
 			if (bgp_node_has_bgp_path_info_data(node)) {
 				bgp_lock_node(node);
 				listnode_add(matches, node);

--- a/bgpd/bgp_table.h
+++ b/bgpd/bgp_table.h
@@ -443,4 +443,9 @@ static inline bool bgp_node_has_bgp_path_info_data(struct bgp_node *node)
 	return !!node->info;
 }
 
+static inline const struct prefix *bgp_node_get_prefix(struct bgp_node *node)
+{
+	return &node->p;
+}
+
 #endif /* _QUAGGA_BGP_TABLE_H */

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -78,7 +78,9 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 
 	for (rn = bgp_table_top(bgp->rib[afi][safi]); rn;
 	     rn = bgp_route_next(rn)) {
-		if (prd && memcmp(rn->p.u.val, prd->val, 8) != 0)
+		const struct prefix *rn_p = bgp_node_get_prefix(rn);
+
+		if (prd && memcmp(rn_p->u.val, prd->val, 8) != 0)
 			continue;
 
 		table = bgp_node_get_bgp_table_info(rn);
@@ -156,9 +158,9 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 #if ENABLE_BGP_VNC
 				struct rd_vnc_eth rd_vnc_eth = {0};
 #endif
-				uint8_t *pnt;
+				const uint8_t *pnt;
 
-				pnt = rn->p.u.val;
+				pnt = rn_p->u.val;
 
 				/* Decode RD type. */
 				type = decode_rd_type(pnt);
@@ -221,9 +223,8 @@ int show_adj_route_vpn(struct vty *vty, struct peer *peer,
 				}
 				rd_header = 0;
 			}
-			route_vty_out_tmp(vty, &rm->p, attr,
-					  safi, use_json,
-					  json_routes);
+			route_vty_out_tmp(vty, bgp_node_get_prefix(rm), attr,
+					  safi, use_json, json_routes);
 			output_count++;
 		}
 

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -1184,7 +1184,8 @@ void bgp_zebra_announce(struct bgp_node *rn, const struct prefix *p,
 		prefix2str(p, buf_prefix, sizeof(buf_prefix));
 
 	if (safi == SAFI_FLOWSPEC) {
-		bgp_pbr_update_entry(bgp, &rn->p, info, afi, safi, true);
+		bgp_pbr_update_entry(bgp, bgp_node_get_prefix(rn),
+				     info, afi, safi, true);
 		return;
 	}
 
@@ -1480,8 +1481,8 @@ void bgp_zebra_announce_table(struct bgp *bgp, afi_t afi, safi_t safi)
 			     && (pi->sub_type == BGP_ROUTE_NORMAL
 				 || pi->sub_type == BGP_ROUTE_IMPORTED)))
 
-				bgp_zebra_announce(rn, &rn->p, pi, bgp, afi,
-						   safi);
+				bgp_zebra_announce(rn, bgp_node_get_prefix(rn),
+						   pi, bgp, afi, safi);
 }
 
 void bgp_zebra_withdraw(const struct prefix *p, struct bgp_path_info *info,

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -4213,9 +4213,11 @@ static void rfapiBgpTableFilteredImport(struct bgp *bgp,
 						safi))(
 						it, /* which import table */
 						FIF_ACTION_UPDATE, bpi->peer,
-						NULL, &rn2->p, /* prefix */
+						NULL, bgp_node_get_prefix(rn2),
 						NULL, afi,
-						(struct prefix_rd *)&rn1->p,
+						(struct prefix_rd *)
+							bgp_node_get_prefix(
+								rn1),
 						bpi->attr, bpi->type,
 						bpi->sub_type, &label);
 				}

--- a/bgpd/rfapi/rfapi_monitor.c
+++ b/bgpd/rfapi/rfapi_monitor.c
@@ -1273,7 +1273,7 @@ static void rfapiMonitorEthDetachImport(
 #if DEBUG_L2_EXTRA
 	char buf_prefix[PREFIX_STRLEN];
 
-	prefix2str(&rn->p, buf_prefix, sizeof(buf_prefix));
+	prefix2str(agg_node_get_prefix(rn), buf_prefix, sizeof(buf_prefix));
 #endif
 
 	/*

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -1813,7 +1813,8 @@ int rfapiRibFTDFilterRecentPrefix(
 	{
 		char buf_pfx[PREFIX_STRLEN];
 
-		prefix2str(&it_rn->p, buf_pfx, sizeof(buf_pfx));
+		prefix2str(agg_node_get_prefix(it_rn), buf_pfx,
+			   sizeof(buf_pfx));
 		vnc_zlog_debug_verbose("%s: prefix %s", __func__, buf_pfx);
 	}
 #endif
@@ -1994,7 +1995,8 @@ rfapiRibPreload(struct bgp *bgp, struct rfapi_descriptor *rfd,
 		}
 		vnc_zlog_debug_verbose(
 			"%s: RIB skiplist for this prefix follows", __func__);
-		rfapiRibShowRibSl(NULL, &rn->p, (struct skiplist *)rn->info);
+		rfapiRibShowRibSl(NULL, agg_node_get_prefix(rn),
+				  (struct skiplist *)rn->info);
 #endif
 
 

--- a/bgpd/rfapi/vnc_export_table.c
+++ b/bgpd/rfapi/vnc_export_table.c
@@ -165,8 +165,9 @@ void vnc_eti_delete(struct vnc_export_info *goner)
 
 struct vnc_export_info *vnc_eti_checktimer(struct bgp *bgp,
 					   vnc_export_type_t etype,
-					   struct prefix *p, struct peer *peer,
-					   uint8_t type, uint8_t subtype)
+					   const struct prefix *p,
+					   struct peer *peer, uint8_t type,
+					   uint8_t subtype)
 {
 	struct agg_node *etn;
 	struct vnc_export_info *eti;

--- a/bgpd/rfapi/vnc_export_table.h
+++ b/bgpd/rfapi/vnc_export_table.h
@@ -58,8 +58,9 @@ vnc_eti_get(struct bgp *bgp, vnc_export_type_t etype, const struct prefix *p,
 extern void vnc_eti_delete(struct vnc_export_info *goner);
 
 extern struct vnc_export_info *
-vnc_eti_checktimer(struct bgp *bgp, vnc_export_type_t etype, struct prefix *p,
-		   struct peer *peer, uint8_t type, uint8_t subtype);
+vnc_eti_checktimer(struct bgp *bgp, vnc_export_type_t etype,
+		   const struct prefix *p, struct peer *peer, uint8_t type,
+		   uint8_t subtype);
 
 
 #endif /* _QUAGGA_VNC_VNC_EXPORT_TABLE_H_ */

--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -674,8 +674,9 @@ static void vnc_import_bgp_add_route_mode_resolve_nve(
 			continue;
 
 		vnc_import_bgp_add_route_mode_resolve_nve_one_rd(
-			(struct prefix_rd *)&bnp->p, table, afi, bgp, prefix,
-			ecom, &local_pref, med, &pfx_unicast_nexthop);
+			(struct prefix_rd *)bgp_node_get_prefix(bnp), table,
+			afi, bgp, prefix, ecom, &local_pref, med,
+			&pfx_unicast_nexthop);
 	}
 
 
@@ -1377,8 +1378,8 @@ vnc_import_bgp_del_route_mode_resolve_nve(struct bgp *bgp, afi_t afi,
 			continue;
 
 		vnc_import_bgp_del_route_mode_resolve_nve_one_rd(
-			(struct prefix_rd *)&bnp->p, table, afi, bgp, prefix,
-			&pfx_unicast_nexthop); /* TBD how is this set? */
+			(struct prefix_rd *)bgp_node_get_prefix(bnp), table,
+			afi, bgp, prefix, &pfx_unicast_nexthop);
 	}
 
 	if (ecom)
@@ -2754,7 +2755,8 @@ void vnc_import_bgp_redist_enable(struct bgp *bgp, afi_t afi)
 			if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED))
 				continue;
 
-			vnc_import_bgp_add_route(bgp, &rn->p, bpi);
+			vnc_import_bgp_add_route(bgp, bgp_node_get_prefix(rn),
+						 bpi);
 		}
 	}
 	vnc_zlog_debug_verbose(
@@ -2795,8 +2797,8 @@ void vnc_import_bgp_exterior_redist_enable(struct bgp *bgp, afi_t afi)
 			if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED))
 				continue;
 
-			vnc_import_bgp_exterior_add_route(bgp_exterior, &rn->p,
-							  bpi);
+			vnc_import_bgp_exterior_add_route(
+				bgp_exterior, bgp_node_get_prefix(rn), bpi);
 		}
 	}
 	vnc_zlog_debug_verbose(
@@ -2842,7 +2844,8 @@ void vnc_import_bgp_exterior_redist_enable_it(
 				continue;
 
 			vnc_import_bgp_exterior_add_route_it(
-				bgp_exterior, &rn->p, bpi, it_only);
+				bgp_exterior, bgp_node_get_prefix(rn), bpi,
+				it_only);
 		}
 	}
 }
@@ -2872,13 +2875,15 @@ void vnc_import_bgp_redist_disable(struct bgp *bgp, afi_t afi)
 	 */
 	for (rn1 = bgp_table_top(bgp->rib[afi][SAFI_MPLS_VPN]); rn1;
 	     rn1 = bgp_route_next(rn1)) {
+		const struct prefix *rn1_p;
 
 		if (!bgp_node_has_bgp_path_info_data(rn1))
 			continue;
 
+		rn1_p = bgp_node_get_prefix(rn1);
 		for (rn2 = bgp_table_top(bgp_node_get_bgp_table_info(rn1)); rn2;
 		     rn2 = bgp_route_next(rn2)) {
-
+			const struct prefix *rn2_p = bgp_node_get_prefix(rn2);
 			struct bgp_path_info *bpi;
 			struct bgp_path_info *nextbpi;
 
@@ -2907,8 +2912,8 @@ void vnc_import_bgp_redist_disable(struct bgp *bgp, afi_t afi)
 					rfd);
 
 				del_vnc_route(rfd, bpi->peer, bgp,
-					      SAFI_MPLS_VPN, &rn2->p,
-					      (struct prefix_rd *)&rn1->p,
+					      SAFI_MPLS_VPN, rn2_p,
+					      (struct prefix_rd *)rn1_p,
 					      bpi->type, bpi->sub_type, NULL,
 					      1); /* kill */
 
@@ -2968,8 +2973,9 @@ void vnc_import_bgp_exterior_redist_disable(struct bgp *bgp, afi_t afi)
 				if (CHECK_FLAG(bpi->flags, BGP_PATH_REMOVED))
 					continue;
 
-				vnc_import_bgp_exterior_del_route(bgp_exterior,
-								  &rn->p, bpi);
+				vnc_import_bgp_exterior_del_route(
+					bgp_exterior, bgp_node_get_prefix(rn),
+					bpi);
 			}
 		}
 #if DEBUG_RHN_LIST

--- a/bgpd/rfapi/vnc_zebra.c
+++ b/bgpd/rfapi/vnc_zebra.c
@@ -304,10 +304,12 @@ static void vnc_redistribute_withdraw(struct bgp *bgp, afi_t afi, uint8_t type)
 	 */
 	for (prn = bgp_table_top(bgp->rib[afi][SAFI_MPLS_VPN]); prn;
 	     prn = bgp_route_next(prn)) {
+		const struct prefix *prn_p = bgp_node_get_prefix(prn);
+
 		memset(&prd, 0, sizeof(prd));
 		prd.family = AF_UNSPEC;
 		prd.prefixlen = 64;
-		memcpy(prd.val, prn->p.u.val, 8);
+		memcpy(prd.val, prn_p->u.val, 8);
 
 		/* This is the per-RD table of prefixes */
 		table = bgp_node_get_bgp_table_info(prn);
@@ -329,7 +331,7 @@ static void vnc_redistribute_withdraw(struct bgp *bgp, afi_t afi, uint8_t type)
 				del_vnc_route(
 					&vncHD1VR, /* use dummy ptr as cookie */
 					vncHD1VR.peer, bgp, SAFI_MPLS_VPN,
-					&(rn->p), &prd, type,
+					bgp_node_get_prefix(rn), &prd, type,
 					BGP_ROUTE_REDISTRIBUTE, NULL, 0);
 			}
 		}

--- a/lib/smux.h
+++ b/lib/smux.h
@@ -105,7 +105,7 @@ extern int smux_trap(struct variable *, size_t, const oid *, size_t,
 extern int oid_compare(const oid *, int, const oid *, int);
 extern void oid2in_addr(oid[], int, struct in_addr *);
 extern void *oid_copy(void *, const void *, size_t);
-extern void oid_copy_addr(oid[], struct in_addr *, int);
+extern void oid_copy_addr(oid[], const struct in_addr *, int);
 
 #ifdef __cplusplus
 }

--- a/lib/snmp.c
+++ b/lib/snmp.c
@@ -64,10 +64,10 @@ void oid2in_addr(oid oid[], int len, struct in_addr *addr)
 		*pnt++ = oid[i];
 }
 
-void oid_copy_addr(oid oid[], struct in_addr *addr, int len)
+void oid_copy_addr(oid oid[], const struct in_addr *addr, int len)
 {
 	int i;
-	uint8_t *pnt;
+	const uint8_t *pnt;
 
 	if (len == 0)
 		return;

--- a/lib/stream.c
+++ b/lib/stream.c
@@ -898,7 +898,7 @@ int stream_put_prefix(struct stream *s, const struct prefix *p)
 }
 
 /* Put NLRI with label */
-int stream_put_labeled_prefix(struct stream *s, struct prefix *p,
+int stream_put_labeled_prefix(struct stream *s, const struct prefix *p,
 			      mpls_label_t *label, int addpath_encode,
 			      uint32_t addpath_tx_id)
 {

--- a/lib/stream.h
+++ b/lib/stream.h
@@ -196,7 +196,7 @@ extern int stream_put_prefix_addpath(struct stream *s,
 				     int addpath_encode,
 				     uint32_t addpath_tx_id);
 extern int stream_put_prefix(struct stream *s, const struct prefix *p);
-extern int stream_put_labeled_prefix(struct stream *, struct prefix *,
+extern int stream_put_labeled_prefix(struct stream *, const struct prefix *,
 				     mpls_label_t *, int addpath_encode,
 				     uint32_t addpath_tx_id);
 extern void stream_get(void *, struct stream *, size_t);

--- a/tests/bgpd/test_bgp_table.c
+++ b/tests/bgpd/test_bgp_table.c
@@ -82,7 +82,7 @@ static void print_range_result(struct list *list)
 	for (ALL_LIST_ELEMENTS_RO(list, listnode, bnode)) {
 		char buf[PREFIX2STR_BUFFER];
 
-		prefix2str(&bnode->p, buf, PREFIX2STR_BUFFER);
+		prefix2str(bgp_node_get_prefix(bnode), buf, PREFIX2STR_BUFFER);
 		printf("%s\n", buf);
 	}
 }
@@ -106,7 +106,7 @@ static void check_lookup_result(struct list *list, va_list arglist)
 			assert(0);
 
 		for (ALL_LIST_ELEMENTS_RO(list, listnode, bnode)) {
-			if (prefix_same(&bnode->p, &p))
+			if (prefix_same(bgp_node_get_prefix(bnode), &p))
 				found = true;
 		}
 


### PR DESCRIPTION
More work on the path of getting bgp_dest into the code base.

This adds an accessor `bgp_node_get_prefix()` that all of bgp now uses.