### PR TITLE
*: remove tabs and linefeeds from log messages

### DIFF
--- a/bfdd/config.c
+++ b/bfdd/config.c
@@ -178,7 +178,7 @@ static int parse_peer_config(struct json_object *jo, struct bfd_peer_cfg *bpc)
 	int family_type = (bpc->bpc_ipv4) ? AF_INET : AF_INET6;
 	int error = 0;
 
-	log_debug("\tpeer: %s", bpc->bpc_ipv4 ? "ipv4" : "ipv6");
+	log_debug("        peer: %s", bpc->bpc_ipv4 ? "ipv4" : "ipv6");
 
 	JSON_FOREACH (jo, joi, join) {
 		key = json_object_iter_peek_name(&joi);
@@ -186,7 +186,7 @@ static int parse_peer_config(struct json_object *jo, struct bfd_peer_cfg *bpc)
 
 		if (strcmp(key, "multihop") == 0) {
 			bpc->bpc_mhop = json_object_get_boolean(jo_val);
-			log_debug("\tmultihop: %s",
+			log_debug("        multihop: %s",
 				  bpc->bpc_mhop ? "true" : "false");
 		} else if (strcmp(key, "peer-address") == 0) {
 			sval = json_object_get_string(jo_val);
@@ -197,7 +197,7 @@ static int parse_peer_config(struct json_object *jo, struct bfd_peer_cfg *bpc)
 					__func__, __LINE__, sval);
 				error++;
 			}
-			log_debug("\tpeer-address: %s", sval);
+			log_debug("        peer-address: %s", sval);
 		} else if (strcmp(key, "local-address") == 0) {
 			sval = json_object_get_string(jo_val);
 			if (strtosa(sval, &bpc->bpc_local) != 0
@@ -208,18 +208,19 @@ static int parse_peer_config(struct json_object *jo, struct bfd_peer_cfg *bpc)
 					__func__, __LINE__, sval);
 				error++;
 			}
-			log_debug("\tlocal-address: %s", sval);
+			log_debug("        local-address: %s", sval);
 		} else if (strcmp(key, "local-interface") == 0) {
 			bpc->bpc_has_localif = true;
 			sval = json_object_get_string(jo_val);
 			if (strlcpy(bpc->bpc_localif, sval,
 				    sizeof(bpc->bpc_localif))
 			    > sizeof(bpc->bpc_localif)) {
-				log_debug("\tlocal-interface: %s (truncated)",
-					  sval);
+				log_debug(
+					"        local-interface: %s (truncated)",
+					sval);
 				error++;
 			} else {
-				log_debug("\tlocal-interface: %s", sval);
+				log_debug("        local-interface: %s", sval);
 			}
 		} else if (strcmp(key, "vrf-name") == 0) {
 			bpc->bpc_has_vrfname = true;
@@ -227,43 +228,44 @@ static int parse_peer_config(struct json_object *jo, struct bfd_peer_cfg *bpc)
 			if (strlcpy(bpc->bpc_vrfname, sval,
 				    sizeof(bpc->bpc_vrfname))
 			    > sizeof(bpc->bpc_vrfname)) {
-				log_debug("\tvrf-name: %s (truncated)", sval);
+				log_debug("        vrf-name: %s (truncated)",
+					  sval);
 				error++;
 			} else {
-				log_debug("\tvrf-name: %s", sval);
+				log_debug("        vrf-name: %s", sval);
 			}
 		} else if (strcmp(key, "detect-multiplier") == 0) {
 			bpc->bpc_detectmultiplier =
 				json_object_get_int64(jo_val);
 			bpc->bpc_has_detectmultiplier = true;
-			log_debug("\tdetect-multiplier: %u",
+			log_debug("        detect-multiplier: %u",
 				  bpc->bpc_detectmultiplier);
 		} else if (strcmp(key, "receive-interval") == 0) {
 			bpc->bpc_recvinterval = json_object_get_int64(jo_val);
 			bpc->bpc_has_recvinterval = true;
-			log_debug("\treceive-interval: %llu",
+			log_debug("        receive-interval: %llu",
 				  bpc->bpc_recvinterval);
 		} else if (strcmp(key, "transmit-interval") == 0) {
 			bpc->bpc_txinterval = json_object_get_int64(jo_val);
 			bpc->bpc_has_txinterval = true;
-			log_debug("\ttransmit-interval: %llu",
+			log_debug("        transmit-interval: %llu",
 				  bpc->bpc_txinterval);
 		} else if (strcmp(key, "echo-interval") == 0) {
 			bpc->bpc_echointerval = json_object_get_int64(jo_val);
 			bpc->bpc_has_echointerval = true;
-			log_debug("\techo-interval: %llu",
+			log_debug("        echo-interval: %llu",
 				  bpc->bpc_echointerval);
 		} else if (strcmp(key, "create-only") == 0) {
 			bpc->bpc_createonly = json_object_get_boolean(jo_val);
-			log_debug("\tcreate-only: %s",
+			log_debug("        create-only: %s",
 				  bpc->bpc_createonly ? "true" : "false");
 		} else if (strcmp(key, "shutdown") == 0) {
 			bpc->bpc_shutdown = json_object_get_boolean(jo_val);
-			log_debug("\tshutdown: %s",
+			log_debug("        shutdown: %s",
 				  bpc->bpc_shutdown ? "true" : "false");
 		} else if (strcmp(key, "echo-mode") == 0) {
 			bpc->bpc_echo = json_object_get_boolean(jo_val);
-			log_debug("\techo-mode: %s",
+			log_debug("        echo-mode: %s",
 				  bpc->bpc_echo ? "true" : "false");
 		} else if (strcmp(key, "label") == 0) {
 			bpc->bpc_has_label = true;
@@ -271,10 +273,11 @@ static int parse_peer_config(struct json_object *jo, struct bfd_peer_cfg *bpc)
 			if (strlcpy(bpc->bpc_label, sval,
 				    sizeof(bpc->bpc_label))
 			    > sizeof(bpc->bpc_label)) {
-				log_debug("\tlabel: %s (truncated)", sval);
+				log_debug("        label: %s (truncated)",
+					  sval);
 				error++;
 			} else {
-				log_debug("\tlabel: %s", sval);
+				log_debug("        label: %s", sval);
 			}
 		} else {
 			sval = json_object_get_string(jo_val);
@@ -309,7 +312,7 @@ static int parse_peer_label_config(struct json_object *jo,
 	if (pl == NULL)
 		return 1;
 
-	log_debug("\tpeer-label: %s", sval);
+	log_debug("        peer-label: %s", sval);
 
 	/* Translate the label into BFD address keys. */
 	bs_to_bpc(pl->pl_bs, bpc);

--- a/bgpd/bgp_bmp.c
+++ b/bgpd/bgp_bmp.c
@@ -385,15 +385,15 @@ static struct stream *bmp_peerstate(struct peer *peer, bool down)
 			stream_put(s, bbpeer->open_tx, bbpeer->open_tx_len);
 		else {
 			stream_put(s, dummy_open, sizeof(dummy_open));
-			zlog_warn("bmp: missing TX OPEN message for peer %s\n",
-					peer->host);
+			zlog_warn("bmp: missing TX OPEN message for peer %s",
+				  peer->host);
 		}
 		if (bbpeer && bbpeer->open_rx)
 			stream_put(s, bbpeer->open_rx, bbpeer->open_rx_len);
 		else {
 			stream_put(s, dummy_open, sizeof(dummy_open));
-			zlog_warn("bmp: missing RX OPEN message for peer %s\n",
-					peer->host);
+			zlog_warn("bmp: missing RX OPEN message for peer %s",
+				  peer->host);
 		}
 
 		if (peer->desc)
@@ -1342,8 +1342,7 @@ static int bmp_accept(struct thread *thread)
 	/* We can handle IPv4 or IPv6 socket. */
 	bmp_sock = sockunion_accept(bl->sock, &su);
 	if (bmp_sock < 0) {
-		zlog_info("bmp: accept_sock failed: %s\n",
-                          safe_strerror (errno));
+		zlog_info("bmp: accept_sock failed: %s", safe_strerror(errno));
 		return -1;
 	}
 	bmp_open(bl->targets, bmp_sock);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6845,7 +6845,7 @@ static int bgp_aggregate_set(struct vty *vty, const char *prefix_str, afi_t afi,
 		if (as_set == AGGREGATE_AS_SET) {
 			as_set_new = AGGREGATE_AS_UNSET;
 			zlog_warn(
-				"%s: Ignoring as-set because `bgp reject-as-sets` is enabled.\n",
+				"%s: Ignoring as-set because `bgp reject-as-sets` is enabled.",
 				__func__);
 			vty_out(vty,
 				"Ignoring as-set because `bgp reject-as-sets` is enabled.\n");

--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -353,7 +353,7 @@ void isis_adj_print(struct isis_adjacency *adj)
 	if (dyn)
 		zlog_debug("%s", dyn->hostname);
 
-	zlog_debug("SystemId %20s SNPA %s, level %d\nHolding Time %d",
+	zlog_debug("SystemId %20s SNPA %s, level %d; Holding Time %d",
 		   sysid_print(adj->sysid), snpa_print(adj->snpa), adj->level,
 		   adj->hold_time);
 	if (adj->ipv4_address_count) {

--- a/isisd/isis_circuit.c
+++ b/isisd/isis_circuit.c
@@ -345,8 +345,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 		} else {
 			prefix2str(connected->address, buf, sizeof(buf));
 			zlog_warn(
-				"Nonexistent ip address %s removal attempt from \
-                      circuit %s",
+				"Nonexistent ip address %s removal attempt from circuit %s",
 				buf, circuit->interface->name);
 			zlog_warn("Current ip addresses on %s:",
 				  circuit->interface->name);
@@ -394,8 +393,7 @@ void isis_circuit_del_addr(struct isis_circuit *circuit,
 		if (!found) {
 			prefix2str(connected->address, buf, sizeof(buf));
 			zlog_warn(
-				"Nonexistent ip address %s removal attempt from \
-		      circuit %s",
+				"Nonexistent ip address %s removal attempt from circuit %s",
 				buf, circuit->interface->name);
 			zlog_warn("Current ip addresses on %s:",
 				  circuit->interface->name);

--- a/lib/log.c
+++ b/lib/log.c
@@ -1228,59 +1228,47 @@ int proto_redistnum(int afi, const char *s)
 	return -1;
 }
 
-void zlog_hexdump(const void *mem, unsigned int len)
+void zlog_hexdump(const void *mem, size_t len)
 {
-	unsigned long i = 0;
-	unsigned int j = 0;
-	unsigned int columns = 8;
-	/*
-	 * 19 bytes for 0xADDRESS:
-	 * 24 bytes for data; 2 chars plus a space per data byte
-	 *  1 byte for space
-	 *  8 bytes for ASCII representation
-	 *  1 byte for a newline
-	 * =====================
-	 * 53 bytes per 8 bytes of data
-	 *  1 byte for null term
-	 */
-	size_t bs = ((len / 8) + 1) * 53 + 1;
-	char buf[bs];
-	char *s = buf;
-	const unsigned char *memch = mem;
+	char line[64];
+	const uint8_t *src = mem;
+	const uint8_t *end = src + len;
 
-	memset(buf, 0, sizeof(buf));
-
-	for (i = 0; i < len + ((len % columns) ? (columns - len % columns) : 0);
-	     i++) {
-		/* print offset */
-		if (i % columns == 0)
-			s += snprintf(s, bs - (s - buf),
-				      "0x%016lx: ", (unsigned long)memch + i);
-
-		/* print hex data */
-		if (i < len)
-			s += snprintf(s, bs - (s - buf), "%02x ", memch[i]);
-
-		/* end of block, just aligning for ASCII dump */
-		else
-			s += snprintf(s, bs - (s - buf), "   ");
-
-		/* print ASCII dump */
-		if (i % columns == (columns - 1)) {
-			for (j = i - (columns - 1); j <= i; j++) {
-				/* end of block not really printing */
-				if (j >= len)
-					s += snprintf(s, bs - (s - buf), " ");
-				else if (isprint(memch[j]))
-					s += snprintf(s, bs - (s - buf), "%c",
-						      memch[j]);
-				else /* other char */
-					s += snprintf(s, bs - (s - buf), ".");
-			}
-			s += snprintf(s, bs - (s - buf), "\n");
-		}
+	if (len == 0) {
+		zlog_debug("%016lx: (zero length / no data)", (long)src);
+		return;
 	}
-	zlog_debug("\n%s", buf);
+
+	while (src < end) {
+		struct fbuf fb = {
+			.buf = line,
+			.pos = line,
+			.len = sizeof(line),
+		};
+		const uint8_t *lineend = src + 8;
+		unsigned line_bytes = 0;
+
+		bprintfrr(&fb, "%016lx: ", (long)src);
+
+		while (src < lineend && src < end) {
+			bprintfrr(&fb, "%02x ", *src++);
+			line_bytes++;
+		}
+		if (line_bytes < 8)
+			bprintfrr(&fb, "%*s", (8 - line_bytes) * 3, "");
+
+		src -= line_bytes;
+		while (src < lineend && src < end && fb.pos < fb.buf + fb.len) {
+			uint8_t byte = *src++;
+
+			if (isprint(byte))
+				*fb.pos++ = byte;
+			else
+				*fb.pos++ = '.';
+		}
+
+		zlog_debug("%.*s", (int)(fb.pos - fb.buf), fb.buf);
+	}
 }
 
 const char *zlog_sanitize(char *buf, size_t bufsz, const void *in, size_t inlen)

--- a/lib/log.h
+++ b/lib/log.h
@@ -152,7 +152,7 @@ extern void zlog_backtrace_sigsafe(int priority, void *program_counter);
 extern size_t quagga_timestamp(int timestamp_precision /* # subsecond digits */,
 			       char *buf, size_t buflen);
 
-extern void zlog_hexdump(const void *mem, unsigned int len);
+extern void zlog_hexdump(const void *mem, size_t len);
 extern const char *zlog_sanitize(char *buf, size_t bufsz, const void *in,
 				 size_t inlen);
 

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -691,7 +691,7 @@ static int ospf_ase_calculate_timer(struct thread *t)
 
 		if (IS_DEBUG_OSPF_EVENT)
 			zlog_info(
-				"SPF Processing Time(usecs): External Routes: %lld\n",
+				"SPF Processing Time(usecs): External Routes: %lld",
 				(stop_time.tv_sec - start_time.tv_sec)
 						* 1000000LL
 					+ (stop_time.tv_usec

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -2805,7 +2805,7 @@ static int ospf_maxage_lsa_remover(struct thread *thread)
 			if (CHECK_FLAG(lsa->flags, OSPF_LSA_PREMATURE_AGE)) {
 				if (IS_DEBUG_OSPF(lsa, LSA_FLOODING))
 					zlog_debug(
-						"originating new lsa for lsa 0x%p\n",
+						"originating new lsa for lsa 0x%p",
 						(void *)lsa);
 				ospf_lsa_refresh(ospf, lsa);
 			}

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -611,7 +611,7 @@ static void ospf_write_frags(int fd, struct ospf_packet *op, struct ip *iph,
 
 		if (IS_DEBUG_OSPF_PACKET(type - 1, SEND)) {
 			zlog_debug(
-				"ospf_write_frags: sent id %d, off %d, len %d to %s\n",
+				"ospf_write_frags: sent id %d, off %d, len %d to %s",
 				iph->ip_id, iph->ip_off, iph->ip_len,
 				inet_ntoa(iph->ip_dst));
 		}

--- a/ospfd/ospf_ri.c
+++ b/ospfd/ospf_ri.c
@@ -1382,9 +1382,8 @@ static uint16_t show_vty_sr_algorithm(struct vty *vty, struct tlv_header *tlvh)
 				zlog_debug("    Algorithm %d: Strict SPF", i);
 				break;
 			default:
-				zlog_debug(
-					"    Algorithm %d: Unknown value %d\n",
-					i, algo->value[i]);
+				zlog_debug("    Algorithm %d: Unknown value %d",
+					   i, algo->value[i]);
 				break;
 			}
 	}

--- a/ospfd/ospf_route.c
+++ b/ospfd/ospf_route.c
@@ -631,27 +631,15 @@ void ospf_route_table_dump(struct route_table *rt)
 {
 	struct route_node *rn;
 	struct ospf_route * or ;
-	char buf1[BUFSIZ];
-	char buf2[BUFSIZ];
 	struct listnode *pnode;
 	struct ospf_path *path;
-
-#if 0
-  zlog_debug ("Type   Dest   Area   Path	 Type	 Cost	Next	 Adv.");
-  zlog_debug ("					Hop(s)	 Router(s)");
-#endif /* 0 */
 
 	zlog_debug("========== OSPF routing table ==========");
 	for (rn = route_top(rt); rn; rn = route_next(rn))
 		if ((or = rn->info) != NULL) {
 			if (or->type == OSPF_DESTINATION_NETWORK) {
-				zlog_debug("N %s/%d\t%s\t%s\t%d",
-					   inet_ntop(AF_INET, &rn->p.u.prefix4,
-						     buf1, BUFSIZ),
-					   rn->p.prefixlen,
-					   inet_ntop(AF_INET,
-						     & or->u.std.area_id, buf2,
-						     BUFSIZ),
+				zlog_debug("N %-18pFX %-15pI4 %s %d", &rn->p,
+					   &or->u.std.area_id,
 					   ospf_path_type_str[or->path_type],
 					   or->cost);
 				for (ALL_LIST_ELEMENTS_RO(or->paths, pnode,
@@ -659,12 +647,9 @@ void ospf_route_table_dump(struct route_table *rt)
 					zlog_debug("  -> %s",
 						   inet_ntoa(path->nexthop));
 			} else
-				zlog_debug("R %s\t%s\t%s\t%d",
-					   inet_ntop(AF_INET, &rn->p.u.prefix4,
-						     buf1, BUFSIZ),
-					   inet_ntop(AF_INET,
-						     & or->u.std.area_id, buf2,
-						     BUFSIZ),
+				zlog_debug("R %-18pI4 %-15pI4 %s %d",
+					   &rn->p.u.prefix4,
+					   &or->u.std.area_id,
 					   ospf_path_type_str[or->path_type],
 					   or->cost);
 		}

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -1401,13 +1401,13 @@ static int ospf_spf_calculate_timer(struct thread *thread)
 
 	if (IS_DEBUG_OSPF_EVENT) {
 		zlog_info("SPF Processing Time(usecs): %ld", total_spf_time);
-		zlog_info("\t    SPF Time: %ld", spf_time);
-		zlog_info("\t   InterArea: %ld", ia_time);
-		zlog_info("\t       Prune: %ld", prune_time);
-		zlog_info("\tRouteInstall: %ld", rt_time);
+		zlog_info("            SPF Time: %ld", spf_time);
+		zlog_info("           InterArea: %ld", ia_time);
+		zlog_info("               Prune: %ld", prune_time);
+		zlog_info("        RouteInstall: %ld", rt_time);
 		if (IS_OSPF_ABR(ospf))
-			zlog_info("\t         ABR: %ld (%d areas)", abr_time,
-				  areas_processed);
+			zlog_info("                 ABR: %ld (%d areas)",
+				  abr_time, areas_processed);
 		zlog_info("Reason(s) for SPF: %s", rbuf);
 	}
 

--- a/ospfd/ospf_te.c
+++ b/ospfd/ospf_te.c
@@ -1780,7 +1780,7 @@ static uint16_t show_vty_link_subtlv_unrsv_bw(struct vty *vty,
 				i, fval1, i + 1, fval2);
 		else
 			zlog_debug(
-				"      [%d]: %g (Bytes/sec),\t[%d]: %g (Bytes/sec)",
+				"      [%d]: %g (Bytes/sec),  [%d]: %g (Bytes/sec)",
 				i, fval1, i + 1, fval2);
 	}
 

--- a/pimd/pim_bsm.c
+++ b/pimd/pim_bsm.c
@@ -1068,13 +1068,13 @@ static bool pim_install_bsm_grp_rp(struct pim_instance *pim,
 	if (listnode_add_sort_nodup(grpnode->partial_bsrp_list, bsm_rpinfo)) {
 		if (PIM_DEBUG_BSM)
 			zlog_debug(
-				"%s, bs_rpinfo node added to the partial bs_rplist.\r\n",
+				"%s, bs_rpinfo node added to the partial bs_rplist.",
 				__func__);
 		return true;
 	}
 
 	if (PIM_DEBUG_BSM)
-		zlog_debug("%s: list node not added\n", __func__);
+		zlog_debug("%s: list node not added", __func__);
 
 	XFREE(MTYPE_PIM_BSRP_NODE, bsm_rpinfo);
 	return false;
@@ -1092,7 +1092,7 @@ static void pim_update_pending_rp_cnt(struct bsm_scope *sz,
 		if (bsm_frag_tag != bsgrp->frag_tag) {
 			if (PIM_DEBUG_BSM)
 				zlog_debug(
-					"%s,Received a new BSM ,so clear the pending bs_rpinfo list.\r\n",
+					"%s,Received a new BSM ,so clear the pending bs_rpinfo list.",
 					__func__);
 			list_delete_all_node(bsgrp->partial_bsrp_list);
 			bsgrp->pend_rp_cnt = total_rp_count;
@@ -1132,7 +1132,7 @@ static bool pim_bsm_parse_install_g2rp(struct bsm_scope *scope, uint8_t *buf,
 			pim_inet4_dump("<Group?>", grpinfo.group.addr, grp_str,
 				       sizeof(grp_str));
 			zlog_debug(
-				"%s, Group %s  Rpcount:%d Fragment-Rp-count:%d\r\n",
+				"%s, Group %s  Rpcount:%d Fragment-Rp-count:%d",
 				__func__, grp_str, grpinfo.rp_count,
 				grpinfo.frag_rp_count);
 		}
@@ -1146,9 +1146,8 @@ static bool pim_bsm_parse_install_g2rp(struct bsm_scope *scope, uint8_t *buf,
 
 				pim_inet4_dump("<Group?>", grpinfo.group.addr,
 					       grp_str, sizeof(grp_str));
-				zlog_debug(
-					"%s, Rp count is zero for group: %s\r\n",
-					__func__, grp_str);
+				zlog_debug("%s, Rp count is zero for group: %s",
+					   __func__, grp_str);
 			}
 			return false;
 		}
@@ -1169,9 +1168,8 @@ static bool pim_bsm_parse_install_g2rp(struct bsm_scope *scope, uint8_t *buf,
 
 		if (!bsgrp) {
 			if (PIM_DEBUG_BSM)
-				zlog_debug(
-					"%s, Create new  BSM Group node.\r\n",
-					__func__);
+				zlog_debug("%s, Create new  BSM Group node.",
+					   __func__);
 
 			/* create a new node to be added to the tree. */
 			bsgrp = pim_bsm_new_bsgrp_node(scope->bsrp_table,
@@ -1179,7 +1177,7 @@ static bool pim_bsm_parse_install_g2rp(struct bsm_scope *scope, uint8_t *buf,
 
 			if (!bsgrp) {
 				zlog_debug(
-					"%s, Failed to get the BSM group node.\r\n",
+					"%s, Failed to get the BSM group node.",
 					__func__);
 				continue;
 			}
@@ -1214,7 +1212,7 @@ static bool pim_bsm_parse_install_g2rp(struct bsm_scope *scope, uint8_t *buf,
 				pim_inet4_dump("<Rpaddr?>", rpinfo.rpaddr.addr,
 					       rp_str, sizeof(rp_str));
 				zlog_debug(
-					"%s, Rp address - %s; pri:%d hold:%d\r\n",
+					"%s, Rp address - %s; pri:%d hold:%d",
 					__func__, rp_str, rpinfo.rp_pri,
 					rpinfo.rp_holdtime);
 			}
@@ -1378,7 +1376,7 @@ int pim_bsm_process(struct interface *ifp, struct ip *ip_hdr, uint8_t *buf,
 		    (buf_size - PIM_BSM_HDR_LEN - PIM_MSG_HEADER_LEN),
 		    frag_tag)) {
 		if (PIM_DEBUG_BSM) {
-			zlog_debug("%s, Parsing BSM failed.\r\n", __func__);
+			zlog_debug("%s, Parsing BSM failed.", __func__);
 		}
 		pim->bsm_dropped++;
 		return -1;

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -186,7 +186,7 @@ void pim_register_send(const uint8_t *buf, int buf_size, struct in_addr src,
 	if (!pinfo) {
 		if (PIM_DEBUG_PIM_REG)
 			zlog_debug(
-				"%s: Interface: %s not configured for pim to trasmit on!\n",
+				"%s: Interface: %s not configured for pim to transmit on!",
 				__func__, ifp->name);
 		return;
 	}

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -353,7 +353,7 @@ static int sharp_debug_nexthops(struct zapi_route *api)
 		case NEXTHOP_TYPE_IPV4_IFINDEX:
 		case NEXTHOP_TYPE_IPV4:
 			zlog_debug(
-				"\tNexthop %s, type: %d, ifindex: %d, vrf: %d, label_num: %d",
+				"        Nexthop %s, type: %d, ifindex: %d, vrf: %d, label_num: %d",
 				inet_ntop(AF_INET, &znh->gate.ipv4.s_addr, buf,
 					  sizeof(buf)),
 				znh->type, znh->ifindex, znh->vrf_id,
@@ -362,18 +362,18 @@ static int sharp_debug_nexthops(struct zapi_route *api)
 		case NEXTHOP_TYPE_IPV6_IFINDEX:
 		case NEXTHOP_TYPE_IPV6:
 			zlog_debug(
-				"\tNexthop %s, type: %d, ifindex: %d, vrf: %d, label_num: %d",
+				"        Nexthop %s, type: %d, ifindex: %d, vrf: %d, label_num: %d",
 				inet_ntop(AF_INET6, &znh->gate.ipv6, buf,
 					  sizeof(buf)),
 				znh->type, znh->ifindex, znh->vrf_id,
 				znh->label_num);
 			break;
 		case NEXTHOP_TYPE_IFINDEX:
-			zlog_debug("\tNexthop IFINDEX: %d, ifindex: %d",
+			zlog_debug("        Nexthop IFINDEX: %d, ifindex: %d",
 				   znh->type, znh->ifindex);
 			break;
 		case NEXTHOP_TYPE_BLACKHOLE:
-			zlog_debug("\tNexthop blackhole");
+			zlog_debug("        Nexthop blackhole");
 			break;
 		}
 	}

--- a/tests/lib/test_zlog.c
+++ b/tests/lib/test_zlog.c
@@ -34,12 +34,14 @@ static bool test_zlog_hexdump(void)
 	unsigned int nl = 1;
 
 	do {
-		long d[nl];
+		uint8_t d[nl];
 
 		for (unsigned int i = 0; i < nl; i++)
 			d[i] = random();
-		zlog_hexdump(d, nl * sizeof(long));
-	} while (++nl * sizeof(long) <= MAXDATA);
+		zlog_hexdump(d, nl - 1);
+
+		nl += 1 + (nl / 2);
+	} while (nl <= MAXDATA);
 
 	return true;
 }

--- a/zebra/kernel_socket.c
+++ b/zebra/kernel_socket.c
@@ -1393,7 +1393,7 @@ static int kernel_read(struct thread *thread)
 	 */
 	if (rtm->rtm_msglen != nbytes) {
 		zlog_debug(
-			"kernel_read: rtm->rtm_msglen %d, nbytes %d, type %d\n",
+			"kernel_read: rtm->rtm_msglen %d, nbytes %d, type %d",
 			rtm->rtm_msglen, nbytes, rtm->rtm_type);
 		return -1;
 	}

--- a/zebra/redistribute.c
+++ b/zebra/redistribute.c
@@ -268,7 +268,7 @@ void redistribute_delete(const struct prefix *p, const struct prefix *src_p,
 	/* Add DISTANCE_INFINITY check. */
 	if (old_re && (old_re->distance == DISTANCE_INFINITY)) {
 		if (IS_ZEBRA_DEBUG_RIB)
-			zlog_debug("\tSkipping due to Infinite Distance");
+			zlog_debug("        Skipping due to Infinite Distance");
 		return;
 	}
 

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -2676,7 +2676,7 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
 
 	if (filter_vlan && vid != filter_vlan) {
 		if (IS_ZEBRA_DEBUG_KERNEL)
-			zlog_debug("\tFiltered due to filter vlan: %d",
+			zlog_debug("        Filtered due to filter vlan: %d",
 				   filter_vlan);
 		return 0;
 	}
@@ -2690,8 +2690,9 @@ static int netlink_macfdb_change(struct nlmsghdr *h, int len, ns_id_t ns_id)
                 /* Drop "permanent" entries. */
                 if (ndm->ndm_state & NUD_PERMANENT) {
 			if (IS_ZEBRA_DEBUG_KERNEL)
-				zlog_debug("\tDropping entry because of NUD_PERMANENT");
-                        return 0;
+				zlog_debug(
+					"        Dropping entry because of NUD_PERMANENT");
+			return 0;
 		}
 
 		if (IS_ZEBRA_IF_VXLAN(ifp))

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1063,7 +1063,7 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 
 	if (IS_ZEBRA_DEBUG_NHT)
 		zlog_debug(
-			"rnh_register msg from client %s: hdr->length=%d, type=%s vrf=%u\n",
+			"rnh_register msg from client %s: hdr->length=%d, type=%s vrf=%u",
 			zebra_route_string(client->proto), hdr->length,
 			(type == RNH_NEXTHOP_TYPE) ? "nexthop" : "route",
 			zvrf->vrf->vrf_id);
@@ -1152,7 +1152,7 @@ static void zread_rnh_unregister(ZAPI_HANDLER_ARGS)
 
 	if (IS_ZEBRA_DEBUG_NHT)
 		zlog_debug(
-			"rnh_unregister msg from client %s: hdr->length=%d vrf: %u\n",
+			"rnh_unregister msg from client %s: hdr->length=%d vrf: %u",
 			zebra_route_string(client->proto), hdr->length,
 			zvrf->vrf->vrf_id);
 

--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -1411,7 +1411,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 		if (!ifp) {
 			if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 				zlog_debug(
-					"\t%s: Onlink and interface: %u[%u] does not exist",
+					"        %s: Onlink and interface: %u[%u] does not exist",
 					__func__, nexthop->ifindex,
 					nexthop->vrf_id);
 			return 0;
@@ -1422,14 +1422,14 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 
 			if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 				zlog_debug(
-					"\t%s: Onlink and interface %s is not operative",
+					"        %s: Onlink and interface %s is not operative",
 					__func__, ifp->name);
 			return 0;
 		}
 		if (!if_is_operative(ifp)) {
 			if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 				zlog_debug(
-					"\t%s: Interface %s is not unnumbered",
+					"        %s: Interface %s is not unnumbered",
 					__func__, ifp->name);
 			return 0;
 		}
@@ -1441,7 +1441,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 		&& memcmp(&nexthop->gate.ipv6, &top->p.u.prefix6, 16) == 0)) {
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 			zlog_debug(
-				"\t:%s: Attempting to install a max prefixlength route through itself",
+				"        :%s: Attempting to install a max prefixlength route through itself",
 				__func__);
 		return 0;
 	}
@@ -1469,7 +1469,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 	zvrf = zebra_vrf_lookup_by_id(nexthop->vrf_id);
 	if (!table || !zvrf) {
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
-			zlog_debug("\t%s: Table not found", __func__);
+			zlog_debug("        %s: Table not found", __func__);
 		return 0;
 	}
 
@@ -1487,7 +1487,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 			    || ((afi == AFI_IP6) && (rn->p.prefixlen != 128))) {
 				if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 					zlog_debug(
-						"\t%s: Matched against ourself and prefix length is not max bit length",
+						"        %s: Matched against ourself and prefix length is not max bit length",
 						__func__);
 				return 0;
 			}
@@ -1500,7 +1500,7 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 		    && !rnh_resolve_via_default(zvrf, p.family)) {
 			if (IS_ZEBRA_DEBUG_RIB_DETAILED)
 				zlog_debug(
-					"\t:%s: Resolved against default route",
+					"        :%s: Resolved against default route",
 					__func__);
 			return 0;
 		}
@@ -1552,8 +1552,9 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 				re->nexthop_mtu = match->mtu;
 
 			if (!resolved && IS_ZEBRA_DEBUG_RIB_DETAILED)
-				zlog_debug("\t%s: Recursion failed to find",
-					   __func__);
+				zlog_debug(
+					"        %s: Recursion failed to find",
+					__func__);
 			return resolved;
 		} else if (re->type == ZEBRA_ROUTE_STATIC) {
 			resolved = 0;
@@ -1574,24 +1575,25 @@ static int nexthop_active(afi_t afi, struct route_entry *re,
 
 			if (!resolved && IS_ZEBRA_DEBUG_RIB_DETAILED)
 				zlog_debug(
-					"\t%s: Static route unable to resolve",
+					"        %s: Static route unable to resolve",
 					__func__);
 			return resolved;
 		} else {
 			if (IS_ZEBRA_DEBUG_RIB_DETAILED) {
 				zlog_debug(
-					"\t%s: Route Type %s has not turned on recursion",
+					"        %s: Route Type %s has not turned on recursion",
 					__func__, zebra_route_string(re->type));
 				if (re->type == ZEBRA_ROUTE_BGP
 				    && !CHECK_FLAG(re->flags, ZEBRA_FLAG_IBGP))
 					zlog_debug(
-						"\tEBGP: see \"disable-ebgp-connected-route-check\" or \"disable-connected-check\"");
+						"        EBGP: see \"disable-ebgp-connected-route-check\" or \"disable-connected-check\"");
 			}
 			return 0;
 		}
 	}
 	if (IS_ZEBRA_DEBUG_RIB_DETAILED)
-		zlog_debug("\t%s: Nexthop did not lookup in table", __func__);
+		zlog_debug("        %s: Nexthop did not lookup in table",
+			   __func__);
 	return 0;
 }
 
@@ -1683,8 +1685,9 @@ static unsigned nexthop_active_check(struct route_node *rn,
 	}
 	if (!CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE)) {
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
-			zlog_debug("\t%s: Unable to find a active nexthop",
-				   __func__);
+			zlog_debug(
+				"        %s: Unable to find a active nexthop",
+				__func__);
 		return 0;
 	}
 
@@ -1713,7 +1716,7 @@ static unsigned nexthop_active_check(struct route_node *rn,
 	zvrf = zebra_vrf_lookup_by_id(nexthop->vrf_id);
 	if (!zvrf) {
 		if (IS_ZEBRA_DEBUG_RIB_DETAILED)
-			zlog_debug("\t%s: zvrf is NULL", __func__);
+			zlog_debug("        %s: zvrf is NULL", __func__);
 		return CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_ACTIVE);
 	}
 

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -471,7 +471,7 @@ zebra_rnh_resolve_import_entry(struct zebra_vrf *zvrf, afi_t afi,
 		*prn = rn;
 
 	if (!re && IS_ZEBRA_DEBUG_NHT_DETAILED)
-		zlog_debug("\tRejected due to removed or is a bgp route");
+		zlog_debug("        Rejected due to removed or is a bgp route");
 
 	return re;
 }
@@ -656,7 +656,7 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 		    && !rnh_resolve_via_default(zvrf, rn->p.family)) {
 			if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 				zlog_debug(
-					"\tNot allowed to resolve through default prefix");
+					"        Not allowed to resolve through default prefix");
 			return NULL;
 		}
 
@@ -665,7 +665,7 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 			if (CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED)) {
 				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 					zlog_debug(
-						"\tRoute Entry %s removed",
+						"        Route Entry %s removed",
 						zebra_route_string(re->type));
 				continue;
 			}
@@ -673,7 +673,7 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 			    !CHECK_FLAG(re->flags, ZEBRA_FLAG_FIB_OVERRIDE)) {
 				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 					zlog_debug(
-						"\tRoute Entry %s !selected",
+						"        Route Entry %s !selected",
 						zebra_route_string(re->type));
 				continue;
 			}
@@ -681,7 +681,7 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 			if (CHECK_FLAG(re->status, ROUTE_ENTRY_QUEUED)) {
 				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 					zlog_debug(
-						"\tRoute Entry %s queued",
+						"        Route Entry %s queued",
 						zebra_route_string(re->type));
 				continue;
 			}
@@ -697,7 +697,7 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 			if (nexthop == NULL) {
 				if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 					zlog_debug(
-						"\tRoute Entry %s no nexthops",
+						"        Route Entry %s no nexthops",
 						zebra_route_string(re->type));
 				continue;
 			}
@@ -732,7 +732,7 @@ zebra_rnh_resolve_nexthop_entry(struct zebra_vrf *zvrf, afi_t afi,
 		else {
 			if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 				zlog_debug(
-					"\tNexthop must be connected, cannot recurse up");
+					"        Nexthop must be connected, cannot recurse up");
 			return NULL;
 		}
 	}

--- a/zebra/zebra_vxlan.c
+++ b/zebra/zebra_vxlan.c
@@ -3059,7 +3059,7 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
 	if (!zvrf) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("\tUnable to find vrf for: %d",
+			zlog_debug("        Unable to find vrf for: %d",
 				   zvni->vxlan_if->vrf_id);
 		return -1;
 	}
@@ -3094,7 +3094,7 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 			if (!mac_different && is_router == cur_is_router) {
 				if (IS_ZEBRA_DEBUG_VXLAN)
 					zlog_debug(
-						"\tIgnoring entry mac is the same and is_router == cur_is_router");
+						"        Ignoring entry mac is the same and is_router == cur_is_router");
 				n->ifindex = ifp->ifindex;
 				return 0;
 			}
@@ -3126,7 +3126,7 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 				else {
 					if (IS_ZEBRA_DEBUG_VXLAN)
 						zlog_debug(
-							"\tNeighbor active and frozen");
+							"        Neighbor active and frozen");
 				}
 				return 0;
 			}
@@ -3271,7 +3271,7 @@ static int zvni_local_neigh_update(zebra_vni_t *zvni,
 					     n->flags, n->loc_seq);
 	} else {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("\tNeighbor on hold not sending");
+			zlog_debug("        Neighbor on hold not sending");
 	}
 	return 0;
 }
@@ -8034,7 +8034,7 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 	if (!zvni) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
-				"\tAdd/Update %sMAC %s intf %s(%u) VID %u, could not find VNI",
+				"        Add/Update %sMAC %s intf %s(%u) VID %u, could not find VNI",
 				sticky ? "sticky " : "",
 				prefix_mac2str(macaddr, buf, sizeof(buf)),
 				ifp->name, ifp->ifindex, vid);
@@ -8044,7 +8044,7 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 	if (!zvni->vxlan_if) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
 			zlog_debug(
-				"\tVNI %u hash %p doesn't have intf upon local MAC ADD",
+				"        VNI %u hash %p doesn't have intf upon local MAC ADD",
 				zvni->vni, zvni);
 		return -1;
 	}
@@ -8052,7 +8052,7 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 	zvrf = vrf_info_lookup(zvni->vxlan_if->vrf_id);
 	if (!zvrf) {
 		if (IS_ZEBRA_DEBUG_VXLAN)
-			zlog_debug("\tNo Vrf found for vrf_id: %d",
+			zlog_debug("        No Vrf found for vrf_id: %d",
 				   zvni->vxlan_if->vrf_id);
 		return -1;
 	}
@@ -8105,7 +8105,7 @@ int zebra_vxlan_local_mac_add_update(struct interface *ifp,
 			    && mac->fwd_info.local.vid == vid) {
 				if (IS_ZEBRA_DEBUG_VXLAN)
 					zlog_debug(
-						"\tAdd/Update %sMAC %s intf %s(%u) VID %u -> VNI %u, "
+						"        Add/Update %sMAC %s intf %s(%u) VID %u -> VNI %u, "
 						"entry exists and has not changed ",
 						sticky ? "sticky " : "",
 						prefix_mac2str(macaddr, buf,


### PR DESCRIPTION
Some logging systems are, er, "allergic" to tabs in log messages.
(RFC5424: "The syslog application SHOULD avoid octet values below 32")

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>