### PR TITLE
bgpd: Print readable error message when parsing AGGREGATOR attribute

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1655,19 +1655,20 @@ static int bgp_attr_aggregator(struct bgp_attr_parser_args *args)
 	else
 		aggregator_as = stream_getw(peer->curr);
 
-	/* Codification of AS 0 Processing */
-	if (aggregator_as == BGP_AS_ZERO) {
-		flog_err(EC_BGP_ATTR_LEN,
-			 "AGGREGATOR attribute is BGP_AS_ZERO(0)");
-		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_MAL_AS_PATH,
-					  args->total);
-	}
-
 	attr->aggregator_as = aggregator_as;
 	attr->aggregator_addr.s_addr = stream_get_ipv4(peer->curr);
 
 	/* Set atomic aggregate flag. */
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AGGREGATOR);
+
+	/* Codification of AS 0 Processing */
+	if (aggregator_as == BGP_AS_ZERO) {
+		flog_err(EC_BGP_ATTR_LEN,
+			 "AGGREGATOR AS number is 0 for aspath: %s",
+			 aspath_print(attr->aspath));
+		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_MAL_AS_PATH,
+					  args->total);
+	}
 
 	return BGP_ATTR_PARSE_PROCEED;
 }
@@ -1690,19 +1691,20 @@ bgp_attr_as4_aggregator(struct bgp_attr_parser_args *args,
 					  0);
 	}
 
-	/* Codification of AS 0 Processing */
 	aggregator_as = stream_getl(peer->curr);
-	if (aggregator_as == BGP_AS_ZERO) {
-		flog_err(EC_BGP_ATTR_LEN,
-			 "AS4_AGGREGATOR attribute is BGP_AS_ZERO(0)");
-		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_MAL_AS_PATH,
-					  0);
-	}
-
 	*as4_aggregator_as = aggregator_as;
 	as4_aggregator_addr->s_addr = stream_get_ipv4(peer->curr);
 
 	attr->flag |= ATTR_FLAG_BIT(BGP_ATTR_AS4_AGGREGATOR);
+
+	/* Codification of AS 0 Processing */
+	if (aggregator_as == BGP_AS_ZERO) {
+		flog_err(EC_BGP_ATTR_LEN,
+			 "AS4_AGGREGATOR AS number is 0 for aspath: %s",
+			 aspath_print(attr->aspath));
+		return bgp_attr_malformed(args, BGP_NOTIFY_UPDATE_MAL_AS_PATH,
+					  0);
+	}
 
 	return BGP_ATTR_PARSE_PROCEED;
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8713,10 +8713,22 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp,
 			json_object_string_add(
 				json_path, "aggregatorId",
 				inet_ntoa(attr->aggregator_addr));
+			if (attr->aggregator_as == BGP_AS_ZERO)
+				json_object_boolean_true_add(
+					json_path, "aggregatorAsMalformed");
+			else
+				json_object_boolean_false_add(
+					json_path, "aggregatorAsMalformed");
 		} else {
-			vty_out(vty, ", (aggregated by %u %s)",
-				attr->aggregator_as,
-				inet_ntoa(attr->aggregator_addr));
+			if (attr->aggregator_as == BGP_AS_ZERO)
+				vty_out(vty,
+					", (aggregated by %u(malformed) %s)",
+					attr->aggregator_as,
+					inet_ntoa(attr->aggregator_addr));
+			else
+				vty_out(vty, ", (aggregated by %u %s)",
+					attr->aggregator_as,
+					inet_ntoa(attr->aggregator_addr));
 		}
 	}
 


### PR DESCRIPTION
Having a full feed this leads to unknown. You can't point which prefix or
aspath has this malforming behavior.

Printing just `[EC 33554434] AGGREGATOR attribute is BGP_AS_ZERO(0)` isn't
enough, you can't directly pin-point where is the problem.

Additionally print at least aspath here:
```
[EC 33554434] AGGREGATOR AS number is 0 for aspath: 65000 65031
```

Overall the full table has only 6 such malformed prefixes:
```
aspath: 64539 15096 6939 45430 45458
aspath: 64539 15096 6939 1299 3257 34984 34984 34984 34984 34984 51174
aspath: 64539 15096 6939 286 34984 16135 16135 {16135}
aspath: 64539 15096 6939 7545 7545 136001
aspath: 64539 15096 6939 6762 3269 20746
aspath: 64539 15096 6939 7018 3379
```

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>