### PR TITLE
bgpd: Convert from `struct bgp_node` to `struct bgp_dest`

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -111,7 +111,7 @@ static const struct message bgp_pmsi_tnltype_str[] = {
 #define VRFID_NONE_STR "-"
 
 DEFINE_HOOK(bgp_process,
-	    (struct bgp * bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
+	    (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
 	     struct peer *peer, bool withdraw),
 	    (bgp, afi, safi, bn, peer, withdraw))
 
@@ -2625,7 +2625,7 @@ static void bgp_process_main_one(struct bgp *bgp, struct bgp_dest *dest,
 	 */
 	if (CHECK_FLAG(dest->flags, BGP_NODE_SELECT_DEFER)) {
 		if (BGP_DEBUG(update, UPDATE_OUT))
-			zlog_debug("SELECT_DEFER falg set for route %p", dest);
+			zlog_debug("SELECT_DEFER flag set for route %p", dest);
 		return;
 	}
 

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -513,7 +513,7 @@ static inline void prep_for_rmap_apply(struct bgp_path_info *dst_pi,
 
 /* called before bgp_process() */
 DECLARE_HOOK(bgp_process,
-	     (struct bgp * bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
+	     (struct bgp *bgp, afi_t afi, safi_t safi, struct bgp_dest *bn,
 	      struct peer *peer, bool withdraw),
 	     (bgp, afi, safi, bn, peer, withdraw))
 

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -60,45 +60,31 @@ void bgp_table_finish(struct bgp_table **rt)
 	}
 }
 
-/*
- * bgp_node_create
- */
-static struct route_node *bgp_node_create(route_table_delegate_t *delegate,
-					  struct route_table *table)
+inline void bgp_dest_unlock_node(struct bgp_dest *dest)
 {
-	struct bgp_node *node;
-	node = XCALLOC(MTYPE_BGP_NODE, sizeof(struct bgp_node));
+	bgp_delete_listnode(dest);
+	struct route_node *rn = bgp_dest_to_rnode(dest);
 
-	RB_INIT(bgp_adj_out_rb, &node->adj_out);
-	return bgp_dest_to_rnode(node);
-}
+	if (rn->lock == 1) {
+		struct bgp_table *rt = bgp_dest_table(dest);
+		if (rt->bgp)
+			bgp_addpath_free_node_data(&rt->bgp->tx_addpath,
+						   &dest->tx_addpath, rt->afi,
+						   rt->safi);
 
-/*
- * bgp_node_destroy
- */
-static void bgp_node_destroy(route_table_delegate_t *delegate,
-			     struct route_table *table, struct route_node *node)
-{
-	struct bgp_node *bgp_node;
-	struct bgp_table *rt;
-	bgp_node = bgp_dest_from_rnode(node);
-	rt = table->info;
-
-	if (rt->bgp) {
-		bgp_addpath_free_node_data(&rt->bgp->tx_addpath,
-					 &bgp_node->tx_addpath,
-					 rt->afi, rt->safi);
+		XFREE(MTYPE_BGP_NODE, dest);
+		rn->info = NULL;
 	}
-
-	XFREE(MTYPE_BGP_NODE, bgp_node);
+	route_unlock_node(rn);
 }
 
 /*
  * Function vector to customize the behavior of the route table
  * library for BGP route tables.
  */
-route_table_delegate_t bgp_table_delegate = {.create_node = bgp_node_create,
-					     .destroy_node = bgp_node_destroy};
+route_table_delegate_t bgp_table_delegate = {.create_node = route_node_create,
+					     .destroy_node =
+						     route_node_destroy};
 
 /*
  * bgp_table_init
@@ -129,9 +115,9 @@ struct bgp_table *bgp_table_init(struct bgp *bgp, afi_t afi, safi_t safi)
 }
 
 /* Delete the route node from the selection deferral route list */
-void bgp_delete_listnode(struct bgp_node *node)
+void bgp_delete_listnode(struct bgp_dest *dest)
 {
-	struct route_node *rn = NULL;
+	const struct route_node *rn = NULL;
 	struct bgp_table *table = NULL;
 	struct bgp *bgp = NULL;
 	afi_t afi;
@@ -140,8 +126,8 @@ void bgp_delete_listnode(struct bgp_node *node)
 	/* If the route to be deleted is selection pending, update the
 	 * route node in gr_info
 	 */
-	if (CHECK_FLAG(node->flags, BGP_NODE_SELECT_DEFER)) {
-		table = bgp_dest_table(node);
+	if (CHECK_FLAG(dest->flags, BGP_NODE_SELECT_DEFER)) {
+		table = bgp_dest_table(dest);
 
 		if (table) {
 			bgp = table->bgp;
@@ -150,52 +136,53 @@ void bgp_delete_listnode(struct bgp_node *node)
 		} else
 			return;
 
-		rn = bgp_dest_to_rnode(node);
+		rn = bgp_dest_to_rnode(dest);
 
 		if (bgp && rn && rn->lock == 1) {
 			/* Delete the route from the selection pending list */
-			if ((node->rt_node)
+			if ((dest->rt_node)
 			    && (bgp->gr_info[afi][safi].route_list)) {
 				list_delete_node(
 					bgp->gr_info[afi][safi].route_list,
-					node->rt_node);
-				node->rt_node = NULL;
+					dest->rt_node);
+				dest->rt_node = NULL;
 			}
 		}
 	}
 }
 
-struct bgp_node *bgp_table_subtree_lookup(const struct bgp_table *table,
+struct bgp_dest *bgp_table_subtree_lookup(const struct bgp_table *table,
 					  const struct prefix *p)
 {
-	struct bgp_node *node = bgp_dest_from_rnode(table->route_table->top);
-	struct bgp_node *matched = NULL;
+	struct bgp_dest *dest = bgp_dest_from_rnode(table->route_table->top);
+	struct bgp_dest *matched = NULL;
 
-	if (node == NULL)
+	if (dest == NULL)
 		return NULL;
 
 
-	while (node) {
-		const struct prefix *node_p = bgp_dest_get_prefix(node);
+	while (dest) {
+		const struct prefix *dest_p = bgp_dest_get_prefix(dest);
+		struct route_node *node = dest->rn;
 
-		if (node_p->prefixlen >= p->prefixlen) {
-			if (!prefix_match(p, node_p))
+		if (dest_p->prefixlen >= p->prefixlen) {
+			if (!prefix_match(p, dest_p))
 				return NULL;
 
-			matched = node;
+			matched = dest;
 			break;
 		}
 
-		if (!prefix_match(node_p, p))
+		if (!prefix_match(dest_p, p))
 			return NULL;
 
-		if (node_p->prefixlen == p->prefixlen) {
-			matched = node;
+		if (dest_p->prefixlen == p->prefixlen) {
+			matched = dest;
 			break;
 		}
 
-		node = bgp_dest_from_rnode(node->link[prefix_bit(
-			&p->u.prefix, node_p->prefixlen)]);
+		dest = bgp_dest_from_rnode(node->link[prefix_bit(
+			&p->u.prefix, dest_p->prefixlen)]);
 	}
 
 	if (!matched)


### PR DESCRIPTION
The current code base has replaced the `struct route_node`
with a `struct bgp_node` data structure.  The problem with
this is that it creates a bunch of extra data per route_node.
For an entire bgp feed of 800k routes this is ~1.4 million nodes
this additional data adds up tremendously.  Split out the
bgp_node into `struct route_node`, which is the original
data structure and a `struct bgp_dest` which was the extra data.
Modify all the code so that it understands this distinction.

Why does this matter?  It saves a decent chunk of memory:

Before:
Memory statistics for bgpd:
System allocator statistics:
  Total heap allocated:  575 MiB
  Holding block headers: 18 MiB
  Used small blocks:     0 bytes
  Used ordinary blocks:  565 MiB
  Free small blocks:     4991 KiB
  Free ordinary blocks:  10451 KiB
  Ordinary blocks:       123597
  Small blocks:          43138
  Holding blocks:        2
After:
Memory statistics for bgpd:
System allocator statistics:
  Total heap allocated:  550 MiB
  Holding block headers: 18 MiB
  Used small blocks:     0 bytes
  Used ordinary blocks:  539 MiB
  Free small blocks:     5018 KiB
  Free ordinary blocks:  10458 KiB
  Ordinary blocks:       123846
  Small blocks:          43372
  Holding blocks:        2

Additionally this sets us up for doing some work to change the
data structure for bgp_path_info to allow us to easily do
a O(1) type lookup for the bgp_path_info's peer.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>