### PR TITLE
zebra: don't treat every interface as unnumbered

### DIFF
--- a/zebra/connected.c
+++ b/zebra/connected.c
@@ -566,5 +566,5 @@ int connected_is_unnumbered(struct interface *ifp)
 			return CHECK_FLAG(connected->flags,
 					  ZEBRA_IFA_UNNUMBERED);
 	}
-	return 1;
+	return 0;
 }


### PR DESCRIPTION
Commit e93a6fbb4 from PR3908 changed every interface into an 'unnumbered' interface - even interfaces that do not have ipv4 at all. Undo that. I'd like to open some discussion about the goals of that original PR, and try to find some alternative solution to the problem.

Issue #5926 is also tracking this.
